### PR TITLE
perf(gateway): reuse request-scoped store caches in mutation authorization

### DIFF
--- a/src/gateway/session-sharing-store-cache.test.ts
+++ b/src/gateway/session-sharing-store-cache.test.ts
@@ -1,0 +1,136 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import * as sessionsConfig from "../config/sessions.js";
+import * as sessionAccessor from "../config/sessions/session-accessor.js";
+import { closeOpenClawAgentDatabasesForTest } from "../state/openclaw-agent-db.js";
+import { withOpenClawTestState } from "../test-utils/openclaw-test-state.js";
+import type { GatewayClient } from "./server-methods/types.js";
+import {
+  authorizeResolvedSessionMutation,
+  resolveSessionMutationAuthorization,
+} from "./session-sharing.js";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  closeOpenClawAgentDatabasesForTest();
+});
+
+function identifiedClient(userId: string): GatewayClient {
+  return {
+    connect: {
+      minProtocol: 1,
+      maxProtocol: 1,
+      client: {
+        id: "openclaw-control-ui",
+        version: "test",
+        platform: "test",
+        mode: "webchat",
+      },
+      role: "operator",
+      scopes: ["operator.read", "operator.write"],
+    },
+    authenticatedUserId: userId,
+    authenticatedUserProfile: {
+      profileId: userId,
+      displayName: null,
+      hasAvatar: false,
+      updatedAt: 1,
+    },
+  };
+}
+
+describe("session mutation authorization store caches", () => {
+  it("materializes and discovers each store once when one request resolves multiple targets", async () => {
+    await withOpenClawTestState({ scenario: "minimal" }, async () => {
+      for (const [sessionKey, sessionId] of [
+        ["agent:main:cache-one", "session-cache-one"],
+        ["agent:main:cache-two", "session-cache-two"],
+      ] as const) {
+        await sessionAccessor.upsertSessionEntry(
+          { agentId: "main", sessionKey },
+          { sessionId, updatedAt: 1, visibility: "shared", category: "Cache Test" },
+        );
+      }
+
+      const materializations = new Map<string, number>();
+      const originalListSessionEntries = sessionAccessor.listSessionEntries;
+      vi.spyOn(sessionAccessor, "listSessionEntries").mockImplementation((scope) => {
+        const entries = originalListSessionEntries(scope);
+        if (scope?.clone === false) {
+          const storePath = scope.storePath ?? "default";
+          materializations.set(storePath, (materializations.get(storePath) ?? 0) + 1);
+        }
+        return entries;
+      });
+      const discoverySpy = vi.spyOn(sessionsConfig, "resolveExistingAgentSessionStoreTargetsSync");
+      const cfg = {};
+
+      expect(
+        resolveSessionMutationAuthorization({
+          client: identifiedClient("viewer@example.com"),
+          method: "sessions.groups.delete",
+          requestParams: { name: "Cache Test" },
+          context: {
+            chatAbortControllers: new Map(),
+            getRuntimeConfig: () => cfg,
+          } as never,
+        }).error,
+      ).toBeNull();
+
+      expect([...materializations.values()]).toEqual([1]);
+      expect(discoverySpy.mock.calls.filter((call) => call[1] === "main")).toHaveLength(1);
+    });
+  });
+
+  it.each([
+    {
+      name: "shared",
+      sessionKey: "agent:main:cache-parity-shared",
+      entry: { sessionId: "session-shared", updatedAt: 1, visibility: "shared" as const },
+    },
+    {
+      name: "private draft",
+      sessionKey: "agent:main:cache-parity-private",
+      entry: {
+        sessionId: "session-private",
+        updatedAt: 1,
+        visibility: "draft" as const,
+        createdActor: { type: "human" as const, id: "owner@example.com" },
+      },
+    },
+    {
+      name: "incognito",
+      sessionKey: "agent:main:dashboard:incognito-cache-parity",
+      entry: {
+        sessionId: "session-incognito",
+        updatedAt: 1,
+        visibility: "shared" as const,
+        incognito: true as const,
+        createdActor: { type: "human" as const, id: "owner@example.com" },
+      },
+    },
+  ])("matches uncached $name authorization", async ({ sessionKey, entry }) => {
+    await withOpenClawTestState({ scenario: "minimal" }, async () => {
+      await sessionAccessor.upsertSessionEntry({ agentId: "main", sessionKey }, entry);
+      const cfg = {};
+      const requestClient = identifiedClient("viewer@example.com");
+      const uncachedError = authorizeResolvedSessionMutation({
+        cfg,
+        client: requestClient,
+        sessionKey,
+        agentId: "main",
+      });
+
+      expect(
+        resolveSessionMutationAuthorization({
+          client: requestClient,
+          method: "chat.send",
+          requestParams: { sessionKey, agentId: "main" },
+          context: {
+            chatAbortControllers: new Map(),
+            getRuntimeConfig: () => cfg,
+          } as never,
+        }).error,
+      ).toEqual(uncachedError);
+    });
+  });
+});

