### PR TITLE
fix(signal): escape real newlines in inbound verbose-log preview

### DIFF
--- a/extensions/signal/src/monitor/event-handler.inbound-context.test.ts
+++ b/extensions/signal/src/monitor/event-handler.inbound-context.test.ts
@@ -38,6 +38,8 @@ const {
   dispatchInboundMessageMock,
   enqueueSystemEventMock,
   recordInboundSessionMock,
+  logVerboseMock,
+  shouldLogVerboseMock,
   capture,
 } = vi.hoisted(() => {
   const captureState: { ctx?: MsgContext } = {};
@@ -52,6 +54,8 @@ const {
       await Promise.resolve(params.replyOptions?.onReplyStart?.());
       return { queuedFinal: false, counts: { tool: 0, block: 0, final: 0 } };
     }),
+    logVerboseMock: vi.fn(),
+    shouldLogVerboseMock: vi.fn(() => false),
     capture: captureState,
   };
 });
@@ -194,6 +198,17 @@ vi.mock("../approval-reactions.js", async () => {
   };
 });
 
+vi.mock("openclaw/plugin-sdk/runtime-env", async () => {
+  const actual = await vi.importActual<typeof import("openclaw/plugin-sdk/runtime-env")>(
+    "openclaw/plugin-sdk/runtime-env",
+  );
+  return {
+    ...actual,
+    logVerbose: logVerboseMock,
+    shouldLogVerbose: shouldLogVerboseMock,
+  };
+});
+
 function requireCapturedContext(): MsgContext {
   if (!capture.ctx) {
     throw new Error("expected inbound MsgContext");
@@ -223,6 +238,8 @@ describe("signal createSignalEventHandler inbound context", () => {
     enqueueSystemEventMock.mockReset();
     recordInboundSessionMock.mockReset().mockResolvedValue(undefined);
     dispatchInboundMessageMock.mockClear();
+    logVerboseMock.mockClear();
+    shouldLogVerboseMock.mockReset().mockReturnValue(false);
     approvalReactionMocks.maybeResolveSignalApprovalReaction.mockReset().mockResolvedValue(false);
   });
 
@@ -2171,6 +2188,35 @@ describe("signal createSignalEventHandler inbound context", () => {
 
     expect(capture.ctx).toBeUndefined();
     expect(dispatchInboundMessageMock).not.toHaveBeenCalled();
+  });
+
+  it("keeps inbound verbose preview single-line by escaping real newlines", async () => {
+    shouldLogVerboseMock.mockReturnValue(true);
+    try {
+      const handler = createSignalEventHandler(
+        createBaseSignalEventHandlerDeps({
+          cfg: {
+            messages: { inbound: { debounceMs: 0 } },
+            channels: { signal: { dmPolicy: "open", allowFrom: ["*"] } },
+          },
+          historyLimit: 0,
+        }),
+      );
+
+      await handler(
+        createSignalReceiveEvent({
+          dataMessage: { message: "line one\nline two" },
+        }),
+      );
+
+      // body is formatInboundEnvelope(...) with an envelope prefix, so assert
+      // the escaped tail is present and the logged line stays single-line.
+      expect(logVerboseMock).toHaveBeenCalledWith(expect.stringContaining("line one\\nline two"));
+      const logged = String(logVerboseMock.mock.calls[0]?.[0] ?? "");
+      expect(logged).not.toContain("\n");
+    } finally {
+      shouldLogVerboseMock.mockReturnValue(false);
+    }
   });
 });
 /* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */

--- a/extensions/signal/src/monitor/event-handler.inbound-context.test.ts
+++ b/extensions/signal/src/monitor/event-handler.inbound-context.test.ts
@@ -2190,7 +2190,12 @@ describe("signal createSignalEventHandler inbound context", () => {
     expect(dispatchInboundMessageMock).not.toHaveBeenCalled();
   });
 
