### PR TITLE
fix: preserve pruned history when compaction summarization fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,7 +51,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- **Compaction pruning safety:** cancel compaction when the pruned history prefix cannot be summarized, preserving the transcript for retry instead of advancing a boundary with missing context.
 - **Codex native controls:** stop misclassifying valid thinking/fast runtime controls as provider overrides so Codex routes keep their native controls, while provider-native objects and invalid values stay fail-closed. Thanks @VACInc. (#107588)
 - **State snapshot verification:** run SQLite snapshot verification in a separate process so worker-thread file closes no longer drop the Gateway's POSIX WAL locks, eliminating spurious WAL misses and I/O errors. Thanks @VACInc. (#114016)
 - **Reply latency with model policies:** reuse one immutable plugin-metadata snapshot per model-selection run instead of repeating plugin discovery, cutting reply delay when a model policy is configured. Thanks @VACInc. (#114117)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Compaction pruning safety:** cancel compaction when the pruned history prefix cannot be summarized, preserving the transcript for retry instead of advancing a boundary with missing context.
 - **Codex native controls:** stop misclassifying valid thinking/fast runtime controls as provider overrides so Codex routes keep their native controls, while provider-native objects and invalid values stay fail-closed. Thanks @VACInc. (#107588)
 - **State snapshot verification:** run SQLite snapshot verification in a separate process so worker-thread file closes no longer drop the Gateway's POSIX WAL locks, eliminating spurious WAL misses and I/O errors. Thanks @VACInc. (#114016)
 - **Reply latency with model policies:** reuse one immutable plugin-metadata snapshot per model-selection run instead of repeating plugin discovery, cutting reply delay when a model policy is configured. Thanks @VACInc. (#114117)

--- a/src/agents/agent-hooks/compaction-safeguard.test.ts
+++ b/src/agents/agent-hooks/compaction-safeguard.test.ts
@@ -1569,10 +1569,11 @@ describe("compaction-safeguard recent-turn preservation", () => {
     const abortError = Object.assign(new Error("This operation was aborted"), {
       name: "AbortError",
     });
+    const lateSummarizationError = new Error("transport failed after cancellation");
     mockSummarizeInStages
       .mockImplementationOnce(async () => {
-        controller.abort();
-        throw abortError;
+        controller.abort(abortError);
+        throw lateSummarizationError;
       })
       .mockResolvedValue(summaryResult("later summary must not run"));
 

--- a/src/agents/agent-hooks/compaction-safeguard.test.ts
+++ b/src/agents/agent-hooks/compaction-safeguard.test.ts
@@ -1446,16 +1446,70 @@ describe("compaction-safeguard recent-turn preservation", () => {
     expect(summary).not.toContain("N/A (identifier policy off).");
   });
 
-  it("uses structured instructions when summarizing dropped history chunks", async () => {
+  it("cancels without advancing the boundary when dropped history cannot be summarized", async () => {
     mockSummarizeInStages.mockReset();
-    mockSummarizeInStages.mockResolvedValue(summaryResult("mock summary"));
+    mockSummarizeInStages
+      .mockRejectedValueOnce(new Error("dropped prefix unavailable"))
+      .mockResolvedValue(summaryResult("later summary must not run"));
 
     const sessionManager = stubSessionManager();
     const model = createAnthropicModelFixture();
     setCompactionSafeguardRuntime(sessionManager, {
       model,
       maxHistoryShare: 0.1,
-      recentTurnsPreserve: 12,
+      recentTurnsPreserve: 0,
+    });
+
+    const compactionHandler = createCompactionHandler();
+    const mockContext = createCompactionContext({
+      sessionManager,
+      getApiKeyMock: vi.fn().mockResolvedValue("test-key"),
+    });
+    const messagesToSummarize: AgentMessage[] = Array.from({ length: 4 }, (_unused, index) => ({
+      role: "user",
+      content: `msg-${index}-${"x".repeat(120_000)}`,
+      timestamp: index + 1,
+    }));
+    const transcriptBefore = structuredClone(messagesToSummarize);
+    const event = {
+      preparation: {
+        messagesToSummarize,
+        turnPrefixMessages: [],
+        firstKeptEntryId: "entry-1",
+        tokensBefore: 400_000,
+        fileOps: { read: [], edited: [], written: [] },
+        settings: { reserveTokens: 4000 },
+        previousSummary: undefined,
+        isSplitTurn: false,
+      },
+      customInstructions: "Keep security caveats.",
+      signal: new AbortController().signal,
+    };
+
+    const result = await compactionHandler(event, mockContext);
+
+    expect(result).toEqual({ cancel: true });
+    expect(result).not.toHaveProperty("compaction");
+    expect(mockSummarizeInStages).toHaveBeenCalledTimes(1);
+    expect(messagesToSummarize).toStrictEqual(transcriptBefore);
+    expect(consumeCompactionSafeguardCancelReason(sessionManager)).toBe(
+      "Compaction safeguard could not summarize the session: " +
+        "Failed to summarize dropped messages. | dropped prefix unavailable",
+    );
+  });
+
+  it("incorporates a successful dropped-history summary into the main summary", async () => {
+    mockSummarizeInStages.mockReset();
+    mockSummarizeInStages
+      .mockResolvedValueOnce(summaryResult("dropped history summary"))
+      .mockResolvedValueOnce(summaryResult("main history summary"));
+
+    const sessionManager = stubSessionManager();
+    const model = createAnthropicModelFixture();
+    setCompactionSafeguardRuntime(sessionManager, {
+      model,
+      maxHistoryShare: 0.1,
+      recentTurnsPreserve: 0,
     });
 
     const compactionHandler = createCompactionHandler();
@@ -1469,6 +1523,7 @@ describe("compaction-safeguard recent-turn preservation", () => {
       content: `msg-${index}-${"x".repeat(120_000)}`,
       timestamp: index + 1,
     }));
+    const transcriptBefore = structuredClone(messagesToSummarize);
     const event = {
       preparation: {
         messagesToSummarize,
@@ -1490,17 +1545,75 @@ describe("compaction-safeguard recent-turn preservation", () => {
 
     const result = (await compactionHandler(event, mockContext)) as {
       cancel?: boolean;
-      compaction?: { summary?: string };
+      compaction?: { summary?: string; firstKeptEntryId?: string };
     };
 
     expect(result.cancel).not.toBe(true);
-    expect(mockSummarizeInStages).toHaveBeenCalledTimes(1);
+    expect(result.compaction?.summary).toContain("main history summary");
+    expect(result.compaction?.firstKeptEntryId).toBe("entry-1");
+    expect(mockSummarizeInStages).toHaveBeenCalledTimes(2);
     const droppedCall = requireRecord(mockCallArg(mockSummarizeInStages));
     expect(droppedCall?.customInstructions).toContain(
       "Produce a compact, factual summary with these exact section headings:",
     );
     expect(droppedCall?.customInstructions).toContain("## Decisions");
     expect(droppedCall?.customInstructions).toContain("Keep security caveats.");
+    const mainCall = requireRecord(mockCallArg(mockSummarizeInStages, 1));
+    expect(JSON.stringify(mainCall?.messages)).toContain("dropped history summary");
+    expect(messagesToSummarize).toStrictEqual(transcriptBefore);
+  });
+
+  it("propagates caller abort while summarizing dropped history", async () => {
+    mockSummarizeInStages.mockReset();
+    const controller = new AbortController();
+    const abortError = Object.assign(new Error("This operation was aborted"), {
+      name: "AbortError",
+    });
+    mockSummarizeInStages
+      .mockImplementationOnce(async () => {
+        controller.abort();
+        throw abortError;
+      })
+      .mockResolvedValue(summaryResult("later summary must not run"));
+
+    const sessionManager = stubSessionManager();
+    const model = createAnthropicModelFixture();
+    setCompactionSafeguardRuntime(sessionManager, {
+      model,
+      maxHistoryShare: 0.1,
+      recentTurnsPreserve: 0,
+    });
+
+    const compactionHandler = createCompactionHandler();
+    const mockContext = createCompactionContext({
+      sessionManager,
+      getApiKeyMock: vi.fn().mockResolvedValue("test-key"),
+    });
+    const messagesToSummarize: AgentMessage[] = Array.from({ length: 4 }, (_unused, index) => ({
+      role: "user",
+      content: `msg-${index}-${"x".repeat(120_000)}`,
+      timestamp: index + 1,
+    }));
+    const transcriptBefore = structuredClone(messagesToSummarize);
+    const event = {
+      preparation: {
+        messagesToSummarize,
+        turnPrefixMessages: [],
+        firstKeptEntryId: "entry-1",
+        tokensBefore: 400_000,
+        fileOps: { read: [], edited: [], written: [] },
+        settings: { reserveTokens: 4000 },
+        previousSummary: undefined,
+        isSplitTurn: false,
+      },
+      customInstructions: "",
+      signal: controller.signal,
+    };
+
+    await expect(compactionHandler(event, mockContext)).rejects.toBe(abortError);
+    expect(mockSummarizeInStages).toHaveBeenCalledTimes(1);
+    expect(consumeCompactionSafeguardCancelReason(sessionManager)).toBeNull();
+    expect(messagesToSummarize).toStrictEqual(transcriptBefore);
   });
 
   it("caps summarization reserve tokens to the model output limit", async () => {

--- a/src/agents/agent-hooks/compaction-safeguard.ts
+++ b/src/agents/agent-hooks/compaction-safeguard.ts
@@ -1322,11 +1322,12 @@ export default function compactionSafeguardExtension(api: ExtensionAPI): void {
                   streamFn,
                 });
               } catch (droppedError) {
-                log.warn(
-                  `Compaction safeguard: failed to summarize dropped messages, continuing without: ${formatErrorMessage(
-                    droppedError,
-                  )}`,
-                );
+                if (signal?.aborted) {
+                  throw droppedError;
+                }
+                throw new Error("Failed to summarize dropped messages.", {
+                  cause: droppedError,
+                });
               }
             }
           }
@@ -1501,6 +1502,11 @@ export default function compactionSafeguardExtension(api: ExtensionAPI): void {
         },
       };
     } catch (error) {
+      // Caller cancellation is terminal, not a safeguard failure. Preserve the
+      // original abort so the runner can classify it without a false data-loss warning.
+      if (signal?.aborted) {
+        throw error;
+      }
       const message = formatErrorMessage(error);
       log.warn(
         `Compaction summarization failed; cancelling compaction to preserve history: ${message}`,

--- a/src/agents/agent-hooks/compaction-safeguard.ts
+++ b/src/agents/agent-hooks/compaction-safeguard.ts
@@ -1323,7 +1323,7 @@ export default function compactionSafeguardExtension(api: ExtensionAPI): void {
                 });
               } catch (droppedError) {
                 if (signal?.aborted) {
-                  throw droppedError;
+                  signal.throwIfAborted();
                 }
                 throw new Error("Failed to summarize dropped messages.", {
                   cause: droppedError,
@@ -1505,7 +1505,7 @@ export default function compactionSafeguardExtension(api: ExtensionAPI): void {
       // Caller cancellation is terminal, not a safeguard failure. Preserve the
       // original abort so the runner can classify it without a false data-loss warning.
       if (signal?.aborted) {
-        throw error;
+        signal.throwIfAborted();
       }
       const message = formatErrorMessage(error);
       log.warn(


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users whose new session content exceeded the compaction history budget could lose the pruned older prefix when its dedicated summary request failed. Compaction previously continued successfully, advanced the boundary, and persisted a checkpoint even though that history survived nowhere in the result.

## Why This Change Was Made

The pruning path intentionally says both “Summarize dropped messages so context isn't lost” and “Feed dropped-messages summary as previousSummary so the main summarization incorporates context from pruned messages instead of losing it entirely.” The old catch violated both invariants by suppressing the only summary failure that could preserve that prefix.

This fails closed at the safeguard owner: a non-abort dropped-prefix summary failure now cancels compaction and records the safeguard reason. Caller-triggered aborts continue to propagate as cancellations rather than being relabeled as safeguard failures. The direct runner remains untouched because it cannot distinguish a complete extension summary from a partial one.

This changes behavior by design: compaction now fails loudly in a case where it previously “succeeded” while dropping context. A cancelled compaction is visible and recoverable—the transcript remains intact and a later attempt can retry—while silently advancing the boundary is not.

Maintainer decision: **FAIL CLOSED**. The additional visible cancellation is the intended safety tradeoff.

The defective pruning catch was introduced in #104815. This fix is AI-assisted and maintainer-directed.

## User Impact

When summarizing a pruned history prefix fails, users now keep the complete transcript and receive a compaction cancellation reason instead of seeing an apparently successful compaction with missing context. Successful pruning and compaction behavior is unchanged.

## Evidence

- `node scripts/run-vitest.mjs src/agents/agent-hooks/compaction-safeguard.test.ts`: 117/117 tests passed.
- Focused fail-closed, success, and caller-abort regressions passed in both routed agent configs (6/6 selected assertions).
- Failure regression forces pruning, rejects the dropped-prefix call, leaves a hypothetical later call able to succeed, and proves the hook returns only `{ cancel: true }`, emits no compaction/boundary payload, makes no later summary call, preserves the transcript, and records the safeguard reason.
- Success regression proves the dropped-prefix summary is incorporated into the main summary and the normal boundary result remains intact.
- Blacksmith Testbox changed gate: https://github.com/openclaw/openclaw/actions/runs/30295813820 (`tbx_01kyjest7vd63xmz1hwr1e3x6a`, exit 0).
- Fresh Codex autoreview after the abort-race fix: no accepted/actionable findings; patch correct at 0.95 confidence.

### Real runtime cancellation and retry

Blacksmith Testbox run https://github.com/openclaw/openclaw/actions/runs/30300120153 (`tbx_01kyjj4zxpm73vx63n4xn5xet1`, exit 0) exercised a real isolated OpenClaw session through `openclaw agent --local`, a running Gateway, and the public `openclaw sessions compact` command.

- Prepared state: `tokensBefore=400007`, `newContentTokens=339903`, `maxHistoryTokens=9600`; pruning dropped 3 older chunks / 8 messages.
- Provider unavailable: the command exited 1 with `compacted:false` and reason `Failed to summarize dropped messages`.
- Persisted transcript before and after cancellation: 23 events, 0 compaction boundaries, identical SHA-256 `49a0312331799d8fdd731283c866722335ae450eda2e2a8d48906b3e9ae73e93`.
- Provider restored: retry returned `ok:true`, `compacted:true`, `tokensBefore=400007`, `tokensAfter=30053`.
- Persisted transcript after retry: 24 events, 1 compaction boundary, last event type `compaction`.
