### PR TITLE
fix(agents): preserve image content in MCP tool results that also return structuredContent

### DIFF
--- a/src/agents/agent-bundle-mcp-materialize.ts
+++ b/src/agents/agent-bundle-mcp-materialize.ts
@@ -102,10 +102,13 @@ function toAgentToolResult(params: {
           text: `structuredContent:\n${JSON.stringify(params.result.structuredContent, null, 2)}`,
         } as const)
       : null;
-  // Structured MCP results are the canonical model payload here; replacing
-  // mirrored content avoids duplicating large tool output in the prompt.
+  // Structured MCP results are the canonical model payload here; replacing the mirrored
+  // TEXT content avoids duplicating large tool output in the prompt. Image blocks are never
+  // represented in structuredContent's JSON, so preserve them alongside it -- otherwise a
+  // multimodal tool that returns an image plus structuredContent loses the image entirely.
+  const preservedImages = content.filter((block) => block.type === "image");
   const normalizedContent: AgentToolResult<unknown>["content"] = structuredContentBlock
-    ? [structuredContentBlock]
+    ? [structuredContentBlock, ...preservedImages]
     : content.length > 0
       ? content
       : ([

--- a/src/agents/agent-bundle-mcp-tools.materialize.test.ts
+++ b/src/agents/agent-bundle-mcp-tools.materialize.test.ts
@@ -267,6 +267,32 @@ describe("createBundleMcpToolRuntime", () => {
     );
   });
 
+  it("keeps image content when MCP tools also return structuredContent", async () => {
+    const runtime = await materializeBundleMcpToolsForRun({
+      runtime: makeToolRuntime({
+        result: {
+          content: [{ type: "image", data: "aW1hZ2U=", mimeType: "image/png" }],
+          structuredContent: { chart: "sales-q3", points: 42 },
+          isError: false,
+        },
+      }),
+    });
+
+    const result = await expectDefined(runtime.tools[0], "runtime.tools[0] test invariant").execute(
+      "call-bundle-probe",
+      {},
+      undefined,
+      undefined,
+    );
+
+    expectTextContentBlock(
+      result.content[0],
+      `structuredContent:\n${JSON.stringify({ chart: "sales-q3", points: 42 }, null, 2)}`,
+    );
+    expect(result.content[1]).toEqual({ type: "image", data: "aW1hZ2U=", mimeType: "image/png" });
+    expect(result.content).toHaveLength(2);
+  });
+
   it("keeps structuredContent visible when MCP tools also return text content", async () => {
     const runtime = await materializeBundleMcpToolsForRun({
       runtime: makeToolRuntime({


### PR DESCRIPTION
## What Problem This Solves

When an MCP tool returns an **image** block *and* a `structuredContent` payload in the same result, the image is silently dropped — the model never sees it. This breaks any multimodal MCP tool (screenshot capture, chart/diagram renderers) that returns a rendered image alongside a structured JSON summary.

## Why This Change Was Made

`toAgentToolResult` (`src/agents/agent-bundle-mcp-materialize.ts`) mirrors `structuredContent` into a single text block and — to avoid duplicating large tool output in the prompt — **replaces the entire `content` array** with just that text block:

```ts
const normalizedContent = structuredContentBlock ? [structuredContentBlock] : /* … */;
```

That dedup is right for the *text* content the MCP spec asks servers to mirror. But image blocks are never represented in `structuredContent`'s JSON, so replacing the whole array is pure data loss for them. The gap dates to #87540, which introduced the `structuredContent` mirroring and only handled text content.

## User Impact

A multimodal MCP tool that returns an image + `structuredContent` now delivers the image to the model instead of losing it. Text-only and image-only results are unchanged.

## Evidence

Reproduce-first regression test added to `agent-bundle-mcp-tools.materialize.test.ts` (beside the existing text-only case). It drives the real tool-execution path (`materializeBundleMcpToolsForRun` → `execute` → `toAgentToolResult`):

Before (fix reverted) — the image is dropped:
```
AssertionError: expected undefined to deeply equal { type: 'image', … }
(result.content has length 1 — only the structuredContent text block)
```
After (fix applied):
```
Test Files  1 passed (1)
     Tests  18 passed (18)
```

## Real-behavior proof (real MCP server, current main)

Backed by an end-to-end run through a **real `@modelcontextprotocol/sdk` server**. A standalone harness stands up a real MCP `Server` (whose tool returns an image block **plus** `structuredContent`) linked to a real MCP `Client` over `InMemoryTransport`, backs OpenClaw's `SessionMcpRuntime.callTool` with that client, and runs the actual `materializeBundleMcpToolsForRun` → materialized `tool.execute(...)` → `toAgentToolResult` path. The only difference between the two runs is the checked-out `agent-bundle-mcp-materialize.ts`.

**Before — `upstream/main`:**
```
== REAL MCP server roundtrip (client.callTool) ==
  content kinds : [ 'image' ]
  structuredContent: {"chart":"sales-q3","points":42}
== OpenClaw AgentToolResult (what the model sees) ==
  content kinds : [ 'text' ]  length: 1
  image preserved to the model? : false
```
The real server returns the image, but OpenClaw hands the model only the structuredContent text mirror — the image is dropped.

**After — this PR:**
```
== REAL MCP server roundtrip (client.callTool) ==
  content kinds : [ 'image' ]
  structuredContent: {"chart":"sales-q3","points":42}
== OpenClaw AgentToolResult (what the model sees) ==
  content kinds : [ 'text', 'image' ]  length: 2
  image preserved to the model? : true
```
The image is preserved alongside the structuredContent text mirror.

Summary of the model-visible `content`:

| | `content` handed to the model |
|---|---|
| **before** | `[{ type: "text", text: "structuredContent:\n{…}" }]` — 1 item, **image lost** |
| **after** | `[{ type: "text", … }, { type: "image", data, mimeType }]` — 2 items, **image preserved** |

**Note for maintainers:** this keeps #87540's intent (the text mirror still replaces duplicated text output) and only preserves the non-JSON-representable image blocks. Minimal and provider-agnostic.

