### PR TITLE
fix(cli): prevent update dry runs from mutating state

### DIFF
--- a/src/cli/update-cli.option-collisions.test.ts
+++ b/src/cli/update-cli.option-collisions.test.ts
@@ -49,9 +49,11 @@ function firstCallOptions(mock: { mock: { calls: unknown[][] } }) {
 
 type UpdateFinalizeCommandOptions = {
   acknowledgeClawHubRisk?: boolean;
+  channel?: string;
   json?: boolean;
   timeout?: string;
   restart?: boolean;
+  yes?: boolean;
 };
 
 describe("update cli option collisions", () => {
@@ -155,6 +157,112 @@ describe("update cli option collisions", () => {
 
     assert();
   });
+
+  it.each([
+    { name: "repair", handler: updateFinalizeCommand },
+    { name: "finalize", handler: updateFinalizeCommand },
+    { name: "wizard", handler: updateWizardCommand },
+  ])("rejects parent --dry-run before running update $name", async ({ name, handler }) => {
+    await runRegisteredCli({
+      register: registerUpdateCli as (program: Command) => void,
+      argv: ["update", "--dry-run", name],
+    });
+
+    expect(handler).not.toHaveBeenCalled();
+    expect(updateCommand).not.toHaveBeenCalled();
+    expect(defaultRuntime.error).toHaveBeenCalledWith(
+      `--dry-run is not supported for \`openclaw update ${name}\`. Run \`openclaw update --dry-run\` instead.`,
+    );
+    expect(defaultRuntime.exit).toHaveBeenCalledWith(1);
+  });
+
+  it.each(["repair", "finalize"])(
+    "forwards parent channel and confirmation to update %s",
+    async (name) => {
+      await runRegisteredCli({
+        register: registerUpdateCli as (program: Command) => void,
+        argv: ["update", "--channel", "beta", "--yes", name],
+      });
+
+      expect(updateFinalizeCommand).toHaveBeenCalledOnce();
+      expect(firstCallOptions(updateFinalizeCommand)).toMatchObject({
+        channel: "beta",
+        yes: true,
+      });
+    },
+  );
+
+  it.each(["repair", "finalize"])(
+    "lets the explicit update %s channel override its parent",
+    async (name) => {
+      await runRegisteredCli({
+        register: registerUpdateCli as (program: Command) => void,
+        argv: ["update", "--channel", "beta", "--yes", name, "--channel", "dev"],
+      });
+
+      expect(updateFinalizeCommand).toHaveBeenCalledOnce();
+      expect(firstCallOptions(updateFinalizeCommand)).toMatchObject({
+        channel: "dev",
+        yes: true,
+      });
+    },
+  );
+
+  it.each(["repair", "finalize"])(
+    "preserves an explicitly empty parent channel for update %s validation",
+    async (name) => {
+      await runRegisteredCli({
+        register: registerUpdateCli as (program: Command) => void,
+        argv: ["update", "--channel", "", name],
+      });
+
+      expect(updateFinalizeCommand).toHaveBeenCalledOnce();
+      expect(firstCallOptions(updateFinalizeCommand)).toMatchObject({ channel: "" });
+    },
+  );
+
+  it.each(["repair", "finalize"])(
+    "lets an explicitly empty update %s channel override its parent",
+    async (name) => {
+      await runRegisteredCli({
+        register: registerUpdateCli as (program: Command) => void,
+        argv: ["update", "--channel", "beta", name, "--channel", ""],
+      });
+
+      expect(updateFinalizeCommand).toHaveBeenCalledOnce();
+      expect(firstCallOptions(updateFinalizeCommand)).toMatchObject({ channel: "" });
+    },
+  );
+
+  it.each(["repair", "finalize"])(
+    "forwards all explicitly inherited options to update %s",
+    async (name) => {
+      await runRegisteredCli({
+        register: registerUpdateCli as (program: Command) => void,
+        argv: [
+          "update",
+          "--json",
+          "--timeout",
+          "31",
+          "--acknowledge-clawhub-risk",
+          "--channel",
+          "beta",
+          "--yes",
+          name,
+        ],
+      });
+
+      expect(updateFinalizeCommand).toHaveBeenCalledOnce();
+      expect(firstCallOptions(updateFinalizeCommand)).toMatchObject({
+        acknowledgeClawHubRisk: true,
+        channel: "beta",
+        json: true,
+        restart: false,
+        timeout: "31",
+        yes: true,
+      } satisfies UpdateFinalizeCommandOptions);
+    },
+  );
 
   it.each([
     {

--- a/src/cli/update-cli.test.ts
+++ b/src/cli/update-cli.test.ts
@@ -20,6 +20,7 @@ import {
   UPDATE_POST_INSTALL_DOCTOR_RESULT_PATH_ENV,
   writeUpdatePostInstallDoctorResult,
 } from "../infra/update-doctor-result.js";
+import { cleanupStaleManagedServiceUpdateHandoffs } from "../infra/update-managed-service-handoff-cleanup.js";
 import type { UpdateRunResult } from "../infra/update-runner.js";
 import { CLAWHUB_INSTALL_ERROR_CODE } from "../plugins/clawhub-error-codes.js";
 import { captureEnv, withEnvAsync } from "../test-utils/env.js";
@@ -2817,6 +2818,7 @@ describe("update-cli", () => {
       },
       assert: () => {
         expectNoSideEffects(
+          cleanupStaleManagedServiceUpdateHandoffs,
           replaceConfigFile,
           runGatewayUpdate,
           runDaemonInstall,
@@ -2839,6 +2841,7 @@ describe("update-cli", () => {
       },
       assert: () => {
         expect(defaultRuntime.exit).not.toHaveBeenCalledWith(1);
+        expect(cleanupStaleManagedServiceUpdateHandoffs).not.toHaveBeenCalled();
         expect(runGatewayUpdate).not.toHaveBeenCalled();
         expect(
           launchdUpdateCleanupMocks.disableCurrentOpenClawUpdateLaunchdJob,
@@ -2846,6 +2849,40 @@ describe("update-cli", () => {
       },
     },
   ] as const)("updateCommand dry-run behavior: $name", runUpdateCliScenario);
+
+  it("does not clean managed-service handoffs during a JSON dry run", async () => {
+    await updateCommand({ dryRun: true, json: true, channel: "beta" });
+
+    expect(cleanupStaleManagedServiceUpdateHandoffs).not.toHaveBeenCalled();
+    expectNoSideEffects(replaceConfigFile, runGatewayUpdate, runDaemonInstall);
+    expect(defaultRuntime.writeJson).toHaveBeenCalled();
+  });
+
+  it("does not clean managed-service handoffs before rejecting an invalid timeout", async () => {
+    await updateCommand({ timeout: "" });
+
+    expect(cleanupStaleManagedServiceUpdateHandoffs).not.toHaveBeenCalled();
+    expect(defaultRuntime.exit).toHaveBeenCalledWith(1);
+  });
+
+  it.each([
+    { name: "update", run: async () => await updateCommand({ channel: "" }) },
+    { name: "finalization", run: async () => await updateFinalizeCommand({ channel: "" }) },
+  ])("rejects an explicitly empty $name channel before mutation", async ({ run }) => {
+    await run();
+
+    expect(defaultRuntime.error).toHaveBeenCalledWith(
+      '--channel must be "stable", "extended-stable", "beta", or "dev" (got "")',
+    );
+    expect(defaultRuntime.exit).toHaveBeenCalledWith(1);
+    expectNoSideEffects(
+      cleanupStaleManagedServiceUpdateHandoffs,
+      replaceConfigFile,
+      runGatewayUpdate,
+      doctorCommand,
+      syncPluginsForUpdateChannel,
+    );
+  });
 
   it("refuses an incompatible package target before service stop or install", async () => {
     mockPackageInstallStatus(createCaseDir("openclaw-schema-refusal"));
@@ -6378,6 +6415,28 @@ describe("update-cli", () => {
     });
     expect(sentinel?.payload.stats?.mode).toBe("npm");
     expect(sentinel?.payload.stats?.after?.version).toBe("2026.4.24");
+  });
+
+  it("does not write a control-plane sentinel when a dry-run preflight fails", async () => {
+    const sentinel = await runControlPlaneUpdate({
+      meta: {
+        sessionKey: "agent:main:webchat:dm:user-123",
+        handoffId: "extended-stable-dry-run",
+        note: "Preview requested from the agent.",
+      },
+      options: { channel: "extended-stable", dryRun: true, yes: true, json: true },
+      beforeUpdate: () => {
+        mockPackageInstallStatus(createCaseDir("openclaw-update"));
+        vi.mocked(resolveExtendedStablePackage).mockResolvedValueOnce({
+          status: "failed",
+          reason: "selector_missing",
+        });
+      },
+    });
+
+    expect(sentinel).toBeNull();
+    expect(cleanupStaleManagedServiceUpdateHandoffs).not.toHaveBeenCalled();
+    expect(defaultRuntime.exit).toHaveBeenCalledWith(1);
   });
 
   it("writes an extended-stable selector failure to the control-plane sentinel", async () => {

--- a/src/cli/update-cli.ts
+++ b/src/cli/update-cli.ts
@@ -61,6 +61,18 @@ function inheritedUpdateClawHubRisk(command?: Command): boolean {
   );
 }
 
+function rejectUnsupportedInheritedUpdateDryRun(command: Command): boolean {
+  if (!inheritOptionFromParent<boolean>(command, "dryRun")) {
+    return false;
+  }
+
+  defaultRuntime.error(
+    `--dry-run is not supported for \`openclaw update ${command.name()}\`. Run \`openclaw update --dry-run\` instead.`,
+  );
+  defaultRuntime.exit(1);
+  return true;
+}
+
 function registerUpdateFinalizationCommand(update: Command, name: string, hidden: boolean) {
   const command = update.command(name, { hidden });
   command
@@ -90,11 +102,17 @@ function registerUpdateFinalizationCommand(update: Command, name: string, hidden
     )
     .action(async (opts, actionCommand) => {
       try {
+        if (rejectUnsupportedInheritedUpdateDryRun(actionCommand)) {
+          return;
+        }
+
         await updateFinalizeCommand({
           json: Boolean(opts.json) || inheritedUpdateJson(actionCommand),
-          channel: opts.channel as string | undefined,
+          channel:
+            (opts.channel as string | undefined) ??
+            inheritOptionFromParent<string>(actionCommand, "channel"),
           timeout: inheritedUpdateTimeout(opts, actionCommand),
-          yes: Boolean(opts.yes),
+          yes: Boolean(opts.yes) || Boolean(inheritOptionFromParent<boolean>(actionCommand, "yes")),
           restart: false,
           acknowledgeClawHubRisk:
             normalizeCommanderClawHubRiskOption(opts) || inheritedUpdateClawHubRisk(actionCommand),
@@ -209,6 +227,10 @@ ${theme.muted("Docs:")} ${formatDocsLink("/cli/update", "docs.openclaw.ai/cli/up
     )
     .action(async (opts, command) => {
       try {
+        if (rejectUnsupportedInheritedUpdateDryRun(command)) {
+          return;
+        }
+
         await updateWizardCommand({
           timeout: inheritedUpdateTimeout(opts, command),
         });

--- a/src/cli/update-cli/update-command-post-core.ts
+++ b/src/cli/update-cli/update-command-post-core.ts
@@ -107,11 +107,13 @@ export async function reportPreMutationUpdateFailure(params: {
     steps: [],
     durationMs: 0,
   };
-  await writeControlPlaneUpdateRestartSentinelBestEffort({
-    meta: params.controlPlaneUpdateSentinelMeta,
-    result,
-    jsonMode: Boolean(params.opts.json),
-  });
+  if (params.opts.dryRun !== true) {
+    await writeControlPlaneUpdateRestartSentinelBestEffort({
+      meta: params.controlPlaneUpdateSentinelMeta,
+      result,
+      jsonMode: Boolean(params.opts.json),
+    });
+  }
   printResult(result, params.opts);
   defaultRuntime.exit(1);
 }
@@ -136,6 +138,15 @@ export async function updateFinalizeCommand(opts: UpdateFinalizeOptions): Promis
   if (timeoutMs === null) {
     return;
   }
+  const requestedChannel = normalizeUpdateChannel(opts.channel);
+  if (opts.channel !== undefined && !requestedChannel) {
+    defaultRuntime.error(
+      `--channel must be "stable", "extended-stable", "beta", or "dev" (got "${opts.channel}")`,
+    );
+    defaultRuntime.exit(1);
+    return;
+  }
+
   assertConfigWriteAllowedInCurrentMode();
 
   const root = await resolveUpdateRoot();
@@ -153,14 +164,6 @@ export async function updateFinalizeCommand(opts: UpdateFinalizeOptions): Promis
             : configSnapshot.sourceConfig,
         }
       : undefined);
-  const requestedChannel = normalizeUpdateChannel(opts.channel);
-  if (opts.channel && !requestedChannel) {
-    defaultRuntime.error(
-      `--channel must be "stable", "extended-stable", "beta", or "dev" (got "${opts.channel}")`,
-    );
-    defaultRuntime.exit(1);
-    return;
-  }
   if (requestedChannel === "extended-stable") {
     const updateStatus = await checkUpdateStatus({
       root,

--- a/src/cli/update-cli/update-command.ts
+++ b/src/cli/update-cli/update-command.ts
@@ -115,7 +115,6 @@ async function updateCommandInternal(
   recoveryState: UpdateCommandRecoveryState,
 ): Promise<void> {
   suppressDeprecations();
-  await cleanupStaleManagedServiceUpdateHandoffs().catch(() => undefined);
   const invocationCwd = tryResolveInvocationCwd();
   const postCoreUpdateResume = process.env[POST_CORE_UPDATE_ENV] === "1";
   const postCoreUpdateChannel = process.env[POST_CORE_UPDATE_CHANNEL_ENV]?.trim();
@@ -125,6 +124,15 @@ async function updateCommandInternal(
   if (timeoutMs === null) {
     return;
   }
+  const requestedChannel = normalizeUpdateChannel(opts.channel);
+  if (opts.channel !== undefined && !requestedChannel) {
+    defaultRuntime.error(
+      `--channel must be "stable", "extended-stable", "beta", or "dev" (got "${opts.channel}")`,
+    );
+    defaultRuntime.exit(1);
+    return;
+  }
+
   if (!postCoreUpdateResume && opts.dryRun !== true && isGatewayExternallySupervised()) {
     defaultRuntime.error(formatExternalSupervisorUpdateRequired());
     defaultRuntime.exit(1);
@@ -137,6 +145,9 @@ async function updateCommandInternal(
       await disableCurrentOpenClawUpdateLaunchdJob().catch(() => undefined);
       throw err;
     }
+
+    // Cleanup deletes handoff directories, so previews and rejected invocations must never run it.
+    await cleanupStaleManagedServiceUpdateHandoffs().catch(() => undefined);
   }
   const updateStepTimeoutMs = timeoutMs ?? DEFAULT_UPDATE_STEP_TIMEOUT_MS;
 
@@ -158,15 +169,6 @@ async function updateCommandInternal(
     fetchGit: false,
     includeRegistry: false,
   });
-
-  const requestedChannel = normalizeUpdateChannel(opts.channel);
-  if (opts.channel && !requestedChannel) {
-    defaultRuntime.error(
-      `--channel must be "stable", "extended-stable", "beta", or "dev" (got "${opts.channel}")`,
-    );
-    defaultRuntime.exit(1);
-    return;
-  }
 
   if (requestedChannel === "extended-stable" && updateStatus.installKind === "git") {
     await reportPreMutationUpdateFailure({


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users previewing an OpenClaw update could unexpectedly delete real managed-service handoff directories, persist a failed-update restart sentinel, or run the mutating repair, finalization, or interactive wizard when `--dry-run` appeared before a subcommand.

Also fixes parent-position `--channel` and `--yes` silently disappearing from repair/finalization, and explicitly empty channels being accepted before update mutations.

## Why This Change Was Made

Keep the update CLI's existing documented preview contract: perform cleanup and restart-sentinel writes only for real updates, fail closed when a mutating subcommand has no preview implementation, validate explicitly supplied channels before reading or changing update state, and inherit parent options through the existing source-aware Commander helper while preserving an explicit child override.

The change preserves gateway-owned finalization, normal update cleanup, plugin convergence, JSON output, and the existing stable, extended-stable, beta, and dev channel contracts. No configuration option, environment variable, SQLite schema, plugin boundary, or dependency is added.

## User Impact

`openclaw update --dry-run` and its JSON/Nix variants no longer remove real stale update handoffs or create failure restart sentinels. `openclaw update --dry-run repair`, `finalize`, and `wizard` exit before invoking their mutating handlers and tell users to run the supported `openclaw update --dry-run` preview. Parent-position channel and confirmation options are honored; explicitly empty channels are rejected before any updater, doctor, or plugin mutation.

## Evidence

AI-assisted; independently reviewed against the freshly pulled current `main`.

Before the fix, the new real-Commander and mutation-owner regression tests fail against the frozen current-main baseline:

```text
Test Files  2 failed
Tests       14 failed | 211 passed
```

After the fix, rebased onto the freshly pulled latest main:

```text
update channels                 50 passed
managed handoff/finalization    34 passed | 1 existing skipped
CLI and update regressions     403 passed
doctor completion               16 passed
setup completion                 5 passed
real CLI JSON end-to-end         7 passed
total                          515 passed | 1 existing skipped
projects                       6 passed
```

The regressions exercise real registered Commander option parsing; parent-before-child dry-run rejection for repair, finalization, and wizard; parent channel/confirmation inheritance; child-over-parent precedence; invalid and explicitly empty channels; JSON/Nix dry runs; real control-plane restart-sentinel behavior; unchanged valid gateway finalization; completion, doctor, and wizard integrations; and parseable CLI stdout.

Exact-head checks:

- `pnpm check:changed -- src/cli/update-cli.ts src/cli/update-cli.option-collisions.test.ts src/cli/update-cli.test.ts src/cli/update-cli/update-command.ts src/cli/update-cli/update-command-post-core.ts` — passed; includes formatting, production/test TypeScript, lint, plugin SDK contracts and ownership, environment/dependency ratchets, SQLite schema and database-first guards, runtime cycles, and webhook/pairing security.
- `pnpm build` — passed; packaged CLI, public plugin SDK, Control UI, performance, and finalized assets.
- Fresh branch autoreview — zero findings; `patch is correct`.

- Real release-package and source CLI: **40 passed, 0 failed** against isolated real 26-hour-old managed-service handoffs; includes all 28 packaged option, timeout, human/JSON/Nix preview, help, and version cases plus 12 highest-risk source entry-point cases. Every case verifies the stale handoff and user configuration remain unchanged; rejected commands allow only the existing canonical SQLite bootstrap.
