### PR TITLE
feat(codex): add workspaceWriteNetworkAccess flag for workspace-write sandbox network control

### DIFF
--- a/extensions/codex/src/app-server/config-contracts.ts
+++ b/extensions/codex/src/app-server/config-contracts.ts
@@ -212,7 +212,7 @@ export type CodexAppServerRuntimeOptions = {
   approvalsReviewer: CodexAppServerApprovalsReviewer;
   serviceTier?: CodexServiceTier | null;
   networkProxy?: ResolvedCodexAppServerNetworkProxyConfig;
-  workspaceWriteNetworkAccess: boolean;
+  workspaceWriteNetworkAccess?: boolean;
 };
 
 export type CodexModelBackedReviewerContext = {

--- a/extensions/codex/src/app-server/config-contracts.ts
+++ b/extensions/codex/src/app-server/config-contracts.ts
@@ -212,6 +212,7 @@ export type CodexAppServerRuntimeOptions = {
   approvalsReviewer: CodexAppServerApprovalsReviewer;
   serviceTier?: CodexServiceTier | null;
   networkProxy?: ResolvedCodexAppServerNetworkProxyConfig;
+  workspaceWriteNetworkAccess: boolean;
 };
 
 export type CodexModelBackedReviewerContext = {
@@ -256,5 +257,6 @@ export type CodexPluginConfig = {
     networkProxy?: CodexAppServerNetworkProxyConfig;
     defaultWorkspaceDir?: string;
     experimental?: CodexAppServerExperimentalConfig;
+    workspaceWriteNetworkAccess?: boolean;
   };
 };

--- a/extensions/codex/src/app-server/config-parsing.ts
+++ b/extensions/codex/src/app-server/config-parsing.ts
@@ -190,6 +190,7 @@ const codexPluginConfigSchema = z
         networkProxy: codexAppServerNetworkProxySchema.optional(),
         defaultWorkspaceDir: z.string().optional(),
         experimental: codexAppServerExperimentalSchema.optional(),
+        workspaceWriteNetworkAccess: z.boolean().optional(),
       })
       .strict()
       .optional(),

--- a/extensions/codex/src/app-server/config-runtime.ts
+++ b/extensions/codex/src/app-server/config-runtime.ts
@@ -296,6 +296,7 @@ export function resolveCodexAppServerRuntimeOptions(
       (policyMode === "guardian" ? "auto_review" : "user"),
     ...(serviceTier ? { serviceTier } : {}),
     ...resolveCodexAppServerNetworkProxy(config.networkProxy, resolvedSandbox),
+    workspaceWriteNetworkAccess: config.workspaceWriteNetworkAccess === true,
   };
 }
 
