### PR TITLE
fix: prevent cron and Workboard lifecycle races

### DIFF
--- a/extensions/workboard/src/dispatcher.races.test.ts
+++ b/extensions/workboard/src/dispatcher.races.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it, vi } from "vitest";
+import { dispatchAndStartWorkboardCards } from "./dispatcher.js";
+import type { PersistedWorkboardCard, WorkboardKeyedStore } from "./persistence-types.js";
+import { WorkboardStore } from "./store.js";
+
+function createMemoryStore(): WorkboardKeyedStore {
+  const entries = new Map<string, PersistedWorkboardCard>();
+  return {
+    async register(key, value) {
+      entries.set(key, value);
+    },
+    async lookup(key) {
+      return entries.get(key);
+    },
+    async delete(key) {
+      return entries.delete(key);
+    },
+    async entries() {
+      return [...entries].map(([key, value]) => ({ key, value }));
+    },
+  };
+}
+
+describe("Workboard dispatcher lifecycle races", () => {
+  it.each([
+    { name: "archived", archive: true },
+    { name: "completed", status: "done" as const },
+    { name: "blocked", status: "blocked" as const },
+    { name: "under review", status: "review" as const },
+    { name: "moved to another board", boardId: "product" },
+  ])("does not start a card $name during dispatch preflight", async (transition) => {
+    const store = new WorkboardStore(createMemoryStore());
+    const card = await store.create({
+      title: "Concurrent dispatch transition",
+      status: "ready",
+      boardId: "ops",
+      workspaceAccess: { unrestricted: true },
+    });
+    const originalClaim = store.claim.bind(store);
+    vi.spyOn(store, "claim").mockImplementationOnce(async (id, input, options) => {
+      if ("archive" in transition) {
+        await store.archive(id, true);
+      } else if ("boardId" in transition) {
+        await store.update(id, { boardId: transition.boardId });
+      } else {
+        await store.update(id, { status: transition.status });
+      }
+      return await originalClaim(id, input, options);
+    });
+    const run = vi.fn();
+
+    const result = await dispatchAndStartWorkboardCards({
+      store,
+      subagent: { run },
+      options: { maxStarts: 1, boardId: "ops", workspaceAccess: { unrestricted: true } },
+    });
+
+    expect(run).not.toHaveBeenCalled();
+    expect(result.started).toEqual([]);
+    expect(result.startFailures).toEqual([
+      expect.objectContaining({
+        cardId: card.id,
+        error: expect.stringMatching(/archived|authority/),
+      }),
+    ]);
+    const current = await store.get(card.id);
+    expect(current?.metadata?.claim).toBeUndefined();
+    if ("archive" in transition) {
+      expect(current?.metadata?.archivedAt).toBeGreaterThan(0);
+    } else if ("boardId" in transition) {
+      expect(current?.metadata?.automation?.boardId).toBe("product");
+    } else {
+      expect(current?.status).toBe(transition.status);
+    }
+  });
+});

--- a/extensions/workboard/src/dispatcher.ts
+++ b/extensions/workboard/src/dispatcher.ts
@@ -15,6 +15,7 @@ import {
   resolveDispatchWorkspaceAccess,
   type ResolveAgentWorkspaceRuntime,
 } from "./dispatcher-workspace.js";
