### PR TITLE
fix(code-mode): preserve concurrent tool execution safely

### DIFF
--- a/src/agents/code-mode-execution.ts
+++ b/src/agents/code-mode-execution.ts
@@ -22,14 +22,17 @@ import {
 } from "./code-mode-runtime.js";
 import {
   activeRuns,
+  cancelPendingBridgeStates,
   codeModeWaitingReason,
   createPendingBridgeStates,
   disposeCodeModeRun,
   pendingBridgeRequestsReplaySafe,
+  pendingBridgeStatesForSettlement,
   pendingToolCalls,
   removeExpiredRuns,
   reserveActiveRunSlot,
   resumingRunIds,
+  settledBridgeRequestsInCompletionOrder,
   snapshotState,
   storeSnapshotState,
   telemetry,
@@ -156,11 +159,15 @@ async function waitForPending(
   pending: PendingBridgeState[],
   timeoutMs: number,
   signal?: AbortSignal,
+  waitForAll = false,
 ): Promise<boolean> {
   // Abort wins even over already-settled requests: callers treat `false` as
   // "do not resume the guest", which is what a cancelled exec/wait needs.
   if (signal?.aborted) {
     return false;
+  }
+  if (!waitForAll && pending.some((entry) => entry.settled)) {
+    return true;
   }
   const pendingPromises = pending.filter((entry) => !entry.settled).map((entry) => entry.promise);
   if (pendingPromises.length === 0) {
@@ -169,8 +176,11 @@ async function waitForPending(
   let timer: ReturnType<typeof setTimeout> | undefined;
   let onAbort: (() => void) | undefined;
   try {
+    const bridgeReady = waitForAll
+      ? Promise.all(pendingPromises).then(() => true)
+      : Promise.race(pendingPromises).then(() => true);
     return await Promise.race([
-      Promise.all(pendingPromises).then(() => true),
+      bridgeReady,
       new Promise<boolean>((resolve) => {
         timer = setTimeout(() => resolve(false), timeoutMs);
       }),
@@ -204,10 +214,14 @@ async function settleCodeModeResult(params: {
   runtime: ToolSearchRuntime;
   namespaceRuntime: CodeModeNamespaceRuntime;
   deadlineMs: number;
+  pending?: PendingBridgeState[];
+  activeRunId?: string;
   signal?: AbortSignal;
   onUpdate?: AgentToolUpdateCallback;
 }) {
   let result = params.result;
+  let pending = params.pending ?? [];
+  const activeRunId = params.activeRunId ?? `cm_${randomUUID()}`;
   const output = params.output;
   // One exec/wait call shares a single wall-clock deadline across its initial
   // worker run and this inline settle phase, so auto-draining bridge calls
@@ -239,6 +253,7 @@ async function settleCodeModeResult(params: {
       // Replay-safe runs never inline-drain: namespace calls stay a hard error
       // and other pending work falls through to the replay-safe snapshot check.
       if (result.pendingRequests.every((request) => request.method === "namespace")) {
+        cancelPendingBridgeStates(pending);
         return {
           status: "failed" as const,
           error: "restart-safe code mode cannot call namespace tools.",
@@ -255,28 +270,37 @@ async function settleCodeModeResult(params: {
       break;
     }
     if (params.signal?.aborted) {
+      cancelPendingBridgeStates(pending);
       return abortedResult();
     }
-    enforceSnapshotPayloadLimits({
-      snapshotBytes: result.snapshotBytes,
-      config: params.config,
-      output,
-    });
-    const releaseReservation = reserveActiveRunSlot();
+    let releaseReservation: (() => void) | undefined;
     try {
-      const activeRunId = `cm_${randomUUID()}`;
-      const pending = createPendingBridgeStates({
-        pendingRequests: result.pendingRequests,
-        runtime: params.runtime,
-        namespaceRuntime: params.namespaceRuntime,
-        parentToolCallId: params.parentToolCallId,
-        codeModeRunId: params.codeModeReplayId,
-        activeRunId,
-        ctx: params.ctx,
-        signal: params.signal,
-        onUpdate: params.onUpdate,
+      enforceSnapshotPayloadLimits({
+        snapshotBytes: result.snapshotBytes,
+        config: params.config,
+        output,
       });
-      const ready = await waitForPending(pending, remainingMs, params.signal);
+      releaseReservation = reserveActiveRunSlot();
+      const pendingIds = new Set(pending.map((entry) => entry.id));
+      pending.push(
+        ...createPendingBridgeStates({
+          pendingRequests: result.pendingRequests.filter((request) => !pendingIds.has(request.id)),
+          runtime: params.runtime,
+          namespaceRuntime: params.namespaceRuntime,
+          parentToolCallId: params.parentToolCallId,
+          codeModeRunId: params.codeModeReplayId,
+          activeRunId,
+          ctx: params.ctx,
+          signal: params.signal,
+          onUpdate: params.onUpdate,
+        }),
+      );
+      const ready = await waitForPending(
+        pendingBridgeStatesForSettlement(pending, result.settlementMode),
+        remainingMs,
+        params.signal,
+        result.settlementMode.kind === "draining",
+      );
       const resumeBudgetMs = ready
         ? usableResumeBudgetMs(settleDeadline, params.config)
         : undefined;
@@ -285,6 +309,7 @@ async function settleCodeModeResult(params: {
         // cancelled call could never be waited on and would pin one of the
         // process-global active-run slots until TTL expiry.
         if (params.signal?.aborted) {
+          cancelPendingBridgeStates(pending);
           return abortedResult();
         }
         // Parked rather than resumed: without a usable budget the restore alone
@@ -294,6 +319,7 @@ async function settleCodeModeResult(params: {
           replayId: params.codeModeReplayId,
           pending,
           replaySafe: false,
+          settlementMode: result.settlementMode,
           snapshotBytes: result.snapshotBytes,
           parentToolCallId: params.parentToolCallId,
           ctx: params.ctx,
@@ -303,10 +329,11 @@ async function settleCodeModeResult(params: {
           output,
         });
       }
-      const settledRequests: SettledBridgeRequest[] = [];
-      for (const entry of pending) {
-        settledRequests.push(entry.settled ?? (await entry.promise));
-      }
+      // Deliver the settled frontier only. Unresolved sibling promises remain
+      // attached to their original bridge ids across the restored snapshot.
+      const settledRequests: SettledBridgeRequest[] =
+        settledBridgeRequestsInCompletionOrder(pending);
+      pending = pending.filter((entry) => !entry.settled);
       // The resumed guest inherits only the remaining shared budget as its
       // QuickJS interrupt deadline; the extra host margin is watchdog grace,
       // not extra guest run time.
@@ -320,20 +347,25 @@ async function settleCodeModeResult(params: {
               timeoutMs: resumeBudgetMs,
             },
             settledRequests,
+            pendingRequests: pending.map(({ id, method, args }) => ({ id, method, args })),
           },
           resumeBudgetMs + CODE_MODE_WORKER_WATCHDOG_GRACE_MS,
           undefined,
           params.signal,
         ),
       );
+      output.push(...result.output);
+      enforceOutputLimit(output, params.config);
+    } catch (error) {
+      cancelPendingBridgeStates(pending);
+      throw error;
     } finally {
-      releaseReservation();
+      releaseReservation?.();
     }
-    output.push(...result.output);
-    enforceOutputLimit(output, params.config);
   }
   if (result.status === "waiting") {
     if (params.signal?.aborted) {
+      cancelPendingBridgeStates(pending);
       return abortedResult();
     }
     const pendingReplaySafe = pendingBridgeRequestsReplaySafe(
@@ -341,6 +373,7 @@ async function settleCodeModeResult(params: {
       params.runtime,
     );
     if (params.replaySafe && !pendingReplaySafe) {
+      cancelPendingBridgeStates(pending);
       return {
         status: "failed" as const,
         error: "restart-safe code mode cannot call side-effecting tools.",
@@ -349,6 +382,56 @@ async function settleCodeModeResult(params: {
         replaySafe: true,
         telemetry: telemetry(params.runtime),
       };
+    }
+    if (pending.length > 0) {
+      let releaseReservation: (() => void) | undefined;
+      try {
+        // A resumed guest can grow its next snapshot before the shared deadline
+        // expires; validate that new payload before reserving or parking it.
+        enforceSnapshotPayloadLimits({
+          snapshotBytes: result.snapshotBytes,
+          config: params.config,
+          output,
+        });
+        // Reserve before launching fresh work; transferred snapshots must
+        // obey the same process-wide active-run cap as initial suspensions.
+        releaseReservation = reserveActiveRunSlot();
+        const pendingIds = new Set(pending.map((entry) => entry.id));
+        pending.push(
+          ...createPendingBridgeStates({
+            pendingRequests: result.pendingRequests.filter(
+              (request) => !pendingIds.has(request.id),
+            ),
+            runtime: params.runtime,
+            namespaceRuntime: params.namespaceRuntime,
+            parentToolCallId: params.parentToolCallId,
+            codeModeRunId: params.codeModeReplayId,
+            activeRunId,
+            ctx: params.ctx,
+            signal: params.signal,
+            onUpdate: params.onUpdate,
+          }),
+        );
+        return storeSnapshotState({
+          runId: activeRunId,
+          replayId: params.codeModeReplayId,
+          pending,
+          replaySafe: params.replaySafe && pendingReplaySafe,
+          settlementMode: result.settlementMode,
+          snapshotBytes: result.snapshotBytes,
+          parentToolCallId: params.parentToolCallId,
+          ctx: params.ctx,
+          config: params.config,
+          runtime: params.runtime,
+          namespaceRuntime: params.namespaceRuntime,
+          output,
+        });
+      } catch (error) {
+        cancelPendingBridgeStates(pending);
+        throw error;
+      } finally {
+        releaseReservation?.();
+      }
     }
     return snapshotState({
       pendingRequests: result.pendingRequests,
@@ -361,10 +444,14 @@ async function settleCodeModeResult(params: {
       namespaceRuntime: params.namespaceRuntime,
       output,
       replaySafe: params.replaySafe,
+      settlementMode: result.settlementMode,
       signal: params.signal,
       onUpdate: params.onUpdate,
     });
   }
+  // Defensive cleanup covers aborts or terminal failures; successful runs have
+  // already drained every dispatched call before releasing their snapshot.
+  cancelPendingBridgeStates(pending);
   enforceResultLimit({
     output,
     value: result.status === "completed" ? result.value : undefined,
@@ -409,9 +496,10 @@ export async function runWait(params: {
   const deadlineMs = Date.now() + state.config.timeoutMs;
   try {
     const ready = await waitForPending(
-      state.pending,
+      pendingBridgeStatesForSettlement(state.pending, state.settlementMode),
       Math.max(1, deadlineMs - Date.now()),
       params.signal,
+      state.settlementMode.kind === "draining",
     );
     const resumeBudgetMs = ready ? usableResumeBudgetMs(deadlineMs, state.config) : undefined;
     if (!ready || resumeBudgetMs === undefined) {
@@ -443,11 +531,13 @@ export async function runWait(params: {
       };
     }
 
-    disposeCodeModeRun(state.runId);
-    const settledRequests: SettledBridgeRequest[] = [];
-    for (const entry of state.pending) {
-      settledRequests.push(entry.settled ?? (await entry.promise));
-    }
+    const settledRequests: SettledBridgeRequest[] = settledBridgeRequestsInCompletionOrder(
+      state.pending,
+    );
+    const pending = state.pending.filter((entry) => !entry.settled);
+    // Transfer outstanding calls to the next snapshot; dispose would abort a
+    // still-live sibling before the guest observes the completed frontier.
+    activeRuns.delete(state.runId);
     // The resumed guest inherits only the remaining shared budget as its QuickJS
     // interrupt deadline; the extra host margin is watchdog grace only.
     const result = normalizeCodeModeWorkerResult(
@@ -460,6 +550,7 @@ export async function runWait(params: {
             timeoutMs: resumeBudgetMs,
           },
           settledRequests,
+          pendingRequests: pending.map(({ id, method, args }) => ({ id, method, args })),
         },
         resumeBudgetMs + CODE_MODE_WORKER_WATCHDOG_GRACE_MS,
         undefined,
@@ -473,16 +564,23 @@ export async function runWait(params: {
       output,
       replaySafe: state.replaySafe,
       deadlineMs,
-      parentToolCallId: params.toolCallId,
+      parentToolCallId: state.parentToolCallId,
       codeModeReplayId: state.replayId,
       ctx: state.ctx,
       config: state.config,
       runtime: state.runtime,
       namespaceRuntime: state.namespaceRuntime,
+      pending,
+      activeRunId: state.runId,
       signal: params.signal,
       onUpdate: params.onUpdate,
     });
   } catch (error) {
+    // After ownership leaves activeRuns, worker/limit failures must cancel
+    // every transferred loser; there is no parked snapshot left to own it.
+    if (!activeRuns.has(state.runId)) {
+      cancelPendingBridgeStates(state.pending);
+    }
     return {
       status: "failed" as const,
       error: codeModeFailureMessage(error),

--- a/src/agents/code-mode-headless.test.ts
+++ b/src/agents/code-mode-headless.test.ts
@@ -94,6 +94,300 @@ describe("headless Code Mode", () => {
     expect(second.execute).toHaveBeenCalledOnce();
   });
 
+  it("keeps the headless race winner when the later-started tool settles first", async () => {
+    let firstAborted = false;
+    const first = fakeTool("headless_first_race", async (_toolCallId, _input, signal) => {
+      await new Promise<void>((resolve, reject) => {
+        const timer = setTimeout(resolve, 25);
+        signal?.addEventListener(
+          "abort",
+          () => {
+            clearTimeout(timer);
+            firstAborted = true;
+            reject(new Error("aborted"));
+          },
+          { once: true },
+        );
+      });
+      return jsonResult({ winner: "first" });
+    });
+    const second = fakeTool("headless_second_race", async () => jsonResult({ winner: "second" }));
+
+    const result = expectCompleted(
+      await runCodeModeScriptHeadless({
+        ctx: createHeadlessHarness([first, second]),
+        code: `return await Promise.race([
+          tools.callValue("openclaw:core:headless_first_race", {}),
+          tools.callValue("openclaw:core:headless_second_race", {}),
+        ]);`,
+        wallClockMs: 5_000,
+      }),
+    );
+
+    expect(result.value).toEqual({ winner: "second" });
+    expect(result.toolCallCount).toBe(2);
+    expect(first.execute).toHaveBeenCalledOnce();
+    expect(second.execute).toHaveBeenCalledOnce();
+    expect(firstAborted).toBe(false);
+  });
+
+  it("drains a headless nested combinator after its outer race wins", async () => {
+    let nestedAborted = false;
+    const never = fakeTool("headless_nested_race_never", async (_toolCallId, _input, signal) => {
+      await new Promise<void>((resolve, reject) => {
+        const timer = setTimeout(resolve, 25);
+        signal?.addEventListener(
+          "abort",
+          () => {
+            clearTimeout(timer);
+            nestedAborted = true;
+            reject(new Error("aborted"));
+          },
+          { once: true },
+        );
+      });
+      return jsonResult({ winner: "nested" });
+    });
+    const fast = fakeTool("headless_nested_race_fast", async () => jsonResult({ winner: "fast" }));
+
+    const result = expectCompleted(
+      await runCodeModeScriptHeadless({
+        ctx: createHeadlessHarness([never, fast]),
+        code: `return await Promise.race([
+          Promise.all([tools.callValue("openclaw:core:headless_nested_race_never", {})]),
+          tools.callValue("openclaw:core:headless_nested_race_fast", {}),
+        ]);`,
+        wallClockMs: 5_000,
+      }),
+    );
+
+    expect(result.value).toEqual({ winner: "fast" });
+    expect(result.toolCallCount).toBe(2);
+    expect(never.execute).toHaveBeenCalledOnce();
+    expect(fast.execute).toHaveBeenCalledOnce();
+    expect(nestedAborted).toBe(false);
+  });
+
+  it.each([
+    {
+      label: "directly",
+      auditCode: 'void tools.callValue("openclaw:core:headless_early_audit", {});',
+    },
+    {
+      label: "in a detached already-settled Promise.race",
+      auditCode:
+        'void Promise.race([tools.callValue("openclaw:core:headless_early_audit", {}), Promise.resolve()]);',
+    },
+    {
+      label: "in a detached Promise.all",
+      auditCode: 'void Promise.all([tools.callValue("openclaw:core:headless_early_audit", {})]);',
+    },
+    {
+      label: "in a detached Promise.allSettled",
+      auditCode:
+        'void Promise.allSettled([tools.callValue("openclaw:core:headless_early_audit", {})]);',
+    },
+    {
+      label: "in a detached Promise.any",
+      auditCode: 'void Promise.any([tools.callValue("openclaw:core:headless_early_audit", {})]);',
+    },
+    {
+      label: "in a detached Promise.race",
+      auditCode: 'void Promise.race([tools.callValue("openclaw:core:headless_early_audit", {})]);',
+    },
+  ])(
+    "drains a headless detached audit started $label before an awaited nested call",
+    async ({ auditCode }) => {
+      let auditCompleted = false;
+      let auditAborted = false;
+      const audit = fakeTool("headless_early_audit", async (_toolCallId, _input, signal) => {
+        await new Promise<void>((resolve, reject) => {
+          const timer = setTimeout(resolve, 250);
+          signal?.addEventListener(
+            "abort",
+            () => {
+              clearTimeout(timer);
+              auditAborted = true;
+              reject(new Error("aborted"));
+            },
+            { once: true },
+          );
+        });
+        auditCompleted = true;
+        return jsonResult({ recorded: true });
+      });
+      const fast = fakeTool("headless_awaited_fast", async () => jsonResult({ winner: "fast" }));
+
+      const result = expectCompleted(
+        await runCodeModeScriptHeadless({
+          ctx: createHeadlessHarness([audit, fast]),
+          code: `${auditCode}
+          return await tools.callValue("openclaw:core:headless_awaited_fast", {});`,
+          wallClockMs: 5_000,
+        }),
+      );
+
+      expect(result.value).toEqual({ winner: "fast" });
+      expect(result.toolCallCount).toBe(2);
+      expect(audit.execute).toHaveBeenCalledOnce();
+      expect(fast.execute).toHaveBeenCalledOnce();
+      expect(auditCompleted).toBe(true);
+      expect(auditAborted).toBe(false);
+    },
+  );
+
+  it("drains a headless race winner's detached audit and its slower race branch", async () => {
+    let loserAborted = false;
+    const winner = fakeTool("headless_race_winner", async () => jsonResult({ winner: "fast" }));
+    const loser = fakeTool("headless_race_loser", async (_toolCallId, _input, signal) => {
+      await new Promise<void>((resolve, reject) => {
+        const timer = setTimeout(resolve, 25);
+        signal?.addEventListener(
+          "abort",
+          () => {
+            clearTimeout(timer);
+            loserAborted = true;
+            reject(new Error("aborted"));
+          },
+          { once: true },
+        );
+      });
+      return jsonResult({ winner: "slow" });
+    });
+    const audit = fakeTool("headless_race_audit", async () => jsonResult({ recorded: true }));
+
+    const result = expectCompleted(
+      await runCodeModeScriptHeadless({
+        ctx: createHeadlessHarness([winner, loser, audit]),
+        code: `return Promise.race([
+          tools.callValue("openclaw:core:headless_race_winner", {}),
+          tools.callValue("openclaw:core:headless_race_loser", {}),
+        ]).then((value) => {
+          void tools.callValue("openclaw:core:headless_race_audit", {});
+          return value;
+        });`,
+        wallClockMs: 5_000,
+      }),
+    );
+
+    expect(result.value).toEqual({ winner: "fast" });
+    expect(result.toolCallCount).toBe(3);
+    expect(winner.execute).toHaveBeenCalledOnce();
+    expect(loser.execute).toHaveBeenCalledOnce();
+    expect(audit.execute).toHaveBeenCalledOnce();
+    expect(loserAborted).toBe(false);
+  });
+
+  it("drains every detached headless tool before completing the guest", async () => {
+    const first = fakeTool("headless_detached_first", async () => jsonResult({ name: "first" }));
+    const second = fakeTool("headless_detached_second", async () => jsonResult({ name: "second" }));
+
+    const result = expectCompleted(
+      await runCodeModeScriptHeadless({
+        ctx: createHeadlessHarness([first, second]),
+        code: `void tools.callValue("openclaw:core:headless_detached_first", {});
+          void tools.callValue("openclaw:core:headless_detached_second", {});
+          return "done";`,
+        wallClockMs: 5_000,
+      }),
+    );
+
+    expect(result.value).toBe("done");
+    expect(result.toolCallCount).toBe(2);
+    expect(first.execute).toHaveBeenCalledOnce();
+    expect(second.execute).toHaveBeenCalledOnce();
+  });
+
+  it.each(["race", "any"] as const)(
+    "preserves the headless Promise.%s winner while draining the slower nested tool",
+    async (combinator) => {
+      let slowAborted = false;
+      let slowCompleted = false;
+      const fast = fakeTool("headless_fast", async () => jsonResult({ winner: "fast" }));
+      const slow = fakeTool("headless_slow", async (_toolCallId, _input, signal) => {
+        await new Promise<void>((resolve, reject) => {
+          const timer = setTimeout(resolve, 25);
+          signal?.addEventListener(
+            "abort",
+            () => {
+              clearTimeout(timer);
+              slowAborted = true;
+              reject(new Error("aborted"));
+            },
+            { once: true },
+          );
+        });
+        slowCompleted = true;
+        return jsonResult({ winner: "slow" });
+      });
+
+      const result = expectCompleted(
+        await runCodeModeScriptHeadless({
+          ctx: createHeadlessHarness([fast, slow]),
+          code: `return await Promise.${combinator}([
+            tools.callValue("openclaw:core:headless_fast", {}),
+            tools.callValue("openclaw:core:headless_slow", {}),
+          ]);`,
+          wallClockMs: 5_000,
+        }),
+      );
+
+      expect(result.value).toEqual({ winner: "fast" });
+      expect(result.toolCallCount).toBe(2);
+      expect(fast.execute).toHaveBeenCalledOnce();
+      expect(slow.execute).toHaveBeenCalledOnce();
+      expect(slowCompleted).toBe(true);
+      expect(slowAborted).toBe(false);
+    },
+  );
+
+  it("preserves headless fail-fast Promise.all while draining the slower nested tool", async () => {
+    let slowAborted = false;
+    let slowCompleted = false;
+    const failed = fakeTool("headless_failed", async () => {
+      throw new Error("fast failure");
+    });
+    const slow = fakeTool("headless_slow", async (_toolCallId, _input, signal) => {
+      await new Promise<void>((resolve, reject) => {
+        const timer = setTimeout(resolve, 25);
+        signal?.addEventListener(
+          "abort",
+          () => {
+            clearTimeout(timer);
+            slowAborted = true;
+            reject(new Error("aborted"));
+          },
+          { once: true },
+        );
+      });
+      slowCompleted = true;
+      return jsonResult({ winner: "slow" });
+    });
+
+    const result = expectCompleted(
+      await runCodeModeScriptHeadless({
+        ctx: createHeadlessHarness([failed, slow]),
+        code: `try {
+          await Promise.all([
+            tools.callValue("openclaw:core:headless_failed", {}),
+            tools.callValue("openclaw:core:headless_slow", {}),
+          ]);
+          return "unexpected success";
+        } catch (error) {
+          return error.message;
+        }`,
+        wallClockMs: 5_000,
+      }),
+    );
+
+    expect(result.value).toBe("fast failure");
+    expect(result.toolCallCount).toBe(2);
+    expect(failed.execute).toHaveBeenCalledOnce();
+    expect(slow.execute).toHaveBeenCalledOnce();
+    expect(slowCompleted).toBe(true);
+    expect(slowAborted).toBe(false);
+  });
+
   it("does not expose collector globals without resumable snapshot state", async () => {
     const result = expectCompleted(
       await runCodeModeScriptHeadless({

--- a/src/agents/code-mode-headless.ts
+++ b/src/agents/code-mode-headless.ts
@@ -1,6 +1,5 @@
 import { randomUUID } from "node:crypto";
 import { clampNumber } from "../utils.js";
-import { runBridgeRequest } from "./code-mode-bridge.js";
 import { toCodeModeJsonSafe } from "./code-mode-json.js";
 import {
   createCodeModeNamespaceRuntime,
@@ -28,6 +27,13 @@ import {
   type CodeModeHeadlessResult,
   type CodeModeWorkerResult,
 } from "./code-mode-runtime.js";
+import {
+  cancelPendingBridgeStates,
+  createPendingBridgeStates,
+  pendingBridgeStatesForSettlement,
+  settledBridgeRequestsInCompletionOrder,
+  type PendingBridgeState,
+} from "./code-mode-state.js";
 import {
   CodeModeHeadlessAbortError,
   CodeModeHeadlessTimeoutError,
@@ -235,6 +241,7 @@ export async function runCodeModeScriptHeadless(params: {
   const deadline = Date.now() + wallClockMs;
   const abortScope = createHeadlessAbortScope(params.signal, wallClockMs);
   const output: unknown[] = [];
+  let pending: PendingBridgeState[] = [];
   let toolCallCount = 0;
   try {
     // Headless runs publish no resumable snapshot/handle, so collector globals stay unavailable.
@@ -288,7 +295,9 @@ export async function runCodeModeScriptHeadless(params: {
       }
 
       enforceSnapshotPayloadLimits({ snapshotBytes: result.snapshotBytes, config, output });
-      const requestedToolCalls = result.pendingRequests.filter(
+      const pendingIds = new Set(pending.map((entry) => entry.id));
+      const newRequests = result.pendingRequests.filter((request) => !pendingIds.has(request.id));
+      const requestedToolCalls = newRequests.filter(
         (request) =>
           request.method === "call" ||
           request.method === "callValue" ||
@@ -304,29 +313,56 @@ export async function runCodeModeScriptHeadless(params: {
         });
       }
 
-      const settledRequests = await awaitHeadlessDeadline({
-        promise: Promise.all(
-          result.pendingRequests.map((request) =>
-            runBridgeRequest({
-              runtime,
-              namespaceRuntime,
-              parentToolCallId,
-              codeModeRunId,
-              ctx: params.ctx,
-              request,
-              signal: abortScope.signal,
-            }),
-          ),
-        ),
+      pending.push(
+        ...createPendingBridgeStates({
+          pendingRequests: newRequests,
+          runtime,
+          namespaceRuntime,
+          parentToolCallId,
+          codeModeRunId,
+          ctx: params.ctx,
+          signal: abortScope.signal,
+        }),
+      );
+      const frontierPending = pendingBridgeStatesForSettlement(pending, result.settlementMode);
+      if (frontierPending.length === 0) {
+        return headlessFailure({
+          code: "internal_error",
+          error: "code mode is waiting without pending bridge requests",
+          output,
+          toolCallCount,
+        });
+      }
+      // Detached calls belong to an already-completed guest and must all run;
+      // an awaiting guest resumes at its actual first settled frontier.
+      const bridgeFrontier =
+        result.settlementMode.kind === "awaiting"
+          ? Promise.race(frontierPending.map((entry) => entry.promise))
+          : Promise.all(frontierPending.map((entry) => entry.promise)).then((settled) => {
+              const first = settled[0];
+              if (!first) {
+                throw new Error("code mode is waiting without pending bridge requests");
+              }
+              return first;
+            });
+      const firstSettled = await awaitHeadlessDeadline({
+        promise: bridgeFrontier,
         deadline,
         signal: abortScope.signal,
       });
+      const settledRequests = settledBridgeRequestsInCompletionOrder(pending);
+      if (!settledRequests.some((entry) => entry.id === firstSettled.id)) {
+        settledRequests.push(firstSettled);
+      }
+      const settledIds = new Set(settledRequests.map((entry) => entry.id));
+      pending = pending.filter((entry) => !settledIds.has(entry.id));
       result = normalizeCodeModeWorkerResult(
         await runHeadlessWorkerLeg({
           input: {
             kind: "resume",
             snapshotBytes: result.snapshotBytes,
             settledRequests,
+            pendingRequests: pending.map(({ id, method, args }) => ({ id, method, args })),
           },
           config,
           deadline,
@@ -344,6 +380,7 @@ export async function runCodeModeScriptHeadless(params: {
       toolCallCount,
     });
   } finally {
+    cancelPendingBridgeStates(pending);
     abortScope.cleanup();
   }
 }

--- a/src/agents/code-mode-runtime.ts
+++ b/src/agents/code-mode-runtime.ts
@@ -93,6 +93,10 @@ export type CodeModeHeadlessResult =
       toolCallCount: number;
     };
 
+export type CodeModeSettlementMode =
+  | { kind: "awaiting" }
+  | { kind: "draining"; requiredRequestIds: string[] };
+
 export type CodeModeWorkerResult =
   | {
       status: "completed";
@@ -103,6 +107,7 @@ export type CodeModeWorkerResult =
       status: "waiting";
       snapshotBytes: Uint8Array;
       pendingRequests: PendingBridgeRequest[];
+      settlementMode: CodeModeSettlementMode;
       output: unknown[];
     }
   | {

--- a/src/agents/code-mode-state.ts
+++ b/src/agents/code-mode-state.ts
@@ -9,6 +9,7 @@ import type { CodeModeNamespaceRuntime } from "./code-mode-namespaces.js";
 import {
   enforceSnapshotPayloadLimits,
   type CodeModeConfig,
+  type CodeModeSettlementMode,
   type PendingBridgeRequest,
   type SettledBridgeRequest,
 } from "./code-mode-runtime.js";
@@ -19,6 +20,7 @@ import { ToolInputError } from "./tools/common.js";
 export type PendingBridgeState = PendingBridgeRequest & {
   promise: Promise<SettledBridgeRequest>;
   settled?: SettledBridgeRequest;
+  settledSequence?: number;
   cancel?: () => void;
 };
 
@@ -30,6 +32,7 @@ type CodeModeRunState = {
   config: CodeModeConfig;
   snapshotBytes: Uint8Array;
   pending: PendingBridgeState[];
+  settlementMode: CodeModeSettlementMode;
   // True only when every future bridge call is enforced read-only before execution.
   replaySafe: boolean;
   output: unknown[];
@@ -46,6 +49,7 @@ const MAX_AGENT_WAIT_SNAPSHOT_TTL_WINDOWS = 4;
 export const activeRuns = new Map<string, CodeModeRunState>();
 export const resumingRunIds = new Set<string>();
 let activeRunReservations = 0;
+let nextPendingBridgeSettlementSequence = 0;
 
 export function removeExpiredRuns(now = Date.now()): void {
   for (const [runId, state] of activeRuns) {
@@ -69,13 +73,40 @@ export function removeExpiredRuns(now = Date.now()): void {
 
 export function disposeCodeModeRun(runId: string): void {
   const state = activeRuns.get(runId);
-  for (const pending of state?.pending ?? []) {
-    if (!pending.settled) {
-      pending.cancel?.();
-    }
-  }
+  cancelPendingBridgeStates(state?.pending ?? []);
   activeRuns.delete(runId);
   resumingRunIds.delete(runId);
+}
+
+/** Abort each bridge call whose result has not already reached its guest. */
+export function cancelPendingBridgeStates(pending: readonly PendingBridgeState[]): void {
+  for (const entry of pending) {
+    if (!entry.settled) {
+      entry.cancel?.();
+    }
+  }
+}
+
+/** Deliver bridge responses in actual settlement order, not request order. */
+export function settledBridgeRequestsInCompletionOrder(
+  pending: readonly PendingBridgeState[],
+): SettledBridgeRequest[] {
+  return pending
+    .filter((entry) => entry.settled !== undefined)
+    .toSorted((left, right) => (left.settledSequence ?? 0) - (right.settledSequence ?? 0))
+    .flatMap((entry) => (entry.settled ? [entry.settled] : []));
+}
+
+/** Keep every dispatched bridge call required until its guest has received the result. */
+export function pendingBridgeStatesForSettlement(
+  pending: PendingBridgeState[],
+  settlementMode: CodeModeSettlementMode,
+): PendingBridgeState[] {
+  if (settlementMode.kind === "awaiting") {
+    return pending;
+  }
+  const requiredRequestIds = new Set(settlementMode.requiredRequestIds);
+  return pending.filter((entry) => requiredRequestIds.has(entry.id));
 }
 
 function resolveCodeModeSnapshotExpiresAt(now: number, ttlSeconds: number): number | undefined {
@@ -113,23 +144,31 @@ export function snapshotState(params: {
   namespaceRuntime: CodeModeNamespaceRuntime;
   output: unknown[];
   replaySafe: boolean;
+  settlementMode: CodeModeSettlementMode;
   signal?: AbortSignal;
   onUpdate?: AgentToolUpdateCallback;
 }) {
   enforceSnapshotStateLimits(params);
   const runId = `cm_${randomUUID()}`;
-  return storeSnapshotState({
+  const pending = createPendingBridgeStates({
     ...params,
-    runId,
-    replayId: params.codeModeReplayId,
-    pending: createPendingBridgeStates({
-      ...params,
-      activeRunId: runId,
-      codeModeRunId: params.codeModeReplayId,
-    }),
-    replaySafe:
-      params.replaySafe && pendingBridgeRequestsReplaySafe(params.pendingRequests, params.runtime),
+    activeRunId: runId,
+    codeModeRunId: params.codeModeReplayId,
   });
+  try {
+    return storeSnapshotState({
+      ...params,
+      runId,
+      replayId: params.codeModeReplayId,
+      pending,
+      replaySafe:
+        params.replaySafe &&
+        pendingBridgeRequestsReplaySafe(params.pendingRequests, params.runtime),
+    });
+  } catch (error) {
+    cancelPendingBridgeStates(pending);
+    throw error;
+  }
 }
 
 export function pendingBridgeRequestsReplaySafe(
@@ -197,6 +236,7 @@ export function createPendingBridgeStates(params: {
       cancel: () => abortController.abort(),
     };
     void promise.then((settled) => {
+      state.settledSequence = ++nextPendingBridgeSettlementSequence;
       state.settled = settled;
       if (state.method === "agentWait" && params.activeRunId) {
         const active = activeRuns.get(params.activeRunId);
@@ -220,6 +260,7 @@ export function storeSnapshotState(params: {
   replayId: string;
   pending: PendingBridgeState[];
   replaySafe: boolean;
+  settlementMode: CodeModeSettlementMode;
   snapshotBytes: Uint8Array;
   parentToolCallId: string;
   ctx: ToolSearchToolContext;
@@ -250,6 +291,7 @@ export function storeSnapshotState(params: {
     config: params.config,
     snapshotBytes: params.snapshotBytes,
     pending: params.pending,
+    settlementMode: params.settlementMode,
     replaySafe: params.replaySafe,
     output: params.output,
     createdAt: now,
@@ -278,7 +320,11 @@ export function codeModeWaitingReason(
 }
 
 export function pendingToolCalls(pending: readonly PendingBridgeState[]) {
-  return pending.map((entry) => ({ id: entry.id, method: entry.method }));
+  // Settled calls remain in snapshots until QuickJS consumes their response,
+  // but they must not be advertised as outstanding work to exec or wait.
+  return pending
+    .filter((entry) => !entry.settled)
+    .map((entry) => ({ id: entry.id, method: entry.method }));
 }
 
 export function telemetry(runtime: ToolSearchRuntime) {

--- a/src/agents/code-mode-worker-types.ts
+++ b/src/agents/code-mode-worker-types.ts
@@ -55,7 +55,12 @@ export type CodeModeWorkerInput =
       snapshotBytes: Uint8Array;
       config: CodeModeConfig;
       settledRequests: SettledBridgeRequest[];
+      pendingRequests?: PendingBridgeRequest[];
     };
+
+export type CodeModeSettlementMode =
+  | { kind: "awaiting" }
+  | { kind: "draining"; requiredRequestIds: string[] };
 
 export type CodeModeWorkerResult =
   | {
@@ -67,6 +72,7 @@ export type CodeModeWorkerResult =
       status: "waiting";
       snapshotBytes: Uint8Array;
       pendingRequests: PendingBridgeRequest[];
+      settlementMode: CodeModeSettlementMode;
       output: unknown[];
     }
   | {

--- a/src/agents/code-mode-worker-types.ts
+++ b/src/agents/code-mode-worker-types.ts
@@ -58,7 +58,7 @@ export type CodeModeWorkerInput =
       pendingRequests?: PendingBridgeRequest[];
     };
 
-export type CodeModeSettlementMode =
+type CodeModeSettlementMode =
   | { kind: "awaiting" }
   | { kind: "draining"; requiredRequestIds: string[] };
 

--- a/src/agents/code-mode-worker.ts
+++ b/src/agents/code-mode-worker.ts
@@ -129,14 +129,14 @@ export async function runCodeModeWorker(
         finish(failedCodeModeWorkerResult(error, "runtime_unavailable"));
       });
       worker.once("exit", (code) => {
-        if (code !== 0) {
-          finish(
-            failedCodeModeWorkerResult(
-              new Error(`code mode worker exited with code ${code}`),
-              "runtime_unavailable",
-            ),
-          );
-        }
+        // A clean exit without a response is still unavailable; `finish` keeps
+        // the normal message-then-exit sequence from replacing a real result.
+        finish(
+          failedCodeModeWorkerResult(
+            new Error(`code mode worker exited with code ${code} before returning a result`),
+            "runtime_unavailable",
+          ),
+        );
       });
     });
   } finally {

--- a/src/agents/code-mode.test.ts
+++ b/src/agents/code-mode.test.ts
@@ -764,6 +764,61 @@ describe("Code Mode", () => {
     ).rejects.toThrow("code and command must match when both are provided");
   });
 
+  it("drains a nested combinator after its outer race wins", async () => {
+    const { config, catalogRef, tools: codeModeTools } = createCodeModeHarness();
+    let nestedAborted = false;
+    const never = pluginToolWithExecute(
+      "fake_nested_race_never",
+      "Never-settling nested race helper",
+      async (_toolCallId, _input, signal) => {
+        await new Promise<void>((resolve, reject) => {
+          const timer = setTimeout(resolve, 25);
+          signal?.addEventListener(
+            "abort",
+            () => {
+              clearTimeout(timer);
+              nestedAborted = true;
+              reject(new Error("aborted"));
+            },
+            { once: true },
+          );
+        });
+        return jsonResult({ winner: "nested" });
+      },
+    );
+    const fast = pluginToolWithExecute(
+      "fake_nested_race_fast",
+      "Fast nested race helper",
+      async () => jsonResult({ winner: "fast" }),
+    );
+    applyCodeModeCatalog({
+      tools: [...codeModeTools, never, fast],
+      config,
+      sessionId: "session-code-mode",
+      sessionKey: "agent:main:main",
+      runId: "run-code-mode",
+      catalogRef,
+    });
+
+    const details = resultDetails(
+      await expectDefined(codeModeTools[0], "Code Mode exec test invariant").execute(
+        "code-call-nested-combinator-race",
+        {
+          code: `return await Promise.race([
+            Promise.all([tools.callValue("fake_nested_race_never", {})]),
+            tools.callValue("fake_nested_race_fast", {}),
+          ]);`,
+        },
+      ),
+    );
+
+    expect(details).toMatchObject({ status: "completed", value: { winner: "fast" } });
+    expect(never.execute).toHaveBeenCalledOnce();
+    expect(fast.execute).toHaveBeenCalledOnce();
+    expect(nestedAborted).toBe(false);
+    expect(testing.activeRuns.size).toBe(0);
+  });
+
   it.each([
     { code: "ls -la /workspace/" },
     { code: "ls -1" },
@@ -925,6 +980,52 @@ describe("Code Mode", () => {
     expect(ticket.execute).toHaveBeenCalledTimes(1);
   });
 
+  it("returns structured values from named tools while preserving the raw call envelope", async () => {
+    const { config, catalogRef, tools: codeModeTools } = createCodeModeHarness();
+    const ticket = pluginTool("fake_create_ticket", "Create a fake ticket");
+    applyCodeModeCatalog({
+      tools: [...codeModeTools, ticket],
+      config,
+      sessionId: "session-code-mode",
+      sessionKey: "agent:main:main",
+      runId: "run-code-mode",
+      catalogRef,
+    });
+
+    const details = await runUntilCompleted({
+      execTool: expectDefined(codeModeTools[0], "codeModeTools[0] test invariant"),
+      waitTool: expectDefined(codeModeTools[1], "codeModeTools[1] test invariant"),
+      code: `
+        const id = "openclaw:fake-code-mode:fake_create_ticket";
+        const input = { value: "ship" };
+        return {
+          named: await tools.fake_create_ticket(input),
+          value: await tools.callValue(id, input),
+          envelope: await tools.call(id, input),
+        };
+      `,
+    });
+
+    const expectedValue = {
+      name: "fake_create_ticket",
+      input: { value: "ship" },
+    };
+    expect(details.status).toBe("completed");
+    expect(details.value).toEqual({
+      named: expectedValue,
+      value: expectedValue,
+      envelope: {
+        tool: expect.objectContaining({
+          id: "openclaw:fake-code-mode:fake_create_ticket",
+          name: "fake_create_ticket",
+        }),
+        result: expect.objectContaining({ details: expectedValue }),
+      },
+    });
+    expect(details.telemetry).toMatchObject({ callCount: 3 });
+    expect(ticket.execute).toHaveBeenCalledTimes(3);
+  });
+
   it("returns ordinary read content through tools.callValue", async () => {
     const { config, catalogRef, tools: codeModeTools } = createCodeModeHarness();
     const read = createOpenClawReadTool(
@@ -1003,6 +1104,357 @@ describe("Code Mode", () => {
     expect(details.status).toBe("completed");
     expect(details.value).toEqual([0, 1, 2, 3, 4]);
     expect(ticket.execute).toHaveBeenCalledTimes(5);
+    expect(testing.activeRuns.size).toBe(0);
+  });
+
+  it("keeps the actual winner when the later-started nested tool settles first", async () => {
+    const { config, catalogRef, tools: codeModeTools } = createCodeModeHarness();
+    let firstAborted = false;
+    const first = pluginToolWithExecute(
+      "fake_first",
+      "Earlier slow helper",
+      async (_toolCallId, _input, signal) => {
+        await new Promise<void>((resolve, reject) => {
+          const timer = setTimeout(resolve, 25);
+          signal?.addEventListener(
+            "abort",
+            () => {
+              clearTimeout(timer);
+              firstAborted = true;
+              reject(new Error("aborted"));
+            },
+            { once: true },
+          );
+        });
+        return jsonResult({ winner: "first" });
+      },
+    );
+    const second = pluginToolWithExecute("fake_second", "Later fast helper", async () =>
+      jsonResult({ winner: "second" }),
+    );
+    applyCodeModeCatalog({
+      tools: [...codeModeTools, first, second],
+      config,
+      sessionId: "session-code-mode",
+      sessionKey: "agent:main:main",
+      runId: "run-code-mode",
+      catalogRef,
+    });
+
+    const details = resultDetails(
+      await expectDefined(codeModeTools[0], "Code Mode exec test invariant").execute(
+        "code-call-later-winner",
+        {
+          code: `return await Promise.race([
+            tools.callValue("fake_first", {}),
+            tools.callValue("fake_second", {}),
+          ]);`,
+        },
+      ),
+    );
+
+    expect(details).toMatchObject({ status: "completed", value: { winner: "second" } });
+    expect(first.execute).toHaveBeenCalledOnce();
+    expect(second.execute).toHaveBeenCalledOnce();
+    expect(firstAborted).toBe(false);
+    expect(testing.activeRuns.size).toBe(0);
+  });
+
+  it.each([
+    {
+      label: "directly",
+      auditCode: 'void tools.callValue("fake_early_audit", {});',
+    },
+    {
+      label: "in a detached already-settled Promise.race",
+      auditCode: 'void Promise.race([tools.callValue("fake_early_audit", {}), Promise.resolve()]);',
+    },
+    {
+      label: "in a detached Promise.all",
+      auditCode: 'void Promise.all([tools.callValue("fake_early_audit", {})]);',
+    },
+    {
+      label: "in a detached Promise.allSettled",
+      auditCode: 'void Promise.allSettled([tools.callValue("fake_early_audit", {})]);',
+    },
+    {
+      label: "in a detached Promise.any",
+      auditCode: 'void Promise.any([tools.callValue("fake_early_audit", {})]);',
+    },
+    {
+      label: "in a detached Promise.race",
+      auditCode: 'void Promise.race([tools.callValue("fake_early_audit", {})]);',
+    },
+  ])(
+    "drains a detached audit started $label before an awaited nested call",
+    async ({ auditCode }) => {
+      const { config, catalogRef, tools: codeModeTools } = createCodeModeHarness();
+      let auditCompleted = false;
+      let auditAborted = false;
+      const audit = pluginToolWithExecute(
+        "fake_early_audit",
+        "Early detached audit",
+        async (_toolCallId, _input, signal) => {
+          await new Promise<void>((resolve, reject) => {
+            const timer = setTimeout(resolve, 250);
+            signal?.addEventListener(
+              "abort",
+              () => {
+                clearTimeout(timer);
+                auditAborted = true;
+                reject(new Error("aborted"));
+              },
+              { once: true },
+            );
+          });
+          auditCompleted = true;
+          return jsonResult({ recorded: true });
+        },
+      );
+      const fast = pluginToolWithExecute("fake_awaited_fast", "Awaited fast helper", async () =>
+        jsonResult({ winner: "fast" }),
+      );
+      applyCodeModeCatalog({
+        tools: [...codeModeTools, audit, fast],
+        config,
+        sessionId: "session-code-mode",
+        sessionKey: "agent:main:main",
+        runId: "run-code-mode",
+        catalogRef,
+      });
+
+      const details = resultDetails(
+        await expectDefined(codeModeTools[0], "Code Mode exec test invariant").execute(
+          "code-call-early-detached-audit",
+          {
+            code: `${auditCode}
+            return await tools.callValue("fake_awaited_fast", {});`,
+          },
+        ),
+      );
+
+      expect(details).toMatchObject({ status: "completed", value: { winner: "fast" } });
+      expect(audit.execute).toHaveBeenCalledOnce();
+      expect(fast.execute).toHaveBeenCalledOnce();
+      expect(auditCompleted).toBe(true);
+      expect(auditAborted).toBe(false);
+      expect(testing.activeRuns.size).toBe(0);
+    },
+  );
+
+  it("drains a race winner's detached audit and its slower race branch", async () => {
+    const { config, catalogRef, tools: codeModeTools } = createCodeModeHarness();
+    let loserAborted = false;
+    const winner = pluginToolWithExecute("fake_race_winner", "Race winner", async () =>
+      jsonResult({ winner: "fast" }),
+    );
+    const loser = pluginToolWithExecute(
+      "fake_race_loser",
+      "Race loser",
+      async (_toolCallId, _input, signal) => {
+        await new Promise<void>((resolve, reject) => {
+          const timer = setTimeout(resolve, 25);
+          signal?.addEventListener(
+            "abort",
+            () => {
+              clearTimeout(timer);
+              loserAborted = true;
+              reject(new Error("aborted"));
+            },
+            { once: true },
+          );
+        });
+        return jsonResult({ winner: "slow" });
+      },
+    );
+    const audit = pluginToolWithExecute("fake_race_audit", "Detached audit", async () =>
+      jsonResult({ recorded: true }),
+    );
+    applyCodeModeCatalog({
+      tools: [...codeModeTools, winner, loser, audit],
+      config,
+      sessionId: "session-code-mode",
+      sessionKey: "agent:main:main",
+      runId: "run-code-mode",
+      catalogRef,
+    });
+
+    const details = resultDetails(
+      await expectDefined(codeModeTools[0], "Code Mode exec test invariant").execute(
+        "code-call-race-detached-audit",
+        {
+          code: `return Promise.race([
+            tools.callValue("fake_race_winner", {}),
+            tools.callValue("fake_race_loser", {}),
+          ]).then((value) => {
+            void tools.callValue("fake_race_audit", {});
+            return value;
+          });`,
+        },
+      ),
+    );
+
+    expect(details).toMatchObject({ status: "completed", value: { winner: "fast" } });
+    expect(winner.execute).toHaveBeenCalledOnce();
+    expect(loser.execute).toHaveBeenCalledOnce();
+    expect(audit.execute).toHaveBeenCalledOnce();
+    expect(loserAborted).toBe(false);
+    expect(testing.activeRuns.size).toBe(0);
+  });
+
+  it("drains every detached nested tool before completing the guest", async () => {
+    const { config, catalogRef, tools: codeModeTools } = createCodeModeHarness();
+    const first = pluginToolWithExecute("fake_detached_first", "First detached helper", async () =>
+      jsonResult({ name: "first" }),
+    );
+    const second = pluginToolWithExecute(
+      "fake_detached_second",
+      "Second detached helper",
+      async () => jsonResult({ name: "second" }),
+    );
+    applyCodeModeCatalog({
+      tools: [...codeModeTools, first, second],
+      config,
+      sessionId: "session-code-mode",
+      sessionKey: "agent:main:main",
+      runId: "run-code-mode",
+      catalogRef,
+    });
+
+    const details = resultDetails(
+      await expectDefined(codeModeTools[0], "Code Mode exec test invariant").execute(
+        "code-call-detached",
+        {
+          code: `void tools.callValue("fake_detached_first", {});
+            void tools.callValue("fake_detached_second", {});
+            return "done";`,
+        },
+      ),
+    );
+
+    expect(details).toMatchObject({ status: "completed", value: "done" });
+    expect(first.execute).toHaveBeenCalledOnce();
+    expect(second.execute).toHaveBeenCalledOnce();
+    expect(testing.activeRuns.size).toBe(0);
+  });
+
+  it.each(["race", "any"] as const)(
+    "preserves the Promise.%s winner while draining the slower nested tool",
+    async (combinator) => {
+      const { config, catalogRef, tools: codeModeTools } = createCodeModeHarness();
+      let slowAborted = false;
+      let slowCompleted = false;
+      const fast = pluginToolWithExecute("fake_fast", "Fast helper", async () =>
+        jsonResult({ winner: "fast" }),
+      );
+      const slow = pluginToolWithExecute(
+        "fake_slow",
+        "Slow helper",
+        async (_toolCallId, _input, signal) => {
+          await new Promise<void>((resolve, reject) => {
+            const timer = setTimeout(resolve, 25);
+            signal?.addEventListener(
+              "abort",
+              () => {
+                clearTimeout(timer);
+                slowAborted = true;
+                reject(new Error("aborted"));
+              },
+              { once: true },
+            );
+          });
+          slowCompleted = true;
+          return jsonResult({ winner: "slow" });
+        },
+      );
+      applyCodeModeCatalog({
+        tools: [...codeModeTools, fast, slow],
+        config,
+        sessionId: "session-code-mode",
+        sessionKey: "agent:main:main",
+        runId: "run-code-mode",
+        catalogRef,
+      });
+
+      const details = resultDetails(
+        await expectDefined(codeModeTools[0], "Code Mode exec test invariant").execute(
+          `code-call-${combinator}-fast`,
+          {
+            code: `return await Promise.${combinator}([
+              tools.callValue("fake_fast", {}),
+              tools.callValue("fake_slow", {}),
+            ]);`,
+          },
+        ),
+      );
+
+      expect(details).toMatchObject({ status: "completed", value: { winner: "fast" } });
+      expect(fast.execute).toHaveBeenCalledOnce();
+      expect(slow.execute).toHaveBeenCalledOnce();
+      expect(slowCompleted).toBe(true);
+      expect(slowAborted).toBe(false);
+      expect(testing.activeRuns.size).toBe(0);
+    },
+  );
+
+  it("preserves fail-fast Promise.all while draining the slower nested tool", async () => {
+    const { config, catalogRef, tools: codeModeTools } = createCodeModeHarness();
+    let slowAborted = false;
+    let slowCompleted = false;
+    const failed = pluginToolWithExecute("fake_failed", "Failed helper", async () => {
+      throw new Error("fast failure");
+    });
+    const slow = pluginToolWithExecute(
+      "fake_slow",
+      "Slow helper",
+      async (_toolCallId, _input, signal) => {
+        await new Promise<void>((resolve, reject) => {
+          const timer = setTimeout(resolve, 25);
+          signal?.addEventListener(
+            "abort",
+            () => {
+              clearTimeout(timer);
+              slowAborted = true;
+              reject(new Error("aborted"));
+            },
+            { once: true },
+          );
+        });
+        slowCompleted = true;
+        return jsonResult({ winner: "slow" });
+      },
+    );
+    applyCodeModeCatalog({
+      tools: [...codeModeTools, failed, slow],
+      config,
+      sessionId: "session-code-mode",
+      sessionKey: "agent:main:main",
+      runId: "run-code-mode",
+      catalogRef,
+    });
+
+    const details = resultDetails(
+      await expectDefined(codeModeTools[0], "Code Mode exec test invariant").execute(
+        "code-call-fail-fast",
+        {
+          code: `try {
+            await Promise.all([
+              tools.callValue("fake_failed", {}),
+              tools.callValue("fake_slow", {}),
+            ]);
+            return "unexpected success";
+          } catch (error) {
+            return error.message;
+          }`,
+        },
+      ),
+    );
+
+    expect(details).toMatchObject({ status: "completed", value: "fast failure" });
+    expect(failed.execute).toHaveBeenCalledOnce();
+    expect(slow.execute).toHaveBeenCalledOnce();
+    expect(slowCompleted).toBe(true);
+    expect(slowAborted).toBe(false);
     expect(testing.activeRuns.size).toBe(0);
   });
 
@@ -1599,6 +2051,43 @@ describe("Code Mode", () => {
     ]);
   });
 
+  it("preserves the original exec identity for tool calls after yield and wait", async () => {
+    const { config, catalogRef, tools: codeModeTools } = createCodeModeHarness();
+    const target = pluginTool("fake_resumed_identity", "Resumed identity helper");
+    applyCodeModeCatalog({
+      tools: [...codeModeTools, target],
+      config,
+      sessionId: "session-code-mode",
+      sessionKey: "agent:main:main",
+      runId: "run-code-mode",
+      catalogRef,
+    });
+
+    const suspended = resultDetails(
+      await expectDefined(codeModeTools[0], "Code Mode exec test invariant").execute(
+        "code-call-original-parent",
+        {
+          code: 'await yield_control("pause"); return await tools.callValue("fake_resumed_identity", {});',
+        },
+      ),
+    );
+    expect(suspended.status).toBe("waiting");
+
+    const resumed = resultDetails(
+      await expectDefined(codeModeTools[1], "Code Mode wait test invariant").execute(
+        "code-wait-different-parent",
+        { runId: suspended.runId },
+      ),
+    );
+
+    expect(resumed.status).toBe("completed");
+    expect(target.execute).toHaveBeenCalledOnce();
+    expect(vi.mocked(target.execute).mock.calls[0]?.[0]).toContain("code-call-original-parent");
+    expect(vi.mocked(target.execute).mock.calls[0]?.[0]).not.toContain(
+      "code-wait-different-parent",
+    );
+  });
+
   it("allocates distinct replay identities when a later turn reuses a tool-call id", async () => {
     const { config, catalogRef, tools: codeModeTools } = createCodeModeHarness();
     applyCodeModeCatalog({
@@ -2090,7 +2579,7 @@ describe("Code Mode", () => {
       ),
     );
     expect(first.status).toBe("waiting");
-    expect(first.pendingToolCalls).toHaveLength(2);
+    expect(first.pendingToolCalls).toEqual([expect.objectContaining({ method: "callValue" })]);
     const runId = first.runId;
     expect(typeof runId).toBe("string");
     if (typeof runId !== "string") {
@@ -2109,7 +2598,7 @@ describe("Code Mode", () => {
     );
 
     expect(second.status).toBe("waiting");
-    expect(second.pendingToolCalls).toEqual([expect.objectContaining({ method: "call" })]);
+    expect(second.pendingToolCalls).toEqual([expect.objectContaining({ method: "callValue" })]);
   });
 
   it("does not load TypeScript for plain JavaScript code mode runs", async () => {
@@ -2867,6 +3356,28 @@ describe("Code Mode", () => {
     expect(result.status).toBe("failed");
     expect(result).toMatchObject({
       code: "runtime_unavailable",
+    });
+  });
+
+  it("classifies clean worker exits without a result as unavailable", async () => {
+    const config = resolveCodeModeConfig({ tools: { codeMode: true } } as never);
+    const exitingWorkerUrl = new URL("data:text/javascript,");
+
+    const result = await testing.runCodeModeWorker(
+      {
+        kind: "exec",
+        source: "return 1;",
+        config,
+        catalog: [],
+      },
+      5_000,
+      exitingWorkerUrl,
+    );
+
+    expect(result).toMatchObject({
+      status: "failed",
+      code: "runtime_unavailable",
+      error: "code mode worker exited with code 0 before returning a result",
     });
   });
 

--- a/src/agents/code-mode.worker.ts
+++ b/src/agents/code-mode.worker.ts
@@ -264,7 +264,7 @@ const CONTROLLER_SOURCE = String.raw`
       continue;
     }
     Object.defineProperty(baseTools, name, {
-      value: (input) => request("call", [id, input]),
+      value: (input) => request("callValue", [id, input]),
       enumerable: true,
     });
   }
@@ -519,6 +519,7 @@ async function readCompletedResult(vm: QuickJS, resultHandle: JSValueHandle): Pr
 function waitingResult(params: {
   vm: QuickJS;
   pendingRequests: PendingBridgeRequest[];
+  settlementMode: Extract<CodeModeWorkerResult, { status: "waiting" }>["settlementMode"];
   output: unknown[];
   config: CodeModeConfig;
 }): CodeModeWorkerResult {
@@ -530,6 +531,7 @@ function waitingResult(params: {
     status: "waiting",
     snapshotBytes,
     pendingRequests: params.pendingRequests,
+    settlementMode: params.settlementMode,
     output: params.output,
   };
 }
@@ -548,18 +550,23 @@ async function runVmExecution(params: {
     output = takeOutput(params.vm);
     const resultHandle = params.vm.global.getProp("__openclawResult");
     try {
-      if (params.pendingRequests.length > 0) {
-        // Pending host work suspends the VM instead of blocking in-worker; the
-        // host resumes with settled bridge results via runResume.
+      const promisePending = resultHandle.isPromise && resultHandle.promiseState === 0;
+      if (promisePending && params.pendingRequests.length === 0) {
+        throw new Error("code mode promise is pending without host work");
+      }
+      const requiredPendingRequestIds = params.pendingRequests.map((request) => request.id);
+      if (promisePending || requiredPendingRequestIds.length > 0) {
+        // Native await does not expose Promise ownership. Every dispatched
+        // call remains required, including detached calls and race branches.
         return waitingResult({
           vm: params.vm,
           pendingRequests: params.pendingRequests,
+          settlementMode: promisePending
+            ? { kind: "awaiting" }
+            : { kind: "draining", requiredRequestIds: requiredPendingRequestIds },
           output,
           config: params.config,
         });
-      }
-      if (resultHandle.isPromise && resultHandle.promiseState === 0) {
-        throw new Error("code mode promise is pending without host work");
       }
       return {
         status: "completed",
@@ -607,7 +614,9 @@ async function runExec(input: Extract<CodeModeWorkerInput, { kind: "exec" }>) {
 }
 
 async function runResume(input: Extract<CodeModeWorkerInput, { kind: "resume" }>) {
-  const pendingRequests: PendingBridgeRequest[] = [];
+  // Restored promises keep their original bridge ids; do not redispatch calls
+  // that are still running when a faster sibling resumes this snapshot.
+  const pendingRequests: PendingBridgeRequest[] = [...(input.pendingRequests ?? [])];
   const { vm, didTimeout } = await restoreVm({
     snapshotBytes: input.snapshotBytes,
     config: input.config,
@@ -672,6 +681,9 @@ async function main(): Promise<CodeModeWorkerResult> {
         config: input.config as CodeModeConfig,
         settledRequests: Array.isArray(input.settledRequests)
           ? (input.settledRequests as SettledBridgeRequest[])
+          : [],
+        pendingRequests: Array.isArray(input.pendingRequests)
+          ? (input.pendingRequests as PendingBridgeRequest[])
           : [],
       });
     }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users running Code Mode with concurrent or detached tools could receive the wrong Promise race result, lose an in-flight side effect, see already-finished calls reported as pending, or lose the original execution identity after suspending and resuming. Resolves silent hangs when a guest worker exits cleanly without returning a result and preserves structured results from named convenience tools.

## Why This Change Was Made

Resume QuickJS snapshots in actual bridge completion order, carry unresolved requests across restore, and safely drain every dispatched tool before terminal completion. Native JavaScript await does not expose reliable promise ownership, so deliberately preserve native Promise semantics and never guess which race branches are disposable. Reserve and validate transferred snapshots, clean up pending requests on terminal errors and aborts, retain the original exec parent identity, and make clean resultless worker exits fail immediately.

## User Impact

Concurrent and headless Code Mode scripts preserve their actual race winner without dropping detached audits or side effects. Named tools return usable structured values, suspended execution remains traceable, waiting lists contain only truly unfinished calls, and worker/runtime failures surface promptly.

## Evidence

- Fresh independent autoreview: clean; no accepted or actionable findings.
- Blacksmith Testbox: all four Code Mode suites passing, 371 tests.
- 130,000 adversarial JavaScript, regular-expression, module-loader, and Unicode inputs.
- Interactive and headless real-worker coverage for race, any, fail-fast all, nested combinators, allSettled, detached already-settled races, cancellation, snapshot transfer, parent identity, 64 active runs, and clean worker exits.
- Hosted production/core check: both core and test typechecks, changed-file lint, format, plugin SDK and boundary checks, import cycles, snapshot/state guards, and auth/runtime guards.
- Hosted production build: packaged runtime, worker, plugin SDK declarations, Control UI, sidecars, and CLI bootstrap.
- Directly verified upstream Codex revision 3418498f01422f5f650ea645d4bd19e05c3a9616 in codex-rs/core/src/tools/code_mode/execute_handler.rs, codex-rs/core/src/tools/code_mode/wait_handler.rs, and codex-rs/code-mode/src/cell_actor/mod.rs.
- AI-assisted and independently autoreviewed.

### Inspectable hosted after-fix proof

```text
src/agents/code-mode.test.ts                207 passed
src/agents/code-mode-headless.test.ts        60 passed
src/agents/code-mode-runtime.test.ts         90 passed
src/agents/code-mode-swarm.test.ts           14 passed

Test Files  4 passed (4)
Tests       371 passed (371)

50,000 deterministic literal/module-shaped inputs: passed
50,000 adversarial division/regexp contexts: passed
20,000 disguised module-loader cases: passed
10,000 Unicode-shifted TypeScript module attempts: passed

detached already-settled Promise.race audit: completed
detached Promise.all, allSettled, any, race audits: completed
later-started race winner: preserved
nested outer race/inner Promise.all: winner preserved; slower call drained
resumed nested call: original exec parent identity preserved
zero-result clean worker exit: runtime_unavailable
settled pending calls: excluded from wait projection

[deadcode] Knip production unused-export scan passed with 0 entries.
[deadcode] Knip full-tree unused-export scan passed with 0 entries.
[deadcode] Knip script unused-export scan passed with 0 entries.
[deadcode] Knip production and full-tree unused-export checks passed with 0 entries.
```

### Maintainer decision

Adopt drain-all for every tool request already dispatched by a Code Mode cell. Preserve the real JavaScript Promise winner through completion-order snapshot replay, then allow all launched race branches and detached side effects to finish within the existing execution deadline. Explicit abort and deadline expiry still cancel outstanding calls and release the active-run slot. Native QuickJS await provides no observable ownership graph, so guessing that a completed Promise race owns another in-flight request would silently drop audits and other mutating operations. No JavaScript Promise monkey-patching, new config, compatibility fallback, SQLite migration, or public API is introduced.