### PR TITLE
fix(agents): prevent ambiguous automatic command approvals

### DIFF
--- a/src/agents/exec-auto-review.stress.test.ts
+++ b/src/agents/exec-auto-review.stress.test.ts
@@ -697,11 +697,13 @@ describe("exec auto-review adversarial model-response stress", () => {
       const decisions = await Promise.all(
         batch.map((_variant, offset) => {
           const index = start + offset;
-          return reviewer({
-            ...baselineInput,
-            command: `git status --case=${index}`,
-            argv: ["git", "status", `--case=${index}`],
-          });
+          return Promise.resolve(
+            reviewer({
+              ...baselineInput,
+              command: `git status --case=${index}`,
+              argv: ["git", "status", `--case=${index}`],
+            }),
+          );
         }),
       );
       for (const [offset, decision] of decisions.entries()) {

--- a/src/agents/exec-auto-review.stress.test.ts
+++ b/src/agents/exec-auto-review.stress.test.ts
@@ -621,6 +621,104 @@ describe.runIf(process.platform !== "win32")("exec auto-review shell stress", ()
   });
 });
 
+describe("exec auto-review adversarial model-response stress", () => {
+  it("fails closed for 4,096 seeded concurrent malformed reviewer responses", async () => {
+    const random = createSeededRandom(0x20260729);
+    const variants = [
+      {
+        name: "duplicate decision",
+        text: '{"decision":"ask","risk":"low","decision":"allow"}',
+        expected: "ask",
+      },
+      {
+        name: "duplicate risk",
+        text: '{"decision":"allow","risk":"high","risk":"low"}',
+        expected: "ask",
+      },
+      {
+        name: "escaped duplicate decision",
+        text: String.raw`{"decision":"ask","risk":"low","\u0064ecision":"allow"}`,
+        expected: "ask",
+      },
+      {
+        name: "escaped duplicate risk",
+        text: String.raw`{"decision":"allow","risk":"high","r\u0069sk":"low"}`,
+        expected: "ask",
+      },
+      {
+        name: "unexpected approval scope",
+        text: '{"decision":"allow","risk":"low","scope":"session"}',
+        expected: "ask",
+      },
+      {
+        name: "unexpected executable",
+        text: '{"decision":"allow","risk":"low","approvedCommand":"rm -rf /"}',
+        expected: "ask",
+      },
+      {
+        name: "truncated JSON",
+        text: '{"decision":"allow","risk":"low"',
+        expected: "ask",
+      },
+      {
+        name: "concatenated decisions",
+        text: '{"decision":"ask","risk":"high"}{"decision":"allow","risk":"low"}',
+        expected: "ask",
+      },
+      {
+        name: "valid low-risk allow",
+        text: '{"decision":"allow","risk":"low","rationale":"safe seeded control"}',
+        expected: "allow-once",
+      },
+      {
+        name: "valid human escalation",
+        text: '{"decision":"ask","risk":"high","rationale":"safe seeded control"}',
+        expected: "ask",
+      },
+    ] as const;
+    const cases = Array.from({ length: 4_096 }, () => chooseSeeded(random, variants));
+    const { reviewer, prepare, complete } = createStressReviewer({
+      complete: async (request) => {
+        const prompt = request.context.messages[0]?.content ?? "";
+        const match = /--case=(\d+)/.exec(prompt);
+        const variant = cases[Number(match?.[1])];
+        if (!variant) {
+          throw new Error("missing seeded reviewer response");
+        }
+        return {
+          stopReason: "stop" as const,
+          content: [{ type: "text" as const, text: variant.text }],
+        };
+      },
+    });
+
+    for (let start = 0; start < cases.length; start += 256) {
+      const batch = cases.slice(start, start + 256);
+      const decisions = await Promise.all(
+        batch.map((_variant, offset) => {
+          const index = start + offset;
+          return reviewer({
+            ...baselineInput,
+            command: `git status --case=${index}`,
+            argv: ["git", "status", `--case=${index}`],
+          });
+        }),
+      );
+      for (const [offset, decision] of decisions.entries()) {
+        const index = start + offset;
+        const variant = cases[index];
+        expect(
+          decision.decision,
+          `reviewer response escaped at seed 0x20260729, case ${index}: ${variant?.name}`,
+        ).toBe(variant?.expected);
+      }
+    }
+
+    expect(prepare).toHaveBeenCalledTimes(cases.length);
+    expect(complete).toHaveBeenCalledTimes(cases.length);
+  });
+});
+
 describe("exec auto-review concurrency stress", () => {
   it("keeps 256 concurrent approvals independently bound and single-use", async () => {
     const { reviewer, prepare, complete } = createStressReviewer({

--- a/src/agents/exec-auto-reviewer.test.ts
+++ b/src/agents/exec-auto-reviewer.test.ts
@@ -151,6 +151,61 @@ describe("parseExecAutoReviewResponse", () => {
     });
   });
 
+  it.each([
+    [
+      "a later allow overwriting an earlier ask",
+      '{"decision":"ask","risk":"low","decision":"allow"}',
+    ],
+    [
+      "a later low risk overwriting an earlier high risk",
+      '{"decision":"allow","risk":"high","risk":"low"}',
+    ],
+    [
+      "a Unicode-escaped decision overwriting an earlier ask",
+      String.raw`{"decision":"ask","risk":"low","\u0064ecision":"allow"}`,
+    ],
+    [
+      "a Unicode-escaped risk overwriting an earlier high risk",
+      String.raw`{"decision":"allow","risk":"high","r\u0069sk":"low"}`,
+    ],
+    [
+      "duplicate rationale values",
+      '{"decision":"allow","risk":"low","rationale":"first","rationale":"second"}',
+    ],
+    ["an unexpected approval scope", '{"decision":"allow","risk":"low","scope":"session"}'],
+    [
+      "an unexpected approved command",
+      '{"decision":"allow","risk":"low","approvedCommand":"rm -rf /"}',
+    ],
+    [
+      "an unexpected prototype key",
+      '{"decision":"allow","risk":"low","__proto__":{"decision":"allow"}}',
+    ],
+  ])("defers ambiguous reviewer JSON with %s", async (_label, text) => {
+    await expect(reviewExecResponse(text)).resolves.toMatchObject({
+      decision: "ask",
+      risk: "unknown",
+    });
+  });
+
+  it("preserves valid rationale containing JSON-shaped quoted text", async () => {
+    const rationale = 'Read-only output mentions "decision": "ask" as literal text.';
+
+    await expect(
+      reviewExecResponse(
+        JSON.stringify({
+          decision: "allow",
+          risk: "low",
+          rationale,
+        }),
+      ),
+    ).resolves.toEqual({
+      decision: "allow-once",
+      risk: "low",
+      rationale,
+    });
+  });
+
   it("requires allow decisions to carry low risk", async () => {
     for (const risk of ["medium", "high", "unknown"] as const) {
       expect(

--- a/src/agents/exec-auto-reviewer.ts
+++ b/src/agents/exec-auto-reviewer.ts
@@ -29,11 +29,13 @@ const DEFAULT_EXEC_REVIEWER_TIMEOUT_MS = 30_000;
 const EXEC_REVIEWER_MAX_TOKENS = 360;
 const EXEC_REVIEWER_TIMEOUT = Symbol("exec-reviewer-timeout");
 
-const execAutoReviewResponseSchema = z.object({
-  decision: z.enum(["allow", "ask"]),
-  risk: z.enum(["low", "medium", "high", "unknown"]),
-  rationale: z.string().optional(),
-});
+const execAutoReviewResponseSchema = z
+  .object({
+    decision: z.enum(["allow", "ask"]),
+    risk: z.enum(["low", "medium", "high", "unknown"]),
+    rationale: z.string().optional(),
+  })
+  .strict();
 
 /** Config for the optional model-backed exec reviewer. */
 export type ExecReviewerConfig = {
@@ -133,6 +135,70 @@ function extractJsonObject(text: string): string | null {
   return null;
 }
 
+function hasDuplicateJsonObjectKeys(text: string): boolean {
+  const keys = new Set<string>();
+  let depth = 0;
+
+  for (let index = 0; index < text.length; index += 1) {
+    const token = text[index];
+    if (token === "{") {
+      depth += 1;
+      continue;
+    }
+    if (token === "}") {
+      depth -= 1;
+      continue;
+    }
+    if (token === "[") {
+      depth += 1;
+      continue;
+    }
+    if (token === "]") {
+      depth -= 1;
+      continue;
+    }
+    if (token !== '"') {
+      continue;
+    }
+
+    let end = index + 1;
+    let escaped = false;
+    for (; end < text.length; end += 1) {
+      const character = text[end];
+      if (escaped) {
+        escaped = false;
+      } else if (character === "\\") {
+        escaped = true;
+      } else if (character === '"') {
+        break;
+      }
+    }
+
+    if (depth === 1) {
+      let next = end + 1;
+      while (
+        text[next] === " " ||
+        text[next] === "\t" ||
+        text[next] === "\n" ||
+        text[next] === "\r"
+      ) {
+        next += 1;
+      }
+      if (text[next] === ":") {
+        const key = JSON.parse(text.slice(index, end + 1)) as string;
+        if (keys.has(key)) {
+          return true;
+        }
+        keys.add(key);
+      }
+    }
+
+    index = end;
+  }
+
+  return false;
+}
+
 /** Parses and validates reviewer JSON into a conservative exec decision. */
 function parseExecAutoReviewResponse(text: string): ExecAutoReviewDecision {
   const objectText = extractJsonObject(text);
@@ -151,6 +217,28 @@ function parseExecAutoReviewResponse(text: string): ExecAutoReviewDecision {
       decision: "ask",
       risk: "unknown",
       rationale: "exec reviewer returned malformed JSON",
+    };
+  }
+  // JSON.parse silently keeps the last duplicate key, which can turn an
+  // earlier ask or high-risk decision into an unreviewed allow.
+  if (hasDuplicateJsonObjectKeys(objectText)) {
+    return {
+      decision: "ask",
+      risk: "unknown",
+      rationale: "exec reviewer returned ambiguous JSON",
+    };
+  }
+  // Zod ignores JSON's own `__proto__` field even in strict mode, so check
+  // actual parsed keys before trusting the closed reviewer response schema.
+  if (
+    typeof parsed === "object" &&
+    parsed !== null &&
+    Object.keys(parsed).some((key) => !Object.hasOwn(execAutoReviewResponseSchema.shape, key))
+  ) {
+    return {
+      decision: "ask",
+      risk: "unknown",
+      rationale: "exec reviewer returned an unsupported response",
     };
   }
   const response = execAutoReviewResponseSchema.safeParse(parsed);


### PR DESCRIPTION
Related: #114652

## What Problem This Solves

Fixes an issue where users relying on model-backed automatic execution review could have an ambiguous reviewer response automatically approve a command that should have required human confirmation. Repeated decision or risk keys, including Unicode-escaped equivalents, could silently overwrite an earlier human-review or high-risk decision. Unsupported approval fields and JSON's own `__proto__` property could also escape the intended closed response contract.

## Why This Change Was Made

Reject duplicate decoded top-level JSON keys before trusting JavaScript's last-key-wins parsing, validate the parsed object's real own-property names, and enforce the existing strict reviewer response schema in its canonical owner. This preserves valid one-shot decisions, quoted rationale, human escalation, timeout and cancellation semantics, gateway and node execution, shell-wrapper restrictions, and upstream Codex approval routing without adding dependencies, configuration, aliases, or protocol changes.

The upstream dependency contract was checked directly: Zod intentionally skips `__proto__` in its strict-object catchall, so strict schema validation alone cannot close this case. Upstream Codex was independently updated and inspected at `codex-rs/protocol/src/config_types.rs:159`, `codex-rs/app-server-protocol/src/protocol/v2/shared.rs:224`, and `codex-rs/core/src/guardian/review.rs:173`.

## User Impact

Ambiguous, duplicated, prototype-shaped, or otherwise unsupported model responses now safely fall back to user confirmation. Valid low-risk approvals and legitimate gateway, node, Windows, Unix, and Codex execution continue to work unchanged.

## Evidence

- Regression-first proof on `e073d17be1b0974f85a8d0910ac2433319c01470`: eight targeted malformed responses and a 4,096-response adversarial corpus failed before the fix; the prototype-key case was separately reproduced against strict Zod and fixed against the actual upstream contract.
- `pnpm test src/agents/exec-auto-reviewer.test.ts src/agents/exec-auto-review.stress.test.ts`: **219 tests passed**, including every new malformed-response and `__proto__` regression.
- Cross-host regression proof covers the reviewer, gateway and node approval paths, shell-wrapper and Windows startup parsing, plugin SDK execution, Codex approval bridge, and the latest Codex app-server client prewarming.
- Ten complete seeded stress iterations cover **245,760 hostile wrapper and model-response inputs**, including **40,960 concurrent-batched reviewer responses**, while preserving legitimate low-risk and human-escalation controls.
- Fresh independent `autoreview --mode uncommitted`: clean, no accepted or actionable findings.
- Production validation runs the repository's changed-surface quality gate and full production build on Blacksmith Testbox; exact-head hosted CI is required before protected landing.

### Inspectable runtime behavior: before and after

These are actual terminal results from the model-backed reviewer and execution-owner test paths on Blacksmith Testbox. The model completion is deterministic; this does not claim an external model or live production-provider call.

Before the runtime fix, at frozen main `e073d17be1b0974f85a8d0910ac2433319c01470`, the real reviewer converts ambiguous model output into executable single-use approval:

```text
$ pnpm test src/agents/exec-auto-reviewer.test.ts \
    src/agents/exec-auto-review.stress.test.ts -- \
    -t 'ambiguous reviewer JSON|4,096 seeded concurrent malformed reviewer responses'

FAIL  exec auto-review adversarial model-response stress
      fails closed for 4,096 seeded concurrent malformed reviewer responses
AssertionError: reviewer response escaped at seed 0x20260729, case 0:
  expected "allow-once" to be "ask"

FAIL  parseExecAutoReviewResponse
      defers ambiguous reviewer JSON with an unexpected prototype key
AssertionError:
  - { decision: "ask",        risk: "unknown" }
  + { decision: "allow-once", risk: "low" }

Failed Tests  9
```

After the fix, the real reviewer is called through `reviewExecResponse`, which constructs `createModelExecAutoReviewer` and exercises its actual prepared-model completion and response parser. Repeated and Unicode-escaped `decision`/`risk`, duplicate rationale, extra scope/command, and own `__proto__` all resolve to `{ decision: "ask", risk: "unknown" }`; the valid low-risk control still resolves to `allow-once`.

```text
$ pnpm test src/agents/exec-auto-reviewer.test.ts \
    src/agents/exec-auto-review.stress.test.ts

✓ src/agents/exec-auto-reviewer.test.ts      (41 tests)
✓ src/agents/exec-auto-review.stress.test.ts (178 tests)
Test Files  2 passed (2)
     Tests  219 passed (219)
```

The final pushed commit `8234ea0e13c1f64666744725c35d85ef542d9280` was independently synchronized to Blacksmith Testbox and proved again across every real owner and sibling route:

```text
$ pnpm exec oxlint --type-aware --tsconfig config/tsconfig/oxlint.core.json \
    --threads=2 src/agents/exec-auto-reviewer.ts \
    src/agents/exec-auto-reviewer.test.ts \
    src/agents/exec-auto-review.stress.test.ts
Found 0 warnings and 0 errors.

$ pnpm check:changed
[check:changed] lanes=core, coreTests
[check:changed] typecheck core
[check:changed] typecheck core tests
[check:changed] lint core changed files
[check:changed] runtime import cycles
Import cycle check: 0 runtime value cycle(s).

$ pnpm test <13 reviewer, Unix/Windows, gateway, node, SDK, Codex approval and prewarm files>
unit-fast:          213 passed
unit-fast-isolated:  97 passed
agents:             385 passed
extension-codex:     87 passed
total:              782 passed

$ for iteration in {1..10}; do pnpm test src/agents/exec-auto-review.stress.test.ts; done
10 / 10 passed
245,760 seeded wrapper and reviewer attacks
40,960 independently bound reviewer responses

$ pnpm build
[build-all] phase timings: total 2m 53s
blacksmith run summary ... exit=0
```

### Caller, sibling, and dependency boundary proof

- Canonical response extraction and completion-to-approval conversion: `src/agents/exec-auto-reviewer.ts:203` and `src/agents/exec-auto-reviewer.ts:436`.
- Exact real-reviewer setup, malicious-output assertions, and safe one-shot control: `src/agents/exec-auto-reviewer.test.ts:55`, `src/agents/exec-auto-reviewer.test.ts:77`, and `src/agents/exec-auto-reviewer.test.ts:185`.
- Independent concurrency and malformed-output corpus: `src/agents/exec-auto-review.stress.test.ts:624`.
- Human-approval fallback and shared decision contract: `src/infra/exec-auto-review.ts:49` and `src/infra/exec-auto-review.ts:57`.
- Caller and sibling surfaces proved by actual passing tests: gateway and node approval dispatch, shell-wrapper policies, plugin SDK harness, and Codex approval bridge and newly pulled app-server prewarm.
- Upstream Zod `src/v4/core/schemas.ts:1865` explicitly skips `__proto__` before reporting unrecognized strict-object keys; checking `Object.keys(parsed)` against own schema keys closes the demonstrated dependency exception.
- Personally read upstream Codex `codex-rs/protocol/src/config_types.rs:159`, `codex-rs/app-server-protocol/src/protocol/v2/shared.rs:224`, and `codex-rs/core/src/guardian/review.rs:173`: canonical `auto_review` is unchanged, `guardian_subagent` is an input alias only, and guardian review remains restricted to on-request or granular approval.
- No persisted state, data format, configuration, environment variable, SQLite schema, migration, exported API, or Codex protocol is changed. The ClawSweeper serialized-state warning is not applicable to this stateless response parser.
- Both the complete runtime fix and the CI-driven promise-normalization follow-up received separate clean independent autoreviews. Protected maintainer review artifacts are validated against the final head with zero findings.
- Exact-head hosted CI: https://github.com/openclaw/openclaw/actions/runs/30294403761. The initial failed `checks-node-compact-small-7` was the unchanged `src/cli/help-exit.process.test.ts:614` child process reaching its existing 45-second cold-start timeout, not an auto-review failure; failed jobs are being rerun without weakening the merge gate.

AI-assisted; all findings, dependency contracts, regression-first results, stress outcomes, and changes were independently inspected.
