### PR TITLE
feat(gateway): title untitled sessions when their discussion opens

### DIFF
--- a/src/gateway/dashboard-session-title.ts
+++ b/src/gateway/dashboard-session-title.ts
@@ -27,7 +27,7 @@ const DASHBOARD_SESSION_TITLE_PROMPT =
 // call cannot pin an entry here and block future attempts.
 const sessionTitleRequests = new Map<string, Promise<boolean>>();
 
-export type SessionTitleAttempt =
+type SessionTitleAttempt =
   | { kind: "persisted" }
   | { kind: "skipped" }
   | { kind: "in-flight"; settled: Promise<boolean> };

--- a/src/gateway/dashboard-session-title.ts
+++ b/src/gateway/dashboard-session-title.ts
@@ -21,10 +21,18 @@ const DASHBOARD_SESSION_TITLE_PROMPT =
   "Generate a concise session title (3-6 words, max 60 characters) from the user's first message. Use the same language as the message. No emoji. Return only the title.";
 
 // One title request per first turn. Concurrent sends cannot race duplicate model
-// calls or metadata writes while the initial agent run advances session state.
-const dashboardTitleRequests = new Set<string>();
+// calls or metadata writes; late callers receive the in-flight promise so they
+// may await the persisted title before proceeding. Stored promises always
+// settle: the label generator aborts internally (TIMEOUT_MS), so a hung model
+// call cannot pin an entry here and block future attempts.
+const sessionTitleRequests = new Map<string, Promise<boolean>>();
 
