### PR TITLE
fix(microsoft-foundry): preserve GPT deployment limits

### DIFF
--- a/extensions/microsoft-foundry/index.test.ts
+++ b/extensions/microsoft-foundry/index.test.ts
@@ -1370,6 +1370,111 @@ describe("microsoft-foundry plugin", () => {
     expect(provider?.models[0]?.compat?.maxTokensField).toBe("max_tokens");
   });
 
+  it.each([
+    ["gpt-5.6", 1_050_000, undefined],
+    ["gpt-5.6-sol", 1_050_000, undefined],
+    ["gpt-5.6-terra", 1_050_000, undefined],
+    ["gpt-5.6-luna", 1_050_000, undefined],
+    ["gpt-5.5", 1_050_000, 922_000],
+    ["gpt-5.4", 1_050_000, undefined],
+    ["gpt-5.4-pro", 1_050_000, undefined],
+    ["gpt-5.4-mini", 400_000, undefined],
+    ["gpt-5.4-nano", 400_000, undefined],
+    ["gpt-5.3-codex", 400_000, undefined],
+    ["gpt-5.2", 400_000, undefined],
+    ["gpt-5.2-codex", 400_000, undefined],
+    ["gpt-5.1", 400_000, undefined],
+    ["gpt-5.1-codex", 400_000, undefined],
+    ["gpt-5.1-codex-mini", 400_000, undefined],
+    ["gpt-5.1-codex-max", 400_000, undefined],
+    ["gpt-5", 400_000, undefined],
+    ["gpt-5-mini", 400_000, undefined],
+    ["gpt-5-nano", 400_000, undefined],
+    ["gpt-5-codex", 400_000, undefined],
+    ["gpt-5-pro", 400_000, undefined],
+  ] as const)(
+    "uses documented Foundry GPT token limits for %s",
+    (modelNameHint, contextWindow, contextTokens) => {
+      const result = buildFoundryAuthResult({
+        profileId: "microsoft-foundry:default",
+        apiKey: "test-api-key",
+        endpoint: "https://example.services.ai.azure.com",
+        modelId: "custom-production-alias",
+        modelNameHint,
+        api: "openai-responses",
+        authMethod: "api-key",
+      });
+
+      const model = result.configPatch?.models?.providers?.["microsoft-foundry"]?.models[0];
+      expect(model).toMatchObject({
+        id: "custom-production-alias",
+        name: modelNameHint,
+        contextWindow,
+        maxTokens: 128_000,
+        params: { canonicalModelId: modelNameHint },
+      });
+      expect(model?.contextTokens).toBe(contextTokens);
+    },
+  );
+
+  it("keeps the GPT-5.5 Responses budget out of Foundry Chat Completions", () => {
+    const result = buildFoundryAuthResult({
+      profileId: "microsoft-foundry:default",
+      apiKey: "test-api-key",
+      endpoint: "https://example.services.ai.azure.com",
+      modelId: "custom-gpt55-chat-alias",
+      modelNameHint: "gpt-5.5",
+      api: "openai-completions",
+      authMethod: "api-key",
+    });
+
+    const model = result.configPatch?.models?.providers?.["microsoft-foundry"]?.models[0];
+    expect(model).toMatchObject({
+      contextWindow: 1_050_000,
+      maxTokens: 128_000,
+    });
+    expect(model?.contextTokens).toBeUndefined();
+  });
+
+  it.each(["gpt-chat-latest", "gpt-5.3-chat", "gpt-5.2-chat", "gpt-5.1-chat", "gpt-5-chat"])(
+    "keeps documented Foundry chat limits for %s",
+    (modelNameHint) => {
+      const result = buildFoundryAuthResult({
+        profileId: "microsoft-foundry:default",
+        apiKey: "test-api-key",
+        endpoint: "https://example.services.ai.azure.com",
+        modelId: "custom-chat-alias",
+        modelNameHint,
+        api: "openai-completions",
+        authMethod: "api-key",
+      });
+
+      expect(result.configPatch?.models?.providers?.["microsoft-foundry"]?.models[0]).toMatchObject(
+        {
+          contextWindow: 128_000,
+          maxTokens: 16_384,
+        },
+      );
+    },
+  );
+
+  it("keeps conservative token limits for unknown Foundry GPT model names", () => {
+    const result = buildFoundryAuthResult({
+      profileId: "microsoft-foundry:default",
+      apiKey: "test-api-key",
+      endpoint: "https://example.services.ai.azure.com",
+      modelId: "custom-unknown-alias",
+      modelNameHint: "gpt-6-unknown",
+      api: "openai-responses",
+      authMethod: "api-key",
+    });
+
+    expect(result.configPatch?.models?.providers?.["microsoft-foundry"]?.models[0]).toMatchObject({
+      contextWindow: 128_000,
+      maxTokens: 16_384,
+    });
+  });
+
   it("routes Claude deployments through Foundry Anthropic Messages", () => {
     const result = buildFoundryAuthResult({
       profileId: "microsoft-foundry:entra",

--- a/extensions/microsoft-foundry/shared.ts
+++ b/extensions/microsoft-foundry/shared.ts
@@ -99,6 +99,7 @@ type FoundryModelCapabilities = {
   thinkingLevelMap?: Record<string, string | null>;
   input: Array<"text" | "image">;
   contextWindow: number;
+  contextTokens?: number;
   maxTokens: number;
   compat?: FoundryModelCompat;
 };
@@ -225,12 +226,45 @@ function supportsFoundryManualClaudeThinking(value?: string | null): boolean {
     : false;
 }
 
-function resolveFoundryModelTokenLimits(value?: string | null): {
+type FoundryModelTokenLimits = {
   contextWindow: number;
+  responsesContextTokens?: number;
   maxTokens: number;
-} {
+};
+
+const FOUNDRY_GPT_TOKEN_LIMITS = new Map<string, FoundryModelTokenLimits>([
+  ["gpt-5.6", { contextWindow: 1_050_000, maxTokens: 128_000 }],
+  ["gpt-5.6-sol", { contextWindow: 1_050_000, maxTokens: 128_000 }],
+  ["gpt-5.6-terra", { contextWindow: 1_050_000, maxTokens: 128_000 }],
+  ["gpt-5.6-luna", { contextWindow: 1_050_000, maxTokens: 128_000 }],
+  ["gpt-5.5", { contextWindow: 1_050_000, responsesContextTokens: 922_000, maxTokens: 128_000 }],
+  ["gpt-5.4", { contextWindow: 1_050_000, maxTokens: 128_000 }],
+  ["gpt-5.4-pro", { contextWindow: 1_050_000, maxTokens: 128_000 }],
+  ["gpt-5.4-mini", { contextWindow: 400_000, maxTokens: 128_000 }],
+  ["gpt-5.4-nano", { contextWindow: 400_000, maxTokens: 128_000 }],
+  ["gpt-5.3-codex", { contextWindow: 400_000, maxTokens: 128_000 }],
+  ["gpt-5.2", { contextWindow: 400_000, maxTokens: 128_000 }],
+  ["gpt-5.2-codex", { contextWindow: 400_000, maxTokens: 128_000 }],
+  ["gpt-5.1", { contextWindow: 400_000, maxTokens: 128_000 }],
+  ["gpt-5.1-codex", { contextWindow: 400_000, maxTokens: 128_000 }],
+  ["gpt-5.1-codex-mini", { contextWindow: 400_000, maxTokens: 128_000 }],
+  ["gpt-5.1-codex-max", { contextWindow: 400_000, maxTokens: 128_000 }],
+  ["gpt-5", { contextWindow: 400_000, maxTokens: 128_000 }],
+  ["gpt-5-mini", { contextWindow: 400_000, maxTokens: 128_000 }],
+  ["gpt-5-nano", { contextWindow: 400_000, maxTokens: 128_000 }],
+  ["gpt-5-codex", { contextWindow: 400_000, maxTokens: 128_000 }],
+  ["gpt-5-pro", { contextWindow: 400_000, maxTokens: 128_000 }],
+]);
+
+function resolveFoundryModelTokenLimits(value?: string | null): FoundryModelTokenLimits {
   const normalized = normalizeFoundryModelName(value);
   const normalizedVersion = normalized?.replace(/\./g, "-");
+  // Deployment aliases are arbitrary, so this table must stay keyed by the canonical
+  // model name discovered from Foundry. Unknown and chat variants retain the safe fallback.
+  const foundryGptTokenLimits = normalized ? FOUNDRY_GPT_TOKEN_LIMITS.get(normalized) : undefined;
+  if (foundryGptTokenLimits) {
+    return foundryGptTokenLimits;
+  }
   if (
     normalized &&
     (supportsClaudeAdaptiveThinking({ id: normalized }) ||
@@ -487,6 +521,9 @@ export function resolveFoundryModelCapabilities(
         ? ["text", "image"]
         : normalizedInput,
     contextWindow: tokenLimits.contextWindow,
+    ...(api === DEFAULT_GPT5_API && tokenLimits.responsesContextTokens
+      ? { contextTokens: tokenLimits.responsesContextTokens }
+      : {}),
     maxTokens: tokenLimits.maxTokens,
     compat: buildFoundryModelCompat(modelId, modelName, api),
   };
@@ -559,6 +596,7 @@ function buildFoundryProviderConfig(
           input: capabilities.input,
           cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
           contextWindow: capabilities.contextWindow,
+          ...(capabilities.contextTokens ? { contextTokens: capabilities.contextTokens } : {}),
           maxTokens: capabilities.maxTokens,
         },
         capabilities.compat ? { compat: capabilities.compat } : {},


### PR DESCRIPTION
Closes #114165

## What Problem This Solves

Fixes an issue where users discovering GPT deployments through Microsoft Foundry would receive the generic 128K context and 16K output metadata even when the deployed model supports substantially larger limits. This caused premature compaction and could truncate long replies.

The Claude Opus 5 half of #114165 was already fixed on `main`; this PR addresses the remaining GPT metadata defect.

## Why This Change Was Made

Microsoft Foundry now owns an exact capability table keyed by the canonical model name returned during deployment discovery, so custom deployment aliases inherit the documented limits of their underlying GPT model. Known chat variants and unknown future names retain the conservative fallback.

GPT-5.5 keeps its advertised 1.05M context window while Responses API configurations also record the documented 922K effective combined runtime budget through `contextTokens`.

## User Impact

Foundry users can use the documented context and output capacity of known GPT-5 deployments instead of compacting at 128K or capping output at 16K. Renamed deployments work because capability lookup uses the discovered canonical model name rather than the deployment alias.

## Evidence

- `node scripts/run-vitest.mjs extensions/microsoft-foundry/index.test.ts` — 124 tests passed.
- Extension production and test type checks passed with the repository `tsgo` wrapper.
- Targeted `oxfmt` and extension `oxlint` checks passed.
- `git diff --check` passed.
- Limits were checked against [Microsoft Foundry's current model capability table](https://learn.microsoft.com/en-us/azure/foundry/foundry-models/concepts/models-sold-directly-by-azure).
- One permitted autoreview pass found the GPT-5.5 Responses API budget distinction; the patch now preserves the 1.05M advertised window and applies the 922K effective budget only to Responses API configurations. Repository draft-PR guardrails preclude a second review loop.
- Live Azure Foundry validation was not run because no Foundry credentials are available in this environment. This PR remains a draft for CI and credentialed provider validation.
- Blacksmith Testbox was unavailable because its local client is not installed. The focused trusted-source test and type/lint/format checks ran locally using the clean main checkout's existing dependencies without installing or reconciling the worktree.

## Regression Provenance

The generic token fallback originated in commit `1ba782f286b012ef40a50c3e4d7faa1a58049e74` on June 9, 2026. GitHub records @vincentkoc as both commit author and committer and returns no associated pull request, so there is no separate PR author, merger, or automerge trigger to attribute.

## AI Assistance

This change was implemented with Codex assistance. The implementation and generated tests were inspected, focused proof was run, and the documented provider contract was verified before publication.
