### PR TITLE
fix(release): exclude automation changelog credit

### DIFF
--- a/.agents/skills/openclaw-changelog-update/scripts/verify-release-notes.mjs
+++ b/.agents/skills/openclaw-changelog-update/scripts/verify-release-notes.mjs
@@ -24,7 +24,15 @@ const repo = "openclaw/openclaw";
 const githubSnapshotSchemaVersion = 1;
 const githubSnapshotCheckpointInterval = 25;
 const commitAssociationQueryBatchSize = 20;
-const excludedHandles = new Set(["openclaw", "clawsweeper", "claude", "codex", "steipete"]);
+const excludedHandles = new Set([
+  "openclaw",
+  "clawsweeper",
+  "claude",
+  "codex",
+  "hugin-bot",
+  "steipete",
+  "steipete-oai",
+]);
 const nonEditorialTypes = new Set([
   "build",
   "chore",
@@ -405,7 +413,7 @@ function escapeRegExp(value) {
   return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
-function isEligibleHandle(handle) {
+export function isEligibleHandle(handle) {
   return (
     typeof handle === "string" &&
     handle.toLowerCase() !== "undefined" &&

--- a/src/agents/embedded-agent-runner/run/attempt.sessions-yield.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.sessions-yield.test.ts
@@ -188,12 +188,12 @@ describe("stripSessionsYieldArtifacts", () => {
 
     stripSessionsYieldArtifacts(session);
 
-    const branch = sessionManager.getBranch();
+    const entries = sessionManager.getEntries();
     expect(
-      branch.some((entry) => entry.type === "custom" && entry.customType === "plugin-state"),
+      entries.some((entry) => entry.type === "custom" && entry.customType === "plugin-state"),
     ).toBe(true);
     expect(
-      branch.some(
+      entries.some(
         (entry) =>
           (entry.type === "message" && entry.message.role === "assistant") ||
           (entry.type === "custom_message" &&

--- a/src/agents/embedded-agent-runner/run/attempt.sessions-yield.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.sessions-yield.ts
@@ -179,7 +179,6 @@ export function stripSessionsYieldArtifacts(activeSession: {
   agent: { state: { messages: AgentMessage[] } };
   sessionManager: Pick<SessionManager, "removeTrailingEntries">;
 }) {
-  const originalLength = activeSession.messages.length;
   const strippedMessages = activeSession.messages.slice();
 
   // The tool-calling assistant turn and synthetic abort artifacts form one

--- a/test/external-script-modules.d.ts
+++ b/test/external-script-modules.d.ts
@@ -173,6 +173,7 @@ declare module "*openclaw-changelog-update/scripts/verify-release-notes.mjs" {
   };
   export function countTopLevelSectionBullets(sectionSource: string, heading: string): number;
   export function highlightCountError(sectionSource: string): string | undefined;
+  export function isEligibleHandle(handle: string): boolean;
   export function ledgerChecks(...args: unknown[]): string[];
 }
 

--- a/test/scripts/verify-release-notes.test.ts
+++ b/test/scripts/verify-release-notes.test.ts
@@ -15,6 +15,7 @@ import {
   defaultGithubSnapshotPath,
   githubApiWithSnapshot,
   highlightCountError,
+  isEligibleHandle,
   persistGithubSnapshot,
   pullRequestTitleFromCommitSubject,
   releaseNoteReferences,
@@ -48,6 +49,13 @@ function git(cwd: string, args: string[]): string {
 }
 
 describe("release-note verification", () => {
+  it("excludes maintainer and automation identities from contributor credit", () => {
+    expect(isEligibleHandle("human-contributor")).toBe(true);
+    expect(isEligibleHandle("steipete")).toBe(false);
+    expect(isEligibleHandle("steipete-oai")).toBe(false);
+    expect(isEligibleHandle("hugin-bot")).toBe(false);
+  });
+
   it("accepts only canonical commit PR suffixes", () => {
     expect(pullRequestTitleFromCommitSubject("Fix status (#102147)", 102147)).toBe("Fix status");
     expect(pullRequestTitleFromCommitSubject("Fix status(#102147)", 102147)).toBeUndefined();


### PR DESCRIPTION
## What Problem This Solves

Prevents release-note generation from crediting the `steipete-oai` maintainer automation account and `hugin-bot` as human contributors. The 2026.7.2 beta.5 ledger currently emits both handles, which conflicts with the release attribution policy and blocks final changelog verification.

## Why This Change Was Made

The existing centralized contributor eligibility filter already excludes maintainer and automation identities. This adds the two observed automation handles to that exact boundary and exports the helper for direct regression coverage.

## User Impact

No product behavior changes. Future generated changelogs keep human credit intact while omitting these automation identities.

## Evidence

- Reproduced in the generated 2026.7.2 ledger for PRs #114477, #114512, and #114524
- Ran the PR-head verifier against the real anchored 2026.7.2 release range in a detached proof worktree: `2026.7.2: 3909 PRs, 151 issues, verified, GitHub snapshot 571 hits/5 misses`
- The regenerated target section contains zero `steipete-oai` or `hugin-bot` matches while retaining human credit, including `Thanks @vincentkoc` and `Thanks @obviyus`
- Added direct positive/negative eligibility assertions
- Node syntax, formatting, `git diff --check`, and autoreview are clean
