### PR TITLE
fix(ui): use Traditional Chinese for Hant browser locales

### DIFF
--- a/ui/src/i18n/lib/registry.test.ts
+++ b/ui/src/i18n/lib/registry.test.ts
@@ -1,0 +1,27 @@
+// @vitest-environment node
+
+import { describe, expect, it } from "vitest";
+import { resolveNavigatorLocale } from "./registry.ts";
+
+describe("resolveNavigatorLocale", () => {
+  it.each([
+    ["zh-Hant", "zh-TW"],
+    ["zh-Hant-TW", "zh-TW"],
+    ["zh-Hant-HK", "zh-TW"],
+    ["zh-Hant-MO", "zh-TW"],
+    ["zh-TW", "zh-TW"],
+    ["zh-HK", "zh-TW"],
+    ["zh-MO", "zh-TW"],
+    ["ZH-hAnT-tW", "zh-TW"],
+    ["zh-Hans", "zh-CN"],
+    ["zh-Hans-CN", "zh-CN"],
+    ["zh-Hans-SG", "zh-CN"],
+    ["zh-Hans-TW", "zh-CN"],
+    ["zh-Hant-CN", "zh-TW"],
+    ["zh", "zh-CN"],
+    ["zh-CN", "zh-CN"],
+    ["zh-SG", "zh-CN"],
+  ] as const)("maps %s to %s", (language, expected) => {
+    expect(resolveNavigatorLocale(language)).toBe(expected);
+  });
+});

--- a/ui/src/i18n/lib/registry.ts
+++ b/ui/src/i18n/lib/registry.ts
@@ -127,9 +127,30 @@ function isLazyLocale(locale: Locale): locale is LazyLocale {
   return LAZY_LOCALES.includes(locale as LazyLocale);
 }
 
+function resolveChineseNavigatorLocale(navLang: string): Locale {
+  let locale: Intl.Locale;
+  try {
+    locale = new Intl.Locale(navLang);
+  } catch {
+    return "zh-CN";
+  }
+  if (locale.script === "Hans") {
+    return "zh-CN";
+  }
+  if (
+    locale.script === "Hant" ||
+    locale.region === "TW" ||
+    locale.region === "HK" ||
+    locale.region === "MO"
+  ) {
+    return "zh-TW";
+  }
+  return "zh-CN";
+}
+
 export function resolveNavigatorLocale(navLang: string): Locale {
-  if (navLang.startsWith("zh")) {
-    return navLang === "zh-TW" || navLang === "zh-HK" ? "zh-TW" : "zh-CN";
+  if (navLang.toLowerCase().startsWith("zh")) {
+    return resolveChineseNavigatorLocale(navLang);
   }
   if (navLang.startsWith("pt")) {
     return "pt-BR";

--- a/ui/src/i18n/test/translate.test.ts
+++ b/ui/src/i18n/test/translate.test.ts
@@ -135,6 +135,20 @@ describe("i18n", () => {
     expect(fresh.t("common.health")).toBe("健康状况");
   });
 
+  it.each(["zh-Hant", "zh-MO", "ZH-hAnT-tW"])(
+    "loads Traditional Chinese for the %s browser locale",
+    async (language) => {
+      vi.stubGlobal("navigator", { language } as Navigator);
+
+      const fresh = await importFreshTranslate();
+
+      await vi.waitFor(() => {
+        expect(fresh.i18n.getLocale()).toBe("zh-TW");
+      });
+      expect(fresh.t("common.health")).toBe(zh_TW.common.health);
+    },
+  );
+
   it("skips node localStorage accessors that warn without a storage file", async () => {
     vi.unstubAllGlobals();
     vi.stubGlobal("navigator", { language: "en-US" } as Navigator);


### PR DESCRIPTION
Fixes #114859

## What Problem This Solves

Fixes an issue where users whose browser advertises Traditional Chinese through BCP 47 script or region tags would see the Simplified Chinese Control UI instead.

## Why This Change Was Made

Browser locale detection now parses Chinese language tags with `Intl.Locale`, honors explicit `Hans` and `Hant` scripts, and maps Taiwan, Hong Kong, and Macao region tags to the existing Traditional Chinese locale. This keeps locale policy at the registry boundary and leaves generated translation bundles unchanged.

This is the best-fix boundary because `I18nManager.resolveInitialLocale()` is the only first-load browser-language caller; saved/manual locale selection already uses the canonical `setLocale()` path. The other `navigator.language` consumers only send client metadata or format embedded content and do not choose a Control UI translation bundle.

## User Impact

Traditional Chinese browser preferences such as `zh-Hant`, `zh-Hant-TW`, `zh-HK`, and `zh-MO` now open the Traditional Chinese UI automatically. Explicit Simplified Chinese tags continue to select Simplified Chinese.

## Evidence

### Real browser proof

Playwright launched real Chromium 149.0.7827.55 against the mocked Control UI/Gateway at `/settings/general` in a fresh browser context with locale `zh-Hant`.

- `navigator.language`: `zh-Hant`
- selected and persisted UI locale: `zh-TW`
- visible page title: `設置 — OpenClaw`
- Traditional `設置` rendered: yes
- Simplified `设置` rendered: no
- assertion result: pass
- screenshot SHA-256: `28d6e221eeb346d8ae2fc8f9cf1d94944ad1dd39e624e2aaad0b1d67b5f2b62f`
- [machine-readable proof](https://gist.githubusercontent.com/MonkeyLeeT/be2ec470f003072f6ddc6e07be7e08fb/raw/6a7547c9c438ac05a7d1ad855e5f8c5b327144ce/proof.json)

![Traditional Chinese Control UI selected from a zh-Hant browser locale](https://gist.githubusercontent.com/MonkeyLeeT/be2ec470f003072f6ddc6e07be7e08fb/raw/39cb214c7901b8de84788fcafa493f5ffe5041ab/zh-Hant-settings-proof.svg)

The preferred remote visual backend was unavailable because this machine lacks its broker login, so repository policy routed this trusted-source browser proof to the identical local Chromium flow.

### Automated regression proof

- Red proof: the new focused coverage failed 10 cases before the implementation.
- Green proof: `node scripts/run-vitest.mjs ui/src/i18n/lib/registry.test.ts ui/src/i18n/test/translate.test.ts` — 31 tests passed.
- Translation integrity: `pnpm ui:i18n:verify` passed with 4,138 source keys.
- Patch hygiene: `git diff --check` passed.
- One required autoreview round completed cleanly with no findings.

### Current-main integration and history pass

- Reviewed against `origin/main` at `d7622734d583da36ee303b144bf740c0c0bd10b2`.
- No commits between this branch base (`b4e246be01efa25750ccd44faa73515a4036c8b8`) and that current-main head changed the locale registry, its automatic-selection caller, adjacent startup tests, or the Control UI language contract.
- The automatic browser-locale path is `ui/src/i18n/lib/translate.ts` → `resolveNavigatorLocale()` → the existing lazy locale registry. Manual and synced preferences remain on `setLocale()`.
- The original exact `zh-TW`/`zh-HK` equality rule was added in direct commit [`e1f3ded033ea`](https://github.com/openclaw/openclaw/commit/e1f3ded033ea7848d67ed5fbe7c7bf19e4430288) by `@steipete` on 2026-03-02; GitHub reports no linked PR for that commit.
- The parsing contract is the standard [`Intl.Locale`](https://402.ecma-international.org/#locale-objects) script/region interface; invalid Chinese-prefixed tags retain the existing safe `zh-CN` fallback.
