### PR TITLE
fix(ui): allow clearing unavailable worktree

### DIFF
--- a/ui/src/e2e/new-session-page.e2e.test.ts
+++ b/ui/src/e2e/new-session-page.e2e.test.ts
@@ -961,6 +961,74 @@ describeControlUiE2e("Control UI new-session page mocked Gateway E2E", () => {
     }
   });
 
+  it("lets users clear an explicit worktree choice after Git rediscovery fails", async () => {
+    const context = await browser.newContext({ locale: "en-US", serviceWorkers: "block" });
+    const page = await context.newPage();
+    const gateway = await installMockGateway(page, {
+      workspace: WORKSPACE,
+      workspaceGit: true,
+      methodResponses: {
+        "worktrees.branches": {
+          branches: [{ kind: "local", name: "main" }],
+          defaultBranch: "main",
+          repositoryStatus: "git",
+        },
+        "fs.listDir": {
+          cases: [
+            {
+              match: { path: WORKSPACE },
+              response: {
+                path: WORKSPACE,
+                parent: "/home/peter",
+                home: "/home/peter",
+                entries: [{ name: "packages", path: PICKED }],
+              },
+            },
+            {
+              match: { path: PICKED },
+              response: { path: PICKED, parent: WORKSPACE, home: "/home/peter", entries: [] },
+            },
+          ],
+        },
+        "sessions.create": { key: "agent:main:worktree-recovery", runStarted: true },
+      },
+    });
+    try {
+      await page.goto(`${server.baseUrl}new`);
+      await choosePackagesFolder(page);
+      await page.locator(".new-session-page__message").fill("continue without a worktree");
+      await gateway.deferNext("worktrees.branches");
+
+      const placeTrigger = page.locator("#new-session-place-trigger");
+      await placeTrigger.click();
+      const worktree = page.getByRole("button", { name: "Worktree" });
+      await worktree.click();
+      await gateway.waitForRequest("worktrees.branches");
+      await gateway.rejectDeferred("worktrees.branches", {
+        code: "UNAVAILABLE",
+        message: "branch lookup unavailable",
+      });
+
+      const start = page.getByRole("button", { name: "Start thread" });
+      await expect.poll(() => placeTrigger.getAttribute("data-worktree")).toBe("true");
+      await expect.poll(() => start.isDisabled()).toBe(true);
+      await expect.poll(() => worktree.isEnabled()).toBe(true);
+      await worktree.click();
+      await expect.poll(() => placeTrigger.getAttribute("data-worktree")).toBe("false");
+      await expect.poll(() => start.isDisabled()).toBe(false);
+
+      await start.click();
+      const create = await gateway.waitForRequest("sessions.create");
+      expect(create.params).toMatchObject({
+        cwd: PICKED,
+        message: "continue without a worktree",
+      });
+      expect(create.params).not.toHaveProperty("worktree");
+    } finally {
+      await context.close();
+    }
+  });
+
   it("blocks an immediate submit until remembered model and worktree choices validate", async () => {
     const context = await browser.newContext({ locale: "en-US", serviceWorkers: "block" });
     const page = await context.newPage();

--- a/ui/src/pages/new-session/place-picker.ts
+++ b/ui/src/pages/new-session/place-picker.ts
@@ -399,7 +399,9 @@ export function renderPlaceSelect(params: {
                         value: "worktree",
                         label: t("newSession.worktree"),
                         checked: params.worktree,
-                        disabled: Boolean(params.cloudProfileId) || !params.worktreeAvailable,
+                        disabled:
+                          Boolean(params.cloudProfileId) ||
+                          (!params.worktreeAvailable && !params.worktree),
                         title: params.cloudProfileId
                           ? t("newSession.cloudRequiresWorktree")
                           : params.worktreeAvailable


### PR DESCRIPTION
Closes #114361

## What Problem This Solves

Fixes an issue where users who explicitly enabled **Worktree** could become trapped in an unsubmittable new-session draft when Git rediscovery later failed. The checked toggle became disabled, so the user could not clear the invalid selection.

## Why This Change Was Made

An unavailable repository now prevents enabling Worktree, but does not disable an already-checked toggle. Cloud-profile worktrees remain locked because that workflow requires the selection.

## User Impact

Users can clear the stale Worktree choice and continue creating an ordinary session without changing folders or reloading the page.

## Evidence

- Added a mocked-Gateway Control UI E2E regression covering: successful discovery, explicit Worktree selection, failed rediscovery, clearing the still-checked toggle, and a successful non-worktree `sessions.create`.
- `git diff --check` passes.
- Local E2E execution was not attempted from this sparse checkout because dependencies are absent; draft CI is the execution proof.

## AI assistance

AI-assisted. OpenAI Codex helped inspect the state flow, implement the bounded fix, and add the regression test. I reviewed the code and validation scope.
