### PR TITLE
feat(cli): add lightweight context flag to agent turns

### DIFF
--- a/docs/cli/agent.md
+++ b/docs/cli/agent.md
@@ -83,6 +83,7 @@ Plain output writes only the final assistant text to stdout. Diagnostics use std
 - `--session-id <id>`: explicit session id
 - `--agent <id>`: agent id; overrides routing bindings
 - `--model <id>`: model override for this run (`provider/model` or model id)
+- `--light-context`: omit workspace bootstrap files for this run; useful for bounded machine tasks that do not need workspace identity or human-facing instructions
 - `--thinking <level>`: agent thinking level (`off`, `minimal`, `low`, `medium`, `high`, plus provider-supported custom levels such as `xhigh`, `adaptive`, or `max`)
 - `--verbose <on|off>`: persist verbose level for the session
 - `--channel <channel>`: delivery channel; omit to use the main session channel
@@ -101,6 +102,7 @@ openclaw agent --to +15555550123 --message "status update" --deliver
 openclaw agent --agent ops --message "Summarize logs"
 openclaw agent --agent ops --message-file ./task.md
 openclaw agent --agent ops --model openai/gpt-5.4 --message "Summarize logs"
+openclaw agent --agent ops --model openai/gpt-5.4 --light-context --message "Run focused tests"
 openclaw agent --session-key agent:ops:incident-42 --message "Summarize status"
 openclaw agent --agent ops --session-key incident-42 --message "Summarize status"
 openclaw agent --session-id 1234 --message "Summarize inbox" --thinking medium
@@ -112,6 +114,7 @@ openclaw agent --agent ops --message "Run locally" --local
 ## Notes
 
 - Pass exactly one of `--message` or `--message-file`. `--message-file` strips a leading UTF-8 BOM and preserves multiline content; it rejects files that are not valid UTF-8. Files larger than 4 MiB are rejected before dispatch.
+- `--light-context` uses OpenClaw's lightweight bootstrap mode. For ordinary agent turns, this omits workspace bootstrap files such as `AGENTS.md`, `SOUL.md`, and `USER.md`; the explicit task message, system prompt, tools, and response contract remain available.
 - Slash commands (for example `/compact`) cannot run through `--message`. The CLI rejects them and points you at the first-class command instead (`openclaw sessions compact <key>` for compaction).
 - `--local` runs are one-shot: bundled MCP loopback resources and warm Claude stdio sessions opened for the run are retired after the reply, so scripted invocations do not leave local child processes running. Gateway-backed runs keep Gateway-owned MCP loopback resources under the running Gateway process instead.
 - Standalone embedded execution with `--local` refuses to reuse an existing main session while restart recovery is pending. Run the turn through a healthy Gateway, or reset it there with `/new` or `/reset`; an independent embedded process cannot safely coordinate that recovery owner with the Gateway scanner.

