### PR TITLE
fix(doctor): persist safe migrations before runtime timeouts

### DIFF
--- a/src/commands/doctor/repair-sequencing.test.ts
+++ b/src/commands/doctor/repair-sequencing.test.ts
@@ -6,7 +6,6 @@ import { runDoctorRepairSequence } from "./repair-sequencing.js";
 const mocks = vi.hoisted(() => ({
   applyPluginAutoEnable: vi.fn(),
   materializePluginAutoEnableCandidates: vi.fn(),
-  collectActiveToolSchemaProjectionWarnings: vi.fn(),
   collectChannelDoctorCompatibilityMutations: vi.fn(),
   ensureAuthProfileStore: vi.fn(),
   evaluateStoredCredentialEligibility: vi.fn(),
@@ -132,10 +131,6 @@ vi.mock("./shared/allowlist-policy-repair.js", () => ({
 
 vi.mock("./shared/allowfrom-fallback-migration.js", () => ({
   maybeRepairGroupAllowFromFallback: mocks.maybeRepairGroupAllowFromFallback,
-}));
-
-vi.mock("./shared/active-tool-schema-warnings.js", () => ({
-  collectActiveToolSchemaProjectionWarnings: mocks.collectActiveToolSchemaProjectionWarnings,
 }));
 
 vi.mock("./shared/bundled-plugin-load-paths.js", () => ({
@@ -288,7 +283,6 @@ describe("doctor repair sequencing", () => {
       changes: [],
       warnings: [],
     });
-    mocks.collectActiveToolSchemaProjectionWarnings.mockResolvedValue([]);
     mocks.collectChannelDoctorCompatibilityMutations.mockReturnValue([]);
     mocks.resolveAuthProfileOrder.mockReturnValue([]);
     mocks.resolveProfileUnusableUntilForDisplay.mockReturnValue(null);
@@ -612,37 +606,6 @@ describe("doctor repair sequencing", () => {
     ]);
     expect(result.state.pendingChanges).toBe(false);
     expect(result.state.candidate.channels?.discord?.allowFrom).toEqual([106232522769186816]);
-  });
-
-  it("emits active tool schema projection warnings during doctor repair", async () => {
-    mocks.collectActiveToolSchemaProjectionWarnings.mockResolvedValueOnce([
-      '- agents.main: active tool "fuzzplugin_move_angles" from plugin "fuzzplugin" has unsupported runtime input schema.',
-    ]);
-
-    const result = await runDoctorRepairSequence({
-      state: {
-        cfg: {
-          tools: { allow: ["fuzzplugin_move_angles"] },
-        } as OpenClawConfig,
-        candidate: {
-          tools: { allow: ["fuzzplugin_move_angles"] },
-        } as OpenClawConfig,
-        pendingChanges: false,
-        fixHints: [],
-      },
-      doctorFixCommand: "openclaw doctor --fix",
-    });
-
-    expect(result.changeNotes).toStrictEqual([]);
-    expect(result.warningNotes).toContain(
-      '- agents.main: active tool "fuzzplugin_move_angles" from plugin "fuzzplugin" has unsupported runtime input schema.',
-    );
-    expect(mocks.collectActiveToolSchemaProjectionWarnings).toHaveBeenCalledWith({
-      cfg: {
-        tools: { allow: ["fuzzplugin_move_angles"] },
-      },
-      env: process.env,
-    });
   });
 
   it("auto-enables newly installed configured plugins after doctor repair", async () => {

--- a/src/commands/doctor/repair-sequencing.ts
+++ b/src/commands/doctor/repair-sequencing.ts
@@ -16,7 +16,6 @@ import {
   maybeRepairManagedNpmOpenClawPeerLinks,
   maybeRepairStaleManagedNpmBundledPlugins,
 } from "../doctor-plugin-registry.js";
-import { collectActiveToolSchemaProjectionWarnings } from "./shared/active-tool-schema-warnings.js";
 import { maybeRepairGroupAllowFromFallback } from "./shared/allowfrom-fallback-migration.js";
 import { maybeRepairAllowlistPolicyAllowFrom } from "./shared/allowlist-policy-repair.js";
 import { maybeRepairBundledPluginLoadPaths } from "./shared/bundled-plugin-load-paths.js";
@@ -270,12 +269,6 @@ export async function runDoctorRepairSequence(params: {
     openAIAuthProviderRepair.changes.length > 0 ||
     staleOAuthShadowRepair.changes.length > 0 ||
     authProfileSqliteMigration.changes.length > 0;
-
-  const activeToolSchemaWarnings = await collectActiveToolSchemaProjectionWarnings({
-    cfg: state.candidate,
-    env,
-  });
-  appendNotes(warningNotes, activeToolSchemaWarnings);
 
   return { state, changeNotes, warningNotes, authProfilesRepaired };
 }

--- a/src/flows/doctor-health-contribution-runners.config.ts
+++ b/src/flows/doctor-health-contribution-runners.config.ts
@@ -25,13 +25,16 @@ function shouldSkipLegacyUpdateDoctorConfigWrite(env: NodeJS.ProcessEnv): boolea
   );
 }
 
-export async function runWriteConfigHealth(ctx: DoctorHealthFlowContext): Promise<void> {
+export async function runWriteConfigHealth(
+  ctx: DoctorHealthFlowContext,
+  options: { runPostWriteRepairs?: boolean } = {},
+): Promise<void> {
   const { applyWizardMetadata } = await import("../commands/onboard-helpers.js");
   const { replaceConfigFile } = await import("../config/config.js");
   const { logConfigUpdated } = await import("../config/logging.js");
   const { shortenHomePath } = await import("../utils.js");
   const shouldWriteConfig =
-    ctx.configResult.shouldWriteConfig ||
+    (ctx.configResult.shouldWriteConfig && ctx.configResultWriteCommitted !== true) ||
     JSON.stringify(ctx.cfg) !== JSON.stringify(ctx.cfgForPersistence);
   if (shouldWriteConfig) {
     const updateDoctorRun = isUpdateDoctorRun(ctx.env ?? process.env);
@@ -61,6 +64,12 @@ export async function runWriteConfigHealth(ctx: DoctorHealthFlowContext): Promis
           : {}),
       },
     });
+    // The final writer runs again after health repairs. Advance its baseline only
+    // after the atomic write succeeds so later failures cannot mark volatile state durable.
+    ctx.cfgForPersistence = structuredClone(ctx.cfg);
+    if (ctx.configResult.shouldWriteConfig === true) {
+      ctx.configResultWriteCommitted = true;
+    }
     // logConfigUpdated already prints the `.bak` backup line when it exists.
     logConfigUpdated(ctx.runtime);
     const preUpdateSnapshotPath = `${ctx.configPath}.pre-update`;
@@ -70,7 +79,11 @@ export async function runWriteConfigHealth(ctx: DoctorHealthFlowContext): Promis
       );
     }
   }
-  if (ctx.configResult.shouldRepairCronCodexModelRefsAfterConfigWrite !== true) {
+  if (
+    options.runPostWriteRepairs === false ||
+    ctx.configResult.shouldRepairCronCodexModelRefsAfterConfigWrite !== true ||
+    ctx.postConfigWriteRepairsCommitted === true
+  ) {
     return;
   }
   // The config write above must finish before cron rows are rewritten against
@@ -83,6 +96,7 @@ export async function runWriteConfigHealth(ctx: DoctorHealthFlowContext): Promis
       ? { blockedModelIdentities: new Set(ctx.configResult.blockedCodexModelIdentities) }
       : {}),
   });
+  ctx.postConfigWriteRepairsCommitted = true;
   const { note } = await import("../../packages/terminal-core/src/note.js");
   if (result.changes.length > 0) {
     note(result.changes.join("\n"), "Doctor changes");
@@ -90,6 +104,14 @@ export async function runWriteConfigHealth(ctx: DoctorHealthFlowContext): Promis
   if (result.warnings.length > 0) {
     note(result.warnings.join("\n"), "Doctor warnings");
   }
+}
+
+/** Commits the finalized config-flow candidate before fallible health diagnostics start. */
+export async function runInitialConfigWriteHealth(ctx: DoctorHealthFlowContext): Promise<void> {
+  if (ctx.configResult.shouldWriteConfig !== true) {
+    return;
+  }
+  await runWriteConfigHealth(ctx, { runPostWriteRepairs: false });
 }
 
 export async function collectWriteConfigHealthFindings(

--- a/src/flows/doctor-health-contribution-runners.workspace.ts
+++ b/src/flows/doctor-health-contribution-runners.workspace.ts
@@ -9,6 +9,27 @@ type PluginVersionDriftReport =
 const loadDoctorStateIntegrityModule = async () =>
   await import("../commands/doctor-state-integrity.js");
 
+export async function runActiveToolSchemaWarningsHealth(
+  ctx: DoctorHealthFlowContext,
+): Promise<void> {
+  // Preview mode already collects these while deciding whether to apply repairs.
+  // Repair mode defers the runtime-backed diagnostic until migrations are durable.
+  if (!ctx.prompter.shouldRepair) {
+    return;
+  }
+  const { collectActiveToolSchemaProjectionWarnings } =
+    await import("../commands/doctor/shared/active-tool-schema-warnings.js");
+  const warnings = await collectActiveToolSchemaProjectionWarnings({
+    cfg: ctx.cfg,
+    env: ctx.env ?? process.env,
+  });
+  if (warnings.length === 0) {
+    return;
+  }
+  const { note } = await import("../../packages/terminal-core/src/note.js");
+  note(warnings.join("\n"), "Doctor warnings");
+}
+
 export async function runHooksModelHealth(ctx: DoctorHealthFlowContext): Promise<void> {
   if (!ctx.cfg.hooks?.gmail?.model?.trim()) {
     return;

--- a/src/flows/doctor-health-contribution-types.ts
+++ b/src/flows/doctor-health-contribution-types.ts
@@ -28,6 +28,10 @@ export type DoctorHealthFlowContext = {
   configResult: DoctorConfigResult;
   cfg: OpenClawConfig;
   cfgForPersistence: OpenClawConfig;
+  /** The finalized config-flow candidate crossed the atomic writer boundary. */
+  configResultWriteCommitted?: boolean;
+  /** One-shot repairs that require a durable config write have completed. */
+  postConfigWriteRepairsCommitted?: boolean;
   sourceConfigValid: boolean;
   configPath: string;
   env?: NodeJS.ProcessEnv;

--- a/src/flows/doctor-health-contributions-initial.ts
+++ b/src/flows/doctor-health-contributions-initial.ts
@@ -1,3 +1,4 @@
+import { runInitialConfigWriteHealth } from "./doctor-health-contribution-runners.config.js";
 import {
   runClaudeCliHealth,
   runCommandOwnerHealth,
@@ -19,6 +20,7 @@ import {
   runSessionTranscriptsHealth,
   runStateIntegrityHealth,
 } from "./doctor-health-contribution-runners.state.js";
+import { runActiveToolSchemaWarningsHealth } from "./doctor-health-contribution-runners.workspace.js";
 import type {
   DoctorHealthContribution,
   DoctorHealthFlowContext,
@@ -53,6 +55,16 @@ export function resolveInitialDoctorHealthContributions(params: {
   runLegacyStateHealth: (ctx: DoctorHealthFlowContext) => Promise<void>;
 }): DoctorHealthContribution[] {
   return [
+    createDoctorHealthContribution({
+      id: "doctor:write-config-migrations",
+      label: "Write config migrations",
+      run: runInitialConfigWriteHealth,
+    }),
+    createDoctorHealthContribution({
+      id: "doctor:active-tool-schema-warnings",
+      label: "Active tool schema warnings",
+      run: runActiveToolSchemaWarningsHealth,
+    }),
     createDoctorHealthContribution({
       id: "doctor:gateway-config",
       label: "Gateway config",

--- a/src/flows/doctor-health-contributions.test.ts
+++ b/src/flows/doctor-health-contributions.test.ts
@@ -88,6 +88,7 @@ const mocks = vi.hoisted(() => ({
       cfg.agents?.defaults?.contextLimits ?? {},
   ),
   note: vi.fn(),
+  collectActiveToolSchemaProjectionWarnings: vi.fn(),
   loadModelCatalog: vi.fn(async () => []),
   findModelCatalogEntry: vi.fn(() => ({ contextTokens: 200_000 })),
   getModelRefStatus: vi.fn(() => ({ allowed: true, inCatalog: true, key: "openai/gpt-5.5" })),
@@ -352,6 +353,10 @@ vi.mock("../agents/agent-scope.js", () => ({
 
 vi.mock("../../packages/terminal-core/src/note.js", () => ({
   note: mocks.note,
+}));
+
+vi.mock("../commands/doctor/shared/active-tool-schema-warnings.js", () => ({
+  collectActiveToolSchemaProjectionWarnings: mocks.collectActiveToolSchemaProjectionWarnings,
 }));
 
 vi.mock("../agents/model-catalog.js", () => ({
@@ -661,6 +666,8 @@ describe("doctor health contributions", () => {
         cfg.agents?.defaults?.contextLimits ?? {},
     );
     mocks.note.mockReset();
+    mocks.collectActiveToolSchemaProjectionWarnings.mockReset();
+    mocks.collectActiveToolSchemaProjectionWarnings.mockResolvedValue([]);
     mocks.loadModelCatalog.mockReset();
     mocks.loadModelCatalog.mockResolvedValue([]);
     mocks.findModelCatalogEntry.mockReset();
@@ -827,6 +834,100 @@ describe("doctor health contributions", () => {
       ids.indexOf("doctor:plugin-registry"),
     );
     expect(ids.indexOf("doctor:plugin-registry")).toBeLessThan(ids.indexOf("doctor:write-config"));
+  });
+
+  it("orders the config-flow commit before runtime-backed diagnostics", () => {
+    const ids = resolveDoctorHealthContributions().map((entry) => entry.id);
+    const migrationWriteIndex = ids.indexOf("doctor:write-config-migrations");
+
+    expect(migrationWriteIndex).toBe(0);
+    expect(migrationWriteIndex).toBeLessThan(ids.indexOf("doctor:active-tool-schema-warnings"));
+    expect(migrationWriteIndex).toBeLessThan(ids.indexOf("doctor:hooks-model"));
+    expect(migrationWriteIndex).toBeLessThan(ids.indexOf("doctor:runtime-tool-schemas"));
+    expect(migrationWriteIndex).toBeLessThan(ids.indexOf("doctor:write-config"));
+  });
+
+  it("keeps a late runtime publication failure after committing config migrations", async () => {
+    const cfg = { hooks: { gmail: { model: "openai/gpt-5.5" } } } as OpenClawConfig;
+    const ctx = {
+      cfg,
+      cfgForPersistence: structuredClone(cfg),
+      configResult: { cfg, shouldWriteConfig: true },
+      configPath: "/tmp/fake-openclaw.json",
+      sourceConfigValid: true,
+      prompter: buildDoctorPrompter(true),
+      runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() },
+      options: {},
+      env: {},
+    } as DoctorContributionRunContext;
+    const timeout = new Error("prepared model runtime publication timed out");
+    mocks.collectActiveToolSchemaProjectionWarnings.mockResolvedValueOnce([
+      `- agents.main: active tool schema validation could not resolve the runtime model context (${timeout.message}).`,
+    ]);
+    mocks.loadModelCatalog.mockRejectedValueOnce(timeout);
+
+    await requireDoctorContribution("doctor:write-config-migrations").run(ctx);
+    await requireDoctorContribution("doctor:active-tool-schema-warnings").run(ctx);
+    await expect(requireDoctorContribution("doctor:hooks-model").run(ctx)).rejects.toThrow(
+      timeout.message,
+    );
+
+    expect(mocks.replaceConfigFile).toHaveBeenCalledOnce();
+    expect(ctx.configResultWriteCommitted).toBe(true);
+    expect(mocks.note).toHaveBeenCalledWith(
+      expect.stringContaining(timeout.message),
+      "Doctor warnings",
+    );
+  });
+
+  it("writes a successful config migration once across both write phases", async () => {
+    const cfg = { gateway: { mode: "local" } } as OpenClawConfig;
+    const ctx = {
+      cfg,
+      cfgForPersistence: structuredClone(cfg),
+      configResult: { cfg, shouldWriteConfig: true },
+      configPath: "/tmp/fake-openclaw.json",
+      sourceConfigValid: true,
+      prompter: buildDoctorPrompter(true),
+      runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() },
+      options: {},
+      env: {},
+    } as DoctorContributionRunContext;
+
+    await requireDoctorContribution("doctor:write-config-migrations").run(ctx);
+    await requireDoctorContribution("doctor:write-config").run(ctx);
+
+    expect(mocks.replaceConfigFile).toHaveBeenCalledOnce();
+    expect(ctx.configResultWriteCommitted).toBe(true);
+    expect(ctx.cfgForPersistence).toEqual(ctx.cfg);
+  });
+
+  it("does not mark an invalid migration durable when validation rejects the write", async () => {
+    const cfg = { gateway: { mode: "invalid" } } as unknown as OpenClawConfig;
+    const ctx = {
+      cfg,
+      cfgForPersistence: structuredClone(cfg),
+      configResult: { cfg, shouldWriteConfig: true },
+      configPath: "/tmp/fake-openclaw.json",
+      sourceConfigValid: true,
+      prompter: buildDoctorPrompter(true),
+      runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() },
+      options: {},
+      env: {},
+    } as DoctorContributionRunContext;
+    mocks.replaceConfigFile.mockRejectedValueOnce(
+      new Error(
+        'Config validation failed: gateway.mode: Invalid input (allowed: "local", "remote")',
+      ),
+    );
+
+    await expect(
+      requireDoctorContribution("doctor:write-config-migrations").run(ctx),
+    ).rejects.toThrow("Config validation failed");
+
+    expect(ctx.configResultWriteCommitted).not.toBe(true);
+    expect(ctx.cfgForPersistence).toEqual(cfg);
+    expect(mocks.collectActiveToolSchemaProjectionWarnings).not.toHaveBeenCalled();
   });
 
   it("skips read-scope gateway probes when gateway health only proved reachability", async () => {
@@ -3146,6 +3247,7 @@ describe("doctor health contributions", () => {
   });
 
   it("preserves gateway service config repairs for later doctor writes", async () => {
+    const migrationWriteContribution = requireDoctorContribution("doctor:write-config-migrations");
     const gatewayServicesContribution = requireDoctorContribution("doctor:gateway-services");
     const writeConfigContribution = requireDoctorContribution("doctor:write-config");
     const originalCfg = { gateway: {} };
@@ -3176,6 +3278,7 @@ describe("doctor health contributions", () => {
       env: {},
     } as unknown as DoctorContributionRunContext;
 
+    await migrationWriteContribution.run(ctx);
     await gatewayServicesContribution.run(ctx);
     await writeConfigContribution.run(ctx);
 
@@ -3191,7 +3294,14 @@ describe("doctor health contributions", () => {
         skipPluginValidation: true,
       }),
     );
-    expect(mocks.replaceConfigFile).toHaveBeenCalledWith(
+    expect(mocks.replaceConfigFile).toHaveBeenCalledTimes(2);
+    expect(mocks.replaceConfigFile).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        nextConfig: originalCfg,
+      }),
+    );
+    expect(mocks.replaceConfigFile).toHaveBeenLastCalledWith(
       expect.objectContaining({
         nextConfig: repairedCfg,
       }),
@@ -3306,7 +3416,7 @@ describe("doctor health contributions", () => {
     expect(mocks.repairCronCodexModelRefsAfterConfigWrite).not.toHaveBeenCalled();
   });
 
-  it("commits deferred cron migration after the config write succeeds", async () => {
+  it("keeps deferred cron migration in the final phase after the early config write", async () => {
     const cfg = { agents: { defaults: { models: {} } } } as OpenClawConfig;
     const ctx = {
       cfg,
@@ -3324,6 +3434,10 @@ describe("doctor health contributions", () => {
       options: {},
       env: {},
     } as DoctorContributionRunContext;
+
+    await requireDoctorContribution("doctor:write-config-migrations").run(ctx);
+
+    expect(mocks.repairCronCodexModelRefsAfterConfigWrite).not.toHaveBeenCalled();
 
     await requireDoctorContribution("doctor:write-config").run(ctx);
 


### PR DESCRIPTION
Related: #111627

## What Problem This Solves

Fixes an issue where users running `openclaw doctor --fix` during an upgrade could hit a prepared model runtime publication timeout before otherwise-safe config migrations were written. Re-running doctor repeated the timeout and could leave the gateway unable to start because retired keys remained on disk.

## Why This Change Was Made

Doctor now commits the finalized config-flow candidate through the existing validating atomic writer before runtime-backed health diagnostics begin. The later config-write phase remains in place for repairs made by subsequent health checks, while rejected writes do not advance the durable baseline and publication failures are still reported.

AI-assisted: yes. The implementation was inspected, tested, behavior-validated, and passed the repository autoreview workflow. No agent transcript is included per requester instruction.

## User Impact

Safe upgrade migrations persist even if a later model-runtime publication step times out. Operators still see the timeout and receive a nonzero exit, while invalid migration candidates remain completely unpersisted.

## Evidence

- Current-main red proof at `3923a9c8b9ca4a01ed0cb7a798e395fa77043607`: `prepared model runtime publication timed out`, unchanged before/after config hash, retired `tui` key still present.
- Exact proposed-head proof at `392ec7c25f2a9e4beadc44e3dad8bc399f797b86`: the exact timeout and nonzero result remain, the config hash changes, `tui` is absent, and the persisted file reparses as valid JSON. [Testbox run](https://github.com/openclaw/openclaw/actions/runs/30306366242)
- Focused tests: 117 passed across `src/flows/doctor-health-contributions.test.ts` and `src/commands/doctor/repair-sequencing.test.ts` on the patch rebased through current main; later base-only movement was surface-audited and did not touch those tests or their Doctor owners.
- `pnpm check:changed -- <7 touched files>` passed core/core-test typechecks, lint, formatting, import-cycle checks, and repository guards.
- Source-blind behavior validation: timeout, successful, invalid, and idempotent rerun paths passed. The invalid fixture exited 1 with byte-identical SHA-256 before/after and valid JSON.
- Opus 5 autoreview on exact proposed head: clean, no accepted/actionable findings.
