### PR TITLE
fix(ui): prevent stale and read-only Workboard dashboard actions

### DIFF
--- a/ui/src/components/board/board-widget-cell-plugin.test.ts
+++ b/ui/src/components/board/board-widget-cell-plugin.test.ts
@@ -170,8 +170,10 @@ describe("plugin board widget cells", () => {
         position: 0,
         grantState: "none",
         revision: 1,
-        readOnly: widgetReadOnly,
       };
+      if (widgetReadOnly) {
+        Reflect.set(widget, "readOnly", true);
+      }
       const provider = createApplicationContextProvider(context);
       const cell = document.createElement("openclaw-board-widget-cell");
       cell.widget = widget;

--- a/ui/src/components/board/board-widget-cell-plugin.test.ts
+++ b/ui/src/components/board/board-widget-cell-plugin.test.ts
@@ -116,4 +116,85 @@ describe("plugin board widget cells", () => {
     );
     expect(cell.querySelector('[data-test-id="board-widget-error"]')).toBeNull();
   });
+
+  it.each([
+    { name: "read-only board", canMutate: false, widgetReadOnly: false },
+    { name: "read-only widget", canMutate: true, widgetReadOnly: true },
+  ])(
+    "keeps an embedded Workboard card read-only for a $name",
+    async ({ canMutate, widgetReadOnly }) => {
+      const request = vi.fn(async (method: string) => {
+        if (method === "workboard.cards.list") {
+          return {
+            cards: [
+              {
+                id: "card-123",
+                title: "Read-only embedded card",
+                status: "ready",
+                priority: "normal",
+                labels: [],
+                position: 0,
+                createdAt: 1,
+                updatedAt: 1,
+              },
+            ],
+            statuses: ["ready", "running", "done"],
+          };
+        }
+        throw new Error(`Unexpected method: ${method}`);
+      });
+      const context = {
+        gateway: {
+          snapshot: {
+            phase: "connected",
+            client: { request },
+            hello: {
+              controlUiWidgetKinds: [
+                { pluginId: "workboard", kind: "workboard:card", label: "Workboard card" },
+              ],
+            },
+          },
+          subscribe: () => () => undefined,
+          subscribeEvents: () => () => undefined,
+        },
+      } as unknown as ApplicationContext;
+      const widget: BoardViewWidget = {
+        name: "work-item",
+        tabId: "main",
+        title: "Work item",
+        contentKind: "plugin",
+        pluginKind: "workboard:card",
+        props: { cardId: "card-123" },
+        sizeW: 6,
+        sizeH: 4,
+        position: 0,
+        grantState: "none",
+        revision: 1,
+        readOnly: widgetReadOnly,
+      };
+      const provider = createApplicationContextProvider(context);
+      const cell = document.createElement("openclaw-board-widget-cell");
+      cell.widget = widget;
+      cell.rect = { name: widget.name, x: 0, y: 0, w: 6, h: 4 };
+      cell.sessionKey = "agent:main:test";
+      cell.callbacks = callbacks();
+      cell.canMutate = canMutate;
+      provider.append(cell);
+      document.body.append(provider);
+
+      await vi.waitFor(() =>
+        expect(cell.querySelector("openclaw-workboard-card-widget")?.textContent).toContain(
+          "Read-only embedded card",
+        ),
+      );
+      const select = cell.querySelector<HTMLSelectElement>("openclaw-workboard-card-widget select");
+      expect(select).not.toBeNull();
+      expect(select?.disabled).toBe(true);
+      if (select) {
+        select.value = "running";
+        select.dispatchEvent(new Event("change"));
+      }
+      expect(request).not.toHaveBeenCalledWith("workboard.cards.move", expect.anything());
+    },
+  );
 });

