### PR TITLE
refactor(sessions): consolidate SQLite lifecycle ownership

### DIFF
--- a/src/config/sessions/cleanup-service.ts
+++ b/src/config/sessions/cleanup-service.ts
@@ -580,12 +580,10 @@ export async function runSessionsCleanup(params: {
         storePath: target.storePath,
         removals,
         activeSessionKey: opts.activeKey,
-        preserveActiveWork: true,
         maintenanceOverride: {
           ...maintenance,
           mode,
         },
-        restrictArchivedTranscriptsToStoreDir: true,
       });
       const postApplyStore = loadCleanupSessionStore(target, { createIfMissing: true });
       const appliedUnreferencedArtifacts =

--- a/src/config/sessions/session-accessor.lifecycle-types.ts
+++ b/src/config/sessions/session-accessor.lifecycle-types.ts
@@ -42,6 +42,26 @@ export type ResetSessionEntryLifecycleMutation = Omit<
   "archivedTranscripts"
 >;
 
+export type ResetSessionEntryLifecycleParams = {
+  /** Preserve legacy rotation archival unless the caller appended an in-log boundary. */
+  archivePreviousTranscript?: boolean;
+  /** Runs after the persisted entry changes and any requested archival completes. */
+  afterEntryMutation?: (mutation: ResetSessionEntryLifecycleMutation) => Promise<void> | void;
+  /** Agent owner used to resolve backend transcript artifacts. */
+  agentId?: string;
+  /** Builds the persisted replacement entry from the current backend row. */
+  buildNextEntry: (context: {
+    currentEntry?: SessionEntry;
+    primaryKey: string;
+  }) => Promise<SessionEntry> | SessionEntry;
+  /** Atomically append this boundary with the reset entry mutation. */
+  resetBoundaryReason?: SessionResetBoundaryReason;
+  /** Explicit store target for SQLite session ownership. */
+  storePath: string;
+  /** Canonical key plus aliases that identify the logical entry. */
+  target: SessionLifecycleStoreTarget;
+};
+
 export type DeleteSessionEntryLifecycleResult = {
   archivedTranscripts: SessionLifecycleArchivedTranscript[];
   deleted: boolean;
@@ -49,6 +69,29 @@ export type DeleteSessionEntryLifecycleResult = {
   deletedEntry?: SessionEntry;
   deletedSessionFile?: string;
   deletedSessionId?: string;
+};
+
+export type DeleteSessionEntryLifecycleParams = {
+  /** Agent owner used to resolve backend transcript artifacts. */
+  agentId?: string;
+  /** Whether transcript artifacts should be archived/deleted with the entry. */
+  archiveTranscript: boolean;
+  /** Delete transcript rows without writing an archive artifact. */
+  deleteTranscriptWithoutArchive?: boolean;
+  /** Optional exact row guard checked under the storage writer lock. */
+  expectedEntry?: SessionEntry;
+  /** Optional provider-run identity guard checked under the storage writer lock. */
+  expectedSessionId?: string | null;
+  /** Optional owner revision guard checked under the storage writer lock. */
+  expectedLifecycleRevision?: string;
+  /** Optional persisted revision guard checked under the storage writer lock. */
+  expectedUpdatedAt?: number;
+  /** Fail when the underlying store cannot confirm a durable write. */
+  requireWriteSuccess?: boolean;
+  /** Explicit store target for SQLite session ownership. */
+  storePath: string;
+  /** Canonical key plus aliases that identify the logical entry. */
+  target: SessionLifecycleStoreTarget;
 };
 
 export type SessionEntryLifecycleRemoval = {

--- a/src/config/sessions/session-accessor.lifecycle.ts
+++ b/src/config/sessions/session-accessor.lifecycle.ts
@@ -16,19 +16,12 @@ import {
   replaceSessionEntry,
   patchSessionEntry,
 } from "./session-accessor.entry.js";
-import type {
-  DeleteSessionEntryLifecycleResult,
-  SessionArchivedTranscriptCleanupRule,
-  SessionEntryLifecycleMutationResult,
-  SessionEntryLifecycleRemoval,
-  SessionEntryLifecycleUpsert,
-} from "./session-accessor.lifecycle-types.js";
 import {
-  applySqliteSessionEntryLifecycleMutation,
+  applySqliteSessionEntryLifecycleMutation as applySessionEntryLifecycleMutation,
   applySqliteSessionEntryReplacements as applySessionEntryReplacements,
   applySqliteSessionStoreProjection as applySessionStoreProjection,
   cleanupSqliteSessionLifecycleArtifacts as cleanupSessionLifecycleArtifacts,
-  deleteSqliteSessionEntryLifecycle,
+  deleteSqliteSessionEntryLifecycle as deleteSessionEntryLifecycle,
   purgeSqliteDeletedAgentSessionEntries as purgeDeletedAgentSessionEntries,
   rollbackSqliteAgentHarnessSessionEntryLifecycle as rollbackAgentHarnessSessionEntryLifecycle,
   rollbackSqlitePluginOwnedSessionEntryLifecycle as rollbackPluginOwnedSessionEntryLifecycle,
@@ -47,18 +40,18 @@ import type {
   SessionPatchProjectionContext,
   SessionPatchProjectionFailure,
   SessionPatchProjectionResult,
-  DeleteSessionEntryLifecycleParams,
 } from "./session-accessor.types.js";
 import { resolveProjectionExistingEntry } from "./session-entry-selection.js";
-import type { ResolvedSessionMaintenanceConfig } from "./store-maintenance.js";
 import type { SessionCompactionCheckpoint, SessionEntry } from "./types.js";
 
 // Session lifecycle storage is canonical SQLite; direct exports keep reset,
 // rollback, cleanup, and bulk projections on their actual transaction owner.
 export {
+  applySessionEntryLifecycleMutation,
   applySessionEntryReplacements,
   applySessionStoreProjection,
   cleanupSessionLifecycleArtifacts,
+  deleteSessionEntryLifecycle,
   purgeDeletedAgentSessionEntries,
   resetSessionEntryLifecycle,
   rollbackAgentHarnessSessionEntryLifecycle,
@@ -288,38 +281,6 @@ export async function preserveTemporarySessionMapping<T>(
     ...(snapshot.canRestore ? {} : { snapshotFailure: snapshot.snapshotFailure }),
     ...(restoreFailure ? { restoreFailure } : {}),
   };
-}
-
-/** Keeps the broader lifecycle compatibility contract at its public boundary. */
-export async function deleteSessionEntryLifecycle(
-  params: DeleteSessionEntryLifecycleParams,
-): Promise<DeleteSessionEntryLifecycleResult> {
-  return await deleteSqliteSessionEntryLifecycle(params);
-}
-
-/** Applies exact entry lifecycle mutations and artifact cleanup at the storage boundary. */
-export async function applySessionEntryLifecycleMutation(params: {
-  agentId?: string;
-  storePath: string;
-  removals?: Iterable<SessionEntryLifecycleRemoval>;
-  upserts?: Iterable<SessionEntryLifecycleUpsert>;
-  activeSessionKey?: string;
-  maintenanceOverride?: Partial<ResolvedSessionMaintenanceConfig>;
-  skipMaintenance?: boolean;
-  preserveActiveWork?: boolean;
-  archiveReason?: "deleted" | "reset";
-  restrictArchivedTranscriptsToStoreDir?: boolean;
-  cleanupArchivedTranscripts?: {
-    rules: SessionArchivedTranscriptCleanupRule[];
-    nowMs?: number;
-  };
-  pruneUnreferencedArtifacts?: {
-    olderThanMs: number;
-    dryRun?: boolean;
-  };
-  captureArtifactCleanupError?: boolean;
-}): Promise<SessionEntryLifecycleMutationResult> {
-  return await applySqliteSessionEntryLifecycleMutation(params);
 }
 
 /**

--- a/src/config/sessions/session-accessor.sqlite-contract.ts
+++ b/src/config/sessions/session-accessor.sqlite-contract.ts
@@ -2,8 +2,9 @@ import type { SessionTranscriptUpdate } from "../../sessions/transcript-events.j
 import type { OpenClawConfig } from "../types.openclaw.js";
 import type {
   DeletedAgentSessionEntryPurgeParams,
+  DeleteSessionEntryLifecycleParams,
   DeleteSessionEntryLifecycleResult,
-  ResetSessionEntryLifecycleMutation,
+  ResetSessionEntryLifecycleParams,
   ResetSessionEntryLifecycleResult,
   SessionEntryLifecycleMutationResult,
   SessionEntryLifecycleRemoval,
@@ -177,34 +178,11 @@ export type SessionEntryReplacementUpdate<T> = {
   result: T;
 };
 
-export type ResetSessionEntryLifecycleParams = {
-  archivePreviousTranscript?: boolean;
-  afterEntryMutation?: (mutation: ResetSessionEntryLifecycleMutation) => Promise<void> | void;
-  agentId?: string;
-  buildNextEntry: (context: {
-    currentEntry?: SessionEntry;
-    primaryKey: string;
-  }) => Promise<SessionEntry> | SessionEntry;
-  resetBoundaryReason?: import("./session-reset-boundary-event.js").SessionResetBoundaryReason;
-  storePath: string;
-  target: SessionLifecycleStoreTarget;
-};
-
-export type DeleteSessionEntryLifecycleParams = {
-  agentId?: string;
-  archiveTranscript: boolean;
-  deleteTranscriptWithoutArchive?: boolean;
-  expectedEntry?: SessionEntry;
-  expectedSessionId?: string | null;
-  expectedLifecycleRevision?: string;
-  expectedUpdatedAt?: number;
-  storePath: string;
-  target: SessionLifecycleStoreTarget;
-};
-
 export type {
   DeletedAgentSessionEntryPurgeParams,
+  DeleteSessionEntryLifecycleParams,
   DeleteSessionEntryLifecycleResult,
+  ResetSessionEntryLifecycleParams,
   ResetSessionEntryLifecycleResult,
   SessionEntryLifecycleMutationResult,
   SessionEntryLifecycleRemoval,

--- a/src/config/sessions/session-accessor.test.ts
+++ b/src/config/sessions/session-accessor.test.ts
@@ -57,7 +57,9 @@ import {
   readSqliteSessionEntryKeys,
 } from "./session-accessor.sqlite-entry-store.js";
 import {
+  applySqliteSessionEntryLifecycleMutation,
   appendSqliteTranscriptEventSync,
+  deleteSqliteSessionEntryLifecycle,
   importSqliteSessionRows,
   loadExactSqliteSessionEntry,
   replaceSqliteSessionEntrySync,
@@ -122,6 +124,11 @@ describe("session accessor seam", () => {
 
   afterEach(() => {
     fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it("exposes the canonical SQLite session lifecycle owners", () => {
+    expect(applySessionEntryLifecycleMutation).toBe(applySqliteSessionEntryLifecycleMutation);
+    expect(deleteSessionEntryLifecycle).toBe(deleteSqliteSessionEntryLifecycle);
   });
 
   it("loads, lists, and patches session entries without exposing the file store shape", async () => {

--- a/src/config/sessions/session-accessor.types.ts
+++ b/src/config/sessions/session-accessor.types.ts
@@ -1,8 +1,9 @@
 import type { SessionTranscriptUpdate } from "../../sessions/transcript-events.js";
 import type { OpenClawConfig } from "../types.openclaw.js";
 import type {
+  DeleteSessionEntryLifecycleParams,
   DeleteSessionEntryLifecycleResult,
-  ResetSessionEntryLifecycleMutation,
+  ResetSessionEntryLifecycleParams,
   ResetSessionEntryLifecycleResult,
   DeletedAgentSessionEntryPurgeParams,
   SessionArchivedTranscriptCleanupRule,
@@ -822,7 +823,9 @@ export type SessionPatchProjectionResult<TFailure extends SessionPatchProjection
   | TFailure;
 
 export type {
+  DeleteSessionEntryLifecycleParams,
   DeleteSessionEntryLifecycleResult,
+  ResetSessionEntryLifecycleParams,
   ResetSessionEntryLifecycleResult,
   SessionLifecycleArchivedTranscript,
   SessionLifecycleArtifactCleanupParams,
@@ -836,49 +839,6 @@ export type {
   SessionEntryLifecycleMutationResult,
   SessionEntryLifecycleRemoval,
   SessionEntryLifecycleUpsert,
-};
-
-export type ResetSessionEntryLifecycleParams = {
-  /** Preserve legacy rotation archival unless the caller appended an in-log boundary. */
-  archivePreviousTranscript?: boolean;
-  /** Runs after the persisted entry changes and any requested archival completes. */
-  afterEntryMutation?: (mutation: ResetSessionEntryLifecycleMutation) => Promise<void> | void;
-  /** Agent owner used to resolve backend transcript artifacts. */
-  agentId?: string;
-  /** Builds the persisted replacement entry from the current backend row. */
-  buildNextEntry: (context: {
-    currentEntry?: SessionEntry;
-    primaryKey: string;
-  }) => Promise<SessionEntry> | SessionEntry;
-  /** Atomically append this boundary with the reset entry mutation. */
-  resetBoundaryReason?: import("./session-reset-boundary-event.js").SessionResetBoundaryReason;
-  /** Explicit store target for file-backed stores and SQLite migration adapters. */
-  storePath: string;
-  /** Canonical key plus aliases that identify the logical entry. */
-  target: SessionLifecycleStoreTarget;
-};
-
-export type DeleteSessionEntryLifecycleParams = {
-  /** Agent owner used to resolve backend transcript artifacts. */
-  agentId?: string;
-  /** Whether transcript artifacts should be archived/deleted with the entry. */
-  archiveTranscript: boolean;
-  /** Delete transcript rows without writing an archive artifact. */
-  deleteTranscriptWithoutArchive?: boolean;
-  /** Optional exact row guard checked under the storage writer lock. */
-  expectedEntry?: SessionEntry;
-  /** Optional provider-run identity guard checked under the storage writer lock. */
-  expectedSessionId?: string | null;
-  /** Optional owner revision guard checked under the storage writer lock. */
-  expectedLifecycleRevision?: string;
-  /** Optional persisted revision guard checked under the storage writer lock. */
-  expectedUpdatedAt?: number;
-  /** Fail when the underlying store cannot confirm a durable write. */
-  requireWriteSuccess?: boolean;
-  /** Explicit store target for file-backed stores and SQLite migration adapters. */
-  storePath: string;
-  /** Canonical key plus aliases that identify the logical entry. */
-  target: SessionLifecycleStoreTarget;
 };
 
 export type CanonicalizeSessionEntryAliasesResult = {

--- a/src/cron/session-reaper.ts
+++ b/src/cron/session-reaper.ts
@@ -135,8 +135,6 @@ export async function sweepCronRunSessions(params: {
         agentId: params.agentId,
         storePath,
         removals,
-        preserveActiveWork: true,
-        restrictArchivedTranscriptsToStoreDir: true,
         ...(archiveRetentionMs == null
           ? {}
           : {

--- a/src/infra/heartbeat-runner-execution.ts
+++ b/src/infra/heartbeat-runner-execution.ts
@@ -489,9 +489,9 @@ export async function prepareHeartbeatRunStage(wake: ReadyHeartbeatWake) {
         ]
       : [];
     const lifecycleResult = await applySessionEntryLifecycleMutation({
+      activeSessionKey: isolatedSessionKey,
       storePath: isolatedStorePath,
       removals,
-      preserveActiveWork: true,
       upserts: [
         {
           sessionKey: isolatedSessionKey,
@@ -513,7 +513,6 @@ export async function prepareHeartbeatRunStage(wake: ReadyHeartbeatWake) {
           },
         },
       ],
-      restrictArchivedTranscriptsToStoreDir: true,
       captureArtifactCleanupError: true,
     });
     if (lifecycleResult.artifactCleanupError) {


### PR DESCRIPTION
## What Problem This Solves

Session creation, reset, removal, heartbeat cleanup, and cron reaping passed through duplicated lifecycle wrappers and independently declared reset/delete contracts. The wrappers also accepted legacy preservation/archive flags that the actual SQLite lifecycle owner never read, making it easy for callers to believe active-session and transcript protections were enforced when they were not.

## Why This Change Was Made

Use the existing SQLite lifecycle and projection implementations as the single runtime owner while preserving the established public accessor names. Define reset/delete parameter types once, retain the existing `requireWriteSuccess` contract for cron continuation cleanup, remove all six ineffective legacy flags, and protect the isolated heartbeat's live entry through the canonical `activeSessionKey`. No schema-version, protocol, config, migration, transcript-artifact, or plugin contract changes.

## User Impact

Session creation/reset and durable cleanup have one authoritative implementation and one reset/delete contract. Cron and heartbeat retain their existing admission, transcript, identity, and retention behavior; active isolated heartbeat sessions now receive the actual SQLite maintenance-preservation signal.

## Evidence

- Net production change: **+56/-119 (63 fewer production lines)**; one focused regression proves the public lifecycle names are the exact canonical SQLite functions.
- Fresh structured Codex autoreview: `gpt-5.6-sol`, high reasoning; TruffleHog clean; **zero accepted/actionable findings**.
- Blacksmith Testbox: `tbx_01kykf31va5r708zbn1xv512gp`; [hosted validation](https://github.com/openclaw/openclaw/actions/runs/30328356033).
- Focused remote proof: **217 passing tests across 14 files and five Vitest projects**, including SQLite conformance, concurrent lifecycle operations, stale cleanup, parent-fork DAG, isolated heartbeat, cron in-flight preservation, real Gateway reset, and chat-injection parent links.
- Remote `pnpm check:changed`: **passed**, including core and core-test TSGo, oxlint, formatting, SQLite schema v6, database-first storage, plugin contracts, and import cycles.
- Remote `pnpm build`: passed, including plugin SDK, Control UI, precompressed assets, and startup import guards.
- Exact hosted-CI deadcode gates: `pnpm deadcode:dependencies` and `pnpm deadcode:exports`, passed with zero production, full-tree, or script unused exports.
- Live built Gateway: fresh `OPENCLAW_STATE_DIR` **and** `OPENCLAW_CONFIG_PATH`, ephemeral loopback port, redacted ephemeral token; `/healthz`, `/readyz`, `sessions.create`, `chat.inject`, `chat.history`, `sessions.reset` preserving the canonical session ID while rotating its lifecycle revision, and post-reset inject/history proving the previous transcript is hidden, passed.
- `git diff --check`: passed; no lockfile, schema, protocol, user-state, or operator-Gateway changes.
Actual token-redacted built-Gateway output from the isolated Testbox:

```text
GATEWAY_HEALTH live=ok ready=true
SESSIONS_CREATE key=agent:main:session-lifecycle-proof-6c91f8a9a3cd durableSessionId=present
CHAT_INJECT beforeReset=ok
CHAT_HISTORY beforeReset=ok
SESSIONS_RESET sessionIdStable=true lifecycleRevisionRotated=true
CHAT_INJECT afterReset=ok
CHAT_HISTORY afterReset=ok previousTranscriptHidden=true
SESSION_LIFECYCLE_GATEWAY_PROOF passed freshState=true freshConfig=true loopback=true tokenRedacted=true
provider=blacksmith-testbox leaseId=tbx_01kykf31va5r708zbn1xv512gp exitCode=0
```

Focused tests: 217 passed in 57.15 s; full changed gate: 5 min 12 s; full build: 2 min 23 s; deadcode plus isolated Gateway proof: 1 min 41 s. The task-owned Testbox was stopped after proof.