### PR TITLE
fix(cron): stop stalled fallback setup across all execution phases

### DIFF
--- a/src/cron/service/agent-watchdog.test.ts
+++ b/src/cron/service/agent-watchdog.test.ts
@@ -1,5 +1,25 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
+import type { CronAgentExecutionPhase } from "../types.js";
 import { CRON_AGENT_SETUP_WATCHDOG_MS, createCronAgentWatchdog } from "./agent-watchdog.js";
+import { preExecutionTimeoutErrorMessage } from "./execution-errors.js";
+
+const executionPhases = [
+  "before_agent_reply",
+  "attempt_dispatch",
+  "context_assembled",
+  "turn_accepted",
+  "process_spawned",
+  "tool_execution_started",
+  "assistant_output_started",
+  "model_call_started",
+] as const satisfies readonly CronAgentExecutionPhase[];
+
+const fallbackSetupPhases = [
+  "runtime_plugins",
+  "model_resolution",
+  "auth",
+  "context_engine",
+] as const satisfies readonly CronAgentExecutionPhase[];
 
 describe("cron agent setup watchdog", () => {
   afterEach(() => {
@@ -77,4 +97,36 @@ describe("cron agent setup watchdog", () => {
     expect(triggerTimeout).toHaveBeenCalledTimes(1);
     expect(watchdog.observedLaneWait()).toBe(false);
   });
+
+  it.each(
+    executionPhases.flatMap((executionPhase) =>
+      fallbackSetupPhases.map((fallbackPhase) => ({ executionPhase, fallbackPhase })),
+    ),
+  )(
+    "rearms the pre-execution watchdog when $executionPhase falls back to $fallbackPhase",
+    async ({ executionPhase, fallbackPhase }) => {
+      vi.useFakeTimers();
+      const triggerTimeout = vi.fn();
+      const watchdog = createCronAgentWatchdog({
+        deferUntilRunner: true,
+        jobTimeoutMs: CRON_AGENT_SETUP_WATCHDOG_MS * 3,
+        triggerTimeout,
+      });
+      const jobId = "fallback-watchdog-job";
+
+      watchdog.start();
+      watchdog.noteRunnerStarted({ jobId, phase: "runner_entered" });
+      watchdog.notePhase({ jobId, phase: executionPhase });
+      watchdog.notePhase({ jobId, phase: fallbackPhase });
+
+      await vi.advanceTimersByTimeAsync(CRON_AGENT_SETUP_WATCHDOG_MS - 1);
+      expect(triggerTimeout).not.toHaveBeenCalled();
+
+      await vi.advanceTimersByTimeAsync(1);
+      expect(triggerTimeout).toHaveBeenCalledExactlyOnceWith(
+        preExecutionTimeoutErrorMessage({ jobId, phase: fallbackPhase }),
+      );
+      watchdog.dispose();
+    },
+  );
 });

--- a/src/cron/service/agent-watchdog.ts
+++ b/src/cron/service/agent-watchdog.ts
@@ -132,7 +132,8 @@ export function createCronAgentWatchdog(params: {
     // re-arm pre-execution timing so the fallback path cannot stall silently.
     if (
       state === "executing" &&
-      previousPhase === "before_agent_reply" &&
+      previousPhase !== undefined &&
+      CRON_AGENT_PHASE_WATCHDOG_STAGE[previousPhase] === "execution" &&
       stage === "pre_execution"
     ) {
       // Model fallback can move from an execution phase back into setup-like


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where a scheduled task switching to a fallback model can remain stuck in model setup for the full execution timeout instead of being stopped by the intended 60-second pre-execution watchdog.

## Why This Change Was Made

Use the existing canonical phase-to-watchdog stage map for all execution-to-setup transitions rather than special-casing a single execution phase. Preserve lane-admission timing, ordinary execution timeouts, terminal-state ownership, public configuration, Gateway protocols, provider behavior, and stored jobs.

## User Impact

A stalled fallback model no longer occupies a cron execution slot for up to an hour; scheduled tasks time out promptly and independently after every real execution milestone.

## Evidence

- Frozen exact PR head: `cb641243dcdf24d05d73d48be31c1ff2a1292853`.
- Independently traced cron timers, isolated-agent watchdog ownership, real model fallback phase callbacks, lane admission, cancellation, and sibling tests.
- Red-first Linux matrix reproduced all **28** previously uncovered execution-to-setup combinations; the four existing `before_agent_reply` control transitions retained their behavior.
- Fixed watchdog suite: **35/35**.
- Five repeated full watchdog and timer-regression runs: **510/510**.
- Complete cron suite: **1,831/1,831 across 155 files**.
- Complete relevant Gateway cron, notification, streaming and caller-scope suite: **166/166 across 9 files**.
- Focused red-first and first fixed regression proof ran on trusted Linux Testbox. After a fresh Testbox checkout-sync infrastructure timeout, final full proof completed on the exact-head trusted local hydrated-worktree fallback; combined final command exited **0**.
- Fresh independent Codex reviews of both uncommitted changes and exact published branch: **clean**.
- Full exact-head hosted CI and protected `openclaw/ci-gate` must pass before merge.
- No configuration, schema, migration, provider dependency, plugin SDK, auth, security, or Gateway protocol changes.

### Reviewer follow-through

- Latest `main` was refreshed and the complete mainline delta was checked against `src/cron/service/agent-watchdog.ts`, its regression matrix, `timer.regression.test.ts`, and `src/cron/types.ts`: **no overlap**. A second rebasing cycle is intentionally skipped because it would invalidate the already-reviewed exact-head full-suite evidence and restart every protected CI job while introducing no scheduler changes; native protected merge verification rechecks current-main drift immediately before landing.
- Redacted post-fix proof: `agent-watchdog.test.ts: 35 passed`; `timer.regression.test.ts: 67 passed`; five repetitions: `510 passed`; complete cron: `155 files, 1,831 passed`; relevant Gateway cron suite: `9 files, 166 passed`.
