### PR TITLE
feat(browser): return inline page state after navigation

### DIFF
--- a/docs/tools/browser.md
+++ b/docs/tools/browser.md
@@ -922,6 +922,11 @@ The agent gets **one tool** for browser automation:
 How it maps:
 
 - `browser snapshot` returns a stable UI tree (AI or ARIA).
+- `browser navigate` also returns the loaded page's snapshot inline (efficient
+  interactive tier, so the payload stays compact and bounded), so the agent
+  does not need a follow-up snapshot call. Batch `act` results that report a
+  cross-document navigation include the same fresh page state. Navigations
+  that resolve to a download skip it.
 - `browser act` uses the snapshot `ref` IDs to click/type/drag/select.
 - `browser screenshot` captures pixels (full page, element, or labeled refs).
 - `browser doctor` checks Gateway, plugin, profile, browser, and tab readiness.

--- a/extensions/browser/skills/browser-automation/SKILL.md
+++ b/extensions/browser/skills/browser-automation/SKILL.md
@@ -34,7 +34,8 @@ Use this skill when you need the `browser` tool for anything beyond a single pag
    - Use `labels=true` on snapshot or screenshot when visual position matters. On Playwright-backed profiles, the response includes an `annotations` array (`{ref, number, role, name?, box}`) with each ref's bounding box in the captured image's coordinate space, so you can reason about position without re-snapshotting; screenshot labels can also combine with `fullPage=true` (CLI: `--full-page`) to label the whole document, or `ref` / `element` to clip to one element. `profile="user"` and other existing-session (chrome-mcp) profiles render an overlay into page screenshots but do not attach `annotations` or use the Playwright full-page/ref/element projection helper, so read positions from the labeled image itself on those profiles. The raw-CDP fallback (no Playwright) does not support labeled screenshots at all and returns a 501, so only request `labels` when Playwright is available.
 4. Act narrowly:
    - Prefer `action="act"` with a ref from the latest snapshot.
-   - After navigation, modal changes, or form submission, snapshot again before the next action.
+   - `navigate` returns the loaded page's compact snapshot inline, and batch `act` results that report a cross-document navigation include fresh page state; use those refs directly instead of a follow-up snapshot call.
+   - After a single act that triggers navigation, and after modal changes or form submissions, snapshot again before the next action.
    - Avoid blind waits. Wait for visible UI state when possible.
 5. Report real blockers:
    - If the page needs login, permission, captcha, 2FA, camera/microphone approval, or another manual step, stop and tell the user exactly what is needed.

--- a/extensions/browser/src/browser-extract.ts
+++ b/extensions/browser/src/browser-extract.ts
@@ -10,6 +10,7 @@ import {
   readStringValue,
   wrapExternalContent,
 } from "./browser-tool.runtime.js";
