### PR TITLE
fix(codex): refuse Platform routes on a subscription-signed native Codex home

### DIFF
--- a/docs/plugins/codex-harness.md
+++ b/docs/plugins/codex-harness.md
@@ -142,16 +142,20 @@ User-home mode supports a local managed stdio process or the shared Unix-socket
 transport. It uses `$CODEX_HOME` when set and `~/.codex` otherwise, including
 that home's native Codex auth, config, plugins, and thread store. OpenClaw does
 not inject an OpenClaw auth profile into this app-server, even when the agent's
-model route has a stored OpenAI profile: a subscription route is verified
-against the native account instead. Log in with Codex itself if a turn reports
-missing subscription credentials.
+model route has a stored OpenAI profile. The native account is verified against
+the route instead, in both directions:
 
-Because user-home mode refuses a prepared OpenClaw auth profile outright
-(`Prepared Codex auth requires an isolated app-server home.`), a stored OpenAI
-profile plus `homeScope: "user"` stops the agent from starting. Check with
-`openclaw models auth list --provider openai` and remove the stored profile with
-`openclaw models auth logout <profileId> --yes`, or switch back to
-`homeScope: "agent"` if you want OpenClaw to keep managing that credential.
+- A subscription route requires the native home to be signed in to ChatGPT. Run
+  `codex login` in that home if a turn reports missing subscription credentials.
+- A Platform (API-key) route refuses a native home signed in with a ChatGPT
+  subscription, so an API-billed route never silently spends the plan. Sign that
+  home in with `codex login --with-api-key`, or switch to `homeScope: "agent"`
+  and let OpenClaw inject the key it already holds.
+
+A stored OpenAI profile is fine alongside `homeScope: "user"`; OpenClaw keeps it
+for agent-scoped connections and simply does not hand it to the native home. Use
+`openclaw models auth list --provider openai` to inspect stored profiles and
+`openclaw models auth logout <profileId> --yes` to remove one you no longer want.
 
 Owner turns gain the `codex_threads` tool: list, search, read, fork, rename,
 archive, and restore native threads. Fork a thread to continue it in

--- a/extensions/codex/src/app-server/auth-bridge.test.ts
+++ b/extensions/codex/src/app-server/auth-bridge.test.ts
@@ -595,6 +595,7 @@ describe("bridgeCodexAppServerStartOptions", () => {
             },
           },
         },
+        homeScope: "agent",
         subscriptionProfileRequiredError: "unused",
         subscriptionProfileUnusableError: "unused",
       }),
@@ -602,44 +603,6 @@ describe("bridgeCodexAppServerStartOptions", () => {
       nativeAuthProfile: false,
       preparedAuth: { kind: "api-key", apiKey: "prepared-platform-key" },
     });
