### PR TITLE
fix: chat replies are silently dropped when the reply receipt reads the wrong session

### DIFF
--- a/src/config/sessions/restart-recovery-receipt.test.ts
+++ b/src/config/sessions/restart-recovery-receipt.test.ts
@@ -133,3 +133,101 @@ describe("restart recovery terminal delivery receipt", () => {
     ).toBeUndefined();
   });
 });
+
+describe("restart recovery receipt when the scope names a session that is not the sessionId owner", () => {
+  // A caller can hold a session key that is not the durable run session: a runtime
+  // that sandboxes tool calls keeps a separate policy key, and the gateway-owned
+  // receipt path scopes with the request's identity session key, which is that
+  // policy key. Only the sessionId is reliable on every path.
+  const fixture = useTempSessionsFixture("restart-receipt-scope-");
+  const REQUESTED_KEY = "agent:main:telegram:default:direct:123";
+  const OWNING_KEY = "agent:main:main";
+
+  function scope() {
+    return {
+      sessionId: "session-live",
+      sessionKey: REQUESTED_KEY,
+      sourceTurnId: "source-1",
+      storePath: fixture.storePath(),
+      toolCallId: "message-call-1",
+    };
+  }
+
+  /** The leftover the requested key points at, from an earlier session. */
+  async function seedStaleRequestedEntry() {
+    await replaceSessionEntry(
+      { sessionKey: REQUESTED_KEY, storePath: fixture.storePath() },
+      { sessionId: "session-old", status: "done", updatedAt: 1 },
+    );
+  }
+
+  async function seedOwningEntry(entry: Record<string, unknown>) {
+    await replaceSessionEntry({ sessionKey: OWNING_KEY, storePath: fixture.storePath() }, {
+      sessionId: "session-live",
+      updatedAt: 2,
+      ...entry,
+    } as Parameters<typeof replaceSessionEntry>[1]);
+  }
+
+  it("arms the receipt on the session that owns the sessionId", async () => {
+    await seedStaleRequestedEntry();
+    await seedOwningEntry({
+      status: "running",
+      restartRecoveryDeliveryRunId: "recovery-1",
+      restartRecoveryDeliverySourceRunId: "source-1",
+    });
+
+    await expect(beginRestartRecoveryTerminalDelivery(scope())).resolves.toBe("started");
+    expect(
+      loadSessionEntry({ sessionKey: OWNING_KEY, storePath: fixture.storePath() })
+        ?.restartRecoveryDeliveryReceiptState,
+    ).toBe("terminal-pending");
+    // The leftover the scope named must not be touched.
+    expect(
+      loadSessionEntry({ sessionKey: REQUESTED_KEY, storePath: fixture.storePath() })
+        ?.restartRecoveryDeliveryReceiptState,
+    ).toBeUndefined();
+    // And the receipt must be completable through the same re-anchoring.
+    await expect(completeRestartRecoveryTerminalDelivery(scope())).resolves.toBe("recorded");
+  });
+
+  it("treats a claimless live owner as not-applicable instead of refusing the reply", async () => {
+    // The observed production case: the owning session carries no claim at all,
+    // which the claimless-live path is meant to allow through. Scoped at the
+    // leftover instead, that path cannot match and the send is refused.
+    await seedStaleRequestedEntry();
+    await seedOwningEntry({ status: "running" });
+
+    await expect(beginRestartRecoveryTerminalDelivery(scope())).resolves.toBe("not-applicable");
+  });
+
+  it("stays stale when no entry owns the sessionId", async () => {
+    await seedStaleRequestedEntry();
+
+    await expect(beginRestartRecoveryTerminalDelivery(scope())).resolves.toBe("stale");
+  });
+
+  it("defers to the canonical session-id resolver when several keys share the sessionId", async () => {
+    // Not a strict-uniqueness rule: resolvePreferredSessionKeyForSessionIdMatches
+    // is the same selector session_status, usage and transcript lookups already
+    // use, and it picks the freshest match. Pinning that here so the receipt is
+    // never quietly given its own, divergent notion of which session wins.
+    await seedStaleRequestedEntry();
+    await replaceSessionEntry(
+      { sessionKey: "agent:main:other", storePath: fixture.storePath() },
+      { sessionId: "session-live", status: "running", updatedAt: 2 },
+    );
+    await seedOwningEntry({
+      status: "running",
+      restartRecoveryDeliveryRunId: "recovery-1",
+      restartRecoveryDeliverySourceRunId: "source-1",
+      updatedAt: 3,
+    });
+
+    await expect(beginRestartRecoveryTerminalDelivery(scope())).resolves.toBe("started");
+    expect(
+      loadSessionEntry({ sessionKey: OWNING_KEY, storePath: fixture.storePath() })
+        ?.restartRecoveryDeliveryReceiptState,
+    ).toBe("terminal-pending");
+  });
+});

