### PR TITLE
fix(ui): preserve agent, session, locale, and dashboard ownership

### DIFF
--- a/extensions/qa-lab/src/scenario-flow-runner.test.ts
+++ b/extensions/qa-lab/src/scenario-flow-runner.test.ts
@@ -402,6 +402,84 @@ const planningEvidenceFixtures = readQaScenarioPack()
   .map(createPlanningEvidenceFixture);
 
 describe("scenario-flow-runner", () => {
+  it.each([
+    "control-ui-qa-channel-image-roundtrip",
+    "control-ui-assistant-transcript-role-boundary",
+  ])("opens the selected Control UI session on the chat route for %s", async (scenarioId) => {
+    const scenario = readQaScenarioById(scenarioId);
+    const actions = scenario.execution.flow?.steps.flatMap((step) => step.actions);
+    if (!actions) {
+      throw new Error(`scenario has no flow: ${scenarioId}`);
+    }
+
+    const sessionAction = actions.find(
+      (action) =>
+        typeof action === "object" &&
+        action !== null &&
+        "set" in action &&
+        action.set === "uiSessionKey",
+    );
+    const urlAction = actions.find(
+      (action) =>
+        typeof action === "object" &&
+        action !== null &&
+        "set" in action &&
+        action.set === "controlUiChatUrl",
+    );
+    const openAction = actions.find(
+      (action) =>
+        typeof action === "object" &&
+        action !== null &&
+        "call" in action &&
+        action.call === "webOpenPage",
+    );
+    if (!sessionAction || !urlAction || !openAction) {
+      throw new Error(`scenario has no Control UI session navigation: ${scenarioId}`);
+    }
+
+    const sessionKey = "agent:main:qa-channel:direct:control-ui-session";
+    const gatewayToken = "qa token/+";
+    const openedUrls: string[] = [];
+    const result = await runLoadedScenarioFlow(scenarioId, {
+      flow: {
+        steps: [
+          {
+            name: "opens the selected chat session",
+            actions: [sessionAction, urlAction, openAction],
+          },
+        ],
+      },
+      api: {
+        env: {
+          providerMode: "mock-openai",
+          cfg: {
+            agents: { list: [{ id: "main", default: true }] },
+          },
+          gateway: {
+            baseUrl: "http://127.0.0.1:43124",
+            token: gatewayToken,
+          },
+        },
+        buildAgentSessionKey: () => sessionKey,
+        webOpenPage: async ({ url }: { url: string }) => {
+          openedUrls.push(url);
+          return { pageId: "control-ui-session-page" };
+        },
+      },
+    });
+
+    expect(result.status).toBe("pass");
+    expect(openedUrls).toHaveLength(1);
+    const openedUrl = openedUrls[0];
+    if (!openedUrl) {
+      throw new Error(`scenario did not open its Control UI session: ${scenarioId}`);
+    }
+    const chatUrl = new URL(openedUrl);
+    expect(chatUrl.pathname).toBe("/chat");
+    expect(chatUrl.searchParams.get("session")).toBe(sessionKey);
+    expect(chatUrl.hash).toBe(`#token=${encodeURIComponent(gatewayToken)}`);
+  });
+
   it.each(planningEvidenceFixtures)(
     "accepts current-attempt planning evidence for $scenario.id",
     async (fixture) => {

--- a/qa/scenarios/ui/control-ui-assistant-transcript-role-boundary.yaml
+++ b/qa/scenarios/ui/control-ui-assistant-transcript-role-boundary.yaml
@@ -141,7 +141,7 @@ flow:
       actions:
         - set: controlUiChatUrl
           value:
-            expr: "(() => { const url = new URL(`${env.gateway.baseUrl}/`); url.searchParams.set('session', uiSessionKey); url.hash = `token=${encodeURIComponent(env.gateway.token ?? '')}`; return url.toString(); })()"
+            expr: "(() => { const url = new URL(`${env.gateway.baseUrl}/chat`); url.searchParams.set('session', uiSessionKey); url.hash = `token=${encodeURIComponent(env.gateway.token ?? '')}`; return url.toString(); })()"
         - call: webOpenPage
           saveAs: uiTab
           args:

--- a/qa/scenarios/ui/control-ui-qa-channel-image-roundtrip.yaml
+++ b/qa/scenarios/ui/control-ui-qa-channel-image-roundtrip.yaml
@@ -66,7 +66,7 @@ flow:
             expr: "buildAgentSessionKey({ agentId: env.cfg.agents?.list?.find((agent) => agent.default)?.id ?? env.cfg.agents?.list?.[0]?.id ?? 'main', channel: 'qa-channel', accountId: 'default', peer: { kind: 'direct', id: config.conversationId }, dmScope: env.cfg.session?.dmScope, identityLinks: env.cfg.session?.identityLinks })"
         - set: controlUiChatUrl
           value:
-            expr: "(() => { const url = new URL(`${env.gateway.baseUrl}/`); url.searchParams.set('session', uiSessionKey); url.hash = `token=${encodeURIComponent(env.gateway.token ?? '')}`; return url.toString(); })()"
+            expr: "(() => { const url = new URL(`${env.gateway.baseUrl}/chat`); url.searchParams.set('session', uiSessionKey); url.hash = `token=${encodeURIComponent(env.gateway.token ?? '')}`; return url.toString(); })()"
         - call: webOpenPage
           saveAs: uiTab
           args:

--- a/ui/src/e2e/chat-composer-redesign.e2e.test.ts
+++ b/ui/src/e2e/chat-composer-redesign.e2e.test.ts
@@ -912,7 +912,7 @@ describeControlUiE2e("Control UI chat composer redesign", () => {
           agentsList: {
             agents: [{ id: "work", name: "Work" }],
             defaultId: "main",
-            mainKey: "agent:work:main",
+            mainKey: "main",
             scope: "agent",
           },
           messages: [],
@@ -924,7 +924,13 @@ describeControlUiE2e("Control UI chat composer redesign", () => {
 
     try {
       await page.goto(controlUiSessionUrl(server.baseUrl, "agent:work:main"));
-      await expect.poll(async () => (await gateway.getRequests("chat.startup")).length).toBe(1);
+      const startupRequest = await gateway.waitForRequest("chat.startup");
+      expect(startupRequest.params).toEqual(
+        expect.objectContaining({ sessionKey: "agent:work:main" }),
+      );
+      for (const request of await gateway.getRequests("chat.startup")) {
+        expect(request.params).toEqual(expect.objectContaining({ sessionKey: "agent:work:main" }));
+      }
 
       const composer = page.locator(".agent-chat__input");
       await expect

--- a/ui/src/i18n/lib/registry.test.ts
+++ b/ui/src/i18n/lib/registry.test.ts
@@ -1,0 +1,51 @@
+// @vitest-environment node
+
+import { describe, expect, it } from "vitest";
+import { resolveNavigatorLocale } from "./registry.ts";
+
+describe("resolveNavigatorLocale", () => {
+  it.each([
+    ["zh", "zh-CN"],
+    ["zh-CN", "zh-CN"],
+    ["zh-SG", "zh-CN"],
+    ["zh-Hans", "zh-CN"],
+    ["zh-Hans-CN", "zh-CN"],
+    ["zh-Hans-SG", "zh-CN"],
+    ["zh-Hans-HK", "zh-CN"],
+    ["zh-Hans-TW", "zh-CN"],
+    ["zh-Hant", "zh-TW"],
+    ["zh-Hant-TW", "zh-TW"],
+    ["zh-Hant-HK", "zh-TW"],
+    ["zh-Hant-MO", "zh-TW"],
+    ["zh-TW", "zh-TW"],
+    ["zh-HK", "zh-TW"],
+    ["zh-MO", "zh-TW"],
+    ["ZH-hAnT-hK", "zh-TW"],
+    ["ZH-hAnS-hK", "zh-CN"],
+    ["en-US", "en"],
+    ["pt-PT", "pt-BR"],
+    ["PT-br", "pt-BR"],
+    ["de-DE", "de"],
+    ["DE-at", "de"],
+    ["es-MX", "es"],
+    ["ja-JP", "ja-JP"],
+    ["ko-KR", "ko"],
+    ["fr-CA", "fr"],
+    ["hi-IN", "hi"],
+    ["ar-EG", "ar"],
+    ["it-IT", "it"],
+    ["tr-TR", "tr"],
+    ["uk-UA", "uk"],
+    ["id-ID", "id"],
+    ["pl-PL", "pl"],
+    ["th-TH", "th"],
+    ["vi-VN", "vi"],
+    ["nl-NL", "nl"],
+    ["fa-IR", "fa"],
+    ["ru-RU", "ru"],
+    ["sv-SE", "en"],
+    ["", "en"],
+  ] as const)("maps browser language %s to %s", (browserLanguage, expectedLocale) => {
+    expect(resolveNavigatorLocale(browserLanguage)).toBe(expectedLocale);
+  });
+});

--- a/ui/src/i18n/lib/registry.ts
+++ b/ui/src/i18n/lib/registry.ts
@@ -127,9 +127,19 @@ function isLazyLocale(locale: Locale): locale is LazyLocale {
   return LAZY_LOCALES.includes(locale as LazyLocale);
 }
 
-export function resolveNavigatorLocale(navLang: string): Locale {
+export function resolveNavigatorLocale(browserLanguage: string): Locale {
+  const navLang = browserLanguage.toLowerCase();
   if (navLang.startsWith("zh")) {
-    return navLang === "zh-TW" || navLang === "zh-HK" ? "zh-TW" : "zh-CN";
+    const [, ...subtags] = navLang.split("-");
+    if (subtags.includes("hant")) {
+      return "zh-TW";
+    }
+    if (subtags.includes("hans")) {
+      return "zh-CN";
+    }
+    return subtags.some((subtag) => subtag === "tw" || subtag === "hk" || subtag === "mo")
+      ? "zh-TW"
+      : "zh-CN";
   }
   if (navLang.startsWith("pt")) {
     return "pt-BR";

--- a/ui/src/i18n/test/translate.test.ts
+++ b/ui/src/i18n/test/translate.test.ts
@@ -135,6 +135,30 @@ describe("i18n", () => {
     expect(fresh.t("common.health")).toBe("健康状况");
   });
 
+  it.each([
+    ["zh-Hant", "zh-TW"],
+    ["zh-Hant-TW", "zh-TW"],
+    ["zh-Hant-HK", "zh-TW"],
+    ["zh-Hant-MO", "zh-TW"],
+    ["zh-MO", "zh-TW"],
+    ["ZH-hAnT-hK", "zh-TW"],
+    ["zh-Hans-HK", "zh-CN"],
+    ["ZH-hAnS-hK", "zh-CN"],
+  ] as const)(
+    "loads the %s browser language as the registered %s locale on startup",
+    async (browserLanguage, expectedLocale) => {
+      vi.stubGlobal("navigator", { language: browserLanguage } as Navigator);
+      localStorage.removeItem("openclaw.i18n.locale");
+
+      const fresh = await importFreshTranslate();
+
+      await vi.waitFor(() => expect(fresh.i18n.getLocale()).toBe(expectedLocale));
+      expect(fresh.t("common.health")).toBe(
+        readString(expectedLocale === "zh-TW" ? zh_TW : zh_CN, "common.health"),
+      );
+    },
+  );
+
   it("skips node localStorage accessors that warn without a storage file", async () => {
     vi.unstubAllGlobals();
     vi.stubGlobal("navigator", { language: "en-US" } as Navigator);

--- a/ui/src/lib/board/provider.test.ts
+++ b/ui/src/lib/board/provider.test.ts
@@ -156,6 +156,36 @@ describe("board providers", () => {
     expect(listeners.size).toBe(0);
   });
 
+  it("preserves known board availability until the first gateway snapshot loads", async () => {
+    mockLocation.search = "";
+    const sessionKey = "agent:main:loading-board-availability";
+    const emptySnapshot = { sessionKey, revision: 1, tabs: [], widgets: [] };
+    let resolveSnapshot: ((snapshot: typeof emptySnapshot) => void) | undefined;
+    recordSessionBoardAvailability(sessionKey, true);
+    const lease = acquireBoardProviderForSession(sessionKey, {
+      request: vi.fn(
+        () =>
+          new Promise<typeof emptySnapshot>((resolve) => {
+            resolveSnapshot = resolve;
+          }),
+      ) as never,
+      addEventListener: () => () => {},
+    });
+
+    try {
+      expect(lease.provider).toBeInstanceOf(GatewayBoardProvider);
+      expect(sessionHasBoard(sessionKey)).toBe(true);
+
+      resolveSnapshot?.(emptySnapshot);
+      await vi.waitFor(() => expect(lease.provider.snapshot$.value).toEqual(emptySnapshot));
+
+      expect(sessionHasBoard(sessionKey)).toBe(false);
+    } finally {
+      resolveSnapshot?.(emptySnapshot);
+      lease.release();
+    }
+  });
+
   it("preserves known availability when a provider is released before its first load", () => {
     mockLocation.search = "";
     const sessionKey = "agent:main:provisional-provider";

--- a/ui/src/lib/board/provider.ts
+++ b/ui/src/lib/board/provider.ts
@@ -445,5 +445,9 @@ export function clearSessionBoardAvailability(): boolean {
 export function sessionHasBoard(sessionKey: string): boolean {
   const key = boardProviderCacheKey(sessionKey);
   const provider = gatewayProviders.get(key)?.provider ?? mockProviders.get(key);
+  // An unloaded gateway provider holds a placeholder, not an authoritative empty board.
+  if (provider instanceof GatewayBoardProvider && !provider.hasLoadedSnapshot) {
+    return boardAvailability.get(key) ?? false;
+  }
   return provider ? boardExists(provider.snapshot$.value) : (boardAvailability.get(key) ?? false);
 }

--- a/ui/src/lib/cron/index.test.ts
+++ b/ui/src/lib/cron/index.test.ts
@@ -1797,8 +1797,12 @@ describe("cron controller", () => {
     });
   });
 
-  it("canceling edit resets form to defaults and clears edit mode", () => {
-    const state = createState();
+  it.each([
+    { scenario: "all agents", cronAgentId: null, expectedAgentId: "" },
+    { scenario: "the default agent", cronAgentId: "main", expectedAgentId: "main" },
+    { scenario: "a selected agent", cronAgentId: "writer", expectedAgentId: "writer" },
+  ])("canceling edit resets form for $scenario and clears edit mode", (scenario) => {
+    const state = createState({ cronAgentId: scenario.cronAgentId });
     const job = {
       id: "job-cancel",
       name: "Editable",
@@ -1819,7 +1823,10 @@ describe("cron controller", () => {
     cancelCronEdit(state);
 
     expect(state.cronEditingJobId).toBeNull();
-    expect(state.cronForm).toEqual({ ...DEFAULT_CRON_FORM });
+    expect(state.cronForm).toEqual({
+      ...DEFAULT_CRON_FORM,
+      agentId: scenario.expectedAgentId,
+    });
     // Fresh forms start visually clean; validation re-arms on change/submit.
     expect(state.cronFieldErrors).toEqual({});
   });
@@ -1871,6 +1878,7 @@ describe("cron controller", () => {
     const sourceJob = {
       id: "job-1",
       name: "Daily ping",
+      agentId: "writer",
       enabled: true,
       createdAtMs: 0,
       updatedAtMs: 0,
@@ -1883,6 +1891,7 @@ describe("cron controller", () => {
     const state = createState({
       client: { request } as unknown as CronState["client"],
       cronJobs: [sourceJob],
+      cronAgentId: "main",
       cronEditingJobId: "job-1",
     });
 
@@ -1892,7 +1901,9 @@ describe("cron controller", () => {
     const addCall = findRequestCall(request.mock.calls, "cron.add");
     const updateCall = request.mock.calls.find(([method]) => method === "cron.update");
     expect(updateCall).toBeUndefined();
-    expect((addCall[1] as { name?: string } | undefined)?.name).toBe("Daily ping copy");
+    expect(addCall[1]).toEqual(
+      expect.objectContaining({ name: "Daily ping copy", agentId: "writer" }),
+    );
   });
 
   it("loads paged jobs with query/filter/sort params", async () => {

--- a/ui/src/lib/cron/index.ts
+++ b/ui/src/lib/cron/index.ts
@@ -683,7 +683,7 @@ function clearCronRunsPage(state: CronState) {
 }
 
 function resetCronFormToDefaults(state: CronState) {
-  state.cronForm = { ...DEFAULT_CRON_FORM };
+  state.cronForm = { ...DEFAULT_CRON_FORM, agentId: state.cronAgentId ?? "" };
   // A fresh form starts visually clean; validation re-arms on the first change
   // or submit so required-field errors do not greet the user immediately.
   state.cronFieldErrors = {};

--- a/ui/src/pages/chat/chat-state-events.ts
+++ b/ui/src/pages/chat/chat-state-events.ts
@@ -349,6 +349,8 @@ export function handlePageGatewayEvent(state: ChatPageHost, event: GatewayEventF
       payload?.state === "delta" &&
       typeof payload.runId === "string" &&
       chatScopedEventSessionMatches(state, payload.sessionKey, payload.agentId) &&
+      // Same-session background streams cannot clear the foreground run's status.
+      (!state.chatRunId || state.chatRunId === payload.runId) &&
       state.observerDigest &&
       state.observerDigest.runId !== payload.runId
     ) {

--- a/ui/src/pages/chat/chat-state.test.ts
+++ b/ui/src/pages/chat/chat-state.test.ts
@@ -55,6 +55,37 @@ afterEach(() => {
 });
 
 describe("ChatStateController render lifecycle", () => {
+  it("keeps the active observer digest when another run streams in the same session", () => {
+    const projectedDigest = {
+      sessionKey: "agent:main:current",
+      runId: "run-1",
+      revision: 1,
+      updatedAt: 1_000,
+      headline: "The active run's status",
+      health: "on-track" as const,
+    };
+    const state = {
+      sessionKey: projectedDigest.sessionKey,
+      assistantAgentId: "main",
+      agentsList: { defaultId: "main" },
+      chatRunId: "run-1",
+      observerDigest: projectedDigest,
+      requestUpdate: vi.fn(),
+    } as unknown as ChatPageHost;
+
+    handlePageGatewayEvent(state, {
+      type: "event",
+      event: "chat",
+      payload: {
+        state: "delta",
+        runId: "run-2",
+        sessionKey: projectedDigest.sessionKey,
+      },
+    });
+
+    expect(state.observerDigest).toBe(projectedDigest);
+  });
+
   it("rejects a run-less observer digest during an identified active run", () => {
     const projectedDigest = {
       sessionKey: "agent:main:current",

--- a/ui/src/pages/chat/tool-stream-fallback.node.test.ts
+++ b/ui/src/pages/chat/tool-stream-fallback.node.test.ts
@@ -305,6 +305,91 @@ describe("app-tool-stream fallback lifecycle handling", () => {
     vi.useRealTimers();
   });
 
+  it.each([
+    { progressText: "Another run's commentary", name: "replace" },
+    { progressText: "", name: "clear" },
+  ])("does not let another run $name the active preamble", ({ progressText }) => {
+    useToolStreamFakeTimers();
+    const host = createHost({ chatRunId: "run-1" });
+
+    handleAgentEvent(host, {
+      runId: "run-1",
+      seq: 1,
+      stream: "item",
+      ts: Date.now(),
+      sessionKey: "main",
+      data: {
+        kind: "preamble",
+        itemId: "msg-preamble-1",
+        progressText: "The active run's commentary",
+      },
+    });
+    handleAgentEvent(host, {
+      runId: "run-2",
+      seq: 2,
+      stream: "item",
+      ts: Date.now(),
+      sessionKey: "main",
+      data: { kind: "preamble", itemId: "msg-preamble-1", progressText },
+    });
+
+    expect(host.chatStreamSegments).toEqual([
+      {
+        text: "The active run's commentary",
+        ts: TOOL_STREAM_TEST_NOW,
+        runId: "run-1",
+        itemId: "msg-preamble-1",
+      },
+    ]);
+  });
+
+  it("does not insert another run's preamble into the active transcript", () => {
+    useToolStreamFakeTimers();
+    const host = createHost({ chatRunId: "run-1" });
+
+    handleAgentEvent(host, {
+      runId: "run-2",
+      seq: 1,
+      stream: "item",
+      ts: Date.now(),
+      sessionKey: "main",
+      data: {
+        kind: "preamble",
+        itemId: "msg-preamble-2",
+        progressText: "Another run's commentary",
+      },
+    });
+
+    expect(host.chatStreamSegments).toEqual([]);
+  });
+
+  it("accepts a session-scoped preamble while no run is active", () => {
+    useToolStreamFakeTimers();
+    const host = createHost();
+
+    handleAgentEvent(host, {
+      runId: "run-1",
+      seq: 1,
+      stream: "item",
+      ts: Date.now(),
+      sessionKey: "main",
+      data: {
+        kind: "preamble",
+        itemId: "msg-preamble-1",
+        progressText: "An already active session's commentary",
+      },
+    });
+
+    expect(host.chatStreamSegments).toEqual([
+      {
+        text: "An already active session's commentary",
+        ts: TOOL_STREAM_TEST_NOW,
+        runId: "run-1",
+        itemId: "msg-preamble-1",
+      },
+    ]);
+  });
+
   it("clears keyed preamble item progress on empty updates", () => {
     useToolStreamFakeTimers();
     const host = createHost({ chatRunId: "run-1" });

--- a/ui/src/pages/chat/tool-stream.ts
+++ b/ui/src/pages/chat/tool-stream.ts
@@ -814,6 +814,11 @@ function handlePreambleProgressEvent(host: ToolStreamHost, payload: AgentEventPa
   if (!progress) {
     return false;
   }
+  // Preambles belong to the visible run; a sibling run must never replace,
+  // clear, or persist its commentary into this transcript.
+  if (!resolveAcceptedSession(host, payload, { allowSessionScopedWhenIdle: true }).accepted) {
+    return true;
+  }
   if (progress.itemId && !progress.text.trim()) {
     host.chatStreamSegments = host.chatStreamSegments.filter(
       (segment) => segment.itemId !== progress.itemId,

--- a/ui/src/pages/cron/cron-page.test.ts
+++ b/ui/src/pages/cron/cron-page.test.ts
@@ -159,6 +159,71 @@ afterEach(() => {
 });
 
 describe("CronPage editor state sync", () => {
+  it.each([
+    {
+      scenario: "a new task for the selected agent",
+      scopeId: "writer",
+      suggested: false,
+      expectedAgentId: "writer",
+    },
+    {
+      scenario: "a suggested task for the selected agent",
+      scopeId: "writer",
+      suggested: true,
+      expectedAgentId: "writer",
+    },
+    {
+      scenario: "a new task for the default agent",
+      scopeId: "main",
+      suggested: false,
+      expectedAgentId: "main",
+    },
+    {
+      scenario: "a new task from the all-agents view",
+      scopeId: null,
+      suggested: false,
+      expectedAgentId: undefined,
+    },
+  ])("creates $scenario with its intended agent ownership", async (scenario) => {
+    const request = createRequest();
+    const gateway = createGateway({ request } as unknown as GatewayBrowserClient, true);
+    const page = createPage(createContext(gateway, scenario.scopeId), { render: true });
+
+    const createSelector = scenario.suggested
+      ? '[data-suggestion="repoPulse"]'
+      : '[data-test-id="cron-new-task"]';
+    await waitForCronPage(() => expect(page.querySelector(createSelector)).not.toBeNull());
+    (page.querySelector(createSelector) as HTMLButtonElement).click();
+
+    await waitForCronPage(() => {
+      expect(page.querySelector("#cron-name")).not.toBeNull();
+      expect(page.querySelector("#cron-payload-text")).not.toBeNull();
+    });
+    const name = page.querySelector("#cron-name") as HTMLInputElement;
+    name.value = "Agent-scoped task";
+    name.dispatchEvent(new Event("input", { bubbles: true }));
+    const payload = page.querySelector("#cron-payload-text") as HTMLTextAreaElement;
+    payload.value = "Run for the selected agent";
+    payload.dispatchEvent(new Event("input", { bubbles: true }));
+
+    await waitForCronPage(() => {
+      const submit = page.querySelector('[data-test-id="cron-submit"]') as HTMLButtonElement;
+      expect(submit).not.toBeNull();
+      expect(submit.disabled).toBe(false);
+    });
+    (page.querySelector('[data-test-id="cron-submit"]') as HTMLButtonElement).click();
+
+    await waitForCronPage(() => {
+      expect(request).toHaveBeenCalledWith(
+        "cron.add",
+        expect.objectContaining({
+          name: "Agent-scoped task",
+          agentId: scenario.expectedAgentId,
+        }),
+      );
+    });
+  });
+
   it("scopes list, stats, and run history requests to the selected agent", async () => {
     const request = createRequest();
     const gateway = createGateway({ request } as unknown as GatewayBrowserClient, true);
@@ -194,7 +259,7 @@ describe("CronPage editor state sync", () => {
     });
     const client = { request } as unknown as GatewayBrowserClient;
     const gateway = createGateway(client, true);
-    const page = createPage(createContext(gateway), { render: true });
+    const page = createPage(createContext(gateway, "writer"), { render: true });
 
     await waitForCronPage(() =>
       expect(page.querySelector('[data-test-id="cron-new-task"]')).not.toBeNull(),
@@ -209,6 +274,10 @@ describe("CronPage editor state sync", () => {
       const methods = request.mock.calls.map((call) => call[0]);
       expect(methods.indexOf("cron.run")).toBeGreaterThan(methods.indexOf("cron.add"));
     });
+    expect(request).toHaveBeenCalledWith(
+      "cron.add",
+      expect.objectContaining({ agentId: "writer" }),
+    );
     expect(request).toHaveBeenCalledWith("cron.run", { id: "job-fresh", mode: "force" });
     await waitForCronPage(() => expect(page.cron.cronCreateOpen).toBe(false));
   });


### PR DESCRIPTION
Closes #114859
Closes #114860
Closes #114861
Closes #114862
Closes #114863

## What Problem This Solves

Fixes an issue where users working with concurrent chat turns, selected agents, session dashboards, Traditional Chinese browser languages, or real-Gateway QA routes would receive state belonging to the wrong run, agent, language, route, or provisional dashboard.

## Why This Change Was Made

Keep ownership in the existing Control UI and QA owners: reject sibling-run commentary and observer deltas while preserving idle session adoption; initialize new Cron forms from the selected agent while preserving all-agent and clone semantics; retain known board availability until its first authoritative snapshot; resolve Chinese script and region tags without generated-locale edits; and exercise the real `/chat` deep link in both Gateway-hosted QA flows. Browser-panel concurrency remains deliberately isolated in #114858 instead of broadening this patch.

## User Impact

Foreground conversations keep their own commentary and status; new schedules run under the agent users actually selected; session dashboards remain discoverable while loading; Traditional Chinese users receive the correct bundle; and real-Gateway image/transcript QA actually opens the intended authenticated chat session.

## Evidence

- Failing-first proof for each linked issue on frozen `main` `5ae4a8fb8e243cd7634c1819651703a4e9753715`.
- Final isolated remote proof: **549 passing focused UI and QA tests**, including run/session ownership, all-agent and clone behavior, real Cron page submits, board lifecycle, 40 locale variants, translated browser startup, real loaded scenario actions, and authenticated route bootstrap.
- Full Control UI Chromium proof: **91 files / 359 real-browser scenarios passed**.
- Full relevant changed gates, UI typechecking, focused core/QA lint, 15-file formatting and `git diff --check` passed.
- Fresh independent structured review: **clean; no accepted or actionable findings**.
- Direct upstream turn-ownership contract inspected in `openai/codex:codex-rs/app-server-protocol/src/protocol/event_mapping.rs`; thread and turn identity remain explicit.

AI-assisted, source-audited, and independently reviewed.