### PR TITLE
fix(cron): prevent completed jobs rerunning after gateway restart

### DIFF
--- a/src/cron/service/ops.test.ts
+++ b/src/cron/service/ops.test.ts
@@ -8,10 +8,12 @@ import { findTaskByRunId, listTaskRecordsUnsorted } from "../../tasks/task-regis
 import { resetTaskRegistryForTests } from "../../tasks/task-runtime.test-helpers.js";
 import { formatTaskStatusDetail } from "../../tasks/task-status.js";
 import { withEnvAsync } from "../../test-utils/env.js";
+import { createCronExecutionId } from "../run-id.js";
 import * as cronSchedule from "../schedule.js";
 import { setupCronServiceSuite, writeCronStoreSnapshot } from "../service.test-harness.js";
 import * as cronStoreModule from "../store.js";
 import { loadCronJobsStoreWithConfigJobs, loadCronStore } from "../store.js";
+import { cronStoreKey } from "../store/key.js";
 import type { CronJob } from "../types.js";
 import { start, stop } from "./ops-lifecycle.js";
 import { add, remove, update } from "./ops-mutations.js";
@@ -489,97 +491,114 @@ describe("cron service ops seam coverage", () => {
     stop(state);
   });
 
-  it("preserves a finalized canonical task run when startup finds its stale marker", async () => {
-    const { storePath } = await makeStorePath();
-    const now = Date.parse("2026-03-23T12:00:00.000Z");
-    const reservedAt = now - 30 * 60_000;
-    const startedAt = reservedAt + 250;
-    const endedAt = startedAt + 4_000;
+  it.each([
+    { identity: "canonical", reservationOffsetMs: undefined },
+    { identity: "shipped reservation-keyed", reservationOffsetMs: 250 },
+  ])(
+    "preserves a finalized $identity task run when startup finds its stale marker",
+    async ({ reservationOffsetMs }) => {
+      const { storePath } = await makeStorePath();
+      const now = Date.parse("2026-03-23T12:00:00.000Z");
+      const startedAt = now - 30 * 60_000 + 250;
+      const endedAt = startedAt + 4_000;
 
-    await withStateDirForStorePath(storePath, async () => {
-      const job = createInterruptedMainJob(now);
-      job.trigger = { script: "json({ fire: true })", once: true };
-      job.payload = { kind: "script", script: "return { state: { cursor: 'payload' } }" };
-      job.state.triggerState = { cursor: "old" };
-      await writeCronStoreSnapshot({ storePath, jobs: [job] });
-      const events: CronEvent[] = [];
-      const state = createCronServiceState({
-        storePath,
-        cronEnabled: true,
-        log: logger,
-        nowMs: () => now,
-        enqueueSystemEvent: vi.fn(),
-        requestHeartbeat: vi.fn(),
-        runIsolatedAgentJob: vi.fn(async () => ({ status: "ok" as const })),
-        onEvent: (event) => events.push(structuredClone(event)),
-      });
-      const taskRunId = tryCreateCronTaskRun({
-        state,
-        job,
-        startedAt,
-        runIdStartedAt: reservedAt,
-      });
-      if (!taskRunId) {
-        throw new Error("expected reserved cron task run");
-      }
+      await withStateDirForStorePath(storePath, async () => {
+        const job = createInterruptedMainJob(now);
+        job.state.runningAtMs = startedAt;
+        job.trigger = { script: "json({ fire: true })", once: true };
+        job.payload = { kind: "script", script: "return { state: { cursor: 'payload' } }" };
+        job.state.triggerState = { cursor: "old" };
+        await writeCronStoreSnapshot({ storePath, jobs: [job] });
+        const events: CronEvent[] = [];
+        const state = createCronServiceState({
+          storePath,
+          cronEnabled: true,
+          log: logger,
+          nowMs: () => now,
+          enqueueSystemEvent: vi.fn(),
+          requestHeartbeat: vi.fn(),
+          runIsolatedAgentJob: vi.fn(async () => ({ status: "ok" as const })),
+          onEvent: (event) => events.push(structuredClone(event)),
+        });
+        const taskRunId =
+          reservationOffsetMs === undefined
+            ? tryCreateCronTaskRun({ state, job, startedAt })
+            : taskExecutor.createRunningTaskRun({
+                runtime: "cron",
+                sourceId: job.id,
+                ownerKey: "",
+                scopeKind: "system",
+                runId: `${createCronExecutionId(job.id, startedAt - reservationOffsetMs)}:legacy-upgrade`,
+                agentId: "main",
+                task: job.name,
+                deliveryStatus: "not_applicable",
+                notifyPolicy: "silent",
+                startedAt,
+                lastEventAt: startedAt,
+                detail: { storeKey: cronStoreKey(storePath) },
+              })?.runId;
+        if (!taskRunId) {
+          throw new Error("expected reserved cron task run");
+        }
 
-      tryFinishCronTaskRun(state, {
-        taskRunId,
-        job,
-        triggerEval: { fired: true, stateChanged: true, state: { cursor: "new" } },
-        scriptResult: { scriptStateChanged: true, scriptState: { cursor: "payload" } },
-        event: {
-          jobId: job.id,
-          action: "finished",
+        tryFinishCronTaskRun(state, {
+          taskRunId,
           job,
-          status: "ok",
-          summary: "completed before crash",
-          delivered: true,
-          deliveryStatus: "delivered",
-          failureNotificationDelivery: { status: "not-requested" },
-          runAtMs: startedAt,
-          durationMs: endedAt - startedAt,
-          triggerFired: true,
-        },
-      });
+          triggerEval: { fired: true, stateChanged: true, state: { cursor: "new" } },
+          scriptResult: { scriptStateChanged: true, scriptState: { cursor: "payload" } },
+          event: {
+            jobId: job.id,
+            action: "finished",
+            job,
+            status: "ok",
+            summary: "completed before crash",
+            delivered: true,
+            deliveryStatus: "delivered",
+            failureNotificationDelivery: { status: "not-requested" },
+            runAtMs: startedAt,
+            durationMs: endedAt - startedAt,
+            triggerFired: true,
+          },
+        });
 
-      await start(state);
+        await start(state);
 
-      expect(findTaskByRunId(taskRunId)).toMatchObject({
-        status: "succeeded",
-        startedAt,
-        terminalSummary: "completed before crash",
-        endedAt,
-        detail: {
-          kind: "cron-run",
-          status: "ok",
-          triggerFired: true,
-          scriptStateChanged: true,
-          scriptState: { cursor: "payload" },
-        },
+        expect(findTaskByRunId(taskRunId)).toMatchObject({
+          status: "succeeded",
+          startedAt,
+          terminalSummary: "completed before crash",
+          endedAt,
+          detail: {
+            kind: "cron-run",
+            status: "ok",
+            triggerFired: true,
+            scriptStateChanged: true,
+            scriptState: { cursor: "payload" },
+          },
+        });
+        const persisted = await loadCronStore(storePath);
+        expect(persisted.jobs[0]).toMatchObject({
+          enabled: false,
+          state: {
+            lastRunAtMs: startedAt,
+            lastRunStatus: "ok",
+            lastStatus: "ok",
+            lastDurationMs: endedAt - startedAt,
+            lastDelivered: true,
+            lastDeliveryStatus: "delivered",
+            lastTriggerEvalAtMs: endedAt,
+            lastTriggerFireAtMs: endedAt,
+            triggerState: { cursor: "payload" },
+          },
+        });
+        expect(persisted.jobs[0]?.state.runningAtMs).toBeUndefined();
+        expect(persisted.jobs[0]?.state.lastError).toBeUndefined();
+        expect(persisted.jobs[0]?.state.nextRunAtMs).toBeUndefined();
+        expect(events.filter((event) => event.action === "finished")).toEqual([]);
+        stop(state);
       });
-      const persisted = await loadCronStore(storePath);
-      expect(persisted.jobs[0]).toMatchObject({
-        enabled: false,
-        state: {
-          lastRunAtMs: startedAt,
-          lastRunStatus: "ok",
-          lastStatus: "ok",
-          lastDurationMs: endedAt - startedAt,
-          lastDelivered: true,
-          lastDeliveryStatus: "delivered",
-          lastTriggerEvalAtMs: endedAt,
-          lastTriggerFireAtMs: endedAt,
-          triggerState: { cursor: "payload" },
-        },
-      });
-      expect(persisted.jobs[0]?.state.runningAtMs).toBeUndefined();
-      expect(persisted.jobs[0]?.state.lastError).toBeUndefined();
-      expect(persisted.jobs[0]?.state.nextRunAtMs).toBeUndefined();
-      expect(events.filter((event) => event.action === "finished")).toEqual([]);
-      stop(state);
-    });
-  });
+    },
+  );
 
   it("keeps a finalized one-shot disabled when startup restores its stale marker", async () => {
     const { storePath } = await makeStorePath();

--- a/src/cron/service/task-runs.ts
+++ b/src/cron/service/task-runs.ts
@@ -104,19 +104,14 @@ function resolveCronTaskChildSessionKey(params: {
   });
 }
 
-/** Creates a best-effort detached task ledger row for a cron run. */
+/** Creates a best-effort detached task row keyed to the persisted execution start. */
 export function tryCreateCronTaskRun(params: {
   state: CronServiceState;
   job: CronJob;
   startedAt: number;
-  runIdStartedAt?: number;
   publicRunId?: string;
 }): string | undefined {
-  const runId = createCronTaskRunId(
-    params.job.id,
-    params.runIdStartedAt ?? params.startedAt,
-    params.publicRunId,
-  );
+  const runId = createCronTaskRunId(params.job.id, params.startedAt, params.publicRunId);
   return tryCreateCronTaskRunRecord({
     state: params.state,
     job: params.job,
@@ -126,18 +121,18 @@ export function tryCreateCronTaskRun(params: {
   });
 }
 
-function createCronTaskRunId(jobId: string, reservationAt: number, publicRunId?: string): string {
+function createCronTaskRunId(jobId: string, startedAt: number, publicRunId?: string): string {
   const discriminator = publicRunId?.trim() || randomUUID();
-  return `${createCronExecutionId(jobId, reservationAt)}:${discriminator}`;
+  return `${createCronExecutionId(jobId, startedAt)}:${discriminator}`;
 }
 
 function findLatestCronTaskRunForRecovery(
   jobId: string,
-  reservationAt: number,
+  startedAt: number,
   storeKey: string,
 ): TaskRecord | undefined {
-  const reservationRunId = createCronExecutionId(jobId, reservationAt);
-  const prefix = `${reservationRunId}:`;
+  const executionRunId = createCronExecutionId(jobId, startedAt);
+  const prefix = `${executionRunId}:`;
   return listTaskRecordsUnsorted()
     .filter((task) => {
       if (task.runtime !== "cron" || task.sourceId !== jobId) {
@@ -146,11 +141,14 @@ function findLatestCronTaskRunForRecovery(
       const taskStoreKey = cronTaskRecordStoreKey(task);
       if (taskStoreKey === undefined) {
         // Exact match covers detail-less pre-discriminator rows from older releases.
-        return task.runId === reservationRunId;
+        return task.runId === executionRunId;
       }
       return (
         taskStoreKey === storeKey &&
-        (task.runId === reservationRunId || task.runId?.startsWith(prefix))
+        (task.runId === executionRunId ||
+          task.runId?.startsWith(prefix) ||
+          // Released reservation-keyed rows still record the authoritative execution start.
+          task.startedAt === startedAt)
       );
     })
     .toSorted(

--- a/src/cron/service/timer-catchup.ts
+++ b/src/cron/service/timer-catchup.ts
@@ -385,7 +385,6 @@ async function runStartupCatchupCandidate(
     state,
     job: executionJob,
     startedAt,
-    runIdStartedAt: candidate.reservedAtMs,
   });
   const activeJobMarker = markCronJobActive(executionJob.id, {
     preserveAcrossGenerationAdvance: !runsDetachedFromMainSession(executionJob),

--- a/src/cron/service/timer-scheduler.ts
+++ b/src/cron/service/timer-scheduler.ts
@@ -289,7 +289,6 @@ async function onAdmittedTimer(state: CronServiceState) {
     const runDueJob = async (params: {
       id: string;
       job: CronJob;
-      reservedAtMs: number;
       reservationIdentity: object;
       startedAt: number;
     }): Promise<TimedCronRunOutcome> => {
@@ -311,7 +310,6 @@ async function onAdmittedTimer(state: CronServiceState) {
         state,
         job: executionJob,
         startedAt,
-        runIdStartedAt: params.reservedAtMs,
       });
 
       try {

--- a/src/cron/service/timer.batch-finalization.test.ts
+++ b/src/cron/service/timer.batch-finalization.test.ts
@@ -10,9 +10,13 @@ import { DEFAULT_CRON_MAX_CONCURRENT_RUNS } from "../../config/cron-limits.js";
 import { listTaskRecordsUnsorted } from "../../tasks/task-registry.js";
 import { resetTaskRegistryForTests } from "../../tasks/task-runtime.test-helpers.js";
 import { isCronJobActive, markCronJobActive } from "../active-jobs.js";
+import { createCronExecutionId } from "../run-id.js";
 import * as cronStoreModule from "../store.js";
 import { loadCronStore, saveCronStore } from "../store.js";
+import { cronStoreKey } from "../store/key.js";
+import { readCronTaskRunHistoryPage } from "../task-run-history.js";
 import type { CronJob } from "../types.js";
+import { start, stop } from "./ops-lifecycle.js";
 import { add, remove } from "./ops-mutations.js";
 import { createCronServiceState } from "./state.js";
 import {
@@ -70,6 +74,119 @@ function findCronTask(jobId: string) {
 }
 
 describe("cron batch outcome finalization", () => {
+  it.each(["scheduled", "startup"] as const)(
+    "recovers one finalized %s run when admission advances its execution clock",
+    async (trigger) => {
+      const store = fixtures.makeStorePath();
+      const reservedAt = Date.parse("2026-02-06T10:05:00.250Z");
+      const startedAt = reservedAt + 7;
+      const job = createDueIsolatedJob({
+        id: `${trigger}-recover-advanced-execution-clock`,
+        nowMs: reservedAt,
+        nextRunAtMs: reservedAt,
+      });
+      await saveCronStore(store.storePath, { version: 1, jobs: [job] });
+
+      let now = reservedAt;
+      let reservationPersisted = false;
+      let terminalWriteRejected = false;
+      const events: Array<{ action: string; jobId: string; status?: string }> = [];
+      const runIsolatedAgentJob = vi.fn(async () => ({
+        status: "ok" as const,
+        summary: "finished before terminal store failure",
+      }));
+      const state = createCronServiceState({
+        cronEnabled: true,
+        storePath: store.storePath,
+        log: noopLogger,
+        nowMs: () => now,
+        enqueueSystemEvent: vi.fn(),
+        requestHeartbeat: vi.fn(),
+        runIsolatedAgentJob,
+        onEvent: (event) => events.push(event),
+      });
+      const save = cronStoreModule.saveCronJobsStore;
+      const saveSpy = vi
+        .spyOn(cronStoreModule, "saveCronJobsStore")
+        .mockImplementation(async (...args) => {
+          const persistedJob = args[1].jobs.find((entry) => entry.id === job.id);
+          if (!reservationPersisted && persistedJob?.state.queuedAtMs === reservedAt) {
+            await save(...args);
+            reservationPersisted = true;
+            now = startedAt;
+            return;
+          }
+          if (!terminalWriteRejected && persistedJob?.state.lastRunStatus === "ok") {
+            terminalWriteRejected = true;
+            throw new Error("cron terminal write failed");
+          }
+          await save(...args);
+        });
+
+      let recoveryState: ReturnType<typeof createCronServiceState> | undefined;
+      try {
+        await expect(startBatch(trigger, state)).rejects.toThrow("cron terminal write failed");
+        expect(runIsolatedAgentJob).toHaveBeenCalledOnce();
+        expect((await loadCronStore(store.storePath)).jobs[0]?.state.runningAtMs).toBe(startedAt);
+
+        const task = findCronTask(job.id);
+        expect(task).toMatchObject({
+          runId: expect.stringMatching(new RegExp(`^${createCronExecutionId(job.id, startedAt)}:`)),
+          startedAt,
+          status: "succeeded",
+          terminalSummary: "finished before terminal store failure",
+        });
+        expect(events.filter((event) => event.action === "finished")).toEqual([
+          expect.objectContaining({ jobId: job.id, status: "ok" }),
+        ]);
+
+        saveSpy.mockRestore();
+        recoveryState = createCronServiceState({
+          cronEnabled: true,
+          storePath: store.storePath,
+          log: noopLogger,
+          nowMs: () => startedAt + 1,
+          enqueueSystemEvent: vi.fn(),
+          requestHeartbeat: vi.fn(),
+          runIsolatedAgentJob,
+          onEvent: (event) => events.push(event),
+        });
+        await start(recoveryState);
+
+        expect(runIsolatedAgentJob).toHaveBeenCalledOnce();
+        expect(
+          listTaskRecordsUnsorted().filter(
+            (record) => record.runtime === "cron" && record.sourceId === job.id,
+          ),
+        ).toEqual([expect.objectContaining({ runId: task?.runId, status: "succeeded" })]);
+        expect(
+          readCronTaskRunHistoryPage({
+            storeKey: cronStoreKey(store.storePath),
+            jobId: job.id,
+          }).entries,
+        ).toEqual([
+          expect.objectContaining({
+            jobId: job.id,
+            runAtMs: startedAt,
+            status: "ok",
+            summary: "finished before terminal store failure",
+          }),
+        ]);
+        expect((await loadCronStore(store.storePath)).jobs[0]).toMatchObject({
+          enabled: false,
+          state: { lastRunAtMs: startedAt, lastRunStatus: "ok", lastStatus: "ok" },
+        });
+        expect(events.filter((event) => event.action === "finished")).toHaveLength(1);
+      } finally {
+        saveSpy.mockRestore();
+        stop(state);
+        if (recoveryState) {
+          stop(recoveryState);
+        }
+      }
+    },
+  );
+
   it.each([
     { trigger: "scheduled", deleteAfterRun: false },
     { trigger: "scheduled", deleteAfterRun: true },

--- a/src/cron/service/timer.test.ts
+++ b/src/cron/service/timer.test.ts
@@ -247,7 +247,7 @@ describe("cron service timer seam coverage", () => {
     timeoutSpy.mockRestore();
   });
 
-  it("uses the persisted reservation timestamp for the canonical timer task", async () => {
+  it("uses the persisted execution timestamp for the canonical timer task", async () => {
     const { storePath } = await makeStorePath();
     const now = Date.parse("2026-03-23T12:00:00.000Z");
     let clock = now;
@@ -300,10 +300,13 @@ describe("cron service timer seam coverage", () => {
 
     expect(reservedAt).toEqual(expect.any(Number));
     expect(persistedReservation).toEqual(expect.any(Number));
+    expect(reservedAt).not.toBe(persistedReservation);
     expect(liveReservation).toBe(persistedReservation);
     expect(liveError).toBeUndefined();
     expect(emittedStartedAt).toBe(persistedReservation);
-    expect(findCronTaskByBaseRunId(`cron:isolated-agent-job:${reservedAt}`)).toMatchObject({
+    expect(
+      findCronTaskByBaseRunId(`cron:isolated-agent-job:${persistedReservation}`),
+    ).toMatchObject({
       startedAt: emittedStartedAt,
       status: "succeeded",
     });


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where a scheduled or startup cron job that completed successfully could be reported as interrupted, receive duplicate task/history finalization, or run again after a Gateway restart when the execution clock advanced between scheduling reservation and admission.

## Why This Change Was Made

Use the durable execution start as the single task identity for scheduled, startup, and manual cron runs, while preserving same-job, same-SQLite-store recovery of reservation-keyed task rows from shipped 2026.7.2 beta releases. Keep the existing shared SQLite task ledger, existing public manual run identity, UUID same-millisecond discriminator, admission queue, heartbeat ownership, and one terminal finalization.

## User Impact

Completed cron jobs remain successful and visible exactly once in both cron history and task status across Gateway restarts, including upgrades from released reservation-keyed versions. One-shot jobs remain finalized and the scheduler does not enter a stale-marker hot loop.

## Evidence

- Reproduced the clock-advanced scheduled and startup restart failure on the original main: both targeted regressions failed before the fix and passed afterward.
- Final focused Testbox run: all **8 files / 223 tests passed**, including scheduled/startup finalization, manual admission and cleanup, same-millisecond identities, stale-marker tight loops, and both canonical and shipped reservation-keyed startup recovery.
- Full remote changed-files gate: `pnpm check:changed` passed for formatting, core/core-test typechecks, lint, dependency, SQLite, configuration, plugin, and public-API contracts.
- Authenticated isolated development Gateway on free loopback port **36555**, using the repository's existing `createOpenClawTestInstance` helper and a one-time redacted token: `/healthz` and `/readyz` both returned HTTP 200; a disposable command cron job was added, listed, run once, checked through `cron runs` and the shared task ledger, removed, and confirmed absent. Exactly one successful history entry and one successful task had the same execution/public identity; no timer hot loop; the proof stopped only its own Gateway and removed only its own temporary state.
- Independent review: `.agents/skills/autoreview/scripts/autoreview --mode uncommitted` → **autoreview clean: no accepted/actionable findings reported**.
- Dedicated Blacksmith Testbox: `tbx_01kyk0y69hs45b7af1fx3jx0kb`; [validation run](https://github.com/openclaw/openclaw/actions/runs/30316517441).
- Net production code: **5 fewer lines**.
- Compatibility: no SQLite schema/version bump, new file state, new config/environment option, protocol change, queue ownership change, heartbeat ownership change, or changed public cron CLI/SDK identity.