### PR TITLE
refactor(channels): mattermost event-plan builder and whatsapp durable admission

### DIFF
--- a/extensions/mattermost/src/mattermost/monitor-auth.ts
+++ b/extensions/mattermost/src/mattermost/monitor-auth.ts
@@ -90,7 +90,7 @@ export function isMattermostSenderAllowed(params: {
   return match.allowed;
 }
 
-export function mapMattermostChannelTypeToChatType(channelType?: string | null): ChatType {
+function mapMattermostChannelTypeToChatType(channelType?: string | null): ChatType {
   const normalized = channelType?.trim().toUpperCase();
   if (!normalized) {
     return "direct";

--- a/extensions/mattermost/src/mattermost/monitor-event-plan.ts
+++ b/extensions/mattermost/src/mattermost/monitor-event-plan.ts
@@ -1,0 +1,143 @@
+// Mattermost plugin module prepares shared routing and reply facts for monitor events.
+import { finalizeInboundContext } from "openclaw/plugin-sdk/reply-runtime";
+import { resolveMattermostReplyToMode } from "./accounts.js";
+import type { MattermostChannel } from "./client.js";
+import { resolveMattermostTrustedChatKind } from "./monitor-auth.js";
+import { resolveMattermostThreadSessionContext } from "./monitor-context.js";
+import type { MattermostMonitorContext } from "./monitor-types.js";
+import { createMattermostReplyDeliveryBarrier } from "./reply-delivery.js";
+import { logTypingFailure } from "./runtime-api.js";
+
+type MattermostEventPlanParams = {
+  channelId: string;
+  senderId: string;
+  postId?: string | null;
+  threadRootId?: string | null;
+  channelInfo?: MattermostChannel | null;
+  channelTypeFallback?: string | null;
+  teamId?: string | null;
+  channelName?: string | null;
+  channelDisplay?: string | null;
+  dropLabel: string;
+};
+
+export async function buildMattermostEventPlan(
+  monitor: MattermostMonitorContext,
+  params: MattermostEventPlanParams,
+) {
+  // Gather transport metadata once, normalize its optional labels, then decide
+  // the route/thread identity every event consumer must share.
+  const channelInfo =
+    params.channelInfo ?? (await monitor.resources.resolveChannelInfo(params.channelId));
+  const channelType = channelInfo?.type?.trim() || params.channelTypeFallback?.trim();
+  if (!channelType) {
+    monitor.logVerboseMessage(
+      `mattermost: drop ${params.dropLabel} (cannot resolve channel type for ${params.channelId})`,
+    );
+    return null;
+  }
+  const kind = resolveMattermostTrustedChatKind({ channelType });
+  const teamId = params.teamId ?? channelInfo?.team_id ?? undefined;
+  const channelName = params.channelName ?? channelInfo?.name ?? "";
+  const channelDisplay = params.channelDisplay ?? channelInfo?.display_name ?? channelName;
+  const roomLabel = channelName ? `#${channelName}` : channelDisplay || `#${params.channelId}`;
+  const route = monitor.core.channel.routing.resolveAgentRoute({
+    cfg: monitor.cfg,
+    channel: "mattermost",
+    accountId: monitor.account.accountId,
+    teamId,
+    peer: {
+      kind,
+      id: kind === "direct" ? params.senderId : params.channelId,
+    },
+  });
+  const thread = resolveMattermostThreadSessionContext({
+    baseSessionKey: route.sessionKey,
+    kind,
+    postId: params.postId,
+    replyToMode: resolveMattermostReplyToMode(monitor.account, kind),
+    threadRootId: params.threadRootId,
+  });
+  const to = kind === "direct" ? `user:${params.senderId}` : `channel:${params.channelId}`;
+
+  return {
+    channelId: params.channelId,
+    senderId: params.senderId,
+    channelInfo,
+    kind,
+    teamId,
+    channelName,
+    channelDisplay,
+    roomLabel,
+    route,
+    thread,
+    to,
+    finalizeContext: <T extends Record<string, unknown>>(context: T) =>
+      finalizeInboundContext({
+        ...context,
+        From:
+          kind === "direct"
+            ? `mattermost:${params.senderId}`
+            : kind === "group"
+              ? `mattermost:group:${params.channelId}`
+              : `mattermost:channel:${params.channelId}`,
+        To: to,
+        SessionKey: thread.sessionKey,
+        DmScope: route.dmScope,
+        ParentSessionKey: thread.parentSessionKey,
+        AccountId: route.accountId,
+        ChatType: kind,
+        GroupChannel: channelName ? `#${channelName}` : undefined,
+        GroupSpace: teamId,
+        SenderId: params.senderId,
+        Provider: "mattermost" as const,
+        Surface: "mattermost" as const,
+        ReplyToId: thread.effectiveReplyToId,
+        MessageThreadId: thread.effectiveReplyToId,
+        OriginatingChannel: "mattermost" as const,
+        OriginatingTo: to,
+      }),
+    createReplyPlan: () => {
+      const deliveryBarrier = createMattermostReplyDeliveryBarrier({
+        isDirect: kind === "direct",
+        dmRetryOptions: monitor.account.config.dmChannelRetry,
+      });
+      return {
+        textLimit: monitor.core.channel.text.resolveTextChunkLimit(
+          monitor.cfg,
+          "mattermost",
+          monitor.account.accountId,
+          { fallbackLimit: monitor.account.textChunkLimit ?? 4000 },
+        ),
+        tableMode: monitor.core.channel.text.resolveMarkdownTableMode({
+          cfg: monitor.cfg,
+          channel: "mattermost",
+          accountId: monitor.account.accountId,
+        }),
+        deliveryBarrier,
+        replyPipeline: {
+          typing: {
+            start: () =>
+              monitor.resources.sendTypingIndicator(params.channelId, thread.effectiveReplyToId),
+            onStartError: (error: unknown) => {
+              logTypingFailure({
+                log: monitor.logDebugMessage,
+                channel: "mattermost",
+                target: params.channelId,
+                error,
+              });
+            },
+          },
+        },
+        replyOptions: {
+          disableBlockStreaming:
+            typeof monitor.account.blockStreaming === "boolean"
+              ? !monitor.account.blockStreaming
+              : undefined,
+        },
+      };
+    },
+  };
+}
+
+export type MattermostEventPlan = NonNullable<Awaited<ReturnType<typeof buildMattermostEventPlan>>>;

--- a/extensions/mattermost/src/mattermost/monitor-interactions.ts
+++ b/extensions/mattermost/src/mattermost/monitor-interactions.ts
@@ -1,25 +1,17 @@
 // Mattermost plugin module registers interactive callback transport handling.
 import { resolveHumanDelayConfig } from "openclaw/plugin-sdk/agent-runtime";
-import { finalizeInboundContext } from "openclaw/plugin-sdk/reply-runtime";
-import { resolveMattermostReplyToMode } from "./accounts.js";
 import { createMattermostInteractionHandler } from "./interactions.js";
-import {
-  authorizeMattermostCommandInvocation,
-  mapMattermostChannelTypeToChatType,
-} from "./monitor-auth.js";
-import {
-  resolveMattermostReplyRootId,
-  resolveMattermostThreadSessionContext,
-} from "./monitor-context.js";
+import { authorizeMattermostCommandInvocation } from "./monitor-auth.js";
+import { resolveMattermostReplyRootId } from "./monitor-context.js";
+import { buildMattermostEventPlan } from "./monitor-event-plan.js";
 import type { MattermostModelPickerInteractionHandler } from "./monitor-model-picker.js";
 import type { MattermostMonitorContext } from "./monitor-types.js";
 import {
-  createMattermostReplyDeliveryBarrier,
   deliverMattermostReplyPayload,
   toMattermostChannelDeliveryResult,
 } from "./reply-delivery.js";
 import type { ReplyPayload } from "./runtime-api.js";
-import { logTypingFailure, registerPluginHttpRoute } from "./runtime-api.js";
+import { registerPluginHttpRoute } from "./runtime-api.js";
 import { sendMessageMattermost } from "./send.js";
 
 export function registerMattermostInteractions(params: {
@@ -30,7 +22,7 @@ export function registerMattermostInteractions(params: {
 }): (() => void) | undefined {
   const { monitor } = params;
   const { account, botUserId, cfg, client, core, pairing, resources, runtime } = monitor;
-  const { resolveChannelInfo, sendTypingIndicator } = resources;
+  const { resolveChannelInfo } = resources;
   return registerPluginHttpRoute({
     path: params.interactionPath,
     fallbackPath: "/mattermost/interactions/default",
@@ -75,112 +67,45 @@ export function registerMattermostInteractions(params: {
         };
       },
       resolveSessionKey: async ({ channelId, userId, post }) => {
-        const channelInfo = await resolveChannelInfo(channelId);
-        if (!channelInfo?.type) {
-          monitor.logVerboseMessage(
-            `mattermost: drop interaction session event (cannot resolve channel type for ${channelId})`,
-          );
+        const eventPlan = await buildMattermostEventPlan(monitor, {
+          channelId,
+          senderId: userId,
+          postId: post.id,
+          threadRootId: post.root_id,
+          dropLabel: "interaction session event",
+        });
+        if (!eventPlan) {
           throw new Error("Mattermost channel type could not be resolved");
         }
-        const kind = mapMattermostChannelTypeToChatType(channelInfo.type);
-        const route = core.channel.routing.resolveAgentRoute({
-          cfg,
-          channel: "mattermost",
-          accountId: account.accountId,
-          teamId: channelInfo.team_id ?? undefined,
-          peer: {
-            kind,
-            id: kind === "direct" ? userId : channelId,
-          },
-        });
-        return resolveMattermostThreadSessionContext({
-          baseSessionKey: route.sessionKey,
-          kind,
-          postId: post.id || undefined,
-          replyToMode: resolveMattermostReplyToMode(account, kind),
-          threadRootId: post.root_id,
-        }).sessionKey;
+        return eventPlan.thread.sessionKey;
       },
       dispatchButtonClick: async (button) => {
-        const channelInfo = await resolveChannelInfo(button.channelId);
-        if (!channelInfo?.type) {
-          monitor.logVerboseMessage(
-            `mattermost: drop interaction dispatch (cannot resolve channel type for ${button.channelId})`,
-          );
+        const eventPlan = await buildMattermostEventPlan(monitor, {
+          channelId: button.channelId,
+          senderId: button.userId,
+          postId: button.post.id || button.postId,
+          threadRootId: button.post.root_id,
+          dropLabel: "interaction dispatch",
+        });
+        if (!eventPlan) {
           return;
         }
-        const kind = mapMattermostChannelTypeToChatType(channelInfo.type);
-        const teamId = channelInfo.team_id ?? undefined;
-        const channelName = channelInfo.name ?? undefined;
-        const channelDisplay = channelInfo.display_name ?? channelName ?? button.channelId;
-        const route = core.channel.routing.resolveAgentRoute({
-          cfg,
-          channel: "mattermost",
-          accountId: account.accountId,
-          teamId,
-          peer: {
-            kind,
-            id: kind === "direct" ? button.userId : button.channelId,
-          },
-        });
-        const threadContext = resolveMattermostThreadSessionContext({
-          baseSessionKey: route.sessionKey,
-          kind,
-          postId: button.post.id || button.postId,
-          replyToMode: resolveMattermostReplyToMode(account, kind),
-          threadRootId: button.post.root_id,
-        });
-        const to = kind === "direct" ? `user:${button.userId}` : `channel:${button.channelId}`;
+        const { channelDisplay, kind, route, thread, to } = eventPlan;
         const bodyText = `[Button click: user @${button.userName} selected "${button.actionName}"]`;
-        const ctxPayload = finalizeInboundContext({
+        const ctxPayload = eventPlan.finalizeContext({
           Body: bodyText,
           BodyForAgent: bodyText,
           RawBody: bodyText,
           CommandBody: bodyText,
-          From:
-            kind === "direct"
-              ? `mattermost:${button.userId}`
-              : kind === "group"
-                ? `mattermost:group:${button.channelId}`
-                : `mattermost:channel:${button.channelId}`,
-          To: to,
-          SessionKey: threadContext.sessionKey,
-          DmScope: route.dmScope,
-          ParentSessionKey: threadContext.parentSessionKey,
-          AccountId: route.accountId,
-          ChatType: kind,
           ConversationLabel: `mattermost:${button.userName}`,
-          GroupSubject: kind !== "direct" ? channelDisplay : undefined,
-          GroupChannel: channelName ? `#${channelName}` : undefined,
-          GroupSpace: teamId,
+          GroupSubject: kind !== "direct" ? channelDisplay || button.channelId : undefined,
           SenderName: button.userName,
-          SenderId: button.userId,
-          Provider: "mattermost" as const,
-          Surface: "mattermost" as const,
           MessageSid: `interaction:${button.postId}:${button.actionId}`,
-          ReplyToId: threadContext.effectiveReplyToId,
-          MessageThreadId: threadContext.effectiveReplyToId,
           WasMentioned: true,
           CommandAuthorized: false,
-          OriginatingChannel: "mattermost" as const,
-          OriginatingTo: to,
         });
-
-        const textLimit = core.channel.text.resolveTextChunkLimit(
-          cfg,
-          "mattermost",
-          account.accountId,
-          { fallbackLimit: account.textChunkLimit ?? 4000 },
-        );
-        const tableMode = core.channel.text.resolveMarkdownTableMode({
-          cfg,
-          channel: "mattermost",
-          accountId: account.accountId,
-        });
-        const deliveryBarrier = createMattermostReplyDeliveryBarrier({
-          isDirect: kind === "direct",
-          dmRetryOptions: account.config.dmChannelRetry,
-        });
+        const { deliveryBarrier, replyOptions, replyPipeline, tableMode, textLimit } =
+          eventPlan.createReplyPlan();
         await core.channel.inbound.dispatch({
           cfg,
           channel: "mattermost",
@@ -188,7 +113,7 @@ export function registerMattermostInteractions(params: {
           route: {
             agentId: route.agentId,
             dmScope: route.dmScope,
-            sessionKey: threadContext.sessionKey,
+            sessionKey: thread.sessionKey,
           },
           ctxPayload,
           delivery: {
@@ -203,7 +128,7 @@ export function registerMattermostInteractions(params: {
                   agentId: route.agentId,
                   replyToId: resolveMattermostReplyRootId({
                     kind,
-                    threadRootId: threadContext.effectiveReplyToId,
+                    threadRootId: thread.effectiveReplyToId,
                     replyToId: payload.replyToId,
                   }),
                   textLimit,
@@ -221,28 +146,13 @@ export function registerMattermostInteractions(params: {
               runtime.error?.(`mattermost button-click ${info.kind} reply failed: ${String(err)}`);
             },
           },
-          replyPipeline: {
-            typing: {
-              start: () => sendTypingIndicator(button.channelId, threadContext.effectiveReplyToId),
-              onStartError: (err) => {
-                logTypingFailure({
-                  log: monitor.logDebugMessage,
-                  channel: "mattermost",
-                  target: button.channelId,
-                  error: err,
-                });
-              },
-            },
-          },
+          replyPipeline,
           dispatcherOptions: {
             resolveFollowupAdmissionBarrierTimeoutPolicy: deliveryBarrier.resolveTimeoutPolicy,
             onDeliverySettled: deliveryBarrier.markDeliverySettled,
             humanDelay: resolveHumanDelayConfig(cfg, route.agentId),
           },
-          replyOptions: {
-            disableBlockStreaming:
-              typeof account.blockStreaming === "boolean" ? !account.blockStreaming : undefined,
-          },
+          replyOptions,
         });
       },
       log: (message) => runtime.log?.(message),

--- a/extensions/mattermost/src/mattermost/monitor-model-picker.ts
+++ b/extensions/mattermost/src/mattermost/monitor-model-picker.ts
@@ -1,7 +1,4 @@
 // Mattermost plugin module owns native model-picker interactions.
-import { finalizeInboundContext } from "openclaw/plugin-sdk/reply-runtime";
-import type { ResolvedAgentRoute } from "openclaw/plugin-sdk/routing";
-import { resolveMattermostReplyToMode } from "./accounts.js";
 import type { MattermostPost } from "./client.js";
 import type { MattermostInteractionResponse } from "./interactions.js";
 import {
@@ -15,34 +12,23 @@ import { authorizeMattermostCommandInvocation } from "./monitor-auth.js";
 import {
   buildMattermostModelPickerSelectMessageSid,
   resolveMattermostReplyRootId,
-  resolveMattermostThreadSessionContext,
 } from "./monitor-context.js";
+import { buildMattermostEventPlan, type MattermostEventPlan } from "./monitor-event-plan.js";
 import type { MattermostMonitorContext } from "./monitor-types.js";
 import {
-  createMattermostReplyDeliveryBarrier,
   deliverMattermostReplyPayload,
   toMattermostChannelDeliveryResult,
 } from "./reply-delivery.js";
-import type { ChatType, ReplyPayload } from "./runtime-api.js";
-import { buildModelsProviderData, logTypingFailure } from "./runtime-api.js";
+import type { ReplyPayload } from "./runtime-api.js";
+import { buildModelsProviderData } from "./runtime-api.js";
 import { sendMessageMattermost } from "./send.js";
 
 type RunModelPickerCommandParams = {
   commandText: string;
   commandAuthorized: boolean;
-  route: ResolvedAgentRoute;
-  sessionKey: string;
-  parentSessionKey?: string;
-  channelId: string;
-  senderId: string;
+  eventPlan: MattermostEventPlan;
   senderName: string;
-  kind: ChatType;
-  channelName?: string;
-  channelDisplay?: string;
-  roomLabel: string;
-  teamId?: string;
   messageSid: string;
-  effectiveReplyToId?: string;
 };
 
 export type MattermostModelPickerInteractionHandler = (params: {
@@ -61,74 +47,38 @@ export function createMattermostModelPickerInteractionHandler(
   monitor: MattermostMonitorContext,
 ): MattermostModelPickerInteractionHandler {
   const { account, cfg, core, pairing, resources, runtime } = monitor;
-  const { resolveChannelInfo, sendTypingIndicator, updateModelPickerPost } = resources;
+  const { resolveChannelInfo, updateModelPickerPost } = resources;
 
   const runModelPickerCommand = async (params: RunModelPickerCommandParams): Promise<void> => {
-    const to = params.kind === "direct" ? `user:${params.senderId}` : `channel:${params.channelId}`;
+    const { channelDisplay, kind, roomLabel, route, thread, to } = params.eventPlan;
     const fromLabel =
-      params.kind === "direct"
+      kind === "direct"
         ? `Mattermost DM from ${params.senderName}`
-        : `Mattermost message in ${params.roomLabel} from ${params.senderName}`;
-    const ctxPayload = finalizeInboundContext({
+        : `Mattermost message in ${roomLabel} from ${params.senderName}`;
+    const ctxPayload = params.eventPlan.finalizeContext({
       Body: params.commandText,
       BodyForAgent: params.commandText,
       RawBody: params.commandText,
       CommandBody: params.commandText,
-      From:
-        params.kind === "direct"
-          ? `mattermost:${params.senderId}`
-          : params.kind === "group"
-            ? `mattermost:group:${params.channelId}`
-            : `mattermost:channel:${params.channelId}`,
-      To: to,
-      SessionKey: params.sessionKey,
-      DmScope: params.route.dmScope,
-      ParentSessionKey: params.parentSessionKey,
-      AccountId: params.route.accountId,
-      ChatType: params.kind,
       ConversationLabel: fromLabel,
-      GroupSubject:
-        params.kind !== "direct" ? params.channelDisplay || params.roomLabel : undefined,
-      GroupChannel: params.channelName ? `#${params.channelName}` : undefined,
-      GroupSpace: params.teamId,
+      GroupSubject: kind !== "direct" ? channelDisplay || roomLabel : undefined,
       SenderName: params.senderName,
-      SenderId: params.senderId,
-      Provider: "mattermost" as const,
-      Surface: "mattermost" as const,
       MessageSid: params.messageSid,
-      ReplyToId: params.effectiveReplyToId,
-      MessageThreadId: params.effectiveReplyToId,
       Timestamp: Date.now(),
       WasMentioned: true,
       CommandAuthorized: params.commandAuthorized,
       CommandSource: "native" as const,
-      OriginatingChannel: "mattermost" as const,
-      OriginatingTo: to,
     });
-
-    const tableMode = core.channel.text.resolveMarkdownTableMode({
-      cfg,
-      channel: "mattermost",
-      accountId: account.accountId,
-    });
-    const textLimit = core.channel.text.resolveTextChunkLimit(
-      cfg,
-      "mattermost",
-      account.accountId,
-      { fallbackLimit: account.textChunkLimit ?? 4000 },
-    );
-    const deliveryBarrier = createMattermostReplyDeliveryBarrier({
-      isDirect: params.kind === "direct",
-      dmRetryOptions: account.config.dmChannelRetry,
-    });
+    const { deliveryBarrier, replyOptions, replyPipeline, tableMode, textLimit } =
+      params.eventPlan.createReplyPlan();
     await core.channel.inbound.dispatch({
       cfg,
       channel: "mattermost",
       accountId: account.accountId,
       route: {
-        agentId: params.route.agentId,
-        dmScope: params.route.dmScope,
-        sessionKey: params.sessionKey,
+        agentId: route.agentId,
+        dmScope: route.dmScope,
+        sessionKey: thread.sessionKey,
       },
       ctxPayload,
       delivery: {
@@ -145,10 +95,10 @@ export function createMattermostModelPickerInteractionHandler(
               payload: trimmedPayload,
               to,
               accountId: account.accountId,
-              agentId: params.route.agentId,
+              agentId: route.agentId,
               replyToId: resolveMattermostReplyRootId({
-                kind: params.kind,
-                threadRootId: params.effectiveReplyToId,
+                kind,
+                threadRootId: thread.effectiveReplyToId,
                 replyToId: trimmedPayload.replyToId,
               }),
               textLimit,
@@ -163,27 +113,12 @@ export function createMattermostModelPickerInteractionHandler(
           runtime.error?.(`mattermost model picker ${info.kind} reply failed: ${String(err)}`);
         },
       },
-      replyPipeline: {
-        typing: {
-          start: () => sendTypingIndicator(params.channelId, params.effectiveReplyToId),
-          onStartError: (err) => {
-            logTypingFailure({
-              log: monitor.logDebugMessage,
-              channel: "mattermost",
-              target: params.channelId,
-              error: err,
-            });
-          },
-        },
-      },
+      replyPipeline,
       dispatcherOptions: {
         resolveFollowupAdmissionBarrierTimeoutPolicy: deliveryBarrier.resolveTimeoutPolicy,
         onDeliverySettled: deliveryBarrier.markDeliverySettled,
       },
-      replyOptions: {
-        disableBlockStreaming:
-          typeof account.blockStreaming === "boolean" ? !account.blockStreaming : undefined,
-      },
+      replyOptions,
     });
   };
 
@@ -252,27 +187,28 @@ export function createMattermostModelPickerInteractionHandler(
       return { ephemeral_text: denyText };
     }
 
-    const { channelDisplay, channelName, kind, roomLabel } = auth;
     const teamId = auth.channelInfo.team_id ?? params.payload.team_id ?? undefined;
-    const route = core.channel.routing.resolveAgentRoute({
-      cfg,
-      channel: "mattermost",
-      accountId: account.accountId,
-      teamId,
-      peer: {
-        kind,
-        id: kind === "direct" ? params.payload.user_id : params.payload.channel_id,
-      },
-    });
-    const threadContext = resolveMattermostThreadSessionContext({
-      baseSessionKey: route.sessionKey,
-      kind,
+    const eventPlan = await buildMattermostEventPlan(monitor, {
+      channelId: params.payload.channel_id,
+      senderId: params.payload.user_id,
       postId: params.post.id || params.payload.post_id,
-      replyToMode: resolveMattermostReplyToMode(account, kind),
       threadRootId: params.post.root_id,
+      channelInfo: auth.channelInfo,
+      teamId,
+      channelName: auth.channelName,
+      channelDisplay: auth.channelDisplay,
+      dropLabel: "model picker event",
     });
-    const modelSessionRoute = { agentId: route.agentId, sessionKey: threadContext.sessionKey };
-    const data = await buildModelsProviderData(cfg, route.agentId);
+    if (!eventPlan) {
+      return {
+        ephemeral_text: "Temporary error: unable to determine channel type. Please try again.",
+      };
+    }
+    const modelSessionRoute = {
+      agentId: eventPlan.route.agentId,
+      sessionKey: eventPlan.thread.sessionKey,
+    };
+    const data = await buildModelsProviderData(cfg, eventPlan.route.agentId);
     if (data.providers.length === 0) {
       return await updatePickerPost("No models available.");
     }
@@ -317,23 +253,13 @@ export function createMattermostModelPickerInteractionHandler(
         await runModelPickerCommand({
           commandText: `/model ${targetModelRef}`,
           commandAuthorized: auth.commandAuthorized,
-          route,
-          sessionKey: threadContext.sessionKey,
-          parentSessionKey: threadContext.parentSessionKey,
-          channelId: params.payload.channel_id,
-          senderId: params.payload.user_id,
+          eventPlan,
           senderName: params.userName,
-          kind,
-          channelName: channelName || undefined,
-          channelDisplay: channelDisplay || channelName || params.payload.channel_id,
-          roomLabel,
-          teamId,
           messageSid: buildMattermostModelPickerSelectMessageSid({
             postId: params.payload.post_id,
             provider: pickerState.provider,
             model: pickerState.model,
           }),
-          effectiveReplyToId: threadContext.effectiveReplyToId,
         });
         const currentModel = resolveMattermostModelPickerCurrentModel({
           cfg,

--- a/extensions/mattermost/src/mattermost/monitor-posts.ts
+++ b/extensions/mattermost/src/mattermost/monitor-posts.ts
@@ -3,7 +3,6 @@ import {
   formatInboundEnvelope,
   implicitMentionKindWhen,
 } from "openclaw/plugin-sdk/channel-inbound";
-import { finalizeInboundContext } from "openclaw/plugin-sdk/reply-runtime";
 import { resolvePinnedMainDmOwnerFromAllowlist } from "openclaw/plugin-sdk/security-runtime";
 import {
   normalizeLowercaseStringOrEmpty,
@@ -12,19 +11,15 @@ import {
   uniqueStrings,
 } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
-import { resolveMattermostReplyToMode } from "./accounts.js";
 import type { MattermostPost } from "./client.js";
 import { resolveMattermostInboundMentionDecision } from "./monitor-activation.js";
 import {
   formatMattermostDirectMessageDropLog,
   normalizeMattermostAllowEntry,
   resolveMattermostMonitorInboundAccess,
-  resolveMattermostTrustedChatKind,
 } from "./monitor-auth.js";
-import {
-  resolveMattermostPendingHistoryKey,
-  resolveMattermostThreadSessionContext,
-} from "./monitor-context.js";
+import { resolveMattermostPendingHistoryKey } from "./monitor-context.js";
+import { buildMattermostEventPlan } from "./monitor-event-plan.js";
 import {
   formatInboundFromLabel,
   normalizeMention,
@@ -51,7 +46,7 @@ import { hasMattermostThreadParticipationWithPersistence } from "./thread-partic
 
 export function createMattermostPostHandler(monitor: MattermostMonitorContext) {
   const { account, botUserId, botUsername, cfg, core, groupPolicy, pairing, resources } = monitor;
-  const { resolveChannelInfo, resolveMattermostMedia, resolveUserInfo } = resources;
+  const { resolveMattermostMedia, resolveUserInfo } = resources;
   const channelHistories = new Map<string, HistoryEntry[]>();
   const historyLimit = Math.max(
     0,
@@ -90,17 +85,21 @@ export function createMattermostPostHandler(monitor: MattermostMonitorContext) {
       return;
     }
 
-    const channelInfo = await resolveChannelInfo(channelId);
-    const channelType =
-      normalizeOptionalString(channelInfo?.type) ??
-      normalizeOptionalString(payload.data?.channel_type);
-    if (!channelType) {
-      monitor.logVerboseMessage(
-        `mattermost: drop post (cannot resolve channel type for ${channelId})`,
-      );
+    const eventPlan = await buildMattermostEventPlan(monitor, {
+      channelId,
+      senderId,
+      postId: post.id,
+      threadRootId: normalizeOptionalString(post.root_id),
+      channelTypeFallback: payload.data?.channel_type,
+      teamId: payload.data?.team_id,
+      channelName: payload.data?.channel_name,
+      channelDisplay: payload.data?.channel_display_name,
+      dropLabel: "post",
+    });
+    if (!eventPlan) {
       return;
     }
-    const kind = resolveMattermostTrustedChatKind({ channelType });
+    const { channelDisplay, kind, roomLabel, route, thread } = eventPlan;
     const senderName =
       normalizeOptionalString(payload.data?.sender_name) ??
       normalizeOptionalString((await resolveUserInfo(senderId))?.username) ??
@@ -202,29 +201,7 @@ export function createMattermostPostHandler(monitor: MattermostMonitorContext) {
       return;
     }
 
-    const teamId = payload.data?.team_id ?? channelInfo?.team_id ?? undefined;
-    const channelName = payload.data?.channel_name ?? channelInfo?.name ?? "";
-    const channelDisplay =
-      payload.data?.channel_display_name ?? channelInfo?.display_name ?? channelName;
-    const roomLabel = channelName ? `#${channelName}` : channelDisplay || `#${channelId}`;
-    const route = core.channel.routing.resolveAgentRoute({
-      cfg,
-      channel: "mattermost",
-      accountId: account.accountId,
-      teamId,
-      peer: {
-        kind,
-        id: kind === "direct" ? senderId : channelId,
-      },
-    });
-    const threadContext = resolveMattermostThreadSessionContext({
-      baseSessionKey: route.sessionKey,
-      kind,
-      postId: post.id,
-      replyToMode: resolveMattermostReplyToMode(account, kind),
-      threadRootId: normalizeOptionalString(post.root_id),
-    });
-    const { effectiveReplyToId, sessionKey, parentSessionKey } = threadContext;
+    const { effectiveReplyToId, sessionKey } = thread;
     const historyKey = resolveMattermostPendingHistoryKey({ kind, sessionKey });
     const fileIds = uniqueStrings(normalizeTrimmedStringList(post.file_ids ?? []));
     const nativeMedia = fileIds.map(() => ({}));
@@ -380,7 +357,6 @@ export function createMattermostPostHandler(monitor: MattermostMonitorContext) {
       });
     }
 
-    const to = kind === "direct" ? `user:${senderId}` : `channel:${channelId}`;
     const commandBody = rawText.trim();
     const inboundHistory =
       historyKey && historyLimit > 0
@@ -389,40 +365,21 @@ export function createMattermostPostHandler(monitor: MattermostMonitorContext) {
             limit: historyLimit,
           })
         : undefined;
-    const ctxPayload = finalizeInboundContext({
+    const ctxPayload = eventPlan.finalizeContext({
       Body: combinedBody,
       BodyForAgent: bodyForAgent,
       InboundHistory: inboundHistory,
       RawBody: commandBody,
       CommandBody: commandBody,
       BodyForCommands: commandBody,
-      From:
-        kind === "direct"
-          ? `mattermost:${senderId}`
-          : kind === "group"
-            ? `mattermost:group:${channelId}`
-            : `mattermost:channel:${channelId}`,
-      To: to,
-      SessionKey: sessionKey,
-      DmScope: route.dmScope,
-      ParentSessionKey: parentSessionKey,
-      AccountId: route.accountId,
-      ChatType: kind,
       ConversationLabel: fromLabel,
       GroupSubject: kind !== "direct" ? channelDisplay || roomLabel : undefined,
-      GroupChannel: channelName ? `#${channelName}` : undefined,
-      GroupSpace: teamId,
       SenderName: senderName,
-      SenderId: senderId,
-      Provider: "mattermost" as const,
-      Surface: "mattermost" as const,
       MessageSid: post.id,
       MessageSids: allMessageIds.length > 1 ? allMessageIds : undefined,
       MessageSidFirst: allMessageIds.length > 1 ? allMessageIds[0] : undefined,
       MessageSidLast:
         allMessageIds.length > 1 ? allMessageIds[allMessageIds.length - 1] : undefined,
-      ReplyToId: effectiveReplyToId,
-      MessageThreadId: effectiveReplyToId,
       Timestamp: typeof post.create_at === "number" ? post.create_at : undefined,
       WasMentioned: kind !== "direct" ? mentionDecision.effectiveWasMentioned : undefined,
       CommandAuthorized: commandAuthorized,
@@ -431,8 +388,6 @@ export function createMattermostPostHandler(monitor: MattermostMonitorContext) {
       // exception in source-reply-delivery-mode.ts surfaces their acknowledgements under
       // message_tool_only delivery modes (e.g. Codex harness DMs). Mirrors iMessage #82642.
       CommandSource: commandAuthorized && isControlCommand ? ("text" as const) : undefined,
-      OriginatingChannel: "mattermost" as const,
-      OriginatingTo: to,
       ...buildMattermostInboundMediaPayload(mediaList),
     });
     const pinnedMainDmOwner =
@@ -452,12 +407,7 @@ export function createMattermostPostHandler(monitor: MattermostMonitorContext) {
       post,
       rawText,
       ctxPayload,
-      kind,
-      route,
-      channelId,
-      senderId,
-      to,
-      effectiveReplyToId,
+      eventPlan,
       historyKey,
       historyLimit,
       channelHistories,

--- a/extensions/mattermost/src/mattermost/monitor-reactions.ts
+++ b/extensions/mattermost/src/mattermost/monitor-reactions.ts
@@ -1,10 +1,8 @@
 // Mattermost plugin module maps reaction transport events into system events.
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
-import {
-  mapMattermostChannelTypeToChatType,
-  resolveMattermostMonitorInboundAccess,
-} from "./monitor-auth.js";
+import { resolveMattermostMonitorInboundAccess } from "./monitor-auth.js";
 import { resolveMattermostReactionChannelId } from "./monitor-context.js";
+import { buildMattermostEventPlan } from "./monitor-event-plan.js";
 import type { MattermostMonitorContext } from "./monitor-types.js";
 import type { MattermostEventPayload } from "./monitor-websocket.js";
 
@@ -12,7 +10,7 @@ type MattermostReaction = { user_id?: string; post_id?: string; emoji_name?: str
 
 export function createMattermostReactionHandler(monitor: MattermostMonitorContext) {
   const { account, botUserId, cfg, core, groupPolicy, pairing, resources } = monitor;
-  const { resolveChannelInfo, resolveUserInfo } = resources;
+  const { resolveUserInfo } = resources;
   return async (payload: MattermostEventPayload) => {
     const reactionData = payload.data?.reaction;
     if (!reactionData) {
@@ -45,15 +43,15 @@ export function createMattermostReactionHandler(monitor: MattermostMonitorContex
       );
       return;
     }
-    const channelInfo = await resolveChannelInfo(channelId);
-    if (!channelInfo?.type) {
-      // Cannot determine channel type — drop to avoid policy bypass.
-      monitor.logVerboseMessage(
-        `mattermost: drop reaction (cannot resolve channel type for ${channelId})`,
-      );
+    const eventPlan = await buildMattermostEventPlan(monitor, {
+      channelId,
+      senderId: userId,
+      dropLabel: "reaction",
+    });
+    if (!eventPlan) {
       return;
     }
-    const kind = mapMattermostChannelTypeToChatType(channelInfo.type);
+    const { kind, route } = eventPlan;
     const reactionAccess = await resolveMattermostMonitorInboundAccess({
       account,
       cfg,
@@ -77,16 +75,6 @@ export function createMattermostReactionHandler(monitor: MattermostMonitorContex
       return;
     }
 
-    const route = core.channel.routing.resolveAgentRoute({
-      cfg,
-      channel: "mattermost",
-      accountId: account.accountId,
-      teamId: channelInfo.team_id ?? undefined,
-      peer: {
-        kind,
-        id: kind === "direct" ? userId : channelId,
-      },
-    });
     const eventText = `Mattermost reaction ${action}: :${emojiName}: by @${senderName} on post ${postId} in channel ${channelId}`;
     core.system.enqueueSystemEvent(eventText, {
       sessionKey: route.sessionKey,

--- a/extensions/mattermost/src/mattermost/monitor-turn.ts
+++ b/extensions/mattermost/src/mattermost/monitor-turn.ts
@@ -7,10 +7,7 @@ import {
   createChannelProgressDraftCompositor,
 } from "openclaw/plugin-sdk/channel-outbound";
 import type { finalizeInboundContext } from "openclaw/plugin-sdk/reply-runtime";
-import {
-  resolveInboundLastRouteSessionKey,
-  type ResolvedAgentRoute,
-} from "openclaw/plugin-sdk/routing";
+import { resolveInboundLastRouteSessionKey } from "openclaw/plugin-sdk/routing";
 import type { MattermostPost } from "./client.js";
 import {
   createMattermostDraftPreviewBoundaryController,
@@ -27,14 +24,12 @@ import {
   deliverMattermostReplyWithDraftPreview,
   type MattermostDraftPreviewState,
 } from "./monitor-draft-delivery.js";
+import type { MattermostEventPlan } from "./monitor-event-plan.js";
 import type { MattermostIngressLifecycle } from "./monitor-ingress.js";
 import type { MattermostMonitorContext } from "./monitor-types.js";
-import {
-  createMattermostReplyDeliveryBarrier,
-  deliverMattermostReplyPayload,
-} from "./reply-delivery.js";
-import type { ChatType, HistoryEntry, ReplyPayload } from "./runtime-api.js";
-import { createChannelMessageReplyPipeline, logTypingFailure } from "./runtime-api.js";
+import { deliverMattermostReplyPayload } from "./reply-delivery.js";
+import type { HistoryEntry, ReplyPayload } from "./runtime-api.js";
+import { createChannelMessageReplyPipeline } from "./runtime-api.js";
 import { sendMessageMattermost } from "./send.js";
 import { recordMattermostThreadParticipation } from "./thread-participation.js";
 
@@ -42,12 +37,7 @@ type MattermostInboundTurnParams = {
   post: MattermostPost;
   rawText: string;
   ctxPayload: ReturnType<typeof finalizeInboundContext>;
-  kind: ChatType;
-  route: ResolvedAgentRoute;
-  channelId: string;
-  senderId: string;
-  to: string;
-  effectiveReplyToId?: string;
+  eventPlan: MattermostEventPlan;
   historyKey: string | null;
   historyLimit: number;
   channelHistories: Map<string, HistoryEntry[]>;
@@ -77,49 +67,34 @@ export async function dispatchMattermostInboundTurn(
   params: MattermostInboundTurnParams,
 ): Promise<void> {
   const { account, cfg, client, core, runtime } = monitor;
-  const { sendTypingIndicator } = monitor.resources;
   const {
     channelHistories,
-    channelId,
     ctxPayload,
-    effectiveReplyToId,
+    eventPlan,
     historyKey,
     historyLimit,
-    kind,
     pinnedMainDmOwner,
     post,
     rawText,
-    route,
-    senderId,
-    to,
     turnAdoptionLifecycle,
   } = params;
-  const textLimit = core.channel.text.resolveTextChunkLimit(cfg, "mattermost", account.accountId, {
-    fallbackLimit: account.textChunkLimit ?? 4000,
-  });
-  const tableMode = core.channel.text.resolveMarkdownTableMode({
-    cfg,
-    channel: "mattermost",
-    accountId: account.accountId,
-  });
+  const { channelId, kind, route, senderId, thread, to } = eventPlan;
+  const { effectiveReplyToId } = thread;
+  const {
+    deliveryBarrier,
+    replyOptions,
+    replyPipeline: baseReplyPipeline,
+    tableMode,
+    textLimit,
+  } = eventPlan.createReplyPlan();
   const chunkMode = core.channel.text.resolveChunkMode(cfg, "mattermost", account.accountId);
-  const { onModelSelected, typingCallbacks, resolveResponsePrefix, ...replyPipeline } =
+  const { onModelSelected, typingCallbacks, resolveResponsePrefix, ...dispatcherPipeline } =
     createChannelMessageReplyPipeline({
       cfg,
       agentId: route.agentId,
       channel: "mattermost",
       accountId: account.accountId,
-      typing: {
-        start: () => sendTypingIndicator(channelId, effectiveReplyToId),
-        onStartError: (err) => {
-          logTypingFailure({
-            log: monitor.logDebugMessage,
-            channel: "mattermost",
-            target: channelId,
-            error: err,
-          });
-        },
-      },
+      typing: baseReplyPipeline.typing,
     });
   const draftPreviewEnabled = account.streamingMode !== "off";
   const draftToolProgressEnabled = shouldUpdateMattermostDraftToolProgress(account);
@@ -257,12 +232,8 @@ export async function dispatchMattermostInboundTurn(
     return boundarySettled;
   };
 
-  const deliveryBarrier = createMattermostReplyDeliveryBarrier({
-    isDirect: kind === "direct",
-    dmRetryOptions: account.config.dmChannelRetry,
-  });
   const dispatcherOptions: NonNullable<ChannelInboundTurnPlan["dispatcherOptions"]> = {
-    ...replyPipeline,
+    ...dispatcherPipeline,
     resolveFollowupAdmissionBarrierTimeoutPolicy: deliveryBarrier.resolveTimeoutPolicy,
     onDeliverySettled: deliveryBarrier.markDeliverySettled,
     humanDelay: resolveHumanDelayConfig(cfg, route.agentId),
@@ -430,11 +401,7 @@ export async function dispatchMattermostInboundTurn(
             onObservedReplyDelivery: draftToolProgressEnabled
               ? () => draftStream.clear()
               : undefined,
-            disableBlockStreaming: draftPreviewEnabled
-              ? true
-              : typeof account.blockStreaming === "boolean"
-                ? !account.blockStreaming
-                : undefined,
+            disableBlockStreaming: draftPreviewEnabled ? true : replyOptions.disableBlockStreaming,
             ...(suppressDefaultToolProgressMessages
               ? { suppressDefaultToolProgressMessages: true }
               : {}),

--- a/extensions/mattermost/src/mattermost/monitor.channel-kind.test-support.ts
+++ b/extensions/mattermost/src/mattermost/monitor.channel-kind.test-support.ts
@@ -1,26 +1,26 @@
 // Mattermost test support covers monitor.channel kind plugin behavior.
 import { describe, expect, it } from "vitest";
-import { mapMattermostChannelTypeToChatType } from "./monitor-auth.js";
+import { resolveMattermostTrustedChatKind } from "./monitor-auth.js";
 
-describe("mapMattermostChannelTypeToChatType", () => {
+describe("resolveMattermostTrustedChatKind", () => {
   it("maps direct and group dm channel types", () => {
-    expect(mapMattermostChannelTypeToChatType("D")).toBe("direct");
-    expect(mapMattermostChannelTypeToChatType("g")).toBe("group");
+    expect(resolveMattermostTrustedChatKind({ channelType: "D" })).toBe("direct");
+    expect(resolveMattermostTrustedChatKind({ channelType: "g" })).toBe("group");
   });
 
   it("maps private channels to group", () => {
-    expect(mapMattermostChannelTypeToChatType("P")).toBe("group");
-    expect(mapMattermostChannelTypeToChatType(" p ")).toBe("group");
+    expect(resolveMattermostTrustedChatKind({ channelType: "P" })).toBe("group");
+    expect(resolveMattermostTrustedChatKind({ channelType: " p " })).toBe("group");
   });
 
   it("keeps public channels and unknown typed values as channel", () => {
-    expect(mapMattermostChannelTypeToChatType("O")).toBe("channel");
-    expect(mapMattermostChannelTypeToChatType("x")).toBe("channel");
+    expect(resolveMattermostTrustedChatKind({ channelType: "O" })).toBe("channel");
+    expect(resolveMattermostTrustedChatKind({ channelType: "x" })).toBe("channel");
   });
 
   it("treats missing channel type as direct", () => {
-    expect(mapMattermostChannelTypeToChatType(undefined)).toBe("direct");
-    expect(mapMattermostChannelTypeToChatType(null)).toBe("direct");
-    expect(mapMattermostChannelTypeToChatType("")).toBe("direct");
+    expect(resolveMattermostTrustedChatKind({ channelType: undefined })).toBe("direct");
+    expect(resolveMattermostTrustedChatKind({ channelType: null })).toBe("direct");
+    expect(resolveMattermostTrustedChatKind({ channelType: "" })).toBe("direct");
   });
 });

--- a/extensions/whatsapp/src/inbound/durable-receive.test.ts
+++ b/extensions/whatsapp/src/inbound/durable-receive.test.ts
@@ -12,7 +12,6 @@ import {
 import {
   createWhatsAppDurableInboundMessageId,
   createWhatsAppIngressMonitor,
-  enqueueWhatsAppDurableInbound,
   type WhatsAppDurableInboundPayload,
 } from "./durable-receive.js";
 
@@ -153,8 +152,8 @@ describe("createWhatsAppIngressMonitor", () => {
       const monitor = createWhatsAppIngressMonitor({
         queue,
         pollIntervalMs: 10,
-        dispatch: async (inbound, _payload, lifecycle) => {
-          const id = inbound.key.id;
+        dispatch: async (inbound, lifecycle) => {
+          const id = inbound.message.key.id;
           if (!id) {
             throw new Error("expected transport id");
           }
@@ -202,7 +201,7 @@ describe("WhatsApp durable message serialization", () => {
     expect(deserializeWhatsAppDurableInboundMessage(serialized).messageTimestamp).toBe(timestamp);
   });
 
-  it("persists receive-time skip decisions", async () => {
+  it("carries receive-time skip decisions through admission and replay", async () => {
     await withTempState(async (stateDir) => {
       const queue = createChannelIngressQueueForTests<WhatsAppDurableInboundPayload>({
         channelId: "whatsapp",
@@ -210,24 +209,46 @@ describe("WhatsApp durable message serialization", () => {
         stateDir,
       });
 
-      await enqueueWhatsAppDurableInbound({
+      const dispatched: Array<{
+        upsertType?: string;
+        skipStaleAppend?: boolean;
+        skipRecentOutboundEcho?: boolean;
+        receiveOrder?: number;
+      }> = [];
+      const monitor = createWhatsAppIngressMonitor({
         queue,
-        message: message("stale-append"),
-        upsertType: "append",
-        skipStaleAppend: true,
-        skipRecentOutboundEcho: true,
-        receivedAt: 1,
+        pollIntervalMs: 10,
+        dispatch: async (admission) => {
+          dispatched.push(admission);
+          return { kind: "completed" };
+        },
       });
-
-      await expect(queue.listPending()).resolves.toMatchObject([
-        {
-          payload: {
+      monitor.start();
+      await expect(
+        monitor.admit(
+          {
+            message: message("stale-append"),
             upsertType: "append",
             skipStaleAppend: true,
             skipRecentOutboundEcho: true,
+            receivedAt: 1,
+            receiveOrder: 7,
           },
-        },
+          { receivedAt: 1 },
+        ),
+      ).resolves.toMatchObject({ kind: "durable", queueResult: { kind: "accepted" } });
+      await monitor.waitForIdle();
+
+      expect(dispatched).toEqual([
+        expect.objectContaining({
+          upsertType: "append",
+          skipStaleAppend: true,
+          skipRecentOutboundEcho: true,
+          receivedAt: 1,
+          receiveOrder: 7,
+        }),
       ]);
+      await monitor.stop();
     });
   });
 });

--- a/extensions/whatsapp/src/inbound/durable-receive.test.ts
+++ b/extensions/whatsapp/src/inbound/durable-receive.test.ts
@@ -1,4 +1,5 @@
 // WhatsApp durable ingress drain adapter: completion, retry, and lane serialization.
+import { createHash } from "node:crypto";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
@@ -9,11 +10,16 @@ import {
   deserializeWhatsAppDurableInboundMessage,
   serializeWhatsAppDurableInboundMessage,
 } from "./durable-payload.js";
-import {
-  createWhatsAppDurableInboundMessageId,
-  createWhatsAppIngressMonitor,
-  type WhatsAppDurableInboundPayload,
-} from "./durable-receive.js";
+import { createWhatsAppIngressMonitor } from "./durable-receive.js";
+
+type WhatsAppDurableInboundPayload = {
+  message: ReturnType<typeof serializeWhatsAppDurableInboundMessage>;
+  upsertType?: string;
+  skipStaleAppend?: boolean;
+  skipRecentOutboundEcho?: boolean;
+  receivedAt: number;
+  receiveOrder?: number;
+};
 
 const REMOTE_JID = "1@s.whatsapp.net";
 
@@ -34,7 +40,7 @@ function message(id: string, remoteJid = REMOTE_JID): WAMessage {
 }
 
 function eventId(id: string, remoteJid = REMOTE_JID): string {
-  return createWhatsAppDurableInboundMessageId({ remoteJid, id });
+  return createHash("sha256").update(`${remoteJid}\n${id}`).digest("hex");
 }
 
 function payload(id: string, remoteJid = REMOTE_JID): WhatsAppDurableInboundPayload {

--- a/extensions/whatsapp/src/inbound/durable-receive.ts
+++ b/extensions/whatsapp/src/inbound/durable-receive.ts
@@ -28,7 +28,7 @@ export type WhatsAppReadReceiptTarget = {
   participant?: string;
 };
 
-export type WhatsAppDurableInboundPayload = {
+type WhatsAppDurableInboundPayload = {
   message: SerializedWhatsAppDurableInboundMessage;
   upsertType?: string;
   skipStaleAppend?: boolean;
@@ -54,7 +54,7 @@ function hashNamespacePart(value: string): string {
   return createHash("sha256").update(value).digest("hex").slice(0, 24);
 }
 
-export function createWhatsAppDurableInboundMessageId(params: {
+function createWhatsAppDurableInboundMessageId(params: {
   remoteJid: string;
   id: string;
 }): string {

--- a/extensions/whatsapp/src/inbound/durable-receive.ts
+++ b/extensions/whatsapp/src/inbound/durable-receive.ts
@@ -54,10 +54,7 @@ function hashNamespacePart(value: string): string {
   return createHash("sha256").update(value).digest("hex").slice(0, 24);
 }
 
-function createWhatsAppDurableInboundMessageId(params: {
-  remoteJid: string;
-  id: string;
-}): string {
+function createWhatsAppDurableInboundMessageId(params: { remoteJid: string; id: string }): string {
   return createHash("sha256").update(`${params.remoteJid}\n${params.id}`).digest("hex");
 }
 

--- a/extensions/whatsapp/src/inbound/durable-receive.ts
+++ b/extensions/whatsapp/src/inbound/durable-receive.ts
@@ -37,6 +37,10 @@ export type WhatsAppDurableInboundPayload = {
   receiveOrder?: number;
 };
 
+export type WhatsAppIngressAdmission = Omit<WhatsAppDurableInboundPayload, "message"> & {
+  message: WAMessage;
+};
+
 export type WhatsAppIngressLifecycle = Omit<ChannelIngressMonitorLifecycle, "admission">;
 
 type WhatsAppIngressDispatchResult = ChannelIngressMonitorDeliveryResult;
@@ -82,34 +86,6 @@ export function createWhatsAppDurableInboundQueue(accountId: string): WhatsAppDu
   });
 }
 
-/** Raw receive chokepoint: append first, then let the drain normalize and dispatch. */
-export async function enqueueWhatsAppDurableInbound(params: {
-  queue: WhatsAppDurableInboundQueue;
-  message: WAMessage;
-  upsertType?: string;
-  skipStaleAppend?: boolean;
-  skipRecentOutboundEcho?: boolean;
-  receivedAt?: number;
-  receiveOrder?: number;
-}) {
-  const facts = inspectWhatsAppIngressMessage(params.message);
-  const receivedAt = params.receivedAt ?? Date.now();
-  return await params.queue.enqueue(
-    facts.eventId,
-    {
-      message: serializeWhatsAppDurableInboundMessage(params.message),
-      upsertType: params.upsertType,
-      ...(params.skipStaleAppend === undefined ? {} : { skipStaleAppend: params.skipStaleAppend }),
-      ...(params.skipRecentOutboundEcho === undefined
-        ? {}
-        : { skipRecentOutboundEcho: params.skipRecentOutboundEcho }),
-      receivedAt,
-      ...(params.receiveOrder === undefined ? {} : { receiveOrder: params.receiveOrder }),
-    },
-    { receivedAt, laneKey: facts.laneKey },
-  );
-}
-
 function resolveWhatsAppIngressNonRetryableFailure(error: unknown) {
   return error instanceof WhatsAppIngressPermanentError
     ? { reason: error.reason, message: error.message }
@@ -120,8 +96,7 @@ function resolveWhatsAppIngressNonRetryableFailure(error: unknown) {
 export function createWhatsAppIngressMonitor(params: {
   queue: WhatsAppDurableInboundQueue;
   dispatch: (
-    message: WAMessage,
-    payload: WhatsAppDurableInboundPayload,
+    admission: WhatsAppIngressAdmission,
     lifecycle: WhatsAppIngressLifecycle,
   ) => Promise<WhatsAppIngressDispatchResult> | WhatsAppIngressDispatchResult;
   onLog?: (message: string) => void;
@@ -131,19 +106,23 @@ export function createWhatsAppIngressMonitor(params: {
   abortSignal?: AbortSignal;
 }) {
   return createChannelIngressMonitor<
-    WAMessage,
+    WhatsAppIngressAdmission,
     WhatsAppDurableInboundPayload,
     WhatsAppDurableInboundPayload
   >({
     queue: params.queue,
-    inspect: (message) => inspectWhatsAppIngressMessage(message),
+    inspect: (admission) => inspectWhatsAppIngressMessage(admission.message),
     payload: {
       version: WHATSAPP_DURABLE_INBOUND_PAYLOAD_VERSION,
-      serialize: (message, { receivedAt }) => ({
-        message: serializeWhatsAppDurableInboundMessage(message),
+      serialize: (admission, { receivedAt }) => ({
+        ...admission,
+        message: serializeWhatsAppDurableInboundMessage(admission.message),
         receivedAt,
       }),
-      deserialize: (payload) => deserializeWhatsAppDurableInboundMessage(payload.message),
+      deserialize: (payload) => ({
+        ...payload,
+        message: deserializeWhatsAppDurableInboundMessage(payload.message),
+      }),
       encode: ({ body }) => body,
       // This shipped queue shape predates the shared envelope. Treat it as v1
       // without rewriting or rejecting durable rows accepted by the beta.
@@ -158,7 +137,7 @@ export function createWhatsAppIngressMonitor(params: {
     },
     // WhatsApp can retain adoption for its debounce/reply lane. Require an explicit
     // outcome so a retained callback cannot fall through to the monitor's terminal default.
-    deliver: (message, lifecycle, claim) => params.dispatch(message, claim.payload, lifecycle),
+    deliver: (admission, lifecycle) => params.dispatch(admission, lifecycle),
     pollIntervalMs: params.pollIntervalMs,
     retention: {
       pruneIntervalMs: WHATSAPP_DURABLE_INBOUND_PRUNE_INTERVAL_MS,

--- a/extensions/whatsapp/src/inbound/monitor.ts
+++ b/extensions/whatsapp/src/inbound/monitor.ts
@@ -1,4 +1,5 @@
 // Whatsapp plugin module implements monitor behavior.
+import { createHash } from "node:crypto";
 import type {
   AnyMessageContent,
   MiscMessageGenerationOptions,
@@ -1127,6 +1128,11 @@ export async function attachWebInboxToSocket(
     return msgTsMs < appendAfterMs;
   };
 
+  // Live rows keep receive-time identity facts until their first drain attempt.
+  // Restart replay has no entry and re-normalizes from the persisted payload.
+  type PreparedInbound = NonNullable<Awaited<ReturnType<typeof normalizeInboundMessage>>>;
+  const preparedInboundByDurableId = new Map<string, Promise<PreparedInbound | null | undefined>>();
+
   type EnrichedInboundMessage = {
     body: string;
     commandBody: string;
@@ -1417,10 +1423,24 @@ export async function attachWebInboxToSocket(
   ): Promise<"completed" | "deferred"> => {
     const { message: msg, ...context } = admission;
     rememberBaileysMessage(msg.key?.remoteJid, msg.key?.id, msg.message);
+    const remoteJid = msg.key?.remoteJid;
+    const id = msg.key?.id;
+    const durableId =
+      remoteJid && id
+        ? createHash("sha256").update(`${remoteJid}\n${id}`).digest("hex")
+        : undefined;
+    const preparation = durableId ? preparedInboundByDurableId.get(durableId) : undefined;
+    if (durableId) {
+      preparedInboundByDurableId.delete(durableId);
+    }
     if (context.skipRecentOutboundEcho === true) {
       return "completed";
     }
-    const inbound = await normalizeInboundMessage(msg);
+    const prepared = await preparation;
+    if (prepared === null) {
+      return "completed";
+    }
+    const inbound = prepared ?? (await normalizeInboundMessage(msg));
     if (!inbound) {
       return "completed";
     }
@@ -1499,6 +1519,37 @@ export async function attachWebInboxToSocket(
       const receivedAt = Date.now();
       const skipStaleAppend = shouldSkipStaleAppend(msg, upsert.type);
       const skipRecentOutboundEcho = shouldSkipRecentOutboundEcho(msg);
+      const remoteJid = msg.key?.remoteJid;
+      const id = msg.key?.id;
+      const durableId =
+        remoteJid && id
+          ? createHash("sha256").update(`${remoteJid}\n${id}`).digest("hex")
+          : undefined;
+      let resolvePrepared: ((inbound: PreparedInbound | null | undefined) => void) | undefined;
+      // A redelivery must not replace the first accepted delivery's preparation.
+      if (durableId && !preparedInboundByDurableId.has(durableId)) {
+        if (preparedInboundByDurableId.size >= 1000) {
+          const oldest = preparedInboundByDurableId.keys().next().value;
+          if (oldest !== undefined) {
+            preparedInboundByDurableId.delete(oldest);
+          }
+        }
+        preparedInboundByDurableId.set(
+          durableId,
+          new Promise((resolve) => {
+            resolvePrepared = resolve;
+          }),
+        );
+      }
+      const finishPreparation = (
+        inbound: PreparedInbound | null | undefined,
+        keepForDrain = false,
+      ) => {
+        resolvePrepared?.(inbound);
+        if (!keepForDrain && durableId && resolvePrepared) {
+          preparedInboundByDurableId.delete(durableId);
+        }
+      };
       let result: Awaited<ReturnType<typeof durableInboundMonitor.admit>>;
       try {
         // Shared admission owns the serialized [0, 100, 300] append retries and
@@ -1515,6 +1566,7 @@ export async function attachWebInboxToSocket(
           { receivedAt },
         );
       } catch (error) {
+        finishPreparation(undefined);
         const formattedError = formatError(error);
         inboundLogger.error(
           { error: formattedError },
@@ -1526,10 +1578,28 @@ export async function attachWebInboxToSocket(
         continue;
       }
       if (result.kind === "durable" && result.queueResult.kind === "completed") {
+        finishPreparation(undefined);
         const inbound = await normalizeInboundMessage(msg);
         if (inbound) {
           await maybeMarkNonSelfChatReadReceipt(inbound, buildReadReceiptTarget(inbound));
         }
+      } else if (result.kind === "durable" && result.queueResult.kind === "accepted") {
+        if (skipRecentOutboundEcho) {
+          finishPreparation(null);
+        } else {
+          try {
+            finishPreparation(await normalizeInboundMessage(msg), true);
+          } catch (error) {
+            finishPreparation(undefined);
+            inboundLogger.warn(
+              { error: formatError(error) },
+              "failed preparing WhatsApp inbound identity; durable drain will normalize again",
+            );
+          }
+        }
+      } else {
+        // Pending redelivery leaves the first accepted delivery's preparation in place.
+        finishPreparation(undefined);
       }
     }
   };

--- a/extensions/whatsapp/src/inbound/monitor.ts
+++ b/extensions/whatsapp/src/inbound/monitor.ts
@@ -60,12 +60,10 @@ import {
 } from "./admission.js";
 import { isRecentOutboundMessage, rememberRecentOutboundMessage } from "./dedupe.js";
 import {
-  createWhatsAppDurableInboundMessageId,
   createWhatsAppDurableInboundQueue,
   createWhatsAppIngressMonitor,
-  enqueueWhatsAppDurableInbound,
-  type WhatsAppDurableInboundPayload,
   type WhatsAppDurableInboundQueue,
+  type WhatsAppIngressAdmission,
   type WhatsAppIngressLifecycle,
   type WhatsAppReadReceiptTarget,
 } from "./durable-receive.js";
@@ -1129,11 +1127,6 @@ export async function attachWebInboxToSocket(
     return msgTsMs < appendAfterMs;
   };
 
-  // Live rows keep receive-time identity facts until their first drain attempt.
-  // Restart replay has no entry and re-normalizes from the persisted payload.
-  type PreparedInbound = NonNullable<Awaited<ReturnType<typeof normalizeInboundMessage>>>;
-  const preparedInboundByDurableId = new Map<string, Promise<PreparedInbound | null | undefined>>();
-
   type EnrichedInboundMessage = {
     body: string;
     commandBody: string;
@@ -1419,30 +1412,15 @@ export async function attachWebInboxToSocket(
   };
 
   const processDurableInboundMessage = async (
-    msg: WAMessage,
-    context: Pick<
-      WhatsAppDurableInboundPayload,
-      "upsertType" | "skipStaleAppend" | "skipRecentOutboundEcho" | "receivedAt" | "receiveOrder"
-    > & {
-      eventId?: string;
-      lifecycle?: WhatsAppIngressLifecycle;
-    },
+    admission: WhatsAppIngressAdmission,
+    lifecycle: WhatsAppIngressLifecycle,
   ): Promise<"completed" | "deferred"> => {
+    const { message: msg, ...context } = admission;
     rememberBaileysMessage(msg.key?.remoteJid, msg.key?.id, msg.message);
     if (context.skipRecentOutboundEcho === true) {
       return "completed";
     }
-    const preparation = context.eventId
-      ? preparedInboundByDurableId.get(context.eventId)
-      : undefined;
-    if (context.eventId) {
-      preparedInboundByDurableId.delete(context.eventId);
-    }
-    const prepared = await preparation;
-    if (prepared === null) {
-      return "completed";
-    }
-    const inbound = prepared ?? (await normalizeInboundMessage(msg));
+    const inbound = await normalizeInboundMessage(msg);
     if (!inbound) {
       return "completed";
     }
@@ -1475,26 +1453,16 @@ export async function attachWebInboxToSocket(
     await enqueueInboundMessage(msg, inbound, enriched, {
       readReceipt: deliveryReadReceipt,
       receiveOrder: context.receiveOrder ?? context.receivedAt,
-      turnAdoptionLifecycle: context.lifecycle,
+      turnAdoptionLifecycle: lifecycle,
     });
     return "deferred";
   };
 
   const durableInboundMonitor = createWhatsAppIngressMonitor({
     queue: durableInboundQueue,
-    dispatch: async (msg, payload, lifecycle) => {
-      const remoteJid = msg.key?.remoteJid;
-      const id = msg.key?.id;
-      return {
-        kind: await processDurableInboundMessage(msg, {
-          ...payload,
-          ...(remoteJid && id
-            ? { eventId: createWhatsAppDurableInboundMessageId({ remoteJid, id }) }
-            : {}),
-          lifecycle,
-        }),
-      };
-    },
+    dispatch: async (admission, lifecycle) => ({
+      kind: await processDurableInboundMessage(admission, lifecycle),
+    }),
     pollIntervalMs: WHATSAPP_INGRESS_DRAIN_INTERVAL_MS,
     onLog: (message) => inboundLogger.warn({ message }, "whatsapp ingress drain"),
     onError: (error) =>
@@ -1531,72 +1499,23 @@ export async function attachWebInboxToSocket(
       const receivedAt = Date.now();
       const skipStaleAppend = shouldSkipStaleAppend(msg, upsert.type);
       const skipRecentOutboundEcho = shouldSkipRecentOutboundEcho(msg);
-      const remoteJid = msg.key?.remoteJid;
-      const id = msg.key?.id;
-      const durableId =
-        remoteJid && id ? createWhatsAppDurableInboundMessageId({ remoteJid, id }) : undefined;
-      let resolvePrepared: ((inbound: PreparedInbound | null | undefined) => void) | undefined;
-      // A redelivery must not clobber the first delivery's in-flight
-      // preparation: the drain consumes exactly one entry per durable id.
-      if (durableId && !preparedInboundByDurableId.has(durableId)) {
-        // Queue pruning caps pending rows, but evicted rows' entries would
-        // linger here forever on a blocked lane; evict oldest-first well above
-        // the queue's own pending cap. Dispatch falls back to re-normalizing
-        // the journaled payload when its entry is gone.
-        if (preparedInboundByDurableId.size >= 1000) {
-          const oldest = preparedInboundByDurableId.keys().next().value;
-          if (oldest !== undefined) {
-            preparedInboundByDurableId.delete(oldest);
-          }
-        }
-        preparedInboundByDurableId.set(
-          durableId,
-          new Promise((resolve) => {
-            resolvePrepared = resolve;
-          }),
-        );
-      }
-      const finishPreparation = (
-        inbound: PreparedInbound | null | undefined,
-        keepForDrain = false,
-      ) => {
-        resolvePrepared?.(inbound);
-        // Only the delivery that installed the entry may remove it; a
-        // duplicate pending delivery (resolvePrepared undefined) must not
-        // delete the first delivery's kept preparation.
-        if (!keepForDrain && durableId && resolvePrepared) {
-          preparedInboundByDurableId.delete(durableId);
-        }
-      };
-      let result: { kind: string } | undefined;
-      let appendError: unknown;
-      // Admission stays local because the prepared-context map needs enqueue's
-      // atomic accepted/pending/completed result; the shared monitor hides it.
-      for (const delayMs of [0, 100, 300]) {
-        if (delayMs > 0) {
-          await new Promise((resolve) => {
-            setTimeout(resolve, delayMs);
-          });
-        }
-        try {
-          result = await enqueueWhatsAppDurableInbound({
-            queue: durableInboundQueue,
+      let result: Awaited<ReturnType<typeof durableInboundMonitor.admit>>;
+      try {
+        // Shared admission owns the serialized [0, 100, 300] append retries and
+        // returns the atomic accepted/pending/completed queue verdict.
+        result = await durableInboundMonitor.admit(
+          {
             message: msg,
             upsertType: upsert.type,
             skipStaleAppend,
             skipRecentOutboundEcho,
             receivedAt,
             receiveOrder,
-          });
-          appendError = undefined;
-          break;
-        } catch (error) {
-          appendError = error;
-        }
-      }
-      if (result === undefined) {
-        finishPreparation(undefined);
-        const formattedError = formatError(appendError);
+          },
+          { receivedAt },
+        );
+      } catch (error) {
+        const formattedError = formatError(error);
         inboundLogger.error(
           { error: formattedError },
           "failed persisting durable WhatsApp inbound after retries; message dropped",
@@ -1606,29 +1525,11 @@ export async function attachWebInboxToSocket(
         );
         continue;
       }
-      if (result.kind === "completed") {
-        finishPreparation(undefined);
+      if (result.kind === "durable" && result.queueResult.kind === "completed") {
         const inbound = await normalizeInboundMessage(msg);
         if (inbound) {
           await maybeMarkNonSelfChatReadReceipt(inbound, buildReadReceiptTarget(inbound));
         }
-      } else {
-        if (result.kind === "accepted") {
-          try {
-            finishPreparation(
-              skipRecentOutboundEcho ? null : await normalizeInboundMessage(msg),
-              true,
-            );
-          } catch (error) {
-            finishPreparation(undefined);
-            throw error;
-          }
-        } else {
-          // "pending": the first delivery owns preparation; resolving without
-          // keepForDrain avoids orphaning a second map entry forever.
-          finishPreparation(undefined);
-        }
-        durableInboundMonitor.requestDrain();
       }
     }
   };

--- a/extensions/whatsapp/src/monitor-inbox.streams-inbound-messages.test-support.ts
+++ b/extensions/whatsapp/src/monitor-inbox.streams-inbound-messages.test-support.ts
@@ -371,7 +371,7 @@ describe("web monitor inbox", () => {
     await listener.close();
   });
 
-  it("keeps the first delivery's prepared entry when a duplicate arrives", async () => {
+  it("keeps the first durable delivery when a duplicate arrives", async () => {
     const onMessage = vi.fn(async () => undefined);
     const { listener, sock } = await startInboxMonitor(onMessage as InboxOnMessage);
     const messageId = nextMessageId("dup-prepared");
@@ -384,8 +384,7 @@ describe("web monitor inbox", () => {
     });
 
     sock.ev.emit("messages.upsert", upsert);
-    // Duplicate delivery of the same message id: its pending verdict must not
-    // delete the first delivery's kept preparation.
+    // Duplicate delivery of the same message id stays pending behind the first claim.
     sock.ev.emit("messages.upsert", upsert);
     await waitForMessageCalls(onMessage, 1);
     await settleInboundWork();


### PR DESCRIPTION
## What Problem This Solves

Mattermost event handling repeated the same routing and reply-planning work across handlers, while WhatsApp durable admission reconstructed facts after persistence instead of carrying the receive-time decision through the queue.

## Why This Change Was Made

This adds one shared Mattermost event-plan builder and routes WhatsApp through the shared durable-admission integration. Prepared routing, context, lifecycle, and admission facts are carried forward rather than rediscovered, while existing retry, dedupe, thread, typing, and delivery contracts remain intact.

AI-assisted; reviewed with the repository autoreview workflow.

## User Impact

No intended visible behavior change. Mattermost events follow the same routing and reply semantics through less duplicated code, and WhatsApp durable delivery preserves receive-time admission decisions consistently across persistence and replay.

## Evidence

- 144 focused Mattermost tests passed.
- 22 durable ingress/admission tests passed.
- Six WhatsApp dedupe/append regression tests passed.
- Blacksmith Testbox branch-wide changed gate passed during preparation.
- Fresh branch autoreview against current `origin/main`: clean, no accepted/actionable findings.
