### PR TITLE
fix(discord): reject mismatched reply context

### DIFF
--- a/extensions/discord/src/monitor/message-handler.hydration.test.ts
+++ b/extensions/discord/src/monitor/message-handler.hydration.test.ts
@@ -172,7 +172,21 @@ describe("hydrateDiscordMessageIfNeeded", () => {
     const rest = createFakeRestClient([
       createReferencedMessagePayload("the directly fetched message"),
     ]);
-    const message = new Message(client, createDefaultReplyPayload());
+    const message = new Message(
+      client,
+      createDefaultReplyPayload({
+        content: "<@bot> ok do it",
+        mentions: [
+          {
+            id: "bot",
+            username: "openclaw",
+            global_name: null,
+            discriminator: "0",
+            avatar: null,
+          },
+        ],
+      }),
+    );
 
     const { message: hydrated } = await hydrateDiscordMessageIfNeeded({
       client: { rest },
@@ -200,6 +214,57 @@ describe("hydrateDiscordMessageIfNeeded", () => {
 
     expect(result.ctxPayload.ReplyToId).toBe("m0");
     expect(result.ctxPayload.ReplyToBody).toBe("the directly fetched message");
+  });
+
+  it("replaces a mismatched nested reply with the canonical referenced message", async () => {
+    const client = createInternalTestClient();
+    const rest = createFakeRestClient([
+      createReferencedMessagePayload("the canonical reply target"),
+    ]);
+    const message = new Message(
+      client,
+      createDefaultReplyPayload({
+        referenced_message: createMessagePayload({
+          id: "stale-message",
+          content: "unrelated older context",
+        }),
+      }),
+    );
+
+    const { message: hydrated } = await hydrateDiscordMessageIfNeeded({
+      client: { rest },
+      message,
+      messageChannelId: "c1",
+    });
+
+    expect(rest.calls.map((call) => call.path)).toEqual(["/channels/c1/messages/m0"]);
+    expect(hydrated.referencedMessage?.id).toBe("m0");
+    expect(hydrated.referencedMessage?.content).toBe("the canonical reply target");
+  });
+
+  it("discards a mismatched nested reply when canonical hydration fails", async () => {
+    const client = createInternalTestClient();
+    const rest = createFakeRestClient();
+    rest.get = vi.fn(async () => {
+      throw Object.assign(new Error("Missing Access"), { status: 403 });
+    });
+    const message = new Message(
+      client,
+      createDefaultReplyPayload({
+        referenced_message: createMessagePayload({
+          id: "stale-message",
+          content: "unrelated older context",
+        }),
+      }),
+    );
+
+    const { message: hydrated } = await hydrateDiscordMessageIfNeeded({
+      client: { rest },
+      message,
+      messageChannelId: "c1",
+    });
+
+    expect(hydrated.referencedMessage).toBeNull();
   });
 
   it("uses the referenced channel when directly hydrating a cross-channel reply", async () => {

--- a/extensions/discord/src/monitor/message-handler.hydration.test.ts
+++ b/extensions/discord/src/monitor/message-handler.hydration.test.ts
@@ -240,6 +240,25 @@ describe("hydrateDiscordMessageIfNeeded", () => {
     expect(rest.calls.map((call) => call.path)).toEqual(["/channels/c1/messages/m0"]);
     expect(hydrated.referencedMessage?.id).toBe("m0");
     expect(hydrated.referencedMessage?.content).toBe("the canonical reply target");
+
+    const ctx = await createBaseDiscordMessageContext({
+      message: hydrated,
+      author: hydrated.author,
+      baseText: hydrated.content,
+      messageText: hydrated.content,
+    });
+    const result = await buildDiscordMessageProcessContext({
+      ctx,
+      text: hydrated.content,
+      mediaList: [],
+    });
+    if (!result) {
+      throw new Error("expected a built Discord message context");
+    }
+
+    expect(result.ctxPayload.ReplyToId).toBe("m0");
+    expect(result.ctxPayload.ReplyToBody).toBe("the canonical reply target");
+    expect(result.ctxPayload.ReplyToBody).not.toContain("unrelated older context");
   });
 
   it("discards a mismatched nested reply when canonical hydration fails", async () => {
@@ -265,6 +284,24 @@ describe("hydrateDiscordMessageIfNeeded", () => {
     });
 
     expect(hydrated.referencedMessage).toBeNull();
+
+    const ctx = await createBaseDiscordMessageContext({
+      message: hydrated,
+      author: hydrated.author,
+      baseText: hydrated.content,
+      messageText: hydrated.content,
+    });
+    const result = await buildDiscordMessageProcessContext({
+      ctx,
+      text: hydrated.content,
+      mediaList: [],
+    });
+    if (!result) {
+      throw new Error("expected a built Discord message context");
+    }
+
+    expect(result.ctxPayload.ReplyToId).toBeUndefined();
+    expect(result.ctxPayload.ReplyToBody).toBeUndefined();
   });
 
   it("uses the referenced channel when directly hydrating a cross-channel reply", async () => {

--- a/extensions/discord/src/monitor/message-handler.hydration.ts
+++ b/extensions/discord/src/monitor/message-handler.hydration.ts
@@ -172,18 +172,32 @@ function shouldHydrateDiscordMessagePayload(params: { message: Message }) {
   return /<@!?\d+>|<@&\d+>|@everyone|@here/u.test(currentText);
 }
 
-function hasMissingReferencedMessagePayload(message: Message): boolean {
+type ReferencedMessagePayloadState = "complete" | "missing" | "invalid";
+
+function resolveReferencedMessagePayloadState(message: Message): ReferencedMessagePayloadState {
   const reference = message.messageReference;
   if (!reference?.message_id) {
-    return false;
+    return "complete";
   }
   if (reference.type != null && reference.type !== MessageReferenceType.Default) {
-    return false;
+    return "complete";
   }
   if (message.type != null && message.type !== MessageType.Reply) {
-    return false;
+    return "complete";
   }
-  return !Object.hasOwn(readMessageRawData(message), "referenced_message");
+  const rawData = readMessageRawData(message);
+  if (!Object.hasOwn(rawData, "referenced_message")) {
+    return "missing";
+  }
+  const referenced = rawData.referenced_message;
+  if (referenced == null) {
+    return "complete";
+  }
+  return typeof referenced === "object" &&
+    typeof referenced.id === "string" &&
+    referenced.id === reference.message_id
+    ? "complete"
+    : "invalid";
 }
 
 async function hydrateDiscordReplyReference(params: {
@@ -191,7 +205,8 @@ async function hydrateDiscordReplyReference(params: {
   message: Message;
   messageChannelId: string;
 }): Promise<Message> {
-  if (!hasMissingReferencedMessagePayload(params.message)) {
+  const payloadState = resolveReferencedMessagePayloadState(params.message);
+  if (payloadState === "complete") {
     return params.message;
   }
   const reference = params.message.messageReference;
@@ -216,6 +231,13 @@ async function hydrateDiscordReplyReference(params: {
     logVerbose(
       `discord: failed to hydrate referenced message ${referencedMessageId}: ${String(err)}`,
     );
+    if (payloadState === "invalid") {
+      // A mismatched nested payload must never become reply context for another message.
+      return mergeFetchedDiscordMessage(params.message, {
+        ...readMessageRawData(params.message),
+        referenced_message: null,
+      } as APIMessage);
+    }
     return params.message;
   }
 }


### PR DESCRIPTION
## Summary

- verify that Discord's nested `referenced_message.id` matches `message_reference.message_id`
- fetch the canonical reply target when the nested payload is missing or mismatched
- clear mismatched reply context if canonical hydration fails, preventing unrelated message text from reaching the model

## What Problem This Solves

Discord reply turns can arrive with stale or mismatched nested referenced-message data. Trusting that payload allows an unrelated older message to be assembled as the current reply context.

This hardens the existing reply hydration path associated with #112650.

## Evidence

- `pnpm test:changed` — 1 shard, 9/9 tests passed
- `pnpm check:changed` — passed (format, policy guards, API contracts, extension and extension-test typechecks, lint, import cycles)
- mandatory autoreview — clean, no actionable findings
- TruffleHog preflight — clean
- After-fix runtime proof on rebased head `21221e103f7d`:
  - `replaces a mismatched nested reply with the canonical referenced message` passed through the real `Message` hydration and `buildDiscordMessageProcessContext` path.
  - The resulting context asserts `ReplyToId === "m0"`, `ReplyToBody === "the canonical reply target"`, and that `ReplyToBody` excludes `"unrelated older context"`.
  - `discards a mismatched nested reply when canonical hydration fails` passed through the same downstream context builder and asserts both `ReplyToId` and `ReplyToBody` are absent.
  - Verbose run: 9/9 passed in the Discord extension shard.
- Contract inspection:
  - The internal `Message.referencedMessage` getter reads `rawData.referenced_message`.
  - Hydration runs in message preflight before `buildDiscordMessageProcessContext`.
  - `resolveReplyContext` consumes only the hydrated `message.referencedMessage`, so clearing an invalid nested payload prevents it from reaching the agent envelope.
- Redacted real-Discord setup proof:
  - Captured a real native reply and two real bot messages from the active Discord channel through OpenClaw's Discord connector.
  - Replayed the captured reply through the patched hydration/context path with the unrelated captured message injected as stale nested context and the real referenced message supplied as the canonical fetch result.
  - Output proved `replyToIdMatchesCanonical: true`, `staleBodyExcluded: true`, and a redacted canonical body digest.
  - Fault-injected canonical fetch failure proved `replyToIdOmitted: true` and `replyToBodyOmitted: true`.

## Release note

Fixed Discord replies occasionally using unrelated stale message context when a referenced-message payload did not match the canonical reply target.
