### PR TITLE
feat: per-model code-mode capability flags with an "auto" master-switch tier

### DIFF
--- a/docs/docs_map.md
+++ b/docs/docs_map.md
@@ -9907,6 +9907,10 @@ Do not edit it by hand; run `pnpm docs:map:gen`.
   - H2: Scope
   - H2: Terms
   - H2: Configuration
+  - H2: Automatic per-model activation
+  - H3: The compat.codeMode catalog flag
+  - H3: Shipped preferred models
+  - H3: Choosing when to enable
   - H2: Activation
   - H2: Model-visible tools
   - H2: exec

--- a/docs/gateway/config-tools.md
+++ b/docs/gateway/config-tools.md
@@ -108,6 +108,10 @@ The shorthand is also accepted:
 }
 ```
 
+`enabled` also accepts `"auto"`, which engages code mode only for models whose
+catalog entry flags `compat.codeMode: "preferred"`. See
+[Code Mode - automatic per-model activation](/tools/code-mode#automatic-per-model-activation).
+
 MCP declarations are exposed through the read-only virtual API file surface in
 code mode. Guest code can call `API.list("mcp")` and
 `API.read("mcp/<server>.d.ts")` to inspect TypeScript-style signatures before

--- a/docs/tools/code-mode.md
+++ b/docs/tools/code-mode.md
@@ -24,7 +24,7 @@ separate implementations:
   prefixed by a `// @exec: {...}` pragma line for execution options), executed
   in Codex's in-process V8 Code Mode runtime.
 - OpenClaw code mode runs in the generic OpenClaw agent runtime and is
-  disabled unless `tools.codeMode.enabled: true` is configured. Its `exec`
+  disabled unless `tools.codeMode.enabled` is `true` or `"auto"`. Its `exec`
   tool takes a JSON `{ code, language }` payload, executed in a QuickJS-WASI
   worker.
 
