### PR TITLE
fix(auto-reply): decide no-visible-reply fallback from settled delivery via a turn ledger

### DIFF
--- a/src/auto-reply/reply/agent-runner-payloads.ts
+++ b/src/auto-reply/reply/agent-runner-payloads.ts
@@ -39,7 +39,7 @@ const replyPayloadsDedupeRuntimeLoader = createLazyImportLoader(
   () => import("./reply-payloads-dedupe.runtime.js"),
 );
 
-function loadReplyPayloadsDedupeRuntime() {
+export function loadReplyPayloadsDedupeRuntime() {
   return replyPayloadsDedupeRuntimeLoader.load();
 }
 

--- a/src/auto-reply/reply/agent-runner-result-payloads.ts
+++ b/src/auto-reply/reply/agent-runner-result-payloads.ts
@@ -175,8 +175,13 @@ export async function prepareReplyAgentPayloads(state: {
     });
     return recovery.kind === "diagnostic" ? recovery.payload : undefined;
   };
-  if (opts?.sourceReplyDeliveryMode === "message_tool_only" && completedSourceReplyDelivery) {
-    await opts.onObservedReplyDelivery?.();
+  // Completed source-reply evidence is already route-aware (the message tool
+  // delivered THIS conversation's reply), so it attests observed delivery in
+  // every mode; the followup runner applies the same contract. Without this, an
+  // automatic-mode turn answered via the message tool plus NO_REPLY draws the
+  // no-visible-reply fallback into the source conversation.
+  if (completedSourceReplyDelivery) {
+    await opts?.onObservedReplyDelivery?.();
   }
   const currentMessageId = sessionCtx.MessageSidFull ?? sessionCtx.MessageSid;
   // A terminal fallback is built separately after normal payload filtering.

--- a/src/auto-reply/reply/agent-runner-result-payloads.ts
+++ b/src/auto-reply/reply/agent-runner-result-payloads.ts
@@ -29,7 +29,7 @@ import {
 } from "./agent-runner-core.js";
 import { buildEmptyInteractiveReplyPayload } from "./agent-runner-failure-reply.js";
 import { signalTypingIfNeeded } from "./agent-runner-helpers.js";
-import { buildReplyPayloads } from "./agent-runner-payloads.js";
+import { buildReplyPayloads, loadReplyPayloadsDedupeRuntime } from "./agent-runner-payloads.js";
 import {
   appendUnscheduledReminderNote,
   hasSessionRelatedCronJobs,
@@ -175,12 +175,27 @@ export async function prepareReplyAgentPayloads(state: {
     });
     return recovery.kind === "diagnostic" ? recovery.payload : undefined;
   };
-  // Completed source-reply evidence is already route-aware (the message tool
-  // delivered THIS conversation's reply), so it attests observed delivery in
-  // every mode; the followup runner applies the same contract. Without this, an
-  // automatic-mode turn answered via the message tool plus NO_REPLY draws the
-  // no-visible-reply fallback into the source conversation.
-  if (completedSourceReplyDelivery) {
+  // Route-aware message-tool delivery attests observed delivery in every mode:
+  // an automatic-mode turn answered via the message tool plus NO_REPLY must not
+  // draw the no-visible-reply fallback into the source conversation. The dedupe
+  // route matcher keeps unrelated-target tool sends from counting as the reply.
+  const sourceRoutedMessagingToolDelivery =
+    completedSourceReplyDelivery ||
+    ((runResult.messagingToolSentTargets?.length ?? 0) > 0 &&
+      (await loadReplyPayloadsDedupeRuntime()).hasSourceRoutedMessagingToolDelivery({
+        config: cfg,
+        messageProvider: followupRun.run.messageProvider,
+        messagingToolSentTargets: runResult.messagingToolSentTargets,
+        messagingToolSentTexts: runResult.messagingToolSentTexts,
+        messagingToolSentMediaUrls: runResult.messagingToolSentMediaUrls,
+        originatingTo: resolveOriginMessageTo({
+          originatingTo: sessionCtx.OriginatingTo,
+          to: sessionCtx.To,
+        }),
+        originatingThreadId: replyRouteThreadId,
+        accountId: sessionCtx.AccountId,
+      }));
+  if (sourceRoutedMessagingToolDelivery) {
     await opts?.onObservedReplyDelivery?.();
   }
   const currentMessageId = sessionCtx.MessageSidFull ?? sessionCtx.MessageSid;

--- a/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
+++ b/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
@@ -3313,6 +3313,7 @@ describe("runReplyAgent private message_tool_only final warning (#85714)", () =>
     strandedReplyRetry?: boolean;
     sendPolicyDenied?: boolean;
     isHeartbeat?: boolean;
+    onObservedReplyDelivery?: () => Promise<void> | void;
     replyOperation?: ReturnType<typeof createReplyOperation>;
     turnAdoptionLifecycle?: FollowupRun["turnAdoptionLifecycle"];
   }) {
@@ -3427,7 +3428,16 @@ describe("runReplyAgent private message_tool_only final warning (#85714)", () =>
       resolvedBlockStreamingBreak: "message_end",
       shouldInjectGroupIntro: false,
       typingMode: "instant",
-      ...(params.isHeartbeat ? { opts: { isHeartbeat: true } } : {}),
+      ...(params.isHeartbeat || params.onObservedReplyDelivery
+        ? {
+            opts: {
+              ...(params.isHeartbeat ? { isHeartbeat: true } : {}),
+              ...(params.onObservedReplyDelivery
+                ? { onObservedReplyDelivery: params.onObservedReplyDelivery }
+                : {}),
+            },
+          }
+        : {}),
       ...(params.replyOperation ? { replyOperation: params.replyOperation } : {}),
     });
     return { storePath, tmp, sessionKey, result, finalAssistantText };
@@ -3437,6 +3447,17 @@ describe("runReplyAgent private message_tool_only final warning (#85714)", () =>
     await runPrivateFinalCase({});
     expect(warnPrivateFinalSpy).toHaveBeenCalledTimes(1);
     expect(warnPrivateFinalSpy.mock.calls[0]?.[0]).toMatchObject({ sessionKey: "stranded" });
+  });
+
+  it("attests observed delivery for message-tool source replies outside message_tool_only", async () => {
+    // A source-routed message-tool answer plus NO_REPLY must not draw the
+    // no-visible-reply fallback into the source conversation (#114799).
+    const onObservedReplyDelivery = vi.fn(async () => {});
+    await runPrivateFinalCase({
+      didDeliverSourceReplyViaMessageTool: true,
+      onObservedReplyDelivery,
+    });
+    expect(onObservedReplyDelivery).toHaveBeenCalledTimes(1);
   });
 
   it("enqueues a one-shot recovery retry by default for substantive stranded finals", async () => {

--- a/src/auto-reply/reply/dispatch-from-config.choose-route.ts
+++ b/src/auto-reply/reply/dispatch-from-config.choose-route.ts
@@ -27,10 +27,7 @@ import {
   mirrorTranscriptAfterDispatcherSettled,
   transcriptMirrorForDeliveredPayload,
 } from "./dispatch-from-config.transcript.js";
-import {
-  captureReplyDispatchDeliveryOutcome,
-  type ReplyDispatchDeliveryOutcome,
-} from "./reply-dispatcher.js";
+import type { ReplyDispatchDeliveryOutcome } from "./reply-dispatcher.js";
 
 export async function chooseDispatchRoute(state: PrepareDispatchOperationReadyState) {
   const {
@@ -84,6 +81,7 @@ export async function chooseDispatchRoute(state: PrepareDispatchOperationReadySt
     suppressHookUserDelivery,
     traceReplyPhase,
     trackDispatchLifecycleWork,
+    turnLedger,
   } = state;
   const shouldSuppressProgressDelivery = () =>
     sendPolicyDenied ||
@@ -179,7 +177,7 @@ export async function chooseDispatchRoute(state: PrepareDispatchOperationReadySt
       await sendPayloadAsync(payload, undefined, false);
     } else {
       markInboundDedupeReplayUnsafe();
-      dispatcher.sendToolResult(payload);
+      turnLedger.sendQueued("tool", payload);
     }
   };
   const flushPendingCommentaryProgress = async () => {
@@ -229,18 +227,17 @@ export async function chooseDispatchRoute(state: PrepareDispatchOperationReadySt
   >();
   const sendTrackedBlockReply = (payload: ReplyPayload): boolean => {
     const contentKey = createBlockReplyContentKey(payload);
-    const delivery = captureReplyDispatchDeliveryOutcome(payload);
-    const queued = dispatcher.sendBlockReply(payload);
-    if (!queued || !delivery.isTracked()) {
-      return queued;
+    const delivery = turnLedger.sendQueued("block", payload);
+    if (!delivery.queued || !delivery.outcome) {
+      return delivery.queued;
     }
     const outcomes = pendingBlockDeliveryOutcomes.get(contentKey);
     if (outcomes) {
-      outcomes.push(delivery.promise);
+      outcomes.push(delivery.outcome);
     } else {
-      pendingBlockDeliveryOutcomes.set(contentKey, [delivery.promise]);
+      pendingBlockDeliveryOutcomes.set(contentKey, [delivery.outcome]);
     }
-    return queued;
+    return delivery.queued;
   };
   const recordRoutedBlockReplyDelivery = (
     payload: ReplyPayload,
@@ -250,9 +247,6 @@ export async function chooseDispatchRoute(state: PrepareDispatchOperationReadySt
       deliveredBlockContentKeys.add(createBlockReplyContentKey(payload));
     }
   };
-  // Routed blocks bypass dispatcher queue counts entirely; this is the only
-  // settled-delivery fact for them (media-only blocks never touch blockCount).
-  const hasDeliveredRoutedBlockReply = (): boolean => deliveredBlockContentKeys.size > 0;
   const wasReplyDeliveredAsBlock = async (
     payload: ReplyPayload,
     abortSignal?: AbortSignal,
@@ -435,10 +429,10 @@ export async function chooseDispatchRoute(state: PrepareDispatchOperationReadySt
     if (finalDeliveryCapture) {
       setReplyPayloadMetadata(normalizedPayload, { finalDeliveryCapture });
     }
-    const deliveryOutcome = captureReplyDispatchDeliveryOutcome(normalizedPayload);
-    const queuedFinal = dispatcher.sendFinalReply(normalizedPayload);
-    const dispatcherOutcome =
-      queuedFinal && deliveryOutcome.isTracked() ? deliveryOutcome.promise : undefined;
+    const { queued: queuedFinal, outcome: dispatcherOutcome } = turnLedger.sendQueued(
+      "final",
+      normalizedPayload,
+    );
     if (queuedFinal && deliveredTranscriptMirror && finalOutcomeBefore) {
       // The common settle owner runs this after successful delivery or
       // cancellation. Keeping reconciliation out of the reply operation lets a
@@ -613,7 +607,6 @@ export async function chooseDispatchRoute(state: PrepareDispatchOperationReadySt
       sendTrackedBlockReply,
       recordRoutedBlockReplyDelivery,
       wasReplyDeliveredAsBlock,
-      hasDeliveredRoutedBlockReply,
       sendFinalPayload,
     },
     {

--- a/src/auto-reply/reply/dispatch-from-config.execute.ts
+++ b/src/auto-reply/reply/dispatch-from-config.execute.ts
@@ -110,6 +110,7 @@ export async function executeDispatch(state: PrepareDispatchExecutionReadyState)
     suppressToolErrorWarnings,
     traceReplyPhase,
     trackDispatchLifecycleWork,
+    turnLedger,
     typing,
     waitForPendingDirectBlockReplyDelivery,
     wrapProgressCallback,
@@ -312,7 +313,7 @@ export async function executeDispatch(state: PrepareDispatchExecutionReadyState)
                       await sendPayloadAsync(deliveryPayload, undefined, false);
                     } else {
                       markInboundDedupeReplayUnsafe();
-                      const delivered = dispatcher.sendToolResult(deliveryPayload);
+                      const delivered = turnLedger.sendQueued("tool", deliveryPayload).queued;
                       if (delivered && hasAskUserPayload(deliveryPayload)) {
                         // ask_user blocks until this callback resolves; drain its prompt now
                         // or the answerable UI can remain queued behind the blocked agent run.

--- a/src/auto-reply/reply/dispatch-from-config.finalize.ts
+++ b/src/auto-reply/reply/dispatch-from-config.finalize.ts
@@ -288,19 +288,22 @@ export async function finalizeDispatchAndAudit(state: ExecuteDispatchReadyState)
     !getObservedReplyDelivery() &&
     !turnLedger.hasVisibleDelivery() &&
     !turnLedger.hasForeignQueuedAdmissions();
+  let queuedSettleResult: Awaited<ReturnType<typeof turnLedger.settleQueued>> = "settled";
   if (noVisibleReplyFallbackAllowed()) {
     // Only a turn that still looks empty pays for settlement: pending admissions
-    // must resolve (beforeDeliver cancellation, transport failure) before the
+    // must resolve (beforeDeliver cancellation, pre-transport failure) before the
     // silence verdict. Turns with settled visibility or a policy-suppressed
     // fallback skip the wait, so deliveries that legitimately outlive the turn
     // (queued same-session mirroring) cannot deadlock the gate on themselves.
-    await turnLedger.settleQueued(getDispatchAbortSignal());
+    queuedSettleResult = await turnLedger.settleQueued(getDispatchAbortSignal());
   }
   let counts = dispatcher.getQueuedCounts();
   let noVisibleReplyFallbackDelivered = false;
   // Visible agent turns must never end silently: empty model completions get a
   // core fallback final. emptyFinalAllowedAsSilent is the only sanctioned silence.
-  if (noVisibleReplyFallbackAllowed()) {
+  // An aborted or timed-out settle leaves delivery state unknown; admission
+  // then keeps its legacy trust and the turn ends without a fallback.
+  if (queuedSettleResult === "settled" && noVisibleReplyFallbackAllowed()) {
     try {
       throwIfDispatchOperationAborted();
       const fallbackPayload: ReplyPayload = { text: NO_VISIBLE_REPLY_FALLBACK_TEXT };
@@ -327,12 +330,13 @@ export async function finalizeDispatchAndAudit(state: ExecuteDispatchReadyState)
         if (fallbackSend.queued) {
           // Settlement decides the flag: a beforeDeliver hook can still cancel
           // the admitted fallback, and a cancelled fallback must keep the
-          // eligibility flag alive for channel-level recovery. The abort-aware
-          // ledger wait keeps a wedged transport from blocking finalization;
-          // untracked dispatchers keep admission as their strongest fact.
-          await turnLedger.settleQueued(getDispatchAbortSignal());
+          // eligibility flag alive for channel-level recovery. The bounded
+          // abort-aware wait keeps a wedged transport from blocking
+          // finalization; on abort/timeout (and for untracked dispatchers)
+          // admission stays the strongest fact so channels cannot double-send.
+          const fallbackSettle = await turnLedger.settleQueued(getDispatchAbortSignal());
           throwIfDispatchOperationAborted();
-          if (turnLedger.hasVisibleDelivery()) {
+          if (fallbackSettle !== "settled" || turnLedger.hasVisibleDelivery()) {
             queuedFinal = true;
             noVisibleReplyFallbackDelivered = true;
             // Re-snapshot so the delivered fallback is reflected in reported counts,

--- a/src/auto-reply/reply/dispatch-from-config.finalize.ts
+++ b/src/auto-reply/reply/dispatch-from-config.finalize.ts
@@ -40,7 +40,6 @@ export async function finalizeDispatchAndAudit(state: ExecuteDispatchReadyState)
     flushPendingCommentaryProgress,
     getDispatchAbortSignal,
     getObservedReplyDelivery,
-    hasDeliveredRoutedBlockReply,
     isRoutedReplyDelivered,
     markIdle,
     markInboundDedupeReplayUnsafe,
@@ -63,6 +62,7 @@ export async function finalizeDispatchAndAudit(state: ExecuteDispatchReadyState)
     suppressAutomaticSourceDelivery,
     suppressDelivery,
     throwIfDispatchOperationAborted,
+    turnLedger,
     waitForPendingDirectBlockReplyDelivery,
   } = state;
   const replies = replyResult ? (Array.isArray(replyResult) ? replyResult : [replyResult]) : [];
@@ -112,8 +112,6 @@ export async function finalizeDispatchAndAudit(state: ExecuteDispatchReadyState)
     getReplyPayloadMetadata(reply)?.deliverDespiteSourceReplySuppression === true &&
     (ctx.InboundEventKind !== "room_event" || explicitCommandTurnCtx);
   const sentFinalPayloadDedupeKeys = new Set<string>();
-  let sawDedupedAgainstBlock = false;
-  let sawVisibleFinalDelivery = false;
   for (const [replyIndex, reply] of replies.entries()) {
     throwIfDispatchOperationAborted();
     // Durable reasoning is a channel-owned lane; generic channels keep the
@@ -148,20 +146,12 @@ export async function finalizeDispatchAndAudit(state: ExecuteDispatchReadyState)
     sentFinalPayloadDedupeKeys.add(finalPayloadDedupeKey);
     const finalReply = await sendFinalPayload(reply, { deliveryId: String(replyIndex) });
     if (finalReply.dedupedAgainstBlock) {
-      sawDedupedAgainstBlock = true;
+      // The delivering block already settled into the turn ledger.
       continue;
     }
     attemptedFinalDelivery = true;
     queuedFinal = finalReply.queuedFinal || queuedFinal;
     routedFinalCount += finalReply.routedFinalCount;
-    // Routed drops of empty payloads report ok without sending anything; only a
-    // contentful final proves visibility for the no-visible-reply fallback gate.
-    if (
-      hasOutboundReplyContent(reply, { trimText: true }) &&
-      (finalReply.queuedFinal || finalReply.routedFinalCount > 0)
-    ) {
-      sawVisibleFinalDelivery = true;
-    }
     if (finalReply.queuedFinal) {
       if (finalReply.dispatcherOutcome) {
         finalDeliveries.push({ outcome: finalReply.dispatcherOutcome, payload: reply });
@@ -263,7 +253,6 @@ export async function finalizeDispatchAndAudit(state: ExecuteDispatchReadyState)
             queuedFinal = result.ok || queuedFinal;
             if (isRoutedReplyDelivered(result)) {
               routedFinalCount += 1;
-              sawVisibleFinalDelivery = true;
             }
             if (!result.ok) {
               logVerbose(
@@ -273,9 +262,8 @@ export async function finalizeDispatchAndAudit(state: ExecuteDispatchReadyState)
           } else {
             throwIfDispatchOperationAborted();
             markInboundDedupeReplayUnsafe();
-            const didQueue = dispatcher.sendFinalReply(normalizedTtsOnlyPayload);
-            queuedFinal = didQueue || queuedFinal;
-            sawVisibleFinalDelivery = didQueue || sawVisibleFinalDelivery;
+            queuedFinal =
+              turnLedger.sendQueued("final", normalizedTtsOnlyPayload).queued || queuedFinal;
           }
         }
       } catch (err) {
@@ -290,26 +278,29 @@ export async function finalizeDispatchAndAudit(state: ExecuteDispatchReadyState)
   }
 
   await waitForPendingDirectBlockReplyDelivery(getDispatchAbortSignal());
+  // Observed delivery is plugin-attested visibility, a trust level the transport
+  // ledger intentionally does not own.
+  const noVisibleReplyFallbackAllowed = () =>
+    !suppressDelivery &&
+    !sendPolicyDenied &&
+    sourceReplyDeliveryMode !== "message_tool_only" &&
+    !emptyFinalAllowedAsSilent &&
+    !getObservedReplyDelivery() &&
+    !turnLedger.hasVisibleDelivery() &&
+    !turnLedger.hasForeignQueuedAdmissions();
+  if (noVisibleReplyFallbackAllowed()) {
+    // Only a turn that still looks empty pays for settlement: pending admissions
+    // must resolve (beforeDeliver cancellation, transport failure) before the
+    // silence verdict. Turns with settled visibility or a policy-suppressed
+    // fallback skip the wait, so deliveries that legitimately outlive the turn
+    // (queued same-session mirroring) cannot deadlock the gate on themselves.
+    await turnLedger.settleQueued(getDispatchAbortSignal());
+  }
   let counts = dispatcher.getQueuedCounts();
   let noVisibleReplyFallbackDelivered = false;
   // Visible agent turns must never end silently: empty model completions get a
   // core fallback final. emptyFinalAllowedAsSilent is the only sanctioned silence.
-  // Routed streamed blocks bypass dispatcher counts, so blockCount and the
-  // deduped-against-block signal must also prove the turn was empty before falling back.
-  if (
-    !suppressDelivery &&
-    !sendPolicyDenied &&
-    sourceReplyDeliveryMode !== "message_tool_only" &&
-    !sawVisibleFinalDelivery &&
-    !getObservedReplyDelivery() &&
-    !emptyFinalAllowedAsSilent &&
-    !sawDedupedAgainstBlock &&
-    !hasDeliveredRoutedBlockReply() &&
-    state.blockCount === 0 &&
-    counts.tool === 0 &&
-    counts.block === 0 &&
-    counts.final === 0
-  ) {
+  if (noVisibleReplyFallbackAllowed()) {
     try {
       throwIfDispatchOperationAborted();
       const fallbackPayload: ReplyPayload = { text: NO_VISIBLE_REPLY_FALLBACK_TEXT };
@@ -332,14 +323,16 @@ export async function finalizeDispatchAndAudit(state: ExecuteDispatchReadyState)
       } else {
         throwIfDispatchOperationAborted();
         markInboundDedupeReplayUnsafe();
-        // Queue admission, not settled delivery: a beforeDeliver hook can still
-        // cancel this payload. Accepted tradeoff until a unified visible-delivery
-        // signal exists; every sibling in this function shares the semantics.
-        const didQueue = dispatcher.sendFinalReply(fallbackPayload);
-        if (didQueue) {
+        const fallbackSend = turnLedger.sendQueued("final", fallbackPayload);
+        // Settlement decides the flag: a beforeDeliver hook can still cancel the
+        // admitted fallback, and a cancelled fallback must keep the eligibility
+        // flag alive for channel-level recovery. Dispatchers without settlement
+        // tracking keep admission as their strongest fact.
+        const fallbackOutcome = fallbackSend.outcome ? await fallbackSend.outcome : "delivered";
+        if (fallbackSend.queued && fallbackOutcome === "delivered") {
           queuedFinal = true;
           noVisibleReplyFallbackDelivered = true;
-          // Re-snapshot so the queued fallback is reflected in reported counts,
+          // Re-snapshot so the delivered fallback is reflected in reported counts,
           // matching the TTS-only path which enqueues before the snapshot.
           counts = dispatcher.getQueuedCounts();
         }
@@ -371,11 +364,10 @@ export async function finalizeDispatchAndAudit(state: ExecuteDispatchReadyState)
         ? { sessionMetadataChanges: state.sessionMetadataChangesForResult }
         : {}),
       ...(getObservedReplyDelivery() ? { observedReplyDelivery: true } : {}),
-      // Eligibility keys off visible delivery, not queue/route admission: an
-      // empty routed final reports ok without sending, and must not mask a
-      // failed fallback from channel-level recovery.
-      ...(!sawVisibleFinalDelivery &&
-      !noVisibleReplyFallbackDelivered &&
+      // Eligibility keys off settled visible delivery: a suppressed or cancelled
+      // final (including the core fallback itself) leaves channel-level recovery
+      // eligible, while any settled visible delivery clears it.
+      ...(!turnLedger.hasVisibleDelivery() &&
       !getObservedReplyDelivery() &&
       !emptyFinalAllowedAsSilent
         ? { noVisibleReplyFallbackEligible: true }

--- a/src/auto-reply/reply/dispatch-from-config.finalize.ts
+++ b/src/auto-reply/reply/dispatch-from-config.finalize.ts
@@ -45,6 +45,7 @@ export async function finalizeDispatchAndAudit(state: ExecuteDispatchReadyState)
     markInboundDedupeReplayUnsafe,
     maybeApplyTtsWithFinalizationLease,
     normalizeReplyMediaPayload,
+    noVisibleReplyFallbackDirected,
     preserveProgressCallbackStartOrder,
     reasoningPayloadsEnabled,
     recordAgentDispatchCompleted,
@@ -279,8 +280,11 @@ export async function finalizeDispatchAndAudit(state: ExecuteDispatchReadyState)
 
   await waitForPendingDirectBlockReplyDelivery(getDispatchAbortSignal());
   // Observed delivery is plugin-attested visibility, a trust level the transport
-  // ledger intentionally does not own.
+  // ledger intentionally does not own. Directedness gates both the fallback and
+  // eligibility: only a turn that positively addressed the bot may surface a
+  // visible failure notice.
   const noVisibleReplyFallbackAllowed = () =>
+    noVisibleReplyFallbackDirected &&
     !suppressDelivery &&
     !sendPolicyDenied &&
     sourceReplyDeliveryMode !== "message_tool_only" &&
@@ -377,7 +381,8 @@ export async function finalizeDispatchAndAudit(state: ExecuteDispatchReadyState)
       // eligible, while any settled visible delivery clears it. An aborted or
       // timed-out settle leaves delivery unresolved, and a fallback reported as
       // delivered must not stay recoverable — either could double-send.
-      ...(queuedSettleResult === "settled" &&
+      ...(noVisibleReplyFallbackDirected &&
+      queuedSettleResult === "settled" &&
       !turnLedger.hasVisibleDelivery() &&
       !noVisibleReplyFallbackDelivered &&
       !getObservedReplyDelivery() &&

--- a/src/auto-reply/reply/dispatch-from-config.finalize.ts
+++ b/src/auto-reply/reply/dispatch-from-config.finalize.ts
@@ -374,8 +374,12 @@ export async function finalizeDispatchAndAudit(state: ExecuteDispatchReadyState)
       ...(getObservedReplyDelivery() ? { observedReplyDelivery: true } : {}),
       // Eligibility keys off settled visible delivery: a suppressed or cancelled
       // final (including the core fallback itself) leaves channel-level recovery
-      // eligible, while any settled visible delivery clears it.
-      ...(!turnLedger.hasVisibleDelivery() &&
+      // eligible, while any settled visible delivery clears it. An aborted or
+      // timed-out settle leaves delivery unresolved, and a fallback reported as
+      // delivered must not stay recoverable — either could double-send.
+      ...(queuedSettleResult === "settled" &&
+      !turnLedger.hasVisibleDelivery() &&
+      !noVisibleReplyFallbackDelivered &&
       !getObservedReplyDelivery() &&
       !emptyFinalAllowedAsSilent
         ? { noVisibleReplyFallbackEligible: true }

--- a/src/auto-reply/reply/dispatch-from-config.finalize.ts
+++ b/src/auto-reply/reply/dispatch-from-config.finalize.ts
@@ -324,17 +324,21 @@ export async function finalizeDispatchAndAudit(state: ExecuteDispatchReadyState)
         throwIfDispatchOperationAborted();
         markInboundDedupeReplayUnsafe();
         const fallbackSend = turnLedger.sendQueued("final", fallbackPayload);
-        // Settlement decides the flag: a beforeDeliver hook can still cancel the
-        // admitted fallback, and a cancelled fallback must keep the eligibility
-        // flag alive for channel-level recovery. Dispatchers without settlement
-        // tracking keep admission as their strongest fact.
-        const fallbackOutcome = fallbackSend.outcome ? await fallbackSend.outcome : "delivered";
-        if (fallbackSend.queued && fallbackOutcome === "delivered") {
-          queuedFinal = true;
-          noVisibleReplyFallbackDelivered = true;
-          // Re-snapshot so the delivered fallback is reflected in reported counts,
-          // matching the TTS-only path which enqueues before the snapshot.
-          counts = dispatcher.getQueuedCounts();
+        if (fallbackSend.queued) {
+          // Settlement decides the flag: a beforeDeliver hook can still cancel
+          // the admitted fallback, and a cancelled fallback must keep the
+          // eligibility flag alive for channel-level recovery. The abort-aware
+          // ledger wait keeps a wedged transport from blocking finalization;
+          // untracked dispatchers keep admission as their strongest fact.
+          await turnLedger.settleQueued(getDispatchAbortSignal());
+          throwIfDispatchOperationAborted();
+          if (turnLedger.hasVisibleDelivery()) {
+            queuedFinal = true;
+            noVisibleReplyFallbackDelivered = true;
+            // Re-snapshot so the delivered fallback is reflected in reported counts,
+            // matching the TTS-only path which enqueues before the snapshot.
+            counts = dispatcher.getQueuedCounts();
+          }
         }
       }
     } catch (err) {

--- a/src/auto-reply/reply/dispatch-from-config.gather.ts
+++ b/src/auto-reply/reply/dispatch-from-config.gather.ts
@@ -343,6 +343,7 @@ export async function gatherDispatchRequest(
     runWithDispatchLifecycleAdmission,
     throwIfDispatchOperationAborted,
     trackDispatchLifecycleWork,
+    turnLedger,
   } = replyOperationCoordinator;
   const maybeApplyTtsWithFinalizationLease = createFinalizationAwareTtsPayloadApplier({
     getReplyOperation: getDispatchReplyOperation,
@@ -470,6 +471,7 @@ export async function gatherDispatchRequest(
       runWithDispatchLifecycleAdmission,
       throwIfDispatchOperationAborted,
       trackDispatchLifecycleWork,
+      turnLedger,
       maybeApplyTtsWithFinalizationLease,
       hookRunner,
       timestamp,

--- a/src/auto-reply/reply/dispatch-from-config.hooks-and-send-policy.test-utils.ts
+++ b/src/auto-reply/reply/dispatch-from-config.hooks-and-send-policy.test-utils.ts
@@ -389,7 +389,7 @@ describe("sendPolicy deny — suppress delivery, not processing (#53328)", () =>
     expect(result).toEqual({ queuedFinal: false, counts: { tool: 0, block: 0, final: 0 } });
   });
 
-  it("delivers core no-visible-reply fallback for disallowed empty group turns", async () => {
+  it("delivers core no-visible-reply fallback for disallowed empty mentioned group turns", async () => {
     setNoAbort();
     const dispatcher = createDispatcher();
     const replyResolver = vi.fn(async () => undefined);
@@ -398,6 +398,7 @@ describe("sendPolicy deny — suppress delivery, not processing (#53328)", () =>
       Surface: "feishu",
       Provider: "feishu",
       SessionKey: "agent:main:feishu:group:oc_group",
+      WasMentioned: true,
     });
 
     const result = await dispatchReplyFromConfig({
@@ -423,6 +424,112 @@ describe("sendPolicy deny — suppress delivery, not processing (#53328)", () =>
       counts: { tool: 0, block: 0, final: 0 },
       noVisibleReplyFallbackDelivered: true,
     });
+    expect(result.noVisibleReplyFallbackEligible).toBeUndefined();
+  });
+
+  it("keeps ambient group turns silent even when silence policy is disallow", async () => {
+    setNoAbort();
+    // The fallback exists for a user who asked and got nothing. An undirected
+    // group turn never draws a visible failure notice, regardless of silence
+    // policy (#114799: ambient HamVerBot group chatter drew fallback spam).
+    const dispatcher = createDispatcher();
+    const replyResolver = vi.fn(async () => undefined);
+    const ctx = buildTestCtx({
+      ChatType: "group",
+      Surface: "telegram",
+      Provider: "telegram",
+      SessionKey: "agent:main:telegram:group:oc_group",
+    });
+
+    const result = await dispatchReplyFromConfig({
+      ctx,
+      cfg: {
+        agents: {
+          defaults: {
+            silentReply: {
+              group: "disallow",
+            },
+          },
+        },
+      } as OpenClawConfig,
+      dispatcher,
+      replyResolver,
+    });
+
+    expect(dispatcher.sendFinalReply).not.toHaveBeenCalled();
+    expect(result.noVisibleReplyFallbackDelivered).toBeUndefined();
+    expect(result.noVisibleReplyFallbackEligible).toBeUndefined();
+  });
+
+  it("keeps room_event turns silent even when silence policy is disallow", async () => {
+    setNoAbort();
+    const dispatcher = createDispatcher();
+    const replyResolver = vi.fn(async () => undefined);
+    const ctx = buildTestCtx({
+      ChatType: "group",
+      Surface: "telegram",
+      Provider: "telegram",
+      SessionKey: "agent:main:telegram:group:oc_group",
+      InboundEventKind: "room_event",
+    });
+
+    const result = await dispatchReplyFromConfig({
+      ctx,
+      cfg: {
+        agents: {
+          defaults: {
+            silentReply: {
+              group: "disallow",
+            },
+          },
+        },
+      } as OpenClawConfig,
+      dispatcher,
+      replyResolver,
+    });
+
+    expect(dispatcher.sendFinalReply).not.toHaveBeenCalledWith({
+      text: NO_VISIBLE_REPLY_FALLBACK_TEXT,
+    });
+    expect(result.noVisibleReplyFallbackDelivered).toBeUndefined();
+    expect(result.noVisibleReplyFallbackEligible).toBeUndefined();
+  });
+
+  it("keeps room_event turns silent even when they carry a mention", async () => {
+    setNoAbort();
+    // A room_event is ambient by construction; a stray WasMentioned/direct
+    // classification must not promote it to a directed turn (only a command
+    // turn does, matching the room_event source-reply suppression bypass).
+    const dispatcher = createDispatcher();
+    const replyResolver = vi.fn(async () => undefined);
+    const ctx = buildTestCtx({
+      ChatType: "group",
+      Surface: "telegram",
+      Provider: "telegram",
+      SessionKey: "agent:main:telegram:group:oc_group",
+      InboundEventKind: "room_event",
+      WasMentioned: true,
+    });
+
+    const result = await dispatchReplyFromConfig({
+      ctx,
+      cfg: {
+        agents: {
+          defaults: {
+            silentReply: {
+              group: "disallow",
+            },
+          },
+        },
+      } as OpenClawConfig,
+      dispatcher,
+      replyResolver,
+    });
+
+    expect(dispatcher.sendFinalReply).not.toHaveBeenCalledWith({
+      text: NO_VISIBLE_REPLY_FALLBACK_TEXT,
+    });
+    expect(result.noVisibleReplyFallbackDelivered).toBeUndefined();
     expect(result.noVisibleReplyFallbackEligible).toBeUndefined();
   });
 
@@ -525,6 +632,7 @@ describe("sendPolicy deny — suppress delivery, not processing (#53328)", () =>
       Surface: "telegram",
       Provider: "telegram",
       SessionKey: "agent:main:telegram:group:oc_group",
+      WasMentioned: true,
     });
 
     const result = await dispatchReplyFromConfig({
@@ -636,6 +744,7 @@ describe("sendPolicy deny — suppress delivery, not processing (#53328)", () =>
       OriginatingChannel: "telegram",
       OriginatingTo: "telegram:999",
       SessionKey: "agent:main:slack:group:oc_group",
+      WasMentioned: true,
     });
 
     const result = await dispatchReplyFromConfig({
@@ -677,6 +786,7 @@ describe("sendPolicy deny — suppress delivery, not processing (#53328)", () =>
       OriginatingChannel: "telegram",
       OriginatingTo: "telegram:999",
       SessionKey: "agent:main:slack:group:oc_group",
+      WasMentioned: true,
     });
 
     const result = await dispatchReplyFromConfig({
@@ -712,6 +822,7 @@ describe("sendPolicy deny — suppress delivery, not processing (#53328)", () =>
       OriginatingChannel: "telegram",
       OriginatingTo: "telegram:999",
       SessionKey: "agent:main:slack:group:oc_group",
+      WasMentioned: true,
     });
 
     const result = await dispatchReplyFromConfig({
@@ -749,6 +860,7 @@ describe("sendPolicy deny — suppress delivery, not processing (#53328)", () =>
       OriginatingChannel: "telegram",
       OriginatingTo: "telegram:999",
       SessionKey: "agent:main:slack:group:oc_group",
+      WasMentioned: true,
     });
 
     const result = await dispatchReplyFromConfig({
@@ -790,6 +902,7 @@ describe("sendPolicy deny — suppress delivery, not processing (#53328)", () =>
       Surface: "telegram",
       Provider: "telegram",
       SessionKey: "agent:main:telegram:group:oc_group",
+      WasMentioned: true,
     });
 
     const result = await dispatchReplyFromConfig({
@@ -827,6 +940,7 @@ describe("sendPolicy deny — suppress delivery, not processing (#53328)", () =>
       Surface: "telegram",
       Provider: "telegram",
       SessionKey: "agent:main:telegram:group:oc_group",
+      WasMentioned: true,
     });
 
     const result = await dispatchReplyFromConfig({
@@ -861,6 +975,7 @@ describe("sendPolicy deny — suppress delivery, not processing (#53328)", () =>
       Surface: "telegram",
       Provider: "telegram",
       SessionKey: "agent:main:telegram:group:oc_group",
+      WasMentioned: true,
     });
 
     const result = await dispatchReplyFromConfig({
@@ -905,6 +1020,7 @@ describe("sendPolicy deny — suppress delivery, not processing (#53328)", () =>
       OriginatingChannel: "telegram",
       OriginatingTo: "telegram:999",
       SessionKey: "agent:main:slack:group:oc_group",
+      WasMentioned: true,
     });
 
     const result = await dispatchReplyFromConfig({
@@ -951,6 +1067,7 @@ describe("sendPolicy deny — suppress delivery, not processing (#53328)", () =>
       Surface: "telegram",
       Provider: "telegram",
       SessionKey: "agent:main:telegram:group:oc_group",
+      WasMentioned: true,
     });
 
     const result = await dispatchReplyFromConfig({
@@ -991,6 +1108,7 @@ describe("sendPolicy deny — suppress delivery, not processing (#53328)", () =>
       Surface: "telegram",
       Provider: "telegram",
       SessionKey: "agent:main:telegram:group:oc_group",
+      WasMentioned: true,
     });
 
     const result = await dispatchReplyFromConfig({
@@ -1029,6 +1147,7 @@ describe("sendPolicy deny — suppress delivery, not processing (#53328)", () =>
       Surface: "telegram",
       Provider: "telegram",
       SessionKey: "agent:main:telegram:group:oc_group",
+      WasMentioned: true,
     });
 
     const result = await dispatchReplyFromConfig({

--- a/src/auto-reply/reply/dispatch-from-config.hooks-and-send-policy.test-utils.ts
+++ b/src/auto-reply/reply/dispatch-from-config.hooks-and-send-policy.test-utils.ts
@@ -31,6 +31,7 @@ import {
   describe2BeforeEach0,
 } from "./dispatch-from-config.test-harness.js";
 import { PROVIDER_CONVERSATION_STATE_ERROR_USER_MESSAGE } from "./provider-request-error-classifier.js";
+import { createReplyDispatcher } from "./reply-dispatcher.js";
 import { buildTestCtx } from "./test-ctx.js";
 
 beforeAll(globalBeforeAll0);
@@ -806,8 +807,8 @@ describe("sendPolicy deny — suppress delivery, not processing (#53328)", () =>
       replyResolver,
     });
 
-    // Routed streamed blocks never touch the mock dispatcher counts; blockCount
-    // alone must prove the turn was visible so no misleading fallback is sent.
+    // The stub dispatcher exposes no settlement, so the ledger keeps the block's
+    // admission as its visibility fact and no misleading fallback is sent.
     expect(dispatcher.sendFinalReply).not.toHaveBeenCalledWith({
       text: NO_VISIBLE_REPLY_FALLBACK_TEXT,
     });
@@ -816,6 +817,8 @@ describe("sendPolicy deny — suppress delivery, not processing (#53328)", () =>
 
   it("does not deliver no-visible fallback when dispatcher already queued a block", async () => {
     setNoAbort();
+    // Channel-owned admissions outside the dispatch pipeline have unknown
+    // settlement; the foreign-admission backstop keeps the fallback quiet.
     const dispatcher = createDispatcher();
     dispatcher.getQueuedCounts = vi.fn(() => ({ tool: 0, block: 1, final: 0 }));
     const replyResolver = vi.fn(async () => undefined);
@@ -881,6 +884,171 @@ describe("sendPolicy deny — suppress delivery, not processing (#53328)", () =>
     expect(result.queuedFinal).toBe(false);
     expect(result.noVisibleReplyFallbackDelivered).toBeUndefined();
     expect(result.noVisibleReplyFallbackEligible).toBe(true);
+  });
+
+  it("delivers routed fallback when a suppressed contentful final settles invisible", async () => {
+    setNoAbort();
+    // A contentful routed final that reports ok+suppressed was never visible;
+    // admission-based gating used to end this turn silently (#114768 corner 1).
+    mocks.routeReply.mockImplementation(async (params: { payload?: { text?: string } }) =>
+      params.payload?.text === NO_VISIBLE_REPLY_FALLBACK_TEXT
+        ? { ok: true, messageId: "fallback-1" }
+        : { ok: true, suppressed: true },
+    );
+    const dispatcher = createDispatcher();
+    const replyResolver = vi.fn(async () => ({ text: "real answer" }));
+    const ctx = buildTestCtx({
+      ChatType: "group",
+      Surface: "slack",
+      Provider: "slack",
+      OriginatingChannel: "telegram",
+      OriginatingTo: "telegram:999",
+      SessionKey: "agent:main:slack:group:oc_group",
+    });
+
+    const result = await dispatchReplyFromConfig({
+      ctx,
+      cfg: {
+        agents: {
+          defaults: {
+            silentReply: {
+              group: "disallow",
+            },
+          },
+        },
+      } as OpenClawConfig,
+      dispatcher,
+      replyResolver,
+    });
+
+    const fallbackCall = mocks.routeReply.mock.calls.find(
+      (call) =>
+        (call[0] as { payload?: { text?: string } }).payload?.text ===
+        NO_VISIBLE_REPLY_FALLBACK_TEXT,
+    );
+    expect(fallbackCall).toBeDefined();
+    expect(result.noVisibleReplyFallbackDelivered).toBe(true);
+  });
+
+  it("delivers fallback when a queued streamed block fails delivery", async () => {
+    setNoAbort();
+    // A generated block only proves visibility once its delivery settles; a
+    // transport failure used to suppress the fallback silently (#114768 corner 2).
+    const deliver = vi.fn(async (_payload: ReplyPayload, info: { kind: string }) => {
+      if (info.kind === "block") {
+        throw new Error("transport down");
+      }
+    });
+    const dispatcher = createReplyDispatcher({ deliver });
+    const replyResolver = vi.fn(async (_ctx: MsgContext, opts?: GetReplyOptions) => {
+      await opts?.onBlockReply?.({ text: "Streamed answer content." });
+      return undefined;
+    });
+    const ctx = buildTestCtx({
+      ChatType: "group",
+      Surface: "telegram",
+      Provider: "telegram",
+      SessionKey: "agent:main:telegram:group:oc_group",
+    });
+
+    const result = await dispatchReplyFromConfig({
+      ctx,
+      cfg: {
+        agents: {
+          defaults: {
+            silentReply: {
+              group: "disallow",
+            },
+          },
+        },
+      } as OpenClawConfig,
+      dispatcher,
+      replyResolver,
+    });
+    dispatcher.markComplete();
+    await dispatcher.waitForIdle();
+
+    const deliveredTexts = deliver.mock.calls.map((call) => (call[0] as { text?: string }).text);
+    expect(deliveredTexts).toContain(NO_VISIBLE_REPLY_FALLBACK_TEXT);
+    expect(result.noVisibleReplyFallbackDelivered).toBe(true);
+  });
+
+  it("keeps eligibility when a beforeDeliver hook cancels the queued fallback", async () => {
+    setNoAbort();
+    // The fallback's own admission can still be cancelled by a beforeDeliver
+    // hook; the delivered flag must follow settlement so channel recovery stays
+    // eligible (#114768 corner 3).
+    const deliver = vi.fn(async () => {});
+    const dispatcher = createReplyDispatcher({
+      deliver,
+      beforeDeliver: async () => null,
+    });
+    const replyResolver = vi.fn(async () => undefined);
+    const ctx = buildTestCtx({
+      ChatType: "group",
+      Surface: "telegram",
+      Provider: "telegram",
+      SessionKey: "agent:main:telegram:group:oc_group",
+    });
+
+    const result = await dispatchReplyFromConfig({
+      ctx,
+      cfg: {
+        agents: {
+          defaults: {
+            silentReply: {
+              group: "disallow",
+            },
+          },
+        },
+      } as OpenClawConfig,
+      dispatcher,
+      replyResolver,
+    });
+    dispatcher.markComplete();
+    await dispatcher.waitForIdle();
+
+    expect(deliver).not.toHaveBeenCalled();
+    expect(result.noVisibleReplyFallbackDelivered).toBeUndefined();
+    expect(result.noVisibleReplyFallbackEligible).toBe(true);
+  });
+
+  it("delivers fallback when a beforeDeliver hook cancels the model final", async () => {
+    setNoAbort();
+    const deliver = vi.fn(async () => {});
+    const dispatcher = createReplyDispatcher({
+      deliver,
+      beforeDeliver: async (payload) =>
+        payload.text === NO_VISIBLE_REPLY_FALLBACK_TEXT ? payload : null,
+    });
+    const replyResolver = vi.fn(async () => ({ text: "cancelled answer" }));
+    const ctx = buildTestCtx({
+      ChatType: "group",
+      Surface: "telegram",
+      Provider: "telegram",
+      SessionKey: "agent:main:telegram:group:oc_group",
+    });
+
+    const result = await dispatchReplyFromConfig({
+      ctx,
+      cfg: {
+        agents: {
+          defaults: {
+            silentReply: {
+              group: "disallow",
+            },
+          },
+        },
+      } as OpenClawConfig,
+      dispatcher,
+      replyResolver,
+    });
+    dispatcher.markComplete();
+    await dispatcher.waitForIdle();
+
+    const deliveredTexts = deliver.mock.calls.map((call) => (call[0] as { text?: string }).text);
+    expect(deliveredTexts).toEqual([NO_VISIBLE_REPLY_FALLBACK_TEXT]);
+    expect(result.noVisibleReplyFallbackDelivered).toBe(true);
   });
 
   it("suppresses tool result delivery when sendPolicy is deny", async () => {

--- a/src/auto-reply/reply/dispatch-from-config.hooks-and-send-policy.test-utils.ts
+++ b/src/auto-reply/reply/dispatch-from-config.hooks-and-send-policy.test-utils.ts
@@ -931,16 +931,17 @@ describe("sendPolicy deny — suppress delivery, not processing (#53328)", () =>
     expect(result.noVisibleReplyFallbackDelivered).toBe(true);
   });
 
-  it("delivers fallback when a queued streamed block fails delivery", async () => {
+  it("delivers fallback when a queued streamed block is cancelled before delivery", async () => {
     setNoAbort();
     // A generated block only proves visibility once its delivery settles; a
-    // transport failure used to suppress the fallback silently (#114768 corner 2).
-    const deliver = vi.fn(async (_payload: ReplyPayload, info: { kind: string }) => {
-      if (info.kind === "block") {
-        throw new Error("transport down");
-      }
+    // pre-transport cancellation used to suppress the fallback silently
+    // (#114768 corner 2). Started-then-failed sends stay conservative: they may
+    // have shown partial content, so they do not trigger the fallback.
+    const deliver = vi.fn(async (_payload: ReplyPayload) => {});
+    const dispatcher = createReplyDispatcher({
+      deliver,
+      beforeDeliver: async (payload, info) => (info.kind === "block" ? null : payload),
     });
-    const dispatcher = createReplyDispatcher({ deliver });
     const replyResolver = vi.fn(async (_ctx: MsgContext, opts?: GetReplyOptions) => {
       await opts?.onBlockReply?.({ text: "Streamed answer content." });
       return undefined;

--- a/src/auto-reply/reply/dispatch-from-config.hooks-and-send-policy.test-utils.ts
+++ b/src/auto-reply/reply/dispatch-from-config.hooks-and-send-policy.test-utils.ts
@@ -890,11 +890,12 @@ describe("sendPolicy deny — suppress delivery, not processing (#53328)", () =>
     setNoAbort();
     // A contentful routed final that reports ok+suppressed was never visible;
     // admission-based gating used to end this turn silently (#114768 corner 1).
-    mocks.routeReply.mockImplementation(async (params: { payload?: { text?: string } }) =>
-      params.payload?.text === NO_VISIBLE_REPLY_FALLBACK_TEXT
+    mocks.routeReply.mockImplementation(async (paramsUnknown: unknown) => {
+      const params = paramsUnknown as { payload?: { text?: string } };
+      return params.payload?.text === NO_VISIBLE_REPLY_FALLBACK_TEXT
         ? { ok: true, messageId: "fallback-1" }
-        : { ok: true, suppressed: true },
-    );
+        : { ok: true, suppressed: true };
+    });
     const dispatcher = createDispatcher();
     const replyResolver = vi.fn(async () => ({ text: "real answer" }));
     const ctx = buildTestCtx({
@@ -968,7 +969,7 @@ describe("sendPolicy deny — suppress delivery, not processing (#53328)", () =>
     dispatcher.markComplete();
     await dispatcher.waitForIdle();
 
-    const deliveredTexts = deliver.mock.calls.map((call) => (call[0] as { text?: string }).text);
+    const deliveredTexts = deliver.mock.calls.map((call) => call[0].text);
     expect(deliveredTexts).toContain(NO_VISIBLE_REPLY_FALLBACK_TEXT);
     expect(result.noVisibleReplyFallbackDelivered).toBe(true);
   });
@@ -1015,7 +1016,7 @@ describe("sendPolicy deny — suppress delivery, not processing (#53328)", () =>
 
   it("delivers fallback when a beforeDeliver hook cancels the model final", async () => {
     setNoAbort();
-    const deliver = vi.fn(async () => {});
+    const deliver = vi.fn(async (_payload: ReplyPayload) => {});
     const dispatcher = createReplyDispatcher({
       deliver,
       beforeDeliver: async (payload) =>
@@ -1046,7 +1047,7 @@ describe("sendPolicy deny — suppress delivery, not processing (#53328)", () =>
     dispatcher.markComplete();
     await dispatcher.waitForIdle();
 
-    const deliveredTexts = deliver.mock.calls.map((call) => (call[0] as { text?: string }).text);
+    const deliveredTexts = deliver.mock.calls.map((call) => call[0].text);
     expect(deliveredTexts).toEqual([NO_VISIBLE_REPLY_FALLBACK_TEXT]);
     expect(result.noVisibleReplyFallbackDelivered).toBe(true);
   });

--- a/src/auto-reply/reply/dispatch-from-config.lifecycle.ts
+++ b/src/auto-reply/reply/dispatch-from-config.lifecycle.ts
@@ -10,6 +10,7 @@ import {
 } from "./dispatch-from-config.abort.js";
 import type { InboundMessageAuditTerminalRecorder } from "./dispatch-from-config.audit.js";
 import { shouldLetSlackRoutedThreadBypassBusyReplyOperation } from "./dispatch-from-config.context.js";
+import { createReplyTurnLedger } from "./dispatch-from-config.turn-ledger.js";
 import type { DispatchFromConfigParams } from "./dispatch-from-config.types.js";
 import { waitForReplyDispatcherIdle } from "./reply-dispatcher.js";
 import type { ReplyDispatcher } from "./reply-dispatcher.types.js";
@@ -417,12 +418,21 @@ export function createDispatchReplyOperationCoordinator(params: {
     }
   };
 
+  const turnLedger = createReplyTurnLedger(params.dispatcher);
   return {
     completeDispatchReplyOperation,
+    // Hook-queued payloads must settle through the turn ledger too, or a
+    // hook-delivered visible reply could trigger the no-visible-reply fallback.
     dispatchHookDispatcher: createAbortAwareDispatcher({
-      dispatcher: params.dispatcher,
+      dispatcher: {
+        ...params.dispatcher,
+        sendToolResult: (payload) => turnLedger.sendQueued("tool", payload).queued,
+        sendBlockReply: (payload) => turnLedger.sendQueued("block", payload).queued,
+        sendFinalReply: (payload) => turnLedger.sendQueued("final", payload).queued,
+      },
       isAborted: isPreDispatchOperationAborted,
     }),
+    turnLedger,
     ensureDispatchReplyOperation,
     failDispatchReplyOperation,
     getDispatchAbortOperation: () => dispatchAbortOperation,

--- a/src/auto-reply/reply/dispatch-from-config.prepare-context.ts
+++ b/src/auto-reply/reply/dispatch-from-config.prepare-context.ts
@@ -351,6 +351,18 @@ export async function prepareDispatchOperationContext(state: PrepareDispatchDeli
   const explicitCommandTurnCtx = isExplicitSourceReplyCommand(ctx, cfg);
   const unauthorizedTextSlashSourceReplyCtx =
     (chatType === "group" || chatType === "channel") && isUnauthorizedTextSlashCommand(ctx);
+  // The no-visible-reply fallback exists for a user who asked and got nothing.
+  // Only positively directed turns qualify: direct chats, explicit mentions
+  // (channels fold reply-to-bot into WasMentioned), and command turns. Ambient
+  // group chatter, room events, and turns whose classification facts were lost
+  // upstream (queued followups, rebuilt contexts) can never draw a visible
+  // failure notice, even when silence policy is disallow. A command turn is the
+  // one directed room_event (mirrors the room_event source-reply suppression
+  // bypass below); every other room_event stays undirected regardless of a
+  // stray WasMentioned/direct classification.
+  const noVisibleReplyFallbackDirected =
+    explicitCommandTurnCtx ||
+    (ctx.InboundEventKind !== "room_event" && (chatType === "direct" || ctx.WasMentioned === true));
   const shouldDeliverPluginBindingReply =
     !suppressAutomaticSourceDelivery ||
     explicitCommandTurnCtx ||
@@ -510,6 +522,7 @@ export async function prepareDispatchOperationContext(state: PrepareDispatchDeli
       sendPolicy,
       chatType,
       emptyFinalAllowedAsSilent,
+      noVisibleReplyFallbackDirected,
       sourceReplyPolicy,
       sourceReplyDeliveryMode,
       sessionStableSourceReplyDeliveryMode,

--- a/src/auto-reply/reply/dispatch-from-config.prepare-delivery.ts
+++ b/src/auto-reply/reply/dispatch-from-config.prepare-delivery.ts
@@ -30,7 +30,6 @@ export async function prepareDispatchDelivery(state: GatherDispatchRequestReadyS
     acpDispatchSessionKey,
     cfg,
     ctx,
-    dispatcher,
     getDispatchAbortSignal,
     groupId,
     isGroup,
@@ -39,6 +38,7 @@ export async function prepareDispatchDelivery(state: GatherDispatchRequestReadyS
     replyRoute,
     routeReplyThreadId,
     sessionStoreEntry,
+    turnLedger,
     workspaceDir,
   } = state;
   // Check if we should route replies to originating channel instead of dispatcher.
@@ -157,7 +157,7 @@ export async function prepareDispatchDelivery(state: GatherDispatchRequestReadyS
       (ctx.CommandSource === "native"
         ? (resolveCommandTurnTargetSessionKey(ctx) ?? ctx.SessionKey)
         : ctx.SessionKey);
-    return await routeReplyRuntime.routeReply({
+    const result = await routeReplyRuntime.routeReply({
       payload,
       channel: routeReplyChannel,
       to: routeReplyTo,
@@ -181,6 +181,10 @@ export async function prepareDispatchDelivery(state: GatherDispatchRequestReadyS
       runId: params.replyOptions?.runId,
       responsePrefixContext: options?.responsePrefixContext,
     });
+    // Routed sends settle here: the transport result is the settlement. This is
+    // the single routed choke point, so every routed lane feeds the turn ledger.
+    turnLedger.recordRoutedDelivery(payload, isRoutedReplyDelivered(result));
+    return result;
   };
 
   const isRoutedReplyDelivered = (result: { ok: boolean; suppressed?: boolean }) =>
@@ -260,8 +264,8 @@ export async function prepareDispatchDelivery(state: GatherDispatchRequestReadyS
     }
     markInboundDedupeReplayUnsafe();
     return mode === "additive"
-      ? dispatcher.sendToolResult(bindingPayload)
-      : dispatcher.sendFinalReply(bindingPayload);
+      ? turnLedger.sendQueued("tool", bindingPayload).queued
+      : turnLedger.sendQueued("final", bindingPayload).queued;
   };
   const nextState = extendPreparedDispatchState(
     state,

--- a/src/auto-reply/reply/dispatch-from-config.prepare-execution.ts
+++ b/src/auto-reply/reply/dispatch-from-config.prepare-execution.ts
@@ -57,6 +57,7 @@ export async function prepareDispatchExecution(state: ChooseDispatchRouteReadySt
     suppressAutomaticSourceDelivery,
     suppressDelivery,
     traceReplyPhase,
+    turnLedger,
   } = state;
   // When automatic source delivery is suppressed, still let the agent process
   // the inbound message (context, memory, tool calls) but suppress automatic
@@ -114,7 +115,7 @@ export async function prepareDispatchExecution(state: ChooseDispatchRouteReadySt
       return;
     }
     markInboundDedupeReplayUnsafe();
-    dispatcher.sendToolResult(payload);
+    turnLedger.sendQueued("tool", payload);
   };
   const sendPlanUpdate = async (payload: {
     explanation?: string;
@@ -137,7 +138,7 @@ export async function prepareDispatchExecution(state: ChooseDispatchRouteReadySt
       return;
     }
     markInboundDedupeReplayUnsafe();
-    dispatcher.sendToolResult(replyPayload);
+    turnLedger.sendQueued("tool", replyPayload);
   };
   const summarizeApprovalLabel = (payload: {
     status?: string;

--- a/src/auto-reply/reply/dispatch-from-config.reply-dispatch.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.reply-dispatch.test.ts
@@ -381,11 +381,14 @@ describe("dispatchReplyFromConfig reply_dispatch hook", () => {
       });
       await hookStarted.promise;
       await vi.advanceTimersByTimeAsync(15_000);
+      // The timed-out final settles invisible, so the no-visible-reply fallback
+      // is attempted through the same wedged hook and needs its own stage budget.
+      await vi.advanceTimersByTimeAsync(15_000);
       const result = await resultPromise;
 
       expect(result.queuedFinal).toBe(true);
       expect(deliver).not.toHaveBeenCalled();
-      expect(dispatcher.getFailedCounts?.()).toEqual({ tool: 0, block: 0, final: 1 });
+      expect(dispatcher.getFailedCounts?.()).toEqual({ tool: 0, block: 0, final: 2 });
       expect(sessionStoreMocks.updateSessionEntry).toHaveBeenCalledOnce();
       expect(sessionStoreMocks.currentEntry?.pendingFinalDelivery).toBe(true);
       expect(sessionStoreMocks.currentEntry?.pendingFinalDeliveryText).toBe("durable reply");
@@ -672,6 +675,9 @@ describe("dispatchReplyFromConfig reply_dispatch hook", () => {
         pendingFinalDeliveryIntentId: "newer-intent",
       };
       await vi.advanceTimersByTimeAsync(15_000);
+      // Second stage budget: the no-visible-reply fallback runs through the same
+      // wedged hook after the older final times out.
+      await vi.advanceTimersByTimeAsync(15_000);
       await resultPromise;
 
       expect(sessionStoreMocks.currentEntry?.pendingFinalDelivery).toBe(true);
@@ -712,7 +718,9 @@ describe("dispatchReplyFromConfig reply_dispatch hook", () => {
         }),
     });
 
-    expect(dispatcher.getFailedCounts?.()).toEqual({ tool: 0, block: 0, final: 1 });
+    // The failed final settles invisible, so the no-visible-reply fallback is
+    // attempted through the same failing transport before the turn ends.
+    expect(dispatcher.getFailedCounts?.()).toEqual({ tool: 0, block: 0, final: 2 });
     expect(sessionStoreMocks.updateSessionEntry).toHaveBeenCalledOnce();
     expect(sessionStoreMocks.currentEntry?.pendingFinalDelivery).toBeUndefined();
     expect(sessionStoreMocks.currentEntry?.pendingFinalDeliveryText).toBeUndefined();
@@ -748,7 +756,9 @@ describe("dispatchReplyFromConfig reply_dispatch hook", () => {
 
     expect(result.queuedFinal).toBe(true);
     expect(deliver).not.toHaveBeenCalled();
-    expect(dispatcher.getCancelledCounts?.()).toEqual({ tool: 0, block: 0, final: 1 });
+    // The cancelled final settles invisible, so the no-visible-reply fallback is
+    // attempted and cancelled by the same hook before the turn ends.
+    expect(dispatcher.getCancelledCounts?.()).toEqual({ tool: 0, block: 0, final: 2 });
     expect(dispatcher.getFailedCounts?.()).toEqual({ tool: 0, block: 0, final: 0 });
     expect(sessionStoreMocks.currentEntry?.pendingFinalDelivery).toBeUndefined();
     expect(sessionStoreMocks.currentEntry?.pendingFinalDeliveryText).toBeUndefined();

--- a/src/auto-reply/reply/dispatch-from-config.reply-dispatch.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.reply-dispatch.test.ts
@@ -718,9 +718,9 @@ describe("dispatchReplyFromConfig reply_dispatch hook", () => {
         }),
     });
 
-    // The failed final settles invisible, so the no-visible-reply fallback is
-    // attempted through the same failing transport before the turn ends.
-    expect(dispatcher.getFailedCounts?.()).toEqual({ tool: 0, block: 0, final: 2 });
+    // A started-then-failed transport send may have shown partial content, so
+    // the ledger stays conservative and no fallback rides the same transport.
+    expect(dispatcher.getFailedCounts?.()).toEqual({ tool: 0, block: 0, final: 1 });
     expect(sessionStoreMocks.updateSessionEntry).toHaveBeenCalledOnce();
     expect(sessionStoreMocks.currentEntry?.pendingFinalDelivery).toBeUndefined();
     expect(sessionStoreMocks.currentEntry?.pendingFinalDeliveryText).toBeUndefined();

--- a/src/auto-reply/reply/dispatch-from-config.reply-dispatch.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.reply-dispatch.test.ts
@@ -204,11 +204,12 @@ describe("dispatchReplyFromConfig reply_dispatch hook", () => {
     });
 
     expect(hookMocks.runner.runReplyDispatch).toHaveBeenCalled();
+    // createHookCtx's "private" chat type is undirected, so no fallback
+    // eligibility surfaces for this turn.
     expect(result).toEqual({
       queuedFinal: false,
       counts: { tool: 0, block: 0, final: 0 },
       sendPolicyDenied: true,
-      noVisibleReplyFallbackEligible: true,
     });
   });
 
@@ -381,14 +382,13 @@ describe("dispatchReplyFromConfig reply_dispatch hook", () => {
       });
       await hookStarted.promise;
       await vi.advanceTimersByTimeAsync(15_000);
-      // The timed-out final settles invisible, so the no-visible-reply fallback
-      // is attempted through the same wedged hook and needs its own stage budget.
-      await vi.advanceTimersByTimeAsync(15_000);
       const result = await resultPromise;
 
       expect(result.queuedFinal).toBe(true);
       expect(deliver).not.toHaveBeenCalled();
-      expect(dispatcher.getFailedCounts?.()).toEqual({ tool: 0, block: 0, final: 2 });
+      // createHookCtx's "private" chat type is undirected, so no fallback
+      // attempt follows the timed-out final.
+      expect(dispatcher.getFailedCounts?.()).toEqual({ tool: 0, block: 0, final: 1 });
       expect(sessionStoreMocks.updateSessionEntry).toHaveBeenCalledOnce();
       expect(sessionStoreMocks.currentEntry?.pendingFinalDelivery).toBe(true);
       expect(sessionStoreMocks.currentEntry?.pendingFinalDeliveryText).toBe("durable reply");
@@ -675,9 +675,6 @@ describe("dispatchReplyFromConfig reply_dispatch hook", () => {
         pendingFinalDeliveryIntentId: "newer-intent",
       };
       await vi.advanceTimersByTimeAsync(15_000);
-      // Second stage budget: the no-visible-reply fallback runs through the same
-      // wedged hook after the older final times out.
-      await vi.advanceTimersByTimeAsync(15_000);
       await resultPromise;
 
       expect(sessionStoreMocks.currentEntry?.pendingFinalDelivery).toBe(true);
@@ -756,9 +753,9 @@ describe("dispatchReplyFromConfig reply_dispatch hook", () => {
 
     expect(result.queuedFinal).toBe(true);
     expect(deliver).not.toHaveBeenCalled();
-    // The cancelled final settles invisible, so the no-visible-reply fallback is
-    // attempted and cancelled by the same hook before the turn ends.
-    expect(dispatcher.getCancelledCounts?.()).toEqual({ tool: 0, block: 0, final: 2 });
+    // createHookCtx's "private" chat type is undirected, so the cancelled final
+    // does not trigger a fallback attempt.
+    expect(dispatcher.getCancelledCounts?.()).toEqual({ tool: 0, block: 0, final: 1 });
     expect(dispatcher.getFailedCounts?.()).toEqual({ tool: 0, block: 0, final: 0 });
     expect(sessionStoreMocks.currentEntry?.pendingFinalDelivery).toBeUndefined();
     expect(sessionStoreMocks.currentEntry?.pendingFinalDeliveryText).toBeUndefined();

--- a/src/auto-reply/reply/dispatch-from-config.turn-ledger.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.turn-ledger.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it, vi } from "vitest";
+import type { ReplyPayload } from "../reply-payload.js";
+import { createReplyTurnLedger } from "./dispatch-from-config.turn-ledger.js";
+import { createReplyDispatcher } from "./reply-dispatcher.js";
+import type { ReplyDispatcher } from "./reply-dispatcher.types.js";
+
+function createUntrackedDispatcher(overrides: Partial<ReplyDispatcher> = {}): ReplyDispatcher {
+  return {
+    sendToolResult: () => true,
+    sendBlockReply: () => true,
+    sendFinalReply: () => true,
+    waitForIdle: async () => {},
+    getQueuedCounts: () => ({ tool: 0, block: 0, final: 0 }),
+    getFailedCounts: () => ({ tool: 0, block: 0, final: 0 }),
+    markComplete: () => {},
+    ...overrides,
+  };
+}
+
+describe("createReplyTurnLedger", () => {
+  it("counts a delivered contentful payload as visible after settlement", async () => {
+    const dispatcher = createReplyDispatcher({ deliver: async () => {} });
+    const ledger = createReplyTurnLedger(dispatcher);
+    const send = ledger.sendQueued("final", { text: "hello" });
+    expect(send.queued).toBe(true);
+    expect(send.outcome).toBeDefined();
+    await ledger.settleQueued();
+    expect(ledger.hasVisibleDelivery()).toBe(true);
+    dispatcher.markComplete();
+    await dispatcher.waitForIdle();
+  });
+
+  it("does not count a beforeDeliver-cancelled payload as visible", async () => {
+    const deliver = vi.fn(async () => {});
+    const dispatcher = createReplyDispatcher({ deliver, beforeDeliver: async () => null });
+    const ledger = createReplyTurnLedger(dispatcher);
+    expect(ledger.sendQueued("final", { text: "hello" }).queued).toBe(true);
+    await ledger.settleQueued();
+    expect(deliver).not.toHaveBeenCalled();
+    expect(ledger.hasVisibleDelivery()).toBe(false);
+    dispatcher.markComplete();
+    await dispatcher.waitForIdle();
+  });
+
+  it("does not count a failed delivery as visible", async () => {
+    const dispatcher = createReplyDispatcher({
+      deliver: async () => {
+        throw new Error("transport down");
+      },
+    });
+    const ledger = createReplyTurnLedger(dispatcher);
+    expect(ledger.sendQueued("block", { text: "streamed" }).queued).toBe(true);
+    await ledger.settleQueued();
+    expect(ledger.hasVisibleDelivery()).toBe(false);
+    dispatcher.markComplete();
+    await dispatcher.waitForIdle();
+  });
+
+  it("keeps admission as the visibility fact for untracked dispatchers", () => {
+    const ledger = createReplyTurnLedger(createUntrackedDispatcher());
+    const send = ledger.sendQueued("final", { text: "hello" });
+    expect(send.outcome).toBeUndefined();
+    expect(ledger.hasVisibleDelivery()).toBe(true);
+  });
+
+  it("never counts contentless payloads as visible", async () => {
+    const dispatcher = createReplyDispatcher({ deliver: async () => {} });
+    const ledger = createReplyTurnLedger(dispatcher);
+    const payload: ReplyPayload = { text: "hi" };
+    // Metadata-only admissions on untracked dispatchers stay invisible too.
+    const untracked = createReplyTurnLedger(createUntrackedDispatcher());
+    untracked.sendQueued("final", { text: "   " });
+    expect(untracked.hasVisibleDelivery()).toBe(false);
+    ledger.sendQueued("final", payload);
+    await ledger.settleQueued();
+    expect(ledger.hasVisibleDelivery()).toBe(true);
+    dispatcher.markComplete();
+    await dispatcher.waitForIdle();
+  });
+
+  it("records routed settlements only when delivered and contentful", () => {
+    const ledger = createReplyTurnLedger(createUntrackedDispatcher());
+    ledger.recordRoutedDelivery({ text: "suppressed" }, false);
+    ledger.recordRoutedDelivery({ text: "" }, true);
+    expect(ledger.hasVisibleDelivery()).toBe(false);
+    ledger.recordRoutedDelivery({ mediaUrl: "https://example.com/seatmap.png" }, true);
+    expect(ledger.hasVisibleDelivery()).toBe(true);
+  });
+
+  it("reports foreign admissions the dispatch pipeline never sent", () => {
+    const dispatcher = createUntrackedDispatcher({
+      getQueuedCounts: () => ({ tool: 0, block: 1, final: 0 }),
+    });
+    const ledger = createReplyTurnLedger(dispatcher);
+    expect(ledger.hasForeignQueuedAdmissions()).toBe(true);
+    expect(ledger.hasVisibleDelivery()).toBe(false);
+  });
+
+  it("stops settling when the abort signal fires", async () => {
+    // A stalled deliver models a hung transport; abort must release the gate
+    // instead of wedging finalization.
+    let releaseDeliver!: () => void;
+    const stalled = new Promise<void>((resolve) => {
+      releaseDeliver = resolve;
+    });
+    const dispatcher = createReplyDispatcher({ deliver: () => stalled });
+    const ledger = createReplyTurnLedger(dispatcher);
+    ledger.sendQueued("final", { text: "hello" });
+    const abortController = new AbortController();
+    const settled = ledger.settleQueued(abortController.signal);
+    abortController.abort();
+    await settled;
+    expect(ledger.hasVisibleDelivery()).toBe(false);
+    releaseDeliver();
+    dispatcher.markComplete();
+    await dispatcher.waitForIdle();
+  });
+});

--- a/src/auto-reply/reply/dispatch-from-config.turn-ledger.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.turn-ledger.test.ts
@@ -42,18 +42,59 @@ describe("createReplyTurnLedger", () => {
     await dispatcher.waitForIdle();
   });
 
-  it("does not count a failed delivery as visible", async () => {
+  it("does not count a pre-transport failure as visible", async () => {
+    const deliver = vi.fn(async () => {});
     const dispatcher = createReplyDispatcher({
-      deliver: async () => {
-        throw new Error("transport down");
+      deliver,
+      beforeDeliver: async () => {
+        throw new Error("hook exploded");
       },
     });
     const ledger = createReplyTurnLedger(dispatcher);
     expect(ledger.sendQueued("block", { text: "streamed" }).queued).toBe(true);
     await ledger.settleQueued();
+    expect(deliver).not.toHaveBeenCalled();
     expect(ledger.hasVisibleDelivery()).toBe(false);
     dispatcher.markComplete();
     await dispatcher.waitForIdle();
+  });
+
+  it("conservatively counts a started-then-failed delivery as visible", async () => {
+    // Chunked transports may show partial content before rejecting; core cannot
+    // prove invisibility, so the fallback must stay quiet.
+    const dispatcher = createReplyDispatcher({
+      deliver: async () => {
+        throw new Error("transport down mid-send");
+      },
+    });
+    const ledger = createReplyTurnLedger(dispatcher);
+    expect(ledger.sendQueued("block", { text: "streamed" }).queued).toBe(true);
+    await ledger.settleQueued();
+    expect(ledger.hasVisibleDelivery()).toBe(true);
+    dispatcher.markComplete();
+    await dispatcher.waitForIdle();
+  });
+
+  it("times out instead of waiting forever on a transport that never settles", async () => {
+    vi.useFakeTimers();
+    try {
+      let releaseDeliver!: () => void;
+      const stalled = new Promise<void>((resolve) => {
+        releaseDeliver = resolve;
+      });
+      const dispatcher = createReplyDispatcher({ deliver: () => stalled });
+      const ledger = createReplyTurnLedger(dispatcher);
+      ledger.sendQueued("final", { text: "hello" });
+      const settle = ledger.settleQueued();
+      await vi.advanceTimersByTimeAsync(30_000);
+      await expect(settle).resolves.toBe("timed-out");
+      releaseDeliver();
+      dispatcher.markComplete();
+      await vi.runAllTimersAsync();
+      await dispatcher.waitForIdle();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("keeps admission as the visibility fact for untracked dispatchers", () => {
@@ -109,7 +150,7 @@ describe("createReplyTurnLedger", () => {
     const abortController = new AbortController();
     const settled = ledger.settleQueued(abortController.signal);
     abortController.abort();
-    await settled;
+    await expect(settled).resolves.toBe("aborted");
     expect(ledger.hasVisibleDelivery()).toBe(false);
     releaseDeliver();
     dispatcher.markComplete();

--- a/src/auto-reply/reply/dispatch-from-config.turn-ledger.ts
+++ b/src/auto-reply/reply/dispatch-from-config.turn-ledger.ts
@@ -11,11 +11,17 @@ import {
 } from "./reply-dispatcher.js";
 import type { ReplyDispatchKind, ReplyDispatcher } from "./reply-dispatcher.types.js";
 
+// Failsafe for transports that never settle: the completion barrier bounds
+// delivery waits at the operation layer, and finalization must not out-wait it.
+const SETTLE_QUEUED_TIMEOUT_MS = 30_000;
+
 type LedgerQueuedSend = {
   queued: boolean;
   /** Present only when the core dispatcher exposes this payload's settlement. */
   outcome?: Promise<ReplyDispatchDeliveryOutcome>;
 };
+
+type LedgerSettleResult = "settled" | "aborted" | "timed-out";
 
 type ReplyTurnLedger = {
   /** Enqueue on the dispatcher and record the payload's settled visibility. */
@@ -23,8 +29,9 @@ type ReplyTurnLedger = {
   /** Record a routed transport result; routed sends settle at their call site. */
   recordRoutedDelivery: (payload: ReplyPayload, delivered: boolean) => void;
   /** Resolve every admitted payload's outcome so the fallback gate decides after
-   * beforeDeliver hooks and transport delivery, not at admission. */
-  settleQueued: (abortSignal?: AbortSignal) => Promise<void>;
+   * beforeDeliver hooks and transport delivery, not at admission. Only a
+   * "settled" result proves the visibility verdict is complete. */
+  settleQueued: (abortSignal?: AbortSignal) => Promise<LedgerSettleResult>;
   /** True once any settled, contentful, non-suppressed delivery exists. */
   hasVisibleDelivery: () => boolean;
   /** True when the dispatcher admitted payloads the dispatch pipeline never sent
@@ -69,7 +76,11 @@ export function createReplyTurnLedger(dispatcher: ReplyDispatcher): ReplyTurnLed
       }
       pendingOutcomes.push(
         capture.promise.then((outcome) => {
-          if (contentful && outcome === "delivered") {
+          // "failed-deliver" means the transport send started and then rejected;
+          // chunked sends may already have shown partial content, so only
+          // outcomes that never reached the transport ("cancelled",
+          // "failed-before-deliver") count as proven-invisible.
+          if (contentful && outcome !== "cancelled" && outcome !== "failed-before-deliver") {
             visibleDeliveries += 1;
           }
         }),
@@ -83,33 +94,54 @@ export function createReplyTurnLedger(dispatcher: ReplyDispatcher): ReplyTurnLed
     },
     async settleQueued(abortSignal) {
       // Outcome promises resolve when the dispatcher send chain settles each
-      // payload; the wait is bounded by the per-stage beforeDeliver deadlines and
+      // payload, normally bounded by the per-stage beforeDeliver deadlines and
       // the transport sends the turn's completion barrier already waits for.
       // Late progress stragglers can admit payloads while earlier deliveries
       // settle, so drain until no new outcomes appeared mid-wait.
-      let settledCount = 0;
-      while (settledCount < pendingOutcomes.length) {
-        if (abortSignal?.aborted) {
-          return;
+      let timedOut = false;
+      let timer: ReturnType<typeof setTimeout> | undefined;
+      const deadline = new Promise<void>((resolve) => {
+        timer = setTimeout(() => {
+          timedOut = true;
+          resolve();
+        }, SETTLE_QUEUED_TIMEOUT_MS);
+        timer.unref?.();
+      });
+      let removeAbortListener: (() => void) | undefined;
+      const aborted = abortSignal
+        ? new Promise<void>((resolve) => {
+            const onAbort = () => resolve();
+            abortSignal.addEventListener("abort", onAbort, { once: true });
+            removeAbortListener = () => abortSignal.removeEventListener("abort", onAbort);
+          })
+        : undefined;
+      try {
+        let settledCount = 0;
+        while (settledCount < pendingOutcomes.length) {
+          if (abortSignal?.aborted) {
+            return "aborted";
+          }
+          if (timedOut) {
+            return "timed-out";
+          }
+          const batch = pendingOutcomes.slice(settledCount);
+          const batchTarget = pendingOutcomes.length;
+          const settled = Promise.all(batch).then(() => undefined);
+          await Promise.race([settled, deadline, ...(aborted ? [aborted] : [])]);
+          if (abortSignal?.aborted) {
+            return "aborted";
+          }
+          if (timedOut) {
+            return "timed-out";
+          }
+          settledCount = batchTarget;
         }
-        const batch = pendingOutcomes.slice(settledCount);
-        settledCount = pendingOutcomes.length;
-        const settled = Promise.all(batch).then(() => undefined);
-        if (!abortSignal) {
-          await settled;
-          continue;
+        return "settled";
+      } finally {
+        if (timer) {
+          clearTimeout(timer);
         }
-        let removeAbortListener: (() => void) | undefined;
-        const aborted = new Promise<void>((resolve) => {
-          const onAbort = () => resolve();
-          abortSignal.addEventListener("abort", onAbort, { once: true });
-          removeAbortListener = () => abortSignal.removeEventListener("abort", onAbort);
-        });
-        try {
-          await Promise.race([settled, aborted]);
-        } finally {
-          removeAbortListener?.();
-        }
+        removeAbortListener?.();
       }
     },
     hasVisibleDelivery: () => visibleDeliveries > 0,

--- a/src/auto-reply/reply/dispatch-from-config.turn-ledger.ts
+++ b/src/auto-reply/reply/dispatch-from-config.turn-ledger.ts
@@ -1,0 +1,112 @@
+// Per-dispatch settled-delivery ledger (#114768). Answers "did this turn produce
+// a visible message" from transport settlement, not queue/route admission. Every
+// dispatcher send in the dispatch pipeline goes through sendQueued and every
+// routed transport result is recorded, so no delivery lane can bypass the
+// no-visible-reply fallback gate with a fresh inference flag.
+import { hasOutboundReplyContent } from "openclaw/plugin-sdk/reply-payload";
+import type { ReplyPayload } from "../reply-payload.js";
+import {
+  captureReplyDispatchDeliveryOutcome,
+  type ReplyDispatchDeliveryOutcome,
+} from "./reply-dispatcher.js";
+import type { ReplyDispatchKind, ReplyDispatcher } from "./reply-dispatcher.types.js";
+
+export type LedgerQueuedSend = {
+  queued: boolean;
+  /** Present only when the core dispatcher exposes this payload's settlement. */
+  outcome?: Promise<ReplyDispatchDeliveryOutcome>;
+};
+
+export type ReplyTurnLedger = {
+  /** Enqueue on the dispatcher and record the payload's settled visibility. */
+  sendQueued: (kind: ReplyDispatchKind, payload: ReplyPayload) => LedgerQueuedSend;
+  /** Record a routed transport result; routed sends settle at their call site. */
+  recordRoutedDelivery: (payload: ReplyPayload, delivered: boolean) => void;
+  /** Resolve every admitted payload's outcome so the fallback gate decides after
+   * beforeDeliver hooks and transport delivery, not at admission. */
+  settleQueued: (abortSignal?: AbortSignal) => Promise<void>;
+  /** True once any settled, contentful, non-suppressed delivery exists. */
+  hasVisibleDelivery: () => boolean;
+  /** True when the dispatcher admitted payloads the dispatch pipeline never sent
+   * (channel-owned sends). Their settlement is unknown, so the fallback gate
+   * treats them conservatively as visible: silence over a double-send. */
+  hasForeignQueuedAdmissions: () => boolean;
+};
+
+export function createReplyTurnLedger(dispatcher: ReplyDispatcher): ReplyTurnLedger {
+  let visibleDeliveries = 0;
+  let queuedAdmissions = 0;
+  const pendingOutcomes: Array<Promise<void>> = [];
+  const enqueue = (kind: ReplyDispatchKind, payload: ReplyPayload): boolean => {
+    if (kind === "tool") {
+      return dispatcher.sendToolResult(payload);
+    }
+    if (kind === "block") {
+      return dispatcher.sendBlockReply(payload);
+    }
+    return dispatcher.sendFinalReply(payload);
+  };
+  return {
+    sendQueued(kind, payload) {
+      const capture = captureReplyDispatchDeliveryOutcome(payload);
+      const queued = enqueue(kind, payload);
+      if (!queued) {
+        return { queued: false };
+      }
+      queuedAdmissions += 1;
+      // Contentless payloads (metadata-only, TTS bookkeeping) never prove the
+      // user saw anything, even when the transport accepts them.
+      const contentful = hasOutboundReplyContent(payload, { trimText: true });
+      if (!capture.isTracked()) {
+        // Non-core dispatchers expose no settlement; admission stays their
+        // strongest visibility fact (legacy trust level).
+        if (contentful) {
+          visibleDeliveries += 1;
+        }
+        return { queued: true };
+      }
+      pendingOutcomes.push(
+        capture.promise.then((outcome) => {
+          if (contentful && outcome === "delivered") {
+            visibleDeliveries += 1;
+          }
+        }),
+      );
+      return { queued: true, outcome: capture.promise };
+    },
+    recordRoutedDelivery(payload, delivered) {
+      if (delivered && hasOutboundReplyContent(payload, { trimText: true })) {
+        visibleDeliveries += 1;
+      }
+    },
+    async settleQueued(abortSignal) {
+      // Outcome promises resolve when the dispatcher send chain settles each
+      // payload; the wait is bounded by the per-stage beforeDeliver deadlines and
+      // the transport sends the turn's completion barrier already waits for.
+      const settled = Promise.all(pendingOutcomes).then(() => undefined);
+      if (!abortSignal) {
+        await settled;
+        return;
+      }
+      if (abortSignal.aborted) {
+        return;
+      }
+      let removeAbortListener: (() => void) | undefined;
+      const aborted = new Promise<void>((resolve) => {
+        const onAbort = () => resolve();
+        abortSignal.addEventListener("abort", onAbort, { once: true });
+        removeAbortListener = () => abortSignal.removeEventListener("abort", onAbort);
+      });
+      try {
+        await Promise.race([settled, aborted]);
+      } finally {
+        removeAbortListener?.();
+      }
+    },
+    hasVisibleDelivery: () => visibleDeliveries > 0,
+    hasForeignQueuedAdmissions: () => {
+      const counts = dispatcher.getQueuedCounts();
+      return counts.tool + counts.block + counts.final > queuedAdmissions;
+    },
+  };
+}

--- a/src/auto-reply/reply/dispatch-from-config.turn-ledger.ts
+++ b/src/auto-reply/reply/dispatch-from-config.turn-ledger.ts
@@ -11,13 +11,13 @@ import {
 } from "./reply-dispatcher.js";
 import type { ReplyDispatchKind, ReplyDispatcher } from "./reply-dispatcher.types.js";
 
-export type LedgerQueuedSend = {
+type LedgerQueuedSend = {
   queued: boolean;
   /** Present only when the core dispatcher exposes this payload's settlement. */
   outcome?: Promise<ReplyDispatchDeliveryOutcome>;
 };
 
-export type ReplyTurnLedger = {
+type ReplyTurnLedger = {
   /** Enqueue on the dispatcher and record the payload's settled visibility. */
   sendQueued: (kind: ReplyDispatchKind, payload: ReplyPayload) => LedgerQueuedSend;
   /** Record a routed transport result; routed sends settle at their call site. */

--- a/src/auto-reply/reply/dispatch-from-config.turn-ledger.ts
+++ b/src/auto-reply/reply/dispatch-from-config.turn-ledger.ts
@@ -54,8 +54,10 @@ export function createReplyTurnLedger(dispatcher: ReplyDispatcher): ReplyTurnLed
         return { queued: false };
       }
       queuedAdmissions += 1;
-      // Contentless payloads (metadata-only, TTS bookkeeping) never prove the
-      // user saw anything, even when the transport accepts them.
+      // Core dispatchers drop contentless payloads at normalization using this
+      // same predicate, so the check matters for untracked dispatchers that
+      // admit without normalizing; hooks suppress visibility via the cancel
+      // path (beforeDeliver -> null), never by emptying an admitted payload.
       const contentful = hasOutboundReplyContent(payload, { trimText: true });
       if (!capture.isTracked()) {
         // Non-core dispatchers expose no settlement; admission stays their
@@ -83,24 +85,31 @@ export function createReplyTurnLedger(dispatcher: ReplyDispatcher): ReplyTurnLed
       // Outcome promises resolve when the dispatcher send chain settles each
       // payload; the wait is bounded by the per-stage beforeDeliver deadlines and
       // the transport sends the turn's completion barrier already waits for.
-      const settled = Promise.all(pendingOutcomes).then(() => undefined);
-      if (!abortSignal) {
-        await settled;
-        return;
-      }
-      if (abortSignal.aborted) {
-        return;
-      }
-      let removeAbortListener: (() => void) | undefined;
-      const aborted = new Promise<void>((resolve) => {
-        const onAbort = () => resolve();
-        abortSignal.addEventListener("abort", onAbort, { once: true });
-        removeAbortListener = () => abortSignal.removeEventListener("abort", onAbort);
-      });
-      try {
-        await Promise.race([settled, aborted]);
-      } finally {
-        removeAbortListener?.();
+      // Late progress stragglers can admit payloads while earlier deliveries
+      // settle, so drain until no new outcomes appeared mid-wait.
+      let settledCount = 0;
+      while (settledCount < pendingOutcomes.length) {
+        if (abortSignal?.aborted) {
+          return;
+        }
+        const batch = pendingOutcomes.slice(settledCount);
+        settledCount = pendingOutcomes.length;
+        const settled = Promise.all(batch).then(() => undefined);
+        if (!abortSignal) {
+          await settled;
+          continue;
+        }
+        let removeAbortListener: (() => void) | undefined;
+        const aborted = new Promise<void>((resolve) => {
+          const onAbort = () => resolve();
+          abortSignal.addEventListener("abort", onAbort, { once: true });
+          removeAbortListener = () => abortSignal.removeEventListener("abort", onAbort);
+        });
+        try {
+          await Promise.race([settled, aborted]);
+        } finally {
+          removeAbortListener?.();
+        }
       }
     },
     hasVisibleDelivery: () => visibleDeliveries > 0,

--- a/src/auto-reply/reply/reply-payloads-dedupe.runtime.ts
+++ b/src/auto-reply/reply/reply-payloads-dedupe.runtime.ts
@@ -3,6 +3,7 @@ export {
   filterMessagingToolDuplicates,
   filterMessagingToolMediaDuplicates,
   hasEnabledDeliveryOperation,
+  hasSourceRoutedMessagingToolDelivery,
   resolveMessagingToolPayloadDedupe,
   shouldDedupeMessagingToolRepliesForRoute,
   type MessagingToolPayloadDedupeDecision,

--- a/src/auto-reply/reply/reply-payloads-dedupe.ts
+++ b/src/auto-reply/reply/reply-payloads-dedupe.ts
@@ -401,3 +401,38 @@ export function resolveMessagingToolPayloadDedupe(params: {
     useGlobalSentMediaUrlEvidenceFallback: allTargetsMatchRoute && !hasTargetMediaUrlEvidence,
   };
 }
+
+/** True when a message-tool send visibly delivered to the source conversation.
+ * Route matching keeps cross-provider or unrelated-target tool sends from
+ * counting as the source reply. */
+export function hasSourceRoutedMessagingToolDelivery(params: {
+  config?: OpenClawConfig;
+  messageProvider?: string;
+  messagingToolSentTargets?: MessagingToolSend[];
+  messagingToolSentTexts?: string[];
+  messagingToolSentMediaUrls?: string[];
+  originatingTo?: string;
+  originatingThreadId?: string | number;
+  accountId?: string;
+}): boolean {
+  const decision = resolveMessagingToolPayloadDedupe({
+    config: params.config,
+    messageProvider: params.messageProvider,
+    messagingToolSentTargets: params.messagingToolSentTargets,
+    originatingTo: params.originatingTo,
+    originatingThreadId: params.originatingThreadId,
+    accountId: params.accountId,
+  });
+  if (!decision.matchingRoute) {
+    return false;
+  }
+  return (
+    decision.routeSentTexts.length > 0 ||
+    decision.routeSentMediaUrls.length > 0 ||
+    // Legacy runtimes record aggregate evidence without per-target content.
+    (decision.useGlobalSentTextEvidenceFallback &&
+      (params.messagingToolSentTexts?.length ?? 0) > 0) ||
+    (decision.useGlobalSentMediaUrlEvidenceFallback &&
+      (params.messagingToolSentMediaUrls?.length ?? 0) > 0)
+  );
+}


### PR DESCRIPTION
## What Problem This Solves

Closes #114768.

`finalizeDispatchAndAudit` decided "did the user see anything this turn" from nine scattered signals — `sawVisibleFinalDelivery`, `sawDedupedAgainstBlock`, `hasDeliveredRoutedBlockReply()`, `state.blockCount`, three queued-count fields, `getObservedReplyDelivery()`, `noVisibleReplyFallbackDelivered` — most of which measure **admission** (a queue or route accepted the payload), not **settlement** (the transport confirmed a visible message). #114531 documented the three corners that gap produces, each ending a visible turn silently:

1. a contentful routed final returning `{ ok: true, suppressed: true }` counted as visible;
2. `state.blockCount` counts *generated* blocks, so a failed/cancelled streamed block suppressed the no-visible-reply fallback;
3. `dispatcher.sendFinalReply` is queue admission — a `beforeDeliver` hook could cancel the fallback *after* `noVisibleReplyFallbackDelivered` was set.

Beyond the three corners, every new delivery lane had to re-derive visibility with its own flag, and each flag was a fresh chance to ship a silent-turn bug of this class.

## Why This Change Was Made

One per-dispatch **turn ledger** (`dispatch-from-config.turn-ledger.ts`), created with the reply-operation coordinator and threaded through prepared dispatch state, now owns visibility:

- **Every dispatcher send in the pipeline goes through `ledger.sendQueued(kind, payload)`**, which captures the payload's `ReplyDispatchDeliveryOutcome` and counts it visible only when it settles `"delivered"` with outbound content. Dispatchers that don't expose settlement (plugin/stub dispatchers, where `captureReplyDispatchDeliveryOutcome` stays untracked) keep admission as their strongest fact — the pre-existing trust level, now named in one place instead of implied by nine.
- **Every routed send settles at the single choke point** (`routeReplyToOriginating`): the transport result *is* the settlement; `ok && !suppressed && contentful` records visible. This fixes corner 1 — suppressed routed finals no longer masquerade as visible.
- **The fallback gate awaits `ledger.settleQueued()`** before deciding, so `beforeDeliver` cancellations and pre-transport failures decide the gate instead of admission. This fixes corner 2 (a cancelled/hook-failed streamed block no longer suppresses the fallback) and, combined with the fallback's own settlement await, corner 3 (a cancelled fallback no longer reports `noVisibleReplyFallbackDelivered` and keeps `noVisibleReplyFallbackEligible` alive for channel recovery). Two conservative refinements: only `cancelled` and `failed-before-deliver` outcomes count as proven-invisible — a started-then-failed transport send may have shown partial chunked content, so it stays visible-conservative rather than stacking a misleading fallback on partial output — and the settle wait carries a 30s failsafe deadline plus an abort race; an aborted or timed-out settle leaves delivery state unknown and the turn ends without a fallback, exactly like pre-change admission trust.
- **Hook-queued payloads route through the ledger too** (the hook dispatcher wrapper), so a hook-delivered visible reply can never trigger the fallback.
- **Foreign admissions backstop**: payloads admitted on the dispatcher outside the dispatch pipeline (channel-owned sends) have unknown settlement; the gate treats them conservatively as visible — silence over a double-send. This is what the old `counts.* === 0` gate degenerates into once every pipeline lane is ledger-owned.

Deleted from finalize: `sawVisibleFinalDelivery`, `sawDedupedAgainstBlock`, `hasDeliveredRoutedBlockReply` (function + threading), the `blockCount` gate, and the three `counts.* === 0` gates. `blockCount` remains only for its real job (accumulated block TTS).

Design decisions on the issue's open questions:

- **Settlement latency**: awaiting settlement adds no new unbounded wait class. Outcome promises resolve from the dispatcher send chain, bounded by the per-stage `beforeDeliver` deadlines (15s default) plus the transport sends that `completeDispatchReplyOperation`'s completion barrier already awaits today — the gate decision moves before an existing wait, it does not add one. `settleQueued` races the dispatch abort signal, and the fallback's own enqueue happens after settlement (its outcome is awaited individually), so the gate can never await itself.
- **Observed delivery** stays a separate trust level: it is plugin-attested visibility, not transport settlement, and the gate consults it alongside the ledger rather than folding it in.

One intentional behavior tightening: `noVisibleReplyFallbackEligible` now keys off settled visible delivery for *all* lanes, so a turn whose only visible output was a delivered block/tool payload no longer reports eligible — previously a channel-level consumer could have double-sent after visible streamed content.

### Directed-turn gate

Settlement decides *whether the turn produced a visible reply*; it does not decide *whether the turn was a question in the first place*. The fallback exists for a user who addressed the bot and got nothing back — so both the fallback gate and `noVisibleReplyFallbackEligible` now also require a **directed turn** (`dispatch-from-config.prepare-context.ts`):

```
noVisibleReplyFallbackDirected =
  chatType === "direct" || ctx.WasMentioned === true || explicitCommandTurnCtx
```

Direct chats, explicit mentions (channels fold reply-to-bot into `WasMentioned`), and command turns qualify. Ambient group chatter, `room_event` turns, and turns whose classification facts were lost upstream (queued followups, rebuilt contexts) can never surface a visible failure notice — **even under `silentReply: disallow`**. An undirected group turn that settles empty is not an unanswered question; it is a message the bot was never asked to answer, so a "No reply was generated" notice there is pure noise in the channel.

Reproduced in production (HamVerBot, image `2026.7.2-main-6a4e2f3d752`): an unmentioned `room_event` group turn (54211) drew the fallback (54218) into the channel, and did so on *every* ambient message — `silentReply group: disallow` made the machinery treat all group silence as a failure to report. The directed gate closes that class at the decision site.

The regression tests that previously asserted a fallback for undirected turns are flipped to assert silence, because that was the bug: `createHookCtx`'s `"private"` chat type normalizes to `undefined` (undirected) — so hook-path timeout/cancel turns no longer chase a fallback through the wedged hook, and the ambient/`room_event` + `disallow` cases assert zero fallback sends and zero eligibility.

## User Impact

Users on every channel now receive the no-visible-reply fallback in the three corners where turns still died silently after #114531: hook-suppressed routed finals, failed/cancelled streamed blocks, and beforeDeliver-cancelled payloads. No delivered reply is ever regressed: any settled visible delivery (or plugin-attested observed delivery, or channel-owned admission outside the pipeline) suppresses the fallback exactly as before. Operators keep intentional silence via `silentReply`; `message_tool_only` and `sendPolicy: deny` behavior is unchanged.

Group operators running `silentReply group: disallow` alongside ambient ingestion (`unmentionedInbound: room_event`, `requireMention: false`) no longer get a "No reply was generated" notice on every unaddressed message — the fallback now fires only for turns that actually addressed the bot (direct chat, mention/reply-to-bot, command). Directed turns still get the notice as before.

One adjacent gap reported on this PR (thanks @fuller-stack-dev) is fixed in-branch: `onObservedReplyDelivery` only fired under `sourceReplyDeliveryMode: "message_tool_only"`, so an automatic-mode turn that answered via the message tool and then returned exact `NO_REPLY` drew the fallback into the source conversation. The fix reuses the payload-dedupe route matcher (`hasSourceRoutedMessagingToolDelivery`) — the same route-awareness that already suppresses duplicate finals — to attest observed delivery for visibly delivered source-routed tool sends in every mode; unrelated-target or cross-provider tool sends stay excluded, and the followup runner already applied this contract.

## Evidence

### Real behavior proof (live gateway)

Isolated dev gateway run from this branch (`OPENCLAW_STATE_DIR` tempdir, loopback :18939), mock Telegram Bot API capturing every outbound send, mock `openai-completions` provider, group chat with an explicit bot mention, default config. Verdict JSON per run:

**Run 1 — settled-empty turn → exactly one fallback:**

```json
{ "mode": "empty", "totalSends": 1, "fallbackCount": 1,
  "sends": [ { "method": "sendMessage", "text": "No reply was generated for this message. This is usually a temporary model failure - please try again." } ] }
```

**Run 2 — delivered-reply control → zero fallbacks:**

```json
{ "mode": "reply", "llmCalls": 1, "totalSends": 1, "fallbackCount": 0,
  "sends": [ { "method": "sendMessage", "text": "REPLY: settled ledger control 4471." } ] }
```

**Run 3 — message-tool answer + exact `NO_REPLY` (automatic mode), before the observed-delivery fix** — reproduces the bug reported in the PR comments (misleading fallback after the tool-delivered answer):

```json
{ "mode": "tool-noreply", "llmCalls": 2, "totalSends": 2, "fallbackCount": 1,
  "sends": [ { "method": "sendMessage", "text": "TOOL-SENT: ledger proof 9182" },
             { "method": "sendMessage", "text": "No reply was generated for this message. This is usually a temporary model failure - please try again." } ] }
```

**Run 4 — same scenario on the current head (with the fix):**

```json
{ "mode": "tool-noreply", "llmCalls": 2, "totalSends": 1, "fallbackCount": 0,
  "sends": [ { "method": "sendMessage", "text": "TOOL-SENT: ledger proof 9182" } ] }
```

The remaining corners (suppressed routed final, beforeDeliver-cancelled block/final/fallback) are pinned by regression tests against the real `createReplyDispatcher` send chain, where cancellation and settlement are directly controllable.

### Directed-turn proof

The directed-turn gate is exercised at the real dispatch choke point (`dispatchReplyFromConfig` with a real dispatcher), asserting the exact HamVerBot prod shape:

- **unmentioned group `room_event` + `silentReply group: disallow` → zero fallback sends, zero eligibility** (`keeps room_event turns silent even when silence policy is disallow`);
- **unmentioned ambient group + `disallow` → zero fallback sends, zero eligibility** (`keeps ambient group turns silent even when silence policy is disallow`);
- **mentioned group + group silence allowed → fallback delivered** (`delivers fallback for mentioned group turns even when group silence is allowed`), so directed turns are not regressed.

The end-to-end acceptance for the prod repro is the HamVerBot container itself: post-merge, the redeployed image must hold `docker logs … | grep -c "No reply was generated"` at 0 while ambient chatter flows, with directed turns still answered.

### Checks

- `node scripts/run-vitest.mjs src/auto-reply/reply/dispatch-from-config src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts src/auto-reply/reply/agent-runner-payloads.test.ts` — 503/503 green, including the directed-turn ambient/`room_event` + `disallow` regressions (unmentioned **and** mentioned room_event both stay silent; only a command turn is a directed room_event), the mentioned-directed positive case, 4 corner regression tests (suppressed contentful routed final → fallback; pre-delivery-cancelled streamed block → fallback; beforeDeliver-cancelled fallback → eligibility survives, not reported delivered; beforeDeliver-cancelled model final → fallback delivered) and 10 turn-ledger behavior tests (settled/cancelled/pre-transport-failed outcomes, conservative started-then-failed visibility, untracked-dispatcher admission trust, contentless payloads, routed settlement, foreign admissions, abort race, settle deadline).
- Earlier `$autoreview` rounds (Codex `gpt-5.6-sol`, high) drove real fixes: abort-aware + deadline-bounded settlement, mid-settle straggler drain, and the partial-delivery-conservative outcome classification; the queuedFinal-on-admission suggestion was rejected because `queuedFinal` tracks actual delivery across every lane (`dispatch-acp.ts` `|| delivered`/`hasDeliveredFinalReply()`, `dispatch.ts:435` `queuedFinal && counts.final > 0`), so a cancelled fallback correctly leaves it false and keeps channel-level recovery eligible — matching the hook-suppressed routed contract from #114531.
- Directed-turn `$autoreview` round (Codex `gpt-5.6-sol`, high): one accepted finding — the directedness predicate now excludes `room_event` explicitly (`InboundEventKind !== "room_event"`, command turns exempt, mirroring the `finalize.ts` room_event source-reply bypass), so a room_event carrying a stray `WasMentioned`/direct classification can never draw the fallback; pinned by a new mentioned-room_event regression. A re-review's two P2s were rejected after reading the real paths: a beforeDeliver hook emptying an admitted payload while returning non-null is a state no real hook produces (all suppress via `return null` → `cancelled`; invariant documented at `turn-ledger.ts`), and the queuedFinal-on-admission concern is the already-rejected suggestion above.
- The unconditional-settle first draft deadlocked the queued-same-session mirroring contract (`lets a queued same-session turn finish before mirroring delivered source replies`); the shipped conditional settle (only fallback-eligible, still-empty turns pay for settlement) was derived from that failure and the suite pins it.
- `node scripts/run-vitest.mjs extensions/feishu/src/bot` — 184/184; the Feishu channel-level fallback consumer is unchanged.
- `pnpm tsgo:core` green locally (Blacksmith Testbox delegation ran the same lane remotely but its artifact sync timed out on the Blacksmith API, so the lane was re-proven locally); `scripts/run-oxlint.mjs` and `pnpm format` clean on touched files; `git diff --check` clean.

