### PR TITLE
refactor(net): extract local one-hop fetch dispatcher

### DIFF
--- a/src/infra/net/fetch-guard.ts
+++ b/src/infra/net/fetch-guard.ts
@@ -14,13 +14,15 @@ import {
   shouldResolveConfiguredLocalOriginManagedProxyBypass,
   type ConfiguredLocalOriginManagedProxyBypass,
 } from "./configured-local-origin-bypass.js";
+import {
+  createLocalOneHopFetchDispatcher,
+  type FetchLike,
+  type OneHopFetchDispatcher,
+  type OneHopFetchRequest,
+} from "./one-hop-fetch-dispatcher.js";
 import { shouldUseEnvHttpProxyForUrl } from "./proxy-env.js";
 import { retainSafeHeadersForCrossOriginRedirect as retainSafeRedirectHeaders } from "./redirect-headers.js";
-import {
-  fetchWithRuntimeDispatcher,
-  isMockedFetch,
-  type DispatcherAwareRequestInit,
-} from "./runtime-fetch.js";
+import { fetchWithRuntimeDispatcher, isMockedFetch } from "./runtime-fetch.js";
 import {
   assertHostnameAllowedWithPolicy,
   closeDispatcher,
@@ -51,8 +53,6 @@ function resolveDispatcherTimeoutMs(fromParams: number | undefined): number | un
   }
   return undefined;
 }
