### PR TITLE
chore(sdk): record flushLogger in the deprecated surface budgets

### DIFF
--- a/scripts/plugin-sdk-surface-report.mjs
+++ b/scripts/plugin-sdk-surface-report.mjs
@@ -115,7 +115,8 @@ const defaultPublicDeprecatedExportsByEntrypointBudget = Object.freeze({
   "agent-media-payload": 3,
   // +2: deprecated media projection type and builder.
   "reply-payload": 2,
-  "text-runtime": 191,
+  // +1: flushLogger projected through the deprecated text-runtime barrel.
+  "text-runtime": 192,
   "agent-runtime": 2,
   "channel-secret-runtime": 23,
   "agent-harness-runtime": 4,
@@ -224,7 +225,8 @@ export function readPluginSdkSurfaceBudgets(env = process.env) {
       // +2: shipped Slack and Discord setup compatibility helpers.
       // +10: named media legacy projection deprecations across public compatibility barrels.
       // +2: channel prompt-context type and metadata builder compatibility aliases.
-      1700,
+      // +1: flushLogger projected through the deprecated text-runtime barrel.
+      1701,
       env,
     ),
     publicWildcardReexports: readPluginSdkSurfaceBudgetEnv(


### PR DESCRIPTION
## What Problem This Solves

`pnpm plugin-sdk:surface:check` fails on clean main: `public deprecated exports 1701 > 1700` / `text-runtime 192 > 191`. Cause: #114769 added the public `flushLogger` export to `src/logging/logger.js`, which the wholly-`@deprecated` `text-runtime` wildcard barrel re-exports — so the export also counts against the deprecated budgets. #114769 recorded the export/callable budget growth but missed the deprecated pair, and this gate is not part of PR CI, so main drifted silently.

## Why This Change Was Made

Restore the surface gate so local closeout checks and any gated lanes pass on main.

## User Impact

None — budget bookkeeping only, annotated per house convention.

## Evidence

- `pnpm plugin-sdk:surface:check` green with the change (fails on clean main).
- `node scripts/run-vitest.mjs test/scripts/plugin-sdk-surface-report.test.ts` green.