@@ -490,6 +491,7 @@ export function codexAppServerStartOptionsKey(
 export function codexSandboxPolicyForTurn(
   mode: CodexAppServerSandboxMode,
   cwd: string,
+  workspaceWriteNetworkAccess = false,
 ): CodexSandboxPolicy {
   if (mode === "danger-full-access") {
     return { type: "dangerFullAccess" };
@@ -500,7 +502,7 @@ export function codexSandboxPolicyForTurn(
   return {
     type: "workspaceWrite",
     writableRoots: [cwd],
-    networkAccess: false,
+    networkAccess: workspaceWriteNetworkAccess,
     excludeTmpdirEnvVar: false,
     excludeSlashTmp: false,
   };

--- a/extensions/codex/src/app-server/turn-params.ts
+++ b/extensions/codex/src/app-server/turn-params.ts
@@ -53,7 +53,11 @@ export function buildTurnStartParams(
       : {
           sandboxPolicy:
             options.sandboxPolicy ??
-            codexSandboxPolicyForTurn(options.appServer.sandbox, options.cwd),
+            codexSandboxPolicyForTurn(
+              options.appServer.sandbox,
+              options.cwd,
+              options.appServer.workspaceWriteNetworkAccess,
+            ),
         }),
     ...(modelSelection
       ? { model: modelSelection.model, personality: CODEX_NATIVE_PERSONALITY_NONE }

--- a/extensions/codex/src/conversation-binding.ts
+++ b/extensions/codex/src/conversation-binding.ts
@@ -872,7 +872,13 @@ async function runBoundTurn(params: {
         approvalsReviewer: modelScopedRuntime.approvalsReviewer,
         ...(useStickyNetworkProfile
           ? {}
-          : { sandboxPolicy: codexSandboxPolicyForTurn(sandbox, workspaceDir) }),
+          : {
+              sandboxPolicy: codexSandboxPolicyForTurn(
+                sandbox,
+                workspaceDir,
+                modelScopedRuntime.workspaceWriteNetworkAccess,
+              ),
+            }),
         ...(modelSelection?.model ? { model: modelSelection.model } : {}),
         personality: CODEX_NATIVE_PERSONALITY_NONE,
         ...(serviceTier ? { serviceTier } : {}),


### PR DESCRIPTION
## What Problem This Solves

Fleet operators running Codex agent turns in `workspace-write` sandbox mode currently have no way to grant network access without escalating to `danger-full-access`. The workspace-write sandbox hardcodes `networkAccess: false`, which blocks legitimate local-DB and Unix-socket workflows (e.g., connecting to a local PostgreSQL instance or Redis socket). Operators are forced to choose between "no network at all" and "full unrestricted access," with nothing in between.

This creates a practical enforcement gap: detect-and-log write-ban enforcement is insufficient when Codex turns run under `danger-full-access` (which bypasses writable-root boundaries entirely). The fix introduces a first-class config key so operators can keep the writable-root boundary of `workspace-write` while selectively enabling network egress — closing the gap without sacrificing filesystem safety.

## Summary

Add config key `appServer.workspaceWriteNetworkAccess` that controls network access in workspace-write sandbox mode.

- **Default: `false`** — workspace-write remains `networkAccess: false` (no behavior change)
- **Explicit `true`** — workspace-write sandbox gets `networkAccess: true`
- **`danger-full-access` and `read-only` modes are unchanged**
- **No `networkProxy` involvement** — this flag only controls the sandbox network policy
- Legacy `[sandbox_workspace_write].writable_roots` remains honored

## Config path

```json
{
  "appServer": {
    "sandbox": "workspace-write",
    "workspaceWriteNetworkAccess": true
  }
}
```

## Changes (5 files, +18 −3)

| File | Change |
|---|---|
| `config-contracts.ts` | +`workspaceWriteNetworkAccess: boolean` on `CodexAppServerRuntimeOptions`; +optional on plugin config type |
| `config-parsing.ts` | +`workspaceWriteNetworkAccess: z.boolean().optional()` in Zod schema |
| `config-runtime.ts` | Resolves to `config.workspaceWriteNetworkAccess === true` (defaults false); `codexSandboxPolicyForTurn()` gains 3rd param |
| `turn-params.ts` | Passes `workspaceWriteNetworkAccess` to `codexSandboxPolicyForTurn` |
| `conversation-binding.ts` | Passes `workspaceWriteNetworkAccess` in sticky-network-profile bypass path |

## Evidence

### Local focused tests (on latest upstream main `52e519220ce`)

| Check | Result |
|---|---|
| `vitest.extension-codex-app-server-runtime` (16 files, 628 tests) | ✅ 628/628 pass (32.3s) |
| `vitest.extension-codex-app-server-attempt` (1 file, 117 tests) | ✅ 117/117 pass (55.1s) |
| `vitest.extension-codex-surface` (25 files, 595 tests) | ✅ 595/595 pass (29.6s) |
| config.test.ts re-run on rebased main (126 tests) | ✅ 126/126 pass (9.0s) |
| oxlint on 5 changed files | ✅ 0 errors, 0 warnings |
| `scripts/check.mjs` | ✅ exit 0 |

**Total: 1466 focused tests pass, 0 failures.**

### Diff integrity

- Diff applies cleanly on upstream main `52e519220ce` (rebased from `1695854877f`; 0 of 5 files touched in the 34 commits between bases).
- No `networkProxy` code paths touched — verified by diff inspection.
- No local live install, node_modules hotpatch, or gateway restart was performed.

### Pending CI

- Full `tsc --noEmit` OOM'd on local 16GB Mac Studio (pre-existing machine limit). CI pipeline will have adequate RAM.
- Generated JSON schema / AJV validators are produced by the normal build pipeline from the Zod schema in `config-parsing.ts`.