### PR TITLE
perf(sessions): stop cloning the whole store per catalog request

### DIFF
--- a/src/config/sessions/session-accessor.sqlite-data-version.test.ts
+++ b/src/config/sessions/session-accessor.sqlite-data-version.test.ts
@@ -111,6 +111,55 @@ function createSessionScope(label: string) {
 }
 
 describe("SQLite session entry cache", () => {
+  it("keeps sqlite-entry-cache list projections lazy and memoized per key", async () => {
+    const scope = createSessionScope("lazy-list-projection");
+    await upsertSessionEntry(scope, {
+      label: "projected",
+      sessionId: "lazy-list-projection",
+      updatedAt: 1,
+      skillsSnapshot: { prompt: "large skill prompt", skills: [] },
+      systemPromptReport: {
+        source: "run",
+        generatedAt: 1,
+        systemPrompt: { chars: 1, projectContextChars: 0, nonProjectContextChars: 1 },
+        injectedWorkspaceFiles: [],
+        skills: { promptChars: 0, entries: [] },
+        tools: { listChars: 0, schemaChars: 0, entries: [] },
+      },
+    });
+
+    const cloneEntry = globalThis.structuredClone;
+    const cloneSpy = vi.spyOn(globalThis, "structuredClone");
+    try {
+      const fullEntry = listSessionEntries({ ...scope, clone: false })[0]?.entry;
+      expect(fullEntry).toBeDefined();
+      expect(cloneSpy).not.toHaveBeenCalled();
+      if (!fullEntry) {
+        throw new Error("missing seeded lazy-list-projection entry");
+      }
+      const expected = cloneEntry(fullEntry);
+      delete expected.skillsSnapshot;
+      delete expected.systemPromptReport;
+
+      const first = listSessionEntries({
+        ...scope,
+        clone: false,
+        projection: "list",
+      })[0]?.entry;
+      const second = listSessionEntries({
+        ...scope,
+        clone: false,
+        projection: "list",
+      })[0]?.entry;
+
+      expect(first).toEqual(expected);
+      expect(second).toBe(first);
+      expect(cloneSpy).toHaveBeenCalledOnce();
+    } finally {
+      cloneSpy.mockRestore();
+    }
+  });
+
   it("reuses parsed entries on the second list", async () => {
     const scope = createSessionScope("second-list");
     await upsertSessionEntry(scope, { label: "first", sessionId: "first", updatedAt: 1 });

--- a/src/config/sessions/session-accessor.sqlite-entry-cache.ts
+++ b/src/config/sessions/session-accessor.sqlite-entry-cache.ts
@@ -13,7 +13,7 @@ type SessionEntryCacheDatabase = Pick<OpenClawAgentDatabase, "agentId" | "db" | 
 export type SqliteSessionEntryCacheSnapshot = {
   entries: Map<string, SessionEntry>;
   keys: string[];
-  listEntries: Map<string, SessionEntry>;
+  listEntries: Pick<ReadonlyMap<string, SessionEntry>, "get">;
 };
 
 type SqliteSessionEntryCache = SqliteSessionEntryCacheSnapshot & {
@@ -68,6 +68,29 @@ function createListProjection(entry: SessionEntry): SessionEntry {
   return projected;
 }
 
+function createLazyListProjections(
+  entries: ReadonlyMap<string, SessionEntry>,
+): Pick<ReadonlyMap<string, SessionEntry>, "get"> {
+  const projectedByKey = new Map<string, SessionEntry>();
+  return {
+    get: (sessionKey) => {
+      const cached = projectedByKey.get(sessionKey);
+      if (cached) {
+        return cached;
+      }
+      const entry = entries.get(sessionKey);
+      if (!entry) {
+        return undefined;
+      }
+      // A snapshot projects each key once. clone:false readers share this immutable
+      // value, so replacing it would break identity and reintroduce store-wide cloning.
+      const projected = createListProjection(entry);
+      projectedByKey.set(sessionKey, projected);
+      return projected;
+    },
+  };
+}
+
 function loadSessionEntrySnapshot(
   database: SessionEntryCacheDatabase,
 ): SqliteSessionEntryCacheSnapshot {
@@ -77,19 +100,17 @@ function loadSessionEntrySnapshot(
     db.selectFrom("session_nodes").select(["session_key", "entry_json"]).orderBy("session_key"),
   ).rows;
   const entries = new Map<string, SessionEntry>();
-  const listEntries = new Map<string, SessionEntry>();
   for (const row of rows) {
     const entry = parseSqliteSessionEntryJson(row);
     if (!entry) {
       continue;
     }
     entries.set(row.session_key, entry);
-    listEntries.set(row.session_key, createListProjection(entry));
   }
   return {
     entries,
     keys: rows.map((row) => row.session_key),
-    listEntries,
+    listEntries: createLazyListProjections(entries),
   };
 }
 

--- a/src/gateway/server-methods/session-catalog-entry-snapshot.ts
+++ b/src/gateway/server-methods/session-catalog-entry-snapshot.ts
@@ -2,6 +2,7 @@ import type {
   SessionCatalogHost,
   SessionCatalogSession,
 } from "../../../packages/gateway-protocol/src/index.js";
+import { listAgentIds, resolveDefaultAgentId } from "../../agents/agent-scope.js";
 import type { SessionEntry } from "../../config/sessions.js";
 import {
   listSessionEntriesReadOnly,
@@ -25,13 +26,34 @@ export function createSessionCatalogRequestEntrySnapshot(params: {
   const entriesByAgentId = new Map<string, readonly SessionEntrySummary[]>();
   const entryIndexByAgentId = new Map<string, ReadonlyMap<string, SessionEntry>>();
   const actorBySessionKey = new Map<string, SessionCatalogSession["createdActor"]>();
+  let catalogEntries:
+    | ReturnType<NonNullable<SessionCatalogEntrySnapshot["entriesForCatalog"]>>
+    | undefined;
 
   const entriesForAgent = (rawAgentId: string): readonly SessionEntrySummary[] => {
     const agentId = normalizeAgentId(rawAgentId);
     if (!entriesByAgentId.has(agentId)) {
-      entriesByAgentId.set(agentId, listSessionEntriesReadOnly({ agentId }));
+      entriesByAgentId.set(
+        agentId,
+        listSessionEntriesReadOnly({ agentId, clone: false, projection: "list" }),
+      );
     }
     return entriesByAgentId.get(agentId) ?? [];
+  };
+
+  const entriesForCatalog: NonNullable<SessionCatalogEntrySnapshot["entriesForCatalog"]> = () => {
+    if (catalogEntries) {
+      return catalogEntries;
+    }
+    const defaultAgentId = resolveDefaultAgentId(params.cfg);
+    const agentIds = [
+      defaultAgentId,
+      ...listAgentIds(params.cfg).filter((agentId) => agentId !== defaultAgentId),
+    ];
+    catalogEntries = agentIds.flatMap((agentId) =>
+      entriesForAgent(agentId).map((entry) => Object.assign({}, entry, { agentId })),
+    );
+    return catalogEntries;
   };
 
   const entryIndexForAgent = (agentId: string): ReadonlyMap<string, SessionEntry> => {
@@ -72,7 +94,7 @@ export function createSessionCatalogRequestEntrySnapshot(params: {
   };
 
   return {
-    sessionEntries: { entriesForAgent },
+    sessionEntries: { entriesForAgent, entriesForCatalog },
     projectHostCreatedActors: (host) => ({
       ...host,
       sessions: host.sessions.map(({ createdActor: _providerCreatedActor, ...session }) => {

--- a/src/gateway/server-methods/session-catalog.test.ts
+++ b/src/gateway/server-methods/session-catalog.test.ts
@@ -2,13 +2,16 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { ErrorCodes } from "../../../packages/gateway-protocol/src/index.js";
 import { gatewaySubagentState } from "../../plugins/runtime/gateway-bindings.js";
 import { createPluginRuntime } from "../../plugins/runtime/index.js";
-import type { SessionCatalogProvider } from "../../plugins/session-catalog.js";
+import {
+  listSessionCatalogEntries,
+  type SessionCatalogProvider,
+} from "../../plugins/session-catalog.js";
 
 const hoisted = vi.hoisted(() => ({
   activeRegistry: { sessionCatalogs: [] as unknown[] },
   pinnedSessionExtensionRegistry: undefined as { sessionCatalogs: unknown[] } | undefined,
   listSessionEntriesReadOnly: vi.fn<
-    (scope?: { agentId?: string }) => Array<{
+    (scope?: { agentId?: string; clone?: boolean; projection?: "full" | "list" }) => Array<{
       sessionKey: string;
       entry: {
         createdActor?: { type: "human" | "agent" | "system"; id?: string };
@@ -246,10 +249,51 @@ describe("session catalog Gateway methods", () => {
       ],
     });
     expect(hoisted.listSessionEntriesReadOnly).toHaveBeenCalledOnce();
-    expect(hoisted.listSessionEntriesReadOnly).toHaveBeenCalledWith({ agentId: "main" });
+    expect(hoisted.listSessionEntriesReadOnly).toHaveBeenCalledWith({
+      agentId: "main",
+      clone: false,
+      projection: "list",
+    });
   });
 
-  it("shares one per-agent entry snapshot across catalogs and creator projection", async () => {
+  it("does not clone the shared list projection for each catalog request", async () => {
+    const storedEntries = [
+      {
+        sessionKey: "agent:main:shared",
+        entry: { createdActor: { type: "agent" as const, id: "worker" }, updatedAt: 1 },
+      },
+    ];
+    hoisted.listSessionEntriesReadOnly.mockImplementation((scope) =>
+      scope?.clone === false ? storedEntries : structuredClone(storedEntries),
+    );
+    hoisted.activeRegistry.sessionCatalogs = [
+      {
+        provider: provider("claude", {
+          list: vi.fn(async ({ sessionEntries }) => {
+            sessionEntries?.entriesForAgent("main");
+            return [];
+          }),
+        }),
+      },
+    ];
+    const cloneSpy = vi.spyOn(globalThis, "structuredClone");
+    try {
+      await call("sessions.catalog.list", {});
+      await call("sessions.catalog.list", {});
+
+      expect(cloneSpy).not.toHaveBeenCalled();
+      expect(hoisted.listSessionEntriesReadOnly).toHaveBeenCalledTimes(2);
+      expect(hoisted.listSessionEntriesReadOnly).toHaveBeenLastCalledWith({
+        agentId: "main",
+        clone: false,
+        projection: "list",
+      });
+    } finally {
+      cloneSpy.mockRestore();
+    }
+  });
+
+  it("shares one flattened entry snapshot across catalogs and creator projection", async () => {
     hoisted.listSessionEntriesReadOnly.mockReturnValue([
       {
         sessionKey: "agent:main:alpha-adopted",
@@ -260,12 +304,14 @@ describe("session catalog Gateway methods", () => {
         entry: { createdActor: { type: "system", id: "scheduler" }, updatedAt: 1 },
       },
     ]);
+    const flattenedEntries: unknown[] = [];
+    const runtime = createPluginRuntime();
     const catalogProvider = (id: string, sessionKey: string) =>
       provider(id, {
         list: vi.fn(async ({ sessionEntries }) => {
-          const adopted = sessionEntries
-            ?.entriesForAgent("main")
-            .find((candidate: { sessionKey: string }) => candidate.sessionKey === sessionKey);
+          const entries = listSessionCatalogEntries({ config: {}, runtime, sessionEntries });
+          flattenedEntries.push(entries);
+          const adopted = entries.find((candidate) => candidate.sessionKey === sessionKey);
           return [
             {
               hostId: `gateway:${id}`,
@@ -296,6 +342,8 @@ describe("session catalog Gateway methods", () => {
     const respond = await call("sessions.catalog.list", {});
 
     expect(hoisted.listSessionEntriesReadOnly).toHaveBeenCalledOnce();
+    expect(flattenedEntries).toHaveLength(2);
+    expect(flattenedEntries[0]).toBe(flattenedEntries[1]);
     expect(respond).toHaveBeenCalledWith(true, {
       catalogs: [
         {

--- a/src/plugins/session-catalog.ts
+++ b/src/plugins/session-catalog.ts
@@ -16,7 +16,7 @@ export type SessionCatalogListProviderParams = {
   limitPerHost?: number;
   hostIds?: string[];
   cursors?: Record<string, string>;
-  /** Request-owned session entries. Providers must not retain this past `list`. */
+  /** Request-owned shared entries. Providers must not mutate or retain them past `list`. */
   sessionEntries?: SessionCatalogEntrySnapshot;
   /** Lazily lists Gateway nodes once per catalog request. Providers must not retain this past `list`. */
   listNodes?: () => ReturnType<PluginRuntime["nodes"]["list"]>;
@@ -61,9 +61,11 @@ export type SessionCatalogEntrySummary = ReturnType<
   PluginRuntime["agent"]["session"]["listSessionEntries"]
 >[number];
 
-/** Mutable store contents captured lazily and reused only within one catalog request. */
+/** Shared, logically frozen store state for one request; copy locally before mutating. */
 export type SessionCatalogEntrySnapshot = {
   entriesForAgent: (agentId: string) => readonly SessionCatalogEntrySummary[];
+  /** Request-wide flatten; optional for compatibility with pre-flatten plugin hosts. */
+  entriesForCatalog?: () => SessionCatalogAgentEntry[];
 };
 
 type SessionCatalogAgentEntry = SessionCatalogEntrySummary & { agentId: string };
@@ -160,6 +162,12 @@ export function listSessionCatalogEntries(params: {
   runtime: PluginRuntime;
   sessionEntries?: SessionCatalogEntrySnapshot;
 }): SessionCatalogAgentEntry[] {
+  const requestEntries = params.sessionEntries?.entriesForCatalog?.();
+  if (requestEntries) {
+    // Keep the shipped SDK helper as the compatibility entry point while the
+    // Gateway snapshot owns the one request-wide flatten.
+    return requestEntries;
+  }
   const defaultAgentId = resolveDefaultAgentId(params.config);
   const agentIds = [
     defaultAgentId,


### PR DESCRIPTION
## What Problem This Solves

`sessions.catalog.list` is the dominant warm Control UI cost on team.openclaw.ai (500ms avg, ~1.5 calls/min/client, ~800 sessions). Three store-clone costs scale with session count and were not covered by any landed cache:

1. The catalog entry snapshot called `listSessionEntriesReadOnly({agentId})` without `clone:false`/`projection:"list"` — ~800 full-projection `structuredClone`s (including the fat `skillsSnapshot`/`systemPromptReport` fields) per request, while every other hot caller already opts out.
2. The entry-cache snapshot rebuild (#114453) eagerly `structuredClone`d every row for `listEntries` — and any tracked write invalidates the snapshot, so with agents running turns the rebuild is the common case.
3. `listSessionCatalogEntries` re-flattened all entries once per provider (~5 × 800 allocations per request).

## Why This Change Was Made

Production perf campaign; this is the largest remaining server-side axis in session loading.

## User Impact

Faster sidebar/catalog loading; no behavior change (responses byte-identical).

- Snapshot entries now come from `clone:false, projection:"list"`; all catalog consumers (gateway projector + claude/codex/acpx/opencode providers) audited read-only and none touches the stripped fields; the request-owned/must-not-retain contract is strengthened in comments.
- `listEntries` in the entry cache is a lazy per-key projection (memoized, immutable-per-key) instead of eager clone-all.
- Providers reuse one request-wide flattened array via the snapshot; `listSessionCatalogEntries` remains as the shipped public SDK wrapper over it.

## Evidence

- New regressions: no per-request re-clone (clone-count spy), lazy projection parity + per-key memoization, one flatten per request.
- 786 tests green across the grep-selected suites; `pnpm tsgo:core`; targeted oxlint; format; `git diff --check`; Blacksmith Testbox run 30317438335.
- Codex autoreview clean (two speculative compat findings rejected against the audited contract).
- Note: local `pnpm plugin-sdk:surface:check` shows a pre-existing main-side deprecated-budget drift (1701>1700) unrelated to this diff — fixed separately in #114827.
