### PR TITLE
feat(plugins): add manifest-first host contribution bundles

### DIFF
--- a/docs/plugins/manifest.md
+++ b/docs/plugins/manifest.md
@@ -165,6 +165,7 @@ See [Plugins](/tools/plugin) for the full plugin system guide, and [Capability m
 | `dashboard`                          | No       | `object`                     | Dashboard widget data bindings and action verbs. Each entry is validated against a Gateway method registered by this plugin with the required read or write scope. See [dashboard reference](#dashboard-reference).                                                                            |
 | `mcpServers`                         | No       | `Record<string, object>`     | Static MCP server definitions contributed while this plugin is enabled. Relative command arguments and working directories resolve from the plugin root. Operator `mcp.servers` entries override or disable definitions with the same name. See [MCP server reference](#mcp-server-reference). |
 | `contracts`                          | No       | `object`                     | Static capability ownership snapshot for external auth hooks, embeddings, speech, realtime transcription, realtime voice, media-understanding, image/video/music generation, web fetch, web search, worker providers, document/web-content extraction, and tool ownership.                     |
+| `hostIntegrationBundle`              | No       | `object`                     | One atomic, inert host contribution inventory. OpenClaw validates and records it without importing plugin runtime. See [hostIntegrationBundle reference](#hostintegrationbundle-reference).                                                                                                    |
 | `configContracts`                    | No       | `object`                     | Manifest-owned config behavior consumed by generic core helpers: dangerous-flag detection, SecretRef migration targets, and legacy config-path narrowing. See [configContracts reference](#configcontracts-reference).                                                                         |
 | `mediaUnderstandingProviderMetadata` | No       | `Record<string, object>`     | Cheap media-understanding defaults for provider ids declared in `contracts.mediaUnderstandingProviders`.                                                                                                                                                                                       |
 | `imageGenerationProviderMetadata`    | No       | `Record<string, object>`     | Cheap image-generation auth metadata for provider ids declared in `contracts.imageGenerationProviders`, including provider-owned auth aliases and base-url guards.                                                                                                                             |
@@ -625,6 +626,47 @@ the channel root and under `accounts.<id>`. A channel that declares its own
 `help` for one of those keys always wins, so override it whenever the shared
 wording is wrong for your provider. Provider-specific keys such as credentials,
 hosts, and webhooks still need their own hints.
+
+## hostIntegrationBundle reference
+
+Use `hostIntegrationBundle` when one host plugin needs to publish a coherent inventory of contributions that other OpenClaw owners can inspect. OpenClaw reads and validates the bundle before importing plugin runtime code. The declaration does not activate contributions, evaluate readiness, resolve credentials, select owners, or grant runtime authority.
+
+```json
+{
+  "hostIntegrationBundle": {
+    "contractVersion": "host-integration-bundle/v1",
+    "id": "acme/host",
+    "version": "1.0.0",
+    "contributions": [
+      {
+        "owner": "model-provider",
+        "kind": "model-provider-adapter",
+        "id": "acme/inference",
+        "contractVersion": "model-provider-adapter/v1"
+      },
+      {
+        "owner": "provider-request",
+        "kind": "credential-slot-resolver",
+        "id": "acme/inference-token",
+        "contractVersion": "credential-slot-resolver/v1"
+      }
+    ]
+  }
+}
+```
+
+The bundle object has these fields:
+
+| Field             | Type       | Required | Constraints                                                   |
+| ----------------- | ---------- | -------- | ------------------------------------------------------------- |
+| `contractVersion` | `string`   | Yes      | Must be exactly `host-integration-bundle/v1`.                 |
+| `id`              | `string`   | Yes      | Lowercase namespaced id such as `acme/host`.                  |
+| `version`         | `string`   | Yes      | Exact SemVer; ranges such as `^1.0.0` are rejected.           |
+| `contributions`   | `object[]` | Yes      | Non-empty. Contribution ids must be unique within the bundle. |
+
+Each contribution requires `owner`, `kind`, `id`, and `contractVersion`. The owner and kind are lowercase canonical tokens. The id is lowercase and namespaced. The contribution contract version uses a versioned id such as `credential-slot-resolver/v1`.
+
+The schema is closed: unknown bundle or contribution fields make the plugin manifest invalid. This prevents a declaration from implying unsupported activation or readiness behavior. If multiple plugins declare the same bundle id, OpenClaw records an error and rejects every conflicting bundle declaration instead of choosing a winner. Enabled, non-failed declarations retain loader-owned plugin id, source, root, and origin provenance in the current plugin registry snapshot.
 
 ## contracts reference
 

--- a/src/plugins/host-integration-bundle-registry.ts
+++ b/src/plugins/host-integration-bundle-registry.ts
@@ -1,0 +1,42 @@
+/** Registry-scoped view of validated host integration bundle declarations. */
+import type { PluginManifestHostIntegrationBundle } from "./host-integration-bundle.js";
+import type { PluginRegistry } from "./registry-types.js";
+import type { PluginOrigin } from "./types.js";
+
+export type RegisteredHostIntegrationBundle = Readonly<{
+  pluginId: string;
+  source: string;
+  rootDir?: string;
+  origin: PluginOrigin;
+  bundle: PluginManifestHostIntegrationBundle;
+}>;
+
+/** Returns the enabled, non-failed bundle declarations in the supplied registry snapshot. */
+export function listRegisteredHostIntegrationBundles(
+  registry: Pick<PluginRegistry, "plugins">,
+): readonly RegisteredHostIntegrationBundle[] {
+  const registrations = registry.plugins
+    .filter(
+      (
+        plugin,
+      ): plugin is typeof plugin & {
+        hostIntegrationBundle: PluginManifestHostIntegrationBundle;
+      } =>
+        plugin.enabled && plugin.status !== "error" && plugin.hostIntegrationBundle !== undefined,
+    )
+    .map((plugin) =>
+      Object.freeze({
+        pluginId: plugin.id,
+        source: plugin.source,
+        ...(plugin.rootDir ? { rootDir: plugin.rootDir } : {}),
+        origin: plugin.origin,
+        bundle: plugin.hostIntegrationBundle,
+      }),
+    )
+    .toSorted(
+      (left, right) =>
+        left.bundle.id.localeCompare(right.bundle.id) ||
+        left.pluginId.localeCompare(right.pluginId),
+    );
+  return Object.freeze(registrations);
+}

--- a/src/plugins/host-integration-bundle.test.ts
+++ b/src/plugins/host-integration-bundle.test.ts
@@ -1,0 +1,200 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import type { PluginCandidate } from "./discovery.js";
+import { listRegisteredHostIntegrationBundles } from "./host-integration-bundle-registry.js";
+import {
+  HOST_INTEGRATION_BUNDLE_CONTRACT_VERSION,
+  parsePluginManifestHostIntegrationBundle,
+  type PluginManifestHostIntegrationBundle,
+} from "./host-integration-bundle.js";
+import { createPluginRecord } from "./loader-records.js";
+import { loadPluginManifestRegistry } from "./manifest-registry.js";
+import { loadPluginManifest } from "./manifest.js";
+import { createEmptyPluginRegistry } from "./registry-empty.js";
+
+const tempDirs: string[] = [];
+
+function makeTempDir(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-host-bundle-"));
+  tempDirs.push(dir);
+  return dir;
+}
+
+function contribution(id: string) {
+  return {
+    owner: "provider-request",
+    kind: "credential-slot-resolver",
+    id,
+    contractVersion: "credential-slot-resolver/v1",
+  };
+}
+
+function bundle(
+  id = "lobster/host",
+  contributions: unknown[] = [contribution("lobster/capi-token")],
+): Record<string, unknown> {
+  return {
+    contractVersion: HOST_INTEGRATION_BUNDLE_CONTRACT_VERSION,
+    id,
+    version: "1.0.0",
+    contributions,
+  };
+}
+
+function writeManifest(rootDir: string, id: string, hostIntegrationBundle: unknown): void {
+  fs.writeFileSync(
+    path.join(rootDir, "openclaw.plugin.json"),
+    JSON.stringify({
+      id,
+      configSchema: { type: "object", additionalProperties: false, properties: {} },
+      hostIntegrationBundle,
+    }),
+    "utf-8",
+  );
+}
+
+function candidate(rootDir: string, idHint: string): PluginCandidate {
+  return {
+    idHint,
+    source: path.join(rootDir, "index.ts"),
+    rootDir,
+    origin: "workspace",
+  };
+}
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe("host integration bundle manifest", () => {
+  it("normalizes and freezes an inert contribution inventory", () => {
+    const result = parsePluginManifestHostIntegrationBundle(
+      bundle("lobster/host", [
+        {
+          owner: "model-provider",
+          kind: "model-provider-adapter",
+          id: "lobster/capi",
+          contractVersion: "capi-model-provider-adapter/v1",
+        },
+        contribution("lobster/capi-token"),
+      ]),
+    );
+
+    expect(result.ok).toBe(true);
+    if (!result.ok || !result.bundle) {
+      throw new Error("expected bundle");
+    }
+    expect(result.bundle).toMatchObject({
+      id: "lobster/host",
+      version: "1.0.0",
+      contributions: [{ id: "lobster/capi" }, { id: "lobster/capi-token" }],
+    });
+    expect(Object.isFrozen(result.bundle)).toBe(true);
+    expect(Object.isFrozen(result.bundle.contributions)).toBe(true);
+    expect(result.bundle.contributions.every(Object.isFrozen)).toBe(true);
+  });
+
+  it.each([
+    ["unsupported contract", { ...bundle(), contractVersion: "host-integration-bundle/v2" }],
+    ["unscoped bundle id", bundle("lobster")],
+    ["non-exact version", { ...bundle(), version: "^1.0.0" }],
+    ["empty inventory", bundle("lobster/host", [])],
+    [
+      "duplicate contribution",
+      bundle("lobster/host", [
+        contribution("lobster/capi-token"),
+        contribution("lobster/capi-token"),
+      ]),
+    ],
+    [
+      "readiness field",
+      bundle("lobster/host", [
+        {
+          ...contribution("lobster/capi-token"),
+          readinessCriterion: "provider.request.credentials",
+        },
+      ]),
+    ],
+  ])("rejects %s", (_label, value) => {
+    expect(parsePluginManifestHostIntegrationBundle(value)).toMatchObject({ ok: false });
+  });
+
+  it("loads the declaration from openclaw.plugin.json without importing runtime code", () => {
+    const dir = makeTempDir();
+    writeManifest(dir, "lobster-host", bundle());
+
+    const result = loadPluginManifest(dir, false);
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) {
+      throw new Error(result.error);
+    }
+    expect(result.manifest.hostIntegrationBundle?.id).toBe("lobster/host");
+  });
+
+  it("rejects duplicate bundle ownership across the manifest registry", () => {
+    const first = makeTempDir();
+    const second = makeTempDir();
+    writeManifest(first, "lobster-host-a", bundle());
+    writeManifest(second, "lobster-host-b", bundle());
+
+    const registry = loadPluginManifestRegistry({
+      candidates: [candidate(first, "lobster-host-a"), candidate(second, "lobster-host-b")],
+    });
+
+    expect(registry.plugins.map((plugin) => plugin.id)).toEqual([
+      "lobster-host-a",
+      "lobster-host-b",
+    ]);
+    expect(registry.plugins.every((plugin) => plugin.hostIntegrationBundle === undefined)).toBe(
+      true,
+    );
+    expect(
+      registry.diagnostics.filter((entry) =>
+        entry.message.includes('host integration bundle id "lobster/host"'),
+      ),
+    ).toHaveLength(2);
+  });
+
+  it("returns only enabled, non-failed bundles with loader-owned provenance", () => {
+    const parsed = parsePluginManifestHostIntegrationBundle(bundle());
+    if (!parsed.ok || !parsed.bundle) {
+      throw new Error("expected bundle");
+    }
+    const hostBundle = parsed.bundle satisfies PluginManifestHostIntegrationBundle;
+    const registry = createEmptyPluginRegistry();
+    registry.plugins.push(
+      createPluginRecord({
+        id: "lobster-host",
+        source: "/plugins/lobster-host/index.js",
+        rootDir: "/plugins/lobster-host",
+        origin: "workspace",
+        enabled: true,
+        configSchema: true,
+        hostIntegrationBundle: hostBundle,
+      }),
+      createPluginRecord({
+        id: "disabled-host",
+        source: "/plugins/disabled/index.js",
+        origin: "global",
+        enabled: false,
+        configSchema: true,
+        hostIntegrationBundle: hostBundle,
+      }),
+    );
+
+    expect(listRegisteredHostIntegrationBundles(registry)).toEqual([
+      {
+        pluginId: "lobster-host",
+        source: "/plugins/lobster-host/index.js",
+        rootDir: "/plugins/lobster-host",
+        origin: "workspace",
+        bundle: hostBundle,
+      },
+    ]);
+  });
+});

--- a/src/plugins/host-integration-bundle.ts
+++ b/src/plugins/host-integration-bundle.ts
@@ -1,0 +1,157 @@
+/** Static, manifest-owned inventory for one host integration bundle. */
+import { isRecord } from "../utils.js";
+
+export const HOST_INTEGRATION_BUNDLE_CONTRACT_VERSION = "host-integration-bundle/v1" as const;
+
+const EXACT_SEMVER_PATTERN =
+  /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[A-Za-z-][0-9A-Za-z-]*)(?:\.(?:0|[1-9]\d*|\d*[A-Za-z-][0-9A-Za-z-]*))*))?(?:\+([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?$/;
+const NAMESPACED_ID_PATTERN =
+  /^[a-z0-9](?:[a-z0-9._-]*[a-z0-9])?\/[a-z0-9](?:[a-z0-9._-]*[a-z0-9])?$/;
+const TOKEN_PATTERN = /^[a-z0-9](?:[a-z0-9._-]*[a-z0-9])?$/;
+const CONTRACT_VERSION_PATTERN = /^[a-z0-9](?:[a-z0-9._-]*[a-z0-9])?\/v[1-9]\d*$/;
+
+export type PluginManifestHostIntegrationContribution = Readonly<{
+  owner: string;
+  kind: string;
+  id: string;
+  contractVersion: string;
+}>;
+
+export type PluginManifestHostIntegrationBundle = Readonly<{
+  contractVersion: typeof HOST_INTEGRATION_BUNDLE_CONTRACT_VERSION;
+  id: string;
+  version: string;
+  contributions: readonly PluginManifestHostIntegrationContribution[];
+}>;
+
+export type HostIntegrationBundleParseResult =
+  | { ok: true; bundle: PluginManifestHostIntegrationBundle | undefined }
+  | { ok: false; error: string };
+
+function hasOnlyKeys(value: Record<string, unknown>, allowed: readonly string[]): boolean {
+  const allowedKeys = new Set(allowed);
+  return Object.keys(value).every((key) => allowedKeys.has(key));
+}
+
+function readRequiredString(value: Record<string, unknown>, key: string): string | undefined {
+  const candidate = value[key];
+  if (typeof candidate !== "string" || candidate.trim() !== candidate || !candidate) {
+    return undefined;
+  }
+  return candidate;
+}
+
+/**
+ * Parses the versioned bundle declaration without importing plugin runtime code.
+ * Unknown fields fail closed so a plugin cannot imply readiness or activation
+ * semantics that this contract does not implement.
+ */
+export function parsePluginManifestHostIntegrationBundle(
+  value: unknown,
+): HostIntegrationBundleParseResult {
+  if (value === undefined) {
+    return { ok: true, bundle: undefined };
+  }
+  if (!isRecord(value)) {
+    return { ok: false, error: "hostIntegrationBundle must be an object" };
+  }
+  if (!hasOnlyKeys(value, ["contractVersion", "id", "version", "contributions"])) {
+    return { ok: false, error: "hostIntegrationBundle contains unsupported fields" };
+  }
+
+  const contractVersion = readRequiredString(value, "contractVersion");
+  if (contractVersion !== HOST_INTEGRATION_BUNDLE_CONTRACT_VERSION) {
+    return {
+      ok: false,
+      error: `hostIntegrationBundle.contractVersion must be ${HOST_INTEGRATION_BUNDLE_CONTRACT_VERSION}`,
+    };
+  }
+  const id = readRequiredString(value, "id");
+  if (!id || !NAMESPACED_ID_PATTERN.test(id) || id.includes("//")) {
+    return { ok: false, error: "hostIntegrationBundle.id must be a namespaced id" };
+  }
+  const version = readRequiredString(value, "version");
+  if (!version || !EXACT_SEMVER_PATTERN.test(version)) {
+    return { ok: false, error: "hostIntegrationBundle.version must be an exact SemVer" };
+  }
+  if (!Array.isArray(value.contributions) || value.contributions.length === 0) {
+    return {
+      ok: false,
+      error: "hostIntegrationBundle.contributions must be a non-empty array",
+    };
+  }
+
+  const ids = new Set<string>();
+  const contributions: PluginManifestHostIntegrationContribution[] = [];
+  for (const [index, rawContribution] of value.contributions.entries()) {
+    if (
+      !isRecord(rawContribution) ||
+      !hasOnlyKeys(rawContribution, ["owner", "kind", "id", "contractVersion"])
+    ) {
+      return {
+        ok: false,
+        error: `hostIntegrationBundle.contributions[${index}] must contain only owner, kind, id, and contractVersion`,
+      };
+    }
+    const owner = readRequiredString(rawContribution, "owner");
+    const kind = readRequiredString(rawContribution, "kind");
+    const contributionId = readRequiredString(rawContribution, "id");
+    const contributionContractVersion = readRequiredString(rawContribution, "contractVersion");
+    if (!owner || !TOKEN_PATTERN.test(owner)) {
+      return {
+        ok: false,
+        error: `hostIntegrationBundle.contributions[${index}].owner must be a canonical token`,
+      };
+    }
+    if (!kind || !TOKEN_PATTERN.test(kind)) {
+      return {
+        ok: false,
+        error: `hostIntegrationBundle.contributions[${index}].kind must be a canonical token`,
+      };
+    }
+    if (
+      !contributionId ||
+      !NAMESPACED_ID_PATTERN.test(contributionId) ||
+      contributionId.includes("//")
+    ) {
+      return {
+        ok: false,
+        error: `hostIntegrationBundle.contributions[${index}].id must be a namespaced id`,
+      };
+    }
+    if (ids.has(contributionId)) {
+      return {
+        ok: false,
+        error: `hostIntegrationBundle contains duplicate contribution id ${JSON.stringify(contributionId)}`,
+      };
+    }
+    if (
+      !contributionContractVersion ||
+      !CONTRACT_VERSION_PATTERN.test(contributionContractVersion)
+    ) {
+      return {
+        ok: false,
+        error: `hostIntegrationBundle.contributions[${index}].contractVersion must be a versioned contract id`,
+      };
+    }
+    ids.add(contributionId);
+    contributions.push(
+      Object.freeze({
+        owner,
+        kind,
+        id: contributionId,
+        contractVersion: contributionContractVersion,
+      }),
+    );
+  }
+
+  return {
+    ok: true,
+    bundle: Object.freeze({
+      contractVersion: HOST_INTEGRATION_BUNDLE_CONTRACT_VERSION,
+      id,
+      version,
+      contributions: Object.freeze(contributions),
+    }),
+  };
+}

--- a/src/plugins/loader-records.ts
+++ b/src/plugins/loader-records.ts
@@ -2,6 +2,7 @@
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
 import type { PluginCompatCode } from "./compat/registry.js";
 import type { PluginActivationState } from "./config-state.js";
+import type { PluginManifestHostIntegrationBundle } from "./host-integration-bundle.js";
 import type { PluginBundleFormat, PluginDiagnosticCode, PluginFormat } from "./manifest-types.js";
 import type {
   PluginManifestContracts,
@@ -40,6 +41,7 @@ export function createPluginRecord(params: {
   providerIds?: readonly string[];
   configSchema: boolean;
   contracts?: PluginManifestContracts;
+  hostIntegrationBundle?: PluginManifestHostIntegrationBundle;
   dashboard?: PluginManifestDashboard;
   mcpServers?: Record<string, PluginManifestMcpServer>;
 }): PluginRecord {
@@ -97,6 +99,7 @@ export function createPluginRecord(params: {
     configUiHints: undefined,
     configJsonSchema: undefined,
     contracts: params.contracts,
+    hostIntegrationBundle: params.hostIntegrationBundle,
     dashboard: params.dashboard,
     mcpServers: params.mcpServers,
   };

--- a/src/plugins/loader-shared.ts
+++ b/src/plugins/loader-shared.ts
@@ -311,6 +311,7 @@ export function createManifestPluginRecord(params: {
     providerIds: manifestRecord.providers,
     configSchema: Boolean(manifestRecord.configSchema),
     contracts: manifestRecord.contracts,
+    hostIntegrationBundle: manifestRecord.hostIntegrationBundle,
     dashboard: manifestRecord.dashboard,
     mcpServers: manifestRecord.mcpServers,
   });

--- a/src/plugins/manifest-registry.ts
+++ b/src/plugins/manifest-registry.ts
@@ -22,6 +22,7 @@ import {
   type PluginDiscoveryResult,
 } from "./discovery.js";
 import { shouldRejectHardlinkedPluginFiles } from "./hardlink-policy.js";
+import type { PluginManifestHostIntegrationBundle } from "./host-integration-bundle.js";
 import { loadInstalledPluginIndexInstallRecordsSync } from "./installed-plugin-index-record-reader.js";
 import type { PluginManifestCommandAlias } from "./manifest-command-aliases.js";
 import type {
@@ -266,6 +267,7 @@ export type PluginManifestRecord = {
   configSchema?: Record<string, unknown>;
   configUiHints?: Record<string, PluginConfigUiHint>;
   contracts?: PluginManifestContracts;
+  hostIntegrationBundle?: PluginManifestHostIntegrationBundle;
   mediaUnderstandingProviderMetadata?: Record<
     string,
     PluginManifestMediaUnderstandingProviderMetadata
@@ -326,6 +328,48 @@ function rejectCaseFoldedIdCollisions(
     }
   }
   return records.filter((record) => !rejected.has(record));
+}
+
+function rejectHostIntegrationBundleIdCollisions(
+  records: readonly PluginManifestRecord[],
+  diagnostics: PluginDiagnostic[],
+): PluginManifestRecord[] {
+  const recordsByBundleId = new Map<string, PluginManifestRecord[]>();
+  for (const record of records) {
+    const bundleId = record.hostIntegrationBundle?.id;
+    if (!bundleId) {
+      continue;
+    }
+    const matches = recordsByBundleId.get(bundleId) ?? [];
+    matches.push(record);
+    recordsByBundleId.set(bundleId, matches);
+  }
+
+  const rejected = new Set<PluginManifestRecord>();
+  for (const [bundleId, matches] of recordsByBundleId) {
+    if (matches.length < 2) {
+      continue;
+    }
+    const pluginIds = matches.map((record) => record.id).toSorted();
+    const message = `host integration bundle id ${JSON.stringify(bundleId)} is declared by multiple plugins: ${pluginIds.map((id) => JSON.stringify(id)).join(", ")}; refusing all conflicting bundles`;
+    for (const record of matches) {
+      rejected.add(record);
+      diagnostics.push({
+        level: "error",
+        pluginId: record.id,
+        source: record.source,
+        message,
+      });
+    }
+  }
+  return records.map((record) => {
+    if (!rejected.has(record)) {
+      return record;
+    }
+    const copy = { ...record };
+    delete copy.hostIntegrationBundle;
+    return copy;
+  });
 }
 
 function safeStatMtimeMs(filePath: string): number | null {
@@ -623,6 +667,7 @@ function buildRecord(params: {
       params.manifest.contracts,
       officialCatalogManifest?.contracts,
     ),
+    hostIntegrationBundle: params.manifest.hostIntegrationBundle,
     mediaUnderstandingProviderMetadata: params.manifest.mediaUnderstandingProviderMetadata,
     imageGenerationProviderMetadata: params.manifest.imageGenerationProviderMetadata,
     videoGenerationProviderMetadata: params.manifest.videoGenerationProviderMetadata,
@@ -1252,7 +1297,10 @@ export function loadPluginManifestRegistry(
     pushManifestCompatibilityDiagnostics({ record, diagnostics, normalized });
   }
 
-  const plugins = rejectCaseFoldedIdCollisions(records, diagnostics);
+  const plugins = rejectHostIntegrationBundleIdCollisions(
+    rejectCaseFoldedIdCollisions(records, diagnostics),
+    diagnostics,
+  );
   const registry = { plugins, diagnostics: dedupePluginDiagnostics(diagnostics) };
   return registry;
 }

--- a/src/plugins/manifest-types.ts
+++ b/src/plugins/manifest-types.ts
@@ -2,6 +2,7 @@ import type { ModelCatalog } from "@openclaw/model-catalog-core/model-catalog-ty
 import type { ChannelConfigRuntimeSchema } from "../channels/plugins/types.config.js";
 import type { ConfigUiPresentation } from "../shared/config-ui-hints-types.js";
 import type { JsonSchemaObject } from "../shared/json-schema.types.js";
+import type { PluginManifestHostIntegrationBundle } from "./host-integration-bundle.js";
 import type { PluginManifestCommandAlias } from "./manifest-command-aliases.js";
 import type { PluginKind } from "./plugin-kind.types.js";
 
@@ -405,6 +406,8 @@ export type PluginManifest = {
    * compat wiring, and contract coverage without importing plugin runtime.
    */
   contracts?: PluginManifestContracts;
+  /** Atomic, inert host contribution inventory owned by this plugin manifest. */
+  hostIntegrationBundle?: PluginManifestHostIntegrationBundle;
   /** Cheap media-understanding provider defaults without importing plugin runtime. */
   mediaUnderstandingProviderMetadata?: Record<
     string,

--- a/src/plugins/manifest.ts
+++ b/src/plugins/manifest.ts
@@ -7,6 +7,7 @@ import { normalizeTrimmedStringList } from "../../packages/normalization-core/sr
 import { matchRootFileOpenFailure, openRootFileSync } from "../infra/boundary-file-read.js";
 import { isRecord } from "../utils.js";
 import { parseJsonWithJson5Fallback } from "../utils/parse-json-compat.js";
+import { parsePluginManifestHostIntegrationBundle } from "./host-integration-bundle.js";
 import * as capabilityNormalizers from "./manifest-capability-normalizers.js";
 import { normalizeManifestCommandAliases } from "./manifest-command-aliases.js";
 import * as modelProviderNormalizers from "./manifest-model-provider-normalizers.js";
@@ -256,6 +257,16 @@ export function loadPluginManifest(
     setup: setupNormalizers.normalizeManifestSetup(raw.setup),
     qaRunners: setupNormalizers.normalizeManifestQaRunners(raw.qaRunners),
   };
+  const hostIntegrationBundleResult = parsePluginManifestHostIntegrationBundle(
+    raw.hostIntegrationBundle,
+  );
+  if (!hostIntegrationBundleResult.ok) {
+    return cacheResult({
+      ok: false,
+      error: `invalid plugin manifest: ${hostIntegrationBundleResult.error}`,
+      manifestPath,
+    });
+  }
   const dashboardResult = setupNormalizers.normalizeManifestDashboard(raw.dashboard);
   if (!dashboardResult.ok) {
     return cacheResult({
@@ -279,6 +290,7 @@ export function loadPluginManifest(
       version: normalizeOptionalString(raw.version),
       uiHints: setupNormalizers.normalizeConfigUiHints(raw.uiHints),
       contracts: capabilityNormalizers.normalizeManifestContracts(raw.contracts),
+      hostIntegrationBundle: hostIntegrationBundleResult.bundle,
       mediaUnderstandingProviderMetadata:
         capabilityNormalizers.normalizeMediaUnderstandingProviderMetadata(
           raw.mediaUnderstandingProviderMetadata,

--- a/src/plugins/registry-types.ts
+++ b/src/plugins/registry-types.ts
@@ -22,6 +22,7 @@ import type {
   PluginToolMetadataRegistration,
   PluginTrustedToolPolicyRegistration,
 } from "./host-hooks.js";
+import type { PluginManifestHostIntegrationBundle } from "./host-integration-bundle.js";
 import type { PluginManifestRecord } from "./manifest-registry.js";
 import type {
   PluginBundleFormat,
@@ -476,6 +477,7 @@ export type PluginRecord = {
   configUiHints?: Record<string, PluginConfigUiHint>;
   configJsonSchema?: JsonSchemaObject;
   contracts?: PluginManifestContracts;
+  hostIntegrationBundle?: PluginManifestHostIntegrationBundle;
   dashboard?: PluginManifestDashboard;
   mcpServers?: Record<string, PluginManifestMcpServer>;
   memorySlotSelected?: boolean;


### PR DESCRIPTION
Closes #114782

## What Problem This Solves

External host plugins can own several independent OpenClaw contributions, but
the current manifest cannot describe those declarations as one coherent,
deployable inventory. Consumers must reconstruct the relationship from
plugin-specific runtime state or introduce a second registry, losing
manifest-first discovery and deterministic ownership validation.

## Why This Change Was Made

This adds one optional, closed `hostIntegrationBundle` declaration to
`openclaw.plugin.json`. OpenClaw validates and freezes the versioned inventory
without importing plugin runtime, rejects duplicate bundle ownership without
choosing a winner, and carries enabled declarations in the existing registry
snapshot with loader-owned provenance.

The field is deliberately inert: it adds no runtime registration API,
activation, readiness, Status, Doctor, credentials, dispatch, or hosted
execution behavior. Because this is a new plugin-manifest contract, the field
name, versioning boundary, and compatibility posture require confirmation from
the OpenClaw plugin owner before merge.

## User Impact

Ordinary installations see no behavior change and do not need a host bundle.
External plugin authors that package several host-supplied contributions can
publish one deterministic inventory that OpenClaw can inspect before runtime
activation, while every contribution's canonical owner keeps its existing
authority.

## Evidence

- `node scripts/run-vitest.mjs src/plugins/host-integration-bundle.test.ts src/plugins/loader-records.test.ts src/plugins/manifest-registry.test.ts src/plugins/manifest.json5-tolerance.test.ts` — 143 tests passed.
- `pnpm tsgo:core` — passed.
- Type-aware Oxlint on all nine changed TypeScript files — 0 warnings and 0
  errors.
- Oxfmt on all ten changed files — passed.
- `pnpm build` — passed, including all 143 public Plugin SDK subpaths.
- Focused MDX and Markdown lint, the upstream-base i18n glossary check, and
  `pnpm docs:check-links` — passed; 6,239 internal links checked with 0 broken.
- `git diff --check upstream/main...HEAD` — passed.
- `codex review --base upstream/main` — no actionable correctness defects.

## Real behavior proof

Behavior or issue addressed:
A real external Lobster host plugin declares one five-contribution host bundle,
OpenClaw discovers it without importing plugin runtime code, and the enabled
registry snapshot retains loader-owned plugin provenance.

Real environment tested:
Ubuntu 24.04 under WSL2; OpenClaw source checkout at
`dbc74b3c1d2eb3a29f68b97ff4b078d556da7f99`, rebased onto upstream `main` at
`dd248759ef565438fdcd74ec0dd5f5412bd13bb0`; Lobster external-plugin checkout
at `54d133652aa9d2d90083515c549793e3cc2d6188`; production OpenClaw manifest
discovery, loader record construction, and registry snapshot code; no network
services or credentials.

Exact steps or command run after this patch:

1. Point `OPENCLAW_SOURCE_DIR` at the refreshed OpenClaw checkout and
   `LOBSTER_HOST_PLUGIN_DIR` at Lobster's `lobster-host` plugin.
2. Run Lobster's `scripts/validation/openclaw-host-bundle-registry.mjs` through
   the hydrated OpenClaw checkout with `pnpm exec tsx`.

Evidence after fix:

```json
{"proof":"lobster-openclaw-host-bundle","lane":"manifest-discovery","bundleId":"lobster/host","contributionCount":5,"runtimeImported":false}
{"proof":"lobster-openclaw-host-bundle","lane":"registry-snapshot","pluginId":"lobster-host","origin":"workspace","bundleId":"lobster/host"}
{"proof":"lobster-openclaw-host-bundle","result":"pass","openclawHead":"dbc74b3c1d2eb3a29f68b97ff4b078d556da7f99","lobsterHead":"54d133652aa9d2d90083515c549793e3cc2d6188"}
```

Observed result after fix:
OpenClaw accepted the complete immutable bundle, preserved all five
contribution identities, imported no Lobster runtime for discovery, and
exposed exactly one enabled registration bound to the external plugin's source
and workspace origin.

What was not tested:
The five contribution implementations were not activated because this contract
is intentionally inventory-only. No credentials, network service, hosted
dispatch, readiness, Status, or Doctor behavior was exercised.
