### PR TITLE
fix(tool-display): avoid recursive search summaries

### DIFF
--- a/src/agents/tool-display-exec.ts
+++ b/src/agents/tool-display-exec.ts
@@ -306,8 +306,7 @@ function isUnsafeSearchSummaryPattern(pattern: string): boolean {
 
 // Match the two labels this formatter emits, without hiding normal prose such as
 // "search engine" or "search textual data".
-const GENERATED_SEARCH_SUMMARY_FRAGMENT_RE =
-  /^search\s+(?:["']|text(?:\s+in(?:\s|$)|$))/iu;
+const GENERATED_SEARCH_SUMMARY_FRAGMENT_RE = /^search\s+(?:["']|text(?:\s+in(?:\s|$)|$))/iu;
 
 function containsGeneratedSearchSummary(pattern: string): boolean {
   return pattern

--- a/src/agents/tool-display-exec.ts
+++ b/src/agents/tool-display-exec.ts
@@ -118,6 +118,9 @@ function summarizeKnownExec(words: string[]): string {
     const pattern = optionValue(words, ["-e", "--regexp"]) ?? positional[0];
     const target = positional.length > 1 ? positional.at(-1) : undefined;
     if (pattern) {
+      if (isUnsafeSearchSummaryPattern(pattern)) {
+        return target ? `search text in ${target}` : "search text";
+      }
       return target ? `search "${pattern}" in ${target}` : `search "${pattern}"`;
     }
     return "search text";
@@ -288,6 +291,17 @@ function summarizeKnownExec(words: string[]): string {
     return `run ${bin}`;
   }
   return /^[A-Za-z0-9._/-]+$/.test(arg) ? `run ${bin} ${arg}` : `run ${bin}`;
+}
+
+function isUnsafeSearchSummaryPattern(pattern: string): boolean {
+  const trimmed = pattern.trim();
+  return (
+    !trimmed ||
+    pattern.length > 120 ||
+    /[\r\n`]/u.test(pattern) ||
+    /^Bash failed:/iu.test(trimmed) ||
+    /(?:^|(?:\||->)\s*)search\s+["']/iu.test(trimmed)
+  );
 }
 
 function summarizePipeline(stage: string): string {

--- a/src/agents/tool-display-exec.ts
+++ b/src/agents/tool-display-exec.ts
@@ -300,8 +300,19 @@ function isUnsafeSearchSummaryPattern(pattern: string): boolean {
     pattern.length > 120 ||
     /[\r\n`]/u.test(pattern) ||
     /^Bash failed:/iu.test(trimmed) ||
-    /(?:^|(?:\||->)\s*)search\s+["']/iu.test(trimmed)
+    containsGeneratedSearchSummary(trimmed)
   );
+}
+
+// Match the two labels this formatter emits, without hiding normal prose such as
+// "search engine" or "search textual data".
+const GENERATED_SEARCH_SUMMARY_FRAGMENT_RE =
+  /^search\s+(?:["']|text(?:\s+in(?:\s|$)|$))/iu;
+
+function containsGeneratedSearchSummary(pattern: string): boolean {
+  return pattern
+    .split(/(?:\||->)/u)
+    .some((fragment) => GENERATED_SEARCH_SUMMARY_FRAGMENT_RE.test(fragment.trim()));
 }
 
 function summarizePipeline(stage: string): string {

--- a/src/agents/tool-display.test.ts
+++ b/src/agents/tool-display.test.ts
@@ -224,6 +224,50 @@ describe("tool display details", () => {
     expect(detail).toBe("print lines 1-80 from extensions/discord/src/draft-stream.ts");
   });
 
+  it("keeps normal search patterns concise", () => {
+    for (const [command, expected] of [
+      ['rg "foo|bar" src/agents', 'search "foo|bar" in src/agents'],
+      ["rg 'search engine' src/agents", 'search "search engine" in src/agents'],
+    ]) {
+      expect(
+        formatToolDetail(
+          resolveToolDisplay({ name: "exec", args: { command }, detailMode: "explain" }),
+        ),
+      ).toBe(expected);
+    }
+  });
+
+  it("uses a neutral label for recursive or malformed search patterns", () => {
+    for (const command of [
+      `rg 'search "foo" in src/agents' src`,
+      `rg 'Bash failed: search "foo" in src|search "bar"' src`,
+      `rg 'run printf -> search "foo" in src' src`,
+      "rg 'line1\nline2' src",
+      "rg 'line with trailing newline\n' src",
+      "rg '`generated command`' src",
+      `rg '${"x".repeat(121)}' src`,
+      `rg '${" ".repeat(121)}x' src`,
+    ]) {
+      expect(
+        formatToolDetail(
+          resolveToolDisplay({ name: "exec", args: { command }, detailMode: "explain" }),
+        ),
+      ).toBe("search text in src");
+    }
+  });
+
+  it("sanitizes recursive search patterns inside pipelines", () => {
+    expect(
+      formatToolDetail(
+        resolveToolDisplay({
+          name: "exec",
+          args: { command: `printf x | rg 'search "foo" in src' .` },
+          detailMode: "explain",
+        }),
+      ),
+    ).toBe("print text -> search text in .");
+  });
+
   it("moves cd path to context suffix and appends raw command", () => {
     const detail = formatToolDetail(
       resolveToolDisplay({

--- a/src/agents/tool-display.test.ts
+++ b/src/agents/tool-display.test.ts
@@ -228,6 +228,8 @@ describe("tool display details", () => {
     for (const [command, expected] of [
       ['rg "foo|bar" src/agents', 'search "foo|bar" in src/agents'],
       ["rg 'search engine' src/agents", 'search "search engine" in src/agents'],
+      ["rg 'search textual data' src/agents", 'search "search textual data" in src/agents'],
+      ["rg 'research text in docs' src/agents", 'search "research text in docs" in src/agents'],
     ]) {
       expect(
         formatToolDetail(
@@ -242,6 +244,10 @@ describe("tool display details", () => {
       `rg 'search "foo" in src/agents' src`,
       `rg 'Bash failed: search "foo" in src|search "bar"' src`,
       `rg 'run printf -> search "foo" in src' src`,
+      "rg 'search text' src",
+      "rg 'search text in src/agents' src",
+      "rg 'foo|search text in src/agents' src",
+      "rg 'run printf -> search text' src",
       "rg 'line1\nline2' src",
       "rg 'line with trailing newline\n' src",
       "rg '`generated command`' src",


### PR DESCRIPTION
Closes #113401

Supersedes #113551, #114253, and #114484. Thanks @Linux2010, @qingminglong, and @Universe-ustc for converging on the shared display boundary; @qingminglong is preserved as a commit co-author.

## What Problem This Solves

Fixes an issue where an `rg` or `grep` pattern containing an earlier tool summary could be wrapped again as `search "..." in ...`. Browser and log output then showed recursive or malformed command labels that obscured the real shell failure.

## Why This Change Was Made

The shared exec-summary formatter now recognizes its complete emitted search-summary grammar: quoted summaries and neutral `search text` / `search text in ...` labels, including fragments after pipelines and arrows. It falls back to `search text` only for those generated summaries, failure presentation text, raw multiline/backtick content, blank content, or pathological length. Ordinary patterns—including `search engine`, `search textual data`, `research text`, and regex alternation such as `foo|bar`—retain their concise detail.

## User Impact

Search failures remain readable and non-recursive in tool timelines, while normal `rg`/`grep` commands keep their useful pattern and target summary.

## Evidence

Blacksmith Testbox `tbx_01kykkngys9eeafznew4tmfm1y` / run https://github.com/openclaw/openclaw/actions/runs/30332213361 on final head `1967346194472f6943491436027ee39799c29734`:

- focused tool-display suite: 57 tests passed
- `check:changed`: formatting, production/test typechecks, lint, plugin boundaries, dependency guards, import cycles, state guards, and architecture checks passed

Observed after-fix formatter invocation through the real TypeScript runtime:

```json
{"unsafe":"search text in target","normal":"search \"search engine\" in target"}
```

The unsafe input was `rg 'search text in src' target`; the normal input was `rg 'search engine' target`. Regression cases also cover quoted summaries, raw shell pipelines, unquoted summaries after `|` and `->`, boundary newlines, padded length, backticks, failure prefixes, and preserved nearby prose.

Final branch autoreview on current `main`: clean, no accepted/actionable findings.
