### PR TITLE
fix(gateway): make busyStaleThresholdMs configurable in channel health policy

### DIFF
--- a/src/gateway/channel-health-monitor.test.ts
+++ b/src/gateway/channel-health-monitor.test.ts
@@ -888,5 +888,25 @@ describe("channel-health-monitor", () => {
       expect(manager.startChannel).toHaveBeenCalledWith("slack", "default");
       monitor.stop();
     });
+
+    it("respects custom busyStaleThresholdMs", async () => {
+      const customThreshold = 40 * 60_000;
+      const now = Date.now();
+      const manager = createSlackSnapshotManager({
+        running: true,
+        connected: false,
+        busy: true,
+        activeRuns: 1,
+        lastStartAt: now - 30 * 60_000,
+        lastRunActivityAt: now - 30 * 60_000,
+        activeRunStartedAt: now - 30 * 60_000,
+      });
+      const monitor = await startAndRunCheck(manager, {
+        timing: { busyStaleThresholdMs: customThreshold },
+      });
+      expect(manager.stopChannel).not.toHaveBeenCalled();
+      expect(manager.startChannel).not.toHaveBeenCalled();
+      monitor.stop();
+    });
   });
 });

--- a/src/gateway/channel-health-monitor.ts
+++ b/src/gateway/channel-health-monitor.ts
@@ -4,6 +4,7 @@ import type { ChannelId } from "../channels/plugins/types.public.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import { resolveTimerTimeoutMs } from "../shared/number-coercion.js";
 import {
+  DEFAULT_CHANNEL_BUSY_STALE_THRESHOLD_MS,
   DEFAULT_CHANNEL_CONNECT_GRACE_MS,
   DEFAULT_CHANNEL_STALE_EVENT_THRESHOLD_MS,
   evaluateChannelHealth,
@@ -31,6 +32,7 @@ type ChannelHealthTimingPolicy = {
   monitorStartupGraceMs: number;
   channelConnectGraceMs: number;
   staleEventThresholdMs: number;
+  busyStaleThresholdMs: number;
 };
 
 type ChannelHealthMonitorDeps = {
@@ -61,6 +63,8 @@ function resolveTimingPolicy(
     channelConnectGraceMs: deps.timing?.channelConnectGraceMs ?? DEFAULT_CHANNEL_CONNECT_GRACE_MS,
     staleEventThresholdMs:
       deps.timing?.staleEventThresholdMs ?? DEFAULT_CHANNEL_STALE_EVENT_THRESHOLD_MS,
+    busyStaleThresholdMs:
+      deps.timing?.busyStaleThresholdMs ?? DEFAULT_CHANNEL_BUSY_STALE_THRESHOLD_MS,
   };
 }
 
@@ -138,6 +142,7 @@ export function startChannelHealthMonitor(deps: ChannelHealthMonitorDeps): Chann
             now,
             staleEventThresholdMs: timing.staleEventThresholdMs,
             channelConnectGraceMs: timing.channelConnectGraceMs,
+            busyStaleThresholdMs: timing.busyStaleThresholdMs,
           };
           const health = evaluateChannelHealth(status, healthPolicy);
           if (health.healthy) {

--- a/src/gateway/channel-health-policy.test.ts
+++ b/src/gateway/channel-health-policy.test.ts
@@ -6,14 +6,15 @@ import { evaluateChannelHealth, resolveChannelRestartReason } from "./channel-he
 
 function evaluateHealth(
   account: Record<string, unknown>,
-  opts: { now?: number; channelId?: string } = {},
+  opts: { now?: number; channelId?: string; busyStaleThresholdMs?: number } = {},
 ) {
-  const { now = 100_000, channelId = "discord" } = opts;
+  const { now = 100_000, channelId = "discord", busyStaleThresholdMs } = opts;
   return evaluateChannelHealth(account, {
     channelId,
     now,
     channelConnectGraceMs: 10_000,
     staleEventThresholdMs: 30_000,
+    ...(busyStaleThresholdMs !== undefined ? { busyStaleThresholdMs } : {}),
   });
 }
 
@@ -96,6 +97,19 @@ describe("evaluateChannelHealth", () => {
       { now },
     );
     expect(evaluation).toEqual({ healthy: false, reason: "stuck" });
+  });
+
+  it("respects a custom busyStaleThresholdMs override", () => {
+    const now = 35 * 60_000;
+    const customThresholdMs = 40 * 60_000;
+    const evaluation = evaluateHealth(
+      activeRunAccount(now - 30 * 60_000, {
+        connected: false,
+        activeRunStartedAt: now - 30 * 60_000,
+      }),
+      { now, busyStaleThresholdMs: customThresholdMs },
+    );
+    expect(evaluation).toEqual({ healthy: true, reason: "busy" });
   });
 
   it("keeps a connected run healthy past the threshold while its heartbeat stays fresh", () => {

--- a/src/gateway/channel-health-policy.ts
+++ b/src/gateway/channel-health-policy.ts
@@ -42,6 +42,7 @@ export type ChannelHealthPolicy = {
   now: number;
   staleEventThresholdMs: number;
   channelConnectGraceMs: number;
+  busyStaleThresholdMs?: number;
 };
 
 type ChannelRestartReason = "gave-up" | "stopped" | "stale-socket" | "stuck" | "disconnected";
@@ -50,7 +51,7 @@ function isManagedAccount(snapshot: ChannelHealthSnapshot): boolean {
   return snapshot.enabled !== false && snapshot.configured !== false;
 }
 
-const BUSY_ACTIVITY_STALE_THRESHOLD_MS = 25 * 60_000;
+export const DEFAULT_CHANNEL_BUSY_STALE_THRESHOLD_MS = 25 * 60_000;
 // Keep these shared between the background health monitor and on-demand readiness
 // probes so both surfaces evaluate channel lifecycle windows consistently.
 export const DEFAULT_CHANNEL_STALE_EVENT_THRESHOLD_MS = 30 * 60_000;
@@ -110,7 +111,13 @@ export function evaluateChannelHealth(
           ? Math.max(0, policy.now - activeRunStartedAt)
           : 0;
       const busyAge = Math.max(runActivityAge, disconnectedRunStartAge);
-      if (busyAge < BUSY_ACTIVITY_STALE_THRESHOLD_MS) {
+      const busyStaleThresholdMs =
+        typeof policy.busyStaleThresholdMs === "number" &&
+        Number.isFinite(policy.busyStaleThresholdMs) &&
+        policy.busyStaleThresholdMs > 0
+          ? policy.busyStaleThresholdMs
+          : DEFAULT_CHANNEL_BUSY_STALE_THRESHOLD_MS;
+      if (busyAge < busyStaleThresholdMs) {
         return { healthy: true, reason: "busy" };
       }
       return { healthy: false, reason: "stuck" };


### PR DESCRIPTION
Resolves #114169

### Summary
The gateway channel health monitor's busy activity cutoff was hardcoded to 25 minutes (`BUSY_ACTIVITY_STALE_THRESHOLD_MS = 25 * 60_000`) and could not be configured or overridden via health policy parameters. Long-running agent turns on channels (e.g. Telegram/Slack) exceeding 25 minutes of continuous busy activity were misclassified as `stuck` and restarted mid-turn.

### Changes
1. Exported `DEFAULT_CHANNEL_BUSY_STALE_THRESHOLD_MS` (25 minutes) from `src/gateway/channel-health-policy.ts`.
2. Added optional `busyStaleThresholdMs?: number` to `ChannelHealthPolicy` and updated `evaluateChannelHealth` to use `policy.busyStaleThresholdMs` when present.
3. Added `busyStaleThresholdMs` to `ChannelHealthTimingPolicy` in `src/gateway/channel-health-monitor.ts` so programmatically configured timing options are passed through to the health monitor check loop.
4. Added unit test in `src/gateway/channel-health-policy.test.ts` verifying that custom `busyStaleThresholdMs` overrides (e.g. 40 min) keep active runs healthy.
5. Added unit test in `src/gateway/channel-health-monitor.test.ts` verifying that `startChannelHealthMonitor` respects custom timing policies without restarting active runs.

### Testing
- Ran `npx vitest run src/gateway/channel-health-policy.test.ts src/gateway/channel-health-monitor.test.ts` (216 tests passed across core/server/client suites).