--- a/ui/src/components/board/board-widget-cell.ts
+++ b/ui/src/components/board/board-widget-cell.ts
@@ -270,6 +270,7 @@ class OpenClawBoardWidgetCell extends OpenClawLightDomElement {
         return this.pluginRenderer({
           widget,
           sessionKey: this.sessionKey,
+          canMutate: this.canMutate && widget.readOnly !== true,
           requestUpdate: () => this.requestUpdate(),
         });
       }

--- a/ui/src/components/board/board-widget-cell.ts
+++ b/ui/src/components/board/board-widget-cell.ts
@@ -270,7 +270,7 @@ class OpenClawBoardWidgetCell extends OpenClawLightDomElement {
         return this.pluginRenderer({
           widget,
           sessionKey: this.sessionKey,
-          canMutate: this.canMutate && widget.readOnly !== true,
+          canMutate: this.canMutate && !widget.readOnly,
           requestUpdate: () => this.requestUpdate(),
         });
       }

--- a/ui/src/e2e/session-dashboard.e2e.test.ts
+++ b/ui/src/e2e/session-dashboard.e2e.test.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import { chromium, type Browser, type Page } from "playwright";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { GATEWAY_SERVER_CAPS } from "../../../packages/gateway-protocol/src/index.js";
+import { PROTOCOL_VERSION } from "../../../packages/gateway-protocol/src/version.js";
 import { SANDBOX_HOST_PATH } from "../../../src/agents/sandbox-host.js";
 import { createSandboxHostHttpServer } from "../../../src/gateway/mcp-app-sandbox-http.js";
 import {
@@ -559,6 +560,82 @@ describeControlUiE2e("Control UI session dashboard stitch", () => {
       if (recordProof && video) {
         await video.saveAs(path.join(pluginWidgetsProofDir, "workboard-plugin-widgets.webm"));
       }
+    }
+  });
+
+  it("keeps a read-only Workboard dashboard card visible without allowing status changes", async () => {
+    const context = await browser.newContext({ viewport: { height: 900, width: 1280 } });
+    const page = await context.newPage();
+    const widgetKinds = [
+      { pluginId: "workboard", kind: "workboard:card", label: "Workboard card" },
+      { pluginId: "workboard", kind: "workboard:mini", label: "Workboard summary" },
+    ];
+    const methods = [
+      "board.get",
+      "chat.metadata",
+      "chat.startup",
+      "workboard.cards.list",
+      "workboard.cards.move",
+    ];
+    const card = {
+      id: "card-widget-ready",
+      title: "Read-only dashboard card",
+      status: "ready",
+      priority: "high",
+      labels: ["dashboard"],
+      position: 1,
+      createdAt: 1,
+      updatedAt: 2,
+      agentId: "main",
+      metadata: { automation: { boardId: "platform" } },
+    };
+    const gateway = await installMockGateway(page, {
+      controlUiWidgetKinds: widgetKinds,
+      featureMethods: methods,
+      methodResponses: {
+        connect: {
+          type: "hello-ok",
+          protocol: PROTOCOL_VERSION,
+          server: { connId: "read-only-dashboard-widget", version: "e2e" },
+          auth: {
+            deviceToken: "e2e-read-only-dashboard-device-token",
+            role: "operator",
+            scopes: ["operator.read"],
+          },
+          features: { capabilities: [], events: [], methods },
+          controlUiWidgetKinds: widgetKinds,
+          snapshot: {
+            sessionDefaults: {
+              defaultAgentId: "main",
+              mainKey: "main",
+              mainSessionKey: "main",
+              scope: "agent",
+            },
+          },
+        },
+        "board.get": pluginWidgetBoardSnapshot,
+        "workboard.cards.list": {
+          cards: [card],
+          statuses: ["ready", "running", "done"],
+        },
+      },
+    });
+    await showDashboard(page);
+
+    try {
+      await page.goto(`${server.baseUrl}dashboard`);
+      const cardWidget = page.locator('[data-test-id="workboard-card-widget"]');
+      await cardWidget.waitFor();
+      await expect.poll(() => cardWidget.textContent()).toContain(card.title);
+      const status = cardWidget.getByRole("combobox");
+      await expect.poll(() => status.isDisabled()).toBe(true);
+      await status.evaluate((select) => {
+        (select as HTMLSelectElement).value = "running";
+        select.dispatchEvent(new Event("change", { bubbles: true }));
+      });
+      expect(await gateway.getRequests("workboard.cards.move")).toHaveLength(0);
+    } finally {
+      await context.close();
     }
   });
 