-function hasExplicitSessionName(entry: SessionEntry | undefined): boolean {
+export type SessionTitleAttempt =
+  | { kind: "persisted" }
+  | { kind: "skipped" }
+  | { kind: "in-flight"; settled: Promise<boolean> };
+
+export function hasExplicitSessionName(entry: SessionEntry | undefined): boolean {
   return Boolean(
     entry?.label?.trim() ||
     entry?.displayName?.trim() ||
@@ -138,20 +146,40 @@ export async function maybeGenerateDashboardSessionTitle(params: {
     !isDashboardSessionTitleCandidate({
       sessionKey: params.sessionKey,
       userMessage: sourceText,
-    }) ||
+    })
+  ) {
+    return false;
+  }
+  // Dashboard sends never wait on a duplicate request: only the owning call
+  // may claim persistence (and emit sessions.changed), duplicates skip fast.
+  const attempt = await maybeGenerateSessionTitle({ ...params, userMessage: sourceText });
+  return attempt.kind === "persisted";
+}
+
+export async function maybeGenerateSessionTitle(params: {
+  cfg: OpenClawConfig;
+  agentId: string;
+  entry: SessionEntry | undefined;
+  sessionId: string;
+  sessionKey: string;
+  storePath: string;
+  userMessage: string;
+}): Promise<SessionTitleAttempt> {
+  const sourceText = params.userMessage.trim();
+  if (
     hasExplicitSessionName(params.entry) ||
     params.entry?.systemSent === true ||
     params.entry?.sessionId !== params.sessionId
   ) {
-    return false;
+    return { kind: "skipped" };
   }
 
   const requestKey = `${params.storePath}\0${params.sessionKey}\0${params.sessionId}`;
-  if (dashboardTitleRequests.has(requestKey)) {
-    return false;
+  const existing = sessionTitleRequests.get(requestKey);
+  if (existing) {
+    return { kind: "in-flight", settled: existing };
   }
-  dashboardTitleRequests.add(requestKey);
-  try {
+  const request = (async () => {
     const displayName = await generateDashboardSessionTitle({
       cfg: params.cfg,
       agentId: params.agentId,
@@ -179,7 +207,11 @@ export async function maybeGenerateDashboardSessionTitle(params: {
       { requireWriteSuccess: true },
     );
     return persisted;
+  })();
+  sessionTitleRequests.set(requestKey, request);
+  try {
+    return (await request) ? { kind: "persisted" } : { kind: "skipped" };
   } finally {
-    dashboardTitleRequests.delete(requestKey);
+    sessionTitleRequests.delete(requestKey);
   }
 }

--- a/src/gateway/server-methods/session-discussion.test.ts
+++ b/src/gateway/server-methods/session-discussion.test.ts
@@ -1,12 +1,52 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { SessionEntry } from "../../config/sessions/types.js";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import type { SessionDiscussionProvider } from "../../plugins/session-discussion-registry.js";
 import { sessionDiscussionHandlers } from "./session-discussion.js";
 
-const mocks = vi.hoisted(() => ({ getProvider: vi.fn() }));
+const mocks = vi.hoisted(() => ({
+  emitSessionsChanged: vi.fn(),
+  generateConversationLabelWithFallback: vi.fn(),
+  getProvider: vi.fn(),
+  loadSessionTarget: vi.fn(),
+  maybeGenerateSessionTitle: vi.fn(),
+  readSessionTitleFields: vi.fn(),
+  resolveUtilityModelRefForAgent: vi.fn(),
+  updateSessionEntry: vi.fn(),
+}));
 
 vi.mock("../../plugins/session-discussion-registry.js", () => ({
   getSessionDiscussionProvider: mocks.getProvider,
 }));
+vi.mock("../../agents/utility-model.js", () => ({
+  resolveUtilityModelRefForAgent: mocks.resolveUtilityModelRefForAgent,
+}));
+vi.mock("../../auto-reply/reply/conversation-label-generator.js", () => ({
+  generateConversationLabelWithFallback: mocks.generateConversationLabelWithFallback,
+}));
+vi.mock("../../config/sessions/session-accessor.js", () => ({
+  updateSessionEntry: mocks.updateSessionEntry,
+}));
+vi.mock("../dashboard-session-title.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../dashboard-session-title.js")>();
+  mocks.maybeGenerateSessionTitle.mockImplementation(actual.maybeGenerateSessionTitle);
+  return { ...actual, maybeGenerateSessionTitle: mocks.maybeGenerateSessionTitle };
+});
+vi.mock("../session-transcript-readers.js", () => ({
+  readSessionTitleFieldsFromTranscript: mocks.readSessionTitleFields,
+}));
+vi.mock("./session-change-event.js", () => ({
+  emitSessionsChanged: mocks.emitSessionsChanged,
+}));
+vi.mock("./sessions-shared.js", () => ({
+  loadAccessorSessionEntryForGatewayTarget: mocks.loadSessionTarget,
+}));
+
+const cfg = {
+  agents: { defaults: { model: { primary: "openai/gpt-5.5" } } },
+} as OpenClawConfig;
+const sessionKey = "agent:main:thread";
+const storePath = "/tmp/openclaw/sessions.sqlite";
 
 type Method = "session.discussion.info" | "session.discussion.open";
 
@@ -18,9 +58,18 @@ async function invoke(method: Method, params: Record<string, unknown>) {
     client: null,
     isWebchatConnect: () => false,
     respond: (ok, payload, error) => calls.push({ ok, payload, error }),
-    context: {} as never,
+    context: { getRuntimeConfig: () => cfg } as never,
   });
   return calls[0];
+}
+
+function mockSession(entry: SessionEntry | undefined): void {
+  mocks.loadSessionTarget.mockReturnValue({
+    canonicalKey: sessionKey,
+    entry,
+    storePath,
+    target: { agentId: "main" },
+  });
 }
 
 function provider() {
@@ -39,8 +88,24 @@ function provider() {
 
 describe("session discussion gateway methods", () => {
   beforeEach(() => {
+    mocks.emitSessionsChanged.mockReset();
+    mocks.generateConversationLabelWithFallback.mockReset();
     mocks.getProvider.mockReset();
+    mocks.loadSessionTarget.mockReset();
+    mocks.maybeGenerateSessionTitle.mockClear();
+    mocks.readSessionTitleFields.mockReset();
+    mocks.resolveUtilityModelRefForAgent.mockReset();
+    mocks.updateSessionEntry.mockReset();
+    mocks.generateConversationLabelWithFallback.mockResolvedValue("Release Planning");
+    mocks.readSessionTitleFields.mockReturnValue({
+      firstUserMessage: null,
+      lastMessagePreview: null,
+    });
+    mocks.resolveUtilityModelRefForAgent.mockReturnValue("openai/gpt-5.6-luna");
+    mockSession(undefined);
   });
+
+  afterEach(() => vi.useRealTimers());
 
   it.each(["session.discussion.info", "session.discussion.open"] as const)(
     "returns none when %s has no provider",
@@ -82,6 +147,125 @@ describe("session discussion gateway methods", () => {
 
     expect(registered.open).toHaveBeenCalledWith({ sessionKey: "agent:main:thread" });
     expect(response).toMatchObject({ ok: true, payload: { state: "available" } });
+  });
+
+  it("persists a generated title before opening an untitled session discussion", async () => {
+    const entry: SessionEntry = { sessionId: "session-1", updatedAt: 1 };
+    let persistedEntry: SessionEntry | undefined;
+    mockSession(entry);
+    mocks.readSessionTitleFields.mockReturnValue({
+      firstUserMessage: "[Mon 2026-07-27 09:00 PDT] Plan the release",
+      lastMessagePreview: null,
+    });
+    mocks.updateSessionEntry.mockImplementation(async (_scope, update) => {
+      const patch = await update({ ...entry });
+      persistedEntry = patch ? { ...entry, ...patch } : undefined;
+      return persistedEntry;
+    });
+    const registered = provider();
+    mocks.getProvider.mockReturnValue(registered.value);
+
+    await invoke("session.discussion.open", { sessionKey });
+
+    expect(mocks.maybeGenerateSessionTitle).toHaveBeenCalledWith(
+      expect.objectContaining({
+        agentId: "main",
+        entry,
+        sessionId: "session-1",
+        sessionKey,
+        storePath,
+        userMessage: "Plan the release",
+      }),
+    );
+    expect(persistedEntry?.displayName).toBe("Release Planning");
+    expect(
+      mocks.updateSessionEntry.mock.invocationCallOrder[0] ?? Number.POSITIVE_INFINITY,
+    ).toBeLessThan(registered.open.mock.invocationCallOrder[0] ?? Number.NEGATIVE_INFINITY);
+    expect(mocks.emitSessionsChanged).toHaveBeenCalledExactlyOnceWith(
+      expect.anything(),
+      expect.objectContaining({ sessionKey, agentId: "main", reason: "chat.title" }),
+    );
+  });
+
+  it("titles via the canonical session key when opened through an alias key", async () => {
+    const entry: SessionEntry = { sessionId: "session-1", updatedAt: 1 };
+    mocks.loadSessionTarget.mockReturnValue({
+      canonicalKey: sessionKey,
+      entry,
+      storePath,
+      target: { agentId: "main" },
+    });
+    mocks.readSessionTitleFields.mockReturnValue({
+      firstUserMessage: "Plan the release",
+      lastMessagePreview: null,
+    });
+    mocks.updateSessionEntry.mockImplementation(async (_scope, update) => {
+      const patch = await update({ ...entry });
+      return patch ? { ...entry, ...patch } : undefined;
+    });
+    const registered = provider();
+    mocks.getProvider.mockReturnValue(registered.value);
+
+    await invoke("session.discussion.open", { sessionKey: "agent:main:thread-alias" });
+
+    expect(mocks.maybeGenerateSessionTitle).toHaveBeenCalledWith(
+      expect.objectContaining({ sessionKey }),
+    );
+  });
+
+  it("does not generate a title for an explicitly named session", async () => {
+    mockSession({ sessionId: "session-1", updatedAt: 1, displayName: "Manual title" });
+    const registered = provider();
+    mocks.getProvider.mockReturnValue(registered.value);
+
+    await invoke("session.discussion.open", { sessionKey });
+
+    expect(mocks.maybeGenerateSessionTitle).not.toHaveBeenCalled();
+    expect(mocks.readSessionTitleFields).not.toHaveBeenCalled();
+    expect(registered.open).toHaveBeenCalledOnce();
+  });
+
+  it("opens the discussion when title generation times out", async () => {
+    vi.useFakeTimers();
+    mockSession({ sessionId: "session-timeout", updatedAt: 1 });
+    mocks.readSessionTitleFields.mockReturnValue({
+      firstUserMessage: "Plan the release",
+      lastMessagePreview: null,
+    });
+    // Resolvable deferred: settling it after the assertions evicts the shared
+    // single-flight map entry so module state stays clean across suites.
+    let releaseGeneration: ((value: string | null) => void) | undefined;
+    mocks.generateConversationLabelWithFallback.mockReturnValue(
+      new Promise<string | null>((resolve) => {
+        releaseGeneration = resolve;
+      }),
+    );
+    const registered = provider();
+    mocks.getProvider.mockReturnValue(registered.value);
+
+    const responsePromise = invoke("session.discussion.open", { sessionKey });
+    await vi.advanceTimersByTimeAsync(10_000);
+
+    await expect(responsePromise).resolves.toMatchObject({
+      ok: true,
+      payload: { state: "available" },
+    });
+    expect(registered.open).toHaveBeenCalledOnce();
+    expect(mocks.emitSessionsChanged).not.toHaveBeenCalled();
+    releaseGeneration?.(null);
+    await vi.runAllTimersAsync();
+  });
+
+  it("never generates a title for discussion info", async () => {
+    mockSession({ sessionId: "session-1", updatedAt: 1 });
+    const registered = provider();
+    mocks.getProvider.mockReturnValue(registered.value);
+
+    await invoke("session.discussion.info", { sessionKey });
+
+    expect(mocks.loadSessionTarget).not.toHaveBeenCalled();
+    expect(mocks.maybeGenerateSessionTitle).not.toHaveBeenCalled();
+    expect(registered.info).toHaveBeenCalledOnce();
   });
 
   it.each(["session.discussion.info", "session.discussion.open"] as const)(

--- a/src/gateway/server-methods/session-discussion.ts
+++ b/src/gateway/server-methods/session-discussion.ts
@@ -7,9 +7,97 @@ import {
   validateSessionDiscussionOpenParams,
   validateSessionDiscussionOpenResult,
 } from "../../../packages/gateway-protocol/src/index.js";
+import { stripInboundMetadata } from "../../auto-reply/reply/strip-inbound-meta.js";
 import { getSessionDiscussionProvider } from "../../plugins/session-discussion-registry.js";
-import type { GatewayRequestHandlers } from "./types.js";
+import { hasExplicitSessionName, maybeGenerateSessionTitle } from "../dashboard-session-title.js";
+import { readSessionTitleFieldsFromTranscript } from "../session-transcript-readers.js";
+import { emitSessionsChanged } from "./session-change-event.js";
+import { loadAccessorSessionEntryForGatewayTarget } from "./sessions-shared.js";
+import type { GatewayRequestContext, GatewayRequestHandlers } from "./types.js";
 import { assertValidParams } from "./validation.js";
+
+const DISCUSSION_TITLE_TIMEOUT_MS = 10_000;
+
+async function maybeGenerateTitleBeforeDiscussionOpen(params: {
+  context: GatewayRequestContext;
+  sessionKey: string;
+}): Promise<void> {
+  try {
+    const cfg = params.context.getRuntimeConfig();
+    const resolved = loadAccessorSessionEntryForGatewayTarget({
+      cfg,
+      key: params.sessionKey,
+    });
+    const { entry } = resolved;
+    const sessionId = entry?.sessionId;
+    if (!entry || !sessionId || entry.systemSent === true || hasExplicitSessionName(entry)) {
+      return;
+    }
+    const fields = readSessionTitleFieldsFromTranscript({
+      agentId: resolved.target.agentId,
+      sessionEntry: entry,
+      sessionId,
+      sessionKey: resolved.canonicalKey,
+      storePath: resolved.storePath,
+    });
+    const userMessage = fields.firstUserMessage
+      ? stripInboundMetadata(fields.firstUserMessage).trim()
+      : "";
+    if (!userMessage) {
+      return;
+    }
+
+    // Owning attempts and joins of an in-flight dashboard request both settle
+    // through this promise; joins report false so only the owner claims the
+    // persistence (and the emit below stays single-shot per title).
+    const titleRequest = maybeGenerateSessionTitle({
+      cfg,
+      agentId: resolved.target.agentId,
+      entry,
+      sessionId,
+      // Canonical key keeps metadata writes and request dedup consistent when
+      // the open request addresses the session through an alias key.
+      sessionKey: resolved.canonicalKey,
+      storePath: resolved.storePath,
+      userMessage,
+    }).then(async (attempt) => {
+      if (attempt.kind === "in-flight") {
+        await attempt.settled.catch(() => {});
+        return false;
+      }
+      return attempt.kind === "persisted";
+    });
+    let timeout: NodeJS.Timeout | undefined;
+    let persisted = false;
+    // Discussion open waits at most 10 seconds for best-effort titling.
+    // If generation fails or finishes later, open proceeds; a later plugin reconcile
+    // picks up any title that completes after the timeout.
+    try {
+      persisted = await Promise.race([
+        titleRequest.catch(() => false),
+        new Promise<boolean>((resolve) => {
+          timeout = setTimeout(() => resolve(false), DISCUSSION_TITLE_TIMEOUT_MS);
+          timeout.unref?.();
+        }),
+      ]);
+    } finally {
+      if (timeout) {
+        clearTimeout(timeout);
+      }
+    }
+    if (persisted) {
+      // Mirror the dashboard first-turn path so session lists learn the new
+      // title immediately instead of on their next full refresh.
+      emitSessionsChanged(params.context, {
+        sessionKey: resolved.canonicalKey,
+        agentId: resolved.target.agentId,
+        reason: "chat.title",
+      });
+    }
+  } catch {
+    // Titling is best-effort; provider open remains the authoritative operation.
+  }
+}
 
 export const sessionDiscussionHandlers: GatewayRequestHandlers = {
   "session.discussion.info": async ({ params, respond }) => {
@@ -56,7 +144,7 @@ export const sessionDiscussionHandlers: GatewayRequestHandlers = {
       );
     }
   },
-  "session.discussion.open": async ({ params, respond }) => {
+  "session.discussion.open": async ({ params, respond, context }) => {
     if (
       !assertValidParams(
         params,
@@ -73,6 +161,10 @@ export const sessionDiscussionHandlers: GatewayRequestHandlers = {
       return;
     }
     try {
+      await maybeGenerateTitleBeforeDiscussionOpen({
+        context,
+        sessionKey: params.sessionKey,
+      });
       const result = await provider.open({ sessionKey: params.sessionKey });
       if (!validateSessionDiscussionOpenResult(result)) {
         respond(


### PR DESCRIPTION
Part of #114685.

## What Problem This Solves

Model-generated session titles only existed for `dashboard:` sessions; channel-originated sessions opened ClickClack discussions with hash fallback names because no title ever existed. This is a follow-up to #114711.

## Why This Change Was Made

`session.discussion.open` is user-triggered, so the open can afford a bounded (10s) best-effort one-shot title generation before the provider creates the channel. Channels are born correctly named instead of renamed later.

## Change Summary

Generalized the dashboard one-shot title generator into `maybeGenerateSessionTitle` with a discriminated attempt result (`persisted`/`skipped`/`in-flight`). Single-flight requests are joinable so a discussion open racing first-turn titling waits for persistence while dashboard duplicates still skip instantly. The open handler resolves the canonical session key, reads the first user message via the transcript title reader, strips inbound metadata, races a 10s unref'd timeout, and emits `sessions.changed` (reason `chat.title`) only when its own attempt persisted. Titling failures never block the open.

## User Impact

ClickClack discussion channels for previously untitled sessions get real names at creation; session lists update immediately via `sessions.changed`.

## Evidence

- `node scripts/run-vitest.mjs src/gateway/server-methods/session-discussion.test.ts src/gateway/dashboard-session-title.test.ts src/gateway/server-methods/chat-send-user-turn.test.ts` -> 46 tests passed.
- Changed-file gate green on Testbox `tbx_01kyjjb6gmv9kgphh7aynwq4r0`.
- Four autoreview rounds ending clean: "patch is correct".
