### PR TITLE
perf(cli): skip plugin-runtime evaluation in config preflight for loadPlugins:never commands

### DIFF
--- a/src/channels/plugins/legacy-config.test.ts
+++ b/src/channels/plugins/legacy-config.test.ts
@@ -159,6 +159,44 @@ describe("collectChannelLegacyConfigRules", () => {
     expect(listPluginDoctorLegacyConfigRulesMock).not.toHaveBeenCalled();
   });
 
+  it("skips runtime fallbacks for empty and unresolved contracts in plugin-free mode", () => {
+    loadBundledChannelDoctorContractApiMock.mockImplementation((channelId: string) =>
+      channelId === "imessage" ? { legacyConfigRules: [] } : undefined,
+    );
+    getBootstrapChannelPluginMock.mockReturnValue({
+      doctor: {
+        legacyConfigRules: [
+          {
+            path: ["channels", "imessage", "legacy"],
+            message: "should not load bootstrap rules",
+          },
+        ],
+      },
+    });
+    listPluginDoctorLegacyConfigRulesMock.mockReturnValue([
+      {
+        path: ["channels", "custom-chat", "legacy"],
+        message: "should not scan plugin contracts",
+      },
+    ]);
+
+    const rules = collectChannelLegacyConfigRules(
+      {
+        channels: {
+          imessage: {},
+          "custom-chat": {},
+        },
+      },
+      undefined,
+      undefined,
+      "none",
+    );
+
+    expect(rules).toStrictEqual([]);
+    expect(getBootstrapChannelPluginMock).not.toHaveBeenCalled();
+    expect(listPluginDoctorLegacyConfigRulesMock).not.toHaveBeenCalled();
+  });
+
   it("scopes channel legacy scans to touched channels during dry-run validation", () => {
     loadBundledChannelDoctorContractApiMock.mockImplementation((channelId: string) => ({
       legacyConfigRules: [

--- a/src/channels/plugins/legacy-config.ts
+++ b/src/channels/plugins/legacy-config.ts
@@ -6,6 +6,7 @@
 import type { LegacyConfigRule } from "../../config/legacy.shared.js";
 import type { OpenClawConfig } from "../../config/types.js";
 import { listPluginDoctorLegacyConfigRules } from "../../plugins/doctor-contract-registry.js";
+import type { PluginRuntimeMode } from "../../plugins/plugin-runtime-mode.js";
 import { getBootstrapChannelPlugin } from "./bootstrap-registry.js";
 import { loadBundledChannelDoctorContractApi } from "./doctor-contract-api.js";
 import type { ChannelId } from "./types.public.js";
@@ -83,6 +84,7 @@ export function collectChannelLegacyConfigRules(
   raw?: unknown,
   touchedPaths?: ReadonlyArray<ReadonlyArray<string>>,
   excludedChannelIds?: ReadonlySet<ChannelId>,
+  pluginRuntime: PluginRuntimeMode = "full",
 ): LegacyConfigRule[] {
   const channelIds = collectRelevantChannelIdsForTouchedPaths({
     raw,
@@ -96,6 +98,11 @@ export function collectChannelLegacyConfigRules(
     const contractRules = contractApi?.legacyConfigRules;
     if (Array.isArray(contractRules)) {
       rules.push(...contractRules);
+      continue;
+    }
+    if (pluginRuntime === "none") {
+      // Plugin-free CLI preflight trusts only the narrow bundled contract surface.
+      // Unresolved channels defer runtime-backed discovery to doctor or plugin startup.
       continue;
     }
 

--- a/src/cli/command-bootstrap.plugin-free.test.ts
+++ b/src/cli/command-bootstrap.plugin-free.test.ts
@@ -1,0 +1,197 @@
+// Behavioral bootstrap coverage for plugin-free CLI command preflight.
+import fs from "node:fs/promises";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  resetAutoMigrateLegacyStateDirForTest,
+  resetAutoMigrateLegacyStateForTest,
+  resetAutoMigrateLegacyTaskStateSidecarsForTest,
+} from "../infra/state-migrations.js";
+import { clearPluginDoctorContractRegistryCache } from "../plugins/doctor-contract-registry.test-fixtures.js";
+import {
+  createOpenClawTestState,
+  type OpenClawTestState,
+} from "../test-utils/openclaw-test-state.js";
+import { ensureCliCommandBootstrap } from "./command-bootstrap.js";
+import { testApi as configGuardTestApi } from "./program/config-guard.js";
+
+const sourceTransformMocks = vi.hoisted(() => {
+  const loader = vi.fn(() => ({}));
+  return {
+    loader,
+    createLoader: vi.fn(() => loader),
+  };
+});
+
+vi.mock("../plugins/plugin-module-loader-cache.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../plugins/plugin-module-loader-cache.js")>();
+  return {
+    ...actual,
+    getCachedPluginModuleLoader: (
+      params: Parameters<typeof actual.getCachedPluginModuleLoader>[0],
+    ) =>
+      actual.getCachedPluginModuleLoader({
+        ...params,
+        createLoader: sourceTransformMocks.createLoader as never,
+      }),
+  };
+});
+
+describe("plugin-free command bootstrap", () => {
+  let testState: OpenClawTestState | undefined;
+  let sourceOnlyPluginRoot = "";
+
+  beforeEach(async () => {
+    testState = await createOpenClawTestState({
+      label: "cli-plugin-free",
+      scenario: "minimal",
+    });
+    sourceOnlyPluginRoot = testState.path("source-only-channel");
+    await fs.mkdir(sourceOnlyPluginRoot, { recursive: true });
+    await fs.writeFile(
+      testState.path("source-only-channel", "openclaw.plugin.json"),
+      JSON.stringify({
+        id: "source-only-channel",
+        configSchema: {
+          type: "object",
+          additionalProperties: false,
+          properties: {},
+        },
+      }),
+      "utf8",
+    );
+    await fs.writeFile(
+      testState.path("source-only-channel", "index.ts"),
+      "export default { id: 'source-only-channel', register() {} };\n",
+      "utf8",
+    );
+    await testState.writeConfig({
+      channels: {
+        "source-only-channel": {
+          enabled: false,
+        },
+      },
+      plugins: {
+        load: {
+          paths: [sourceOnlyPluginRoot],
+        },
+        entries: {
+          "source-only-channel": {
+            enabled: true,
+          },
+        },
+      },
+    });
+    configGuardTestApi.resetConfigGuardStateForTests();
+    resetAutoMigrateLegacyStateForTest();
+    resetAutoMigrateLegacyStateDirForTest();
+    resetAutoMigrateLegacyTaskStateSidecarsForTest();
+    clearPluginDoctorContractRegistryCache();
+    sourceTransformMocks.loader.mockClear();
+    sourceTransformMocks.createLoader.mockClear();
+  });
+
+  afterEach(async () => {
+    clearPluginDoctorContractRegistryCache();
+    configGuardTestApi.resetConfigGuardStateForTests();
+    resetAutoMigrateLegacyStateForTest();
+    resetAutoMigrateLegacyStateDirForTest();
+    resetAutoMigrateLegacyTaskStateSidecarsForTest();
+    await testState?.cleanup();
+    testState = undefined;
+  });
+
+  async function writeInvalidSourceChannelConfig() {
+    await testState?.writeConfig({
+      gateway: {
+        port: "invalid",
+      },
+      channels: {
+        "source-only-channel": {
+          enabled: false,
+        },
+      },
+      plugins: {
+        load: {
+          paths: [sourceOnlyPluginRoot],
+        },
+        entries: {
+          "source-only-channel": {
+            enabled: true,
+          },
+        },
+      },
+    });
+  }
+
+  it("does not create a source-transform loader for gateway call", async () => {
+    await writeInvalidSourceChannelConfig();
+    const runtime = {
+      error: vi.fn(),
+      exit: vi.fn((code: number) => {
+        throw new Error(`unexpected config-guard exit ${code}`);
+      }),
+    };
+
+    await ensureCliCommandBootstrap({
+      runtime: runtime as never,
+      commandPath: ["gateway", "call"],
+      loadPlugins: false,
+    });
+
+    expect(sourceTransformMocks.loader).not.toHaveBeenCalled();
+    expect(sourceTransformMocks.createLoader).not.toHaveBeenCalled();
+    expect(runtime.exit).not.toHaveBeenCalled();
+  });
+
+  it("keeps invalid-config snapshots plugin-free for health", async () => {
+    await writeInvalidSourceChannelConfig();
+    const runtime = {
+      error: vi.fn(),
+      exit: vi.fn((code: number) => {
+        throw new Error(`unexpected config-guard exit ${code}`);
+      }),
+    };
+
+    await ensureCliCommandBootstrap({
+      runtime: runtime as never,
+      commandPath: ["health"],
+      loadPlugins: false,
+    });
+
+    expect(sourceTransformMocks.loader).not.toHaveBeenCalled();
+    expect(sourceTransformMocks.createLoader).not.toHaveBeenCalled();
+    expect(runtime.exit).not.toHaveBeenCalled();
+  });
+
+  it("defers opaque channel session migration without loading its runtime", async () => {
+    const legacySessionKey = "15551234567@g.us";
+    await testState?.writeJson("sessions/sessions.json", {
+      [legacySessionKey]: {
+        sessionId: "legacy-channel-session",
+        updatedAt: 1,
+      },
+    });
+    const runtime = {
+      error: vi.fn(),
+      exit: vi.fn((code: number) => {
+        throw new Error(`unexpected config-guard exit ${code}`);
+      }),
+    };
+
+    await ensureCliCommandBootstrap({
+      runtime: runtime as never,
+      commandPath: ["gateway", "call"],
+      loadPlugins: false,
+    });
+
+    const preservedStore = JSON.parse(
+      await fs.readFile(testState!.statePath("sessions", "sessions.json"), "utf8"),
+    ) as Record<string, unknown>;
+    expect(preservedStore).toHaveProperty(legacySessionKey);
+    await expect(
+      fs.stat(testState!.statePath("agents", "main", "sessions", "sessions.json")),
+    ).rejects.toMatchObject({ code: "ENOENT" });
+    expect(sourceTransformMocks.createLoader).not.toHaveBeenCalled();
+    expect(runtime.exit).not.toHaveBeenCalled();
+  });
+});

--- a/src/cli/command-bootstrap.test.ts
+++ b/src/cli/command-bootstrap.test.ts
@@ -35,6 +35,7 @@ describe("ensureCliCommandBootstrap", () => {
     expect(ensureConfigReadyMock).toHaveBeenCalledWith({
       runtime,
       commandPath: ["agents", "list"],
+      pluginRuntime: "full",
       allowInvalid: true,
       suppressDoctorStdout: true,
     });
@@ -58,6 +59,7 @@ describe("ensureCliCommandBootstrap", () => {
     expect(ensureConfigReadyMock).toHaveBeenCalledWith({
       runtime,
       commandPath: ["gateway"],
+      pluginRuntime: "none",
       skipPristineCoreStateMigrations: true,
       skipPristineStartupStateMigrations: true,
     });

--- a/src/cli/command-bootstrap.ts
+++ b/src/cli/command-bootstrap.ts
@@ -1,5 +1,6 @@
 // Shared command preflight: config readiness plus optional plugin registry activation.
 import type { ConfigFileSnapshot } from "../config/types.js";
+import type { PluginRuntimeMode } from "../plugins/plugin-runtime-mode.js";
 import type { RuntimeEnv } from "../runtime.js";
 import { createLazyImportLoader } from "../shared/lazy-promise.js";
 import type { CliPluginRegistryPolicy } from "./command-catalog.js";
@@ -25,11 +26,15 @@ export async function ensureCliCommandBootstrap(params: {
   skipPristineCoreStateMigrations?: boolean;
   skipPristineStartupStateMigrations?: boolean;
 }) {
+  const pluginRuntime: PluginRuntimeMode = params.loadPlugins === false ? "none" : "full";
   if (!params.skipConfigGuard) {
     const { ensureConfigReady } = await loadConfigGuardModule();
+    // Plugin-free commands must keep doctor from re-entering executable plugin surfaces
+    // before the explicit registry-loading gate below.
     await ensureConfigReady({
       runtime: params.runtime,
       commandPath: params.commandPath,
+      pluginRuntime,
       ...(params.allowInvalid ? { allowInvalid: true } : {}),
       ...(params.beforeStateMigrations
         ? { beforeStateMigrations: params.beforeStateMigrations }

--- a/src/cli/command-path-policy.test.ts
+++ b/src/cli/command-path-policy.test.ts
@@ -254,6 +254,10 @@ describe("command-path-policy", () => {
       loadPlugins: "never",
       networkProxy: "bypass",
     });
+    expectResolvedPolicy(["gateway", "call"], {
+      loadPlugins: "never",
+      networkProxy: "bypass",
+    });
     expectResolvedPolicy(["plugins", "update"], {
       loadPlugins: "never",
       hideBanner: true,

--- a/src/cli/gateway-cli/startup-migrations.test.ts
+++ b/src/cli/gateway-cli/startup-migrations.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it, vi } from "vitest";
+import { runGatewayStartupMigrations } from "./startup-migrations.js";
+
+const runDoctorConfigPreflight = vi.hoisted(() => vi.fn(async () => undefined));
+
+vi.mock("../../commands/doctor-config-preflight.js", () => ({
+  runDoctorConfigPreflight,
+}));
+
+describe("runGatewayStartupMigrations", () => {
+  it("completes the full plugin-aware migration phase", async () => {
+    const beforeStateMigrations = vi.fn(async () => true);
+
+    await runGatewayStartupMigrations({ beforeStateMigrations });
+
+    expect(runDoctorConfigPreflight).toHaveBeenCalledWith({
+      migrateState: true,
+      migrateLegacyConfig: false,
+      invalidConfigNote: false,
+      requireStartupMigrationCheckpoint: true,
+      pluginRuntime: "full",
+      beforeStateMigrations,
+    });
+  });
+});

--- a/src/cli/gateway-cli/startup-migrations.ts
+++ b/src/cli/gateway-cli/startup-migrations.ts
@@ -1,0 +1,16 @@
+// Gateway-owned full migration completion after the plugin-free CLI config guard.
+import type { ConfigFileSnapshot } from "../../config/types.js";
+
+export async function runGatewayStartupMigrations(params: {
+  beforeStateMigrations: (snapshot?: ConfigFileSnapshot) => Promise<boolean>;
+}): Promise<void> {
+  const { runDoctorConfigPreflight } = await import("../../commands/doctor-config-preflight.js");
+  await runDoctorConfigPreflight({
+    migrateState: true,
+    migrateLegacyConfig: false,
+    invalidConfigNote: false,
+    requireStartupMigrationCheckpoint: true,
+    pluginRuntime: "full",
+    beforeStateMigrations: params.beforeStateMigrations,
+  });
+}

--- a/src/cli/program/config-guard.test.ts
+++ b/src/cli/program/config-guard.test.ts
@@ -4,6 +4,7 @@ import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { note } from "../../../packages/terminal-core/src/note.js";
+import type { PluginRuntimeMode } from "../../plugins/plugin-runtime-mode.js";
 import { ExitError } from "../../runtime.js";
 import { captureEnv, deleteTestEnvValue, setTestEnvValue } from "../../test-utils/env.js";
 import { formatCliCommand } from "../command-format.js";
@@ -77,9 +78,18 @@ describe("ensureConfigReady", () => {
   const tempRoots: string[] = [];
   let envSnapshot: ReturnType<typeof captureEnv> | undefined;
 
-  async function runEnsureConfigReady(commandPath: string[], suppressDoctorStdout = false) {
+  async function runEnsureConfigReady(
+    commandPath: string[],
+    suppressDoctorStdout = false,
+    pluginRuntime?: PluginRuntimeMode,
+  ) {
     const runtime = makeRuntime();
-    await ensureConfigReady({ runtime: runtime as never, commandPath, suppressDoctorStdout });
+    await ensureConfigReady({
+      runtime: runtime as never,
+      commandPath,
+      suppressDoctorStdout,
+      ...(pluginRuntime ? { pluginRuntime } : {}),
+    });
     return runtime;
   }
 
@@ -135,6 +145,7 @@ describe("ensureConfigReady", () => {
       "OPENCLAW_NIX_MODE",
       "OPENCLAW_PROFILE",
       "OPENCLAW_STATE_DIR",
+      "VITEST",
     ]);
     vi.clearAllMocks();
     resetConfigGuardStateForTests();
@@ -157,7 +168,12 @@ describe("ensureConfigReady", () => {
     }
   });
 
-  it.each([
+  const migrationCases: Array<{
+    name: string;
+    commandPath: string[];
+    expectedDoctorCalls: number;
+    pluginRuntime?: PluginRuntimeMode;
+  }> = [
     {
       name: "skips doctor flow for status task reads without legacy state",
       commandPath: ["status"],
@@ -183,22 +199,47 @@ describe("ensureConfigReady", () => {
       commandPath: ["message"],
       expectedDoctorCalls: 1,
     },
-  ])("$name", async ({ commandPath, expectedDoctorCalls }) => {
-    await runEnsureConfigReady(commandPath);
+    {
+      name: "runs gateway calls without plugin-runtime evaluation",
+      commandPath: ["gateway", "call"],
+      expectedDoctorCalls: 1,
+      pluginRuntime: "none",
+    },
+  ];
+
+  it.each(migrationCases)("$name", async ({ commandPath, expectedDoctorCalls, pluginRuntime }) => {
+    await runEnsureConfigReady(commandPath, false, pluginRuntime);
     expect(loadAndMaybeMigrateDoctorConfigMock).toHaveBeenCalledTimes(expectedDoctorCalls);
     if (expectedDoctorCalls > 0) {
       expect(loadAndMaybeMigrateDoctorConfigMock).toHaveBeenCalledWith({
         migrateState: true,
         migrateLegacyConfig: false,
         invalidConfigNote: false,
+        ...(pluginRuntime ? { pluginRuntime } : {}),
       });
     }
+  });
+
+  it("caches config snapshots separately for each plugin runtime mode", async () => {
+    setTestEnvValue("VITEST", "false");
+
+    await runEnsureConfigReady(["update", "status"], false, "full");
+    await runEnsureConfigReady(["update", "status"], false, "none");
+    await runEnsureConfigReady(["update", "status"], false, "full");
+
+    expect(readConfigFileSnapshotMock.mock.calls).toEqual([
+      [{ pluginRuntime: "full" }],
+      [{ pluginRuntime: "none" }],
+    ]);
   });
 
   it("keeps status config guard reads non-observing", async () => {
     await runEnsureConfigReady(["status"]);
 
-    expect(readConfigFileSnapshotMock).toHaveBeenCalledWith({ observe: false });
+    expect(readConfigFileSnapshotMock).toHaveBeenCalledWith({
+      observe: false,
+      pluginRuntime: "full",
+    });
   });
 
   it("runs doctor flow when lightweight startup detection finds legacy state", async () => {

--- a/src/cli/program/config-guard.ts
+++ b/src/cli/program/config-guard.ts
@@ -14,6 +14,7 @@ import {
 import type { ConfigFileSnapshot } from "../../config/types.js";
 import { resolveExecApprovalsPath } from "../../infra/exec-approvals-config.js";
 import { resolveRequiredHomeDir } from "../../infra/home-dir.js";
+import type { PluginRuntimeMode } from "../../plugins/plugin-runtime-mode.js";
 import { ExitError, type RuntimeEnv } from "../../runtime.js";
 import { shouldMigrateStateFromPath } from "../argv.js";
 import type { InvalidConfigRecoveryDeps } from "../invalid-config-recovery.js";
@@ -34,12 +35,14 @@ const ALLOWED_INVALID_GATEWAY_SUBCOMMANDS = new Set([
 ]);
 const ALLOWED_INVALID_TASK_SUBCOMMANDS = new Set(["list", "audit"]);
 let didRunDoctorConfigFlow = false;
-let configSnapshotPromise: Promise<Awaited<ReturnType<typeof readConfigFileSnapshot>>> | null =
-  null;
+const configSnapshotPromises = new Map<
+  PluginRuntimeMode,
+  Promise<Awaited<ReturnType<typeof readConfigFileSnapshot>>>
+>();
 
 function resetConfigGuardStateForTests() {
   didRunDoctorConfigFlow = false;
-  configSnapshotPromise = null;
+  configSnapshotPromises.clear();
 }
 
 function fileOrDirExists(pathname: string): boolean {
@@ -189,24 +192,28 @@ function isGatewayStartupCommand(commandPath: string[]): boolean {
   );
 }
 
-async function getConfigSnapshot(options?: { observe: false }) {
+async function getConfigSnapshot(options: { observe?: false; pluginRuntime: PluginRuntimeMode }) {
   if (options?.observe === false) {
     return readConfigFileSnapshot(options);
   }
   // Tests often mutate config fixtures; caching can make those flaky.
   if (process.env.VITEST === "true") {
-    return readConfigFileSnapshot();
+    return readConfigFileSnapshot(options);
   }
-  if (!configSnapshotPromise) {
-    const pendingSnapshot = readConfigFileSnapshot();
-    configSnapshotPromise = pendingSnapshot;
+  const cachedSnapshot = configSnapshotPromises.get(options.pluginRuntime);
+  if (!cachedSnapshot) {
+    // A plugin-free read cannot satisfy a later full-runtime caller: invalid-config
+    // legacy discovery differs, so cache each closed runtime mode independently.
+    const pendingSnapshot = readConfigFileSnapshot(options);
+    configSnapshotPromises.set(options.pluginRuntime, pendingSnapshot);
     pendingSnapshot.catch(() => {
-      if (configSnapshotPromise === pendingSnapshot) {
-        configSnapshotPromise = null;
+      if (configSnapshotPromises.get(options.pluginRuntime) === pendingSnapshot) {
+        configSnapshotPromises.delete(options.pluginRuntime);
       }
     });
+    return pendingSnapshot;
   }
-  return configSnapshotPromise;
+  return cachedSnapshot;
 }
 
 export async function ensureConfigReady(
@@ -218,12 +225,14 @@ export async function ensureConfigReady(
     beforeStateMigrations?: (snapshot?: ConfigFileSnapshot) => Promise<boolean>;
     skipPristineCoreStateMigrations?: boolean;
     skipPristineStartupStateMigrations?: boolean;
+    pluginRuntime?: PluginRuntimeMode;
   },
   recoveryDeps?: InvalidConfigRecoveryDeps,
 ): Promise<void> {
   const commandPath = params.commandPath ?? [];
   const commandName = commandPath[0];
   const subcommandName = commandPath[1];
+  const pluginRuntime = params.pluginRuntime ?? "full";
   let preflightSnapshot: Awaited<ReturnType<typeof readConfigFileSnapshot>> | null = null;
   const shouldConsiderStateMigration = shouldMigrateStateFromPath(commandPath);
   const requiresLegacyStateInput = shouldRunStateMigrationOnlyWithLegacyInputs(commandPath);
@@ -234,6 +243,7 @@ export async function ensureConfigReady(
         migrateState: true,
         migrateLegacyConfig: false,
         invalidConfigNote: false,
+        ...(params.pluginRuntime ? { pluginRuntime } : {}),
         ...(commandName === "status" ? { observe: false } : {}),
         ...(shouldRequireStartupMigrationCheckpoint(commandPath)
           ? { requireStartupMigrationCheckpoint: true }
@@ -270,8 +280,11 @@ export async function ensureConfigReady(
 
   // Status performs a second non-observing read for its materialized/source pair;
   // keep the startup guard from recording config health before the command begins.
-  const configSnapshotOptions =
-    commandName === "status" ? ({ observe: false } as const) : undefined;
+  const doctorSnapshotOptions = commandName === "status" ? ({ observe: false } as const) : {};
+  const configSnapshotOptions = {
+    pluginRuntime,
+    ...doctorSnapshotOptions,
+  };
   let snapshot = preflightSnapshot ?? (await getConfigSnapshot(configSnapshotOptions));
   if (
     !preflightSnapshot &&
@@ -380,7 +393,7 @@ export async function ensureConfigReady(
       retry: async () => {
         // Doctor may rewrite config; retry the same legacy/plugin-aware validation without
         // rerunning startup state migrations.
-        configSnapshotPromise = null;
+        configSnapshotPromises.clear();
         const { runDoctorConfigPreflight } =
           await import("../../commands/doctor-config-preflight.js");
         const retrySnapshot = (
@@ -388,7 +401,8 @@ export async function ensureConfigReady(
             migrateState: false,
             migrateLegacyConfig: false,
             invalidConfigNote: false,
-            ...configSnapshotOptions,
+            ...(params.pluginRuntime ? { pluginRuntime } : {}),
+            ...doctorSnapshotOptions,
           })
         ).snapshot;
         if (retrySnapshot.exists && !retrySnapshot.valid) {

--- a/src/cli/program/preaction.test.ts
+++ b/src/cli/program/preaction.test.ts
@@ -15,6 +15,7 @@ type EnsureConfigReadyOptions = {
   allowInvalid?: boolean;
   beforeStateMigrations?: () => Promise<boolean>;
   commandPath?: string[];
+  pluginRuntime?: "full" | "none";
   requireConfig?: boolean;
   skipPristineCoreStateMigrations?: boolean;
   skipPristineStartupStateMigrations?: boolean;
@@ -27,6 +28,7 @@ const routeLogsToStderrMock = vi.fn();
 const prepareGatewayRunBootstrapMock = vi.fn(async () => true);
 const recheckGatewayRunBootstrapMock = vi.fn(async () => true);
 const reloadTrustedGatewayRunEnvironmentMock = vi.fn(async () => true);
+const runGatewayStartupMigrationsMock = vi.fn(async () => undefined);
 const wasPreparedGatewayRunCoreStatePristineMock = vi.fn(() => true);
 const wasPreparedGatewayRunStatePristineMock = vi.fn(() => true);
 
@@ -72,6 +74,10 @@ vi.mock("../gateway-cli/pre-bootstrap.js", () => ({
   reloadTrustedGatewayRunEnvironment: reloadTrustedGatewayRunEnvironmentMock,
   wasPreparedGatewayRunCoreStatePristine: wasPreparedGatewayRunCoreStatePristineMock,
   wasPreparedGatewayRunStatePristine: wasPreparedGatewayRunStatePristineMock,
+}));
+
+vi.mock("../gateway-cli/startup-migrations.js", () => ({
+  runGatewayStartupMigrations: runGatewayStartupMigrationsMock,
 }));
 
 let registerPreActionHooks: typeof import("./preaction.js").registerPreActionHooks;
@@ -290,6 +296,7 @@ describe("registerPreActionHooks", () => {
     expect(ensureConfigReadyMock).toHaveBeenCalledWith({
       runtime: runtimeMock,
       commandPath: ["status"],
+      pluginRuntime: "none",
     });
     expect(ensurePluginRegistryLoadedMock).not.toHaveBeenCalled();
     expect(processTitleSetSpy).toHaveBeenCalledWith("openclaw-status");
@@ -305,6 +312,7 @@ describe("registerPreActionHooks", () => {
     expect(ensureConfigReadyMock).toHaveBeenCalledWith({
       runtime: runtimeMock,
       commandPath: ["agents", "list"],
+      pluginRuntime: "none",
     });
     expect(ensurePluginRegistryLoadedMock).not.toHaveBeenCalled();
     processTitleSetSpy.mockRestore();
@@ -338,6 +346,7 @@ describe("registerPreActionHooks", () => {
       runtime: runtimeMock,
     });
     expect(ensureConfigReadyMock).not.toHaveBeenCalled();
+    expect(runGatewayStartupMigrationsMock).not.toHaveBeenCalled();
   });
 
   it("passes the gateway config recheck to the state migration boundary", async () => {
@@ -350,6 +359,7 @@ describe("registerPreActionHooks", () => {
       expect.objectContaining({
         beforeStateMigrations: expect.any(Function),
         commandPath: ["gateway", "run"],
+        pluginRuntime: "none",
         skipPristineCoreStateMigrations: true,
         skipPristineStartupStateMigrations: true,
       }),
@@ -363,6 +373,12 @@ describe("registerPreActionHooks", () => {
     expect(reloadTrustedGatewayRunEnvironmentMock).toHaveBeenCalledWith({
       runtime: runtimeMock,
     });
+    expect(runGatewayStartupMigrationsMock).toHaveBeenCalledWith({
+      beforeStateMigrations,
+    });
+    expect(runGatewayStartupMigrationsMock.mock.invocationCallOrder[0]).toBeLessThan(
+      reloadTrustedGatewayRunEnvironmentMock.mock.invocationCallOrder[0] ?? 0,
+    );
   });
 
   it("passes --allow-unconfigured through as an invalid-config override", async () => {
@@ -381,6 +397,7 @@ describe("registerPreActionHooks", () => {
       expect.objectContaining({
         allowInvalid: true,
         commandPath: ["gateway", "run"],
+        pluginRuntime: "none",
       }),
     );
   });
@@ -394,6 +411,7 @@ describe("registerPreActionHooks", () => {
     expect(ensureConfigReadyMock).toHaveBeenCalledWith({
       runtime: runtimeMock,
       commandPath: ["update"],
+      pluginRuntime: "none",
       allowInvalid: true,
     });
 
@@ -406,6 +424,7 @@ describe("registerPreActionHooks", () => {
     expect(ensureConfigReadyMock).toHaveBeenCalledWith({
       runtime: runtimeMock,
       commandPath: ["update", "status"],
+      pluginRuntime: "none",
       allowInvalid: true,
       suppressDoctorStdout: true,
     });
@@ -420,6 +439,7 @@ describe("registerPreActionHooks", () => {
     expect(ensureConfigReadyMock).toHaveBeenCalledWith({
       runtime: runtimeMock,
       commandPath: ["agent"],
+      pluginRuntime: "full",
     });
     expect(ensurePluginRegistryLoadedMock).toHaveBeenCalledWith({
       scope: "all",
@@ -435,6 +455,7 @@ describe("registerPreActionHooks", () => {
     expect(ensureConfigReadyMock).toHaveBeenCalledWith({
       runtime: runtimeMock,
       commandPath: ["agent"],
+      pluginRuntime: "full",
       suppressDoctorStdout: true,
     });
     expect(ensurePluginRegistryLoadedMock).toHaveBeenCalledWith({
@@ -463,6 +484,7 @@ describe("registerPreActionHooks", () => {
     expect(ensureConfigReadyMock).toHaveBeenCalledWith({
       runtime: runtimeMock,
       commandPath: ["onboard"],
+      pluginRuntime: "none",
     });
     expect(ensurePluginRegistryLoadedMock).not.toHaveBeenCalled();
 
@@ -475,6 +497,7 @@ describe("registerPreActionHooks", () => {
     expect(ensureConfigReadyMock).toHaveBeenCalledWith({
       runtime: runtimeMock,
       commandPath: ["channels", "add"],
+      pluginRuntime: "none",
     });
     expect(ensurePluginRegistryLoadedMock).not.toHaveBeenCalled();
   });
@@ -550,6 +573,7 @@ describe("registerPreActionHooks", () => {
     expect(ensureConfigReadyMock).toHaveBeenCalledWith({
       runtime: runtimeMock,
       commandPath: ["plugins", "install"],
+      pluginRuntime: "none",
       allowInvalid: true,
     });
 
@@ -562,6 +586,7 @@ describe("registerPreActionHooks", () => {
     expect(ensureConfigReadyMock).toHaveBeenCalledWith({
       runtime: runtimeMock,
       commandPath: ["plugins", "install"],
+      pluginRuntime: "none",
       allowInvalid: true,
     });
 
@@ -574,6 +599,7 @@ describe("registerPreActionHooks", () => {
     expect(ensureConfigReadyMock).toHaveBeenCalledWith({
       runtime: runtimeMock,
       commandPath: ["plugins", "install"],
+      pluginRuntime: "none",
       allowInvalid: true,
     });
 
@@ -586,6 +612,7 @@ describe("registerPreActionHooks", () => {
     expect(ensureConfigReadyMock).toHaveBeenCalledWith({
       runtime: runtimeMock,
       commandPath: ["plugins", "install"],
+      pluginRuntime: "none",
       allowInvalid: true,
     });
 
@@ -598,6 +625,7 @@ describe("registerPreActionHooks", () => {
     expect(ensureConfigReadyMock).toHaveBeenCalledWith({
       runtime: runtimeMock,
       commandPath: ["plugins", "install"],
+      pluginRuntime: "none",
     });
 
     vi.clearAllMocks();
@@ -609,6 +637,7 @@ describe("registerPreActionHooks", () => {
     expect(ensureConfigReadyMock).toHaveBeenCalledWith({
       runtime: runtimeMock,
       commandPath: ["plugins", "install"],
+      pluginRuntime: "none",
       allowInvalid: true,
     });
 
@@ -629,6 +658,7 @@ describe("registerPreActionHooks", () => {
     expect(ensureConfigReadyMock).toHaveBeenCalledWith({
       runtime: runtimeMock,
       commandPath: ["plugins", "install"],
+      pluginRuntime: "none",
     });
   });
 
@@ -663,6 +693,7 @@ describe("registerPreActionHooks", () => {
     expect(ensureConfigReadyMock).toHaveBeenCalledWith({
       runtime: runtimeMock,
       commandPath: ["status"],
+      pluginRuntime: "none",
       suppressDoctorStdout: true,
     });
     expect(ensurePluginRegistryLoadedMock).not.toHaveBeenCalled();
@@ -676,6 +707,7 @@ describe("registerPreActionHooks", () => {
     expect(ensureConfigReadyMock).toHaveBeenCalledWith({
       runtime: runtimeMock,
       commandPath: ["update", "status"],
+      pluginRuntime: "none",
       allowInvalid: true,
       suppressDoctorStdout: true,
     });
@@ -690,6 +722,7 @@ describe("registerPreActionHooks", () => {
     expect(ensureConfigReadyMock).toHaveBeenCalledWith({
       runtime: runtimeMock,
       commandPath: ["config", "set"],
+      pluginRuntime: "none",
     });
   });
 
@@ -767,6 +800,7 @@ describe("registerPreActionHooks", () => {
     expect(ensureConfigReadyMock).toHaveBeenCalledWith({
       runtime: runtimeMock,
       commandPath: ["machine"],
+      pluginRuntime: "none",
       suppressDoctorStdout: true,
     });
   });
@@ -781,6 +815,7 @@ describe("registerPreActionHooks", () => {
     expect(ensureConfigReadyMock).toHaveBeenCalledWith({
       runtime: runtimeMock,
       commandPath: ["acp"],
+      pluginRuntime: "none",
       suppressDoctorStdout: true,
     });
 
@@ -794,6 +829,7 @@ describe("registerPreActionHooks", () => {
     expect(ensureConfigReadyMock).toHaveBeenCalledWith({
       runtime: runtimeMock,
       commandPath: ["acp", "client"],
+      pluginRuntime: "none",
     });
 
     vi.clearAllMocks();
@@ -806,6 +842,7 @@ describe("registerPreActionHooks", () => {
     expect(ensureConfigReadyMock).toHaveBeenCalledWith({
       runtime: runtimeMock,
       commandPath: ["mcp", "serve"],
+      pluginRuntime: "none",
       suppressDoctorStdout: true,
     });
   });

--- a/src/cli/program/preaction.ts
+++ b/src/cli/program/preaction.ts
@@ -186,6 +186,10 @@ export function registerPreActionHooks(program: Command, programVersion: string)
       skipConfigGuard: shouldBypassConfigGuardForCommandPath(commandPath),
     });
     if (beforeStateMigrations) {
+      // The config guard intentionally avoids plugin runtime; gateway readiness still
+      // requires the plugin-aware migration pass and full startup checkpoint.
+      const { runGatewayStartupMigrations } = await import("../gateway-cli/startup-migrations.js");
+      await runGatewayStartupMigrations({ beforeStateMigrations });
       const { reloadTrustedGatewayRunEnvironment } =
         await import("../gateway-cli/pre-bootstrap.js");
       await reloadTrustedGatewayRunEnvironment({ runtime: defaultRuntime });

--- a/src/cli/run-main.exit.test.ts
+++ b/src/cli/run-main.exit.test.ts
@@ -132,6 +132,7 @@ const addGatewayRunCommandMock = vi.hoisted(() =>
 const ensureCliExecutionBootstrapMock = vi.hoisted(() =>
   vi.fn<(_opts: CliExecutionBootstrapOptions) => Promise<void>>(async () => {}),
 );
+const runGatewayStartupMigrationsMock = vi.hoisted(() => vi.fn(async () => undefined));
 const emitCliBannerMock = vi.hoisted(() => vi.fn());
 const enableConsoleCaptureMock = vi.hoisted(() => vi.fn());
 const progressDoneMock = vi.hoisted(() => vi.fn());
@@ -196,6 +197,10 @@ vi.mock("./gateway-cli/run-command.js", () => ({
 
 vi.mock("./command-execution-startup.js", () => ({
   ensureCliExecutionBootstrap: ensureCliExecutionBootstrapMock,
+}));
+
+vi.mock("./gateway-cli/startup-migrations.js", () => ({
+  runGatewayStartupMigrations: runGatewayStartupMigrationsMock,
 }));
 
 vi.mock("../version.js", () => ({
@@ -658,6 +663,9 @@ describe("runCli exit behavior", () => {
     const bootstrapOrder = ensureCliExecutionBootstrapMock.mock.invocationCallOrder[0] ?? 0;
     expect(recoveryOrder).toBeGreaterThan(0);
     expect(bootstrapOrder).toBeGreaterThan(recoveryOrder);
+    expect(runGatewayStartupMigrationsMock).toHaveBeenCalledWith({
+      beforeStateMigrations: expect.any(Function),
+    });
   });
 
   it("defers config-drift exit to the migration owner before startup migrations", async () => {

--- a/src/cli/run-main.ts
+++ b/src/cli/run-main.ts
@@ -223,7 +223,8 @@ async function tryRunGatewayRunFastPath(
       }
       return prepared;
     });
-    if (!shouldBootstrap) {
+    const gatewayMigrationGuard = beforeStateMigrations;
+    if (!shouldBootstrap || !gatewayMigrationGuard) {
       return;
     }
     await startupTrace.measure("gateway-run-bootstrap", async () => {
@@ -232,10 +233,14 @@ async function tryRunGatewayRunFastPath(
         commandPath,
         startupPolicy,
         loadPlugins: false,
-        ...(beforeStateMigrations ? { beforeStateMigrations } : {}),
+        beforeStateMigrations: gatewayMigrationGuard,
         ...(skipPristineStartupStateMigrations ? { skipPristineStartupStateMigrations: true } : {}),
         ...(skipPristineCoreStateMigrations ? { skipPristineCoreStateMigrations: true } : {}),
       });
+      // The fast config guard stays plugin-free; the starting gateway owns the
+      // plugin-aware migration pass that completes the startup checkpoint.
+      const { runGatewayStartupMigrations } = await import("./gateway-cli/startup-migrations.js");
+      await runGatewayStartupMigrations({ beforeStateMigrations: gatewayMigrationGuard });
       const { reloadTrustedGatewayRunEnvironment } = await import("./gateway-cli/pre-bootstrap.js");
       await reloadTrustedGatewayRunEnvironment({ runtime: defaultRuntime });
     });

--- a/src/commands/doctor-config-preflight.state-migration.test.ts
+++ b/src/commands/doctor-config-preflight.state-migration.test.ts
@@ -453,6 +453,31 @@ describe("runDoctorConfigPreflight state migration", () => {
     expect(startupMigrationLeaseRelease).toHaveBeenCalledOnce();
   });
 
+  it("leases plugin-free core migrations without stamping the full startup checkpoint", async () => {
+    needsStartupMigrationCheckpoint.mockReturnValue(true);
+
+    await runDoctorConfigPreflight({
+      migrateLegacyConfig: false,
+      invalidConfigNote: false,
+      requireStartupMigrationCheckpoint: true,
+      pluginRuntime: "none",
+    });
+
+    expect(autoMigrateLegacyStateDir).toHaveBeenCalledOnce();
+    expect(autoMigrateLegacyState).toHaveBeenCalledWith({
+      cfg: { gateway: { mode: "local", port: 19091 } },
+      env: process.env,
+      recoverCorruptTargetStore: undefined,
+      pluginRuntime: "none",
+    });
+    const pinnedEnv = acquireStartupMigrationLease.mock.calls[0]?.[0]?.env;
+    expect(needsStartupMigrationCheckpoint).toHaveBeenCalledWith({ env: pinnedEnv });
+    expect(acquireStartupMigrationLease).toHaveBeenCalledOnce();
+    expect(runPostCorePluginConvergence).not.toHaveBeenCalled();
+    expect(recordSuccessfulStartupMigrations).not.toHaveBeenCalled();
+    expect(startupMigrationLeaseRelease).toHaveBeenCalledOnce();
+  });
+
   it("records the startup migration checkpoint when state migrations only leave notices", async () => {
     needsStartupMigrationCheckpoint.mockReturnValue(true);
     autoMigrateLegacyStateDir.mockResolvedValueOnce({
@@ -704,6 +729,29 @@ describe("runDoctorConfigPreflight state migration", () => {
       "OpenClaw startup migrations did not complete cleanly; refusing to report the gateway ready.",
     );
 
+    expect(recordSuccessfulStartupMigrations).not.toHaveBeenCalled();
+    expect(startupMigrationLeaseRelease).toHaveBeenCalledOnce();
+  });
+
+  it("blocks the plugin-free gateway phase when core migration warnings remain", async () => {
+    needsStartupMigrationCheckpoint.mockReturnValue(true);
+    autoMigrateLegacyStateDir.mockResolvedValueOnce({
+      migrated: false,
+      skipped: false,
+      changes: [],
+      warnings: ["Left legacy state directory in place."],
+    });
+
+    await expect(
+      runDoctorConfigPreflight({
+        migrateLegacyConfig: false,
+        invalidConfigNote: false,
+        requireStartupMigrationCheckpoint: true,
+        pluginRuntime: "none",
+      }),
+    ).rejects.toThrow("refusing to report the gateway ready");
+
+    expect(runPostCorePluginConvergence).not.toHaveBeenCalled();
     expect(recordSuccessfulStartupMigrations).not.toHaveBeenCalled();
     expect(startupMigrationLeaseRelease).toHaveBeenCalledOnce();
   });

--- a/src/commands/doctor-config-preflight.ts
+++ b/src/commands/doctor-config-preflight.ts
@@ -18,6 +18,7 @@ import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { isTruthyEnvValue } from "../infra/env.js";
 import type { StartupMigrationLease } from "../infra/startup-migration-checkpoint.js";
 import { normalizePluginsConfig, resolveEffectiveEnableState } from "../plugins/config-state.js";
+import type { PluginRuntimeMode } from "../plugins/plugin-runtime-mode.js";
 import {
   buildDegradedPluginsFromVerificationFailures,
   formatPluginVerificationDiagnostic,
@@ -125,19 +126,21 @@ export type DoctorConfigPreflightResult = {
 
 function collectDoctorLegacyIssues(
   snapshot: Awaited<ReturnType<typeof readConfigFileSnapshot>>,
+  pluginRuntime: PluginRuntimeMode,
 ): LegacyConfigIssue[] {
   if (!snapshot.exists) {
     return [];
   }
   const resolvedRaw = snapshot.sourceConfig ?? snapshot.config ?? {};
   const sourceRaw = snapshot.parsed ?? resolvedRaw;
-  return findDoctorLegacyConfigIssues(resolvedRaw, sourceRaw);
+  return findDoctorLegacyConfigIssues(resolvedRaw, sourceRaw, undefined, pluginRuntime);
 }
 
 function addDoctorLegacyIssues(
   snapshot: Awaited<ReturnType<typeof readConfigFileSnapshot>>,
+  pluginRuntime: PluginRuntimeMode,
 ): Awaited<ReturnType<typeof readConfigFileSnapshot>> {
-  const legacyIssues = collectDoctorLegacyIssues(snapshot);
+  const legacyIssues = collectDoctorLegacyIssues(snapshot, pluginRuntime);
   if (legacyIssues.length === 0) {
     return snapshot;
   }
@@ -416,8 +419,10 @@ export async function runDoctorConfigPreflight(
     skipPristineStartupStateMigrations?: boolean;
     /** Enable migrations that may retire security-sensitive stores only during explicit repair. */
     doctorOnlyStateMigrations?: boolean;
+    pluginRuntime?: PluginRuntimeMode;
   } = {},
 ): Promise<DoctorConfigPreflightResult> {
+  const pluginRuntime = options.pluginRuntime ?? "full";
   const stateMigrationsRequested = options.migrateState !== false;
   const startupCheckpoint =
     options.requireStartupMigrationCheckpoint === true
@@ -425,6 +430,7 @@ export async function runDoctorConfigPreflight(
       : undefined;
   let stateMigrations: Awaited<ReturnType<typeof loadDoctorStateMigrations>> | undefined;
   let startupMigrationEnv = process.env;
+  let needsStartupCheckpoint = false;
   let shouldRecordStartupCheckpoint = false;
   let skipPristineStartupStateMigrations = options.skipPristineStartupStateMigrations === true;
   let skipPristineCoreStateMigrations =
@@ -468,10 +474,13 @@ export async function runDoctorConfigPreflight(
     if (startupCheckpoint) {
       // Later config reads can apply state selectors. Pin the accepted lease target for its lifetime.
       startupMigrationEnv = cloneEnvWithPlatformSemantics(process.env);
-      shouldRecordStartupCheckpoint = startupCheckpoint.needsStartupMigrationCheckpoint({
+      needsStartupCheckpoint = startupCheckpoint.needsStartupMigrationCheckpoint({
         env: startupMigrationEnv,
       });
-      startupMigrationLease = shouldRecordStartupCheckpoint
+      // Plugin-free startup still leases core mutations, but cannot prove plugin-owned
+      // convergence complete and must not stamp the process-wide full checkpoint.
+      shouldRecordStartupCheckpoint = needsStartupCheckpoint && pluginRuntime === "full";
+      startupMigrationLease = needsStartupCheckpoint
         ? startupCheckpoint.acquireStartupMigrationLease({ env: startupMigrationEnv })
         : undefined;
       if (startupMigrationLease) {
@@ -489,7 +498,7 @@ export async function runDoctorConfigPreflight(
     // migration. Keep repeated Gateway boots out of the legacy/plugin migration import graph.
     stateMigrations =
       stateMigrationsRequested &&
-      (!startupCheckpoint || shouldRecordStartupCheckpoint) &&
+      (!startupCheckpoint || needsStartupCheckpoint) &&
       !skipPristineStartupStateMigrations
         ? await measureStartupPreflightStep("state-migrations-import", loadDoctorStateMigrations)
         : undefined;
@@ -511,11 +520,13 @@ export async function runDoctorConfigPreflight(
     const readOptions = {
       ...(options.observe === false ? { observe: false } : {}),
       skipPluginValidation: shouldSkipPluginValidationForDoctorConfigPreflight(),
+      pluginRuntime,
     };
     let snapshot = addDoctorLegacyIssues(
       await measureStartupPreflightStep("config-snapshot", () =>
         readConfigFileSnapshot(readOptions),
       ),
+      pluginRuntime,
     );
     if (options.repairPrefixedConfig === true && snapshot.exists && !snapshot.valid) {
       if (await recoverConfigFromJsonRootSuffix(snapshot)) {
@@ -523,7 +534,7 @@ export async function runDoctorConfigPreflight(
           "Removed non-JSON prefix from openclaw.json; original saved as .clobbered.*.",
           "Config",
         );
-        snapshot = addDoctorLegacyIssues(await readConfigFileSnapshot(readOptions));
+        snapshot = addDoctorLegacyIssues(await readConfigFileSnapshot(readOptions), pluginRuntime);
       } else if (
         await recoverConfigFromLastKnownGood({ snapshot, reason: "doctor-invalid-config" })
       ) {
@@ -531,7 +542,7 @@ export async function runDoctorConfigPreflight(
           "Restored openclaw.json from last-known-good; original saved as .clobbered.*.",
           "Config",
         );
-        snapshot = addDoctorLegacyIssues(await readConfigFileSnapshot(readOptions));
+        snapshot = addDoctorLegacyIssues(await readConfigFileSnapshot(readOptions), pluginRuntime);
       }
       if (
         !snapshot.valid &&
@@ -593,6 +604,7 @@ export async function runDoctorConfigPreflight(
             await autoMigrateLegacyPluginDoctorState({
               config: pluginDoctorOnlyConfig,
               env: process.env,
+              ...(options.pluginRuntime ? { pluginRuntime } : {}),
             }),
           );
         } else if (stateMigrationInput.cfg) {
@@ -623,6 +635,7 @@ export async function runDoctorConfigPreflight(
             env: process.env,
             recoverCorruptTargetStore: options.recoverCorruptTargetStore,
             doctorOnlyStateMigrations: options.doctorOnlyStateMigrations,
+            ...(options.pluginRuntime ? { pluginRuntime } : {}),
           });
           doctorMediaPersistenceAttempted = options.doctorOnlyStateMigrations === true;
           noteStartupStateMigrationResult(legacyStateResult);
@@ -631,6 +644,7 @@ export async function runDoctorConfigPreflight(
             await autoMigrateLegacyPluginDoctorState({
               config: stateMigrationInput.pluginDoctorConfig,
               env: process.env,
+              ...(options.pluginRuntime ? { pluginRuntime } : {}),
             }),
           );
           noteStartupStateMigrationResult(
@@ -659,7 +673,7 @@ export async function runDoctorConfigPreflight(
       );
     }
     if (startupCheckpoint) {
-      if (shouldRecordStartupCheckpoint) {
+      if (startupMigrationLease) {
         if (startupMigrationHeartbeatError) {
           throw startupMigrationHeartbeatError instanceof Error
             ? startupMigrationHeartbeatError
@@ -673,6 +687,8 @@ export async function runDoctorConfigPreflight(
             }),
           );
         }
+      }
+      if (shouldRecordStartupCheckpoint) {
         if (!snapshot.valid) {
           throwStartupMigrationRefusal(
             formatStartupMigrationFailure({
@@ -682,32 +698,33 @@ export async function runDoctorConfigPreflight(
           );
         }
       }
-      // This state is established before the first Gateway plugin load and remains
-      // fixed for the boot. Refresh it on every process start because migration
-      // checkpoints do not persist plugin availability or quarantine state.
-      setActiveDegradedPlugins([]);
-      if (snapshot.valid) {
-        const pluginConvergence = shouldRecordStartupCheckpoint
-          ? await runStartupUpgradeConvergence({
-              cfg: baseConfig,
-              env: process.env,
-            })
-          : await refreshStartupPluginQuarantine({
-              cfg: baseConfig,
-              env: process.env,
-            });
-        setActiveDegradedPlugins(pluginConvergence.quarantinedPlugins);
-        if (pluginConvergence.blockingDiagnostic) {
-          throwStartupMigrationRefusal(
-            formatStartupPluginVerificationFailure(pluginConvergence.blockingDiagnostic),
-          );
+      if (pluginRuntime === "full") {
+        // This state is established before the first Gateway plugin load and remains
+        // fixed for the boot. Plugin-free CLI preflight must leave it to Gateway startup.
+        setActiveDegradedPlugins([]);
+        if (snapshot.valid) {
+          const pluginConvergence = shouldRecordStartupCheckpoint
+            ? await runStartupUpgradeConvergence({
+                cfg: baseConfig,
+                env: process.env,
+              })
+            : await refreshStartupPluginQuarantine({
+                cfg: baseConfig,
+                env: process.env,
+              });
+          setActiveDegradedPlugins(pluginConvergence.quarantinedPlugins);
+          if (pluginConvergence.blockingDiagnostic) {
+            throwStartupMigrationRefusal(
+              formatStartupPluginVerificationFailure(pluginConvergence.blockingDiagnostic),
+            );
+          }
         }
-      }
-      if (shouldRecordStartupCheckpoint) {
-        startupCheckpoint.recordSuccessfulStartupMigrations({
-          env: startupMigrationEnv,
-          lease: startupMigrationLease,
-        });
+        if (shouldRecordStartupCheckpoint) {
+          startupCheckpoint.recordSuccessfulStartupMigrations({
+            env: startupMigrationEnv,
+            lease: startupMigrationLease,
+          });
+        }
       }
     }
 

--- a/src/commands/doctor/shared/legacy-config-issues.ts
+++ b/src/commands/doctor/shared/legacy-config-issues.ts
@@ -8,6 +8,7 @@ import {
   collectRelevantDoctorPluginIdsForTouchedPaths,
   listPluginDoctorLegacyConfigRules,
 } from "../../../plugins/doctor-contract-registry.js";
+import type { PluginRuntimeMode } from "../../../plugins/plugin-runtime-mode.js";
 
 function collectConfiguredChannelIds(raw: unknown): ReadonlySet<string> {
   if (!raw || typeof raw !== "object") {
@@ -23,7 +24,11 @@ function collectConfiguredChannelIds(raw: unknown): ReadonlySet<string> {
 function collectPluginLegacyConfigRules(
   raw: unknown,
   touchedPaths?: ReadonlyArray<ReadonlyArray<string>>,
+  pluginRuntime: PluginRuntimeMode = "full",
 ): LegacyConfigRule[] {
+  if (pluginRuntime === "none") {
+    return [];
+  }
   const channelIds = collectConfiguredChannelIds(raw);
   const pluginIds = (
     touchedPaths
@@ -41,13 +46,14 @@ export function findDoctorLegacyConfigIssues(
   raw: unknown,
   sourceRaw?: unknown,
   touchedPaths?: ReadonlyArray<ReadonlyArray<string>>,
+  pluginRuntime: PluginRuntimeMode = "full",
 ): LegacyConfigIssue[] {
   return findLegacyConfigIssues(
     raw,
     sourceRaw,
     [
-      ...collectChannelLegacyConfigRules(raw, touchedPaths),
-      ...collectPluginLegacyConfigRules(raw, touchedPaths),
+      ...collectChannelLegacyConfigRules(raw, touchedPaths, undefined, pluginRuntime),
+      ...collectPluginLegacyConfigRules(raw, touchedPaths, pluginRuntime),
     ],
     touchedPaths,
   );

--- a/src/config/io.runtime.ts
+++ b/src/config/io.runtime.ts
@@ -138,6 +138,7 @@ export async function readConfigFileSnapshot(
     ...(options.isolateEnv ? { env: cloneEnvWithPlatformSemantics(process.env) } : {}),
     ...(options.lowerPrecedenceEnv ? { lowerPrecedenceEnv: options.lowerPrecedenceEnv } : {}),
     ...(options.skipPluginValidation ? { pluginValidation: "skip" } : {}),
+    ...(options.pluginRuntime ? { pluginRuntime: options.pluginRuntime } : {}),
     ...(options.suppressFutureVersionWarning ? { suppressFutureVersionWarning: true } : {}),
     ...(options.preservedLegacyRootKeys
       ? { preservedLegacyRootKeys: options.preservedLegacyRootKeys }

--- a/src/config/io.snapshot-shared.ts
+++ b/src/config/io.snapshot-shared.ts
@@ -1,3 +1,4 @@
+import type { PluginRuntimeMode } from "../plugins/plugin-runtime-mode.js";
 import { observeConfigSnapshot } from "./io.observe.js";
 import type { NormalizedConfigIoDeps, ReadConfigFileSnapshotInternalResult } from "./io.types.js";
 import { asResolvedSourceConfig, asRuntimeConfig } from "./materialize.js";
@@ -72,11 +73,12 @@ export async function finalizeReadConfigSnapshotInternalResult(
 export async function collectInvalidConfigLegacyIssues(
   raw: unknown,
   sourceRaw: unknown,
+  pluginRuntime: PluginRuntimeMode,
 ): Promise<LegacyConfigIssue[]> {
   if (!raw || typeof raw !== "object") {
     return [];
   }
   const { findDoctorLegacyConfigIssues } =
     await import("../commands/doctor/shared/legacy-config-issues.js");
-  return findDoctorLegacyConfigIssues(raw, sourceRaw);
+  return findDoctorLegacyConfigIssues(raw, sourceRaw, undefined, pluginRuntime);
 }

--- a/src/config/io.snapshot.ts
+++ b/src/config/io.snapshot.ts
@@ -193,7 +193,11 @@ export async function readConfigFileSnapshotInternal(
     );
     if (!validated.ok) {
       const legacyIssues = await deps.measure("config.snapshot.read.legacy-issues", () =>
-        collectInvalidConfigLegacyIssues(effectiveConfigRaw, effectiveParsed),
+        collectInvalidConfigLegacyIssues(
+          effectiveConfigRaw,
+          effectiveParsed,
+          context.options.pluginRuntime ?? "full",
+        ),
       );
       // Invalid snapshots stay inspectable, but rejected env.vars must not become runtime state.
       restoreEnvChangesIfUnchanged({

--- a/src/config/io.types.ts
+++ b/src/config/io.types.ts
@@ -1,6 +1,7 @@
 import type fs from "node:fs";
 import type JSON5 from "json5";
 import type { PluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot.js";
+import type { PluginRuntimeMode } from "../plugins/plugin-runtime-mode.js";
 import type {
   ConfigWriteAfterWrite,
   RuntimeConfigSnapshotRefreshOptions,
@@ -111,6 +112,7 @@ export type NormalizedConfigIoDeps = Required<ConfigIoDeps>;
 
 export type ConfigIoFactoryOptions = ConfigIoDeps & {
   pluginValidation?: "full" | "skip";
+  pluginRuntime?: PluginRuntimeMode;
   preservedLegacyRootKeys?: readonly string[];
   shellEnvFallback?: "load" | "defer";
 };
@@ -125,6 +127,7 @@ export type ConfigSnapshotReadOptions = {
     candidate: OpenClawConfig,
     current: OpenClawConfig,
   ) => boolean | Promise<boolean>;
+  pluginRuntime?: PluginRuntimeMode;
   skipPluginValidation?: boolean;
   preservedLegacyRootKeys?: readonly string[];
   suppressFutureVersionWarning?: boolean;

--- a/src/infra/state-migrations.doctor.ts
+++ b/src/infra/state-migrations.doctor.ts
@@ -23,6 +23,7 @@ import {
   type PluginDoctorStateMigrationDetection,
 } from "../plugins/doctor-contract-registry.js";
 import { resolveLegacyInstalledPluginIndexStorePath } from "../plugins/installed-plugin-index-store.js";
+import type { PluginRuntimeMode } from "../plugins/plugin-runtime-mode.js";
 import {
   DEFAULT_ACCOUNT_ID,
   DEFAULT_MAIN_KEY,
@@ -199,10 +200,16 @@ export function resetAutoMigrateLegacyStateForTest(): void {
 
 async function collectChannelLegacyStateMigrationPlans(params: {
   cfg: OpenClawConfig;
+  pluginRuntime: PluginRuntimeMode;
   env: NodeJS.ProcessEnv;
   stateDir: string;
   oauthDir: string;
 }): Promise<ChannelLegacyStateMigrationPlan[]> {
+  if (params.pluginRuntime === "none") {
+    // Channel-owned discovery evaluates setup modules, so plugin-free CLI
+    // preflights defer it to explicit doctor or plugin-loading startup.
+    return [];
+  }
   const plans: ChannelLegacyStateMigrationPlan[] = [];
   // Legacy state detection belongs on a narrow setup-entry surface so doctor
   // does not cold-load unrelated runtime channel code.
@@ -230,12 +237,18 @@ async function collectChannelLegacyStateMigrationPlans(params: {
 async function collectPluginDoctorStateMigrationPlans(params: {
   cfg: OpenClawConfig;
   pluginDoctorConfig?: OpenClawConfig;
+  pluginRuntime: PluginRuntimeMode;
   env: NodeJS.ProcessEnv;
   stateDir: string;
   oauthDir: string;
   includeDoctorOnly?: boolean;
   warnings?: string[];
 }): Promise<DetectedPluginDoctorStateMigrationPlan[]> {
+  if (params.pluginRuntime === "none") {
+    // Core migrations still run for plugin-free CLI commands, but executable plugin
+    // doctor contracts must wait for explicit doctor or plugin-loading startup.
+    return [];
+  }
   const plans: DetectedPluginDoctorStateMigrationPlan[] = [];
   const config = params.pluginDoctorConfig ?? params.cfg;
   for (const entry of listPluginDoctorStateMigrationEntries({
@@ -307,10 +320,12 @@ export async function detectLegacyStateMigrations(params: {
   env?: NodeJS.ProcessEnv;
   homedir?: () => string;
   pluginSessionStoreAgentIds?: readonly string[];
+  pluginRuntime?: PluginRuntimeMode;
   sessionStoreOwnership?: SessionStoreOwnership;
   doctorOnlyStateMigrations?: boolean;
 }): Promise<LegacyStateDetection> {
   const env = params.env ?? process.env;
+  const pluginRuntime = params.pluginRuntime ?? "full";
   const homedir = params.homedir ?? os.homedir;
   const stateDir = resolveStateDir(env, homedir);
   const oauthDir = resolveOAuthDir(env, stateDir);
@@ -327,14 +342,19 @@ export async function detectLegacyStateMigrations(params: {
   const sessionsLegacyStorePath = path.join(sessionsLegacyDir, "sessions.json");
   const sessionsTargetDir = path.join(stateDir, "agents", targetAgentId, "sessions");
   const sessionsTargetStorePath = path.join(sessionsTargetDir, "sessions.json");
+  // Moving the legacy store consumes provenance needed for channel classification and
+  // direct-chat fallback. Leave the whole session migration for the later full pass.
+  const detectSessionMigrations = pluginRuntime === "full";
   const pluginConfig = params.pluginDoctorConfig ?? params.cfg;
   const pluginSessionStoreAgentIds =
     params.pluginSessionStoreAgentIds ??
-    listPluginDoctorSessionStoreAgentIds({
-      config: pluginConfig,
-      env,
-      pluginIds: collectRelevantDoctorPluginIds(pluginConfig),
-    });
+    (pluginRuntime === "none"
+      ? []
+      : listPluginDoctorSessionStoreAgentIds({
+          config: pluginConfig,
+          env,
+          pluginIds: collectRelevantDoctorPluginIds(pluginConfig),
+        }));
   const currentSessionStoreOwnership = resolveSessionStoreOwnership({
     cfg: params.cfg,
     env,
@@ -355,14 +375,16 @@ export async function detectLegacyStateMigrations(params: {
     ),
   };
   const { preserveForeignMainAliases } = sessionStoreOwnership;
-  const legacySessionEntries = safeReadDir(sessionsLegacyDir);
+  const legacySessionEntries = detectSessionMigrations ? safeReadDir(sessionsLegacyDir) : [];
   const hasLegacySessions =
-    fileExists(sessionsLegacyStorePath) ||
-    legacySessionEntries.some((e) => e.isFile() && e.name.endsWith(".jsonl"));
+    detectSessionMigrations &&
+    (fileExists(sessionsLegacyStorePath) ||
+      legacySessionEntries.some((e) => e.isFile() && e.name.endsWith(".jsonl")));
 
-  const targetSessionParsed = fileExists(sessionsTargetStorePath)
-    ? readSessionStoreJson5(sessionsTargetStorePath)
-    : { store: {}, ok: true };
+  const targetSessionParsed =
+    detectSessionMigrations && fileExists(sessionsTargetStorePath)
+      ? readSessionStoreJson5(sessionsTargetStorePath)
+      : { store: {}, ok: true };
   const legacyKeys = targetSessionParsed.ok
     ? listLegacySessionKeys({
         store: targetSessionParsed.store,
@@ -371,9 +393,11 @@ export async function detectLegacyStateMigrations(params: {
         scope: targetScope,
         preserveAmbiguousKeys: sessionStoreOwnership.preserveAmbiguousKeys,
         preserveForeignMainAliases,
+        pluginRuntime,
       })
     : [];
   const hasStaleSessionFiles =
+    detectSessionMigrations &&
     targetSessionParsed.ok &&
     Object.values(targetSessionParsed.store).some((entry) =>
       Boolean(
@@ -524,7 +548,8 @@ export async function detectLegacyStateMigrations(params: {
         value && typeof value === "object" && !Array.isArray(value)
           ? (value as { accounts?: unknown; defaultAccount?: unknown })
           : undefined;
-      const plugin = getChannelPlugin(channelId as ChannelId);
+      const plugin =
+        pluginRuntime === "full" ? getChannelPlugin(channelId as ChannelId) : undefined;
       const accountIds = [
         ...(plugin?.config.listAccountIds(params.cfg) ?? []),
         ...(channelConfig?.accounts &&
@@ -568,7 +593,8 @@ export async function detectLegacyStateMigrations(params: {
         if (typeof defaultAccount === "string" && defaultAccount.trim()) {
           return [[channelId, defaultAccount.trim()]];
         }
-        const plugin = getChannelPlugin(channelId as ChannelId);
+        const plugin =
+          pluginRuntime === "full" ? getChannelPlugin(channelId as ChannelId) : undefined;
         if (plugin) {
           return [[channelId, resolveChannelDefaultAccountId({ plugin, cfg: params.cfg })]];
         }
@@ -579,6 +605,7 @@ export async function detectLegacyStateMigrations(params: {
   });
   const channelPlans = await collectChannelLegacyStateMigrationPlans({
     cfg: params.cfg,
+    pluginRuntime,
     env,
     stateDir,
     oauthDir,
@@ -590,6 +617,7 @@ export async function detectLegacyStateMigrations(params: {
       : await collectPluginDoctorStateMigrationPlans({
           cfg: params.cfg,
           pluginDoctorConfig: params.pluginDoctorConfig,
+          pluginRuntime,
           env,
           stateDir,
           oauthDir,
@@ -725,6 +753,7 @@ export async function detectLegacyStateMigrations(params: {
 
   return {
     doctorOnlyStateMigrations: params.doctorOnlyStateMigrations === true,
+    pluginRuntime,
     targetAgentId,
     targetMainKey,
     targetScope,
@@ -830,6 +859,7 @@ async function runPluginDoctorStateMigrationPlans(params: {
   const notices: string[] = [];
   const refreshedPlans = await collectPluginDoctorStateMigrationPlans({
     cfg: params.config,
+    pluginRuntime: params.detected.pluginRuntime ?? "full",
     env: params.env,
     stateDir: params.detected.stateDir,
     oauthDir: params.detected.oauthDir,
@@ -926,6 +956,7 @@ export async function autoMigrateLegacyPluginDoctorState(params: {
   env?: NodeJS.ProcessEnv;
   homedir?: () => string;
   log?: MigrationLogger;
+  pluginRuntime?: PluginRuntimeMode;
 }): Promise<{
   migrated: boolean;
   skipped: boolean;
@@ -958,6 +989,7 @@ export async function autoMigrateLegacyPluginDoctorState(params: {
   }
   const plans = await collectPluginDoctorStateMigrationPlans({
     cfg: params.config,
+    pluginRuntime: params.pluginRuntime ?? "full",
     env,
     stateDir,
     oauthDir,
@@ -1273,6 +1305,7 @@ export async function autoMigrateLegacyState(params: {
   now?: () => number;
   recoverCorruptTargetStore?: boolean;
   doctorOnlyStateMigrations?: boolean;
+  pluginRuntime?: PluginRuntimeMode;
 }): Promise<{
   migrated: boolean;
   skipped: boolean;
@@ -1282,9 +1315,10 @@ export async function autoMigrateLegacyState(params: {
 }> {
   const env = params.env ?? process.env;
   const homedir = params.homedir ?? os.homedir;
+  const pluginRuntime = params.pluginRuntime ?? "full";
   const migrationMode = params.doctorOnlyStateMigrations === true ? "doctor-repair" : "automatic";
   const initialStateDir = resolveStateDir(env, homedir);
-  const checkKey = `${path.resolve(initialStateDir)}\0${migrationMode}`;
+  const checkKey = `${path.resolve(initialStateDir)}\0${migrationMode}\0${pluginRuntime}`;
   if (autoMigrateChecked.has(checkKey)) {
     return { migrated: false, skipped: true, changes: [], warnings: [] };
   }
@@ -1296,7 +1330,9 @@ export async function autoMigrateLegacyState(params: {
     log: params.log,
   });
   const stateDir = resolveStateDir(env, homedir);
-  autoMigrateChecked.add(`${path.resolve(stateDir)}\0${migrationMode}`);
+  // Gateway startup follows the plugin-free core pass with a full plugin-aware pass.
+  // Track them separately or the first pass suppresses required plugin migrations.
+  autoMigrateChecked.add(`${path.resolve(stateDir)}\0${migrationMode}\0${pluginRuntime}`);
   const stateSchema = repairOpenClawStateDatabaseSchema({
     env: { ...env, OPENCLAW_STATE_DIR: stateDir },
   });
@@ -1330,11 +1366,14 @@ export async function autoMigrateLegacyState(params: {
     config: pluginDoctorConfig,
     env: { ...env, OPENCLAW_STATE_DIR: stateDir },
   });
-  const pluginSessionStoreAgentIds = listPluginDoctorSessionStoreAgentIds({
-    config: pluginDoctorConfig,
-    env,
-    pluginIds: collectRelevantDoctorPluginIds(pluginDoctorConfig),
-  });
+  const pluginSessionStoreAgentIds =
+    pluginRuntime === "none"
+      ? []
+      : listPluginDoctorSessionStoreAgentIds({
+          config: pluginDoctorConfig,
+          env,
+          pluginIds: collectRelevantDoctorPluginIds(pluginDoctorConfig),
+        });
   // Capture ownership before orphan-key rewrites. Atomic replacement can split
   // a configured filesystem alias from the standard target pathname.
   const sessionStoreOwnership = resolveSessionStoreOwnership({
@@ -1351,12 +1390,14 @@ export async function autoMigrateLegacyState(params: {
     cfg: params.cfg,
     env,
     additionalAgentIds: pluginSessionStoreAgentIds,
+    pluginRuntime,
   });
   const acpSessionMetadata = await migrateLegacyAcpSessionMetadata({
     cfg: params.cfg,
     env,
     now: params.now,
     pluginSessionStoreAgentIds,
+    pluginRuntime,
   });
 
   const logMigrationResults = (changes: string[], warnings: string[], notices: string[]) => {
@@ -1382,6 +1423,7 @@ export async function autoMigrateLegacyState(params: {
     cfg: params.cfg,
     pluginDoctorConfig: params.pluginDoctorConfig,
     pluginSessionStoreAgentIds,
+    pluginRuntime,
     sessionStoreOwnership,
     env,
     homedir: params.homedir,
@@ -1683,6 +1725,7 @@ export async function autoMigrateLegacyState(params: {
     env,
     now,
     pluginSessionStoreAgentIds,
+    pluginRuntime,
   });
   const agentDir = await migrateLegacyAgentDir(detected, now);
   const channelPlans = await runLegacyMigrationPlans(

--- a/src/infra/state-migrations.legacy-sessions.ts
+++ b/src/infra/state-migrations.legacy-sessions.ts
@@ -98,6 +98,7 @@ export async function migrateLegacySessions(
     preserveCanonicalAgentOwner: true,
     preserveAmbiguousKeys: detected.sessions.preserveAmbiguousKeys,
     preserveForeignMainAliases: detected.sessions.preserveForeignMainAliases,
+    pluginRuntime: detected.pluginRuntime,
   });
   const canonicalizedLegacy = canonicalizeSessionStore({
     store: legacyStore,
@@ -106,6 +107,7 @@ export async function migrateLegacySessions(
     scope: detected.targetScope,
     preserveCanonicalAgentOwner: true,
     preserveForeignMainAliases: detected.sessions.preserveForeignMainAliases,
+    pluginRuntime: detected.pluginRuntime,
   });
   const preservedLegacyForeignMainAliasCount = detected.sessions.preserveForeignMainAliases
     ? Object.keys(legacyStore).filter((key) =>
@@ -144,7 +146,7 @@ export async function migrateLegacySessions(
   });
   let migratedDirectChatKey: string | undefined;
   if (!merged[mainKey]) {
-    const latest = pickLatestLegacyDirectEntry(legacyStore);
+    const latest = pickLatestLegacyDirectEntry(legacyStore, detected.pluginRuntime);
     if (latest?.sessionId) {
       merged[mainKey] = latest;
       migratedDirectChatKey = mainKey;

--- a/src/infra/state-migrations.session-store.ts
+++ b/src/infra/state-migrations.session-store.ts
@@ -20,6 +20,7 @@ import {
   collectRelevantDoctorPluginIds,
   listPluginDoctorSessionStoreAgentIds,
 } from "../plugins/doctor-contract-registry.js";
+import type { PluginRuntimeMode } from "../plugins/plugin-runtime-mode.js";
 import {
   LEGACY_IMPLICIT_AGENT_ID as DEFAULT_AGENT_ID,
   DEFAULT_MAIN_KEY,
@@ -78,6 +79,7 @@ function canonicalizeSessionKeyForAgent(params: {
   preserveCanonicalAgentOwner?: boolean;
   preserveAmbiguousKeys?: boolean;
   preserveForeignMainAliases?: boolean;
+  pluginRuntime?: PluginRuntimeMode;
 }): string {
   const raw = params.key.trim();
   if (!raw) {
@@ -178,10 +180,15 @@ function canonicalizeSessionKeyForAgent(params: {
     const rest = raw.slice("subagent:".length);
     return normalizeLowercaseStringOrEmpty(`agent:${agentId}:subagent:${rest}`);
   }
+  if (params.pluginRuntime === "none") {
+    // Without channel surfaces, opaque legacy keys cannot be classified safely.
+    // Preserve them for the full pass instead of persisting a generic fallback.
+    return params.key;
+  }
   // Channel-owned legacy shapes must win before the generic group/channel
   // fallback so plugin-specific legacy group keys can canonicalize to their
   // owning channel instead of the generic `...:unknown:group:...` bucket.
-  for (const surface of getLegacySessionSurfaces()) {
+  for (const surface of getLegacySessionSurfaces(params.pluginRuntime)) {
     const canonicalized = surface.canonicalizeLegacySessionKey?.({
       key: raw,
       agentId,
@@ -202,7 +209,12 @@ function canonicalizeSessionKeyForAgent(params: {
 
 export function pickLatestLegacyDirectEntry(
   store: Record<string, SessionEntryLike>,
+  pluginRuntime: PluginRuntimeMode = "full",
 ): SessionEntryLike | null {
+  // Plugin-free preflight cannot distinguish an opaque direct key from a channel-owned key.
+  if (pluginRuntime === "none") {
+    return null;
+  }
   let best: SessionEntryLike | null = null;
   let bestUpdated = -1;
   for (const [key, entry] of Object.entries(store)) {
@@ -223,7 +235,7 @@ export function pickLatestLegacyDirectEntry(
     if (normalizedLower.startsWith("subagent:")) {
       continue;
     }
-    if (isLegacyGroupKey(normalized) || isSurfaceGroupKey(normalized)) {
+    if (isLegacyGroupKey(normalized, pluginRuntime) || isSurfaceGroupKey(normalized)) {
       continue;
     }
     const updatedAt = typeof entry.updatedAt === "number" ? entry.updatedAt : 0;
@@ -289,6 +301,7 @@ export function canonicalizeSessionStore(params: {
   preserveCanonicalAgentOwner?: boolean;
   preserveAmbiguousKeys?: boolean;
   preserveForeignMainAliases?: boolean;
+  pluginRuntime?: PluginRuntimeMode;
 }): { store: Record<string, SessionEntryLike>; legacyKeys: string[] } {
   const canonical = Object.create(null) as Record<string, SessionEntryLike>;
   const meta = new Map<string, { isCanonical: boolean; updatedAt: number }>();
@@ -307,6 +320,7 @@ export function canonicalizeSessionStore(params: {
       preserveCanonicalAgentOwner: params.preserveCanonicalAgentOwner,
       preserveAmbiguousKeys: params.preserveAmbiguousKeys,
       preserveForeignMainAliases: params.preserveForeignMainAliases,
+      pluginRuntime: params.pluginRuntime,
     });
     const isCanonical = canonicalKey === key;
     if (!isCanonical) {
@@ -682,6 +696,7 @@ export function listLegacySessionKeys(params: {
   scope?: SessionScope;
   preserveAmbiguousKeys?: boolean;
   preserveForeignMainAliases?: boolean;
+  pluginRuntime?: PluginRuntimeMode;
 }): string[] {
   const legacy: string[] = [];
   for (const key of Object.keys(params.store)) {
@@ -694,6 +709,7 @@ export function listLegacySessionKeys(params: {
       preserveCanonicalAgentOwner: params.preserveAmbiguousKeys,
       preserveAmbiguousKeys: params.preserveAmbiguousKeys,
       preserveForeignMainAliases: params.preserveForeignMainAliases,
+      pluginRuntime: params.pluginRuntime,
     });
     if (canonical !== key) {
       legacy.push(key);
@@ -727,6 +743,7 @@ export async function migrateOrphanedSessionKeys(params: {
   cfg: OpenClawConfig;
   env?: NodeJS.ProcessEnv;
   additionalAgentIds?: readonly string[];
+  pluginRuntime?: PluginRuntimeMode;
 }): Promise<{ changes: string[]; warnings: string[] }> {
   const changes: string[] = [];
   const warnings: string[] = [];
@@ -737,11 +754,13 @@ export async function migrateOrphanedSessionKeys(params: {
   const storeConfig = params.cfg.session?.store;
   const pluginAgentIds =
     params.additionalAgentIds ??
-    listPluginDoctorSessionStoreAgentIds({
-      config: params.cfg,
-      env,
-      pluginIds: collectRelevantDoctorPluginIds(params.cfg),
-    });
+    (params.pluginRuntime === "none"
+      ? []
+      : listPluginDoctorSessionStoreAgentIds({
+          config: params.cfg,
+          env,
+          pluginIds: collectRelevantDoctorPluginIds(params.cfg),
+        }));
   const pluginAgentIdSet = new Set(pluginAgentIds.map((id) => normalizeAgentId(id)));
 
   // Collect all known agent store paths with their owning agentIds.
@@ -886,6 +905,7 @@ export async function migrateOrphanedSessionKeys(params: {
         preserveCanonicalAgentOwner: true,
         preserveAmbiguousKeys,
         preserveForeignMainAliases: pluginForeignMainAliasRisk,
+        pluginRuntime: params.pluginRuntime,
       });
       working = canonicalized;
       // Each pass only counts keys it changed from the current working store, so
@@ -923,7 +943,12 @@ export async function migrateLegacyAcpSessionMetadata(params: {
   env?: NodeJS.ProcessEnv;
   now?: () => number;
   pluginSessionStoreAgentIds?: readonly string[];
+  pluginRuntime?: PluginRuntimeMode;
 }): Promise<{ changes: string[]; warnings: string[] }> {
+  // ACP metadata keys must follow the same channel-aware canonicalization as their sessions.
+  if (params.pluginRuntime === "none") {
+    return { changes: [], warnings: [] };
+  }
   const changes: string[] = [];
   const warnings: string[] = [];
   const env = params.env ?? process.env;
@@ -1085,6 +1110,7 @@ export async function migrateLegacyAcpSessionMetadata(params: {
           mainKey,
           scope,
           skipCrossAgentRemap: true,
+          pluginRuntime: params.pluginRuntime,
         });
         writeAcpSessionMetaForMigration({
           sessionKey: canonicalSessionKey,

--- a/src/infra/state-migrations.session-surfaces.ts
+++ b/src/infra/state-migrations.session-surfaces.ts
@@ -1,5 +1,6 @@
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
 import { listBundledChannelLegacySessionSurfaces } from "../channels/plugins/bundled.js";
+import type { PluginRuntimeMode } from "../plugins/plugin-runtime-mode.js";
 
 type LegacySessionSurface = {
   isLegacyGroupSessionKey?: (key: string) => boolean;
@@ -11,7 +12,14 @@ type LegacySessionSurface = {
 
 let cachedLegacySessionSurfaces: LegacySessionSurface[] | null = null;
 
-export function getLegacySessionSurfaces(): LegacySessionSurface[] {
+export function getLegacySessionSurfaces(
+  pluginRuntime: PluginRuntimeMode = "full",
+): LegacySessionSurface[] {
+  if (pluginRuntime === "none") {
+    // Session cleanup evaluates channel setup modules; plugin-free preflight
+    // leaves channel-owned key shapes for the later full migration pass.
+    return [];
+  }
   // Legacy migrations run on cold doctor/startup paths. Prefer the narrower
   // setup plugin surface here so session-key cleanup does not materialize full
   // bundled channel runtimes.
@@ -23,7 +31,7 @@ export function isSurfaceGroupKey(key: string): boolean {
   return key.includes(":group:") || key.includes(":channel:");
 }
 
-export function isLegacyGroupKey(key: string): boolean {
+export function isLegacyGroupKey(key: string, pluginRuntime: PluginRuntimeMode = "full"): boolean {
   const trimmed = key.trim();
   if (!trimmed) {
     return false;
@@ -32,7 +40,7 @@ export function isLegacyGroupKey(key: string): boolean {
   if (lower.startsWith("group:") || lower.startsWith("channel:")) {
     return true;
   }
-  for (const surface of getLegacySessionSurfaces()) {
+  for (const surface of getLegacySessionSurfaces(pluginRuntime)) {
     if (surface.isLegacyGroupSessionKey?.(trimmed)) {
       return true;
     }

--- a/src/infra/state-migrations.test.ts
+++ b/src/infra/state-migrations.test.ts
@@ -1888,6 +1888,57 @@ describe("state migrations", () => {
     await expectMissingPath(restartSentinelPath);
   });
 
+  it("runs a full migration pass after a plugin-free core pass", async () => {
+    const root = await createTempDir();
+    const stateDir = path.join(root, ".openclaw");
+    const env = createEnv(stateDir);
+    const cfg = createConfig();
+    const legacyStorePath = path.join(stateDir, "sessions", "sessions.json");
+    await fs.mkdir(path.dirname(legacyStorePath), { recursive: true });
+    await fs.writeFile(
+      legacyStorePath,
+      JSON.stringify({
+        "legacy-direct": {
+          sessionId: "legacy-direct-session",
+          updatedAt: 1,
+        },
+      }),
+      "utf8",
+    );
+
+    const pluginFree = await autoMigrateLegacyState({
+      cfg,
+      env,
+      homedir: () => root,
+      pluginRuntime: "none",
+    });
+    await expect(fs.readFile(legacyStorePath, "utf8")).resolves.toContain("legacy-direct-session");
+    const full = await autoMigrateLegacyState({
+      cfg,
+      env,
+      homedir: () => root,
+      pluginRuntime: "full",
+    });
+    const repeatedFull = await autoMigrateLegacyState({
+      cfg,
+      env,
+      homedir: () => root,
+      pluginRuntime: "full",
+    });
+
+    expect(pluginFree.skipped).toBe(false);
+    expect(full.skipped).toBe(false);
+    expect(repeatedFull.skipped).toBe(true);
+    const targetStore = JSON.parse(
+      await fs.readFile(
+        path.join(stateDir, "agents", "worker-1", "sessions", "sessions.json"),
+        "utf8",
+      ),
+    ) as Record<string, { sessionId?: string }>;
+    expect(targetStore["agent:worker-1:desk"]?.sessionId).toBe("legacy-direct-session");
+    await expectMissingPath(legacyStorePath);
+  });
+
   it("runs plugin doctor migrations after repairing shared state schema", async () => {
     const root = await createTempDir();
     const stateDir = path.join(root, ".openclaw");

--- a/src/infra/state-migrations.types.ts
+++ b/src/infra/state-migrations.types.ts
@@ -1,6 +1,7 @@
 import type { ChannelLegacyStateMigrationPlan } from "../channels/plugins/types.core.js";
 import type { SessionScope } from "../config/sessions/types.js";
 import type { PluginDoctorStateMigration } from "../plugins/doctor-contract-registry.js";
+import type { PluginRuntimeMode } from "../plugins/plugin-runtime-mode.js";
 import type { LegacyAuditLogsDetection } from "./state-migrations.audit-logs.types.js";
 import type { LegacyChannelPairingStateDetection } from "./state-migrations.channel-pairing.js";
 import type { LegacyDeviceIdentityDetection } from "./state-migrations.device-identity.types.js";
@@ -23,6 +24,7 @@ export type SessionStoreAliasPlan = {
 
 export type LegacyStateDetection = {
   doctorOnlyStateMigrations?: boolean;
+  pluginRuntime?: PluginRuntimeMode;
   targetAgentId: string;
   targetMainKey: string;
   targetScope?: SessionScope;

--- a/src/plugins/plugin-runtime-mode.ts
+++ b/src/plugins/plugin-runtime-mode.ts
@@ -1,0 +1,2 @@
+/** Whether a control-plane preflight may evaluate executable plugin-owned modules. */
+export type PluginRuntimeMode = "full" | "none";


### PR DESCRIPTION
Closes #114615

## What Problem This Solves

Fixes an issue where users running plugin-free CLI commands such as `openclaw gateway call` would still initialize executable plugin code during config preflight, adding seconds of client-side latency before the gateway RPC.

## Why This Change Was Made

The resolved CLI plugin policy now drives an internal closed `PluginRuntimeMode` through config guard and doctor preflight. `loadPlugins: "never"` commands still parse, include-resolve, validate, and run core state migrations, but legacy channel discovery trusts only the narrow bundled doctor-contract API and defers executable plugin doctor/state/session discovery to explicit doctor or plugin-loading gateway startup.

Gateway startup completes a separate full plugin-aware migration phase before recording its startup checkpoint. No config key or environment variable is added.

## User Impact

Gateway RPCs and other `loadPlugins: "never"` commands no longer create a jiti/source-transform loader during config preflight. Commands that load plugins, explicit `openclaw doctor`, and gateway startup retain the existing plugin-aware validation and migration behavior.

Stable v2026.7.1 investigation on macOS 26.5.2 / Node v22.22.3:

| Measurement | Plugin runtime evaluated | Plugin runtime suppressed |
|---|---:|---:|
| `gateway call status` end-to-end | 16.759 s | 0.936 s |
| Gateway-side `status` handling for the 16.759 s call | 0.528 s | — |

Patch A/B (same host, same running gateway, unpatched vs patched build of the stable worktree; `node dist/index.js`, three runs each — timings are host-load sensitive):

| RPC | Before (s) | Before mean | After (s) | After mean |
|---|---|---:|---|---:|
| `gateway call health` | 5.09, 4.90, 4.93 | 4.97 | 0.91, 0.90, 0.88 | 0.90 |
| `gateway call status` | 5.17, 5.25, 5.36 | 5.26 | 1.16, 1.09, 1.11 | 1.12 |

## Evidence

- A real bootstrap/config-guard regression configures a source-only channel plugin, injects the loader factory at `getCachedPluginModuleLoader`, and proves zero source-transform factory calls for `gateway call`, `health`, and deferred opaque session migration.
- Policy and guard tests assert `["gateway", "call"]` resolves `loadPlugins: "never"` and enters doctor preflight with `pluginRuntime: "none"`.
- Legacy-config tests prove empty or unresolved narrow contracts cannot fall back to `getBootstrapChannelPlugin()` or the plugin doctor registry in plugin-free mode.
- State-migration and gateway-startup tests prove core/plugin-free work runs first, full plugin-owned migration remains eligible afterward, and only the full phase records the startup checkpoint.
- Main-based worktree validation:
  - `pnpm install`: passed; all 175 workspace projects already up to date.
  - `pnpm build`: passed; CLI bootstrap import guard and all 143 public plugin SDK subpaths passed; no `INEFFECTIVE_DYNAMIC_IMPORT` warning.
  - `pnpm tsgo:prod`: passed for core, UI, and extensions.
  - Focused/touched tests: 13 files, 441 tests passed.
  - `git diff --check`: passed.

AI-assisted: Codex ported the reviewed stable overlay to current main, adapted it to the split config/state-migration modules, and ran the validation above. Human review is requested for the startup checkpoint and split session-migration adaptations.
