### PR TITLE
fix(pr): keep landing mutations inside the dedicated PR worktree

### DIFF
--- a/scripts/pr-lib/worktree.sh
+++ b/scripts/pr-lib/worktree.sh
@@ -43,31 +43,48 @@ enter_worktree() {
 
   cd "$root"
   ensure_gh_api_auth
-  git fetch origin main
+  git -C "$root" fetch origin main
 
-  local dir=".worktrees/pr-$pr"
-  if [ -d "$dir" ]; then
-    cd "$dir"
-    git fetch origin main
-    if [ "$reset_to_main" = "true" ]; then
-      git checkout -B "temp/pr-$pr" origin/main
-    fi
-  else
-    local resolved_parent=""
-    resolved_parent=$(resolve_existing_dir_path "$(dirname "$dir")" 2>/dev/null || true)
-    local resolved_dir=""
-    if [ -n "$resolved_parent" ]; then
-      resolved_dir="$resolved_parent/$(basename "$dir")"
-    fi
-    if [ ! -e "$dir" ] && [ -n "$resolved_dir" ] && worktree_is_registered "$resolved_dir"; then
-      echo "Pruning stale worktree registration for $dir"
-      git worktree prune
+  # Resolve through the parent, never through the leaf: a missing directory has
+  # no real path of its own, and resolving a leaf symlink would silently adopt
+  # whichever worktree it aliases.
+  local dir="$root/.worktrees/pr-$pr"
+  local resolved_parent resolved_dir=""
+  resolved_parent=$(resolve_existing_dir_path "$(dirname "$dir")" 2>/dev/null || true)
+  [ -z "$resolved_parent" ] || resolved_dir="$resolved_parent/pr-$pr"
+
+  if [ ! -d "$dir" ] || [ -z "$resolved_dir" ] || ! worktree_is_registered "$resolved_dir"; then
+    if [ -e "$dir" ] || { [ -n "$resolved_dir" ] && worktree_is_registered "$resolved_dir"; }; then
+      echo "Pruning stale worktree registration for .worktrees/pr-$pr"
+      git -C "$root" worktree prune
+      remove_worktree_if_present "$dir"
+      [ ! -e "$dir" ] || {
+        echo "Refusing scripts/pr operation for PR #$pr: $dir is not a registered worktree and could not be cleared; scripts/pr refuses to mutate the shared canonical checkout." >&2
+        return 1
+      }
     fi
     # Per-PR locking makes resetting this script-owned branch namespace safe.
-    git worktree add "$dir" -B "temp/pr-$pr" origin/main
-    cd "$dir"
+    git -C "$root" worktree add "$dir" -B "temp/pr-$pr" origin/main
+    resolved_dir="$(resolve_existing_dir_path "$(dirname "$dir")")/pr-$pr"
   fi
 
+  cd "$resolved_dir"
+
+  # Containment, not repair: every mutation below runs against ambient cwd, so
+  # prove Git resolves it to this worktree before any branch moves. A directory
+  # that is not a worktree lets discovery escape up into the shared canonical
+  # checkout, where a sibling session's branch would be clobbered.
+  local actual_toplevel
+  actual_toplevel=$(resolve_existing_dir_path "$(git rev-parse --path-format=absolute --show-toplevel 2>/dev/null)" 2>/dev/null || true)
+  if [ "$actual_toplevel" != "$resolved_dir" ]; then
+    echo "Refusing scripts/pr operation for PR #$pr: expected worktree $resolved_dir, Git resolved ${actual_toplevel:-no repository}; scripts/pr refuses to mutate the shared canonical checkout." >&2
+    return 1
+  fi
+
+  git fetch origin main
+  if [ "$reset_to_main" = "true" ]; then
+    git checkout -B "temp/pr-$pr" origin/main
+  fi
   mkdir -p .local
 }
 

