### PR TITLE
fix(browser): abort lifecycle barrier waits

### DIFF
--- a/extensions/browser/src/browser/server-context.lifecycle.abort.test.ts
+++ b/extensions/browser/src/browser/server-context.lifecycle.abort.test.ts
@@ -1,0 +1,59 @@
+// Browser tests cover cancellation while waiting on the per-profile lifecycle barrier.
+import { describe, expect, it, vi } from "vitest";
+import {
+  enqueueProfileStart,
+  getOrCreateProfileRuntime,
+  withProfileOperationLease,
+} from "./server-context.lifecycle.js";
+import { makeBrowserProfile } from "./server-context.test-harness.js";
+import type { BrowserServerState } from "./server-context.types.js";
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
+}
+
+describe("profile lifecycle barrier cancellation", () => {
+  it("stops waiting when the caller aborts without cancelling the lifecycle owner", async () => {
+    const profile = makeBrowserProfile();
+    const state = {
+      resolved: { profiles: { [profile.name]: profile } },
+      profiles: new Map(),
+    } as unknown as BrowserServerState;
+    const runtime = getOrCreateProfileRuntime(state, profile);
+    const startGate = deferred<void>();
+    const startEntered = deferred<void>();
+    const start = enqueueProfileStart({
+      state,
+      runtime,
+      configRevision: 0,
+      key: "stuck-start",
+      run: async () => {
+        startEntered.resolve();
+        await startGate.promise;
+      },
+    });
+    await startEntered.promise;
+
+    const abort = new AbortController();
+    const run = vi.fn(async () => "never");
+    const operation = withProfileOperationLease({
+      state,
+      runtime,
+      configRevision: 0,
+      signal: abort.signal,
+      run,
+    });
+    const reason = new Error("browser request timed out");
+    abort.abort(reason);
+
+    await expect(operation).rejects.toBe(reason);
+    expect(run).not.toHaveBeenCalled();
+
+    startGate.resolve();
+    await expect(start).resolves.toBeUndefined();
+  });
+});

--- a/extensions/browser/src/browser/server-context.lifecycle.ts
+++ b/extensions/browser/src/browser/server-context.lifecycle.ts
@@ -171,7 +171,7 @@ function combineSignals(lifecycleSignal: AbortSignal, callerSignal?: AbortSignal
   return AbortSignal.any([lifecycleSignal, callerSignal]);
 }
 
-function waitForStart(promise: Promise<void>, signal?: AbortSignal): Promise<void> {
+function waitForLifecycleBarrier(promise: Promise<void>, signal?: AbortSignal): Promise<void> {
   if (!signal) {
     return promise;
   }
@@ -299,7 +299,7 @@ export async function withProfileOperationLease<T>(params: {
   // skipped between observing an old settled tail and lease admission.
   for (;;) {
     const ready = actor.tail;
-    await ready;
+    await waitForLifecycleBarrier(ready, params.signal);
     if (actor.tail === ready) {
       break;
     }
@@ -340,7 +340,7 @@ export function enqueueProfileStart(params: {
   const actor = getProfileLifecycle(params.runtime);
   const existing = actor.starts.get(params.key);
   if (existing) {
-    return waitForStart(existing, params.signal);
+    return waitForLifecycleBarrier(existing, params.signal);
   }
 
   const generation = actor.generation;
@@ -361,7 +361,7 @@ export function enqueueProfileStart(params: {
     }
   };
   actor.tail = promise.then(settleStart, settleStart);
-  return waitForStart(promise, params.signal);
+  return waitForLifecycleBarrier(promise, params.signal);
 }
 
 function capturePlaywrightRetirement(


### PR DESCRIPTION
AI-assisted; implementation and live failure analysis reviewed by the submitting operator.

## What Problem This Solves

Fixes an issue where Browser requests that timed out while a profile lifecycle transition was pending could continue waiting inside the browser controller after the caller had already been cancelled. Repeated requests could accumulate behind the same lifecycle barrier and make a managed profile appear permanently wedged even while its Chrome CDP endpoint remained healthy.

## Why This Change Was Made

Profile start waiters already use an abort-aware lifecycle-barrier helper. Ordinary profile operations now use the same helper while waiting for the serialized actor tail, so caller cancellation releases the request without cancelling the lifecycle owner that other callers may still depend on.

## User Impact

Timed-out Browser requests stop consuming controller work while a profile transition is pending. Later retries no longer add abandoned waiters behind the same lifecycle barrier.

## Evidence

- Live pre-fix observation on OpenClaw 2026.7.2-beta.4: direct CDP returned immediately and listed the managed browser targets while Browser status, doctor, and profile requests stayed pending for 10, 15, and 60 seconds.
- Source tracing showed withProfileOperationLease awaited actor.tail without racing the caller AbortSignal, although start waiters already used the abort-aware helper.
- Added a focused regression test that holds a lifecycle-owned start open, begins an ordinary profile operation, aborts that caller, and verifies the operation rejects immediately while the lifecycle owner continues and completes normally.
- git diff --check passes.
- Focused CI is pending on this draft PR.