--- a/src/gateway/session-sharing.ts
+++ b/src/gateway/session-sharing.ts
@@ -482,6 +482,13 @@ export function resolveSessionMutationAuthorization(params: {
   // config change cannot split target discovery from authorization.
   let cachedCfg: OpenClawConfig | undefined;
   const getCfg = (): OpenClawConfig => (cachedCfg ??= params.context.getRuntimeConfig());
+  // Each cache pair defines one synchronous freshness epoch: initial authorization shares one,
+  // while commit-time guards start fresh after handler work.
+  const createLookupCaches = (): {
+    storeCache: GatewaySessionStoreCache;
+    targetDiscoveryCache: GatewaySessionStoreDiscoveryCache;
+  } => ({ storeCache: new Map(), targetDiscoveryCache: new Map() });
+  const lookupCaches = createLookupCaches();
   // Incognito direct reads and writes share this central participation choke point;
   // hidden keys use the stale-session refusal instead of revealing existence.
   for (const targetRef of resolveDirectIncognitoTargets(params.method, params.requestParams)) {
@@ -489,6 +496,7 @@ export function resolveSessionMutationAuthorization(params: {
       cfg: getCfg(),
       sessionKey: targetRef.sessionKey,
       agentId: targetRef.agentId,
+      ...lookupCaches,
     });
     const error = authorizeIncognitoSessionTarget({
       client: params.client,
@@ -522,6 +530,7 @@ export function resolveSessionMutationAuthorization(params: {
       cfg,
       sessionKey: targetRef.sessionKey,
       agentId: targetRef.agentId,
+      ...lookupCaches,
     });
     const error = target ? authorizeSessionSharingTarget({ client: params.client, target }) : null;
     if (error) {
@@ -547,11 +556,13 @@ export function resolveSessionMutationAuthorization(params: {
         targetRef: SessionMutationTarget,
         expected: AuthorizedSessionMutationTarget | undefined,
         currentCfg: OpenClawConfig,
+        currentLookupCaches?: ReturnType<typeof createLookupCaches>,
       ) => {
         const current = resolveSessionSharingTarget({
           cfg: currentCfg,
           sessionKey: targetRef.sessionKey,
           agentId: targetRef.agentId,
+          ...currentLookupCaches,
         });
         const sameResolvedTarget =
           expected === undefined ||
@@ -589,8 +600,9 @@ export function resolveSessionMutationAuthorization(params: {
       return {
         assertCurrent: () => {
           const currentCfg = params.context.getRuntimeConfig();
+          const currentLookupCaches = createLookupCaches();
           for (const authorized of authorizedTargets) {
-            assertTargetCurrent(authorized, authorized, currentCfg);
+            assertTargetCurrent(authorized, authorized, currentCfg, currentLookupCaches);
           }
         },
         assertTargetCurrent: (targetRef: SessionMutationTarget) => {


### PR DESCRIPTION
## What Problem This Solves

Non-admin mutation requests (`chat.send`, `sessions.patch`, `sessions.send`, `tools.invoke`, ...) pay repeated full-store materializations inside `resolveSessionMutationAuthorization`: both `resolveSessionSharingTarget` call sites (incognito direct targets and session mutation targets) ran without `storeCache`/`targetDiscoveryCache`, so each target resolution re-listed and re-mapped every session entry in the store. This is the same per-request rediscovery class fixed on the read paths in #114003 and #114659. W12's entry cache (#114453) removed per-entry `structuredClone` but full key iteration, array mapping, and `Object.fromEntries` per call remain — and incognito stores bypass the entry cache entirely.

## Why This Change Was Made

Production perf campaign on team.openclaw.ai: trivial gateway methods carry a 200-260ms floor; mutation-auth store rediscovery scales with total session count and runs on every non-admin mutation.

## User Impact

Faster mutation-path requests (chat sends, session patches) on gateways with many sessions. No behavior change: authorization decisions are byte-identical; caches only dedupe reads within a single request. Commit-time guards (`assertCurrent`/`assertTargetCurrent`) mint fresh caches so post-handler revalidation still sees current store state.

## Evidence

- New `src/gateway/session-sharing-store-cache.test.ts`: (1) one request resolving multiple targets materializes the lookup store at most once per store; (2) authorization parity for shared/private-draft/incognito sessions vs the uncached path.
- 48 tests passed across the session-sharing suites; core typecheck lane, oxlint, oxfmt, `git diff --check` clean; Codex autoreview clean.