+import type { BrowserProxyRequest } from "./browser-tool.snapshot.js";
 import {
   BROWSER_EXTRACT_MAX_CHARS,
   BROWSER_EXTRACT_TRUNCATION_MARKER,
@@ -48,15 +49,6 @@ type BrowserExtractCompletionDeps = {
 type BrowserExtractDeps = BrowserExtractCompletionDeps & {
   browserPageContent: typeof browserPageContent;
 };
-
-type BrowserProxyRequest = (opts: {
-  method: string;
-  path: string;
-  body?: unknown;
-  timeoutMs?: number;
-  profile?: string;
-  signal?: AbortSignal;
-}) => Promise<unknown>;
 
 export function resolveBrowserExtractTimeoutMs(input: Record<string, unknown>): number {
   const requested = readPositiveIntegerParam(input, "timeoutMs", {

--- a/extensions/browser/src/browser-tool-description.ts
+++ b/extensions/browser/src/browser-tool-description.ts
@@ -14,6 +14,7 @@ export function describeBrowserTool(opts: {
     "For multi-step browser work, login checks, stale refs, duplicate tabs, or Google Meet flows, use the bundled browser-automation skill when it is available.",
     'For stable, self-resolving refs across calls, use snapshot with refs="aria" (Playwright aria-ref ids). Default refs="role" are role+name-based.',
     "Repeated compatible snapshots with stable document identity mark newly appeared ref-bearing elements with [new].",
+    "navigate returns the loaded page's compact snapshot inline (efficient interactive tier; use action=snapshot for a full snapshot); do not call snapshot after navigate. Batch act results that report a cross-document navigation also include fresh page state; after a single act that triggers navigation, snapshot before using refs.",
     "Use snapshot+act for UI automation. Avoid act:wait by default; use only in exceptional cases when no reliable UI state exists.",
     "To read or answer questions from page text, prefer action=extract with query (optionally selector, ignoreSelectors, or schema) over snapshot: it answers in one call without loading page content into context.",
     "For file chooser uploads, pass the trigger ref with paths in the same upload call when available; use paths-only arming only when a later trigger is intentional. Use inputRef or element to set a file input directly.",

--- a/extensions/browser/src/browser-tool.actions.ts
+++ b/extensions/browser/src/browser-tool.actions.ts
@@ -10,42 +10,42 @@ import {
   readPositiveIntegerParam,
 } from "openclaw/plugin-sdk/param-readers";
 import {
-  DEFAULT_AI_SNAPSHOT_MAX_CHARS,
   browserAct,
   browserConsoleMessages,
   browserDownload,
-  browserSnapshot,
   browserTabs,
   browserWaitForDownload,
   getBrowserProfileCapabilities,
   getRuntimeConfig,
-  imageResultFromFile,
   jsonResult,
   normalizeOptionalString,
   readStringParam,
   readStringValue,
   resolveBrowserConfig,
   resolveProfile,
-  resolveRuntimeImageSanitization,
-  wrapExternalContent,
 } from "./browser-tool.runtime.js";
+import {
+  appendNavigatedPageState,
+  wrapBrowserExternalJson,
+  type BrowserProxyRequest,
+} from "./browser-tool.snapshot.js";
 import { resolveBrowserActRequestTimeoutMs } from "./browser/act-policy.js";
+import type {
+  BrowserBatchAbort,
+  BrowserBatchActionResult,
+} from "./browser/client-actions-types.js";
 import {
   DEFAULT_BROWSER_ACTION_TIMEOUT_MS,
   DEFAULT_BROWSER_DOWNLOAD_TIMEOUT_MS,
-  DEFAULT_BROWSER_SNAPSHOT_TIMEOUT_MS,
 } from "./browser/constants.js";
-import { neutralizeMediaDirectives } from "./browser/vision.js";
 
 const browserToolActionDeps = {
   browserAct,
   browserConsoleMessages,
   browserDownload,
-  browserSnapshot,
   browserTabs,
   browserWaitForDownload,
   getRuntimeConfig,
-  imageResultFromFile,
 };
 
 const BROWSER_DOWNLOAD_REQUEST_TIMEOUT_SLACK_MS = 5_000;
@@ -128,15 +128,6 @@ function resolveActProxyTimeoutMs(request: BrowserActRequest): number | undefine
   return resolveBrowserActRequestTimeoutMs(request);
 }
 
-type BrowserProxyRequest = (opts: {
-  method: string;
-  path: string;
-  query?: Record<string, string | number | boolean | undefined>;
-  body?: unknown;
-  timeoutMs?: number;
-  profile?: string;
-}) => Promise<unknown>;
-
 type BrowserTabLike = {
   suggestedTargetId?: unknown;
   tabId?: unknown;
@@ -166,37 +157,6 @@ function formatAgentTab(tab: unknown): Record<string, unknown> {
     type: source.type,
     ...(targetId ? { targetId } : {}),
     ...(source.wsUrl ? { wsUrl: source.wsUrl } : {}),
-  };
-}
-
-function wrapBrowserExternalJson(params: {
-  kind: "snapshot" | "console" | "tabs";
-  payload: unknown;
-  includeWarning?: boolean;
-}): { wrappedText: string; safeDetails: Record<string, unknown> } {
-  const extractedText = JSON.stringify(
-    params.payload,
-    (_key: string, value: unknown) =>
-      typeof value === "string" ? neutralizeMediaDirectives(value) : value,
-    2,
-  );
-  // Browser tabs, snapshots, and console output are page-controlled data. Keep
-  // text wrapped even when details carry the structured fields for callers.
-  const wrappedText = wrapExternalContent(extractedText, {
-    source: "browser",
-    includeWarning: params.includeWarning ?? true,
-  });
-  return {
-    wrappedText,
-    safeDetails: {
-      ok: true,
-      externalContent: {
-        untrusted: true,
-        source: "browser",
-        kind: params.kind,
-        wrapped: true,
-      },
-    },
   };
 }
 
@@ -285,20 +245,6 @@ function canRetryChromeActAfterSoleTargetRefresh(request: BrowserActRequest): bo
   ].every((value) => !normalizeOptionalString(value));
 }
 
-function isAriaRefsUnsupportedError(err: unknown): boolean {
-  const msg = String(err).toLowerCase();
-  return msg.includes("refs=aria") && msg.includes("not support");
-}
-
-function withRoleRefsFallback<T extends { refs?: "aria" | "role" }>(
-  snapshotQuery: T,
-): T & { refs: "role" } {
-  return {
-    ...snapshotQuery,
-    refs: "role",
-  };
-}
-
 export async function executeTabsAction(params: {
   baseUrl?: string;
   profile?: string;
@@ -327,197 +273,41 @@ export async function executeTabsAction(params: {
   return formatTabsToolResult(tabs);
 }
 
-/** Execute and format browser snapshots for agent consumption. */
-export async function executeSnapshotAction(params: {
-  input: Record<string, unknown>;
-  baseUrl?: string;
-  profile?: string;
-  proxyRequest: BrowserProxyRequest | null;
-  onTabActivity?: (targetId: string | undefined) => void;
-}): Promise<AgentToolResult<unknown>> {
-  const { input, baseUrl, profile, proxyRequest } = params;
-  const snapshotDefaults = browserToolActionDeps.getRuntimeConfig().browser?.snapshotDefaults;
-  const format: "ai" | "aria" | undefined =
-    input.snapshotFormat === "ai" ? "ai" : input.snapshotFormat === "aria" ? "aria" : undefined;
-  const formatExplicit = format !== undefined;
-  const mode: "efficient" | undefined =
-    input.mode === "efficient"
-      ? "efficient"
-      : !formatExplicit && format !== "aria" && snapshotDefaults?.mode === "efficient"
-        ? "efficient"
-        : undefined;
-  const labels = typeof input.labels === "boolean" ? input.labels : undefined;
-  const urls = typeof input.urls === "boolean" ? input.urls : undefined;
-  const refs: "aria" | "role" | undefined =
-    input.refs === "aria" || input.refs === "role" ? input.refs : undefined;
-  const hasMaxChars = Object.hasOwn(input, "maxChars");
-  const targetId = normalizeOptionalString(input.targetId);
-  const limit = readPositiveIntegerParam(input, "limit", {
-    message: "limit must be a positive integer.",
-  });
-  const maxCharsRaw = readNonNegativeIntegerParam(input, "maxChars", {
-    message: "maxChars must be a non-negative integer.",
-  });
-  const maxChars = maxCharsRaw !== undefined && maxCharsRaw > 0 ? maxCharsRaw : undefined;
-  const interactive = typeof input.interactive === "boolean" ? input.interactive : undefined;
-  const compact = typeof input.compact === "boolean" ? input.compact : undefined;
-  const depth = readNonNegativeIntegerParam(input, "depth", {
-    message: "depth must be a non-negative integer.",
-  });
-  const selector = normalizeOptionalString(input.selector);
-  const frame = normalizeOptionalString(input.frame);
-  const resolvedMaxChars =
-    format === "ai"
-      ? hasMaxChars
-        ? maxChars
-        : mode === "efficient"
-          ? undefined
-          : DEFAULT_AI_SNAPSHOT_MAX_CHARS
-      : hasMaxChars
-        ? maxChars
-        : undefined;
-  // AI snapshots have a compact default cap; ARIA snapshots keep full structure
-  // unless maxChars is explicit, because agents often need complete node refs.
-  const snapshotTimeoutMs =
-    readPositiveIntegerParam(input, "timeoutMs", {
-      message: "timeoutMs must be a positive integer.",
-    }) ?? DEFAULT_BROWSER_SNAPSHOT_TIMEOUT_MS;
-  const snapshotQuery = {
-    ...(format ? { format } : {}),
-    targetId,
-    limit,
-    ...(typeof resolvedMaxChars === "number" ? { maxChars: resolvedMaxChars } : {}),
-    refs,
-    interactive,
-    compact,
-    depth,
-    selector,
-    frame,
-    labels,
-    urls,
-    mode,
-    timeoutMs: snapshotTimeoutMs,
-  };
-  let refsFallback: "role" | undefined;
-  const readSnapshot = async (query: typeof snapshotQuery) =>
-    proxyRequest
-      ? ((await proxyRequest({
-          method: "GET",
-          path: "/snapshot",
-          profile,
-          query,
-          timeoutMs: snapshotTimeoutMs,
-        })) as Awaited<ReturnType<typeof browserSnapshot>>)
-      : await browserToolActionDeps.browserSnapshot(baseUrl, {
-          ...query,
-          profile,
-        });
-  let snapshot: Awaited<ReturnType<typeof browserSnapshot>>;
-  try {
-    snapshot = await readSnapshot(snapshotQuery);
-  } catch (err) {
-    if (refs !== "aria" || !isAriaRefsUnsupportedError(err)) {
-      throw err;
-    }
-    refsFallback = "role";
-    snapshot = await readSnapshot(withRoleRefsFallback(snapshotQuery));
+/** Validate the /act wire payload's abort summary once for note and page-state decisions. */
+function readBrowserBatchAbort(result: unknown): BrowserBatchAbort | null {
+  if (!result || typeof result !== "object") {
+    return null;
   }
-  params.onTabActivity?.(readStringValue(snapshot.targetId) ?? targetId);
-  if (snapshot.format === "ai") {
-    const dialogStateFields = {
-      ...(snapshot.blockedByDialog ? { blockedByDialog: true } : {}),
-      ...(snapshot.browserState !== undefined ? { browserState: snapshot.browserState } : {}),
-    };
-    if (snapshot.blockedByDialog) {
-      const wrapped = wrapBrowserExternalJson({
-        kind: "snapshot",
-        payload: {
-          format: snapshot.format,
-          targetId: snapshot.targetId,
-          url: snapshot.url,
-          ...dialogStateFields,
-        },
-      });
-      return {
-        content: [{ type: "text" as const, text: wrapped.wrappedText }],
-        details: {
-          ...wrapped.safeDetails,
-          format: snapshot.format,
-          targetId: snapshot.targetId,
-          url: snapshot.url,
-          ...dialogStateFields,
-        },
-      };
-    }
-    const extractedText = snapshot.snapshot ?? "";
-    const wrappedSnapshot = wrapExternalContent(neutralizeMediaDirectives(extractedText), {
-      source: "browser",
-      includeWarning: true,
-    });
-    const safeDetails = {
-      ok: true,
-      format: snapshot.format,
-      targetId: snapshot.targetId,
-      url: snapshot.url,
-      truncated: snapshot.truncated,
-      newElements: snapshot.newElements,
-      stats: snapshot.stats,
-      refs: snapshot.refs ? Object.keys(snapshot.refs).length : undefined,
-      labels: snapshot.labels,
-      labelsCount: snapshot.labelsCount,
-      labelsSkipped: snapshot.labelsSkipped,
-      annotations: snapshot.annotations,
-      imagePath: snapshot.imagePath,
-      imageType: snapshot.imageType,
-      refsFallback,
-      ...dialogStateFields,
-      externalContent: {
-        untrusted: true,
-        source: "browser",
-        kind: "snapshot",
-        format: "ai",
-        wrapped: true,
-      },
-    };
-    if (labels && snapshot.imagePath) {
-      return await browserToolActionDeps.imageResultFromFile({
-        label: "browser:snapshot",
-        path: snapshot.imagePath,
-        extraText: wrappedSnapshot,
-        details: safeDetails,
-        imageSanitization: resolveRuntimeImageSanitization(),
-      });
-    }
-    return {
-      content: [{ type: "text" as const, text: wrappedSnapshot }],
-      details: safeDetails,
-    };
+  const aborted = (result as { aborted?: unknown }).aborted;
+  if (!aborted || typeof aborted !== "object") {
+    return null;
   }
-  {
-    const wrapped = wrapBrowserExternalJson({
-      kind: "snapshot",
-      payload: snapshot,
-    });
-    return {
-      content: [{ type: "text" as const, text: wrapped.wrappedText }],
-      details: {
-        ...wrapped.safeDetails,
-        format: "aria",
-        targetId: snapshot.targetId,
-        url: snapshot.url,
-        nodeCount: snapshot.nodes.length,
-        ...(snapshot.blockedByDialog ? { blockedByDialog: true } : {}),
-        ...(snapshot.browserState !== undefined ? { browserState: snapshot.browserState } : {}),
-        externalContent: {
-          untrusted: true,
-          source: "browser",
-          kind: "snapshot",
-          format: "aria",
-          wrapped: true,
-        },
-      },
-    };
+  const { reason, afterAction, url, skipped } = aborted as Partial<
+    Record<keyof BrowserBatchAbort, unknown>
+  >;
+  if (
+    (reason !== "navigation" && reason !== "closed") ||
+    typeof afterAction !== "number" ||
+    typeof url !== "string" ||
+    typeof skipped !== "number"
+  ) {
+    return null;
   }
+  return { reason, afterAction, url, skipped };
+}
+
+/** True when an /act response reports a cross-document navigation. */
+function actObservedNavigation(result: unknown, aborted: BrowserBatchAbort | null): boolean {
+  if (aborted?.reason === "navigation") {
+    return true;
+  }
+  const results = (result as { results?: unknown } | null | undefined)?.results;
+  return (
+    Array.isArray(results) &&
+    results.some(
+      (entry) => (entry as Partial<BrowserBatchActionResult> | undefined)?.navigated === true,
+    )
+  );
 }
 
 /** Execute browser console retrieval and wrap page-controlled messages. */
@@ -632,6 +422,25 @@ export async function executeActAction(params: {
 }): Promise<AgentToolResult<unknown>> {
   const { request, baseUrl, profile, proxyRequest } = params;
   const effectiveRequest = withConfiguredActTimeout(request, profile);
+  // resolvedTargetId is the id the act actually ran against (retry paths swap
+  // it), so page-state capture must use it rather than the original request's.
+  const finishActResult = async (result: unknown, resolvedTargetId: string | undefined) => {
+    params.onTabActivity?.(resolvedTargetId);
+    const aborted = readBrowserBatchAbort(result);
+    const formatted = formatActToolResult(result, aborted);
+    if (!actObservedNavigation(result, aborted)) {
+      return formatted;
+    }
+    // Batch aborts snapshot at navigation commit, so a slow page can still be
+    // loading; the model may need one follow-up snapshot for late content.
+    return await appendNavigatedPageState({
+      result: formatted,
+      targetId: resolvedTargetId,
+      baseUrl,
+      profile,
+      proxyRequest,
+    });
+  };
   try {
     const result = proxyRequest
       ? await proxyRequest({
@@ -644,11 +453,11 @@ export async function executeActAction(params: {
       : await browserToolActionDeps.browserAct(baseUrl, effectiveRequest, {
           profile,
         });
-    params.onTabActivity?.(
+    return await finishActResult(
+      result,
       readStringValue((result as { targetId?: unknown }).targetId) ??
         readStringValue(effectiveRequest.targetId),
     );
-    return formatActToolResult(result);
   } catch (err) {
     if (isChromeStaleTargetError(profile, err)) {
       const tabs = proxyRequest
@@ -686,11 +495,11 @@ export async function executeActAction(params: {
           : await browserToolActionDeps.browserAct(baseUrl, retryRequest, {
               profile,
             });
-        params.onTabActivity?.(
+        return await finishActResult(
+          retryResult,
           readStringValue((retryResult as { targetId?: unknown }).targetId) ??
             readStringValue(retryRequest.targetId),
         );
-        return formatActToolResult(retryResult);
       }
       if (!tabs.length) {
         throw new Error(
@@ -707,34 +516,20 @@ export async function executeActAction(params: {
   }
 }
 
-function formatActToolResult(result: unknown): AgentToolResult<unknown> {
+function formatActToolResult(
+  result: unknown,
+  aborted: BrowserBatchAbort | null,
+): AgentToolResult<unknown> {
   const formatted = jsonResult(result);
-  if (!result || typeof result !== "object") {
+  if (!aborted) {
     return formatted;
   }
-  const aborted = (result as { aborted?: unknown }).aborted;
-  if (!aborted || typeof aborted !== "object") {
-    return formatted;
-  }
-  const summary = aborted as {
-    reason?: unknown;
-    afterAction?: unknown;
-    url?: unknown;
-    skipped?: unknown;
-  };
-  if (
-    (summary.reason !== "navigation" && summary.reason !== "closed") ||
-    typeof summary.afterAction !== "number" ||
-    typeof summary.url !== "string" ||
-    typeof summary.skipped !== "number"
-  ) {
-    return formatted;
-  }
-  const reason =
-    summary.reason === "navigation"
-      ? `the page navigated to ${summary.url}`
-      : "the page or browser context closed";
-  const note = `Batch aborted after action ${summary.afterAction} because ${reason}; ${summary.skipped} remaining action(s) skipped. Take a new snapshot before continuing.`;
+  // Navigation aborts get fresh page state (or an unavailable hint) appended by
+  // finishActResult, so only the closed case tells the model to snapshot manually.
+  const note =
+    aborted.reason === "navigation"
+      ? `Batch aborted after action ${aborted.afterAction} because the page navigated to ${aborted.url}; ${aborted.skipped} remaining action(s) skipped. Earlier refs are stale.`
+      : `Batch aborted after action ${aborted.afterAction} because the page or browser context closed; ${aborted.skipped} remaining action(s) skipped. Take a new snapshot before continuing.`;
   return {
     ...formatted,
     content: [...formatted.content, { type: "text", text: note }],

--- a/extensions/browser/src/browser-tool.schema.ts
+++ b/extensions/browser/src/browser-tool.schema.ts
@@ -248,6 +248,16 @@ export const BrowserToolOutputSchema = Type.Object(
       ),
     ),
     aborted: Type.Optional(BrowserBatchAbortSchema),
+    pageState: Type.Optional(
+      Type.Object(
+        {},
+        {
+          additionalProperties: true,
+          description:
+            "Inline snapshot details attached when the action changed the page document.",
+        },
+      ),
+    ),
     enabled: Type.Optional(Type.Boolean()),
     running: Type.Optional(Type.Boolean()),
     profile: Type.Optional(Type.String()),

--- a/extensions/browser/src/browser-tool.snapshot.ts
+++ b/extensions/browser/src/browser-tool.snapshot.ts
@@ -1,0 +1,346 @@
+/**
+ * Browser agent tool snapshot execution and inline page-state feedback.
+ *
+ * Owns the model-facing snapshot result shape (untrusted-content wrapping,
+ * caps, dialog states) and attaches fresh page state to actions that changed
+ * the page document so the model does not need a follow-up snapshot call.
+ */
+import type { AgentToolResult } from "openclaw/plugin-sdk/agent-core";
+import {
+  readNonNegativeIntegerParam,
+  readPositiveIntegerParam,
+} from "openclaw/plugin-sdk/param-readers";
+import {
+  DEFAULT_AI_SNAPSHOT_MAX_CHARS,
+  browserSnapshot,
+  getRuntimeConfig,
+  imageResultFromFile,
+  normalizeOptionalString,
+  readStringValue,
+  resolveRuntimeImageSanitization,
+  wrapExternalContent,
+} from "./browser-tool.runtime.js";
+import { DEFAULT_BROWSER_SNAPSHOT_TIMEOUT_MS } from "./browser/constants.js";
+import { neutralizeMediaDirectives } from "./browser/vision.js";
+import { formatErrorMessage } from "./infra/errors.js";
+
+export type BrowserProxyRequest = ((opts: {
+  method: string;
+  path: string;
+  query?: Record<string, string | number | boolean | undefined>;
+  body?: unknown;
+  timeoutMs?: number;
+  profile?: string;
+  signal?: AbortSignal;
+}) => Promise<unknown>) & {
+  // Present on node-proxy requests: reports whether the proxy silently fell
+  // back to the Gateway host browser after the node became unreachable.
+  isHostFallbackActive?: () => boolean;
+};
+
+/** Wrap page-controlled JSON payloads as untrusted browser content. */
+export function wrapBrowserExternalJson(params: {
+  kind: "snapshot" | "console" | "tabs";
+  payload: unknown;
+  includeWarning?: boolean;
+}): { wrappedText: string; safeDetails: Record<string, unknown> } {
+  const extractedText = JSON.stringify(
+    params.payload,
+    (_key: string, value: unknown) =>
+      typeof value === "string" ? neutralizeMediaDirectives(value) : value,
+    2,
+  );
+  // Browser tabs, snapshots, and console output are page-controlled data. Keep
+  // text wrapped even when details carry the structured fields for callers.
+  const wrappedText = wrapExternalContent(extractedText, {
+    source: "browser",
+    includeWarning: params.includeWarning ?? true,
+  });
+  return {
+    wrappedText,
+    safeDetails: {
+      ok: true,
+      externalContent: {
+        untrusted: true,
+        source: "browser",
+        kind: params.kind,
+        wrapped: true,
+      },
+    },
+  };
+}
+
+function isAriaRefsUnsupportedError(err: unknown): boolean {
+  const msg = String(err).toLowerCase();
+  return msg.includes("refs=aria") && msg.includes("not support");
+}
+
+function withRoleRefsFallback<T extends { refs?: "aria" | "role" }>(
+  snapshotQuery: T,
+): T & { refs: "role" } {
+  return {
+    ...snapshotQuery,
+    refs: "role",
+  };
+}
+
+/** Execute and format browser snapshots for agent consumption. */
+export async function executeSnapshotAction(params: {
+  input: Record<string, unknown>;
+  baseUrl?: string;
+  profile?: string;
+  proxyRequest: BrowserProxyRequest | null;
+  onTabActivity?: (targetId: string | undefined) => void;
+}): Promise<AgentToolResult<unknown>> {
+  const { input, baseUrl, profile, proxyRequest } = params;
+  const snapshotDefaults = getRuntimeConfig().browser?.snapshotDefaults;
+  const format: "ai" | "aria" | undefined =
+    input.snapshotFormat === "ai" ? "ai" : input.snapshotFormat === "aria" ? "aria" : undefined;
+  const formatExplicit = format !== undefined;
+  const mode: "efficient" | undefined =
+    input.mode === "efficient"
+      ? "efficient"
+      : !formatExplicit && format !== "aria" && snapshotDefaults?.mode === "efficient"
+        ? "efficient"
+        : undefined;
+  const labels = typeof input.labels === "boolean" ? input.labels : undefined;
+  const urls = typeof input.urls === "boolean" ? input.urls : undefined;
+  const refs: "aria" | "role" | undefined =
+    input.refs === "aria" || input.refs === "role" ? input.refs : undefined;
+  const hasMaxChars = Object.hasOwn(input, "maxChars");
+  const targetId = normalizeOptionalString(input.targetId);
+  const limit = readPositiveIntegerParam(input, "limit", {
+    message: "limit must be a positive integer.",
+  });
+  const maxCharsRaw = readNonNegativeIntegerParam(input, "maxChars", {
+    message: "maxChars must be a non-negative integer.",
+  });
+  const maxChars = maxCharsRaw !== undefined && maxCharsRaw > 0 ? maxCharsRaw : undefined;
+  const interactive = typeof input.interactive === "boolean" ? input.interactive : undefined;
+  const compact = typeof input.compact === "boolean" ? input.compact : undefined;
+  const depth = readNonNegativeIntegerParam(input, "depth", {
+    message: "depth must be a non-negative integer.",
+  });
+  const selector = normalizeOptionalString(input.selector);
+  const frame = normalizeOptionalString(input.frame);
+  const resolvedMaxChars =
+    format === "ai"
+      ? hasMaxChars
+        ? maxChars
+        : mode === "efficient"
+          ? undefined
+          : DEFAULT_AI_SNAPSHOT_MAX_CHARS
+      : hasMaxChars
+        ? maxChars
+        : undefined;
+  // AI snapshots have a compact default cap; ARIA snapshots keep full structure
+  // unless maxChars is explicit, because agents often need complete node refs.
+  const snapshotTimeoutMs =
+    readPositiveIntegerParam(input, "timeoutMs", {
+      message: "timeoutMs must be a positive integer.",
+    }) ?? DEFAULT_BROWSER_SNAPSHOT_TIMEOUT_MS;
+  const snapshotQuery = {
+    ...(format ? { format } : {}),
+    targetId,
+    limit,
+    ...(typeof resolvedMaxChars === "number" ? { maxChars: resolvedMaxChars } : {}),
+    refs,
+    interactive,
+    compact,
+    depth,
+    selector,
+    frame,
+    labels,
+    urls,
+    mode,
+    timeoutMs: snapshotTimeoutMs,
+  };
+  let refsFallback: "role" | undefined;
+  const readSnapshot = async (query: typeof snapshotQuery) =>
+    proxyRequest
+      ? ((await proxyRequest({
+          method: "GET",
+          path: "/snapshot",
+          profile,
+          query,
+          timeoutMs: snapshotTimeoutMs,
+        })) as Awaited<ReturnType<typeof browserSnapshot>>)
+      : await browserSnapshot(baseUrl, {
+          ...query,
+          profile,
+        });
+  let snapshot: Awaited<ReturnType<typeof browserSnapshot>>;
+  try {
+    snapshot = await readSnapshot(snapshotQuery);
+  } catch (err) {
+    if (refs !== "aria" || !isAriaRefsUnsupportedError(err)) {
+      throw err;
+    }
+    refsFallback = "role";
+    snapshot = await readSnapshot(withRoleRefsFallback(snapshotQuery));
+  }
+  params.onTabActivity?.(readStringValue(snapshot.targetId) ?? targetId);
+  if (snapshot.format === "ai") {
+    const dialogStateFields = {
+      ...(snapshot.blockedByDialog ? { blockedByDialog: true } : {}),
+      ...(snapshot.browserState !== undefined ? { browserState: snapshot.browserState } : {}),
+    };
+    if (snapshot.blockedByDialog) {
+      const wrapped = wrapBrowserExternalJson({
+        kind: "snapshot",
+        payload: {
+          format: snapshot.format,
+          targetId: snapshot.targetId,
+          url: snapshot.url,
+          ...dialogStateFields,
+        },
+      });
+      return {
+        content: [{ type: "text" as const, text: wrapped.wrappedText }],
+        details: {
+          ...wrapped.safeDetails,
+          format: snapshot.format,
+          targetId: snapshot.targetId,
+          url: snapshot.url,
+          ...dialogStateFields,
+        },
+      };
+    }
+    const extractedText = snapshot.snapshot ?? "";
+    const wrappedSnapshot = wrapExternalContent(neutralizeMediaDirectives(extractedText), {
+      source: "browser",
+      includeWarning: true,
+    });
+    const safeDetails = {
+      ok: true,
+      format: snapshot.format,
+      targetId: snapshot.targetId,
+      url: snapshot.url,
+      truncated: snapshot.truncated,
+      newElements: snapshot.newElements,
+      stats: snapshot.stats,
+      refs: snapshot.refs ? Object.keys(snapshot.refs).length : undefined,
+      labels: snapshot.labels,
+      labelsCount: snapshot.labelsCount,
+      labelsSkipped: snapshot.labelsSkipped,
+      annotations: snapshot.annotations,
+      imagePath: snapshot.imagePath,
+      imageType: snapshot.imageType,
+      refsFallback,
+      ...dialogStateFields,
+      externalContent: {
+        untrusted: true,
+        source: "browser",
+        kind: "snapshot",
+        format: "ai",
+        wrapped: true,
+      },
+    };
+    if (labels && snapshot.imagePath) {
+      return await imageResultFromFile({
+        label: "browser:snapshot",
+        path: snapshot.imagePath,
+        extraText: wrappedSnapshot,
+        details: safeDetails,
+        imageSanitization: resolveRuntimeImageSanitization(),
+      });
+    }
+    return {
+      content: [{ type: "text" as const, text: wrappedSnapshot }],
+      details: safeDetails,
+    };
+  }
+  {
+    const wrapped = wrapBrowserExternalJson({
+      kind: "snapshot",
+      payload: snapshot,
+    });
+    return {
+      content: [{ type: "text" as const, text: wrapped.wrappedText }],
+      details: {
+        ...wrapped.safeDetails,
+        format: "aria",
+        targetId: snapshot.targetId,
+        url: snapshot.url,
+        nodeCount: snapshot.nodes.length,
+        ...(snapshot.blockedByDialog ? { blockedByDialog: true } : {}),
+        ...(snapshot.browserState !== undefined ? { browserState: snapshot.browserState } : {}),
+        externalContent: {
+          untrusted: true,
+          source: "browser",
+          kind: "snapshot",
+          format: "aria",
+          wrapped: true,
+        },
+      },
+    };
+  }
+}
+
+function withPageStateUnavailableHint(
+  result: AgentToolResult<unknown>,
+  reason: string,
+): AgentToolResult<unknown> {
+  return {
+    ...result,
+    content: [
+      ...result.content,
+      {
+        type: "text",
+        text: `[page snapshot unavailable: ${reason}. Use action=snapshot to read the page.]`,
+      },
+    ],
+  };
+}
+
+/**
+ * Attach fresh page state to the result of an action that changed the page
+ * document (navigate, act that navigated). The model can act on the new page
+ * without a follow-up snapshot call. The inline state uses the efficient
+ * interactive tier so the unsolicited payload stays bounded on every profile
+ * (mode=efficient forces the capped ai format even where the profile default
+ * would be an uncapped aria tree); a full snapshot stays one explicit call away.
+ */
+export async function appendNavigatedPageState(params: {
+  result: AgentToolResult<unknown>;
+  targetId?: string;
+  baseUrl?: string;
+  profile?: string;
+  proxyRequest: BrowserProxyRequest | null;
+}): Promise<AgentToolResult<unknown>> {
+  const hostFallbackWasActive = params.proxyRequest?.isHostFallbackActive?.() ?? false;
+  let snapshot: AgentToolResult<unknown>;
+  try {
+    snapshot = await executeSnapshotAction({
+      input: { targetId: params.targetId, mode: "efficient" },
+      baseUrl: params.baseUrl,
+      profile: params.profile,
+      proxyRequest: params.proxyRequest,
+    });
+  } catch (err) {
+    // Cancellation must keep aborting the whole tool call; only genuine
+    // snapshot failures degrade, because page state is feedback on an
+    // already-successful mutation and must not fail the action.
+    if (err instanceof Error && err.name === "AbortError") {
+      throw err;
+    }
+    return withPageStateUnavailableHint(
+      params.result,
+      neutralizeMediaDirectives(formatErrorMessage(err)),
+    );
+  }
+  if (!hostFallbackWasActive && params.proxyRequest?.isHostFallbackActive?.()) {
+    // The node became unreachable between the action and this snapshot and the
+    // proxy fell back to the Gateway host browser: that snapshot describes a
+    // different browser, so presenting it as the navigated page misleads the model.
+    return withPageStateUnavailableHint(params.result, "the browser node became unreachable");
+  }
+  const baseDetails =
+    params.result.details && typeof params.result.details === "object"
+      ? (params.result.details as Record<string, unknown>)
+      : {};
+  return {
+    content: [...params.result.content, ...snapshot.content],
+    details: { ...baseDetails, pageState: snapshot.details },
+  };
+}

--- a/extensions/browser/src/browser-tool.test.ts
+++ b/extensions/browser/src/browser-tool.test.ts
@@ -70,7 +70,7 @@ const browserActionsMocks = vi.hoisted(() => ({
       },
     ],
   })),
-  browserNavigate: vi.fn(async () => ({ ok: true })),
+  browserNavigate: vi.fn(async (): Promise<Record<string, unknown>> => ({ ok: true })),
   browserPageContent: vi.fn(async () => ({
     ok: true as const,
     targetId: "t1",
@@ -2427,6 +2427,171 @@ describe("browser tool url alias support", () => {
     expect(request.profile).toBeUndefined();
   });
 
+  it("returns inline page state after navigate", async () => {
+    browserActionsMocks.browserNavigate.mockResolvedValueOnce({
+      ok: true,
+      targetId: "nav-tab",
+      url: "https://example.com/next",
+    });
+    const tool = createBrowserTool();
+
+    const result = await tool.execute?.("call-1", {
+      action: "navigate",
+      url: "https://example.com/next",
+    });
+
+    const snapshotOpts = lastMockCallArg<{ targetId?: string; mode?: string }>(
+      browserClientMocks.browserSnapshot,
+      1,
+    );
+    expect(snapshotOpts.targetId).toBe("nav-tab");
+    expect(snapshotOpts.mode).toBe("efficient");
+    expect(result?.details).toMatchObject({
+      targetId: "nav-tab",
+      pageState: { ok: true, format: "ai" },
+    });
+    expect(result?.content.at(-1)).toMatchObject({
+      type: "text",
+      text: expect.stringContaining("EXTERNAL_UNTRUSTED_CONTENT"),
+    });
+  });
+
+  it("returns inline page state after node-proxied navigate", async () => {
+    mockSingleBrowserProxyNode();
+    gatewayMocks.callGatewayTool
+      .mockResolvedValueOnce({
+        ok: true,
+        payload: { result: { ok: true, targetId: "proxy-tab", url: "https://example.com/next" } },
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        payload: {
+          result: {
+            ok: true,
+            format: "ai",
+            targetId: "proxy-tab",
+            url: "https://example.com/next",
+            snapshot: "proxy page",
+          },
+        },
+      });
+    const tool = createBrowserTool();
+
+    const result = await tool.execute?.("call-1", {
+      action: "navigate",
+      target: "node",
+      url: "https://example.com/next",
+    });
+
+    expect(gatewayMocks.callGatewayTool).toHaveBeenCalledTimes(2);
+    expect(result?.details).toMatchObject({
+      targetId: "proxy-tab",
+      pageState: { ok: true, format: "ai", targetId: "proxy-tab" },
+    });
+    expect(result?.content.at(-1)).toMatchObject({
+      type: "text",
+      text: expect.stringContaining("proxy page"),
+    });
+  });
+
+  it("keeps navigate success when the inline snapshot fails", async () => {
+    browserActionsMocks.browserNavigate.mockResolvedValueOnce({
+      ok: true,
+      targetId: "nav-tab",
+      url: "https://example.com/next",
+    });
+    browserClientMocks.browserSnapshot.mockRejectedValueOnce(new Error("snapshot exploded"));
+    const tool = createBrowserTool();
+
+    const result = await tool.execute?.("call-1", {
+      action: "navigate",
+      url: "https://example.com/next",
+    });
+
+    expect(result?.details).toMatchObject({ ok: true, targetId: "nav-tab" });
+    expect(result?.details).not.toHaveProperty("pageState");
+    expect(result?.content.at(-1)).toMatchObject({
+      type: "text",
+      text: expect.stringContaining("page snapshot unavailable: snapshot exploded"),
+    });
+  });
+
+  it("propagates cancellation from the inline page-state snapshot", async () => {
+    browserActionsMocks.browserNavigate.mockResolvedValueOnce({
+      ok: true,
+      targetId: "nav-tab",
+      url: "https://example.com/next",
+    });
+    const abortError = new Error("This operation was aborted");
+    abortError.name = "AbortError";
+    browserClientMocks.browserSnapshot.mockRejectedValueOnce(abortError);
+    const tool = createBrowserTool();
+
+    await expect(
+      tool.execute?.("call-1", { action: "navigate", url: "https://example.com/next" }),
+    ).rejects.toMatchObject({ name: "AbortError" });
+  });
+
+  it("degrades inline page state when the node proxy falls back to the host mid-call", async () => {
+    mockSingleBrowserProxyNode();
+    gatewayMocks.callGatewayTool
+      .mockResolvedValueOnce({
+        ok: true,
+        payload: { result: { ok: true, targetId: "proxy-tab", url: "https://example.com/next" } },
+      })
+      .mockRejectedValueOnce(
+        new Error("Browser control host is not reachable on 127.0.0.1:18791."),
+      );
+    toolCommonMocks.fetchBrowserJson.mockResolvedValueOnce({
+      ok: true,
+      format: "ai",
+      targetId: "host-tab",
+      url: "https://host.example.com",
+      snapshot: "host page",
+    });
+    const tool = createBrowserTool();
+
+    const result = await tool.execute?.("call-1", {
+      action: "navigate",
+      url: "https://example.com/next",
+    });
+
+    expect(result?.details).toMatchObject({ targetId: "proxy-tab" });
+    expect(result?.details).not.toHaveProperty("pageState");
+    expect(result?.content.at(-1)).toMatchObject({
+      type: "text",
+      text: expect.stringContaining(
+        "page snapshot unavailable: the browser node became unreachable",
+      ),
+    });
+    const combinedText = result?.content
+      .map((block) => ("text" in block ? block.text : ""))
+      .join("\n");
+    expect(combinedText).not.toContain("host page");
+  });
+
+  it("skips inline page state when navigate resolves to a download", async () => {
+    browserActionsMocks.browserNavigate.mockResolvedValueOnce({
+      ok: true,
+      targetId: "nav-tab",
+      url: "https://example.com/report.pdf",
+      download: {
+        path: "/tmp/openclaw/downloads/report.pdf",
+        suggestedFilename: "report.pdf",
+        url: "https://example.com/report.pdf",
+      },
+    });
+    const tool = createBrowserTool();
+
+    const result = await tool.execute?.("call-1", {
+      action: "navigate",
+      url: "https://example.com/report.pdf",
+    });
+
+    expect(browserClientMocks.browserSnapshot).not.toHaveBeenCalled();
+    expect(result?.details).toMatchObject({ ok: true, targetId: "nav-tab" });
+  });
+
   it("rejects credentialed navigate URLs before host or node dispatch", async () => {
     mockSingleBrowserProxyNode();
     const tool = createBrowserTool();
@@ -2519,13 +2684,54 @@ describe("browser tool act compatibility", () => {
       },
     });
 
-    expect(result?.details).toMatchObject({ aborted: { reason: "navigation", skipped: 2 } });
-    expect(result?.content.at(-1)).toMatchObject({
+    expect(result?.details).toMatchObject({
+      aborted: { reason: "navigation", skipped: 2 },
+      pageState: { ok: true, format: "ai" },
+    });
+    expect(result?.content.at(-2)).toMatchObject({
       type: "text",
       text: expect.stringContaining(
         "Batch aborted after action 1 because the page navigated to https://example.com/next",
       ),
     });
+    expect(result?.content.at(-1)).toMatchObject({
+      type: "text",
+      text: expect.stringContaining("EXTERNAL_UNTRUSTED_CONTENT"),
+    });
+  });
+
+  it("appends page state when a completed batch reports navigation", async () => {
+    browserActionsMocks.browserAct.mockResolvedValueOnce({
+      ok: true,
+      targetId: "tab-after-nav",
+      results: [{ ok: true, navigated: true, url: "https://example.com/next" }],
+    });
+    const tool = createBrowserTool();
+
+    const result = await tool.execute?.("call-1", {
+      action: "act",
+      request: { kind: "batch", actions: [{ kind: "click", ref: "1" }] },
+    });
+
+    const snapshotOpts = lastMockCallArg<{ targetId?: string }>(
+      browserClientMocks.browserSnapshot,
+      1,
+    );
+    expect(snapshotOpts.targetId).toBe("tab-after-nav");
+    expect(result?.details).toMatchObject({ pageState: { ok: true, format: "ai" } });
+  });
+
+  it("does not snapshot after acts that stay on the same document", async () => {
+    browserActionsMocks.browserAct.mockResolvedValueOnce({ ok: true, targetId: "tab-1" });
+    const tool = createBrowserTool();
+
+    const result = await tool.execute?.("call-1", {
+      action: "act",
+      request: { kind: "click", ref: "e3", targetId: "tab-1" },
+    });
+
+    expect(browserClientMocks.browserSnapshot).not.toHaveBeenCalled();
+    expect(result?.details).not.toHaveProperty("pageState");
   });
 
   it("accepts flattened act params for backward compatibility", async () => {

--- a/extensions/browser/src/browser-tool.ts
+++ b/extensions/browser/src/browser-tool.ts
@@ -16,7 +16,6 @@ import {
   executeConsoleAction,
   executeDownloadAction,
   executeExtractAction,
-  executeSnapshotAction,
   executeTabsAction,
 } from "./browser-tool.actions.js";
 import {
@@ -70,6 +69,7 @@ import {
   untrackSessionBrowserTab,
   validateJsonSchemaValue,
 } from "./browser-tool.runtime.js";
+import { appendNavigatedPageState, executeSnapshotAction } from "./browser-tool.snapshot.js";
 import { DEFAULT_BROWSER_SCREENSHOT_TIMEOUT_MS } from "./browser/constants.js";
 import { parseBrowserNavigationUrl } from "./browser/navigation-guard.js";
 import { normalizeBrowserScreenshot } from "./browser/screenshot.js";
@@ -900,28 +900,36 @@ export function createBrowserTool(opts?: {
         case "navigate": {
           const targetUrl = readTargetUrlParam(params);
           const targetId = readStringParam(params, "targetId");
-          if (proxyRequest) {
-            const result = await proxyRequest({
-              method: "POST",
-              path: "/navigate",
-              profile,
-              body: {
+          const result = proxyRequest
+            ? await proxyRequest({
+                method: "POST",
+                path: "/navigate",
+                profile,
+                body: {
+                  url: targetUrl,
+                  targetId,
+                },
+              })
+            : await browserToolDeps.browserNavigate(baseUrl, {
                 url: targetUrl,
                 targetId,
-              },
-            });
-            sessionTabs.touch(
-              readStringValue((result as { targetId?: unknown }).targetId) ?? targetId,
-            );
+                profile,
+              });
+          const navigatedTargetId =
+            readStringValue((result as { targetId?: unknown }).targetId) ?? targetId;
+          sessionTabs.touch(navigatedTargetId);
+          // A navigation that resolved to a download leaves the document
+          // unchanged, so inline page state would describe the wrong thing.
+          if ((result as { download?: unknown }).download) {
             return jsonResult(result);
           }
-          const result = await browserToolDeps.browserNavigate(baseUrl, {
-            url: targetUrl,
-            targetId,
+          return await appendNavigatedPageState({
+            result: jsonResult(result),
+            targetId: navigatedTargetId,
+            baseUrl,
             profile,
+            proxyRequest,
           });
-          sessionTabs.touch(readStringValue(result.targetId) ?? targetId);
-          return jsonResult(result);
         }
         case "console": {
           const result = await executeConsoleAction({


### PR DESCRIPTION
### What Problem This Solves

Every browser navigation costs two model round-trips: `navigate` returns only navigation metadata, so the model must issue a separate `snapshot` call before it can act on the page. On multi-step web flows the extra model turn per navigation dominates wall-clock time far more than browser latency does. Implements the snapshot-on-navigate item of #114798.

### Why This Change Was Made

Root-cause seam instead of a point patch: actions that change the page document now return fresh page state inline, through one shared step (`appendNavigatedPageState` in `extensions/browser/src/browser-tool.snapshot.ts`) that reuses the existing snapshot executor — so proxy/direct routing, untrusted-content wrapping, size caps, and snapshot delta markers are inherited rather than reimplemented.

Design decisions:

- **Efficient tier for inline state.** The inline capture pins `mode=efficient` (interactive+compact, 8k-char cap, forces the capped `ai` format on every profile — including raw-CDP profiles whose default `aria` format is uncapped). A full snapshot stays one explicit `action=snapshot` call away. This matches the canonical request's own economy argument ("compact interactive-elements format plus opt-in full snapshot").
- **Coverage.** `navigate` always (proxy + direct paths, now unified into one tail); `act` when the result reports a cross-document navigation (batch `results[].navigated` / abort `reason: "navigation"`), replacing the old "take a new snapshot before continuing" advisory with the snapshot itself. Navigations that resolve to a download skip it (document unchanged).
- **Failure isolation.** Page state is feedback on an already-successful mutation: snapshot failures degrade to a one-line remediation hint (redacted via `formatErrorMessage`), cancellation (`AbortError`) still aborts the call, and a mid-call node→host proxy fallback degrades to the hint instead of presenting a different browser's page as the navigated page's state.
- **File split.** Snapshot execution moved from `browser-tool.actions.ts` (was over the 700-line cap) into concept-named `browser-tool.snapshot.ts`; the actions file drops to 537 lines with no suppression. Note for reviewers: `browser-tool.snapshot.ts` holds no serialized/persistent state — "snapshot" here is the model-facing page snapshot result shape; there is no data-model or migration surface in this PR.

**Default-contract note:** the canonical request #114798 is maintainer-authored and explicitly specifies inline compact page state on navigate as the desired default; this PR implements that direction with the size bounded at the efficient tier. Formal confirmation is the maintainer's PR review/approval.

Named follow-ups / accepted tradeoffs:

- Single (non-batch) acts cannot report cross-document navigation today — the observation lives inside the SSRF-policy wrapper and is not threaded into single-act `/act` responses. Surfacing `navigated: true` there is a server-layer change tracked as the remaining half of this class; tool description and the browser-automation skill state the limitation honestly ("after a single act that triggers navigation, snapshot before using refs").
- Node-proxied navigate pays a second proxy round trip for the snapshot (model turns dominate wall-clock; payload capped at the efficient tier). Server-side `includeSnapshot` composition is the follow-up if node latency ever matters.
- `open` (new tab) is excluded: `/tabs/open` does not wait for page load, so an inline snapshot would race a loading document.
- Batch aborts snapshot at navigation commit; a slow page may still be loading (commented at the call site).

### User Impact

Multi-step browser tasks need roughly half the model turns: every `navigate` (all channels, host/sandbox/node targets, Playwright and Chrome MCP profiles) returns the loaded page's compact snapshot inline, and navigating batch acts return fresh page state instead of an instruction to fetch it. Tool results grow by up to ~8k chars per navigation (bounded efficient tier); `details` gains an additive `pageState` field. No config, server-API, or CLI changes; `browser.snapshotDefaults` and explicit `action=snapshot` behavior are unchanged.

### Evidence

**Live after-fix behavior proof (real browser, real pages).** Driver: isolated `OPENCLAW_STATE_DIR`, real browser control server (`startBrowserControlServerFromConfig`, listening on `127.0.0.1:19791`), real headless Chromium 145 (Playwright build), real network, calling the actual `createBrowserTool().execute` path from this branch. The full loop below uses **zero explicit `snapshot` calls**:

1. `action=navigate url=https://example.com` — the result now carries the loaded page's state inline (trimmed; the injection-warning wrapper text elided as `[…]`):

```json
{
  "content": [
    { "type": "text", "text": "{ \"ok\": true, \"targetId\": \"E5383…\", \"url\": \"https://example.com/\" }" },
    { "type": "text", "text": "[…SECURITY NOTICE wrapper…]\n<<<EXTERNAL_UNTRUSTED_CONTENT id=\"d762f…\">>>\nSource: Browser\n---\n- link \"Learn more\" [ref=e1]\n<<<END_EXTERNAL_UNTRUSTED_CONTENT>>>" }
  ],
  "details": {
    "ok": true, "targetId": "E5383…", "url": "https://example.com/",
    "pageState": { "ok": true, "format": "ai", "stats": { "lines": 1, "chars": 28, "refs": 1, "interactive": 1 }, "refs": 1, "externalContent": { "untrusted": true, "source": "browser", "kind": "snapshot", "format": "ai", "wrapped": true } }
  }
}
```

2. `ref=e1` taken **from that inline state** drives `action=act` (batch click) → cross-document navigation to `iana.org` → the act result reports `navigated: true` and again includes fresh page state of the **new** document, bounded at the efficient tier:

```json
{
  "details": {
    "ok": true, "targetId": "E5383…", "url": "https://www.iana.org/help/example-domains",
    "results": [ { "ok": true, "navigated": true, "url": "https://www.iana.org/help/example-domains" } ],
    "pageState": { "ok": true, "format": "ai", "url": "https://www.iana.org/help/example-domains", "stats": { "lines": 17, "chars": 552, "refs": 17, "interactive": 17 }, "refs": 17, "externalContent": { "untrusted": true, "source": "browser", "kind": "snapshot", "wrapped": true } }
  }
}
```

The inline content block lists the new page's 17 interactive refs (`- link "Homepage" [ref=e1] …`), wrapped in the standard untrusted-content envelope. Node-proxied parity is enforced structurally — both paths converge on the same `appendNavigatedPageState` step — and covered by unit tests exercising the proxy envelope (`returns inline page state after node-proxied navigate`, `degrades inline page state when the node proxy falls back to the host mid-call`).

**Tests and checks:**

- `node scripts/run-vitest.mjs extensions/browser/src/browser-tool.test.ts` — 127 passed, including new coverage: inline state on direct and node-proxied navigate, efficient-tier pinning, snapshot-failure degradation, AbortError propagation, host-fallback mid-call degradation, download skip, batch-navigation page state, and no-snapshot-on-same-document acts.
- `node scripts/run-vitest.mjs extensions/browser/src/browser-extract.test.ts extensions/browser/src/browser-tool-binding.test.ts extensions/browser/src/browser-tool.schema.test.ts` — passed.
- `tsgo` extensions + extensions-test lanes, `scripts/run-oxlint.mjs` on changed files, `oxfmt --check`, and `check-import-cycles` — all clean, run locally (remote Crabbox/Testbox backend unavailable in this environment; trusted-source local fallback per repo policy).
- Fresh autoreview (8-angle, high effort): 7 findings fixed in this PR (stale-target retry targetId, AbortError swallowing, host-fallback page-state mixup, uncapped aria inline snapshots, over-promising guidance, unredacted error text, duplicated act-payload parsing); 3 accepted with rationale above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
