### PR TITLE
fix(tlon): settle monitor on abort during async startup

### DIFF
--- a/extensions/tlon/src/monitor/index.test.ts
+++ b/extensions/tlon/src/monitor/index.test.ts
@@ -1,10 +1,37 @@
-// Tlon monitor tests cover authentication retry scheduling.
+// Tlon monitor tests cover authentication retry scheduling and shutdown lifecycle.
 import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const { authenticateMock, sleepWithAbortMock } = vi.hoisted(() => ({
+const {
+  authenticateMock,
+  sleepWithAbortMock,
+  sseClientCtorMock,
+  sseClientInstanceMock,
+  settingsManagerMock,
+  ingressMonitorMock,
+} = vi.hoisted(() => ({
   authenticateMock: vi.fn(),
   sleepWithAbortMock: vi.fn(),
+  sseClientCtorMock: vi.fn(),
+  sseClientInstanceMock: {
+    scry: vi.fn(async () => null),
+    poke: vi.fn(async () => undefined),
+    subscribe: vi.fn(async () => undefined),
+    connect: vi.fn(async () => undefined),
+    stopReceiving: vi.fn(),
+    close: vi.fn(async () => undefined),
+  },
+  settingsManagerMock: {
+    load: vi.fn(async () => ({})),
+    onChange: vi.fn(() => () => {}),
+    startSubscription: vi.fn(async () => undefined),
+  },
+  ingressMonitorMock: {
+    receive: vi.fn(async () => ({ kind: "ignored" })),
+    start: vi.fn(),
+    stop: vi.fn(async () => undefined),
+    waitForIdle: vi.fn(async () => undefined),
+  },
 }));
 
 vi.mock("openclaw/plugin-sdk/runtime-env", async (importOriginal) => {
@@ -38,6 +65,29 @@ vi.mock("../urbit/auth.js", () => ({
   authenticate: authenticateMock,
 }));
 
+vi.mock("../urbit/sse-client.js", () => ({
+  UrbitSSEClient: vi.fn((...args: unknown[]) => {
+    sseClientCtorMock(...args);
+    return sseClientInstanceMock;
+  }),
+}));
+
+vi.mock("../settings.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../settings.js")>();
+  return {
+    ...actual,
+    createSettingsManager: vi.fn(() => settingsManagerMock),
+  };
+});
+
+vi.mock("./ingress.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./ingress.js")>();
+  return {
+    ...actual,
+    createTlonIngressMonitor: vi.fn(() => ingressMonitorMock),
+  };
+});
+
 import { monitorTlonProvider } from "./index.js";
 
 describe("monitorTlonProvider authentication retry", () => {
@@ -56,5 +106,41 @@ describe("monitorTlonProvider authentication retry", () => {
 
     expect(authenticateMock).toHaveBeenCalledTimes(1);
     expect(sleepWithAbortMock).toHaveBeenCalledWith(1_000, controller.signal);
+  });
+});
+
+describe("monitorTlonProvider shutdown during startup", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("settles and runs cleanup when abort fires while api.connect() is pending", async () => {
+    // Regression for #114886: an abort during async startup must not leave the
+    // monitor hanging. After connect() resolves, waitUntilAbort sees an
+    // already-aborted signal and resolves immediately so finally cleanup runs.
+    const controller = new AbortController();
+    const runtime = { error: vi.fn(), exit: vi.fn(), log: vi.fn() } satisfies RuntimeEnv;
+    authenticateMock.mockResolvedValueOnce("cookie");
+
+    let resolveConnect!: () => void;
+    sseClientInstanceMock.connect.mockImplementationOnce(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveConnect = resolve;
+        }),
+    );
+
+    const monitor = monitorTlonProvider({ abortSignal: controller.signal, runtime });
+
+    // Wait for connect() to be in flight, then abort during the pending startup.
+    await vi.waitFor(() => expect(sseClientInstanceMock.connect).toHaveBeenCalled());
+    controller.abort();
+    resolveConnect();
+
+    // The monitor must settle (not hang) and run finally cleanup exactly once.
+    await expect(monitor).resolves.toBeUndefined();
+    expect(sseClientInstanceMock.stopReceiving).toHaveBeenCalledTimes(1);
+    expect(sseClientInstanceMock.close).toHaveBeenCalledTimes(1);
+    expect(ingressMonitorMock.stop).toHaveBeenCalledTimes(1);
   });
 });

--- a/extensions/tlon/src/monitor/index.ts
+++ b/extensions/tlon/src/monitor/index.ts
@@ -1,6 +1,9 @@
 import { resolveHumanDelayConfig } from "openclaw/plugin-sdk/agent-runtime";
 import { createChannelInboundEnvelopeBuilder } from "openclaw/plugin-sdk/channel-inbound";
-import { bindIngressLifecycleToReplyOptions } from "openclaw/plugin-sdk/channel-outbound";
+import {
+  bindIngressLifecycleToReplyOptions,
+  waitUntilAbort,
+} from "openclaw/plugin-sdk/channel-outbound";
 import type { GetReplyOptions, ReplyPayload } from "openclaw/plugin-sdk/reply-runtime";
 import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime";
 import { sleepWithAbort } from "openclaw/plugin-sdk/runtime-env";
