### PR TITLE
fix(discord): prevent original replies flashing before outbound hooks

### DIFF
--- a/extensions/discord/src/monitor/message-handler.draft-preview.ts
+++ b/extensions/discord/src/monitor/message-handler.draft-preview.ts
@@ -13,6 +13,7 @@ import {
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 // Discord plugin module implements message handlerraft preview behavior.
 import { expectDefined } from "openclaw/plugin-sdk/expect-runtime";
+import { getGlobalHookRunner } from "openclaw/plugin-sdk/plugin-runtime";
 import {
   convertMarkdownTables,
   stripInlineDirectiveTagsForDelivery,
@@ -45,6 +46,13 @@ export function createDiscordDraftPreviewController(params: {
   log: (message: string) => void;
 }) {
   const discordStreamMode = resolveDiscordPreviewStreamMode(params.discordConfig);
+  // Provider drafts are visible before outbound modifiers run. Keep them off whenever a hook
+  // can rewrite or cancel so the original payload cannot flash before durable delivery.
+  const hookRunner = getGlobalHookRunner();
+  const allowProviderPreview = !(
+    (hookRunner?.hasHooks("reply_payload_sending") ?? false) ||
+    (hookRunner?.hasHooks("message_sending") ?? false)
+  );
   const draftMaxChars = Math.min(params.textLimit, 2000);
   const accountBlockStreamingEnabled =
     resolveChannelStreamingBlockEnabled(params.discordConfig) ??
@@ -52,6 +60,7 @@ export function createDiscordDraftPreviewController(params: {
   const canStreamProgressDraftForToolOnlySource =
     params.sourceRepliesAreToolOnly && discordStreamMode === "progress";
   const canStreamDraft =
+    allowProviderPreview &&
     (!params.sourceRepliesAreToolOnly || canStreamProgressDraftForToolOnlySource) &&
     discordStreamMode !== "off" &&
     !accountBlockStreamingEnabled;

--- a/extensions/discord/src/monitor/message-handler.process.draft-final.test.ts
+++ b/extensions/discord/src/monitor/message-handler.process.draft-final.test.ts
@@ -10,6 +10,7 @@ import {
   deliverDiscordReply,
   dispatchInboundMessageForTest as dispatchInboundMessage,
   editMessageDiscord,
+  getGlobalHookRunnerForTest as getGlobalHookRunner,
   getLastDispatchReplyOptions,
   getSessionEntry,
   readLatestAssistantTextByIdentity,
@@ -28,6 +29,84 @@ import {
 } from "./message-handler.process.test-helpers.js";
 
 registerDiscordProcessTestLifecycle();
+
+const PREVIEW_MODES = ["partial", "block", "progress"] as const;
+
+function registerHooks(...hooks: string[]) {
+  const registered = new Set(hooks);
+  getGlobalHookRunner.mockReturnValue({
+    hasHooks: vi.fn((hookName: string) => registered.has(hookName)),
+  });
+}
+
+async function runHookSafetyFinalReply(mode: (typeof PREVIEW_MODES)[number]) {
+  dispatchInboundMessage.mockImplementationOnce(async (params?: DispatchInboundParams) => {
+    await params?.dispatcher.sendFinalReply({ text: "final answer" });
+    await params?.dispatcher.waitForIdle();
+    return { queuedFinal: true, counts: { final: 1, tool: 0, block: 0 } };
+  });
+  const ctx = await createAutomaticSourceDeliveryContext({
+    discordConfig: { streaming: { mode } },
+  });
+  await runProcessDiscordMessage(ctx);
+}
+
+describe("processDiscordMessage provider preview hook safety", () => {
+  it.each(PREVIEW_MODES)("preserves %s previews when no hooks are registered", async (mode) => {
+    await runHookSafetyFinalReply(mode);
+
+    expect(createDiscordDraftStream).toHaveBeenCalledTimes(1);
+  });
+
+  it("preserves previews for observer-only hooks", async () => {
+    registerHooks("message_sent");
+
+    await runHookSafetyFinalReply("progress");
+
+    expect(createDiscordDraftStream).toHaveBeenCalledTimes(1);
+  });
+
+  it.each(
+    ["reply_payload_sending", "message_sending"].flatMap((hookName) =>
+      PREVIEW_MODES.map((mode) => [hookName, mode] as const),
+    ),
+  )("suppresses %s-capable %s previews", async (hookName, mode) => {
+    registerHooks(hookName);
+
+    await runHookSafetyFinalReply(mode);
+
+    expect(createDiscordDraftStream).not.toHaveBeenCalled();
+    expect(deliverDiscordReply).toHaveBeenCalledTimes(1);
+  });
+
+  it("suppresses previews when both modifying hooks are registered", async () => {
+    registerHooks("reply_payload_sending", "message_sending");
+
+    await runHookSafetyFinalReply("partial");
+
+    expect(createDiscordDraftStream).not.toHaveBeenCalled();
+  });
+
+  it("keeps explicitly disabled previews off without hooks", async () => {
+    const ctx = await createAutomaticSourceDeliveryContext({
+      discordConfig: { streaming: { mode: "off" } },
+    });
+
+    await runProcessDiscordMessage(ctx);
+
+    expect(createDiscordDraftStream).not.toHaveBeenCalled();
+  });
+
+  it("does not re-enter final delivery after message_sending cancellation", async () => {
+    registerHooks("message_sending");
+    deliverDiscordReply.mockResolvedValueOnce({ visibleReplySent: false });
+
+    await runHookSafetyFinalReply("partial");
+
+    expect(createDiscordDraftStream).not.toHaveBeenCalled();
+    expect(deliverDiscordReply).toHaveBeenCalledTimes(1);
+  });
+});
 
 describe("processDiscordMessage draft streaming final delivery", () => {
   it("sends a fresh final message when final fits one chunk", async () => {

--- a/extensions/discord/src/monitor/message-handler.process.test-harness.ts
+++ b/extensions/discord/src/monitor/message-handler.process.test-harness.ts
@@ -7,6 +7,18 @@ import type { DiscordMessagePreflightContext } from "./message-handler.preflight
 
 vi.mock("openclaw/plugin-sdk/runtime-env", { spy: true });
 
+const getGlobalHookRunner = vi.hoisted(() => vi.fn());
+
+vi.mock("openclaw/plugin-sdk/plugin-runtime", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("openclaw/plugin-sdk/plugin-runtime")>();
+  return {
+    ...actual,
+    getGlobalHookRunner,
+  };
+});
+
+export const getGlobalHookRunnerForTest = getGlobalHookRunner;
+
 export const logVerboseForTest = logVerbose;
 export const sleepWithAbortForTest = sleepWithAbort;
 
@@ -50,7 +62,7 @@ const deliveryMocks = vi.hoisted(() => ({
       opts?: unknown,
     ) => Promise<import("discord-api-types/v10").APIMessage>
   >(async () => ({ id: "m1" }) as import("discord-api-types/v10").APIMessage),
-  deliverDiscordReply: vi.fn<(params: unknown) => Promise<{ visibleReplySent: true }>>(
+  deliverDiscordReply: vi.fn<(params: unknown) => Promise<{ visibleReplySent: boolean }>>(
     async () => ({
       visibleReplySent: true,
     }),
@@ -567,12 +579,14 @@ export function registerDiscordProcessTestLifecycle() {
     readLatestAssistantTextByIdentity.mockClear();
     resolveStorePath.mockClear();
     createDiscordRestClientSpy.mockClear();
+    getGlobalHookRunner.mockReset();
     dispatchInboundMessage.mockResolvedValue(createNoQueuedDispatchResult());
     recordInboundSession.mockResolvedValue(undefined);
     readSessionUpdatedAt.mockReturnValue(undefined);
     getSessionEntry.mockReturnValue(undefined);
     readLatestAssistantTextByIdentity.mockResolvedValue(undefined);
     resolveStorePath.mockReturnValue("/tmp/openclaw-discord-process-test-sessions.json");
+    getGlobalHookRunner.mockReturnValue(null);
     threadBindingTesting.resetThreadBindingsForTests();
   });
 


### PR DESCRIPTION
Related: #92374

## What Problem This Solves

Fixes an issue where Discord users could briefly see the original agent reply in a
streaming preview before an installed outbound hook rewrote or cancelled that reply.
`message_sending` cancellation could also re-enter durable delivery after the preview
path skipped its normal send.

## Why This Change Was Made

Discord now keeps provider previews disabled whenever either modifier-capable outbound
hook is registered, while preserving typing/status feedback and the authoritative
durable final delivery. No-hook and observer-only deployments retain normal Discord
streaming previews. This stays inside the Discord plugin and adds no SDK, config,
protocol, or core policy surface.

## User Impact

Deployments using `reply_payload_sending` or `message_sending` can rely on Discord not
displaying unapproved model content before rewrite or cancellation. The conservative
tradeoff is intentional: when either global modifying hook is registered, Discord
previews are disabled even on replies that the hook ultimately leaves unchanged.

## Evidence

- Live-tested candidate: `cd3b9a35d77c261773bdba49532555afd5e6f859`, implemented from
  frozen base `d0669429d857e4cd2cfc39b030095c5424f0b94f`. The PR was then rebased
  once onto `aa26ecfac1958474cc7d579b5bc6dc4c7cff5e5d`; rebased head `173f26a27b2`
  has the identical stable patch ID.
- Focused Discord process proof: 37 assertions passed, including no-hook,
  observer-only, each modifying hook across partial/block/progress modes, both hooks,
  and cancellation without delivery re-entry.
- Full Discord extension proof: 204 test files and 2,340 tests passed.
- Post-rebase focused proof: 37/37 passed on Blacksmith Testbox
  ([run 30326535077](https://github.com/openclaw/openclaw/actions/runs/30326535077));
  fresh branch autoreview reported no actionable findings.
- Changed-surface format, lint, type, boundary, cycle, and SDK checks passed against the
  frozen base; a fresh autoreview reported no actionable findings.
- `LIVE_EXTERNAL` no-hook control: real Discord guild, production plugin/Gateway, and
  live frontier model. A provider draft was visible during generation and finalized
  into eight durable messages with real Discord IDs; hook trace remained empty.
  [Crabbox run](https://crabbox.openclaw.ai/portal/runs/run_a54b997041b4)
- `LIVE_EXTERNAL` rewrite: real Discord guild with the same production path. No preview
  appeared during generation; the one provider final was `MS:RPS:` transformed, with
  exact RPS -> MS -> native send -> sent trace order.
  [Crabbox run](https://crabbox.openclaw.ai/portal/runs/run_d34a9abd9770)
- `LIVE_EXTERNAL` cancellation: both hooks were exercised on fresh exact-marker turns.
  RPS cancellation traced RPS once with no MS/sent; MS cancellation traced RPS -> MS
  once with no sent. Discord API readback and Chrome both showed zero SUT messages.
  [Crabbox run](https://crabbox.openclaw.ai/portal/runs/run_2eecc094db7e)
