### PR TITLE
test(gateway): flush discussion title eviction without runAllTimers

### DIFF
--- a/src/gateway/server-methods/session-discussion.test.ts
+++ b/src/gateway/server-methods/session-discussion.test.ts
@@ -253,7 +253,10 @@ describe("session discussion gateway methods", () => {
     expect(registered.open).toHaveBeenCalledOnce();
     expect(mocks.emitSessionsChanged).not.toHaveBeenCalled();
     releaseGeneration?.(null);
-    await vi.runAllTimersAsync();
+    // Bounded flush: eviction settles via microtasks, so advancing 0ms is
+    // enough. runAllTimersAsync livelocks (10000-timer abort) when any other
+    // suite in a shared shard worker schedules an interval into this fake clock.
+    await vi.advanceTimersByTimeAsync(0);
   });
 
   it("never generates a title for discussion info", async () => {


### PR DESCRIPTION
## What Problem This Solves

`checks-node-compact-large-6` (shard `agentic-gateway-methods`) fails deterministically on every CI run containing 5210e1b4d38 (#114740, landed 2026-07-27 20:46Z): `session-discussion.test.ts > opens the discussion when title generation times out` aborts with `Error: Aborting after running 10000 timers, assuming an infinite loop!`. Four consecutive runs across three unrelated branches (30304532801 ×2 attempts, 30304713337, 30305069826) hit the identical failure, blocking all PR landings.

## Why This Change Was Made

The test ends with `await vi.runAllTimersAsync()`. `runAllTimersAsync` also runs timers scheduled *while it runs*, so a single live `setInterval` in the fake clock loops it to the 10000-timer abort. The shard runs 126 files in shared workers; leaked async work from earlier suites can schedule an interval into this test's fake-timer window (CI Linux worker packing makes this deterministic there; macOS local passes standalone and full-shard). The trailing flush only needs to settle the title singleflight eviction, which is pure microtask (`await request` → `finally { sessionTitleRequests.delete }` in `src/gateway/dashboard-session-title.ts:211-216`) — no timers involved.

## User Impact

CI-only; unblocks all PR merges. No product behavior change.

## Evidence

- Fix: replace `vi.runAllTimersAsync()` with bounded `vi.advanceTimersByTimeAsync(0)` (flushes microtask ticks; cannot livelock), with a comment explaining the shard hazard.
- `node scripts/run-vitest.mjs src/gateway/server-methods/session-discussion.test.ts`: 15/15 pass.
- Full local shard run of `src/gateway/server-methods` on main: 126 files / 2512 tests pass (macOS; the abort only reproduces under CI Linux worker packing, which this fix makes impossible by construction).
