### PR TITLE
fix(config): reject a blank gateway.tls.caPath like certPath/keyPath

### DIFF
--- a/src/config/zod-schema.gateway.ts
+++ b/src/config/zod-schema.gateway.ts
@@ -120,7 +120,10 @@ export const GatewayConfigSchema = z
           .string()
           .optional()
           .refine((v) => v === undefined || v.trim().length > 0, "keyPath must not be blank"),
-        caPath: z.string().optional(),
+        caPath: z
+          .string()
+          .optional()
+          .refine((v) => v === undefined || v.trim().length > 0, "caPath must not be blank"),
       })
       .optional(),
     http: z

--- a/src/config/zod-schema.tls.test.ts
+++ b/src/config/zod-schema.tls.test.ts
@@ -16,6 +16,14 @@ describe("gateway.tls schema", () => {
     expect(res.ok).toBe(false);
   });
 
+  it("rejects whitespace-only caPath", () => {
+    const res = validateConfigObject({ gateway: { tls: { enabled: true, caPath: "   " } } });
+    expect(res.ok).toBe(false);
+    if (!res.ok) {
+      expect(res.issues[0]?.path).toMatch(/caPath/);
+    }
+  });
+
   it("accepts a non-empty certPath", () => {
     const res = validateConfigObject({
       gateway: { tls: { enabled: true, certPath: "/etc/ssl/cert.pem" } },


### PR DESCRIPTION
## What Problem This Solves

`gateway.tls.certPath` and `keyPath` reject a blank/whitespace-only value at config validation, but `caPath` did not — it was accepted. A blank `caPath` is then **silently ignored** at runtime: `resolveUserPath` trims it to `""`, and the `caPath ? await fs.readFile(caPath) : undefined` guard (`src/infra/tls/gateway.ts`) skips the read, so the gateway starts with **no custom CA loaded and no warning**. For a security-relevant field (custom PKI / client-cert trust chain per the config help), silently ignoring a misconfiguration is a footgun — the operator believes their CA is in effect when it isn't.

## Why This Change Was Made

In `src/config/zod-schema.gateway.ts`, `certPath` and `keyPath` carry a non-blank refine and the inline comment documents that intent for **all three** PEM paths — but `caPath` was left a bare `z.string().optional()`, the lone outlier:

```ts
certPath: z.string().optional().refine((v) => v === undefined || v.trim().length > 0, "certPath must not be blank"),
keyPath:  z.string().optional().refine((v) => v === undefined || v.trim().length > 0, "keyPath must not be blank"),
caPath:   z.string().optional(),   // <- missing the sibling refine
```

This adds the same non-blank refine to `caPath`, so a blank value fails fast at config validation with a clear `caPath must not be blank` message instead of being silently accepted and ignored.

## User Impact

A blank `caPath` now fails config validation with a clear message, matching its `certPath`/`keyPath` siblings, so a misconfigured CA-verification path surfaces immediately instead of the gateway starting with the CA silently disabled. Non-blank paths validate unchanged.

**Compatibility note:** a config that previously carried a blank `caPath` (and started successfully, silently ignoring it) will now fail validation — an intentional fail-fast on an obvious misconfiguration, consistent with `certPath`/`keyPath`.

## Evidence

Reproduce-first test added to `zod-schema.tls.test.ts` (beside the certPath/keyPath blank tests):

Before (fix reverted) — a whitespace caPath is wrongly accepted:
```
× rejects whitespace-only caPath
  AssertionError: expected true to be false
```
After (fix applied):
```
Test Files  1 passed (1)
     Tests  6 passed (6)
```

**Note for maintainers:** one-line sibling-consistency + fail-fast hardening — `caPath` now uses the same non-blank refine as `certPath`/`keyPath`, matching the documented intent (it rejects both `""` and whitespace-only).
