### PR TITLE
chore(messages): guard delegated alias authorization order

### DIFF
--- a/src/infra/outbound/message-action-runner.plugin-dispatch.test.ts
+++ b/src/infra/outbound/message-action-runner.plugin-dispatch.test.ts
@@ -890,6 +890,70 @@ describe("runMessageAction plugin dispatch", () => {
       },
     );
 
+    it("rejects directory-only external aliases before resolver or plugin code", async () => {
+      const looksLikeId = vi.fn(() => false);
+      const resolveTarget = vi.fn(async () => ({
+        to: "actionhub:current",
+        kind: "group" as const,
+      }));
+      const listGroups = vi.fn(async () => [
+        { kind: "group" as const, id: "actionhub:current", name: "current-room" },
+      ]);
+      const listGroupsLive = vi.fn(async () => [
+        { kind: "group" as const, id: "actionhub:current", name: "current-room" },
+      ]);
+      setActivePluginRegistry(
+        createTestRegistry([
+          {
+            pluginId: "actionhub",
+            source: "test",
+            origin: "config",
+            plugin: {
+              ...actionHubPlugin,
+              messaging: {
+                ...actionHubPlugin.messaging,
+                targetResolver: { looksLikeId, resolveTarget },
+              },
+              directory: { listGroups, listGroupsLive },
+            },
+          },
+        ]),
+      );
+
+      await expect(
+        runMessageAction({
+          cfg: {
+            channels: {
+              actionhub: {
+                enabled: true,
+              },
+            },
+          } as OpenClawConfig,
+          action: "pin",
+          params: {
+            channel: "actionhub",
+            target: "current-room",
+            messageId: "om_123",
+          },
+          defaultAccountId: "default",
+          requesterAccountId: "default",
+          conversationReadOrigin: "delegated",
+          toolContext: {
+            currentChannelId: "actionhub:current",
+            currentChannelProvider: "actionhub",
+            currentChatType: "group",
+          },
+          dryRun: false,
+        }),
+      ).rejects.toThrow("requires the exact current conversation and account");
+
+      expect(looksLikeId).not.toHaveBeenCalled();
+      expect(resolveTarget).not.toHaveBeenCalled();
+      expect(listGroups).not.toHaveBeenCalled();
+      expect(listGroupsLive).not.toHaveBeenCalled();
+      expect(handleAction).not.toHaveBeenCalled();
+    });
+
     it("preserves no-context owner Discord admin actions through the shared runner", async () => {
       const handleDiscordAction = vi.fn(async (ctx: ChannelMessageActionContext) => {
         const currentProvider = ctx.toolContext?.currentChannelProvider?.trim().toLowerCase();


### PR DESCRIPTION
Related: #113432

## What Problem This Solves

Resolves a regression-coverage gap where future shared message-action refactors could let a delegated external-plugin read alias reach target or directory resolution before the host proves it names the exact current conversation.

## Why This Change Was Made

Adds a focused external-plugin contract test that supplies an alias resolvable only through cached/live directory data or plugin target fallback. The test requires rejection before every resolver, directory, and plugin callback.

## User Impact

No runtime behavior changes. Maintainers gain a durable regression guard for the fail-closed authorization ordering established by #113432.

## Evidence

- 65 message-action runner plugin-dispatch tests passed.
- 75 shared message-action security tests passed.
- Exact changed-surface gate passed on Blacksmith Testbox: https://github.com/openclaw/openclaw/actions/runs/30322376621
- Fresh autoreview: clean, no actionable findings.
- Formatting and `git diff --check`: passed.

AI-assisted: yes. I reviewed the test setup, asserted callback ordering, and validation results.