-  it("keeps inbound verbose preview single-line by escaping real newlines", async () => {
+  it.each([
+    ["LF", "line one\nline two", "line one\\nline two"],
+    ["CR", "line one\rline two", "line one\\rline two"],
+    ["CRLF", "line one\r\nline two", "line one\\r\\nline two"],
+    ["literal escape", "line one\\nline two", "line one\\nline two"],
+  ])("keeps %s inbound verbose previews single-line", async (_label, message, expectedPreview) => {
     shouldLogVerboseMock.mockReturnValue(true);
     try {
       const handler = createSignalEventHandler(
@@ -2205,15 +2210,15 @@ describe("signal createSignalEventHandler inbound context", () => {
 
       await handler(
         createSignalReceiveEvent({
-          dataMessage: { message: "line one\nline two" },
+          dataMessage: { message },
         }),
       );
 
       // body is formatInboundEnvelope(...) with an envelope prefix, so assert
       // the escaped tail is present and the logged line stays single-line.
-      expect(logVerboseMock).toHaveBeenCalledWith(expect.stringContaining("line one\\nline two"));
+      expect(logVerboseMock).toHaveBeenCalledWith(expect.stringContaining(expectedPreview));
       const logged = String(logVerboseMock.mock.calls[0]?.[0] ?? "");
-      expect(logged).not.toContain("\n");
+      expect(logged).not.toMatch(/[\r\n]/);
     } finally {
       shouldLogVerboseMock.mockReturnValue(false);
     }

--- a/extensions/signal/src/monitor/event-handler.ts
+++ b/extensions/signal/src/monitor/event-handler.ts
@@ -318,7 +318,7 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
     });
 
     if (shouldLogVerbose()) {
-      const preview = truncateUtf16Safe(body, 200).replace(/\n/g, "\\n");
+      const preview = truncateUtf16Safe(body, 200).replace(/\r/g, "\\r").replace(/\n/g, "\\n");
       logVerbose(`signal inbound: from=${ctxPayload.From} len=${body.length} preview="${preview}"`);
     }
 

--- a/extensions/signal/src/monitor/event-handler.ts
+++ b/extensions/signal/src/monitor/event-handler.ts
@@ -318,7 +318,7 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
     });
 
     if (shouldLogVerbose()) {
-      const preview = truncateUtf16Safe(body, 200).replace(/\\n/g, "\\\\n");
+      const preview = truncateUtf16Safe(body, 200).replace(/\n/g, "\\n");
       logVerbose(`signal inbound: from=${ctxPayload.From} len=${body.length} preview="${preview}"`);
     }
 


### PR DESCRIPTION
Related: #110086 (the adjacent Signal debounce fix left this verbose-log preview unchanged).

## What Problem This Solves

Fixes an issue where a multiline inbound Signal message broke a single `signal inbound:` verbose-log record into multiple physical lines. The production expression accidentally escaped the literal two-character `\\n` sequence while leaving real LF characters untouched. Carriage returns and CRLF could also overwrite or split the diagnostic record.

## Why This Change Was Made

Normalize actual CR and LF characters in the Signal plugin's existing UTF-16-safe preview before passing it to the production verbose logger. Keep literal backslash escapes unchanged. This is a single owner-local production expression; inbound admission, agent input, delivery, configuration, dependencies, and the plugin SDK are untouched.

## User Impact

Signal verbose and debug log records remain physically single-line for LF, CR, and CRLF message bodies. Existing log prefixes, safe Unicode truncation, literal escape sequences, and actual message delivery remain unchanged.

## Evidence

The regression drives the actual Signal inbound event handler with a JSON-encoded received message, turns on the production verbose-logging decision, captures the resulting logger call, and proves both its expected escaped message and the absence of real CR/LF characters. Parameterized cases cover:

- LF: `line one\nline two` becomes `line one\\nline two`.
- CR: `line one\rline two` becomes `line one\\rline two`.
- CRLF: `line one\r\nline two` becomes `line one\\r\\nline two`.
- Literal backslash-n remains `line one\\nline two`.

An independent Node string-encoding proof reproduces the previous physical-record break for CR and CRLF and verifies all four corrected cases without using a Signal account or claiming a live external-channel delivery. The existing contributor's complete hosted CI was green before the review amendment; GitHub CI is rerunning on the final pushed head.

### Implementation detail

- Fix: `extensions/signal/src/monitor/event-handler.ts` escapes actual CR and LF after `truncateUtf16Safe`.
- Regression: `extensions/signal/src/monitor/event-handler.inbound-context.test.ts` checks the complete real inbound-handler/logging path for LF, CR, CRLF, and existing literal backslashes.
- Provenance: `4540c6b3bc1` (PR #45531 file move) carried the original literal-newline regex; `c16bb8725a8` retained it while introducing UTF-16-safe truncation.
- Fresh independent Codex review of exact pushed head `d277e1b7a69` at `xhigh` effort: clean, confidence `0.96`.

Original contribution and branch by @guanbear; review follow-up preserves their commits and authorship. AI-assisted.
