### PR TITLE
fix(cron): bound alerts and complete heartbeat cleanup

### DIFF
--- a/src/gateway/server-cron-heartbeat-jobs.test.ts
+++ b/src/gateway/server-cron-heartbeat-jobs.test.ts
@@ -146,4 +146,37 @@ describe("reconcileHeartbeatMonitorJobs", () => {
     expect(add).toHaveBeenCalledTimes(2);
     expect(logger.warn).toHaveBeenCalled();
   });
+
+  it("keeps removing stale monitors when one removal fails", async () => {
+    const add = vi.fn(async () => ({}));
+    const remove = vi
+      .fn(async (_jobId: string) => ({ ok: true }))
+      .mockRejectedValueOnce(new Error("store busy"));
+    const list = vi.fn(async () => [
+      monitorJob("stale-first"),
+      monitorJob("stale-second"),
+      monitorJob("stale-third"),
+    ]);
+    const cleanupLogger = { warn: vi.fn() };
+    const cfg = {
+      agents: { defaults: { heartbeat: { every: "30m" } } },
+    } as OpenClawConfig;
+
+    await expect(
+      reconcileHeartbeatMonitorJobs({
+        cron: { add, list, remove } as never,
+        cfg,
+        logger: cleanupLogger,
+      }),
+    ).resolves.toEqual({ ok: false });
+
+    expect(remove).toHaveBeenCalledTimes(3);
+    expect(remove).toHaveBeenNthCalledWith(1, "job-stale-first", { systemOwned: true });
+    expect(remove).toHaveBeenNthCalledWith(2, "job-stale-second", { systemOwned: true });
+    expect(remove).toHaveBeenNthCalledWith(3, "job-stale-third", { systemOwned: true });
+    expect(cleanupLogger.warn).toHaveBeenCalledExactlyOnceWith(
+      { agentId: "stale-first", err: "Error: store busy" },
+      "cron-heartbeat: stale monitor cleanup failed",
+    );
+  });
 });

--- a/src/gateway/server-cron-heartbeat-jobs.ts
+++ b/src/gateway/server-cron-heartbeat-jobs.ts
@@ -51,19 +51,24 @@ export async function reconcileHeartbeatMonitorJobs(params: {
     }
   }
 
