### PR TITLE
perf(ui): trust startup metadata and damp catalog polling

### DIFF
--- a/src/gateway/server-methods/chat-history-handler.ts
+++ b/src/gateway/server-methods/chat-history-handler.ts
@@ -269,6 +269,8 @@ async function buildChatStartupModelCatalogProjection(params: {
   return { getProjector, modelCatalogByAgentId, sessionCatalogProjector, sessionModelCatalog };
 }
 
+// The UI fills metadata gaps as soon as chat.startup returns, so history never waits
+// beyond this budget for a catalog snapshot that requires slower discovery.
 const CHAT_STARTUP_OPTIONAL_MODEL_CATALOG_TIMEOUT_MS = 25;
 function resolveChatHistoryNextOffset(params: {
   messages: unknown[];

--- a/ui/src/components/app-sidebar-session-catalog-live.ts
+++ b/ui/src/components/app-sidebar-session-catalog-live.ts
@@ -21,6 +21,35 @@ function sessionCatalogSnapshot(catalogs: readonly SessionCatalog[]): string {
   return JSON.stringify(catalogs);
 }
 
+function sessionCatalogMaterialSnapshot(catalogs: readonly SessionCatalog[]): string {
+  // Fast follow-up polls cover catalog/host/session identity sets, labels, connectivity,
+  // and session title/status. Ordering and recency timestamps cannot pin the 5s cadence.
+  return JSON.stringify(
+    catalogs
+      .map((catalog) => ({
+        id: catalog.id,
+        label: catalog.label,
+        hosts: catalog.hosts
+          .map((host) => ({
+            hostId: host.hostId,
+            label: host.label,
+            connected: host.connected,
+            errorCode: host.error?.code,
+            sessions: host.sessions
+              .map((session) => ({
+                threadId: session.threadId,
+                name: session.name,
+                status: session.status,
+                archived: session.archived,
+              }))
+              .toSorted((left, right) => left.threadId.localeCompare(right.threadId)),
+          }))
+          .toSorted((left, right) => left.hostId.localeCompare(right.hostId)),
+      }))
+      .toSorted((left, right) => left.id.localeCompare(right.id)),
+  );
+}
+
 export function sessionCatalogListClient(
   snapshot: ApplicationGatewaySnapshot | undefined,
   connected: boolean,
@@ -204,6 +233,10 @@ export class SessionCatalogLiveState {
     return this.refetchOwner !== null;
   }
 
+  get hasRequested() {
+    return this.progressSequence > 0;
+  }
+
   beginRefetch(active: boolean): symbol | null {
     if (!active) {
       return null;
@@ -259,11 +292,13 @@ export class SessionCatalogLiveState {
   markFinal(params: {
     catalogs: readonly SessionCatalog[];
     hadCatalogs: boolean;
-    previousSnapshot: string;
+    previousMaterialSnapshot: string;
     progressSequence: number;
   }) {
     this.sawChange =
-      params.hadCatalogs && params.previousSnapshot !== sessionCatalogSnapshot(params.catalogs);
+      params.hadCatalogs &&
+      (this.sawChange ||
+        params.previousMaterialSnapshot !== sessionCatalogMaterialSnapshot(params.catalogs));
     const finalCatalogIds = new Set(params.catalogs.map((catalog) => catalog.id));
     for (const [catalogId, previousHostIds] of this.hostIdsByCatalog) {
       if (finalCatalogIds.has(catalogId)) {
@@ -338,7 +373,7 @@ export class SessionCatalogLiveState {
     agentId: string;
     catalogs: SessionCatalog[];
     pageDepths: ReadonlyMap<string, number>;
-  }): { catalogs: SessionCatalog[]; catalogId: string } | null {
+  }): { catalogs: SessionCatalog[]; catalogId: string; materialChange: boolean } | null {
     if (!isSessionsCatalogHostEvent(params.payload)) {
       return null;
     }
@@ -386,8 +421,10 @@ export class SessionCatalogLiveState {
     if (sessionCatalogSnapshot(catalogs) === sessionCatalogSnapshot(params.catalogs)) {
       return null;
     }
-    this.sawChange = true;
-    return { catalogs, catalogId: event.catalog.id };
+    const materialChange =
+      sessionCatalogMaterialSnapshot(catalogs) !== sessionCatalogMaterialSnapshot(params.catalogs);
+    this.sawChange ||= materialChange;
+    return { catalogs, catalogId: event.catalog.id, materialChange };
   }
 
   schedule(delayMs: number, isConnected: boolean, refresh: () => void) {
@@ -434,8 +471,8 @@ export class SessionCatalogLiveState {
     if (this.activationTimer !== null) {
       return;
     }
-    // Browsers fire visibilitychange and focus as one foregrounding pair.
-    // The short window prevents that pair from triggering two fleet scans.
+    // Presence, host updates, visibilitychange, and focus arrive in activation bursts.
+    // One short window keeps the burst to a single fleet scan.
     this.activationTimer = globalThis.setTimeout(() => {
       this.activationTimer = null;
       refresh();
@@ -466,7 +503,7 @@ export async function refreshSessionCatalogsLive(params: {
   }
   const { progressId, progressSequence, requestOwner } = live.beginRequest(generation);
   const hadCatalogs = params.catalogs().length > 0;
-  const previousSnapshot = sessionCatalogSnapshot(params.catalogs());
+  const previousMaterialSnapshot = sessionCatalogMaterialSnapshot(params.catalogs());
   let refetchOwner: symbol | null = null;
   const requestIsCurrent = () =>
     live.ownsRequest(requestOwner) &&
@@ -496,7 +533,7 @@ export async function refreshSessionCatalogsLive(params: {
       ...catalogs.map((catalog) => catalog.id),
     ]);
     params.applyFinal(catalogs, revisedCatalogIds);
-    live.markFinal({ catalogs, hadCatalogs, previousSnapshot, progressSequence });
+    live.markFinal({ catalogs, hadCatalogs, previousMaterialSnapshot, progressSequence });
   } catch (error) {
     // A transient poll failure must not collapse already visible or expanded pages.
     if (revisionIsCurrent()) {

--- a/ui/src/components/session-data-controller-catalog.ts
+++ b/ui/src/components/session-data-controller-catalog.ts
@@ -56,16 +56,14 @@ export interface SessionCatalogDataOwner {
   refreshSessionCatalogs(): Promise<void>;
 }
 
-export function visibleSessionCatalogClient(
-  owner: SessionCatalogDataOwner,
-): GatewayBrowserClient | null {
+function visibleSessionCatalogClient(owner: SessionCatalogDataOwner): GatewayBrowserClient | null {
   if (document.visibilityState === "hidden") {
     return null;
   }
   return sessionCatalogListClient(owner.context?.gateway.snapshot, owner.sessionDataHostConnected);
 }
 
-export function synchronizeSessionCatalogAgent(
+function synchronizeSessionCatalogAgent(
   owner: SessionCatalogDataOwner,
   agentId: string | null,
 ): void {
@@ -127,7 +125,7 @@ function resolveSessionCatalogAgentId(
   return selected && selected !== helloDefault ? null : helloDefault;
 }
 
-export function requestSessionCatalogRefresh(owner: SessionCatalogDataOwner): void {
+function requestSessionCatalogRefresh(owner: SessionCatalogDataOwner): void {
   const snapshot = owner.context?.gateway.snapshot;
   owner.sessionCatalogLive.requestRefresh({
     visible: document.visibilityState !== "hidden",

--- a/ui/src/components/session-data-controller-catalog.ts
+++ b/ui/src/components/session-data-controller-catalog.ts
@@ -140,6 +140,32 @@ export function requestSessionCatalogRefresh(owner: SessionCatalogDataOwner): vo
   });
 }
 
+export function scheduleSessionCatalogRefresh(owner: SessionCatalogDataOwner): void {
+  if (document.visibilityState === "hidden") {
+    owner.sessionCatalogLive.cancelScheduledRefreshes();
+    return;
+  }
+  owner.sessionCatalogLive.scheduleActivation(() => requestSessionCatalogRefresh(owner));
+}
+
+export function updateSessionCatalogData(owner: SessionCatalogDataOwner, defer = false): void {
+  if (owner.context) {
+    synchronizeSessionCatalogAgent(owner, owner.expandedAgentId());
+  }
+  if (
+    !visibleSessionCatalogClient(owner) ||
+    owner.sessionCatalogLive.timer ||
+    owner.sessionCatalogLive.requestGeneration === owner.sessionCatalogGeneration
+  ) {
+    return;
+  }
+  if (defer && owner.sessionCatalogLive.hasRequested) {
+    scheduleSessionCatalogRefresh(owner);
+    return;
+  }
+  void owner.refreshSessionCatalogs();
+}
+
 export function applySessionCatalogHostEvent(
   owner: SessionCatalogDataOwner,
   payload: unknown,
@@ -158,7 +184,10 @@ export function applySessionCatalogHostEvent(
   owner.sessionCatalogRevision += owner.sessionCatalogLive.refetching ? 1 : 0;
   const catalogRevision = owner.sessionCatalogRevisions.get(update.catalogId) ?? 0;
   owner.sessionCatalogRevisions.set(update.catalogId, catalogRevision + 1);
-  if (owner.sessionCatalogLive.requestGeneration !== owner.sessionCatalogGeneration) {
+  if (
+    update.materialChange &&
+    owner.sessionCatalogLive.requestGeneration !== owner.sessionCatalogGeneration
+  ) {
     owner.sessionCatalogLive.schedule(
       SESSION_CATALOG_CHANGED_REFRESH_MS,
       owner.isSessionDataHostConnected,

--- a/ui/src/components/session-data-controller.ts
+++ b/ui/src/components/session-data-controller.ts
@@ -37,11 +37,10 @@ import {
   applySessionCatalogHostEvent as applySessionCatalogHostEventToData,
   loadMoreSessionCatalog as loadMoreSessionCatalogData,
   refreshSessionCatalogs as refreshSessionCatalogData,
-  requestSessionCatalogRefresh as requestSessionCatalogDataRefresh,
-  synchronizeSessionCatalogAgent,
+  scheduleSessionCatalogRefresh,
   type SessionCatalogDataOwner,
   type SessionDataControllerHost,
-  visibleSessionCatalogClient,
+  updateSessionCatalogData as updateSessionCatalogDataForHost,
 } from "./session-data-controller-catalog.ts";
 
 /** Gateway-backed session-list and external-catalog data ownership. */
@@ -185,7 +184,7 @@ export class SessionDataController implements ReactiveController, SessionCatalog
 
   hostUpdated(): void {
     this.syncSessionsScrollObserver();
-    this.updateSessionCatalogData();
+    this.updateSessionCatalogData(true);
   }
 
   hostDisconnected(): void {
@@ -260,18 +259,8 @@ export class SessionDataController implements ReactiveController, SessionCatalog
     this.notify();
   }
 
-  updateSessionCatalogData(): void {
-    if (this.context) {
-      synchronizeSessionCatalogAgent(this, this.host.expandedAgentId());
-    }
-    if (
-      !visibleSessionCatalogClient(this) ||
-      this.sessionCatalogLive.timer ||
-      this.sessionCatalogLive.requestGeneration === this.sessionCatalogGeneration
-    ) {
-      return;
-    }
-    void this.refreshSessionCatalogs();
+  updateSessionCatalogData(defer = false): void {
+    updateSessionCatalogDataForHost(this, defer);
   }
 
   handleSessionCatalogHostEvent(payload: unknown): void {
@@ -280,7 +269,7 @@ export class SessionDataController implements ReactiveController, SessionCatalog
 
   handleSessionCatalogPresence(payload: unknown): void {
     if (this.sessionCatalogLive.observePresence(payload)) {
-      requestSessionCatalogDataRefresh(this);
+      scheduleSessionCatalogRefresh(this);
     }
   }
 
@@ -303,11 +292,7 @@ export class SessionDataController implements ReactiveController, SessionCatalog
   };
 
   private readonly handleSessionCatalogPageActivation = () => {
-    if (document.visibilityState === "hidden") {
-      this.sessionCatalogLive.cancelScheduledRefreshes();
-      return;
-    }
-    this.sessionCatalogLive.scheduleActivation(() => requestSessionCatalogDataRefresh(this));
+    scheduleSessionCatalogRefresh(this);
   };
 
   refreshSessionCatalogs(): Promise<void> {

--- a/ui/src/e2e/chat-composer-redesign.e2e.test.ts
+++ b/ui/src/e2e/chat-composer-redesign.e2e.test.ts
@@ -112,8 +112,7 @@ describeControlUiE2e("Control UI chat composer redesign", () => {
 
     try {
       await page.goto(`${server.baseUrl}chat`);
-      await gateway.waitForRequest("chat.metadata");
-      expect(await gateway.getRequests("models.list")).toHaveLength(0);
+      await gateway.waitForRequest("chat.startup");
 
       const composer = page.locator(".agent-chat__input");
       const composerShell = page.locator(".agent-chat__composer-shell");
@@ -133,6 +132,8 @@ describeControlUiE2e("Control UI chat composer redesign", () => {
       const voice = page.getByRole("button", { name: "Start voice input" });
 
       await expect.poll(() => model.isVisible()).toBe(true);
+      expect(await gateway.getRequests("chat.metadata")).toHaveLength(0);
+      expect(await gateway.getRequests("models.list")).toHaveLength(0);
       await expect.poll(() => contextUsage.isVisible()).toBe(true);
       await expect.poll(() => usage.isVisible()).toBe(false);
       await expect.poll(() => settings.isVisible()).toBe(true);
@@ -705,17 +706,10 @@ describeControlUiE2e("Control UI chat composer redesign", () => {
 
     try {
       await page.goto(controlUiSessionUrl(server.baseUrl, "agent:work:main"));
-      await expect
-        .poll(
-          async () => {
-            const requests = await gateway.getRequests("chat.metadata");
-            return requests.some(
-              (request) => (request.params as { agentId?: string } | undefined)?.agentId === "work",
-            );
-          },
-          { timeout: 10_000 },
-        )
-        .toBe(true);
+      await gateway.waitForRequest("chat.startup");
+      // The initial work-agent catalog is complete in chat.startup, so only the
+      // later switch to the other agent should require chat.metadata.
+      expect(await gateway.getRequests("chat.metadata")).toHaveLength(0);
 
       const composer = page.locator(".agent-chat__input");
       await expect
@@ -729,23 +723,28 @@ describeControlUiE2e("Control UI chat composer redesign", () => {
       await expect
         .poll(async () => {
           const requests = await gateway.getRequests("chat.metadata");
-          return requests.some(
+          return requests.filter(
             (request) => (request.params as { agentId?: string } | undefined)?.agentId === "other",
-          );
+          ).length;
         })
-        .toBe(true);
+        .toBe(1);
       await expect
         .poll(() => composer.locator('[data-chat-model-option="anthropic/other-model"]').count())
         .toBe(1);
       await expect
         .poll(() => composer.locator('[data-chat-model-option="openai/work-model"]').count())
         .toBe(0);
+      const metadataRequests = await gateway.getRequests("chat.metadata");
+      expect(metadataRequests).toHaveLength(1);
+      expect((metadataRequests[0]?.params as { agentId?: string } | undefined)?.agentId).toBe(
+        "other",
+      );
     } finally {
       await context.close();
     }
   });
 
-  it("keeps startup models when the metadata refresh fails", async () => {
+  it("keeps startup models when an explicit metadata refresh fails", async () => {
     const context = await browser.newContext({ viewport: { width: 1280, height: 900 } });
     const page = await context.newPage();
     const gateway = await installMockGateway(page, {
@@ -755,12 +754,23 @@ describeControlUiE2e("Control UI chat composer redesign", () => {
 
     try {
       await page.goto(`${server.baseUrl}chat`);
+      await gateway.waitForRequest("chat.startup");
+      const composer = page.locator(".agent-chat__input");
+      await expect
+        .poll(() => composer.locator('[data-chat-model-provider-group="openai"]').textContent())
+        .toContain("GPT-5.5");
+      expect(await gateway.getRequests("chat.metadata")).toHaveLength(0);
+
+      // Startup metadata now owns the initial catalog, so there is no unconditional
+      // parallel refresh. Exercise the same-agent pane refresh path explicitly.
+      await page.locator("openclaw-chat-pane").evaluate((pane) => {
+        (pane as HTMLElement & { sessionKey: string }).sessionKey = "agent:main:refreshed";
+      });
       await gateway.waitForRequest("chat.metadata");
       await gateway.rejectDeferred("chat.metadata", {
         code: "UNAVAILABLE",
         message: "metadata unavailable",
       });
-      const composer = page.locator(".agent-chat__input");
       await expect
         .poll(() => composer.locator('[data-chat-model-provider-group="openai"]').textContent())
         .toContain("GPT-5.5");

--- a/ui/src/e2e/chat-flow.e2e.test.ts
+++ b/ui/src/e2e/chat-flow.e2e.test.ts
@@ -2270,7 +2270,9 @@ describeControlUiE2e("Control UI mocked Gateway E2E", () => {
       await page.goto(`${server.baseUrl}chat`);
       await gateway.waitForRequest("chat.startup");
       expect(await gateway.getRequests("agents.list")).toHaveLength(0);
-      expect(await gateway.getRequests("chat.metadata")).toHaveLength(1);
+      // chat.startup owns the initial metadata load; the old parallel
+      // chat.metadata request was only a synchronization point for this test.
+      expect(await gateway.getRequests("chat.metadata")).toHaveLength(0);
       expect(await gateway.getRequests("commands.list")).toHaveLength(0);
       expect(await gateway.getRequests("models.list")).toHaveLength(0);
 
@@ -2316,24 +2318,45 @@ describeControlUiE2e("Control UI mocked Gateway E2E", () => {
         },
         messages: [],
         metadata: {
-          models: [],
+          commands: [
+            {
+              acceptsArgs: false,
+              description: "Loaded after startup completes",
+              name: "startup-ready",
+              scope: "text",
+              source: "native",
+            },
+          ],
+          models: [
+            {
+              available: true,
+              id: "startup-model",
+              name: "Startup Model",
+              provider: "openai",
+            },
+          ],
         },
         sessionId: "control-ui-e2e-session",
         thinkingLevel: null,
       });
       await page.locator(".chat-thread").getByText(prompt).waitFor({ timeout: 10_000 });
       await page.getByText("First token visible.").waitFor({ timeout: 10_000 });
-      await gateway.waitForRequest("chat.metadata");
-      expect(await gateway.getRequests("chat.metadata")).toHaveLength(1);
-      expect(await gateway.getRequests("models.list")).toHaveLength(0);
-      expect(await gateway.getRequests("commands.list")).toHaveLength(0);
+      await expect
+        .poll(() => page.locator('[data-chat-model-option="openai/startup-model"]').count())
+        .toBe(1);
       await gateway.emitChatFinal({ runId, text: "History race stayed visible." });
       await page
         .locator(".chat-thread-inner")
         .getByText("History race stayed visible.")
         .waitFor({ timeout: 10_000 });
       await page.locator(".agent-chat__composer-combobox textarea").fill("/");
-      expect(await gateway.getRequests("commands.list")).toHaveLength(0);
+      await page.getByRole("option", { name: /\/startup-ready/ }).waitFor({ timeout: 10_000 });
+      // Check after both controls render so no late fallback RPC supplied either catalog.
+      expect({
+        commands: (await gateway.getRequests("commands.list")).length,
+        metadata: (await gateway.getRequests("chat.metadata")).length,
+        models: (await gateway.getRequests("models.list")).length,
+      }).toEqual({ commands: 0, metadata: 0, models: 0 });
       expect(await gateway.getRequests("agents.list")).toHaveLength(0);
     } finally {
       await closeBrowserContext(context);

--- a/ui/src/pages/chat/chat-pane-session.ts
+++ b/ui/src/pages/chat/chat-pane-session.ts
@@ -182,6 +182,7 @@ export abstract class ChatPaneSession extends ChatPaneSuggestions {
     this.cancelHeaderRename();
     this.resetOlderMessagesViewport();
     const catalogKey = parseCatalogSessionKey(nextSessionKey);
+    const previousAgentId = resolveChatAgentId(state);
     const previousSessionsResult = state.sessionsResult;
     const nextSessionRow = state.sessionsResult?.sessions.find((row) => row.key === nextSessionKey);
     const nextSessionLabel = resolveSessionDisplayName(nextSessionKey, nextSessionRow);
@@ -241,7 +242,12 @@ export abstract class ChatPaneSession extends ChatPaneSuggestions {
     }
     void state.loadAssistantIdentity();
     void refreshChatAvatar(state).finally(() => this.requestUpdate());
-    void refreshChatMetadata(state).finally(() => state.requestUpdate?.());
+    const nextAgentId = resolveChatAgentId(state);
+    // Agent-scoped catalogs remain valid across same-agent sessions. Cross-agent
+    // failures must clear instead of retaining models owned by the previous agent.
+    void refreshChatMetadata(state, {
+      preserveModelCatalogOnFallback: Boolean(previousAgentId && previousAgentId === nextAgentId),
+    }).finally(() => state.requestUpdate?.());
     const subscriptionSync = syncSelectedSessionMessageSubscription(state);
     const composerStorageError = state.chatError === CHAT_COMPOSER_DRAFT_STORAGE_ERROR;
     const historyLoad = loadChatHistory(state, { deferBranches: true });

--- a/ui/src/pages/chat/chat-send.test.ts
+++ b/ui/src/pages/chat/chat-send.test.ts
@@ -5,6 +5,7 @@ import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vite
 import { GatewayRequestError } from "../../api/gateway.ts";
 import type { GatewaySessionRow, SessionsListResult } from "../../api/types.ts";
 import type { UiSettings } from "../../app/settings.ts";
+import { SLASH_COMMANDS } from "../../lib/chat/commands.ts";
 import { createSessionCapability } from "../../lib/sessions/index.ts";
 import { createStorageMock } from "../../test-helpers/storage.ts";
 import { waitForFast } from "../../test-helpers/wait-for.ts";
@@ -548,15 +549,13 @@ describe("refreshChat", () => {
     expect(requestUpdate).not.toHaveBeenCalled();
   });
 
-  it("starts startup metadata without waiting for the transcript response", async () => {
+  it("uses startup-shipped metadata without requesting chat.metadata", async () => {
     const startup = createDeferred<unknown>();
-    const metadata = createDeferred<unknown>();
     const host = makeHost({
       hello: {
         features: { methods: ["chat.metadata", "chat.startup"] },
       } as TestChatHost["hello"],
       requestHandlers: {
-        "chat.metadata": () => metadata.promise,
         "chat.startup": () => startup.promise,
       },
     });
@@ -567,39 +566,8 @@ describe("refreshChat", () => {
       startup: true,
     });
 
-    expect(host.request.mock.calls.map(([method]) => method)).toEqual([
-      "chat.startup",
-      "chat.metadata",
-    ]);
+    expect(host.request.mock.calls.map(([method]) => method)).toEqual(["chat.startup"]);
     expect(await raceWithMacrotask(refresh)).toBe("pending");
-
-    metadata.resolve({ commands: [], models: [] });
-    startup.resolve({ messages: [] });
-    await expect(refresh).resolves.toBeUndefined();
-  });
-
-  it("preserves startup metadata when parallel metadata needs fallbacks", async () => {
-    const startup = createDeferred<unknown>();
-    const metadata = createDeferred<unknown>();
-    const host = makeHost({
-      hello: {
-        features: { methods: ["chat.metadata", "chat.startup"] },
-      } as TestChatHost["hello"],
-      requestHandlers: {
-        "chat.metadata": () => metadata.promise,
-        "chat.startup": () => startup.promise,
-      },
-    });
-    const refresh = refreshPageChat(asChatPageHost(host), {
-      awaitHistory: true,
-      deferBranches: true,
-      startup: true,
-    });
-
-    metadata.resolve({});
-    await Promise.resolve();
-    expect(host.request).not.toHaveBeenCalledWith("models.list", expect.anything());
-    expect(host.request).not.toHaveBeenCalledWith("commands.list", expect.anything());
 
     startup.resolve({
       messages: [],
@@ -616,7 +584,7 @@ describe("refreshChat", () => {
       },
     });
     await expect(refresh).resolves.toBeUndefined();
-    await vi.waitFor(() =>
+    await waitForFast(() =>
       expect(host.chatModelCatalog).toEqual([
         {
           available: true,
@@ -626,8 +594,73 @@ describe("refreshChat", () => {
         },
       ]),
     );
+    expect(host.request).not.toHaveBeenCalledWith("chat.metadata", expect.anything());
     expect(host.request).not.toHaveBeenCalledWith("models.list", expect.anything());
     expect(host.request).not.toHaveBeenCalledWith("commands.list", expect.anything());
+  });
+
+  it("fills omitted startup metadata immediately and populates models and commands", async () => {
+    const startup = createDeferred<unknown>();
+    const host = makeHost({
+      hello: {
+        features: { methods: ["chat.metadata", "chat.startup"] },
+      } as TestChatHost["hello"],
+      requestHandlers: {
+        "chat.metadata": {},
+        "commands.list": {
+          commands: [
+            {
+              name: "startup-gap-command",
+              textAliases: ["/startup-gap-command"],
+              description: "Loaded from the startup metadata gap fill.",
+              source: "plugin",
+              scope: "text",
+              acceptsArgs: false,
+            },
+          ],
+        },
+        "chat.startup": () => startup.promise,
+        "models.list": {
+          models: [
+            {
+              available: true,
+              id: "gap-model",
+              name: "Gap Model",
+              provider: "openai",
+            },
+          ],
+        },
+      },
+    });
+    const refresh = refreshPageChat(asChatPageHost(host), {
+      awaitHistory: true,
+      deferBranches: true,
+      startup: true,
+    });
+
+    expect(host.request.mock.calls.map(([method]) => method)).toEqual(["chat.startup"]);
+    expect(host.request).not.toHaveBeenCalledWith("models.list", expect.anything());
+    expect(host.request).not.toHaveBeenCalledWith("commands.list", expect.anything());
+
+    startup.resolve({ messages: [] });
+    await expect(refresh).resolves.toBeUndefined();
+    await waitForFast(() =>
+      expect(host.chatModelCatalog).toEqual([
+        {
+          available: true,
+          id: "gap-model",
+          name: "Gap Model",
+          provider: "openai",
+        },
+      ]),
+    );
+    expect(SLASH_COMMANDS.some((command) => command.name === "startup-gap-command")).toBe(true);
+    expect(host.request).toHaveBeenCalledWith("models.list", { view: "configured" });
+    expect(host.request).toHaveBeenCalledWith(
+      "commands.list",
+      expect.objectContaining({ includeArgs: true, scope: "text" }),
+    );
+    expect(host.request).toHaveBeenCalledWith("chat.metadata", { agentId: "main" });
   });
 
   it.each([

--- a/ui/src/pages/chat/chat-state-refresh.ts
+++ b/ui/src/pages/chat/chat-state-refresh.ts
@@ -46,8 +46,6 @@ type ChatMetadataRequest = {
 };
 
 type ChatMetadataRefreshOptions = {
-  fallbackMetadata?: Promise<ChatMetadataApplyResult>;
-  onApplied?: (result: ChatMetadataApplyResult) => void;
   preserveModelCatalogOnFallback?: boolean;
   requestVersion?: number;
 };
@@ -132,17 +130,13 @@ async function refreshMissingChatMetadata(
   applied: ChatMetadataApplyResult,
   opts?: ChatMetadataRefreshOptions,
 ): Promise<void> {
-  const startupApplied = opts?.fallbackMetadata
-    ? await opts.fallbackMetadata.catch(() => EMPTY_CHAT_METADATA_APPLY_RESULT)
-    : EMPTY_CHAT_METADATA_APPLY_RESULT;
   if (!ownsChatMetadataRequest(request)) {
     return;
   }
-  const commandsRefresh =
-    applied.commands || startupApplied.commands
-      ? Promise.resolve()
-      : refreshCompatibilityCommands(request);
-  const preserveModels = opts?.preserveModelCatalogOnFallback || startupApplied.models;
+  const commandsRefresh = applied.commands
+    ? Promise.resolve()
+    : refreshCompatibilityCommands(request);
+  const preserveModels = opts?.preserveModelCatalogOnFallback;
   const modelsRefresh =
     applied.models || preserveModels
       ? Promise.resolve()
@@ -187,7 +181,6 @@ export async function refreshChatMetadata(
       return EMPTY_CHAT_METADATA_APPLY_RESULT;
     }
     const metadataApplied = applyChatMetadataResult(host, client, agentId, result);
-    opts?.onApplied?.(metadataApplied);
     if (!metadataApplied.models || !metadataApplied.commands) {
       await refreshMissingChatMetadata(request, metadataApplied, opts);
     }
@@ -316,35 +309,55 @@ async function refreshChat(
 }
 
 export function refreshPageChat(host: ChatPageHost, opts?: ChatRefreshOptions) {
-  let resolveStartupMetadata: (result: ChatMetadataApplyResult) => void = () => {};
-  const ownsStartupMetadata = Boolean(opts?.startup && host.client && host.connected);
+  const ownsStartupMetadata = Boolean(
+    opts?.startup &&
+    host.client &&
+    host.connected &&
+    isGatewayMethodAdvertised(host as unknown as ChatState, "chat.startup") !== false,
+  );
   const startupMetadataRequestVersion = ownsStartupMetadata
     ? ++host.chatMetadataRequestVersion
     : null;
-  const startupMetadataApplied = ownsStartupMetadata
-    ? new Promise<ChatMetadataApplyResult>((resolve) => {
-        resolveStartupMetadata = resolve;
-      })
-    : Promise.resolve({ commands: false, models: false });
-  let parallelMetadataApplied = EMPTY_CHAT_METADATA_APPLY_RESULT;
+  if (ownsStartupMetadata) {
+    host.chatModelsLoading = true;
+  }
 
   const refresh = refreshChat(host, {
     ...opts,
-    onStartupMetadata: ({ client, agentId, metadata }) => {
-      const ownsMetadata =
-        startupMetadataRequestVersion !== null &&
-        host.chatMetadataRequestVersion === startupMetadataRequestVersion &&
-        host.client === client &&
-        host.connected &&
-        resolveChatAgentId(host) === agentId;
-      const applied =
-        metadata && ownsMetadata
-          ? applyChatMetadataResult(host, client, agentId, metadata, {
-              commands: !parallelMetadataApplied.commands,
-              models: !parallelMetadataApplied.models,
-            })
-          : { commands: false, models: false };
-      resolveStartupMetadata(applied);
+    onStartupMetadata: async ({ client, agentId, metadata }) => {
+      if (
+        startupMetadataRequestVersion === null ||
+        host.chatMetadataRequestVersion !== startupMetadataRequestVersion ||
+        host.client !== client ||
+        !host.connected ||
+        resolveChatAgentId(host) !== agentId
+      ) {
+        return;
+      }
+      const request: ChatMetadataRequest = {
+        host,
+        client,
+        agentId,
+        version: startupMetadataRequestVersion,
+      };
+      try {
+        if (!metadata) {
+          // Missing startup metadata means the bounded catalog projection could not finish.
+          // Start the scoped combined fallback now, on the response signal, rather than at idle.
+          await refreshChatMetadata(host, { requestVersion: startupMetadataRequestVersion });
+          return;
+        }
+        const applied = applyChatMetadataResult(host, client, agentId, metadata);
+        if (!applied.models || !applied.commands) {
+          // chat.startup owns the first metadata load. Fill only omitted fields here;
+          // a parallel chat.metadata request would repeat the same catalog discovery.
+          await refreshMissingChatMetadata(request, applied);
+        }
+      } finally {
+        if (ownsChatMetadataRequest(request)) {
+          host.chatModelsLoading = false;
+        }
+      }
     },
   });
 
@@ -354,47 +367,14 @@ export function refreshPageChat(host: ChatPageHost, opts?: ChatRefreshOptions) {
     host.connected &&
     (startupMetadataRequestVersion === null ||
       host.chatMetadataRequestVersion === startupMetadataRequestVersion);
-  const parallelMetadataRefresh =
-    startupMetadataRequestVersion !== null &&
-    isGatewayMethodAdvertised(host as unknown as ChatState, "chat.metadata") !== false
-      ? refreshChatMetadata(host, {
-          fallbackMetadata: startupMetadataApplied,
-          requestVersion: startupMetadataRequestVersion,
-          onApplied: (applied) => {
-            parallelMetadataApplied = {
-              commands: parallelMetadataApplied.commands || applied.commands,
-              models: parallelMetadataApplied.models || applied.models,
-            };
-          },
-        })
-      : null;
-  if (parallelMetadataRefresh) {
-    void parallelMetadataRefresh.finally(() => host.requestUpdate?.());
-  }
   scheduleChatMetadataRefresh(() => {
     if (!ownsScheduledMetadataRefresh()) {
       return;
     }
-    void startupMetadataApplied
-      .catch(() => ({ commands: false, models: false }))
-      .then(async (metadataApplied) => {
-        // Startup metadata can settle after a session switch. Recheck ownership
-        // so stale startup work cannot supersede the new pane's catalog refresh.
-        if (!ownsScheduledMetadataRefresh()) {
-          return;
-        }
-        await Promise.allSettled([
-          refreshChatAvatar(host),
-          ...(parallelMetadataRefresh
-            ? []
-            : [
-                refreshChatMetadata(host, {
-                  preserveModelCatalogOnFallback: opts?.startup === true && metadataApplied.models,
-                }),
-              ]),
-        ]);
-      })
-      .finally(() => host.requestUpdate?.());
+    void Promise.allSettled([
+      refreshChatAvatar(host),
+      ...(startupMetadataRequestVersion === null ? [refreshChatMetadata(host)] : []),
+    ]).finally(() => host.requestUpdate?.());
   });
   return refresh;
 }

--- a/ui/src/test-helpers/app-sidebar-cases/catalog-compat.ts
+++ b/ui/src/test-helpers/app-sidebar-cases/catalog-compat.ts
@@ -44,7 +44,7 @@ describe("AppSidebar session catalog pagination", () => {
       selection.scopeId = "research";
       sidebar.requestUpdate();
       await sidebar.updateComplete;
-      await vi.advanceTimersByTimeAsync(0);
+      await vi.advanceTimersByTimeAsync(50);
 
       expect(request).toHaveBeenNthCalledWith(2, "sessions.catalog.list", {
         agentId: "research",

--- a/ui/src/test-helpers/app-sidebar-cases/catalog-live-state.ts
+++ b/ui/src/test-helpers/app-sidebar-cases/catalog-live-state.ts
@@ -1,5 +1,11 @@
-import { describe, expect, it } from "vitest";
-import { SessionCatalogLiveState } from "../../components/app-sidebar-session-catalog-live.ts";
+import { describe, expect, it, vi } from "vitest";
+import type { SessionsCatalogListResult } from "../../../../packages/gateway-protocol/src/index.ts";
+import type { GatewayBrowserClient } from "../../api/gateway.ts";
+import {
+  refreshSessionCatalogsLive,
+  SessionCatalogLiveState,
+} from "../../components/app-sidebar-session-catalog-live.ts";
+import { catalogPage } from "../app-sidebar.ts";
 
 describe("AppSidebar session catalog pagination", () => {
   it("keeps the current refetch guard when an older request finishes", () => {
@@ -21,5 +27,55 @@ describe("AppSidebar session catalog pagination", () => {
 
     expect(live.ownsRequest(first.requestOwner)).toBe(false);
     expect(live.ownsRequest(second.requestOwner)).toBe(true);
+  });
+
+  it("keeps the stable cadence when only session recency timestamps change", async () => {
+    vi.useFakeTimers();
+    try {
+      const pageAt = (timestamp: number): SessionsCatalogListResult => {
+        const page = catalogPage([{ threadId: "thread-active", name: "Active session" }]);
+        const catalog = page.catalogs[0];
+        const host = catalog?.hosts[0];
+        const session = host?.sessions[0];
+        if (!catalog || !host || !session) {
+          throw new Error("recency catalog fixture is incomplete");
+        }
+        host.sessions = [{ ...session, updatedAt: timestamp, recencyAt: timestamp }];
+        return page;
+      };
+      let catalogs = pageAt(1).catalogs;
+      const client = {
+        request: vi.fn().mockResolvedValue(pageAt(2)),
+      } as unknown as GatewayBrowserClient;
+      const refresh = vi.fn();
+
+      await refreshSessionCatalogsLive({
+        live: new SessionCatalogLiveState(),
+        client,
+        agentId: "main",
+        generation: 1,
+        revision: 1,
+        currentGeneration: () => 1,
+        currentRevision: () => 1,
+        currentClient: () => client,
+        catalogs: () => catalogs,
+        pageDepths: new Map(),
+        connected: () => true,
+        applyFinal: (next) => {
+          catalogs = next;
+        },
+        applyError: (error) => {
+          throw error;
+        },
+        refresh,
+      });
+
+      await vi.advanceTimersByTimeAsync(5_000);
+      expect(refresh).not.toHaveBeenCalled();
+      await vi.advanceTimersByTimeAsync(25_000);
+      expect(refresh).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/ui/src/test-helpers/app-sidebar-cases/catalog-live.ts
+++ b/ui/src/test-helpers/app-sidebar-cases/catalog-live.ts
@@ -105,7 +105,7 @@ describe("AppSidebar session catalog pagination", () => {
       });
       provider.setContext(createContext(currentGateway.gateway, sessions));
       await sidebar.updateComplete;
-      await vi.advanceTimersByTimeAsync(0);
+      await vi.advanceTimersByTimeAsync(50);
 
       legacyFallback.resolve(catalogPage([]));
       await vi.advanceTimersByTimeAsync(0);
@@ -692,7 +692,7 @@ describe("AppSidebar session catalog pagination", () => {
     }
   });
 
-  it("refreshes immediately when paired-node presence changes", async () => {
+  it("coalesces a presence and focus burst into one catalog refresh", async () => {
     vi.useFakeTimers();
     try {
       const request = vi.fn().mockResolvedValue(catalogPage([]));
@@ -713,13 +713,13 @@ describe("AppSidebar session catalog pagination", () => {
       gateway.publishEvent("presence", {
         presence: [{ deviceId: "node-1", mode: "node", reason: "connect" }],
       });
+      globalThis.dispatchEvent(new Event("focus"));
+      await vi.advanceTimersByTimeAsync(49);
+      expect(request).toHaveBeenCalledTimes(1);
+      await vi.advanceTimersByTimeAsync(1);
       expect(request).toHaveBeenCalledTimes(2);
-
-      gateway.publishEvent("presence", {
-        presence: [{ deviceId: "node-1", mode: "node", reason: "disconnect" }],
-      });
       await vi.advanceTimersByTimeAsync(0);
-      expect(request).toHaveBeenCalledTimes(3);
+      expect(request).toHaveBeenCalledTimes(2);
     } finally {
       vi.useRealTimers();
     }


### PR DESCRIPTION
## What Problem This Solves

Two Control UI inefficiencies around session loading (team.openclaw.ai production evidence):

1. Opening a session fired `chat.startup` (avg 437ms) AND `chat.metadata` (avg 441ms) in parallel — but `chat.startup` already computes and ships the same metadata (`buildChatStartupMetadataResult`), and the client discarded whichever response arrived second. The redundant call could even trigger full catalog discovery server-side (no `preloadedOnly`).
2. The sidebar catalog poll drops to its fast 5s cadence whenever a `JSON.stringify` diff of the whole payload changes — and rows carry `updatedAt`/`recencyAt`, so any activity on any listed external session pinned every client at 5s (a 6× poll amplifier). Presence/focus/visibility/hostUpdated triggers also fired independent refreshes on foregrounding.

## Why This Change Was Made

Production perf campaign on session loading: one whole ~440ms request per session open was pure waste, and the poll amplifier multiplied the (separately expensive) catalog cost.

## User Impact

Faster session opens and materially fewer catalog polls; no protocol or response-shape changes:

- Complete startup-shipped metadata → no `chat.metadata` request; partial metadata → a scoped gap-fill for missing fields only; absent metadata (startup's 25ms catalog budget missed or full discovery required) → immediate `chat.metadata` so the model picker/commands never sit empty.
- The changed-signal now compares material identity (sorted catalog/host/session identities, labels, connectivity/errors, session name/status/archive) and ignores ordering plus bare `updatedAt`/`recencyAt` ticks; genuinely new/removed rows still hit the 5s cadence.
- Presence, focus, visibility, and host-update bursts coalesce into the existing 50ms activation debounce.

## Evidence

- 487 UI tests green, including new regressions: no chat.metadata when startup metadata is complete; immediate gap-fill on omitted metadata; updatedAt-only diffs keep the 30s cadence while identity changes drop to 5s; presence+focus burst produces one refresh.
- UI production/test typechecks on Blacksmith Testbox (run 30318477709); oxlint, format, max-lines ratchet, `git diff --check` clean.
- Codex autoreview: zero accepted findings.
