### PR TITLE
fix(process): stop processes cancelled during startup

### DIFF
--- a/src/process/supervisor/supervisor.test.ts
+++ b/src/process/supervisor/supervisor.test.ts
@@ -257,6 +257,195 @@ describe("process supervisor", () => {
     expect(exit.exitSignal).toBe("SIGKILL");
   });
 
+  it.each(["child", "pty"] as const)(
+    "cancels a %s process by run ID while its adapter is starting",
+    async (mode) => {
+      const adapter = createStubChildAdapter({
+        onKill: (signal, current) => {
+          current.settle(null, signal ?? "SIGTERM");
+        },
+      });
+      const startup = createDeferred<StubChildAdapter>();
+      if (mode === "pty") {
+        createPtyAdapterMock.mockReturnValueOnce(startup.promise);
+      } else {
+        createChildAdapterMock.mockReturnValueOnce(startup.promise);
+      }
+
+      const supervisor = createProcessSupervisor();
+      const runId = `cancel-starting-${mode}`;
+      const pendingRun =
+        mode === "pty"
+          ? supervisor.spawn({
+              runId,
+              sessionId: "cancel-starting",
+              backendId: "test",
+              mode: "pty",
+              ptyCommand: "printf cancelled",
+              scopeKey: "scope:cancel-starting",
+            })
+          : spawnChild(supervisor, {
+              runId,
+              sessionId: "cancel-starting",
+              scopeKey: "scope:cancel-starting",
+              argv: createSilentIdleArgv(),
+            });
+
+      expect(supervisor.getRecord(runId)).toMatchObject({ state: "starting" });
+      supervisor.cancel(runId, "manual-cancel");
+      expect(supervisor.getRecord(runId)).toMatchObject({
+        state: "exiting",
+        terminationReason: "manual-cancel",
+      });
+
+      startup.resolve(adapter);
+      const run = await pendingRun;
+      expect(adapter.killMock).toHaveBeenCalledWith("SIGTERM");
+      await expect(run.wait()).resolves.toMatchObject({ reason: "manual-cancel" });
+      expect(supervisor.getRecord(runId)).toMatchObject({
+        state: "exited",
+        terminationReason: "manual-cancel",
+      });
+    },
+  );
+
+  it("cancels every starting scoped process without canceling a later arrival", async () => {
+    const runCount = 16;
+    const startups = Array.from({ length: runCount }, () => createDeferred<StubChildAdapter>());
+    const adapters = Array.from({ length: runCount }, (_unused, index) =>
+      createStubChildAdapter({
+        pid: 7_000 + index,
+        onKill: (signal, current) => {
+          current.settle(null, signal ?? "SIGTERM");
+        },
+      }),
+    );
+    const laterAdapter = createStubChildAdapter({ pid: 8_000 });
+    let adapterIndex = 0;
+    createChildAdapterMock.mockImplementation(() => {
+      const index = adapterIndex++;
+      if (index === runCount) {
+        return Promise.resolve(laterAdapter);
+      }
+      const startup = startups[index];
+      if (!startup) {
+        throw new Error(`unexpected scope cancellation startup ${index}`);
+      }
+      return startup.promise;
+    });
+
+    const supervisor = createProcessSupervisor();
+    const pendingRuns = Array.from({ length: runCount }, (_unused, index) =>
+      spawnChild(supervisor, {
+        runId: `cancel-scope-starting-${index}`,
+        sessionId: "cancel-scope-starting",
+        scopeKey: "scope:cancel-every-start",
+        argv: createSilentIdleArgv(),
+      }),
+    );
+
+    expect(createChildAdapterMock).toHaveBeenCalledTimes(runCount);
+    supervisor.cancelScope("scope:cancel-every-start", "manual-cancel");
+    for (let index = 0; index < runCount; index += 1) {
+      expect(supervisor.getRecord(`cancel-scope-starting-${index}`)).toMatchObject({
+        state: "exiting",
+        terminationReason: "manual-cancel",
+      });
+    }
+
+    const laterRun = await spawnChild(supervisor, {
+      runId: "cancel-scope-later-arrival",
+      sessionId: "cancel-scope-starting",
+      scopeKey: "scope:cancel-every-start",
+      argv: createSilentIdleArgv(),
+    });
+    expect(laterAdapter.killMock).not.toHaveBeenCalled();
+
+    for (let index = runCount - 1; index >= 0; index -= 1) {
+      const startup = startups[index];
+      const adapter = adapters[index];
+      if (!startup || !adapter) {
+        throw new Error(`missing scope cancellation startup ${index}`);
+      }
+      startup.resolve(adapter);
+    }
+
+    const runs = await Promise.all(pendingRuns);
+    for (const adapter of adapters) {
+      expect(adapter.killMock).toHaveBeenCalledWith("SIGTERM");
+    }
+    await expect(Promise.all(runs.map((run) => run.wait()))).resolves.toEqual(
+      Array.from({ length: runCount }, () => expect.objectContaining({ reason: "manual-cancel" })),
+    );
+
+    expect(laterAdapter.killMock).not.toHaveBeenCalled();
+    laterAdapter.settle(0);
+    await expect(laterRun.wait()).resolves.toMatchObject({ reason: "exit" });
+  });
+
+  it("cancels a replacement that is fenced behind an earlier startup", async () => {
+    const first = createStubChildAdapter({
+      onKill: (signal, current) => {
+        current.settle(null, signal ?? "SIGTERM");
+      },
+    });
+    const replacement = createStubChildAdapter({
+      onKill: (signal, current) => {
+        current.settle(null, signal ?? "SIGTERM");
+      },
+    });
+    const later = createStubChildAdapter();
+    const firstStartup = createDeferred<StubChildAdapter>();
+    createChildAdapterMock
+      .mockReturnValueOnce(firstStartup.promise)
+      .mockResolvedValueOnce(replacement)
+      .mockResolvedValueOnce(later);
+
+    const supervisor = createProcessSupervisor();
+    const firstRunPromise = spawnChild(supervisor, {
+      runId: "cancel-fenced-first",
+      sessionId: "cancel-fenced",
+      scopeKey: "scope:cancel-fenced",
+      argv: createSilentIdleArgv(),
+    });
+    const replacementPromise = spawnChild(supervisor, {
+      runId: "cancel-fenced-replacement",
+      sessionId: "cancel-fenced",
+      scopeKey: "scope:cancel-fenced",
+      replaceExistingScope: true,
+      argv: createSilentIdleArgv(),
+    });
+
+    expect(createChildAdapterMock).toHaveBeenCalledTimes(1);
+    supervisor.cancelScope("scope:cancel-fenced", "manual-cancel");
+
+    const laterPromise = spawnChild(supervisor, {
+      runId: "cancel-fenced-later",
+      sessionId: "cancel-fenced",
+      scopeKey: "scope:cancel-fenced",
+      argv: createSilentIdleArgv(),
+    });
+    firstStartup.resolve(first);
+
+    const [firstRun, replacementRun, laterRun] = await Promise.all([
+      firstRunPromise,
+      replacementPromise,
+      laterPromise,
+    ]);
+    expect(first.killMock).toHaveBeenCalledWith("SIGTERM");
+    expect(replacement.killMock).toHaveBeenCalledWith("SIGTERM");
+    expect(later.killMock).not.toHaveBeenCalled();
+
+    later.settle(0);
+    await expect(
+      Promise.all([firstRun.wait(), replacementRun.wait(), laterRun.wait()]),
+    ).resolves.toEqual([
+      expect.objectContaining({ reason: "manual-cancel" }),
+      expect.objectContaining({ reason: "manual-cancel" }),
+      expect.objectContaining({ reason: "exit" }),
+    ]);
+  });
+
   it("cancels prior scoped run when replaceExistingScope is enabled", async () => {
     const first = createStubChildAdapter({
       onKill: (signal, current) => {

--- a/src/process/supervisor/supervisor.ts
+++ b/src/process/supervisor/supervisor.ts
@@ -23,6 +23,12 @@ type ActiveRun = {
   scopeKey?: string;
 };
 
+type StartingRun = {
+  scopeKey?: string;
+  terminationReason?: TerminationReason;
+  cancel?: (reason: TerminationReason) => void;
+};
+
 type StartingScope = {
   runs: Set<Promise<ManagedRun>>;
   replacement?: Promise<ManagedRun>;
@@ -99,23 +105,31 @@ function resolveElapsedTimeoutReason(params: {
 export function createProcessSupervisor(): ProcessSupervisor {
   const registry = createRunRegistry();
   const active = new Map<string, ActiveRun>();
+  const startingRuns = new Map<string, StartingRun>();
   const startingScopes = new Map<string, StartingScope>();
 
   const cancel = (runId: string, reason: TerminationReason = "manual-cancel") => {
     const current = active.get(runId);
-    if (!current) {
+    if (current) {
+      registry.updateState(runId, "exiting", {
+        terminationReason: reason,
+      });
+      current.run.cancel(reason);
       return;
     }
+
+    const starting = startingRuns.get(runId);
+    if (!starting) {
+      return;
+    }
+    starting.terminationReason ??= reason;
     registry.updateState(runId, "exiting", {
-      terminationReason: reason,
+      terminationReason: starting.terminationReason,
     });
-    current.run.cancel(reason);
+    starting.cancel?.(starting.terminationReason);
   };
 
-  const cancelScope = (scopeKey: string, reason: TerminationReason = "manual-cancel") => {
-    if (!scopeKey.trim()) {
-      return;
-    }
+  const cancelActiveScope = (scopeKey: string, reason: TerminationReason) => {
     for (const [runId, run] of active.entries()) {
       if (run.scopeKey !== scopeKey) {
         continue;
@@ -124,10 +138,28 @@ export function createProcessSupervisor(): ProcessSupervisor {
     }
   };
 
-  const startRun = async (input: SpawnInput, scopeKey?: string): Promise<ManagedRun> => {
-    const runId = normalizeOptionalString(input.runId) ?? crypto.randomUUID();
+  const cancelScope = (scopeKey: string, reason: TerminationReason = "manual-cancel") => {
+    if (!scopeKey.trim()) {
+      return;
+    }
+    cancelActiveScope(scopeKey, reason);
+    for (const [runId, starting] of startingRuns.entries()) {
+      if (starting.scopeKey === scopeKey) {
+        cancel(runId, reason);
+      }
+    }
+  };
+
+  const startRun = async (
+    input: SpawnInput,
+    scopeKey: string | undefined,
+    runId: string,
+    startingRun: StartingRun,
+  ): Promise<ManagedRun> => {
     if (input.replaceExistingScope && scopeKey) {
-      cancelScope(scopeKey, "manual-cancel");
+      // Scope admission already waited for predecessor startups. Do not
+      // cancel this replacement or later runs reserved behind its fence.
+      cancelActiveScope(scopeKey, "manual-cancel");
     }
     const startedAtMs = Date.now();
     const record: RunRecord = {
@@ -135,7 +167,10 @@ export function createProcessSupervisor(): ProcessSupervisor {
       sessionId: input.sessionId,
       backendId: input.backendId,
       scopeKey,
-      state: "starting",
+      state: startingRun.terminationReason ? "exiting" : "starting",
+      ...(startingRun.terminationReason
+        ? { terminationReason: startingRun.terminationReason }
+        : {}),
       startedAtMs,
       lastOutputAtMs: startedAtMs,
       createdAtMs: startedAtMs,
@@ -143,7 +178,7 @@ export function createProcessSupervisor(): ProcessSupervisor {
     };
     registry.add(record);
 
-    let forcedReason: TerminationReason | null = null;
+    let forcedReason: TerminationReason | null = startingRun.terminationReason ?? null;
     let settled = false;
     let stdout = "";
     let stderr = "";
@@ -175,6 +210,7 @@ export function createProcessSupervisor(): ProcessSupervisor {
       setForcedReason(reason);
       cancelAdapter?.(reason);
     };
+    startingRun.cancel = requestCancel;
 
     const touchOutput = () => {
       registry.touchOutput(runId);
@@ -219,7 +255,10 @@ export function createProcessSupervisor(): ProcessSupervisor {
               secretInput: input.secretInput,
             });
 
-      registry.updateState(runId, "running", { pid: adapter.pid });
+      registry.updateState(runId, forcedReason ? "exiting" : "running", {
+        pid: adapter.pid,
+        ...(forcedReason ? { terminationReason: forcedReason } : {}),
+      });
 
       const clearTimers = () => {
         if (timeoutTimer) {
@@ -365,6 +404,9 @@ export function createProcessSupervisor(): ProcessSupervisor {
         run: managedRun,
         scopeKey,
       });
+      if (forcedReason) {
+        managedRun.cancel(forcedReason);
+      }
       return managedRun;
     } catch (err) {
       registry.finalize(runId, {
@@ -380,35 +422,46 @@ export function createProcessSupervisor(): ProcessSupervisor {
 
   const spawn = (input: SpawnInput): Promise<ManagedRun> => {
     const scopeKey = normalizeOptionalString(input.scopeKey);
-    if (!scopeKey) {
-      return startRun(input);
-    }
+    const runId = normalizeOptionalString(input.runId) ?? crypto.randomUUID();
+    const startingRun: StartingRun = { scopeKey };
+    // Reserve cancellation before either adapter startup or a replacement
+    // fence, so stopping a run cannot silently leave a late child alive.
+    startingRuns.set(runId, startingRun);
 
-    const starting = startingScopes.get(scopeKey) ?? { runs: new Set<Promise<ManagedRun>>() };
-    startingScopes.set(scopeKey, starting);
+    const starting = scopeKey
+      ? (startingScopes.get(scopeKey) ?? { runs: new Set<Promise<ManagedRun>>() })
+      : undefined;
+    if (scopeKey && starting) {
+      startingScopes.set(scopeKey, starting);
+    }
 
     // Ordinary runs start together, but replacements fence later arrivals so
     // delayed cancellation cannot accidentally terminate a newer scoped run.
-    const previous = input.replaceExistingScope
-      ? Array.from(starting.runs)
-      : starting.replacement
-        ? [starting.replacement]
-        : [];
+    const previous = starting
+      ? input.replaceExistingScope
+        ? Array.from(starting.runs)
+        : starting.replacement
+          ? [starting.replacement]
+          : []
+      : [];
     const pending =
       previous.length > 0
-        ? Promise.allSettled(previous).then(() => startRun(input, scopeKey))
-        : startRun(input, scopeKey);
-    starting.runs.add(pending);
-    if (input.replaceExistingScope) {
+        ? Promise.allSettled(previous).then(() => startRun(input, scopeKey, runId, startingRun))
+        : startRun(input, scopeKey, runId, startingRun);
+    starting?.runs.add(pending);
+    if (starting && input.replaceExistingScope) {
       starting.replacement = pending;
     }
 
     const clearPendingStart = () => {
-      starting.runs.delete(pending);
-      if (starting.replacement === pending) {
+      if (startingRuns.get(runId) === startingRun) {
+        startingRuns.delete(runId);
+      }
+      starting?.runs.delete(pending);
+      if (starting?.replacement === pending) {
         delete starting.replacement;
       }
-      if (starting.runs.size === 0 && startingScopes.get(scopeKey) === starting) {
+      if (scopeKey && starting?.runs.size === 0 && startingScopes.get(scopeKey) === starting) {
         startingScopes.delete(scopeKey);
       }
     };


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users stopping an agent background process, terminating a process by run ID, or cancelling a process scope could leave a child or PTY process running if cancellation happened during adapter startup. A scoped replacement queued behind an earlier startup could also miss a subsequent explicit scope cancellation.

## Why This Change Was Made

The process supervisor now reserves each process run synchronously before adapter startup or scope fencing, records cancellation as sticky lifecycle state, and applies it as soon as the real process becomes available. Public scope cancellation includes pending starts; replacement-internal cancellation remains limited to already-active processes, preserving ordinary same-scope concurrency and processes started after the explicit cancellation. This is an owner-local lifecycle fix; no provider, configuration, gateway protocol, or storage surface changes.

## User Impact

Stopping a starting background process now reliably terminates its real operating-system child or PTY. Scoped cancellation also reliably stops every process already in that scope without accidentally stopping a later process.

## Evidence

- Before the fix, all four new deterministic regression cases fail against main while the 20 existing supervisor cases pass.
- After the fix, 837 tests pass across 20 process-supervisor, child/PTY adapter, background-exec, gateway, node-host, auto-review, and process-registry test files.
- 20 consecutive focused stress runs pass: 520 supervisor and PTY test executions, including 64-way scoped-replacement races, injected startup failures, concurrent scope cancellation, and queued replacement ordering.
- Live real operating-system child **and** native PTY proof on the exact PR commit:

```json
{"scenario":"immediate real adapter-startup cancellation","mode":"child","actualPid":48214,"reason":"manual-cancel","result":"PASS"}
{"scenario":"immediate real adapter-startup cancellation","mode":"pty","actualPid":48228,"reason":"manual-cancel","result":"PASS"}
{"scenario":"pending real mixed child and PTY scope cancellation","childProcesses":6,"ptyProcesses":6,"cancelled":12,"laterPtyPid":48243,"laterProcessPreserved":true,"result":"PASS"}
{"scenario":"real child and PTY queued replacement cancellation","cancelled":2,"laterChildPid":48246,"laterProcessPreserved":true,"result":"PASS"}
```

- All 81 exact-head hosted CI checks pass, including lint, production/test type checks, the max-lines ratchet, Linux/Windows test shards, QA-smoke profiles, real behavior proof, and process/security boundary scans.
- Fresh independent auto-review returned no findings.
- Native maintainer review artifacts validate with no findings.

AI-assisted; every reported scenario was independently reproduced and regression-tested.