### PR TITLE
fix: decode Windows bash session output

### DIFF
--- a/src/agents/sessions/agent-session-execution.ts
+++ b/src/agents/sessions/agent-session-execution.ts
@@ -141,12 +141,13 @@ export abstract class AgentSessionExecution extends AgentSessionExtensions {
     const prefix = this.settingsManager.getShellCommandPrefix();
     const shellPath = this.settingsManager.getShellPath();
     const resolvedCommand = prefix ? `${prefix}\n${command}` : command;
+    const operations = options?.operations ?? createLocalBashOperations({ shellPath });
 
     try {
       const result = await executeBashWithOperations(
         resolvedCommand,
         this.sessionManager.getCwd(),
-        options?.operations ?? createLocalBashOperations({ shellPath }),
+        operations,
         {
           onChunk,
           signal: this.bashAbortController.signal,

--- a/src/agents/sessions/agent-session-execution.ts
+++ b/src/agents/sessions/agent-session-execution.ts
@@ -1,5 +1,6 @@
 import { isContextOverflow } from "@openclaw/ai/internal/runtime";
 import type { AssistantMessage } from "../../llm/types.js";
+import { createWindowsOutputDecoder } from "../../infra/windows-encoding.js";
 import { classifyRateLimitWindow } from "../../llm/utils/rate-limit-window.js";
 import { isRetryableAssistantError } from "../../llm/utils/retry.js";
 import { sleep } from "../utils/sleep.js";
@@ -150,6 +151,7 @@ export abstract class AgentSessionExecution extends AgentSessionExtensions {
         {
           onChunk,
           signal: this.bashAbortController.signal,
+          createTextDecoder: options?.operations ? undefined : createWindowsOutputDecoder,
         },
       );
 

--- a/src/agents/sessions/agent-session-execution.ts
+++ b/src/agents/sessions/agent-session-execution.ts
@@ -1,6 +1,5 @@
 import { isContextOverflow } from "@openclaw/ai/internal/runtime";
 import type { AssistantMessage } from "../../llm/types.js";
-import { createWindowsOutputDecoder } from "../../infra/windows-encoding.js";
 import { classifyRateLimitWindow } from "../../llm/utils/rate-limit-window.js";
 import { isRetryableAssistantError } from "../../llm/utils/retry.js";
 import { sleep } from "../utils/sleep.js";
@@ -142,16 +141,16 @@ export abstract class AgentSessionExecution extends AgentSessionExtensions {
     const prefix = this.settingsManager.getShellCommandPrefix();
     const shellPath = this.settingsManager.getShellPath();
     const resolvedCommand = prefix ? `${prefix}\n${command}` : command;
+    const operations = options?.operations ?? createLocalBashOperations({ shellPath });
 
     try {
       const result = await executeBashWithOperations(
         resolvedCommand,
         this.sessionManager.getCwd(),
-        options?.operations ?? createLocalBashOperations({ shellPath }),
+        operations,
         {
           onChunk,
           signal: this.bashAbortController.signal,
-          createTextDecoder: options?.operations ? undefined : createWindowsOutputDecoder,
         },
       );
 

--- a/src/agents/sessions/bash-executor.test.ts
+++ b/src/agents/sessions/bash-executor.test.ts
@@ -39,8 +39,8 @@ describe("executeBashWithOperations", () => {
 
   it("uses the operation owner's decoder while defaulting injected output to UTF-8", async () => {
     const cp936 = Buffer.from([
-      199, 253, 182, 175, 198, 247, 32, 67, 32, 214, 208, 181, 196, 190, 237, 202, 199, 32, 65,
-      99, 101, 114,
+      199, 253, 182, 175, 198, 247, 32, 67, 32, 214, 208, 181, 196, 190, 237, 202, 199, 32, 65, 99,
+      101, 114,
     ]);
     const injectedOperations = operationsForChunks([[cp936]]);
     const localOperations = operationsForChunks([[cp936]], () =>
@@ -49,10 +49,15 @@ describe("executeBashWithOperations", () => {
 
     const utf8Result = await executeBashWithOperations("printf output", "/tmp", injectedOperations);
     const windowsResult = await executeBashWithOperations("printf output", "/tmp", localOperations);
-    const explicitResult = await executeBashWithOperations("printf output", "/tmp", injectedOperations, {
-      createTextDecoder: () =>
-        createWindowsOutputDecoder({ platform: "win32", windowsEncoding: "gbk" }),
-    });
+    const explicitResult = await executeBashWithOperations(
+      "printf output",
+      "/tmp",
+      injectedOperations,
+      {
+        createTextDecoder: () =>
+          createWindowsOutputDecoder({ platform: "win32", windowsEncoding: "gbk" }),
+      },
+    );
 
     expect(utf8Result.output).toBe(new TextDecoder().decode(cp936));
     expect(windowsResult.output).toBe("\u9a71\u52a8\u5668 C \u4e2d\u7684\u5377\u662f Acer");

--- a/src/agents/sessions/bash-executor.test.ts
+++ b/src/agents/sessions/bash-executor.test.ts
@@ -1,6 +1,7 @@
 // Bash executor tests cover bounded UTF-8 output and private sanitized spills.
 import { readFile, rm, stat } from "node:fs/promises";
 import { describe, expect, it } from "vitest";
+import { createWindowsOutputDecoder } from "../../infra/windows-encoding.js";
 import { executeBashWithOperations } from "./bash-executor.js";
 import {
   expectNativeBashSpill,
@@ -13,8 +14,12 @@ type OutputChunk = readonly [data: Buffer, stream?: "stdout" | "stderr"];
 
 const ESC = String.fromCharCode(27);
 
-function operationsForChunks(chunks: readonly OutputChunk[]): BashOperations {
+function operationsForChunks(
+  chunks: readonly OutputChunk[],
+  createTextDecoder?: BashOperations["createTextDecoder"],
+): BashOperations {
   return {
+    ...(createTextDecoder ? { createTextDecoder } : {}),
     exec: async (_command, _cwd, options) => {
       for (const [data, stream] of chunks) {
         options.onData(data, stream);
@@ -32,6 +37,27 @@ describe("executeBashWithOperations", () => {
     },
   );
 
+  it("uses the operation owner's decoder while defaulting injected output to UTF-8", async () => {
+    const cp936 = Buffer.from([
+      199, 253, 182, 175, 198, 247, 32, 67, 32, 214, 208, 181, 196, 190, 237, 202, 199, 32, 65,
+      99, 101, 114,
+    ]);
+    const injectedOperations = operationsForChunks([[cp936]]);
+    const localOperations = operationsForChunks([[cp936]], () =>
+      createWindowsOutputDecoder({ platform: "win32", windowsEncoding: "gbk" }),
+    );
+
+    const utf8Result = await executeBashWithOperations("printf output", "/tmp", injectedOperations);
+    const windowsResult = await executeBashWithOperations("printf output", "/tmp", localOperations);
+    const explicitResult = await executeBashWithOperations("printf output", "/tmp", injectedOperations, {
+      createTextDecoder: () =>
+        createWindowsOutputDecoder({ platform: "win32", windowsEncoding: "gbk" }),
+    });
+
+    expect(utf8Result.output).toBe(new TextDecoder().decode(cp936));
+    expect(windowsResult.output).toBe("\u9a71\u52a8\u5668 C \u4e2d\u7684\u5377\u662f Acer");
+    expect(explicitResult.output).toBe("\u9a71\u52a8\u5668 C \u4e2d\u7684\u5377\u662f Acer");
+  });
   it("stores truncated full output in an owner-only temp file", async () => {
     const sanitizedOutput = "secret output\n".repeat(9000);
     const operations: BashOperations = {

--- a/src/agents/sessions/bash-executor.test.ts
+++ b/src/agents/sessions/bash-executor.test.ts
@@ -1,6 +1,7 @@
 // Bash executor tests cover bounded UTF-8 output and private sanitized spills.
 import { readFile, rm, stat } from "node:fs/promises";
 import { describe, expect, it } from "vitest";
+import { createWindowsOutputDecoder } from "../../infra/windows-encoding.js";
 import { executeBashWithOperations } from "./bash-executor.js";
 import type { BashOperations } from "./tools/bash-operations.js";
 import { DEFAULT_MAX_BYTES } from "./tools/truncate.js";
@@ -21,6 +22,23 @@ function operationsForChunks(chunks: readonly OutputChunk[]): BashOperations {
 }
 
 describe("executeBashWithOperations", () => {
+  it("keeps injected operation output UTF-8 unless the owner selects another decoder", async () => {
+    const cp936 = Buffer.from([
+      199, 253, 182, 175, 198, 247, 32, 67, 32, 214, 208, 181, 196, 190, 237, 202, 199, 32, 65,
+      99, 101, 114,
+    ]);
+    const operations = operationsForChunks([[cp936]]);
+
+    const utf8Result = await executeBashWithOperations("printf output", "/tmp", operations);
+    const windowsResult = await executeBashWithOperations("printf output", "/tmp", operations, {
+      createTextDecoder: () =>
+        createWindowsOutputDecoder({ platform: "win32", windowsEncoding: "gbk" }),
+    });
+
+    expect(utf8Result.output).toBe(new TextDecoder().decode(cp936));
+    expect(windowsResult.output).toBe("驱动器 C 中的卷是 Acer");
+  });
+
   it("stores truncated full output in an owner-only temp file", async () => {
     const sanitizedOutput = "secret output\n".repeat(9000);
     const operations: BashOperations = {

--- a/src/agents/sessions/bash-executor.test.ts
+++ b/src/agents/sessions/bash-executor.test.ts
@@ -10,8 +10,12 @@ type OutputChunk = readonly [data: Buffer, stream?: "stdout" | "stderr"];
 
 const ESC = String.fromCharCode(27);
 
-function operationsForChunks(chunks: readonly OutputChunk[]): BashOperations {
+function operationsForChunks(
+  chunks: readonly OutputChunk[],
+  createTextDecoder?: BashOperations["createTextDecoder"],
+): BashOperations {
   return {
+    ...(createTextDecoder ? { createTextDecoder } : {}),
     exec: async (_command, _cwd, options) => {
       for (const [data, stream] of chunks) {
         options.onData(data, stream);
@@ -22,21 +26,26 @@ function operationsForChunks(chunks: readonly OutputChunk[]): BashOperations {
 }
 
 describe("executeBashWithOperations", () => {
-  it("keeps injected operation output UTF-8 unless the owner selects another decoder", async () => {
+  it("uses the operation owner's decoder while defaulting injected output to UTF-8", async () => {
     const cp936 = Buffer.from([
       199, 253, 182, 175, 198, 247, 32, 67, 32, 214, 208, 181, 196, 190, 237, 202, 199, 32, 65,
       99, 101, 114,
     ]);
-    const operations = operationsForChunks([[cp936]]);
+    const injectedOperations = operationsForChunks([[cp936]]);
+    const localOperations = operationsForChunks([[cp936]], () =>
+      createWindowsOutputDecoder({ platform: "win32", windowsEncoding: "gbk" }),
+    );
 
-    const utf8Result = await executeBashWithOperations("printf output", "/tmp", operations);
-    const windowsResult = await executeBashWithOperations("printf output", "/tmp", operations, {
+    const utf8Result = await executeBashWithOperations("printf output", "/tmp", injectedOperations);
+    const windowsResult = await executeBashWithOperations("printf output", "/tmp", localOperations);
+    const explicitResult = await executeBashWithOperations("printf output", "/tmp", injectedOperations, {
       createTextDecoder: () =>
         createWindowsOutputDecoder({ platform: "win32", windowsEncoding: "gbk" }),
     });
 
     expect(utf8Result.output).toBe(new TextDecoder().decode(cp936));
     expect(windowsResult.output).toBe("驱动器 C 中的卷是 Acer");
+    expect(explicitResult.output).toBe("驱动器 C 中的卷是 Acer");
   });
 
   it("stores truncated full output in an owner-only temp file", async () => {

--- a/src/agents/sessions/bash-executor.ts
+++ b/src/agents/sessions/bash-executor.ts
@@ -8,7 +8,7 @@
 
 import { createStreamingBinaryOutputSanitizer } from "../shell-utils.js";
 import type { BashOperations } from "./tools/bash-operations.js";
-import { OutputAccumulator } from "./tools/output-accumulator.js";
+import { OutputAccumulator, type OutputTextDecoder } from "./tools/output-accumulator.js";
 
 // ============================================================================
 // Types
@@ -19,6 +19,8 @@ export interface BashExecutorOptions {
   onChunk?: (chunk: string) => void;
   /** AbortSignal for cancellation */
   signal?: AbortSignal;
+  /** Explicit decoder override; otherwise use the operation owner's decoder or UTF-8. */
+  createTextDecoder?: () => OutputTextDecoder;
 }
 
 export interface BashResult {
@@ -50,6 +52,7 @@ export async function executeBashWithOperations(
 ): Promise<BashResult> {
   const output = new OutputAccumulator({
     tempFilePrefix: "openclaw-bash",
+    createTextDecoder: options?.createTextDecoder ?? operations.createTextDecoder,
     createTextTransform: () => {
       const sanitizeOutput = createStreamingBinaryOutputSanitizer();
       return (text) => sanitizeOutput(text).replace(/\r/g, "");

--- a/src/agents/sessions/bash-executor.ts
+++ b/src/agents/sessions/bash-executor.ts
@@ -19,7 +19,7 @@ export interface BashExecutorOptions {
   onChunk?: (chunk: string) => void;
   /** AbortSignal for cancellation */
   signal?: AbortSignal;
-  /** Decoder selected by the operation owner; defaults to UTF-8 for injected operations. */
+  /** Explicit decoder override; otherwise use the operation owner's decoder or UTF-8. */
   createTextDecoder?: () => OutputTextDecoder;
 }
 
@@ -52,7 +52,7 @@ export async function executeBashWithOperations(
 ): Promise<BashResult> {
   const output = new OutputAccumulator({
     tempFilePrefix: "openclaw-bash",
-    createTextDecoder: options?.createTextDecoder,
+    createTextDecoder: options?.createTextDecoder ?? operations.createTextDecoder,
     createTextTransform: () => {
       const sanitizeOutput = createStreamingBinaryOutputSanitizer();
       return (text) => sanitizeOutput(text).replace(/\r/g, "");

--- a/src/agents/sessions/bash-executor.ts
+++ b/src/agents/sessions/bash-executor.ts
@@ -8,7 +8,7 @@
 
 import { createStreamingBinaryOutputSanitizer } from "../shell-utils.js";
 import type { BashOperations } from "./tools/bash-operations.js";
-import { OutputAccumulator } from "./tools/output-accumulator.js";
+import { OutputAccumulator, type OutputTextDecoder } from "./tools/output-accumulator.js";
 
 // ============================================================================
 // Types
@@ -19,6 +19,8 @@ export interface BashExecutorOptions {
   onChunk?: (chunk: string) => void;
   /** AbortSignal for cancellation */
   signal?: AbortSignal;
+  /** Decoder selected by the operation owner; defaults to UTF-8 for injected operations. */
+  createTextDecoder?: () => OutputTextDecoder;
 }
 
 export interface BashResult {
@@ -50,6 +52,7 @@ export async function executeBashWithOperations(
 ): Promise<BashResult> {
   const output = new OutputAccumulator({
     tempFilePrefix: "openclaw-bash",
+    createTextDecoder: options?.createTextDecoder,
     createTextTransform: () => {
       const sanitizeOutput = createStreamingBinaryOutputSanitizer();
       return (text) => sanitizeOutput(text).replace(/\r/g, "");

--- a/src/agents/sessions/exec.real.test.ts
+++ b/src/agents/sessions/exec.real.test.ts
@@ -1,9 +1,13 @@
 import { spawnSync } from "node:child_process";
 import { readFileSync } from "node:fs";
+import { readFile, rm } from "node:fs/promises";
 import { join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
+import { createWindowsOutputDecoder } from "../../infra/windows-encoding.js";
+import type { TextContent } from "../../llm/types.js";
 import { execCommand } from "./exec.js";
+import { createBashTool, createLocalBashOperations } from "./tools/bash.js";
 
 const cleanupPids = new Set<number>();
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
@@ -82,4 +86,53 @@ describe("execCommand process-tree cleanup", () => {
       { timeout: 500, interval: 25 },
     );
   }, 12_000);
+});
+
+describe("Windows bash session output", () => {
+  it.runIf(process.platform === "win32")(
+    "proves readable CP936 output and decoded truncated spill through the local tool",
+    async () => {
+      const cp936Bytes =
+        "\\xC7\\xFD\\xB6\\xAF\\xC6\\xF7 C \\xD6\\xD0\\xB5\\xC4\\xBE\\xED\\xCA\\xC7 Acer";
+      const expected = "\u9a71\u52a8\u5668 C \u4e2d\u7684\u5377\u662f Acer";
+      const tool = createBashTool(process.cwd(), {
+        operations: {
+          ...createLocalBashOperations(),
+          createTextDecoder: () =>
+            createWindowsOutputDecoder({ platform: "win32", windowsEncoding: "gbk" }),
+        },
+      });
+      const decodedResult = await tool.execute("windows-cp936", {
+        command: `printf '${cp936Bytes}\\n'`,
+      });
+      const decoded =
+        decodedResult.content.find((item): item is TextContent => item.type === "text")?.text ?? "";
+      expect(decoded).toBe(`${expected}\n`);
+
+      const spillResult = await tool.execute("windows-cp936-spill", {
+        command: `for i in $(seq 1 9000); do printf '${cp936Bytes}\\n'; done`,
+      });
+      const fullOutputPath = (spillResult.details as { fullOutputPath?: string } | undefined)
+        ?.fullOutputPath;
+      expect(fullOutputPath).toBeDefined();
+      const fullOutput = await readFile(fullOutputPath!, "utf8");
+      expect(fullOutput.startsWith(`${expected}\n`)).toBe(true);
+      expect(fullOutput.includes("\ufffd")).toBe(false);
+
+      const utf8Result = await tool.execute("windows-utf8-control", {
+        command: "printf 'UTF8_OK_hello\\n'",
+      });
+      const utf8Output =
+        utf8Result.content.find((item): item is TextContent => item.type === "text")?.text ?? "";
+      expect(utf8Output).toBe("UTF8_OK_hello\n");
+      console.log(`WINDOWS_BASH_PROOF decoded=${decoded.trim()}`);
+      const spillDecoded = fullOutput.startsWith(`${expected}\n`);
+      const replacementCharacter = fullOutput.includes("\ufffd");
+      console.log(
+        `WINDOWS_BASH_PROOF spillDecoded=${spillDecoded} replacementCharacter=${replacementCharacter}`,
+      );
+      console.log(`WINDOWS_BASH_PROOF utf8=${utf8Output.trim()}`);
+      await rm(fullOutputPath!, { force: true });
+    },
+  );
 });

--- a/src/agents/sessions/tools/bash-operations.ts
+++ b/src/agents/sessions/tools/bash-operations.ts
@@ -1,8 +1,11 @@
 /**
  * Minimal shell execution interface injected into bash session tools.
  */
+import type { OutputTextDecoder } from "./output-accumulator.js";
 
 export interface BashOperations {
+  /** Decoder selected by this operation owner; omitted custom backends default to UTF-8. */
+  createTextDecoder?: () => OutputTextDecoder;
   exec: (
     command: string,
     cwd: string,

--- a/src/agents/sessions/tools/bash.test.ts
+++ b/src/agents/sessions/tools/bash.test.ts
@@ -4,12 +4,12 @@ import path from "node:path";
 // timer-safe millisecond values.
 import { MAX_TIMER_TIMEOUT_MS } from "@openclaw/normalization-core/number-coercion";
 import { describe, expect, it, vi } from "vitest";
+import { createWindowsOutputDecoder } from "../../../infra/windows-encoding.js";
 import { buildShellCommandInvocation } from "../../shell-utils.js";
 import {
   expectNativeBashSpill,
   nativeBashSpillScenarios,
 } from "../bash-output-spill.test-support.js";
-import { createWindowsOutputDecoder } from "../../../infra/windows-encoding.js";
 import type { BashOperations } from "./bash-operations.js";
 import { createBashTool, createLocalBashOperations } from "./bash.js";
 import { resolveBashTimeoutMs } from "./bash.test-support.js";

--- a/src/agents/sessions/tools/bash.test.ts
+++ b/src/agents/sessions/tools/bash.test.ts
@@ -5,14 +5,11 @@ import path from "node:path";
 import { MAX_TIMER_TIMEOUT_MS } from "@openclaw/normalization-core/number-coercion";
 import { describe, expect, it, vi } from "vitest";
 import { buildShellCommandInvocation } from "../../shell-utils.js";
-<<<<<<< HEAD
 import {
   expectNativeBashSpill,
   nativeBashSpillScenarios,
 } from "../bash-output-spill.test-support.js";
-=======
 import { createWindowsOutputDecoder } from "../../../infra/windows-encoding.js";
->>>>>>> 7239ded0b20f (rebase: preserve Windows bash output decoding)
 import type { BashOperations } from "./bash-operations.js";
 import { createBashTool, createLocalBashOperations } from "./bash.js";
 import { resolveBashTimeoutMs } from "./bash.test-support.js";
@@ -108,8 +105,8 @@ describe("bash tool output lifecycle", () => {
 
   it("uses the decoder carried by wrapped local operations", async () => {
     const cp936 = Buffer.from([
-      199, 253, 182, 175, 198, 247, 32, 67, 32, 214, 208, 181, 196, 190, 237, 202, 199, 32, 65,
-      99, 101, 114,
+      199, 253, 182, 175, 198, 247, 32, 67, 32, 214, 208, 181, 196, 190, 237, 202, 199, 32, 65, 99,
+      101, 114,
     ]);
     const operations: BashOperations = {
       ...createLocalBashOperations(),
@@ -124,7 +121,10 @@ describe("bash tool output lifecycle", () => {
 
     const result = await tool.execute("call-wrapped-local", { command: "ignored" });
 
-    expect(result.content[0]).toEqual({ type: "text", text: "\u9a71\u52a8\u5668 C \u4e2d\u7684\u5377\u662f Acer" });
+    expect(result.content[0]).toEqual({
+      type: "text",
+      text: "\u9a71\u52a8\u5668 C \u4e2d\u7684\u5377\u662f Acer",
+    });
   });
   it.runIf(process.platform !== "win32")("surfaces a configured shell launch error", async () => {
     const operations = createLocalBashOperations({

--- a/src/agents/sessions/tools/bash.test.ts
+++ b/src/agents/sessions/tools/bash.test.ts
@@ -5,10 +5,14 @@ import path from "node:path";
 import { MAX_TIMER_TIMEOUT_MS } from "@openclaw/normalization-core/number-coercion";
 import { describe, expect, it, vi } from "vitest";
 import { buildShellCommandInvocation } from "../../shell-utils.js";
+<<<<<<< HEAD
 import {
   expectNativeBashSpill,
   nativeBashSpillScenarios,
 } from "../bash-output-spill.test-support.js";
+=======
+import { createWindowsOutputDecoder } from "../../../infra/windows-encoding.js";
+>>>>>>> 7239ded0b20f (rebase: preserve Windows bash output decoding)
 import type { BashOperations } from "./bash-operations.js";
 import { createBashTool, createLocalBashOperations } from "./bash.js";
 import { resolveBashTimeoutMs } from "./bash.test-support.js";
@@ -102,6 +106,26 @@ describe("bash tool output lifecycle", () => {
     },
   );
 
+  it("uses the decoder carried by wrapped local operations", async () => {
+    const cp936 = Buffer.from([
+      199, 253, 182, 175, 198, 247, 32, 67, 32, 214, 208, 181, 196, 190, 237, 202, 199, 32, 65,
+      99, 101, 114,
+    ]);
+    const operations: BashOperations = {
+      ...createLocalBashOperations(),
+      createTextDecoder: () =>
+        createWindowsOutputDecoder({ platform: "win32", windowsEncoding: "gbk" }),
+      exec: async (_command, _cwd, { onData }) => {
+        onData(cp936, "stdout");
+        return { exitCode: 0 };
+      },
+    };
+    const tool = createBashTool(process.cwd(), { operations });
+
+    const result = await tool.execute("call-wrapped-local", { command: "ignored" });
+
+    expect(result.content[0]).toEqual({ type: "text", text: "\u9a71\u52a8\u5668 C \u4e2d\u7684\u5377\u662f Acer" });
+  });
   it.runIf(process.platform !== "win32")("surfaces a configured shell launch error", async () => {
     const operations = createLocalBashOperations({
       shellPath: path.join(process.cwd(), "package.json"),

--- a/src/agents/sessions/tools/bash.test.ts
+++ b/src/agents/sessions/tools/bash.test.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import { MAX_TIMER_TIMEOUT_MS } from "@openclaw/normalization-core/number-coercion";
 import { describe, expect, it, vi } from "vitest";
 import { buildShellCommandInvocation } from "../../shell-utils.js";
+import { createWindowsOutputDecoder } from "../../../infra/windows-encoding.js";
 import type { BashOperations } from "./bash-operations.js";
 import { createBashTool, createLocalBashOperations } from "./bash.js";
 import { resolveBashTimeoutMs } from "./bash.test-support.js";
@@ -56,6 +57,27 @@ describe("bash tool timeout helpers", () => {
 });
 
 describe("bash tool output lifecycle", () => {
+  it("uses the decoder carried by wrapped local operations", async () => {
+    const cp936 = Buffer.from([
+      199, 253, 182, 175, 198, 247, 32, 67, 32, 214, 208, 181, 196, 190, 237, 202, 199, 32, 65,
+      99, 101, 114,
+    ]);
+    const operations: BashOperations = {
+      ...createLocalBashOperations(),
+      createTextDecoder: () =>
+        createWindowsOutputDecoder({ platform: "win32", windowsEncoding: "gbk" }),
+      exec: async (_command, _cwd, { onData }) => {
+        onData(cp936, "stdout");
+        return { exitCode: 0 };
+      },
+    };
+    const tool = createBashTool(process.cwd(), { operations });
+
+    const result = await tool.execute("call-wrapped-local", { command: "ignored" });
+
+    expect(result.content[0]).toEqual({ type: "text", text: "驱动器 C 中的卷是 Acer" });
+  });
+
   it.runIf(process.platform !== "win32")("surfaces a configured shell launch error", async () => {
     const operations = createLocalBashOperations({
       shellPath: path.join(process.cwd(), "package.json"),

--- a/src/agents/sessions/tools/bash.ts
+++ b/src/agents/sessions/tools/bash.ts
@@ -9,6 +9,7 @@ import { resolveTimerTimeoutMs } from "@openclaw/normalization-core/number-coerc
 import { Type } from "typebox";
 import { toErrorObject } from "../../../infra/errors.js";
 import { formatDurationSeconds } from "../../../infra/format-time/format-duration.js";
+import { createWindowsOutputDecoder } from "../../../infra/windows-encoding.js";
 import { releaseChildProcessOutputAfterExit } from "../../../process/child-process.js";
 import { COMMAND_PROCESS_TREE_KILL_GRACE_MS } from "../../../process/exec-spawn.js";
 import { createCommandTerminationController } from "../../../process/exec-termination.js";
@@ -62,6 +63,7 @@ if (process.env.VITEST || process.env.NODE_ENV === "test") {
  */
 export function createLocalBashOperations(options?: { shellPath?: string }): BashOperations {
   return {
+    createTextDecoder: createWindowsOutputDecoder,
     exec: (command, cwd, { onData, signal, timeout, env }) => {
       return new Promise((resolve, reject) => {
         const shellConfig = getBashShellConfig(options?.shellPath);
@@ -353,7 +355,10 @@ export function createBashToolDefinition(
       resolveBashTimeoutMs(timeout);
       const resolvedCommand = commandPrefix ? `${commandPrefix}\n${command}` : command;
       const spawnContext = resolveSpawnContext(resolvedCommand, cwd, spawnHook, options?.shellPath);
-      const output = new OutputAccumulator({ tempFilePrefix: "openclaw-bash" });
+      const output = new OutputAccumulator({
+        tempFilePrefix: "openclaw-bash",
+        createTextDecoder: ops.createTextDecoder,
+      });
       let acceptingOutput = true;
       let updateTimer: NodeJS.Timeout | undefined;
       let updateDirty = false;

--- a/src/agents/sessions/tools/bash.ts
+++ b/src/agents/sessions/tools/bash.ts
@@ -62,6 +62,7 @@ if (process.env.VITEST || process.env.NODE_ENV === "test") {
  */
 export function createLocalBashOperations(options?: { shellPath?: string }): BashOperations {
   return {
+    createTextDecoder: createWindowsOutputDecoder,
     exec: (command, cwd, { onData, signal, timeout, env }) => {
       return new Promise((resolve, reject) => {
         const shellConfig = getBashShellConfig(options?.shellPath);
@@ -328,7 +329,7 @@ export function createBashToolDefinition(
       const spawnContext = resolveSpawnContext(resolvedCommand, cwd, spawnHook, options?.shellPath);
       const output = new OutputAccumulator({
         tempFilePrefix: "openclaw-bash",
-        createTextDecoder: options?.operations ? undefined : createWindowsOutputDecoder,
+        createTextDecoder: ops.createTextDecoder,
       });
       let acceptingOutput = true;
       let updateTimer: NodeJS.Timeout | undefined;

--- a/src/agents/sessions/tools/bash.ts
+++ b/src/agents/sessions/tools/bash.ts
@@ -9,6 +9,7 @@ import { resolveTimerTimeoutMs } from "@openclaw/normalization-core/number-coerc
 import { Type } from "typebox";
 import { toErrorObject } from "../../../infra/errors.js";
 import { formatDurationSeconds } from "../../../infra/format-time/format-duration.js";
+import { createWindowsOutputDecoder } from "../../../infra/windows-encoding.js";
 import { releaseChildProcessOutputAfterExit } from "../../../process/child-process.js";
 import { spawnCommand } from "../../../process/exec.js";
 import { keyHint } from "../../modes/interactive/components/keybinding-hints.js";
@@ -325,7 +326,10 @@ export function createBashToolDefinition(
       resolveBashTimeoutMs(timeout);
       const resolvedCommand = commandPrefix ? `${commandPrefix}\n${command}` : command;
       const spawnContext = resolveSpawnContext(resolvedCommand, cwd, spawnHook, options?.shellPath);
-      const output = new OutputAccumulator({ tempFilePrefix: "openclaw-bash" });
+      const output = new OutputAccumulator({
+        tempFilePrefix: "openclaw-bash",
+        createTextDecoder: options?.operations ? undefined : createWindowsOutputDecoder,
+      });
       let acceptingOutput = true;
       let updateTimer: NodeJS.Timeout | undefined;
       let updateDirty = false;

--- a/src/agents/sessions/tools/output-accumulator.test.ts
+++ b/src/agents/sessions/tools/output-accumulator.test.ts
@@ -3,8 +3,8 @@ import { mkdtemp, readFile, realpath, rm, stat } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
-import { spawnNodeEvalSync } from "../../../test-utils/node-process.js";
 import { createWindowsOutputDecoder } from "../../../infra/windows-encoding.js";
+import { spawnNodeEvalSync } from "../../../test-utils/node-process.js";
 import { OutputAccumulator } from "./output-accumulator.js";
 
 describe("OutputAccumulator", () => {

--- a/src/agents/sessions/tools/output-accumulator.test.ts
+++ b/src/agents/sessions/tools/output-accumulator.test.ts
@@ -233,7 +233,9 @@ describe("OutputAccumulator", () => {
     const text = accumulator.append(cp936DirHeader, "stdout") + accumulator.finish();
 
     expect(text).toBe("\u9a71\u52a8\u5668 C \u4e2d\u7684\u5377\u662f Acer");
-    expect(accumulator.snapshot().content).toBe("\u9a71\u52a8\u5668 C \u4e2d\u7684\u5377\u662f Acer");
+    expect(accumulator.snapshot().content).toBe(
+      "\u9a71\u52a8\u5668 C \u4e2d\u7684\u5377\u662f Acer",
+    );
   });
   it("spills tagged streams in decoded delivery order", async () => {
     const accumulator = new OutputAccumulator({

--- a/src/agents/sessions/tools/output-accumulator.test.ts
+++ b/src/agents/sessions/tools/output-accumulator.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 import { spawnNodeEvalSync } from "../../../test-utils/node-process.js";
+import { createWindowsOutputDecoder } from "../../../infra/windows-encoding.js";
 import { OutputAccumulator } from "./output-accumulator.js";
 
 describe("OutputAccumulator", () => {
@@ -219,6 +220,21 @@ describe("OutputAccumulator", () => {
     expect(flushed).toBe("��");
   });
 
+  it("decodes Windows console code page output for session bash streams", () => {
+    const accumulator = new OutputAccumulator({
+      createTextDecoder: () =>
+        createWindowsOutputDecoder({ platform: "win32", windowsEncoding: "gbk" }),
+    });
+    const cp936DirHeader = Buffer.from([
+      199, 253, 182, 175, 198, 247, 32, 67, 32, 214, 208, 181, 196, 190, 237, 202, 199, 32, 65, 99,
+      101, 114,
+    ]);
+
+    const text = accumulator.append(cp936DirHeader, "stdout") + accumulator.finish();
+
+    expect(text).toBe("\u9a71\u52a8\u5668 C \u4e2d\u7684\u5377\u662f Acer");
+    expect(accumulator.snapshot().content).toBe("\u9a71\u52a8\u5668 C \u4e2d\u7684\u5377\u662f Acer");
+  });
   it("spills tagged streams in decoded delivery order", async () => {
     const accumulator = new OutputAccumulator({
       maxBytes: 1,
@@ -235,6 +251,30 @@ describe("OutputAccumulator", () => {
 
     expect(snapshot.fullOutputPath).toBeDefined();
     expect(await readFile(snapshot.fullOutputPath!, "utf8")).toBe("E日");
+    await rm(snapshot.fullOutputPath!, { force: true });
+  });
+
+  it("spills decoded text for truncated untagged custom-decoder output", async () => {
+    const accumulator = new OutputAccumulator({
+      maxBytes: 1,
+      maxLines: 10,
+      tempFilePrefix: "openclaw-output-test",
+      createTextDecoder: () =>
+        createWindowsOutputDecoder({ platform: "win32", windowsEncoding: "gbk" }),
+    });
+    const cp936Text = "\u9a71\u52a8\u5668 C \u4e2d\u7684\u5377\u662f Acer";
+    const cp936Bytes = Buffer.from([
+      199, 253, 182, 175, 198, 247, 32, 67, 32, 214, 208, 181, 196, 190, 237, 202, 199, 32, 65, 99,
+      101, 114,
+    ]);
+
+    accumulator.append(cp936Bytes);
+    accumulator.finish();
+    const snapshot = accumulator.snapshot({ persistIfTruncated: true });
+    await accumulator.closeTempFile();
+
+    expect(snapshot.truncation.truncated).toBe(true);
+    expect(await readFile(snapshot.fullOutputPath!, "utf8")).toBe(cp936Text);
     await rm(snapshot.fullOutputPath!, { force: true });
   });
 });

--- a/src/agents/sessions/tools/output-accumulator.test.ts
+++ b/src/agents/sessions/tools/output-accumulator.test.ts
@@ -1,7 +1,20 @@
 // OutputAccumulator tests cover bounded UTF-8 tails and private spill files.
 import { readFile, rm, stat } from "node:fs/promises";
 import { describe, expect, it } from "vitest";
+import { createWindowsOutputDecoder } from "../../../infra/windows-encoding.js";
 import { OutputAccumulator } from "./output-accumulator.js";
+
+function createUtf8TextDecoder(): {
+  decode(chunk: Buffer | string): string;
+  flush(): string;
+} {
+  const decoder = new TextDecoder();
+  return {
+    decode: (chunk) =>
+      typeof chunk === "string" ? chunk : decoder.decode(chunk, { stream: true }),
+    flush: () => decoder.decode(),
+  };
+}
 
 describe("OutputAccumulator", () => {
   it("stores spilled full output in an owner-only temp file", async () => {
@@ -46,7 +59,7 @@ describe("OutputAccumulator", () => {
   it("flushes pending bytes held by every stream lane", () => {
     // Each lane decodes independently, so a truncated character left on one
     // pipe must not stop the other pipe's tail from being flushed.
-    const accumulator = new OutputAccumulator();
+    const accumulator = new OutputAccumulator({ createTextDecoder: createUtf8TextDecoder });
 
     accumulator.append(Buffer.from([0xe6, 0x97]), "stdout"); // leading bytes of 日
     accumulator.append(Buffer.from([0xe6, 0x97]), "stderr");
@@ -54,6 +67,22 @@ describe("OutputAccumulator", () => {
     const flushed = accumulator.finish();
 
     expect(flushed).toBe("��");
+  });
+
+  it("decodes Windows console code page output for session bash streams", () => {
+    const accumulator = new OutputAccumulator({
+      createTextDecoder: () =>
+        createWindowsOutputDecoder({ platform: "win32", windowsEncoding: "gbk" }),
+    });
+    const cp936DirHeader = Buffer.from([
+      199, 253, 182, 175, 198, 247, 32, 67, 32, 214, 208, 181, 196, 190, 237, 202, 199, 32, 65, 99,
+      101, 114,
+    ]);
+
+    const text = accumulator.append(cp936DirHeader, "stdout") + accumulator.finish();
+
+    expect(text).toBe("驱动器 C 中的卷是 Acer");
+    expect(accumulator.snapshot().content).toBe("驱动器 C 中的卷是 Acer");
   });
 
   it("spills tagged streams in decoded delivery order", async () => {

--- a/src/agents/sessions/tools/output-accumulator.test.ts
+++ b/src/agents/sessions/tools/output-accumulator.test.ts
@@ -4,18 +4,6 @@ import { describe, expect, it } from "vitest";
 import { createWindowsOutputDecoder } from "../../../infra/windows-encoding.js";
 import { OutputAccumulator } from "./output-accumulator.js";
 
-function createUtf8TextDecoder(): {
-  decode(chunk: Buffer | string): string;
-  flush(): string;
-} {
-  const decoder = new TextDecoder();
-  return {
-    decode: (chunk) =>
-      typeof chunk === "string" ? chunk : decoder.decode(chunk, { stream: true }),
-    flush: () => decoder.decode(),
-  };
-}
-
 describe("OutputAccumulator", () => {
   it("stores spilled full output in an owner-only temp file", async () => {
     const accumulator = new OutputAccumulator({
@@ -59,7 +47,7 @@ describe("OutputAccumulator", () => {
   it("flushes pending bytes held by every stream lane", () => {
     // Each lane decodes independently, so a truncated character left on one
     // pipe must not stop the other pipe's tail from being flushed.
-    const accumulator = new OutputAccumulator({ createTextDecoder: createUtf8TextDecoder });
+    const accumulator = new OutputAccumulator();
 
     accumulator.append(Buffer.from([0xe6, 0x97]), "stdout"); // leading bytes of 日
     accumulator.append(Buffer.from([0xe6, 0x97]), "stderr");

--- a/src/agents/sessions/tools/output-accumulator.test.ts
+++ b/src/agents/sessions/tools/output-accumulator.test.ts
@@ -91,4 +91,28 @@ describe("OutputAccumulator", () => {
     expect(await readFile(snapshot.fullOutputPath!, "utf8")).toBe("E日");
     await rm(snapshot.fullOutputPath!, { force: true });
   });
+
+  it("spills decoded text for truncated untagged custom-decoder output", async () => {
+    const accumulator = new OutputAccumulator({
+      maxBytes: 1,
+      maxLines: 10,
+      tempFilePrefix: "openclaw-output-test",
+      createTextDecoder: () =>
+        createWindowsOutputDecoder({ platform: "win32", windowsEncoding: "gbk" }),
+    });
+    const cp936Text = "\u9a71\u52a8\u5668 C \u4e2d\u7684\u5377\u662f Acer";
+    const cp936Bytes = Buffer.from([
+      199, 253, 182, 175, 198, 247, 32, 67, 32, 214, 208, 181, 196, 190, 237, 202, 199, 32, 65, 99,
+      101, 114,
+    ]);
+
+    accumulator.append(cp936Bytes);
+    accumulator.finish();
+    const snapshot = accumulator.snapshot({ persistIfTruncated: true });
+    await accumulator.closeTempFile();
+
+    expect(snapshot.truncation.truncated).toBe(true);
+    expect(await readFile(snapshot.fullOutputPath!, "utf8")).toBe(cp936Text);
+    await rm(snapshot.fullOutputPath!, { force: true });
+  });
 });

--- a/src/agents/sessions/tools/output-accumulator.ts
+++ b/src/agents/sessions/tools/output-accumulator.ts
@@ -17,6 +17,7 @@ interface OutputAccumulatorOptions {
   maxLines?: number;
   maxBytes?: number;
   tempFilePrefix?: string;
+  createTextDecoder?: () => OutputTextDecoder;
   /**
    * Builds the decoded-text transform. Called once per stream lane so stateful
    * transforms (ANSI parsers) cannot consume another stream's pending sequence.
@@ -26,9 +27,23 @@ interface OutputAccumulatorOptions {
 
 type OutputStream = "stdout" | "stderr";
 
+export interface OutputTextDecoder {
+  decode(chunk: Buffer | string): string;
+  flush(): string;
+}
+
+function createUtf8TextDecoder(): OutputTextDecoder {
+  const decoder = new TextDecoder();
+  return {
+    decode: (chunk) =>
+      typeof chunk === "string" ? chunk : decoder.decode(chunk, { stream: true }),
+    flush: () => decoder.decode(),
+  };
+}
+
 /** Per-stream decode state. Streams are independent pipes and must not share it. */
 interface DecodeLane {
-  decoder: TextDecoder;
+  decoder: OutputTextDecoder;
   transform?: (text: string) => string;
   spillDecoded: boolean;
 }
@@ -55,6 +70,8 @@ export class OutputAccumulator {
   private readonly maxBytes: number;
   private readonly maxRollingBytes: number;
   private readonly tempFilePrefix: string;
+  private readonly createTextDecoder: () => OutputTextDecoder;
+  private readonly spillDecodedByDefault: boolean;
   private readonly createTextTransform?: () => (text: string) => string;
   private readonly lanes = new Map<OutputStream | undefined, DecodeLane>();
 
@@ -80,6 +97,8 @@ export class OutputAccumulator {
     // Keep enough extra bytes that an incomplete leading line cannot fit the display.
     this.maxRollingBytes = Math.max(this.maxBytes * 2, this.maxBytes + 5);
     this.tempFilePrefix = options.tempFilePrefix ?? "openclaw-output";
+    this.createTextDecoder = options.createTextDecoder ?? createUtf8TextDecoder;
+    this.spillDecodedByDefault = options.createTextDecoder !== undefined;
     this.createTextTransform = options.createTextTransform;
   }
 
@@ -87,11 +106,14 @@ export class OutputAccumulator {
     let lane = this.lanes.get(stream);
     if (!lane) {
       lane = {
-        decoder: new TextDecoder(),
+        decoder: this.createTextDecoder(),
         transform: this.createTextTransform?.(),
-        // Tagged streams must spill decoded text because raw pipe bytes can
-        // interleave inside a UTF-8 character. Keep untagged raw spills stable.
-        spillDecoded: stream !== undefined || this.createTextTransform !== undefined,
+        // Tagged streams and custom decoders must spill decoded text so the
+        // full-output artifact matches the text shown to callers.
+        spillDecoded:
+          stream !== undefined ||
+          this.createTextTransform !== undefined ||
+          this.spillDecodedByDefault,
       };
       this.lanes.set(stream, lane);
     }
@@ -105,7 +127,7 @@ export class OutputAccumulator {
 
     this.totalRawBytes += data.length;
     const lane = this.lane(stream);
-    const decodedText = lane.decoder.decode(data, { stream: true });
+    const decodedText = lane.decoder.decode(data);
     const text = lane.transform?.(decodedText) ?? decodedText;
     this.appendDecodedText(text);
 
@@ -126,7 +148,7 @@ export class OutputAccumulator {
     // Every lane holds its own pending bytes, so all of them must be flushed.
     let flushed = "";
     for (const lane of this.lanes.values()) {
-      const decodedText = lane.decoder.decode();
+      const decodedText = lane.decoder.flush();
       const text = lane.transform?.(decodedText) ?? decodedText;
       if (text.length === 0) {
         continue;

--- a/src/agents/sessions/tools/output-accumulator.ts
+++ b/src/agents/sessions/tools/output-accumulator.ts
@@ -70,6 +70,7 @@ export class OutputAccumulator {
   private readonly maxRollingBytes: number;
   private readonly tempFilePrefix: string;
   private readonly createTextDecoder: () => OutputTextDecoder;
+  private readonly spillDecodedByDefault: boolean;
   private readonly createTextTransform?: () => (text: string) => string;
   private readonly lanes = new Map<OutputStream | undefined, DecodeLane>();
 
@@ -94,6 +95,7 @@ export class OutputAccumulator {
     this.maxRollingBytes = Math.max(this.maxBytes * 2, 1);
     this.tempFilePrefix = options.tempFilePrefix ?? "openclaw-output";
     this.createTextDecoder = options.createTextDecoder ?? createUtf8TextDecoder;
+    this.spillDecodedByDefault = options.createTextDecoder !== undefined;
     this.createTextTransform = options.createTextTransform;
   }
 
@@ -103,9 +105,12 @@ export class OutputAccumulator {
       lane = {
         decoder: this.createTextDecoder(),
         transform: this.createTextTransform?.(),
-        // Tagged streams must spill decoded text because raw pipe bytes can
-        // interleave inside a UTF-8 character. Keep untagged raw spills stable.
-        spillDecoded: stream !== undefined || this.createTextTransform !== undefined,
+        // Tagged streams and custom decoders must spill decoded text so the
+        // full-output artifact matches the text shown to callers.
+        spillDecoded:
+          stream !== undefined ||
+          this.createTextTransform !== undefined ||
+          this.spillDecodedByDefault,
       };
       this.lanes.set(stream, lane);
     }

--- a/src/agents/sessions/tools/output-accumulator.ts
+++ b/src/agents/sessions/tools/output-accumulator.ts
@@ -4,6 +4,7 @@
  * Keeps bounded display tails in memory while spilling full output to private temp files when needed.
  */
 import type { WriteStream } from "node:fs";
+import { createWindowsOutputDecoder } from "../../../infra/windows-encoding.js";
 import { createPrivateTempWriteStream } from "./private-temp-file.js";
 import {
   DEFAULT_MAX_BYTES,
@@ -16,6 +17,7 @@ interface OutputAccumulatorOptions {
   maxLines?: number;
   maxBytes?: number;
   tempFilePrefix?: string;
+  createTextDecoder?: () => OutputTextDecoder;
   /**
    * Builds the decoded-text transform. Called once per stream lane so stateful
    * transforms (ANSI parsers) cannot consume another stream's pending sequence.
@@ -25,9 +27,14 @@ interface OutputAccumulatorOptions {
 
 type OutputStream = "stdout" | "stderr";
 
+interface OutputTextDecoder {
+  decode(chunk: Buffer | string): string;
+  flush(): string;
+}
+
 /** Per-stream decode state. Streams are independent pipes and must not share it. */
 interface DecodeLane {
-  decoder: TextDecoder;
+  decoder: OutputTextDecoder;
   transform?: (text: string) => string;
   spillDecoded: boolean;
 }
@@ -54,6 +61,7 @@ export class OutputAccumulator {
   private readonly maxBytes: number;
   private readonly maxRollingBytes: number;
   private readonly tempFilePrefix: string;
+  private readonly createTextDecoder: () => OutputTextDecoder;
   private readonly createTextTransform?: () => (text: string) => string;
   private readonly lanes = new Map<OutputStream | undefined, DecodeLane>();
 
@@ -77,6 +85,7 @@ export class OutputAccumulator {
     this.maxBytes = options.maxBytes ?? DEFAULT_MAX_BYTES;
     this.maxRollingBytes = Math.max(this.maxBytes * 2, 1);
     this.tempFilePrefix = options.tempFilePrefix ?? "openclaw-output";
+    this.createTextDecoder = options.createTextDecoder ?? createWindowsOutputDecoder;
     this.createTextTransform = options.createTextTransform;
   }
 
@@ -84,7 +93,7 @@ export class OutputAccumulator {
     let lane = this.lanes.get(stream);
     if (!lane) {
       lane = {
-        decoder: new TextDecoder(),
+        decoder: this.createTextDecoder(),
         transform: this.createTextTransform?.(),
         // Tagged streams must spill decoded text because raw pipe bytes can
         // interleave inside a UTF-8 character. Keep untagged raw spills stable.
@@ -102,7 +111,7 @@ export class OutputAccumulator {
 
     this.totalRawBytes += data.length;
     const lane = this.lane(stream);
-    const decodedText = lane.decoder.decode(data, { stream: true });
+    const decodedText = lane.decoder.decode(data);
     const text = lane.transform?.(decodedText) ?? decodedText;
     this.appendDecodedText(text);
 
@@ -123,7 +132,7 @@ export class OutputAccumulator {
     // Every lane holds its own pending bytes, so all of them must be flushed.
     let flushed = "";
     for (const lane of this.lanes.values()) {
-      const decodedText = lane.decoder.decode();
+      const decodedText = lane.decoder.flush();
       const text = lane.transform?.(decodedText) ?? decodedText;
       if (text.length === 0) {
         continue;

--- a/src/agents/sessions/tools/output-accumulator.ts
+++ b/src/agents/sessions/tools/output-accumulator.ts
@@ -4,7 +4,6 @@
  * Keeps bounded display tails in memory while spilling full output to private temp files when needed.
  */
 import type { WriteStream } from "node:fs";
-import { createWindowsOutputDecoder } from "../../../infra/windows-encoding.js";
 import { createPrivateTempWriteStream } from "./private-temp-file.js";
 import {
   DEFAULT_MAX_BYTES,
@@ -27,9 +26,18 @@ interface OutputAccumulatorOptions {
 
 type OutputStream = "stdout" | "stderr";
 
-interface OutputTextDecoder {
+export interface OutputTextDecoder {
   decode(chunk: Buffer | string): string;
   flush(): string;
+}
+
+function createUtf8TextDecoder(): OutputTextDecoder {
+  const decoder = new TextDecoder();
+  return {
+    decode: (chunk) =>
+      typeof chunk === "string" ? chunk : decoder.decode(chunk, { stream: true }),
+    flush: () => decoder.decode(),
+  };
 }
 
 /** Per-stream decode state. Streams are independent pipes and must not share it. */
@@ -85,7 +93,7 @@ export class OutputAccumulator {
     this.maxBytes = options.maxBytes ?? DEFAULT_MAX_BYTES;
     this.maxRollingBytes = Math.max(this.maxBytes * 2, 1);
     this.tempFilePrefix = options.tempFilePrefix ?? "openclaw-output";
-    this.createTextDecoder = options.createTextDecoder ?? createWindowsOutputDecoder;
+    this.createTextDecoder = options.createTextDecoder ?? createUtf8TextDecoder;
     this.createTextTransform = options.createTextTransform;
   }
 


### PR DESCRIPTION
@{body=Related: #113219

## What Problem This Solves

Fixes an issue where Windows users running bash/session commands could see legacy console-code-page output returned as replacement-character mojibake when the shell emits bytes outside UTF-8.

## Why This Change Was Made

`OutputAccumulator` now builds each stdout/stderr decode lane with the existing Windows console-output decoder, so session bash output follows the same platform decoding contract as the other process-output paths while keeping per-stream pending-byte state isolated. This is scoped to session bash output and does not change the shared fallback policy for file reads or whole-buffer exec output.

## User Impact

Windows users on locales such as CP936 can get readable local shell output in bash/session tool results instead of corrupted transcript text, while UTF-8 output and truncation/spill behavior stay on the existing path.

## Evidence

Current head: `44c1b96da8ea7d3c08364de898c5592234b048d1`
- Exact-head native Windows Git Bash proof at `44c1b96da8ea7d3c08364de898c5592234b048d1` exercised the production local `createBashTool` path with an explicit operation-owner GBK decoder in [Windows Testbox Probe run 33097550737](https://github.com/qingminglong/openclaw/actions/runs/33097550737). The Windows Server 2025 runner checked out this exact SHA and the real runner output was:

```text
WINDOWS_BASH_PROOF decoded=驱动器 C 中的卷是 Acer
WINDOWS_BASH_PROOF spillDecoded=true replacementCharacter=false
WINDOWS_BASH_PROOF utf8=UTF8_OK_hello
```

- The same exact-head Windows run completed successfully on Windows Server 2025 with 14 Vitest shards. The claim-matched session-bash test passed alongside the existing Windows test coverage; the workflow completed successfully.
- Current-main merge-result proof: temporary merge commit `c1c665470de86370bbf046d8e5adcc1e1579a538` combined current `main` `c85be96d6ef185ca8d331e1b648bb181a3f38bde` with PR head `44c1b96da8ea7d3c08364de898c5592234b048d1`; the same Windows Server 2025 workflow completed successfully with the decoder output above. See [merge-result Windows Testbox Probe run 33099649285](https://github.com/qingminglong/openclaw/actions/runs/33099649285).
- Focused decoder, spill, interleaving, and owner-boundary regression tests passed in `src/agents/sessions/tools/output-accumulator.test.ts` and `src/agents/sessions/bash-executor.test.ts`.
- `git diff --check` passed.

Proof boundary: the real behavior proof covers a local Windows Git Bash process, the operation-owner GBK decoder, readable CP936 output, decoded truncated spill content, and an unchanged UTF-8 control. It does not claim injected remote-operation encoding, external provider/channel delivery, file-read decoding, or whole-buffer exec behavior.}