### PR TITLE
feat(plugins): mirror local coding sessions to a remote Beam receiver

### DIFF
--- a/config/knip.config.ts
+++ b/config/knip.config.ts
@@ -371,6 +371,9 @@ const config = {
     "extensions/onepassword/onepassword-op-path.js": ["exports"],
     // Focused CLI tests exercise plan construction through this explicit test seam.
     "extensions/onepassword/src/secret-ref-cli.ts": ["exports"],
+    // Mirror config parsing, redaction mapping, cap fitting, and the runner are
+    // asserted by the focused Beam mirror tests; production wires only the service.
+    "extensions/beam/src/mirror.ts": ["exports", "types"],
     "src/infra/heartbeat-wake.ts": ["exports"],
   },
   workspaces: {

--- a/docs/docs_map.md
+++ b/docs/docs_map.md
@@ -5719,6 +5719,7 @@ Do not edit it by hand; run `pnpm docs:map:gen`.
   - H2: Request
   - H2: Storage and visibility
   - H2: Security boundary
+  - H2: Mirroring
   - H2: Troubleshooting
   - H2: Related
 

--- a/docs/plugins/beam.md
+++ b/docs/plugins/beam.md
@@ -117,6 +117,37 @@ Beam is passive session publication, not remote control.
 - The receiver still treats every transcript as untrusted text. Copying a beamed transcript into a new agent session is a separate operator action.
 - Requests are rate-limited and concurrency-limited before the body is read.
 
+## Mirroring
+
+Beam can also act as the sender: an opt-in mirror that continuously publishes this machine's active local coding sessions (Claude Code, Codex, and other registered session catalogs) to a remote Beam receiver, such as a shared team Gateway. Teammates then watch near-live session transcripts in the remote Control UI without any access to the source machine.
+
+```json5
+{
+  plugins: {
+    entries: {
+      beam: {
+        enabled: true,
+        config: {
+          mirror: {
+            endpoint: "https://team.example.com/api/v1/beam/sessions",
+            token: { source: "env", provider: "default", id: "BEAM_TEAM_TOKEN" },
+            catalogs: ["claude", "codex"],
+          },
+        },
+      },
+    },
+  },
+}
+```
+
+- `endpoint` (required): the remote receiver URL. Use HTTPS outside loopback development.
+- `token`: Gateway credential for the remote receiver, sent as `Authorization: Bearer`. Accepts a plain string or a secret reference; a configured-but-unresolved token pauses mirroring instead of sending unauthenticated requests. Deployments fronted by an identity-aware proxy need an ingress that accepts this bearer credential.
+- `catalogs`: session catalog ids to mirror (default: every local catalog). The local `beam` receiver catalog is always excluded so two mirrored Gateways cannot re-mirror each other's rows.
+- `pollSeconds` (default 30, minimum 10): how often the mirror scans local catalogs.
+- `activeWindowMinutes` (default 180): sessions with newer activity than this window count as live and stay mirrored; when a session goes idle past the window the mirror sends one final `completed` update.
+
+The mirror applies the same redaction contract as the beam skill before anything leaves the machine: only user and agent message text is uploaded, while reasoning, tool calls, tool results, and raw payloads are replaced with compact counts. Snapshots are capped to the receiver limits (200 items, 56 KiB), dropping oldest entries first and marking the upload `truncated`. Sessions on paired nodes are not mirrored; the mirror shares only sessions from this Gateway's machine, newest 32 first.
+
 ## Troubleshooting
 
 `404 Not Found`

--- a/docs/plugins/beam.md
+++ b/docs/plugins/beam.md
@@ -140,9 +140,9 @@ Beam can also act as the sender: an opt-in mirror that continuously publishes th
 }
 ```
 
-- `endpoint` (required): the remote receiver URL. Use HTTPS outside loopback development.
+- `endpoint` (required): the remote receiver URL. HTTPS is enforced for non-loopback hosts; plaintext `http://` is accepted only for `localhost`/`127.0.0.1`/`::1` development.
 - `token`: Gateway credential for the remote receiver, sent as `Authorization: Bearer`. Accepts a plain string or a secret reference; a configured-but-unresolved token pauses mirroring instead of sending unauthenticated requests. Deployments fronted by an identity-aware proxy need an ingress that accepts this bearer credential.
-- `catalogs`: session catalog ids to mirror (default: every local catalog). The local `beam` receiver catalog is always excluded so two mirrored Gateways cannot re-mirror each other's rows.
+- `catalogs` (required): the session catalog ids to mirror, as explicit per-catalog consent — an omitted or empty list mirrors nothing. The local `beam` receiver catalog is always excluded so two mirrored Gateways cannot re-mirror each other's rows.
 - `pollSeconds` (default 30, minimum 10): how often the mirror scans local catalogs.
 - `activeWindowMinutes` (default 180): sessions with newer activity than this window count as live and stay mirrored; when a session goes idle past the window the mirror sends one final `completed` update.
 

--- a/extensions/beam/index.ts
+++ b/extensions/beam/index.ts
@@ -1,5 +1,6 @@
 import { definePluginEntry } from "openclaw/plugin-sdk/plugin-entry";
 import { createBeamRequestHandler } from "./src/http.js";
+import { createBeamMirrorService } from "./src/mirror.js";
 import { createBeamSessionCatalog } from "./src/session-catalog.js";
 import { createBeamStore } from "./src/store.js";
 
@@ -19,5 +20,6 @@ export default definePluginEntry({
         resolveControlUiBasePath: () => api.runtime.config.current().gateway?.controlUi?.basePath,
       }),
     });
+    api.registerService(createBeamMirrorService({ runtime: api.runtime }));
   },
 });

--- a/extensions/beam/openclaw.plugin.json
+++ b/extensions/beam/openclaw.plugin.json
@@ -22,7 +22,7 @@
       "mirror": {
         "type": "object",
         "additionalProperties": false,
-        "required": ["endpoint"],
+        "required": ["endpoint", "catalogs"],
         "properties": {
           "endpoint": {
             "type": "string"

--- a/extensions/beam/openclaw.plugin.json
+++ b/extensions/beam/openclaw.plugin.json
@@ -4,9 +4,46 @@
     "onStartup": false,
     "onConfigPaths": ["plugins.entries.beam"]
   },
+  "uiHints": {
+    "mirror.endpoint": {
+      "label": "Mirror Endpoint",
+      "help": "Remote Beam receiver URL, e.g. https://team.example.com/api/v1/beam/sessions."
+    },
+    "mirror.token": {
+      "label": "Mirror Token",
+      "help": "Gateway credential for the remote receiver, sent as a Bearer token.",
+      "sensitive": true
+    }
+  },
   "configSchema": {
     "type": "object",
     "additionalProperties": false,
-    "properties": {}
+    "properties": {
+      "mirror": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["endpoint"],
+        "properties": {
+          "endpoint": {
+            "type": "string"
+          },
+          "token": {
+            "type": ["string", "object"]
+          },
+          "catalogs": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "pollSeconds": {
+            "type": "number"
+          },
+          "activeWindowMinutes": {
+            "type": "number"
+          }
+        }
+      }
+    }
   }
 }

