### PR TITLE
fix(heartbeat): prevent duplicated cron wakes and stale handler races

### DIFF
--- a/src/agents/embedded-agent-runner/run/attempt.sessions-yield.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.sessions-yield.test.ts
@@ -188,12 +188,12 @@ describe("stripSessionsYieldArtifacts", () => {
 
     stripSessionsYieldArtifacts(session);
 
-    const branch = sessionManager.getBranch();
+    const entries = sessionManager.getEntries();
     expect(
-      branch.some((entry) => entry.type === "custom" && entry.customType === "plugin-state"),
+      entries.some((entry) => entry.type === "custom" && entry.customType === "plugin-state"),
     ).toBe(true);
     expect(
-      branch.some(
+      entries.some(
         (entry) =>
           (entry.type === "message" && entry.message.role === "assistant") ||
           (entry.type === "custom_message" &&

--- a/src/agents/embedded-agent-runner/run/attempt.sessions-yield.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.sessions-yield.ts
@@ -179,7 +179,6 @@ export function stripSessionsYieldArtifacts(activeSession: {
   agent: { state: { messages: AgentMessage[] } };
   sessionManager: Pick<SessionManager, "removeTrailingEntries">;
 }) {
-  const originalLength = activeSession.messages.length;
   const strippedMessages = activeSession.messages.slice();
 
   // The tool-calling assistant turn and synthetic abort artifacts form one

--- a/src/infra/heartbeat-wake.test.ts
+++ b/src/infra/heartbeat-wake.test.ts
@@ -548,6 +548,97 @@ describe("heartbeat-wake", () => {
     });
   });
 
+  it.each([
+    { source: "manual" as const, intent: "manual" as const, reason: "manual" },
+    { source: "cron" as const, intent: "immediate" as const, reason: "cron:job-now" },
+  ])(
+    "does not let a retained event cooldown defer an explicit $intent wake",
+    async (explicitWake) => {
+      vi.useFakeTimers();
+      vi.setSystemTime(2_000_000_000_000);
+      const handler = vi
+        .fn()
+        .mockResolvedValueOnce({
+          status: "skipped",
+          reason: "not-due",
+          retryAtMs: Date.now() + 30 * 60_000,
+        })
+        .mockResolvedValue({ status: "ran", durationMs: 1 });
+      setHeartbeatWakeHandler(handler);
+
+      requestHeartbeat({
+        source: "exec-event",
+        intent: "event",
+        reason: "exec-event",
+        agentId: "main",
+        sessionKey: "agent:main:main",
+        coalesceMs: 0,
+      });
+      await vi.advanceTimersByTimeAsync(1);
+
+      requestHeartbeat({
+        ...explicitWake,
+        agentId: "main",
+        sessionKey: "agent:main:main",
+        coalesceMs: 0,
+      });
+      await vi.advanceTimersByTimeAsync(1);
+
+      expect(handler).toHaveBeenCalledTimes(2);
+      expect(handler.mock.calls[1]?.[0]).toMatchObject({
+        ...explicitWake,
+        agentId: "main",
+        sessionKey: "agent:main:main",
+      });
+    },
+  );
+
+  it("keeps a retained immediate wake guarded when an ordinary event joins", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(2_000_000_000_000);
+    const handler = vi
+      .fn()
+      .mockResolvedValueOnce({
+        status: "skipped",
+        reason: "not-due",
+        retryAtMs: Date.now() + 30_000,
+      })
+      .mockResolvedValue({ status: "ran", durationMs: 1 });
+    setHeartbeatWakeHandler(handler);
+
+    requestHeartbeat({
+      source: "cron",
+      intent: "immediate",
+      reason: "cron:job-now",
+      agentId: "main",
+      sessionKey: "agent:main:main",
+      coalesceMs: 0,
+    });
+    await vi.advanceTimersByTimeAsync(1);
+
+    requestHeartbeat({
+      source: "exec-event",
+      intent: "event",
+      reason: "exec-event",
+      agentId: "main",
+      sessionKey: "agent:main:main",
+      coalesceMs: 0,
+    });
+    await vi.advanceTimersByTimeAsync(1);
+    expect(handler).toHaveBeenCalledOnce();
+
+    await vi.advanceTimersByTimeAsync(29_997);
+    expect(handler).toHaveBeenCalledOnce();
+
+    await vi.advanceTimersByTimeAsync(1);
+    expect(handler).toHaveBeenCalledTimes(2);
+    expect(handler.mock.calls[1]?.[0]).toMatchObject({
+      source: "cron",
+      intent: "immediate",
+      reason: "cron:job-now",
+    });
+  });
+
   it("retries requests-in-flight after the default retry delay", async () => {
     vi.useFakeTimers();
     const handler = vi
@@ -606,6 +697,95 @@ describe("heartbeat-wake", () => {
       initialReason: "exec-event",
       expectedRetryReason: "exec-event",
     });
+  });
+
+  it.each(["a", "b", "c"])(
+    "retries only the failed targeted wake when batch target %s throws",
+    async (failedTarget) => {
+      vi.useFakeTimers();
+      let hasFailed = false;
+      const handler = vi.fn(async (request: WakeRequest) => {
+        if (request.reason === `cron:job-${failedTarget}` && !hasFailed) {
+          hasFailed = true;
+          throw new Error("heartbeat target failed");
+        }
+        return { status: "ran" as const, durationMs: 1 };
+      });
+      setHeartbeatWakeHandler(handler);
+
+      for (const target of ["a", "b", "c"]) {
+        requestHeartbeat({
+          source: "cron",
+          intent: "event",
+          reason: `cron:job-${target}`,
+          agentId: `agent-${target}`,
+          sessionKey: `agent:agent-${target}:main`,
+          coalesceMs: 100,
+        });
+      }
+
+      await vi.advanceTimersByTimeAsync(100);
+
+      expect(handler.mock.calls.map(([request]) => request.reason)).toEqual([
+        "cron:job-a",
+        "cron:job-b",
+        "cron:job-c",
+      ]);
+      expect(getActiveGatewayRootWorkCount()).toBe(0);
+
+      await vi.advanceTimersByTimeAsync(999);
+      expect(handler).toHaveBeenCalledTimes(3);
+
+      await vi.advanceTimersByTimeAsync(1);
+      expect(handler.mock.calls.map(([request]) => request.reason)).toEqual([
+        "cron:job-a",
+        "cron:job-b",
+        "cron:job-c",
+        `cron:job-${failedTarget}`,
+      ]);
+      expect(handler.mock.calls[3]?.[0]).toMatchObject({
+        agentId: `agent-${failedTarget}`,
+        sessionKey: `agent:agent-${failedTarget}:main`,
+      });
+      expect(getActiveGatewayRootWorkCount()).toBe(0);
+    },
+  );
+
+  it("does not replay completed wake targets when another target keeps throwing", async () => {
+    vi.useFakeTimers();
+    let failedAttempts = 0;
+    const handler = vi.fn(async (request: WakeRequest) => {
+      if (request.reason === "cron:job-b" && failedAttempts < 2) {
+        failedAttempts += 1;
+        throw new Error("heartbeat target failed");
+      }
+      return { status: "ran" as const, durationMs: 1 };
+    });
+    setHeartbeatWakeHandler(handler);
+
+    for (const target of ["a", "b", "c"]) {
+      requestHeartbeat({
+        source: "cron",
+        intent: "event",
+        reason: `cron:job-${target}`,
+        agentId: `agent-${target}`,
+        sessionKey: `agent:agent-${target}:main`,
+        coalesceMs: 100,
+      });
+    }
+
+    await vi.advanceTimersByTimeAsync(100);
+    await vi.advanceTimersByTimeAsync(1_000);
+    await vi.advanceTimersByTimeAsync(1_000);
+
+    expect(handler.mock.calls.map(([request]) => request.reason)).toEqual([
+      "cron:job-a",
+      "cron:job-b",
+      "cron:job-c",
+      "cron:job-b",
+      "cron:job-b",
+    ]);
+    expect(getActiveGatewayRootWorkCount()).toBe(0);
   });
 
   it("preempts existing timer when a sooner schedule is requested", async () => {
@@ -697,6 +877,109 @@ describe("heartbeat-wake", () => {
     resolveHang!();
     await Promise.resolve();
   });
+
+  it("does not let a stale heartbeat lifecycle release a newer active wake", async () => {
+    vi.useFakeTimers();
+    let finishOldWake!: () => void;
+    let finishNewWake!: () => void;
+    const oldWakeFinished = new Promise<void>((resolve) => {
+      finishOldWake = resolve;
+    });
+    const newWakeFinished = new Promise<void>((resolve) => {
+      finishNewWake = resolve;
+    });
+    const oldHandler = vi.fn(async () => {
+      await oldWakeFinished;
+      return { status: "ran" as const, durationMs: 1 };
+    });
+    setHeartbeatWakeHandler(oldHandler);
+    requestHeartbeat(wake("interval", { agentId: "main", coalesceMs: 0 }));
+    await vi.advanceTimersByTimeAsync(1);
+    expect(oldHandler).toHaveBeenCalledOnce();
+
+    const newHandler = vi.fn(async (_request: WakeRequest) => {
+      await newWakeFinished;
+      return { status: "ran" as const, durationMs: 1 };
+    });
+    setHeartbeatWakeHandler(newHandler);
+    requestHeartbeat(wake("interval", { agentId: "main", coalesceMs: 0 }));
+    await vi.advanceTimersByTimeAsync(1);
+    expect(newHandler).toHaveBeenCalledOnce();
+
+    finishOldWake();
+    await vi.advanceTimersByTimeAsync(0);
+    expect(getActiveGatewayRootWorkCount()).toBe(1);
+
+    requestHeartbeat(wake("manual", { agentId: "main", coalesceMs: 25 }));
+    await vi.advanceTimersByTimeAsync(25);
+    expect(newHandler).toHaveBeenCalledOnce();
+
+    finishNewWake();
+    await vi.advanceTimersByTimeAsync(25);
+    expect(newHandler).toHaveBeenCalledTimes(2);
+    expect(newHandler.mock.calls[1]?.[0]).toMatchObject({
+      intent: "manual",
+      reason: "manual",
+      agentId: "main",
+    });
+    expect(getActiveGatewayRootWorkCount()).toBe(0);
+  });
+
+  it.each([
+    { outcome: "completed", expectedReasons: ["cron:job-b"] },
+    { outcome: "thrown", expectedReasons: ["cron:job-a", "cron:job-b"] },
+    { outcome: "busy", expectedReasons: ["cron:job-a", "cron:job-b"] },
+    { outcome: "guarded", expectedReasons: ["cron:job-a", "cron:job-b"] },
+  ] as const)(
+    "hands off only unfinished wakes when a replaced handler is $outcome",
+    async ({ outcome, expectedReasons }) => {
+      vi.useFakeTimers();
+      let finishOldWake!: () => void;
+      const oldWakeFinished = new Promise<void>((resolve) => {
+        finishOldWake = resolve;
+      });
+      const oldHandler = vi.fn(async () => {
+        await oldWakeFinished;
+        if (outcome === "thrown") {
+          throw new Error("stale heartbeat target failed");
+        }
+        if (outcome === "busy") {
+          return { status: "skipped" as const, reason: HEARTBEAT_SKIP_REQUESTS_IN_FLIGHT };
+        }
+        if (outcome === "guarded") {
+          return {
+            status: "skipped" as const,
+            reason: "not-due",
+            retryAtMs: Date.now() + 30 * 60_000,
+          };
+        }
+        return { status: "ran" as const, durationMs: 1 };
+      });
+      setHeartbeatWakeHandler(oldHandler);
+
+      for (const target of ["a", "b"]) {
+        requestHeartbeat({
+          source: "cron",
+          intent: "event",
+          reason: `cron:job-${target}`,
+          agentId: `agent-${target}`,
+          sessionKey: `agent:agent-${target}:main`,
+          coalesceMs: 100,
+        });
+      }
+      await vi.advanceTimersByTimeAsync(100);
+      expect(oldHandler).toHaveBeenCalledOnce();
+
+      const newHandler = vi.fn().mockResolvedValue({ status: "ran", durationMs: 1 });
+      setHeartbeatWakeHandler(newHandler);
+      finishOldWake();
+      await vi.advanceTimersByTimeAsync(250);
+
+      expect(oldHandler).toHaveBeenCalledOnce();
+      expect(newHandler.mock.calls.map(([request]) => request.reason)).toEqual(expectedReasons);
+      expect(getActiveGatewayRootWorkCount()).toBe(0);
+    },
+  );
 
   it("does not let a stale disposer clear a newer handler", async () => {
     vi.useFakeTimers();

--- a/src/infra/heartbeat-wake.ts
+++ b/src/infra/heartbeat-wake.ts
@@ -187,11 +187,17 @@ function mergePendingWakeReasons(
       ? next
       : previous;
   const other = preferred === previous ? next : previous;
+  // Explicit wakes bypass a retained spacing guard, but busy backoff remains
+  // target-owned in PendingWakeGroup.blockedUntilMs.
+  const bypassGuardRetry =
+    (preferred.intent === "manual" || preferred.intent === "immediate") &&
+    preferred.guardRetry !== true &&
+    (previous.guardRetry === true || next.guardRetry === true);
   const scheduledEveryMs = preferred.scheduledEveryMs ?? other.scheduledEveryMs;
   const scheduledAnchorMs = preferred.scheduledAnchorMs ?? other.scheduledAnchorMs;
   const merged: PendingWakeReason = {
     ...preferred,
-    ...(previous.notBeforeMs !== undefined || next.notBeforeMs !== undefined
+    ...(!bypassGuardRetry && (previous.notBeforeMs !== undefined || next.notBeforeMs !== undefined)
       ? {
           requestedAt: Math.min(previous.requestedAt, next.requestedAt),
           notBeforeMs: Math.max(previous.notBeforeMs ?? 0, next.notBeforeMs ?? 0),
@@ -204,7 +210,7 @@ function mergePendingWakeReasons(
     ...(scheduledAnchorMs !== undefined ? { scheduledAnchorMs } : {}),
     ...(mergedTasks.length ? { tasks: mergedTasks } : {}),
   };
-  if (previous.guardRetry || next.guardRetry) {
+  if (!bypassGuardRetry && (previous.guardRetry || next.guardRetry)) {
     merged.guardRetry = true;
   } else {
     delete merged.guardRetry;
@@ -338,6 +344,36 @@ function queuePendingWakeReason(params: {
   pendingWakes.set(wakeTargetKey, group);
 }
 
+function retryPendingWake(pendingWake: PendingWakeReason) {
+  // A thrown or busy wake owns only its target; replaying the whole batch
+  // duplicates completed reminders and stalls unrelated agents.
+  queuePendingWakeReason({
+    source: pendingWake.source,
+    intent: pendingWake.intent,
+    reason: pendingWake.reason ?? "retry",
+    agentId: pendingWake.agentId,
+    sessionKey: pendingWake.sessionKey,
+    heartbeat: pendingWake.heartbeat,
+    scheduledEveryMs: pendingWake.scheduledEveryMs,
+    scheduledAnchorMs: pendingWake.scheduledAnchorMs,
+    tasks: pendingWake.tasks,
+    requestedAt: pendingWake.requestedAt,
+    blockTargetUntilMs: Date.now() + DEFAULT_RETRY_MS,
+  });
+  schedule(DEFAULT_RETRY_MS);
+}
+
+function handOffPendingWakeBatch(pendingBatch: PendingWakeReason[], startIndex: number) {
+  // A replacement handler inherits unfinished work, never the old handler's
+  // completed targets, busy backoff, or spacing guard.
+  for (const pendingWake of pendingBatch.slice(startIndex)) {
+    queuePendingWakeReason(pendingWake);
+  }
+  if (handler && startIndex < pendingBatch.length) {
+    schedulePendingWakes(DEFAULT_COALESCE_MS);
+  }
+}
+
 function schedule(coalesceMs: number) {
   const delay = resolveTimerTimeoutMs(coalesceMs, DEFAULT_COALESCE_MS, 0);
   const dueAt = Date.now() + delay;
@@ -361,6 +397,7 @@ function schedule(coalesceMs: number) {
       if (!active) {
         return;
       }
+      const activeGeneration = handlerGeneration;
       if (running) {
         scheduled = true;
         schedule(delay);
@@ -370,7 +407,11 @@ function schedule(coalesceMs: number) {
       const pendingBatch = takePendingWakeBatch();
       running = true;
       try {
-        for (const pendingWake of pendingBatch) {
+        for (const [pendingWakeIndex, pendingWake] of pendingBatch.entries()) {
+          if (handlerGeneration !== activeGeneration) {
+            handOffPendingWakeBatch(pendingBatch, pendingWakeIndex);
+            return;
+          }
           const wakeOpts = {
             source: pendingWake.source,
             intent: pendingWake.intent,
@@ -389,25 +430,31 @@ function schedule(coalesceMs: number) {
           };
           // Each wake is detached process work: admit the whole handler before
           // it can mutate sessions or commitments, and keep it visible until done.
-          const res = await runWithGatewayIndependentRootWorkAdmission(async () =>
-            active(wakeOpts),
-          );
+          let res: HeartbeatRunResult;
+          try {
+            res = await runWithGatewayIndependentRootWorkAdmission(async () => active(wakeOpts));
+          } catch {
+            if (handlerGeneration !== activeGeneration) {
+              handOffPendingWakeBatch(pendingBatch, pendingWakeIndex);
+              return;
+            }
+            retryPendingWake(pendingWake);
+            continue;
+          }
+          if (handlerGeneration !== activeGeneration) {
+            const retainedWake =
+              res.status === "skipped" &&
+              (isRetryableHeartbeatBusySkipReason(res.reason) ||
+                (RETRYABLE_GUARD_SKIP_REASONS.has(res.reason) &&
+                  (pendingWake.tasks?.length ||
+                    pendingWake.intent === "task" ||
+                    pendingWake.intent === "event" ||
+                    pendingWake.intent === "immediate")));
+            handOffPendingWakeBatch(pendingBatch, pendingWakeIndex + (retainedWake ? 0 : 1));
+            return;
+          }
           if (res.status === "skipped" && isRetryableHeartbeatBusySkipReason(res.reason)) {
-            // The target runtime is busy; retry this wake target soon.
-            queuePendingWakeReason({
-              source: pendingWake.source,
-              intent: pendingWake.intent,
-              reason: pendingWake.reason ?? "retry",
-              agentId: pendingWake.agentId,
-              sessionKey: pendingWake.sessionKey,
-              heartbeat: pendingWake.heartbeat,
-              scheduledEveryMs: pendingWake.scheduledEveryMs,
-              scheduledAnchorMs: pendingWake.scheduledAnchorMs,
-              tasks: pendingWake.tasks,
-              requestedAt: pendingWake.requestedAt,
-              blockTargetUntilMs: Date.now() + DEFAULT_RETRY_MS,
-            });
-            schedule(DEFAULT_RETRY_MS);
+            retryPendingWake(pendingWake);
           } else if (
             res.status === "skipped" &&
             RETRYABLE_GUARD_SKIP_REASONS.has(res.reason) &&
@@ -437,28 +484,14 @@ function schedule(coalesceMs: number) {
             schedule(retryAtMs - Date.now());
           }
         }
-      } catch {
-        // Error is already logged by the heartbeat runner; schedule a retry.
-        for (const pendingWake of pendingBatch) {
-          queuePendingWakeReason({
-            source: pendingWake.source,
-            intent: pendingWake.intent,
-            reason: pendingWake.reason ?? "retry",
-            agentId: pendingWake.agentId,
-            sessionKey: pendingWake.sessionKey,
-            heartbeat: pendingWake.heartbeat,
-            scheduledEveryMs: pendingWake.scheduledEveryMs,
-            scheduledAnchorMs: pendingWake.scheduledAnchorMs,
-            tasks: pendingWake.tasks,
-            requestedAt: pendingWake.requestedAt,
-            blockTargetUntilMs: Date.now() + DEFAULT_RETRY_MS,
-          });
-        }
-        schedule(DEFAULT_RETRY_MS);
       } finally {
-        running = false;
-        if (pendingWakes.size > 0 || scheduled) {
-          schedulePendingWakes(delay);
+        // A replaced handler owns its own in-flight turn; an old completion
+        // must not unlock or reschedule the newer heartbeat lifecycle.
+        if (handlerGeneration === activeGeneration) {
+          running = false;
+          if (pendingWakes.size > 0 || scheduled) {
+            schedulePendingWakes(delay);
+          }
         }
       }
     })();


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where concurrent scheduled reminders, background tasks, and heartbeat events could execute more than once, block unrelated agents, or delay an explicitly requested wake when another target failed or a heartbeat handler restarted.

## Why This Change Was Made

Refactor the canonical heartbeat wake owner so retries belong only to the failing target, unfinished batches transfer safely to the current handler generation, completed targets are never replayed, and a fresh manual/immediate wake bypasses only a retained spacing guard. Preserve target-owned busy backoff, Gateway work admission, chronological task coalescing, and existing public configuration, Gateway protocols, persistence, plugin APIs, and dependencies.

## User Impact

Scheduled tasks and notifications are delivered once; one stalled or failed agent cannot hold unrelated heartbeat targets; manual and `cron --wake now` requests run promptly; restarting the heartbeat handler cannot start overlapping agent work or inherit a stale retry cooldown.

## Evidence

- Frozen clean main: `a4c4f905ff7b5a7a65114c5225ddc563c7014fb7`.
- Eleven independent read-only audits covered timers, wake pacing, mutation, recovery, delivery, Gateway RPC, cancellation, session admission, outcome handling, and CLI scheduling.
- Red-first trusted Linux proof: **seven original regression cases failed** before production changes.
- Final heartbeat suite: **41/41**, covering failed-target position, repeated failures, explicit manual/immediate wake priority, retained-guard ordering, stale running ownership, and completed/thrown/busy/guarded handler handoff.
- Repeated heartbeat race stress: **410/410** over ten complete passes.
- Complete cron suite: **1,799/1,799** across **155** test files.
- Full heartbeat-runner, Gateway, root-work admission, session-manager, session-yield, and prompt-error regression suites passed together on dedicated Blacksmith Testbox `tbx_01kyjxea36n4rkz93a8m65yb41`; exact-head combined command exit **0**.
- `pnpm check:changed` passed production and test `tsgo`, formatting, lint, dependency/plugin boundaries, state schema, database-first, sidecar, import-cycle, webhook, and pairing guards.
- Existing-main CI repair: remove the unused session-yield variable and make its preservation regression inspect the canonical full entry ledger rather than an intentionally rewound active branch.
- Fresh exact-head independent Codex review: **clean; no accepted or actionable findings**.
- No SQLite schema, migration, public configuration, provider, security, dependency, or Gateway protocol change.
