### PR TITLE
fix(cli): keep read-only config queries from writing state

### DIFF
--- a/src/cli/command-catalog.ts
+++ b/src/cli/command-catalog.ts
@@ -240,7 +240,12 @@ export const cliCommandCatalog: readonly CliCommandCatalogEntry[] = [
   {
     commandPath: ["config", "get"],
     exact: true,
-    policy: { ensureCliPath: false, networkProxy: "bypass" },
+    policy: {
+      bypassConfigGuard: true,
+      routeConfigGuard: "always",
+      ensureCliPath: false,
+      networkProxy: "bypass",
+    },
     route: { id: "config-get" },
   },
   {

--- a/src/cli/command-path-policy.test.ts
+++ b/src/cli/command-path-policy.test.ts
@@ -293,6 +293,16 @@ describe("command-path-policy", () => {
     });
   });
 
+  it("keeps routed and Commander config reads ahead of observing startup guards", () => {
+    expectResolvedPolicy(["config", "get"], {
+      bypassConfigGuard: true,
+      routeConfigGuard: "always",
+      ensureCliPath: false,
+      loadPlugins: "never",
+      networkProxy: "bypass",
+    });
+  });
+
   it("defaults unknown command paths to network proxy routing", () => {
     expect(resolveCliNetworkProxyPolicy(["node", "openclaw", "googlemeet", "login"])).toBe(
       "default",

--- a/src/cli/config-cli-validation.ts
+++ b/src/cli/config-cli-validation.ts
@@ -1,7 +1,7 @@
 import { isRecord as isPlainRecord } from "@openclaw/normalization-core/record-coerce";
 import type { ConfigFileSnapshot } from "../config/config.js";
 import { readConfigFileSnapshot } from "../config/config.js";
-import { formatConfigIssueLines } from "../config/issue-format.js";
+import { formatConfigIssueLines, normalizeConfigIssues } from "../config/issue-format.js";
 import { attachConfigIssueDiagnostics } from "../config/issue-location.js";
 import { isPluginPackagingRuntimeOutputInvalidConfigSnapshot } from "../config/recovery-policy.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
@@ -13,7 +13,7 @@ import {
 } from "../config/types.secrets.js";
 import { validateConfigObjectRawWithPlugins } from "../config/validation.js";
 import { loadPluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot.js";
-import { type RuntimeEnv, defaultRuntime } from "../runtime.js";
+import { type RuntimeEnv, defaultRuntime, writeRuntimeJson } from "../runtime.js";
 import {
   isPluginIntegrationSecretProviderConfig,
   resolveSecretProviderIntegrationConfig,
@@ -40,9 +40,23 @@ function formatInvalidConfigRepairHint(
     : `Run \`${formatCliCommand("openclaw doctor --fix")}\` ${doctorMessage}`;
 }
 
-export async function loadValidConfig(runtime: RuntimeEnv = defaultRuntime) {
-  const snapshot = await readConfigFileSnapshot();
+export async function loadValidConfig(
+  runtime: RuntimeEnv = defaultRuntime,
+  options: { observe?: boolean; json?: boolean } = {},
+) {
+  const snapshot =
+    options.observe === false
+      ? await readConfigFileSnapshot({ observe: false })
+      : await readConfigFileSnapshot();
   if (snapshot.valid) {
+    return snapshot;
+  }
+  if (options.json) {
+    writeRuntimeJson(runtime, {
+      error: `OpenClaw config is invalid: ${shortenHomePath(snapshot.path)}`,
+      issues: normalizeConfigIssues(snapshot.issues),
+    });
+    runtime.exit(1);
     return snapshot;
   }
   runtime.error(`OpenClaw config is invalid: ${shortenHomePath(snapshot.path)}`);

--- a/src/cli/config-cli.test.ts
+++ b/src/cli/config-cli.test.ts
@@ -17,7 +17,8 @@ import { createCliRuntimeCapture, mockRuntimeModule } from "./test-runtime-captu
  * but before runtime defaults), so runtime defaults don't leak into the written config.
  */
 
-const mockReadConfigFileSnapshot = vi.fn<() => Promise<ConfigFileSnapshot>>();
+const mockReadConfigFileSnapshot =
+  vi.fn<(options?: { observe?: boolean }) => Promise<ConfigFileSnapshot>>();
 const mockWriteConfigFile = vi.fn<
   (
     cfg: OpenClawConfig,
@@ -36,7 +37,8 @@ const mockLoadPluginMetadataSnapshot = vi.fn((_configForTest: unknown) =>
 );
 
 vi.mock("../config/config.js", () => ({
-  readConfigFileSnapshot: () => mockReadConfigFileSnapshot(),
+  readConfigFileSnapshot: (...args: Parameters<typeof mockReadConfigFileSnapshot>) =>
+    mockReadConfigFileSnapshot(...args),
   writeConfigFile: (
     cfg: OpenClawConfig,
     options?: {
@@ -1180,6 +1182,15 @@ describe("config cli", () => {
   });
 
   describe("config get", () => {
+    it("reads the valid configuration without observing persistent health state", async () => {
+      setGatewaySnapshot();
+
+      await runConfigCommand(["config", "get", "gateway.port", "--json"]);
+
+      expect(mockReadConfigFileSnapshot).toHaveBeenCalledWith({ observe: false });
+      expect(parseLastLogPayload()).toBe(18789);
+    });
+
     it("redacts sensitive values", async () => {
       const resolved: OpenClawConfig = {
         gateway: {
@@ -1226,9 +1237,64 @@ describe("config cli", () => {
       const payload = parseLastLogPayload() as { error: string };
       expect(payload.error).toBe("Config path not found: nonexistent.path");
     });
+
+    it.each([
+      {
+        path: "gateway.__proto__.token",
+        error: "Invalid path segment: __proto__",
+      },
+      {
+        path: ".gateway.port",
+        error: "Invalid path (empty segment): .gateway.port",
+      },
+      {
+        path: "agents.list[0]id",
+        error: "Invalid path (missing separator after bracket): agents.list[0]id",
+      },
+    ])(
+      "returns a JSON error without reading configuration for malformed $path",
+      async (testCase) => {
+        await expect(runConfigCommand(["config", "get", testCase.path, "--json"])).rejects.toThrow(
+          ExitError,
+        );
+
+        expect(mockReadConfigFileSnapshot).not.toHaveBeenCalled();
+        expect(mockError).not.toHaveBeenCalled();
+        expect(parseLastLogPayload()).toMatchObject({
+          error: expect.stringContaining(testCase.error),
+        });
+      },
+    );
+
+    it("returns invalid configuration as JSON without observing persistent state", async () => {
+      setSnapshotOnce(
+        makeInvalidSnapshot({
+          issues: [{ path: "gateway.bind", message: "Invalid enum value" }],
+        }),
+      );
+
+      await expect(runConfigCommand(["config", "get", "gateway.port", "--json"])).rejects.toThrow(
+        ExitError,
+      );
+
+      expect(mockReadConfigFileSnapshot).toHaveBeenCalledWith({ observe: false });
+      expect(mockError).not.toHaveBeenCalled();
+      expect(parseLastLogPayload()).toMatchObject({
+        error: expect.stringContaining("OpenClaw config is invalid"),
+        issues: [{ path: "gateway.bind", message: "Invalid enum value" }],
+      });
+    });
   });
 
   describe("config validate", () => {
+    it("validates without observing persistent configuration health state", async () => {
+      setGatewaySnapshot();
+
+      await runConfigCommand(["config", "validate"]);
+
+      expect(mockReadConfigFileSnapshot).toHaveBeenCalledWith({ observe: false });
+    });
+
     it("prints success and exits 0 when config is valid", async () => {
       setGatewaySnapshot();
 

--- a/src/cli/config-cli.ts
+++ b/src/cli/config-cli.ts
@@ -150,7 +150,7 @@ export async function runConfigGet(opts: { path: string; json?: boolean; runtime
   const runtime = opts.runtime ?? defaultRuntime;
   try {
     const parsedPath = parseConfigSetPath(opts.path);
-    const snapshot = await loadValidConfig(runtime);
+    const snapshot = await loadValidConfig(runtime, { observe: false, json: opts.json });
     const res = getAtPath(redactConfigObject(snapshot.config), parsedPath);
     if (!res.found) {
       if (opts.json) {
@@ -180,6 +180,11 @@ export async function runConfigGet(opts: { path: string; json?: boolean; runtime
   } catch (err) {
     if (err instanceof ExitError) {
       throw err;
+    }
+    if (opts.json) {
+      writeRuntimeJson(runtime, { error: String(err) });
+      runtime.exit(1);
+      return;
     }
     runtime.error(danger(String(err)));
     runtime.exit(1);
@@ -301,7 +306,7 @@ async function runConfigValidate(opts: { json?: boolean; runtime?: RuntimeEnv } 
   const runtime = opts.runtime ?? defaultRuntime;
   let outputPath = CONFIG_PATH ?? "openclaw.json";
   try {
-    const snapshot = await readConfigFileSnapshot();
+    const snapshot = await readConfigFileSnapshot({ observe: false });
     outputPath = snapshot.path;
     const shortPath = shortenHomePath(outputPath);
     if (!snapshot.exists) {

--- a/src/cli/route.test.ts
+++ b/src/cli/route.test.ts
@@ -120,14 +120,21 @@ describe("tryRouteCli", () => {
     });
   });
 
-  it("suppresses startup output for bare config get machine output", async () => {
+  it("suppresses config get machine output without running an observing startup guard", async () => {
+    const captured: boolean[] = [];
+    runRouteMock.mockImplementationOnce(async () => {
+      captured.push(loggingState.forceConsoleToStderr);
+      return true;
+    });
+
     await expect(
       tryRouteCli(["node", "openclaw", "config", "get", "gateway.port"], {
         machineOutput: true,
       }),
     ).resolves.toBe(true);
 
-    expect(firstConfigReadyCall()?.suppressDoctorStdout).toBe(true);
+    expect(ensureConfigReadyMock).not.toHaveBeenCalled();
+    expect(captured).toEqual([true]);
   });
 
   it("keeps logs routed to stderr for routed --json commands", async () => {

--- a/src/config/runtime-schema.test.ts
+++ b/src/config/runtime-schema.test.ts
@@ -11,7 +11,9 @@ import {
 import type { ConfigFileSnapshot, OpenClawConfig } from "./types.js";
 
 const mockLoadConfig = vi.hoisted(() => vi.fn<() => OpenClawConfig>());
-const mockReadConfigFileSnapshot = vi.hoisted(() => vi.fn<() => Promise<ConfigFileSnapshot>>());
+const mockReadConfigFileSnapshot = vi.hoisted(() =>
+  vi.fn<(options?: { observe?: boolean }) => Promise<ConfigFileSnapshot>>(),
+);
 const mockLoadPluginManifestRegistry = vi.hoisted(() => vi.fn());
 const mockGetCurrentPluginMetadataSnapshot = vi.hoisted(() => vi.fn());
 
@@ -26,7 +28,8 @@ vi.mock("./config.js", () => {
   return {
     getRuntimeConfig: () => mockLoadConfig(),
     loadConfig: () => mockLoadConfig(),
-    readConfigFileSnapshot: () => mockReadConfigFileSnapshot(),
+    readConfigFileSnapshot: (...args: Parameters<typeof mockReadConfigFileSnapshot>) =>
+      mockReadConfigFileSnapshot(...args),
   };
 });
 
@@ -242,6 +245,16 @@ describe("readBestEffortRuntimeConfigSchema", () => {
     expect(channelProps).toHaveProperty("telegram");
     expect(channelProps).toHaveProperty("matrix");
     expect(entryProps).toHaveProperty("demo");
+  });
+
+  it("reads the best-effort CLI schema without observing configuration health", async () => {
+    mockReadConfigFileSnapshot.mockResolvedValueOnce(
+      makeSnapshot({ valid: true, config: explicitMainRoster() }),
+    );
+
+    await readBestEffortRuntimeConfigSchema();
+
+    expect(mockReadConfigFileSnapshot).toHaveBeenCalledWith({ observe: false });
   });
 
   it("falls back to bundled channel metadata when config is invalid", async () => {

--- a/src/config/runtime-schema.ts
+++ b/src/config/runtime-schema.ts
@@ -31,7 +31,7 @@ export function loadGatewayRuntimeConfigSchema(): ConfigSchemaResponse {
 }
 
 export async function readBestEffortRuntimeConfigSchema(): Promise<ConfigSchemaResponse> {
-  const snapshot = await readConfigFileSnapshot();
+  const snapshot = await readConfigFileSnapshot({ observe: false });
   const config = snapshot.valid
     ? snapshot.config
     : { agents: { list: [{ id: "main", default: true }] }, plugins: { enabled: true } };

--- a/test/cli-json-stdout.e2e.test.ts
+++ b/test/cli-json-stdout.e2e.test.ts
@@ -30,6 +30,142 @@ function runSourceCli(tempHome: string, args: string[], envOverrides: NodeJS.Pro
 
 describe("cli json stdout contract", () => {
   it.each([
+    {
+      name: "routed config get",
+      args: ["config", "get", "gateway.port", "--json"],
+      overrides: {},
+    },
+    {
+      name: "Commander config get",
+      args: ["config", "get", "gateway.port", "--json"],
+      overrides: { OPENCLAW_DISABLE_ROUTE_FIRST: "1" },
+    },
+    {
+      name: "Nix config get",
+      args: ["config", "get", "gateway.port", "--json"],
+      overrides: { OPENCLAW_NIX_MODE: "1" },
+    },
+    { name: "config schema", args: ["config", "schema"], overrides: {} },
+    {
+      name: "Nix config schema",
+      args: ["config", "schema"],
+      overrides: { OPENCLAW_NIX_MODE: "1" },
+    },
+    { name: "config validate", args: ["config", "validate", "--json"], overrides: {} },
+    {
+      name: "Nix config validate",
+      args: ["config", "validate", "--json"],
+      overrides: { OPENCLAW_NIX_MODE: "1" },
+    },
+  ])("does not initialize shared SQLite for $name", async (testCase) => {
+    await withTempHome(
+      async (tempHome) => {
+        const stateDir = path.join(tempHome, "read-only-state");
+        const configPath = path.join(tempHome, "read-only-openclaw.json");
+        await fs.writeFile(
+          configPath,
+          `${JSON.stringify({ gateway: { mode: "local", port: 18789 } })}\n`,
+          "utf8",
+        );
+
+        const result = runSourceCli(tempHome, testCase.args, {
+          OPENCLAW_CONFIG_PATH: configPath,
+          OPENCLAW_STATE_DIR: stateDir,
+          ...testCase.overrides,
+        });
+
+        expect(result.status, result.stderr).toBe(0);
+        expect(() => JSON.parse(result.stdout)).not.toThrow();
+        await expect(
+          fs.access(path.join(stateDir, "state", "openclaw.sqlite")),
+        ).rejects.toMatchObject({
+          code: "ENOENT",
+        });
+      },
+      { prefix: "openclaw-read-only-config-e2e-" },
+    );
+  });
+
+  it.each([
+    { name: "routed malformed config get", overrides: {} },
+    {
+      name: "Commander malformed config get",
+      overrides: { OPENCLAW_DISABLE_ROUTE_FIRST: "1" },
+    },
+  ])("returns actionable JSON without creating state for $name", async (testCase) => {
+    await withTempHome(
+      async (tempHome) => {
+        const stateDir = path.join(tempHome, "read-only-state");
+        const configPath = path.join(tempHome, "read-only-openclaw.json");
+        await fs.writeFile(configPath, "{}\n", "utf8");
+
+        const result = runSourceCli(
+          tempHome,
+          ["config", "get", "gateway.__proto__.token", "--json"],
+          {
+            OPENCLAW_CONFIG_PATH: configPath,
+            OPENCLAW_STATE_DIR: stateDir,
+            ...testCase.overrides,
+          },
+        );
+
+        expect(result.status, result.stderr).toBe(1);
+        expect(JSON.parse(result.stdout)).toMatchObject({
+          error: expect.stringContaining("Invalid path segment: __proto__"),
+        });
+        expect(result.stderr).toBe("");
+        await expect(
+          fs.access(path.join(stateDir, "state", "openclaw.sqlite")),
+        ).rejects.toMatchObject({
+          code: "ENOENT",
+        });
+      },
+      { prefix: "openclaw-read-only-invalid-config-e2e-" },
+    );
+  });
+
+  it.each([
+    { name: "routed invalid config get", overrides: {} },
+    {
+      name: "Commander invalid config get",
+      overrides: { OPENCLAW_DISABLE_ROUTE_FIRST: "1" },
+    },
+  ])("reports invalid configuration as JSON without creating state for $name", async (testCase) => {
+    await withTempHome(
+      async (tempHome) => {
+        const stateDir = path.join(tempHome, "read-only-state");
+        const configPath = path.join(tempHome, "read-only-openclaw.json");
+        await fs.writeFile(
+          configPath,
+          `${JSON.stringify({ gateway: { bind: "not-a-supported-mode" } })}\n`,
+          "utf8",
+        );
+
+        const result = runSourceCli(tempHome, ["config", "get", "gateway.port", "--json"], {
+          OPENCLAW_CONFIG_PATH: configPath,
+          OPENCLAW_STATE_DIR: stateDir,
+          ...testCase.overrides,
+        });
+
+        expect(result.status, result.stderr).toBe(1);
+        expect(JSON.parse(result.stdout)).toMatchObject({
+          error: expect.stringContaining("OpenClaw config is invalid"),
+          issues: expect.arrayContaining([
+            expect.objectContaining({ path: "gateway.bind", message: expect.any(String) }),
+          ]),
+        });
+        expect(result.stderr).toBe("");
+        await expect(
+          fs.access(path.join(stateDir, "state", "openclaw.sqlite")),
+        ).rejects.toMatchObject({
+          code: "ENOENT",
+        });
+      },
+      { prefix: "openclaw-read-only-invalid-snapshot-e2e-" },
+    );
+  });
+
+  it.each([
     { name: "default service", inheritedProfile: undefined, inheritedStateName: ".openclaw" },
     { name: "named service", inheritedProfile: "main", inheritedStateName: ".openclaw-main" },
   ])("resolves the requested profile from inherited $name state", async (inherited) => {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users inspecting configuration with `openclaw config get`, `openclaw config schema`, or `openclaw config validate` unexpectedly create, update, or migrate the shared SQLite state database, including in Nix mode. Routed `config get` also ran a second observing startup guard. Malformed paths and invalid configuration under `config get --json` produced empty stdout rather than an actionable machine-readable error.

## Why This Change Was Made

Use the existing non-observing snapshot contract at the documented read-only command owners, align routed and Commander startup policy, and return one normalized JSON failure for malformed paths or invalid configuration. Preserve the observing default for mutation, health recovery, ordinary startup, gateway runtime schema, installed plugin metadata, and valid missing-path semantics. Update the existing route regression to prove the read-only guard is bypassed while machine-output logs stay on stderr. No configuration option, environment variable, state format, database schema version, or migration changes.

## User Impact

Operators can inspect configuration without initializing or upgrading `state/openclaw.sqlite`; Nix-managed and existing installations remain untouched. Automation receives exactly one parseable JSON failure for malformed or invalid `config get --json`.

## Evidence

- Red baseline on freshly pulled main `09bd7d7d17abc1c45556063128527008f9f01a3e`: actual CLI E2E **9 failed / 7 passed**, config/routing **7 failed / 159 passed**, schema **1 failed / 5 passed**.
- Final expanded focused regression: **712 passed, 0 failed** across 20 routing, startup, config, Nix, observation, recovery, mutation, health, and machine-output files.
- **18 real CLI subprocess tests**, including routed/Commander/Nix config reads, malformed paths, invalid schema, and absence of shared SQLite creation.
- **44 independent real source and production-packaged CLI stress cases**, including byte-for-byte preservation of existing version-5 SQLite, unchanged schema and health rows, no WAL/SHM, prototype-pollution paths, Nix, routed/Commander modes, and clean JSON failure streams.
- Reproduced the one initial hosted CI failure, corrected its stale `src/cli/route.test.ts` expectation, and proved the exact startup/route regression: **34 passed, 0 failed**.
- Full `pnpm build`, both exact changed-path gates, plugin and SDK contracts, targeted lint/typechecks, formatting, no runtime import cycles, SQLite/schema/storage guards, and security guards: **passed** on the proven source revision.
- Clean fresh full-branch `autoreview` after rebasing to current `main`.
- Protected maintainer review artifacts: **READY FOR /prepare-pr**, zero findings.
- AI-assisted; behavior, risks, compatibility boundaries, and validation reviewed and understood.
