### PR TITLE
fix(agents): classify Google invalid API keys as auth

### DIFF
--- a/src/agents/embedded-agent-helpers/failover-matches.test.ts
+++ b/src/agents/embedded-agent-helpers/failover-matches.test.ts
@@ -106,6 +106,28 @@ describe("Z.ai vendor error codes (#48988)", () => {
   });
 });
 
+describe("Google invalid API key errors (#114784)", () => {
+  it("classifies the Google Generative AI invalid-key response as auth", () => {
+    const raw =
+      "Google Generative AI API error (400): API key not valid. Please pass a valid API key. [code=INVALID_ARGUMENT]";
+
+    expect(isAuthErrorMessage(raw)).toBe(true);
+    expect(classifyFailoverReason(raw)).toBe("auth");
+  });
+
+  it("classifies the structured API_KEY_INVALID variant as auth", () => {
+    expect(isAuthErrorMessage('{"code":"API_KEY_INVALID"}')).toBe(true);
+  });
+
+  it("does not treat unrelated Google invalid arguments as auth", () => {
+    const raw =
+      "Google Generative AI API error (400): Request contains an invalid argument. [code=INVALID_ARGUMENT]";
+
+    expect(isAuthErrorMessage(raw)).toBe(false);
+    expect(classifyFailoverReason(raw)).toBeNull();
+  });
+});
+
 describe("Chinese provider overload messages", () => {
   const ZHIPU_OVERLOAD = "[1305][该模型当前访问量过大，请您稍后再试]";
 

--- a/src/agents/embedded-agent-helpers/failover-matches.ts
+++ b/src/agents/embedded-agent-helpers/failover-matches.ts
@@ -19,6 +19,8 @@ const HIGH_CONFIDENCE_AUTH_PERMANENT_PATTERNS = [
 
 const AMBIGUOUS_AUTH_ERROR_PATTERNS = [
   /invalid[_ ]?api[_ ]?key/,
+  // Google returns HTTP 400 with these variants for an invalid Generative AI key (#114784).
+  /api[_ ]?key(?:[_ ]?(?:is )?(?:invalid|not valid))\b/i,
   /could not (?:authenticate|validate).*(?:api[_ ]?key|credentials)/i,
   "permission_error",
 ] as const satisfies readonly ErrorPattern[];

--- a/src/agents/model-fallback.test.ts
+++ b/src/agents/model-fallback.test.ts
@@ -1914,6 +1914,42 @@ describe("runWithModelFallback", () => {
     expect(result.provider).toBe("anthropic");
   });
 
+  it("continues to the next model after a Google invalid-key response (#114784)", async () => {
+    const cfg = makeCfg({
+      agents: {
+        defaults: {
+          model: {
+            primary: "google/gemini-3.1-pro-preview",
+            fallbacks: ["anthropic/claude-sonnet-4-6"],
+          },
+        },
+      },
+    });
+    const googleInvalidKey = new Error(
+      "Google Generative AI API error (400): API key not valid. Please pass a valid API key. [code=INVALID_ARGUMENT]",
+    );
+    const run = vi
+      .fn()
+      .mockRejectedValueOnce(googleInvalidKey)
+      .mockResolvedValueOnce("fallback ok");
+
+    const result = await runWithModelFallback({
+      cfg,
+      provider: "google",
+      model: "gemini-3.1-pro-preview",
+      run,
+    });
+
+    expect(result.result).toBe("fallback ok");
+    expect(result.provider).toBe("anthropic");
+    expect(result.attempts[0]).toMatchObject({
+      provider: "google",
+      model: "gemini-3.1-pro-preview",
+      reason: "auth",
+    });
+    expect(run).toHaveBeenCalledTimes(2);
+  });
+
   it("keeps provider failover metadata authoritative over nested session locks", async () => {
     const cfg = makeCfg({
       agents: {


### PR DESCRIPTION
Closes #114784

## What Problem This Solves

A Google Generative AI invalid API key can return HTTP 400 with `API key not valid` or `API_KEY_INVALID`. The shared failover matcher did not recognize those forms as authentication failures, so fallback could stop at Google instead of attempting later configured models.

## Why This Change Was Made

The shared auth matcher now recognizes only the missing invalid-key word order:

- `API key not valid`
- `API key is invalid`
- `API_KEY_INVALID`

It does not classify generic Google `INVALID_ARGUMENT` responses as auth failures, preserving malformed-request and input-validation behavior.

## Evidence

- Base checked locally: `6125edfb76fd9b3edf3521f676052a7efa12cada`
- Exact head: `072e317f4693bf1a88f96902446b9eb4d740e61e`
- Environment: isolated macOS source worktree, Node.js 22.23.0, lockfile-installed dependencies. No provider credentials or network calls were used.

Before the repair, the exact Google error text invoked the real shared production classifier as:

```json
{"auth":false,"reason":null}
```

On the exact head, the same production-function probe reports:

```json
{
  "invalidKey":{"auth":true,"reason":"auth"},
  "invalidArgument":{"auth":false,"reason":null}
}
```

The focused fallback regression invokes the production `runWithModelFallback` orchestration with the exact Google error, then proves the next configured Anthropic candidate is called and succeeds. Its first attempt is recorded as `reason: "auth"`.

## Validation

```text
node scripts/run-vitest.mjs run src/agents/embedded-agent-helpers/failover-matches.test.ts src/agents/embedded-agent-helpers.isbillingerrormessage.test.ts src/agents/model-fallback.test.ts

Test Files  3 passed (3)
Tests       320 passed (320)

node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.core.test.json --pretty false
passed

./node_modules/.bin/oxfmt --check <3 changed files>
passed

node scripts/run-oxlint.mjs <3 changed files>
passed

git diff --check
passed
```

Not tested: no live Google request was made because the invalid-key response is deterministic and the regression uses the real shared classifier plus production fallback orchestrator without requiring a credential. The existing embedded-runner E2E fixture currently fails from the untouched base before its test body because it lacks the newly required explicit agent roster; this PR does not alter that unrelated fixture.