### PR TITLE
fix: CJK tool results stay within context budgets

### DIFF
--- a/qa/scenarios/runtime/cjk-tool-result-budget.yaml
+++ b/qa/scenarios/runtime/cjk-tool-result-budget.yaml
@@ -69,7 +69,7 @@ flow:
             - ref: state
             - lambda:
                 params: [candidate]
-                expr: "candidate.conversation.id === 'qa-operator' && candidate.text.includes(config.expectedReply)"
+                expr: "candidate.conversation.id === 'qa-operator' && candidate.text.trim() === config.expectedReply"
             - expr: liveTurnTimeoutMs(env, 30000)
         - set: scenarioRequests
           value:
@@ -95,7 +95,7 @@ flow:
             message:
               expr: "`expected provider-bound CJK output below ${config.maxProviderOutputChars} raw chars, saw ${providerToolOutput.length}`"
         - assert:
-            expr: "outbound.text.includes(config.expectedReply)"
+            expr: "outbound.text.trim() === config.expectedReply"
             message:
               expr: "`agent did not finish after bounded CJK result: ${outbound.text}`"
       detailsExpr: "`status=pass sourceChars=${config.fixtureChars} providerChars=${providerToolOutput.length} truncated=${providerToolOutput.includes('truncated')} final=${outbound.text.trim()}`"

--- a/qa/scenarios/runtime/cjk-tool-result-budget.yaml
+++ b/qa/scenarios/runtime/cjk-tool-result-budget.yaml
@@ -1,0 +1,101 @@
+title: CJK-aware tool-result budget
+
+scenario:
+  id: cjk-tool-result-budget
+  surface: runtime
+  coverage:
+    primary:
+      - session-memory.compaction
+  objective: Verify a dense CJK tool result is truncated by token-budget weight before the real Gateway agent loop sends it back to the model.
+  successCriteria:
+    - Scenario is mock-openai only so the provider-bound request is deterministic and inspectable.
+    - The model requests a normal read of a 16000-character CJK workspace file.
+    - The provider-bound tool output contains the standard truncation notice and is below 9000 raw characters for the 128K mock model context.
+    - The agent receives that bounded result and returns the exact final marker.
+  docsRefs:
+    - docs/help/testing.md
+    - docs/reference/session-management-compaction.md
+  codeRefs:
+    - src/agents/embedded-agent-runner/tool-result-text-budget.ts
+    - src/agents/embedded-agent-runner/tool-result-truncation.ts
+    - src/agents/embedded-agent-runner/run/attempt-prompt-context.ts
+  execution:
+    kind: flow
+    summary: Read dense CJK through the real agent loop and inspect the provider-bound truncated tool result.
+    config:
+      requiredProviderMode: mock-openai
+      promptSnippet: CJK tool progress QA check
+      fixtureFile: CJK_TOOL_RESULT.txt
+      fixtureChars: 16000
+      maxProviderOutputChars: 9000
+      expectedReply: CJK-TOOL-RESULT-OK
+      prompt: "CJK tool progress QA check: read `CJK_TOOL_RESULT.txt`, then reply exactly `CJK-TOOL-RESULT-OK`."
+
+flow:
+  steps:
+    - name: bounds dense CJK before the next model request
+      actions:
+        - assert:
+            expr: "env.providerMode === config.requiredProviderMode"
+            message: this seeded scenario is mock-openai only
+        - call: waitForGatewayHealthy
+          args:
+            - ref: env
+            - 60000
+        - call: reset
+        - call: fs.writeFile
+          args:
+            - expr: "path.join(env.gateway.workspaceDir, config.fixtureFile)"
+            - expr: "'你'.repeat(config.fixtureChars)"
+            - utf8
+        - set: requestCursorBefore
+          value:
+            expr: "(await fetchJson(`${env.mock.baseUrl}/debug/request-cursor`)).cursor"
+        - set: sessionKey
+          value:
+            expr: "`agent:qa:cjk-tool-result:${randomUUID().slice(0, 8)}`"
+        - call: runAgentPrompt
+          args:
+            - ref: env
+            - sessionKey:
+                ref: sessionKey
+              message:
+                expr: config.prompt
+              timeoutMs:
+                expr: liveTurnTimeoutMs(env, 60000)
+        - call: waitForOutboundMessage
+          saveAs: outbound
+          args:
+            - ref: state
+            - lambda:
+                params: [candidate]
+                expr: "candidate.conversation.id === 'qa-operator' && candidate.text.includes(config.expectedReply)"
+            - expr: liveTurnTimeoutMs(env, 30000)
+        - set: scenarioRequests
+          value:
+            expr: "(await fetchJson(`${env.mock.baseUrl}/debug/requests?after=${requestCursorBefore}`)).filter((request) => String(request.allInputText ?? '').includes(config.promptSnippet))"
+        - set: readRequest
+          value:
+            expr: "scenarioRequests.find((request) => request.plannedToolName === 'read')"
+        - set: resultRequest
+          value:
+            expr: "scenarioRequests.find((request) => String(request.toolOutput ?? '').includes('truncated'))"
+        - set: providerToolOutput
+          value:
+            expr: "String(resultRequest?.toolOutput ?? '')"
+        - assert:
+            expr: "readRequest?.plannedToolArgs?.path === config.fixtureFile"
+            message:
+              expr: "`expected read(${config.fixtureFile}), saw ${JSON.stringify(readRequest?.plannedToolArgs ?? null)}`"
+        - assert:
+            expr: "providerToolOutput.includes('truncated')"
+            message: provider-bound CJK tool result was not truncated
+        - assert:
+            expr: "providerToolOutput.length > 0 && providerToolOutput.length < config.maxProviderOutputChars"
+            message:
+              expr: "`expected provider-bound CJK output below ${config.maxProviderOutputChars} raw chars, saw ${providerToolOutput.length}`"
+        - assert:
+            expr: "outbound.text.includes(config.expectedReply)"
+            message:
+              expr: "`agent did not finish after bounded CJK result: ${outbound.text}`"
+      detailsExpr: "`status=pass sourceChars=${config.fixtureChars} providerChars=${providerToolOutput.length} truncated=${providerToolOutput.includes('truncated')} final=${outbound.text.trim()}`"

--- a/src/agents/embedded-agent-runner/tool-result-char-estimator.test.ts
+++ b/src/agents/embedded-agent-runner/tool-result-char-estimator.test.ts
@@ -68,6 +68,18 @@ describe("tool-result-char-estimator", () => {
     expect(chars).toBe(22);
   });
 