--- a/test/scripts/pr-worktree-containment.test.ts
+++ b/test/scripts/pr-worktree-containment.test.ts
@@ -1,0 +1,164 @@
+import { spawnSync } from "node:child_process";
+import { mkdirSync, realpathSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../helpers/temp-dir.js";
+
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+const repoRoot = process.cwd();
+const commonScript = join(repoRoot, "scripts/pr-lib/common.sh");
+const worktreeScript = join(repoRoot, "scripts/pr-lib/worktree.sh");
+const reviewScript = join(repoRoot, "scripts/pr-lib/review.sh");
+const describePosix = process.platform === "win32" ? describe.skip : describe;
+
+type Fixture = {
+  root: string;
+  mainSha: string;
+  siblingBranch: string;
+  siblingSha: string;
+};
+
+function git(root: string, ...args: string[]) {
+  const result = spawnSync("git", args, { cwd: root, encoding: "utf8" });
+  expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(0);
+  return result.stdout.trim();
+}
+
+function createFixture(): Fixture {
+  const root = realpathSync(tempDirs.make("openclaw-pr-worktree-containment-"));
+  git(root, "init", "--initial-branch=main");
+  git(root, "config", "user.name", "OpenClaw Test");
+  git(root, "config", "user.email", "test@openclaw.invalid");
+  writeFileSync(join(root, "fixture.txt"), "main\n");
+  git(root, "add", "fixture.txt");
+  git(root, "commit", "-m", "main fixture");
+  const mainSha = git(root, "rev-parse", "HEAD");
+  git(root, "remote", "add", "origin", root);
+  git(root, "fetch", "origin");
+  git(root, "checkout", "-b", "sibling/work");
+  writeFileSync(join(root, "fixture.txt"), "sibling\n");
+  git(root, "commit", "-am", "sibling fixture");
+  return {
+    root,
+    mainSha,
+    siblingBranch: git(root, "branch", "--show-current"),
+    siblingSha: git(root, "rev-parse", "HEAD"),
+  };
+}
+
+function makeStaleWorktreeDir(fixture: Fixture) {
+  mkdirSync(join(fixture.root, ".worktrees", "pr-42"), { recursive: true });
+}
+
+function runShell(fixture: Fixture, commands: string[]) {
+  return spawnSync(
+    "bash",
+    [
+      "-c",
+      [
+        "set -euo pipefail",
+        'source "$1"',
+        'source "$2"',
+        'source "$3"',
+        'fixture_root="$4"',
+        'repo_root() { printf "%s\\n" "$fixture_root"; }',
+        "ensure_gh_api_auth() { :; }",
+        "mark_pr_operation_side_effects_started() { :; }",
+        "set_review_mode() { :; }",
+        ...commands,
+      ].join("\n"),
+      "pr-worktree-containment",
+      commonScript,
+      worktreeScript,
+      reviewScript,
+      fixture.root,
+    ],
+    { cwd: fixture.root, encoding: "utf8" },
+  );
+}
+
+function expectCanonicalCheckoutUnchanged(fixture: Fixture) {
+  expect(git(fixture.root, "branch", "--show-current")).toBe(fixture.siblingBranch);
+  expect(git(fixture.root, "rev-parse", "HEAD")).toBe(fixture.siblingSha);
+}
+
+describePosix("scripts/pr worktree containment", () => {
+  it("stale .worktrees/pr-<N> directory does not clobber the canonical checkout", () => {
+    const fixture = createFixture();
+    makeStaleWorktreeDir(fixture);
+
+    runShell(fixture, ["enter_worktree 42 true"]);
+
+    expectCanonicalCheckoutUnchanged(fixture);
+  });
+
+  it("review_checkout_main cannot detach the canonical checkout", () => {
+    const fixture = createFixture();
+    makeStaleWorktreeDir(fixture);
+
+    const result = runShell(fixture, ["review_checkout_main 42"]);
+
+    expectCanonicalCheckoutUnchanged(fixture);
+    if (result.status !== 0) {
+      expect(result.stderr).toContain("scripts/pr refuses to mutate the shared canonical checkout");
+    }
+  });
+
+  it("failure midway leaves the canonical checkout untouched", () => {
+    const fixture = createFixture();
+    const brokenWorktree = join(fixture.root, ".worktrees", "pr-42");
+    git(fixture.root, "worktree", "add", brokenWorktree, "-b", "temp/pr-42", "origin/main");
+    rmSync(join(brokenWorktree, ".git"));
+
+    const result = runShell(fixture, [
+      "enter_worktree 42 false",
+      "git checkout --detach origin/main",
+      "exit 1",
+    ]);
+
+    expect(result.status).not.toBe(0);
+    expectCanonicalCheckoutUnchanged(fixture);
+  });
+
+  it("refuses a symlink alias pointing at another PR's worktree", () => {
+    const fixture = createFixture();
+    const worktrees = join(fixture.root, ".worktrees");
+    mkdirSync(worktrees, { recursive: true });
+    git(
+      fixture.root,
+      "worktree",
+      "add",
+      join(worktrees, "pr-99"),
+      "-b",
+      "temp/pr-99",
+      "origin/main",
+    );
+    symlinkSync("pr-99", join(worktrees, "pr-42"), "dir");
+
+    const result = runShell(fixture, ["enter_worktree 42 true"]);
+
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain("refuses to mutate the shared canonical checkout");
+    expect(git(join(worktrees, "pr-99"), "branch", "--show-current")).toBe("temp/pr-99");
+    expectCanonicalCheckoutUnchanged(fixture);
+  });
+
+  it("reuses a properly registered PR worktree", () => {
+    const fixture = createFixture();
+    const expectedWorktree = join(fixture.root, ".worktrees", "pr-42");
+    git(fixture.root, "worktree", "add", expectedWorktree, "-b", "temp/pr-42", "origin/main");
+
+    const result = runShell(fixture, [
+      "enter_worktree 42 false",
+      'printf "cwd=%s\\n" "$PWD"',
+      'printf "branch=%s\\n" "$(git branch --show-current)"',
+      'printf "head=%s\\n" "$(git rev-parse HEAD)"',
+    ]);
+
+    expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(0);
+    expect(result.stdout).toContain(`cwd=${realpathSync(expectedWorktree)}`);
+    expect(result.stdout).toContain("branch=temp/pr-42");
+    expect(result.stdout).toContain(`head=${fixture.mainSha}`);
+    expectCanonicalCheckoutUnchanged(fixture);
+  });
+});


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where maintainers running `scripts/pr merge-run` (or any other landing subcommand) could have the shared canonical checkout hijacked out from under a different, concurrently-running session. Observed in production: a checkout sitting on `fix/mac-wizard-gateway-progress` was detached onto `origin/main` mid-merge, and the parallel session's branch had to be manually recreated at its prior tip. Reflog from the affected checkout:

```
a2c65d0... a854cea... checkout: moving from fix/mac-wizard-gateway-progress to origin/main
```

That is the signature of `git checkout --detach origin/main` in `review_checkout_main` — executed against the canonical checkout instead of the dedicated `.worktrees/pr-<N>` worktree. Root `AGENTS.md` explicitly says parallel agents share the checkout and must never have its branch switched while sibling work runs; the landing tooling was doing exactly that.

## Why This Change Was Made

`enter_worktree` in `scripts/pr-lib/worktree.sh` is the single funnel every landing subcommand passes through, and it selected its working directory with a bare `[ -d ".worktrees/pr-$pr" ]` test. Every later mutation — `git checkout --detach origin/main`, `git checkout -B temp/pr-<N> origin/main`, `git checkout -B pr-<N>-prep`, `git rebase` — is then issued against ambient cwd. Nothing asserted that the directory it entered was actually the dedicated linked worktree. Any leftover directory at that path (a partially failed `git worktree remove`, a pruned registration, an interrupted `worktree add`, a deleted `.git` file) makes Git discovery walk *up* into the canonical checkout, so branch-destroying commands land there.

The fix is containment at that boundary rather than compensation after the fact. `enter_worktree` now (1) resolves the target through its *parent* directory — a missing directory has no real path of its own, and resolving a leaf symlink would silently adopt whichever worktree it aliases; (2) reuses the path only when it is a registered linked worktree, otherwise prunes, clears and rebuilds it, failing closed with an actionable message when a leftover cannot be cleared; and (3) proves `git rev-parse --show-toplevel` resolves to that worktree before any branch moves. Repository-level fetches are routed through `git -C "$root"` so the flow never has the canonical checkout as its ambient Git target.

Deliberately **not** save-and-restore of the original HEAD. A restore is a compensating action that fails open on SIGKILL, crash, machine sleep, or an interrupted merge — precisely the conditions where the clobber does the most damage — and it still leaves a window in which a concurrent sibling session reads a wrong working tree. Containment means the mutation never targets the shared checkout, so there is nothing to undo on any exit path. It is also not a "refuse when the canonical checkout is dirty" gate: that guards the wrong object, would block legitimate landings whenever a sibling happens to be working, and would still permit the clobber whenever the canonical checkout happened to be on `main`.

Non-goals: no new config or env escape hatch, no second code path behind a flag, and no changes to the operation lock, wrapper trust boundary, or gates.

## User Impact

Maintainers and agents can run `scripts/pr review-init`, `review-checkout-main`, `review-checkout-pr`, `prepare-run`, and `merge-run` while sibling sessions work in the shared checkout without risking that checkout's branch, HEAD, or working tree. A landing that cannot establish its own worktree now stops with a clear refusal naming the PR and the expected path instead of silently operating on the shared checkout. Because `enter_worktree` is the shared funnel for all landing subcommands, the guarantee covers every one of them rather than only the merge path.

## Evidence

Regression tests build a real Git fixture whose "canonical checkout" sits on a sibling branch, then assert its branch **and** commit SHA are unchanged.

Before the fix (baseline `scripts/pr-lib/worktree.sh`) — the fixture's shared checkout is hijacked exactly as in production:

```
FAIL > stale .worktrees/pr-<N> directory does not clobber the canonical checkout
  Expected: "sibling/work"
  Received: "temp/pr-42"
FAIL > review_checkout_main cannot detach the canonical checkout
  expected '' to be 'sibling/work'      <- detached HEAD, the production signature
FAIL > failure midway leaves the canonical checkout untouched
  expected '' to be 'sibling/work'
Tests  3 failed | 1 passed (4)
```

After the fix:

```
$ node scripts/run-vitest.mjs test/scripts/pr-worktree-containment.test.ts
 Test Files  1 passed (1)
      Tests  5 passed (5)
```

Coverage includes the interrupted-merge case (a registered worktree whose `.git` file is gone, then a mid-flight failure) — it passes with no restore logic running, which is what distinguishes containment from save/restore — plus a symlink alias pointing at another PR's worktree, and a positive reuse case.

Sibling `scripts/pr` suites, unchanged and green:

```
$ node scripts/run-vitest.mjs test/scripts/pr-worktree-containment.test.ts \
    test/scripts/pr-operation-lock.test.ts test/scripts/pr-wrappers.test.ts \
    test/scripts/pr-review-artifact-validation.test.ts \
    test/scripts/pr-prepare-gates.test.ts test/scripts/pr-metadata.test.ts
 Test Files  6 passed (6)
      Tests  123 passed | 1 skipped (124)
```

`node scripts/check-changed.mjs` delegated to Blacksmith Testbox: `exit=0` (format, package patch guard, script declaration contracts, test-root typecheck, scripts lint all pass).

Codex autoreview (`gpt-5.6-sol`, high) on the change: `autoreview clean: no accepted/actionable findings reported`.

Non-test LOC delta for `scripts/pr-lib/worktree.sh` is `+37 / -20`; the growth is a data-loss guard that replaces the previous two-branch stale-registration dance with one canonical path.
