### PR TITLE
fix(tui): prevent lost replies, session races, and unsafe terminal input

### DIFF
--- a/docs/web/tui.md
+++ b/docs/web/tui.md
@@ -86,6 +86,7 @@ openclaw tui --local
 ## Keyboard shortcuts
 
 - Enter: send message
+- Shift+Enter or Ctrl+J: insert a newline without sending
 - Esc: abort active run
 - Ctrl+C: clear input (press twice to exit)
 - Ctrl+D: exit

--- a/src/tui/commands.test.ts
+++ b/src/tui/commands.test.ts
@@ -178,6 +178,13 @@ describe("getSlashCommands", () => {
 });
 
 describe("helpText", () => {
+  it.each([{}, { local: true }])("documents multiline input shortcuts", (options) => {
+    const output = helpText(options);
+
+    expect(output).toContain("Enter: send message");
+    expect(output).toContain("Shift+Enter or Ctrl+J: insert a newline");
+  });
+
   it.each(["/verbose <on|off|full>", "/reasoning <on|off|stream>"])(
     "includes the full canonical directive levels for %s",
     (usage) => {

--- a/src/tui/commands.ts
+++ b/src/tui/commands.ts
@@ -271,5 +271,9 @@ export function helpText(options: SlashCommandOptions = {}): string {
     "/abort",
     "/settings",
     "/exit",
+    "",
+    "Keyboard shortcuts:",
+    "Enter: send message",
+    "Shift+Enter or Ctrl+J: insert a newline",
   ].join("\n");
 }

--- a/src/tui/components/custom-editor.test.ts
+++ b/src/tui/components/custom-editor.test.ts
@@ -26,6 +26,22 @@ describe("CustomEditor", () => {
     vi.restoreAllMocks();
   });
 
+  it.each([
+    { name: "Kitty Shift+Enter", input: "\u001b[13;2u" },
+    { name: "Ctrl+J", input: "\n" },
+  ])("inserts a newline without submitting on $name", ({ input }) => {
+    const tui = { requestRender: vi.fn() } as unknown as TUI;
+    const editor = new CustomEditor(tui, editorTheme);
+    const onSubmit = vi.fn();
+    editor.onSubmit = onSubmit;
+    editor.setText("first line");
+
+    editor.handleInput(input);
+
+    expect(editor.getText()).toBe("first line\n");
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
   it("routes alt+enter to the follow-up handler", () => {
     const tui = { requestRender: vi.fn() } as unknown as TUI;
     const editor = new CustomEditor(tui, editorTheme);

--- a/src/tui/components/filterable-select-list.test.ts
+++ b/src/tui/components/filterable-select-list.test.ts
@@ -1,4 +1,5 @@
 // Filterable select list tests cover keyboard filtering and cursor behavior.
+import { CURSOR_MARKER, visibleWidth } from "@earendil-works/pi-tui";
 import { describe, expect, it } from "vitest";
 import { FilterableSelectList, type FilterableSelectItem } from "./filterable-select-list.js";
 
@@ -34,6 +35,82 @@ describe("FilterableSelectList", () => {
       list.handleInput(ch);
     }
   }
+
+  it("emits the hardware cursor marker only while the filter input is focused", () => {
+    const list = new FilterableSelectList(testItems, 5, mockTheme);
+
+    expect(list.focused).toBe(false);
+    expect(list.render(80)[0]).not.toContain(CURSOR_MARKER);
+
+    list.focused = true;
+    expect(list.focused).toBe(true);
+    expect(list.render(80)[0]).toContain(CURSOR_MARKER);
+
+    list.focused = false;
+    expect(list.focused).toBe(false);
+    expect(list.render(80)[0]).not.toContain(CURSOR_MARKER);
+  });
+
+  it.each([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12])(
+    "keeps ANSI, CJK, scroll, and no-match rows within %i terminal columns",
+    (width) => {
+      const items: FilterableSelectItem[] = [
+        {
+          value: "cjk",
+          label: "\u001b[32m日本語の検索結果\u001b[0m",
+          description: "長い説明と表示幅の検証",
+        },
+        { value: "other", label: "another long search result" },
+      ];
+      const list = new FilterableSelectList(items, 1, mockTheme);
+      list.focused = true;
+
+      for (const line of list.render(width)) {
+        expect(visibleWidth(line)).toBeLessThanOrEqual(width);
+      }
+
+      typeInput(list, "missing");
+      for (const line of list.render(width)) {
+        expect(visibleWidth(line)).toBeLessThanOrEqual(width);
+      }
+    },
+  );
+
+  it.each([
+    { query: "j", expectedValue: "juliet" },
+    { query: "k", expectedValue: "kilo" },
+  ])("filters names beginning with $query", ({ query, expectedValue }) => {
+    const list = new FilterableSelectList(
+      [
+        { value: "alpha", label: "alpha" },
+        { value: "kilo", label: "kilo" },
+        { value: "juliet", label: "juliet" },
+      ],
+      5,
+      mockTheme,
+    );
+
+    list.handleInput(query);
+
+    expect(list.getFilterText()).toBe(query);
+    expect(list.getSelectedItem()?.value).toBe(expectedValue);
+  });
+
+  it("preserves arrow and Ctrl-key navigation", () => {
+    const list = new FilterableSelectList(testItems, 5, mockTheme);
+
+    list.handleInput("\x1b[B");
+    expect(list.getSelectedItem()?.value).toBe("session-2");
+
+    list.handleInput("\u0010");
+    expect(list.getSelectedItem()?.value).toBe("session-1");
+
+    list.handleInput("\u000e");
+    expect(list.getSelectedItem()?.value).toBe("session-2");
+
+    list.handleInput("\x1b[A");
+    expect(list.getSelectedItem()?.value).toBe("session-1");
+  });
 
   it("clears the active filter before cancelling", () => {
     const list = new FilterableSelectList(testItems, 5, mockTheme);

--- a/src/tui/components/filterable-select-list.ts
+++ b/src/tui/components/filterable-select-list.ts
@@ -1,12 +1,15 @@
 // Filterable select list component supports filtered keyboard selection.
-import type { Component } from "@earendil-works/pi-tui";
 import {
+  type Component,
+  type Focusable,
   fuzzyFilter,
   Input,
   matchesKey,
   type SelectItem,
   SelectList,
   type SelectListTheme,
+  truncateToWidth,
+  visibleWidth,
 } from "@earendil-works/pi-tui";
 import chalk from "chalk";
 
@@ -21,9 +24,9 @@ interface FilterableSelectListTheme extends SelectListTheme {
 
 /**
  * Combines text input filtering with a select list.
- * User types to filter, arrows/j/k to navigate, Enter to select, Escape to clear/cancel.
+ * User types to filter, arrows or Ctrl+P/Ctrl+N navigate, and Escape clears or cancels.
  */
-export class FilterableSelectList implements Component {
+export class FilterableSelectList implements Component, Focusable {
   private input: Input;
   private selectList: SelectList;
   private allItems: FilterableSelectItem[];
@@ -40,6 +43,14 @@ export class FilterableSelectList implements Component {
     this.theme = theme;
     this.input = new Input();
     this.selectList = new SelectList(this.allItems, maxVisible, theme);
+  }
+
+  get focused(): boolean {
+    return this.input.focused;
+  }
+
+  set focused(value: boolean) {
+    this.input.focused = value;
   }
 
   private applyFilter(): void {
@@ -60,41 +71,32 @@ export class FilterableSelectList implements Component {
 
   render(width: number): string[] {
     const lines: string[] = [];
+    const safeWidth = Math.max(0, width);
 
     // Filter input row
     const filterLabel = this.theme.filterLabel("Filter: ");
-    const inputLines = this.input.render(width - 8);
+    const inputLines = this.input.render(Math.max(0, safeWidth - visibleWidth(filterLabel)));
     const inputText = inputLines[0] ?? "";
-    lines.push(filterLabel + inputText);
+    lines.push(truncateToWidth(filterLabel + inputText, safeWidth, ""));
 
     // Separator
-    lines.push(chalk.dim("─".repeat(Math.max(0, width))));
+    lines.push(chalk.dim("─".repeat(safeWidth)));
 
     // Select list
-    const listLines = this.selectList.render(width);
-    lines.push(...listLines);
+    const listLines = this.selectList.render(safeWidth);
+    lines.push(...listLines.map((line) => truncateToWidth(line, safeWidth, "")));
 
     return lines;
   }
 
   handleInput(keyData: string): void {
-    const allowVimNav = !this.filterText.trim();
-
-    // Navigation: arrows, vim j/k, or ctrl+p/ctrl+n
-    if (
-      matchesKey(keyData, "up") ||
-      matchesKey(keyData, "ctrl+p") ||
-      (allowVimNav && keyData === "k")
-    ) {
+    // Printable keys must reach the filter; arrows and Ctrl keys own navigation.
+    if (matchesKey(keyData, "up") || matchesKey(keyData, "ctrl+p")) {
       this.selectList.handleInput("\x1b[A");
       return;
     }
 
-    if (
-      matchesKey(keyData, "down") ||
-      matchesKey(keyData, "ctrl+n") ||
-      (allowVimNav && keyData === "j")
-    ) {
+    if (matchesKey(keyData, "down") || matchesKey(keyData, "ctrl+n")) {
       this.selectList.handleInput("\x1b[B");
       return;
     }

--- a/src/tui/components/searchable-select-list.test.ts
+++ b/src/tui/components/searchable-select-list.test.ts
@@ -1,6 +1,7 @@
 // Searchable select list tests cover filtering and selection behavior.
+import { CURSOR_MARKER, visibleWidth } from "@earendil-works/pi-tui";
 import { describe, expect, it } from "vitest";
-import { stripAnsi, visibleWidth } from "../../../packages/terminal-core/src/ansi.js";
+import { stripAnsi } from "../../../packages/terminal-core/src/ansi.js";
 import { SearchableSelectList, type SearchableSelectListTheme } from "./searchable-select-list.js";
 
 const mockTheme: SearchableSelectListTheme = {
@@ -88,6 +89,46 @@ describe("SearchableSelectList", () => {
     expect(output.length).toBeGreaterThanOrEqual(3);
     expect(output[0]).toContain("search");
   });
+
+  it("emits the hardware cursor marker only while the search input is focused", () => {
+    const list = new SearchableSelectList(testItems, 5, mockTheme);
+
+    expect(list.focused).toBe(false);
+    expect(list.render(80)[0]).not.toContain(CURSOR_MARKER);
+
+    list.focused = true;
+    expect(list.focused).toBe(true);
+    expect(list.render(80)[0]).toContain(CURSOR_MARKER);
+
+    list.focused = false;
+    expect(list.focused).toBe(false);
+    expect(list.render(80)[0]).not.toContain(CURSOR_MARKER);
+  });
+
+  it.each([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12])(
+    "keeps ANSI, CJK, scroll, and no-match rows within %i terminal columns",
+    (width) => {
+      const items = [
+        {
+          value: "cjk",
+          label: "\u001b[32m日本語の検索結果\u001b[0m",
+          description: "長い説明と表示幅の検証",
+        },
+        { value: "other", label: "another long search result" },
+      ];
+      const list = new SearchableSelectList(items, 1, ansiHighlightTheme);
+      list.focused = true;
+
+      for (const line of list.render(width)) {
+        expect(visibleWidth(line)).toBeLessThanOrEqual(width);
+      }
+
+      list.handleInput("missing");
+      for (const line of list.render(width)) {
+        expect(visibleWidth(line)).toBeLessThanOrEqual(width);
+      }
+    },
+  );
 
   it("does not truncate long labels on wide terminals when description is present", () => {
     const tail = "__TAIL__";
@@ -325,22 +366,24 @@ describe("SearchableSelectList", () => {
     expect(list.getSelectedItem()?.value).toBe("anthropic/claude-3-sonnet");
   });
 
-  it("types j and k into search input instead of intercepting as vim navigation", () => {
-    const items = [
-      { value: "alpha", label: "alpha" },
-      { value: "kilo", label: "kilo" },
-      { value: "juliet", label: "juliet" },
-    ];
+  it.each([
+    { query: "j", expectedValue: "juliet" },
+    { query: "k", expectedValue: "kilo" },
+  ])("filters names beginning with $query", ({ query, expectedValue }) => {
+    const list = new SearchableSelectList(
+      [
+        { value: "alpha", label: "alpha" },
+        { value: "kilo", label: "kilo" },
+        { value: "juliet", label: "juliet" },
+      ],
+      5,
+      mockTheme,
+    );
 
-    const jList = new SearchableSelectList(items, 5, mockTheme);
-    jList.handleInput("j");
-    expect(jList.getSelectedItem()?.value).toBe("juliet");
-    expect(stripAnsi(jList.render(80)[0] ?? "")).toContain("j");
+    list.handleInput(query);
 
-    const kList = new SearchableSelectList(items, 5, mockTheme);
-    kList.handleInput("k");
-    expect(kList.getSelectedItem()?.value).toBe("kilo");
-    expect(stripAnsi(kList.render(80)[0] ?? "")).toContain("k");
+    expect(list.getSelectedItem()?.value).toBe(expectedValue);
+    expect(stripAnsi(list.render(80)[0] ?? "")).toContain(query);
   });
 
   it("calls onSelect when enter is pressed", () => {

--- a/src/tui/components/searchable-select-list.ts
+++ b/src/tui/components/searchable-select-list.ts
@@ -1,6 +1,7 @@
 // Searchable select list component adds search input to selectable TUI lists.
 import {
   type Component,
+  type Focusable,
   fuzzyFilter,
   Input,
   isKeyRelease,
@@ -8,10 +9,11 @@ import {
   type SelectItem,
   type SelectListTheme,
   truncateToWidth,
+  visibleWidth,
 } from "@earendil-works/pi-tui";
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
 import { uniqueStrings } from "@openclaw/normalization-core/string-normalization";
-import { stripAnsi, visibleWidth } from "../../../packages/terminal-core/src/ansi.js";
+import { stripAnsi } from "../../../packages/terminal-core/src/ansi.js";
 
 const ANSI_ESCAPE = String.fromCharCode(27);
 const ANSI_SGR_REGEX = new RegExp(`${ANSI_ESCAPE}\\[[0-9;]*m`, "g");
@@ -29,7 +31,7 @@ export interface SearchableSelectItem extends SelectItem {
 /**
  * A select list with a search input at the top for fuzzy filtering.
  */
-export class SearchableSelectList implements Component {
+export class SearchableSelectList implements Component, Focusable {
   private items: SearchableSelectItem[];
   private filteredItems: SearchableSelectItem[];
   private selectedIndex = 0;
@@ -54,6 +56,14 @@ export class SearchableSelectList implements Component {
     this.maxVisible = maxVisible;
     this.theme = theme;
     this.searchInput = new Input();
+  }
+
+  get focused(): boolean {
+    return this.searchInput.focused;
+  }
+
+  set focused(value: boolean) {
+    this.searchInput.focused = value;
   }
 
   private getCachedRegex(pattern: string): RegExp {
@@ -211,21 +221,22 @@ export class SearchableSelectList implements Component {
 
   render(width: number): string[] {
     const lines: string[] = [];
+    const safeWidth = Math.max(0, width);
 
     // Search input line
     const promptText = "search: ";
     const prompt = this.theme.searchPrompt(promptText);
-    const inputWidth = Math.max(1, width - visibleWidth(prompt));
+    const inputWidth = Math.max(0, safeWidth - visibleWidth(prompt));
     const inputLines = this.searchInput.render(inputWidth);
     const inputText = inputLines[0] ?? "";
-    lines.push(`${prompt}${this.theme.searchInput(inputText)}`);
+    lines.push(truncateToWidth(`${prompt}${this.theme.searchInput(inputText)}`, safeWidth, ""));
     lines.push(""); // Spacer
 
     const query = this.searchInput.getValue().trim();
 
     // If no items match filter, show message
     if (this.filteredItems.length === 0) {
-      lines.push(this.theme.noMatch("  No matches"));
+      lines.push(truncateToWidth(this.theme.noMatch("  No matches"), safeWidth, ""));
       return lines;
     }
 
@@ -246,13 +257,15 @@ export class SearchableSelectList implements Component {
         continue;
       }
       const isSelected = i === this.selectedIndex;
-      lines.push(this.renderItemLine(item, isSelected, width, query));
+      lines.push(
+        truncateToWidth(this.renderItemLine(item, isSelected, safeWidth, query), safeWidth, ""),
+      );
     }
 
     // Show scroll indicator if needed
     if (this.filteredItems.length > this.maxVisible) {
       const scrollInfo = `${this.selectedIndex + 1}/${this.filteredItems.length}`;
-      lines.push(this.theme.scrollInfo(`  ${scrollInfo}`));
+      lines.push(truncateToWidth(this.theme.scrollInfo(`  ${scrollInfo}`), safeWidth, ""));
     }
 
     return lines;

--- a/src/tui/components/tool-execution.test.ts
+++ b/src/tui/components/tool-execution.test.ts
@@ -1,0 +1,85 @@
+import { visibleWidth } from "@earendil-works/pi-tui";
+import { describe, expect, it } from "vitest";
+import { normalizeTestText } from "../../../test/helpers/normalize-text.js";
+import { ToolExecutionComponent } from "./tool-execution.js";
+
+const MAX_COLLAPSED_COMPONENT_LINES = 17;
+
+function renderToolOutput(text: string, width: number) {
+  const component = new ToolExecutionComponent("read_file", { path: "example.txt" });
+  component.setResult({ content: [{ type: "text", text }] });
+  return { component, lines: component.render(width) };
+}
+
+describe("ToolExecutionComponent", () => {
+  it.each([
+    { width: 20, characters: 8_192 },
+    { width: 20, characters: 16_384 },
+    { width: 80, characters: 8_192 },
+    { width: 80, characters: 16_384 },
+  ])(
+    "bounds a $characters-character single-line preview at terminal width $width",
+    ({ characters, width }) => {
+      const { lines } = renderToolOutput("x".repeat(characters), width);
+
+      expect(lines.length).toBeLessThanOrEqual(MAX_COLLAPSED_COMPONENT_LINES);
+      expect(lines.map(normalizeTestText).join("\n")).toContain("...");
+      for (const line of lines) {
+        expect(visibleWidth(line)).toBeLessThanOrEqual(width);
+      }
+    },
+  );
+
+  it.each([
+    { label: "wide CJK", text: "表".repeat(8_192), width: 20 },
+    { label: "wide CJK", text: "表".repeat(8_192), width: 80 },
+    { label: "ANSI-styled text", text: `\u001b[31m${"x".repeat(8_192)}\u001b[0m`, width: 20 },
+    { label: "ANSI-styled text", text: `\u001b[31m${"x".repeat(8_192)}\u001b[0m`, width: 80 },
+  ])("keeps $label within a $width-column collapsed preview", ({ text, width }) => {
+    const { lines } = renderToolOutput(text, width);
+
+    expect(lines.length).toBeLessThanOrEqual(MAX_COLLAPSED_COMPONENT_LINES);
+    expect(lines.map(normalizeTestText).join("\n")).toContain("...");
+    expect(lines.join("\n")).not.toContain("\uFFFD");
+    for (const line of lines) {
+      expect(visibleWidth(line)).toBeLessThanOrEqual(width);
+    }
+  });
+
+  it("retains the complete result when expanding and recollapsing a preview", () => {
+    const text = `START_MARKER ${"x".repeat(16_384)} END_MARKER`;
+    const { component, lines: collapsed } = renderToolOutput(text, 80);
+
+    expect(collapsed.length).toBeLessThanOrEqual(MAX_COLLAPSED_COMPONENT_LINES);
+    expect(collapsed.map(normalizeTestText).join("\n")).not.toContain("END_MARKER");
+
+    component.setExpanded(true);
+    const expanded = component.render(80);
+
+    expect(expanded.length).toBeGreaterThan(MAX_COLLAPSED_COMPONENT_LINES);
+    expect(expanded.map(normalizeTestText).join("\n")).toContain("START_MARKER");
+    expect(expanded.map(normalizeTestText).join("\n")).toContain("END_MARKER");
+
+    component.setExpanded(false);
+    const recollapsed = component.render(80);
+
+    expect(recollapsed.length).toBeLessThanOrEqual(MAX_COLLAPSED_COMPONENT_LINES);
+    expect(recollapsed.map(normalizeTestText).join("\n")).toContain("...");
+    expect(recollapsed.map(normalizeTestText).join("\n")).not.toContain("END_MARKER");
+  });
+
+  it("bounds output with more than twelve explicit source lines", () => {
+    const text = Array.from({ length: 30 }, (_, index) => `tool output line ${index + 1}`).join(
+      "\n",
+    );
+    const { component, lines } = renderToolOutput(text, 80);
+
+    expect(lines.length).toBeLessThanOrEqual(MAX_COLLAPSED_COMPONENT_LINES);
+    expect(lines.map(normalizeTestText).join("\n")).toContain("...");
+    expect(lines.map(normalizeTestText).join("\n")).not.toContain("tool output line 30");
+
+    component.setExpanded(true);
+
+    expect(component.render(80).map(normalizeTestText).join("\n")).toContain("tool output line 30");
+  });
+});

--- a/src/tui/components/tool-execution.ts
+++ b/src/tui/components/tool-execution.ts
@@ -1,5 +1,6 @@
 // Tool execution component renders tool call status and output in the TUI.
-import { Box, Container, Markdown, Spacer, Text } from "@earendil-works/pi-tui";
+import { Box, Container, Markdown, Spacer, Text, truncateToWidth } from "@earendil-works/pi-tui";
+import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import { formatToolDetail, resolveToolDisplay } from "../../agents/tool-display.js";
 import { markdownTheme, theme } from "../theme/theme.js";
 import { sanitizeRenderableText } from "../tui-formatters.js";
@@ -19,6 +20,55 @@ type ToolResult = {
 };
 
 const PREVIEW_LINES = 12;
+const MAX_PREVIEW_CHARS = PREVIEW_LINES * 256;
+
+// Bound the actual wrapped Markdown, not just source newlines: a single long
+// tool-output line can otherwise produce thousands of rows and stall the TUI.
+class ToolOutputComponent extends Markdown {
+  private sourceText = "";
+  private renderedSource: string | undefined;
+  private expanded = false;
+
+  override setText(text: string): void {
+    if (this.sourceText === text) {
+      return;
+    }
+    this.sourceText = text;
+    this.renderedSource = undefined;
+    super.invalidate();
+  }
+
+  setExpanded(expanded: boolean): void {
+    if (this.expanded === expanded) {
+      return;
+    }
+    this.expanded = expanded;
+    this.renderedSource = undefined;
+    super.invalidate();
+  }
+
+  override render(width: number): string[] {
+    const safeWidth = Math.max(0, Math.floor(width));
+    const previewBudget = Math.min(MAX_PREVIEW_CHARS, PREVIEW_LINES * Math.max(1, safeWidth));
+    const text = this.expanded
+      ? this.sourceText
+      : truncateUtf16Safe(this.sourceText, previewBudget);
+
+    if (this.renderedSource !== text) {
+      super.setText(text);
+      this.renderedSource = text;
+    }
+
+    const lines = super.render(safeWidth);
+    if (
+      this.expanded ||
+      (text.length === this.sourceText.length && lines.length <= PREVIEW_LINES)
+    ) {
+      return lines;
+    }
+    return [...lines.slice(0, PREVIEW_LINES - 1), truncateToWidth("…", safeWidth, "")];
+  }
+}
 
 // Prefer curated display summaries, then fall back to sanitized JSON args.
 function formatArgs(toolName: string, args: unknown): string {
@@ -61,7 +111,7 @@ export class ToolExecutionComponent extends Container {
   private box: Box;
   private header: Text;
   private argsLine: Text;
-  private output: Markdown;
+  private output: ToolOutputComponent;
   private toolName: string;
   private args: unknown;
   private result?: ToolResult;
@@ -76,7 +126,7 @@ export class ToolExecutionComponent extends Container {
     this.box = new Box(1, 1, (line) => theme.toolPendingBg(line));
     this.header = new Text("", 0, 0);
     this.argsLine = new Text("", 0, 0);
-    this.output = new Markdown("", 0, 0, markdownTheme, {
+    this.output = new ToolOutputComponent("", 0, 0, markdownTheme, {
       color: (line) => theme.toolOutput(line),
     });
     this.addChild(new Spacer(1));
@@ -134,13 +184,7 @@ export class ToolExecutionComponent extends Container {
 
     const raw = extractText(this.result);
     const text = raw || (this.isPartial ? "…" : "");
-    if (!this.expanded && text) {
-      const lines = text.split("\n");
-      const preview =
-        lines.length > PREVIEW_LINES ? `${lines.slice(0, PREVIEW_LINES).join("\n")}\n…` : text;
-      this.output.setText(preview);
-    } else {
-      this.output.setText(text);
-    }
+    this.output.setExpanded(this.expanded);
+    this.output.setText(text);
   }
 }

--- a/src/tui/embedded-backend.test.ts
+++ b/src/tui/embedded-backend.test.ts
@@ -2299,6 +2299,79 @@ describe("EmbeddedTuiBackend", () => {
     expect(agentCommandFromIngressMock).toHaveBeenCalledTimes(2);
   });
 
+  it.each([
+    {
+      name: "replaces streamed drafts with the authoritative final answer",
+      finalPayloads: [{ text: "Authoritative final answer" }],
+      expectedText: "Authoritative final answer",
+    },
+    {
+      name: "keeps an authoritative final answer that extends the streamed draft",
+      finalPayloads: [{ text: "Draft answer with its complete authoritative tail" }],
+      expectedText: "Draft answer with its complete authoritative tail",
+    },
+    {
+      name: "preserves every authoritative final payload block",
+      finalPayloads: [{ text: "First final block" }, { text: "Second final block" }],
+      expectedText: "First final block\n\nSecond final block",
+    },
+    {
+      name: "preserves streamed text when the final payload contains no text",
+      finalPayloads: [],
+      expectedText: "Draft answer",
+    },
+  ])("$name", async ({ finalPayloads, expectedText }) => {
+    const { EmbeddedTuiBackend } = await import("./embedded-backend.js");
+    const pending = deferred<{
+      payloads: Array<{ text: string }>;
+      meta: Record<string, unknown>;
+    }>();
+    agentCommandFromIngressMock.mockReturnValueOnce(pending.promise);
+
+    const backend = new EmbeddedTuiBackend();
+    const events: Array<{ event: string; payload: unknown }> = [];
+    backend.onEvent = (event) => {
+      events.push({ event: event.event, payload: event.payload });
+    };
+
+    backend.start();
+    await backend.sendChat({
+      sessionKey: "agent:main:main",
+      message: "finish the draft",
+      runId: "run-local-authoritative-final",
+    });
+
+    registeredListener?.({
+      runId: "run-local-authoritative-final",
+      stream: "assistant",
+      data: { text: "Draft answer", delta: "Draft answer" },
+    });
+    registeredListener?.({
+      runId: "run-local-authoritative-final",
+      stream: "lifecycle",
+      data: { phase: "end", stopReason: "stop" },
+    });
+
+    pending.resolve({ payloads: finalPayloads, meta: {} });
+    await flushMicrotasks();
+
+    const chatPayloads = events
+      .filter((event) => event.event === "chat")
+      .map((event) => event.payload);
+
+    expect(chatPayloads.at(-1)).toStrictEqual({
+      runId: "run-local-authoritative-final",
+      sessionKey: "agent:main:main",
+      state: "final",
+      stopReason: "stop",
+      message: {
+        role: "assistant",
+        content: [{ type: "text", text: expectedText }],
+        timestamp: embeddedEventTimestamp,
+      },
+    });
+  });
+
   it("keeps final short replies like No after suppressing lead-fragment deltas", async () => {
     const { EmbeddedTuiBackend } = await import("./embedded-backend.js");
     const pending = deferred<{

--- a/src/tui/embedded-backend.ts
+++ b/src/tui/embedded-backend.ts
@@ -1528,9 +1528,10 @@ export class EmbeddedTuiBackend implements TuiBackend {
       }
 
       if (!run.finalSent) {
-        const normalizedText = payloadText(result?.payloads);
-        if (normalizedText && !run.buffer) {
-          run.buffer = normalizedText;
+        const finalText = payloadText(result?.payloads);
+        // A completed response is authoritative; keep the stream only when it has no final text.
+        if (finalText) {
+          run.buffer = finalText;
         }
         const stopReason =
           run.lifecycleStopReason ??

--- a/src/tui/tui-command-handlers.test.ts
+++ b/src/tui/tui-command-handlers.test.ts
@@ -45,6 +45,16 @@ async function flushAsyncSelect() {
   });
 }
 
+function createDeferred<T>() {
+  let resolve: (value: T) => void = () => {};
+  let reject: (reason?: unknown) => void = () => {};
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
+}
+
 function expectSendChatFields(
   sendChat: ReturnType<typeof vi.fn>,
   expected: { message: string; agentId?: string; sessionId?: string; sessionKey?: string },
@@ -992,9 +1002,42 @@ describe("tui command handlers", () => {
     // /reset still resets the shared session
     expect(resetSession).toHaveBeenCalledTimes(1);
     expect(resetSession).toHaveBeenCalledWith("agent:main:main", "reset", undefined);
-    expect(applySessionMutationResult).toHaveBeenCalledWith(resetResult);
+    expect(applySessionMutationResult).toHaveBeenCalledWith(resetResult, {
+      sessionKey: "agent:main:main",
+      agentId: "main",
+    });
     expect(refreshSessionInfo).toHaveBeenCalledTimes(1);
     expect(loadHistory).not.toHaveBeenCalled();
+  });
+
+  it("reports a reset after adopting the backend's replacement session key", async () => {
+    const resetResult = {
+      ok: true as const,
+      key: "agent:main:replacement",
+      entry: { sessionId: "replacement-session" },
+    };
+    const applySessionMutationResult = vi.fn((result: typeof resetResult) => {
+      harness.state.currentSessionKey = result.key;
+      harness.state.currentSessionId = result.entry.sessionId;
+      return true;
+    });
+    const refreshSessionInfo = vi.fn().mockResolvedValue(undefined);
+    const harness = createHarness({
+      applySessionMutationResult,
+      refreshSessionInfo,
+      resetSession: vi.fn().mockResolvedValue(resetResult),
+    });
+
+    await harness.handleCommand("/reset");
+
+    expect(applySessionMutationResult).toHaveBeenCalledExactlyOnceWith(resetResult, {
+      sessionKey: "agent:main:main",
+      agentId: "main",
+    });
+    expect(refreshSessionInfo).toHaveBeenCalledOnce();
+    expect(harness.state.currentSessionKey).toBe("agent:main:replacement");
+    expect(harness.state.currentSessionId).toBe("replacement-session");
+    expect(harness.addSystem).toHaveBeenCalledWith("session agent:main:replacement reset");
   });
 
   it.each([
@@ -1146,7 +1189,10 @@ describe("tui command handlers", () => {
 
     await handleCommand("/reset");
 
-    expect(applySessionMutationResult).toHaveBeenCalledWith({ ok: true });
+    expect(applySessionMutationResult).toHaveBeenCalledWith(
+      { ok: true },
+      { sessionKey: "agent:main:main", agentId: "main" },
+    );
     expect(loadHistory).toHaveBeenCalledTimes(1);
   });
 
@@ -1176,6 +1222,198 @@ describe("tui command handlers", () => {
       agentId: "work",
       fastMode: true,
     });
+  });
+
+  it.each([
+    "/model openai/gpt-5.6-luna",
+    "/think medium",
+    "/verbose off",
+    "/verbose full",
+    "/trace on",
+    "/fast on",
+    "/reasoning on",
+    "/usage reset",
+    "/usage full",
+    "/elevated ask",
+    "/activation always",
+  ])("ignores a stale %s result after switching sessions", async (command) => {
+    const deferred = createDeferred<{
+      ok: true;
+      path: string;
+      key: string;
+      entry: Record<string, unknown>;
+    }>();
+    const harness = createHarness({
+      currentSessionKey: "agent:main:first",
+      sessionInfo: { responseUsage: "tokens", effectiveResponseUsage: "tokens" },
+      patchSession: vi.fn(() => deferred.promise),
+    });
+
+    const pending = harness.handleCommand(command);
+    expect(harness.patchSession).toHaveBeenCalledWith(
+      expect.objectContaining({ key: "agent:main:first" }),
+    );
+    harness.state.currentSessionKey = "agent:main:second";
+    deferred.resolve({
+      ok: true,
+      path: "/sessions/patch",
+      key: "agent:main:first",
+      entry: { model: "stale-model" },
+    });
+    await pending;
+
+    expect(harness.state.currentSessionKey).toBe("agent:main:second");
+    expect(harness.state.sessionInfo.responseUsage).toBe("tokens");
+    expect(harness.state.sessionInfo.effectiveResponseUsage).toBe("tokens");
+    expect(harness.applySessionInfoFromPatch).not.toHaveBeenCalled();
+    expect(harness.refreshSessionInfo).not.toHaveBeenCalled();
+    expect(harness.loadHistory).not.toHaveBeenCalled();
+    expect(harness.clearTools).not.toHaveBeenCalled();
+    expect(harness.addSystem).not.toHaveBeenCalled();
+  });
+
+  it.each(["/model openai/gpt-5.6-luna", "/usage reset"])(
+    "ignores a stale global-agent %s result",
+    async (command) => {
+      const deferred = createDeferred<{
+        ok: true;
+        path: string;
+        key: string;
+        entry: Record<string, unknown>;
+      }>();
+      const harness = createHarness({
+        currentSessionKey: "global",
+        currentAgentId: "main",
+        sessionInfo: { responseUsage: "tokens", effectiveResponseUsage: "tokens" },
+        patchSession: vi.fn(() => deferred.promise),
+      });
+
+      const pending = harness.handleCommand(command);
+      expect(harness.patchSession).toHaveBeenCalledWith(
+        expect.objectContaining({ key: "global", agentId: "main" }),
+      );
+      harness.state.currentAgentId = "work";
+      deferred.resolve({
+        ok: true,
+        path: "/sessions/patch",
+        key: "global",
+        entry: { model: "main-agent-model" },
+      });
+      await pending;
+
+      expect(harness.state.currentSessionKey).toBe("global");
+      expect(harness.state.currentAgentId).toBe("work");
+      expect(harness.state.sessionInfo.responseUsage).toBe("tokens");
+      expect(harness.applySessionInfoFromPatch).not.toHaveBeenCalled();
+      expect(harness.refreshSessionInfo).not.toHaveBeenCalled();
+      expect(harness.addSystem).not.toHaveBeenCalled();
+    },
+  );
+
+  it("applies a model patch after its selected session becomes canonical", async () => {
+    const deferred = createDeferred<{
+      ok: true;
+      path: string;
+      key: string;
+      entry: Record<string, unknown>;
+    }>();
+    const harness = createHarness({
+      currentSessionKey: "main",
+      patchSession: vi.fn(() => deferred.promise),
+    });
+
+    const pending = harness.handleCommand("/model openai/gpt-5.6-luna");
+    harness.state.currentSessionKey = "agent:main:main";
+    const result = {
+      ok: true as const,
+      path: "/sessions/patch",
+      key: "agent:main:main",
+      entry: { model: "gpt-5.6-luna" },
+    };
+    deferred.resolve(result);
+    await pending;
+
+    expect(harness.applySessionInfoFromPatch).toHaveBeenCalledWith(result);
+    expect(harness.refreshSessionInfo).toHaveBeenCalledOnce();
+    expect(harness.addSystem).toHaveBeenCalledWith("model set to openai/gpt-5.6-luna");
+  });
+
+  it("ignores a rejected model patch after switching sessions", async () => {
+    const deferred = createDeferred<never>();
+    const harness = createHarness({
+      currentSessionKey: "agent:main:first",
+      patchSession: vi.fn(() => deferred.promise),
+    });
+
+    const pending = harness.handleCommand("/model openai/gpt-5.6-luna");
+    harness.state.currentSessionKey = "agent:main:second";
+    deferred.reject(new Error("stale model patch"));
+    await pending;
+
+    expect(harness.applySessionInfoFromPatch).not.toHaveBeenCalled();
+    expect(harness.refreshSessionInfo).not.toHaveBeenCalled();
+    expect(harness.addSystem).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    { name: "another session", initialKey: "agent:main:first", nextKey: "agent:main:second" },
+    { name: "another global agent", initialKey: "global", nextKey: "global" },
+  ])("ignores a stale reset after selecting $name", async ({ initialKey, nextKey }) => {
+    const deferred = createDeferred<{
+      ok: true;
+      key: string;
+      entry: { sessionId: string };
+    }>();
+    const harness = createHarness({
+      currentSessionKey: initialKey,
+      currentAgentId: "main",
+      resetSession: vi.fn(() => deferred.promise),
+      applySessionMutationResult: vi.fn().mockReturnValue(true),
+    });
+
+    const pending = harness.handleCommand("/reset");
+    expect(harness.resetSession).toHaveBeenCalledWith(
+      initialKey,
+      "reset",
+      initialKey === "global" ? { agentId: "main" } : undefined,
+    );
+    harness.state.currentSessionKey = nextKey;
+    if (initialKey === "global") {
+      harness.state.currentAgentId = "work";
+    }
+    harness.state.currentSessionId = "second-session";
+    deferred.resolve({
+      ok: true,
+      key: initialKey,
+      entry: { sessionId: "stale-reset-session" },
+    });
+    await pending;
+
+    expect(harness.state.currentSessionKey).toBe(nextKey);
+    expect(harness.state.currentSessionId).toBe("second-session");
+    expect(harness.applySessionMutationResult).not.toHaveBeenCalled();
+    expect(harness.refreshSessionInfo).not.toHaveBeenCalled();
+    expect(harness.loadHistory).not.toHaveBeenCalled();
+    expect(harness.addSystem).not.toHaveBeenCalled();
+  });
+
+  it("ignores a rejected global reset after switching agents", async () => {
+    const deferred = createDeferred<never>();
+    const harness = createHarness({
+      currentSessionKey: "global",
+      currentAgentId: "main",
+      resetSession: vi.fn(() => deferred.promise),
+    });
+
+    const pending = harness.handleCommand("/reset");
+    harness.state.currentAgentId = "work";
+    deferred.reject(new Error("stale global reset"));
+    await pending;
+
+    expect(harness.applySessionMutationResult).not.toHaveBeenCalled();
+    expect(harness.refreshSessionInfo).not.toHaveBeenCalled();
+    expect(harness.loadHistory).not.toHaveBeenCalled();
+    expect(harness.addSystem).not.toHaveBeenCalled();
   });
 
   it("uses the effective runtime for the no-arg /think usage", async () => {
@@ -1809,6 +2047,88 @@ describe("tui command handlers", () => {
     await pending;
 
     expect(openOverlay).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not open a stale model selector after switching sessions", async () => {
+    const deferred = createDeferred<Array<{ provider: string; id: string; name?: string }>>();
+    const harness = createHarness({
+      currentSessionKey: "agent:main:first",
+      listModels: vi.fn(() => deferred.promise),
+    });
+
+    const pending = harness.handleCommand("/models");
+    expect(harness.addSystem).toHaveBeenCalledWith("loading models...");
+    harness.addSystem.mockClear();
+    harness.state.currentSessionKey = "agent:main:second";
+    deferred.resolve([{ provider: "openai", id: "gpt-5.6-luna" }]);
+    await pending;
+
+    expect(harness.openOverlay).not.toHaveBeenCalled();
+    expect(harness.addSystem).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    { name: "another session", initialKey: "agent:main:first", nextKey: "agent:main:second" },
+    { name: "another global agent", initialKey: "global", nextKey: "global" },
+  ])("ignores a model-picker result after selecting $name", async ({ initialKey, nextKey }) => {
+    const deferred = createDeferred<{
+      ok: true;
+      path: string;
+      key: string;
+      entry: Record<string, unknown>;
+    }>();
+    const harness = createHarness({
+      currentSessionKey: initialKey,
+      currentAgentId: "main",
+      listModels: vi.fn().mockResolvedValue([{ provider: "openai", id: "gpt-5.6-luna" }]),
+      patchSession: vi.fn(() => deferred.promise),
+    });
+
+    await harness.handleCommand("/models");
+    const selector = firstMockArg(harness.openOverlay, "openOverlay") as SelectableOverlay;
+    harness.addSystem.mockClear();
+    selector.onSelect?.({ value: "openai/gpt-5.6-luna" });
+    expect(harness.patchSession).toHaveBeenCalledWith({
+      key: initialKey,
+      ...(initialKey === "global" ? { agentId: "main" } : {}),
+      model: "openai/gpt-5.6-luna",
+    });
+    harness.state.currentSessionKey = nextKey;
+    if (initialKey === "global") {
+      harness.state.currentAgentId = "work";
+    }
+    deferred.resolve({
+      ok: true,
+      path: "/sessions/patch",
+      key: initialKey,
+      entry: { model: "stale-model" },
+    });
+    await flushAsyncSelect();
+
+    expect(harness.state.currentSessionKey).toBe(nextKey);
+    expect(harness.applySessionInfoFromPatch).not.toHaveBeenCalled();
+    expect(harness.refreshSessionInfo).not.toHaveBeenCalled();
+    expect(harness.addSystem).not.toHaveBeenCalled();
+  });
+
+  it("does not open a stale session selector after switching agents", async () => {
+    const deferred = createDeferred<{
+      sessions: Array<{ key: string; updatedAt: number }>;
+    }>();
+    const harness = createHarness({
+      currentAgentId: "main",
+      listSessions: vi.fn(() => deferred.promise),
+    });
+
+    const pending = harness.openSessionSelector();
+    harness.state.currentAgentId = "work";
+    deferred.resolve({
+      sessions: [{ key: "agent:main:main", updatedAt: 1 }],
+    });
+    await pending;
+
+    expect(harness.openOverlay).not.toHaveBeenCalled();
+    expect(harness.addSystem).not.toHaveBeenCalled();
   });
 
   it("/usage reset clears the stale local responseUsage after the gateway patch", async () => {

--- a/src/tui/tui-command-handlers.ts
+++ b/src/tui/tui-command-handlers.ts
@@ -18,7 +18,7 @@ import {
 } from "../auto-reply/thinking.js";
 import { isChatStopCommandText } from "../gateway/chat-abort.js";
 import { formatRelativeTimestamp } from "../infra/format-time/format-relative.ts";
-import { normalizeAgentId } from "../routing/session-key.js";
+import { agentSessionKeysMatchByRequestKey, normalizeAgentId } from "../routing/session-key.js";
 import {
   formatTuiLevelCommandUsage,
   helpText,
@@ -75,7 +75,10 @@ type CommandHandlerContext = {
   setActivityStatus: (text: string) => void;
   formatSessionKey: (key: string) => string;
   applySessionInfoFromPatch: (result: SessionsPatchResult) => void;
-  applySessionMutationResult: (result?: TuiSessionMutationResult | null) => boolean;
+  applySessionMutationResult: (
+    result?: TuiSessionMutationResult | null,
+    requestSelection?: { sessionKey: string; agentId: string },
+  ) => boolean;
   noteLocalRunId?: (runId: string) => void;
   noteLocalBtwRunId?: (runId: string) => void;
   forgetLocalRunId?: (runId: string) => void;
@@ -190,10 +193,33 @@ export function createCommandHandlers(context: CommandHandlerContext) {
     return true;
   };
 
-  const currentSessionPatchTarget = () => ({
-    key: state.currentSessionKey,
-    ...(state.currentSessionKey === "global" ? { agentId: state.currentAgentId } : {}),
+  const captureSessionSelection = () => ({
+    sessionKey: state.currentSessionKey,
+    agentId: state.currentAgentId,
   });
+
+  const isCurrentSessionSelection = (selection: { sessionKey: string; agentId: string }) =>
+    state.currentAgentId === selection.agentId &&
+    agentSessionKeysMatchByRequestKey(state.currentSessionKey, selection.sessionKey);
+
+  const patchCurrentSession = async (
+    patch: Omit<Parameters<TuiBackend["patchSession"]>[0], "key" | "agentId">,
+  ): Promise<SessionsPatchResult | null> => {
+    const selection = captureSessionSelection();
+    try {
+      const result = await client.patchSession({
+        key: selection.sessionKey,
+        ...(selection.sessionKey === "global" ? { agentId: selection.agentId } : {}),
+        ...patch,
+      });
+      return isCurrentSessionSelection(selection) ? result : null;
+    } catch (err) {
+      if (!isCurrentSessionSelection(selection)) {
+        return null;
+      }
+      throw err;
+    }
+  };
 
   const openSelector = (
     selector: {
@@ -214,10 +240,14 @@ export function createCommandHandlers(context: CommandHandlerContext) {
   };
 
   const openModelSelector = async () => {
+    const selection = captureSessionSelection();
     try {
       chatLog.addSystem("loading models...");
       tui.requestRender();
       const models = await client.listModels();
+      if (!isCurrentSessionSelection(selection)) {
+        return;
+      }
       if (models.length === 0) {
         chatLog.addSystem("no models available");
         tui.requestRender();
@@ -234,10 +264,10 @@ export function createCommandHandlers(context: CommandHandlerContext) {
       const selector = createSearchableSelectList(items, 9);
       openSelector(selector, async (value) => {
         try {
-          const result = await client.patchSession({
-            ...currentSessionPatchTarget(),
-            model: value,
-          });
+          const result = await patchCurrentSession({ model: value });
+          if (!result) {
+            return;
+          }
           chatLog.addSystem(`model set to ${value}`);
           applySessionInfoFromPatch(result);
           await refreshSessionInfo();
@@ -246,6 +276,9 @@ export function createCommandHandlers(context: CommandHandlerContext) {
         }
       });
     } catch (err) {
+      if (!isCurrentSessionSelection(selection)) {
+        return;
+      }
       chatLog.addSystem(`model list failed: ${String(err)}`);
       tui.requestRender();
     }
@@ -295,6 +328,7 @@ export function createCommandHandlers(context: CommandHandlerContext) {
   };
 
   const openSessionSelector = async () => {
+    const selection = captureSessionSelection();
     try {
       const result = await client.listSessions({
         limit: TUI_SESSION_PICKER_LIMIT,
@@ -303,8 +337,11 @@ export function createCommandHandlers(context: CommandHandlerContext) {
         includeUnknown: false,
         includeDerivedTitles: true,
         includeLastMessage: true,
-        agentId: state.currentAgentId,
+        agentId: selection.agentId,
       });
+      if (!isCurrentSessionSelection(selection)) {
+        return;
+      }
       const items = result.sessions.map((session) => {
         const title = session.derivedTitle ?? session.displayName;
         const formattedKey = formatSessionKey(session.key);
@@ -338,6 +375,9 @@ export function createCommandHandlers(context: CommandHandlerContext) {
         await setSession(value);
       });
     } catch (err) {
+      if (!isCurrentSessionSelection(selection)) {
+        return;
+      }
       chatLog.addSystem(`sessions list failed: ${String(err)}`);
       tui.requestRender();
     }
@@ -536,10 +576,10 @@ export function createCommandHandlers(context: CommandHandlerContext) {
           await openModelSelector();
         } else {
           try {
-            const result = await client.patchSession({
-              ...currentSessionPatchTarget(),
-              model: args,
-            });
+            const result = await patchCurrentSession({ model: args });
+            if (!result) {
+              return;
+            }
             const resolvedModel = result.resolved?.model;
             const resolvedProvider = result.resolved?.modelProvider;
             const resolvedModelRef = resolvedModel
@@ -573,10 +613,10 @@ export function createCommandHandlers(context: CommandHandlerContext) {
           break;
         }
         try {
-          const result = await client.patchSession({
-            ...currentSessionPatchTarget(),
-            thinkingLevel: args,
-          });
+          const result = await patchCurrentSession({ thinkingLevel: args });
+          if (!result) {
+            return;
+          }
           chatLog.addSystem(`thinking set to ${args}`);
           applySessionInfoFromPatch(result);
           await refreshSessionInfo();
@@ -590,10 +630,10 @@ export function createCommandHandlers(context: CommandHandlerContext) {
           break;
         }
         try {
-          const result = await client.patchSession({
-            ...currentSessionPatchTarget(),
-            verboseLevel: args,
-          });
+          const result = await patchCurrentSession({ verboseLevel: args });
+          if (!result) {
+            return;
+          }
           chatLog.addSystem(`verbose set to ${args}`);
           applySessionInfoFromPatch(result);
           if (args === "off") {
@@ -612,10 +652,10 @@ export function createCommandHandlers(context: CommandHandlerContext) {
           break;
         }
         try {
-          const result = await client.patchSession({
-            ...currentSessionPatchTarget(),
-            traceLevel: args,
-          });
+          const result = await patchCurrentSession({ traceLevel: args });
+          if (!result) {
+            return;
+          }
           chatLog.addSystem(`trace set to ${args}`);
           applySessionInfoFromPatch(result);
           await refreshSessionInfo();
@@ -633,10 +673,12 @@ export function createCommandHandlers(context: CommandHandlerContext) {
           break;
         }
         try {
-          const result = await client.patchSession({
-            ...currentSessionPatchTarget(),
+          const result = await patchCurrentSession({
             fastMode: args === "auto" ? "auto" : args === "on",
           });
+          if (!result) {
+            return;
+          }
           chatLog.addSystem(`fast mode set to ${args}`);
           applySessionInfoFromPatch(result);
           await refreshSessionInfo();
@@ -650,10 +692,10 @@ export function createCommandHandlers(context: CommandHandlerContext) {
           break;
         }
         try {
-          const result = await client.patchSession({
-            ...currentSessionPatchTarget(),
-            reasoningLevel: args,
-          });
+          const result = await patchCurrentSession({ reasoningLevel: args });
+          if (!result) {
+            return;
+          }
           chatLog.addSystem(`reasoning set to ${args}`);
           applySessionInfoFromPatch(result);
           await refreshSessionInfo();
@@ -670,10 +712,10 @@ export function createCommandHandlers(context: CommandHandlerContext) {
         }
         if (isReset) {
           try {
-            const result = await client.patchSession({
-              ...currentSessionPatchTarget(),
-              responseUsage: null,
-            });
+            const result = await patchCurrentSession({ responseUsage: null });
+            if (!result) {
+              return;
+            }
             chatLog.addSystem("usage footer: reset to default");
             applySessionInfoFromPatch(result);
             delete state.sessionInfo.responseUsage;
@@ -690,10 +732,10 @@ export function createCommandHandlers(context: CommandHandlerContext) {
         const next =
           normalized ?? (current === "off" ? "tokens" : current === "tokens" ? "full" : "off");
         try {
-          const result = await client.patchSession({
-            ...currentSessionPatchTarget(),
-            responseUsage: next,
-          });
+          const result = await patchCurrentSession({ responseUsage: next });
+          if (!result) {
+            return;
+          }
           chatLog.addSystem(`usage footer: ${next}`);
           applySessionInfoFromPatch(result);
           await refreshSessionInfo();
@@ -712,10 +754,10 @@ export function createCommandHandlers(context: CommandHandlerContext) {
           break;
         }
         try {
-          const result = await client.patchSession({
-            ...currentSessionPatchTarget(),
-            elevatedLevel: args,
-          });
+          const result = await patchCurrentSession({ elevatedLevel: args });
+          if (!result) {
+            return;
+          }
           chatLog.addSystem(`elevated set to ${args}`);
           applySessionInfoFromPatch(result);
           await refreshSessionInfo();
@@ -734,10 +776,10 @@ export function createCommandHandlers(context: CommandHandlerContext) {
           break;
         }
         try {
-          const result = await client.patchSession({
-            ...currentSessionPatchTarget(),
-            groupActivation: activation,
-          });
+          const result = await patchCurrentSession({ groupActivation: activation });
+          if (!result) {
+            return;
+          }
           chatLog.addSystem(`activation set to ${activation}`);
           applySessionInfoFromPatch(result);
           await refreshSessionInfo();
@@ -777,10 +819,12 @@ export function createCommandHandlers(context: CommandHandlerContext) {
           sessionCreationInFlight = false;
         }
         break;
-      case "reset":
+      case "reset": {
         if (rejectUnsafeSessionRollover("reset")) {
           break;
         }
+        const resetSelection = captureSessionSelection();
+        let resetResultSelection = resetSelection;
         try {
           // Clear token counts immediately to avoid stale display (#1523)
           state.sessionInfo.inputTokens = null;
@@ -789,20 +833,33 @@ export function createCommandHandlers(context: CommandHandlerContext) {
           tui.requestRender();
 
           const result = await client.resetSession(
-            state.currentSessionKey,
+            resetSelection.sessionKey,
             name,
-            state.currentSessionKey === "global" ? { agentId: state.currentAgentId } : undefined,
+            resetSelection.sessionKey === "global"
+              ? { agentId: resetSelection.agentId }
+              : undefined,
           );
-          if (applySessionMutationResult(result)) {
+          if (!isCurrentSessionSelection(resetSelection)) {
+            return;
+          }
+          if (applySessionMutationResult(result, resetSelection)) {
+            resetResultSelection = captureSessionSelection();
             await refreshSessionInfo();
           } else {
             await loadHistory();
           }
+          if (!isCurrentSessionSelection(resetResultSelection)) {
+            return;
+          }
           chatLog.addSystem(`session ${state.currentSessionKey} reset`);
         } catch (err) {
+          if (!isCurrentSessionSelection(resetResultSelection)) {
+            return;
+          }
           chatLog.addSystem(`reset failed: ${sanitizeRenderableText(String(err))}`);
         }
         break;
+      }
       case "abort":
         await abortActive();
         break;

--- a/src/tui/tui-event-handlers.test.ts
+++ b/src/tui/tui-event-handlers.test.ts
@@ -357,6 +357,166 @@ describe("tui-event-handlers: handleAgentEvent", () => {
     vi.useRealTimers();
   });
 
+  it("finalizes the authoritative buffered reply when a local run is aborted", () => {
+    const {
+      state,
+      chatLog,
+      loadHistory,
+      noteLocalRunId,
+      isLocalRunId,
+      setActivityStatus,
+      handleChatEvent,
+    } = createHandlersHarness({
+      state: { activeChatRunId: "run-aborted-partial" },
+    });
+    noteLocalRunId("run-aborted-partial");
+
+    handleChatEvent({
+      runId: "run-aborted-partial",
+      sessionKey: state.currentSessionKey,
+      seq: 1,
+      state: "delta",
+      message: {
+        role: "assistant",
+        content: [{ type: "text", text: "Already visible" }],
+      },
+    } satisfies ChatEvent);
+
+    handleChatEvent({
+      runId: "run-aborted-partial",
+      sessionKey: state.currentSessionKey,
+      seq: 2,
+      state: "aborted",
+      message: {
+        role: "assistant",
+        content: [{ type: "text", text: "Already visible and the throttled tail" }],
+      },
+    } satisfies ChatEvent);
+
+    expect(chatLog.updateAssistant).toHaveBeenCalledWith("Already visible", "run-aborted-partial");
+    expect(chatLog.finalizeAssistant).toHaveBeenCalledExactlyOnceWith(
+      "Already visible and the throttled tail",
+      "run-aborted-partial",
+    );
+    expect(chatLog.addSystem).toHaveBeenCalledExactlyOnceWith("run aborted");
+    expect(chatLog.dropAssistant).not.toHaveBeenCalled();
+    expect(loadHistory).not.toHaveBeenCalled();
+    expect(isLocalRunId("run-aborted-partial")).toBe(false);
+    expect(state.activeChatRunId).toBeNull();
+    expect(setActivityStatus).toHaveBeenLastCalledWith("aborted");
+  });
+
+  it("finalizes streamed partial text when an abort has no assistant payload", () => {
+    const { state, chatLog, loadHistory, noteLocalRunId, handleChatEvent } = createHandlersHarness({
+      state: { activeChatRunId: "run-aborted-stream" },
+    });
+    noteLocalRunId("run-aborted-stream");
+
+    handleChatEvent({
+      runId: "run-aborted-stream",
+      sessionKey: state.currentSessionKey,
+      state: "delta",
+      message: {
+        role: "assistant",
+        content: [{ type: "text", text: "Keep the streamed partial" }],
+      },
+    } satisfies ChatEvent);
+
+    handleChatEvent({
+      runId: "run-aborted-stream",
+      sessionKey: state.currentSessionKey,
+      state: "aborted",
+    } satisfies ChatEvent);
+
+    expect(chatLog.finalizeAssistant).toHaveBeenCalledExactlyOnceWith(
+      "Keep the streamed partial",
+      "run-aborted-stream",
+    );
+    expect(chatLog.addSystem).toHaveBeenCalledExactlyOnceWith("run aborted");
+    expect(loadHistory).not.toHaveBeenCalled();
+    expect(state.activeChatRunId).toBeNull();
+  });
+
+  it.each([
+    { name: "the authoritative abort reply", streamText: undefined, finalText: "(no output)" },
+    { name: "a streamed partial reply", streamText: "(no output)", finalText: undefined },
+  ])("preserves literal empty-placeholder text from $name", ({ streamText, finalText }) => {
+    const { state, chatLog, loadHistory, noteLocalRunId, handleChatEvent } = createHandlersHarness({
+      state: { activeChatRunId: "run-aborted-literal" },
+    });
+    noteLocalRunId("run-aborted-literal");
+
+    if (streamText !== undefined) {
+      handleChatEvent({
+        runId: "run-aborted-literal",
+        sessionKey: state.currentSessionKey,
+        state: "delta",
+        message: {
+          role: "assistant",
+          content: [{ type: "text", text: streamText }],
+        },
+      } satisfies ChatEvent);
+    }
+
+    handleChatEvent({
+      runId: "run-aborted-literal",
+      sessionKey: state.currentSessionKey,
+      state: "aborted",
+      ...(finalText === undefined
+        ? {}
+        : {
+            message: {
+              role: "assistant",
+              content: [{ type: "text", text: finalText }],
+            },
+          }),
+    } satisfies ChatEvent);
+
+    expect(chatLog.finalizeAssistant).toHaveBeenCalledExactlyOnceWith(
+      "(no output)",
+      "run-aborted-literal",
+    );
+    expect(chatLog.addSystem).toHaveBeenCalledExactlyOnceWith("run aborted");
+    expect(loadHistory).not.toHaveBeenCalled();
+    expect(state.activeChatRunId).toBeNull();
+  });
+
+  it.each([
+    { name: "missing", message: undefined },
+    { name: "empty", message: { role: "assistant", content: [] } },
+    {
+      name: "thinking-only",
+      message: {
+        role: "assistant",
+        content: [{ type: "thinking", thinking: "hidden reasoning" }],
+      },
+    },
+    {
+      name: "non-text",
+      message: {
+        role: "assistant",
+        content: [{ type: "image", source: { type: "base64", data: "image-data" } }],
+      },
+    },
+  ])("does not create a placeholder for a $name aborted reply", ({ message }) => {
+    const { state, chatLog, loadHistory, noteLocalRunId, handleChatEvent } = createHandlersHarness({
+      state: { activeChatRunId: "run-aborted-empty" },
+    });
+    noteLocalRunId("run-aborted-empty");
+
+    handleChatEvent({
+      runId: "run-aborted-empty",
+      sessionKey: state.currentSessionKey,
+      state: "aborted",
+      message,
+    } satisfies ChatEvent);
+
+    expect(chatLog.finalizeAssistant).not.toHaveBeenCalled();
+    expect(chatLog.addSystem).toHaveBeenCalledExactlyOnceWith("run aborted");
+    expect(loadHistory).not.toHaveBeenCalled();
+    expect(state.activeChatRunId).toBeNull();
+  });
+
   it("appends the tool-error summary to the abort line when present", () => {
     const { state, chatLog, handleChatEvent } = createHandlersHarness({
       state: { activeChatRunId: "run-validation-loop" },

--- a/src/tui/tui-event-handlers.ts
+++ b/src/tui/tui-event-handlers.ts
@@ -345,10 +345,24 @@ export function createEventHandlers(context: EventHandlerContext) {
     if (evt.state === "aborted") {
       forgetLocalBtwRunId?.(evt.runId);
       const wasActiveRun = state.activeChatRunId === evt.runId;
+      // Determine content from the message and stream, not the user-visible
+      // empty placeholder: "(no output)" is also valid assistant text.
+      const hasDisplayableAbortedText =
+        Boolean(
+          extractTextFromMessage(evt.message, { includeThinking: state.showThinking }).trim(),
+        ) || streamAssembler.hasDisplayText(evt.runId);
+      // Abort envelopes carry the complete buffered reply, including text
+      // suppressed by Gateway delta throttling; finalize it before run cleanup.
+      const abortedText = streamAssembler.finalize(evt.runId, evt.message, state.showThinking);
+      if (hasDisplayableAbortedText) {
+        chatLog.finalizeAssistant(abortedText, evt.runId);
+      }
       const diagnostic = formatAbortDiagnostic(evt.errorMessage);
       chatLog.addSystem(diagnostic ? `run aborted: ${diagnostic}` : "run aborted");
       terminateRun({ runId: evt.runId, wasActiveRun, status: "aborted" });
-      maybeRefreshHistoryForRun(evt.runId);
+      maybeRefreshHistoryForRun(evt.runId, {
+        hasDisplayableFinal: hasDisplayableAbortedText,
+      });
     }
     if (evt.state === "error") {
       forgetLocalBtwRunId?.(evt.runId);

--- a/src/tui/tui-pty-harness-fixture-test-support.ts
+++ b/src/tui/tui-pty-harness-fixture-test-support.ts
@@ -1,6 +1,557 @@
 // Keeps fake-terminal test-only logs and opaque-session fixtures independently bounded.
-import { readFile } from "node:fs/promises";
+import { readFile, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
 import { sleep, type PtyRun } from "./tui-pty-test-support.js";
+
+export async function writeTuiPtyFixtureScript(dir: string) {
+  // Temp files sit outside the repo package scope; .mts preserves the ESM contract under tsx.
+  const scriptPath = path.join(dir, "run-tui-pty-fixture.mts");
+  const tuiModuleUrl = pathToFileURL(path.join(process.cwd(), "src/tui/tui.ts")).href;
+  const payloadsModuleUrl = pathToFileURL(
+    path.join(process.cwd(), "src/agents/embedded-agent-runner/run/payloads.ts"),
+  ).href;
+  const replyPayloadModuleUrl = pathToFileURL(
+    path.join(process.cwd(), "src/auto-reply/reply-payload.ts"),
+  ).href;
+  const outboundPayloadsModuleUrl = pathToFileURL(
+    path.join(process.cwd(), "src/infra/outbound/payloads.ts"),
+  ).href;
+  await writeFile(
+    scriptPath,
+    `
+      import { appendFileSync } from "node:fs";
+      import { buildEmbeddedRunPayloads } from ${JSON.stringify(payloadsModuleUrl)};
+      import { getReplyPayloadMetadata } from ${JSON.stringify(replyPayloadModuleUrl)};
+      import { normalizeReplyPayloadsForDelivery } from ${JSON.stringify(outboundPayloadsModuleUrl)};
+      import type { TuiBackend } from ${JSON.stringify(tuiModuleUrl.replace("/tui.ts", "/tui-backend.ts"))};
+      import { runTui } from ${JSON.stringify(tuiModuleUrl)};
+
+      const actionLogPath = process.env.OPENCLAW_TUI_PTY_LOG_PATH;
+      const gatewayStatus = process.env.OPENCLAW_TUI_PTY_GATEWAY_STATUS ?? "fixture gateway ok";
+      const startupDelayMs = Number(process.env.OPENCLAW_TUI_PTY_STARTUP_DELAY_MS ?? 0);
+      const footerModel = process.env.OPENCLAW_TUI_PTY_MODEL;
+      const footerThinkingLevel = process.env.OPENCLAW_TUI_PTY_THINKING_LEVEL;
+      const launchThinkingLevel = process.env.OPENCLAW_TUI_PTY_LAUNCH_THINKING;
+      const initialMessage = process.env.OPENCLAW_TUI_PTY_INITIAL_MESSAGE;
+      const enablePickerFixture = process.env.OPENCLAW_TUI_PTY_PICKER_FIXTURE === "1";
+      const xaiLimitError = '403 {"code":"The caller does not have permission to execute the specified operation","error":"Your team team-redacted has either used all available credits or reached its monthly spending limit. To continue making API requests, please purchase more credits or raise your spending limit."}';
+      let currentModel = footerModel ?? "fixture-provider/fixture-model";
+      let currentThinkingLevel = footerThinkingLevel;
+      let fastMode = process.env.OPENCLAW_TUI_PTY_FAST_MODE === "true";
+      let pendingPluginApproval: {
+        id: string;
+        request: {
+          title: string;
+          description: string;
+          toolName: string;
+          allowedDecisions: string[];
+          sessionKey: string;
+        };
+        createdAtMs: number;
+        expiresAtMs: number;
+      } | null = null;
+      let pendingPluginApprovalRun: { runId: string; sessionKey: string } | null = null;
+      let pendingTaskSuggestion: {
+        id: string;
+        title: string;
+        prompt: string;
+        tldr: string;
+        cwd: string;
+        sessionKey: string;
+        agentId: string;
+        createdAt: number;
+      } | null = null;
+
+      function record(method: string, payload?: unknown) {
+        if (!actionLogPath) {
+          return;
+        }
+        appendFileSync(actionLogPath, JSON.stringify({ method, payload }) + "\\n", "utf8");
+      }
+
+      function sessionEntry(key = "main") {
+        return {
+          key,
+          displayName: "Main",
+          model: currentModel,
+          modelProvider: "fixture-provider",
+          contextTokens: 128,
+          fastMode,
+          ...(currentThinkingLevel ? { thinkingLevel: currentThinkingLevel } : {}),
+          thinkingLevels: [],
+        };
+      }
+
+      function assistantMessageFromSourceReplyPayloads(payloads: ReturnType<typeof buildEmbeddedRunPayloads>) {
+        if (payloads.length === 0) {
+          throw new Error("expected source reply payload");
+        }
+        for (const payload of payloads) {
+          const metadata = getReplyPayloadMetadata(payload);
+          if (!metadata?.sourceReplyTranscriptMirror) {
+            throw new Error("expected source reply transcript mirror metadata");
+          }
+          record("sourceReplyMetadata", metadata.sourceReplyTranscriptMirror);
+        }
+        const normalized = normalizeReplyPayloadsForDelivery(payloads);
+        const content = normalized.flatMap((payload) => {
+          const text = payload.text?.trim();
+          return text ? [{ type: "text", text }] : [];
+        });
+        if (content.length === 0) {
+          throw new Error("expected displayable source reply content");
+        }
+        return {
+          role: "assistant",
+          content,
+          timestamp: Date.now(),
+        };
+      }
+
+      class FixtureBackend implements TuiBackend {
+        connection = { url: "pty-fixture://local" };
+        onEvent?: TuiBackend["onEvent"];
+        onConnected?: TuiBackend["onConnected"];
+        onDisconnected?: TuiBackend["onDisconnected"];
+        onGap?: TuiBackend["onGap"];
+
+        start() {
+          queueMicrotask(() => this.onConnected?.());
+        }
+
+        stop() {
+          record("stop");
+        }
+
+        async sendChat(opts: Parameters<TuiBackend["sendChat"]>[0]) {
+          record("sendChat", {
+            sessionKey: opts.sessionKey,
+            message: opts.message,
+            deliver: opts.deliver,
+            thinking: opts.thinking,
+          });
+          const runId = opts.runId ?? "run-pty-fixture";
+          if (opts.message === "/btw picker focus proof") {
+            queueMicrotask(() => {
+              record("pickerSideResult", { runId, sessionKey: opts.sessionKey });
+              this.onEvent?.({
+                event: "chat.side_result",
+                payload: {
+                  kind: "btw",
+                  runId,
+                  sessionKey: opts.sessionKey,
+                  question: "picker focus proof",
+                  text: "PTY_SIDE_OK",
+                },
+              });
+              this.onEvent?.({
+                event: "chat",
+                payload: { runId, sessionKey: opts.sessionKey, state: "final" },
+              });
+            });
+            return { runId };
+          }
+          if (opts.message === "cross-session abort source proof") {
+            for (const [delayMs, state, text] of [
+              [100, "delta", "PTY_LATE_FOREIGN_DELTA"],
+              [130, "final", "PTY_LATE_FOREIGN_FINAL"],
+            ] as const) {
+              setTimeout(() => {
+                record("lateSessionEvent", { sessionKey: opts.sessionKey, state });
+                this.onEvent?.({
+                  event: "chat",
+                  payload: {
+                    runId,
+                    sessionKey: opts.sessionKey,
+                    state,
+                    message: {
+                      role: "assistant",
+                      content: [{ type: "text", text }],
+                      timestamp: Date.now(),
+                    },
+                  },
+                });
+              }, delayMs);
+            }
+            return { runId };
+          }
+          if (opts.message === "burst streaming proof") {
+            const tokens = Array.from({ length: 128 }, (_, index) =>
+              "T" + String(index).padStart(3, "0"),
+            );
+            setTimeout(() => {
+              for (let index = 0; index < tokens.length; index += 1) {
+                this.onEvent?.({
+                  event: "chat",
+                  payload: {
+                    runId,
+                    sessionKey: opts.sessionKey,
+                    state: "delta",
+                    message: {
+                      role: "assistant",
+                      content: [
+                        {
+                          type: "text",
+                          text: "PTY_STREAM_BURST: " + tokens.slice(0, index + 1).join(" "),
+                        },
+                      ],
+                      timestamp: Date.now(),
+                    },
+                  },
+                });
+              }
+              this.onEvent?.({
+                event: "chat",
+                payload: {
+                  runId,
+                  sessionKey: opts.sessionKey,
+                  state: "final",
+                  message: {
+                    role: "assistant",
+                    content: [
+                      { type: "text", text: "PTY_STREAM_BURST: " + tokens.join(" ") },
+                    ],
+                    timestamp: Date.now(),
+                  },
+                },
+              });
+              record("streamBurstComplete", { count: tokens.length });
+            }, 0);
+            return { runId };
+          }
+          if (opts.message === "skill approval proof" || opts.message === "skill approval gap proof") {
+            pendingPluginApproval = {
+              id: "plugin:skill-pty",
+              request: {
+                title: "Apply workspace skill proposal",
+                description: "Apply a pending workspace skill proposal into live workspace skills.",
+                pluginId: "workspace-skills",
+                severity: "warning",
+                toolName: "skill_workshop",
+                allowedDecisions: ["allow-once", "deny"],
+                sessionKey: opts.sessionKey,
+              },
+              createdAtMs: Date.now(),
+              expiresAtMs: Date.now() + 120_000,
+            };
+            pendingPluginApprovalRun = { runId, sessionKey: opts.sessionKey };
+            queueMicrotask(() => {
+              if (opts.message === "skill approval gap proof") {
+                this.onGap?.({ expected: 4, received: 5 });
+              } else {
+                this.onEvent?.({
+                  event: "plugin.approval.requested",
+                  payload: pendingPluginApproval,
+                });
+              }
+            });
+            return { runId };
+          }
+          if (opts.message === "task suggestion proof") {
+            pendingTaskSuggestion = {
+              id: "task_pty",
+              title: "Remove stale adapter",
+              prompt: "Delete the stale adapter and update its tests.",
+              tldr: "The adapter is unreachable and adds maintenance cost.",
+              cwd: "/repo/project",
+              sessionKey: opts.sessionKey,
+              agentId: "main",
+              createdAt: Date.now(),
+            };
+            queueMicrotask(() => {
+              this.onEvent?.({
+                event: "task.suggestion",
+                payload: { action: "created", suggestion: pendingTaskSuggestion },
+              });
+            });
+            return { runId };
+          }
+          ${buildOpaqueSessionIsolationFixture()}
+          const responseDelayMs =
+            opts.message === "slow prompt" ||
+            opts.message === "slow reset proof" ||
+            opts.message === "streaming prompt"
+              ? 500
+              : 20;
+          if (opts.message === "streaming prompt") {
+            setTimeout(() => {
+              this.onEvent?.({
+                event: "chat",
+                payload: {
+                  runId,
+                  sessionKey: opts.sessionKey,
+                  state: "delta",
+                  message: {
+                    role: "assistant",
+                    content: [{ type: "text", text: "PTY_STREAMING: streaming prompt" }],
+                    timestamp: Date.now(),
+                  },
+                },
+              });
+            }, 5);
+          }
+          const isSourceReplyProof = opts.message === "message tool only source reply proof";
+          const isXaiLimitProof = opts.message === "xai limit proof";
+          setTimeout(() => {
+            if (isXaiLimitProof) {
+              this.onEvent?.({
+                event: "chat",
+                payload: {
+                  runId,
+                  sessionKey: opts.sessionKey,
+                  state: "error",
+                  errorMessage: xaiLimitError,
+                },
+              });
+              return;
+            }
+            const sourceReplyPayloads = isSourceReplyProof
+              ? buildEmbeddedRunPayloads({
+                  assistantTexts: [],
+                  toolMetas: [],
+                  lastAssistant: undefined,
+                  inlineToolResultsAllowed: false,
+                  sessionKey: opts.sessionKey,
+                  sourceReplyDeliveryMode: "message_tool_only",
+                  messagingToolSourceReplyPayloads: [
+                    {
+                      text: "VISIBLE_TUI_SOURCE_REPLY_PROOF",
+                    },
+                  ],
+                  runId,
+                })
+              : [];
+            const message = isSourceReplyProof
+              ? assistantMessageFromSourceReplyPayloads(sourceReplyPayloads)
+              : {
+                  role: "assistant",
+                  content: [{ type: "text", text: "PTY_RESPONSE: " + opts.message }],
+                  timestamp: Date.now(),
+                };
+            this.onEvent?.({
+              event: "chat",
+              payload: {
+                runId,
+                sessionKey: opts.sessionKey,
+                state: "final",
+                message,
+              },
+            });
+          }, responseDelayMs);
+          return { runId };
+        }
+
+        async abortChat(opts: Parameters<TuiBackend["abortChat"]>[0]) {
+          record("abortChat", opts);
+          if (opts.sessionKey.endsWith(":abort-source")) {
+            await new Promise((resolve) => setTimeout(resolve, 80));
+            record("abortResolved", { sessionKey: opts.sessionKey });
+          }
+          return { ok: true, aborted: true };
+        }
+
+        async loadHistory(opts: Parameters<TuiBackend["loadHistory"]>[0]) {
+          const sessionKey = opts?.sessionKey ?? "main";
+          record("loadHistory", { sessionKey });
+          const rapidSwitchMarker = sessionKey.endsWith("switch-a")
+            ? "A"
+            : sessionKey.endsWith("switch-b")
+              ? "B"
+              : null;
+          const delayMs =
+            rapidSwitchMarker === "A" ? 500 : rapidSwitchMarker === "B" ? 40 : startupDelayMs;
+          if (delayMs > 0) {
+            await new Promise((resolve) => setTimeout(resolve, delayMs));
+          }
+          if (rapidSwitchMarker) {
+            record("loadHistoryResolved", { sessionKey });
+            return {
+              sessionId: "session-" + rapidSwitchMarker,
+              sessionInfo: {
+                key: sessionKey,
+                sessionId: "session-" + rapidSwitchMarker,
+                model: currentModel,
+                modelProvider: "fixture-provider",
+                contextTokens: 128,
+                fastMode,
+                thinkingLevels: [],
+              },
+              messages: [{ role: "user", content: rapidSwitchMarker + "_HISTORY_MARKER" }],
+            };
+          }
+          return {
+            messages: [],
+            fastMode,
+            ...(footerModel
+              ? {
+                  thinkingLevel: footerThinkingLevel,
+                  sessionInfo: sessionEntry(sessionKey),
+                }
+              : {}),
+          };
+        }
+
+        async listSessions(opts?: Parameters<TuiBackend["listSessions"]>[0]) {
+          record("listSessions", {
+            purpose: opts?.includeDerivedTitles ? "picker" : "refresh",
+          });
+          const sessions = enablePickerFixture
+            ? [sessionEntry("main"), { ...sessionEntry("agent:main:picker-target"), displayName: "Picker target" }]
+            : [];
+          return {
+            ts: Date.now(),
+            path: "",
+            count: sessions.length,
+            sessions,
+            defaults: {
+              model: currentModel,
+              modelProvider: "fixture-provider",
+              contextTokens: 128,
+              thinkingLevels: [],
+            },
+          };
+        }
+
+        async listAgents() {
+          return {
+            defaultId: "main",
+            mainKey: "main",
+            scope: "per-sender",
+            agents: [{ id: "main", name: "Main" }],
+          };
+        }
+
+        async patchSession(opts: Parameters<TuiBackend["patchSession"]>[0]) {
+          record("patchSession", opts);
+          if (opts.model) {
+            currentModel = opts.model;
+          }
+          if (opts.thinkingLevel) {
+            currentThinkingLevel = opts.thinkingLevel;
+          }
+          if (typeof opts.fastMode === "boolean") {
+            fastMode = opts.fastMode;
+          }
+          return {
+            ok: true,
+            path: "",
+            key: opts.key,
+            entry: sessionEntry(opts.key),
+            resolved: {
+              modelProvider: "fixture-provider",
+              model: currentModel,
+            },
+          };
+        }
+
+        async createSession(opts: Parameters<TuiBackend["createSession"]>[0]) {
+          record("createSession", opts);
+          const key = "agent:main:" + opts.key;
+          return { ok: true, key, entry: { ...sessionEntry(key), sessionId: "created-session" } };
+        }
+
+        async resetSession(key: string, reason?: "new" | "reset") {
+          record("resetSession", { key, reason });
+          return {};
+        }
+
+        async getGatewayStatus() {
+          record("getGatewayStatus");
+          return gatewayStatus;
+        }
+
+        async listModels() {
+          record("listModels");
+          return [
+            { id: "fixture-provider/fixture-model", name: "Fixture", provider: "fixture-provider" },
+            { id: "fixture-provider/fixture-model-2", name: "Fixture 2", provider: "fixture-provider" },
+          ];
+        }
+
+        async listPluginApprovals() {
+          record("listPluginApprovals", { pending: Boolean(pendingPluginApproval) });
+          return pendingPluginApproval ? [pendingPluginApproval] : [];
+        }
+
+        async resolvePluginApproval(id: string, decision: "allow-once" | "allow-always" | "deny") {
+          record("resolvePluginApproval", { id, decision });
+          const pendingRun = pendingPluginApprovalRun;
+          pendingPluginApproval = null;
+          pendingPluginApprovalRun = null;
+          this.onEvent?.({
+            event: "plugin.approval.resolved",
+            payload: { id, decision },
+          });
+          this.onEvent?.({
+            event: "chat",
+            payload: {
+              runId: pendingRun?.runId ?? "run-pty-fixture",
+              sessionKey: pendingRun?.sessionKey ?? "agent:main:main",
+              state: "final",
+              message: {
+                role: "assistant",
+                content: [{ type: "text", text: "PTY_SKILL_APPROVAL_RESOLVED: " + decision }],
+                timestamp: Date.now(),
+              },
+            },
+          });
+          return { ok: true };
+        }
+
+        async listTaskSuggestions() {
+          record("listTaskSuggestions", { pending: Boolean(pendingTaskSuggestion) });
+          return pendingTaskSuggestion ? [pendingTaskSuggestion] : [];
+        }
+
+        async acceptTaskSuggestion(taskId: string) {
+          record("acceptTaskSuggestion", { taskId });
+          pendingTaskSuggestion = null;
+          this.onEvent?.({
+            event: "task.suggestion",
+            payload: { action: "resolved", taskId, resolution: "accepted" },
+          });
+          return { taskId, key: "agent:main:task-pty" };
+        }
+
+        async dismissTaskSuggestion(taskId: string) {
+          record("dismissTaskSuggestion", { taskId });
+          pendingTaskSuggestion = null;
+          this.onEvent?.({
+            event: "task.suggestion",
+            payload: { action: "resolved", taskId, resolution: "dismissed" },
+          });
+          return { taskId, dismissed: true };
+        }
+      }
+
+      async function main() {
+        await runTui({
+          backend: new FixtureBackend(),
+          config: {
+            agents: {
+              defaults: { model: "fixture-provider/fixture-model" },
+              entries: { main: { default: true } },
+            },
+            session: { scope: "per-sender", mainKey: "main" },
+          },
+          deliver: false,
+          thinking: launchThinkingLevel,
+          message: initialMessage,
+          historyLimit: 5,
+          title: "openclaw tui pty fixture",
+        });
+      }
+
+      main().catch((error) => {
+        console.error(error);
+        process.exitCode = 1;
+      });
+    `,
+    "utf8",
+  );
+  return scriptPath;
+}
 
 export type FixtureLogEntry = {
   method: string;
@@ -112,7 +663,7 @@ export async function approveWorkspaceSkill(
   await fixture.run.waitForOutput("PTY_SKILL_APPROVAL_RESOLVED: allow-once");
 }
 
-export function buildOpaqueSessionIsolationFixture(): string {
+function buildOpaqueSessionIsolationFixture(): string {
   return `
           if (opts.message.startsWith("opaque session isolation proof: ")) {
             const otherSessionKey = opts.sessionKey.includes(":matrix:")

--- a/src/tui/tui-pty-harness.e2e.test.ts
+++ b/src/tui/tui-pty-harness.e2e.test.ts
@@ -1,17 +1,16 @@
 // Exercises the fake-backend TUI PTY harness and visible terminal output.
-import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
-import { pathToFileURL } from "node:url";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import {
   approveWorkspaceSkill,
-  buildOpaqueSessionIsolationFixture,
   COMPACT_TERMINAL_SIZES,
   exerciseFragmentedUnicodePrompt,
   objectFieldEquals,
   readFixtureLog,
   waitForFixtureLogEntry,
+  writeTuiPtyFixtureScript,
   type FixtureLogEntry,
 } from "./tui-pty-harness-fixture-test-support.js";
 import { sleep, startPty, type PtyRun } from "./tui-pty-test-support.js";
@@ -22,453 +21,6 @@ const OUTPUT_TIMEOUT_MS = 2_000;
 const EXIT_TIMEOUT_MS = 4_000;
 const TEST_TIMEOUT_MS = 5_000;
 const STARTUP_TEST_TIMEOUT_MS = 25_000;
-
-async function writeTuiPtyFixtureScript(dir: string) {
-  // Temp files sit outside the repo package scope; .mts preserves the ESM contract under tsx.
-  const scriptPath = path.join(dir, "run-tui-pty-fixture.mts");
-  const tuiModuleUrl = pathToFileURL(path.join(process.cwd(), "src/tui/tui.ts")).href;
-  const payloadsModuleUrl = pathToFileURL(
-    path.join(process.cwd(), "src/agents/embedded-agent-runner/run/payloads.ts"),
-  ).href;
-  const replyPayloadModuleUrl = pathToFileURL(
-    path.join(process.cwd(), "src/auto-reply/reply-payload.ts"),
-  ).href;
-  const outboundPayloadsModuleUrl = pathToFileURL(
-    path.join(process.cwd(), "src/infra/outbound/payloads.ts"),
-  ).href;
-  await writeFile(
-    scriptPath,
-    `
-      import { appendFileSync } from "node:fs";
-      import { buildEmbeddedRunPayloads } from ${JSON.stringify(payloadsModuleUrl)};
-      import { getReplyPayloadMetadata } from ${JSON.stringify(replyPayloadModuleUrl)};
-      import { normalizeReplyPayloadsForDelivery } from ${JSON.stringify(outboundPayloadsModuleUrl)};
-      import type { TuiBackend } from ${JSON.stringify(tuiModuleUrl.replace("/tui.ts", "/tui-backend.ts"))};
-      import { runTui } from ${JSON.stringify(tuiModuleUrl)};
-
-      const actionLogPath = process.env.OPENCLAW_TUI_PTY_LOG_PATH;
-      const gatewayStatus = process.env.OPENCLAW_TUI_PTY_GATEWAY_STATUS ?? "fixture gateway ok";
-      const startupDelayMs = Number(process.env.OPENCLAW_TUI_PTY_STARTUP_DELAY_MS ?? 0);
-      const footerModel = process.env.OPENCLAW_TUI_PTY_MODEL;
-      const footerThinkingLevel = process.env.OPENCLAW_TUI_PTY_THINKING_LEVEL;
-      const launchThinkingLevel = process.env.OPENCLAW_TUI_PTY_LAUNCH_THINKING;
-      const initialMessage = process.env.OPENCLAW_TUI_PTY_INITIAL_MESSAGE;
-      const xaiLimitError = '403 {"code":"The caller does not have permission to execute the specified operation","error":"Your team team-redacted has either used all available credits or reached its monthly spending limit. To continue making API requests, please purchase more credits or raise your spending limit."}';
-      let currentModel = footerModel ?? "fixture-provider/fixture-model";
-      let currentThinkingLevel = footerThinkingLevel;
-      let fastMode = process.env.OPENCLAW_TUI_PTY_FAST_MODE === "true";
-      let pendingPluginApproval: {
-        id: string;
-        request: {
-          title: string;
-          description: string;
-          toolName: string;
-          allowedDecisions: string[];
-          sessionKey: string;
-        };
-        createdAtMs: number;
-        expiresAtMs: number;
-      } | null = null;
-      let pendingPluginApprovalRun: { runId: string; sessionKey: string } | null = null;
-      let pendingTaskSuggestion: {
-        id: string;
-        title: string;
-        prompt: string;
-        tldr: string;
-        cwd: string;
-        sessionKey: string;
-        agentId: string;
-        createdAt: number;
-      } | null = null;
-
-      function record(method: string, payload?: unknown) {
-        if (!actionLogPath) {
-          return;
-        }
-        appendFileSync(actionLogPath, JSON.stringify({ method, payload }) + "\\n", "utf8");
-      }
-
-      function sessionEntry(key = "main") {
-        return {
-          key,
-          displayName: "Main",
-          model: currentModel,
-          modelProvider: "fixture-provider",
-          contextTokens: 128,
-          fastMode,
-          ...(currentThinkingLevel ? { thinkingLevel: currentThinkingLevel } : {}),
-          thinkingLevels: [],
-        };
-      }
-
-      function assistantMessageFromSourceReplyPayloads(payloads: ReturnType<typeof buildEmbeddedRunPayloads>) {
-        if (payloads.length === 0) {
-          throw new Error("expected source reply payload");
-        }
-        for (const payload of payloads) {
-          const metadata = getReplyPayloadMetadata(payload);
-          if (!metadata?.sourceReplyTranscriptMirror) {
-            throw new Error("expected source reply transcript mirror metadata");
-          }
-          record("sourceReplyMetadata", metadata.sourceReplyTranscriptMirror);
-        }
-        const normalized = normalizeReplyPayloadsForDelivery(payloads);
-        const content = normalized.flatMap((payload) => {
-          const text = payload.text?.trim();
-          return text ? [{ type: "text", text }] : [];
-        });
-        if (content.length === 0) {
-          throw new Error("expected displayable source reply content");
-        }
-        return {
-          role: "assistant",
-          content,
-          timestamp: Date.now(),
-        };
-      }
-
-      class FixtureBackend implements TuiBackend {
-        connection = { url: "pty-fixture://local" };
-        onEvent?: TuiBackend["onEvent"];
-        onConnected?: TuiBackend["onConnected"];
-        onDisconnected?: TuiBackend["onDisconnected"];
-        onGap?: TuiBackend["onGap"];
-
-        start() {
-          queueMicrotask(() => this.onConnected?.());
-        }
-
-        stop() {}
-
-        async sendChat(opts: Parameters<TuiBackend["sendChat"]>[0]) {
-          record("sendChat", {
-            sessionKey: opts.sessionKey,
-            message: opts.message,
-            deliver: opts.deliver,
-            thinking: opts.thinking,
-          });
-          const runId = opts.runId ?? "run-pty-fixture";
-          if (opts.message === "skill approval proof" || opts.message === "skill approval gap proof") {
-            pendingPluginApproval = {
-              id: "plugin:skill-pty",
-              request: {
-                title: "Apply workspace skill proposal",
-                description: "Apply a pending workspace skill proposal into live workspace skills.",
-                pluginId: "workspace-skills",
-                severity: "warning",
-                toolName: "skill_workshop",
-                allowedDecisions: ["allow-once", "deny"],
-                sessionKey: opts.sessionKey,
-              },
-              createdAtMs: Date.now(),
-              expiresAtMs: Date.now() + 120_000,
-            };
-            pendingPluginApprovalRun = { runId, sessionKey: opts.sessionKey };
-            queueMicrotask(() => {
-              if (opts.message === "skill approval gap proof") {
-                this.onGap?.({ expected: 4, received: 5 });
-              } else {
-                this.onEvent?.({
-                  event: "plugin.approval.requested",
-                  payload: pendingPluginApproval,
-                });
-              }
-            });
-            return { runId };
-          }
-          if (opts.message === "task suggestion proof") {
-            pendingTaskSuggestion = {
-              id: "task_pty",
-              title: "Remove stale adapter",
-              prompt: "Delete the stale adapter and update its tests.",
-              tldr: "The adapter is unreachable and adds maintenance cost.",
-              cwd: "/repo/project",
-              sessionKey: opts.sessionKey,
-              agentId: "main",
-              createdAt: Date.now(),
-            };
-            queueMicrotask(() => {
-              this.onEvent?.({
-                event: "task.suggestion",
-                payload: { action: "created", suggestion: pendingTaskSuggestion },
-              });
-            });
-            return { runId };
-          }
-          ${buildOpaqueSessionIsolationFixture()}
-          const responseDelayMs =
-            opts.message === "slow prompt" ||
-            opts.message === "slow reset proof" ||
-            opts.message === "streaming prompt"
-              ? 500
-              : 20;
-          if (opts.message === "streaming prompt") {
-            setTimeout(() => {
-              this.onEvent?.({
-                event: "chat",
-                payload: {
-                  runId,
-                  sessionKey: opts.sessionKey,
-                  state: "delta",
-                  message: {
-                    role: "assistant",
-                    content: [{ type: "text", text: "PTY_STREAMING: streaming prompt" }],
-                    timestamp: Date.now(),
-                  },
-                },
-              });
-            }, 5);
-          }
-          const isSourceReplyProof = opts.message === "message tool only source reply proof";
-          const isXaiLimitProof = opts.message === "xai limit proof";
-          setTimeout(() => {
-            if (isXaiLimitProof) {
-              this.onEvent?.({
-                event: "chat",
-                payload: {
-                  runId,
-                  sessionKey: opts.sessionKey,
-                  state: "error",
-                  errorMessage: xaiLimitError,
-                },
-              });
-              return;
-            }
-            const sourceReplyPayloads = isSourceReplyProof
-              ? buildEmbeddedRunPayloads({
-                  assistantTexts: [],
-                  toolMetas: [],
-                  lastAssistant: undefined,
-                  inlineToolResultsAllowed: false,
-                  sessionKey: opts.sessionKey,
-                  sourceReplyDeliveryMode: "message_tool_only",
-                  messagingToolSourceReplyPayloads: [
-                    {
-                      text: "VISIBLE_TUI_SOURCE_REPLY_PROOF",
-                    },
-                  ],
-                  runId,
-                })
-              : [];
-            const message = isSourceReplyProof
-              ? assistantMessageFromSourceReplyPayloads(sourceReplyPayloads)
-              : {
-                  role: "assistant",
-                  content: [{ type: "text", text: "PTY_RESPONSE: " + opts.message }],
-                  timestamp: Date.now(),
-                };
-            this.onEvent?.({
-              event: "chat",
-              payload: {
-                runId,
-                sessionKey: opts.sessionKey,
-                state: "final",
-                message,
-              },
-            });
-          }, responseDelayMs);
-          return { runId };
-        }
-
-        async abortChat() {
-          record("abortChat");
-          return { ok: true, aborted: true };
-        }
-
-        async loadHistory(opts: Parameters<TuiBackend["loadHistory"]>[0]) {
-          const sessionKey = opts?.sessionKey ?? "main";
-          record("loadHistory", { sessionKey });
-          const rapidSwitchMarker = sessionKey.endsWith("switch-a")
-            ? "A"
-            : sessionKey.endsWith("switch-b")
-              ? "B"
-              : null;
-          const delayMs =
-            rapidSwitchMarker === "A" ? 500 : rapidSwitchMarker === "B" ? 40 : startupDelayMs;
-          if (delayMs > 0) {
-            await new Promise((resolve) => setTimeout(resolve, delayMs));
-          }
-          if (rapidSwitchMarker) {
-            record("loadHistoryResolved", { sessionKey });
-            return {
-              sessionId: "session-" + rapidSwitchMarker,
-              sessionInfo: {
-                key: sessionKey,
-                sessionId: "session-" + rapidSwitchMarker,
-                model: currentModel,
-                modelProvider: "fixture-provider",
-                contextTokens: 128,
-                fastMode,
-                thinkingLevels: [],
-              },
-              messages: [{ role: "user", content: rapidSwitchMarker + "_HISTORY_MARKER" }],
-            };
-          }
-          return {
-            messages: [],
-            fastMode,
-            ...(footerModel
-              ? {
-                  thinkingLevel: footerThinkingLevel,
-                  sessionInfo: sessionEntry(sessionKey),
-                }
-              : {}),
-          };
-        }
-
-        async listSessions() {
-          return {
-            ts: Date.now(),
-            path: "",
-            count: 0,
-            sessions: [],
-            defaults: {
-              model: currentModel,
-              modelProvider: "fixture-provider",
-              contextTokens: 128,
-              thinkingLevels: [],
-            },
-          };
-        }
-
-        async listAgents() {
-          return {
-            defaultId: "main",
-            mainKey: "main",
-            scope: "per-sender",
-            agents: [{ id: "main", name: "Main" }],
-          };
-        }
-
-        async patchSession(opts: Parameters<TuiBackend["patchSession"]>[0]) {
-          record("patchSession", opts);
-          if (opts.model) {
-            currentModel = opts.model;
-          }
-          if (opts.thinkingLevel) {
-            currentThinkingLevel = opts.thinkingLevel;
-          }
-          if (typeof opts.fastMode === "boolean") {
-            fastMode = opts.fastMode;
-          }
-          return {
-            ok: true,
-            path: "",
-            key: opts.key,
-            entry: sessionEntry(opts.key),
-            resolved: {
-              modelProvider: "fixture-provider",
-              model: currentModel,
-            },
-          };
-        }
-
-        async createSession(opts: Parameters<TuiBackend["createSession"]>[0]) {
-          record("createSession", opts);
-          const key = "agent:main:" + opts.key;
-          return { ok: true, key, entry: { ...sessionEntry(key), sessionId: "created-session" } };
-        }
-
-        async resetSession(key: string, reason?: "new" | "reset") {
-          record("resetSession", { key, reason });
-          return {};
-        }
-
-        async getGatewayStatus() {
-          record("getGatewayStatus");
-          return gatewayStatus;
-        }
-
-        async listModels() {
-          return [
-            { id: "fixture-provider/fixture-model", name: "Fixture", provider: "fixture-provider" },
-            { id: "fixture-provider/fixture-model-2", name: "Fixture 2", provider: "fixture-provider" },
-          ];
-        }
-
-        async listPluginApprovals() {
-          record("listPluginApprovals", { pending: Boolean(pendingPluginApproval) });
-          return pendingPluginApproval ? [pendingPluginApproval] : [];
-        }
-
-        async resolvePluginApproval(id: string, decision: "allow-once" | "allow-always" | "deny") {
-          record("resolvePluginApproval", { id, decision });
-          const pendingRun = pendingPluginApprovalRun;
-          pendingPluginApproval = null;
-          pendingPluginApprovalRun = null;
-          this.onEvent?.({
-            event: "plugin.approval.resolved",
-            payload: { id, decision },
-          });
-          this.onEvent?.({
-            event: "chat",
-            payload: {
-              runId: pendingRun?.runId ?? "run-pty-fixture",
-              sessionKey: pendingRun?.sessionKey ?? "agent:main:main",
-              state: "final",
-              message: {
-                role: "assistant",
-                content: [{ type: "text", text: "PTY_SKILL_APPROVAL_RESOLVED: " + decision }],
-                timestamp: Date.now(),
-              },
-            },
-          });
-          return { ok: true };
-        }
-
-        async listTaskSuggestions() {
-          record("listTaskSuggestions", { pending: Boolean(pendingTaskSuggestion) });
-          return pendingTaskSuggestion ? [pendingTaskSuggestion] : [];
-        }
-
-        async acceptTaskSuggestion(taskId: string) {
-          record("acceptTaskSuggestion", { taskId });
-          pendingTaskSuggestion = null;
-          this.onEvent?.({
-            event: "task.suggestion",
-            payload: { action: "resolved", taskId, resolution: "accepted" },
-          });
-          return { taskId, key: "agent:main:task-pty" };
-        }
-
-        async dismissTaskSuggestion(taskId: string) {
-          record("dismissTaskSuggestion", { taskId });
-          pendingTaskSuggestion = null;
-          this.onEvent?.({
-            event: "task.suggestion",
-            payload: { action: "resolved", taskId, resolution: "dismissed" },
-          });
-          return { taskId, dismissed: true };
-        }
-      }
-
-      async function main() {
-        await runTui({
-          backend: new FixtureBackend(),
-          config: {
-            agents: {
-              defaults: { model: "fixture-provider/fixture-model" },
-              entries: { main: { default: true } },
-            },
-            session: { scope: "per-sender", mainKey: "main" },
-          },
-          deliver: false,
-          thinking: launchThinkingLevel,
-          message: initialMessage,
-          historyLimit: 5,
-          title: "openclaw tui pty fixture",
-        });
-      }
-
-      main().catch((error) => {
-        console.error(error);
-        process.exitCode = 1;
-      });
-    `,
-    "utf8",
-  );
-  return scriptPath;
-}
 
 async function startTuiFixture(opts: { env?: NodeJS.ProcessEnv } = {}) {
   const tempDir = await mkdtemp(path.join(tmpdir(), "openclaw-tui-pty-"));
@@ -702,6 +254,34 @@ describe.sequential("TUI PTY harness", () => {
     STARTUP_TEST_TIMEOUT_MS,
   );
 
+  it.each([
+    { name: "Ctrl+D", input: "\u0004" },
+    { name: "/exit", input: "/exit\r" },
+  ])(
+    "stops the real terminal cleanly when $name interrupts an active run",
+    async ({ input }) => {
+      const busyFixture = await startTuiFixture();
+      try {
+        await busyFixture.run.waitForOutput("local ready", STARTUP_TIMEOUT_MS);
+        await busyFixture.run.write("slow prompt\r", { delay: false });
+        await busyFixture.waitForLogEntry(
+          (entry) =>
+            entry.method === "sendChat" && objectFieldEquals(entry, "message", "slow prompt"),
+        );
+
+        await busyFixture.run.write(input, { delay: false });
+
+        expect((await busyFixture.run.waitForExit()).exitCode).toBe(0);
+        expect(await readFixtureLog(busyFixture.logPath)).toEqual(
+          expect.arrayContaining([expect.objectContaining({ method: "stop" })]),
+        );
+      } finally {
+        await busyFixture.cleanup();
+      }
+    },
+    STARTUP_TEST_TIMEOUT_MS,
+  );
+
   it(
     "presents and resolves workspace skill approval in the TUI",
     async () => {
@@ -725,6 +305,59 @@ describe.sequential("TUI PTY harness", () => {
         await approveWorkspaceSkill(compactFixture, "skill approval proof");
       } finally {
         await compactFixture.cleanup();
+      }
+    },
+    STARTUP_TEST_TIMEOUT_MS,
+  );
+
+  it(
+    "keeps Enter focused on model and session pickers beside a side result in a 20×18 terminal",
+    async () => {
+      const compactPickerFixture = await startTuiFixture({
+        env: {
+          OPENCLAW_TUI_PTY_COLS: "20",
+          OPENCLAW_TUI_PTY_ROWS: "18",
+          OPENCLAW_TUI_PTY_PICKER_FIXTURE: "1",
+        },
+      });
+
+      try {
+        await compactPickerFixture.run.waitForOutput("local ready", STARTUP_TIMEOUT_MS);
+        await compactPickerFixture.run.write("/btw picker focus proof\r", { delay: false });
+        await compactPickerFixture.waitForLogEntry((entry) => entry.method === "pickerSideResult");
+
+        await compactPickerFixture.run.write("\u000c", { delay: false });
+        await compactPickerFixture.waitForLogEntry((entry) => entry.method === "listModels");
+        await compactPickerFixture.run.write("\u001b[B", { delay: false });
+        await compactPickerFixture.run.write("\r", { delay: false });
+        await compactPickerFixture.waitForLogEntry(
+          (entry) =>
+            entry.method === "patchSession" &&
+            objectFieldEquals(entry, "model", "fixture-provider/fixture-model-2"),
+        );
+
+        await compactPickerFixture.run.write("\u0010", { delay: false });
+        await compactPickerFixture.waitForLogEntry(
+          (entry) =>
+            entry.method === "listSessions" && objectFieldEquals(entry, "purpose", "picker"),
+        );
+        await compactPickerFixture.run.write("\u001b[B", { delay: false });
+        await compactPickerFixture.run.write("\r", { delay: false });
+        await compactPickerFixture.waitForLogEntry(
+          (entry) =>
+            entry.method === "loadHistory" &&
+            objectFieldEquals(entry, "sessionKey", "agent:main:picker-target"),
+        );
+
+        await compactPickerFixture.run.write("picker target proof\r", { delay: false });
+        const sent = await compactPickerFixture.waitForLogEntry(
+          (entry) =>
+            entry.method === "sendChat" &&
+            objectFieldEquals(entry, "message", "picker target proof"),
+        );
+        expect(sent.payload).toMatchObject({ sessionKey: "agent:main:picker-target" });
+      } finally {
+        await compactPickerFixture.cleanup();
       }
     },
     STARTUP_TEST_TIMEOUT_MS,
@@ -881,6 +514,87 @@ describe.sequential("TUI PTY harness", () => {
       await fixture.run.waitForOutput("PTY_RESPONSE: streaming prompt");
     },
     TEST_TIMEOUT_MS,
+  );
+
+  it(
+    "renders all 128 ordered chat deltas without losing the final streamed token",
+    async () => {
+      await fixture.run.write("burst streaming proof\r", { delay: false });
+      const burst = await fixture.waitForLogEntry(
+        (entry) => entry.method === "streamBurstComplete" && objectFieldEquals(entry, "count", 128),
+      );
+
+      expect(burst.payload).toMatchObject({ count: 128 });
+      await fixture.run.waitForOutput("PTY_STREAM_BURST:");
+      await fixture.run.waitForOutput("T127");
+    },
+    TEST_TIMEOUT_MS,
+  );
+
+  it(
+    "ignores delayed aborts and streamed events from the previously selected session",
+    async () => {
+      const isolationFixture = await startTuiFixture();
+      const sourceSessionKey = "agent:main:abort-source";
+      const targetSessionKey = "agent:main:abort-target";
+
+      try {
+        await isolationFixture.run.waitForOutput("local ready", STARTUP_TIMEOUT_MS);
+        await isolationFixture.run.write(`/session ${sourceSessionKey}\r`, { delay: false });
+        await isolationFixture.waitForLogEntry(
+          (entry) =>
+            entry.method === "loadHistory" &&
+            objectFieldEquals(entry, "sessionKey", sourceSessionKey),
+        );
+        await isolationFixture.run.write("cross-session abort source proof\r", { delay: false });
+        await isolationFixture.waitForLogEntry(
+          (entry) =>
+            entry.method === "sendChat" &&
+            objectFieldEquals(entry, "message", "cross-session abort source proof"),
+        );
+
+        await isolationFixture.run.write("/abort\r", { delay: false });
+        await isolationFixture.waitForLogEntry(
+          (entry) =>
+            entry.method === "abortChat" &&
+            objectFieldEquals(entry, "sessionKey", sourceSessionKey),
+        );
+        const outputOffset = isolationFixture.run.visibleOutput().length;
+        await isolationFixture.run.write(`/session ${targetSessionKey}\r`, { delay: false });
+        await isolationFixture.waitForLogEntry(
+          (entry) =>
+            entry.method === "loadHistory" &&
+            objectFieldEquals(entry, "sessionKey", targetSessionKey),
+        );
+        await isolationFixture.waitForLogEntry(
+          (entry) =>
+            entry.method === "abortResolved" &&
+            objectFieldEquals(entry, "sessionKey", sourceSessionKey),
+        );
+        await isolationFixture.waitForLogEntry(
+          (entry) =>
+            entry.method === "lateSessionEvent" &&
+            objectFieldEquals(entry, "sessionKey", sourceSessionKey) &&
+            objectFieldEquals(entry, "state", "final"),
+        );
+
+        const targetOutput = isolationFixture.run.visibleOutput().slice(outputOffset);
+        expect(targetOutput).not.toContain("PTY_LATE_FOREIGN_DELTA");
+        expect(targetOutput).not.toContain("PTY_LATE_FOREIGN_FINAL");
+
+        await isolationFixture.run.write("cross-session target proof\r", { delay: false });
+        const sent = await isolationFixture.waitForLogEntry(
+          (entry) =>
+            entry.method === "sendChat" &&
+            objectFieldEquals(entry, "message", "cross-session target proof"),
+        );
+        expect(sent.payload).toMatchObject({ sessionKey: targetSessionKey });
+        await isolationFixture.run.waitForOutput("PTY_RESPONSE: cross-session target proof");
+      } finally {
+        await isolationFixture.cleanup();
+      }
+    },
+    STARTUP_TEST_TIMEOUT_MS,
   );
 
   it(

--- a/src/tui/tui-session-actions.test.ts
+++ b/src/tui/tui-session-actions.test.ts
@@ -378,6 +378,72 @@ describe("tui session actions", () => {
     );
   });
 
+  it.each([
+    {
+      name: "another session",
+      currentAgentId: "main",
+      currentSessionKey: "agent:main:current",
+      resultKey: "agent:main:previous",
+    },
+    {
+      name: "the same request key owned by another agent",
+      currentAgentId: "main",
+      currentSessionKey: "agent:main:main",
+      resultKey: "agent:work:main",
+    },
+  ])(
+    "ignores a session patch belonging to $name",
+    ({ currentAgentId, currentSessionKey, resultKey }) => {
+      const updateHeader = vi.fn();
+      const updateFooter = vi.fn();
+      const state = createBaseState({
+        currentAgentId,
+        currentSessionKey,
+        sessionInfo: { model: "current-model", modelProvider: "openai" },
+      });
+      const { applySessionInfoFromPatch } = createTestSessionActions({
+        state,
+        updateHeader,
+        updateFooter,
+      });
+
+      applySessionInfoFromPatch({
+        ok: true,
+        path: "/sessions/patch",
+        key: resultKey,
+        entry: { model: "stale-model", modelProvider: "anthropic" },
+      });
+
+      expect(state.currentSessionKey).toBe(currentSessionKey);
+      expect(state.currentAgentId).toBe(currentAgentId);
+      expect(state.sessionInfo.model).toBe("current-model");
+      expect(state.sessionInfo.modelProvider).toBe("openai");
+      expect(updateHeader).not.toHaveBeenCalled();
+      expect(updateFooter).not.toHaveBeenCalled();
+    },
+  );
+
+  it("adopts the canonical key for a patch belonging to the selected alias", () => {
+    const state = createBaseState({ currentSessionKey: "main" });
+    const updateHeader = vi.fn();
+    const { applySessionInfoFromPatch } = createTestSessionActions({
+      state,
+      updateHeader,
+    });
+
+    applySessionInfoFromPatch({
+      ok: true,
+      path: "/sessions/patch",
+      key: "agent:main:main",
+      entry: { model: "gpt-5.6-luna", modelProvider: "openai" },
+    });
+
+    expect(state.currentSessionKey).toBe("agent:main:main");
+    expect(state.currentAgentId).toBe("main");
+    expect(state.sessionInfo.model).toBe("gpt-5.6-luna");
+    expect(updateHeader).toHaveBeenCalledOnce();
+  });
+
   it("clears the footer goal when the current session has no row yet", async () => {
     const listSessions = vi.fn().mockResolvedValue({
       ts: Date.now(),
@@ -1035,12 +1101,12 @@ describe("tui session actions", () => {
     expect(state.pendingSubmit).toBeNull();
   });
 
-  it("applies reset mutation result without reloading gateway history", () => {
+  it("adopts a reset mutation's replacement key without reloading gateway history", () => {
     const loadHistory = vi.fn().mockResolvedValue({ messages: [] });
     const addSystem = vi.fn();
     const clearAll = vi.fn();
     const state = createBaseState({
-      currentSessionKey: "agent:main:old",
+      currentSessionKey: "old",
       currentSessionId: "old-session",
       sessionInfo: {
         model: "old-model",
@@ -1078,6 +1144,45 @@ describe("tui session actions", () => {
     expect(state.historyLoaded).toBe(true);
     expect(clearAll).toHaveBeenCalled();
     expect(addSystem).toHaveBeenCalledWith("session agent:main:new");
+  });
+
+  it("does not clear the selected session for another session's reset result", () => {
+    const addSystem = vi.fn();
+    const clearAll = vi.fn();
+    const updateHeader = vi.fn();
+    const state = createBaseState({
+      currentSessionKey: "agent:main:current",
+      currentSessionId: "current-session",
+      historyLoaded: true,
+      sessionInfo: { model: "current-model", modelProvider: "openai" },
+    });
+    const { applySessionMutationResult } = createTestSessionActions({
+      chatLog: { addSystem, clearAll } as unknown as ChatLog,
+      state,
+      updateHeader,
+    });
+
+    const applied = applySessionMutationResult(
+      {
+        ok: true,
+        key: "agent:main:previous",
+        entry: {
+          sessionId: "stale-reset-session",
+          model: "stale-model",
+          modelProvider: "anthropic",
+        },
+      },
+      { sessionKey: "agent:main:previous", agentId: "main" },
+    );
+
+    expect(applied).toBe(false);
+    expect(state.currentSessionKey).toBe("agent:main:current");
+    expect(state.currentSessionId).toBe("current-session");
+    expect(state.sessionInfo.model).toBe("current-model");
+    expect(state.historyLoaded).toBe(true);
+    expect(clearAll).not.toHaveBeenCalled();
+    expect(addSystem).not.toHaveBeenCalled();
+    expect(updateHeader).not.toHaveBeenCalled();
   });
 
   it("does not fast-clear reset results without a replacement entry", () => {
@@ -1254,6 +1359,115 @@ describe("tui session actions", () => {
 
     expect(dropPendingUser).toHaveBeenCalledTimes(1);
     expect(dropPendingUser).toHaveBeenCalledWith("run-queued");
+  });
+
+  it.each([
+    {
+      name: "successful abort after a session switch",
+      initialKey: "agent:main:first",
+      nextKey: "agent:main:second",
+      aborted: true,
+      rejected: false,
+    },
+    {
+      name: "no-active-run abort after a session switch",
+      initialKey: "agent:main:first",
+      nextKey: "agent:main:second",
+      aborted: false,
+      rejected: false,
+    },
+    {
+      name: "rejected abort after a session switch",
+      initialKey: "agent:main:first",
+      nextKey: "agent:main:second",
+      aborted: false,
+      rejected: true,
+    },
+    {
+      name: "successful global abort after an agent switch",
+      initialKey: "global",
+      nextKey: "global",
+      aborted: true,
+      rejected: false,
+    },
+    {
+      name: "no-active-run global abort after an agent switch",
+      initialKey: "global",
+      nextKey: "global",
+      aborted: false,
+      rejected: false,
+    },
+    {
+      name: "rejected global abort after an agent switch",
+      initialKey: "global",
+      nextKey: "global",
+      aborted: false,
+      rejected: true,
+    },
+  ])("ignores a $name", async ({ initialKey, nextKey, aborted, rejected }) => {
+    const deferred = createDeferred<Awaited<ReturnType<TuiBackend["abortChat"]>>>();
+    const abortChat = vi.fn(() => deferred.promise);
+    const loadHistory = vi.fn().mockResolvedValue({
+      sessionInfo: {
+        key: nextKey,
+        sessionId: "second-session",
+        model: "current-model",
+      },
+      messages: [],
+    });
+    const { chatLog, addSystem } = createHistoryChatLog();
+    const dropPendingUser = vi.fn();
+    const setActivityStatus = vi.fn();
+    const state = createBaseState({
+      currentSessionKey: initialKey,
+      currentAgentId: "main",
+      activeChatRunId: "first-active-run",
+      pendingSubmit: acceptedSubmit("first-pending-run"),
+    });
+    const { abortActive, setSession } = createTestSessionActions({
+      client: { listSessions: vi.fn(), loadHistory, abortChat } as unknown as TuiBackend,
+      chatLog: Object.assign(chatLog, { dropPendingUser }),
+      state,
+      setActivityStatus,
+    });
+
+    const pendingAbort = abortActive();
+    expect(abortChat).toHaveBeenCalledWith({
+      sessionKey: initialKey,
+      ...(initialKey === "global" ? { agentId: "main" } : {}),
+    });
+    if (initialKey === "global") {
+      state.currentAgentId = "work";
+    }
+    await setSession(nextKey);
+    state.activeChatRunId = "second-active-run";
+    state.pendingSubmit = acceptedSubmit("second-pending-run", "second draft");
+    addSystem.mockClear();
+    setActivityStatus.mockClear();
+
+    if (rejected) {
+      deferred.reject(new Error("stale session abort"));
+    } else {
+      deferred.resolve({
+        ok: true,
+        aborted,
+        runIds: ["first-active-run", "first-pending-run"],
+      });
+    }
+    await pendingAbort;
+
+    expect(state.currentSessionKey).toBe(nextKey);
+    expect(state.currentAgentId).toBe(initialKey === "global" ? "work" : "main");
+    expect(state.currentSessionId).toBe("second-session");
+    expect(state.activeChatRunId).toBe("second-active-run");
+    expect(getPendingSubmitAcceptedRunId(state)).toBe("second-pending-run");
+    expect(getPendingSubmitDraft(state)).toEqual({
+      runId: "second-pending-run",
+      text: "second draft",
+    });
+    expect(dropPendingUser).not.toHaveBeenCalled();
+    expect(addSystem).not.toHaveBeenCalled();
+    expect(setActivityStatus).not.toHaveBeenCalled();
   });
 
   it("passes the selected agent when aborting selected global runs", async () => {

--- a/src/tui/tui-session-actions.ts
+++ b/src/tui/tui-session-actions.ts
@@ -144,6 +144,17 @@ export function createSessionActions(context: SessionActionContext) {
     state.currentAgentId === selection.agentId &&
     agentSessionKeysMatchByRequestKey(state.currentSessionKey, selection.sessionKey);
 
+  const isCurrentSessionMutation = (result: { key?: string }): boolean => {
+    if (!result.key) {
+      return true;
+    }
+    const parsed = parseAgentSessionKey(result.key);
+    return isCurrentSessionSelection({
+      sessionKey: result.key,
+      agentId: parsed ? normalizeAgentId(parsed.agentId) : state.currentAgentId,
+    });
+  };
+
   const applyAgentsResult = (result: TuiAgentsList) => {
     state.agentDefaultId = normalizeAgentId(result.defaultId);
     state.sessionMainKey = normalizeMainKey(result.mainKey);
@@ -410,7 +421,7 @@ export function createSessionActions(context: SessionActionContext) {
   const applySessionInfoFromPatch = (
     result?: SessionsPatchResult | TuiSessionMutationResult | null,
   ) => {
-    if (!result?.entry) {
+    if (!result?.entry || !isCurrentSessionMutation(result)) {
       return;
     }
     if (result.key && result.key !== state.currentSessionKey) {
@@ -441,8 +452,13 @@ export function createSessionActions(context: SessionActionContext) {
     tui.requestRender(true);
   };
 
-  const applySessionMutationResult = (result?: TuiSessionMutationResult | null): boolean => {
-    if (!result?.entry) {
+  const applySessionMutationResult = (
+    result?: TuiSessionMutationResult | null,
+    requestSelection = captureSessionSelection(),
+  ): boolean => {
+    // A reset can legitimately return a replacement key. Reject results using
+    // the request's original selection, not the key the response must adopt.
+    if (!result?.entry || !isCurrentSessionSelection(requestSelection)) {
       return false;
     }
     if (result.key && result.key !== state.currentSessionKey) {
@@ -648,18 +664,22 @@ export function createSessionActions(context: SessionActionContext) {
       tui.requestRender();
       return;
     }
+    const selection = captureSessionSelection();
     const pendingRunId = submit.getPendingSubmitAcceptedRunId(state);
     const abortsPendingRun = Boolean(pendingRunId);
     const activeRunId = state.activeChatRunId;
     const sessionAbortParams = {
-      sessionKey: state.currentSessionKey,
-      ...(state.currentSessionKey === "global" ? { agentId: state.currentAgentId } : {}),
+      sessionKey: selection.sessionKey,
+      ...(selection.sessionKey === "global" ? { agentId: selection.agentId } : {}),
     };
     try {
       // Session-scoped abort is the only reliable TUI stop contract: queued
       // chat.send calls can terminalize before the queue drains, so their run
       // ids may no longer exist in local UI state.
       const result = await client.abortChat(sessionAbortParams);
+      if (!isCurrentSessionSelection(selection)) {
+        return;
+      }
       if (!result.aborted) {
         chatLog.addSystem("no active run", { coalesceConsecutive: true });
         tui.requestRender();
@@ -684,6 +704,9 @@ export function createSessionActions(context: SessionActionContext) {
       }
       setActivityStatus("aborted");
     } catch (err) {
+      if (!isCurrentSessionSelection(selection)) {
+        return;
+      }
       chatLog.addSystem(`abort failed: ${String(err)}`);
       setActivityStatus("abort failed");
     }

--- a/src/tui/tui-stream-assembler.test.ts
+++ b/src/tui/tui-stream-assembler.test.ts
@@ -82,6 +82,20 @@ describe("TuiStreamAssembler", () => {
     expect(output).toBe("Visible");
   });
 
+  it("tracks literal placeholder text as real displayable content until finalization", () => {
+    const assembler = new TuiStreamAssembler();
+
+    expect(assembler.hasDisplayText("run-literal-output")).toBe(false);
+
+    assembler.ingestDelta("run-literal-output", messageWithContent([text("(no output)")]), false);
+
+    expect(assembler.hasDisplayText("run-literal-output")).toBe(true);
+    expect(
+      assembler.finalize("run-literal-output", { role: "assistant", content: [] }, false),
+    ).toBe("(no output)");
+    expect(assembler.hasDisplayText("run-literal-output")).toBe(false);
+  });
+
   it("falls back to streamed text on empty final payload", () => {
     const assembler = new TuiStreamAssembler();
     assembler.ingestDelta("run-3", messageWithContent([text("Streamed")]), false);

--- a/src/tui/tui-stream-assembler.ts
+++ b/src/tui/tui-stream-assembler.ts
@@ -206,6 +206,11 @@ export class TuiStreamAssembler {
     return state.displayText;
   }
 
+  /** Reports whether a run already has real displayable streamed content. */
+  hasDisplayText(runId: string): boolean {
+    return Boolean(this.runs.get(runId)?.displayText);
+  }
+
   /** Finalizes a run, combines any error text, and drops stored stream state. */
   finalize(runId: string, message: unknown, showThinking: boolean, errorMessage?: string): string {
     // Late finals must not insert an evicted run and displace a live stream.

--- a/src/tui/tui-submit.ts
+++ b/src/tui/tui-submit.ts
@@ -20,6 +20,7 @@ function runSubmitAction(
 
 export function createEditorSubmitHandler(params: {
   editor: {
+    getText?: () => string;
     setText: (value: string) => void;
     addToHistory: (value: string) => void;
   };
@@ -33,28 +34,36 @@ export function createEditorSubmitHandler(params: {
     reason: Exclude<TuiChatSubmitAdmission, "allowed">,
   ) => void;
 }) {
+  const clearSubmittedEditor = () => {
+    // pi-tui clears before onSubmit; a delayed paste flush must not erase a newer draft.
+    if (!params.editor.getText?.()) {
+      params.editor.setText("");
+    }
+  };
+
   return (text: string) => {
     const raw = text;
     const value = raw.trim();
+    const multiline = raw.includes("\n");
 
     // Keep previous behavior: ignore empty/whitespace-only submissions.
     if (!value) {
-      params.editor.setText("");
+      clearSubmittedEditor();
       return;
     }
 
     // Bash mode: only if the very first character is '!' and it's not just '!'.
     // IMPORTANT: use the raw (untrimmed) text so leading spaces do NOT trigger.
     // Per requirement: a lone '!' should be treated as a normal message.
-    if (raw.startsWith("!") && raw !== "!") {
-      params.editor.setText("");
+    if (!multiline && raw.startsWith("!") && raw !== "!") {
+      clearSubmittedEditor();
       params.editor.addToHistory(raw);
       runSubmitAction("local shell", () => params.handleBangLine(raw), params.onSubmitError);
       return;
     }
 
-    if (value.startsWith("/")) {
-      params.editor.setText("");
+    if (!multiline && value.startsWith("/")) {
+      clearSubmittedEditor();
       // Enable built-in editor prompt history navigation (up/down).
       params.editor.addToHistory(value);
       runSubmitAction("command", () => params.handleCommand(value), params.onSubmitError);
@@ -68,7 +77,7 @@ export function createEditorSubmitHandler(params: {
       return;
     }
 
-    params.editor.setText("");
+    clearSubmittedEditor();
     // Enable built-in editor prompt history navigation (up/down).
     params.editor.addToHistory(value);
     runSubmitAction("message", () => params.sendMessage(value), params.onSubmitError);

--- a/src/tui/tui.submit-handler.test.ts
+++ b/src/tui/tui.submit-handler.test.ts
@@ -128,6 +128,20 @@ describe("createEditorSubmitHandler", () => {
   });
 
   it.each([
+    { name: "a slash command", input: "/exit\npasted notes" },
+    { name: "a local shell command", input: "!touch pasted-file\npasted notes" },
+    { name: "a whitespace-prefixed slash command", input: "  /abort\npasted notes" },
+  ])("treats a complete multiline paste beginning with $name as chat", ({ input }) => {
+    const { handleCommand, sendMessage, handleBangLine, onSubmit } = createSubmitHarness();
+
+    onSubmit(input);
+
+    expect(sendMessage).toHaveBeenCalledExactlyOnceWith(input.trim());
+    expect(handleCommand).not.toHaveBeenCalled();
+    expect(handleBangLine).not.toHaveBeenCalled();
+  });
+
+  it.each([
     ["local shell", "!false", "handleBangLine"],
     ["command", "/broken", "handleCommand"],
     ["message", "hello", "sendMessage"],
@@ -176,6 +190,37 @@ describe("createSubmitBurstCoalescer", () => {
 
     expect(submit).toHaveBeenCalledTimes(1);
     expect(submit).toHaveBeenCalledWith("Line 1\nLine 2\nLine 3");
+    vi.useRealTimers();
+  });
+
+  it("preserves a newer real editor draft when a buffered message flushes", () => {
+    vi.useFakeTimers();
+    const tui = { requestRender: vi.fn() } as unknown as TUI;
+    const editor = new CustomEditor(tui, editorTheme);
+    const sendMessage = vi.fn();
+    const submit = createEditorSubmitHandler({
+      editor,
+      handleCommand: vi.fn(),
+      sendMessage,
+      handleBangLine: vi.fn(),
+      onSubmitError: vi.fn(),
+    });
+    editor.onSubmit = createSubmitBurstCoalescer({
+      submit,
+      enabled: true,
+      burstWindowMs: 50,
+    });
+    editor.setText("submitted message");
+
+    editor.handleInput("\r");
+    for (const character of "new draft") {
+      editor.handleInput(character);
+    }
+
+    vi.advanceTimersByTime(50);
+
+    expect(sendMessage).toHaveBeenCalledExactlyOnceWith("submitted message");
+    expect(editor.getText()).toBe("new draft");
     vi.useRealTimers();
   });
 

--- a/src/tui/tui.test.ts
+++ b/src/tui/tui.test.ts
@@ -441,7 +441,7 @@ describe("TUI shutdown safety", () => {
     beginTuiShutdown({
       stopClient: vi.fn(),
       stopTui: vi.fn(),
-      stopStatusTimeout: vi.fn(),
+      disposeStatus: vi.fn(),
       requestFinish: vi.fn(),
       forceExit: vi.fn(),
       hardExitMs: 2000,
@@ -453,6 +453,37 @@ describe("TUI shutdown safety", () => {
   afterEach(() => {
     vi.useRealTimers();
     vi.restoreAllMocks();
+  });
+
+  it("disposes every status animation before teardown and after it settles", async () => {
+    vi.useFakeTimers();
+    const tick = vi.fn();
+    const statusTimer = setInterval(tick, 1000);
+    const waitingTimer = setInterval(tick, 120);
+    const loaderTimer = setInterval(tick, 80);
+    const statusTimeout = setTimeout(tick, 5000);
+    const loader = { stop: vi.fn(() => clearInterval(loaderTimer)) };
+    const disposeStatus = vi.fn(() => {
+      clearInterval(statusTimer);
+      clearInterval(waitingTimer);
+      clearTimeout(statusTimeout);
+      loader.stop();
+    });
+
+    beginTestShutdown({ disposeStatus, keepHardExitArmed: false });
+
+    expect(disposeStatus).toHaveBeenCalledOnce();
+    expect(loader.stop).toHaveBeenCalledOnce();
+    expect(vi.getTimerCount()).toBe(1);
+
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(disposeStatus).toHaveBeenCalledTimes(2);
+    expect(loader.stop).toHaveBeenCalledTimes(2);
+    expect(vi.getTimerCount()).toBe(0);
+
+    await vi.advanceTimersByTimeAsync(5000);
+    expect(tick).not.toHaveBeenCalled();
   });
 
   it("drains terminal input before stopping the TUI", async () => {
@@ -637,7 +668,7 @@ describe("TUI shutdown safety", () => {
       stopTui: async () => {
         calls.push("tui");
       },
-      stopStatusTimeout: () => {
+      disposeStatus: () => {
         calls.push("status");
       },
       requestFinish: () => {
@@ -647,7 +678,7 @@ describe("TUI shutdown safety", () => {
     });
 
     await vi.advanceTimersByTimeAsync(0);
-    expect(calls).toEqual(["client", "tui", "status", "finish"]);
+    expect(calls).toEqual(["status", "client", "tui", "status", "finish"]);
     expect(forceExit).not.toHaveBeenCalled();
   });
 

--- a/src/tui/tui.ts
+++ b/src/tui/tui.ts
@@ -411,7 +411,7 @@ type TuiShutdownTask = () => void | Promise<void>;
 export function beginTuiShutdown(params: {
   stopClient: TuiShutdownTask;
   stopTui: TuiShutdownTask;
-  stopStatusTimeout: () => void;
+  disposeStatus: () => void;
   requestFinish: () => void;
   forceExit: () => void;
   hardExitMs: number;
@@ -425,6 +425,8 @@ export function beginTuiShutdown(params: {
     ((callback, timeoutMs) => setTimeout(callback, timeoutMs) as unknown as TuiProcessExitTimer);
   const hardExitTimer = setTimeoutFn(params.forceExit, params.hardExitMs);
   hardExitTimer.unref?.();
+  // Stop referenced animations before transport teardown can stall or redraw.
+  params.disposeStatus();
   void Promise.resolve()
     .then(params.stopClient)
     .then(params.stopTui)
@@ -435,7 +437,7 @@ export function beginTuiShutdown(params: {
           ((timer) => clearTimeout(timer as unknown as ReturnType<typeof setTimeout>));
         clearTimeoutFn(hardExitTimer);
       }
-      params.stopStatusTimeout();
+      params.disposeStatus();
     })
     .catch(params.onError)
     .finally(params.requestFinish);
@@ -605,6 +607,7 @@ export async function runTui(opts: RunTuiOptions): Promise<TuiResult> {
   let pendingSubmit: TuiPendingSubmit | null = null;
   let historyLoaded = false;
   let isConnected = false;
+  let connectionGeneration = 0;
   let wasDisconnected = false;
   let toolsExpanded = false;
   let showThinking = false;
@@ -985,20 +988,24 @@ export async function runTui(opts: RunTuiOptions): Promise<TuiResult> {
     }).catch(() => undefined);
   };
 
-  const restoreRememberedSession = async () => {
+  const restoreRememberedSession = async (expectedConnectionGeneration: number) => {
     if (initialSessionInput || rememberedSessionApplied) {
       return;
     }
-    rememberedSessionApplied = true;
     const remembered = await readTuiLastSessionKey({
       scopeKey: buildLastSessionScopeKeyFor(),
     });
+    if (expectedConnectionGeneration !== connectionGeneration || !isConnected || exitRequested) {
+      return;
+    }
     const rememberedKey = remembered ? resolveSessionKey(remembered) : null;
     if (!rememberedKey || rememberedKey === currentSessionKey) {
+      rememberedSessionApplied = true;
       return;
     }
     const rememberedAgent = parseAgentSessionKey(rememberedKey)?.agentId;
     if (rememberedAgent && normalizeAgentId(rememberedAgent) !== currentAgentId) {
+      rememberedSessionApplied = true;
       return;
     }
     const sessions = await client
@@ -1010,9 +1017,16 @@ export async function runTui(opts: RunTuiOptions): Promise<TuiResult> {
         agentId: currentAgentId,
       })
       .catch(() => null);
-    if (!sessions) {
+    if (
+      !sessions ||
+      expectedConnectionGeneration !== connectionGeneration ||
+      !isConnected ||
+      exitRequested
+    ) {
       return;
     }
+    // An abandoned connection must leave restoration eligible for the next handshake.
+    rememberedSessionApplied = true;
     const restored = resolveRememberedTuiSessionKey({
       rememberedKey,
       currentAgentId,
@@ -1159,6 +1173,16 @@ export async function runTui(opts: RunTuiOptions): Promise<TuiResult> {
     clearInterval(waitingTimer);
     waitingTimer = null;
     waitingPhrase = null;
+  };
+
+  const disposeStatus = () => {
+    stopStatusTimer();
+    stopWaitingTimer();
+    stopStatusTimeout();
+    clearDynamicSlashCommandsRefreshTimer();
+    dynamicSlashCommandsRequestId += 1;
+    statusLoader?.stop();
+    statusLoader = null;
   };
 
   const renderStatus = () => {
@@ -1415,6 +1439,7 @@ export async function runTui(opts: RunTuiOptions): Promise<TuiResult> {
       return;
     }
     exitRequested = true;
+    connectionGeneration += 1;
     exitResult = {
       exitReason: result?.exitReason ?? "exit",
       ...(result?.systemAgentMessage ? { systemAgentMessage: result.systemAgentMessage } : {}),
@@ -1425,7 +1450,7 @@ export async function runTui(opts: RunTuiOptions): Promise<TuiResult> {
     beginTuiShutdown({
       stopClient: () => client.stop(),
       stopTui: () => drainAndStopTuiSafely(tui),
-      stopStatusTimeout,
+      disposeStatus,
       requestFinish: deferredFinish.requestFinish,
       forceExit,
       hardExitMs: resolveTuiShutdownHardExitMs({ localMode: isLocalMode }),
@@ -1590,7 +1615,8 @@ export async function runTui(opts: RunTuiOptions): Promise<TuiResult> {
   };
 
   tui.addInputListener((data) => {
-    if (!chatLog.hasVisibleBtw()) {
+    // A visible overlay owns Enter even while an inline BTW card remains visible.
+    if (tui.hasOverlay() || !chatLog.hasVisibleBtw()) {
       return undefined;
     }
     if (editor.getText().length > 0) {
@@ -1605,6 +1631,9 @@ export async function runTui(opts: RunTuiOptions): Promise<TuiResult> {
   });
 
   client.onEvent = (evt) => {
+    if (exitRequested) {
+      return;
+    }
     pluginApprovals?.handleEvent(evt.event, evt.payload);
     taskSuggestions?.handleEvent(evt.event, evt.payload);
     if (evt.event === "chat") {
@@ -1625,6 +1654,12 @@ export async function runTui(opts: RunTuiOptions): Promise<TuiResult> {
   };
 
   client.onConnected = () => {
+    if (exitRequested) {
+      return;
+    }
+    const connectedGeneration = ++connectionGeneration;
+    const ownsConnection = () =>
+      connectedGeneration === connectionGeneration && isConnected && !exitRequested;
     isConnected = true;
     pairingHintShown = false;
     const reconnected = wasDisconnected;
@@ -1642,23 +1677,50 @@ export async function runTui(opts: RunTuiOptions): Promise<TuiResult> {
       try {
         await client.subscribeSessionEvents?.();
       } catch (err) {
+        if (!ownsConnection()) {
+          return;
+        }
         chatLog.addSystem(`session event subscribe failed: ${String(err)}`);
       }
+      if (!ownsConnection()) {
+        return;
+      }
       await refreshAgents();
-      await restoreRememberedSession();
+      if (!ownsConnection()) {
+        return;
+      }
+      await restoreRememberedSession(connectedGeneration);
+      if (!ownsConnection()) {
+        return;
+      }
       updateHeader();
       updateAutocompleteProvider();
       try {
         await pluginApprovals?.refresh();
       } catch (err) {
+        if (!ownsConnection()) {
+          return;
+        }
         chatLog.addSystem(`plugin approval refresh failed: ${String(err)}`);
+      }
+      if (!ownsConnection()) {
+        return;
       }
       try {
         await taskSuggestions?.refresh();
       } catch (err) {
+        if (!ownsConnection()) {
+          return;
+        }
         chatLog.addSystem(`task suggestion refresh failed: ${String(err)}`);
       }
+      if (!ownsConnection()) {
+        return;
+      }
       await loadHistory();
+      if (!ownsConnection()) {
+        return;
+      }
       if (activityStatus === "starting up") {
         setActivityStatus("idle");
       }
@@ -1672,10 +1734,16 @@ export async function runTui(opts: RunTuiOptions): Promise<TuiResult> {
       if (!autoMessageSent && autoMessage) {
         autoMessageSent = true;
         await sendMessage(autoMessage);
+        if (!ownsConnection()) {
+          return;
+        }
       }
       updateFooter();
       tui.requestRender();
     })().catch((err: unknown) => {
+      if (!ownsConnection()) {
+        return;
+      }
       chatLog.addSystem(`startup failed: ${String(err)}`);
       if (activityStatus === "starting up") {
         setActivityStatus("idle");
@@ -1686,6 +1754,10 @@ export async function runTui(opts: RunTuiOptions): Promise<TuiResult> {
   };
 
   client.onDisconnected = (reason) => {
+    if (exitRequested) {
+      return;
+    }
+    connectionGeneration += 1;
     isConnected = false;
     wasDisconnected = true;
     historyLoaded = false;
@@ -1715,6 +1787,9 @@ export async function runTui(opts: RunTuiOptions): Promise<TuiResult> {
   };
 
   client.onGap = (info) => {
+    if (exitRequested || !isConnected) {
+      return;
+    }
     setConnectionStatus(`event gap: expected ${info.expected}, got ${info.received}`, 5000);
     void (async () => {
       try {
@@ -1748,6 +1823,7 @@ export async function runTui(opts: RunTuiOptions): Promise<TuiResult> {
   client.start();
   await new Promise<void>((resolve) => {
     const finish = () => {
+      disposeStatus();
       disposeEventHandlers();
       pluginApprovals?.dispose();
       taskSuggestions?.dispose();


### PR DESCRIPTION
Closes #10118

## What Problem This Solves

Fixes an issue where terminal users could lose streamed or aborted replies, render delayed work into the wrong session, lose a newly typed editor draft, or encounter broken model and session pickers in compact terminals. Multiline editor shortcuts also existed without being discoverable in terminal help or public documentation.

## Why This Change Was Made

Hardens the existing terminal, Gateway, session, streaming, input, and upstream pi-tui boundaries without adding dependencies, configuration options, security-policy changes, or parallel implementations. Session mutations are guarded using the selection captured when each request began, so canonical replacement keys remain supported. Complete multiline submissions remain chat rather than shell or slash commands; the shipped Windows and macOS paste fallback and standalone command timing remain unchanged. The oversized fake-backend fixture is extracted into its existing bounded test-support owner and obsolete exports are removed.

## User Impact

Terminal conversations remain isolated across session and agent switches; streamed, final, and aborted responses stay visible; existing shell, slash, and paste behavior remains compatible; newly typed drafts survive delayed submission; Ctrl+D and /exit shut down cleanly; IME, CJK, and printable j/k work in narrow focused pickers; collapsed tool output is bounded without losing full expansion; and Shift+Enter and Ctrl+J are documented in both /help and the TUI guide.

## Evidence

AI-assisted; the branch is independently autoreviewed.

- Hosted Linux full TUI suite: 877 passing tests across 35 files on the published head.
- Hosted Linux full TUI type-aware lint: 81 files, zero warnings and zero errors.
- Real PTY and real Gateway stress lane: 56 scenarios covering real local execution, real Gateway WebSocket delivery, reconnection, cross-client messages, cancellation, queued follow-ups, streaming bursts, narrow picker overlays, and clean exits.
- Production build: unified CLI, bundled plugin assets, 143 public plugin SDK subpaths, and Control UI all build successfully.
- All production, full-tree, and script unused-export scans pass with zero entries.
- Verified the pinned pi-tui editor, bracketed-paste, terminal, focus-marker, and width contracts directly.
- No dependency, configuration, storage, Gateway protocol, or security-ownership changes.