+  it("uses CJK weighting without multiplying the existing ASCII safety floor", () => {
+    const msg = {
+      role: "toolResult",
+      toolName: "read",
+      content: [{ type: "text", text: "你好" }],
+      timestamp: Date.now(),
+    } as unknown as AgentMessage;
+
+    const cache = createMessageCharEstimateCache();
+    expect(estimateMessageCharsCached(msg, cache)).toBe(8);
+  });
+
   it("estimates a large bashExecution near its rendered size", () => {
     const bigOutput = "build log line\n".repeat(60000);
     const msg = {

--- a/src/agents/embedded-agent-runner/tool-result-char-estimator.ts
+++ b/src/agents/embedded-agent-runner/tool-result-char-estimator.ts
@@ -1,4 +1,3 @@
-import { CHARS_PER_TOKEN_ESTIMATE } from "../../utils/cjk-chars.js";
 /**
  * Estimates message and tool-result character costs for context guards.
  */
@@ -10,6 +9,7 @@ import {
   COMPACTION_SUMMARY_SUFFIX,
   bashExecutionToText,
 } from "../runtime/index.js";
+import { estimateToolResultTextChars } from "./tool-result-text-budget.js";
 
 export const TOOL_RESULT_CHARS_PER_TOKEN_ESTIMATE = 2;
 const IMAGE_CHAR_ESTIMATE = 8_000;
@@ -77,6 +77,22 @@ function estimateContentBlockChars(content: unknown[]): number {
   return chars;
 }
 
+function estimateToolResultContentChars(content: unknown[]): number {
+  let chars = 0;
+  for (const block of content) {
+    if (isTextBlock(block)) {
+      chars += estimateToolResultTextChars(block.text, {
+        minimumRawWeight: TOOL_RESULT_CHARS_PER_TOKEN_ESTIMATE,
+      });
+    } else if (isImageBlock(block)) {
+      chars += IMAGE_CHAR_ESTIMATE * TOOL_RESULT_CHARS_PER_TOKEN_ESTIMATE;
+    } else {
+      chars += estimateUnknownChars(block) * TOOL_RESULT_CHARS_PER_TOKEN_ESTIMATE;
+    }
+  }
+  return chars;
+}
+
 export function getToolResultText(msg: AgentMessage): string {
   const content = getToolResultContent(msg);
   const chunks: string[] = [];
@@ -139,11 +155,7 @@ function estimateMessageChars(msg: AgentMessage): number {
   if (isToolResultMessage(msg)) {
     // `details` is stripped before provider conversion; estimate only visible content.
     const content = getToolResultContent(msg);
-    const chars = estimateContentBlockChars(content);
-    const weightedChars = Math.ceil(
-      chars * (CHARS_PER_TOKEN_ESTIMATE / TOOL_RESULT_CHARS_PER_TOKEN_ESTIMATE),
-    );
-    return Math.max(chars, weightedChars);
+    return estimateToolResultContentChars(content);
   }
 
   const record = msg as unknown as Record<string, unknown>;

--- a/src/agents/embedded-agent-runner/tool-result-context-guard.test.ts
+++ b/src/agents/embedded-agent-runner/tool-result-context-guard.test.ts
@@ -14,6 +14,7 @@ import {
   installToolResultContextGuard,
   markTranscriptPromptText,
 } from "./tool-result-context-guard.js";
+import { estimateToolResultTextChars } from "./tool-result-text-budget.js";
 
 const CONTEXT_LIMIT_TRUNCATION_NOTICE = "more characters truncated";
 
@@ -225,6 +226,24 @@ describe("installToolResultContextGuard", () => {
         expectDefined(contextForNextCall[0], "contextForNextCall[0] test invariant"),
       ),
     ).toBe("z".repeat(5_000));
+  });
+
+  it("truncates dense CJK output that the ASCII safety floor would undercount", async () => {
+    const agent = makeGuardableAgent();
+    const cjk = "你".repeat(300);
+    const contextForNextCall = [makeToolResult("call_cjk", cjk)];
+
+    const transformed = (await applyGuardToContext(agent, contextForNextCall)) as AgentMessage[];
+    const transformedText = getToolResultText(
+      expectDefined(transformed[0], "transformed[0] test invariant"),
+    );
+
+    expect(transformedText.length).toBeLessThan(cjk.length);
+    expect(
+      estimateToolResultTextChars(transformedText, { minimumRawWeight: 2 }),
+    ).toBeLessThanOrEqual(1_024);
+    expectOpenClawTruncation(transformedText);
+    expect(getToolResultText(contextForNextCall[0]!)).toBe(cjk);
   });
 
   it("wraps an existing transformContext and guards the transformed output", async () => {

--- a/src/agents/embedded-agent-runner/tool-result-context-guard.ts
+++ b/src/agents/embedded-agent-runner/tool-result-context-guard.ts
@@ -22,9 +22,12 @@ import {
   invalidateMessageCharsCacheEntry,
   isToolResultMessage,
 } from "./tool-result-char-estimator.js";
+import {
+  estimateToolResultTextChars,
+  sliceToolResultTextToBudget,
+} from "./tool-result-text-budget.js";
 
 const SINGLE_TOOL_RESULT_CONTEXT_SHARE = 0.5;
-const TOOL_RESULT_ESTIMATE_TO_TEXT_RATIO = 4 / TOOL_RESULT_CHARS_PER_TOKEN_ESTIMATE;
 const TRANSCRIPT_PROMPT_TEXT_KEY = "__openclawTranscriptPromptText";
 
 type GuardableTransformContext = (
@@ -133,7 +136,8 @@ function stripTranscriptPromptMarkers(messages: AgentMessage[]): AgentMessage[] 
 }
 
 function truncateTextToBudget(text: string, maxChars: number): string {
-  if (text.length <= maxChars) {
+  const budgetOptions = { minimumRawWeight: TOOL_RESULT_CHARS_PER_TOKEN_ESTIMATE };
+  if (estimateToolResultTextChars(text, budgetOptions) <= maxChars) {
     return text;
   }
 
@@ -141,21 +145,33 @@ function truncateTextToBudget(text: string, maxChars: number): string {
     return formatContextLimitTruncationNotice(text.length);
   }
 
-  let bodyBudget = maxChars;
+  let prefix = sliceToolResultTextToBudget(text, maxChars, budgetOptions);
   for (let i = 0; i < 4; i += 1) {
-    const estimatedSuffix = formatContextLimitTruncationNotice(
-      Math.max(1, text.length - bodyBudget),
+    const suffix = formatContextLimitTruncationNotice(Math.max(1, text.length - prefix.length));
+    prefix = sliceToolResultTextToBudget(
+      text,
+      Math.max(0, maxChars - estimateToolResultTextChars(suffix, budgetOptions)),
+      budgetOptions,
     );
-    bodyBudget = Math.max(0, maxChars - estimatedSuffix.length);
   }
 
-  let cutPoint = bodyBudget;
-  const newline = text.lastIndexOf("\n", cutPoint);
-  if (newline > bodyBudget * 0.7) {
-    cutPoint = newline;
+  const newline = prefix.lastIndexOf("\n");
+  if (newline > prefix.length * 0.7) {
+    prefix = truncateUtf16Safe(prefix, newline);
   }
 
-  const prefix = truncateUtf16Safe(text, cutPoint);
+  for (let i = 0; i < 4; i += 1) {
+    const suffix = formatContextLimitTruncationNotice(text.length - prefix.length);
+    const nextPrefix = sliceToolResultTextToBudget(
+      prefix,
+      Math.max(0, maxChars - estimateToolResultTextChars(suffix, budgetOptions)),
+      budgetOptions,
+    );
+    if (nextPrefix.length === prefix.length) {
+      return prefix + suffix;
+    }
+    prefix = nextPrefix;
+  }
   return prefix + formatContextLimitTruncationNotice(text.length - prefix.length);
 }
 
@@ -172,8 +188,8 @@ function replaceToolResultText(msg: AgentMessage, text: string): AgentMessage {
   } as AgentMessage;
 }
 
-function estimateBudgetToTextBudget(maxChars: number): number {
-  return Math.max(0, Math.floor(maxChars / TOOL_RESULT_ESTIMATE_TO_TEXT_RATIO));
+function estimateBudgetToRawChars(maxChars: number): number {
+  return Math.max(0, Math.floor(maxChars / TOOL_RESULT_CHARS_PER_TOKEN_ESTIMATE));
 }
 
 function truncateToolResultToChars(
@@ -194,21 +210,16 @@ function truncateToolResultToChars(
   if (!rawText) {
     const omittedChars = Math.max(
       1,
-      estimateBudgetToTextBudget(Math.max(estimatedChars - maxChars, 1)),
+      estimateBudgetToRawChars(Math.max(estimatedChars - maxChars, 1)),
     );
     return replaceToolResultText(msg, formatContextLimitTruncationNotice(omittedChars));
   }
 
-  const textBudget = estimateBudgetToTextBudget(maxChars);
-  if (textBudget <= 0) {
+  if (maxChars <= 0) {
     return replaceToolResultText(msg, formatContextLimitTruncationNotice(rawText.length));
   }
 
-  if (rawText.length <= textBudget) {
-    return replaceToolResultText(msg, rawText);
-  }
-
-  const truncatedText = truncateTextToBudget(rawText, textBudget);
+  const truncatedText = truncateTextToBudget(rawText, maxChars);
   return replaceToolResultText(msg, truncatedText);
 }
 

--- a/src/agents/embedded-agent-runner/tool-result-text-budget.test.ts
+++ b/src/agents/embedded-agent-runner/tool-result-text-budget.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import {
+  estimateToolResultTextChars,
+  sliceToolResultTextTailToBudget,
+  sliceToolResultTextToBudget,
+} from "./tool-result-text-budget.js";
+
+describe("tool-result text budgets", () => {
+  it("preserves ASCII accounting while weighting dense CJK", () => {
+    expect(estimateToolResultTextChars("hello")).toBe(5);
+    expect(estimateToolResultTextChars("你好")).toBe(8);
+  });
+
+  it("combines the context guard's ASCII floor with CJK weighting", () => {
+    const options = { minimumRawWeight: 2 };
+    expect(estimateToolResultTextChars("hello", options)).toBe(10);
+    expect(estimateToolResultTextChars("你好", options)).toBe(8);
+    expect(estimateToolResultTextChars("ab你好", options)).toBe(12);
+  });
+
+  it("finds prefix and tail cuts on complete UTF-16 boundaries", () => {
+    const text = "A😀你好B";
+    expect(sliceToolResultTextToBudget(text, 7)).toBe("A😀你");
+    expect(sliceToolResultTextTailToBudget(text, 7)).toBe("好B");
+    expect(sliceToolResultTextToBudget("😀", 1)).toBe("");
+    expect(sliceToolResultTextTailToBudget("😀", 1)).toBe("");
+  });
+
+  it("honors the larger of CJK cost and a caller safety floor", () => {
+    const options = { minimumRawWeight: 2 };
+    expect(sliceToolResultTextToBudget("ab你好", 9, options)).toBe("ab你");
+    expect(sliceToolResultTextTailToBudget("你好ab", 9, options)).toBe("好ab");
+  });
+});

--- a/src/agents/embedded-agent-runner/tool-result-text-budget.ts
+++ b/src/agents/embedded-agent-runner/tool-result-text-budget.ts
@@ -5,7 +5,7 @@ type ToolResultTextBudgetOptions = {
   minimumRawWeight?: number;
 };
 
-const ASCII_RUN_OR_NON_ASCII_CODE_POINT_RE = /[\u0000-\u007f]+|[^\u0000-\u007f]/gu;
+const ASCII_RUN_OR_NON_ASCII_CODE_POINT_RE = /[\p{ASCII}]+|[^\p{ASCII}]/gu;
 
 /**
  * Returns provider-independent character-budget units for tool-result text.

--- a/src/agents/embedded-agent-runner/tool-result-text-budget.ts
+++ b/src/agents/embedded-agent-runner/tool-result-text-budget.ts
@@ -1,0 +1,89 @@
+import { sliceUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
+import { estimateStringChars } from "../../utils/cjk-chars.js";
+
+type ToolResultTextBudgetOptions = {
+  minimumRawWeight?: number;
+};
+
+const ASCII_RUN_OR_NON_ASCII_CODE_POINT_RE = /[\u0000-\u007f]+|[^\u0000-\u007f]/gu;
+
+/**
+ * Returns provider-independent character-budget units for tool-result text.
+ * CJK weights match the shared token heuristic; callers may retain a larger
+ * existing raw-text safety floor without multiplying the CJK adjustment twice.
+ */
+export function estimateToolResultTextChars(
+  text: string,
+  options: ToolResultTextBudgetOptions = {},
+): number {
+  const minimumRawWeight = Math.max(1, options.minimumRawWeight ?? 1);
+  if (minimumRawWeight === 1) {
+    return estimateStringChars(text);
+  }
+  let chars = 0;
+  for (const match of text.matchAll(ASCII_RUN_OR_NON_ASCII_CODE_POINT_RE)) {
+    const segment = match[0];
+    const minimumChars = Math.ceil(segment.length * minimumRawWeight);
+    chars +=
+      segment.charCodeAt(0) <= 0x7f
+        ? minimumChars
+        : Math.max(estimateStringChars(segment), minimumChars);
+  }
+  return chars;
+}
+
+export function sliceToolResultTextToBudget(
+  text: string,
+  maxChars: number,
+  options: ToolResultTextBudgetOptions = {},
+): string {
+  const budget = Math.max(0, Math.floor(maxChars));
+  if (estimateToolResultTextChars(text, options) <= budget) {
+    return text;
+  }
+
+  let best = "";
+  let low = 0;
+  let high = text.length;
+  while (low <= high) {
+    const midpoint = Math.floor((low + high) / 2);
+    const candidate = sliceUtf16Safe(text, 0, midpoint);
+    if (estimateToolResultTextChars(candidate, options) <= budget) {
+      if (candidate.length > best.length) {
+        best = candidate;
+      }
+      low = midpoint + 1;
+    } else {
+      high = midpoint - 1;
+    }
+  }
+  return best;
+}
+
+export function sliceToolResultTextTailToBudget(
+  text: string,
+  maxChars: number,
+  options: ToolResultTextBudgetOptions = {},
+): string {
+  const budget = Math.max(0, Math.floor(maxChars));
+  if (estimateToolResultTextChars(text, options) <= budget) {
+    return text;
+  }
+
+  let best = "";
+  let low = 0;
+  let high = text.length;
+  while (low <= high) {
+    const midpoint = Math.floor((low + high) / 2);
+    const candidate = sliceUtf16Safe(text, midpoint);
+    if (estimateToolResultTextChars(candidate, options) <= budget) {
+      if (candidate.length > best.length) {
+        best = candidate;
+      }
+      high = midpoint - 1;
+    } else {
+      low = midpoint + 1;
+    }
+  }
+  return best;
+}

--- a/src/agents/embedded-agent-runner/tool-result-truncation.test.ts
+++ b/src/agents/embedded-agent-runner/tool-result-truncation.test.ts
@@ -18,6 +18,7 @@ import {
 import { formatSqliteSessionFileMarker } from "../../config/sessions/sqlite-marker.js";
 import type { SessionEntry as SessionStoreEntry } from "../../config/sessions/types.js";
 import { onInternalSessionTranscriptUpdate } from "../../sessions/transcript-events.js";
+import { estimateStringChars } from "../../utils/cjk-chars.js";
 import { formatFullOutputFooter } from "../sessions/tools/tool-contracts.js";
 import { makeAgentAssistantMessage } from "../test-helpers/agent-message-fixtures.js";
 import {
@@ -274,6 +275,15 @@ describe("truncateToolResultText", () => {
     ).toBe("");
   });
 
+  it("reports the full omission count when only a suffix fits", () => {
+    expect(
+      truncateToolResultText("x".repeat(100), 4, {
+        suffix: (truncatedChars) => `[${truncatedChars}]`,
+        minKeepChars: 1,
+      }),
+    ).toBe("[100");
+  });
+
   it("keeps both head and tail cuts on complete code points", () => {
     const marker = "\n\n⚠️ [... middle content omitted — showing head and tail ...]\n\n";
     const text = `${"a".repeat(6)}😀${"m".repeat(100)}😀${"x".repeat(22)} Error`;
@@ -383,6 +393,94 @@ describe("truncateToolResultMessage", () => {
     expect(String(firstBlock.text).length).toBeLessThan(oversized.length);
     expect(firstBlock.content).toBe(firstBlock.text);
   });
+
+  it("truncates dense CJK by weighted budget while leaving same-size ASCII unchanged", () => {
+    const maxChars = 16_000;
+    const asciiMessage = makeToolResult("a".repeat(maxChars));
+    expect(truncateToolResultMessage(asciiMessage, maxChars)).toBe(asciiMessage);
+
+    const cjk = "你".repeat(maxChars);
+    const cjkMessage = makeToolResult(cjk);
+    const result = truncateToolResultMessage(cjkMessage, maxChars);
+    const resultText = getFirstToolResultText(result);
+
+    expect(result).not.toBe(cjkMessage);
+    expect(resultText.length).toBeLessThan(cjk.length);
+    expect(estimateStringChars(resultText)).toBeLessThanOrEqual(maxChars);
+    expect(resultText).toContain("truncated");
+  });
+
+  it("shares weighted budget across mixed ASCII and CJK blocks", () => {
+    const msg = {
+      ...makeToolResult("unused"),
+      content: [
+        { type: "text", text: "你".repeat(1_000) },
+        { type: "text", text: "a".repeat(4_000) },
+      ],
+    } as ToolResultMessage;
+
+    const result = truncateToolResultMessage(msg, 4_000);
+    expect(result.role).toBe("toolResult");
+    if (result.role !== "toolResult") {
+      throw new Error("expected toolResult");
+    }
+    const estimated = result.content.reduce(
+      (sum, block) => sum + (block.type === "text" ? estimateStringChars(block.text) : 0),
+      0,
+    );
+    expect(estimated).toBeLessThanOrEqual(4_000);
+    expect(result.content).toHaveLength(2);
+  });
+
+  it("reserves omission notices before preserving multiple small blocks", () => {
+    const msg = {
+      ...makeToolResult("unused"),
+      content: [
+        { type: "text", text: "a".repeat(50) },
+        { type: "text", text: "b".repeat(50) },
+        { type: "text", text: "c".repeat(500) },
+      ],
+    } as ToolResultMessage;
+
+    const result = truncateToolResultMessage(msg, 100, {
+      suffix: "!",
+      minKeepChars: 99,
+    });
+    expect(result.role).toBe("toolResult");
+    if (result.role !== "toolResult") {
+      throw new Error("expected toolResult");
+    }
+    const texts = result.content.map((block) => (block.type === "text" ? block.text : ""));
+    expect(texts[2]).toContain("!");
+    expect(texts.every((text) => text.length > 0)).toBe(true);
+    expect(texts.reduce((sum, text) => sum + estimateStringChars(text), 0)).toBeLessThanOrEqual(
+      100,
+    );
+  });
+
+  it("does not let empty text blocks consume omission-notice budget", () => {
+    const msg = {
+      ...makeToolResult("unused"),
+      content: [
+        ...Array.from({ length: 150 }, () => ({ type: "text" as const, text: "" })),
+        { type: "text" as const, text: "x".repeat(500) },
+      ],
+    } as ToolResultMessage;
+
+    const result = truncateToolResultMessage(msg, 100, {
+      suffix: "!",
+      minKeepChars: 0,
+    });
+    expect(result.role).toBe("toolResult");
+    if (result.role !== "toolResult") {
+      throw new Error("expected toolResult");
+    }
+    expect(
+      result.content.slice(0, -1).every((block) => block.type !== "text" || block.text === ""),
+    ).toBe(true);
+    const lastBlock = result.content.at(-1);
+    expect(lastBlock?.type === "text" ? lastBlock.text : "").toMatch(/!$/u);
+  });
 });
 
 describe("calculateMaxToolResultChars", () => {
@@ -435,6 +533,13 @@ describe("calculateMaxToolResultChars", () => {
 });
 
 describe("sessionLikelyHasOversizedToolResults", () => {
+  it("detects dense CJK that fits the raw character cap", () => {
+    const messages: AgentMessage[] = [makeToolResult("你".repeat(5_000))];
+    expect(sessionLikelyHasOversizedToolResults({ messages, contextWindowTokens: 50_000 })).toBe(
+      true,
+    );
+  });
+
   it("returns true for individually oversized tool results", () => {
     const messages: AgentMessage[] = [makeToolResult("x".repeat(500_000))];
     expect(sessionLikelyHasOversizedToolResults({ messages, contextWindowTokens: 128_000 })).toBe(
@@ -600,6 +705,23 @@ describe("truncateOversizedToolResultsInMessages", () => {
       const text = getFirstToolResultText(msg);
       expect(text.length).toBeLessThan(500_000);
     }
+  });
+
+  it("applies the aggregate cap to CJK-weighted prompt history", () => {
+    const messages = Array.from({ length: 6 }, (_, index) =>
+      makeToolResult("你".repeat(3_000), `call_${index}`),
+    );
+
+    const result = truncateOversizedToolResultsInMessages(messages, 20_000);
+    const estimated = result.messages.reduce(
+      (sum, message) =>
+        sum +
+        (message.role === "toolResult" ? estimateStringChars(getFirstToolResultText(message)) : 0),
+      0,
+    );
+
+    expect(result.aggregateTruncatedCount).toBeGreaterThan(0);
+    expect(estimated).toBeLessThanOrEqual(result.aggregateBudgetChars);
   });
 
   it("bounds aggregate tool-result text in prompt history without rewriting callers", () => {

--- a/src/agents/embedded-agent-runner/tool-result-truncation.ts
+++ b/src/agents/embedded-agent-runner/tool-result-truncation.ts
@@ -4,7 +4,7 @@
 import { createHash } from "node:crypto";
 import { existsSync } from "node:fs";
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
-import { sliceUtf16Safe, truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
+import { sliceUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import { loadTranscriptEvents } from "../../config/sessions/session-accessor.js";
 import { parseSqliteSessionFileMarker } from "../../config/sessions/sqlite-marker.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
@@ -28,6 +28,11 @@ import {
 import { formatContextLimitTruncationNotice } from "./context-truncation-notice.js";
 import { log } from "./logger.js";
 import type { ToolResultPromptProjectionState } from "./session-prompt-state.js";
+import {
+  estimateToolResultTextChars,
+  sliceToolResultTextTailToBudget,
+  sliceToolResultTextToBudget,
+} from "./tool-result-text-budget.js";
 import {
   createTranscriptFileStateFromPersistedEntries,
   persistTranscriptStateMutation,
@@ -142,7 +147,7 @@ function resolveEffectiveMinKeepChars(params: {
   minKeepChars: number;
   suffixFactory: (truncatedChars: number) => string;
 }): number {
-  const suffixFloor = params.suffixFactory(1).length;
+  const suffixFloor = estimateToolResultTextChars(params.suffixFactory(1));
   return Math.max(0, Math.min(params.minKeepChars, Math.max(0, params.maxChars - suffixFloor)));
 }
 
@@ -152,22 +157,26 @@ function appendBoundedTruncationSuffix(params: {
   maxChars: number;
   suffixFactory: (truncatedChars: number) => string;
 }): string {
-  const build = (keptText: string) =>
-    keptText + params.suffixFactory(Math.max(1, params.originalTextLength - keptText.length));
-
   let keptText = params.keptText;
   while (true) {
-    const finalText = build(keptText);
-    if (finalText.length <= params.maxChars) {
+    const suffix = params.suffixFactory(Math.max(1, params.originalTextLength - keptText.length));
+    const suffixChars = estimateToolResultTextChars(suffix);
+    if (suffixChars >= params.maxChars) {
+      const fullOmissionSuffix = params.suffixFactory(Math.max(1, params.originalTextLength));
+      return sliceToolResultTextToBudget(fullOmissionSuffix, params.maxChars);
+    }
+    const nextKeptText = sliceToolResultTextToBudget(keptText, params.maxChars - suffixChars);
+    const finalText = nextKeptText + suffix;
+    if (
+      nextKeptText.length === keptText.length &&
+      estimateToolResultTextChars(finalText) <= params.maxChars
+    ) {
       return finalText;
     }
-    if (keptText.length === 0) {
-      return truncateUtf16Safe(finalText, params.maxChars);
+    if (nextKeptText.length === 0 && keptText.length === 0) {
+      return sliceToolResultTextToBudget(finalText, params.maxChars);
     }
-    const overflow = finalText.length - params.maxChars;
-    const nextKeptText = sliceUtf16Safe(keptText, 0, Math.max(0, keptText.length - overflow));
-    keptText =
-      nextKeptText.length < keptText.length ? nextKeptText : sliceUtf16Safe(keptText, 0, -1);
+    keptText = nextKeptText;
   }
 }
 
@@ -212,49 +221,49 @@ function truncateToolResultText(
     minKeepChars: options.minKeepChars ?? MIN_KEEP_CHARS,
     suffixFactory,
   });
-  if (text.length <= maxChars) {
+  if (estimateToolResultTextChars(text) <= maxChars) {
     return text;
   }
-  const defaultSuffix = suffixFactory(Math.max(1, text.length - maxChars));
-  const budget = Math.max(minKeepChars, maxChars - defaultSuffix.length);
+  const initialKeptText = sliceToolResultTextToBudget(text, maxChars);
+  const defaultSuffix = suffixFactory(Math.max(1, text.length - initialKeptText.length));
+  const budget = Math.max(minKeepChars, maxChars - estimateToolResultTextChars(defaultSuffix));
 
   // If tail looks important, split budget between head and tail
   if (hasImportantTail(text) && budget > minKeepChars * 2) {
     const tailBudget = Math.min(Math.floor(budget * 0.3), 4_000);
-    const headBudget = budget - tailBudget - MIDDLE_OMISSION_MARKER.length;
+    const headBudget = budget - tailBudget - estimateToolResultTextChars(MIDDLE_OMISSION_MARKER);
 
     if (headBudget > minKeepChars) {
       // Find clean cut points at newline boundaries
-      let headCut = headBudget;
-      const headNewline = text.lastIndexOf("\n", headBudget);
-      if (headNewline > headBudget * 0.8) {
-        headCut = headNewline;
+      let headText = sliceToolResultTextToBudget(text, headBudget);
+      const headNewline = headText.lastIndexOf("\n");
+      if (headNewline > headText.length * 0.8) {
+        headText = sliceUtf16Safe(headText, 0, headNewline);
       }
 
-      let tailStart = text.length - tailBudget;
-      const tailNewline = text.indexOf("\n", tailStart);
-      if (tailNewline !== -1 && tailNewline < tailStart + tailBudget * 0.2) {
-        tailStart = tailNewline + 1;
+      let tailText = sliceToolResultTextTailToBudget(text, tailBudget);
+      const tailNewline = tailText.indexOf("\n");
+      if (tailNewline !== -1 && tailNewline < tailText.length * 0.2) {
+        tailText = sliceUtf16Safe(tailText, tailNewline + 1);
       }
 
-      const keptText =
-        sliceUtf16Safe(text, 0, headCut) + MIDDLE_OMISSION_MARKER + sliceUtf16Safe(text, tailStart);
-      return appendBoundedTruncationSuffix({
-        keptText,
-        originalTextLength: text.length,
-        maxChars,
-        suffixFactory,
-      });
+      if (headText.length + tailText.length < text.length) {
+        return appendBoundedTruncationSuffix({
+          keptText: headText + MIDDLE_OMISSION_MARKER + tailText,
+          originalTextLength: text.length,
+          maxChars,
+          suffixFactory,
+        });
+      }
     }
   }
 
   // Default: keep the beginning
-  let cutPoint = budget;
-  const lastNewline = text.lastIndexOf("\n", budget);
-  if (lastNewline > budget * 0.8) {
-    cutPoint = lastNewline;
+  let keptText = sliceToolResultTextToBudget(text, budget);
+  const lastNewline = keptText.lastIndexOf("\n");
+  if (lastNewline > keptText.length * 0.8) {
+    keptText = sliceUtf16Safe(keptText, 0, lastNewline);
   }
-  const keptText = sliceUtf16Safe(text, 0, cutPoint);
   return appendBoundedTruncationSuffix({
     keptText,
     originalTextLength: text.length,
@@ -306,9 +315,9 @@ export function resolveLiveToolResultAggregateMaxChars(params: {
 }
 
 /**
- * Get the total character count of text content blocks in a tool result message.
+ * Get the total token-budget character estimate for text blocks in a tool result message.
  */
-function getToolResultTextLength(msg: AgentMessage): number {
+function getToolResultTextBudget(msg: AgentMessage): number {
   if (!msg || (msg as { role?: string }).role !== "toolResult") {
     return 0;
   }
@@ -321,7 +330,7 @@ function getToolResultTextLength(msg: AgentMessage): number {
     if (isToolResultTextBlock(block)) {
       const text = block.text;
       if (typeof text === "string") {
-        totalLength += text.length;
+        totalLength += estimateToolResultTextChars(text);
       }
     }
   }
@@ -349,33 +358,64 @@ export function truncateToolResultMessage(
   }
 
   // Calculate total text size
-  const totalTextChars = getToolResultTextLength(msg);
+  const totalTextChars = getToolResultTextBudget(msg);
   if (totalTextChars <= maxChars) {
     return msg;
   }
 
-  // Distribute the budget proportionally among text blocks
-  const newContent = content.map((block: unknown) => {
+  const blockTextChars = content.map((block) =>
+    isToolResultTextBlock(block) ? estimateToolResultTextChars(block.text) : 0,
+  );
+  const blockNoticeChars = content.map((block, index) =>
+    (blockTextChars[index] ?? 0) > 0 && isToolResultTextBlock(block)
+      ? estimateToolResultTextChars(suffixFactory(Math.max(1, block.text.length)))
+      : 0,
+  );
+  const smallBlockChars = blockTextChars.reduce(
+    (sum, chars) => sum + (chars > 0 && chars <= minKeepChars ? chars : 0),
+    0,
+  );
+  const largeBlockNoticeChars = blockTextChars.reduce(
+    (sum, chars, index) => sum + (chars > minKeepChars ? (blockNoticeChars[index] ?? 0) : 0),
+    0,
+  );
+  // Preserve short semantic blocks (for example image-disabled notices) when
+  // larger blocks can still retain a complete truncation notice inside the cap.
+  const preserveSmallBlocks = smallBlockChars + largeBlockNoticeChars <= maxChars;
+  const preservedChars = preserveSmallBlocks ? smallBlockChars : 0;
+  const remainingBudget = Math.max(0, maxChars - preservedChars);
+  const reducibleChars = blockTextChars.reduce(
+    (sum, chars) => sum + (preserveSmallBlocks && chars > 0 && chars <= minKeepChars ? 0 : chars),
+    0,
+  );
+  const reducibleNoticeChars = blockTextChars.reduce(
+    (sum, chars, index) =>
+      sum +
+      (preserveSmallBlocks && chars > 0 && chars <= minKeepChars
+        ? 0
+        : (blockNoticeChars[index] ?? 0)),
+    0,
+  );
+  const noticeScale =
+    reducibleNoticeChars > 0 ? Math.min(1, remainingBudget / reducibleNoticeChars) : 0;
+  const distributableBudget = Math.max(0, remainingBudget - reducibleNoticeChars);
+
+  const newContent = content.map((block: unknown, index) => {
     if (!isToolResultTextBlock(block)) {
       return block; // Keep non-text blocks (images) as-is
     }
     const textBlock = block;
-    if (typeof textBlock.text !== "string") {
-      return block;
-    }
-    // Proportional budget for this block
-    const blockShare = textBlock.text.length / totalTextChars;
-    const defaultSuffix = suffixFactory(
-      Math.max(1, textBlock.text.length - Math.floor(maxChars * blockShare)),
-    );
-    const proportionalBudget = Math.floor(maxChars * blockShare);
-    const blockBudget = Math.max(
-      1,
-      Math.min(maxChars, Math.max(minKeepChars + defaultSuffix.length, proportionalBudget)),
-    );
+    const textChars = blockTextChars[index] ?? 0;
+    const preserveBlock = preserveSmallBlocks && textChars > 0 && textChars <= minKeepChars;
+    const blockShare = reducibleChars > 0 ? textChars / reducibleChars : 0;
+    const noticeBudget = (blockNoticeChars[index] ?? 0) * noticeScale;
+    const blockBudget = preserveBlock
+      ? textChars
+      : Math.floor(noticeBudget + distributableBudget * blockShare);
+    const blockMinKeepChars = preserveBlock ? textChars : Math.floor(minKeepChars * blockShare);
     const truncatedText = truncateToolResultText(textBlock.text, blockBudget, {
       suffix: suffixFactory,
-      minKeepChars,
+      minKeepChars: blockMinKeepChars,
     });
     const nextBlock = Object.assign({}, textBlock, { text: truncatedText });
     if (typeof textBlock.content === "string") {
@@ -501,13 +541,16 @@ function formatAggregateElisionText(
   if (remainingTextBudget <= 0) {
     return "";
   }
-  if (spillMarkers?.full && spillMarkers.full.length <= remainingTextBudget) {
+  if (spillMarkers?.full && estimateToolResultTextChars(spillMarkers.full) <= remainingTextBudget) {
     return spillMarkers.full;
   }
-  if (spillMarkers?.compact && spillMarkers.compact.length <= remainingTextBudget) {
+  if (
+    spillMarkers?.compact &&
+    estimateToolResultTextChars(spillMarkers.compact) <= remainingTextBudget
+  ) {
     return spillMarkers.compact;
   }
-  return AGGREGATE_ELISION_MARKER.slice(0, remainingTextBudget);
+  return sliceToolResultTextToBudget(AGGREGATE_ELISION_MARKER, remainingTextBudget);
 }
 
 /**
@@ -813,7 +856,7 @@ function buildAggregateToolResultReplacements(params: {
       entryId: item.entry.id,
       message: item.entry.message,
       spillSourceMessage: params.spillSourceBranch?.[item.index]?.message ?? item.entry.message,
-      textLength: getToolResultTextLength(item.entry.message),
+      textLength: getToolResultTextBudget(item.entry.message),
       aggregateEligible: item.entry.aggregateEligible !== false,
       deferredByFreshProjection: item.entry.deferAggregateRecovery === true,
       protectedByTrailingBatch: protectedEntryIds.has(item.entry.id),
@@ -826,10 +869,10 @@ function buildAggregateToolResultReplacements(params: {
 
   const suffixFactory =
     minKeepChars === RECOVERY_MIN_KEEP_CHARS &&
-    params.aggregateBudgetChars < candidates.length * DEFAULT_SUFFIX(1).length
+    params.aggregateBudgetChars < candidates.length * estimateToolResultTextChars(DEFAULT_SUFFIX(1))
       ? COMPACT_RECOVERY_SUFFIX
       : DEFAULT_SUFFIX;
-  const minTruncatedTextChars = minKeepChars + suffixFactory(1).length;
+  const minTruncatedTextChars = minKeepChars + estimateToolResultTextChars(suffixFactory(1));
 
   const totalChars = candidates.reduce((sum, item) => sum + item.textLength, 0);
   if (totalChars <= params.aggregateBudgetChars) {
@@ -870,12 +913,15 @@ function buildAggregateToolResultReplacements(params: {
     const targetChars = Math.max(minTruncatedTextChars, candidate.textLength - requestedReduction);
     const spillMarkers = resolveAggregateElisionMarkers(candidate.spillSourceMessage);
     const candidateSuffixFactory = spillMarkers?.truncationSuffix ?? suffixFactory;
-    const candidateTargetChars = Math.max(targetChars, candidateSuffixFactory(1).length);
+    const candidateTargetChars = Math.max(
+      targetChars,
+      estimateToolResultTextChars(candidateSuffixFactory(1)),
+    );
     const truncatedMessage = truncateToolResultMessage(candidate.message, candidateTargetChars, {
       minKeepChars,
       suffix: candidateSuffixFactory,
     });
-    const newLength = getToolResultTextLength(truncatedMessage);
+    const newLength = getToolResultTextBudget(truncatedMessage);
     const actualReduction = Math.max(0, candidate.textLength - newLength);
     if (actualReduction <= 0) {
       continue;
@@ -894,11 +940,11 @@ function buildAggregateToolResultReplacements(params: {
         (replacement) => replacement.entryId === candidate.entryId,
       );
       const baseMessage = existingReplacement?.message ?? candidate.message;
-      const baseTextLength = getToolResultTextLength(baseMessage);
+      const baseTextLength = getToolResultTextBudget(baseMessage);
       const targetTextChars = Math.max(0, baseTextLength - remainingReduction);
       const spillMarkers = resolveAggregateElisionMarkers(candidate.spillSourceMessage);
       const emptyMessage = clearToolResultText(candidate.message, targetTextChars, spillMarkers);
-      const actualReduction = Math.max(0, baseTextLength - getToolResultTextLength(emptyMessage));
+      const actualReduction = Math.max(0, baseTextLength - getToolResultTextBudget(emptyMessage));
       if (actualReduction <= 0 && !spillMarkers) {
         continue;
       }
@@ -952,7 +998,10 @@ function clearToolResultText(
   if (spillMarkers) {
     // The pointer is what makes elision recoverable. ~130 chars per entry is
     // negligible against the 64k+ aggregate floor, and accounting uses actual lengths.
-    remainingTextBudget = Math.max(remainingTextBudget, spillMarkers.compact.length);
+    remainingTextBudget = Math.max(
+      remainingTextBudget,
+      estimateToolResultTextChars(spillMarkers.compact),
+    );
   }
   return {
     ...message,
@@ -961,7 +1010,10 @@ function clearToolResultText(
         return block;
       }
       const replacementText = formatAggregateElisionText(remainingTextBudget, spillMarkers);
-      remainingTextBudget = Math.max(0, remainingTextBudget - replacementText.length);
+      remainingTextBudget = Math.max(
+        0,
+        remainingTextBudget - estimateToolResultTextChars(replacementText),
+      );
       return Object.assign({}, block, {
         text: replacementText,
         ...(typeof block.content === "string" ? { content: replacementText } : {}),
@@ -987,7 +1039,7 @@ function buildOversizedToolResultReplacements(params: {
     if ((msg as { role?: string }).role !== "toolResult") {
       continue;
     }
-    if (getToolResultTextLength(msg) <= params.maxChars) {
+    if (getToolResultTextBudget(msg) <= params.maxChars) {
       continue;
     }
     const replacementMinKeepChars = params.protectedEntryIds?.has(entry.id)
@@ -995,7 +1047,10 @@ function buildOversizedToolResultReplacements(params: {
       : minKeepChars;
     const spillMarkers = resolveAggregateElisionMarkers(msg);
     const suffixFactory = spillMarkers?.truncationSuffix;
-    const maxChars = Math.max(params.maxChars, suffixFactory?.(1).length ?? 0);
+    const maxChars = Math.max(
+      params.maxChars,
+      suffixFactory ? estimateToolResultTextChars(suffixFactory(1)) : 0,
+    );
     replacements.push({
       entryId: entry.id,
       message: truncateToolResultMessage(msg, maxChars, {
@@ -1025,7 +1080,7 @@ function calculateReplacementReduction(
     }
     reduction += Math.max(
       0,
-      getToolResultTextLength(entry.message) - getToolResultTextLength(replacement.message),
+      getToolResultTextBudget(entry.message) - getToolResultTextBudget(replacement.message),
     );
   }
 
@@ -1170,7 +1225,7 @@ export function estimateToolResultReductionPotential(params: {
     if ((msg as { role?: string }).role !== "toolResult") {
       continue;
     }
-    const textLength = getToolResultTextLength(msg);
+    const textLength = getToolResultTextBudget(msg);
     if (textLength <= 0) {
       continue;
     }

--- a/src/auto-reply/reply/get-reply-run.media-only.test.ts
+++ b/src/auto-reply/reply/get-reply-run.media-only.test.ts
@@ -12,9 +12,26 @@ import type { SessionEntry } from "../../config/sessions.js";
 import { HEARTBEAT_RUN_SCOPE } from "../../infra/heartbeat-run-scope.js";
 import { MESSAGE_TOOL_ONLY_DELIVERY_HINT } from "../../plugin-sdk/message-tool-delivery-hints.js";
 import { normalizeSessionDeliveryState } from "../../utils/delivery-context.shared.js";
+import { runReplyAgent } from "./agent-runner.runtime.js";
+import { applySessionHints } from "./body.js";
+import {
+  loadAgentRunnerRuntime,
+  loadEmbeddedAgentRuntime,
+  loadSessionUpdatesRuntime,
+} from "./get-reply-run-helpers.js";
+import { runPreparedReply } from "./get-reply-run.js";
+import { buildDirectChatContext, buildGroupChatContext, buildGroupIntro } from "./groups.js";
 import { finalizeInboundContextForSdk } from "./inbound-context.js";
-import { createReplyOperation } from "./reply-run-registry.js";
+import {
+  buildInboundUserContextPrefix,
+  resolveInboundUserContextPromptJoiner,
+} from "./inbound-meta.js";
+import { createReplyOperation, getActiveReplyRunCount } from "./reply-run-registry.js";
+import { testing as replyRunTesting } from "./reply-run-registry.test-support.js";
+import { routeReply } from "./route-reply.runtime.js";
+import { drainFormattedSystemEvents } from "./session-system-events.js";
 import { buildChannelSourceTurnId } from "./source-turn-id.js";
+import { resolveTypingMode } from "./typing-mode.js";
 
 vi.mock("../../agents/auth-profiles/session-override.js", () => ({
   resolveSessionAuthProfileOverride: vi.fn().mockResolvedValue(undefined),
@@ -156,20 +173,6 @@ vi.mock("./session-reset-prompt.js", () => ({
 vi.mock("./typing-mode.js", () => ({
   resolveTypingMode: vi.fn().mockReturnValue("off"),
 }));
-
-let runPreparedReply: typeof import("./get-reply-run.js").runPreparedReply;
-let runReplyAgent: typeof import("./agent-runner.runtime.js").runReplyAgent;
-let routeReply: typeof import("./route-reply.runtime.js").routeReply;
-let drainFormattedSystemEvents: typeof import("./session-system-events.js").drainFormattedSystemEvents;
-let applySessionHints: typeof import("./body.js").applySessionHints;
-let resolveTypingMode: typeof import("./typing-mode.js").resolveTypingMode;
-let buildDirectChatContext: typeof import("./groups.js").buildDirectChatContext;
-let buildGroupIntro: typeof import("./groups.js").buildGroupIntro;
-let buildGroupChatContext: typeof import("./groups.js").buildGroupChatContext;
-let buildInboundUserContextPrefix: typeof import("./inbound-meta.js").buildInboundUserContextPrefix;
-let resolveInboundUserContextPromptJoiner: typeof import("./inbound-meta.js").resolveInboundUserContextPromptJoiner;
-let getActiveReplyRunCount: typeof import("./reply-run-registry.js").getActiveReplyRunCount;
-let replyRunTesting: typeof import("./reply-run-registry.test-support.js").testing;
 
 function createGatewayDrainingError(): Error {
   const error = new Error("Gateway is draining for restart; new tasks are not accepted");
@@ -344,21 +347,13 @@ describe("runPreparedReply media-only handling", () => {
   const cleanupPaths: string[] = [];
 
   beforeAll(async () => {
-    ({ runPreparedReply } = await import("./get-reply-run.js"));
-    ({ runReplyAgent } = await import("./agent-runner.runtime.js"));
-    ({ routeReply } = await import("./route-reply.runtime.js"));
-    ({ drainFormattedSystemEvents } = await import("./session-system-events.js"));
-    ({ applySessionHints } = await import("./body.js"));
-    ({ resolveTypingMode } = await import("./typing-mode.js"));
-    ({ buildDirectChatContext, buildGroupIntro, buildGroupChatContext } =
-      await import("./groups.js"));
-    ({ buildInboundUserContextPrefix, resolveInboundUserContextPromptJoiner } =
-      await import("./inbound-meta.js"));
-    ({ getActiveReplyRunCount } = await import("./reply-run-registry.js"));
-    ({ testing: replyRunTesting } = await import("./reply-run-registry.test-support.js"));
-
-    // Load deferred reply dependencies before per-case timing starts.
-    await runPreparedReply(baseParams());
+    // Preload the runtime seams directly so test setup does not need a synthetic
+    // reply turn with registry and session side effects.
+    await Promise.all([
+      loadEmbeddedAgentRuntime(),
+      loadAgentRunnerRuntime(),
+      loadSessionUpdatesRuntime(),
+    ]);
   });
 
   beforeEach(async () => {


### PR DESCRIPTION
Closes #103847

AI-assisted. Thanks to @yetval for the precise report and source reproduction.

## What Problem This Solves

Fixes an issue where CJK-heavy tool output could consume up to roughly four times the intended context budget because live truncation, aggregate prompt budgeting, persisted recovery, and the mid-turn guard did not share language-aware accounting.

The same multi-block allocator could also exceed its total cap through independent minimums, starve later blocks, spend suffix budget on empty blocks, and underreport omissions in suffix-only truncation.

## Why This Change Was Made

This introduces one canonical CJK-aware, UTF-16-safe budget-and-slice abstraction and routes every affected tool-result path through it. ASCII behavior and the context guard's existing safety floor remain intact, while the allocator now owns one bounded total budget across all text blocks.

The committed QA scenario exercises a real Gateway agent loop through qa-channel and the mock provider, then inspects the provider-bound tool result rather than relying only on helper tests. Its final marker check requires exact trimmed equality to avoid false-positive live proof.

During exact-head CI, an unrelated 3,545-line auto-reply suite timed out while sequentially importing modules and running a synthetic reply in `beforeAll`. The test harness now uses normal mocked imports and preloads the three real lazy runtime seams in parallel, removing the synthetic turn and its registry/session side effects instead of merely extending the timeout.

## User Impact

CJK-heavy tool sessions now stay within the same context-pressure limits as ASCII-heavy sessions, reducing avoidable overflow, compaction, and lost-progress behavior. Mixed and multi-block tool results also remain within their declared aggregate cap without starving later output.

## Evidence

- Before: a 16,000-character dense-CJK tool result fit the 16,000 raw-character cap while representing roughly 16,000 weighted units against the intended 4,000-token budget.
- Live Gateway QA: Actions run https://github.com/openclaw/openclaw/actions/runs/30303634693 used a source-built Gateway, real agent loop, qa-channel, and mock provider. The 16,000-character source became 8,054 provider-bound characters, included the standard truncation notice, and returned exactly `CJK-TOOL-RESULT-OK` in 20.4 seconds.
- Rebased exact-head local proof: 374 focused tests passed across unit-fast, auto-reply, agents, and QA catalog shards; the full lint, import-cycle, formatting, guards, and `git diff --check` gates passed.
- Auto-reply CI hardening: the 101-test media-only suite passed three consecutive single-worker local runs, then its original 2-CPU `large-7` CI shard passed on both refreshed heads.
- Final exact-head CI: https://github.com/openclaw/openclaw/actions/runs/30310423556 completed successfully with 57 green jobs and zero failures.
- Final exact-head autoreview: clean, no accepted/actionable findings, confidence 0.92.
