### PR TITLE
feat(code-mode): first-class skills access

### DIFF
--- a/src/agents/code-mode-bridge.ts
+++ b/src/agents/code-mode-bridge.ts
@@ -11,6 +11,7 @@ import {
   type PendingBridgeRequest,
   type SettledBridgeRequest,
 } from "./code-mode-runtime.js";
+import { readCodeModeSkill } from "./code-mode-skills.js";
 import type { AgentToolUpdateCallback } from "./runtime/index.js";
 import { stableStringify } from "./stable-stringify.js";
 import { getSwarmRunByLaunchReplayKey, initSubagentRegistry } from "./subagent-registry.js";
@@ -506,6 +507,28 @@ export async function runBridgeRequest(params: {
       }
       case "agentWait": {
         value = await runAgentWaitBridge(params);
+        break;
+      }
+      case "skillsList": {
+        value = (params.ctx.codeModeSkills ?? []).map(({ name, description, location }) => ({
+          name,
+          description,
+          location,
+        }));
+        break;
+      }
+      case "skillsRead": {
+        const name = values[0];
+        const available = params.ctx.codeModeSkills ?? [];
+        const skill =
+          typeof name === "string" ? available.find((entry) => entry.name === name) : null;
+        if (!skill) {
+          const names = available.map((entry) => entry.name).join(", ") || "(none)";
+          throw new ToolInputError(
+            `Unknown skill ${JSON.stringify(name)}. Available skills: ${names}`,
+          );
+        }
+        value = await readCodeModeSkill(skill, params.signal);
         break;
       }
       case "swarmNote": {

--- a/src/agents/code-mode-runtime.ts
+++ b/src/agents/code-mode-runtime.ts
@@ -60,6 +60,8 @@ type CodeModeBridgeMethod =
   | "namespace"
   | "agentSpawn"
   | "agentWait"
+  | "skillsList"
+  | "skillsRead"
   | "swarmNote";
 
 export type PendingBridgeRequest = {

--- a/src/agents/code-mode-skills.ts
+++ b/src/agents/code-mode-skills.ts
@@ -1,0 +1,75 @@
+import { readFile } from "node:fs/promises";
+import type { Skill } from "../skills/loading/skill-contract.js";
+
+export type CodeModeSkill = {
+  name: string;
+  description: string;
+  location: string;
+  source: Pick<Skill, "filePath" | "readContent">;
+  reader?: CodeModeSkillReader;
+};
+
+export type CodeModeSkillReader = (params: {
+  location: string;
+  signal?: AbortSignal;
+}) => Promise<string>;
+
+function decodeXml(value: string): string {
+  return value
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&quot;/g, '"')
+    .replace(/&apos;/g, "'")
+    .replace(/&amp;/g, "&");
+}
+
+function readSkillField(block: string, field: "location" | "name"): string | undefined {
+  const match = new RegExp(`^[ ]{4}<${field}>(.*)</${field}>$`, "mu").exec(block)?.[1];
+  return match === undefined ? undefined : decodeXml(match);
+}
+
+/** Select Code Mode skills from the exact catalog rendered into this run's prompt. */
+export function resolveCodeModeSkills(params: {
+  skillsPrompt: string;
+  candidates: readonly Skill[];
+  reader?: CodeModeSkillReader;
+}): CodeModeSkill[] {
+  const catalog = /<available_skills>\n([\s\S]*?)\n<\/available_skills>/u.exec(
+    params.skillsPrompt,
+  )?.[1];
+  if (!catalog) {
+    return [];
+  }
+  const candidatesByName = new Map(params.candidates.map((skill) => [skill.name, skill]));
+  const result: CodeModeSkill[] = [];
+  for (const match of catalog.matchAll(/^[ ]{2}<skill>\n([\s\S]*?)\n[ ]{2}<\/skill>$/gmu)) {
+    const block = match[1] ?? "";
+    const name = readSkillField(block, "name");
+    const location = readSkillField(block, "location");
+    const source = name ? candidatesByName.get(name) : undefined;
+    if (!name || !location || !source) {
+      continue;
+    }
+    result.push({
+      name,
+      description: source.description,
+      location,
+      source: { filePath: source.filePath, readContent: source.readContent },
+      reader: params.reader,
+    });
+  }
+  return result;
+}
+
+export async function readCodeModeSkill(
+  skill: CodeModeSkill,
+  signal?: AbortSignal,
+): Promise<string> {
+  if (typeof skill.source.readContent === "string") {
+    return skill.source.readContent;
+  }
+  if (skill.reader) {
+    return await skill.reader({ location: skill.location, signal });
+  }
+  return await readFile(skill.source.filePath, { encoding: "utf8", signal });
+}

--- a/src/agents/code-mode-state.ts
+++ b/src/agents/code-mode-state.ts
@@ -181,7 +181,9 @@ export function pendingBridgeRequestsReplaySafe(
       request.method === "describe" ||
       request.method === "yield" ||
       request.method === "agentSpawn" ||
-      request.method === "agentWait"
+      request.method === "agentWait" ||
+      request.method === "skillsList" ||
+      request.method === "skillsRead"
     ) {
       return true;
     }

--- a/src/agents/code-mode-worker-types.ts
+++ b/src/agents/code-mode-worker-types.ts
@@ -11,6 +11,8 @@ type CodeModeBridgeMethod =
   | "namespace"
   | "agentSpawn"
   | "agentWait"
+  | "skillsList"
+  | "skillsRead"
   | "swarmNote";
 
 export type CodeModeConfig = {

--- a/src/agents/code-mode.test.ts
+++ b/src/agents/code-mode.test.ts
@@ -5,8 +5,10 @@ import { Type } from "typebox";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { runWithAgentToolExecutionContext } from "../../packages/agent-core/src/tool-execution-context.js";
 import { setPluginToolMeta } from "../plugins/tools.js";
+import type { Skill } from "../skills/loading/skill-contract.js";
 import { buildBlockedToolResult } from "./agent-tools.before-tool-call.js";
 import { createOpenClawReadTool } from "./agent-tools.read.js";
+import { resolveCodeModeSkills, type CodeModeSkill } from "./code-mode-skills.js";
 import {
   applyCodeModeCatalog,
   CODE_MODE_EXEC_TOOL_NAME,
@@ -24,6 +26,26 @@ import {
   TOOL_SEARCH_RAW_TOOL_NAME,
 } from "./tool-search.js";
 import { jsonResult, type AnyAgentTool } from "./tools/common.js";
+
+function skillCandidate(params: {
+  name: string;
+  description: string;
+  filePath: string;
+  readContent?: string;
+}): Skill {
+  return {
+    ...params,
+    baseDir: params.filePath.replace(/\/[^/]+$/u, ""),
+    sourceInfo: {
+      path: params.filePath,
+      source: "test",
+      scope: "temporary",
+      origin: "top-level",
+    },
+    disableModelInvocation: false,
+    source: "test",
+  };
+}
 
 function fakeTool(name: string, description: string): AnyAgentTool {
   // Minimal tool shape keeps Code Mode catalog tests runtime-free.
@@ -112,6 +134,7 @@ function createCodeModeHarness(
   params: {
     agentId?: string;
     catalogRef?: ToolSearchCatalogRef;
+    codeModeSkills?: readonly CodeModeSkill[];
     forceRestartSafeTools?: boolean;
   } = {},
 ) {
@@ -126,6 +149,7 @@ function createCodeModeHarness(
     runId: "run-code-mode",
     catalogRef,
     forceRestartSafeTools: params.forceRestartSafeTools,
+    codeModeSkills: params.codeModeSkills,
   };
   const tools = createCodeModeTools(ctx);
   return { catalogRef, config, ctx, tools };
@@ -1030,6 +1054,88 @@ describe("Code Mode", () => {
     });
     expect(details.telemetry).toMatchObject({ callCount: 3 });
     expect(ticket.execute).toHaveBeenCalledTimes(3);
+  });
+
+  it("lists and reads only prompt-eligible skills through the worker bridge", async () => {
+    const demo = skillCandidate({
+      name: "demo",
+      description: "Full demo description",
+      filePath: "/host/skills/demo/SKILL.md",
+    });
+    const hidden = skillCandidate({
+      name: "hidden",
+      description: "Hidden skill",
+      filePath: "/host/skills/hidden/SKILL.md",
+    });
+    const reader = vi.fn(async ({ location }: { location: string }) =>
+      location === "/guest/skills/demo/SKILL.md"
+        ? "---\nname: demo\n---\n\n# Complete demo instructions\n"
+        : "# Hidden\n",
+    );
+    const codeModeSkills = resolveCodeModeSkills({
+      skillsPrompt: [
+        "<available_skills>",
+        "  <skill>",
+        "    <name>demo</name>",
+        "    <description>Short prompt description</description>",
+        "    <location>/guest/skills/demo/SKILL.md</location>",
+        "  </skill>",
+        "</available_skills>",
+      ].join("\n"),
+      candidates: [demo, hidden],
+      reader,
+    });
+    const {
+      config,
+      catalogRef,
+      tools: codeModeTools,
+    } = createCodeModeHarness({
+      codeModeSkills,
+    });
+    applyCodeModeCatalog({
+      tools: [...codeModeTools, pluginTool("fake_noop", "Noop")],
+      config,
+      sessionId: "session-code-mode",
+      sessionKey: "agent:main:main",
+      runId: "run-code-mode",
+      catalogRef,
+      codeModeSkills,
+    });
+
+    const details = await runUntilCompleted({
+      execTool: expectDefined(codeModeTools[0], "codeModeTools[0] test invariant"),
+      waitTool: expectDefined(codeModeTools[1], "codeModeTools[1] test invariant"),
+      code: `
+        const listed = await skills.list();
+        const body = await skills.read("demo");
+        let unknown;
+        try {
+          await skills.read("missing");
+        } catch (error) {
+          unknown = error.message;
+        }
+        return { listed, body, unknown };
+      `,
+    });
+
+    expect(details.status).toBe("completed");
+    expect(details.value).toEqual({
+      listed: [
+        {
+          name: "demo",
+          description: "Full demo description",
+          location: "/guest/skills/demo/SKILL.md",
+        },
+      ],
+      body: "---\nname: demo\n---\n\n# Complete demo instructions\n",
+      unknown: 'Unknown skill "missing". Available skills: demo',
+    });
+    expect(codeModeTools[0]?.description).toContain("`await skills.read(name)`");
+    expect(reader).toHaveBeenCalledOnce();
+    expect(reader).toHaveBeenCalledWith({
+      location: "/guest/skills/demo/SKILL.md",
+      signal: expect.any(AbortSignal),
+    });
   });
 
   it("returns ordinary read content through tools.callValue", async () => {

--- a/src/agents/code-mode.test.ts
+++ b/src/agents/code-mode.test.ts
@@ -6,6 +6,8 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { runWithAgentToolExecutionContext } from "../../packages/agent-core/src/tool-execution-context.js";
 import { setPluginToolMeta } from "../plugins/tools.js";
 import type { Skill } from "../skills/loading/skill-contract.js";
+import { resolveSkillsPromptForRun } from "../skills/loading/workspace.js";
+import { createFixtureSkillEntry } from "../skills/test-support/test-helpers.js";
 import { buildBlockedToolResult } from "./agent-tools.before-tool-call.js";
 import { createOpenClawReadTool } from "./agent-tools.read.js";
 import { resolveCodeModeSkills, type CodeModeSkill } from "./code-mode-skills.js";
@@ -1054,6 +1056,24 @@ describe("Code Mode", () => {
     });
     expect(details.telemetry).toMatchObject({ callCount: 3 });
     expect(ticket.execute).toHaveBeenCalledTimes(3);
+  });
+
+  it("keeps Code Mode skill parsing aligned with the production prompt renderer", () => {
+    const entries = [createFixtureSkillEntry("alpha"), createFixtureSkillEntry("beta")];
+    const skillsPrompt = resolveSkillsPromptForRun({
+      entries,
+      workspaceDir: "/workspace",
+    });
+
+    expect(
+      resolveCodeModeSkills({
+        skillsPrompt,
+        candidates: entries.map((entry) => entry.skill),
+      }).map(({ name, location }) => ({ name, location })),
+    ).toEqual([
+      { name: "alpha", location: "/skills/alpha/SKILL.md" },
+      { name: "beta", location: "/skills/beta/SKILL.md" },
+    ]);
   });
 
   it("lists and reads only prompt-eligible skills through the worker bridge", async () => {

--- a/src/agents/code-mode.ts
+++ b/src/agents/code-mode.ts
@@ -146,6 +146,9 @@ function createCodeModeExecDescription(
     : "";
   const nodesGuidance =
     "\n- nodes: paired Gateway nodes; nodes.list(), (await nodes.get(id)).invoke(command, params)\n";
+  const skillsGuidance = ctx.codeModeSkills?.length
+    ? " Skills are available through the async `skills` global: use `await skills.list()` and `await skills.read(name)`."
+    : "";
   const catalogIndex = catalog ? formatCodeModeCatalogIndex(catalog) : "";
   return (
     "Run JavaScript or TypeScript in OpenClaw code mode. Use `return` to pass the final value back; otherwise the result is `null`. Quick-index arrows show trusted declared output hints; `-> ?` means never guess result field names. For declared fields, process them in the first exec; do not spend another exec inspecting them. Perform dependent reads, checks, and follow-up calls in order; parallelize independent work only. For an unknown output, including a final dependent call after declared-output calls, return the raw tool value unchanged; do not wrap it in the requested answer shape or guess fields; filter or map it only in a later exec. Nested calls enforce normal tool policy and approvals. `ALL_TOOLS` is the complete compact catalog. Select exact ids directly or with `tools.search(query: string, options?)`; use `tools.describe(id: string)` only when needed. Never invent or transform a tool id. `tools.callValue(id: string, args?)` returns its JSON value directly; `tools.call(id: string, args?)` preserves `{ tool, result }`. Example: `const hit = ALL_TOOLS.find((entry) => entry.description.includes('weather')) ?? (await tools.search('weather'))[0]; return await tools.callValue(hit.id, {});`. Node.js modules and `require`/`import` are NOT available; use enabled catalog tools allowed by policy for shell, file, network, or external actions." +
@@ -153,6 +156,7 @@ function createCodeModeExecDescription(
     mcpGuidance +
     swarmGuidance +
     nodesGuidance +
+    skillsGuidance +
     ' The `language` field accepts only "javascript" or "typescript"; do not pass "bash", "shell", or other values.' +
     " Both `code` and `command` contain JavaScript or TypeScript, never a shell command. " +
     "For shell or file operations, call the exact catalog tool from guest JavaScript; do not retry failed shell source." +
@@ -256,6 +260,7 @@ export function applyCodeModeCatalog(params: {
   catalogRef?: ToolSearchCatalogRef;
   toolHookContext?: HookContext;
   directToolNames?: Iterable<string>;
+  codeModeSkills?: CodeModeToolContext["codeModeSkills"];
 }) {
   const config = resolveCodeModeConfig(params.config, params.agentId);
   // Engagement (including "auto" per-model resolution) is decided by the run
@@ -303,6 +308,7 @@ export function applyCodeModeCatalog(params: {
           sessionKey: params.sessionKey,
           runId: params.runId,
           catalogRef: params.catalogRef,
+          codeModeSkills: params.codeModeSkills,
         },
         visibleCatalog,
       );

--- a/src/agents/code-mode.worker.ts
+++ b/src/agents/code-mode.worker.ts
@@ -219,6 +219,10 @@ const CONTROLLER_SOURCE = String.raw`
     call: { value: (id, input) => request("call", [id, input]), enumerable: true },
     callValue: { value: (id, input) => request("callValue", [id, input]), enumerable: true },
   });
+  const skills = Object.freeze({
+    list: () => request("skillsList", []),
+    read: (name) => request("skillsRead", [name]),
+  });
 
   if (globalThis.__openclawSwarmEnabled === true) {
     Object.defineProperties(globalThis, {
@@ -317,6 +321,7 @@ const CONTROLLER_SOURCE = String.raw`
     API: { value: api, enumerable: true },
     nodes: { value: nodes, enumerable: true },
     namespaces: { value: Object.freeze(namespaceGlobals), enumerable: true },
+    skills: { value: skills, enumerable: true },
     tools: { value: Object.freeze(baseTools), enumerable: true },
     text: { value: (value) => output.push({ type: "text", text: asText(value) }), enumerable: true },
     json: { value: (value) => output.push({ type: "json", value: safe(value) }), enumerable: true },
@@ -356,6 +361,8 @@ function createHostRequestHandler(params: {
       method !== "namespace" &&
       method !== "agentSpawn" &&
       method !== "agentWait" &&
+      method !== "skillsList" &&
+      method !== "skillsRead" &&
       method !== "swarmNote"
     ) {
       throw new Error("unsupported code mode bridge method");

--- a/src/agents/embedded-agent-runner/run/attempt-startup.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-startup.ts
@@ -18,6 +18,7 @@ import {
   applySkillEnvOverrides,
   applySkillEnvOverridesFromSnapshot,
 } from "../../../skills/runtime/env-overrides.js";
+import { resolveCodeModeSkills, type CodeModeSkillReader } from "../../code-mode-skills.js";
 import {
   mapSandboxSkillEntriesForPrompt,
   mapSandboxSkillUsagePaths,
@@ -40,6 +41,7 @@ export function prepareEmbeddedAttemptSkills(params: {
       skillUsagePaths: undefined,
       skillsPrompt: "",
       skillsSnapshotForRun: undefined,
+      codeModeSkills: [],
     };
   }
   const {
@@ -89,11 +91,33 @@ export function prepareEmbeddedAttemptSkills(params: {
       agentId: params.sessionAgentId,
       eligibility: skillsEligibility,
     });
+    const sandbox = params.sandbox;
+    const sandboxSkillReader: CodeModeSkillReader | undefined = sandbox?.enabled
+      ? async ({ location, signal }) => {
+          const bridge = sandbox.fsBridge;
+          if (!bridge) {
+            throw new Error("Sandbox filesystem bridge is unavailable for skill reads.");
+          }
+          return (
+            await bridge.readFile({
+              filePath: location,
+              cwd: sandbox.containerWorkdir,
+              signal,
+            })
+          ).toString("utf8");
+        }
+      : undefined;
+    const codeModeSkills = resolveCodeModeSkills({
+      skillsPrompt,
+      candidates: skillsSnapshot?.resolvedSkills ?? skillEntries.map((entry) => entry.skill),
+      reader: sandboxSkillReader,
+    });
     return {
       restoreSkillEnv,
       skillUsagePaths,
       skillsPrompt,
       skillsSnapshotForRun: skillsSnapshot,
+      codeModeSkills,
     };
   } catch (error) {
     restoreSkillEnv();

--- a/src/agents/embedded-agent-runner/run/attempt-system-prompt-prepare.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-system-prompt-prepare.ts
@@ -65,6 +65,7 @@ export async function prepareEmbeddedAttemptSystemPrompt(params: {
   sandboxSessionKey: string;
   sessionAgentId: string;
   skillsPrompt: string;
+  codeModeActive?: boolean;
   toolSearchCatalogRef?: ToolSearchCatalogRef;
   toolSearchDirectoryEnabled: boolean;
   toolSearchRuntimeConfig: EmbeddedRunAttemptParams["config"];
@@ -266,6 +267,7 @@ export async function prepareEmbeddedAttemptSystemPrompt(params: {
       reasoningTagHint,
       heartbeatPrompt,
       skillsPrompt: effectiveSkillsPrompt,
+      codeModeActive: params.codeModeActive,
       docsPath: openClawReferences.docsPath ?? undefined,
       sourcePath: openClawReferences.sourcePath ?? undefined,
       workspaceNotes: params.bootstrap.workspaceNotes.length

--- a/src/agents/embedded-agent-runner/run/attempt-tool-base-prepare.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-tool-base-prepare.ts
@@ -6,6 +6,7 @@ import { isSubagentSessionKey } from "../../../routing/session-key.js";
 import { createOpenClawCodingTools } from "../../agent-tools.js";
 import { getActiveAgentRingZeroTools } from "../../agent-tools.ring-zero-context.js";
 import { getChannelAgentToolMeta } from "../../channel-tools.js";
+import type { CodeModeSkill } from "../../code-mode-skills.js";
 import { isCodeModeEngagedForModel, resolveCodeModeConfig } from "../../code-mode.js";
 import { resolveConversationCapabilityProfile } from "../../conversation-capability-profile.js";
 import {
@@ -55,6 +56,7 @@ export function prepareEmbeddedAttemptToolBase(params: {
   sessionAgentId: string;
   skillUsagePaths: SkillUsagePaths;
   skillsSnapshot: EmbeddedRunAttemptParams["skillsSnapshot"];
+  codeModeSkills: readonly CodeModeSkill[];
   toolSearchCatalogExecutor: ToolSearchCatalogToolExecutor;
 }) {
   const { attempt } = params;
@@ -117,6 +119,7 @@ export function prepareEmbeddedAttemptToolBase(params: {
       ? createToolSearchCatalogRef()
       : undefined;
   const toolSearchTargetTranscriptProjections: ToolSearchTargetTranscriptProjection[] = [];
+  const codeModeSkills = attempt.toolsAllow?.length ? [] : params.codeModeSkills;
   const cronCreatorToolAllowlist: CronCreatorToolAllowlistEntry[] = [];
   const inheritedToolAllowlist: string[] = [];
   const spawnWorkspaceDir =
@@ -334,6 +337,7 @@ export function prepareEmbeddedAttemptToolBase(params: {
 
   return {
     codeModeControlsEnabledForRun,
+    codeModeSkills,
     computerContextEpoch,
     cronCreatorToolAllowlist,
     effectiveToolsAllow,

--- a/src/agents/embedded-agent-runner/run/attempt-tool-catalog.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-tool-catalog.ts
@@ -51,6 +51,8 @@ export function prepareEmbeddedAttemptToolCatalog(input: {
   const { attempt, preparedToolBase } = input;
   const {
     codeModeControlsEnabledForRun,
+    codeModeSkills,
+    localModelLeanEnabled,
     localModelLeanPreserveToolNames,
     runtimeCapabilityProfile,
     toolSearchConfig,
@@ -89,6 +91,7 @@ export function prepareEmbeddedAttemptToolCatalog(input: {
         abortSignal: input.abortSignal,
         forceRestartSafeTools: attempt.forceRestartSafeTools,
         executeTool: input.executeCodeModeTool,
+        codeModeSkills,
       })
     : [];
   // When the message tool is the only reply path it must stay directly visible
@@ -105,6 +108,7 @@ export function prepareEmbeddedAttemptToolCatalog(input: {
         catalogRef: preparedToolBase.toolSearchCatalogRef,
         toolHookContext: catalogToolHookContext,
         directToolNames: requiredDirectToolNames,
+        codeModeSkills,
       })
     : toolSearchConfig.mode === "directory"
       ? applyToolSchemaDirectoryCatalog({

--- a/src/agents/embedded-agent-runner/run/attempt-tool-catalog.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-tool-catalog.ts
@@ -52,7 +52,6 @@ export function prepareEmbeddedAttemptToolCatalog(input: {
   const {
     codeModeControlsEnabledForRun,
     codeModeSkills,
-    localModelLeanEnabled,
     localModelLeanPreserveToolNames,
     runtimeCapabilityProfile,
     toolSearchConfig,

--- a/src/agents/embedded-agent-runner/run/attempt.spawn-workspace.test-support.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.spawn-workspace.test-support.ts
@@ -208,7 +208,7 @@ const hoisted = vi.hoisted((): AttemptSpawnWorkspaceHoisted => {
   const hasCompletedBootstrapTurnMock = vi.fn<() => Promise<boolean>>(async () => false);
   const resolveEmbeddedRunSkillEntriesMock = vi.fn(() => ({
     shouldLoadSkillEntries: false,
-    skillEntries: undefined,
+    skillEntries: [],
   }));
   const resolveSkillsPromptForRunMock = vi.fn(() => "");
   const supportsModelToolsMock = vi.fn<(model?: unknown) => boolean>(() => true);
@@ -1103,7 +1103,7 @@ export function resetEmbeddedAttemptHarness(
   hoisted.hasCompletedBootstrapTurnMock.mockReset().mockResolvedValue(false);
   hoisted.resolveEmbeddedRunSkillEntriesMock.mockReset().mockReturnValue({
     shouldLoadSkillEntries: false,
-    skillEntries: undefined,
+    skillEntries: [],
   });
   hoisted.resolveSkillsPromptForRunMock.mockReset().mockReturnValue("");
   hoisted.supportsModelToolsMock.mockReset().mockReturnValue(true);

--- a/src/agents/embedded-agent-runner/run/attempt.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.ts
@@ -151,7 +151,7 @@ export async function runEmbeddedAttempt(
       sessionAgentId,
     });
     restoreSkillEnv = preparedSkills.restoreSkillEnv;
-    const { skillUsagePaths, skillsPrompt, skillsSnapshotForRun } = preparedSkills;
+    const { codeModeSkills, skillUsagePaths, skillsPrompt, skillsSnapshotForRun } = preparedSkills;
     prepStages.mark("skills");
 
     const isRawModelRun = params.modelRun === true || params.promptMode === "none";
@@ -196,6 +196,7 @@ export async function runEmbeddedAttempt(
       sessionAgentId,
       skillUsagePaths,
       skillsSnapshot: skillsSnapshotForRun,
+      codeModeSkills,
       toolSearchCatalogExecutor: (toolParams) => {
         if (!toolSearchCatalogExecutor) {
           throw new Error("Tool Search catalog executor is unavailable for this run.");
@@ -298,6 +299,7 @@ export async function runEmbeddedAttempt(
       sandboxSessionKey,
       sessionAgentId,
       skillsPrompt,
+      codeModeActive: codeModeControlsEnabledForRun,
       toolSearchCatalogRef,
       toolSearchDirectoryEnabled: toolSearchControlsEnabledForRun && toolSearch.catalogRegistered,
       toolSearchRuntimeConfig,

--- a/src/agents/embedded-agent-runner/system-prompt.ts
+++ b/src/agents/embedded-agent-runner/system-prompt.ts
@@ -33,6 +33,7 @@ export function buildEmbeddedSystemPrompt(params: {
   reasoningTagHint: boolean;
   heartbeatPrompt?: string;
   skillsPrompt?: string;
+  codeModeActive?: boolean;
   docsPath?: string;
   sourcePath?: string;
   ttsHint?: string;
@@ -107,6 +108,7 @@ export function buildEmbeddedSystemPrompt(params: {
     reasoningTagHint: params.reasoningTagHint,
     heartbeatPrompt: params.heartbeatPrompt,
     skillsPrompt: params.skillsPrompt,
+    codeModeActive: params.codeModeActive,
     docsPath: params.docsPath,
     sourcePath: params.sourcePath,
     ttsHint: params.ttsHint,

--- a/src/agents/system-prompt.test.ts
+++ b/src/agents/system-prompt.test.ts
@@ -841,6 +841,20 @@ describe("buildAgentSystemPrompt", () => {
     expect(prompt).toContain("Several: most specific");
   });
 
+  it("switches skills access guidance under code mode", () => {
+    const prompt = buildAgentSystemPrompt({
+      workspaceDir: "/tmp/openclaw",
+      codeModeActive: true,
+      skillsPrompt:
+        "<available_skills>\n  <skill>\n    <name>demo</name>\n  </skill>\n</available_skills>",
+    });
+
+    expect(prompt).toContain(
+      'Scan <available_skills>. Clear match: use `skills.read("<name>")` inside `exec`; obey.',
+    );
+    expect(prompt).not.toContain("read exact <location> with `read`");
+  });
+
   it("instructs models to use skill_workshop only when the tool is available", () => {
     const section = buildSkillWorkshopPromptSection();
     expect(section).toEqual([

--- a/src/agents/system-prompt.ts
+++ b/src/agents/system-prompt.ts
@@ -285,14 +285,20 @@ function buildExecApprovalPromptGuidance(params: {
   return 'exec approval-pending: send exact /approve from "Reply with:"; never ask for another code.';
 }
 
-function buildSkillsSection(params: { skillsPrompt?: string; readToolName: string }) {
+function buildSkillsSection(params: {
+  skillsPrompt?: string;
+  readToolName: string;
+  codeModeActive?: boolean;
+}) {
   const trimmed = params.skillsPrompt?.trim();
   if (!trimmed) {
     return [];
   }
   return [
     "## Skills",
-    `Scan <available_skills>. Clear match: read exact <location> with \`${params.readToolName}\`; obey.`,
+    params.codeModeActive
+      ? 'Scan <available_skills>. Clear match: use `skills.read("<name>")` inside `exec`; obey.'
+      : `Scan <available_skills>. Clear match: read exact <location> with \`${params.readToolName}\`; obey.`,
     "Changed <version>: re-read. Several: most specific. None: read none.",
     "Up-front max one. Never invent paths.",
     "External writes: batch safely; no tight loops; honor 429/Retry-After.",
@@ -742,6 +748,7 @@ export function buildAgentSystemPrompt(params: {
   bootstrapMode?: BootstrapMode;
   bootstrapTruncationNotice?: string;
   skillsPrompt?: string;
+  codeModeActive?: boolean;
   heartbeatPrompt?: string;
   docsPath?: string;
   sourcePath?: string;
@@ -1031,6 +1038,7 @@ export function buildAgentSystemPrompt(params: {
   const skillsSection = buildSkillsSection({
     skillsPrompt,
     readToolName,
+    codeModeActive: params.codeModeActive,
   });
   const skillWorkshopSection = availableTools.has(SKILL_WORKSHOP_TOOL_NAME)
     ? buildSkillWorkshopPromptSection()
@@ -1101,6 +1109,7 @@ export function buildAgentSystemPrompt(params: {
     docsPath: params.docsPath,
     sourcePath: params.sourcePath,
     skillsPrompt,
+    codeModeActive: params.codeModeActive,
     modelAliasLines: params.modelAliasLines,
     includeMemorySection: params.includeMemorySection,
     memoryCitationsMode: params.memoryCitationsMode,

--- a/src/agents/tool-search-types.ts
+++ b/src/agents/tool-search-types.ts
@@ -3,6 +3,7 @@ import type { TSchema } from "typebox";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { PluginToolMcpMeta } from "../plugins/tools.js";
 import type { HookContext } from "./agent-tools.before-tool-call.js";
+import type { CodeModeSkill } from "./code-mode-skills.js";
 import type { AgentToolResult, AgentToolUpdateCallback } from "./runtime/index.js";
 import type { ToolDefinition } from "./sessions/index.js";
 import type { AnyAgentTool } from "./tools/common.js";
@@ -90,6 +91,7 @@ export type ToolSearchToolContext = {
   abortSignal?: AbortSignal;
   executeTool?: ToolSearchCatalogToolExecutor;
   forceRestartSafeTools?: boolean;
+  codeModeSkills?: readonly CodeModeSkill[];
 };
 
 /** Catalog entry retained behind compacted Tool Search control tools. */

--- a/src/skills/loading/workspace.ts
+++ b/src/skills/loading/workspace.ts
@@ -1416,6 +1416,8 @@ function buildRenderedSkillsPrompt(params: {
   total: number;
   format: SkillsPromptFormat;
 }): string {
+  // resolveCodeModeSkills in src/agents/code-mode-skills.ts parses this exact format; update both together.
+  // The production-renderer parity test in src/agents/code-mode.test.ts enforces this coupling.
   const truncated = params.skills.length < params.total;
   const limitNote = buildSkillsLimitNote({
     truncated,


### PR DESCRIPTION
## What Problem This Solves

Code Mode had no skills integration. The system prompt's skills section told the model to read skill locations with the `read` tool, but that tool is not visible under Code Mode, so skills were effectively unusable there.

## Why This Change Was Made

Skills become first-class Code Mode guest citizens with on-demand body loading. This keeps prompt cost flat and reuses the exact prompt-visible eligibility set, so the catalog the model sees and the skills the guest can read stay aligned by construction. Production-renderer parity coverage enforces that boundary.

## User Impact

Code Mode exposes `skills.list()` for the prompt catalog's name, description, and location entries, plus `skills.read(name)` for full instruction bodies on demand. Unknown names fail with the available names. Sandboxed runs read through the existing sandbox filesystem bridge, and the skills prompt directs Code Mode runs to `skills.read("<name>")`. This adds no config surface and grants no guest filesystem access.

## Evidence

- Rebased focused proof: `node scripts/run-vitest.mjs src/agents/code-mode.test.ts src/agents/code-mode-nodes.test.ts src/agents/system-prompt.test.ts` (315 tests passed after the conflict rebase, including production-renderer parity and current-main Code Mode coverage). After the CI-driven test-harness correction, representative embedded-runner tests passed and `src/agents/code-mode.test.ts` passed 209/209 on its single flake rerun.
- Pre-rebase branch proof: full changed gate plus production and core-test tsgo lanes passed.
- Fresh branch-diff Codex autoreview against `origin/main`: clean, with no accepted/actionable findings.
- Sanitized real QuickJS worker/bridge proof: `skills.list()` returned only `demo`; `skills.read("demo")` returned its complete fixture instructions; `skills.read("missing")` returned `Unknown skill "missing". Available skills: demo` (2/2 focused executions passed).
- ClawSweeper prompt/access move: no additional code applied because the claimed mismatch is absent in the production owner path. A non-empty `toolsAllow` makes `effectiveSkillsPrompt` undefined in `attempt-system-prompt-prepare.ts` and makes `codeModeSkills` empty in `attempt-tool-base-prepare.ts`, so neither the prompt nor the guest advertises skills. The requested excluded-name transcript is therefore inapplicable for that state; the bridge proof above covers the eligible and rejected-name behavior without weakening the allowlist boundary.
- Initial exact-head CI exposed and motivated removal of one stale rebase binding; the post-rebase run exposed a stale shared test mock. Replacement [run 30327925214](https://github.com/openclaw/openclaw/actions/runs/30327925214) is attached to `2f029c510d17ab3b511e1e33fe11746acedd8514`.
