### PR TITLE
fix(agents): drop unused originalLength from sessions-yield strip

### DIFF
--- a/src/agents/embedded-agent-runner/run/attempt.sessions-yield.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.sessions-yield.test.ts
@@ -188,12 +188,15 @@ describe("stripSessionsYieldArtifacts", () => {
 
     stripSessionsYieldArtifacts(session);
 
-    const branch = sessionManager.getBranch();
+    // removeTrailingEntries preserves trailing metadata in the transcript
+    // entries while deliberately parking the leaf below it, so the next
+    // append replaces the stripped suffix. Assert on entries, not the branch.
+    const entries = sessionManager.getEntries();
     expect(
-      branch.some((entry) => entry.type === "custom" && entry.customType === "plugin-state"),
+      entries.some((entry) => entry.type === "custom" && entry.customType === "plugin-state"),
     ).toBe(true);
     expect(
-      branch.some(
+      entries.some(
         (entry) =>
           (entry.type === "message" && entry.message.role === "assistant") ||
           (entry.type === "custom_message" &&

--- a/src/agents/embedded-agent-runner/run/attempt.sessions-yield.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.sessions-yield.ts
@@ -179,7 +179,6 @@ export function stripSessionsYieldArtifacts(activeSession: {
   agent: { state: { messages: AgentMessage[] } };
   sessionManager: Pick<SessionManager, "removeTrailingEntries">;
 }) {
-  const originalLength = activeSession.messages.length;
   const strippedMessages = activeSession.messages.slice();
 
   // The tool-calling assistant turn and synthetic abort artifacts form one


### PR DESCRIPTION
## What Problem This Solves

`main` is red after eeeae78bccb (#113190) was merged with failing CI (its head had `check-prod-types: failure`). Two distinct breaks block every PR's merge ref:

1. **TS6133 / lint**: `const originalLength = ...` in `stripSessionsYieldArtifacts` (src/agents/embedded-agent-runner/run/attempt.sessions-yield.ts:182) has no reader — fails `check-prod-types`, `check-test-types`, `check-lint`.
2. **Failing unit test**: `attempt.sessions-yield.test.ts > preserves trailing transcript metadata` asserts the preserved `plugin-state` row appears in `getBranch()`. That contradicts the established `removeTrailingEntries` contract (see the #111949-era test `preserves trailing opaque rows when cleanup removes the preceding entry`, src/agents/sessions/session-manager.test.ts:2268): `preserveTrailing` keeps rows in the transcript entries while deliberately parking the leaf below them so the next append replaces the stripped suffix. Fails `checks-node-compact-large-6` deterministically (also locally on pristine main).

## Why This Change Was Made

Unblock all PR landings; both breaks came from one merged-red PR.

## User Impact

None — deletes one dead declaration and corrects a new test to assert the established contract (entries, not branch). The strip invariant #113190 wanted ("transcript must end with a non-assistant role") still holds and is still asserted.

## Evidence

- `node scripts/run-vitest.mjs src/agents/embedded-agent-runner/run/attempt.sessions-yield.test.ts src/agents/sessions/session-manager.test.ts` — both suites green with the fix; the sessions-yield test fails on pristine main.
- `pnpm tsgo:core` green with the deletion.
- Failure provenance: run 30311697578 (types/lint), run 30312250090 (large-6); #113190 head 5ff86bd843e shows `check-prod-types: failure` pre-merge.