@@ -112,7 +112,21 @@ Shorthand:
 ```
 
 Code mode stays off when `tools.codeMode` is omitted, `false`, or an object
-without `enabled: true`.
+without `enabled: true` or `enabled: "auto"`.
+
+To engage code mode only for models whose catalog marks them as strong code-mode
+performers, use the `"auto"` tier instead of `true`:
+
+```json5
+{
+  tools: {
+    codeMode: "auto",
+  },
+}
+```
+
+See [Automatic per-model activation](#automatic-per-model-activation) for the
+exact semantics and the shipped model list.
 
 If you use sandboxed agents with configured MCP servers, also allow the
 bundled MCP plugin in the sandbox tool policy, for example
@@ -238,7 +252,7 @@ enable the feature on its own.
 
 | Field                 | Default                        | Clamp                                           |
 | --------------------- | ------------------------------ | ----------------------------------------------- |
-| `enabled`             | `false`                        | boolean; only `true` enables code mode          |
+| `enabled`             | `false`                        | `false`, `true`, or `"auto"` (per-model)        |
 | `runtime`             | `"quickjs-wasi"`               | only supported value                            |
 | `mode`                | `"only"`                       | exposes control/direct tools, catalogs the rest |
 | `languages`           | `["javascript", "typescript"]` | any subset of the two                           |
@@ -252,7 +266,75 @@ enable the feature on its own.
 | `maxSearchLimit`      | `50`                           | `1`-`50`                                        |
 
 If code mode is enabled but QuickJS-WASI cannot load, OpenClaw fails closed
-for that run; it does not silently expose normal tools as a fallback.
+for that run; it does not silently expose normal tools as a fallback. This
+holds for `true` and for `"auto"` runs where the model resolves as preferred:
+an engaged run never silently falls back to broad direct tool exposure.
+
+## Automatic per-model activation
+
+`tools.codeMode.enabled` accepts three values:
+
+- `false` (default): code mode is off for every run.
+- `true`: code mode engages for every tool-capable run, regardless of model.
+- `"auto"`: code mode engages only when the run's model is flagged as a
+  preferred code-mode performer in its provider catalog.
+
+`false` and `true` behave exactly as before the `"auto"` tier existed; `"auto"`
+is purely additive.
+
+### The `compat.codeMode` catalog flag
+
+Provider catalogs can tier a model with `compat.codeMode` on its model entry,
+next to flags like `compat.supportsTools`:
+
+- `"preferred"`: the model reliably writes short orchestration programs and
+  benefits from the compact code-mode surface; `"auto"` engages code mode.
+- `"capable"` (or absent): the model can run code mode when forced with
+  `enabled: true`, but `"auto"` keeps normal tool exposure.
+
+Models without tool support cannot use code mode at all; there is no separate
+"unsupported" tier. The flag is capability metadata owned by the provider
+plugin's catalog; core only reads the generic compat field.
+
+### Shipped preferred models
+
+Bundled provider catalogs currently flag these models as `"preferred"`:
+
+| Provider  | Models                                                                                                                                       |
+| --------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
+| anthropic | `claude-fable-5`, `claude-opus-5`, `claude-sonnet-5`, `claude-mythos-5`, `claude-opus-4-8`, `claude-haiku-4-5`                               |
+| deepseek  | `deepseek-v4-pro`, `deepseek-v4-flash`                                                                                                       |
+| google    | `gemini-3-flash-preview`, `gemini-3.1-pro-preview`, `gemini-3.1-flash-lite`, `gemini-3.5-flash`, `gemini-3.5-flash-lite`, `gemini-3.6-flash` |
+| minimax   | `MiniMax-M3`                                                                                                                                 |
+| moonshot  | `kimi-k3`                                                                                                                                    |
+| openai    | `gpt-5.6`, `gpt-5.6-sol`, `gpt-5.6-terra`, `gpt-5.6-luna`, `gpt-5.5`, `gpt-5.5-pro`                                                          |
+| xiaomi    | `mimo-v2.5`                                                                                                                                  |
+| zai       | `glm-5.2`, `glm-5.1`                                                                                                                         |
+
+Everything else, including all Ollama-served local models, stays unflagged and
+keeps normal tool exposure under `"auto"`.
+
+For OpenAI models, the flag matters only when the run resolves to the OpenClaw
+embedded agent runtime. Default OpenAI routing uses the Codex-style harness
+surface, where OpenClaw code mode does not apply; the catalog flag never
+changes that routing decision.
+
+### Choosing when to enable
+
+In A/B evaluations on the preferred models above, code mode reduced total
+token usage by roughly 30-50% at equal-or-better task pass rates, mostly by
+replacing many full tool schemas and per-tool round trips with one compact
+program surface. Models below the preferred tier showed no consistent win and
+sometimes regressed, which is why `"auto"` leaves them on direct tools.
+
+Use `"auto"` when agents switch between models: strong models get the compact
+surface, weaker or local ones keep the exposure they handle best. Use `true`
+when you have verified a specific unflagged model performs well with code
+mode; global force-on is most predictable for single-model deployments. For
+open-weight or uncached serving where every prompt token is billed or
+recomputed, prefer enabling per model (via `"auto"` or a per-agent override)
+rather than globally, since the token savings depend on the model actually
+using the program surface well.
 
 ## Activation
 
@@ -264,7 +346,8 @@ final model request is assembled:
 2. Build the effective OpenClaw tool list, adding eligible plugin, MCP, and
    client tools.
 3. Apply allow/deny policy.
-4. If `tools.codeMode.enabled` is false, continue with normal tool exposure.
+4. If `tools.codeMode.enabled` is `false`, or is `"auto"` and the run's model
+   is not catalog-preferred, continue with normal tool exposure.
 5. If enabled and tools are active for the run, retain required direct-only
    tools and register every catalog-eligible effective tool in the code-mode
    catalog.

--- a/docs/tools/code-mode.md
+++ b/docs/tools/code-mode.md
@@ -302,7 +302,7 @@ Bundled provider catalogs currently flag these models as `"preferred"`:
 
 | Provider  | Models                                                                                                                                       |
 | --------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
-| anthropic | `claude-fable-5`, `claude-opus-5`, `claude-sonnet-5`, `claude-mythos-5`, `claude-opus-4-8`, `claude-sonnet-4-6`, `claude-haiku-4-5`          |
+| anthropic | `claude-fable-5`, `claude-opus-5`, `claude-sonnet-5`, `claude-mythos-5`, `claude-opus-4-8`, `claude-haiku-4-5`                               |
 | deepseek  | `deepseek-v4-pro`, `deepseek-v4-flash`                                                                                                       |
 | google    | `gemini-3-flash-preview`, `gemini-3.1-pro-preview`, `gemini-3.1-flash-lite`, `gemini-3.5-flash`, `gemini-3.5-flash-lite`, `gemini-3.6-flash` |
 | minimax   | `MiniMax-M3`                                                                                                                                 |

--- a/docs/tools/code-mode.md
+++ b/docs/tools/code-mode.md
@@ -302,7 +302,7 @@ Bundled provider catalogs currently flag these models as `"preferred"`:
 
 | Provider  | Models                                                                                                                                       |
 | --------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
-| anthropic | `claude-fable-5`, `claude-opus-5`, `claude-sonnet-5`, `claude-mythos-5`, `claude-opus-4-8`, `claude-haiku-4-5`                               |
+| anthropic | `claude-fable-5`, `claude-opus-5`, `claude-sonnet-5`, `claude-mythos-5`, `claude-opus-4-8`, `claude-sonnet-4-6`, `claude-haiku-4-5`          |
 | deepseek  | `deepseek-v4-pro`, `deepseek-v4-flash`                                                                                                       |
 | google    | `gemini-3-flash-preview`, `gemini-3.1-pro-preview`, `gemini-3.1-flash-lite`, `gemini-3.5-flash`, `gemini-3.5-flash-lite`, `gemini-3.6-flash` |
 | minimax   | `MiniMax-M3`                                                                                                                                 |

--- a/extensions/anthropic/forward-compat-generation.test.ts
+++ b/extensions/anthropic/forward-compat-generation.test.ts
@@ -47,6 +47,32 @@ describe("unreleased Claude generations", () => {
     expect(supportsClaudeAdaptiveThinking({ id: "claude-haiku-4-5-20251001" })).toBe(false);
   });
 
+  it("carries manifest catalog compat onto hand-built modern rows", () => {
+    // The hand-built forward-compat row replaces the catalog row when the
+    // runtime prefers plugin-resolved modern models. Dropping compat here
+    // silently disables catalog-driven behavior such as codeMode "auto",
+    // including on env-key-only runs whose model registry is empty.
+    expect(resolveModel("claude-opus-5")?.compat).toEqual({ codeMode: "preferred" });
+    expect(resolveModel("claude-sonnet-5")?.compat).toEqual({ codeMode: "preferred" });
+    // The Claude CLI provider rows are intentionally unflagged: those runs use
+    // the CLI harness where OpenClaw code mode does not apply.
+    expect(resolveModel("claude-opus-5", "claude-cli")?.compat).toBeUndefined();
+  });
+
+  it("prefers registry compat over the manifest index", () => {
+    const model = buildAnthropicProvider().resolveDynamicModel?.({
+      provider: "anthropic",
+      modelId: "claude-opus-5",
+      config: {},
+      modelRegistry: {
+        find: () => ({ compat: { codeMode: "capable" } }),
+      },
+    } as unknown as Parameters<
+      NonNullable<ReturnType<typeof buildAnthropicProvider>["resolveDynamicModel"]>
+    >[0]);
+    expect(model?.compat).toEqual({ codeMode: "capable" });
+  });
+
   it("does not claim non-Claude ids", () => {
     // Third-party models reach the Anthropic-compatible transport too.
     expect(resolveModel("mimo-v2-flash")).toBeUndefined();

--- a/extensions/anthropic/openclaw.plugin.json
+++ b/extensions/anthropic/openclaw.plugin.json
@@ -86,7 +86,8 @@
               "minimal": "low",
               "xhigh": "xhigh",
               "max": "max"
-            }
+            },
+            "compat": { "codeMode": "preferred" }
           },
           {
             "id": "claude-opus-5",
@@ -102,7 +103,8 @@
             "thinkingLevelMap": {
               "xhigh": "xhigh",
               "max": "max"
-            }
+            },
+            "compat": { "codeMode": "preferred" }
           },
           {
             "id": "claude-sonnet-5",
@@ -118,7 +120,8 @@
             "thinkingLevelMap": {
               "xhigh": "xhigh",
               "max": "max"
-            }
+            },
+            "compat": { "codeMode": "preferred" }
           },
           {
             "id": "claude-mythos-5",
@@ -136,7 +139,8 @@
               "minimal": "low",
               "xhigh": "xhigh",
               "max": "max"
-            }
+            },
+            "compat": { "codeMode": "preferred" }
           },
           {
             "id": "claude-opus-4-8",
@@ -149,7 +153,8 @@
               "image": { "maxSidePx": 2576, "preferredSidePx": 2576, "tokenMode": "provider" }
             },
             "contextWindow": 1000000,
-            "maxTokens": 128000
+            "maxTokens": 128000,
+            "compat": { "codeMode": "preferred" }
           },
           {
             "id": "claude-haiku-4-5",
@@ -160,7 +165,8 @@
               "image": { "maxSidePx": 1568, "preferredSidePx": 1568, "tokenMode": "provider" }
             },
             "contextWindow": 200000,
-            "maxTokens": 64000
+            "maxTokens": 64000,
+            "compat": { "codeMode": "preferred" }
           }
         ]
       }

--- a/extensions/anthropic/openclaw.plugin.json
+++ b/extensions/anthropic/openclaw.plugin.json
@@ -157,6 +157,18 @@
             "compat": { "codeMode": "preferred" }
           },
           {
+            "id": "claude-sonnet-4-6",
+            "name": "Claude Sonnet 4.6",
+            "reasoning": true,
+            "input": ["text", "image"],
+            "mediaInput": {
+              "image": { "maxSidePx": 1568, "preferredSidePx": 1568, "tokenMode": "provider" }
+            },
+            "contextWindow": 1000000,
+            "maxTokens": 128000,
+            "compat": { "codeMode": "preferred" }
+          },
+          {
             "id": "claude-haiku-4-5",
             "name": "Claude Haiku 4.5",
             "reasoning": true,

--- a/extensions/anthropic/openclaw.plugin.json
+++ b/extensions/anthropic/openclaw.plugin.json
@@ -157,18 +157,6 @@
             "compat": { "codeMode": "preferred" }
           },
           {
-            "id": "claude-sonnet-4-6",
-            "name": "Claude Sonnet 4.6",
-            "reasoning": true,
-            "input": ["text", "image"],
-            "mediaInput": {
-              "image": { "maxSidePx": 1568, "preferredSidePx": 1568, "tokenMode": "provider" }
-            },
-            "contextWindow": 1000000,
-            "maxTokens": 128000,
-            "compat": { "codeMode": "preferred" }
-          },
-          {
             "id": "claude-haiku-4-5",
             "name": "Claude Haiku 4.5",
             "reasoning": true,

--- a/extensions/anthropic/openclaw.plugin.test.ts
+++ b/extensions/anthropic/openclaw.plugin.test.ts
@@ -25,6 +25,7 @@ type AnthropicCatalogModel = {
   thinkingLevelMap?: Record<string, string | null>;
   status?: string;
   replacedBy?: string;
+  compat?: { codeMode?: string };
 };
 
 type AnthropicManifest = {

--- a/extensions/anthropic/openclaw.plugin.test.ts
+++ b/extensions/anthropic/openclaw.plugin.test.ts
@@ -42,6 +42,14 @@ const manifest = JSON.parse(
 ) as AnthropicManifest;
 
 describe("Anthropic plugin manifest", () => {
+  it("flags every static Anthropic API model as code-mode preferred", () => {
+    const models = manifest.modelCatalog?.providers?.anthropic?.models ?? [];
+    expect(models.length).toBeGreaterThan(0);
+    for (const model of models) {
+      expect(model.compat?.codeMode, model.id).toBe("preferred");
+    }
+  });
+
   it("publishes the exact Claude Opus 5 API contract", () => {
     const models = manifest.modelCatalog?.providers?.anthropic?.models ?? [];
     expect(models.find((model) => model.id === "claude-opus-5")).toEqual({

--- a/extensions/anthropic/openclaw.plugin.test.ts
+++ b/extensions/anthropic/openclaw.plugin.test.ts
@@ -56,6 +56,7 @@ describe("Anthropic plugin manifest", () => {
       contextWindow: 1_000_000,
       maxTokens: 128_000,
       thinkingLevelMap: { xhigh: "xhigh", max: "max" },
+      compat: { codeMode: "preferred" },
     });
   });
 
@@ -73,6 +74,7 @@ describe("Anthropic plugin manifest", () => {
       contextWindow: 1_000_000,
       maxTokens: 128_000,
       thinkingLevelMap: { xhigh: "xhigh", max: "max" },
+      compat: { codeMode: "preferred" },
     });
   });
 
@@ -90,6 +92,7 @@ describe("Anthropic plugin manifest", () => {
       contextWindow: 1_000_000,
       maxTokens: 128_000,
       thinkingLevelMap: { xhigh: "xhigh", max: "max" },
+      compat: { codeMode: "preferred" },
     });
     // Opus 5's 1M window is the model default, so the CLI row is not clamped to 200k.
     const cliModels = manifest.modelCatalog?.providers?.["claude-cli"]?.models ?? [];
@@ -134,6 +137,7 @@ describe("Anthropic plugin manifest", () => {
       },
       contextWindow: 200000,
       maxTokens: 64000,
+      compat: { codeMode: "preferred" },
     });
     expect(models.find((model) => model.id === "claude-haiku-4-5-20251001")).toBeUndefined();
   });

--- a/extensions/anthropic/register.runtime.ts
+++ b/extensions/anthropic/register.runtime.ts
@@ -33,6 +33,7 @@ import {
 import {
   buildProviderReplayFamilyHooks,
   cloneFirstTemplateModel,
+  type ModelCompatConfig,
   modelCostsEqual,
   type ProviderPlugin,
   resolveClaudeFable5ModelIdentity,
@@ -442,6 +443,30 @@ function resolveAnthropicUnreleasedCanonicalModelId(modelId: string): string {
   return /(?:^|-)claude-sonnet-/.test(modelId) ? "claude-sonnet-5" : "claude-opus-5";
 }
 
+// Lazily indexed manifest compat per provider so hand-built dynamic rows keep
+// catalog capability metadata even when the run's model registry is empty
+// (for example env-key-only runs without a generated models.json).
+let anthropicManifestCompatIndex: Map<string, ModelCompatConfig> | undefined;
+
+function resolveAnthropicManifestCompat(
+  provider: string,
+  modelId: string,
+): ModelCompatConfig | undefined {
+  if (!anthropicManifestCompatIndex) {
+    anthropicManifestCompatIndex = new Map();
+    const providers = manifest.modelCatalog?.providers ?? {};
+    for (const [providerId, catalog] of Object.entries(providers)) {
+      for (const model of catalog.models ?? []) {
+        const compat = (model as { compat?: ModelCompatConfig }).compat;
+        if (compat) {
+          anthropicManifestCompatIndex.set(`${providerId}/${model.id}`, compat);
+        }
+      }
+    }
+  }
+  return anthropicManifestCompatIndex.get(`${provider}/${modelId}`);
+}
+
 function buildAnthropicForwardCompatModel(
   ctx: ProviderResolveDynamicModelContext,
 ): ProviderRuntimeModel | undefined {
@@ -457,10 +482,21 @@ function buildAnthropicForwardCompatModel(
   }
   const provider =
     normalizedProvider === CLAUDE_CLI_BACKEND_ID ? CLAUDE_CLI_BACKEND_ID : PROVIDER_ID;
+  // This hand-built row replaces the catalog row when the runtime prefers
+  // plugin-resolved modern models, so it must carry the catalog's compat
+  // capability metadata (for example compat.codeMode) instead of dropping it.
+  // Registry compat wins when present (it may carry config overrides); the
+  // manifest index covers empty-registry runs such as env-key-only sessions.
+  const catalogModel = ctx.modelRegistry.find(provider, trimmedModelId) as
+    | Pick<ProviderRuntimeModel, "compat">
+    | null
+    | undefined;
+  const compat = catalogModel?.compat ?? resolveAnthropicManifestCompat(provider, trimmedModelId);
   return {
     id: trimmedModelId,
     name: trimmedModelId,
     provider,
+    ...(compat ? { compat } : {}),
     api: "anthropic-messages",
     baseUrl: "https://api.anthropic.com",
     reasoning: true,

--- a/extensions/copilot/src/tool-bridge.ts
+++ b/extensions/copilot/src/tool-bridge.ts
@@ -201,6 +201,8 @@ export async function createCopilotToolBridge(
     executeTool: (toolParams) => executeCatalogTool(input, toolParams),
     forceMessageTool: shouldForceCopilotMessageTool(attemptParams),
     isRawModelRun: isCopilotRawModelRun(attemptParams),
+    // Carries catalog compat so `tools.codeMode.enabled: "auto"` can resolve per model.
+    model: attemptParams.model,
     modelId: input.modelId,
     modelProvider: input.modelProvider,
     modelToolsEnabled: true,

--- a/extensions/deepseek/openclaw.plugin.json
+++ b/extensions/deepseek/openclaw.plugin.json
@@ -46,7 +46,8 @@
             "compat": {
               "supportsUsageInStreaming": true,
               "supportsReasoningEffort": true,
-              "maxTokensField": "max_tokens"
+              "maxTokensField": "max_tokens",
+              "codeMode": "preferred"
             }
           },
           {
@@ -65,7 +66,8 @@
             "compat": {
               "supportsUsageInStreaming": true,
               "supportsReasoningEffort": true,
-              "maxTokensField": "max_tokens"
+              "maxTokensField": "max_tokens",
+              "codeMode": "preferred"
             }
           }
         ]

--- a/extensions/google/provider-catalog.ts
+++ b/extensions/google/provider-catalog.ts
@@ -50,6 +50,7 @@ const GOOGLE_GEMINI_TEXT_MODELS: ModelDefinitionConfig[] = [
     cost: GOOGLE_GEMINI_COST,
     contextWindow: 1_048_576,
     maxTokens: 65_536,
+    compat: { codeMode: "preferred" },
   },
   {
     id: "gemini-3.6-flash",
@@ -59,6 +60,7 @@ const GOOGLE_GEMINI_TEXT_MODELS: ModelDefinitionConfig[] = [
     cost: GOOGLE_GEMINI_COST,
     contextWindow: 1_048_576,
     maxTokens: 65_536,
+    compat: { codeMode: "preferred" },
   },
   {
     id: "gemini-3.5-flash-lite",
@@ -68,6 +70,7 @@ const GOOGLE_GEMINI_TEXT_MODELS: ModelDefinitionConfig[] = [
     cost: GOOGLE_GEMINI_COST,
     contextWindow: 1_048_576,
     maxTokens: 65_536,
+    compat: { codeMode: "preferred" },
   },
   {
     id: "gemini-3.1-pro-preview",
@@ -77,6 +80,7 @@ const GOOGLE_GEMINI_TEXT_MODELS: ModelDefinitionConfig[] = [
     cost: GOOGLE_GEMINI_COST,
     contextWindow: 1_048_576,
     maxTokens: 65_536,
+    compat: { codeMode: "preferred" },
   },
   {
     id: "gemini-3.1-flash-lite",
@@ -86,6 +90,7 @@ const GOOGLE_GEMINI_TEXT_MODELS: ModelDefinitionConfig[] = [
     cost: GOOGLE_GEMINI_COST,
     contextWindow: 1_048_576,
     maxTokens: 65_536,
+    compat: { codeMode: "preferred" },
   },
   {
     id: "gemini-3-flash-preview",
@@ -95,6 +100,7 @@ const GOOGLE_GEMINI_TEXT_MODELS: ModelDefinitionConfig[] = [
     cost: GOOGLE_GEMINI_COST,
     contextWindow: 1_048_576,
     maxTokens: 65_536,
+    compat: { codeMode: "preferred" },
   },
 ];
 

--- a/extensions/minimax/model-definitions.test.ts
+++ b/extensions/minimax/model-definitions.test.ts
@@ -39,6 +39,7 @@ describe("minimax model definitions", () => {
       maxTokens: DEFAULT_MINIMAX_MAX_TOKENS,
     });
     expect(model).toEqual({
+      compat: { codeMode: "preferred" },
       contextWindow: MINIMAX_M3_CATALOG_CONTEXT_WINDOW,
       cost: MINIMAX_API_COST,
       id: "MiniMax-M3",

--- a/extensions/minimax/model-definitions.ts
+++ b/extensions/minimax/model-definitions.ts
@@ -80,6 +80,7 @@ export function buildMinimaxModelDefinition(params: {
   maxTokens: number;
 }): ModelDefinitionConfig {
   const catalog = MINIMAX_TEXT_MODEL_CATALOG[params.id as MinimaxCatalogId];
+  const compat = catalog && "compat" in catalog ? catalog.compat : undefined;
   return {
     id: params.id,
     name: params.name ?? catalog?.name ?? `MiniMax ${params.id}`,
@@ -88,6 +89,7 @@ export function buildMinimaxModelDefinition(params: {
     cost: params.cost,
     contextWindow: params.contextWindow,
     maxTokens: params.maxTokens,
+    ...(compat ? { compat: { ...compat } } : {}),
   };
 }
 

--- a/extensions/minimax/provider-models.ts
+++ b/extensions/minimax/provider-models.ts
@@ -16,6 +16,7 @@ export const MINIMAX_TEXT_MODEL_CATALOG = {
     reasoning: true,
     input: ["text", "image"],
     contextWindow: 1_000_000,
+    compat: { codeMode: "preferred" },
   },
   "MiniMax-M2.7": {
     name: "MiniMax M2.7",

--- a/extensions/moonshot/openclaw.plugin.json
+++ b/extensions/moonshot/openclaw.plugin.json
@@ -87,7 +87,8 @@
                 "low",
                 "high",
                 "max"
-              ]
+              ],
+              "codeMode": "preferred"
             }
           },
           {

--- a/extensions/openai/openclaw.plugin.json
+++ b/extensions/openai/openclaw.plugin.json
@@ -53,7 +53,8 @@
             "compat": {
               "supportsReasoningEffort": true,
               "supportedReasoningEfforts": ["none", "low", "medium", "high", "xhigh", "max"],
-              "supportsTemperature": false
+              "supportsTemperature": false,
+              "codeMode": "preferred"
             }
           },
           {
@@ -69,7 +70,8 @@
             "compat": {
               "supportsReasoningEffort": true,
               "supportedReasoningEfforts": ["none", "low", "medium", "high", "xhigh", "max"],
-              "supportsTemperature": false
+              "supportsTemperature": false,
+              "codeMode": "preferred"
             }
           },
           {
@@ -85,7 +87,8 @@
             "compat": {
               "supportsReasoningEffort": true,
               "supportedReasoningEfforts": ["none", "low", "medium", "high", "xhigh", "max"],
-              "supportsTemperature": false
+              "supportsTemperature": false,
+              "codeMode": "preferred"
             }
           },
           {
@@ -101,7 +104,8 @@
             "compat": {
               "supportsReasoningEffort": true,
               "supportedReasoningEfforts": ["none", "low", "medium", "high", "xhigh", "max"],
-              "supportsTemperature": false
+              "supportsTemperature": false,
+              "codeMode": "preferred"
             }
           },
           {
@@ -117,7 +121,8 @@
             "contextWindow": 1050000,
             "contextTokens": 272000,
             "maxTokens": 128000,
-            "cost": { "input": 5, "output": 30, "cacheRead": 0.5, "cacheWrite": 0 }
+            "cost": { "input": 5, "output": 30, "cacheRead": 0.5, "cacheWrite": 0 },
+            "compat": { "codeMode": "preferred" }
           },
           {
             "id": "gpt-5.5-pro",
@@ -132,7 +137,8 @@
             "contextWindow": 1050000,
             "contextTokens": 272000,
             "maxTokens": 128000,
-            "cost": { "input": 30, "output": 180, "cacheRead": 0, "cacheWrite": 0 }
+            "cost": { "input": 30, "output": 180, "cacheRead": 0, "cacheWrite": 0 },
+            "compat": { "codeMode": "preferred" }
           }
         ]
       }

--- a/extensions/xiaomi/openclaw.plugin.json
+++ b/extensions/xiaomi/openclaw.plugin.json
@@ -37,7 +37,8 @@
               "output": 0.28,
               "cacheRead": 0.0028,
               "cacheWrite": 0
-            }
+            },
+            "compat": { "codeMode": "preferred" }
           },
           {
             "id": "mimo-v2.5-pro",
@@ -75,7 +76,8 @@
             "reasoning": true,
             "contextWindow": 1048576,
             "maxTokens": 131072,
-            "cost": { "input": 0, "output": 0, "cacheRead": 0, "cacheWrite": 0 }
+            "cost": { "input": 0, "output": 0, "cacheRead": 0, "cacheWrite": 0 },
+            "compat": { "codeMode": "preferred" }
           }
         ]
       }

--- a/extensions/zai/openclaw.plugin.json
+++ b/extensions/zai/openclaw.plugin.json
@@ -46,7 +46,8 @@
               "output": 4.4,
               "cacheRead": 0.26,
               "cacheWrite": 0
-            }
+            },
+            "compat": { "codeMode": "preferred" }
           },
           {
             "id": "glm-5-turbo",
@@ -90,7 +91,8 @@
               "output": 4.4,
               "cacheRead": 0.26,
               "cacheWrite": 0
-            }
+            },
+            "compat": { "codeMode": "preferred" }
           }
         ]
       }

--- a/packages/model-catalog-core/src/model-catalog-normalize.test.ts
+++ b/packages/model-catalog-core/src/model-catalog-normalize.test.ts
@@ -57,6 +57,7 @@ describe("model catalog normalization", () => {
                 },
                 compat: {
                   supportsTools: true,
+                  codeMode: " preferred ",
                   openRouterRouting: {
                     only: [" anthropic ", "", 1],
                     allow_fallbacks: false,
@@ -164,6 +165,7 @@ describe("model catalog normalization", () => {
               },
               compat: {
                 supportsTools: true,
+                codeMode: "preferred",
                 openRouterRouting: { only: ["anthropic"], allow_fallbacks: false },
                 vercelGatewayRouting: { order: ["anthropic"] },
                 zaiToolStream: true,

--- a/packages/model-catalog-core/src/model-catalog-normalize.ts
+++ b/packages/model-catalog-core/src/model-catalog-normalize.ts
@@ -412,6 +412,11 @@ function normalizeModelCatalogCompat(value: unknown): ModelCatalogCompatConfig |
     }
   }
 
+  const codeMode = normalizeOptionalString(value.codeMode) ?? "";
+  if (codeMode === "preferred" || codeMode === "capable") {
+    compat.codeMode = codeMode;
+  }
+
   const maxTokensField = normalizeOptionalString(value.maxTokensField) ?? "";
   if (maxTokensField === "max_completion_tokens" || maxTokensField === "max_tokens") {
     compat.maxTokensField = maxTokensField;

--- a/packages/model-catalog-core/src/model-catalog-types.ts
+++ b/packages/model-catalog-core/src/model-catalog-types.ts
@@ -61,6 +61,8 @@ export type ModelCatalogCompatConfig = {
   supportsLongCacheRetention?: boolean;
   supportsPromptCacheKey?: boolean;
   supportsTools?: boolean;
+  /** Code-mode tier consumed by `tools.codeMode.enabled: "auto"`; absent means "capable". */
+  codeMode?: "preferred" | "capable";
   requiresStringContent?: boolean;
   strictMessageKeys?: boolean;
   toolSchemaProfile?: string;

--- a/src/agents/code-mode-execution.ts
+++ b/src/agents/code-mode-execution.ts
@@ -56,7 +56,9 @@ export async function runExec(params: {
     params.ctx.runtimeConfig ?? params.ctx.config,
     params.ctx.agentId,
   );
-  if (!config.enabled) {
+  // The exec/wait tools only exist when the run gate engaged code mode, so
+  // "auto" counts as enabled here; only a hard `false` rejects execution.
+  if (config.enabled === false) {
     throw new ToolInputError("code mode is disabled.");
   }
   const runtime = new ToolSearchRuntime(params.ctx, toToolSearchConfig(config));

--- a/src/agents/code-mode-runtime.test.ts
+++ b/src/agents/code-mode-runtime.test.ts
@@ -1,7 +1,65 @@
 import { describe, expect, it } from "vitest";
-import { prepareSource, resolveCodeModeConfig } from "./code-mode-runtime.js";
+import {
+  isCodeModeEngagedForModel,
+  prepareSource,
+  resolveCodeModeConfig,
+} from "./code-mode-runtime.js";
 
 const config = resolveCodeModeConfig({ tools: { codeMode: true } } as never);
+
+describe("Code Mode master switch resolution", () => {
+  it.each([
+    { name: "boolean shorthand true", codeMode: true, enabled: true },
+    { name: "boolean shorthand false", codeMode: false, enabled: false },
+    { name: "auto shorthand", codeMode: "auto", enabled: "auto" },
+    { name: "object enabled auto", codeMode: { enabled: "auto" }, enabled: "auto" },
+    { name: "object without enabled", codeMode: { timeoutMs: 5000 }, enabled: false },
+    { name: "omitted", codeMode: undefined, enabled: false },
+  ])("resolves enabled for $name", ({ codeMode, enabled }) => {
+    expect(resolveCodeModeConfig({ tools: { codeMode } } as never).enabled).toBe(enabled);
+  });
+
+  const preferredModel = { compat: { codeMode: "preferred" } };
+  const capableModel = { compat: { codeMode: "capable" } };
+  const unflaggedModel = { compat: { supportsTools: true } };
+
+  it.each([
+    {
+      name: "true engages an unflagged model",
+      enabled: true,
+      model: unflaggedModel,
+      engaged: true,
+    },
+    {
+      name: "false stays off for a preferred model",
+      enabled: false,
+      model: preferredModel,
+      engaged: false,
+    },
+    {
+      name: "auto engages a preferred model",
+      enabled: "auto",
+      model: preferredModel,
+      engaged: true,
+    },
+    {
+      name: "auto skips an explicit capable model",
+      enabled: "auto",
+      model: capableModel,
+      engaged: false,
+    },
+    {
+      name: "auto skips an unflagged model",
+      enabled: "auto",
+      model: unflaggedModel,
+      engaged: false,
+    },
+    { name: "auto skips a compat-free model", enabled: "auto", model: {}, engaged: false },
+    { name: "auto skips a missing model", enabled: "auto", model: undefined, engaged: false },
+  ] as const)("$name", ({ enabled, model, engaged }) => {
+    expect(isCodeModeEngagedForModel({ enabled }, model)).toBe(engaged);
+  });
+});
 
 describe("Code Mode guest source validation", () => {
   it.each([

--- a/src/agents/code-mode-runtime.ts
+++ b/src/agents/code-mode-runtime.ts
@@ -35,7 +35,8 @@ export type CodeModeLanguage = "javascript" | "typescript";
 
 /** Resolved Code Mode runtime limits and visible language options. */
 export type CodeModeConfig = {
-  enabled: boolean;
+  /** Master switch tier: true/false, or "auto" (engage per model catalog flag). */
+  enabled: boolean | "auto";
   runtime: "quickjs-wasi";
   mode: "only";
   languages: CodeModeLanguage[];
@@ -124,6 +125,9 @@ function normalizeCodeModeRawConfig(value: unknown): Record<string, unknown> | u
   if (codeMode === false) {
     return { enabled: false };
   }
+  if (codeMode === "auto") {
+    return { enabled: "auto" };
+  }
   return isRecord(codeMode) ? codeMode : undefined;
 }
 
@@ -137,8 +141,8 @@ function readCodeModeRawConfig(config?: OpenClawConfig, agentId?: string): Recor
   return agentRaw ? { ...globalRaw, ...agentRaw } : globalRaw;
 }
 
-function readBoolean(value: unknown, fallback: boolean): boolean {
-  return typeof value === "boolean" ? value : fallback;
+function readEnabled(value: unknown): boolean | "auto" {
+  return typeof value === "boolean" || value === "auto" ? value : false;
 }
 
 export function readPositiveInteger(value: unknown, fallback: number): number {
@@ -164,7 +168,7 @@ export function resolveCodeModeConfig(config?: OpenClawConfig, agentId?: string)
     DEFAULT_MAX_SEARCH_LIMIT,
   );
   return {
-    enabled: readBoolean(raw.enabled, false),
+    enabled: readEnabled(raw.enabled),
     runtime: "quickjs-wasi",
     mode: "only",
     languages: readLanguages(raw.languages),
@@ -201,6 +205,27 @@ export function resolveCodeModeConfig(config?: OpenClawConfig, agentId?: string)
     ),
     maxSearchLimit,
   };
+}
+
+/**
+ * Resolves the master switch against one model's catalog capability flag.
+ * `true`/`false` are absolute; `"auto"` engages only for models whose catalog
+ * compat declares `codeMode: "preferred"`. This gates the model-facing tool
+ * surface only; runs that route to a provider-native harness (for example the
+ * default OpenAI Codex surface) never reach this embedded-runtime gate.
+ */
+export function isCodeModeEngagedForModel(
+  config: Pick<CodeModeConfig, "enabled">,
+  model: { compat?: unknown } | undefined,
+): boolean {
+  if (config.enabled !== "auto") {
+    return config.enabled;
+  }
+  const compat =
+    model?.compat && typeof model.compat === "object"
+      ? (model.compat as { codeMode?: unknown })
+      : undefined;
+  return compat?.codeMode === "preferred";
 }
 
 export function toToolSearchConfig(config: CodeModeConfig): ToolSearchConfig {

--- a/src/agents/code-mode.ts
+++ b/src/agents/code-mode.ts
@@ -22,6 +22,7 @@ import { createHeadlessAbortScope, runCodeModeScriptHeadless } from "./code-mode
 import { describeCodeModeNamespacesForPrompt } from "./code-mode-namespaces.js";
 import {
   codeModeRuntimeTesting,
+  isCodeModeEngagedForModel,
   readCode,
   readRunId,
   resolveCodeModeConfig,
@@ -58,6 +59,7 @@ export { CODE_MODE_EXEC_TOOL_NAME, CODE_MODE_WAIT_TOOL_NAME };
 export {
   CodeModeHeadlessAbortError,
   CodeModeHeadlessTimeoutError,
+  isCodeModeEngagedForModel,
   runCodeModeScriptHeadless,
   resolveCodeModeConfig,
 };
@@ -251,7 +253,9 @@ export function applyCodeModeCatalog(params: {
   toolHookContext?: HookContext;
 }) {
   const config = resolveCodeModeConfig(params.config, params.agentId);
-  if (!config.enabled) {
+  // Engagement (including "auto" per-model resolution) is decided by the run
+  // gates before this is called; only a hard `false` may disable compaction.
+  if (config.enabled === false) {
     return applyToolCatalogCompaction({
       ...params,
       enabled: false,
@@ -309,7 +313,8 @@ export function addClientToolsToCodeModeCatalog(params: {
 }) {
   return addClientToolsToToolCatalog({
     ...params,
-    enabled: resolveCodeModeConfig(params.config, params.agentId).enabled,
+    // Callers gate on run engagement; "auto" counts as enabled here.
+    enabled: resolveCodeModeConfig(params.config, params.agentId).enabled !== false,
   });
 }
 

--- a/src/agents/embedded-agent-runner/run/attempt-tool-base-prepare.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-tool-base-prepare.ts
@@ -5,7 +5,7 @@ import { isSubagentSessionKey } from "../../../routing/session-key.js";
 import { createOpenClawCodingTools } from "../../agent-tools.js";
 import { getActiveAgentRingZeroTools } from "../../agent-tools.ring-zero-context.js";
 import { getChannelAgentToolMeta } from "../../channel-tools.js";
-import { resolveCodeModeConfig } from "../../code-mode.js";
+import { isCodeModeEngagedForModel, resolveCodeModeConfig } from "../../code-mode.js";
 import { resolveConversationCapabilityProfile } from "../../conversation-capability-profile.js";
 import {
   isLocalModelLeanEnabled,
@@ -91,7 +91,7 @@ export function prepareEmbeddedAttemptToolBase(params: {
     !isRawModelRun &&
     attempt.skillWorkshopProposalOnly !== true &&
     attempt.toolsAllow?.length !== 0 &&
-    codeModeConfig.enabled;
+    isCodeModeEngagedForModel(codeModeConfig, attempt.model);
   const toolSearchControlsEnabledForRun =
     toolsEnabled &&
     !ringZeroToolRun &&

--- a/src/agents/harness/tool-surface-bridge.test.ts
+++ b/src/agents/harness/tool-surface-bridge.test.ts
@@ -209,6 +209,48 @@ describe("createAgentHarnessToolSurfaceRuntime", () => {
     }
   });
 
+  it.each([
+    {
+      name: "auto engages a catalog-preferred model",
+      codeMode: "auto",
+      codeModeTier: "preferred",
+      engaged: true,
+    },
+    {
+      name: "auto falls back to tool search for an unflagged model",
+      codeMode: "auto",
+      codeModeTier: undefined,
+      engaged: false,
+    },
+    {
+      name: "true engages an unflagged model",
+      codeMode: true,
+      codeModeTier: undefined,
+      engaged: true,
+    },
+    {
+      name: "false never engages a preferred model",
+      codeMode: false,
+      codeModeTier: "preferred",
+      engaged: false,
+    },
+  ] as const)("$name", ({ codeMode, codeModeTier, engaged }) => {
+    const runtime = createAgentHarnessToolSurfaceRuntime({
+      config: { tools: { codeMode, toolSearch: true } },
+      executeTool: async () => ({ content: [], details: {} }),
+      model: codeModeTier ? { compat: { codeMode: codeModeTier } } : { compat: {} },
+      modelToolsEnabled: true,
+    });
+
+    try {
+      expect(runtime.codeModeControlsEnabled).toBe(engaged);
+      // Code mode and tool search stay mutually exclusive for one run.
+      expect(runtime.toolSearchControlsEnabled).toBe(!engaged);
+    } finally {
+      runtime.cleanup();
+    }
+  });
+
   it("preserves explicit code-mode compaction for lean runs", () => {
     testing.setToolSearchCodeModeSupportedForTest(true);
     try {

--- a/src/agents/harness/tool-surface-bridge.ts
+++ b/src/agents/harness/tool-surface-bridge.ts
@@ -6,6 +6,7 @@ import {
   CODE_MODE_WAIT_TOOL_NAME,
   applyCodeModeCatalog,
   createCodeModeTools,
+  isCodeModeEngagedForModel,
   resolveCodeModeConfig,
 } from "../code-mode.js";
 import { resolveConversationCapabilityProfile } from "../conversation-capability-profile.js";
@@ -64,6 +65,8 @@ export function createAgentHarnessToolSurfaceRuntime(params: {
   executeTool: ToolSearchCatalogToolExecutor;
   forceMessageTool?: boolean;
   isRawModelRun?: boolean;
+  /** Prepared model row carrying catalog compat; required for `"auto"` code-mode resolution. */
+  model?: { compat?: unknown };
   modelId?: string;
   modelProvider?: string;
   modelToolsEnabled: boolean;
@@ -92,7 +95,8 @@ export function createAgentHarnessToolSurfaceRuntime(params: {
     params.isRawModelRun !== true &&
     params.toolsAllow?.length !== 0;
   const ringZeroToolRun = getActiveAgentRingZeroTools().length > 0;
-  const codeModeControlsEnabled = toolsAvailable && !ringZeroToolRun && codeModeConfig.enabled;
+  const codeModeControlsEnabled =
+    toolsAvailable && !ringZeroToolRun && isCodeModeEngagedForModel(codeModeConfig, params.model);
   const toolSearchControlsEnabled =
     toolsAvailable && !ringZeroToolRun && !codeModeControlsEnabled && toolSearchConfig.enabled;
   const toolSearchCatalogRef =

--- a/src/config/schema.help.runtime.ts
+++ b/src/config/schema.help.runtime.ts
@@ -112,7 +112,7 @@ export const RUNTIME_FIELD_HELP: Record<string, string> = {
   "tools.codeMode":
     "Generic OpenClaw code mode. When enabled, agent runs expose only `exec` and `wait` to the model and hide normal tools behind a QuickJS-WASI catalog bridge.",
   "tools.codeMode.enabled":
-    "Enables generic code mode. Default is off. When explicitly enabled, OpenClaw fails closed if the runtime is unavailable instead of exposing the full tool list.",
+    'Enables generic code mode. Default is off. `true` engages every tool-capable run and fails closed if the runtime is unavailable instead of exposing the full tool list. `"auto"` engages only models whose catalog flags `compat.codeMode: "preferred"`.',
   "tools.codeMode.runtime": 'Guest JavaScript runtime. Only "quickjs-wasi" is supported.',
   "tools.codeMode.mode":
     'Model-facing surface. Only "only" is supported: expose code-mode `exec` and `wait` and hide normal tools.',

--- a/src/config/schema.test.ts
+++ b/src/config/schema.test.ts
@@ -896,6 +896,16 @@ describe("config schema", () => {
     ).toBe(false);
   });
 
+  it("accepts the Code Mode auto tier and rejects unknown tiers", () => {
+    expect(ToolsSchema.parse({ codeMode: "auto" })?.codeMode).toBe("auto");
+    expect(ToolsSchema.parse({ codeMode: false })?.codeMode).toBe(false);
+    expect(ToolsSchema.parse({ codeMode: { enabled: "auto" } })?.codeMode).toEqual({
+      enabled: "auto",
+    });
+    expect(ToolsSchema.safeParse({ codeMode: "on" }).success).toBe(false);
+    expect(ToolsSchema.safeParse({ codeMode: { enabled: "always" } }).success).toBe(false);
+  });
+
   it("accepts strict Swarm config in the runtime zod schema", () => {
     expect(ToolsSchema.parse({ swarm: true })?.swarm).toBe(true);
     expect(

--- a/src/config/types.models.ts
+++ b/src/config/types.models.ts
@@ -93,6 +93,8 @@ export type ModelCompatConfig = SupportedOpenAICompatFields &
     visibleReasoningDetailTypes?: string[];
     /** Whether this model supports tool/function calling. */
     supportsTools?: boolean;
+    /** Code-mode tier consumed by `tools.codeMode.enabled: "auto"`; absent means "capable". */
+    codeMode?: "preferred" | "capable";
     /** Whether provider accepts prompt-cache/session affinity keys. */
     supportsPromptCacheKey?: boolean;
     /** Whether all message parts must be coerced to plain strings. */

--- a/src/config/types.tools.ts
+++ b/src/config/types.tools.ts
@@ -179,9 +179,10 @@ export type ToolSearchConfig =
 
 export type CodeModeConfig =
   | boolean
+  | "auto"
   | {
-      /** Enable generic OpenClaw code mode. Default: false. */
-      enabled?: boolean;
+      /** Enable generic OpenClaw code mode. Default: false. "auto" engages it only for models whose catalog compat flags `codeMode: "preferred"`. */
+      enabled?: boolean | "auto";
       /** Guest runtime. Only quickjs-wasi is supported. */
       runtime?: "quickjs-wasi";
       /** Model-facing mode. Only "only" is supported: expose exec/wait and hide normal tools. */

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -597,9 +597,10 @@ const ToolSearchSchema = z
 const CodeModeSchema = z
   .union([
     z.boolean(),
+    z.literal("auto"),
     z
       .object({
-        enabled: z.boolean().optional(),
+        enabled: z.union([z.boolean(), z.literal("auto")]).optional(),
         runtime: z.literal("quickjs-wasi").optional(),
         mode: z.literal("only").optional(),
         languages: z.array(z.enum(["javascript", "typescript"])).optional(),

--- a/src/config/zod-schema.core.ts
+++ b/src/config/zod-schema.core.ts
@@ -210,6 +210,7 @@ const ModelCompatSchema = z
     supportsTemperature: z.boolean().optional(),
     supportsUsageInStreaming: z.boolean().optional(),
     supportsTools: z.boolean().optional(),
+    codeMode: z.enum(["preferred", "capable"]).optional(),
     supportsStrictMode: z.boolean().optional(),
     supportsJsonSchemaResponseFormat: z.boolean().optional(),
     requiresStringContent: z.boolean().optional(),

--- a/src/llm/providers/stream-wrappers/openai.ts
+++ b/src/llm/providers/stream-wrappers/openai.ts
@@ -698,8 +698,15 @@ export function createCodexNativeWebSearchWrapper(
 ): StreamFn {
   const underlying = baseStreamFn ?? streamSimple;
   return (model, context, options) => {
+    // Under `tools.codeMode.enabled: "auto"` the config alone cannot prove the
+    // surface; the run-level wrapper passes it down via stream options so the
+    // provider-family wrapper stays aligned for the same request.
+    const codeModeSurfaceFromOptions =
+      (options as OpenClawSimpleStreamOptions | undefined)?.openclawCodeModeToolSurface === true;
     if (
-      (params.codeModeToolSurfaceEnabled === true || isCodeModeEnabled(params.config)) &&
+      (params.codeModeToolSurfaceEnabled === true ||
+        codeModeSurfaceFromOptions ||
+        isCodeModeEnabled(params.config)) &&
       hasCodeModeVisibleTools(context)
     ) {
       emitModelTransportDebug(

--- a/ui/src/pages/labs/labs-page.test.ts
+++ b/ui/src/pages/labs/labs-page.test.ts
@@ -105,6 +105,12 @@ describe("LabsPage", () => {
     expect(codeModeToggle(page).checked).toBe(true);
   });
 
+  it("reads the per-model auto tier as enabled", async () => {
+    const { page } = await mountPage({ tools: { codeMode: { enabled: "auto" } } });
+
+    expect(codeModeToggle(page).checked).toBe(true);
+  });
+
   it("writes an explicit false in the RFC 7396 merge patch when disabling", async () => {
     const { page, runtimeConfig } = await mountPage({
       tools: { codeMode: { enabled: true } },

--- a/ui/src/pages/labs/labs-registry.ts
+++ b/ui/src/pages/labs/labs-registry.ts
@@ -49,7 +49,9 @@ export const LAB_FEATURES = [
     configPath: ["tools", "codeMode", "enabled"],
     onValue: true,
     offValue: false,
-    activeValues: [true],
+    // "auto" engages code mode per model catalog flag; it must read as on so
+    // the toggle does not silently narrow an operator's deliberate auto tier.
+    activeValues: [true, "auto"],
     readEnabled: null,
     enableAlso: null,
     restartHint: null,


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

`tools.codeMode.enabled` is all-or-nothing today: `true` forces the compact code-mode surface onto every tool-capable run, including models that do not write short orchestration programs reliably, and `false` leaves the savings on the table for models that clearly benefit. Operators who mix strong hosted models with weaker or local ones have no way to say "use code mode where it wins, normal tools elsewhere".

## Why This Change Was Made

Adds a per-model capability flag to the model catalog compat surface (`compat.codeMode: "preferred" | "capable"`, absent = capable) and an additive `"auto"` tier on the master switch. `"auto"` engages code mode only for catalog-preferred models, resolved at the two run engagement gates (embedded attempt prep and the harness tool-surface bridge) where the prepared model row is already in hand — no request-time catalog rediscovery. `true`/`false` behavior is byte-identical to before, the shipped default stays `false`, and the flag is provider-owned catalog metadata: values live in each provider plugin's manifest/catalog and core reads only the generic compat field. For OpenAI models the flag matters only when a run resolves to the OpenClaw embedded runtime; default OpenAI routing to the Codex-style harness surface is unchanged.

Live verification surfaced one latent bug this PR also fixes: the Anthropic plugin's hand-built forward-compat model rows (used when the runtime prefers plugin-resolved modern models, including env-key-only runs with an empty model registry) silently dropped catalog `compat` metadata. The row now carries registry compat when present and falls back to a lazily indexed manifest compat lookup, with regression tests in `extensions/anthropic/forward-compat-generation.test.ts`.

Codex boundary check for the touched stream wrapper (`createCodexNativeWebSearchWrapper` in `src/llm/providers/stream-wrappers/openai.ts`): the sibling Codex source defines the provider-native `web_search` ToolSpec payload entry in `codex-rs/tools/src/tool_spec.rs` (WebSearch variant, `#[serde(rename = "web_search")]`). This PR does not change that payload contract; it only adds an OpenClaw-side signal (`openclawCodeModeToolSurface` stream option) so the provider-family wrapper skips native web-search injection consistently when an `"auto"`-engaged run owns the tool surface — the same skip that `enabled: true` already triggers via config.