--- a/src/config/sessions/restart-recovery-receipt.ts
+++ b/src/config/sessions/restart-recovery-receipt.ts
@@ -1,9 +1,14 @@
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
+import { resolvePreferredSessionKeyForSessionIdMatches } from "../../sessions/session-id-resolution.js";
 import {
   hasActiveRestartRecoverySourceClaim,
   hasRestartRecoveryTerminalRun,
 } from "./restart-recovery-state.js";
-import { loadSessionEntry, updateSessionEntry } from "./session-accessor.js";
+import {
+  listSessionEntriesReadOnly,
+  loadSessionEntry,
+  updateSessionEntry,
+} from "./session-accessor.js";
 import type { SessionEntry } from "./types.js";
 
 export type RestartRecoveryTerminalDeliveryScope = {
@@ -43,6 +48,39 @@ function hasClaimlessLiveDeliveryState(
   );
 }
 
+/**
+ * Re-anchors a scope on the session entry that actually holds its sessionId.
+ *
+ * Every predicate in this module compares `entry.sessionId` with
+ * `scope.sessionId`, so a scope naming a session key whose entry holds a
+ * different sessionId can only ever produce a false negative: neither the active
+ * claim nor the claimless-live escape hatch can match. Callers legitimately hold
+ * a key that is not the durable run session. A runtime that sandboxes tool calls
+ * keeps a separate policy session key, and the gateway-owned receipt path scopes
+ * with the request's identity session key, which is that policy key. The
+ * sessionId is the one identifier that is already correct on every path.
+ *
+ * Falls back to the scope untouched when the sessionId is ambiguous or absent
+ * from the store, so this can only ever turn a false refusal into a decision the
+ * other predicates were meant to make.
+ */
+function resolveClaimOwningScope(
+  scope: RestartRecoveryTerminalDeliveryScope,
+): RestartRecoveryTerminalDeliveryScope {
+  const requested = loadSessionEntry({
+    sessionKey: scope.sessionKey,
+    storePath: scope.storePath,
+  });
+  if (requested?.sessionId === scope.sessionId) {
+    return scope;
+  }
+  const matches = listSessionEntriesReadOnly({ storePath: scope.storePath, clone: false })
+    .filter(({ entry }) => entry.sessionId === scope.sessionId)
+    .map(({ sessionKey, entry }): [string, SessionEntry] => [sessionKey, entry]);
+  const owningSessionKey = resolvePreferredSessionKeyForSessionIdMatches(matches, scope.sessionId);
+  return owningSessionKey ? { ...scope, sessionKey: owningSessionKey } : scope;
+}
+
 function loadCurrent(scope: RestartRecoveryTerminalDeliveryScope): SessionEntry | undefined {
   return loadSessionEntry({
     sessionKey: scope.sessionKey,
@@ -53,8 +91,9 @@ function loadCurrent(scope: RestartRecoveryTerminalDeliveryScope): SessionEntry 
 
 /** Persists ambiguity before a terminal external send is allowed to start. */
 export async function beginRestartRecoveryTerminalDelivery(
-  scope: RestartRecoveryTerminalDeliveryScope,
+  requestedScope: RestartRecoveryTerminalDeliveryScope,
 ): Promise<"started" | "blocked" | "stale" | "not-applicable"> {
+  const scope = resolveClaimOwningScope(requestedScope);
   let started = false;
   const updated = await updateSessionEntry(
     { sessionKey: scope.sessionKey, storePath: scope.storePath },
@@ -108,8 +147,11 @@ export async function beginRestartRecoveryTerminalDelivery(
 
 /** Resolves a pre-send ambiguity only after the provider confirms delivery. */
 export async function completeRestartRecoveryTerminalDelivery(
-  scope: RestartRecoveryTerminalDeliveryScope,
+  requestedScope: RestartRecoveryTerminalDeliveryScope,
 ): Promise<"recorded" | "stale"> {
+  // Same re-anchoring as begin, or a receipt armed on the owning session could
+  // never be completed and would leave the entry pending forever.
+  const scope = resolveClaimOwningScope(requestedScope);
   const updated = await updateSessionEntry(
     { sessionKey: scope.sessionKey, storePath: scope.storePath },
     (entry) => {
@@ -148,8 +190,9 @@ export async function completeRestartRecoveryTerminalDelivery(
 
 /** Clears the pre-send intent only when the provider proves no delivery occurred. */
 export async function cancelRestartRecoveryTerminalDelivery(
-  scope: RestartRecoveryTerminalDeliveryScope,
+  requestedScope: RestartRecoveryTerminalDeliveryScope,
 ): Promise<"cleared" | "stale"> {
+  const scope = resolveClaimOwningScope(requestedScope);
   const updated = await updateSessionEntry(
     { sessionKey: scope.sessionKey, storePath: scope.storePath },
     (entry) => {


### PR DESCRIPTION
Closes #111519

Real behavior proof from the affected host is in [this comment](https://github.com/openclaw/openclaw/pull/114779#issuecomment-5106536674): this exact revision now runs there, the re-anchor is observable in the log, and the terminal reply goes out once through the normal `message.action` path with zero refusals, where six of six were refused before.

## What Problem This Solves

Fixes an issue where users chatting with an agent over a channel such as Telegram would get no reply at all, while the channel itself stayed healthy and the inbound message was logged.

The failing path logs `message.action ... errorCode=UNAVAILABLE errorMessage=Error: terminal source reply lost restart recovery ownership`. It retries; when a retry wins the answer arrives late through the `conversations.send` fallback, and when the retries are exhausted the answer is lost silently while the bot still looks alive.

Reported on 2026.7.2-beta.3, independently reproduced on 2026.7.2-beta.4, and current `main` still carries it.

## Why This Change Was Made

Every predicate in `restart-recovery-receipt.ts` compares `entry.sessionId` with `scope.sessionId`: `hasActiveClaim()` requires it, and so does the `hasClaimlessLiveDeliveryState()` escape hatch that exists precisely to let a live turn with no claim through. So a scope naming a session **key** whose entry holds a *different* sessionId cannot produce a correct answer. Both branches miss, and the function falls through to `stale`, which the caller turns into the refusal above. It is a false negative by construction.

Callers legitimately hold a key that is not the durable run session:

- A runtime that sandboxes tool calls keeps a separate policy session key. On the affected host, the live session `agent:main:main` records `runtimePolicySessionKey = agent:main:telegram:default:direct:<redacted>`.
- The gateway-owned receipt path (`server-methods/send.ts`, taken whenever the gateway is not remote, i.e. the common local case) scopes the receipt with `request.sessionKey`, and that key is pinned to the agent runtime identity, so it *must* stay the policy key for authorization to pass.

The sessionId, in contrast, is already correct on every path. So the receipt now re-anchors its scope on the entry that actually owns `scope.sessionId`, using `resolvePreferredSessionKeyForSessionIdMatches`, the same selector `session_status`, usage lookups and transcript key resolution already use. When the sessionId is absent from the store or the selector declines, the scope is passed through untouched, so this can only convert a false refusal into the decision the other predicates were meant to make.

It lands in the receipt module rather than at either call site, so the gateway-owned and caller-owned paths are both covered by one change, and `complete`/`cancel` re-anchor identically. A receipt armed on the owning session must be completable there too, or the entry would be left pending forever.

Two dead ends worth recording, since both look right:

- **Repointing `request.sessionKey` to the run session.** Tried first, on a live host. The gateway rejects it with `INVALID_REQUEST: agent runtime identity does not match the requested session`, and the reply then arrives late through `conversations.send` instead. The identity key and the claim-owning key cannot be the same field.
- **Threading the run session key down to the message tool.** Also tried, also on a live host: inert. The failing receipt is armed gateway-side, so a caller-side field never reaches it, and the refusals continued byte-identically.

## User Impact

Replies go out through the normal reply path instead of being refused, so they arrive once and on time rather than late through the fallback or not at all. Operators no longer need a gateway restart loop to keep a chat answering, which today only buys about 25 minutes. Behavior is unchanged whenever the scope already names the session that owns its sessionId, which is every single-key runtime.

## Evidence

Four new tests in `src/config/sessions/restart-recovery-receipt.test.ts`. The three that assert the fix each fail on the parent commit with `expected 'stale'`, the production symptom:

```text
× arms the receipt on the session that owns the sessionId
  AssertionError: expected 'stale' to be 'started'
× treats a claimless live owner as not-applicable instead of refusing the reply
  AssertionError: expected 'stale' to be 'not-applicable'
× defers to the canonical session-id resolver when several keys share the sessionId
  AssertionError: expected 'stale' to be 'started'
Tests  3 failed | 9 passed (12)
```

The fourth pins the no-owner case as still `stale`, and the nine pre-existing tests in that file pass untouched, including `does not mutate a replacement session`.

Green elsewhere: session accessor and restart recovery suites (58), session-id resolution (141), agents restart recovery (94), outbound source-reply mirror and message-action-runner (74), message tool (145), gateway `send` (78). `tsgo -p tsconfig.core.json`, `oxlint`, `oxfmt --check`, and the `session-accessor`, `session-transcript-reader` and `tsgo-core` boundary guards all clean. The full `pnpm test` lane was not run locally; CI covers it.

### Live evidence

From the affected host, with a temporary diagnostic added at the `stale` return to print the deciding state. Five refusals captured over about an hour, all identical:

```text
[diag] restart-recovery stale sessionKey=agent:main:telegram:default:direct:<redacted>
  scopeSessionId=047c001f-… entry=present entrySessionId=2ac0114f-…
  entryStatus=done entryDeliveryRunId=undefined entrySourceRunId=undefined
  entryReceiptState=undefined
```

Cross-referenced with the store: the entry the scope named was last updated four days earlier and is `done`, while the session holding `scopeSessionId` is `agent:main:main`, `status: running`, updated the same second as the refusal. So the receipt was reading a stale session while the live one sat beside it, which is what this change corrects. It also explains why `sessions cleanup --enforce --fix-dm-scope` shifted the symptom for the original reporter without eliminating it: retiring the stale DM entry changes which entry is found, not which one is looked for.

**After the fix, on that same host** (full log in the [proof comment](https://github.com/openclaw/openclaw/pull/114779#issuecomment-5106536674)): the re-anchor fires with exactly the predicted key pair, `agent:main:telegram:default:direct:<redacted>` to `agent:main:main`, and the terminal reply is delivered once through `res ✓ message.action`. Zero `lost restart recovery ownership` and zero identity errors since. Two re-anchor lines appear per turn, `begin` and `complete`, which is the field evidence for placing this in the receipt module rather than at a call site.

Sample size is one inbound terminal turn, so it is a qualitative flip (6 of 6 refused before, 0 after) rather than a large sample, and the host exercises the gateway-owned receipt path; the caller-owned path is covered by the same function but was not observed in the field.

---

Submitted by Claude Opus 5, an AI agent acting on behalf of dpriscal, who initiated and reviewed this change.
