### PR TITLE
fix(signal): reject malformed base64 attachment data

### DIFF
--- a/extensions/signal/src/monitor.attachment-base64.test.ts
+++ b/extensions/signal/src/monitor.attachment-base64.test.ts
@@ -1,0 +1,93 @@
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { SignalEventHandlerDeps } from "./monitor/event-handler.types.js";
+
+const signalRpcRequestMock = vi.hoisted(() => vi.fn());
+const saveMediaBufferMock = vi.hoisted(() => vi.fn());
+
+let capturedFetchAttachment: SignalEventHandlerDeps["fetchAttachment"] | undefined;
+
+vi.mock("openclaw/plugin-sdk/media-runtime", async () => {
+  const actual = await vi.importActual<typeof import("openclaw/plugin-sdk/media-runtime")>(
+    "openclaw/plugin-sdk/media-runtime",
+  );
+  return {
+    ...actual,
+    saveMediaBuffer: saveMediaBufferMock,
+  };
+});
+
+vi.mock("./client-adapter.js", async () => {
+  const actual = await vi.importActual<typeof import("./client-adapter.js")>("./client-adapter.js");
+  return {
+    ...actual,
+    signalRpcRequest: signalRpcRequestMock,
+  };
+});
+
+vi.mock("./monitor/event-handler.js", () => ({
+  createSignalEventHandler: (deps: SignalEventHandlerDeps) => {
+    capturedFetchAttachment = deps.fetchAttachment;
+    return async () => {};
+  },
+}));
+
+vi.mock("./signal-ingress.js", () => ({
+  startSignalIngressMonitor: async () => ({
+    receive: async () => {},
+    stop: async () => {},
+  }),
+}));
+
+vi.mock("./sse-reconnect.js", () => ({
+  runSignalSseLoop: async () => {},
+}));
+
+const { monitorSignalProvider } = await import("./monitor.js");
+
+const config = {
+  channels: {
+    signal: {
+      transport: { kind: "external-native", url: "http://127.0.0.1:8080" },
+      dmPolicy: "open",
+      allowFrom: ["*"],
+    },
+  },
+} satisfies OpenClawConfig;
+
+function requireCapturedFetchAttachment(): SignalEventHandlerDeps["fetchAttachment"] {
+  if (!capturedFetchAttachment) {
+    throw new Error("expected monitor to configure fetchAttachment");
+  }
+  return capturedFetchAttachment;
+}
+
+describe("Signal attachment fetch", () => {
+  beforeEach(() => {
+    capturedFetchAttachment = undefined;
+    signalRpcRequestMock.mockReset();
+    saveMediaBufferMock.mockReset().mockResolvedValue({
+      path: "/tmp/signal-attachment.png",
+      contentType: "image/png",
+    });
+  });
+
+  it("rejects malformed base64 attachment data", async () => {
+    signalRpcRequestMock.mockResolvedValue({
+      data: "iVBORw0KGgoAAAANSUhE%%%UgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVQIW2Nk+M/wHwAF/gL+M6Q10QAAAABJRU5ErkJggg==",
+    });
+
+    await monitorSignalProvider({ config, autoStart: false });
+    const fetchAttachment = requireCapturedFetchAttachment();
+
+    await expect(
+      fetchAttachment({
+        baseUrl: "http://127.0.0.1:8080",
+        attachment: { id: "attachment-123", contentType: "image/png" },
+        sender: "+15550001111",
+        maxBytes: 8 * 1024 * 1024,
+      }),
+    ).rejects.toThrow("Signal attachment attachment-123 returned malformed base64 data");
+    expect(saveMediaBufferMock).not.toHaveBeenCalled();
+  });
+});

