### PR TITLE
fix(agents): reject non-UTF-8 files in edit and apply_patch

### DIFF
--- a/src/agents/apply-patch.test.ts
+++ b/src/agents/apply-patch.test.ts
@@ -159,6 +159,29 @@ describe("applyPatch", () => {
     expect(result.summary.modified).toEqual(["source.txt"]);
   });
 
+  it("rejects non-UTF-8 files without touching a single byte", async () => {
+    await withTempDir(async (dir) => {
+      // Lossy decode + rewrite would turn every invalid byte into U+FFFD, so
+      // the patch must fail before anything is written.
+      const filePath = path.join(dir, "recette.txt");
+      const original = Buffer.from(
+        "2320436166e9206d656e750a70726963653a20350a6e61ef766520646573736572740a",
+        "hex",
+      );
+      await fs.writeFile(filePath, original);
+
+      const patch = `*** Begin Patch
+*** Update File: recette.txt
+@@
+-price: 5
++price: 7
+*** End Patch`;
+
+      await expect(applyPatch(patch, { cwd: dir })).rejects.toThrow(/not valid UTF-8/);
+      expect(await fs.readFile(filePath)).toEqual(original);
+    });
+  });
+
   it("returns a terminal no-op without rewriting unchanged update hunks", async () => {
     const memory = createMemoryPatchSandbox({
       "source.txt": "foo\nbar\n",

--- a/src/agents/apply-patch.ts
+++ b/src/agents/apply-patch.ts
@@ -285,13 +285,26 @@ type PatchFileOps = {
   mkdirp: (dir: string) => Promise<void>;
 };
 
+// Lossy decoding rewrites invalid bytes to U+FFFD, and writing the result
+// back makes the corruption permanent. Fail the patch before anything is
+// written so the file stays byte-for-byte intact.
+function decodeUtf8Strict(buffer: Buffer, filePath: string): string {
+  try {
+    return new TextDecoder("utf-8", { fatal: true }).decode(buffer);
+  } catch {
+    throw new Error(
+      `Cannot apply patch to ${filePath}: file is not valid UTF-8; edit it in an editor that supports its encoding.`,
+    );
+  }
+}
+
 function resolvePatchFileOps(options: ApplyPatchOptions): PatchFileOps {
   if (options.sandbox) {
     const { root, bridge } = options.sandbox;
     return {
       readFile: async (filePath) => {
         const buf = await bridge.readFile({ filePath, cwd: root });
-        return buf.toString("utf8");
+        return decodeUtf8Strict(buf, filePath);
       },
       writeFile: (filePath, content) => bridge.writeFile({ filePath, cwd: root, data: content }),
       remove: (filePath) => bridge.remove({ filePath, cwd: root, force: false }),
@@ -303,7 +316,7 @@ function resolvePatchFileOps(options: ApplyPatchOptions): PatchFileOps {
   return {
     readFile: async (filePath) => {
       if (!workspaceOnly) {
-        return await fs.readFile(filePath, "utf8");
+        return decodeUtf8Strict(await fs.readFile(filePath), filePath);
       }
       const opened = await openRootFile({
         absolutePath: filePath,
@@ -312,7 +325,7 @@ function resolvePatchFileOps(options: ApplyPatchOptions): PatchFileOps {
       });
       assertBoundaryRead(opened, filePath);
       try {
-        return syncFs.readFileSync(opened.fd, "utf8");
+        return decodeUtf8Strict(syncFs.readFileSync(opened.fd), filePath);
       } finally {
         syncFs.closeSync(opened.fd);
       }

--- a/src/agents/sessions/tools/edit.test.ts
+++ b/src/agents/sessions/tools/edit.test.ts
@@ -67,6 +67,31 @@ describe("edit tool", () => {
     ).rejects.toThrow(`${"a".repeat(799)}\n... (truncated)`);
   });
 
+  it("rejects non-UTF-8 files without touching a single byte", async () => {
+    // Lossy decode + rewrite would turn every invalid byte into U+FFFD, so
+    // the tool must refuse before writing anything.
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-edit-tool-"));
+    const filePath = path.join(tmpDir, "recette.txt");
+    const original = Buffer.from(
+      "2320436166e9206d656e750a70726963653a20350a6e61ef766520646573736572740a",
+      "hex",
+    );
+    await fs.writeFile(filePath, original);
+    const tool = createEditTool(tmpDir);
+
+    await expect(
+      tool.execute(
+        "call-1",
+        {
+          path: filePath,
+          edits: [{ oldText: "price: 5", newText: "price: 7" }],
+        },
+        undefined,
+      ),
+    ).rejects.toThrow(/not valid UTF-8/);
+    expect(await fs.readFile(filePath)).toEqual(original);
+  });
+
   it("recovers success after a post-write throw when the edit already applied", async () => {
     // Some backends throw after flushing content; a readback match is the
     // contract that lets the tool report success without duplicating edits.

--- a/src/agents/sessions/tools/edit.ts
+++ b/src/agents/sessions/tools/edit.ts
@@ -437,6 +437,16 @@ export function createEditToolDefinition(
         }
 
         const buffer = await ops.readFile(absolutePath);
+        // buffer.toString("utf-8") silently rewrites invalid bytes to U+FFFD,
+        // and writing the decoded string back corrupts them permanently.
+        // Refuse the edit up front so the file stays byte-for-byte intact.
+        try {
+          new TextDecoder("utf-8", { fatal: true }).decode(buffer);
+        } catch {
+          throw new Error(
+            `Could not edit file: ${path}. File is not valid UTF-8; edit it in an editor that supports its encoding.`,
+          );
+        }
         const rawContent = buffer.toString("utf-8");
         try {
           if (signal?.aborted) {


### PR DESCRIPTION
## What

Fixes #114895. `edit` and `apply_patch` decoded the target file with the default lossy UTF-8 mode, so any invalid byte became U+FFFD, and the decoded string was written back in full. A single targeted edit silently corrupted every non-UTF-8 byte in the file, including bytes on untouched lines, and the returned diff hid it because both sides were derived from the same lossy string.

## How

Decode strictly and refuse before anything is written, which is the behavior the issue asks for: an unsupported file stays byte-for-byte intact and the error says why. `apply_patch` gets the guard on all three read paths (sandbox bridge, unconfined fs, workspace-root fd).

## Verification

New tests on both tools build the issue's exact byte sequence (`# Café menu\nprice: 5\nnaïve dessert\n` in latin1), attempt the `price: 5` → `price: 7` edit, and assert the operation rejects with a `not valid UTF-8` error and the file bytes are unchanged. Full files run green (`edit.test.ts` 24/24, `apply-patch.test.ts` 26/26 here; the `allows deleting a symlink itself even if it points outside cwd` case fails on pristine main too, a /var vs /private/var canonicalization issue in the fs-safe boundary check on macOS, unrelated to this change).


## Real host proof (added 2026-07-28)

Ran the built tools directly on this Mac against a real latin1 file on disk, going through the same entry points an agent session uses (`createEditTool(dir).execute(...)` and `applyPatch(input, { cwd: dir })` from the branch source), not just vitest. Transcript:

```text
== edit tool target, before (Latin-1 bytes) ==
00000000: 2320 4361 66e9 206d 656e 750a 7072 6963  # Caf. menu.pric
00000010: 653a 2035 0a6e 61ef 7665 2064 6573 7365  e: 5.na.ve desse
00000020: 7274 0a                                  rt.
edit tool rejected: Could not edit file: /tmp/utf8-guard-proof/work/recette.txt. File is not valid UTF-8; edit it in an editor that supports its encoding.
== after ==
00000000: 2320 4361 66e9 206d 656e 750a 7072 6963  # Caf. menu.pric
00000010: 653a 2035 0a6e 61ef 7665 2064 6573 7365  e: 5.na.ve desse
00000020: 7274 0a                                  rt.
bytes unchanged: true
apply_patch rejected: Failed to read file to update /tmp/utf8-guard-proof/work/recette2.txt: Cannot apply patch to /tmp/utf8-guard-proof/work/recette2.txt: file is not valid UTF-8; edit it in an editor that supports its encoding.
apply_patch bytes unchanged: true
control utf-8 edit applied: true
```

The xxd dumps before and after a rejected operation are byte identical, and a valid UTF-8 control file still edits normally, so the guard fails closed without changing supported behavior.
