### PR TITLE
fix: keep model switching and config recovery reliable under load

### DIFF
--- a/src/agents/agent-model-discovery.test.ts
+++ b/src/agents/agent-model-discovery.test.ts
@@ -4,7 +4,7 @@ import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
-import { clearCurrentPluginMetadataSnapshot } from "../plugins/current-plugin-metadata-snapshot.js";
+import { clearCurrentPluginMetadataSnapshot } from "../plugins/current-plugin-metadata-state.js";
 import { discoverAuthStorage, discoverModels } from "./agent-model-discovery.js";
 
 // Discovery must not cold-load bundled plugin runtime: with build artifacts

--- a/src/agents/embedded-agent-runner/compact.hooks.harness.ts
+++ b/src/agents/embedded-agent-runner/compact.hooks.harness.ts
@@ -627,7 +627,6 @@ export async function loadCompactHooksHarness(): Promise<{
       compatiblePolicyHashes: undefined,
       compatibleConfigFingerprints: undefined,
     })),
-    clearCurrentPluginMetadataSnapshot: vi.fn(),
     getCurrentPluginMetadataSnapshot: () => emptyPluginMetadataSnapshot,
     resolvePluginMetadataControlPlaneFingerprint: vi.fn(() => "test-plugin-fingerprint"),
     restoreCurrentPluginMetadataSnapshotState: vi.fn(),

--- a/src/agents/model-fallback.test.ts
+++ b/src/agents/model-fallback.test.ts
@@ -12,10 +12,8 @@ import {
 } from "../infra/diagnostic-events.js";
 import { resetLogger, setLoggerOverride } from "../logging/logger.js";
 import { createWarnLogCapture } from "../logging/test-helpers/warn-log-capture.js";
