### PR TITLE
fix(claws): report plugin setup readiness

### DIFF
--- a/extensions/azure-speech/openclaw.plugin.json
+++ b/extensions/azure-speech/openclaw.plugin.json
@@ -10,11 +10,11 @@
     "providers": [
       {
         "id": "azure-speech",
-        "envVars": ["AZURE_SPEECH_KEY", "AZURE_SPEECH_API_KEY", "SPEECH_KEY", "AZURE_SPEECH_REGION", "SPEECH_REGION"]
+        "envVars": ["AZURE_SPEECH_KEY", "AZURE_SPEECH_API_KEY", "SPEECH_KEY"]
       },
       {
         "id": "azure",
-        "envVars": ["AZURE_SPEECH_KEY", "AZURE_SPEECH_API_KEY", "SPEECH_KEY", "AZURE_SPEECH_REGION", "SPEECH_REGION"]
+        "envVars": ["AZURE_SPEECH_KEY", "AZURE_SPEECH_API_KEY", "SPEECH_KEY"]
       }
     ]
   },

--- a/extensions/azure-speech/openclaw.plugin.json
+++ b/extensions/azure-speech/openclaw.plugin.json
@@ -10,11 +10,11 @@
     "providers": [
       {
         "id": "azure-speech",
-        "envVars": ["AZURE_SPEECH_KEY", "AZURE_SPEECH_API_KEY", "SPEECH_KEY"]
+        "envVars": ["AZURE_SPEECH_KEY", "AZURE_SPEECH_API_KEY", "SPEECH_KEY", "AZURE_SPEECH_REGION", "SPEECH_REGION"]
       },
       {
         "id": "azure",
-        "envVars": ["AZURE_SPEECH_KEY", "AZURE_SPEECH_API_KEY", "SPEECH_KEY"]
+        "envVars": ["AZURE_SPEECH_KEY", "AZURE_SPEECH_API_KEY", "SPEECH_KEY", "AZURE_SPEECH_REGION", "SPEECH_REGION"]
       }
     ]
   },

--- a/src/agents/model-auth-env.ts
+++ b/src/agents/model-auth-env.ts
@@ -1,13 +1,11 @@
 /**
  * Resolves model provider API keys from explicit environment variables.
  */
-import fs from "node:fs";
-import os from "node:os";
 import { normalizeProviderIdForAuth } from "@openclaw/model-catalog-core/provider-id";
-import { normalizeOptionalString as normalizeOptionalPathInput } from "@openclaw/normalization-core/string-coerce";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { getShellEnvAppliedKeys } from "../infra/shell-env.js";
 import { resolvePluginSetupProvider } from "../plugins/setup-registry.js";
+import { resolveLocalProviderAuthEvidence } from "../secrets/provider-auth-evidence.js";
 import type { ProviderAuthEvidence } from "../secrets/provider-env-vars.js";
 import { normalizeOptionalSecretInput } from "../utils/normalize-secret-input.js";
 import { resolveProviderEnvAuthLookupMaps } from "./model-auth-env-vars.js";
@@ -44,66 +42,12 @@ export type EnvApiKeyLookupOptions = {
   skipSetupProviderFallback?: boolean;
 };
 
-function expandAuthEvidencePath(rawPath: string, env: NodeJS.ProcessEnv): string | undefined {
-  const trimmed = rawPath.trim();
-  if (!trimmed) {
-    return undefined;
-  }
-  const homeDir = normalizeOptionalPathInput(env.HOME) ?? os.homedir();
-  const appDataDir = normalizeOptionalPathInput(env.APPDATA);
-  if (trimmed.includes("${APPDATA}") && !appDataDir) {
-    return undefined;
-  }
-  return trimmed.replaceAll("${HOME}", homeDir).replaceAll("${APPDATA}", appDataDir ?? "");
-}
-
-function hasRequiredAuthEvidenceEnv(
-  evidence: ProviderAuthEvidence,
-  env: NodeJS.ProcessEnv,
-): boolean {
-  const hasEnv = (key: string) => Boolean(normalizeOptionalSecretInput(env[key]));
-  if (evidence.requiresAnyEnv?.length && !evidence.requiresAnyEnv.some(hasEnv)) {
-    return false;
-  }
-  if (evidence.requiresAllEnv?.length && !evidence.requiresAllEnv.every(hasEnv)) {
-    return false;
-  }
-  return true;
-}
-
-function hasLocalFileAuthEvidence(evidence: ProviderAuthEvidence, env: NodeJS.ProcessEnv): boolean {
-  if (evidence.fileEnvVar) {
-    const explicitPath = normalizeOptionalPathInput(env[evidence.fileEnvVar]);
-    if (explicitPath) {
-      return fs.existsSync(explicitPath);
-    }
-  }
-  for (const rawPath of evidence.fallbackPaths ?? []) {
-    const expandedPath = expandAuthEvidencePath(rawPath, env);
-    if (expandedPath && fs.existsSync(expandedPath)) {
-      return true;
-    }
-  }
-  return false;
-}
-
 function resolveAuthEvidence(
   evidence: readonly ProviderAuthEvidence[] | undefined,
   env: NodeJS.ProcessEnv,
 ): EnvApiKeyResult | null {
-  for (const entry of evidence ?? []) {
-    if (entry.type !== "local-file-with-env") {
-      continue;
-    }
-    if (!hasRequiredAuthEvidenceEnv(entry, env) || !hasLocalFileAuthEvidence(entry, env)) {
-      continue;
-    }
-    return {
-      apiKey: entry.credentialMarker,
-      source: entry.source ?? "local auth evidence",
-    };
-  }
-  return null;
+  const resolved = resolveLocalProviderAuthEvidence(evidence, env);
+  return resolved ? { apiKey: resolved.credentialMarker, source: resolved.source } : null;
 }
 
 /** Reports env/local auth presence without returning or resolving credential material. */