-  });
-
-  it("declines every prepared handoff for a user-home app-server", async () => {
-    const authProfileStore: AuthProfileStore = {
-      version: 1,
-      profiles: {
-        "openai:work": {
-          type: "token",
-          provider: "openai",
-          token: "prepared-subscription-token",
-          email: "prepared@example.test",
-        },
-      },
-    };
-
-    await expect(
-      resolveCodexAppServerPreparedAuthHandoff({
-        authRequirement: "subscription",
-        authProfileId: "openai:work",
-        authProfileStore,
-        agentDir: "/tmp/openclaw-agent",
-        homeScope: "user",
-        subscriptionProfileRequiredError: "profile required",
-        subscriptionProfileUnusableError: "profile unusable",
-      }),
-    ).resolves.toEqual({ authProfileId: "openai:work", nativeAuthProfile: true });
-
-    await expect(
-      resolveCodexAppServerPreparedAuthHandoff({
-        authRequirement: "api-key",
-        authProfileId: "openai:work",
-        authProfileStore,
-        agentDir: "/tmp/openclaw-agent",
-        homeScope: "user",
-        subscriptionProfileRequiredError: "profile required",
-        subscriptionProfileUnusableError: "profile unusable",
-      }),
-    ).resolves.toEqual({ authProfileId: "openai:work", nativeAuthProfile: true });
   });
 
   it("materializes one prepared subscription profile snapshot", async () => {
@@ -660,6 +623,7 @@ describe("bridgeCodexAppServerStartOptions", () => {
       authProfileId: "openai:work",
       authProfileStore,
       agentDir: "/tmp/openclaw-agent",
+      homeScope: "agent",
       subscriptionProfileRequiredError: "profile required",
       subscriptionProfileUnusableError: "profile unusable",
     });
@@ -731,6 +695,7 @@ describe("bridgeCodexAppServerStartOptions", () => {
       resolveCodexAppServerPreparedAuthHandoff({
         authProfileId: "openai:legacy",
         authProfileStore,
+        homeScope: "agent",
         subscriptionProfileRequiredError: "unused",
         subscriptionProfileUnusableError: "unused",
       }),

--- a/extensions/codex/src/app-server/auth-bridge.ts
+++ b/extensions/codex/src/app-server/auth-bridge.ts
@@ -260,7 +260,8 @@ export async function resolveCodexAppServerPreparedAuthHandoff(params: {
   authProfileId?: string;
   authProfileStore: AuthProfileStore;
   agentDir?: string;
-  homeScope?: CodexAppServerHomeScope;
+  /** Required: an omitted scope would silently reintroduce prepared logins on native homes. */
+  homeScope: CodexAppServerHomeScope;
   config?: AuthProfileOrderConfig;
   subscriptionProfileRequiredError: string;
   subscriptionProfileUnusableError: string;
@@ -514,16 +515,7 @@ export async function applyCodexAppServerAuthProfile(params: {
     return;
   }
   if (params.authProfileId === null) {
-    if (params.authRequirement === "subscription") {
-      const response = await params.client.request<CodexGetAccountResponse>("account/read", {
-        refreshToken: false,
-      });
-      if (!isJsonObject(response.account) || response.account.type !== "chatgpt") {
-        throw createCodexAppServerAuthError(
-          "Codex subscription auth profile could not produce login credentials.",
-        );
-      }
-    }
+    await assertNativeCodexAccountMatchesRoute(params.client, params.authRequirement);
     return;
   }
   let loginParams: CodexLoginAccountParams | undefined;
@@ -574,6 +566,39 @@ export async function applyCodexAppServerAuthProfile(params: {
     return;
   }
   await params.client.request("account/login/start", loginParams);
+}
+
+/**
+ * Native-home connections are verified, never logged into. Both directions of the
+ * check protect the same billing boundary: a subscription route cannot run without
+ * ChatGPT tokens, and a Platform route must not silently spend the operator's
+ * ChatGPT plan. An absent account is left alone because the native home may serve a
+ * custom model provider that reports no OpenAI account at all.
+ */
+async function assertNativeCodexAccountMatchesRoute(
+  client: CodexAppServerClient,
+  authRequirement: CodexAppServerAuthRequirement | undefined,
+): Promise<void> {
+  if (!authRequirement) {
+    return;
+  }
+  const response = await client.request<CodexGetAccountResponse>("account/read", {
+    refreshToken: false,
+  });
+  const accountType = isJsonObject(response.account) ? response.account.type : undefined;
+  if (authRequirement === "subscription") {
+    if (accountType !== "chatgpt") {
+      throw createCodexAppServerAuthError(
+        "Codex subscription auth profile could not produce login credentials.",
+      );
+    }
+    return;
+  }
+  if (accountType === "chatgpt") {
+    throw createCodexAppServerAuthError(
+      'Codex Platform route requires an API-key account, but the native Codex home is signed in with a ChatGPT subscription. Sign that home in with `codex login --with-api-key`, or set appServer.homeScope="agent" so OpenClaw can inject its own key.',
+    );
+  }
 }
 
 function createCodexAppServerAuthError(message: string, cause?: unknown): Error & { status: 401 } {

--- a/extensions/codex/src/app-server/auth-requirement-matrix.test.ts
+++ b/extensions/codex/src/app-server/auth-requirement-matrix.test.ts
@@ -1,0 +1,285 @@
+// Codex tests pin the full app-server auth-requirement matrix so one-sided changes fail loudly.
+import type { AuthProfileStore } from "openclaw/plugin-sdk/agent-runtime";
+import { describe, expect, it, vi } from "vitest";
+import {
+  applyCodexAppServerAuthProfile,
+  resolveCodexAppServerPreparedAuthHandoff,
+} from "./auth-bridge.js";
+import type { CodexAppServerHomeScope } from "./config.js";
+
+const AGENT_DIR = "/tmp/openclaw-codex-auth-matrix";
+const SUBSCRIPTION_REQUIRED_ERROR = "subscription profile required";
+const SUBSCRIPTION_UNUSABLE_ERROR = "subscription profile unusable";
+
+type StoredProfileKind = "oauth" | "api_key" | "none";
+type AuthRequirement = "subscription" | "api-key" | undefined;
+
+function buildStore(kind: StoredProfileKind): AuthProfileStore {
+  if (kind === "none") {
+    return { version: 1, profiles: {} };
+  }
+  if (kind === "oauth") {
+    return {
+      version: 1,
+      profiles: {
+        "openai:default": {
+          type: "oauth",
+          provider: "openai",
+          access: "matrix-access-token",
+          refresh: "matrix-refresh-token",
+          expires: Date.now() + 60 * 60_000,
+          accountId: "matrix-account",
+        },
+      },
+      order: { openai: ["openai:default"] },
+    };
+  }
+  return {
+    version: 1,
+    profiles: {
+      "openai:default": { type: "api_key", provider: "openai", key: "matrix-api-key" },
+    },
+    order: { openai: ["openai:default"] },
+  };
+}
+
+/**
+ * Expected handoff per cell. `prepared` names the auth material OpenClaw hands to the
+ * app-server; `native` means the connection keeps whatever account its Codex home owns.
+ */
+type ExpectedHandoff =
+  | { outcome: "prepared-api-key" }
+  | { outcome: "prepared-profile" }
+  | { outcome: "native"; nativeAuthProfile: boolean }
+  | { outcome: "throws"; message: string };
+
+const HANDOFF_MATRIX: {
+  homeScope: CodexAppServerHomeScope;
+  authRequirement: AuthRequirement;
+  storedProfile: StoredProfileKind;
+  expected: ExpectedHandoff;
+}[] = [
+  // Agent scope owns an isolated CODEX_HOME, so OpenClaw may inject prepared auth.
+  {
+    homeScope: "agent",
+    authRequirement: "api-key",
+    storedProfile: "oauth",
+    expected: { outcome: "prepared-api-key" },
+  },
+  {
+    homeScope: "agent",
+    authRequirement: "api-key",
+    storedProfile: "api_key",
+    expected: { outcome: "prepared-api-key" },
+  },
+  {
+    homeScope: "agent",
+    authRequirement: "api-key",
+    storedProfile: "none",
+    expected: { outcome: "prepared-api-key" },
+  },
+  {
+    homeScope: "agent",
+    authRequirement: "subscription",
+    storedProfile: "oauth",
+    expected: { outcome: "prepared-profile" },
+  },
+  // An API-key credential is not a subscription credential, so the route must not
+  // quietly downgrade to Platform billing behind a subscription selection.
+  {
+    homeScope: "agent",
+    authRequirement: "subscription",
+    storedProfile: "api_key",
+    expected: { outcome: "throws", message: SUBSCRIPTION_REQUIRED_ERROR },
+  },
+  {
+    homeScope: "agent",
+    authRequirement: "subscription",
+    storedProfile: "none",
+    expected: { outcome: "throws", message: SUBSCRIPTION_REQUIRED_ERROR },
+  },
+  {
+    homeScope: "agent",
+    authRequirement: undefined,
+    storedProfile: "oauth",
+    expected: { outcome: "native", nativeAuthProfile: true },
+  },
+  {
+    homeScope: "agent",
+    authRequirement: undefined,
+    storedProfile: "api_key",
+    expected: { outcome: "native", nativeAuthProfile: false },
+  },
+  {
+    homeScope: "agent",
+    authRequirement: undefined,
+    storedProfile: "none",
+    expected: { outcome: "native", nativeAuthProfile: false },
+  },
+  // User scope shares the operator's native Codex home. Every cell stays native:
+  // a prepared login would rewrite the account Codex CLI and Desktop share.
+  {
+    homeScope: "user",
+    authRequirement: "api-key",
+    storedProfile: "oauth",
+    expected: { outcome: "native", nativeAuthProfile: true },
+  },
+  {
+    homeScope: "user",
+    authRequirement: "api-key",
+    storedProfile: "api_key",
+    expected: { outcome: "native", nativeAuthProfile: false },
+  },
+  {
+    homeScope: "user",
+    authRequirement: "api-key",
+    storedProfile: "none",
+    expected: { outcome: "native", nativeAuthProfile: false },
+  },
+  {
+    homeScope: "user",
+    authRequirement: "subscription",
+    storedProfile: "oauth",
+    expected: { outcome: "native", nativeAuthProfile: true },
+  },
+  {
+    homeScope: "user",
+    authRequirement: "subscription",
+    storedProfile: "api_key",
+    expected: { outcome: "native", nativeAuthProfile: false },
+  },
+  {
+    homeScope: "user",
+    authRequirement: "subscription",
+    storedProfile: "none",
+    expected: { outcome: "native", nativeAuthProfile: false },
+  },
+  {
+    homeScope: "user",
+    authRequirement: undefined,
+    storedProfile: "oauth",
+    expected: { outcome: "native", nativeAuthProfile: true },
+  },
+  {
+    homeScope: "user",
+    authRequirement: undefined,
+    storedProfile: "api_key",
+    expected: { outcome: "native", nativeAuthProfile: false },
+  },
+  {
+    homeScope: "user",
+    authRequirement: undefined,
+    storedProfile: "none",
+    expected: { outcome: "native", nativeAuthProfile: false },
+  },
+];
+
+describe("Codex app-server auth requirement matrix", () => {
+  it.each(HANDOFF_MATRIX)(
+    "resolves homeScope=$homeScope authRequirement=$authRequirement storedProfile=$storedProfile",
+    async ({ homeScope, authRequirement, storedProfile, expected }) => {
+      const authProfileStore = buildStore(storedProfile);
+      const authProfileId = storedProfile === "none" ? undefined : "openai:default";
+      const handoff = resolveCodexAppServerPreparedAuthHandoff({
+        ...(authRequirement ? { authRequirement } : {}),
+        resolvedApiKey: "prepared-platform-key",
+        ...(authProfileId ? { authProfileId } : {}),
+        authProfileStore,
+        agentDir: AGENT_DIR,
+        homeScope,
+        subscriptionProfileRequiredError: SUBSCRIPTION_REQUIRED_ERROR,
+        subscriptionProfileUnusableError: SUBSCRIPTION_UNUSABLE_ERROR,
+      });
+
+      if (expected.outcome === "throws") {
+        await expect(handoff).rejects.toThrow(expected.message);
+        return;
+      }
+      const resolved = await handoff;
+      if (expected.outcome === "prepared-api-key") {
+        expect(resolved).toEqual({
+          nativeAuthProfile: false,
+          preparedAuth: { kind: "api-key", apiKey: "prepared-platform-key" },
+        });
+        return;
+      }
+      if (expected.outcome === "prepared-profile") {
+        expect(resolved).toMatchObject({
+          authProfileId,
+          nativeAuthProfile: true,
+          preparedAuth: { kind: "profile", profileId: authProfileId },
+        });
+        return;
+      }
+      expect(resolved).toEqual({
+        authProfileId,
+        nativeAuthProfile: expected.nativeAuthProfile,
+      });
+      expect(resolved).not.toHaveProperty("preparedAuth");
+    },
+  );
+
+  it("fails a prepared Platform route that lost its resolved key", async () => {
+    await expect(
+      resolveCodexAppServerPreparedAuthHandoff({
+        authRequirement: "api-key",
+        authProfileStore: buildStore("none"),
+        agentDir: AGENT_DIR,
+        homeScope: "agent",
+        subscriptionProfileRequiredError: SUBSCRIPTION_REQUIRED_ERROR,
+        subscriptionProfileUnusableError: SUBSCRIPTION_UNUSABLE_ERROR,
+      }),
+    ).rejects.toThrow("Prepared Codex API-key route is missing its resolved API key.");
+  });
+});
+
+/**
+ * A native-home connection reaches `applyCodexAppServerAuthProfile` with a null profile:
+ * OpenClaw verifies the account it found instead of logging in over it.
+ */
+describe("native Codex account verification", () => {
+  const NATIVE_ACCOUNT_MATRIX: {
+    authRequirement: AuthRequirement;
+    account: Record<string, unknown> | null;
+    expected: "accepts" | "rejects";
+  }[] = [
+    { authRequirement: "subscription", account: { type: "chatgpt" }, expected: "accepts" },
+    { authRequirement: "subscription", account: { type: "apiKey" }, expected: "rejects" },
+    { authRequirement: "subscription", account: { type: "amazonBedrock" }, expected: "rejects" },
+    { authRequirement: "subscription", account: null, expected: "rejects" },
+    { authRequirement: "api-key", account: { type: "apiKey" }, expected: "accepts" },
+    { authRequirement: "api-key", account: { type: "chatgpt" }, expected: "rejects" },
+    // A native home can serve a custom model provider that reports no OpenAI account.
+    // Only a positively identified ChatGPT plan is refused for a Platform route.
+    { authRequirement: "api-key", account: { type: "amazonBedrock" }, expected: "accepts" },
+    { authRequirement: "api-key", account: null, expected: "accepts" },
+    // No prepared route means no billing class to protect; the account is not read.
+    { authRequirement: undefined, account: { type: "chatgpt" }, expected: "accepts" },
+    { authRequirement: undefined, account: { type: "apiKey" }, expected: "accepts" },
+  ];
+
+  it.each(NATIVE_ACCOUNT_MATRIX)(
+    "$expected authRequirement=$authRequirement against native account $account",
+    async ({ authRequirement, account, expected }) => {
+      const request = vi.fn(async () => ({ account }));
+      const apply = applyCodexAppServerAuthProfile({
+        client: { request } as never,
+        agentDir: AGENT_DIR,
+        authProfileId: null,
+        ...(authRequirement ? { authRequirement } : {}),
+      });
+
+      if (expected === "rejects") {
+        await expect(apply).rejects.toMatchObject({ status: 401 });
+      } else {
+        await expect(apply).resolves.toBeUndefined();
+      }
+      expect(request).not.toHaveBeenCalledWith("account/login/start", expect.anything());
+      if (authRequirement) {
+        expect(request).toHaveBeenCalledWith("account/read", { refreshToken: false });
+      } else {
+        expect(request).not.toHaveBeenCalled();
+      }
+    },
+  );
+});

--- a/extensions/codex/src/app-server/config-runtime.ts
+++ b/extensions/codex/src/app-server/config-runtime.ts
@@ -8,6 +8,7 @@ import type {
   CodexAppServerStartOptions,
   CodexManagedCommandOrder,
   CodexComputerUseConfig,
+  CodexPluginConfig,
   OpenClawExecMode,
   OpenClawExecPolicyForCodexAppServer,
   ProviderAuthAliasConfig,
@@ -60,6 +61,27 @@ import {
 } from "./config-utils.js";
 import type { CodexSandboxPolicy } from "./protocol.js";
 
+/**
+ * Sole owner of the app-server home-scope decision. Ordinary harness connections
+ * default to the isolated agent home; the supervision connection owns the operator's
+ * native Codex home on local transports. Auth handoffs must read the scope from here
+ * (or from resolved start options) because a prepared login on a native home rewrites
+ * the account Codex CLI and Desktop share.
+ */
+export function resolveCodexAppServerHomeScope(params: {
+  appServer: CodexPluginConfig["appServer"];
+  connectionScope?: "harness" | "supervision";
+}): CodexAppServerHomeScope {
+  const configured = params.appServer?.homeScope;
+  if (configured) {
+    return configured;
+  }
+  return params.connectionScope === "supervision" &&
+    resolveTransport(params.appServer?.transport) !== "websocket"
+    ? "user"
+    : "agent";
+}
+
 export function resolveCodexAppServerRuntimeOptions(
   params: {
     pluginConfig?: unknown;
@@ -84,7 +106,7 @@ export function resolveCodexAppServerRuntimeOptions(
   const pluginConfig = readCodexPluginConfig(params.pluginConfig);
   const config = pluginConfig.appServer ?? {};
   const transport = resolveTransport(config.transport);
-  const homeScope: CodexAppServerHomeScope = config.homeScope ?? "agent";
+  const homeScope = resolveCodexAppServerHomeScope({ appServer: config });
   const configCommand = readNonEmptyString(config.command);
   const envCommand = readNonEmptyString(env.OPENCLAW_CODEX_APP_SERVER_BIN);
   const command = configCommand ?? envCommand ?? "codex";
@@ -512,8 +534,10 @@ export function resolveCodexSupervisionAppServerRuntimeOptions(
 ): CodexAppServerRuntimeOptions {
   const pluginConfig = readCodexPluginConfig(params.pluginConfig);
   const appServer = pluginConfig.appServer ?? {};
-  const transport = resolveTransport(appServer.transport);
-  const homeScope = appServer.homeScope ?? (transport === "websocket" ? "agent" : "user");
+  const homeScope = resolveCodexAppServerHomeScope({
+    appServer,
+    connectionScope: "supervision",
+  });
   return resolveCodexAppServerRuntimeOptions({
     ...params,
     pluginConfig: {

--- a/extensions/codex/src/app-server/config.ts
+++ b/extensions/codex/src/app-server/config.ts
@@ -37,6 +37,7 @@ export { isCodexAppServerApprovalPolicyAllowedByRequirements } from "./config-re
 export {
   codexAppServerStartOptionsKey,
   codexSandboxPolicyForTurn,
+  resolveCodexAppServerHomeScope,
   resolveCodexAppServerRuntimeOptions,
   resolveCodexAppServerStartOptionsForAgent,
   resolveCodexComputerUseConfig,

--- a/extensions/codex/src/app-server/run-attempt-connection.ts
+++ b/extensions/codex/src/app-server/run-attempt-connection.ts
@@ -27,6 +27,7 @@ import { resolveCodexBindingAppServerConnection } from "./binding-connection.js"
 import {
   isCodexAppServerApprovalPolicyAllowedByRequirements,
   readCodexPluginConfig,
+  resolveCodexAppServerHomeScope,
   resolveCodexComputerUseConfig,
   resolveCodexModelBackedReviewerPolicyContext,
   resolveOpenClawExecPolicyForCodexAppServer,
@@ -201,9 +202,7 @@ export async function prepareCodexAttemptConnection({ params, options }: CodexRu
         authProfileId: resolvedStartupAuthProfileId,
         authProfileStore: params.authProfileStore,
         agentDir,
-        ...(pluginConfig.appServer?.homeScope
-          ? { homeScope: pluginConfig.appServer.homeScope }
-          : {}),
+        homeScope: resolveCodexAppServerHomeScope({ appServer: pluginConfig.appServer }),
         config: params.config,
         subscriptionProfileRequiredError:
           "Prepared Codex subscription route requires a forwarded OpenAI OAuth or token profile.",

--- a/extensions/codex/src/app-server/side-question.ts
+++ b/extensions/codex/src/app-server/side-question.ts
@@ -30,6 +30,7 @@ import { isCodexAppServerApprovalRequest, type CodexAppServerClient } from "./cl
 import {
   canUseCodexModelBackedApprovalsReviewerForModel,
   readCodexPluginConfig,
+  resolveCodexAppServerHomeScope,
   resolveOpenClawExecPolicyForCodexAppServer,
   resolveCodexModelBackedReviewerPolicyContext,
   shouldAutoApproveCodexAppServerApprovals,
@@ -199,9 +200,7 @@ export async function runCodexAppServerSideQuestion(
         authProfileId: preparedRuntimeAuth.plan.forwardedAuthProfileId,
         authProfileStore: preparedRuntimeAuth.authProfileStore,
         agentDir: params.agentDir,
-        ...(pluginConfig.appServer?.homeScope
-          ? { homeScope: pluginConfig.appServer.homeScope }
-          : {}),
+        homeScope: resolveCodexAppServerHomeScope({ appServer: pluginConfig.appServer }),
         config: params.cfg,
         subscriptionProfileRequiredError:
           "Prepared Codex subscription route requires a scoped native OAuth or token profile.",


### PR DESCRIPTION
## What Problem This Solves

Resolves two problems for operators running the Codex harness against their own
Codex home (`plugins.entries.codex.config.appServer.homeScope: "user"`).

First, a Platform (API-key) model route ran silently on whatever account the
native home held. An operator signed in to Codex with a ChatGPT subscription who
selected an API-billed model got their subscription spent instead, with no
message. The mirror case — a subscription route on an API-key home — already
failed loudly, so only one direction of the same billing boundary was protected.

Second, the user-home section of the Codex harness docs still described the
startup failure that #114397 removed. It told operators that a stored OpenAI
profile plus `homeScope: "user"` stops the agent from starting and instructed
them to delete that profile — advice that costs them a working credential for no
reason, and that contradicts the paragraph directly above it.

## Why This Change Was Made

The user-home contract is "verify the native account, never log into it": a
prepared OpenClaw login rewrites `CODEX_HOME/auth.json` or swaps the live account
that Codex CLI and Desktop share. `applyCodexAppServerAuthProfile` implemented
only the subscription half of that verification. It now checks both directions
off the same `account/read` call. An absent account is deliberately left alone,
because a native home may serve a custom model provider that reports no OpenAI
account at all; only a positively identified ChatGPT plan is refused for a
Platform route.

The home-scope decision itself was the structural weakness behind #114397. Two
call sites spread it in conditionally (`...(pluginConfig.appServer?.homeScope ? {
homeScope } : {})`), two others read the resolved start options, and the
supervision path applied a different default inline — four expressions of one
rule, where forgetting the spread at a new call site silently reintroduces the
outage. `resolveCodexAppServerHomeScope` is now the sole owner of that rule, and
`homeScope` is a **required** argument of
`resolveCodexAppServerPreparedAuthHandoff`, so omitting it is a compile error
rather than a per-turn production failure.

Non-goal: the `enabledByDefault: livePluginConfig !== undefined` duplication
between `extensions/codex/index.ts` and `extensions/onepassword/index.ts` is
deliberately left in place. Its only shared home is
`plugin-sdk/plugin-config-runtime`, which the SDK surface gate already tracks for
demotion (`plugin-sdk-plugin-config-runtime-public-demotion`, due 2026-07-30) in
favor of `api.pluginConfig` and focused config subpaths. Two other bundled
plugins (`canvas`, `browser`) use a different `enabledByDefault` value, so a
shared helper would add a fifth shape rather than remove one. The correct
consolidation is a live, enable-aware plugin-config accessor on the plugin
runtime API, which is a shipped SDK contract change and needs owner review.

## User Impact

Operators on `homeScope: "user"` now get a clear, actionable 401 when a Platform
route meets a ChatGPT-subscription native home, naming both fixes (`codex login
--with-api-key`, or `homeScope: "agent"` so OpenClaw injects its own key) instead
of an unexplained charge against their plan. Everyone else is unaffected: agent
scope, supervision connections, subscription routes, and API-key native homes all
behave exactly as before.

The Codex harness docs no longer tell user-home operators to delete a working
OpenAI auth profile.

## Evidence

New table-driven contract
`extensions/codex/src/app-server/auth-requirement-matrix.test.ts` pins the whole
surface: handoff cells over {`homeScope`: agent, user} x {`authRequirement`:
subscription, api-key, unset} x {stored profile: oauth, api_key, none}, plus
native-account cells over {`authRequirement`} x {native account: chatgpt, apiKey,
amazonBedrock, none}. Every cell asserts the resulting handoff and whether native
auth is used; the ad-hoc user-home test it subsumes was deleted.

```
node scripts/run-vitest.mjs extensions/codex/src/app-server/auth-requirement-matrix.test.ts
  Test Files  1 passed (1)   Tests  29 passed (29)

node scripts/run-vitest.mjs \
  extensions/codex/src/app-server/auth-bridge.test.ts \
  extensions/codex/src/app-server/auth-profile-runtime-contract.test.ts
  Test Files  2 passed (2)   Tests  91 passed (91)
```

`node scripts/check-changed.mjs` (delegated to Blacksmith Testbox) exited 0:
formatting, extension typecheck, extension-test typecheck, plugin-SDK API
baseline, and the ratchet/guard lanes.

Codex autoreview (`gpt-5.6-sol`, xhigh) on the full diff: `autoreview clean: no
accepted/actionable findings reported`, `overall: patch is correct (0.89)`.

Codex protocol behavior verified directly against sibling `openai/codex`
@ `634a998d8a`:

- `codex-rs/login/src/auth/manager.rs:907-927` — `login_with_api_key` writes a
  fresh `AuthDotJson` with `tokens: None` into `codex_home`, destroying an
  existing ChatGPT login.
- `codex-rs/login/src/auth/auth_tests.rs:67` —
  `login_with_api_key_overwrites_existing_auth_json` pins that overwrite.
- `codex-rs/app-server/src/request_processors/account_processor.rs:700-765` —
  `chatgptAuthTokens` login routes through `set_external_auth`, replacing the
  live account; `codex-rs/login/src/auth/manager.rs:2248-2290` plus the
  `external_auth_active_error` guard confirm it then blocks API-key login.
- `codex-rs/app-server-protocol/src/protocol/v2/account.rs:16-58` —
  `account/read` returns exactly `apiKey`, `chatgpt`, or `amazonBedrock`, which
  is what the new check discriminates on.
- `codex-rs/login/src/auth/manager.rs:1219-1231` — env `CODEX_API_KEY` takes
  precedence over persisted auth, so `account/read` reflects an env-keyed home.
- `codex-rs/cli/src/main.rs:458-484` — `codex login --api-key` is deprecated and
  exits with guidance, so the new error message points at `--with-api-key`.
