### PR TITLE
fix(pr): bind review artifacts to the PR being landed

### DIFF
--- a/scripts/pr-lib/review-artifacts.mjs
+++ b/scripts/pr-lib/review-artifacts.mjs
@@ -29,8 +29,44 @@ function reviewArtifactEnumHint(enumName, initialValue) {
   return `${initialValue} (allowed: ${allowed.join("|")})`;
 }
 
-function createReviewArtifactTemplate() {
+// Both artifacts carry the same stamp: review.md holds the prose verdict a human
+// reads, so binding only review.json would still let a foreign markdown verdict
+// ride along with a freshly stamped JSON.
+function reviewIdentityLine({ number, headSha }) {
+  return `Review artifact for PR #${number} at ${headSha}`;
+}
+
+function createReviewMarkdownTemplate(identity) {
+  return `${reviewIdentityLine(identity)}
+
+A) TL;DR recommendation
+
+B) What changed and what is good?
+
+C) Security findings
+
+D) What is the PR intent? Is this the most optimal implementation?
+
+E) Concerns or questions (actionable)
+
+F) Tests
+
+G) Docs status
+
+H) Changelog
+
+I) Follow ups (optional)
+
+J) Suggested PR comment (optional)
+`;
+}
+
+function createReviewArtifactTemplate({ number, headSha }) {
   return {
+    // Identity stamp, not reviewer input: validation refuses artifacts whose pr
+    // disagrees with .local/pr-meta.json, so a review written for another PR (or
+    // an already-superseded head) can never be landed as this one's verdict.
+    pr: { number, headSha },
     recommendation: reviewArtifactEnumHint("recommendation", "NEEDS WORK"),
     findings: [],
     nitSweep: {
@@ -100,6 +136,50 @@ function validateReviewArtifacts({ review, reviewMarkdown, prMeta }) {
     "Invalid .local/review.json: top-level value must be an object",
   );
   const value = reviewIsObject ? review : {};
+
+  const prMetaIsValid =
+    isObject(prMeta) &&
+    Array.isArray(prMeta.files) &&
+    prMeta.files.every((file) => isObject(file) && typeof file.path === "string");
+  if (!prMetaIsValid) {
+    add("Invalid .local/pr-meta.json: files must be an array of objects with string path");
+  }
+  const prMetaIdentifiesHead =
+    isObject(prMeta) && Number.isInteger(prMeta.number) && typeof prMeta.headRefOid === "string";
+  if (!prMetaIdentifiesHead) {
+    add(
+      "Invalid .local/pr-meta.json: number and headRefOid must identify the reviewed PR head; re-run scripts/pr review-init",
+    );
+  }
+  const stamp = isObject(value.pr) ? value.pr : undefined;
+  const stampIsValid =
+    stamp !== undefined && Number.isInteger(stamp.number) && typeof stamp.headSha === "string";
+  if (!stampIsValid) {
+    add(
+      "Invalid PR identity in .local/review.json: pr.number must be an integer and pr.headSha must be a string; re-run scripts/pr review-artifacts-init",
+    );
+  }
+  if (
+    stampIsValid &&
+    prMetaIdentifiesHead &&
+    (stamp.number !== prMeta.number || stamp.headSha !== prMeta.headRefOid)
+  ) {
+    add(
+      `Review artifact identity mismatch in .local/review.json: authored for PR #${stamp.number} at ${stamp.headSha}, but .local/pr-meta.json describes PR #${prMeta.number} at ${prMeta.headRefOid}; re-run scripts/pr review-artifacts-init`,
+    );
+  }
+  if (prMetaIdentifiesHead) {
+    const expectedLine = reviewIdentityLine({
+      number: prMeta.number,
+      headSha: prMeta.headRefOid,
+    });
+    if (reviewMarkdown.split("\n")[0] !== expectedLine) {
+      add(
+        `Review artifact identity mismatch in .local/review.md: first line must be ${jsonValue(expectedLine)}; re-run scripts/pr review-artifacts-init`,
+      );
+    }
+  }
+
   const recommendationIsString = requireType(
     typeof value.recommendation === "string",
     "Invalid recommendation in .local/review.json: recommendation must be a string",
@@ -259,13 +339,6 @@ function validateReviewArtifacts({ review, reviewMarkdown, prMeta }) {
     );
   }
 
-  const prMetaIsValid =
-    isObject(prMeta) &&
-    Array.isArray(prMeta.files) &&
-    prMeta.files.every((file) => isObject(file) && typeof file.path === "string");
-  if (!prMetaIsValid) {
-    add("Invalid .local/pr-meta.json: files must be an array of objects with string path");
-  }
   const runtimeFileCount = prMetaIsValid
     ? prMeta.files.filter(
         ({ path }) =>
@@ -462,8 +535,21 @@ function readJson(filePath) {
 
 function main(argv = process.argv.slice(2)) {
   const [command, ...args] = argv;
-  if (command === "template" && args.length === 0) {
-    process.stdout.write(`${JSON.stringify(createReviewArtifactTemplate(), null, 2)}\n`);
+  if ((command === "template" || command === "markdown") && args.length === 2) {
+    const [prNumber, headSha] = args;
+    if (!/^[1-9][0-9]*$/u.test(prNumber) || !/^[0-9a-f]{40}$/u.test(headSha)) {
+      console.error(
+        `Usage: review-artifacts.mjs ${command} <pr-number> <head-sha>; pr-number must be a positive integer and head-sha a 40-character lowercase hex commit id.`,
+      );
+      process.exitCode = 2;
+      return;
+    }
+    const identity = { number: Number(prNumber), headSha };
+    process.stdout.write(
+      command === "markdown"
+        ? createReviewMarkdownTemplate(identity)
+        : `${JSON.stringify(createReviewArtifactTemplate(identity), null, 2)}\n`,
+    );
     return;
   }
   if (command === "validate" && args.length === 3) {
@@ -483,7 +569,7 @@ function main(argv = process.argv.slice(2)) {
     return;
   }
   console.error(
-    "Usage: review-artifacts.mjs template | validate <review.json> <review.md> <pr-meta.json>",
+    "Usage: review-artifacts.mjs template|markdown <pr-number> <head-sha> | validate <review.json> <review.md> <pr-meta.json>",
   );
   process.exitCode = 2;
 }

--- a/scripts/pr-lib/review.sh
+++ b/scripts/pr-lib/review.sh
@@ -18,10 +18,11 @@ review_artifacts_helper_path() {
 review_claim() {
   local pr="$1"
   mark_pr_operation_side_effects_started
-  local root
-  root=$(repo_root)
-  cd "$root"
-  mkdir -p .local
+  # Claim logs are per-PR review state: keeping them in the PR worktree leaves the
+  # shared canonical checkout with no scripts/pr-owned .local, so a stray artifact
+  # there can never be mistaken for this flow's output. Claiming still works on a
+  # cold PR because enter_worktree provisions both the worktree and .local.
+  enter_worktree "$pr" false
 
   local reviewer=""
   local max_attempts=3
@@ -107,6 +108,11 @@ review_guard() {
   # shellcheck disable=SC1091
   source .local/pr-meta.env
 
+  if [ "${PR_NUMBER:-}" != "$pr" ]; then
+    echo "Review guard failed: .local/pr-meta.env describes PR #${PR_NUMBER:-unknown}, not #$pr. Re-run: scripts/pr review-init $pr"
+    exit 1
+  fi
+
   local branch
   branch=$(git branch --show-current)
   local head_sha
@@ -147,42 +153,74 @@ review_artifacts_init() {
   local pr="$1"
   enter_worktree "$pr" false
   require_artifact .local/pr-meta.env
+  require_artifact .local/pr-meta.json
 
   mark_pr_operation_side_effects_started
 
-  if [ ! -f .local/review.md ]; then
-    cat > .local/review.md <<'EOF_MD'
-A) TL;DR recommendation
-
-B) What changed and what is good?
-
-C) Security findings
-
-D) What is the PR intent? Is this the most optimal implementation?
-
-E) Concerns or questions (actionable)
-
-F) Tests
-
-G) Docs status
-
-H) Changelog
-
-I) Follow ups (optional)
-
-J) Suggested PR comment (optional)
-EOF_MD
+  local meta_number head_sha
+  meta_number=$(jq -r '.number' .local/pr-meta.json)
+  head_sha=$(jq -r '.headRefOid' .local/pr-meta.json)
+  if [ "$meta_number" != "$pr" ] || ! printf '%s' "$head_sha" | rg -q '^[0-9a-f]{40}$'; then
+    echo "Review artifacts init failed: .local/pr-meta.json describes PR #$meta_number at '$head_sha', not PR #$pr. Re-run: scripts/pr review-init $pr"
+    exit 1
   fi
 
-  if [ ! -f .local/review.json ]; then
-    node "$(review_artifacts_helper_path)" template > .local/review.json
+  # Take the first line in the shell, not through `head`: pipefail turns the
+  # helper's EPIPE into a spurious failure once the template outgrows the pipe.
+  local identity_line
+  identity_line=$(node "$(review_artifacts_helper_path)" markdown "$meta_number" "$head_sha")
+  identity_line=${identity_line%%$'\n'*}
+
+  if [ -f .local/review.json ] && [ -f .local/review.md ] &&
+    jq -e --argjson number "$meta_number" --arg head "$head_sha" \
+      '.pr.number == $number and .pr.headSha == $head' .local/review.json >/dev/null 2>&1 &&
+    [ "$(head -n1 .local/review.md)" = "$identity_line" ]
+  then
+    echo "review artifacts already stamped for PR #$meta_number at $head_sha"
+    echo "files=.local/review.md .local/review.json"
+    return 0
   fi
+
+  # Artifacts on disk were authored for another PR or a superseded head. Keep them
+  # instead of deleting: a mid-review head change is legitimate and the prose is
+  # worth salvaging, but only a freshly stamped template may gate this landing.
+  # mktemp -d allocates the archive slot atomically so a retry, a concurrent init,
+  # or a repeated clock second cannot overwrite an earlier preserved review.
+  local superseded_dir="" ext
+  for ext in json md; do
+    [ -f ".local/review.$ext" ] || continue
+    if [ -z "$superseded_dir" ]; then
+      mkdir -p .local/superseded
+      superseded_dir=$(mktemp -d ".local/superseded/$(date -u +%Y%m%dT%H%M%SZ)-XXXXXX")
+    fi
+    mv ".local/review.$ext" "$superseded_dir/review.$ext"
+    echo "moved aside .local/review.$ext -> $superseded_dir/review.$ext (not authored for PR #$meta_number at $head_sha)"
+  done
+
+  node "$(review_artifacts_helper_path)" markdown "$meta_number" "$head_sha" > .local/review.md
+  node "$(review_artifacts_helper_path)" template "$meta_number" "$head_sha" > .local/review.json
 
   echo "review artifact templates are ready"
   echo "files=.local/review.md .local/review.json"
 }
 
 validate_review_artifact_data() {
+  # pr-meta.json is the identity authority the review artifacts are stamped against,
+  # so it must itself be anchored: review_guard binds pr-meta.env to the guarded PR
+  # and the checked-out head, and this ties pr-meta.json to pr-meta.env. Without it a
+  # wholly foreign but self-consistent .local set still gates the landing.
+  local meta_number meta_head
+  meta_number=$(jq -r '.number' .local/pr-meta.json)
+  meta_head=$(jq -r '.headRefOid' .local/pr-meta.json)
+  if ! (
+    # shellcheck disable=SC1091
+    source .local/pr-meta.env
+    [ "$meta_number" = "${PR_NUMBER:-}" ] && [ "$meta_head" = "${PR_HEAD_SHA:-}" ]
+  ); then
+    echo "Review artifact identity mismatch: .local/pr-meta.json describes PR #$meta_number at $meta_head, which does not match .local/pr-meta.env. Re-run: scripts/pr review-init"
+    return 1
+  fi
+
   if ! node "$(review_artifacts_helper_path)" validate \
     .local/review.json \
     .local/review.md \

--- a/test/scripts/pr-review-artifact-validation.test.ts
+++ b/test/scripts/pr-review-artifact-validation.test.ts
@@ -1,5 +1,5 @@
 import { spawnSync } from "node:child_process";
-import { mkdirSync, writeFileSync } from "node:fs";
+import { mkdirSync, readdirSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../helpers/temp-dir.js";
@@ -10,8 +10,13 @@ const reviewArtifactsScript = join(process.cwd(), "scripts/pr-lib/review-artifac
 const mergeScript = join(process.cwd(), "scripts/pr-lib/merge.sh");
 const describePosix = process.platform === "win32" ? describe.skip : describe;
 
+const REVIEWED_PR = 42;
+const REVIEWED_HEAD = "b".repeat(40);
+const REVIEWED_IDENTITY_LINE = `Review artifact for PR #${REVIEWED_PR} at ${REVIEWED_HEAD}`;
+
 function validReview() {
   return {
+    pr: { number: REVIEWED_PR, headSha: REVIEWED_HEAD },
     recommendation: "NEEDS WORK",
     findings: [] as Array<{
       id: string;
@@ -60,6 +65,8 @@ function runValidation(
   options: {
     files?: string[];
     guardFailure?: boolean;
+    markdownIdentityLine?: string;
+    metaEnvPrNumber?: number;
     mode?: "pr" | "main";
     orList?: boolean;
   } = {},
@@ -70,12 +77,31 @@ function runValidation(
   writeFileSync(join(localDir, "review.json"), `${JSON.stringify(review)}\n`);
   writeFileSync(
     join(localDir, "review.md"),
-    ["A)", "B)", "C)", "D)", "E)", "F)", "G)", "H)", "I)", "J)"].join("\n"),
+    [
+      options.markdownIdentityLine ?? REVIEWED_IDENTITY_LINE,
+      "A)",
+      "B)",
+      "C)",
+      "D)",
+      "E)",
+      "F)",
+      "G)",
+      "H)",
+      "I)",
+      "J)",
+    ].join("\n"),
   );
-  writeFileSync(join(localDir, "pr-meta.env"), "PR_URL=https://example.invalid/pr/42\n");
+  writeFileSync(
+    join(localDir, "pr-meta.env"),
+    `PR_URL=https://example.invalid/pr/42\nPR_NUMBER=${options.metaEnvPrNumber ?? REVIEWED_PR}\nPR_HEAD_SHA=${REVIEWED_HEAD}\n`,
+  );
   writeFileSync(
     join(localDir, "pr-meta.json"),
-    `${JSON.stringify({ files: (options.files ?? []).map((path) => ({ path })) })}\n`,
+    `${JSON.stringify({
+      number: REVIEWED_PR,
+      headRefOid: REVIEWED_HEAD,
+      files: (options.files ?? []).map((path) => ({ path })),
+    })}\n`,
   );
 
   return spawnSync(
@@ -100,6 +126,48 @@ function runValidation(
     ],
     { encoding: "utf8" },
   );
+}
+
+function runReviewShellFunction(fixtureRoot: string, invocation: string) {
+  return spawnSync(
+    "bash",
+    [
+      "-c",
+      [
+        "set -euo pipefail",
+        'source "$1"',
+        'fixture_root="$2"',
+        'enter_worktree() { cd "$fixture_root"; }',
+        'require_artifact() { [ -s "$1" ]; }',
+        "mark_pr_operation_side_effects_started() { :; }",
+        invocation,
+      ].join("\n"),
+      "pr-review-shell",
+      reviewScript,
+      fixtureRoot,
+    ],
+    { encoding: "utf8" },
+  );
+}
+
+function runArtifactsInit(existing: { review?: unknown; markdown?: string } = {}) {
+  const fixtureRoot = tempDirs.make("openclaw-pr-review-artifacts-init-");
+  const localDir = join(fixtureRoot, ".local");
+  mkdirSync(localDir);
+  writeFileSync(join(localDir, "pr-meta.env"), `PR_NUMBER=${REVIEWED_PR}\n`);
+  writeFileSync(
+    join(localDir, "pr-meta.json"),
+    `${JSON.stringify({ number: REVIEWED_PR, headRefOid: REVIEWED_HEAD, files: [] })}\n`,
+  );
+  if (existing.review !== undefined) {
+    writeFileSync(join(localDir, "review.json"), `${JSON.stringify(existing.review)}\n`);
+  }
+  if (existing.markdown !== undefined) {
+    writeFileSync(join(localDir, "review.md"), existing.markdown);
+  }
+
+  const result = runReviewShellFunction(fixtureRoot, `review_artifacts_init ${REVIEWED_PR}`);
+  return { result, localDir };
 }
 
 function runMergeVerification(checks: "api-error" | "invalid-json" | "no-required" | "pending") {
@@ -149,6 +217,131 @@ describePosix("scripts/pr review artifact validation", () => {
 
     expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(0);
     expect(result.stdout).toContain("review artifacts validated");
+  });
+
+  it("rejects a review authored for a different PR", () => {
+    const review = validReadyReview();
+    review.pr.number = 113928;
+
+    const result = runValidation(review);
+
+    expect(result.status).toBe(1);
+    expect(result.stdout).toContain(
+      `Review artifact identity mismatch in .local/review.json: authored for PR #113928 at ${REVIEWED_HEAD}, but .local/pr-meta.json describes PR #${REVIEWED_PR} at ${REVIEWED_HEAD}`,
+    );
+  });
+
+  it("rejects a review stamped with a superseded head", () => {
+    const review = validReadyReview();
+    review.pr.headSha = "c".repeat(40);
+
+    const result = runValidation(review);
+
+    expect(result.status).toBe(1);
+    expect(result.stdout).toContain("Review artifact identity mismatch in .local/review.json");
+  });
+
+  it("rejects a self-consistent artifact set describing another PR", () => {
+    const result = runValidation(validReadyReview(), { metaEnvPrNumber: 113928 });
+
+    expect(result.status).toBe(1);
+    expect(result.stdout).toContain(
+      `Review artifact identity mismatch: .local/pr-meta.json describes PR #${REVIEWED_PR} at ${REVIEWED_HEAD}, which does not match .local/pr-meta.env.`,
+    );
+  });
+
+  it("rejects a review markdown authored for a different PR", () => {
+    const result = runValidation(validReadyReview(), {
+      markdownIdentityLine: `Review artifact for PR #113928 at ${REVIEWED_HEAD}`,
+    });
+
+    expect(result.status).toBe(1);
+    expect(result.stdout).toContain(
+      `Review artifact identity mismatch in .local/review.md: first line must be "${REVIEWED_IDENTITY_LINE}"`,
+    );
+  });
+
+  it("rejects a review with no PR identity stamp", () => {
+    const review = validReadyReview() as Partial<ReturnType<typeof validReadyReview>>;
+    review.pr = undefined;
+
+    const result = runValidation(review as ReturnType<typeof validReadyReview>);
+
+    expect(result.status).toBe(1);
+    expect(result.stdout).toContain("Invalid PR identity in .local/review.json");
+  });
+
+  it("moves foreign review artifacts aside and stamps a fresh template", () => {
+    const foreign = validReadyReview();
+    foreign.pr.number = 113928;
+    const { result, localDir } = runArtifactsInit({
+      review: foreign,
+      markdown: "A) Ship another PR\n",
+    });
+
+    expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(0);
+    expect(result.stdout).toContain("moved aside .local/review.json");
+    const archives = readdirSync(join(localDir, "superseded"));
+    expect(archives).toHaveLength(1);
+    const archive = join(localDir, "superseded", archives[0]!);
+    expect(readdirSync(archive).sort()).toEqual(["review.json", "review.md"]);
+    expect(JSON.parse(readFileSync(join(archive, "review.json"), "utf8")).pr.number).toBe(113928);
+    expect(readFileSync(join(archive, "review.md"), "utf8")).toBe("A) Ship another PR\n");
+
+    const rewritten = JSON.parse(readFileSync(join(localDir, "review.json"), "utf8"));
+    expect(rewritten.pr).toEqual({ number: REVIEWED_PR, headSha: REVIEWED_HEAD });
+    expect(rewritten.recommendation).toContain("NEEDS WORK");
+    const markdown = readFileSync(join(localDir, "review.md"), "utf8");
+    expect(markdown.split("\n")[0]).toBe(REVIEWED_IDENTITY_LINE);
+    expect(markdown).toContain("A) TL;DR recommendation");
+  });
+
+  it("re-stamps markdown left over from another PR even when the JSON stamp matches", () => {
+    const { result, localDir } = runArtifactsInit({
+      review: validReadyReview(),
+      markdown: `Review artifact for PR #113928 at ${REVIEWED_HEAD}\n\nA) Ship another PR\n`,
+    });
+
+    expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(0);
+    expect(result.stdout).toContain("moved aside .local/review.md");
+    expect(readFileSync(join(localDir, "review.md"), "utf8").split("\n")[0]).toBe(
+      REVIEWED_IDENTITY_LINE,
+    );
+  });
+
+  it("preserves in-progress artifacts already stamped for this head", () => {
+    const inProgress = validReadyReview();
+    inProgress.issueValidation.summary = "Half-written review worth keeping.";
+    const { result, localDir } = runArtifactsInit({
+      review: inProgress,
+      markdown: `${REVIEWED_IDENTITY_LINE}\n\nA) Half-written review worth keeping.\n`,
+    });
+
+    expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(0);
+    expect(result.stdout).toContain(
+      `review artifacts already stamped for PR #${REVIEWED_PR} at ${REVIEWED_HEAD}`,
+    );
+    expect(readFileSync(join(localDir, "review.md"), "utf8")).toBe(
+      `${REVIEWED_IDENTITY_LINE}\n\nA) Half-written review worth keeping.\n`,
+    );
+    expect(
+      JSON.parse(readFileSync(join(localDir, "review.json"), "utf8")).issueValidation.summary,
+    ).toBe("Half-written review worth keeping.");
+  });
+
+  it("rejects a review guard whose PR metadata describes another PR", () => {
+    const fixtureRoot = tempDirs.make("openclaw-pr-review-guard-");
+    const localDir = join(fixtureRoot, ".local");
+    mkdirSync(localDir);
+    writeFileSync(join(localDir, "review-mode.env"), "REVIEW_MODE=pr\n");
+    writeFileSync(join(localDir, "pr-meta.env"), "PR_NUMBER=113928\n");
+
+    const result = runReviewShellFunction(fixtureRoot, `review_guard ${REVIEWED_PR}`);
+
+    expect(result.status).toBe(1);
+    expect(result.stdout).toContain(
+      `Review guard failed: .local/pr-meta.env describes PR #113928, not #${REVIEWED_PR}`,
+    );
   });
 
   it("rejects validation from main-baseline mode", () => {
@@ -337,12 +530,15 @@ describePosix("scripts/pr review artifact validation", () => {
   });
 
   it("derives template enum hints from the validation table", () => {
-    const result = spawnSync(process.execPath, [reviewArtifactsScript, "template"], {
-      encoding: "utf8",
-    });
+    const result = spawnSync(
+      process.execPath,
+      [reviewArtifactsScript, "template", String(REVIEWED_PR), REVIEWED_HEAD],
+      { encoding: "utf8" },
+    );
     const template = JSON.parse(result.stdout) as ReturnType<typeof validReview>;
 
     expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(0);
+    expect(template.pr).toEqual({ number: REVIEWED_PR, headSha: REVIEWED_HEAD });
     expect(template.recommendation).toBe(
       "NEEDS WORK (allowed: READY FOR /prepare-pr|NEEDS WORK|NEEDS DISCUSSION|NOT USEFUL (CLOSE))",
     );


### PR DESCRIPTION
## What Problem This Solves

**The review gate could approve one PR's verdict for a different PR.** That is the defect — not the artifact clutter that led me to it.

`scripts/pr review-validate-artifacts` had no way to tell whose review it was validating. `review_guard` compares the checked-out HEAD against `PR_HEAD_SHA` read from `.local/pr-meta.env` — but both live in the *same* `.local` directory, so a wholesale foreign artifact set is internally self-consistent and passes every check. `validateReviewArtifacts` read `.local/pr-meta.json` only to count runtime files for the behavioral-sweep rule; it never compared the review to the PR being landed, because there was nothing in the review to compare. Neither `review.json` nor `review.md` named a PR at all.

Proof, using two real artifact sets produced by the real flow on one machine — the `READY FOR /prepare-pr` verdict written while reviewing #114388, placed in the landing directory of #114897, whose `pr-meta.json` came from an actual `scripts/pr review-init 114897`:

```
PR being landed : #114897 at 537fa698569ba00eeea4efde2b349632752712e5
verdict on disk : READY FOR /prepare-pr
…which was written about: The PR body states the concrete ambient-misrouting problem and user impact…
…i.e. a different PR entirely. Nothing in the artifact names a PR.

=== BEFORE (origin/main gate) ===
exit=0   <-- the gate ACCEPTS another PR's READY verdict for #114897

=== AFTER (this PR's gate, byte-identical inputs) ===
Invalid PR identity in .local/review.json: pr.number must be an integer and pr.headSha must be a string; re-run scripts/pr review-artifacts-init
Review artifact identity mismatch in .local/review.md: first line must be "Review artifact for PR #114897 at 537fa698569ba00eeea4efde2b349632752712e5"; re-run scripts/pr review-artifacts-init
2 artifact violations
exit=1   <-- refused
```

Three agents hit this tonight, each finding artifacts pre-filled with another PR's review, and validation passing on that content. An agent trusting the flow rather than re-reading every field would submit someone else's verdict as its own and land on it.

Two contributing details, both verified against source rather than inherited:

- **Artifacts have always lived in the per-PR worktree.** `git show f3055f64f4a^:scripts/pr-lib/worktree.sh` shows the pre-#114723 `enter_worktree` already did `cd .worktrees/pr-$pr` and `mkdir -p .local`. #114723 changed containment, not location. So "the artifacts moved" is not the explanation, and directory separation alone was never the fix.
- **`review_claim` was the one subcommand running in the shared canonical checkout** (`cd "$root"; mkdir -p .local`), writing `review-claim-*.log` there. That is why the canonical root carries a script-owned-*looking* `.local` — on this machine it holds those logs beside a stray `review.json`/`review.md` for an unrelated PR. An author whose shell cwd is the canonical root writes artifacts there while the validator reads the worktree copy, producing exactly the "the values reported back aren't what I wrote" confusion.

## Why This Change Was Made

Make cross-PR contamination structurally impossible rather than something a reviewer must notice.

- **Both artifacts are stamped.** `review.json` gains `pr: { number, headSha }`; `review.md` is now generated by the same helper with a first-line identity header, which also removes a duplicated template heredoc from the shell. Binding only the JSON would let a foreign markdown verdict — the prose a human actually reads — ride along with a freshly stamped JSON.
- **The identity chain is anchored end to end.** Validation rejects a stamp disagreeing with `.local/pr-meta.json`, and `validate_review_artifact_data` now ties `pr-meta.json` itself to `pr-meta.env`, which `review_guard` binds to the CLI argument and the checked-out head: CLI arg → `pr-meta.env` → HEAD, and `pr-meta.env` → `pr-meta.json` → `review.json` + `review.md`. Without that last link, the authority for the stamp was just another local file that travels with the artifacts. Both `prepare-init` and `merge-run` run this path.
- **Init no longer adopts artifacts it did not stamp.** Mismatches are archived into a `mktemp -d` directory under `.local/superseded/` — allocated atomically so a retry, a concurrent init, or a repeated clock second cannot overwrite an earlier preserved review — never deleted, because a mid-review head change is legitimate and the prose is worth salvaging.
- **`review_claim` moves into the PR worktree**, so no `scripts/pr` subcommand writes review state to the shared canonical checkout. Claiming still works on a cold PR because `enter_worktree` provisions both the worktree and `.local`.

Head-SHA binding also mechanically enforces an existing repository rule: after a push and a fresh `review-init`, a review stamped against the superseded head fails instead of quietly gating the new one.

### `.worktrees/` residue — no new command, deliberately

`scripts/pr gc [--dry-run]` already exists, takes per-PR operation locks, and reclaims worktrees plus branches for MERGED/CLOSED PRs; `merge_run` already reclaims on success. `scripts/pr ls` on the canonical checkout shows the residue is exactly gc-eligible: 104923 CLOSED, 112542/112958/113076 MERGED, 114388 legitimately OPEN, plus an unparseable `pr-wrapper-112442`. So this is operator hygiene, not missing tooling.

Auto-running `gc` from `enter_worktree` would be actively wrong: `gc` walks *other* PRs and takes their operation locks, so one landing would contend with concurrent landings — the exact hazard this PR exists to remove. Post-#114723 `enter_worktree` already refuses or repairs a stale directory before any branch moves, so the residue is disk usage, not a correctness risk. No code change.

## User Impact

Maintainer/agent tooling only; no runtime, product, config, or plugin surface. `scripts/pr review-artifacts-init` now requires `.local/pr-meta.json` (already written by `review-init`) and re-stamps artifacts it did not author, preserving the originals under `.local/superseded/`. In-progress reviews stamped for the current PR and head are untouched. This is a deliberate fail-closed change to a landing gate.

## Evidence

**Real behavior proof, after the fix, on real artifacts (no fixtures).** Landing directory seeded with real `pr-meta.json` from `scripts/pr review-init` and the real review artifacts authored for a different PR:

```
=== review_artifacts_init on the contaminated set ===
moved aside .local/review.json -> .local/superseded/20260728T034302Z-yGLvnb/review.json (not authored for PR #114388 at ef661baa1d2e…)
moved aside .local/review.md   -> .local/superseded/20260728T034302Z-yGLvnb/review.md   (not authored for PR #114388 at ef661baa1d2e…)
review artifact templates are ready

foreign verdict preserved, not deleted: READY FOR /prepare-pr
fresh artifact is stamped for the landing PR: {"number":114388,"headSha":"ef661baa1d2ee2196d3dd72bb0794f6cb20fd699"}
fresh markdown identity line: Review artifact for PR #114388 at ef661baa1d2ee2196d3dd72bb0794f6cb20fd699

=== a matching in-progress review is preserved, not clobbered ===
review artifacts already stamped for PR #114388 at ef661baa1d2ee2196d3dd72bb0794f6cb20fd699
in-progress prose still there: A) half-written prose worth keeping
in-progress summary still there: Half-written review worth keeping.
```

The cross-PR rejection transcript is in *What Problem This Solves* above (`exit=0` before, `exit=1` after, byte-identical inputs).

This PR's own landing also exercised the real flow: `review-init` → `review-checkout-pr` → `review-artifacts-init` → `review-validate-artifacts`, all against the canonical wrapper. Worth recording: the freshly created `.worktrees/pr-114897` produced **clean, unfilled templates**. Contamination is not automatic on a fresh worktree — it needs a reused artifact location, which is exactly what the stamp now catches.

Other proof:

- `node scripts/run-vitest.mjs test/scripts/pr-review-artifact-validation.test.ts test/scripts/pr-merge.test.ts test/scripts/pr-worktree-containment.test.ts` — 45 passed. New coverage rejects a review stamped for another PR, a superseded head, an unstamped review, a foreign markdown header, and a self-consistent set whose `pr-meta.json` disagrees with the guarded PR; init archives foreign artifacts, preserves matching in-progress work, and re-stamps foreign markdown even when the JSON stamp matches; `review_guard` rejects mismatched `pr-meta.env`.
- `node scripts/check-changed.mjs` — exit=0 (typecheck test root + scripts lint, Testbox `tbx_01kykby60ma05tce43mzhkanvy`).
- CI green on exact head `537fa698569` — run 30325983523.
- `oxfmt` on touched JS/TS; `git diff --check` clean.
- Codex autoreview (`gpt-5.6-sol`, xhigh) three rounds. Round 1 accepted two findings: markdown not identity-bound, and a one-second-resolution archive name `mv` could overwrite. Round 2 accepted one: `pr-meta.json` was itself unanchored. All fixed. Round 3's only finding claimed `review_claim` breaks on a cold PR — rejected as factually incorrect, since `enter_worktree` provisions the worktree and `.local`; the reason is recorded inline.
- `git diff --numstat`: `review-artifacts.mjs` +97/-11, `review.sh` +66/-28, test +203/-7. Non-test growth is a new integrity gate, not a refactor; the unconditional-adoption path and the duplicated markdown heredoc are deleted.
