### PR TITLE
fix(qqbot): add heartbeat-ACK liveness watchdog

### DIFF
--- a/extensions/qqbot/src/engine/gateway/gateway-connection.test.ts
+++ b/extensions/qqbot/src/engine/gateway/gateway-connection.test.ts
@@ -456,9 +456,10 @@ describe("GatewayConnection heartbeat liveness", () => {
     // queue open inside ingress.receive(), an Op 11 must still reset the counter.
     let releaseIngress!: () => void;
     const receive = vi.fn(
-      () => new Promise<void>((resolve) => {
-        releaseIngress = resolve;
-      }),
+      () =>
+        new Promise<void>((resolve) => {
+          releaseIngress = resolve;
+        }),
     );
     const { ws, controller, started } = await startConnection({
       createIngressMonitor: () => ({
@@ -474,11 +475,19 @@ describe("GatewayConnection heartbeat liveness", () => {
     // tick 1: send heartbeat 1.
     await vi.advanceTimersByTimeAsync(10_000);
     // A DISPATCH enters ingress.receive() and blocks the serialized queue.
-    ws.emit("message", JSON.stringify({
-      op: GatewayOp.DISPATCH,
-      t: GatewayEvent.C2C_MESSAGE_CREATE,
-      d: { id: "m1", content: "hi", timestamp: "2026-07-18T12:00:00Z", author: { user_openid: "u1" } },
-    }));
+    ws.emit(
+      "message",
+      JSON.stringify({
+        op: GatewayOp.DISPATCH,
+        t: GatewayEvent.C2C_MESSAGE_CREATE,
+        d: {
+          id: "m1",
+          content: "hi",
+          timestamp: "2026-07-18T12:00:00Z",
+          author: { user_openid: "u1" },
+        },
+      }),
+    );
     await vi.waitFor(() => expect(receive).toHaveBeenCalled());
     // tick 2: send heartbeat 2 while the queue is still blocked.
     await vi.advanceTimersByTimeAsync(10_000);

--- a/extensions/qqbot/src/engine/gateway/gateway-connection.test.ts
+++ b/extensions/qqbot/src/engine/gateway/gateway-connection.test.ts
@@ -400,3 +400,123 @@ describe("GatewayConnection disconnect status", () => {
     await started;
   });
 });
+
+describe("GatewayConnection heartbeat liveness", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    createQQWSClientMock.mockReset();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.clearAllMocks();
+  });
+
+  it("does not terminate when heartbeats are ACKed within the interval", async () => {
+    const { ws, controller, started } = await startConnection({});
+    ws.readyState = 1; // OPEN so the heartbeat sender fires
+    ws.emit("open");
+    ws.emit("message", JSON.stringify({ op: GatewayOp.HELLO, d: { heartbeat_interval: 10_000 } }));
+
+    // Advance one interval, then deliver the ACK for that heartbeat.
+    await vi.advanceTimersByTimeAsync(10_000);
+    expect(ws.send).toHaveBeenCalledWith(expect.stringContaining('"op":1'));
+    ws.emit("message", JSON.stringify({ op: GatewayOp.HEARTBEAT_ACK }));
+    await vi.advanceTimersByTimeAsync(10_000);
+    ws.emit("message", JSON.stringify({ op: GatewayOp.HEARTBEAT_ACK }));
+
+    expect(ws.terminate).not.toHaveBeenCalled();
+    controller.abort();
+    await started;
+  });
+
+  it("terminates a half-open connection whose heartbeats receive no ACK", async () => {
+    // A connection that sends heartbeats but never receives Op 11 must be torn
+    // down so handleClose → scheduleReconnect re-establishes delivery.
+    const { ws, controller, started } = await startConnection({});
+    ws.readyState = 1; // OPEN so the heartbeat sender fires
+    ws.emit("open");
+    ws.emit("message", JSON.stringify({ op: GatewayOp.HELLO, d: { heartbeat_interval: 10_000 } }));
+
+    // tick 1: sends heartbeat 1 (outstanding=1), no ACK.
+    await vi.advanceTimersByTimeAsync(10_000);
+    expect(ws.send).toHaveBeenCalledWith(expect.stringContaining('"op":1'));
+    // tick 2: sends heartbeat 2 (outstanding=2), no ACK.
+    await vi.advanceTimersByTimeAsync(10_000);
+    // tick 3: two unanswered sends → terminate.
+    await vi.advanceTimersByTimeAsync(10_000);
+
+    expect(ws.terminate).toHaveBeenCalledTimes(1);
+    controller.abort();
+    await started;
+  });
+
+  it("clears an ACK that arrives while socketMessageTail is blocked by ingress", async () => {
+    // Guards the pre-tail ACK path: even with a DISPATCH holding the serialized
+    // queue open inside ingress.receive(), an Op 11 must still reset the counter.
+    let releaseIngress!: () => void;
+    const receive = vi.fn(
+      () => new Promise<void>((resolve) => {
+        releaseIngress = resolve;
+      }),
+    );
+    const { ws, controller, started } = await startConnection({
+      createIngressMonitor: () => ({
+        receive,
+        stop: vi.fn(async () => {}),
+        waitForIdle: vi.fn(async () => {}),
+      }),
+    });
+    ws.readyState = 1; // OPEN
+    ws.emit("open");
+    ws.emit("message", JSON.stringify({ op: GatewayOp.HELLO, d: { heartbeat_interval: 10_000 } }));
+
+    // tick 1: send heartbeat 1.
+    await vi.advanceTimersByTimeAsync(10_000);
+    // A DISPATCH enters ingress.receive() and blocks the serialized queue.
+    ws.emit("message", JSON.stringify({
+      op: GatewayOp.DISPATCH,
+      t: GatewayEvent.C2C_MESSAGE_CREATE,
+      d: { id: "m1", content: "hi", timestamp: "2026-07-18T12:00:00Z", author: { user_openid: "u1" } },
+    }));
+    await vi.waitFor(() => expect(receive).toHaveBeenCalled());
+    // tick 2: send heartbeat 2 while the queue is still blocked.
+    await vi.advanceTimersByTimeAsync(10_000);
+    // The ACK for heartbeat 1 arrives now — it must reset the counter despite the
+    // blocked queue, or the next tick would falsely terminate a live socket.
+    ws.emit("message", JSON.stringify({ op: GatewayOp.HEARTBEAT_ACK }));
+    // tick 3: counter was reset, so this sends heartbeat 3 instead of terminating.
+    await vi.advanceTimersByTimeAsync(10_000);
+
+    expect(ws.terminate).not.toHaveBeenCalled();
+    releaseIngress();
+    controller.abort();
+    await started;
+  });
+
+  it("does not throw on a malformed null frame and keeps handling later frames", async () => {
+    // A syntactically valid but non-object frame (JSON null) must not escape the
+    // synchronous message listener as an uncaught exception.
+    const { ws, controller, started } = await startConnection({});
+    ws.readyState = 1; // OPEN
+    ws.emit("open");
+    ws.emit("message", JSON.stringify({ op: GatewayOp.HELLO, d: { heartbeat_interval: 10_000 } }));
+    // tick 1: send heartbeat 1 (outstanding=1).
+    await vi.advanceTimersByTimeAsync(10_000);
+    expect(ws.send).toHaveBeenCalledWith(expect.stringContaining('"op":1'));
+
+    // A syntactically valid but non-object frame (JSON null) must not escape the
+    // synchronous message listener as an uncaught exception or terminate the socket.
+    ws.emit("message", "null");
+    await Promise.resolve();
+    expect(ws.terminate).not.toHaveBeenCalled();
+
+    // The ACK for heartbeat 1 still resets the counter after the malformed frame.
+    ws.emit("message", JSON.stringify({ op: GatewayOp.HEARTBEAT_ACK }));
+    await vi.advanceTimersByTimeAsync(10_000); // tick 2: pre-send 0 < 2 → send (outstanding=1)
+    await vi.advanceTimersByTimeAsync(10_000); // tick 3: pre-send 1 < 2 → send (outstanding=2)
+    expect(ws.terminate).not.toHaveBeenCalled();
+    controller.abort();
+    await started;
+  });
+});

--- a/extensions/qqbot/src/engine/gateway/gateway-connection.ts
+++ b/extensions/qqbot/src/engine/gateway/gateway-connection.ts
@@ -61,6 +61,9 @@ export class GatewayConnection {
   private heartbeatInterval: ReturnType<typeof setInterval> | null = null;
   private sessionId: string | null = null;
   private lastSeq: number | null = null;
+  // Sent heartbeats not yet cleared by an op:11 ACK. Counter-based (not wall-clock)
+  // so an event-loop stall cannot trip a false termination on a live socket.
+  private outstandingHeartbeats = 0;
   private isConnecting = false;
   private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
   private shouldRefreshToken = false;
@@ -317,9 +320,33 @@ export class GatewayConnection {
       });
 
       // ---- WebSocket: message ----
+      // Decode/parse once and carry the prepared frame into the serialized handler.
+      // Op 11 Heartbeat ACK resets the liveness counter here and returns, never enqueued
+      // behind socketMessageTail, so a slow ingress.receive() cannot mask an arrived ACK.
       ws.on("message", (data) => {
+        if (this.isAborted || this.currentWs !== ws || this.failedIngressSockets.has(ws)) {
+          return;
+        }
+        let payload: WSPayload;
+        let rawData: string;
+        try {
+          rawData = decodeGatewayMessageData(data);
+          payload = JSON.parse(rawData) as WSPayload;
+        } catch (error: unknown) {
+          const message = error instanceof Error ? error.message : String(error);
+          log?.error(`Message parse error: ${message}`);
+          return;
+        }
+        if (payload === null || typeof payload !== "object") {
+          log?.error(`Message parse error: unexpected payload shape`);
+          return;
+        }
+        if (payload.op === GatewayOp.HEARTBEAT_ACK) {
+          this.outstandingHeartbeats = 0;
+          return;
+        }
         this.socketMessageTail = this.socketMessageTail
-          .then(() => this.handleSocketMessage(ws, data, accessToken))
+          .then(() => this.handleSocketMessage(ws, { rawData, payload }, accessToken))
           .catch((error: unknown) => {
             const message = error instanceof Error ? error.message : String(error);
             if (error instanceof QQBotIngressAdmissionError) {
@@ -369,14 +396,13 @@ export class GatewayConnection {
 
   private async handleSocketMessage(
     ws: WebSocket,
-    data: unknown,
+    frame: { rawData: string; payload: WSPayload },
     accessToken: string,
   ): Promise<void> {
     if (this.isAborted || this.currentWs !== ws || this.failedIngressSockets.has(ws)) {
       return;
     }
-    const rawData = decodeGatewayMessageData(data);
-    const payload = JSON.parse(rawData) as WSPayload;
+    const { rawData, payload } = frame;
     const { op, d, s, t } = payload;
     let saveAfterDispatch = false;
 
@@ -408,10 +434,6 @@ export class GatewayConnection {
         }
         break;
       }
-
-      case GatewayOp.HEARTBEAT_ACK:
-        break;
-
       case GatewayOp.RECONNECT:
         this.ctx.onDisconnected?.({ reason: "server requested reconnect", fatal: false });
         this.cleanup();
@@ -476,10 +498,23 @@ export class GatewayConnection {
     if (this.heartbeatInterval) {
       clearInterval(this.heartbeatInterval);
     }
+    this.outstandingHeartbeats = 0;
+    // Terminate after this many heartbeats go unanswered. Check before sending so the
+    // threshold counts unanswered sends: tick 1 sends (1), tick 2 sends (2), tick 3 trips.
+    const missedAckThreshold = 2;
     this.heartbeatInterval = setInterval(() => {
-      if (ws.readyState === WebSocket.OPEN) {
-        ws.send(JSON.stringify({ op: GatewayOp.HEARTBEAT, d: this.lastSeq }));
+      if (ws.readyState !== WebSocket.OPEN) {
+        return;
       }
+      if (this.outstandingHeartbeats >= missedAckThreshold) {
+        log?.error(
+          `Heartbeat ACK overdue (${this.outstandingHeartbeats} unanswered); terminating gateway socket`,
+        );
+        ws.terminate();
+        return;
+      }
+      ws.send(JSON.stringify({ op: GatewayOp.HEARTBEAT, d: this.lastSeq }));
+      this.outstandingHeartbeats += 1;
     }, interval);
   }
 

--- a/extensions/qqbot/src/engine/gateway/gateway-connection.ts
+++ b/extensions/qqbot/src/engine/gateway/gateway-connection.ts
@@ -507,7 +507,7 @@ export class GatewayConnection {
         return;
       }
       if (this.outstandingHeartbeats >= missedAckThreshold) {
-        log?.error(
+        this.ctx.log?.error(
           `Heartbeat ACK overdue (${this.outstandingHeartbeats} unanswered); terminating gateway socket`,
         );
         ws.terminate();


### PR DESCRIPTION
Closes #114885

## What Problem This Solves

Fixes an issue where the QQBot gateway WebSocket sent heartbeats but never verified that the server's `op:11` Heartbeat ACK arrived, so a connection that stopped receiving ACKs was not detected client-side and could remain `OPEN` until the transport emitted close.

## Why This Change Was Made

The QQ Bot gateway contract defines `op:11` Heartbeat ACK as the message received after a heartbeat is sent successfully ([event-emit.html](https://bot.q.qq.com/wiki/develop/api-v2/dev-prepare/interface-framework/event-emit.html)). The client should use its absence to detect an unhealthy connection. This adds a counter-based liveness watchdog: each heartbeat sent increments an outstanding count; each `op:11` resets it. When the count reaches the missed-ACK threshold (2 unanswered sends), the socket is terminated so the existing `handleClose` → `scheduleReconnect` path re-establishes delivery.

Key design decisions, driven by review:

- **Counter-based, not wall-clock.** A true event-loop stall (GC pause, CPU saturation) pauses both the heartbeat timer and message processing together, so a live socket cannot trip a false termination on elapsed time.
- **ACK recognized before `socketMessageTail`.** Slow async ingress is not a stall — the heartbeat timer keeps firing while an `ingress.receive()` promise is pending. Op 11 resets the counter synchronously in `ws.on("message")` and returns, never enqueued behind the serialized queue, so a backlogged ACK cannot look overdue.
- **Single decode/parse.** The raw frame is decoded and parsed once on receipt and carried as `{rawData, payload}` into the serialized handler (avoids double-parsing every inbound frame on the hot path; preserves the exact `rawData` for durable `ingress.receive`).
- **Send-then-increment.** If `ws.send` throws, the counter is not inflated by a heartbeat that was never sent.

## User Impact

A QQBot connection whose heartbeats go unanswered is now detected and terminated for reconnect (via Resume) instead of remaining `OPEN` until the transport emits close. Whether such half-open states occur in practice, and how long they persist, was not observed (see #114885 `NOT_ENOUGH_INFO`); the fix closes the client-side detection gap regardless. Tolerates one missed ACK before tearing down, so transient latency does not reconnect a healthy session.

## Evidence

- Fix: `extensions/qqbot/src/engine/gateway/gateway-connection.ts` — `outstandingHeartbeats` counter, sync ACK reset in `ws.on("message")`, threshold check in the heartbeat tick.
- Contract: QQ Bot opcode table — Op 11 "当发送心跳成功之后，就会收到该消息" (received after a heartbeat is sent successfully).
- Sibling precedent: `extensions/mattermost/src/mattermost/monitor-websocket.ts:138-209` (pong-timeout watchdog).
- Focused exact-head test: `node scripts/run-vitest.mjs extensions/qqbot/src/engine/gateway/gateway-connection.test.ts` — **14 tests passed** on `305e504c4347e89b153d83092929dbea633addd1` (Node 25.9.0, isolated remote checkout).

### Exact-head real-channel fault-injection proof — 2026-07-29

A built checkout of exact head `305e504c4347e89b153d83092929dbea633addd1` started a real QQBot gateway with an isolated state directory. A loopback-only TLS CONNECT relay was selected solely through `HTTPS_PROXY`; it allowed only the QQBot token/API hosts, forwarded all traffic, and suppressed only server WebSocket Op 11 ACK frames. The relay used a temporary host-valid certificate trusted only by this proof process. It logged no credentials, endpoint authorities, payloads, or messages; the temporary credentials, config, key, certificate, state, logs, and relay were removed at process exit.

```text
QQBOT_PROXY_MODE=HTTPS_PROXY_only
QQBOT_WEBSOCKET_READY=true
QQBOT_PROXY_CONNECT_ACCEPTED=2
QQBOT_PROXY_WEBSOCKET_UPGRADES=2
QQBOT_PROXY_CLIENT_HEARTBEATS=2
QQBOT_PROXY_ACK_SUPPRESSED=2
QQBOT_WATCHDOG_OVERDUE_LOGGED=true
QQBOT_WATCHDOG_RECONNECT_OBSERVED=true
QQBOT_WATCHDOG_TRIGGERED=true
QQBOT_PROOF_ARTIFACTS_REMOVED=true
```

The first live WebSocket sent two real heartbeat frames whose real Op 11 ACKs were intentionally withheld. On the next tick, the production code logged the two-unanswered-ACK condition, terminated that socket, and completed a second WebSocket upgrade through the existing reconnect path. This proves the changed production behavior—not a mocked transport—while leaving normal ACK traffic and all application messages unmodified.

### Maintainer decision still needed

The proof establishes the behavior and reconnection path. The explicit `2`-unanswered-ACK threshold remains a product/reliability policy choice for the QQBot owner: whether to tolerate a single missed ACK before reconnecting is not determined by the QQBot protocol itself.

This is AI-assisted.
