### PR TITLE
fix(openai): reject malformed base64 audio in realtime voice deltas

### DIFF
--- a/extensions/openai/realtime-voice-provider.test.ts
+++ b/extensions/openai/realtime-voice-provider.test.ts
@@ -1741,6 +1741,63 @@ describe("buildOpenAIRealtimeVoiceProvider", () => {
     expect(hasSentEventType(socket, "conversation.item.truncate")).toBe(false);
   });
 
+  it("reports malformed base64 audio deltas through onError without emitting audio", async () => {
+    const provider = buildOpenAIRealtimeVoiceProvider();
+    const onAudio = vi.fn();
+    const onError = vi.fn();
+    const bridge = provider.createBridge({
+      providerConfig: { apiKey: "sk-test" }, // pragma: allowlist secret
+      onAudio,
+      onClearAudio: vi.fn(),
+      onError,
+    });
+    const connecting = bridge.connect();
+    const socket = FakeWebSocket.instances[0];
+    if (!socket) {
+      throw new Error("expected bridge to create a websocket");
+    }
+
+    socket.readyState = FakeWebSocket.OPEN;
+    socket.emit("open");
+    socket.emit("message", Buffer.from(JSON.stringify({ type: "session.updated" })));
+    await connecting;
+
+    socket.emit(
+      "message",
+      Buffer.from(JSON.stringify({ type: "response.created", response: { id: "resp_1" } })),
+    );
+    socket.emit(
+      "message",
+      Buffer.from(
+        JSON.stringify({
+          type: "response.audio.delta",
+          item_id: "item_1",
+          delta: "%%%not-base64!!",
+        }),
+      ),
+    );
+    // A subsequent valid delta must still be emitted: one bad frame does not
+    // terminate the live session.
+    socket.emit(
+      "message",
+      Buffer.from(
+        JSON.stringify({
+          type: "response.audio.delta",
+          item_id: "item_1",
+          delta: Buffer.from("assistant audio").toString("base64"),
+        }),
+      ),
+    );
+
+    expect(onAudio).toHaveBeenCalledTimes(1);
+    expect(onError).toHaveBeenCalledTimes(1);
+    expect(onError).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: "OpenAI Realtime voice stream returned malformed base64 audio data",
+      }),
+    );
+  });
+
   it("keeps assistant playback active on server VAD when automatic audio responses are disabled", async () => {
     const provider = buildOpenAIRealtimeVoiceProvider();
     const onAudio = vi.fn();

--- a/extensions/openai/realtime-voice-provider.test.ts
+++ b/extensions/openai/realtime-voice-provider.test.ts
@@ -131,6 +131,13 @@ vi.mock("openclaw/plugin-sdk/provider-auth", () => ({
   resolveProviderAuthProfileApiKey: resolveProviderAuthProfileApiKeyMock,
 }));
 
+vi.mock("openclaw/plugin-sdk/media-runtime", async () => {
+  // Route through the lightweight base64 submodule so the test does not pull
+  // in the full media-runtime barrel (ffmpeg/native deps) at collection time.
+  const { canonicalizeBase64 } = await import("@openclaw/media-core/base64");
+  return { canonicalizeBase64 };
+});
+
 type FakeWebSocketInstance = InstanceType<typeof FakeWebSocket>;
 type SentRealtimeEvent = {
   type: string;

--- a/extensions/openai/realtime-voice-provider.ts
+++ b/extensions/openai/realtime-voice-provider.ts
@@ -1,6 +1,7 @@
 // Openai provider module implements model/runtime integration.
 import { execFileSync } from "node:child_process";
 import { randomUUID } from "node:crypto";
+import { canonicalizeBase64 } from "@openclaw/media-core/base64";
 import {
   isProviderAuthProfileConfigured,
   resolveProviderAuthProfileApiKey,
@@ -489,8 +490,17 @@ function readRealtimeErrorEventId(error: unknown): string | undefined {
   return typeof eventId === "string" ? eventId : undefined;
 }
 
-function base64ToBuffer(b64: string): Buffer {
-  return Buffer.from(b64, "base64");
+function base64ToBuffer(b64: string): Buffer | null {
+  // `Buffer.from(x, "base64")` silently drops characters outside the base64
+  // alphabet, so a damaged delta would decode into garbage bytes. Validate
+  // with `canonicalizeBase64` (rejects invalid chars, bad padding, bad length)
+  // and return null so the caller can surface the error instead of playing
+  // corrupted audio.
+  const canonical = canonicalizeBase64(b64);
+  if (!canonical) {
+    return null;
+  }
+  return Buffer.from(canonical, "base64");
 }
 
 class OpenAIRealtimeVoiceBridge implements RealtimeVoiceBridge {
@@ -1120,6 +1130,15 @@ class OpenAIRealtimeVoiceBridge implements RealtimeVoiceBridge {
           return;
         }
         const audio = base64ToBuffer(audioDelta);
+        if (!audio) {
+          // One corrupt frame must not terminate a live voice conversation,
+          // but it must never reach the speaker silently. Report through
+          // onError and let the next valid delta resume playback.
+          this.config.onError?.(
+            new Error("OpenAI Realtime voice stream returned malformed base64 audio data"),
+          );
+          return;
+        }
         this.config.onAudio(audio);
         if (event.item_id && event.item_id !== this.lastAssistantItemId) {
           this.lastAssistantItemId = event.item_id;

--- a/extensions/openai/realtime-voice-provider.ts
+++ b/extensions/openai/realtime-voice-provider.ts
@@ -1,7 +1,7 @@
 // Openai provider module implements model/runtime integration.
 import { execFileSync } from "node:child_process";
 import { randomUUID } from "node:crypto";
-import { canonicalizeBase64 } from "@openclaw/media-core/base64";
+import { canonicalizeBase64 } from "openclaw/plugin-sdk/media-runtime";
 import {
   isProviderAuthProfileConfigured,
   resolveProviderAuthProfileApiKey,


### PR DESCRIPTION
## What Problem This Solves

The OpenAI Realtime voice provider's `base64ToBuffer` decoded incoming `response.audio.delta` payloads with `Buffer.from(b64, "base64")`, which silently discards characters outside the base64 alphabet. A damaged delta from the server (truncated frame, encoding error, or protocol corruption) would decode into garbage bytes and play corrupted audio without any warning — the user would hear noise with no error surfaced.

## Why This Change Was Made

`base64ToBuffer` now validates input with `canonicalizeBase64` (from `openclaw/plugin-sdk/media-runtime`) before decoding. This function rejects invalid characters, bad padding, and bad length — returning `undefined` for malformed input. When validation fails, the bridge reports the error through `onError` and skips the delta, so one corrupt frame does not terminate a live voice conversation but also never reaches the speaker silently. This follows the same pattern already used in `extensions/openai/image-generation-provider.ts` and `extensions/xiaomi/speech-provider.ts`.

## User Impact

- Normal path: valid base64 audio deltas decode and play exactly as before.
- Error path: a malformed delta now triggers `onError` and is skipped, instead of playing corrupted audio silently.

## Evidence

- `node scripts/run-vitest.mjs extensions/openai/realtime-voice-provider.test.ts` - 72/72 passed
- `pnpm tsgo` - passed
- `pnpm exec oxlint extensions/openai/realtime-voice-provider.ts extensions/openai/realtime-voice-provider.test.ts` - 0 warnings, 0 errors
- `pnpm exec oxfmt --check extensions/openai/realtime-voice-provider.ts extensions/openai/realtime-voice-provider.test.ts` - passed
- `git diff --check` - passed

Related implementation pattern: #106969

Real behavior proof at exact PR head `8ac745def9d`:

**Standalone validator (canonicalizeBase64 before/after):**

```text
$ node --import tsx -e "
import { canonicalizeBase64 } from '@openclaw/media-core/base64';
const malformed = '%%%not-base64!!';
const valid = Buffer.from('assistant audio').toString('base64');
console.log('Before: Buffer.from(malformed, base64) =', JSON.stringify(Buffer.from(malformed, 'base64')), '(garbage, no error)');
console.log('After:  canonicalizeBase64(malformed) =', JSON.stringify(canonicalizeBase64(malformed)), '(rejected)');
console.log('After:  canonicalizeBase64(valid) =', JSON.stringify(canonicalizeBase64(valid)), '(accepted)');
"
Before: Buffer.from(malformed, base64) = {"type":"Buffer","data":[158,139,126,109,171,30,235]} (garbage, no error)
After:  canonicalizeBase64(malformed) = undefined (rejected)
After:  canonicalizeBase64(valid) = "YXNzaXN0YW50IGF1ZGlv" (accepted)
```

**Bridge-level runtime trace (real OpenAI Realtime voice bridge, malformed delta → onError + skip, valid delta → onAudio):**

```text
$ node scripts/run-vitest.mjs extensions/openai/realtime-voice-provider.base64-proof.test.ts --reporter=verbose

stdout | extensions/openai/realtime-voice-provider.base64-proof.test.ts > bridge-level proof: malformed base64 audio delta > reports malformed delta through onError, skips audio, and resumes on valid delta
[bridge] connected — session.updated received
[bridge] receiving malformed delta: %%%not-base64!!
[bridge] onError: OpenAI Realtime voice stream returned malformed base64 audio data
[bridge] receiving valid delta: YXNzaXN0YW50IGF1ZGlv
[bridge] onAudio: emitted 15 bytes (hex: 617373697374616e7420617564696f)

=== Bridge-level proof summary ===
onAudio calls: 1
onError calls: 1
malformed delta reached playback: NO (GOOD)
valid delta reached playback:     YES (GOOD)
PASS: malformed delta reported via onError and skipped; valid delta played

 ✓  extension-provider-openai  extensions/openai/realtime-voice-provider.base64-proof.test.ts > bridge-level proof: malformed base64 audio delta > reports malformed delta through onError, skips audio, and resumes on valid delta 22565ms

 Test Files  1 passed (1)
      Tests  1 passed (1)
```

The bridge-level proof drives the real `OpenAIRealtimeVoiceBridge` (not a mock) through the `response.audio.delta` event path. The malformed delta `%%%not-base64!!` triggers `onError` and is skipped — no audio reaches playback. The subsequent valid delta `YXNzaXN0YW50IGF1ZGlv` decodes to `assistant audio` (15 bytes) and plays normally, proving one corrupt frame does not terminate the session.

AI-assisted: Codex
