### PR TITLE
fix(agents): keep reply-path and run-contract tools visible under tool search

### DIFF
--- a/src/agents/embedded-agent-runner/run/attempt-tool-catalog.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-tool-catalog.ts
@@ -9,10 +9,7 @@ import {
   CODE_MODE_WAIT_TOOL_NAME,
   createCodeModeTools,
 } from "../../code-mode.js";
-import {
-  filterLocalModelLeanTools,
-  shouldCatalogToolForLocalModelLean,
-} from "../../local-model-lean.js";
+import { filterLocalModelLeanTools } from "../../local-model-lean.js";
 import { logAgentRuntimeToolDiagnostics } from "../../runtime-plan/tools.js";
 import { buildEmptyExplicitToolAllowlistError } from "../../tool-allowlist-guard.js";
 import { filterRuntimeCompatibleTools } from "../../tool-schema-projection.js";
@@ -54,7 +51,6 @@ export function prepareEmbeddedAttemptToolCatalog(input: {
   const { attempt, preparedToolBase } = input;
   const {
     codeModeControlsEnabledForRun,
-    localModelLeanEnabled,
     localModelLeanPreserveToolNames,
     runtimeCapabilityProfile,
     toolSearchConfig,
@@ -95,7 +91,9 @@ export function prepareEmbeddedAttemptToolCatalog(input: {
         executeTool: input.executeCodeModeTool,
       })
     : [];
-  const directoryDirectToolNames =
+  // When the message tool is the only reply path it must stay directly visible
+  // in every search mode; a hidden delivery tool can leave the run mute.
+  const requiredDirectToolNames =
     attempt.forceMessageTool === true || attempt.sourceReplyDeliveryMode === "message_tool_only"
       ? ["message"]
       : [];
@@ -120,7 +118,7 @@ export function prepareEmbeddedAttemptToolCatalog(input: {
           runId: attempt.runId,
           catalogRef: preparedToolBase.toolSearchCatalogRef,
           toolHookContext: catalogToolHookContext,
-          directToolNames: directoryDirectToolNames,
+          directToolNames: requiredDirectToolNames,
         })
       : applyToolSearchCatalog({
           tools: effectiveTools,
@@ -131,10 +129,7 @@ export function prepareEmbeddedAttemptToolCatalog(input: {
           runId: attempt.runId,
           catalogRef: preparedToolBase.toolSearchCatalogRef,
           toolHookContext: catalogToolHookContext,
-          shouldCatalogTool:
-            localModelLeanEnabled && toolSearchConfig.mode === "tools"
-              ? shouldCatalogToolForLocalModelLean
-              : undefined,
+          directToolNames: requiredDirectToolNames,
         });
   const projectedToolSearchTools = filterLocalModelLeanTools({
     tools: toolSearch.tools,

--- a/src/agents/harness/tool-surface-bridge.test.ts
+++ b/src/agents/harness/tool-surface-bridge.test.ts
@@ -144,6 +144,38 @@ describe("createAgentHarnessToolSurfaceRuntime", () => {
     }
   });
 
+  it("keeps policy-required message delivery directly visible in structured mode", () => {
+    const runtime = createAgentHarnessToolSurfaceRuntime({
+      config: { tools: { toolSearch: { enabled: true, mode: "tools" } } },
+      executeTool: async () => ({ content: [], details: {} }),
+      sourceReplyDeliveryMode: "message_tool_only",
+      modelToolsEnabled: true,
+    });
+
+    try {
+      expect(
+        runtime
+          .compactTools(
+            tools([
+              TOOL_SEARCH_RAW_TOOL_NAME,
+              TOOL_DESCRIBE_RAW_TOOL_NAME,
+              TOOL_CALL_RAW_TOOL_NAME,
+              "web_search",
+              "message",
+            ]),
+          )
+          .tools.map((tool) => tool.name),
+      ).toEqual([
+        TOOL_SEARCH_RAW_TOOL_NAME,
+        TOOL_DESCRIBE_RAW_TOOL_NAME,
+        TOOL_CALL_RAW_TOOL_NAME,
+        "message",
+      ]);
+    } finally {
+      runtime.cleanup();
+    }
+  });
+
   it("keeps policy-required message delivery directly visible in directory mode", () => {
     const runtime = createAgentHarnessToolSurfaceRuntime({
       config: { tools: { toolSearch: { enabled: true, mode: "directory" } } },

--- a/src/agents/harness/tool-surface-bridge.ts
+++ b/src/agents/harness/tool-surface-bridge.ts
@@ -11,9 +11,7 @@ import {
 import { resolveConversationCapabilityProfile } from "../conversation-capability-profile.js";
 import {
   filterLocalModelLeanTools,
-  isLocalModelLeanEnabled,
   resolveLocalModelLeanPreserveToolNames,
-  shouldCatalogToolForLocalModelLean,
 } from "../local-model-lean.js";
 import type { ScheduledToolPolicyContext } from "../scheduled-tool-policy.js";
 import { filterRuntimeCompatibleTools } from "../tool-schema-projection.js";
@@ -80,11 +78,6 @@ export function createAgentHarnessToolSurfaceRuntime(params: {
 }): AgentHarnessToolSurfaceRuntime {
   const forceDirectMessageTool =
     params.forceMessageTool === true || params.sourceReplyDeliveryMode === "message_tool_only";
-  const localModelLeanEnabled = isLocalModelLeanEnabled({
-    config: params.config,
-    agentId: params.agentId,
-    sessionKey: params.sessionKey,
-  });
   const codeModeConfig = resolveCodeModeConfig(params.config, params.agentId);
   const toolSearchRuntimeConfig = resolveAgentToolSearchRuntimeConfig({
     config: params.config,
@@ -162,7 +155,9 @@ export function createAgentHarnessToolSurfaceRuntime(params: {
           executeTool: params.executeTool,
         })
       : [];
-    const directoryDirectToolNames = forceDirectMessageTool ? ["message"] : [];
+    // When the message tool is the only reply path it must stay directly visible
+    // in every search mode; a hidden delivery tool can leave the run mute.
+    const requiredDirectToolNames = forceDirectMessageTool ? ["message"] : [];
     const compacted = codeModeControlsEnabled
       ? applyCodeModeCatalog({
           tools: [...codeModeTools, ...effectiveTools],
@@ -184,7 +179,7 @@ export function createAgentHarnessToolSurfaceRuntime(params: {
             runId: params.runId,
             catalogRef: toolSearchCatalogRef,
             toolHookContext: options.hookContext,
-            directToolNames: directoryDirectToolNames,
+            directToolNames: requiredDirectToolNames,
           })
         : applyToolSearchCatalog({
             tools: effectiveTools,
@@ -195,10 +190,7 @@ export function createAgentHarnessToolSurfaceRuntime(params: {
             runId: params.runId,
             catalogRef: toolSearchCatalogRef,
             toolHookContext: options.hookContext,
-            shouldCatalogTool:
-              localModelLeanEnabled && toolSearchConfig.mode === "tools"
-                ? shouldCatalogToolForLocalModelLean
-                : undefined,
+            directToolNames: requiredDirectToolNames,
           });
     const projectedCompactedTools = options.localModelLeanApplied
       ? compacted.tools

--- a/src/agents/local-model-lean.test.ts
+++ b/src/agents/local-model-lean.test.ts
@@ -10,7 +10,6 @@ import {
   filterLocalModelLeanTools,
   isLocalModelLeanEnabled,
   resolveLocalModelLeanPreserveToolNames,
-  shouldCatalogToolForLocalModelLean,
 } from "./local-model-lean.js";
 
 function tools(names: string[]): AnyAgentTool[] {
@@ -341,10 +340,5 @@ describe("local model lean tool filtering", () => {
     };
 
     expect(applyLocalModelLeanToolSearchDefaults({ config: cfg, agentId: "main" })).toBe(cfg);
-  });
-
-  it("keeps exec outside the lean Tool Search catalog", () => {
-    expect(shouldCatalogToolForLocalModelLean({ name: "exec" } as AnyAgentTool)).toBe(false);
-    expect(shouldCatalogToolForLocalModelLean({ name: "read" } as AnyAgentTool)).toBe(true);
   });
 });

--- a/src/agents/local-model-lean.ts
+++ b/src/agents/local-model-lean.ts
@@ -20,7 +20,6 @@ const LOCAL_MODEL_LEAN_DENY_TOOL_NAMES = new Set([
   "tts",
   "video_generate",
 ]);
-const LOCAL_MODEL_LEAN_DIRECT_TOOL_NAMES = new Set(["exec"]);
 const LOCAL_MODEL_LEAN_TOOL_SEARCH_DEFAULTS = {
   enabled: true,
   mode: "tools",
@@ -106,12 +105,6 @@ export function filterLocalModelLeanTools(params: {
       !LOCAL_MODEL_LEAN_DENY_TOOL_NAMES.has(normalizedName)
     );
   });
-}
-
-// Lean mode targets coding-tuned local models; keep their familiar shell
-// primitive visible instead of requiring a catalog search to rediscover it.
-export function shouldCatalogToolForLocalModelLean(tool: AnyAgentTool): boolean {
-  return !LOCAL_MODEL_LEAN_DIRECT_TOOL_NAMES.has(normalizeToolName(tool.name));
 }
 
 export function applyLocalModelLeanToolSearchDefaults(params: {

--- a/src/agents/tool-search.test.ts
+++ b/src/agents/tool-search.test.ts
@@ -150,6 +150,90 @@ describe("Tool Search", () => {
     expect(catalogRef.current?.entries.map((entry) => entry.name)).toEqual(["fake_lookup"]);
   });
 
+  it("keeps run-contract tools direct-only so search never hides them", async () => {
+    const { createStructuredOutputTool } = await import("./tools/structured-output-tool.js");
+    const { createSessionsYieldTool } = await import("./tools/sessions-yield-tool.js");
+    const { createHeartbeatResponseTool } = await import("./tools/heartbeat-response-tool.js");
+    const contractTools = [
+      createStructuredOutputTool({ runId: "run-contract-tools", schema: { type: "object" } }),
+      createSessionsYieldTool({ sessionId: "session-contract-tools" }),
+      createHeartbeatResponseTool(),
+    ];
+
+    const catalogRef = createToolSearchCatalogRef();
+    const compacted = applyToolSearchCatalog({
+      tools: [
+        fakeTool(TOOL_SEARCH_RAW_TOOL_NAME, "search"),
+        fakeTool(TOOL_DESCRIBE_RAW_TOOL_NAME, "describe"),
+        fakeTool(TOOL_CALL_RAW_TOOL_NAME, "call"),
+        ...contractTools,
+        pluginTool("fake_lookup", "Look up a record"),
+      ],
+      config: { tools: { toolSearch: { enabled: true, mode: "tools" } } } as never,
+      catalogRef,
+    });
+
+    expect(compacted.tools.map((tool) => tool.name)).toEqual([
+      TOOL_SEARCH_RAW_TOOL_NAME,
+      TOOL_DESCRIBE_RAW_TOOL_NAME,
+      TOOL_CALL_RAW_TOOL_NAME,
+      "structured_output",
+      "sessions_yield",
+      "heartbeat_respond",
+    ]);
+    // Direct-only contract tools never enter the search catalog.
+    expect(catalogRef.current?.entries.map((entry) => entry.name)).toEqual(["fake_lookup"]);
+  });
+
+  it("keeps caller-required direct tools visible in structured mode", () => {
+    const catalogRef = createToolSearchCatalogRef();
+    const compacted = applyToolSearchCatalog({
+      tools: [
+        fakeTool(TOOL_SEARCH_RAW_TOOL_NAME, "search"),
+        fakeTool(TOOL_DESCRIBE_RAW_TOOL_NAME, "describe"),
+        fakeTool(TOOL_CALL_RAW_TOOL_NAME, "call"),
+        fakeTool("message", "Send channel messages"),
+        pluginTool("fake_lookup", "Look up a record"),
+      ],
+      config: { tools: { toolSearch: { enabled: true, mode: "tools" } } } as never,
+      catalogRef,
+      directToolNames: ["message"],
+    });
+
+    expect(compacted.tools.map((tool) => tool.name)).toEqual([
+      TOOL_SEARCH_RAW_TOOL_NAME,
+      TOOL_DESCRIBE_RAW_TOOL_NAME,
+      TOOL_CALL_RAW_TOOL_NAME,
+      "message",
+    ]);
+    expect(catalogRef.current?.entries.map((entry) => entry.name)).toEqual([
+      "message",
+      "fake_lookup",
+    ]);
+  });
+
+  it("never promotes MCP lookalikes through required direct names", () => {
+    const catalogRef = createToolSearchCatalogRef();
+    const compacted = applyToolSearchCatalog({
+      tools: [
+        fakeTool(TOOL_SEARCH_RAW_TOOL_NAME, "search"),
+        fakeTool(TOOL_DESCRIBE_RAW_TOOL_NAME, "describe"),
+        fakeTool(TOOL_CALL_RAW_TOOL_NAME, "call"),
+        mcpPluginTool("message", "MCP tool shadowing the delivery tool"),
+      ],
+      config: { tools: { toolSearch: { enabled: true, mode: "tools" } } } as never,
+      catalogRef,
+      directToolNames: ["message"],
+    });
+
+    expect(compacted.tools.map((tool) => tool.name)).toEqual([
+      TOOL_SEARCH_RAW_TOOL_NAME,
+      TOOL_DESCRIBE_RAW_TOOL_NAME,
+      TOOL_CALL_RAW_TOOL_NAME,
+    ]);
+    expect(catalogRef.current?.entries.map((entry) => entry.name)).toEqual(["message"]);
+  });
+
   it("keeps core coding tools visible while still cataloging them", () => {
     const catalogRef = createToolSearchCatalogRef();
     const compacted = applyToolSearchCatalog({

--- a/src/agents/tool-search.ts
+++ b/src/agents/tool-search.ts
@@ -1,4 +1,5 @@
 /** Tool Search catalog compaction for large OpenClaw, MCP, and client tool inventories. */
+import { normalizeStringEntries } from "@openclaw/normalization-core/string-normalization";
 import { Type } from "typebox";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { HookContext } from "./agent-tools.before-tool-call.js";
@@ -101,19 +102,28 @@ export function applyToolSearchCatalog(params: {
   catalogRef?: ToolSearchCatalogRef;
   toolHookContext?: HookContext;
   shouldCatalogTool?: (tool: AnyAgentTool) => boolean;
+  directToolNames?: Iterable<string>;
 }) {
   const config = resolveToolSearchConfig(params.config);
+  const directToolNames = new Set(normalizeStringEntries(Array.from(params.directToolNames ?? [])));
   return applyToolCatalogCompaction({
     ...params,
     enabled: config.enabled,
     isVisibleControlTool: (tool) =>
       TOOL_SEARCH_CONTROL_TOOL_NAMES.has(tool.name) &&
       shouldExposeControlTool(tool.name, config.mode),
-    // Core file/shell primitives stay in the visible tool list (while remaining
-    // searchable); the source check keeps plugin/MCP tools that reuse a core
-    // name deferred like any other cataloged tool.
-    isVisibleCatalogTool: (tool) =>
-      isCoreCodingSurfaceToolName(tool.name) && classifyTool(tool).sourceName === "core",
+    // Core file/shell primitives and caller-required names (e.g. message when it
+    // is the only reply path) stay visible while remaining searchable. Required
+    // names must resolve to trusted OpenClaw tools; an MCP lookalike must never
+    // become a direct delivery or core-coding tool.
+    isVisibleCatalogTool: (tool) => {
+      const classified = classifyTool(tool);
+      return (
+        classified.source === "openclaw" &&
+        (directToolNames.has(tool.name) ||
+          (isCoreCodingSurfaceToolName(tool.name) && classified.sourceName === "core"))
+      );
+    },
   });
 }
 

--- a/src/agents/tools/heartbeat-response-tool.ts
+++ b/src/agents/tools/heartbeat-response-tool.ts
@@ -51,6 +51,9 @@ export function createHeartbeatResponseTool(): AnyAgentTool {
   return {
     label: "Heartbeat",
     name: HEARTBEAT_RESPONSE_TOOL_NAME,
+    // Heartbeat prompts instruct the model to call this one-shot tool; hiding
+    // it behind tool search would break the heartbeat contract.
+    catalogMode: "direct-only",
     displaySummary: "Record heartbeat outcome/notify choice.",
     description:
       "Record heartbeat result. `notify=false` no visible send. `notify=true` needs concise notificationText. Scratch is monitor prose only; manage recurring tasks with cron.",

--- a/src/agents/tools/sessions-yield-tool.ts
+++ b/src/agents/tools/sessions-yield-tool.ts
@@ -20,6 +20,9 @@ export function createSessionsYieldTool(opts?: {
   return {
     label: "Yield",
     name: "sessions_yield",
+    // Turn-lifecycle contract: spawn flows instruct the model to yield, so the
+    // tool must stay visible even when tool search compacts the catalog.
+    catalogMode: "direct-only",
     description: "End turn after subagent spawn; results arrive next message.",
     parameters: SessionsYieldToolSchema,
     execute: async (_toolCallId, args) => {

--- a/src/agents/tools/structured-output-tool.ts
+++ b/src/agents/tools/structured-output-tool.ts
@@ -56,6 +56,9 @@ export function createStructuredOutputTool(params: {
   return {
     label: "Structured Output",
     name: "structured_output",
+    // Per-run collector contract: must be callable without discovery, and its
+    // schema-dump description would only pollute the search index.
+    catalogMode: "direct-only",
     displaySummary: "Record the collector result.",
     description: `Call exactly once as {"result": ...}, where result matches this JSON Schema: ${requestedSchema}`,
     // Runtime argument validation must reach execute so invalid attempts consume

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.discord-group.json
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.discord-group.json
@@ -260,19 +260,6 @@
     "type": "function"
   },
   {
-    "description": "End turn after subagent spawn; results arrive next message.",
-    "inputSchema": {
-      "properties": {
-        "message": {
-          "type": "string"
-        }
-      },
-      "type": "object"
-    },
-    "name": "sessions_yield",
-    "type": "function"
-  },
-  {
     "description": "",
     "name": "openclaw",
     "tools": [
@@ -1613,6 +1600,26 @@
           "type": "object"
         },
         "name": "web_fetch",
+        "type": "function"
+      }
+    ],
+    "type": "namespace"
+  },
+  {
+    "description": "",
+    "name": "openclaw_direct",
+    "tools": [
+      {
+        "description": "End turn after subagent spawn; results arrive next message.",
+        "inputSchema": {
+          "properties": {
+            "message": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "name": "sessions_yield",
         "type": "function"
       }
     ],

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.heartbeat-turn.json
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.heartbeat-turn.json
@@ -256,19 +256,6 @@
     "type": "function"
   },
   {
-    "description": "End turn after subagent spawn; results arrive next message.",
-    "inputSchema": {
-      "properties": {
-        "message": {
-          "type": "string"
-        }
-      },
-      "type": "object"
-    },
-    "name": "sessions_yield",
-    "type": "function"
-  },
-  {
     "description": "",
     "name": "openclaw",
     "tools": [
@@ -1276,46 +1263,6 @@
       },
       {
         "deferLoading": true,
-        "description": "Record heartbeat result. `notify=false` no visible send. `notify=true` needs concise notificationText. Scratch is monitor prose only; manage recurring tasks with cron.",
-        "inputSchema": {
-          "additionalProperties": false,
-          "properties": {
-            "nextCheck": {
-              "type": "string"
-            },
-            "notificationText": {
-              "type": "string"
-            },
-            "notify": {
-              "type": "boolean"
-            },
-            "outcome": {
-              "enum": ["no_change", "progress", "done", "blocked", "needs_attention"],
-              "type": "string"
-            },
-            "priority": {
-              "enum": ["low", "normal", "high"],
-              "type": "string"
-            },
-            "reason": {
-              "type": "string"
-            },
-            "scratch": {
-              "description": "Complete replacement for heartbeat monitor prose. Recurring schedules belong in cron jobs, not scratch.",
-              "type": "string"
-            },
-            "summary": {
-              "type": "string"
-            }
-          },
-          "required": ["outcome", "notify", "summary"],
-          "type": "object"
-        },
-        "name": "heartbeat_respond",
-        "type": "function"
-      },
-      {
-        "deferLoading": true,
         "description": "Convert text to spoken audio (TTS) with the configured voice provider. Only explicit voice/speech/TTS intent or active TTS config; never ordinary text reply. Audio auto-delivered. After success follow reply instructions; no duplicate text/audio.",
         "inputSchema": {
           "properties": {
@@ -1649,6 +1596,65 @@
           "type": "object"
         },
         "name": "web_fetch",
+        "type": "function"
+      }
+    ],
+    "type": "namespace"
+  },
+  {
+    "description": "",
+    "name": "openclaw_direct",
+    "tools": [
+      {
+        "description": "Record heartbeat result. `notify=false` no visible send. `notify=true` needs concise notificationText. Scratch is monitor prose only; manage recurring tasks with cron.",
+        "inputSchema": {
+          "additionalProperties": false,
+          "properties": {
+            "nextCheck": {
+              "type": "string"
+            },
+            "notificationText": {
+              "type": "string"
+            },
+            "notify": {
+              "type": "boolean"
+            },
+            "outcome": {
+              "enum": ["no_change", "progress", "done", "blocked", "needs_attention"],
+              "type": "string"
+            },
+            "priority": {
+              "enum": ["low", "normal", "high"],
+              "type": "string"
+            },
+            "reason": {
+              "type": "string"
+            },
+            "scratch": {
+              "description": "Complete replacement for heartbeat monitor prose. Recurring schedules belong in cron jobs, not scratch.",
+              "type": "string"
+            },
+            "summary": {
+              "type": "string"
+            }
+          },
+          "required": ["outcome", "notify", "summary"],
+          "type": "object"
+        },
+        "name": "heartbeat_respond",
+        "type": "function"
+      },
+      {
+        "description": "End turn after subagent spawn; results arrive next message.",
+        "inputSchema": {
+          "properties": {
+            "message": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "name": "sessions_yield",
         "type": "function"
       }
     ],

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.telegram-direct.json
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.telegram-direct.json
@@ -256,19 +256,6 @@
     "type": "function"
   },
   {
-    "description": "End turn after subagent spawn; results arrive next message.",
-    "inputSchema": {
-      "properties": {
-        "message": {
-          "type": "string"
-        }
-      },
-      "type": "object"
-    },
-    "name": "sessions_yield",
-    "type": "function"
-  },
-  {
     "description": "",
     "name": "openclaw",
     "tools": [
@@ -1609,6 +1596,26 @@
           "type": "object"
         },
         "name": "web_fetch",
+        "type": "function"
+      }
+    ],
+    "type": "namespace"
+  },
+  {
+    "description": "",
+    "name": "openclaw_direct",
+    "tools": [
+      {
+        "description": "End turn after subagent spawn; results arrive next message.",
+        "inputSchema": {
+          "properties": {
+            "message": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "name": "sessions_yield",
         "type": "function"
       }
     ],

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/discord-group-codex-message-tool.md
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/discord-group-codex-message-tool.md
@@ -64,6 +64,7 @@
   "approvalPolicy": "never",
   "approvalsReviewer": "user",
   "config": {
+    "code_mode.direct_only_tool_namespaces": ["openclaw_direct"],
     "features.apply_patch_streaming_events": true,
     "features.code_mode": true,
     "features.code_mode_only": false,
@@ -77,7 +78,6 @@
     "message",
     "agents_list",
     "sessions_spawn",
-    "sessions_yield",
     "nodes",
     "cron",
     "tts",
@@ -89,7 +89,8 @@
     "subagents",
     "session_status",
     "web_search",
-    "web_fetch"
+    "web_fetch",
+    "sessions_yield"
   ],
   "experimentalRawEvents": true,
   "model": "gpt-5.5",
@@ -220,8 +221,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 0
   },
   "dynamicToolsJson": {
-    "chars": 61223,
-    "roughTokens": 15306
+    "chars": 61383,
+    "roughTokens": 15346
   },
   "openClawDeveloperInstructions": {
     "chars": 3471,
@@ -232,8 +233,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 6964
   },
   "totalWithDynamicToolsJson": {
-    "chars": 89079,
-    "roughTokens": 22270
+    "chars": 89239,
+    "roughTokens": 22310
   },
   "userInputText": {
     "chars": 1300,
@@ -523,7 +524,6 @@ Full JSON: `codex-dynamic-tools.discord-group.json`
   "message",
   "agents_list",
   "sessions_spawn",
-  "sessions_yield",
   "nodes",
   "cron",
   "tts",
@@ -535,7 +535,8 @@ Full JSON: `codex-dynamic-tools.discord-group.json`
   "subagents",
   "session_status",
   "web_search",
-  "web_fetch"
+  "web_fetch",
+  "sessions_yield"
 ]
 ```
 

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-direct-codex-message-tool.md
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-direct-codex-message-tool.md
@@ -64,6 +64,7 @@
   "approvalPolicy": "never",
   "approvalsReviewer": "user",
   "config": {
+    "code_mode.direct_only_tool_namespaces": ["openclaw_direct"],
     "features.apply_patch_streaming_events": true,
     "features.code_mode": true,
     "features.code_mode_only": false,
@@ -77,7 +78,6 @@
     "message",
     "agents_list",
     "sessions_spawn",
-    "sessions_yield",
     "nodes",
     "cron",
     "tts",
@@ -89,7 +89,8 @@
     "subagents",
     "session_status",
     "web_search",
-    "web_fetch"
+    "web_fetch",
+    "sessions_yield"
   ],
   "experimentalRawEvents": true,
   "model": "gpt-5.5",
@@ -220,8 +221,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 0
   },
   "dynamicToolsJson": {
-    "chars": 60915,
-    "roughTokens": 15229
+    "chars": 61075,
+    "roughTokens": 15269
   },
   "openClawDeveloperInstructions": {
     "chars": 2362,
@@ -232,8 +233,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 6594
   },
   "totalWithDynamicToolsJson": {
-    "chars": 87291,
-    "roughTokens": 21823
+    "chars": 87451,
+    "roughTokens": 21863
   },
   "userInputText": {
     "chars": 929,
@@ -517,7 +518,6 @@ Full JSON: `codex-dynamic-tools.telegram-direct.json`
   "message",
   "agents_list",
   "sessions_spawn",
-  "sessions_yield",
   "nodes",
   "cron",
   "tts",
@@ -529,7 +529,8 @@ Full JSON: `codex-dynamic-tools.telegram-direct.json`
   "subagents",
   "session_status",
   "web_search",
-  "web_fetch"
+  "web_fetch",
+  "sessions_yield"
 ]
 ```
 

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-heartbeat-codex-tool.md
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-heartbeat-codex-tool.md
@@ -64,6 +64,7 @@
   "approvalPolicy": "never",
   "approvalsReviewer": "user",
   "config": {
+    "code_mode.direct_only_tool_namespaces": ["openclaw_direct"],
     "features.apply_patch_streaming_events": true,
     "features.code_mode": true,
     "features.code_mode_only": false,
@@ -77,10 +78,8 @@
     "message",
     "agents_list",
     "sessions_spawn",
-    "sessions_yield",
     "nodes",
     "cron",
-    "heartbeat_respond",
     "tts",
     "gateway",
     "sessions_list",
@@ -90,7 +89,9 @@
     "subagents",
     "session_status",
     "web_search",
-    "web_fetch"
+    "web_fetch",
+    "heartbeat_respond",
+    "sessions_yield"
   ],
   "experimentalRawEvents": true,
   "model": "gpt-5.5",
@@ -221,20 +222,20 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 0
   },
   "dynamicToolsJson": {
-    "chars": 62477,
-    "roughTokens": 15620
+    "chars": 62607,
+    "roughTokens": 15652
   },
   "openClawDeveloperInstructions": {
-    "chars": 2381,
-    "roughTokens": 596
+    "chars": 2362,
+    "roughTokens": 591
   },
   "totalTextOnly": {
-    "chars": 26822,
-    "roughTokens": 6706
+    "chars": 26803,
+    "roughTokens": 6701
   },
   "totalWithDynamicToolsJson": {
-    "chars": 89301,
-    "roughTokens": 22326
+    "chars": 89412,
+    "roughTokens": 22353
   },
   "userInputText": {
     "chars": 1284,
@@ -421,7 +422,7 @@ Approval policy is currently never. Do not provide the `sandbox_permissions` for
 ````text
 You are a personal agent running inside OpenClaw. OpenClaw has dynamic tools for OpenClaw-owned messaging, cron, sessions, media, gateway, and nodes.
 
-Deferred searchable OpenClaw dynamic tools available: cron, gateway, heartbeat_respond, nodes, session_status, sessions_history, sessions_list, sessions_search, sessions_send, subagents, tts, web_fetch, web_search. Use `tool_search` to load exact callable specs before use.
+Deferred searchable OpenClaw dynamic tools available: cron, gateway, nodes, session_status, sessions_history, sessions_list, sessions_search, sessions_send, subagents, tts, web_fetch, web_search. Use `tool_search` to load exact callable specs before use.
 
 Use Codex native `spawn_agent` for Codex subagents. `spawn_agent` and the other native collaboration tools may be deferred: when `spawn_agent` is not directly listed, load it with `tool_search` before spawning. Use OpenClaw `sessions_spawn` only for OpenClaw or ACP delegation, never as a substitute for `spawn_agent`.
 
@@ -518,10 +519,8 @@ Full JSON: `codex-dynamic-tools.heartbeat-turn.json`
   "message",
   "agents_list",
   "sessions_spawn",
-  "sessions_yield",
   "nodes",
   "cron",
-  "heartbeat_respond",
   "tts",
   "gateway",
   "sessions_list",
@@ -531,7 +530,9 @@ Full JSON: `codex-dynamic-tools.heartbeat-turn.json`
   "subagents",
   "session_status",
   "web_search",
-  "web_fetch"
+  "web_fetch",
+  "heartbeat_respond",
+  "sessions_yield"
 ]
 ```
 
@@ -667,7 +668,6 @@ Full JSON: `codex-dynamic-tools.heartbeat-turn.json`
     "type": "function"
   },
   {
-    "deferLoading": true,
     "description": "Record heartbeat result. `notify=false` no visible send. `notify=true` needs concise notificationText. Scratch is monitor prose only; manage recurring tasks with cron.",
     "inputSchema": {
       "additionalProperties": false,

--- a/test/vitest/vitest.extension-codex-app-server-attempt-extra.config.ts
+++ b/test/vitest/vitest.extension-codex-app-server-attempt-extra.config.ts
@@ -6,6 +6,7 @@ function createExtensionCodexAppServerAttemptExtraVitestConfig(
 ) {
   return createScopedVitestConfig(
     [
+      "extensions/codex/src/app-server/run-attempt-client-prewarm.test.ts",
       "extensions/codex/src/app-server/run-attempt-lifecycle-controller.test.ts",
       "extensions/codex/src/app-server/run-attempt-thread-cleanup.test.ts",
       "extensions/codex/src/app-server/run-attempt.context-engine.test.ts",


### PR DESCRIPTION
## What Problem This Solves

Follow-up to #114560 (core coding tools stay visible under embedded tool search). Three tool classes could still be hidden by `tools.toolSearch`, breaking run contracts rather than merely adding a discovery round-trip:

- **`message` when it is the only reply path** (`sourceReplyDeliveryMode: "message_tool_only"` / forced message tool): directory mode already kept it visible, but the structured modes ("tools"/"code") cataloged and hid it — an agent that does not search for its own delivery tool ends the turn mute.
- **`structured_output`**: injected per-run into swarm collector subagents with a call-exactly-once contract, and its description is a raw JSON-schema dump — nearly unsearchable by design, yet it was cataloged like a normal tool.
- **`sessions_yield` / `heartbeat_respond`**: turn-lifecycle tools that prompts explicitly instruct the model to call; hiding them behind search breaks spawn-yield and heartbeat flows. The Codex harness already keeps `sessions_yield` always-direct.

## Why This Change Was Made

Two mechanisms, each at its existing owner boundary. (1) `applyToolSearchCatalog` gains the same `directToolNames` seam `applyToolSchemaDirectoryCatalog` already has; both embedded call sites (attempt-tool-catalog, harness tool-surface-bridge) now pass their already-computed required set (`message` when it owns delivery) to every search mode, with the same trust gate (OpenClaw-source only; an MCP lookalike never gets promoted). (2) The three contract tools declare `catalogMode: "direct-only"`, the existing marker used by `computer`/`openclaw`/`image` — always visible, never in the search index (which also stops `structured_output`'s schema dump from polluting BM25 ranking). Cleanup: `LOCAL_MODEL_LEAN_DIRECT_TOOL_NAMES`/`shouldCatalogToolForLocalModelLean` (lean mode's "keep exec visible" special case) is deleted — #114560's core-surface rule subsumes it. Net prod LOC is negative (35+/36−).

## User Impact

Operators enabling tool search can no longer end up with mute message-only agents, stuck collector subagents, or unyielded spawn turns; heartbeats keep their contract. Lean-mode behavior is unchanged except `exec` now also appears in search results.

## Evidence

- New regression tests: structured mode keeps a required `message` visible while cataloging it; an MCP tool named `message` stays deferred even when required; the three contract tools stay visible and out of the catalog; bridge-level structured-mode test mirrors the existing directory-mode one. Old lean assertions for the removed helper deleted.
- Focused runs all green: tool-search (96), tool-surface-bridge + local-model-lean + tool-name-allowlist (28), structured-output + heartbeat (11), codex dynamic-tools suites (166 — direct-only tools route to the `openclaw_direct` namespace there, the intended contract behavior), swarm integration (1).
- Local tsgo core lane clean, oxlint clean, oxfmt clean, `git diff --check` clean (local fallback; Blacksmith backend unreachable — hosted CI supplies the full gates).
- Live embedded-runtime proof on an isolated dev gateway from this branch (`toolSearch: {enabled: true, mode: "tools"}`, swarm enabled, gpt-5.6-sol): parent found `sessions_spawn`/`agents_wait` via `tool_search` → `tool_call` (deferred path intact), spawned a collector child with an outputSchema, and the child called `structured_output` **directly by name** — transcript shows `toolCall name="structured_output" arguments={result:{answer:"4"}}` → `{"status":"recorded"}` — with the parent receiving `{"answer":"4"}` through `agents_wait`.
- Autoreview (Codex gpt-5.6-sol, xhigh): clean — "preserves required reply-path and run-contract tools in the direct tool surface … source classification check prevents MCP lookalikes from being promoted" (0.91).

## Note: unrelated red-main fix included

`main` was red on `checks-node-compact-small-3`: #114551 added `extensions/codex/src/app-server/run-attempt-client-prewarm.test.ts` without registering it in a full-suite shard, so `test/scripts/test-projects.test.ts` ("covers each normal full-suite test file exactly once") fails on current main and on every PR merge ref. Per repo policy this landing PR carries the smallest correct fix: the file is registered in `vitest.extension-codex-app-server-attempt-extra.config.ts` alongside its run-attempt siblings (shard coverage test 219/219, prewarm file 5/5 in the new lane).
