### PR TITLE
test(ui): deflake workboard view provider release and drawer dialog tests

### DIFF
--- a/ui/src/pages/workboard/view.test.ts
+++ b/ui/src/pages/workboard/view.test.ts
@@ -143,15 +143,29 @@ describe("renderWorkboard", () => {
       } as unknown as GatewayBrowserClient,
     });
 
-    renderInto(container, props);
-    await vi.waitFor(() => expect(request).toHaveBeenCalledWith("board.get", { sessionKey }));
+    try {
+      renderInto(container, props);
+      // The dashboard element is lazily imported; on loaded CI runners that
+      // import can outlive vi.waitFor's default timeout. Await the definition
+      // and the upgraded element's first update, which acquires the provider
+      // and issues board.get synchronously.
+      await customElements.whenDefined("openclaw-workboard-card-dashboard");
+      const dashboard = container.querySelector("openclaw-workboard-card-dashboard");
+      expect(dashboard).not.toBeNull();
+      await dashboard!.updateComplete;
+      expect(request).toHaveBeenCalledWith("board.get", { sessionKey });
 
-    state.detailCardId = null;
-    renderInto(container, props);
-    await nextFrame();
+      state.detailCardId = null;
+      renderInto(container, props);
+      await nextFrame();
 
-    expect(removeListener).toHaveBeenCalledOnce();
-    container.remove();
+      expect(removeListener).toHaveBeenCalledOnce();
+    } finally {
+      // A leaked open drawer poisons later dialog tests in this shared jsdom
+      // document, so tear down even when an assertion above fails.
+      render(nothing, container);
+      container.remove();
+    }
   });
 
   it("keeps manual recovery refresh visible while data is loading", () => {


### PR DESCRIPTION
## What Problem This Solves

`ui/src/pages/workboard/view.test.ts` is a known intermittent failure on the CI `core-runtime-media-ui` shard (Linux Node 24). Two tests fail together on loaded runners and pass on rerun, most recently on unrelated PR #114664 (head `415f8dbc4d9`, run 30293306869, attempt 1):

- `renderWorkboard > releases the card dashboard provider when the details panel closes` — `AssertionError: expected "vi.fn()" to be called with arguments: [ 'board.get', … ] / Number of calls: 0` at `view.test.ts:147`
- `renderWorkboard > treats the detail drawer as a labelled keyboard-modal dialog` — `AssertionError: the given combination of arguments (undefined and string) is invalid for this assertion` at `view.test.ts:1184`

## Why This Change Was Made

Root cause (reproduced deterministically, see Evidence):

1. The provider-release test raced a fixed timer against a lazy module import. `renderCardDetailsPanel` defines `openclaw-workboard-card-dashboard` via a dynamic `import()` (`ui/src/pages/workboard/view-card-details.ts:39`), and `board.get` is only issued once that element upgrades and its first Lit update acquires the board provider (`workboard-card-dashboard.ts` -> `GatewayBoardProvider` constructor -> `runRefreshLoop`). The test asserted the `board.get` call with `vi.waitFor`'s default 1s timeout. On a loaded CI worker the Vite transform/import chain for the dashboard module takes longer than that (in the failing run the upgrade landed ~10s later — visible as the late `openclaw-workboard-card-dashboard scheduled an update` stderr warning attributed to a *later* test), so the waitFor expired with zero calls.
2. The drawer-dialog failure is pure collateral from that first failure. The provider test was the only body-appended test in the file without `try/finally` cleanup, so its failure leaked an open drawer modal (with `wa-dialog`'s scroll lock, dismissible registration, and document listeners) into the shared jsdom document. That leak corrupts scoped `querySelector` results for later dialog tests: the drawer content of the later test is present under its own container per `document.querySelectorAll`, yet `container.querySelector("#workboard-card-detail-title")` returns `null`, producing the `(undefined and string)` assertion error.

The fix stays at the test boundary because production is not racy: lazily defining the dashboard element and fetching the board after upgrade is intended behavior; users just see the dashboard once the chunk loads. The test now awaits the actual completion signal instead of a timer:

- `await customElements.whenDefined("openclaw-workboard-card-dashboard")` plus the upgraded element's `updateComplete`, after which the provider acquisition has issued `board.get` synchronously — no fixed timeout, no sleeps, no retry loops.
- The test body is wrapped in `try/finally` that renders `nothing` and removes the container, so even a genuine failure can no longer cascade into unrelated dialog tests.

## User Impact

None at runtime; CI-only. Unrelated PRs stop failing the `core-runtime-media-ui` shard on this file.

## Evidence

- Root cause reproduced exactly: adding a temporary 15s delay to the lazy dashboard import reproduced both CI failures byte-for-byte (same two tests, same assertion messages, same lines 147/1184). With the same delay plus this fix, all 84 tests pass (test 1 simply waits out the import). Restoring the old assertion with a 30s waitFor also made both tests pass, proving the second failure is caused by the first test's leak, not an independent race.
- Stability: 10 consecutive local runs of `node scripts/run-vitest.mjs ui/src/pages/workboard/view.test.ts`, all `84 passed (84)`.