-
-type FetchLike = (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>;
 
 export const GUARDED_FETCH_MODE = {
   STRICT: "strict",
@@ -620,7 +620,7 @@ async function fetchWithSsrFGuardInternal(
         dispatcher = createPinnedDispatcher(pinned, dispatcherPolicy, policyForUrl, timeoutMs);
       }
 
-      const init: DispatcherAwareRequestInit = {
+      const init: OneHopFetchRequest["init"] = {
         ...(currentInit ? { ...currentInit } : {}),
         redirect: "manual",
         ...(dispatcher ? { dispatcher } : {}),
@@ -639,9 +639,13 @@ async function fetchWithSsrFGuardInternal(
       // because the default global fetch path will not honor per-request
       // dispatchers.
       const shouldUseRuntimeFetch = Boolean(dispatcher) && !supportsDispatcherInit;
-      const response = shouldUseRuntimeFetch
-        ? await fetchWithRuntimeDispatcher(parsedUrl.toString(), init)
-        : await defaultFetch(parsedUrl.toString(), init);
+      const oneHopDispatcher: OneHopFetchDispatcher = createLocalOneHopFetchDispatcher(
+        shouldUseRuntimeFetch ? fetchWithRuntimeDispatcher : defaultFetch,
+      );
+      const response = await oneHopDispatcher.dispatch({
+        url: parsedUrl.toString(),
+        init,
+      });
       const capturedByGlobalFetchPatch =
         !shouldUseRuntimeFetch &&
         isAmbientGlobalFetch({

--- a/src/infra/net/one-hop-fetch-dispatcher.test.ts
+++ b/src/infra/net/one-hop-fetch-dispatcher.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it, vi } from "vitest";
+import { createLocalOneHopFetchDispatcher } from "./one-hop-fetch-dispatcher.js";
+
+describe("createLocalOneHopFetchDispatcher", () => {
+  it("delegates one manual-redirect exchange and preserves HTTP responses", async () => {
+    const response = new Response("rate limited", { status: 429 });
+    const fetchImpl = vi.fn().mockResolvedValue(response);
+    const dispatcher = createLocalOneHopFetchDispatcher(fetchImpl);
+    const signal = new AbortController().signal;
+
+    await expect(
+      dispatcher.dispatch({
+        url: "https://public.example/resource",
+        init: {
+          method: "POST",
+          redirect: "manual",
+          signal,
+        },
+      }),
+    ).resolves.toBe(response);
+    expect(fetchImpl).toHaveBeenCalledWith("https://public.example/resource", {
+      method: "POST",
+      redirect: "manual",
+      signal,
+    });
+  });
+
+  it("propagates transport failures unchanged", async () => {
+    const transportError = new Error("socket closed");
+    const dispatcher = createLocalOneHopFetchDispatcher(vi.fn().mockRejectedValue(transportError));
+
+    await expect(
+      dispatcher.dispatch({
+        url: "https://public.example/resource",
+        init: { redirect: "manual" },
+      }),
+    ).rejects.toBe(transportError);
+  });
+});

--- a/src/infra/net/one-hop-fetch-dispatcher.ts
+++ b/src/infra/net/one-hop-fetch-dispatcher.ts
@@ -1,0 +1,22 @@
+import type { DispatcherAwareRequestInit } from "./runtime-fetch.js";
+
+export type OneHopFetchRequest = {
+  url: string;
+  init: DispatcherAwareRequestInit & { redirect: "manual" };
+};
+
+export type OneHopFetchDispatcher = {
+  dispatch: (request: OneHopFetchRequest) => Promise<Response>;
+};
+
+export type FetchLike = (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>;
+
+type LocalOneHopFetch = (url: string, init: OneHopFetchRequest["init"]) => Promise<Response>;
+
+export function createLocalOneHopFetchDispatcher(
+  fetchImpl: LocalOneHopFetch,
+): OneHopFetchDispatcher {
+  return {
+    dispatch: async ({ url, init }) => await fetchImpl(url, init),
+  };
+}


### PR DESCRIPTION
Closes #114772

Supersedes #113513 with only the review-supported local extraction; the
proposed versioned network-guard profile is not included.

## What Problem This Solves

`fetchWithSsrFGuard` currently selects and invokes the concrete fetch
implementation inside the same loop that owns SSRF checks, DNS pinning, proxy
routing, redirects, timeout, and release behavior. This change gives that
physical exchange a narrow internal boundary without moving any security or
redirect authority out of guarded fetch.

## Why This Change Was Made

The patch adds an internal `OneHopFetchRequest` whose redirect mode is fixed to
`"manual"` and extracts the existing local invocation into
`createLocalOneHopFetchDispatcher`. The existing choice between a
caller-provided fetch and `fetchWithRuntimeDispatcher` remains unchanged. No
configuration, plugin API, portable guard profile, credentials, or hosted
execution contract is added.

## User Impact

No intended user-visible behavior change. Existing direct, proxy, pinned-DNS,
redirect, timeout, capture, and error paths continue through the same guarded
fetch owner.

## Evidence

- `node scripts/run-vitest.mjs src/infra/net/one-hop-fetch-dispatcher.test.ts src/infra/net/fetch-guard.ssrf.test.ts` — 101 tests passed.
- `pnpm tsgo:core` — passed.
- Type-aware Oxlint on all three changed TypeScript files — 0 warnings and 0
  errors.
- Oxfmt check on all three changed TypeScript files — passed.
- `git diff --check upstream/main...HEAD` — passed.
- `codex review --base upstream/main` — no actionable regression identified.

## Real behavior proof

Behavior or issue addressed:
The production guarded-fetch redirect loop performs each HTTP exchange through
the extracted local one-hop dispatcher while retaining redirect ownership.

Real environment tested:
Ubuntu 24.04 under WSL2, Node.js 24.15.0, source checkout at
`48fab2d723d0a109ae58e7503e9a54a03ee7389e`, rebased onto upstream `main` at
`dd248759ef565438fdcd74ec0dd5f5412bd13bb0`, with a real ephemeral loopback
HTTP server and production `fetchWithSsrFGuard`.

Exact steps or command run after this patch:

1. Start an ephemeral loopback HTTP server that returns `302 /finish` for
   `/start` and `200 ok` for `/finish`.
2. Invoke production `fetchWithSsrFGuard` for `/start`, allowing only private
   network access for this loopback proof.
3. Read the final response and release the guarded-fetch resources.

Evidence after fix:

```text
{"proof":"o1-one-hop-dispatch","status":200,"finalPath":"/finish","paths":["/start","/finish"],"body":"ok"}
```

Observed result after fix:
The real server received exactly the initial and redirected requests, guarded
fetch returned the final HTTP 200 response, and the final body was `ok`.

What was not tested:
No external proxy or remote connection owner was tested because this PR keeps
only the existing local transport and adds no remote dispatch contract.