The `"auto"` tier makes catalog annotations a runtime input for opted-in operators; the owner has accepted ownership of the initial preferred-model list and future catalog corrections as provider-owned policy. Flipping the default from `false` to `"auto"` is a deliberate one-line owner follow-up, intentionally not part of this PR.

## User Impact

Operators can set `tools.codeMode: "auto"` (or `enabled: "auto"`) and get code-mode token savings (~30-50% total-token reduction at equal-or-better pass rates in A/B evals) on catalog-preferred models — the recent anthropic, gpt-5.5+, gemini-3.x, deepseek-v4, kimi-k3, MiniMax-M3, glm-5.1/5.2, and mimo-v2.5 lines — while unflagged and Ollama-served models keep normal tool exposure. Existing `true`/`false` configs behave exactly as before, including the fail-closed promise when the QuickJS runtime is unavailable. The Labs toggle reads `"auto"` as on instead of silently narrowing it. Docs cover the new tier, the catalog flag semantics, the shipped preferred list, the OpenAI routing caveat, and tier-choice guidance.

## Evidence

Real behavior proof (isolated `OPENCLAW_STATE_DIR`, dev CLI `openclaw agent --local`, deliberately invalid provider keys so runs stop at the provider 401 after the tool surface is assembled; no credentials or private endpoints involved):

