### PR TITLE
improve(agents): avoid duplicate subagent registry write

### DIFF
--- a/src/agents/subagent-registry-run-manager.ts
+++ b/src/agents/subagent-registry-run-manager.ts
@@ -907,7 +907,6 @@ export function createSubagentRunManager(params: {
       });
     }
     params.ensureListener();
-    params.persist();
     // Always start sweeper — session-mode runs (no archiveAtMs) also need TTL cleanup.
     params.startSweeper();
     // Wait for subagent completion via gateway RPC (cross-process).

--- a/src/agents/subagent-registry-run-manager.ts
+++ b/src/agents/subagent-registry-run-manager.ts
@@ -878,7 +878,9 @@ export function createSubagentRunManager(params: {
         sourceId: runId,
         ownerKey: requesterSessionKey,
         scopeKind: "session",
-        requesterOrigin,
+        // Detached task runtimes are plugin-replaceable. Isolate their input so
+        // mutation cannot change the already-persisted registry record.
+        requesterOrigin: requesterOrigin ? structuredClone(requesterOrigin) : undefined,
         childSessionKey,
         runId,
         label: registerParams.label,

--- a/src/agents/subagent-registry.test.ts
+++ b/src/agents/subagent-registry.test.ts
@@ -4471,6 +4471,24 @@ describe("subagent registry seam flow", () => {
     ).toBeUndefined();
   });
 
+  it.each([
+    { name: "running", queued: false },
+    { name: "queued", queued: true },
+  ])("persists a $name registration exactly once", ({ queued }) => {
+    mockGatewayMethods(mocks.callGateway, {
+      "agent.wait": { status: "pending" },
+    });
+
+    mod.registerSubagentRun({
+      runId: `run-single-persist-${queued ? "queued" : "running"}`,
+      task: "persist one registry snapshot",
+      queued,
+    });
+
+    expect(mocks.persistSubagentRunsToDiskOrThrow).toHaveBeenCalledOnce();
+    expect(mocks.persistSubagentRunsToDisk).not.toHaveBeenCalled();
+  });
+
   it("retains an already-running replacement when its durable write fails", () => {
     mocks.callGateway.mockImplementation(async (request: { method?: string }) =>
       request.method === "agent.wait" ? { status: "pending" } : {},

--- a/src/agents/subagent-registry.test.ts
+++ b/src/agents/subagent-registry.test.ts
@@ -38,6 +38,7 @@ import {
   SUBAGENT_ENDED_REASON_ERROR,
   SUBAGENT_ENDED_REASON_KILLED,
 } from "./subagent-lifecycle-events.js";
+import type { SubagentRunRecord } from "./subagent-registry.types.js";
 import {
   createSessionStore,
   createSubagentRunParams,
@@ -4485,6 +4486,67 @@ describe("subagent registry seam flow", () => {
       queued,
     });
 
+    expect(mocks.persistSubagentRunsToDiskOrThrow).toHaveBeenCalledOnce();
+    expect(mocks.persistSubagentRunsToDisk).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    { name: "running", queued: false },
+    { name: "queued", queued: true },
+  ])("isolates a $name registration from task runtime input mutation", ({ queued }) => {
+    const runId = `run-isolated-origin-${queued ? "queued" : "running"}`;
+    const expectedRequesterOrigin = {
+      channel: "discord",
+      to: "channel:123",
+      accountId: "acct-1",
+      threadId: 42,
+    };
+    const requesterOrigin = {
+      ...expectedRequesterOrigin,
+      deliveryIntent: {
+        id: "delivery-1",
+        kind: "outbound_queue" as const,
+        queuePolicy: "required" as const,
+      },
+    };
+    let persistedEntry: SubagentRunRecord | undefined;
+    mocks.persistSubagentRunsToDiskOrThrow.mockImplementationOnce((runs) => {
+      persistedEntry = structuredClone(runs.get(runId));
+    });
+    mockGatewayMethods(mocks.callGateway, {
+      "agent.wait": { status: "pending" },
+    });
+    const defaultRuntime = getDetachedTaskLifecycleRuntime();
+    const createMutatingTaskRun = vi.fn(
+      (taskParams: Parameters<typeof defaultRuntime.createQueuedTaskRun>[0]) => {
+        if (!taskParams.requesterOrigin) {
+          throw new Error("expected requester origin");
+        }
+        Object.assign(taskParams.requesterOrigin, {
+          channel: "mutated",
+          to: "mutated",
+          accountId: "mutated",
+          threadId: "mutated",
+        });
+        return null;
+      },
+    );
+    setDetachedTaskLifecycleRuntime({
+      ...defaultRuntime,
+      createQueuedTaskRun: createMutatingTaskRun,
+      createRunningTaskRun: createMutatingTaskRun,
+    });
+
+    mod.registerSubagentRun({
+      runId,
+      task: "isolate the registry delivery context",
+      queued,
+      requesterOrigin,
+    });
+
+    expect(createMutatingTaskRun).toHaveBeenCalledOnce();
+    expect(findRequesterRun(runId)?.requesterOrigin).toEqual(expectedRequesterOrigin);
+    expect(persistedEntry?.requesterOrigin).toEqual(expectedRequesterOrigin);
     expect(mocks.persistSubagentRunsToDiskOrThrow).toHaveBeenCalledOnce();
     expect(mocks.persistSubagentRunsToDisk).not.toHaveBeenCalled();
   });


### PR DESCRIPTION
## Summary

### High Level TLDR

Subagent registration rewrote the full registry twice even though nothing changed between the two snapshots. This keeps the durable throwing write and removes the later best-effort duplicate, cutting measured SQLite row writes for 64 growing registrations from 4160 to 2080. The registry-owned requester origin is now copied before it crosses the plugin-replaceable detached task runtime boundary.

AI-assisted: yes.

## What Problem This Solves

Resolves an operational performance problem where registering a burst of subagents performs two synchronous full-snapshot registry rewrites per run. This work blocks the gateway event loop and delays unrelated queued work during large bursts.

## Why This Change Was Made

The registration path now performs one durable snapshot write. The surviving `persistOrThrow` call retains rollback and visible failure semantics. The change does not reorder task creation, listener setup, sweeper startup, or completion waiting, and it does not change the schema, serialized format, or full-snapshot persistence design.

## User Impact

Gateway operators should see less synchronous SQLite work during subagent bursts. Behavior and persisted state remain unchanged for queued and immediately running subagents.

## Root Cause

`registerSubagentRun` first called `persistOrThrow` after adding the new run and reconciling older kill state. That durable write was added by `214f718be7b3` to guarantee accepted registrations were persisted or rolled back. The older `persist` call remained after task creation and listener setup.

Both helpers reach `saveSubagentRegistryToSqlite`, which rewrites the full snapshot in one transaction by upserting every run and pruning rows not present in the snapshot. Since no registry mutation is reachable between the calls, the second call wrote the same snapshot and emitted a second persistence notification.

### The removed write was vestigial, not load-bearing

The commit history shows the removed call could never have been intended to capture state produced by task creation, because it predates task creation entirely:

```text
<= 2026-03-27  cfbef8035dd  trailing persist() already present (relocated by a refactor)
   2026-03-29  ec13f6d73eb  createRunningTaskRun inserted above it (#57481)
   2026-05-17  214f718be7b  persistOrThrow added directly before task creation (#83132)
```

When the trailing write was written it was the only durable write in the function. Task creation was later inserted above it. In May, `214f718be7b` added the strict throwing write specifically because, in that commit's own words, registry save failures were being swallowed; its stated goal was to persist the registry before returning accepted. That commit established the pre-task-creation write as the authoritative durability boundary and left the older best-effort call in place.

So this change does not remove a guarantee. It removes a redundant write that has been superseded since May.

The first transaction is atomic. A failed `persistOrThrow` rolls back SQLite, removes the newly inserted in-memory run, restores each older run's kill-reconciliation snapshot, and rethrows before task creation or runtime setup. A successful first write cannot be partially repaired by the later best-effort write.

## What Changed

Removed the non-throwing `persist` call after `ensureListener`, isolated the registry-owned `requesterOrigin` before passing it to the plugin-replaceable detached task runtime, and added parameterized queued and running regressions.

Enumeration proof for the removed write:

1. Mutation sites between the writes

   - `createQueuedTaskRun` and `createRunningTaskRun` write task and task-flow records through the detached task runtime. The production implementations do not import or mutate the subagent registry, `params.runs`, or any reachable `SubagentRunRecord`.
   - The detached task lifecycle runtime is plugin replaceable. Its only object-valued input here is now a `structuredClone` of the registry-owned `requesterOrigin`, so synchronous plugin mutation cannot alter the in-memory registry record after its durable write. A custom runtime regression mutates that input in both queued and running paths and proves the registry record and captured persisted snapshot remain unchanged. This closes the prior residual finding.
   - This is not only a guard against hypothetical third-party runtimes. The in-tree default runtime also retains the same reference: `createRunningTaskRun` and `createQueuedTaskRun` pass `params.requesterOrigin` straight into `ensureSingleTaskFlow` (`src/tasks/task-executor.ts:113,131`), which stores it on the task record. Before this change the subagent registry row and the task registry row therefore shared one mutable object across two independent stores. The copy severs that too.
   - `structuredClone` rather than a shallow spread is deliberate. `DeliveryContext` declares an optional nested `deliveryIntent` object (`src/utils/delivery-context.types.ts:28`). The value is flat at this call site only because `normalizeDeliveryContext` currently projects to `channel`, `to`, `accountId`, and `threadId` (`src/utils/delivery-context.shared.ts:48-57`). A spread would be correct today but silently degrade to partial isolation if that projection ever carried the nested field through. `structuredClone` is also the established idiom for this record family (`src/agents/subagent-registry-state.ts:49`, `src/agents/subagent-registry.store.sqlite.ts:273`).
   - The task-creation catch only logs and does not mutate registry state.
   - `ensureListener` reaches `onAgentEvent`, whose registration helper only adds the callback to a listener set. It does not synchronously deliver buffered or replayed events, so subscribing cannot mutate the registry before registration continues.
   - `startSweeper` remains after listener setup. The removed write was before `startSweeper`, so it never observed sweeper work.

2. Persistence subscribers

   - The production subscriber in `src/agents/tools/agents-wait-tool.ts` rechecks collector completion on every emit and performs a second check immediately after subscribing to close the read-subscribe race. A new registration has no collector completion state, and this subscriber reads only the subagent registry, so the duplicate emit and task-record timing are irrelevant.
   - The test subscriber in `src/agents/tools/agents-wait-tool.test.ts` is an explicit listener set driven by the test to simulate completion. It does not count registration emits or depend on task records.
   - The direct subscriber in `src/agents/subagent-registry-state.test.ts` verifies one wake after a best-effort persistence failure. That helper still emits once per call and is unchanged.
   - Repository-wide search found no other `onSubagentRegistryPersisted` subscribers.

3. Error paths

   - If `persistOrThrow` fails, the SQLite transaction rolls back, the new in-memory entry is removed, older kill-reconciliation fields are restored, and the error is rethrown. Task creation, listener setup, sweeper startup, and completion waiting do not run.
   - If it succeeds, the full snapshot is durable. Task creation failure is logged and does not change registry state. The removed best-effort write swallowed its own errors and could not repair a partial first write because the first transaction is atomic.

4. Queued, running, and wait paths

   - Both branches share the same durable write, isolated runtime input, task creation, listener setup, and sweeper startup ordering.
   - The queued branch creates a queued task and does not start completion waiting until later activation, which has its own durable persistence.
   - The running branch creates a running task and starts `waitForSubagentCompletion` only after the sweeper. Its first gateway wait is asynchronous, and later completion or yield mutations persist themselves.

Alternatives considered:

- Moving the one write after task creation would allow task-store side effects before a registry write failure and would weaken the existing rollback boundary.
- Adding dirty tracking or snapshot comparison would add state and work to prove what the current control flow already guarantees.
- Freezing the runtime input would make an in-place mutating third-party runtime throw in strict mode. Copying isolates registry ownership without imposing that behavior change.

## Real behavior proof

The exact-once regression was written before the original implementation. With the second call present:

```text
node scripts/run-vitest.mjs src/agents/subagent-registry.test.ts --testNamePattern 'persists a .* registration exactly once'
4 failed
persistSubagentRunsToDisk was called once in every queued and running case
```

After removing the call:

```text
2 test files passed
4 tests passed, 258 skipped
Duration 3.57s
```

The new isolation regression installs a custom detached task lifecycle runtime through the existing test-support seam. It mutates `params.requesterOrigin` in place during both `createQueuedTaskRun` and `createRunningTaskRun`, then checks the live registry entry and the snapshot captured by the one durable persistence call.

With the runtime copy locally reverted, all four routed queued and running cases failed:

```text
expected requesterOrigin:
{ channel: "discord", to: "channel:123", accountId: "acct-1", threadId: 42 }

received requesterOrigin:
{ channel: "mutated", to: "mutated", accountId: "mutated", threadId: "mutated" }
```

With the copy restored:

```text
2 test files passed
4 tests passed, 262 skipped
Duration 3.45s
```

A throwaway fixture used real SQLite `AFTER INSERT`, `AFTER UPDATE`, and `AFTER DELETE` triggers on `subagent_runs`. For 64 sequential registrations against a growing registry, five measured repetitions per arm, alternating arm order, with one discarded warmup per arm:

```text
two snapshots: 4160 row writes, 315.73 ms median
one snapshot:  2080 row writes, 161.32 ms median
row ratio:    2.000x
time ratio:   1.957x
```

The isolated copy runs once per registration, outside the persisted-row loop. The remeasurement preserves the full 2080-row write reduction. Timing remains in the same range as the earlier 320.24 ms and 158.24 ms medians and is not treated as a precise copy-cost estimate.

Whole-process resource runs of the original harness, including startup and one warmup:

```text
two snapshots: 4.69s wall, 308576 KB maximum RSS
one snapshot:  3.71s wall, 303408 KB maximum RSS
```

The RSS difference is small and is not treated as a memory improvement claim.

## Evidence

- The exact-once regression directly counts both persistence dependency calls and fails if the removed non-throwing call returns.
- The mutation regression uses the existing runtime registration helper and proves plugin input cannot alias the live registry record.
- The measurement counts actual SQLite row changes, not only final database contents.
- The state, wait-tool, lifecycle, and SQLite store focused suites pass.
- Core production type checking, lint, formatting, and diff checks pass.

## Verification

- `node scripts/run-vitest.mjs src/agents/subagent-registry.test.ts --testNamePattern 'isolates a .* registration from task runtime input mutation'`
  - isolation restored: 4 passed
  - isolation reverted: 4 failed with the live registry entry mutated
- `node scripts/run-vitest.mjs src/agents/subagent-registry.test.ts`
  - 133 passed, run three consecutive times with the same result
  - with the isolation reverted: 2 failed, 131 passed, confirming the new cases are not tautological
- `node scripts/run-vitest.mjs src/agents/subagent-registry-state.test.ts src/agents/tools/agents-wait-tool.test.ts src/agents/subagent-registry-lifecycle.test.ts src/agents/subagent-registry.store.sqlite.test.ts`
  - 132 passed
- `node scripts/run-tsgo.mjs -p tsconfig.core.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core.tsbuildinfo`
  - passed
- `node scripts/run-oxlint.mjs src/agents/subagent-registry-run-manager.ts src/agents/subagent-registry.test.ts`
  - passed
- `./node_modules/.bin/oxfmt --check src/agents/subagent-registry-run-manager.ts src/agents/subagent-registry.test.ts`
  - passed
- `git diff --check`
  - passed
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main --stream-engine-output`
  - clean, no accepted or actionable findings

## What was not tested

- No live gateway burst measurement was run for this change.
- An earlier run of the complete `subagent-registry.test.ts` file timed out in a constrained sandbox and was initially attributed to order-dependent test contamination. That attribution was wrong. Re-running the file three times on an unconstrained host gave 133 passed with zero failures each time, so no such contamination is claimed.
- The isolation regression cannot distinguish clone depth. The normalizer drops `deliveryIntent` before the clone site, so the cloned object never contains a nested field for the test to observe. The deep clone is justified by the type contract above rather than by that test.
- No incremental registry-write design was tested. The full-snapshot upserts and load-bearing prune remain unchanged and are intentionally out of scope.