-import {
-  clearCurrentPluginMetadataSnapshot,
-  setCurrentPluginMetadataSnapshot,
-} from "../plugins/current-plugin-metadata-snapshot.js";
+import { setCurrentPluginMetadataSnapshot } from "../plugins/current-plugin-metadata-snapshot.js";
+import { clearCurrentPluginMetadataSnapshot } from "../plugins/current-plugin-metadata-state.js";
 import { loadPluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot.js";
 import { AUTH_STORE_VERSION } from "./auth-profiles/constants.js";
 import type { AuthProfileStore } from "./auth-profiles/types.js";

--- a/src/agents/model-ref-shared.test.ts
+++ b/src/agents/model-ref-shared.test.ts
@@ -1,9 +1,7 @@
 // Documents provider/model id normalization from built-ins and plugin manifests.
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import {
-  clearCurrentPluginMetadataSnapshot,
-  setCurrentPluginMetadataSnapshot,
-} from "../plugins/current-plugin-metadata-snapshot.js";
+import { setCurrentPluginMetadataSnapshot } from "../plugins/current-plugin-metadata-snapshot.js";
+import { clearCurrentPluginMetadataSnapshot } from "../plugins/current-plugin-metadata-state.js";
 import {
   normalizeConfiguredProviderCatalogModelId,
   normalizeStaticProviderModelId,

--- a/src/agents/model-selection.plugin-runtime.test.ts
+++ b/src/agents/model-selection.plugin-runtime.test.ts
@@ -26,14 +26,9 @@ vi.mock("./provider-model-normalization.runtime.js", () => ({
     normalizeProviderModelIdWithPluginMock(params),
 }));
 
-vi.mock("../plugins/current-plugin-metadata-snapshot.js", async () => {
-  const { clearCurrentPluginMetadataSnapshot } =
-    await import("../plugins/current-plugin-metadata-state.js");
-  return {
-    clearCurrentPluginMetadataSnapshot,
-    getCurrentPluginMetadataSnapshot: getCurrentPluginMetadataSnapshotMock,
-  };
-});
+vi.mock("../plugins/current-plugin-metadata-snapshot.js", () => ({
+  getCurrentPluginMetadataSnapshot: getCurrentPluginMetadataSnapshotMock,
+}));
 
 vi.mock("./model-catalog.runtime.js", () => ({
   loadManifestModelCatalog: () => [],

--- a/src/agents/models-config.write-serialization.test.ts
+++ b/src/agents/models-config.write-serialization.test.ts
@@ -31,7 +31,7 @@ let actualPrivateFileStore:
 installModelsConfigTestHooks();
 
 let ensureOpenClawModelsJson: typeof import("./models-config.js").ensureOpenClawModelsJson;
-let clearCurrentPluginMetadataSnapshot: typeof import("../plugins/current-plugin-metadata-snapshot.js").clearCurrentPluginMetadataSnapshot;
+let clearCurrentPluginMetadataSnapshot: typeof import("../plugins/current-plugin-metadata-state.js").clearCurrentPluginMetadataSnapshot;
 let setCurrentPluginMetadataSnapshot: typeof import("../plugins/current-plugin-metadata-snapshot.js").setCurrentPluginMetadataSnapshot;
 
 function createPluginMetadataSnapshot(workspaceDir: string): PluginMetadataSnapshot {
@@ -134,7 +134,9 @@ beforeAll(async () => {
     };
   });
   ({ ensureOpenClawModelsJson } = await import("./models-config.js"));
-  ({ clearCurrentPluginMetadataSnapshot, setCurrentPluginMetadataSnapshot } =
+  ({ clearCurrentPluginMetadataSnapshot } =
+    await import("../plugins/current-plugin-metadata-state.js"));
+  ({ setCurrentPluginMetadataSnapshot } =
     await import("../plugins/current-plugin-metadata-snapshot.js"));
 });
 

--- a/src/agents/openclaw-tools.media-factory-plan.test.ts
+++ b/src/agents/openclaw-tools.media-factory-plan.test.ts
@@ -3,10 +3,10 @@ import path from "node:path";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import {
-  clearCurrentPluginMetadataSnapshot,
   getCurrentPluginMetadataSnapshot,
   setCurrentPluginMetadataSnapshot,
 } from "../plugins/current-plugin-metadata-snapshot.js";
+import { clearCurrentPluginMetadataSnapshot } from "../plugins/current-plugin-metadata-state.js";
 import { resolveInstalledPluginIndexPolicyHash } from "../plugins/installed-plugin-index-policy.js";
 import type { InstalledPluginIndexRecord } from "../plugins/installed-plugin-index.js";
 import type { PluginManifestRecord } from "../plugins/manifest-registry.js";

--- a/src/agents/provider-auth-aliases.test.ts
+++ b/src/agents/provider-auth-aliases.test.ts
@@ -45,10 +45,8 @@ vi.mock("../plugins/plugin-metadata-snapshot.js", () => ({
   loadPluginMetadataSnapshot: pluginRegistryMocks.loadPluginMetadataSnapshot,
 }));
 
-import {
-  clearCurrentPluginMetadataSnapshot,
-  setCurrentPluginMetadataSnapshot,
-} from "../plugins/current-plugin-metadata-snapshot.js";
+import { setCurrentPluginMetadataSnapshot } from "../plugins/current-plugin-metadata-snapshot.js";
+import { clearCurrentPluginMetadataSnapshot } from "../plugins/current-plugin-metadata-state.js";
 import { resolveInstalledPluginIndexPolicyHash } from "../plugins/installed-plugin-index-policy.js";
 import type { InstalledPluginIndexRecord } from "../plugins/installed-plugin-index.js";
 import type { PluginManifestRecord } from "../plugins/manifest-registry.js";

--- a/src/agents/subagent-announce.live.test.ts
+++ b/src/agents/subagent-announce.live.test.ts
@@ -12,7 +12,7 @@ import { startGatewayServer, type GatewayServer } from "../gateway/server.js";
 import { extractPayloadText } from "../gateway/test-helpers.agent-results.js";
 import { onAgentEvent, type AgentEventPayload } from "../infra/agent-events.js";
 import { isTruthyEnvValue } from "../infra/env.js";
-import { clearCurrentPluginMetadataSnapshot } from "../plugins/current-plugin-metadata-snapshot.js";
+import { clearCurrentPluginMetadataSnapshot } from "../plugins/current-plugin-metadata-state.js";
 import {
   createOpenClawTestState,
   type OpenClawTestState,

--- a/src/agents/tools/video-generate-tool.test.ts
+++ b/src/agents/tools/video-generate-tool.test.ts
@@ -6,10 +6,10 @@ import type { OpenClawConfig } from "../../config/config.js";
 import * as mediaStore from "../../media/store.js";
 import * as webMedia from "../../media/web-media.js";
 import {
-  clearCurrentPluginMetadataSnapshot,
   getCurrentPluginMetadataSnapshot,
   setCurrentPluginMetadataSnapshot,
 } from "../../plugins/current-plugin-metadata-snapshot.js";
+import { clearCurrentPluginMetadataSnapshot } from "../../plugins/current-plugin-metadata-state.js";
 import { resolveInstalledPluginIndexPolicyHash } from "../../plugins/installed-plugin-index-policy.js";
 import type { PluginManifestRecord } from "../../plugins/manifest-registry.js";
 import type { PluginMetadataSnapshot } from "../../plugins/plugin-metadata-snapshot.types.js";

--- a/src/auto-reply/reply/commands-models.test.ts
+++ b/src/auto-reply/reply/commands-models.test.ts
@@ -136,10 +136,7 @@ vi.mock("../../agents/provider-model-normalization.runtime.js", () => ({
     normalizeProviderModelIdWithRuntimeMock(params),
 }));
 
-vi.mock("../../plugins/current-plugin-metadata-snapshot.js", async () => ({
-  clearCurrentPluginMetadataSnapshot: (
-    await import("../../plugins/current-plugin-metadata-state.js")
-  ).clearCurrentPluginMetadataSnapshot,
+vi.mock("../../plugins/current-plugin-metadata-snapshot.js", () => ({
   getCurrentPluginMetadataSnapshot: () => pluginMetadataMocks.snapshot,
 }));
 

--- a/src/config/io.clobber-snapshot.test.ts
+++ b/src/config/io.clobber-snapshot.test.ts
@@ -104,17 +104,18 @@ describe("config clobber snapshots", () => {
       const warn = vi.fn();
       const observedAt = "2026-05-03T00:00:00.000Z";
 
-      await Promise.all(
-        Array.from({ length: CONFIG_CLOBBER_SNAPSHOT_LIMIT + 24 }, async (_, index) => {
-          await persistBoundedClobberedConfigSnapshot({
+      const snapshotPaths = await Promise.all(
+        Array.from({ length: CONFIG_CLOBBER_SNAPSHOT_LIMIT + 24 }, (_, index) =>
+          persistBoundedClobberedConfigSnapshot({
             deps: { fs, logger: { warn } },
             configPath,
             raw: `polluted-${index}\n`,
             observedAt,
-          });
-        }),
+          }),
+        ),
       );
 
+      expect(snapshotPaths).not.toContain(null);
       const clobberFiles = await listClobberFiles(configPath);
       expect(clobberFiles).toHaveLength(CONFIG_CLOBBER_SNAPSHOT_LIMIT);
       const capWarnings = warn.mock.calls.filter(

--- a/src/config/io.clobber-snapshot.ts
+++ b/src/config/io.clobber-snapshot.ts
@@ -1,6 +1,7 @@
 // Detects suspicious config clobbers and finds recovery snapshots.
 import path from "node:path";
 import { createDedupeCache } from "../infra/dedupe.js";
+import { KeyedAsyncQueue } from "../plugin-sdk/keyed-async-queue.js";
 import { sleep } from "../utils/sleep.js";
 
 /** Maximum retained clobbered-config snapshots per config file. */
@@ -9,6 +10,8 @@ const CONFIG_CLOBBER_SNAPSHOT_LIMIT = 32;
 const CONFIG_CLOBBER_LOCK_STALE_MS = 30_000;
 const CONFIG_CLOBBER_LOCK_RETRY_MS = 10;
 const CONFIG_CLOBBER_LOCK_TIMEOUT_MS = 2_000;
+// Queue local writes first so filesystem-lock timeouts cover other processes, not sibling tasks.
+const clobberSnapshotQueue = new KeyedAsyncQueue();
 const clobberCapWarnedPaths = createDedupeCache({
   ttlMs: 0,
   maxSize: 4096,
@@ -268,38 +271,40 @@ export async function persistBoundedClobberedConfigSnapshot(params: {
   observedAt: string;
 }): Promise<string | null> {
   const paths = resolveClobberPaths(params.configPath);
-  const locked = await acquireClobberLock(params.deps, paths.lockPath);
-  if (!locked) {
-    return null;
-  }
-  try {
-    const existing = await listClobberedSiblings(params.deps, paths.dir, paths.prefix);
-    if (existing.length >= CONFIG_CLOBBER_SNAPSHOT_LIMIT) {
-      warnClobberCapReached(params.deps, params.configPath, existing.length);
-      const rotated = await rotateOldestClobberedSiblings(params.deps, existing);
-      if (!rotated) {
-        return null;
-      }
+  return await clobberSnapshotQueue.enqueue(paths.lockPath, async () => {
+    const locked = await acquireClobberLock(params.deps, paths.lockPath);
+    if (!locked) {
+      return null;
     }
-    for (let attempt = 0; attempt < CONFIG_CLOBBER_SNAPSHOT_LIMIT; attempt++) {
-      const targetPath = buildClobberedTargetPath(params.configPath, params.observedAt, attempt);
-      try {
-        await params.deps.fs.promises.writeFile(targetPath, params.raw, {
-          encoding: "utf-8",
-          mode: 0o600,
-          flag: "wx",
-        });
-        return targetPath;
-      } catch (error) {
-        if (!isFsErrorCode(error, "EEXIST")) {
+    try {
+      const existing = await listClobberedSiblings(params.deps, paths.dir, paths.prefix);
+      if (existing.length >= CONFIG_CLOBBER_SNAPSHOT_LIMIT) {
+        warnClobberCapReached(params.deps, params.configPath, existing.length);
+        const rotated = await rotateOldestClobberedSiblings(params.deps, existing);
+        if (!rotated) {
           return null;
         }
       }
+      for (let attempt = 0; attempt < CONFIG_CLOBBER_SNAPSHOT_LIMIT; attempt++) {
+        const targetPath = buildClobberedTargetPath(params.configPath, params.observedAt, attempt);
+        try {
+          await params.deps.fs.promises.writeFile(targetPath, params.raw, {
+            encoding: "utf-8",
+            mode: 0o600,
+            flag: "wx",
+          });
+          return targetPath;
+        } catch (error) {
+          if (!isFsErrorCode(error, "EEXIST")) {
+            return null;
+          }
+        }
+      }
+      return null;
+    } finally {
+      await params.deps.fs.promises.rmdir(paths.lockPath).catch(() => {});
     }
-    return null;
-  } finally {
-    await params.deps.fs.promises.rmdir(paths.lockPath).catch(() => {});
-  }
+  });
 }
 
 export function persistBoundedClobberedConfigSnapshotSync(params: {

--- a/src/config/plugin-auto-enable.test-helpers.ts
+++ b/src/config/plugin-auto-enable.test-helpers.ts
@@ -1,6 +1,5 @@
 // Provides fixtures for plugin auto-enable config tests.
 import path from "node:path";
-import { clearCurrentPluginMetadataSnapshot } from "../plugins/current-plugin-metadata-snapshot.js";
 import { resolveInstalledPluginIndexPolicyHash } from "../plugins/installed-plugin-index-policy.js";
 import type { PluginManifestRegistry } from "../plugins/manifest-registry.js";
 import { clearPluginMetadataLifecycleCaches } from "../plugins/plugin-metadata-lifecycle.js";
@@ -13,7 +12,6 @@ const tempDirs: string[] = [];
 
 /** Clears auto-enable plugin caches and temp dirs between tests. */
 export function resetPluginAutoEnableTestState(): void {
-  clearCurrentPluginMetadataSnapshot();
   clearPluginMetadataLifecycleCaches();
   cleanupTrackedTempDirs(tempDirs);
 }

--- a/src/infra/dotenv-workspace-blocklist.test.ts
+++ b/src/infra/dotenv-workspace-blocklist.test.ts
@@ -3,10 +3,8 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { describe, expect, it, vi } from "vitest";
-import {
-  clearCurrentPluginMetadataSnapshot,
-  setCurrentPluginMetadataSnapshot,
-} from "../plugins/current-plugin-metadata-snapshot.js";
+import { setCurrentPluginMetadataSnapshot } from "../plugins/current-plugin-metadata-snapshot.js";
+import { clearCurrentPluginMetadataSnapshot } from "../plugins/current-plugin-metadata-state.js";
 import { resolveInstalledPluginIndexPolicyHash } from "../plugins/installed-plugin-index-policy.js";
 import type { PluginManifestRecord } from "../plugins/manifest-registry.js";
 import type { PluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot.types.js";

--- a/src/plugin-sdk/facade-runtime.test.ts
+++ b/src/plugin-sdk/facade-runtime.test.ts
@@ -5,10 +5,8 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { clearRuntimeConfigSnapshot, setRuntimeConfigSnapshot } from "../config/config.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { createPluginActivationSource, normalizePluginsConfig } from "../plugins/config-state.js";
-import {
-  clearCurrentPluginMetadataSnapshot,
-  setCurrentPluginMetadataSnapshot,
-} from "../plugins/current-plugin-metadata-snapshot.js";
+import { setCurrentPluginMetadataSnapshot } from "../plugins/current-plugin-metadata-snapshot.js";
+import { clearCurrentPluginMetadataSnapshot } from "../plugins/current-plugin-metadata-state.js";
 import { resolveInstalledPluginIndexPolicyHash } from "../plugins/installed-plugin-index-policy.js";
 import { clearPluginMetadataLifecycleCaches } from "../plugins/plugin-metadata-lifecycle.js";
 import type { PluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot.types.js";

--- a/src/plugins/activation-context.test.ts
+++ b/src/plugins/activation-context.test.ts
@@ -5,10 +5,8 @@ import {
   makeRegistry,
 } from "../config/plugin-auto-enable.test-helpers.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
-import {
-  clearCurrentPluginMetadataSnapshot,
-  setCurrentPluginMetadataSnapshot,
-} from "./current-plugin-metadata-snapshot.js";
+import { setCurrentPluginMetadataSnapshot } from "./current-plugin-metadata-snapshot.js";
+import { clearCurrentPluginMetadataSnapshot } from "./current-plugin-metadata-state.js";
 
 const applyPluginAutoEnableMock = vi.hoisted(() =>
   vi.fn((params: { config?: OpenClawConfig }) => ({

--- a/src/plugins/capability-provider-runtime.test.ts
+++ b/src/plugins/capability-provider-runtime.test.ts
@@ -126,7 +126,7 @@ vi.mock("./bundled-compat.js", () => ({
 let resolvePluginCapabilityProviders: typeof import("./capability-provider-runtime.js").resolvePluginCapabilityProviders;
 let resolvePluginCapabilityProvider: typeof import("./capability-provider-runtime.js").resolvePluginCapabilityProvider;
 let prepareMediaCapabilityProviders: typeof import("./capability-provider-runtime.js").prepareMediaCapabilityProviders;
-let clearCurrentPluginMetadataSnapshot: typeof import("./current-plugin-metadata-snapshot.js").clearCurrentPluginMetadataSnapshot;
+let clearCurrentPluginMetadataSnapshot: typeof import("./current-plugin-metadata-state.js").clearCurrentPluginMetadataSnapshot;
 let setCurrentPluginMetadataSnapshot: typeof import("./current-plugin-metadata-snapshot.js").setCurrentPluginMetadataSnapshot;
 let clearPluginMetadataLifecycleCaches: typeof import("./plugin-metadata-lifecycle.js").clearPluginMetadataLifecycleCaches;
 
@@ -288,8 +288,8 @@ describe("resolvePluginCapabilityProviders", () => {
       resolvePluginCapabilityProvider,
       resolvePluginCapabilityProviders,
     } = await import("./capability-provider-runtime.js"));
-    ({ clearCurrentPluginMetadataSnapshot, setCurrentPluginMetadataSnapshot } =
-      await import("./current-plugin-metadata-snapshot.js"));
+    ({ clearCurrentPluginMetadataSnapshot } = await import("./current-plugin-metadata-state.js"));
+    ({ setCurrentPluginMetadataSnapshot } = await import("./current-plugin-metadata-snapshot.js"));
     ({ clearPluginMetadataLifecycleCaches } = await import("./plugin-metadata-lifecycle.js"));
   });
 

--- a/src/plugins/current-plugin-metadata-snapshot.test.ts
+++ b/src/plugins/current-plugin-metadata-snapshot.test.ts
@@ -5,11 +5,11 @@ import path from "node:path";
 import { describe, expect, it } from "vitest";
 import {
   captureCurrentPluginMetadataSnapshotState,
-  clearCurrentPluginMetadataSnapshot,
   getCurrentPluginMetadataSnapshot,
   restoreCurrentPluginMetadataSnapshotState,
   setCurrentPluginMetadataSnapshot,
 } from "./current-plugin-metadata-snapshot.js";
+import { clearCurrentPluginMetadataSnapshot } from "./current-plugin-metadata-state.js";
 import { resolveInstalledPluginIndexPolicyHash } from "./installed-plugin-index-policy.js";
 import { writePersistedInstalledPluginIndexSync } from "./installed-plugin-index-store.js";
 import { clearPluginMetadataLifecycleCaches } from "./plugin-metadata-lifecycle.js";

--- a/src/plugins/current-plugin-metadata-snapshot.ts
+++ b/src/plugins/current-plugin-metadata-snapshot.ts
@@ -18,7 +18,6 @@ import type {
 import { normalizePluginIdScope, serializePluginIdScope } from "./plugin-scope.js";
 
 type CurrentPluginMetadataSnapshotState = ReturnType<typeof getCurrentPluginMetadataSnapshotState>;
-export { clearCurrentPluginMetadataSnapshot } from "./current-plugin-metadata-state.js";
 
 function resolvePluginMetadataControlPlaneFingerprint(
   config?: OpenClawConfig,

--- a/src/plugins/manifest-model-id-normalization.test.ts
+++ b/src/plugins/manifest-model-id-normalization.test.ts
@@ -4,7 +4,6 @@ import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { captureEnv, deleteTestEnvValue, setTestEnvValue } from "../test-utils/env.js";
-import { clearCurrentPluginMetadataSnapshot } from "./current-plugin-metadata-snapshot.js";
 import { writePersistedInstalledPluginIndexSync } from "./installed-plugin-index-store.js";
 import { listOpenClawPluginManifestMetadata } from "./manifest-metadata-scan.js";
 import { normalizeProviderModelIdWithManifest } from "./manifest-model-id-normalization.js";
@@ -101,7 +100,6 @@ describe("manifest model id normalization", () => {
   });
 
   afterEach(() => {
-    clearCurrentPluginMetadataSnapshot();
     resetPluginRuntimeStateForTest();
     clearPluginMetadataLifecycleCaches();
     restoreEnv();

--- a/src/plugins/plugin-metadata-snapshot.test.ts
+++ b/src/plugins/plugin-metadata-snapshot.test.ts
@@ -1,9 +1,7 @@
 // Verifies lifecycle snapshot loading, ownership facts, and immutable boundaries.
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import {
-  clearCurrentPluginMetadataSnapshot,
-  setCurrentPluginMetadataSnapshot,
-} from "./current-plugin-metadata-snapshot.js";
+import { setCurrentPluginMetadataSnapshot } from "./current-plugin-metadata-snapshot.js";
+import { clearCurrentPluginMetadataSnapshot } from "./current-plugin-metadata-state.js";
 import type { PluginDiscoveryResult } from "./discovery.js";
 import { resolveInstalledPluginIndexPolicyHash } from "./installed-plugin-index-policy.js";
 import type { InstalledPluginIndex } from "./installed-plugin-index.js";

--- a/src/plugins/plugin-registry-contributions.current-snapshot.test.ts
+++ b/src/plugins/plugin-registry-contributions.current-snapshot.test.ts
@@ -1,10 +1,8 @@
 // Verifies current plugin registry contribution snapshots.
 import { afterEach, describe, expect, it } from "vitest";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
-import {
-  clearCurrentPluginMetadataSnapshot,
-  setCurrentPluginMetadataSnapshot,
-} from "./current-plugin-metadata-snapshot.js";
+import { setCurrentPluginMetadataSnapshot } from "./current-plugin-metadata-snapshot.js";
+import { clearCurrentPluginMetadataSnapshot } from "./current-plugin-metadata-state.js";
 import { resolveInstalledPluginIndexPolicyHash } from "./installed-plugin-index-policy.js";
 import type { InstalledPluginIndex } from "./installed-plugin-index.js";
 import type { PluginManifestRecord } from "./manifest-registry.js";

--- a/src/plugins/plugin-registry-snapshot.lifecycle.test.ts
+++ b/src/plugins/plugin-registry-snapshot.lifecycle.test.ts
@@ -1,0 +1,24 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  getCurrentPluginMetadataSnapshotState,
+  setCurrentPluginMetadataSnapshotState,
+} from "./current-plugin-metadata-state.js";
+import { clearPluginMetadataLifecycleCaches } from "./plugin-metadata-lifecycle.js";
+import "./plugin-registry-snapshot.js";
+
+vi.mock("./current-plugin-metadata-snapshot.js", () => ({
+  getCurrentPluginMetadataSnapshot: vi.fn(() => undefined),
+}));
+
+afterEach(() => {
+  clearPluginMetadataLifecycleCaches();
+});
+
+describe("plugin registry snapshot lifecycle", () => {
+  it("clears registry metadata when the snapshot facade is mocked", () => {
+    setCurrentPluginMetadataSnapshotState({ plugins: [] }, "mocked-snapshot-facade");
+
+    expect(() => clearPluginMetadataLifecycleCaches()).not.toThrow();
+    expect(getCurrentPluginMetadataSnapshotState().snapshot).toBeUndefined();
+  });
+});

--- a/src/plugins/plugin-registry-snapshot.test.ts
+++ b/src/plugins/plugin-registry-snapshot.test.ts
@@ -4,10 +4,8 @@ import fs from "node:fs";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
-import {
-  clearCurrentPluginMetadataSnapshot,
-  setCurrentPluginMetadataSnapshot,
-} from "./current-plugin-metadata-snapshot.js";
+import { setCurrentPluginMetadataSnapshot } from "./current-plugin-metadata-snapshot.js";
+import { clearCurrentPluginMetadataSnapshot } from "./current-plugin-metadata-state.js";
 import type { PluginCandidate } from "./discovery.js";
 import { loadInstalledPluginIndexInstallRecordsSync } from "./installed-plugin-index-records.js";
 import { writePersistedInstalledPluginIndexSync } from "./installed-plugin-index-store.js";

--- a/src/plugins/plugin-registry-snapshot.ts
+++ b/src/plugins/plugin-registry-snapshot.ts
@@ -9,10 +9,8 @@ import { resolveBundledPluginsDir } from "./bundled-dir.js";
 import { buildLegacyBundledRootPath } from "./bundled-load-path-aliases.js";
 import { listBundledSourceOverlayDirs } from "./bundled-source-overlays.js";
 import { normalizePluginsConfig } from "./config-state.js";
-import {
-  clearCurrentPluginMetadataSnapshot,
-  getCurrentPluginMetadataSnapshot,
-} from "./current-plugin-metadata-snapshot.js";
+import { getCurrentPluginMetadataSnapshot } from "./current-plugin-metadata-snapshot.js";
+import { clearCurrentPluginMetadataSnapshot } from "./current-plugin-metadata-state.js";
 import { discoverConfiguredPluginLoadPaths, type PluginDiscoveryResult } from "./discovery.js";
 import { fileSignatureMatches, hashJson } from "./installed-plugin-index-hash.js";
 import { hasOptionalMissingPluginManifestFile } from "./installed-plugin-index-manifest.js";

--- a/src/plugins/providers.runtime.consult-current-snapshot.test.ts
+++ b/src/plugins/providers.runtime.consult-current-snapshot.test.ts
@@ -1,10 +1,8 @@
 // Verifies provider runtime uses current plugin metadata snapshots.
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
-import {
-  clearCurrentPluginMetadataSnapshot,
-  setCurrentPluginMetadataSnapshot,
-} from "./current-plugin-metadata-snapshot.js";
+import { setCurrentPluginMetadataSnapshot } from "./current-plugin-metadata-snapshot.js";
+import { clearCurrentPluginMetadataSnapshot } from "./current-plugin-metadata-state.js";
 import { resolveInstalledPluginIndexPolicyHash } from "./installed-plugin-index-policy.js";
 import type { InstalledPluginIndex } from "./installed-plugin-index.js";
 import type { PluginManifestRecord, PluginManifestRegistry } from "./manifest-registry.js";

--- a/src/plugins/setup-registry.runtime.test.ts
+++ b/src/plugins/setup-registry.runtime.test.ts
@@ -1,9 +1,7 @@
 // Verifies metadata-backed setup registry descriptor lookup.
 import { afterEach, describe, expect, it, vi } from "vitest";
-import {
-  clearCurrentPluginMetadataSnapshot,
-  setCurrentPluginMetadataSnapshot,
-} from "./current-plugin-metadata-snapshot.js";
+import { setCurrentPluginMetadataSnapshot } from "./current-plugin-metadata-snapshot.js";
+import { clearCurrentPluginMetadataSnapshot } from "./current-plugin-metadata-state.js";
 import { resolveInstalledPluginIndexPolicyHash } from "./installed-plugin-index-policy.js";
 import type { InstalledPluginIndex } from "./installed-plugin-index.js";
 import type { PluginMetadataSnapshot } from "./plugin-metadata-snapshot.js";

--- a/src/plugins/tools.optional.test.ts
+++ b/src/plugins/tools.optional.test.ts
@@ -43,7 +43,7 @@ let getActivePluginRegistry: typeof import("./runtime.js").getActivePluginRegist
 let pinActivePluginChannelRegistry: typeof import("./runtime.js").pinActivePluginChannelRegistry;
 let resetPluginRuntimeStateForTest: typeof import("./runtime.js").resetPluginRuntimeStateForTest;
 let setActivePluginRegistry: typeof import("./runtime.js").setActivePluginRegistry;
-let clearCurrentPluginMetadataSnapshot: typeof import("./current-plugin-metadata-snapshot.js").clearCurrentPluginMetadataSnapshot;
+let clearCurrentPluginMetadataSnapshot: typeof import("./current-plugin-metadata-state.js").clearCurrentPluginMetadataSnapshot;
 let setCurrentPluginMetadataSnapshot: typeof import("./current-plugin-metadata-snapshot.js").setCurrentPluginMetadataSnapshot;
 let getPluginRuntimeGatewayRequestScope: typeof import("./runtime/gateway-request-scope.js").getPluginRuntimeGatewayRequestScope;
 let withPluginRuntimeGatewayRequestScope: typeof import("./runtime/gateway-request-scope.js").withPluginRuntimeGatewayRequestScope;
@@ -501,8 +501,8 @@ describe("resolvePluginTools optional tools", () => {
     } = await import("./runtime.js"));
     ({ getPluginRuntimeGatewayRequestScope, withPluginRuntimeGatewayRequestScope } =
       await import("./runtime/gateway-request-scope.js"));
-    ({ clearCurrentPluginMetadataSnapshot, setCurrentPluginMetadataSnapshot } =
-      await import("./current-plugin-metadata-snapshot.js"));
+    ({ clearCurrentPluginMetadataSnapshot } = await import("./current-plugin-metadata-state.js"));
+    ({ setCurrentPluginMetadataSnapshot } = await import("./current-plugin-metadata-snapshot.js"));
     ({ resetPluginToolDescriptorCacheForTest } = await import("./tools.test-fixtures.js"));
   });
 

--- a/src/skills/loading/workspace-load.test.ts
+++ b/src/skills/loading/workspace-load.test.ts
@@ -7,10 +7,8 @@ import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { resetLogger, setLoggerOverride } from "../../logging/logger.js";
 import { loggingState } from "../../logging/state.js";
-import {
-  clearCurrentPluginMetadataSnapshot,
-  setCurrentPluginMetadataSnapshot,
-} from "../../plugins/current-plugin-metadata-snapshot.js";
+import { setCurrentPluginMetadataSnapshot } from "../../plugins/current-plugin-metadata-snapshot.js";
+import { clearCurrentPluginMetadataSnapshot } from "../../plugins/current-plugin-metadata-state.js";
 import { resolveInstalledPluginIndexPolicyHash } from "../../plugins/installed-plugin-index-policy.js";
 import type {
   PluginManifestRecord,

--- a/test/vitest/vitest.extension-codex-app-server-attempt-extra.config.ts
+++ b/test/vitest/vitest.extension-codex-app-server-attempt-extra.config.ts
@@ -6,7 +6,6 @@ function createExtensionCodexAppServerAttemptExtraVitestConfig(
 ) {
   return createScopedVitestConfig(
     [
-      "extensions/codex/src/app-server/run-attempt-client-prewarm.test.ts",
       "extensions/codex/src/app-server/run-attempt-lifecycle-controller.test.ts",
       "extensions/codex/src/app-server/run-attempt-thread-cleanup.test.ts",
       "extensions/codex/src/app-server/run-attempt.context-engine.test.ts",


### PR DESCRIPTION
## What Problem This Solves

Fixes dynamic model discovery, provider fallback, and Gateway plugin lifecycle failures caused by clearing metadata through a separately mocked read facade. Fixes concurrent config recovery on Node 22 LTS silently dropping forensic snapshots when sibling writes exhaust the cross-process lock timeout.

## Why This Change Was Made

Give metadata cleanup one canonical state owner, retire its obsolete facade re-export, migrate internal callers, and delete redundant resets and stale mock fields. Serialize same-path recovery writes using the existing independently tested keyed queue before the existing cross-process file lock; unrelated paths remain parallel.

## User Impact

Model switching, provider fallback, plugin reload, live Gateway requests, and configuration recovery remain reliable under stress. All 56 simultaneous recovery operations succeed while the newest 32 forensic artifacts are retained. No SQLite schema bump, new JSON state, compatibility shim, additional lock implementation, setting, or environment variable. The final changes delete more lines than they add.

## Evidence

Inspectable redacted terminal output from the trusted Blacksmith Testbox, using the rebased PR source:

```text
EXACT_NODE_MATRIX node22=v22.23.1 node24=v24.18.0 node26=v26.5.0

EXACT_HEAD_LANE_PASS canonical-keyed-queue
Test Files  1 passed (1)
Tests       6 passed (6)

EXACT_HEAD_LANE_PASS plugin-metadata-lifecycle
Test Files  3 passed (3)
Tests      48 passed (48)

EXACT_HEAD_LANE_PASS node22-snapshot-race-1
...
EXACT_HEAD_LANE_PASS node22-snapshot-race-12

EXACT_HEAD_LANE_PASS node22-full-config
Test Files  211 passed (211)
Tests     2,900 passed (2,900)

EXACT_HEAD_LANE_PASS node24-full-config
Test Files  211 passed (211)
Tests     2,900 passed (2,900)

EXACT_HEAD_LANE_PASS node26-full-config
Test Files  211 passed (211)
Tests     2,900 passed (2,900)

EXACT_HEAD_LANE_PASS full-gateway-methods
Test Files  126 passed (126)
Tests     2,506 passed (2,506)

[qa-suite] scenario pass (1/3): model-switch-follow-up
[qa-suite] scenario pass (2/3): model-switch-tool-continuity
[qa-suite] scenario pass (3/3): subagent-handoff
[qa-suite] run complete: passed=3 failed=0 skipped=0 total=3

[live] [all-models] 1/1 openai/gpt-5.4: prompt
[live] [all-models] 1/1 openai/gpt-5.4: tool-read
[live] [all-models] 1/1 openai/gpt-5.4: tool-only regression
Test Files  1 passed (1)
Tests     137 passed (137)

FINAL_EXACT_HEAD_STRESS completed_lanes=21 failed_lanes=0
```

The CI-discovered obsolete facade export was removed, and the exact failing checks were rerun against the complete follow-up:

```text
CLEANUP_LANE_PASS production-deadcode-dependencies
[deadcode] Knip production unused-export scan passed with 0 entries.
[deadcode] Knip full-tree unused-export scan passed with 0 entries.
[deadcode] Knip script unused-export scan passed with 0 entries.
CLEANUP_LANE_PASS production-deadcode-exports

[deadcode] Knip production unused-file scan passed with 0 entries.
[deadcode] Knip full-tree unused-file scan passed with 0 entries.
CLEANUP_LANE_PASS unused-runtime-files

Test Files 10 passed (10)
Tests     216 passed (216)
CLEANUP_LANE_PASS all-migrated-model-plugin-callers

Test Files 211 passed (211)
Tests    2,900 passed (2,900)
CLEANUP_LANE_PASS full-current-runtime-config

[qa-suite] run complete: passed=3 failed=0 skipped=0 total=3
CLEANUP_LANE_PASS real-model-switch-workflows

CLEANUP_LANE_PASS complete-changed-quality-gate
FINAL_METADATA_CLEANUP passed=9 failed=0
```

The complete quality gate passed formatting, all 143 public SDK entrypoints, core and plugin production/test typechecks, full core/UI/plugin lint, plugin boundaries, unchanged native state schema, database-first guards, and runtime import cycles. The same 56-concurrent-write regression passed 28 total stress repetitions. Two fresh independent autoreviews found no accepted or actionable issues.

AI-assisted implementation and review.

### Fresh latest-main exact-CI-shard proof

Hosted CI exposed a pre-existing current-main routing bug: the Codex prewarm test was assigned to both the extra and light Vitest shards. This branch keeps its canonical light-shard owner and deletes the duplicate registration.

```text
Node: v24.18.0 (current LTS)
full-suite sharding regression: 220 passed
checks-node-compact-small-3: 91 passed files; 2,326 passed; 1 pre-existing skip
Codex app-server prewarm regression: 5 passed
pnpm check:changed: passed (core/plugin production + test typecheck, complete core/plugin lint, SDK boundaries, format, schema and database-first guards, zero import cycles)
pnpm deadcode:dependencies: passed
pnpm deadcode:exports: passed; zero unused exports
pnpm deadcode:unused-files: passed; zero unused files
FINAL_REBASED_CI_STRESS all_lanes=passed exact_hosted_shard=passed canonical_codex_prewarm=passed
```

Dependency contract inspected directly against upstream `openai/codex` revision `8495963`: `codex-rs/app-server-protocol/src/protocol/common.rs` and `codex-rs/app-server/src/message_processor.rs`. No runtime Codex behavior, compatibility aliases, JSON state, or SQLite schema version was changed.
