### PR TITLE
fix(diagnostics): exclude active steering from session backlog

### DIFF
--- a/qa/scenarios/runtime/active-talk-agent-run-status.yaml
+++ b/qa/scenarios/runtime/active-talk-agent-run-status.yaml
@@ -13,12 +13,14 @@ scenario:
     - A consult tool call starts a real active agent run through the Gateway chat path.
     - Status, steering, and follow-up RPCs observe and queue work to that active run.
     - Cancellation RPC aborts that same active run from the owning browser connection.
+    - Both active-run injections remain observable without increasing backlog, and the completed run returns diagnostics to idle with queue depth zero.
   docsRefs:
     - docs/nodes/talk.md
     - docs/web/control-ui.md
   codeRefs:
     - src/gateway/server-methods/talk-client.ts
     - src/talk/agent-run-control.ts
+    - src/logging/diagnostic.ts
     - test/e2e/qa-lab/runtime/media-talk-gateway.ts
   execution:
     kind: script

--- a/src/agents/embedded-agent-runner/runs.diagnostics.test.ts
+++ b/src/agents/embedded-agent-runner/runs.diagnostics.test.ts
@@ -1,4 +1,6 @@
 import { afterEach, describe, expect, it } from "vitest";
+import { createReplyOperation } from "../../auto-reply/reply/reply-run-registry.js";
+import { testing as replyRunTesting } from "../../auto-reply/reply/reply-run-registry.test-support.js";
 import {
   onDiagnosticEvent,
   setDiagnosticsEnabledForProcess,
@@ -7,6 +9,7 @@ import {
   getDiagnosticSessionState,
   resetDiagnosticSessionStateForTest,
 } from "../../logging/diagnostic-session-state.js";
+import { logMessageQueued, logSessionStateChange } from "../../logging/diagnostic.js";
 import {
   clearActiveEmbeddedRun,
   queueEmbeddedAgentMessageWithOutcome,
@@ -14,18 +17,28 @@ import {
 } from "./runs.js";
 import { testing } from "./runs.test-support.js";
 
-describe("embedded-agent run diagnostics", () => {
+function startDiagnosticTurn(sessionId: string): void {
+  logMessageQueued({ sessionId, source: "test-turn" });
+  logSessionStateChange({ sessionId, state: "processing" });
+}
+
+function finishDiagnosticTurn(sessionId: string): void {
+  logSessionStateChange({ sessionId, state: "idle" });
+}
+
+describe("active run injection diagnostics", () => {
   afterEach(() => {
     testing.resetActiveEmbeddedRuns();
+    replyRunTesting.resetReplyRunRegistry();
     resetDiagnosticSessionStateForTest();
     setDiagnosticsEnabledForProcess(false);
   });
 
   it("does not retain active-run steering as idle session backlog", () => {
     setDiagnosticsEnabledForProcess(true);
-    const queuedDepths: number[] = [];
+    const queuedDepths: Array<number | undefined> = [];
     const unsubscribe = onDiagnosticEvent((event) => {
-      if (event.type === "message.queued") {
+      if (event.type === "message.queued" && event.source === "embedded-agent-runner") {
         queuedDepths.push(event.queueDepth);
       }
     });
@@ -35,24 +48,63 @@ describe("embedded-agent run diagnostics", () => {
       isCompacting: () => false,
       abort: () => {},
     };
+    startDiagnosticTurn("session-steer-diagnostics");
+    setActiveEmbeddedRun("session-steer-diagnostics", handle);
     try {
-      setActiveEmbeddedRun("session-steer-diagnostics", handle);
-
       expect(
         queueEmbeddedAgentMessageWithOutcome("session-steer-diagnostics", "first").queued,
       ).toBe(true);
       expect(
         queueEmbeddedAgentMessageWithOutcome("session-steer-diagnostics", "second").queued,
       ).toBe(true);
-
-      clearActiveEmbeddedRun("session-steer-diagnostics", handle);
     } finally {
+      clearActiveEmbeddedRun("session-steer-diagnostics", handle);
+      finishDiagnosticTurn("session-steer-diagnostics");
       unsubscribe();
     }
 
     expect(getDiagnosticSessionState({ sessionId: "session-steer-diagnostics" }).queueDepth).toBe(
       0,
     );
-    expect(queuedDepths).toEqual([0, 0]);
+    expect(queuedDepths).toEqual([1, 1]);
+  });
+
+  it("does not retain reply-run steering as idle session backlog", () => {
+    setDiagnosticsEnabledForProcess(true);
+    const queuedDepths: Array<number | undefined> = [];
+    const unsubscribe = onDiagnosticEvent((event) => {
+      if (event.type === "message.queued" && event.source === "embedded-agent-runner") {
+        queuedDepths.push(event.queueDepth);
+      }
+    });
+    const operation = createReplyOperation({
+      sessionKey: "agent:main:reply-steer-diagnostics",
+      sessionId: "session-reply-steer-diagnostics",
+      resetTriggered: false,
+    });
+    operation.attachBackend({
+      kind: "cli",
+      cancel: () => {},
+      isStreaming: () => true,
+      queueMessage: async () => {},
+    });
+    operation.setPhase("running");
+    try {
+      startDiagnosticTurn("session-reply-steer-diagnostics");
+      expect(
+        queueEmbeddedAgentMessageWithOutcome("session-reply-steer-diagnostics", "first").queued,
+      ).toBe(true);
+      expect(
+        queueEmbeddedAgentMessageWithOutcome("session-reply-steer-diagnostics", "second").queued,
+      ).toBe(true);
+    } finally {
+      operation.complete();
+      finishDiagnosticTurn("session-reply-steer-diagnostics");
+      unsubscribe();
+    }
+
+    expect(getDiagnosticSessionState({ sessionId: "session-reply-steer-diagnostics" }).queueDepth)
+      .toBe(0);
+    expect(queuedDepths).toEqual([1, 1]);
   });
 });

--- a/src/agents/embedded-agent-runner/runs.diagnostics.test.ts
+++ b/src/agents/embedded-agent-runner/runs.diagnostics.test.ts
@@ -103,8 +103,9 @@ describe("active run injection diagnostics", () => {
       unsubscribe();
     }
 
-    expect(getDiagnosticSessionState({ sessionId: "session-reply-steer-diagnostics" }).queueDepth)
-      .toBe(0);
+    expect(
+      getDiagnosticSessionState({ sessionId: "session-reply-steer-diagnostics" }).queueDepth,
+    ).toBe(0);
     expect(queuedDepths).toEqual([1, 1]);
   });
 });

--- a/src/agents/embedded-agent-runner/runs.diagnostics.test.ts
+++ b/src/agents/embedded-agent-runner/runs.diagnostics.test.ts
@@ -1,0 +1,58 @@
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  onDiagnosticEvent,
+  setDiagnosticsEnabledForProcess,
+} from "../../infra/diagnostic-events.js";
+import {
+  getDiagnosticSessionState,
+  resetDiagnosticSessionStateForTest,
+} from "../../logging/diagnostic-session-state.js";
+import {
+  clearActiveEmbeddedRun,
+  queueEmbeddedAgentMessageWithOutcome,
+  setActiveEmbeddedRun,
+} from "./runs.js";
+import { testing } from "./runs.test-support.js";
+
+describe("embedded-agent run diagnostics", () => {
+  afterEach(() => {
+    testing.resetActiveEmbeddedRuns();
+    resetDiagnosticSessionStateForTest();
+    setDiagnosticsEnabledForProcess(false);
+  });
+
+  it("does not retain active-run steering as idle session backlog", () => {
+    setDiagnosticsEnabledForProcess(true);
+    const queuedDepths: number[] = [];
+    const unsubscribe = onDiagnosticEvent((event) => {
+      if (event.type === "message.queued") {
+        queuedDepths.push(event.queueDepth);
+      }
+    });
+    const handle = {
+      queueMessage: async () => {},
+      isStreaming: () => true,
+      isCompacting: () => false,
+      abort: () => {},
+    };
+    try {
+      setActiveEmbeddedRun("session-steer-diagnostics", handle);
+
+      expect(
+        queueEmbeddedAgentMessageWithOutcome("session-steer-diagnostics", "first").queued,
+      ).toBe(true);
+      expect(
+        queueEmbeddedAgentMessageWithOutcome("session-steer-diagnostics", "second").queued,
+      ).toBe(true);
+
+      clearActiveEmbeddedRun("session-steer-diagnostics", handle);
+    } finally {
+      unsubscribe();
+    }
+
+    expect(getDiagnosticSessionState({ sessionId: "session-steer-diagnostics" }).queueDepth).toBe(
+      0,
+    );
+    expect(queuedDepths).toEqual([0, 0]);
+  });
+});

--- a/src/agents/embedded-agent-runner/runs.ts
+++ b/src/agents/embedded-agent-runner/runs.ts
@@ -33,9 +33,9 @@ import {
   markDiagnosticEmbeddedRunStarted,
   resolveRunStaleThresholdMs,
 } from "../../logging/diagnostic-run-activity.js";
+import { logMessageQueuedWithBacklogPolicy } from "../../logging/diagnostic-runtime.js";
 import {
   diagnosticLogger as diag,
-  logMessageQueued,
   logSessionStateChange,
   updateDiagnosticSessionFile,
 } from "../../logging/diagnostic.js";
@@ -348,11 +348,13 @@ function formatQueueError(err: unknown): string {
 function logActiveRunMessageAccepted(sessionId: string): void {
   // Active-run steering is consumed by the current turn, not queued as another
   // turn for the single idle transition to drain. Keep the event and activity.
-  logMessageQueued({
-    sessionId,
-    source: "embedded-agent-runner",
-    countsTowardBacklog: false,
-  });
+  logMessageQueuedWithBacklogPolicy(
+    {
+      sessionId,
+      source: "embedded-agent-runner",
+    },
+    false,
+  );
 }
 
 function isEmbeddedQueueHandleMessageInjectable(

--- a/src/agents/embedded-agent-runner/runs.ts
+++ b/src/agents/embedded-agent-runner/runs.ts
@@ -324,11 +324,7 @@ export function queueEmbeddedAgentMessageWithOutcome(
   if (prepared.kind === "complete") {
     return prepared.outcome;
   }
-  logMessageQueued({
-    sessionId,
-    source: "embedded-agent-runner",
-    countsTowardBacklog: false,
-  });
+  logActiveRunMessageAccepted(sessionId);
   void prepared.handle
     .queueMessage(text, options ?? { steeringMode: "all" })
     .catch((err: unknown) => {
@@ -347,6 +343,16 @@ export function queueEmbeddedAgentMessageWithOutcome(
 
 function formatQueueError(err: unknown): string {
   return err instanceof Error ? err.message : String(err);
+}
+
+function logActiveRunMessageAccepted(sessionId: string): void {
+  // Active-run steering is consumed by the current turn, not queued as another
+  // turn for the single idle transition to drain. Keep the event and activity.
+  logMessageQueued({
+    sessionId,
+    source: "embedded-agent-runner",
+    countsTowardBacklog: false,
+  });
 }
 
 function isEmbeddedQueueHandleMessageInjectable(
@@ -431,11 +437,7 @@ export async function queueEmbeddedAgentMessageWithOutcomeAsync(
     const enqueuedAtMs = Date.now();
     await prepared.handle.queueMessage(text, options ?? { steeringMode: "all" });
     const deliveredAtMs = options?.waitForTranscriptCommit ? Date.now() : undefined;
-    logMessageQueued({
-      sessionId,
-      source: "embedded-agent-runner",
-      countsTowardBacklog: false,
-    });
+    logActiveRunMessageAccepted(sessionId);
     return {
       queued: true,
       sessionId,
@@ -476,7 +478,7 @@ function prepareEmbeddedAgentQueueMessage(
     }
     const queuedReplyRunMessage = queueReplyRunMessage(sessionId, text, options);
     if (queuedReplyRunMessage) {
-      logMessageQueued({ sessionId, source: "embedded-agent-runner" });
+      logActiveRunMessageAccepted(sessionId);
       return {
         kind: "complete",
         outcome: {

--- a/src/agents/embedded-agent-runner/runs.ts
+++ b/src/agents/embedded-agent-runner/runs.ts
@@ -324,7 +324,11 @@ export function queueEmbeddedAgentMessageWithOutcome(
   if (prepared.kind === "complete") {
     return prepared.outcome;
   }
-  logMessageQueued({ sessionId, source: "embedded-agent-runner" });
+  logMessageQueued({
+    sessionId,
+    source: "embedded-agent-runner",
+    countsTowardBacklog: false,
+  });
   void prepared.handle
     .queueMessage(text, options ?? { steeringMode: "all" })
     .catch((err: unknown) => {
@@ -427,7 +431,11 @@ export async function queueEmbeddedAgentMessageWithOutcomeAsync(
     const enqueuedAtMs = Date.now();
     await prepared.handle.queueMessage(text, options ?? { steeringMode: "all" });
     const deliveredAtMs = options?.waitForTranscriptCommit ? Date.now() : undefined;
-    logMessageQueued({ sessionId, source: "embedded-agent-runner" });
+    logMessageQueued({
+      sessionId,
+      source: "embedded-agent-runner",
+      countsTowardBacklog: false,
+    });
     return {
       queued: true,
       sessionId,

--- a/src/logging/diagnostic-runtime.ts
+++ b/src/logging/diagnostic-runtime.ts
@@ -3,6 +3,7 @@ import {
   areDiagnosticsEnabledForProcess,
   emitInternalDiagnosticEvent as emitDiagnosticEvent,
 } from "../infra/diagnostic-events.js";
+import { getDiagnosticSessionState, type SessionRef } from "./diagnostic-session-state.js";
 import { createSubsystemLogger } from "./subsystem.js";
 
 // Shared diagnostic logger and queue-activity event helpers.
@@ -25,6 +26,45 @@ export function getLastDiagnosticActivityAt(): number {
 /** Clears diagnostic activity state for tests. */
 export function resetDiagnosticActivityForTest(): void {
   lastActivityAt = 0;
+}
+
+type DiagnosticMessageQueueParams = SessionRef & {
+  channel?: string;
+  source: string;
+};
+
+/** Records queue activity while letting internal run owners distinguish steering from backlog. */
+export function logMessageQueuedWithBacklogPolicy(
+  params: DiagnosticMessageQueueParams,
+  countsTowardBacklog: boolean,
+): void {
+  if (!areDiagnosticsEnabledForProcess()) {
+    return;
+  }
+  const state = getDiagnosticSessionState(params);
+  if (countsTowardBacklog) {
+    state.queueDepth += 1;
+  }
+  state.lastActivity = Date.now();
+  state.generation = (state.generation ?? 0) + 1;
+  state.lastStuckWarnAgeMs = undefined;
+  state.lastLongRunningWarnAgeMs = undefined;
+  if (diag.isEnabled("debug")) {
+    diag.debug(
+      `message queued: sessionId=${state.sessionId ?? "unknown"} sessionKey=${
+        state.sessionKey ?? "unknown"
+      } source=${params.source} queueDepth=${state.queueDepth} sessionState=${state.state}`,
+    );
+  }
+  emitDiagnosticEvent({
+    type: "message.queued",
+    sessionId: state.sessionId,
+    sessionKey: state.sessionKey,
+    channel: params.channel,
+    source: params.source,
+    queueDepth: state.queueDepth,
+  });
+  markDiagnosticActivity();
 }
 
 /** Logs and emits a diagnostic event when work enters a serialized lane. */

--- a/src/logging/diagnostic.ts
+++ b/src/logging/diagnostic.ts
@@ -670,6 +670,7 @@ export function logMessageQueued(params: {
   sessionKey?: string;
   channel?: string;
   source: string;
+  /** False when an active run consumes the message without creating a queued turn. */
   countsTowardBacklog?: boolean;
 }) {
   if (!areDiagnosticsEnabledForProcess()) {

--- a/src/logging/diagnostic.ts
+++ b/src/logging/diagnostic.ts
@@ -670,12 +670,15 @@ export function logMessageQueued(params: {
   sessionKey?: string;
   channel?: string;
   source: string;
+  countsTowardBacklog?: boolean;
 }) {
   if (!areDiagnosticsEnabledForProcess()) {
     return;
   }
   const state = getDiagnosticSessionState(params);
-  state.queueDepth += 1;
+  if (params.countsTowardBacklog !== false) {
+    state.queueDepth += 1;
+  }
   state.lastActivity = Date.now();
   state.generation = (state.generation ?? 0) + 1;
   state.lastStuckWarnAgeMs = undefined;

--- a/src/logging/diagnostic.ts
+++ b/src/logging/diagnostic.ts
@@ -29,6 +29,7 @@ import {
 import {
   diagnosticLogger as diag,
   getLastDiagnosticActivityAt,
+  logMessageQueuedWithBacklogPolicy,
   markDiagnosticActivity as markActivity,
   resetDiagnosticActivityForTest,
 } from "./diagnostic-runtime.js";
@@ -670,36 +671,8 @@ export function logMessageQueued(params: {
   sessionKey?: string;
   channel?: string;
   source: string;
-  /** False when an active run consumes the message without creating a queued turn. */
-  countsTowardBacklog?: boolean;
 }) {
-  if (!areDiagnosticsEnabledForProcess()) {
-    return;
-  }
-  const state = getDiagnosticSessionState(params);
-  if (params.countsTowardBacklog !== false) {
-    state.queueDepth += 1;
-  }
-  state.lastActivity = Date.now();
-  state.generation = (state.generation ?? 0) + 1;
-  state.lastStuckWarnAgeMs = undefined;
-  state.lastLongRunningWarnAgeMs = undefined;
-  if (diag.isEnabled("debug")) {
-    diag.debug(
-      `message queued: sessionId=${state.sessionId ?? "unknown"} sessionKey=${
-        state.sessionKey ?? "unknown"
-      } source=${params.source} queueDepth=${state.queueDepth} sessionState=${state.state}`,
-    );
-  }
-  emitDiagnosticEvent({
-    type: "message.queued",
-    sessionId: state.sessionId,
-    sessionKey: state.sessionKey,
-    channel: params.channel,
-    source: params.source,
-    queueDepth: state.queueDepth,
-  });
-  markActivity();
+  logMessageQueuedWithBacklogPolicy(params, true);
 }
 
 export function logMessageReceived(params: {

--- a/test/e2e/qa-lab/runtime/media-talk-gateway.ts
+++ b/test/e2e/qa-lab/runtime/media-talk-gateway.ts
@@ -13,6 +13,7 @@ import {
 import { startQaGatewayChild } from "../../../../extensions/qa-lab/src/gateway-child.js";
 import { startQaMockOpenAiServer } from "../../../../extensions/qa-lab/src/providers/mock-openai/server.js";
 import { GatewayClient, type GatewayClientOptions } from "../../../../src/gateway/client.js";
+import type { DiagnosticStabilitySnapshot } from "../../../../src/logging/diagnostic-stability.js";
 import {
   GATEWAY_CLIENT_MODES,
   GATEWAY_CLIENT_NAMES,
@@ -542,7 +543,29 @@ async function runActiveTalkAgentRunProof(options: ProducerOptions): Promise<str
     });
     assertControlResult(cancel, { mode: "cancel", active: true, aborted: true });
     await consultRequest;
-    return `real Gateway pid=${gateway.pid ?? "unknown"}; persistent WebChat connection created Talk session and completed status, steer, follow-up, cancel RPCs`;
+    const queuedDiagnostics = await client.request<DiagnosticStabilitySnapshot>(
+      "diagnostics.stability",
+      { type: "message.queued", limit: 20 },
+    );
+    const steeringQueueDepths = queuedDiagnostics.events
+      .filter((event) => event.source === "embedded-agent-runner")
+      .map((event) => event.queueDepth);
+    if (JSON.stringify(steeringQueueDepths) !== JSON.stringify([1, 1])) {
+      throw new Error(
+        `active-run steering changed diagnostic backlog: ${JSON.stringify(queuedDiagnostics.events)}`,
+      );
+    }
+    const stateDiagnostics = await client.request<DiagnosticStabilitySnapshot>(
+      "diagnostics.stability",
+      { type: "session.state", limit: 20 },
+    );
+    const finalState = stateDiagnostics.events.at(-1);
+    if (finalState?.outcome !== "idle" || finalState.queueDepth !== 0) {
+      throw new Error(
+        `Talk run did not finish with empty diagnostic backlog: ${JSON.stringify(stateDiagnostics.events)}`,
+      );
+    }
+    return `real Gateway pid=${gateway.pid ?? "unknown"}; persistent WebChat connection completed status, steer, follow-up, cancel RPCs; steeringQueueDepths=${steeringQueueDepths.join(",")}; finalState=${finalState.outcome}; finalQueueDepth=${finalState.queueDepth}`;
   } finally {
     client?.stop();
     await gateway?.stop().catch(() => undefined);

--- a/test/e2e/qa-lab/runtime/media-talk-gateway.ts
+++ b/test/e2e/qa-lab/runtime/media-talk-gateway.ts
@@ -442,20 +442,29 @@ async function waitForActiveTalkStatus(client: GatewayClient, sessionKey: string
 async function waitForQueuedTalkSteer(client: GatewayClient, sessionKey: string) {
   const deadline = Date.now() + 20_000;
   let lastResult: unknown;
+  let lastError: unknown;
   while (Date.now() < deadline) {
-    lastResult = await client.request("talk.client.steer", {
-      sessionKey,
-      text: "use the safer path",
-      mode: "steer",
-    });
-    if (
-      lastResult &&
-      typeof lastResult === "object" &&
-      (lastResult as Record<string, unknown>).queued === true
-    ) {
-      return lastResult;
+    try {
+      lastResult = await client.request("talk.client.steer", {
+        sessionKey,
+        text: "use the safer path",
+        mode: "steer",
+      });
+      lastError = undefined;
+      if (
+        lastResult &&
+        typeof lastResult === "object" &&
+        (lastResult as Record<string, unknown>).queued === true
+      ) {
+        return lastResult;
+      }
+    } catch (error) {
+      lastError = error;
     }
     await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+  if (lastError instanceof Error) {
+    throw lastError;
   }
   throw new Error(`timed out waiting for steerable Talk run: ${JSON.stringify(lastResult)}`);
 }
@@ -527,6 +536,9 @@ async function runActiveTalkAgentRunProof(options: ProducerOptions): Promise<str
       name: "openclaw_agent_consult",
       args: { question: "final-only marker streaming qa check: inspect the active run" },
     });
+    // A failed control step can end the scenario before this long-lived request
+    // is awaited; observe rejection immediately so cleanup cannot mask the cause.
+    void consultRequest.catch(() => undefined);
     const steer = await waitForQueuedTalkSteer(client, sessionKey);
     assertControlResult(steer, { mode: "steer", active: true, queued: true });
     await waitForActiveTalkStatus(client, sessionKey);

--- a/test/e2e/qa-lab/runtime/media-talk-gateway.ts
+++ b/test/e2e/qa-lab/runtime/media-talk-gateway.ts
@@ -466,6 +466,7 @@ async function runActiveTalkAgentRunProof(options: ProducerOptions): Promise<str
   const mock = await startQaMockOpenAiServer({ finalOnlyMarkerPauseMs: 60_000 });
   let gateway: Awaited<ReturnType<typeof startQaGatewayChild>> | undefined;
   let client: GatewayClient | undefined;
+  let diagnosticsClient: GatewayClient | undefined;
   try {
     gateway = await startQaGatewayChild({
       repoRoot: options.repoRoot,
@@ -543,7 +544,13 @@ async function runActiveTalkAgentRunProof(options: ProducerOptions): Promise<str
     });
     assertControlResult(cancel, { mode: "cancel", active: true, aborted: true });
     await consultRequest;
-    const queuedDiagnostics = await client.request<DiagnosticStabilitySnapshot>(
+    diagnosticsClient = await connectGatewayClient({
+      clientName: GATEWAY_CLIENT_NAMES.CLI,
+      mode: GATEWAY_CLIENT_MODES.CLI,
+      token: gateway.token,
+      url: gateway.wsUrl,
+    });
+    const queuedDiagnostics = await diagnosticsClient.request<DiagnosticStabilitySnapshot>(
       "diagnostics.stability",
       { type: "message.queued", limit: 20 },
     );
@@ -555,7 +562,7 @@ async function runActiveTalkAgentRunProof(options: ProducerOptions): Promise<str
         `active-run steering changed diagnostic backlog: ${JSON.stringify(queuedDiagnostics.events)}`,
       );
     }
-    const stateDiagnostics = await client.request<DiagnosticStabilitySnapshot>(
+    const stateDiagnostics = await diagnosticsClient.request<DiagnosticStabilitySnapshot>(
       "diagnostics.stability",
       { type: "session.state", limit: 20 },
     );
@@ -567,6 +574,7 @@ async function runActiveTalkAgentRunProof(options: ProducerOptions): Promise<str
     }
     return `real Gateway pid=${gateway.pid ?? "unknown"}; persistent WebChat connection completed status, steer, follow-up, cancel RPCs; steeringQueueDepths=${steeringQueueDepths.join(",")}; finalState=${finalState.outcome}; finalQueueDepth=${finalState.queueDepth}`;
   } finally {
+    diagnosticsClient?.stop();
     client?.stop();
     await gateway?.stop().catch(() => undefined);
     await mock.stop();

--- a/test/e2e/qa-lab/runtime/media-talk-gateway.ts
+++ b/test/e2e/qa-lab/runtime/media-talk-gateway.ts
@@ -544,6 +544,8 @@ async function runActiveTalkAgentRunProof(options: ProducerOptions): Promise<str
     });
     assertControlResult(cancel, { mode: "cancel", active: true, aborted: true });
     await consultRequest;
+    client.stop();
+    client = undefined;
     diagnosticsClient = await connectGatewayClient({
       clientName: GATEWAY_CLIENT_NAMES.CLI,
       mode: GATEWAY_CLIENT_MODES.CLI,

--- a/test/e2e/qa-lab/runtime/media-talk-gateway.ts
+++ b/test/e2e/qa-lab/runtime/media-talk-gateway.ts
@@ -466,7 +466,6 @@ async function runActiveTalkAgentRunProof(options: ProducerOptions): Promise<str
   const mock = await startQaMockOpenAiServer({ finalOnlyMarkerPauseMs: 60_000 });
   let gateway: Awaited<ReturnType<typeof startQaGatewayChild>> | undefined;
   let client: GatewayClient | undefined;
-  let diagnosticsClient: GatewayClient | undefined;
   try {
     gateway = await startQaGatewayChild({
       repoRoot: options.repoRoot,
@@ -546,16 +545,10 @@ async function runActiveTalkAgentRunProof(options: ProducerOptions): Promise<str
     await consultRequest;
     client.stop();
     client = undefined;
-    diagnosticsClient = await connectGatewayClient({
-      clientName: GATEWAY_CLIENT_NAMES.CLI,
-      mode: GATEWAY_CLIENT_MODES.CLI,
-      token: gateway.token,
-      url: gateway.wsUrl,
-    });
-    const queuedDiagnostics = await diagnosticsClient.request<DiagnosticStabilitySnapshot>(
-      "diagnostics.stability",
-      { type: "message.queued", limit: 20 },
-    );
+    const queuedDiagnostics = (await gateway.call("diagnostics.stability", {
+      type: "message.queued",
+      limit: 20,
+    })) as DiagnosticStabilitySnapshot;
     const steeringQueueDepths = queuedDiagnostics.events
       .filter((event) => event.source === "embedded-agent-runner")
       .map((event) => event.queueDepth);
@@ -564,10 +557,10 @@ async function runActiveTalkAgentRunProof(options: ProducerOptions): Promise<str
         `active-run steering changed diagnostic backlog: ${JSON.stringify(queuedDiagnostics.events)}`,
       );
     }
-    const stateDiagnostics = await diagnosticsClient.request<DiagnosticStabilitySnapshot>(
-      "diagnostics.stability",
-      { type: "session.state", limit: 20 },
-    );
+    const stateDiagnostics = (await gateway.call("diagnostics.stability", {
+      type: "session.state",
+      limit: 20,
+    })) as DiagnosticStabilitySnapshot;
     const finalState = stateDiagnostics.events.at(-1);
     if (finalState?.outcome !== "idle" || finalState.queueDepth !== 0) {
       throw new Error(
@@ -576,7 +569,6 @@ async function runActiveTalkAgentRunProof(options: ProducerOptions): Promise<str
     }
     return `real Gateway pid=${gateway.pid ?? "unknown"}; persistent WebChat connection completed status, steer, follow-up, cancel RPCs; steeringQueueDepths=${steeringQueueDepths.join(",")}; finalState=${finalState.outcome}; finalQueueDepth=${finalState.queueDepth}`;
   } finally {
-    diagnosticsClient?.stop();
     client?.stop();
     await gateway?.stop().catch(() => undefined);
     await mock.stop();


### PR DESCRIPTION
Closes #98685

AI-assisted: yes. Ho Lim authored the initial fix and regression; maintainer follow-up widened the owner boundary and added durable live proof.

## What Problem This Solves

Messages accepted into an active run were counted as queued session backlog. When one run absorbed multiple steering messages, completion decremented the diagnostic depth only once, leaving an idle session with a false positive `queueDepth > 0` even though every message had been processed.

The same bug existed in three sibling paths: immediate embedded-run steering, awaited embedded-run steering, and steering into an attached reply-run backend.

## Why This Change Was Made

All active-run injection paths now use one internal diagnostic helper that preserves the existing `message.queued` event and activity refresh while explicitly excluding the injected message from queued-turn backlog. The public `logMessageQueued` API keeps its original always-increment contract, so ordinary message lifecycle and true queued work remain unchanged.

The existing real Gateway Talk QA scenario now checks the production diagnostic contract after steer and follow-up RPCs. Its active-run wait retries transient registration races, and its long-lived consult promise is observed immediately so cleanup cannot mask the real failure.

## User Impact

Liveness diagnostics converge to zero queued work after embedded or reply-backed runs process multiple steered messages. This avoids false stuck-session warnings and recovery signals without hiding genuinely waiting session work.

## Evidence

- Before: two accepted active-run steering messages followed by one normal completion left idle `queueDepth=1`.
- Focused regression: both embedded-run and reply-run paths start with one real queued turn, accept two steering messages at observed depths `[1, 1]`, then finish idle at `queueDepth=0`.
- Real Gateway proof: sanitized direct AWS Crabbox `cbx_f91afc61fe35`, run `run_a9ac11aac736`, exact SHA `7d943354868af1b3c1c8f8bbd63774358b81411f`. Public networking, no Tailscale, no instance role, no credential hydration, and only `CI` forwarded.
- Live command: private-QA build followed by `media-talk-gateway.ts --scenario active-talk-agent-run-status`. A packaged Gateway, persistent WebChat Talk client, and mock provider completed consult, status, steer, follow-up, and cancel; evidence recorded `steeringQueueDepths=1,1`, `finalState=idle`, `finalQueueDepth=0`. Total remote time: 5m25s.
- Full private-QA build and plugin SDK export checks passed before the live scenario.
- Final whole-branch autoreview: clean, no accepted/actionable findings, confidence 0.93.

Signed-off-by: Ho Lim <subhoya@gmail.com>
