### PR TITLE
feat(code-mode): unify node MCP servers into the MCP namespace

### DIFF
--- a/src/agents/code-mode-namespaces.ts
+++ b/src/agents/code-mode-namespaces.ts
@@ -5,6 +5,7 @@
  */
 import { tokTypes } from "acorn";
 import { isRecord } from "../../packages/normalization-core/src/record-coerce.js";
+import type { PluginToolMcpMeta } from "../plugins/tools.js";
 import { toCodeModeJsonSafe } from "./code-mode-json.js";
 
 const FORBIDDEN_NAMESPACE_PATH_SEGMENTS = new Set(["__proto__", "constructor", "prototype"]);
@@ -87,12 +88,7 @@ type CodeModeNamespaceCatalogEntry = {
   sourceName?: string;
   description?: string;
   parameters?: unknown;
-  mcp?: {
-    serverName: string;
-    safeServerName: string;
-    toolName: string;
-    operation: "tool" | "resources_list" | "resources_read" | "prompts_list" | "prompts_get";
-  };
+  mcp?: PluginToolMcpMeta;
 };
 
 /** Runtime dispatcher for invoking callable namespace paths. */
@@ -393,6 +389,7 @@ type McpApiToolDoc = {
 type McpApiServerDoc = {
   identifier: string;
   serverName: string;
+  nodeLabel?: string;
   tools: McpApiToolDoc[];
 };
 
@@ -602,6 +599,74 @@ type McpNamespaceModel = {
   docs: McpApiServerDoc[];
 };
 
+type McpNamespaceServer = {
+  key: string;
+  serverName: string;
+  safeServerName: string;
+  node?: NonNullable<NonNullable<CodeModeNamespaceCatalogEntry["mcp"]>["node"]>;
+};
+
+function mcpNamespaceServerKey(mcp: NonNullable<CodeModeNamespaceCatalogEntry["mcp"]>): string {
+  return mcp.node
+    ? JSON.stringify(["node", mcp.node.id, mcp.serverName])
+    : JSON.stringify(["gateway", mcp.safeServerName]);
+}
+
+function sanitizeNodeFragment(value: string): string {
+  const fragment = value
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9_]+/g, "_")
+    .replace(/^_+|_+$/g, "")
+    .slice(0, 32);
+  if (!fragment) {
+    return "node";
+  }
+  return /^[a-z]/.test(fragment) ? fragment : `node_${fragment}`.slice(0, 32);
+}
+
+function assignMcpNamespaceServerNames(
+  servers: readonly McpNamespaceServer[],
+): Map<string, string> {
+  const baseCounts = new Map<string, number>();
+  const used = new Set<string>();
+  const assignments = new Map<string, string>();
+  for (const server of servers) {
+    const normalized = server.safeServerName.toLowerCase();
+    baseCounts.set(normalized, (baseCounts.get(normalized) ?? 0) + 1);
+    if (!server.node) {
+      assignments.set(server.key, server.safeServerName);
+      used.add(normalized);
+    }
+  }
+  for (const server of servers) {
+    if (!server.node || (baseCounts.get(server.safeServerName.toLowerCase()) ?? 0) > 1) {
+      continue;
+    }
+    assignments.set(server.key, server.safeServerName);
+    used.add(server.safeServerName.toLowerCase());
+  }
+  for (const server of servers) {
+    if (!server.node || assignments.has(server.key)) {
+      continue;
+    }
+    const base = `${sanitizeNodeFragment(server.node.id)}_${server.safeServerName}`;
+    let candidate = base;
+    let index = 2;
+    while (used.has(candidate.toLowerCase())) {
+      candidate = `${base}_${index}`;
+      index += 1;
+    }
+    assignments.set(server.key, candidate);
+    used.add(candidate.toLowerCase());
+  }
+  return assignments;
+}
+
+function mcpNodeLabel(node: NonNullable<McpNamespaceServer["node"]>): string {
+  return (node.displayName?.trim() || node.id).replace(/\s+/gu, " ").slice(0, 128);
+}
+
 function createMcpNamespaceModel(
   catalog: readonly CodeModeNamespaceCatalogEntry[],
 ): McpNamespaceModel | undefined {
@@ -609,15 +674,30 @@ function createMcpNamespaceModel(
   if (mcpEntries.length === 0) {
     return undefined;
   }
-  const serverNames = new Map<string, string>();
-  const usedServerIdentifiers = new Set<string>();
-  for (const entry of mcpEntries) {
-    const safeServerName = entry.mcp?.safeServerName ?? entry.sourceName ?? "mcp";
-    if (serverNames.has(safeServerName)) {
+  const serversByKey = new Map<string, McpNamespaceServer>();
+  for (const entry of mcpEntries.toSorted((a, b) => (a.id ?? "").localeCompare(b.id ?? ""))) {
+    const mcp = entry.mcp;
+    if (!mcp) {
       continue;
     }
-    serverNames.set(
-      safeServerName,
+    const key = mcpNamespaceServerKey(mcp);
+    if (!serversByKey.has(key)) {
+      serversByKey.set(key, {
+        key,
+        serverName: mcp.serverName,
+        safeServerName: mcp.safeServerName,
+        ...(mcp.node ? { node: mcp.node } : {}),
+      });
+    }
+  }
+  const servers = [...serversByKey.values()].toSorted((a, b) => a.key.localeCompare(b.key));
+  const assignedServerNames = assignMcpNamespaceServerNames(servers);
+  const serverIdentifiers = new Map<string, string>();
+  const usedServerIdentifiers = new Set<string>();
+  for (const server of servers) {
+    const safeServerName = assignedServerNames.get(server.key) ?? server.safeServerName;
+    serverIdentifiers.set(
+      server.key,
       uniqueIdentifier(toIdentifier(safeServerName, "server"), usedServerIdentifiers),
     );
   }
@@ -629,13 +709,19 @@ function createMcpNamespaceModel(
     if (!mcp || !entry.id) {
       continue;
     }
+    const serverKey = mcpNamespaceServerKey(mcp);
     const serverIdentifier =
-      serverNames.get(mcp.safeServerName) ?? uniqueIdentifier("server", usedServerIdentifiers);
+      serverIdentifiers.get(serverKey) ?? uniqueIdentifier("server", usedServerIdentifiers);
     const serverScope = scopeAtPath(root, [serverIdentifier]);
     serverScope.$serverName = mcp.serverName;
     let serverDoc = serverDocs.get(serverIdentifier);
     if (!serverDoc) {
-      serverDoc = { identifier: serverIdentifier, serverName: mcp.serverName, tools: [] };
+      serverDoc = {
+        identifier: serverIdentifier,
+        serverName: mcp.serverName,
+        ...(mcp.node ? { nodeLabel: mcpNodeLabel(mcp.node) } : {}),
+        tools: [],
+      };
       serverDocs.set(serverIdentifier, serverDoc);
     }
     const path =
@@ -669,11 +755,13 @@ function createMcpNamespaceModel(
       params: buildMcpParamDocs(entry.parameters),
     });
   }
-  const docs = [...serverDocs.values()].map((server) =>
-    Object.assign({}, server, {
-      tools: server.tools.toSorted((a, b) => a.method.localeCompare(b.method)),
-    }),
-  );
+  const docs = [...serverDocs.values()]
+    .map((server) =>
+      Object.assign({}, server, {
+        tools: server.tools.toSorted((a, b) => a.method.localeCompare(b.method)),
+      }),
+    )
+    .toSorted((a, b) => a.identifier.localeCompare(b.identifier));
   root.$api = createCodeModeNamespaceLocalFunction("$api", (args) =>
     buildMcpApiResponse({ servers: docs, args }),
   );
@@ -781,20 +869,21 @@ function createMcpNamespaceEntry(
 function describeMcpNamespaceForPrompt(
   catalog: readonly CodeModeNamespaceCatalogEntry[],
 ): string[] {
-  const scope = createMcpNamespaceScope(catalog);
-  if (!scope) {
+  const model = createMcpNamespaceModel(catalog);
+  if (!model) {
     return [];
   }
-  const servers = Object.entries(scope)
-    .filter(([, value]) => isRecord(value) && typeof value.$serverName === "string")
-    .map(([key]) => key)
-    .toSorted();
+  const servers = model.docs.map(
+    (server) => `${server.identifier}${server.nodeLabel ? ` (node: ${server.nodeLabel})` : ""}`,
+  );
   if (servers.length === 0) {
     return [];
   }
+  // Node-backed servers keep the gateway-style name when unique. Collisions
+  // use the existing node-id fragment prefix idiom, then a numeric suffix.
   return [
     "- MCP: MCP server tools grouped by server.",
-    `Read API files such as mcp/index.d.ts and mcp/<server>.d.ts for TypeScript-style MCP headers; visible servers: ${servers.join(", ")}.`,
+    `Read API files such as mcp/index.d.ts and mcp/<server>.d.ts for TypeScript-style MCP headers; visible servers: ${servers.join(", ")}. Node-backed name collisions use a sanitized node-id fragment prefix.`,
     "Call MCP tools as MCP.<server>.<tool>({ ...input }) with one object argument matching the header.",
   ];
 }

--- a/src/agents/node-plugin-tools.test.ts
+++ b/src/agents/node-plugin-tools.test.ts
@@ -8,8 +8,12 @@ import {
   removeConnectedNodePluginTools,
   replaceConnectedNodePluginTools,
 } from "../gateway/node-plugin-tool-snapshot.js";
-import { getPluginToolMeta } from "../plugins/tools.js";
+import { getPluginToolMeta, setPluginToolMeta } from "../plugins/tools.js";
+import { applyCodeModeCatalog, createCodeModeTools } from "./code-mode.js";
+import { testing } from "./code-mode.test-support.js";
 import { createNodePluginTools } from "./node-plugin-tools.js";
+import { compactToolSearchCatalogEntry, createToolSearchCatalogRef } from "./tool-search.js";
+import { jsonResult, type AnyAgentTool } from "./tools/common.js";
 import { callGatewayTool } from "./tools/gateway.js";
 
 vi.mock("./tools/gateway.js", () => ({
@@ -29,11 +33,75 @@ function replaceNodePluginTools(
   });
 }
 
+function createCodeModeHarness(tools: AnyAgentTool[]) {
+  const catalogRef = createToolSearchCatalogRef();
+  const config = { tools: { codeMode: true } } as never;
+  const ctx = {
+    config,
+    runtimeConfig: config,
+    sessionId: "session-node-mcp-code-mode",
+    sessionKey: "agent:main:node-mcp-code-mode",
+    runId: "run-node-mcp-code-mode",
+    catalogRef,
+  };
+  const codeModeTools = createCodeModeTools(ctx);
+  const compacted = applyCodeModeCatalog({
+    tools: [...codeModeTools, ...tools],
+    config,
+    sessionId: ctx.sessionId,
+    sessionKey: ctx.sessionKey,
+    runId: ctx.runId,
+    catalogRef,
+  });
+  return { catalogRef, codeModeTools, compacted };
+}
+
+async function runCodeMode(codeModeTools: AnyAgentTool[], code: string) {
+  let details = (
+    await expectDefined(codeModeTools[0], "codeModeTools[0] test invariant").execute(
+      "code-node-mcp",
+      { code },
+    )
+  ).details as Record<string, unknown>;
+  for (let index = 0; index < 8 && details.status === "waiting"; index += 1) {
+    details = (
+      await expectDefined(codeModeTools[1], "codeModeTools[1] test invariant").execute(
+        `wait-node-mcp-${index}`,
+        { runId: details.runId },
+      )
+    ).details as Record<string, unknown>;
+  }
+  return details;
+}
+
+function gatewayMcpTool(serverName: string): AnyAgentTool {
+  const tool: AnyAgentTool = {
+    name: `${serverName}__status`,
+    label: "status",
+    description: `Read ${serverName} status`,
+    parameters: { type: "object", properties: {} },
+    execute: vi.fn(async () => jsonResult({ source: "gateway" })),
+  };
+  setPluginToolMeta(tool, {
+    pluginId: "bundle-mcp",
+    optional: false,
+    mcp: {
+      serverName,
+      safeServerName: serverName,
+      toolName: "status",
+      operation: "tool",
+    },
+  });
+  return tool;
+}
+
 afterEach(() => {
   for (const nodeId of new Set(listConnectedNodePluginTools().map((tool) => tool.nodeId))) {
     removeConnectedNodePluginTools(nodeId);
   }
   vi.mocked(callGatewayTool).mockReset();
+  testing.activeRuns.clear();
+  testing.resumingRunIds.clear();
 });
 
 describe("createNodePluginTools", () => {
@@ -142,6 +210,7 @@ describe("createNodePluginTools", () => {
       { scopes: ["operator.write"] },
     );
     expect(tool.executionMode).toBe("sequential");
+    expect(getPluginToolMeta(tool)?.mcp?.node).toEqual({ id: "node-1" });
     expect(result.content).toEqual([
       { type: "image", data: "aW1hZ2UtMQ==", mimeType: "image/png" },
       { type: "text", text: "first" },
@@ -149,6 +218,153 @@ describe("createNodePluginTools", () => {
       { type: "image", data: "aW1hZ2UtMg==", mimeType: "image/png" },
       { type: "text", text: '{\n  "hits": 2\n}' },
     ]);
+  });
+
+  it("projects node MCP schemas and calls through the exact namespace catalog entry", async () => {
+    replaceNodePluginTools({
+      nodeId: "node-1",
+      displayName: "Studio Node",
+      tools: [
+        {
+          pluginId: "node-mcp",
+          name: "docs_search",
+          description: "Search node-local docs",
+          parameters: {
+            type: "object",
+            properties: {
+              query: { type: "string", description: "Search phrase" },
+            },
+            required: ["query"],
+          },
+          command: "mcp.tools.call.v1",
+          mcp: { server: "docs", tool: "search" },
+        },
+      ],
+    });
+    vi.mocked(callGatewayTool).mockResolvedValueOnce({
+      payload: {
+        content: [{ type: "text", text: "found" }],
+        structuredContent: { hits: 1 },
+      },
+    });
+
+    const nodeTools = createNodePluginTools({ agentSessionKey: "agent:main:node-mcp-code-mode" });
+    const { catalogRef, codeModeTools, compacted } = createCodeModeHarness(nodeTools);
+    const nodeEntry = catalogRef.current?.entries.find(
+      (entry) => entry.name === "docs_search" && entry.source === "mcp",
+    );
+
+    expect(nodeEntry?.id).toBe("mcp:docs:docs_search");
+    expect(nodeEntry && compactToolSearchCatalogEntry(nodeEntry).mcp).toEqual({
+      serverName: "docs",
+      safeServerName: "docs",
+      toolName: "search",
+      operation: "tool",
+    });
+    expect(compacted.tools[0]?.description).toContain("docs (node: Studio Node)");
+    const details = await runCodeMode(
+      codeModeTools,
+      `
+        const api = await API.read("mcp/docs.d.ts");
+        const called = await MCP.docs.search({ query: "needle" });
+        const direct = await tools.search("docs_search");
+        return {
+          api: api.content,
+          called: called.details,
+          allHasNodeMcp: ALL_TOOLS.some((entry) => entry.id === "mcp:docs:docs_search"),
+          direct,
+        };
+      `,
+    );
+
+    expect(details.status).toBe("completed");
+    expect(details.value).toEqual({
+      api: expect.stringContaining("query: string;"),
+      called: {
+        content: [{ type: "text", text: "found" }],
+        structuredContent: { hits: 1 },
+      },
+      allHasNodeMcp: false,
+      direct: [],
+    });
+    expect((details.value as { api: string }).api).toContain("@param query Search phrase");
+    expect(callGatewayTool).toHaveBeenCalledWith(
+      "node.invoke",
+      { timeoutMs: 125_000 },
+      {
+        nodeId: "node-1",
+        command: "mcp.tools.call.v1",
+        params: { server: "docs", tool: "search", arguments: { query: "needle" } },
+        timeoutMs: 120_000,
+        idempotencyKey: expect.stringContaining("docs_search"),
+        sessionKey: "agent:main:node-mcp-code-mode",
+      },
+      { scopes: ["operator.write"] },
+    );
+  });
+
+  it("disambiguates gateway-node and node-node MCP server collisions", async () => {
+    for (const [nodeId, displayName, serverName, toolName] of [
+      ["node-a", "Node A", "tickets", "search_a"],
+      ["node-b", "Node B", "docs", "search_b"],
+      ["node-c", "Node C", "docs", "search_c"],
+    ] as const) {
+      replaceNodePluginTools({
+        nodeId,
+        displayName,
+        tools: [
+          {
+            pluginId: "node-mcp",
+            name: `docs_${toolName}`,
+            description: `Search docs from ${displayName}`,
+            parameters: { type: "object", properties: {} },
+            command: "mcp.tools.call.v1",
+            mcp: { server: serverName, tool: toolName },
+          },
+        ],
+      });
+    }
+    vi.mocked(callGatewayTool).mockResolvedValueOnce({
+      payload: { content: [{ type: "text", text: "node-b" }] },
+    });
+
+    const { codeModeTools, compacted } = createCodeModeHarness([
+      gatewayMcpTool("tickets"),
+      ...createNodePluginTools({}),
+    ]);
+    expect(compacted.tools[0]?.description).toContain(
+      "visible servers: nodeATickets (node: Node A), nodeBDocs (node: Node B), nodeCDocs (node: Node C), tickets",
+    );
+
+    const details = await runCodeMode(
+      codeModeTools,
+      `
+        const files = await API.list("mcp");
+        const called = await MCP.nodeCDocs.searchC({});
+        return { files: files.files.map((file) => file.path), called: called.details };
+      `,
+    );
+
+    expect(details.status).toBe("completed");
+    expect(details.value).toEqual({
+      files: [
+        "mcp/index.d.ts",
+        "mcp/nodeATickets.d.ts",
+        "mcp/nodeBDocs.d.ts",
+        "mcp/nodeCDocs.d.ts",
+        "mcp/tickets.d.ts",
+      ],
+      called: { content: [{ type: "text", text: "node-b" }] },
+    });
+    expect(callGatewayTool).toHaveBeenCalledWith(
+      "node.invoke",
+      { timeoutMs: 125_000 },
+      expect.objectContaining({
+        nodeId: "node-c",
+        params: { server: "docs", tool: "search_c", arguments: {} },
+      }),
+      { scopes: ["operator.write"] },
+    );
   });
 
   it("disambiguates node tools that collide with existing tool names", () => {

--- a/src/agents/node-plugin-tools.ts
+++ b/src/agents/node-plugin-tools.ts
@@ -17,6 +17,7 @@ import { callGatewayTool } from "./tools/gateway.js";
 
 const NODE_PLUGIN_TOOL_NAME_RE = /^[A-Za-z][A-Za-z0-9_-]{0,63}$/;
 const NODE_PLUGIN_TOOL_NAME_MAX_LENGTH = 64;
+const NODE_MCP_PLUGIN_ID = "node-mcp";
 
 type MaterializedNodeToolEntry = ReturnType<typeof listConnectedNodePluginTools>[number] & {
   command: string;
@@ -264,6 +265,16 @@ export function createNodePluginTools(params: {
               safeServerName: sanitizeServerName(descriptor.mcp.server, new Set<string>()),
               toolName: descriptor.mcp.tool,
               operation: "tool",
+              ...(descriptor.pluginId === NODE_MCP_PLUGIN_ID && mcpTool
+                ? {
+                    node: {
+                      id: entry.nodeId,
+                      ...(entry.displayName?.trim()
+                        ? { displayName: entry.displayName.trim() }
+                        : {}),
+                    },
+                  }
+                : {}),
             },
           }
         : {}),

--- a/src/agents/tool-search-catalog.ts
+++ b/src/agents/tool-search-catalog.ts
@@ -431,11 +431,21 @@ export function visibleCatalogEntries(
 export function compactToolSearchCatalogEntry(entry: ToolSearchCatalogEntry) {
   const output =
     entry.source === "openclaw" ? compactToolOutputHint(entry.outputSchema) : undefined;
+  // Node provenance is namespace-only metadata; generic Tool Search keeps its
+  // existing MCP result shape outside Code Mode.
+  const mcp = entry.mcp
+    ? {
+        serverName: entry.mcp.serverName,
+        safeServerName: entry.mcp.safeServerName,
+        toolName: entry.mcp.toolName,
+        operation: entry.mcp.operation,
+      }
+    : undefined;
   return {
     id: entry.id,
     source: entry.source,
     sourceName: entry.sourceName,
-    ...(entry.mcp ? { mcp: entry.mcp } : {}),
+    ...(mcp ? { mcp } : {}),
     name: entry.name,
     label: entry.label,
     description: entry.description,

--- a/src/agents/tool-search-runtime.ts
+++ b/src/agents/tool-search-runtime.ts
@@ -540,6 +540,7 @@ export class ToolSearchRuntime {
   namespaceEntries = () =>
     resolveCatalog(this.ctx).entries.map((entry) =>
       Object.assign(compactToolSearchCatalogEntry(entry), {
+        ...(entry.mcp ? { mcp: entry.mcp } : {}),
         parameters: entry.parameters ?? {},
       }),
     );

--- a/src/plugins/tools.ts
+++ b/src/plugins/tools.ts
@@ -52,6 +52,10 @@ export type PluginToolMcpMeta = {
   safeServerName: string;
   toolName: string;
   operation: "tool" | "resources_list" | "resources_read" | "prompts_list" | "prompts_get";
+  node?: {
+    id: string;
+    displayName?: string;
+  };
 };
 
 /** Runtime metadata used to trace an agent tool back to its owning plugin registration. */


### PR DESCRIPTION
## What Problem This Solves

Node-bridged MCP servers (`nodeHost.mcp.servers` exposed as `node-mcp` descriptors) followed the generic tool path in Code Mode. Unlike gateway `mcp.servers`, they had no typed `MCP.<server>.*` namespace or generated TypeScript declarations, so the two MCP entry points appeared differently to agents.

## Why This Change Was Made

Unify both MCP entry points so every MCP server, whether local to the gateway or hosted on a paired node, receives the same first-class Code Mode surface. This also establishes the shared boundary needed for computer-use providers to present as native MCP servers.

## User Impact

Code Mode agents can call node-backed MCP tools as `MCP.<server>.<tool>()` with generated TypeScript declarations. Node-backed MCP tools leave `ALL_TOOLS` and `tools.*`; server-name collisions are resolved deterministically with a node-id prefix, and the Code Mode preamble identifies the owning node. Behavior outside Code Mode is unchanged. Existing policy and forwarding through `mcp.tools.call.v1` are unchanged.

## Evidence

- `node scripts/run-vitest.mjs src/agents/node-plugin-tools.test.ts src/agents/code-mode.test.ts` passed; the focused suites were also independently rerun by the reviewing maintainer session.
- `node scripts/check-changed.mjs` passed its typecheck, lint, and guard lanes.
- Branch autoreview completed cleanly with no accepted or actionable findings.
- Exact-head GitHub CI passed: [run 30324091214](https://github.com/openclaw/openclaw/actions/runs/30324091214) at `9168e05cf4f4a423bf03df53bbdef570e6876f65`.

Maintainer compatibility decision: removing node-backed MCP tools from the generic `tools.*` and `ALL_TOOLS` Code Mode surfaces is intentional. MCP tools should have one canonical Code Mode surface rather than a transition alias. `src/agents/node-plugin-tools.test.ts` covers the intended upgrade behavior by asserting the generated declaration, successful `MCP.docs.search(...)` forwarding through `mcp.tools.call.v1`, and absence from both generic discovery surfaces.

ClawSweeper's optional live-proof rank-up move is skipped for this pre-reviewed landing lane because no paired-node live fixture was supplied. The PR does not claim live paired-node proof; the accepted evidence is the real Code Mode execution harness with mocked gateway forwarding, the focused suites, the changed gate, clean autoreview, and exact-head CI.