`tools.codeMode: "auto"` + catalog-preferred model (`anthropic/claude-opus-5`) — code mode engages:

```
[agent/embedded] code-mode: cataloged 30 tools behind exec/wait
[provider-transport-fetch] [model-fetch] response provider=anthropic api=anthropic-messages model=claude-opus-5 status=401 ...
```

Side-by-side under one identical `tools.codeMode: "auto"` config (Tool Search enabled as the positive control signal for the non-code-mode surface):

```
# auto + catalog-preferred model (anthropic/claude-opus-5): code mode owns the surface
[agent/embedded] code-mode: cataloged 30 tools behind exec/wait
[provider-transport-fetch] [model-fetch] start provider=anthropic api=anthropic-messages model=claude-opus-5 method=POST url=https://api.anthropic.com/v1/messages ...

# auto + unflagged model (google/gemini-2.5-flash, explicit config row without the flag): normal surface kept
[agent/embedded] tool-search: cataloged 34 tools behind compact prompt surface
[provider-transport-fetch] [model-fetch] start provider=google api=google-generative-ai model=gemini-2.5-flash method=POST url=https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:streamGenerateContent ...
```


`tools.codeMode: true` + the same unflagged model — force-on still engages:

```
[agent/embedded] code-mode: cataloged 34 tools behind exec/wait
```

