### PR TITLE
fix(tui): recover chat after dropped Gateway events

### DIFF
--- a/src/tui/tui-event-handlers.test.ts
+++ b/src/tui/tui-event-handlers.test.ts
@@ -184,6 +184,40 @@ describe("tui-event-handlers: handleAgentEvent", () => {
     };
   };
 
+  it("recovers a missed final from authoritative history after an event gap", async () => {
+    const { state, loadHistory, reconcileHistoryAfterGap, setActivityStatus } =
+      createHandlersHarness({ state: { activeChatRunId: "run-gap" } });
+
+    reconcileHistoryAfterGap();
+
+    await vi.waitFor(() => expect(state.activeChatRunId).toBeNull());
+    expect(loadHistory).toHaveBeenCalledTimes(1);
+    expect(setActivityStatus).toHaveBeenCalledWith("idle");
+  });
+
+  it("preserves an in-flight run when gap-recovery history reports it is still active", async () => {
+    const { state, loadHistory, reconcileHistoryAfterGap, setActivityStatus } =
+      createHandlersHarness({ state: { activeChatRunId: "run-gap" } });
+    loadHistory.mockResolvedValue({ loaded: true, inFlightRunId: "run-gap" });
+
+    reconcileHistoryAfterGap();
+
+    await vi.waitFor(() => expect(loadHistory).toHaveBeenCalledTimes(1));
+    expect(state.activeChatRunId).toBe("run-gap");
+    expect(setActivityStatus).not.toHaveBeenCalledWith("idle");
+  });
+
+  it("reloads the selected session after an event gap while no run is active", async () => {
+    const { state, loadHistory, reconcileHistoryAfterGap } = createHandlersHarness({
+      state: { activeChatRunId: null },
+    });
+
+    reconcileHistoryAfterGap();
+
+    await vi.waitFor(() => expect(loadHistory).toHaveBeenCalledTimes(1));
+    expect(state.activeChatRunId).toBeNull();
+  });
+
   it("processes tool events when runId matches activeChatRunId (even if sessionId differs)", () => {
     const { chatLog, tui, handleAgentEvent } = createHandlersHarness({
       state: { currentSessionId: "session-xyz", activeChatRunId: "run-123" },

--- a/src/tui/tui-event-handlers.ts
+++ b/src/tui/tui-event-handlers.ts
@@ -706,6 +706,17 @@ export function createEventHandlers(context: EventHandlerContext) {
   // registered so it does not re-arm a draft the abort path would then drop.
   const isRunObserved = (runId: string) => sessionRuns.has(runId);
 
+  const reconcileHistoryAfterGap = () => {
+    const { runIds, displayedRunIds } = collectTrackedSessionRunIds();
+    if (runIds.size === 0) {
+      runCoordinator.queueHistoryReload();
+      return;
+    }
+    // A dropped final cannot distinguish a finished run from a still-streaming
+    // one; authoritative history must either finalize it or restore it.
+    runCoordinator.queueGapHistoryReload(runIds, displayedRunIds);
+  };
+
   return {
     handleChatEvent,
     handleAgentEvent,
@@ -716,6 +727,7 @@ export function createEventHandlers(context: EventHandlerContext) {
     reconnectStreamingWatchdog,
     consumeCompletedRunForPendingSend,
     isRunObserved,
+    reconcileHistoryAfterGap,
     flushPendingHistoryRefreshIfIdle,
     dispose,
   };

--- a/src/tui/tui-pty-gap-fixture-test-support.ts
+++ b/src/tui/tui-pty-gap-fixture-test-support.ts
@@ -1,0 +1,40 @@
+// Keep gap-only test behavior out of the shared, size-bounded PTY fixture.
+export const TUI_PTY_GAP_HISTORY_FIXTURE_SCRIPT = `
+      let gapHistorySessionKey: string | null = null;
+
+      function beginGapHistoryRecovery(
+        backend: Pick<TuiBackend, "onEvent" | "onGap">,
+        runId: string,
+        sessionKey: string,
+      ) {
+        gapHistorySessionKey = sessionKey;
+        setTimeout(() => {
+          backend.onEvent?.({
+            event: "agent",
+            payload: {
+              runId,
+              sessionKey,
+              stream: "lifecycle",
+              data: { phase: "start" },
+            },
+          });
+          backend.onGap?.({ expected: 4, received: 5 });
+        }, 0);
+        return { runId };
+      }
+
+      function loadGapHistory(sessionKey: string) {
+        if (gapHistorySessionKey !== sessionKey) {
+          return undefined;
+        }
+        gapHistorySessionKey = null;
+        record("gapHistoryRecovered", { sessionKey });
+        return {
+          sessionInfo: sessionEntry(sessionKey),
+          messages: [
+            { role: "user", content: "history gap proof" },
+            { role: "assistant", content: "PTY_GAP_RECOVERED" },
+          ],
+        };
+      }
+`;

--- a/src/tui/tui-pty-harness-fixture-test-support.ts
+++ b/src/tui/tui-pty-harness-fixture-test-support.ts
@@ -2,6 +2,7 @@
 import { readFile, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
+import { TUI_PTY_GAP_HISTORY_FIXTURE_SCRIPT } from "./tui-pty-gap-fixture-test-support.js";
 import { sleep, type PtyRun } from "./tui-pty-test-support.js";
 
 export async function writeTuiPtyFixtureScript(dir: string) {
@@ -110,6 +111,8 @@ export async function writeTuiPtyFixtureScript(dir: string) {
           timestamp: Date.now(),
         };
       }
+
+      ${TUI_PTY_GAP_HISTORY_FIXTURE_SCRIPT}
 
       class FixtureBackend implements TuiBackend {
         connection = { url: "pty-fixture://local" };
@@ -253,6 +256,7 @@ export async function writeTuiPtyFixtureScript(dir: string) {
             }, 0);
             return { runId };
           }
+          if (opts.message === "history gap proof") { return beginGapHistoryRecovery(this, runId, opts.sessionKey); }
           if (opts.message === "skill approval proof" || opts.message === "skill approval gap proof") {
             pendingPluginApproval = {
               id: "plugin:skill-pty",
@@ -387,6 +391,8 @@ export async function writeTuiPtyFixtureScript(dir: string) {
         async loadHistory(opts: Parameters<TuiBackend["loadHistory"]>[0]) {
           const sessionKey = opts?.sessionKey ?? "main";
           record("loadHistory", { sessionKey });
+          const gapHistory = loadGapHistory(sessionKey);
+          if (gapHistory) { return gapHistory; }
           const rapidSwitchMarker = sessionKey.endsWith("switch-a")
             ? "A"
             : sessionKey.endsWith("switch-b")

--- a/src/tui/tui-pty-harness.e2e.test.ts
+++ b/src/tui/tui-pty-harness.e2e.test.ts
@@ -364,6 +364,30 @@ describe.sequential("TUI PTY harness", () => {
   );
 
   it(
+    "recovers the visible conversation from session history after a Gateway event gap",
+    async () => {
+      const gapFixture = await startTuiFixture();
+      try {
+        await gapFixture.run.waitForOutput("local ready", STARTUP_TIMEOUT_MS);
+        await gapFixture.run.write("history gap proof\r");
+        await gapFixture.waitForLogEntry((entry) => entry.method === "gapHistoryRecovered");
+        await gapFixture.run.waitForOutput("PTY_GAP_RECOVERED");
+
+        await gapFixture.run.write("after gap recovery proof\r");
+        await gapFixture.waitForLogEntry(
+          (entry) =>
+            entry.method === "sendChat" &&
+            objectFieldEquals(entry, "message", "after gap recovery proof"),
+        );
+        await gapFixture.run.waitForOutput("PTY_RESPONSE: after gap recovery proof");
+      } finally {
+        await gapFixture.cleanup();
+      }
+    },
+    STARTUP_TEST_TIMEOUT_MS,
+  );
+
+  it(
     "refreshes pending workspace skill approvals after an event gap",
     async () => {
       await fixture.run.write("skill approval gap proof\r");

--- a/src/tui/tui-session-run-coordinator.test.ts
+++ b/src/tui/tui-session-run-coordinator.test.ts
@@ -218,6 +218,70 @@ describe("TuiSessionRunCoordinator", () => {
     resolveHistory?.({ loaded: true, inFlightRunId: null });
   });
 
+  it("does not finalize a gap-recovery run when authoritative history fails", async () => {
+    const { coordinator, loadHistory, finalizeHistoryOwnedRun } = createCoordinator({
+      loadHistory: async () => {
+        throw new Error("history temporarily unavailable");
+      },
+    });
+
+    coordinator.queueGapHistoryReload(["run-gap"]);
+
+    await vi.waitFor(() => expect(loadHistory).toHaveBeenCalledTimes(1));
+    await vi.waitFor(() => expect(coordinator.isHistoryReloadingRun("run-gap")).toBe(false));
+    expect(finalizeHistoryOwnedRun).not.toHaveBeenCalled();
+  });
+
+  it("reconciles every tracked run after a Gateway event gap", async () => {
+    const { coordinator, finalizeHistoryOwnedRun } = createCoordinator();
+
+    coordinator.queueGapHistoryReload(["run-first", "run-second"]);
+
+    await vi.waitFor(() => expect(finalizeHistoryOwnedRun).toHaveBeenCalledTimes(2));
+    expect(finalizeHistoryOwnedRun).toHaveBeenCalledWith({
+      runId: "run-first",
+      result: { loaded: true, inFlightRunId: null },
+      previouslyDisplayed: false,
+    });
+    expect(finalizeHistoryOwnedRun).toHaveBeenCalledWith({
+      runId: "run-second",
+      result: { loaded: true, inFlightRunId: null },
+      previouslyDisplayed: false,
+    });
+  });
+
+  it.each([
+    { firstHistory: "still streaming", inFlightRunId: "run-gap" },
+    { firstHistory: "already completed", inFlightRunId: null },
+  ])(
+    "defers overlapping gap finalization when the older history is $firstHistory",
+    async ({ inFlightRunId }) => {
+      let resolveHistory: ((result: TuiHistoryLoadResult) => void) | undefined;
+      const { coordinator, loadHistory, finalizeHistoryOwnedRun } = createCoordinator({
+        loadHistory: () =>
+          new Promise<TuiHistoryLoadResult>((resolve) => {
+            resolveHistory = resolve;
+          }),
+      });
+
+      coordinator.queueGapHistoryReload(["run-gap"]);
+      coordinator.queueGapHistoryReload(["run-gap"]);
+      expect(loadHistory).toHaveBeenCalledTimes(1);
+
+      resolveHistory?.({ loaded: true, inFlightRunId });
+      await vi.waitFor(() => expect(loadHistory).toHaveBeenCalledTimes(2));
+      expect(finalizeHistoryOwnedRun).not.toHaveBeenCalled();
+
+      resolveHistory?.({ loaded: true, inFlightRunId: null });
+      await vi.waitFor(() => expect(finalizeHistoryOwnedRun).toHaveBeenCalledTimes(1));
+      expect(finalizeHistoryOwnedRun).toHaveBeenCalledWith({
+        runId: "run-gap",
+        result: { loaded: true, inFlightRunId: null },
+        previouslyDisplayed: false,
+      });
+    },
+  );
+
   it("discards a stale in-flight reload when the selected session resets", async () => {
     let resolveHistory: ((result: TuiHistoryLoadResult) => void) | undefined;
     const { coordinator, finalizeHistoryOwnedRun, replayHistoryRunEvent } = createCoordinator({

--- a/src/tui/tui-session-run-coordinator.ts
+++ b/src/tui/tui-session-run-coordinator.ts
@@ -40,6 +40,7 @@ export class TuiSessionRunCoordinator {
   private readonly historyReloadRunIds = new Set<string>();
   private readonly historyOwnedReloadRunIds = new Set<string>();
   private readonly historyDisplayedReloadRunIds = new Set<string>();
+  private readonly gapRecoveryReloadRunIds = new Set<string>();
   private readonly queuedHistoryReloadRunIds = new Set<string>();
   private readonly deferredHistoryRunEvents = new Map<string, ChatEvent>();
   private readonly sessionMessagePersistenceRunIds = new Set<string>();
@@ -298,6 +299,17 @@ export class TuiSessionRunCoordinator {
 
     const generation = this.historyReloadGeneration;
     const runIds = Array.from(this.queuedHistoryReloadRunIds);
+    // A second gap may arrive before this reload finishes; keep each drain's
+    // ownership separate so the next reload cannot lose its finalization.
+    const historyOwnedRunIds = new Set(
+      runIds.filter((runId) => this.historyOwnedReloadRunIds.delete(runId)),
+    );
+    const historyDisplayedRunIds = new Set(
+      runIds.filter((runId) => this.historyDisplayedReloadRunIds.delete(runId)),
+    );
+    const gapRecoveryRunIds = new Set(
+      runIds.filter((runId) => this.gapRecoveryReloadRunIds.delete(runId)),
+    );
     this.queuedHistoryReloadRunIds.clear();
     this.historyReloadQueued = false;
     this.historyReloadInFlight = true;
@@ -307,14 +319,17 @@ export class TuiSessionRunCoordinator {
         return;
       }
       for (const runId of runIds) {
+        if (this.queuedHistoryReloadRunIds.has(runId)) {
+          continue;
+        }
         this.historyReloadRunIds.delete(runId);
         const deferred = this.deferredHistoryRunEvents.get(runId);
         this.deferredHistoryRunEvents.delete(runId);
-        const historyOwned = this.historyOwnedReloadRunIds.delete(runId);
-        const previouslyDisplayed = this.historyDisplayedReloadRunIds.delete(runId);
+        const historyOwned = historyOwnedRunIds.has(runId);
+        const previouslyDisplayed = historyDisplayedRunIds.has(runId);
         const restoredInFlight = result.loaded && result.inFlightRunId === runId;
 
-        if (historyOwned && !restoredInFlight) {
+        if (historyOwned && !restoredInFlight && (result.loaded || !gapRecoveryRunIds.has(runId))) {
           this.context.finalizeHistoryOwnedRun({ runId, result, previouslyDisplayed });
         }
         if (deferred && (!result.loaded || historyOwned || restoredInFlight)) {
@@ -367,6 +382,22 @@ export class TuiSessionRunCoordinator {
     this.drainHistoryReloadQueue();
   }
 
+  queueGapHistoryReload(runIds: Iterable<string>, displayedRunIds: Iterable<string> = []): void {
+    if (!this.context.loadHistory) {
+      void this.context.refreshSessionInfo?.();
+      return;
+    }
+    const trackedRunIds = Array.from(runIds);
+    if (trackedRunIds.length === 0) {
+      this.queueHistoryReload();
+      return;
+    }
+    for (const runId of trackedRunIds) {
+      this.gapRecoveryReloadRunIds.add(runId);
+    }
+    this.queueHistoryReload(trackedRunIds, trackedRunIds, displayedRunIds);
+  }
+
   clear(): void {
     this.historyReloadGeneration += 1;
     this.sessionRuns.clear();
@@ -380,6 +411,7 @@ export class TuiSessionRunCoordinator {
     this.historyReloadRunIds.clear();
     this.historyOwnedReloadRunIds.clear();
     this.historyDisplayedReloadRunIds.clear();
+    this.gapRecoveryReloadRunIds.clear();
     this.queuedHistoryReloadRunIds.clear();
     this.deferredHistoryRunEvents.clear();
     this.confirmedStreamRunIds.clear();

--- a/src/tui/tui.ts
+++ b/src/tui/tui.ts
@@ -1403,6 +1403,7 @@ export async function runTui(opts: RunTuiOptions): Promise<TuiResult> {
     reconnectStreamingWatchdog,
     consumeCompletedRunForPendingSend,
     isRunObserved,
+    reconcileHistoryAfterGap,
     flushPendingHistoryRefreshIfIdle,
     dispose: disposeEventHandlers,
   } = createEventHandlers({
@@ -1790,6 +1791,7 @@ export async function runTui(opts: RunTuiOptions): Promise<TuiResult> {
       return;
     }
     setConnectionStatus(`event gap: expected ${info.expected}, got ${info.received}`, 5000);
+    reconcileHistoryAfterGap();
     void (async () => {
       try {
         await pluginApprovals?.refresh();


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where terminal users would lose a completed assistant response, retain a stuck busy indicator, or become unable to submit the next message when the Gateway reported dropped events.

## Why This Change Was Made

Recover the selected conversation through the existing bounded, session-aware history coordinator. Preserve live runs when authoritative history is unavailable or still reports them in flight; reconcile every tracked run; and allow only the newest overlapping history reload to finalize a completed session. No Gateway protocol, provider, configuration, dependency, SQLite, or storage contract is changed.

## User Impact

A transient Gateway event gap no longer requires restarting the TUI. The persisted answer reappears, completed sessions return to idle, genuine streaming continues, concurrent runs stay correctly owned, and the next prompt can be submitted normally.

## Evidence

### Before: reproducible real-terminal failure on clean main

```text
FAIL  src/tui/tui-pty-harness.e2e.test.ts
  TUI PTY harness > recovers the visible conversation from session history after a Gateway event gap
  Error: timed out waiting for fixture log entry
  sendChat: history gap proof
  listPluginApprovals: pending=false
  listTaskSuggestions: pending=false
  status: event gap: expected 4, got 5
  missing: gapHistoryRecovered
```

### After: real terminal and real Gateway

```text
PASS  src/tui/tui-pty-harness.e2e.test.ts (43 tests)
  recovers the visible conversation from session history after a Gateway event gap
  renders: PTY_GAP_RECOVERED
  accepts: after gap recovery proof
  renders: PTY_RESPONSE: after gap recovery proof
PASS  src/tui/tui-pty-local.e2e.test.ts (16 tests)
  preserves a disconnected draft across a real Gateway restart
  renders messages sent by another real Gateway client without restarting
  forwards an active-run prompt through the real Gateway followup queue
  cancels an admitted followup with Esc before it reaches the model
  collects two TUI-client prompts into one real Gateway followup turn
Test Files  2 passed (2)
     Tests  59 passed (59)
```

- Full TUI unit suite: 897 passing tests across 35 files.
- Dedicated deterministic regressions cover idle gaps, failed history reads, every tracked run, in-flight history, and overlapping gaps with both streaming and already-completed first snapshots.
- Eight changed files pass oxfmt, full type-aware TUI lint, the max-lines ratchet, core and core-test tsgo checks, runtime-cycle checks, dependency/plugin-boundary guards, and the complete pnpm check:changed gate.
- Final independent Codex autoreview: no accepted or actionable findings.
- Remote proof: Blacksmith Testbox tbx_01kykcb0gf50qsjgvaf418dp8c, [execution and runner provenance](https://github.com/openclaw/openclaw/actions/runs/30326072677); final six-minute multi-phase run exited 0.
- Exact PR CI: [run 30329420347](https://github.com/openclaw/openclaw/actions/runs/30329420347).
- Reviewed and published head: d1b89e982b6f230db7bf1fbb74b187baa19bce4b.