### PR TITLE
fix(models): recognize loopback endpoints and clamp fallback output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,7 +51,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- **Model resolution:** recognize the full IPv4 loopback range consistently in provider auth and cron preflight, and clamp configured fallback output caps to their resolved context windows.
 - **Codex native controls:** stop misclassifying valid thinking/fast runtime controls as provider overrides so Codex routes keep their native controls, while provider-native objects and invalid values stay fail-closed. Thanks @VACInc. (#107588)
 - **State snapshot verification:** run SQLite snapshot verification in a separate process so worker-thread file closes no longer drop the Gateway's POSIX WAL locks, eliminating spurious WAL misses and I/O errors. Thanks @VACInc. (#114016)
 - **Reply latency with model policies:** reuse one immutable plugin-metadata snapshot per model-selection run instead of repeating plugin discovery, cutting reply delay when a model policy is configured. Thanks @VACInc. (#114117)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Model resolution:** recognize the full IPv4 loopback range consistently in provider auth and cron preflight, and clamp configured fallback output caps to their resolved context windows.
 - **Codex native controls:** stop misclassifying valid thinking/fast runtime controls as provider overrides so Codex routes keep their native controls, while provider-native objects and invalid values stay fail-closed. Thanks @VACInc. (#107588)
 - **State snapshot verification:** run SQLite snapshot verification in a separate process so worker-thread file closes no longer drop the Gateway's POSIX WAL locks, eliminating spurious WAL misses and I/O errors. Thanks @VACInc. (#114016)
 - **Reply latency with model policies:** reuse one immutable plugin-metadata snapshot per model-selection run instead of repeating plugin discovery, cutting reply delay when a model policy is configured. Thanks @VACInc. (#114117)

--- a/src/agents/embedded-agent-runner/model.configured-fallback.ts
+++ b/src/agents/embedded-agent-runner/model.configured-fallback.ts
@@ -10,6 +10,7 @@ import {
 } from "../provider-request-config.js";
 import { mergeModelMediaInput, resolveConfiguredFallbackReasoning } from "./model.compat.js";
 import {
+  clampModelMaxTokensToContextWindow,
   findConfiguredProviderModel,
   hasConfiguredFallbackSurface,
   mergeConfiguredRuntimeModelParams,
@@ -155,6 +156,16 @@ export function resolveConfiguredFallbackModel(params: {
     providerConfig?.maxTokens ??
     providerConfig?.models?.[0]?.maxTokens;
   const resolvedFallbackMaxTokens = configuredFallbackMaxTokens ?? staticCatalogModel?.maxTokens;
+  const resolvedFallbackContextWindow =
+    configuredModel?.contextWindow ??
+    providerConfig?.contextWindow ??
+    providerConfig?.models?.[0]?.contextWindow ??
+    staticCatalogModel?.contextWindow ??
+    DEFAULT_CONTEXT_TOKENS;
+  const normalizedResolvedFallbackMaxTokens = clampModelMaxTokensToContextWindow(
+    resolvedFallbackMaxTokens,
+    resolvedFallbackContextWindow,
+  );
   return normalizeResolvedModel({
     provider,
     cfg,
@@ -179,12 +190,7 @@ export function resolveConfiguredFallbackModel(params: {
             ? { thinkingLevelMap: configuredModel.thinkingLevelMap }
             : {}),
           cost: metadataModel?.cost ?? { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-          contextWindow:
-            configuredModel?.contextWindow ??
-            providerConfig?.contextWindow ??
-            providerConfig?.models?.[0]?.contextWindow ??
-            staticCatalogModel?.contextWindow ??
-            DEFAULT_CONTEXT_TOKENS,
+          contextWindow: resolvedFallbackContextWindow,
           contextTokens:
             configuredModel?.contextTokens ??
             providerConfig?.contextTokens ??
@@ -192,9 +198,9 @@ export function resolveConfiguredFallbackModel(params: {
             staticCatalogModel?.contextTokens,
           // maxTokens is a wire-level output cap, not a context-budget fallback.
           // Omit an unknown cap so strict providers can apply their own limit.
-          ...(resolvedFallbackMaxTokens !== undefined
+          ...(normalizedResolvedFallbackMaxTokens !== undefined
             ? {
-                maxTokens: resolvedFallbackMaxTokens,
+                maxTokens: normalizedResolvedFallbackMaxTokens,
                 maxTokensSource:
                   configuredFallbackMaxTokens !== undefined ? "configured" : "discovered",
               }

--- a/src/agents/embedded-agent-runner/model.configured-overrides.ts
+++ b/src/agents/embedded-agent-runner/model.configured-overrides.ts
@@ -307,6 +307,18 @@ function markDiscoveredMaxTokensSource(model: ProviderRuntimeModel): ProviderRun
   return { ...model, maxTokensSource: "discovered" };
 }
 
+export function clampModelMaxTokensToContextWindow(
+  maxTokens: number | undefined,
+  contextWindow: number | undefined,
+): number | undefined {
+  if (typeof maxTokens !== "number" || !Number.isFinite(maxTokens)) {
+    return undefined;
+  }
+  return typeof contextWindow === "number" && Number.isFinite(contextWindow)
+    ? Math.min(maxTokens, contextWindow)
+    : maxTokens;
+}
+
 export function applyConfiguredProviderOverrides(params: {
   provider: string;
   discoveredModel: ProviderRuntimeModel;
@@ -503,12 +515,10 @@ export function applyConfiguredProviderOverrides(params: {
     metadataOverrideModel?.contextWindow ?? providerConfig.contextWindow;
   const configuredMaxTokens = metadataOverrideModel?.maxTokens ?? providerConfig.maxTokens;
   const resolvedMaxTokens = configuredMaxTokens ?? discoveredModel.maxTokens;
-  const normalizedResolvedMaxTokens =
-    typeof resolvedMaxTokens === "number" && Number.isFinite(resolvedMaxTokens)
-      ? typeof resolvedContextWindow === "number" && Number.isFinite(resolvedContextWindow)
-        ? Math.min(resolvedMaxTokens, resolvedContextWindow)
-        : resolvedMaxTokens
-      : undefined;
+  const normalizedResolvedMaxTokens = clampModelMaxTokensToContextWindow(
+    resolvedMaxTokens,
+    resolvedContextWindow,
+  );
   const catalogCompat = mergeModelCompat(
     configuredStaticCatalogModel?.compat,
     discoveredModel.compat,

--- a/src/agents/embedded-agent-runner/model.test.ts
+++ b/src/agents/embedded-agent-runner/model.test.ts
@@ -1501,7 +1501,7 @@ describe("resolveModel", () => {
     expect(model.baseUrl).toBe("https://aiplatform.googleapis.com");
   });
 
-  it("uses bundled static metadata for configured provider fallback token limits", () => {
+  it("clamps inherited fallback maxTokens to the configured context window", () => {
     resolveBundledStaticCatalogModelMock.mockReturnValueOnce({
       provider: "xiaomi-token-plan",
       id: "mimo-v2.5-pro",
@@ -1520,6 +1520,7 @@ describe("resolveModel", () => {
           "xiaomi-token-plan": {
             baseUrl: "https://token-plan-sgp.xiaomimimo.com/v1",
             api: "openai-completions",
+            contextWindow: 16_000,
             models: [],
           },
         },
@@ -1531,8 +1532,8 @@ describe("resolveModel", () => {
 
     expect(model.name).toBe("Xiaomi MiMo V2.5 Pro");
     expect(model.baseUrl).toBe("https://token-plan-sgp.xiaomimimo.com/v1");
-    expect(model.contextWindow).toBe(1_048_576);
-    expect(model.maxTokens).toBe(32_000);
+    expect(model.contextWindow).toBe(16_000);
+    expect(model.maxTokens).toBe(16_000);
     expectRecordFields(model, { maxTokensSource: "discovered" });
     expect(resolveBundledStaticCatalogModelMock).toHaveBeenCalledWith({
       provider: "xiaomi-token-plan",

--- a/src/agents/model-auth-provider-config.ts
+++ b/src/agents/model-auth-provider-config.ts
@@ -1,7 +1,6 @@
 /**
  * Provider-entry configuration and stored-profile binding for model auth.
  */
-import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
 import {
   getRuntimeConfigSnapshot,
   getRuntimeConfigSourceSnapshot,
@@ -32,7 +31,14 @@ import {
   SECRETREF_ENV_HEADER_MARKER_PREFIX,
 } from "./model-auth-markers.js";
 import type { ResolvedProviderAuth } from "./model-auth-runtime-shared.js";
+import { isLocalProviderBaseUrl } from "./model-provider-local.js";
 import { normalizeProviderId } from "./model-selection.js";
+
+const MODEL_AUTH_LOCAL_HOST_ALIASES = new Set([
+  "docker.orb.internal",
+  "host.docker.internal",
+  "host.orb.internal",
+]);
 
 export function sentinelizeSecretRefProfileApiKey(params: {
   apiKey: string;
@@ -185,7 +191,7 @@ export function resolveUsableCustomProviderApiKey(params: {
     isCustomLocalProviderConfig(customProviderConfig) &&
     (customProviderConfig.api === "openai-completions" || customProviderConfig.api === "ollama") &&
     customProviderConfig.baseUrl &&
-    isLocalBaseUrl(customProviderConfig.baseUrl)
+    isLocalAuthProviderBaseUrl(customProviderConfig.baseUrl)
   ) {
     return {
       apiKey: customProviderConfig.api === "ollama" ? customKey : CUSTOM_LOCAL_AUTH_MARKER,
@@ -477,42 +483,8 @@ export function resolveConfiguredAwsSdkProfileAuth(params: {
   };
 }
 
-export function isLocalBaseUrl(baseUrl: string): boolean {
-  try {
-    let host = normalizeLowercaseStringOrEmpty(new URL(baseUrl).hostname);
-    if (host.startsWith("[") && host.endsWith("]")) {
-      host = host.slice(1, -1);
-    }
-    return (
-      host === "localhost" ||
-      host === "127.0.0.1" ||
-      host === "0.0.0.0" ||
-      host === "::1" ||
-      host === "::ffff:7f00:1" ||
-      host === "::ffff:127.0.0.1" ||
-      host === "docker.orb.internal" ||
-      host === "host.docker.internal" ||
-      host === "host.orb.internal" ||
-      host.endsWith(".local") ||
-      isPrivateIpv4Host(host)
-    );
-  } catch {
-    return false;
-  }
-}
-
-function isPrivateIpv4Host(host: string): boolean {
-  if (!/^\d+\.\d+\.\d+\.\d+$/.test(host)) {
-    return false;
-  }
-  const octets = host.split(".").map((part) => Number.parseInt(part, 10));
-  if (octets.some((part) => !Number.isInteger(part) || part < 0 || part > 255)) {
-    return false;
-  }
-  const [a, b] = octets;
-  return (
-    a === 10 || (a === 172 && b !== undefined && b >= 16 && b <= 31) || (a === 192 && b === 168)
-  );
+export function isLocalAuthProviderBaseUrl(baseUrl: string): boolean {
+  return isLocalProviderBaseUrl(baseUrl, MODEL_AUTH_LOCAL_HOST_ALIASES);
 }
 
 export function hasExplicitProviderApiKeyConfig(providerConfig: ModelProviderConfig): boolean {

--- a/src/agents/model-auth-runtime.ts
+++ b/src/agents/model-auth-runtime.ts
@@ -203,7 +203,9 @@ export function hasSyntheticLocalProviderAuthConfig(params: {
   if (authConfig.hasExplicitProviderApiKeyConfig(providerConfig)) {
     return false;
   }
-  return Boolean(providerConfig.baseUrl && authConfig.isLocalBaseUrl(providerConfig.baseUrl));
+  return Boolean(
+    providerConfig.baseUrl && authConfig.isLocalAuthProviderBaseUrl(providerConfig.baseUrl),
+  );
 }
 
 function listProviderSyntheticAuthRefs(params: {

--- a/src/agents/model-auth.test.ts
+++ b/src/agents/model-auth.test.ts
@@ -1782,10 +1782,15 @@ describe("resolveApiKeyForProvider – synthetic local auth for custom providers
   it("recognizes local baseUrl variants for synthetic auth config", () => {
     const localBaseUrls = [
       "http://127.0.0.1:8080/v1",
+      "http://127.0.0.2:8080/v1",
+      "http://127.255.255.254:8080/v1",
+      "http://10.0.0.1:11434/v1",
+      "http://172.16.0.1:11434/v1",
       "http://192.168.0.222:11434/v1",
       "http://localhost:11434/v1",
       "http://[::1]:8080/v1",
       "http://0.0.0.0:11434/v1",
+      "http://[::ffff:7f00:1]:8080/v1",
       "http://[::ffff:127.0.0.1]:8080/v1",
     ];
 
@@ -1804,6 +1809,21 @@ describe("resolveApiKeyForProvider – synthetic local auth for custom providers
         baseUrl,
       ).toBe(true);
     }
+  });
+
+  it("does not recognize addresses outside the IPv4 loopback range as local", () => {
+    expect(
+      hasSyntheticLocalProviderAuthConfig({
+        provider: "custom-remote",
+        cfg: {
+          models: {
+            providers: {
+              "custom-remote": createCustomProviderConfig("http://128.0.0.1:8080/v1"),
+            },
+          },
+        },
+      }),
+    ).toBe(false);
   });
 
   it("synthesizes a local auth marker for custom providers with a local baseUrl and no apiKey", async () => {

--- a/src/agents/model-provider-local.ts
+++ b/src/agents/model-provider-local.ts
@@ -1,0 +1,25 @@
+/** Shared local model-provider URL classification. */
+import { isLoopbackIpAddress, isRfc1918Ipv4Address } from "@openclaw/net-policy/ip";
+import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
+
+export function isLocalProviderBaseUrl(
+  baseUrl: string,
+  additionalHostnames?: ReadonlySet<string>,
+): boolean {
+  try {
+    let host = normalizeLowercaseStringOrEmpty(new URL(baseUrl).hostname);
+    if (host.startsWith("[") && host.endsWith("]")) {
+      host = host.slice(1, -1);
+    }
+    return (
+      host === "localhost" ||
+      host === "0.0.0.0" ||
+      host.endsWith(".local") ||
+      additionalHostnames?.has(host) === true ||
+      isLoopbackIpAddress(host) ||
+      isRfc1918Ipv4Address(host)
+    );
+  } catch {
+    return false;
+  }
+}

--- a/src/cron/isolated-agent/model-preflight.runtime.test.ts
+++ b/src/cron/isolated-agent/model-preflight.runtime.test.ts
@@ -42,28 +42,41 @@ describe("preflightCronModelProvider", () => {
     resetCronModelProviderPreflightCacheForTest();
   });
 
-  it("skips network checks for cloud provider URLs", async () => {
-    const result = await preflightCronModelProvider({
-      cfg: {
-        models: {
-          providers: {
-            openai: {
-              api: "openai-responses",
-              baseUrl: "https://api.openai.com/v1",
-              models: [],
+  it.each(["https://api.openai.com/v1", "http://128.0.0.1:8000/v1"])(
+    "skips network checks for non-local provider URL %s",
+    async (baseUrl) => {
+      const result = await preflightCronModelProvider({
+        cfg: {
+          models: {
+            providers: {
+              openai: {
+                api: "openai-responses",
+                baseUrl,
+                models: [],
+              },
             },
           },
         },
-      },
-      provider: "openai",
-      model: "gpt-5.4",
-    });
+        provider: "openai",
+        model: "gpt-5.4",
+      });
 
-    expect(result).toEqual({ status: "available" });
-    expect(fetchWithSsrFGuardMock).not.toHaveBeenCalled();
-  });
+      expect(result).toEqual({ status: "available" });
+      expect(fetchWithSsrFGuardMock).not.toHaveBeenCalled();
+    },
+  );
 
-  it("treats any HTTP response from a local OpenAI-compatible endpoint as reachable", async () => {
+  it.each([
+    "127.0.0.1",
+    "127.0.0.2",
+    "127.255.255.254",
+    "10.0.0.1",
+    "172.16.0.1",
+    "192.168.0.222",
+    "[::1]",
+    "[::ffff:7f00:1]",
+    "[::ffff:127.0.0.1]",
+  ])("treats any HTTP response from local endpoint host %s as reachable", async (host) => {
     mockReachableResponse(401);
 
     const result = await preflightCronModelProvider({
@@ -72,7 +85,7 @@ describe("preflightCronModelProvider", () => {
           providers: {
             vllm: {
               api: "openai-completions",
-              baseUrl: "http://127.0.0.1:8000/v1",
+              baseUrl: `http://${host}:8000/v1`,
               models: [],
             },
           },
@@ -84,7 +97,7 @@ describe("preflightCronModelProvider", () => {
 
     expect(result).toEqual({ status: "available" });
     const request = requireFetchPreflightRequest();
-    expect(request.url).toBe("http://127.0.0.1:8000/v1/models");
+    expect(request.url).toBe(`http://${host}:8000/v1/models`);
     expect(request.timeoutMs).toBe(2500);
   });
 

--- a/src/cron/isolated-agent/model-preflight.runtime.ts
+++ b/src/cron/isolated-agent/model-preflight.runtime.ts
@@ -1,8 +1,8 @@
 /** Preflights local model-provider endpoints before scheduled cron runner startup. */
 import { normalizeProviderId } from "@openclaw/model-catalog-core/provider-id";
-import { expectDefined } from "@openclaw/normalization-core";
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
 import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
+import { isLocalProviderBaseUrl } from "../../agents/model-provider-local.js";
 import type { ModelProviderConfig } from "../../config/types.models.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { fetchWithSsrFGuard } from "../../infra/net/fetch-guard.js";
@@ -69,45 +69,6 @@ function normalizeBaseUrl(value: unknown): string | undefined {
 function normalizeProbeApi(providerConfig: ModelProviderConfig): PreflightApi | undefined {
   const api = normalizeLowercaseStringOrEmpty(providerConfig.api);
   return api === "ollama" || api === "openai-completions" ? api : undefined;
-}
-
-function isPrivateIpv4Host(host: string): boolean {
-  if (!/^\d+\.\d+\.\d+\.\d+$/.test(host)) {
-    return false;
-  }
-  const octets = host.split(".").map((part) => Number.parseInt(part, 10));
-  if (octets.some((part) => !Number.isInteger(part) || part < 0 || part > 255)) {
-    return false;
-  }
-  const [a, b] = octets;
-  return (
-    a === 10 ||
-    (a === 172 &&
-      expectDefined(b, "model preflight.runtime b") >= 16 &&
-      expectDefined(b, "model preflight.runtime b") <= 31) ||
-    (a === 192 && b === 168)
-  );
-}
-
-function isLocalProviderBaseUrl(baseUrl: string): boolean {
-  try {
-    let host = normalizeLowercaseStringOrEmpty(new URL(baseUrl).hostname);
-    if (host.startsWith("[") && host.endsWith("]")) {
-      host = host.slice(1, -1);
-    }
-    return (
-      host === "localhost" ||
-      host === "127.0.0.1" ||
-      host === "0.0.0.0" ||
-      host === "::1" ||
-      host === "::ffff:7f00:1" ||
-      host === "::ffff:127.0.0.1" ||
-      host.endsWith(".local") ||
-      isPrivateIpv4Host(host)
-    );
-  } catch {
-    return false;
-  }
 }
 
 function buildProbeUrl(api: PreflightApi, baseUrl: string): string {


### PR DESCRIPTION
## What Problem This Solves

Fixes two model-resolution issues: custom endpoints on IPv4 loopback addresses other than `127.0.0.1` were treated as remote and could incorrectly require auth, and configured fallback models could retain a static-catalog `maxTokens` value larger than a narrowed `contextWindow`.

## Why This Change Was Made

Provider auth and cron preflight now use one shared local-provider classifier backed by the existing net-policy IP contract, while auth-only container host aliases retain their current behavior. Primary and configured-fallback model resolution now use one shared output-cap clamp. The cron runtime remains dynamically imported; no static/dynamic boundary was changed.

AI-assisted implementation and review.

## User Impact

Local model servers anywhere in `127.0.0.0/8` no longer require spurious credentials, cron preflight classifies the same endpoints consistently, and strict providers no longer receive fallback output caps larger than the resolved context window.

## Evidence

- Blacksmith Testbox `tbx_01kyjea8tb9641fscaxff8x1w7`, run https://github.com/openclaw/openclaw/actions/runs/30295174791
- `pnpm test src/agents/model-auth.test.ts src/cron/isolated-agent/model-preflight.runtime.test.ts src/agents/embedded-agent-runner/model.test.ts` — 247 tests passed across 3 files / 2 routed shards
- `pnpm check:import-cycles` — 0 runtime value cycles
- `pnpm build` — passed; no `[INEFFECTIVE_DYNAMIC_IMPORT]`
- `pnpm check:changed` — passed (core prod/test types, formatting, lint, and guards)
- Fresh Codex autoreview completed with no accepted/actionable findings; two test-only findings were rejected against the parsed source and the exact green Testbox run
- Real after-fix runtime proof on Blacksmith Testbox `tbx_01kyjhapgaj9jwq84mpnknjwe4`, run https://github.com/openclaw/openclaw/actions/runs/30299071559:
  - an actual embedded agent request reached `http://127.0.0.2:44082/v1/chat/completions`, returned `OPENCLAW_E2E_LOOPBACK_OK`, and the server observed `authorization: false`
  - cron preflight against the same live endpoint returned `{"status":"available"}`
  - the production async resolver returned `{"provider":"xiaomi-token-plan","id":"mimo-v2.5-pro","contextWindow":16000,"maxTokens":16000,"maxTokensSource":"discovered"}` for a configured 16,000-token window inheriting the larger catalog cap
  - a real fallback agent request then reached the same endpoint and completed successfully

Maintainer acceptance: the smaller fallback cap is the intended compatibility correction—an output cap must not exceed its resolved context window. Release-note context is retained in this PR body; `CHANGELOG.md` remains release-owned.
