### PR TITLE
refactor(providers): consolidate compatible replay policies

### DIFF
--- a/extensions/baseten/stream.ts
+++ b/extensions/baseten/stream.ts
@@ -1,6 +1,9 @@
 /** Baseten request payload policy for models with opt-in chat-template reasoning. */
 import type { ProviderWrapStreamFnContext } from "openclaw/plugin-sdk/plugin-entry";
-import { createPayloadPatchStreamWrapper } from "openclaw/plugin-sdk/provider-stream-shared";
+import {
+  createPayloadPatchStreamWrapper,
+  normalizeOpenAICompatibleReasoningReplay,
+} from "openclaw/plugin-sdk/provider-stream-shared";
 import { usesBasetenChatTemplateThinking } from "./models.js";
 
 const BASETEN_DEEPSEEK_V4_MODEL_ID = "deepseek-ai/deepseek-v4-pro";
@@ -11,31 +14,6 @@ function isThinkingEnabled(level: ProviderWrapStreamFnContext["thinkingLevel"]):
 
 function isBasetenDeepSeekV4ModelId(modelId: string): boolean {
   return modelId.trim().toLowerCase() === BASETEN_DEEPSEEK_V4_MODEL_ID;
-}
-
-function patchBasetenDeepSeekV4Replay(
-  payload: Record<string, unknown>,
-  thinkingEnabled: boolean,
-): void {
-  if (!Array.isArray(payload.messages)) {
-    return;
-  }
-  for (const message of payload.messages) {
-    if (!message || typeof message !== "object" || Array.isArray(message)) {
-      continue;
-    }
-    const record = message as Record<string, unknown>;
-    if (record.role !== "assistant") {
-      continue;
-    }
-    // DeepSeek V4 requires reasoning_content on replayed assistant turns.
-    // Cross-provider turns lack it, so backfill while thinking is enabled.
-    if (thinkingEnabled) {
-      record.reasoning_content ??= "";
-    } else {
-      delete record.reasoning_content;
-    }
-  }
 }
 
 /** Adds Baseten's `chat_template_args.enable_thinking` without dropping caller args. */
