### PR TITLE
refactor(providers): unify stream wrapper composition

### DIFF
--- a/extensions/openrouter/stream.ts
+++ b/extensions/openrouter/stream.ts
@@ -3,6 +3,7 @@ import type { StreamFn } from "openclaw/plugin-sdk/agent-core";
 import type { ProviderWrapStreamFnContext } from "openclaw/plugin-sdk/plugin-entry";
 import { buildProviderStreamFamilyHooks } from "openclaw/plugin-sdk/provider-stream-family";
 import {
+  composeProviderStreamWrappers,
   createPayloadPatchStreamWrapper,
   normalizeOpenAICompatibleReasoningReplay,
 } from "openclaw/plugin-sdk/provider-stream-shared";
@@ -285,24 +286,19 @@ export function wrapOpenRouterProviderStream(
     ? injectOpenRouterRouting(ctx.streamFn, providerRouting)
     : ctx.streamFn;
   const wrapStreamFn = openRouterThinkingStreamHooks.wrapStreamFn ?? undefined;
-  if (!wrapStreamFn) {
-    return createOpenRouterAnthropicPrefillWrapper(
-      createOpenRouterAuthHeaderWrapper(
-        createOpenRouterDeepSeekV4ReplayWrapper(routedStreamFn, ctx.thinkingLevel),
-      ),
-    );
-  }
-  const wrappedStreamFn =
-    wrapStreamFn({
-      ...ctx,
-      streamFn: routedStreamFn,
-      thinkingLevel: isOpenRouterProxyReasoningUnsupportedModel(ctx.modelId)
-        ? undefined
-        : ctx.thinkingLevel,
-    }) ?? undefined;
-  return createOpenRouterAnthropicPrefillWrapper(
-    createOpenRouterAuthHeaderWrapper(
-      createOpenRouterDeepSeekV4ReplayWrapper(wrappedStreamFn, ctx.thinkingLevel),
-    ),
+  return composeProviderStreamWrappers(
+    routedStreamFn,
+    wrapStreamFn &&
+      ((streamFn) =>
+        wrapStreamFn({
+          ...ctx,
+          streamFn,
+          thinkingLevel: isOpenRouterProxyReasoningUnsupportedModel(ctx.modelId)
+            ? undefined
+            : ctx.thinkingLevel,
+        }) ?? undefined),
+    (streamFn) => createOpenRouterDeepSeekV4ReplayWrapper(streamFn, ctx.thinkingLevel),
+    createOpenRouterAuthHeaderWrapper,
+    createOpenRouterAnthropicPrefillWrapper,
   );
 }

--- a/extensions/vllm/stream.test.ts
+++ b/extensions/vllm/stream.test.ts
@@ -117,10 +117,11 @@ describe("createVllmQwenThinkingWrapper", () => {
   });
 });
 
