### PR TITLE
fix: prevent cron and Workboard lifecycle regressions

### DIFF
--- a/src/cli/cron-cli.test.ts
+++ b/src/cli/cron-cli.test.ts
@@ -289,9 +289,11 @@ async function runCronRunAndCaptureExit(params: {
   enqueued?: boolean;
   runId?: string;
   runStatus?: "ok" | "error" | "skipped";
+  runStatuses?: Array<"ok" | "error" | "skipped" | undefined>;
   args?: string[];
 }) {
   resetGatewayMock();
+  let runPollCount = 0;
   callGatewayFromCli.mockImplementation(
     async (method: string, _opts: unknown, callParams?: unknown) => {
       if (method === "cron.status") {
@@ -307,8 +309,10 @@ async function runCronRunAndCaptureExit(params: {
         };
       }
       if (method === "cron.runs") {
+        const runStatus = params.runStatuses?.[runPollCount] ?? params.runStatus;
+        runPollCount += 1;
         return {
-          entries: params.runStatus ? [{ status: params.runStatus }] : [],
+          entries: runStatus ? [{ status: runStatus }] : [],
         };
       }
       return { ok: true, params: callParams };
@@ -391,6 +395,107 @@ describe("cron cli", () => {
       expect(stdoutText()).toContain(`"status": "${status}"`);
     },
   );
+
+  it.each([
+    {
+      name: "bounds the default history RPC by the wait deadline",
+      waitTimeout: "1s",
+      rpcTimeout: undefined,
+      expectedEnqueueTimeout: "600000",
+      expectedMaxPollTimeoutMs: 1_000,
+    },
+    {
+      name: "preserves a shorter explicit history RPC timeout",
+      waitTimeout: "1s",
+      rpcTimeout: "5",
+      expectedEnqueueTimeout: "5",
+      expectedMaxPollTimeoutMs: 5,
+    },
+    {
+      name: "bounds a longer explicit history RPC by the wait deadline",
+      waitTimeout: "10ms",
+      rpcTimeout: "5000",
+      expectedEnqueueTimeout: "5000",
+      expectedMaxPollTimeoutMs: 10,
+    },
+    {
+      name: "keeps one immediate history poll for a zero wait deadline",
+      waitTimeout: "0ms",
+      rpcTimeout: undefined,
+      expectedEnqueueTimeout: "600000",
+      expectedMaxPollTimeoutMs: 1,
+    },
+  ])(
+    "$name",
+    async ({ waitTimeout, rpcTimeout, expectedEnqueueTimeout, expectedMaxPollTimeoutMs }) => {
+      const { calls, exitSpy, runOpts } = await runCronRunAndCaptureExit({
+        enqueued: true,
+        runId: "manual:job-1:123:0",
+        runStatus: "ok",
+        args: [
+          "cron",
+          "run",
+          "job-1",
+          "--wait",
+          "--wait-timeout",
+          waitTimeout,
+          "--poll-interval",
+          "1ms",
+          ...(rpcTimeout === undefined ? [] : ["--timeout", rpcTimeout]),
+        ],
+      });
+
+      const historyCalls = calls.filter(([method]) => method === "cron.runs");
+      const historyOptions = historyCalls[0]?.[1] as { timeout?: string } | undefined;
+      const pollTimeoutMs = Number(historyOptions?.timeout);
+
+      expect(exitSpy).toHaveBeenCalledWith(0);
+      expect(historyCalls).toHaveLength(1);
+      expect(runOpts.timeout).toBe(expectedEnqueueTimeout);
+      expect(Number.isSafeInteger(pollTimeoutMs)).toBe(true);
+      expect(pollTimeoutMs).toBeGreaterThan(0);
+      expect(pollTimeoutMs).toBeLessThanOrEqual(expectedMaxPollTimeoutMs);
+    },
+  );
+
+  it("reduces each history RPC timeout as the cron run wait budget elapses", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-07-27T12:00:00.000Z"));
+
+    const pendingRun = runCronRunAndCaptureExit({
+      enqueued: true,
+      runId: "manual:job-1:123:0",
+      runStatuses: [undefined, "ok"],
+      args: [
+        "cron",
+        "run",
+        "job-1",
+        "--wait",
+        "--wait-timeout",
+        "100ms",
+        "--poll-interval",
+        "25ms",
+      ],
+    });
+
+    await vi.advanceTimersByTimeAsync(0);
+    expect(callGatewayFromCli.mock.calls.filter(([method]) => method === "cron.runs")).toHaveLength(
+      1,
+    );
+    await vi.advanceTimersByTimeAsync(25);
+
+    const { calls, exitSpy, runOpts } = await pendingRun;
+    const pollTimeouts = calls
+      .filter(([method]) => method === "cron.runs")
+      .map(([, options]) => Number((options as { timeout?: string }).timeout));
+
+    expect(exitSpy).toHaveBeenCalledWith(0);
+    expect(runOpts.timeout).toBe("600000");
+    expect(pollTimeouts).toHaveLength(2);
+    expect(pollTimeouts[0]).toBeLessThanOrEqual(100);
+    expect(pollTimeouts[1]).toBeLessThanOrEqual(75);
+    expect(pollTimeouts[1]).toBeLessThan(pollTimeouts[0] ?? 0);
+  });
 
   it("rejects zero poll interval for cron run wait before enqueueing", async () => {
     await expectCronCommandExit([

--- a/src/cli/cron-cli/register.cron-simple.ts
+++ b/src/cli/cron-cli/register.cron-simple.ts
@@ -10,6 +10,7 @@ import { sleep } from "../../utils/sleep.js";
 import type { GatewayRpcOpts } from "../gateway-rpc.js";
 import { addGatewayClientOptions, callGatewayFromCli } from "../gateway-rpc.js";
 import { parseDurationMs } from "../parse-duration.js";
+import { parseTimeoutMs } from "../parse-timeout.js";
 import { findCronJobByIdOrName } from "./list-jobs.js";
 import {
   enrichCronJsonWithStatus,
@@ -62,8 +63,21 @@ async function waitForCronRunCompletion(params: {
 }): Promise<CronRunLogEntryResult> {
   // Poll the task ledger rather than cron.run because completion state is written asynchronously.
   const startedAt = Date.now();
+  let hasPolled = false;
   for (;;) {
-    const page = (await callGatewayFromCli("cron.runs", params.opts, {
+    const elapsedBeforePollMs = Date.now() - startedAt;
+    if (hasPolled && elapsedBeforePollMs >= params.timeoutMs) {
+      throw new Error(`timed out waiting for cron run ${params.runId}`);
+    }
+    const remainingMs = Math.max(1, params.timeoutMs - elapsedBeforePollMs);
+    const configuredTimeoutMs = parseTimeoutMs(params.opts.timeout);
+    const pollTimeoutMs =
+      configuredTimeoutMs === undefined ? remainingMs : Math.min(configuredTimeoutMs, remainingMs);
+    hasPolled = true;
+    // History reads share the wait deadline, but enqueue keeps its own RPC
+    // timeout and a zero-duration wait still gets one immediate ledger poll.
+    const pollOpts = { ...params.opts, timeout: String(pollTimeoutMs) };
+    const page = (await callGatewayFromCli("cron.runs", pollOpts, {
       id: params.jobId,
       runId: params.runId,
       limit: 1,

--- a/src/gateway/server-cron.test.ts
+++ b/src/gateway/server-cron.test.ts
@@ -430,9 +430,75 @@ describe("buildGatewayCronService", () => {
       state.cron.stop();
       expect(cancelRun).toHaveBeenCalledWith("manual-cancel");
       expect(cancelScope).toHaveBeenCalledWith(`cron-exit:${job.id}`, "manual-cancel");
+
+      await state.reconcileExitWatchers?.();
+      expect(spawn).toHaveBeenCalledTimes(1);
     } finally {
       state.cron.stop();
       vi.unstubAllEnvs();
+    }
+  });
+
+  it("restarts on-exit watchers only after their scheduler successfully restarts", async () => {
+    const spawn = vi.fn(async () => {
+      const runDone = createDeferred<{
+        reason: "manual-cancel";
+        exitCode: null;
+        exitSignal: null;
+        durationMs: number;
+        stdout: string;
+        stderr: string;
+        timedOut: false;
+        noOutputTimedOut: false;
+      }>();
+      return {
+        runId: `run-on-exit-restart-${spawn.mock.calls.length}`,
+        startedAtMs: Date.now(),
+        cancel: vi.fn(() =>
+          runDone.resolve({
+            reason: "manual-cancel",
+            exitCode: null,
+            exitSignal: null,
+            durationMs: 1,
+            stdout: "",
+            stderr: "",
+            timedOut: false,
+            noOutputTimedOut: false,
+          }),
+        ),
+        wait: () => runDone.promise,
+      };
+    });
+    getProcessSupervisorMock.mockReturnValue({ spawn, cancelScope: vi.fn() });
+    const cfg = createCronConfig("server-cron-restart-exit-watchers");
+    loadConfigMock.mockReturnValue(cfg);
+    const state = buildGatewayCronService({
+      cfg,
+      deps: {} as CliDeps,
+      broadcast: () => {},
+    });
+
+    try {
+      await state.cron.add({
+        name: "restart watched build",
+        enabled: true,
+        schedule: { kind: "on-exit", command: "sleep 60" },
+        payload: { kind: "systemEvent", text: "done" },
+        sessionTarget: "main",
+        wakeMode: "next-heartbeat",
+      });
+      await state.reconcileExitWatchers?.();
+      await vi.waitFor(() => expect(spawn).toHaveBeenCalledOnce());
+
+      state.cron.stop();
+      await state.reconcileExitWatchers?.();
+      expect(spawn).toHaveBeenCalledOnce();
+
+      await state.cron.start();
+      await state.reconcileExitWatchers?.();
+      await vi.waitFor(() => expect(spawn).toHaveBeenCalledTimes(2));
+    } finally {
+      state.cron.stop();
     }
   });
 

--- a/src/gateway/server-cron.ts
+++ b/src/gateway/server-cron.ts
@@ -453,6 +453,7 @@ export function buildGatewayCronService(params: {
   const terminalExitCompletionTokens = new Map<string, object>();
   let exitWatcherGeneration = 0;
   let exitWatcherMutationRevision = 0;
+  let exitWatchersStopped = false;
   let streamWatcherGeneration = 0;
   // Bumped when a direct watcher route begins; fences reconcile's async list
   // snapshot against mutations that commit inside the list await.
@@ -463,11 +464,15 @@ export function buildGatewayCronService(params: {
     const generation = exitWatcherGeneration;
     exitWatcherReconciliations += 1;
     try {
-      if (!exitWatchersRef.current) {
+      if (!exitWatchersRef.current || exitWatchersStopped) {
         return;
       }
       const result = await cron.list({ includeDisabled: true });
-      if (generation !== exitWatcherGeneration || revision !== exitWatcherMutationRevision) {
+      if (
+        exitWatchersStopped ||
+        generation !== exitWatcherGeneration ||
+        revision !== exitWatcherMutationRevision
+      ) {
         return;
       }
       const jobs: CronJob[] = Array.isArray(result) ? result : (result as { jobs: CronJob[] }).jobs;
@@ -1305,6 +1310,9 @@ export function buildGatewayCronService(params: {
     (exitWatchersRef.current?.activeJobIds().length ?? 0) +
     (streamWatchersRef.current?.activeJobIds().length ?? 0);
   const stopExitWatchers = () => {
+    // Late completion cleanup can request reconciliation after shutdown.
+    // Fence new requests before cancellation so stopped children cannot respawn.
+    exitWatchersStopped = true;
     exitWatcherGeneration += 1;
     exitWatchersRef.current?.cancelAll();
   };
@@ -1422,6 +1430,7 @@ export function buildGatewayCronService(params: {
     if (generation !== streamWatcherGeneration) {
       return;
     }
+    exitWatchersStopped = false;
     streamWatchersStopped = false;
     // A reload restart owns a fresh watcher lifecycle; the next stop must run.
     streamWatchersStopPromise = undefined;

--- a/src/tasks/cron-history-retention.ts
+++ b/src/tasks/cron-history-retention.ts
@@ -10,10 +10,15 @@ function isTerminalTask(task: TaskRecord): boolean {
   return task.status !== "queued" && task.status !== "running";
 }
 
+type CronHistoryRetentionPartition = {
+  history: TaskRecord[];
+  quiet: TaskRecord[];
+};
+
 export function collectCronHistoryOverflowTaskIds(tasks: readonly TaskRecord[]): Set<string> {
   // Cron job ids are unique only within a configured store. Retention must
   // use the same storeKey/sourceId partition as history reads.
-  const byStore = new Map<string | undefined, Map<string, TaskRecord[]>>();
+  const byStore = new Map<string | undefined, Map<string, CronHistoryRetentionPartition>>();
   for (const task of tasks) {
     if (
       task.runtime !== "cron" ||
@@ -24,24 +29,35 @@ export function collectCronHistoryOverflowTaskIds(tasks: readonly TaskRecord[]):
       continue;
     }
     const storeKey = cronTaskRecordStoreKey(task);
-    const bySource = byStore.get(storeKey) ?? new Map<string, TaskRecord[]>();
-    const rows = bySource.get(task.sourceId) ?? [];
+    const bySource = byStore.get(storeKey) ?? new Map<string, CronHistoryRetentionPartition>();
+    const partition = bySource.get(task.sourceId) ?? { history: [], quiet: [] };
+    const detail = task.detail;
+    const hasHistory =
+      typeof detail === "object" &&
+      detail !== null &&
+      !Array.isArray(detail) &&
+      detail.kind === "cron-run";
+    // Quiet watcher ticks have no history entry. Bound them separately so
+    // ordinary non-firing evaluations cannot evict actual run history.
+    const rows = hasHistory ? partition.history : partition.quiet;
     rows.push(task);
-    bySource.set(task.sourceId, rows);
+    bySource.set(task.sourceId, partition);
     byStore.set(storeKey, bySource);
   }
   const overflow = new Set<string>();
   for (const bySource of byStore.values()) {
-    for (const rows of bySource.values()) {
-      rows.sort((left, right) => {
-        return (
-          resolveCronTaskRecordTimestamp(right) - resolveCronTaskRecordTimestamp(left) ||
-          right.createdAt - left.createdAt ||
-          right.taskId.localeCompare(left.taskId)
-        );
-      });
-      for (const task of rows.slice(CRON_HISTORY_KEEP_PER_JOB)) {
-        overflow.add(task.taskId);
+    for (const partition of bySource.values()) {
+      for (const rows of [partition.history, partition.quiet]) {
+        rows.sort((left, right) => {
+          return (
+            resolveCronTaskRecordTimestamp(right) - resolveCronTaskRecordTimestamp(left) ||
+            right.createdAt - left.createdAt ||
+            right.taskId.localeCompare(left.taskId)
+          );
+        });
+        for (const task of rows.slice(CRON_HISTORY_KEEP_PER_JOB)) {
+          overflow.add(task.taskId);
+        }
       }
     }
   }

--- a/src/tasks/task-registry.maintenance.issue-60299.test.ts
+++ b/src/tasks/task-registry.maintenance.issue-60299.test.ts
@@ -900,6 +900,7 @@ describe("task-registry maintenance issue #60299", () => {
         endedAt: now + index + 1,
         lastEventAt: now + index + 1,
         cleanupAfter: 0,
+        detail: { kind: "cron-run", status: "ok", storeKey: "store:history" },
       }),
     );
     const lostTask = makeStaleTask({
@@ -923,6 +924,46 @@ describe("task-registry maintenance issue #60299", () => {
     expect(currentTasks.has(lostTask.taskId)).toBe(true);
   });
 
+  it("keeps real cron run history while bounding newer quiet watcher evaluations", async () => {
+    const now = Date.now();
+    const sourceId = "cron-watcher-history-job";
+    const storeKey = "store:watcher-history";
+    const historicalRun = makeStaleTask({
+      taskId: "cron-watcher-fired-run",
+      runtime: "cron",
+      sourceId,
+      status: "succeeded",
+      endedAt: now,
+      lastEventAt: now,
+      cleanupAfter: 0,
+      detail: { kind: "cron-run", status: "ok", storeKey },
+    });
+    const quietRuns = Array.from({ length: CRON_HISTORY_KEEP_PER_JOB + 1 }, (_, index) =>
+      makeStaleTask({
+        taskId: `cron-watcher-quiet-${index}`,
+        runtime: "cron",
+        sourceId,
+        status: "succeeded",
+        endedAt: now + index + 1,
+        lastEventAt: now + index + 1,
+        cleanupAfter: 0,
+        detail: { storeKey },
+      }),
+    );
+    const { currentTasks } = createTaskRegistryMaintenanceHarness({
+      tasks: [historicalRun, ...quietRuns],
+    });
+
+    const result = await runTaskRegistryMaintenance();
+
+    expect(result.pruned).toBe(1);
+    expect(currentTasks.size).toBe(CRON_HISTORY_KEEP_PER_JOB + 1);
+    expect(currentTasks.has(historicalRun.taskId)).toBe(true);
+    expect(currentTasks.has("cron-watcher-quiet-0")).toBe(false);
+    expect(currentTasks.has("cron-watcher-quiet-1")).toBe(true);
+    expect(currentTasks.has(`cron-watcher-quiet-${CRON_HISTORY_KEEP_PER_JOB}`)).toBe(true);
+  });
+
   it("retains the newest-created cron runs when terminal timestamps are identical", async () => {
     const now = Date.now();
     const tasks = Array.from({ length: CRON_HISTORY_KEEP_PER_JOB + 1 }, (_, index) =>
@@ -936,6 +977,7 @@ describe("task-registry maintenance issue #60299", () => {
         endedAt: now + CRON_HISTORY_KEEP_PER_JOB + 1,
         lastEventAt: now + CRON_HISTORY_KEEP_PER_JOB + 1,
         cleanupAfter: 0,
+        detail: { kind: "cron-run", status: "ok", storeKey: "store:same-ms" },
       }),
     );
     const { currentTasks } = createTaskRegistryMaintenanceHarness({ tasks });
@@ -959,7 +1001,7 @@ describe("task-registry maintenance issue #60299", () => {
         endedAt: now + index + 2,
         lastEventAt: now + index + 2,
         cleanupAfter: 0,
-        detail: { storeKey: "store:a" },
+        detail: { kind: "cron-run", status: "ok", storeKey: "store:a" },
       }),
     );
     const storeBTask = makeStaleTask({
@@ -970,7 +1012,7 @@ describe("task-registry maintenance issue #60299", () => {
       endedAt: now + 1,
       lastEventAt: now + 1,
       cleanupAfter: 0,
-      detail: { storeKey: "store:b" },
+      detail: { kind: "cron-run", status: "ok", storeKey: "store:b" },
     });
     const { currentTasks } = createTaskRegistryMaintenanceHarness({
       tasks: [...storeATasks, storeBTask],

--- a/ui/src/e2e/session-dashboard.e2e.test.ts
+++ b/ui/src/e2e/session-dashboard.e2e.test.ts
@@ -466,13 +466,13 @@ describeControlUiE2e("Control UI session dashboard stitch", () => {
       status: "ready",
       priority: "high",
       labels: ["dashboard"],
-      position: 1,
+      position: 1_000,
       createdAt: 1,
       updatedAt: 2,
       agentId: "main",
       metadata: { automation: { boardId: "platform" } },
     };
-    const runningCard = { ...readyCard, status: "running", updatedAt: 3 };
+    const runningCard = { ...readyCard, status: "running", position: 2_000, updatedAt: 3 };
     const gateway = await installMockGateway(page, {
       sessionKey,
       controlUiWidgetKinds: [
@@ -496,7 +496,7 @@ describeControlUiE2e("Control UI session dashboard stitch", () => {
               id: "card-widget-running",
               title: "Already running",
               status: "running",
-              position: 2,
+              position: 1_000,
             },
           ],
           statuses: ["ready", "running", "done"],
@@ -528,7 +528,7 @@ describeControlUiE2e("Control UI session dashboard stitch", () => {
       expect(moveRequest.params).toEqual({
         id: "card-widget-ready",
         status: "running",
-        position: 3,
+        position: 2_000,
       });
       await expect.poll(() => cardWidget.textContent()).toContain("Running");
       await gateway.setMethodResponse("workboard.cards.list", {
@@ -539,7 +539,7 @@ describeControlUiE2e("Control UI session dashboard stitch", () => {
             id: "card-widget-running",
             title: "Already running",
             status: "running",
-            position: 2,
+            position: 1_000,
           },
         ],
         statuses: ["ready", "running", "done"],

--- a/ui/src/lib/board/widgets/workboard-widget.ts
+++ b/ui/src/lib/board/widgets/workboard-widget.ts
@@ -4,6 +4,7 @@ import type { GatewayBrowserClient } from "../../../api/gateway.ts";
 import { applicationContext, type ApplicationContext } from "../../../app/context.ts";
 import { OpenClawLightDomElement } from "../../../lit/openclaw-element.ts";
 import { SubscriptionsController } from "../../../lit/subscriptions-controller.ts";
+import { isActiveWorkboardCard, nextWorkboardCardPosition } from "../../workboard/card-state.ts";
 import { moveWorkboardCard } from "../../workboard/mutations.ts";
 import { normalizeCardsPayload } from "../../workboard/normalization.ts";
 import { getWorkboardState, type WorkboardHost } from "../../workboard/runtime.ts";
@@ -30,6 +31,7 @@ export abstract class WorkboardWidgetElement extends OpenClawLightDomElement {
   protected error = "";
   private loadAttempted = false;
 
+  private allCards: WorkboardCard[] = [];
   private workboardHost: WorkboardHost = {};
   private client: GatewayBrowserClient | null = null;
   private refreshGeneration = 0;
@@ -69,6 +71,8 @@ export abstract class WorkboardWidgetElement extends OpenClawLightDomElement {
     this.refreshPromise = null;
     this.refreshPending = false;
     this.client = null;
+    this.allCards = [];
+    this.cards = [];
     this.workboardHost = {};
     this.loaded = false;
     this.loadAttempted = false;
@@ -94,29 +98,22 @@ export abstract class WorkboardWidgetElement extends OpenClawLightDomElement {
 
   protected async moveCard(card: WorkboardCard, status: WorkboardStatus): Promise<void> {
     const client = this.client;
-    if (!client || !this.canMutate || card.status === status) {
+    if (!client || !this.canMutate || !isActiveWorkboardCard(card) || card.status === status) {
       return;
     }
     const host = this.workboardHost;
     const state = getWorkboardState(host);
-    state.cards = [...this.cards];
+    state.cards = [...this.allCards];
     state.statuses = this.statuses;
     state.loaded = true;
     state.loadAttempted = true;
     state.mutationReadiness = "ready";
-    const position =
-      Math.max(
-        -1,
-        ...state.cards
-          .filter((candidate) => candidate.status === status)
-          .map((candidate) => candidate.position),
-      ) + 1;
     await moveWorkboardCard({
       host,
       client,
       cardId: card.id,
       status,
-      position,
+      position: nextWorkboardCardPosition(state.cards, card, status),
       requestUpdate: () => {
         if (this.client === client && this.workboardHost === host) {
           this.syncFromHost();
@@ -137,6 +134,8 @@ export abstract class WorkboardWidgetElement extends OpenClawLightDomElement {
     // Pending mutation state belongs to its connection; never let its completion
     // block or replace cards loaded through the next Gateway client.
     this.workboardHost = {};
+    this.allCards = [];
+    this.cards = [];
     this.refreshGeneration += 1;
     this.refreshPromise = null;
     this.refreshPending = false;
@@ -172,7 +171,8 @@ export abstract class WorkboardWidgetElement extends OpenClawLightDomElement {
         if (generation !== this.refreshGeneration || client !== this.client) {
           return;
         }
-        this.cards = normalized.cards.filter((card) => !card.metadata?.archivedAt);
+        this.allCards = normalized.cards;
+        this.cards = normalized.cards.filter(isActiveWorkboardCard);
         this.statuses = normalized.statuses;
         this.loaded = true;
       } catch (error) {
@@ -204,7 +204,8 @@ export abstract class WorkboardWidgetElement extends OpenClawLightDomElement {
 
   private syncFromHost(): void {
     const state = getWorkboardState(this.workboardHost);
-    this.cards = [...state.cards];
+    this.allCards = [...state.cards];
+    this.cards = this.allCards.filter(isActiveWorkboardCard);
     this.statuses = state.statuses;
     this.error = state.error ?? "";
     this.requestRender();

--- a/ui/src/lib/board/widgets/workboard.test.ts
+++ b/ui/src/lib/board/widgets/workboard.test.ts
@@ -12,7 +12,7 @@ const cards = [
     status: "ready",
     priority: "high",
     labels: [],
-    position: 0,
+    position: 1000,
     createdAt: 1,
     updatedAt: 1,
     agentId: "agent-a",
@@ -24,7 +24,7 @@ const cards = [
     status: "running",
     priority: "normal",
     labels: [],
-    position: 1,
+    position: 2000,
     createdAt: 1,
     updatedAt: 1,
     metadata: { automation: { boardId: "ops" } },
@@ -35,7 +35,7 @@ const cards = [
     status: "done",
     priority: "low",
     labels: [],
-    position: 2,
+    position: 3000,
     createdAt: 1,
     updatedAt: 1,
     metadata: { automation: { boardId: "ops" } },
@@ -121,7 +121,7 @@ describe("Workboard plugin widgets", () => {
         return { cards, statuses: ["ready", "running", "done"] };
       }
       if (method === "workboard.cards.move") {
-        return { card: { ...cards[0], status: "running", position: 2 } };
+        return { card: { ...cards[0], status: "running", position: 3000 } };
       }
       throw new Error(`Unexpected method: ${method}`);
     });
@@ -140,9 +140,74 @@ describe("Workboard plugin widgets", () => {
       expect(request).toHaveBeenCalledWith("workboard.cards.move", {
         id: "card-ready",
         status: "running",
-        position: 2,
+        position: 3000,
       }),
     );
+  });
+
+  it.each([
+    {
+      name: "starts an empty destination at the canonical position",
+      listedCards: [cards[0], cards[2]],
+      position: 1000,
+    },
+    {
+      name: "ignores higher positions on another board",
+      listedCards: [
+        ...cards,
+        {
+          ...cards[1],
+          id: "product-running",
+          title: "Product run",
+          position: 9000,
+          metadata: { automation: { boardId: "product" } },
+        },
+      ],
+      position: 3000,
+    },
+    {
+      name: "preserves hidden archived positions on the same board",
+      listedCards: [
+        ...cards,
+        {
+          ...cards[1],
+          id: "archived-ops-running",
+          title: "Archived Operations run",
+          position: 9000,
+          metadata: { archivedAt: 10, automation: { boardId: "ops" } },
+        },
+      ],
+      position: 10000,
+    },
+  ])("$name", async ({ listedCards, position }) => {
+    const request = vi.fn(async (method: string) => {
+      if (method === "workboard.cards.list") {
+        return { cards: listedCards, statuses: ["ready", "running", "done"] };
+      }
+      if (method === "workboard.cards.move") {
+        return { card: { ...cards[0], status: "running", position } };
+      }
+      throw new Error(`Unexpected method: ${method}`);
+    });
+    const element = document.createElement("openclaw-workboard-card-widget");
+    element.widget = pluginWidget("workboard:card", { cardId: "card-ready" });
+    element.sessionKey = "agent:main:test";
+
+    await mount(element, createContext(request), request);
+
+    const select = element.querySelector("select");
+    expect(select).not.toBeNull();
+    select!.value = "running";
+    select!.dispatchEvent(new Event("change"));
+
+    await vi.waitFor(() =>
+      expect(request).toHaveBeenCalledWith("workboard.cards.move", {
+        id: "card-ready",
+        status: "running",
+        position,
+      }),
+    );
+    expect(element.textContent).not.toContain("Archived Operations run");
   });
 
   it("does not offer or issue status changes for a read-only card widget", async () => {
@@ -186,7 +251,7 @@ describe("Workboard plugin widgets", () => {
         return { cards: [currentCard], statuses: ["ready", "running", "done"] };
       }
       if (method === "workboard.cards.move") {
-        return { card: { ...currentCard, status: "running", position: 0 } };
+        return { card: { ...currentCard, status: "running", position: 1000 } };
       }
       throw new Error(`Unexpected method: ${method}`);
     });
@@ -208,7 +273,7 @@ describe("Workboard plugin widgets", () => {
       expect(staleRequest).toHaveBeenCalledWith("workboard.cards.move", {
         id: "card-ready",
         status: "running",
-        position: 2,
+        position: 3000,
       }),
     );
     const moveCallIndex = staleRequest.mock.calls.findIndex(
@@ -228,11 +293,11 @@ describe("Workboard plugin widgets", () => {
       expect(currentRequest).toHaveBeenCalledWith("workboard.cards.move", {
         id: "card-ready",
         status: "running",
-        position: 0,
+        position: 1000,
       }),
     );
     staleMove.resolve({
-      card: { ...cards[0], title: "Stale connection card", status: "running", position: 2 },
+      card: { ...cards[0], title: "Stale connection card", status: "running", position: 3000 },
     });
     await pendingMove;
     await Promise.resolve();

--- a/ui/src/lib/workboard/card-state.ts
+++ b/ui/src/lib/workboard/card-state.ts
@@ -4,6 +4,7 @@ import type {
   WorkboardDependencyState,
   WorkboardMetadata,
   WorkboardStaleState,
+  WorkboardStatus,
   WorkboardUiState,
 } from "./types.ts";
 
@@ -11,6 +12,24 @@ const WORKBOARD_STALE_SESSION_MS = 30 * 60 * 1000;
 
 export function isActiveWorkboardCard(card: WorkboardCard): boolean {
   return !card.metadata?.archivedAt;
+}
+
+export function nextWorkboardCardPosition(
+  cards: readonly WorkboardCard[],
+  card: WorkboardCard,
+  status: WorkboardStatus,
+): number {
+  const boardId = card.metadata?.automation?.boardId?.trim() || "default";
+  const positions = cards
+    .filter(
+      (candidate) =>
+        candidate.id !== card.id &&
+        candidate.status === status &&
+        (candidate.metadata?.automation?.boardId?.trim() || "default") === boardId,
+    )
+    .map((candidate) => candidate.position);
+  // Archived cards still own their persisted positions in the canonical store.
+  return Math.max(0, ...positions) + 1000;
 }
 
 export function selectedWorkboardBoardParams(

--- a/ui/src/lib/workboard/index.test.ts
+++ b/ui/src/lib/workboard/index.test.ts
@@ -3012,6 +3012,47 @@ describe("workboard controller", () => {
     expect(state.cards).toEqual([archived, active]);
   });
 
+  it.each([
+    { name: "reuses the newest active captured session", inFlight: false },
+    {
+      name: "returns the newest active captured session while a capture is in flight",
+      inFlight: true,
+    },
+  ])("$name", async ({ inFlight }) => {
+    const archived = {
+      ...sampleCard,
+      id: "archived-newest-session-card",
+      sessionKey: sampleSession.key,
+      position: 0,
+      updatedAt: 30,
+      metadata: { archivedAt: 40 },
+    } satisfies WorkboardCard;
+    const older = {
+      ...sampleCard,
+      id: "older-active-session-card",
+      sessionKey: sampleSession.key,
+      position: 1000,
+      updatedAt: 10,
+    } satisfies WorkboardCard;
+    const newest = {
+      ...sampleCard,
+      id: "newest-active-session-card",
+      sessionKey: sampleSession.key,
+      position: 2000,
+      updatedAt: 20,
+    } satisfies WorkboardCard;
+    state.loaded = true;
+    state.cards = [archived, older, newest];
+    if (inFlight) {
+      state.capturingSessionKeys.add(sampleSession.key);
+    }
+    const client = createClient({});
+
+    await expect(captureSession(client, sampleSession)).resolves.toBe(newest);
+    expect(client.request).not.toHaveBeenCalled();
+    expect(state.cards).toEqual([archived, older, newest]);
+  });
+
   it("returns the active captured session while a duplicate capture is in flight", async () => {
     const archived = {
       ...sampleCard,

--- a/ui/src/lib/workboard/session-capture.ts
+++ b/ui/src/lib/workboard/session-capture.ts
@@ -2,6 +2,7 @@ import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import type { GatewayBrowserClient } from "../../api/gateway.ts";
 import type { GatewaySessionRow } from "../../api/types.ts";
 import {
+  isActiveWorkboardCard,
   isFailedSessionStatus,
   normalizeString,
   replaceCard,
@@ -106,17 +107,22 @@ function sessionCaptureStatus(session: GatewaySessionRow): WorkboardStatus {
 }
 
 function findCapturedSessionCard(cards: WorkboardCard[], sessionKey: string): WorkboardCard | null {
+  let active: WorkboardCard | undefined;
   let archived: WorkboardCard | undefined;
   for (const card of cards) {
     if (workboardCardSessionKey(card) !== sessionKey) {
       continue;
     }
-    if (!card.metadata?.archivedAt) {
-      return card;
+    if (isActiveWorkboardCard(card)) {
+      if (!active || card.updatedAt > active.updatedAt) {
+        active = card;
+      }
+    } else if (!archived || card.updatedAt > archived.updatedAt) {
+      archived = card;
     }
-    archived ??= card;
   }
-  return archived ?? null;
+  // Dashboard matches the newest active card; an archived match is only a restore candidate.
+  return active ?? archived ?? null;
 }
 
 async function loadSessionCaptureHistory(params: {

--- a/ui/src/lib/workboard/session-card-lookup.test.ts
+++ b/ui/src/lib/workboard/session-card-lookup.test.ts
@@ -101,6 +101,43 @@ describe("Workboard session card lookup", () => {
     lease.release();
   });
 
+  it("matches the newest active card when a session is captured on multiple boards", async () => {
+    const { client } = createClient([
+      {
+        cards: [
+          card({
+            id: "card-old",
+            position: 1000,
+            updatedAt: 2,
+            metadata: { automation: { boardId: "ops" } },
+          }),
+          card({
+            id: "card-new",
+            position: 2000,
+            updatedAt: 3,
+            metadata: { automation: { boardId: "product" } },
+          }),
+        ],
+      },
+    ]);
+    const lease = acquireWorkboardSessionCardLookup(client);
+    const listener = vi.fn();
+    const unsubscribe = lease.subscribe("agent:main:workboard-card", listener);
+
+    await vi.waitFor(() =>
+      expect(listener).toHaveBeenCalledWith({
+        cardId: "card-new",
+        title: "Ship dashboard stitch",
+        status: "running",
+        boardId: "product",
+      }),
+    );
+    expect(listener).not.toHaveBeenCalledWith(expect.objectContaining({ cardId: "card-old" }));
+
+    unsubscribe();
+    lease.release();
+  });
+
   it("does not match or scan run history for an archived card", async () => {
     const { client, request } = createClient([
       {

--- a/ui/src/lib/workboard/session-card-lookup.ts
+++ b/ui/src/lib/workboard/session-card-lookup.ts
@@ -1,5 +1,6 @@
 import type { GatewayBrowserClient } from "../../api/gateway.ts";
 import { normalizeSessionKeyForUiComparison } from "../sessions/session-key.ts";
+import { isActiveWorkboardCard } from "./card-state.ts";
 import { normalizeCardsPayload } from "./normalization.ts";
 import { WORKBOARD_CHANGED_EVENT, type WorkboardCard, type WorkboardStatus } from "./types.ts";
 
@@ -191,7 +192,7 @@ class WorkboardSessionCardLookup {
 
   private async loadMatches(): Promise<WorkboardLookupSnapshot> {
     const payload = await this.client.request("workboard.cards.list", {});
-    const cards = normalizeCardsPayload(payload).cards.filter((card) => !card.metadata?.archivedAt);
+    const cards = normalizeCardsPayload(payload).cards.filter(isActiveWorkboardCard);
     const matches = indexCards(cards);
     const runCandidates = cards
       .toSorted((left, right) => right.updatedAt - left.updatedAt)

--- a/ui/src/pages/sessions/sessions-page.test.ts
+++ b/ui/src/pages/sessions/sessions-page.test.ts
@@ -65,6 +65,7 @@ type MutableGateway = {
 
 type TestSessionMenu = HTMLElement & {
   forkDisabled: boolean;
+  workboard: { captured: boolean; busy: boolean } | null;
   readonly updateComplete: Promise<boolean>;
 };
 
@@ -612,6 +613,81 @@ describe("sessions page lifecycle", () => {
     await menu.updateComplete;
     expect(menu.forkDisabled).toBe(true);
     expect(menu.querySelector<HTMLButtonElement>('[data-shortcut="f"]')?.disabled).toBe(true);
+  });
+
+  it.each([
+    {
+      name: "offers capture when only an archived Workboard card matches",
+      metadata: { archivedAt: 10 },
+      captured: false,
+    },
+    {
+      name: "recognizes an active Workboard card",
+      metadata: undefined,
+      captured: true,
+    },
+  ])("$name", async ({ metadata, captured }) => {
+    const row = { key: "agent:main:captured", kind: "direct" } as GatewaySessionRow;
+    const { gateway } = createGateway({} as GatewayBrowserClient);
+    const context = createContext(gateway, createSessions());
+    context.runtimeConfig.state.configSnapshot = {
+      config: { plugins: { entries: { workboard: { enabled: true } } } },
+    };
+    context.workboard.state.cards = [
+      {
+        id: "captured-card",
+        title: "Captured session",
+        status: "todo",
+        priority: "normal",
+        labels: [],
+        position: 1000,
+        createdAt: 1,
+        updatedAt: 2,
+        sessionKey: row.key,
+        metadata,
+      },
+    ];
+    const result = { count: 1, sessions: [row] } as SessionsListResult;
+    const page = await createRenderedPage(context, result);
+
+    page.openSessionMenu(row, { x: 10, y: 20 }, document.createElement("button"));
+    await page.updateComplete;
+
+    const menu = page.querySelector<TestSessionMenu>("openclaw-session-menu");
+    if (!menu) {
+      throw new Error("Expected sessions page menu");
+    }
+    await menu.updateComplete;
+
+    expect(menu.workboard).toEqual({ captured, busy: false });
+    expect(menu.querySelector('[value="workboard"]')?.textContent).toContain(
+      captured ? "Open Workboard card" : "Add to Workboard",
+    );
+  });
+
+  it("disables the Workboard action for every concurrently captured session", async () => {
+    const row = { key: "agent:main:second-capture", kind: "direct" } as GatewaySessionRow;
+    const { gateway } = createGateway({} as GatewayBrowserClient);
+    const context = createContext(gateway, createSessions());
+    context.runtimeConfig.state.configSnapshot = {
+      config: { plugins: { entries: { workboard: { enabled: true } } } },
+    };
+    context.workboard.state.capturingSessionKeys.add("agent:main:first-capture");
+    context.workboard.state.capturingSessionKeys.add(row.key);
+    const result = { count: 1, sessions: [row] } as SessionsListResult;
+    const page = await createRenderedPage(context, result);
+
+    page.openSessionMenu(row, { x: 10, y: 20 }, document.createElement("button"));
+    await page.updateComplete;
+
+    const menu = page.querySelector<TestSessionMenu>("openclaw-session-menu");
+    if (!menu) {
+      throw new Error("Expected sessions page menu");
+    }
+    await menu.updateComplete;
+
+    expect(menu.workboard).toEqual({ captured: false, busy: true });
+    expect(menu.querySelector('[value="workboard"]')?.hasAttribute("disabled")).toBe(true);
   });
 
   it("rejects preloaded data after a same-client reconnect and loads the current epoch", async () => {

--- a/ui/src/pages/sessions/sessions-page.ts
+++ b/ui/src/pages/sessions/sessions-page.ts
@@ -44,6 +44,7 @@ import {
 } from "../../lib/sessions/session-key.ts";
 import { normalizeOptionalString } from "../../lib/string-coerce.ts";
 import { showToast } from "../../lib/toast.ts";
+import { isActiveWorkboardCard } from "../../lib/workboard/card-state.ts";
 import { captureSessionToWorkboard } from "../../lib/workboard/index.ts";
 import { OpenClawLightDomElement } from "../../lit/openclaw-element.ts";
 import { SubscriptionsController } from "../../lit/subscriptions-controller.ts";
@@ -1183,6 +1184,7 @@ class SessionsPage extends OpenClawLightDomElement {
     const workboardState = context.workboard.state;
     const capturedSessionKeys = new Set(
       workboardState.cards
+        .filter(isActiveWorkboardCard)
         .flatMap((card) => [card.sessionKey, card.execution?.sessionKey])
         .filter((key): key is string => typeof key === "string" && key.length > 0),
     );
@@ -1217,7 +1219,7 @@ class SessionsPage extends OpenClawLightDomElement {
         .workboard=${canCapture && row.kind !== "global"
           ? {
               captured: capturedSessionKeys.has(row.key),
-              busy: [...workboardState.capturingSessionKeys][0] === row.key,
+              busy: workboardState.capturingSessionKeys.has(row.key),
             }
           : null}
         .onClose=${() => this.closeSessionMenu()}

--- a/ui/src/pages/workboard/view-card-actions.ts
+++ b/ui/src/pages/workboard/view-card-actions.ts
@@ -2,6 +2,10 @@ import { html, nothing, type TemplateResult } from "lit";
 import { icons } from "../../components/icons.ts";
 import { t } from "../../i18n/index.ts";
 import {
+  isActiveWorkboardCard,
+  nextWorkboardCardPosition,
+} from "../../lib/workboard/card-state.ts";
+import {
   archiveWorkboardCard,
   deleteWorkboardCard,
   findWorkboardSession,
@@ -22,13 +26,13 @@ import {
   cardHasUnresolvedStartedRun,
   engineBlockedByRuntime,
   formatStatusLabel,
-  nextPosition,
   type WorkboardProps,
 } from "./view-helpers.ts";
 
 function moveCardToStatus(props: WorkboardProps, card: WorkboardCard, status: WorkboardStatus) {
   const state = getWorkboardState(props.host);
   if (
+    !isActiveWorkboardCard(card) ||
     status === card.status ||
     state.busyCardIds.has(card.id) ||
     state.dispatching ||
@@ -42,7 +46,7 @@ function moveCardToStatus(props: WorkboardProps, card: WorkboardCard, status: Wo
     client: props.client,
     cardId: card.id,
     status,
-    position: nextPosition(state.cards, status),
+    position: nextWorkboardCardPosition(state.cards, card, status),
     requestUpdate: props.onRequestUpdate,
   });
 }
@@ -57,7 +61,7 @@ export function renderCardMoveControl(
   const statuses = state.statuses.includes(card.status)
     ? state.statuses
     : [card.status, ...state.statuses];
-  if (statuses.length < 2) {
+  if (!isActiveWorkboardCard(card) || statuses.length < 2) {
     return nothing;
   }
   return html`

--- a/ui/src/pages/workboard/view-card-details.ts
+++ b/ui/src/pages/workboard/view-card-details.ts
@@ -372,7 +372,9 @@ export function renderCardDetailsPanel(props: WorkboardProps) {
           <div class="workboard-detail__actions">
             ${writable && !archived ? renderEditCardAction(props, card) : nothing}
             ${writable ? renderArchiveCardAction(props, card, busy, archived) : nothing}
-            ${writable ? renderCardMoveControl(props, card, busy, { wide: true }) : nothing}
+            ${writable && !archived
+              ? renderCardMoveControl(props, card, busy, { wide: true })
+              : nothing}
             ${writable && (linkedSessionKey ? live : activeTask)
               ? renderStopCardAction(props, card, busy)
               : nothing}

--- a/ui/src/pages/workboard/view-card.ts
+++ b/ui/src/pages/workboard/view-card.ts
@@ -3,6 +3,10 @@ import { icons } from "../../components/icons.ts";
 import { t } from "../../i18n/index.ts";
 import { clampText } from "../../lib/format.ts";
 import {
+  isActiveWorkboardCard,
+  nextWorkboardCardPosition,
+} from "../../lib/workboard/card-state.ts";
+import {
   getWorkboardDependencyState,
   getWorkboardLifecycle,
   getWorkboardState,
@@ -36,7 +40,6 @@ import {
   formatStatusLabel,
   formatTime,
   formatUpdatedTime,
-  nextPosition,
   taskDetail,
   taskMatchesLifecycle,
   type WorkboardProps,
@@ -251,7 +254,7 @@ function renderCard(props: WorkboardProps, card: WorkboardCard) {
     writable && (linkedSessionKey ? live : activeTask)
       ? renderStopCardAction(props, card, busy, { iconOnly: true })
       : nothing;
-  const moveAction = writable ? renderCardMoveControl(props, card, busy) : nothing;
+  const moveAction = writable && !archived ? renderCardMoveControl(props, card, busy) : nothing;
   const deleteAction = writable
     ? renderDeleteCardAction(props, card, busy, { iconOnly: true })
     : nothing;
@@ -269,7 +272,7 @@ function renderCard(props: WorkboardProps, card: WorkboardCard) {
       aria-haspopup="dialog"
       aria-expanded=${state.detailCardId === card.id ? "true" : "false"}
       aria-controls=${workboardCardDetailDrawerId}
-      draggable=${writable && !state.dispatching ? "true" : "false"}
+      draggable=${writable && !archived && !state.dispatching ? "true" : "false"}
       @click=${(event: MouseEvent) => {
         if (!isCardActionTarget(event)) {
           openCardDetails(state, card);
@@ -285,7 +288,7 @@ function renderCard(props: WorkboardProps, card: WorkboardCard) {
         event.preventDefault();
       }}
       @dragstart=${(event: DragEvent) => {
-        if (!writable || state.dispatching) {
+        if (!writable || archived || state.dispatching) {
           event.preventDefault();
           return;
         }
@@ -372,7 +375,8 @@ export function renderColumn(
           return;
         }
         const cardId = event.dataTransfer?.getData("text/plain") || state.draggedCardId;
-        if (!cardId) {
+        const card = state.cards.find((candidate) => candidate.id === cardId);
+        if (!card || !isActiveWorkboardCard(card)) {
           return;
         }
         void moveWorkboardCard({
@@ -380,7 +384,7 @@ export function renderColumn(
           client: props.client,
           cardId,
           status,
-          position: nextPosition(state.cards, status),
+          position: nextWorkboardCardPosition(state.cards, card, status),
           requestUpdate: props.onRequestUpdate,
         });
       }}

--- a/ui/src/pages/workboard/view-card.ts
+++ b/ui/src/pages/workboard/view-card.ts
@@ -382,7 +382,7 @@ export function renderColumn(
         void moveWorkboardCard({
           host: props.host,
           client: props.client,
-          cardId,
+          cardId: card.id,
           status,
           position: nextWorkboardCardPosition(state.cards, card, status),
           requestUpdate: props.onRequestUpdate,

--- a/ui/src/pages/workboard/view-helpers.ts
+++ b/ui/src/pages/workboard/view-helpers.ts
@@ -189,11 +189,6 @@ export function matchesFilter(
     .some((value) => value.toLowerCase().includes(query));
 }
 
-export function nextPosition(cards: readonly WorkboardCard[], status: WorkboardStatus): number {
-  const positions = cards.filter((card) => card.status === status).map((card) => card.position);
-  return (positions.length ? Math.max(...positions) : 0) + 1000;
-}
-
 export function isWorkboardSessionChoice(session: GatewaySessionRow): boolean {
   if (session.archived || session.kind === "global") {
     return false;

--- a/ui/src/pages/workboard/view.test.ts
+++ b/ui/src/pages/workboard/view.test.ts
@@ -590,6 +590,36 @@ describe("renderWorkboard", () => {
     expect(container.querySelector(".workboard-column--drop")).toBeNull();
   });
 
+  it("moves the resolved active card when a drop has no transfer payload", async () => {
+    const { host, state } = createLoadedWorkboardState();
+    const card = createWorkboardCard({ title: "Fallback drag move" });
+    const moved = { ...card, status: "running" as const, position: 1000 };
+    state.cards = [card];
+    state.draggedCardId = card.id;
+    const request = vi.fn(async () => ({ card: moved }));
+    const container = document.createElement("div");
+
+    renderInto(
+      container,
+      createWorkboardRenderProps(host, {
+        client: { request } as unknown as GatewayBrowserClient,
+      }),
+    );
+
+    container
+      .querySelector(".workboard-column--running")
+      ?.dispatchEvent(new Event("drop", { bubbles: true, cancelable: true }));
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(request).toHaveBeenCalledWith("workboard.cards.move", {
+      id: card.id,
+      status: "running",
+      position: 1000,
+    });
+    expect(state.cards).toContainEqual(moved);
+  });
+
   it("hides cached card mutation controls until a lifecycle teardown reload succeeds", async () => {
     const { host, state } = createLoadedWorkboardState();
     state.cards = [

--- a/ui/src/pages/workboard/view.test.ts
+++ b/ui/src/pages/workboard/view.test.ts
@@ -2,6 +2,7 @@
 import { nothing, render } from "lit";
 import { describe, expect, it, vi } from "vitest";
 import type { GatewayBrowserClient } from "../../api/gateway.ts";
+import { nextWorkboardCardPosition } from "../../lib/workboard/card-state.ts";
 import { getWorkboardState, stopWorkboardLifecycleRefresh } from "../../lib/workboard/index.ts";
 import {
   createWorkboardCard,
@@ -90,6 +91,114 @@ function selectWorkboardAgent(select: Element | null | undefined, value: string)
   expect(control).not.toBeNull();
   control?.onSelect(value);
 }
+
+describe("nextWorkboardCardPosition", () => {
+  const opsCard = createWorkboardCard({
+    metadata: { automation: { boardId: "ops" } },
+  });
+  const runningOpsCard = createWorkboardCard({
+    id: "moving-ops-running",
+    status: "running",
+    position: 9000,
+    metadata: { automation: { boardId: "ops" } },
+  });
+
+  it.each([
+    {
+      name: "starts an empty board column at the canonical position",
+      card: opsCard,
+      cards: [],
+      position: 1000,
+    },
+    {
+      name: "appends after cards on the same board",
+      card: opsCard,
+      cards: [
+        createWorkboardCard({
+          id: "ops-running",
+          status: "running",
+          position: 2000,
+          metadata: { automation: { boardId: "ops" } },
+        }),
+      ],
+      position: 3000,
+    },
+    {
+      name: "does not count a card dropped back into its own empty column",
+      card: runningOpsCard,
+      cards: [runningOpsCard],
+      position: 1000,
+    },
+    {
+      name: "appends a same-column drop after its other cards only",
+      card: runningOpsCard,
+      cards: [
+        runningOpsCard,
+        createWorkboardCard({
+          id: "other-ops-running",
+          status: "running",
+          position: 2000,
+          metadata: { automation: { boardId: "ops" } },
+        }),
+      ],
+      position: 3000,
+    },
+    {
+      name: "ignores larger positions on another board",
+      card: opsCard,
+      cards: [
+        createWorkboardCard({
+          id: "product-running",
+          status: "running",
+          position: 9000,
+          metadata: { automation: { boardId: "product" } },
+        }),
+      ],
+      position: 1000,
+    },
+    {
+      name: "preserves archived positions on the same board",
+      card: opsCard,
+      cards: [
+        createWorkboardCard({
+          id: "archived-ops-running",
+          status: "running",
+          position: 3000,
+          metadata: { archivedAt: 10, automation: { boardId: "ops" } },
+        }),
+      ],
+      position: 4000,
+    },
+    {
+      name: "ignores a larger position in another status",
+      card: opsCard,
+      cards: [
+        createWorkboardCard({
+          id: "ops-done",
+          status: "done",
+          position: 9000,
+          metadata: { automation: { boardId: "ops" } },
+        }),
+      ],
+      position: 1000,
+    },
+    {
+      name: "normalizes explicit and implicit default board ids",
+      card: createWorkboardCard(),
+      cards: [
+        createWorkboardCard({
+          id: "default-running",
+          status: "running",
+          position: 1000,
+          metadata: { automation: { boardId: " default " } },
+        }),
+      ],
+      position: 2000,
+    },
+  ])("$name", ({ card, cards, position }) => {
+    expect(nextWorkboardCardPosition(cards, card, "running")).toBe(position);
+  });
+});
 
 describe("renderWorkboard", () => {
   it("shows a card dashboard only for linked cards while the plugin is active", () => {
@@ -1714,6 +1823,55 @@ describe("renderWorkboard", () => {
     expect(state.cards[0]).toMatchObject({ status: "blocked", updatedAt: 2 });
   });
 
+  it("appends a status move after archived cards on its own board only", async () => {
+    const { host, state } = createLoadedWorkboardState();
+    const movingCard = createWorkboardCard({
+      title: "Move within Operations",
+      metadata: { automation: { boardId: "ops" } },
+    });
+    state.boardFilter = "ops";
+    state.cards = [
+      movingCard,
+      createWorkboardCard({
+        id: "archived-ops-running",
+        title: "Archived Operations run",
+        status: "running",
+        position: 3000,
+        metadata: { archivedAt: 10, automation: { boardId: "ops" } },
+      }),
+      createWorkboardCard({
+        id: "product-running",
+        title: "Unrelated Product run",
+        status: "running",
+        position: 9000,
+        metadata: { automation: { boardId: "product" } },
+      }),
+    ];
+    const moved = { ...movingCard, status: "running" as const, position: 4000 };
+    const request = vi.fn(async () => ({ card: moved }));
+    const container = document.createElement("div");
+
+    renderInto(
+      container,
+      createWorkboardRenderProps(host, {
+        client: { request } as unknown as GatewayBrowserClient,
+      }),
+    );
+    const moveSelect = container.querySelector<HTMLSelectElement>(".workboard-card__move-select");
+    expect(moveSelect).not.toBeNull();
+    moveSelect!.value = "running";
+    moveSelect!.dispatchEvent(new Event("change", { bubbles: true }));
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(request).toHaveBeenCalledWith("workboard.cards.move", {
+      id: movingCard.id,
+      status: "running",
+      position: 4000,
+    });
+    expect(state.cards).toContainEqual(moved);
+  });
+
   it("moves a focused status control with keyboard arrows", async () => {
     const { host, state } = createLoadedWorkboardState();
     state.cards = [
@@ -2520,6 +2678,49 @@ describe("renderWorkboard", () => {
 
     expect(container.querySelector(".workboard-detail")).toBeNull();
     expect(container.querySelectorAll<HTMLButtonElement>(".workboard-card__start")).toHaveLength(0);
+  });
+
+  it("keeps visible archived cards inspectable and restorable without move or drag controls", () => {
+    const { host, state } = createLoadedWorkboardState();
+    const archivedCard = createWorkboardCard({
+      title: "Archived historical task",
+      metadata: { archivedAt: 10 },
+    });
+    state.cards = [archivedCard];
+    state.showArchived = true;
+    const request = vi.fn();
+    const props = createWorkboardRenderProps(host, {
+      client: { request } as unknown as GatewayBrowserClient,
+    });
+    const container = document.createElement("div");
+
+    renderInto(container, props);
+
+    const article = container.querySelector<HTMLElement>(".workboard-card--archived");
+    expect(article).not.toBeNull();
+    expect(article?.getAttribute("draggable")).toBe("false");
+    expect(article?.querySelector(".workboard-card__move-select")).toBeNull();
+    expect(buttonByLabel(article!, "Restore from archive")).not.toBeNull();
+    expect(
+      article!.dispatchEvent(new Event("dragstart", { bubbles: true, cancelable: true })),
+    ).toBe(false);
+    expect(state.draggedCardId).toBeNull();
+
+    state.draggedCardId = archivedCard.id;
+    container
+      .querySelector(".workboard-column--running")
+      ?.dispatchEvent(new Event("drop", { bubbles: true, cancelable: true }));
+    expect(request).not.toHaveBeenCalled();
+
+    state.draggedCardId = null;
+    state.detailCardId = archivedCard.id;
+    renderInto(container, props);
+
+    const drawer = container.querySelector<HTMLElement>(".workboard-detail");
+    expect(drawer?.textContent).toContain(archivedCard.title);
+    expect(drawer?.querySelector(".workboard-card__move-select")).toBeNull();
+    expect(buttonByLabel(drawer!, "Restore from archive")).not.toBeNull();
+    expect(request).not.toHaveBeenCalled();
   });
 
   it("shows stale lifecycle on executed linked cards", () => {

--- a/ui/src/pages/workboard/workboard-status-persistence.e2e.test.ts
+++ b/ui/src/pages/workboard/workboard-status-persistence.e2e.test.ts
@@ -58,6 +58,30 @@ const initialCard = {
   ],
 } satisfies WorkboardCard;
 
+const productRunningCard = {
+  id: "product-running-card",
+  title: "Product board running card",
+  status: "running",
+  priority: "normal",
+  labels: [],
+  position: 9_000,
+  createdAt: 900,
+  updatedAt: manualTodoAt,
+  metadata: { automation: { boardId: "product" } },
+} satisfies WorkboardCard;
+
+const archivedDefaultRunningCard = {
+  id: "archived-default-running-card",
+  title: "Archived default board running card",
+  status: "running",
+  priority: "normal",
+  labels: [],
+  position: 3_000,
+  createdAt: 900,
+  updatedAt: manualTodoAt,
+  metadata: { archivedAt: 1_000 },
+} satisfies WorkboardCard;
+
 const editedCard = {
   ...initialCard,
   title: "Persisted renamed card",
@@ -70,7 +94,7 @@ const editedCard = {
 const draggedRunningCard = {
   ...editedCard,
   status: "running",
-  position: 1_000,
+  position: 4_000,
   updatedAt: draggedRunningAt,
   events: [
     ...editedCard.events,
@@ -394,7 +418,7 @@ describeControlUiE2e("Control UI Workboard status persistence E2E", () => {
           tasks: [],
         },
         "workboard.cards.list": {
-          cards: [initialCard],
+          cards: [initialCard, productRunningCard, archivedDefaultRunningCard],
           statuses: [
             "triage",
             "backlog",
@@ -443,6 +467,10 @@ describeControlUiE2e("Control UI Workboard status persistence E2E", () => {
       const response = await page.goto(`${server.baseUrl}workboard`);
       expect(response?.status()).toBe(200);
       await workboardCard(page, "Todo", "Persist queue status").waitFor({ timeout: 10_000 });
+      await workboardCard(page, "Running", productRunningCard.title).waitFor({
+        timeout: 10_000,
+      });
+      await expect.poll(() => page.getByText(archivedDefaultRunningCard.title).count()).toBe(0);
       await waitForRequestCount(gateway, "workboard.cards.update", 0);
 
       await workboardCard(page, "Todo", "Persist queue status")
@@ -505,7 +533,7 @@ describeControlUiE2e("Control UI Workboard status persistence E2E", () => {
       const moveRequest = await gateway.waitForRequest("workboard.cards.move");
       expect(requestParams(moveRequest)).toMatchObject({
         id: "card-1",
-        position: 1_000,
+        position: 4_000,
         status: "running",
       });
       await workboardCard(page, "Running", "Persisted renamed card").waitFor({


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users moving or restoring Workboard cards could see inconsistent card order, archived cards remain movable, or session capture associate the wrong card when several boards, archived matches, or concurrent captures were present. Resolves cron runs waiting beyond their requested deadline, exit-triggered watchers starting again after the gateway stopped, and quiet watcher evaluations evicting real cron run history.

## Why This Change Was Made

Centralizes board-local card eligibility and positioning so dashboard, drag, dropdown, and session-capture surfaces follow the same active-card and 1,000-position-stride rules. Uses the resolved canonical card identity for drag-and-drop, including drops without a transfer payload. Bounds each cron-history poll by the remaining overall deadline, fences exit-watcher reconciliation by gateway lifecycle, and retains real run history separately from no-fire evaluations. Keeps existing configuration, SQLite schemas, public SDK, authentication, and permissions unchanged.

## User Impact

Workboard cards keep deterministic board-local order, archived cards cannot accidentally be moved, and payload-less drag-and-drop and session capture consistently resolve the correct active card. Cron waits respect the requested timeout, stopped gateways do not restart exit watchers, and real cron run history remains visible under sustained watcher traffic.

## Evidence

- Independently reviewed corrected head: 26f2b0c5a4fff080e267f10921d4bd95dcb13fff.
- 918 passing focused tests across 25 cron, gateway, Workboard, and UI regression-test files, including the new payload-less canonical-card drag regression.
- 22 passing real-Chromium Workboard, session, dashboard, routing, persistence, and cron-filter E2E cases.
- Four isolated-gateway, mock-provider cron scenarios covering actual timer firing, recovery, and duplicate prevention.
- Three additional serial cron and Workboard race-stress passes.
- Full exact-path changed-code gate over all 22 touched files: core and UI type checks, all core/UI lint shards, formatting, architecture, plugin boundaries, import-cycle, schema, legacy-store, and authentication guards.
- Fresh-lease, deliberately cold-cache production and test type checks: pnpm tsgo:prod and pnpm check:test-types; all incremental core, UI, plugin, and test build-info caches removed first.
- Fresh independent full-branch autoreview against the actual merge base: no accepted or actionable findings.
- Native maintainer review uses the corrected exact head and records the real user-path proof.
- No configuration, migration, SQLite schema, plugin SDK, security-boundary, or permissions changes.
- AI-assisted.