### PR TITLE
fix(plugins): scope reply hooks by turn trigger

### DIFF
--- a/docs/gateway/restart-recovery.md
+++ b/docs/gateway/restart-recovery.md
@@ -58,8 +58,13 @@ Three complementary mechanisms mark sessions whose turn did not finish:
   Recovery never replays a hook interrupted mid-call. Once an unhandled hook
   finishes, its checkpoint records that result, but recovery still fails closed
   while that hook remains active: a checkpoint cannot prove that the same
-  plugin code and configuration loaded after the restart. Handled text and
-  silent results are checkpointed separately for deterministic settlement.
+  plugin code and configuration loaded after the restart. A
+  `before_agent_reply` hook may declare a host-enforced
+  `eligibleTriggers` scope; a hook limited to scheduled `heartbeat` or `cron`
+  turns is not active for a recovered user turn and therefore does not block
+  it. Unscoped or invalid registrations remain active for this safety check.
+  Handled text and silent results are checkpointed separately for deterministic
+  settlement.
   Durable recovery claims written by older versions have no source-ownership
   marker, so they receive the same fail-closed hook check during an upgrade.
 - **At shutdown:** during the restart drain, every session with an active run

--- a/docs/plugins/hooks.md
+++ b/docs/plugins/hooks.md
@@ -57,11 +57,19 @@ observation side effects.
 
 `api.on(name, handler, opts?)` accepts:
 
-| Option           | Effect                                                                                                                                                                                            |
-| ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `priority`       | Ordering; higher runs first.                                                                                                                                                                      |
-| `registrationId` | Stable identity for one registration inside a plugin. Skill evaluators use it as `evaluatorId`; otherwise the plugin id is used.                                                                  |
-| `timeoutMs`      | Per-hook await budget. When it expires, OpenClaw stops awaiting that handler and moves on. It does not cancel the handler or its side effects. Omit to use the runner's default per-hook timeout. |
+| Option             | Effect                                                                                                                                                                                            |
+| ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `priority`         | Ordering; higher runs first.                                                                                                                                                                      |
+| `registrationId`   | Stable identity for one registration inside a plugin. Skill evaluators use it as `evaluatorId`; otherwise the plugin id is used.                                                                  |
+| `timeoutMs`        | Per-hook await budget. When it expires, OpenClaw stops awaiting that handler and moves on. It does not cancel the handler or its side effects. Omit to use the runner's default per-hook timeout. |
+| `eligibleTriggers` | For `before_agent_reply` only, limits host dispatch to one or more of `cron`, `heartbeat`, or `user`.                                                                                             |
+
+Trigger eligibility is enforced by the host before it invokes the handler. A
+hook registered with `eligibleTriggers: ["heartbeat", "cron"]` is therefore
+inactive for user turns and does not block recovery of an interrupted user
+turn. Omitted, empty, malformed, or partly unknown lists remain unrestricted
+so dispatch and recovery fail closed. Other hook kinds do not accept this
+option.
 
 Operators can set hook budgets without patching plugin code:
 

--- a/extensions/memory-core/index.test.ts
+++ b/extensions/memory-core/index.test.ts
@@ -148,6 +148,27 @@ describe("memory-core plugin runtime registration", () => {
     expect(subagentRun).not.toHaveBeenCalled();
   });
 
