### PR TITLE
fix: prevent cron and Workboard lifecycle races

### DIFF
--- a/extensions/workboard/src/dispatcher-ownership.test.ts
+++ b/extensions/workboard/src/dispatcher-ownership.test.ts
@@ -97,6 +97,46 @@ describe("Workboard dispatcher ownership", () => {
     ]);
   });
 
+  it("does not spend worker attempts on cards that fail workspace preflight", async () => {
+    const store = new WorkboardStore(createMemoryStore());
+    const inaccessible = [];
+    for (const [index, priority] of (["urgent", "high"] as const).entries()) {
+      inaccessible.push(
+        await store.create({
+          title: `Inaccessible worker ${index + 1}`,
+          status: "ready",
+          priority,
+          agentId: `inaccessible-worker-${index + 1}`,
+          workspace: { kind: "worktree", path: "/repo" },
+        }),
+      );
+    }
+    const healthy = await store.create({
+      title: "Healthy worker",
+      status: "ready",
+      agentId: "healthy-worker",
+      workspaceAccess: { unrestricted: true },
+    });
+    const run = vi.fn().mockResolvedValue({ runId: "run-healthy-worker" });
+
+    const result = await dispatchAndStartWorkboardCards({
+      store,
+      subagent: { run },
+      options: { now: 10, maxStarts: 1 },
+    });
+
+    expect(result.startFailures.map((failure) => failure.cardId)).toEqual(
+      inaccessible.map((card) => card.id),
+    );
+    expect(result.started).toEqual([
+      expect.objectContaining({ cardId: healthy.id, runId: "run-healthy-worker" }),
+    ]);
+    expect(run).toHaveBeenCalledOnce();
+    for (const card of inaccessible) {
+      await expect(store.get(card.id)).resolves.toMatchObject({ status: "ready" });
+    }
+  });
+
   it("tries a healthy owner before retrying a failed owner's queued cards", async () => {
     const store = new WorkboardStore(createMemoryStore());
     const failed = await store.create({
@@ -188,76 +228,82 @@ describe("Workboard dispatcher ownership", () => {
     await expect(store.get(normal.id)).resolves.toMatchObject({ status: "ready" });
   });
 
-  it("keeps a cross-board running worker slot until its heartbeat grace expires", async () => {
-    const store = new WorkboardStore(createMemoryStore());
-    const stale = await store.create({
-      title: "Abandoned product worker",
-      status: "running",
-      agentId: "shared-worker",
-      boardId: "product",
-      execution: {
-        id: "stale-execution",
-        kind: "agent-session",
-        mode: "autonomous",
+  it.each([
+    { name: "matching", agentId: "shared-worker" },
+    { name: "different", agentId: "assigned-worker" },
+  ])(
+    "keeps a cross-board running worker slot for a $name assigned agent until its heartbeat grace expires",
+    async ({ agentId }) => {
+      const store = new WorkboardStore(createMemoryStore());
+      const stale = await store.create({
+        title: "Abandoned product worker",
         status: "running",
-        startedAt: 1,
-        updatedAt: 1,
-      },
-    });
-    const claimed = await store.claim(stale.id, {
-      ownerId: "shared-worker",
-      token: "stale-token",
-      ttlSeconds: 1,
-    });
-    const ready = await store.create({
-      title: "Ready operations recovery",
-      status: "ready",
-      agentId: "shared-worker",
-      boardId: "ops",
-      workspaceAccess: { unrestricted: true },
-    });
-    const run = vi.fn().mockResolvedValue({ runId: "run-after-grace" });
-    const expiresAt = claimed.card.metadata?.claim?.expiresAt;
-    expect(expiresAt).toBeDefined();
-
-    const withinGrace = await dispatchAndStartWorkboardCards({
-      store,
-      subagent: { run },
-      options: {
-        now: expiresAt! + CLAIM_RECLAIM_MS,
-        maxStarts: 1,
+        agentId,
+        boardId: "product",
+        execution: {
+          id: "stale-execution",
+          kind: "agent-session",
+          mode: "autonomous",
+          status: "running",
+          startedAt: 1,
+          updatedAt: 1,
+        },
+      });
+      const claimed = await store.claim(stale.id, {
+        ownerId: "shared-worker",
+        token: "stale-token",
+        ttlSeconds: 1,
+      });
+      const ready = await store.create({
+        title: "Ready operations recovery",
+        status: "ready",
+        agentId: "shared-worker",
         boardId: "ops",
-      },
-    });
+        workspaceAccess: { unrestricted: true },
+      });
+      const run = vi.fn().mockResolvedValue({ runId: "run-after-grace" });
+      const expiresAt = claimed.card.metadata?.claim?.expiresAt;
+      expect(expiresAt).toBeDefined();
 
-    expect(withinGrace.started).toEqual([]);
-    expect(run).not.toHaveBeenCalled();
-    await expect(store.get(stale.id)).resolves.toMatchObject({
-      status: "running",
-      execution: { status: "running" },
-      metadata: { claim: { ownerId: "shared-worker" } },
-    });
+      const withinGrace = await dispatchAndStartWorkboardCards({
+        store,
+        subagent: { run },
+        options: {
+          now: expiresAt! + CLAIM_RECLAIM_MS,
+          maxStarts: 1,
+          boardId: "ops",
+        },
+      });
 
-    const reclaimed = await dispatchAndStartWorkboardCards({
-      store,
-      subagent: { run },
-      options: {
-        now: expiresAt! + CLAIM_RECLAIM_MS + 1,
-        maxStarts: 1,
-        boardId: "ops",
-      },
-    });
+      expect(withinGrace.started).toEqual([]);
+      expect(run).not.toHaveBeenCalled();
+      await expect(store.get(stale.id)).resolves.toMatchObject({
+        status: "running",
+        execution: { status: "running" },
+        metadata: { claim: { ownerId: "shared-worker" } },
+      });
 
-    expect(reclaimed.started).toEqual([
-      expect.objectContaining({ cardId: ready.id, runId: "run-after-grace" }),
-    ]);
-    expect(run).toHaveBeenCalledOnce();
-    await expect(store.get(stale.id)).resolves.toMatchObject({
-      status: "running",
-      execution: { status: "running" },
-      metadata: { claim: { ownerId: "shared-worker" } },
-    });
-  });
+      const reclaimed = await dispatchAndStartWorkboardCards({
+        store,
+        subagent: { run },
+        options: {
+          now: expiresAt! + CLAIM_RECLAIM_MS + 1,
+          maxStarts: 1,
+          boardId: "ops",
+        },
+      });
+
+      expect(reclaimed.started).toEqual([
+        expect.objectContaining({ cardId: ready.id, runId: "run-after-grace" }),
+      ]);
+      expect(run).toHaveBeenCalledOnce();
+      await expect(store.get(stale.id)).resolves.toMatchObject({
+        status: "running",
+        execution: { status: "running" },
+        metadata: { claim: { ownerId: "shared-worker" } },
+      });
+    },
+  );
 
   it("does not let an expired review claim consume worker capacity", async () => {
     const store = new WorkboardStore(createMemoryStore());

--- a/extensions/workboard/src/dispatcher.ts
+++ b/extensions/workboard/src/dispatcher.ts
@@ -272,7 +272,9 @@ function selectStartableCards(
     if (!consumesOwnerSlot || cardIsArchived(card)) {
       continue;
     }
-    const owner = resolveDispatchOwner(card, now);
+    // A grace-protected running claim still occupies its actual worker, even
+    // after the lease expires and the card's assigned agent differs.
+    const owner = claim?.ownerId ?? resolveDispatchOwner(card, now);
     runningByOwner.set(owner, (runningByOwner.get(owner) ?? 0) + 1);
   }
   const selected: WorkboardCard[] = [];
@@ -351,7 +353,6 @@ async function runWorkboardDispatch(
     if (startedOwners.has(ownerId)) {
       continue;
     }
-    attemptedStarts += 1;
     const sessionKey = buildSessionKey(card);
     let claimValue = "";
     let materializedWorkspace: WorkboardWorkspace | undefined;
@@ -441,6 +442,8 @@ async function runWorkboardDispatch(
         continue;
       }
     }
+    // Invalid workspace preflights must not spend the provider outage budget.
+    attemptedStarts += 1;
     try {
       const claimed = await params.store.claim(
         card.id,

--- a/extensions/workboard/src/store-core.ts
+++ b/extensions/workboard/src/store-core.ts
@@ -270,7 +270,7 @@ export class WorkboardCoreStore {
       if (card.metadata?.archivedAt) {
         archived += 1;
       }
-      if (card.status === "ready") {
+      if (card.status === "ready" && !card.metadata?.archivedAt) {
         oldestReadyAt = Math.min(oldestReadyAt ?? card.updatedAt, card.updatedAt);
       }
       updatedAt = Math.max(updatedAt ?? 0, card.updatedAt);

--- a/extensions/workboard/src/store-notifications.ts
+++ b/extensions/workboard/src/store-notifications.ts
@@ -83,7 +83,7 @@ export class WorkboardNotificationStore extends WorkboardWorkflowStore {
     const effectiveRunId = subscription?.runId;
     const events: WorkboardNotification[] = [];
     for (const card of await this.list({ boardId: effectiveBoardId })) {
-      if (effectiveCardId && card.id !== effectiveCardId) {
+      if (card.metadata?.archivedAt || (effectiveCardId && card.id !== effectiveCardId)) {
         continue;
       }
       const stale = card.metadata?.stale;

--- a/extensions/workboard/src/store.test.ts
+++ b/extensions/workboard/src/store.test.ts
@@ -2680,6 +2680,47 @@ describe("WorkboardStore", () => {
     expect(metadataBoardSecond.position).toBe(2000);
   });
 
+  it("excludes archived ready cards from active queue-age statistics", async () => {
+    vi.useFakeTimers();
+    try {
+      vi.setSystemTime(1_000);
+      const store = new WorkboardStore(createMemoryStore());
+      const oldReady = await store.create({
+        title: "Archived ready work",
+        boardId: "ops",
+        status: "ready",
+      });
+      vi.setSystemTime(2_000);
+      await store.archive(oldReady.id, true);
+
+      await expect(store.stats({ boardId: "ops" }, 5_000)).resolves.toMatchObject({
+        total: 1,
+        active: 0,
+        archived: 1,
+        byStatus: { ready: 1 },
+      });
+      await expect(store.stats({ boardId: "ops" }, 5_000)).resolves.not.toHaveProperty(
+        "oldestReadyAgeMs",
+      );
+
+      vi.setSystemTime(3_000);
+      await store.create({
+        title: "Active ready work",
+        boardId: "ops",
+        status: "ready",
+      });
+      await expect(store.stats({ boardId: "ops" }, 5_000)).resolves.toMatchObject({
+        total: 2,
+        active: 1,
+        archived: 1,
+        byStatus: { ready: 2 },
+        oldestReadyAgeMs: 2_000,
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("rejects completed manifests for cards not created from the parent", async () => {
     const store = new WorkboardStore(createMemoryStore());
     const parent = await store.create({ title: "Parent", status: "running" });
@@ -2841,6 +2882,64 @@ describe("WorkboardStore", () => {
     await expect(store.listNotificationSubscriptions({ boardId: "ops" })).resolves.toMatchObject({
       subscriptions: [expect.objectContaining({ id: subscription.id, cardId: card.id })],
     });
+  });
+
+  it("excludes archived cards from notification replay without discarding their history", async () => {
+    const subscriptions = createMemoryStore<PersistedWorkboardNotificationSubscription>();
+    const store = new WorkboardStore(createMemoryStore(), { subscriptions });
+    const historical = await store.create({
+      title: "Archived notifications",
+      boardId: "ops",
+      status: "done",
+      metadata: {
+        notifications: [
+          { id: "archived-completed", kind: "completed", createdAt: 101, message: "Done" },
+          { id: "archived-failed", kind: "failed", createdAt: 102, message: "Failed" },
+        ],
+        stale: { detectedAt: 103, reason: "Previous worker stopped" },
+      },
+    });
+    const archived = await store.archive(historical.id, true);
+    const active = await store.create({ title: "Active notifications", boardId: "ops" });
+    await store.complete(active.id, { summary: "Still active." });
+    const boardSubscription = await store.subscribeNotifications({
+      boardId: "ops",
+      target: "session:operator",
+    });
+    const archivedSubscription = await store.subscribeNotifications({
+      cardId: archived.id,
+      target: "session:operator",
+    });
+
+    await expect(
+      store.notificationEvents({ subscriptionId: boardSubscription.id }),
+    ).resolves.toMatchObject({
+      events: [expect.objectContaining({ kind: "completed", message: "Still active." })],
+    });
+    await expect(
+      store.notificationEvents({ subscriptionId: archivedSubscription.id }),
+    ).resolves.toMatchObject({ events: [] });
+    await expect(
+      store.advanceNotificationEvents({ subscriptionId: archivedSubscription.id }),
+    ).resolves.toMatchObject({ events: [] });
+    const storedSubscription = await subscriptions.lookup(archivedSubscription.id);
+    expect(storedSubscription?.subscription).not.toHaveProperty("lastEventAt");
+    expect(storedSubscription?.subscription).not.toHaveProperty("lastEventId");
+    expect(storedSubscription?.subscription).not.toHaveProperty("lastEventSequence");
+    await expect(store.get(archived.id)).resolves.toEqual(archived);
+
+    await store.archive(archived.id, false);
+    const restored = await store.notificationEvents({
+      subscriptionId: archivedSubscription.id,
+    });
+    expect(restored.events).toHaveLength(3);
+    expect(restored.events).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ id: "archived-completed", kind: "completed" }),
+        expect.objectContaining({ id: "archived-failed", kind: "failed" }),
+        expect.objectContaining({ kind: "stale" }),
+      ]),
+    );
   });
 
   it("replays notification events with subscription cursors", async () => {

--- a/src/cli/cron-cli.test.ts
+++ b/src/cli/cron-cli.test.ts
@@ -1068,6 +1068,41 @@ describe("cron cli", () => {
     expect(params?.payload?.toolsAllow).toEqual(["exec", "read", "write"]);
   });
 
+  it.each([
+    {
+      kind: "systemEvent",
+      args: ["--system-event", "tick"],
+      tools: "read,write",
+    },
+    {
+      kind: "command",
+      args: ["--command", "echo ok"],
+      tools: "read write",
+    },
+    {
+      kind: "command",
+      args: ["--command-argv", '["echo","ok"]'],
+      tools: "read,write",
+    },
+    {
+      kind: "agentTurn",
+      args: ["--message", "hello"],
+      tools: "read write",
+    },
+  ])(
+    "preserves the requested tool allowlist for $kind cron jobs",
+    async ({ kind, args, tools }) => {
+      const params = await runCronAddAndGetParams(
+        namedCronAddArgs(`Restricted ${kind}`, ...args, "--tools", tools),
+      );
+
+      expect(params?.payload).toMatchObject({
+        kind,
+        toolsAllow: ["read", "write"],
+      });
+    },
+  );
+
   it("sets fallback models on cron add", async () => {
     const params = await runCronAddAndGetParams(
       namedCronAddArgs(

--- a/src/cli/cron-cli/register.cron-add.ts
+++ b/src/cli/cron-cli/register.cron-add.ts
@@ -221,6 +221,7 @@ export function registerCronAddCommand(cron: Command) {
               const commandShell = normalizeOptionalString(opts.command);
               const commandArgv = parseCronCommandArgv(opts.commandArgv);
               const scriptPath = normalizeOptionalString(opts.script);
+              const toolsAllow = parseCronToolsAllow(opts.tools);
               if (optionMessage && positionalMessage && optionMessage !== positionalMessage) {
                 throw new Error(
                   "Pass the cron job message either positionally or with --message, not both.",
@@ -244,7 +245,11 @@ export function registerCronAddCommand(cron: Command) {
                 );
               }
               if (systemEvent) {
-                return { kind: "systemEvent" as const, text: systemEvent };
+                return {
+                  kind: "systemEvent" as const,
+                  text: systemEvent,
+                  ...(toolsAllow ? { toolsAllow } : {}),
+                };
               }
               if (scriptPath) {
                 const scriptTimeoutSeconds = parseStrictPositiveIntOrUndefined(
@@ -262,7 +267,7 @@ export function registerCronAddCommand(cron: Command) {
                   scriptPath,
                   timeoutSeconds: scriptTimeoutSeconds,
                   toolBudget: scriptToolBudget,
-                  toolsAllow: parseCronToolsAllow(opts.tools),
+                  toolsAllow,
                 };
               }
               const timeoutSeconds = parseStrictPositiveIntOrUndefined(opts.timeoutSeconds);
@@ -304,6 +309,7 @@ export function registerCronAddCommand(cron: Command) {
                       : undefined,
                   outputMaxBytes:
                     outputMaxBytes && Number.isFinite(outputMaxBytes) ? outputMaxBytes : undefined,
+                  ...(toolsAllow ? { toolsAllow } : {}),
                 };
               }
               return {
@@ -315,7 +321,7 @@ export function registerCronAddCommand(cron: Command) {
                 timeoutSeconds:
                   timeoutSeconds && Number.isFinite(timeoutSeconds) ? timeoutSeconds : undefined,
                 lightContext: opts.lightContext === true ? true : undefined,
-                toolsAllow: parseCronToolsAllow(opts.tools),
+                toolsAllow,
               };
             })();
             const resolvedPayload = await (async () => {

--- a/src/cron/delivery-plan.ts
+++ b/src/cron/delivery-plan.ts
@@ -180,9 +180,19 @@ export function resolveFailureDestination(
     const hasJobModeField = "mode" in jobFailureDest;
 
     const jobToExplicitValue = hasJobToField && jobTo !== undefined;
+    const globalChannel = resolveAnnounceChannel({ channel, to });
 
     if (hasJobChannelField) {
       channel = jobChannel;
+      if (jobChannel && jobChannel !== globalChannel) {
+        // Targets and accounts belong to the channel that supplied them.
+        if (!hasJobToField) {
+          to = undefined;
+        }
+        if (!hasJobAccountIdField) {
+          accountId = undefined;
+        }
+      }
     }
     if (hasJobToField) {
       to = jobTo;
@@ -197,9 +207,14 @@ export function resolveFailureDestination(
       const effectiveJobMode = jobImpliesAnnounce ? "announce" : jobMode;
       const globalMode = mode ?? "announce";
       const resolvedJobMode = effectiveJobMode ?? "announce";
-      if (!jobToExplicitValue && globalMode !== resolvedJobMode) {
-        // Do not carry an inherited target across modes; an announce chat is not a webhook URL.
-        to = undefined;
+      if (globalMode !== resolvedJobMode) {
+        // Chat targets and accounts cannot be reused as webhook routing, or vice versa.
+        if (!jobToExplicitValue) {
+          to = undefined;
+        }
+        if (!hasJobAccountIdField) {
+          accountId = undefined;
+        }
       }
       mode = effectiveJobMode;
     }

--- a/src/cron/delivery.test.ts
+++ b/src/cron/delivery.test.ts
@@ -234,8 +234,108 @@ describe("resolveFailureDestination", () => {
     expect(plan).toEqual({
       mode: "announce",
       channel: "signal",
-      to: "222",
-      accountId: "global-account",
+      to: undefined,
+      accountId: undefined,
+    });
+  });
+
+  it("preserves global targets and accounts for same-channel failure overrides", () => {
+    const plan = resolveFailureDestination(
+      makeCronJob({
+        delivery: {
+          mode: "none",
+          failureDestination: { channel: "slack", mode: "announce" },
+        },
+      }),
+      {
+        channel: "slack",
+        to: "slack:cron-alerts",
+        accountId: "slack-bot",
+        mode: "announce",
+      },
+    );
+
+    expect(plan).toEqual({
+      mode: "announce",
+      channel: "slack",
+      to: "slack:cron-alerts",
+      accountId: "slack-bot",
+    });
+  });
+
+  it("does not reuse a global recipient or account across failure channels", () => {
+    const plan = resolveFailureDestination(
+      makeCronJob({
+        delivery: {
+          mode: "none",
+          failureDestination: { channel: "telegram" },
+        },
+      }),
+      {
+        channel: "slack",
+        to: "slack:cron-alerts",
+        accountId: "slack-bot",
+        mode: "announce",
+      },
+    );
+
+    expect(plan).toEqual({
+      mode: "announce",
+      channel: "telegram",
+      to: undefined,
+      accountId: undefined,
+    });
+  });
+
+  it("does not reuse a channel-specific recipient or account for the last failure channel", () => {
+    const plan = resolveFailureDestination(
+      makeCronJob({
+        delivery: {
+          mode: "none",
+          failureDestination: { channel: "last" },
+        },
+      }),
+      {
+        channel: "slack",
+        to: "slack:cron-alerts",
+        accountId: "slack-bot",
+        mode: "announce",
+      },
+    );
+
+    expect(plan).toEqual({
+      mode: "announce",
+      channel: "last",
+      to: undefined,
+      accountId: undefined,
+    });
+  });
+
+  it("preserves an explicitly overridden recipient and account on a different failure channel", () => {
+    const plan = resolveFailureDestination(
+      makeCronJob({
+        delivery: {
+          mode: "none",
+          failureDestination: {
+            channel: "telegram",
+            to: "telegram:123",
+            accountId: "telegram-bot",
+          },
+        },
+      }),
+      {
+        channel: "slack",
+        to: "slack:cron-alerts",
+        accountId: "slack-bot",
+        mode: "announce",
+      },
+    );
+
+    expect(plan).toEqual({
+      mode: "announce",
+      channel: "telegram",
+      to: "telegram:123",
+      accountId: "telegram-bot",
     });
   });
 

--- a/src/cron/service.failure-alert.test.ts
+++ b/src/cron/service.failure-alert.test.ts
@@ -381,12 +381,34 @@ describe("CronService failure alerts", () => {
         mode: "announce" as const,
         channel: "slack",
         to: "slack:cron-alerts",
+        accountId: "slack-bot",
       },
       jobAlert: undefined,
       expected: {
         mode: "announce",
         channel: "slack",
         to: "slack:cron-alerts",
+        accountId: "slack-bot",
+      },
+    },
+    {
+      name: "preserves a global route when a job explicitly repeats its alert mode",
+      globalAlert: {
+        enabled: true,
+        after: 1,
+        mode: "announce" as const,
+        channel: "slack",
+        to: "slack:cron-alerts",
+        accountId: "slack-bot",
+      },
+      jobAlert: {
+        mode: "announce" as const,
+      },
+      expected: {
+        mode: "announce",
+        channel: "slack",
+        to: "slack:cron-alerts",
+        accountId: "slack-bot",
       },
     },
     {
@@ -431,6 +453,7 @@ describe("CronService failure alerts", () => {
         mode: "announce" as const,
         channel: "slack",
         to: "slack:cron-alerts",
+        accountId: "slack-bot",
       },
       jobAlert: {
         mode: "announce" as const,
@@ -440,6 +463,28 @@ describe("CronService failure alerts", () => {
         mode: "announce",
         channel: "telegram",
         to: "telegram:19098680",
+        accountId: undefined,
+      },
+    },
+    {
+      name: "never reuses a global chat target or account for the last failure channel",
+      globalAlert: {
+        enabled: true,
+        after: 1,
+        mode: "announce" as const,
+        channel: "slack",
+        to: "slack:cron-alerts",
+        accountId: "slack-bot",
+      },
+      jobAlert: {
+        mode: "announce" as const,
+        channel: "last",
+      },
+      expected: {
+        mode: "announce",
+        channel: "last",
+        to: undefined,
+        accountId: undefined,
       },
     },
     {

--- a/src/cron/service/failure-alerts.ts
+++ b/src/cron/service/failure-alerts.ts
@@ -97,10 +97,9 @@ export function resolveFailureAlert(
     : undefined;
   // Webhook destinations have no chat-channel identity. Announce destinations
   // must stay on their original channel when a job overrides its route.
-  const globalTo =
-    mode === "webhook" || !jobChannel || jobChannel === globalChannel
-      ? configuredGlobalTo
-      : undefined;
+  const inheritsGlobalRoute =
+    inheritsGlobalMode && (mode === "webhook" || !jobChannel || jobChannel === globalChannel);
+  const globalTo = inheritsGlobalRoute ? configuredGlobalTo : undefined;
   const deliveryTo = normalizeTo(job.delivery?.to);
   const deliveryChannel = resolveFailureAlertChannel(job.delivery?.channel, deliveryTo);
   const channel = jobChannel ?? globalChannel ?? deliveryChannel ?? "last";
@@ -121,7 +120,7 @@ export function resolveFailureAlert(
     channel,
     to: mode === "webhook" ? explicitTo : (explicitTo ?? compatibleDeliveryTo),
     mode,
-    accountId: jobConfig?.accountId ?? globalConfig?.accountId,
+    accountId: jobConfig?.accountId ?? (inheritsGlobalRoute ? globalConfig?.accountId : undefined),
     includeSkipped: jobConfig?.includeSkipped ?? globalConfig?.includeSkipped ?? false,
   };
 }

--- a/src/cron/service/timer-execution.ts
+++ b/src/cron/service/timer-execution.ts
@@ -109,6 +109,11 @@ export async function executeJobCore(
       streamBatch: options?.streamBatch,
       abortSignal,
     });
+    // Trigger scripts may settle after cancellation; never start payload work
+    // or persist trigger results for a run that has already been aborted.
+    if (abortSignal?.aborted) {
+      return resolveAbortError();
+    }
     if (evaluation.kind === "busy") {
       state.deps.log.debug({ jobId: job.id }, "cron: trigger evaluation skipped while busy");
       return {

--- a/src/cron/service/timer.test.ts
+++ b/src/cron/service/timer.test.ts
@@ -13,6 +13,7 @@ import * as taskExecutor from "../../tasks/task-executor.js";
 import { findTaskByRunId, listTaskRecordsUnsorted } from "../../tasks/task-registry.js";
 import { resetTaskRegistryForTests } from "../../tasks/task-runtime.test-helpers.js";
 import { formatTaskStatusDetail } from "../../tasks/task-status.js";
+import { createDeferred } from "../../test-utils/deferred.js";
 import { normalizeSessionDeliveryState } from "../../utils/delivery-context.shared.js";
 
 const { logger, makeStorePath } = setupCronServiceSuite({
@@ -361,6 +362,66 @@ describe("cron service timer seam coverage", () => {
       finalizeSpy.mockRestore();
     }
   });
+
+  it.each(["command", "script", "systemEvent", "heartbeat"] as const)(
+    "does not run a %s payload when trigger evaluation resolves after cancellation",
+    async (kind) => {
+      const { storePath } = await makeStorePath();
+      const now = Date.parse("2026-07-27T12:00:00.000Z");
+      const evaluation = createDeferred<{
+        kind: "evaluated";
+        fire: true;
+        state: { revision: number };
+      }>();
+      const evaluateCronTrigger = vi.fn(() => evaluation.promise);
+      const enqueueSystemEvent = vi.fn();
+      const requestHeartbeat = vi.fn();
+      const runCommandJob = vi.fn(async () => ({ status: "ok" as const }));
+      const runScriptJob = vi.fn(async () => ({ status: "ok" as const }));
+      const runIsolatedAgentJob = vi.fn(async () => ({ status: "ok" as const }));
+      const state = createCronServiceState({
+        storePath,
+        cronEnabled: true,
+        cronConfig: { triggers: { enabled: true } },
+        log: logger,
+        nowMs: () => now,
+        enqueueSystemEvent,
+        requestHeartbeat,
+        evaluateCronTrigger,
+        runCommandJob,
+        runScriptJob,
+        runIsolatedAgentJob,
+      });
+      const baseJob =
+        kind === "command"
+          ? createDueCommandJob({ now })
+          : kind === "script"
+            ? createDueScriptJob({ now })
+            : kind === "heartbeat"
+              ? {
+                  ...createDueMainJob({ now, wakeMode: "next-heartbeat" }),
+                  payload: { kind: "heartbeat" as const },
+                }
+              : createDueMainJob({ now, wakeMode: "next-heartbeat" });
+      const job: CronJob = {
+        ...baseJob,
+        trigger: { script: "json({ fire: true })" },
+      };
+      const controller = new AbortController();
+
+      const result = executeJobCore(state, job, controller.signal);
+      expect(evaluateCronTrigger).toHaveBeenCalledOnce();
+      controller.abort(new Error("operator cancelled the scheduled run"));
+      evaluation.resolve({ kind: "evaluated", fire: true, state: { revision: 2 } });
+
+      await expect(result).resolves.toMatchObject({ status: "error" });
+      expect(enqueueSystemEvent).not.toHaveBeenCalled();
+      expect(requestHeartbeat).not.toHaveBeenCalled();
+      expect(runCommandJob).not.toHaveBeenCalled();
+      expect(runScriptJob).not.toHaveBeenCalled();
+      expect(runIsolatedAgentJob).not.toHaveBeenCalled();
+    },
+  );
 
   it("runs command cron jobs without isolated agent setup", async () => {
     const { storePath } = await makeStorePath();

--- a/test/vitest/vitest.extension-codex-app-server-attempt-extra.config.ts
+++ b/test/vitest/vitest.extension-codex-app-server-attempt-extra.config.ts
@@ -6,6 +6,7 @@ function createExtensionCodexAppServerAttemptExtraVitestConfig(
 ) {
   return createScopedVitestConfig(
     [
+      "extensions/codex/src/app-server/run-attempt-client-prewarm.test.ts",
       "extensions/codex/src/app-server/run-attempt-lifecycle-controller.test.ts",
       "extensions/codex/src/app-server/run-attempt-thread-cleanup.test.ts",
       "extensions/codex/src/app-server/run-attempt.context-engine.test.ts",

--- a/ui/src/lib/workboard/index.test.ts
+++ b/ui/src/lib/workboard/index.test.ts
@@ -2908,6 +2908,49 @@ describe("workboard controller", () => {
     expect(client.request).not.toHaveBeenCalled();
   });
 
+  it("reuses an active captured session before an older archived match", async () => {
+    const archived = {
+      ...sampleCard,
+      id: "archived-session-card",
+      sessionKey: sampleSession.key,
+      metadata: { archivedAt: 10 },
+    } satisfies WorkboardCard;
+    const active = {
+      ...sampleCard,
+      id: "active-session-card",
+      sessionKey: sampleSession.key,
+    } satisfies WorkboardCard;
+    state.loaded = true;
+    state.cards = [archived, active];
+    const client = createClient({});
+
+    await expect(captureSession(client, sampleSession)).resolves.toBe(active);
+    expect(client.request).not.toHaveBeenCalled();
+    expect(state.cards).toEqual([archived, active]);
+  });
+
+  it("returns the active captured session while a duplicate capture is in flight", async () => {
+    const archived = {
+      ...sampleCard,
+      id: "archived-inflight-session-card",
+      sessionKey: sampleSession.key,
+      metadata: { archivedAt: 10 },
+    } satisfies WorkboardCard;
+    const active = {
+      ...sampleCard,
+      id: "active-inflight-session-card",
+      sessionKey: sampleSession.key,
+    } satisfies WorkboardCard;
+    state.loaded = true;
+    state.cards = [archived, active];
+    state.capturingSessionKeys.add(sampleSession.key);
+    const client = createClient({});
+
+    await expect(captureSession(client, sampleSession)).resolves.toBe(active);
+    expect(client.request).not.toHaveBeenCalled();
+    expect(state.cards).toEqual([archived, active]);
+  });
+
   it("restores archived captured sessions instead of leaving them hidden", async () => {
     const archived = {
       ...sampleCard,

--- a/ui/src/lib/workboard/session-capture.ts
+++ b/ui/src/lib/workboard/session-capture.ts
@@ -104,6 +104,20 @@ function sessionCaptureStatus(session: GatewaySessionRow): WorkboardStatus {
   return "todo";
 }
 
+function findCapturedSessionCard(cards: WorkboardCard[], sessionKey: string): WorkboardCard | null {
+  let archived: WorkboardCard | undefined;
+  for (const card of cards) {
+    if (workboardCardSessionKey(card) !== sessionKey) {
+      continue;
+    }
+    if (!card.metadata?.archivedAt) {
+      return card;
+    }
+    archived ??= card;
+  }
+  return archived ?? null;
+}
+
 async function loadSessionCaptureHistory(params: {
   client: GatewayBrowserClient;
   sessionKey: string;
@@ -146,7 +160,7 @@ export async function captureSessionToWorkboard(params: {
     return null;
   }
   if (state.capturingSessionKeys.has(params.session.key)) {
-    return state.cards.find((card) => workboardCardSessionKey(card) === params.session.key) ?? null;
+    return findCapturedSessionCard(state.cards, params.session.key);
   }
   state.error = null;
   let captureStarted = false;
@@ -164,16 +178,12 @@ export async function captureSessionToWorkboard(params: {
       return null;
     }
     if (state.capturingSessionKeys.has(params.session.key)) {
-      return (
-        state.cards.find((card) => workboardCardSessionKey(card) === params.session.key) ?? null
-      );
+      return findCapturedSessionCard(state.cards, params.session.key);
     }
     state.capturingSessionKeys.add(params.session.key);
     captureStarted = true;
     params.requestUpdate?.();
-    const existing = state.cards.find(
-      (card) => workboardCardSessionKey(card) === params.session.key,
-    );
+    const existing = findCapturedSessionCard(state.cards, params.session.key);
     if (existing) {
       if (existing.metadata?.archivedAt) {
         invalidateWorkboardLoads(params.host);


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where scheduled jobs could still execute after trigger cancellation, cron failure notifications could use a recipient or account from the wrong channel, command and system-event schedules could silently discard explicit tool restrictions, and Workboard dispatch, queue statistics, notifications, and session capture could be distorted by archived cards, expired claims, or invalid workspaces.

## Why This Change Was Made

Preserve cancellation, channel-account ownership, and explicit tool policy in the existing cron owners; preserve live worker ownership and valid dispatch capacity in the Workboard owner; exclude archived cards only from active projections and prefer an active captured session over its archived duplicate. No schema migration, new configuration, provider behavior, or SDK surface. Also register the main-branch Codex prewarm regression in its existing dedicated test shard: hosted CI exposed that recent main excludes this new test from the support shard without including it in the attempt shard.

## User Impact

Canceled cron jobs no longer perform late work; failure alerts route to the correct channel and account, including channel last; explicitly restricted cron tools remain restricted; valid Workboard jobs are not starved; archived cards no longer replay alerts or inflate queue age; capturing a session reuses the live card. Full-suite CI also includes the existing main-branch Codex prewarm test exactly once.

## Evidence

- Red-phase Linux reproductions: seven cron cancellation/routing failures, four Workboard dispatch/archive failures, three cron CLI policy failures, and two Workboard session-capture failures.
- Exact published bugfix head on Blacksmith: 701 focused cron, CLI, Workboard store/dispatcher/gateway/tool, and Workboard controller tests passed, including channel-last and explicit same-mode inheritance regressions.
- Three repeated scheduler, duplicate-timer, stream-trigger, and Workboard-dispatch stress passes completed successfully.
- Live QA gateway: all four cron scenarios passed, zero failures or skips, with evidence in `.artifacts/qa-e2e/cron-workboard-stress-followup-mock/qa-suite-summary.json`.
- Real Chromium: all ten Workboard, persistence, and session-dashboard end-to-end tests passed.
- Fresh independent autoreview: clean for both the complete bugfix and the one-line main-shard repair.
- The failing hosted compact shard identified `extensions/codex/src/app-server/run-attempt-client-prewarm.test.ts` as the only uncovered full-suite file; the follow-up assigns it to `test/vitest/vitest.extension-codex-app-server-attempt-extra.config.ts`, preserving one-owner shard coverage.
- ClawSweeper rank-up: verified same-channel inheritance, explicit different-channel recipient/account overrides, cross-channel clearing, `last` channel clearing, matching global/per-job mode inheritance, announce-to-webhook isolation, and webhook-to-announce isolation with direct regression tests. No serialized shape, SQLite schema, migration, or persisted card data changes.
- Historical Workboard proof preservation remains tracked separately in #113309 because its persisted-data repair requires owner review and is intentionally not bundled here.
- Exact final-head hosted CI and Linux changed-file checks are required before native landing.