### PR TITLE
fix(tui): preserve Unicode during fragmented terminal input [AI-assisted]

### DIFF
--- a/src/tui/tui-pty-harness-fixture-test-support.ts
+++ b/src/tui/tui-pty-harness-fixture-test-support.ts
@@ -7,6 +7,13 @@ export type FixtureLogEntry = {
   payload?: unknown;
 };
 
+export const COMPACT_TERMINAL_SIZES = [
+  [64, 18],
+  [68, 18],
+  [72, 20],
+  [80, 20],
+] as const;
+
 export async function readFixtureLog(logPath: string): Promise<FixtureLogEntry[]> {
   try {
     const text = await readFile(logPath, "utf8");
@@ -51,6 +58,32 @@ export function objectFieldEquals(entry: FixtureLogEntry, field: string, value: 
   }
   const payload = entry.payload as Record<string, unknown>;
   return Object.hasOwn(payload, field) && payload[field] === value;
+}
+
+/** Proves fixture-local fragmentation preserves a Unicode prompt through the real TUI loop. */
+export async function exerciseFragmentedUnicodePrompt(
+  startFixture: (opts: { env?: NodeJS.ProcessEnv }) => Promise<{
+    run: PtyRun;
+    waitForLogEntry: (predicate: (entry: FixtureLogEntry) => boolean) => Promise<FixtureLogEntry>;
+    cleanup: () => Promise<void>;
+  }>,
+  startupTimeoutMs: number,
+) {
+  const fixture = await startFixture({
+    env: { OPENCLAW_TUI_PTY_TYPE_CHUNK_SIZE: "1", OPENCLAW_TUI_PTY_TYPE_DELAY_MS: "1" },
+  });
+  const message = "hello 👋 from pty";
+
+  try {
+    await fixture.run.waitForOutput("local ready", startupTimeoutMs);
+    await fixture.run.write(`${message}\r`);
+    await fixture.run.waitForOutput(`PTY_RESPONSE: ${message}`);
+    await fixture.waitForLogEntry(
+      (entry) => entry.method === "sendChat" && objectFieldEquals(entry, "message", message),
+    );
+  } finally {
+    await fixture.cleanup();
+  }
 }
 
 /** Approves a workspace skill using exact fragments that survive narrow-terminal wrapping. */

--- a/src/tui/tui-pty-harness.e2e.test.ts
+++ b/src/tui/tui-pty-harness.e2e.test.ts
@@ -7,6 +7,8 @@ import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import {
   approveWorkspaceSkill,
   buildOpaqueSessionIsolationFixture,
+  COMPACT_TERMINAL_SIZES,
+  exerciseFragmentedUnicodePrompt,
   objectFieldEquals,
   readFixtureLog,
   waitForFixtureLogEntry,
@@ -655,7 +657,7 @@ describe.sequential("TUI PTY harness", () => {
   });
 
   it(
-    "drives the real TUI terminal loop through typed input",
+    "drives the real TUI terminal loop through typed and fragmented Unicode input",
     async () => {
       await fixture.run.write("hello from pty\r");
       await fixture.run.waitForOutput("PTY_RESPONSE: hello from pty");
@@ -663,31 +665,7 @@ describe.sequential("TUI PTY harness", () => {
         (entry) =>
           entry.method === "sendChat" && objectFieldEquals(entry, "message", "hello from pty"),
       );
-    },
-    TEST_TIMEOUT_MS,
-  );
-
-  it(
-    "preserves Unicode prompts during fragmented terminal input",
-    async () => {
-      const fragmentedFixture = await startTuiFixture({
-        env: {
-          OPENCLAW_TUI_PTY_TYPE_CHUNK_SIZE: "1",
-          OPENCLAW_TUI_PTY_TYPE_DELAY_MS: "1",
-        },
-      });
-
-      try {
-        await fragmentedFixture.run.waitForOutput("local ready", STARTUP_TIMEOUT_MS);
-        await fragmentedFixture.run.write("hello 👋 from pty\r");
-        await fragmentedFixture.run.waitForOutput("PTY_RESPONSE: hello 👋 from pty");
-        await fragmentedFixture.waitForLogEntry(
-          (entry) =>
-            entry.method === "sendChat" && objectFieldEquals(entry, "message", "hello 👋 from pty"),
-        );
-      } finally {
-        await fragmentedFixture.cleanup();
-      }
+      await exerciseFragmentedUnicodePrompt(startTuiFixture, STARTUP_TIMEOUT_MS);
     },
     STARTUP_TEST_TIMEOUT_MS,
   );
@@ -732,14 +710,9 @@ describe.sequential("TUI PTY harness", () => {
     TEST_TIMEOUT_MS,
   );
 
-  it.each([
-    { cols: 64, rows: 18 },
-    { cols: 68, rows: 18 },
-    { cols: 72, rows: 20 },
-    { cols: 80, rows: 20 },
-  ])(
-    "presents and resolves workspace skill approval in a $cols×$rows terminal",
-    async ({ cols, rows }) => {
+  it.each(COMPACT_TERMINAL_SIZES)(
+    "presents and resolves workspace skill approval in a %i×%i terminal",
+    async (cols, rows) => {
       const compactFixture = await startTuiFixture({
         env: {
           OPENCLAW_TUI_PTY_COLS: String(cols),

--- a/src/tui/tui-pty-harness.e2e.test.ts
+++ b/src/tui/tui-pty-harness.e2e.test.ts
@@ -668,6 +668,31 @@ describe.sequential("TUI PTY harness", () => {
   );
 
   it(
+    "preserves Unicode prompts during fragmented terminal input",
+    async () => {
+      const fragmentedFixture = await startTuiFixture({
+        env: {
+          OPENCLAW_TUI_PTY_TYPE_CHUNK_SIZE: "1",
+          OPENCLAW_TUI_PTY_TYPE_DELAY_MS: "1",
+        },
+      });
+
+      try {
+        await fragmentedFixture.run.waitForOutput("local ready", STARTUP_TIMEOUT_MS);
+        await fragmentedFixture.run.write("hello 👋 from pty\r");
+        await fragmentedFixture.run.waitForOutput("PTY_RESPONSE: hello 👋 from pty");
+        await fragmentedFixture.waitForLogEntry(
+          (entry) =>
+            entry.method === "sendChat" && objectFieldEquals(entry, "message", "hello 👋 from pty"),
+        );
+      } finally {
+        await fragmentedFixture.cleanup();
+      }
+    },
+    STARTUP_TEST_TIMEOUT_MS,
+  );
+
+  it(
     "deletes forward with Ctrl+D without exiting a nonempty terminal editor",
     async () => {
       await fixture.run.write("keepXword", { delay: false });
@@ -709,7 +734,9 @@ describe.sequential("TUI PTY harness", () => {
 
   it.each([
     { cols: 64, rows: 18 },
+    { cols: 68, rows: 18 },
     { cols: 72, rows: 20 },
+    { cols: 80, rows: 20 },
   ])(
     "presents and resolves workspace skill approval in a $cols×$rows terminal",
     async ({ cols, rows }) => {

--- a/src/tui/tui-pty-test-support.test.ts
+++ b/src/tui/tui-pty-test-support.test.ts
@@ -72,6 +72,32 @@ describe("TUI PTY test support", () => {
   });
 
   it.each([
+    { chunkSize: "1", chunks: ["A", "👋", "B"] },
+    { chunkSize: "2", chunks: ["A👋", "B"] },
+  ])(
+    "preserves Unicode characters with fixture-specific $chunkSize-character input chunks",
+    async ({ chunkSize, chunks }) => {
+      const pty = createMockPty();
+      nodePtyMocks.spawn.mockReturnValue(pty);
+
+      const run = startPty("node", [], {
+        cwd: process.cwd(),
+        env: {
+          OPENCLAW_TUI_PTY_TYPE_CHUNK_SIZE: chunkSize,
+          OPENCLAW_TUI_PTY_TYPE_DELAY_MS: "1",
+        },
+        exitTimeoutMs: 1_000,
+        outputTimeoutMs: 1_000,
+      });
+
+      await run.write("A👋B");
+
+      expect(pty.write).toHaveBeenCalledTimes(chunks.length);
+      expect(vi.mocked(pty.write).mock.calls.map(([chunk]) => chunk)).toEqual(chunks);
+    },
+  );
+
+  it.each([
     {
       label: "split ANSI control sequences",
       chunks: ["\u001b[38;2;155;163;178minto live     \r\n\u001b[", "0mworkspace"],

--- a/src/tui/tui-pty-test-support.test.ts
+++ b/src/tui/tui-pty-test-support.test.ts
@@ -77,7 +77,8 @@ describe("TUI PTY test support", () => {
   ])(
     "preserves Unicode characters with fixture-specific $chunkSize-character input chunks",
     async ({ chunkSize, chunks }) => {
-      const pty = createMockPty();
+      const write = vi.fn();
+      const pty = createMockPty({ write });
       nodePtyMocks.spawn.mockReturnValue(pty);
 
       const run = startPty("node", [], {
@@ -92,8 +93,8 @@ describe("TUI PTY test support", () => {
 
       await run.write("A👋B");
 
-      expect(pty.write).toHaveBeenCalledTimes(chunks.length);
-      expect(vi.mocked(pty.write).mock.calls.map(([chunk]) => chunk)).toEqual(chunks);
+      expect(write).toHaveBeenCalledTimes(chunks.length);
+      expect(write.mock.calls.map(([chunk]) => chunk)).toEqual(chunks);
     },
   );
 

--- a/src/tui/tui-pty-test-support.ts
+++ b/src/tui/tui-pty-test-support.ts
@@ -69,18 +69,20 @@ function readPtyDimensionEnv(name: string, fallback: number, env: NodeJS.Process
 async function writePtyInput(
   pty: IPty,
   data: string,
+  env: NodeJS.ProcessEnv,
   opts: { delay?: boolean } = {},
 ): Promise<void> {
-  const delayMs = readPositiveIntegerEnv("OPENCLAW_TUI_PTY_TYPE_DELAY_MS");
+  const delayMs = readPositiveIntegerEnv("OPENCLAW_TUI_PTY_TYPE_DELAY_MS", env);
   if (!delayMs || opts.delay === false) {
     pty.write(data);
     return;
   }
-  const chunkSize = readPositiveIntegerEnv("OPENCLAW_TUI_PTY_TYPE_CHUNK_SIZE") ?? 1;
-  // Chunked writes reproduce paste/type races without making every PTY test slow by default.
-  for (let idx = 0; idx < data.length; idx += chunkSize) {
-    pty.write(data.slice(idx, idx + chunkSize));
-    if (idx + chunkSize < data.length) {
+  const chunkSize = readPositiveIntegerEnv("OPENCLAW_TUI_PTY_TYPE_CHUNK_SIZE", env) ?? 1;
+  // Chunk by Unicode characters so stress typing never sends half of a surrogate pair.
+  const characters = Array.from(data);
+  for (let idx = 0; idx < characters.length; idx += chunkSize) {
+    pty.write(characters.slice(idx, idx + chunkSize).join(""));
+    if (idx + chunkSize < characters.length) {
       await sleep(delayMs);
     }
   }
@@ -149,7 +151,7 @@ export function startPty(
   const run: PtyRun = {
     output: () => output,
     visibleOutput: () => visibleOutput,
-    write: async (data, writeOpts) => await writePtyInput(pty, data, writeOpts),
+    write: async (data, writeOpts) => await writePtyInput(pty, data, ptyEnv, writeOpts),
     waitForOutput: async (needle, timeoutMs = opts.outputTimeoutMs) =>
       await waitFor({
         timeoutMs,

--- a/test/vitest/vitest.extension-codex-app-server-attempt-light.config.ts
+++ b/test/vitest/vitest.extension-codex-app-server-attempt-light.config.ts
@@ -9,7 +9,6 @@ function createExtensionCodexAppServerAttemptLightVitestConfig(
       "extensions/codex/src/app-server/attempt-client-cleanup.test.ts",
       "extensions/codex/src/app-server/attempt-diagnostics.test.ts",
       "extensions/codex/src/app-server/attempt-steering.test.ts",
-      // Prewarming belongs to this shard only; duplicate ownership reruns initialization.
       "extensions/codex/src/app-server/run-attempt-client-prewarm.test.ts",
     ],
     {

--- a/test/vitest/vitest.extension-codex-app-server-attempt-light.config.ts
+++ b/test/vitest/vitest.extension-codex-app-server-attempt-light.config.ts
@@ -9,6 +9,7 @@ function createExtensionCodexAppServerAttemptLightVitestConfig(
       "extensions/codex/src/app-server/attempt-client-cleanup.test.ts",
       "extensions/codex/src/app-server/attempt-diagnostics.test.ts",
       "extensions/codex/src/app-server/attempt-steering.test.ts",
+      // Prewarming belongs to this shard only; duplicate ownership reruns initialization.
       "extensions/codex/src/app-server/run-attempt-client-prewarm.test.ts",
     ],
     {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where stress-testing the OpenClaw terminal UI with fragmented typing would corrupt emoji and other supplementary Unicode characters. Per-terminal typing controls were also read from the parent process instead of the fixture being tested, so fixture-specific fragmentation silently was not exercised.

## Why This Change Was Made

Resolve typing delay and chunk size from each PTY fixture's effective environment. Split delayed writes at Unicode code-point boundaries so surrogate pairs reach the terminal intact. Keep full-terminal Unicode and four compact-screen geometries in the existing bounded fixture support instead of growing the end-to-end file past the CI max-lines limit.

## User Impact

TUI terminal stress tests reliably cover real typing races, Unicode prompts, and approvals at four compact terminal sizes. Gateway restart, cross-client delivery, queued follow-ups, Escape cancellation, and collected follow-ups retain verified behavior. No public configuration or protocol changes.

## Evidence

- Reproduced before the fix: both fixture-specific Unicode chunk tests failed because the PTY wrote `A👋B` as one chunk instead of respecting one-character or two-character fragmentation.
- `node scripts/run-vitest.mjs src/tui/tui-pty-test-support.test.ts`: 9 passed, including both red-to-green Unicode cases.
- `node scripts/run-vitest.mjs src/tui`: 780 tests passed across 34 files.
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.tui-pty.config.ts src/tui/tui-pty-harness.e2e.test.ts`: all 35 real-terminal/fake-backend scenarios passed, including fragmented emoji and approvals at 64×18, 68×18, 72×20, and 80×20.
- Real Gateway PTY: all 5 targeted restart, cross-client, queued follow-up, Escape cancellation, and collected follow-up scenarios passed.
- Full-suite routing and Codex prewarming: 220 routing tests and all 5 prewarm tests passed; the duplicate discovered during the sweep was independently removed from current `main`.
- CI-equivalent type-aware `oxlint --type-aware --tsconfig config/tsconfig/oxlint.core.json` passed for all four changed TUI files, including the 1,000-line budget and unbound-method checks.
- Targeted `oxfmt --check` and `git diff --check` passed.
- Fresh structured Codex autoreview: clean; no accepted or actionable findings.
- AI-assisted.
