### PR TITLE
fix(ui): avoid duplicate session refreshes during startup

### DIFF
--- a/ui/src/e2e/codex-sessions.e2e.test.ts
+++ b/ui/src/e2e/codex-sessions.e2e.test.ts
@@ -92,9 +92,7 @@ suite("Codex native session catalog", () => {
     });
 
     await page.goto(`${server.baseUrl}chat`);
-    await expect
-      .poll(async () => (await gateway.getRequests("sessions.catalog.list")).length)
-      .toBeGreaterThan(0);
+    await gateway.waitForRequest("sessions.catalog.list");
     expect(await page.locator('[data-session-section="catalog:codex"]').count()).toBe(0);
     expect(await page.locator('[data-session-section="catalog:claude"]').count()).toBe(0);
     await page.close();

--- a/ui/src/e2e/session-management.sidebar.e2e.test.ts
+++ b/ui/src/e2e/session-management.sidebar.e2e.test.ts
@@ -1,5 +1,6 @@
 import path from "node:path";
 import { expect, it } from "vitest";
+import { expectRequestCountStable } from "./chat-flow.test-support.ts";
 import {
   actionOpacity,
   actionPointerEvents,
@@ -286,17 +287,10 @@ suite.define(() => {
         sessionRow(otherSessionKeys[0], "Other A", Date.parse("2026-07-01T15:59:00.000Z")),
         sessionRow(otherSessionKeys[1], "Other B", Date.parse("2026-07-01T15:58:00.000Z")),
       ]);
-      // Reconnect can queue a second refresh behind session hydration. Hold both
-      // so each response carries the changed black-box fixture.
-      await gateway.deferNext("sessions.list");
       await gateway.resolveDeferred("sessions.list", refreshedResponse);
       await expect.poll(() => sidebarRow.textContent()).toContain("Reconnect refreshed");
       await expect.poll(() => sidebarRows.count()).toBe(3);
-      await expect
-        .poll(async () => (await gateway.getRequests("sessions.list")).length, { timeout: 10_000 })
-        .toBeGreaterThan(firstReconnectListCount);
-      await gateway.resolveDeferred("sessions.list", refreshedResponse);
-      await expect.poll(() => sidebarRow.textContent()).toContain("Reconnect refreshed");
+      await expectRequestCountStable(gateway, "sessions.list", firstReconnectListCount);
     } finally {
       await context.close();
     }

--- a/ui/src/lib/sessions/connection-hydration.test.ts
+++ b/ui/src/lib/sessions/connection-hydration.test.ts
@@ -56,4 +56,62 @@ describe("session connection hydration", () => {
     expect(sessions.state.result).toBe(result);
     sessions.dispose();
   });
+
+  it("ignores same-connection gateway metadata snapshots during hydration", async () => {
+    let resolveList: (result: SessionsListResult) => void = () => undefined;
+    const pendingList = new Promise<SessionsListResult>((resolve) => {
+      resolveList = resolve;
+    });
+    let listCalls = 0;
+    const result: SessionsListResult = {
+      ts: 1,
+      path: "(multiple)",
+      count: 0,
+      defaults: { modelProvider: null, model: null, contextTokens: null },
+      sessions: [],
+    };
+    const request = vi.fn(async (method: string) => {
+      if (method === "sessions.subscribe") {
+        return {};
+      }
+      if (method === "sessions.list") {
+        listCalls += 1;
+        return listCalls === 1 ? await pendingList : result;
+      }
+      throw new Error(`Unexpected request: ${method}`);
+    });
+    const client = { request } as unknown as GatewayBrowserClient;
+    let snapshot = {
+      client: null as GatewayBrowserClient | null,
+      phase: "reconnecting" as "connected" | "reconnecting",
+      sessionKey: "agent:main:main",
+      assistantAgentId: "main" as string | null,
+      hello: null as GatewayHelloOk | null,
+    };
+    let gatewayListener: ((next: typeof snapshot) => void) | undefined;
+    const sessions = createSessionCapability({
+      get snapshot() {
+        return snapshot;
+      },
+      subscribe(listener) {
+        gatewayListener = listener;
+        return () => undefined;
+      },
+      subscribeEvents: () => () => undefined,
+    });
+
+    snapshot = { ...snapshot, client, phase: "connected" };
+    gatewayListener?.(snapshot);
+    await waitForFast(() => expect(listCalls).toBe(1));
+
+    gatewayListener?.({ ...snapshot });
+    gatewayListener?.({ ...snapshot });
+    resolveList(result);
+    await waitForFast(() => expect(sessions.state.result).toBe(result));
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(listCalls).toBe(1);
+    sessions.dispose();
+  });
 });