--- a/extensions/beam/src/mirror.test.ts
+++ b/extensions/beam/src/mirror.test.ts
@@ -1,0 +1,330 @@
+import type { PluginRuntime } from "openclaw/plugin-sdk/plugin-runtime";
+import type {
+  SessionCatalogHost,
+  SessionCatalogTranscriptItem,
+  SessionsCatalogReadResult,
+} from "openclaw/plugin-sdk/session-catalog";
+import type { ActiveSessionCatalog } from "openclaw/plugin-sdk/session-catalog-runtime";
+import { describe, expect, it } from "vitest";
+import {
+  beamMirrorId,
+  buildBeamMirrorItems,
+  createBeamMirrorRunner,
+  fitBeamMirrorUpload,
+  parseBeamMirrorConfig,
+  type BeamMirrorUpload,
+} from "./mirror.js";
+import { BEAM_MAX_ITEMS, parseBeamUpload } from "./types.js";
+
+const NOW = Date.parse("2026-07-27T12:00:00.000Z");
+
+function mirrorConfig(overrides: Record<string, unknown> = {}): unknown {
+  return {
+    plugins: {
+      entries: {
+        beam: {
+          enabled: true,
+          config: {
+            mirror: { endpoint: "https://team.example/api/v1/beam/sessions", ...overrides },
+          },
+        },
+      },
+    },
+  };
+}
+
+function fakeCatalog(params: {
+  id: string;
+  sessions: Array<{ threadId: string; name?: string; recencyAt: number }>;
+  items?: SessionCatalogTranscriptItem[];
+  hostKind?: string;
+  onRead?: (threadId: string) => void;
+}): ActiveSessionCatalog {
+  const host: SessionCatalogHost = {
+    hostId: "gateway:local",
+    label: "Local",
+    kind: (params.hostKind ?? "gateway") as SessionCatalogHost["kind"],
+    connected: true,
+    sessions: params.sessions.map((session) => ({
+      threadId: session.threadId,
+      ...(session.name ? { name: session.name } : {}),
+      status: "stored",
+      createdAt: NOW - 60_000,
+      updatedAt: session.recencyAt,
+      recencyAt: session.recencyAt,
+      archived: false,
+      canContinue: false,
+      canArchive: false,
+    })),
+  };
+  return {
+    pluginId: params.id,
+    id: params.id,
+    label: params.id,
+    list: async () => [host],
+    read: async ({ threadId }): Promise<SessionsCatalogReadResult> => {
+      params.onRead?.(threadId);
+      return {
+        hostId: "gateway:local",
+        label: "Local",
+        threadId,
+        items: params.items ?? [
+          { type: "userMessage", text: "Fix the flow." },
+          { type: "agentMessage", text: "Done." },
+        ],
+      };
+    },
+  };
+}
+
+function fakeRuntime(config: unknown): PluginRuntime {
+  return { config: { current: () => config } } as unknown as PluginRuntime;
+}
+
+type SentRequest = { url: string; auth?: string; payload: BeamMirrorUpload };
+
+function captureFetch(sent: SentRequest[], status = 200): typeof fetch {
+  return (async (url: unknown, init?: RequestInit) => {
+    const headers = (init?.headers ?? {}) as Record<string, string>;
+    sent.push({
+      url: String(url),
+      ...(headers.Authorization ? { auth: headers.Authorization } : {}),
+      payload: JSON.parse(init?.body as string) as BeamMirrorUpload,
+    });
+    return new Response("{}", { status });
+  }) as typeof fetch;
+}
+
+const silentLogger = { warn: () => {}, info: () => {} };
+
+describe("parseBeamMirrorConfig", () => {
+  it("returns undefined without mirror config", () => {
+    expect(parseBeamMirrorConfig({ plugins: { entries: { beam: { enabled: true } } } })).toBe(
+      undefined,
+    );
+  });
+
+  it("applies defaults and normalizes catalogs", () => {
+    const parsed = parseBeamMirrorConfig(mirrorConfig({ catalogs: [" Claude "] }));
+    expect(parsed).toMatchObject({
+      endpoint: "https://team.example/api/v1/beam/sessions",
+      catalogs: ["claude"],
+      pollSeconds: 30,
+      activeWindowMinutes: 180,
+    });
+  });
+
+  it("rejects unknown keys and non-http endpoints", () => {
+    expect(typeof parseBeamMirrorConfig(mirrorConfig({ bogus: true }))).toBe("string");
+    expect(typeof parseBeamMirrorConfig(mirrorConfig({ endpoint: "ftp://x" }))).toBe("string");
+    expect(typeof parseBeamMirrorConfig(mirrorConfig({ endpoint: "not a url" }))).toBe("string");
+  });
+
+  it("bounds poll and window values", () => {
+    const parsed = parseBeamMirrorConfig(
+      mirrorConfig({ pollSeconds: 1, activeWindowMinutes: 999_999 }),
+    );
+    expect(parsed).toMatchObject({ pollSeconds: 10, activeWindowMinutes: 10_080 });
+  });
+});
+
+describe("buildBeamMirrorItems", () => {
+  it("keeps user and agent text, collapses the rest into counts", () => {
+    const reduced = buildBeamMirrorItems([
+      { type: "userMessage", text: "Fix it." },
+      { type: "toolCall", text: "rm -rf /tmp/x", raw: { command: "secret" } },
+      { type: "toolResult", raw: { output: "secret output" } },
+      { type: "reasoning", text: "private thoughts" },
+      { type: "agentMessage", text: "Done." },
+    ]);
+    expect(reduced.items).toEqual([
+      { type: "userMessage", text: "Fix it." },
+      {
+        type: "other",
+        text: "1 tool calls, 1 tool results, 1 reasoning items; raw content dropped",
+      },
+      { type: "agentMessage", text: "Done." },
+    ]);
+    expect(reduced.droppedRaw).toBe(3);
+    expect(JSON.stringify(reduced.items)).not.toContain("secret");
+    expect(JSON.stringify(reduced.items)).not.toContain("private thoughts");
+  });
+
+  it("clips oversized message text to the receiver cap", () => {
+    const reduced = buildBeamMirrorItems([{ type: "userMessage", text: "x".repeat(10_000) }]);
+    expect(reduced.items[0]?.text.length).toBe(6_000);
+  });
+});
+
+describe("fitBeamMirrorUpload", () => {
+  it("drops oldest items to satisfy item and byte caps and marks truncation", () => {
+    const upload: BeamMirrorUpload = {
+      version: 1,
+      beamId: "0123456789abcdef0123456789abcdef",
+      source: "claude",
+      title: "big",
+      updatedAt: "2026-07-27T12:00:00.000Z",
+      completed: false,
+      items: Array.from({ length: 300 }, (_, index) => ({
+        type: "agentMessage" as const,
+        text: `entry ${index} ${"pad".repeat(200)}`,
+      })),
+    };
+    const fitted = fitBeamMirrorUpload(upload);
+    expect(fitted.truncated).toBe(true);
+    expect(fitted.items.length).toBeLessThanOrEqual(BEAM_MAX_ITEMS);
+    expect(fitted.items.at(-1)?.text).toContain("entry 299");
+    expect(Buffer.byteLength(JSON.stringify(fitted), "utf8")).toBeLessThanOrEqual(56 * 1024);
+    // The fitted payload must remain acceptable to the receiver.
+    expect(parseBeamUpload(structuredClone(fitted)).ok).toBe(true);
+  });
+});
+
+describe("createBeamMirrorRunner", () => {
+  it("uploads active local sessions and skips unchanged ones", async () => {
+    const sent: SentRequest[] = [];
+    const reads: string[] = [];
+    const catalog = fakeCatalog({
+      id: "claude",
+      sessions: [{ threadId: "t1", name: "Fix flow", recencyAt: NOW - 60_000 }],
+      onRead: (threadId) => reads.push(threadId),
+    });
+    const runner = createBeamMirrorRunner({
+      runtime: fakeRuntime(mirrorConfig({ token: "scratch-token" })),
+      logger: silentLogger,
+      fetchFn: captureFetch(sent),
+      now: () => NOW,
+      listCatalogs: () => [catalog],
+    });
+    await runner.tick();
+    await runner.tick();
+    expect(sent).toHaveLength(1);
+    expect(reads).toEqual(["t1", "t1"]);
+    expect(sent[0]?.auth).toBe("Bearer scratch-token");
+    expect(sent[0]?.payload).toMatchObject({
+      version: 1,
+      beamId: beamMirrorId("claude", "gateway:local", "t1"),
+      source: "claude",
+      title: "Fix flow",
+      completed: false,
+    });
+    expect(parseBeamUpload(structuredClone(sent[0]?.payload)).ok).toBe(true);
+  });
+
+  it("ignores idle sessions, node hosts, the beam catalog, and unlisted catalogs", async () => {
+    const sent: SentRequest[] = [];
+    const idle = fakeCatalog({
+      id: "claude",
+      sessions: [{ threadId: "old", recencyAt: NOW - 24 * 60 * 60_000 }],
+    });
+    const nodeHost = fakeCatalog({
+      id: "codex",
+      sessions: [{ threadId: "remote", recencyAt: NOW }],
+      hostKind: "node",
+    });
+    const beamCatalog = fakeCatalog({
+      id: "beam",
+      sessions: [{ threadId: "loop", recencyAt: NOW }],
+    });
+    const unlisted = fakeCatalog({
+      id: "pi",
+      sessions: [{ threadId: "p1", recencyAt: NOW }],
+    });
+    const runner = createBeamMirrorRunner({
+      runtime: fakeRuntime(mirrorConfig({ catalogs: ["claude", "codex", "beam"] })),
+      logger: silentLogger,
+      fetchFn: captureFetch(sent),
+      now: () => NOW,
+      listCatalogs: () => [idle, nodeHost, beamCatalog, unlisted],
+    });
+    await runner.tick();
+    expect(sent).toHaveLength(0);
+  });
+
+  it("sends one completed upload when a session leaves the active window", async () => {
+    const sent: SentRequest[] = [];
+    const recency = NOW - 60_000;
+    const catalog = fakeCatalog({ id: "claude", sessions: [] });
+    const liveCatalog: ActiveSessionCatalog = {
+      ...catalog,
+      list: async () => [
+        {
+          hostId: "gateway:local",
+          label: "Local",
+          kind: "gateway",
+          connected: true,
+          sessions: [
+            {
+              threadId: "t1",
+              name: "Fix flow",
+              status: "stored",
+              createdAt: NOW - 120_000,
+              updatedAt: recency,
+              recencyAt: recency,
+              archived: false,
+              canContinue: false,
+              canArchive: false,
+            },
+          ],
+        },
+      ],
+    };
+    let clock = NOW;
+    const runner = createBeamMirrorRunner({
+      runtime: fakeRuntime(mirrorConfig()),
+      logger: silentLogger,
+      fetchFn: captureFetch(sent),
+      now: () => clock,
+      listCatalogs: () => [liveCatalog],
+    });
+    await runner.tick();
+    expect(sent).toHaveLength(1);
+    expect(sent[0]?.payload.completed).toBe(false);
+    // Session goes idle past the window; the next tick finalizes it once.
+    clock = NOW + 4 * 60 * 60_000;
+    await runner.tick();
+    await runner.tick();
+    expect(sent).toHaveLength(2);
+    expect(sent[1]?.payload.completed).toBe(true);
+    expect(sent[1]?.payload.beamId).toBe(sent[0]?.payload.beamId);
+  });
+
+  it("keeps tracking for retry when the receiver rejects an upload", async () => {
+    const sent: SentRequest[] = [];
+    const warnings: string[] = [];
+    const catalog = fakeCatalog({
+      id: "claude",
+      sessions: [{ threadId: "t1", recencyAt: NOW - 60_000 }],
+    });
+    const runner = createBeamMirrorRunner({
+      runtime: fakeRuntime(mirrorConfig()),
+      logger: { warn: (message) => warnings.push(message), info: () => {} },
+      fetchFn: captureFetch(sent, 503),
+      now: () => NOW,
+      listCatalogs: () => [catalog],
+    });
+    await runner.tick();
+    await runner.tick();
+    // Both ticks retry because the failed upload was never fingerprinted.
+    expect(sent).toHaveLength(2);
+    expect(warnings.length).toBeGreaterThan(0);
+  });
+
+  it("skips ticks when a configured token cannot be resolved", async () => {
+    const sent: SentRequest[] = [];
+    const runner = createBeamMirrorRunner({
+      runtime: fakeRuntime(
+        mirrorConfig({ token: { source: "env", provider: "default", id: "BEAM_MISSING_TOKEN" } }),
+      ),
+      logger: silentLogger,
+      env: {},
+      fetchFn: captureFetch(sent),
+      now: () => NOW,
+      listCatalogs: () => [
+        fakeCatalog({ id: "claude", sessions: [{ threadId: "t1", recencyAt: NOW }] }),
+      ],
+    });
+    await runner.tick();
+    expect(sent).toHaveLength(0);
+  });
+});

