### PR TITLE
fix(qa-channel): prevent duplicate agent replies

### DIFF
--- a/extensions/qa-channel/src/inbound.test.ts
+++ b/extensions/qa-channel/src/inbound.test.ts
@@ -162,6 +162,58 @@ describe("handleQaInbound", () => {
     );
   });
 
+  it("delivers identical block and final replies exactly once", async () => {
+    const runtime = createPluginRuntimeMock();
+    setQaChannelRuntime(runtime);
+
+    await handleQaInbound(createQaInboundParams());
+
+    const assembled = firstRunAssembledParams(runtime);
+    await assembled.delivery.deliver({ text: "single answer" }, { kind: "block" });
+    await assembled.delivery.deliver({ text: "single answer" }, { kind: "final" });
+
+    expect(sendQaBusMessage).toHaveBeenCalledOnce();
+    expect(sendQaBusMessage).toHaveBeenCalledWith(
+      expect.objectContaining({ text: "single answer" }),
+    );
+  });
+
+  it("delivers an identical final when it adds tool-call trace data", async () => {
+    const runtime = createPluginRuntimeMock();
+    setQaChannelRuntime(runtime);
+
+    await handleQaInbound(createQaInboundParams());
+
+    const assembled = firstRunAssembledParams(runtime);
+    await assembled.delivery.deliver({ text: "single answer" }, { kind: "block" });
+    await assembled.replyOptions?.onToolStart?.({ phase: "start", name: "search" });
+    await assembled.delivery.deliver({ text: "single answer" }, { kind: "final" });
+
+    expect(sendQaBusMessage).toHaveBeenCalledTimes(2);
+    expect(sendQaBusMessage).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ text: "single answer", toolCalls: [{ name: "search" }] }),
+    );
+  });
+
+  it("clears an active preview before suppressing an identical final", async () => {
+    const runtime = createPluginRuntimeMock();
+    setQaChannelRuntime(runtime);
+
+    await handleQaInbound(createQaInboundParams());
+
+    const assembled = firstRunAssembledParams(runtime);
+    await assembled.delivery.deliver({ text: "single answer" }, { kind: "block" });
+    await assembled.replyOptions?.onPartialReply?.({ text: "new preview" });
+    await assembled.delivery.deliver({ text: "single answer" }, { kind: "final" });
+
+    expect(sendQaBusMessage).toHaveBeenCalledTimes(2);
+    expect(deleteQaBusMessage).toHaveBeenCalledOnce();
+    expect(deleteQaBusMessage).toHaveBeenCalledWith(
+      expect.objectContaining({ messageId: "preview-1" }),
+    );
+  });
+
   it("deletes an active preview when reply dispatch fails", async () => {
     const runtime = createPluginRuntimeMock();
     setQaChannelRuntime(runtime);

--- a/extensions/qa-channel/src/inbound.test.ts
+++ b/extensions/qa-channel/src/inbound.test.ts
@@ -196,6 +196,59 @@ describe("handleQaInbound", () => {
     );
   });
 
+  it("suppresses an identical normalized tool-call snapshot", async () => {
+    const runtime = createPluginRuntimeMock();
+    setQaChannelRuntime(runtime);
+
+    await handleQaInbound(createQaInboundParams());
+
+    const assembled = firstRunAssembledParams(runtime);
+    await assembled.replyOptions?.onToolStart?.({
+      phase: "start",
+      name: "search",
+      args: { second: 2, first: 1 },
+    });
+    await assembled.delivery.deliver({ text: "single answer" }, { kind: "block" });
+    const toolCalls = vi.mocked(sendQaBusMessage).mock.calls[0]?.[0].toolCalls;
+    if (!toolCalls?.[0]) {
+      throw new Error("expected durable tool-call trace");
+    }
+    toolCalls[0].arguments = { first: 1, second: 2 };
+    await assembled.delivery.deliver({ text: "single answer" }, { kind: "final" });
+
+    expect(sendQaBusMessage).toHaveBeenCalledOnce();
+  });
+
+  it("delivers a same-count final when its tool-call record changes", async () => {
+    const runtime = createPluginRuntimeMock();
+    setQaChannelRuntime(runtime);
+
+    await handleQaInbound(createQaInboundParams());
+
+    const assembled = firstRunAssembledParams(runtime);
+    await assembled.replyOptions?.onToolStart?.({
+      phase: "start",
+      name: "search",
+      args: { attempt: 1 },
+    });
+    await assembled.delivery.deliver({ text: "single answer" }, { kind: "block" });
+    const toolCalls = vi.mocked(sendQaBusMessage).mock.calls[0]?.[0].toolCalls;
+    if (!toolCalls?.[0]) {
+      throw new Error("expected durable tool-call trace");
+    }
+    toolCalls[0] = { name: "search", arguments: { attempt: 2 } };
+    await assembled.delivery.deliver({ text: "single answer" }, { kind: "final" });
+
+    expect(sendQaBusMessage).toHaveBeenCalledTimes(2);
+    expect(sendQaBusMessage).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        text: "single answer",
+        toolCalls: [{ name: "search", arguments: { attempt: 2 } }],
+      }),
+    );
+  });
+
   it("clears an active preview before suppressing an identical final", async () => {
     const runtime = createPluginRuntimeMock();
     setQaChannelRuntime(runtime);

--- a/extensions/qa-channel/src/inbound.ts
+++ b/extensions/qa-channel/src/inbound.ts
@@ -111,6 +111,33 @@ function formatQaErrorForLog(error: unknown): string {
   return escaped;
 }
 
+function normalizeQaToolCallSnapshotValue(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map(normalizeQaToolCallSnapshotValue);
+  }
+  if (value && typeof value === "object") {
+    return Object.fromEntries(
+      Object.entries(value as Record<string, unknown>)
+        .toSorted(([left], [right]) => (left < right ? -1 : left > right ? 1 : 0))
+        .map(([key, entry]) => [key, normalizeQaToolCallSnapshotValue(entry)]),
+    );
+  }
+  return value;
+}
+
+function serializeQaToolCallSnapshot(toolCalls: QaBusToolCall[]): string {
+  // Call order is chronological trace data; nested argument keys are the
+  // unordered surface that must be canonicalized before comparison.
+  return JSON.stringify(
+    toolCalls.map((toolCall) => ({
+      name: toolCall.name,
+      ...(toolCall.arguments
+        ? { arguments: normalizeQaToolCallSnapshotValue(toolCall.arguments) }
+        : {}),
+    })),
+  );
+}
+
 function createQaReplyPreview(params: {
   account: ResolvedQaChannelAccount;
   inbound: QaBusMessage;
@@ -120,7 +147,7 @@ function createQaReplyPreview(params: {
   let messageId: string | null = null;
   let currentText = "";
   let lastDurableText = "";
-  let lastDurableToolCallCount = 0;
+  let lastDurableToolCallSnapshot = "[]";
   let pending = Promise.resolve();
 
   const write = (text: string) => {
@@ -172,6 +199,7 @@ function createQaReplyPreview(params: {
     if (!text.trim()) {
       return;
     }
+    const toolCallSnapshot = serializeQaToolCallSnapshot(params.toolCalls);
     await sendQaBusMessage({
       baseUrl: params.account.baseUrl,
       accountId: params.account.accountId,
@@ -184,7 +212,7 @@ function createQaReplyPreview(params: {
       toolCalls: params.toolCalls,
     });
     lastDurableText = text;
-    lastDurableToolCallCount = params.toolCalls.length;
+    lastDurableToolCallSnapshot = toolCallSnapshot;
   };
 
   return {
@@ -196,8 +224,10 @@ function createQaReplyPreview(params: {
       if (
         kind === "final" &&
         text === lastDurableText &&
-        params.toolCalls.length === lastDurableToolCallCount
+        serializeQaToolCallSnapshot(params.toolCalls) === lastDurableToolCallSnapshot
       ) {
+        // Count equality is not record equality: a same-count final with changed
+        // tool records must still be delivered.
         await clear();
         return;
       }

--- a/extensions/qa-channel/src/inbound.ts
+++ b/extensions/qa-channel/src/inbound.ts
@@ -119,6 +119,8 @@ function createQaReplyPreview(params: {
 }) {
   let messageId: string | null = null;
   let currentText = "";
+  let lastDurableText = "";
+  let lastDurableToolCallCount = 0;
   let pending = Promise.resolve();
 
   const write = (text: string) => {
@@ -181,12 +183,24 @@ function createQaReplyPreview(params: {
       replyToId: params.inbound.id,
       toolCalls: params.toolCalls,
     });
+    lastDurableText = text;
+    lastDurableToolCallCount = params.toolCalls.length;
   };
 
   return {
     clear,
     async deliver(text: string, kind: string) {
       await pending;
+      // Core may close a streamed block with an identical final payload.
+      // The block is already durable, so posting the final again duplicates the reply.
+      if (
+        kind === "final" &&
+        text === lastDurableText &&
+        params.toolCalls.length === lastDurableToolCallCount
+      ) {
+        await clear();
+        return;
+      }
       if (kind === "final" && messageId && params.toolCalls.length === 0) {
         await write(text);
         return;


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where qa-channel consumers would receive every agent reply twice. This was reproduced live on 2026-07-27 with an isolated source-checkout dev gateway and QA bus: core legitimately queued a streamed block followed by an identical final, and the qa-channel delivery funnel posted both (`extensions/qa-channel/src/inbound.ts:192`).

## Why This Change Was Made

Transport channels own exactly-once delivery on their transport. The qa-channel-local fix deduplicates terminal delivery using the last durable text plus its tool-call snapshot, so richer finals remain deliverable, and it clears any active preview before suppressing an already-durable final. Core delivery behavior and other channels are unchanged.

## User Impact

QA bus consumers and live QA tooling no longer see duplicate agent replies for ordinary turns that close an already-delivered streamed block with the same final text.

## Evidence

- Added an exactly-once regression for identical block and final payloads; it failed before the fix because `sendQaBusMessage` was called twice.
- Added coverage proving an identical final is still delivered when it adds tool-call trace data.
- Added coverage proving an active preview is cleared before an identical final is suppressed.
- `node scripts/run-vitest.mjs extensions/qa-channel`: 5 files passed, 52 tests passed.
- `node scripts/check-changed.mjs -- extensions/qa-channel/src/inbound.ts extensions/qa-channel/src/inbound.test.ts`: passed on Blacksmith Testbox.
- Final autoreview: clean, with no accepted or actionable findings.


### After-fix live QA-bus proof (2026-07-28)

Isolated dev gateway built from this PR's head (`7478100`), fresh state dir, qa-lab bus on
127.0.0.1:43124, real model turn (`openai/gpt-5.6-sol`, embedded runtime). One inbound
message; the bus state shows exactly one durable outbound reply:

```text
$ curl -s -X POST http://127.0.0.1:43124/v1/inbound/message -d {conversation:{id:"proof-1",kind:"direct"},senderId:"qa-owner",text:"say hello and briefly mention one fact about crabs"}
{"message":{"id":"39edacc4-2d79-4f70-9493-fc60d2180208","accountId":"default","direction":"inbound","conversation":{"id":"proof-1","kind":"direct"},"senderId":"qa-owner","text":"say hello and briefly

$ curl -s http://127.0.0.1:43124/v1/state  # outbound message count + texts
inbound: 1, outbound: 1
outbound[0]: "Hello! Crabs have five pairs of legs. I'm your new assistant—what would you like to call me?"
```

Pre-fix baseline from the same live setup (source checkout without this patch, captured
2026-07-27 while running memory QA): the identical reply arrived twice —

```text
messages: 3
--- [inbound] qa-owner: the web build is failing on node 26 again, what was the fix?
--- [outbound] openclaw: Run: ... pnpm rebuild esbuild ...   (identical)
--- [outbound] openclaw: Run: ... pnpm rebuild esbuild ...   (identical)
```