+import { cardBoardId } from "./store-card-helpers.js";
 import { isWorkboardClaimReclaimable } from "./store-constants.js";
 import { WorkboardStore, type WorkboardDispatchResult } from "./store.js";
 import {
@@ -74,10 +75,6 @@ function normalizePositiveInteger(value: number | undefined, fallback: number): 
   return typeof value === "number" && Number.isFinite(value)
     ? Math.max(0, Math.trunc(value))
     : fallback;
-}
-
-function cardBoardId(card: WorkboardCard): string {
-  return card.metadata?.automation?.boardId ?? "default";
 }
 
 function sanitizeSessionSegment(value: string | undefined, fallback: string): string {
@@ -450,6 +447,8 @@ async function runWorkboardDispatch(
         { ownerId, ttlSeconds: card.metadata?.automation?.maxRuntimeSeconds },
         {
           expectedAuthority: {
+            boardId: cardBoardId(card),
+            status: card.status,
             agentId: card.agentId,
             workspace: card.metadata?.automation?.workspace,
             workspaceAccess: card.metadata?.automation?.workspaceAccess,

--- a/extensions/workboard/src/store-core.ts
+++ b/extensions/workboard/src/store-core.ts
@@ -917,6 +917,9 @@ export class WorkboardCoreStore {
     if (!card) {
       throw new Error(`card not found: ${id}`);
     }
+    if (card.metadata?.archivedAt) {
+      return card;
+    }
     const target = await this.dependencyTargetStatus(card, now);
     if (target === card.status) {
       return card;

--- a/extensions/workboard/src/store-inputs.ts
+++ b/extensions/workboard/src/store-inputs.ts
@@ -88,6 +88,8 @@ export type WorkboardClaimInput = {
 export type WorkboardClaimOptions = {
   /** Trusted dispatcher guard; never accepted from public tool or gateway input. */
   expectedAuthority?: {
+    boardId: string;
+    status: WorkboardCard["status"];
     agentId?: string;
     workspace?: WorkboardWorkspace;
     workspaceAccess?: WorkboardWorkspaceAccess;

--- a/extensions/workboard/src/store-notifications.ts
+++ b/extensions/workboard/src/store-notifications.ts
@@ -51,7 +51,9 @@ export class WorkboardNotificationStore extends WorkboardWorkflowStore {
   }
 
   async deleteNotificationSubscription(id: string): Promise<{ deleted: boolean }> {
-    return { deleted: await this.subscriptionStore.delete(id.trim()) };
+    return await this.enqueueMutation(async () => ({
+      deleted: await this.subscriptionStore.delete(id.trim()),
+    }));
   }
 
   private async collectNotificationEvents(input: WorkboardNotificationEventsInput = {}): Promise<{

--- a/extensions/workboard/src/store-workflow.ts
+++ b/extensions/workboard/src/store-workflow.ts
@@ -13,6 +13,7 @@ import {
   appendEvent,
   assertCanMutateClaimedCard,
   capText,
+  cardBoardId,
   cardChildIds,
   cardParentIds,
   cardRunId,
@@ -91,10 +92,15 @@ export class WorkboardWorkflowStore extends WorkboardPromoteStore {
         ttlSeconds ? secondsToDurationMs(ttlSeconds) : DEFAULT_CLAIM_TTL_MS,
       );
       const guarded = await this.promoteDependencyReady(id, now);
+      if (guarded.metadata?.archivedAt) {
+        throw new Error("card is archived.");
+      }
       const expectedAuthority = options.expectedAuthority;
       if (
         expectedAuthority &&
-        (guarded.agentId !== expectedAuthority.agentId ||
+        (guarded.status !== expectedAuthority.status ||
+          cardBoardId(guarded) !== expectedAuthority.boardId ||
+          guarded.agentId !== expectedAuthority.agentId ||
           !isDeepStrictEqual(
             guarded.metadata?.automation?.workspace,
             expectedAuthority.workspace,

--- a/extensions/workboard/src/store.test.ts
+++ b/extensions/workboard/src/store.test.ts
@@ -1484,6 +1484,8 @@ describe("WorkboardStore", () => {
     const store = new WorkboardStore(createMemoryStore());
     const card = await store.create({ title: "Legacy dispatch", status: "ready" });
     const expectedAuthority = {
+      boardId: "default",
+      status: card.status,
       agentId: card.agentId,
       workspace: card.metadata?.automation?.workspace,
       workspaceAccess: card.metadata?.automation?.workspaceAccess,
@@ -1519,6 +1521,8 @@ describe("WorkboardStore", () => {
       { ownerId: "dispatcher" },
       {
         expectedAuthority: {
+          boardId: "default",
+          status: legacy.status,
           agentId: legacy.agentId,
           workspace: legacy.metadata?.automation?.workspace,
           workspaceAccess: legacy.metadata?.automation?.workspaceAccess,
@@ -2987,6 +2991,48 @@ describe("WorkboardStore", () => {
     );
   });
 
+  it("does not resurrect a subscription deleted during cursor advancement", async () => {
+    let markCursorWriteStarted!: () => void;
+    let releaseCursorWrite!: () => void;
+    const cursorWriteStarted = new Promise<void>((resolve) => {
+      markCursorWriteStarted = resolve;
+    });
+    const cursorWriteReleased = new Promise<void>((resolve) => {
+      releaseCursorWrite = resolve;
+    });
+    const subscriptions = createMemoryStore<PersistedWorkboardNotificationSubscription>({
+      async beforeRegister(_key, value) {
+        if (!value.subscription.lastEventId) {
+          return;
+        }
+        markCursorWriteStarted();
+        await cursorWriteReleased;
+      },
+    });
+    const store = new WorkboardStore(createMemoryStore(), { subscriptions });
+    const card = await store.create({ title: "Delete in-flight notification", boardId: "ops" });
+    const subscription = await store.subscribeNotifications({
+      boardId: "ops",
+      target: "session:operator",
+      eventKinds: ["completed"],
+    });
+    await store.complete(card.id, { summary: "Done." });
+
+    const advancing = store.advanceNotificationEvents({ subscriptionId: subscription.id });
+    await cursorWriteStarted;
+    const deleting = store.deleteNotificationSubscription(subscription.id);
+    releaseCursorWrite();
+
+    await expect(Promise.all([advancing, deleting])).resolves.toEqual([
+      expect.objectContaining({
+        events: [expect.objectContaining({ kind: "completed" })],
+      }),
+      { deleted: true },
+    ]);
+    await expect(subscriptions.lookup(subscription.id)).resolves.toBeUndefined();
+    await expect(store.listNotificationSubscriptions()).resolves.toEqual({ subscriptions: [] });
+  });
+
   it("does not skip same-millisecond notification events after cursor advancement", async () => {
     const store = new WorkboardStore(createMemoryStore(), {
       subscriptions: createMemoryStore<PersistedWorkboardNotificationSubscription>(),
@@ -3249,6 +3295,40 @@ describe("WorkboardStore", () => {
 
     await expect(store.get(card.id)).resolves.toEqual(archived);
     expect(changes).not.toHaveBeenCalled();
+  });
+
+  it("does not promote or claim an archived scheduled card", async () => {
+    vi.useFakeTimers();
+    try {
+      vi.setSystemTime(1_000);
+      const store = new WorkboardStore(createMemoryStore());
+      const card = await store.create({
+        title: "Archived scheduled work",
+        status: "scheduled",
+        scheduledAt: 2_000,
+      });
+      const archived = await store.archive(card.id, true);
+      const changes = vi.fn();
+      store.subscribeChanges(changes);
+
+      for (let attempt = 0; attempt < 10; attempt += 1) {
+        await expect(store.promoteReady(3_000 + attempt)).resolves.toEqual({
+          cards: [],
+          count: 0,
+        });
+      }
+      await expect(store.claim(card.id, { ownerId: "worker" })).rejects.toThrow(/archived/);
+      await expect(store.get(card.id)).resolves.toEqual(archived);
+      expect(changes).not.toHaveBeenCalled();
+
+      vi.setSystemTime(3_000);
+      await store.archive(card.id, false);
+      await expect(store.claim(card.id, { ownerId: "worker" })).resolves.toMatchObject({
+        card: { id: card.id, status: "running" },
+      });
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("does not promote, time out, or reclaim archived cards during dispatch", async () => {

--- a/src/cli/cron-cli/register.cron-edit.test.ts
+++ b/src/cli/cron-cli/register.cron-edit.test.ts
@@ -54,6 +54,58 @@ describe("cron edit command", () => {
     });
   });
 
+  it("reuses one versioned snapshot for combined pacing and tool edits", async () => {
+    const configRevision = "current-job-revision";
+    callGatewayFromCli.mockImplementation(async (method: string) => {
+      if (method === "cron.get") {
+        return {
+          id: "job-1",
+          configRevision,
+          pacing: { min: "15m", max: "4h" },
+          payload: { kind: "agentTurn", message: "hello" },
+        };
+      }
+      return { ok: true };
+    });
+
+    await createCronProgram().parseAsync(
+      ["edit", "job-1", "--pacing-min", "30m", "--tools", "read"],
+      { from: "user" },
+    );
+
+    expect(callGatewayFromCli.mock.calls.filter(([method]) => method === "cron.get")).toHaveLength(
+      1,
+    );
+    expect(callGatewayFromCli).toHaveBeenCalledWith("cron.update", expect.anything(), {
+      id: "job-1",
+      patch: {
+        pacing: { min: "30m", max: "4h" },
+        payload: { kind: "agentTurn", toolsAllow: ["read"] },
+      },
+      expectedConfigRevision: configRevision,
+    });
+  });
+
+  it.each(["read", ""])("rejects --tools %j combined with --clear-tools", async (tools) => {
+    const errorSpy = vi.spyOn(defaultRuntime, "error").mockImplementation(() => {});
+    const exitSpy = vi.spyOn(defaultRuntime, "exit").mockImplementation((() => undefined) as never);
+
+    try {
+      await createCronProgram().parseAsync(
+        ["edit", "job-1", "--pacing-min", "30m", "--tools", tools, "--clear-tools"],
+        { from: "user" },
+      );
+
+      expect(errorSpy).toHaveBeenCalledWith(
+        expect.stringContaining("Use --tools or --clear-tools, not both"),
+      );
+      expect(callGatewayFromCli).not.toHaveBeenCalled();
+    } finally {
+      errorSpy.mockRestore();
+      exitSpy.mockRestore();
+    }
+  });
+
   it("keeps --best-effort-deliver-only edits delivery-only (#83908)", async () => {
     const program = createCronProgram();
 

--- a/src/cli/cron-cli/register.cron-edit.ts
+++ b/src/cli/cron-cli/register.cron-edit.ts
@@ -28,9 +28,11 @@ import { getCronChannelOptions, warnIfCronSchedulerDisabled } from "./shared.js"
 import { normalizeCronSessionTargetOption } from "./thread-id-shared.js";
 import { readCronTriggerScript } from "./trigger-options.js";
 
-async function readCronJobForEdit(opts: GatewayRpcOpts, id: string): Promise<CronJob> {
+type CronJobForEdit = CronJob & { configRevision?: string };
+
+async function readCronJobForEdit(opts: GatewayRpcOpts, id: string): Promise<CronJobForEdit> {
   try {
-    return (await callGatewayFromCli("cron.get", opts, { id })) as CronJob;
+    return (await callGatewayFromCli("cron.get", opts, { id })) as CronJobForEdit;
   } catch (error) {
     if (!isUnknownCronGetMethodError(error)) {
       throw error;
@@ -162,6 +164,18 @@ export function registerCronEditCommand(cron: Command) {
       )
       .action(async (id, opts) => {
         try {
+          if (opts.clearTools && opts.tools !== undefined) {
+            throw new Error("Use --tools or --clear-tools, not both");
+          }
+          let existingJobPromise: Promise<CronJobForEdit> | undefined;
+          let expectedConfigRevision: string | undefined;
+          const readExistingCronJob = async (): Promise<CronJobForEdit> => {
+            const existing = await (existingJobPromise ??= readCronJobForEdit(opts, String(id)));
+            if (typeof existing.configRevision === "string") {
+              expectedConfigRevision = existing.configRevision;
+            }
+            return existing;
+          };
           const sessionTarget =
             typeof opts.session === "string"
               ? normalizeCronSessionTargetOption(opts.session)
@@ -283,7 +297,7 @@ export function registerCronEditCommand(cron: Command) {
           if (opts.clearPacing) {
             patch.pacing = null;
           } else if (hasPacingMin || hasPacingMax) {
-            const existing = await readCronJobForEdit(opts, String(id));
+            const existing = await readExistingCronJob();
             patch.pacing = {
               ...existing.pacing,
               ...(pacingMin ? { min: pacingMin } : {}),
@@ -303,7 +317,7 @@ export function registerCronEditCommand(cron: Command) {
               ...(opts.triggerOnce ? { once: true } : {}),
             };
           } else if (opts.triggerOnce) {
-            const existing = await readCronJobForEdit(opts, String(id));
+            const existing = await readExistingCronJob();
             if (!existing.trigger) {
               throw new Error("--trigger-once requires an existing trigger or --trigger-script");
             }
@@ -326,7 +340,7 @@ export function registerCronEditCommand(cron: Command) {
           });
           if (scheduleRequest.kind === "direct") {
             if (scheduleRequest.schedule.kind === "stream") {
-              const existing = await readCronJobForEdit(opts, String(id));
+              const existing = await readExistingCronJob();
               if (existing.schedule.kind === "stream") {
                 const metadataRequest = resolveCronEditScheduleRequest({
                   streamCwd: opts.streamCwd,
@@ -348,7 +362,7 @@ export function registerCronEditCommand(cron: Command) {
               scheduleRequest.schedule.kind === "cron" &&
               scheduleRequest.schedule.tz === undefined
             ) {
-              const existing = await readCronJobForEdit(opts, String(id));
+              const existing = await readExistingCronJob();
               patch.schedule =
                 existing.schedule.kind === "cron" && existing.schedule.tz !== undefined
                   ? { ...scheduleRequest.schedule, tz: existing.schedule.tz }
@@ -357,18 +371,16 @@ export function registerCronEditCommand(cron: Command) {
               patch.schedule = scheduleRequest.schedule;
             }
           } else if (scheduleRequest.kind === "patch-existing-cron") {
-            const existing = await readCronJobForEdit(opts, String(id));
+            const existing = await readExistingCronJob();
             patch.schedule = applyExistingCronSchedulePatch(existing.schedule, scheduleRequest);
           } else if (scheduleRequest.kind === "patch-existing-stream") {
-            const existing = await readCronJobForEdit(opts, String(id));
+            const existing = await readExistingCronJob();
             patch.schedule = applyExistingStreamSchedulePatch(existing.schedule, scheduleRequest);
           }
 
           Object.assign(
             patch,
-            await resolveCronEditPayloadDeliveryPatch(opts, () =>
-              readCronJobForEdit(opts, String(id)),
-            ),
+            await resolveCronEditPayloadDeliveryPatch(opts, readExistingCronJob),
           );
 
           const hasFailureAlertAfter = typeof opts.failureAlertAfter === "string";
@@ -447,6 +459,7 @@ export function registerCronEditCommand(cron: Command) {
           const res = await callGatewayFromCli("cron.update", opts, {
             id,
             patch,
+            ...(expectedConfigRevision !== undefined ? { expectedConfigRevision } : {}),
           });
           defaultRuntime.writeJson(res);
           await warnIfCronSchedulerDisabled(opts);

--- a/src/cron/delivery-plan.ts
+++ b/src/cron/delivery-plan.ts
@@ -170,8 +170,11 @@ export function resolveFailureDestination(
   }
 
   if (hasJobFailureDest) {
-    const jobChannel = normalizeChannel(jobFailureDest.channel);
     const jobTo = normalizeOptionalString(jobFailureDest.to);
+    const explicitJobChannel = normalizeChannel(jobFailureDest.channel);
+    const jobChannel =
+      explicitJobChannel ??
+      (jobTo ? (resolveTargetPrefixedChannel(jobTo) as CronMessageChannel | undefined) : undefined);
     const jobAccountId = normalizeOptionalString(jobFailureDest.accountId);
     const jobMode = normalizeFailureMode(jobFailureDest.mode);
     const hasJobChannelField = "channel" in jobFailureDest;
@@ -182,7 +185,7 @@ export function resolveFailureDestination(
     const jobToExplicitValue = hasJobToField && jobTo !== undefined;
     const globalChannel = resolveAnnounceChannel({ channel, to });
 
-    if (hasJobChannelField) {
+    if (hasJobChannelField || (jobChannel && jobTo)) {
       channel = jobChannel;
       if (jobChannel && jobChannel !== globalChannel) {
         // Targets and accounts belong to the channel that supplied them.

--- a/src/cron/delivery.test.ts
+++ b/src/cron/delivery.test.ts
@@ -593,4 +593,33 @@ describe("resolveFailureDestination", () => {
       accountId: undefined,
     });
   });
+
+  it("does not inherit a foreign global account for a prefixed failure destination", () => {
+    const plan = resolveFailureDestination(
+      makeCronJob({
+        delivery: {
+          mode: "announce",
+          channel: "telegram",
+          to: "111",
+          failureDestination: {
+            mode: "announce",
+            to: "slack:U123",
+          },
+        },
+      }),
+      {
+        mode: "announce",
+        channel: "telegram",
+        to: "telegram:alerts",
+        accountId: "telegram-bot",
+      },
+    );
+
+    expect(plan).toEqual({
+      mode: "announce",
+      channel: "slack",
+      to: "slack:U123",
+      accountId: undefined,
+    });
+  });
 });

--- a/src/cron/execution-error-constants.ts
+++ b/src/cron/execution-error-constants.ts
@@ -1,2 +1,19 @@
 /** Stable cron execution error text shared by runtime and ledger codecs. */
 export const CRON_JOB_EXECUTION_TIMEOUT_ERROR = "cron: job execution timed out";
+export const CRON_SETUP_TIMEOUT_ERROR = "cron: isolated agent setup timed out before runner start";
+export const CRON_PRE_EXECUTION_TIMEOUT_ERROR =
+  "cron: isolated agent run stalled before execution start";
+
+const CRON_TIMEOUT_ERROR_PREFIXES = [
+  CRON_JOB_EXECUTION_TIMEOUT_ERROR,
+  CRON_SETUP_TIMEOUT_ERROR,
+  CRON_PRE_EXECUTION_TIMEOUT_ERROR,
+] as const;
+
+/** Recognizes watchdog timeouts without loading agent or execution-phase runtime. */
+export function isCronTimeoutErrorText(error: unknown): error is string {
+  return (
+    typeof error === "string" &&
+    CRON_TIMEOUT_ERROR_PREFIXES.some((prefix) => error === prefix || error.startsWith(`${prefix} `))
+  );
+}

--- a/src/cron/service/execution-errors.ts
+++ b/src/cron/service/execution-errors.ts
@@ -1,31 +1,23 @@
 /** Formats stable cron timeout and execution error messages. */
 import { formatEmbeddedAgentExecutionPhase } from "../../agents/embedded-agent-runner/execution-phase.js";
-import { CRON_JOB_EXECUTION_TIMEOUT_ERROR } from "../execution-error-constants.js";
+import {
+  CRON_JOB_EXECUTION_TIMEOUT_ERROR,
+  CRON_PRE_EXECUTION_TIMEOUT_ERROR,
+  CRON_SETUP_TIMEOUT_ERROR,
+  isCronTimeoutErrorText,
+} from "../execution-error-constants.js";
 import type { CronAgentExecutionStarted } from "../types.js";
 
 function formatCronAgentExecutionPhase(execution?: CronAgentExecutionStarted): string | undefined {
   return formatEmbeddedAgentExecutionPhase(execution?.phase);
 }
 
-const CRON_SETUP_TIMEOUT_ERROR = "cron: isolated agent setup timed out before runner start";
-const CRON_PRE_EXECUTION_TIMEOUT_ERROR = "cron: isolated agent run stalled before execution start";
-const CRON_TIMEOUT_ERROR_PREFIXES: readonly string[] = [
-  CRON_JOB_EXECUTION_TIMEOUT_ERROR,
-  CRON_SETUP_TIMEOUT_ERROR,
-  CRON_PRE_EXECUTION_TIMEOUT_ERROR,
-];
-
 function hasCronTimeoutPrefix(error: string, prefix: string): boolean {
   return error === prefix || error.startsWith(prefix + " ");
 }
 
 export function isCronTerminalAbortReasonText(error: string): boolean {
-  for (const prefix of CRON_TIMEOUT_ERROR_PREFIXES) {
-    if (hasCronTimeoutPrefix(error, prefix)) {
-      return true;
-    }
-  }
-  return false;
+  return isCronTimeoutErrorText(error);
 }
 
 /** Formats the generic cron execution timeout message with last-known phase context when available. */

--- a/src/cron/service/failure-alerts.account-routing.test.ts
+++ b/src/cron/service/failure-alerts.account-routing.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it, vi } from "vitest";
+import type { CronJob } from "../types.js";
+import { resolveFailureAlert } from "./failure-alerts.js";
+import { createCronServiceState } from "./state.js";
+
+describe("cron failure alert account routing", () => {
+  it.each([
+    {
+      name: "inherits the primary account when an alert uses its delivery route",
+      globalAlert: { enabled: true, after: 1 },
+      jobAlert: undefined,
+      expected: {
+        channel: "telegram",
+        to: "telegram:19098680",
+        accountId: "telegram-bot",
+      },
+    },
+    {
+      name: "prefers an explicit alert account over the primary account",
+      globalAlert: { enabled: true, after: 1 },
+      jobAlert: { accountId: "alert-bot" },
+      expected: {
+        channel: "telegram",
+        to: "telegram:19098680",
+        accountId: "alert-bot",
+      },
+    },
+    {
+      name: "does not inherit the primary account for another channel",
+      globalAlert: { enabled: true, after: 1, channel: "slack" },
+      jobAlert: undefined,
+      expected: { channel: "slack", to: undefined, accountId: undefined },
+    },
+    {
+      name: "does not inherit the primary account for a webhook",
+      globalAlert: {
+        enabled: true,
+        after: 1,
+        mode: "webhook" as const,
+        to: "https://alerts.example.test/cron-failures",
+      },
+      jobAlert: undefined,
+      expected: {
+        mode: "webhook",
+        to: "https://alerts.example.test/cron-failures",
+        accountId: undefined,
+      },
+    },
+  ])("$name", ({ globalAlert, jobAlert, expected }) => {
+    const state = createCronServiceState({
+      storePath: "/tmp/openclaw-cron-failure-alert-account-routing.json",
+      cronEnabled: true,
+      defaultAgentId: "main",
+      cronConfig: { failureAlert: globalAlert },
+      log: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+      enqueueSystemEvent: vi.fn(),
+      requestHeartbeat: vi.fn(),
+      runIsolatedAgentJob: vi.fn(async () => ({ status: "ok" as const })),
+    });
+    const job: CronJob = {
+      id: "account-routed-job",
+      name: "Account-routed job",
+      enabled: true,
+      createdAtMs: 1,
+      updatedAtMs: 1,
+      schedule: { kind: "every", everyMs: 60_000 },
+      sessionTarget: "isolated",
+      wakeMode: "next-heartbeat",
+      payload: { kind: "agentTurn", message: "report" },
+      delivery: {
+        mode: "announce",
+        channel: "telegram",
+        to: "telegram:19098680",
+        accountId: "telegram-bot",
+      },
+      ...(jobAlert ? { failureAlert: jobAlert } : {}),
+      state: {},
+    };
+
+    expect(resolveFailureAlert(state, job)).toMatchObject(expected);
+  });
+});

--- a/src/cron/service/failure-alerts.ts
+++ b/src/cron/service/failure-alerts.ts
@@ -103,11 +103,14 @@ export function resolveFailureAlert(
   const deliveryTo = normalizeTo(job.delivery?.to);
   const deliveryChannel = resolveFailureAlertChannel(job.delivery?.channel, deliveryTo);
   const channel = jobChannel ?? globalChannel ?? deliveryChannel ?? "last";
-  const compatibleDeliveryTo =
-    channel === deliveryChannel || (channel === "last" && !deliveryChannel)
-      ? deliveryTo
-      : undefined;
+  const inheritsDeliveryChannel =
+    channel === deliveryChannel || (channel === "last" && !deliveryChannel);
+  const compatibleDeliveryTo = inheritsDeliveryChannel ? deliveryTo : undefined;
   const explicitTo = jobTo ?? globalTo;
+  const inheritedDeliveryAccountId =
+    mode !== "webhook" && !explicitTo && inheritsDeliveryChannel
+      ? job.delivery?.accountId
+      : undefined;
 
   // Announce alerts inherit the job delivery target; webhook alerts require an
   // explicit alert target so chat recipients are not reused as URLs.
@@ -120,7 +123,10 @@ export function resolveFailureAlert(
     channel,
     to: mode === "webhook" ? explicitTo : (explicitTo ?? compatibleDeliveryTo),
     mode,
-    accountId: jobConfig?.accountId ?? (inheritsGlobalRoute ? globalConfig?.accountId : undefined),
+    accountId:
+      jobConfig?.accountId ??
+      (inheritsGlobalRoute ? globalConfig?.accountId : undefined) ??
+      inheritedDeliveryAccountId,
     includeSkipped: jobConfig?.includeSkipped ?? globalConfig?.includeSkipped ?? false,
   };
 }

--- a/src/cron/service/task-runs.test.ts
+++ b/src/cron/service/task-runs.test.ts
@@ -699,6 +699,68 @@ describe("cron task run terminal records", () => {
     );
   });
 
+  it.each([
+    "cron: job execution timed out",
+    "cron: job execution timed out (last phase: model_call_started)",
+    "cron: isolated agent setup timed out before runner start",
+    "cron: isolated agent setup timed out before runner start (last phase: preparing)",
+    "cron: isolated agent run stalled before execution start",
+    "cron: isolated agent run stalled before execution start (last phase: preparing)",
+  ])("preserves %j as a provisional timed-out task", async (error) => {
+    await withOpenClawTestState(
+      { layout: "state-only", prefix: "openclaw-cron-provisional-watchdog-timeout-" },
+      async () => {
+        resetTaskRegistryForTests();
+        const startedAt = 5_000;
+        const job: CronJob = {
+          id: "provisional-watchdog-timeout",
+          name: "provisional watchdog timeout",
+          enabled: true,
+          createdAtMs: 100,
+          updatedAtMs: 100,
+          schedule: { kind: "every", everyMs: 60_000, anchorMs: 100 },
+          sessionTarget: "isolated",
+          wakeMode: "next-heartbeat",
+          payload: { kind: "agentTurn", message: "work" },
+          state: { nextRunAtMs: 60_000 },
+        };
+        const state = createCronServiceState({
+          storePath: "/tmp/jobs.json",
+          cronEnabled: true,
+          log: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+          nowMs: () => startedAt + 100,
+          enqueueSystemEvent: vi.fn(),
+          requestHeartbeat: vi.fn(),
+          runIsolatedAgentJob: vi.fn(async () => ({ status: "ok" as const })),
+        });
+        const taskRunId = tryCreateCronTaskRun({ state, job, startedAt });
+        if (!taskRunId) {
+          throw new Error("expected cron task run id");
+        }
+
+        tryFinishCronTaskRunWithoutHistory(state, {
+          taskRunId,
+          status: "error",
+          error,
+          endedAt: startedAt + 100,
+        });
+
+        expect(
+          listTaskRegistryRecordsByRuntimeSourceIdFromSqlite({
+            runtime: "cron",
+            sourceId: job.id,
+          }),
+        ).toEqual([
+          expect.objectContaining({
+            status: "timed_out",
+            error,
+            endedAt: startedAt + 100,
+          }),
+        ]);
+      },
+    );
+  });
+
   it("overwrites a provisional timeout with restart terminal history", async () => {
     await withOpenClawTestState(
       { layout: "state-only", prefix: "openclaw-cron-task-timeout-recovery-" },

--- a/src/cron/service/task-runs.ts
+++ b/src/cron/service/task-runs.ts
@@ -7,6 +7,7 @@ import {
   resolveAgentIdFromSessionKey,
 } from "../../routing/session-key.js";
 import { resolveCronJobEffectiveAgentId } from "../agent-id.js";
+import { isCronTimeoutErrorText } from "../execution-error-constants.js";
 
 function requireCronAgentId(agentId: string | undefined): string {
   if (!agentId?.trim()) {
@@ -41,7 +42,7 @@ import {
 } from "../task-run-detail.js";
 import { cronRunLogEntryFromEvent } from "../task-run-event-codec.js";
 import type { CronJob, CronRunErrorClassification, CronRunStatus } from "../types.js";
-import { normalizeCronRunErrorText, timeoutErrorMessage } from "./execution-errors.js";
+import { normalizeCronRunErrorText } from "./execution-errors.js";
 import type { CronEvent, CronServiceState } from "./state.js";
 import { CRON_TASK_RUNNING_PROGRESS_SUMMARY } from "./task-ledger.js";
 
@@ -301,7 +302,7 @@ export function tryFinishCronTaskRunWithoutHistory(
       status:
         result.status === "ok" || result.status === "skipped"
           ? "succeeded"
-          : error === timeoutErrorMessage()
+          : isCronTimeoutErrorText(error)
             ? "timed_out"
             : "failed",
       endedAt: result.endedAt,

--- a/src/cron/session-reaper.test.ts
+++ b/src/cron/session-reaper.test.ts
@@ -524,6 +524,35 @@ describe("sweepCronRunSessions", () => {
     expect(r2.swept).toBe(false);
   });
 
+  it("resumes retention cleanup after the wall clock moves backward", async () => {
+    const now = Date.now();
+    const rolledBackNow = now - 3_600_000;
+    const sessionKey = "agent:main:cron:job1:run:clock-rollback";
+
+    await expect(
+      sweepCronRunSessions({ sessionStorePath: storePath, nowMs: now, log }),
+    ).resolves.toEqual({ swept: true, pruned: 0 });
+
+    await seedSessionEntries(storePath, {
+      [sessionKey]: {
+        sessionId: "clock-rollback",
+        updatedAt: rolledBackNow - 25 * 3_600_000,
+      },
+    });
+
+    await expect(
+      sweepCronRunSessions({ sessionStorePath: storePath, nowMs: rolledBackNow, log }),
+    ).resolves.toEqual({ swept: true, pruned: 1 });
+    expect(readSessionEntries(storePath)[sessionKey]).toBeUndefined();
+    await expect(
+      sweepCronRunSessions({
+        sessionStorePath: storePath,
+        nowMs: rolledBackNow + 1_000,
+        log,
+      }),
+    ).resolves.toEqual({ swept: false, pruned: 0 });
+  });
+
   it("shares one throttle for canonical agent and session-store aliases", async () => {
     const now = Date.now();
 

--- a/src/cron/session-reaper.ts
+++ b/src/cron/session-reaper.ts
@@ -77,7 +77,7 @@ export async function sweepCronRunSessions(params: {
 
   // Timer ticks can be frequent; throttle per agent/store target to avoid
   // repeated session-store I/O while preserving a force path for tests.
-  if (!params.force && now - lastSweepAtMs < MIN_SWEEP_INTERVAL_MS) {
+  if (!params.force && now >= lastSweepAtMs && now - lastSweepAtMs < MIN_SWEEP_INTERVAL_MS) {
     return { swept: false, pruned: 0 };
   }
 

--- a/src/cron/task-run-detail.ts
+++ b/src/cron/task-run-detail.ts
@@ -2,7 +2,7 @@
  * Deliberately free of agent/runtime imports so history reads stay dependency-light;
  * the event->entry write codec lives in task-run-event-codec.ts. */
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
-import { CRON_JOB_EXECUTION_TIMEOUT_ERROR } from "./execution-error-constants.js";
+import { isCronTimeoutErrorText } from "./execution-error-constants.js";
 import { normalizeCronRunDiagnostics } from "./run-diagnostics-normalize.js";
 
 type FailoverReason = import("../agents/embedded-agent-helpers/types.js").FailoverReason;
@@ -259,7 +259,7 @@ export function cronRunStatusToTaskStatus(
   if (entry.status === "ok" || entry.status === "skipped") {
     return "succeeded";
   }
-  return entry.error === CRON_JOB_EXECUTION_TIMEOUT_ERROR ? "timed_out" : "failed";
+  return isCronTimeoutErrorText(entry.error) ? "timed_out" : "failed";
 }
 
 /** Reconstructs the unchanged CronRunLogEntry wire shape from a cron task row. */

--- a/src/cron/task-run-history.test.ts
+++ b/src/cron/task-run-history.test.ts
@@ -64,6 +64,37 @@ function futureCronDetailTask(storeKey: string): TaskRecord {
 }
 
 describe("cron task run history", () => {
+  it.each([
+    "cron: job execution timed out",
+    "cron: job execution timed out (last phase: model_call_started)",
+    "cron: isolated agent setup timed out before runner start",
+    "cron: isolated agent setup timed out before runner start (last phase: preparing)",
+    "cron: isolated agent run stalled before execution start",
+    "cron: isolated agent run stalled before execution start (last phase: preparing)",
+  ])("classifies the watchdog timeout %j as a timed-out task", (error) => {
+    expect(
+      cronRunStatusToTaskStatus({
+        ts: 100,
+        jobId: JOB_ID,
+        action: "finished",
+        status: "error",
+        error,
+      }),
+    ).toBe("timed_out");
+  });
+
+  it("does not classify unrelated errors as watchdog timeouts", () => {
+    expect(
+      cronRunStatusToTaskStatus({
+        ts: 100,
+        jobId: JOB_ID,
+        action: "finished",
+        status: "error",
+        error: "provider request timed out",
+      }),
+    ).toBe("failed");
+  });
+
   it("reads executions produced by the cron service from the ledger", async () => {
     await withOpenClawTestState(
       { layout: "state-only", prefix: "openclaw-cron-task-service-history-" },

--- a/src/gateway/server-cron.test.ts
+++ b/src/gateway/server-cron.test.ts
@@ -436,6 +436,105 @@ describe("buildGatewayCronService", () => {
     }
   });
 
+  it.each(["add", "remove"] as const)(
+    "does not apply a stale on-exit watcher snapshot after a concurrent %s",
+    async (mutation) => {
+      const runDone = createDeferred<{
+        reason: "manual-cancel";
+        exitCode: null;
+        exitSignal: null;
+        durationMs: number;
+        stdout: string;
+        stderr: string;
+        timedOut: false;
+        noOutputTimedOut: false;
+      }>();
+      const cancel = vi.fn(() =>
+        runDone.resolve({
+          reason: "manual-cancel",
+          exitCode: null,
+          exitSignal: null,
+          durationMs: 1,
+          stdout: "",
+          stderr: "",
+          timedOut: false,
+          noOutputTimedOut: false,
+        }),
+      );
+      const cancelScope = vi.fn();
+      const spawn = vi.fn(async () => ({
+        runId: `run-on-exit-${mutation}-race`,
+        startedAtMs: Date.now(),
+        cancel,
+        wait: () => runDone.promise,
+      }));
+      getProcessSupervisorMock.mockReturnValue({ spawn, cancelScope });
+      const cfg = createCronConfig(`server-cron-on-exit-${mutation}-race`);
+      loadConfigMock.mockReturnValue(cfg);
+      const state = buildGatewayCronService({
+        cfg,
+        deps: {} as CliDeps,
+        broadcast: () => {},
+      });
+      const captured = createDeferred();
+      const release = createDeferred();
+
+      try {
+        const addJob = async () =>
+          await state.cron.add({
+            name: "Watch concurrent mutation",
+            enabled: true,
+            schedule: { kind: "on-exit", command: "sleep 60" },
+            payload: { kind: "systemEvent", text: "done" },
+            sessionTarget: "main",
+            wakeMode: "next-heartbeat",
+          });
+        const existing = mutation === "remove" ? await addJob() : undefined;
+        if (existing) {
+          await state.reconcileExitWatchers?.();
+          await vi.waitFor(() => expect(spawn).toHaveBeenCalledOnce());
+        }
+
+        const originalList = state.cron.list.bind(state.cron);
+        let gateNextList = true;
+        state.cron.list = async (options?: Parameters<typeof originalList>[0]) => {
+          if (!gateNextList) {
+            return await originalList(options);
+          }
+          gateNextList = false;
+          const snapshot = await originalList(options);
+          captured.resolve();
+          await release.promise;
+          return snapshot;
+        };
+
+        const staleReconciliation = state.reconcileExitWatchers?.();
+        await captured.promise;
+        if (mutation === "remove") {
+          if (!existing) {
+            throw new Error("expected an existing exit-watcher job");
+          }
+          await state.cron.remove(existing.id);
+          await vi.waitFor(() => expect(cancel).toHaveBeenCalledOnce());
+        } else {
+          await addJob();
+          await vi.waitFor(() => expect(spawn).toHaveBeenCalledOnce());
+        }
+        release.resolve();
+        await staleReconciliation;
+
+        expect(spawn).toHaveBeenCalledOnce();
+        if (mutation === "add") {
+          expect(cancel).not.toHaveBeenCalled();
+          expect(cancelScope).not.toHaveBeenCalled();
+        }
+      } finally {
+        release.resolve();
+        state.cron.stop();
+      }
+    },
+  );
+
   it("fires an on-exit payload after persisting its terminal disable", async () => {
     let resolveWait!: (result: {
       reason: "exit";

--- a/src/gateway/server-cron.ts
+++ b/src/gateway/server-cron.ts
@@ -452,12 +452,14 @@ export function buildGatewayCronService(params: {
   let streamWatcherReconciliations = 0;
   const terminalExitCompletionTokens = new Map<string, object>();
   let exitWatcherGeneration = 0;
+  let exitWatcherMutationRevision = 0;
   let streamWatcherGeneration = 0;
   // Bumped when a direct watcher route begins; fences reconcile's async list
   // snapshot against mutations that commit inside the list await.
   let streamWatcherMutationRevision = 0;
   let streamWatchersStopped = false;
   const reconcileExitWatchers = async () => {
+    const revision = ++exitWatcherMutationRevision;
     const generation = exitWatcherGeneration;
     exitWatcherReconciliations += 1;
     try {
@@ -465,7 +467,7 @@ export function buildGatewayCronService(params: {
         return;
       }
       const result = await cron.list({ includeDisabled: true });
-      if (generation !== exitWatcherGeneration) {
+      if (generation !== exitWatcherGeneration || revision !== exitWatcherMutationRevision) {
         return;
       }
       const jobs: CronJob[] = Array.isArray(result) ? result : (result as { jobs: CronJob[] }).jobs;

--- a/src/gateway/server-methods/cron-run-log-filters.test.ts
+++ b/src/gateway/server-methods/cron-run-log-filters.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import type { CronJob } from "../../cron/types.js";
+import { filterCronRunLogJobsByAgent } from "./cron-run-log-filters.js";
+
+function createJob(overrides: Partial<CronJob>): CronJob {
+  return {
+    id: "job-1",
+    name: "Scheduled work",
+    enabled: true,
+    createdAtMs: 1,
+    updatedAtMs: 1,
+    schedule: { kind: "every", everyMs: 60_000 },
+    sessionTarget: "main",
+    wakeMode: "next-heartbeat",
+    payload: { kind: "systemEvent", text: "tick" },
+    state: {},
+    ...overrides,
+  };
+}
+
+describe("filterCronRunLogJobsByAgent", () => {
+  it("uses the agent owned by a scoped session instead of the configured default", () => {
+    const scopedJob = createJob({ id: "scoped", sessionKey: "agent:ops:main" });
+    const defaultJob = createJob({ id: "default" });
+
+    expect(filterCronRunLogJobsByAgent([scopedJob, defaultJob], "ops", "main")).toEqual([
+      scopedJob,
+    ]);
+    expect(filterCronRunLogJobsByAgent([scopedJob, defaultJob], "main", "main")).toEqual([
+      defaultJob,
+    ]);
+  });
+
+  it("uses scoped ownership when an optional explicit agent is blank", () => {
+    const scopedJob = createJob({
+      id: "scoped",
+      agentId: "   ",
+      sessionKey: "agent:ops:main",
+    });
+
+    expect(filterCronRunLogJobsByAgent([scopedJob], "OPS", "main")).toEqual([scopedJob]);
+    expect(filterCronRunLogJobsByAgent([scopedJob], "main", "main")).toEqual([]);
+  });
+
+  it("does not resolve ownership when no agent filter was requested", () => {
+    const job = createJob({ id: "unfiltered" });
+
+    expect(filterCronRunLogJobsByAgent([job], undefined, undefined)).toEqual([job]);
+  });
+});

--- a/src/gateway/server-methods/cron-run-log-filters.ts
+++ b/src/gateway/server-methods/cron-run-log-filters.ts
@@ -1,3 +1,4 @@
+import { resolveCronJobEffectiveAgentId } from "../../cron/agent-id.js";
 import type { CronDeliveryStatus, CronJob, CronRunStatus } from "../../cron/types.js";
 import { normalizeAgentId } from "../../routing/session-key.js";
 
@@ -11,7 +12,7 @@ export function filterCronRunLogJobsByAgent(
   }
   const normalizedAgentId = normalizeAgentId(agentId);
   return jobs.filter(
-    (job) => normalizeAgentId(job.agentId ?? defaultAgentId) === normalizedAgentId,
+    (job) => resolveCronJobEffectiveAgentId(job, defaultAgentId) === normalizedAgentId,
   );
 }
 

--- a/ui/src/e2e/new-session-page.e2e.test.ts
+++ b/ui/src/e2e/new-session-page.e2e.test.ts
@@ -1373,7 +1373,11 @@ describeControlUiE2e("Control UI new-session page mocked Gateway E2E", () => {
       const trigger = page.locator("#new-session-place-trigger");
       await trigger.click();
       await page.getByRole("button", { name: "Browse folders" }).click();
-      await page.locator("input.new-session-page__browser-path").fill(TARGET_REPO);
+      const browserPath = page.locator("input.new-session-page__browser-path");
+      // Resolve the browser listing without resolving the deferred agent roster;
+      // otherwise its initial path update can race Playwright's folder input.
+      await expect.poll(() => browserPath.inputValue()).toBe(TARGET_REPO);
+      await browserPath.fill(TARGET_REPO);
       await page.getByRole("button", { name: "Use this folder" }).click();
       await gateway.resolveDeferred("agents.list", {
         agents: [

--- a/ui/src/lib/workboard/card-state.ts
+++ b/ui/src/lib/workboard/card-state.ts
@@ -9,6 +9,17 @@ import type {
 
 const WORKBOARD_STALE_SESSION_MS = 30 * 60 * 1000;
 
+export function isActiveWorkboardCard(card: WorkboardCard): boolean {
+  return !card.metadata?.archivedAt;
+}
+
+export function selectedWorkboardBoardParams(
+  state: Pick<WorkboardUiState, "boards" | "boardFilter">,
+): { boardId?: string } {
+  const boardId = state.boards.find((board) => board.id === state.boardFilter)?.id;
+  return boardId ? { boardId } : {};
+}
+
 export function replaceCard(state: WorkboardUiState, card: WorkboardCard) {
   const next = state.cards.filter((existing) => existing.id !== card.id);
   next.push(card);

--- a/ui/src/lib/workboard/index.test.ts
+++ b/ui/src/lib/workboard/index.test.ts
@@ -2714,6 +2714,58 @@ describe("workboard controller", () => {
     expect(client.request).not.toHaveBeenCalled();
   });
 
+  it("does not poll tasks or reconcile archived session cards", async () => {
+    state.loaded = true;
+    const archived = createWorkboardCard({
+      status: "running",
+      sessionKey: sampleSession.key,
+      taskId: "archived-task",
+      metadata: { archivedAt: 10 },
+    });
+    state.cards = [archived];
+    const client = createClient({});
+
+    await syncLifecycle(client, [
+      { ...sampleSession, status: "done", hasActiveRun: false, updatedAt: 20 },
+    ]);
+
+    expect(client.request).not.toHaveBeenCalled();
+    expect(state.cards).toEqual([archived]);
+    expect(state.tasksByCardId.size).toBe(0);
+  });
+
+  it("reconciles active session cards without rewriting an archived sibling", async () => {
+    state.loaded = true;
+    const archived = createWorkboardCard({
+      id: "archived-session-card",
+      status: "running",
+      sessionKey: sampleSession.key,
+      taskId: "archived-task",
+      metadata: { archivedAt: 10 },
+    });
+    const active = createWorkboardCard({
+      id: "active-session-card",
+      status: "todo",
+      sessionKey: sampleSession.key,
+    });
+    state.cards = [archived, active];
+    const updated = { ...active, status: "review" as const };
+    const client = createClient((method) =>
+      method === "workboard.cards.update" ? { card: updated } : {},
+    );
+
+    await syncLifecycle(client, [
+      { ...sampleSession, status: "done", hasActiveRun: false, updatedAt: 20 },
+    ]);
+
+    expect(client.request).toHaveBeenCalledOnce();
+    expect(client.request).toHaveBeenCalledWith(
+      "workboard.cards.update",
+      expect.objectContaining({ id: active.id }),
+    );
+    expect(state.cards.find((card) => card.id === archived.id)).toEqual(archived);
+  });
+
   it.each(["editing", "dragging"] as const)(
     "does not start lifecycle writes while a card is %s",
     async (interaction) => {
@@ -2893,6 +2945,37 @@ describe("workboard controller", () => {
       sessionKey: sampleSession.key,
     });
     expect(getWorkboardState(host).cards[0]).toMatchObject({ sessionKey: sampleSession.key });
+  });
+
+  it("captures a session on the selected named board", async () => {
+    state.loaded = true;
+    state.boardFilter = "ops";
+    state.boards = [{ id: "ops", total: 0, active: 0, archived: 0, byStatus: {} }];
+    const created = createWorkboardCard({
+      id: "captured-ops-card",
+      sessionKey: sampleSession.key,
+      metadata: { automation: { boardId: "ops" } },
+    });
+    const client = createClient((method) => {
+      if (method === "chat.history") {
+        return { messages: [] };
+      }
+      if (method === "workboard.cards.create") {
+        return { card: created };
+      }
+      return {};
+    });
+
+    await expect(captureSession(client, sampleSession)).resolves.toMatchObject({
+      id: "captured-ops-card",
+      metadata: { automation: { boardId: "ops" } },
+    });
+
+    expect(client.request).toHaveBeenCalledWith(
+      "workboard.cards.create",
+      expect.objectContaining({ boardId: "ops", sessionKey: sampleSession.key }),
+    );
+    expect(state.cards).toContainEqual(created);
   });
 
   it("does not duplicate existing captured sessions", async () => {

--- a/ui/src/lib/workboard/lifecycle-reconciliation.ts
+++ b/ui/src/lib/workboard/lifecycle-reconciliation.ts
@@ -1,6 +1,6 @@
 import type { GatewayBrowserClient } from "../../api/gateway.ts";
 import type { GatewaySessionRow } from "../../api/types.ts";
-import { replaceCard, staleSessionState } from "./card-state.ts";
+import { isActiveWorkboardCard, replaceCard, staleSessionState } from "./card-state.ts";
 import {
   executionStatusForLifecycle,
   getLifecycleSyncKeys,
@@ -265,6 +265,9 @@ export async function syncWorkboardLifecycle(params: {
   const syncKeys = getLifecycleSyncKeys(params.host);
   let lifecycleWriteStarted = false;
   for (const card of state.cards) {
+    if (!isActiveWorkboardCard(card)) {
+      continue;
+    }
     if (
       !isCurrentWorkboardLifecycleReconciliationEpoch(params.host, reconciliationEpoch) ||
       workboardLifecycleSyncBlocked(params.host, state)

--- a/ui/src/lib/workboard/mutations.ts
+++ b/ui/src/lib/workboard/mutations.ts
@@ -4,6 +4,7 @@ import {
   removeCardAndReferences,
   replaceCard,
   resetDraftState,
+  selectedWorkboardBoardParams,
 } from "./card-state.ts";
 import { clearPendingStatusTransition, recordPendingStatusTransition } from "./lifecycle.ts";
 import { formatError, isRecord } from "./normalization-utils.ts";
@@ -18,14 +19,7 @@ import {
   type WorkboardHost,
 } from "./runtime.ts";
 import { applyTaskSummariesToState, listWorkboardTasks } from "./task-links.ts";
-import type { WorkboardDispatchSummary, WorkboardStatus, WorkboardUiState } from "./types.ts";
-
-function selectedBoardParams(state: Pick<WorkboardUiState, "boards" | "boardFilter">): {
-  boardId?: string;
-} {
-  const boardId = state.boards.find((board) => board.id === state.boardFilter)?.id;
-  return boardId ? { boardId } : {};
-}
+import type { WorkboardDispatchSummary, WorkboardStatus } from "./types.ts";
 
 function normalizeDispatchSummary(value: unknown): WorkboardDispatchSummary {
   const countArray = (key: string) =>
@@ -63,7 +57,7 @@ async function createWorkboardCard(params: {
   try {
     const payload = await params.client.request("workboard.cards.create", {
       ...draftPayload(state),
-      ...selectedBoardParams(state),
+      ...selectedWorkboardBoardParams(state),
     });
     replaceCard(state, normalizeCardPayload(payload));
     resetDraftState(state);
@@ -299,7 +293,7 @@ export async function dispatchWorkboard(params: {
   try {
     const dispatchResult = await params.client.request(
       "workboard.cards.dispatch",
-      selectedBoardParams(state),
+      selectedWorkboardBoardParams(state),
     );
     const payload = await params.client.request("workboard.cards.list", {});
     const normalized = normalizeCardsPayload(payload);

--- a/ui/src/lib/workboard/runtime.ts
+++ b/ui/src/lib/workboard/runtime.ts
@@ -1,5 +1,5 @@
 import type { GatewayBrowserClient } from "../../api/gateway.ts";
-import { normalizeString, workboardCardSessionKey } from "./card-state.ts";
+import { isActiveWorkboardCard, normalizeString, workboardCardSessionKey } from "./card-state.ts";
 import { WORKBOARD_STATUSES, type WorkboardTaskLinkState, type WorkboardUiState } from "./types.ts";
 
 export type WorkboardHost = object;
@@ -424,8 +424,11 @@ export function workboardLifecycleSyncBlocked(
 
 export function workboardLifecycleRequiresTaskRefresh(state: WorkboardTaskLinkState): boolean {
   return (
-    state.tasksByCardId.size > 0 ||
+    state.cards.some((card) => isActiveWorkboardCard(card) && state.tasksByCardId.has(card.id)) ||
     state.cards.some((card) => {
+      if (!isActiveWorkboardCard(card)) {
+        return false;
+      }
       const taskId = normalizeString(card.taskId);
       return Boolean(taskId && !state.missingTaskIds.has(taskId));
     })
@@ -435,7 +438,12 @@ export function workboardLifecycleRequiresTaskRefresh(state: WorkboardTaskLinkSt
 export function shouldRefreshWorkboardTasksForLifecycle(state: WorkboardTaskLinkState): boolean {
   return (
     workboardLifecycleRequiresTaskRefresh(state) ||
-    state.cards.some((card) => card.status === "running" && Boolean(workboardCardSessionKey(card)))
+    state.cards.some(
+      (card) =>
+        isActiveWorkboardCard(card) &&
+        card.status === "running" &&
+        Boolean(workboardCardSessionKey(card)),
+    )
   );
 }
 
@@ -444,6 +452,9 @@ export function workboardTaskLinksReadyForLifecycle(
   options: { requireRunningTaskDiscovery?: boolean } = {},
 ): boolean {
   return state.cards.every((card) => {
+    if (!isActiveWorkboardCard(card)) {
+      return true;
+    }
     const taskId = normalizeString(card.taskId);
     if (taskId) {
       return state.missingTaskIds.has(taskId) || state.tasksByCardId.has(card.id);

--- a/ui/src/lib/workboard/session-capture.ts
+++ b/ui/src/lib/workboard/session-capture.ts
@@ -5,6 +5,7 @@ import {
   isFailedSessionStatus,
   normalizeString,
   replaceCard,
+  selectedWorkboardBoardParams,
   workboardCardSessionKey,
 } from "./card-state.ts";
 import { loadWorkboard } from "./loading.ts";
@@ -215,6 +216,7 @@ export async function captureSessionToWorkboard(params: {
       priority: "normal",
       agentId: "",
       sessionKey: params.session.key,
+      ...selectedWorkboardBoardParams(state),
     });
     const card = normalizeCardPayload(payload);
     replaceCard(state, card);

--- a/ui/src/lib/workboard/task-links.ts
+++ b/ui/src/lib/workboard/task-links.ts
@@ -1,6 +1,11 @@
 import { GatewayRequestError, type GatewayBrowserClient } from "../../api/gateway.ts";
 import type { GatewaySessionRow } from "../../api/types.ts";
-import { normalizeString, workboardCardRunId, workboardCardSessionKey } from "./card-state.ts";
+import {
+  isActiveWorkboardCard,
+  normalizeString,
+  workboardCardRunId,
+  workboardCardSessionKey,
+} from "./card-state.ts";
 import { formatError, isRecord } from "./normalization-utils.ts";
 import { normalizeTaskSummary, normalizeTasksPage } from "./normalization.ts";
 import { getWorkboardRuntime, type WorkboardHost } from "./runtime.ts";
@@ -144,6 +149,9 @@ export function selectWorkboardTaskPollIds(
   const ids: string[] = [];
   const seen = new Set<string>();
   for (const card of cards) {
+    if (!isActiveWorkboardCard(card)) {
+      continue;
+    }
     const previousTask = previousTasksByCardId.get(card.id);
     const previousMatches = previousTask
       ? taskMatchesTrackedCardLink(previousTask, card, missingTaskIds)
@@ -180,6 +188,9 @@ export function selectWorkboardTaskDiscoveryQueries(
   const seenSessionKeys = new Set<string>();
   let hasUnfilteredQuery = false;
   for (const card of cards) {
+    if (!isActiveWorkboardCard(card)) {
+      continue;
+    }
     const previousTask = previousTasksByCardId.get(card.id);
     const cardTaskId = normalizeString(card.taskId);
     const hasCanonicalTask =
@@ -371,6 +382,9 @@ export function selectWorkboardMissingTaskConfirmationIds(
   const ids: string[] = [];
   const seen = new Set<string>();
   for (const card of cards) {
+    if (!isActiveWorkboardCard(card)) {
+      continue;
+    }
     const previousTask = previousTasksByCardId.get(card.id);
     const previousMatches = previousTask
       ? taskMatchesTrackedCardLink(previousTask, card, missingTaskIds)
@@ -405,6 +419,9 @@ export function applyTaskSummariesToState(
   // Confirmed misses stop blocking starts without writes from passive refresh paths.
   const missingTaskIds = new Set([...state.missingTaskIds, ...(options.missingTaskIds ?? [])]);
   const cards = state.cards.map((card) => {
+    if (!isActiveWorkboardCard(card)) {
+      return card;
+    }
     const cardTaskId = normalizeString(card.taskId);
     const task = findLatestTaskForCard(taskIndex, card, missingTaskIds);
     if (!task) {


### PR DESCRIPTION
## What Problem This Solves

Fixes issues where users running cron jobs or managing Workboard cards could experience duplicate or cancelled process watches, lost concurrent job edits, incorrect failure-alert accounts, missing agent-scoped job history, misclassified timeouts, stopped session cleanup after clock corrections, worker starts for archived or reassigned cards, deleted notification subscriptions returning, hidden cards captured onto the wrong board, and background task updates mutating archived cards.

## Why This Change Was Made

Stress-tested the current scheduler, gateway, plugin, and browser flows and fixed each reproduced race inside its existing owner. Cron edits reuse a single gateway snapshot and its existing configuration-revision precondition; exit watchers discard superseded snapshots; timeout/history and failure routing reuse canonical ownership and classification. Workboard claims and notification deletions use existing atomic mutation ownership, and the UI now shares canonical active-card and selected-board helpers. No schema versions, state migrations, new configuration, public plugin contracts, or authorization-recovery policy are changed.

## User Impact

Scheduled work and notifications remain consistent during simultaneous edits, process exits, multi-account delivery, timeout phases, and system-clock changes. Archived and moved Workboard cards cannot start or be silently rewritten, subscriptions stay deleted, and sessions captured from a named board remain visible and runnable on that board.

## Evidence

- Independent code review: clean; no accepted or actionable findings.
- Blacksmith Testbox `tbx_01kyjkd0cv0nyyq5esx4yqz2xm`: **716 passed** across 24 focused cron, CLI, gateway, Workboard plugin, and Control UI test files.
- Repeated scheduler, history, CLI, subscription, dispatch, and Workboard lifecycle race tests **three times**; all three runs passed.
- Real Chromium: **68 passed** across the complete new-session suite, Workboard lifecycle, routing, status persistence, session dashboard, and cron filter E2E tests.
- Running-gateway `mock-openai` QA: **4 passed, 0 failed, 0 skipped**, including naturally firing cron and duplicate-delivery detection.
- Full changed-code format, type, lint, architecture, and plugin-boundary gate: recorded in PR checks.
- AI-assisted implementation; no raw or private task transcript included.

### Inspectable runtime race proof

Reproduced on a freshly provisioned Linux Blacksmith Testbox using the reviewed cron and Workboard implementation and the repository's real gateway, cron, CLI, Workboard plugin, and Control UI test runners. The final PR commit is `dfcbfdc683a7529f6336286271babfaa8e282874`, rebased onto the latest `main`. The Workboard case changes each ready card to archived, completed, blocked, under review, or another board after dispatch preflight and verifies that no worker starts and no stale claim is written.

```text
Changes synced in 4846ms (remote-fetch)
✓ gateway-server src/gateway/server-cron.test.ts (59 tests)
✓ gateway-server src/gateway/server-cron-notifications.test.ts (19 tests)
✓ gateway-methods src/gateway/server-methods/cron-run-log-filters.test.ts (3 tests)
Test Files  3 passed (3)
Tests       81 passed (81)
✓ cron src/cron/service.failure-alert.test.ts (27 tests)
✓ cron src/cron/service/timer.regression.test.ts (67 tests)
✓ cron src/cron/service/task-runs.test.ts (22 tests)
✓ extensions extensions/workboard/src/dispatcher.test.ts (30 tests)
✓ extensions extensions/workboard/src/dispatcher-ownership.test.ts (15 tests)
✓ extensions extensions/workboard/src/dispatcher.races.test.ts (5 tests)
blacksmith run summary sync=delegated command=1m8.762s total=1m8.979s exit=0
{"provider":"blacksmith-testbox","leaseId":"tbx_01kyjnx41byezwx94nbj0beawm","exitCode":0,"runStatus":"succeeded"}
```

The actual Chromium rerun additionally proves the previously failing early-folder race and complete affected browser flows:

```text
✓ ui-e2e ui/src/e2e/new-session-page.e2e.test.ts (47 tests)
  ✓ keeps a folder chosen before the agent roster finishes loading submit-ready
✓ ui-e2e ui/src/pages/workboard/workboard.e2e.test.ts (3 tests)
✓ ui-e2e ui/src/e2e/session-dashboard.e2e.test.ts (7 tests)
✓ ui-e2e ui/src/e2e/cron-filters.e2e.test.ts (7 tests)
✓ ui-e2e ui/src/pages/workboard/workboard-status-persistence.e2e.test.ts (1 test)
✓ ui-e2e ui/src/pages/workboard/workboard-routing.e2e.test.ts (3 tests)
Test Files  6 passed (6)
Tests       68 passed (68)
blacksmith run summary sync=delegated command=2m54.453s total=2m54.542s exit=0
```

Both original CI findings were corrected without suppressions; the prior exact-head `check-test-types`, `check-lint`, and build jobs pass. The additional browser race discovered by CI is fixed in the same change so the existing new-session folder preference test waits for initial directory hydration while intentionally keeping agent discovery deferred. The independently landed latest-main discussion timeout repair is preserved verbatim rather than duplicated. A maintainer intentionally reviewed and kept the coordinated cron, Workboard-store, and Control UI scope together because these paths own the same job/card/session lifecycle invariants.
