### PR TITLE
fix(cron): normalize delivery targets and reuse prepared plans

### DIFF
--- a/src/cron/isolated-agent/delivery-target.test.ts
+++ b/src/cron/isolated-agent/delivery-target.test.ts
@@ -229,6 +229,11 @@ const DEFAULT_TARGET = {
   channel: "forum" as const,
   to: "room:default",
 };
+const malformedAccountIdCases = [
+  { description: "numeric", accountId: 123 },
+  { description: "boolean", accountId: false },
+  { description: "object", accountId: {} },
+] as const;
 
 type SessionStore = Record<
   string,
@@ -383,6 +388,96 @@ describe("resolveDeliveryTarget", () => {
 
     expect(result.accountId).toBe("account-b");
   });
+
+  it.each([
+    {
+      description: "trims an explicit account",
+      explicitAccountId: "  explicit-account  ",
+      expectedAccountId: "explicit-account",
+    },
+    {
+      description: "falls back to the session for a whitespace-only account",
+      explicitAccountId: "   ",
+      expectedAccountId: "session-account",
+    },
+    {
+      description: "falls back to the session for an empty account",
+      explicitAccountId: "",
+      expectedAccountId: "session-account",
+    },
+  ])("$description", async ({ explicitAccountId, expectedAccountId }) => {
+    setLastSessionEntry({
+      sessionId: "sess-account-normalization",
+      lastChannel: "forum",
+      lastTo: "room:ops",
+      lastAccountId: "session-account",
+    });
+
+    const result = await resolveDeliveryTarget(makeForumBoundCfg(), AGENT_ID, {
+      channel: "forum",
+      to: "room:ops",
+      accountId: explicitAccountId,
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.accountId).toBe(expectedAccountId);
+  });
+
+  it.each([
+    { description: "whitespace-only", explicitAccountId: "   " },
+    { description: "empty", explicitAccountId: "" },
+  ])(
+    "falls back to the bound account for a $description account",
+    async ({ explicitAccountId }) => {
+      setMainSessionEntry(undefined);
+
+      const result = await resolveDeliveryTarget(makeForumBoundCfg(), AGENT_ID, {
+        channel: "forum",
+        to: "room:ops",
+        accountId: explicitAccountId,
+      });
+
+      expect(result.ok).toBe(true);
+      expect(result.accountId).toBe("account-b");
+    },
+  );
+
+  it.each(malformedAccountIdCases)(
+    "falls back to the session for a malformed $description account",
+    async ({ accountId }) => {
+      setLastSessionEntry({
+        sessionId: "sess-malformed-account",
+        lastChannel: "forum",
+        lastTo: "room:ops",
+        lastAccountId: "session-account",
+      });
+
+      const result = await resolveDeliveryTarget(makeForumBoundCfg(), AGENT_ID, {
+        channel: "forum",
+        to: "room:ops",
+        accountId: accountId as unknown as string,
+      });
+
+      expect(result.ok).toBe(true);
+      expect(result.accountId).toBe("session-account");
+    },
+  );
+
+  it.each(malformedAccountIdCases)(
+    "falls back to the bound account for a malformed $description account",
+    async ({ accountId }) => {
+      setMainSessionEntry(undefined);
+
+      const result = await resolveDeliveryTarget(makeForumBoundCfg(), AGENT_ID, {
+        channel: "forum",
+        to: "room:ops",
+        accountId: accountId as unknown as string,
+      });
+
+      expect(result.ok).toBe(true);
+      expect(result.accountId).toBe("account-b");
+    },
+  );
 
   it("preserves binding order when peerless delivery falls back to a bound accountId", async () => {
     setMainSessionEntry(undefined);

--- a/src/cron/isolated-agent/delivery-target.ts
+++ b/src/cron/isolated-agent/delivery-target.ts
@@ -235,9 +235,7 @@ export async function resolveDeliveryTarget(
   // --account on cron add/edit). Fall back to the session's lastAccountId,
   // then to the agent's bound account from bindings config.
   const explicitAccountId =
-    typeof jobPayload.accountId === "string" && jobPayload.accountId.trim()
-      ? jobPayload.accountId.trim()
-      : undefined;
+    typeof jobPayload.accountId === "string" ? jobPayload.accountId.trim() || undefined : undefined;
   let accountId = explicitAccountId ?? resolved.accountId;
   if (!accountId && channel) {
     accountId = deliveryTargetRuntime.resolveFirstBoundAccountId({
@@ -245,11 +243,6 @@ export async function resolveDeliveryTarget(
       channelId: channel,
       agentId,
     });
-  }
-
-  // job.delivery.accountId takes highest precedence — explicitly set by the job author.
-  if (jobPayload.accountId) {
-    accountId = jobPayload.accountId;
   }
 
   if (!channel) {
@@ -492,16 +485,6 @@ export async function resolveDeliveryTarget(
     route?.threadId ??
     parserExplicitThreadId ??
     (canUseSessionThread ? resolved.threadId : undefined);
-  if (options?.dryRun) {
-    return {
-      ok: true,
-      channel,
-      to: toCandidate,
-      accountId,
-      threadId,
-      mode,
-    };
-  }
   return {
     ok: true,
     channel,

--- a/src/cron/isolated-agent/run-delivery-trace.ts
+++ b/src/cron/isolated-agent/run-delivery-trace.ts
@@ -25,7 +25,7 @@ import type {
   CronRunDiagnostics,
 } from "../types.js";
 import { logWarn } from "./run.runtime.js";
-import { resolveCronSourceDeliveryPlan } from "./source-delivery-fallback.js";
+import { resolveCronSourceDeliveryPlan } from "./source-delivery-plan.js";
 
 const cronDeliveryRuntimeLoader = createLazyImportLoader(() => import("./run-delivery.runtime.js"));
 const codexNativeWebSearchLoader = createLazyImportLoader(

--- a/src/cron/isolated-agent/run-executor.ts
+++ b/src/cron/isolated-agent/run-executor.ts
@@ -55,7 +55,6 @@ import type {
   PersistCronSessionEntry,
 } from "./run-session-state.js";
 import { syncCronSessionLiveSelection } from "./run-session-state.js";
-import { resolveFallbackCronSourceDeliveryPlan } from "./source-delivery-fallback.js";
 import { isLikelyInterimCronMessage } from "./subagent-followup-hints.js";
 
 type AgentTurnPayload = Extract<CronJob["payload"], { kind: "agentTurn" }> | null;
@@ -221,7 +220,7 @@ function createCronPromptExecutor(params: {
   resolvedDeliveryOk: boolean;
   messageToolPromptEnabled: boolean;
   deliveryRequested?: boolean;
-  sourceDelivery?: SourceDeliveryPlan;
+  sourceDelivery: SourceDeliveryPlan;
   skillsSnapshot: SkillSnapshot;
   agentPayload: AgentTurnPayload;
   useSubagentFallbacks: boolean;
@@ -268,14 +267,7 @@ function createCronPromptExecutor(params: {
     scheduledToolPolicy: params.job.scheduledToolPolicy,
     owner: params.job.owner,
   });
-  if (!params.sourceDelivery) {
-    logWarn(
-      `[cron:${params.job.id}] sourceDelivery is undefined; using fallback — possible build artifact mismatch`,
-    );
-  }
-  const sourceDelivery =
-    params.sourceDelivery ??
-    resolveFallbackCronSourceDeliveryPlan(params.job, params.resolvedDelivery);
+  const { sourceDelivery } = params;
   const sourceReplyDeliveryMode = sourceDelivery.sourceReplyDeliveryMode;
   const messageChannel = sourceDelivery.target.channel ?? params.resolvedDelivery.channel;
   // Cron prompts may intentionally have nothing to report; both runners must agree on silence.
@@ -636,7 +628,7 @@ export async function executeCronRun(params: {
   resolvedDeliveryOk: boolean;
   messageToolPromptEnabled: boolean;
   deliveryRequested?: boolean;
-  sourceDelivery?: SourceDeliveryPlan;
+  sourceDelivery: SourceDeliveryPlan;
   skillsSnapshot: SkillSnapshot;
   agentPayload: AgentTurnPayload;
   useSubagentFallbacks: boolean;
@@ -675,14 +667,6 @@ export async function executeCronRun(params: {
     sessionId: params.cronSession.sessionEntry.sessionId,
     verboseLevel: resolvedVerboseLevel,
   });
-  if (!params.sourceDelivery) {
-    logWarn(
-      `[cron:${params.job.id}] sourceDelivery is undefined; using fallback — possible build artifact mismatch`,
-    );
-  }
-  const sourceDelivery =
-    params.sourceDelivery ??
-    resolveFallbackCronSourceDeliveryPlan(params.job, params.resolvedDelivery);
   const executor = createCronPromptExecutor({
     cfg: params.cfg,
     cfgWithAgentDefaults: params.cfgWithAgentDefaults,
@@ -704,7 +688,7 @@ export async function executeCronRun(params: {
     resolvedDeliveryOk: params.resolvedDeliveryOk,
     messageToolPromptEnabled: params.messageToolPromptEnabled,
     deliveryRequested: params.deliveryRequested,
-    sourceDelivery,
+    sourceDelivery: params.sourceDelivery,
     skillsSnapshot: params.skillsSnapshot,
     agentPayload: params.agentPayload,
     useSubagentFallbacks: params.useSubagentFallbacks,

--- a/src/cron/isolated-agent/run.source-delivery-guard.test.ts
+++ b/src/cron/isolated-agent/run.source-delivery-guard.test.ts
@@ -16,8 +16,7 @@ import {
 const actualDeliveryPlanModule =
   await vi.importActual<typeof import("../delivery-plan.js")>("../delivery-plan.js");
 const { executeCronRun } = await import("./run-executor.js");
-const { resolveCronSourceDeliveryPlan, resolveFallbackCronSourceDeliveryPlan } =
-  await import("./source-delivery-fallback.js");
+const { resolveCronSourceDeliveryPlan } = await import("./source-delivery-plan.js");
 
 const emptySkillsSnapshot: SkillSnapshot = {
   prompt: "",
@@ -68,7 +67,7 @@ function getEmbeddedRunArg(): Record<string, unknown> {
   return call[0] as Record<string, unknown>;
 }
 
-describe("resolveFallbackCronSourceDeliveryPlan", () => {
+describe("resolveCronSourceDeliveryPlan", () => {
   beforeEach(() => {
     resolveCronDeliveryPlanMock.mockReset();
     resolveCronDeliveryPlanMock.mockImplementation(
@@ -76,13 +75,18 @@ describe("resolveFallbackCronSourceDeliveryPlan", () => {
     );
   });
 
-  it('rebuilds delivery.mode "none" with no owner and unforced message tool', () => {
-    const plan = resolveFallbackCronSourceDeliveryPlan(makeJob({ delivery: { mode: "none" } }), {
-      channel: "messagechat",
-      to: "room-1",
-      accountId: "acct-1",
-      threadId: "thread-1",
-      ok: true,
+  it('prepares delivery.mode "none" with no owner and unforced message tool', () => {
+    const plan = resolveCronSourceDeliveryPlan({
+      deliveryPlan: actualDeliveryPlanModule.resolveCronDeliveryPlan(
+        makeJob({ delivery: { mode: "none" } }),
+      ),
+      resolvedDelivery: {
+        channel: "messagechat",
+        to: "room-1",
+        accountId: "acct-1",
+        threadId: "thread-1",
+        ok: true,
+      },
     });
 
     expect(plan.owner).toBe("none");
@@ -98,15 +102,17 @@ describe("resolveFallbackCronSourceDeliveryPlan", () => {
     });
   });
 
-  it('rebuilds delivery.mode "announce" with direct fallback and unforced message tool', () => {
-    const plan = resolveFallbackCronSourceDeliveryPlan(
-      makeJob({ delivery: { mode: "announce", channel: "messagechat", to: "room-1" } }),
-      {
+  it('prepares delivery.mode "announce" with direct fallback and unforced message tool', () => {
+    const plan = resolveCronSourceDeliveryPlan({
+      deliveryPlan: actualDeliveryPlanModule.resolveCronDeliveryPlan(
+        makeJob({ delivery: { mode: "announce", channel: "messagechat", to: "room-1" } }),
+      ),
+      resolvedDelivery: {
         channel: "messagechat",
         to: "room-1",
         ok: true,
       },
-    );
+    });
 
     expect(plan.owner).toBe("direct_fallback");
     expect(plan.reason).toBe("cron_announce");
@@ -116,11 +122,16 @@ describe("resolveFallbackCronSourceDeliveryPlan", () => {
     expect(plan.fallback.skipWhenMessageToolSentToTarget).toBe(true);
   });
 
-  it('rebuilds delivery.mode "webhook" with message tool disabled', () => {
-    const plan = resolveFallbackCronSourceDeliveryPlan(makeJob({ delivery: { mode: "webhook" } }), {
-      channel: "messagechat",
-      to: "room-1",
-      ok: true,
+  it('prepares delivery.mode "webhook" with message tool disabled', () => {
+    const plan = resolveCronSourceDeliveryPlan({
+      deliveryPlan: actualDeliveryPlanModule.resolveCronDeliveryPlan(
+        makeJob({ delivery: { mode: "webhook" } }),
+      ),
+      resolvedDelivery: {
+        channel: "messagechat",
+        to: "room-1",
+        ok: true,
+      },
     });
 
     expect(plan.owner).toBe("none");
@@ -132,10 +143,15 @@ describe("resolveFallbackCronSourceDeliveryPlan", () => {
   });
 
   it("defaults an isolated agentTurn with no delivery config to announce behavior", () => {
-    const plan = resolveFallbackCronSourceDeliveryPlan(makeJob({ omitDelivery: true }), {
-      channel: "messagechat",
-      to: "room-1",
-      ok: false,
+    const plan = resolveCronSourceDeliveryPlan({
+      deliveryPlan: actualDeliveryPlanModule.resolveCronDeliveryPlan(
+        makeJob({ omitDelivery: true }),
+      ),
+      resolvedDelivery: {
+        channel: "messagechat",
+        to: "room-1",
+        ok: false,
+      },
     });
 
     expect(plan.owner).toBe("direct_fallback");
@@ -145,99 +161,6 @@ describe("resolveFallbackCronSourceDeliveryPlan", () => {
     expect(plan.fallback.directDelivery).toBe(true);
     expect(plan.fallback.skipWhenMessageToolSentToTarget).toBe(false);
   });
-
-  it("preserves duplicate suppression when stale caller omits ok", () => {
-    const plan = resolveFallbackCronSourceDeliveryPlan(
-      makeJob({ delivery: { mode: "announce", channel: "messagechat", to: "room-1" } }),
-      {
-        channel: "messagechat",
-        to: "room-1",
-        // ok intentionally omitted — stale caller shape
-      },
-    );
-
-    expect(plan.owner).toBe("direct_fallback");
-    expect(plan.reason).toBe("cron_announce");
-    expect(plan.fallback.directDelivery).toBe(true);
-    // When ok is absent, default to true to prevent double-posting
-    expect(plan.fallback.skipWhenMessageToolSentToTarget).toBe(true);
-  });
-});
-
-describe("resolveCronSourceDeliveryPlan", () => {
-  beforeEach(() => {
-    resolveCronDeliveryPlanMock.mockReset();
-    resolveCronDeliveryPlanMock.mockImplementation(
-      actualDeliveryPlanModule.resolveCronDeliveryPlan,
-    );
-  });
-
-  const cases: Array<{
-    name: string;
-    job: CronJob;
-    resolvedDelivery: {
-      channel?: string;
-      accountId?: string;
-      to?: string;
-      threadId?: string | number;
-      ok?: boolean;
-    };
-  }> = [
-    {
-      name: "none",
-      job: makeJob({ delivery: { mode: "none" } }),
-      resolvedDelivery: {
-        channel: "messagechat",
-        accountId: "acct-1",
-        to: "room-1",
-        threadId: "thread-1",
-        ok: true,
-      },
-    },
-    {
-      name: "announce",
-      job: makeJob({ delivery: { mode: "announce", channel: "messagechat", to: "room-1" } }),
-      resolvedDelivery: {
-        channel: "messagechat",
-        to: "room-1",
-        ok: true,
-      },
-    },
-    {
-      name: "webhook",
-      job: makeJob({ delivery: { mode: "webhook" } }),
-      resolvedDelivery: {
-        channel: "messagechat",
-        to: "room-1",
-        ok: true,
-      },
-    },
-    {
-      name: "implicit announce",
-      job: makeJob({ omitDelivery: true }),
-      resolvedDelivery: {
-        channel: "messagechat",
-        to: "room-1",
-        ok: false,
-      },
-    },
-  ];
-
-  for (const testCase of cases) {
-    it(`matches the fallback wrapper for ${testCase.name}`, () => {
-      const deliveryPlan = actualDeliveryPlanModule.resolveCronDeliveryPlan(testCase.job);
-      const normalPathPlan = resolveCronSourceDeliveryPlan({
-        deliveryPlan,
-        resolvedDelivery: testCase.resolvedDelivery,
-      });
-      const fallbackPathPlan = resolveFallbackCronSourceDeliveryPlan(
-        testCase.job,
-        testCase.resolvedDelivery,
-      );
-
-      expect(normalPathPlan).toEqual(fallbackPathPlan);
-    });
-  }
 });
 
 describe("executeCronRun sourceDelivery mapping", () => {
@@ -255,12 +178,11 @@ describe("executeCronRun sourceDelivery mapping", () => {
     restoreFastTestEnv(previousFastTestEnv);
   });
 
-  it('falls back from delivery.mode "none" with messageToolForced false and owner none', async () => {
+  it('uses prepared delivery.mode "none" with messageToolForced false and owner none', async () => {
     mockRunCronFallbackPassthrough();
     const executor = makeExecutor({
       job: makeJob({ delivery: { mode: "none" } }),
       deliveryRequested: false,
-      sourceDelivery: undefined,
       resolvedDelivery: {
         channel: "messagechat",
         accountId: "acct-1",
@@ -282,12 +204,11 @@ describe("executeCronRun sourceDelivery mapping", () => {
     expect(args.messageThreadId).toBe("thread-99");
   });
 
-  it('falls back from delivery.mode "announce" with direct fallback semantics', async () => {
+  it('uses prepared delivery.mode "announce" with direct fallback semantics', async () => {
     mockRunCronFallbackPassthrough();
     const executor = makeExecutor({
       job: makeJob({ delivery: { mode: "announce", channel: "messagechat", to: "123" } }),
       deliveryRequested: true,
-      sourceDelivery: undefined,
       resolvedDelivery: { ok: true, channel: "messagechat", to: "123" },
     });
 
@@ -304,12 +225,11 @@ describe("executeCronRun sourceDelivery mapping", () => {
     expect(args.messageTo).toBe("123");
   });
 
-  it('falls back from delivery.mode "webhook" with message tool disabled', async () => {
+  it('uses prepared delivery.mode "webhook" with message tool disabled', async () => {
     mockRunCronFallbackPassthrough();
     const executor = makeExecutor({
       job: makeJob({ delivery: { mode: "webhook" } }),
       deliveryRequested: false,
-      sourceDelivery: undefined,
       resolvedDelivery: { channel: "messagechat", to: "123" },
     });
 
@@ -324,12 +244,11 @@ describe("executeCronRun sourceDelivery mapping", () => {
     expect(args.messageChannel).toBe("messagechat");
   });
 
-  it("falls back with announce behavior when isolated agentTurn has no delivery config", async () => {
+  it("uses prepared announce behavior when isolated agentTurn has no delivery config", async () => {
     mockRunCronFallbackPassthrough();
     const executor = makeExecutor({
       job: makeJob({ omitDelivery: true }),
       deliveryRequested: true,
-      sourceDelivery: undefined,
       resolvedDelivery: { channel: "messagechat", to: "123" },
     });
 
@@ -344,11 +263,10 @@ describe("executeCronRun sourceDelivery mapping", () => {
     expect(args.messageChannel).toBe("messagechat");
   });
 
-  it("ignores stale legacy fields when sourceDelivery is missing", async () => {
+  it("uses the prepared plan instead of stale legacy delivery fields", async () => {
     mockRunCronFallbackPassthrough();
     const executor = makeExecutor({
       job: makeJob({ delivery: { mode: "announce", channel: "messagechat", to: "123" } }),
-      sourceDelivery: undefined,
       resolvedDelivery: { channel: "messagechat", to: "123" },
       messageChannel: "legacychat",
       toolPolicy: {
@@ -376,7 +294,6 @@ describe("executeCronRun sourceDelivery mapping", () => {
       job: makeJob({ delivery: { mode: "announce", channel: "messagechat", to: "123" } }),
       deliveryRequested: true,
       resolvedDeliveryOk: false,
-      sourceDelivery: undefined,
       resolvedDelivery: { ok: false, channel: "messagechat", to: "123" },
     });
 
@@ -386,7 +303,7 @@ describe("executeCronRun sourceDelivery mapping", () => {
     expect(getEmbeddedRunArg().terminalReplyExpectation).toBe("optional");
   });
 
-  it("still works with a valid sourceDelivery", async () => {
+  it("preserves an explicitly prepared message-tool source delivery", async () => {
     mockRunCronFallbackPassthrough();
     const executor = makeExecutor({
       sourceDelivery: createSourceDeliveryPlan({
@@ -402,6 +319,7 @@ describe("executeCronRun sourceDelivery mapping", () => {
 
     await executor.runPrompt("send a message");
 
+    expect(resolveCronDeliveryPlanMock).not.toHaveBeenCalled();
     expect(runEmbeddedAgentMock).toHaveBeenCalledTimes(1);
     const args = getEmbeddedRunArg();
     expect(args.sourceReplyDeliveryMode).toBe("message_tool_only");
@@ -446,10 +364,19 @@ describe("executeCronRun sourceDelivery mapping", () => {
 });
 
 function makeExecuteCronRunParams(overrides: Record<string, unknown> = {}) {
+  const job = (overrides.job ?? makeJob()) as CronJob;
+  const resolvedDelivery = (overrides.resolvedDelivery ?? {}) as {
+    channel?: string;
+    accountId?: string;
+    to?: string;
+    threadId?: string | number;
+    ok?: boolean;
+  };
+
   return {
     cfg: {},
     cfgWithAgentDefaults: {},
-    job: makeJob(),
+    job,
     agentId: "default",
     agentDir: "/tmp/agent-dir",
     agentSessionKey: "cron:source-delivery-guard",
@@ -471,67 +398,11 @@ function makeExecuteCronRunParams(overrides: Record<string, unknown> = {}) {
     thinkLevel: undefined,
     timeoutMs: 60_000,
     suppressExecNotifyOnExit: true,
-    resolvedDelivery: {},
-    sourceDelivery: undefined,
+    resolvedDelivery,
+    sourceDelivery: resolveCronSourceDeliveryPlan({
+      deliveryPlan: actualDeliveryPlanModule.resolveCronDeliveryPlan(job),
+      resolvedDelivery,
+    }),
     ...overrides,
   } as never;
 }
-
-describe("executeCronRun sourceDelivery guard", () => {
-  let previousFastTestEnv: string | undefined;
-
-  beforeEach(() => {
-    resetRunCronIsolatedAgentTurnHarness();
-    resolveCronDeliveryPlanMock.mockImplementation(
-      actualDeliveryPlanModule.resolveCronDeliveryPlan,
-    );
-    previousFastTestEnv = clearFastTestEnv();
-  });
-
-  afterEach(() => {
-    restoreFastTestEnv(previousFastTestEnv);
-  });
-
-  it("rebuilds fallback from job delivery config and ignores stale legacy params", async () => {
-    mockRunCronFallbackPassthrough();
-    await executeCronRun(
-      makeExecuteCronRunParams({
-        job: makeJob({ delivery: { mode: "none" } }),
-        sourceDelivery: undefined,
-        resolvedDelivery: { channel: "messagechat", to: "123" },
-        messageChannel: "legacychat",
-        toolPolicy: {
-          disableMessageTool: true,
-          forceMessageTool: true,
-          requireExplicitMessageTarget: true,
-        },
-        sourceReplyDeliveryMode: "message_tool_only",
-      }),
-    );
-
-    expect(runEmbeddedAgentMock).toHaveBeenCalledTimes(1);
-    const args = getEmbeddedRunArg();
-    expect(args.messageChannel).toBe("messagechat");
-    expect(args.sourceReplyDeliveryMode).toBeUndefined();
-    expect(args.disableMessageTool).toBe(false);
-    expect(args.forceMessageTool).toBe(false);
-    expect(args.requireExplicitMessageTarget).toBe(false);
-  });
-
-  it('rebuilds delivery.mode "webhook" with message tool disabled through executeCronRun', async () => {
-    mockRunCronFallbackPassthrough();
-    await executeCronRun(
-      makeExecuteCronRunParams({
-        job: makeJob({ delivery: { mode: "webhook" } }),
-        sourceDelivery: undefined,
-        resolvedDelivery: { channel: "messagechat", to: "202" },
-      }),
-    );
-
-    expect(runEmbeddedAgentMock).toHaveBeenCalledTimes(1);
-    const args = getEmbeddedRunArg();
-    expect(args.sourceReplyDeliveryMode).toBeUndefined();
-    expect(args.disableMessageTool).toBe(true);
-    expect(args.forceMessageTool).toBe(false);
-  });
-});

--- a/src/cron/isolated-agent/source-delivery-plan.ts
+++ b/src/cron/isolated-agent/source-delivery-plan.ts
@@ -1,8 +1,6 @@
 import { createSourceDeliveryPlan } from "../../infra/outbound/source-delivery-plan.js";
 import type { SourceDeliveryPlan } from "../../infra/outbound/source-delivery-plan.js";
-import { resolveCronDeliveryPlan } from "../delivery-plan.js";
 import type { CronDeliveryPlan } from "../delivery-plan.js";
-import type { CronJob } from "../types.js";
 
 type CronSourceDeliveryResolvedTarget = {
   channel?: string;
@@ -54,12 +52,4 @@ export function resolveCronSourceDeliveryPlan(params: {
     directFallback: true,
     skipFallbackWhenMessageToolSentToTarget: params.resolvedDelivery.ok ?? true,
   });
-}
-
-export function resolveFallbackCronSourceDeliveryPlan(
-  job: CronJob,
-  resolvedDelivery: CronSourceDeliveryResolvedTarget,
-): SourceDeliveryPlan {
-  const deliveryPlan = resolveCronDeliveryPlan(job);
-  return resolveCronSourceDeliveryPlan({ deliveryPlan, resolvedDelivery });
 }


### PR DESCRIPTION
## What Problem This Solves\n\nFixes an issue where whitespace-padded, empty, or malformed cron delivery account selections could override the correctly resolved session or account binding. Removes duplicated source-delivery planning that allowed prepared execution state to diverge from the actual delivery path.\n\n## Why This Change Was Made\n\nNormalize explicitly configured string account IDs once, preserve the persisted-input type guard and existing account fallback precedence, and pass one required prepared source-delivery plan through execution instead of recalculating defensive alternatives. Remove the identical dry-run-only success return and retire the obsolete fallback-named internal module. No public dry-run option, channel, provider, persisted format, or plugin API is removed.\n\n## User Impact\n\nCron announcements choose the intended bound account consistently, malformed stored account values do not crash delivery, and prompts, message-tool decisions, and direct fallback all use the same prepared target. The combined production and regression change removes more code than it adds.\n\n## Evidence\n\n- Baseline: 7ebd486ed127580c7edc9b7e3f1b142898ce070a; latest main has no overlapping changes in any touched path.\n- Delivery target, inheritance safety, and preview suites: 75 passed, including 11 table-driven whitespace, malformed number/boolean/object, session-fallback, and binding-fallback regressions.\n- Prepared delivery guard and message-tool policy suites: 69 passed.\n- Source-level whole-caller audit: every production executeCronRun call originates from src/cron/isolated-agent/run.ts, passes prepared.context.sourceDelivery, and forwards that same required plan into createCronPromptExecutor; all three delivery-trace branches prepare their plan through resolveCronSourceDeliveryPlan. No retired fallback-module references remain.\n- Fresh independent autoreview of the exact combined branch: no accepted or actionable findings; secret scan clean.\n- Combined branch git diff --check: passed; net change 163 insertions and 240 deletions.\n- Exact-head hosted CI: all checks passed; openclaw/ci-gate succeeded.\n- ClawSweeper rank-up resolution: source-level executor audit completed above. The requested account-normalization and fallback evidence is supplied by the 11 deterministic regression cases and 75 passing account, inheritance, and preview tests; a credentialed live channel send is not performed because this bounded internal fix does not require accessing user accounts or provider credentials.