### PR TITLE
fix(docs): replace rate-limited Star History badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,7 +294,7 @@ Minimal `~/.openclaw/openclaw.json` (model + defaults):
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=openclaw/openclaw&type=date&legend=top-left)](https://www.star-history.com/#openclaw/openclaw&type=date&legend=top-left)
+[View OpenClaw's star history](https://www.star-history.com/#openclaw/openclaw&type=date&legend=top-left).
 
 ## Molty
 


### PR DESCRIPTION
Related: #114746

## What Problem This Solves

Fixes the one remaining advisory error in the post-merge Docs External Link Audit. The Star History image API returned HTTP 404 with a rate-limit message body even though the navigable Star History page remained live.

## Why This Change Was Made

Replaces the bot-hostile dynamic SVG badge with a normal link to the same Star History page. This removes the noisy API request without adding an exclusion or accepting 404, so genuine 404/410 link rot remains observable.

AI-assisted maintainer change.

## User Impact

README readers can still open OpenClaw's Star History page, and the weekly audit no longer depends on Star History's rate-limited image API.

## Evidence

- Post-merge audit run 30307649797 on landed SHA `69b54cf13cc7e10b06d1efd52914153eda3b6bb8`: 6,150 unique URLs, 1 error; the sole error was the SVG API's rate-limit-body 404.
- Replacement page: HTTP 200.
- `node scripts/check-docs-mdx.mjs README.md`: passed.
- `git diff --check`: passed.
- Diff: README only, +1/-1.
- Independent adversarial refuter: `NO-ACTIONABLE-OBJECTION`.
- Codex autoreview: clean, no accepted/actionable findings.

After merge, dispatch Docs External Link Audit again and confirm the new advisory error count.
