### PR TITLE
fix(ui): show resolved avatars on session owner chips

### DIFF
--- a/ui/src/app/user-profile.ts
+++ b/ui/src/app/user-profile.ts
@@ -2,6 +2,12 @@ import type { PresenceEntry } from "../api/types.ts";
 
 export type AuthenticatedUser = NonNullable<PresenceEntry["user"]>;
 export type PresencePayload = { presence: readonly PresenceEntry[] };
+export type ActorIdentityUser = {
+  id: string;
+  name?: string;
+  email?: string;
+  avatarUrl?: string;
+};
 
 export function readPresenceEntries(value: unknown): PresenceEntry[] | undefined {
   if (!value || typeof value !== "object") {
@@ -40,6 +46,52 @@ export function resolveCurrentSelfUser({
   return snapshotUser && (!presenceUser || snapshotUser.id === presenceUser.id)
     ? snapshotUser
     : presenceUser;
+}
+
+function normalizeActorIdentityUser(
+  user: AuthenticatedUser | null | undefined,
+): ActorIdentityUser | null {
+  if (!user) {
+    return null;
+  }
+  const id = user.id.trim();
+  if (!id) {
+    return null;
+  }
+  const optional = (value: string | null | undefined) => value?.trim() || undefined;
+  return {
+    id,
+    ...(optional(user.name) ? { name: optional(user.name) } : {}),
+    ...(optional(user.email) ? { email: optional(user.email) } : {}),
+    ...(optional(user.avatarUrl) ? { avatarUrl: optional(user.avatarUrl) } : {}),
+  };
+}
+
+/** Builds actor identities from the same self and presence sources as the sidebar footer. */
+export function resolveActorIdentityUsers({
+  snapshotUser,
+  presenceEntries,
+  presenceInstanceId,
+}: {
+  snapshotUser?: AuthenticatedUser | null;
+  presenceEntries?: readonly PresenceEntry[];
+  presenceInstanceId?: string;
+}): ReadonlyMap<string, ActorIdentityUser> {
+  const users = new Map<string, ActorIdentityUser>();
+  const addUser = (user: AuthenticatedUser | null | undefined) => {
+    const normalized = normalizeActorIdentityUser(user);
+    if (!normalized) {
+      return;
+    }
+    users.set(normalized.id, { ...users.get(normalized.id), ...normalized });
+  };
+  for (const entry of presenceEntries ?? []) {
+    if (entry.reason !== "disconnect") {
+      addUser(entry.user);
+    }
+  }
+  addUser(resolveCurrentSelfUser({ snapshotUser, presenceEntries, presenceInstanceId }));
+  return users;
 }
 
 export function userProfileAvatarUrl(

--- a/ui/src/components/app-sidebar-session-menu-renderers.ts
+++ b/ui/src/components/app-sidebar-session-menu-renderers.ts
@@ -1,6 +1,7 @@
 import { html, nothing } from "lit";
 import { keyed } from "lit/directives/keyed.js";
 import { ref } from "lit/directives/ref.js";
+import type { ActorIdentityUser } from "../app/user-profile.ts";
 import { t } from "../i18n/index.ts";
 import type { CatalogProjectGrouping } from "../lib/sessions/catalog-project-grouping.ts";
 import type { SidebarSessionsGrouping } from "../lib/sessions/grouping.ts";
@@ -96,6 +97,7 @@ export function renderSidebarCatalogViewMenu(params: {
   grouping: CatalogProjectGrouping;
   creators: readonly SessionCreatorOption[];
   creatorFilterId: string | null;
+  resolveCreatorUser: (creatorId: string) => ActorIdentityUser | undefined;
   onGroupingChange: (grouping: CatalogProjectGrouping) => void;
   onCreatorFilterChange: (creatorId: string | null) => void;
   onClose: (restoreFocus: boolean) => void;
@@ -192,7 +194,12 @@ export function renderSidebarCatalogViewMenu(params: {
                       <span slot="details" class="session-menu__check" aria-hidden="true"
                         >${params.creatorFilterId === creator.id ? icons.check : nothing}</span
                       >
-                      ${renderSessionOwnerChip(creator, "row")}
+                      ${renderSessionOwnerChip(
+                        creator,
+                        "row",
+                        "created",
+                        params.resolveCreatorUser(creator.id),
+                      )}
                       <span class="session-menu__text">${creator.label ?? creator.id}</span>
                     </wa-dropdown-item>
                   `,
@@ -214,6 +221,7 @@ export function renderSidebarSessionSortMenu(params: {
   showCron: boolean;
   creators: readonly SessionCreatorOption[];
   creatorFilterId: string | null;
+  resolveCreatorUser: (creatorId: string) => ActorIdentityUser | undefined;
   onGroupingChange: (grouping: SidebarSessionsGrouping) => void;
   onSortModeChange: (mode: SidebarSessionSortMode) => void;
   onStatusFilterChange: (statusFilter: SidebarSessionStatusFilter) => void;
@@ -364,7 +372,12 @@ export function renderSidebarSessionSortMenu(params: {
                       <span slot="details" class="session-menu__check" aria-hidden="true"
                         >${params.creatorFilterId === creator.id ? icons.check : nothing}</span
                       >
-                      ${renderSessionOwnerChip(creator, "row")}
+                      ${renderSessionOwnerChip(
+                        creator,
+                        "row",
+                        "created",
+                        params.resolveCreatorUser(creator.id),
+                      )}
                       <span class="session-menu__text">${creator.label ?? creator.id}</span>
                     </wa-dropdown-item>
                   `,

--- a/ui/src/components/app-sidebar-session-row-render.ts
+++ b/ui/src/components/app-sidebar-session-row-render.ts
@@ -26,6 +26,10 @@ import type { SessionDataController } from "./session-data-controller.ts";
 import { renderSessionLeadingState } from "./session-leading-indicator.ts";
 import type { SessionPullRequestIndicatorState } from "./session-menu-work.ts";
 import type { SessionOrganizerController } from "./session-organizer-controller.ts";
+import {
+  resolveSessionOwnerUser,
+  type SessionOwnerIdentityHost,
+} from "./session-owner-identity.ts";
 import { renderSessionRowBadges } from "./session-row-badges.ts";
 import {
   renderSidebarSessionSubtitle,
@@ -36,7 +40,7 @@ import "./elapsed-time.ts";
 
 const SIDEBAR_VISIBLE_CHILD_SESSION_LIMIT = 4;
 
-export interface SessionListHost {
+export interface SessionListHost extends SessionOwnerIdentityHost {
   readonly sidebarLiveActivity: boolean;
   readonly sidebarNarrationLines: ReadonlyMap<string, string>;
   readonly sidebarObserverDigests: ReadonlyMap<string, SessionObserverDigest>;
@@ -164,6 +168,7 @@ export function renderRecentSession(params: {
     pullRequestState,
     ownerActor,
     ownerAttribution,
+    resolveSessionOwnerUser(host, ownerActor?.id),
   );
   const meta = display?.meta ?? session.meta;
   const rowMeta = session.pinned ? "" : meta;

--- a/ui/src/components/session-leading-indicator.ts
+++ b/ui/src/components/session-leading-indicator.ts
@@ -1,4 +1,5 @@
 import { html, nothing } from "lit";
+import type { ActorIdentityUser } from "../app/user-profile.ts";
 import { t } from "../i18n/index.ts";
 import type { SidebarRecentSession } from "./app-sidebar-session-types.ts";
 import { icons } from "./icons.ts";
@@ -41,6 +42,7 @@ export function renderSessionLeadingState(
   pullRequestState: SessionPullRequestIndicatorState,
   ownerActor: SessionCreatedActor | null | undefined,
   attribution: "created" | "archived",
+  ownerUser?: ActorIdentityUser,
 ) {
   const running = session.hasActiveRun || session.status === "running";
 
@@ -72,7 +74,7 @@ export function renderSessionLeadingState(
     return {
       running,
       leadingIndicator: renderSessionGlyph({
-        content: renderSessionOwnerChip(ownerActor, "row", attribution),
+        content: renderSessionOwnerChip(ownerActor, "row", attribution, ownerUser),
         running,
         circular: true,
         badge: renderGlyphBadge(session, pullRequestState),

--- a/ui/src/components/session-owner-chip.ts
+++ b/ui/src/components/session-owner-chip.ts
@@ -1,8 +1,11 @@
 import { html, nothing } from "lit";
 import { property } from "lit/decorators.js";
 import type { SessionCreatedActor as ProtocolSessionCreatedActor } from "../../../packages/gateway-protocol/src/schema/sessions.js";
+import type { ActorIdentityUser } from "../app/user-profile.ts";
 import { t } from "../i18n/index.ts";
+import { resolveAvatar } from "../lib/identity-avatar.ts";
 import { OpenClawLightDomElement } from "../lit/openclaw-element.ts";
+import "./viewer-facepile.ts";
 
 export type SessionCreatedActor = ProtocolSessionCreatedActor;
 export type SessionCreatorOption = SessionCreatedActor & { id: string };
@@ -36,10 +39,12 @@ export function renderSessionOwnerChip(
   createdActor: SessionCreatedActor | null | undefined,
   size: "row" | "header",
   attribution: "created" | "archived" = "created",
+  user?: ActorIdentityUser,
 ) {
   return createdActor?.id
     ? html`<openclaw-session-owner-chip
         .createdActor=${createdActor}
+        .user=${user ?? null}
         size=${size}
         attribution=${attribution}
       ></openclaw-session-owner-chip>`
@@ -73,9 +78,12 @@ function ownerHue(id: string): number {
  * this chip is solid and never pulses/expires, in deliberate contrast to the
  * translucent, ring-styled live-presence chips. Render only when the gateway
  * has 2+ distinct creator identities (solo mode shows no attribution chrome).
+ * Actors absent from the current self/presence identities keep their stable
+ * initials because provenance outlives presence.
  */
 class SessionOwnerChip extends OpenClawLightDomElement {
   @property({ attribute: false }) createdActor: SessionCreatedActor | null = null;
+  @property({ attribute: false }) user: ActorIdentityUser | null = null;
   @property({ type: String }) size: "row" | "header" = "row";
   @property({ type: String }) attribution: "created" | "archived" = "created";
 
@@ -93,6 +101,15 @@ class SessionOwnerChip extends OpenClawLightDomElement {
       this.attribution === "archived" ? "sessionsView.archivedBy" : "sessionsView.createdBy",
       { name: title },
     );
+    const user = this.user?.id.trim() === createdActor.id.trim() ? this.user : null;
+    const avatar = user
+      ? resolveAvatar({
+          id: user.id,
+          name: user.name,
+          username: user.email,
+          profileAvatarUrl: user.avatarUrl,
+        })
+      : null;
     return html`
       <span
         class="session-owner-chip session-owner-chip--${this.size}"
@@ -100,7 +117,13 @@ class SessionOwnerChip extends OpenClawLightDomElement {
         role="img"
         aria-label=${accessibleLabel}
         title=${accessibleLabel}
-        >${initials}</span
+        >${avatar?.kind === "profile" && user
+          ? html`<openclaw-viewer-avatar
+              .user=${{ ...user, watchedSessions: [] }}
+              variant="session"
+              aria-hidden="true"
+            ></openclaw-viewer-avatar>`
+          : initials}</span
       >
     `;
   }

--- a/ui/src/components/session-owner-identity.ts
+++ b/ui/src/components/session-owner-identity.ts
@@ -1,0 +1,59 @@
+import {
+  readPresenceEntries,
+  resolveActorIdentityUsers,
+  type ActorIdentityUser,
+  type AuthenticatedUser,
+} from "../app/user-profile.ts";
+
+export type SessionOwnerIdentityHost = object & {
+  readonly sessionDataContext:
+    | {
+        gateway: { snapshot: { selfUser?: AuthenticatedUser | null } };
+      }
+    | undefined;
+  readonly sessionData: {
+    presencePayload?: unknown;
+    presenceInstanceId?: string;
+  };
+};
+
+type SessionOwnerIdentityCache = {
+  snapshotUser: AuthenticatedUser | null | undefined;
+  presencePayload: unknown;
+  presenceInstanceId: string | undefined;
+  users: ReadonlyMap<string, ActorIdentityUser>;
+};
+
+const cacheByHost = new WeakMap<SessionOwnerIdentityHost, SessionOwnerIdentityCache>();
+
+export function resolveSessionOwnerUser(
+  host: SessionOwnerIdentityHost,
+  actorId: string | null | undefined,
+): ActorIdentityUser | undefined {
+  const id = actorId?.trim();
+  if (!id) {
+    return undefined;
+  }
+  const snapshotUser = host.sessionDataContext?.gateway.snapshot.selfUser;
+  const { presencePayload, presenceInstanceId } = host.sessionData;
+  let cached = cacheByHost.get(host);
+  if (
+    !cached ||
+    cached.snapshotUser !== snapshotUser ||
+    cached.presencePayload !== presencePayload ||
+    cached.presenceInstanceId !== presenceInstanceId
+  ) {
+    cached = {
+      snapshotUser,
+      presencePayload,
+      presenceInstanceId,
+      users: resolveActorIdentityUsers({
+        snapshotUser,
+        presenceEntries: readPresenceEntries(presencePayload),
+        presenceInstanceId,
+      }),
+    };
+    cacheByHost.set(host, cached);
+  }
+  return cached.users.get(id);
+}

--- a/ui/src/components/sidebar-menus-render.ts
+++ b/ui/src/components/sidebar-menus-render.ts
@@ -19,6 +19,7 @@ import {
   renderSidebarSessionSortMenu,
 } from "./app-sidebar-session-menu-renderers.ts";
 import type { SessionMenuAction } from "./session-menu.ts";
+import { resolveSessionOwnerUser } from "./session-owner-identity.ts";
 import type {
   SidebarMenusController,
   SidebarMenusControllerHost,
@@ -291,6 +292,7 @@ export function renderSidebarSessionSortMenuForController(controller: SidebarMen
     showCron: host.sessionsShowCron,
     creators: host.sessionOwnershipVisible ? host.sessionCreatorOptions : [],
     creatorFilterId: host.sessionCreatorFilterActive ? host.sessionCreatorFilterId : null,
+    resolveCreatorUser: (creatorId) => resolveSessionOwnerUser(host, creatorId),
     onGroupingChange: (grouping) => {
       host.sessionOrganizer.setSessionsGrouping(grouping);
       controller.closeSessionSortMenu({ restoreFocus: true });
@@ -330,6 +332,7 @@ export function renderSidebarCatalogViewMenuForController(controller: SidebarMen
     grouping: host.catalogProjectGrouping,
     creators: host.sessionOwnershipVisible ? host.sessionCreatorOptions : [],
     creatorFilterId: host.sessionCreatorFilterActive ? host.sessionCreatorFilterId : null,
+    resolveCreatorUser: (creatorId) => resolveSessionOwnerUser(host, creatorId),
     onGroupingChange: (grouping) => {
       host.setCatalogProjectGrouping(grouping);
       controller.closeCatalogViewMenu({ restoreFocus: true });

--- a/ui/src/pages/chat/chat-pane-deps.ts
+++ b/ui/src/pages/chat/chat-pane-deps.ts
@@ -65,7 +65,6 @@ export {
   readPresenceEntries,
   resolveActorIdentityUsers,
   resolveCurrentSelfUser,
-  type ActorIdentityUser,
   type PresencePayload,
 } from "../../app/user-profile.ts";
 export {

--- a/ui/src/pages/chat/chat-pane-deps.ts
+++ b/ui/src/pages/chat/chat-pane-deps.ts
@@ -63,7 +63,9 @@ export {
 export { loadSettings, patchSettings } from "../../app/settings.ts";
 export {
   readPresenceEntries,
+  resolveActorIdentityUsers,
   resolveCurrentSelfUser,
+  type ActorIdentityUser,
   type PresencePayload,
 } from "../../app/user-profile.ts";
 export {

--- a/ui/src/pages/chat/chat-pane-header-render.ts
+++ b/ui/src/pages/chat/chat-pane-header-render.ts
@@ -18,6 +18,8 @@ import {
   renderChatSessionSharing,
   renderSessionDiffToggle,
   renderSessionWorkspaceToggle,
+  readPresenceEntries,
+  resolveActorIdentityUsers,
   resolveChatPaneWorkspace,
   t,
   type BackgroundTasksProps,
@@ -76,6 +78,14 @@ export abstract class ChatPaneHeaderRender extends ChatPaneHeader {
       : branchSwitchWorking
         ? t("chat.sessionHeader.branchSwitchUnavailable")
         : null;
+    const ownerActorId = row?.createdActor?.id?.trim();
+    const ownerUser = ownerActorId
+      ? resolveActorIdentityUsers({
+          snapshotUser: this.context.gateway.snapshot.selfUser,
+          presenceEntries: readPresenceEntries(this.presencePayload),
+          presenceInstanceId: this.context.gateway.snapshot.client?.instanceId,
+        }).get(ownerActorId)
+      : undefined;
     return renderChatPaneHeader({
       paneId: this.paneId,
       narrow: this.narrow,
@@ -87,6 +97,7 @@ export abstract class ChatPaneHeaderRender extends ChatPaneHeader {
           this.state?.sessionsResult?.creators ??
           listSessionCreators(this.state?.sessionsResult?.sessions ?? [])
         ).length >= 2,
+      ownerUser,
       catalog,
       editing: this.headerEditing && this.headerRenameSessionKey === row?.key,
       renameValue: this.headerRenameValue,

--- a/ui/src/pages/chat/components/chat-pane-header.test.ts
+++ b/ui/src/pages/chat/components/chat-pane-header.test.ts
@@ -273,6 +273,25 @@ describe("chat pane header", () => {
     expect(dormant.container.querySelector("openclaw-session-owner-chip")).toBeNull();
   });
 
+  it("renders a resolved owner avatar with the header attribution semantics", async () => {
+    const mounted = mount({
+      showOwnerChip: true,
+      session: row({ createdActor: { type: "human", id: "profile-ada", label: "Ada" } }),
+      ownerUser: {
+        id: "profile-ada",
+        name: "Ada",
+        avatarUrl: "/api/users/profile-ada/avatar",
+      },
+    });
+
+    await vi.waitFor(() => {
+      expect(mounted.container.querySelector("openclaw-session-owner-chip img")).not.toBeNull();
+    });
+    const chip = mounted.container.querySelector(".session-owner-chip--header");
+    expect(chip?.getAttribute("aria-label")).toBe("Created by Ada");
+    expect(chip?.getAttribute("title")).toBe("Created by Ada");
+  });
+
   it("routes Enter and Escape from the rename input", () => {
     const enter = mount({ editing: true, renameValue: "  Updated  " });
     const enterInput = enter.container.querySelector<HTMLInputElement>("input");

--- a/ui/src/pages/chat/components/chat-pane-header.ts
+++ b/ui/src/pages/chat/components/chat-pane-header.ts
@@ -8,6 +8,7 @@ import type {
 } from "../../../app/native-gateways.runtime.ts";
 import { isNativeWebChromeHost } from "../../../app/native-web-chrome.ts";
 import { beginNativeWindowDrag } from "../../../app/native-window-drag.ts";
+import type { ActorIdentityUser } from "../../../app/user-profile.ts";
 import {
   COMMAND_PALETTE_OPEN_EVENT,
   SHELL_NAV_DRAWER_TOGGLE_EVENT,
@@ -31,6 +32,7 @@ type ChatPaneHeaderProps = {
   title: string;
   session: GatewaySessionRow | undefined;
   showOwnerChip?: boolean;
+  ownerUser?: ActorIdentityUser;
   catalog: boolean;
   editing: boolean;
   renameValue: string;
@@ -307,6 +309,8 @@ export function renderChatPaneHeader(props: ChatPaneHeaderProps) {
       ${renderSessionOwnerChip(
         props.showOwnerChip ? props.session?.createdActor : undefined,
         "header",
+        "created",
+        props.ownerUser,
       )}
       ${!props.catalog && props.workspaceLabel
         ? html`

--- a/ui/src/styles/components.css
+++ b/ui/src/styles/components.css
@@ -45,6 +45,13 @@ openclaw-session-owner-chip {
   font-size: 10px;
 }
 
+.session-owner-chip .viewer-avatar {
+  width: 100%;
+  height: 100%;
+  border: 0;
+  font-size: inherit;
+}
+
 /* Leading slot shared by every sidebar row: the row's own artwork plus a run
    ring and corner badge, so run state always reads at the row's left edge. */
 .session-glyph {

--- a/ui/src/test-helpers/app-sidebar-cases/session-ownership.ts
+++ b/ui/src/test-helpers/app-sidebar-cases/session-ownership.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import type { GatewayBrowserClient } from "../../api/gateway.ts";
 import {
   createGateway,
+  createGatewayHarness,
   createSessionsHarness,
   mountSidebar,
   type SidebarLifecycleState,
@@ -35,6 +36,80 @@ async function selectCreator(sidebar: SidebarLifecycleState, creatorId: string |
 }
 
 describe("AppSidebar session ownership", () => {
+  it("renders self and presence avatars while unmatched actors keep initials", async () => {
+    const gateway = createGatewayHarness({} as GatewayBrowserClient);
+    gateway.publish({
+      selfUser: {
+        id: "profile-ada",
+        name: "Ada",
+        avatarUrl: "/api/users/profile-ada/avatar?v=1",
+      },
+    });
+    const harness = createSessionsHarness("main", [
+      "agent:main:main",
+      "agent:main:ada",
+      "agent:main:bob",
+      "agent:main:carol",
+    ]);
+    const result = harness.sessions.state.result;
+    if (!result) {
+      throw new Error("expected session list");
+    }
+    const ada = result.sessions.find((row) => row.key.endsWith(":ada"));
+    const bob = result.sessions.find((row) => row.key.endsWith(":bob"));
+    const carol = result.sessions.find((row) => row.key.endsWith(":carol"));
+    if (!ada || !bob || !carol) {
+      throw new Error("expected creator rows");
+    }
+    ada.createdActor = { type: "human", id: "profile-ada", label: "Ada" };
+    bob.createdActor = { type: "human", id: "profile-bob", label: "Bob" };
+    carol.createdActor = { type: "human", id: "profile-carol", label: "Carol" };
+    result.creators = [
+      { id: "profile-ada", label: "Ada" },
+      { id: "profile-bob", label: "Bob" },
+      { id: "profile-carol", label: "Carol" },
+    ];
+
+    const { sidebar } = await mountSidebar(gateway.gateway, harness.sessions);
+    gateway.publishEvent("presence", {
+      presence: [
+        {
+          instanceId: "bob-browser",
+          user: {
+            id: "profile-bob",
+            name: "Bob",
+            avatarUrl: "/api/users/profile-bob/avatar?v=2",
+          },
+        },
+      ],
+    });
+    harness.publishList({ result, agentId: "main" });
+
+    await waitForFast(() => {
+      expect(
+        sidebar.querySelector('[data-session-key="agent:main:ada"] openclaw-viewer-avatar img'),
+      ).not.toBeNull();
+      expect(
+        sidebar.querySelector('[data-session-key="agent:main:bob"] openclaw-viewer-avatar img'),
+      ).not.toBeNull();
+    });
+
+    const adaChip = sidebar.querySelector(
+      '[data-session-key="agent:main:ada"] .session-owner-chip',
+    );
+    expect(adaChip?.getAttribute("aria-label")).toBe("Created by Ada");
+    expect(adaChip?.getAttribute("title")).toBe("Created by Ada");
+    const adaImage = adaChip?.querySelector("img");
+    adaImage?.dispatchEvent(new Event("error"));
+    expect(adaChip?.querySelector(".viewer-avatar")?.classList.contains("is-fallback")).toBe(true);
+
+    const carolChip = sidebar.querySelector(
+      '[data-session-key="agent:main:carol"] .session-owner-chip',
+    );
+    expect(carolChip?.querySelector("openclaw-viewer-avatar")).toBeNull();
+    expect(carolChip?.textContent?.trim()).toBe("C");
+  });
+
   it("uses the complete facet and requests unloaded creators from the Gateway", async () => {
     const gateway = createGateway({} as GatewayBrowserClient);
     const harness = createSessionsHarness("main", ["agent:main:main", "agent:main:ada"]);
@@ -81,7 +156,14 @@ describe("AppSidebar session ownership", () => {
   });
 
   it("renders no ownership chrome when the listed sessions have fewer than two creators", async () => {
-    const gateway = createGateway({} as GatewayBrowserClient);
+    const gateway = createGatewayHarness({} as GatewayBrowserClient);
+    gateway.publish({
+      selfUser: {
+        id: "profile-ada",
+        name: "Ada",
+        avatarUrl: "/api/users/profile-ada/avatar",
+      },
+    });
     const harness = createSessionsHarness("main", [
       "agent:main:main",
       "agent:main:a",
@@ -94,7 +176,7 @@ describe("AppSidebar session ownership", () => {
     for (const row of result.sessions) {
       row.createdActor = { type: "human", id: "profile-ada", label: "Ada" };
     }
-    const { sidebar } = await mountSidebar(gateway, harness.sessions);
+    const { sidebar } = await mountSidebar(gateway.gateway, harness.sessions);
     harness.publishList({ result, agentId: "main" });
     await sidebar.updateComplete;
 


### PR DESCRIPTION
## What Problem This Solves

On team.openclaw.ai the operator's avatar renders in the sidebar footer identity card, but their own session rows show only the initials chip (an "S" on a hue-colored disc). Root cause: `SessionOwnerChip` was initials-only by construction — it never attempted image resolution, while the footer uses `openclaw-viewer-avatar`, which resolves real images from the gateway snapshot's self user and presence entries (`user.avatarUrl`).

## Why This Change Was Made

Session rows carry `createdActor: {id, label, type}` where the actor id equals the auth user id — the same identity the footer already resolves an image for. This adds a client-side identity join at the sidebar host: a lookup from actor id → avatar-capable user assembled from the exact sources the footer uses (snapshot selfUser + presence entries). The owner chip renders `openclaw-viewer-avatar` when the actor resolves — preserving its authenticated image loading and error-fallback behavior — and keeps the existing initials chip for actors with no identity match (offline/unknown users; the accepted tradeoff is documented in the chip's provenance-vs-presence doc comment). Applied consistently to sidebar rows, the creator filter menu, and header owner chips. No server-side storage or endpoint changes; ownership-hidden solo mode still renders no chip.

## User Impact

Your threads show your actual avatar in the sidebar, matching the footer identity card. Unresolvable actors keep the deterministic initials chip; aria-labels and archived-attribution semantics are unchanged in both modes.

## Evidence

- Sidebar/header suites: 221/221; ownership E2E: 8/8; new regressions: resolved actor renders the avatar image with intact aria semantics, unmatched actor keeps initials, image-failure fallback wired via the reused component, solo mode renders no chip
- UI test-types lane, oxlint, oxfmt, `git diff --check` green; autoreview (Codex gpt-5.6-sol, xhigh) clean
- Testbox run: https://github.com/openclaw/openclaw/actions/runs/30293310372
