### PR TITLE
fix(imessage): render complete poll selections [AI-assisted]

### DIFF
--- a/extensions/imessage/src/monitor/monitor-provider.ts
+++ b/extensions/imessage/src/monitor/monitor-provider.ts
@@ -728,7 +728,7 @@ export async function monitorIMessageProvider(opts: MonitorIMessageOpts = {}): P
   function resolveIMessageInboundBodyText(message: IMessagePayload) {
     // Native poll balloons carry only a 0xFFFD placeholder in `text`; render the
     // decoded poll (question/options/votes) so the agent sees the actual poll.
-    const pollBody = message.poll ? renderIMessagePollBody(message.poll) : null;
+    const pollBody = message.poll ? renderIMessagePollBody(message.poll, message.sender) : null;
     const messageText = (pollBody ?? message.text ?? "").trim();
     const attachments = includeAttachments ? (message.attachments ?? []) : [];
     const effectiveAttachmentRoots = remoteHost ? remoteAttachmentRoots : attachmentRoots;

--- a/extensions/imessage/src/monitor/poll-render.test-support.ts
+++ b/extensions/imessage/src/monitor/poll-render.test-support.ts
@@ -49,6 +49,67 @@ describe("renderIMessagePollBody", () => {
     expect(out).toContain("Blue");
   });
 
+  it("renders the full selection snapshot instead of a stale singular vote", () => {
+    const out = renderIMessagePollBody({
+      kind: "vote",
+      vote: {
+        participant: "+12065550123",
+        option_id: "a",
+        option_text: "Lobster",
+        event_type: "selected",
+      },
+      votes: [
+        {
+          participant: "+12065550123",
+          option_id: "a",
+          option_text: "Lobster",
+          event_type: "selected",
+        },
+        {
+          participant: "+12065550123",
+          option_id: "b",
+          option_text: "Also lobster",
+          event_type: "selected",
+        },
+      ],
+    });
+
+    expect(out).toContain('currently selected "Lobster", "Also lobster"');
+    expect(out).not.toContain('voted for "Lobster"');
+  });
+
+  it("does not report a remaining selection as a new vote", () => {
+    const out = renderIMessagePollBody({
+      kind: "vote",
+      vote: {
+        participant: "+12065550123",
+        option_id: "b",
+        option_text: "Beta",
+        event_type: "selected",
+      },
+      votes: [
+        {
+          participant: "+12065550123",
+          option_id: "b",
+          option_text: "Beta",
+          event_type: "selected",
+        },
+      ],
+    });
+
+    expect(out).toContain('currently selected "Beta"');
+    expect(out).not.toContain('voted for "Beta"');
+  });
+
+  it("renders an empty selection snapshot", () => {
+    const out = renderIMessagePollBody({
+      kind: "vote",
+      votes: [],
+    });
+
+    expect(out).toContain("no options currently selected");
+  });
+
   it("returns null for a poll with no options and no vote", () => {
     expect(renderIMessagePollBody({ kind: "created", options: [] })).toBeNull();
   });

--- a/extensions/imessage/src/monitor/poll-render.test-support.ts
+++ b/extensions/imessage/src/monitor/poll-render.test-support.ts
@@ -101,13 +101,16 @@ describe("renderIMessagePollBody", () => {
     expect(out).not.toContain('voted for "Beta"');
   });
 
-  it("renders an empty selection snapshot", () => {
-    const out = renderIMessagePollBody({
-      kind: "vote",
-      votes: [],
-    });
+  it("scopes an empty selection snapshot to the event sender", () => {
+    const out = renderIMessagePollBody(
+      {
+        kind: "vote",
+        votes: [],
+      },
+      "+12065550123",
+    );
 
-    expect(out).toContain("no options currently selected");
+    expect(out).toBe("\u{1F4CA} Poll selections: +12065550123 currently selected no options");
   });
 
   it("returns null for a poll with no options and no vote", () => {

--- a/extensions/imessage/src/monitor/poll-render.ts
+++ b/extensions/imessage/src/monitor/poll-render.ts
@@ -6,7 +6,7 @@
 // numbered options so it can vote by 1-based index via the poll-vote action.
 import type { IMessagePoll } from "./types.js";
 
-export function renderIMessagePollBody(poll: IMessagePoll): string | null {
+export function renderIMessagePollBody(poll: IMessagePoll, sender?: string | null): string | null {
   const options = poll.options ?? [];
 
   // Vote update: prefer imsg's full selection snapshot. Its singular `vote`
@@ -14,12 +14,18 @@ export function renderIMessagePollBody(poll: IMessagePoll): string | null {
   // changed. Older imsg builds without `votes` still use the singular fallback.
   if (poll.kind === "vote" || (poll.vote && options.length === 0)) {
     if (poll.votes) {
+      // An empty snapshot carries no vote-level participant, but it still only
+      // describes the event sender's selections—not the state of the full poll.
+      const snapshotParticipant =
+        poll.votes.find((vote) => vote.participant?.trim())?.participant?.trim() ||
+        sender?.trim() ||
+        "someone";
       const selectionsByParticipant = new Map<string, string[]>();
       for (const vote of poll.votes) {
         if (vote.event_type === "removed") {
           continue;
         }
-        const who = vote.participant?.trim() || "someone";
+        const who = vote.participant?.trim() || snapshotParticipant;
         const what = vote.option_text?.trim() || vote.option_id || "an option";
         const selections = selectionsByParticipant.get(who) ?? [];
         if (!selections.includes(what)) {
@@ -29,7 +35,7 @@ export function renderIMessagePollBody(poll: IMessagePoll): string | null {
       }
 
       if (selectionsByParticipant.size === 0) {
-        return "\u{1F4CA} Poll selections: no options currently selected";
+        return `\u{1F4CA} Poll selections: ${snapshotParticipant} currently selected no options`;
       }
 
       const snapshots = Array.from(selectionsByParticipant, ([who, selections]) => {
@@ -43,7 +49,7 @@ export function renderIMessagePollBody(poll: IMessagePoll): string | null {
     if (!vote) {
       return "\u{1F4CA} Poll vote received";
     }
-    const who = vote.participant?.trim() || "someone";
+    const who = vote.participant?.trim() || sender?.trim() || "someone";
     const what = vote.option_text?.trim() || vote.option_id || "an option";
     const verb = vote.event_type === "removed" ? "removed their vote for" : "voted for";
     return `\u{1F4CA} Poll vote: ${who} ${verb} "${what}"`;

--- a/extensions/imessage/src/monitor/poll-render.ts
+++ b/extensions/imessage/src/monitor/poll-render.ts
@@ -9,8 +9,36 @@ import type { IMessagePoll } from "./types.js";
 export function renderIMessagePollBody(poll: IMessagePoll): string | null {
   const options = poll.options ?? [];
 
-  // Vote update: surface who voted for what so the agent can follow tallies.
+  // Vote update: prefer imsg's full selection snapshot. Its singular `vote`
+  // field is only the first decoded entry, not necessarily the option that
+  // changed. Older imsg builds without `votes` still use the singular fallback.
   if (poll.kind === "vote" || (poll.vote && options.length === 0)) {
+    if (poll.votes) {
+      const selectionsByParticipant = new Map<string, string[]>();
+      for (const vote of poll.votes) {
+        if (vote.event_type === "removed") {
+          continue;
+        }
+        const who = vote.participant?.trim() || "someone";
+        const what = vote.option_text?.trim() || vote.option_id || "an option";
+        const selections = selectionsByParticipant.get(who) ?? [];
+        if (!selections.includes(what)) {
+          selections.push(what);
+        }
+        selectionsByParticipant.set(who, selections);
+      }
+
+      if (selectionsByParticipant.size === 0) {
+        return "\u{1F4CA} Poll selections: no options currently selected";
+      }
+
+      const snapshots = Array.from(selectionsByParticipant, ([who, selections]) => {
+        const quotedSelections = selections.map((selection) => `"${selection}"`).join(", ");
+        return `${who} currently selected ${quotedSelections}`;
+      });
+      return `\u{1F4CA} Poll selections: ${snapshots.join("; ")}`;
+    }
+
     const vote = poll.vote;
     if (!vote) {
       return "\u{1F4CA} Poll vote received";


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users with multi-select iMessage polls would receive an
incorrect agent-visible vote notification when another participant selected a
second option or removed one of several selections.

`imsg` exposes vote updates as full selected-option snapshots. Its singular
`poll.vote` field is only the first decoded entry, so treating it as the option
that just changed can falsely report the first or remaining option as a new
vote.

## Why This Change Was Made

When `poll.votes` is present, the iMessage monitor now renders the complete
current selection snapshot, grouped by participant. The singular `poll.vote`
path remains as a compatibility fallback for older `imsg` builds that do not
emit the plural field.

Outbound poll creation and voting are unchanged.

## User Impact

Agents now see every currently selected option instead of a false single-option
delta. Removing one selection no longer looks like a new vote for whichever
option remains.

## Evidence

- Reproduced against current `main` with a fixture matching `imsg`'s documented
  snapshot contract:
  - `poll.votes = ["Lobster", "Also lobster"]`
  - stale compatibility field: `poll.vote = "Lobster"`
  - before: `📊 Poll vote: … voted for "Lobster"`
  - after: both current selections are rendered
- `node scripts/run-vitest.mjs extensions/imessage/src/monitor.behavior.test.ts`
  — 173 tests passed.
- Targeted type-aware oxlint passed for both changed files.
- Targeted `oxfmt --check` passed.
- `git diff origin/main...HEAD --check` passed.
- The required repo-local `autoreview` was invoked, but its preflight stopped
  because TruffleHog is not installed on this host. No bypass or tool install
  was performed.

AI-assisted with Codex. I reviewed the resulting behavior and tests.
### Live exact-head proof (2026-07-28)

Verified against a real native Messages poll on macOS 26.5.1 with `imsg` 0.13.3. Participant identity and local message identifiers were redacted before posting.

The Messages UI produced these live decoded snapshots:

```text
multi-select:
  poll.vote  = Beta
  poll.votes = [Beta, Alpha]

after deselecting Alpha:
  poll.vote  = Beta
  poll.votes = [Beta]
```

The second event is the false-delta regression: the singular field still names the remaining Beta selection, so rendering it as the changed option would incorrectly report a new Beta vote.

Running those redacted live payloads through the submitted head `f4db17073e7c86d13a7d00862178620cd8c9468e` produced:

```text
📊 Poll selections: participant-1 currently selected "Beta", "Alpha"
📊 Poll selections: participant-1 currently selected "Beta"
```

This confirms the external contract directly: when present, `poll.votes` is the participant's complete current selection snapshot, while `poll.vote` is only a lossy first-entry compatibility projection. Hosted CI for this head is green.