--- a/ui/src/lib/sessions/connection-hydration.test.ts
+++ b/ui/src/lib/sessions/connection-hydration.test.ts
@@ -87,6 +87,8 @@ describe("session connection hydration", () => {
       sessionKey: "agent:main:main",
       assistantAgentId: "main" as string | null,
       hello: null as GatewayHelloOk | null,
+      canvasPluginSurfaceUrl: null as string | null,
+      selfUser: null as { id: string; name?: string } | null,
     };
     let gatewayListener: ((next: typeof snapshot) => void) | undefined;
     const sessions = createSessionCapability({
@@ -104,14 +106,73 @@ describe("session connection hydration", () => {
     gatewayListener?.(snapshot);
     await waitForFast(() => expect(listCalls).toBe(1));
 
-    gatewayListener?.({ ...snapshot });
-    gatewayListener?.({ ...snapshot });
+    snapshot = { ...snapshot, canvasPluginSurfaceUrl: "https://gateway.example.test/canvas" };
+    gatewayListener?.(snapshot);
+    snapshot = { ...snapshot, selfUser: { id: "operator", name: "Operator" } };
+    gatewayListener?.(snapshot);
     resolveList(result);
     await waitForFast(() => expect(sessions.state.result).toBe(result));
     await Promise.resolve();
     await Promise.resolve();
 
     expect(listCalls).toBe(1);
+    sessions.dispose();
+  });
+
+  it("hydrates again after the current client reconnects", async () => {
+    let listCalls = 0;
+    const result: SessionsListResult = {
+      ts: 1,
+      path: "(multiple)",
+      count: 0,
+      defaults: { modelProvider: null, model: null, contextTokens: null },
+      sessions: [],
+    };
+    const request = vi.fn(async (method: string) => {
+      if (method === "sessions.subscribe") {
+        return {};
+      }
+      if (method === "sessions.list") {
+        listCalls += 1;
+        return result;
+      }
+      throw new Error(`Unexpected request: ${method}`);
+    });
+    const client = { request } as unknown as GatewayBrowserClient;
+    let snapshot = {
+      client,
+      phase: "connected" as "connected" | "reconnecting",
+      sessionKey: "agent:main:main",
+      assistantAgentId: "main" as string | null,
+      hello: null as GatewayHelloOk | null,
+      canvasPluginSurfaceUrl: null as string | null,
+      selfUser: null as { id: string; name?: string } | null,
+    };
+    let gatewayListener: ((next: typeof snapshot) => void) | undefined;
+    const sessions = createSessionCapability({
+      get snapshot() {
+        return snapshot;
+      },
+      subscribe(listener) {
+        gatewayListener = listener;
+        return () => undefined;
+      },
+      subscribeEvents: () => () => undefined,
+    });
+
+    gatewayListener?.(snapshot);
+    await waitForFast(() => expect(listCalls).toBe(1));
+    await waitForFast(() => expect(sessions.state.result).toBe(result));
+
+    snapshot = { ...snapshot, phase: "reconnecting" };
+    gatewayListener?.(snapshot);
+    expect(sessions.state.result).toBeNull();
+
+    snapshot = { ...snapshot, phase: "connected" };
+    gatewayListener?.(snapshot);
+    await waitForFast(() => expect(listCalls).toBe(2));
+    await waitForFast(() => expect(sessions.state.result).toBe(result));
+
     sessions.dispose();
   });
 });

--- a/ui/src/lib/sessions/index.ts
+++ b/ui/src/lib/sessions/index.ts
@@ -1896,7 +1896,8 @@ export function createSessionCapability(gateway: SessionGateway): SessionCapabil
       })();
       return;
     }
-    void refresh();
+    // Gateway snapshots also change for recovery scope, presence, and canvas metadata.
+    // Only a connection transition owns list hydration; refreshing here duplicates startup work.
   });
   const stopEvents = gateway.subscribeEvents((event) => {
     if (isSessionStateEvent(event)) {

--- a/ui/src/lib/sessions/index.ts
+++ b/ui/src/lib/sessions/index.ts
@@ -1894,7 +1894,6 @@ export function createSessionCapability(gateway: SessionGateway): SessionCapabil
           }
         }
       })();
-      return;
     }
     // Gateway snapshots also change for recovery scope, presence, and canvas metadata.
     // Only a connection transition owns list hydration; refreshing here duplicates startup work.