-describe("createVllmProviderThinkingWrapper", () => {
+describe("vLLM provider thinking composition", () => {
   function captureProviderPayload(params: {
     thinkingLevel?: "off" | "low" | "medium" | "high" | "xhigh" | "max";
     initialPayload?: Record<string, unknown>;
+    contextModelId?: string;
     model?: Partial<Model<"openai-completions">>;
   }): Record<string, unknown> {
     let captured: Record<string, unknown> = {};
@@ -140,7 +141,7 @@ describe("createVllmProviderThinkingWrapper", () => {
     } as Model<"openai-completions">;
     const wrapped = wrapVllmProviderStream({
       provider: "vllm",
-      modelId: model.id,
+      modelId: params.contextModelId ?? model.id,
       model,
       thinkingLevel: params.thinkingLevel ?? "high",
       streamFn: baseStreamFn,
@@ -176,6 +177,24 @@ describe("createVllmProviderThinkingWrapper", () => {
     ).toEqual({
       chat_template_kwargs: {
         enable_thinking: true,
+        force_nonempty_content: true,
+      },
+    });
+  });
+
+  it("composes Qwen thinking before runtime Nemotron payload defaults", () => {
+    expect(
+      captureProviderPayload({
+        thinkingLevel: "off",
+        contextModelId: "Qwen/Qwen3-8B",
+        model: {
+          compat: { thinkingFormat: "qwen-chat-template" },
+        },
+      }),
+    ).toEqual({
+      chat_template_kwargs: {
+        enable_thinking: false,
+        preserve_thinking: true,
         force_nonempty_content: true,
       },
     });

--- a/extensions/vllm/stream.ts
+++ b/extensions/vllm/stream.ts
@@ -3,6 +3,7 @@ import type { StreamFn } from "openclaw/plugin-sdk/agent-core";
 import type { ProviderWrapStreamFnContext } from "openclaw/plugin-sdk/plugin-entry";
 import { normalizeProviderId } from "openclaw/plugin-sdk/provider-model-shared";
 import {
+  composeProviderStreamWrappers,
   createPayloadPatchStreamWrapper,
   isOpenAICompatibleThinkingEnabled,
   setQwenChatTemplateThinking,
@@ -76,32 +77,6 @@ export function createVllmQwenThinkingWrapper(params: {
   );
 }
 
-function createVllmProviderThinkingWrapper(params: {
-  baseStreamFn: StreamFn | undefined;
-  qwenFormat?: VllmQwenThinkingFormat;
-  thinkingLevel: VllmThinkingLevel;
-}): StreamFn {
-  const qwenWrapped = params.qwenFormat
-    ? createVllmQwenThinkingWrapper({
-        baseStreamFn: params.baseStreamFn,
-        format: params.qwenFormat,
-        thinkingLevel: params.thinkingLevel,
-      })
-    : params.baseStreamFn;
-  return createPayloadPatchStreamWrapper(
-    qwenWrapped,
-    ({ payload: payloadObj }) => {
-      setNemotronThinkingOffChatTemplateKwargs(payloadObj);
-    },
-    {
-      shouldPatch: ({ model }) =>
-        model.api === "openai-completions" &&
-        params.thinkingLevel === "off" &&
-        isVllmNemotronModel(model),
-    },
-  );
-}
-
 export function wrapVllmProviderStream(ctx: ProviderWrapStreamFnContext): StreamFn | undefined {
   if (!isVllmProviderId(ctx.provider) || (ctx.model && ctx.model.api !== "openai-completions")) {
     return undefined;
@@ -117,9 +92,25 @@ export function wrapVllmProviderStream(ctx: ProviderWrapStreamFnContext): Stream
   if (!qwenFormat && !shouldHandleNemotron) {
     return undefined;
   }
-  return createVllmProviderThinkingWrapper({
-    baseStreamFn: ctx.streamFn,
-    qwenFormat,
-    thinkingLevel: ctx.thinkingLevel,
-  });
+  return composeProviderStreamWrappers(
+    ctx.streamFn,
+    qwenFormat &&
+      ((streamFn) =>
+        createVllmQwenThinkingWrapper({
+          baseStreamFn: streamFn,
+          format: qwenFormat,
+          thinkingLevel: ctx.thinkingLevel,
+        })),
+    (streamFn) =>
+      createPayloadPatchStreamWrapper(
+        streamFn,
+        ({ payload }) => setNemotronThinkingOffChatTemplateKwargs(payload),
+        {
+          shouldPatch: ({ model }) =>
+            model.api === "openai-completions" &&
+            ctx.thinkingLevel === "off" &&
+            isVllmNemotronModel(model),
+        },
+      ),
+  );
 }

--- a/extensions/xai/stream.ts
+++ b/extensions/xai/stream.ts
@@ -273,14 +273,12 @@ function hasXaiFastModeParam(extraParams: Record<string, unknown> | undefined): 
 export function wrapXaiProviderStream(ctx: ProviderWrapStreamFnContext): StreamFn | undefined {
   const extraParams = ctx.extraParams;
   const toolStreamEnabled = extraParams?.tool_stream !== false;
-  return composeProviderStreamWrappers(ctx.streamFn, (streamFn) => {
-    let wrappedStreamFn = createXaiToolPayloadCompatibilityWrapper(streamFn);
-    if (hasXaiFastModeParam(extraParams)) {
-      wrappedStreamFn = createXaiFastModeWrapper(wrappedStreamFn, () =>
-        resolveXaiFastMode(extraParams),
-      );
-    }
-    wrappedStreamFn = createPlainTextToolCallCompatWrapper(wrappedStreamFn);
-    return createToolStreamWrapper(wrappedStreamFn, toolStreamEnabled);
-  });
+  return composeProviderStreamWrappers(
+    ctx.streamFn,
+    createXaiToolPayloadCompatibilityWrapper,
+    hasXaiFastModeParam(extraParams) &&
+      ((streamFn) => createXaiFastModeWrapper(streamFn, () => resolveXaiFastMode(extraParams))),
+    createPlainTextToolCallCompatWrapper,
+    (streamFn) => createToolStreamWrapper(streamFn, toolStreamEnabled),
+  );
 }


### PR DESCRIPTION
## What Problem This Solves

Bundled provider plugins assembled stream wrappers through independently nested chains, increasing the chance that reasoning replay, request routing, authentication, tool events, fast-mode selection, or thinking payloads diverged across providers.

## Why This Change Was Made

Use the existing public, left-to-right provider stream composer as the single composition contract for xAI, OpenRouter, and vLLM. Preserve OpenRouter routing, proxy thinking, DeepSeek replay, authorization, and Anthropic prefill; preserve xAI lazy fast mode and tool streaming; retain vLLM's runtime-model Nemotron predicate even when the configured Qwen model ID is stale.

No SDK exports, provider credentials, configuration options, model routes, dependencies, Codex surfaces, or Gateway protocol change. Production code decreases by 15 lines (+45/-60).

## User Impact

Provider streaming retains its vendor-specific safeguards through fewer duplicate assembly paths. The regression prevents a stale model alias from suppressing Nemotron thinking safety. No operator action or configuration migration is required.

## Evidence

### Exact head and required checks

- Exact PR head: `b96c720f3119175480a4e207296bff3d3ae90778`.
- Exact-head canonical GitHub CI: run `30329077772`, native watcher emitted `GREEN` and exit 0.
- Focused xAI, OpenRouter, vLLM, and shared-provider-composer tests: 6 files, 3 Vitest shards, 140 passing.
- `pnpm check:changed`: both extension typechecks, formatting, zero-warning lint, public SDK baseline, plugin boundaries, dependency and import-cycle guards passed.
- `pnpm build`: complete production build, bundled plugins, CLI, Control UI, and all 143 public SDK exports passed.
- Structured Codex autoreview: clean, no accepted or actionable findings.
- `git diff --check`: passed.
- Both task-owned Blacksmith Testboxes were stopped after proof.

### Real built-Gateway streaming proof

After the review requested actual streamed behavior, reran the unchanged PR head on dedicated Testbox `tbx_01kykgp98enh73gpwz60h01eb0`. Used the repository's real `scripts/e2e/mock-openai-server.mjs` on a temporary loopback port, the complete built Gateway on a second free loopback port, an isolated `OPENCLAW_STATE_DIR`, an explicitly isolated `OPENCLAW_CONFIG_PATH`, and a fresh ephemeral Gateway token.

Executed and asserted actual HTTP SSE streams for each changed provider, not only health, discovery, unit mocks, or model listing:

- xAI: captured a real SSE `text_delta` and final response marker; asserted `grok-4` became `grok-4-fast`, native tools survived, and unsupported reasoning fields were removed.
- OpenRouter DeepSeek: captured a real SSE `text_delta` and final response marker; asserted provider routing, `reasoning.effort=high`, assistant `reasoning_content` replay, and Authorization, HTTP-Referer, and X-OpenRouter-Title headers without exposing their values.
- OpenRouter Anthropic: captured a real SSE `text_delta` and final response marker; observed the real plugin log `removed 1 trailing assistant prefill message`; asserted the outgoing messages end in the user turn and retain high reasoning plus all three header-presence flags.
- vLLM: captured a real SSE `text_delta` and final response marker using a stale `Qwen/Qwen3-8B` context with runtime `nemotron-3-super`; asserted `enable_thinking=false`, `preserve_thinking=true`, and `force_nonempty_content=true`.
- Drove a real authenticated built-Gateway `openclaw agent` turn for xAI, OpenRouter, and vLLM. Asserted each returned its provider-specific SSE marker through the Gateway.
- Parsed the temporary mock request log and proved seven actual `POST /v1/chat/completions` streaming requests across `grok-4`, `grok-4-fast`, `deepseek/deepseek-v4-pro`, `anthropic/claude-opus-4.6`, and `nemotron-3-super`.

Redacted observed proof:

```json
{"provider":"xai","transport":"real-loopback-SSE","streamChunks":1,"markerVerified":true,"payloadAssertions":"passed"}
{"provider":"openrouter","transport":"real-loopback-SSE","streamChunks":1,"markerVerified":true,"payloadAssertions":"passed","authorization":true,"referer":true,"title":true}
{"openrouterPrefillObserved":{"roles":["user"],"reasoning":"high"}}
{"provider":"openrouter-anthropic-prefill","transport":"real-loopback-SSE","streamChunks":1,"markerVerified":true,"payloadAssertions":"passed","authorization":true,"referer":true,"title":true}
{"provider":"vllm","transport":"real-loopback-SSE","streamChunks":1,"markerVerified":true,"payloadAssertions":"passed"}
{"provider":"xai","gateway":"authenticated-built-agent","transport":"loopback-SSE","markerVerified":true,"externalCredentials":"none"}
{"provider":"openrouter","gateway":"authenticated-built-agent","transport":"loopback-SSE","markerVerified":true,"externalCredentials":"none"}
{"provider":"vllm","gateway":"authenticated-built-agent","transport":"loopback-SSE","markerVerified":true,"externalCredentials":"none"}
{"requestLog":"temporary","streamedPosts":7,"models":["anthropic/claude-opus-4.6","deepseek/deepseek-v4-pro","grok-4","grok-4-fast","nemotron-3-super"],"externalCredentials":"none","assertions":"passed"}
```

The only credential check was boolean presence: `XAI_API_KEY=false`, `OPENROUTER_API_KEY=false`, and `VLLM_API_KEY=false`. No external credentialed provider inference is claimed; the streamed requests were real network/SSE requests against the named repository-owned loopback fixture. Temporary state, logs, token, Gateway, mock server, and the proof lease were cleaned up.

### Moving-main rank-up

The PR was not rebased solely because `main` advanced. Repository policy treats behind-main drift as advisory unless strict drift is explicitly enabled; this exact unchanged head already has a green canonical CI run, a clean structured review, and complete streamed behavior proof. Refreshing it without a conflict would invalidate known-good exact-head evidence and trigger unnecessary duplicate CI.