@@ -143,13 +87,11 @@ export function resolveProviderEnvAuthEvidence(
     };
   }
 
-  for (const evidence of authEvidenceMap[normalized] ?? []) {
-    if (!hasRequiredAuthEvidenceEnv(evidence, env) || !hasLocalFileAuthEvidence(evidence, env)) {
-      continue;
-    }
+  const localEvidence = resolveLocalProviderAuthEvidence(authEvidenceMap[normalized], env);
+  if (localEvidence) {
     return {
       mode: normalized === "amazon-bedrock" ? "aws-sdk" : "api-key",
-      source: evidence.source ?? "local auth evidence",
+      source: localEvidence.source,
     };
   }
   return null;

--- a/src/claws/lifecycle.ts
+++ b/src/claws/lifecycle.ts
@@ -56,6 +56,7 @@ export type ClawAddPlanContext = {
     integrity?: string;
     installId?: string;
     warning?: string;
+    requirements?: ClawLocalPrerequisite[];
     installedVersion?: string;
     code?: string;
     message?: string;
@@ -459,6 +460,9 @@ export async function buildClawAddPlan(params: {
     if (diagnostic) {
       blockers.push(diagnostic);
     }
+    if (preflight.ok && preflight.requirements) {
+      readinessRequirements.push(...preflight.requirements);
+    }
     actions.push({
       kind: "package",
       id: `${pkg.kind}:${pkg.ref}`,
@@ -470,6 +474,7 @@ export async function buildClawAddPlan(params: {
         ...(preflight.integrity ? { integrity: preflight.integrity } : {}),
         ...(preflight.installId ? { installId: preflight.installId } : {}),
         ...(preflight.warning ? { riskWarning: preflight.warning } : {}),
+        ...(preflight.requirements ? { prerequisites: preflight.requirements } : {}),
         expectedState: !preflight.ok
           ? "unresolved"
           : preflight.action === "reuse"
@@ -538,7 +543,7 @@ export async function buildClawAddPlan(params: {
         ...server,
         expectedState: exactExisting ? "present-exact" : "absent",
         prerequisites: readinessRequirements.filter(
-          (requirement) => requirement.mcpServer === name,
+          (requirement) => requirement.kind !== "plugin-setup" && requirement.mcpServer === name,
         ),
       },
       blocked,

--- a/src/claws/packages.test.ts
+++ b/src/claws/packages.test.ts
@@ -168,6 +168,36 @@ describe("preflightClawPackage plugin setup requirements", () => {
     ).resolves.not.toHaveProperty("requirements");
   });
 
+  it("reports setup for an auth-method-only provider", async () => {
+    probePluginSetup.mockResolvedValueOnce({
+      ok: true,
+      pluginId: "evidence",
+      setup: {
+        providers: [{ id: "oauth-only", authMethods: ["oauth"] }],
+      },
+      clawhub: { integrity },
+    });
+
+    await expect(
+      preflightClawPackage(pluginPackage, "/tmp/workspace", {
+        env: {},
+        deps: { preflightPlugin, probePlugin: probePluginSetup },
+      }),
+    ).resolves.toEqual(
+      expect.objectContaining({
+        requirements: [
+          {
+            kind: "plugin-setup",
+            plugin: "evidence",
+            provider: "oauth-only",
+            envVars: [],
+            authMethods: ["oauth"],
+          },
+        ],
+      }),
+    );
+  });
+
   it("accepts declared local auth evidence", async () => {
     const credentialsDir = await mkdtemp(join(tmpdir(), "claw-auth-evidence-"));
     const credentialsPath = join(credentialsDir, "credentials.json");

--- a/src/claws/packages.test.ts
+++ b/src/claws/packages.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
-import { installClawPackages } from "./packages.js";
+import { installClawPackages, resolveClawPluginSetupRequirements } from "./packages.js";
 import type { PersistedClawPackageRef } from "./provenance.js";
 import type { ClawAddPlan, ResolvedClawPackage } from "./types.js";
 
@@ -115,6 +115,40 @@ const probePlugin = vi.fn(async ({ spec }: { spec: string }) => {
       integrity,
     },
   };
+});
+
+describe("resolveClawPluginSetupRequirements", () => {
+  const setup = {
+    providers: [
+      {
+        id: "evidence",
+        authMethods: ["api-key"],
+        envVars: ["EVIDENCE_API_KEY", "EVIDENCE_TOKEN"],
+      },
+    ],
+  };
+
+  it("reports plugin setup when no declared environment credential is present", () => {
+    expect(resolveClawPluginSetupRequirements({ pluginId: "evidence", setup, env: {} })).toEqual([
+      {
+        kind: "plugin-setup",
+        plugin: "evidence",
+        provider: "evidence",
+        envVars: ["EVIDENCE_API_KEY", "EVIDENCE_TOKEN"],
+        authMethods: ["api-key"],
+      },
+    ]);
+  });
+
+  it("accepts any declared environment credential", () => {
+    expect(
+      resolveClawPluginSetupRequirements({
+        pluginId: "evidence",
+        setup,
+        env: { EVIDENCE_TOKEN: "configured" },
+      }),
+    ).toEqual([]);
+  });
 });
 
 describe("installClawPackages", () => {

--- a/src/claws/packages.test.ts
+++ b/src/claws/packages.test.ts
@@ -1,3 +1,6 @@
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { describe, expect, it, vi } from "vitest";
 import { installClawPackages, preflightClawPackage } from "./packages.js";
 import type { PersistedClawPackageRef } from "./provenance.js";
@@ -163,6 +166,46 @@ describe("preflightClawPackage plugin setup requirements", () => {
         deps: { preflightPlugin, probePlugin: probePluginSetup },
       }),
     ).resolves.not.toHaveProperty("requirements");
+  });
+
+  it("accepts declared local auth evidence", async () => {
+    const credentialsDir = await mkdtemp(join(tmpdir(), "claw-auth-evidence-"));
+    const credentialsPath = join(credentialsDir, "credentials.json");
+    await writeFile(credentialsPath, "{}", "utf8");
+    probePluginSetup.mockResolvedValueOnce({
+      ok: true,
+      pluginId: "evidence",
+      setup: {
+        providers: [
+          {
+            ...setup.providers[0],
+            authEvidence: [
+              {
+                type: "local-file-with-env",
+                fileEnvVar: "EVIDENCE_CREDENTIALS",
+                requiresAllEnv: ["EVIDENCE_PROJECT"],
+                credentialMarker: "evidence-local-credentials",
+              },
+            ],
+          },
+        ],
+      },
+      clawhub: { integrity },
+    });
+
+    try {
+      await expect(
+        preflightClawPackage(pluginPackage, "/tmp/workspace", {
+          env: {
+            EVIDENCE_CREDENTIALS: credentialsPath,
+            EVIDENCE_PROJECT: "project",
+          },
+          deps: { preflightPlugin, probePlugin: probePluginSetup },
+        }),
+      ).resolves.not.toHaveProperty("requirements");
+    } finally {
+      await rm(credentialsDir, { recursive: true, force: true });
+    }
   });
 });
 

--- a/src/claws/packages.test.ts
+++ b/src/claws/packages.test.ts
@@ -168,6 +168,27 @@ describe("preflightClawPackage plugin setup requirements", () => {
     ).resolves.not.toHaveProperty("requirements");
   });
 
+  it("accepts credentials for any declared provider", async () => {
+    probePluginSetup.mockResolvedValueOnce({
+      ok: true,
+      pluginId: "evidence",
+      setup: {
+        providers: [
+          { id: "first", envVars: ["FIRST_API_KEY"] },
+          { id: "second", envVars: ["SECOND_API_KEY"] },
+        ],
+      },
+      clawhub: { integrity },
+    });
+
+    await expect(
+      preflightClawPackage(pluginPackage, "/tmp/workspace", {
+        env: { SECOND_API_KEY: "configured" },
+        deps: { preflightPlugin, probePlugin: probePluginSetup },
+      }),
+    ).resolves.not.toHaveProperty("requirements");
+  });
+
   it("reports setup for an auth-method-only provider", async () => {
     probePluginSetup.mockResolvedValueOnce({
       ok: true,

--- a/src/claws/packages.test.ts
+++ b/src/claws/packages.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
-import { installClawPackages, resolveClawPluginSetupRequirements } from "./packages.js";
+import { installClawPackages, preflightClawPackage } from "./packages.js";
 import type { PersistedClawPackageRef } from "./provenance.js";
 import type { ClawAddPlan, ResolvedClawPackage } from "./types.js";
 
@@ -117,7 +117,7 @@ const probePlugin = vi.fn(async ({ spec }: { spec: string }) => {
   };
 });
 
-describe("resolveClawPluginSetupRequirements", () => {
+describe("preflightClawPackage plugin setup requirements", () => {
   const setup = {
     providers: [
       {
@@ -127,27 +127,42 @@ describe("resolveClawPluginSetupRequirements", () => {
       },
     ],
   };
-
-  it("reports plugin setup when no declared environment credential is present", () => {
-    expect(resolveClawPluginSetupRequirements({ pluginId: "evidence", setup, env: {} })).toEqual([
-      {
-        kind: "plugin-setup",
-        plugin: "evidence",
-        provider: "evidence",
-        envVars: ["EVIDENCE_API_KEY", "EVIDENCE_TOKEN"],
-        authMethods: ["api-key"],
-      },
-    ]);
+  const preflightPlugin = vi.fn().mockResolvedValue({ ok: true, action: "install" });
+  const probePluginSetup = vi.fn().mockResolvedValue({
+    ok: true,
+    pluginId: "evidence",
+    setup,
+    clawhub: { integrity },
   });
 
-  it("accepts any declared environment credential", () => {
-    expect(
-      resolveClawPluginSetupRequirements({
-        pluginId: "evidence",
-        setup,
-        env: { EVIDENCE_TOKEN: "configured" },
+  it("reports plugin setup when no declared environment credential is present", async () => {
+    await expect(
+      preflightClawPackage(pluginPackage, "/tmp/workspace", {
+        env: {},
+        deps: { preflightPlugin, probePlugin: probePluginSetup },
       }),
-    ).toEqual([]);
+    ).resolves.toEqual(
+      expect.objectContaining({
+        requirements: [
+          {
+            kind: "plugin-setup",
+            plugin: "evidence",
+            provider: "evidence",
+            envVars: ["EVIDENCE_API_KEY", "EVIDENCE_TOKEN"],
+            authMethods: ["api-key"],
+          },
+        ],
+      }),
+    );
+  });
+
+  it("accepts any declared environment credential", async () => {
+    await expect(
+      preflightClawPackage(pluginPackage, "/tmp/workspace", {
+        env: { EVIDENCE_TOKEN: "configured" },
+        deps: { preflightPlugin, probePlugin: probePluginSetup },
+      }),
+    ).resolves.not.toHaveProperty("requirements");
   });
 });
 

--- a/src/claws/packages.test.ts
+++ b/src/claws/packages.test.ts
@@ -189,7 +189,7 @@ describe("preflightClawPackage plugin setup requirements", () => {
     ).resolves.not.toHaveProperty("requirements");
   });
 
-  it("reports setup for an auth-method-only provider", async () => {
+  it("does not gate readiness on an auth-method-only provider", async () => {
     probePluginSetup.mockResolvedValueOnce({
       ok: true,
       pluginId: "evidence",
@@ -204,19 +204,7 @@ describe("preflightClawPackage plugin setup requirements", () => {
         env: {},
         deps: { preflightPlugin, probePlugin: probePluginSetup },
       }),
-    ).resolves.toEqual(
-      expect.objectContaining({
-        requirements: [
-          {
-            kind: "plugin-setup",
-            plugin: "evidence",
-            provider: "oauth-only",
-            envVars: [],
-            authMethods: ["oauth"],
-          },
-        ],
-      }),
-    );
+    ).resolves.not.toHaveProperty("requirements");
   });
 
   it("accepts declared local auth evidence", async () => {

--- a/src/claws/packages.ts
+++ b/src/claws/packages.ts
@@ -141,7 +141,7 @@ type ClawPackagePreflightResult =
       warning?: string;
     };
 
-export function resolveClawPluginSetupRequirements(params: {
+function resolveClawPluginSetupRequirements(params: {
   pluginId: string;
   setup?: PluginManifestSetup;
   env: NodeJS.ProcessEnv;
@@ -166,7 +166,10 @@ export function resolveClawPluginSetupRequirements(params: {
 export async function preflightClawPackage(
   pkg: ClawPackage,
   workspaceDir: string,
-  options: { env?: NodeJS.ProcessEnv } = {},
+  options: {
+    env?: NodeJS.ProcessEnv;
+    deps?: Pick<PackageInstallerDeps, "preflightPlugin" | "probePlugin">;
+  } = {},
 ): Promise<ClawPackagePreflightResult> {
   if (pkg.kind === "skill") {
     const result = await preflightSkillFromClawHub({
@@ -177,7 +180,7 @@ export async function preflightClawPackage(
     });
     return result.ok ? result : { ok: false, code: result.code, message: result.error };
   }
-  const result = await preflightPluginInstall({
+  const result = await (options.deps?.preflightPlugin ?? preflightPluginInstall)({
     clawhubPackage: pkg.ref,
     rawSpec: `clawhub:${pkg.ref}@${pkg.version}`,
     expectedVersion: pkg.version,
@@ -189,7 +192,7 @@ export async function preflightClawPackage(
       message: result.error,
     };
   }
-  const probe = await installPluginFromClawHub({
+  const probe = await (options.deps?.probePlugin ?? installPluginFromClawHub)({
     spec: `clawhub:${pkg.ref}@${pkg.version}`,
     dryRun: true,
     acknowledgeClawHubRisk: true,

--- a/src/claws/packages.ts
+++ b/src/claws/packages.ts
@@ -9,6 +9,7 @@ import {
 } from "../plugins/plugin-install-preflight.js";
 import { withPluginLifecycleLease } from "../plugins/plugin-lifecycle-lease.js";
 import { defaultRuntime, type RuntimeEnv } from "../runtime.js";
+import { resolveLocalProviderAuthEvidence } from "../secrets/provider-auth-evidence.js";
 import { installSkillFromClawHub, preflightSkillFromClawHub } from "../skills/lifecycle/clawhub.js";
 import {
   acquireClawPackageLifecycleLease,
@@ -148,7 +149,12 @@ function resolveClawPluginSetupRequirements(params: {
 }): ClawLocalPrerequisite[] {
   return (params.setup?.providers ?? []).flatMap((provider) => {
     const envVars = provider.envVars ?? [];
-    if (envVars.length === 0 || envVars.some((name) => Boolean(params.env[name]?.trim()))) {
+    const authEvidence = provider.authEvidence ?? [];
+    if (
+      (envVars.length === 0 && authEvidence.length === 0) ||
+      envVars.some((name) => Boolean(params.env[name]?.trim())) ||
+      resolveLocalProviderAuthEvidence(authEvidence, params.env)
+    ) {
       return [];
     }
     return [

--- a/src/claws/packages.ts
+++ b/src/claws/packages.ts
@@ -150,8 +150,9 @@ function resolveClawPluginSetupRequirements(params: {
   return (params.setup?.providers ?? []).flatMap((provider) => {
     const envVars = provider.envVars ?? [];
     const authEvidence = provider.authEvidence ?? [];
+    const authMethods = provider.authMethods ?? [];
     if (
-      (envVars.length === 0 && authEvidence.length === 0) ||
+      (envVars.length === 0 && authEvidence.length === 0 && authMethods.length === 0) ||
       envVars.some((name) => Boolean(params.env[name]?.trim())) ||
       resolveLocalProviderAuthEvidence(authEvidence, params.env)
     ) {

--- a/src/claws/packages.ts
+++ b/src/claws/packages.ts
@@ -147,15 +147,22 @@ function resolveClawPluginSetupRequirements(params: {
   setup?: PluginManifestSetup;
   env: NodeJS.ProcessEnv;
 }): ClawLocalPrerequisite[] {
-  return (params.setup?.providers ?? []).flatMap((provider) => {
+  const providers = params.setup?.providers ?? [];
+  // Providers are alternative setup routes for one plugin. Any configured
+  // route satisfies readiness; otherwise expose every route to the operator.
+  const hasConfiguredProvider = providers.some(
+    (provider) =>
+      (provider.envVars ?? []).some((name) => Boolean(params.env[name]?.trim())) ||
+      resolveLocalProviderAuthEvidence(provider.authEvidence, params.env),
+  );
+  if (hasConfiguredProvider) {
+    return [];
+  }
+  return providers.flatMap((provider) => {
     const envVars = provider.envVars ?? [];
     const authEvidence = provider.authEvidence ?? [];
     const authMethods = provider.authMethods ?? [];
-    if (
-      (envVars.length === 0 && authEvidence.length === 0 && authMethods.length === 0) ||
-      envVars.some((name) => Boolean(params.env[name]?.trim())) ||
-      resolveLocalProviderAuthEvidence(authEvidence, params.env)
-    ) {
+    if (envVars.length === 0 && authEvidence.length === 0 && authMethods.length === 0) {
       return [];
     }
     return [

--- a/src/claws/packages.ts
+++ b/src/claws/packages.ts
@@ -161,8 +161,9 @@ function resolveClawPluginSetupRequirements(params: {
   return providers.flatMap((provider) => {
     const envVars = provider.envVars ?? [];
     const authEvidence = provider.authEvidence ?? [];
-    const authMethods = provider.authMethods ?? [];
-    if (envVars.length === 0 && authEvidence.length === 0 && authMethods.length === 0) {
+    // Dry-run has no persisted setup state, so only gate on credential evidence
+    // it can actually observe. Auth methods remain descriptive metadata.
+    if (envVars.length === 0 && authEvidence.length === 0) {
       return [];
     }
     return [

--- a/src/claws/packages.ts
+++ b/src/claws/packages.ts
@@ -2,6 +2,7 @@ import { runPluginInstallCommand } from "../cli/plugins-install-command.js";
 import { runPluginUninstallCommand } from "../cli/plugins-uninstall-command.js";
 import { normalizeClawHubSha256Integrity } from "../infra/clawhub.js";
 import { installPluginFromClawHub } from "../plugins/clawhub.js";
+import type { PluginManifestSetup } from "../plugins/manifest.js";
 import {
   preflightPluginInstall,
   resolveInstalledClawHubPlugin,
@@ -21,7 +22,13 @@ import {
   updateClawPackageRefStatus,
   type PersistedClawPackageRef,
 } from "./provenance.js";
-import type { ClawAddPlan, ClawAddPlanAction, ClawPackage, ResolvedClawPackage } from "./types.js";
+import type {
+  ClawAddPlan,
+  ClawAddPlanAction,
+  ClawLocalPrerequisite,
+  ClawPackage,
+  ResolvedClawPackage,
+} from "./types.js";
 
 export class ClawPackageInstallError extends Error {
   constructor(
@@ -122,6 +129,7 @@ type ClawPackagePreflightResult =
       integrity: string;
       installId?: string;
       warning?: string;
+      requirements?: ClawLocalPrerequisite[];
     }
   | {
       ok: false;
@@ -133,9 +141,32 @@ type ClawPackagePreflightResult =
       warning?: string;
     };
 
+export function resolveClawPluginSetupRequirements(params: {
+  pluginId: string;
+  setup?: PluginManifestSetup;
+  env: NodeJS.ProcessEnv;
+}): ClawLocalPrerequisite[] {
+  return (params.setup?.providers ?? []).flatMap((provider) => {
+    const envVars = provider.envVars ?? [];
+    if (envVars.length === 0 || envVars.some((name) => Boolean(params.env[name]?.trim()))) {
+      return [];
+    }
+    return [
+      {
+        kind: "plugin-setup" as const,
+        plugin: params.pluginId,
+        provider: provider.id,
+        envVars,
+        authMethods: provider.authMethods ?? [],
+      },
+    ];
+  });
+}
+
 export async function preflightClawPackage(
   pkg: ClawPackage,
   workspaceDir: string,
+  options: { env?: NodeJS.ProcessEnv } = {},
 ): Promise<ClawPackagePreflightResult> {
   if (pkg.kind === "skill") {
     const result = await preflightSkillFromClawHub({
@@ -199,11 +230,17 @@ export async function preflightClawPackage(
       message: `Plugin ${pkg.ref}@${pkg.version} is installed as ${result.installedId} with integrity ${result.installedIntegrity ?? "unknown"}, expected ${probe.pluginId} with ${integrity}.`,
     };
   }
+  const requirements = resolveClawPluginSetupRequirements({
+    pluginId: probe.pluginId,
+    setup: probe.setup,
+    env: options.env ?? process.env,
+  });
   return {
     ok: true,
     action: result.action,
     integrity,
     installId: probe.pluginId,
+    ...(requirements.length > 0 ? { requirements } : {}),
     ...(probe.warning ? { warning: probe.warning } : {}),
   };
 }

--- a/src/claws/schema.test.ts
+++ b/src/claws/schema.test.ts
@@ -780,6 +780,46 @@ describe("buildClawAddPlan", () => {
     );
   });
 
+  it("includes package setup requirements in plan readiness", async () => {
+    const { source, workspace } = await createPlanSource();
+    const plan = await buildClawAddPlan({
+      manifest: requireManifest(),
+      source,
+      context: {
+        workspace,
+        packagePreflight: async (pkg) => ({
+          ok: true,
+          action: "install",
+          integrity: `sha256:${"a".repeat(64)}`,
+          ...(pkg.kind === "plugin"
+            ? {
+                installId: "github",
+                requirements: [
+                  {
+                    kind: "plugin-setup" as const,
+                    plugin: "github",
+                    provider: "github",
+                    envVars: ["GITHUB_TOKEN"],
+                    authMethods: ["token"],
+                  },
+                ],
+              }
+            : {}),
+        }),
+      },
+    });
+
+    expect(plan.readiness.ready).toBe(false);
+    expect(plan.readiness.requirements).toEqual(
+      expect.arrayContaining([expect.objectContaining({ kind: "plugin-setup", plugin: "github" })]),
+    );
+    expect(plan.actions.find((action) => action.id === "plugin:@acme/github")?.details).toEqual(
+      expect.objectContaining({
+        prerequisites: expect.arrayContaining([expect.objectContaining({ kind: "plugin-setup" })]),
+      }),
+    );
+  });
+
   it("plans one new agent, workspace, packages, MCP servers, and agent-pinned cron jobs", async () => {
     const { source, workspace } = await createPlanSource();
     const canonicalWorkspace = join(await realpath(source.packageRoot), "new-workspace");

--- a/src/claws/types.ts
+++ b/src/claws/types.ts
@@ -217,7 +217,14 @@ export type ClawAddCapabilityChange = {
 
 export type ClawLocalPrerequisite =
   | { kind: "environment"; mcpServer: string; name: string }
-  | { kind: "oauth"; mcpServer: string };
+  | { kind: "oauth"; mcpServer: string }
+  | {
+      kind: "plugin-setup";
+      plugin: string;
+      provider: string;
+      envVars: string[];
+      authMethods: string[];
+    };
 
 export type ClawAddPlan = {
   schemaVersion: typeof CLAW_ADD_PLAN_SCHEMA_VERSION;

--- a/src/plugins/install-installed-package.ts
+++ b/src/plugins/install-installed-package.ts
@@ -36,6 +36,7 @@ type ValidatedPackagePlugin = {
   manifestName?: string;
   version?: string;
   extensions: string[];
+  setup?: import("./manifest.js").PluginManifestSetup;
   hasRuntimeDependencies: boolean;
   peerDependencies: Record<string, string>;
 };
@@ -191,6 +192,9 @@ export async function validatePackagePluginInstallSource(params: {
       manifestName: pkgName || undefined,
       version: typeof manifest.version === "string" ? manifest.version : undefined,
       extensions,
+      ...(ocManifestResult.ok && ocManifestResult.manifest.setup
+        ? { setup: ocManifestResult.manifest.setup }
+        : {}),
       hasRuntimeDependencies: hasPackageRuntimeDependencies(manifest),
       peerDependencies: manifest.peerDependencies ?? {},
     },
@@ -323,6 +327,7 @@ async function installPluginFromInstalledPackageDirInternal(
     manifestName: validated.plugin.manifestName,
     version: validated.plugin.version,
     extensions: validated.plugin.extensions,
+    setup: validated.plugin.setup,
   });
   if (params.emitSuccessSecurityEvent !== false) {
     emitSuccessfulPluginInstallSecurityEvent(result, {

--- a/src/plugins/install-package.ts
+++ b/src/plugins/install-package.ts
@@ -288,6 +288,7 @@ async function installPluginFromPackageDir(
     manifestName: plugin.manifestName,
     version: plugin.version,
     extensions: plugin.extensions,
+    setup: plugin.setup,
     targetDir: preparedTarget.targetPath,
     extensionsDir: params.extensionsDir,
     logger,

--- a/src/plugins/install-shared.ts
+++ b/src/plugins/install-shared.ts
@@ -166,6 +166,7 @@ export function buildDirectoryInstallResult(params: {
   manifestName?: string;
   version?: string;
   extensions: string[];
+  setup?: import("./manifest.js").PluginManifestSetup;
 }): InstallPluginResult {
   return {
     ok: true,
@@ -174,6 +175,7 @@ export function buildDirectoryInstallResult(params: {
     manifestName: params.manifestName,
     version: params.version,
     extensions: params.extensions,
+    ...(params.setup ? { setup: params.setup } : {}),
   };
 }
 
@@ -356,6 +358,7 @@ export async function installPluginDirectoryIntoExtensions(params: {
   manifestName?: string;
   version?: string;
   extensions: string[];
+  setup?: import("./manifest.js").PluginManifestSetup;
   targetDir?: string;
   extensionsDir?: string;
   logger: PluginInstallLogger;
@@ -402,6 +405,7 @@ export async function installPluginDirectoryIntoExtensions(params: {
       manifestName: params.manifestName,
       version: params.version,
       extensions: params.extensions,
+      setup: params.setup,
     });
   }
 
@@ -442,6 +446,7 @@ export async function installPluginDirectoryIntoExtensions(params: {
     manifestName: params.manifestName,
     version: params.version,
     extensions: params.extensions,
+    setup: params.setup,
   });
 }
 

--- a/src/plugins/install-types.ts
+++ b/src/plugins/install-types.ts
@@ -1,7 +1,7 @@
 import type { NpmIntegrityDrift, NpmSpecResolution } from "../infra/install-source-utils.js";
 import type { InstallPolicySource } from "../security/install-policy.js";
 import type { InstallSafetyOverrides } from "./install-security-scan.js";
-import type { PackageManifest as PluginPackageManifest } from "./manifest.js";
+import type { PackageManifest as PluginPackageManifest, PluginManifestSetup } from "./manifest.js";
 
 export type PluginInstallLogger = {
   info?: (message: string) => void;
@@ -44,6 +44,7 @@ export type InstallPluginResult =
       manifestName?: string;
       version?: string;
       extensions: string[];
+      setup?: PluginManifestSetup;
       npmResolution?: NpmSpecResolution;
       integrityDrift?: NpmIntegrityDrift;
     }

--- a/src/secrets/provider-auth-evidence.ts
+++ b/src/secrets/provider-auth-evidence.ts
@@ -1,0 +1,86 @@
+/** Resolves cheap, secret-free local credential evidence declared by provider manifests. */
+import fs from "node:fs";
+import os from "node:os";
+import { normalizeOptionalString as normalizeOptionalPathInput } from "@openclaw/normalization-core/string-coerce";
+import { normalizeOptionalSecretInput } from "../utils/normalize-secret-input.js";
+
+type LocalProviderAuthEvidence = {
+  type: "local-file-with-env";
+  fileEnvVar?: string;
+  fallbackPaths?: readonly string[];
+  requiresAnyEnv?: readonly string[];
+  requiresAllEnv?: readonly string[];
+  credentialMarker: string;
+  source?: string;
+};
+
+type ResolvedLocalProviderAuthEvidence = {
+  credentialMarker: string;
+  source: string;
+};
+
+function expandAuthEvidencePath(rawPath: string, env: NodeJS.ProcessEnv): string | undefined {
+  const trimmed = rawPath.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+  const homeDir = normalizeOptionalPathInput(env.HOME) ?? os.homedir();
+  const appDataDir = normalizeOptionalPathInput(env.APPDATA);
+  if (trimmed.includes("${APPDATA}") && !appDataDir) {
+    return undefined;
+  }
+  return trimmed.replaceAll("${HOME}", homeDir).replaceAll("${APPDATA}", appDataDir ?? "");
+}
+
+function hasRequiredAuthEvidenceEnv(
+  evidence: LocalProviderAuthEvidence,
+  env: NodeJS.ProcessEnv,
+): boolean {
+  const hasEnv = (key: string) => Boolean(normalizeOptionalSecretInput(env[key]));
+  if (evidence.requiresAnyEnv?.length && !evidence.requiresAnyEnv.some(hasEnv)) {
+    return false;
+  }
+  if (evidence.requiresAllEnv?.length && !evidence.requiresAllEnv.every(hasEnv)) {
+    return false;
+  }
+  return true;
+}
+
+function hasLocalFileAuthEvidence(
+  evidence: LocalProviderAuthEvidence,
+  env: NodeJS.ProcessEnv,
+): boolean {
+  if (evidence.fileEnvVar) {
+    const explicitPath = normalizeOptionalPathInput(env[evidence.fileEnvVar]);
+    if (explicitPath) {
+      return fs.existsSync(explicitPath);
+    }
+  }
+  for (const rawPath of evidence.fallbackPaths ?? []) {
+    const expandedPath = expandAuthEvidencePath(rawPath, env);
+    if (expandedPath && fs.existsSync(expandedPath)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+export function resolveLocalProviderAuthEvidence(
+  evidenceEntries: readonly LocalProviderAuthEvidence[] | undefined,
+  env: NodeJS.ProcessEnv,
+): ResolvedLocalProviderAuthEvidence | null {
+  for (const evidence of evidenceEntries ?? []) {
+    if (
+      evidence.type !== "local-file-with-env" ||
+      !hasRequiredAuthEvidenceEnv(evidence, env) ||
+      !hasLocalFileAuthEvidence(evidence, env)
+    ) {
+      continue;
+    }
+    return {
+      credentialMarker: evidence.credentialMarker,
+      source: evidence.source ?? "local auth evidence",
+    };
+  }
+  return null;
+}


### PR DESCRIPTION
## Summary

- preserve normalized plugin `setup.providers` metadata during ClawHub install preflight
- report missing plugin credentials in `claws add --dry-run` readiness and package action details
- keep readiness satisfied when any declared provider environment credential is present

This follows up the experimental Claws lifecycle from [RFC #27](https://github.com/openclaw/rfcs/pull/27). Real validation with the Awesome Claws catalog found that plugin-backed Claws could report `ready: true` even when their plugin could not run without an API key.

## Validation

- `pnpm exec vitest run src/claws/packages.test.ts src/claws/schema.test.ts --config vitest.config.ts` (62 passed)
- `pnpm tsgo:prod`
- `pnpm tsgo:test:root`
- focused `oxlint` and `oxfmt --check` on all changed files
- built OpenClaw and previewed real ClawHub packages:
  - Tavily without `TAVILY_API_KEY`: `ready: false`, `plugin-setup` requirement emitted
  - Tavily with `TAVILY_API_KEY`: `ready: true`, no requirements
  - Firecrawl without `FIRECRAWL_API_KEY`: `ready: false`, `plugin-setup` requirement emitted
  - Lobster (credential-free): remains `ready: true`

`pnpm check:changed` could not delegate because the current Blacksmith credential cannot access the authenticated organization. The legacy `tsc` lane exceeded both 4 GB and 8 GB heaps; the repository's `tsgo` production and test lanes pass.