### PR TITLE
fix(compaction): prevent zero-progress cuts

### DIFF
--- a/packages/agent-core/src/harness/compaction/compaction.test.ts
+++ b/packages/agent-core/src/harness/compaction/compaction.test.ts
@@ -418,6 +418,46 @@ describe("session-entry compaction budgeting", () => {
     expect(result.value.messagesToSummarize.length).toBeGreaterThan(0);
   });
 
+  it("does not normalize from provider usage older than the current boundary", () => {
+    const buildEntries = (usageTokens: number): SessionTreeEntry[] => {
+      const entries = Array.from({ length: 5 }, (_, index) =>
+        createMessageEntry(
+          {
+            role: "user",
+            content: `retained ${index} ${"x".repeat(20_000)}`,
+            timestamp: index + 1,
+          },
+          index,
+        ),
+      );
+      entries.push(
+        createMessageEntry(createAssistant("checkpoint", createUsage(usageTokens), 6), 5),
+      );
+      entries.push({
+        type: "compaction",
+        id: "entry-6",
+        parentId: "entry-5",
+        timestamp: new Date(7).toISOString(),
+        summary: "older context",
+        firstKeptEntryId: "entry-0",
+        tokensBefore: 40_000,
+      });
+      entries.push(createMessageEntry({ role: "user", content: "new request", timestamp: 8 }, 7));
+      return entries;
+    };
+    const settings = { enabled: true, reserveTokens: 16_384, keepRecentTokens: 20_000 };
+
+    const withStaleUsage = prepareCompaction(buildEntries(40_000), settings);
+    const withoutUsage = prepareCompaction(buildEntries(0), settings);
+
+    expect(withStaleUsage.ok && withStaleUsage.value).toBeTruthy();
+    expect(withoutUsage.ok && withoutUsage.value).toBeTruthy();
+    if (!withStaleUsage.ok || !withStaleUsage.value || !withoutUsage.ok || !withoutUsage.value) {
+      throw new Error("expected retained history to be compactable");
+    }
+    expect(withStaleUsage.value.firstKeptEntryId).toBe(withoutUsage.value.firstKeptEntryId);
+  });
+
   it("keeps reset-filtered tool rows out of later compaction input", () => {
     const entries: SessionTreeEntry[] = [
       createMessageEntry({ role: "user", content: "discarded", timestamp: 1 }, 0),

--- a/packages/agent-core/src/harness/compaction/compaction.test.ts
+++ b/packages/agent-core/src/harness/compaction/compaction.test.ts
@@ -391,6 +391,33 @@ describe("session-entry compaction budgeting", () => {
     ).toBeGreaterThan(0);
   });
 
+  it("does not scale estimated messages after the provider usage snapshot", () => {
+    const entries: SessionTreeEntry[] = Array.from({ length: 5 }, (_, index) =>
+      createMessageEntry(
+        { role: "user", content: `old ${index} ${"x".repeat(4_000)}`, timestamp: index + 1 },
+        index,
+      ),
+    );
+    entries.push(createMessageEntry(createAssistant("checkpoint", createUsage(40_000), 6), 5));
+    entries.push(
+      createMessageEntry({ role: "user", content: "a".repeat(20_000), timestamp: 7 }, 6),
+      createMessageEntry({ role: "user", content: "b".repeat(20_000), timestamp: 8 }, 7),
+    );
+
+    const result = prepareCompaction(entries, {
+      enabled: true,
+      reserveTokens: 16_384,
+      keepRecentTokens: 20_000,
+    });
+
+    expect(result.ok && result.value).toBeTruthy();
+    if (!result.ok || !result.value) {
+      throw new Error("expected the usage-covered prefix to be compactable");
+    }
+    expect(Number(result.value.firstKeptEntryId.slice("entry-".length))).toBeLessThan(6);
+    expect(result.value.messagesToSummarize.length).toBeGreaterThan(0);
+  });
+
   it("keeps reset-filtered tool rows out of later compaction input", () => {
     const entries: SessionTreeEntry[] = [
       createMessageEntry({ role: "user", content: "discarded", timestamp: 1 }, 0),

--- a/packages/agent-core/src/harness/compaction/compaction.test.ts
+++ b/packages/agent-core/src/harness/compaction/compaction.test.ts
@@ -419,7 +419,7 @@ describe("session-entry compaction budgeting", () => {
   });
 
   it("does not normalize from provider usage older than the current boundary", () => {
-    const buildEntries = (usageTokens: number): SessionTreeEntry[] => {
+    const buildEntries = (usageTokens: number, postBoundaryUsage = false): SessionTreeEntry[] => {
       const entries = Array.from({ length: 5 }, (_, index) =>
         createMessageEntry(
           {
@@ -442,7 +442,17 @@ describe("session-entry compaction budgeting", () => {
         firstKeptEntryId: "entry-0",
         tokensBefore: 40_000,
       });
-      entries.push(createMessageEntry({ role: "user", content: "new request", timestamp: 8 }, 7));
+      if (postBoundaryUsage) {
+        entries.push(
+          createMessageEntry(createAssistant("new checkpoint", createUsage(40_000), 7), 7),
+        );
+      }
+      entries.push(
+        createMessageEntry(
+          { role: "user", content: "new request", timestamp: 8 },
+          postBoundaryUsage ? 8 : 7,
+        ),
+      );
       return entries;
     };
     const settings = { enabled: true, reserveTokens: 16_384, keepRecentTokens: 20_000 };
@@ -456,6 +466,15 @@ describe("session-entry compaction budgeting", () => {
       throw new Error("expected retained history to be compactable");
     }
     expect(withStaleUsage.value.firstKeptEntryId).toBe(withoutUsage.value.firstKeptEntryId);
+
+    const withCurrentUsage = prepareCompaction(buildEntries(40_000, true), settings);
+    expect(withCurrentUsage.ok && withCurrentUsage.value).toBeTruthy();
+    if (!withCurrentUsage.ok || !withCurrentUsage.value) {
+      throw new Error("expected current usage to normalize the retained budget");
+    }
+    expect(Number(withCurrentUsage.value.firstKeptEntryId.slice("entry-".length))).toBeGreaterThan(
+      Number(withoutUsage.value.firstKeptEntryId.slice("entry-".length)),
+    );
   });
 
   it("keeps reset-filtered tool rows out of later compaction input", () => {

--- a/packages/agent-core/src/harness/compaction/compaction.test.ts
+++ b/packages/agent-core/src/harness/compaction/compaction.test.ts
@@ -333,6 +333,64 @@ describe("session-entry compaction budgeting", () => {
     ).toEqual({ ok: true, value: undefined });
   });
 
+  it("does not normalize the keep budget from non-finite provider usage", () => {
+    const entries = [
+      createMessageEntry({ role: "user", content: "hello", timestamp: 1 }, 0),
+      createMessageEntry(createAssistant("done", createUsage(Number.POSITIVE_INFINITY), 2), 1),
+    ];
+
+    expect(
+      prepareCompaction(entries, {
+        enabled: true,
+        reserveTokens: 0,
+        keepRecentTokens: 10_000,
+      }),
+    ).toEqual({ ok: true, value: undefined });
+  });
+
+  it("advances the boundary when provider usage exceeds transcript estimates", () => {
+    const entries: SessionTreeEntry[] = [
+      createMessageEntry({ role: "user", content: `task ${"x".repeat(3_000)}`, timestamp: 1 }, 0),
+    ];
+    for (let turn = 0; turn < 30; turn++) {
+      entries.push(
+        createMessageEntry(
+          createAssistant(`step ${turn}`, createUsage(20_000 + turn * 1_000), 2 + turn * 2),
+          entries.length,
+        ),
+      );
+      entries.push(
+        createMessageEntry(
+          {
+            role: "toolResult",
+            toolCallId: `call-${turn}`,
+            toolName: "read",
+            content: [{ type: "text", text: `tool output ${turn} `.repeat(40) }],
+            isError: false,
+            timestamp: 3 + turn * 2,
+          },
+          entries.length,
+        ),
+      );
+    }
+
+    const result = prepareCompaction(entries, {
+      enabled: true,
+      reserveTokens: 16_384,
+      keepRecentTokens: 20_000,
+    });
+
+    expect(result.ok && result.value).toBeTruthy();
+    if (!result.ok || !result.value) {
+      throw new Error("expected usage pressure to produce a compaction boundary");
+    }
+    expect(result.value.tokensBefore).toBe(49_150);
+    expect(result.value.firstKeptEntryId).not.toBe("entry-0");
+    expect(
+      result.value.messagesToSummarize.length + result.value.turnPrefixMessages.length,
+    ).toBeGreaterThan(0);
+  });
+
   it("keeps reset-filtered tool rows out of later compaction input", () => {
     const entries: SessionTreeEntry[] = [
       createMessageEntry({ role: "user", content: "discarded", timestamp: 1 }, 0),

--- a/packages/agent-core/src/harness/compaction/compaction.ts
+++ b/packages/agent-core/src/harness/compaction/compaction.ts
@@ -739,6 +739,7 @@ export function prepareCompaction(
       break;
     }
   }
+  const boundaryEntryIndex = prevBoundaryIndex;
   const prevBoundary = prevBoundaryIndex >= 0 ? pathEntries[prevBoundaryIndex] : undefined;
 
   let previousSummary: string | undefined;
@@ -776,14 +777,15 @@ export function prepareCompaction(
     contextUsage.lastUsageIndex === null
       ? []
       : contextMessages.slice(0, contextUsage.lastUsageIndex + 1);
-  const usageSourceMessage =
-    contextUsage.lastUsageIndex === null
-      ? undefined
-      : contextMessages.at(contextUsage.lastUsageIndex);
   const usageIsCurrent =
-    !prevBoundary ||
-    (usageSourceMessage?.role === "assistant" &&
-      usageSourceMessage.timestamp > new Date(prevBoundary.timestamp).getTime());
+    boundaryEntryIndex < 0 ||
+    pathEntries.slice(boundaryEntryIndex + 1).some((entry) => {
+      if (entry.type !== "message") {
+        return false;
+      }
+      const usage = getAssistantUsage(entry.message);
+      return usage && usage.contextUsage?.state !== "unavailable";
+    });
   const estimatedUsageCoveredTokens = usageCoveredMessages.reduce(
     (total, message) => total + estimateTokens(message),
     0,

--- a/packages/agent-core/src/harness/compaction/compaction.ts
+++ b/packages/agent-core/src/harness/compaction/compaction.ts
@@ -770,17 +770,25 @@ export function prepareCompaction(
   const boundaryEnd = effectiveEntries.length;
 
   const contextMessages = buildSessionContext(pathEntries).messages;
-  const tokensBefore = estimateContextTokens(contextMessages).tokens;
-  const estimatedContextTokens = contextMessages.reduce(
+  const contextUsage = estimateContextTokens(contextMessages);
+  const tokensBefore = contextUsage.tokens;
+  const usageCoveredMessages =
+    contextUsage.lastUsageIndex === null
+      ? []
+      : contextMessages.slice(0, contextUsage.lastUsageIndex + 1);
+  const estimatedUsageCoveredTokens = usageCoveredMessages.reduce(
     (total, message) => total + estimateTokens(message),
     0,
   );
   // Provider usage and transcript estimates must use compatible units here;
   // otherwise a high usage-to-estimate ratio can make every cut a no-op.
   const usageToEstimateRatio =
-    estimatedContextTokens > 0 && Number.isFinite(tokensBefore)
-      ? Math.max(1, tokensBefore / estimatedContextTokens)
+    estimatedUsageCoveredTokens > 0 && Number.isFinite(contextUsage.usageTokens)
+      ? Math.max(1, contextUsage.usageTokens / estimatedUsageCoveredTokens)
       : 1;
+  const trailingKeepTokens = Math.min(settings.keepRecentTokens, contextUsage.trailingTokens);
+  const normalizedKeepRecentTokens =
+    trailingKeepTokens + (settings.keepRecentTokens - trailingKeepTokens) / usageToEstimateRatio;
   const resetPreludeTokens = resetPreludeMessages.reduce(
     (total, message) => total + estimateTokens(message),
     0,
@@ -789,7 +797,7 @@ export function prepareCompaction(
   // other model-visible boundary context so a large kept tail moves the cut earlier.
   const keepRecentTokens = Math.min(
     Number.MAX_SAFE_INTEGER,
-    settings.keepRecentTokens / usageToEstimateRatio + resetPreludeTokens,
+    normalizedKeepRecentTokens + resetPreludeTokens,
   );
 
   const cutPoint = findCutPoint(effectiveEntries, boundaryStart, boundaryEnd, keepRecentTokens);

--- a/packages/agent-core/src/harness/compaction/compaction.ts
+++ b/packages/agent-core/src/harness/compaction/compaction.ts
@@ -769,7 +769,18 @@ export function prepareCompaction(
   }
   const boundaryEnd = effectiveEntries.length;
 
-  const tokensBefore = estimateContextTokens(buildSessionContext(pathEntries).messages).tokens;
+  const contextMessages = buildSessionContext(pathEntries).messages;
+  const tokensBefore = estimateContextTokens(contextMessages).tokens;
+  const estimatedContextTokens = contextMessages.reduce(
+    (total, message) => total + estimateTokens(message),
+    0,
+  );
+  // Provider usage and transcript estimates must use compatible units here;
+  // otherwise a high usage-to-estimate ratio can make every cut a no-op.
+  const usageToEstimateRatio =
+    estimatedContextTokens > 0 && Number.isFinite(tokensBefore)
+      ? Math.max(1, tokensBefore / estimatedContextTokens)
+      : 1;
   const resetPreludeTokens = resetPreludeMessages.reduce(
     (total, message) => total + estimateTokens(message),
     0,
@@ -778,7 +789,7 @@ export function prepareCompaction(
   // other model-visible boundary context so a large kept tail moves the cut earlier.
   const keepRecentTokens = Math.min(
     Number.MAX_SAFE_INTEGER,
-    settings.keepRecentTokens + resetPreludeTokens,
+    settings.keepRecentTokens / usageToEstimateRatio + resetPreludeTokens,
   );
 
   const cutPoint = findCutPoint(effectiveEntries, boundaryStart, boundaryEnd, keepRecentTokens);

--- a/packages/agent-core/src/harness/compaction/compaction.ts
+++ b/packages/agent-core/src/harness/compaction/compaction.ts
@@ -739,13 +739,13 @@ export function prepareCompaction(
       break;
     }
   }
+  const prevBoundary = prevBoundaryIndex >= 0 ? pathEntries[prevBoundaryIndex] : undefined;
 
   let previousSummary: string | undefined;
   let effectiveEntries = pathEntries;
   let resetPreludeMessages: AgentMessage[] = [];
   let boundaryStart = 0;
   if (prevBoundaryIndex >= 0) {
-    const prevBoundary = pathEntries[prevBoundaryIndex];
     previousSummary = prevBoundary?.type === "compaction" ? prevBoundary.summary : undefined;
     const firstKeptEntryId =
       prevBoundary?.type === "compaction" || prevBoundary?.type === "reset"
@@ -776,6 +776,14 @@ export function prepareCompaction(
     contextUsage.lastUsageIndex === null
       ? []
       : contextMessages.slice(0, contextUsage.lastUsageIndex + 1);
+  const usageSourceMessage =
+    contextUsage.lastUsageIndex === null
+      ? undefined
+      : contextMessages.at(contextUsage.lastUsageIndex);
+  const usageIsCurrent =
+    !prevBoundary ||
+    (usageSourceMessage?.role === "assistant" &&
+      usageSourceMessage.timestamp > new Date(prevBoundary.timestamp).getTime());
   const estimatedUsageCoveredTokens = usageCoveredMessages.reduce(
     (total, message) => total + estimateTokens(message),
     0,
@@ -783,7 +791,7 @@ export function prepareCompaction(
   // Provider usage and transcript estimates must use compatible units here;
   // otherwise a high usage-to-estimate ratio can make every cut a no-op.
   const usageToEstimateRatio =
-    estimatedUsageCoveredTokens > 0 && Number.isFinite(contextUsage.usageTokens)
+    usageIsCurrent && estimatedUsageCoveredTokens > 0 && Number.isFinite(contextUsage.usageTokens)
       ? Math.max(1, contextUsage.usageTokens / estimatedUsageCoveredTokens)
       : 1;
   const trailingKeepTokens = Math.min(settings.keepRecentTokens, contextUsage.trailingTokens);


### PR DESCRIPTION
AI-assisted: yes. I reviewed the change and understand the compaction accounting behavior.

Closes #111886

## What Problem This Solves

Compaction pressure is measured from provider-reported context usage, but the retained-tail cut point is selected with transcript character estimates. When provider usage materially exceeds the transcript estimate, the default 20,000-token keep budget can exceed the entire estimated transcript. The cut then remains at the first entry and compaction returns no preparation, so an overflowing session cannot make progress.

## Why This Change Was Made

`prepareCompaction` now normalizes only the portion of the keep budget covered by a current provider usage snapshot. Estimated messages after that snapshot stay in native estimator units, and snapshots older than the latest compaction/reset boundary are ignored using session entry order. Existing turn boundaries, tool-result pairing, and cut-point selection remain unchanged. Missing, empty, lower, stale, or non-finite provider usage preserves the existing estimator behavior.

## User Impact

Long-running sessions can advance the compaction boundary and summarize real history when provider context usage is much larger than the transcript heuristic, instead of repeatedly reporting a successful trigger that frees no context.

## Evidence

- Current-main baseline: the deterministic issue transcript reports 49,150 context tokens but returns no compaction preparation because the 20,000-token keep budget exceeds the transcript estimate.
- After: the same transcript advances `firstKeptEntryId` beyond `entry-0` and produces non-empty history or split-turn summary input.
- Regression safety: estimated-only trailing messages remain unscaled; stale and non-finite provider usage retain the previous estimator behavior; same-timestamp post-boundary usage is accepted by entry order.
- Focused validation: three agent-core compaction files passed 32/32 tests with one worker, including image-heavy and oversized trailing tool-result cut points.
- Changed-file `oxfmt`, targeted `oxlint`, and `git diff --check` passed on the rebased head.
- Independent `codex review --base origin/main` found no actionable regression.
- A broader embedded-runner test attempt was stopped by the local resource guard after sustained 99% CPU; the relevant broad shard is left to hosted CI rather than claiming local success.
- Ownership/overlap: #111886 is unassigned and accepted as a P1 core compaction bug. Open PRs #94046, #109984, and #97580 address manual compaction, mirror-usage validation, and multi-pass compaction respectively; none repairs this automatic usage-to-estimate mismatch.

Signed-off-by: Ho Lim <subhoya@gmail.com>
