### PR TITLE
docs: add Buzz to generated plugin inventory

### DIFF
--- a/docs/docs_map.md
+++ b/docs/docs_map.md
@@ -6356,6 +6356,15 @@ Do not edit it by hand; run `pnpm docs:map:gen`.
   - H2: Surface
   - H2: Related docs
 
+## plugins/reference/buzz.md
+
+- Route: /plugins/reference/buzz
+- Headings:
+  - H1: Buzz plugin
+  - H2: Distribution
+  - H2: Surface
+  - H2: Related docs
+
 ## plugins/reference/byteplus.md
 
 - Route: /plugins/reference/byteplus

--- a/docs/plugins/plugin-inventory.md
+++ b/docs/plugins/plugin-inventory.md
@@ -197,7 +197,7 @@ Each entry lists the package, distribution route, and description.
 
 ## Official external packages
 
-72 plugins
+73 plugins
 
 - **[acpx](/plugins/reference/acpx)** (`@openclaw/acpx`) - npm; ClawHub. OpenClaw ACP runtime backend with plugin-owned session and transport management.
 
@@ -212,6 +212,8 @@ Each entry lists the package, distribution route, and description.
 - **[baseten](/plugins/reference/baseten)** (`@openclaw/baseten-provider`) - npm; ClawHub: `clawhub:@openclaw/baseten-provider`. OpenClaw Baseten provider plugin.
 
 - **[brave](/plugins/reference/brave)** (`@openclaw/brave-plugin`) - npm; ClawHub. OpenClaw Brave Search provider plugin for web search.
+
+- **[buzz](/plugins/reference/buzz)** (`@openclaw/buzz`) - npm; ClawHub: `clawhub:@openclaw/buzz`. Connect OpenClaw agents to Buzz rooms.
 
 - **[cerebras](/plugins/reference/cerebras)** (`@openclaw/cerebras-provider`) - npm; ClawHub: `clawhub:@openclaw/cerebras-provider`. Adds Cerebras model provider support to OpenClaw.
 

--- a/docs/plugins/reference.md
+++ b/docs/plugins/reference.md
@@ -15,5 +15,5 @@ This page is generated from `extensions/*/package.json` and
 pnpm plugins:inventory:gen
 ```
 
-Use [Plugin inventory](/plugins/plugin-inventory) to browse all 144
+Use [Plugin inventory](/plugins/plugin-inventory) to browse all 145
 generated plugin reference pages by distribution, package, and description.

--- a/docs/plugins/reference/buzz.md
+++ b/docs/plugins/reference/buzz.md
@@ -1,0 +1,23 @@
+---
+summary: "Connect OpenClaw agents to Buzz rooms."
+read_when:
+  - You are installing, configuring, or auditing the buzz plugin
+title: "Buzz plugin"
+---
+
+# Buzz plugin
+
+Connect OpenClaw agents to Buzz rooms.
+
+## Distribution
+
+- Package: `@openclaw/buzz`
+- Install route: npm; ClawHub: `clawhub:@openclaw/buzz`
+
+## Surface
+
+channels: `buzz`
+
+## Related docs
+
+- [buzz](/channels/buzz)


### PR DESCRIPTION
## What Problem This Solves

The generated plugin inventory was stale after Buzz was added to the official external plugin catalog. Buzz was missing from the package inventory and generated reference index, and both published counts were one short.

## Why This Change Was Made

Regenerates the plugin inventory from the catalog so Buzz receives its generated reference page and the official-external and total-reference counts stay accurate. The generated docs map is refreshed as a second projection so the new Buzz reference page is covered by documentation navigation checks. This is an AI-assisted generated-docs refresh with no handwritten runtime changes.

## User Impact

Users browsing the plugin inventory can now find the official `@openclaw/buzz` package, its npm and ClawHub install routes, and the related Buzz channel documentation.

## Evidence

- `pnpm plugins:inventory:gen`
- `pnpm plugins:inventory:check`
- `pnpm docs:map:gen`
- `pnpm docs:map:check`
- `git diff --check origin/main...HEAD`
- `pnpm docs:list` lists `plugins/reference/buzz.md`
- Codex autoreview: clean, no accepted or actionable findings
