### PR TITLE
fix(agents): safely guard optional binding.sessionId in setCliSessionBinding

### DIFF
--- a/src/agents/cli-session.ts
+++ b/src/agents/cli-session.ts
@@ -33,7 +33,7 @@ export function setCliSessionBinding(
   binding: CliSessionBinding,
 ): void {
   const normalized = normalizeProviderId(provider);
-  const trimmed = binding.sessionId.trim();
+  const trimmed = binding?.sessionId?.trim();
   if (!trimmed) {
     return;
   }


### PR DESCRIPTION
## Description
This PR resolves issue #114656 by safely dereferencing `binding?.sessionId?.trim()` in `setCliSessionBinding` (`src/agents/cli-session.ts`).

## Details
- Prevents `TypeError: Cannot read properties of undefined (reading 'trim')` when empty or undefined session bindings are passed during compaction.