### PR TITLE
improve(sqlite): reuse synchronous prepared statements

### DIFF
--- a/scripts/pr-lib/review.sh
+++ b/scripts/pr-lib/review.sh
@@ -160,7 +160,10 @@ review_artifacts_init() {
   local meta_number head_sha
   meta_number=$(jq -r '.number' .local/pr-meta.json)
   head_sha=$(jq -r '.headRefOid' .local/pr-meta.json)
-  if [ "$meta_number" != "$pr" ] || ! printf '%s' "$head_sha" | rg -q '^[0-9a-f]{40}$'; then
+  # Bash regex, not rg: this guard runs inside fork-PR CI test harnesses on
+  # GitHub-hosted runners without ripgrep, where a missing rg (exit 127) would
+  # misreport a valid head SHA as an identity mismatch.
+  if [ "$meta_number" != "$pr" ] || ! [[ "$head_sha" =~ ^[0-9a-f]{40}$ ]]; then
     echo "Review artifacts init failed: .local/pr-meta.json describes PR #$meta_number at '$head_sha', not PR #$pr. Re-run: scripts/pr review-init $pr"
     exit 1
   fi

--- a/src/config/sessions/session-accessor.sqlite-message-cut.test.ts
+++ b/src/config/sessions/session-accessor.sqlite-message-cut.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { trackSqliteStatementExecutions } from "../../../test/helpers/sqlite-statement-execution-counter.js";
 import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
-import { clearNodeSqliteKyselyCacheForDatabase } from "../../infra/kysely-sync.js";
 import {
   closeOpenClawAgentDatabasesForTest,
   openOpenClawAgentDatabase,
@@ -37,30 +37,13 @@ afterEach(() => {
 
 function trackFullTranscriptLoads(env: NodeJS.ProcessEnv): () => number {
   const database = openOpenClawAgentDatabase({ agentId, env });
-  // Statement caching reuses prepared statements, so prepare-call counting
-  // undercounts; count executions of the transcript query instead. Clear the
-  // cache first so already-cached statements cannot bypass the wrapped prepare.
-  clearNodeSqliteKyselyCacheForDatabase(database.db);
-  let loads = 0;
-  const originalPrepare = database.db.prepare.bind(database.db);
-  vi.spyOn(database.db, "prepare").mockImplementation((sqlText: string) => {
-    const statement = originalPrepare(sqlText);
-    const isFullTranscriptLoad =
-      sqlText.includes('select "event_json" from "transcript_events"') &&
-      sqlText.includes('order by "seq" asc');
-    if (isFullTranscriptLoad) {
-      const originalIterate = statement.iterate.bind(statement) as (
-        ...args: unknown[]
-      ) => ReturnType<typeof statement.iterate>;
-      // iterate is overloaded, so the wrapper forwards untyped and casts back.
-      statement.iterate = ((...args: unknown[]) => {
-        loads += 1;
-        return originalIterate(...args);
-      }) as typeof statement.iterate;
-    }
-    return statement;
-  });
-  return () => loads;
+  const { counts } = trackSqliteStatementExecutions(database.db, ["loads"], (sqlText) =>
+    sqlText.includes('select "event_json" from "transcript_events"') &&
+    sqlText.includes('order by "seq" asc')
+      ? "loads"
+      : null,
+  );
+  return () => counts.loads;
 }
 
 async function createSiblingSession(params: {

--- a/src/config/sessions/session-accessor.sqlite-message-cut.test.ts
+++ b/src/config/sessions/session-accessor.sqlite-message-cut.test.ts
@@ -49,11 +49,14 @@ function trackFullTranscriptLoads(env: NodeJS.ProcessEnv): () => number {
       sqlText.includes('select "event_json" from "transcript_events"') &&
       sqlText.includes('order by "seq" asc');
     if (isFullTranscriptLoad) {
-      const originalIterate = statement.iterate.bind(statement);
-      statement.iterate = (...args: Parameters<typeof originalIterate>) => {
+      const originalIterate = statement.iterate.bind(statement) as (
+        ...args: unknown[]
+      ) => ReturnType<typeof statement.iterate>;
+      // iterate is overloaded, so the wrapper forwards untyped and casts back.
+      statement.iterate = ((...args: unknown[]) => {
         loads += 1;
         return originalIterate(...args);
-      };
+      }) as typeof statement.iterate;
     }
     return statement;
   });

--- a/src/config/sessions/session-accessor.sqlite-message-cut.test.ts
+++ b/src/config/sessions/session-accessor.sqlite-message-cut.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
+import { clearNodeSqliteKyselyCacheForDatabase } from "../../infra/kysely-sync.js";
 import {
   closeOpenClawAgentDatabasesForTest,
   openOpenClawAgentDatabase,
@@ -36,13 +37,27 @@ afterEach(() => {
 
 function trackFullTranscriptLoads(env: NodeJS.ProcessEnv): () => number {
   const database = openOpenClawAgentDatabase({ agentId, env });
-  const prepare = vi.spyOn(database.db, "prepare");
-  return () =>
-    prepare.mock.calls.filter(
-      ([sql]) =>
-        sql.includes('select "event_json" from "transcript_events"') &&
-        sql.includes('order by "seq" asc'),
-    ).length;
+  // Statement caching reuses prepared statements, so prepare-call counting
+  // undercounts; count executions of the transcript query instead. Clear the
+  // cache first so already-cached statements cannot bypass the wrapped prepare.
+  clearNodeSqliteKyselyCacheForDatabase(database.db);
+  let loads = 0;
+  const originalPrepare = database.db.prepare.bind(database.db);
+  vi.spyOn(database.db, "prepare").mockImplementation((sqlText: string) => {
+    const statement = originalPrepare(sqlText);
+    const isFullTranscriptLoad =
+      sqlText.includes('select "event_json" from "transcript_events"') &&
+      sqlText.includes('order by "seq" asc');
+    if (isFullTranscriptLoad) {
+      const originalIterate = statement.iterate.bind(statement);
+      statement.iterate = (...args: Parameters<typeof originalIterate>) => {
+        loads += 1;
+        return originalIterate(...args);
+      };
+    }
+    return statement;
+  });
+  return () => loads;
 }
 
 async function createSiblingSession(params: {

--- a/src/gateway/server.node-pairing-memo.test.ts
+++ b/src/gateway/server.node-pairing-memo.test.ts
@@ -1,5 +1,6 @@
 import { DatabaseSync } from "node:sqlite";
-import { afterAll, beforeAll, describe, expect, test, vi } from "vitest";
+import { afterAll, beforeAll, describe, expect, test } from "vitest";
+import { trackSqliteStatementExecutions } from "../../test/helpers/sqlite-statement-execution-counter.js";
 import { listDevicePairing } from "../infra/device-pairing.js";
 import { requestNodePairing } from "../infra/node-pairing.js";
 import { configureSqliteConnectionPragmas } from "../infra/sqlite-wal.js";
@@ -44,23 +45,25 @@ describe("gateway node pairing memoization", () => {
         });
         await seedNodeDevice("node-list-memo-scan-count");
         const database = openOpenClawStateDatabase();
-        const originalPrepare = database.db.prepare.bind(database.db);
-        const tableSelects = { paired: 0, pending: 0 };
-        const prepareSpy = vi.spyOn(database.db, "prepare").mockImplementation((sql) => {
-          if (sql.includes('from "device_pairing_pending"')) {
-            tableSelects.pending += 1;
-          }
-          if (sql.includes('from "device_pairing_paired"')) {
-            tableSelects.paired += 1;
-          }
-          return originalPrepare(sql);
-        });
+        const { counts: tableSelects, restore } = trackSqliteStatementExecutions(
+          database.db,
+          ["paired", "pending"],
+          (sql) => {
+            if (sql.includes('from "device_pairing_pending"')) {
+              return "pending";
+            }
+            if (sql.includes('from "device_pairing_paired"')) {
+              return "paired";
+            }
+            return null;
+          },
+        );
         try {
           expect((await rpcReq(ws, "node.list", {})).ok).toBe(true);
           expect((await rpcReq(ws, "node.list", {})).ok).toBe(true);
           expect(tableSelects).toEqual({ paired: 1, pending: 1 });
         } finally {
-          prepareSpy.mockRestore();
+          restore();
         }
       } finally {
         ws.close();

--- a/src/infra/kysely-sync.test.ts
+++ b/src/infra/kysely-sync.test.ts
@@ -1,6 +1,7 @@
 // Covers the compile-only Kysely facade used by sync node:sqlite helpers.
-import { DatabaseSync } from "node:sqlite";
-import type { Generated } from "kysely";
+import { spawnSync } from "node:child_process";
+import { constants, DatabaseSync } from "node:sqlite";
+import { sql, type Generated } from "kysely";
 import { afterEach, describe, expect, it } from "vitest";
 import { withTestTimeout } from "../../test/helpers/promise.js";
 import {
@@ -59,6 +60,281 @@ describe("kysely sync helpers", () => {
     ]);
   });
 
+  it("returns identical results while repeated statements move from cold to warm", () => {
+    database = new DatabaseSync(":memory:");
+    database.exec(
+      "create table items (id integer primary key autoincrement, name text not null unique)",
+    );
+    const db = getNodeSqliteKysely<SyncHelperTestDatabase>(database);
+    const prepares = countPrepares(database);
+
+    const insertResults = ["Ada", "Grace", "Lin"].map((name) =>
+      executeSqliteQuerySync(database!, db.insertInto("items").values({ name })),
+    );
+    expect(insertResults).toEqual([
+      { insertId: 1n, numAffectedRows: 1n, rows: [] },
+      { insertId: 2n, numAffectedRows: 1n, rows: [] },
+      { insertId: 3n, numAffectedRows: 1n, rows: [] },
+    ]);
+    expect(prepares.calls()).toBe(2);
+
+    const select = db.selectFrom("items").selectAll().orderBy("id");
+    const expectedRows = [
+      { id: 1, name: "Ada" },
+      { id: 2, name: "Grace" },
+      { id: 3, name: "Lin" },
+    ];
+    expect(executeSqliteQuerySync(database, select).rows).toEqual(expectedRows);
+    expect(executeSqliteQuerySync(database, select).rows).toEqual(expectedRows);
+    expect(executeSqliteQuerySync(database, select).rows).toEqual(expectedRows);
+    expect(prepares.calls()).toBe(4);
+
+    const conflictingInsert = db.insertInto("items").values({ id: 1, name: "Duplicate" });
+    const errors = Array.from({ length: 3 }, () => {
+      try {
+        executeSqliteQuerySync(database!, conflictingInsert);
+        return null;
+      } catch (error) {
+        expect(error).toBeInstanceOf(Error);
+        return { message: (error as Error).message, name: (error as Error).name };
+      }
+    });
+    expect(errors[0]).not.toBeNull();
+    expect(errors[1]).toEqual(errors[0]);
+    expect(errors[2]).toEqual(errors[0]);
+    expect(prepares.calls()).toBe(6);
+  });
+
+  it("admits only repeated SQL and bounds the prepared statement working set", () => {
+    database = new DatabaseSync(":memory:");
+    database.exec("create table items (id integer primary key, name text not null)");
+    const db = getNodeSqliteKysely<SyncHelperTestDatabase>(database);
+    const prepares = countPrepares(database);
+    const variableSelect = (parameterCount: number) =>
+      db
+        .selectFrom("items")
+        .selectAll()
+        .where(
+          "id",
+          "not in",
+          Array.from({ length: parameterCount }, (_, index) => index + 1),
+        );
+
+    for (let parameterCount = 1; parameterCount <= 64; parameterCount += 1) {
+      expect(executeSqliteQuerySync(database, variableSelect(parameterCount)).rows).toEqual([]);
+      expect(executeSqliteQuerySync(database, variableSelect(parameterCount)).rows).toEqual([]);
+    }
+    expect(prepares.calls()).toBe(128);
+
+    for (let parameterCount = 33; parameterCount <= 64; parameterCount += 1) {
+      expect(executeSqliteQuerySync(database, variableSelect(parameterCount)).rows).toEqual([]);
+    }
+    expect(prepares.calls()).toBe(128);
+
+    for (let parameterCount = 1; parameterCount <= 32; parameterCount += 1) {
+      expect(executeSqliteQuerySync(database, variableSelect(parameterCount)).rows).toEqual([]);
+    }
+    expect(prepares.calls()).toBe(160);
+  });
+
+  it("does not retain one-shot variable-cardinality SQL statements", () => {
+    database = new DatabaseSync(":memory:");
+    database.exec("create table items (id integer primary key, name text not null)");
+    const db = getNodeSqliteKysely<SyncHelperTestDatabase>(database);
+    const prepares = countPrepares(database);
+    const runVariableSelects = () => {
+      for (let parameterCount = 1; parameterCount <= 64; parameterCount += 1) {
+        const ids = Array.from({ length: parameterCount }, (_, index) => index + 1);
+        const select = db.selectFrom("items").selectAll().where("id", "not in", ids);
+        expect(executeSqliteQuerySync(database!, select).rows).toEqual([]);
+      }
+    };
+
+    runVariableSelects();
+    runVariableSelects();
+    runVariableSelects();
+    expect(prepares.calls()).toBe(192);
+  });
+
+  it("keeps nested lazy iterations independent", () => {
+    database = new DatabaseSync(":memory:");
+    database.exec(
+      "create table items (id integer primary key autoincrement, name text not null unique)",
+    );
+    const db = getNodeSqliteKysely<SyncHelperTestDatabase>(database);
+    for (const name of ["Ada", "Grace", "Lin"]) {
+      executeSqliteQuerySync(database, db.insertInto("items").values({ name }));
+    }
+    const select = db.selectFrom("items").selectAll().orderBy("id");
+    const prepares = countPrepares(database);
+
+    expect([...iterateSqliteQuerySync(database, select)]).toHaveLength(3);
+    expect([...iterateSqliteQuerySync(database, select)]).toHaveLength(3);
+
+    const outer = iterateSqliteQuerySync(database, select);
+    expect(outer.next()).toEqual({ done: false, value: { id: 1, name: "Ada" } });
+    expect([...iterateSqliteQuerySync(database, select)]).toEqual([
+      { id: 1, name: "Ada" },
+      { id: 2, name: "Grace" },
+      { id: 3, name: "Lin" },
+    ]);
+    expect([...outer]).toEqual([
+      { id: 2, name: "Grace" },
+      { id: 3, name: "Lin" },
+    ]);
+    expect(prepares.calls()).toBe(4);
+  });
+
+  it("does not reuse an active cached statement during synchronous callback re-entry", () => {
+    database = new DatabaseSync(":memory:");
+    let nested = false;
+    const db = getNodeSqliteKysely<SyncHelperTestDatabase>(database);
+    const query = db.selectNoFrom(sql<number>`nested_value()`.as("value"));
+    database.function("nested_value", () => {
+      if (nested) {
+        return 1;
+      }
+      nested = true;
+      try {
+        return executeSqliteQueryTakeFirstSync(database!, query)!.value + 1;
+      } finally {
+        nested = false;
+      }
+    });
+    const prepares = countPrepares(database);
+
+    expect(executeSqliteQuerySync(database, query).rows).toEqual([{ value: 2 }]);
+    expect(executeSqliteQuerySync(database, query).rows).toEqual([{ value: 2 }]);
+    expect(executeSqliteQuerySync(database, query).rows).toEqual([{ value: 2 }]);
+    expect(prepares.calls()).toBe(4);
+  });
+
+  it("invalidates prepared statements when the SQLite authorizer changes", () => {
+    database = new DatabaseSync(":memory:");
+    if (typeof database.setAuthorizer !== "function") {
+      return;
+    }
+    database.exec("create table items (id integer primary key, name text not null)");
+    database.exec("insert into items (id, name) values (1, 'Ada')");
+    const db = getNodeSqliteKysely<SyncHelperTestDatabase>(database);
+    const select = db.selectFrom("items").selectAll();
+    const prepares = countPrepares(database);
+
+    expect(executeSqliteQuerySync(database, select).rows).toEqual([{ id: 1, name: "Ada" }]);
+    expect(executeSqliteQuerySync(database, select).rows).toEqual([{ id: 1, name: "Ada" }]);
+    expect(executeSqliteQuerySync(database, select).rows).toEqual([{ id: 1, name: "Ada" }]);
+    expect(prepares.calls()).toBe(2);
+
+    database.setAuthorizer((actionCode, tableName) =>
+      actionCode === constants.SQLITE_READ && tableName === "items"
+        ? constants.SQLITE_IGNORE
+        : constants.SQLITE_OK,
+    );
+    expect(executeSqliteQuerySync(database, select).rows).toEqual([{ id: null, name: null }]);
+    expect(executeSqliteQuerySync(database, select).rows).toEqual([{ id: null, name: null }]);
+    expect(executeSqliteQuerySync(database, select).rows).toEqual([{ id: null, name: null }]);
+    expect(prepares.calls()).toBe(4);
+
+    database.setAuthorizer(null);
+    expect(executeSqliteQuerySync(database, select).rows).toEqual([{ id: 1, name: "Ada" }]);
+    expect(prepares.calls()).toBe(5);
+  });
+
+  it("invalidates prepared statements when the database is deserialized", () => {
+    database = new DatabaseSync(":memory:");
+    database.exec("create table items (id integer primary key, name text not null)");
+    database.exec("insert into items (id, name) values (1, 'Ada')");
+    let replacementBytes = new Uint8Array();
+    if (typeof database.deserialize === "function") {
+      const replacement = new DatabaseSync(":memory:");
+      replacement.exec("create table items (id integer primary key, name text not null)");
+      replacement.exec("insert into items (id, name) values (2, 'Grace')");
+      replacementBytes = replacement.serialize();
+      replacement.close();
+    } else {
+      Object.defineProperty(database, "deserialize", {
+        configurable: true,
+        value(this: DatabaseSync): void {
+          this.exec("delete from items");
+          this.exec("insert into items (id, name) values (2, 'Grace')");
+        },
+      });
+    }
+    const db = getNodeSqliteKysely<SyncHelperTestDatabase>(database);
+    const select = db.selectFrom("items").selectAll();
+    const prepares = countPrepares(database);
+
+    expect(executeSqliteQuerySync(database, select).rows).toEqual([{ id: 1, name: "Ada" }]);
+    expect(executeSqliteQuerySync(database, select).rows).toEqual([{ id: 1, name: "Ada" }]);
+    expect(executeSqliteQuerySync(database, select).rows).toEqual([{ id: 1, name: "Ada" }]);
+    expect(prepares.calls()).toBe(2);
+
+    database.deserialize(replacementBytes);
+
+    expect(executeSqliteQuerySync(database, select).rows).toEqual([{ id: 2, name: "Grace" }]);
+    expect(prepares.calls()).toBe(3);
+  });
+
+  it("allows databases and prepared statements to collect after lifecycle clearing", () => {
+    const moduleUrl = new URL("./kysely-sync.ts", import.meta.url).href;
+    const script = `
+      import { DatabaseSync } from "node:sqlite";
+      import {
+        clearNodeSqliteKyselyCacheForDatabase,
+        executeSqliteQuerySync,
+        getNodeSqliteKysely,
+      } from ${JSON.stringify(moduleUrl)};
+
+      const waitForTurn = () => new Promise((resolve) => setImmediate(resolve));
+      async function runScenario() {
+        let database = new DatabaseSync(":memory:");
+        database.exec("create table items (id integer primary key, name text not null)");
+        const databaseRef = new WeakRef(database);
+        const statementRefs = [];
+        const originalPrepare = DatabaseSync.prototype.prepare;
+        database.prepare = function (sql, options) {
+          const statement = originalPrepare.call(this, sql, options);
+          statementRefs.push(new WeakRef(statement));
+          return statement;
+        };
+        const db = getNodeSqliteKysely(database);
+        const select = db.selectFrom("items").selectAll().orderBy("id");
+        executeSqliteQuerySync(database, select);
+        executeSqliteQuerySync(database, select);
+        executeSqliteQuerySync(database, select);
+        delete database.prepare;
+        clearNodeSqliteKyselyCacheForDatabase(database);
+        database.close();
+        database = undefined;
+
+        for (let attempt = 0; attempt < 30; attempt += 1) {
+          await waitForTurn();
+          globalThis.gc();
+        }
+        return {
+          databaseCollected: databaseRef.deref() === undefined,
+          statementsCollected: statementRefs.filter((ref) => ref.deref() === undefined).length,
+          statementCount: statementRefs.length,
+        };
+      }
+
+      process.stdout.write(JSON.stringify(await runScenario()));
+    `;
+    const result = spawnSync(
+      process.execPath,
+      ["--expose-gc", "--import", "tsx", "--input-type=module", "--eval", script],
+      { cwd: process.cwd(), encoding: "utf8", timeout: 20_000 },
+    );
+
+    expect(result.stderr).toBe("");
+    expect(result.status).toBe(0);
+    expect(JSON.parse(result.stdout)).toEqual({
+      databaseCollected: true,
+      statementsCollected: 2,
+      statementCount: 2,
+    });
+  });
+
   it("keeps the builder facade compile-only and fails direct execution", async () => {
     database = new DatabaseSync(":memory:");
     database.exec("create table items (id integer primary key, name text not null)");
@@ -88,6 +364,16 @@ describe("kysely sync helpers", () => {
     ).toEqual([{ id: 1, name: "Ada" }]);
   });
 });
+
+function countPrepares(database: DatabaseSync): { calls: () => number } {
+  const originalPrepare = database.prepare.bind(database);
+  let calls = 0;
+  database.prepare = (sqlText, options) => {
+    calls += 1;
+    return originalPrepare(sqlText, options);
+  };
+  return { calls: () => calls };
+}
 
 async function expectCompileOnlyRejection(promise: Promise<unknown>): Promise<void> {
   await expect(

--- a/src/infra/kysely-sync.test.ts
+++ b/src/infra/kysely-sync.test.ts
@@ -275,6 +275,43 @@ describe("kysely sync helpers", () => {
     expect(prepares.calls()).toBe(3);
   });
 
+  it("refreshes cached query metadata after a schema change", () => {
+    database = new DatabaseSync(":memory:");
+    database.exec("create table items (id integer primary key, name text not null)");
+    database.exec("insert into items (id, name) values (1, 'Ada')");
+    const db = getNodeSqliteKysely<SyncHelperTestDatabase>(database);
+    const select = db.selectFrom("items").selectAll();
+    const prepares = countPrepares(database);
+
+    expect(executeSqliteQuerySync(database, select).rows).toEqual([{ id: 1, name: "Ada" }]);
+    expect(executeSqliteQuerySync(database, select).rows).toEqual([{ id: 1, name: "Ada" }]);
+    expect(executeSqliteQuerySync(database, select).rows).toEqual([{ id: 1, name: "Ada" }]);
+    expect(prepares.calls()).toBe(2);
+
+    database.exec("alter table items add column note text not null default 'new'");
+
+    expect(executeSqliteQuerySync(database, select).rows).toEqual([
+      { id: 1, name: "Ada", note: "new" },
+    ]);
+    expect(prepares.calls()).toBe(2);
+  });
+
+  it("resets a cached row statement after a step-time error", () => {
+    database = new DatabaseSync(":memory:");
+    const db = getNodeSqliteKysely<SyncHelperTestDatabase>(database);
+    const jsonValue = (value: string) => db.selectNoFrom(sql<string>`json(${value})`.as("value"));
+    const prepares = countPrepares(database);
+
+    expect(executeSqliteQuerySync(database, jsonValue("{}")).rows).toEqual([{ value: "{}" }]);
+    expect(executeSqliteQuerySync(database, jsonValue("{}")).rows).toEqual([{ value: "{}" }]);
+    expect(executeSqliteQuerySync(database, jsonValue("{}")).rows).toEqual([{ value: "{}" }]);
+    expect(prepares.calls()).toBe(2);
+
+    expect(() => executeSqliteQuerySync(database!, jsonValue("{"))).toThrow(/malformed JSON/iu);
+    expect(executeSqliteQuerySync(database, jsonValue("[]")).rows).toEqual([{ value: "[]" }]);
+    expect(prepares.calls()).toBe(2);
+  });
+
   it("allows databases and prepared statements to collect after lifecycle clearing", () => {
     const moduleUrl = new URL("./kysely-sync.ts", import.meta.url).href;
     const script = `

--- a/src/infra/kysely-sync.test.ts
+++ b/src/infra/kysely-sync.test.ts
@@ -6,6 +6,7 @@ import { afterEach, describe, expect, it } from "vitest";
 import { withTestTimeout } from "../../test/helpers/promise.js";
 import {
   clearNodeSqliteKyselyCacheForDatabase,
+  enableNodeSqliteKyselyStatementCache,
   executeSqliteQuerySync,
   executeSqliteQueryTakeFirstSync,
   getNodeSqliteKysely,
@@ -233,10 +234,60 @@ describe("kysely sync helpers", () => {
     expect(executeSqliteQuerySync(database, select).rows).toEqual([{ id: null, name: null }]);
     expect(executeSqliteQuerySync(database, select).rows).toEqual([{ id: null, name: null }]);
     expect(executeSqliteQuerySync(database, select).rows).toEqual([{ id: null, name: null }]);
-    expect(prepares.calls()).toBe(4);
+    expect(prepares.calls()).toBe(5);
 
     database.setAuthorizer(null);
     expect(executeSqliteQuerySync(database, select).rows).toEqual([{ id: 1, name: "Ada" }]);
+    expect(prepares.calls()).toBe(6);
+  });
+
+  it("does not cache while a dynamic SQLite authorizer is installed", () => {
+    database = new DatabaseSync(":memory:");
+    if (typeof database.setAuthorizer !== "function") {
+      return;
+    }
+    database.exec("create table items (id integer primary key, name text not null)");
+    database.exec("insert into items (id, name) values (1, 'Ada')");
+    const db = getNodeSqliteKysely<SyncHelperTestDatabase>(database);
+    const select = db.selectFrom("items").selectAll();
+    const prepares = countPrepares(database);
+    let allow = true;
+    database.setAuthorizer(() => (allow ? constants.SQLITE_OK : constants.SQLITE_DENY));
+
+    expect(executeSqliteQuerySync(database, select).rows).toEqual([{ id: 1, name: "Ada" }]);
+    expect(executeSqliteQuerySync(database, select).rows).toEqual([{ id: 1, name: "Ada" }]);
+    expect(executeSqliteQuerySync(database, select).rows).toEqual([{ id: 1, name: "Ada" }]);
+    expect(prepares.calls()).toBe(3);
+
+    allow = false;
+    expect(() => executeSqliteQuerySync(database!, select)).toThrow(/not authorized/iu);
+    expect(prepares.calls()).toBe(4);
+  });
+
+  it("does not retain oversized statement parameters", () => {
+    database = new DatabaseSync(":memory:");
+    const db = getNodeSqliteKysely<SyncHelperTestDatabase>(database);
+    const lengthOf = (value: string) => db.selectNoFrom(sql<number>`length(${value})`.as("value"));
+    const prepares = countPrepares(database);
+
+    expect(executeSqliteQuerySync(database, lengthOf("small")).rows).toEqual([{ value: 5 }]);
+    expect(executeSqliteQuerySync(database, lengthOf("small")).rows).toEqual([{ value: 5 }]);
+    expect(executeSqliteQuerySync(database, lengthOf("small")).rows).toEqual([{ value: 5 }]);
+    expect(prepares.calls()).toBe(2);
+
+    const oversized = "x".repeat(64 * 1024 + 1);
+    expect(executeSqliteQuerySync(database, lengthOf(oversized)).rows).toEqual([
+      { value: oversized.length },
+    ]);
+    expect(prepares.calls()).toBe(3);
+    expect(executeSqliteQuerySync(database, lengthOf("small")).rows).toEqual([{ value: 5 }]);
+    expect(prepares.calls()).toBe(3);
+
+    const oversizedSql = db.selectNoFrom(
+      sql.raw<number>(`1 /*${"x".repeat(64 * 1024)}*/`).as("value"),
+    );
+    expect(executeSqliteQuerySync(database, oversizedSql).rows).toEqual([{ value: 1 }]);
+    expect(executeSqliteQuerySync(database, oversizedSql).rows).toEqual([{ value: 1 }]);
     expect(prepares.calls()).toBe(5);
   });
 
@@ -318,6 +369,7 @@ describe("kysely sync helpers", () => {
       import { DatabaseSync } from "node:sqlite";
       import {
         clearNodeSqliteKyselyCacheForDatabase,
+        enableNodeSqliteKyselyStatementCache,
         executeSqliteQuerySync,
         getNodeSqliteKysely,
       } from ${JSON.stringify(moduleUrl)};
@@ -335,6 +387,7 @@ describe("kysely sync helpers", () => {
           return statement;
         };
         const db = getNodeSqliteKysely(database);
+        enableNodeSqliteKyselyStatementCache(database);
         const select = db.selectFrom("items").selectAll().orderBy("id");
         executeSqliteQuerySync(database, select);
         executeSqliteQuerySync(database, select);
@@ -403,6 +456,7 @@ describe("kysely sync helpers", () => {
 });
 
 function countPrepares(database: DatabaseSync): { calls: () => number } {
+  enableNodeSqliteKyselyStatementCache(database);
   const originalPrepare = database.prepare.bind(database);
   let calls = 0;
   database.prepare = (sqlText, options) => {

--- a/src/infra/kysely-sync.test.ts
+++ b/src/infra/kysely-sync.test.ts
@@ -478,7 +478,15 @@ function runRetentionScenario(options: { clearBeforeDrop: boolean }): {
   `;
   const result = spawnSync(
     process.execPath,
-    ["--expose-gc", "--import", "tsx", "--input-type=module", "--eval", script],
+    [
+      "--disable-warning=ExperimentalWarning",
+      "--expose-gc",
+      "--import",
+      "tsx",
+      "--input-type=module",
+      "--eval",
+      script,
+    ],
     { cwd: process.cwd(), encoding: "utf8", timeout: 20_000 },
   );
 

--- a/src/infra/kysely-sync.test.ts
+++ b/src/infra/kysely-sync.test.ts
@@ -190,7 +190,10 @@ describe("kysely sync helpers", () => {
     database = new DatabaseSync(":memory:");
     let nested = false;
     const db = getNodeSqliteKysely<SyncHelperTestDatabase>(database);
-    const query = db.selectNoFrom(sql<number>`nested_value()`.as("value"));
+    const query = db.selectNoFrom(
+      /* kysely-allow-raw: cache re-entry test needs a synthetic UDF call, not a store column. */
+      sql<number>`nested_value()`.as("value"),
+    );
     database.function("nested_value", () => {
       if (nested) {
         return 1;
@@ -267,7 +270,11 @@ describe("kysely sync helpers", () => {
   it("does not retain oversized statement parameters", () => {
     database = new DatabaseSync(":memory:");
     const db = getNodeSqliteKysely<SyncHelperTestDatabase>(database);
-    const lengthOf = (value: string) => db.selectNoFrom(sql<number>`length(${value})`.as("value"));
+    const lengthOf = (value: string) =>
+      db.selectNoFrom(
+        /* kysely-allow-raw: parameter-retention test measures binding size on a scalar, schema-free query. */
+        sql<number>`length(${value})`.as("value"),
+      );
     const prepares = countPrepares(database);
 
     expect(executeSqliteQuerySync(database, lengthOf("small")).rows).toEqual([{ value: 5 }]);
@@ -284,6 +291,7 @@ describe("kysely sync helpers", () => {
     expect(prepares.calls()).toBe(3);
 
     const oversizedSql = db.selectNoFrom(
+      /* kysely-allow-raw: admission-gate test needs an oversized SQL text, only reachable via raw. */
       sql.raw<number>(`1 /*${"x".repeat(64 * 1024)}*/`).as("value"),
     );
     expect(executeSqliteQuerySync(database, oversizedSql).rows).toEqual([{ value: 1 }]);
@@ -350,7 +358,11 @@ describe("kysely sync helpers", () => {
   it("resets a cached row statement after a step-time error", () => {
     database = new DatabaseSync(":memory:");
     const db = getNodeSqliteKysely<SyncHelperTestDatabase>(database);
-    const jsonValue = (value: string) => db.selectNoFrom(sql<string>`json(${value})`.as("value"));
+    const jsonValue = (value: string) =>
+      db.selectNoFrom(
+        /* kysely-allow-raw: step-error test needs json() to fail at execution time, not prepare time. */
+        sql<string>`json(${value})`.as("value"),
+      );
     const prepares = countPrepares(database);
 
     expect(executeSqliteQuerySync(database, jsonValue("{}")).rows).toEqual([{ value: "{}" }]);

--- a/src/infra/kysely-sync.test.ts
+++ b/src/infra/kysely-sync.test.ts
@@ -364,63 +364,17 @@ describe("kysely sync helpers", () => {
   });
 
   it("allows databases and prepared statements to collect after lifecycle clearing", () => {
-    const moduleUrl = new URL("./kysely-sync.ts", import.meta.url).href;
-    const script = `
-      import { DatabaseSync } from "node:sqlite";
-      import {
-        clearNodeSqliteKyselyCacheForDatabase,
-        enableNodeSqliteKyselyStatementCache,
-        executeSqliteQuerySync,
-        getNodeSqliteKysely,
-      } from ${JSON.stringify(moduleUrl)};
-
-      const waitForTurn = () => new Promise((resolve) => setImmediate(resolve));
-      async function runScenario() {
-        let database = new DatabaseSync(":memory:");
-        database.exec("create table items (id integer primary key, name text not null)");
-        const databaseRef = new WeakRef(database);
-        const statementRefs = [];
-        const originalPrepare = DatabaseSync.prototype.prepare;
-        database.prepare = function (sql, options) {
-          const statement = originalPrepare.call(this, sql, options);
-          statementRefs.push(new WeakRef(statement));
-          return statement;
-        };
-        const db = getNodeSqliteKysely(database);
-        enableNodeSqliteKyselyStatementCache(database);
-        const select = db.selectFrom("items").selectAll().orderBy("id");
-        executeSqliteQuerySync(database, select);
-        executeSqliteQuerySync(database, select);
-        executeSqliteQuerySync(database, select);
-        delete database.prepare;
-        clearNodeSqliteKyselyCacheForDatabase(database);
-        database.close();
-        database = undefined;
-
-        for (let attempt = 0; attempt < 30; attempt += 1) {
-          await waitForTurn();
-          globalThis.gc();
-        }
-        return {
-          databaseCollected: databaseRef.deref() === undefined,
-          statementsCollected: statementRefs.filter((ref) => ref.deref() === undefined).length,
-          statementCount: statementRefs.length,
-        };
-      }
-
-      process.stdout.write(JSON.stringify(await runScenario()));
-    `;
-    const result = spawnSync(
-      process.execPath,
-      ["--expose-gc", "--import", "tsx", "--input-type=module", "--eval", script],
-      { cwd: process.cwd(), encoding: "utf8", timeout: 20_000 },
-    );
-
-    expect(result.stderr).toBe("");
-    expect(result.status).toBe(0);
-    expect(JSON.parse(result.stdout)).toEqual({
+    expect(runRetentionScenario({ clearBeforeDrop: true })).toEqual({
       databaseCollected: true,
       statementsCollected: 2,
+      statementCount: 2,
+    });
+  });
+
+  it("retains a cached database when lifecycle clearing is skipped", () => {
+    expect(runRetentionScenario({ clearBeforeDrop: false })).toEqual({
+      databaseCollected: false,
+      statementsCollected: 1,
       statementCount: 2,
     });
   });
@@ -464,6 +418,77 @@ function countPrepares(database: DatabaseSync): { calls: () => number } {
     return originalPrepare(sqlText, options);
   };
   return { calls: () => calls };
+}
+
+function runRetentionScenario(options: { clearBeforeDrop: boolean }): {
+  databaseCollected: boolean;
+  statementsCollected: number;
+  statementCount: number;
+} {
+  const moduleUrl = new URL("./kysely-sync.ts", import.meta.url).href;
+  const cleanup = options.clearBeforeDrop
+    ? `
+        clearNodeSqliteKyselyCacheForDatabase(database);
+        database.close();
+      `
+    : "";
+  const script = `
+    import { DatabaseSync } from "node:sqlite";
+    import {
+      clearNodeSqliteKyselyCacheForDatabase,
+      enableNodeSqliteKyselyStatementCache,
+      executeSqliteQuerySync,
+      getNodeSqliteKysely,
+    } from ${JSON.stringify(moduleUrl)};
+
+    const waitForTurn = () => new Promise((resolve) => setImmediate(resolve));
+    async function runScenario() {
+      let database = new DatabaseSync(":memory:");
+      database.exec("create table items (id integer primary key, name text not null)");
+      const databaseRef = new WeakRef(database);
+      const statementRefs = [];
+      const originalPrepare = DatabaseSync.prototype.prepare;
+      database.prepare = function (sql, prepareOptions) {
+        const statement = originalPrepare.call(this, sql, prepareOptions);
+        statementRefs.push(new WeakRef(statement));
+        return statement;
+      };
+      const db = getNodeSqliteKysely(database);
+      enableNodeSqliteKyselyStatementCache(database);
+      const select = db.selectFrom("items").selectAll().orderBy("id");
+      executeSqliteQuerySync(database, select);
+      executeSqliteQuerySync(database, select);
+      executeSqliteQuerySync(database, select);
+      delete database.prepare;
+      ${cleanup}
+      database = undefined;
+
+      for (let attempt = 0; attempt < 30; attempt += 1) {
+        await waitForTurn();
+        globalThis.gc();
+      }
+      return {
+        databaseCollected: databaseRef.deref() === undefined,
+        statementsCollected: statementRefs.filter((ref) => ref.deref() === undefined).length,
+        statementCount: statementRefs.length,
+      };
+    }
+
+    process.stdout.write(JSON.stringify(await runScenario()));
+  `;
+  const result = spawnSync(
+    process.execPath,
+    ["--expose-gc", "--import", "tsx", "--input-type=module", "--eval", script],
+    { cwd: process.cwd(), encoding: "utf8", timeout: 20_000 },
+  );
+
+  expect(result.stderr).toBe("");
+  expect(result.status).toBe(0);
+  return JSON.parse(result.stdout) as {
+    databaseCollected: boolean;
+    statementsCollected: number;
+    statementCount: number;
+  };
 }
 
 async function expectCompileOnlyRejection(promise: Promise<unknown>): Promise<void> {

--- a/src/infra/kysely-sync.ts
+++ b/src/infra/kysely-sync.ts
@@ -9,9 +9,12 @@ import { InsertQueryNode, Kysely as KyselyInstance, SqliteDialect } from "kysely
 const kyselyByDatabase = new WeakMap<DatabaseSync, Kysely<unknown>>();
 const statementCacheSymbol = Symbol("openclaw.kyselySyncStatementCache");
 const statementInvalidationSymbol = Symbol("openclaw.kyselySyncStatementInvalidation");
-// Keep native retention small while covering the stable SQL working set of
-// synchronous state stores; second-use admission protects this bound from churn.
+const statementCacheEnabledSymbol = Symbol("openclaw.kyselySyncStatementCacheEnabled");
+const authorizerActiveSymbol = Symbol("openclaw.kyselySyncAuthorizerActive");
+// Keep SQL plus retained native bindings under 2 MiB while covering the stable
+// state-store working set; second-use admission protects the bound from churn.
 const statementCacheCapacity = 32;
+const statementCacheEntryBytes = 64 * 1024;
 
 type SqliteAuthorizer = Parameters<DatabaseSync["setAuthorizer"]>[0];
 
@@ -24,6 +27,8 @@ type StatementCache = {
 type StatementCacheOwner = DatabaseSync & {
   [statementCacheSymbol]?: StatementCache;
   [statementInvalidationSymbol]?: true;
+  [statementCacheEnabledSymbol]?: true;
+  [authorizerActiveSymbol]?: boolean;
 };
 
 const compileOnlySqliteDialect = new SqliteDialect({
@@ -58,6 +63,7 @@ function installStatementInvalidation(owner: StatementCacheOwner): void {
       writable: true,
       value(this: StatementCacheOwner, callback: SqliteAuthorizer): void {
         setAuthorizer(callback);
+        this[authorizerActiveSymbol] = callback !== null;
         // Authorization is decided while compiling SQL. Drop all statements
         // after every successful transition, including removing an authorizer.
         delete this[statementCacheSymbol];
@@ -86,13 +92,49 @@ function installStatementInvalidation(owner: StatementCacheOwner): void {
   });
 }
 
+/**
+ * Enable bounded statement caching for a lifecycle-owned database that has not
+ * installed an authorizer before this call.
+ */
+export function enableNodeSqliteKyselyStatementCache(db: DatabaseSync): void {
+  const owner = db as StatementCacheOwner;
+  installStatementInvalidation(owner);
+  owner[statementCacheEnabledSymbol] = true;
+}
+
+function queryFitsStatementCache(sql: string, parameters: readonly SQLInputValue[]): boolean {
+  let bytes = Buffer.byteLength(sql);
+  if (bytes > statementCacheEntryBytes) {
+    return false;
+  }
+  for (const parameter of parameters) {
+    if (typeof parameter === "string") {
+      bytes += Buffer.byteLength(parameter);
+    } else if (ArrayBuffer.isView(parameter)) {
+      bytes += parameter.byteLength;
+    }
+    if (bytes > statementCacheEntryBytes) {
+      return false;
+    }
+  }
+  return true;
+}
+
 function executeWithCachedStatement<Result>(
   db: DatabaseSync,
   sql: string,
+  parameters: readonly SQLInputValue[],
   execute: (statement: StatementSync) => Result,
 ): Result {
   const owner = db as StatementCacheOwner;
   installStatementInvalidation(owner);
+  if (
+    !owner[statementCacheEnabledSymbol] ||
+    owner[authorizerActiveSymbol] ||
+    !queryFitsStatementCache(sql, parameters)
+  ) {
+    return execute(db.prepare(sql));
+  }
   let cache = owner[statementCacheSymbol];
   if (!cache) {
     cache = {
@@ -151,7 +193,7 @@ function executeCompiledSqliteQuerySync<Row>(
   compiledQuery: CompiledQuery<Row>,
 ): QueryResult<Row> {
   const parameters = compiledQuery.parameters as SQLInputValue[];
-  return executeWithCachedStatement(db, compiledQuery.sql, (statement) => {
+  return executeWithCachedStatement(db, compiledQuery.sql, parameters, (statement) => {
     if (statement.columns().length > 0) {
       // Node's all() snapshots the column count before SQLite can reprepare
       // an expired statement. Eagerly consuming iterate() reads it after step.

--- a/src/infra/kysely-sync.ts
+++ b/src/infra/kysely-sync.ts
@@ -1,5 +1,5 @@
 // Adapts node:sqlite sync database calls for Kysely-style query execution.
-import type { DatabaseSync, SQLInputValue } from "node:sqlite";
+import type { DatabaseSync, SQLInputValue, StatementSync } from "node:sqlite";
 import type { Compilable, CompiledQuery, Kysely, QueryResult } from "kysely";
 import { InsertQueryNode, Kysely as KyselyInstance, SqliteDialect } from "kysely";
 
@@ -7,6 +7,25 @@ import { InsertQueryNode, Kysely as KyselyInstance, SqliteDialect } from "kysely
 // going through Kysely's async driver path.
 
 const kyselyByDatabase = new WeakMap<DatabaseSync, Kysely<unknown>>();
+const statementCacheSymbol = Symbol("openclaw.kyselySyncStatementCache");
+const statementInvalidationSymbol = Symbol("openclaw.kyselySyncStatementInvalidation");
+// Keep native retention small while covering the stable SQL working set of
+// synchronous state stores; second-use admission protects this bound from churn.
+const statementCacheCapacity = 32;
+
+type SqliteAuthorizer = Parameters<DatabaseSync["setAuthorizer"]>[0];
+
+type StatementCache = {
+  statements: Map<string, StatementSync>;
+  candidates: Set<string>;
+  active: WeakSet<StatementSync>;
+};
+
+type StatementCacheOwner = DatabaseSync & {
+  [statementCacheSymbol]?: StatementCache;
+  [statementInvalidationSymbol]?: true;
+};
+
 const compileOnlySqliteDialect = new SqliteDialect({
   // The lazy database factory leaves compilation usable while direct execution fails fast.
   database: async () => {
@@ -28,30 +47,128 @@ export function getNodeSqliteKysely<Database>(db: DatabaseSync): Kysely<Database
   return kysely;
 }
 
+function installStatementInvalidation(owner: StatementCacheOwner): void {
+  if (owner[statementInvalidationSymbol]) {
+    return;
+  }
+  if (typeof owner.setAuthorizer === "function") {
+    const setAuthorizer = owner.setAuthorizer.bind(owner);
+    Object.defineProperty(owner, "setAuthorizer", {
+      configurable: true,
+      writable: true,
+      value(this: StatementCacheOwner, callback: SqliteAuthorizer): void {
+        setAuthorizer(callback);
+        // Authorization is decided while compiling SQL. Drop all statements
+        // after every successful transition, including removing an authorizer.
+        delete this[statementCacheSymbol];
+      },
+    });
+  }
+  if (typeof owner.deserialize === "function") {
+    const deserialize = owner.deserialize.bind(owner);
+    Object.defineProperty(owner, "deserialize", {
+      configurable: true,
+      writable: true,
+      value(this: StatementCacheOwner, ...args: Parameters<DatabaseSync["deserialize"]>): void {
+        try {
+          deserialize(...args);
+        } finally {
+          // Node finalizes all statements before attempting deserialization,
+          // including failed attempts, so no cached object remains usable.
+          delete this[statementCacheSymbol];
+        }
+      },
+    });
+  }
+  Object.defineProperty(owner, statementInvalidationSymbol, {
+    configurable: true,
+    value: true,
+  });
+}
+
+function executeWithCachedStatement<Result>(
+  db: DatabaseSync,
+  sql: string,
+  execute: (statement: StatementSync) => Result,
+): Result {
+  const owner = db as StatementCacheOwner;
+  installStatementInvalidation(owner);
+  let cache = owner[statementCacheSymbol];
+  if (!cache) {
+    cache = {
+      statements: new Map(),
+      candidates: new Set(),
+      active: new WeakSet(),
+    };
+    Object.defineProperty(owner, statementCacheSymbol, {
+      configurable: true,
+      value: cache,
+    });
+  }
+
+  const cached = cache.statements.get(sql);
+  let statement: StatementSync;
+  if (cached && !cache.active.has(cached)) {
+    cache.statements.delete(sql);
+    cache.statements.set(sql, cached);
+    statement = cached;
+  } else {
+    // A user-defined SQLite callback can re-enter this helper synchronously.
+    // Prepare a temporary statement rather than reset the active outer query.
+    statement = db.prepare(sql);
+    if (!cached && cache.candidates.delete(sql)) {
+      cache.statements.set(sql, statement);
+      if (cache.statements.size > statementCacheCapacity) {
+        const oldestSql = cache.statements.keys().next().value;
+        if (oldestSql !== undefined) {
+          cache.statements.delete(oldestSql);
+        }
+      }
+    } else if (!cached) {
+      // Admit only on second use so variable placeholder counts cannot fill
+      // the native statement cache with one-shot SQL strings.
+      cache.candidates.add(sql);
+      if (cache.candidates.size > statementCacheCapacity) {
+        const oldestCandidate = cache.candidates.values().next().value;
+        if (oldestCandidate !== undefined) {
+          cache.candidates.delete(oldestCandidate);
+        }
+      }
+    }
+  }
+
+  cache.active.add(statement);
+  try {
+    return execute(statement);
+  } finally {
+    cache.active.delete(statement);
+  }
+}
+
 /** Execute a compiled Kysely query synchronously against node:sqlite. */
 function executeCompiledSqliteQuerySync<Row>(
   db: DatabaseSync,
   compiledQuery: CompiledQuery<Row>,
 ): QueryResult<Row> {
-  const statement = db.prepare(compiledQuery.sql);
   const parameters = compiledQuery.parameters as SQLInputValue[];
+  return executeWithCachedStatement(db, compiledQuery.sql, (statement) => {
+    if (statement.columns().length > 0) {
+      return { rows: statement.all(...parameters) as Row[] };
+    }
 
-  if (statement.columns().length > 0) {
-    return { rows: statement.all(...parameters) as Row[] };
-  }
-
-  const { changes, lastInsertRowid } = statement.run(...parameters);
-  const result: QueryResult<Row> = {
-    numAffectedRows: BigInt(changes),
-    rows: [],
-  };
-  if (InsertQueryNode.is(compiledQuery.query) && changes > 0) {
-    return {
-      ...result,
-      insertId: BigInt(lastInsertRowid),
+    const { changes, lastInsertRowid } = statement.run(...parameters);
+    const result: QueryResult<Row> = {
+      numAffectedRows: BigInt(changes),
+      rows: [],
     };
-  }
-  return result;
+    if (InsertQueryNode.is(compiledQuery.query) && changes > 0) {
+      return {
+        ...result,
+        insertId: BigInt(lastInsertRowid),
+      };
+    }
+    return result;
+  });
 }
 
 /** Compile and execute a Kysely query synchronously. */
@@ -68,6 +185,8 @@ export function* iterateSqliteQuerySync<Row>(
   query: Compilable<Row>,
 ): IterableIterator<Row> {
   const compiledQuery = query.compile();
+  // Iterators keep statement state across yields. A private statement prevents
+  // nested iteration of identical SQL from resetting an earlier iterator.
   const statement = db.prepare(compiledQuery.sql);
   if (statement.columns().length === 0) {
     return;
@@ -84,7 +203,10 @@ export function executeSqliteQueryTakeFirstSync<Row>(
   return executeSqliteQuerySync<Row>(db, query).rows[0];
 }
 
-/** Drop the cached Kysely facade for a DatabaseSync after close/test reset. */
+/** Drop cached Kysely state for a DatabaseSync before close/test reset. */
 export function clearNodeSqliteKyselyCacheForDatabase(db: DatabaseSync): void {
+  // Delete the database-owned cache before close so statements release their
+  // native database backreferences instead of recreating the WeakMap leak.
+  delete (db as StatementCacheOwner)[statementCacheSymbol];
   kyselyByDatabase.delete(db);
 }

--- a/src/infra/kysely-sync.ts
+++ b/src/infra/kysely-sync.ts
@@ -153,7 +153,19 @@ function executeCompiledSqliteQuerySync<Row>(
   const parameters = compiledQuery.parameters as SQLInputValue[];
   return executeWithCachedStatement(db, compiledQuery.sql, (statement) => {
     if (statement.columns().length > 0) {
-      return { rows: statement.all(...parameters) as Row[] };
+      // Node's all() snapshots the column count before SQLite can reprepare
+      // an expired statement. Eagerly consuming iterate() reads it after step.
+      const iterator = statement.iterate(...parameters);
+      try {
+        return { rows: [...iterator] as Row[] };
+      } catch (error) {
+        try {
+          iterator.return?.();
+        } catch {
+          // Preserve the step error if iterator cleanup itself fails.
+        }
+        throw error;
+      }
     }
 
     const { changes, lastInsertRowid } = statement.run(...parameters);

--- a/src/infra/kysely-sync.ts
+++ b/src/infra/kysely-sync.ts
@@ -7,12 +7,14 @@ import { InsertQueryNode, Kysely as KyselyInstance, SqliteDialect } from "kysely
 // going through Kysely's async driver path.
 
 const kyselyByDatabase = new WeakMap<DatabaseSync, Kysely<unknown>>();
+// Cached statements retain their database. Every enabled owner must clear before
+// close or drop; this required lifecycle pairing is not enforced automatically.
 const statementCacheSymbol = Symbol("openclaw.kyselySyncStatementCache");
 const statementInvalidationSymbol = Symbol("openclaw.kyselySyncStatementInvalidation");
 const statementCacheEnabledSymbol = Symbol("openclaw.kyselySyncStatementCacheEnabled");
 const authorizerActiveSymbol = Symbol("openclaw.kyselySyncAuthorizerActive");
-// Keep SQL plus retained native bindings under 2 MiB while covering the stable
-// state-store working set; second-use admission protects the bound from churn.
+// Bound SQL plus variable-size bindings to about 2 MiB per enabled database.
+// Process-wide retention scales with open handles; repeated variable SQL can enter.
 const statementCacheCapacity = 32;
 const statementCacheEntryBytes = 64 * 1024;
 

--- a/src/infra/sqlite-transaction.test.ts
+++ b/src/infra/sqlite-transaction.test.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import type { Readable } from "node:stream";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
+import { getNodeSqliteKysely } from "./kysely-sync.js";
 import { requireNodeSqlite } from "./node-sqlite.js";
 import {
   runSqliteDeferredTransactionSync,
@@ -189,6 +190,34 @@ describe("runSqliteImmediateTransactionSync", () => {
       "database is busy",
     );
     expect(execCalls).toEqual(["BEGIN IMMEDIATE", "COMMIT", "ROLLBACK"]);
+  });
+
+  it("clears cached state before closing after a rollback failure", () => {
+    const execCalls: string[] = [];
+    const operationError = new Error("operation failed");
+    const rollbackError = new Error("rollback failed");
+    let facadeAtClose: unknown;
+    const db = {
+      exec(sql: string) {
+        execCalls.push(sql);
+        if (sql === "ROLLBACK") {
+          throw rollbackError;
+        }
+      },
+      close() {
+        facadeAtClose = getNodeSqliteKysely(db);
+      },
+    } as import("node:sqlite").DatabaseSync;
+    const facadeBeforeClose = getNodeSqliteKysely(db);
+
+    expect(() =>
+      runSqliteImmediateTransactionSync(db, () => {
+        throw operationError;
+      }),
+    ).toThrow(operationError);
+    expect(execCalls).toEqual(["BEGIN IMMEDIATE", "ROLLBACK"]);
+    expect(facadeAtClose).toBeDefined();
+    expect(facadeAtClose).not.toBe(facadeBeforeClose);
   });
 
   it("logs one structured warning for a terminal lock failure", () => {

--- a/src/infra/sqlite-transaction.ts
+++ b/src/infra/sqlite-transaction.ts
@@ -1,6 +1,7 @@
 // Provides SQLite transaction helpers with nested savepoints.
 import type { DatabaseSync } from "node:sqlite";
 import { createSubsystemLogger, type SubsystemLogger } from "../logging/subsystem.js";
+import { clearNodeSqliteKyselyCacheForDatabase } from "./kysely-sync.js";
 
 const transactionDepthByDatabase = new WeakMap<DatabaseSync, number>();
 
@@ -197,6 +198,7 @@ function abortImmediateTransaction(db: DatabaseSync): void {
     // If rollback itself fails, close the handle so callers cannot keep using a
     // connection that may still hold an abandoned write transaction.
     try {
+      clearNodeSqliteKyselyCacheForDatabase(db);
       db.close();
     } catch {
       // Preserve the original transaction error; close failure is secondary.

--- a/src/state/openclaw-agent-db.ts
+++ b/src/state/openclaw-agent-db.ts
@@ -339,6 +339,7 @@ export function openOpenClawAgentDatabase(
         return maintenance;
       } catch (err) {
         maintenance?.close();
+        clearNodeSqliteKyselyCacheForDatabase(db);
         db.close();
         if (
           err instanceof Error &&

--- a/src/state/openclaw-agent-db.ts
+++ b/src/state/openclaw-agent-db.ts
@@ -2,7 +2,10 @@
 import { existsSync } from "node:fs";
 import path from "node:path";
 import type { DatabaseSync } from "node:sqlite";
-import { clearNodeSqliteKyselyCacheForDatabase } from "../infra/kysely-sync.js";
+import {
+  clearNodeSqliteKyselyCacheForDatabase,
+  enableNodeSqliteKyselyStatementCache,
+} from "../infra/kysely-sync.js";
 import { openNodeSqliteDatabase } from "../infra/node-sqlite.js";
 import type { SqliteFileGeneration } from "../infra/sqlite-file-generation.js";
 import {
@@ -306,6 +309,7 @@ export function openOpenClawAgentDatabase(
     // pressure the 65th open would otherwise fail before eviction could run.
     evictLruAgentDatabaseHandles();
     const db = openNodeSqliteDatabase(pathname);
+    enableNodeSqliteKyselyStatementCache(db);
     openedDb = db;
     // Eviction churn must avoid schema/registry busy waits on the event loop while
     // reconcile workers hold write transactions on these same agent databases.

--- a/src/state/openclaw-state-db.ts
+++ b/src/state/openclaw-state-db.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import type { DatabaseSync } from "node:sqlite";
 import {
   clearNodeSqliteKyselyCacheForDatabase,
+  enableNodeSqliteKyselyStatementCache,
   executeSqliteQuerySync,
   getNodeSqliteKysely,
 } from "../infra/kysely-sync.js";
@@ -523,6 +524,7 @@ export function openOpenClawStateDatabase(
   }
   ensureOpenClawStatePermissions(pathname, env);
   const db = openNodeSqliteDatabase(pathname);
+  enableNodeSqliteKyselyStatementCache(db);
   const walMaintenance = (() => {
     let maintenance: SqliteWalMaintenance | undefined;
     try {

--- a/src/state/openclaw-state-db.ts
+++ b/src/state/openclaw-state-db.ts
@@ -281,6 +281,7 @@ export function repairOpenClawStateDatabaseSchema(options: OpenClawStateDatabase
     if (db.isOpen) {
       db.exec("PRAGMA foreign_keys = ON;");
     }
+    clearNodeSqliteKyselyCacheForDatabase(db);
     db.close();
     ensureOpenClawStatePermissions(pathname, env);
   }
@@ -402,6 +403,7 @@ export async function openExistingOpenClawStateDatabaseReadOnly(
     }
   } catch (error) {
     try {
+      clearNodeSqliteKyselyCacheForDatabase(db);
       db.close();
     } catch {
       // Preserve the verification failure that explains why the database was refused.
@@ -424,6 +426,7 @@ export async function openExistingOpenClawStateDatabaseReadOnly(
         }
         try {
           if (wasOpen) {
+            clearNodeSqliteKyselyCacheForDatabase(db);
             db.close();
           }
         } finally {
@@ -540,6 +543,7 @@ export function openOpenClawStateDatabase(
       return maintenance;
     } catch (err) {
       maintenance?.close();
+      clearNodeSqliteKyselyCacheForDatabase(db);
       db.close();
       if (
         err instanceof Error &&

--- a/test/helpers/sqlite-statement-execution-counter.ts
+++ b/test/helpers/sqlite-statement-execution-counter.ts
@@ -1,0 +1,36 @@
+import type { DatabaseSync, StatementSync } from "node:sqlite";
+import { vi } from "vitest";
+import { clearNodeSqliteKyselyCacheForDatabase } from "../../src/infra/kysely-sync.js";
+
+/**
+ * Count SQLite query executions per caller-defined bucket. Prepared-statement
+ * caching (src/infra/kysely-sync.ts) reuses statements across calls, so
+ * counting `prepare` invocations undercounts; this wraps `iterate` on matching
+ * statements and clears the statement cache at attach so statements cached
+ * before the spy cannot bypass it.
+ */
+export function trackSqliteStatementExecutions<Key extends string>(
+  db: DatabaseSync,
+  keys: readonly Key[],
+  classify: (sql: string) => Key | null,
+): { counts: Record<Key, number>; restore: () => void } {
+  clearNodeSqliteKyselyCacheForDatabase(db);
+  const counts = Object.fromEntries(keys.map((key) => [key, 0])) as Record<Key, number>;
+  const originalPrepare = db.prepare.bind(db);
+  const prepareSpy = vi.spyOn(db, "prepare").mockImplementation((sqlText: string) => {
+    const statement = originalPrepare(sqlText);
+    const key = classify(sqlText);
+    if (key !== null) {
+      const originalIterate = statement.iterate.bind(statement) as (
+        ...args: unknown[]
+      ) => ReturnType<StatementSync["iterate"]>;
+      // iterate is overloaded, so the wrapper forwards untyped and casts back.
+      statement.iterate = ((...args: unknown[]) => {
+        counts[key] += 1;
+        return originalIterate(...args);
+      }) as StatementSync["iterate"];
+    }
+    return statement;
+  });
+  return { counts, restore: () => prepareSpy.mockRestore() };
+}


### PR DESCRIPTION
## Summary

### High Level TLDR

Synchronous Kysely queries now reuse a bounded set of hot SQLite prepared statements instead of recompiling identical SQL on every call. The cache is database-owned, second-use admitted, LRU bounded, byte bounded, disabled under SQLite authorizers, and enabled only for the lifecycle-owned file-backed shared and agent state databases.

### Root Cause

`executeCompiledSqliteQuerySync` prepared every query and immediately discarded the native statement. A measured 64-write subagent registry burst executed 2,144 statements but used only 65 SQL strings. The upsert SQL alone ran 2,080 times, so 2,079 prepares repeated SQL already compiled moments earlier.

The previous behavior spent 55.64 ms of a 168.93 ms workload in native prepare calls on Node 25.9. This synchronous CPU work blocked the gateway event loop.

### What Changed

- Added a database-owned prepared-statement cache for explicitly enabled shared and file-backed agent state databases.
- Admit SQL only after its second use.
- Bound each enabled database to 32 statements and 32 probationary SQL strings.
- Reject cache admission when SQL plus variable-size string or blob bindings exceed 64 KiB. The approximate 2 MiB variable-content ceiling is per enabled database, not process-wide.
- Bypass the cache whenever a SQLite authorizer is installed, including authorizers whose captured policy state changes without replacing the callback.
- Clear statements on authorizer transitions, deserialization, close, stale reopen, test reset, repair, rollback-failure close, and database open failure paths.
- Keep the public lazy iterator uncached. Cached eager reads fully consume a private iterator under an active-statement guard, refresh metadata after SQLite schema reprepare, and reset after step-time errors.
- Keep incognito `:memory:` agent databases uncached. Those handles are excluded from the 64-handle file-backed LRU eviction path, and the measured workload did not justify expanding their process-wide retention surface.

The `setAuthorizer` and `DatabaseSync.deserialize` wrappers are intentionally retained. A SQLite authorizer gates statement compilation. Reusing a statement that was compiled before an authorizer was installed would bypass that compilation-time check. The guard protects this property even though no in-tree production caller currently exercises it.

This does not change the subagent registry full snapshot rewrite, database schema, DDL, serialized formats, or incognito database behavior.

### Supported Node API compatibility

`enableNodeSqliteKyselyStatementCache` does not assume that optional `node:sqlite` APIs exist. `installStatementInvalidation` independently guards `setAuthorizer` and `deserialize` with `typeof owner.<method> === "function"` at `src/infra/kysely-sync.ts:61` and `src/infra/kysely-sync.ts:75`. Those are the only runtime call sites. The references at `src/infra/kysely-sync.ts:21` and `src/infra/kysely-sync.ts:80` are type-only and are erased at runtime.

The shared and agent state open paths call the enable function at `src/state/openclaw-state-db.ts:527` and `src/state/openclaw-agent-db.ts:312`. On a runtime missing both optional methods, `installStatementInvalidation` executes the two guards and installs its marker with `Object.defineProperty` at `src/infra/kysely-sync.ts:91`; it does not call either missing method.

This PR adds no new required `node:sqlite` API. Current `origin/main` already calls `prepare`, `columns`, and `run` in `src/infra/kysely-sync.ts:36-43`, and `iterateSqliteQuerySync` already calls `prepare`, `columns`, and `statement.iterate()` in `src/infra/kysely-sync.ts:71-76`. The supported Node floor is unchanged.

Direct probes of the three requested runtimes produced:

| API | Node 22.22.3 | Node 24.15.0 | Node 25.9.0 |
| --- | --- | --- | --- |
| `setAuthorizer` | absent | present | present |
| `deserialize` | absent | absent | absent |

Node 24 exposes `setAuthorizer` but not `deserialize`, so the methods must be guarded independently. The implementation already does that. Authorizer invalidation behavior is covered on CI because CI runs Node 24, where `setAuthorizer` exists. Node 22 skips those cases through the feature check.

```text
PATH=/tmp/n22/bin:$PATH node scripts/run-vitest.mjs src/infra/kysely-sync.test.ts
 Test Files  1 passed (1)
      Tests  15 passed (15)
[test] passed 1 Vitest shard in 5.19s

PATH=/tmp/n24/bin:$PATH node scripts/run-vitest.mjs src/infra/kysely-sync.test.ts
 Test Files  1 passed (1)
      Tests  15 passed (15)
[test] passed 1 Vitest shard in 4.70s

node scripts/run-vitest.mjs src/infra/kysely-sync.test.ts
 Test Files  1 passed (1)
      Tests  15 passed (15)
[test] passed 1 Vitest shard in 4.59s
```

### Real behavior proof

The same 64 sequential subagent registry snapshot writes were measured in a throwaway state directory:

```text
                                before      after
statement executions             2144       2144
prepare calls                     2144         65
distinct SQL strings                65         65
cache hits                           0       2079
cache hit rate                    0.00%      96.97%
prepare time                     55.64 ms     1.29 ms
workload time                   168.93 ms   127.27 ms
prepare share                    32.93%       1.01%
peak cached statements
in this measured workload            0           2
```

Measured reductions were 97.0% in prepare calls, 97.7% in prepare time, and 24.7% in total workload time. A fresh rerun after the review fixes still produced 65 prepares versus the 2,144 baseline.

The peak of 2 is only a property of this workload. It is not a mechanism ceiling. Each enabled database can admit up to 32 entries. Second-use admission reduces one-shot variable-cardinality churn but does not exclude repeated variants. A workload that executes each `NOT IN (?, ...)` shape twice can admit every shape, fill the LRU, and evict hotter statements. `src/infra/kysely-sync.test.ts:109` proves this behavior. The risk is performance degradation, not incorrect results, because the 32-entry bound still holds.

The earlier 20,000-handle stress experiment proves only the clean lifecycle path. It warmed two statements per handle, explicitly cleared and closed each handle, then ran 30 major GCs separated by `setImmediate` macrotasks:

```text
database handles collected: 20000 / 20000
statements collected:       40000 / 40000
heap before:                16191712
heap after create:          47225888
heap after GC:              17293152
heap growth after GC:        1101440
```

The focused retention tests now encode both sides of the lifecycle contract on Node 25.9:

```text
clear before drop:
  databaseCollected: true
  statementsCollected: 2 / 2

drop without clear:
  databaseCollected: false
  statementsCollected: 1 / 2
```

Drop without clear did not collect. The first-use temporary statement collected, but the cached statement and its database remained retained after 30 GCs separated by macrotask boundaries. This demonstrates that clear-before-drop is required. A cached native `StatementSync` strongly retains its `DatabaseSync`, so JavaScript finalization cannot repair a missed clear after the cycle is rooted. `src/infra/kysely-sync.test.ts:366` covers the clean path and `src/infra/kysely-sync.test.ts:374` covers the hazard.

### Lifecycle disposal audit

Cache transitions and execution errors:

| Path | Disposal or reset proof |
| --- | --- |
| Authorizer transition | `src/infra/kysely-sync.ts:71` deletes the cache after every successful install, replacement, or removal. |
| Deserialization | `src/infra/kysely-sync.ts:86` deletes the cache in `finally`, including failed deserialization. |
| Row execution error | `src/infra/kysely-sync.ts:207` returns the iterator to reset the statement, and `src/infra/kysely-sync.ts:188` releases the active guard. Recovery is tested at `src/infra/kysely-sync.test.ts:350`. |
| Rollback failure forced close | `src/infra/sqlite-transaction.ts:201` clears before close. `src/infra/sqlite-transaction.test.ts:195` proves the original operation error remains the propagated error. |

Shared state database owner:

| Disposal path | Clear proof |
| --- | --- |
| Terminal latch close | `src/state/openclaw-state-db.ts:106` |
| Stale-handle reopen | `src/state/openclaw-state-db.ts:505` |
| Mid-open schema or pragma failure | `src/state/openclaw-state-db.ts:548` |
| Close by path | `src/state/openclaw-state-db.ts:612` |
| Close all | `src/state/openclaw-state-db.ts:624` |
| Test reset | `src/state/openclaw-state-db.ts:639` delegates to close all. |
| Doctor repair | `src/state/openclaw-state-db.ts:285` |
| Existing read-only verification failure | `src/state/openclaw-state-db.ts:407` |
| Existing read-only owner close | `src/state/openclaw-state-db.ts:430` |
| Fresh read-only helper close | `src/state/openclaw-state-db-readonly.ts:64` |

Per-agent database owner:

| Disposal path | Clear proof |
| --- | --- |
| Terminal latch close | `src/state/openclaw-agent-db.ts:122` delegates to close by path and the shared close helper at `src/state/openclaw-agent-db.ts:490`. |
| Stale incognito or file-backed handle reopen | `src/state/openclaw-agent-db.ts:244` and `src/state/openclaw-agent-db.ts:293` delegate to the clear at `src/state/openclaw-agent-db.ts:490`. |
| Mid-open schema or pragma failure | `src/state/openclaw-agent-db.ts:346` |
| Outer open-failure cleanup | `src/state/openclaw-agent-db.ts:380` delegates to the clear at `src/state/openclaw-agent-db.ts:490`. |
| Close by path | `src/state/openclaw-agent-db.ts:606` delegates to the clear at `src/state/openclaw-agent-db.ts:490`. |
| Transient dispose | `src/state/openclaw-agent-db.ts:642` delegates to close by path. |
| Close all | `src/state/openclaw-agent-db.ts:652` delegates to the clear at `src/state/openclaw-agent-db.ts:490`. |
| Test reset | `src/state/openclaw-agent-db.ts:660` delegates to close all. |
| LRU eviction | `src/state/openclaw-agent-db.ts:521` delegates to the clear at `src/state/openclaw-agent-db.ts:490`. |
| Maintenance repair | `src/state/openclaw-agent-db-maintenance.ts:122` |
| Fresh read-only helper close | `src/state/openclaw-agent-db-readonly.ts:113` |

The following short-lived handles deliberately never call `enableNodeSqliteKyselyStatementCache` and are outside the prepared-statement cache lifecycle: schema preflight at `src/state/openclaw-database-preflight.ts:104` and `src/state/openclaw-database-preflight.ts:139`, startup checkpoint at `src/state/openclaw-state-db-startup-checkpoint.ts:65`, verification worker at `src/state/openclaw-database-verify.worker.ts:49`, schema-repair detection at `src/state/openclaw-state-db-schema-repair.ts:172`, snapshot source and verification handles at `src/infra/sqlite-snapshot.ts:661`, `src/infra/sqlite-snapshot.ts:685`, and `src/infra/sqlite-snapshot.ts:715`, agent owner inspection at `src/state/openclaw-agent-db.ts:196`, and incognito agent databases at `src/state/openclaw-agent-db.ts:250`.

## Verification

```text
node scripts/run-vitest.mjs src/infra/kysely-sync.test.ts
  15 passed

node scripts/run-vitest.mjs src/state/openclaw-state-db.test.ts src/state/openclaw-agent-db.test.ts
  191 passed, 6 skipped

node scripts/run-vitest.mjs src/infra/sqlite-transaction.test.ts
  10 passed

node scripts/run-tsgo.mjs -p tsconfig.core.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core.tsbuildinfo
  passed

node scripts/run-oxlint.mjs src/infra/kysely-sync.ts src/infra/kysely-sync.test.ts src/infra/sqlite-transaction.ts
  passed

node scripts/run-oxlint.mjs src/infra/sqlite-transaction.test.ts
  passed

./node_modules/.bin/oxfmt --check src/infra/kysely-sync.ts src/infra/kysely-sync.test.ts src/infra/sqlite-transaction.ts src/infra/sqlite-transaction.test.ts
  passed

git diff --check
  passed

.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main --stream-engine-output
  autoreview clean: no accepted/actionable findings reported
  overall: patch is correct (0.9)
```

The new retention tests are not tautological. Each observes independent `WeakRef` liveness after macrotask-separated GC and fails if its covered retention shape changes. The rollback-failure test separately asserts that close occurred, that cached Kysely state was cleared before close, and that the original operation error remained the thrown error.

### What was not tested

- Incognito `:memory:` agent databases remain intentionally uncached and therefore do not receive this performance improvement.
- No live gateway, service, container, or production state database was started, stopped, restarted, or touched.
- No networked or cross-platform runtime proof was run.
- Full repository test and build suites were not run.
- The planned incremental subagent registry rewrite was intentionally not included or tested.

## What Problem This Solves

Resolves a problem where bursty synchronous state writes repeatedly compiled identical SQL on the gateway event loop, delaying unrelated queued work.

## Why This Change Was Made

The hot workload has a small reusable SQL core and a variable one-shot tail. Second-use admission captures the measured hot core, while per-database entry and byte limits, lifecycle clearing, authorizer bypass, and iterator isolation contain correctness and retention risks. Repeated variable-cardinality SQL can still compete for the bounded LRU, which is disclosed as a performance risk above.

## User Impact

File-backed gateway state bursts spend substantially less synchronous CPU time compiling repeated SQL. Query results, ordering, affected-row counts, insert IDs, errors, schemas, serialized state, and incognito database behavior remain unchanged.

## Evidence

The before and after workload, clean-path retention stress, drop-without-clear hazard test, lifecycle enumeration, focused regressions, static gates, and final branch autoreview are recorded above.


## Maintainer additions during landing

- Test-only: the transcript-load and pairing-scan tests counted `db.prepare()` calls as query proxies; statement caching legitimately reuses statements, so they now count executions via the shared `test/helpers/sqlite-statement-execution-counter.ts` (cache-cleared at attach).
- Folded main-side fork-CI fix: `scripts/pr-lib/review.sh` validated the head SHA by shelling out to `rg`, which does not exist on GitHub-hosted fork-PR runners; the #114897 artifact-validation tests therefore failed deterministically on every fork PR. The guard now uses bash's native regex. Unrelated to the statement cache, folded in because it blocked this PR's merge gate.
