### PR TITLE
fix(doctor): keep SQLite state migration and recovery consistent

### DIFF
--- a/src/commands/doctor-state-migrations.test.ts
+++ b/src/commands/doctor-state-migrations.test.ts
@@ -2997,6 +2997,64 @@ describe("doctor legacy state migrations", () => {
     });
   });
 
+  it("reports completed transcript migration when a custom agent owns session state", async () => {
+    const root = await makeTempRoot();
+    const sessionId = "custom-agent-review";
+    const sourceDir = path.join(root, "transcripts", "2026-07-01", sessionId);
+    fs.mkdirSync(sourceDir, { recursive: true });
+    writeJson5(path.join(sourceDir, "metadata.json"), {
+      sessionId,
+      title: "Design review",
+      source: {
+        providerId: "manual-transcript",
+        meetingUrl: "https://meet.example.invalid/room",
+      },
+      startedAt: "2026-07-01T10:00:00.000Z",
+      stoppedAt: "2026-07-01T10:30:00.000Z",
+    });
+    const utterances = [
+      { id: "u-1", sessionId, speaker: { label: "Alex" }, text: "First line", final: true },
+      { id: "u-2", sessionId, speaker: { label: "Sam" }, text: "Second line", final: true },
+    ];
+    fs.writeFileSync(
+      path.join(sourceDir, "transcript.jsonl"),
+      `${utterances.map((utterance) => JSON.stringify(utterance)).join("\n")}\n`,
+    );
+    writeJson5(path.join(sourceDir, "summary.json"), {
+      sessionId,
+      title: "Design review",
+      generatedAt: "2026-07-01T10:31:00.000Z",
+      overview: "First line. Second line.",
+      transcript: ["Alex: First line", "Sam: Second line"],
+      decisions: [],
+      actionItems: [],
+      risks: [],
+      utteranceCount: 2,
+    });
+    fs.writeFileSync(path.join(sourceDir, "summary.md"), "# Design review\n\nFirst line.\n");
+    const env = {
+      OPENCLAW_STATE_DIR: root,
+      OPENCLAW_AGENT_DIR: path.join(root, "custom-agent"),
+    } as NodeJS.ProcessEnv;
+
+    const result = await autoMigrateLegacyState({
+      cfg: {},
+      doctorOnlyStateMigrations: true,
+      env,
+      log: { info: vi.fn(), warn: vi.fn() },
+      now: () => Date.parse("2026-07-02T00:00:00.000Z"),
+    });
+
+    expect(result).toMatchObject({ migrated: true, skipped: true, warnings: [] });
+    expect(result.changes.join("\n")).not.toMatch(/meeting transcript|utterance/i);
+    expect(fs.existsSync(sourceDir)).toBe(false);
+    expect(
+      openOpenClawStateDatabase({ env })
+        .db.prepare("SELECT COUNT(*) AS count FROM meeting_transcript_sessions")
+        .get(),
+    ).toEqual({ count: 1 });
+  });
+
   it("never imports default exec approvals into a custom state dir", async () => {
     // Regression: every custom state root is an independent trust scope.
     // Even direct doctor repair must not copy or archive default approvals.

--- a/src/infra/state-migrations.apns.ts
+++ b/src/infra/state-migrations.apns.ts
@@ -1,6 +1,5 @@
 // Doctor-only import for the retired APNs registration JSON store.
 import { createHash } from "node:crypto";
-import fs from "node:fs";
 import path from "node:path";
 import { root, type Root } from "@openclaw/fs-safe";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
@@ -26,6 +25,12 @@ import {
   normalizeCanonicalApnsRegistration,
   type ApnsRegistration,
 } from "./push-apns-store.js";
+import {
+  legacyMigrationSourceOrClaimMayExist,
+  legacyMigrationSourceSnapshotsMatch as snapshotsMatch,
+  resolveLegacyMigrationRelativePath,
+  type LegacyMigrationSourceSnapshot,
+} from "./state-migrations.source-snapshot.js";
 import type { LegacyStateDetection, MigrationMessages } from "./state-migrations.types.js";
 
 const LEGACY_APNS_REGISTRATION_PATH = "push/apns-registrations.json";
@@ -63,14 +68,10 @@ type ApnsMigrationDatabase = Pick<
   "apns_registrations" | "apns_registration_tombstones" | "migration_runs" | "migration_sources"
 >;
 
-type LegacySourceSnapshot = {
-  sourcePath: string;
-  dev: number;
-  ino: number;
-  mtimeMs: number;
-  sha256: string;
-  size: number;
-};
+type LegacySourceSnapshot = Pick<
+  LegacyMigrationSourceSnapshot,
+  "sourcePath" | "dev" | "ino" | "mtimeMs" | "sha256" | "size"
+>;
 
 type MigrationReceipt = {
   sourceKey: string;
@@ -81,21 +82,6 @@ function resolveLegacyApnsPath(stateDir: string): string {
   return path.join(stateDir, LEGACY_APNS_REGISTRATION_PATH);
 }
 
-function legacyPathMayExist(filePath: string): boolean {
-  try {
-    fs.lstatSync(filePath);
-    return true;
-  } catch (error) {
-    return (error as NodeJS.ErrnoException).code !== "ENOENT";
-  }
-}
-
-function sourceOrClaimMayExist(sourcePath: string): boolean {
-  return (
-    legacyPathMayExist(sourcePath) || legacyPathMayExist(`${sourcePath}${APNS_DOCTOR_CLAIM_SUFFIX}`)
-  );
-}
-
 /** Detect the retired APNs store only when an explicit Doctor flow opts in. */
 export function detectLegacyApnsRegistrations(params: {
   stateDir: string;
@@ -104,21 +90,14 @@ export function detectLegacyApnsRegistrations(params: {
   const sourcePath = resolveLegacyApnsPath(params.stateDir);
   return {
     sourcePath,
-    hasLegacy: params.doctorOnlyStateMigrations === true && sourceOrClaimMayExist(sourcePath),
+    hasLegacy:
+      params.doctorOnlyStateMigrations === true &&
+      legacyMigrationSourceOrClaimMayExist(sourcePath, APNS_DOCTOR_CLAIM_SUFFIX),
   };
 }
 
 function relativeLegacyPath(stateDir: string, filePath: string): string {
-  const relativePath = path.relative(path.resolve(stateDir), path.resolve(filePath));
-  if (
-    !relativePath ||
-    relativePath === ".." ||
-    relativePath.startsWith(`..${path.sep}`) ||
-    path.isAbsolute(relativePath)
-  ) {
-    throw new Error("legacy APNs path is outside the state directory");
-  }
-  return relativePath;
+  return resolveLegacyMigrationRelativePath(stateDir, filePath, "APNs", false);
 }
 
 async function readLegacySourceSnapshot(
@@ -136,16 +115,6 @@ async function readLegacySourceSnapshot(
     sourcePath,
     ...snapshot,
   };
-}
-
-function snapshotsMatch(left: LegacySourceSnapshot, right: LegacySourceSnapshot): boolean {
-  return (
-    left.dev === right.dev &&
-    left.ino === right.ino &&
-    left.mtimeMs === right.mtimeMs &&
-    left.sha256 === right.sha256 &&
-    left.size === right.size
-  );
 }
 
 function assertOnlyKeys(value: Record<string, unknown>, allowed: ReadonlySet<string>): void {

--- a/src/infra/state-migrations.commitments.ts
+++ b/src/infra/state-migrations.commitments.ts
@@ -1,5 +1,4 @@
 // Doctor-only import for the retired commitments JSON store.
-import { createHash, randomUUID } from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
 import type { DatabaseSync } from "node:sqlite";
@@ -24,16 +23,13 @@ import {
   executeSqliteQueryTakeFirstSync,
   getNodeSqliteKysely,
 } from "./kysely-sync.js";
+import {
+  assertLegacyMigrationSourceUnchanged,
+  claimAndRemoveLegacyMigrationSource,
+  readLegacyMigrationSourceSnapshotSync,
+  type LegacyMigrationSourceSnapshot as LegacySourceSnapshot,
+} from "./state-migrations.source-snapshot.js";
 import type { LegacyStateDetection, MigrationMessages } from "./state-migrations.types.js";
-
-type LegacySourceSnapshot = {
-  dev: number;
-  ino: number;
-  mtimeMs: number;
-  raw: string;
-  sha256: string;
-  size: number;
-};
 
 const LEGACY_STORE_KEYS = new Set(["version", "commitments"]);
 const ACTIVE_STATUSES = ["pending", "snoozed"] as const;
@@ -55,46 +51,11 @@ export function detectLegacyCommitments(params: {
 }
 
 function readLegacySourceSnapshot(sourcePath: string): LegacySourceSnapshot {
-  const before = fs.lstatSync(sourcePath);
-  if (!before.isFile() || before.isSymbolicLink()) {
-    throw new Error("legacy commitments source is not a regular non-symlink file");
-  }
-  const raw = fs.readFileSync(sourcePath, "utf8");
-  const after = fs.lstatSync(sourcePath);
-  if (
-    !after.isFile() ||
-    after.isSymbolicLink() ||
-    before.dev !== after.dev ||
-    before.ino !== after.ino ||
-    before.size !== after.size ||
-    before.mtimeMs !== after.mtimeMs
-  ) {
-    throw new Error("legacy commitments source changed while doctor was reading it");
-  }
-  return {
-    dev: after.dev,
-    ino: after.ino,
-    mtimeMs: after.mtimeMs,
-    raw,
-    sha256: createHash("sha256").update(raw).digest("hex"),
-    size: after.size,
-  };
-}
-
-function sourceSnapshotsMatch(left: LegacySourceSnapshot, right: LegacySourceSnapshot): boolean {
-  return (
-    left.dev === right.dev &&
-    left.ino === right.ino &&
-    left.mtimeMs === right.mtimeMs &&
-    left.sha256 === right.sha256 &&
-    left.size === right.size
-  );
+  return readLegacyMigrationSourceSnapshotSync({ sourcePath, label: "commitments" });
 }
 
 function assertLegacySourceUnchanged(sourcePath: string, snapshot: LegacySourceSnapshot): void {
-  if (!sourceSnapshotsMatch(readLegacySourceSnapshot(sourcePath), snapshot)) {
-    throw new Error("legacy commitments source changed after doctor loaded it");
-  }
+  assertLegacyMigrationSourceUnchanged({ sourcePath, snapshot, label: "commitments" });
 }
 
 function parseLegacyCommitments(raw: string): CommitmentRecord[] {
@@ -169,39 +130,6 @@ function updateCommitmentRow(db: DatabaseSync, record: CommitmentRecord): void {
       .set(commitmentRecordToUpdate(record))
       .where("id", "=", record.id),
   );
-}
-
-function restoreClaimAfterCleanupFailure(claimPath: string, sourcePath: string): string | null {
-  if (!fs.existsSync(claimPath) || fs.existsSync(sourcePath)) {
-    return null;
-  }
-  try {
-    fs.renameSync(claimPath, sourcePath);
-    return null;
-  } catch (error) {
-    return `; claimed source remains at ${claimPath} because restore also failed: ${String(error)}`;
-  }
-}
-
-function claimAndRemoveSource(params: {
-  sourcePath: string;
-  snapshot: LegacySourceSnapshot;
-  beforeClaim?: () => void;
-  removeSource?: (sourcePath: string) => void;
-}): void {
-  params.beforeClaim?.();
-  const claimPath = `${params.sourcePath}.doctor-importing-${process.pid}-${randomUUID()}`;
-  fs.renameSync(params.sourcePath, claimPath);
-  try {
-    const claimed = readLegacySourceSnapshot(claimPath);
-    if (!sourceSnapshotsMatch(claimed, params.snapshot)) {
-      throw new Error("legacy commitments source changed before doctor could claim it");
-    }
-    (params.removeSource ?? fs.unlinkSync)(claimPath);
-  } catch (error) {
-    const restoreFailure = restoreClaimAfterCleanupFailure(claimPath, params.sourcePath);
-    throw new Error(`${String(error)}${restoreFailure ?? ""}`, { cause: error });
-  }
 }
 
 /** Import, verify, and remove the retired JSON store during explicit doctor repair. */
@@ -316,9 +244,10 @@ export function migrateLegacyCommitments(params: {
   }
 
   try {
-    claimAndRemoveSource({
+    claimAndRemoveLegacyMigrationSource({
       sourcePath: params.detected.sourcePath,
       snapshot,
+      label: "commitments",
       beforeClaim: params.beforeClaim,
       removeSource: params.removeSource,
     });

--- a/src/infra/state-migrations.device-identity.ts
+++ b/src/infra/state-migrations.device-identity.ts
@@ -30,6 +30,12 @@ import {
   repairInvalidCanonicalIdentity,
 } from "./state-migrations.device-identity-repair.js";
 import type { LegacyDeviceIdentityDetection } from "./state-migrations.device-identity.types.js";
+import {
+  legacyMigrationSourceSnapshotsMatch as snapshotsMatch,
+  readLegacyMigrationSourceSnapshot,
+  resolveLegacyMigrationRelativePath,
+  type LegacyMigrationSourceSnapshot,
+} from "./state-migrations.source-snapshot.js";
 import type { MigrationMessages } from "./state-migrations.types.js";
 
 const IDENTITY_KEY = "primary";
@@ -63,13 +69,7 @@ type DeviceIdentityMigrationDatabase = Pick<
   "device_identities" | "migration_runs" | "migration_sources"
 >;
 
-type LegacySourceSnapshot = {
-  sourcePath: string;
-  dev: number;
-  ino: number;
-  mtimeMs: number;
-  sha256: string;
-  size: number;
+type LegacySourceSnapshot = LegacyMigrationSourceSnapshot & {
   identity: NormalizedLegacyDeviceIdentity;
 };
 
@@ -82,16 +82,7 @@ type MigrationReceipt = {
 export { detectLegacyDeviceIdentity } from "./state-migrations.device-identity-repair.js";
 
 function relativeLegacyPath(stateDir: string, filePath: string): string {
-  const relativePath = path.relative(path.resolve(stateDir), path.resolve(filePath));
-  if (
-    !relativePath ||
-    relativePath === ".." ||
-    relativePath.startsWith(`..${path.sep}`) ||
-    path.isAbsolute(relativePath)
-  ) {
-    throw new Error("legacy device identity path is outside the state directory");
-  }
-  return relativePath;
+  return resolveLegacyMigrationRelativePath(stateDir, filePath, "device identity", false);
 }
 
 async function readLegacySourceSnapshot(params: {
@@ -99,40 +90,16 @@ async function readLegacySourceSnapshot(params: {
   stateDir: string;
   sourcePath: string;
 }): Promise<LegacySourceSnapshot> {
-  const opened = await params.stateRoot.read(
-    relativeLegacyPath(params.stateDir, params.sourcePath),
-    {
-      hardlinks: "reject",
-      maxBytes: MAX_LEGACY_IDENTITY_BYTES,
-      symlinks: "reject",
-    },
-  );
-  if (opened.stat.size !== opened.buffer.byteLength) {
-    throw new Error("legacy device identity changed while it was being read");
-  }
-  const identity = normalizeLegacyDeviceIdentity(JSON.parse(utf8Decoder.decode(opened.buffer)));
+  const snapshot = await readLegacyMigrationSourceSnapshot({
+    ...params,
+    maxBytes: MAX_LEGACY_IDENTITY_BYTES,
+    label: "device identity",
+  });
+  const identity = normalizeLegacyDeviceIdentity(JSON.parse(utf8Decoder.decode(snapshot.buffer)));
   if (!identity) {
     throw new Error("legacy device identity is invalid or unsupported");
   }
-  return {
-    sourcePath: params.sourcePath,
-    dev: opened.stat.dev,
-    ino: opened.stat.ino,
-    mtimeMs: opened.stat.mtimeMs,
-    sha256: createHash("sha256").update(opened.buffer).digest("hex"),
-    size: opened.stat.size,
-    identity,
-  };
-}
-
-function snapshotsMatch(left: LegacySourceSnapshot, right: LegacySourceSnapshot): boolean {
-  return (
-    left.dev === right.dev &&
-    left.ino === right.ino &&
-    left.mtimeMs === right.mtimeMs &&
-    left.sha256 === right.sha256 &&
-    left.size === right.size
-  );
+  return { ...snapshot, identity };
 }
 
 function receiptSourceKey(sourcePath: string): string {

--- a/src/infra/state-migrations.doctor.ts
+++ b/src/infra/state-migrations.doctor.ts
@@ -1005,251 +1005,300 @@ export async function runLegacyStateMigrations(params: {
   const now = params.now ?? (() => Date.now());
   const detected = params.detected;
   const env = params.env ?? process.env;
+  const stateDir = detected.stateDir;
   const stateSchema = migrateLegacyStateSchema(detected, env);
   if (detected.stateSchema.hasLegacy && stateSchema.warnings.length > 0) {
     return stateSchema;
   }
-  const pluginStateSidecar = await migrateLegacyPluginStateSidecar({
-    stateDir: detected.stateDir,
-  });
-  const pluginInstallIndex = await migrateLegacyInstalledPluginIndex({
-    stateDir: detected.stateDir,
-  });
+  type LegacyMigrationStep = {
+    collectNotices?: boolean;
+    run: () => MigrationMessages | Promise<MigrationMessages>;
+  };
+  const steps: LegacyMigrationStep[] = [
+    { run: () => migrateLegacyPluginStateSidecar({ stateDir }) },
+    { collectNotices: true, run: () => migrateLegacyInstalledPluginIndex({ stateDir }) },
+    {
+      run: () =>
+        migrateLegacyDebugProxyCaptureSidecar({
+          stateDir,
+          detected: detected.debugProxyCaptureSidecar,
+        }),
+    },
+    { run: () => migrateLegacyTaskStateSidecars({ stateDir }) },
+    { run: () => migrateLegacyDeliveryQueues({ stateDir }) },
+    { run: () => migrateLegacyVoiceWakeSettings({ detected: detected.voiceWake, stateDir }) },
+    {
+      collectNotices: true,
+      run: () => migrateLegacyUpdateCheckState({ detected: detected.updateCheck, stateDir }),
+    },
+    { run: () => migrateLegacyConfigHealth({ detected: detected.configHealth, stateDir }) },
+    {
+      run: () =>
+        migrateLegacyPluginBindingApprovals({
+          detected: detected.pluginBindingApprovals,
+          stateDir,
+        }),
+    },
+    {
+      run: () =>
+        migrateLegacyCurrentConversationBindings({
+          detected: detected.currentConversationBindings,
+          stateDir,
+        }),
+    },
+    {
+      collectNotices: true,
+      run: () => migrateLegacyTuiLastSessions({ detected: detected.tuiLastSessions, stateDir }),
+    },
+    {
+      collectNotices: true,
+      run: () => migrateLegacyCommitments({ detected: detected.commitments, stateDir }),
+    },
+    {
+      collectNotices: true,
+      run: () => migrateLegacyAuditLogs({ detected: detected.auditLogs, stateDir }),
+    },
+    {
+      collectNotices: true,
+      run: () => migrateLegacyAcpReplayLedger({ detected: detected.acpReplayLedger, stateDir }),
+    },
+    {
+      collectNotices: true,
+      run: () =>
+        migrateLegacyManagedOutgoingImages({ detected: detected.managedOutgoingImages, stateDir }),
+    },
+    {
+      collectNotices: true,
+      run: () => migrateLegacyApnsRegistrations({ detected: detected.apns, env, stateDir }),
+    },
+    {
+      collectNotices: true,
+      run: () => migrateLegacyDeviceAuth({ detected: detected.deviceAuth, env, stateDir }),
+    },
+    {
+      collectNotices: true,
+      run: () =>
+        migrateLegacyDeviceIdentity({
+          detected: detected.deviceIdentity,
+          env,
+          stateDir,
+          doctorOnlyStateMigrations: params.doctorOnlyStateMigrations,
+        }),
+    },
+    {
+      collectNotices: true,
+      run: () => migrateLegacyExecApprovals({ detected: detected.execApprovals, env, stateDir }),
+    },
+    {
+      collectNotices: true,
+      run: () => migrateLegacyMcpOAuthStores({ detected: detected.mcpOauth, env, stateDir }),
+    },
+    {
+      collectNotices: true,
+      run: () =>
+        migrateLegacyMeetingTranscripts({
+          detected: detected.meetingTranscripts,
+          env,
+          stateDir,
+          now,
+        }),
+    },
+    {
+      collectNotices: true,
+      run: () =>
+        migrateLegacyRestartSentinel({ detected: detected.restartSentinel, env, stateDir }),
+    },
+    {
+      collectNotices: true,
+      run: () => migrateLegacyWorkspaceState({ detected: detected.workspace, env, stateDir }),
+    },
+    {
+      collectNotices: true,
+      run: () => migrateLegacyWebPush({ detected: detected.webPush, env, stateDir }),
+    },
+    {
+      collectNotices: true,
+      run: () => migrateLegacyNodeHostConfig({ detected: detected.nodeHost, env, stateDir }),
+    },
+    {
+      collectNotices: true,
+      run: () =>
+        migrateLegacySubagentRegistry({ detected: detected.subagentRegistry, env, stateDir }),
+    },
+    { run: () => discardLegacyRescuePending({ detected: detected.rescuePending, stateDir }) },
+    {
+      run: () =>
+        migrateLegacyChannelPairingState({
+          detected: detected.channelPairing,
+          env: { ...env, OPENCLAW_STATE_DIR: stateDir },
+        }),
+    },
+    {
+      run: () =>
+        runLegacyMigrationPlans(
+          detected.channelPlans.plans.filter((plan) => plan.kind === "plugin-state-import"),
+        ),
+    },
+    {
+      collectNotices: true,
+      run: () =>
+        detected.stateSchema.hasLegacy
+          ? { changes: [], warnings: [] }
+          : runPluginDoctorStateMigrationPlans({
+              detected,
+              config: params.config ?? ({} as OpenClawConfig),
+              env,
+            }),
+    },
+    {
+      run: () =>
+        migrateLegacySessions(detected, now, {
+          recoverCorruptTargetStore: params.recoverCorruptTargetStore,
+        }),
+    },
+    {
+      run: () =>
+        migrateLegacyAcpSessionMetadata({
+          cfg: params.config ?? ({} as OpenClawConfig),
+          env: { ...env, OPENCLAW_STATE_DIR: stateDir },
+          now,
+        }),
+    },
+    { run: () => migrateLegacyAgentDir(detected, now) },
+    {
+      run: () =>
+        runLegacyMigrationPlans(
+          detected.channelPlans.plans.filter((plan) => plan.kind !== "plugin-state-import"),
+        ),
+    },
+  ];
+  const messages: MigrationMessages[] = [];
+  const noticeSources: MigrationMessages[] = [];
+  // Keep migration/verification serial: later owners consume the canonical
+  // SQLite state and verified archive receipts produced by earlier owners.
+  for (const step of steps) {
+    const result = await step.run();
+    messages.push(result);
+    if (step.collectNotices) {
+      noticeSources.push(result);
+    }
+  }
+  const notices = mergeNotices(noticeSources);
+  return {
+    changes: [...stateSchema.changes, ...messages.flatMap((result) => result.changes)],
+    warnings: [
+      ...stateSchema.warnings,
+      ...detected.warnings,
+      ...messages.flatMap((result) => result.warnings),
+    ],
+    ...(notices.length > 0 ? { notices } : {}),
+  };
+}
+
+type AutomaticDetectedStateMigrationResult = {
+  sharedSources: MigrationMessages[];
+  finalSources: MigrationMessages[];
+  pluginInstallIndex: MigrationMessages;
+  updateCheck: MigrationMessages;
+  restartSentinel: MigrationMessages;
+  pluginPlans: MigrationMessages;
+};
+
+async function runAutomaticDetectedStateMigrations(params: {
+  detected: LegacyStateDetection;
+  config: OpenClawConfig;
+  sessionConfig: OpenClawConfig;
+  env: NodeJS.ProcessEnv;
+  now?: () => number;
+  pluginSessionStoreAgentIds: readonly string[];
+  recoverCorruptTargetStore?: boolean;
+  skipAgentScopedMigrations: boolean;
+}): Promise<AutomaticDetectedStateMigrationResult> {
+  const { detected, env } = params;
+  const stateDir = detected.stateDir;
+  const pluginStateSidecar = await migrateLegacyPluginStateSidecar({ stateDir });
+  const pluginInstallIndex = await migrateLegacyInstalledPluginIndex({ stateDir });
   const debugProxyCaptureSidecar = migrateLegacyDebugProxyCaptureSidecar({
-    stateDir: detected.stateDir,
+    stateDir,
     detected: detected.debugProxyCaptureSidecar,
   });
-  const taskStateSidecars = await migrateLegacyTaskStateSidecars({
-    stateDir: detected.stateDir,
-  });
-  const deliveryQueues = await migrateLegacyDeliveryQueues({
-    stateDir: detected.stateDir,
-  });
-  const voiceWake = migrateLegacyVoiceWakeSettings({
-    detected: detected.voiceWake,
-    stateDir: detected.stateDir,
-  });
-  const updateCheck = migrateLegacyUpdateCheckState({
-    detected: detected.updateCheck,
-    stateDir: detected.stateDir,
-  });
-  const configHealth = migrateLegacyConfigHealth({
-    detected: detected.configHealth,
-    stateDir: detected.stateDir,
-  });
+  const taskStateSidecars = await migrateLegacyTaskStateSidecars({ stateDir });
+  const deliveryQueues = await migrateLegacyDeliveryQueues({ stateDir });
+  const voiceWake = migrateLegacyVoiceWakeSettings({ detected: detected.voiceWake, stateDir });
+  const updateCheck = migrateLegacyUpdateCheckState({ detected: detected.updateCheck, stateDir });
+  const configHealth = migrateLegacyConfigHealth({ detected: detected.configHealth, stateDir });
   const pluginBindingApprovals = migrateLegacyPluginBindingApprovals({
     detected: detected.pluginBindingApprovals,
-    stateDir: detected.stateDir,
+    stateDir,
   });
   const currentConversationBindings = migrateLegacyCurrentConversationBindings({
     detected: detected.currentConversationBindings,
-    stateDir: detected.stateDir,
-  });
-  const tuiLastSessions = migrateLegacyTuiLastSessions({
-    detected: detected.tuiLastSessions,
-    stateDir: detected.stateDir,
-  });
-  const commitments = migrateLegacyCommitments({
-    detected: detected.commitments,
-    stateDir: detected.stateDir,
-  });
-  const auditLogs = await migrateLegacyAuditLogs({
-    detected: detected.auditLogs,
-    stateDir: detected.stateDir,
-  });
-  const acpReplayLedger = await migrateLegacyAcpReplayLedger({
-    detected: detected.acpReplayLedger,
-    stateDir: detected.stateDir,
-  });
-  const managedOutgoingImages = migrateLegacyManagedOutgoingImages({
-    detected: detected.managedOutgoingImages,
-    stateDir: detected.stateDir,
-  });
-  const apns = await migrateLegacyApnsRegistrations({
-    detected: detected.apns,
-    env,
-    stateDir: detected.stateDir,
-  });
-  const deviceAuth = await migrateLegacyDeviceAuth({
-    detected: detected.deviceAuth,
-    env,
-    stateDir: detected.stateDir,
-  });
-  const deviceIdentity = await migrateLegacyDeviceIdentity({
-    detected: detected.deviceIdentity,
-    env,
-    stateDir: detected.stateDir,
-    doctorOnlyStateMigrations: params.doctorOnlyStateMigrations,
-  });
-  const execApprovals = await migrateLegacyExecApprovals({
-    detected: detected.execApprovals,
-    env,
-    stateDir: detected.stateDir,
-  });
-  const mcpOauth = await migrateLegacyMcpOAuthStores({
-    detected: detected.mcpOauth,
-    env,
-    stateDir: detected.stateDir,
-  });
-  const meetingTranscripts = await migrateLegacyMeetingTranscripts({
-    detected: detected.meetingTranscripts,
-    env,
-    stateDir: detected.stateDir,
-    now,
+    stateDir,
   });
   const restartSentinel = await migrateLegacyRestartSentinel({
     detected: detected.restartSentinel,
     env,
-    stateDir: detected.stateDir,
-  });
-  const workspace = await migrateLegacyWorkspaceState({
-    detected: detected.workspace,
-    env,
-    stateDir: detected.stateDir,
-  });
-  const webPush = await migrateLegacyWebPush({
-    detected: detected.webPush,
-    env,
-    stateDir: detected.stateDir,
-  });
-  const nodeHost = await migrateLegacyNodeHostConfig({
-    detected: detected.nodeHost,
-    env,
-    stateDir: detected.stateDir,
-  });
-  const subagentRegistry = await migrateLegacySubagentRegistry({
-    detected: detected.subagentRegistry,
-    env,
-    stateDir: detected.stateDir,
-  });
-  const rescuePending = discardLegacyRescuePending({
-    detected: detected.rescuePending,
-    stateDir: detected.stateDir,
+    stateDir,
   });
   const channelPairing = migrateLegacyChannelPairingState({
     detected: detected.channelPairing,
-    env: { ...env, OPENCLAW_STATE_DIR: detected.stateDir },
+    env: { ...env, OPENCLAW_STATE_DIR: stateDir },
   });
   const preSessionChannelPlans = await runLegacyMigrationPlans(
     detected.channelPlans.plans.filter((plan) => plan.kind === "plugin-state-import"),
   );
-  const pluginPlans = detected.stateSchema.hasLegacy
-    ? { changes: [], warnings: [] }
-    : await runPluginDoctorStateMigrationPlans({
-        detected,
-        config: params.config ?? ({} as OpenClawConfig),
+  const pluginPlans = await runPluginDoctorStateMigrationPlans({
+    detected,
+    config: params.config,
+    env,
+  });
+  const sharedSources: MigrationMessages[] = [
+    pluginStateSidecar,
+    pluginInstallIndex,
+    debugProxyCaptureSidecar,
+    taskStateSidecars,
+    deliveryQueues,
+    voiceWake,
+    updateCheck,
+    configHealth,
+    pluginBindingApprovals,
+    currentConversationBindings,
+  ];
+  const finalSources: MigrationMessages[] = [
+    restartSentinel,
+    channelPairing,
+    preSessionChannelPlans,
+    pluginPlans,
+  ];
+
+  // A custom agent directory still owns its session and agent artifacts. Shared
+  // SQLite/plugin repairs remain safe; never run the default-agent migrations.
+  if (!params.skipAgentScopedMigrations) {
+    const now = params.now ?? (() => Date.now());
+    finalSources.push(
+      await migrateLegacySessions(detected, now, {
+        recoverCorruptTargetStore: params.recoverCorruptTargetStore,
+      }),
+      await migrateLegacyAcpSessionMetadata({
+        cfg: params.sessionConfig,
         env,
-      });
-  const sessions = await migrateLegacySessions(detected, now, {
-    recoverCorruptTargetStore: params.recoverCorruptTargetStore,
-  });
-  const acpSessionMetadata = await migrateLegacyAcpSessionMetadata({
-    cfg: params.config ?? ({} as OpenClawConfig),
-    env: { ...env, OPENCLAW_STATE_DIR: detected.stateDir },
-    now,
-  });
-  const agentDir = await migrateLegacyAgentDir(detected, now);
-  const channelPlans = await runLegacyMigrationPlans(
-    detected.channelPlans.plans.filter((plan) => plan.kind !== "plugin-state-import"),
-  );
-  const notices = mergeNotices([
+        now,
+        pluginSessionStoreAgentIds: params.pluginSessionStoreAgentIds,
+      }),
+      await migrateLegacyAgentDir(detected, now),
+      await runLegacyMigrationPlans(
+        detected.channelPlans.plans.filter((plan) => plan.kind !== "plugin-state-import"),
+      ),
+    );
+  }
+
+  return {
+    sharedSources,
+    finalSources,
     pluginInstallIndex,
     updateCheck,
-    tuiLastSessions,
-    commitments,
-    auditLogs,
-    acpReplayLedger,
-    managedOutgoingImages,
-    apns,
-    deviceAuth,
-    deviceIdentity,
-    execApprovals,
-    mcpOauth,
-    meetingTranscripts,
     restartSentinel,
-    workspace,
-    webPush,
-    nodeHost,
-    subagentRegistry,
     pluginPlans,
-  ]);
-  return {
-    changes: [
-      ...stateSchema.changes,
-      ...pluginStateSidecar.changes,
-      ...pluginInstallIndex.changes,
-      ...debugProxyCaptureSidecar.changes,
-      ...taskStateSidecars.changes,
-      ...deliveryQueues.changes,
-      ...voiceWake.changes,
-      ...updateCheck.changes,
-      ...configHealth.changes,
-      ...pluginBindingApprovals.changes,
-      ...currentConversationBindings.changes,
-      ...tuiLastSessions.changes,
-      ...commitments.changes,
-      ...auditLogs.changes,
-      ...acpReplayLedger.changes,
-      ...managedOutgoingImages.changes,
-      ...apns.changes,
-      ...deviceAuth.changes,
-      ...deviceIdentity.changes,
-      ...execApprovals.changes,
-      ...mcpOauth.changes,
-      ...meetingTranscripts.changes,
-      ...restartSentinel.changes,
-      ...workspace.changes,
-      ...webPush.changes,
-      ...nodeHost.changes,
-      ...subagentRegistry.changes,
-      ...rescuePending.changes,
-      ...channelPairing.changes,
-      ...preSessionChannelPlans.changes,
-      ...pluginPlans.changes,
-      ...sessions.changes,
-      ...acpSessionMetadata.changes,
-      ...agentDir.changes,
-      ...channelPlans.changes,
-    ],
-    warnings: [
-      ...stateSchema.warnings,
-      ...detected.warnings,
-      ...pluginStateSidecar.warnings,
-      ...pluginInstallIndex.warnings,
-      ...debugProxyCaptureSidecar.warnings,
-      ...taskStateSidecars.warnings,
-      ...deliveryQueues.warnings,
-      ...voiceWake.warnings,
-      ...updateCheck.warnings,
-      ...configHealth.warnings,
-      ...pluginBindingApprovals.warnings,
-      ...currentConversationBindings.warnings,
-      ...tuiLastSessions.warnings,
-      ...commitments.warnings,
-      ...auditLogs.warnings,
-      ...acpReplayLedger.warnings,
-      ...managedOutgoingImages.warnings,
-      ...apns.warnings,
-      ...deviceAuth.warnings,
-      ...deviceIdentity.warnings,
-      ...execApprovals.warnings,
-      ...mcpOauth.warnings,
-      ...meetingTranscripts.warnings,
-      ...restartSentinel.warnings,
-      ...workspace.warnings,
-      ...webPush.warnings,
-      ...nodeHost.warnings,
-      ...subagentRegistry.warnings,
-      ...rescuePending.warnings,
-      ...channelPairing.warnings,
-      ...preSessionChannelPlans.warnings,
-      ...pluginPlans.warnings,
-      ...sessions.warnings,
-      ...acpSessionMetadata.warnings,
-      ...agentDir.warnings,
-      ...channelPlans.warnings,
-    ],
-    ...(notices.length > 0 ? { notices } : {}),
   };
 }
 
@@ -1405,154 +1454,16 @@ export async function autoMigrateLegacyState(params: {
     now: params.now,
   });
   const hasCustomAgentDir = env.OPENCLAW_AGENT_DIR?.trim() || env.PI_CODING_AGENT_DIR?.trim();
-  if (hasCustomAgentDir) {
-    const pluginStateSidecar = await migrateLegacyPluginStateSidecar({
-      stateDir: detected.stateDir,
-    });
-    const pluginInstallIndex = await migrateLegacyInstalledPluginIndex({
-      stateDir: detected.stateDir,
-    });
-    const debugProxyCaptureSidecar = migrateLegacyDebugProxyCaptureSidecar({
-      stateDir: detected.stateDir,
-      detected: detected.debugProxyCaptureSidecar,
-    });
-    const taskStateSidecars = await migrateLegacyTaskStateSidecars({
-      stateDir: detected.stateDir,
-    });
-    const deliveryQueues = await migrateLegacyDeliveryQueues({
-      stateDir: detected.stateDir,
-    });
-    const voiceWake = migrateLegacyVoiceWakeSettings({
-      detected: detected.voiceWake,
-      stateDir: detected.stateDir,
-    });
-    const updateCheck = migrateLegacyUpdateCheckState({
-      detected: detected.updateCheck,
-      stateDir: detected.stateDir,
-    });
-    const configHealth = migrateLegacyConfigHealth({
-      detected: detected.configHealth,
-      stateDir: detected.stateDir,
-    });
-    const pluginBindingApprovals = migrateLegacyPluginBindingApprovals({
-      detected: detected.pluginBindingApprovals,
-      stateDir: detected.stateDir,
-    });
-    const currentConversationBindings = migrateLegacyCurrentConversationBindings({
-      detected: detected.currentConversationBindings,
-      stateDir: detected.stateDir,
-    });
-    const restartSentinel = await migrateLegacyRestartSentinel({
-      detected: detected.restartSentinel,
-      env,
-      stateDir: detected.stateDir,
-    });
-    const channelPairing = migrateLegacyChannelPairingState({
-      detected: detected.channelPairing,
-      env: { ...env, OPENCLAW_STATE_DIR: detected.stateDir },
-    });
-    const preSessionChannelPlans = await runLegacyMigrationPlans(
-      detected.channelPlans.plans.filter((plan) => plan.kind === "plugin-state-import"),
-    );
-    const pluginPlans = await runPluginDoctorStateMigrationPlans({
-      detected,
-      config: params.pluginDoctorConfig ?? params.cfg,
-      env,
-    });
-    const changes = [
-      ...stateDirResult.changes,
-      ...stateSchema.changes,
-      ...mediaPersistence.changes,
-      ...configMachineState.changes,
-      ...orphanKeys.changes,
-      ...acpSessionMetadata.changes,
-      ...pluginStateSidecar.changes,
-      ...pluginInstallIndex.changes,
-      ...debugProxyCaptureSidecar.changes,
-      ...taskStateSidecars.changes,
-      ...deliveryQueues.changes,
-      ...voiceWake.changes,
-      ...updateCheck.changes,
-      ...configHealth.changes,
-      ...pluginBindingApprovals.changes,
-      ...currentConversationBindings.changes,
-      ...deviceAuth.changes,
-      ...deviceIdentity.changes,
-      ...restartSentinel.changes,
-      ...channelPairing.changes,
-      ...preSessionChannelPlans.changes,
-      ...pluginPlans.changes,
-    ];
-    const warnings = [
-      ...stateDirResult.warnings,
-      ...stateSchema.warnings,
-      ...mediaPersistence.warnings,
-      ...configMachineState.warnings,
-      ...detected.warnings,
-      ...orphanKeys.warnings,
-      ...acpSessionMetadata.warnings,
-      ...pluginStateSidecar.warnings,
-      ...pluginInstallIndex.warnings,
-      ...debugProxyCaptureSidecar.warnings,
-      ...taskStateSidecars.warnings,
-      ...deliveryQueues.warnings,
-      ...voiceWake.warnings,
-      ...updateCheck.warnings,
-      ...configHealth.warnings,
-      ...pluginBindingApprovals.warnings,
-      ...currentConversationBindings.warnings,
-      ...deviceAuth.warnings,
-      ...deviceIdentity.warnings,
-      ...restartSentinel.warnings,
-      ...channelPairing.warnings,
-      ...preSessionChannelPlans.warnings,
-      ...pluginPlans.warnings,
-    ];
-    const noticeSources = [
-      stateDirResult,
-      detected,
-      pluginInstallIndex,
-      updateCheck,
-      deviceAuth,
-      deviceIdentity,
-      meetingTranscripts,
-      restartSentinel,
-      pluginPlans,
-    ];
-    const notices = mergeNotices(noticeSources);
-    logMigrationResults(changes, warnings, notices);
-    return {
-      migrated:
-        stateDirResult.migrated ||
-        stateSchema.changes.length > 0 ||
-        mediaPersistence.changes.length > 0 ||
-        configMachineState.changes.length > 0 ||
-        orphanKeys.changes.length > 0 ||
-        acpSessionMetadata.changes.length > 0 ||
-        pluginStateSidecar.changes.length > 0 ||
-        pluginInstallIndex.changes.length > 0 ||
-        debugProxyCaptureSidecar.changes.length > 0 ||
-        taskStateSidecars.changes.length > 0 ||
-        deliveryQueues.changes.length > 0 ||
-        voiceWake.changes.length > 0 ||
-        updateCheck.changes.length > 0 ||
-        configHealth.changes.length > 0 ||
-        pluginBindingApprovals.changes.length > 0 ||
-        currentConversationBindings.changes.length > 0 ||
-        deviceAuth.changes.length > 0 ||
-        deviceIdentity.changes.length > 0 ||
-        meetingTranscripts.changes.length > 0 ||
-        restartSentinel.changes.length > 0 ||
-        channelPairing.changes.length > 0 ||
-        preSessionChannelPlans.changes.length > 0 ||
-        pluginPlans.changes.length > 0,
-      skipped: true,
-      changes,
-      warnings,
-      ...(notices.length > 0 ? { notices } : {}),
-    };
-  }
+  const initialMigrationSources = [
+    stateDirResult,
+    stateSchema,
+    mediaPersistence,
+    configMachineState,
+    orphanKeys,
+    acpSessionMetadata,
+  ];
   if (
+    !hasCustomAgentDir &&
     !detected.sessions.hasLegacy &&
     !detected.agentDir.hasLegacy &&
     !detected.channelPlans.hasLegacy &&
@@ -1573,17 +1484,13 @@ export async function autoMigrateLegacyState(params: {
     !detected.workspace.hasLegacy &&
     !detected.channelPairing.hasLegacy
   ) {
-    const changes = [
-      ...stateDirResult.changes,
-      ...stateSchema.changes,
-      ...mediaPersistence.changes,
-      ...configMachineState.changes,
-      ...orphanKeys.changes,
-      ...acpSessionMetadata.changes,
-      ...deviceAuth.changes,
-      ...deviceIdentity.changes,
-      ...meetingTranscripts.changes,
+    const completedSources = [
+      ...initialMigrationSources,
+      deviceAuth,
+      deviceIdentity,
+      meetingTranscripts,
     ];
+    const changes = completedSources.flatMap((source) => source.changes);
     const warnings = [
       ...stateDirResult.warnings,
       ...stateSchema.warnings,
@@ -1596,24 +1503,10 @@ export async function autoMigrateLegacyState(params: {
       ...deviceIdentity.warnings,
       ...meetingTranscripts.warnings,
     ];
-    const notices = [
-      ...(stateDirResult.notices ?? []),
-      ...detected.notices,
-      ...(deviceAuth.notices ?? []),
-      ...(deviceIdentity.notices ?? []),
-    ];
+    const notices = mergeNotices([stateDirResult, detected, deviceAuth, deviceIdentity]);
     logMigrationResults(changes, warnings, notices);
     return {
-      migrated:
-        stateDirResult.migrated ||
-        stateSchema.changes.length > 0 ||
-        mediaPersistence.changes.length > 0 ||
-        configMachineState.changes.length > 0 ||
-        orphanKeys.changes.length > 0 ||
-        acpSessionMetadata.changes.length > 0 ||
-        deviceAuth.changes.length > 0 ||
-        deviceIdentity.changes.length > 0 ||
-        meetingTranscripts.changes.length > 0,
+      migrated: stateDirResult.migrated || changes.length > 0,
       skipped: false,
       changes,
       warnings,
@@ -1621,102 +1514,25 @@ export async function autoMigrateLegacyState(params: {
     };
   }
 
-  const now = params.now ?? (() => Date.now());
-  const pluginStateSidecar = await migrateLegacyPluginStateSidecar({
-    stateDir: detected.stateDir,
-  });
-  const pluginInstallIndex = await migrateLegacyInstalledPluginIndex({
-    stateDir: detected.stateDir,
-  });
-  const debugProxyCaptureSidecar = migrateLegacyDebugProxyCaptureSidecar({
-    stateDir: detected.stateDir,
-    detected: detected.debugProxyCaptureSidecar,
-  });
-  const taskStateSidecars = await migrateLegacyTaskStateSidecars({
-    stateDir: detected.stateDir,
-  });
-  const deliveryQueues = await migrateLegacyDeliveryQueues({
-    stateDir: detected.stateDir,
-  });
-  const voiceWake = migrateLegacyVoiceWakeSettings({
-    detected: detected.voiceWake,
-    stateDir: detected.stateDir,
-  });
-  const updateCheck = migrateLegacyUpdateCheckState({
-    detected: detected.updateCheck,
-    stateDir: detected.stateDir,
-  });
-  const configHealth = migrateLegacyConfigHealth({
-    detected: detected.configHealth,
-    stateDir: detected.stateDir,
-  });
-  const pluginBindingApprovals = migrateLegacyPluginBindingApprovals({
-    detected: detected.pluginBindingApprovals,
-    stateDir: detected.stateDir,
-  });
-  const currentConversationBindings = migrateLegacyCurrentConversationBindings({
-    detected: detected.currentConversationBindings,
-    stateDir: detected.stateDir,
-  });
-  const restartSentinel = await migrateLegacyRestartSentinel({
-    detected: detected.restartSentinel,
-    env,
-    stateDir: detected.stateDir,
-  });
-  const channelPairing = migrateLegacyChannelPairingState({
-    detected: detected.channelPairing,
-    env: { ...env, OPENCLAW_STATE_DIR: detected.stateDir },
-  });
-  const preSessionChannelPlans = await runLegacyMigrationPlans(
-    detected.channelPlans.plans.filter((plan) => plan.kind === "plugin-state-import"),
-  );
-  const pluginPlans = await runPluginDoctorStateMigrationPlans({
+  const migrations = await runAutomaticDetectedStateMigrations({
     detected,
     config: params.pluginDoctorConfig ?? params.cfg,
+    sessionConfig: params.cfg,
     env,
-  });
-  const sessions = await migrateLegacySessions(detected, now, {
-    recoverCorruptTargetStore: params.recoverCorruptTargetStore,
-  });
-  const postSessionAcpMetadata = await migrateLegacyAcpSessionMetadata({
-    cfg: params.cfg,
-    env,
-    now,
+    now: params.now,
     pluginSessionStoreAgentIds,
+    recoverCorruptTargetStore: params.recoverCorruptTargetStore,
+    skipAgentScopedMigrations: Boolean(hasCustomAgentDir),
   });
-  const agentDir = await migrateLegacyAgentDir(detected, now);
-  const channelPlans = await runLegacyMigrationPlans(
-    detected.channelPlans.plans.filter((plan) => plan.kind !== "plugin-state-import"),
-  );
-  const changes = [
-    ...stateDirResult.changes,
-    ...stateSchema.changes,
-    ...mediaPersistence.changes,
-    ...configMachineState.changes,
-    ...orphanKeys.changes,
-    ...acpSessionMetadata.changes,
-    ...pluginStateSidecar.changes,
-    ...pluginInstallIndex.changes,
-    ...debugProxyCaptureSidecar.changes,
-    ...taskStateSidecars.changes,
-    ...deliveryQueues.changes,
-    ...voiceWake.changes,
-    ...updateCheck.changes,
-    ...configHealth.changes,
-    ...pluginBindingApprovals.changes,
-    ...currentConversationBindings.changes,
-    ...deviceAuth.changes,
-    ...deviceIdentity.changes,
-    ...meetingTranscripts.changes,
-    ...restartSentinel.changes,
-    ...channelPairing.changes,
-    ...preSessionChannelPlans.changes,
-    ...pluginPlans.changes,
-    ...sessions.changes,
-    ...postSessionAcpMetadata.changes,
-    ...agentDir.changes,
-    ...channelPlans.changes,
+  const completedSources = [
+    ...initialMigrationSources,
+    ...migrations.sharedSources,
+    deviceAuth,
+    deviceIdentity,
+    ...(hasCustomAgentDir ? [] : [meetingTranscripts]),
+    ...migrations.finalSources,
   ];
+  const changes = completedSources.flatMap((source) => source.changes);
   const warnings = [
     ...stateDirResult.warnings,
     ...stateSchema.warnings,
@@ -1725,46 +1541,30 @@ export async function autoMigrateLegacyState(params: {
     ...detected.warnings,
     ...orphanKeys.warnings,
     ...acpSessionMetadata.warnings,
-    ...pluginStateSidecar.warnings,
-    ...pluginInstallIndex.warnings,
-    ...debugProxyCaptureSidecar.warnings,
-    ...taskStateSidecars.warnings,
-    ...deliveryQueues.warnings,
-    ...voiceWake.warnings,
-    ...updateCheck.warnings,
-    ...configHealth.warnings,
-    ...pluginBindingApprovals.warnings,
-    ...currentConversationBindings.warnings,
+    ...migrations.sharedSources.flatMap((source) => source.warnings),
     ...deviceAuth.warnings,
     ...deviceIdentity.warnings,
-    ...meetingTranscripts.warnings,
-    ...restartSentinel.warnings,
-    ...channelPairing.warnings,
-    ...preSessionChannelPlans.warnings,
-    ...pluginPlans.warnings,
-    ...sessions.warnings,
-    ...postSessionAcpMetadata.warnings,
-    ...agentDir.warnings,
-    ...channelPlans.warnings,
+    ...(hasCustomAgentDir ? [] : meetingTranscripts.warnings),
+    ...migrations.finalSources.flatMap((source) => source.warnings),
   ];
-  const noticeSources = [
+  const notices = mergeNotices([
     stateDirResult,
     detected,
-    pluginInstallIndex,
-    updateCheck,
+    migrations.pluginInstallIndex,
+    migrations.updateCheck,
     deviceAuth,
     deviceIdentity,
     meetingTranscripts,
-    restartSentinel,
-    pluginPlans,
-  ];
-  const notices = mergeNotices(noticeSources);
-
+    migrations.restartSentinel,
+    migrations.pluginPlans,
+  ]);
   logMigrationResults(changes, warnings, notices);
-
   return {
-    migrated: changes.length > 0,
-    skipped: false,
+    // Custom agent roots omit transcript changes from their shared-state report.
+    // Preserve the completed migration status without claiming agent ownership.
+    migrated:
+      stateDirResult.migrated || changes.length > 0 || meetingTranscripts.changes.length > 0,
+    skipped: Boolean(hasCustomAgentDir),
     changes,
     warnings,
     ...(notices.length > 0 ? { notices } : {}),

--- a/src/infra/state-migrations.exec-approvals.ts
+++ b/src/infra/state-migrations.exec-approvals.ts
@@ -1,6 +1,5 @@
 // Doctor-only import for the retired exec approvals JSON store.
 import { createHash } from "node:crypto";
-import fs from "node:fs";
 import path from "node:path";
 import { isDeepStrictEqual } from "node:util";
 import { root, type Root } from "@openclaw/fs-safe";
@@ -24,6 +23,13 @@ import {
   getNodeSqliteKysely,
 } from "./kysely-sync.js";
 import type { LegacyExecApprovalsDetection } from "./state-migrations.exec-approvals.types.js";
+import {
+  legacyMigrationSourceOrClaimMayExist,
+  legacyMigrationSourceSnapshotsMatch as snapshotsMatch,
+  readLegacyMigrationSourceSnapshot,
+  resolveLegacyMigrationRelativePath,
+  type LegacyMigrationSourceSnapshot,
+} from "./state-migrations.source-snapshot.js";
 import type { MigrationMessages } from "./state-migrations.types.js";
 
 const DOCTOR_CLAIM_SUFFIX = ".doctor-importing";
@@ -39,15 +45,7 @@ type ExecApprovalsMigrationDatabase = Pick<
   "exec_approvals_config" | "migration_runs" | "migration_sources"
 >;
 
-type LegacySourceSnapshot = {
-  buffer: Buffer;
-  dev: number;
-  ino: number;
-  mtimeMs: number;
-  raw: string | null;
-  sha256: string;
-  size: number;
-};
+type LegacySourceSnapshot = Omit<LegacyMigrationSourceSnapshot, "raw"> & { raw: string | null };
 
 type MigrationDecision =
   | "canonical-preserved"
@@ -56,15 +54,6 @@ type MigrationDecision =
   | "malformed-legacy-preserved"
   | "receipt-authoritative";
 
-function legacyPathMayExist(filePath: string): boolean {
-  try {
-    fs.lstatSync(filePath);
-    return true;
-  } catch (error) {
-    return (error as NodeJS.ErrnoException).code !== "ENOENT";
-  }
-}
-
 /** Detect retired approvals only when an explicit Doctor flow opts in. */
 export function detectLegacyExecApprovals(params: {
   stateDir: string;
@@ -72,8 +61,7 @@ export function detectLegacyExecApprovals(params: {
 }): LegacyExecApprovalsDetection {
   const env = { ...process.env, OPENCLAW_STATE_DIR: params.stateDir };
   const sourcePath = resolveExecApprovalsPath(env);
-  const sourcePresent =
-    legacyPathMayExist(sourcePath) || legacyPathMayExist(`${sourcePath}${DOCTOR_CLAIM_SUFFIX}`);
+  const sourcePresent = legacyMigrationSourceOrClaimMayExist(sourcePath, DOCTOR_CLAIM_SUFFIX);
   return {
     sourcePath,
     hasLegacy: params.doctorOnlyStateMigrations === true && sourcePresent,
@@ -81,16 +69,7 @@ export function detectLegacyExecApprovals(params: {
 }
 
 function relativeLegacyPath(stateDir: string, filePath: string): string {
-  const relativePath = path.relative(path.resolve(stateDir), path.resolve(filePath));
-  if (
-    !relativePath ||
-    relativePath === ".." ||
-    relativePath.startsWith(`..${path.sep}`) ||
-    path.isAbsolute(relativePath)
-  ) {
-    throw new Error("legacy exec approvals path is outside the state directory");
-  }
-  return relativePath;
+  return resolveLegacyMigrationRelativePath(stateDir, filePath, "exec approvals", false);
 }
 
 async function readLegacySourceSnapshot(
@@ -98,39 +77,20 @@ async function readLegacySourceSnapshot(
   stateDir: string,
   sourcePath: string,
 ): Promise<LegacySourceSnapshot> {
-  const opened = await stateRoot.read(relativeLegacyPath(stateDir, sourcePath), {
-    hardlinks: "reject",
+  const snapshot = await readLegacyMigrationSourceSnapshot({
+    stateRoot,
+    stateDir,
+    sourcePath,
     maxBytes: MAX_LEGACY_EXEC_APPROVALS_BYTES,
-    symlinks: "reject",
+    label: "exec approvals",
   });
-  if (!opened.stat.isFile() || opened.stat.size !== opened.buffer.byteLength) {
-    throw new Error("legacy exec approvals are not a stable regular file");
-  }
   let raw: string | null = null;
   try {
-    raw = utf8Decoder.decode(opened.buffer);
+    raw = utf8Decoder.decode(snapshot.buffer);
   } catch {
     // Invalid UTF-8 is malformed input that must stay available for recovery.
   }
-  return {
-    buffer: opened.buffer,
-    dev: opened.stat.dev,
-    ino: opened.stat.ino,
-    mtimeMs: opened.stat.mtimeMs,
-    raw,
-    sha256: createHash("sha256").update(opened.buffer).digest("hex"),
-    size: opened.stat.size,
-  };
-}
-
-function snapshotsMatch(left: LegacySourceSnapshot, right: LegacySourceSnapshot): boolean {
-  return (
-    left.dev === right.dev &&
-    left.ino === right.ino &&
-    left.mtimeMs === right.mtimeMs &&
-    left.sha256 === right.sha256 &&
-    left.size === right.size
-  );
+  return { ...snapshot, raw };
 }
 
 function receiptSourceKey(sourcePath: string): string {

--- a/src/infra/state-migrations.managed-outgoing-images.ts
+++ b/src/infra/state-migrations.managed-outgoing-images.ts
@@ -1,5 +1,5 @@
 // Doctor-only import for retired managed outgoing image metadata JSON files.
-import { createHash, randomUUID } from "node:crypto";
+import { randomUUID } from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
@@ -21,6 +21,11 @@ import {
   executeSqliteQueryTakeFirstSync,
   getNodeSqliteKysely,
 } from "./kysely-sync.js";
+import {
+  legacyMigrationSourceSnapshotsMatch as sourceSnapshotsMatch,
+  readLegacyMigrationSourceSnapshotSync,
+  type LegacyMigrationSourceSnapshot as LegacySourceSnapshot,
+} from "./state-migrations.source-snapshot.js";
 import type { LegacyStateDetection, MigrationMessages } from "./state-migrations.types.js";
 
 const LEGACY_RECORD_MAX_BYTES = 1024 * 1024;
@@ -41,16 +46,6 @@ const RECORD_KEYS = new Set([
   "original",
 ]);
 const ORIGINAL_KEYS = new Set(["path", "contentType", "width", "height", "sizeBytes", "filename"]);
-
-type LegacySourceSnapshot = {
-  sourcePath: string;
-  dev: number;
-  ino: number;
-  mtimeMs: number;
-  raw: string;
-  sha256: string;
-  size: number;
-};
 
 type ParsedLegacyRecord = {
   record: ManagedImageRecord;
@@ -125,44 +120,11 @@ function recoverInterruptedDoctorClaims(sourceDir: string): void {
 }
 
 function readLegacySourceSnapshot(sourcePath: string): LegacySourceSnapshot {
-  const before = fs.lstatSync(sourcePath);
-  if (!before.isFile() || before.isSymbolicLink()) {
-    throw new Error("legacy managed image source is not a regular non-symlink file");
-  }
-  if (before.size > LEGACY_RECORD_MAX_BYTES) {
-    throw new Error("legacy managed image source exceeds the metadata size limit");
-  }
-  const raw = fs.readFileSync(sourcePath, "utf8");
-  const after = fs.lstatSync(sourcePath);
-  if (
-    !after.isFile() ||
-    after.isSymbolicLink() ||
-    before.dev !== after.dev ||
-    before.ino !== after.ino ||
-    before.size !== after.size ||
-    before.mtimeMs !== after.mtimeMs
-  ) {
-    throw new Error("legacy managed image source changed while doctor was reading it");
-  }
-  return {
+  return readLegacyMigrationSourceSnapshotSync({
     sourcePath,
-    dev: after.dev,
-    ino: after.ino,
-    mtimeMs: after.mtimeMs,
-    raw,
-    sha256: createHash("sha256").update(raw).digest("hex"),
-    size: after.size,
-  };
-}
-
-function sourceSnapshotsMatch(left: LegacySourceSnapshot, right: LegacySourceSnapshot): boolean {
-  return (
-    left.dev === right.dev &&
-    left.ino === right.ino &&
-    left.mtimeMs === right.mtimeMs &&
-    left.sha256 === right.sha256 &&
-    left.size === right.size
-  );
+    label: "managed image",
+    maxBytes: LEGACY_RECORD_MAX_BYTES,
+  });
 }
 
 function optionalNonEmptyString(value: unknown): string | undefined {

--- a/src/infra/state-migrations.mcp-oauth.ts
+++ b/src/infra/state-migrations.mcp-oauth.ts
@@ -19,6 +19,12 @@ import {
 import { parseLegacyMcpOAuthStore } from "./state-migrations.mcp-oauth-format.js";
 import { withRootBoundedLegacyFileLock } from "./state-migrations.mcp-oauth-lock.js";
 import type { LegacyMcpOAuthDetection } from "./state-migrations.mcp-oauth.types.js";
+import {
+  legacyMigrationSourceSnapshotsMatch as snapshotsMatch,
+  readLegacyMigrationSourceSnapshot,
+  resolveLegacyMigrationRelativePath,
+  type LegacyMigrationSourceSnapshot,
+} from "./state-migrations.source-snapshot.js";
 import type { MigrationMessages } from "./state-migrations.types.js";
 
 const LEGACY_MCP_OAUTH_DIR = "mcp-oauth";
@@ -35,15 +41,7 @@ type McpOAuthMigrationDatabase = Pick<
   "mcp_oauth_stores" | "migration_runs" | "migration_sources"
 >;
 
-type LegacySourceSnapshot = {
-  sourcePath: string;
-  dev: number;
-  ino: number;
-  mtimeMs: number;
-  sha256: string;
-  size: number;
-  store: Record<string, unknown>;
-};
+type LegacySourceSnapshot = LegacyMigrationSourceSnapshot & { store: Record<string, unknown> };
 
 type MigrationReceipt = {
   sourceKey: string;
@@ -114,16 +112,7 @@ export function detectLegacyMcpOAuthStores(params: {
 }
 
 function relativeLegacyPath(stateDir: string, filePath: string): string {
-  const relativePath = path.relative(path.resolve(stateDir), path.resolve(filePath));
-  if (
-    !relativePath ||
-    relativePath === ".." ||
-    relativePath.startsWith(`..${path.sep}`) ||
-    path.isAbsolute(relativePath)
-  ) {
-    throw new Error("legacy MCP OAuth path is outside the state directory");
-  }
-  return relativePath;
+  return resolveLegacyMigrationRelativePath(stateDir, filePath, "MCP OAuth", false);
 }
 
 async function readLegacySourceSnapshot(
@@ -132,37 +121,18 @@ async function readLegacySourceSnapshot(
   sourcePath: string,
   options: { parseStore?: boolean } = {},
 ): Promise<LegacySourceSnapshot> {
-  const opened = await stateRoot.read(relativeLegacyPath(stateDir, sourcePath), {
-    hardlinks: "reject",
+  const snapshot = await readLegacyMigrationSourceSnapshot({
+    stateRoot,
+    stateDir,
+    sourcePath,
     maxBytes: MAX_LEGACY_STORE_BYTES,
-    symlinks: "reject",
+    label: "MCP OAuth",
   });
-  if (opened.stat.size !== opened.buffer.byteLength) {
-    throw new Error("legacy MCP OAuth store changed while it was being read");
-  }
   const parsed =
     options.parseStore === false
       ? {}
-      : parseLegacyMcpOAuthStore(JSON.parse(utf8Decoder.decode(opened.buffer)));
-  return {
-    sourcePath,
-    dev: opened.stat.dev,
-    ino: opened.stat.ino,
-    mtimeMs: opened.stat.mtimeMs,
-    sha256: createHash("sha256").update(opened.buffer).digest("hex"),
-    size: opened.stat.size,
-    store: parsed,
-  };
-}
-
-function snapshotsMatch(left: LegacySourceSnapshot, right: LegacySourceSnapshot): boolean {
-  return (
-    left.dev === right.dev &&
-    left.ino === right.ino &&
-    left.mtimeMs === right.mtimeMs &&
-    left.sha256 === right.sha256 &&
-    left.size === right.size
-  );
+      : parseLegacyMcpOAuthStore(JSON.parse(utf8Decoder.decode(snapshot.buffer)));
+  return { ...snapshot, store: parsed };
 }
 
 function storeKeyForSource(sourcePath: string): string {

--- a/src/infra/state-migrations.meeting-transcripts.test.ts
+++ b/src/infra/state-migrations.meeting-transcripts.test.ts
@@ -9,7 +9,6 @@ import {
 } from "../state/openclaw-state-db.js";
 import { TranscriptsStore } from "../transcripts/store.js";
 import { summarizeTranscripts } from "../transcripts/summary.js";
-import { autoMigrateLegacyState } from "./state-migrations.js";
 import { restoreCanonicalMeetingTranscriptExports } from "./state-migrations.meeting-transcripts-files.js";
 import {
   detectLegacyMeetingTranscripts,
@@ -94,30 +93,6 @@ describe("meeting transcript Doctor migration", () => {
     expect(
       detectLegacyMeetingTranscripts({ stateDir, doctorOnlyStateMigrations: true }),
     ).toMatchObject({ hasLegacy: true });
-  });
-
-  it("reports completed transcript migration when a custom agent owns session state", async () => {
-    const stateDir = tempDirs.make("openclaw-meeting-transcripts-custom-agent-");
-    const sourceDir = await seedLegacySession({ stateDir, sessionId: "custom-agent-review" });
-    const env = {
-      ...databaseEnv(stateDir),
-      OPENCLAW_AGENT_DIR: path.join(stateDir, "custom-agent"),
-    };
-
-    const result = await autoMigrateLegacyState({
-      cfg: {},
-      doctorOnlyStateMigrations: true,
-      env,
-      now: () => Date.parse("2026-07-02T00:00:00.000Z"),
-    });
-
-    expect(result).toMatchObject({ migrated: true, skipped: true, warnings: [] });
-    expect(result.changes.join("\n")).not.toMatch(/meeting transcript|utterance/i);
-    await expect(fs.stat(sourceDir)).rejects.toMatchObject({ code: "ENOENT" });
-    const database = openOpenClawStateDatabase({ env }).db;
-    expect(
-      database.prepare("SELECT COUNT(*) AS count FROM meeting_transcript_sessions").get(),
-    ).toEqual({ count: 1 });
   });
 
   it("surfaces filesystem errors during detection", async () => {

--- a/src/infra/state-migrations.meeting-transcripts.test.ts
+++ b/src/infra/state-migrations.meeting-transcripts.test.ts
@@ -9,6 +9,7 @@ import {
 } from "../state/openclaw-state-db.js";
 import { TranscriptsStore } from "../transcripts/store.js";
 import { summarizeTranscripts } from "../transcripts/summary.js";
+import { autoMigrateLegacyState } from "./state-migrations.js";
 import { restoreCanonicalMeetingTranscriptExports } from "./state-migrations.meeting-transcripts-files.js";
 import {
   detectLegacyMeetingTranscripts,
@@ -93,6 +94,30 @@ describe("meeting transcript Doctor migration", () => {
     expect(
       detectLegacyMeetingTranscripts({ stateDir, doctorOnlyStateMigrations: true }),
     ).toMatchObject({ hasLegacy: true });
+  });
+
+  it("reports completed transcript migration when a custom agent owns session state", async () => {
+    const stateDir = tempDirs.make("openclaw-meeting-transcripts-custom-agent-");
+    const sourceDir = await seedLegacySession({ stateDir, sessionId: "custom-agent-review" });
+    const env = {
+      ...databaseEnv(stateDir),
+      OPENCLAW_AGENT_DIR: path.join(stateDir, "custom-agent"),
+    };
+
+    const result = await autoMigrateLegacyState({
+      cfg: {},
+      doctorOnlyStateMigrations: true,
+      env,
+      now: () => Date.parse("2026-07-02T00:00:00.000Z"),
+    });
+
+    expect(result).toMatchObject({ migrated: true, skipped: true, warnings: [] });
+    expect(result.changes.join("\n")).not.toMatch(/meeting transcript|utterance/i);
+    await expect(fs.stat(sourceDir)).rejects.toMatchObject({ code: "ENOENT" });
+    const database = openOpenClawStateDatabase({ env }).db;
+    expect(
+      database.prepare("SELECT COUNT(*) AS count FROM meeting_transcript_sessions").get(),
+    ).toEqual({ count: 1 });
   });
 
   it("surfaces filesystem errors during detection", async () => {

--- a/src/infra/state-migrations.node-host.ts
+++ b/src/infra/state-migrations.node-host.ts
@@ -1,6 +1,4 @@
 // Doctor-only import for the retired node-host JSON config.
-import { createHash } from "node:crypto";
-import fs from "node:fs";
 import path from "node:path";
 import { root, type Root } from "@openclaw/fs-safe";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
@@ -20,6 +18,14 @@ import {
   executeSqliteQueryTakeFirstSync,
   getNodeSqliteKysely,
 } from "./kysely-sync.js";
+import {
+  legacyMigrationSourceContentMatches as contentSnapshotsMatch,
+  legacyMigrationSourceOrClaimMayExist,
+  legacyMigrationSourceSnapshotsMatch as sourceSnapshotsMatch,
+  readLegacyMigrationSourceSnapshot,
+  resolveLegacyMigrationRelativePath,
+  type LegacyMigrationSourceSnapshot as LegacySourceSnapshot,
+} from "./state-migrations.source-snapshot.js";
 import type { LegacyStateDetection, MigrationMessages } from "./state-migrations.types.js";
 
 const LEGACY_NODE_HOST_MAX_BYTES = 64 * 1024;
@@ -30,36 +36,10 @@ const GATEWAY_KEYS = new Set(["host", "port", "tls", "tlsFingerprint", "contextP
 
 type NodeHostConfigDatabase = Pick<OpenClawStateKyselyDatabase, "node_host_config">;
 
-type LegacySourceSnapshot = {
-  sourcePath: string;
-  dev: number;
-  ino: number;
-  mtimeMs: number;
-  raw: string;
-  sha256: string;
-  size: number;
-};
-
 type CanonicalNodeHostState = {
   config: NodeHostConfig;
   updatedAtMs: number;
 };
-
-function legacyPathMayExist(filePath: string): boolean {
-  try {
-    fs.lstatSync(filePath);
-    return true;
-  } catch (error) {
-    return (error as NodeJS.ErrnoException).code !== "ENOENT";
-  }
-}
-
-function sourceOrClaimMayExist(sourcePath: string): boolean {
-  return (
-    legacyPathMayExist(sourcePath) ||
-    legacyPathMayExist(`${sourcePath}${LEGACY_NODE_HOST_CONFIG_CLAIM_SUFFIX}`)
-  );
-}
 
 /** Detect retired node-host state only when an explicit Doctor flow opts in. */
 export function detectLegacyNodeHostConfig(params: {
@@ -69,21 +49,14 @@ export function detectLegacyNodeHostConfig(params: {
   const sourcePath = path.join(params.stateDir, LEGACY_NODE_HOST_CONFIG_FILE);
   return {
     sourcePath,
-    hasLegacy: params.doctorOnlyStateMigrations === true && sourceOrClaimMayExist(sourcePath),
+    hasLegacy:
+      params.doctorOnlyStateMigrations === true &&
+      legacyMigrationSourceOrClaimMayExist(sourcePath, LEGACY_NODE_HOST_CONFIG_CLAIM_SUFFIX),
   };
 }
 
 function relativeLegacyPath(stateDir: string, filePath: string): string {
-  const relativePath = path.relative(path.resolve(stateDir), path.resolve(filePath));
-  if (
-    !relativePath ||
-    relativePath === ".." ||
-    relativePath.startsWith(`..${path.sep}`) ||
-    path.isAbsolute(relativePath)
-  ) {
-    throw new Error(`legacy node-host path is outside the state directory: ${filePath}`);
-  }
-  return relativePath;
+  return resolveLegacyMigrationRelativePath(stateDir, filePath, "node-host");
 }
 
 async function readLegacySourceSnapshot(
@@ -91,35 +64,14 @@ async function readLegacySourceSnapshot(
   stateDir: string,
   sourcePath: string,
 ): Promise<LegacySourceSnapshot> {
-  const opened = await stateRoot.read(relativeLegacyPath(stateDir, sourcePath), {
-    hardlinks: "reject",
-    maxBytes: LEGACY_NODE_HOST_MAX_BYTES,
-    symlinks: "reject",
-  });
-  const raw = opened.buffer.toString("utf8");
-  return {
+  return readLegacyMigrationSourceSnapshot({
+    stateRoot,
+    stateDir,
     sourcePath,
-    dev: opened.stat.dev,
-    ino: opened.stat.ino,
-    mtimeMs: opened.stat.mtimeMs,
-    raw,
-    sha256: createHash("sha256").update(raw).digest("hex"),
-    size: opened.stat.size,
-  };
-}
-
-function sourceSnapshotsMatch(left: LegacySourceSnapshot, right: LegacySourceSnapshot): boolean {
-  return (
-    left.dev === right.dev &&
-    left.ino === right.ino &&
-    left.mtimeMs === right.mtimeMs &&
-    left.sha256 === right.sha256 &&
-    left.size === right.size
-  );
-}
-
-function contentSnapshotsMatch(left: LegacySourceSnapshot, right: LegacySourceSnapshot): boolean {
-  return left.sha256 === right.sha256 && left.size === right.size;
+    maxBytes: LEGACY_NODE_HOST_MAX_BYTES,
+    label: "node-host",
+    hashDecodedText: true,
+  });
 }
 
 async function recoverInterruptedClaim(

--- a/src/infra/state-migrations.restart-sentinel.ts
+++ b/src/infra/state-migrations.restart-sentinel.ts
@@ -1,6 +1,5 @@
 // Startup/Doctor migration for the retired restart-sentinel JSON file.
 import { createHash } from "node:crypto";
-import fs from "node:fs";
 import path from "node:path";
 import { isDeepStrictEqual } from "node:util";
 import { root, type Root } from "@openclaw/fs-safe";
@@ -23,6 +22,13 @@ import {
   type RestartSentinelEnvelope,
 } from "./restart-sentinel-store.js";
 import type { LegacyRestartSentinelDetection } from "./state-migrations.restart-sentinel.types.js";
+import {
+  legacyMigrationSourceOrClaimMayExist,
+  legacyMigrationSourceSnapshotsMatch as snapshotsMatch,
+  readLegacyMigrationSourceSnapshot,
+  resolveLegacyMigrationRelativePath,
+  type LegacyMigrationSourceSnapshot as LegacySourceSnapshot,
+} from "./state-migrations.source-snapshot.js";
 import type { MigrationMessages } from "./state-migrations.types.js";
 
 const LEGACY_RESTART_SENTINEL_FILENAME = "restart-sentinel.json";
@@ -38,30 +44,12 @@ type RestartSentinelMigrationDatabase = Pick<
   "gateway_restart_sentinel" | "migration_runs" | "migration_sources"
 >;
 
-type LegacySourceSnapshot = {
-  buffer: Buffer;
-  dev: number;
-  ino: number;
-  mtimeMs: number;
-  sha256: string;
-  size: number;
-};
-
 type MigrationDecision =
   | "canonical-preserved"
   | "invalid-canonical-repaired"
   | "legacy-imported"
   | "malformed-legacy-discarded"
   | "receipt-authoritative";
-
-function legacyPathMayExist(filePath: string): boolean {
-  try {
-    fs.lstatSync(filePath);
-    return true;
-  } catch (error) {
-    return (error as NodeJS.ErrnoException).code !== "ENOENT";
-  }
-}
 
 /** Detect the exact retired file for startup preflight and explicit Doctor alike. */
 export function detectLegacyRestartSentinel(params: {
@@ -70,22 +58,12 @@ export function detectLegacyRestartSentinel(params: {
   const sourcePath = path.join(params.stateDir, LEGACY_RESTART_SENTINEL_FILENAME);
   return {
     sourcePath,
-    hasLegacy:
-      legacyPathMayExist(sourcePath) || legacyPathMayExist(`${sourcePath}${DOCTOR_CLAIM_SUFFIX}`),
+    hasLegacy: legacyMigrationSourceOrClaimMayExist(sourcePath, DOCTOR_CLAIM_SUFFIX),
   };
 }
 
 function relativeLegacyPath(stateDir: string, filePath: string): string {
-  const relativePath = path.relative(path.resolve(stateDir), path.resolve(filePath));
-  if (
-    !relativePath ||
-    relativePath === ".." ||
-    relativePath.startsWith(`..${path.sep}`) ||
-    path.isAbsolute(relativePath)
-  ) {
-    throw new Error("legacy restart sentinel path is outside the state directory");
-  }
-  return relativePath;
+  return resolveLegacyMigrationRelativePath(stateDir, filePath, "restart sentinel", false);
 }
 
 async function readLegacySourceSnapshot(
@@ -93,32 +71,13 @@ async function readLegacySourceSnapshot(
   stateDir: string,
   sourcePath: string,
 ): Promise<LegacySourceSnapshot> {
-  const opened = await stateRoot.read(relativeLegacyPath(stateDir, sourcePath), {
-    hardlinks: "reject",
+  return readLegacyMigrationSourceSnapshot({
+    stateRoot,
+    stateDir,
+    sourcePath,
     maxBytes: MAX_LEGACY_RESTART_SENTINEL_BYTES,
-    symlinks: "reject",
+    label: "restart sentinel",
   });
-  if (!opened.stat.isFile() || opened.stat.size !== opened.buffer.byteLength) {
-    throw new Error("legacy restart sentinel is not a stable regular file");
-  }
-  return {
-    buffer: opened.buffer,
-    dev: opened.stat.dev,
-    ino: opened.stat.ino,
-    mtimeMs: opened.stat.mtimeMs,
-    sha256: createHash("sha256").update(opened.buffer).digest("hex"),
-    size: opened.stat.size,
-  };
-}
-
-function snapshotsMatch(left: LegacySourceSnapshot, right: LegacySourceSnapshot): boolean {
-  return (
-    left.dev === right.dev &&
-    left.ino === right.ino &&
-    left.mtimeMs === right.mtimeMs &&
-    left.sha256 === right.sha256 &&
-    left.size === right.size
-  );
 }
 
 function parseLegacyEnvelope(snapshot: LegacySourceSnapshot): RestartSentinelEnvelope | null {

--- a/src/infra/state-migrations.source-snapshot.test.ts
+++ b/src/infra/state-migrations.source-snapshot.test.ts
@@ -1,0 +1,77 @@
+import fs from "node:fs";
+import path from "node:path";
+import { root } from "@openclaw/fs-safe";
+import { afterEach, describe, expect, it } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
+import {
+  assertLegacyMigrationSourceUnchanged,
+  claimAndRemoveLegacyMigrationSource,
+  legacyMigrationSourceOrClaimMayExist,
+  legacyMigrationSourceSnapshotsMatch,
+  readLegacyMigrationSourceSnapshot,
+  readLegacyMigrationSourceSnapshotSync,
+  resolveLegacyMigrationRelativePath,
+} from "./state-migrations.source-snapshot.js";
+
+describe("doctor legacy migration source contract", () => {
+  const tempDirs = useAutoCleanupTempDirTracker((cleanup) => {
+    afterEach(cleanup);
+  });
+
+  function createSource(content = '{"version":1}\n') {
+    const stateDir = tempDirs.make("openclaw-migration-source-");
+    const sourcePath = path.join(stateDir, "legacy.json");
+    fs.writeFileSync(sourcePath, content, "utf8");
+    return { sourcePath, stateDir };
+  }
+
+  it("detects an interrupted claim without accepting absent source state", () => {
+    const { sourcePath } = createSource();
+    fs.renameSync(sourcePath, `${sourcePath}.doctor-importing`);
+    expect(legacyMigrationSourceOrClaimMayExist(sourcePath)).toBe(true);
+    fs.unlinkSync(`${sourcePath}.doctor-importing`);
+    expect(legacyMigrationSourceOrClaimMayExist(sourcePath)).toBe(false);
+  });
+
+  it("rejects source paths outside the trusted migration root", () => {
+    const { stateDir } = createSource();
+    expect(() =>
+      resolveLegacyMigrationRelativePath(stateDir, path.join(stateDir, "..", "escape"), "test"),
+    ).toThrow("outside the state directory");
+  });
+
+  it("shares the same pinned source identity across root-bound and sync readers", async () => {
+    const { sourcePath, stateDir } = createSource();
+    const stateRoot = await root(stateDir, { hardlinks: "reject", symlinks: "reject" });
+    const bounded = await readLegacyMigrationSourceSnapshot({
+      stateRoot,
+      stateDir,
+      sourcePath,
+      maxBytes: 1024,
+      label: "test",
+    });
+    const sync = readLegacyMigrationSourceSnapshotSync({ sourcePath, label: "test" });
+    expect(legacyMigrationSourceSnapshotsMatch(bounded, sync)).toBe(true);
+    fs.writeFileSync(sourcePath, '{"version":2}\n', "utf8");
+    expect(() =>
+      assertLegacyMigrationSourceUnchanged({ sourcePath, snapshot: sync, label: "test" }),
+    ).toThrow("changed after doctor loaded it");
+  });
+
+  it("restores the original source when verified claim cleanup fails", () => {
+    const { sourcePath } = createSource();
+    const snapshot = readLegacyMigrationSourceSnapshotSync({ sourcePath, label: "test" });
+    expect(() =>
+      claimAndRemoveLegacyMigrationSource({
+        sourcePath,
+        snapshot,
+        label: "test",
+        removeSource: () => {
+          throw new Error("simulated cleanup failure");
+        },
+      }),
+    ).toThrow("simulated cleanup failure");
+    expect(fs.readFileSync(sourcePath, "utf8")).toBe(snapshot.raw);
+    expect(fs.readdirSync(path.dirname(sourcePath))).toEqual(["legacy.json"]);
+  });
+});

--- a/src/infra/state-migrations.source-snapshot.ts
+++ b/src/infra/state-migrations.source-snapshot.ts
@@ -1,0 +1,199 @@
+import { createHash, randomUUID } from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+import type { Root } from "@openclaw/fs-safe";
+
+/** The stable source identity every doctor-owned import verifies before cleanup. */
+export type LegacyMigrationSourceSnapshot = {
+  buffer: Buffer;
+  dev: number;
+  ino: number;
+  mtimeMs: number;
+  raw: string;
+  sha256: string;
+  size: number;
+  sourcePath: string;
+};
+
+/** A source may be inaccessible; only a proven absence permits skipping repair. */
+export function legacyMigrationPathMayExist(filePath: string): boolean {
+  try {
+    fs.lstatSync(filePath);
+    return true;
+  } catch (error) {
+    return (error as NodeJS.ErrnoException).code !== "ENOENT";
+  }
+}
+
+export function legacyMigrationSourceOrClaimMayExist(
+  sourcePath: string,
+  claimSuffix = ".doctor-importing",
+): boolean {
+  return (
+    legacyMigrationPathMayExist(sourcePath) ||
+    legacyMigrationPathMayExist(`${sourcePath}${claimSuffix}`)
+  );
+}
+
+/** Constrain migration reads and moves to the original trusted state root. */
+export function resolveLegacyMigrationRelativePath(
+  stateDir: string,
+  filePath: string,
+  label: string,
+  includeFilePath = true,
+): string {
+  const relativePath = path.relative(path.resolve(stateDir), path.resolve(filePath));
+  if (
+    !relativePath ||
+    relativePath === ".." ||
+    relativePath.startsWith(`..${path.sep}`) ||
+    path.isAbsolute(relativePath)
+  ) {
+    throw new Error(
+      `legacy ${label} path is outside the state directory${includeFilePath ? `: ${filePath}` : ""}`,
+    );
+  }
+  return relativePath;
+}
+
+/** Hash the exact bounded bytes returned by the symlink/hardlink-safe root. */
+export async function readLegacyMigrationSourceSnapshot(params: {
+  stateRoot: Root;
+  stateDir: string;
+  sourcePath: string;
+  maxBytes: number;
+  label: string;
+  hashDecodedText?: boolean;
+}): Promise<LegacyMigrationSourceSnapshot> {
+  const opened = await params.stateRoot.read(
+    resolveLegacyMigrationRelativePath(params.stateDir, params.sourcePath, params.label),
+    { hardlinks: "reject", maxBytes: params.maxBytes, symlinks: "reject" },
+  );
+  if (!opened.stat.isFile() || opened.stat.size !== opened.buffer.byteLength) {
+    throw new Error(`legacy ${params.label} source is not a stable regular file`);
+  }
+  const raw = opened.buffer.toString("utf8");
+  return {
+    buffer: opened.buffer,
+    dev: opened.stat.dev,
+    ino: opened.stat.ino,
+    mtimeMs: opened.stat.mtimeMs,
+    raw,
+    sha256: createHash("sha256")
+      .update(params.hashDecodedText ? raw : opened.buffer)
+      .digest("hex"),
+    size: opened.stat.size,
+    sourcePath: params.sourcePath,
+  };
+}
+
+/** Pin synchronous legacy files before and after parsing; never follow new links. */
+export function readLegacyMigrationSourceSnapshotSync(params: {
+  sourcePath: string;
+  label: string;
+  followSymlinks?: boolean;
+  maxBytes?: number;
+}): LegacyMigrationSourceSnapshot {
+  const stat = params.followSymlinks ? fs.statSync : fs.lstatSync;
+  const before = stat(params.sourcePath);
+  if (!before.isFile() || (!params.followSymlinks && before.isSymbolicLink())) {
+    throw new Error(
+      `legacy ${params.label} source is not a regular${params.followSymlinks ? "" : " non-symlink"} file`,
+    );
+  }
+  if (params.maxBytes !== undefined && before.size > params.maxBytes) {
+    throw new Error(`legacy ${params.label} source exceeds the metadata size limit`);
+  }
+  const raw = fs.readFileSync(params.sourcePath, "utf8");
+  const after = stat(params.sourcePath);
+  if (
+    !after.isFile() ||
+    (!params.followSymlinks && after.isSymbolicLink()) ||
+    before.dev !== after.dev ||
+    before.ino !== after.ino ||
+    before.size !== after.size ||
+    before.mtimeMs !== after.mtimeMs
+  ) {
+    throw new Error(`legacy ${params.label} source changed while doctor was reading it`);
+  }
+  return {
+    buffer: Buffer.from(raw),
+    dev: after.dev,
+    ino: after.ino,
+    mtimeMs: after.mtimeMs,
+    raw,
+    sha256: createHash("sha256").update(raw).digest("hex"),
+    size: after.size,
+    sourcePath: params.sourcePath,
+  };
+}
+
+/** Check source identity again before committing or deleting a verified import. */
+export function assertLegacyMigrationSourceUnchanged(params: {
+  sourcePath: string;
+  snapshot: LegacyMigrationSourceSnapshot;
+  label: string;
+  followSymlinks?: boolean;
+  maxBytes?: number;
+}): void {
+  if (
+    !legacyMigrationSourceSnapshotsMatch(
+      readLegacyMigrationSourceSnapshotSync(params),
+      params.snapshot,
+    )
+  ) {
+    throw new Error(`legacy ${params.label} source changed after doctor loaded it`);
+  }
+}
+
+/** Restore a claimed legacy source when verified cleanup cannot complete. */
+export function claimAndRemoveLegacyMigrationSource(params: {
+  sourcePath: string;
+  snapshot: LegacyMigrationSourceSnapshot;
+  label: string;
+  followSymlinks?: boolean;
+  maxBytes?: number;
+  beforeClaim?: () => void;
+  removeSource?: (sourcePath: string) => void;
+}): void {
+  params.beforeClaim?.();
+  const claimPath = `${params.sourcePath}.doctor-importing-${process.pid}-${randomUUID()}`;
+  fs.renameSync(params.sourcePath, claimPath);
+  try {
+    const claimed = readLegacyMigrationSourceSnapshotSync({ ...params, sourcePath: claimPath });
+    if (!legacyMigrationSourceSnapshotsMatch(claimed, params.snapshot)) {
+      throw new Error(`legacy ${params.label} source changed before doctor could claim it`);
+    }
+    (params.removeSource ?? fs.unlinkSync)(claimPath);
+  } catch (error) {
+    let restoreFailure = "";
+    if (fs.existsSync(claimPath) && !fs.existsSync(params.sourcePath)) {
+      try {
+        fs.renameSync(claimPath, params.sourcePath);
+      } catch (restoreError) {
+        restoreFailure = `; the claimed source remains at ${claimPath} because restore also failed: ${String(restoreError)}`;
+      }
+    }
+    throw new Error(`${String(error)}${restoreFailure}`, { cause: error });
+  }
+}
+
+export function legacyMigrationSourceSnapshotsMatch(
+  left: Pick<LegacyMigrationSourceSnapshot, "dev" | "ino" | "mtimeMs" | "sha256" | "size">,
+  right: Pick<LegacyMigrationSourceSnapshot, "dev" | "ino" | "mtimeMs" | "sha256" | "size">,
+): boolean {
+  return (
+    left.dev === right.dev &&
+    left.ino === right.ino &&
+    left.mtimeMs === right.mtimeMs &&
+    left.sha256 === right.sha256 &&
+    left.size === right.size
+  );
+}
+
+export function legacyMigrationSourceContentMatches(
+  left: Pick<LegacyMigrationSourceSnapshot, "sha256" | "size">,
+  right: Pick<LegacyMigrationSourceSnapshot, "sha256" | "size">,
+): boolean {
+  return left.sha256 === right.sha256 && left.size === right.size;
+}

--- a/src/infra/state-migrations.subagent-registry.ts
+++ b/src/infra/state-migrations.subagent-registry.ts
@@ -1,10 +1,15 @@
 // Doctor-only removal for the retired subagent run registry JSON store.
-import { createHash } from "node:crypto";
-import fs from "node:fs";
 import path from "node:path";
 import { root, type Root } from "@openclaw/fs-safe";
 import { formatErrorMessage } from "./errors.js";
 import { acquireGatewayLock, GatewayLockError } from "./gateway-lock.js";
+import {
+  legacyMigrationSourceOrClaimMayExist as sourceOrClaimMayExist,
+  legacyMigrationSourceSnapshotsMatch as sourceSnapshotsMatch,
+  readLegacyMigrationSourceSnapshot,
+  resolveLegacyMigrationRelativePath,
+  type LegacyMigrationSourceSnapshot as LegacySourceSnapshot,
+} from "./state-migrations.source-snapshot.js";
 import {
   markLegacySubagentRegistrySourceRemoved,
   recordLegacySubagentRegistryDiscard,
@@ -16,32 +21,8 @@ const MIGRATION_LOCK_TIMEOUT_MS = 250;
 const MIGRATION_LOCK_POLL_INTERVAL_MS = 25;
 const DOCTOR_CLAIM_SUFFIX = ".doctor-importing";
 
-type LegacySourceSnapshot = {
-  sourcePath: string;
-  dev: number;
-  ino: number;
-  mtimeMs: number;
-  sha256: string;
-  size: number;
-};
-
 function resolveLegacySubagentRegistryPath(stateDir: string): string {
   return path.join(stateDir, "subagents", "runs.json");
-}
-
-function legacyPathMayExist(filePath: string): boolean {
-  try {
-    fs.lstatSync(filePath);
-    return true;
-  } catch (error) {
-    return (error as NodeJS.ErrnoException).code !== "ENOENT";
-  }
-}
-
-function sourceOrClaimMayExist(sourcePath: string): boolean {
-  return (
-    legacyPathMayExist(sourcePath) || legacyPathMayExist(`${sourcePath}${DOCTOR_CLAIM_SUFFIX}`)
-  );
 }
 
 /** Detect retired subagent state only when an explicit Doctor flow opts in. */
@@ -57,16 +38,7 @@ export function detectLegacySubagentRegistry(params: {
 }
 
 function relativeLegacyPath(stateDir: string, filePath: string): string {
-  const relativePath = path.relative(path.resolve(stateDir), path.resolve(filePath));
-  if (
-    !relativePath ||
-    relativePath === ".." ||
-    relativePath.startsWith(`..${path.sep}`) ||
-    path.isAbsolute(relativePath)
-  ) {
-    throw new Error(`legacy subagent registry path is outside the state directory: ${filePath}`);
-  }
-  return relativePath;
+  return resolveLegacyMigrationRelativePath(stateDir, filePath, "subagent registry");
 }
 
 async function readLegacySourceSnapshot(
@@ -74,29 +46,13 @@ async function readLegacySourceSnapshot(
   stateDir: string,
   sourcePath: string,
 ): Promise<LegacySourceSnapshot> {
-  const opened = await stateRoot.read(relativeLegacyPath(stateDir, sourcePath), {
-    hardlinks: "reject",
-    maxBytes: LEGACY_SUBAGENT_REGISTRY_MAX_BYTES,
-    symlinks: "reject",
-  });
-  return {
+  return readLegacyMigrationSourceSnapshot({
+    stateRoot,
+    stateDir,
     sourcePath,
-    dev: opened.stat.dev,
-    ino: opened.stat.ino,
-    mtimeMs: opened.stat.mtimeMs,
-    sha256: createHash("sha256").update(opened.buffer).digest("hex"),
-    size: opened.stat.size,
-  };
-}
-
-function sourceSnapshotsMatch(left: LegacySourceSnapshot, right: LegacySourceSnapshot): boolean {
-  return (
-    left.dev === right.dev &&
-    left.ino === right.ino &&
-    left.mtimeMs === right.mtimeMs &&
-    left.sha256 === right.sha256 &&
-    left.size === right.size
-  );
+    maxBytes: LEGACY_SUBAGENT_REGISTRY_MAX_BYTES,
+    label: "subagent registry",
+  });
 }
 
 async function recoverInterruptedClaim(

--- a/src/infra/state-migrations.tui-last-session.ts
+++ b/src/infra/state-migrations.tui-last-session.ts
@@ -1,5 +1,4 @@
 // Doctor-only import for the retired TUI last-session JSON store.
-import { createHash, randomUUID } from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
 import type { DB as OpenClawStateKyselyDatabase } from "../state/openclaw-state-db.generated.js";
@@ -12,6 +11,12 @@ import {
   executeSqliteQueryTakeFirstSync,
   getNodeSqliteKysely,
 } from "./kysely-sync.js";
+import {
+  assertLegacyMigrationSourceUnchanged,
+  claimAndRemoveLegacyMigrationSource,
+  readLegacyMigrationSourceSnapshotSync,
+  type LegacyMigrationSourceSnapshot as LegacySourceSnapshot,
+} from "./state-migrations.source-snapshot.js";
 import type { LegacyStateDetection, MigrationMessages } from "./state-migrations.types.js";
 
 type TuiLastSessionMigrationDatabase = Pick<OpenClawStateKyselyDatabase, "tui_last_sessions">;
@@ -20,15 +25,6 @@ type LegacyTuiLastSession = {
   scopeKey: string;
   sessionKey: string;
   updatedAt: number;
-};
-
-type LegacySourceSnapshot = {
-  dev: number;
-  ino: number;
-  mtimeMs: number;
-  raw: string;
-  sha256: string;
-  size: number;
 };
 
 const LEGACY_RECORD_KEYS = new Set(["sessionKey", "updatedAt"]);
@@ -50,87 +46,20 @@ export function detectLegacyTuiLastSessions(params: {
 }
 
 function readLegacySourceSnapshot(sourcePath: string): LegacySourceSnapshot {
-  const before = fs.statSync(sourcePath);
-  if (!before.isFile()) {
-    throw new Error("legacy TUI last-session source is not a regular file");
-  }
-  const raw = fs.readFileSync(sourcePath, "utf8");
-  const after = fs.statSync(sourcePath);
-  if (
-    before.dev !== after.dev ||
-    before.ino !== after.ino ||
-    before.size !== after.size ||
-    before.mtimeMs !== after.mtimeMs
-  ) {
-    throw new Error("legacy TUI last-session source changed while doctor was reading it");
-  }
-  return {
-    dev: after.dev,
-    ino: after.ino,
-    mtimeMs: after.mtimeMs,
-    raw,
-    sha256: createHash("sha256").update(raw).digest("hex"),
-    size: after.size,
-  };
+  return readLegacyMigrationSourceSnapshotSync({
+    sourcePath,
+    label: "TUI last-session",
+    followSymlinks: true,
+  });
 }
 
 function assertLegacySourceUnchanged(sourcePath: string, expected: LegacySourceSnapshot): void {
-  const current = readLegacySourceSnapshot(sourcePath);
-  if (!legacySourceSnapshotsMatch(current, expected)) {
-    throw new Error("legacy TUI last-session source changed after doctor loaded it");
-  }
-}
-
-function legacySourceSnapshotsMatch(
-  current: LegacySourceSnapshot,
-  expected: LegacySourceSnapshot,
-): boolean {
-  return (
-    current.dev === expected.dev &&
-    current.ino === expected.ino &&
-    current.size === expected.size &&
-    current.mtimeMs === expected.mtimeMs &&
-    current.sha256 === expected.sha256
-  );
-}
-
-function restoreClaimAfterCleanupFailure(params: {
-  claimPath: string;
-  sourcePath: string;
-}): string | null {
-  if (!fs.existsSync(params.claimPath) || fs.existsSync(params.sourcePath)) {
-    return null;
-  }
-  try {
-    fs.renameSync(params.claimPath, params.sourcePath);
-    return null;
-  } catch (error) {
-    return `; the claimed source remains at ${params.claimPath} because restore also failed: ${String(error)}`;
-  }
-}
-
-function claimAndRemoveVerifiedLegacySource(params: {
-  sourcePath: string;
-  snapshot: LegacySourceSnapshot;
-  beforeClaim?: () => void;
-  removeSource?: (sourcePath: string) => void;
-}): void {
-  params.beforeClaim?.();
-  const claimPath = `${params.sourcePath}.doctor-importing-${process.pid}-${randomUUID()}`;
-  fs.renameSync(params.sourcePath, claimPath);
-  try {
-    const claimedSnapshot = readLegacySourceSnapshot(claimPath);
-    if (!legacySourceSnapshotsMatch(claimedSnapshot, params.snapshot)) {
-      throw new Error("legacy TUI last-session source changed before doctor could claim it");
-    }
-    (params.removeSource ?? fs.unlinkSync)(claimPath);
-  } catch (error) {
-    const restoreFailure = restoreClaimAfterCleanupFailure({
-      claimPath,
-      sourcePath: params.sourcePath,
-    });
-    throw new Error(`${String(error)}${restoreFailure ?? ""}`, { cause: error });
-  }
+  assertLegacyMigrationSourceUnchanged({
+    sourcePath,
+    snapshot: expected,
+    label: "TUI last-session",
+    followSymlinks: true,
+  });
 }
 
 function isObjectRecord(value: unknown): value is Record<string, unknown> {
@@ -305,9 +234,11 @@ export function migrateLegacyTuiLastSessions(params: {
   }
 
   try {
-    claimAndRemoveVerifiedLegacySource({
+    claimAndRemoveLegacyMigrationSource({
       sourcePath: params.detected.sourcePath,
       snapshot,
+      label: "TUI last-session",
+      followSymlinks: true,
       beforeClaim: params.beforeClaim,
       removeSource: params.removeSource,
     });

--- a/src/infra/state-migrations.web-push.ts
+++ b/src/infra/state-migrations.web-push.ts
@@ -1,5 +1,3 @@
-import { createHash } from "node:crypto";
-import fs from "node:fs";
 import path from "node:path";
 import type { DatabaseSync } from "node:sqlite";
 import { root, type Root } from "@openclaw/fs-safe";
@@ -22,6 +20,14 @@ import {
   type WebPushDatabase,
   type WebPushSubscription,
 } from "./push-web-store.js";
+import {
+  legacyMigrationSourceContentMatches as contentSnapshotsMatch,
+  legacyMigrationSourceOrClaimMayExist as sourceOrClaimMayExist,
+  legacyMigrationSourceSnapshotsMatch as sourceSnapshotsMatch,
+  readLegacyMigrationSourceSnapshot,
+  resolveLegacyMigrationRelativePath,
+  type LegacyMigrationSourceSnapshot as LegacySourceSnapshot,
+} from "./state-migrations.source-snapshot.js";
 import type { LegacyStateDetection, MigrationMessages } from "./state-migrations.types.js";
 import {
   parseLegacySubscriptions,
@@ -33,16 +39,6 @@ const LEGACY_VAPID_KEYS_MAX_BYTES = 64 * 1024;
 const MIGRATION_LOCK_TIMEOUT_MS = 250;
 const MIGRATION_LOCK_POLL_INTERVAL_MS = 25;
 const DOCTOR_CLAIM_SUFFIX = ".doctor-importing";
-
-type LegacySourceSnapshot = {
-  sourcePath: string;
-  dev: number;
-  ino: number;
-  mtimeMs: number;
-  raw: string;
-  sha256: string;
-  size: number;
-};
 
 type ParsedLegacyState = {
   subscriptions: Map<string, WebPushSubscription>;
@@ -57,30 +53,9 @@ function resolveLegacyWebPushPaths(stateDir: string) {
   };
 }
 
-function legacyPathMayExist(filePath: string): boolean {
-  try {
-    fs.lstatSync(filePath);
-    return true;
-  } catch (error) {
-    return (error as NodeJS.ErrnoException).code !== "ENOENT";
-  }
-}
-
 function relativeLegacyPath(stateDir: string, filePath: string): string {
-  const relativePath = path.relative(path.resolve(stateDir), path.resolve(filePath));
-  if (
-    !relativePath ||
-    relativePath === ".." ||
-    relativePath.startsWith(`..${path.sep}`) ||
-    path.isAbsolute(relativePath)
-  ) {
-    throw new Error(`legacy Web Push path is outside the state directory: ${filePath}`);
-  }
-  return relativePath;
+  return resolveLegacyMigrationRelativePath(stateDir, filePath, "Web Push");
 }
-
-const sourceOrClaimMayExist = (sourcePath: string) =>
-  legacyPathMayExist(sourcePath) || legacyPathMayExist(`${sourcePath}${DOCTOR_CLAIM_SUFFIX}`);
 
 export function detectLegacyWebPush(params: {
   stateDir: string;
@@ -102,35 +77,14 @@ async function readLegacySourceSnapshot(
   sourcePath: string,
   maxBytes: number,
 ): Promise<LegacySourceSnapshot> {
-  const opened = await stateRoot.read(relativeLegacyPath(stateDir, sourcePath), {
-    hardlinks: "reject",
-    maxBytes,
-    symlinks: "reject",
-  });
-  const raw = opened.buffer.toString("utf8");
-  return {
+  return readLegacyMigrationSourceSnapshot({
+    stateRoot,
+    stateDir,
     sourcePath,
-    dev: opened.stat.dev,
-    ino: opened.stat.ino,
-    mtimeMs: opened.stat.mtimeMs,
-    raw,
-    sha256: createHash("sha256").update(raw).digest("hex"),
-    size: opened.stat.size,
-  };
-}
-
-function sourceSnapshotsMatch(left: LegacySourceSnapshot, right: LegacySourceSnapshot): boolean {
-  return (
-    left.dev === right.dev &&
-    left.ino === right.ino &&
-    left.mtimeMs === right.mtimeMs &&
-    left.sha256 === right.sha256 &&
-    left.size === right.size
-  );
-}
-
-function contentSnapshotsMatch(left: LegacySourceSnapshot, right: LegacySourceSnapshot): boolean {
-  return left.sha256 === right.sha256 && left.size === right.size;
+    maxBytes,
+    label: "Web Push",
+    hashDecodedText: true,
+  });
 }
 
 function maxBytesForSource(sourcePath: string, subscriptionsPath: string): number {

--- a/src/infra/state-migrations.workspace-setup.ts
+++ b/src/infra/state-migrations.workspace-setup.ts
@@ -19,6 +19,11 @@ import { resolveLegacyStateDirs } from "../config/paths.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { formatErrorMessage } from "./errors.js";
 import { acquireGatewayLock, GatewayLockError } from "./gateway-lock.js";
+import {
+  legacyMigrationPathMayExist as pathMayExist,
+  legacyMigrationSourceOrClaimMayExist as sourceOrClaimMayExist,
+  legacyMigrationSourceSnapshotsMatch as snapshotsMatch,
+} from "./state-migrations.source-snapshot.js";
 import type { MigrationMessages } from "./state-migrations.types.js";
 import {
   markSourceRemoved,
@@ -42,19 +47,6 @@ const CLAIM_SUFFIX = WORKSPACE_DOCTOR_CLAIM_SUFFIX;
 const MIGRATION_LOCK_TIMEOUT_MS = 250;
 const MIGRATION_LOCK_POLL_INTERVAL_MS = 25;
 const utf8Decoder = new TextDecoder("utf-8", { fatal: true });
-
-function pathMayExist(filePath: string): boolean {
-  try {
-    fs.lstatSync(filePath);
-    return true;
-  } catch (error) {
-    return (error as NodeJS.ErrnoException).code !== "ENOENT";
-  }
-}
-
-function sourceOrClaimMayExist(sourcePath: string): boolean {
-  return pathMayExist(sourcePath) || pathMayExist(`${sourcePath}${CLAIM_SUFFIX}`);
-}
 
 async function readBoundedRegularFile(params: {
   sourceRoot: Root;
@@ -139,16 +131,6 @@ function createLegacySource(
     throw new Error("legacy workspace source is outside its migration root");
   }
   return { ...params, rootDir, relativePath, sourcePath };
-}
-
-function snapshotsMatch(left: SourceSnapshot, right: SourceSnapshot): boolean {
-  return (
-    left.dev === right.dev &&
-    left.ino === right.ino &&
-    left.mtimeMs === right.mtimeMs &&
-    left.sha256 === right.sha256 &&
-    left.size === right.size
-  );
 }
 
 function siblingAttestationNeedsDoctor(filePath: string): boolean {

--- a/test/vitest/vitest.extension-codex-app-server-attempt-extra.config.ts
+++ b/test/vitest/vitest.extension-codex-app-server-attempt-extra.config.ts
@@ -6,7 +6,6 @@ function createExtensionCodexAppServerAttemptExtraVitestConfig(
 ) {
   return createScopedVitestConfig(
     [
-      "extensions/codex/src/app-server/run-attempt-client-prewarm.test.ts",
       "extensions/codex/src/app-server/run-attempt-lifecycle-controller.test.ts",
       "extensions/codex/src/app-server/run-attempt-thread-cleanup.test.ts",
       "extensions/codex/src/app-server/run-attempt.context-engine.test.ts",


### PR DESCRIPTION
## What Problem This Solves

OpenClaw doctor and startup independently reimplemented legacy-state source detection, root containment, snapshot verification, archive claims, and migration reporting. The paths could drift, including a successful custom-agent transcript migration reported as not migrated.

## Why This Change Was Made

Share one doctor-owned, root-bounded SQLite migration source contract across session, device, approval, OAuth, push, node-host, workspace, and transient-state owners. Preserve serial owner order, plugin-owned contracts, multi-agent boundaries, archive and restore receipts, malformed-input handling, and canonical custom-agent reporting. The production refactor removes 510 net production lines without adding a SQLite schema version, configuration, environment, JSON runtime fallback, provider, or plugin-SDK surface.

## User Impact

Existing installations retain shipped doctor repair, account and device credentials, recoverable archives, transcript history, and per-agent SQLite ownership. Fresh installs remain SQLite-only. Custom-agent transcript repairs report `migrated: true` and `skipped: true` without exposing agent-owned transcript changes.

## Hosted CI Root Causes and Repairs

Personally retrieved both failed jobs from run 30296372546 before changing the branch.

- `checks-node-compact-small-8`: the original custom-agent regression unnecessarily imported the full doctor and bundled plugin discovery into the isolated infrastructure project and timed out after 174,417 ms. Move the same real `autoMigrateLegacyState` regression into the existing isolated commands doctor harness, which already mocks channel and plugin discovery. Preserve real SQLite import, source archival, custom agent ownership, `migrated: true`, `skipped: true`, no transcript-report leakage, and warning assertions. Do not increase timeouts or weaken coverage.
- `checks-node-compact-small-3`: current main commit `f85a458a45bf5f778bbfa294ad246d1724ce6cd3` (#114671) assigned the existing Codex prewarm test to `attempt-extra` even though `attempt-light` already owned it. Rebase onto main `52e519220cea9cf91904e927d63d2dc6ff8f8b78` and remove only the duplicate `attempt-extra` entry. Keep `attempt-light`, the actual Codex runtime, and all five real prewarm tests unchanged. This explicitly repairs inherited red-main test inventory rather than hiding or rerunning it.

## Exact Linux Evidence

One trusted Blacksmith Testbox, one command at a time, candidate source `3c64b7e13eef81615fed64b49b1dc0d83bd8685f`.

The exact original hosted `core-runtime-infra-storage-state` job was reconstructed from its actual job log and replayed through `scripts/ci-run-node-test-shard.mjs` with the original infrastructure config, include list, and three workers:

```text
Test Files  44 passed (44)
     Tests  664 passed | 2 skipped (666)
  Duration  92.09s
[test] passed 1 Vitest shard
{"exitCode":0,"runStatus":"succeeded"}
```

The targeted four-project Linux command was:

```text
pnpm test src/commands/doctor-state-migrations.test.ts src/infra/state-migrations.meeting-transcripts.test.ts test/scripts/test-projects.test.ts extensions/codex/src/app-server/run-attempt-client-prewarm.test.ts
```

Actual redacted runtime output:

```text
test/scripts/test-projects.test.ts                       220 passed
src/infra/state-migrations.meeting-transcripts.test.ts    27 passed (1.82s)
src/commands/doctor-state-migrations.test.ts              91 passed
extensions/codex/src/app-server/run-attempt-client-prewarm.test.ts  5 passed
[test] passed 4 Vitest shards in 40.17s
{"exitCode":0,"runStatus":"succeeded"}
```

Real process and rollback proof, not a mocked gateway:

```text
node scripts/run-vitest.mjs run --config test/vitest/vitest.e2e.config.ts test/scripts/sqlite-sessions-transcripts-flip-proof.e2e.test.ts
✓ proves isolated gateway lifecycle state stays SQLite-first (89967ms)
Test Files  1 passed (1)
     Tests  1 passed (1)
{"exitCode":0,"runStatus":"succeeded"}
```

That passing test asserts all 22 real lifecycle checkpoints, including doctor inspect and validate, startup SQLite import, forced post-archive failure and source restoration, restart, full agent turn, compaction, plugin consumer, busy contention, idempotent doctor import, downgrade/reupgrade, and final doctor inspection. It explicitly verifies `failedManifestIssueCode: e2e_forced_post_archive_failure`, `sourceRestored: true`, `archivedBeforeRestore: true`, `sqliteStillExists: true`, restored and idempotently skipped source files, and 24 imported sessions.

Full remote gate:

```text
pnpm check:changed
typecheck all: passed
oxlint core:       14,508 files; 0 warnings; 0 errors
oxlint extensions:  7,853 files; 0 warnings; 0 errors
oxlint scripts:       858 files; 0 warnings; 0 errors
runtime import cycles: 0
{"commandMs":748626,"exitCode":0,"runStatus":"succeeded"}
```

The gate also passed formatting, all dependency locks, SDK manifest and plugin boundaries, database-first and runtime-sidecar guards, script declarations, environment and max-lines ratchets, and media resource checks. SQLite schema remains v6.

Codex dependency hard gate: personally inspected upstream Codex commit `95637f7056835fea66bdd0044414af480fc0fd74`, including `codex-rs/app-server/README.md:74` and `codex-rs/app-server/src/message_processor.rs:760`; the one-time initialization contract and OpenClaw prewarm runtime remain unchanged.

Fresh exact committed `gpt-5.6-sol` / `xhigh` review and TruffleHog secret scan: clean.

AI-assisted; author and independent reviewer inspected source ownership, migration status, transaction and archive contracts, upstream Codex handshake, exact hosted failures, and actual gateway restore evidence.
