### PR TITLE
fix(onboarding): validate provider setup before writing agent state

### DIFF
--- a/src/commands/onboard-non-interactive/api-keys.test.ts
+++ b/src/commands/onboard-non-interactive/api-keys.test.ts
@@ -41,6 +41,36 @@ function createRuntime() {
 }
 
 describe("resolveNonInteractiveApiKey", () => {
+  it("resolves provider environment auth against the staged config and agent workspace", async () => {
+    const runtime = createRuntime();
+    const cfg = { plugins: { entries: { example: { enabled: true } } } };
+    const workspaceDir = "/tmp/openclaw-example-workspace";
+    resolveEnvApiKey.mockReturnValue({
+      apiKey: "example-manifest-key",
+      source: "env: EXAMPLE_WORKSPACE_API_KEY",
+    });
+
+    const result = await resolveNonInteractiveApiKey({
+      provider: "example",
+      cfg,
+      workspaceDir,
+      flagName: "--example-api-key",
+      envVar: "EXAMPLE_API_KEY",
+      runtime: runtime as never,
+    });
+
+    expect(result).toEqual({
+      key: "example-manifest-key",
+      source: "env",
+      envVarName: "EXAMPLE_WORKSPACE_API_KEY",
+    });
+    expect(resolveEnvApiKey).toHaveBeenCalledWith("example", process.env, {
+      config: cfg,
+      workspaceDir,
+    });
+    expect(runtime.exit).not.toHaveBeenCalled();
+  });
+
   it("returns explicit flag keys before resolving env or plugin-backed setup", async () => {
     const runtime = createRuntime();
     resolveEnvApiKey.mockImplementation(() => {

--- a/src/commands/onboard-non-interactive/api-keys.ts
+++ b/src/commands/onboard-non-interactive/api-keys.ts
@@ -69,6 +69,7 @@ export async function resolveNonInteractiveApiKey(params: {
   envVarName?: string;
   runtime: RuntimeEnv;
   agentDir?: string;
+  workspaceDir?: string;
   allowProfile?: boolean;
   required?: boolean;
   secretInputMode?: SecretInputMode;
@@ -77,7 +78,10 @@ export async function resolveNonInteractiveApiKey(params: {
   const explicitEnvVar = params.envVarName?.trim() || params.envVar.trim();
   const resolveExplicitEnvKey = () => normalizeOptionalSecretInput(process.env[explicitEnvVar]);
   const resolveEnvKey = () => {
-    const envResolved = resolveEnvApiKey(params.provider);
+    const envResolved = resolveEnvApiKey(params.provider, process.env, {
+      config: params.cfg,
+      workspaceDir: params.workspaceDir,
+    });
     const explicitEnvKey = explicitEnvVar
       ? normalizeOptionalSecretInput(process.env[explicitEnvVar])
       : undefined;

--- a/src/commands/onboard-non-interactive/config-write.test.ts
+++ b/src/commands/onboard-non-interactive/config-write.test.ts
@@ -1,0 +1,57 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
+
+const writeWizardConfigFile = vi.hoisted(() => vi.fn());
+
+vi.mock("../../wizard/setup.shared.js", () => ({ writeWizardConfigFile }));
+
+import { commitNonInteractiveOnboardConfig } from "./config-write.js";
+
+describe("commitNonInteractiveOnboardConfig", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    writeWizardConfigFile.mockImplementation(async (config: OpenClawConfig) => config);
+  });
+
+  it("keeps the verified config hash and pending-install owner on the canonical writer", async () => {
+    const baseConfig: OpenClawConfig = {
+      plugins: {
+        installs: { demo: { source: "npm", spec: "demo@1.0.0" } },
+      },
+    };
+    const nextConfig: OpenClawConfig = {
+      ...baseConfig,
+      gateway: { port: 19_001 },
+    };
+
+    await expect(
+      commitNonInteractiveOnboardConfig({
+        nextConfig,
+        baseConfig,
+        baseHash: "verified-config-hash",
+      }),
+    ).resolves.toBe(nextConfig);
+
+    expect(writeWizardConfigFile).toHaveBeenCalledWith(nextConfig, {
+      allowConfigSizeDrop: false,
+      baseHash: "verified-config-hash",
+      migrationBaseConfig: baseConfig,
+    });
+  });
+
+  it("permits config size reduction only for an explicitly requested reset", async () => {
+    const baseConfig: OpenClawConfig = { gateway: { port: 19_001 } };
+    const nextConfig: OpenClawConfig = {};
+
+    await commitNonInteractiveOnboardConfig({
+      nextConfig,
+      baseConfig,
+      reset: true,
+    });
+
+    expect(writeWizardConfigFile).toHaveBeenCalledWith(nextConfig, {
+      allowConfigSizeDrop: true,
+      migrationBaseConfig: baseConfig,
+    });
+  });
+});

--- a/src/commands/onboard-non-interactive/config-write.ts
+++ b/src/commands/onboard-non-interactive/config-write.ts
@@ -1,17 +1,4 @@
-import { replaceConfigFile } from "../../config/config.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
-/**
- * Config write commit helper for non-interactive onboarding.
- *
- * It preserves pending plugin install records before replacing the user config,
- * which lets setup reruns avoid dropping plugin-owned state accidentally.
- */
-import {
-  commitConfigWriteWithPendingPluginInstalls,
-  hasPendingPluginInstallRecords,
-  stripPendingPluginInstallRecords,
-  unchangedPendingPluginInstallRecordIds,
-} from "../../plugins/install-record-commit.js";
 
 /** Commits a non-interactive onboard config update with pending plugin records handled first. */
 export async function commitNonInteractiveOnboardConfig(params: {
@@ -20,43 +7,12 @@ export async function commitNonInteractiveOnboardConfig(params: {
   baseHash?: string;
   reset?: boolean;
 }): Promise<OpenClawConfig> {
+  const { writeWizardConfigFile } = await import("../../wizard/setup.shared.js");
   // Ordinary onboard reruns must preserve existing agents.list / bindings.
   // Only explicit --reset may allow a config size drop; see openclaw#84692.
-  const allowConfigSizeDrop = params.reset === true;
-  let writeBaseHash = params.baseHash;
-  let nextConfig = params.nextConfig;
-  if (!allowConfigSizeDrop && hasPendingPluginInstallRecords(params.baseConfig)) {
-    // Pending install records are persisted against the old config first so the
-    // later onboard write can use the fresh hash and keep optimistic locking.
-    const migrated = await commitConfigWriteWithPendingPluginInstalls({
-      nextConfig: params.baseConfig,
-      writeOptions: { allowConfigSizeDrop: true },
-      commit: async (config, writeOptions) => {
-        return await replaceConfigFile({
-          nextConfig: config,
-          ...(writeBaseHash !== undefined ? { baseHash: writeBaseHash } : {}),
-          ...(writeOptions ? { writeOptions } : {}),
-        });
-      },
-    });
-    writeBaseHash = migrated.persistedHash ?? undefined;
-    // If onboard did not change a pending record, strip it from the next write;
-    // the migration above has already committed the durable version.
-    nextConfig = stripPendingPluginInstallRecords(
-      nextConfig,
-      unchangedPendingPluginInstallRecordIds(nextConfig, params.baseConfig),
-    );
-  }
-  const committed = await commitConfigWriteWithPendingPluginInstalls({
-    nextConfig,
-    writeOptions: { allowConfigSizeDrop },
-    commit: async (config, writeOptions) => {
-      return await replaceConfigFile({
-        nextConfig: config,
-        ...(writeBaseHash !== undefined ? { baseHash: writeBaseHash } : {}),
-        ...(writeOptions ? { writeOptions } : {}),
-      });
-    },
+  return await writeWizardConfigFile(params.nextConfig, {
+    allowConfigSizeDrop: params.reset === true,
+    ...(params.baseHash !== undefined ? { baseHash: params.baseHash } : {}),
+    migrationBaseConfig: params.baseConfig,
   });
-  return committed.config;
 }

--- a/src/commands/onboard-non-interactive/local.default-agent.test.ts
+++ b/src/commands/onboard-non-interactive/local.default-agent.test.ts
@@ -4,8 +4,12 @@ import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import type { RuntimeEnv } from "../../runtime.js";
 
 const mocks = vi.hoisted(() => ({
+  applyAuthChoice: vi.fn(),
+  applyGatewayConfig: vi.fn(),
   commitConfig: vi.fn(),
+  ensureOnboardingAgent: vi.fn(),
   ensureWorkspaceAndSessions: vi.fn(),
+  inferAuthChoice: vi.fn(),
   logConfigUpdated: vi.fn(),
   logJson: vi.fn(),
 }));
@@ -30,14 +34,20 @@ vi.mock("./config-write.js", () => ({
   commitNonInteractiveOnboardConfig: mocks.commitConfig,
 }));
 
+vi.mock("../onboard-agent.js", () => ({
+  ensureOnboardingAgent: mocks.ensureOnboardingAgent,
+}));
+
+vi.mock("./local/auth-choice.js", () => ({
+  applyNonInteractiveAuthChoice: mocks.applyAuthChoice,
+}));
+
+vi.mock("./local/auth-choice-inference.js", () => ({
+  inferAuthChoiceFromFlags: mocks.inferAuthChoice,
+}));
+
 vi.mock("./local/gateway-config.js", () => ({
-  applyNonInteractiveGatewayConfig: ({ nextConfig }: { nextConfig: OpenClawConfig }) => ({
-    nextConfig,
-    port: 18789,
-    bind: "loopback",
-    authMode: "token",
-    tailscaleMode: "off",
-  }),
+  applyNonInteractiveGatewayConfig: mocks.applyGatewayConfig,
 }));
 
 vi.mock("./local/output.js", () => ({
@@ -60,9 +70,136 @@ const runtime = {
 describe("runNonInteractiveLocalSetup default-agent ownership", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mocks.applyAuthChoice.mockImplementation(
+      async ({ nextConfig }: { nextConfig: OpenClawConfig }) => nextConfig,
+    );
+    mocks.applyGatewayConfig.mockImplementation(
+      ({ nextConfig }: { nextConfig: OpenClawConfig }) => ({
+        nextConfig,
+        port: 18789,
+        bind: "loopback",
+        authMode: "token",
+        tailscaleMode: "off",
+      }),
+    );
     mocks.commitConfig.mockImplementation(
       async ({ nextConfig }: { nextConfig: OpenClawConfig }) => nextConfig,
     );
+    mocks.ensureOnboardingAgent.mockImplementation(
+      async ({ config }: { config: OpenClawConfig }) => ({
+        config,
+        agentId: "ops",
+        bootstrapPending: false,
+      }),
+    );
+    mocks.inferAuthChoice.mockReturnValue({ matches: [] });
+  });
+
+  it("rejects ambiguous provider flags before creating an agent or writing setup state", async () => {
+    mocks.inferAuthChoice.mockReturnValue({
+      matches: [
+        { optionKey: "openaiApiKey", authChoice: "openai-api-key", label: "--openai-api-key" },
+        {
+          optionKey: "anthropicApiKey",
+          authChoice: "anthropic-api-key",
+          label: "--anthropic-api-key",
+        },
+      ],
+    });
+
+    await runNonInteractiveLocalSetup({
+      opts: {
+        nonInteractive: true,
+        mode: "local",
+        openaiApiKey: "openai-test-key",
+        anthropicApiKey: "anthropic-test-key",
+        skipHooks: true,
+        skipSkills: true,
+        skipHealth: true,
+      },
+      runtime,
+      baseConfig: {},
+    });
+
+    expect(runtime.error).toHaveBeenCalledWith(
+      expect.stringContaining("Multiple API key flags were provided"),
+    );
+    expect(runtime.exit).toHaveBeenCalledWith(1);
+    expect(mocks.applyGatewayConfig).not.toHaveBeenCalled();
+    expect(mocks.applyAuthChoice).not.toHaveBeenCalled();
+    expect(mocks.ensureOnboardingAgent).not.toHaveBeenCalled();
+    expect(mocks.commitConfig).not.toHaveBeenCalled();
+    expect(mocks.ensureWorkspaceAndSessions).not.toHaveBeenCalled();
+  });
+
+  it("resolves provider auth in the requested first-agent workspace before creating state", async () => {
+    const workspace = "/tmp/requested-provider-workspace";
+    mocks.ensureOnboardingAgent.mockImplementationOnce(
+      async ({ config }: { config: OpenClawConfig }) => ({
+        config: {
+          ...config,
+          agents: {
+            ...config.agents,
+            entries: { main: { default: true, workspace } },
+          },
+        },
+        agentId: "main",
+        bootstrapPending: true,
+      }),
+    );
+
+    await runNonInteractiveLocalSetup({
+      opts: {
+        nonInteractive: true,
+        mode: "local",
+        workspace,
+        authChoice: "demo-api-key",
+        skipHooks: true,
+        skipSkills: true,
+        skipHealth: true,
+      },
+      runtime,
+      baseConfig: {},
+    });
+
+    expect(mocks.applyAuthChoice).toHaveBeenCalledWith(
+      expect.objectContaining({
+        nextConfig: expect.objectContaining({
+          agents: expect.objectContaining({ defaults: expect.objectContaining({ workspace }) }),
+        }),
+        target: expect.objectContaining({ agentId: "main", workspaceDir: workspace }),
+      }),
+    );
+    expect(mocks.applyAuthChoice.mock.invocationCallOrder[0]).toBeLessThan(
+      mocks.ensureOnboardingAgent.mock.invocationCallOrder[0]!,
+    );
+    expect(mocks.commitConfig.mock.invocationCallOrder[0]).toBeGreaterThan(
+      mocks.ensureOnboardingAgent.mock.invocationCallOrder[0]!,
+    );
+  });
+
+  it("rejects invalid gateway options before provider auth or first-agent creation", async () => {
+    mocks.applyGatewayConfig.mockReturnValue(null);
+
+    await runNonInteractiveLocalSetup({
+      opts: {
+        nonInteractive: true,
+        mode: "local",
+        authChoice: "demo-api-key",
+        gatewayPort: 70_000,
+        skipHooks: true,
+        skipSkills: true,
+        skipHealth: true,
+      },
+      runtime,
+      baseConfig: {},
+    });
+
+    expect(mocks.applyGatewayConfig).toHaveBeenCalledOnce();
+    expect(mocks.applyAuthChoice).not.toHaveBeenCalled();
+    expect(mocks.ensureOnboardingAgent).not.toHaveBeenCalled();
+    expect(mocks.commitConfig).not.toHaveBeenCalled();
+    expect(mocks.ensureWorkspaceAndSessions).not.toHaveBeenCalled();
   });
 
   it("provisions and reports the keyed default agent while preserving the global workspace", async () => {

--- a/src/commands/onboard-non-interactive/local.ts
+++ b/src/commands/onboard-non-interactive/local.ts
@@ -199,20 +199,8 @@ export async function runNonInteractiveLocalSetup(params: {
   if (opts.skipBootstrap) {
     nextConfig = applySkipBootstrapConfig(nextConfig);
   }
-  const { ensureOnboardingAgent } = await import("../onboard-agent.js");
-  const created = await ensureOnboardingAgent({
-    config: nextConfig,
-    workspace: workspaceDir,
-    baseConfig,
-  });
-  nextConfig = applyLocalSetupWorkspaceConfig(created.config, requestedWorkspaceDir);
-  // Creating the first roster agent writes the config file, so the hash captured
-  // before this step no longer matches. Adopt the post-create hash; foreign
-  // writes are still rejected because we only trust the write we just made.
-  const effectiveBaseHash = created.configHash ?? baseHash;
-  if (opts.skipBootstrap) {
-    nextConfig = applySkipBootstrapConfig(nextConfig);
-  }
+  // Workspace defaults are already staged above; provider discovery must use
+  // that requested owner before first-agent creation is allowed to write.
   const authTarget = resolveOnboardingAgentTarget(nextConfig);
 
   const inferredAuthChoice = opts.authChoice
@@ -236,6 +224,21 @@ export async function runNonInteractiveLocalSetup(params: {
     return;
   }
   const authChoice = opts.authChoice ?? inferredAuthChoice?.choice ?? "skip";
+
+  // Validate the complete Gateway proposal before provider methods or first-
+  // agent creation can write credentials, config, or workspace state.
+  const gatewayResult = applyNonInteractiveGatewayConfig({
+    nextConfig,
+    opts,
+    runtime,
+    defaultPort: resolveGatewayPort(baseConfig),
+  });
+  if (!gatewayResult) {
+    return;
+  }
+  nextConfig = gatewayResult.nextConfig;
+  nextConfig = applyNonInteractiveSkillsConfig({ nextConfig, opts, runtime });
+
   if (authChoice !== "skip") {
     // Auth-choice handling is loaded only when needed so skip-only onboarding
     // avoids provider plugin discovery and credential helper imports.
@@ -254,21 +257,22 @@ export async function runNonInteractiveLocalSetup(params: {
     nextConfig = nextConfigAfterAuth;
   }
 
-  const gatewayBasePort = resolveGatewayPort(baseConfig);
-  const gatewayResult = applyNonInteractiveGatewayConfig({
-    nextConfig,
-    opts,
-    runtime,
-    defaultPort: gatewayBasePort,
-  });
-  if (!gatewayResult) {
-    return;
-  }
-  nextConfig = gatewayResult.nextConfig;
-
-  nextConfig = applyNonInteractiveSkillsConfig({ nextConfig, opts, runtime });
   if (!opts.skipHooks) {
     nextConfig = enableDefaultOnboardingInternalHooks(nextConfig);
+  }
+
+  const { ensureOnboardingAgent } = await import("../onboard-agent.js");
+  const created = await ensureOnboardingAgent({
+    config: nextConfig,
+    workspace: workspaceDir,
+    baseConfig,
+  });
+  nextConfig = applyLocalSetupWorkspaceConfig(created.config, requestedWorkspaceDir);
+  // First-agent creation is the first permitted config mutation. Preserve its
+  // resulting hash so the canonical wizard write still rejects foreign edits.
+  const effectiveBaseHash = created.configHash ?? baseHash;
+  if (opts.skipBootstrap) {
+    nextConfig = applySkipBootstrapConfig(nextConfig);
   }
 
   nextConfig = applyWizardMetadata(nextConfig, { command: "onboard", mode });

--- a/src/commands/onboard-non-interactive/local/auth-choice.ts
+++ b/src/commands/onboard-non-interactive/local/auth-choice.ts
@@ -95,6 +95,7 @@ export async function applyNonInteractiveAuthChoice(params: {
     resolveNonInteractiveApiKey({
       ...input,
       agentDir: params.target.agentDir,
+      workspaceDir: params.target.workspaceDir,
       secretInputMode: requestedSecretInputMode,
     });
   const toApiKeyCredential = (paramsLocal: {
@@ -222,7 +223,7 @@ export async function applyNonInteractiveAuthChoice(params: {
     resolveApiKey: (input) =>
       resolveApiKey({
         ...input,
-        cfg: baseConfig,
+        cfg: nextConfig,
         runtime,
       }),
     toApiKeyCredential,
@@ -263,7 +264,7 @@ export async function applyNonInteractiveAuthChoice(params: {
       });
       const resolvedCustomApiKey = await resolveApiKey({
         provider: resolvedProviderId.providerId,
-        cfg: baseConfig,
+        cfg: nextConfig,
         flagValue: customAuth.apiKey,
         flagName: "--custom-api-key",
         envVar: "CUSTOM_API_KEY",

--- a/src/plugins/provider-auth-input.test.ts
+++ b/src/plugins/provider-auth-input.test.ts
@@ -1,5 +1,6 @@
 // Covers provider auth input collection and credential handling.
 import { afterEach, describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { WizardPrompter } from "../wizard/prompts.js";
 import {
   ensureApiKeyFromEnvOrPrompt,
@@ -13,13 +14,19 @@ import {
 const acceptAnyApiKeyInput = () => undefined;
 
 const resolveEnvApiKey = vi.hoisted(() =>
-  vi.fn((provider: string, env?: NodeJS.ProcessEnv) => {
-    if (provider !== "minimax") {
-      return null;
-    }
-    const apiKey = env?.MINIMAX_API_KEY?.trim();
-    return apiKey ? { apiKey, source: "env: MINIMAX_API_KEY" } : null;
-  }),
+  vi.fn(
+    (
+      provider: string,
+      env?: NodeJS.ProcessEnv,
+      _options?: { config?: OpenClawConfig; workspaceDir?: string },
+    ) => {
+      if (provider !== "minimax") {
+        return null;
+      }
+      const apiKey = env?.MINIMAX_API_KEY?.trim();
+      return apiKey ? { apiKey, source: "env: MINIMAX_API_KEY" } : null;
+    },
+  ),
 );
 
 vi.mock("../agents/model-auth-env.js", () => ({
@@ -243,6 +250,32 @@ describe("validateApiKeyInput", () => {
 });
 
 describe("ensureApiKeyFromEnvOrPrompt", () => {
+  it("resolves environment auth using the same config and workspace as provider runtime", async () => {
+    const workspaceDir = "/tmp/openclaw-provider-workspace";
+    const config: OpenClawConfig = {
+      agents: { defaults: { workspace: workspaceDir } },
+      plugins: { entries: { minimax: { enabled: true } } },
+    };
+    const env = { MINIMAX_API_KEY: "workspace-env-key" } as NodeJS.ProcessEnv;
+    const { confirm, text, setCredential } = createPromptAndCredentialSpies();
+
+    const result = await ensureMinimaxApiKey({
+      config,
+      env,
+      confirm,
+      text,
+      setCredential,
+    });
+
+    expect(result).toBe("workspace-env-key");
+    expect(resolveEnvApiKey).toHaveBeenCalledWith("minimax", env, {
+      config,
+      workspaceDir,
+    });
+    expect(setCredential).toHaveBeenCalledWith("workspace-env-key", "plaintext");
+    expect(text).not.toHaveBeenCalled();
+  });
+
   it("uses env credential when user confirms", async () => {
     const { result, setCredential, text } = await runEnsureMinimaxApiKeyFlow({
       confirmResult: true,

--- a/src/plugins/provider-auth-input.ts
+++ b/src/plugins/provider-auth-input.ts
@@ -5,6 +5,7 @@ import {
   normalizeStringifiedOptionalString,
 } from "@openclaw/normalization-core/string-coerce";
 import { sliceUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
+import { resolveAgentWorkspaceDir, resolveDefaultAgentId } from "../agents/agent-scope-config.js";
 import { isMalformedApiKeyInput } from "../agents/auth-profiles/credential-state.js";
 import { resolveEnvApiKey } from "../agents/model-auth-env.js";
 import type { OpenClawConfig } from "../config/types.js";
@@ -196,7 +197,16 @@ export async function ensureApiKeyFromEnvOrPrompt(params: {
     explicitMode: params.secretInputMode,
   });
   const env = params.env ?? process.env;
-  const envKey = resolveEnvApiKey(params.provider, env);
+  // Setup must resolve the same trusted workspace/provider descriptors as
+  // runtime; dropping the staged config silently changes credential ownership.
+  const envKey = resolveEnvApiKey(params.provider, env, {
+    config: params.config,
+    workspaceDir: resolveAgentWorkspaceDir(
+      params.config,
+      resolveDefaultAgentId(params.config),
+      env,
+    ),
+  });
 
   if (selectedMode === "ref") {
     if (typeof params.prompter.select !== "function") {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users running non-interactive provider onboarding could end up with a newly created agent or provider credentials even though their API-key flags were ambiguous or their Gateway options were invalid. Also resolves a problem where provider setup could miss a trusted, workspace-scoped credential that the model runtime can already resolve.

## Why This Change Was Made

Stage and validate the requested workspace, provider choice, and Gateway configuration before first-agent creation or provider-auth side effects. Route local and remote onboarding through the existing canonical wizard config writer so optimistic hashes, pending plugin-install migration, reset size-drop policy, and config-safe after-write handling have one owner. Resolve interactive and non-interactive provider credentials with the same staged configuration and intended workspace as runtime.

This deliberately preserves existing provider manifests, plugin trust and disablement, documented CLI flags and aliases, OAuth, SecretRefs, self-hosted/custom URLs, cold discovery, model defaults, and the public Plugin SDK baseline. It does not migrate Chutes OAuth or custom vLLM/SGLang provider methods to an incompatible API-key factory.

## User Impact

Invalid non-interactive onboarding exits without creating an agent or partially writing configuration. Valid provider onboarding continues to honor existing workspaces, custom LiteLLM proxy URLs, provider defaults, stored profiles, SecretRefs, and pending plugin installs.

## Evidence

- Blacksmith Testbox: `tbx_01kyjz1s8gn80qca0hfsbnahyk` (`violet-hermit-d51a`); [run](https://github.com/openclaw/openclaw/actions/runs/30314743733).
- Focused proof: `pnpm test src/commands/onboard-non-interactive/config-write.test.ts src/commands/onboard-non-interactive/local.default-agent.test.ts src/commands/onboard-non-interactive.gateway.test.ts src/commands/onboard-non-interactive/api-keys.test.ts src/plugins/provider-auth-input.test.ts src/plugins/provider-api-key-auth.test.ts src/wizard/setup.shared.test.ts src/plugin-sdk/provider-entry.test.ts test/plugins/bundled-provider-auth-literal-parity.test.ts extensions/litellm/index.test.ts extensions/litellm/onboard.test.ts extensions/sglang/index.test.ts extensions/sglang/provider-discovery.contract.test.ts extensions/vllm/provider-discovery.contract.test.ts extensions/chutes/oauth.test.ts`.
- Final exact-diff provider, onboarding, auth, hash, pending-install, and workspace regressions: **PASS — 168 tests, 15 test files, 8 Vitest shards.**
- Changed gate: `pnpm docs:list` and `pnpm check:changed`, including core production and test typechecks, lint, formatting, plugin boundaries, dependency guards, and unchanged Plugin SDK API baseline: PASS.
- Build: `pnpm build`: PASS.
- Live proof on a disposable Testbox state directory and isolated loopback port `43369`: ambiguous OpenAI/Anthropic flags exit `1` with no config or agent state; valid non-interactive LiteLLM onboarding preserves `http://127.0.0.1:19999/v1`, `litellm/claude-opus-4-6`, and `litellm:default`; the independently started built Gateway returns `/healthz` HTTP `200` and `/readyz` HTTP `200`; the proof-owned PID and temporary state are cleaned up.
- Independent review: `.agents/skills/autoreview/scripts/autoreview --mode uncommitted` — `autoreview clean: no accepted/actionable findings reported`.
- Production code: **55 additions, 80 deletions; net -25 lines.** No schema, protocol, environment, generated baseline, or public SDK changes.
- AI-assisted implementation and review.
