### PR TITLE
fix(qa): keep tracked runtime harness gaps advisory

### DIFF
--- a/extensions/qa-lab/src/runtime-parity-outcomes.test.ts
+++ b/extensions/qa-lab/src/runtime-parity-outcomes.test.ts
@@ -80,6 +80,71 @@ describe("runtime parity outcomes", () => {
     expect(isRuntimeParityResultPass(result)).toBe(false);
   });
 
+  it("keeps one explicitly known harness gap advisory when its paired runtime passes", async () => {
+    const result = await runRuntimeParityScenario({
+      scenarioId: "known-harness-gap",
+      runCell: async (runtime) => ({
+        status: runtime === "codex" ? "skip" : "pass",
+        ...(runtime === "codex"
+          ? {
+              details:
+                "known-harness-gap exec: Codex owns command execution natively\ntracking: #80319",
+            }
+          : {}),
+        cell: makeRuntimeParityCell(runtime),
+      }),
+    });
+
+    expect(result).toMatchObject({
+      cells: {
+        openclaw: { status: "pass" },
+        codex: { status: "skip" },
+      },
+      drift: "structural",
+      driftDetails: "known harness gap in codex runtime; paired runtime passed",
+    });
+    expect(isRuntimeParityResultPass(result)).toBe(true);
+  });
+
+  it("keeps unannotated, doubly skipped, and failed known-gap cells blocking", async () => {
+    const run = (params: {
+      codexDetails?: string;
+      openclawStatus?: "pass" | "skip";
+      codexRuntimeErrorClass?: string;
+    }) =>
+      runRuntimeParityScenario({
+        scenarioId: "blocking-skip",
+        runCell: async (runtime) => ({
+          status: runtime === "openclaw" ? (params.openclawStatus ?? "pass") : ("skip" as const),
+          ...(runtime === "codex" && params.codexDetails ? { details: params.codexDetails } : {}),
+          cell: {
+            ...makeRuntimeParityCell(runtime),
+            ...(runtime === "codex" && params.codexRuntimeErrorClass
+              ? { runtimeErrorClass: params.codexRuntimeErrorClass }
+              : {}),
+          },
+        }),
+      });
+
+    const unannotated = await run({ codexDetails: "implementation unavailable" });
+    expect(unannotated.drift).toBe("failure-mode");
+    expect(isRuntimeParityResultPass(unannotated)).toBe(false);
+
+    const bothSkipped = await run({
+      codexDetails: "known-harness-gap exec: tracked",
+      openclawStatus: "skip",
+    });
+    expect(bothSkipped.drift).toBe("failure-mode");
+    expect(isRuntimeParityResultPass(bothSkipped)).toBe(false);
+
+    const failed = await run({
+      codexDetails: "known-harness-gap exec: tracked",
+      codexRuntimeErrorClass: "auth",
+    });
+    expect(failed.drift).toBe("failure-mode");
+    expect(isRuntimeParityResultPass(failed)).toBe(false);
+  });
+
   it("requires every canonical runtime-pair cell status to pass", async () => {
     const result = await runRuntimeParityScenario({
       scenarioId: "complete-result-cells",

--- a/extensions/qa-lab/src/runtime-parity.ts
+++ b/extensions/qa-lab/src/runtime-parity.ts
@@ -68,6 +68,19 @@ type RuntimeParityResultCell = RuntimeParityCell & {
   details?: string;
 };
 
+// Runtime-tool fixtures reserve this prefix for tracked harness limitations.
+// Matching only that explicit skip keeps unexpected coverage loss blocking.
+const KNOWN_HARNESS_GAP_DETAILS_PREFIX = "known-harness-gap ";
+
+function isKnownHarnessGapSkip(
+  cell: Pick<RuntimeParityResultCell, "details" | "status"> | undefined,
+) {
+  return (
+    cell?.status === "skip" &&
+    cell.details?.trimStart().startsWith(KNOWN_HARNESS_GAP_DETAILS_PREFIX) === true
+  );
+}
+
 export type RuntimeParityDrift =
   | "none"
   | "text-only"
@@ -116,12 +129,18 @@ export function runtimeParityCellStatus(
 }
 
 export function isRuntimeParityResultPass(result: RuntimeParityResult) {
+  if (result.drift === "failure-mode") {
+    return false;
+  }
+  const cells = CANONICAL_RUNTIME_IDS.map((runtime) => result.cells[runtime]);
+  const knownHarnessGapSkips = cells.filter((cell) => isKnownHarnessGapSkip(cell));
   return (
-    result.drift !== "failure-mode" &&
-    CANONICAL_RUNTIME_IDS.every((runtime) => {
-      const cell = result.cells[runtime];
-      return cell?.status === "pass" && isRuntimeParityCellPassable(cell);
-    })
+    knownHarnessGapSkips.length <= 1 &&
+    cells.every(
+      (cell) =>
+        isRuntimeParityCellPassable(cell) &&
+        (cell.status === "pass" || isKnownHarnessGapSkip(cell)),
+    )
   );
 }
 
@@ -1111,6 +1130,8 @@ function classifyRuntimeParityCells(params: {
   codex: RuntimeParityCell;
   openclawStatus: RuntimeParityStatus;
   codexStatus: RuntimeParityStatus;
+  openclawDetails?: string;
+  codexDetails?: string;
 }): Pick<RuntimeParityResult, "drift" | "driftDetails"> {
   if (
     isHardFailureRuntimeError(params.openclaw.runtimeErrorClass) ||
@@ -1134,6 +1155,27 @@ function classifyRuntimeParityCells(params: {
     return {
       drift: "failure-mode",
       driftDetails: "at least one runtime planned a tool call without a tool result",
+    };
+  }
+
+  const openclawKnownHarnessGap = isKnownHarnessGapSkip({
+    status: params.openclawStatus,
+    details: params.openclawDetails,
+  });
+  const codexKnownHarnessGap = isKnownHarnessGapSkip({
+    status: params.codexStatus,
+    details: params.codexDetails,
+  });
+  if (
+    openclawKnownHarnessGap !== codexKnownHarnessGap &&
+    (openclawKnownHarnessGap ? params.codexStatus : params.openclawStatus) === "pass" &&
+    isRuntimeParityCellPassable(params.openclaw) &&
+    isRuntimeParityCellPassable(params.codex)
+  ) {
+    const skippedRuntime = openclawKnownHarnessGap ? "openclaw" : "codex";
+    return {
+      drift: "structural",
+      driftDetails: `known harness gap in ${skippedRuntime} runtime; paired runtime passed`,
     };
   }
 
@@ -1448,6 +1490,8 @@ export async function runRuntimeParityScenario(params: {
     codex: codex.cell,
     openclawStatus: openclaw.status,
     codexStatus: codex.status,
+    openclawDetails: openclaw.details,
+    codexDetails: codex.details,
   });
   return {
     scenarioId: params.scenarioId,

--- a/extensions/qa-lab/src/suite-runtime-parity-result.ts
+++ b/extensions/qa-lab/src/suite-runtime-parity-result.ts
@@ -45,13 +45,16 @@ function runtimeParityScenarioResultStatus(result: RuntimeParityResult) {
     runtimeParityScenarioStepStatus(result.cells.openclaw),
     runtimeParityScenarioStepStatus(result.cells.codex),
   ]);
+  if (isRuntimeParityResultPass(result)) {
+    return "pass";
+  }
   if (cellStatuses.has("fail")) {
     return "fail";
   }
   if (cellStatuses.has("skip")) {
     return "skip";
   }
-  return isRuntimeParityResultPass(result) ? "pass" : "fail";
+  return "fail";
 }
 
 export function buildRuntimeParityScenarioResult(params: {

--- a/extensions/qa-lab/src/suite-runtime-parity-runner.test.ts
+++ b/extensions/qa-lab/src/suite-runtime-parity-runner.test.ts
@@ -57,4 +57,27 @@ describe("QA suite runtime parity result projection", () => {
     expect(skipped.status).toBe("skip");
     expect(skipped.steps?.map((step) => step.status)).toEqual(["skip", "skip", "skip"]);
   });
+
+  it("passes an explicitly known one-sided harness gap while preserving its skipped cell", () => {
+    const result = buildRuntimeParityScenarioResult({
+      scenarioName: "Runtime tool fixture — exec",
+      result: {
+        scenarioId: "runtime-tool-exec",
+        cells: {
+          openclaw: makeCell("openclaw", "pass"),
+          codex: {
+            ...makeCell("codex", "skip"),
+            details:
+              "known-harness-gap exec: Codex owns command execution natively\ntracking: #80319",
+          },
+        },
+        drift: "structural",
+        driftDetails: "known harness gap in codex runtime; paired runtime passed",
+      },
+    });
+
+    expect(result.status).toBe("pass");
+    expect(result.steps?.map((step) => step.status)).toEqual(["pass", "skip", "pass"]);
+    expect(result.steps?.[1]?.details).toContain("known-harness-gap exec");
+  });
 });


### PR DESCRIPTION
## What Problem This Solves

Resolves a release-validation false positive where explicitly tracked QA harness gaps in Codex-native workspace-tool fixtures were treated as candidate runtime failures. In Full Release Validation run 30287623769, all eight OpenClaw fixture cells passed while the paired Codex cells intentionally skipped, but Release Checks classified each pass/skip pair as blocking failure-mode drift.

## Why This Change Was Made

The parity contract now recognizes only the existing exact known-harness-gap diagnostic on a single skipped runtime whose peer passed. It preserves the skipped cell and tracking detail as advisory structural drift. Unannotated skips, both-skipped pairs, runtime or transport failures, missing tool results, and malformed results remain blocking.

This is a trusted-main release-tooling repair; the frozen beta.5 product SHA remains unchanged.

## User Impact

No product behavior changes. Release validation no longer rejects a candidate because a tracked QA harness limitation was already declared and the comparable runtime passed.

## Evidence

- Failing release evidence: https://github.com/openclaw/openclaw/actions/runs/30288606313/job/90052578672
- Parity report artifact: https://github.com/openclaw/openclaw/actions/runs/30288606313/artifacts/8662644841
- Focused proof: runtime-parity-outcomes and suite-runtime-parity-runner, 2 files and 8 tests passed
- Autoreview: clean, no actionable findings
- Related historical harness contract: #80320
