### PR TITLE
fix(gateway): keep tearing down listeners when cron.stopAndDrain() rejects on shutdown

### DIFF
--- a/src/gateway/server-close.test.ts
+++ b/src/gateway/server-close.test.ts
@@ -182,6 +182,26 @@ describe("createGatewayCloseHandler", () => {
     }
   });
 
+  it("still runs later teardown when cron.stopAndDrain() rejects (no listener strand)", async () => {
+    const stopAndDrain = vi.fn().mockRejectedValue(new Error("stream watcher stop failed"));
+    const httpClose = vi.fn((cb: (err?: Error | null) => void) => cb(null));
+    const deps = createGatewayCloseTestDeps({
+      cron: { stop: vi.fn(), stopAndDrain } as never,
+      httpServer: { close: httpClose, closeIdleConnections: vi.fn() } as never,
+    });
+    const close = createGatewayCloseHandler(deps);
+
+    const result = await close({ reason: "test" });
+
+    // A rejecting stopAndDrain must be swallowed (recorded as a warning) and must NOT skip the
+    // remaining teardown -- otherwise the HTTP/WS listeners and timers strand and the next
+    // start hits EADDRINUSE.
+    expect(stopAndDrain).toHaveBeenCalledTimes(1);
+    expect(deps.heartbeatRunner.stop).toHaveBeenCalledTimes(1);
+    expect(httpClose).toHaveBeenCalled();
+    expect(result.warnings.length).toBeGreaterThan(0);
+  });
+
   it("completes a clean shutdown with a ShutdownResult", async () => {
     const deps = createGatewayCloseTestDeps();
     const close = createGatewayCloseHandler(deps);

--- a/src/gateway/server-close.ts
+++ b/src/gateway/server-close.ts
@@ -884,12 +884,12 @@ export function createGatewayCloseHandler(
       await measureCloseStep("gmail-watcher", () =>
         shutdownStep("gmail-watcher", () => stopGmailWatcherOnDemand(), warnings),
       );
-      if (params.cron.stopAndDrain) {
-        await params.cron.stopAndDrain();
-      } else {
-        params.cron.stop();
-      }
-      params.heartbeatRunner.stop();
+      await shutdownStep(
+        "cron",
+        () => (params.cron.stopAndDrain ? params.cron.stopAndDrain() : params.cron.stop()),
+        warnings,
+      );
+      await shutdownStep("heartbeat-runner", () => params.heartbeatRunner.stop(), warnings);
       await shutdownStep(
         "task-registry-maintenance",
         () => params.stopTaskRegistryMaintenance?.(),


### PR DESCRIPTION
## What Problem This Solves

If the gateway's cron `stopAndDrain()` rejects during shutdown, the HTTP/WebSocket listeners and cleanup timers are never torn down — the listening port stays bound and the timers stay live. On an in-process or supervised restart, the next `listen()` fails with `EADDRINUSE`, stranding the gateway. This is the same class of failure as the previously-fixed launchd/drain race (#110213).

## Why This Change Was Made

In the gateway close handler (`src/gateway/server-close.ts`), every teardown step is wrapped in `shutdownStep(name, fn, warnings)`, which catches, warns, and **continues** — so one failing step can't strand the rest. Two calls were left bare:

```ts
if (params.cron.stopAndDrain) {
  await params.cron.stopAndDrain();   // bare — no shutdownStep
} else {
  params.cron.stop();
}
params.heartbeatRunner.stop();        // bare
```

`cron.stopAndDrain()` deliberately re-throws stream-watcher stop failures (`server-cron.ts`), so a rejection here propagates out of the close handler and skips everything after it: `wss.close()`, `httpServer.close()`, the client socket closes, and all the `clearInterval`s.

## User Impact

A failed cron drain during shutdown no longer strands the gateway. The listeners and timers are always torn down — the drain failure is recorded as a shutdown warning, consistent with the other teardown steps — so restarts don't hit `EADDRINUSE`.

## Evidence

Reproduce-first regression test added to `server-close.test.ts`: a `cron.stopAndDrain` that rejects must still let the later teardown run.

Before (fix reverted) — the rejection escapes and strands teardown:
```
× still runs later teardown when cron.stopAndDrain() rejects (no listener strand)
  Error: stream watcher stop failed
  (heartbeatRunner.stop / httpServer.close never called)
```
After (fix applied):
```
Test Files  1 passed (1)
     Tests  46 passed (46)
```

**Note for maintainers:** wrapping both calls in the existing `shutdownStep` matches every sibling teardown — swallow-and-warn is the established contract here — and it lets the listener/timer teardown always run. Minimal change.
