### PR TITLE
fix(clickclack): name discussion channels from session titles

### DIFF
--- a/extensions/clickclack/src/discussions/binding-store.ts
+++ b/extensions/clickclack/src/discussions/binding-store.ts
@@ -21,6 +21,7 @@ export type ClickClackDiscussionBinding = {
   section: string;
   archived: boolean;
   label: string;
+  displayTitle?: string;
 };
 
 export function bindingMatchesSessionIncarnation(

--- a/extensions/clickclack/src/discussions/naming.test.ts
+++ b/extensions/clickclack/src/discussions/naming.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import {
+  fallbackDiscussionLabel,
+  resolveDiscussionLabel,
+  slugifyDiscussionLabel,
+} from "./naming.js";
+
+describe("ClickClack discussion naming", () => {
+  it.each([
+    {
+      entry: { label: " Explicit ", displayName: "Generated", subject: "Subject" },
+      expected: "Explicit",
+    },
+    {
+      entry: { label: "  ", displayName: " Generated ", subject: "Subject" },
+      expected: "Generated",
+    },
+    {
+      entry: { label: "", displayName: "  ", subject: " Subject " },
+      expected: "Subject",
+    },
+  ])("resolves and trims the first available title", ({ entry, expected }) => {
+    expect(resolveDiscussionLabel(entry, "agent:main:naming", "main")).toBe(expected);
+  });
+
+  it("uses compact agent-scoped and agentless fallbacks", () => {
+    const sessionKey = "agent:main:naming";
+
+    expect(fallbackDiscussionLabel(sessionKey, " Main ")).toMatch(/^s-main-[0-9a-f]{8}$/u);
+    expect(fallbackDiscussionLabel(sessionKey)).toMatch(/^s-[0-9a-f]{8}$/u);
+    expect(resolveDiscussionLabel({}, sessionKey, "main")).toBe(
+      fallbackDiscussionLabel(sessionKey, "main"),
+    );
+  });
+
+  it("preserves discussion slug normalization", () => {
+    expect(slugifyDiscussionLabel("  Déjà vu / Release!  ", "unused")).toBe("deja-vu-release");
+  });
+});

--- a/extensions/clickclack/src/discussions/naming.ts
+++ b/extensions/clickclack/src/discussions/naming.ts
@@ -5,16 +5,8 @@ function shortSessionHash(sessionKey: string): string {
   return createHash("sha256").update(sessionKey).digest("hex").slice(0, 32);
 }
 
-export function fallbackDiscussionLabel(sessionKey: string): string {
-  return `s-${shortSessionHash(sessionKey)}`;
-}
-
-export function resolveDiscussionLabel(label: string | undefined, sessionKey: string): string {
-  return label?.trim() || fallbackDiscussionLabel(sessionKey);
-}
-
-export function slugifyDiscussionLabel(label: string, sessionKey: string): string {
-  const slug = label
+function slugifyLabel(label: string): string {
+  return label
     .normalize("NFKD")
     .replace(/[\u0300-\u036f]/gu, "")
     .toLowerCase()
@@ -22,6 +14,38 @@ export function slugifyDiscussionLabel(label: string, sessionKey: string): strin
     .replace(/^-+|-+$/gu, "")
     .slice(0, 80)
     .replace(/-+$/gu, "");
+}
+
+export function fallbackDiscussionLabel(sessionKey: string, agentId?: string): string {
+  const agentSegment = agentId?.trim() ? slugifyLabel(agentId) : "";
+  const hash = shortSessionHash(sessionKey).slice(0, 8);
+  // Channel identity lives in external_ref/channelId; this short name is display-only.
+  // resolveAvailableChannelName suffixes collisions instead of relying on a long hash.
+  return `s-${agentSegment ? `${agentSegment}-` : ""}${hash}`;
+}
+
+export function resolveDiscussionLabel(
+  entry: { label?: string; displayName?: string; subject?: string },
+  sessionKey: string,
+  agentId?: string,
+): string {
+  // Keep this entry-only prefix aligned with deriveSessionTitle in src/gateway/session-utils-core.ts.
+  return (
+    entry.label?.trim() ||
+    entry.displayName?.trim() ||
+    entry.subject?.trim() ||
+    fallbackDiscussionLabel(sessionKey, agentId)
+  );
+}
+
+export function truncateDiscussionDisplayTitle(label: string): string {
+  // Mirror the server's normalization (trim after the 200-rune cut) so the
+  // display_title equality assertions cannot fail on a whitespace boundary.
+  return Array.from(label).slice(0, 200).join("").trim();
+}
+
+export function slugifyDiscussionLabel(label: string, sessionKey: string): string {
+  const slug = slugifyLabel(label);
   return slug || fallbackDiscussionLabel(sessionKey);
 }
 

--- a/extensions/clickclack/src/discussions/service-contract.test.ts
+++ b/extensions/clickclack/src/discussions/service-contract.test.ts
@@ -8,7 +8,7 @@ import {
 import type { ClickClackDiscussionBinding } from "./binding-store.js";
 import { discussionCredentialFingerprint } from "./naming.js";
 import { markClickClackDiscussionChannelRevoked } from "./revoked-channel-store.js";
-import { assertManagedChannelListContract } from "./service-open.js";
+import { assertChannelPatch, assertManagedChannelListContract } from "./service-open.js";
 import {
   TEST_DESTINATION_IDENTITY,
   createHarness,
@@ -112,6 +112,62 @@ describe("ClickClack discussion service contracts", () => {
       state: "open",
     });
     expect(harness.createChannel).toHaveBeenCalledTimes(1);
+  });
+
+  it("accepts a legacy create response that omits display_title", async () => {
+    const harness = createHarness({ label: "Legacy title response" });
+    vi.mocked(harness.createChannel).mockImplementationOnce(async (_workspaceId, input) => {
+      const channel = {
+        id: "chn_legacy_title",
+        route_id: "legacy-title-route",
+        workspace_id: "wsp_team",
+        ...input,
+        kind: "public",
+        created_at: "2026-07-19T00:00:00.000Z",
+      };
+      Reflect.deleteProperty(channel, "display_title");
+      return channel;
+    });
+
+    await expect(harness.service.open("agent:main:legacy-title")).resolves.toMatchObject({
+      state: "open",
+    });
+  });
+
+  it("rejects a create response with the wrong display_title", async () => {
+    const harness = createHarness({ label: "Expected title" });
+    vi.mocked(harness.createChannel).mockImplementationOnce(async (_workspaceId, input) => ({
+      id: "chn_wrong_title",
+      route_id: "wrong-title-route",
+      workspace_id: "wsp_team",
+      ...input,
+      display_title: "Wrong title",
+      kind: "public",
+      created_at: "2026-07-19T00:00:00.000Z",
+    }));
+
+    await expect(harness.service.open("agent:main:wrong-title")).rejects.toThrow(
+      "managed discussion channel contract",
+    );
+  });
+
+  it("checks display_title patches only when the response advertises the field", () => {
+    const channel = {
+      id: "chn_patch_title",
+      route_id: "patch-title-route",
+      workspace_id: "wsp_team",
+      name: "expected-title",
+      kind: "public",
+      created_at: "2026-07-19T00:00:00.000Z",
+    };
+
+    expect(() => assertChannelPatch(channel, { display_title: "Expected title" })).not.toThrow();
+    expect(() =>
+      assertChannelPatch(
+        { ...channel, display_title: "Wrong title" },
+        { display_title: "Expected title" },
+      ),
+    ).toThrow("did not apply display_title");
   });
 
   it("accepts a managed channel whose absent external URL is omitted", async () => {

--- a/extensions/clickclack/src/discussions/service-open.ts
+++ b/extensions/clickclack/src/discussions/service-open.ts
@@ -26,6 +26,7 @@ import {
   fallbackDiscussionLabel,
   resolveDiscussionLabel,
   slugifyDiscussionLabel,
+  truncateDiscussionDisplayTitle,
 } from "./naming.js";
 import { markClickClackDiscussionChannelIdentityRevoked } from "./revoked-channel-store.js";
 
@@ -60,6 +61,7 @@ export async function resolveAvailableChannelName(params: {
   workspaceId: string;
   label: string;
   sessionKey: string;
+  agentId?: string;
   ownChannelId?: string;
   channels?: Awaited<ReturnType<ClickClackClient["channels"]>>;
 }): Promise<string> {
@@ -71,7 +73,15 @@ export async function resolveAvailableChannelName(params: {
   if (!occupied.has(desired)) {
     return desired;
   }
-  const fallback = fallbackDiscussionLabel(params.sessionKey);
+  // Suffixed candidates may exceed the 80-char slug cap; that cap is client-side
+  // cosmetics only — the ClickClack server stores names without a length limit.
+  for (let suffix = 2; suffix <= 20; suffix += 1) {
+    const candidate = `${desired}-${suffix}`;
+    if (!occupied.has(candidate)) {
+      return candidate;
+    }
+  }
+  const fallback = fallbackDiscussionLabel(params.sessionKey, params.agentId);
   if (!occupied.has(fallback)) {
     return fallback;
   }
@@ -92,11 +102,17 @@ export function assertChannelPatch(
     "external_managed",
     "external_ref",
     "external_url",
+    "display_title",
     "name",
     "sidebar_section",
   ] as const) {
     const expected = patch[key];
     if (expected === undefined) {
+      continue;
+    }
+    // Older ClickClack servers omit display_title during the rollout skew window.
+    // Verify it only when the response advertises the new field.
+    if (key === "display_title" && !(key in channel)) {
       continue;
     }
     const actual =
@@ -111,13 +127,24 @@ export function assertChannelPatch(
 
 function assertManagedChannelContract(
   channel: Awaited<ReturnType<ClickClackClient["createChannel"]>>,
-  expected: { sessionKey: string; externalRef: string; section: string; externalUrl?: string },
+  expected: {
+    sessionKey: string;
+    externalRef: string;
+    section: string;
+    externalUrl?: string;
+    displayTitle: string;
+  },
 ): void {
+  // Older ClickClack servers omit display_title during the rollout skew window.
+  // A present field must still match so partial or broken deployments fail closed.
+  const displayTitleMatches =
+    !("display_title" in channel) || channel.display_title === expected.displayTitle;
   if (
     channel.external_managed !== true ||
     (channel.external_ref ?? "") !== (expected.externalRef ?? "") ||
     (channel.sidebar_section ?? "") !== (expected.section ?? "") ||
-    (channel.external_url ?? "") !== (expected.externalUrl ?? "")
+    (channel.external_url ?? "") !== (expected.externalUrl ?? "") ||
+    !displayTitleMatches
   ) {
     throw new Error(
       `ClickClack server does not support the managed discussion channel contract for ${expected.sessionKey}`,
@@ -187,13 +214,17 @@ export async function openClickClackDiscussionBinding(
     }
   }
 
-  const label = resolveDiscussionLabel(entry.label, sessionKey);
+  const config = runtime.config.current() as CoreConfig;
+  const agentId = resolveAgentIdFromSessionKey(sessionKey, resolveDefaultAgentId(config));
+  const fallback = fallbackDiscussionLabel(sessionKey, agentId);
+  const label = resolveDiscussionLabel(entry, sessionKey, agentId);
+  const displayTitle = label === fallback ? "" : truncateDiscussionDisplayTitle(label);
   const section = entry.category?.trim() || account.discussions.section;
   const externalUrl = controlSessionUrl(
     account.discussions.controlUrlBase,
     sessionKey,
     account.agentId ?? "main",
-    (runtime.config.current() as CoreConfig).session?.mainKey,
+    config.session?.mainKey,
     label,
   );
   const archived = entry.archivedAt !== undefined;
@@ -225,6 +256,7 @@ export async function openClickClackDiscussionBinding(
           external_ref: string;
           external_url: string;
           sidebar_section: string;
+          display_title: string;
         }
       | undefined;
     let resolved: Awaited<ReturnType<ClickClackClient["createChannel"]>> | undefined;
@@ -238,6 +270,7 @@ export async function openClickClackDiscussionBinding(
         workspaceId: workspace.id,
         label,
         sessionKey,
+        agentId,
         channels,
         ownChannelId: adopted?.id,
       });
@@ -247,6 +280,7 @@ export async function openClickClackDiscussionBinding(
         external_ref: externalRef,
         external_url: externalUrl ?? "",
         sidebar_section: section,
+        display_title: displayTitle,
       };
       recordPendingDiscussionOpen({
         runtime,
@@ -332,7 +366,13 @@ export async function openClickClackDiscussionBinding(
       throw new Error("ClickClack discussion channel name retries were exhausted");
     }
     try {
-      assertManagedChannelContract(resolved, { sessionKey, externalRef, section, externalUrl });
+      assertManagedChannelContract(resolved, {
+        sessionKey,
+        externalRef,
+        section,
+        externalUrl,
+        displayTitle,
+      });
       if (adopted) {
         assertChannelPatch(resolved, { ...managedFields, archived });
       }
@@ -375,10 +415,7 @@ export async function openClickClackDiscussionBinding(
     }
     const nextBinding: ClickClackDiscussionBinding = {
       accountId: account.accountId,
-      agentId: resolveAgentIdFromSessionKey(
-        sessionKey,
-        resolveDefaultAgentId(runtime.config.current() as CoreConfig),
-      ),
+      agentId,
       sessionId: entry.sessionId,
       serverBaseUrl,
       credentialFingerprint,
@@ -392,6 +429,7 @@ export async function openClickClackDiscussionBinding(
       section,
       archived,
       label,
+      displayTitle: "display_title" in channel ? channel.display_title : undefined,
     };
     const currentEntry = runtime.agent.session.getSessionEntry({
       sessionKey,

--- a/extensions/clickclack/src/discussions/service-test-support.ts
+++ b/extensions/clickclack/src/discussions/service-test-support.ts
@@ -67,7 +67,16 @@ export function discussionConfig(): CoreConfig {
 }
 
 export function createHarness(
-  entry: { sessionId?: string; label?: string; category?: string; archivedAt?: number } | undefined,
+  entry:
+    | {
+        sessionId?: string;
+        label?: string;
+        displayName?: string;
+        subject?: string;
+        category?: string;
+        archivedAt?: number;
+      }
+    | undefined,
   options: { bindingGenerationFactory?: () => string } = {},
 ) {
   let sessionEntry = entry;
@@ -117,6 +126,7 @@ export function createHarness(
       external_ref: patch.external_ref ?? "agent:main:main",
       external_url: patch.external_url ?? "https://control.example/control/chat/main",
       sidebar_section: patch.sidebar_section ?? "Projects",
+      ...(patch.display_title !== undefined ? { display_title: patch.display_title } : {}),
       archived: patch.archived ?? false,
       created_at: "2026-07-19T00:00:00.000Z",
     }),

--- a/extensions/clickclack/src/discussions/service.test.ts
+++ b/extensions/clickclack/src/discussions/service.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
-import { ClickClackHttpError } from "../http-client.js";
+import { ClickClackHttpError, type ClickClackClient } from "../http-client.js";
+import type { ClickClackChannel } from "../types.js";
 import { controlSessionUrl } from "./control-session-url.js";
 import { fallbackDiscussionLabel } from "./naming.js";
 import { MANAGED_CONTRACT_FIELDS, createHarness, testExternalRef } from "./service-test-support.js";
@@ -98,6 +99,21 @@ const SESSION_URL_CONTRACT_CASES = [
   },
 ] satisfies readonly SessionUrlContractCase[];
 
+function legacyCreateResponse(
+  input: Parameters<ClickClackClient["createChannel"]>[1],
+): ClickClackChannel {
+  const response: ClickClackChannel = {
+    id: "chn_discussion",
+    route_id: "discussion-route",
+    workspace_id: "wsp_team",
+    ...input,
+    kind: "public",
+    created_at: "2026-07-19T00:00:00.000Z",
+  };
+  Reflect.deleteProperty(response, "display_title");
+  return response;
+}
+
 describe("ClickClack discussion service", () => {
   it("matches the Control UI session URL contract vectors", () => {
     for (const testCase of SESSION_URL_CONTRACT_CASES) {
@@ -149,7 +165,89 @@ describe("ClickClack discussion service", () => {
       external_ref: testExternalRef(sessionKey),
       external_url: "https://control.example/control/chat/main",
       sidebar_section: "Projects",
+      display_title: "Release Planning",
     });
+  });
+
+  it("clears display_title for fallback labels", async () => {
+    const harness = createHarness({});
+    const sessionKey = "agent:main:untitled";
+
+    await harness.service.open(sessionKey);
+
+    expect(harness.createChannel).toHaveBeenCalledWith(
+      "wsp_team",
+      expect.objectContaining({
+        name: fallbackDiscussionLabel(sessionKey, "main"),
+        display_title: "",
+      }),
+    );
+  });
+
+  it("truncates display_title by Unicode code point", async () => {
+    const harness = createHarness({ label: "😀".repeat(201) });
+
+    await harness.service.open("agent:main:long-title");
+
+    expect(harness.createChannel).toHaveBeenCalledWith(
+      "wsp_team",
+      expect.objectContaining({ display_title: "😀".repeat(200) }),
+    );
+  });
+
+  it("records display_title confirmation only when create responses include it", async () => {
+    const modern = createHarness({ label: "Confirmed title" });
+    await modern.service.open("agent:main:confirmed-title");
+    expect(modern.store.lookup("agent:main:confirmed-title")).toMatchObject({
+      displayTitle: "Confirmed title",
+    });
+
+    const legacy = createHarness({ label: "Unconfirmed title" });
+    vi.mocked(legacy.createChannel).mockImplementationOnce(async (_workspaceId, input) =>
+      legacyCreateResponse(input),
+    );
+    await legacy.service.open("agent:main:unconfirmed-title");
+    expect(legacy.store.lookup("agent:main:unconfirmed-title")).toMatchObject({
+      displayTitle: undefined,
+    });
+  });
+
+  it("backfills an unchanged title after a sibling confirms server support", async () => {
+    const harness = createHarness({ label: "Needs Backfill" });
+    const sessionKey = "agent:main:needs-backfill";
+    vi.mocked(harness.createChannel).mockImplementationOnce(async (_workspaceId, input) =>
+      legacyCreateResponse(input),
+    );
+    await harness.service.open(sessionKey);
+
+    harness.setSessionEntry({ label: "Confirmed Sibling" });
+    await harness.service.open("agent:main:confirmed-sibling");
+    expect(harness.store.lookup("agent:main:confirmed-sibling")).toMatchObject({
+      displayTitle: "Confirmed Sibling",
+    });
+
+    harness.updateChannel.mockClear();
+    harness.setSessionEntry({ label: "Needs Backfill" });
+    await harness.service.reconcile(sessionKey);
+
+    expect(harness.updateChannel).toHaveBeenCalledWith("chn_discussion", {
+      display_title: "Needs Backfill",
+    });
+    expect(harness.store.lookup(sessionKey)).toMatchObject({ displayTitle: "Needs Backfill" });
+  });
+
+  it("does not retry an unchanged title without server capability confirmation", async () => {
+    const harness = createHarness({ label: "Legacy title" });
+    const sessionKey = "agent:main:legacy-title-no-retry";
+    vi.mocked(harness.createChannel).mockImplementationOnce(async (_workspaceId, input) =>
+      legacyCreateResponse(input),
+    );
+    await harness.service.open(sessionKey);
+
+    harness.updateChannel.mockClear();
+    await harness.service.reconcile(sessionKey);
+
+    expect(harness.updateChannel).not.toHaveBeenCalled();
   });
 
   it("pins the configured default for global keys and preserves qualified owners", async () => {
@@ -255,6 +353,7 @@ describe("ClickClack discussion service", () => {
     await harness.service.reconcile(sessionKey);
     expect(harness.updateChannel).toHaveBeenLastCalledWith("chn_discussion", {
       archived: true,
+      display_title: "Renamed Session",
       name: "renamed-session",
       sidebar_section: "Incidents",
     });
@@ -272,6 +371,21 @@ describe("ClickClack discussion service", () => {
       archived: true,
     });
     expect(await harness.service.info(sessionKey)).toEqual({ state: "available" });
+  });
+
+  it("renames a fallback discussion when displayName arrives", async () => {
+    const harness = createHarness({});
+    const sessionKey = "agent:main:generated-title";
+    await harness.service.open(sessionKey);
+
+    harness.setSessionEntry({ displayName: "Generated Session Title" });
+    await harness.service.reconcile(sessionKey);
+
+    expect(harness.updateChannel).toHaveBeenLastCalledWith("chn_discussion", {
+      display_title: "Generated Session Title",
+      name: "generated-session-title",
+    });
+    expect(harness.store.lookup(sessionKey)).toMatchObject({ label: "Generated Session Title" });
   });
 
   it("does not return a binding removed while info or open reconciles a deleted session", async () => {
@@ -328,7 +442,7 @@ describe("ClickClack discussion service", () => {
     expect(harness.store.lookup(sessionKey)).toBeUndefined();
   });
 
-  it("uses the short session fallback when a label slug already exists", async () => {
+  it("suffixes a desired name when its slug already exists", async () => {
     const harness = createHarness({ label: "Release Planning" });
     vi.mocked(harness.channels).mockResolvedValue([
       {
@@ -346,39 +460,30 @@ describe("ClickClack discussion service", () => {
 
     expect(harness.createChannel).toHaveBeenCalledWith(
       "wsp_team",
-      expect.objectContaining({ name: fallbackDiscussionLabel("agent:main:duplicate-label") }),
+      expect.objectContaining({ name: "release-planning-2" }),
     );
   });
 
-  it("adds a deterministic suffix when both the label and hash fallback are occupied", async () => {
+  it("falls back after exhausting desired-name suffixes through 20", async () => {
     const harness = createHarness({ label: "Release Planning" });
     const sessionKey = "agent:main:duplicate-label";
-    vi.mocked(harness.channels).mockResolvedValue([
-      {
-        id: "chn_existing_label",
-        route_id: "existing-label-route",
+    vi.mocked(harness.channels).mockResolvedValue(
+      Array.from({ length: 20 }, (_, index) => ({
+        id: `chn_existing_${index}`,
+        route_id: `existing-route-${index}`,
         workspace_id: "wsp_team",
-        name: "release-planning",
+        name: index === 0 ? "release-planning" : `release-planning-${index + 1}`,
         kind: "public",
         ...MANAGED_CONTRACT_FIELDS,
         created_at: "2026-07-19T00:00:00.000Z",
-      },
-      {
-        id: "chn_existing_hash",
-        route_id: "existing-hash-route",
-        workspace_id: "wsp_team",
-        name: fallbackDiscussionLabel(sessionKey),
-        kind: "public",
-        ...MANAGED_CONTRACT_FIELDS,
-        created_at: "2026-07-19T00:00:00.000Z",
-      },
-    ]);
+      })),
+    );
 
     await harness.service.open(sessionKey);
 
     expect(harness.createChannel).toHaveBeenCalledWith(
       "wsp_team",
-      expect.objectContaining({ name: `${fallbackDiscussionLabel(sessionKey)}-2` }),
+      expect.objectContaining({ name: fallbackDiscussionLabel(sessionKey, "main") }),
     );
   });
 
@@ -410,7 +515,7 @@ describe("ClickClack discussion service", () => {
     expect(harness.createChannel).toHaveBeenCalledTimes(2);
     expect(harness.createChannel).toHaveBeenLastCalledWith(
       "wsp_team",
-      expect.objectContaining({ name: fallbackDiscussionLabel(sessionKey) }),
+      expect.objectContaining({ name: "release-planning-2" }),
     );
   });
 
@@ -444,7 +549,7 @@ describe("ClickClack discussion service", () => {
     expect(harness.updateChannel).toHaveBeenCalledTimes(2);
     expect(harness.updateChannel).toHaveBeenLastCalledWith(
       "chn_discussion",
-      expect.objectContaining({ name: fallbackDiscussionLabel(sessionKey) }),
+      expect.objectContaining({ name: "renamed-2" }),
     );
   });
 

--- a/extensions/clickclack/src/discussions/service.ts
+++ b/extensions/clickclack/src/discussions/service.ts
@@ -30,7 +30,12 @@ import {
   type DiscussionBindingAccountResolution,
 } from "./eligibility.js";
 import { getClickClackDiscussionInstallationId } from "./installation.js";
-import { discussionCredentialFingerprint, resolveDiscussionLabel } from "./naming.js";
+import {
+  discussionCredentialFingerprint,
+  fallbackDiscussionLabel,
+  resolveDiscussionLabel,
+  truncateDiscussionDisplayTitle,
+} from "./naming.js";
 import {
   clearClickClackDiscussionChannelRevoked,
   isClickClackDiscussionChannelRevoked,
@@ -332,7 +337,10 @@ export class ClickClackDiscussionService {
     }
     const archived = entry ? entry.archivedAt !== undefined : true;
     const deleted = entry === undefined;
-    const label = entry ? resolveDiscussionLabel(entry.label, sessionKey) : binding.label;
+    const fallback = fallbackDiscussionLabel(sessionKey, binding.agentId);
+    const label = entry
+      ? resolveDiscussionLabel(entry, sessionKey, binding.agentId)
+      : binding.label;
     const section = entry?.category?.trim() || account.discussions.section;
     // Binding ownership follows global session routing; unscoped link decoration
     // follows the ClickClack account agent so reconciliation keeps the URL stable.
@@ -346,6 +354,7 @@ export class ClickClackDiscussionService {
       ) ?? "";
     const patch: {
       archived?: boolean;
+      display_title?: string;
       external_url?: string;
       name?: string;
       sidebar_section?: string;
@@ -354,6 +363,26 @@ export class ClickClackDiscussionService {
       patch.archived = archived;
     }
     const labelChanged = label !== binding.label;
+    const desiredDisplayTitle = label === fallback ? "" : truncateDiscussionDisplayTitle(label);
+    // Confirmation piggybacks on normal opens/renames, so a workspace backfills after any channel
+    // round-trips a title. Legacy servers never confirm, avoiding retry spam; a fully dormant
+    // workspace may wait until its next titled open. Scoped to this binding's server+account so a
+    // confirmation from a previous deployment cannot arm backfill against a legacy server.
+    const serverSupportsDisplayTitle = this.#store
+      .entries()
+      .some(
+        ({ binding: candidate }) =>
+          candidate.displayTitle !== undefined &&
+          candidate.serverBaseUrl === binding.serverBaseUrl &&
+          candidate.accountId === binding.accountId,
+      );
+    const shouldBackfillDisplayTitle =
+      desiredDisplayTitle !== "" &&
+      binding.displayTitle !== desiredDisplayTitle &&
+      serverSupportsDisplayTitle;
+    if (labelChanged || shouldBackfillDisplayTitle) {
+      patch.display_title = desiredDisplayTitle;
+    }
     if (section !== binding.section) {
       patch.sidebar_section = section;
     }
@@ -367,20 +396,22 @@ export class ClickClackDiscussionService {
       return;
     }
     const client = this.#clientFactory(account);
+    let updated: Awaited<ReturnType<ClickClackClient["updateChannel"]>>;
     if (labelChanged) {
-      await this.#withChannelMutationLock(async () => {
+      updated = await this.#withChannelMutationLock(async () => {
         for (let attempt = 0; attempt < CHANNEL_NAME_MUTATION_ATTEMPTS; attempt += 1) {
           patch.name = await resolveAvailableChannelName({
             client,
             workspaceId: binding.workspaceId,
             label,
             sessionKey,
+            agentId: binding.agentId,
             ownChannelId: binding.channelId,
           });
           try {
-            const updated = await client.updateChannel(binding.channelId, patch);
-            assertChannelPatch(updated, patch);
-            return;
+            const renamed = await client.updateChannel(binding.channelId, patch);
+            assertChannelPatch(renamed, patch);
+            return renamed;
           } catch (error) {
             if (
               !isClickClackChannelNameConflict(error) ||
@@ -390,16 +421,24 @@ export class ClickClackDiscussionService {
             }
           }
         }
+        throw new Error("ClickClack discussion channel name retries were exhausted");
       });
     } else {
-      const updated = await client.updateChannel(binding.channelId, patch);
+      updated = await client.updateChannel(binding.channelId, patch);
       assertChannelPatch(updated, patch);
     }
     if (deleted) {
       this.#revokeAndDeleteBinding(sessionKey, binding);
       return;
     }
-    this.#store.set(sessionKey, { ...binding, archived, externalUrl, label, section });
+    this.#store.set(sessionKey, {
+      ...binding,
+      archived,
+      externalUrl,
+      label,
+      section,
+      displayTitle: "display_title" in updated ? updated.display_title : undefined,
+    });
   }
 
   async #reconcilePendingOpen(

--- a/extensions/clickclack/src/http-client.ts
+++ b/extensions/clickclack/src/http-client.ts
@@ -229,6 +229,7 @@ export function createClickClackClient(options: ClientOptions) {
         external_ref: string;
         external_url?: string;
         sidebar_section: string;
+        display_title?: string;
       },
     ): Promise<ClickClackChannel> => {
       const data = await request<{ channel: ClickClackChannel }>(
@@ -246,6 +247,7 @@ export function createClickClackClient(options: ClientOptions) {
         external_ref?: string;
         external_url?: string;
         sidebar_section?: string;
+        display_title?: string;
       },
     ): Promise<ClickClackChannel> => {
       const data = await request<{ channel: ClickClackChannel }>(

--- a/extensions/clickclack/src/types.ts
+++ b/extensions/clickclack/src/types.ts
@@ -146,6 +146,7 @@ export type ClickClackChannel = {
   external_ref?: string;
   external_url?: string;
   sidebar_section?: string;
+  display_title?: string;
   archived?: boolean;
   created_at: string;
 };


### PR DESCRIPTION
Part of #114685.

## What Problem This Solves

ClickClack discussion channels are named `s-<32 hex>` because channel creation consulted only `entry.label`, which represents an explicit rename. Automatic session titles in `displayName` were ignored, slug collisions dropped directly to the hash, and the raw title was never sent to the server.

## Why This Change Was Made

The title selection chain is now `label` -> `displayName` -> `subject`, mirroring the entry-only prefix of `deriveSessionTitle`. The fallback is the more compact `s-<agent>-<8 hex>`, and slug collisions receive deterministic `-2` through `-20` suffixes before falling back.

Channel creation sends the new ClickClack `display_title` field with version-skew-tolerant contract assertions: older servers that omit the field remain compatible, while a present-but-wrong value fails closed. Reconciliation backfills titles after the server confirms support, scoped per server and account, and bindings persist the confirmed title.

## User Impact

Sidebars on ClickClack team instances show session titles instead of hashes. Existing hash-named channels self-heal through reconciliation renames. The companion server feature, openclaw/clickclack#132, has landed.

## Evidence

- `node scripts/run-vitest.mjs extensions/clickclack` -> 22 files, 264 tests passed.
- Four autoreview rounds ended clean with "patch is correct."
- The check-changed classifier was clean for the changed files.
