### PR TITLE
fix(talk): realtime Talk speaks a no-text placeholder before the real answer

### DIFF
--- a/docs/.generated/config-baseline.counts.json
+++ b/docs/.generated/config-baseline.counts.json
@@ -1,5 +1,5 @@
 {
-  "core": 2306,
+  "core": 2307,
   "channel": 3646,
   "plugin": 3580
 }

--- a/docs/gateway/config-agents.md
+++ b/docs/gateway/config-agents.md
@@ -1476,6 +1476,7 @@ Defaults for Talk mode (macOS/iOS/Android and the browser Control UI).
       vadThreshold: 0.5,
       silenceDurationMs: 500,
       prefixPaddingMs: 300,
+      emptyFinalGraceMs: 60000,
       reasoningEffort: "medium",
       brain: "agent-consult", // agent-consult | direct-tools | none
     },
@@ -1500,6 +1501,7 @@ Defaults for Talk mode (macOS/iOS/Android and the browser Control UI).
 - `realtime.vadThreshold` sets the provider voice-activity threshold from `0` (most sensitive) to `1` (least sensitive). Unset keeps the provider default.
 - `realtime.silenceDurationMs` sets the positive whole-number silence window before the provider commits a realtime user turn. Unset keeps the provider default.
 - `realtime.prefixPaddingMs` sets the non-negative whole-number amount of audio retained before detected speech begins. Unset keeps the provider default.
+- `realtime.emptyFinalGraceMs` sets how long a Control UI realtime consult keeps waiting for real reply text after the run reports an empty final before it answers `"OpenClaw finished with no text."`. Unset keeps the 60000 ms default; `0` answers immediately. Lower it only if you prefer a fast placeholder over slow agent answers, because the placeholder is spoken aloud.
 - `realtime.reasoningEffort` sets the provider-specific reasoning level for realtime sessions. Unset keeps the provider default.
 - `realtime.consultRouting`: `"provider-direct"` (default) preserves direct provider replies when the realtime provider produces a final user transcript without `openclaw_agent_consult`. `"force-agent-consult"` routes the finalized request through OpenClaw instead.
 

