### PR TITLE
fix(ui): draw themed chevron on settings selects instead of native arrow

### DIFF
--- a/ui/src/components/form-controls.browser.test.ts
+++ b/ui/src/components/form-controls.browser.test.ts
@@ -226,10 +226,13 @@ describeBrowserLayout("touch-primary form controls", () => {
     const fixture = await openMobileFixture();
     const { page } = fixture;
     try {
-      const selects = await page.locator(".field select.settings-select").evaluateAll((nodes) =>
+      // Both the .field-wrapped and bare settings selects draw the themed
+      // chevron; bare ones once fell back to the misaligned native arrow.
+      const selects = await page.locator("select.settings-select").evaluateAll((nodes) =>
         nodes.map((node) => {
           const style = getComputedStyle(node as HTMLElement);
           return {
+            appearance: style.appearance,
             image: style.backgroundImage,
             paddingRight: Number.parseFloat(style.paddingRight),
             positionX: style.backgroundPositionX,
@@ -238,8 +241,9 @@ describeBrowserLayout("touch-primary form controls", () => {
         }),
       );
 
-      expect(selects).toHaveLength(1);
+      expect(selects).toHaveLength(2);
       for (const select of selects) {
+        expect(select.appearance).toBe("none");
         expect(select.image).not.toBe("none");
         expect(select.paddingRight).toBeGreaterThanOrEqual(32);
         expect(select.positionX).toBe("calc(100% - 10px)");

--- a/ui/src/styles/base.css
+++ b/ui/src/styles/base.css
@@ -177,6 +177,10 @@
   /* Layering */
   --z-dropdown: 100;
 
+  /* Custom select chevron. Data URIs cannot read var(--muted), so the stroke
+     color is baked per theme mode; light mode overrides the whole image. */
+  --select-chevron: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' viewBox='0 0 24 24' fill='none' stroke='%23a1a1aa' stroke-width='2'%3E%3Cpolyline points='6 9 12 15 18 9'%3E%3C/polyline%3E%3C/svg%3E");
+
   color-scheme: dark;
 }
 
@@ -287,6 +291,8 @@
   --shadow-lg: 0 12px 28px rgba(60, 42, 24, 0.09);
   --shadow-xl: 0 24px 48px rgba(60, 42, 24, 0.11);
   --shadow-glow: 0 0 20px var(--accent-glow);
+
+  --select-chevron: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' viewBox='0 0 24 24' fill='none' stroke='%23444' stroke-width='2'%3E%3Cpolyline points='6 9 12 15 18 9'%3E%3C/polyline%3E%3C/svg%3E");
 
   color-scheme: light;
 }

--- a/ui/src/styles/components.css
+++ b/ui/src/styles/components.css
@@ -1131,7 +1131,7 @@ openclaw-session-owner-chip {
 .field select {
   appearance: none;
   padding-right: 36px;
-  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' viewBox='0 0 24 24' fill='none' stroke='%23a1a1aa' stroke-width='2'%3E%3Cpolyline points='6 9 12 15 18 9'%3E%3C/polyline%3E%3C/svg%3E");
+  background-image: var(--select-chevron);
   background-repeat: no-repeat;
   background-position: right 10px center;
 }
@@ -1283,10 +1283,6 @@ openclaw-session-owner-chip {
 :root[data-theme-mode="light"] .field select {
   background-color: var(--card);
   border-color: var(--input);
-}
-
-:root[data-theme-mode="light"] .field select {
-  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' viewBox='0 0 24 24' fill='none' stroke='%23444' stroke-width='2'%3E%3Cpolyline points='6 9 12 15 18 9'%3E%3C/polyline%3E%3C/svg%3E");
 }
 
 :root[data-theme-mode="light"] .btn {

--- a/ui/src/styles/settings.css
+++ b/ui/src/styles/settings.css
@@ -520,11 +520,16 @@ select.settings-select {
   transition: border-color var(--duration-fast) var(--ease-out);
 }
 
-/* Inside generic .field wrappers (Model Providers) the select is
-   appearance: none with a background chevron; the padding shorthand above
-   collapses its 36px gutter to 10px and long model names run under the arrow. */
-.field select.settings-select {
+/* Single-value selects draw the themed chevron; the engine's stock arrow
+   ignores the 32px control box and renders misaligned. Multi-select list
+   boxes keep native rendering. */
+select.settings-select:not([multiple]) {
+  appearance: none;
+  -webkit-appearance: none;
   padding-right: 36px;
+  background-image: var(--select-chevron);
+  background-repeat: no-repeat;
+  background-position: right 10px center;
 }
 
 .settings-row:not(.settings-row--stacked) .settings-row__control > .settings-select {


### PR DESCRIPTION
## What Problem This Solves
Native `<select class="settings-select">` controls across Settings (send shortcut, follow-up mode, session-open target, small model, media devices) rendered with `appearance: auto`, so the browser drew its stock dropdown arrow. That glyph ignores the 32px settings control box: it sits jammed against the right edge, off-center, and inconsistent with the custom chevron already used by `.field` selects and `wa-select`.

## Why This Change Was Made
The chevron data URI was duplicated per theme in `components.css` and only applied inside `.field` wrappers. This change centralizes it as a `--select-chevron` token in `base.css` (dark + light variants, since data URIs cannot read `var(--muted)`), gives single-value `select.settings-select` controls `appearance: none` plus the themed chevron and 36px text gutter, and deletes the now-redundant `.field select.settings-select` padding special-case and light-mode background-image override. Multi-select list boxes keep native rendering.

## User Impact
Settings comboboxes show a consistently aligned, theme-aware chevron (right 10px, vertically centered) in dark and light mode; long option labels no longer run under the arrow.

## Evidence
| Before (dark) | After (dark) | After (light) |
| --- | --- | --- |
| ![before](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/combobox-arrow-alignment/before-dark.png) | ![after](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/combobox-arrow-alignment/after-dark.png) | ![after light](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/combobox-arrow-alignment/after-light.png) |

- `node scripts/run-vitest.mjs ui/src/components/form-controls.browser.test.ts` — 6/6 green, including the extended affordance test now asserting both `.field`-wrapped and bare settings selects draw the chevron (`appearance: none`, gutter ≥ 32px, `calc(100% - 10px)` position).
- stylelint (`config/stylelint.config.mjs`) and `oxfmt --check` clean on the three touched stylesheets; `git diff --check` clean.
- Verified live in the mock dev harness (`pnpm dev:ui:mock`): computed style flips from `appearance: auto` / no background image to the themed chevron; Model Providers `.field` selects keep their 36px gutter; light mode picks up the `%23444` stroke variant.
