### PR TITLE
fix(exec): keep auto review failures on the human approval path

### DIFF
--- a/src/agents/bash-tools.exec-host-gateway.test.ts
+++ b/src/agents/bash-tools.exec-host-gateway.test.ts
@@ -212,7 +212,8 @@ vi.mock("../infra/exec-approvals.js", async (importOriginal) => ({
   resolveExecApprovalUnavailableDecisions: resolveExecApprovalUnavailableDecisionsMock,
 }));
 
-vi.mock("../infra/exec-auto-review.js", () => ({
+vi.mock("../infra/exec-auto-review.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../infra/exec-auto-review.js")>()),
   defaultExecAutoReviewer: defaultExecAutoReviewerMock,
 }));
 
@@ -886,6 +887,43 @@ describe("processGatewayAllowlist", () => {
 
     await expect(result).rejects.toThrow("cancelled during review");
     expect(createAndRegisterDefaultExecApprovalRequestMock).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    {
+      name: "throws synchronously",
+      reviewer: () => {
+        throw new Error("provider\n\u001b[31mfailed\u001b[0m\u202e");
+      },
+    },
+    {
+      name: "rejects asynchronously",
+      reviewer: async () => {
+        throw new Error("provider\n\u001b[31mfailed\u001b[0m\u202e");
+      },
+    },
+  ])("requests human approval when a gateway reviewer $name", async ({ reviewer }) => {
+    const command = "echo ok";
+    await configurePlanBackedCommand({ command });
+    const autoReviewer = vi.fn<ExecAutoReviewer>(reviewer);
+    const warnings: string[] = [];
+
+    const result = await runGatewayAllowlist({
+      command,
+      ask: "on-miss",
+      autoReview: true,
+      autoReviewer,
+      warnings,
+    });
+
+    expect(autoReviewer).toHaveBeenCalledTimes(1);
+    expect(result.pendingResult?.details.status).toBe("approval-pending");
+    expect(createAndRegisterDefaultExecApprovalRequestMock).toHaveBeenCalledTimes(1);
+    expect(commitExecAuthorizationMock).not.toHaveBeenCalled();
+    expect(runExecProcessMock).not.toHaveBeenCalled();
+    expect(warnings).toEqual([
+      "Exec auto-review deferred to human approval (risk=unknown): exec reviewer failed: provider\\nfailed",
+    ]);
   });
 
   it("reviews and executes the same PATH-resolved executable", async () => {

--- a/src/agents/bash-tools.exec-host-gateway.ts
+++ b/src/agents/bash-tools.exec-host-gateway.ts
@@ -36,6 +36,7 @@ import type { ExecAuthorizationPlan } from "../infra/exec-authorization-plan.js"
 import { buildAuthorizedShellCommandFromPlan } from "../infra/exec-authorization-render.js";
 import {
   defaultExecAutoReviewer,
+  resolveExecAutoReviewDecision,
   type ExecAutoReviewer,
   type ExecAutoReviewInput,
 } from "../infra/exec-auto-review.js";
@@ -798,36 +799,34 @@ export async function processGatewayAllowlist(
       requiresSecurityAuditSuppressionApproval;
     if (canAutoReviewApprovalMiss) {
       const reviewer = params.autoReviewer ?? defaultExecAutoReviewer;
-      const pendingDecision = Promise.resolve(
-        reviewer({
-          command: params.command,
-          argv: autoReviewArgv,
-          resolvedPath: autoReviewResolvedPath,
-          cwd: params.workdir,
-          envKeys: Object.keys(params.requestedEnv ?? {}).toSorted(),
-          host: "gateway",
-          reason: resolveGatewayAutoReviewReason({
-            requiresInlineEvalApproval,
-            requiresHeredocApproval,
-            requiresAllowlistPlanApproval,
-            hostSecurity,
-            analysisOk,
-            allowlistSatisfied,
-            durableApprovalSatisfied,
-          }),
-          analysis: {
-            parsed: analysisOk,
-            allowlistMatched: allowlistSatisfied,
-            durableApprovalMatched: durableApprovalSatisfied,
-            inlineEval: requiresInlineEvalApproval,
-            heredoc: requiresHeredocApproval,
-          },
-          agent: {
-            id: params.agentId,
-            sessionKey: params.sessionKey,
-          },
+      const pendingDecision = resolveExecAutoReviewDecision(reviewer, {
+        command: params.command,
+        argv: autoReviewArgv,
+        resolvedPath: autoReviewResolvedPath,
+        cwd: params.workdir,
+        envKeys: Object.keys(params.requestedEnv ?? {}).toSorted(),
+        host: "gateway",
+        reason: resolveGatewayAutoReviewReason({
+          requiresInlineEvalApproval,
+          requiresHeredocApproval,
+          requiresAllowlistPlanApproval,
+          hostSecurity,
+          analysisOk,
+          allowlistSatisfied,
+          durableApprovalSatisfied,
         }),
-      );
+        analysis: {
+          parsed: analysisOk,
+          allowlistMatched: allowlistSatisfied,
+          durableApprovalMatched: durableApprovalSatisfied,
+          inlineEval: requiresInlineEvalApproval,
+          heredoc: requiresHeredocApproval,
+        },
+        agent: {
+          id: params.agentId,
+          sessionKey: params.sessionKey,
+        },
+      });
       // Custom reviewers may never settle; cancellation must not retain approval authority.
       const decision = params.signal
         ? await abortable(params.signal, pendingDecision)

--- a/src/agents/bash-tools.exec-host-node.test.ts
+++ b/src/agents/bash-tools.exec-host-node.test.ts
@@ -1305,6 +1305,64 @@ describe("executeNodeHostCommand", () => {
     expect(registerExecApprovalRequestForHostOrThrowMock).not.toHaveBeenCalled();
   });
 
+  it.each([
+    {
+      name: "throws synchronously",
+      reviewer: () => {
+        throw new Error("provider\n\u001b[31mfailed\u001b[0m\u202e");
+      },
+    },
+    {
+      name: "rejects asynchronously",
+      reviewer: async () => {
+        throw new Error("provider\n\u001b[31mfailed\u001b[0m\u202e");
+      },
+    },
+  ])("requests human approval when a node reviewer $name", async ({ reviewer }) => {
+    const autoReviewer = vi.fn<ExecAutoReviewer>(reviewer);
+    const warnings: string[] = [];
+    resolveExecHostApprovalContextMock.mockReturnValue({
+      approvals: { allowlist: [], file: { version: 1, agents: {} } },
+      hostSecurity: "allowlist",
+      hostAsk: "on-miss",
+      askFallback: "deny",
+    });
+
+    const result = await executeNodeHostCommand({
+      command: "bun ./script.ts",
+      workdir: "/tmp/work",
+      env: {},
+      security: "allowlist",
+      ask: "on-miss",
+      autoReview: true,
+      autoReviewer,
+      defaultTimeoutSec: 30,
+      approvalRunningNoticeMs: 0,
+      warnings,
+      agentId: "requested-agent",
+      sessionKey: "requested-session",
+    });
+
+    expect(autoReviewer).toHaveBeenCalledTimes(1);
+    expect(result.details?.status).toBe("approval-pending");
+    expect(createAndRegisterDefaultExecApprovalRequestMock).toHaveBeenCalledTimes(1);
+    expect(registerExecApprovalRequestForHostOrThrowMock).toHaveBeenCalledWith(
+      expect.objectContaining({ approvalId: "approval-1", host: "node" }),
+    );
+    expect(callGatewayToolMock.mock.calls).not.toEqual(
+      expect.arrayContaining([
+        expect.arrayContaining([
+          "node.invoke",
+          expect.anything(),
+          expect.objectContaining({ command: "system.run" }),
+        ]),
+      ]),
+    );
+    expect(warnings).toEqual([
+      "Exec auto-review deferred to human approval (risk=unknown): exec reviewer failed: provider\\nfailed",
+    ]);
+  });
+
   it("reviews the prepared node plan before suppressing human approval", async () => {
     const divergentPlan = {
       argv: ["rm", "-rf", "/tmp/work"],

--- a/src/agents/bash-tools.exec-host-node.ts
+++ b/src/agents/bash-tools.exec-host-node.ts
@@ -14,7 +14,11 @@ import {
   resolveExecApprovalAllowedDecisions,
   resolveExecApprovalUnavailableDecisions,
 } from "../infra/exec-approvals.js";
-import { defaultExecAutoReviewer, type ExecAutoReviewInput } from "../infra/exec-auto-review.js";
+import {
+  defaultExecAutoReviewer,
+  resolveExecAutoReviewDecision,
+  type ExecAutoReviewInput,
+} from "../infra/exec-auto-review.js";
 import { tail } from "./bash-process-registry.js";
 import {
   buildExecApprovalRequesterContext,
@@ -377,32 +381,30 @@ export async function executeNodeHostCommand(
       !requiresSecurityAuditSuppressionApproval
     ) {
       const reviewer = params.autoReviewer ?? defaultExecAutoReviewer;
-      const pendingDecision = Promise.resolve(
-        reviewer({
-          command: prepared.rawCommand,
-          argv: autoReviewArgv,
-          cwd: prepared.cwd,
-          envKeys: Object.keys(params.requestedEnv ?? {}).toSorted(),
-          host: "node",
-          reason: resolveNodeAutoReviewReason({
-            inlineEvalHit,
-            hostSecurity,
-            analysisOk,
-            allowlistSatisfied,
-            durableApprovalSatisfied,
-          }),
-          analysis: {
-            parsed: analysisOk,
-            allowlistMatched: allowlistSatisfied,
-            durableApprovalMatched: durableApprovalSatisfied,
-            inlineEval: inlineEvalHit !== null,
-          },
-          agent: {
-            id: prepared.agentId,
-            sessionKey: prepared.sessionKey,
-          },
+      const pendingDecision = resolveExecAutoReviewDecision(reviewer, {
+        command: prepared.rawCommand,
+        argv: autoReviewArgv,
+        cwd: prepared.cwd,
+        envKeys: Object.keys(params.requestedEnv ?? {}).toSorted(),
+        host: "node",
+        reason: resolveNodeAutoReviewReason({
+          inlineEvalHit,
+          hostSecurity,
+          analysisOk,
+          allowlistSatisfied,
+          durableApprovalSatisfied,
         }),
-      );
+        analysis: {
+          parsed: analysisOk,
+          allowlistMatched: allowlistSatisfied,
+          durableApprovalMatched: durableApprovalSatisfied,
+          inlineEval: inlineEvalHit !== null,
+        },
+        agent: {
+          id: prepared.agentId,
+          sessionKey: prepared.sessionKey,
+        },
+      });
       // An injected reviewer cannot keep a cancelled node invocation or approval alive.
       const decision = params.signal
         ? await abortable(params.signal, pendingDecision)

--- a/src/agents/exec-auto-review.stress.test.ts
+++ b/src/agents/exec-auto-review.stress.test.ts
@@ -726,6 +726,69 @@ describe("exec auto-review adversarial model-response stress", () => {
 });
 
 describe("exec auto-review concurrency stress", () => {
+  it("keeps 128 mixed concurrent provider failures bounded and isolated", async () => {
+    const providerFailure = "provider\n\u001b[31mfailed\u001b[0m\u202e" + "x".repeat(1_024);
+    const cases = Array.from({ length: 128 }, (_unused, index) => {
+      const prepare = vi.fn(async () => {
+        if (index % 4 === 0) {
+          return { error: providerFailure };
+        }
+        return {
+          selection: { provider: "openrouter", modelId: "reviewer", agentDir: "/agent" },
+          model: { provider: "openrouter", id: "reviewer", api: "openai" as const },
+          auth: { apiKey: "redacted", mode: "env" as const },
+        };
+      });
+      const complete = vi.fn(async () => {
+        if (index % 4 === 1) {
+          return {
+            stopReason: "error" as const,
+            errorMessage: providerFailure,
+            content: [],
+          };
+        }
+        if (index % 4 === 2) {
+          throw new Error(providerFailure);
+        }
+        return modelResponse("allow", "low");
+      });
+      const reviewer = createModelExecAutoReviewer({
+        cfg: {},
+        deps: {
+          prepareSimpleCompletionModelForAgent:
+            prepare as unknown as typeof import("./simple-completion-runtime.js").prepareSimpleCompletionModelForAgent,
+          completeWithPreparedSimpleCompletionModel:
+            complete as unknown as typeof import("./simple-completion-runtime.js").completeWithPreparedSimpleCompletionModel,
+        },
+      });
+      return { reviewer, prepare, complete };
+    });
+
+    const decisions = await Promise.all(
+      cases.map(({ reviewer }, index) =>
+        Promise.resolve(
+          reviewer({
+            ...baselineInput,
+            command: `git status --failure-case=${index}`,
+            argv: ["git", "status", `--failure-case=${index}`],
+          }),
+        ),
+      ),
+    );
+
+    for (const [index, decision] of decisions.entries()) {
+      expect(decision.decision, `provider failure case ${index}`).toBe(
+        index % 4 === 3 ? "allow-once" : "ask",
+      );
+      expect(decision.rationale.length, `provider failure case ${index}`).toBeLessThanOrEqual(500);
+      expect(decision.rationale, `provider failure case ${index}`).not.toMatch(
+        /[\p{Cc}\p{Cf}\u2028\u2029]/u,
+      );
+      expect(cases[index]?.prepare).toHaveBeenCalledTimes(1);
+      expect(cases[index]?.complete).toHaveBeenCalledTimes(index % 4 === 0 ? 0 : 1);
+    }
+  });
+
   it("cancels 64 concurrent provider reviews without sharing execution signals", async () => {
     const controllers = Array.from({ length: 64 }, () => new AbortController());
     const observedSignals: AbortSignal[] = [];

--- a/src/agents/exec-auto-reviewer.test.ts
+++ b/src/agents/exec-auto-reviewer.test.ts
@@ -453,6 +453,92 @@ describe("createModelExecAutoReviewer", () => {
     });
   });
 
+  it.each([
+    { name: "terminal controls", message: "first\n\u001b[31msecond\u001b[0m\u202e" },
+    { name: "operating-system commands", message: "first\u001b]0;hidden title\u0007second" },
+    { name: "Unicode line separators", message: "first\u2028second\u2029third" },
+    { name: "oversized provider output", message: "x".repeat(10_000) },
+    { name: "a surrogate-pair boundary", message: "x".repeat(499) + "🚀tail" },
+  ])("normalizes model preparation failures containing $name", async ({ message }) => {
+    const reviewer = createModelExecAutoReviewer({
+      cfg: {},
+      deps: {
+        prepareSimpleCompletionModelForAgent: vi.fn(async () => ({
+          error: message,
+        })) as unknown as typeof import("./simple-completion-runtime.js").prepareSimpleCompletionModelForAgent,
+      },
+    });
+
+    const decision = await reviewer(input);
+
+    expect(decision).toMatchObject({ decision: "ask", risk: "unknown" });
+    expect(decision.rationale).toContain("exec reviewer model unavailable:");
+    expect(decision.rationale.length).toBeLessThanOrEqual(500);
+    expect(decision.rationale).not.toMatch(/[\p{Cc}\p{Cf}\u2028\u2029]/u);
+    expect(decision.rationale).not.toMatch(
+      /[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/u,
+    );
+  });
+
+  it.each([
+    { name: "terminal controls", message: "first\n\u001b[31msecond\u001b[0m\u202e" },
+    { name: "operating-system commands", message: "first\u001b]0;hidden title\u0007second" },
+    { name: "Unicode line separators", message: "first\u2028second\u2029third" },
+    { name: "oversized provider output", message: "x".repeat(10_000) },
+    { name: "a surrogate-pair boundary", message: "x".repeat(499) + "🚀tail" },
+  ])("normalizes complete model errors containing $name", async ({ message }) => {
+    const { prepare } = createReviewerHarness();
+    const reviewer = createModelExecAutoReviewer({
+      cfg: {},
+      deps: {
+        prepareSimpleCompletionModelForAgent:
+          prepare as unknown as typeof import("./simple-completion-runtime.js").prepareSimpleCompletionModelForAgent,
+        completeWithPreparedSimpleCompletionModel: vi.fn(async () => ({
+          stopReason: "error" as const,
+          errorMessage: message,
+          content: [],
+        })) as unknown as typeof import("./simple-completion-runtime.js").completeWithPreparedSimpleCompletionModel,
+      },
+    });
+
+    const decision = await reviewer(input);
+
+    expect(decision).toMatchObject({ decision: "ask", risk: "unknown" });
+    expect(decision.rationale).toContain("exec reviewer completion failed:");
+    expect(decision.rationale.length).toBeLessThanOrEqual(500);
+    expect(decision.rationale).not.toMatch(/[\p{Cc}\p{Cf}\u2028\u2029]/u);
+    expect(decision.rationale).not.toMatch(
+      /[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/u,
+    );
+  });
+
+  it.each([
+    { name: "terminal controls", message: "first\n\u001b[31msecond\u001b[0m\u202e" },
+    { name: "operating-system commands", message: "first\u001b]0;hidden title\u0007second" },
+    { name: "Unicode line separators", message: "first\u2028second\u2029third" },
+    { name: "oversized provider output", message: "x".repeat(10_000) },
+    { name: "a surrogate-pair boundary", message: "x".repeat(499) + "🚀tail" },
+  ])("normalizes thrown provider failures containing $name", async ({ message }) => {
+    const reviewer = createModelExecAutoReviewer({
+      cfg: {},
+      deps: {
+        prepareSimpleCompletionModelForAgent: vi.fn(async () => {
+          throw new Error(message);
+        }) as unknown as typeof import("./simple-completion-runtime.js").prepareSimpleCompletionModelForAgent,
+      },
+    });
+
+    const decision = await reviewer(input);
+
+    expect(decision).toMatchObject({ decision: "ask", risk: "unknown" });
+    expect(decision.rationale).toContain("exec reviewer failed:");
+    expect(decision.rationale.length).toBeLessThanOrEqual(500);
+    expect(decision.rationale).not.toMatch(/[\p{Cc}\p{Cf}\u2028\u2029]/u);
+    expect(decision.rationale).not.toMatch(
+      /[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/u,
+    );
+  });
+
   it.each(["aborted", "length", "toolUse"] as const)(
     "rejects %s completions even when partial content says allow",
     async (stopReason) => {

--- a/src/agents/exec-auto-reviewer.ts
+++ b/src/agents/exec-auto-reviewer.ts
@@ -5,15 +5,13 @@
  * the model response into conservative allow-once or ask decisions.
  */
 import { resolveTimerTimeoutMs } from "@openclaw/normalization-core/number-coercion";
-import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
-import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import { z } from "zod";
-import { sanitizeTerminalText } from "../../packages/terminal-core/src/safe-text.js";
 import type { AgentModelConfig } from "../config/types.agents-shared.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
-import { formatErrorMessage } from "../infra/errors.js";
 import {
+  buildExecAutoReviewFailureDecision,
   defaultExecAutoReviewer,
+  normalizeExecAutoReviewRationale,
   type ExecAutoReviewDecision,
   type ExecAutoReviewInput,
   type ExecAutoReviewer,
@@ -79,15 +77,6 @@ function buildReviewerUserPrompt(input: ExecAutoReviewInput): string {
     stringifyInput(input),
     "UNTRUSTED_EXEC_REQUEST_JSON_END",
   ].join("\n");
-}
-
-function normalizeRationale(value: unknown, fallback: string): string {
-  const text = normalizeOptionalString(typeof value === "string" ? value : undefined);
-  const sanitized = sanitizeTerminalText(text ?? fallback)
-    .replace(/[\p{Cf}\u2028\u2029]/gu, "")
-    .replace(/\s+/gu, " ")
-    .trim();
-  return truncateUtf16Safe(sanitized || fallback, 500);
 }
 
 function textLooksLikeReviewerDirective(value: string): boolean {
@@ -252,7 +241,7 @@ function parseExecAutoReviewResponse(text: string): ExecAutoReviewDecision {
   }
 
   const { decision, risk } = response.data;
-  const rationale = normalizeRationale(
+  const rationale = normalizeExecAutoReviewRationale(
     response.data.rationale,
     "exec reviewer did not explain decision",
   );
@@ -301,7 +290,7 @@ function extractCompletionFailure(
       "errorMessage" in result && typeof result.errorMessage === "string"
         ? result.errorMessage
         : undefined;
-    return normalizeRationale(message, "model returned an error");
+    return message?.trim() ? message : "model returned an error";
   }
   return `model stopped without a complete response (${stopReason ?? "unknown"})`;
 }
@@ -392,11 +381,10 @@ export function createModelExecAutoReviewer(params: {
         return buildReviewerTimeoutDecision(timeoutMs);
       }
       if ("error" in prepared) {
-        return {
-          decision: "ask",
-          risk: "unknown",
-          rationale: `exec reviewer model unavailable: ${prepared.error}`,
-        };
+        return buildExecAutoReviewFailureDecision(
+          "exec reviewer model unavailable",
+          prepared.error,
+        );
       }
 
       completionController = new AbortController();
@@ -435,11 +423,10 @@ export function createModelExecAutoReviewer(params: {
       }
       const completionFailure = extractCompletionFailure(result);
       if (completionFailure) {
-        return {
-          decision: "ask",
-          risk: "unknown",
-          rationale: `exec reviewer completion failed: ${completionFailure}`,
-        };
+        return buildExecAutoReviewFailureDecision(
+          "exec reviewer completion failed",
+          completionFailure,
+        );
       }
       return parseExecAutoReviewResponse(extractTextContent(result));
     } catch (err) {
@@ -447,11 +434,7 @@ export function createModelExecAutoReviewer(params: {
       if (completionController?.signal.aborted) {
         return buildReviewerTimeoutDecision(timeoutMs);
       }
-      return {
-        decision: "ask",
-        risk: "unknown",
-        rationale: `exec reviewer failed: ${formatErrorMessage(err)}`,
-      };
+      return buildExecAutoReviewFailureDecision("exec reviewer failed", err);
     }
   };
 }

--- a/src/infra/exec-auto-review.test.ts
+++ b/src/infra/exec-auto-review.test.ts
@@ -1,6 +1,25 @@
 // Covers conservative default exec auto-review decisions.
 import { describe, expect, it } from "vitest";
-import { defaultExecAutoReviewer, type ExecAutoReviewInput } from "./exec-auto-review.js";
+import {
+  buildExecAutoReviewFailureDecision,
+  defaultExecAutoReviewer,
+  normalizeExecAutoReviewRationale,
+  resolveExecAutoReviewDecision,
+  type ExecAutoReviewInput,
+  type ExecAutoReviewer,
+} from "./exec-auto-review.js";
+
+const reviewInput = {
+  command: "git status",
+  argv: ["git", "status"],
+  host: "gateway",
+  reason: "approval-required",
+  analysis: {
+    parsed: true,
+    allowlistMatched: false,
+    inlineEval: false,
+  },
+} satisfies ExecAutoReviewInput;
 
 function reviewCommand(command: string, argv: string[]) {
   return defaultExecAutoReviewer({
@@ -48,4 +67,85 @@ describe("default exec auto reviewer", () => {
       });
     },
   );
+});
+
+describe("exec auto-review failure handling", () => {
+  it.each([
+    {
+      name: "newlines, terminal controls, and bidirectional text",
+      value: "first\n\u001b[31msecond\u001b[0m\u202e",
+      expected: "first\\nsecond",
+    },
+    {
+      name: "operating-system command sequences",
+      value: "first\u001b]0;hidden title\u0007second",
+      expected: "firstsecond",
+    },
+    {
+      name: "Unicode line separators",
+      value: "first\u2028second\u2029third",
+      expected: "firstsecondthird",
+    },
+    { name: "empty provider explanations", value: "", expected: "review failed" },
+    { name: "missing provider explanations", value: undefined, expected: "review failed" },
+  ])("normalizes $name before human approval", ({ value, expected }) => {
+    expect(normalizeExecAutoReviewRationale(value, "review failed")).toBe(expected);
+  });
+
+  it("bounds the complete failure rationale without splitting surrogate pairs", () => {
+    const decision = buildExecAutoReviewFailureDecision(
+      "exec reviewer failed",
+      "x".repeat(477) + "🚀tail",
+    );
+
+    expect(decision).toMatchObject({ decision: "ask", risk: "unknown" });
+    expect(decision.rationale.length).toBeLessThanOrEqual(500);
+    expect(decision.rationale).not.toMatch(
+      /[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/u,
+    );
+  });
+
+  it.each([
+    {
+      name: "throws synchronously",
+      reviewer: () => {
+        throw new Error("provider\n\u001b[31mfailed\u001b[0m\u202e");
+      },
+    },
+    {
+      name: "rejects asynchronously",
+      reviewer: async () => {
+        throw new Error("provider\n\u001b[31mfailed\u001b[0m\u202e");
+      },
+    },
+  ])("defers when a reviewer $name", async ({ reviewer }) => {
+    await expect(resolveExecAutoReviewDecision(reviewer, reviewInput)).resolves.toEqual({
+      decision: "ask",
+      risk: "unknown",
+      rationale: "exec reviewer failed: provider\\nfailed",
+    });
+  });
+
+  it("preserves a successful reviewer's original decision", async () => {
+    const decision = {
+      decision: "allow-once",
+      risk: "low",
+      rationale: "read-only inspection",
+    } as const;
+    const reviewer: ExecAutoReviewer = () => decision;
+
+    await expect(resolveExecAutoReviewDecision(reviewer, reviewInput)).resolves.toBe(decision);
+  });
+
+  it("redacts provider credentials before displaying a reviewer failure", async () => {
+    const secret = "sk-proj-abcdefghijklmnopqrstuvwxyz0123456789ABCDEFGHIJ";
+    const reviewer: ExecAutoReviewer = () => {
+      throw new Error(`Authorization: Bearer ${secret}`);
+    };
+
+    const decision = await resolveExecAutoReviewDecision(reviewer, reviewInput);
+
+    expect(decision).toMatchObject({ decision: "ask", risk: "unknown" });
+    expect(decision.rationale).not.toContain(secret);
+  });
 });

--- a/src/infra/exec-auto-review.ts
+++ b/src/infra/exec-auto-review.ts
@@ -1,3 +1,8 @@
+import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
+import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
+import { sanitizeTerminalText } from "../../packages/terminal-core/src/safe-text.js";
+import { formatErrorMessage } from "./errors.js";
+
 /** Risk level returned by exec auto-reviewers for approval routing decisions. */
 type ExecAutoReviewRisk = "unknown" | "low" | "medium" | "high";
 
@@ -50,6 +55,40 @@ export type ExecAutoReviewInput = {
 export type ExecAutoReviewer = (
   input: ExecAutoReviewInput,
 ) => Promise<ExecAutoReviewDecision> | ExecAutoReviewDecision;
+
+/** Keeps reviewer and provider explanations safe for human-facing approval text. */
+export function normalizeExecAutoReviewRationale(value: unknown, fallback: string): string {
+  const text = normalizeOptionalString(typeof value === "string" ? value : undefined);
+  const sanitized = sanitizeTerminalText(text ?? fallback)
+    .replace(/[\p{Cf}\u2028\u2029]/gu, "")
+    .replace(/\s+/gu, " ")
+    .trim();
+  return truncateUtf16Safe(sanitized || fallback, 500);
+}
+
+/** Turns reviewer and provider failures into a bounded, redacted human-review decision. */
+export function buildExecAutoReviewFailureDecision(
+  prefix: string,
+  error: unknown,
+): ExecAutoReviewDecision {
+  return {
+    decision: "ask",
+    risk: "unknown",
+    rationale: normalizeExecAutoReviewRationale(`${prefix}: ${formatErrorMessage(error)}`, prefix),
+  };
+}
+
+/** Custom reviewer failures must defer to a human, never authorize or crash execution. */
+export async function resolveExecAutoReviewDecision(
+  reviewer: ExecAutoReviewer,
+  input: ExecAutoReviewInput,
+): Promise<ExecAutoReviewDecision> {
+  try {
+    return await reviewer(input);
+  } catch (error) {
+    return buildExecAutoReviewFailureDecision("exec reviewer failed", error);
+  }
+}
 
 /**
  * Conservative fallback used when no model-backed reviewer is available.

--- a/src/node-host/invoke-system-run.test.ts
+++ b/src/node-host/invoke-system-run.test.ts
@@ -809,6 +809,50 @@ describe("handleSystemRunInvoke mac app exec host routing", () => {
     }
   });
 
+  it.each([
+    {
+      name: "throws synchronously",
+      reviewer: () => {
+        throw new Error("provider\n\u001b[31mfailed\u001b[0m\u202e");
+      },
+    },
+    {
+      name: "rejects asynchronously",
+      reviewer: async () => {
+        throw new Error("provider\n\u001b[31mfailed\u001b[0m\u202e");
+      },
+    },
+  ])("denies direct system.run when its reviewer $name", async ({ reviewer }) => {
+    const tmp = createFixtureDir("openclaw-system-run-auto-review-failure-");
+    const executablePath = createTempExecutable({ dir: tmp, name: "read-info" });
+    setRuntimeConfigSnapshot({ tools: { exec: { mode: "auto" } } });
+    const autoReviewer = vi.fn<ExecAutoReviewer>(reviewer);
+    const runCommand = vi.fn(async () => createLocalRunResult("should-not-run"));
+    const prepared = buildSystemRunApprovalPlan({ command: [executablePath], cwd: tmp });
+    expect(prepared.ok).toBe(true);
+    if (!prepared.ok) {
+      throw new Error("expected a bound system.run approval plan");
+    }
+
+    const invoke = await runSystemInvoke({
+      preferMacAppExecHost: false,
+      command: prepared.plan.argv,
+      cwd: prepared.plan.cwd ?? tmp,
+      systemRunPlan: prepared.plan,
+      runCommand,
+      resolveExecSecurity: resolveProductionExecSecurity,
+      resolveExecAsk: resolveProductionExecAsk,
+      autoReviewer,
+    });
+
+    expect(autoReviewer).toHaveBeenCalledTimes(1);
+    expect(runCommand).not.toHaveBeenCalled();
+    expectInvokeErrorMessage(invoke.sendInvokeResult, {
+      message:
+        "exec auto-review deferred to human approval: exec reviewer failed: provider\\nfailed",
+    });
+  });
+
   it.runIf(process.platform !== "win32").each(["bash", "sh", "/bin/sh"])(
     "does not auto-review direct %s login-shell startup",
     async (shell) => {

--- a/src/node-host/invoke-system-run.ts
+++ b/src/node-host/invoke-system-run.ts
@@ -33,7 +33,7 @@ import {
   type SkillBinTrustEntry,
 } from "../infra/exec-approvals.js";
 import type { ExecAuthorizationPlan } from "../infra/exec-authorization-plan.js";
-import type { ExecAutoReviewer } from "../infra/exec-auto-review.js";
+import { resolveExecAutoReviewDecision, type ExecAutoReviewer } from "../infra/exec-auto-review.js";
 import type { ExecHostRequest, ExecHostResponse, ExecHostRunResult } from "../infra/exec-host.js";
 import { applyExecPolicyLayer } from "../infra/exec-policy.js";
 import { resolveExecSafeBinRuntimePolicy } from "../infra/exec-safe-bin-runtime-policy.js";
@@ -722,7 +722,7 @@ async function evaluateSystemRunPolicyPhase(
         agentExec,
         globalExec,
       });
-      const decision = await reviewer({
+      const decision = await resolveExecAutoReviewDecision(reviewer, {
         command: parsed.commandText,
         argv: autoReviewArgv,
         cwd: parsed.cwd,


### PR DESCRIPTION
Related: #114745

## What Problem This Solves

Fixes an issue where users running commands in automatic review mode could see execution fail when a configured reviewer throws synchronously or rejects asynchronously instead of receiving the normal human approval request. Provider failures could also produce unbounded, unsanitized diagnostics in approval messages.

## Why This Change Was Made

Use one shared owner for reviewer-failure conversion, credential redaction, terminal-safe rationale normalization, and conservative human-review decisions. Apply the same contract to gateway execution, remote node execution, direct node-host `system.run`, and model preparation/completion failures without changing successful one-shot approvals, command policy, cancellation, or configured reviewer timeouts.

## User Impact

Reviewer and provider outages now reliably defer to normal human approval. Failure messages remain bounded, single-line, Unicode-safe, and redacted. Commands are never executed or granted approval when review fails.

## Evidence

Exact published head: `927f98daea53950e18c2e5b160db978243336ecf`.

After-fix, actual execution-path transcript from the trusted PR-head worktree:

```text
$ node scripts/run-vitest.mjs \
    src/agents/bash-tools.exec-host-gateway.test.ts \
    src/agents/bash-tools.exec-host-node.test.ts \
    src/node-host/invoke-system-run.test.ts \
    --reporter verbose \
    --testNamePattern 'reviewer.*(throws synchronously|rejects asynchronously)'

✓ gateway requests human approval when a gateway reviewer throws synchronously
✓ gateway requests human approval when a gateway reviewer rejects asynchronously
✓ remote node requests human approval when a node reviewer throws synchronously
✓ remote node requests human approval when a node reviewer rejects asynchronously
✓ direct system.run denies execution when its reviewer throws synchronously
✓ direct system.run denies execution when its reviewer rejects asynchronously

Test Files  5 passed
Tests       10 passed | 379 filtered
```

The execution-path assertions also prove no gateway process is spawned, no node `system.run` is dispatched, no direct command is executed, the ordinary human approval is registered, and the visible warning is exactly:

```text
Exec auto-review deferred to human approval (risk=unknown): exec reviewer failed: provider\nfailed
```

Additional exact-surface and hosted proof:

- [All 79 hosted CI and security checks passed](https://github.com/openclaw/openclaw/actions/runs/30315663016).
- Full remote changed-file gate passed: whole-core lint, production and test type-checking, formatting, dependency pins, SDK and plugin boundaries, generated API baseline, import cycles, native schema, and database-first guards.
- Passed 917 tests across 23 reviewer, gateway/node, direct-node, cancellation, approval-policy, plugin-harness, and PR/CI-maintenance surfaces.
- Passed five consecutive reviewer stress repetitions: 1,290 test executions, 20,480 seeded malformed model responses, and 128 concurrent mixed provider failures per repetition.
- Added direct regressions for ANSI/OSC/bidi and Unicode line separators, 10,000-character messages, safe surrogate truncation, credential redaction, and preserved successful one-shot approvals.
- Three fresh independent Codex autoreviews: zero accepted or actionable findings.
- Repository-native maintainer review artifacts validated as `READY FOR /prepare-pr` on the exact head.

AI-assisted with Codex; implementation, dependency contracts, execution siblings, and failure-path evidence independently reviewed.