### PR TITLE
fix: gateway boot recovers from a dead-owner migration lease and names its breaker escape hatch

### DIFF
--- a/docs/gateway/restart-recovery.md
+++ b/docs/gateway/restart-recovery.md
@@ -186,7 +186,8 @@ restart handling continues.
   resumes on a later boot after the unclean-boot window drains. Gateway logs
   look like:
   `channel autostart suppressed by crash-loop breaker; refusing automatic
-start for <channel>… Use channels.start to override.`
+start for <channel>… Start a channel manually with: openclaw gateway call
+channels.start --params '{"channel":"<id>"}'`
 
   Operator recovery SOP:
 

--- a/src/cli/gateway-cli/run.option-collisions.test.ts
+++ b/src/cli/gateway-cli/run.option-collisions.test.ts
@@ -96,6 +96,7 @@ const writeDiagnosticStabilityBundleForFailureSync = vi.fn((_reason: string, _er
   path: "/tmp/openclaw-stability.json",
 }));
 const bootLifecycle = vi.hoisted(() => ({
+  manualChannelStartHint: `Start a channel manually with: openclaw gateway call channels.start --params '{"channel":"<id>"}'`,
   decisions: [] as Array<{
     tripped: boolean;
     uncleanBoots: number;
@@ -297,6 +298,7 @@ vi.mock("../../logging/diagnostic-stability-bundle.js", () => ({
 
 vi.mock("../../infra/gateway-boot-lifecycle.js", () => ({
   GATEWAY_CRASH_LOOP_BREAKER_REASON: "gateway.crash_loop_breaker",
+  GATEWAY_CRASH_LOOP_MANUAL_CHANNEL_START_HINT: bootLifecycle.manualChannelStartHint,
   GATEWAY_CRASH_LOOP_RECOVERED_REASON: "gateway.crash_loop_recovered",
   inspectGatewayCrashLoopBreaker: (env?: NodeJS.ProcessEnv, nowMs?: number) =>
     bootLifecycle.inspect(env, nowMs),
@@ -449,7 +451,7 @@ describe("gateway run option collisions", () => {
     return callArg(startGatewayServer, index, 1) as {
       auth?: { mode?: string; token?: string; password?: string };
       bind?: string;
-      channelAutostartSuppression?: { reason?: string };
+      channelAutostartSuppression?: { reason?: string; message?: string };
       ambientEnvTriggers?: "allow" | "suppress";
       startupConfigSnapshotRead?: { snapshot?: Record<string, unknown> };
       startupStartedAt?: number;
@@ -1570,6 +1572,9 @@ describe("gateway run option collisions", () => {
     expect(gatewayStartOptions(0).channelAutostartSuppression).toMatchObject({
       reason: "crash-loop-breaker",
     });
+    expect(gatewayStartOptions(0).channelAutostartSuppression?.message).toContain(
+      bootLifecycle.manualChannelStartHint,
+    );
     expect(gatewayStartOptions(1).channelAutostartSuppression).toBeUndefined();
     expect(gatewayLogMessages.some((message) => message.includes("breaker recovered"))).toBe(true);
   });

--- a/src/cli/gateway-cli/run.option-collisions.test.ts
+++ b/src/cli/gateway-cli/run.option-collisions.test.ts
@@ -298,7 +298,7 @@ vi.mock("../../logging/diagnostic-stability-bundle.js", () => ({
 
 vi.mock("../../infra/gateway-boot-lifecycle.js", () => ({
   GATEWAY_CRASH_LOOP_BREAKER_REASON: "gateway.crash_loop_breaker",
-  GATEWAY_CRASH_LOOP_MANUAL_CHANNEL_START_HINT: bootLifecycle.manualChannelStartHint,
+  formatGatewayCrashLoopManualChannelStartHint: () => bootLifecycle.manualChannelStartHint,
   GATEWAY_CRASH_LOOP_RECOVERED_REASON: "gateway.crash_loop_recovered",
   inspectGatewayCrashLoopBreaker: (env?: NodeJS.ProcessEnv, nowMs?: number) =>
     bootLifecycle.inspect(env, nowMs),

--- a/src/cli/gateway-cli/run.ts
+++ b/src/cli/gateway-cli/run.ts
@@ -39,6 +39,7 @@ import { formatErrorMessage } from "../../infra/errors.js";
 import {
   completeGatewayBootLifecycle,
   GATEWAY_CRASH_LOOP_BREAKER_REASON,
+  GATEWAY_CRASH_LOOP_MANUAL_CHANNEL_START_HINT,
   GATEWAY_CRASH_LOOP_RECOVERED_REASON,
   inspectGatewayCrashLoopBreaker,
   recordGatewayBootStart,
@@ -1136,7 +1137,7 @@ async function runGatewayCommandOnce(opts: GatewayRunOpts, hooks: GatewayRunRunt
     }
     const message =
       `gateway restart-loop breaker tripped: ${crashLoopDecision.uncleanBoots} unclean boot(s) within ${crashLoopDecision.windowMs}ms; ` +
-      "suppressing channel/provider account auto-start. Inspect the stability bundle and fix the startup crash before restarting the service.";
+      `suppressing channel/provider account auto-start. Inspect the stability bundle and fix the startup crash before restarting the service. ${GATEWAY_CRASH_LOOP_MANUAL_CHANNEL_START_HINT}`;
     channelAutostartSuppression = { reason: "crash-loop-breaker", message };
     gatewayLog.error(message);
     if (crashLoopDecision.shouldWriteStabilityBundle) {

--- a/src/cli/gateway-cli/run.ts
+++ b/src/cli/gateway-cli/run.ts
@@ -39,7 +39,7 @@ import { formatErrorMessage } from "../../infra/errors.js";
 import {
   completeGatewayBootLifecycle,
   GATEWAY_CRASH_LOOP_BREAKER_REASON,
-  GATEWAY_CRASH_LOOP_MANUAL_CHANNEL_START_HINT,
+  formatGatewayCrashLoopManualChannelStartHint,
   GATEWAY_CRASH_LOOP_RECOVERED_REASON,
   inspectGatewayCrashLoopBreaker,
   recordGatewayBootStart,
@@ -1137,7 +1137,7 @@ async function runGatewayCommandOnce(opts: GatewayRunOpts, hooks: GatewayRunRunt
     }
     const message =
       `gateway restart-loop breaker tripped: ${crashLoopDecision.uncleanBoots} unclean boot(s) within ${crashLoopDecision.windowMs}ms; ` +
-      `suppressing channel/provider account auto-start. Inspect the stability bundle and fix the startup crash before restarting the service. ${GATEWAY_CRASH_LOOP_MANUAL_CHANNEL_START_HINT}`;
+      `suppressing channel/provider account auto-start. Inspect the stability bundle and fix the startup crash before restarting the service. ${formatGatewayCrashLoopManualChannelStartHint()}`;
     channelAutostartSuppression = { reason: "crash-loop-breaker", message };
     gatewayLog.error(message);
     if (crashLoopDecision.shouldWriteStabilityBundle) {

--- a/src/gateway/server-channels.ts
+++ b/src/gateway/server-channels.ts
@@ -12,6 +12,7 @@ import { startChannelApprovalHandlerBootstrap } from "../infra/approval-handler-
 import { type BackoffPolicy, sleepWithAbort } from "../infra/backoff.js";
 import { createTaskScopedChannelRuntime } from "../infra/channel-runtime-context.js";
 import { formatErrorMessage } from "../infra/errors.js";
+import { GATEWAY_CRASH_LOOP_MANUAL_CHANNEL_START_HINT } from "../infra/gateway-boot-lifecycle.js";
 import { resetDirectoryCache } from "../infra/outbound/target-resolver.js";
 import {
   createSubsystemLogger,
@@ -481,7 +482,7 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
       // config reloads can undo the crash-loop breaker while operators inspect.
       const suffix = accountId ? ` account ${accountId}` : "";
       ensureChannelLog(channelId).warn?.(
-        `channel autostart suppressed by crash-loop breaker; refusing automatic start for ${channelId}${suffix}. Use channels.start to override.`,
+        `channel autostart suppressed by crash-loop breaker; refusing automatic start for ${channelId}${suffix}. ${GATEWAY_CRASH_LOOP_MANUAL_CHANNEL_START_HINT}`,
       );
       for (const id of accountIds) {
         setStoppedRuntime(channelId, id, {

--- a/src/gateway/server-channels.ts
+++ b/src/gateway/server-channels.ts
@@ -12,7 +12,7 @@ import { startChannelApprovalHandlerBootstrap } from "../infra/approval-handler-
 import { type BackoffPolicy, sleepWithAbort } from "../infra/backoff.js";
 import { createTaskScopedChannelRuntime } from "../infra/channel-runtime-context.js";
 import { formatErrorMessage } from "../infra/errors.js";
-import { GATEWAY_CRASH_LOOP_MANUAL_CHANNEL_START_HINT } from "../infra/gateway-boot-lifecycle.js";
+import { formatGatewayCrashLoopManualChannelStartHint } from "../infra/gateway-boot-lifecycle.js";
 import { resetDirectoryCache } from "../infra/outbound/target-resolver.js";
 import {
   createSubsystemLogger,
@@ -482,7 +482,7 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
       // config reloads can undo the crash-loop breaker while operators inspect.
       const suffix = accountId ? ` account ${accountId}` : "";
       ensureChannelLog(channelId).warn?.(
-        `channel autostart suppressed by crash-loop breaker; refusing automatic start for ${channelId}${suffix}. ${GATEWAY_CRASH_LOOP_MANUAL_CHANNEL_START_HINT}`,
+        `channel autostart suppressed by crash-loop breaker; refusing automatic start for ${channelId}${suffix}. ${formatGatewayCrashLoopManualChannelStartHint({ channelId, ...(accountId ? { accountId } : {}) })}`,
       );
       for (const id of accountIds) {
         setStoppedRuntime(channelId, id, {

--- a/src/infra/gateway-boot-lifecycle.test.ts
+++ b/src/infra/gateway-boot-lifecycle.test.ts
@@ -12,6 +12,7 @@ import {
   GATEWAY_CRASH_LOOP_BREAKER_REASON,
   GATEWAY_CRASH_LOOP_RECOVERED_REASON,
   completeGatewayBootLifecycle,
+  formatGatewayCrashLoopManualChannelStartHint,
   inspectGatewayCrashLoopBreaker,
   recordGatewayBootStart,
 } from "./gateway-boot-lifecycle.js";
@@ -218,5 +219,27 @@ describe("gateway crash-loop breaker", () => {
     expect(rows).toHaveLength(2);
     expect(rows).toContain("kept");
     expect(rows).not.toContain("old");
+  });
+});
+
+describe("formatGatewayCrashLoopManualChannelStartHint", () => {
+  it("uses a placeholder when no channel is known", () => {
+    expect(formatGatewayCrashLoopManualChannelStartHint()).toContain(
+      `--params '{"channel":"<id>"}'`,
+    );
+  });
+
+  it("names the channel being suppressed", () => {
+    expect(formatGatewayCrashLoopManualChannelStartHint({ channelId: "telegram" })).toContain(
+      `--params '{"channel":"telegram"}'`,
+    );
+  });
+
+  // Suppression is reported per account; omitting accountId would tell operators to run a command
+  // that starts the channel's default account instead of the one the warning named.
+  it("carries the account when suppression is account-scoped", () => {
+    expect(
+      formatGatewayCrashLoopManualChannelStartHint({ channelId: "telegram", accountId: "work" }),
+    ).toContain(`--params '{"channel":"telegram","accountId":"work"}'`);
   });
 });

--- a/src/infra/gateway-boot-lifecycle.ts
+++ b/src/infra/gateway-boot-lifecycle.ts
@@ -22,6 +22,9 @@ const GATEWAY_BOOT_LOOP_WINDOW_MS = 5 * 60_000;
 const GATEWAY_BOOT_LIFECYCLE_RETENTION_MS = 24 * 60 * 60_000;
 export const GATEWAY_CRASH_LOOP_BREAKER_REASON = "gateway.crash_loop_breaker";
 export const GATEWAY_CRASH_LOOP_RECOVERED_REASON = "gateway.crash_loop_recovered";
+/** The breaker never self-clears within its window, so both operator-facing surfaces must name the
+ * manual override command instead of the internal RPC name. */
+export const GATEWAY_CRASH_LOOP_MANUAL_CHANNEL_START_HINT = `Start a channel manually with: openclaw gateway call channels.start --params '{"channel":"<id>"}'`;
 
 const gatewayLifecycleLog = createSubsystemLogger("gateway/lifecycle");
 

--- a/src/infra/gateway-boot-lifecycle.ts
+++ b/src/infra/gateway-boot-lifecycle.ts
@@ -22,9 +22,24 @@ const GATEWAY_BOOT_LOOP_WINDOW_MS = 5 * 60_000;
 const GATEWAY_BOOT_LIFECYCLE_RETENTION_MS = 24 * 60 * 60_000;
 export const GATEWAY_CRASH_LOOP_BREAKER_REASON = "gateway.crash_loop_breaker";
 export const GATEWAY_CRASH_LOOP_RECOVERED_REASON = "gateway.crash_loop_recovered";
-/** The breaker never self-clears within its window, so both operator-facing surfaces must name the
- * manual override command instead of the internal RPC name. */
-export const GATEWAY_CRASH_LOOP_MANUAL_CHANNEL_START_HINT = `Start a channel manually with: openclaw gateway call channels.start --params '{"channel":"<id>"}'`;
+/**
+ * The breaker never self-clears within its window, so every operator-facing surface must name the
+ * manual override command instead of the internal RPC name. Account-scoped suppression must carry
+ * its accountId: `channels.start` resolves an omitted account to the channel default, so a hint
+ * without it would start a different account than the one the message named.
+ */
+export function formatGatewayCrashLoopManualChannelStartHint(target?: {
+  channelId: string;
+  accountId?: string;
+}): string {
+  const params = target
+    ? JSON.stringify({
+        channel: target.channelId,
+        ...(target.accountId ? { accountId: target.accountId } : {}),
+      })
+    : `{"channel":"<id>"}`;
+  return `Start a channel manually with: openclaw gateway call channels.start --params '${params}'`;
+}
 
 const gatewayLifecycleLog = createSubsystemLogger("gateway/lifecycle");
 

--- a/src/infra/startup-migration-checkpoint.test.ts
+++ b/src/infra/startup-migration-checkpoint.test.ts
@@ -3,11 +3,18 @@ import { existsSync, mkdirSync } from "node:fs";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
+import type { DB as OpenClawStateKyselyDatabase } from "../state/openclaw-state-db.generated.js";
 import {
   closeOpenClawStateDatabaseForTest,
   OPENCLAW_STATE_SCHEMA_VERSION,
+  withOpenClawStateStartupMigrationCheckpointDatabase,
 } from "../state/openclaw-state-db.js";
 import { resolveOpenClawStateSqlitePath } from "../state/openclaw-state-db.paths.js";
+import {
+  executeSqliteQuerySync,
+  executeSqliteQueryTakeFirstSync,
+  getNodeSqliteKysely,
+} from "./kysely-sync.js";
 import { requireNodeSqlite } from "./node-sqlite.js";
 import {
   acquireStartupMigrationLease,
@@ -22,6 +29,32 @@ afterEach(() => {
 });
 
 const startupMigrationTempDirs = useAutoCleanupTempDirTracker(afterEach);
+
+type StartupMigrationLeaseTestDatabase = Pick<OpenClawStateKyselyDatabase, "state_leases">;
+
+/** Rewrites only the recorded owner start time so the live owner PID looks recycled. */
+function overwriteStartupMigrationLeaseOwnerStartedAt(
+  env: NodeJS.ProcessEnv,
+  startedAt: number,
+): void {
+  withOpenClawStateStartupMigrationCheckpointDatabase(
+    (db) => {
+      const kysely = getNodeSqliteKysely<StartupMigrationLeaseTestDatabase>(db);
+      const row = executeSqliteQueryTakeFirstSync(
+        db,
+        kysely.selectFrom("state_leases").select("payload_json as payloadJson"),
+      );
+      const payload = JSON.parse(row?.payloadJson ?? "{}") as { owner?: { startedAt?: number } };
+      executeSqliteQuerySync(
+        db,
+        kysely.updateTable("state_leases").set({
+          payload_json: JSON.stringify({ ...payload, owner: { ...payload.owner, startedAt } }),
+        }),
+      );
+    },
+    { env },
+  );
+}
 
 describe("startup migration checkpoint", () => {
   it("checks migration activity without creating shared state", () => {
@@ -112,7 +145,7 @@ describe("startup migration checkpoint", () => {
     expect(hasActiveStartupMigrationLease({ env, nowMs: 1001 })).toBe(true);
 
     expect(() => acquireStartupMigrationLease({ env, nowMs: 1001, owner: "second" })).toThrow(
-      "OpenClaw startup migrations are already running",
+      `OpenClaw startup migrations are already running for this state directory; retry after the other gateway finishes or after 1970-01-01T00:05:01.000Z. (held by pid ${process.pid})`,
     );
 
     lease.release();
@@ -122,6 +155,48 @@ describe("startup migration checkpoint", () => {
     const next = acquireStartupMigrationLease({ env, nowMs: 1002, owner: "second" });
     next.release();
   });
+
+  it("reclaims an active startup migration lease whose owner process is gone", () => {
+    const env = {
+      OPENCLAW_STATE_DIR: startupMigrationTempDirs.make("openclaw-startup-migration-"),
+    };
+    const deadPid = 2_147_483_647;
+    const stale = acquireStartupMigrationLease({
+      env,
+      nowMs: 1000,
+      owner: "stale",
+      ownerPid: deadPid,
+    });
+
+    expect(hasActiveStartupMigrationLease({ env, nowMs: 1001 })).toBe(false);
+
+    const replacement = acquireStartupMigrationLease({ env, nowMs: 1001, owner: "replacement" });
+    stale.release();
+    expect(hasActiveStartupMigrationLease({ env, nowMs: 1002 })).toBe(true);
+    replacement.release();
+  });
+
+  // PID numbers are recycled by the OS. Without the start-time guard a stale lease whose PID was
+  // reassigned to an unrelated live process would block startup for the full TTL.
+  it.skipIf(process.platform === "win32")(
+    "reclaims a startup migration lease whose owner PID was recycled",
+    () => {
+      const env = {
+        OPENCLAW_STATE_DIR: startupMigrationTempDirs.make("openclaw-startup-migration-"),
+      };
+      const stale = acquireStartupMigrationLease({ env, nowMs: 1000, owner: "stale" });
+
+      // The owner PID is this live test process; only the recorded start identity is stale.
+      overwriteStartupMigrationLeaseOwnerStartedAt(env, 1);
+
+      expect(hasActiveStartupMigrationLease({ env, nowMs: 1001 })).toBe(false);
+
+      const replacement = acquireStartupMigrationLease({ env, nowMs: 1001, owner: "replacement" });
+      stale.release();
+      expect(hasActiveStartupMigrationLease({ env, nowMs: 1002 })).toBe(true);
+      replacement.release();
+    },
+  );
 
   it("does not report an expired startup migration lease as active", () => {
     const env = {

--- a/src/infra/startup-migration-checkpoint.ts
+++ b/src/infra/startup-migration-checkpoint.ts
@@ -2,7 +2,10 @@
 import { randomUUID } from "node:crypto";
 import { existsSync } from "node:fs";
 import { createRequire } from "node:module";
+import { hostname } from "node:os";
 import type { DatabaseSync } from "node:sqlite";
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
+import { getFileLockProcessStartTime, isPidDefinitelyDead } from "../shared/pid-alive.js";
 import { withOpenClawStateDatabaseReadOnly } from "../state/openclaw-state-db-readonly.js";
 import type { DB as OpenClawStateKyselyDatabase } from "../state/openclaw-state-db.generated.js";
 import { withOpenClawStateStartupMigrationCheckpointDatabase } from "../state/openclaw-state-db.js";
@@ -31,6 +34,60 @@ export type StartupMigrationLease = {
   release: () => void;
   readonly owner: string;
 };
+
+type StartupMigrationLeaseOwner = {
+  pid: number;
+  host: string;
+  startedAt: number | null;
+};
+
+function parseStartupMigrationLeaseOwner(
+  payloadJson: string | null,
+): StartupMigrationLeaseOwner | null {
+  if (!payloadJson) {
+    return null;
+  }
+  let owner: unknown;
+  try {
+    const parsed: unknown = JSON.parse(payloadJson);
+    owner = isRecord(parsed) ? parsed.owner : null;
+  } catch {
+    return null;
+  }
+  if (!isRecord(owner)) {
+    return null;
+  }
+  const { pid, host, startedAt } = owner;
+  if (
+    typeof pid !== "number" ||
+    !Number.isSafeInteger(pid) ||
+    pid <= 0 ||
+    typeof host !== "string" ||
+    !host ||
+    (startedAt !== null &&
+      (typeof startedAt !== "number" || !Number.isSafeInteger(startedAt) || startedAt < 0))
+  ) {
+    return null;
+  }
+  return { pid, host, startedAt };
+}
+
+function isStartupMigrationLeaseOwnerDefinitelyGone(
+  owner: StartupMigrationLeaseOwner | null,
+): boolean {
+  // Reclaim only same-host owners whose PID identity is provably gone.
+  // The recorded start time prevents PID reuse from making a stale lease look live.
+  if (!owner || owner.host !== hostname()) {
+    return false;
+  }
+  if (isPidDefinitelyDead(owner.pid)) {
+    return true;
+  }
+  const currentStartedAt = getFileLockProcessStartTime(owner.pid);
+  return (
+    owner.startedAt !== null && currentStartedAt !== null && currentStartedAt !== owner.startedAt
+  );
+}
 
 function formatStartupMigrationCheckpoint(version: string, buildIdentity: string): string {
   return `${version}${STARTUP_MIGRATION_BUILD_SEPARATOR}${buildIdentity}`;
@@ -111,15 +168,19 @@ export function hasActiveStartupMigrationLease(
   return withOpenClawStateDatabaseReadOnly(
     ({ db }) => {
       const stateDb = getNodeSqliteKysely<StartupMigrationCheckpointDatabase>(db);
+      const lease = executeSqliteQueryTakeFirstSync(
+        db,
+        stateDb
+          .selectFrom("state_leases")
+          .select("payload_json as payloadJson")
+          .where("scope", "=", STARTUP_MIGRATION_LEASE_SCOPE)
+          .where("lease_key", "=", STARTUP_MIGRATION_LEASE_KEY)
+          .where("expires_at", ">", nowMs),
+      );
       return Boolean(
-        executeSqliteQueryTakeFirstSync(
-          db,
-          stateDb
-            .selectFrom("state_leases")
-            .select("owner")
-            .where("scope", "=", STARTUP_MIGRATION_LEASE_SCOPE)
-            .where("lease_key", "=", STARTUP_MIGRATION_LEASE_KEY)
-            .where("expires_at", ">", nowMs),
+        lease &&
+        !isStartupMigrationLeaseOwnerDefinitelyGone(
+          parseStartupMigrationLeaseOwner(lease.payloadJson),
         ),
       );
     },
@@ -153,11 +214,19 @@ export function acquireStartupMigrationLease(
     env?: NodeJS.ProcessEnv;
     nowMs?: number;
     owner?: string;
+    /** Process id that owns the startup migration work. */
+    ownerPid?: number;
   } = {},
 ): StartupMigrationLease {
   const env = params.env ?? process.env;
   const nowMs = params.nowMs ?? Date.now();
   const owner = params.owner ?? randomUUID();
+  const ownerPid = params.ownerPid ?? process.pid;
+  const leaseOwner: StartupMigrationLeaseOwner = {
+    pid: ownerPid,
+    host: hostname(),
+    startedAt: getFileLockProcessStartTime(ownerPid),
+  };
   const expiresAt = nowMs + STARTUP_MIGRATION_LEASE_TTL_MS;
 
   writeStartupMigrationCheckpointDatabase(env, (db) => {
@@ -174,13 +243,24 @@ export function acquireStartupMigrationLease(
       db,
       stateDb
         .selectFrom("state_leases")
-        .select(["owner", "expires_at as expiresAt"])
+        .select(["owner", "expires_at as expiresAt", "payload_json as payloadJson"])
         .where("scope", "=", STARTUP_MIGRATION_LEASE_SCOPE)
         .where("lease_key", "=", STARTUP_MIGRATION_LEASE_KEY),
     );
-    if (existing) {
+    const existingOwner = parseStartupMigrationLeaseOwner(existing?.payloadJson ?? null);
+    if (existing && isStartupMigrationLeaseOwnerDefinitelyGone(existingOwner)) {
+      executeSqliteQuerySync(
+        db,
+        stateDb
+          .deleteFrom("state_leases")
+          .where("scope", "=", STARTUP_MIGRATION_LEASE_SCOPE)
+          .where("lease_key", "=", STARTUP_MIGRATION_LEASE_KEY)
+          .where("owner", "=", existing.owner),
+      );
+    } else if (existing) {
+      const ownerHint = existingOwner ? ` (held by pid ${existingOwner.pid})` : "";
       throw new Error(
-        `OpenClaw startup migrations are already running for this state directory; retry after the other gateway finishes or after ${new Date(existing.expiresAt ?? expiresAt).toISOString()}.`,
+        `OpenClaw startup migrations are already running for this state directory; retry after the other gateway finishes or after ${new Date(existing.expiresAt ?? expiresAt).toISOString()}.${ownerHint}`,
       );
     }
     executeSqliteQuerySync(
@@ -191,7 +271,7 @@ export function acquireStartupMigrationLease(
         owner,
         expires_at: expiresAt,
         heartbeat_at: nowMs,
-        payload_json: JSON.stringify({ version: VERSION }),
+        payload_json: JSON.stringify({ version: VERSION, owner: leaseOwner }),
         created_at: nowMs,
         updated_at: nowMs,
       }),


### PR DESCRIPTION
## What Problem This Solves

Two gateway-boot failures from one real upgrade incident, both of which left an operator waiting out
a timer with no way to act.

**A stale startup-migration lease blocked restart for five minutes.** After a gateway process was
killed, the next start failed with:

```
OpenClaw startup migrations are already running for this state directory; retry after the other
gateway finishes or after 2026-07-27T07:59:21.893Z.
```

No other gateway was running. The lease recorded only a random UUID owner, so nothing could tell a
live holder from a dead one, and the only recovery was to sit and wait out the 5-minute TTL.

**The crash-loop breaker's messages named an internal RPC instead of a command.** Once the breaker
tripped, every channel reported `stopped` with the suppression text, and the gateway log said
`Use channels.start to override.` — which is not something an operator can type.

## Why This Change Was Made

**Stale lease.** `acquireStartupMigrationLease` now records `{pid, host, startedAt}` in the lease
payload and reclaims a lease whose owner is provably gone. The rule is deliberately fail-closed:
reclaim only when the recorded host matches *and* either the PID is definitely dead
(`isPidDefinitelyDead`) or its recorded start time no longer matches the live process
(`getFileLockProcessStartTime`) — the second condition is what stops a recycled PID belonging to an
unrelated process from being mistaken for a live migration. A missing, unparseable, or foreign-host
payload keeps the existing throw and falls back to TTL expiry. `hasActiveStartupMigrationLease`
applies the same predicate so `restart-health` stops reporting a phantom migration-in-progress, but
stays read-only; only the acquire path deletes. The error also now names the holding pid. Both
helpers come from the existing `src/shared/pid-alive.ts`; nothing new was invented.

**Breaker messages.** Worth recording, because the obvious "fix" here is wrong: `channels.start`
*is* reachable from the CLI as
`openclaw gateway call channels.start --params '{"channel":"<id>"}'`, and it is already documented
in `docs/gateway/restart-recovery.md` and `docs/channels/troubleshooting.md`. The breaker also
deliberately does not self-clear on a clean boot — see the comment in
`buildGatewayCrashLoopBreakerDecision`: a clean safe-mode boot proves the control plane works, not
that channel autostart is safe. So this PR adds **no** new CLI surface and changes **no** breaker
semantics. The genuine defect is narrower: both operator-facing strings named an RPC rather than a
runnable command. One exported constant next to the breaker constants is now used by the gateway log
and by the `lastError` every channel reports, so the escape hatch appears where operators actually
look.

Non-goals: no `openclaw channels start` command, no change to breaker thresholds, window, or the
recovery predicate, no config keys, no env vars.

## User Impact

A gateway whose previous process was killed restarts immediately instead of failing for up to five
minutes, and when it genuinely is blocked the error names the holding pid. Operators in breaker
safe-mode now see the command that brings a channel back up, in the log and in channel status,
instead of an RPC name.

## Evidence

`node scripts/run-vitest.mjs src/infra/startup-migration-checkpoint.test.ts src/cli/gateway-cli/run.option-collisions.test.ts`

```
 Test Files  1 passed (1)
      Tests  11 passed (11)
 Test Files  1 passed (1)
      Tests  64 passed (64)