--- a/ui/src/lib/board/widgets/index.ts
+++ b/ui/src/lib/board/widgets/index.ts
@@ -13,6 +13,7 @@ type BuiltinBoardWidgetRenderer = (context: {
 export type PluginBoardWidgetRenderer = (props: {
   widget: BoardViewWidget;
   sessionKey: string;
+  canMutate: boolean;
   requestUpdate: () => void;
 }) => TemplateResult;
 
@@ -24,8 +25,8 @@ type PluginWidgetKindContribution = {
 
 /**
  * Plugin renderers are trusted first-party Control UI code. They render in the
- * cell without an iframe or grants, receive only widget/session/update props,
- * and use the standard gateway client for RPCs owned by their plugin.
+ * cell without an iframe or grants, receive only widget/session/capability/update
+ * props, and use the standard gateway client for RPCs owned by their plugin.
  */
 const PLUGIN_WIDGET_KIND_CONTRIBUTIONS: Record<string, PluginWidgetKindContribution> = {
   "workboard:card": {

--- a/ui/src/lib/board/widgets/workboard-card.ts
+++ b/ui/src/lib/board/widgets/workboard-card.ts
@@ -67,6 +67,7 @@ class OpenClawWorkboardCardWidget extends WorkboardWidgetElement {
                 <select
                   aria-label=${`${t("workboard.fieldStatus")}: ${card.title}`}
                   .value=${card.status}
+                  ?disabled=${!this.canMutate}
                   @change=${(event: Event) => void this.handleStatusChange(event)}
                 >
                   ${statuses.map(
@@ -92,15 +93,18 @@ if (!customElements.get("openclaw-workboard-card-widget")) {
 export const renderWorkboardCardWidget: PluginBoardWidgetRenderer = ({
   widget,
   sessionKey,
+  canMutate,
   requestUpdate,
 }: {
   widget: BoardViewWidget;
   sessionKey: string;
+  canMutate: boolean;
   requestUpdate: () => void;
 }) => html`
   <openclaw-workboard-card-widget
     .widget=${widget}
     .sessionKey=${sessionKey}
+    .canMutate=${canMutate}
     .hostRequestUpdate=${requestUpdate}
   ></openclaw-workboard-card-widget>
 `;

--- a/ui/src/lib/board/widgets/workboard-widget.ts
+++ b/ui/src/lib/board/widgets/workboard-widget.ts
@@ -20,6 +20,7 @@ export abstract class WorkboardWidgetElement extends OpenClawLightDomElement {
 
   @property({ attribute: false }) widget?: BoardViewWidget;
   @property({ attribute: false }) sessionKey = "";
+  @property({ type: Boolean }) canMutate = true;
   @property({ attribute: false }) hostRequestUpdate?: () => void;
 
   protected cards: WorkboardCard[] = [];
@@ -29,7 +30,7 @@ export abstract class WorkboardWidgetElement extends OpenClawLightDomElement {
   protected error = "";
   private loadAttempted = false;
 
-  private readonly workboardHost: WorkboardHost = {};
+  private workboardHost: WorkboardHost = {};
   private client: GatewayBrowserClient | null = null;
   private refreshGeneration = 0;
   private refreshPromise: Promise<void> | null = null;
@@ -68,6 +69,7 @@ export abstract class WorkboardWidgetElement extends OpenClawLightDomElement {
     this.refreshPromise = null;
     this.refreshPending = false;
     this.client = null;
+    this.workboardHost = {};
     this.loaded = false;
     this.loadAttempted = false;
     this.loading = false;
@@ -92,10 +94,11 @@ export abstract class WorkboardWidgetElement extends OpenClawLightDomElement {
 
   protected async moveCard(card: WorkboardCard, status: WorkboardStatus): Promise<void> {
     const client = this.client;
-    if (!client || card.status === status) {
+    if (!client || !this.canMutate || card.status === status) {
       return;
     }
-    const state = getWorkboardState(this.workboardHost);
+    const host = this.workboardHost;
+    const state = getWorkboardState(host);
     state.cards = [...this.cards];
     state.statuses = this.statuses;
     state.loaded = true;
@@ -109,14 +112,20 @@ export abstract class WorkboardWidgetElement extends OpenClawLightDomElement {
           .map((candidate) => candidate.position),
       ) + 1;
     await moveWorkboardCard({
-      host: this.workboardHost,
+      host,
       client,
       cardId: card.id,
       status,
       position,
-      requestUpdate: () => this.syncFromHost(),
+      requestUpdate: () => {
+        if (this.client === client && this.workboardHost === host) {
+          this.syncFromHost();
+        }
+      },
     });
-    this.syncFromHost();
+    if (this.client === client && this.workboardHost === host) {
+      this.syncFromHost();
+    }
   }
 
   private syncGateway(snapshot: ApplicationContext["gateway"]["snapshot"] | undefined): void {
@@ -125,6 +134,9 @@ export abstract class WorkboardWidgetElement extends OpenClawLightDomElement {
       return;
     }
     this.client = nextClient;
+    // Pending mutation state belongs to its connection; never let its completion
+    // block or replace cards loaded through the next Gateway client.
+    this.workboardHost = {};
     this.refreshGeneration += 1;
     this.refreshPromise = null;
     this.refreshPending = false;

--- a/ui/src/lib/board/widgets/workboard.test.ts
+++ b/ui/src/lib/board/widgets/workboard.test.ts
@@ -145,6 +145,104 @@ describe("Workboard plugin widgets", () => {
     );
   });
 
+  it("does not offer or issue status changes for a read-only card widget", async () => {
+    const request = vi.fn(async (method: string) => {
+      if (method === "workboard.cards.list") {
+        return { cards, statuses: ["ready", "running", "done"] };
+      }
+      throw new Error(`Unexpected method: ${method}`);
+    });
+    const element = document.createElement("openclaw-workboard-card-widget");
+    element.widget = pluginWidget("workboard:card", { cardId: "card-ready" });
+    element.sessionKey = "agent:main:test";
+    Reflect.set(element, "canMutate", false);
+
+    await mount(element, createContext(request), request);
+
+    const select = element.querySelector("select");
+    expect(select).not.toBeNull();
+    expect(select?.disabled).toBe(true);
+    if (select) {
+      select.value = "running";
+      select.dispatchEvent(new Event("change"));
+    }
+    expect(request).not.toHaveBeenCalledWith("workboard.cards.move", expect.anything());
+  });
+
+  it("ignores a stale card move after the gateway connection changes", async () => {
+    const staleMove = deferred<unknown>();
+    const staleRequest = vi.fn(async (method: string) => {
+      if (method === "workboard.cards.list") {
+        return { cards, statuses: ["ready", "running", "done"] };
+      }
+      if (method === "workboard.cards.move") {
+        return await staleMove.promise;
+      }
+      throw new Error(`Unexpected method: ${method}`);
+    });
+    const currentCard = { ...cards[0], title: "Current connection card" };
+    const currentRequest = vi.fn(async (method: string) => {
+      if (method === "workboard.cards.list") {
+        return { cards: [currentCard], statuses: ["ready", "running", "done"] };
+      }
+      if (method === "workboard.cards.move") {
+        return { card: { ...currentCard, status: "running", position: 0 } };
+      }
+      throw new Error(`Unexpected method: ${method}`);
+    });
+    const element = document.createElement("openclaw-workboard-card-widget");
+    element.widget = pluginWidget("workboard:card", { cardId: "card-ready" });
+    element.sessionKey = "agent:main:test";
+    const provider = createApplicationContextProvider(createContext(staleRequest));
+    provider.append(element);
+    document.body.append(provider);
+    await vi.waitFor(() => expect(element.textContent).toContain("Ready card"));
+
+    const select = element.querySelector("select");
+    expect(select).not.toBeNull();
+    if (select) {
+      select.value = "running";
+      select.dispatchEvent(new Event("change"));
+    }
+    await vi.waitFor(() =>
+      expect(staleRequest).toHaveBeenCalledWith("workboard.cards.move", {
+        id: "card-ready",
+        status: "running",
+        position: 2,
+      }),
+    );
+    const moveCallIndex = staleRequest.mock.calls.findIndex(
+      ([method]) => method === "workboard.cards.move",
+    );
+    const pendingMove = staleRequest.mock.results[moveCallIndex]?.value as Promise<unknown>;
+
+    provider.setContext(createContext(currentRequest));
+    await vi.waitFor(() => expect(element.textContent).toContain("Current connection card"));
+    const currentSelect = element.querySelector("select");
+    expect(currentSelect).not.toBeNull();
+    if (currentSelect) {
+      currentSelect.value = "running";
+      currentSelect.dispatchEvent(new Event("change"));
+    }
+    await vi.waitFor(() =>
+      expect(currentRequest).toHaveBeenCalledWith("workboard.cards.move", {
+        id: "card-ready",
+        status: "running",
+        position: 0,
+      }),
+    );
+    staleMove.resolve({
+      card: { ...cards[0], title: "Stale connection card", status: "running", position: 2 },
+    });
+    await pendingMove;
+    await Promise.resolve();
+    await element.updateComplete;
+
+    expect(element.textContent).toContain("Current connection card");
+    expect(element.textContent).not.toContain("Stale connection card");
+    expect(element.querySelector("select")?.value).toBe("running");
+  });
+
   it("does not render or move an archived card", async () => {
     const archivedCard = {
       ...cards[0],


### PR DESCRIPTION
Closes #114683
Closes #114684

## What Problem This Solves

Fixes an issue where users viewing a read-only session dashboard or read-only Workboard card widget could change the visible card status and trigger a Gateway write that their connection cannot perform. Also fixes a reconnect race where an earlier card move could block or overwrite the card already loaded by the replacement Gateway connection.

## Why This Change Was Made

Carry the existing effective board/widget mutation capability through the internal first-party widget renderer, disable the read-only status selector, and enforce the same boundary inside the actual mutation owner. Isolate mutation state by Gateway connection and discard old completion callbacks so the current connection remains authoritative. This does not change Gateway authorization, plugin APIs, protocol, persisted configuration, or card data.

## User Impact

Read-only users retain a fully visible dashboard and accurate card status without being offered an impossible action. After reconnecting, operators can immediately move the current card without an earlier request replacing it.

## Evidence

- Proved the original failures first: read-only parent board; independently read-only card widget; and a deferred move from a disconnected Gateway overwriting the replacement card.
- `node scripts/run-vitest.mjs ui/src/lib/board/widgets/workboard.test.ts ui/src/lib/board/widgets/index.test.ts ui/src/components/board/board-widget-cell-plugin.test.ts ui/src/components/board/board-view.test.ts`: **58 tests passed**.
- Linux/Chromium Blacksmith: `pnpm test:ui:e2e ui/src/e2e/session-dashboard.e2e.test.ts ui/src/pages/workboard/workboard-routing.e2e.test.ts`: **10 browser scenarios passed**; includes a real read-only `operator.read` handshake, visible dashboard card, disabled status selector, artificially dispatched change, and proof that no mutation RPC is sent.
- Fresh independent autoreview: **clean; no accepted or actionable findings**.
- AI-assisted; Gateway permission ownership verified directly in `extensions/workboard/src/gateway.ts`.