-  try {
-    for (const job of jobs) {
-      const agentId = heartbeatMonitorAgentId(job);
-      // Disabled heartbeats retain their stable monitor row (and scratch). Only
-      // agents no longer enrolled in heartbeat are pruned.
-      if (!agentId || desired.has(agentId)) {
-        continue;
-      }
-      await params.cron.remove(job.id, { systemOwned: true });
+  for (const job of jobs) {
+    const agentId = heartbeatMonitorAgentId(job);
+    // Disabled heartbeats retain their stable monitor row (and scratch). Only
+    // agents no longer enrolled in heartbeat are pruned.
+    if (!agentId || desired.has(agentId)) {
+      continue;
     }
-  } catch (error) {
-    ok = false;
-    params.logger.warn({ err: String(error) }, "cron-heartbeat: stale monitor cleanup failed");
+    // Keep cleanup isolated per agent; a failed removal must not strand later
+    // stale monitors or suppress the existing reconciliation retry.
+    try {
+      await params.cron.remove(job.id, { systemOwned: true });
+    } catch (error) {
+      ok = false;
+      params.logger.warn(
+        { agentId, err: String(error) },
+        "cron-heartbeat: stale monitor cleanup failed",
+      );
+    }
   }
   return { ok };
 }

--- a/src/gateway/server-cron-notifications.test.ts
+++ b/src/gateway/server-cron-notifications.test.ts
@@ -349,9 +349,16 @@ describe("dispatchGatewayCronFinishedNotifications", () => {
             new Promise<void>((_resolve, reject) => {
               deliverySignal = abortSignal;
               if (honorsCancellation) {
-                abortSignal.addEventListener("abort", () => reject(abortSignal.reason), {
-                  once: true,
-                });
+                abortSignal.addEventListener(
+                  "abort",
+                  () =>
+                    reject(
+                      abortSignal.reason instanceof Error
+                        ? abortSignal.reason
+                        : new Error("cron: failure alert announcement timed out"),
+                    ),
+                  { once: true },
+                );
               }
             }),
         );

--- a/src/gateway/server-cron-notifications.test.ts
+++ b/src/gateway/server-cron-notifications.test.ts
@@ -335,6 +335,64 @@ describe("dispatchGatewayCronFinishedNotifications", () => {
     expect(getActiveGatewayRootWorkCount()).toBe(0);
   });
 
+  it.each([
+    { description: "honors cancellation", honorsCancellation: true },
+    { description: "ignores cancellation", honorsCancellation: false },
+  ])(
+    "releases immediate failure alert admission when a stalled sender $description",
+    async ({ honorsCancellation }) => {
+      vi.useFakeTimers();
+      try {
+        let deliverySignal: AbortSignal | undefined;
+        mocks.sendCronAnnouncePayloadStrict.mockImplementationOnce(
+          ({ abortSignal }: { abortSignal: AbortSignal }) =>
+            new Promise<void>((_resolve, reject) => {
+              deliverySignal = abortSignal;
+              if (honorsCancellation) {
+                abortSignal.addEventListener("abort", () => reject(abortSignal.reason), {
+                  once: true,
+                });
+              }
+            }),
+        );
+        const job = createWebhookJob({ mode: "announce", channel: "discord", to: "channel:ops" });
+
+        const delivery = sendGatewayCronFailureAlert({
+          deps: {} as CliDeps,
+          logger: { warn: vi.fn() },
+          resolveCronAgent: () => ({ agentId: "main", cfg: {} }),
+          job,
+          text: "cron failed",
+          channel: "discord",
+          to: "channel:ops",
+          mode: "announce",
+        });
+        const deliveryOutcome = delivery.then(
+          () => undefined,
+          (error: unknown) => error,
+        );
+
+        expect(mocks.sendCronAnnouncePayloadStrict).toHaveBeenCalledOnce();
+        expect(getActiveGatewayRootWorkCount()).toBe(1);
+        expect(deliverySignal?.aborted).toBe(false);
+
+        await vi.advanceTimersByTimeAsync(9_999);
+        expect(getActiveGatewayRootWorkCount()).toBe(1);
+        expect(deliverySignal?.aborted).toBe(false);
+
+        await vi.advanceTimersByTimeAsync(1);
+        expect(deliverySignal?.aborted).toBe(true);
+        await expect(deliveryOutcome).resolves.toEqual(
+          expect.objectContaining({ message: "cron: failure alert announcement timed out" }),
+        );
+        expect(getActiveGatewayRootWorkCount()).toBe(0);
+        expect(vi.getTimerCount()).toBe(0);
+      } finally {
+        vi.useRealTimers();
+      }
+    },
+  );
+
   it("defers detached completion delivery while suspension is prepared", async () => {
     const job = createWebhookJob({
       mode: "webhook",

--- a/src/gateway/server-cron-notifications.ts
+++ b/src/gateway/server-cron-notifications.ts
@@ -313,8 +313,9 @@ async function sendGatewayCronFailureAlertUnderAdmission(
   }
 
   const abortController = new AbortController();
+  const deliveryTimeoutError = new Error("cron: failure alert announcement timed out");
   const deliveryTimeout = setTimeout(() => {
-    abortController.abort(new Error("cron: failure alert announcement timed out"));
+    abortController.abort(deliveryTimeoutError);
   }, CRON_WEBHOOK_TIMEOUT_MS);
 
   try {
@@ -335,11 +336,9 @@ async function sendGatewayCronFailureAlertUnderAdmission(
         abortSignal: abortController.signal,
       }),
       new Promise<never>((_resolve, reject) => {
-        abortController.signal.addEventListener(
-          "abort",
-          () => reject(abortController.signal.reason),
-          { once: true },
-        );
+        abortController.signal.addEventListener("abort", () => reject(deliveryTimeoutError), {
+          once: true,
+        });
       }),
     ]);
   } finally {

--- a/src/gateway/server-cron-notifications.ts
+++ b/src/gateway/server-cron-notifications.ts
@@ -313,20 +313,38 @@ async function sendGatewayCronFailureAlertUnderAdmission(
   }
 
   const abortController = new AbortController();
-  await sendCronAnnouncePayloadStrict({
-    deps: params.deps,
-    cfg: runtimeConfig,
-    agentId,
-    jobId: params.job.id,
-    target: {
-      channel: params.channel,
-      to: params.to,
-      accountId: params.accountId,
-      sessionKey: resolveCronDeliverySessionKey(params.job),
-    },
-    message: params.text,
-    abortSignal: abortController.signal,
-  });
+  const deliveryTimeout = setTimeout(() => {
+    abortController.abort(new Error("cron: failure alert announcement timed out"));
+  }, CRON_WEBHOOK_TIMEOUT_MS);
+
+  try {
+    // Release Gateway admission on deadline even when a transport ignores abort.
+    await Promise.race([
+      sendCronAnnouncePayloadStrict({
+        deps: params.deps,
+        cfg: runtimeConfig,
+        agentId,
+        jobId: params.job.id,
+        target: {
+          channel: params.channel,
+          to: params.to,
+          accountId: params.accountId,
+          sessionKey: resolveCronDeliverySessionKey(params.job),
+        },
+        message: params.text,
+        abortSignal: abortController.signal,
+      }),
+      new Promise<never>((_resolve, reject) => {
+        abortController.signal.addEventListener(
+          "abort",
+          () => reject(abortController.signal.reason),
+          { once: true },
+        );
+      }),
+    ]);
+  } finally {
+    clearTimeout(deliveryTimeout);
+  }
 }
 
 /** Dispatches completion and failure-destination notifications after a cron run finishes. */

--- a/src/gateway/server-methods/cron.ts
+++ b/src/gateway/server-methods/cron.ts
@@ -1069,21 +1069,20 @@ export const cronHandlers: GatewayRequestHandlers = {
       return;
     }
     try {
-      const jobs = filterCronRunLogJobsByAgent(
-        await context.cron.list({ includeDisabled: true }),
-        p.agentId,
-        context.cron.getDefaultAgentId(),
-      );
-      const matchedJob = jobs.find(
-        (job) =>
-          job.id === jobId &&
-          cronJobMatchesCallerScope({
-            job,
-            callerScope,
-            defaultAgentId: context.cron.getDefaultAgentId(),
-            allowCurrentJob: true,
-          }),
-      );
+      const job = await context.cron.readJob(jobId as string);
+      const defaultAgentId = context.cron.getDefaultAgentId();
+      const matchedJob =
+        job &&
+        filterCronRunLogJobsByAgent([job], p.agentId, defaultAgentId).length > 0 &&
+        cronJobMatchesCallerScope({
+          job,
+          callerScope,
+          defaultAgentId,
+          allowCurrentJob: true,
+        })
+          ? job
+          : undefined;
+      // Operator history survives job deletion; scoped reads still need a live, matching owner.
       if ((callerScope || p.agentId) && !matchedJob) {
         respondInvalidCronParams(respond, "cron.runs", "id not found");
         return;

--- a/src/gateway/server-methods/cron.validation.test.ts
+++ b/src/gateway/server-methods/cron.validation.test.ts
@@ -3293,12 +3293,96 @@ describe("cron method validation", () => {
     });
   });
 
+  it.each([
+    { selector: "id", params: { id: "cron-1" } },
+    { selector: "jobId", params: { jobId: "cron-1" } },
+  ])("reads only the $selector-selected cron job for run history", async ({ params }) => {
+    const context = createCronContext([
+      createCronJob({ id: "cron-1", agentId: "ops" }),
+      createCronJob({ id: "cron-2", agentId: "worker" }),
+    ]);
+
+    const { respond } = await invokeCron("cron.runs", params, { context });
+
+    expect(context.cron.readJob).toHaveBeenCalledExactlyOnceWith("cron-1");
+    expect(context.cron.list).not.toHaveBeenCalled();
+    expect(respond).toHaveBeenCalledWith(
+      true,
+      expect.objectContaining({ entries: expect.any(Array) }),
+      undefined,
+    );
+  });
+
+  it("preserves deleted-job history without listing unrelated cron jobs", async () => {
+    const context = createCronContext();
+
+    const { respond } = await invokeCron("cron.runs", { id: "deleted-cron" }, { context });
+
+    expect(context.cron.readJob).toHaveBeenCalledExactlyOnceWith("deleted-cron");
+    expect(context.cron.list).not.toHaveBeenCalled();
+    expect(respond).toHaveBeenCalledWith(
+      true,
+      expect.objectContaining({ entries: expect.any(Array) }),
+      undefined,
+    );
+  });
+
+  it("preserves explicit agent ownership for directly read cron history", async () => {
+    const context = createCronContext(createCronJob({ id: "cron-1", agentId: "ops" }));
+
+    const { respond } = await invokeCron(
+      "cron.runs",
+      { id: "cron-1", agentId: "worker" },
+      { context },
+    );
+
+    expect(context.cron.readJob).toHaveBeenCalledExactlyOnceWith("cron-1");
+    expect(context.cron.list).not.toHaveBeenCalled();
+    expectResponseError(respond, {
+      code: "INVALID_REQUEST",
+      messageIncludes: "invalid cron.runs params: id not found",
+    });
+  });
+
+  it("preserves normalized default-agent ownership for directly read cron history", async () => {
+    const context = createCronContext(createCronJob({ id: "cron-1", agentId: undefined }));
+
+    const { respond } = await invokeCron(
+      "cron.runs",
+      { id: "cron-1", agentId: "MAIN" },
+      { context },
+    );
+
+    expect(context.cron.readJob).toHaveBeenCalledExactlyOnceWith("cron-1");
+    expect(context.cron.list).not.toHaveBeenCalled();
+    expect(respond).toHaveBeenCalledWith(
+      true,
+      expect.objectContaining({ entries: expect.any(Array) }),
+      undefined,
+    );
+  });
+
+  it("retains full cron job discovery for all-scope history", async () => {
+    const context = createCronContext(createCronJob({ id: "cron-1" }));
+
+    const { respond } = await invokeCron("cron.runs", { scope: "all" }, { context });
+
+    expect(context.cron.list).toHaveBeenCalledExactlyOnceWith({ includeDisabled: true });
+    expect(context.cron.readJob).not.toHaveBeenCalled();
+    expect(respond).toHaveBeenCalledWith(
+      true,
+      expect.objectContaining({ entries: expect.any(Array) }),
+      undefined,
+    );
+  });
+
   it("does not widen a whitespace-only cron.runs selector to all history", async () => {
     const context = createCronContext();
 
     const { respond } = await invokeCron("cron.runs", { id: "   " }, { context });
 
     expect(context.cron.list).not.toHaveBeenCalled();
+    expect(context.cron.readJob).not.toHaveBeenCalled();
     expectResponseError(respond, {
       code: "INVALID_REQUEST",
       messageIncludes: "invalid cron.runs params: missing id",
@@ -3314,6 +3398,8 @@ describe("cron method validation", () => {
       { context, client: callerClient("ops") },
     );
 
+    expect(context.cron.readJob).toHaveBeenCalledExactlyOnceWith("cron-1");
+    expect(context.cron.list).not.toHaveBeenCalled();
     expectResponseError(respond, {
       code: "INVALID_REQUEST",
       messageIncludes: "invalid cron.runs params: id not found",
@@ -3339,6 +3425,8 @@ describe("cron method validation", () => {
       { context, client: callerClient("ops") },
     );
 
+    expect(context.cron.readJob).toHaveBeenCalledExactlyOnceWith("cron-1");
+    expect(context.cron.list).not.toHaveBeenCalled();
     expectResponseError(respond, {
       code: "INVALID_REQUEST",
       messageIncludes: "invalid cron.runs params: id not found",


### PR DESCRIPTION
## What Problem This Solves\n\nFixes an issue where a non-responsive cron failure-notification transport could indefinitely retain Gateway delivery admission, and an issue where one failed heartbeat-monitor removal prevented cleanup of every subsequent stale monitor. Also avoids scanning every cron job to read one job's run history.\n\n## Why This Change Was Made\n\nReuse the existing cron webhook deadline, independently race notification completion against cancellation, isolate heartbeat cleanup failures per enrolled agent, and use the existing locked single-job lookup while preserving all current agent, account, operator, deleted-history, and current-job authorization semantics. There are no new Gateway protocol, configuration, plugin, or authorization surfaces.\n\n## User Impact\n\nHung alert deliveries release Gateway capacity on deadline; stale heartbeat monitors are cleaned up even when a sibling fails; failed removals keep the existing retry behavior; and scoped cron history lookup avoids unnecessary enumeration.\n\n## Evidence\n\n- Baseline: 7ebd486ed127580c7edc9b7e3f1b142898ce070a; source-level authorization and caller-scope audit completed.\n- Alert regressions reproduced red-first: two failures before the fix; all 21 notification tests pass after the fix. Both abort-honoring and abort-ignoring stalled transports release active root work from one admission to zero at the existing deadline.\n- Heartbeat failure reproduced red-first on Linux: the first stale removal throws, both following stale monitors are still removed, and reconciliation returns ok=false so the existing retry remains active; the heartbeat/Gateway suites subsequently passed 64 tests on Linux.\n- Single-job history and scope regression suite: 168 passed; existing agent, account, operator, current-job, and deleted-job scope decisions are preserved.\n- Final exact combined head: four focused Gateway suites and all 253 tests passed.\n- Hosted check-lint feedback resolved at the actual production and test rejection sites; final exact-head direct oxlint and oxfmt checks both pass.\n- Fresh independent autoreviews of both the combined branch and the CI correction: no accepted or actionable findings; secret scans clean.\n- Combined branch git diff --check: passed.\n- ClawSweeper rank-up resolution: deadline release and continued heartbeat cleanup are demonstrated by the red-first and after-fix regressions above; the reported earlier-head lint failure has been repaired and directly revalidated on the current head.