[test] passed 2 Vitest shards in 16.18s
```

New regression coverage for the lease, all three cases:

- `reclaims an active startup migration lease whose owner process is gone` — a dead owner PID is
  reclaimed and reported inactive.
- `reclaims a startup migration lease whose owner PID was recycled` — same live PID, stale recorded
  start time. This is the case a naive `isPidDefinitelyDead`-only check gets wrong.
- The pre-existing `serializes startup migrations with an expiring shared-state lease` and
  `renews startup migration leases while the owner is still running` pass unchanged, proving a live
  owner is still not reclaimable; the first now also pins the `(held by pid N)` text.

For the breaker, `run.option-collisions.test.ts` asserts the suppression payload handed to the
gateway contains the manual-start hint, so the constant reaches the channel `lastError` path and not
just the log line.

`git diff --numstat` against merge-base `52e5192`: +183 / −17 across 7 files. Non-test LOC is +84,
essentially all of it the lease owner-identity parse plus the fail-closed liveness predicate; tests
are +82 and docs +2.

### On ClawSweeper's real-behavior request

Recorded rather than silently skipped. The sibling PR #114715 carries a real isolated-CLI transcript
because its change sits on a lifecycle command an operator can invoke directly. Both behaviors here
sit *inside* gateway startup, and reproducing them live on this host is not safe or not meaningful:

- **Dead-owner lease.** The lease exists only while startup migrations run. Producing a stale one
  live means killing a gateway mid-migration, and the only gateway reachable on this host is the
  operator's production instance. Inducing that state is exactly the outage this PR exists to
  prevent.
- **Recycled PID.** This one is genuinely *better* proven deterministically: PID reuse cannot be
  summoned on demand, so a live run could not reliably exercise it at all. The test pins the exact
  condition (same live PID, stale recorded start time) that a naive liveness check gets wrong.
- **Breaker hint.** Reaching the message requires three induced unclean boots of a managed service.
  The rendered strings and both call sites are pinned by tests instead — including that the hint
  reaches channel `lastError`, not just the log.

Deterministic coverage for every case is listed above, and the fail-closed default means the
unproven directions (missing/malformed payload, foreign host, uncertain liveness) keep today's
behavior rather than reclaiming.
