### PR TITLE
fix(ui): board ticket refresh tests stay reliable under load

### DIFF
--- a/ui/src/components/board/board-view.test.ts
+++ b/ui/src/components/board/board-view.test.ts
@@ -1,6 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { BoardSnapshot } from "../../lib/board/types.ts";
-import { recordBoardWidgetTicketReceipt } from "../../lib/board/widget-ticket-lifetime.ts";
 // Side-effect import: registers the custom elements mount() depends on
 // without relying on transitive fixture imports.
 import "./board-view.ts";
@@ -237,32 +236,6 @@ describe("openclaw-board-view", () => {
     expect(frameLoadFailed).toHaveBeenCalledTimes(3);
   });
 
-  it("pauses ticket refresh while hidden and re-arms when the document becomes visible", async () => {
-    vi.useFakeTimers();
-    let visibilityState: DocumentVisibilityState = "hidden";
-    vi.spyOn(document, "visibilityState", "get").mockImplementation(() => visibilityState);
-    const frameLoadFailed = vi.fn(async () => undefined);
-    const ticketedWidget = boardWidget({
-      viewTicket: "ticket",
-      viewTicketTtlMs: 30_000,
-    });
-    recordBoardWidgetTicketReceipt(ticketedWidget);
-    await mount({
-      callbacks: callbacks({ frameLoadFailed }),
-      snapshot: snapshot({ widgets: [ticketedWidget] }),
-    });
-
-    await vi.advanceTimersByTimeAsync(60_000);
-    expect(frameLoadFailed).not.toHaveBeenCalled();
-
-    visibilityState = "visible";
-    document.dispatchEvent(new Event("visibilitychange"));
-    await vi.advanceTimersByTimeAsync(999);
-    expect(frameLoadFailed).not.toHaveBeenCalled();
-    await vi.advanceTimersByTimeAsync(1);
-    expect(frameLoadFailed).toHaveBeenCalledOnce();
-  });
-
   it("schedules proactive refresh from the relative ticket TTL", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2099-01-01T00:00:00Z"));
@@ -284,30 +257,6 @@ describe("openclaw-board-view", () => {
     // 2s rules out the 1s floor, and having fired by 8s rules out the 15s a full-TTL
     // calculation would produce. Call count is left open because the unreplaced ticket
     // keeps retrying, which is a different behavior with its own test.
-    await vi.advanceTimersByTimeAsync(2_000);
-    expect(frameLoadFailed).not.toHaveBeenCalled();
-    await vi.advanceTimersByTimeAsync(6_000);
-    expect(frameLoadFailed).toHaveBeenCalled();
-  });
-
-  it("schedules proactive refresh from a delayed mount's remaining ticket lifetime", async () => {
-    vi.useFakeTimers();
-    vi.setSystemTime(new Date("2099-01-01T00:00:00Z"));
-    const frameLoadFailed = vi.fn(async () => undefined);
-    const delayedWidget = boardWidget({
-      viewTicket: "ticket",
-      viewTicketTtlMs: 30_000,
-    });
-    recordBoardWidgetTicketReceipt(delayedWidget);
-    await vi.advanceTimersByTimeAsync(10_000);
-
-    await mount({
-      callbacks: callbacks({ frameLoadFailed }),
-      snapshot: snapshot({ widgets: [delayedWidget] }),
-    });
-
-    // Same band as above: the point is that the delay came from the 20s remaining
-    // lifetime, not the full 30s TTL, which would not fire until 15s.
     await vi.advanceTimersByTimeAsync(2_000);
     expect(frameLoadFailed).not.toHaveBeenCalled();
     await vi.advanceTimersByTimeAsync(6_000);

--- a/ui/src/components/board/board-widget-frame.test.ts
+++ b/ui/src/components/board/board-widget-frame.test.ts
@@ -1,7 +1,8 @@
 /* @vitest-environment jsdom */
 
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import type { BoardViewWidget } from "../../lib/board/view-types.ts";
+import { recordBoardWidgetTicketReceipt } from "../../lib/board/widget-ticket-lifetime.ts";
 import { BoardWidgetFrameLifecycle } from "./board-widget-frame.ts";
 
 type LifecycleInternals = {
@@ -10,6 +11,31 @@ type LifecycleInternals = {
   frameRefreshAttempts: number;
   refreshFailedFrame: (widget: BoardViewWidget) => void;
 };
+
+function createTicketRefreshLifecycle(
+  widget: BoardViewWidget,
+  refreshFrame: (name: string) => Promise<void>,
+): BoardWidgetFrameLifecycle {
+  const lifecycle = new BoardWidgetFrameLifecycle({
+    connected: () => true,
+    context: () => undefined,
+    refreshFrame: () => refreshFrame,
+    reportContentHeight: () => {},
+    requestUpdate: () => {},
+    resolveFrameUrl: () => () => "",
+    root: () => document,
+    ticketRefreshEnabled: () => true,
+    widget: () => widget,
+  });
+  lifecycle.connect();
+  lifecycle.update();
+  return lifecycle;
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.useRealTimers();
+});
 
 // Drives the private terminal-failure path directly: attempts are exhausted so
 // refreshFailedFrame surfaces the terminal message for the given sandbox origin.
@@ -71,5 +97,60 @@ describe("board widget frame terminal failure message", () => {
     const message = terminalFailureError({ widget: {}, resolvedSandboxOrigin: "" });
     expect(message).toContain("authorization failed");
     expect(message).not.toContain("mcp.apps.sandboxOrigin");
+  });
+});
+
+describe("board widget frame ticket refresh", () => {
+  it("pauses while hidden and re-arms when the document becomes visible", async () => {
+    vi.useFakeTimers();
+    let visibilityState: DocumentVisibilityState = "hidden";
+    vi.spyOn(document, "visibilityState", "get").mockImplementation(() => visibilityState);
+    const refreshFrame = vi.fn(async () => undefined);
+    const widget = {
+      name: "clock",
+      revision: 1,
+      viewTicket: "ticket",
+      viewTicketTtlMs: 30_000,
+    } as BoardViewWidget;
+    recordBoardWidgetTicketReceipt(widget);
+    const lifecycle = createTicketRefreshLifecycle(widget, refreshFrame);
+
+    try {
+      await vi.advanceTimersByTimeAsync(60_000);
+      expect(refreshFrame).not.toHaveBeenCalled();
+
+      visibilityState = "visible";
+      document.dispatchEvent(new Event("visibilitychange"));
+      await vi.advanceTimersByTimeAsync(999);
+      expect(refreshFrame).not.toHaveBeenCalled();
+      await vi.advanceTimersByTimeAsync(1);
+      expect(refreshFrame).toHaveBeenCalledOnce();
+    } finally {
+      lifecycle.disconnect();
+    }
+  });
+
+  it("schedules from a delayed lifecycle's remaining ticket lifetime", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2099-01-01T00:00:00Z"));
+    const refreshFrame = vi.fn(async () => undefined);
+    const widget = {
+      name: "clock",
+      revision: 1,
+      viewTicket: "ticket",
+      viewTicketTtlMs: 30_000,
+    } as BoardViewWidget;
+    recordBoardWidgetTicketReceipt(widget);
+    await vi.advanceTimersByTimeAsync(10_000);
+    const lifecycle = createTicketRefreshLifecycle(widget, refreshFrame);
+
+    try {
+      await vi.advanceTimersByTimeAsync(4_999);
+      expect(refreshFrame).not.toHaveBeenCalled();
+      await vi.advanceTimersByTimeAsync(1);
+      expect(refreshFrame).toHaveBeenCalledOnce();
+    } finally {
+      lifecycle.disconnect();
+    }
   });
 });


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where two board ticket-refresh tests could fail under a saturated Control UI worker pool even though the board runtime was unchanged. The failures made unrelated branches red and encouraged retries instead of trustworthy CI results.

