### PR TITLE
fix(google): keep static compat flags on discovered Gemini id variants

### DIFF
--- a/extensions/google/provider-catalog.test.ts
+++ b/extensions/google/provider-catalog.test.ts
@@ -160,6 +160,46 @@ describe("google provider catalog", () => {
     expect(release).toHaveBeenCalledTimes(2);
   });
 
+  it("propagates static compat to discovered id variants of the same weights", async () => {
+    const cases: ReadonlyArray<{ id: string; compat: { codeMode: string } | undefined }> = [
+      { id: "gemini-3.5-flash", compat: { codeMode: "preferred" } },
+      { id: "gemini-3.5-flash-preview-06-17", compat: { codeMode: "preferred" } },
+      { id: "gemini-3.1-pro-preview-05-06", compat: { codeMode: "preferred" } },
+      { id: "gemini-flash-latest", compat: { codeMode: "preferred" } },
+      { id: "gemini-flash-lite-latest", compat: { codeMode: "preferred" } },
+      { id: "gemini-pro-latest", compat: { codeMode: "preferred" } },
+      // Dated variant of unflagged weights resolves but carries no compat.
+      { id: "gemini-2.5-flash-preview-05-20", compat: undefined },
+      // Unknown family member fails closed: no static entry, no compat.
+      { id: "gemini-3.9-flash", compat: undefined },
+    ];
+    const fetchGuard: LiveModelCatalogFetchGuard = vi.fn(async ({ url }) => ({
+      response: Response.json({
+        models: cases.map(({ id }) => ({
+          name: `models/${id}`,
+          displayName: id,
+          inputTokenLimit: 1_048_576,
+          outputTokenLimit: 65_536,
+          supportedGenerationMethods: ["generateContent"],
+          thinking: true,
+        })),
+      }),
+      finalUrl: url,
+      release: async () => undefined,
+    }));
+
+    const provider = await buildGoogleLiveCatalogProvider({
+      apiKey: "GEMINI_API_KEY",
+      fetchGuard,
+    });
+
+    for (const { id, compat } of cases) {
+      const model = provider.models.find((entry) => entry.id === id);
+      expect(model, id).toBeDefined();
+      expect(model?.compat, id).toEqual(compat);
+    }
+  });
+
   it("falls back to bundled rows when live discovery is unusable", async () => {
     const fetchGuard: LiveModelCatalogFetchGuard = vi.fn(async ({ url }) => ({
       response: Response.json({ models: [{ name: "models/gemini-3.6-flash" }] }),

--- a/extensions/google/provider-catalog.ts
+++ b/extensions/google/provider-catalog.ts
@@ -7,7 +7,7 @@ import type {
   ModelDefinitionConfig,
   ModelProviderConfig,
 } from "openclaw/plugin-sdk/provider-model-shared";
-import { isGoogleTextGenerationModelId } from "./provider-models.js";
+import { isGoogleTextGenerationModelId, resolveGoogleStaticModelId } from "./provider-models.js";
 
 const GOOGLE_GEMINI_BASE_URL = "https://generativelanguage.googleapis.com/v1beta";
 const GOOGLE_GEMINI_MODELS_ENDPOINT = `${GOOGLE_GEMINI_BASE_URL}/models?pageSize=1000`;
@@ -103,6 +103,12 @@ const GOOGLE_GEMINI_TEXT_MODELS: ModelDefinitionConfig[] = [
     compat: { codeMode: "preferred" },
   },
 ];
+const GOOGLE_GEMINI_TEXT_MODEL_BY_ID = new Map(
+  GOOGLE_GEMINI_TEXT_MODELS.map((model) => [model.id, model]),
+);
+const GOOGLE_GEMINI_TEXT_MODEL_IDS: ReadonlySet<string> = new Set(
+  GOOGLE_GEMINI_TEXT_MODEL_BY_ID.keys(),
+);
 
 export function buildGoogleStaticCatalogProvider(): ModelProviderConfig {
   return {
@@ -161,7 +167,11 @@ function buildGoogleLiveModel(row: unknown): ModelDefinitionConfig | undefined {
   ) {
     return undefined;
   }
-  const staticModel = GOOGLE_GEMINI_TEXT_MODELS.find((model) => model.id === id);
+  // Compat flags apply to evaluated weights only. Resolve discovered id
+  // variants (aliases, dated previews, -latest) to the bundled entry with the
+  // same weights; ids that do not resolve keep no compat (fail closed).
+  const staticId = resolveGoogleStaticModelId(id, GOOGLE_GEMINI_TEXT_MODEL_IDS);
+  const staticModel = staticId ? GOOGLE_GEMINI_TEXT_MODEL_BY_ID.get(staticId) : undefined;
   return {
     id,
     name: readString(record, "displayName") ?? id,

--- a/extensions/google/provider-models.ts
+++ b/extensions/google/provider-models.ts
@@ -197,6 +197,42 @@ const GOOGLE_FORWARD_COMPAT_CASES: readonly GoogleForwardCompatCase[] = [
   },
 ];
 
+// Live discovery copies per-model `compat` from the bundled static catalog.
+// Resolve a discovered id to the static entry carrying the same weights:
+// alias normalization, dated preview releases, and the -latest family aliases.
+// Fail closed: an id that does not canonically resolve keeps no compat, so
+// flags like codeMode are never enabled for unevaluated configurations.
+export function resolveGoogleStaticModelId(
+  id: string,
+  staticIds: ReadonlySet<string>,
+): string | undefined {
+  const canonical = normalizeGoogleModelId(id);
+  if (staticIds.has(canonical)) {
+    return canonical;
+  }
+  // Dated releases publish the same weights under `<id>[-preview]-MM-DD`.
+  const dateless = canonical.replace(/(?:-preview)?-\d{2}-\d{2}$/, "");
+  if (dateless !== canonical) {
+    const canonicalDateless = normalizeGoogleModelId(dateless);
+    if (staticIds.has(canonicalDateless)) {
+      return canonicalDateless;
+    }
+  }
+  const isLatestAlias =
+    canonical === GEMINI_PRO_LATEST_ID ||
+    canonical === GEMINI_FLASH_LATEST_ID ||
+    canonical === GEMINI_FLASH_LITE_LATEST_ID;
+  if (!isLatestAlias) {
+    return undefined;
+  }
+  // -latest aliases track the newest family member; reuse the family template
+  // ordering instead of maintaining a parallel alias map.
+  const familyCase = GOOGLE_FORWARD_COMPAT_CASES.find((entry) =>
+    typeof entry.match === "function" ? entry.match(canonical) : entry.match.includes(canonical),
+  );
+  return familyCase?.family[0].find((templateId) => staticIds.has(templateId));
+}
+
 export function resolveGoogleGeminiForwardCompatModel(params: {
   providerId: string;
   templateProviderId?: string;


### PR DESCRIPTION
## What Problem This Solves

Live Google model discovery (`extensions/google/provider-catalog.ts`) copies per-model `compat` — including the `codeMode: "preferred"` flag introduced in #114695 — from the bundled static catalog via exact static-id match only. Discovered Gemini ids that are variants of the same weights (dated previews like `gemini-3.5-flash-preview-06-17`, the `gemini-flash-latest` / `gemini-flash-lite-latest` / `gemini-pro-latest` aliases, and alias-normalized forms like `gemini-3.1-flash`) silently lose the flag and any other compat fields even though the identical weights are flagged in the static catalog.

## Why This Change Was Made

Discovered id variants of already-evaluated weights should behave like their static catalog entry. The fix resolves the static entry by canonical/family id, reusing the extension's existing machinery instead of inventing a parallel matcher: `normalizeGoogleModelId` alias normalization, a dated-release suffix strip (`<id>[-preview]-MM-DD` publishes the same weights), and the existing `GOOGLE_FORWARD_COMPAT_CASES` family template ordering for the three `-latest` aliases only. The resolver fails closed: an id that does not canonically resolve to a static entry keeps no compat, so flags are never enabled for unevaluated configurations (e.g. a hypothetical `gemini-3.9-flash` or Gemma ids get nothing). This does not broaden which models are flagged — `gemini-2.5-flash-preview-05-20` resolves to `gemini-2.5-flash`, which carries no compat, and still gets none.

## User Impact

Users whose Google catalog comes from live discovery get the intended code-mode preference (and any future compat fields) on dated preview ids and `-latest` aliases of flagged Gemini weights, matching static-catalog behavior. No change for unknown or unflagged models.

## Evidence

- `node scripts/run-vitest.mjs extensions/google/provider-catalog.test.ts extensions/google/provider-models.test.ts` — 31 passed, including a new table-driven test that drives `buildGoogleLiveCatalogProvider` with a mocked `models.list` payload covering exact ids, dated previews, all three `-latest` aliases, a dated variant of unflagged weights, and an unknown family member (fail closed).
- `node scripts/check-changed.mjs` delegated to Blacksmith Testbox — exit 0 (extensions + extensionTests lanes: typecheck, lint, plugin boundaries, guards).
- Codex autoreview (`gpt-5.6-sol`, uncommitted mode) — clean, no accepted findings.
- PR CI green on head a49ae9a8 (`openclaw/ci-gate` SUCCESS).
