### PR TITLE
test(active-memory): canonicalize session delivery fixtures

### DIFF
--- a/extensions/active-memory/index.test.ts
+++ b/extensions/active-memory/index.test.ts
@@ -4810,7 +4810,12 @@ describe("active-memory plugin", () => {
     hoisted.sessionStore["agent:main:telegram:direct:12345"] = {
       sessionId: "session-a",
       updatedAt: 25,
-      channel: "telegram",
+      delivery: {
+        kind: "external",
+        route: { channel: "telegram" },
+        context: { channel: "telegram" },
+        origin: { provider: "telegram" },
+      },
     };
 
     await runPromptBuild(
@@ -4893,7 +4898,12 @@ describe("active-memory plugin", () => {
     hoisted.sessionStore["agent:main:telegram:direct:12345"] = {
       sessionId: "session-a",
       updatedAt: 25,
-      channel: "telegram",
+      delivery: {
+        kind: "external",
+        route: { channel: "telegram" },
+        context: { channel: "telegram" },
+        origin: { provider: "telegram" },
+      },
     };
 
     await runPromptBuild(
@@ -4911,9 +4921,11 @@ describe("active-memory plugin", () => {
     hoisted.sessionStore["agent:main:qqbot:direct:12345"] = {
       sessionId: "session-a",
       updatedAt: 25,
-      channel: "c2c:10D4F7C2",
-      origin: {
-        provider: "qqbot",
+      delivery: {
+        kind: "external",
+        route: { channel: "qqbot" },
+        context: { channel: "c2c:10D4F7C2" },
+        origin: { provider: "qqbot" },
       },
     };
 
@@ -4933,8 +4945,11 @@ describe("active-memory plugin", () => {
     hoisted.sessionStore["agent:main:telegram:direct:12345"] = {
       sessionId: "session-a",
       updatedAt: 25,
-      origin: {
-        provider: "webchat",
+      delivery: {
+        kind: "external",
+        route: { channel: "webchat" },
+        context: {},
+        origin: { provider: "webchat" },
       },
     };
 
@@ -4953,8 +4968,11 @@ describe("active-memory plugin", () => {
     hoisted.sessionStore["agent:main:telegram:direct:12345"] = {
       sessionId: "session-a",
       updatedAt: 25,
-      origin: {
-        provider: "webchat",
+      delivery: {
+        kind: "external",
+        route: { channel: "webchat" },
+        context: {},
+        origin: { provider: "webchat" },
       },
     };
 


### PR DESCRIPTION
## What Problem This Solves
Five session-store fixtures in extensions/active-memory/index.test.ts still seeded the legacy flat channel/origin fields. #113225 moved the plugin's channel resolution to canonical delivery state only (deliveryContextFromSession / sessionDeliveryOrigin), which broke two tests (canonical session key by sessionId; resolved channel over wrapper hint) and left three more passing vacuously (the #77396 colon-channel guard and both weak-wrapper precedence tests no longer exercised their store fixtures).

## Why This Change Was Made
Tests must seed the canonical delivery shape (delivery: { kind: "external", route, context, origin }) per the repository rule that runtime reads canonical shapes only. Production is unaffected: the real session store normalizes legacy rows at load; the test mock returns raw objects and bypasses normalization.

## User Impact
None at runtime; restores signal for five active-memory channel-resolution tests so future regressions in that path are caught again.

## Evidence
- Introduction proven by file-level bisection: with pre-#113225 session.ts swapped in (all else current), the failing test passes.
- Full suite: `node scripts/run-vitest.mjs extensions/active-memory` 203/203 passing (was 201/203).
- Codex autoreview: clean, no actionable findings (0.96).
