### PR TITLE
test(scripts): deflake credential process-tree timeout tests

### DIFF
--- a/test/scripts/telegram-user-credential.test.ts
+++ b/test/scripts/telegram-user-credential.test.ts
@@ -20,6 +20,17 @@ import { resolveWindowsTaskkillPath } from "../../scripts/lib/windows-taskkill.m
 const tempDirs: string[] = [];
 const CHUNKED_PAYLOAD_MARKER = "__openclawQaCredentialPayloadChunksV1";
 
+// Upper bound for polling a spawned process to reach a state. Polls return as
+// soon as the state holds, so a wide budget costs nothing on success and only
+// bounds genuine hangs. Cold Node start measured 59-85ms directly and
+// 483-1224ms through the tsx runner on a loaded machine, so tighter budgets
+// reported slow spawns as behavior failures.
+const PROCESS_WAIT_TIMEOUT_MS = 30_000;
+// runCommand timeout for cases whose child must install signal handlers before
+// the timeout fires. This one is paid in wall-clock, so it stays modest while
+// keeping an order-of-magnitude margin over measured child startup.
+const TIMEOUT_TRIGGER_MS = 1_500;
+
 function expectedTaskkillPath(): string {
   return resolveWindowsTaskkillPath();
 }
@@ -308,6 +319,7 @@ describe("telegram user credential IO", () => {
     async () => {
       const dir = makeTempDir("openclaw-telegram-credential-timeout-");
       const terminatedPath = path.join(dir, "terminated.txt");
+      const readyPath = path.join(dir, "ready.txt");
       const scriptPath = path.join(dir, "ignore-term.cjs");
       writeFileSync(
         scriptPath,
@@ -319,22 +331,31 @@ process.on("SIGTERM", () => {
     process.exit(0);
   }, 75);
 });
+fs.writeFileSync(process.argv[3], "ready");
 setInterval(() => {}, 1000);
 `,
         "utf8",
       );
 
-      const runPromise = runCommand(process.execPath, [scriptPath, terminatedPath], undefined, {
-        timeoutKillGraceMs: 1_000,
-        timeoutMs: 100,
-      });
+      const runPromise = runCommand(
+        process.execPath,
+        [scriptPath, terminatedPath, readyPath],
+        undefined,
+        {
+          timeoutKillGraceMs: 1_000,
+          timeoutMs: TIMEOUT_TRIGGER_MS,
+        },
+      );
       const runError = runPromise.catch((error: unknown) => error);
 
       try {
+        // The delayed-exit contract only holds once the child owns SIGTERM, so
+        // prove startup finished before the timeout rather than racing it.
+        await waitForFile(readyPath, PROCESS_WAIT_TIMEOUT_MS);
         const error = (await runError) as Error & { code?: string };
         expect(error).toBeInstanceOf(Error);
         expect(error.code).toBe("ETIMEDOUT");
-        expect(error.message).toContain("timed out after 100ms");
+        expect(error.message).toContain(`timed out after ${TIMEOUT_TRIGGER_MS}ms`);
         expect(existsSync(terminatedPath)).toBe(true);
       } finally {
         await runPromise.catch(() => {});
@@ -374,19 +395,24 @@ setInterval(() => {}, 1000);
         const startedAt = Date.now();
         const runPromise = runCommand(process.execPath, ["-e", parentScript], dir, {
           timeoutKillGraceMs: 250,
-          timeoutMs: 300,
+          timeoutMs: TIMEOUT_TRIGGER_MS,
         });
         const runError = runPromise.catch((error: unknown) => error);
-        await waitForFile(readyPath, 2_000);
+        await waitForFile(readyPath, PROCESS_WAIT_TIMEOUT_MS);
+        // The descendant can reach readiness before its parent records the pid,
+        // so wait for that write too instead of inferring it from readiness.
+        await waitForFile(childPidPath, PROCESS_WAIT_TIMEOUT_MS);
         childPid = Number.parseInt(readFileSync(childPidPath, "utf8"), 10);
 
         await expect(runError).resolves.toMatchObject({
           code: "ETIMEDOUT",
-          message: expect.stringContaining("timed out after 300ms"),
+          message: expect.stringContaining(`timed out after ${TIMEOUT_TRIGGER_MS}ms`),
         });
 
         expect(readFileSync(cleanupPath, "utf8")).toBe("clean");
-        expect(Date.now() - startedAt).toBeLessThan(800);
+        // Clean descendant exits must settle shortly after the timeout instead
+        // of waiting out the full kill grace.
+        expect(Date.now() - startedAt).toBeLessThan(TIMEOUT_TRIGGER_MS + 500);
       } finally {
         if (childPid !== undefined && isProcessAlive(childPid)) {
           process.kill(childPid, "SIGKILL");
@@ -412,17 +438,18 @@ setInterval(() => {}, 1000);
 
       const runPromise = runCommand(process.execPath, ["-e", parentScript], dir, {
         timeoutKillGraceMs: 25,
-        timeoutMs: 500,
+        timeoutMs: TIMEOUT_TRIGGER_MS,
       });
       const runError = runPromise.catch((error: unknown) => error);
-      await waitForFile(childPidPath, 2_000);
+      // The parent must reach its spawn before the timeout kills the group.
+      await waitForFile(childPidPath, PROCESS_WAIT_TIMEOUT_MS);
       childPid = Number.parseInt(readFileSync(childPidPath, "utf8"), 10);
 
       await expect(runError).resolves.toMatchObject({
         code: "ETIMEDOUT",
-        message: expect.stringContaining("timed out after 500ms"),
+        message: expect.stringContaining(`timed out after ${TIMEOUT_TRIGGER_MS}ms`),
       });
-      await waitForDead(childPid, 2_000);
+      await waitForDead(childPid, PROCESS_WAIT_TIMEOUT_MS);
     } finally {
       if (childPid !== undefined && isProcessAlive(childPid)) {
         process.kill(childPid, "SIGKILL");
@@ -532,15 +559,15 @@ setInterval(() => {}, 1000);
       });
       let childPid: number | undefined;
       try {
-        await waitForFile(readyPath, 2_000);
+        await waitForFile(readyPath, PROCESS_WAIT_TIMEOUT_MS);
         childPid = Number.parseInt(readFileSync(childPidPath, "utf8"), 10);
         const startedAt = Date.now();
         runner.kill("SIGTERM");
-        const exit = await waitForExit(runner, 2_000);
+        const exit = await waitForExit(runner, PROCESS_WAIT_TIMEOUT_MS);
 
         expect(exit).toEqual({ code: 143, signal: null });
         expect(Date.now() - startedAt).toBeLessThan(1_500);
-        await waitForDead(childPid, 2_000);
+        await waitForDead(childPid, PROCESS_WAIT_TIMEOUT_MS);
       } finally {
         if (runner.exitCode === null && runner.signalCode === null) {
           runner.kill("SIGKILL");
@@ -595,14 +622,14 @@ setInterval(() => {}, 1000);
       });
       let grandchildPid: number | undefined;
       try {
-        await waitForFile(readyPath, 2_000);
-        await waitForFile(grandchildPidPath, 2_000);
+        await waitForFile(readyPath, PROCESS_WAIT_TIMEOUT_MS);
+        await waitForFile(grandchildPidPath, PROCESS_WAIT_TIMEOUT_MS);
         grandchildPid = Number.parseInt(readFileSync(grandchildPidPath, "utf8"), 10);
         runner.kill("SIGTERM");
-        const exit = await waitForExit(runner, 2_000);
+        const exit = await waitForExit(runner, PROCESS_WAIT_TIMEOUT_MS);
 
         expect(exit).toEqual({ code: 143, signal: null });
-        await waitForDead(grandchildPid, 2_000);
+        await waitForDead(grandchildPid, PROCESS_WAIT_TIMEOUT_MS);
       } finally {
         if (runner.exitCode === null && runner.signalCode === null) {
           runner.kill("SIGKILL");


### PR DESCRIPTION
## What Problem This Solves

`test/scripts/telegram-user-credential.test.ts` flaked in CI on unrelated PRs (observed in `checks-node-compact-small-1` during #114722's run). The file's process-tree tests assume child-process startup fits inside millisecond budgets sized for an idle machine. On a loaded host the whole file is unreliable: a baseline run on `main` failed on the first attempt here, with **four different tests** failing across two runs.

Three distinct races, each reproduced and measured on a loaded machine:

1. **`timeoutMs: 100` vs Node cold start** — "waits for timed-out child processes to exit before rejecting" spawns a child that writes a cleanup file from its `SIGTERM` handler. If the timeout fires before Node finishes booting, the default signal action kills the child and the file is never written (`expect(existsSync(terminatedPath)).toBe(true)` → false). Measured plain Node cold start to handler-installed: **59–85ms against a 100ms budget**.
2. **`waitForFile(readyPath, 2_000)` vs the tsx runner** — the forwarded-signal tests boot `node --import tsx`, transpile `telegram-user-credential-io.ts`, then spawn a grandchild that signals readiness. Measured readiness latency: **483–1224ms against a 2000ms budget**, so the readiness poll times out under CI-level parallelism.
3. **Waiting on the wrong signal** — "rejects timed-out commands when descendant processes exit cleanly" waits for the *grandchild's* ready file, then reads the *parent's* pid file. `spawn()` returns before the parent's `writeFileSync`, so under saturation the parent can be descheduled while the already-forked grandchild races ahead, and the read fails with `ENOENT`. This one only surfaced after fixing (1) and (2), at 1-in-10 under full CPU saturation.

## Why This Change Was Made

Test-only timing budgets; production is not racy (`runCommand` timeouts are seconds-to-minutes in real use, and the lane's `testTimeout` is 120s). The fix replaces guessed millisecond literals with two documented constants chosen from the measurements above:

- `PROCESS_WAIT_TIMEOUT_MS = 30_000` for every `waitForFile`/`waitForDead`/`waitForExit` poll. These return the instant the condition holds, so a wide budget costs nothing on success and only bounds a genuine hang.
- `TIMEOUT_TRIGGER_MS = 1_500` for the `runCommand` timeouts that must fire *after* the child installs its signal handlers. This one is paid in wall-clock, so it stays modest while keeping ~18x margin over measured startup.

Plus the two structural fixes: an explicit readiness marker in the ignore-SIGTERM child (so a slow spawn fails with "timeout waiting for ready.txt" instead of masquerading as a behavior failure), and the missing `childPidPath` wait — matching the pattern the sibling grandchild test in this file already uses.

The `expect(Date.now() - startedAt).toBeLessThan(1_500)` promptness bound is deliberately left alone: its clock starts after readiness, it never flaked, and it proves the forwarded-signal path beats the 5s default kill grace. Widening it would weaken a real assertion.

## User Impact

None — test-only. CI stops failing unrelated PRs on this file.

## Evidence

- Baseline on `main` (loaded machine): first run failed 2 tests, second failed 3; four distinct tests implicated.
- Measurements driving the constants: plain Node cold start 59/73/84/59/59/85ms; tsx-runner readiness 1220/483/916/702/1224ms.
- After fixes (1)+(2) only: **9/10** under 12 busy loops on 12 cores — the residual failure is what exposed race (3).
- After all three fixes: **12/12 green** on a heavily loaded machine (load average >200), and 21/21 on a normal run.
- oxlint clean, oxfmt clean, `git diff --check` clean, `tsgo` test-types lane clean.
- Autoreview (Codex gpt-5.6-sol, xhigh): clean, 0.96.
