### PR TITLE
fix(cli): install cached shell completions without plugin loading

### DIFF
--- a/src/cli/completion-cli.ts
+++ b/src/cli/completion-cli.ts
@@ -211,6 +211,15 @@ export function registerCompletionCli(program: Command) {
       // Route logs to stderr so plugin loading messages do not corrupt
       // the completion script written to stdout.
       routeLogsToStderr();
+
+      // Cached installation needs only the existing script; loading the command tree can
+      // introduce unrelated plugin failures before the cache can be checked or installed.
+      if (options.install && !options.writeState) {
+        const targetShell = options.shell ?? resolveShellFromEnv();
+        await installCompletion(targetShell, Boolean(options.yes), program.name());
+        return;
+      }
+
       const shell = options.shell ?? "zsh";
 
       // Completion needs the full Commander command tree (including nested subcommands).

--- a/src/cli/completion-cli.write-state.test.ts
+++ b/src/cli/completion-cli.write-state.test.ts
@@ -5,6 +5,11 @@ import path from "node:path";
 import { Command } from "commander";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { withEnvAsync } from "../test-utils/env.js";
+import {
+  COMPLETION_SHELLS,
+  resolveCompletionCachePath,
+  resolveCompletionProfilePath,
+} from "./completion-runtime.js";
 
 const stderrWrites = vi.hoisted(() => vi.fn());
 const getCoreCliCommandNamesMock = vi.hoisted(() => vi.fn(() => []));
@@ -45,6 +50,31 @@ vi.mock("../plugins/cli.js", () => ({
   registerPluginCliCommandsFromValidatedConfig: registerPluginCliCommandsFromValidatedConfigMock,
 }));
 
+async function withIsolatedCompletionState(
+  run: () => Promise<void>,
+  env: Record<string, string | undefined> = {},
+): Promise<void> {
+  const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-completion-state-"));
+  const homeDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-completion-home-"));
+
+  try {
+    await withEnvAsync({ HOME: homeDir, OPENCLAW_STATE_DIR: stateDir, ...env }, run);
+  } finally {
+    await fs.rm(stateDir, { recursive: true, force: true });
+    await fs.rm(homeDir, { recursive: true, force: true });
+  }
+}
+
+function expectCompletionInstallationToSkipRegistration(): void {
+  expect(getProgramContextMock).not.toHaveBeenCalled();
+  expect(getCoreCliCommandNamesMock).not.toHaveBeenCalled();
+  expect(registerCoreCliByNameMock).not.toHaveBeenCalled();
+  expect(getSubCliEntriesMock).not.toHaveBeenCalled();
+  expect(registerSubCliByNameMock).not.toHaveBeenCalled();
+  expect(registerPluginCliCommandsFromValidatedConfigMock).not.toHaveBeenCalled();
+  expect(stderrWrites).not.toHaveBeenCalled();
+}
+
 describe("completion-cli write-state", () => {
   let restoreStderrWriteSpy: (() => void) | null = null;
 
@@ -67,6 +97,106 @@ describe("completion-cli write-state", () => {
 
   afterEach(async () => {
     restoreStderrWriteSpy?.();
+  });
+
+  it.each(COMPLETION_SHELLS)(
+    "installs cached %s completion without registering commands or plugins",
+    async (shell) => {
+      const { registerCompletionCli } = await import("./completion-cli.js");
+
+      await withIsolatedCompletionState(async () => {
+        const cachePath = resolveCompletionCachePath(shell, "openclaw");
+        await fs.mkdir(path.dirname(cachePath), { recursive: true });
+        await fs.writeFile(cachePath, "# cached completion\n", "utf8");
+
+        const program = new Command().name("openclaw");
+        registerCompletionCli(program);
+        await program.parseAsync(["completion", "--shell", shell, "--install", "--yes"], {
+          from: "user",
+        });
+
+        await expect(fs.readFile(resolveCompletionProfilePath(shell), "utf8")).resolves.toContain(
+          cachePath,
+        );
+        await expect(fs.readFile(cachePath, "utf8")).resolves.toBe("# cached completion\n");
+        expectCompletionInstallationToSkipRegistration();
+      });
+    },
+  );
+
+  it.each(COMPLETION_SHELLS)(
+    "reports missing %s completion cache without registering commands or plugins",
+    async (shell) => {
+      const { registerCompletionCli } = await import("./completion-cli.js");
+
+      await withIsolatedCompletionState(async () => {
+        const cachePath = resolveCompletionCachePath(shell, "openclaw");
+        const profilePath = resolveCompletionProfilePath(shell);
+        const program = new Command().name("openclaw");
+        registerCompletionCli(program);
+
+        await expect(
+          program.parseAsync(["completion", "--shell", shell, "--install", "--yes"], {
+            from: "user",
+          }),
+        ).rejects.toThrow(
+          `Completion cache not found at ${cachePath}. Run \`openclaw completion --write-state\` first.`,
+        );
+
+        await expect(fs.access(profilePath)).rejects.toThrow();
+        expectCompletionInstallationToSkipRegistration();
+      });
+    },
+  );
+
+  it("detects the active shell for cached installation without registering commands", async () => {
+    const { registerCompletionCli } = await import("./completion-cli.js");
+
+    await withIsolatedCompletionState(
+      async () => {
+        const cachePath = resolveCompletionCachePath("fish", "openclaw");
+        await fs.mkdir(path.dirname(cachePath), { recursive: true });
+        await fs.writeFile(cachePath, "# fish completion\n", "utf8");
+
+        const program = new Command().name("openclaw");
+        registerCompletionCli(program);
+        await program.parseAsync(["completion", "--install", "--yes"], { from: "user" });
+
+        await expect(fs.readFile(resolveCompletionProfilePath("fish"), "utf8")).resolves.toContain(
+          cachePath,
+        );
+        expectCompletionInstallationToSkipRegistration();
+      },
+      { SHELL: "/usr/bin/fish" },
+    );
+  });
+
+  it("generates and installs completion after registering commands and plugins", async () => {
+    const { registerCompletionCli } = await import("./completion-cli.js");
+
+    await withIsolatedCompletionState(async () => {
+      const program = new Command().name("openclaw");
+      registerCompletionCli(program);
+      await program.parseAsync(
+        ["completion", "--shell", "zsh", "--write-state", "--install", "--yes"],
+        { from: "user" },
+      );
+
+      const cachePath = resolveCompletionCachePath("zsh", "openclaw");
+      await expect(fs.readFile(cachePath, "utf8")).resolves.toContain("#compdef openclaw");
+      await expect(fs.readFile(resolveCompletionProfilePath("zsh"), "utf8")).resolves.toContain(
+        cachePath,
+      );
+      expect(registerSubCliByNameMock.mock.calls).toEqual([
+        [program, "qa", process.argv, { purpose: "completion" }],
+      ]);
+      expect(registerPluginCliCommandsFromValidatedConfigMock).toHaveBeenCalledTimes(1);
+      expect(stderrWrites.mock.calls).toEqual([
+        [
+          "[completion] skipping subcommand `qa` while building completion cache: qa scenario pack not found: qa/scenarios/index.yaml\n",
+        ],
+      ]);
+    });
   });
 
   it("keeps completion cache generation alive when a subcli fails to register", async () => {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users installing an existing shell completion cache could encounter unrelated command or plugin registration failures, slow full-tree discovery, and misleading cache-generation warnings before their profile was updated. Missing caches could likewise be masked by registration failures instead of showing the documented recovery command.

## Why This Change Was Made

Route cache-only completion installation directly to the existing completion installer before eagerly registering commands or plugins. Preserve the existing complete command tree for printed completion scripts, cache generation, and combined generation plus installation.

## User Impact

Cached zsh, bash, fish, and PowerShell completions install promptly and deterministically, honor automatic shell detection, preserve the generated cache, and retain the existing actionable missing-cache error. Combined `--write-state --install`, doctor, onboarding, update, and machine-readable CLI behavior are unchanged.

## Evidence

Fresh-main before/after reproduction on merge-base `903d8bc9d5734c0182f90af5949c84bee8005fb8`:

```text
$ pnpm test src/cli/completion-cli.write-state.test.ts
FAIL src/cli/completion-cli.write-state.test.ts (13 tests | 9 failed)
× installs cached zsh completion without registering commands or plugins
× installs cached bash completion without registering commands or plugins
× installs cached powershell completion without registering commands or plugins
× installs cached fish completion without registering commands or plugins
× reports missing zsh completion cache without registering commands or plugins
× reports missing bash completion cache without registering commands or plugins
× reports missing powershell completion cache without registering commands or plugins
× reports missing fish completion cache without registering commands or plugins
× detects the active shell for cached installation without registering commands
```

Exact pushed head `daf6c47dea3956b9b139293103e86b11a6bd3d5a`, rerun after formatting and commit:

```text
$ pnpm test src/cli/completion-cli.write-state.test.ts src/cli/completion-cli.test.ts \
    src/cli/completion-fish.test.ts src/cli/completion-runtime.test.ts \
    src/cli/program/register.subclis.test.ts src/commands/doctor-completion.test.ts \
    src/wizard/setup.completion.test.ts src/cli/update-cli.test.ts \
    src/cli/update-cli.option-collisions.test.ts \
    src/cli/update-cli/shared.command-runner.test.ts test/cli-json-stdout.e2e.test.ts
unit-fast:    4 passed
cli:        278 passed
commands:    16 passed
wizard:       5 passed
e2e:          7 passed
[test] passed 5 Vitest shards
exit=0
```

Real Linux source and production-packaged CLI proof, in isolated home, state, and configuration directories:

```text
[cli-stress] PASS source generates all four real completion caches
[cli-stress] PASS source zsh cached install #1
[cli-stress] PASS source bash cached install #1
[cli-stress] PASS source powershell cached install #1
[cli-stress] PASS source fish cached install #1
[cli-stress] PASS source zsh missing cache
[cli-stress] PASS source bash missing cache
[cli-stress] PASS source powershell missing cache
[cli-stress] PASS source fish missing cache
[cli-stress] PASS source detects fish without command or plugin loading
[cli-stress] PASS source generates every shell and installs auto-detected fish
[cli-stress] PASS packaged generates all four real completion caches
[cli-stress] PASS packaged zsh cached install #1
[cli-stress] PASS packaged bash cached install #1
[cli-stress] PASS packaged powershell cached install #1
[cli-stress] PASS packaged fish cached install #1
[cli-stress] PASS packaged zsh missing cache
[cli-stress] PASS packaged bash missing cache
[cli-stress] PASS packaged powershell missing cache
[cli-stress] PASS packaged fish missing cache
[cli-stress] PASS packaged detects fish without command or plugin loading
[cli-stress] PASS packaged generates every shell and installs auto-detected fish
[cli-stress] SUMMARY 62 passed; 0 failed; source and packaged; all four shells
exit=0
```

Every repeated install additionally asserts empty stdout, no registration warning, unchanged generated cache, unchanged configuration, unchanged state-directory contents, and the correct idempotent shell profile. Missing-cache runs assert the exact recovery path and that no profile is created. Combined generation is verified for all four shells and for automatically detected fish.

```text
$ pnpm build
OK: All 143 public plugin-sdk subpaths verified.
verified 662 finalized Control UI sidecars
[build-all] phase timings: total 2m 54.4s
exit=0

$ pnpm check:changed -- src/cli/completion-cli.ts src/cli/completion-cli.write-state.test.ts
[check:changed] lanes=core, coreTests
All matched files use the correct format.
Found 0 warnings and 0 errors.
Import cycle check: 0 runtime value cycle(s).
exit=0

$ autoreview --mode uncommitted
autoreview clean: no accepted/actionable findings reported
overall: patch is correct
```

The protected CLI-area maintainer review independently verified all six cache/generation branches and the exact PR head using the latest canonical `main` checkout:

```text
$ scripts/pr review-validate-artifacts 114761
review guard passed
head=daf6c47dea3956b9b139293103e86b11a6bd3d5a
review artifacts validated
recommendation: READY FOR /prepare-pr
findings: 0
```

AI-assisted; behavior, docs, owner boundaries, previous-main reproduction, live source and packaged execution, and the exact pushed commit were independently verified.