### PR TITLE
fix(ui): prevent Workboard dashboard verification races

### DIFF
--- a/ui/src/pages/workboard/workboard-card-dashboard.test.ts
+++ b/ui/src/pages/workboard/workboard-card-dashboard.test.ts
@@ -43,9 +43,10 @@ async function mountDashboard(
   element.connected = true;
   document.body.append(element);
   mounted.push(element);
-  await vi.waitFor(() =>
-    expect(element.querySelector(".workboard-card-dashboard__toggle")).not.toBeNull(),
-  );
+  // The provider is acquired in updated(), after the first DOM render.
+  // Await the real lifecycle so a loaded runner cannot observe the toggle early.
+  await element.updateComplete;
+  expect(element.querySelector(".workboard-card-dashboard__toggle")).not.toBeNull();
   return element;
 }
 


### PR DESCRIPTION
## What Problem This Solves

Resolves a newly reproduced Workboard dashboard lifecycle race where the combined cron, gateway, Workboard, and UI stress suite failed three dashboard checks under parallel load because the rendered toggle became observable before the component finished acquiring its board provider.

## Why This Change Was Made

Await the Lit component's actual first `updateComplete` lifecycle in the shared dashboard mount helper before checking its rendered toggle. This matches the neighboring Workboard panel lifecycle regression and avoids both timer-based guesses and changes to production behavior.

## User Impact

More reliable Workboard dashboard and cron verification under parallel load. No change to shipped product behavior.

## Evidence

- Before: the fresh-main 73-file, eight-shard stress run failed all three board-provider dashboard lifecycle assertions.
- After: the identical 73-file, eight-shard stress run passed all 1,693 tests.
- Five additional parallel race passes: 1,420 passing cron, watcher, dispatcher, invalidation, and dashboard tests.
- Real Chromium: 57 passing tests across nine Workboard, dashboard, sessions, routing, and cron-filter browser files.
- Six real isolated-gateway QA scheduling scenarios, including natural duplicate prevention, condition-watcher timers, one-shot delivery, side-effect recovery, and heartbeat coverage; six passed, none skipped.
- Fresh production and test typechecks after clearing all six incremental tsgo caches.
- `.agents/skills/autoreview/scripts/autoreview --mode uncommitted`: clean; no accepted or actionable findings.
- AI-assisted, maintainer-requested cron and Workboard stress sweep.
