### PR TITLE
fix(tui): prevent unsafe errors and out-of-order streamed replies

### DIFF
--- a/src/tui/components/chat-log.test.ts
+++ b/src/tui/components/chat-log.test.ts
@@ -126,9 +126,10 @@ describe("ChatLog", () => {
     expect(rendered.split("Hallo before the tool.")).toHaveLength(2);
     expect(rendered.split("Revised answer.")).toHaveLength(2);
     expect(chatLog.children.map((component) => component.constructor.name)).toEqual([
-      "AssistantMessageComponent",
       "ToolExecutionComponent",
+      "AssistantMessageComponent",
     ]);
+    expect(rendered.indexOf("Read File")).toBeLessThan(rendered.indexOf("Revised answer."));
 
     chatLog.updateAssistant("Hallo before the tool.\n\nRevised answer.\n\nNext segment.", "run-1");
 
@@ -151,10 +152,11 @@ describe("ChatLog", () => {
     expect(rendered.split("Final answer.")).toHaveLength(2);
     expect(rendered).not.toContain("Second segment.");
     expect(chatLog.children.map((component) => component.constructor.name)).toEqual([
+      "ToolExecutionComponent",
+      "ToolExecutionComponent",
       "AssistantMessageComponent",
-      "ToolExecutionComponent",
-      "ToolExecutionComponent",
     ]);
+    expect(rendered.lastIndexOf("Read File")).toBeLessThan(rendered.indexOf("Final answer."));
   });
 
   it("removes frozen provisional text when the final snapshot retracts it", () => {
@@ -168,7 +170,6 @@ describe("ChatLog", () => {
       "Retracted provisional answer.",
     );
     expect(chatLog.children.map((component) => component.constructor.name)).toEqual([
-      "AssistantMessageComponent",
       "ToolExecutionComponent",
     ]);
   });

--- a/src/tui/components/chat-log.test.ts
+++ b/src/tui/components/chat-log.test.ts
@@ -75,6 +75,181 @@ describe("ChatLog", () => {
     expect(chatLog.children.length).toBe(1);
   });
 
+  it("keeps cumulative assistant text in chronological order around a tool call", () => {
+    const chatLog = new ChatLog(40);
+
+    chatLog.updateAssistant("Before the tool.", "run-1");
+    chatLog.startTool("tool-1", "read_file", { path: "a.txt" });
+    chatLog.updateAssistant("Before the tool.\n\nAfter the tool.", "run-1");
+
+    const rendered = normalizeTestText(chatLog.render(120).join("\n"));
+    expect(chatLog.children.map((component) => component.constructor.name)).toEqual([
+      "AssistantMessageComponent",
+      "ToolExecutionComponent",
+      "AssistantMessageComponent",
+    ]);
+    expect(rendered.indexOf("Before the tool.")).toBeLessThan(rendered.indexOf("Read File"));
+    expect(rendered.indexOf("Read File")).toBeLessThan(rendered.indexOf("After the tool."));
+  });
+
+  it("does not repeat cumulative text across multiple tool calls", () => {
+    const chatLog = new ChatLog(40);
+
+    chatLog.updateAssistant("First segment.", "run-1");
+    chatLog.startTool("tool-1", "read_file", { path: "a.txt" });
+    chatLog.updateAssistant("First segment.\n\nSecond segment.", "run-1");
+    chatLog.startTool("tool-2", "read_file", { path: "b.txt" });
+    chatLog.updateAssistant("First segment.\n\nSecond segment.\n\nThird segment.", "run-1");
+
+    const rendered = normalizeTestText(chatLog.render(120).join("\n"));
+    for (const text of ["First segment.", "Second segment.", "Third segment."]) {
+      expect(rendered.split(text)).toHaveLength(2);
+    }
+    expect(chatLog.children.map((component) => component.constructor.name)).toEqual([
+      "AssistantMessageComponent",
+      "ToolExecutionComponent",
+      "AssistantMessageComponent",
+      "ToolExecutionComponent",
+      "AssistantMessageComponent",
+    ]);
+  });
+
+  it("reconciles revised assistant snapshots without repeating stale frozen text", () => {
+    const chatLog = new ChatLog(40);
+
+    chatLog.updateAssistant("Hello before the tool.", "run-1");
+    chatLog.startTool("tool-1", "read_file", { path: "a.txt" });
+    chatLog.updateAssistant("Hallo before the tool.\n\nRevised answer.", "run-1");
+
+    const rendered = normalizeTestText(chatLog.render(120).join("\n"));
+    expect(rendered).not.toContain("Hello before the tool.");
+    expect(rendered.split("Hallo before the tool.")).toHaveLength(2);
+    expect(rendered.split("Revised answer.")).toHaveLength(2);
+    expect(chatLog.children.map((component) => component.constructor.name)).toEqual([
+      "AssistantMessageComponent",
+      "ToolExecutionComponent",
+    ]);
+
+    chatLog.updateAssistant("Hallo before the tool.\n\nRevised answer.\n\nNext segment.", "run-1");
+
+    const continued = normalizeTestText(chatLog.render(120).join("\n"));
+    expect(continued.indexOf("Read File")).toBeLessThan(continued.indexOf("Next segment."));
+    expect(continued.split("Revised answer.")).toHaveLength(2);
+  });
+
+  it("reconciles a revised final snapshot after multiple frozen tool calls", () => {
+    const chatLog = new ChatLog(40);
+
+    chatLog.updateAssistant("First segment.", "run-1");
+    chatLog.startTool("tool-1", "read_file", { path: "a.txt" });
+    chatLog.updateAssistant("First segment.\n\nSecond segment.", "run-1");
+    chatLog.startTool("tool-2", "read_file", { path: "b.txt" });
+    chatLog.finalizeAssistant("Revised first segment.\n\nFinal answer.", "run-1");
+
+    const rendered = normalizeTestText(chatLog.render(120).join("\n"));
+    expect(rendered.split("Revised first segment.")).toHaveLength(2);
+    expect(rendered.split("Final answer.")).toHaveLength(2);
+    expect(rendered).not.toContain("Second segment.");
+    expect(chatLog.children.map((component) => component.constructor.name)).toEqual([
+      "AssistantMessageComponent",
+      "ToolExecutionComponent",
+      "ToolExecutionComponent",
+    ]);
+  });
+
+  it("removes frozen provisional text when the final snapshot retracts it", () => {
+    const chatLog = new ChatLog(40);
+
+    chatLog.updateAssistant("Retracted provisional answer.", "run-1");
+    chatLog.startTool("tool-1", "read_file", { path: "a.txt" });
+    chatLog.finalizeAssistant("", "run-1");
+
+    expect(normalizeTestText(chatLog.render(120).join("\n"))).not.toContain(
+      "Retracted provisional answer.",
+    );
+    expect(chatLog.children.map((component) => component.constructor.name)).toEqual([
+      "AssistantMessageComponent",
+      "ToolExecutionComponent",
+    ]);
+  });
+
+  it("preserves indentation in assistant text that follows a tool call", () => {
+    const chatLog = new ChatLog(40);
+
+    chatLog.updateAssistant("I ran it:", "run-1");
+    chatLog.startTool("tool-1", "read_file", { path: "a.txt" });
+    chatLog.updateAssistant("I ran it:\n\n    command output", "run-1");
+
+    const segment = chatLog.children.at(-1);
+    expect(segment?.constructor.name).toBe("AssistantMessageComponent");
+    const rendered = normalizeTestText(segment?.render(120).join("\n") ?? "");
+    expect(rendered).toContain("```");
+    expect(rendered).toMatch(/\n {2}command output/);
+  });
+
+  it("finalizes only assistant text that follows an intervening tool call", () => {
+    const chatLog = new ChatLog(40);
+
+    chatLog.updateAssistant("Before the tool.", "run-1");
+    chatLog.startTool("tool-1", "read_file", { path: "a.txt" });
+    chatLog.finalizeAssistant("Before the tool.\n\nFinal answer.", "run-1");
+
+    const rendered = normalizeTestText(chatLog.render(120).join("\n"));
+    expect(rendered.split("Before the tool.")).toHaveLength(2);
+    expect(rendered.indexOf("Read File")).toBeLessThan(rendered.indexOf("Final answer."));
+  });
+
+  it("does not add an empty final assistant segment after a tool call", () => {
+    const chatLog = new ChatLog(40);
+
+    chatLog.updateAssistant("Complete before the tool.", "run-1");
+    chatLog.startTool("tool-1", "read_file", { path: "a.txt" });
+    chatLog.finalizeAssistant("Complete before the tool.", "run-1");
+
+    expect(chatLog.children.map((component) => component.constructor.name)).toEqual([
+      "AssistantMessageComponent",
+      "ToolExecutionComponent",
+    ]);
+  });
+
+  it("clears frozen assistant segments when the chat history is rebuilt", () => {
+    const chatLog = new ChatLog(40);
+
+    chatLog.updateAssistant("Before the tool.", "run-1");
+    chatLog.startTool("tool-1", "read_file", { path: "a.txt" });
+    chatLog.clearAll();
+    chatLog.updateAssistant("Before the tool.\n\nNew history.", "run-1");
+
+    const rendered = normalizeTestText(chatLog.render(120).join("\n"));
+    expect(rendered).toContain("Before the tool.");
+    expect(rendered).toContain("New history.");
+    expect(chatLog.children).toHaveLength(1);
+  });
+
+  it("removes every frozen assistant segment when a tool-using run is dropped", () => {
+    const chatLog = new ChatLog(40);
+
+    chatLog.updateAssistant("First segment.", "run-1");
+    chatLog.startTool("tool-1", "read_file", { path: "a.txt" });
+    chatLog.updateAssistant("First segment.\n\nSecond segment.", "run-1");
+    chatLog.startTool("tool-2", "read_file", { path: "b.txt" });
+    chatLog.updateAssistant("First segment.\n\nSecond segment.\n\nThird segment.", "run-1");
+
+    chatLog.dropAssistant("run-1");
+
+    expect(chatLog.children.map((component) => component.constructor.name)).toEqual([
+      "ToolExecutionComponent",
+      "ToolExecutionComponent",
+    ]);
+    const rendered = normalizeTestText(chatLog.render(120).join("\n"));
+    expect(rendered).not.toContain("First segment.");
+    expect(rendered).not.toContain("Second segment.");
+    expect(rendered).not.toContain("Third segment.");
+
+    chatLog.updateAssistant("Fresh run.", "run-1");
+    expect(normalizeTestText(chatLog.render(120).join("\n"))).toContain("Fresh run.");
+  });
+
   it("reserves assistant position without clearing existing streamed text", () => {
     const chatLog = new ChatLog(40);
     chatLog.startAssistant("partial", "run-active");

--- a/src/tui/components/chat-log.test.ts
+++ b/src/tui/components/chat-log.test.ts
@@ -174,6 +174,21 @@ describe("ChatLog", () => {
     ]);
   });
 
+  it("removes an empty post-tool component when its final snapshot is retracted", () => {
+    const chatLog = new ChatLog(40);
+
+    chatLog.updateAssistant("Before the tool.", "run-1");
+    chatLog.startTool("tool-1", "read_file", { path: "a.txt" });
+    chatLog.updateAssistant("Before the tool.\n\nRetracted answer.", "run-1");
+    chatLog.finalizeAssistant("Before the tool.", "run-1");
+
+    expect(chatLog.children.map((component) => component.constructor.name)).toEqual([
+      "AssistantMessageComponent",
+      "ToolExecutionComponent",
+    ]);
+    expect(normalizeTestText(chatLog.render(120).join("\n"))).not.toContain("Retracted answer.");
+  });
+
   it("preserves indentation in assistant text that follows a tool call", () => {
     const chatLog = new ChatLog(40);
 

--- a/src/tui/components/chat-log.ts
+++ b/src/tui/components/chat-log.ts
@@ -22,6 +22,9 @@ export class ChatLog extends Container {
   private readonly maxComponents: number;
   private toolById = new Map<string, ToolExecutionComponent>();
   private streamingRuns = new Map<string, AssistantMessageComponent>();
+  private frozenAssistants = new Map<string, Set<AssistantMessageComponent>>();
+  private committedAssistantText = new Map<string, string>();
+  private latestAssistantText = new Map<string, string>();
   private pendingUsers = new Map<
     string,
     {
@@ -50,6 +53,14 @@ export class ChatLog extends Container {
     for (const [runId, message] of this.streamingRuns.entries()) {
       if (message === component) {
         this.streamingRuns.delete(runId);
+      }
+    }
+    if (component instanceof AssistantMessageComponent) {
+      for (const [runId, messages] of this.frozenAssistants.entries()) {
+        messages.delete(component);
+        if (messages.size === 0) {
+          this.frozenAssistants.delete(runId);
+        }
       }
     }
     for (const [runId, entry] of this.pendingUsers.entries()) {
@@ -95,6 +106,9 @@ export class ChatLog extends Container {
     this.clear();
     this.toolById.clear();
     this.streamingRuns.clear();
+    this.frozenAssistants.clear();
+    this.committedAssistantText.clear();
+    this.latestAssistantText.clear();
     this.pendingSystemNotices.clear();
     this.btwMessage = null;
     this.repeatableSystemMessage = null;
@@ -270,14 +284,63 @@ export class ChatLog extends Container {
     return runId ?? "default";
   }
 
+  private resolveAssistantSegment(runId: string, text: string) {
+    const committed = this.committedAssistantText.get(runId);
+    if (!committed) {
+      return text;
+    }
+    if (text.startsWith(committed)) {
+      return text.slice(committed.length).replace(/^(?:\r?\n)+/u, "");
+    }
+
+    // A revised provider snapshot cannot be split at an obsolete tool boundary.
+    // Collapse its old segments instead of rendering both the stale and replacement answer.
+    const frozen = this.frozenAssistants.get(runId);
+    if (!frozen?.size) {
+      return text;
+    }
+    const [first, ...superseded] = frozen;
+    if (!first) {
+      return text;
+    }
+    first.setText(text);
+    for (const component of superseded) {
+      this.removeChild(component);
+      frozen.delete(component);
+    }
+    const streaming = this.streamingRuns.get(runId);
+    if (streaming) {
+      this.removeChild(streaming);
+      this.streamingRuns.delete(runId);
+    }
+    this.committedAssistantText.set(runId, text);
+    return "";
+  }
+
+  // Tool rows freeze earlier cumulative text so later deltas render below the tool.
+  private freezeStreamingAssistants() {
+    for (const [runId, component] of this.streamingRuns) {
+      let frozen = this.frozenAssistants.get(runId);
+      if (!frozen) {
+        frozen = new Set();
+        this.frozenAssistants.set(runId, frozen);
+      }
+      frozen.add(component);
+      this.committedAssistantText.set(runId, this.latestAssistantText.get(runId) ?? "");
+    }
+    this.streamingRuns.clear();
+  }
+
   startAssistant(text: string, runId?: string) {
     const effectiveRunId = this.resolveRunId(runId);
+    this.latestAssistantText.set(effectiveRunId, text);
+    const segmentText = this.resolveAssistantSegment(effectiveRunId, text);
     const existing = this.streamingRuns.get(effectiveRunId);
     if (existing) {
-      existing.setText(text);
+      existing.setText(segmentText);
       return existing;
     }
-    const component = new AssistantMessageComponent(text);
+    const component = new AssistantMessageComponent(segmentText);
     this.streamingRuns.set(effectiveRunId, component);
     this.appendNonSystem(component);
     return component;
@@ -294,27 +357,44 @@ export class ChatLog extends Container {
 
   updateAssistant(text: string, runId?: string) {
     const effectiveRunId = this.resolveRunId(runId);
+    this.latestAssistantText.set(effectiveRunId, text);
+    const segmentText = this.resolveAssistantSegment(effectiveRunId, text);
     const existing = this.streamingRuns.get(effectiveRunId);
     if (!existing) {
+      if (!segmentText && this.committedAssistantText.has(effectiveRunId)) {
+        return;
+      }
       this.startAssistant(text, runId);
       return;
     }
-    existing.setText(text);
+    existing.setText(segmentText);
   }
 
   finalizeAssistant(text: string, runId?: string) {
     const effectiveRunId = this.resolveRunId(runId);
     const existing = this.streamingRuns.get(effectiveRunId);
+    const segmentText = this.resolveAssistantSegment(effectiveRunId, text);
+    this.frozenAssistants.delete(effectiveRunId);
+    this.committedAssistantText.delete(effectiveRunId);
+    this.latestAssistantText.delete(effectiveRunId);
     if (existing) {
-      existing.setText(text);
+      existing.setText(segmentText);
       this.streamingRuns.delete(effectiveRunId);
       return;
     }
-    this.appendNonSystem(new AssistantMessageComponent(text));
+    if (segmentText) {
+      this.appendNonSystem(new AssistantMessageComponent(segmentText));
+    }
   }
 
   dropAssistant(runId?: string) {
     const effectiveRunId = this.resolveRunId(runId);
+    for (const component of this.frozenAssistants.get(effectiveRunId) ?? []) {
+      this.removeChild(component);
+    }
+    this.frozenAssistants.delete(effectiveRunId);
+    this.committedAssistantText.delete(effectiveRunId);
+    this.latestAssistantText.delete(effectiveRunId);
     const existing = this.streamingRuns.get(effectiveRunId);
     if (!existing) {
       return;
@@ -356,6 +436,7 @@ export class ChatLog extends Container {
       existing.setArgs(args);
       return existing;
     }
+    this.freezeStreamingAssistants();
     const component = new ToolExecutionComponent(toolName, args);
     component.setExpanded(this.toolsExpanded);
     this.toolById.set(toolCallId, component);

--- a/src/tui/components/chat-log.ts
+++ b/src/tui/components/chat-log.ts
@@ -294,27 +294,22 @@ export class ChatLog extends Container {
     }
 
     // A revised provider snapshot cannot be split at an obsolete tool boundary.
-    // Collapse its old segments instead of rendering both the stale and replacement answer.
+    // Drop obsolete segments so the authoritative replacement lands after the tools.
     const frozen = this.frozenAssistants.get(runId);
     if (!frozen?.size) {
       return text;
     }
-    const [first, ...superseded] = frozen;
-    if (!first) {
-      return text;
-    }
-    first.setText(text);
-    for (const component of superseded) {
+    for (const component of frozen) {
       this.removeChild(component);
-      frozen.delete(component);
     }
+    this.frozenAssistants.delete(runId);
     const streaming = this.streamingRuns.get(runId);
     if (streaming) {
       this.removeChild(streaming);
       this.streamingRuns.delete(runId);
     }
-    this.committedAssistantText.set(runId, text);
-    return "";
+    this.committedAssistantText.delete(runId);
+    return text;
   }
 
   // Tool rows freeze earlier cumulative text so later deltas render below the tool.
@@ -372,8 +367,8 @@ export class ChatLog extends Container {
 
   finalizeAssistant(text: string, runId?: string) {
     const effectiveRunId = this.resolveRunId(runId);
-    const existing = this.streamingRuns.get(effectiveRunId);
     const segmentText = this.resolveAssistantSegment(effectiveRunId, text);
+    const existing = this.streamingRuns.get(effectiveRunId);
     this.frozenAssistants.delete(effectiveRunId);
     this.committedAssistantText.delete(effectiveRunId);
     this.latestAssistantText.delete(effectiveRunId);

--- a/src/tui/components/chat-log.ts
+++ b/src/tui/components/chat-log.ts
@@ -373,7 +373,11 @@ export class ChatLog extends Container {
     this.committedAssistantText.delete(effectiveRunId);
     this.latestAssistantText.delete(effectiveRunId);
     if (existing) {
-      existing.setText(segmentText);
+      if (segmentText) {
+        existing.setText(segmentText);
+      } else {
+        this.removeChild(existing);
+      }
       this.streamingRuns.delete(effectiveRunId);
       return;
     }

--- a/src/tui/embedded-backend.test.ts
+++ b/src/tui/embedded-backend.test.ts
@@ -1007,7 +1007,7 @@ describe("EmbeddedTuiBackend", () => {
     await expect(backend.loadHistory({ sessionKey: "agent:main:main" })).resolves.toMatchObject({
       sessionKey: "agent:main:main",
       messages: [],
-      runtimePluginsPrewarm: { status: "failed", error: "Error: runtime unavailable" },
+      runtimePluginsPrewarm: { status: "failed", error: "runtime unavailable" },
     });
   });
 

--- a/src/tui/embedded-backend.ts
+++ b/src/tui/embedded-backend.ts
@@ -112,6 +112,7 @@ import type {
   TuiSessionList,
   TuiSessionCreateOptions,
 } from "./tui-backend.js";
+import { formatTuiErrorMessage } from "./tui-formatters.js";
 
 type LocalRunState = {
   sessionKey: string;
@@ -203,7 +204,7 @@ function ensureEmbeddedHistoryRuntimePluginsLoaded(params: {
     });
     return { status: "warmed" };
   } catch (err) {
-    return { status: "failed", error: String(err) };
+    return { status: "failed", error: formatTuiErrorMessage(err) };
   }
 }
 

--- a/src/tui/tui-command-handlers.test.ts
+++ b/src/tui/tui-command-handlers.test.ts
@@ -1538,9 +1538,25 @@ describe("tui command handlers", () => {
 
     await handleCommand("/context detail");
 
-    expect(addSystem).toHaveBeenCalledWith("send failed: Error: gateway down");
+    expect(addSystem).toHaveBeenCalledWith("send failed: gateway down");
     expect(setActivityStatus).toHaveBeenLastCalledWith("error");
     expect(state.pendingSubmit).toBeNull();
+  });
+
+  it("redacts secrets and preserves nested causes in displayed send failures", async () => {
+    const secret = "sk-abcdefghijklmnopqrstuv";
+    const cause = new Error(`\u001b[31mAuthorization: Bearer ${secret}\u001b[0m`);
+    const { handleCommand, addSystem } = createHarness({
+      sendChat: vi.fn().mockRejectedValue(new Error("gateway down", { cause })),
+    });
+
+    await handleCommand("/context detail");
+
+    const message = addSystem.mock.calls.at(-1)?.[0];
+    expect(message).toContain("send failed: gateway down");
+    expect(message).toContain("Authorization: Bearer");
+    expect(message).not.toContain(secret);
+    expect(message).not.toContain("\u001b");
   });
 
   it("sanitizes control sequences in /new and /reset failures", async () => {
@@ -1554,8 +1570,8 @@ describe("tui command handlers", () => {
     await handleCommand("/new");
     await handleCommand("/reset");
 
-    expect(addSystem).toHaveBeenNthCalledWith(1, "new session failed: Error: boom");
-    expect(addSystem).toHaveBeenNthCalledWith(2, "reset failed: Error: boom");
+    expect(addSystem).toHaveBeenNthCalledWith(1, "new session failed: boom");
+    expect(addSystem).toHaveBeenNthCalledWith(2, "reset failed: boom");
   });
 
   it("reports disconnected status and skips gateway send when offline", async () => {

--- a/src/tui/tui-command-handlers.ts
+++ b/src/tui/tui-command-handlers.ts
@@ -33,7 +33,7 @@ import {
 } from "./components/selectors.js";
 import type { TuiBackend, TuiSessionMutationResult } from "./tui-backend.js";
 import { addBlockedChatSubmitNotice } from "./tui-busy-notice.js";
-import { sanitizeRenderableText } from "./tui-formatters.js";
+import { formatTuiErrorMessage } from "./tui-formatters.js";
 import {
   TUI_RECENT_SESSIONS_ACTIVE_MINUTES,
   TUI_SESSION_PICKER_LIMIT,
@@ -272,14 +272,14 @@ export function createCommandHandlers(context: CommandHandlerContext) {
           applySessionInfoFromPatch(result);
           await refreshSessionInfo();
         } catch (err) {
-          chatLog.addSystem(`model set failed: ${String(err)}`);
+          chatLog.addSystem(`model set failed: ${formatTuiErrorMessage(err)}`);
         }
       });
     } catch (err) {
       if (!isCurrentSessionSelection(selection)) {
         return;
       }
-      chatLog.addSystem(`model list failed: ${String(err)}`);
+      chatLog.addSystem(`model list failed: ${formatTuiErrorMessage(err)}`);
       tui.requestRender();
     }
   };
@@ -378,7 +378,7 @@ export function createCommandHandlers(context: CommandHandlerContext) {
       if (!isCurrentSessionSelection(selection)) {
         return;
       }
-      chatLog.addSystem(`sessions list failed: ${String(err)}`);
+      chatLog.addSystem(`sessions list failed: ${formatTuiErrorMessage(err)}`);
       tui.requestRender();
     }
   };
@@ -476,7 +476,7 @@ export function createCommandHandlers(context: CommandHandlerContext) {
             setActivityStatus("error");
           }
         } catch (err) {
-          chatLog.addSystem(`auth flow failed: ${sanitizeRenderableText(String(err))}`);
+          chatLog.addSystem(`auth flow failed: ${formatTuiErrorMessage(err)}`);
           setActivityStatus("error");
         }
         break;
@@ -497,7 +497,7 @@ export function createCommandHandlers(context: CommandHandlerContext) {
           }
           chatLog.addSystem("status: unknown response");
         } catch (err) {
-          chatLog.addSystem(`status failed: ${String(err)}`);
+          chatLog.addSystem(`status failed: ${formatTuiErrorMessage(err)}`);
         }
         break;
       case "agent":
@@ -534,7 +534,7 @@ export function createCommandHandlers(context: CommandHandlerContext) {
               await sendMessage(continuation);
             }
           } catch (err) {
-            chatLog.addSystem(`goal failed: ${sanitizeRenderableText(String(err))}`);
+            chatLog.addSystem(`goal failed: ${formatTuiErrorMessage(err)}`);
           }
         } else {
           await sendMessage(raw);
@@ -591,7 +591,7 @@ export function createCommandHandlers(context: CommandHandlerContext) {
             applySessionInfoFromPatch(result);
             await refreshSessionInfo();
           } catch (err) {
-            chatLog.addSystem(`model set failed: ${String(err)}`);
+            chatLog.addSystem(`model set failed: ${formatTuiErrorMessage(err)}`);
           }
         }
         break;
@@ -621,7 +621,7 @@ export function createCommandHandlers(context: CommandHandlerContext) {
           applySessionInfoFromPatch(result);
           await refreshSessionInfo();
         } catch (err) {
-          chatLog.addSystem(`think failed: ${String(err)}`);
+          chatLog.addSystem(`think failed: ${formatTuiErrorMessage(err)}`);
         }
         break;
       case "verbose":
@@ -643,7 +643,7 @@ export function createCommandHandlers(context: CommandHandlerContext) {
             await loadHistory();
           }
         } catch (err) {
-          chatLog.addSystem(`verbose failed: ${String(err)}`);
+          chatLog.addSystem(`verbose failed: ${formatTuiErrorMessage(err)}`);
         }
         break;
       case "trace":
@@ -660,7 +660,7 @@ export function createCommandHandlers(context: CommandHandlerContext) {
           applySessionInfoFromPatch(result);
           await refreshSessionInfo();
         } catch (err) {
-          chatLog.addSystem(`trace failed: ${String(err)}`);
+          chatLog.addSystem(`trace failed: ${formatTuiErrorMessage(err)}`);
         }
         break;
       case "fast":
@@ -683,7 +683,7 @@ export function createCommandHandlers(context: CommandHandlerContext) {
           applySessionInfoFromPatch(result);
           await refreshSessionInfo();
         } catch (err) {
-          chatLog.addSystem(`fast failed: ${String(err)}`);
+          chatLog.addSystem(`fast failed: ${formatTuiErrorMessage(err)}`);
         }
         break;
       case "reasoning":
@@ -700,7 +700,7 @@ export function createCommandHandlers(context: CommandHandlerContext) {
           applySessionInfoFromPatch(result);
           await refreshSessionInfo();
         } catch (err) {
-          chatLog.addSystem(`reasoning failed: ${String(err)}`);
+          chatLog.addSystem(`reasoning failed: ${formatTuiErrorMessage(err)}`);
         }
         break;
       case "usage": {
@@ -722,7 +722,7 @@ export function createCommandHandlers(context: CommandHandlerContext) {
             delete state.sessionInfo.effectiveResponseUsage;
             await refreshSessionInfo();
           } catch (err) {
-            chatLog.addSystem(`usage failed: ${String(err)}`);
+            chatLog.addSystem(`usage failed: ${formatTuiErrorMessage(err)}`);
           }
           break;
         }
@@ -740,7 +740,7 @@ export function createCommandHandlers(context: CommandHandlerContext) {
           applySessionInfoFromPatch(result);
           await refreshSessionInfo();
         } catch (err) {
-          chatLog.addSystem(`usage failed: ${String(err)}`);
+          chatLog.addSystem(`usage failed: ${formatTuiErrorMessage(err)}`);
         }
         break;
       }
@@ -762,7 +762,7 @@ export function createCommandHandlers(context: CommandHandlerContext) {
           applySessionInfoFromPatch(result);
           await refreshSessionInfo();
         } catch (err) {
-          chatLog.addSystem(`elevated failed: ${String(err)}`);
+          chatLog.addSystem(`elevated failed: ${formatTuiErrorMessage(err)}`);
         }
         break;
       case "activation": {
@@ -784,7 +784,7 @@ export function createCommandHandlers(context: CommandHandlerContext) {
           applySessionInfoFromPatch(result);
           await refreshSessionInfo();
         } catch (err) {
-          chatLog.addSystem(`activation failed: ${String(err)}`);
+          chatLog.addSystem(`activation failed: ${formatTuiErrorMessage(err)}`);
         }
         break;
       }
@@ -814,7 +814,7 @@ export function createCommandHandlers(context: CommandHandlerContext) {
           await setSession(result.key);
           chatLog.addSystem(`new session: ${result.key}`);
         } catch (err) {
-          chatLog.addSystem(`new session failed: ${sanitizeRenderableText(String(err))}`);
+          chatLog.addSystem(`new session failed: ${formatTuiErrorMessage(err)}`);
         } finally {
           sessionCreationInFlight = false;
         }
@@ -856,7 +856,7 @@ export function createCommandHandlers(context: CommandHandlerContext) {
           if (!isCurrentSessionSelection(resetResultSelection)) {
             return;
           }
-          chatLog.addSystem(`reset failed: ${sanitizeRenderableText(String(err))}`);
+          chatLog.addSystem(`reset failed: ${formatTuiErrorMessage(err)}`);
         }
         break;
       }
@@ -1029,7 +1029,7 @@ export function createCommandHandlers(context: CommandHandlerContext) {
         clearPendingSubmit(state, runId);
         chatLog.dropPendingUser(runId);
       }
-      chatLog.addSystem(`${isBtw ? "btw failed" : "send failed"}: ${String(err)}`);
+      chatLog.addSystem(`${isBtw ? "btw failed" : "send failed"}: ${formatTuiErrorMessage(err)}`);
       if (!isBtw) {
         setActivityStatus("error");
       }

--- a/src/tui/tui-formatters.test.ts
+++ b/src/tui/tui-formatters.test.ts
@@ -8,6 +8,7 @@ import {
   extractThinkingFromMessage,
   formatModelFooter,
   formatGoalFooter,
+  formatTuiErrorMessage,
   isCommandMessage,
   sanitizeRenderableText,
 } from "./tui-formatters.js";
@@ -359,6 +360,20 @@ describe("isCommandMessage", () => {
     expect(isCommandMessage({ command: true })).toBe(true);
     expect(isCommandMessage({ command: false })).toBe(false);
     expect(isCommandMessage({})).toBe(false);
+  });
+});
+
+describe("formatTuiErrorMessage", () => {
+  it("redacts and sanitizes terminal escapes in nested error causes", () => {
+    const secret = "sk-abcdefghijklmnopqrstuv";
+    const cause = new Error(`\u001b[31mAuthorization: Bearer ${secret}\u001b[0m`);
+
+    const formatted = formatTuiErrorMessage(new Error("gateway down", { cause }));
+
+    expect(formatted).toContain("gateway down");
+    expect(formatted).toContain("Authorization: Bearer");
+    expect(formatted).not.toContain(secret);
+    expect(formatted).not.toContain("\u001b");
   });
 });
 

--- a/src/tui/tui-formatters.ts
+++ b/src/tui/tui-formatters.ts
@@ -3,6 +3,7 @@ import { stripAnsi } from "../../packages/terminal-core/src/ansi.js";
 import { splitTrailingAuthProfile } from "../agents/model-ref-profile.js";
 import { stripLeadingInboundMetadata } from "../auto-reply/reply/strip-inbound-meta.js";
 import type { SessionGoal } from "../config/sessions/types.js";
+import { formatErrorMessage } from "../infra/errors.js";
 import { formatRawAssistantErrorForUi } from "../shared/assistant-error-format.js";
 import { extractAssistantVisibleText } from "../shared/chat-message-content.js";
 import { chunkTextByBreakResolver } from "../shared/text-chunking.js";
@@ -218,6 +219,11 @@ export function sanitizeRenderableText(text: string): string {
       )
     : redacted;
   return applyRtlIsolation(tokenSafe);
+}
+
+/** Render error causes without exposing secrets or terminal control sequences. */
+export function formatTuiErrorMessage(error: unknown): string {
+  return sanitizeRenderableText(formatErrorMessage(error));
 }
 
 export function resolveFinalAssistantText(params: {

--- a/src/tui/tui-local-shell.ts
+++ b/src/tui/tui-local-shell.ts
@@ -5,6 +5,7 @@ import type { Component, OverlayHandle, SelectItem } from "@earendil-works/pi-tu
 import { sliceUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import { tryProcessCwd } from "../infra/safe-cwd.js";
 import { createSearchableSelectList } from "./components/selectors.js";
+import { formatTuiErrorMessage } from "./tui-formatters.js";
 
 type LocalShellDeps = {
   chatLog: {
@@ -165,7 +166,7 @@ export function createLocalShellRunner(deps: LocalShellDeps) {
       });
 
       child.on("error", (err) => {
-        deps.chatLog.addSystem(`[local] error: ${String(err)}`);
+        deps.chatLog.addSystem(`[local] error: ${formatTuiErrorMessage(err)}`);
         deps.tui.requestRender();
         resolve();
       });

--- a/src/tui/tui-pty-harness-fixture-test-support.ts
+++ b/src/tui/tui-pty-harness-fixture-test-support.ts
@@ -32,6 +32,7 @@ export async function writeTuiPtyFixtureScript(dir: string) {
       const startupDelayMs = Number(process.env.OPENCLAW_TUI_PTY_STARTUP_DELAY_MS ?? 0);
       const footerModel = process.env.OPENCLAW_TUI_PTY_MODEL;
       const footerThinkingLevel = process.env.OPENCLAW_TUI_PTY_THINKING_LEVEL;
+      let verboseLevel = process.env.OPENCLAW_TUI_PTY_VERBOSE_LEVEL;
       const launchThinkingLevel = process.env.OPENCLAW_TUI_PTY_LAUNCH_THINKING;
       const initialMessage = process.env.OPENCLAW_TUI_PTY_INITIAL_MESSAGE;
       const enablePickerFixture = process.env.OPENCLAW_TUI_PTY_PICKER_FIXTURE === "1";
@@ -79,6 +80,7 @@ export async function writeTuiPtyFixtureScript(dir: string) {
           contextTokens: 128,
           fastMode,
           ...(currentThinkingLevel ? { thinkingLevel: currentThinkingLevel } : {}),
+          ...(verboseLevel ? { verboseLevel } : {}),
           thinkingLevels: [],
         };
       }
@@ -132,6 +134,37 @@ export async function writeTuiPtyFixtureScript(dir: string) {
             thinking: opts.thinking,
           });
           const runId = opts.runId ?? "run-pty-fixture";
+          if (opts.message === "tui error redaction proof") {
+            const escape = String.fromCharCode(27);
+            throw new Error("gateway down", {
+              cause: new Error(escape + "[31mAuthorization: Bearer sk-abcdefghijklmnopqrstuv" + escape + "[0m"),
+            });
+          }
+          if (opts.message === "tool chronology proof") {
+            setTimeout(() => {
+              const emitAssistant = (state, text) => {
+                const message = {
+                  role: "assistant",
+                  content: [{ type: "text", text }],
+                  timestamp: Date.now(),
+                };
+                this.onEvent?.({ event: "chat", payload: { runId, sessionKey: opts.sessionKey, state, message } });
+              };
+              emitAssistant("delta", "PTY_BEFORE_TOOL");
+              const data = {
+                phase: "start",
+                toolCallId: "pty-chronology-tool",
+                name: "read_file",
+                args: { path: "chronology-proof.txt" },
+              };
+              this.onEvent?.({ event: "agent", payload: { runId, sessionKey: opts.sessionKey, stream: "tool", data } });
+              const completeText = "PTY_BEFORE_TOOL\\n\\nPTY_AFTER_TOOL";
+              emitAssistant("delta", completeText);
+              emitAssistant("final", completeText);
+              record("toolChronologyComplete", { runId });
+            }, 0);
+            return { runId };
+          }
           if (opts.message === "/btw picker focus proof") {
             queueMicrotask(() => {
               record("pickerSideResult", { runId, sessionKey: opts.sessionKey });
@@ -432,6 +465,9 @@ export async function writeTuiPtyFixtureScript(dir: string) {
           }
           if (typeof opts.fastMode === "boolean") {
             fastMode = opts.fastMode;
+          }
+          if (typeof opts.verboseLevel === "string") {
+            verboseLevel = opts.verboseLevel;
           }
           return {
             ok: true,

--- a/src/tui/tui-pty-harness.e2e.test.ts
+++ b/src/tui/tui-pty-harness.e2e.test.ts
@@ -455,6 +455,55 @@ describe.sequential("TUI PTY harness", () => {
   );
 
   it(
+    "renders redacted, cause-aware send failures in the real terminal loop",
+    async () => {
+      await fixture.run.write("tui error redaction proof\r");
+      await fixture.run.waitForOutput("send failed: gateway down");
+      await fixture.run.waitForOutput("Authorization: Bearer");
+
+      expect(fixture.run.visibleOutput()).not.toContain("sk-abcdefghijklmnopqrstuv");
+      await fixture.waitForLogEntry(
+        (entry) =>
+          entry.method === "sendChat" &&
+          objectFieldEquals(entry, "message", "tui error redaction proof"),
+      );
+    },
+    TEST_TIMEOUT_MS,
+  );
+
+  it(
+    "renders cumulative streamed text below the intervening tool in a real terminal",
+    async () => {
+      const chronologyFixture = await startTuiFixture({
+        env: {
+          OPENCLAW_TUI_PTY_MODEL: "fixture-provider/fixture-model",
+          OPENCLAW_TUI_PTY_VERBOSE_LEVEL: "on",
+        },
+      });
+
+      try {
+        await chronologyFixture.run.waitForOutput("local ready", STARTUP_TIMEOUT_MS);
+        await chronologyFixture.run.write("tool chronology proof\r");
+        await chronologyFixture.waitForLogEntry(
+          (entry) => entry.method === "toolChronologyComplete",
+        );
+        await chronologyFixture.run.waitForOutput("PTY_AFTER_TOOL");
+
+        const rendered = chronologyFixture.run.visibleOutput();
+        expect(rendered.lastIndexOf("PTY_BEFORE_TOOL")).toBeLessThan(
+          rendered.lastIndexOf("Read File"),
+        );
+        expect(rendered.lastIndexOf("Read File")).toBeLessThan(
+          rendered.lastIndexOf("PTY_AFTER_TOOL"),
+        );
+      } finally {
+        await chronologyFixture.cleanup();
+      }
+    },
+    STARTUP_TEST_TIMEOUT_MS,
+  );
+
+  it(
     "blocks overlapping normal messages while a run is busy",
     async () => {
       await fixture.run.write("slow prompt\r");

--- a/src/tui/tui-session-actions.ts
+++ b/src/tui/tui-session-actions.ts
@@ -12,7 +12,12 @@ import {
 } from "../routing/session-key.js";
 import type { ChatLog } from "./components/chat-log.js";
 import type { TuiAgentsList, TuiBackend, TuiSessionMutationResult } from "./tui-backend.js";
-import { asString, extractTextFromMessage, isCommandMessage } from "./tui-formatters.js";
+import {
+  asString,
+  extractTextFromMessage,
+  formatTuiErrorMessage,
+  isCommandMessage,
+} from "./tui-formatters.js";
 import { TUI_SESSION_LOOKUP_LIMIT } from "./tui-session-list-policy.js";
 import * as submit from "./tui-submit-state.js";
 import type { SessionInfo, TuiHistoryLoadResult, TuiOptions, TuiStateAccess } from "./tui-types.js";
@@ -197,7 +202,7 @@ export function createSessionActions(context: SessionActionContext) {
       const result = await client.listAgents();
       applyAgentsResult(result);
     } catch (err) {
-      chatLog.addSystem(`agents list failed: ${String(err)}`);
+      chatLog.addSystem(`agents list failed: ${formatTuiErrorMessage(err)}`);
     }
   };
 
@@ -393,7 +398,7 @@ export function createSessionActions(context: SessionActionContext) {
       if (!isCurrentRefresh()) {
         return;
       }
-      chatLog.addSystem(`sessions list failed: ${String(err)}`);
+      chatLog.addSystem(`sessions list failed: ${formatTuiErrorMessage(err)}`);
     }
   };
 
@@ -627,7 +632,7 @@ export function createSessionActions(context: SessionActionContext) {
       if (!isCurrentLoad()) {
         return { loaded: false };
       }
-      chatLog.addSystem(`history failed: ${String(err)}`);
+      chatLog.addSystem(`history failed: ${formatTuiErrorMessage(err)}`);
       tui.requestRender(true);
       return { loaded: false };
     }
@@ -707,7 +712,7 @@ export function createSessionActions(context: SessionActionContext) {
       if (!isCurrentSessionSelection(selection)) {
         return;
       }
-      chatLog.addSystem(`abort failed: ${String(err)}`);
+      chatLog.addSystem(`abort failed: ${formatTuiErrorMessage(err)}`);
       setActivityStatus("abort failed");
     }
     tui.requestRender();

--- a/src/tui/tui.ts
+++ b/src/tui/tui.ts
@@ -17,7 +17,6 @@ import type { CommandEntry } from "../../packages/gateway-protocol/src/index.js"
 import { resolveAgentIdByWorkspacePath, resolveDefaultAgentId } from "../agents/agent-scope.js";
 import { normalizeThinkLevel } from "../auto-reply/thinking.shared.js";
 import { getRuntimeConfig, type OpenClawConfig } from "../config/config.js";
-import { formatErrorMessage } from "../infra/errors.js";
 import { tryProcessCwd } from "../infra/safe-cwd.js";
 import { registerUncaughtExceptionHandler } from "../infra/unhandled-rejections.js";
 import { getWindowsSystem32ExePath } from "../infra/windows-install-roots.js";
@@ -48,7 +47,7 @@ import { createEventHandlers } from "./tui-event-handlers.js";
 import {
   formatGoalFooter,
   formatModelFooter,
-  sanitizeRenderableText,
+  formatTuiErrorMessage,
   formatTokens,
 } from "./tui-formatters.js";
 import {
@@ -1458,7 +1457,7 @@ export async function runTui(opts: RunTuiOptions): Promise<TuiResult> {
       onError: (err) => {
         if (!isTuiTerminalLossError(err)) {
           try {
-            process.stderr.write(`openclaw tui shutdown failed: ${String(err)}\n`);
+            process.stderr.write(`openclaw tui shutdown failed: ${formatTuiErrorMessage(err)}\n`);
           } catch {
             // Best effort only; exit must still complete.
           }
@@ -1528,7 +1527,7 @@ export async function runTui(opts: RunTuiOptions): Promise<TuiResult> {
     tui.requestRender();
   };
   const notifySubmitError = (action: TuiSubmitAction, error: unknown) => {
-    const message = sanitizeRenderableText(formatErrorMessage(error));
+    const message = formatTuiErrorMessage(error);
     chatLog.addSystem(`${action} submit failed: ${message}`);
     tui.requestRender();
   };
@@ -1680,7 +1679,7 @@ export async function runTui(opts: RunTuiOptions): Promise<TuiResult> {
         if (!ownsConnection()) {
           return;
         }
-        chatLog.addSystem(`session event subscribe failed: ${String(err)}`);
+        chatLog.addSystem(`session event subscribe failed: ${formatTuiErrorMessage(err)}`);
       }
       if (!ownsConnection()) {
         return;
@@ -1701,7 +1700,7 @@ export async function runTui(opts: RunTuiOptions): Promise<TuiResult> {
         if (!ownsConnection()) {
           return;
         }
-        chatLog.addSystem(`plugin approval refresh failed: ${String(err)}`);
+        chatLog.addSystem(`plugin approval refresh failed: ${formatTuiErrorMessage(err)}`);
       }
       if (!ownsConnection()) {
         return;
@@ -1712,7 +1711,7 @@ export async function runTui(opts: RunTuiOptions): Promise<TuiResult> {
         if (!ownsConnection()) {
           return;
         }
-        chatLog.addSystem(`task suggestion refresh failed: ${String(err)}`);
+        chatLog.addSystem(`task suggestion refresh failed: ${formatTuiErrorMessage(err)}`);
       }
       if (!ownsConnection()) {
         return;
@@ -1744,7 +1743,7 @@ export async function runTui(opts: RunTuiOptions): Promise<TuiResult> {
       if (!ownsConnection()) {
         return;
       }
-      chatLog.addSystem(`startup failed: ${String(err)}`);
+      chatLog.addSystem(`startup failed: ${formatTuiErrorMessage(err)}`);
       if (activityStatus === "starting up") {
         setActivityStatus("idle");
       }
@@ -1795,12 +1794,12 @@ export async function runTui(opts: RunTuiOptions): Promise<TuiResult> {
       try {
         await pluginApprovals?.refresh();
       } catch (err) {
-        chatLog.addSystem(`plugin approval refresh failed: ${String(err)}`);
+        chatLog.addSystem(`plugin approval refresh failed: ${formatTuiErrorMessage(err)}`);
       }
       try {
         await taskSuggestions?.refresh();
       } catch (err) {
-        chatLog.addSystem(`task suggestion refresh failed: ${String(err)}`);
+        chatLog.addSystem(`task suggestion refresh failed: ${formatTuiErrorMessage(err)}`);
       }
     })();
     tui.requestRender();


### PR DESCRIPTION
Related: #104639
Related: #103147

## What Problem This Solves

Fixes an issue where TUI users saw raw errors that could expose bearer tokens or terminal control sequences when a Gateway, session, model, shell, or startup operation failed. Fixes an issue where streamed assistant replies appeared above intervening tool calls, duplicated text across multiple tools, or left stale text after cancellations or provider snapshot revisions.

## Why This Change Was Made

Routes every affected TUI error through one existing-contract, cause-aware, secret-redacting, terminal-safe formatter. Keeps chronological segmentation in the ChatLog owner without changing Gateway protocol, provider catalogs, TUI verbosity, dependencies, or user configuration. Frozen assistant segments remain owned by their run and safely reconcile revised or retracted provider snapshots.

This independently validated current-main fix is based on the concrete reports in #104639 by @Marnie0415 and #103147 by @Foxy6670. Both contributors are credited in the corresponding git commits. The broader tool-card and verbosity product changes proposed in #103147 are intentionally not bundled.

## User Impact

TUI errors retain helpful nested causes without leaking secrets or ANSI/OSC controls. Assistant text appears in the correct order around tool calls; indentation, repeated calls, run cancellation, revised snapshots, empty retractions, and removal of abandoned assistant rows remain correct.

## Evidence

- Red baseline on clean main: seven focused regression assertions fail for raw Gateway/send errors, runtime prewarm formatting, secret leakage, and one/multiple tool chronology.
- Green exact-head full TUI suite: 890 tests across 35 files on Blacksmith Testbox.
- Real terminal proof: 58 PTY cases, including a real Gateway WebSocket, real cross-client delivery, Gateway restart, real embedded backend, streaming, cancellation, session isolation, and targeted visible-output regressions for redacted errors and chronological tool rendering; final-head fake-backend PTY recheck: all 42 cases passed.
- Type-aware TUI lint: all 81 files, zero errors and zero warnings.
- Production build: CLI, runtime, all 143 plugin SDK subpaths, and Control UI pass.
- Final committed branch independently reviewed; no accepted findings.
- AI-assisted; manually traced against current main, the canonical normalization/redaction contract, both contributor PRs, callers, session replay, streaming, cancellation, authoritative snapshot revision, and PTY behavior.