--- a/src/cli/program/register.agent-turn.ts
+++ b/src/cli/program/register.agent-turn.ts
@@ -51,6 +51,11 @@ export function registerAgentTurnCommand(
     .option("--agent <id>", "Agent id (overrides routing bindings)")
     .option("--model <id>", "Model override for this run (provider/model or model id)")
     .option(
+      "--light-context",
+      "Use lightweight bootstrap context without workspace bootstrap files",
+      false,
+    )
+    .option(
       "--thinking <level>",
       "Thinking level: off | minimal | low | medium | high | xhigh | adaptive | max where supported",
     )

--- a/src/cli/program/register.agent.test.ts
+++ b/src/cli/program/register.agent.test.ts
@@ -147,6 +147,15 @@ describe("agent command registration", () => {
     expect(deps).toBeUndefined();
   });
 
+  it("forwards lightweight bootstrap context for one-shot agent runs", async () => {
+    await runCli(["agent", "--message", "hi", "--agent", "ops", "--light-context"]);
+
+    const [options, callRuntime, deps] = commandCall(agentCliCommandMock);
+    expect((options as { lightContext?: boolean }).lightContext).toBe(true);
+    expect(callRuntime).toBe(runtime);
+    expect(deps).toBeUndefined();
+  });
+
   it("forwards an explicit session key to the agent command", async () => {
     await runCli(["agent", "--message", "hi", "--session-key", "agent:ops:incident-42"]);
 

--- a/src/commands/agent-via-gateway.test.ts
+++ b/src/commands/agent-via-gateway.test.ts
@@ -345,6 +345,18 @@ describe("agentCliCommand", () => {
     }, overrides);
   });
 
+  it("forwards lightweight bootstrap context to the Gateway", async () => {
+    await withTempStore(async () => {
+      mockGatewaySuccessReply();
+
+      await agentCliCommand({ message: "hi", to: "+1555", lightContext: true }, runtime);
+
+      const request = requireRecord(requireFirstCallArg(callGateway, "gateway"), "gateway request");
+      const params = requireRecord(request.params, "gateway request params");
+      expect(params.bootstrapContextMode).toBe("lightweight");
+    });
+  });
+
   it("reads a UTF-8 message file for gateway dispatch", async () => {
     await withTempStore(async ({ dir }) => {
       const messageFile = path.join(dir, "task.md");
@@ -1800,6 +1812,28 @@ describe("agentCliCommand", () => {
       expect(localOpts.cleanupCliLiveSessionOnRunEnd).toBe(true);
       expect(localOpts.oneShotCliRun).toBe(true);
       expect(runtime.log).toHaveBeenCalledWith("local");
+    });
+  });
+
+  it("forwards lightweight bootstrap context to local embedded runs", async () => {
+    await withTempStore(async () => {
+      mockLocalAgentReply();
+
+      await agentCliCommand(
+        {
+          message: "hi",
+          to: "+1555",
+          local: true,
+          lightContext: true,
+        },
+        runtime,
+      );
+
+      const localOpts = requireRecord(
+        requireFirstCallArg(agentCommand, "embedded agent"),
+        "embedded agent options",
+      );
+      expect(localOpts.bootstrapContextMode).toBe("lightweight");
     });
   });
 

--- a/src/commands/agent-via-gateway.ts
+++ b/src/commands/agent-via-gateway.ts
@@ -83,6 +83,7 @@ type AgentCliOpts = {
   lane?: string;
   runId?: string;
   extraSystemPrompt?: string;
+  lightContext?: boolean;
   local?: boolean;
 };
 type AgentDispatchOpts = Omit<AgentCliOpts, "messageFile"> & {
@@ -748,6 +749,7 @@ async function agentViaGatewayCommand(
             timeout: timeoutSeconds,
             lane: opts.lane,
             extraSystemPrompt: opts.extraSystemPrompt,
+            ...(opts.lightContext === true ? { bootstrapContextMode: "lightweight" as const } : {}),
             cleanupBundleMcpOnRunEnd: true,
             idempotencyKey,
           },
@@ -904,6 +906,9 @@ export async function agentCliCommand(
           cleanupBundleMcpOnRunEnd: true,
           cleanupCliLiveSessionOnRunEnd: true,
           oneShotCliRun: true,
+          ...(gatewayDispatchOpts.lightContext === true
+            ? { bootstrapContextMode: "lightweight" as const }
+            : {}),
           abortSignal: signalBridge.signal,
         },
         runtime,


### PR DESCRIPTION
## Summary

- add `--light-context` to the Gateway-backed `openclaw agent` command
- map the flag to the existing typed `bootstrapContextMode: lightweight` field
- preserve the same behavior for explicit `--local` runs
- document the flag and cover CLI registration plus both dispatch paths

## What Problem This Solves

OpenClaw already supports lightweight bootstrap context for cron jobs, heartbeats,
and subagent runs, but scripted one-shot `openclaw agent` calls cannot select it.
That forces bounded machine tasks to inject workspace bootstrap files they do not
need.

The new flag exposes the existing runtime mode without adding configuration,
changing defaults, or parsing prompt text. Callers must opt in explicitly; normal
and human-facing agent turns remain full-context.

## Evidence

### Real behavior proof after rebase

Ran commit `bd42ccf5aee627a5b01f4863de802aff9593de06` from a clean build with an isolated OpenClaw state directory and a marker workspace containing unique `AGENTS.md`, `SOUL.md`, and `USER.md` strings. The Gateway and embedded local runtimes were real; only the external OpenAI-compatible model endpoint was deterministic so the exact request payload could be inspected.

| Path | Exit/reply | Explicit task | System prompt | Tools | AGENTS marker | SOUL marker | USER marker |
|---|---|---:|---:|---:|---:|---:|---:|
| `agent --local --light-context` | `0` / present | present | 14,757 chars | 37 | absent | absent | absent |
| Gateway `agent --light-context` | `0` / present | present | 15,769 chars | 37 | absent | absent | absent |

Both requests reached `/v1/chat/completions`, completed with `stopReason=stop`, retained the explicit task/system prompt/tool surface, and omitted all three documented workspace bootstrap files. The isolated Gateway used loopback port `18889`; no production service or config was changed.

### Automated validation

- rebased onto upstream `main` at `3923a9c8b9`; `pnpm build` — passed
- `pnpm tsgo:core` — passed on the original identical patch
- `pnpm tsgo:core:test` — passed on the original identical patch
- focused `oxfmt --check` — passed
- focused `oxlint` — passed
- `src/cli/program/register.agent.test.ts` — 21/21 passed after rebase
- `src/agents/bootstrap-files.test.ts` — 37/38 passed; the remaining existing Windows-only symlink test could not create a symlink without elevated privileges
- `src/commands/agent-via-gateway.test.ts` — blocked before test execution by an existing Windows SQLite handle cleanup failure (`EPERM` deleting the temporary store); the real Gateway proof above exercised the changed path successfully
- TruffleHog 3.96.0 exact-commit scan on the original identical patch — 0 verified, 0 unknown
- repository autoreview on the original identical patch with `gpt-5.5` — clean, no accepted/actionable findings

The original full `pnpm check` preflight completed its relevant source guards but later failed in the npm package-lock audit because the workstation npm cache returned `ENOENT` for a cached `clawpdf` object.

## Rollback

Revert this commit. The flag is additive and defaults to false, so existing callers and prompt behavior are unchanged.