@@ -1097,6 +1100,8 @@ export async function monitorTlonProvider(opts: MonitorTlonOpts = {}): Promise<v
     },
   });
 
+  // Hoisted so finally can clear it as the single cleanup owner on every exit path.
+  let pollInterval: ReturnType<typeof setInterval> | undefined;
   try {
     runtime.log?.("[tlon] Subscribing to firehose updates...");
 
@@ -1495,7 +1500,7 @@ export async function monitorTlonProvider(opts: MonitorTlonOpts = {}): Promise<v
     runtime.log?.("[tlon] Connected! Firehose subscriptions active");
 
     // Periodically refresh channel discovery
-    const pollInterval = setInterval(
+    pollInterval = setInterval(
       () => {
         void (async () => {
           if (!opts.abortSignal?.aborted) {
@@ -1517,23 +1522,16 @@ export async function monitorTlonProvider(opts: MonitorTlonOpts = {}): Promise<v
       },
       2 * 60 * 1000,
     );
+    // Do not keep the process alive solely for channel-discovery polling.
+    pollInterval.unref();
 
-    if (opts.abortSignal) {
-      const signal = opts.abortSignal;
-      await new Promise((resolve) => {
-        signal.addEventListener(
-          "abort",
-          () => {
-            clearInterval(pollInterval);
-            resolve(null);
-          },
-          { once: true },
-        );
-      });
-    } else {
-      await new Promise(() => {});
-    }
+    // waitUntilAbort resolves on abort, immediately if already aborted (so finally
+    // cleanup runs), or stays pending forever when no signal is given.
+    await waitUntilAbort(opts.abortSignal);
   } finally {
+    if (pollInterval !== undefined) {
+      clearInterval(pollInterval);
+    }
     api?.stopReceiving();
     await ingress.stop();
     try {


### PR DESCRIPTION
Closes #114886

## What Problem This Solves

Fixes an issue where the Tlon channel monitor could hang when the gateway abort signal fired during async startup. The monitor registered its abort listener after substantial async work (invites, subscriptions, channel discovery, SSE connect), so an abort during that window attached a listener to an already-aborted signal that never replays — the await never resolved and `finally` cleanup never ran.

## Why This Change Was Made

The bespoke `if (opts.abortSignal) { await new Promise(...) } else { await new Promise(() => {}) }` block is replaced with the canonical `waitUntilAbort` primitive (`src/plugin-sdk/channel-lifecycle.core.ts:127-144`, exported from `openclaw/plugin-sdk/channel-outbound`). It correctly handles all three cases: undefined signal (stays pending forever — the monitor's intended lifetime), already-aborted signal (resolves immediately so `finally` runs), and normal abort (resolves on the event).

Key design decisions, driven by review:
- **Single cleanup owner.** `waitUntilAbort` is called with no callback; interval clearing lives only in `finally`, so every exit path (normal abort, already-aborted, exception between interval creation and the wait) converges on one cleanup site.
- **Hoisted interval handle.** `pollInterval` is declared before `try` so `finally` can always clear it; the guard handles the case where an earlier exception left it unassigned.
- **`.unref()`.** The discovery-poll interval no longer keeps the process alive solely for polling (codebase precedent: codex, discord, line, voice-call all `.unref()` background timers).

## User Impact

A Tlon monitor that receives an abort during startup now settles and runs cleanup (SSE stop, ingress stop, API close) instead of hanging with open resources. Whether abort-during-startup occurs in practice was not observed (see #114886 `NOT_ENOUGH_INFO`); the fix closes the hang regardless.

## Evidence

- Fix: `extensions/tlon/src/monitor/index.ts` — `waitUntilAbort` import, hoisted `pollInterval`, `await waitUntilAbort(opts.abortSignal)`, `clearInterval` in `finally`, `.unref()`.
- Autoreview (codex, `--mode uncommitted`): clean on the final diff after an initial P1 finding ("abort must interrupt pending startup") was rejected with dependency-contract proof: each dependency-backed startup operation is individually bounded — pre-connect `subscribe()` returns immediately while disconnected (`sse-client.ts:156`), channel create/wake use 30s guarded fetches (`channel-ops.ts:37-38,95-96,154-163`), optional discovery adds a 30s scry (`discovery.ts:63-68`), and `openStream()` has a 60s abort deadline (`sse-client.ts:206`). No startup await can hang indefinitely; once it settles, `waitUntilAbort` resolves on the already-aborted signal and `finally` runs. The late-listener/already-aborted case (the actual #114886 regression) is covered by the deferred-connect test.
- Adjacent (separate) PR: #108168 fixes pending SSE reconnect waits in `sse-client.ts`; this PR fixes the `index.ts:1521` abort-listener registration, a different shutdown path.
- Test: `settles and runs cleanup when abort fires while api.connect() is pending` — mocks the SSE client/settings/ingress, holds `connect()` pending, aborts, resolves, and asserts the monitor settles with `stopReceiving`/`close`/`ingress.stop` each called exactly once.

This is AI-assisted.
