### PR TITLE
fix(ci): unblock production type checks on main

### DIFF
--- a/src/agents/embedded-agent-runner/run/attempt.sessions-yield.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.sessions-yield.test.ts
@@ -188,12 +188,12 @@ describe("stripSessionsYieldArtifacts", () => {
 
     stripSessionsYieldArtifacts(session);
 
-    const branch = sessionManager.getBranch();
+    const entries = sessionManager.getEntries();
     expect(
-      branch.some((entry) => entry.type === "custom" && entry.customType === "plugin-state"),
+      entries.some((entry) => entry.type === "custom" && entry.customType === "plugin-state"),
     ).toBe(true);
     expect(
-      branch.some(
+      entries.some(
         (entry) =>
           (entry.type === "message" && entry.message.role === "assistant") ||
           (entry.type === "custom_message" &&

--- a/src/agents/embedded-agent-runner/run/attempt.sessions-yield.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.sessions-yield.ts
@@ -179,7 +179,6 @@ export function stripSessionsYieldArtifacts(activeSession: {
   agent: { state: { messages: AgentMessage[] } };
   sessionManager: Pick<SessionManager, "removeTrailingEntries">;
 }) {
-  const originalLength = activeSession.messages.length;
   const strippedMessages = activeSession.messages.slice();
 
   // The tool-calling assistant turn and synthetic abort artifacts form one


### PR DESCRIPTION
Regression from #113190.

## What Problem This Solves

Resolves a problem where `main` failed `check-prod-types` in CI run https://github.com/openclaw/openclaw/actions/runs/30311299346 after the sessions-yield transcript cleanup landed.

## Why This Change Was Made

The cleanup left an unused `originalLength` declaration, so `tsgo:prod` stopped on TS6133. This removes that dead declaration. The focused regression file also asserted preserved metadata through the active branch view; it now checks all persisted entries, matching `SessionManager.removeTrailingEntries` semantics without changing runtime behavior.

## User Impact

No product behavior changes. Production type checking on `main` is unblocked, and the sessions-yield persistence regression test now verifies the intended storage boundary.

## Evidence

- Before: `pnpm tsgo:prod` failed at `src/agents/embedded-agent-runner/run/attempt.sessions-yield.ts:182` with TS6133.
- After: `pnpm tsgo:prod` passes on the final rebased head.
- `node scripts/run-vitest.mjs src/agents/embedded-agent-runner/run/attempt.sessions-yield.test.ts` — 6 tests passed.
- `node_modules/.bin/oxfmt --check src/agents/embedded-agent-runner/run/attempt.sessions-yield.ts src/agents/embedded-agent-runner/run/attempt.sessions-yield.test.ts` — clean.
- `git diff --check` — clean.
- Autoreview (`--mode uncommitted`) — clean, no accepted/actionable findings.

AI-assisted: yes. The patch was manually traced through the caller, persistence callee, sibling cleanup path, and focused tests.
