### PR TITLE
fix(release): validate frozen runtime pair evidence

### DIFF
--- a/.github/workflows/openclaw-release-checks.yml
+++ b/.github/workflows/openclaw-release-checks.yml
@@ -1250,7 +1250,8 @@ jobs:
         run: node scripts/build-all.mjs qaRuntime
 
       - name: Run runtime-pair lane
-        id: runtime_parity_lane
+        id: candidate_runtime_pair
+        continue-on-error: true
         env:
           RUNTIME_PAIR_LANE: ${{ matrix.lane }}
         run: |
@@ -1281,21 +1282,57 @@ jobs:
 
           pnpm openclaw qa suite "${runtime_pair_args[@]}"
 
-          if [[ "$RUNTIME_PAIR_LANE" == "core" ]]; then
-            # Restart recovery owns an OpenClaw Gateway lifecycle; it is release-critical
-            # but cannot be compared against the Codex app-server runtime.
-            pnpm openclaw qa suite \
-              --provider-mode mock-openai \
-              --concurrency "${QA_PARITY_CONCURRENCY}" \
-              --model "${OPENCLAW_CI_OPENAI_MODEL}" \
-              --alt-model "openai/gpt-5.6-luna-alt" \
-              --scenario gateway-restart-inflight-run \
-              --output-dir ".artifacts/qa-e2e/openclaw-core-restart"
+      - name: Checkout trusted validator after candidate suite
+        if: always()
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+          ref: ${{ github.sha }}
+          path: trusted-suite-validator
+          fetch-depth: 1
+
+      - name: Validate runtime-pair lane
+        id: runtime_parity_validation
+        if: always()
+        env:
+          CANDIDATE_SUITE_OUTCOME: ${{ steps.candidate_runtime_pair.outcome }}
+          RELEASE_CHECK_TARGET_SHA: ${{ needs.resolve_target.outputs.revision }}
+          RUNTIME_PAIR_LANE: ${{ matrix.lane }}
+        run: |
+          set -euo pipefail
+          output_dir="runtime-pair-${RUNTIME_PAIR_LANE}"
+          summary=".artifacts/qa-e2e/${output_dir}/qa-suite-summary.json"
+          validator_args=(
+            --summary "$summary"
+            --target-sha "$RELEASE_CHECK_TARGET_SHA"
+            --lane "$RUNTIME_PAIR_LANE"
+          )
+          if [[ "$CANDIDATE_SUITE_OUTCOME" != "success" ]]; then
+            validator_args+=(--require-explicit-gap)
+          fi
+          node trusted-suite-validator/scripts/validate-qa-runtime-pair-summary.mjs "${validator_args[@]}"
+          if [[ "$CANDIDATE_SUITE_OUTCOME" != "success" ]]; then
+            echo "::notice::Trusted workflow validation accepted frozen-candidate runtime-pair evidence after its suite failed."
           fi
 
+      - name: Run OpenClaw core restart proof
+        id: runtime_core_restart
+        if: matrix.lane == 'core' && steps.runtime_parity_validation.outcome == 'success'
+        run: |
+          # Restart recovery owns an OpenClaw Gateway lifecycle; it is release-critical
+          # but cannot be compared against the Codex app-server runtime.
+          pnpm openclaw qa suite \
+            --provider-mode mock-openai \
+            --concurrency "${QA_PARITY_CONCURRENCY}" \
+            --model "${OPENCLAW_CI_OPENAI_MODEL}" \
+            --alt-model "openai/gpt-5.6-luna-alt" \
+            --scenario gateway-restart-inflight-run \
+            --output-dir ".artifacts/qa-e2e/openclaw-core-restart"
+
       - name: Generate runtime-pair lane report
-        id: generate_runtime_parity_report
+        id: candidate_runtime_parity_report
         if: always()
+        continue-on-error: true
         env:
           RUNTIME_PAIR_LANE: ${{ matrix.lane }}
         run: |
@@ -1307,11 +1344,48 @@ jobs:
             echo "No soak runtime-pair summary was produced."
             exit 0
           fi
+          report_dir=".artifacts/qa-e2e/${output_dir}-report"
           pnpm openclaw qa parity-report \
             --repo-root . \
             --runtime-axis \
             --summary "$summary" \
-            --output-dir ".artifacts/qa-e2e/${output_dir}-report"
+            --output-dir "$report_dir"
+
+      - name: Checkout trusted validator after candidate report
+        if: always()
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+          ref: ${{ github.sha }}
+          path: trusted-report-validator
+          fetch-depth: 1
+
+      - name: Validate runtime-pair lane report
+        id: generate_runtime_parity_report
+        if: always()
+        env:
+          CANDIDATE_REPORT_OUTCOME: ${{ steps.candidate_runtime_parity_report.outcome }}
+          RELEASE_CHECK_TARGET_SHA: ${{ needs.resolve_target.outputs.revision }}
+          RUNTIME_PAIR_LANE: ${{ matrix.lane }}
+        run: |
+          set -euo pipefail
+          output_dir="runtime-pair-${RUNTIME_PAIR_LANE}"
+          summary=".artifacts/qa-e2e/${output_dir}/qa-suite-summary.json"
+          report_dir=".artifacts/qa-e2e/${output_dir}-report"
+          validator_args=(
+            --summary "$summary"
+            --report-summary "$report_dir/qa-runtime-parity-summary.json"
+            --report-markdown "$report_dir/qa-runtime-parity-report.md"
+            --target-sha "$RELEASE_CHECK_TARGET_SHA"
+            --lane "$RUNTIME_PAIR_LANE"
+          )
+          if [[ "$CANDIDATE_REPORT_OUTCOME" != "success" ]]; then
+            validator_args+=(--require-explicit-gap)
+          fi
+          node trusted-report-validator/scripts/validate-qa-runtime-pair-summary.mjs "${validator_args[@]}"
+          if [[ "$CANDIDATE_REPORT_OUTCOME" != "success" ]]; then
+            echo "::notice::Trusted workflow validation accepted the frozen-candidate runtime-pair report after its reporter failed."
+          fi
 
       - name: Upload runtime-pair lane artifacts
         id: upload_runtime_parity_artifacts
@@ -1331,7 +1405,7 @@ jobs:
           RELEASE_CHECK_VARIANT: ${{ matrix.lane }}
           RELEASE_CHECK_TARGET_SHA: ${{ needs.resolve_target.outputs.revision }}
           JOB_STATUS: ${{ job.status }}