--- a/packages/gateway-protocol/src/schema/channels.ts
+++ b/packages/gateway-protocol/src/schema/channels.ts
@@ -569,6 +569,7 @@ const TalkRealtimeConfigSchema = closedObject({
   vadThreshold: Type.Optional(Type.Number({ minimum: 0, maximum: 1 })),
   silenceDurationMs: Type.Optional(Type.Integer({ minimum: 1 })),
   prefixPaddingMs: Type.Optional(Type.Integer({ minimum: 0 })),
+  emptyFinalGraceMs: Type.Optional(Type.Integer({ minimum: 0 })),
   reasoningEffort: Type.Optional(Type.String({ minLength: 1 })),
   brain: Type.Optional(TalkBrainSchema),
   consultRouting: Type.Optional(

--- a/src/config/schema.help.core.ts
+++ b/src/config/schema.help.core.ts
@@ -1,5 +1,8 @@
 // Defines user-facing config field help text for docs and UI surfaces.
-import { describeTalkSilenceTimeoutDefaults } from "./talk-defaults.js";
+import {
+  DEFAULT_TALK_EMPTY_FINAL_GRACE_MS,
+  describeTalkSilenceTimeoutDefaults,
+} from "./talk-defaults.js";
 import { CLOUD_WORKER_FIELD_HELP } from "./zod-schema.cloud-workers.js";
 
 export const CORE_FIELD_HELP: Record<string, string> = {
@@ -197,6 +200,7 @@ export const CORE_FIELD_HELP: Record<string, string> = {
     "Milliseconds of silence before a realtime Talk user turn is committed.",
   "talk.realtime.prefixPaddingMs":
     "Milliseconds of audio retained before realtime voice activity is detected.",
+  "talk.realtime.emptyFinalGraceMs": `Milliseconds a realtime Talk consult keeps waiting for real reply text after an empty final event before it answers "OpenClaw finished with no text." (default: ${DEFAULT_TALK_EMPTY_FINAL_GRACE_MS}). Set 0 to answer immediately.`,
   "talk.realtime.reasoningEffort":
     "Provider-specific reasoning effort for realtime Talk sessions, such as minimal, low, medium, or high.",
   "talk.realtime.brain":

--- a/src/config/schema.labels.ts
+++ b/src/config/schema.labels.ts
@@ -882,6 +882,7 @@ export const FIELD_LABELS: Record<string, string> = {
   "talk.realtime.vadThreshold": "Talk Realtime VAD Threshold",
   "talk.realtime.silenceDurationMs": "Talk Realtime Silence Duration (ms)",
   "talk.realtime.prefixPaddingMs": "Talk Realtime Prefix Padding (ms)",
+  "talk.realtime.emptyFinalGraceMs": "Talk Realtime Empty Final Grace (ms)",
   "talk.realtime.reasoningEffort": "Talk Realtime Reasoning Effort",
   "talk.realtime.brain": "Talk Realtime Brain",
   "talk.realtime.consultRouting": "Talk Realtime Consult Routing",

--- a/src/config/talk-defaults.ts
+++ b/src/config/talk-defaults.ts
@@ -5,6 +5,15 @@ const TALK_SILENCE_TIMEOUT_MS_BY_PLATFORM = {
   ios: 900,
 } as const;
 
+/**
+ * Grace window a realtime Talk consult keeps listening for real final text after an
+ * empty `final` chat event before it answers with the "no text" placeholder. Agent
+ * runs routinely deliver their text tens of seconds after that empty final, and the
+ * placeholder is spoken aloud, so a short window turns every slow answer into a
+ * double reply.
+ */
+export const DEFAULT_TALK_EMPTY_FINAL_GRACE_MS = 60_000;
+
 /** Formats the talk silence defaults for config help text. */
 export function describeTalkSilenceTimeoutDefaults(): string {
   const macos = TALK_SILENCE_TIMEOUT_MS_BY_PLATFORM.macos;

--- a/src/config/talk.normalize.test.ts
+++ b/src/config/talk.normalize.test.ts
@@ -56,6 +56,7 @@ describe("talk normalization", () => {
         vadThreshold: 0.45,
         silenceDurationMs: 650,
         prefixPaddingMs: 250,
+        emptyFinalGraceMs: 30_000,
         reasoningEffort: " low ",
         brain: "agent-consult",
         consultRouting: "force-agent-consult",
@@ -86,6 +87,7 @@ describe("talk normalization", () => {
         vadThreshold: 0.45,
         silenceDurationMs: 650,
         prefixPaddingMs: 250,
+        emptyFinalGraceMs: 30_000,
         reasoningEffort: "low",
         brain: "agent-consult",
         consultRouting: "force-agent-consult",
@@ -100,6 +102,7 @@ describe("talk normalization", () => {
         vadThreshold: 1.5,
         silenceDurationMs: 0,
         prefixPaddingMs: -1,
+        emptyFinalGraceMs: -1,
         reasoningEffort: "   ",
       },
     } as never);

--- a/src/config/talk.ts
+++ b/src/config/talk.ts
@@ -150,6 +150,10 @@ function normalizeTalkRealtimeConfig(value: unknown): TalkRealtimeConfig | undef
   if (prefixPaddingMs !== undefined) {
     normalized.prefixPaddingMs = prefixPaddingMs;
   }
+  const emptyFinalGraceMs = normalizeNonNegativeInteger(source.emptyFinalGraceMs);
+  if (emptyFinalGraceMs !== undefined) {
+    normalized.emptyFinalGraceMs = emptyFinalGraceMs;
+  }
   const reasoningEffort = normalizeOptionalString(source.reasoningEffort);
   if (reasoningEffort) {
     normalized.reasoningEffort = reasoningEffort;

--- a/src/config/types.gateway.ts
+++ b/src/config/types.gateway.ts
@@ -72,6 +72,11 @@ export type TalkRealtimeConfig = {
   silenceDurationMs?: number;
   /** Milliseconds of audio retained before detected speech begins. */
   prefixPaddingMs?: number;
+  /**
+   * Milliseconds a realtime consult keeps waiting for real final text after an
+   * empty `final` chat event before it answers with the no-text placeholder.
+   */
+  emptyFinalGraceMs?: number;
   /** Provider-specific realtime reasoning effort. */
   reasoningEffort?: string;
   /** Tool/agent strategy for realtime sessions. */

--- a/src/config/zod-schema.root-support.ts
+++ b/src/config/zod-schema.root-support.ts
@@ -217,6 +217,7 @@ const TalkRealtimeSchema = z
     vadThreshold: z.number().min(0).max(1).optional(),
     silenceDurationMs: z.number().int().positive().optional(),
     prefixPaddingMs: z.number().int().nonnegative().optional(),
+    emptyFinalGraceMs: z.number().int().nonnegative().optional(),
     reasoningEffort: z.string().min(1).optional(),
     brain: z.enum(["agent-consult", "direct-tools", "none"]).optional(),
     consultRouting: z.enum(["provider-direct", "force-agent-consult"]).optional(),

--- a/src/config/zod-schema.talk.test.ts
+++ b/src/config/zod-schema.talk.test.ts
@@ -15,6 +15,25 @@ describe("OpenClawSchema talk validation", () => {
     expect(result.success).toBe(true);
   });
 
+  it("accepts a non-negative integer talk.realtime.emptyFinalGraceMs", () => {
+    expect(OpenClawSchema.safeParse({ talk: { realtime: { emptyFinalGraceMs: 0 } } }).success).toBe(
+      true,
+    );
+    expect(
+      OpenClawSchema.safeParse({ talk: { realtime: { emptyFinalGraceMs: 60_000 } } }).success,
+    ).toBe(true);
+  });
+
+  it("rejects a negative talk.realtime.emptyFinalGraceMs", () => {
+    expect(() =>
+      OpenClawSchema.parse({
+        talk: {
+          realtime: { emptyFinalGraceMs: -1 },
+        },
+      }),
+    ).toThrow(/emptyFinalGraceMs/i);
+  });
+
   it("rejects invalid talk.consultThinkingLevel", () => {
     expect(() =>
       OpenClawSchema.parse({

--- a/ui/src/pages/chat/realtime-talk-consult.test.ts
+++ b/ui/src/pages/chat/realtime-talk-consult.test.ts
@@ -1,6 +1,7 @@
 /* @vitest-environment jsdom */
 
 import { describe, expect, it, vi } from "vitest";
+import { DEFAULT_TALK_EMPTY_FINAL_GRACE_MS } from "../../../../src/config/talk-defaults.ts";
 import {
   steerRealtimeTalkActiveConsult,
   submitRealtimeTalkConsult,
@@ -12,6 +13,56 @@ function requireFirstMockCall(calls: readonly unknown[][], label: string): unkno
     throw new Error(`expected ${label} call`);
   }
   return call;
+}
+
+/**
+ * Gateway client that answers one consult with an empty `final`, a completed
+ * `agent.wait`, and optionally a later final that carries the real reply text.
+ * Fake timers drive the delays, so callers control the empty-final race.
+ */
+function emptyFinalConsultClient(
+  options: { lateFinalText?: string; lateFinalDelayMs?: number } = {},
+) {
+  let listener: ((event: { event: string; payload?: unknown }) => void) | undefined;
+  const request = vi.fn(async (method: string) => {
+    if (method === "talk.client.toolCall") {
+      window.setTimeout(() => {
+        listener?.({
+          event: "chat",
+          payload: { runId: "run-1", state: "final", message: undefined },
+        });
+        if (options.lateFinalText !== undefined) {
+          window.setTimeout(() => {
+            listener?.({
+              event: "chat",
+              payload: {
+                runId: "run-1",
+                state: "final",
+                message: {
+                  role: "assistant",
+                  provider: "openclaw",
+                  model: "delivery-mirror",
+                  text: options.lateFinalText,
+                },
+              },
+            });
+          }, options.lateFinalDelayMs ?? 0);
+        }
+      }, 0);
+      return { runId: "run-1" };
+    }
+    if (method === "agent.wait") {
+      return { runId: "run-1", status: "ok" };
+    }
+    throw new Error(`unexpected request: ${method}`);
+  });
+  const addEventListener = vi.fn((callback: typeof listener) => {
+    listener = callback;
+    return () => {
+      listener = undefined;
+    };
+  });
+  return { request, addEventListener };
 }
 
 describe("RealtimeTalkSession consult handoff", () => {
@@ -348,52 +399,100 @@ describe("RealtimeTalkSession consult handoff", () => {
   });
 
   it("submits the no-text fallback after an empty final and completed Gateway run", async () => {
-    let listener: ((event: { event: string; payload?: unknown }) => void) | undefined;
-    const request = vi.fn(async (method: string) => {
-      if (method === "talk.client.toolCall") {
-        setImmediate(() => {
-          listener?.({
-            event: "chat",
-            payload: {
-              runId: "run-1",
-              state: "final",
-              message: undefined,
-            },
-          });
-        });
-        return { runId: "run-1" };
-      }
-      if (method === "agent.wait") {
-        return { runId: "run-1", status: "ok" };
-      }
-      throw new Error(`unexpected request: ${method}`);
-    });
-    const addEventListener = vi.fn((callback: typeof listener) => {
-      listener = callback;
-      return () => {
-        listener = undefined;
-      };
-    });
-    const submit = vi.fn();
+    vi.useFakeTimers();
+    try {
+      const { request, addEventListener } = emptyFinalConsultClient();
+      const submit = vi.fn();
 
-    await submitRealtimeTalkConsult({
-      ctx: {
-        client: { request, addEventListener },
-        sessionKey: "agent:main:main",
-        callbacks: {},
-      } as never,
-      callId: "call-1",
-      args: { question: "Check status" },
-      submit,
-    });
+      const consult = submitRealtimeTalkConsult({
+        ctx: {
+          client: { request, addEventListener },
+          sessionKey: "agent:main:main",
+          callbacks: {},
+        } as never,
+        callId: "call-1",
+        args: { question: "Check status" },
+        submit,
+      });
 
-    expect(request).toHaveBeenCalledWith("agent.wait", {
-      runId: "run-1",
-      timeoutMs: 120_000,
-    });
-    expect(submit).toHaveBeenCalledWith("call-1", {
-      result: "OpenClaw finished with no text.",
-    });
+      await vi.advanceTimersByTimeAsync(DEFAULT_TALK_EMPTY_FINAL_GRACE_MS - 1);
+      expect(submit).not.toHaveBeenCalled();
+      await vi.advanceTimersByTimeAsync(1);
+      await consult;
+
+      expect(request).toHaveBeenCalledWith("agent.wait", {
+        runId: "run-1",
+        timeoutMs: 120_000,
+      });
+      expect(submit).toHaveBeenCalledWith("call-1", {
+        result: "OpenClaw finished with no text.",
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("prefers a late final-with-text arriving inside the default empty-final grace window", async () => {
+    vi.useFakeTimers();
+    try {
+      const { request, addEventListener } = emptyFinalConsultClient({
+        lateFinalText: "The slow answer still wins.",
+        lateFinalDelayMs: 30_000,
+      });
+      const submit = vi.fn();
+
+      const consult = submitRealtimeTalkConsult({
+        ctx: {
+          client: { request, addEventListener },
+          sessionKey: "agent:main:main",
+          callbacks: {},
+        } as never,
+        callId: "call-1",
+        args: { question: "Check status" },
+        submit,
+      });
+
+      await vi.advanceTimersByTimeAsync(30_000);
+      await consult;
+
+      expect(submit).toHaveBeenCalledTimes(1);
+      expect(submit).toHaveBeenCalledWith("call-1", {
+        result: "The slow answer still wins.",
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("honors a configured empty-final grace window instead of the default", async () => {
+    vi.useFakeTimers();
+    try {
+      const { request, addEventListener } = emptyFinalConsultClient();
+      const submit = vi.fn();
+
+      const consult = submitRealtimeTalkConsult({
+        ctx: {
+          client: { request, addEventListener },
+          sessionKey: "agent:main:main",
+          callbacks: {},
+          emptyFinalGraceMs: 1_000,
+        } as never,
+        callId: "call-1",
+        args: { question: "Check status" },
+        submit,
+      });
+
+      await vi.advanceTimersByTimeAsync(999);
+      expect(submit).not.toHaveBeenCalled();
+      await vi.advanceTimersByTimeAsync(1);
+      await consult;
+
+      expect(submit).toHaveBeenCalledWith("call-1", {
+        result: "OpenClaw finished with no text.",
+      });
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it.each([

--- a/ui/src/pages/chat/realtime-talk-shared.ts
+++ b/ui/src/pages/chat/realtime-talk-shared.ts
@@ -1,4 +1,5 @@
 // Control UI chat module implements realtime talk shared behavior.
+import { DEFAULT_TALK_EMPTY_FINAL_GRACE_MS } from "../../../../src/config/talk-defaults.js";
 import { REALTIME_VOICE_AGENT_CONSULT_TOOL_NAME } from "../../../../src/talk/agent-consult-tool.js";
 import {
   buildRealtimeVoiceAgentCancelProviderResult,
@@ -121,6 +122,8 @@ export type RealtimeTalkTransportContext = {
   videoDeviceId?: string;
   consultThinkingLevel?: string;
   consultFastMode?: boolean;
+  /** Configured `talk.realtime.emptyFinalGraceMs`; unset uses the shipped default. */
+  emptyFinalGraceMs?: number;
 };
 
 export function createRealtimeTalkEventEmitter(
@@ -225,7 +228,7 @@ type AgentWaitResult = {
   yielded?: boolean;
 };
 
-const EMPTY_FINAL_FALLBACK_GRACE_MS = 500;
+const CONSULT_RESULT_TIMEOUT_MS = 120_000;
 
 function extractTextFromMessage(message: unknown): string {
   if (!message || typeof message !== "object") {
@@ -283,6 +286,7 @@ function waitForChatResult(params: {
   client: GatewayBrowserClient;
   runId: string;
   timeoutMs: number;
+  emptyFinalGraceMs: number;
   emitTalkEvent?: (input: RealtimeTalkEventInput) => void;
   signal?: AbortSignal;
 }): Promise<string> {
@@ -340,9 +344,12 @@ function waitForChatResult(params: {
           if (result?.status === "timeout") {
             return;
           }
+          // The chat listener stays subscribed through this window, so a late
+          // final-with-text still wins the race and the placeholder only reaches
+          // the voice model when the run really produced nothing.
           emptyFinalFallbackTimer = window.setTimeout(() => {
             settleResolve("OpenClaw finished with no text.");
-          }, EMPTY_FINAL_FALLBACK_GRACE_MS);
+          }, params.emptyFinalGraceMs);
         })
         .catch((error: unknown) => {
           settleReject(error instanceof Error ? error : new Error(String(error)));
@@ -602,7 +609,8 @@ export async function submitRealtimeTalkConsult(params: {
     const result = await waitForChatResult({
       client: ctx.client,
       runId,
-      timeoutMs: 120_000,
+      timeoutMs: CONSULT_RESULT_TIMEOUT_MS,
+      emptyFinalGraceMs: ctx.emptyFinalGraceMs ?? DEFAULT_TALK_EMPTY_FINAL_GRACE_MS,
       emitTalkEvent: params.emitTalkEvent,
       signal: params.signal,
     });

--- a/ui/src/pages/chat/realtime-talk.test.ts
+++ b/ui/src/pages/chat/realtime-talk.test.ts
@@ -210,22 +210,28 @@ describe("RealtimeTalkSession", () => {
   });
 
   it("falls back to talk.session.create when gateway-relay is rejected by talk.client.create", async () => {
-    const request = vi
-      .fn()
-      .mockRejectedValueOnce(
-        new Error("talk.client.create is client-owned; use talk.session.create"),
-      )
-      .mockResolvedValueOnce({
-        provider: "example",
-        transport: "gateway-relay",
-        relaySessionId: "relay-1",
-        audio: {
-          inputEncoding: "pcm16",
-          inputSampleRateHz: 24000,
-          outputEncoding: "pcm16",
-          outputSampleRateHz: 24000,
-        },
-      });
+    const request = vi.fn(async (method: string) => {
+      if (method === "talk.client.create") {
+        throw new Error("talk.client.create is client-owned; use talk.session.create");
+      }
+      if (method === "talk.session.create") {
+        return {
+          provider: "example",
+          transport: "gateway-relay",
+          relaySessionId: "relay-1",
+          audio: {
+            inputEncoding: "pcm16",
+            inputSampleRateHz: 24000,
+            outputEncoding: "pcm16",
+            outputSampleRateHz: 24000,
+          },
+        };
+      }
+      if (method === "talk.config") {
+        return {};
+      }
+      throw new Error(`Unexpected request: ${method}`);
+    });
     const session = new RealtimeTalkSession(
       { request } as never,
       "main",
@@ -235,13 +241,13 @@ describe("RealtimeTalkSession", () => {
 
     await session.start();
 
-    expect(request).toHaveBeenNthCalledWith(1, "talk.client.create", {
+    expect(request).toHaveBeenNthCalledWith(2, "talk.client.create", {
       sessionKey: "main",
       provider: "xai",
       transport: "gateway-relay",
       capabilities: ["voice-transcript"],
     });
-    expect(request).toHaveBeenNthCalledWith(2, "talk.session.create", {
+    expect(request).toHaveBeenNthCalledWith(3, "talk.session.create", {
       sessionKey: "main",
       provider: "xai",
       transport: "gateway-relay",
@@ -290,13 +296,13 @@ describe("RealtimeTalkSession", () => {
 
     await session.start();
 
-    expect(request).toHaveBeenNthCalledWith(2, "talk.client.create", {
+    expect(request).toHaveBeenNthCalledWith(3, "talk.client.create", {
       sessionKey: "main",
       provider: "openai",
       transport: "gateway-relay",
       capabilities: ["voice-transcript", "camera-frame"],
     });
-    expect(request).toHaveBeenNthCalledWith(3, "talk.session.create", {
+    expect(request).toHaveBeenNthCalledWith(4, "talk.session.create", {
       sessionKey: "main",
       provider: "openai",
       transport: "gateway-relay",
@@ -326,6 +332,34 @@ describe("RealtimeTalkSession", () => {
     expect(googleInstances).toHaveLength(0);
     expect(relayInstances).toHaveLength(0);
   });
+
+  it.each([
+    { configured: 1234, expected: 1234 },
+    { configured: -1, expected: undefined },
+    { configured: "60000", expected: undefined },
+  ])(
+    "passes configured talk.realtime.emptyFinalGraceMs $configured to the transport",
+    async ({ configured, expected }) => {
+      const request = vi.fn(async (method: string) => {
+        if (method === "talk.config") {
+          return { config: { talk: { realtime: { emptyFinalGraceMs: configured } } } };
+        }
+        return {
+          provider: "openai",
+          voiceSessionId: "voice-1",
+          transport: "webrtc",
+          clientSecret: "secret",
+        };
+      });
+      const session = new RealtimeTalkSession({ request } as never, "main");
+
+      await session.start();
+
+      expect(transportContext(webRtcInstances[0])).toMatchObject({
+        emptyFinalGraceMs: expected,
+      });
+    },
+  );
 
   it("passes launch options to client-owned realtime session creation", async () => {
     const request = vi.fn(async () => ({
@@ -395,7 +429,7 @@ describe("RealtimeTalkSession", () => {
     await session.start();
 
     expect(request).toHaveBeenNthCalledWith(1, "talk.catalog", {});
-    expect(request).toHaveBeenNthCalledWith(2, "talk.client.create", {
+    expect(request).toHaveBeenNthCalledWith(3, "talk.client.create", {
       sessionKey: "main",
       capabilities: ["voice-transcript", "camera-frame"],
     });
@@ -505,7 +539,7 @@ describe("RealtimeTalkSession", () => {
 
     await session.start();
 
-    expect(request).toHaveBeenNthCalledWith(2, "talk.client.create", {
+    expect(request).toHaveBeenNthCalledWith(3, "talk.client.create", {
       sessionKey: "main",
       capabilities: ["voice-transcript"],
     });
@@ -534,8 +568,8 @@ describe("RealtimeTalkSession", () => {
     await expect(session.start()).rejects.toBe(clientError);
 
     expect(request.mock.calls).toEqual([
-      ["talk.client.create", { sessionKey: "main", capabilities: ["voice-transcript"] }],
       ["talk.config", {}],
+      ["talk.client.create", { sessionKey: "main", capabilities: ["voice-transcript"] }],
     ]);
     expect(relayInstances).toHaveLength(0);
   });
@@ -635,8 +669,8 @@ describe("RealtimeTalkSession", () => {
     await expect(session.start()).rejects.toBe(clientError);
 
     expect(request.mock.calls).toEqual([
-      ["talk.client.create", { sessionKey: "main", capabilities: ["voice-transcript"] }],
       ["talk.config", {}],
+      ["talk.client.create", { sessionKey: "main", capabilities: ["voice-transcript"] }],
     ]);
     expect(relayInstances).toHaveLength(0);
   });
@@ -657,8 +691,8 @@ describe("RealtimeTalkSession", () => {
     await expect(session.start()).rejects.toBe(clientError);
 
     expect(request.mock.calls).toEqual([
-      ["talk.client.create", { sessionKey: "main", capabilities: ["voice-transcript"] }],
       ["talk.config", {}],
+      ["talk.client.create", { sessionKey: "main", capabilities: ["voice-transcript"] }],
     ]);
     expect(relayInstances).toHaveLength(0);
   });

--- a/ui/src/pages/chat/realtime-talk.ts
+++ b/ui/src/pages/chat/realtime-talk.ts
@@ -70,10 +70,15 @@ type RealtimeTalkConfigResult = {
     talk?: {
       realtime?: {
         transport?: unknown;
+        emptyFinalGraceMs?: unknown;
       };
     };
   };
 };
+
+function normalizeEmptyFinalGraceMs(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isInteger(value) && value >= 0 ? value : undefined;
+}
 
 function normalizeLaunchTransport(value: unknown): RealtimeTalkLaunchTransport | undefined {
   if (typeof value !== "string") {
@@ -145,6 +150,7 @@ export class RealtimeTalkSession {
   private acceptingTranscripts = false;
   private serverOwnedVoiceSession = false;
   private transcriptWrites: Promise<void> = Promise.resolve();
+  private talkConfigRead: Promise<RealtimeTalkConfigResult> | null = null;
 
   constructor(
     private readonly client: GatewayBrowserClient,
@@ -157,7 +163,10 @@ export class RealtimeTalkSession {
   async start(): Promise<void> {
     this.closed = false;
     this.callbacks.onStatus?.("connecting");
-    const providerVideoCapable = await this.resolveVideoCapability();
+    const [providerVideoCapable, emptyFinalGraceMs] = await Promise.all([
+      this.resolveVideoCapability(),
+      this.resolveEmptyFinalGraceMs(),
+    ]);
     if (this.closed) {
       return;
     }
@@ -207,11 +216,28 @@ export class RealtimeTalkSession {
       videoDeviceId: this.localOptions.videoDeviceId,
       consultThinkingLevel: session.consultThinkingLevel,
       consultFastMode: session.consultFastMode,
+      emptyFinalGraceMs,
     });
     this.callbacks.onVideoCapability?.(
       providerVideoCapable && typeof this.transport.setVideoEnabled === "function",
     );
     await this.transport.start();
+  }
+
+  // One Gateway config read per session: the transport fallback and the consult
+  // empty-final grace window share it instead of re-asking per use.
+  private readTalkConfig(): Promise<RealtimeTalkConfigResult> {
+    this.talkConfigRead ??= this.client.request<RealtimeTalkConfigResult>("talk.config", {});
+    return this.talkConfigRead;
+  }
+
+  private async resolveEmptyFinalGraceMs(): Promise<number | undefined> {
+    try {
+      const result = await this.readTalkConfig();
+      return normalizeEmptyFinalGraceMs(result.config?.talk?.realtime?.emptyFinalGraceMs);
+    } catch {
+      return undefined;
+    }
   }
 
   private async resolveVideoCapability(): Promise<boolean> {
@@ -255,7 +281,7 @@ export class RealtimeTalkSession {
       if (!transport) {
         let result: RealtimeTalkConfigResult;
         try {
-          result = await this.client.request<RealtimeTalkConfigResult>("talk.config", {});
+          result = await this.readTalkConfig();
         } catch {
           throw error;
         }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Control UI realtime Talk users would hear two answers to every
question: Jarvis immediately says "I got an empty response from OpenClaw" / "OpenClaw
finished with no text.", and then 10-30 seconds later speaks the real answer. It
happens on every consult that is not near-instant, and the placeholder is spoken
aloud by the realtime voice model, so it is not something the user can ignore.

## Why This Change Was Made

`waitForChatResult` in `ui/src/pages/chat/realtime-talk-shared.ts` subscribes to
`chat` gateway events for the consult run. When a `final` payload arrives with empty
text it calls `agent.wait`; if that wait is not a timeout it armed a 500 ms grace
timer that resolved the realtime tool call with the `"OpenClaw finished with no text."`
placeholder. The chat listener stays subscribed the whole time, so a genuine
final-with-text still resolves the promise — it just loses the race, because agent
runs routinely deliver their text tens of seconds after that empty final. 500 ms was
far too short for the placeholder to mean "the run really produced nothing".

The grace window is now the configurable `talk.realtime.emptyFinalGraceMs`, defaulting
to `60000` ms (`DEFAULT_TALK_EMPTY_FINAL_GRACE_MS` in `src/config/talk-defaults.ts`).
60 s comfortably covers the observed 10-30 s late finals while staying inside the
120 s consult result timeout, so a slow answer wins the race and the placeholder is
only reached when the run truly produced no text. `0` restores immediate placeholder
behavior for anyone who prefers it.

Wiring follows the existing `talk.realtime.*` siblings (`vadThreshold`,
`silenceDurationMs`, `prefixPaddingMs`): zod schema, gateway-protocol Talk config
schema, `normalizeTalkRealtimeConfig`, config help + label, and docs. The browser
reads it from the `talk.config` surface it already uses for transport fallback; that
read is now memoized once per Talk session and shared by both consumers, so a session
makes at most one `talk.config` request (previously zero or one), and the value is
carried on `RealtimeTalkTransportContext` instead of being rediscovered per consult.

Non-goal: the sibling `timeoutMs: 120_000` consult ceiling stays a constant
(`CONSULT_RESULT_TIMEOUT_MS`). It is an outer safety bound that is not part of this
race, and the repository's config-surface bar argues against adding a second key that
nobody has reported needing.

## User Impact

Realtime Talk answers once. The "OpenClaw finished with no text." reply is now only
spoken when the run genuinely returned nothing, and operators who want a different
tradeoff can set `talk.realtime.emptyFinalGraceMs` (default `60000`, `0` = answer
immediately).

## Evidence

AI-assisted (Claude Code). Local proof on this branch:

- `node scripts/run-vitest.mjs ui/src/pages/chat/realtime-talk-consult.test.ts` — 19 passed.
  New/updated coverage in that file:
  - `prefers a late final-with-text arriving inside the default empty-final grace window`
    — empty `final`, then real text at 30 s: resolves with the real text, `submit`
    called exactly once. **Fails on the old 500 ms window** (verified by temporarily
    setting the default back to 500: `1 failed | 18 passed`), passes with the fix.
  - `submits the no-text fallback after an empty final and completed Gateway run`
    — nothing follows the empty final: no submit at `default - 1` ms, placeholder at
    the full window (converted to fake timers).
  - `honors a configured empty-final grace window instead of the default` — a ctx
    value of 1000 ms is used instead of the default.
- `node scripts/run-vitest.mjs ui/src/pages/chat/realtime-talk.test.ts` — 29 passed,
  including a new table test that the configured `talk.realtime.emptyFinalGraceMs`
  reaches the transport context and that invalid values (negative, string) are dropped.
- `node scripts/run-vitest.mjs ui/src/pages/chat` — 1995 passed, 11 skipped.
- `node scripts/run-vitest.mjs src/config` — 2904 passed (adds normalization +
  zod accept/reject cases for the new key).
- `node scripts/run-vitest.mjs packages/gateway-protocol` — 304 passed.
- `node scripts/run-vitest.mjs src/gateway/server-methods/talk.test.ts` — 57 passed.
- `node scripts/run-tsgo.mjs -p tsconfig.core.json` — clean.
- `node scripts/run-oxlint.mjs src/config ui/src/pages/chat packages/gateway-protocol/src/schema` — clean.
- `oxfmt --check` on the changed files — clean; `node scripts/format-docs.mjs --check` — clean.
- `node --import tsx scripts/generate-base-config-schema.ts --check` — ok.

Notes on pre-existing `main` state in this checkout (unchanged by this PR, verified by
re-running against a stashed tree):

- `tsgo -p tsconfig.ui.json` and the UI test typecheck lane report
  `ui/src/app-session-route-paths.ts(4,8): TS2307: Cannot find module
  '@openclaw/session-url-contract/parse'` — the same single error before and after this
  change (unbuilt workspace package in the local checkout); no new type errors.
- `generate-config-doc-baseline.ts --check` already drifts on `main` for the `channel`
  (stale budget) and `plugin` (grew) counts plus the baseline hash. This PR raises only
  the `core` budget by 1 for the single added key and leaves the unrelated drift alone
  rather than folding a regeneration of someone else's drift into this diff.
