### PR TITLE
refactor(delivery): centralize durable queue routing metadata

### DIFF
--- a/src/infra/delivery-queue-sqlite.test.ts
+++ b/src/infra/delivery-queue-sqlite.test.ts
@@ -8,6 +8,8 @@ import {
   promoteDeliveryQueueEntryPlatformSend,
 } from "./delivery-queue-sqlite-claim.js";
 import {
+  commitStagedDeliveryQueueEntry,
+  commitStagedDeliveryQueueEntryOnce,
   completeDeliveryQueueEntry,
   countFailedDeliveryQueueEntries,
   deleteDeliveryQueueEntry,
@@ -138,6 +140,156 @@ describe("delivery-queue-sqlite corrupt JSON resilience", () => {
 
       const loaded = loadDeliveryQueueEntry(QUEUE, "rt-1", stateDir);
       expect(loaded).toMatchObject({ id: "rt-1", enqueuedAt: 1000, retryCount: 0 });
+    });
+
+    it.each([
+      {
+        name: "outbound delivery",
+        queueName: "outbound",
+        entry: {
+          id: "metadata-outbound",
+          channel: "discord",
+          to: "channel:123",
+          accountId: "bot-a",
+          session: { key: "agent:main:discord:channel:123" },
+        },
+        expected: {
+          entry_kind: "outbound",
+          session_key: "agent:main:discord:channel:123",
+          channel: "discord",
+          target: "channel:123",
+          account_id: "bot-a",
+        },
+      },
+      {
+        name: "routed session delivery",
+        queueName: "session",
+        entry: {
+          id: "metadata-session-route",
+          kind: "agentTurn",
+          sessionKey: "agent:main:discord:channel:123",
+          route: { channel: "discord", to: "channel:123", accountId: "bot-a" },
+          deliveryContext: { channel: "telegram", to: "999", accountId: "bot-b" },
+        },
+        expected: {
+          entry_kind: "agentTurn",
+          session_key: "agent:main:discord:channel:123",
+          channel: "discord",
+          target: "channel:123",
+          account_id: "bot-a",
+        },
+      },
+      {
+        name: "context-only session delivery",
+        queueName: "session",
+        entry: {
+          id: "metadata-session-context",
+          kind: "systemEvent",
+          sessionKey: "agent:main:telegram:direct:123",
+          deliveryContext: { channel: "telegram", to: "123", accountId: "bot-a" },
+        },
+        expected: {
+          entry_kind: "systemEvent",
+          session_key: "agent:main:telegram:direct:123",
+          channel: "telegram",
+          target: "123",
+          account_id: "bot-a",
+        },
+      },
+    ])("indexes canonical $name metadata", ({ queueName, entry, expected }) => {
+      upsertDeliveryQueueEntry({
+        queueName,
+        entry: { ...entry, enqueuedAt: 1000, retryCount: 0 },
+        stateDir,
+      });
+
+      const { db } = openOpenClawStateDatabase({
+        env: { ...process.env, OPENCLAW_STATE_DIR: stateDir },
+      });
+      const readMetadata = () =>
+        db
+          .prepare(
+            `SELECT entry_kind, session_key, channel, target, account_id
+             FROM delivery_queue_entries WHERE queue_name = ? AND id = ?`,
+          )
+          .get(queueName, entry.id);
+      expect(readMetadata()).toEqual(expected);
+
+      updateDeliveryQueueEntry(queueName, entry.id, stateDir, (current) => ({
+        ...current,
+        retryCount: current.retryCount + 1,
+      }));
+      expect(readMetadata()).toEqual(expected);
+    });
+
+    it("preserves explicit queue metadata ownership", () => {
+      upsertDeliveryQueueEntry({
+        queueName: "outbound-media-staging",
+        entry: { id: "metadata-media-stage", enqueuedAt: 1000, retryCount: 0 },
+        metadata: { entryKind: "outbound-media-stage" },
+        stateDir,
+      });
+
+      const { db } = openOpenClawStateDatabase({
+        env: { ...process.env, OPENCLAW_STATE_DIR: stateDir },
+      });
+      expect(
+        db
+          .prepare("SELECT entry_kind FROM delivery_queue_entries WHERE queue_name = ? AND id = ?")
+          .get("outbound-media-staging", "metadata-media-stage"),
+      ).toEqual({ entry_kind: "outbound-media-stage" });
+    });
+
+    it.each([
+      { name: "ordinary", commit: commitStagedDeliveryQueueEntry, expected: true },
+      { name: "insert-only", commit: commitStagedDeliveryQueueEntryOnce, expected: "created" },
+    ])("indexes $name staged outbound commits", ({ commit, expected }) => {
+      const stagingQueueName = "outbound-media-staging";
+      const stagingId = "metadata-staged-media";
+      const outboundEntry = {
+        id: "metadata-staged-outbound",
+        enqueuedAt: 1000,
+        retryCount: 0,
+        channel: "discord",
+        to: "channel:123",
+        accountId: "bot-a",
+        session: { key: "agent:main:discord:channel:123" },
+      };
+      upsertDeliveryQueueEntry({
+        queueName: stagingQueueName,
+        entry: { id: stagingId, enqueuedAt: 1000, retryCount: 0 },
+        metadata: { entryKind: "outbound-media-stage" },
+        stateDir,
+      });
+
+      expect(
+        commit({
+          queueName: "outbound",
+          entry: outboundEntry,
+          stagingId,
+          stagingQueueName,
+          stateDir,
+        }),
+      ).toBe(expected);
+
+      const { db } = openOpenClawStateDatabase({
+        env: { ...process.env, OPENCLAW_STATE_DIR: stateDir },
+      });
+      expect(
+        db
+          .prepare(
+            `SELECT entry_kind, session_key, channel, target, account_id
+             FROM delivery_queue_entries WHERE queue_name = ? AND id = ?`,
+          )
+          .get("outbound", "metadata-staged-outbound"),
+      ).toEqual({
+        entry_kind: "outbound",
+        session_key: "agent:main:discord:channel:123",
+        channel: "discord",
+        target: "channel:123",
+        account_id: "bot-a",
+      });
+      expect(loadDeliveryQueueEntry(stagingQueueName, stagingId, stateDir)).toBeNull();
     });
 
     it("update increments retry count", () => {

--- a/src/infra/delivery-queue-sqlite.ts
+++ b/src/infra/delivery-queue-sqlite.ts
@@ -25,7 +25,7 @@ export type DeliveryQueueCompletionRetention =
     }>;
 
 /** Indexed metadata extracted from queue payloads for diagnostics and recovery. */
-export type DeliveryQueueRowMetadata = {
+type DeliveryQueueRowMetadata = {
   entryKind?: string;
   sessionKey?: string;
   channel?: string;

--- a/src/infra/delivery-queue-sqlite.ts
+++ b/src/infra/delivery-queue-sqlite.ts
@@ -114,7 +114,7 @@ function inflate(row: QueueRow): DeliveryQueueEntryState | null {
   };
 }
 
-function metadata(entry: DeliveryQueueEntryState): DeliveryQueueRowMetadata {
+function metadata(queueName: string, entry: DeliveryQueueEntryState): DeliveryQueueRowMetadata {
   const item = entry as DeliveryQueueEntryState & {
     kind?: string;
     sessionKey?: string;
@@ -126,7 +126,7 @@ function metadata(entry: DeliveryQueueEntryState): DeliveryQueueRowMetadata {
     deliveryContext?: { channel?: string; to?: string; accountId?: string };
   };
   return {
-    entryKind: item.kind,
+    entryKind: item.kind ?? queueName,
     sessionKey: item.sessionKey ?? item.session?.key,
     channel: item.channel ?? item.route?.channel ?? item.deliveryContext?.channel,
     target: item.to ?? item.route?.to ?? item.deliveryContext?.to,
@@ -140,7 +140,7 @@ function upsertDeliveryQueueEntryInDatabase(
 ): boolean {
   const now = Date.now();
   const status = params.status ?? "pending";
-  const meta = params.metadata ?? metadata(params.entry);
+  const meta = params.metadata ?? metadata(params.queueName, params.entry);
   const queueDb = getNodeSqliteKysely<DeliveryQueueDatabase>(database.db);
   const insert = queueDb.insertInto("delivery_queue_entries").values({
     queue_name: params.queueName,

--- a/src/infra/outbound/delivery-queue-storage.ts
+++ b/src/infra/outbound/delivery-queue-storage.ts
@@ -22,7 +22,6 @@ import {
   reserveDeliveryQueueEntryAttempt,
   updateDeliveryQueueEntry,
   upsertDeliveryQueueEntry,
-  type DeliveryQueueRowMetadata,
   type DeliveryQueueCompletionRetention,
 } from "../delivery-queue-sqlite.js";
 import { generateSecureUuid } from "../secure-random.js";
@@ -120,16 +119,6 @@ export interface QueuedDelivery extends QueuedDeliveryPayload {
   recoveryState?: "producer_claimed" | "send_attempt_started" | "unknown_after_send";
 }
 
-function queuedDeliveryMetadata(entry: QueuedDelivery): DeliveryQueueRowMetadata {
-  return {
-    entryKind: "outbound",
-    sessionKey: entry.session?.key,
-    channel: entry.channel,
-    target: entry.to,
-    accountId: entry.accountId,
-  };
-}
-
 function createQueuedDelivery(params: QueuedDeliveryPayload, id: string): QueuedDelivery {
   return {
     id,
@@ -172,12 +161,10 @@ export async function enqueueDelivery(
 ): Promise<string> {
   const id = generateSecureUuid();
   const entry = createQueuedDelivery(params, id);
-  const metadata = queuedDeliveryMetadata(entry);
   if (mediaStageId) {
     const committed = commitStagedDeliveryQueueEntry({
       queueName: OUTBOUND_DELIVERY_QUEUE_NAME,
       entry,
-      metadata,
       stagingId: mediaStageId,
       stagingQueueName: DELIVERY_QUEUE_MEDIA_STAGING_QUEUE_NAME,
       stateDir,
@@ -189,7 +176,6 @@ export async function enqueueDelivery(
     upsertDeliveryQueueEntry({
       queueName: OUTBOUND_DELIVERY_QUEUE_NAME,
       entry,
-      metadata,
       stateDir,
     });
   }
@@ -208,13 +194,11 @@ export async function enqueueDeliveryOnce(
     throw new Error("Stable delivery queue id is required");
   }
   const entry = createQueuedDelivery(params, normalizedId);
-  const metadata = queuedDeliveryMetadata(entry);
   const created = mediaStageId
     ? (() => {
         const result = commitStagedDeliveryQueueEntryOnce({
           queueName: OUTBOUND_DELIVERY_QUEUE_NAME,
           entry,
-          metadata,
           stagingId: mediaStageId,
           stagingQueueName: DELIVERY_QUEUE_MEDIA_STAGING_QUEUE_NAME,
           stateDir,
@@ -227,7 +211,6 @@ export async function enqueueDeliveryOnce(
     : upsertDeliveryQueueEntry({
         queueName: OUTBOUND_DELIVERY_QUEUE_NAME,
         entry,
-        metadata,
         stateDir,
         insertOnly: true,
       });

--- a/src/infra/session-delivery-queue-storage.ts
+++ b/src/infra/session-delivery-queue-storage.ts
@@ -12,7 +12,6 @@ import {
   updateDeliveryQueueEntry,
   upsertDeliveryQueueEntry,
   type DeliveryQueueCompletionRetention,
-  type DeliveryQueueRowMetadata,
 } from "./delivery-queue-sqlite.js";
 import { generateSecureUuid } from "./secure-random.js";
 
@@ -113,17 +112,6 @@ function buildEntryId(idempotencyKey?: string): string {
   return sha256Hex(idempotencyKey);
 }
 
-function queuedSessionDeliveryMetadata(entry: QueuedSessionDelivery): DeliveryQueueRowMetadata {
-  const route = entry.kind === "agentTurn" ? entry.route : undefined;
-  return {
-    entryKind: entry.kind,
-    sessionKey: entry.sessionKey,
-    channel: route?.channel ?? entry.deliveryContext?.channel,
-    target: route?.to ?? entry.deliveryContext?.to,
-    accountId: route?.accountId ?? entry.deliveryContext?.accountId,
-  };
-}
-
 /** Enqueue a session delivery and return its durable id. */
 export async function enqueueSessionDelivery(
   params: QueuedSessionDeliveryPayload,
@@ -140,7 +128,6 @@ export async function enqueueSessionDelivery(
   upsertDeliveryQueueEntry({
     queueName: QUEUE_NAME,
     entry,
-    metadata: queuedSessionDeliveryMetadata(entry),
     stateDir,
     ...(params.completionRetention === "permanent"
       ? { insertOnly: true }
@@ -170,7 +157,6 @@ export async function enqueueClaimedSessionDelivery(
   const claimed = upsertDeliveryQueueEntry({
     queueName: QUEUE_NAME,
     entry,
-    metadata: queuedSessionDeliveryMetadata(entry),
     stateDir,
     insertOnly: true,
   });
@@ -241,7 +227,6 @@ export async function markSessionDeliveryAttemptStarted(
         ...entry,
         deliveryStartedAt: entry.deliveryStartedAt ?? Date.now(),
       } as QueuedSessionDelivery,
-      metadata: queuedSessionDeliveryMetadata(entry),
       stateDir,
       updatePendingOnly: true,
     });
@@ -278,7 +263,6 @@ export async function markSessionDeliverySettlement(
         settlementOutcome: outcome,
         ...(outcome === "recovered" ? { acknowledgedAt: entry.acknowledgedAt ?? Date.now() } : {}),
       } as QueuedSessionDelivery,
-      metadata: queuedSessionDeliveryMetadata(entry),
       stateDir,
       updatePendingOnly: true,
     });


### PR DESCRIPTION
## What Problem This Solves

Outbound delivery and restart/session recovery maintained separate copies of the same durable SQLite routing metadata. Those copies could diverge during claim, retry, staged-media commit, and recovery updates, making queue diagnostics lose the owning delivery kind or disagree about the channel, destination, account, and session.

## Why This Change Was Made

Use the existing shared SQLite delivery-queue owner to derive routing metadata for both outbound and session deliveries, including ordinary, insert-only, and staged commits. Preserve explicit media-stage metadata and route-over-context account ownership. Remove both queue-specific metadata builders and 33 lines of production code; do not change SQLite schema versions, retry/claim ownership, completion receipts, message-tool-only delivery, or Gateway protocol.

## User Impact

Durable outbound messages and session wakeups retain consistent owning account, route, destination, and queue kind throughout retries and crash recovery. User-visible delivery behavior is unchanged; staged attachments, exactly-once completion, and permanent idempotency receipts are preserved.

## Evidence

- Fresh full-branch structured autoreview on final head `0c1ebf1ac108d96d5c4d422c576f6f6953b5bc83`: clean; no accepted or actionable findings.
- Final-head `pnpm deadcode:dependencies` and `pnpm deadcode:exports` both pass with zero unused production, full-tree, and script exports; exact GitHub CI `check-dependencies` also passes.
- Blacksmith Testbox `tbx_01kykey6n3j8ejc8qxda9g8f1e`: `pnpm check:changed` passed, including core/test typechecking, formatting, lint, runtime import cycles, schema guard, plugin boundaries, and database-first guards.
- Same Testbox: 189 tests passed across `delivery-queue-sqlite`, outbound/session storage and recovery, persistence, staged-media spool, and fenced exactly-once outbound integration.
- New regressions verify outbound metadata, conflicting session route/context account precedence, context-only wake metadata, indexed metadata across retry updates, explicit stage overrides, and both ordinary/insert-only staged-media commit transactions.
- Same Testbox: `pnpm build` and fresh isolated loopback Gateway proof verify pending queued SQLite metadata, `/healthz`, `/readyz`, authenticated Gateway health/session RPC, and exactly-once recovery to the completed durable state.
- AI-assisted; independently autoreviewed.

### Inspectable live Gateway recovery proof

The built CLI ran on Blacksmith Testbox `tbx_01kykey6n3j8ejc8qxda9g8f1e`, with a newly created `OPENCLAW_STATE_DIR`, a separate `OPENCLAW_CONFIG_PATH`, a dynamically allocated loopback-only port, and an ephemeral token that is not included in this output. The test first inserted one real session-delivery row through the production SQLite queue (queue `session`, stable receipt `9058f0ccfec0f54b7b1d8113b4cda5f46d60fbb8af62d599d8dd735986a61702`), asserted its persisted owner/session/channel/account/destination and `pending` status, started the built Gateway, made authenticated RPC calls, and polled that exact same row until production startup recovery changed its unique receipt to `completed`. The loopback port, state directory, configuration path, and token were created only for this proof; no real gateway or credentials were used:

```text
CRABBOX_PHASE:isolated-delivery-gateway
durable session metadata: account, route, destination and pending ownership verified
gateway /healthz: ok
gateway /readyz: ok
authenticated gateway health RPC: ok
authenticated gateway sessions.list RPC: ok
gateway durable session delivery: recovered exactly once and completed
CRABBOX_PHASE:outbound-live-proof-complete
blacksmith run summary sync=delegated command=30.283s total=30.313s exit=0
{"provider":"blacksmith-testbox","leaseId":"tbx_01kykey6n3j8ejc8qxda9g8f1e","exitCode":0,"runStatus":"succeeded"}
```

### Inspectable final-head dead-code, staged-media, and recovery proof

Exact final head `0c1ebf1ac108d96d5c4d422c576f6f6953b5bc83` was separately synced to Blacksmith Testbox `tbx_01kykg2yhw9g61r7n5wazp1fv4`. Both dead-code commands, both ordinary and insert-only staged-media destination-index regressions, conflicting route/account precedence, pending/retry ownership, partial-send fencing, startup recovery, and the complete changed gate passed:

```text
CRABBOX_PHASE:delivery-deadcode-dependencies
pnpm deadcode:dependencies
CRABBOX_PHASE:delivery-deadcode-exports
[deadcode] Knip production unused-export scan passed with 0 entries.
[deadcode] Knip full-tree unused-export scan passed with 0 entries.
[deadcode] Knip script unused-export scan passed with 0 entries.
[deadcode] Knip production and full-tree unused-export checks passed with 0 entries.
CRABBOX_PHASE:delivery-focused-tests
Test Files  8 passed (8)
     Tests  189 passed (189)
CRABBOX_PHASE:delivery-changed-gate
pnpm check:changed
native state schema version guard passed (v6)
Database-first legacy-store guard passed.
Import cycle check: 0 runtime value cycle(s).
CRABBOX_PHASE:delivery-head-proof-complete
blacksmith run summary sync=delegated command=6m3.558s exit=0
{"provider":"blacksmith-testbox","leaseId":"tbx_01kykg2yhw9g61r7n5wazp1fv4","exitCode":0,"runStatus":"succeeded"}
```

Exact-head hosted CI: https://github.com/openclaw/openclaw/actions/runs/30329215173.