--- a/extensions/beam/src/mirror.test.ts
+++ b/extensions/beam/src/mirror.test.ts
@@ -25,7 +25,11 @@ function mirrorConfig(overrides: Record<string, unknown> = {}): unknown {
         beam: {
           enabled: true,
           config: {
-            mirror: { endpoint: "https://team.example/api/v1/beam/sessions", ...overrides },
+            mirror: {
+              endpoint: "https://team.example/api/v1/beam/sessions",
+              catalogs: ["claude", "codex", "beam"],
+              ...overrides,
+            },
           },
         },
       },
@@ -118,6 +122,28 @@ describe("parseBeamMirrorConfig", () => {
     expect(typeof parseBeamMirrorConfig(mirrorConfig({ bogus: true }))).toBe("string");
     expect(typeof parseBeamMirrorConfig(mirrorConfig({ endpoint: "ftp://x" }))).toBe("string");
     expect(typeof parseBeamMirrorConfig(mirrorConfig({ endpoint: "not a url" }))).toBe("string");
+  });
+
+  it("allows plaintext http only for loopback development endpoints", () => {
+    expect(typeof parseBeamMirrorConfig(mirrorConfig({ endpoint: "http://team.example/x" }))).toBe(
+      "string",
+    );
+    expect(
+      parseBeamMirrorConfig(mirrorConfig({ endpoint: "http://127.0.0.1:19351/x" })),
+    ).toMatchObject({ endpoint: "http://127.0.0.1:19351/x" });
+    expect(
+      parseBeamMirrorConfig(mirrorConfig({ endpoint: "http://localhost:19351/x" })),
+    ).toMatchObject({ endpoint: "http://localhost:19351/x" });
+    expect(parseBeamMirrorConfig(mirrorConfig({ endpoint: "http://[::1]:19351/x" }))).toMatchObject(
+      {
+        endpoint: "http://[::1]:19351/x",
+      },
+    );
+  });
+
+  it("requires explicit catalog consent", () => {
+    expect(typeof parseBeamMirrorConfig(mirrorConfig({ catalogs: undefined }))).toBe("string");
+    expect(typeof parseBeamMirrorConfig(mirrorConfig({ catalogs: [] }))).toBe("string");
   });
 
   it("bounds poll and window values", () => {

--- a/extensions/beam/src/mirror.ts
+++ b/extensions/beam/src/mirror.ts
@@ -32,10 +32,15 @@ const MIRROR_WARN_INTERVAL_MS = 5 * 60_000;
 type BeamMirrorConfig = {
   endpoint: string;
   token?: unknown;
-  catalogs?: string[];
+  catalogs: string[];
   pollSeconds: number;
   activeWindowMinutes: number;
 };
+
+function isLoopbackHostname(hostname: string): boolean {
+  const bare = hostname.replace(/^\[|\]$/g, "");
+  return bare === "localhost" || bare === "127.0.0.1" || bare === "::1";
+}
 
 const MIRROR_KEYS = new Set([
   "endpoint",
@@ -75,23 +80,29 @@ export function parseBeamMirrorConfig(config: unknown): BeamMirrorConfig | undef
   } catch {
     return `${MIRROR_CONFIG_PATH}.endpoint must be an absolute URL`;
   }
-  if (parsedEndpoint.protocol !== "https:" && parsedEndpoint.protocol !== "http:") {
+  // Bearer credentials and transcripts must never cross the network in the
+  // clear; plaintext HTTP is a loopback-development affordance only.
+  if (parsedEndpoint.protocol === "http:") {
+    if (!isLoopbackHostname(parsedEndpoint.hostname)) {
+      return `${MIRROR_CONFIG_PATH}.endpoint must use https for non-loopback hosts`;
+    }
+  } else if (parsedEndpoint.protocol !== "https:") {
     return `${MIRROR_CONFIG_PATH}.endpoint must use http(s)`;
   }
-  let catalogs: string[] | undefined;
-  if (mirror.catalogs !== undefined) {
-    if (
-      !Array.isArray(mirror.catalogs) ||
-      mirror.catalogs.some((id) => typeof id !== "string" || !id.trim())
-    ) {
-      return `${MIRROR_CONFIG_PATH}.catalogs must be a list of catalog ids`;
-    }
-    catalogs = mirror.catalogs.map((id) => (id as string).trim().toLowerCase());
+  // Explicit per-catalog consent: an omitted or empty list mirrors nothing,
+  // so one Beam setting can never silently export third-party catalogs.
+  if (
+    !Array.isArray(mirror.catalogs) ||
+    mirror.catalogs.length === 0 ||
+    mirror.catalogs.some((id) => typeof id !== "string" || !id.trim())
+  ) {
+    return `${MIRROR_CONFIG_PATH}.catalogs must explicitly list the catalog ids to mirror`;
   }
+  const catalogs = mirror.catalogs.map((id) => (id as string).trim().toLowerCase());
   return {
     endpoint,
     ...(mirror.token !== undefined ? { token: mirror.token } : {}),
-    ...(catalogs ? { catalogs } : {}),
+    catalogs,
     pollSeconds: boundedNumber(mirror.pollSeconds, DEFAULT_POLL_SECONDS, 10, 3_600),
     activeWindowMinutes: boundedNumber(
       mirror.activeWindowMinutes,
@@ -362,8 +373,7 @@ export function createBeamMirrorRunner(params: {
         (catalog) =>
           // Never mirror the local beam receiver back out: a two-gateway pair
           // would otherwise re-mirror each other's rows forever.
-          catalog.id !== "beam" &&
-          (mirror.catalogs === undefined || mirror.catalogs.includes(catalog.id)),
+          catalog.id !== "beam" && mirror.catalogs.includes(catalog.id),
       );
       const catalogById = new Map(catalogs.map((catalog) => [catalog.id, catalog]));
       const candidates: BeamMirrorCandidate[] = [];
@@ -449,9 +459,7 @@ export function createBeamMirrorService(params: { runtime: PluginRuntime }): {
         void runner.tick();
       }, mirror.pollSeconds * 1_000);
       interval.unref?.();
-      ctx.logger.info(
-        `beam mirror active: ${mirror.catalogs?.join(", ") ?? "all local catalogs"} -> ${mirror.endpoint}`,
-      );
+      ctx.logger.info(`beam mirror active: ${mirror.catalogs.join(", ")} -> ${mirror.endpoint}`);
       void runner.tick();
     },
     stop() {

--- a/extensions/beam/src/mirror.ts
+++ b/extensions/beam/src/mirror.ts
@@ -1,0 +1,456 @@
+import { createHash } from "node:crypto";
+import type { PluginRuntime } from "openclaw/plugin-sdk/plugin-runtime";
+import { resolveConfiguredSecretInputString } from "openclaw/plugin-sdk/secret-input-runtime";
+import type {
+  SessionCatalogHost,
+  SessionCatalogTranscriptItem,
+} from "openclaw/plugin-sdk/session-catalog";
+import {
+  listActiveSessionCatalogs,
+  type ActiveSessionCatalog,
+} from "openclaw/plugin-sdk/session-catalog-runtime";
+import { isRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
+import { BEAM_MAX_BODY_BYTES, BEAM_MAX_ITEM_CHARS, BEAM_MAX_ITEMS } from "./types.js";
+
+const MIRROR_CONFIG_PATH = "plugins.entries.beam.config.mirror";
+const MIRROR_TOKEN_PATH = `${MIRROR_CONFIG_PATH}.token`;
+const DEFAULT_POLL_SECONDS = 30;
+const DEFAULT_ACTIVE_WINDOW_MINUTES = 180;
+const MIRROR_LIST_LIMIT = 100;
+// Strictest transcript-read cap across catalog providers (the Claude Code
+// provider rejects limits above 50); asking for more fails the whole read.
+const MIRROR_READ_LIMIT = 50;
+// Bounds concurrent remote rows and per-tick reads; oldest active sessions
+// beyond the cap simply wait until newer ones go idle.
+const MIRROR_MAX_SESSIONS = 32;
+// Leaves headroom below the receiver's hard body cap for JSON overhead drift.
+const MIRROR_BODY_BUDGET_BYTES = BEAM_MAX_BODY_BYTES - 2_048;
+// One warning per source per interval keeps a broken endpoint from flooding logs.
+const MIRROR_WARN_INTERVAL_MS = 5 * 60_000;
+
+export type BeamMirrorConfig = {
+  endpoint: string;
+  token?: unknown;
+  catalogs?: string[];
+  pollSeconds: number;
+  activeWindowMinutes: number;
+};
+
+const MIRROR_KEYS = new Set([
+  "endpoint",
+  "token",
+  "catalogs",
+  "pollSeconds",
+  "activeWindowMinutes",
+]);
+
+function boundedNumber(value: unknown, fallback: number, min: number, max: number): number {
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    return fallback;
+  }
+  return Math.min(max, Math.max(min, value));
+}
+
+/** Returns the mirror config, undefined when mirroring is not configured, or an error string. */
+export function parseBeamMirrorConfig(config: unknown): BeamMirrorConfig | undefined | string {
+  if (!isRecord(config)) {
+    return undefined;
+  }
+  const plugins = isRecord(config.plugins) ? config.plugins : undefined;
+  const entries = isRecord(plugins?.entries) ? plugins.entries : undefined;
+  const entry = isRecord(entries?.beam) ? entries.beam : undefined;
+  const pluginConfig = isRecord(entry?.config) ? entry.config : undefined;
+  const mirror = pluginConfig?.mirror;
+  if (mirror === undefined) {
+    return undefined;
+  }
+  if (!isRecord(mirror) || !Object.keys(mirror).every((key) => MIRROR_KEYS.has(key))) {
+    return `${MIRROR_CONFIG_PATH} must be a closed object with endpoint/token/catalogs/pollSeconds/activeWindowMinutes`;
+  }
+  const endpoint = typeof mirror.endpoint === "string" ? mirror.endpoint.trim() : "";
+  let parsedEndpoint: URL;
+  try {
+    parsedEndpoint = new URL(endpoint);
+  } catch {
+    return `${MIRROR_CONFIG_PATH}.endpoint must be an absolute URL`;
+  }
+  if (parsedEndpoint.protocol !== "https:" && parsedEndpoint.protocol !== "http:") {
+    return `${MIRROR_CONFIG_PATH}.endpoint must use http(s)`;
+  }
+  let catalogs: string[] | undefined;
+  if (mirror.catalogs !== undefined) {
+    if (
+      !Array.isArray(mirror.catalogs) ||
+      mirror.catalogs.some((id) => typeof id !== "string" || !id.trim())
+    ) {
+      return `${MIRROR_CONFIG_PATH}.catalogs must be a list of catalog ids`;
+    }
+    catalogs = mirror.catalogs.map((id) => (id as string).trim().toLowerCase());
+  }
+  return {
+    endpoint,
+    ...(mirror.token !== undefined ? { token: mirror.token } : {}),
+    ...(catalogs ? { catalogs } : {}),
+    pollSeconds: boundedNumber(mirror.pollSeconds, DEFAULT_POLL_SECONDS, 10, 3_600),
+    activeWindowMinutes: boundedNumber(
+      mirror.activeWindowMinutes,
+      DEFAULT_ACTIVE_WINDOW_MINUTES,
+      1,
+      10_080,
+    ),
+  };
+}
+
+type BeamMirrorItem = { type: "userMessage" | "agentMessage" | "other"; text: string };
+
+export type BeamMirrorUpload = {
+  version: 1;
+  beamId: string;
+  source: string;
+  title: string;
+  updatedAt: string;
+  completed: boolean;
+  truncated?: boolean;
+  items: BeamMirrorItem[];
+};
+
+export function beamMirrorId(catalogId: string, hostId: string, threadId: string): string {
+  return createHash("sha256")
+    .update(`${catalogId}\0${hostId}\0${threadId}`)
+    .digest("hex")
+    .slice(0, 32);
+}
+
+function clipText(text: string): string {
+  return text.length > BEAM_MAX_ITEM_CHARS ? text.slice(0, BEAM_MAX_ITEM_CHARS) : text;
+}
+
+function droppedSummary(counts: Map<string, number>): string | undefined {
+  if (counts.size === 0) {
+    return undefined;
+  }
+  const parts = [...counts.entries()].map(([kind, count]) => `${count} ${kind}`);
+  return `${parts.join(", ")}; raw content dropped`;
+}
+
+/**
+ * Reduce catalog transcript items to the Beam wire shape. Only user/agent
+ * message text crosses the wire; reasoning, tool calls, tool results, and raw
+ * payloads collapse into compact counts, matching the beam skill's redaction
+ * contract so the mirror never widens what a manual publish would share.
+ */
+export function buildBeamMirrorItems(items: readonly SessionCatalogTranscriptItem[]): {
+  items: BeamMirrorItem[];
+  droppedRaw: number;
+} {
+  const out: BeamMirrorItem[] = [];
+  let dropped = new Map<string, number>();
+  let droppedRaw = 0;
+  const flush = () => {
+    const summary = droppedSummary(dropped);
+    if (summary) {
+      out.push({ type: "other", text: clipText(summary) });
+      dropped = new Map();
+    }
+  };
+  const droppedLabel: Record<string, string> = {
+    toolCall: "tool calls",
+    toolResult: "tool results",
+    reasoning: "reasoning items",
+    other: "other entries",
+  };
+  for (const item of items) {
+    const text = item.text?.trim();
+    if ((item.type === "userMessage" || item.type === "agentMessage") && text) {
+      flush();
+      out.push({ type: item.type, text: clipText(text) });
+      continue;
+    }
+    droppedRaw += 1;
+    const label = droppedLabel[item.type] ?? droppedLabel.other;
+    dropped.set(label, (dropped.get(label) ?? 0) + 1);
+  }
+  flush();
+  return { items: out, droppedRaw };
+}
+
+/** Drop oldest items until the payload fits the receiver's item and byte caps. */
+export function fitBeamMirrorUpload(upload: BeamMirrorUpload): BeamMirrorUpload {
+  let items = upload.items.slice(-BEAM_MAX_ITEMS);
+  const truncatedByCount = upload.truncated === true || items.length < upload.items.length;
+  let fitted: BeamMirrorUpload = {
+    ...upload,
+    items,
+    ...(truncatedByCount ? { truncated: true } : {}),
+  };
+  while (
+    items.length > 1 &&
+    Buffer.byteLength(JSON.stringify(fitted), "utf8") > MIRROR_BODY_BUDGET_BYTES
+  ) {
+    items = items.slice(1);
+    fitted = { ...upload, items, truncated: true };
+  }
+  return fitted;
+}
+
+export type BeamMirrorCandidate = {
+  catalogId: string;
+  hostId: string;
+  threadId: string;
+  title: string;
+  recencyAt: number;
+};
+
+function hostCandidates(
+  catalogId: string,
+  hosts: readonly SessionCatalogHost[],
+  activeSinceMs: number,
+): BeamMirrorCandidate[] {
+  const out: BeamMirrorCandidate[] = [];
+  for (const host of hosts) {
+    // Node-attached hosts belong to other machines; the mirror shares only
+    // sessions that run on this gateway's machine.
+    if (host.kind !== "gateway") {
+      continue;
+    }
+    for (const session of host.sessions) {
+      const recencyAt = session.recencyAt ?? session.updatedAt ?? 0;
+      if (recencyAt < activeSinceMs) {
+        continue;
+      }
+      out.push({
+        catalogId,
+        hostId: host.hostId,
+        threadId: session.threadId,
+        title: session.name?.trim() || `${catalogId} session`,
+        recencyAt,
+      });
+    }
+  }
+  return out;
+}
+
+type TrackedMirrorSession = {
+  candidate: BeamMirrorCandidate;
+  fingerprint: string;
+};
+
+export type BeamMirrorRunner = {
+  tick: () => Promise<void>;
+};
+
+export function createBeamMirrorRunner(params: {
+  runtime: PluginRuntime;
+  logger: { warn: (message: string) => void; info: (message: string) => void };
+  env?: NodeJS.ProcessEnv;
+  fetchFn?: typeof fetch;
+  now?: () => number;
+  listCatalogs?: () => ActiveSessionCatalog[];
+}): BeamMirrorRunner {
+  const env = params.env ?? process.env;
+  const fetchFn = params.fetchFn ?? fetch;
+  const now = params.now ?? Date.now;
+  const listCatalogs = params.listCatalogs ?? listActiveSessionCatalogs;
+  const tracked = new Map<string, TrackedMirrorSession>();
+  let lastWarnAt = 0;
+  let running = false;
+
+  const warnThrottled = (message: string) => {
+    if (now() - lastWarnAt >= MIRROR_WARN_INTERVAL_MS) {
+      lastWarnAt = now();
+      params.logger.warn(message);
+    }
+  };
+
+  const upload = async (
+    endpoint: string,
+    token: string | undefined,
+    payload: BeamMirrorUpload,
+  ): Promise<boolean> => {
+    const response = await fetchFn(endpoint, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        ...(token ? { Authorization: `Bearer ${token}` } : {}),
+      },
+      body: JSON.stringify(payload),
+    });
+    if (!response.ok) {
+      warnThrottled(`beam mirror upload failed (${response.status}) for ${payload.source}`);
+      return false;
+    }
+    return true;
+  };
+
+  const buildUpload = async (
+    catalog: ActiveSessionCatalog,
+    candidate: BeamMirrorCandidate,
+    completed: boolean,
+  ): Promise<BeamMirrorUpload> => {
+    const transcript = await catalog.read({
+      hostId: candidate.hostId,
+      threadId: candidate.threadId,
+      limit: MIRROR_READ_LIMIT,
+    });
+    const reduced = buildBeamMirrorItems(transcript.items);
+    const items = reduced.items.length
+      ? reduced.items
+      : [{ type: "other" as const, text: "no shareable messages yet" }];
+    return fitBeamMirrorUpload({
+      version: 1,
+      beamId: beamMirrorId(candidate.catalogId, candidate.hostId, candidate.threadId),
+      source: candidate.catalogId,
+      title: candidate.title.slice(0, 160),
+      updatedAt: new Date(candidate.recencyAt || now()).toISOString(),
+      completed,
+      items,
+    });
+  };
+
+  const mirrorFingerprint = (payload: BeamMirrorUpload): string =>
+    createHash("sha256")
+      .update(
+        JSON.stringify({
+          title: payload.title,
+          completed: payload.completed,
+          items: payload.items,
+        }),
+      )
+      .digest("hex");
+
+  const tick = async (): Promise<void> => {
+    if (running) {
+      return;
+    }
+    running = true;
+    try {
+      const config = params.runtime.config.current();
+      const mirror = parseBeamMirrorConfig(config);
+      if (mirror === undefined) {
+        return;
+      }
+      if (typeof mirror === "string") {
+        warnThrottled(`beam mirror disabled: ${mirror}`);
+        return;
+      }
+      let token: string | undefined;
+      if (mirror.token !== undefined) {
+        const resolved = await resolveConfiguredSecretInputString({
+          config,
+          env,
+          value: mirror.token,
+          path: MIRROR_TOKEN_PATH,
+        });
+        if (!resolved.value) {
+          warnThrottled(
+            `beam mirror token unresolved${resolved.unresolvedRefReason ? `: ${resolved.unresolvedRefReason}` : ""}`,
+          );
+          return;
+        }
+        token = resolved.value;
+      }
+      const activeSinceMs = now() - mirror.activeWindowMinutes * 60_000;
+      const catalogs = listCatalogs().filter(
+        (catalog) =>
+          // Never mirror the local beam receiver back out: a two-gateway pair
+          // would otherwise re-mirror each other's rows forever.
+          catalog.id !== "beam" &&
+          (mirror.catalogs === undefined || mirror.catalogs.includes(catalog.id)),
+      );
+      const catalogById = new Map(catalogs.map((catalog) => [catalog.id, catalog]));
+      const candidates: BeamMirrorCandidate[] = [];
+      for (const catalog of catalogs) {
+        try {
+          const hosts = await catalog.list({ limitPerHost: MIRROR_LIST_LIMIT });
+          candidates.push(...hostCandidates(catalog.id, hosts, activeSinceMs));
+        } catch (error) {
+          warnThrottled(`beam mirror list failed for ${catalog.id}: ${String(error)}`);
+        }
+      }
+      candidates.sort((left, right) => right.recencyAt - left.recencyAt);
+      const selected = candidates.slice(0, MIRROR_MAX_SESSIONS);
+      const selectedKeys = new Set<string>();
+      for (const candidate of selected) {
+        const key = `${candidate.catalogId}\0${candidate.hostId}\0${candidate.threadId}`;
+        selectedKeys.add(key);
+        const catalog = catalogById.get(candidate.catalogId);
+        if (!catalog) {
+          continue;
+        }
+        try {
+          const payload = await buildUpload(catalog, candidate, false);
+          const fingerprint = mirrorFingerprint(payload);
+          if (tracked.get(key)?.fingerprint === fingerprint) {
+            continue;
+          }
+          if (await upload(mirror.endpoint, token, payload)) {
+            tracked.set(key, { candidate, fingerprint });
+          }
+        } catch (error) {
+          warnThrottled(`beam mirror upload failed for ${candidate.catalogId}: ${String(error)}`);
+        }
+      }
+      // Sessions that left the active window get one final completed upload so
+      // remote rows flip from live to completed instead of lingering until TTL.
+      for (const [key, entry] of tracked) {
+        if (selectedKeys.has(key)) {
+          continue;
+        }
+        tracked.delete(key);
+        const catalog = catalogById.get(entry.candidate.catalogId);
+        if (!catalog) {
+          continue;
+        }
+        try {
+          const payload = await buildUpload(catalog, entry.candidate, true);
+          await upload(mirror.endpoint, token, payload);
+        } catch {
+          // The session store may already be gone; the receiver TTL cleans up.
+        }
+      }
+    } finally {
+      running = false;
+    }
+  };
+
+  return { tick };
+}
+
+export function createBeamMirrorService(params: { runtime: PluginRuntime }): {
+  id: string;
+  start: (ctx: { logger: { warn: (m: string) => void; info: (m: string) => void } }) => void;
+  stop: () => void;
+} {
+  let interval: ReturnType<typeof setInterval> | undefined;
+  return {
+    id: "beam-mirror",
+    start(ctx) {
+      const mirror = parseBeamMirrorConfig(params.runtime.config.current());
+      if (mirror === undefined) {
+        return;
+      }
+      if (typeof mirror === "string") {
+        ctx.logger.warn(`beam mirror disabled: ${mirror}`);
+        return;
+      }
+      const runner = createBeamMirrorRunner({ runtime: params.runtime, logger: ctx.logger });
+      // The catalog poll is this service's lifecycle-owned freshness exception:
+      // local coding sessions change outside gateway events, so a bounded
+      // unref'd interval is the only way to observe them.
+      interval = setInterval(() => {
+        void runner.tick();
+      }, mirror.pollSeconds * 1_000);
+      interval.unref?.();
+      ctx.logger.info(
+        `beam mirror active: ${mirror.catalogs?.join(", ") ?? "all local catalogs"} -> ${mirror.endpoint}`,
+      );
+      void runner.tick();
+    },
+    stop() {
+      if (interval) {
+        clearInterval(interval);
+        interval = undefined;
+      }
+    },
+  };
+}

--- a/extensions/beam/src/mirror.ts
+++ b/extensions/beam/src/mirror.ts
@@ -1,4 +1,5 @@
 import { createHash } from "node:crypto";
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-runtime";
 import type { PluginRuntime } from "openclaw/plugin-sdk/plugin-runtime";
 import { resolveConfiguredSecretInputString } from "openclaw/plugin-sdk/secret-input-runtime";
 import type {
@@ -28,7 +29,7 @@ const MIRROR_BODY_BUDGET_BYTES = BEAM_MAX_BODY_BYTES - 2_048;
 // One warning per source per interval keeps a broken endpoint from flooding logs.
 const MIRROR_WARN_INTERVAL_MS = 5 * 60_000;
 
-export type BeamMirrorConfig = {
+type BeamMirrorConfig = {
   endpoint: string;
   token?: unknown;
   catalogs?: string[];
@@ -153,11 +154,17 @@ export function buildBeamMirrorItems(items: readonly SessionCatalogTranscriptIte
       dropped = new Map();
     }
   };
-  const droppedLabel: Record<string, string> = {
-    toolCall: "tool calls",
-    toolResult: "tool results",
-    reasoning: "reasoning items",
-    other: "other entries",
+  const droppedLabel = (type: string): string => {
+    switch (type) {
+      case "toolCall":
+        return "tool calls";
+      case "toolResult":
+        return "tool results";
+      case "reasoning":
+        return "reasoning items";
+      default:
+        return "other entries";
+    }
   };
   for (const item of items) {
     const text = item.text?.trim();
@@ -167,7 +174,7 @@ export function buildBeamMirrorItems(items: readonly SessionCatalogTranscriptIte
       continue;
     }
     droppedRaw += 1;
-    const label = droppedLabel[item.type] ?? droppedLabel.other;
+    const label = droppedLabel(item.type);
     dropped.set(label, (dropped.get(label) ?? 0) + 1);
   }
   flush();
@@ -193,7 +200,7 @@ export function fitBeamMirrorUpload(upload: BeamMirrorUpload): BeamMirrorUpload 
   return fitted;
 }
 
-export type BeamMirrorCandidate = {
+type BeamMirrorCandidate = {
   catalogId: string;
   hostId: string;
   threadId: string;
@@ -235,7 +242,7 @@ type TrackedMirrorSession = {
   fingerprint: string;
 };
 
-export type BeamMirrorRunner = {
+type BeamMirrorRunner = {
   tick: () => Promise<void>;
 };
 
@@ -336,7 +343,8 @@ export function createBeamMirrorRunner(params: {
       let token: string | undefined;
       if (mirror.token !== undefined) {
         const resolved = await resolveConfiguredSecretInputString({
-          config,
+          // The resolver only reads; the plugin runtime exposes a DeepReadonly view.
+          config: config as OpenClawConfig,
           env,
           value: mirror.token,
           path: MIRROR_TOKEN_PATH,

--- a/extensions/beam/src/mirror.ts
+++ b/extensions/beam/src/mirror.ts
@@ -1,5 +1,5 @@
 import { createHash } from "node:crypto";
-import type { OpenClawConfig } from "openclaw/plugin-sdk/config-runtime";
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import type { PluginRuntime } from "openclaw/plugin-sdk/plugin-runtime";
 import { resolveConfiguredSecretInputString } from "openclaw/plugin-sdk/secret-input-runtime";
 import type {

--- a/extensions/beam/src/types.ts
+++ b/extensions/beam/src/types.ts
@@ -4,8 +4,8 @@ export const BEAM_HOST_ID = "gateway";
 export const BEAM_MAX_BODY_BYTES = 56 * 1024;
 export const BEAM_RETENTION_MS = 7 * 24 * 60 * 60 * 1000;
 export const BEAM_MAX_SESSIONS = 500;
-const BEAM_MAX_ITEMS = 200;
-const BEAM_MAX_ITEM_CHARS = 6_000;
+export const BEAM_MAX_ITEMS = 200;
+export const BEAM_MAX_ITEM_CHARS = 6_000;
 
 type BeamTranscriptItem = {
   type: "userMessage" | "agentMessage" | "other";

--- a/extensions/tsconfig.package-boundary.paths.json
+++ b/extensions/tsconfig.package-boundary.paths.json
@@ -296,6 +296,9 @@
       "openclaw/plugin-sdk/session-catalog": [
         "../packages/plugin-sdk/dist/src/plugin-sdk/session-catalog.d.ts"
       ],
+      "openclaw/plugin-sdk/session-catalog-runtime": [
+        "../packages/plugin-sdk/dist/src/plugin-sdk/session-catalog-runtime.d.ts"
+      ],
       "openclaw/plugin-sdk/session-key-runtime": [
         "../packages/plugin-sdk/dist/src/plugin-sdk/session-key-runtime.d.ts"
       ],

--- a/extensions/xai/tsconfig.json
+++ b/extensions/xai/tsconfig.json
@@ -294,6 +294,9 @@
       "openclaw/plugin-sdk/session-catalog": [
         "../../packages/plugin-sdk/dist/src/plugin-sdk/session-catalog.d.ts"
       ],
+      "openclaw/plugin-sdk/session-catalog-runtime": [
+        "../../packages/plugin-sdk/dist/src/plugin-sdk/session-catalog-runtime.d.ts"
+      ],
       "openclaw/plugin-sdk/session-key-runtime": [
         "../../packages/plugin-sdk/dist/src/plugin-sdk/session-key-runtime.d.ts"
       ],

--- a/package.json
+++ b/package.json
@@ -183,6 +183,7 @@
     "!dist/plugin-sdk/secure-random-runtime.d.ts",
     "!dist/plugin-sdk/session-binding-runtime.d.ts",
     "!dist/plugin-sdk/session-catalog.d.ts",
+    "!dist/plugin-sdk/session-catalog-runtime.d.ts",
     "!dist/plugin-sdk/session-key-runtime.d.ts",
     "!dist/plugin-sdk/session-transcript-hit.d.ts",
     "!dist/plugin-sdk/session-transcript-runtime.d.ts",
@@ -1005,6 +1006,9 @@
     },
     "./plugin-sdk/session-catalog": {
       "default": "./dist/plugin-sdk/session-catalog.js"
+    },
+    "./plugin-sdk/session-catalog-runtime": {
+      "default": "./dist/plugin-sdk/session-catalog-runtime.js"
     },
     "./plugin-sdk/session-discussion": {
       "types": "./dist/plugin-sdk/session-discussion.d.ts",

--- a/scripts/lib/plugin-sdk-entrypoints.json
+++ b/scripts/lib/plugin-sdk-entrypoints.json
@@ -201,6 +201,7 @@
   "response-limit-runtime",
   "session-binding-runtime",
   "session-catalog",
+  "session-catalog-runtime",
   "session-discussion",
   "session-key-runtime",
   "session-store-runtime",

--- a/scripts/lib/plugin-sdk-private-local-only-subpaths.json
+++ b/scripts/lib/plugin-sdk-private-local-only-subpaths.json
@@ -136,6 +136,7 @@
   "secure-random-runtime",
   "session-binding-runtime",
   "session-catalog",
+  "session-catalog-runtime",
   "session-key-runtime",
   "session-transcript-hit",
   "session-transcript-runtime",

--- a/src/plugin-sdk/session-catalog-runtime.ts
+++ b/src/plugin-sdk/session-catalog-runtime.ts
@@ -1,0 +1,5 @@
+// Runtime SDK subpath for read-only access to the active registered session catalogs.
+export {
+  listActiveSessionCatalogs,
+  type ActiveSessionCatalog,
+} from "../plugins/session-catalog-active.js";

--- a/src/plugins/session-catalog-active.ts
+++ b/src/plugins/session-catalog-active.ts
@@ -1,0 +1,28 @@
+import { getActivePluginSessionExtensionRegistry } from "./runtime.js";
+import type { SessionCatalogProvider } from "./session-catalog.js";
+
+export type ActiveSessionCatalog = {
+  pluginId: string;
+  id: string;
+  label: string;
+  list: SessionCatalogProvider["list"];
+  read: SessionCatalogProvider["read"];
+};
+
+/**
+ * Read-only list/read facade over the active registered session catalogs.
+ * Deliberately excludes continue/archive/terminal so consumers cannot gain
+ * session control through this seam; mutation stays on the gateway RPCs.
+ */
+export function listActiveSessionCatalogs(): ActiveSessionCatalog[] {
+  const registrations = getActivePluginSessionExtensionRegistry()?.sessionCatalogs ?? [];
+  return registrations
+    .map(({ pluginId, provider }) => ({
+      pluginId,
+      id: provider.id,
+      label: provider.label,
+      list: provider.list.bind(provider),
+      read: provider.read.bind(provider),
+    }))
+    .toSorted((left, right) => left.id.localeCompare(right.id));
+}


### PR DESCRIPTION
# What Problem This Solves

Beam (landed in #112323) can receive one manually published snapshot of a local coding session, and the companion skill can re-publish on lifecycle hooks — but there is no way to continuously MIRROR the live coding sessions running on a developer's machine into a shared team Gateway. Teammates on a team OpenClaw instance (for example team.openclaw.ai) cannot watch what local Claude Code/Codex sessions are doing right now without per-session manual publishes from inside each harness.

# Why This Change Was Made

This adds the sender half of Beam: an opt-in `mirror` config on the bundled `beam` plugin. The local Gateway already catalogs the machine's local coding sessions (Claude Code, Codex, and other registered session catalogs); the mirror reuses exactly that prepared surface — local catalog read → redacted remote Beam write — instead of re-implementing transcript discovery.

- New narrow local-only Plugin SDK subpath `session-catalog-runtime` exposing `listActiveSessionCatalogs()`: a read-only `{id, label, list, read}` facade over the registered catalog providers (no continue/archive/terminal capability crosses the seam).
- New `extensions/beam/src/mirror.ts`: a lifecycle-owned Gateway service that polls local catalogs on a bounded interval, selects sessions active within a configurable window (newest 32, gateway-kind hosts only — paired-node sessions are never mirrored), and POSTs receiver-shaped snapshots to the configured remote Beam endpoint with a Bearer credential resolved through the standard secret-input machinery.
- Redaction parity with the beam skill before anything leaves the machine: only user/agent message text is uploaded; reasoning, tool calls, tool results, and raw payloads collapse into compact counts. Payloads are fitted to the receiver caps (200 items / 56 KiB, oldest dropped first, marked `truncated`).
- Live→completed semantics: unchanged sessions are skipped via fingerprints; when a mirrored session goes idle past the active window, the mirror sends one final `completed` upload so remote rows flip from `live` to `completed` instead of lingering until TTL.
- Loop prevention: the local `beam` receiver catalog is always excluded, so two mirrored Gateways cannot re-mirror each other's rows.
- Config (under `plugins.entries.beam.config.mirror`): required `endpoint`; optional `token` (plain string or secret ref; configured-but-unresolved tokens pause mirroring instead of sending unauthenticated requests), required `catalogs` as explicit per-catalog consent (an omitted or empty list mirrors nothing), `pollSeconds` (default 30, min 10), `activeWindowMinutes` (default 180). HTTPS is enforced for non-loopback endpoints; plaintext HTTP is loopback-development only. Closed schema in the plugin manifest with a sensitive UI hint on `mirror.token`.

# User Impact

A developer sets one config block on their local Gateway and their active local coding sessions appear as near-live, read-only transcripts in the team Gateway's Beam catalog, updating every poll tick and completing automatically when sessions go idle. The receiving side is unchanged (#112323): uploads still require `operator.write`, viewers need `operator.read`, and the receiver keeps its bounded, text-only, no-remote-control contract.

# Evidence

- `node scripts/run-vitest.mjs extensions/beam` — 22 tests passed (14 new mirror tests: config parsing/bounds, redaction mapping incl. no-secret-leak assertions, receiver-cap fitting revalidated against `parseBeamUpload`, dedupe fingerprints, node-host/beam-catalog/idle exclusions, completed-flip on idle, retry-on-5xx, unresolved-token pause).
- Live two-Gateway proof on this head: sender Gateway (mirror configured, `catalogs: ["claude"]`) mirrored real local Claude Code sessions into a second scratch receiver Gateway; `sessions.catalog.list`/`read` on the receiver showed the mirrored rows and reduced transcripts (redacted transcript below).
- Lint (`scripts/run-oxlint.mjs`) and oxfmt clean on changed files.

<details>
<summary>Redacted live two-Gateway mirror transcript on the final head (sender mirrors real local Claude Code sessions into a scratch team receiver)</summary>

```text
== git head ==
f038c4b5efae6ddaccb7e173183a4a90f8344e6d
== worktree dirty files (mirror feature under test) ==
== starting receiver (team) gateway on :19351 ==
== starting sender gateway on :19352 ==
receiver is up
sender is up
== waiting for mirror ticks (~35s) ==
== receiver sessions.catalog.list (beam catalog) ==
mirrored rows on receiver: 12
  - beamId=b6f643cc… source=claude status=live title='OpenClaw competitive gap analysis'
  - beamId=e6199f1e… source=claude status=live title='Session lineage data model'
  - beamId=0d084fda… source=claude status=live title='Onboarding logic and local model options'
  [... remaining rows elided (local session titles redacted); 12 total mirrored ...]
== receiver sessions.catalog.read of first mirrored session ==
transcript items: 22; label='OpenClaw competitive gap analysis'
item type counts: {'agentMessage': 9, 'other': 9, 'userMessage': 4}
non-wire item types leaked: 0
items carrying raw payloads: 0
== sender log: mirror lines ==
2026-07-27T13:58:33.625-07:00 [plugins] beam mirror active: claude -> http://127.0.0.1:19351/api/v1/beam/sessions
== done; scratch=/tmp/beam-mirror-proof-BhA4fm ==
```

</details>

AI-assisted implementation; behavior, ownership boundary, and redaction contract manually reviewed and live-validated.
