### PR TITLE
fix(cli): recover conversations from stale session bindings

### DIFF
--- a/src/agents/command/attempt-execution.cli.test.ts
+++ b/src/agents/command/attempt-execution.cli.test.ts
@@ -1314,6 +1314,17 @@ describe("CLI attempt execution", () => {
       );
       await replaceSessionEntry({ sessionKey, storePath }, concurrentEntry);
       sessionStore[sessionKey] = concurrentEntry;
+      const clearBeforeFreshRetry = runArgs.onBeforeFreshCliSessionRetry;
+      expect(clearBeforeFreshRetry).toBeTypeOf("function");
+      await expect(
+        (
+          clearBeforeFreshRetry as (params: {
+            provider: string;
+            reason: "timeout";
+            sessionId: string;
+          }) => Promise<boolean>
+        )({ provider: "claude-cli", reason: "timeout", sessionId: forkedCliSessionId }),
+      ).resolves.toBe(false);
       throw recoveryError;
     });
 

--- a/src/agents/command/session-store.ts
+++ b/src/agents/command/session-store.ts
@@ -337,6 +337,7 @@ export async function clearCliSessionInStore(params: {
     return undefined;
   }
 
+  let didClear = false;
   const persisted = await patchSessionEntry(
     {
       storePath,
@@ -358,14 +359,16 @@ export async function clearCliSessionInStore(params: {
       const next = { ...currentEntry };
       clearCliSession(next, provider);
       next.updatedAt = Date.now();
+      didClear = true;
       return next;
     },
     { fallbackEntry: entry },
   );
-  if (persisted) {
+  if (persisted && didClear) {
     sessionStore[sessionKey] = persisted;
+    return persisted;
   }
-  return persisted ?? undefined;
+  return undefined;
 }
 
 /** Clears the one-shot fork marker before the resumed CLI process starts. */


### PR DESCRIPTION
Closes #97887

Supersedes #106284 and #114467. Thanks @gangcaiyoule and @Alix-007 for tracing the recovery gap; @Alix-007 remains a commit co-author.

## What Problem This Solves

A stale CLI session clear could lose its compare-and-swap race to a concurrently installed replacement but still report success. The caller would then authorize a fresh retry and treat the replacement snapshot as if the stale binding had been cleared.

## Why This Change Was Made

Current main already owns CLI recovery in the command-attempt path. This rewrite keeps that owner and ports only the missing applied-operation invariant: `clearCliSessionInStore` updates memory and returns success only when its guarded callback actually cleared the expected binding.

The generic SQLite accessor intentionally returns the current snapshot when a patch callback declines a write, so changing that shared contract would be wrong. The obsolete auto-reply recovery module from the stale branch remains deleted.

## User Impact

CLI recovery no longer mistakes a concurrent session replacement for a successful stale-binding clear. The newer binding survives, and the failed turn is not replayed as if it owned the session.

## Evidence

- Before the production change: `node scripts/run-vitest.mjs src/agents/command/attempt-execution.cli.test.ts` failed 1/119. The concurrent-rebind recovery hook returned `true` instead of `false`.
- After the production change: `node scripts/run-vitest.mjs src/agents/command/attempt-execution.cli.test.ts src/agents/command/session-store.test.ts` passed 177/177.
- `node scripts/check-changed.mjs` passed remotely on Blacksmith Testbox `tbx_01kzk8112crvag4kb47478krjy` in 8m41s. It covered core production/test typechecks, format, lint, API baseline, dependency and architecture guards, dead-code scans, state guards, and runtime import cycles. Run: https://github.com/openclaw/openclaw/actions/runs/31313444183
- Exact-head CI is green: https://github.com/openclaw/openclaw/actions/runs/31313870223. One unrelated `acp --help` process timeout in the 6,938-test compact shard passed on the exact-job rerun; no code or timeout was changed.
- `git diff --check` passed.
- Fresh Codex-backed autoreview passed with no accepted or actionable findings.
- Production delta: +5/-2. Test delta: +11/-0.

### ClawSweeper rank-up moves

- Applied: rebased as the narrow `didClear` session-store fix at the current command-attempt owner; deleted auto-reply recovery wiring was not restored.
- Skipped: a live Gateway-plus-Claude run can demonstrate ordinary resume failure, but cannot deterministically create the concurrent SQLite replacement race fixed here. The existing command-attempt boundary test injects that exact ordering and verifies both the callback result and replacement survival; no credentialed live run was performed.
