### PR TITLE
fix(browser): restore shared tabs after extension reconnect

### DIFF
--- a/extensions/browser/src/browser/extension-relay/relay-bridge.test.ts
+++ b/extensions/browser/src/browser/extension-relay/relay-bridge.test.ts
@@ -384,6 +384,41 @@ describe("ExtensionRelayBridge", () => {
     expect(bridge.extensionConnected).toBe(false);
   });
 
+  it("reattaches retained tabs to auto-attach clients after the extension reconnects", async () => {
+    const bridge = new ExtensionRelayBridge();
+    const firstExtension = wireExtension(bridge);
+    sendHello(firstExtension.handlers);
+
+    const client = new FakeSocket();
+    const cdp = bridge.attachCdpClientSocket(client);
+    cdp.onMessage(
+      JSON.stringify({ id: 1, method: "Target.setAutoAttach", params: { autoAttach: true } }),
+    );
+    await flush();
+
+    expect(
+      client.frames().filter((frame) => frame.method === "Target.attachedToTarget"),
+    ).toHaveLength(1);
+
+    firstExtension.handlers.onClose();
+    await flush();
+
+    const secondExtension = wireExtension(bridge);
+    sendHello(secondExtension.handlers);
+    await flush();
+
+    const attachments = client
+      .frames()
+      .filter((frame) => frame.method === "Target.attachedToTarget");
+    expect(attachments).toHaveLength(2);
+    expect(attachments[1]?.params).toMatchObject({
+      targetInfo: { targetId: "target-1" },
+    });
+    expect(
+      secondExtension.socket.frames().find((frame) => frame.type === "attach"),
+    ).toMatchObject({ tabId: 1 });
+  });
+
   it("reports malformed CDP client JSON instead of leaving the client waiting", () => {
     const bridge = new ExtensionRelayBridge();
     const client = new FakeSocket();

--- a/extensions/browser/src/browser/extension-relay/relay-bridge.ts
+++ b/extensions/browser/src/browser/extension-relay/relay-bridge.ts
@@ -355,6 +355,7 @@ export class ExtensionRelayBridge {
 
   private syncTabs(tabs: RelayTabInfo[]): void {
     const nextIds = new Set(tabs.map((tab) => tab.tabId));
+    const hasAutoAttachClient = [...this.clients].some((client) => client.autoAttach);
     for (const [tabId, tab] of this.tabs) {
       if (!nextIds.has(tabId)) {
         if (tab.attached) {
@@ -367,11 +368,25 @@ export class ExtensionRelayBridge {
       const existing = this.tabs.get(info.tabId);
       if (existing) {
         existing.info = info;
+        // Extension reconnects preserve the shared-tab inventory but clear the
+        // old CDP attachments. Reattach those retained tabs for persistent
+        // auto-attach clients just as we do for newly shared tabs.
+        if (!existing.attached && hasAutoAttachClient) {
+          void this.ensureTabAttached(info.tabId)
+            .then(({ targetId, sessionId }) => {
+              this.announceAttachedTab(info.tabId, targetId, sessionId, {
+                onlyAutoAttach: true,
+              });
+            })
+            .catch((err: unknown) => {
+              log.warn(`auto-attach of retained tab ${info.tabId} failed: ${String(err)}`);
+            });
+        }
       } else {
         this.tabs.set(info.tabId, { info });
         // Newly shared tab: expose it to auto-attach clients right away so an
         // agent mid-session sees tabs the user shares via the toolbar action.
-        if ([...this.clients].some((client) => client.autoAttach)) {
+        if (hasAutoAttachClient) {
           void this.ensureTabAttached(info.tabId)
             .then(({ targetId, sessionId }) => {
               this.announceAttachedTab(info.tabId, targetId, sessionId, { onlyAutoAttach: true });


### PR DESCRIPTION
Related: #103785

AI-assisted; implementation and live reproduction reviewed by the submitting operator.

## What Problem This Solves

Fixes an issue where users controlling shared Chrome tabs through the extension relay would lose previously shared tabs from Browser-tool enumeration after the extension service worker disconnected and reconnected. The relay still reported those tabs through /json/list, but persistent Playwright clients could remain limited to whichever tabs attached later.

## Why This Change Was Made

The relay intentionally retains shared-tab inventory across extension reconnects and clears stale CDP attachments. On the next tab sync, it now reattaches retained-but-unattached tabs for existing auto-attach clients, matching the behavior already used for newly shared tabs.

## User Impact

Existing shared tabs reappear automatically after an extension reconnect. Users no longer need to restart the Gateway or reshuffle tabs to repair a stale persistent controller view.

## Evidence

- Live pre-fix reproduction on OpenClaw 2026.7.2-beta.4: the authenticated relay /json/list reported eight shared tabs while the Browser tool, through its persistent Playwright controller, exposed only one. A fresh diagnostic CDP client attached all eight, isolating the stale view to the retained controller connection.
- Added a focused regression test that starts an auto-attach CDP client, disconnects the extension, reconnects with the same retained tab, and verifies the client receives a new Target.attachedToTarget event and the replacement extension receives an attach command.
- git diff --check passes.
- Focused CI is pending on this draft PR.