### PR TITLE
fix(agents): stop interrupted unrestricted host writes from truncating the target

### DIFF
--- a/src/agents/agent-tools.read.host-atomic-write.test.ts
+++ b/src/agents/agent-tools.read.host-atomic-write.test.ts
@@ -83,7 +83,9 @@ describe("unrestricted host tool writes", () => {
     expect(after.gid).toBe(before.gid);
   });
 
-  it.runIf(process.platform !== "win32")("rejects a non-writable existing file", async () => {
+  const asUnprivilegedUser = process.platform !== "win32" && process.getuid?.() !== 0;
+
+  it.runIf(asUnprivilegedUser)("rejects a non-writable existing file", async () => {
     const filePath = await createFile("original");
     await fs.chmod(filePath, 0o444);
 
@@ -95,17 +97,50 @@ describe("unrestricted host tool writes", () => {
     await expect(fs.readFile(filePath, "utf8")).resolves.toBe("original");
   });
 
-  it.runIf(process.platform !== "win32")("rejects a hard-linked existing file", async () => {
+  it.runIf(process.platform !== "win32")("updates a hard-linked existing file", async () => {
     const filePath = await createFile("original");
     const aliasPath = path.join(tempDir, "alias.txt");
     await fs.link(filePath, aliasPath);
+    const before = await fs.stat(filePath);
 
     const tool = createHostWorkspaceWriteTool(tempDir);
-    await expect(
-      tool.execute("call-1", { path: filePath, content: "replacement" }),
-    ).rejects.toThrow("Refusing to replace hard-linked host file atomically");
+    await tool.execute("call-1", { path: filePath, content: "replacement" });
 
-    await expect(fs.readFile(filePath, "utf8")).resolves.toBe("original");
-    await expect(fs.readFile(aliasPath, "utf8")).resolves.toBe("original");
+    const after = await fs.stat(filePath);
+    expect(after.ino).toBe(before.ino);
+    expect(after.nlink).toBe(2);
+    await expect(fs.readFile(filePath, "utf8")).resolves.toBe("replacement");
+    await expect(fs.readFile(aliasPath, "utf8")).resolves.toBe("replacement");
   });
+
+  it.runIf(process.platform !== "win32")("writes through to a non-regular target", async () => {
+    await createFile("original");
+    const linkPath = path.join(tempDir, "null-link");
+    await fs.symlink("/dev/null", linkPath);
+
+    const tool = createHostWorkspaceWriteTool(tempDir);
+    await tool.execute("call-1", { path: linkPath, content: "replacement" });
+
+    expect((await fs.lstat(linkPath)).isSymbolicLink()).toBe(true);
+    expect((await fs.stat("/dev/null")).isCharacterDevice()).toBe(true);
+  });
+
+  it.runIf(process.platform !== "win32")(
+    "updates the existing file when its ownership cannot be restored",
+    async () => {
+      const filePath = await createFile("original");
+      const before = await fs.stat(filePath);
+      vi.spyOn(fs, "chown").mockRejectedValue(
+        Object.assign(new Error("operation not permitted"), { code: "EPERM" }),
+      );
+
+      const tool = createHostWorkspaceWriteTool(tempDir);
+      await tool.execute("call-1", { path: filePath, content: "replacement" });
+
+      const after = await fs.stat(filePath);
+      expect(after.ino).toBe(before.ino);
+      await expect(fs.readFile(filePath, "utf8")).resolves.toBe("replacement");
+      await expect(fs.readdir(tempDir)).resolves.toEqual(["important.txt"]);
+    },
+  );
 });

--- a/src/agents/agent-tools.read.host-atomic-write.test.ts
+++ b/src/agents/agent-tools.read.host-atomic-write.test.ts
@@ -1,0 +1,111 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createHostWorkspaceEditTool, createHostWorkspaceWriteTool } from "./agent-tools.read.js";
+
+describe("unrestricted host tool writes", () => {
+  let tempDir = "";
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    if (tempDir) {
+      await fs.rm(tempDir, { recursive: true, force: true });
+      tempDir = "";
+    }
+  });
+
+  async function createFile(content: string) {
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-host-write-"));
+    const filePath = path.join(tempDir, "important.txt");
+    await fs.writeFile(filePath, content);
+    return filePath;
+  }
+
+  it.each([
+    {
+      name: "write",
+      createTool: (root: string) => createHostWorkspaceWriteTool(root),
+      input: (filePath: string) => ({
+        path: filePath,
+        content: "replacement content\n".repeat(64),
+      }),
+    },
+    {
+      name: "edit",
+      createTool: (root: string) => createHostWorkspaceEditTool(root),
+      input: (filePath: string) => ({
+        path: filePath,
+        edits: [{ oldText: "original", newText: "replacement" }],
+      }),
+    },
+  ])("keeps the original file when $name cannot finish writing", async ({ createTool, input }) => {
+    const originalContent = `original\n${"important content\n".repeat(64)}`;
+    const filePath = await createFile(originalContent);
+    const realWriteFile = fs.writeFile.bind(fs);
+    vi.spyOn(fs, "writeFile").mockImplementation(async (target, data, options) => {
+      if (typeof data !== "string") {
+        throw new TypeError("expected string content");
+      }
+      await realWriteFile(target, data.slice(0, 32), options);
+      throw Object.assign(new Error("disk full"), { code: "ENOSPC" });
+    });
+
+    const tool = createTool(tempDir);
+    await expect(tool.execute("call-1", input(filePath))).rejects.toThrow("disk full");
+
+    await expect(fs.readFile(filePath, "utf8")).resolves.toBe(originalContent);
+  });
+
+  it.runIf(process.platform !== "win32")("writes through an existing symlink", async () => {
+    const targetPath = await createFile("original");
+    const linkPath = path.join(tempDir, "linked.txt");
+    await fs.symlink(targetPath, linkPath);
+
+    const tool = createHostWorkspaceWriteTool(tempDir);
+    await tool.execute("call-1", { path: linkPath, content: "replacement" });
+
+    expect((await fs.lstat(linkPath)).isSymbolicLink()).toBe(true);
+    await expect(fs.readFile(targetPath, "utf8")).resolves.toBe("replacement");
+  });
+
+  it.runIf(process.platform !== "win32")("preserves the existing file mode", async () => {
+    const filePath = await createFile("original");
+    await fs.chmod(filePath, 0o640);
+    const before = await fs.stat(filePath);
+
+    const tool = createHostWorkspaceWriteTool(tempDir);
+    await tool.execute("call-1", { path: filePath, content: "replacement" });
+
+    const after = await fs.stat(filePath);
+    expect(after.mode & 0o777).toBe(0o640);
+    expect(after.uid).toBe(before.uid);
+    expect(after.gid).toBe(before.gid);
+  });
+
+  it.runIf(process.platform !== "win32")("rejects a non-writable existing file", async () => {
+    const filePath = await createFile("original");
+    await fs.chmod(filePath, 0o444);
+
+    const tool = createHostWorkspaceWriteTool(tempDir);
+    await expect(
+      tool.execute("call-1", { path: filePath, content: "replacement" }),
+    ).rejects.toMatchObject({ code: "EACCES" });
+
+    await expect(fs.readFile(filePath, "utf8")).resolves.toBe("original");
+  });
+
+  it.runIf(process.platform !== "win32")("rejects a hard-linked existing file", async () => {
+    const filePath = await createFile("original");
+    const aliasPath = path.join(tempDir, "alias.txt");
+    await fs.link(filePath, aliasPath);
+
+    const tool = createHostWorkspaceWriteTool(tempDir);
+    await expect(
+      tool.execute("call-1", { path: filePath, content: "replacement" }),
+    ).rejects.toThrow("Refusing to replace hard-linked host file atomically");
+
+    await expect(fs.readFile(filePath, "utf8")).resolves.toBe("original");
+    await expect(fs.readFile(aliasPath, "utf8")).resolves.toBe("original");
+  });
+});

--- a/src/agents/agent-tools.read.host-write-integrity.test.ts
+++ b/src/agents/agent-tools.read.host-write-integrity.test.ts
@@ -42,19 +42,40 @@ describe("unrestricted host tool writes", () => {
   ])("keeps the original file when $name cannot finish writing", async ({ createTool, input }) => {
     const originalContent = `original\n${"important content\n".repeat(64)}`;
     const filePath = await createFile(originalContent);
-    const realWriteFile = fs.writeFile.bind(fs);
-    vi.spyOn(fs, "writeFile").mockImplementation(async (target, data, options) => {
-      if (typeof data !== "string") {
-        throw new TypeError("expected string content");
+    const realOpen = fs.open.bind(fs);
+    vi.spyOn(fs, "open").mockImplementation(async (target, flags, mode) => {
+      const handle = await realOpen(target, flags, mode);
+      if (String(target).includes(".openclaw-host-write.")) {
+        handle.writeFile = async () => {
+          throw Object.assign(new Error("disk full"), { code: "ENOSPC" });
+        };
       }
-      await realWriteFile(target, data.slice(0, 32), options);
-      throw Object.assign(new Error("disk full"), { code: "ENOSPC" });
+      return handle;
     });
 
     const tool = createTool(tempDir);
     await expect(tool.execute("call-1", input(filePath))).rejects.toThrow("disk full");
 
     await expect(fs.readFile(filePath, "utf8")).resolves.toBe(originalContent);
+    await expect(fs.readdir(tempDir)).resolves.toEqual(["important.txt"]);
+  });
+
+  it.runIf(process.platform !== "win32")("preserves the target inode and its metadata", async () => {
+    const filePath = await createFile("original");
+    await fs.chmod(filePath, 0o640);
+    const before = await fs.stat(filePath);
+
+    const tool = createHostWorkspaceWriteTool(tempDir);
+    await tool.execute("call-1", { path: filePath, content: "replacement" });
+
+    const after = await fs.stat(filePath);
+    expect(after.ino).toBe(before.ino);
+    expect(after.dev).toBe(before.dev);
+    expect(after.mode & 0o777).toBe(0o640);
+    expect(after.uid).toBe(before.uid);
+    expect(after.gid).toBe(before.gid);
+    await expect(fs.readFile(filePath, "utf8")).resolves.toBe("replacement");
+    await expect(fs.readdir(tempDir)).resolves.toEqual(["important.txt"]);
   });
 
   it.runIf(process.platform !== "win32")("writes through an existing symlink", async () => {
@@ -69,20 +90,6 @@ describe("unrestricted host tool writes", () => {
     await expect(fs.readFile(targetPath, "utf8")).resolves.toBe("replacement");
   });
 
-  it.runIf(process.platform !== "win32")("preserves the existing file mode", async () => {
-    const filePath = await createFile("original");
-    await fs.chmod(filePath, 0o640);
-    const before = await fs.stat(filePath);
-
-    const tool = createHostWorkspaceWriteTool(tempDir);
-    await tool.execute("call-1", { path: filePath, content: "replacement" });
-
-    const after = await fs.stat(filePath);
-    expect(after.mode & 0o777).toBe(0o640);
-    expect(after.uid).toBe(before.uid);
-    expect(after.gid).toBe(before.gid);
-  });
-
   const asUnprivilegedUser = process.platform !== "win32" && process.getuid?.() !== 0;
 
   it.runIf(asUnprivilegedUser)("rejects a non-writable existing file", async () => {
@@ -95,6 +102,19 @@ describe("unrestricted host tool writes", () => {
     ).rejects.toMatchObject({ code: "EACCES" });
 
     await expect(fs.readFile(filePath, "utf8")).resolves.toBe("original");
+  });
+
+  it.runIf(asUnprivilegedUser)("writes when the directory rejects a staged file", async () => {
+    const filePath = await createFile("original");
+    await fs.chmod(tempDir, 0o500);
+
+    try {
+      const tool = createHostWorkspaceWriteTool(tempDir);
+      await tool.execute("call-1", { path: filePath, content: "replacement" });
+      await expect(fs.readFile(filePath, "utf8")).resolves.toBe("replacement");
+    } finally {
+      await fs.chmod(tempDir, 0o700);
+    }
   });
 
   it.runIf(process.platform !== "win32")("updates a hard-linked existing file", async () => {
@@ -123,24 +143,7 @@ describe("unrestricted host tool writes", () => {
 
     expect((await fs.lstat(linkPath)).isSymbolicLink()).toBe(true);
     expect((await fs.stat("/dev/null")).isCharacterDevice()).toBe(true);
+    const devEntries = await fs.readdir("/dev");
+    expect(devEntries.filter((entry) => entry.startsWith(".openclaw-host-write."))).toEqual([]);
   });
-
-  it.runIf(process.platform !== "win32")(
-    "updates the existing file when its ownership cannot be restored",
-    async () => {
-      const filePath = await createFile("original");
-      const before = await fs.stat(filePath);
-      vi.spyOn(fs, "chown").mockRejectedValue(
-        Object.assign(new Error("operation not permitted"), { code: "EPERM" }),
-      );
-
-      const tool = createHostWorkspaceWriteTool(tempDir);
-      await tool.execute("call-1", { path: filePath, content: "replacement" });
-
-      const after = await fs.stat(filePath);
-      expect(after.ino).toBe(before.ino);
-      await expect(fs.readFile(filePath, "utf8")).resolves.toBe("replacement");
-      await expect(fs.readdir(tempDir)).resolves.toEqual(["important.txt"]);
-    },
-  );
 });

--- a/src/agents/agent-tools.read.ts
+++ b/src/agents/agent-tools.read.ts
@@ -16,6 +16,7 @@ import {
 } from "../infra/fs-safe.js";
 import { expandHomePrefix, resolveOsHomeDir } from "../infra/home-dir.js";
 import { hasEncodedFileUrlSeparator, trySafeFileURLToPath } from "../infra/local-file-access.js";
+import { writeSiblingTempFile } from "../infra/sibling-temp-file.js";
 import { decodeWindowsTextFileBuffer } from "../infra/windows-encoding.js";
 import {
   classifyMediaReferenceSource,
@@ -1076,10 +1077,134 @@ function resolveHostPath(filePath: string): string {
   return path.resolve(expandTildeToOsHome(filePath));
 }
 
+async function resolveHostWriteTarget(filePath: string): Promise<string> {
+  try {
+    return await fs.realpath(filePath);
+  } catch (error) {
+    if (!isNotFoundError(error)) {
+      throw error;
+    }
+  }
+
+  try {
+    const linkTarget = await fs.readlink(filePath);
+    return await resolveHostWriteTarget(path.resolve(path.dirname(filePath), linkTarget));
+  } catch (error) {
+    if (!isNotFoundError(error)) {
+      throw error;
+    }
+  }
+
+  return await canonicalPathFromExistingAncestor(filePath);
+}
+
+type HostWriteTargetState = {
+  dev: number;
+  gid: number;
+  ino: number;
+  mode: number;
+  uid: number;
+};
+
+function hostWriteCompatibilityError(code: string, message: string) {
+  return Object.assign(new Error(message), { code });
+}
+
+async function inspectHostWriteTarget(
+  targetPath: string,
+): Promise<HostWriteTargetState | undefined> {
+  const stat = await fs.stat(targetPath).catch((error: unknown) => {
+    if (isNotFoundError(error)) {
+      return undefined;
+    }
+    throw error;
+  });
+  if (!stat) {
+    return undefined;
+  }
+  if (!stat.isFile()) {
+    throw hostWriteCompatibilityError(
+      "EINVAL",
+      `Refusing to replace non-regular host path atomically: ${targetPath}`,
+    );
+  }
+  if (stat.nlink > 1) {
+    throw hostWriteCompatibilityError(
+      "EMLINK",
+      `Refusing to replace hard-linked host file atomically: ${targetPath}`,
+    );
+  }
+  await fs.access(targetPath, fs.constants.W_OK);
+  return {
+    dev: stat.dev,
+    gid: stat.gid,
+    ino: stat.ino,
+    mode: stat.mode & 0o7777,
+    uid: stat.uid,
+  };
+}
+
+async function assertHostWriteTargetUnchanged(
+  targetPath: string,
+  expected: HostWriteTargetState | undefined,
+) {
+  if (!expected) {
+    const appeared = await fs
+      .lstat(targetPath)
+      .then(() => true)
+      .catch((error: unknown) => {
+        if (isNotFoundError(error)) {
+          return false;
+        }
+        throw error;
+      });
+    if (appeared) {
+      throw hostWriteCompatibilityError(
+        "EEXIST",
+        `Host write target appeared while staging replacement: ${targetPath}`,
+      );
+    }
+    return;
+  }
+
+  const current = await inspectHostWriteTarget(targetPath);
+  if (
+    !current ||
+    current.dev !== expected.dev ||
+    current.ino !== expected.ino ||
+    current.uid !== expected.uid ||
+    current.gid !== expected.gid ||
+    current.mode !== expected.mode
+  ) {
+    throw hostWriteCompatibilityError(
+      "EBUSY",
+      `Host write target changed while staging replacement: ${targetPath}`,
+    );
+  }
+}
+
 async function writeHostFile(absolutePath: string, content: string) {
   const resolved = resolveHostPath(absolutePath);
   await fs.mkdir(path.dirname(resolved), { recursive: true });
-  await fs.writeFile(resolved, content, "utf-8");
+  const targetPath = await resolveHostWriteTarget(resolved);
+  const target = await inspectHostWriteTarget(targetPath);
+  const targetDir = path.dirname(targetPath);
+  await fs.access(targetDir);
+  await writeSiblingTempFile({
+    dir: targetDir,
+    chmodDir: false,
+    writeTemp: async (tempPath) => {
+      await fs.writeFile(tempPath, content, { encoding: "utf-8", mode: target?.mode });
+      if (target && process.platform !== "win32") {
+        await fs.chown(tempPath, target.uid, target.gid);
+      }
+      if (target) {
+        await fs.chmod(tempPath, target.mode);
+      }
+      await assertHostWriteTargetUnchanged(targetPath, target);
+    },
+    resolveFinalPath: () => targetPath,
+  });
 }
 
 async function statHostFile(absolutePath: string) {

--- a/src/agents/agent-tools.read.ts
+++ b/src/agents/agent-tools.read.ts
@@ -1106,13 +1106,18 @@ type HostWriteTargetState = {
   uid: number;
 };
 
-function hostWriteCompatibilityError(code: string, message: string) {
+type HostWritePlan =
+  | { kind: "create" }
+  | { kind: "replace"; target: HostWriteTargetState }
+  | { kind: "in-place" };
+
+class HostOwnershipRestoreError extends Error {}
+
+function hostWriteRaceError(code: string, message: string) {
   return Object.assign(new Error(message), { code });
 }
 
-async function inspectHostWriteTarget(
-  targetPath: string,
-): Promise<HostWriteTargetState | undefined> {
+async function planHostWrite(targetPath: string): Promise<HostWritePlan> {
   const stat = await fs.stat(targetPath).catch((error: unknown) => {
     if (isNotFoundError(error)) {
       return undefined;
@@ -1120,35 +1125,29 @@ async function inspectHostWriteTarget(
     throw error;
   });
   if (!stat) {
-    return undefined;
+    return { kind: "create" };
   }
-  if (!stat.isFile()) {
-    throw hostWriteCompatibilityError(
-      "EINVAL",
-      `Refusing to replace non-regular host path atomically: ${targetPath}`,
-    );
-  }
-  if (stat.nlink > 1) {
-    throw hostWriteCompatibilityError(
-      "EMLINK",
-      `Refusing to replace hard-linked host file atomically: ${targetPath}`,
-    );
+  if (!stat.isFile() || stat.nlink > 1) {
+    return { kind: "in-place" };
   }
   await fs.access(targetPath, fs.constants.W_OK);
   return {
-    dev: stat.dev,
-    gid: stat.gid,
-    ino: stat.ino,
-    mode: stat.mode & 0o7777,
-    uid: stat.uid,
+    kind: "replace",
+    target: {
+      dev: stat.dev,
+      gid: stat.gid,
+      ino: stat.ino,
+      mode: stat.mode & 0o7777,
+      uid: stat.uid,
+    },
   };
 }
 
 async function assertHostWriteTargetUnchanged(
   targetPath: string,
-  expected: HostWriteTargetState | undefined,
+  plan: Exclude<HostWritePlan, { kind: "in-place" }>,
 ) {
-  if (!expected) {
+  if (plan.kind === "create") {
     const appeared = await fs
       .lstat(targetPath)
       .then(() => true)
@@ -1159,7 +1158,7 @@ async function assertHostWriteTargetUnchanged(
         throw error;
       });
     if (appeared) {
-      throw hostWriteCompatibilityError(
+      throw hostWriteRaceError(
         "EEXIST",
         `Host write target appeared while staging replacement: ${targetPath}`,
       );
@@ -1167,16 +1166,16 @@ async function assertHostWriteTargetUnchanged(
     return;
   }
 
-  const current = await inspectHostWriteTarget(targetPath);
+  const current = await planHostWrite(targetPath);
   if (
-    !current ||
-    current.dev !== expected.dev ||
-    current.ino !== expected.ino ||
-    current.uid !== expected.uid ||
-    current.gid !== expected.gid ||
-    current.mode !== expected.mode
+    current.kind !== "replace" ||
+    current.target.dev !== plan.target.dev ||
+    current.target.ino !== plan.target.ino ||
+    current.target.uid !== plan.target.uid ||
+    current.target.gid !== plan.target.gid ||
+    current.target.mode !== plan.target.mode
   ) {
-    throw hostWriteCompatibilityError(
+    throw hostWriteRaceError(
       "EBUSY",
       `Host write target changed while staging replacement: ${targetPath}`,
     );
@@ -1187,24 +1186,41 @@ async function writeHostFile(absolutePath: string, content: string) {
   const resolved = resolveHostPath(absolutePath);
   await fs.mkdir(path.dirname(resolved), { recursive: true });
   const targetPath = await resolveHostWriteTarget(resolved);
-  const target = await inspectHostWriteTarget(targetPath);
+  const plan = await planHostWrite(targetPath);
+  if (plan.kind === "in-place") {
+    await fs.writeFile(targetPath, content, "utf-8");
+    return;
+  }
+  const target = plan.kind === "replace" ? plan.target : undefined;
   const targetDir = path.dirname(targetPath);
   await fs.access(targetDir);
-  await writeSiblingTempFile({
-    dir: targetDir,
-    chmodDir: false,
-    writeTemp: async (tempPath) => {
-      await fs.writeFile(tempPath, content, { encoding: "utf-8", mode: target?.mode });
-      if (target && process.platform !== "win32") {
-        await fs.chown(tempPath, target.uid, target.gid);
-      }
-      if (target) {
-        await fs.chmod(tempPath, target.mode);
-      }
-      await assertHostWriteTargetUnchanged(targetPath, target);
-    },
-    resolveFinalPath: () => targetPath,
-  });
+  try {
+    await writeSiblingTempFile({
+      dir: targetDir,
+      chmodDir: false,
+      writeTemp: async (tempPath) => {
+        await fs.writeFile(tempPath, content, { encoding: "utf-8", mode: target?.mode });
+        if (target && process.platform !== "win32") {
+          await fs.chown(tempPath, target.uid, target.gid).catch((error: unknown) => {
+            throw new HostOwnershipRestoreError(
+              `Unable to restore host write target ownership: ${targetPath}`,
+              { cause: error },
+            );
+          });
+        }
+        if (target) {
+          await fs.chmod(tempPath, target.mode);
+        }
+        await assertHostWriteTargetUnchanged(targetPath, plan);
+      },
+      resolveFinalPath: () => targetPath,
+    });
+  } catch (error) {
+    if (!(error instanceof HostOwnershipRestoreError)) {
+      throw error;
+    }
+    await fs.writeFile(targetPath, content, "utf-8");
+  }
 }
 
 async function statHostFile(absolutePath: string) {

--- a/src/agents/agent-tools.read.ts
+++ b/src/agents/agent-tools.read.ts
@@ -2,6 +2,7 @@
 // Adds workspace-root guards, adaptive read paging, image validation, memory
 // append-only writes, and parameter cleanup around the session file tools.
 
+import { randomUUID } from "node:crypto";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { URL } from "node:url";
@@ -16,7 +17,6 @@ import {
 } from "../infra/fs-safe.js";
 import { expandHomePrefix, resolveOsHomeDir } from "../infra/home-dir.js";
 import { hasEncodedFileUrlSeparator, trySafeFileURLToPath } from "../infra/local-file-access.js";
-import { writeSiblingTempFile } from "../infra/sibling-temp-file.js";
 import { decodeWindowsTextFileBuffer } from "../infra/windows-encoding.js";
 import {
   classifyMediaReferenceSource,
@@ -1098,87 +1098,33 @@ async function resolveHostWriteTarget(filePath: string): Promise<string> {
   return await canonicalPathFromExistingAncestor(filePath);
 }
 
-type HostWriteTargetState = {
-  dev: number;
-  gid: number;
-  ino: number;
-  mode: number;
-  uid: number;
-};
+const HOST_WRITE_RESERVATION_SKIP_CODES = new Set(["EACCES", "EPERM", "EROFS"]);
 
-type HostWritePlan =
-  | { kind: "create" }
-  | { kind: "replace"; target: HostWriteTargetState }
-  | { kind: "in-place" };
-
-class HostOwnershipRestoreError extends Error {}
-
-function hostWriteRaceError(code: string, message: string) {
-  return Object.assign(new Error(message), { code });
+function isHostWriteReservationSkipError(error: unknown): boolean {
+  const code = (error as NodeJS.ErrnoException | undefined)?.code;
+  return typeof code === "string" && HOST_WRITE_RESERVATION_SKIP_CODES.has(code);
 }
 
-async function planHostWrite(targetPath: string): Promise<HostWritePlan> {
-  const stat = await fs.stat(targetPath).catch((error: unknown) => {
-    if (isNotFoundError(error)) {
+async function reserveHostWriteContent(targetDir: string, content: string) {
+  const reservationPath = path.join(
+    targetDir,
+    `.openclaw-host-write.${process.pid}.${randomUUID()}.tmp`,
+  );
+  const handle = await fs.open(reservationPath, "wx", 0o600).catch((error: unknown) => {
+    if (isHostWriteReservationSkipError(error)) {
       return undefined;
     }
     throw error;
   });
-  if (!stat) {
-    return { kind: "create" };
-  }
-  if (!stat.isFile() || stat.nlink > 1) {
-    return { kind: "in-place" };
-  }
-  await fs.access(targetPath, fs.constants.W_OK);
-  return {
-    kind: "replace",
-    target: {
-      dev: stat.dev,
-      gid: stat.gid,
-      ino: stat.ino,
-      mode: stat.mode & 0o7777,
-      uid: stat.uid,
-    },
-  };
-}
-
-async function assertHostWriteTargetUnchanged(
-  targetPath: string,
-  plan: Exclude<HostWritePlan, { kind: "in-place" }>,
-) {
-  if (plan.kind === "create") {
-    const appeared = await fs
-      .lstat(targetPath)
-      .then(() => true)
-      .catch((error: unknown) => {
-        if (isNotFoundError(error)) {
-          return false;
-        }
-        throw error;
-      });
-    if (appeared) {
-      throw hostWriteRaceError(
-        "EEXIST",
-        `Host write target appeared while staging replacement: ${targetPath}`,
-      );
-    }
+  if (!handle) {
     return;
   }
-
-  const current = await planHostWrite(targetPath);
-  if (
-    current.kind !== "replace" ||
-    current.target.dev !== plan.target.dev ||
-    current.target.ino !== plan.target.ino ||
-    current.target.uid !== plan.target.uid ||
-    current.target.gid !== plan.target.gid ||
-    current.target.mode !== plan.target.mode
-  ) {
-    throw hostWriteRaceError(
-      "EBUSY",
-      `Host write target changed while staging replacement: ${targetPath}`,
-    );
+  try {
+    await fs.rm(reservationPath, { force: true });
+    await handle.writeFile(content, "utf-8");
+  } finally {
+    await handle.close().catch(() => undefined);
+    await fs.rm(reservationPath, { force: true }).catch(() => undefined);
   }
 }
 
@@ -1186,41 +1132,16 @@ async function writeHostFile(absolutePath: string, content: string) {
   const resolved = resolveHostPath(absolutePath);
   await fs.mkdir(path.dirname(resolved), { recursive: true });
   const targetPath = await resolveHostWriteTarget(resolved);
-  const plan = await planHostWrite(targetPath);
-  if (plan.kind === "in-place") {
-    await fs.writeFile(targetPath, content, "utf-8");
-    return;
-  }
-  const target = plan.kind === "replace" ? plan.target : undefined;
-  const targetDir = path.dirname(targetPath);
-  await fs.access(targetDir);
-  try {
-    await writeSiblingTempFile({
-      dir: targetDir,
-      chmodDir: false,
-      writeTemp: async (tempPath) => {
-        await fs.writeFile(tempPath, content, { encoding: "utf-8", mode: target?.mode });
-        if (target && process.platform !== "win32") {
-          await fs.chown(tempPath, target.uid, target.gid).catch((error: unknown) => {
-            throw new HostOwnershipRestoreError(
-              `Unable to restore host write target ownership: ${targetPath}`,
-              { cause: error },
-            );
-          });
-        }
-        if (target) {
-          await fs.chmod(tempPath, target.mode);
-        }
-        await assertHostWriteTargetUnchanged(targetPath, plan);
-      },
-      resolveFinalPath: () => targetPath,
-    });
-  } catch (error) {
-    if (!(error instanceof HostOwnershipRestoreError)) {
-      throw error;
+  const target = await fs.stat(targetPath).catch((error: unknown) => {
+    if (isNotFoundError(error)) {
+      return undefined;
     }
-    await fs.writeFile(targetPath, content, "utf-8");
+    throw error;
+  });
+  if (!target || target.isFile()) {
+    await reserveHostWriteContent(path.dirname(targetPath), content);
   }
+  await fs.writeFile(resolved, content, "utf-8");
 }
 
 async function statHostFile(absolutePath: string) {


### PR DESCRIPTION
## What Problem This Solves

With the default `tools.fs.workspaceOnly` setting, the write and edit tools wrote unrestricted host files with `fs.writeFile`. That opens an existing target with `O_TRUNC`, so ENOSPC, EDQUOT, EFBIG, or SIGXFSZ during the write irreversibly replaced the original with a truncated prefix. The edit recovery path could then report success if the requested replacement appeared in that prefix.

## Why This Change Was Made

### Root cause

`src/agents/agent-tools.read.ts:1079` routed both unrestricted host tools through a single unconditional in-place write:

```before
async function writeHostFile(absolutePath: string, content: string) {
  const resolved = resolveHostPath(absolutePath);
  await fs.mkdir(path.dirname(resolved), { recursive: true });
  await fs.writeFile(resolved, content, "utf-8");
}
```

The destination was truncated before anything proved the new content could be written at all.

### Fix

`src/agents/agent-tools.read.ts:1131` reserves the payload on the destination's own filesystem before the destination is touched, then writes the existing inode exactly as before:

```after
async function writeHostFile(absolutePath: string, content: string) {
  const resolved = resolveHostPath(absolutePath);
  await fs.mkdir(path.dirname(resolved), { recursive: true });
  const targetPath = await resolveHostWriteTarget(resolved);
  const target = await fs.stat(targetPath).catch(...);
  if (!target || target.isFile()) {
    await reserveHostWriteContent(path.dirname(targetPath), content);
  }
  await fs.writeFile(resolved, content, "utf-8");
}
```

The reservation writes the identical byte payload to a hidden sibling file in the destination's directory, so it is subject to the same free space, quota, and file-size limit as the real write. Any ENOSPC, EDQUOT, EFBIG, or SIGXFSZ therefore surfaces while the original file is still untouched. The reservation is unlinked immediately after it is created and written through the open descriptor, so the space is returned before the real write and nothing is left behind even when a signal terminates the process mid-reservation.

```after
const handle = await fs.open(reservationPath, "wx", 0o600).catch(...);
try {
  await fs.rm(reservationPath, { force: true });
  await handle.writeFile(content, "utf-8");
} finally {
  await handle.close().catch(() => undefined);
  await fs.rm(reservationPath, { force: true }).catch(() => undefined);
}
```

### Why replacement was dropped

Earlier revisions of this PR staged the content in a sibling file and renamed it over the destination. ClawSweeper was right to block that: a rename installs a new inode, so ACLs, extended attributes, security labels, capabilities, and file flags attached to the original are discarded on an otherwise successful write, and Node exposes no portable API to read or copy that state onto the staged file. That is measured, not assumed. The proof below runs the production write tool against a file carrying a real extended attribute and a real ext4 file flag: the previous head silently dropped both, this head keeps them.

Reserving instead of replacing keeps the destination inode, so every inode-attached property survives by construction. It also removes the compatibility branches the replacement design needed: no hard-link special case, no non-regular-file special case, no owner or mode restoration, and no staged-file race checks. Source is `+55` lines here against `+141` on the previous head.

The tradeoff is stated plainly: reserving does not make the write atomic against SIGKILL or power loss, and the PR no longer claims that. It converts the entire allocation and size-limit class of failures from "original silently truncated" into "clean failure, original intact", and it is never worse than current `main` in any case. A genuinely atomic host write that also preserves inode-attached metadata would need a native metadata-copy primitive shared with the fs-safe pinned writer, which is a larger change than this fix and belongs with that writer's owner.

Two behaviors are preserved deliberately. Non-regular destinations such as `/dev/null`, devices, and FIFOs skip the reservation entirely, since they have no content to truncate and a reservation would otherwise be created in directories like `/dev`. If the destination's directory refuses a staged file, for example a writable file inside a read-only directory, the reservation is skipped on EACCES, EPERM, and EROFS and the write proceeds as it does on `main`.

### Why this is the right boundary

`writeHostFile` is the single operation shared by unrestricted `write` and `edit`, so one change covers both production callers. Workspace-only writes already use the fs-safe root writer and sandbox writes already stage before commit, so those sibling surfaces do not need a second implementation.

The closest prior write-integrity PR, #44662, hardened size verification in the workspace and sandbox writers. It did not change this default unrestricted path. Closed PRs #67202 and #89853 addressed delegated false-success verification after writes, not preventing the original from being truncated.

## User Impact

A failed unrestricted write or edit caused by a full disk, an exceeded quota, or a file-size limit now leaves the original host file intact instead of truncating it. Everything else about a host write is unchanged: the same inode is written, so ownership, mode, ACLs, extended attributes, labels, capabilities, file flags, hard links, and symlink targets all behave exactly as they do on `main`. No write that succeeded before this change fails after it. Each host write now writes its payload twice, once to the reservation and once to the destination.

## Evidence

### Verification

- `node scripts/run-vitest.mjs src/agents/agent-tools.read.host-write-integrity.test.ts`: 6 passed, 2 skipped. The two skipped cases assert unprivileged-only behavior and are skipped when the suite runs as root.
- The regression file holds 8 cases: failed write, failed edit including the silent recovery path, target inode and metadata preservation, symlink pass-through, read-only file rejection, write through a read-only directory, hard-linked update, and write-through to a non-regular target without leaving a reservation in `/dev`.
- The two interrupted-write cases fail on pristine main `e8cd287aad23` and pass here.
- Rebased onto current `origin/main` `e8cd287aad23`; the PR merges cleanly.
- Source diff is `+55` lines; the whole replacement path, its plan type, and its race checks are gone.

## Agent review details

The ClawSweeper review of head `aeb84ab110d5` left one P1, "Preserve inode-attached metadata before replacement", plus the matching high security concern, and recommended either preserving that metadata or keeping the files in place. This head keeps every destination in place, so there is no replacement to preserve metadata across. The earlier hard-link P1 from head `34e13032b7a6` stays resolved for the same reason.

The rank-up move asking for a metadata regression fixture is covered by the extended-attribute and file-flag proof below and by the inode-identity assertion in the regression file.

## Real behavior proof
Behavior addressed: A default unrestricted edit destroys the tail of an existing host file when the write is interrupted by a size limit, and the previous head of this PR silently discarded the destination's extended attributes and file flags on successful writes.
Real environment tested: The actual `createHostWorkspaceWriteTool` and `createHostWorkspaceEditTool` production factories with `workspaceOnly: false`, real on-disk ext4 files carrying a real `user.openclaw.demo` extended attribute and a real `d` file flag, and a real Linux `RLIMIT_FSIZE` boundary, on pristine main `e8cd287aad23`, on the previously reviewed head `aeb84ab110d5`, and on this head `1f3695e8fa18`; no external seam was substituted.
Exact steps or command run after this patch: Bundle a throwaway driver that invokes the production factories. For metadata, create `notes.txt` with mode 0640, `setxattr user.openclaw.demo=keep-me`, and `chattr +d`, run `node driver.mjs metadata <dir>`, and compare `stat -c %i`, `os.listxattr`, and `lsattr` before and after. For interruption, run `(ulimit -f 2; node driver.mjs truncate <dir>)` against identical 9,826-byte files, then check `wc -c`, `tail -n 1`, and directory contents.
Evidence after fix:
```
# METADATA, pristine main e8cd287aad23
before ino=4568774 mode=640 xattr=['user.openclaw.demo'] value=keep-me flags=------d-------e-------
WRITE ok=yes
after  ino=4568774 mode=640 xattr=['user.openclaw.demo'] value=keep-me flags=------d-------e-------

# METADATA, previously reviewed head aeb84ab110d5
before ino=4568774 mode=640 xattr=['user.openclaw.demo'] value=keep-me flags=------d-------e-------
WRITE ok=yes
after  ino=4568775 mode=640 xattr=NONE value=LOST flags=--------------e-------

# METADATA, this head 1f3695e8fa18
before ino=4568774 mode=640 xattr=['user.openclaw.demo'] value=keep-me flags=------d-------e-------
WRITE ok=yes
after  ino=4568774 mode=640 xattr=['user.openclaw.demo'] value=keep-me flags=------d-------e-------

# INTERRUPTED EDIT, pristine main e8cd287aad23
before bytes=9826 footer=1
node exit=153
after  bytes=2048 footer=0
dir entries: important.txt
last line: line 042: some content that the user ca

# INTERRUPTED EDIT, this head 1f3695e8fa18, identical input
before bytes=9826 footer=1
node exit=153
after  bytes=9826 footer=1
dir entries: important.txt
last line: FOOTER: end of user notes
```
Observed result after fix: The previously reviewed head changed the inode and lost both the extended attribute and the `d` flag on a successful write; this head reports the identical inode, extended attribute, and flags as pristine main. Under the identical SIGXFSZ interruption, pristine main lost 7,778 bytes and the footer, while this head retained all 9,826 original bytes and the footer and left no reservation file behind.
What was not tested: No Windows filesystem run, no POSIX ACL fixture specifically (the extended-attribute case exercises the same inode-attached storage that POSIX ACLs use), no full build, and no unprivileged host run, so the read-only file and read-only directory cases rest on their unit tests rather than a live non-root run. This change does not touch dynamic imports, module boundaries, packaging, or published surfaces.
