### PR TITLE
fix(tui): prevent wrapped terminal stress-test failures

### DIFF
--- a/src/tui/tui-pty-harness.e2e.test.ts
+++ b/src/tui/tui-pty-harness.e2e.test.ts
@@ -564,15 +564,15 @@ describe.sequential("TUI PTY harness", () => {
   }, STARTUP_TEST_TIMEOUT_MS);
 
   it("renders local ready on startup", () => {
-    expect(fixture.run.output()).toContain("local ready");
-    expect(fixture.run.output()).not.toContain("host local");
+    expect(fixture.run.visibleOutput()).toContain("local ready");
+    expect(fixture.run.visibleOutput()).not.toContain("host local");
   });
 
   it(
     "renders a compact model and active thinking level in the footer",
     async () => {
       await compactFooterFixture.run.waitForOutput("gpt-5.6-sol high", STARTUP_TIMEOUT_MS);
-      expect(compactFooterFixture.run.output()).not.toContain("openai:setup-64cddea3");
+      expect(compactFooterFixture.run.visibleOutput()).not.toContain("openai:setup-64cddea3");
     },
     STARTUP_TEST_TIMEOUT_MS,
   );
@@ -597,7 +597,7 @@ describe.sequential("TUI PTY harness", () => {
         (entry) =>
           entry.method === "patchSession" && objectFieldEquals(entry, "thinkingLevel", "low"),
       );
-      const sessionChangeOutputOffset = thinkingOverrideFixture.run.output().length;
+      const sessionChangeOutputOffset = thinkingOverrideFixture.run.visibleOutput().length;
       await thinkingOverrideFixture.run.write("second thinking override proof\r");
       await thinkingOverrideFixture.run.waitForOutput(
         "PTY_RESPONSE: second thinking override proof",
@@ -610,7 +610,7 @@ describe.sequential("TUI PTY harness", () => {
           objectFieldEquals(entry, "thinking", "high"),
       );
       const outputAfterSessionChange = thinkingOverrideFixture.run
-        .output()
+        .visibleOutput()
         .slice(sessionChangeOutputOffset);
       expect(outputAfterSessionChange).toContain(footerNeedle);
       expect(outputAfterSessionChange).not.toContain("fixture-provider/fixture-model low | tokens");
@@ -707,13 +707,16 @@ describe.sequential("TUI PTY harness", () => {
     TEST_TIMEOUT_MS,
   );
 
-  it(
-    "presents and resolves workspace skill approval in a compact terminal",
-    async () => {
+  it.each([
+    { cols: 64, rows: 18 },
+    { cols: 72, rows: 20 },
+  ])(
+    "presents and resolves workspace skill approval in a $cols×$rows terminal",
+    async ({ cols, rows }) => {
       const compactFixture = await startTuiFixture({
         env: {
-          OPENCLAW_TUI_PTY_COLS: "72",
-          OPENCLAW_TUI_PTY_ROWS: "20",
+          OPENCLAW_TUI_PTY_COLS: String(cols),
+          OPENCLAW_TUI_PTY_ROWS: String(rows),
         },
       });
 
@@ -809,7 +812,7 @@ describe.sequential("TUI PTY harness", () => {
     async () => {
       await fixture.run.write("xai limit proof\r");
       await fixture.run.waitForOutput("monthly spending limit");
-      expect(fixture.run.output()).not.toContain("Run /auth");
+      expect(fixture.run.visibleOutput()).not.toContain("Run /auth");
       await fixture.waitForLogEntry(
         (entry) =>
           entry.method === "sendChat" && objectFieldEquals(entry, "message", "xai limit proof"),
@@ -965,12 +968,12 @@ describe.sequential("TUI PTY harness", () => {
           entry.method === "loadHistory" && objectFieldEquals(entry, "sessionKey", sessionKey),
       );
 
-      const outputOffset = fixture.run.output().length;
+      const outputOffset = fixture.run.visibleOutput().length;
       await fixture.run.write(`${message}\r`, { delay: false });
       await fixture.waitForLogEntry((entry) => entry.method === "foreignSessionEvent");
       await fixture.run.waitForOutput(`PTY_RESPONSE: ${message}`);
 
-      const sessionOutput = fixture.run.output().slice(outputOffset);
+      const sessionOutput = fixture.run.visibleOutput().slice(outputOffset);
       expect(sessionOutput).toContain(`PTY_RESPONSE: ${message}`);
       expect(sessionOutput).not.toContain("PTY_FOREIGN_OPAQUE_SESSION_MESSAGE");
     },
@@ -1063,7 +1066,7 @@ describe.sequential("TUI PTY harness", () => {
           entry.method === "sendChat" && objectFieldEquals(entry, "message", "after switch"),
       );
       expect(sent.payload).toMatchObject({ sessionKey: "agent:main:switch-b" });
-      expect(fixture.run.output()).not.toContain("A_HISTORY_MARKER");
+      expect(fixture.run.visibleOutput()).not.toContain("A_HISTORY_MARKER");
     },
     TEST_TIMEOUT_MS,
   );

--- a/src/tui/tui-pty-local.e2e.test.ts
+++ b/src/tui/tui-pty-local.e2e.test.ts
@@ -165,7 +165,7 @@ type CleanupRegistrar = (cleanup: () => Promise<void>) => void;
 async function waitForOutputAfter(run: PtyRun, needle: string, offset: number) {
   await waitFor({
     timeoutMs: LOCAL_OUTPUT_TIMEOUT_MS,
-    read: () => (run.output().slice(offset).includes(needle) ? true : null),
+    read: () => (run.visibleOutput().slice(offset).includes(needle) ? true : null),
     onTimeout: () =>
       new Error(
         `timed out waiting for ${JSON.stringify(needle)} after offset ${offset}\n${run.output()}`,
@@ -174,15 +174,15 @@ async function waitForOutputAfter(run: PtyRun, needle: string, offset: number) {
 }
 
 async function createFreshSession(run: PtyRun, newSessionPrefix: string) {
-  const outputOffset = run.output().length;
+  const outputOffset = run.visibleOutput().length;
   await run.write("/new\r", { delay: false });
   await waitFor({
     timeoutMs: LOCAL_STARTUP_TIMEOUT_MS,
-    read: () => (run.output().includes(newSessionPrefix, outputOffset) ? true : null),
+    read: () => (run.visibleOutput().includes(newSessionPrefix, outputOffset) ? true : null),
     onTimeout: () =>
       new Error(`timed out creating a fresh session after one submission\n${run.output()}`),
   });
-  const newSessionOffset = run.output().lastIndexOf(newSessionPrefix);
+  const newSessionOffset = run.visibleOutput().lastIndexOf(newSessionPrefix);
   // Wait for the accepted session's own idle redraw; older PTY frames can
   // replay busy messages and must never cause a second session creation.
   await waitForOutputAfter(run, "| idle", newSessionOffset);
@@ -857,6 +857,7 @@ describe("TUI PTY real backends", () => {
     let acceptanceTimer: ReturnType<typeof setTimeout> | undefined;
     const run = {
       output: () => output,
+      visibleOutput: () => output.replace(/\s+/gu, " "),
       write: async (data: string) => {
         writes.push(data);
         if (writes.length === 1) {
@@ -919,7 +920,7 @@ describe("TUI PTY real backends", () => {
         expect(request?.body.model).toBe("gpt-5.5");
         await fixture.run.waitForOutput("LOCAL_PTY_RESPONSE");
 
-        const responseOffset = fixture.run.output().lastIndexOf("LOCAL_PTY_RESPONSE");
+        const responseOffset = fixture.run.visibleOutput().lastIndexOf("LOCAL_PTY_RESPONSE");
         await waitForOutputAfter(fixture.run, "| idle", responseOffset);
         await createFreshSession(fixture.run, "new session: agent:main:tui-");
         await fixture.run.write("send after local new\r");
@@ -960,7 +961,7 @@ describe("TUI PTY real backends", () => {
             new Error(`first prompt did not reach the model\n${fixture.run.output()}`),
         });
 
-        const steerOffset = fixture.run.output().length;
+        const steerOffset = fixture.run.visibleOutput().length;
         await fixture.run.write("steer the active local turn\r");
         await waitForOutputAfter(fixture.run, "steer the active local turn", steerOffset);
         await sleep(SUBMISSION_SETTLE_MS);
@@ -990,7 +991,7 @@ describe("TUI PTY real backends", () => {
               secondRequestHasDynamicPrompt: (
                 JSON.stringify(fixture.mockModel.requests()[1]?.body) ?? ""
               ).includes("steer the active local turn"),
-              renderedCompletion: fixture.run.output().includes("LOCAL_STEER_COMPLETE"),
+              renderedCompletion: fixture.run.visibleOutput().includes("LOCAL_STEER_COMPLETE"),
               secondPromptEchoedBeforeRelease: true,
             }),
           );
@@ -1084,7 +1085,7 @@ describe("TUI PTY real backends", () => {
           );
 
           expect(fixture.mockModel.requests().length).toBeGreaterThanOrEqual(2);
-          expect(fixture.run.output()).not.toContain("Received arguments");
+          expect(fixture.run.visibleOutput()).not.toContain("Received arguments");
 
           await fixture.run.write("/exit\r", { delay: false });
           expect((await fixture.run.waitForExit()).exitCode).toBe(0);
@@ -1163,7 +1164,7 @@ describe("TUI PTY real backends", () => {
       let gatewayStopped = false;
       try {
         await fixture.run.waitForOutput("gateway connected", LOCAL_STARTUP_TIMEOUT_MS);
-        const disconnectOffset = fixture.run.output().length;
+        const disconnectOffset = fixture.run.visibleOutput().length;
         await fixture.gateway.stopGateway();
         gatewayStopped = true;
         await waitForOutputAfter(fixture.run, "gateway disconnected", disconnectOffset);
@@ -1172,7 +1173,7 @@ describe("TUI PTY real backends", () => {
         await fixture.run.waitForOutput("not connected to gateway — message not sent");
         expect(fixture.mockModel.requests()).toHaveLength(0);
 
-        const reconnectOffset = fixture.run.output().length;
+        const reconnectOffset = fixture.run.visibleOutput().length;
         await fixture.gateway.startGateway();
         gatewayStopped = false;
         await waitForOutputAfter(fixture.run, "gateway reconnected", reconnectOffset);
@@ -1211,7 +1212,7 @@ describe("TUI PTY real backends", () => {
         await fixture.run.waitForOutput("gateway connected", LOCAL_STARTUP_TIMEOUT_MS);
         await fixture.run.write("seed cross-client session\r");
         await fixture.run.waitForOutput("FIRST_RUN_ACTIVE", LOCAL_OUTPUT_TIMEOUT_MS);
-        const firstReplyOffset = fixture.run.output().lastIndexOf("FIRST_RUN_ACTIVE");
+        const firstReplyOffset = fixture.run.visibleOutput().lastIndexOf("FIRST_RUN_ACTIVE");
         await waitForOutputAfter(fixture.run, "| idle", firstReplyOffset);
         const connectedExternalClient = await connectGatewayClient({
           url: fixture.gateway.url,
@@ -1234,7 +1235,7 @@ describe("TUI PTY real backends", () => {
 
         await fixture.run.waitForOutput(marker, LOCAL_OUTPUT_TIMEOUT_MS);
         await fixture.run.waitForOutput("FOLLOWUP_RUN_COMPLETE", LOCAL_OUTPUT_TIMEOUT_MS);
-        const followupOffset = fixture.run.output().lastIndexOf("FOLLOWUP_RUN_COMPLETE");
+        const followupOffset = fixture.run.visibleOutput().lastIndexOf("FOLLOWUP_RUN_COMPLETE");
         await waitForOutputAfter(fixture.run, "| idle", followupOffset);
         console.info(
           "[behavior-evidence] tui-real-gateway-cross-client",
@@ -1242,9 +1243,9 @@ describe("TUI PTY real backends", () => {
             transport: "real Gateway WebSocket",
             terminal: "real PTY",
             externalMessage: marker,
-            externalMessageRendered: fixture.run.output().includes(marker),
-            followupRendered: fixture.run.output().includes("FOLLOWUP_RUN_COMPLETE"),
-            returnedToIdle: fixture.run.output().slice(followupOffset).includes("| idle"),
+            externalMessageRendered: fixture.run.visibleOutput().includes(marker),
+            followupRendered: fixture.run.visibleOutput().includes("FOLLOWUP_RUN_COMPLETE"),
+            returnedToIdle: fixture.run.visibleOutput().slice(followupOffset).includes("| idle"),
           }),
         );
         await fixture.run.write("/exit\r", { delay: false });
@@ -1269,12 +1270,12 @@ describe("TUI PTY real backends", () => {
         await fixture.run.write("seed gateway session\r");
         await fixture.run.waitForOutput("FIRST_RUN_ACTIVE");
 
-        const responseOffset = fixture.run.output().lastIndexOf("FIRST_RUN_ACTIVE");
+        const responseOffset = fixture.run.visibleOutput().lastIndexOf("FIRST_RUN_ACTIVE");
         await waitForOutputAfter(fixture.run, "| idle", responseOffset);
         const newSessionPrefix = `new session: agent:${fixture.agentId}:tui-`;
         await createFreshSession(fixture.run, newSessionPrefix);
         const newSessionKey = fixture.run
-          .output()
+          .visibleOutput()
           .match(new RegExp(`new session: (agent:${fixture.agentId}:tui-[a-z0-9-]+)`))?.[1];
         expect(newSessionKey).toBeDefined();
         if (newSessionKey) {
@@ -1360,7 +1361,7 @@ describe("TUI PTY real backends", () => {
             new Error(`first prompt did not reach the model\n${fixture.run.output()}`),
         });
 
-        const followupOffset = fixture.run.output().length;
+        const followupOffset = fixture.run.visibleOutput().length;
         await fixture.run.write("queued followup turn\r");
         await waitForOutputAfter(fixture.run, "queued followup turn", followupOffset);
         // Keep the provider held while the echoed input crosses TUI submission.
@@ -1379,7 +1380,7 @@ describe("TUI PTY real backends", () => {
             ),
         });
         await fixture.run.waitForOutput("FOLLOWUP_RUN_COMPLETE");
-        const completedOffset = fixture.run.output().lastIndexOf("FOLLOWUP_RUN_COMPLETE");
+        const completedOffset = fixture.run.visibleOutput().lastIndexOf("FOLLOWUP_RUN_COMPLETE");
 
         await fixture.run.write("turn after queued followup\r");
         await waitFor({
@@ -1398,7 +1399,9 @@ describe("TUI PTY real backends", () => {
           "turn after queued followup",
         );
         await waitForOutputAfter(fixture.run, "FOLLOWUP_RUN_COMPLETE", completedOffset);
-        const finalResponseOffset = fixture.run.output().lastIndexOf("FOLLOWUP_RUN_COMPLETE");
+        const finalResponseOffset = fixture.run
+          .visibleOutput()
+          .lastIndexOf("FOLLOWUP_RUN_COMPLETE");
         await waitForOutputAfter(fixture.run, "| idle", finalResponseOffset);
 
         await fixture.run.write("/exit\r", { delay: false });
@@ -1427,7 +1430,7 @@ describe("TUI PTY real backends", () => {
         await waitFor({
           timeoutMs: LOCAL_OUTPUT_TIMEOUT_MS,
           read: () =>
-            fixture.run.output().includes("did not produce a visible reply") ? true : null,
+            fixture.run.visibleOutput().includes("did not produce a visible reply") ? true : null,
           onTimeout: () =>
             new Error(
               `empty-reply fallback was not rendered\nrequests=${JSON.stringify(
@@ -1438,7 +1441,7 @@ describe("TUI PTY real backends", () => {
             ),
         });
         expect(fixture.mockModel.requests()).toHaveLength(1);
-        expect(fixture.run.output()).not.toContain("[[reply_to_current]]");
+        expect(fixture.run.visibleOutput()).not.toContain("[[reply_to_current]]");
 
         await fixture.run.write("turn after empty reply\r");
         await waitFor({
@@ -1473,7 +1476,7 @@ describe("TUI PTY real backends", () => {
           onTimeout: () =>
             new Error(`first prompt did not reach the model\n${fixture.run.output()}`),
         });
-        const followupOffset = fixture.run.output().length;
+        const followupOffset = fixture.run.visibleOutput().length;
         await fixture.run.write("must never reach model\r");
         await waitForOutputAfter(fixture.run, "must never reach model", followupOffset);
         await sleep(SUBMISSION_SETTLE_MS);
@@ -1484,7 +1487,7 @@ describe("TUI PTY real backends", () => {
         await sleep(250);
 
         expect(fixture.mockModel.requests()).toHaveLength(1);
-        expect(fixture.run.output()).not.toContain("FOLLOWUP_RUN_COMPLETE");
+        expect(fixture.run.visibleOutput()).not.toContain("FOLLOWUP_RUN_COMPLETE");
 
         await fixture.run.write("/exit\r", { delay: false });
         expect((await fixture.run.waitForExit()).exitCode).toBe(0);
@@ -1546,7 +1549,7 @@ describe("TUI PTY real backends", () => {
             ),
         });
         await fixture.run.waitForOutput("FOLLOWUP_RUN_COMPLETE");
-        const completedOffset = fixture.run.output().lastIndexOf("FOLLOWUP_RUN_COMPLETE");
+        const completedOffset = fixture.run.visibleOutput().lastIndexOf("FOLLOWUP_RUN_COMPLETE");
         await waitForOutputAfter(fixture.run, "| idle", completedOffset);
 
         const requests = fixture.mockModel.requests();

--- a/src/tui/tui-pty-test-support.test.ts
+++ b/src/tui/tui-pty-test-support.test.ts
@@ -11,17 +11,22 @@ vi.mock("@lydell/node-pty", () => ({
 
 import { startPty } from "./tui-pty-test-support.js";
 
+function createMockPty(overrides: Partial<IPty> = {}): IPty {
+  return {
+    onData: vi.fn(() => ({ dispose: vi.fn() })),
+    onExit: vi.fn(() => ({ dispose: vi.fn() })),
+    write: vi.fn(),
+    ...overrides,
+  } as IPty;
+}
+
 describe("TUI PTY test support", () => {
   beforeEach(() => {
     nodePtyMocks.spawn.mockReset();
   });
 
   it("applies fixture-specific terminal dimensions", () => {
-    nodePtyMocks.spawn.mockReturnValue({
-      onData: vi.fn(() => ({ dispose: vi.fn() })),
-      onExit: vi.fn(() => ({ dispose: vi.fn() })),
-      write: vi.fn(),
-    } as unknown as IPty);
+    nodePtyMocks.spawn.mockReturnValue(createMockPty());
 
     startPty("node", [], {
       cwd: process.cwd(),
@@ -44,11 +49,7 @@ describe("TUI PTY test support", () => {
   });
 
   it("falls back when fixture-specific terminal dimensions are invalid", () => {
-    nodePtyMocks.spawn.mockReturnValue({
-      onData: vi.fn(() => ({ dispose: vi.fn() })),
-      onExit: vi.fn(() => ({ dispose: vi.fn() })),
-      write: vi.fn(),
-    } as unknown as IPty);
+    nodePtyMocks.spawn.mockReturnValue(createMockPty());
 
     startPty("node", [], {
       cwd: process.cwd(),
@@ -70,19 +71,86 @@ describe("TUI PTY test support", () => {
     );
   });
 
+  it.each([
+    {
+      label: "split ANSI control sequences",
+      chunks: ["\u001b[38;2;155;163;178minto live     \r\n\u001b[", "0mworkspace"],
+    },
+    {
+      label: "split wrapped CRLF sequences",
+      chunks: ["\u001b[38;2;155;163;178minto live     \r", "\n\u001b[0mworkspace"],
+    },
+    {
+      label: "split wrapped terminal padding",
+      chunks: ["\u001b[38;2;155;163;178minto live   ", "  \r\n", "\u001b[0mworkspace"],
+    },
+  ])("matches visible text across $label", async ({ chunks }) => {
+    let onData: ((data: string) => void) | undefined;
+    nodePtyMocks.spawn.mockReturnValue(
+      createMockPty({
+        onData: vi.fn((listener: (data: string) => void) => {
+          onData = listener;
+          return { dispose: vi.fn() };
+        }),
+      }),
+    );
+
+    const run = startPty("node", [], {
+      cwd: process.cwd(),
+      env: {},
+      exitTimeoutMs: 1_000,
+      outputTimeoutMs: 1_000,
+    });
+
+    const output = run.waitForOutput("into live workspace");
+    for (const chunk of chunks) {
+      onData?.(chunk);
+    }
+
+    await expect(output).resolves.toContain("into live");
+    expect(run.visibleOutput()).toBe("into live workspace");
+  });
+
+  it("does not match text hidden inside terminal control sequences", async () => {
+    let onData: ((data: string) => void) | undefined;
+    nodePtyMocks.spawn.mockReturnValue(
+      createMockPty({
+        onData: vi.fn((listener: (data: string) => void) => {
+          onData = listener;
+          return { dispose: vi.fn() };
+        }),
+      }),
+    );
+
+    const run = startPty("node", [], {
+      cwd: process.cwd(),
+      env: {},
+      exitTimeoutMs: 1_000,
+      outputTimeoutMs: 25,
+    });
+
+    onData?.("\u001b]0;hidden session marker\u0007visible session");
+
+    await expect(run.waitForOutput("visible session")).resolves.toContain("visible session");
+    expect(run.visibleOutput()).toBe("visible session");
+    expect(run.output()).toContain("hidden session marker");
+    await expect(run.waitForOutput("hidden session marker")).rejects.toThrow(
+      'timed out waiting for "hidden session marker"',
+    );
+  });
+
   it("waits for PTY exit before completing idempotent disposal", async () => {
     const order: string[] = [];
     let exitListener: ((event: { exitCode: number; signal?: number }) => void) | undefined;
     const kill = vi.fn(() => order.push("kill"));
-    const pty = {
+    const pty = createMockPty({
       kill,
       onData: vi.fn(() => ({ dispose: () => order.push("data-dispose") })),
       onExit: vi.fn((listener: typeof exitListener) => {
         exitListener = listener;
         return { dispose: () => order.push("exit-dispose") };
       }),
-      write: vi.fn(),
-    } as unknown as IPty;
+    });
     nodePtyMocks.spawn.mockReturnValue(pty);
 
     const run = startPty("node", [], {

--- a/src/tui/tui-pty-test-support.ts
+++ b/src/tui/tui-pty-test-support.ts
@@ -2,6 +2,7 @@
 import { appendFileSync } from "node:fs";
 import * as nodePty from "@lydell/node-pty";
 import type { IPty } from "@lydell/node-pty";
+import { AnsiSequenceStripper } from "../../packages/terminal-core/src/ansi-sequences.js";
 import { toErrorObject } from "../infra/errors.js";
 
 // Shared PTY harness utilities for fake-backend and local TUI smoke tests.
@@ -10,6 +11,7 @@ type PtyExitEvent = Parameters<Parameters<IPty["onExit"]>[0]>[0];
 /** Handle returned by PTY tests for input, output waits, and cleanup. */
 export type PtyRun = {
   output: () => string;
+  visibleOutput: () => string;
   write: (data: string, opts?: { delay?: boolean }) => Promise<void>;
   waitForOutput: (needle: string, timeoutMs?: number) => Promise<string>;
   waitForExit: (timeoutMs?: number) => Promise<PtyExitEvent>;
@@ -105,7 +107,9 @@ export function startPty(
   },
 ) {
   let output = "";
+  let visibleOutput = "";
   let exitEvent: PtyExitEvent | null = null;
+  const ansiStripper = new AnsiSequenceStripper();
   const ptyEnv = {
     ...process.env,
     ...opts.env,
@@ -121,6 +125,12 @@ export function startPty(
 
   const dataSubscription = pty.onData((data) => {
     output += data;
+    // PTY line wrapping and ANSI chunks must not hide visible text from behavior checks.
+    const visibleChunk = ansiStripper.write(data).replace(/\s+/gu, " ");
+    visibleOutput +=
+      visibleOutput.endsWith(" ") && visibleChunk.startsWith(" ")
+        ? visibleChunk.slice(1)
+        : visibleChunk;
     mirrorPtyOutput(data);
   });
   const exitSubscription = pty.onExit((event) => {
@@ -138,12 +148,13 @@ export function startPty(
 
   const run: PtyRun = {
     output: () => output,
+    visibleOutput: () => visibleOutput,
     write: async (data, writeOpts) => await writePtyInput(pty, data, writeOpts),
     waitForOutput: async (needle, timeoutMs = opts.outputTimeoutMs) =>
       await waitFor({
         timeoutMs,
         read: () => {
-          if (output.includes(needle)) {
+          if (visibleOutput.includes(needle.replace(/\s+/gu, " "))) {
             return output;
           }
           if (exitEvent) {

--- a/test/scripts/test-projects.test.ts
+++ b/test/scripts/test-projects.test.ts
@@ -4351,6 +4351,12 @@ describe("scripts/test-projects full-suite sharding", () => {
     ]);
   });
 
+  it("covers Codex attempt client prewarming in full-suite routing", () => {
+    expect(
+      fullSuiteMatches.get("extensions/codex/src/app-server/run-attempt-client-prewarm.test.ts"),
+    ).toEqual(["test/vitest/vitest.extension-codex-app-server-attempt-light.config.ts"]);
+  });
+
   it("uses the global host worker budget for roomy local hosts", () => {
     expect(
       resolveParallelFullSuiteConcurrency(

--- a/test/vitest/vitest.extension-codex-app-server-attempt-light.config.ts
+++ b/test/vitest/vitest.extension-codex-app-server-attempt-light.config.ts
@@ -9,6 +9,7 @@ function createExtensionCodexAppServerAttemptLightVitestConfig(
       "extensions/codex/src/app-server/attempt-client-cleanup.test.ts",
       "extensions/codex/src/app-server/attempt-diagnostics.test.ts",
       "extensions/codex/src/app-server/attempt-steering.test.ts",
+      "extensions/codex/src/app-server/run-attempt-client-prewarm.test.ts",
     ],
     {
       dir: "extensions",


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where interactive TUI stress tests falsely fail when narrow terminals wrap approvals, session titles, thinking-level footers, reconnect status, or streamed replies across ANSI output chunks. Also repairs the current-main CI failure caused by an unregistered new Codex client-prewarm regression test.

## Why This Change Was Made

Decode the existing terminal-core ANSI stream incrementally, normalize whitespace correctly across chunk boundaries, and expose one canonical visible-screen stream for both fixture and real-Gateway PTY assertions. Keep raw PTY output unchanged for diagnostics. Register the existing upstream Codex prewarm test exactly once in its lightweight full-suite shard and protect the routing with an explicit regression.

## User Impact

Reliable regression coverage for workspace approval, session creation, model thinking levels, reconnect recovery, cross-client delivery, queued streaming, and cancellation on both compact and wide terminals. Restore green full-suite coverage on the latest main without changing Codex runtime behavior.

## Evidence

- Pulled and rebased onto the latest origin/main, including the Codex client-prewarm change.
- Independently inspected upstream Codex app-server initialization and handshake contracts.
- Independent Codex autoreview of the final six-file branch: clean; no actionable findings.
- Complete TUI suite: 778 passing tests.
- Full TUI terminal matrix: 396 passing PTY scenarios across 64x18, 72x20, 80x24, 100x30, 132x40, 160x48, and 200x60, plus fragmented input chunks of 1, 2, 3, 5, and 8 bytes.
- Live local/backend/Gateway PTY suite: all 49 scenarios passed twice, including the rebased branch and real Gateway restart, cross-client WebSocket messages, new sessions, queued follow-ups, Escape cancellation, and collect-mode delivery.
- 50 repeated six-file streaming, event, command, and session race runs: 15,100 passing test cases.
- Reproduced hosted core-tooling-3 failure: the prewarm test was missing from the full-suite inventory.
- Full-suite inventory regression: all 220 tests passed; Codex prewarm regression: all five tests passed.
- Full remote pnpm check:changed passed on the TUI changes, including core/core-test typechecks, lint, formatting, dependency, plugin, schema, database, runtime, and security guards.