### PR TITLE
fix(code-mode): preserve direct tools and secure suspended runs

### DIFF
--- a/extensions/google/provider-catalog.test.ts
+++ b/extensions/google/provider-catalog.test.ts
@@ -122,6 +122,7 @@ describe("google provider catalog", () => {
         contextWindow: 1_048_576,
         maxTokens: 65_536,
         input: ["text", "image"],
+        compat: { codeMode: "preferred" },
       }),
       expect.objectContaining({
         id: "gemini-3.6-flash",
@@ -130,6 +131,7 @@ describe("google provider catalog", () => {
         contextWindow: 1_048_576,
         maxTokens: 65_536,
         input: ["text", "image"],
+        compat: { codeMode: "preferred" },
       }),
       expect.objectContaining({
         id: "gemma-3-1b-it",
@@ -142,6 +144,11 @@ describe("google provider catalog", () => {
         input: ["text", "image"],
       }),
     ]);
+    expect(
+      provider.models
+        .filter((model) => model.id.startsWith("gemma-"))
+        .every((model) => model.compat === undefined),
+    ).toBe(true);
     const request = vi.mocked(fetchGuard).mock.calls[0]?.[0];
     expect(request?.url).toBe(
       "https://generativelanguage.googleapis.com/v1beta/models?pageSize=1000",

--- a/extensions/google/provider-catalog.ts
+++ b/extensions/google/provider-catalog.ts
@@ -161,6 +161,7 @@ function buildGoogleLiveModel(row: unknown): ModelDefinitionConfig | undefined {
   ) {
     return undefined;
   }
+  const staticModel = GOOGLE_GEMINI_TEXT_MODELS.find((model) => model.id === id);
   return {
     id,
     name: readString(record, "displayName") ?? id,
@@ -171,6 +172,7 @@ function buildGoogleLiveModel(row: unknown): ModelDefinitionConfig | undefined {
     cost: GOOGLE_GEMINI_COST,
     contextWindow,
     maxTokens,
+    ...(staticModel?.compat ? { compat: { ...staticModel.compat } } : {}),
   };
 }
 

--- a/packages/ai/src/transports.ts
+++ b/packages/ai/src/transports.ts
@@ -20,3 +20,4 @@ export * from "./transports/provider-transport-stream.js";
 export * from "./transports/responses-image-payload-sanitizer.js";
 export * from "./transports/simple-completion-transport.js";
 export * from "./transports/transport-stream-shared.js";
+export { isCodeModeModelVisibleToolName } from "./transports/transport-utils.js";

--- a/packages/ai/src/transports/transport-utils.ts
+++ b/packages/ai/src/transports/transport-utils.ts
@@ -84,7 +84,13 @@ export function supportsModelTools(model: { compat?: unknown }): boolean {
 }
 
 export function isCodeModeModelVisibleToolName(name: string): boolean {
-  return name === "exec" || name === "wait" || name === "computer" || name === "image";
+  return (
+    name === "exec" ||
+    name === "wait" ||
+    name === "computer" ||
+    name === "image" ||
+    name === "message"
+  );
 }
 
 function isGoogleGemini3Model(modelId: string, family: "flash" | "pro"): boolean {

--- a/src/agents/code-mode-execution.ts
+++ b/src/agents/code-mode-execution.ts
@@ -390,15 +390,13 @@ export async function runWait(params: {
   if (!state) {
     throw new ToolInputError("code mode run is unavailable or expired.");
   }
-  if (state.ctx.runId && params.ctx.runId && state.ctx.runId !== params.ctx.runId) {
+  if (state.ctx.runId && state.ctx.runId !== params.ctx.runId) {
     throw new ToolInputError("code mode run belongs to a different agent run.");
   }
   if (
-    (state.ctx.sessionId && params.ctx.sessionId && state.ctx.sessionId !== params.ctx.sessionId) ||
-    (state.ctx.sessionKey &&
-      params.ctx.sessionKey &&
-      state.ctx.sessionKey !== params.ctx.sessionKey) ||
-    (state.ctx.agentId && params.ctx.agentId && state.ctx.agentId !== params.ctx.agentId)
+    (state.ctx.sessionId && state.ctx.sessionId !== params.ctx.sessionId) ||
+    (state.ctx.sessionKey && state.ctx.sessionKey !== params.ctx.sessionKey) ||
+    (state.ctx.agentId && state.ctx.agentId !== params.ctx.agentId)
   ) {
     throw new ToolInputError("code mode run belongs to a different session.");
   }

--- a/src/agents/code-mode-namespaces.ts
+++ b/src/agents/code-mode-namespaces.ts
@@ -3,6 +3,7 @@
  * namespaced tool scopes here; code mode receives descriptors, virtual API
  * files, and a guarded invocation runtime.
  */
+import { tokTypes } from "acorn";
 import { isRecord } from "../../packages/normalization-core/src/record-coerce.js";
 import { toCodeModeJsonSafe } from "./code-mode-json.js";
 
@@ -34,6 +35,12 @@ const RESERVED_NAMESPACE_GLOBALS = new Set([
   "text",
   "tools",
   "yield_control",
+]);
+// API declarations use function names, so JS keywords and TypeScript's `enum`
+// must be escaped even though those words are valid MCP tool identifiers.
+const RESERVED_NAMESPACE_FUNCTION_IDENTIFIERS = new Set([
+  ...Object.values(tokTypes).flatMap((token) => (token.keyword ? [token.keyword] : [])),
+  "enum",
 ]);
 
 /** Object installed into a code-mode namespace global. */
@@ -178,6 +185,7 @@ function uniqueIdentifier(base: string, used: Set<string>): string {
   while (
     used.has(candidate) ||
     RESERVED_NAMESPACE_GLOBALS.has(candidate) ||
+    RESERVED_NAMESPACE_FUNCTION_IDENTIFIERS.has(candidate) ||
     FORBIDDEN_NAMESPACE_PATH_SEGMENTS.has(candidate)
   ) {
     candidate = `${base}${index}`;

--- a/src/agents/code-mode.test.ts
+++ b/src/agents/code-mode.test.ts
@@ -291,6 +291,50 @@ describe("Code Mode", () => {
     expect(catalogRef.current?.entries.map((entry) => entry.name)).toEqual(["fake_create_ticket"]);
   });
 
+  it("keeps explicitly required native message delivery visible and searchable", () => {
+    const { config, catalogRef, tools: codeModeTools } = createCodeModeHarness();
+    const message = fakeTool("message", "Deliver the visible response");
+    const ticket = pluginTool("fake_create_ticket", "Create a fake ticket");
+
+    const compacted = applyCodeModeCatalog({
+      tools: [...codeModeTools, message, ticket],
+      config,
+      sessionId: "session-code-mode",
+      sessionKey: "agent:main:main",
+      runId: "run-code-mode",
+      catalogRef,
+      directToolNames: ["message"],
+    });
+
+    expect(compacted.tools.map((tool) => tool.name)).toEqual(["exec", "wait", "message"]);
+    expect(catalogRef.current?.entries.map((entry) => entry.name)).toEqual([
+      "message",
+      "fake_create_ticket",
+    ]);
+  });
+
+  it("never exposes an MCP lookalike as the required native message tool", () => {
+    const { config, catalogRef, tools: codeModeTools } = createCodeModeHarness();
+    const spoofedMessage = mcpTool({
+      name: "message",
+      serverName: "spoofed",
+      toolName: "message",
+    });
+
+    const compacted = applyCodeModeCatalog({
+      tools: [...codeModeTools, spoofedMessage],
+      config,
+      sessionId: "session-code-mode",
+      sessionKey: "agent:main:main",
+      runId: "run-code-mode",
+      catalogRef,
+      directToolNames: ["message"],
+    });
+
+    expect(compacted.tools.map((tool) => tool.name)).toEqual(["exec", "wait"]);
+    expect(catalogRef.current?.entries.map((entry) => entry.name)).toEqual(["message"]);
+  });
+
   it("marks only the internal wait control as hidden from channel progress", () => {
     const { tools } = createCodeModeHarness();
 
@@ -1433,6 +1477,55 @@ describe("Code Mode", () => {
     });
   });
 
+  it.each(["delete", "default", "return", "enum", "class"])(
+    "renders and executes reserved MCP tool name %s safely",
+    async (toolName) => {
+      const { config, catalogRef, tools: codeModeTools } = createCodeModeHarness();
+      const target = mcpTool({
+        name: `github__${toolName}`,
+        serverName: "github",
+        toolName,
+        parameters: {
+          type: "object",
+          properties: { value: { type: "string" } },
+          required: ["value"],
+        },
+      });
+      applyCodeModeCatalog({
+        tools: [...codeModeTools, target],
+        config,
+        sessionId: "session-code-mode",
+        sessionKey: "agent:main:main",
+        runId: "run-code-mode",
+        catalogRef,
+      });
+
+      const safeName = `${toolName}2`;
+      const details = await runUntilCompleted({
+        execTool: expectDefined(codeModeTools[0], "Code Mode exec test invariant"),
+        waitTool: expectDefined(codeModeTools[1], "Code Mode wait test invariant"),
+        code: `
+          const file = await API.read("mcp/github.d.ts");
+          const api = await MCP.github.$api("${safeName}");
+          const result = await MCP.github.${safeName}({ value: "safe" });
+          return { file: file.content, header: api.header, result: result.details };
+        `,
+      });
+
+      expect(details.status).toBe("completed");
+      expect(details.value).toEqual({
+        file: expect.stringContaining(`function ${safeName}(`),
+        header: expect.stringContaining(`function ${safeName}(`),
+        result: {
+          serverName: "github",
+          toolName,
+          input: { value: "safe" },
+        },
+      });
+      expect(target.execute).toHaveBeenCalledTimes(1);
+    },
+  );
+
   it("marks yield suspensions and resumes the snapshot with wait", async () => {
     const { config, catalogRef, tools: codeModeTools } = createCodeModeHarness();
     applyCodeModeCatalog({
@@ -1799,6 +1892,64 @@ describe("Code Mode", () => {
       otherWaitTool.execute("code-wait-wrong-session", { runId: first.runId }),
     ).rejects.toThrow("different session");
   });
+
+  it.each(["runId", "sessionId", "sessionKey", "agentId"] as const)(
+    "rejects suspended-run callers missing the owner %s",
+    async (missingIdentity) => {
+      const {
+        config,
+        catalogRef,
+        ctx,
+        tools: codeModeTools,
+      } = createCodeModeHarness({
+        agentId: "owner",
+      });
+      applyCodeModeCatalog({
+        tools: [...codeModeTools, pluginTool("fake_noop", "Noop")],
+        config,
+        sessionId: ctx.sessionId,
+        sessionKey: ctx.sessionKey,
+        agentId: ctx.agentId,
+        runId: ctx.runId,
+        catalogRef,
+      });
+
+      const suspended = resultDetails(
+        await expectDefined(codeModeTools[0], "Code Mode exec test invariant").execute(
+          "code-call-scoped-owner",
+          { code: 'await yield_control("pause"); return "owner-secret";' },
+        ),
+      );
+      expect(suspended.status).toBe("waiting");
+
+      const missingIdentityWait = expectDefined(
+        createCodeModeTools({
+          config,
+          runtimeConfig: config,
+          catalogRef,
+          ...(missingIdentity === "runId" ? {} : { runId: ctx.runId }),
+          ...(missingIdentity === "sessionId" ? {} : { sessionId: ctx.sessionId }),
+          ...(missingIdentity === "sessionKey" ? {} : { sessionKey: ctx.sessionKey }),
+          ...(missingIdentity === "agentId" ? {} : { agentId: ctx.agentId }),
+        })[1],
+        "Unscoped Code Mode wait test invariant",
+      );
+
+      await expect(
+        missingIdentityWait.execute("code-wait-missing-owner", { runId: suspended.runId }),
+      ).rejects.toThrow(missingIdentity === "runId" ? "different agent run" : "different session");
+      expect(testing.activeRuns.has(suspended.runId as string)).toBe(true);
+
+      const rightfulResult = resultDetails(
+        await expectDefined(codeModeTools[1], "Owner Code Mode wait test invariant").execute(
+          "code-wait-rightful-owner",
+          { runId: suspended.runId },
+        ),
+      );
+      expect(rightfulResult.status).toBe("completed");
+      expect(rightfulResult.value).toBe("owner-secret");
+    },
+  );
 
   it("rejects concurrent waits for the same suspended run", async () => {
     const catalogRef = createToolSearchCatalogRef();

--- a/src/agents/code-mode.ts
+++ b/src/agents/code-mode.ts
@@ -41,6 +41,7 @@ import type { AgentToolUpdateCallback } from "./runtime/index.js";
 import { optionalStringEnum } from "./schema/typebox.js";
 import type { ToolDefinition } from "./sessions/index.js";
 import { resolveSwarmConfig } from "./swarm-config.js";
+import { isDirectVisibleCatalogTool } from "./tool-search-catalog.js";
 import {
   addClientToolsToToolCatalog,
   applyToolCatalogCompaction,
@@ -251,6 +252,7 @@ export function applyCodeModeCatalog(params: {
   runId?: string;
   catalogRef?: ToolSearchCatalogRef;
   toolHookContext?: HookContext;
+  directToolNames?: Iterable<string>;
 }) {
   const config = resolveCodeModeConfig(params.config, params.agentId);
   // Engagement (including "auto" per-model resolution) is decided by the run
@@ -270,11 +272,16 @@ export function applyCodeModeCatalog(params: {
         tool.name !== TOOL_DESCRIBE_RAW_TOOL_NAME &&
         tool.name !== TOOL_CALL_RAW_TOOL_NAME),
   );
+  const directToolNames = new Set(params.directToolNames);
   const compacted = applyToolCatalogCompaction({
     ...params,
     tools,
     enabled: true,
     isVisibleControlTool: isCodeModeControlTool,
+    // Code mode never exposes core shell/file tools just because structured
+    // search does; only explicitly required, trusted direct tools may remain.
+    isVisibleCatalogTool: (tool) =>
+      directToolNames.has(tool.name) && isDirectVisibleCatalogTool(tool, directToolNames),
     shouldCatalogTool: (tool) => !isCodeModeControlTool(tool),
   });
   // Only the catalog ref reflects the freshly compacted run catalog. Without it

--- a/src/agents/embedded-agent-runner/run/attempt-tool-catalog.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-tool-catalog.ts
@@ -104,6 +104,7 @@ export function prepareEmbeddedAttemptToolCatalog(input: {
         runId: attempt.runId,
         catalogRef: preparedToolBase.toolSearchCatalogRef,
         toolHookContext: catalogToolHookContext,
+        directToolNames: requiredDirectToolNames,
       })
     : toolSearchConfig.mode === "directory"
       ? applyToolSchemaDirectoryCatalog({

--- a/src/agents/harness/tool-surface-bridge.test.ts
+++ b/src/agents/harness/tool-surface-bridge.test.ts
@@ -176,6 +176,26 @@ describe("createAgentHarnessToolSurfaceRuntime", () => {
     }
   });
 
+  it.each([
+    { name: "message-only delivery", sourceReplyDeliveryMode: "message_tool_only" as const },
+    { name: "forced message delivery", forceMessageTool: true },
+  ])("keeps $name directly visible in Code Mode", (delivery) => {
+    const runtime = createAgentHarnessToolSurfaceRuntime({
+      config: { tools: { codeMode: true } },
+      executeTool: async () => ({ content: [], details: {} }),
+      ...delivery,
+      modelToolsEnabled: true,
+    });
+
+    try {
+      expect(
+        runtime.compactTools(tools(["web_search", "message"])).tools.map((tool) => tool.name),
+      ).toEqual(["exec", "wait", "message"]);
+    } finally {
+      runtime.cleanup();
+    }
+  });
+
   it("keeps policy-required message delivery directly visible in directory mode", () => {
     const runtime = createAgentHarnessToolSurfaceRuntime({
       config: { tools: { toolSearch: { enabled: true, mode: "directory" } } },

--- a/src/agents/harness/tool-surface-bridge.ts
+++ b/src/agents/harness/tool-surface-bridge.ts
@@ -172,6 +172,7 @@ export function createAgentHarnessToolSurfaceRuntime(params: {
           runId: params.runId,
           catalogRef: toolSearchCatalogRef,
           toolHookContext: options.hookContext,
+          directToolNames: requiredDirectToolNames,
         })
       : toolSearchConfig.mode === "directory"
         ? applyToolSchemaDirectoryCatalog({

--- a/src/agents/openai-transport-params.code-mode.test.ts
+++ b/src/agents/openai-transport-params.code-mode.test.ts
@@ -5,9 +5,9 @@ import {
 import { describe, expect, it } from "vitest";
 
 describe("OpenAI Code Mode direct tools", () => {
-  it("keeps the native image loader model-visible", () => {
+  it("keeps policy-required direct tools model-visible", () => {
     const payload = {
-      tools: ["exec", "wait", "computer", "image", "web_fetch"].map((name) => ({
+      tools: ["exec", "wait", "computer", "image", "message", "web_fetch"].map((name) => ({
         type: "function",
         name,
       })),
@@ -15,7 +15,13 @@ describe("OpenAI Code Mode direct tools", () => {
 
     enforceCodeModeResponsesToolSurface(payload);
 
-    expect(payload.tools.map((tool) => tool.name)).toEqual(["exec", "wait", "computer", "image"]);
+    expect(payload.tools.map((tool) => tool.name)).toEqual([
+      "exec",
+      "wait",
+      "computer",
+      "image",
+      "message",
+    ]);
     expect(() => assertCodeModeResponsesToolSurface(payload)).not.toThrow();
   });
 });

--- a/src/llm/providers/stream-wrappers/openai.test.ts
+++ b/src/llm/providers/stream-wrappers/openai.test.ts
@@ -209,6 +209,9 @@ describe("createCodexNativeWebSearchWrapper", () => {
         onPayload: async () => ({
           tools: [
             { type: "function", name: "exec" },
+            { type: "function", name: "computer" },
+            { type: "function", name: "image" },
+            { type: "function", name: "message" },
             {
               type: "function",
               get function(): { name: string } {
@@ -226,6 +229,9 @@ describe("createCodexNativeWebSearchWrapper", () => {
     expect(nextPayload).toEqual({
       tools: [
         { type: "function", name: "exec" },
+        { type: "function", name: "computer" },
+        { type: "function", name: "image" },
+        { type: "function", name: "message" },
         { type: "function", name: "wait" },
       ],
     });
@@ -273,6 +279,9 @@ describe("createCodexNativeWebSearchWrapper", () => {
         tools: [
           { type: "function", name: "exec" },
           { type: "function", name: "wait" },
+          { type: "function", name: "computer" },
+          { type: "function", name: "image" },
+          { type: "function", name: "message" },
           { type: "function", name: "read" },
         ],
       };
@@ -304,6 +313,9 @@ describe("createCodexNativeWebSearchWrapper", () => {
     expect(payloads[0]?.tools).toEqual([
       { type: "function", name: "exec" },
       { type: "function", name: "wait" },
+      { type: "function", name: "computer" },
+      { type: "function", name: "image" },
+      { type: "function", name: "message" },
     ]);
   });
 
@@ -316,6 +328,9 @@ describe("createCodexNativeWebSearchWrapper", () => {
           {
             functionDeclarations: [
               { name: "exec", description: "Run code" },
+              { name: "computer", description: "Control a desktop" },
+              { name: "image", description: "Read an image" },
+              { name: "message", description: "Deliver the response" },
               { name: "read", description: "Read a file" },
               { name: "wait", description: "Resume code" },
             ],
@@ -351,6 +366,9 @@ describe("createCodexNativeWebSearchWrapper", () => {
       {
         functionDeclarations: [
           { name: "exec", description: "Run code" },
+          { name: "computer", description: "Control a desktop" },
+          { name: "image", description: "Read an image" },
+          { name: "message", description: "Deliver the response" },
           { name: "wait", description: "Resume code" },
         ],
       },

--- a/src/llm/providers/stream-wrappers/openai.ts
+++ b/src/llm/providers/stream-wrappers/openai.ts
@@ -2,7 +2,7 @@ import {
   resolveOpenAIReasoningEffortForModel,
   supportsOpenAIReasoningEffort,
 } from "@openclaw/ai/internal/openai";
-import { emitModelTransportDebug } from "@openclaw/ai/transports";
+import { emitModelTransportDebug, isCodeModeModelVisibleToolName } from "@openclaw/ai/transports";
 import {
   flattenCompletionMessagesToStringContent,
   stripCompletionMessagesToRoleContent,
@@ -163,7 +163,7 @@ function readPayloadToolName(tool: unknown): string | undefined {
 }
 
 function isCodeModePayloadToolName(name: string | undefined): boolean {
-  return name === "exec" || name === "wait";
+  return typeof name === "string" && isCodeModeModelVisibleToolName(name);
 }
 
 function filterCodeModeToolDeclarations(declarations: unknown): unknown[] | undefined {


### PR DESCRIPTION
Closes #114753

## What Problem This Solves

Fixes an issue where Code Mode users relying on message-only delivery, native desktop/image tools, or live-discovered Gemini models would lose required capabilities. MCP tools named after JavaScript/TypeScript reserved words could also produce unusable declarations, and suspended Code Mode runs did not consistently enforce their recorded owner identity.

## Why This Change Was Made

Preserve only explicitly policy-required, trusted direct tools in both embedded and harness Code Mode catalogs; share one canonical provider-transport visibility predicate. Preserve Google-owned compatibility metadata during authenticated Gemini discovery. Derive reserved MCP declaration identifiers from the existing Acorn keyword contract, and make suspended execution ownership fail closed when stored identity is missing from the caller.

## User Impact

Message-only agents can deliver replies; desktop, image, and explicitly authorized delivery tools remain available without exposing shell, file, or spoofed MCP tools. Code Mode auto correctly activates for preferred discovered Gemini models, ordinary reserved-name MCP tools work, and suspended executions remain session-scoped.

## Evidence

- Reproduced failing regressions on main before applying each fix: four omitted suspended-run identities, five reserved MCP names through the real QuickJS worker, both message-delivery modes, both flat and grouped provider payloads, and authenticated paginated Gemini discovery.
- Linux/Blacksmith targeted stress matrix: 30 files, nine Vitest projects, 956 passing tests, including the existing 130,000-case adversarial parser corpus and real worker, cron, provider, catalog, gateway, and MCP regression tests.
- Full pnpm check:changed passed: all four core/plugin type-check lanes, formatting, core/plugin lint, SDK and plugin boundaries, dependency pins, runtime import cycles, state guards, and security guards.
- pnpm test:docker:mcp-code-mode-gateway passed from a fresh production build and checked npm tarball; the real gateway returned MCP_CODE_MODE_FILE_OK, read its declaration files, invoked the MCP tool once, and reported zero tool-search pollution.
- Fresh independent autoreview: clean, no accepted or actionable findings.
- Source contract checked directly against quickjs-wasi, Acorn, TypeScript, and the sibling Codex runtime at codex-rs/code-mode/src/runtime/module_loader.rs.
- AI-assisted.