### PR TITLE
refactor(outbound): consolidate fenced cross-channel delivery

### DIFF
--- a/extensions/discord/src/outbound-adapter.ts
+++ b/extensions/discord/src/outbound-adapter.ts
@@ -97,6 +97,40 @@ async function maybeSendDiscordWebhookText(params: {
   return result;
 }
 
+type DiscordOutboundMessageContext = Parameters<NonNullable<ChannelOutboundAdapter["sendText"]>>[0];
+
+async function resolveDiscordOutboundMessageSend(params: DiscordOutboundMessageContext) {
+  const send =
+    resolveOutboundSendDep<DiscordSendFn>(params.deps, "discord") ??
+    (await loadDiscordSendRuntime()).sendMessageDiscord;
+  const reply = resolveDiscordReplyReference({
+    replyToId: params.replyToId,
+    replyToIdSource: params.replyToIdSource,
+    replyToMode: params.replyToMode,
+  });
+  return {
+    send,
+    target: resolveDiscordOutboundTarget({ to: params.to, threadId: params.threadId }),
+    options: {
+      verbose: false as const,
+      reply,
+      accountId: params.accountId ?? undefined,
+      silent: params.silent ?? undefined,
+      cfg: params.cfg,
+      ...resolveDiscordFormattingOptions({ formatting: params.formatting }),
+      onDeliveryResult: params.onDeliveryResult
+        ? async (
+            result: Parameters<
+              NonNullable<NonNullable<Parameters<DiscordSendFn>[2]>["onDeliveryResult"]>
+            >[0],
+          ) => {
+            await params.onDeliveryResult?.(attachChannelToResult("discord", result));
+          }
+        : undefined,
+    },
+  };
+}
+
 export const discordOutbound: ChannelOutboundAdapter = {
   deliveryMode: "direct",
   chunker: (text, limit, ctx) =>
@@ -134,144 +168,51 @@ export const discordOutbound: ChannelOutboundAdapter = {
     }),
   ...createAttachedChannelResultAdapter({
     channel: "discord",
-    sendText: async ({
-      cfg,
-      to,
-      text,
-      accountId,
-      deps,
-      replyToId,
-      replyToIdSource,
-      replyToMode,
-      threadId,
-      identity,
-      silent,
-      formatting,
-      onDeliveryResult,
-    }) => {
-      if (!silent) {
+    sendText: async (ctx) => {
+      if (!ctx.silent) {
         const webhookResult = await maybeSendDiscordWebhookText({
-          cfg,
-          text,
-          threadId,
-          accountId,
-          identity,
-          replyToId,
+          cfg: ctx.cfg,
+          text: ctx.text,
+          threadId: ctx.threadId,
+          accountId: ctx.accountId,
+          identity: ctx.identity,
+          replyToId: ctx.replyToId,
         }).catch(() => null);
         if (webhookResult) {
           return webhookResult;
         }
       }
-      const send =
-        resolveOutboundSendDep<DiscordSendFn>(deps, "discord") ??
-        (await loadDiscordSendRuntime()).sendMessageDiscord;
-      return await send(resolveDiscordOutboundTarget({ to, threadId }), text, {
-        verbose: false,
-        reply: resolveDiscordReplyReference({
-          replyToId,
-          replyToIdSource,
-          replyToMode,
-        }),
-        accountId: accountId ?? undefined,
-        silent: silent ?? undefined,
-        cfg,
-        ...resolveDiscordFormattingOptions({ formatting }),
-        onDeliveryResult: onDeliveryResult
-          ? async (result) => {
-              await onDeliveryResult(attachChannelToResult("discord", result));
-            }
-          : undefined,
-      });
+      const { send, target, options } = await resolveDiscordOutboundMessageSend(ctx);
+      return await send(target, ctx.text, options);
     },
-    sendMedia: async ({
-      cfg,
-      to,
-      text,
-      mediaUrl,
-      audioAsVoice,
-      mediaAccess,
-      mediaLocalRoots,
-      mediaReadFile,
-      accountId,
-      deps,
-      replyToId,
-      replyToIdSource,
-      replyToMode,
-      threadId,
-      silent,
-      formatting,
-      onDeliveryResult,
-    }) => {
-      const send =
-        resolveOutboundSendDep<DiscordSendFn>(deps, "discord") ??
-        (await loadDiscordSendRuntime()).sendMessageDiscord;
-      const target = resolveDiscordOutboundTarget({ to, threadId });
-      const formattingOptions = resolveDiscordFormattingOptions({ formatting });
-      const reply = resolveDiscordReplyReference({
-        replyToId,
-        replyToIdSource,
-        replyToMode,
-      });
-      if (audioAsVoice && mediaUrl) {
+    sendMedia: async (ctx) => {
+      const { send, target, options } = await resolveDiscordOutboundMessageSend(ctx);
+      if (ctx.audioAsVoice && ctx.mediaUrl) {
         const sendVoice =
-          resolveOutboundSendDep<DiscordVoiceSendFn>(deps, "discordVoice") ??
+          resolveOutboundSendDep<DiscordVoiceSendFn>(ctx.deps, "discordVoice") ??
           (await loadDiscordSendRuntime()).sendVoiceMessageDiscord;
-        return await sendVoice(target, mediaUrl, {
-          cfg,
-          reply,
-          accountId: accountId ?? undefined,
-          silent: silent ?? undefined,
+        return await sendVoice(target, ctx.mediaUrl, {
+          cfg: ctx.cfg,
+          reply: options.reply,
+          accountId: ctx.accountId ?? undefined,
+          silent: ctx.silent ?? undefined,
         });
       }
-      if (text.trim() && mediaUrl && isLikelyDiscordVideoMedia(mediaUrl)) {
-        await send(target, text, {
-          verbose: false,
-          reply,
-          accountId: accountId ?? undefined,
-          silent: silent ?? undefined,
-          cfg,
-          ...formattingOptions,
-          onDeliveryResult: onDeliveryResult
-            ? async (result) => {
-                await onDeliveryResult(attachChannelToResult("discord", result));
-              }
-            : undefined,
-        });
+      const mediaOptions = {
+        ...options,
+        mediaUrl: ctx.mediaUrl,
+        mediaAccess: ctx.mediaAccess,
+        mediaLocalRoots: ctx.mediaLocalRoots,
+        mediaReadFile: ctx.mediaReadFile,
+      };
+      if (ctx.text.trim() && ctx.mediaUrl && isLikelyDiscordVideoMedia(ctx.mediaUrl)) {
+        await send(target, ctx.text, options);
         return await send(target, "", {
-          verbose: false,
-          mediaUrl,
-          reply: reply?.scope === "all" ? reply : undefined,
-          mediaAccess,
-          mediaLocalRoots,
-          mediaReadFile,
-          accountId: accountId ?? undefined,
-          silent: silent ?? undefined,
-          cfg,
-          ...formattingOptions,
-          onDeliveryResult: onDeliveryResult
-            ? async (result) => {
-                await onDeliveryResult(attachChannelToResult("discord", result));
-              }
-            : undefined,
+          ...mediaOptions,
+          reply: options.reply?.scope === "all" ? options.reply : undefined,
         });
       }
-      return await send(target, text, {
-        verbose: false,
-        mediaUrl,
-        mediaAccess,
-        mediaLocalRoots,
-        mediaReadFile,
-        reply,
-        accountId: accountId ?? undefined,
-        silent: silent ?? undefined,
-        cfg,
-        ...formattingOptions,
-        onDeliveryResult: onDeliveryResult
-          ? async (result) => {
-              await onDeliveryResult(attachChannelToResult("discord", result));
-            }
-          : undefined,
-      });
+      return await send(target, ctx.text, mediaOptions);
     },
     sendPoll: async ({ cfg, to, poll, accountId, threadId, silent }) =>
       await (

--- a/extensions/slack/src/outbound-adapter.ts
+++ b/extensions/slack/src/outbound-adapter.ts
@@ -212,66 +212,8 @@ async function sendSlackOutboundMessage(params: {
 function createSlackAttachedSendAdapter() {
   return createAttachedChannelResultAdapter({
     channel: "slack",
-    sendText: async ({
-      cfg,
-      to,
-      text,
-      accountId,
-      deps,
-      replyToId,
-      threadId,
-      identity,
-      deliveryQueueId,
-      onPlatformSendDispatch,
-      onDeliveryResult,
-    }) =>
-      await sendSlackOutboundMessage({
-        cfg,
-        to,
-        text,
-        accountId,
-        deps,
-        replyToId,
-        threadId,
-        identity,
-        deliveryQueueId,
-        onPlatformSendDispatch,
-        onDeliveryResult,
-      }),
-    sendMedia: async ({
-      cfg,
-      to,
-      text,
-      mediaUrl,
-      mediaAccess,
-      mediaLocalRoots,
-      mediaReadFile,
-      accountId,
-      deps,
-      replyToId,
-      threadId,
-      identity,
-      deliveryQueueId,
-      onPlatformSendDispatch,
-      onDeliveryResult,
-    }) =>
-      await sendSlackOutboundMessage({
-        cfg,
-        to,
-        text,
-        mediaUrl,
-        mediaAccess,
-        mediaLocalRoots,
-        mediaReadFile,
-        accountId,
-        deps,
-        replyToId,
-        threadId,
-        identity,
-        deliveryQueueId,
-        onPlatformSendDispatch,
-        onDeliveryResult,
-      }),
+    sendText: sendSlackOutboundMessage,
+    sendMedia: sendSlackOutboundMessage,
   });
 }
 
@@ -345,34 +287,20 @@ export const slackOutbound: ChannelOutboundAdapter = {
         mediaUrls,
         send: async ({ text, mediaUrl }) =>
           await sendSlackOutboundMessage({
-            cfg: ctx.cfg,
-            to: ctx.to,
+            ...ctx,
             text,
             mediaUrl,
-            mediaAccess: ctx.mediaAccess,
-            mediaLocalRoots: ctx.mediaLocalRoots,
-            mediaReadFile: ctx.mediaReadFile,
-            accountId: ctx.accountId,
-            deps: ctx.deps,
-            replyToId: ctx.replyToId,
-            threadId: ctx.threadId,
-            identity: ctx.identity,
             deliveryQueueId: useSingleDeliveryMarker ? ctx.deliveryQueueId : undefined,
             onPlatformSendDispatch: useSingleDeliveryMarker
               ? ctx.onPlatformSendDispatch
               : undefined,
-            onDeliveryResult: ctx.onDeliveryResult,
           }),
         finalize: async () => {
           let lastResult: Awaited<ReturnType<SlackSendFn>> | undefined;
           for (const message of deliveryMessages) {
             lastResult = await sendSlackOutboundMessage({
-              cfg: ctx.cfg,
-              to: ctx.to,
+              ...ctx,
               text: message.text,
-              mediaAccess: ctx.mediaAccess,
-              mediaLocalRoots: ctx.mediaLocalRoots,
-              mediaReadFile: ctx.mediaReadFile,
               ...(message.blocks ? { blocks: message.blocks } : {}),
               ...(message.authoredTextPlacement
                 ? { authoredTextPlacement: message.authoredTextPlacement }
@@ -381,16 +309,10 @@ export const slackOutbound: ChannelOutboundAdapter = {
                 ? { nativeDataFallbackBaseText: message.nativeDataFallbackBaseText }
                 : {}),
               ...(message.textIsSlackPlainText ? { textIsSlackPlainText: true } : {}),
-              accountId: ctx.accountId,
-              deps: ctx.deps,
-              replyToId: ctx.replyToId,
-              threadId: ctx.threadId,
-              identity: ctx.identity,
               deliveryQueueId: useSingleDeliveryMarker ? ctx.deliveryQueueId : undefined,
               onPlatformSendDispatch: useSingleDeliveryMarker
                 ? ctx.onPlatformSendDispatch
                 : undefined,
-              onDeliveryResult: ctx.onDeliveryResult,
             });
           }
           if (!lastResult) {

--- a/src/gateway/server-restart-sentinel-notice.test.ts
+++ b/src/gateway/server-restart-sentinel-notice.test.ts
@@ -3,8 +3,10 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import { getDeliveryQueueEntryStatus } from "../infra/delivery-queue-sqlite.js";
 import { PlatformMessageNotDispatchedError } from "../infra/outbound/deliver-types.js";
-import { loadPendingDelivery } from "../infra/outbound/delivery-queue-storage.js";
-import { markDeliveryPlatformSendAttemptStarted } from "../infra/outbound/delivery-queue.js";
+import {
+  loadPendingDelivery,
+  markDeliveryPlatformSendAttemptStarted,
+} from "../infra/outbound/delivery-queue-storage.js";
 import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
 import { captureEnv, setTestEnvValue } from "../test-utils/env.js";
 

--- a/src/infra/outbound/deliver-contracts.ts
+++ b/src/infra/outbound/deliver-contracts.ts
@@ -15,7 +15,7 @@ import type { DurableDeliveryCompletion } from "./delivery-completion.js";
 import type {
   QueuedReplyPayloadSendingHook,
   QueuedRenderedMessageBatchPlan,
-} from "./delivery-queue.js";
+} from "./delivery-queue-storage.js";
 import type { OutboundDeliveryFormattingOptions } from "./formatting.js";
 import type { OutboundIdentity } from "./identity.js";
 import type { OutboundMessageSendOverrides } from "./message-plan.js";

--- a/src/infra/outbound/deliver-queue-state.ts
+++ b/src/infra/outbound/deliver-queue-state.ts
@@ -5,10 +5,11 @@ import type { OutboundDeliveryQueuePolicy, PlatformSendRoute } from "./deliver-c
 import { OutboundDeliveryError } from "./deliver-types.js";
 import {
   ackDelivery,
+  failDelivery,
   failDeliveryAfterPlatformSend,
   markDeliveryPlatformOutcomeUnknown,
   markDeliveryPlatformSendAttemptStarted,
-} from "./delivery-queue.js";
+} from "./delivery-queue-storage.js";
 
 const log = createSubsystemLogger("outbound/deliver");
 
@@ -22,6 +23,45 @@ export const isDeliveryAbortError = (err: unknown): boolean =>
 export type QueuedPostSendState = "marked" | "acked" | "failed";
 
 export type QueuedPreSendState = "marked" | "acked";
+
+type QueuedDeliveryFailureRecorder = typeof failDelivery | typeof failDeliveryAfterPlatformSend;
+
+/** Keeps live and recovered queue transitions on the same producer claim. */
+export function createQueuedDeliveryOwner(params: {
+  queueId: string;
+  stateDir?: string;
+  expectedPlatformSendAttemptId?: string | null | (() => string | null | undefined);
+}) {
+  const resolveExpectedPlatformSendAttemptId = () =>
+    typeof params.expectedPlatformSendAttemptId === "function"
+      ? params.expectedPlatformSendAttemptId()
+      : params.expectedPlatformSendAttemptId;
+  return {
+    ack(options?: Parameters<typeof ackDelivery>[2]): Promise<void> {
+      const expectedPlatformSendAttemptId = resolveExpectedPlatformSendAttemptId();
+      if (expectedPlatformSendAttemptId !== undefined) {
+        return ackDelivery(params.queueId, params.stateDir, {
+          ...options,
+          expectedPlatformSendAttemptId,
+        });
+      }
+      return options
+        ? ackDelivery(params.queueId, params.stateDir, options)
+        : params.stateDir !== undefined
+          ? ackDelivery(params.queueId, params.stateDir)
+          : ackDelivery(params.queueId);
+    },
+    fail(record: QueuedDeliveryFailureRecorder, error: string): Promise<void> {
+      const expectedPlatformSendAttemptId = resolveExpectedPlatformSendAttemptId();
+      if (expectedPlatformSendAttemptId !== undefined) {
+        return record(params.queueId, error, params.stateDir, expectedPlatformSendAttemptId);
+      }
+      return params.stateDir !== undefined
+        ? record(params.queueId, error, params.stateDir)
+        : record(params.queueId, error);
+    },
+  };
+}
 
 export async function persistQueuedPreSendState(params: {
   queueId: string;
@@ -69,13 +109,23 @@ export async function persistQueuedPostSendState(params: {
   queuePolicy: OutboundDeliveryQueuePolicy;
   stateDir?: string;
   producerClaimId?: string;
+  expectedPlatformSendAttemptId?: string | null;
+  retainSpoolArtifacts?: boolean;
+  onPostSendMarkerError?: (error: unknown) => void;
 }): Promise<QueuedPostSendState> {
+  const expectedPlatformSendAttemptId =
+    params.producerClaimId ?? params.expectedPlatformSendAttemptId;
+  const owner = createQueuedDeliveryOwner({
+    queueId: params.queueId,
+    stateDir: params.stateDir,
+    expectedPlatformSendAttemptId,
+  });
   try {
-    if (params.producerClaimId) {
+    if (expectedPlatformSendAttemptId !== undefined) {
       await markDeliveryPlatformOutcomeUnknown(
         params.queueId,
         params.stateDir,
-        params.producerClaimId,
+        expectedPlatformSendAttemptId,
       );
     } else if (params.stateDir !== undefined) {
       await markDeliveryPlatformOutcomeUnknown(params.queueId, params.stateDir);
@@ -95,27 +145,20 @@ export async function persistQueuedPostSendState(params: {
       );
       return "failed";
     }
+    params.onPostSendMarkerError?.(markErr);
     log.warn(
       `failed to mark queued delivery ${params.queueId} as platform-outcome-unknown; falling back to direct ack (${params.queuePolicy}): ${formatErrorMessage(markErr)}`,
     );
     try {
       // The platform already returned a result. If state marking is unavailable,
       // deleting the intent is safer than leaving it replayable.
-      if (params.stateDir !== undefined) {
-        await ackDelivery(params.queueId, params.stateDir);
-      } else {
-        await ackDelivery(params.queueId);
-      }
+      await owner.ack(params.retainSpoolArtifacts ? { retainSpoolArtifacts: true } : undefined);
       return "acked";
     } catch (ackErr: unknown) {
       const error = `post-send state persistence failed: marker=${formatErrorMessage(markErr)}; ack=${formatErrorMessage(ackErr)}`;
       // Keep the evidence in the same canonical row if both primary state
       // transitions fail; a generic failure update would make it replayable.
-      if (params.stateDir !== undefined) {
-        await failDeliveryAfterPlatformSend(params.queueId, error, params.stateDir);
-      } else {
-        await failDeliveryAfterPlatformSend(params.queueId, error);
-      }
+      await owner.fail(failDeliveryAfterPlatformSend, error);
       return "failed";
     }
   }

--- a/src/infra/outbound/deliver-queue.ts
+++ b/src/infra/outbound/deliver-queue.ts
@@ -14,6 +14,7 @@ import {
   stageAndEnqueueOutboundDelivery,
 } from "./deliver-queue-admission.js";
 import {
+  createQueuedDeliveryOwner,
   isDeliveryAbortError,
   persistQueuedPostSendState,
   persistQueuedPreSendState,
@@ -33,7 +34,6 @@ import {
 } from "./delivery-completion.js";
 import { loadPendingDelivery } from "./delivery-queue-storage.js";
 import {
-  ackDelivery,
   claimDeliveryPlatformSendAttempt,
   failDelivery,
   failDeliveryAfterPlatformSend,
@@ -198,29 +198,26 @@ async function deliverOutboundPayloadsWithQueueCleanup(
   let platformSendRoute: PlatformSendRoute | undefined;
   let deliveredResults: OutboundDeliveryResult[] = [];
   let commitHooksRun = false;
+  const queueOwner = queueId
+    ? createQueuedDeliveryOwner({
+        queueId,
+        expectedPlatformSendAttemptId: () => producerClaimId,
+      })
+    : undefined;
   const ackOwnedQueue = (options?: { suppressCompletionReceipt?: boolean }) => {
-    if (!queueId) {
+    if (!queueOwner) {
       throw new Error("Queued delivery acknowledgement requires a queue id");
     }
-    return producerClaimId
-      ? ackDelivery(queueId, undefined, {
-          ...options,
-          expectedPlatformSendAttemptId: producerClaimId,
-        })
-      : options
-        ? ackDelivery(queueId, undefined, options)
-        : ackDelivery(queueId);
+    return queueOwner.ack(options);
   };
   const recordOwnedQueueFailure = (
     record: typeof failDelivery | typeof failDeliveryAfterPlatformSend,
     error: string,
   ) => {
-    if (!queueId) {
+    if (!queueOwner) {
       throw new Error("Queued delivery failure requires a queue id");
     }
-    return producerClaimId
-      ? record(queueId, error, undefined, producerClaimId)
-      : record(queueId, error);
+    return queueOwner.fail(record, error);
   };
   const persistOwnedPostSendState = () => {
     if (!queueId) {

--- a/src/infra/outbound/deliver.test.ts
+++ b/src/infra/outbound/deliver.test.ts
@@ -113,7 +113,7 @@ vi.mock("../../hooks/internal-hooks.js", () => ({
   createInternalHookEvent: internalHookMocks.createInternalHookEvent,
   triggerInternalHook: internalHookMocks.triggerInternalHook,
 }));
-vi.mock("./delivery-queue.js", () => ({
+vi.mock("./delivery-queue-storage.js", () => ({
   enqueueDelivery: queueMocks.enqueueDelivery,
   enqueueDeliveryOnce: queueMocks.enqueueDeliveryOnce,
   ackDelivery: queueMocks.ackDelivery,
@@ -123,6 +123,15 @@ vi.mock("./delivery-queue.js", () => ({
   markDeliveryPlatformOutcomeUnknown: queueMocks.markDeliveryPlatformOutcomeUnknown,
   markDeliveryPlatformSendDispatched: queueMocks.markDeliveryPlatformSendDispatched,
   markDeliveryPlatformSendAttemptStarted: queueMocks.markDeliveryPlatformSendAttemptStarted,
+}));
+vi.mock("./delivery-queue.js", () => ({
+  enqueueDelivery: queueMocks.enqueueDelivery,
+  enqueueDeliveryOnce: queueMocks.enqueueDeliveryOnce,
+  ackDelivery: queueMocks.ackDelivery,
+  failDelivery: queueMocks.failDelivery,
+  failDeliveryAfterPlatformSend: queueMocks.failDeliveryAfterPlatformSend,
+  failDeliveryBeforePlatformSend: queueMocks.failDeliveryBeforePlatformSend,
+  markDeliveryPlatformSendDispatched: queueMocks.markDeliveryPlatformSendDispatched,
   withActiveDeliveryClaim: queueMocks.withActiveDeliveryClaim,
 }));
 vi.mock("./delivery-completion.js", () => ({

--- a/src/infra/outbound/delivery-queue-recovery.ts
+++ b/src/infra/outbound/delivery-queue-recovery.ts
@@ -21,6 +21,11 @@ import { formatErrorMessage } from "../errors.js";
 import { resolveOutboundChannelMessageAdapter } from "./channel-resolution.js";
 import { resolveDeferredDeliveryAdmission } from "./deferred-delivery-admission.js";
 import {
+  createQueuedDeliveryOwner,
+  persistQueuedPostSendState,
+  type QueuedPostSendState,
+} from "./deliver-queue-state.js";
+import {
   isOutboundDeliveryError,
   type OutboundDeliveryResult,
   type OutboundPayloadDeliveryOutcome,
@@ -42,7 +47,6 @@ import {
   createDeliveryQueueMediaRecoveryLease,
 } from "./delivery-queue-media-staging.js";
 import {
-  ackDelivery,
   claimDeliveryPlatformSendAttempt,
   failDelivery,
   failDeliveryAfterPlatformSend,
@@ -50,7 +54,6 @@ import {
   failPendingDelivery,
   loadPendingDelivery,
   loadPendingDeliveries,
-  markDeliveryPlatformOutcomeUnknown,
   moveToFailed,
   reserveDeliveryAttempt,
   type QueuedDelivery,
@@ -442,17 +445,11 @@ async function ackRecoveredDelivery(
   options?: { retainSpoolArtifacts?: boolean; suppressCompletionReceipt?: boolean },
   claimedAttemptId?: string,
 ): Promise<void> {
-  const attemptId = recoveryPlatformAttemptId(entry, claimedAttemptId);
-  if (attemptId !== undefined) {
-    await ackDelivery(entry.id, stateDir, {
-      ...options,
-      expectedPlatformSendAttemptId: attemptId,
-    });
-  } else if (options) {
-    await ackDelivery(entry.id, stateDir, options);
-  } else {
-    await ackDelivery(entry.id, stateDir);
-  }
+  await createQueuedDeliveryOwner({
+    queueId: entry.id,
+    stateDir,
+    expectedPlatformSendAttemptId: recoveryPlatformAttemptId(entry, claimedAttemptId),
+  }).ack(options);
 }
 
 async function recordRecoveredFailure(
@@ -462,12 +459,11 @@ async function recordRecoveredFailure(
   stateDir?: string,
   claimedAttemptId?: string,
 ): Promise<void> {
-  const attemptId = recoveryPlatformAttemptId(entry, claimedAttemptId);
-  if (attemptId !== undefined) {
-    await record(entry.id, error, stateDir, attemptId);
-  } else {
-    await record(entry.id, error, stateDir);
-  }
+  await createQueuedDeliveryOwner({
+    queueId: entry.id,
+    stateDir,
+    expectedPlatformSendAttemptId: recoveryPlatformAttemptId(entry, claimedAttemptId),
+  }).fail(record, error);
 }
 
 function markDurableDeliveryFailedBestEffort(entry: QueuedDelivery, log: RecoveryLogger): void {
@@ -587,51 +583,22 @@ async function persistRecoveredPostSendState(opts: {
   log: RecoveryLogger;
   stateDir?: string;
   producerClaimId?: string;
-}): Promise<"marked" | "acked" | "failed"> {
-  try {
-    const attemptId = recoveryPlatformAttemptId(opts.entry, opts.producerClaimId);
-    if (attemptId !== undefined) {
-      await markDeliveryPlatformOutcomeUnknown(opts.entry.id, opts.stateDir, attemptId);
-    } else {
-      await markDeliveryPlatformOutcomeUnknown(opts.entry.id, opts.stateDir);
-    }
-    return "marked";
-  } catch (markErr) {
-    if (opts.producerClaimId) {
-      await recordRecoveredFailure(
-        failDeliveryAfterPlatformSend,
-        opts.entry,
-        `post-send state persistence failed: ${formatErrorMessage(markErr)}`,
-        opts.stateDir,
-        opts.producerClaimId,
+}): Promise<QueuedPostSendState> {
+  // Recovery keeps its media lease until the adapter settles, even if the
+  // canonical post-send marker has to finalize the queue with a direct ack.
+  return persistQueuedPostSendState({
+    queueId: opts.entry.id,
+    queuePolicy: opts.entry.queuePolicy ?? "best_effort",
+    stateDir: opts.stateDir,
+    producerClaimId: opts.producerClaimId,
+    expectedPlatformSendAttemptId: recoveryPlatformAttemptId(opts.entry, opts.producerClaimId),
+    retainSpoolArtifacts: true,
+    onPostSendMarkerError: (error) => {
+      opts.log.warn(
+        `Delivery entry ${opts.entry.id} failed to persist post-send state; falling back to direct ack: ${formatErrorMessage(error)}`,
       );
-      return "failed";
-    }
-    // A result proves at least one send completed. If the intermediate marker
-    // is unavailable, direct ack still removes the replayable intent.
-    opts.log.warn(
-      `Delivery entry ${opts.entry.id} failed to persist post-send state; falling back to direct ack: ${formatErrorMessage(markErr)}`,
-    );
-    try {
-      await ackRecoveredDelivery(
-        opts.entry,
-        opts.stateDir,
-        { retainSpoolArtifacts: true },
-        opts.producerClaimId,
-      );
-      return "acked";
-    } catch (ackErr) {
-      const error = `post-send state persistence failed: marker=${formatErrorMessage(markErr)}; ack=${formatErrorMessage(ackErr)}`;
-      await recordRecoveredFailure(
-        failDeliveryAfterPlatformSend,
-        opts.entry,
-        error,
-        opts.stateDir,
-        opts.producerClaimId,
-      );
-      return "failed";
-    }
-  }
+    },
+  });
 }
 
 async function drainQueuedEntry(opts: {
@@ -756,7 +723,7 @@ async function drainQueuedEntry(opts: {
     }
   }
   const payloadOutcomes: OutboundPayloadDeliveryOutcome[] = [];
-  let postSendState: "marked" | "acked" | "failed" | undefined;
+  let postSendState: QueuedPostSendState | undefined;
   let deliveredResults: OutboundDeliveryResult[] = [];
   let commitHooksRun = false;
   const collectResults = (results: readonly OutboundDeliveryResult[]): void => {

--- a/src/infra/outbound/delivery-queue.reconnect-drain.test.ts
+++ b/src/infra/outbound/delivery-queue.reconnect-drain.test.ts
@@ -4,14 +4,17 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { controlNextRecoverySleep } from "../../../test/helpers/infra/delivery-recovery.js";
 import type { OpenClawConfig } from "../../config/config.js";
 import { openOpenClawStateDatabase } from "../../state/openclaw-state-db.js";
-import { loadPendingDeliveries, reserveDeliveryAttempt } from "./delivery-queue-storage.js";
+import {
+  loadPendingDeliveries,
+  markDeliveryPlatformOutcomeUnknown,
+  markDeliveryPlatformSendAttemptStarted,
+  reserveDeliveryAttempt,
+} from "./delivery-queue-storage.js";
 import {
   type DeliverFn,
   drainPendingDeliveries,
   enqueueDelivery,
   failDelivery,
-  markDeliveryPlatformOutcomeUnknown,
-  markDeliveryPlatformSendAttemptStarted,
   type RecoveryLogger,
   recoverPendingDeliveries,
   withActiveDeliveryClaim,

--- a/src/infra/outbound/delivery-queue.recovery.test.ts
+++ b/src/infra/outbound/delivery-queue.recovery.test.ts
@@ -25,18 +25,18 @@ import {
 } from "./deliver-types.js";
 import { attachOutboundDeliveryCommitHook } from "./delivery-commit-hooks.js";
 import { pruneOrphanedDeliveryQueueMedia } from "./delivery-queue-media-spool.js";
-import { loadPendingDeliveries, reserveDeliveryAttempt } from "./delivery-queue-storage.js";
 import {
   ackDelivery,
   claimDeliveryPlatformSendAttempt,
   enqueueDelivery,
   enqueueDeliveryOnce,
+  loadPendingDeliveries,
   markDeliveryPlatformOutcomeUnknown,
   markDeliveryPlatformSendDispatched,
   markDeliveryPlatformSendAttemptStarted,
-  recoverPendingDeliveries,
-  type DeliverFn,
-} from "./delivery-queue.js";
+  reserveDeliveryAttempt,
+} from "./delivery-queue-storage.js";
+import { recoverPendingDeliveries, type DeliverFn } from "./delivery-queue.js";
 import {
   asDeliverFn,
   createRecoveryLog,

--- a/src/infra/outbound/delivery-queue.storage.test.ts
+++ b/src/infra/outbound/delivery-queue.storage.test.ts
@@ -5,13 +5,6 @@ import path from "node:path";
 import { describe, expect, it, vi } from "vitest";
 import { openOpenClawStateDatabase } from "../../state/openclaw-state-db.js";
 import {
-  failPendingDelivery,
-  loadPendingDelivery,
-  loadPendingDeliveries,
-  moveToFailed,
-  reserveDeliveryAttempt,
-} from "./delivery-queue-storage.js";
-import {
   ackDelivery,
   claimDeliveryPlatformSendAttempt,
   enqueueDelivery,
@@ -19,10 +12,15 @@ import {
   failDelivery,
   failDeliveryAfterPlatformSend,
   failDeliveryBeforePlatformSend,
+  failPendingDelivery,
+  loadPendingDelivery,
+  loadPendingDeliveries,
   markDeliveryPlatformOutcomeUnknown,
   markDeliveryPlatformSendDispatched,
   markDeliveryPlatformSendAttemptStarted,
-} from "./delivery-queue.js";
+  moveToFailed,
+  reserveDeliveryAttempt,
+} from "./delivery-queue-storage.js";
 import { installDeliveryQueueTmpDirHooks, readQueuedEntry } from "./delivery-queue.test-helpers.js";
 
 describe("delivery-queue storage", () => {

--- a/src/infra/outbound/delivery-queue.ts
+++ b/src/infra/outbound/delivery-queue.ts
@@ -7,14 +7,9 @@ export {
   failDelivery,
   failDeliveryAfterPlatformSend,
   failDeliveryBeforePlatformSend,
-  markDeliveryPlatformOutcomeUnknown,
   markDeliveryPlatformSendDispatched,
-  markDeliveryPlatformSendAttemptStarted,
 } from "./delivery-queue-storage.js";
-export type {
-  QueuedReplyPayloadSendingHook,
-  QueuedRenderedMessageBatchPlan,
-} from "./delivery-queue-storage.js";
+export type { QueuedReplyPayloadSendingHook } from "./delivery-queue-storage.js";
 export {
   drainPendingDeliveries,
   recoverPendingDeliveries,

--- a/src/infra/outbound/message-action-runner.ts
+++ b/src/infra/outbound/message-action-runner.ts
@@ -26,11 +26,11 @@ import {
   normalizeConversationReadInvocationOrigin,
   type ConversationReadInvocationOrigin,
 } from "../../channels/plugins/conversation-read-origin.js";
-import { getChannelPlugin } from "../../channels/plugins/index.js";
 import { dispatchChannelMessageAction } from "../../channels/plugins/message-action-dispatch.js";
 import type {
   ChannelId,
   ChannelMessageActionName,
+  ChannelPlugin,
   ChannelThreadingToolContext,
 } from "../../channels/plugins/types.public.js";
 import type { InternalChannelThreadingToolContext } from "../../channels/threading-tool-context-internal.js";
@@ -523,9 +523,13 @@ function normalizeTargetForAccountBinding(channel: ChannelId, target: string): s
   }
 }
 
-function inferPeerKindForAccountBinding(channel: ChannelId, target: string): ChatType | undefined {
+function inferPeerKindForAccountBinding(
+  channel: ChannelId,
+  target: string,
+  channelPlugin?: ChannelPlugin,
+): ChatType | undefined {
   const inferred = normalizeChatType(
-    getChannelPlugin(channel)?.messaging?.inferTargetChatType?.({ to: target }),
+    channelPlugin?.messaging?.inferTargetChatType?.({ to: target }),
   );
   if (inferred) {
     return inferred;
@@ -544,6 +548,7 @@ function inferPeerKindForAccountBinding(channel: ChannelId, target: string): Cha
 function resolveTargetBoundAccountId(params: {
   cfg: OpenClawConfig;
   channel: ChannelId;
+  channelPlugin?: ChannelPlugin;
   args: Record<string, unknown>;
   agentId?: string;
 }): string | undefined {
@@ -573,7 +578,7 @@ function resolveTargetBoundAccountId(params: {
     agentId: params.agentId,
     peerId,
     exactPeerIdAliases,
-    peerKind: inferPeerKindForAccountBinding(params.channel, target),
+    peerKind: inferPeerKindForAccountBinding(params.channel, target, params.channelPlugin),
   });
 }
 
@@ -647,6 +652,7 @@ type ResolvedActionContext = {
   cfg: OpenClawConfig;
   params: Record<string, unknown>;
   channel: ChannelId;
+  channelPlugin?: ChannelPlugin;
   mediaAccess: OutboundMediaAccess;
   extraActionMediaSourceParamKeys?: readonly string[];
   accountId?: string | null;
@@ -855,6 +861,7 @@ async function runGatewayPluginMessageActionOrNull(params: {
   cfg: OpenClawConfig;
   params: Record<string, unknown>;
   channel: ChannelId;
+  channelPlugin?: ChannelPlugin;
   action: ChannelMessageActionName;
   accountId?: string | null;
   dryRun: boolean;
@@ -866,11 +873,11 @@ async function runGatewayPluginMessageActionOrNull(params: {
   if (params.dryRun || !params.gateway) {
     return null;
   }
-  const plugin = resolveOutboundChannelPlugin({ channel: params.channel, cfg: params.cfg });
-  if (!plugin?.actions?.handleAction) {
+  if (!params.channelPlugin?.actions?.handleAction) {
     return null;
   }
-  const executionMode = plugin.actions.resolveExecutionMode?.({ action: params.action }) ?? "local";
+  const executionMode =
+    params.channelPlugin.actions.resolveExecutionMode?.({ action: params.action }) ?? "local";
   if (executionMode !== "gateway") {
     return null;
   }
@@ -961,22 +968,6 @@ async function runGatewayPluginMessageActionOrNull(params: {
     }
   }
   return params.result(payload);
-}
-
-function resolveGateway(input: RunMessageActionParams): MessageActionRunnerGateway | undefined {
-  if (!input.gateway) {
-    return undefined;
-  }
-  return {
-    url: input.gateway.url,
-    token: input.gateway.token,
-    timeoutMs: input.gateway.timeoutMs,
-    clientName: input.gateway.clientName,
-    clientDisplayName: input.gateway.clientDisplayName,
-    mode: input.gateway.mode,
-    resolveAgentRuntimeIdentityToken: input.gateway.resolveAgentRuntimeIdentityToken,
-    terminalSourceReplyReceiptOwner: input.gateway.terminalSourceReplyReceiptOwner,
-  };
 }
 
 async function handleBroadcastAction(
@@ -1362,6 +1353,7 @@ async function handleSendAction(ctx: ResolvedActionContext): Promise<MessageActi
     cfg,
     params,
     channel,
+    channelPlugin,
     accountId,
     dryRun,
     gateway,
@@ -1418,7 +1410,7 @@ async function handleSendAction(ctx: ResolvedActionContext): Promise<MessageActi
   resolveAndApplyOutboundReplyToId(params, {
     channel,
     toolContext: input.toolContext,
-    matchesToolContextTarget: getChannelPlugin(channel)?.threading?.matchesToolContextTarget,
+    matchesToolContextTarget: channelPlugin?.threading?.matchesToolContextTarget,
   });
   const { resolvedThreadId, outboundRoute } = await prepareOutboundMirrorRoute({
     cfg,
@@ -1431,8 +1423,8 @@ async function handleSendAction(ctx: ResolvedActionContext): Promise<MessageActi
     currentSessionKey: input.sessionKey,
     dryRun,
     resolvedTarget,
-    resolveAutoThreadId: getChannelPlugin(channel)?.threading?.resolveAutoThreadId,
-    resolveReplyTransport: getChannelPlugin(channel)?.threading?.resolveReplyTransport,
+    resolveAutoThreadId: channelPlugin?.threading?.resolveAutoThreadId,
+    resolveReplyTransport: channelPlugin?.threading?.resolveReplyTransport,
     replyToIsExplicit,
     resolveOutboundSessionRoute,
     ensureOutboundSessionEntry,
@@ -1483,6 +1475,7 @@ async function handleSendAction(ctx: ResolvedActionContext): Promise<MessageActi
         cfg,
         params,
         channel,
+        channelPlugin,
         action,
         accountId,
         dryRun,
@@ -1512,8 +1505,7 @@ async function handleSendAction(ctx: ResolvedActionContext): Promise<MessageActi
   }
 
   const useCorePresentationDelivery = Boolean(
-    sendPayload.payload.presentation &&
-    hasCorePresentationDelivery(resolveOutboundChannelPlugin({ channel, cfg })?.outbound),
+    sendPayload.payload.presentation && hasCorePresentationDelivery(channelPlugin?.outbound),
   );
   if (sendPayload.payload.presentation && !useCorePresentationDelivery) {
     const fallbackMessage = materializeMessagePresentationFallback({
@@ -1621,7 +1613,18 @@ async function handleSendAction(ctx: ResolvedActionContext): Promise<MessageActi
 }
 
 async function handlePollAction(ctx: ResolvedActionContext): Promise<MessageActionRunResult> {
-  const { cfg, params, channel, accountId, dryRun, gateway, input, agentId, abortSignal } = ctx;
+  const {
+    cfg,
+    params,
+    channel,
+    channelPlugin,
+    accountId,
+    dryRun,
+    gateway,
+    input,
+    agentId,
+    abortSignal,
+  } = ctx;
   throwIfAborted(abortSignal);
   const action: ChannelMessageActionName = "poll";
   const to = readStringParam(params, "to", { required: true });
@@ -1632,7 +1635,7 @@ async function handlePollAction(ctx: ResolvedActionContext): Promise<MessageActi
     to,
     accountId,
     toolContext: input.toolContext,
-    resolveAutoThreadId: getChannelPlugin(channel)?.threading?.resolveAutoThreadId,
+    resolveAutoThreadId: channelPlugin?.threading?.resolveAutoThreadId,
   });
 
   const base = typeof params.message === "string" ? params.message : "";
@@ -1653,6 +1656,7 @@ async function handlePollAction(ctx: ResolvedActionContext): Promise<MessageActi
     cfg,
     params,
     channel,
+    channelPlugin,
     action,
     accountId,
     dryRun,
@@ -1735,6 +1739,7 @@ async function handlePluginAction(ctx: ResolvedActionContext): Promise<MessageAc
     cfg,
     params,
     channel,
+    channelPlugin,
     mediaAccess,
     accountId,
     dryRun,
@@ -1756,8 +1761,7 @@ async function handlePluginAction(ctx: ResolvedActionContext): Promise<MessageAc
     };
   }
 
-  const plugin = resolveOutboundChannelPlugin({ channel, cfg });
-  if (!plugin?.actions?.handleAction) {
+  if (!channelPlugin?.actions?.handleAction) {
     throw new Error(`Channel ${channel} is unavailable for message actions (plugin not loaded).`);
   }
 
@@ -1771,8 +1775,8 @@ async function handlePluginAction(ctx: ResolvedActionContext): Promise<MessageAc
       to: targetForThreading,
       accountId,
       toolContext: input.toolContext,
-      resolveAutoThreadId: plugin.threading?.resolveAutoThreadId,
-      resolveReplyTransport: plugin.threading?.resolveReplyTransport,
+      resolveAutoThreadId: channelPlugin.threading?.resolveAutoThreadId,
+      resolveReplyTransport: channelPlugin.threading?.resolveReplyTransport,
       replyToIsExplicit: Boolean(readStringParam(params, "replyTo")),
     });
   }
@@ -1781,6 +1785,7 @@ async function handlePluginAction(ctx: ResolvedActionContext): Promise<MessageAc
     cfg,
     params,
     channel,
+    channelPlugin,
     action,
     accountId,
     dryRun,
@@ -1893,13 +1898,14 @@ export async function runMessageAction(
     action,
     args: params,
     toolContext: input.toolContext,
-    targetAliasSpec: getChannelPlugin(channel)?.actions?.messageActionTargetAliases?.[action],
+    targetAliasSpec: channelPlugin?.actions?.messageActionTargetAliases?.[action],
   });
   let accountId = readStringParam(params, "accountId") ?? input.defaultAccountId;
   if (!accountId && resolvedAgentId) {
     accountId = resolveTargetBoundAccountId({
       cfg,
       channel,
+      channelPlugin,
       args: params,
       agentId: resolvedAgentId,
     });
@@ -1951,7 +1957,7 @@ export async function runMessageAction(
     sandboxRoot: input.sandboxRoot,
     mediaAccess,
   });
-  const gateway = resolveGateway(input);
+  const gateway = input.gateway;
   const preserveSendBuffer =
     action === "send" &&
     Boolean(gateway) &&
@@ -1998,42 +2004,13 @@ export async function runMessageAction(
     await hydrateActionAttachmentParams();
   }
 
-  if (action === "send") {
-    return handleSendAction({
-      cfg,
-      params,
-      channel,
-      mediaAccess,
-      extraActionMediaSourceParamKeys,
-      accountId,
-      dryRun,
-      gateway,
-      input,
-      agentId: resolvedAgentId,
-      resolvedTarget,
-      abortSignal: input.abortSignal,
-    });
-  }
-
-  if (action === "poll") {
-    return handlePollAction({
-      cfg,
-      params,
-      channel,
-      mediaAccess,
-      extraActionMediaSourceParamKeys,
-      accountId,
-      dryRun,
-      gateway,
-      input,
-      abortSignal: input.abortSignal,
-    });
-  }
-
-  return handlePluginAction({
+  // Channel discovery is process-stable; carry its prepared plugin and route
+  // into every action so handlers cannot rediscover a different transport.
+  const context: ResolvedActionContext = {
     cfg,
     params,
     channel,
+    channelPlugin,
     mediaAccess,
     extraActionMediaSourceParamKeys,
     accountId,
@@ -2041,7 +2018,15 @@ export async function runMessageAction(
     gateway,
     input,
     agentId: resolvedAgentId,
+    resolvedTarget,
     abortSignal: input.abortSignal,
-  });
+  };
+  if (action === "send") {
+    return handleSendAction(context);
+  }
+  if (action === "poll") {
+    return handlePollAction(context);
+  }
+  return handlePluginAction(context);
 }
 /* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */


### PR DESCRIPTION
## What Problem This Solves

Outbound sends, follow-up replies, and crash recovery independently rediscovered channel transport and producer ownership. That duplicated policy increased the risk of stale-attempt acknowledgements, lost recovery media, inconsistent reply threading, and cross-channel delivery.

## Why This Change Was Made

Consolidate durable delivery on one core-owned, claim-fenced queue owner; carry the resolved plugin and route through action dispatch; reuse prepared follow-up source visibility; and keep Slack and Discord responsible only for their native transport behavior. Import queue storage from its canonical owner to prevent recovery facade cycles. Public plugin SDK, provider configuration, Telegram/Feishu/WhatsApp transport policy, and cron source-delivery plans remain unchanged.

## User Impact

More reliable, correctly threaded replies and safer crash recovery across Telegram, Discord, Slack, Feishu, and WhatsApp, with no new configuration or public API. Removes **150 net production lines**: 224 added, 374 deleted across eight production files. Including five regression-test files, the complete 13-file change is 254 additions and 392 deletions (**138 net lines removed**).

## Evidence

- Frozen base: `f0a963a2cb526c574276361ccec847fe97358136`.
- Reviewed head: `a2c6eb832c860799f836a0652b2f5755d1043817`.
- **590 passing tests in 25 files across seven Vitest projects:** all five channel transports, inbound delivery, reply/thread/presentation behavior, fenced queue recovery, unknown platform outcomes, and a real process-death media-recovery test.
- **151 passing queued follow-up tests**, including same-channel fallback, cross-channel isolation, room-event silence, and source-reply visibility.
- Official `pnpm check:changed -- <all five changed core files>` and `pnpm check:changed -- <both changed plugin files>` both passed; together they cover every changed file, all relevant production and test typechecks, formatting, lint, SDK baseline, architecture, and **zero runtime import cycles**.
- Complete production `pnpm build` passed, including bundled plugins, all 143 public SDK subpaths, CLI startup guards, and the packaged control UI.
- Live `pnpm qa:e2e -- --output .artifacts/delivery-refactor-qa.md` passed on the same built remote checkout.
- Fresh exact-base `gpt-5.6-sol`/`xhigh` branch autoreview: **no findings**.
- AI-assisted; reviewed and validated against the complete source and plugin-owner contracts.

## Exact-head rebased delivery and crash-recovery evidence

Final reviewed and hosted-CI-corrected head: `a723fa76ca879977ca4bbe464c8c3dc85de266cb`; frozen rebased main: `52e519220cea9cf91904e927d63d2dc6ff8f8b78`. The actual previous hosted failures `check-dependencies` and `checks-node-compact-small-10` were reproduced from their exact job logs and fixed at their true owner, not bypassed or rerun blindly.

Production contracts import queue types and transition operations from defining `delivery-queue-storage.ts`; only **three proven-unused internal facade re-exports** were removed. All internal delivery, recovery, storage, reconnect, and gateway tests now mock/import that same canonical owner. The facade and `withActiveDeliveryClaim` remain for recovery; the shipped `openclaw/plugin-sdk/delivery-queue-runtime`, package exports, public SDK baseline, config and schema remain unchanged. Current main's canonical 185-line decomposed followup runner is preserved unchanged.

All exact-final-source evidence below comes from one uninterrupted **29m27s** Blacksmith run on `tbx_01kyjjfxbyx09jjjhgz3e5rhxk`; final receipt `runStatus=succeeded, exitCode=0`.

### Exact hosted dependency/export failures fixed

```text
pnpm deadcode:full
production Knip config: PASS
full-tree Knip config: PASS

pnpm deadcode:exports
[deadcode] Knip production unused-export scan passed with 0 entries.
[deadcode] Knip full-tree unused-export scan passed with 0 entries.
[deadcode] Knip script unused-export scan passed with 0 entries.
[deadcode] Knip production and full-tree unused-export checks passed with 0 entries.
```

No ignored names or new suppressions; whole-repository and package-export inspection proves the three removed names were internal and have no production/public SDK consumers.

### Both independent hosted cycle detectors

```text
pnpm check:import-cycles
Import cycle check: 0 runtime value cycle(s).

pnpm check:madge-import-cycles
Madge import cycle check: 0 cycle(s).
```

The static/Madge detector follows type-only imports and is the actual original failing architecture check.

### Complete corrected crash/recovery/compact proof

The expanded whole-file regression command passed **29 specified files across 9 Vitest projects**, including the formerly failing complete `deliver.test.ts`, every recovery/storage/reconnect case, actual process-death media replay, gateway, unchanged public SDK, all five transport channels and the bridge/ingress:

```text
pnpm test \
 src/infra/outbound/deliver.test.ts \
 src/infra/outbound/delivery-queue.storage.test.ts \
 src/infra/outbound/delivery-queue.recovery.test.ts \
 src/infra/outbound/delivery-queue.recovery-backoff.test.ts \
 src/infra/outbound/delivery-queue.reconnect-drain.test.ts \
 src/infra/outbound/deliver.queue-integration.test.ts \
 src/infra/outbound/delivery-queue-media-spool.crash.integration.test.ts \
 src/infra/outbound/message-action-runner.core-send.test.ts \
 src/infra/outbound/message-action-runner.context.test.ts \
 src/infra/outbound/message-action-runner.threading.test.ts \
 src/infra/outbound/message-action-runner.plugin-dispatch.test.ts \
 src/infra/outbound/message-action-runner.media.test.ts \
 src/infra/outbound/message-action-runner.poll.test.ts \
 src/gateway/server-restart-sentinel-notice.test.ts \
 src/plugin-sdk/delivery-queue-runtime.test.ts \
 extensions/slack/src/outbound-adapter.test.ts \
 extensions/slack/src/outbound-delivery.test.ts \
 extensions/slack/src/outbound-payload.test.ts \
 extensions/discord/src/outbound-adapter.test.ts \
 extensions/discord/src/outbound-adapter.interactive-order.test.ts \
 extensions/discord/src/outbound-payload.contract.test.ts \
 extensions/telegram/src/outbound-adapter.test.ts \
 extensions/telegram/src/outbound-adapter.normalize-payload.test.ts \
 extensions/feishu/src/outbound.test.ts \
 extensions/feishu/src/outbound-delivery.test.ts \
 extensions/whatsapp/src/outbound-base.test.ts \
 extensions/whatsapp/src/outbound-adapter.sendpayload.test.ts \
 src/channels/message/ingress-queue.test.ts \
 src/channels/message/outbound-bridge.test.ts

✓ deliver.test.ts (160 tests)
✓ delivery-queue.recovery.test.ts (56 tests)
✓ delivery-queue.storage.test.ts (24 tests)
✓ delivery-queue.reconnect-drain.test.ts (18 tests)
✓ server-restart-sentinel-notice.test.ts (4 tests)
✓ delivery-queue-runtime.test.ts (5 tests)
✓ delivery-queue-media-spool.crash.integration.test.ts (1 test)
  ✓ delivers media enqueued by a process that died before dispatch
✓ never completes bounded recovered Matrix sends without a platform identity
✓ never completes permanent recovered Matrix sends without a platform identity
✓ never completes recovered Matrix batches when any platform send lacks an identity
[test] passed 9 Vitest shards
```

Previous rank-up/P1: live and recovered operations share the canonical queue owner, resolve the current callable attempt at the state transition, retain explicit `null` as an ownership fence, never let a stale producer settle a replacement claim, retain media artifacts while an adapter remains active, and never blindly replay or acknowledge ambiguous/identityless platform sends.

### Full official production + test gates

The following distinct official checks ran serially with `&&`, both succeeded, and their union covers every changed production and test file:

```text
pnpm check:changed -- \
 src/infra/outbound/deliver-contracts.ts \
 src/infra/outbound/deliver-queue-state.ts \
 src/infra/outbound/deliver-queue.ts \
 src/infra/outbound/delivery-queue.ts \
 src/infra/outbound/delivery-queue-recovery.ts \
 src/infra/outbound/message-action-runner.ts \
 src/infra/outbound/deliver.test.ts \
 src/infra/outbound/delivery-queue.reconnect-drain.test.ts \
 src/infra/outbound/delivery-queue.recovery.test.ts \
 src/infra/outbound/delivery-queue.storage.test.ts \
 src/gateway/server-restart-sentinel-notice.test.ts

pnpm check:changed -- \
 extensions/discord/src/outbound-adapter.ts \
 extensions/slack/src/outbound-adapter.ts

blacksmith run summary: exit=0
```

Includes real core/core-test and plugin/plugin-test `tsgo`, every full split-core source/UI/packages lint shard, plugin lint, SDK API baseline and boundary checks, database/schema, conflict, sidecar, pairing, webhook and import-cycle guards.

### Fresh final committed full-branch review

```text
autoreview --mode branch \
 --base 52e519220cea9cf91904e927d63d2dc6ff8f8b78 \
 --engine codex --model gpt-5.6-sol --thinking xhigh
reviewed exact head: a723fa76ca879977ca4bbe464c8c3dc85de266cb
bundle: 44076 bytes
findings: []
overall_correctness: patch is correct
confidence: 0.84
exitCode: 0
```

The reviewer explicitly confirmed no broken producer/platform-attempt fencing, unsafe recovery/replay, media-spool defect, public SDK break, or security regression.

### Live/package proof provenance

The original refactor separately passed a full `pnpm build` and a real started QA Lab `pnpm qa:e2e -- --output .artifacts/delivery-refactor-qa.md` (approximately 3m37s, both exit 0) on pre-rebase parent `a2c6eb832c860799f836a0652b2f5755d1043817`. Those results are not misrepresented as current-head runs. The final head has the real subprocess process-death/media replay, complete 29-file cross-channel proof, actual hosted dead-code gates, full core+plugin gates and both independent topology guards above; protected hosted CI validates the exact final head and merge result.

