### PR TITLE
chore: carry exact Slack QA head for #111955

### DIFF
--- a/extensions/slack/src/outbound-adapter.test.ts
+++ b/extensions/slack/src/outbound-adapter.test.ts
@@ -9,6 +9,11 @@ vi.mock("./send.js", () => ({
 
 const { slackOutbound } = await import("./outbound-adapter.js");
 
+function jsonRoundTrip(value: unknown): unknown {
+  // oxlint-disable-next-line unicorn/prefer-structured-clone -- This test exercises JSON transport.
+  return JSON.parse(JSON.stringify(value)) as unknown;
+}
+
 describe("slackOutbound", () => {
   const cfg = {
     channels: {
@@ -118,7 +123,10 @@ describe("slackOutbound", () => {
     expect(result).toEqual({ channel: "slack", messageId: "m-blocks" });
   });
 
-  it("preserves rendered portable tables across a cloned outbound payload", async () => {
+  it.each([
+    ["structured clone", (value: unknown) => structuredClone(value)],
+    ["JSON round trip", jsonRoundTrip],
+  ])("preserves rendered portable tables across a %s", async (_label, clonePayload) => {
     sendMessageSlackMock.mockResolvedValueOnce({ messageId: "m-table" });
     const presentation = {
       blocks: [
@@ -142,7 +150,7 @@ describe("slackOutbound", () => {
       cfg,
       to: "C123",
       text: "",
-      payload: structuredClone(renderedForDelivery),
+      payload: clonePayload(renderedForDelivery) as typeof renderedForDelivery,
       accountId: "default",
     });
 
@@ -237,6 +245,35 @@ describe("slackOutbound", () => {
       kind: "blocks",
       blocks: [{ type: "divider" }],
     });
+
+    await slackOutbound.sendPayload!({
+      cfg,
+      to: "C123",
+      text: "",
+      payload: tampered,
+      accountId: "default",
+    });
+
+    expect(sendMessageSlackMock).toHaveBeenCalledOnce();
+    expect(sendMessageSlackMock.mock.calls[0]?.[2]).not.toHaveProperty("blocks");
+  });
+
+  it("rejects authored text placement changed after provenance was signed", async () => {
+    sendMessageSlackMock.mockResolvedValueOnce({ messageId: "m-text" });
+    const presentation = {
+      blocks: [{ type: "divider" as const }],
+    };
+    const rendered = await slackOutbound.renderPresentation!({
+      payload: { text: "Safe fallback", presentation },
+      presentation,
+      ctx: { cfg, accountId: "default" } as never,
+    });
+    const { presentation: _presentation, ...renderedForDelivery } = rendered!;
+    const tampered = structuredClone(renderedForDelivery);
+    const slackData = tampered.channelData?.slack as {
+      authoredTextPlacement: string;
+    };
+    slackData.authoredTextPlacement = "outside-blocks";
 
     await slackOutbound.sendPayload!({
       cfg,

--- a/extensions/slack/src/outbound-adapter.test.ts
+++ b/extensions/slack/src/outbound-adapter.test.ts
@@ -118,6 +118,138 @@ describe("slackOutbound", () => {
     expect(result).toEqual({ channel: "slack", messageId: "m-blocks" });
   });
 
+  it("preserves rendered portable tables across a cloned outbound payload", async () => {
+    sendMessageSlackMock.mockResolvedValueOnce({ messageId: "m-table" });
+    const presentation = {
+      blocks: [
+        {
+          type: "table" as const,
+          caption: "Deployments",
+          headers: ["Name", "Status"],
+          rows: [["Marvin", "Ready"]],
+          rowHeaderColumnIndex: 0,
+        },
+      ],
+    };
+    const rendered = await slackOutbound.renderPresentation!({
+      payload: { text: "Current state", presentation },
+      presentation,
+      ctx: { cfg, accountId: "default" } as never,
+    });
+    const { presentation: _presentation, ...renderedForDelivery } = rendered!;
+
+    await slackOutbound.sendPayload!({
+      cfg,
+      to: "C123",
+      text: "",
+      payload: structuredClone(renderedForDelivery),
+      accountId: "default",
+    });
+
+    expect(sendMessageSlackMock).toHaveBeenCalledWith(
+      "C123",
+      "Current state\n\nDeployments (table)\nName\tStatus\nMarvin\tReady",
+      expect.objectContaining({
+        authoredTextPlacement: "blocks",
+        blocks: [
+          {
+            type: "section",
+            text: { type: "mrkdwn", text: "Current state", verbatim: true },
+          },
+          {
+            type: "data_table",
+            caption: "Deployments",
+            rows: [
+              [
+                { type: "raw_text", text: "Name" },
+                { type: "raw_text", text: "Status" },
+              ],
+              [
+                { type: "raw_text", text: "Marvin" },
+                { type: "raw_text", text: "Ready" },
+              ],
+            ],
+            row_header_column_index: 0,
+          },
+        ],
+      }),
+    );
+  });
+
+  it("does not trust caller-authored rendered presentation provenance", async () => {
+    sendMessageSlackMock.mockResolvedValueOnce({ messageId: "m-text" });
+
+    await slackOutbound.sendPayload!({
+      cfg,
+      to: "C123",
+      text: "",
+      payload: {
+        text: "Safe fallback",
+        channelData: {
+          slack: {
+            renderedPresentationProvenance: "forged",
+            authoredTextPlacement: "blocks",
+            renderedPresentationSegments: [
+              {
+                kind: "blocks",
+                blocks: [{ type: "divider" }, { type: "divider" }],
+              },
+              {
+                kind: "blocks",
+                blocks: [{ type: "divider" }],
+              },
+            ],
+          },
+        },
+      },
+      accountId: "default",
+    });
+
+    expect(sendMessageSlackMock).toHaveBeenCalledOnce();
+    expect(sendMessageSlackMock).toHaveBeenCalledWith(
+      "C123",
+      "Safe fallback",
+      expect.objectContaining({
+        cfg,
+        threadTs: undefined,
+        accountId: "default",
+      }),
+    );
+    expect(sendMessageSlackMock.mock.calls[0]?.[2]).not.toHaveProperty("blocks");
+  });
+
+  it("rejects rendered segments changed after provenance was signed", async () => {
+    sendMessageSlackMock.mockResolvedValueOnce({ messageId: "m-text" });
+    const presentation = {
+      blocks: [{ type: "divider" as const }],
+    };
+    const rendered = await slackOutbound.renderPresentation!({
+      payload: { text: "Safe fallback", presentation },
+      presentation,
+      ctx: { cfg, accountId: "default" } as never,
+    });
+    const { presentation: _presentation, ...renderedForDelivery } = rendered!;
+    const tampered = structuredClone(renderedForDelivery);
+    const slackData = tampered.channelData?.slack as {
+      renderedPresentationSegments: Array<{ kind: string; blocks: Array<{ type: string }> }>;
+    };
+    slackData.renderedPresentationSegments.push({
+      kind: "blocks",
+      blocks: [{ type: "divider" }],
+    });
+
+    await slackOutbound.sendPayload!({
+      cfg,
+      to: "C123",
+      text: "",
+      payload: tampered,
+      accountId: "default",
+    });
+
+    expect(sendMessageSlackMock).toHaveBeenCalledOnce();
+    expect(sendMessageSlackMock.mock.calls[0]?.[2]).not.toHaveProperty("blocks");
+  });
+
   it("falls back to threadId when payload replyToId is not a Slack thread timestamp", async () => {
     sendMessageSlackMock.mockResolvedValueOnce({ messageId: "m-blocks" });
 

--- a/extensions/slack/src/outbound-adapter.test.ts
+++ b/extensions/slack/src/outbound-adapter.test.ts
@@ -184,6 +184,49 @@ describe("slackOutbound", () => {
     );
   });
 
+  it("falls back to text for rendered provenance minted before a runtime restart", async () => {
+    sendMessageSlackMock.mockResolvedValueOnce({ messageId: "m-text" });
+    const presentation = {
+      blocks: [
+        {
+          type: "table" as const,
+          caption: "Deployments",
+          headers: ["Name", "Status"],
+          rows: [["Marvin", "Ready"]],
+          rowHeaderColumnIndex: 0,
+        },
+      ],
+    };
+    const rendered = await slackOutbound.renderPresentation!({
+      payload: { text: "Safe fallback", presentation },
+      presentation,
+      ctx: { cfg, accountId: "default" } as never,
+    });
+    const { presentation: _presentation, ...renderedForDelivery } = rendered!;
+
+    vi.resetModules();
+    const { slackOutbound: restartedSlackOutbound } = await import("./outbound-adapter.js");
+    await restartedSlackOutbound.sendPayload!({
+      cfg,
+      to: "C123",
+      text: "",
+      payload: renderedForDelivery,
+      accountId: "default",
+    });
+
+    expect(sendMessageSlackMock).toHaveBeenCalledOnce();
+    expect(sendMessageSlackMock).toHaveBeenCalledWith(
+      "C123",
+      "Safe fallback",
+      expect.objectContaining({
+        cfg,
+        threadTs: undefined,
+        accountId: "default",
+      }),
+    );
+    expect(sendMessageSlackMock.mock.calls[0]?.[2]).not.toHaveProperty("blocks");
+  });
+
   it("does not trust caller-authored rendered presentation provenance", async () => {
     sendMessageSlackMock.mockResolvedValueOnce({ messageId: "m-text" });
 

--- a/extensions/slack/src/outbound-adapter.test.ts
+++ b/extensions/slack/src/outbound-adapter.test.ts
@@ -269,6 +269,39 @@ describe("slackOutbound", () => {
     expect(sendMessageSlackMock.mock.calls[0]?.[2]).not.toHaveProperty("blocks");
   });
 
+  it("falls back to text when forged rendered metadata is malformed", async () => {
+    sendMessageSlackMock.mockResolvedValueOnce({ messageId: "m-text" });
+
+    await slackOutbound.sendPayload!({
+      cfg,
+      to: "C123",
+      text: "",
+      payload: {
+        text: "Safe fallback",
+        channelData: {
+          slack: {
+            renderedPresentationProvenance: "x".repeat(43),
+            authoredTextPlacement: "blocks",
+            renderedPresentationSegments: [{ kind: "blocks", blocks: [] }],
+          },
+        },
+      },
+      accountId: "default",
+    });
+
+    expect(sendMessageSlackMock).toHaveBeenCalledOnce();
+    expect(sendMessageSlackMock).toHaveBeenCalledWith(
+      "C123",
+      "Safe fallback",
+      expect.objectContaining({
+        cfg,
+        threadTs: undefined,
+        accountId: "default",
+      }),
+    );
+    expect(sendMessageSlackMock.mock.calls[0]?.[2]).not.toHaveProperty("blocks");
+  });
+
   it("rejects rendered segments changed after provenance was signed", async () => {
     sendMessageSlackMock.mockResolvedValueOnce({ messageId: "m-text" });
     const presentation = {

--- a/extensions/slack/src/outbound-adapter.ts
+++ b/extensions/slack/src/outbound-adapter.ts
@@ -1,4 +1,5 @@
 // Slack plugin module implements outbound adapter behavior.
+import { createHmac, randomBytes, timingSafeEqual } from "node:crypto";
 import type { OutboundIdentity } from "openclaw/plugin-sdk/channel-outbound";
 import { resolveOutboundSendDep } from "openclaw/plugin-sdk/channel-outbound";
 import {
@@ -49,9 +50,48 @@ type SlackOutboundChannelData = Record<string, unknown> & {
   renderedPresentationSegments?: SlackReplyBlockSegment[];
 };
 
-// Only renderPresentation can mint this identity. Direct channelData must not
-// turn private ordered segments into arbitrary platform-send fanout.
-const SLACK_RENDERED_PRESENTATION_PROVENANCE = Object.freeze({});
+// Rendered payloads may be cloned by outbound hooks. Sign the exact private
+// delivery plan so it survives cloning without allowing a caller to alter or
+// fan out channelData segments before sendPayload validates them.
+const SLACK_RENDERED_PRESENTATION_PROVENANCE_KEY = randomBytes(32);
+
+function createSlackRenderedPresentationProvenance(resolution: SlackReplyBlockResolution): string {
+  return createHmac("sha256", SLACK_RENDERED_PRESENTATION_PROVENANCE_KEY)
+    .update(JSON.stringify([resolution.authoredTextPlacement, resolution.segments]))
+    .digest("base64url");
+}
+
+function hasValidSlackRenderedPresentationProvenance(params: {
+  provenance: unknown;
+  resolution: SlackReplyBlockResolution;
+}): boolean {
+  if (typeof params.provenance !== "string") {
+    return false;
+  }
+  const expected = createSlackRenderedPresentationProvenance(params.resolution);
+  const actualBuffer = Buffer.from(params.provenance);
+  const expectedBuffer = Buffer.from(expected);
+  return (
+    actualBuffer.length === expectedBuffer.length && timingSafeEqual(actualBuffer, expectedBuffer)
+  );
+}
+
+function readSlackRenderedPresentation(
+  slackData: SlackOutboundChannelData | undefined,
+): SlackReplyBlockResolution | undefined {
+  const segments = parseSlackReplyBlockSegments(slackData?.renderedPresentationSegments);
+  const authoredTextPlacement = readSlackAuthoredTextPlacement(slackData?.authoredTextPlacement);
+  if (!segments || !authoredTextPlacement) {
+    return undefined;
+  }
+  const resolution = { authoredTextPlacement, segments };
+  return hasValidSlackRenderedPresentationProvenance({
+    provenance: slackData?.renderedPresentationProvenance,
+    resolution,
+  })
+    ? resolution
+    : undefined;
+}
 
 const loadSlackSendRuntime = createLazyRuntimeModule(() => import("./send.runtime.js"));
 
@@ -121,7 +161,7 @@ function withSlackRenderedPresentation(
       slack: {
         ...preservedSlackData,
         authoredTextPlacement: resolution.authoredTextPlacement,
-        renderedPresentationProvenance: SLACK_RENDERED_PRESENTATION_PROVENANCE,
+        renderedPresentationProvenance: createSlackRenderedPresentationProvenance(resolution),
         renderedPresentationSegments: resolution.segments,
       },
     },
@@ -307,20 +347,10 @@ export const slackOutbound: ChannelOutboundAdapter = {
         }) ?? "",
     };
     const slackData = payload.channelData?.slack as SlackOutboundChannelData | undefined;
-    const hasRenderedPresentationProvenance =
-      slackData?.renderedPresentationProvenance === SLACK_RENDERED_PRESENTATION_PROVENANCE;
-    const renderedSegments = hasRenderedPresentationProvenance
-      ? parseSlackReplyBlockSegments(slackData?.renderedPresentationSegments)
-      : undefined;
-    const renderedPlacement = hasRenderedPresentationProvenance
-      ? readSlackAuthoredTextPlacement(slackData?.authoredTextPlacement)
-      : undefined;
+    const renderedResolution = readSlackRenderedPresentation(slackData);
     let resolution: SlackReplyBlockResolution;
-    if (renderedSegments) {
-      if (!renderedPlacement) {
-        throw new Error("Slack rendered presentation is missing authored text placement");
-      }
-      resolution = { authoredTextPlacement: renderedPlacement, segments: renderedSegments };
+    if (renderedResolution) {
+      resolution = renderedResolution;
     } else {
       resolution = resolveSlackOutboundBlockResolution(payload);
     }
@@ -404,20 +434,16 @@ export const slackOutbound: ChannelOutboundAdapter = {
   afterDeliverPayload: async ({ cfg, target, payload, results }) => {
     const questionId = questionGatewayRuntime.readAskUserQuestionId(payload);
     const slackData = payload.channelData?.slack as SlackOutboundChannelData | undefined;
-    if (
-      !questionId ||
-      slackData?.renderedPresentationProvenance !== SLACK_RENDERED_PRESENTATION_PROVENANCE
-    ) {
+    if (!questionId) {
       return;
     }
-    const segments = parseSlackReplyBlockSegments(slackData.renderedPresentationSegments);
-    const placement = readSlackAuthoredTextPlacement(slackData.authoredTextPlacement);
-    if (!segments || !placement) {
+    const resolution = readSlackRenderedPresentation(slackData);
+    if (!resolution) {
       return;
     }
     const deliveryMessages = resolveSlackReplyDeliveryMessages({
-      authoredTextPlacement: placement,
-      segments,
+      authoredTextPlacement: resolution.authoredTextPlacement,
+      segments: resolution.segments,
       text: payload.text,
     });
     const blockMessageIndex = deliveryMessages.findIndex((message) =>

--- a/extensions/slack/src/outbound-adapter.ts
+++ b/extensions/slack/src/outbound-adapter.ts
@@ -62,12 +62,9 @@ function createSlackRenderedPresentationProvenance(resolution: SlackReplyBlockRe
 }
 
 function hasValidSlackRenderedPresentationProvenance(params: {
-  provenance: unknown;
+  provenance: string;
   resolution: SlackReplyBlockResolution;
 }): boolean {
-  if (typeof params.provenance !== "string") {
-    return false;
-  }
   const expected = createSlackRenderedPresentationProvenance(params.resolution);
   const actualBuffer = Buffer.from(params.provenance);
   const expectedBuffer = Buffer.from(expected);
@@ -79,18 +76,25 @@ function hasValidSlackRenderedPresentationProvenance(params: {
 function readSlackRenderedPresentation(
   slackData: SlackOutboundChannelData | undefined,
 ): SlackReplyBlockResolution | undefined {
-  const segments = parseSlackReplyBlockSegments(slackData?.renderedPresentationSegments);
-  const authoredTextPlacement = readSlackAuthoredTextPlacement(slackData?.authoredTextPlacement);
-  if (!segments || !authoredTextPlacement) {
+  const provenance = slackData?.renderedPresentationProvenance;
+  if (typeof provenance !== "string") {
     return undefined;
   }
-  const resolution = { authoredTextPlacement, segments };
-  return hasValidSlackRenderedPresentationProvenance({
-    provenance: slackData?.renderedPresentationProvenance,
-    resolution,
-  })
-    ? resolution
-    : undefined;
+  try {
+    const segments = parseSlackReplyBlockSegments(slackData?.renderedPresentationSegments);
+    const authoredTextPlacement = readSlackAuthoredTextPlacement(slackData?.authoredTextPlacement);
+    if (!segments || !authoredTextPlacement) {
+      return undefined;
+    }
+    const resolution = { authoredTextPlacement, segments };
+    return hasValidSlackRenderedPresentationProvenance({ provenance, resolution })
+      ? resolution
+      : undefined;
+  } catch {
+    // Private renderer metadata is untrusted until its signature verifies.
+    // Invalid caller-authored shapes must use the public fallback, not abort delivery.
+    return undefined;
+  }
 }
 
 const loadSlackSendRuntime = createLazyRuntimeModule(() => import("./send.runtime.js"));

--- a/extensions/slack/src/question-finalization.test.ts
+++ b/extensions/slack/src/question-finalization.test.ts
@@ -24,6 +24,11 @@ vi.mock("./send.js", () => ({ updateMessageSlack: hoisted.update }));
 
 import { slackOutbound } from "./outbound-adapter.js";
 
+function jsonRoundTrip<T>(value: T): T {
+  // oxlint-disable-next-line unicorn/prefer-structured-clone -- This test exercises JSON transport.
+  return JSON.parse(JSON.stringify(value)) as T;
+}
+
 describe("Slack question finalization", () => {
   it("removes action blocks and appends terminal context", async () => {
     const questionId = "ask_0123456789abcdef0123456789abcdef";
@@ -48,29 +53,19 @@ describe("Slack question finalization", () => {
       ctx: { cfg: {}, to: "C123", text: "Pick one", payload },
     });
     expect(rendered).not.toBeNull();
-    const slackData = rendered!.channelData?.slack as {
-      renderedPresentationSegments: unknown[];
-    };
-    slackData.renderedPresentationSegments.unshift({
-      kind: "text",
-      text: "Preface",
-      mrkdwn: false,
-    });
+    const renderedAfterTransport = jsonRoundTrip(rendered);
     await slackOutbound.afterDeliverPayload?.({
       cfg: {},
       target: { channel: "slack", to: "C123", accountId: "default" },
-      payload: rendered!,
-      results: [
-        { channel: "slack", messageId: "44", channelId: "C123" },
-        { channel: "slack", messageId: "55", channelId: "C123" },
-      ],
+      payload: renderedAfterTransport!,
+      results: [{ channel: "slack", messageId: "44", channelId: "C123" }],
     });
 
     await hoisted.registration?.finalize("Answered: <!channel>");
     expect(hoisted.update).toHaveBeenCalledWith(
       expect.objectContaining({
         channelId: "C123",
-        messageTs: "55",
+        messageTs: "44",
         text: expect.stringContaining("Answered: &lt;!channel&gt;"),
         blocks: expect.arrayContaining([
           {

--- a/extensions/slack/src/question-finalization.test.ts
+++ b/extensions/slack/src/question-finalization.test.ts
@@ -32,10 +32,17 @@ function jsonRoundTrip<T>(value: T): T {
 describe("Slack question finalization", () => {
   it("removes action blocks and appends terminal context", async () => {
     const questionId = "ask_0123456789abcdef0123456789abcdef";
+    const headers = Array.from({ length: 21 }, (_value, index) => `Column ${String(index)}`);
     const payload = {
       channelData: { askUser: { questionId } },
       presentation: {
         blocks: [
+          {
+            type: "table" as const,
+            caption: "Option metadata",
+            headers,
+            rows: [headers.map((_header, index) => `Value ${String(index)}`)],
+          },
           { type: "text" as const, text: "Pick one" },
           {
             type: "buttons" as const,
@@ -54,18 +61,30 @@ describe("Slack question finalization", () => {
     });
     expect(rendered).not.toBeNull();
     const renderedAfterTransport = jsonRoundTrip(rendered);
+    const renderedSegments = (
+      renderedAfterTransport?.channelData?.slack as
+        | { renderedPresentationSegments?: unknown[] }
+        | undefined
+    )?.renderedPresentationSegments;
+    expect(renderedSegments?.map((segment) => (segment as { kind?: unknown }).kind)).toEqual([
+      "text",
+      "blocks",
+    ]);
     await slackOutbound.afterDeliverPayload?.({
       cfg: {},
       target: { channel: "slack", to: "C123", accountId: "default" },
       payload: renderedAfterTransport!,
-      results: [{ channel: "slack", messageId: "44", channelId: "C123" }],
+      results: [
+        { channel: "slack", messageId: "44", channelId: "C123" },
+        { channel: "slack", messageId: "55", channelId: "C123" },
+      ],
     });
 
     await hoisted.registration?.finalize("Answered: <!channel>");
     expect(hoisted.update).toHaveBeenCalledWith(
       expect.objectContaining({
         channelId: "C123",
-        messageTs: "44",
+        messageTs: "55",
         text: expect.stringContaining("Answered: &lt;!channel&gt;"),
         blocks: expect.arrayContaining([
           {


### PR DESCRIPTION
Related: #111955

## What Problem This Solves

Provides a short-lived base-repository head for the secret-bearing Slack QA workflow to validate the exact reviewed commit from fork PR #111955.

## Why This Change Was Made

The QA trust policy intentionally rejects fork heads and unattached feature branches. This draft points at the exact #111955 head so the existing disposable Convex Slack lane can run without changing code or widening secret access.

## User Impact

None. This is a temporary QA carrier and must not be merged.

## Evidence

- Exact candidate: e1e3dba6815f58fd19ee767ddb7e98fb94797558
- Target scenario: slack-table-presentation-native
- This draft will be closed and its branch deleted after the QA run finishes.

DO NOT MERGE.
