### PR TITLE
fix(ui): restore questions safely after Gateway reconnects

### DIFF
--- a/ui/src/app/question-prompt.test.ts
+++ b/ui/src/app/question-prompt.test.ts
@@ -1,6 +1,7 @@
 // @vitest-environment node
 // Control UI tests cover operator question parsing and lifecycle state.
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { GatewayRequestError } from "../api/gateway.ts";
 import { waitForFast } from "../test-helpers/wait-for.ts";
 import {
   cancelQuestionPrompt,
@@ -46,11 +47,41 @@ function requestedPayload(overrides: Record<string, unknown> = {}) {
 }
 
 function questionNotFoundError() {
-  return Object.assign(new Error("question was not found"), {
-    name: "GatewayClientRequestError",
+  return new GatewayRequestError({
+    code: "INVALID_REQUEST",
+    message: "question was not found",
     details: { reason: "QUESTION_NOT_FOUND" },
   });
 }
+
+function createDeferredQuestionRequest() {
+  let finishRequest: (value: unknown) => void = () => {};
+  let failRequest: (error: Error) => void = () => {};
+  const request = vi.fn<RequestFn>(
+    () =>
+      new Promise((resolve, reject) => {
+        finishRequest = resolve;
+        failRequest = reject;
+      }),
+  );
+  return {
+    request,
+    resolve: () => finishRequest({ status: "answered" }),
+    reject: () => failRequest(new Error("stale gateway unavailable")),
+  };
+}
+
+const questionResolutionCases = [
+  {
+    action: "answer",
+    resolve: (state: QuestionPromptState) =>
+      submitQuestionPrompt(state, "question-1", { format: ["Compact"] }),
+  },
+  {
+    action: "cancel",
+    resolve: (state: QuestionPromptState) => cancelQuestionPrompt(state, "question-1"),
+  },
+] as const;
 
 afterEach(() => {
   for (const state of states.splice(0)) {
@@ -379,6 +410,226 @@ describe("question RPC helpers", () => {
       id: "question-1",
       cancel: true,
     });
+  });
+});
+
+describe("question resolution connection ownership", () => {
+  it.each(questionResolutionCases)(
+    "ignores an old $action success after the gateway client changes",
+    async ({ resolve }) => {
+      const stale = createDeferredQuestionRequest();
+      const current = createDeferredQuestionRequest();
+      const state = createState();
+      setQuestionPromptClient(state, { request: stale.request });
+      handleQuestionPromptEvent(state, {
+        event: "question.requested",
+        payload: requestedPayload(),
+      });
+
+      const staleResolution = resolve(state);
+      setQuestionPromptClient(state, { request: current.request });
+      expect(state.prompts.has("question-1")).toBe(false);
+      handleQuestionPromptEvent(state, {
+        event: "question.requested",
+        payload: requestedPayload(),
+      });
+
+      const currentResolution = resolve(state);
+      stale.resolve();
+      await staleResolution;
+
+      expect(state.prompts.get("question-1")).toMatchObject({
+        status: "pending",
+        submitting: true,
+        localResolutionConfirmed: false,
+        error: null,
+      });
+
+      current.resolve();
+      await currentResolution;
+      expect(state.prompts.get("question-1")?.localResolutionConfirmed).toBe(true);
+    },
+  );
+
+  it.each(questionResolutionCases)(
+    "ignores an old $action error after the gateway client changes",
+    async ({ resolve }) => {
+      const stale = createDeferredQuestionRequest();
+      const current = createDeferredQuestionRequest();
+      const state = createState();
+      setQuestionPromptClient(state, { request: stale.request });
+      handleQuestionPromptEvent(state, {
+        event: "question.requested",
+        payload: requestedPayload(),
+      });
+
+      const staleResolution = resolve(state);
+      setQuestionPromptClient(state, { request: current.request });
+      expect(state.prompts.has("question-1")).toBe(false);
+      handleQuestionPromptEvent(state, {
+        event: "question.requested",
+        payload: requestedPayload(),
+      });
+
+      const currentResolution = resolve(state);
+      stale.reject();
+      await staleResolution;
+
+      expect(state.prompts.get("question-1")).toMatchObject({
+        status: "pending",
+        submitting: true,
+        localResolutionConfirmed: false,
+        error: null,
+      });
+
+      current.resolve();
+      await currentResolution;
+      expect(state.prompts.get("question-1")?.localResolutionConfirmed).toBe(true);
+    },
+  );
+
+  it.each(questionResolutionCases)(
+    "retires an old $action when the same gateway client reconnects",
+    async ({ resolve }) => {
+      const stale = createDeferredQuestionRequest();
+      const current = createDeferredQuestionRequest();
+      let requestCount = 0;
+      const client = {
+        request: vi.fn<RequestFn>((method, params) => {
+          requestCount += 1;
+          return requestCount === 1
+            ? stale.request(method, params)
+            : current.request(method, params);
+        }),
+      };
+      const state = createState();
+      setQuestionPromptClient(state, client);
+      handleQuestionPromptEvent(state, {
+        event: "question.requested",
+        payload: requestedPayload(),
+      });
+
+      const staleResolution = resolve(state);
+      setQuestionPromptClient(state, null);
+      expect(state.prompts.get("question-1")?.submitting).toBe(false);
+      setQuestionPromptClient(state, client);
+
+      const currentResolution = resolve(state);
+      stale.resolve();
+      await staleResolution;
+
+      expect(state.prompts.get("question-1")).toMatchObject({
+        status: "pending",
+        submitting: true,
+        localResolutionConfirmed: false,
+        error: null,
+      });
+
+      current.resolve();
+      await currentResolution;
+      expect(state.prompts.get("question-1")?.localResolutionConfirmed).toBe(true);
+    },
+  );
+
+  it.each(questionResolutionCases)(
+    "keeps a current $action after same-connection prompt hydration",
+    async ({ resolve }) => {
+      const pending = createDeferredQuestionRequest();
+      const request = vi.fn<RequestFn>((method, params) =>
+        method === "question.list"
+          ? Promise.resolve({ questions: [requestedPayload()] })
+          : pending.request(method, params),
+      );
+      const state = createState();
+      const client = { request };
+      setQuestionPromptClient(state, client);
+      handleQuestionPromptEvent(state, {
+        event: "question.requested",
+        payload: requestedPayload(),
+      });
+
+      const resolution = resolve(state);
+      const original = state.prompts.get("question-1");
+      refreshPendingQuestionsWithRetry(state, client);
+      await waitForFast(() => expect(state.prompts.get("question-1")).not.toBe(original));
+
+      pending.resolve();
+      await resolution;
+
+      expect(state.prompts.get("question-1")).toMatchObject({
+        status: "pending",
+        localResolutionConfirmed: true,
+        error: null,
+      });
+    },
+  );
+
+  it.each(["pending", "answered", "cancelled", "expired"] as const)(
+    "does not carry a %s question into a replacement gateway",
+    (status) => {
+      const firstClient = { request: vi.fn<RequestFn>(async () => ({})) };
+      const secondClient = { request: vi.fn<RequestFn>(async () => ({})) };
+      const state = createState();
+      setQuestionPromptClient(state, firstClient);
+      handleQuestionPromptEvent(state, {
+        event: "question.requested",
+        payload: requestedPayload(),
+      });
+      if (status !== "pending") {
+        handleQuestionPromptEvent(state, {
+          event: "question.resolved",
+          payload:
+            status === "answered"
+              ? {
+                  id: "question-1",
+                  status,
+                  answers: { answers: { format: ["Detailed"] } },
+                }
+              : { id: "question-1", status },
+        });
+      }
+      handleQuestionPromptEvent(state, {
+        event: "question.resolved",
+        payload: { id: "unmatched-first-gateway", status: "cancelled" },
+      });
+      setQuestionPromptClient(state, null);
+
+      setQuestionPromptClient(state, secondClient);
+
+      expect(state.prompts.size).toBe(0);
+      expect(state.unmatchedResolutions.size).toBe(0);
+    },
+  );
+
+  it("preserves authoritative question records when the same gateway reconnects", () => {
+    const client = { request: vi.fn<RequestFn>(async () => ({})) };
+    const state = createState();
+    setQuestionPromptClient(state, client);
+    handleQuestionPromptEvent(state, {
+      event: "question.requested",
+      payload: requestedPayload(),
+    });
+    handleQuestionPromptEvent(state, {
+      event: "question.resolved",
+      payload: {
+        id: "question-1",
+        status: "answered",
+        answers: { answers: { format: ["Detailed"] } },
+      },
+    });
+    handleQuestionPromptEvent(state, {
+      event: "question.resolved",
+      payload: { id: "unmatched-same-gateway", status: "cancelled" },
+    });
+
+    setQuestionPromptClient(state, null);
+    setQuestionPromptClient(state, client);
+
+    expect(state.prompts.get("question-1")).toMatchObject({
+      status: "answered",
+      answers: { answers: { format: ["Detailed"] } },
+    });
+    expect(state.unmatchedResolutions.has("unmatched-same-gateway")).toBe(true);
   });
 });
 

--- a/ui/src/app/question-prompt.ts
+++ b/ui/src/app/question-prompt.ts
@@ -5,7 +5,7 @@ import type {
   QuestionRecord,
   QuestionResolvedEvent,
 } from "../../../packages/gateway-protocol/src/index.js";
-import type { GatewayEventFrame } from "../api/gateway.ts";
+import { GatewayRequestError, type GatewayEventFrame } from "../api/gateway.ts";
 
 type QuestionClient = {
   request: (method: string, params?: unknown) => Promise<unknown>;
@@ -40,6 +40,8 @@ export type QuestionPrompt = {
 
 type QuestionPromptState = {
   client: QuestionClient | null;
+  ownerClient: QuestionClient | null;
+  clientGeneration: number;
   prompts: Map<string, QuestionPrompt>;
   unmatchedResolutions: Map<string, QuestionResolvedEvent>;
   revision: number;
@@ -250,6 +252,8 @@ function parseQuestionResolvedEvent(payload: unknown): QuestionResolvedEvent | n
 export function createQuestionPromptState(onChange: () => void): QuestionPromptState {
   return {
     client: null,
+    ownerClient: null,
+    clientGeneration: 0,
     prompts: new Map(),
     unmatchedResolutions: new Map(),
     revision: 0,
@@ -401,10 +405,9 @@ function parseQuestionGetResult(value: unknown): QuestionRecord | null {
 
 function isQuestionNotFoundError(error: unknown): boolean {
   return (
-    error instanceof Error &&
-    error.name === "GatewayClientRequestError" &&
-    isRecord((error as Error & { details?: unknown }).details) &&
-    (error as Error & { details: Record<string, unknown> }).details.reason === "QUESTION_NOT_FOUND"
+    error instanceof GatewayRequestError &&
+    isRecord(error.details) &&
+    error.details.reason === "QUESTION_NOT_FOUND"
   );
 }
 
@@ -555,7 +558,47 @@ export function setQuestionPromptClient(
     globalThis.clearTimeout(state.refreshRetryTimer);
     state.refreshRetryTimer = null;
   }
+  if (state.client === client) {
+    return;
+  }
+
+  state.clientGeneration += 1;
+  const ownerChanged =
+    client !== null && state.ownerClient !== null && state.ownerClient !== client;
   state.client = client;
+  if (client !== null) {
+    state.ownerClient = client;
+  }
+
+  if (ownerChanged) {
+    const changed = state.prompts.size > 0 || state.unmatchedResolutions.size > 0;
+    if (state.tickTimer) {
+      globalThis.clearTimeout(state.tickTimer);
+      state.tickTimer = null;
+    }
+    state.prompts.clear();
+    state.unmatchedResolutions.clear();
+    if (changed) {
+      state.revision += 1;
+      state.onChange();
+    }
+    return;
+  }
+
+  let changed = false;
+  for (const prompt of state.prompts.values()) {
+    if (!prompt.submitting) {
+      continue;
+    }
+    // The transport owns this submission. Reconnect must release its spinner
+    // without discarding answers needed for authoritative recovery.
+    prompt.submitting = false;
+    prompt.revision = ++state.revision;
+    changed = true;
+  }
+  if (changed) {
+    state.onChange();
+  }
 }
 
 export function disposeQuestionPromptState(state: QuestionPromptState): void {
@@ -567,7 +610,9 @@ export function disposeQuestionPromptState(state: QuestionPromptState): void {
     globalThis.clearTimeout(state.refreshRetryTimer);
     state.refreshRetryTimer = null;
   }
+  state.clientGeneration += 1;
   state.client = null;
+  state.ownerClient = null;
 }
 
 function buildAnswers(values: QuestionAnswerValues): QuestionAnswers {
@@ -583,6 +628,7 @@ async function resolveQuestionPrompt(
 ): Promise<void> {
   const prompt = state.prompts.get(id);
   const client = state.client;
+  const clientGeneration = state.clientGeneration;
   if (!prompt || prompt.status !== "pending" || prompt.submitting) {
     return;
   }
@@ -603,6 +649,9 @@ async function resolveQuestionPrompt(
       "question.resolve",
       submittedAnswers ? { id, answers: submittedAnswers } : { id, cancel: true },
     );
+    if (state.client !== client || state.clientGeneration !== clientGeneration) {
+      return;
+    }
     const current = state.prompts.get(id);
     if (!current) {
       return;
@@ -615,6 +664,9 @@ async function resolveQuestionPrompt(
     current.revision = ++state.revision;
     state.onChange();
   } catch (error) {
+    if (state.client !== client || state.clientGeneration !== clientGeneration) {
+      return;
+    }
     const current = state.prompts.get(id);
     if (!current) {
       return;

--- a/ui/src/e2e/question-flow.e2e.test.ts
+++ b/ui/src/e2e/question-flow.e2e.test.ts
@@ -281,6 +281,35 @@ describeControlUiE2e("Control UI Gateway question flow", () => {
     });
   });
 
+  it("restores the composer when reconnect recovery cannot find an old question", async () => {
+    const { gateway, page } = await openQuestionPage();
+    const request = questionRecord("question-expired-during-disconnect", [
+      {
+        questionId: "deploy_target",
+        header: "Deploy",
+        question: "Where should I deploy after reconnecting?",
+        options: [{ label: "Staging" }, { label: "Production" }],
+      },
+    ]);
+    await emitRequested(gateway, request);
+    const panel = panelFor(page, "Where should I deploy after reconnecting?");
+    await panel.waitFor();
+
+    await gateway.deferNext("question.get");
+    await gateway.closeLatest();
+    const recovery = await gateway.waitForRequest("question.get");
+    expect(recovery.params).toEqual({ id: request.id });
+    await gateway.rejectDeferred("question.get", {
+      code: "INVALID_REQUEST",
+      message: "question was not found",
+      details: { reason: "QUESTION_NOT_FOUND" },
+    });
+
+    await expect.poll(() => panel.count()).toBe(0);
+    await page.locator(".agent-chat__composer-combobox textarea").waitFor();
+    expect(await gateway.getRequests("question.get")).toHaveLength(1);
+  });
+
   it("shows a 1/2 stepper with answered and expired summaries", async () => {
     const { gateway, page } = await openQuestionPage();
     const elsewhere = questionRecord("question-external-answer", [


### PR DESCRIPTION
Closes #114791
Closes #114792

## What Problem This Solves

Fixes an issue where users who switch Gateways see question cards and answers from the previous Gateway in same-named conversations. Resolves a second issue where a question that expired during a disconnect keeps the composer blocked because the browser does not recognize the real Gateway not-found error. Stale answer and cancellation completions could also update the current conversation after connection ownership changed.

## Why This Change Was Made

Question state is owned by its actual Gateway client, while in-flight answer and skip operations are owned by the logical connection generation. Preserve authoritative questions when the same client reconnects; release obsolete submitting state; clear records and unmatched events only when a genuinely different Gateway becomes the owner. Classify the real structured browser GatewayRequestError for QUESTION_NOT_FOUND. Ordinary same-connection hydration remains supported even when it replaces a prompt object.

## User Impact

Switching Gateways no longer carries old question content or composer state into the next account. Same-Gateway reconnects continue to recover legitimate questions, and expired questions restore the normal composer without repeated recovery requests. No authentication, provider, protocol, or configuration behavior changes.

## Evidence

- Failing-first on current main: 11 new Linux failures reproduced Gateway replacement, stale answer/cancel completion, same-client reconnect, pending/answered/cancelled/expired cross-Gateway state, and the real browser error mismatch.
- `pnpm test ui/src/app/question-prompt.test.ts`: 38 passed on Linux Blacksmith Testbox, including all 11 previously failing regressions and same-connection hydration guards.
- `pnpm test:ui:e2e ui/src/e2e/question-flow.e2e.test.ts`: 4 real Linux Chromium scenarios passed, including disconnect, actual WebSocket INVALID_REQUEST / QUESTION_NOT_FOUND recovery, composer restoration, and no extra question.get retries.
- `pnpm check:changed -- ui/src/app/question-prompt.ts ui/src/app/question-prompt.test.ts ui/src/e2e/question-flow.e2e.test.ts`: full remote gate passed, including format, dependency guards, core and UI tsgo typechecking, UI locale verification, and lint with zero warnings.
- Fresh independent autoreview of the exact committed branch against origin/main: clean, no accepted or actionable findings.
- AI-assisted; every changed behavior is covered by failing-first unit or Chromium regression proof.
