### PR TITLE
fix(ui): keep channel action labels on one line and surface QR next to actions

### DIFF
--- a/scripts/control-ui-mock-dev.ts
+++ b/scripts/control-ui-mock-dev.ts
@@ -848,6 +848,11 @@ async function createChatPickerScenario(
     margin: 2,
     width: 360,
   });
+  const whatsappLoginQrDataUrl = await qrcode.toDataURL("mock-whatsapp-login", {
+    errorCorrectionLevel: "M",
+    margin: 2,
+    width: 360,
+  });
   const workspaceFiles = [
     {
       missing: false,
@@ -1471,6 +1476,17 @@ async function createChatPickerScenario(
       },
       "plugins.list": buildPluginCatalogMock(),
       "channels.status": buildChannelsStatusMock(baseTime),
+      "channels.pairing.list": {
+        accounts: [],
+        requests: [],
+        commandOwnerConfigured: true,
+        limits: { pendingPerAccount: 3, ttlMs: 3_600_000 },
+      },
+      "web.login.start": {
+        message: "Scan the QR code with WhatsApp to link this device.",
+        qrDataUrl: whatsappLoginQrDataUrl,
+      },
+      "web.login.wait": { message: "Linked.", connected: true },
       "wizard.start": channelWizard.start,
       "wizard.next": channelWizard.next,
       "wizard.cancel": { status: "cancelled" },

--- a/test/vitest/vitest.extension-codex-app-server-attempt-extra.config.ts
+++ b/test/vitest/vitest.extension-codex-app-server-attempt-extra.config.ts
@@ -6,7 +6,6 @@ function createExtensionCodexAppServerAttemptExtraVitestConfig(
 ) {
   return createScopedVitestConfig(
     [
-      "extensions/codex/src/app-server/run-attempt-client-prewarm.test.ts",
       "extensions/codex/src/app-server/run-attempt-lifecycle-controller.test.ts",
       "extensions/codex/src/app-server/run-attempt-thread-cleanup.test.ts",
       "extensions/codex/src/app-server/run-attempt.context-engine.test.ts",

--- a/ui/src/pages/channels/view.shared.ts
+++ b/ui/src/pages/channels/view.shared.ts
@@ -162,8 +162,7 @@ export function renderChannelProbeRow(probe: {
 /** Trailing action row carrying a button cluster in the control slot. */
 export function renderChannelActionRow(actions: unknown) {
   return html`
-    <div class="settings-row">
-      <div class="settings-row__text"></div>
+    <div class="settings-row settings-row--actions">
       <div class="settings-row__control">${actions}</div>
     </div>
   `;
@@ -202,8 +201,10 @@ export function renderChannelAccountRow(params: {
 
 /**
  * One channel = one settings section: heading with optional account count,
- * a group holding the status facts, error/probe rows, extra content, the
- * config form, and a trailing action row.
+ * a group holding the status facts, error/probe rows, the config form,
+ * extra content, and a trailing action row. Extra content sits directly
+ * above the actions so action feedback (e.g. the WhatsApp QR) appears next
+ * to the button that triggered it instead of scrolled away above the form.
  */
 export function renderSingleAccountChannelCard(params: {
   title: string;
@@ -225,8 +226,9 @@ export function renderSingleAccountChannelCard(params: {
     html`
       ${renderChannelFacts(params.statusRows)}
       ${params.lastError ? renderChannelErrorRow(params.lastError) : nothing}
-      ${params.secondaryCallout ?? nothing} ${params.extraContent ?? nothing}
-      ${params.configSection} ${params.footer ? renderChannelActionRow(params.footer) : nothing}
+      ${params.secondaryCallout ?? nothing} ${params.configSection}
+      ${params.extraContent ?? nothing}
+      ${params.footer ? renderChannelActionRow(params.footer) : nothing}
     `,
   );
 }

--- a/ui/src/pages/channels/view.test.ts
+++ b/ui/src/pages/channels/view.test.ts
@@ -113,6 +113,7 @@ function renderWhatsAppButtons(params: {
   render(renderWhatsAppCard({ props, whatsapp }), container);
   const buttons = Array.from(container.querySelectorAll("button"));
   return {
+    container,
     buttons,
     labels: buttons.map((button) => button.textContent?.trim()),
   };
@@ -264,5 +265,16 @@ describe("WhatsApp card actions", () => {
     });
 
     expect(labels).toEqual(["Save", "Reload", "Show QR", "Wait for scan", "Logout", "Refresh"]);
+  });
+
+  it("renders the QR directly above the action row so it is visible next to Show QR", () => {
+    const { container } = renderWhatsAppButtons({
+      linked: false,
+      qrDataUrl: "data:image/png;base64,current-qr",
+    });
+
+    const qrRow = container.querySelector(".qr-wrap")?.closest(".settings-row");
+    expect(qrRow).not.toBeNull();
+    expect(qrRow?.nextElementSibling?.classList.contains("settings-row--actions")).toBe(true);
   });
 });

--- a/ui/src/styles/components.css
+++ b/ui/src/styles/components.css
@@ -644,6 +644,9 @@ openclaw-session-owner-chip {
   font-size: 13px;
   font-weight: 500;
   letter-spacing: -0.01em;
+  /* Labels never break mid-text; tight clusters wrap whole buttons instead
+     (see .settings-row--actions). */
+  white-space: nowrap;
   transition:
     border-color var(--duration-fast) var(--ease-out),
     background var(--duration-fast) var(--ease-out),

--- a/ui/src/styles/settings.css
+++ b/ui/src/styles/settings.css
@@ -239,6 +239,15 @@
   justify-content: flex-start;
 }
 
+/* Trailing action rows hold only a button cluster: give it the full row
+   (definite width, see the wrap note on .settings-row__control) so nowrap
+   button labels wrap as whole buttons instead of squeezing into 60%. */
+.settings-row--actions .settings-row__control {
+  width: 100%;
+  max-width: none;
+  flex-wrap: wrap;
+}
+
 /* Label-wrapped toggle row: whole row toggles the switch. */
 .settings-row--toggle {
   cursor: pointer;


### PR DESCRIPTION
## What Problem This Solves

Two papercuts in the web Control UI's WhatsApp channel detail:

1. **Button labels wrap mid-text.** The trailing action row ("Show QR" / "Wait for scan" / "Logout" / "Refresh") lives in a `.settings-row__control` capped at `max-width: 60%`. When the cluster exceeds that cap, buttons get squeezed and their labels break onto two lines while the fixed 32px control height clips them — "Show QR" renders as "Show / QR".
2. **The QR code renders where the user isn't looking.** Clicking "Show QR" at the bottom of the panel inserts the QR into the card's `extraContent` slot, which the shared channel card places *above* the long config form. The user clicks the button, nothing visibly changes near it, and they don't notice the QR appeared far above.

## Why This Change Was Made

- `.btn` now declares `white-space: nowrap` so a button label can never break mid-text.
- `renderChannelActionRow` rows get a `settings-row--actions` modifier whose control column takes the full row width and wraps whole buttons instead of squeezing labels (the empty spacer `settings-row__text` div is dropped; `justify-content: flex-end` keeps the cluster right-aligned).
- `renderSingleAccountChannelCard` moves the `extraContent` slot below the config section, directly above the action row. WhatsApp is the only user of that slot, so the QR (and its status message) now appears adjacent to the button that triggered it. A regression test pins the QR row as the immediate predecessor of the action row.
- Drive-by for the mock dev harness (`pnpm dev:ui:mock`): added `web.login.start` / `web.login.wait` fixtures so the QR flow is demoable, and a `channels.pairing.list` fixture that fixes a pre-existing render crash (`snapshot.requests` undefined) on the channels page.

## User Impact

WhatsApp linking in the web UI is no longer confusing: action button labels stay on one line at any panel width, and the QR code pops in right above the buttons where the user is already looking.

## Evidence

Before (660px viewport — "Wait for scan" wrapped to two lines, QR stranded above the config section):

![before](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/whatsapp-qr-alignment/before.png)

After (same viewport — single-line labels, QR directly above the action row):

![after](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/whatsapp-qr-alignment/after.png)

Screenshots are from the deterministic mock harness (`pnpm dev:ui:mock`), no real data.

Validation:

- `node scripts/run-vitest.mjs ui/src/pages/channels` — 45 passed (includes new QR-placement regression test)
- Playwright layout probe on the mock harness: pre-fix "Wait for scan" shrinks to 86px (wrapped), post-fix 109px single line; QR bottom sits 42px above the action row post-fix
- `stylelint` on touched stylesheets, `oxlint` + `oxfmt --check` on touched files — clean
- Codex autoreview (`--mode uncommitted`) — clean (both commits)

## Red-main fix included

`main` is currently red on the full-suite sharding gate (`test/scripts/test-projects.test.ts`): #114671 added `run-attempt-client-prewarm.test.ts` to the `attempt-extra` shard config while #114672 added it to `attempt-light` (which the sharding test expects as sole owner). Both landed 2026-07-27 and the combination double-covers the file. This PR removes the duplicate entry from `attempt-extra`; `node scripts/run-vitest.mjs test/scripts/test-projects.test.ts` now passes 220/220 (was 2 failures, reproduced on latest `origin/main`).