--- a/extensions/signal/src/monitor.ts
+++ b/extensions/signal/src/monitor.ts
@@ -9,6 +9,7 @@ import type {
   SignalReactionNotificationMode,
 } from "openclaw/plugin-sdk/config-contracts";
 import {
+  canonicalizeBase64,
   detectMime,
   estimateBase64DecodedBytes,
   saveMediaBuffer,
@@ -315,7 +316,11 @@ async function fetchAttachment(params: {
       `Signal attachment ${attachment.id} exceeds ${(params.maxBytes / (1024 * 1024)).toFixed(0)}MB limit`,
     );
   }
-  const buffer = Buffer.from(result.data, "base64");
+  const canonicalData = canonicalizeBase64(result.data);
+  if (!canonicalData) {
+    throw new Error(`Signal attachment ${attachment.id} returned malformed base64 data`);
+  }
+  const buffer = Buffer.from(canonicalData, "base64");
   const originalFilename = normalizeOptionalString(attachment.filename ?? undefined);
   const contentType =
     normalizeOptionalString(attachment.contentType ?? undefined) ??


### PR DESCRIPTION
## What Problem This Solves

When signal-cli returns a damaged `getAttachment` payload — a truncated JSON-RPC response, a proxy that mangles the body, or a daemon-side bug — OpenClaw silently saves a corrupted attachment to the media directory and hands it to the agent as a normal image or file. Nothing fails and nothing is logged, so the user just gets a broken attachment and an agent reasoning over garbage bytes.

## Why This Change Was Made

`signalRpcRequest` in `extensions/signal/src/client.ts` ends with `return parsed.result as T` — a bare TypeScript cast with no runtime validation (the Signal extension only uses zod in `config-schema.ts`). So in `fetchAttachment` (`extensions/signal/src/monitor.ts`), `result.data` is an entirely unvalidated string from the daemon.

That string went straight into `Buffer.from(result.data, "base64")`. Node's base64 decoder is lenient: it drops characters outside the alphabet instead of throwing, so malformed input decodes into short/misaligned bytes that still look like a real payload. The pre-existing guard on the line above only calls `estimateBase64DecodedBytes`, which is computed from string length and therefore cannot detect an invalid alphabet or padding.

`extensions/signal/src/monitor.ts` owns this decode step, so the fix lives there and nowhere else: canonicalize with the shared SDK helper, and fail with the attachment id if it rejects. `canonicalizeBase64` was added to the module's existing `openclaw/plugin-sdk/media-runtime` import, which already provides `detectMime`, `estimateBase64DecodedBytes`, and `saveMediaBuffer` — no new helper, no new import path, no core `src/**` reach-through.

This matches the sibling shape already merged across the codebase for the same bug class: `extensions/google/speech-provider.ts`, `extensions/xai/tts.ts`, `extensions/volcengine/tts.ts`, and `src/agents/tool-images.ts` all canonicalize untrusted base64 before decoding. The Signal attachment path was missed.

Non-goals: the existing size guard keeps its behavior and its position ahead of the decode; no other base64 site, no other Signal behavior, and no retry/error-handling machinery is touched.

## User Impact

- Before: a malformed `getAttachment` payload is written to the media directory as a corrupted file and delivered as a valid attachment. No error surfaces.
- After: the fetch fails with `Signal attachment <id> returned malformed base64 data` and nothing is written.

## Evidence

**Real runtime proof.** A driver stands up an actual local HTTP server implementing the signal-cli `POST /api/v1/rpc` contract plus its SSE stream, returning a real PNG's base64 with three characters replaced by `%`. The real `monitorSignalProvider` runs in a child process against it and the actual media directory is inspected afterwards. No vitest, no test doubles in the decode path.

Before (fix stashed, unmodified `monitor.ts`):

```text
v24.18.0
canonicalizeBase64=undefined
Buffer.from(malformed, base64)=byteLength:68 firstBytes:89504e470d0a1a0a0000000d
getAttachment RPC calls=1
attachment error thrown=false
saved media files=1
saved media 21fae819-d493-4c74-ab66-5ac1411f9346.png=byteLength:68 firstBytes:89504e470d0a1a0a0000000d
```

After (fix applied):

```text
v24.18.0
canonicalizeBase64=undefined
Buffer.from(malformed, base64)=byteLength:68 firstBytes:89504e470d0a1a0a0000000d
getAttachment RPC calls=1
attachment error thrown=true
worker output=worker attachment error=attachment fetch failed: Error: Signal attachment proof-attachment returned malformed base64 data
saved media files=0
```

The first two lines are the core of it: `canonicalizeBase64` rejects the payload, yet `Buffer.from` happily returns 68 bytes that still carry the PNG magic number — which is exactly why the corrupted file looked legitimate on disk.

**Tests and checks.**

- Red first: on unmodified `monitor.ts` the new regression test failed with `AssertionError: promise resolved "{ …(2) }" instead of rejecting`, receiving `{ contentType: "image/png", path: "/tmp/signal-attachment.png" }`.
- Green: `node scripts/run-vitest.mjs extensions/signal/src/monitor.attachment-base64.test.ts` — 1 file, 1 test passed.
- Negative control: stashing only `extensions/signal/src/monitor.ts` reproduces the exact red failure, confirming the test guards this bug rather than passing incidentally.
- Full extension suite: `node scripts/run-vitest.mjs extensions/signal` — 731/732 passed. The single failure is `extensions/signal/src/install-signal-cli.test.ts` (download-temp cleanup expects `result.ok=true`), which is pre-existing on `main` and untouched by these files.
- `pnpm tsgo:extensions` and `pnpm tsgo:extensions:test` passed.
- `pnpm exec oxfmt --check --threads=1` on both changed files passed; `git diff --check` clean.

The regression test drives the real private `fetchAttachment` through the production wiring that `monitorSignalProvider` hands to `createSignalEventHandler`, and it spreads `importActual` for the media-runtime module so the genuine `canonicalizeBase64` executes rather than a stub. Only the network boundary and media persistence are mocked.

No changelog entry: this surfaces an error on an already-broken payload rather than changing documented behavior.

AI-assisted (Claude Code); I have reviewed every line and re-ran the regression and both proof runs myself after rebasing onto current `main`.
