### PR TITLE
refactor(agents): preserve canonical run termination and fallback

### DIFF
--- a/src/agents/agent-run-terminal-outcome.test.ts
+++ b/src/agents/agent-run-terminal-outcome.test.ts
@@ -324,6 +324,49 @@ describe("agent run terminal outcome", () => {
 });
 
 describe("agent run attempt terminal", () => {
+  it.each([
+    {
+      label: "external abort",
+      terminal: { kind: "aborted", source: "external" } as const,
+      expected: { aborted: true, externalAbort: true, timedOut: false, interrupted: true },
+    },
+    {
+      label: "run-budget timeout",
+      terminal: { kind: "timeout", phase: "prompt", source: "run_budget", aborted: true } as const,
+      expected: {
+        aborted: true,
+        externalAbort: false,
+        timedOut: true,
+        timedOutByRunBudget: true,
+        interrupted: true,
+      },
+    },
+    {
+      label: "compaction observation",
+      terminal: { kind: "timeout", phase: "compaction", source: "observation" } as const,
+      expected: {
+        aborted: false,
+        externalAbort: false,
+        timedOut: false,
+        timedOutDuringCompaction: true,
+        interrupted: false,
+      },
+    },
+    {
+      label: "tool-execution observation",
+      terminal: { kind: "timeout", phase: "tool_execution", source: "observation" } as const,
+      expected: {
+        aborted: false,
+        externalAbort: false,
+        timedOut: false,
+        timedOutDuringToolExecution: true,
+        interrupted: false,
+      },
+    },
+  ])("preserves the exact public projection for $label", ({ terminal, expected }) => {
+    expect(projectAgentRunAttemptTerminal(terminal)).toMatchObject(expected);
+  });
+
   it("merges observation-only timeout phases without creating a run timeout", () => {
     const toolExecution = {
       kind: "timeout",

--- a/src/agents/embedded-agent-runner/run/assistant-failover.test.ts
+++ b/src/agents/embedded-agent-runner/run/assistant-failover.test.ts
@@ -14,16 +14,12 @@ function makeParams(overrides: Partial<Params> = {}): Params {
   const model = "claude-haiku-4-5-20251001";
   const defaults: Params = {
     initialDecision: { action: "surface_error", reason: "billing" },
-    aborted: false,
-    externalAbort: false,
+    terminal: { kind: "ok" },
+    signalOwnedInterruption: false,
     fallbackConfigured: false,
     failoverFailure: true,
     failoverReason: "billing",
-    timedOut: false,
-    idleTimedOut: false,
-    timedOutDuringCompaction: false,
-    timedOutDuringToolExecution: false,
-    timedOutByRunBudget: false,
+    harnessOwnsTransport: false,
     allowSameModelIdleTimeoutRetry: false,
     allowSameModelRateLimitRetry: true,
     assistantProfileFailureReason: null,
@@ -488,7 +484,7 @@ describe("handleAssistantFailover", () => {
         makeParams({
           initialDecision: { action: "rotate_profile", reason: "timeout" },
           failoverReason: "timeout",
-          timedOut: true,
+          terminal: { kind: "timeout", phase: "prompt", source: "runtime" },
           cloudCodeAssistFormatError: true,
           lastProfileId: undefined,
           billingFailure: false,
@@ -508,7 +504,7 @@ describe("handleAssistantFailover", () => {
         makeParams({
           initialDecision: { action: "rotate_profile", reason: "timeout" },
           failoverReason: "timeout",
-          timedOut: true,
+          terminal: { kind: "timeout", phase: "prompt", source: "runtime" },
           assistantProfileFailureReason: "timeout",
           lastProfileId: "profile-timeout",
           advanceAuthProfile: vi.fn(async () => true),
@@ -522,6 +518,22 @@ describe("handleAssistantFailover", () => {
         reason: "timeout",
         modelId: "claude-haiku-4-5-20251001",
       });
+    });
+
+    it("preserves harness-owned timeout policy when profile rotation is exhausted", async () => {
+      const outcome = await handleAssistantFailover(
+        makeParams({
+          initialDecision: { action: "rotate_profile", reason: "timeout" },
+          terminal: { kind: "ok" },
+          harnessOwnsTransport: true,
+          fallbackConfigured: true,
+          failoverReason: "timeout",
+          billingFailure: false,
+          advanceAuthProfile: vi.fn(async () => false),
+        }),
+      );
+
+      expect(outcome.action).toBe("continue_normal");
     });
   });
 
@@ -626,7 +638,6 @@ describe("handleAssistantFailover", () => {
         makeParams({
           initialDecision: { action: "surface_error", reason: null },
           failoverReason: null,
-          timedOut: false,
           billingFailure: false,
           authFailure: true,
         }),
@@ -671,8 +682,7 @@ describe("handleAssistantFailover", () => {
       const outcome = await handleAssistantFailover(
         makeParams({
           initialDecision: { action: "surface_error", reason: null },
-          externalAbort: true,
-          aborted: true,
+          terminal: { kind: "aborted", source: "external" },
           failoverReason: null,
           billingFailure: false,
         }),
@@ -694,7 +704,7 @@ describe("handleAssistantFailover", () => {
         makeParams({
           initialDecision: { action: "surface_error", reason: null },
           failoverReason: null,
-          timedOut: true,
+          terminal: { kind: "timeout", phase: "prompt", source: "runtime" },
           billingFailure: false,
         }),
       );
@@ -707,8 +717,7 @@ describe("handleAssistantFailover", () => {
         makeParams({
           initialDecision: { action: "surface_error", reason: null },
           failoverReason: null,
-          timedOut: true,
-          idleTimedOut: true,
+          terminal: { kind: "timeout", phase: "prompt", source: "idle" },
           allowSameModelIdleTimeoutRetry: true,
           billingFailure: false,
         }),

--- a/src/agents/embedded-agent-runner/run/assistant-failover.ts
+++ b/src/agents/embedded-agent-runner/run/assistant-failover.ts
@@ -5,6 +5,10 @@ import { sanitizeForLog } from "../../../../packages/terminal-core/src/ansi.js";
 import type { OpenClawConfig } from "../../../config/types.openclaw.js";
 import type { AssistantMessage } from "../../../llm/types.js";
 import { classifyRateLimitWindow } from "../../../llm/utils/rate-limit-window.js";
+import {
+  projectAgentRunAttemptTerminal,
+  type AgentRunAttemptTerminal,
+} from "../../agent-run-terminal-outcome.js";
 import type { AuthProfileFailureReason } from "../../auth-profiles.js";
 import {
   formatAssistantErrorText,
@@ -62,16 +66,12 @@ export function isShortWindowRateLimitMessage(message: string | undefined): bool
  */
 export async function handleAssistantFailover(params: {
   initialDecision: AssistantFailoverDecision;
-  aborted: boolean;
-  externalAbort: boolean;
+  terminal: AgentRunAttemptTerminal;
+  signalOwnedInterruption: boolean;
   fallbackConfigured: boolean;
   failoverFailure: boolean;
   failoverReason: FailoverReason | null;
-  timedOut: boolean;
-  idleTimedOut: boolean;
-  timedOutDuringCompaction: boolean;
-  timedOutDuringToolExecution: boolean;
-  timedOutByRunBudget: boolean;
+  harnessOwnsTransport: boolean;
   allowSameModelIdleTimeoutRetry: boolean;
   allowSameModelRateLimitRetry: boolean;
   assistantProfileFailureReason: AuthProfileFailureReason | null;
@@ -111,6 +111,8 @@ export async function handleAssistantFailover(params: {
   maybeBackoffBeforeOverloadFailover: (reason: FailoverReason | null) => Promise<void>;
   advanceAuthProfile: () => Promise<boolean>;
 }): Promise<AssistantFailoverOutcome> {
+  const terminal = projectAgentRunAttemptTerminal(params.terminal);
+  const externalAbort = terminal.externalAbort || params.signalOwnedInterruption;
   let overloadProfileRotations = params.overloadProfileRotations;
   let decision = params.initialDecision;
   const sameModelIdleTimeoutRetry = (): AssistantFailoverOutcome => {
@@ -135,13 +137,13 @@ export async function handleAssistantFailover(params: {
     lastRetryFailoverReason: mergeRetryFailoverReason({
       previous: params.previousRetryFailoverReason,
       failoverReason: params.failoverReason,
-      timedOut: params.timedOut || params.idleTimedOut,
+      timedOut: terminal.timedOut,
     }),
   });
 
   if (decision.action === "rotate_profile") {
     const failedProfileId = params.lastProfileId;
-    const timeoutFailure = params.timedOut || params.idleTimedOut;
+    const timeoutFailure = terminal.timedOut;
     const failureReason = params.assistantProfileFailureReason;
     const markFailedProfile = async () => {
       if (!failedProfileId || !failureReason) {
@@ -210,7 +212,7 @@ export async function handleAssistantFailover(params: {
     const rotated = await params.advanceAuthProfile();
     const markFailedProfilePromise = markFailedProfile();
     if (timeoutFailure && !params.isProbeSession && failedProfileId) {
-      const timeoutLabel = params.idleTimedOut ? "idle timeout (model silent)" : "timed out";
+      const timeoutLabel = terminal.idleTimedOut ? "idle timeout (model silent)" : "timed out";
       params.warn(`Profile ${failedProfileId} ${timeoutLabel}. Trying next account...`);
     }
     if (params.cloudCodeAssistFormatError && failedProfileId) {
@@ -231,28 +233,24 @@ export async function handleAssistantFailover(params: {
         lastRetryFailoverReason: mergeRetryFailoverReason({
           previous: params.previousRetryFailoverReason,
           failoverReason: params.failoverReason,
-          timedOut: params.timedOut || params.idleTimedOut,
+          timedOut: terminal.timedOut,
         }),
       };
     }
     await markFailedProfilePromise;
-    if (params.idleTimedOut && params.allowSameModelIdleTimeoutRetry) {
+    if (terminal.idleTimedOut && params.allowSameModelIdleTimeoutRetry) {
       return sameModelIdleTimeoutRetry();
     }
 
     decision = resolveRunFailoverDecision({
       stage: "assistant",
       allowFormatRetry: params.cloudCodeAssistFormatError,
-      aborted: params.aborted,
-      externalAbort: params.externalAbort,
+      terminal: params.terminal,
+      signalOwnedInterruption: params.signalOwnedInterruption,
       fallbackConfigured: params.fallbackConfigured,
       failoverFailure: params.failoverFailure,
       failoverReason: params.failoverReason,
-      timedOut: params.timedOut,
-      idleTimedOut: params.idleTimedOut,
-      timedOutDuringCompaction: params.timedOutDuringCompaction,
-      timedOutDuringToolExecution: params.timedOutDuringToolExecution,
-      timedOutByRunBudget: params.timedOutByRunBudget,
+      harnessOwnsTransport: params.harnessOwnsTransport,
       profileRotated: true,
     });
   }
@@ -286,14 +284,14 @@ export async function handleAssistantFailover(params: {
   }
 
   if (decision.action === "surface_error") {
-    if (!params.externalAbort && params.idleTimedOut && params.allowSameModelIdleTimeoutRetry) {
+    if (!externalAbort && terminal.idleTimedOut && params.allowSameModelIdleTimeoutRetry) {
       return sameModelIdleTimeoutRetry();
     }
     params.logAssistantFailoverDecision("surface_error");
     // Only current provider failures throw here. External aborts, timeout
     // payload synthesis, and stale classified text without failoverFailure
     // keep the normal payload path.
-    if (!params.externalAbort && !params.timedOut && params.failoverFailure) {
+    if (!externalAbort && !terminal.timedOut && params.failoverFailure) {
       const message = resolveAssistantFailoverErrorMessage(params);
       const reason = resolveSurfaceErrorReason(decision.reason, params);
       const status =
@@ -329,15 +327,15 @@ function resolveAssistantFailoverErrorMessage(params: {
   config: OpenClawConfig | undefined;
   sessionKey?: string;
   activeErrorContext: { provider: string; model: string };
-  timedOut: boolean;
-  idleTimedOut: boolean;
+  terminal: AgentRunAttemptTerminal;
   rateLimitFailure: boolean;
   billingFailure: boolean;
   authFailure: boolean;
   /** Credential auth mode passed through to billing copy formatter (#80877). */
   authMode?: string;
 }): string {
-  const timeoutFailure = params.timedOut || params.idleTimedOut;
+  const timeoutFailure =
+    params.terminal.kind === "timeout" && params.terminal.source !== "observation";
   return (
     (params.lastAssistant
       ? formatAssistantErrorText(params.lastAssistant, {

--- a/src/agents/embedded-agent-runner/run/assistant-failure.ts
+++ b/src/agents/embedded-agent-runner/run/assistant-failure.ts
@@ -95,16 +95,8 @@ export async function handleEmbeddedAssistantFailure(input: {
   agentDir: string;
   isProbeSession: boolean;
 }): Promise<EmbeddedRunAssistantFailureOutcome> {
-  const {
-    aborted,
-    externalAbort,
-    idleTimedOut,
-    promptError,
-    timedOut,
-    timedOutByRunBudget,
-    timedOutDuringCompaction,
-    timedOutDuringToolExecution,
-  } = projectAgentRunAttemptTerminal(input.attempt.terminal);
+  const { aborted, idleTimedOut, promptError, timedOut, timedOutDuringCompaction } =
+    projectAgentRunAttemptTerminal(input.attempt.terminal);
   const terminalInterrupted = isEmbeddedRunTerminalInterrupted(input.terminalState.outcome);
   const { signalOwnedInterruption } = input.terminalState;
   const fallbackThinking = pickFallbackThinkingLevel({
@@ -240,31 +232,22 @@ export async function handleEmbeddedAssistantFailure(input: {
   const initialDecision = resolveRunFailoverDecision({
     stage: "assistant",
     allowFormatRetry: cloudCodeAssistFormatError,
-    aborted,
-    externalAbort: externalAbort || signalOwnedInterruption,
+    terminal: input.attempt.terminal,
+    signalOwnedInterruption,
     fallbackConfigured: input.fallbackConfigured,
     failoverFailure,
     failoverReason: assistantFailoverReason,
-    timedOut,
-    idleTimedOut,
-    timedOutDuringCompaction,
-    timedOutDuringToolExecution,
     harnessOwnsTransport: input.pluginHarnessOwnsTransport,
-    timedOutByRunBudget,
     profileRotated: false,
   });
   const outcome = await handleAssistantFailover({
     initialDecision,
-    aborted,
-    externalAbort: externalAbort || signalOwnedInterruption,
+    terminal: input.attempt.terminal,
+    signalOwnedInterruption,
     fallbackConfigured: input.fallbackConfigured,
     failoverFailure,
     failoverReason: assistantFailoverReason,
-    timedOut,
-    idleTimedOut,
-    timedOutDuringCompaction,
-    timedOutDuringToolExecution,
-    timedOutByRunBudget,
+    harnessOwnsTransport: input.pluginHarnessOwnsTransport,
     allowSameModelIdleTimeoutRetry:
       timedOut &&
       idleTimedOut &&

--- a/src/agents/embedded-agent-runner/run/failover-policy.test.ts
+++ b/src/agents/embedded-agent-runner/run/failover-policy.test.ts
@@ -208,16 +208,10 @@ describe("resolveRunFailoverDecision", () => {
     expect(
       resolveRunFailoverDecision({
         stage: "assistant",
-        aborted: false,
-        externalAbort: false,
+        terminal: { kind: "ok" },
         fallbackConfigured: true,
         failoverFailure: false,
         failoverReason: "rate_limit",
-        timedOut: false,
-        idleTimedOut: false,
-        timedOutDuringCompaction: false,
-        timedOutDuringToolExecution: false,
-        timedOutByRunBudget: false,
         profileRotated: false,
       }),
     ).toEqual({
@@ -229,16 +223,10 @@ describe("resolveRunFailoverDecision", () => {
     expect(
       resolveRunFailoverDecision({
         stage: "assistant",
-        aborted: false,
-        externalAbort: false,
+        terminal: { kind: "ok" },
         fallbackConfigured: true,
         failoverFailure: true,
         failoverReason: "format",
-        timedOut: false,
-        idleTimedOut: false,
-        timedOutDuringCompaction: false,
-        timedOutDuringToolExecution: false,
-        timedOutByRunBudget: false,
         profileRotated: false,
       }),
     ).toEqual({
@@ -252,16 +240,10 @@ describe("resolveRunFailoverDecision", () => {
       resolveRunFailoverDecision({
         stage: "assistant",
         allowFormatRetry: true,
-        aborted: false,
-        externalAbort: false,
+        terminal: { kind: "ok" },
         fallbackConfigured: true,
         failoverFailure: true,
         failoverReason: "format",
-        timedOut: false,
-        idleTimedOut: false,
-        timedOutDuringCompaction: false,
-        timedOutDuringToolExecution: false,
-        timedOutByRunBudget: false,
         profileRotated: false,
       }),
     ).toEqual({
@@ -274,16 +256,10 @@ describe("resolveRunFailoverDecision", () => {
     expect(
       resolveRunFailoverDecision({
         stage: "assistant",
-        aborted: false,
-        externalAbort: false,
+        terminal: { kind: "ok" },
         fallbackConfigured: true,
         failoverFailure: true,
         failoverReason: "rate_limit",
-        timedOut: false,
-        idleTimedOut: false,
-        timedOutDuringCompaction: false,
-        timedOutDuringToolExecution: false,
-        timedOutByRunBudget: false,
         profileRotated: true,
       }),
     ).toEqual({
@@ -296,16 +272,10 @@ describe("resolveRunFailoverDecision", () => {
     expect(
       resolveRunFailoverDecision({
         stage: "assistant",
-        aborted: false,
-        externalAbort: false,
+        terminal: { kind: "ok" },
         fallbackConfigured: true,
         failoverFailure: true,
         failoverReason: "tls_certificate",
-        timedOut: false,
-        idleTimedOut: false,
-        timedOutDuringCompaction: false,
-        timedOutDuringToolExecution: false,
-        timedOutByRunBudget: false,
         profileRotated: false,
       }),
     ).toEqual({
@@ -318,16 +288,10 @@ describe("resolveRunFailoverDecision", () => {
     expect(
       resolveRunFailoverDecision({
         stage: "assistant",
-        aborted: false,
-        externalAbort: false,
+        terminal: { kind: "ok" },
         fallbackConfigured: true,
         failoverFailure: false,
         failoverReason: "billing",
-        timedOut: false,
-        idleTimedOut: false,
-        timedOutDuringCompaction: false,
-        timedOutDuringToolExecution: false,
-        timedOutByRunBudget: false,
         profileRotated: true,
       }),
     ).toEqual({
@@ -339,16 +303,10 @@ describe("resolveRunFailoverDecision", () => {
     expect(
       resolveRunFailoverDecision({
         stage: "assistant",
-        aborted: false,
-        externalAbort: false,
+        terminal: { kind: "ok" },
         fallbackConfigured: true,
         failoverFailure: false,
         failoverReason: null,
-        timedOut: false,
-        idleTimedOut: false,
-        timedOutDuringCompaction: false,
-        timedOutDuringToolExecution: false,
-        timedOutByRunBudget: false,
         profileRotated: false,
       }),
     ).toEqual({
@@ -377,22 +335,32 @@ describe("resolveRunFailoverDecision", () => {
     expect(
       resolveRunFailoverDecision({
         stage: "assistant",
-        aborted: true,
-        externalAbort: false,
+        terminal: { kind: "timeout", phase: "tool_execution", source: "runtime", aborted: true },
         fallbackConfigured: true,
         failoverFailure: false,
         failoverReason: null,
-        timedOut: true,
-        idleTimedOut: false,
-        timedOutDuringCompaction: false,
-        timedOutDuringToolExecution: true,
-        timedOutByRunBudget: false,
         profileRotated: false,
       }),
     ).toEqual({
       action: "continue_normal",
     });
   });
+
+  it.each(["compaction", "tool_execution"] as const)(
+    "does not spend profile or fallback retries on a %s timeout observation",
+    (phase) => {
+      expect(
+        resolveRunFailoverDecision({
+          stage: "assistant",
+          terminal: { kind: "timeout", phase, source: "observation" },
+          fallbackConfigured: true,
+          failoverFailure: false,
+          failoverReason: null,
+          profileRotated: false,
+        }),
+      ).toEqual({ action: "continue_normal" });
+    },
+  );
 
   it("falls back for opencode-go provider-owned stalled stream errors after rotation is exhausted", () => {
     const assistantError = {
@@ -419,15 +387,10 @@ describe("resolveRunFailoverDecision", () => {
     expect(
       resolveRunFailoverDecision({
         stage: "assistant",
-        aborted: false,
-        externalAbort: false,
+        terminal: { kind: "ok" },
         fallbackConfigured: true,
         failoverFailure: failoverReason !== null,
         failoverReason,
-        timedOut: false,
-        idleTimedOut: false,
-        timedOutDuringCompaction: false,
-        timedOutDuringToolExecution: false,
         profileRotated: true,
       }),
     ).toEqual({
@@ -440,16 +403,10 @@ describe("resolveRunFailoverDecision", () => {
     expect(
       resolveRunFailoverDecision({
         stage: "assistant",
-        aborted: true,
-        externalAbort: false,
+        terminal: { kind: "timeout", phase: "tool_execution", source: "runtime", aborted: true },
         fallbackConfigured: true,
         failoverFailure: false,
         failoverReason: null,
-        timedOut: true,
-        idleTimedOut: false,
-        timedOutDuringCompaction: false,
-        timedOutDuringToolExecution: true,
-        timedOutByRunBudget: false,
         profileRotated: true,
       }),
     ).toEqual({
@@ -461,16 +418,10 @@ describe("resolveRunFailoverDecision", () => {
     expect(
       resolveRunFailoverDecision({
         stage: "assistant",
-        aborted: true,
-        externalAbort: false,
+        terminal: { kind: "timeout", phase: "prompt", source: "runtime", aborted: true },
         fallbackConfigured: true,
         failoverFailure: false,
         failoverReason: null,
-        timedOut: true,
-        idleTimedOut: false,
-        timedOutDuringCompaction: false,
-        timedOutDuringToolExecution: false,
-        timedOutByRunBudget: false,
         profileRotated: false,
       }),
     ).toEqual({
@@ -485,15 +436,10 @@ describe("resolveRunFailoverDecision", () => {
     expect(
       resolveRunFailoverDecision({
         stage: "assistant",
-        aborted: true,
-        externalAbort: false,
+        terminal: { kind: "timeout", phase: "prompt", source: "runtime", aborted: true },
         fallbackConfigured: true,
         failoverFailure: false,
         failoverReason: null,
-        timedOut: true,
-        idleTimedOut: false,
-        timedOutDuringCompaction: false,
-        timedOutDuringToolExecution: false,
         harnessOwnsTransport: true,
         profileRotated: false,
       }),
@@ -506,15 +452,10 @@ describe("resolveRunFailoverDecision", () => {
     expect(
       resolveRunFailoverDecision({
         stage: "assistant",
-        aborted: false,
-        externalAbort: false,
+        terminal: { kind: "ok" },
         fallbackConfigured: true,
         failoverFailure: true,
         failoverReason: "timeout",
-        timedOut: false,
-        idleTimedOut: false,
-        timedOutDuringCompaction: false,
-        timedOutDuringToolExecution: false,
         harnessOwnsTransport: true,
         profileRotated: false,
       }),
@@ -527,15 +468,10 @@ describe("resolveRunFailoverDecision", () => {
     expect(
       resolveRunFailoverDecision({
         stage: "assistant",
-        aborted: false,
-        externalAbort: false,
+        terminal: { kind: "timeout", phase: "prompt", source: "runtime" },
         fallbackConfigured: true,
         failoverFailure: true,
         failoverReason: "rate_limit",
-        timedOut: true,
-        idleTimedOut: false,
-        timedOutDuringCompaction: false,
-        timedOutDuringToolExecution: false,
         harnessOwnsTransport: true,
         profileRotated: false,
       }),
@@ -549,15 +485,10 @@ describe("resolveRunFailoverDecision", () => {
     expect(
       resolveRunFailoverDecision({
         stage: "assistant",
-        aborted: false,
-        externalAbort: false,
+        terminal: { kind: "timeout", phase: "prompt", source: "runtime" },
         fallbackConfigured: true,
         failoverFailure: true,
         failoverReason: "billing",
-        timedOut: true,
-        idleTimedOut: false,
-        timedOutDuringCompaction: false,
-        timedOutDuringToolExecution: false,
         harnessOwnsTransport: true,
         profileRotated: true,
       }),
@@ -571,16 +502,10 @@ describe("resolveRunFailoverDecision", () => {
     expect(
       resolveRunFailoverDecision({
         stage: "assistant",
-        aborted: true,
-        externalAbort: false,
+        terminal: { kind: "timeout", phase: "tool_execution", source: "idle", aborted: true },
         fallbackConfigured: true,
         failoverFailure: false,
         failoverReason: null,
-        timedOut: true,
-        idleTimedOut: true,
-        timedOutDuringCompaction: false,
-        timedOutDuringToolExecution: true,
-        timedOutByRunBudget: false,
         profileRotated: false,
       }),
     ).toEqual({
@@ -593,16 +518,10 @@ describe("resolveRunFailoverDecision", () => {
     expect(
       resolveRunFailoverDecision({
         stage: "assistant",
-        aborted: true,
-        externalAbort: false,
+        terminal: { kind: "timeout", phase: "tool_execution", source: "idle", aborted: true },
         fallbackConfigured: true,
         failoverFailure: false,
         failoverReason: null,
-        timedOut: true,
-        idleTimedOut: true,
-        timedOutDuringCompaction: false,
-        timedOutDuringToolExecution: true,
-        timedOutByRunBudget: false,
         profileRotated: true,
       }),
     ).toEqual({
@@ -615,16 +534,10 @@ describe("resolveRunFailoverDecision", () => {
     expect(
       resolveRunFailoverDecision({
         stage: "assistant",
-        aborted: true,
-        externalAbort: true,
+        terminal: { kind: "timeout", phase: "prompt", source: "external", aborted: true },
         fallbackConfigured: true,
         failoverFailure: false,
         failoverReason: null,
-        timedOut: true,
-        idleTimedOut: false,
-        timedOutDuringCompaction: false,
-        timedOutDuringToolExecution: false,
-        timedOutByRunBudget: false,
         profileRotated: false,
       }),
     ).toEqual({
@@ -633,20 +546,28 @@ describe("resolveRunFailoverDecision", () => {
     });
   });
 
+  it("keeps an externally owned interruption ahead of an idle watchdog retry", () => {
+    expect(
+      resolveRunFailoverDecision({
+        stage: "assistant",
+        terminal: { kind: "timeout", phase: "tool_execution", source: "idle", aborted: true },
+        signalOwnedInterruption: true,
+        fallbackConfigured: true,
+        failoverFailure: false,
+        failoverReason: null,
+        profileRotated: false,
+      }),
+    ).toEqual({ action: "surface_error", reason: null });
+  });
+
   it("rotates profile on LLM idle timeout before falling back", () => {
     expect(
       resolveRunFailoverDecision({
         stage: "assistant",
-        aborted: false,
-        externalAbort: false,
+        terminal: { kind: "timeout", phase: "prompt", source: "idle" },
         fallbackConfigured: true,
         failoverFailure: false,
         failoverReason: null,
-        timedOut: false,
-        idleTimedOut: true,
-        timedOutDuringCompaction: false,
-        timedOutDuringToolExecution: false,
-        timedOutByRunBudget: false,
         profileRotated: false,
       }),
     ).toEqual({
@@ -659,16 +580,10 @@ describe("resolveRunFailoverDecision", () => {
     expect(
       resolveRunFailoverDecision({
         stage: "assistant",
-        aborted: false,
-        externalAbort: false,
+        terminal: { kind: "timeout", phase: "prompt", source: "idle" },
         fallbackConfigured: true,
         failoverFailure: false,
         failoverReason: null,
-        timedOut: false,
-        idleTimedOut: true,
-        timedOutDuringCompaction: false,
-        timedOutDuringToolExecution: false,
-        timedOutByRunBudget: false,
         profileRotated: true,
       }),
     ).toEqual({
@@ -681,15 +596,10 @@ describe("resolveRunFailoverDecision", () => {
     expect(
       resolveRunFailoverDecision({
         stage: "assistant",
-        aborted: false,
-        externalAbort: false,
+        terminal: { kind: "timeout", phase: "prompt", source: "idle" },
         fallbackConfigured: true,
         failoverFailure: false,
         failoverReason: null,
-        timedOut: false,
-        idleTimedOut: true,
-        timedOutDuringCompaction: false,
-        timedOutDuringToolExecution: false,
         harnessOwnsTransport: true,
         profileRotated: true,
       }),
@@ -758,16 +668,10 @@ describe("resolveRunFailoverDecision", () => {
     expect(
       resolveRunFailoverDecision({
         stage: "assistant",
-        aborted: false,
-        externalAbort: false,
+        terminal: { kind: "timeout", phase: "prompt", source: "idle" },
         fallbackConfigured: false,
         failoverFailure: false,
         failoverReason: null,
-        timedOut: false,
-        idleTimedOut: true,
-        timedOutDuringCompaction: false,
-        timedOutDuringToolExecution: false,
-        timedOutByRunBudget: false,
         profileRotated: true,
       }),
     ).toEqual({
@@ -780,16 +684,11 @@ describe("resolveRunFailoverDecision", () => {
     expect(
       resolveRunFailoverDecision({
         stage: "assistant",
-        aborted: false,
-        externalAbort: true,
+        terminal: { kind: "timeout", phase: "prompt", source: "idle" },
+        signalOwnedInterruption: true,
         fallbackConfigured: true,
         failoverFailure: false,
         failoverReason: null,
-        timedOut: false,
-        idleTimedOut: true,
-        timedOutDuringCompaction: false,
-        timedOutDuringToolExecution: false,
-        timedOutByRunBudget: false,
         profileRotated: false,
       }),
     ).toEqual({
@@ -802,16 +701,10 @@ describe("resolveRunFailoverDecision", () => {
     expect(
       resolveRunFailoverDecision({
         stage: "assistant",
-        aborted: true,
-        externalAbort: false,
+        terminal: { kind: "timeout", phase: "prompt", source: "run_budget", aborted: true },
         fallbackConfigured: true,
         failoverFailure: false,
         failoverReason: null,
-        timedOut: true,
-        idleTimedOut: false,
-        timedOutDuringCompaction: false,
-        timedOutDuringToolExecution: false,
-        timedOutByRunBudget: true,
         profileRotated: false,
       }),
     ).toEqual({
@@ -823,16 +716,10 @@ describe("resolveRunFailoverDecision", () => {
     expect(
       resolveRunFailoverDecision({
         stage: "assistant",
-        aborted: true,
-        externalAbort: false,
+        terminal: { kind: "timeout", phase: "prompt", source: "run_budget", aborted: true },
         fallbackConfigured: true,
         failoverFailure: false,
         failoverReason: null,
-        timedOut: true,
-        idleTimedOut: false,
-        timedOutDuringCompaction: false,
-        timedOutDuringToolExecution: false,
-        timedOutByRunBudget: true,
         profileRotated: true,
       }),
     ).toEqual({

--- a/src/agents/embedded-agent-runner/run/failover-policy.ts
+++ b/src/agents/embedded-agent-runner/run/failover-policy.ts
@@ -1,6 +1,7 @@
 /**
  * Resolves retry, fallback, and terminal failover decisions for a run.
  */
+import type { AgentRunAttemptTerminal } from "../../agent-run-terminal-outcome.js";
 import type { FailoverReason } from "../../embedded-agent-helpers.js";
 
 /** Failover action selected for one embedded run failure decision point. */
@@ -59,17 +60,12 @@ type PromptDecisionParams = {
 type AssistantDecisionParams = {
   stage: "assistant";
   allowFormatRetry?: boolean;
-  aborted: boolean;
-  externalAbort: boolean;
+  terminal: AgentRunAttemptTerminal;
+  signalOwnedInterruption?: boolean;
   fallbackConfigured: boolean;
   failoverFailure: boolean;
   failoverReason: FailoverReason | null;
-  timedOut: boolean;
-  idleTimedOut: boolean;
-  timedOutDuringCompaction: boolean;
-  timedOutDuringToolExecution: boolean;
   harnessOwnsTransport?: boolean;
-  timedOutByRunBudget?: boolean;
   profileRotated: boolean;
 };
 
@@ -108,8 +104,9 @@ function shouldRotatePrompt(params: PromptDecisionParams): boolean {
 
 function isAssistantTimeoutFailure(params: AssistantDecisionParams): boolean {
   return (
-    params.idleTimedOut ||
-    (params.timedOut && !params.timedOutDuringCompaction && !params.timedOutDuringToolExecution)
+    params.terminal.kind === "timeout" &&
+    params.terminal.source !== "observation" &&
+    (params.terminal.source === "idle" || params.terminal.phase === "prompt")
   );
 }
 
@@ -123,7 +120,7 @@ function shouldRotateAssistant(params: AssistantDecisionParams): boolean {
   if (isTerminalFormatFailure(params)) {
     return false;
   }
-  if (params.timedOutByRunBudget) {
+  if (params.terminal.kind === "timeout" && params.terminal.source === "run_budget") {
     return false;
   }
   const timeoutFailure = isAssistantTimeoutFailure(params);
@@ -132,7 +129,12 @@ function shouldRotateAssistant(params: AssistantDecisionParams): boolean {
   if (harnessOwnedTimeout && !isConcreteNonTimeoutAssistantFailure(params)) {
     return false;
   }
-  return (!params.aborted && params.failoverFailure) || timeoutFailure;
+  const aborted =
+    (params.terminal.kind === "aborted" && params.terminal.source !== "yield_cleanup") ||
+    (params.terminal.kind === "timeout" &&
+      params.terminal.source !== "observation" &&
+      params.terminal.aborted === true);
+  return (!aborted && params.failoverFailure) || timeoutFailure;
 }
 
 function assistantFallbackReason(params: AssistantDecisionParams): FailoverReason {
@@ -231,7 +233,11 @@ export function resolveRunFailoverDecision(params: RunFailoverDecisionParams): R
     };
   }
 
-  if (params.externalAbort) {
+  if (
+    params.signalOwnedInterruption ||
+    ((params.terminal.kind === "aborted" || params.terminal.kind === "timeout") &&
+      params.terminal.source === "external")
+  ) {
     return {
       action: "surface_error",
       reason: params.failoverReason,

--- a/src/gateway/server-methods/agent-run-dispatch.ts
+++ b/src/gateway/server-methods/agent-run-dispatch.ts
@@ -5,10 +5,7 @@ import {
 } from "../../agents/agent-run-terminal-outcome.js";
 import type { MainSessionRecoveryPendingTarget } from "../../agents/main-session-recovery-store.js";
 import { isAgentRunRestartAbortReason } from "../../agents/run-termination.js";
-import {
-  normalizeAgentRunTimeoutPhase,
-  normalizeProviderStarted,
-} from "../../agents/run-timeout-attribution.js";
+import { normalizeAgentRunTimeoutPhase } from "../../agents/run-timeout-attribution.js";
 import { agentCommandFromGatewayIngress } from "../../commands/agent.js";
 import { isAbortError } from "../../infra/abort-signal.js";
 import { clearAgentRunContext } from "../../infra/agent-events.js";
@@ -25,17 +22,6 @@ import {
   type GatewayAgentTaskTrackingMode,
 } from "./agent-task-tracking.js";
 import type { GatewayRequestContext, GatewayRequestHandlerOptions } from "./types.js";
-
-function readAgentRunTimeoutAttribution(meta: unknown) {
-  const record =
-    meta && typeof meta === "object" && !Array.isArray(meta)
-      ? (meta as Record<string, unknown>)
-      : undefined;
-  return {
-    timeoutPhase: normalizeAgentRunTimeoutPhase(record?.timeoutPhase),
-    providerStarted: normalizeProviderStarted(record?.providerStarted),
-  };
-}
 
 function isGatewayAbortSignalReason(reason: unknown): boolean {
   return reason === undefined || isAbortError(reason) || readErrorName(reason) === "TimeoutError";
@@ -66,12 +52,6 @@ function resolveGatewayAgentAbortStopReason(signal: AbortSignal): "restart" | "r
 
 function resolveAbortedAgentTaskStatus(stopReason: string | undefined): "cancelled" | "timed_out" {
   return stopReason === "timeout" ? "timed_out" : "cancelled";
-}
-
-function resolveGatewayAgentAbortTimeoutPhase(
-  stopReason: "restart" | "rpc" | "timeout",
-): "gateway_draining" | undefined {
-  return stopReason === "restart" ? "gateway_draining" : undefined;
 }
 
 export function resolveAbortedAgentStopReason(entry?: ChatAbortControllerEntry): string {
@@ -157,7 +137,20 @@ export function dispatchAgentRunFromGateway(params: {
     .then(async (result) => {
       const aborted = result?.meta?.aborted === true;
       const stopReason = aborted ? (result?.meta?.stopReason ?? "rpc") : undefined;
-      const timeoutAttribution = readAgentRunTimeoutAttribution(result?.meta);
+      const timeoutPhase = normalizeAgentRunTimeoutPhase(result?.meta?.timeoutPhase);
+      const terminalOutcome = buildAgentRunTerminalOutcome({
+        status:
+          aborted || result?.meta?.stopReason === "timeout" || timeoutPhase
+            ? "timeout"
+            : result?.meta?.error || result?.meta?.stopReason === "error"
+              ? "error"
+              : "ok",
+        error: result?.meta?.error,
+        stopReason: result?.meta?.stopReason,
+        livenessState: result?.meta?.livenessState,
+        timeoutPhase,
+        providerStarted: result?.meta?.providerStarted,
+      });
       if (taskTracked) {
         tryFinalizeTrackedAgentTask({
           runId: params.runId,
@@ -171,27 +164,14 @@ export function dispatchAgentRunFromGateway(params: {
         status: aborted ? ("timeout" as const) : ("ok" as const),
         summary: aborted ? "aborted" : "completed",
         ...(aborted ? { stopReason } : {}),
-        ...(aborted && timeoutAttribution.timeoutPhase
-          ? { timeoutPhase: timeoutAttribution.timeoutPhase }
+        ...(aborted && terminalOutcome.timeoutPhase
+          ? { timeoutPhase: terminalOutcome.timeoutPhase }
           : {}),
-        ...(aborted && timeoutAttribution.providerStarted !== undefined
-          ? { providerStarted: timeoutAttribution.providerStarted }
+        ...(aborted && terminalOutcome.providerStarted !== undefined
+          ? { providerStarted: terminalOutcome.providerStarted }
           : {}),
         result,
       };
-      const terminalOutcome = buildAgentRunTerminalOutcome({
-        status:
-          aborted || result?.meta?.stopReason === "timeout" || timeoutAttribution.timeoutPhase
-            ? "timeout"
-            : result?.meta?.error || result?.meta?.stopReason === "error"
-              ? "error"
-              : "ok",
-        error: result?.meta?.error,
-        stopReason: result?.meta?.stopReason,
-        livenessState: result?.meta?.livenessState,
-        timeoutPhase: timeoutAttribution.timeoutPhase,
-        providerStarted: timeoutAttribution.providerStarted,
-      });
       const persistTerminalDedupe = () => {
         setGatewayDedupeEntries({
           dedupe: params.context.dedupe,
@@ -227,9 +207,12 @@ export function dispatchAgentRunFromGateway(params: {
       const stopReason = aborted
         ? resolveGatewayAgentAbortStopReason(params.abortController.signal)
         : undefined;
-      const timeoutPhase = stopReason
-        ? resolveGatewayAgentAbortTimeoutPhase(stopReason)
-        : undefined;
+      const terminalOutcome = buildAgentRunTerminalOutcome({
+        status: aborted ? "timeout" : "error",
+        error: renderedErr,
+        stopReason,
+        timeoutPhase: stopReason === "restart" ? "gateway_draining" : undefined,
+      });
       if (taskTracked) {
         tryFinalizeTrackedAgentTask({
           runId: params.runId,
@@ -242,17 +225,18 @@ export function dispatchAgentRunFromGateway(params: {
         });
       }
       const error = errorShape(ErrorCodes.UNAVAILABLE, renderedErr);
-      const terminalOutcome = buildAgentRunTerminalOutcome({
-        status: aborted ? "timeout" : "error",
-        error: renderedErr,
-        stopReason,
-        timeoutPhase,
-      });
       const payload = {
         runId: params.runId,
         status: aborted ? ("timeout" as const) : ("error" as const),
         summary: aborted ? "aborted" : renderedErr,
-        ...(aborted ? { stopReason, ...(timeoutPhase ? { timeoutPhase } : {}) } : {}),
+        ...(aborted
+          ? {
+              stopReason,
+              ...(terminalOutcome.timeoutPhase
+                ? { timeoutPhase: terminalOutcome.timeoutPhase }
+                : {}),
+            }
+          : {}),
       };
       const persistTerminalDedupe = (settlementPersisted: boolean) => {
         setGatewayDedupeEntries({

--- a/src/gateway/server-methods/agent.sessions-and-models.test-utils.ts
+++ b/src/gateway/server-methods/agent.sessions-and-models.test-utils.ts
@@ -692,6 +692,109 @@ describe("gateway agent handler", () => {
     });
   });
 
+  it.each([
+    {
+      label: "completed stop",
+      meta: { stopReason: "stop", providerStarted: true },
+      outcome: { reason: "completed", status: "ok", stopReason: "stop", providerStarted: true },
+      payload: { status: "ok", summary: "completed" },
+    },
+    {
+      label: "completed stop with unknown timeout metadata",
+      meta: {
+        stopReason: "stop",
+        providerStarted: true,
+        timeoutPhase: "unrecognized_timeout_phase",
+      },
+      outcome: { reason: "completed", status: "ok", stopReason: "stop", providerStarted: true },
+      payload: { status: "ok", summary: "completed" },
+    },
+    {
+      label: "external cancellation",
+      meta: {
+        aborted: true,
+        stopReason: "rpc",
+        timeoutPhase: "queue",
+        providerStarted: false,
+      },
+      outcome: {
+        reason: "cancelled",
+        status: "error",
+        stopReason: "rpc",
+        timeoutPhase: "queue",
+        providerStarted: false,
+      },
+      payload: {
+        status: "timeout",
+        summary: "aborted",
+        stopReason: "rpc",
+        timeoutPhase: "queue",
+        providerStarted: false,
+      },
+    },
+    {
+      label: "provider timeout",
+      meta: {
+        aborted: true,
+        stopReason: "timeout",
+        timeoutPhase: "provider",
+        providerStarted: true,
+      },
+      outcome: {
+        reason: "hard_timeout",
+        status: "timeout",
+        stopReason: "timeout",
+        timeoutPhase: "provider",
+        providerStarted: true,
+      },
+      payload: {
+        status: "timeout",
+        summary: "aborted",
+        stopReason: "timeout",
+        timeoutPhase: "provider",
+        providerStarted: true,
+      },
+    },
+  ])("settles $label from the canonical outcome without changing Gateway status", async (test) => {
+    mocks.agentCommand.mockResolvedValueOnce({
+      payloads: [],
+      meta: { durationMs: 1, ...test.meta },
+    });
+    const context = makeContext();
+    const onSettled = vi.fn(() => true);
+    const respond = vi.fn();
+    const runId = `agent-run-terminal-${test.label.replaceAll(" ", "-")}`;
+
+    dispatchAgentRunFromGateway({
+      ingressOpts: {
+        message: "characterize terminal ownership",
+        sessionKey: "agent:main:main",
+        allowModelOverride: false,
+      },
+      runId,
+      dedupeKeys: [`agent:${runId}`],
+      abortController: new AbortController(),
+      cleanupAbortController: vi.fn(),
+      respond,
+      context,
+      taskTrackingMode: "none",
+      onSettled,
+    });
+
+    await waitForAssertion(() => {
+      expect(onSettled).toHaveBeenCalledWith({
+        terminalOutcome: test.outcome,
+        onRecovered: expect.any(Function),
+      });
+      expect(respond).toHaveBeenCalledWith(
+        true,
+        expect.objectContaining({ runId, ...test.payload }),
+        undefined,
+        { runId },
+      );
+    });
+  });
+
   it("settles ordinary async gateway agent rejections as failed", async () => {
     const providerError = new Error("provider request failed");
     mocks.agentCommand.mockRejectedValueOnce(providerError);


### PR DESCRIPTION
## What Problem This Solves

Agent runs can have their terminal reason and fallback decision flattened and reconstructed as they cross the embedded runner and Gateway. That makes explicit cancellation, actual provider timeout, run-budget exhaustion, compaction/tool observation timeouts, and a previously completed run easier to misclassify.

## Why This Change Was Made

Carry the existing closed, typed agent terminal outcome and already-computed retry decision through one bounded embedded assistant failure/failover path. Have Gateway dispatch construct one canonical outcome, normalize timeout metadata once, and project that same outcome into the existing task settlement and Gateway response. Preserve harness-owned transport decisions when assistant profile rotation exhausts.

The four production files have a net reduction of 29 lines. This is an internal ownership refactor: no new framework, provider route, configuration or environment surface, compatibility shim, schema or protocol version, CLI/SDK contract, or public wire status.

## User Impact

Successful agent runs still complete with `agent.wait` status `ok`; an operator-cancelled run still reports the existing `error` status and `rpc` stop reason; real provider timeouts retain their existing timeout attribution. Completed outcomes remain sticky. Compaction/tool observation timeouts and run-budget timeouts retain their respective existing retry behavior. Invalid timeout-phase metadata cannot turn a completed response into a timeout.

## Evidence

- Final exact-patch focused proof: **479 passed, 11 test files, 3 Vitest projects**, using the dedicated Blacksmith Testbox `tbx_01kyjytbap0d5z3emv9axecnks` (`coral-crab-b98c`):
  `node scripts/crabbox-wrapper.mjs run --provider blacksmith-testbox --id tbx_01kyjytbap0d5z3emv9axecnks --timing-json -- OPENCLAW_TESTBOX=1 OPENCLAW_TESTBOX_REMOTE_RUN=1 pnpm test src/agents/agent-run-terminal-outcome.test.ts src/agents/run-wait.test.ts src/agents/harness/lifecycle.test.ts src/agents/embedded-agent-runner/run/terminal-outcome.test.ts src/agents/embedded-agent-runner/run/failover-policy.test.ts src/agents/embedded-agent-runner/run/assistant-failover.test.ts src/agents/embedded-agent-runner/run-entry.test.ts src/agents/embedded-agent-runner/result-fallback-classifier.test.ts src/gateway/server-methods/agent.test.ts src/gateway/server-methods/agent-wait-dedupe.test.ts src/gateway/server-methods/agent-job.timeout-fallback.test.ts`.
- Full reviewed changed gate: `node scripts/crabbox-wrapper.mjs run --provider blacksmith-testbox --id tbx_01kyjytbap0d5z3emv9axecnks --timing-json -- CI=1 NODE_OPTIONS=--max-old-space-size=4096 OPENCLAW_TEST_PROJECTS_PARALLEL=6 OPENCLAW_VITEST_MAX_WORKERS=1 OPENCLAW_TESTBOX=1 OPENCLAW_TESTBOX_REMOTE_RUN=1 pnpm check:changed` — **PASS**, including both core and test typechecking, changed-file lint, formatting, dependency and plugin boundaries, storage/schema guards, and runtime import-cycle checks.
- Real isolated development Gateway live proof on private loopback port **42889**, fresh task-only state/config and the repository mock OpenAI provider: `/healthz` **HTTP 200 live**; `/readyz` **HTTP 200 ready**; real `agent` request accepted; `agent.wait` **status=ok**; expected assistant response confirmed through `chat.history`. A second real provider request was confirmed in flight before production `chat.abort`; subsequent `agent.wait` returned the unchanged **status=error, stopReason=rpc**. The mock provider observed exactly two real Responses requests. Owned Gateway, mock, and temporary state were cleaned up; no real provider secret, operator Gateway, or operator state was used.
- `.agents/skills/autoreview/scripts/autoreview --mode uncommitted` — **clean**, no accepted or actionable findings.
- `git diff --check origin/main...HEAD` — **PASS**.
- Dedicated Testbox stopped cleanly after proof.
- AI-assisted implementation; all generated changes were reviewed and validated.

This PR is ready for **coordinated landing only**; do not merge until the coordinator explicitly authorizes this task.