### PR TITLE
docs: document npm 11 global install scripts

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -148,6 +148,7 @@ The Gateway is the single source of truth for sessions, routing, and channel con
 
     npm 11+ requires explicit package-script approval for global installs. See
     [Install](/install#npm-pnpm-or-bun) for package-manager notes.
+
   </Step>
   <Step title="Onboard and install the service">
     ```bash

--- a/docs/index.md
+++ b/docs/index.md
@@ -143,8 +143,11 @@ The Gateway is the single source of truth for sessions, routing, and channel con
 <Steps>
   <Step title="Install OpenClaw">
     ```bash
-    npm install -g openclaw@latest
+    npm install -g openclaw@latest --allow-scripts openclaw
     ```
+
+    npm 11+ requires explicit package-script approval for global installs. See
+    [Install](/install#npm-pnpm-or-bun) for package-manager notes.
   </Step>
   <Step title="Onboard and install the service">
     ```bash

--- a/docs/index.md
+++ b/docs/index.md
@@ -146,7 +146,8 @@ The Gateway is the single source of truth for sessions, routing, and channel con
     npm install -g openclaw@latest --allow-scripts openclaw
     ```
 
-    npm 11+ requires explicit package-script approval for global installs. See
+    `--allow-scripts openclaw` is the npm-supported global-install allowlist path
+    for npm 11+ configurations that warn on or enforce package-script review. See
     [Install](/install#npm-pnpm-or-bun) for package-manager notes.
 
   </Step>

--- a/docs/install/index.md
+++ b/docs/install/index.md
@@ -83,9 +83,10 @@ If you already manage Node yourself:
     <Note>
     The hosted installer clears npm freshness filters such as `min-release-age`
     for the OpenClaw package install. If you install manually with npm, your own
-    npm policy still applies. npm 11+ also requires package install scripts to
-    be allowlisted; use `--allow-scripts openclaw` for global installs instead
-    of `npm approve-scripts openclaw`, which is project-scoped.
+    npm policy still applies. npm 11+ configurations can warn on or enforce
+    review of package install scripts. For global installs, use
+    `--allow-scripts openclaw` to allowlist OpenClaw's hooks inline instead of
+    `npm approve-scripts openclaw`, which is project-scoped.
     </Note>
 
   </Tab>

--- a/docs/install/index.md
+++ b/docs/install/index.md
@@ -76,14 +76,16 @@ If you already manage Node yourself:
 <Tabs>
   <Tab title="npm">
     ```bash
-    npm install -g openclaw@latest
+    npm install -g openclaw@latest --allow-scripts openclaw
     openclaw onboard --install-daemon
     ```
 
     <Note>
     The hosted installer clears npm freshness filters such as `min-release-age`
     for the OpenClaw package install. If you install manually with npm, your own
-    npm policy still applies.
+    npm policy still applies. npm 11+ also requires package install scripts to
+    be allowlisted; use `--allow-scripts openclaw` for global installs instead
+    of `npm approve-scripts openclaw`, which is project-scoped.
     </Note>
 
   </Tab>


### PR DESCRIPTION
Closes #114665

## What Problem This Solves

Fixes an issue where users installing OpenClaw manually with npm 11+ would follow the documented bare global install command and see OpenClaw's package install scripts left outside npm's allowlist, while npm's suggested `npm approve-scripts openclaw` recovery does not apply to the global install.

## Why This Change Was Made

The npm install docs and docs-home quick start now use `npm install -g openclaw@latest --allow-scripts openclaw`. The install page also explains that npm 11+ configurations can warn on or enforce package-script review, and that `npm approve-scripts openclaw` is project-scoped rather than the right global-install recovery path.

## User Impact

Users who choose the manual npm path get a copy-paste command that approves OpenClaw's own global install hooks up front, reducing first-install confusion on npm 11+ without changing the recommended hosted installer path.

## Evidence

- Current head: `84634486fae1f62471b5e7172062ae8278647714`.
- Current-head docs review: `docs/index.md` and `docs/install/index.md` now describe `--allow-scripts openclaw` as the npm-supported global-install allowlist path for npm 11+ configurations that warn on or enforce package-script review, without claiming every npm 11+ global install requires approval.
- npm 11.16.0 / Node v24.18.0 temp global-prefix proof: bare `npm install -g openclaw@latest --prefix <temp>` installed OpenClaw 2026.7.1-2 but printed npm `allow-scripts` warnings that included OpenClaw's `preinstall` and `postinstall` hooks.
- npm 11.16.0 temp global-prefix proof: `npm approve-scripts openclaw` returned `ENOMATCH`, matching the issue's global-install recovery problem.
- npm 11.16.0 temp global-prefix proof: `npm install -g openclaw@latest --prefix <temp> --allow-scripts openclaw` installed successfully, `openclaw --version` reported `OpenClaw 2026.7.1-2 (0790d9f)`, and the remaining npm `allow-scripts` warning no longer listed OpenClaw's own package hooks.
- Official npm CLI v11 docs checked: `npm install` documents `--allow-scripts <package-list>`, and `npm approve-scripts` is described as approving dependency scripts from the current project's `package.json` dependency graph.
- `oxfmt --check docs/index.md docs/install/index.md`: passed.
- `node scripts/docs-list.js` recognized `docs/index.md` and `docs/install/index.md`.
- `node scripts/docs-link-audit.mjs docs/index.md docs/install/index.md`: `checked_internal_links=6229`, `broken_links=0`.
- `git diff --check`: passed.

Proof boundary: npm install proof used temporary global prefixes and did not modify the user's global npm prefix or credentials.