+  it("scopes both reply hooks to scheduled turns across three registrations", () => {
+    for (let cycle = 1; cycle <= 3; cycle += 1) {
+      const replyHookTriggers: unknown[] = [];
+      plugin.register(
+        createTestPluginApi({
+          runtime: hostRuntime,
+          on(hookName, _handler, options) {
+            if (hookName === "before_agent_reply") {
+              replyHookTriggers.push(options?.eligibleTriggers);
+            }
+          },
+        }),
+      );
+
+      expect(replyHookTriggers, `cycle ${cycle}`).toEqual([
+        ["heartbeat", "cron"],
+        ["heartbeat", "cron"],
+      ]);
+    }
+  });
+
   it("hides intent create, list, and cancel from non-owner turns", () => {
     let intentFactory:
       | ((ctx: { config?: OpenClawConfig; senderIsOwner?: boolean }) => unknown)

--- a/extensions/memory-core/index.ts
+++ b/extensions/memory-core/index.ts
@@ -386,26 +386,30 @@ export default definePluginEntry({
       }
     });
 
-    api.on("before_agent_reply", async (_event, ctx) => {
-      if (ctx.trigger !== "heartbeat" && ctx.trigger !== "cron") {
+    api.on(
+      "before_agent_reply",
+      async (_event, ctx) => {
+        if (ctx.trigger !== "heartbeat" && ctx.trigger !== "cron") {
+          return undefined;
+        }
+        try {
+          const module = await loadStandingIntentsModule();
+          const config = (api.runtime.config?.current?.() ?? api.config) as OpenClawConfig;
+          const { sessionAgentId: agentId } = resolveSessionAgentIds({
+            sessionKey: ctx.sessionKey,
+            config,
+            agentId: ctx.agentId,
+          });
+          module.sweepStandingIntents({ agentId });
+        } catch (error) {
+          api.logger.warn?.(
+            `memory-core: standing intent maintenance failed: ${error instanceof Error ? error.message : String(error)}`,
+          );
+        }
         return undefined;
-      }
-      try {
-        const module = await loadStandingIntentsModule();
-        const config = (api.runtime.config?.current?.() ?? api.config) as OpenClawConfig;
-        const { sessionAgentId: agentId } = resolveSessionAgentIds({
-          sessionKey: ctx.sessionKey,
-          config,
-          agentId: ctx.agentId,
-        });
-        module.sweepStandingIntents({ agentId });
-      } catch (error) {
-        api.logger.warn?.(
-          `memory-core: standing intent maintenance failed: ${error instanceof Error ? error.message : String(error)}`,
-        );
-      }
-      return undefined;
-    });
+      },
+      { eligibleTriggers: ["heartbeat", "cron"] },
+    );
 
     api.registerCommand({
       name: "dreaming",

--- a/extensions/memory-core/src/dreaming.ts
+++ b/extensions/memory-core/src/dreaming.ts
@@ -970,44 +970,48 @@ export function registerShortTermPromotionDreaming(api: OpenClawPluginApi): void
     disposeStartupCronRetry();
   });
 
-  api.on("before_agent_reply", async (event, ctx) => {
-    try {
-      if (ctx.trigger !== "heartbeat" && ctx.trigger !== "cron") {
+  api.on(
+    "before_agent_reply",
+    async (event, ctx) => {
+      try {
+        if (ctx.trigger !== "heartbeat" && ctx.trigger !== "cron") {
+          return undefined;
+        }
+        const currentConfig = resolveCurrentConfig();
+        const hasManagedDreamingToken = includesSystemEventToken(
+          event.cleanedBody,
+          DREAMING_SYSTEM_EVENT_TEXT,
+        );
+        const isManagedHeartbeatTrigger =
+          ctx.trigger === "heartbeat" && hasPendingManagedDreamingCronEvent(ctx.sessionKey);
+        const isManagedCronTrigger = ctx.trigger === "cron";
+        const shouldHandleManagedDreaming =
+          hasManagedDreamingToken && (isManagedHeartbeatTrigger || isManagedCronTrigger);
+        if (!shouldHandleManagedDreaming && !hasCronManagementContext()) {
+          return undefined;
+        }
+        const config = await reconcileManagedDreamingCron({
+          reason: "runtime",
+        });
+        if (!shouldHandleManagedDreaming) {
+          return undefined;
+        }
+        return await runShortTermDreamingPromotionIfTriggered({
+          cleanedBody: event.cleanedBody,
+          trigger: ctx.trigger,
+          agentId: ctx.agentId,
+          workspaceDir: ctx.workspaceDir,
+          cfg: currentConfig,
+          config,
+          logger: api.logger,
+          subagent: config.enabled ? api.runtime?.subagent : undefined,
+        });
+      } catch (err) {
+        api.logger.error(`memory-core: dreaming trigger failed: ${formatErrorMessage(err)}`);
         return undefined;
       }
-      const currentConfig = resolveCurrentConfig();
-      const hasManagedDreamingToken = includesSystemEventToken(
-        event.cleanedBody,
-        DREAMING_SYSTEM_EVENT_TEXT,
-      );
-      const isManagedHeartbeatTrigger =
-        ctx.trigger === "heartbeat" && hasPendingManagedDreamingCronEvent(ctx.sessionKey);
-      const isManagedCronTrigger = ctx.trigger === "cron";
-      const shouldHandleManagedDreaming =
-        hasManagedDreamingToken && (isManagedHeartbeatTrigger || isManagedCronTrigger);
-      if (!shouldHandleManagedDreaming && !hasCronManagementContext()) {
-        return undefined;
-      }
-      const config = await reconcileManagedDreamingCron({
-        reason: "runtime",
-      });
-      if (!shouldHandleManagedDreaming) {
-        return undefined;
-      }
-      return await runShortTermDreamingPromotionIfTriggered({
-        cleanedBody: event.cleanedBody,
-        trigger: ctx.trigger,
-        agentId: ctx.agentId,
-        workspaceDir: ctx.workspaceDir,
-        cfg: currentConfig,
-        config,
-        logger: api.logger,
-        subagent: config.enabled ? api.runtime?.subagent : undefined,
-      });
-    } catch (err) {
-      api.logger.error(`memory-core: dreaming trigger failed: ${formatErrorMessage(err)}`);
-      return undefined;
-    }
-  });
+    },
+    { eligibleTriggers: ["heartbeat", "cron"] },
+  );
 }
 /* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */

--- a/src/agents/main-session-restart-dispatch.ts
+++ b/src/agents/main-session-restart-dispatch.ts
@@ -114,7 +114,7 @@ export function resolveRestartRecoveryResumeBlockReason(params: {
   // A stored hook result proves that invocation completed, but not that the
   // same plugin code and config are still loaded after restart. Fail closed
   // until hook activation owns a stable cross-process implementation digest.
-  const unsafeHook = findRestartRecoveryUnsafeReplyHook();
+  const unsafeHook = findRestartRecoveryUnsafeReplyHook({ trigger: "user" });
   return unsafeHook ? `pre-hook recovery cannot bypass the active ${unsafeHook} hook` : undefined;
 }
 

--- a/src/agents/main-session-restart-recovery.test.ts
+++ b/src/agents/main-session-restart-recovery.test.ts
@@ -91,7 +91,7 @@ const transcriptMocks = vi.hoisted(() => ({
 }));
 const runtimePluginMocks = vi.hoisted(() => ({
   ensureRuntimePluginsLoaded: vi.fn(),
-  findRestartRecoveryUnsafeReplyHook: vi.fn<() => string | undefined>(),
+  findRestartRecoveryUnsafeReplyHook: vi.fn<(ctx: { trigger?: string }) => string | undefined>(),
 }));
 const discordDeliveryContext = {
   channel: "discord",
@@ -1687,7 +1687,9 @@ describe("main-session-restart-recovery", () => {
     ]);
 
     await expectRecovery({ recovered: 1, failed: 0, skipped: 0 }, {});
-    expect(runtimePluginMocks.findRestartRecoveryUnsafeReplyHook).toHaveBeenCalledOnce();
+    expect(runtimePluginMocks.findRestartRecoveryUnsafeReplyHook).toHaveBeenCalledWith({
+      trigger: "user",
+    });
     expect(callGateway).toHaveBeenCalledOnce();
     expect(gatewayParams()).toMatchObject({
       deliver: true,

--- a/src/plugin-sdk/plugin-entry.reply-trigger.test.ts
+++ b/src/plugin-sdk/plugin-entry.reply-trigger.test.ts
@@ -1,0 +1,21 @@
+import { describe, expectTypeOf, it } from "vitest";
+import type { OpenClawPluginApi } from "./plugin-entry.js";
+import type { PluginHookAgentTrigger } from "./types.js";
+
+function registerScopedReplyHook(api: OpenClawPluginApi): void {
+  api.on("before_agent_reply", async () => undefined, { eligibleTriggers: ["heartbeat", "cron"] });
+
+  // @ts-expect-error Trigger eligibility is only supported for before_agent_reply.
+  api.on("before_tool_call", async () => undefined, { eligibleTriggers: ["heartbeat"] });
+  // @ts-expect-error An empty trigger list cannot prove that a hook is inactive.
+  api.on("before_agent_reply", async () => undefined, { eligibleTriggers: [] });
+}
+
+void registerScopedReplyHook;
+
+describe("plugin-entry reply trigger contract", () => {
+  it("exposes the scoped option through the public plugin API", () => {
+    expectTypeOf<OpenClawPluginApi["on"]>().toBeFunction();
+    expectTypeOf<PluginHookAgentTrigger>().toEqualTypeOf<"cron" | "heartbeat" | "user">();
+  });
+});

--- a/src/plugin-sdk/types.ts
+++ b/src/plugin-sdk/types.ts
@@ -2,6 +2,7 @@
  * Public SDK type barrel for plugin hook contracts.
  */
 export type {
+  PluginHookAgentTrigger,
   PluginHookBeforeToolCallEvent,
   PluginHookBeforeToolCallResult,
   PluginHookSkillArtifact,

--- a/src/plugins/before-agent-reply.test.ts
+++ b/src/plugins/before-agent-reply.test.ts
@@ -40,6 +40,42 @@ describe("before_agent_reply runner boundary", () => {
     expect(buildHandledBeforeAgentReplyPayloads(reply)).toEqual([reply]);
   });
 
+  it.each([
+    { runId: "missing", context: { runId: "missing" } },
+    { runId: "mismatch", context: { runId: "mismatch", trigger: "heartbeat" } },
+  ])("uses the validated turn trigger when context is $runId", async ({ runId, context }) => {
+    await runBeforeAgentReplyForTurn({
+      runId,
+      trigger: "user",
+      event: { cleanedBody: runId },
+      context,
+    });
+
+    const expectedContext = { ...context, trigger: "user" };
+    expect(hookRunner.hasHooks).toHaveBeenCalledWith("before_agent_reply", expectedContext);
+    expect(hookRunner.runBeforeAgentReply).toHaveBeenCalledWith(
+      { cleanedBody: runId },
+      expectedContext,
+    );
+  });
+
+  it.each(["manual", "memory", "overflow"] as const)(
+    "does not dispatch for the internal %s trigger",
+    async (trigger) => {
+      await expect(
+        runBeforeAgentReplyForTurn({
+          runId: trigger,
+          trigger,
+          event: { cleanedBody: trigger },
+          context: { runId: trigger, trigger },
+        }),
+      ).resolves.toBeUndefined();
+
+      expect(hookRunner.hasHooks).not.toHaveBeenCalled();
+      expect(hookRunner.runBeforeAgentReply).not.toHaveBeenCalled();
+    },
+  );
+
   it("keeps a nested run from checkpointing its parent admission", async () => {
     const beforeDispatch = vi.fn(async () => undefined);
     const afterDispatch = vi.fn(async (result) => result);

--- a/src/plugins/before-agent-reply.ts
+++ b/src/plugins/before-agent-reply.ts
@@ -9,8 +9,8 @@ import type {
   PluginHookBeforeAgentReplyEvent,
   PluginHookBeforeAgentReplyResult,
 } from "./hook-types.js";
+import { isPluginHookAgentTrigger } from "./hook-types.js";
 
-const BEFORE_AGENT_REPLY_TRIGGERS = new Set(["user", "heartbeat", "cron"]);
 const BEFORE_AGENT_REPLY_OBSERVER_KEY = Symbol.for("openclaw.beforeAgentReply.observer");
 
 type BeforeAgentReplyObserver = {
@@ -48,12 +48,14 @@ export function runBeforeAgentReplyForTurn(params: {
   onDispatch?: () => void;
   onDeclined?: () => void;
 }): Promise<PluginHookBeforeAgentReplyResult | undefined> {
-  if (!params.trigger || !BEFORE_AGENT_REPLY_TRIGGERS.has(params.trigger)) {
+  const trigger = params.trigger;
+  if (!isPluginHookAgentTrigger(trigger)) {
     return Promise.resolve(undefined);
   }
+  const context = { ...params.context, trigger };
   return runOncePerAgentRun(params.runId, "before_agent_reply", async () => {
     const hookRunner = getGlobalHookRunner();
-    if (!hookRunner?.hasHooks("before_agent_reply")) {
+    if (!hookRunner?.hasHooks("before_agent_reply", context)) {
       return undefined;
     }
     const observerScope = beforeAgentReplyObserver.getStore();
@@ -70,7 +72,7 @@ export function runBeforeAgentReplyForTurn(params: {
       return undefined;
     }
     params.onDispatch?.();
-    let result = await hookRunner.runBeforeAgentReply(params.event, params.context);
+    let result = await hookRunner.runBeforeAgentReply(params.event, context);
     if (!result?.handled) {
       params.onDeclined?.();
     }

--- a/src/plugins/hook-runner-global.ts
+++ b/src/plugins/hook-runner-global.ts
@@ -20,7 +20,12 @@ import {
   createComposedHookRegistryFacade,
   getHookRunnerGlobalState,
 } from "./hook-runner-global-state.js";
-import type { PluginHookGatewayContext, PluginHookGatewayStopEvent } from "./hook-types.js";
+import type {
+  PluginHookGatewayContext,
+  PluginHookGatewayStopEvent,
+  PluginHookHandlerMap,
+  PluginHookName,
+} from "./hook-types.js";
 import { createHookRunner, type HookRunner } from "./hooks.js";
 
 const getLog = () => createSubsystemLogger("plugins");
@@ -78,8 +83,11 @@ export function getGlobalPluginRegistry(): GlobalHookRunnerRegistry | null {
 /**
  * Check if any hooks are registered for a given hook name.
  */
-export function hasGlobalHooks(hookName: Parameters<HookRunner["hasHooks"]>[0]): boolean {
-  return getHookRunnerGlobalState().hookRunner?.hasHooks(hookName) ?? false;
+export function hasGlobalHooks<K extends PluginHookName>(
+  hookName: K,
+  ctx?: Parameters<PluginHookHandlerMap[K]>[1],
+): boolean {
+  return getHookRunnerGlobalState().hookRunner?.hasHooks(hookName, ctx) ?? false;
 }
 
 export async function runGlobalGatewayStopSafely(params: {

--- a/src/plugins/hook-types.ts
+++ b/src/plugins/hook-types.ts
@@ -279,6 +279,26 @@ const conversationHookNameSet = new Set<PluginHookName>(CONVERSATION_HOOK_NAMES)
 export const isConversationHookName = (hookName: PluginHookName): boolean =>
   conversationHookNameSet.has(hookName);
 
+const PLUGIN_HOOK_AGENT_TRIGGERS = ["cron", "heartbeat", "user"] as const;
+
+export type PluginHookAgentTrigger = (typeof PLUGIN_HOOK_AGENT_TRIGGERS)[number];
+
+const pluginHookAgentTriggerSet = new Set<PluginHookAgentTrigger>(PLUGIN_HOOK_AGENT_TRIGGERS);
+
+export const isPluginHookAgentTrigger = (trigger: unknown): trigger is PluginHookAgentTrigger =>
+  typeof trigger === "string" && pluginHookAgentTriggerSet.has(trigger as PluginHookAgentTrigger);
+
+export type PluginHookRegistrationOptions<K extends PluginHookName> = {
+  priority?: number;
+  registrationId?: string;
+  timeoutMs?: number;
+} & (K extends "before_agent_reply"
+  ? {
+      /** Host-enforced turn triggers that may invoke this reply hook. */
+      eligibleTriggers?: readonly [PluginHookAgentTrigger, ...PluginHookAgentTrigger[]];
+    }
+  : { eligibleTriggers?: never });
+
 export type PluginHookAgentContext = {
   runId?: string;
   jobId?: string;
@@ -1408,6 +1428,7 @@ export type PluginHookRegistration<K extends PluginHookName = PluginHookName> = 
   handler: PluginHookHandlerMap[K];
   priority?: number;
   timeoutMs?: number;
+  eligibleTriggers?: readonly PluginHookAgentTrigger[];
   source: string;
 };
 /* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */

--- a/src/plugins/hooks.before-agent-reply.test.ts
+++ b/src/plugins/hooks.before-agent-reply.test.ts
@@ -120,4 +120,44 @@ describe("before_agent_reply hook runner (claiming pattern)", () => {
 
     expect(runner.hasHooks("before_agent_reply")).toBe(true);
   });
+
+  it("enforces trigger eligibility before invoking handlers", async () => {
+    const scheduled = vi.fn().mockResolvedValue({ handled: true, reply: { text: "scheduled" } });
+    const unrestricted = vi
+      .fn()
+      .mockResolvedValue({ handled: true, reply: { text: "unrestricted" } });
+    const registry = createMockPluginRegistry([
+      {
+        hookName: "before_agent_reply",
+        handler: scheduled,
+        eligibleTriggers: ["heartbeat", "cron"],
+      },
+      { hookName: "before_agent_reply", handler: unrestricted },
+    ]);
+    const runner = createHookRunner(registry);
+
+    await expect(
+      runner.runBeforeAgentReply(EVENT, { ...TEST_PLUGIN_AGENT_CTX, trigger: "user" }),
+    ).resolves.toEqual({ handled: true, reply: { text: "unrestricted" } });
+    expect(scheduled).not.toHaveBeenCalled();
+    expect(unrestricted).toHaveBeenCalledOnce();
+
+    expect(runner.hasHooks("before_agent_reply", { trigger: "user" })).toBe(true);
+    expect(runner.hasHooks("before_agent_reply", { trigger: "heartbeat" })).toBe(true);
+  });
+
+  it("keeps context-free checks fail-closed for trigger-scoped hooks", () => {
+    const registry = createMockPluginRegistry([
+      {
+        hookName: "before_agent_reply",
+        handler: vi.fn(),
+        eligibleTriggers: ["heartbeat", "cron"],
+      },
+    ]);
+    const runner = createHookRunner(registry);
+
+    expect(runner.hasHooks("before_agent_reply")).toBe(true);
+    expect(runner.hasHooks("before_agent_reply", { trigger: "user" })).toBe(false);
+    expect(runner.hasHooks("before_agent_reply", { trigger: "cron" })).toBe(true);
+  });
 });

--- a/src/plugins/hooks.test-fixtures.ts
+++ b/src/plugins/hooks.test-fixtures.ts
@@ -2,7 +2,11 @@
 import { createHookRunner } from "./hooks.js";
 import { addTestHook, createMockPluginRegistry } from "./hooks.test-helpers.js";
 import type { PluginRegistry } from "./registry.js";
-import type { PluginHookAgentContext, PluginHookRegistration } from "./types.js";
+import type {
+  PluginHookAgentContext,
+  PluginHookAgentTrigger,
+  PluginHookRegistration,
+} from "./types.js";
 
 export { addTestHook, createMockPluginRegistry };
 export type { PluginHookReplyDispatchResult } from "./hook-types.js";
@@ -49,6 +53,7 @@ export function createHookRunnerWithRegistry(
     pluginId?: string;
     priority?: number;
     timeoutMs?: number;
+    eligibleTriggers?: readonly PluginHookAgentTrigger[];
   }>,
   options?: Parameters<typeof createHookRunner>[1],
 ) {

--- a/src/plugins/hooks.test-helpers.ts
+++ b/src/plugins/hooks.test-helpers.ts
@@ -3,7 +3,7 @@ import { uniqueStrings } from "@openclaw/normalization-core/string-normalization
 import { createEmptyPluginRegistry } from "./registry-empty.js";
 import type { PluginRegistry } from "./registry.js";
 import { createPluginRecord } from "./status.test-helpers.js";
-import type { PluginHookRegistration } from "./types.js";
+import type { PluginHookAgentTrigger, PluginHookRegistration } from "./types.js";
 
 export function createMockPluginRegistry(
   hooks: Array<{
@@ -13,6 +13,7 @@ export function createMockPluginRegistry(
     priority?: number;
     registrationId?: string;
     timeoutMs?: number;
+    eligibleTriggers?: readonly PluginHookAgentTrigger[];
   }>,
 ): PluginRegistry {
   const pluginIds =
@@ -37,6 +38,7 @@ export function createMockPluginRegistry(
       priority: h.priority ?? 0,
       ...(h.registrationId ? { registrationId: h.registrationId } : {}),
       ...(h.timeoutMs !== undefined ? { timeoutMs: h.timeoutMs } : {}),
+      ...(h.eligibleTriggers !== undefined ? { eligibleTriggers: h.eligibleTriggers } : {}),
       source: "test",
     })) as PluginRegistry["typedHooks"],
   };
@@ -49,6 +51,7 @@ export function addTestHook(params: {
   priority?: number;
   registrationId?: string;
   timeoutMs?: number;
+  eligibleTriggers?: readonly PluginHookAgentTrigger[];
 }) {
   params.registry.typedHooks.push({
     pluginId: params.pluginId,
@@ -57,6 +60,7 @@ export function addTestHook(params: {
     priority: params.priority ?? 0,
     ...(params.registrationId ? { registrationId: params.registrationId } : {}),
     ...(params.timeoutMs !== undefined ? { timeoutMs: params.timeoutMs } : {}),
+    ...(params.eligibleTriggers !== undefined ? { eligibleTriggers: params.eligibleTriggers } : {}),
     source: "test",
   } as PluginHookRegistration);
 }

--- a/src/plugins/hooks.ts
+++ b/src/plugins/hooks.ts
@@ -21,6 +21,7 @@ import type {
   PluginHookAfterCompactionEvent,
   PluginHookAfterToolCallEvent,
   PluginHookAgentContext,
+  PluginHookAgentTrigger,
   PluginHookAgentEndEvent,
   PluginHookBeforeAgentFinalizeEvent,
   PluginHookBeforeAgentFinalizeResult,
@@ -238,9 +239,25 @@ type SyncHookResult<K extends SyncHookName> = ReturnType<SyncHookHandler<K>>;
 function getHooksForName<K extends PluginHookName>(
   registry: HookRunnerRegistry,
   hookName: K,
+  ctx?: unknown,
 ): PluginHookRegistration<K>[] {
   return (registry.typedHooks as PluginHookRegistration<K>[])
-    .filter((h) => h.hookName === hookName)
+    .filter((hook) => {
+      if (hook.hookName !== hookName) {
+        return false;
+      }
+      if (hookName !== "before_agent_reply" || hook.eligibleTriggers === undefined) {
+        return true;
+      }
+      const trigger =
+        typeof ctx === "object" && ctx !== null && "trigger" in ctx
+          ? (ctx as { trigger?: unknown }).trigger
+          : undefined;
+      return (
+        typeof trigger === "string" &&
+        hook.eligibleTriggers.includes(trigger as PluginHookAgentTrigger)
+      );
+    })
     .toSorted((a, b) => (b.priority ?? 0) - (a.priority ?? 0));
 }
 
@@ -666,7 +683,7 @@ export function createHookRunner(
     event: Parameters<NonNullable<PluginHookRegistration<K>["handler"]>>[0],
     ctx: Parameters<NonNullable<PluginHookRegistration<K>["handler"]>>[1],
   ): Promise<TResult | undefined> {
-    const hooks = getHooksForName(registry, hookName);
+    const hooks = getHooksForName(registry, hookName, ctx);
     if (hooks.length === 0) {
       return undefined;
     }
@@ -1663,8 +1680,14 @@ export function createHookRunner(
   // Utility
   // =========================================================================
 
-  function hasHooks(hookName: PluginHookName): boolean {
-    return registry.typedHooks.some((h) => h.hookName === hookName);
+  function hasHooks<K extends PluginHookName>(
+    hookName: K,
+    ctx?: Parameters<PluginHookHandlerMap[K]>[1],
+  ): boolean {
+    if (ctx === undefined) {
+      return registry.typedHooks.some((hook) => hook.hookName === hookName);
+    }
+    return getHooksForName(registry, hookName, ctx).length > 0;
   }
 
   /**

--- a/src/plugins/loader.hooks-and-runtime.test-utils.ts
+++ b/src/plugins/loader.hooks-and-runtime.test-utils.ts
@@ -1913,6 +1913,49 @@ describe("loadOpenClawPlugins", () => {
     ]);
   });
 
+  it("stores only valid before_agent_reply trigger eligibility", () => {
+    useNoBundledPlugins();
+    const plugin = writePlugin({
+      id: "reply-hook-trigger-eligibility",
+      filename: "reply-hook-trigger-eligibility.cjs",
+      body: `module.exports = { id: "reply-hook-trigger-eligibility", register(api) {
+    api.on("before_agent_reply", () => undefined, { eligibleTriggers: ["heartbeat", "cron", "heartbeat"] });
+    api.on("before_agent_reply", () => undefined);
+    api.on("before_agent_reply", () => undefined, { eligibleTriggers: [] });
+    api.on("before_agent_reply", () => undefined, { eligibleTriggers: ["heartbeat", "unknown"] });
+    api.on("before_agent_reply", () => undefined, { eligibleTriggers: ["manual"] });
+    api.on("before_agent_reply", () => undefined, { eligibleTriggers: "heartbeat" });
+    api.on("before_agent_reply", () => undefined, { eligibleTriggers: Array(1) });
+    api.on("before_agent_reply", () => undefined, { eligibleTriggers: [, "heartbeat"] });
+    api.on("before_tool_call", () => undefined, { eligibleTriggers: ["heartbeat"] });
+  } };`,
+    });
+
+    const registry = loadRegistryFromSinglePlugin({
+      plugin,
+      pluginConfig: {
+        allow: ["reply-hook-trigger-eligibility"],
+        entries: {
+          "reply-hook-trigger-eligibility": {
+            hooks: { allowConversationAccess: true },
+          },
+        },
+      },
+    });
+
+    expect(registry.typedHooks.map((entry) => entry.eligibleTriggers)).toEqual([
+      ["heartbeat", "cron"],
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+    ]);
+  });
+
   it("normalizes legacy deactivate typed hooks onto gateway_stop", () => {
     useNoBundledPlugins();
     const plugin = writePlugin({

--- a/src/plugins/plugin-api.types.ts
+++ b/src/plugins/plugin-api.types.ts
@@ -24,7 +24,11 @@ import type {
 import type { CliBackendPlugin, PluginTextTransforms } from "./cli-backend.types.js";
 import type { CodexAppServerExtensionFactory } from "./codex-app-server-extension-types.js";
 import type { PluginConversationBindingResolvedEvent } from "./conversation-binding.types.js";
-import type { PluginHookHandlerMap, PluginHookName } from "./hook-types.js";
+import type {
+  PluginHookHandlerMap,
+  PluginHookName,
+  PluginHookRegistrationOptions,
+} from "./hook-types.js";
 import type {
   PluginAgentEventEmitParams,
   PluginAgentEventEmitResult,
@@ -451,6 +455,6 @@ export type OpenClawPluginApi = {
   on: <K extends PluginHookName>(
     hookName: K,
     handler: PluginHookHandlerMap[K],
-    opts?: { priority?: number; registrationId?: string; timeoutMs?: number },
+    opts?: PluginHookRegistrationOptions<K>,
   ) => void;
 };

--- a/src/plugins/registry-registrars-tools-hooks.ts
+++ b/src/plugins/registry-registrars-tools-hooks.ts
@@ -32,6 +32,7 @@ import {
   DEPRECATED_PLUGIN_HOOKS,
   isConversationHookName,
   isDeprecatedPluginHookName,
+  isPluginHookAgentTrigger,
   isPluginHookName,
   isPromptInjectionHookName,
 } from "./types.js";
@@ -43,11 +44,23 @@ import type {
   OpenClawPluginToolOptions,
   PluginHookHandlerMap,
   PluginHookName,
+  PluginHookRegistrationOptions,
   PluginHookRegistration as TypedPluginHookRegistration,
 } from "./types.js";
 
 const LEGACY_DEACTIVATE_HOOK_ALIAS_COMPAT = getPluginCompatRecord("legacy-deactivate-hook-alias");
 const LEGACY_SUBAGENT_SPAWNING_HOOK_COMPAT = getPluginCompatRecord("legacy-subagent-spawning-hook");
+
+function normalizeEligibleTriggers(value: unknown) {
+  if (!Array.isArray(value)) {
+    return undefined;
+  }
+  const triggers = Array.from(value);
+  if (triggers.length === 0 || !triggers.every(isPluginHookAgentTrigger)) {
+    return undefined;
+  }
+  return uniqueValues(triggers);
+}
 
 function formatLegacyDeactivateHookAliasDiagnostic(): string {
   const removeAfter =
@@ -381,7 +394,7 @@ export function createToolHookRegistrars(state: PluginRegistryState) {
     record: PluginRecord,
     hookName: K,
     handler: PluginHookHandlerMap[K],
-    opts?: { priority?: number; registrationId?: string; timeoutMs?: number },
+    opts?: PluginHookRegistrationOptions<K>,
     policy?: PluginTypedHookPolicy,
   ) => {
     if (!isPluginHookName(hookName)) {
@@ -446,6 +459,10 @@ export function createToolHookRegistrars(state: PluginRegistryState) {
       }
     }
     const timeoutMs = resolveTypedHookTimeoutMs({ hookName: effectiveHookName, opts, policy });
+    const eligibleTriggers =
+      effectiveHookName === "before_agent_reply"
+        ? normalizeEligibleTriggers(opts?.eligibleTriggers)
+        : undefined;
     record.hookCount += 1;
     registry.typedHooks.push({
       pluginId: record.id,
@@ -454,6 +471,7 @@ export function createToolHookRegistrars(state: PluginRegistryState) {
       handler: effectiveHandler,
       priority: opts?.priority,
       ...(timeoutMs !== undefined ? { timeoutMs } : {}),
+      ...(eligibleTriggers ? { eligibleTriggers } : {}),
       source: record.source,
     } as TypedPluginHookRegistration);
   };

--- a/src/plugins/restart-recovery-hook-safety.test.ts
+++ b/src/plugins/restart-recovery-hook-safety.test.ts
@@ -1,42 +1,66 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { initializeGlobalHookRunner, resetGlobalHookRunner } from "./hook-runner-global.js";
+import { createMockPluginRegistry } from "./hooks.test-fixtures.js";
 import {
   findRestartRecoveryUnsafeChatAdmissionHook,
   findRestartRecoveryUnsafeReplyHook,
 } from "./restart-recovery-hook-safety.js";
 
-const hookMocks = vi.hoisted(() => ({
-  hasGlobalHooks: vi.fn<(hookName: string) => boolean>(),
-}));
-
-vi.mock("./hook-runner-global.js", () => ({
-  hasGlobalHooks: hookMocks.hasGlobalHooks,
-}));
+afterEach(() => {
+  resetGlobalHookRunner();
+});
 
 describe("findRestartRecoveryUnsafeReplyHook", () => {
-  beforeEach(() => {
-    hookMocks.hasGlobalHooks.mockReset();
-    hookMocks.hasGlobalHooks.mockReturnValue(false);
-  });
-
   it("reports the first active unsafe reply hook", () => {
-    hookMocks.hasGlobalHooks.mockImplementation(
-      (hookName) => hookName === "before_agent_reply" || hookName === "before_message_write",
+    initializeGlobalHookRunner(
+      createMockPluginRegistry([
+        { hookName: "before_agent_reply", handler: vi.fn() },
+        { hookName: "before_message_write", handler: vi.fn() },
+      ]),
     );
 
-    expect(findRestartRecoveryUnsafeReplyHook()).toBe("before_agent_reply");
+    expect(findRestartRecoveryUnsafeReplyHook({ trigger: "user" })).toBe("before_agent_reply");
   });
 
   it("does not exempt a checkpointed hook without a cross-process implementation digest", () => {
-    hookMocks.hasGlobalHooks.mockImplementation(
-      (hookName) => hookName === "before_agent_reply" || hookName === "before_message_write",
+    initializeGlobalHookRunner(
+      createMockPluginRegistry([
+        { hookName: "before_agent_reply", handler: vi.fn() },
+        { hookName: "before_message_write", handler: vi.fn() },
+      ]),
     );
 
-    expect(findRestartRecoveryUnsafeReplyHook()).toBe("before_agent_reply");
+    expect(findRestartRecoveryUnsafeReplyHook({ trigger: "user" })).toBe("before_agent_reply");
+  });
+
+  it("reloads scheduled reply hooks safely across three restart cycles", () => {
+    for (let cycle = 1; cycle <= 3; cycle += 1) {
+      resetGlobalHookRunner();
+      initializeGlobalHookRunner(
+        createMockPluginRegistry([
+          {
+            hookName: "before_agent_reply",
+            handler: vi.fn(),
+            eligibleTriggers: ["heartbeat", "cron"],
+          },
+        ]),
+      );
+
+      expect(findRestartRecoveryUnsafeReplyHook({ trigger: "user" }), `cycle ${cycle}`).toBe(
+        undefined,
+      );
+      expect(findRestartRecoveryUnsafeReplyHook({ trigger: "heartbeat" }), `cycle ${cycle}`).toBe(
+        "before_agent_reply",
+      );
+    }
   });
 
   it("allows deferred before_agent_reply at initial durable chat admission", () => {
-    hookMocks.hasGlobalHooks.mockImplementation(
-      (hookName) => hookName === "before_agent_reply" || hookName === "before_message_write",
+    initializeGlobalHookRunner(
+      createMockPluginRegistry([
+        { hookName: "before_agent_reply", handler: vi.fn() },
+        { hookName: "before_message_write", handler: vi.fn() },
+      ]),
     );
 
     expect(findRestartRecoveryUnsafeChatAdmissionHook()).toBe("before_message_write");

--- a/src/plugins/restart-recovery-hook-safety.ts
+++ b/src/plugins/restart-recovery-hook-safety.ts
@@ -1,4 +1,5 @@
 import { hasGlobalHooks } from "./hook-runner-global.js";
+import type { PluginHookAgentContext } from "./hook-types.js";
 
 const RESTART_RECOVERY_UNSAFE_REPLY_HOOKS = [
   "before_dispatch",
@@ -15,10 +16,14 @@ const RESTART_RECOVERY_UNSAFE_CHAT_ADMISSION_HOOKS = [
   "reply_dispatch",
 ] as const;
 
-export function findRestartRecoveryUnsafeReplyHook():
-  | (typeof RESTART_RECOVERY_UNSAFE_REPLY_HOOKS)[number]
-  | undefined {
-  return RESTART_RECOVERY_UNSAFE_REPLY_HOOKS.find((hookName) => hasGlobalHooks(hookName));
+export function findRestartRecoveryUnsafeReplyHook(
+  ctx: PluginHookAgentContext,
+): (typeof RESTART_RECOVERY_UNSAFE_REPLY_HOOKS)[number] | undefined {
+  return RESTART_RECOVERY_UNSAFE_REPLY_HOOKS.find((hookName) =>
+    hookName === "before_agent_reply"
+      ? hasGlobalHooks("before_agent_reply", ctx)
+      : hasGlobalHooks(hookName),
+  );
 }
 
 /** Initial chat admission defers before_agent_reply until after its durable checkpoint. */

--- a/test/scripts/type-suppression-inventory.test.ts
+++ b/test/scripts/type-suppression-inventory.test.ts
@@ -76,6 +76,8 @@ describe("type suppression inventory", () => {
       "src/infra/kysely-sync.types.test.ts:55:@ts-expect-error Kysely checks where-reference string literals.",
       "src/infra/kysely-sync.types.test.ts:58:@ts-expect-error Kysely checks grouped column string literals.",
       "src/infra/kysely-sync.types.test.ts:61:@ts-expect-error Kysely checks order references and selected aliases.",
+      "src/plugin-sdk/plugin-entry.reply-trigger.test.ts:8:@ts-expect-error Trigger eligibility is only supported for before_agent_reply.",
+      "src/plugin-sdk/plugin-entry.reply-trigger.test.ts:10:@ts-expect-error An empty trigger list cannot prove that a hook is inactive.",
     ]);
   });
 });


### PR DESCRIPTION
Fixes #111442

## What Problem This Solves

Restart recovery treated every `before_agent_reply` hook as eligible for an interrupted user turn. Bundled memory maintenance hooks are intended for scheduled heartbeat/cron work, but their mere presence could block recovery after a restart.

## Why This Change Was Made

Adds typed, host-enforced trigger eligibility to `before_agent_reply` registrations and evaluates that eligibility through the live global hook runner:

- valid non-empty trigger lists narrow dispatch and hook-presence checks;
- omitted, empty, malformed, or mixed-unknown metadata remains unrestricted and fail-closed;
- metadata is accepted only for `before_agent_reply`;
- memory-core dreaming and maintenance hooks declare `heartbeat`/`cron` eligibility;
- restart recovery asks whether a hook is eligible for the recovered `user` turn after runtime plugins load.

The implementation uses the existing public `OpenClawPluginApi.on` registration boundary. It adds no SDK export subpath and avoids special-casing memory-core in recovery code.

## User Impact

Interrupted user turns can recover after restart when only scheduled maintenance reply hooks are installed. Unscoped or malformed third-party hooks retain the conservative behavior and continue to block recovery.

## Evidence

Exact reviewed head: `b3f2645ccf0910bf0ebfd0611870899d86df42e3`

- 399 focused tests passed across restart recovery, plugin hooks, public type contracts, plugin loading, memory-core, and the suppression inventory.
- The global hook-runner lifecycle is exercised across three reload cycles.
- `git diff --check`, targeted `oxfmt`, and focused `oxlint` passed.
- SDK API baseline, export sync, SDK surface, plugin-boundary, dead-export, deprecated-API, script-declaration, environment-count, max-lines, and temp-creation checks passed.
- Core production, extension production, and extension test `tsgo` checks passed.
- Fresh branch autoreview found no accepted or actionable findings and rated the patch correct at 0.93 confidence.
- The maintainer rewrite preserves @hannesrudolph as co-author.

The local Blacksmith Testbox client was not authenticated, and the linked sparse worktree cannot safely reconcile shared dependencies. Exact-head hosted CI is therefore the authoritative broad integration gate after push.

## Maintainer Decision And ClawSweeper Moves

The `eligibleTriggers` contract is approved as the generic host-enforced API for `before_agent_reply`. Invalid, empty, or absent metadata intentionally remains unrestricted.

The optional credentialed `gateway-restart-multi-live` rank-up move was not rerun. Deterministic recovery, three global-runner reload cycles, memory-core behavior, and exactly-once dispatch decisions are covered directly by focused tests; exact-head hosted CI remains the broad integration gate.
