### PR TITLE
fix(process): prevent overlapping scoped processes from surviving replacement

### DIFF
--- a/src/process/supervisor/supervisor.test.ts
+++ b/src/process/supervisor/supervisor.test.ts
@@ -1,8 +1,9 @@
 // Process supervisor tests cover lifecycle, restart, and termination behavior.
 import { performance } from "node:perf_hooks";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../test-utils/deferred.js";
 import { mockProcessPlatform } from "../../test-utils/vitest-spies.js";
-import type { SpawnProcessAdapter } from "./types.js";
+import type { ManagedRun, SpawnProcessAdapter } from "./types.js";
 
 const { createChildAdapterMock, createPtyAdapterMock } = vi.hoisted(() => ({
   createChildAdapterMock: vi.fn(),
@@ -292,6 +293,467 @@ describe("process supervisor", () => {
     expect(["manual-cancel", "signal"]).toContain(firstExit.reason);
     expect(secondExit.reason).toBe("exit");
     expect(secondExit.stdout).toBe("new");
+  });
+
+  it("waits for an in-flight scoped startup before replacing its run", async () => {
+    const first = createStubChildAdapter({
+      onKill: (signal, current) => {
+        current.settle(null, signal ?? "SIGTERM");
+      },
+    });
+    const second = createStubChildAdapter();
+    const firstStartup = createDeferred<StubChildAdapter>();
+    createChildAdapterMock.mockReturnValueOnce(firstStartup.promise).mockResolvedValueOnce(second);
+
+    const supervisor = createProcessSupervisor();
+    const firstRunPromise = spawnChild(supervisor, {
+      runId: "scoped-start-first",
+      sessionId: "scoped-start",
+      scopeKey: "scope:overlap",
+      argv: createSilentIdleArgv(),
+    });
+    const replacementPromise = spawnChild(supervisor, {
+      runId: "scoped-start-replacement",
+      sessionId: "scoped-start",
+      scopeKey: "scope:overlap",
+      replaceExistingScope: true,
+      argv: createWriteStdoutArgv("replacement"),
+    });
+
+    expect(createChildAdapterMock).toHaveBeenCalledTimes(1);
+
+    firstStartup.resolve(first);
+    const [firstRun, replacement] = await Promise.all([firstRunPromise, replacementPromise]);
+
+    expect(createChildAdapterMock).toHaveBeenCalledTimes(2);
+    expect(first.killMock).toHaveBeenCalledWith("SIGTERM");
+    await expect(firstRun.wait()).resolves.toMatchObject({ reason: "manual-cancel" });
+
+    second.emitStdout("replacement");
+    second.settle(0);
+    await expect(replacement.wait()).resolves.toMatchObject({
+      reason: "exit",
+      stdout: "replacement",
+    });
+  });
+
+  it("starts same-scope runs concurrently when replacement is not requested", async () => {
+    const first = createStubChildAdapter();
+    const second = createStubChildAdapter();
+    const firstStartup = createDeferred<StubChildAdapter>();
+    const secondStartup = createDeferred<StubChildAdapter>();
+    createChildAdapterMock
+      .mockReturnValueOnce(firstStartup.promise)
+      .mockReturnValueOnce(secondStartup.promise);
+
+    const supervisor = createProcessSupervisor();
+    const firstRunPromise = spawnChild(supervisor, {
+      sessionId: "shared-scope-first",
+      scopeKey: "scope:shared-concurrent",
+      argv: createSilentIdleArgv(),
+    });
+    const secondRunPromise = spawnChild(supervisor, {
+      sessionId: "shared-scope-second",
+      scopeKey: "scope:shared-concurrent",
+      argv: createSilentIdleArgv(),
+    });
+
+    expect(createChildAdapterMock).toHaveBeenCalledTimes(2);
+
+    secondStartup.resolve(second);
+    const secondRun = await secondRunPromise;
+    firstStartup.resolve(first);
+    const firstRun = await firstRunPromise;
+
+    expect(first.killMock).not.toHaveBeenCalled();
+    expect(second.killMock).not.toHaveBeenCalled();
+    first.settle(0);
+    second.settle(0);
+    await expect(Promise.all([firstRun.wait(), secondRun.wait()])).resolves.toEqual([
+      expect.objectContaining({ reason: "exit" }),
+      expect.objectContaining({ reason: "exit" }),
+    ]);
+  });
+
+  it("does not cancel a newer run while an earlier scoped replacement is pending", async () => {
+    const first = createStubChildAdapter({
+      onKill: (signal, current) => {
+        current.settle(null, signal ?? "SIGTERM");
+      },
+    });
+    const replacementAdapter = createStubChildAdapter();
+    const newerAdapter = createStubChildAdapter();
+    const firstStartup = createDeferred<StubChildAdapter>();
+    const replacementStartup = createDeferred<StubChildAdapter>();
+    createChildAdapterMock
+      .mockReturnValueOnce(firstStartup.promise)
+      .mockReturnValueOnce(replacementStartup.promise)
+      .mockResolvedValueOnce(newerAdapter);
+
+    const supervisor = createProcessSupervisor();
+    const firstRunPromise = spawnChild(supervisor, {
+      runId: "replacement-fence-first",
+      sessionId: "replacement-fence",
+      scopeKey: "scope:replacement-fence",
+      argv: createSilentIdleArgv(),
+    });
+    const replacementPromise = spawnChild(supervisor, {
+      runId: "replacement-fence-replacement",
+      sessionId: "replacement-fence",
+      scopeKey: "scope:replacement-fence",
+      replaceExistingScope: true,
+      argv: createSilentIdleArgv(),
+    });
+    const newerRunPromise = spawnChild(supervisor, {
+      runId: "replacement-fence-newer",
+      sessionId: "replacement-fence",
+      scopeKey: "scope:replacement-fence",
+      argv: createSilentIdleArgv(),
+    });
+
+    expect(createChildAdapterMock).toHaveBeenCalledTimes(1);
+
+    firstStartup.resolve(first);
+    const firstRun = await firstRunPromise;
+    await vi.waitFor(() => {
+      expect(createChildAdapterMock).toHaveBeenCalledTimes(2);
+    });
+    expect(first.killMock).toHaveBeenCalledWith("SIGTERM");
+    expect(newerAdapter.killMock).not.toHaveBeenCalled();
+
+    replacementStartup.resolve(replacementAdapter);
+    const [replacement, newerRun] = await Promise.all([replacementPromise, newerRunPromise]);
+    expect(createChildAdapterMock).toHaveBeenCalledTimes(3);
+    expect(replacementAdapter.killMock).not.toHaveBeenCalled();
+    expect(newerAdapter.killMock).not.toHaveBeenCalled();
+
+    replacementAdapter.settle(0);
+    newerAdapter.settle(0);
+    await expect(
+      Promise.all([firstRun.wait(), replacement.wait(), newerRun.wait()]),
+    ).resolves.toEqual([
+      expect.objectContaining({ reason: "manual-cancel" }),
+      expect.objectContaining({ reason: "exit" }),
+      expect.objectContaining({ reason: "exit" }),
+    ]);
+  });
+
+  it("waits for every concurrent same-scope startup before replacing the scope", async () => {
+    const runCount = 8;
+    const startups = Array.from({ length: runCount }, () => createDeferred<StubChildAdapter>());
+    const adapters = Array.from({ length: runCount }, (_unused, index) =>
+      createStubChildAdapter({
+        pid: 5_000 + index,
+        onKill: (signal, current) => {
+          current.settle(null, signal ?? "SIGTERM");
+        },
+      }),
+    );
+    const replacementAdapter = createStubChildAdapter({ pid: 6_000 });
+    let adapterIndex = 0;
+    createChildAdapterMock.mockImplementation(() => {
+      const index = adapterIndex++;
+      if (index === runCount) {
+        return Promise.resolve(replacementAdapter);
+      }
+      const startup = startups[index];
+      if (!startup) {
+        throw new Error(`unexpected shared-scope startup ${index}`);
+      }
+      return startup.promise;
+    });
+
+    const supervisor = createProcessSupervisor();
+    const pendingRuns = Array.from({ length: runCount }, (_unused, index) =>
+      spawnChild(supervisor, {
+        runId: `shared-scope-${index}`,
+        sessionId: "shared-scope",
+        scopeKey: "scope:shared-replacement",
+        argv: createSilentIdleArgv(),
+      }),
+    );
+    const replacementPromise = spawnChild(supervisor, {
+      runId: "shared-scope-replacement",
+      sessionId: "shared-scope",
+      scopeKey: "scope:shared-replacement",
+      replaceExistingScope: true,
+      argv: createWriteStdoutArgv("replacement"),
+    });
+
+    expect(createChildAdapterMock).toHaveBeenCalledTimes(runCount);
+
+    for (let index = runCount - 1; index >= 0; index -= 1) {
+      const startup = startups[index];
+      const adapter = adapters[index];
+      if (!startup || !adapter) {
+        throw new Error(`missing shared-scope startup ${index}`);
+      }
+      startup.resolve(adapter);
+    }
+
+    const runs = await Promise.all(pendingRuns);
+    const replacement = await replacementPromise;
+    expect(createChildAdapterMock).toHaveBeenCalledTimes(runCount + 1);
+    for (const adapter of adapters) {
+      expect(adapter.killMock).toHaveBeenCalledWith("SIGTERM");
+    }
+    await expect(Promise.all(runs.map((run) => run.wait()))).resolves.toEqual(
+      Array.from({ length: runCount }, () => expect.objectContaining({ reason: "manual-cancel" })),
+    );
+
+    replacementAdapter.emitStdout("replacement");
+    replacementAdapter.settle(0);
+    await expect(replacement.wait()).resolves.toMatchObject({
+      reason: "exit",
+      stdout: "replacement",
+    });
+  });
+
+  it("keeps startup independent for different replacement scopes", async () => {
+    const first = createStubChildAdapter();
+    const second = createStubChildAdapter();
+    const firstStartup = createDeferred<StubChildAdapter>();
+    const secondStartup = createDeferred<StubChildAdapter>();
+    createChildAdapterMock
+      .mockReturnValueOnce(firstStartup.promise)
+      .mockReturnValueOnce(secondStartup.promise);
+
+    const supervisor = createProcessSupervisor();
+    const firstRunPromise = spawnChild(supervisor, {
+      sessionId: "independent-a",
+      scopeKey: "scope:independent-a",
+      replaceExistingScope: true,
+      argv: createSilentIdleArgv(),
+    });
+    const secondRunPromise = spawnChild(supervisor, {
+      sessionId: "independent-b",
+      scopeKey: "scope:independent-b",
+      replaceExistingScope: true,
+      argv: createSilentIdleArgv(),
+    });
+
+    expect(createChildAdapterMock).toHaveBeenCalledTimes(2);
+
+    secondStartup.resolve(second);
+    const secondRun = await secondRunPromise;
+    firstStartup.resolve(first);
+    const firstRun = await firstRunPromise;
+
+    expect(first.killMock).not.toHaveBeenCalled();
+    expect(second.killMock).not.toHaveBeenCalled();
+    first.settle(0);
+    second.settle(0);
+    await expect(Promise.all([firstRun.wait(), secondRun.wait()])).resolves.toEqual([
+      expect.objectContaining({ reason: "exit" }),
+      expect.objectContaining({ reason: "exit" }),
+    ]);
+  });
+
+  it("starts a scoped replacement after the previous adapter fails to start", async () => {
+    const second = createStubChildAdapter();
+    createChildAdapterMock
+      .mockRejectedValueOnce(new Error("first adapter could not start"))
+      .mockResolvedValueOnce(second);
+
+    const supervisor = createProcessSupervisor();
+    const firstRunPromise = spawnChild(supervisor, {
+      runId: "failed-scoped-start",
+      sessionId: "failed-scoped-start",
+      scopeKey: "scope:recover-start",
+      argv: createSilentIdleArgv(),
+    });
+    const replacementPromise = spawnChild(supervisor, {
+      runId: "recovered-scoped-start",
+      sessionId: "failed-scoped-start",
+      scopeKey: "scope:recover-start",
+      replaceExistingScope: true,
+      argv: createWriteStdoutArgv("recovered"),
+    });
+
+    await expect(firstRunPromise).rejects.toThrow("first adapter could not start");
+    const replacement = await replacementPromise;
+    second.emitStdout("recovered");
+    second.settle(0);
+
+    await expect(replacement.wait()).resolves.toMatchObject({
+      reason: "exit",
+      stdout: "recovered",
+    });
+    expect(supervisor.getRecord("failed-scoped-start")).toMatchObject({
+      state: "exited",
+      terminationReason: "spawn-error",
+    });
+  });
+
+  it("keeps only the newest run across 64 concurrent same-scope replacements", async () => {
+    const runCount = 64;
+    const adapters = Array.from({ length: runCount }, (_unused, index) =>
+      createStubChildAdapter({
+        pid: 2_000 + index,
+        onKill: (signal, current) => {
+          current.settle(null, signal ?? "SIGTERM");
+        },
+      }),
+    );
+    let adapterIndex = 0;
+    createChildAdapterMock.mockImplementation(async () => {
+      const adapter = adapters[adapterIndex++];
+      if (!adapter) {
+        throw new Error("unexpected concurrent supervisor startup");
+      }
+      return adapter;
+    });
+
+    const supervisor = createProcessSupervisor();
+    const pendingRuns = Array.from({ length: runCount }, (_unused, index) =>
+      spawnChild(supervisor, {
+        runId: `scope-stress-${index}`,
+        sessionId: "scope-stress",
+        scopeKey: "scope:stress",
+        replaceExistingScope: true,
+        argv: createSilentIdleArgv(),
+      }),
+    );
+
+    const runs = await Promise.all(pendingRuns);
+    for (const [index, adapter] of adapters.entries()) {
+      if (index === runCount - 1) {
+        expect(adapter.killMock, `newest scope owner ${index}`).not.toHaveBeenCalled();
+      } else {
+        expect(adapter.killMock, `superseded scope owner ${index}`).toHaveBeenCalledWith("SIGTERM");
+      }
+    }
+
+    const newestAdapter = adapters[runCount - 1];
+    const newestRun = runs[runCount - 1];
+    if (!newestAdapter || !newestRun) {
+      throw new Error("expected the newest scoped process");
+    }
+    newestAdapter.settle(0);
+
+    const exits = await Promise.all(runs.map((run) => run.wait()));
+    for (const [index, exit] of exits.entries()) {
+      expect(exit.reason, `scoped run ${index}`).toBe(
+        index === runCount - 1 ? "exit" : "manual-cancel",
+      );
+    }
+  });
+
+  it("continues replacing scoped runs across interleaved startup failures", async () => {
+    const runCount = 48;
+    const adapters = new Map<number, StubChildAdapter>();
+    let adapterIndex = 0;
+    createChildAdapterMock.mockImplementation(async () => {
+      const index = adapterIndex++;
+      if (index % 7 === 3) {
+        throw new Error(`adapter ${index} could not start`);
+      }
+      const adapter = createStubChildAdapter({
+        pid: 3_000 + index,
+        onKill: (signal, current) => {
+          current.settle(null, signal ?? "SIGTERM");
+        },
+      });
+      adapters.set(index, adapter);
+      return adapter;
+    });
+
+    const supervisor = createProcessSupervisor();
+    const pendingRuns = Array.from({ length: runCount }, (_unused, index) =>
+      spawnChild(supervisor, {
+        runId: `scope-recovery-${index}`,
+        sessionId: "scope-recovery",
+        scopeKey: "scope:interleaved-recovery",
+        replaceExistingScope: true,
+        argv: createSilentIdleArgv(),
+      }),
+    );
+
+    const results = await Promise.allSettled(pendingRuns);
+    const running: ManagedRun[] = [];
+    for (const [index, result] of results.entries()) {
+      if (index % 7 === 3) {
+        expect(result.status, `failed adapter ${index}`).toBe("rejected");
+        if (result.status === "rejected") {
+          expect(result.reason).toMatchObject({ message: `adapter ${index} could not start` });
+        }
+        expect(supervisor.getRecord(`scope-recovery-${index}`)).toMatchObject({
+          state: "exited",
+          terminationReason: "spawn-error",
+        });
+        continue;
+      }
+      expect(result.status, `started adapter ${index}`).toBe("fulfilled");
+      if (result.status === "fulfilled") {
+        running.push(result.value);
+      }
+    }
+
+    const newestAdapter = adapters.get(runCount - 1);
+    if (!newestAdapter) {
+      throw new Error("expected the final replacement adapter");
+    }
+    for (const [index, adapter] of adapters) {
+      if (index === runCount - 1) {
+        expect(adapter.killMock, `newest adapter ${index}`).not.toHaveBeenCalled();
+      } else {
+        expect(adapter.killMock, `superseded adapter ${index}`).toHaveBeenCalledWith("SIGTERM");
+      }
+    }
+    newestAdapter.settle(0);
+
+    const exits = await Promise.all(running.map((run) => run.wait()));
+    expect(exits.filter((exit) => exit.reason === "exit")).toHaveLength(1);
+    expect(exits.filter((exit) => exit.reason === "manual-cancel")).toHaveLength(
+      running.length - 1,
+    );
+  });
+
+  it("starts 24 independent scoped processes without a global startup bottleneck", async () => {
+    const scopeCount = 24;
+    const startups = Array.from({ length: scopeCount }, () => createDeferred<StubChildAdapter>());
+    const adapters = Array.from({ length: scopeCount }, (_unused, index) =>
+      createStubChildAdapter({ pid: 4_000 + index }),
+    );
+    let adapterIndex = 0;
+    createChildAdapterMock.mockImplementation(() => {
+      const startup = startups[adapterIndex++];
+      if (!startup) {
+        throw new Error("unexpected independent supervisor startup");
+      }
+      return startup.promise;
+    });
+
+    const supervisor = createProcessSupervisor();
+    const pendingRuns = Array.from({ length: scopeCount }, (_unused, index) =>
+      spawnChild(supervisor, {
+        runId: `independent-scope-${index}`,
+        sessionId: "scope-independence",
+        scopeKey: `scope:independent-${index}`,
+        replaceExistingScope: true,
+        argv: createSilentIdleArgv(),
+      }),
+    );
+
+    expect(createChildAdapterMock).toHaveBeenCalledTimes(scopeCount);
+
+    for (let index = scopeCount - 1; index >= 0; index -= 1) {
+      const startup = startups[index];
+      const adapter = adapters[index];
+      if (!startup || !adapter) {
+        throw new Error(`missing independent scope ${index}`);
+      }
+      startup.resolve(adapter);
+    }
+
+    const runs = await Promise.all(pendingRuns);
+    for (const adapter of adapters) {
+      expect(adapter.killMock).not.toHaveBeenCalled();
+      adapter.settle(0);
+    }
+
+    const exits = await Promise.all(runs.map((run) => run.wait()));
+    expect(exits.every((exit) => exit.reason === "exit")).toBe(true);
   });
 
   it("applies overall timeout even for near-immediate timer firing", async () => {

--- a/src/process/supervisor/supervisor.ts
+++ b/src/process/supervisor/supervisor.ts
@@ -23,6 +23,11 @@ type ActiveRun = {
   scopeKey?: string;
 };
 
+type StartingScope = {
+  runs: Set<Promise<ManagedRun>>;
+  replacement?: Promise<ManagedRun>;
+};
+
 const GRACEFUL_CANCEL_TIMEOUT_MS = 5000;
 const DEFAULT_MAX_CAPTURED_OUTPUT_CHARS = 1024 * 1024;
 
@@ -94,6 +99,7 @@ function resolveElapsedTimeoutReason(params: {
 export function createProcessSupervisor(): ProcessSupervisor {
   const registry = createRunRegistry();
   const active = new Map<string, ActiveRun>();
+  const startingScopes = new Map<string, StartingScope>();
 
   const cancel = (runId: string, reason: TerminationReason = "manual-cancel") => {
     const current = active.get(runId);
@@ -118,9 +124,8 @@ export function createProcessSupervisor(): ProcessSupervisor {
     }
   };
 
-  const spawn = async (input: SpawnInput): Promise<ManagedRun> => {
+  const startRun = async (input: SpawnInput, scopeKey?: string): Promise<ManagedRun> => {
     const runId = normalizeOptionalString(input.runId) ?? crypto.randomUUID();
-    const scopeKey = normalizeOptionalString(input.scopeKey);
     if (input.replaceExistingScope && scopeKey) {
       cancelScope(scopeKey, "manual-cancel");
     }
@@ -371,6 +376,44 @@ export function createProcessSupervisor(): ProcessSupervisor {
       warnProcessSupervisorSpawnFailure(`spawn failed: runId=${runId} reason=${String(err)}`);
       throw err;
     }
+  };
+
+  const spawn = (input: SpawnInput): Promise<ManagedRun> => {
+    const scopeKey = normalizeOptionalString(input.scopeKey);
+    if (!scopeKey) {
+      return startRun(input);
+    }
+
+    const starting = startingScopes.get(scopeKey) ?? { runs: new Set<Promise<ManagedRun>>() };
+    startingScopes.set(scopeKey, starting);
+
+    // Ordinary runs start together, but replacements fence later arrivals so
+    // delayed cancellation cannot accidentally terminate a newer scoped run.
+    const previous = input.replaceExistingScope
+      ? Array.from(starting.runs)
+      : starting.replacement
+        ? [starting.replacement]
+        : [];
+    const pending =
+      previous.length > 0
+        ? Promise.allSettled(previous).then(() => startRun(input, scopeKey))
+        : startRun(input, scopeKey);
+    starting.runs.add(pending);
+    if (input.replaceExistingScope) {
+      starting.replacement = pending;
+    }
+
+    const clearPendingStart = () => {
+      starting.runs.delete(pending);
+      if (starting.replacement === pending) {
+        delete starting.replacement;
+      }
+      if (starting.runs.size === 0 && startingScopes.get(scopeKey) === starting) {
+        startingScopes.delete(scopeKey);
+      }
+    };
+    void pending.then(clearPendingStart, clearPendingStart);
+    return pending;
   };
 
   return {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users running resumed CLI sessions, scheduled process watchers, or other supervised tasks could end up with multiple processes surviving an explicit replacement when launches for the same scope overlap. The issue could also make process cancellation depend on adapter startup timing.

## Why This Change Was Made

Track in-flight process startup at the process-supervisor owner boundary. Ordinary processes in the same scope continue to start concurrently. A replacement waits for all earlier startups, cancels the earlier active runs, and fences later arrivals until replacement startup completes. Failed adapter startups cannot poison the scope, and completed or rejected startups remove their bookkeeping.

This is a focused lifecycle repair: no new configuration, fallback behavior, plugin coupling, storage, or process-lifetime lock.

## User Impact

Resumed CLI processes and scheduled watchers consistently retain the intended latest replacement. Unrelated scopes and ordinary same-scope background processes retain their existing startup concurrency. Processes submitted after a pending replacement are not accidentally canceled.

## Evidence

- Reproduced both original races against current main before the fix: an overlapping first startup and replacement started two adapters, and 64 concurrent replacements left superseded child processes running.
- Exact-source remote integration matrix: **771 passing tests across 16 files and five shards**, covering process supervision, child and PTY adapters, process registry, resumed CLI execution, cron exit and stream watchers, gateway and node execution, and the auto-review stress paths.
- **10 consecutive focused stress passes; 220 passing test executions.** Each pass proves 64 simultaneous replacements, 48 replacements with repeated injected startup failures, 24 unrelated scopes completing in reverse order, multiple concurrent same-scope predecessor processes, ordinary shared-scope concurrency, and the delayed-replacement/newer-process cancellation fence.
- Full remote changed-code gate passed: core and core-test typechecks, core lint, focused formatting, plugin and dependency boundaries, environment and schema ratchets, database-first storage guards, and zero runtime import cycles.
- Independent `autoreview --mode uncommitted`: no accepted or actionable findings. Earlier review findings were addressed with explicit same-scope concurrency and replacement-ordering regression tests.
- AI-assisted; code, callers, failure modes, tests, and maintainer policies were reviewed.


### Real operating-system child-process proof

Executed against reviewed commit `30c0ee34e06a7eafdf2f61568de1fff082019754`, importing the production process supervisor with `node --import tsx --input-type=module --eval` and launching actual Node child processes through the production child adapter. These are real process IDs and real OS signal/exit results, not mocked adapters or a test-harness substitute:

```text
{"scenario":"12 overlapping real child-process replacements","actualProcesses":12,"supersededManualCancellations":11,"newestPid":30219,"newestState":"running","result":"PASS"}
{"scenario":"ordinary same-scope real processes remain concurrent","distinctLivePids":[30220,30221],"simultaneousRunningProcesses":2,"result":"PASS"}
{"scenario":"delayed replacement preserves a newer real child process","predecessorExit":"manual-cancel","replacementPid":30223,"newerPid":30224,"survivingRealProcesses":2,"result":"PASS"}
REAL_PROCESS_SUPERVISOR_PROOF=PASS
```

Every spawned process was verified by its live OS PID, and all remaining processes were explicitly canceled and awaited after the proof. This directly covers both ClawSweeper rank-up moves: only the latest of 12 overlapping replacement processes survives, and ordinary same-scope processes retain concurrent startup.


### Current-main integration and reviewer rank-up

After the real-process proof, refreshed the canonical checkout with `git pull --ff-only origin main` and checked every upstream commit touching the supervisor production module, supervisor regression tests, PTY tests, and supervisor types:

```console
$ git log --oneline HEAD..origin/main -- src/process/supervisor/supervisor.ts src/process/supervisor/supervisor.test.ts src/process/supervisor/supervisor.pty-command.test.ts src/process/supervisor/types.ts
# no output: current main contains no overlapping supervisor changes
```

All eight hosted workflows are green on the exact live-proven head. The remaining ClawSweeper branch-refresh suggestion is optional; OpenClaw maintainer policy treats fast-moving behind-main drift as advisory and explicitly says not to rebase solely for drift. Preserving the reviewed, live-proven, CI-green commit avoids replacing exact-head evidence when current main has no overlapping change.