The affected cases were the hidden-document re-arm path and the delayed-mount remaining-lifetime path.

## Why This Change Was Made

Both cases asserted frame-lifecycle timer policy through an asynchronously mounted Lit board tree. That made the fake-timer assertions depend on when the cell's render cycle happened to call `BoardWidgetFrameLifecycle.update()` under load.

The tests now live beside the frame lifecycle and invoke that owner directly. The visibility listener, ticket receipt timestamp, retry callback, and production timer code are unchanged; only the unrelated Lit scheduling layer is removed from these two tests. This also lets the delayed-lifetime case restore the stronger exact 4,999/5,000 ms boundary.

This is the best-fix boundary because the reported failures are test-scheduling races, not evidence of incorrect runtime scheduling. Widening the time band was already tried in #114585 and still left the test dependent on render timing. Adding a production-only completion seam would expand a test-only reliability fix into runtime API surface.

Provenance: the hidden-document case was added in #114748 by and merged by @steipete. The delayed-mount case originated in #101328 by and merged by @giodl73-repo; #114585 widened its assertion band but carried forward the asynchronous mount dependency.

## User Impact

No user-visible behavior changes. Maintainers get deterministic board ticket-refresh coverage and fewer unrelated Control UI suite failures.

## Evidence

- Baseline on current `main`: 100 bounded repetitions of `node scripts/run-vitest.mjs ui/src/components/board/board-view.test.ts` passed. The isolated non-reproduction matches the reported parallel-load-only failure mode.
- Focused after-fix proof: 100 bounded repetitions of `node scripts/run-vitest.mjs ui/src/components/board/board-view.test.ts ui/src/components/board/board-widget-frame.test.ts` passed, 46 tests per iteration / 4,600 total test executions.
- Full UI load proof on Blacksmith Testbox `tbx_01kykept4rw33bz8ysv8ame7mx` ([run](https://github.com/openclaw/openclaw/actions/runs/30328033481)):
  - iteration 1: 6,066 passed, 31 skipped
  - iteration 2: both board files passed; the run stopped only on the pre-existing `viewer-facepile.test.ts` avatar-blob flake already documented as the known gap in #114585
- `OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 CI=1 pnpm check:changed`: passed, including test TypeScript, lint, formatting, i18n, and repository guards.
- `.agents/skills/autoreview/scripts/autoreview --mode uncommitted --stream-engine-output`: clean, no accepted/actionable findings; patch correct at 0.93 confidence.
- `git diff --check`: passed.