Focused local runs (trusted source, linked-worktree wrapper):

```
node scripts/run-vitest.mjs src/agents/code-mode-runtime.test.ts src/agents/harness/tool-surface-bridge.test.ts packages/model-catalog-core/src/model-catalog-normalize.test.ts
 Test Files  3 passed — incl. new master-switch resolution table, auto/preferred gate cases, catalog compat normalization

node scripts/run-vitest.mjs src/config/schema.test.ts src/config/zod-schema.agent-defaults.test.ts
 Test Files  2 passed (101 tests) — new: accepts "auto"/{enabled:"auto"}, rejects "on"/{enabled:"always"}

node scripts/run-vitest.mjs extensions/anthropic  (full extension suite, 14 files)
 Test Files  14 passed — incl. new forward-compat compat-carry regression tests

node scripts/run-vitest.mjs extensions/openai/provider-catalog.contract.test.ts extensions/google/provider-catalog.test.ts extensions/deepseek extensions/moonshot/provider-catalog.test.ts extensions/xiaomi extensions/zai extensions/minimax/model-definitions.test.ts src/plugins/manifest-registry.test.ts src/llm/providers/stream-wrappers/openai.test.ts
 all shards passed

node scripts/run-vitest.mjs ui/src/pages/labs/labs-page.test.ts
 Test Files  1 passed — new: "auto" reads as enabled in Labs
```

- `node scripts/check-changed.mjs` (delegated to Blacksmith Testbox): green, exit 0 (all lanes incl. formatting, ratchets, boundaries)
- `node scripts/run-tsgo.mjs` core/extensions/root test lanes and `tsconfig.extensions.json`: clean
- Autoreview (Codex, gpt-5.6-sol, `--mode uncommitted`, run per commit): clean each round — "no accepted/actionable findings reported"
- `node scripts/generate-docs-map.mjs --check` — up to date

Branch drift: this PR intentionally does not chase moving `main`; merge drift is advisory in this repo, GitHub blocks real conflicts, and the land flow validates hosted CI on the exact head.

ClawSweeper rank-up notes: the preferred/unflagged comparison above is the requested after-fix side-by-side. A harness-path (plugin tool-bridge) runtime transcript is intentionally skipped: the only bundled consumer is the Copilot bridge, which requires live GitHub Copilot session auth; its gate is the same `isCodeModeEngagedForModel` helper proven above and is covered by the tool-surface-bridge unit table. The initial preferred-model policy and catalog-correction ownership are sponsored by the repository owner (this PR implements the owner-approved list, including the explicit decision to keep `claude-sonnet-4-6` out of the preferred tier).