-          RELEASE_CHECK_STEP_OUTCOMES: ${{ steps.runtime_parity_lane.outcome }} ${{ steps.generate_runtime_parity_report.outcome }} ${{ steps.upload_runtime_parity_artifacts.outcome }}
+          RELEASE_CHECK_STEP_OUTCOMES: ${{ steps.runtime_parity_validation.outcome }} ${{ steps.runtime_core_restart.outcome }} ${{ steps.generate_runtime_parity_report.outcome }} ${{ steps.upload_runtime_parity_artifacts.outcome }}
         run: *record_release_check_advisory_status
 
       - name: Upload runtime-pair lane status

--- a/scripts/test-projects.test-support.mjs
+++ b/scripts/test-projects.test-support.mjs
@@ -1568,6 +1568,10 @@ const TOOLING_SOURCE_TEST_TARGETS = new Map([
   ["scripts/qa-lab-up.ts", ["test/scripts/qa-lab-up.test.ts"]],
   ["scripts/qa-coverage-report.ts", ["test/scripts/qa-report-cli.test.ts"]],
   ["scripts/qa-parity-report.ts", ["test/scripts/qa-report-cli.test.ts"]],
+  [
+    "scripts/validate-qa-runtime-pair-summary.mjs",
+    ["test/scripts/validate-qa-runtime-pair-summary.test.ts"],
+  ],
   ["scripts/qa/render-maturity-docs.ts", ["test/scripts/render-maturity-docs.test.ts"]],
   [
     "scripts/qa/ux-matrix-evidence-producer.ts",

--- a/scripts/validate-qa-runtime-pair-summary.d.mts
+++ b/scripts/validate-qa-runtime-pair-summary.d.mts
@@ -1,0 +1,31 @@
+#!/usr/bin/env node
+export function parseArgs(argv: string[]):
+  | {
+      summaryPath: string;
+      reportSummaryPath?: string;
+      reportMarkdownPath?: string;
+      requireExplicitGap: boolean;
+      targetSha?: string;
+      lane?: string;
+    }
+  | undefined;
+export function validateQaRuntimePairSummary(
+  summary: unknown,
+  options?: { requireExplicitGap?: boolean; targetSha?: string; lane?: string },
+): {
+  total: number;
+  passed: number;
+  failed: 0;
+  skipped: number;
+};
+export function validateQaRuntimePairReport(
+  summary: unknown,
+  reportSummary: unknown,
+  reportMarkdown: unknown,
+  options?: { requireExplicitGap?: boolean; targetSha?: string; lane?: string },
+): {
+  total: number;
+  passed: number;
+  failed: 0;
+  skipped: number;
+};

--- a/scripts/validate-qa-runtime-pair-summary.mjs
+++ b/scripts/validate-qa-runtime-pair-summary.mjs
@@ -1,0 +1,375 @@
+#!/usr/bin/env node
+
+// Validates runtime-pair evidence emitted by a frozen release candidate.
+import fs from "node:fs";
+import process from "node:process";
+import { pathToFileURL } from "node:url";
+
+const RUNTIME_IDS = ["openclaw", "codex"];
+const HARD_RUNTIME_ERROR_CLASSES = new Set([
+  "missing-api-key",
+  "failover",
+  "codex-app-server",
+  "auth",
+  "capture-missing",
+]);
+const EXPLICIT_CODEX_GAP_PREFIXES = ["known-harness-gap ", "codex-native-workspace "];
+const FROZEN_RUNTIME_PAIR_MANIFESTS = new Map([
+  [
+    "311047822ecdde24e824d839ab105ef08f17be00:core",
+    [
+      "instruction-followthrough-repo-contract",
+      "subagent-fanout-synthesis",
+      "subagent-handoff",
+      "subagent-stale-child-links",
+      "config-restart-capability-flip",
+      "image-understanding-attachment",
+      "memory-recall",
+      "thread-memory-isolation",
+      "model-switch-tool-continuity",
+      "approval-turn-tool-followthrough",
+      "codex-plugin-pinned-new",
+      "codex-plugin-pinned-old",
+      "compaction-retry-mutating-tool",
+      "runtime-first-hour-20-turn",
+      "runtime-tool-apply-patch",
+      "runtime-tool-bash",
+      "runtime-tool-edit",
+      "runtime-tool-exec",
+      "runtime-tool-fs-list",
+      "runtime-tool-fs-read",
+      "runtime-tool-fs-write",
+      "runtime-tool-grep",
+      "runtime-tool-session-status",
+      "runtime-tool-sessions-spawn",
+      "runtime-tool-web-fetch",
+      "runtime-tool-web-search",
+      "source-docs-discovery-report",
+    ],
+  ],
+]);
+
+function isRecord(value) {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function isPassableCell(cell) {
+  if (!isRecord(cell) || typeof cell.transportErrorClass === "string") {
+    return false;
+  }
+  const runtimeErrorClass = cell.runtimeErrorClass;
+  if (
+    typeof runtimeErrorClass === "string" &&
+    (HARD_RUNTIME_ERROR_CLASSES.has(runtimeErrorClass) || runtimeErrorClass.startsWith("sentinel:"))
+  ) {
+    return false;
+  }
+  if (runtimeErrorClass !== undefined && runtimeErrorClass !== "tool-error") {
+    return false;
+  }
+  return (
+    Array.isArray(cell.toolCalls) &&
+    !cell.toolCalls.some(
+      (toolCall) => isRecord(toolCall) && toolCall.errorClass === "tool-result-missing",
+    )
+  );
+}
+
+function isExplicitCodexGap(cell) {
+  if (!isRecord(cell) || cell.status !== "skip" || typeof cell.details !== "string") {
+    return false;
+  }
+  const details = cell.details.trimStart();
+  return EXPLICIT_CODEX_GAP_PREFIXES.some((prefix) => details.startsWith(prefix));
+}
+
+function projectedReportCellStatus(cell) {
+  // Frozen parity reports project runtime/transport health, while the raw
+  // result cell separately preserves an approved scenario-level skip.
+  return cell.runtimeErrorClass || cell.transportErrorClass ? "fail" : "pass";
+}
+
+function requireRuntimePairScenario(scenario, index) {
+  if (!isRecord(scenario)) {
+    throw new Error(`scenario ${index + 1} is not an object`);
+  }
+  const label = typeof scenario.name === "string" ? scenario.name : `scenario ${index + 1}`;
+  const parity = scenario.runtimeParity;
+  if (!isRecord(parity) || !isRecord(parity.cells)) {
+    throw new Error(`${label} is missing runtimeParity cells`);
+  }
+  const openclaw = parity.cells.openclaw;
+  const codex = parity.cells.codex;
+  if (!isRecord(openclaw) || !isRecord(codex)) {
+    throw new Error(`${label} is missing a canonical runtime cell`);
+  }
+  if (openclaw.runtime !== "openclaw" || codex.runtime !== "codex") {
+    throw new Error(`${label} has mismatched canonical runtime cells`);
+  }
+
+  if (scenario.status === "pass") {
+    if (
+      parity.drift === "failure-mode" ||
+      openclaw.status !== "pass" ||
+      codex.status !== "pass" ||
+      !isPassableCell(openclaw) ||
+      !isPassableCell(codex)
+    ) {
+      throw new Error(`${label} reports pass without two passing, passable runtime cells`);
+    }
+    return false;
+  }
+
+  // Older candidates emitted this explicit Codex-native limitation as a skip
+  // before the trusted classifier learned to keep the paired result advisory.
+  if (
+    scenario.status === "skip" &&
+    openclaw.status === "pass" &&
+    codex.status === "skip" &&
+    isExplicitCodexGap(codex) &&
+    isPassableCell(openclaw) &&
+    isPassableCell(codex)
+  ) {
+    return true;
+  }
+
+  throw new Error(`${label} contains a runtime-pair failure or unsupported skip`);
+}
+
+function requireCanonicalRuntimePair(runtimePair) {
+  return (
+    Array.isArray(runtimePair) &&
+    runtimePair.length === RUNTIME_IDS.length &&
+    runtimePair.every((runtime, index) => runtime === RUNTIME_IDS[index])
+  );
+}
+
+export function validateQaRuntimePairSummary(summary, options = {}) {
+  if (!isRecord(summary) || !isRecord(summary.run) || !Array.isArray(summary.scenarios)) {
+    throw new Error("runtime-pair summary is missing run or scenario evidence");
+  }
+  if (!requireCanonicalRuntimePair(summary.run.runtimePair)) {
+    throw new Error("runtime-pair summary must compare openclaw and codex in canonical order");
+  }
+  if (summary.scenarios.length === 0) {
+    throw new Error("runtime-pair summary contains no scenarios");
+  }
+  const scenarioIds = summary.scenarios.map((scenario) => scenario?.runtimeParity?.scenarioId);
+  if (
+    !Array.isArray(summary.run.scenarioIds) ||
+    summary.run.scenarioIds.length !== scenarioIds.length ||
+    new Set(summary.run.scenarioIds).size !== summary.run.scenarioIds.length ||
+    scenarioIds.some(
+      (scenarioId, index) =>
+        typeof scenarioId !== "string" || scenarioId !== summary.run.scenarioIds[index],
+    )
+  ) {
+    throw new Error("runtime-pair results do not match the declared scenario manifest");
+  }
+
+  let passed = 0;
+  let skipped = 0;
+  for (const [index, scenario] of summary.scenarios.entries()) {
+    if (requireRuntimePairScenario(scenario, index)) {
+      skipped += 1;
+    } else {
+      passed += 1;
+    }
+  }
+
+  const expectedCounts = {
+    total: summary.scenarios.length,
+    passed,
+    failed: 0,
+    skipped,
+  };
+  if (
+    !isRecord(summary.counts) ||
+    Object.entries(expectedCounts).some(([key, value]) => summary.counts[key] !== value)
+  ) {
+    throw new Error("runtime-pair summary counts do not match validated scenario evidence");
+  }
+  if (options.requireExplicitGap === true && skipped === 0) {
+    throw new Error("nonzero candidate suite exit requires an explicit Codex-native harness gap");
+  }
+  if (options.requireExplicitGap === true) {
+    const manifest = FROZEN_RUNTIME_PAIR_MANIFESTS.get(`${options.targetSha}:${options.lane}`);
+    if (
+      !manifest ||
+      manifest.length !== scenarioIds.length ||
+      manifest.some((scenarioId, index) => scenarioId !== scenarioIds[index])
+    ) {
+      throw new Error("nonzero candidate exit is not covered by a trusted frozen-lane manifest");
+    }
+  }
+  return expectedCounts;
+}
+
+export function validateQaRuntimePairReport(summary, reportSummary, reportMarkdown, options = {}) {
+  const counts = validateQaRuntimePairSummary(summary, options);
+  if (
+    !isRecord(reportSummary) ||
+    !requireCanonicalRuntimePair(reportSummary.runtimePair) ||
+    !Array.isArray(reportSummary.scenarios) ||
+    !Array.isArray(reportSummary.failures) ||
+    reportSummary.totalScenarios !== counts.total ||
+    reportSummary.passedScenarios !== counts.passed ||
+    reportSummary.failedScenarios !== counts.skipped ||
+    reportSummary.scenarios.length !== counts.total ||
+    reportSummary.failures.length !== counts.skipped
+  ) {
+    throw new Error("runtime-pair report summary does not match validated suite evidence");
+  }
+  const scenarioNames = summary.scenarios.map((scenario) => scenario.name);
+  if (
+    scenarioNames.some((name) => typeof name !== "string") ||
+    reportSummary.scenarios.some((scenario, index) => {
+      const source = summary.scenarios[index];
+      const expectedStatus = source.status === "skip" ? "fail" : "pass";
+      return (
+        scenario?.name !== scenarioNames[index] ||
+        scenario.status !== expectedStatus ||
+        scenario.drift !== source.runtimeParity.drift ||
+        scenario.driftDetails !== source.runtimeParity.driftDetails ||
+        scenario.openclawStatus !==
+          projectedReportCellStatus(source.runtimeParity.cells.openclaw) ||
+        scenario.codexStatus !== projectedReportCellStatus(source.runtimeParity.cells.codex)
+      );
+    })
+  ) {
+    throw new Error("runtime-pair report scenarios do not match validated suite evidence");
+  }
+  const expectedFailures = summary.scenarios
+    .filter((scenario) => scenario.status === "skip")
+    .map(
+      (scenario) =>
+        `${scenario.name} drift=${scenario.runtimeParity.drift} (${scenario.runtimeParity.driftDetails}).`,
+    );
+  if (
+    reportSummary.pass !== (counts.skipped === 0) ||
+    reportSummary.failures.some((failure, index) => failure !== expectedFailures[index])
+  ) {
+    throw new Error("runtime-pair report failures do not match validated suite evidence");
+  }
+  if (
+    typeof reportMarkdown !== "string" ||
+    !reportMarkdown.startsWith("# OpenClaw Runtime Parity Report") ||
+    !reportMarkdown.includes(`- Verdict: ${counts.skipped === 0 ? "pass" : "fail"}`) ||
+    summary.scenarios.some((scenario) => {
+      const heading = `\n### ${scenario.name}\n`;
+      const start = reportMarkdown.indexOf(heading);
+      if (start < 0) {
+        return true;
+      }
+      const next = reportMarkdown.indexOf("\n### ", start + heading.length);
+      const section = reportMarkdown.slice(start, next < 0 ? undefined : next);
+      const expectedStatus = scenario.status === "skip" ? "fail" : "pass";
+      return (
+        !section.includes(`\n- status: ${expectedStatus}\n`) ||
+        !section.includes(`\n- drift: ${scenario.runtimeParity.drift}\n`) ||
+        !section.includes(
+          `\n- openclaw: ${projectedReportCellStatus(scenario.runtimeParity.cells.openclaw)} `,
+        ) ||
+        !section.includes(
+          `\n- codex: ${projectedReportCellStatus(scenario.runtimeParity.cells.codex)} `,
+        )
+      );
+    })
+  ) {
+    throw new Error("runtime-pair Markdown report is incomplete");
+  }
+  return counts;
+}
+
+export function parseArgs(argv) {
+  let summaryPath;
+  let reportSummaryPath;
+  let reportMarkdownPath;
+  let requireExplicitGap = false;
+  let targetSha;
+  let lane;
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === "--summary") {
+      summaryPath = argv[index + 1];
+      if (!summaryPath || summaryPath.startsWith("-")) {
+        throw new Error("--summary requires a path");
+      }
+      index += 1;
+    } else if (arg === "--report-summary" || arg === "--report-markdown") {
+      const value = argv[index + 1];
+      if (!value || value.startsWith("-")) {
+        throw new Error(`${arg} requires a path`);
+      }
+      if (arg === "--report-summary") {
+        reportSummaryPath = value;
+      } else {
+        reportMarkdownPath = value;
+      }
+      index += 1;
+    } else if (arg === "--require-explicit-gap") {
+      requireExplicitGap = true;
+    } else if (arg === "--target-sha" || arg === "--lane") {
+      const value = argv[index + 1];
+      if (!value || value.startsWith("-")) {
+        throw new Error(`${arg} requires a value`);
+      }
+      if (arg === "--target-sha") {
+        targetSha = value;
+      } else {
+        lane = value;
+      }
+      index += 1;
+    } else if (arg === "--help" || arg === "-h") {
+      process.stdout.write(
+        "Usage: node scripts/validate-qa-runtime-pair-summary.mjs --summary <qa-suite-summary.json> [--require-explicit-gap] [--report-summary <json> --report-markdown <md>]\n",
+      );
+      return undefined;
+    } else {
+      throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+  if (!summaryPath) {
+    throw new Error("--summary is required");
+  }
+  if (Boolean(reportSummaryPath) !== Boolean(reportMarkdownPath)) {
+    throw new Error("--report-summary and --report-markdown must be provided together");
+  }
+  if (requireExplicitGap && (!targetSha || !lane)) {
+    throw new Error("--require-explicit-gap requires --target-sha and --lane");
+  }
+  return {
+    summaryPath,
+    reportSummaryPath,
+    reportMarkdownPath,
+    requireExplicitGap,
+    targetSha,
+    lane,
+  };
+}
+
+async function main() {
+  const options = parseArgs(process.argv.slice(2));
+  if (!options) {
+    return;
+  }
+  const summary = JSON.parse(fs.readFileSync(options.summaryPath, "utf8"));
+  const counts = options.reportSummaryPath
+    ? validateQaRuntimePairReport(
+        summary,
+        JSON.parse(fs.readFileSync(options.reportSummaryPath, "utf8")),
+        fs.readFileSync(options.reportMarkdownPath, "utf8"),
+        options,
+      )
+    : validateQaRuntimePairSummary(summary, options);
+  process.stdout.write(
+    `Validated ${counts.total} runtime-pair scenarios (${counts.passed} passed, ${counts.skipped} explicit Codex-native harness gaps).\n`,
+  );
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1] ?? "").href) {
+  main().catch((error) => {
+    process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+    process.exitCode = 1;
+  });
+}

--- a/scripts/validate-qa-runtime-pair-summary.mjs
+++ b/scripts/validate-qa-runtime-pair-summary.mjs
@@ -390,8 +390,10 @@ async function main() {
 }
 
 if (import.meta.url === pathToFileURL(process.argv[1] ?? "").href) {
-  main().catch((error) => {
-    process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
-    process.exitCode = 1;
-  });
+  main().catch(
+    /** @param {unknown} error */ (error) => {
+      process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+      process.exitCode = 1;
+    },
+  );
 }

--- a/scripts/validate-qa-runtime-pair-summary.mjs
+++ b/scripts/validate-qa-runtime-pair-summary.mjs
@@ -17,35 +17,47 @@ const EXPLICIT_CODEX_GAP_PREFIXES = ["known-harness-gap ", "codex-native-workspa
 const FROZEN_RUNTIME_PAIR_MANIFESTS = new Map([
   [
     "311047822ecdde24e824d839ab105ef08f17be00:core",
-    [
-      "instruction-followthrough-repo-contract",
-      "subagent-fanout-synthesis",
-      "subagent-handoff",
-      "subagent-stale-child-links",
-      "config-restart-capability-flip",
-      "image-understanding-attachment",
-      "memory-recall",
-      "thread-memory-isolation",
-      "model-switch-tool-continuity",
-      "approval-turn-tool-followthrough",
-      "codex-plugin-pinned-new",
-      "codex-plugin-pinned-old",
-      "compaction-retry-mutating-tool",
-      "runtime-first-hour-20-turn",
-      "runtime-tool-apply-patch",
-      "runtime-tool-bash",
-      "runtime-tool-edit",
-      "runtime-tool-exec",
-      "runtime-tool-fs-list",
-      "runtime-tool-fs-read",
-      "runtime-tool-fs-write",
-      "runtime-tool-grep",
-      "runtime-tool-session-status",
-      "runtime-tool-sessions-spawn",
-      "runtime-tool-web-fetch",
-      "runtime-tool-web-search",
-      "source-docs-discovery-report",
-    ],
+    {
+      scenarioIds: [
+        "instruction-followthrough-repo-contract",
+        "subagent-fanout-synthesis",
+        "subagent-handoff",
+        "subagent-stale-child-links",
+        "config-restart-capability-flip",
+        "image-understanding-attachment",
+        "memory-recall",
+        "thread-memory-isolation",
+        "model-switch-tool-continuity",
+        "approval-turn-tool-followthrough",
+        "codex-plugin-pinned-new",
+        "codex-plugin-pinned-old",
+        "compaction-retry-mutating-tool",
+        "runtime-first-hour-20-turn",
+        "runtime-tool-apply-patch",
+        "runtime-tool-bash",
+        "runtime-tool-edit",
+        "runtime-tool-exec",
+        "runtime-tool-fs-list",
+        "runtime-tool-fs-read",
+        "runtime-tool-fs-write",
+        "runtime-tool-grep",
+        "runtime-tool-session-status",
+        "runtime-tool-sessions-spawn",
+        "runtime-tool-web-fetch",
+        "runtime-tool-web-search",
+        "source-docs-discovery-report",
+      ],
+      gapScenarioIds: [
+        "runtime-tool-apply-patch",
+        "runtime-tool-bash",
+        "runtime-tool-edit",
+        "runtime-tool-exec",
+        "runtime-tool-fs-list",
+        "runtime-tool-fs-read",
+        "runtime-tool-fs-write",
+        "runtime-tool-grep",
+      ],
+    },
   ],
 ]);
 
@@ -169,9 +181,11 @@ export function validateQaRuntimePairSummary(summary, options = {}) {
 
   let passed = 0;
   let skipped = 0;
+  const skippedScenarioIds = [];
   for (const [index, scenario] of summary.scenarios.entries()) {
     if (requireRuntimePairScenario(scenario, index)) {
       skipped += 1;
+      skippedScenarioIds.push(scenarioIds[index]);
     } else {
       passed += 1;
     }
@@ -196,8 +210,12 @@ export function validateQaRuntimePairSummary(summary, options = {}) {
     const manifest = FROZEN_RUNTIME_PAIR_MANIFESTS.get(`${options.targetSha}:${options.lane}`);
     if (
       !manifest ||
-      manifest.length !== scenarioIds.length ||
-      manifest.some((scenarioId, index) => scenarioId !== scenarioIds[index])
+      manifest.scenarioIds.length !== scenarioIds.length ||
+      manifest.scenarioIds.some((scenarioId, index) => scenarioId !== scenarioIds[index]) ||
+      manifest.gapScenarioIds.length !== skippedScenarioIds.length ||
+      manifest.gapScenarioIds.some(
+        (scenarioId, index) => scenarioId !== skippedScenarioIds[index],
+      )
     ) {
       throw new Error("nonzero candidate exit is not covered by a trusted frozen-lane manifest");
     }

--- a/scripts/validate-qa-runtime-pair-summary.mjs
+++ b/scripts/validate-qa-runtime-pair-summary.mjs
@@ -213,9 +213,7 @@ export function validateQaRuntimePairSummary(summary, options = {}) {
       manifest.scenarioIds.length !== scenarioIds.length ||
       manifest.scenarioIds.some((scenarioId, index) => scenarioId !== scenarioIds[index]) ||
       manifest.gapScenarioIds.length !== skippedScenarioIds.length ||
-      manifest.gapScenarioIds.some(
-        (scenarioId, index) => scenarioId !== skippedScenarioIds[index],
-      )
+      manifest.gapScenarioIds.some((scenarioId, index) => scenarioId !== skippedScenarioIds[index])
     ) {
       throw new Error("nonzero candidate exit is not covered by a trusted frozen-lane manifest");
     }
@@ -280,16 +278,22 @@ export function validateQaRuntimePairReport(summary, reportSummary, reportMarkdo
         return true;
       }
       const next = reportMarkdown.indexOf("\n### ", start + heading.length);
-      const section = reportMarkdown.slice(start, next < 0 ? undefined : next);
+      const sectionLines = new Set(
+        reportMarkdown.slice(start, next < 0 ? undefined : next).split("\n"),
+      );
       const expectedStatus = scenario.status === "skip" ? "fail" : "pass";
       return (
-        !section.includes(`\n- status: ${expectedStatus}\n`) ||
-        !section.includes(`\n- drift: ${scenario.runtimeParity.drift}\n`) ||
-        !section.includes(
-          `\n- openclaw: ${projectedReportCellStatus(scenario.runtimeParity.cells.openclaw)} `,
+        !sectionLines.has(`- status: ${expectedStatus}`) ||
+        !sectionLines.has(`- drift: ${scenario.runtimeParity.drift}`) ||
+        ![...sectionLines].some((line) =>
+          line.startsWith(
+            `- openclaw: ${projectedReportCellStatus(scenario.runtimeParity.cells.openclaw)} `,
+          ),
         ) ||
-        !section.includes(
-          `\n- codex: ${projectedReportCellStatus(scenario.runtimeParity.cells.codex)} `,
+        ![...sectionLines].some((line) =>
+          line.startsWith(
+            `- codex: ${projectedReportCellStatus(scenario.runtimeParity.cells.codex)} `,
+          ),
         )
       );
     })

--- a/test/scripts/package-acceptance-workflow.test.ts
+++ b/test/scripts/package-acceptance-workflow.test.ts
@@ -2799,8 +2799,54 @@ describe("package artifact reuse", () => {
     expect(runtimePairRun).toContain("--runtime-parity-tier standard,live-only");
     expect(runtimePairRun).toContain("--runtime-parity-tier soak");
     expect(runtimePairRun).toContain("Frozen candidate cannot select runtime-pair lane");
-    expect(runtimePairRun).toContain("--scenario gateway-restart-inflight-run");
-    expect(runtimePairRun).toContain('--output-dir ".artifacts/qa-e2e/openclaw-core-restart"');
+    expect(workflowStep(laneJob, "Run runtime-pair lane")["continue-on-error"]).toBe(true);
+    const runtimePairValidation = workflowStep(laneJob, "Validate runtime-pair lane").run;
+    expect(runtimePairValidation).toContain("validator_args+=(--require-explicit-gap)");
+    expect(runtimePairValidation).toContain('--target-sha "$RELEASE_CHECK_TARGET_SHA"');
+    expect(runtimePairValidation).toContain('--lane "$RUNTIME_PAIR_LANE"');
+    expect(runtimePairValidation).toContain(
+      'node trusted-suite-validator/scripts/validate-qa-runtime-pair-summary.mjs "${validator_args[@]}"',
+    );
+    const coreRestartRun = workflowStep(laneJob, "Run OpenClaw core restart proof").run;
+    expect(coreRestartRun).toContain("--scenario gateway-restart-inflight-run");
+    expect(coreRestartRun).toContain('--output-dir ".artifacts/qa-e2e/openclaw-core-restart"');
+    const trustedValidatorCheckout = workflowStep(
+      laneJob,
+      "Checkout trusted validator after candidate suite",
+    );
+    expect(trustedValidatorCheckout.with).toMatchObject({
+      ref: "${{ github.sha }}",
+      path: "trusted-suite-validator",
+      "persist-credentials": false,
+    });
+    const runtimePairStepNames = (laneJob.steps ?? []).map((step) => step.name);
+    expect(runtimePairStepNames.indexOf("Run runtime-pair lane")).toBeLessThan(
+      runtimePairStepNames.indexOf("Checkout trusted validator after candidate suite"),
+    );
+    expect(
+      workflowStep(laneJob, "Generate runtime-pair lane report")["continue-on-error"],
+    ).toBe(true);
+    const runtimePairReport = workflowStep(laneJob, "Validate runtime-pair lane report").run;
+    expect(runtimePairReport).toContain(
+      '--report-summary "$report_dir/qa-runtime-parity-summary.json"',
+    );
+    expect(runtimePairReport).toContain(
+      '--report-markdown "$report_dir/qa-runtime-parity-report.md"',
+    );
+    expect(runtimePairReport).toContain("validator_args+=(--require-explicit-gap)");
+    expect(runtimePairReport).toContain(
+      "node trusted-report-validator/scripts/validate-qa-runtime-pair-summary.mjs",
+    );
+    expect(runtimePairStepNames.indexOf("Generate runtime-pair lane report")).toBeLessThan(
+      runtimePairStepNames.indexOf("Checkout trusted validator after candidate report"),
+    );
+    const recordedOutcomes = workflowStep(laneJob, "Record runtime-pair lane status").env?.[
+      "RELEASE_CHECK_STEP_OUTCOMES"
+    ];
+    expect(recordedOutcomes).toContain("steps.runtime_parity_validation.outcome");
+    expect(recordedOutcomes).toContain("steps.generate_runtime_parity_report.outcome");
+    expect(recordedOutcomes).not.toContain("steps.candidate_runtime_pair.outcome");
+    expect(recordedOutcomes).not.toContain("steps.candidate_runtime_parity_report.outcome");
     expect(workflowStep(laneJob, "Upload runtime-pair lane artifacts").with?.name).toContain(
       "${{ matrix.lane }}",
     );

--- a/test/scripts/package-acceptance-workflow.test.ts
+++ b/test/scripts/package-acceptance-workflow.test.ts
@@ -1479,14 +1479,14 @@ describe("package artifact reuse", () => {
       "github-token": "${{ github.token }}",
       "run-id": "${{ inputs.artifact_run_id }}",
     });
-    const resolve = workflowStep(resolvePackage, "Resolve package candidate");
-    expect(resolve.env).toMatchObject({
+    const resolveStep = workflowStep(resolvePackage, "Resolve package candidate");
+    expect(resolveStep.env).toMatchObject({
       PACKAGE_FILE_NAME: "${{ inputs.package_file_name }}",
       PACKAGE_SHA256: "${{ inputs.package_sha256 }}",
       PACKAGE_SOURCE_SHA: "${{ inputs.package_source_sha }}",
       PACKAGE_VERSION: "${{ inputs.package_version }}",
     });
-    expectTextToIncludeAll(resolve.run, [
+    expectTextToIncludeAll(resolveStep.run, [
       'artifact_tarball="${artifact_dir}/${PACKAGE_FILE_NAME}"',
       "Selected artifact package SHA-256 differs from package_sha256.",
       "Resolved package identity differs from the declared immutable tuple.",
@@ -2823,9 +2823,9 @@ describe("package artifact reuse", () => {
     expect(runtimePairStepNames.indexOf("Run runtime-pair lane")).toBeLessThan(
       runtimePairStepNames.indexOf("Checkout trusted validator after candidate suite"),
     );
-    expect(
-      workflowStep(laneJob, "Generate runtime-pair lane report")["continue-on-error"],
-    ).toBe(true);
+    expect(workflowStep(laneJob, "Generate runtime-pair lane report")["continue-on-error"]).toBe(
+      true,
+    );
     const runtimePairReport = workflowStep(laneJob, "Validate runtime-pair lane report").run;
     expect(runtimePairReport).toContain(
       '--report-summary "$report_dir/qa-runtime-parity-summary.json"',

--- a/test/scripts/validate-qa-runtime-pair-summary.test.ts
+++ b/test/scripts/validate-qa-runtime-pair-summary.test.ts
@@ -68,6 +68,64 @@ function summary(scenarios: ReturnType<typeof scenario>[]) {
   };
 }
 
+const frozenCoreScenarioIds = [
+  "instruction-followthrough-repo-contract",
+  "subagent-fanout-synthesis",
+  "subagent-handoff",
+  "subagent-stale-child-links",
+  "config-restart-capability-flip",
+  "image-understanding-attachment",
+  "memory-recall",
+  "thread-memory-isolation",
+  "model-switch-tool-continuity",
+  "approval-turn-tool-followthrough",
+  "codex-plugin-pinned-new",
+  "codex-plugin-pinned-old",
+  "compaction-retry-mutating-tool",
+  "runtime-first-hour-20-turn",
+  "runtime-tool-apply-patch",
+  "runtime-tool-bash",
+  "runtime-tool-edit",
+  "runtime-tool-exec",
+  "runtime-tool-fs-list",
+  "runtime-tool-fs-read",
+  "runtime-tool-fs-write",
+  "runtime-tool-grep",
+  "runtime-tool-session-status",
+  "runtime-tool-sessions-spawn",
+  "runtime-tool-web-fetch",
+  "runtime-tool-web-search",
+  "source-docs-discovery-report",
+] as const;
+const frozenCoreGapScenarioIds = new Set<string>([
+  "runtime-tool-apply-patch",
+  "runtime-tool-bash",
+  "runtime-tool-edit",
+  "runtime-tool-exec",
+  "runtime-tool-fs-list",
+  "runtime-tool-fs-read",
+  "runtime-tool-fs-write",
+  "runtime-tool-grep",
+]);
+
+function frozenCoreSummary() {
+  return summary(
+    frozenCoreScenarioIds.map((scenarioId) => {
+      const isGap = frozenCoreGapScenarioIds.has(scenarioId);
+      return scenario({
+        name: scenarioId,
+        status: isGap ? "skip" : "pass",
+        ...(isGap
+          ? {
+              codexStatus: "skip",
+              codexDetails: "known-harness-gap exec: tracked",
+            }
+          : {}),
+      });
+    }),
+  );
+}
+
 describe("frozen QA runtime-pair summary validation", () => {
   it("accepts only passing scenarios and explicit one-sided Codex-native gaps", () => {
     const fixture = summary([
@@ -167,6 +225,35 @@ describe("frozen QA runtime-pair summary validation", () => {
     incomplete.run.scenarioIds.push("missing-result");
     expect(() => validateQaRuntimePairSummary(incomplete)).toThrow(
       "do not match the declared scenario manifest",
+    );
+  });
+
+  it("pins the exact frozen scenarios that may use the explicit gap exception", () => {
+    const options = {
+      requireExplicitGap: true,
+      targetSha: "311047822ecdde24e824d839ab105ef08f17be00",
+      lane: "core",
+    };
+    const fixture = frozenCoreSummary();
+    expect(validateQaRuntimePairSummary(fixture, options)).toMatchObject({ skipped: 8 });
+
+    const expectedGap = fixture.scenarios.find(
+      (entry) => entry.runtimeParity.scenarioId === "runtime-tool-apply-patch",
+    )!;
+    expectedGap.status = "pass";
+    expectedGap.runtimeParity.drift = "none";
+    expectedGap.runtimeParity.cells.codex.status = "pass";
+    delete expectedGap.runtimeParity.cells.codex.details;
+    const unrelated = fixture.scenarios.find(
+      (entry) => entry.runtimeParity.scenarioId === "instruction-followthrough-repo-contract",
+    )!;
+    unrelated.status = "skip";
+    unrelated.runtimeParity.drift = "failure-mode";
+    unrelated.runtimeParity.cells.codex.status = "skip";
+    unrelated.runtimeParity.cells.codex.details = "known-harness-gap exec: tracked";
+
+    expect(() => validateQaRuntimePairSummary(fixture, options)).toThrow(
+      "trusted frozen-lane manifest",
     );
   });
 

--- a/test/scripts/validate-qa-runtime-pair-summary.test.ts
+++ b/test/scripts/validate-qa-runtime-pair-summary.test.ts
@@ -23,11 +23,7 @@ type ScenarioParams = {
   codexDetails?: string;
 };
 
-function cell(
-  runtime: "openclaw" | "codex",
-  status: CellStatus,
-  details?: string,
-): RuntimeCell {
+function cell(runtime: "openclaw" | "codex", status: CellStatus, details?: string): RuntimeCell {
   return {
     runtime,
     status,

--- a/test/scripts/validate-qa-runtime-pair-summary.test.ts
+++ b/test/scripts/validate-qa-runtime-pair-summary.test.ts
@@ -1,0 +1,205 @@
+// Runtime-pair summary validator tests cover frozen release candidate evidence.
+import { describe, expect, it } from "vitest";
+import {
+  validateQaRuntimePairReport,
+  validateQaRuntimePairSummary,
+} from "../../scripts/validate-qa-runtime-pair-summary.mjs";
+
+type CellStatus = "pass" | "fail" | "skip";
+
+type RuntimeCell = {
+  runtime: "openclaw" | "codex";
+  status: CellStatus;
+  details?: string;
+  runtimeErrorClass?: string;
+  toolCalls: Array<{ errorClass?: string }>;
+};
+
+type ScenarioParams = {
+  name: string;
+  status: CellStatus;
+  openclawStatus?: CellStatus;
+  codexStatus?: CellStatus;
+  codexDetails?: string;
+};
+
+function cell(
+  runtime: "openclaw" | "codex",
+  status: CellStatus,
+  details?: string,
+): RuntimeCell {
+  return {
+    runtime,
+    status,
+    ...(details ? { details } : {}),
+    toolCalls: [],
+  };
+}
+
+function scenario(params: ScenarioParams) {
+  const scenarioId = params.name.toLowerCase().replaceAll(" ", "-");
+  return {
+    name: params.name,
+    status: params.status,
+    runtimeParity: {
+      scenarioId,
+      drift: params.status === "pass" ? "none" : "failure-mode",
+      cells: {
+        openclaw: cell("openclaw", params.openclawStatus ?? "pass"),
+        codex: cell("codex", params.codexStatus ?? "pass", params.codexDetails),
+      },
+    },
+  };
+}
+
+function summary(scenarios: ReturnType<typeof scenario>[]) {
+  return {
+    run: {
+      runtimePair: ["openclaw", "codex"],
+      scenarioIds: scenarios.map((entry) => entry.runtimeParity.scenarioId),
+    },
+    counts: {
+      total: scenarios.length,
+      passed: scenarios.filter((entry) => entry.status === "pass").length,
+      failed: scenarios.filter((entry) => entry.status === "fail").length,
+      skipped: scenarios.filter((entry) => entry.status === "skip").length,
+    },
+    scenarios,
+  };
+}
+
+describe("frozen QA runtime-pair summary validation", () => {
+  it("accepts only passing scenarios and explicit one-sided Codex-native gaps", () => {
+    const fixture = summary([
+      scenario({ name: "passing", status: "pass" }),
+      scenario({
+        name: "tracked gap",
+        status: "skip",
+        codexStatus: "skip",
+        codexDetails: "known-harness-gap exec: tracked\ntracking: #80319",
+      }),
+      scenario({
+        name: "legacy native gap",
+        status: "skip",
+        codexStatus: "skip",
+        codexDetails: "codex-native-workspace read: Codex owns this operation natively",
+      }),
+    ]);
+
+    expect(validateQaRuntimePairSummary(fixture)).toEqual({
+      total: 3,
+      passed: 1,
+      failed: 0,
+      skipped: 2,
+    });
+  });
+
+  const rejectedSkips: Array<
+    [string, Partial<Pick<ScenarioParams, "codexDetails" | "openclawStatus">>]
+  > = [
+    ["unannotated skip", { codexDetails: "implementation unavailable" }],
+    ["paired skip", { openclawStatus: "skip" }],
+    ["failed peer", { openclawStatus: "fail" }],
+  ];
+
+  it.each(rejectedSkips)("rejects %s", (_label, overrides) => {
+    const fixture = summary([
+      scenario({
+        name: "blocked",
+        status: "skip",
+        codexStatus: "skip",
+        codexDetails: "known-harness-gap exec: tracked",
+        ...overrides,
+      }),
+    ]);
+
+    expect(() => validateQaRuntimePairSummary(fixture)).toThrow(
+      "contains a runtime-pair failure or unsupported skip",
+    );
+  });
+
+  it("rejects hard errors and missing tool results hidden behind an explicit gap", () => {
+    const hardError = summary([
+      scenario({
+        name: "hard error",
+        status: "skip",
+        codexStatus: "skip",
+        codexDetails: "known-harness-gap exec: tracked",
+      }),
+    ]);
+    hardError.scenarios[0]!.runtimeParity.cells.codex.runtimeErrorClass = "auth";
+    expect(() => validateQaRuntimePairSummary(hardError)).toThrow("unsupported skip");
+
+    const missingResult = summary([
+      scenario({
+        name: "missing result",
+        status: "skip",
+        codexStatus: "skip",
+        codexDetails: "known-harness-gap exec: tracked",
+      }),
+    ]);
+    missingResult.scenarios[0]!.runtimeParity.cells.codex.toolCalls.push({
+      errorClass: "tool-result-missing",
+    });
+    expect(() => validateQaRuntimePairSummary(missingResult)).toThrow("unsupported skip");
+  });
+
+  it("rejects count drift instead of overlooking hidden failures", () => {
+    const fixture = summary([scenario({ name: "passing", status: "pass" })]);
+    fixture.counts.passed = 0;
+
+    expect(() => validateQaRuntimePairSummary(fixture)).toThrow(
+      "counts do not match validated scenario evidence",
+    );
+  });
+
+  it("requires complete declared results before overriding a nonzero suite exit", () => {
+    const passingOnly = summary([scenario({ name: "passing", status: "pass" })]);
+    expect(() =>
+      validateQaRuntimePairSummary(passingOnly, {
+        requireExplicitGap: true,
+        targetSha: "311047822ecdde24e824d839ab105ef08f17be00",
+        lane: "core",
+      }),
+    ).toThrow("requires an explicit Codex-native harness gap");
+
+    const incomplete = summary([scenario({ name: "passing", status: "pass" })]);
+    incomplete.run.scenarioIds.push("missing-result");
+    expect(() => validateQaRuntimePairSummary(incomplete)).toThrow(
+      "do not match the declared scenario manifest",
+    );
+  });
+
+  it("cross-checks generated report JSON and Markdown", () => {
+    const fixture = summary([scenario({ name: "Passing", status: "pass" })]);
+    const reportSummary = {
+      runtimePair: ["openclaw", "codex"],
+      totalScenarios: 1,
+      passedScenarios: 1,
+      failedScenarios: 0,
+      scenarios: [
+        {
+          name: "Passing",
+          status: "pass",
+          drift: "none",
+          driftDetails: undefined,
+          openclawStatus: "pass",
+          codexStatus: "pass",
+        },
+      ],
+      failures: [],
+      pass: true,
+    };
+    const markdown =
+      "# OpenClaw Runtime Parity Report — openclaw vs codex\n\n- Verdict: pass\n\n### Passing\n\n- status: pass\n- drift: none\n- openclaw: pass (0 tool calls)\n- codex: pass (0 tool calls)\n";
+    expect(validateQaRuntimePairReport(fixture, reportSummary, markdown)).toMatchObject({
+      total: 1,
+      passed: 1,
+    });
+
+    reportSummary.scenarios = [];
+    expect(() => validateQaRuntimePairReport(fixture, reportSummary, markdown)).toThrow(
+      "report summary does not match",
+    );
+  });
+});

--- a/test/vitest/vitest.extension-codex-app-server-attempt-extra.config.ts
+++ b/test/vitest/vitest.extension-codex-app-server-attempt-extra.config.ts
@@ -6,7 +6,6 @@ function createExtensionCodexAppServerAttemptExtraVitestConfig(
 ) {
   return createScopedVitestConfig(
     [
-      "extensions/codex/src/app-server/run-attempt-client-prewarm.test.ts",
       "extensions/codex/src/app-server/run-attempt-lifecycle-controller.test.ts",
       "extensions/codex/src/app-server/run-attempt-thread-cleanup.test.ts",
       "extensions/codex/src/app-server/run-attempt.context-engine.test.ts",


### PR DESCRIPTION
## What Problem This Solves

Resolves the remaining beta.5 release-validation false positive for frozen Code SHA `311047822ecdde24e824d839ab105ef08f17be00`. Release Checks executes that candidate's historical QA Lab classifier, so the main-only parity fix in #114667 could not change the candidate suite exit. The candidate still reports eight intentional Codex-native harness gaps as failures even though all OpenClaw cells pass.

## Why This Change Was Made

The trusted release workflow now treats the frozen candidate as an evidence producer, then re-checks out a fresh trusted validator after each candidate process. A nonzero suite/report exit is accepted only for the exact Code SHA, core lane, ordered 27-scenario manifest, and ordered eight known runtime-tool gap identities observed in artifacts 8662644841 and 8664381107. Missing, malformed, truncated, reordered, unannotated, hard-error, missing-tool-result, wrong-report, and wrong-target evidence remains blocking.

This is a one-time frozen-target compatibility repair. It does not patch candidate source, change product behavior, or create a generic fallback.

## User Impact

No product behavior changes. The existing beta.5 candidate can reuse its green product evidence while trusted release tooling distinguishes its documented QA harness limitation from a runtime regression.

## Evidence

- Original failed Release Checks: https://github.com/openclaw/openclaw/actions/runs/30288606313/job/90052578672
- Selective reproduction with #114667 present only in trusted tooling: https://github.com/openclaw/openclaw/actions/runs/30293221352/job/90067903354
- Exact reproduced artifact: https://github.com/openclaw/openclaw/actions/runs/30293221352/artifacts/8664381107
- Exact artifact validation: 27 scenarios, 19 passed, exactly eight approved gaps
- Negative probes reject wrong SHA, wrong scenario identity, truncated manifest/report, unannotated skip, hard error, missing tool result, and altered report semantics
- `actionlint`, Node syntax checks, and `git diff --check` pass
- Autoreview completed clean after trust-isolation and exact-identity fixes