@@ -49,7 +27,11 @@ export function createBasetenThinkingWrapper(
     if (isBasetenDeepSeekV4ModelId(model.id)) {
       // DeepSeek reasoning defaults on when no level is supplied. Only an
       // explicit `off` may remove its required replay metadata.
-      patchBasetenDeepSeekV4Replay(payload, ctx.thinkingLevel !== "off");
+      normalizeOpenAICompatibleReasoningReplay(payload, {
+        thinkingEnabled: ctx.thinkingLevel !== "off",
+        stripAssistantMessagesOnly: true,
+        replaceNullReasoningContent: true,
+      });
     }
     if (!usesBasetenChatTemplateThinking(model.id)) {
       return;

--- a/extensions/kimi-coding/stream.ts
+++ b/extensions/kimi-coding/stream.ts
@@ -6,7 +6,10 @@ import {
   type AssistantMessageEvent,
 } from "openclaw/plugin-sdk/llm";
 import type { ProviderWrapStreamFnContext } from "openclaw/plugin-sdk/plugin-entry";
-import { streamWithPayloadPatch } from "openclaw/plugin-sdk/provider-stream-shared";
+import {
+  normalizeOpenAICompatibleReasoningReplay,
+  streamWithPayloadPatch,
+} from "openclaw/plugin-sdk/provider-stream-shared";
 import { normalizeOptionalLowercaseString } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { isKimiK3ModelId } from "./provider-policy-api.js";
 
@@ -92,39 +95,6 @@ function ensureKimiAnthropicMaxTokens(
   );
   const current = normalizeKimiAnthropicMaxTokens(payloadObj.max_tokens);
   payloadObj.max_tokens = current === undefined ? required : Math.max(current, required);
-}
-
-function messageHasOpenAIToolCalls(message: Record<string, unknown>): boolean {
-  return Array.isArray(message.tool_calls) && message.tool_calls.length > 0;
-}
-
-function ensureKimiOpenAIReasoningContent(payloadObj: Record<string, unknown>): void {
-  if (!Array.isArray(payloadObj.messages)) {
-    return;
-  }
-  for (const message of payloadObj.messages) {
-    if (!message || typeof message !== "object") {
-      continue;
-    }
-    const record = message as Record<string, unknown>;
-    if (record.role !== "assistant" || !messageHasOpenAIToolCalls(record)) {
-      continue;
-    }
-    if (!("reasoning_content" in record)) {
-      record.reasoning_content = "";
-    }
-  }
-}
-
-function stripKimiOpenAIReasoningContent(payloadObj: Record<string, unknown>): void {
-  if (!Array.isArray(payloadObj.messages)) {
-    return;
-  }
-  for (const message of payloadObj.messages) {
-    if (message && typeof message === "object") {
-      delete (message as Record<string, unknown>).reasoning_content;
-    }
-  }
 }
 
 function normalizeKimiThinkingType(value: unknown): KimiThinkingType | undefined {
@@ -447,10 +417,12 @@ function createKimiThinkingWrapper(
         model.api === "anthropic-messages" ? { ...normalized } : { type: normalized.type };
       if (model.api === "anthropic-messages") {
         ensureKimiAnthropicMaxTokens(payloadObj, normalized);
-      } else if (normalized.type === "enabled") {
-        ensureKimiOpenAIReasoningContent(payloadObj);
       } else {
-        stripKimiOpenAIReasoningContent(payloadObj);
+        normalizeOpenAICompatibleReasoningReplay(payloadObj, {
+          thinkingEnabled: normalized.type === "enabled",
+          shouldBackfillAssistantMessage: (message) =>
+            Array.isArray(message.tool_calls) && message.tool_calls.length > 0,
+        });
       }
       delete payloadObj.reasoning;
       delete payloadObj.reasoning_effort;

--- a/extensions/ollama/index.ts
+++ b/extensions/ollama/index.ts
@@ -13,6 +13,7 @@ import {
   type ProviderAuthResult,
   type ProviderAugmentModelCatalogContext,
   type ProviderCatalogContext,
+  type ProviderPlugin,
   type ProviderReplayPolicy,
   type ProviderRuntimeModel,
 } from "openclaw/plugin-sdk/plugin-entry";
@@ -28,7 +29,6 @@ import type {
 } from "openclaw/plugin-sdk/provider-model-shared";
 import {
   buildOpenAICompatibleReplayPolicy,
-  buildProviderReplayFamilyHooks,
   selectPreferredLocalModelId,
 } from "openclaw/plugin-sdk/provider-model-shared";
 import { resolveConfiguredSecretInputString } from "openclaw/plugin-sdk/secret-input-runtime";
@@ -712,6 +712,41 @@ async function augmentConfiguredOllamaCatalogModels(params: {
   return entries;
 }
 
+// Local and cloud own distinct auth/catalog policy but share native transport and replay rules.
+const OLLAMA_SHARED_PROVIDER_HOOKS = {
+  createStreamFn: ({ config, model, provider }) => {
+    if (model.api !== "ollama") {
+      return undefined;
+    }
+    return createConfiguredOllamaStreamFn({
+      model,
+      providerBaseUrl:
+        readProviderBaseUrl(
+          resolveConfiguredOllamaProviderConfig({ config, providerId: provider }),
+        ) ?? (provider === OLLAMA_CLOUD_PROVIDER_ID ? OLLAMA_CLOUD_BASE_URL : undefined),
+    });
+  },
+  buildReplayPolicy: ({ modelApi }) =>
+    modelApi === "ollama"
+      ? buildNativeOllamaReplayPolicy()
+      : buildOpenAICompatibleReplayPolicy(modelApi),
+  resolveReasoningOutputMode: () => "native",
+  resolveThinkingProfile: resolveOllamaThinkingProfile,
+  wrapStreamFn: createConfiguredOllamaCompatStreamWrapper,
+  matchesContextOverflowError: ({ errorMessage }) =>
+    matchesOllamaContextOverflowError(errorMessage),
+  classifyFailoverReason: ({ errorMessage }) => classifyOllamaFailoverReason(errorMessage),
+} satisfies Pick<
+  ProviderPlugin,
+  | "createStreamFn"
+  | "buildReplayPolicy"
+  | "resolveReasoningOutputMode"
+  | "resolveThinkingProfile"
+  | "wrapStreamFn"
+  | "matchesContextOverflowError"
+  | "classifyFailoverReason"
+>;
+
 export default definePluginEntry({
   id: "ollama",
   name: "Ollama Provider",
@@ -793,26 +828,7 @@ export default definePluginEntry({
           provider: buildStaticOllamaCloudProvider(),
         }),
       },
-      createStreamFn: ({ config, model, provider }) => {
-        if (model.api !== "ollama") {
-          return undefined;
-        }
-        return createConfiguredOllamaStreamFn({
-          model,
-          providerBaseUrl:
-            readProviderBaseUrl(
-              resolveConfiguredOllamaProviderConfig({ config, providerId: provider }),
-            ) ?? OLLAMA_CLOUD_BASE_URL,
-        });
-      },
-      ...buildProviderReplayFamilyHooks({ family: "openai-compatible" }),
-      buildReplayPolicy: (ctx) =>
-        ctx.modelApi === "ollama"
-          ? buildNativeOllamaReplayPolicy()
-          : buildOpenAICompatibleReplayPolicy(ctx.modelApi),
-      resolveReasoningOutputMode: () => "native",
-      resolveThinkingProfile: resolveOllamaThinkingProfile,
-      wrapStreamFn: createConfiguredOllamaCompatStreamWrapper,
+      ...OLLAMA_SHARED_PROVIDER_HOOKS,
       resolveDynamicModel: ({ provider, modelId }) => {
         const cloudProvider = buildStaticOllamaCloudProvider();
         const model = cloudProvider.models?.find((entry) => entry.id === modelId);
@@ -829,9 +845,6 @@ export default definePluginEntry({
           entries: ctx.entries,
           resolveProviderApiKey: ctx.resolveProviderApiKey,
         }),
-      matchesContextOverflowError: ({ errorMessage }) =>
-        matchesOllamaContextOverflowError(errorMessage),
-      classifyFailoverReason: ({ errorMessage }) => classifyOllamaFailoverReason(errorMessage),
       buildUnknownModelHint: () =>
         "Ollama Cloud requires an API key. " +
         'Set OLLAMA_API_KEY or run "openclaw onboard --auth-choice ollama-cloud". ' +
@@ -971,25 +984,7 @@ export default definePluginEntry({
         }
         await ensureOllamaModelPulled({ config, model, prompter });
       },
-      createStreamFn: ({ config, model, provider }) => {
-        if (model.api !== "ollama") {
-          return undefined;
-        }
-        return createConfiguredOllamaStreamFn({
-          model,
-          providerBaseUrl: readProviderBaseUrl(
-            resolveConfiguredOllamaProviderConfig({ config, providerId: provider }),
-          ),
-        });
-      },
-      ...buildProviderReplayFamilyHooks({ family: "openai-compatible" }),
-      buildReplayPolicy: (ctx) =>
-        ctx.modelApi === "ollama"
-          ? buildNativeOllamaReplayPolicy()
-          : buildOpenAICompatibleReplayPolicy(ctx.modelApi),
-      resolveReasoningOutputMode: () => "native",
-      resolveThinkingProfile: resolveOllamaThinkingProfile,
-      wrapStreamFn: createConfiguredOllamaCompatStreamWrapper,
+      ...OLLAMA_SHARED_PROVIDER_HOOKS,
       augmentModelCatalog: async (ctx) =>
         await augmentConfiguredOllamaCatalogModels({
           config: ctx.config,
@@ -1012,9 +1007,6 @@ export default definePluginEntry({
           client,
         };
       },
-      matchesContextOverflowError: ({ errorMessage }) =>
-        matchesOllamaContextOverflowError(errorMessage),
-      classifyFailoverReason: ({ errorMessage }) => classifyOllamaFailoverReason(errorMessage),
       resolveSyntheticAuth: ({ provider, providerConfig }) => {
         if (!shouldUseSyntheticOllamaAuth(providerConfig)) {
           return undefined;

--- a/extensions/openrouter/stream.ts
+++ b/extensions/openrouter/stream.ts
@@ -2,7 +2,10 @@
 import type { StreamFn } from "openclaw/plugin-sdk/agent-core";
 import type { ProviderWrapStreamFnContext } from "openclaw/plugin-sdk/plugin-entry";
 import { buildProviderStreamFamilyHooks } from "openclaw/plugin-sdk/provider-stream-family";
-import { createPayloadPatchStreamWrapper } from "openclaw/plugin-sdk/provider-stream-shared";
+import {
+  createPayloadPatchStreamWrapper,
+  normalizeOpenAICompatibleReasoningReplay,
+} from "openclaw/plugin-sdk/provider-stream-shared";
 import { createSubsystemLogger } from "openclaw/plugin-sdk/runtime-env";
 import { isOpenRouterDeepSeekV4ModelId } from "./models.js";
 import {
@@ -165,37 +168,6 @@ function isOpenRouterReasoningPayloadEnabled(payload: Record<string, unknown>): 
   );
 }
 
-function stripOpenRouterDeepSeekV4ReasoningContent(payload: Record<string, unknown>): void {
-  if (!Array.isArray(payload.messages)) {
-    return;
-  }
-  for (const message of payload.messages) {
-    if (!message || typeof message !== "object") {
-      continue;
-    }
-    delete (message as Record<string, unknown>).reasoning_content;
-  }
-}
-
-function backfillOpenRouterDeepSeekV4ReasoningContent(payload: Record<string, unknown>): void {
-  if (!Array.isArray(payload.messages)) {
-    return;
-  }
-  for (const message of payload.messages) {
-    if (!message || typeof message !== "object") {
-      continue;
-    }
-    const record = message as Record<string, unknown>;
-    if (
-      record.role === "assistant" &&
-      !assistantMessageHasOpenAIToolCalls(record) &&
-      !("reasoning_content" in record)
-    ) {
-      record.reasoning_content = "";
-    }
-  }
-}
-
 function injectOpenRouterRouting(
   baseStreamFn: StreamFn | undefined,
   providerRouting?: Record<string, unknown>,
@@ -291,11 +263,10 @@ function createOpenRouterDeepSeekV4ReplayWrapper(
     ({ payload }) => {
       delete payload.thinking;
       delete payload.reasoning_effort;
-      if (!applyOpenRouterDeepSeekV4ReasoningEffort(payload, thinkingLevel)) {
-        stripOpenRouterDeepSeekV4ReasoningContent(payload);
-        return;
-      }
-      backfillOpenRouterDeepSeekV4ReasoningContent(payload);
+      normalizeOpenAICompatibleReasoningReplay(payload, {
+        thinkingEnabled: applyOpenRouterDeepSeekV4ReasoningEffort(payload, thinkingLevel),
+        shouldBackfillAssistantMessage: (message) => !assistantMessageHasOpenAIToolCalls(message),
+      });
     },
     {
       shouldPatch: ({ model }) => shouldPatchDeepSeekV4OpenRouterPayload(model),

--- a/extensions/qwen/stream.ts
+++ b/extensions/qwen/stream.ts
@@ -6,6 +6,7 @@ import { normalizeProviderId } from "openclaw/plugin-sdk/provider-model-shared";
 import {
   createPayloadPatchStreamWrapper,
   isOpenAICompatibleThinkingEnabled,
+  normalizeOpenAICompatibleReasoningReplay,
   setQwenChatTemplateThinking,
 } from "openclaw/plugin-sdk/provider-stream-shared";
 import {
@@ -104,28 +105,11 @@ function patchTokenPlanDeepSeekV4Payload(
   delete payload.thinking;
   if (!enableThinking) {
     delete payload.reasoning_effort;
-    if (Array.isArray(payload.messages)) {
-      for (const message of payload.messages) {
-        if (message && typeof message === "object") {
-          delete (message as Record<string, unknown>).reasoning_content;
-        }
-      }
-    }
+    normalizeOpenAICompatibleReasoningReplay(payload, { thinkingEnabled: false });
     return;
   }
   payload.reasoning_effort = thinkingLevel === "xhigh" || thinkingLevel === "max" ? "max" : "high";
-  if (!Array.isArray(payload.messages)) {
-    return;
-  }
-  for (const message of payload.messages) {
-    if (!message || typeof message !== "object") {
-      continue;
-    }
-    const record = message as Record<string, unknown>;
-    if (record.role === "assistant" && !("reasoning_content" in record)) {
-      record.reasoning_content = "";
-    }
-  }
+  normalizeOpenAICompatibleReasoningReplay(payload, { thinkingEnabled: true });
 }
 
 function patchTokenPlanKimiPayload(
@@ -134,22 +118,12 @@ function patchTokenPlanKimiPayload(
 ): void {
   delete payload.thinking;
   delete payload.reasoning_effort;
-  if (!enableThinking || !Array.isArray(payload.messages)) {
-    return;
-  }
-  for (const message of payload.messages) {
-    if (!message || typeof message !== "object") {
-      continue;
-    }
-    const record = message as Record<string, unknown>;
-    if (
-      record.role === "assistant" &&
-      Array.isArray(record.tool_calls) &&
-      record.tool_calls.length > 0 &&
-      !("reasoning_content" in record)
-    ) {
-      record.reasoning_content = "";
-    }
+  if (enableThinking) {
+    normalizeOpenAICompatibleReasoningReplay(payload, {
+      thinkingEnabled: true,
+      shouldBackfillAssistantMessage: (message) =>
+        Array.isArray(message.tool_calls) && message.tool_calls.length > 0,
+    });
   }
 }
 

--- a/extensions/venice/stream.ts
+++ b/extensions/venice/stream.ts
@@ -1,28 +1,12 @@
 // Venice plugin module implements stream behavior.
 import type { ProviderWrapStreamFnContext } from "openclaw/plugin-sdk/plugin-entry";
-import { createPayloadPatchStreamWrapper } from "openclaw/plugin-sdk/provider-stream-shared";
+import {
+  createPayloadPatchStreamWrapper,
+  normalizeOpenAICompatibleReasoningReplay,
+} from "openclaw/plugin-sdk/provider-stream-shared";
 
 function isVeniceDeepSeekV4ModelId(modelId: unknown): boolean {
   return modelId === "deepseek-v4-flash" || modelId === "deepseek-v4-pro";
-}
-
-function ensureVeniceDeepSeekV4Replay(payload: Record<string, unknown>): void {
-  delete payload.thinking;
-  delete payload.reasoning;
-  delete payload.reasoning_effort;
-
-  if (!Array.isArray(payload.messages)) {
-    return;
-  }
-  for (const message of payload.messages) {
-    if (!message || typeof message !== "object") {
-      continue;
-    }
-    const record = message as Record<string, unknown>;
-    if (record.role === "assistant") {
-      record.reasoning_content ??= "";
-    }
-  }
 }
 
 export function createVeniceDeepSeekV4Wrapper(
@@ -32,7 +16,13 @@ export function createVeniceDeepSeekV4Wrapper(
   void thinkingLevel;
   return createPayloadPatchStreamWrapper(baseStreamFn, ({ payload, model }) => {
     if (model.provider === "venice" && isVeniceDeepSeekV4ModelId(model.id)) {
-      ensureVeniceDeepSeekV4Replay(payload);
+      delete payload.thinking;
+      delete payload.reasoning;
+      delete payload.reasoning_effort;
+      normalizeOpenAICompatibleReasoningReplay(payload, {
+        thinkingEnabled: true,
+        replaceNullReasoningContent: true,
+      });
     }
   });
 }

--- a/extensions/xai/stream.ts
+++ b/extensions/xai/stream.ts
@@ -4,6 +4,7 @@ import { streamSimple } from "openclaw/plugin-sdk/llm";
 import type { ProviderWrapStreamFnContext } from "openclaw/plugin-sdk/plugin-entry";
 import {
   composeProviderStreamWrappers,
+  createPayloadPatchStreamWrapper,
   createPlainTextToolCallCompatWrapper,
   createToolStreamWrapper,
 } from "openclaw/plugin-sdk/provider-stream-shared";
@@ -215,28 +216,17 @@ function normalizeXaiResponsesToolResultPayload(
 }
 
 function createXaiToolPayloadCompatibilityWrapper(baseStreamFn: StreamFn | undefined): StreamFn {
-  const underlying = baseStreamFn ?? streamSimple;
-  return (model, context, options) => {
-    const originalOnPayload = options?.onPayload;
-    return underlying(model, context, {
-      ...options,
-      onPayload: (payload) => {
-        if (payload && typeof payload === "object") {
-          const payloadObj = payload as Record<string, unknown>;
-          normalizeXaiResponsesToolResultPayload(payloadObj, model);
-          if (!supportsReasoningControls(model)) {
-            // Only current flagship Grok models advertise configurable effort.
-            delete payloadObj.reasoning;
-            delete payloadObj.reasoningEffort;
-            delete payloadObj.reasoning_effort;
-          }
-          // All reasoning xAI models should still request + later replay encrypted_content.
-          ensureXaiResponsesEncryptedReasoningInclude(payloadObj, model);
-        }
-        return originalOnPayload?.(payload, model);
-      },
-    });
-  };
+  return createPayloadPatchStreamWrapper(baseStreamFn, ({ payload, model }) => {
+    normalizeXaiResponsesToolResultPayload(payload, model);
+    if (!supportsReasoningControls(model)) {
+      // Only current flagship Grok models advertise configurable effort.
+      delete payload.reasoning;
+      delete payload.reasoningEffort;
+      delete payload.reasoning_effort;
+    }
+    // All reasoning xAI models should still request + later replay encrypted_content.
+    ensureXaiResponsesEncryptedReasoningInclude(payload, model);
+  });
 }
 
 function createXaiFastModeWrapper(

--- a/src/plugin-sdk/provider-stream-shared.test.ts
+++ b/src/plugin-sdk/provider-stream-shared.test.ts
@@ -14,6 +14,7 @@ import {
   defaultToolStreamExtraParams,
   isOpenAICompatibleThinkingEnabled,
   normalizeOpenAICompatibleReasoningPayload,
+  normalizeOpenAICompatibleReasoningReplay,
   setQwenChatTemplateThinking,
   stripTrailingAnthropicAssistantPrefillWhenThinking,
 } from "./provider-stream-shared.js";
@@ -260,6 +261,103 @@ describe("normalizeOpenAICompatibleReasoningPayload", () => {
     normalizeOpenAICompatibleReasoningPayload(payload, "ultra");
 
     expect(payload).toEqual({ reasoning: { effort: "xhigh" } });
+  });
+});
+
+describe("normalizeOpenAICompatibleReasoningReplay", () => {
+  it("backfills only assistant messages while preserving existing reasoning", () => {
+    const payload = {
+      messages: [
+        { role: "user", content: "read" },
+        { role: "assistant", content: "done" },
+        { role: "tool", content: "ok" },
+        { role: "assistant", reasoning_content: "native reasoning" },
+        { role: "assistant", reasoning_content: null },
+      ],
+    };
+
+    normalizeOpenAICompatibleReasoningReplay(payload, { thinkingEnabled: true });
+
+    expect(payload.messages).toEqual([
+      { role: "user", content: "read" },
+      { role: "assistant", content: "done", reasoning_content: "" },
+      { role: "tool", content: "ok" },
+      { role: "assistant", reasoning_content: "native reasoning" },
+      { role: "assistant", reasoning_content: null },
+    ]);
+  });
+
+  it("honors provider-owned tool-call replay selection", () => {
+    const payload = {
+      messages: [
+        { role: "assistant", content: "plain" },
+        { role: "assistant", tool_calls: [{ id: "call_1" }] },
+      ],
+    };
+
+    normalizeOpenAICompatibleReasoningReplay(payload, {
+      thinkingEnabled: true,
+      shouldBackfillAssistantMessage: (message) => Array.isArray(message.tool_calls),
+    });
+
+    expect(payload.messages).toEqual([
+      { role: "assistant", content: "plain" },
+      { role: "assistant", tool_calls: [{ id: "call_1" }], reasoning_content: "" },
+    ]);
+  });
+
+  it("normalizes nullable reasoning for providers requiring string replay", () => {
+    const payload = {
+      messages: [
+        { role: "assistant", reasoning_content: null },
+        { role: "assistant", reasoning_content: undefined },
+      ],
+    };
+
+    normalizeOpenAICompatibleReasoningReplay(payload, {
+      thinkingEnabled: true,
+      replaceNullReasoningContent: true,
+    });
+
+    expect(payload.messages).toEqual([
+      { role: "assistant", reasoning_content: "" },
+      { role: "assistant", reasoning_content: "" },
+    ]);
+  });
+
+  it("strips reasoning across all replay messages when thinking is disabled", () => {
+    const payload = {
+      messages: [
+        { role: "user", reasoning_content: "cross-provider" },
+        { role: "assistant", reasoning_content: "native" },
+        { role: "tool", reasoning_content: "cross-provider" },
+      ],
+    };
+
+    normalizeOpenAICompatibleReasoningReplay(payload, { thinkingEnabled: false });
+
+    expect(payload.messages).toEqual([{ role: "user" }, { role: "assistant" }, { role: "tool" }]);
+  });
+
+  it("preserves non-assistant replay metadata for assistant-only provider policies", () => {
+    const payload = {
+      messages: [
+        { role: "user", reasoning_content: "preserve user" },
+        { role: "assistant", reasoning_content: "remove assistant" },
+        { role: "tool", reasoning_content: "preserve tool" },
+      ],
+    };
+
+    normalizeOpenAICompatibleReasoningReplay(payload, {
+      thinkingEnabled: false,
+      stripAssistantMessagesOnly: true,
+    });
+
+    expect(payload.messages).toEqual([
+      { role: "user", reasoning_content: "preserve user" },
+      { role: "assistant" },
+      { role: "tool", reasoning_content: "preserve tool" },
+    ]);
   });
 });
 

--- a/src/plugin-sdk/provider-stream-shared.ts
+++ b/src/plugin-sdk/provider-stream-shared.ts
@@ -457,21 +457,17 @@ function resolveDeepSeekV4ReasoningEffort(
   return thinkingLevel === "xhigh" || thinkingLevel === "max" ? "max" : "high";
 }
 
-function stripDeepSeekV4ReasoningContent(payload: Record<string, unknown>): void {
-  if (!Array.isArray(payload.messages)) {
-    return;
-  }
-  for (const message of payload.messages) {
-    if (!message || typeof message !== "object") {
-      continue;
-    }
-    delete (message as Record<string, unknown>).reasoning_content;
-  }
-}
-
-function ensureDeepSeekV4AssistantReasoningContent(
+/** Normalizes assistant reasoning replay shared by OpenAI-compatible provider families. */
+export function normalizeOpenAICompatibleReasoningReplay(
   payload: Record<string, unknown>,
-  params?: {
+  params: {
+    /** Disabled reasoning strips replay fields instead of backfilling assistant turns. */
+    thinkingEnabled: boolean;
+    /** Restricts disabled-reasoning cleanup to assistant messages when required. */
+    stripAssistantMessagesOnly?: boolean;
+    /** Replaces explicit null values for transports that require string reasoning. */
+    replaceNullReasoningContent?: boolean;
+    /** Preserves provider-specific tool-call selection for assistant replay. */
     shouldBackfillAssistantMessage?: (message: Record<string, unknown>) => boolean;
   },
 ): void {
@@ -483,13 +479,22 @@ function ensureDeepSeekV4AssistantReasoningContent(
       continue;
     }
     const record = message as Record<string, unknown>;
-    if (record.role !== "assistant") {
+    if (!params.thinkingEnabled) {
+      if (!params.stripAssistantMessagesOnly || record.role === "assistant") {
+        delete record.reasoning_content;
+      }
       continue;
     }
-    if (params?.shouldBackfillAssistantMessage && !params.shouldBackfillAssistantMessage(record)) {
+    if (
+      record.role !== "assistant" ||
+      (params.shouldBackfillAssistantMessage && !params.shouldBackfillAssistantMessage(record))
+    ) {
       continue;
     }
-    if (!("reasoning_content" in record)) {
+    if (
+      !("reasoning_content" in record) ||
+      (params.replaceNullReasoningContent && record.reasoning_content == null)
+    ) {
       record.reasoning_content = "";
     }
   }
@@ -518,13 +523,14 @@ export function createDeepSeekV4OpenAICompatibleThinkingWrapper(params: {
         payload.thinking = { type: "disabled" };
         delete payload.reasoning_effort;
         delete payload.reasoning;
-        stripDeepSeekV4ReasoningContent(payload);
+        normalizeOpenAICompatibleReasoningReplay(payload, { thinkingEnabled: false });
         return;
       }
 
       payload.thinking = { type: "enabled" };
       payload.reasoning_effort = resolveReasoningEffort(params.thinkingLevel);
-      ensureDeepSeekV4AssistantReasoningContent(payload, {
+      normalizeOpenAICompatibleReasoningReplay(payload, {
+        thinkingEnabled: true,
         shouldBackfillAssistantMessage: params.shouldBackfillAssistantReasoningContent,
       });
     });


### PR DESCRIPTION
## What Problem This Solves

Users switching between OpenAI-compatible providers depend on replayed assistant reasoning being preserved, removed, or backfilled according to the selected model's actual transport. Maintaining those rules independently across Qwen, Baseten, Venice, OpenRouter, Kimi, and DeepSeek-compatible providers makes cross-provider tool-call replay vulnerable to subtle drift. Ollama's local and hosted providers also repeated their native transport and replay policies, and xAI maintained a separate copy of the standard payload-wrapper contract.

## Why This Change Was Made

This maintainer-requested, AI-assisted refactor consolidates assistant reasoning replay in the existing provider-stream SDK, moves both Ollama providers onto one plugin-owned native transport/replay hook object, and uses the existing generic payload wrapper for xAI. Provider authentication, catalogs, model selection, request wire formats, callback ordering, cancellation, and public SDK paths remain unchanged.

## User Impact

Cross-provider tool-call conversations preserve native reasoning consistently across Qwen, DeepSeek, Baseten, Venice, OpenRouter, Kimi, Xiaomi, and OpenCode Go. Ollama's local and cloud transport behavior remains unchanged. Removes 123 net production lines (+121/-244) without moving production logic into tests or adding a public SDK path.

## Evidence

- 27 targeted provider, native-stream, replay, reasoning, tool-schema, SDK, and runtime test files: 756 tests passed in six Vitest shards on a Blacksmith Testbox.
- Five direct shared-replay regression tests cover existing reasoning, null preservation, provider-specific null replacement, tool-call-only replay selection, all-message cleanup, and assistant-only cleanup.
- Public SDK surface check passed across 316 entry points and 7,457 exports.
- SDK/plugin import-boundary check returned `[]`.
- All changed files pass repository formatting; `git diff --check` passes.
- Fresh independent autoreview: `--engine codex --model gpt-5.6-sol --thinking xhigh`; no accepted or actionable findings.
- Full type-aware lint, all four `tsgo` lanes, full formatting, changed-file checks, dead-code checks, and packaged build are validated on the same Testbox before marking ready.

