### PR TITLE
fix(telegram): prevent unmodified replies flashing in previews

### DIFF
--- a/extensions/telegram/src/bot-message-dispatch-draft.ts
+++ b/extensions/telegram/src/bot-message-dispatch-draft.ts
@@ -60,6 +60,7 @@ function resolveDraftPartialText(
 
 export function createTelegramDraftController(params: {
   accountId: string;
+  allowProviderPreview: boolean;
   bot: Bot;
   cfg: OpenClawConfig;
   chatId: number;
@@ -82,6 +83,7 @@ export function createTelegramDraftController(params: {
     resolveChannelStreamingBlockEnabled(params.telegramCfg) ??
     params.cfg.agents?.defaults?.blockStreamingDefault === "on";
   const canStreamAnswerDraft =
+    params.allowProviderPreview &&
     streamDeliveryEnabled &&
     !params.hasTelegramQuoteReply &&
     !accountBlockStreamingEnabled &&
@@ -90,7 +92,10 @@ export function createTelegramDraftController(params: {
   const streamReasoningInProgressDraft =
     streamReasoningDraft && params.streamMode === "progress" && canStreamAnswerDraft;
   const canStreamReasoningDraft =
-    !params.isRoomEvent && streamReasoningDraft && !streamReasoningInProgressDraft;
+    params.allowProviderPreview &&
+    !params.isRoomEvent &&
+    streamReasoningDraft &&
+    !streamReasoningInProgressDraft;
   const draftMaxChars =
     params.streamMode === "block"
       ? Math.min(

--- a/extensions/telegram/src/bot-message-dispatch.preview-hook-safety.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.preview-hook-safety.test.ts
@@ -1,0 +1,75 @@
+import { expect, it, vi } from "vitest";
+import {
+  createContext,
+  createReasoningStreamContext,
+  createTelegramDraftStream,
+  describeTelegramDispatch,
+  dispatchWithContext,
+  expectDispatchParams,
+  getGlobalHookRunner,
+} from "./bot-message-dispatch.test-harness.js";
+
+function registerHooks(...hooks: string[]) {
+  const registered = new Set(hooks);
+  getGlobalHookRunner.mockReturnValue({
+    hasHooks: vi.fn((hookName: string) => registered.has(hookName)),
+  });
+}
+
+describeTelegramDispatch("Telegram provider preview hook safety", () => {
+  it("preserves answer previews when no hooks are registered", async () => {
+    await dispatchWithContext({ context: createContext() });
+
+    expect(createTelegramDraftStream).toHaveBeenCalledTimes(1);
+    expectDispatchParams({
+      replyOptions: expect.objectContaining({ disableBlockStreaming: true }),
+    });
+  });
+
+  it("preserves answer previews for observer-only hooks", async () => {
+    registerHooks("message_sent");
+
+    await dispatchWithContext({ context: createContext() });
+
+    expect(createTelegramDraftStream).toHaveBeenCalledTimes(1);
+  });
+
+  it.each(["reply_payload_sending", "message_sending"])(
+    "suppresses answer and progress previews when %s is registered",
+    async (hookName) => {
+      registerHooks(hookName);
+
+      await dispatchWithContext({ context: createContext(), streamMode: "progress" });
+
+      expect(createTelegramDraftStream).not.toHaveBeenCalled();
+      expectDispatchParams({
+        replyOptions: expect.objectContaining({
+          onPartialReply: undefined,
+          disableBlockStreaming: undefined,
+        }),
+      });
+    },
+  );
+
+  it("suppresses previews when both modifying hooks are registered", async () => {
+    registerHooks("reply_payload_sending", "message_sending");
+
+    await dispatchWithContext({ context: createContext() });
+
+    expect(createTelegramDraftStream).not.toHaveBeenCalled();
+  });
+
+  it("suppresses the independent reasoning preview when streaming is otherwise off", async () => {
+    registerHooks("message_sending");
+
+    await dispatchWithContext({ context: createReasoningStreamContext(), streamMode: "off" });
+
+    expect(createTelegramDraftStream).not.toHaveBeenCalled();
+  });
+
+  it("preserves the independent reasoning preview without modifying hooks", async () => {
+    await dispatchWithContext({ context: createReasoningStreamContext(), streamMode: "off" });
+
+    expect(createTelegramDraftStream).toHaveBeenCalledTimes(1);
+  });
+});

--- a/extensions/telegram/src/bot-message-dispatch.test-harness.ts
+++ b/extensions/telegram/src/bot-message-dispatch.test-harness.ts
@@ -113,6 +113,7 @@ const getAgentScopedMediaLocalRootsHoisted = vi.hoisted(() =>
 );
 const resolveChunkModeHoisted = vi.hoisted(() => vi.fn(() => undefined));
 const resolveMarkdownTableModeHoisted = vi.hoisted(() => vi.fn(() => "preserve"));
+const getGlobalHookRunnerHoisted = vi.hoisted(() => vi.fn());
 
 export const createTelegramDraftStream = createTelegramDraftStreamHoisted;
 export const dispatchReplyWithBufferedBlockDispatcher =
@@ -153,6 +154,7 @@ const resolveDefaultModelForAgent = resolveDefaultModelForAgentHoisted;
 const getAgentScopedMediaLocalRoots = getAgentScopedMediaLocalRootsHoisted;
 const resolveChunkMode = resolveChunkModeHoisted;
 export const resolveMarkdownTableMode = resolveMarkdownTableModeHoisted;
+export const getGlobalHookRunner = getGlobalHookRunnerHoisted;
 
 vi.mock("./draft-stream.js", () => ({
   createTelegramDraftStream: createTelegramDraftStreamHoisted,
@@ -163,6 +165,14 @@ vi.mock("openclaw/plugin-sdk/channel-outbound", async (importOriginal) => {
   return {
     ...actual,
     deliverInboundReplyWithMessageSendContext: deliverInboundReplyWithMessageSendContextHoisted,
+  };
+});
+
+vi.mock("openclaw/plugin-sdk/plugin-runtime", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("openclaw/plugin-sdk/plugin-runtime")>();
+  return {
+    ...actual,
+    getGlobalHookRunner: getGlobalHookRunnerHoisted,
   };
 });
 
@@ -380,6 +390,7 @@ function resetTelegramDispatchTestState() {
   getAgentScopedMediaLocalRoots.mockClear();
   resolveChunkMode.mockClear();
   resolveMarkdownTableMode.mockClear();
+  getGlobalHookRunner.mockReset();
   describeStickerImage.mockReset();
   loadModelCatalog.mockReset();
   findModelInCatalog.mockReset();
@@ -447,6 +458,7 @@ function resetTelegramDispatchTestState() {
     provider: "openai",
     model: "gpt-test",
   });
+  getGlobalHookRunner.mockReturnValue(null);
 }
 
 function cleanupTelegramDispatchTestState() {

--- a/extensions/telegram/src/bot-message-dispatch.ts
+++ b/extensions/telegram/src/bot-message-dispatch.ts
@@ -3,6 +3,7 @@ import {
   createOutboundPayloadPlan,
   projectOutboundPayloadPlanForDelivery,
 } from "openclaw/plugin-sdk/channel-outbound";
+import { getGlobalHookRunner } from "openclaw/plugin-sdk/plugin-runtime";
 import { createSubsystemLogger, danger, logVerbose } from "openclaw/plugin-sdk/runtime-env";
 import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import { resolveDispatchTelegramContext } from "./bot-message-dispatch-context.js";
@@ -314,11 +315,19 @@ export const dispatchTelegramMessage = async ({
   const forceBlockStreamingForReasoning =
     resolvedReasoningLevel === "on" && streamMode !== "progress";
   const quote = resolveTelegramQuoteContext({ context: dispatchContext, replyToMode });
+  // Draft messages are provider-visible before final modifiers run. Suppress them when a hook
+  // can rewrite or cancel, or the original payload can flash before the normal delivery gate.
+  const hookRunner = getGlobalHookRunner();
+  const allowProviderPreview = !(
+    (hookRunner?.hasHooks("reply_payload_sending") ?? false) ||
+    (hookRunner?.hasHooks("message_sending") ?? false)
+  );
   // Pre-adoption abort is drain-owned via turnAdoptionLifecycle.abortSignal.
   const isDispatchSuperseded = () => turnAdoptionLifecycle?.abortSignal?.aborted === true;
   const dispatchGeneration = 0;
   const draft = createTelegramDraftController({
     accountId: dispatchContext.route.accountId,
+    allowProviderPreview,
     bot,
     cfg,
     chatId: dispatchContext.chatId,


### PR DESCRIPTION
Related to #92374

This PR addresses the Telegram provider-preview disclosure slice only; it does not close the broader shared hook-delivery contract tracked in #92374.

## What Problem This Solves

Fixes an issue where Telegram users could briefly see an original reply before a plugin rewrote or canceled it. Provider-visible draft and progress previews could bypass the outbound modifying-hook boundary, so eventual edit or deletion repaired the final chat state only after content had already been disclosed.

## Why This Change Was Made

Telegram now enables provider previews only when neither `reply_payload_sending` nor `message_sending` is registered. Final delivery remains on the existing hook-governed path; observer-only hooks and hook-free configurations keep normal streaming previews. The change is confined to the Telegram plugin and adds no core or Plugin SDK surface.

## User Impact

Telegram replies governed by rewrite or cancellation plugins no longer flash unmodified content. Users without modifying hooks retain the existing streaming and reasoning-preview behavior.

## Evidence

Real Telegram Bot API, production Telegram plugin, real Gateway/model, and a locally signed-in human Telegram Desktop account:

| Live row | Result |
|---|---|
| Rewrite | No original preview; first bot-visible content was the twice-rewritten final. Provider ID `486`. |
| `reply_payload_sending` cancellation | No preview, draft, final message, or false `message_sent`. |
| `message_sending` cancellation | No preview, draft, final message, or false `message_sent`. |
| Long reply | No provider-visible content during generation; modified 5,051-character final delivered once. Provider ID `490`. |
| Text plus media | No original preview; rewritten caption and hook-added image finalized once. Provider ID `494`. |
| Observer-only control | Normal provider preview remained visible while the reply was still streaming; one final `message_sent`. Provider ID `497`. |

| Modifying hooks: no pre-hook preview | Observer-only hook: preview preserved |
|---|---|
| ![Only the human long-reply prompt is visible while modifiers are registered](https://github.com/user-attachments/assets/7ff1b58a-1df4-4c3a-b402-db0cb0eb4339) | ![The observer-only run visibly streams while Telegram still shows typing](https://github.com/user-attachments/assets/03b4ad94-b38f-4d66-8d2e-b6d881f6b88e) |

Additional inspectable evidence:

- [`reply_payload_sending` cancellation: no bot preview or final](https://github.com/user-attachments/assets/15c48ff7-c43d-40f6-ab39-4b228bfb4786)
- [`message_sending` cancellation: no bot preview or final](https://github.com/user-attachments/assets/754698d7-62f2-4abb-8566-80af9c1a7b76)
- [Rewritten text-plus-media final](https://github.com/user-attachments/assets/861a4c25-8b23-4e56-925b-87cb3b7711ba)
- [Modifying-hook sanitized trace](https://github.com/user-attachments/files/30438794/modifiers-hook-trace.log)
- [Modifying-hook reconciliation](https://github.com/user-attachments/files/30438787/modifiers-reconciliation.json)
- [Observer-only sanitized trace](https://github.com/user-attachments/files/30438797/observer-hook-trace.log)
- [Observer-only reconciliation](https://github.com/user-attachments/files/30438746/observer-reconciliation.json)

Live run provenance:

- Frozen-base failure reproduction: `run_9b03cb901d2e`
- Candidate modifying-hook proof: `run_3b441bfbfc64`
- Candidate observer-only control: `run_ab15cc66594a`
- Candidate lifecycle fingerprint: `f0d240f3b1634a2e2a6abc6e8d756aa675d8a714a9bac32ecd307527090af5d0`

Integrated-head proof:

- Rebased once onto frozen `main` `8a2852bdfa2`; tested merge-result tree exactly matches head `011921619bc`.
- Focused Testbox proof: 7 files, 183 assertions passed.
- Full `check:changed`: all lanes passed, including formatting, Plugin SDK surface, plugin boundaries, both extension typechecks, lint, and runtime guards.
- Fresh autoreview: no accepted/actionable findings. The full patch review scored correctness 0.93; the final lint-only correction scored 0.99.

The traces contain synthetic markers, lengths, hashes, hook state, and provider message IDs only. Images are cropped to the synthetic QA chat pane; credentials and unrelated Telegram content are excluded.

AI-assisted: implemented and validated with Codex, including real-provider E2E proof and mandatory autoreview.
