### PR TITLE
fix(models): recognize all IPv4 loopback hosts

### DIFF
--- a/src/agents/provider-local-service.ts
+++ b/src/agents/provider-local-service.ts
@@ -5,6 +5,7 @@
 import { spawn, type ChildProcess } from "node:child_process";
 import { createHash } from "node:crypto";
 import path from "node:path";
+import { isCanonicalDottedDecimalIPv4, isLoopbackIpAddress } from "@openclaw/net-policy/ip";
 import {
   clampPositiveTimerTimeoutMs,
   resolvePositiveTimerTimeoutMs,
@@ -152,7 +153,11 @@ function isLoopbackProviderBaseUrl(value: string): boolean {
     return false;
   }
   const hostname = new URL(normalized).hostname.toLowerCase();
-  return hostname === "localhost" || hostname === "127.0.0.1" || hostname === "[::1]";
+  return (
+    hostname === "localhost" ||
+    hostname === "[::1]" ||
+    (isCanonicalDottedDecimalIPv4(hostname) && isLoopbackIpAddress(hostname))
+  );
 }
 
 function isConfiguredProviderBaseUrl(targetBaseUrl: string, configuredBaseUrl?: string): boolean {

--- a/src/commands/models/list.local-url.ts
+++ b/src/commands/models/list.local-url.ts
@@ -1,3 +1,4 @@
+import { isCanonicalDottedDecimalIPv4, isLoopbackIpAddress } from "@openclaw/net-policy/ip";
 /** Local URL classifier for model provider status/list output. */
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
 
@@ -8,7 +9,7 @@ export const isLocalBaseUrl = (baseUrl: string) => {
     const host = normalizeLowercaseStringOrEmpty(url.hostname).replace(/^\[|\]$/g, "");
     return (
       host === "localhost" ||
-      host === "127.0.0.1" ||
+      (isCanonicalDottedDecimalIPv4(host) && isLoopbackIpAddress(host)) ||
       host === "0.0.0.0" ||
       host === "::" ||
       host === "::1" ||


### PR DESCRIPTION
Follow-up to #114710. Replaces the over-broad, closed #114752 with the bounded core-only correction.

## What Problem This Solves

Fixes an issue where model local-service defaults and `models list` output treated valid IPv4 loopback endpoints such as `127.0.0.2` as remote because they recognized only `127.0.0.1`.

## Why This Change Was Made

Both core classifiers now call the canonical `@openclaw/net-policy/ip` predicates and retain every previously accepted hostname, IPv6, wildcard, and mDNS form. The change intentionally does not add a Plugin SDK API or touch plugin, browser-extension, SSRF, security, config-schema, or native-app surfaces; boundary-blocked sites are being reported separately.

AI-assisted implementation and review.

## User Impact

Operators can use any canonical address in `127.0.0.0/8` for these two model workflows. `127.0.0.2` and `127.255.255.254` are local, while `128.0.0.1` remains remote.

## Evidence

- Blacksmith Testbox `tbx_01kyjrqh2t7mftya32c493p2xx`: https://github.com/openclaw/openclaw/actions/runs/30308262790
- Inline production-path probes verified both range endpoints, the adjacent negative, and all previously accepted aliases.
- 45 adjacent tests passed: provider local-service, model-row, and model-list rows.
- `pnpm check:changed` passed all selected core/type/format/lint/guard lanes.
- `pnpm check:import-cycles`: 0 runtime value cycles.
- `pnpm build`: passed with no `[INEFFECTIVE_DYNAMIC_IMPORT]` warning.
- Fresh Codex autoreview: clean; no accepted/actionable findings.