--- a/ui/src/pages/agents/panels-tools-skills.browser.test.ts
+++ b/ui/src/pages/agents/panels-tools-skills.browser.test.ts
@@ -1,8 +1,12 @@
 // Control UI tests cover agents panels tools skills behavior.
 import { render } from "lit";
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
 import type { SkillStatusEntry } from "../../api/types.ts";
 import { renderAgentSkills, renderAgentTools } from "./panels-tools-skills.ts";
+
+afterEach(() => {
+  window.history.replaceState(null, "", `${window.location.pathname}${window.location.search}`);
+});
 
 function createBaseParams(overrides: Partial<Parameters<typeof renderAgentTools>[0]> = {}) {
   return {


### PR DESCRIPTION
Related: #114693

## What Problem This Solves

Fixes an issue where users refreshing the Control UI would trigger a second identical `sessions.list` request during startup. Recovery-scope and Canvas metadata publish additional Gateway snapshots on the same connection; the sessions capability treated each snapshot as a reason to queue another list refresh, adding redundant Gateway work and extending the startup tail.

## Why This Change Was Made

Only Gateway connection transitions now own connection hydration. Same-client, same-phase snapshot updates no longer refresh the session list; reconnects, client replacements, session events, and explicit mutations keep their existing authoritative refresh paths.

This is intentionally scoped to the snapshot trigger rather than adding request caches or hydration handoff state.

## User Impact

Control UI startup now sends one session-list request instead of two in the reproduced refresh path. This removes 50% of the `sessions.list` request count and avoids one redundant tail request per refresh.

## Evidence

Measured against base `d3026c3b9038f8fdd8a444ad1b0f70bd0e35e8f9` (`2026-07-27T15:40:04-06:00`). No session keys, message content, connection IDs, or credentials are included.

### Live browser + Gateway proof

A rebuilt Control UI was served from the exact PR branch while Playwright connected to the live local Gateway. Three page starts used the same browser context.

| Metric | Before | After |
|---|---:|---:|
| `sessions.list` requests per page start | 2 (4/4 samples) | 1 (3/3 samples) |
| Duplicate request duration | median `582 ms`, mean `605 ms` (range `521–735 ms`) | Not issued |

The deterministic comparison is request count: **2 → 1 (-50%)**. The duplicate-duration figures summarize the baseline request that no longer occurs after this change.

Primary-request timings are retained only as diagnostic context. The baseline Gateway durations were `3298 ms`, `3158 ms`, `2426 ms`, and `3214 ms`; the exact-branch browser-observed durations are shown below. They are **not a valid latency A/B comparison** because the captures had different Gateway load, request workloads, and timing boundaries.

Redacted exact-branch output (diagnostic only):

```text
run-1: sessions.list=1; durations_ms=6567
run-2: sessions.list=1; durations_ms=5413
run-3: sessions.list=1; durations_ms=5210
```

### Focused tests

```text
Test Files  22 passed (22)
Tests       169 passed (169)
```

The regression test holds the initial hydration request open, publishes two same-client metadata snapshots, then proves no queued second list request is issued.

### Build and static checks

```text
Control UI build: passed
Precompressed assets: 662 finalized sidecars verified
Startup JS: 8 requests, 272.4 KiB gzip (317.0 KiB limit)
git diff --check: passed
```

### Review

```text
autoreview clean: no accepted/actionable findings
trufflehog: clean
overall: patch is correct (0.91)
```

AI-assisted: yes. I reviewed the final two-file diff, the Gateway snapshot lifecycle, event-owned refresh paths, focused regression proof, and live request-count evidence.

## Maintainer exact-head verification

Verified head: `08dbd1827da0b21b860d4e50b85468b6d7aa8720` on reviewed base `cb167acf5e4`.

Sanitized direct AWS proof used a fresh public-network lease with no Tailscale, no instance role, no hydration, and the trusted untrusted-source bootstrap. The bootstrap verified the exact PR head before executing repository code.

- Session hydration regression suite: 3/3 passed, including metadata-only suppression and same-client reconnect rehydration.
- Targeted Oxlint: 0 warnings, 0 errors across the changed source and test.
- `git diff --check`: passed.
- Fresh exact-base autoreview: clean; no accepted/actionable findings; patch correct at 0.91 confidence.
- Remote proof: https://crabbox.openclaw.ai/portal/runs/run_d830f57332d7

The removed fallback was not a general session-state freshness owner: after a list existed it was already a no-op, and during an in-flight hydration it only queued an unscoped duplicate. Real disconnect/reconnect transitions still clear state and enter the authoritative connection hydration path, now covered explicitly.
