### PR TITLE
refactor(ui): redesign channels DM access requests, drop channel-health JSON card

### DIFF
--- a/scripts/control-ui-mock-channels.ts
+++ b/scripts/control-ui-mock-channels.ts
@@ -76,6 +76,59 @@ export function buildChannelsStatusMock(baseTime: number) {
   };
 }
 
+export function buildChannelsPairingMock(baseTime: number) {
+  const iso = (offsetMs: number) => new Date(baseTime + offsetMs).toISOString();
+  return {
+    accounts: [
+      {
+        channel: "telegram",
+        channelLabel: "Telegram",
+        accountId: "default",
+        accountLabel: "Telegram Bot",
+        notifySupported: true,
+      },
+      {
+        channel: "whatsapp",
+        channelLabel: "WhatsApp",
+        accountId: "default",
+        accountLabel: "WhatsApp Web",
+        notifySupported: false,
+      },
+    ],
+    requests: [
+      {
+        requestId: "pairing-req-1",
+        channel: "telegram",
+        channelLabel: "Telegram",
+        accountId: "default",
+        accountLabel: "Telegram Bot",
+        senderId: "552731142",
+        senderLabel: "Mira Delgado (@miradelgado)",
+        metadata: { username: "miradelgado", firstName: "Mira", lastName: "Delgado" },
+        createdAt: iso(-14 * 60_000),
+        lastSeenAt: iso(-2 * 60_000),
+        expiresAt: iso(46 * 60_000),
+        notifySupported: true,
+      },
+      {
+        requestId: "pairing-req-2",
+        channel: "whatsapp",
+        channelLabel: "WhatsApp",
+        accountId: "default",
+        accountLabel: "WhatsApp Web",
+        senderId: "+1 555 0192",
+        senderLabel: "Unknown sender",
+        createdAt: iso(-3 * 60_000),
+        lastSeenAt: iso(-60_000),
+        expiresAt: iso(57 * 60_000),
+        notifySupported: false,
+      },
+    ],
+    commandOwnerConfigured: false,
+    limits: { pendingPerAccount: 3, ttlMs: 3_600_000 },
+  };
+}
+
 export function buildChannelWizardMocks() {
   const channelSelectStep = {
     id: "mock-wizard-step-channel",

--- a/scripts/control-ui-mock-dev.ts
+++ b/scripts/control-ui-mock-dev.ts
@@ -18,7 +18,11 @@ import {
   resolveTsconfigPathAliasesForVite,
 } from "../ui/vite.config.ts";
 import { buildBackgroundTasksMock } from "./control-ui-mock-background-tasks.ts";
-import { buildChannelsStatusMock, buildChannelWizardMocks } from "./control-ui-mock-channels.ts";
+import {
+  buildChannelsPairingMock,
+  buildChannelsStatusMock,
+  buildChannelWizardMocks,
+} from "./control-ui-mock-channels.ts";
 import { buildCronMocks } from "./control-ui-mock-cron.ts";
 import { buildPluginCatalogMock } from "./control-ui-mock-plugins.ts";
 import { buildSkillWorkshopMocks } from "./control-ui-mock-skill-workshop.js";
@@ -1476,11 +1480,36 @@ async function createChatPickerScenario(
       },
       "plugins.list": buildPluginCatalogMock(),
       "channels.status": buildChannelsStatusMock(baseTime),
-      "channels.pairing.list": {
-        accounts: [],
-        requests: [],
-        commandOwnerConfigured: true,
-        limits: { pendingPerAccount: 3, ttlMs: 3_600_000 },
+      "channels.pairing.list": buildChannelsPairingMock(baseTime),
+      "channels.pairing.approve": {
+        cases: [
+          {
+            match: { requestId: "pairing-req-1" },
+            response: {
+              requestId: "pairing-req-1",
+              senderId: "552731142",
+              notification: "sent",
+              commandOwnerBootstrap: "not-requested",
+            },
+          },
+          {
+            response: {
+              requestId: "pairing-req-2",
+              senderId: "+1 555 0192",
+              notification: "unsupported",
+              commandOwnerBootstrap: "not-requested",
+            },
+          },
+        ],
+      },
+      "channels.pairing.dismiss": {
+        cases: [
+          {
+            match: { requestId: "pairing-req-1" },
+            response: { requestId: "pairing-req-1", senderId: "552731142" },
+          },
+          { response: { requestId: "pairing-req-2", senderId: "+1 555 0192" } },
+        ],
       },
       "web.login.start": {
         message: "Scan the QR code with WhatsApp to link this device.",

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -241,11 +241,6 @@ export const en: TranslationMap = {
       channelSchemaUnavailable: "Channel config schema unavailable.",
       loadingSchema: "Loading config schema…",
     },
-    health: {
-      title: "Channel health",
-      subtitle: "Channel status snapshots from the gateway.",
-      noSnapshotYet: "No snapshot yet.",
-    },
     generic: {
       subtitle: "Channel status and configuration.",
     },

--- a/ui/src/pages/channels/view.pairing.test.ts
+++ b/ui/src/pages/channels/view.pairing.test.ts
@@ -134,8 +134,36 @@ describe("channel DM access request views", () => {
     );
 
     expect(container.textContent).toContain("operator.pairing access");
+    expect(container.querySelector(".settings-status--warn")?.textContent).toContain(
+      "operator.pairing access",
+    );
+    expect(container.querySelector(".callout")).toBeNull();
     expect(container.textContent).not.toContain("+15551234567");
     expect(container.textContent).not.toContain("Alice");
+  });
+
+  it("renders notice and error feedback as status rows without nested callouts", () => {
+    const noticeContainer = renderInto(
+      renderChannelPairingQueue(createProps({ pairingNotice: "Request approved" })),
+    );
+    const notice = noticeContainer.querySelector('[role="status"]');
+
+    expect(notice?.textContent).toContain("Request approved");
+    expect(noticeContainer.querySelector(".callout")).toBeNull();
+
+    const errorContainer = renderInto(
+      renderChannelPairingQueue(createProps({ pairingError: "Approval failed" })),
+    );
+    const error = errorContainer.querySelector('[role="alert"]');
+
+    expect(error?.textContent).toContain("Approval failed");
+    expect(errorContainer.querySelector(".callout")).toBeNull();
+  });
+
+  it("uses settings controls for both pairing filters", () => {
+    const container = renderInto(renderChannelPairingQueue(createProps()));
+
+    expect(container.querySelectorAll("select.settings-select")).toHaveLength(2);
   });
 
   it("disables every request action while one mutation is active", () => {

--- a/ui/src/pages/channels/view.pairing.ts
+++ b/ui/src/pages/channels/view.pairing.ts
@@ -59,6 +59,7 @@ function renderFilters(props: ChannelsProps) {
       <label>
         <span>${t("channels.pairing.channelFilter")}</span>
         <select
+          class="settings-select"
           .value=${props.pairingChannelFilter ?? ""}
           @change=${(event: Event) => props.onPairingFilterChange(selectValue(event), null)}
         >
@@ -69,6 +70,7 @@ function renderFilters(props: ChannelsProps) {
       <label>
         <span>${t("channels.pairing.accountFilter")}</span>
         <select
+          class="settings-select"
           .value=${props.pairingAccountFilter ?? ""}
           ?disabled=${!props.pairingChannelFilter}
           @change=${(event: Event) =>
@@ -181,13 +183,28 @@ export function renderChannelPairingQueue(props: ChannelsProps) {
           `,
         },
         !props.canManagePairing
-          ? html`<div class="callout warn">${t("channels.pairing.missingPermission")}</div>`
+          ? html`
+              <div class="settings-row channels-pairing-feedback">
+                ${renderSettingsStatus({
+                  kind: "warn",
+                  label: t("channels.pairing.missingPermission"),
+                })}
+              </div>
+            `
           : html`
               ${props.pairingError
-                ? html`<div class="callout danger">${props.pairingError}</div>`
+                ? html`
+                    <div class="settings-row channels-pairing-feedback" role="alert">
+                      ${renderSettingsStatus({ kind: "danger", label: props.pairingError })}
+                    </div>
+                  `
                 : nothing}
               ${props.pairingNotice
-                ? html`<div class="callout info" role="status">${props.pairingNotice}</div>`
+                ? html`
+                    <div class="settings-row channels-pairing-feedback" role="status">
+                      ${renderSettingsStatus({ kind: "ok", label: props.pairingNotice })}
+                    </div>
+                  `
                 : nothing}
               ${snapshot ? renderFilters(props) : nothing}
               ${props.pairingLoading && !snapshot

--- a/ui/src/pages/channels/view.ts
+++ b/ui/src/pages/channels/view.ts
@@ -1,7 +1,6 @@
 // Channels hub: connected-channel rows, add-a-channel gallery, setup wizard,
 // and a per-channel detail overlay with the full config form.
 import { html, nothing } from "lit";
-import { unsafeHTML } from "lit/directives/unsafe-html.js";
 import "../../styles/channels.css";
 import type {
   ChannelAccountSnapshot,
@@ -17,7 +16,6 @@ import type {
   WhatsAppStatus,
 } from "../../api/types.ts";
 import { icons } from "../../components/icons.ts";
-import { highlightJsonHtml } from "../../components/markdown-code-blocks.ts";
 import "../../components/openclaw-mascot.ts";
 import {
   renderSettingsEmpty,
@@ -102,20 +100,6 @@ export function renderChannels(props: ChannelsProps) {
         },
         html`
           ${available.map((key) => renderAvailableRow(key, props))} ${renderBrowseAllRow(props)}
-        `,
-      )}
-      ${renderSettingsSection(
-        {
-          title: t("channels.health.title"),
-          description: t("channels.health.subtitle"),
-        },
-        html`
-          <div class="settings-row settings-row--stacked">
-            <pre class="code-block">
-${props.snapshot
-                ? unsafeHTML(highlightJsonHtml(JSON.stringify(props.snapshot, null, 2)))
-                : t("channels.health.noSnapshotYet")}</pre>
-          </div>
         `,
       )}
     `)}

--- a/ui/src/styles/channels.css
+++ b/ui/src/styles/channels.css
@@ -122,14 +122,14 @@
 .channels-pairing-filters {
   display: flex;
   flex-wrap: wrap;
-  gap: var(--space-3);
-  padding: var(--space-3);
+  gap: var(--space-3) var(--space-4);
+  padding: var(--space-3) var(--space-4);
   border-bottom: 1px solid var(--border);
 }
 
 .channels-pairing-filters label {
   display: grid;
-  flex: 1 1 180px;
+  flex: 0 1 220px;
   gap: var(--space-1);
   color: var(--muted);
   font-size: var(--control-ui-text-xs);
@@ -137,6 +137,14 @@
 
 .channels-pairing-filters select {
   width: 100%;
+}
+
+.channels-pairing-feedback {
+  min-height: 0;
+}
+
+.channels-pairing-feedback + .channels-pairing-feedback {
+  border-top: 0;
 }
 
 .channels-pairing-request {
@@ -171,7 +179,7 @@
 }
 
 .channels-pairing-help {
-  padding: var(--space-3);
+  padding: var(--space-2) var(--space-4) var(--space-3);
   color: var(--muted);
   font-size: var(--control-ui-text-xs);
   line-height: 1.5;


### PR DESCRIPTION
## What Problem This Solves

The Channels page's "DM access requests" section drifted from the settings design language (`ui/docs/design-system/settings-design.md`):

- Success/error notices rendered as nested callout cards inside the `.settings-group` surface, violating the "exactly one level of elevation" rule (the blue "DM access approved." banner).
- The Channel/Account filter comboboxes were bare native `<select>`s with browser default chrome — inconsistent between themes, and the disabled Account select looked like a washed-out text field. Both stretched full width.
- Filter bar and limits footnote padding didn't align with settings-row insets.

The page also carried a "Channel health" section that dumped the entire `channels.status` snapshot as raw highlighted JSON — a debug card, not a product surface.

## Why This Change Was Made

Bring the pairing queue onto the settings design system instead of forking it, and delete the debug JSON card rather than restyle it:

- Notices/errors/missing-permission now render as slim status rows via `renderSettingsStatus` (ok/danger/warn dot + text) with the same `role="status"`/`role="alert"` semantics as before.
- Filter selects use the `.settings-select` control primitive and size to a 220px column instead of stretching.
- Filter bar, feedback rows, and the limits footnote use `--space-*` token padding aligned with `.settings-row` insets.
- The "Channel health" section, its `channels.health.*` i18n keys, and the now-unused `unsafeHTML`/`highlightJsonHtml` imports are removed.
- The mock dev harness (`pnpm dev:ui:mock`) now serves deterministic `channels.pairing.list` / `approve` / `dismiss` fixtures so the pairing queue is exercisable (and screenshot-able) without a live gateway.

## User Impact

Operators reviewing DM access requests get a cleaner, theme-consistent queue: design-system comboboxes, status feedback as unobtrusive rows instead of banner cards, and aligned spacing. The raw JSON snapshot card is gone from the Channels page.

## Evidence

Before/after (mock harness, deterministic fixtures):

| State | Before | After |
| --- | --- | --- |
| Queue (light) | ![before light](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/channels-pairing-redesign/before-pairing-light.png) | ![after light](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/channels-pairing-redesign/after-pairing-light.png) |
| Approved notice | ![before notice](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/channels-pairing-redesign/before-notice-light.png) | ![after notice](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/channels-pairing-redesign/after-notice-light.png) |
| Queue (dark) | ![before dark](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/channels-pairing-redesign/before-pairing-dark.png) | ![after dark](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/channels-pairing-redesign/after-pairing-dark.png) |
| Channel health card | ![before health](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/channels-pairing-redesign/before-health-light.png) | removed |

- Focused tests: `node scripts/run-vitest.mjs ui/src/pages/channels/view.pairing.test.ts ui/src/pages/channels/view.test.ts ui/src/pages/channels/channels-page.test.ts` — 3 files, 22 tests passed. New coverage: feedback rows render `[role="status"]`/`[role="alert"]` via settings-status with no `.callout` in the queue; both filter selects carry `.settings-select`.
- `pnpm ui:i18n:baseline` clean (key removal only; no baseline drift). Foreign locale bundles untouched (generated post-merge).
- `oxfmt --check` and `scripts/run-oxlint.mjs` clean on changed files.
- `rg -n 'channels\.health\.'` — no remaining references.

## Note: unrelated red-main fix included

`main` is currently red on `checks-node-compact-small-3` (`test/scripts/test-projects.test.ts` sharding invariant: `extensions/codex/src/app-server/run-attempt-client-prewarm.test.ts` routed by both the attempt-extra and attempt-light vitest configs, introduced with #114551's routing follow-ups). Per repo policy this landing PR carries the smallest correct fix: drop the duplicate route from `vitest.extension-codex-app-server-attempt-extra.config.ts`, keeping the canonical attempt-light route.
