### PR TITLE
fix(cli): keep startup safeguards for version-pinned skills

### DIFF
--- a/src/cli/argv-invocation.test.ts
+++ b/src/cli/argv-invocation.test.ts
@@ -25,6 +25,47 @@ describe("argv-invocation", () => {
     });
   });
 
+  it.each([
+    {
+      name: "version-pinned install",
+      argv: ["node", "openclaw", "skills", "install", "@owner/weather", "--version", "1.2.3"],
+      commandPath: ["skills", "install"],
+    },
+    {
+      name: "version-pinned verification",
+      argv: ["node", "openclaw", "skills", "verify", "@owner/weather", "--version", "1.2.3"],
+      commandPath: ["skills", "verify"],
+    },
+    {
+      name: "equals-form version-pinned install",
+      argv: ["node", "openclaw", "skills", "install", "@owner/weather", "--version=1.2.3"],
+      commandPath: ["skills", "install"],
+    },
+    {
+      name: "profiled version-pinned verification",
+      argv: [
+        "node",
+        "openclaw",
+        "--profile",
+        "work",
+        "skills",
+        "verify",
+        "@owner/weather",
+        "--version",
+        "1.2.3",
+      ],
+      commandPath: ["skills", "verify"],
+    },
+  ])("keeps $name in command execution mode", ({ argv, commandPath }) => {
+    expect(resolveCliArgvInvocation(argv)).toEqual({
+      argv,
+      commandPath,
+      primary: "skills",
+      hasHelpOrVersion: false,
+      isRootHelpInvocation: false,
+    });
+  });
+
   it("consumes agent parent option values before the exec subcommand", () => {
     expect(
       resolveCliArgvInvocation([

--- a/src/cli/argv.test.ts
+++ b/src/cli/argv.test.ts
@@ -293,6 +293,75 @@ describe("argv helpers", () => {
       argv: ["node", "openclaw", "nodes", "invoke", "--", "--version"],
       expected: false,
     },
+    {
+      name: "root version flag",
+      argv: ["node", "openclaw", "--version"],
+      expected: true,
+    },
+    {
+      name: "root short version flag",
+      argv: ["node", "openclaw", "-V"],
+      expected: true,
+    },
+    {
+      name: "root version alias after profile",
+      argv: ["node", "openclaw", "--profile", "work", "-v"],
+      expected: true,
+    },
+    {
+      name: "root version flag after profile",
+      argv: ["node", "openclaw", "--profile", "work", "--version"],
+      expected: true,
+    },
+    {
+      name: "version-pinned skill install",
+      argv: ["node", "openclaw", "skills", "install", "@owner/weather", "--version", "1.2.3"],
+      expected: false,
+    },
+    {
+      name: "version-pinned skill verification",
+      argv: ["node", "openclaw", "skills", "verify", "@owner/weather", "--version", "1.2.3"],
+      expected: false,
+    },
+    {
+      name: "equals-form version-pinned skill install",
+      argv: ["node", "openclaw", "skills", "install", "@owner/weather", "--version=1.2.3"],
+      expected: false,
+    },
+    {
+      name: "profiled version-pinned skill verification",
+      argv: [
+        "node",
+        "openclaw",
+        "--profile",
+        "work",
+        "skills",
+        "verify",
+        "@owner/weather",
+        "--version",
+        "1.2.3",
+      ],
+      expected: false,
+    },
+    {
+      name: "help for a version-pinned skill command",
+      argv: [
+        "node",
+        "openclaw",
+        "skills",
+        "verify",
+        "@owner/weather",
+        "--version",
+        "1.2.3",
+        "--help",
+      ],
+      expected: true,
+    },
+    {
+      name: "unknown root option does not turn version into root help",
+      argv: ["node", "openclaw", "--unknown", "--version"],
+      expected: false,
+    },
   ])("detects help/version invocations: $name", ({ argv, expected }) => {
     expect(isHelpOrVersionInvocation(argv)).toBe(expected);
   });

--- a/src/cli/argv.ts
+++ b/src/cli/argv.ts
@@ -30,7 +30,7 @@ const ROOT_COMMANDS_WITH_SUBCOMMANDS: ReadonlySet<string> = new Set(
 );
 
 export function isHelpOrVersionInvocation(argv: string[]): boolean {
-  if (hasRootVersionAlias(argv)) {
+  if (isRootVersionInvocation(argv)) {
     return true;
   }
 
@@ -47,7 +47,7 @@ export function isHelpOrVersionInvocation(argv: string[]): boolean {
       i += rootConsumed - 1;
       continue;
     }
-    if (HELP_FLAGS.has(arg) || VERSION_FLAGS.has(arg)) {
+    if (HELP_FLAGS.has(arg)) {
       return true;
     }
     if (arg.startsWith("-")) {

--- a/src/cli/program/preaction.test.ts
+++ b/src/cli/program/preaction.test.ts
@@ -201,6 +201,14 @@ describe("registerPreActionHooks", () => {
       .action(() => {});
     programLocal.command("completion").action(() => {});
     programLocal.command("secrets").action(() => {});
+    const skills = programLocal.command("skills");
+    for (const skillCommand of ["install", "verify"]) {
+      skills
+        .command(skillCommand)
+        .argument("<skill-ref>")
+        .option("--version <version>")
+        .action(() => {});
+    }
     programLocal
       .command("qa")
       .command("suite")
@@ -653,6 +661,51 @@ describe("registerPreActionHooks", () => {
 
     expect(emitCliBannerMock).not.toHaveBeenCalled();
     expect(ensureConfigReadyMock).toHaveBeenCalledTimes(1);
+  });
+
+  it.each([
+    {
+      name: "version-pinned skill install",
+      action: "install",
+      argv: ["node", "openclaw", "skills", "install", "@owner/weather", "--version", "1.2.3"],
+    },
+    {
+      name: "version-pinned skill verification",
+      action: "verify",
+      argv: ["node", "openclaw", "skills", "verify", "@owner/weather", "--version", "1.2.3"],
+    },
+    {
+      name: "equals-form version-pinned skill install",
+      action: "install",
+      argv: ["node", "openclaw", "skills", "install", "@owner/weather", "--version=1.2.3"],
+    },
+    {
+      name: "profiled version-pinned skill verification",
+      action: "verify",
+      argv: [
+        "node",
+        "openclaw",
+        "--profile",
+        "work",
+        "skills",
+        "verify",
+        "@owner/weather",
+        "--version",
+        "1.2.3",
+      ],
+    },
+  ])("runs the execution bootstrap for $name", async ({ action, argv }) => {
+    await runPreAction({
+      parseArgv: ["skills", action],
+      processArgv: argv,
+    });
+
+    expect(ensureConfigReadyMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        runtime: runtimeMock,
+        commandPath: ["skills", action],
+      }),
+    );
   });
 
   it("applies --json stdout suppression only for explicit JSON output commands", async () => {

--- a/src/cli/run-main.exit.test.ts
+++ b/src/cli/run-main.exit.test.ts
@@ -2212,6 +2212,52 @@ describe("runCli exit behavior", () => {
   });
 
   it.each([
+    {
+      name: "version-pinned skill install",
+      argv: ["node", "openclaw", "skills", "install", "@owner/weather", "--version", "1.2.3"],
+    },
+    {
+      name: "version-pinned skill verification",
+      argv: ["node", "openclaw", "skills", "verify", "@owner/weather", "--version", "1.2.3"],
+    },
+    {
+      name: "equals-form version-pinned skill install",
+      argv: ["node", "openclaw", "skills", "install", "@owner/weather", "--version=1.2.3"],
+    },
+    {
+      name: "profiled version-pinned skill verification",
+      argv: [
+        "node",
+        "openclaw",
+        "--profile",
+        "work",
+        "skills",
+        "verify",
+        "@owner/weather",
+        "--version",
+        "1.2.3",
+      ],
+    },
+  ])("starts the managed proxy for $name", async ({ argv }) => {
+    await withEnvAsync(
+      {
+        OPENCLAW_PROFILE: undefined,
+        OPENCLAW_STATE_DIR: undefined,
+        OPENCLAW_CONFIG_PATH: undefined,
+      },
+      async () => {
+        hasEnvHttpProxyAgentConfiguredMock.mockReturnValue(true);
+        tryRouteCliMock.mockResolvedValueOnce(true);
+
+        await runCli(argv);
+
+        expect(startProxyMock).toHaveBeenCalledWith(undefined);
+        expect(ensureGlobalUndiciEnvProxyDispatcherMock).toHaveBeenCalledOnce();
+      },
+    );
+  });
+
+  it.each([
     ["JSON flag", ["node", "openclaw", "plugins", "marketplace", "list", "--json"]],
     ["models status JSON alias", ["node", "openclaw", "models", "--status-json"]],
   ])("routes managed-proxy startup logs away for the %s", async (_name, argv) => {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users installing or verifying a specific skill version would silently skip normal configuration validation, startup bootstrap, dotenv initialization, and configured network proxy routing when using the documented `skills install --version <version>` or `skills verify --version <version>` commands.

## Why This Change Was Made

Classify only actual root `--version`, `-V`, and `-v` invocations as version-only exits. Continue treating command-owned version selectors as normal actions, while preserving root options, named profiles, nested help, flag terminators, Commander positional-option ownership, and existing help fast paths.

## User Impact

Version-pinned skill installation and verification now respect the same configuration, migration, proxy, and startup safeguards as unversioned commands. Actual root version and help commands retain their existing lightweight behavior.

## Evidence

- Red-first reproduction: 7 newly added assertions fail against current `main` before the two-line production fix.
- 678 passing tests across 16 focused CLI, skill, profile, routing, machine-output, help, Commander pre-action, and managed-proxy suites, including 52 real child-process help and diagnostic tests.
- Full path-scoped `pnpm check:changed`, including formatting, lint, core and core-test typechecking, import-cycle, dependency, plugin-boundary, and database/schema guards.
- Successful complete Linux `pnpm build`, including packaged CLI, plugin SDK, bundled plugins, and control UI.
- 20 passing real-process smoke cases across both the built distribution and TypeScript source: root version aliases, named-profile root version, install/verify help, split and equals-form skill versions, and deterministic invalid-config refusal before any network operation.
- Installed Commander 15.0.0 positional-option behavior directly inspected against the documented skill CLI contract.
- Fresh independent autoreview: clean; no actionable findings.