### PR TITLE
fix(cron): protect recreated reminders from stale active runs

### DIFF
--- a/src/cron/active-jobs.test.ts
+++ b/src/cron/active-jobs.test.ts
@@ -5,6 +5,7 @@ import {
   hasActiveCronJobs,
   hasActiveCronJobsExceptMarker,
   markCronJobActive,
+  noteActiveCronJobRemoval,
   noteActiveCronJobScheduleMutation,
   resetCronActiveJobs,
 } from "./active-jobs.js";
@@ -48,6 +49,31 @@ describe("hasActiveCronJobsExceptMarker", () => {
 });
 
 describe("active cron schedule ownership", () => {
+  it("records durable job removal without releasing the active run marker", () => {
+    const marker = markCronJobActive("removed-job");
+
+    noteActiveCronJobRemoval("removed-job");
+
+    expect(marker?.scheduleMutated).toBe(true);
+    expect(marker?.jobRemoved).toBe(true);
+    expect(hasActiveCronJobs()).toBe(true);
+  });
+
+  it("does not mistake an ordinary schedule edit for job removal", () => {
+    const marker = markCronJobActive("updated-job");
+
+    noteActiveCronJobScheduleMutation("updated-job");
+
+    expect(marker?.scheduleMutated).toBe(true);
+    expect(marker?.jobRemoved).toBeUndefined();
+  });
+
+  it("does not create active markers when removing an idle job", () => {
+    noteActiveCronJobRemoval("idle-removed-job");
+
+    expect(hasActiveCronJobs()).toBe(false);
+  });
+
   it("records durable schedule mutations on the admitted active run", () => {
     const marker = markCronJobActive("rescheduled-job");
 

--- a/src/cron/active-jobs.ts
+++ b/src/cron/active-jobs.ts
@@ -16,6 +16,7 @@ export type CronActiveJobMarker = {
   generation: number;
   token: number;
   scheduleMutated?: true;
+  jobRemoved?: true;
   legacy?: boolean;
   preserveAcrossGenerationAdvance?: boolean;
 };
@@ -130,6 +131,21 @@ export function noteActiveCronJobScheduleMutation(jobId: string): void {
     // Keep mutation history on the admitted run: A→B→A has the original
     // schedule value but still belongs to the operator's newer edit.
     marker.scheduleMutated = true;
+  }
+}
+
+/** Retires the admitted job identity after its deletion becomes durable. */
+export function noteActiveCronJobRemoval(jobId: string): void {
+  if (!jobId) {
+    return;
+  }
+  const state = getCronActiveJobState();
+  const marker = state.activeJobs.get(jobId);
+  if (marker && isMarkerActiveInGeneration(marker, state.generation)) {
+    // A reused ID names a new job, not a reschedule of the old invocation.
+    // Keep its marker until completion so duplicate-run guards remain intact.
+    marker.scheduleMutated = true;
+    marker.jobRemoved = true;
   }
 }
 

--- a/src/cron/service.one-shot-schedule-ownership.test.ts
+++ b/src/cron/service.one-shot-schedule-ownership.test.ts
@@ -41,9 +41,11 @@ async function addOneShot(params: {
   cron: CronService;
   name: string;
   atMs: number;
+  id?: string;
   deleteAfterRun?: boolean;
 }) {
   return await params.cron.add({
+    ...(params.id === undefined ? {} : { id: params.id }),
     name: params.name,
     enabled: true,
     ...(params.deleteAfterRun === undefined ? {} : { deleteAfterRun: params.deleteAfterRun }),
@@ -83,6 +85,105 @@ async function expectFutureOneShot(params: {
 }
 
 describe("cron one-shot schedule ownership", () => {
+  it.each([
+    { mode: "direct", deleteAfterRun: false },
+    { mode: "direct", deleteAfterRun: true },
+    { mode: "queued", deleteAfterRun: false },
+    { mode: "queued", deleteAfterRun: true },
+  ] as const)(
+    "does not finalize an active $mode run into a removed and recreated one-shot (deleteAfterRun=$deleteAfterRun)",
+    async ({ mode, deleteAfterRun }) => {
+      const store = await makeStorePath();
+      const started = createDeferred<void>();
+      const release = createDeferred<{ status: "ok"; summary: string }>();
+      const finished = createDeferred<void>();
+      const events: CronEvent[] = [];
+      const cron = createCron({
+        storePath: store.storePath,
+        runIsolatedAgentJob: vi.fn(async () => {
+          started.resolve();
+          return await release.promise;
+        }),
+        onEvent: (event) => {
+          events.push(event);
+          if (event.action === "finished") {
+            finished.resolve();
+          }
+        },
+      });
+
+      try {
+        await cron.start();
+        const atMs = Date.now() + 60 * 60_000;
+        const original = await addOneShot({
+          cron,
+          id: `removed-active-${mode}-${deleteAfterRun}`,
+          name: "removed original one-shot",
+          atMs,
+          deleteAfterRun,
+        });
+        const directRun = mode === "direct" ? cron.run(original.id, "force") : undefined;
+        if (mode === "queued") {
+          await expect(cron.enqueueRun(original.id, "force")).resolves.toMatchObject({
+            ok: true,
+            enqueued: true,
+          });
+        }
+        await started.promise;
+
+        await expect(cron.remove(original.id)).resolves.toEqual({ ok: true, removed: true });
+        await addOneShot({
+          cron,
+          id: original.id,
+          name: "independent replacement one-shot",
+          atMs,
+          deleteAfterRun,
+        });
+
+        release.resolve({ status: "ok", summary: "original run finished" });
+        if (directRun) {
+          await expect(directRun).resolves.toEqual({ ok: true, ran: true });
+        } else {
+          await finished.promise;
+        }
+        await cron.status();
+
+        for (const jobs of [
+          await cron.list({ includeDisabled: true }),
+          (await loadCronStore(store.storePath)).jobs,
+        ]) {
+          const replacement = jobs.find((job) => job.id === original.id);
+          expect(replacement).toMatchObject({
+            id: original.id,
+            name: "independent replacement one-shot",
+            enabled: true,
+            deleteAfterRun,
+            state: { nextRunAtMs: atMs },
+          });
+          expect(replacement?.state.lastRunAtMs).toBeUndefined();
+          expect(replacement?.state.lastRunStatus).toBeUndefined();
+          expect(replacement?.state.lastStatus).toBeUndefined();
+          expect(replacement?.state.runningAtMs).toBeUndefined();
+        }
+
+        if (mode === "queued") {
+          expect(
+            events.filter((event) => event.action === "finished" && event.jobId === original.id),
+          ).toEqual([
+            expect.objectContaining({
+              status: "ok",
+              summary: "original run finished",
+              job: expect.objectContaining({ name: "removed original one-shot" }),
+            }),
+          ]);
+        }
+      } finally {
+        release.resolve({ status: "ok", summary: "original run finished" });
+        cron.stop();
+      }
+    },
+  );
+
   it.each([
     { label: "successful", outcome: { status: "ok", summary: "done" } },
     { label: "failed", outcome: { status: "error", error: "temporary provider failure" } },

--- a/src/cron/service/ops-mutations.ts
+++ b/src/cron/service/ops-mutations.ts
@@ -4,7 +4,11 @@ import {
   AgentDeletionAuthorityRollbackError,
   AgentDeletionCommitUncertainError,
 } from "../../agents/agent-lifecycle-registry.js";
-import { isCronJobActive, noteActiveCronJobScheduleMutation } from "../active-jobs.js";
+import {
+  isCronJobActive,
+  noteActiveCronJobRemoval,
+  noteActiveCronJobScheduleMutation,
+} from "../active-jobs.js";
 import { cronSchedulingInputsEqual } from "../schedule-identity.js";
 import { deleteCronJobScratch } from "../scratch-store.js";
 import { createCronStreamSourceIdentity, cronStreamScheduleKey } from "../stream-schedule.js";
@@ -407,6 +411,7 @@ export async function remove(
       suppressScheduledJobId: id,
     });
     if (removed) {
+      noteActiveCronJobRemoval(id);
       try {
         deleteCronJobScratch(state.deps.storePath, id);
       } catch (error) {
@@ -456,6 +461,7 @@ export async function removeAgentJobsTransactional<T>(
       if (error instanceof AgentDeletionCommitUncertainError) {
         armTimer(state);
         for (const job of removedJobs) {
+          noteActiveCronJobRemoval(job.id);
           emit(state, { jobId: job.id, action: "removed", job });
         }
         throw error;
@@ -477,6 +483,7 @@ export async function removeAgentJobsTransactional<T>(
       throw error;
     }
     for (const job of removedJobs) {
+      noteActiveCronJobRemoval(job.id);
       try {
         deleteCronJobScratch(state.deps.storePath, job.id);
       } catch (error) {

--- a/src/cron/service/ops-run.ts
+++ b/src/cron/service/ops-run.ts
@@ -83,7 +83,10 @@ async function finishPreparedManualRun(
       if (!tracker || tracker.emitted) {
         return;
       }
-      const job = state.store?.jobs.find((entry) => entry.id === jobId);
+      const job =
+        prepared.activeJobMarker?.jobRemoved === true
+          ? executionJob
+          : state.store?.jobs.find((entry) => entry.id === jobId);
       // enqueueRun acknowledges a concrete run id, so every accepted request
       // needs one terminal event even if the job or service owner changes mid-run.
       emitCronRunFinished(
@@ -140,7 +143,10 @@ async function finishPreparedManualRun(
     let notifySetupTimeout = coreResult.isolatedAgentSetupTimeout !== undefined;
     await locked(state, async () => {
       await ensureLoaded(state, { skipRecompute: true });
-      if (!isCronActiveJobMarkerCurrent(prepared.activeJobMarker)) {
+      if (
+        !isCronActiveJobMarkerCurrent(prepared.activeJobMarker) ||
+        prepared.activeJobMarker?.jobRemoved === true
+      ) {
         notifySetupTimeout = false;
         return;
       }

--- a/src/cron/service/timer-outcomes.ts
+++ b/src/cron/service/timer-outcomes.ts
@@ -541,7 +541,7 @@ export function applyOutcomeToStoredJob(
   }
   const jobs = store.jobs;
   const job = jobs.find((entry) => entry.id === result.jobId);
-  if (!job) {
+  if (!job || result.activeJobMarker?.jobRemoved === true) {
     if (result.status === "ok" && result.triggerEval?.fired === false) {
       tryFinishCronTaskRunWithoutHistory(state, result);
       return undefined;

--- a/src/cron/service/timer.batch-finalization.test.ts
+++ b/src/cron/service/timer.batch-finalization.test.ts
@@ -13,6 +13,7 @@ import { isCronJobActive, markCronJobActive } from "../active-jobs.js";
 import * as cronStoreModule from "../store.js";
 import { loadCronStore, saveCronStore } from "../store.js";
 import type { CronJob } from "../types.js";
+import { add, remove } from "./ops-mutations.js";
 import { createCronServiceState } from "./state.js";
 import {
   createCompletedCronRunOutcomeDrain,
@@ -69,6 +70,90 @@ function findCronTask(jobId: string) {
 }
 
 describe("cron batch outcome finalization", () => {
+  it.each([
+    { trigger: "scheduled", deleteAfterRun: false },
+    { trigger: "scheduled", deleteAfterRun: true },
+    { trigger: "startup", deleteAfterRun: false },
+    { trigger: "startup", deleteAfterRun: true },
+  ] as const)(
+    "does not apply a removed $trigger run to a same-id replacement (deleteAfterRun=$deleteAfterRun)",
+    async ({ trigger, deleteAfterRun }) => {
+      const store = fixtures.makeStorePath();
+      const dueAt = Date.parse("2026-02-06T10:05:00.750Z");
+      const replacementAt = dueAt + 60 * 60_000;
+      const original = createDueIsolatedJob({
+        id: `removed-${trigger}-replacement-${deleteAfterRun}`,
+        nowMs: dueAt,
+        nextRunAtMs: dueAt,
+        deleteAfterRun,
+      });
+      original.name = "removed original scheduled job";
+      await saveCronStore(store.storePath, { version: 1, jobs: [original] });
+
+      const started = createDeferred<void>();
+      const release = createDeferred<{ status: "ok"; summary: string }>();
+      const events: Array<{ action: string; jobId: string; job?: CronJob }> = [];
+      const state = createBatchState({
+        storePath: store.storePath,
+        nowMs: dueAt,
+        runIsolatedAgentJob: vi.fn(async () => {
+          started.resolve();
+          return await release.promise;
+        }),
+        onEvent: (event) => events.push(event),
+      });
+      const batch = startBatch(trigger, state);
+
+      try {
+        await started.promise;
+        await expect(remove(state, original.id)).resolves.toEqual({ ok: true, removed: true });
+        await add(state, {
+          id: original.id,
+          name: "independent replacement scheduled job",
+          enabled: true,
+          deleteAfterRun,
+          schedule: { kind: "at", at: new Date(replacementAt).toISOString() },
+          sessionTarget: "isolated",
+          wakeMode: "next-heartbeat",
+          payload: { kind: "agentTurn", message: "run only the replacement occurrence" },
+          delivery: { mode: "none" },
+        });
+
+        release.resolve({ status: "ok", summary: "removed original completed" });
+        await batch;
+
+        for (const jobs of [state.store?.jobs ?? [], (await loadCronStore(store.storePath)).jobs]) {
+          const replacement = jobs.find((job) => job.id === original.id);
+          expect(replacement).toMatchObject({
+            id: original.id,
+            name: "independent replacement scheduled job",
+            enabled: true,
+            deleteAfterRun,
+            state: { nextRunAtMs: replacementAt },
+          });
+          expect(replacement?.state.lastRunAtMs).toBeUndefined();
+          expect(replacement?.state.lastRunStatus).toBeUndefined();
+          expect(replacement?.state.lastStatus).toBeUndefined();
+          expect(replacement?.state.runningAtMs).toBeUndefined();
+        }
+        expect(
+          events.filter((event) => event.action === "finished" && event.jobId === original.id),
+        ).toEqual([
+          expect.objectContaining({
+            job: expect.objectContaining({ name: "removed original scheduled job" }),
+          }),
+        ]);
+        expect(isCronJobActive(original.id)).toBe(false);
+      } finally {
+        release.resolve({ status: "ok", summary: "removed original completed" });
+        await batch;
+        if (state.timer) {
+          clearTimeout(state.timer);
+        }
+      }
+    },
+  );
+
   it("coalesces simultaneously finished outcomes into one durable write", async () => {
     const store = fixtures.makeStorePath();
     const dueAt = Date.parse("2026-02-06T10:05:01.000Z");


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users who remove a running scheduled reminder and recreate the same explicit job ID can have the original execution overwrite or consume the newly created reminder. The stale run could incorrectly attach its completion, delivery history, or failure status to the replacement across direct manual runs, queued runs, scheduled timer runs, and startup catch-up.

## Why This Change Was Made

The cron active-run registry previously distinguished durable schedule edits but not a durable job deletion. Record deletion on the exact admitted run only after its removal commits, keep its active marker until real completion, finalize old scheduled and queued outcomes against the original job snapshot, and leave a same-ID replacement completely independent. Apply the same ownership invariant to ordinary removals and transactional agent-job deletions, including uncertain commits; rollbacks and idle jobs remain unchanged. No public config, plugin API, Gateway protocol, dependency, SQLite schema, migration, or compatibility surface changes.

## User Impact

Operators can safely remove and recreate a reminder while its previous run is finishing. The replacement stays enabled, keeps its own schedule and untouched run/delivery history, and fires normally; the old execution still receives its correct terminal result without duplicate delivery.

## Evidence

- Frozen clean `main`: `62baf451c14c98dc8ab70e5050083a8efb18823b`.
- Archived and live GitHub searches found no duplicate open issue or PR.
- Red-first trusted Linux proof: all **8** direct, queued, scheduled, startup, and `deleteAfterRun` replacement cases failed on unmodified production.
- Post-fix focused ownership and real durable-store regression suite: **46/46**; independently repeated **3** times.
- Complete cron suite: **1,780/1,780** across **154** test files.
- Complete cron-related Gateway, stream, caller-scope, validation, and CLI regression suites passed.
- `pnpm check:changed` passed production and test typechecking, targeted lint, formatting, plugin/dependency guards, native state schema, database-first, runtime imports, webhook, and pairing checks.
- Dedicated Blacksmith Testbox `tbx_01kyjq52wf8c3hc9bw4ynnxy97`; exact reviewed patch; user command exit `0`.
- Fresh independent Codex autoreview: no accepted or actionable findings.
- Provenance: the durable removal path was carried forward by #113830; no schema or security-owned source changed.

### Refreshed latest-main proof

- Preserved red-first baseline: `62baf451c14c98dc8ab70e5050083a8efb18823b`.
- Rebased baseline, including the new cron/Workboard lifecycle-race fix #114744: `5e8555a7c9b7ceefc2e1be2df57c6251f4411af8`.
- Exact independently reviewed pull-request head: `93fe321608c2d62f6f47e8f36dadf2428063e5e9`.
- Three fresh exact-head ownership stress runs: **138/138** across all direct, queued, timer, startup, and deletion-policy cases.
- Complete rebased cron suite and cron CLI regressions pass; all Gateway cron, stream, validation, and caller-scope tests pass: **370/370**.
- Fresh exact-head branch autoreview: **no accepted or actionable findings**.
- Refreshed trusted Linux Testbox: `tbx_01kyjsdndw4k04t7a6nxpwsw5n`.
- ClawSweeper rank-up completed: rebased against current `main`, incorporated #114744, and reran exact-head ownership stress, the complete cron/Gateway/CLI regression surfaces, and independent review.
