### PR TITLE
refactor(plugins): reuse prepared channel discovery

### DIFF
--- a/src/agents/channel-tools.test.ts
+++ b/src/agents/channel-tools.test.ts
@@ -2,6 +2,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { ChannelPlugin } from "../channels/plugins/types.public.js";
 import type { OpenClawConfig } from "../config/config.js";
+import { EMPTY_PREPARED_MESSAGE_TOOL_CATALOG } from "../plugins/prepared-message-tool-catalog.js";
 import { setActivePluginRegistry } from "../plugins/runtime.js";
 import { defaultRuntime } from "../runtime.js";
 import { createTestRegistry } from "../test-utils/channel-plugins.js";
@@ -40,6 +41,16 @@ describe("channel tools", () => {
 
   afterEach(() => {
     setActivePluginRegistry(createTestRegistry([]));
+  });
+
+  it("keeps an explicitly empty prepared catalog authoritative", () => {
+    expect(
+      listAllChannelSupportedActions({
+        cfg: {} as OpenClawConfig,
+        preparedMessageToolCatalog: EMPTY_PREPARED_MESSAGE_TOOL_CATALOG,
+      }),
+    ).toEqual([]);
+    expect(errorSpy).not.toHaveBeenCalled();
   });
 
   it("skips crashing plugins and logs once", () => {

--- a/src/agents/channel-tools.ts
+++ b/src/agents/channel-tools.ts
@@ -7,6 +7,7 @@ import { normalizeStringEntries } from "@openclaw/normalization-core/string-norm
 import { getChannelPlugin, listChannelPlugins } from "../channels/plugins/index.js";
 import {
   createMessageActionDiscoveryContext,
+  listMessageActionDiscoveryChannels,
   resolveMessageActionDiscoveryForPlugin,
   resolveMessageActionDiscoveryChannelId,
   resolveCurrentChannelMessageToolDiscoveryAdapter,
@@ -74,7 +75,7 @@ export function listAllChannelSupportedActions(
   params: ChannelMessageActionDiscoveryParams,
 ): ChannelMessageActionName[] {
   const actions = new Set<ChannelMessageActionName>();
-  const channels = params.preparedMessageToolCatalog?.channels ?? listChannelPlugins();
+  const channels = listMessageActionDiscoveryChannels(params.preparedMessageToolCatalog);
   for (const plugin of channels) {
     const channelActions = resolveMessageActionDiscoveryForPlugin({
       pluginId: plugin.id,

--- a/src/auto-reply/reply/inbound-meta.test.ts
+++ b/src/auto-reply/reply/inbound-meta.test.ts
@@ -19,7 +19,8 @@ const { formattingHintCalls } = vi.hoisted(() => ({
   formattingHintCalls: [] as Array<{ cfg: OpenClawConfig; accountId?: string | null }>,
 }));
 
-vi.mock("../../channels/plugins/registry-loaded.js", () => ({
+vi.mock("../../channels/plugins/registry-loaded.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../channels/plugins/registry-loaded.js")>()),
   getLoadedChannelPluginById: (channelId: string) =>
     channelId === "slack"
       ? {

--- a/src/channels/plugins/message-action-discovery.ts
+++ b/src/channels/plugins/message-action-discovery.ts
@@ -8,6 +8,7 @@ import { uniqueStrings } from "@openclaw/normalization-core/string-normalization
 import { Type, type TSchema } from "typebox";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { formatErrorMessage } from "../../infra/errors.js";
+import { getPreparedMessageToolCatalog } from "../../plugins/prepared-message-tool-catalog.js";
 import { defaultRuntime } from "../../runtime.js";
 import { normalizeAnyChannelId } from "../registry.js";
 import { getChannelPlugin, getLoadedChannelPlugin, listChannelPlugins } from "./index.js";
@@ -35,6 +36,16 @@ export type PreparedMessageToolCatalog = Readonly<{
   channels: readonly PreparedMessageToolCatalogEntry[];
   getChannel: (id: string) => PreparedMessageToolCatalogEntry | undefined;
 }>;
+
+/** Lists message-action adapters from the caller's exact prepared registry. */
+export function listMessageActionDiscoveryChannels(
+  preparedMessageToolCatalog?: PreparedMessageToolCatalog,
+) {
+  return (
+    (preparedMessageToolCatalog ?? getPreparedMessageToolCatalog())?.channels ??
+    listChannelPlugins()
+  );
+}
 
 /**
  * Input used to discover channel message actions for agent tool schemas.
@@ -194,11 +205,12 @@ export function resolveCurrentChannelMessageToolDiscoveryAdapter(
   if (!channelId) {
     return null;
   }
-  const prepared = preparedMessageToolCatalog?.getChannel(channelId);
+  const catalog = preparedMessageToolCatalog ?? getPreparedMessageToolCatalog();
+  const prepared = catalog?.getChannel(channelId);
   if (prepared?.actions) {
     return { pluginId: prepared.id, actions: prepared.actions };
   }
-  if (!preparedMessageToolCatalog) {
+  if (!catalog) {
     const loadedPlugin = getLoadedChannelPlugin(
       channelId as Parameters<typeof getChannelPlugin>[0],
     );
@@ -218,17 +230,10 @@ export function resolveCurrentChannelMessageToolDiscoveryAdapter(
       actions: bundledActions,
     };
   }
-  if (preparedMessageToolCatalog) {
-    return null;
-  }
-  const plugin = getChannelPlugin(channelId as Parameters<typeof getChannelPlugin>[0]);
-  if (!plugin?.actions) {
-    return null;
-  }
-  return {
-    pluginId: plugin.id,
-    actions: plugin.actions,
-  };
+  const plugin = catalog
+    ? undefined
+    : getChannelPlugin(channelId as Parameters<typeof getChannelPlugin>[0]);
+  return plugin?.actions ? { pluginId: plugin.id, actions: plugin.actions } : null;
 }
 
 /**
@@ -333,7 +338,7 @@ function listChannelMessageCapabilities(params: {
   preparedMessageToolCatalog?: PreparedMessageToolCatalog;
 }): ChannelMessageCapability[] {
   const capabilities = new Set<ChannelMessageCapability>();
-  const channels = params.preparedMessageToolCatalog?.channels ?? listChannelPlugins();
+  const channels = listMessageActionDiscoveryChannels(params.preparedMessageToolCatalog);
   for (const plugin of channels) {
     for (const capability of resolveMessageActionDiscoveryForPlugin({
       pluginId: plugin.id,
@@ -403,7 +408,7 @@ export function resolveChannelMessageToolSchemaProperties(
   const discoveryBase = createMessageActionDiscoveryContext(params);
   const seenPluginIds = new Set<string>();
 
-  const channels = params.preparedMessageToolCatalog?.channels ?? listChannelPlugins();
+  const channels = listMessageActionDiscoveryChannels(params.preparedMessageToolCatalog);
   for (const plugin of channels) {
     if (!plugin.actions) {
       continue;

--- a/src/channels/plugins/message-action-discovery.ts
+++ b/src/channels/plugins/message-action-discovery.ts
@@ -8,7 +8,10 @@ import { uniqueStrings } from "@openclaw/normalization-core/string-normalization
 import { Type, type TSchema } from "typebox";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { formatErrorMessage } from "../../infra/errors.js";
-import { getPreparedMessageToolCatalog } from "../../plugins/prepared-message-tool-catalog.js";
+import {
+  getPreparedMessageToolCatalog,
+  type PreparedMessageToolCatalog,
+} from "../../plugins/prepared-message-tool-catalog.js";
 import { defaultRuntime } from "../../runtime.js";
 import { normalizeAnyChannelId } from "../registry.js";
 import { getChannelPlugin, getLoadedChannelPlugin, listChannelPlugins } from "./index.js";
@@ -18,34 +21,19 @@ import {
   type ChannelMessageToolDiscoveryAdapter,
 } from "./message-tool-api.js";
 import type {
-  ChannelMessageActionAdapter,
   ChannelMessageActionDiscoveryContext,
   ChannelMessageActionName,
   ChannelMessageToolDiscovery,
   ChannelMessageToolSchemaContribution,
 } from "./types.public.js";
 
-type PreparedMessageToolCatalogEntry = Readonly<{
-  id: string;
-  actions?: ChannelMessageActionAdapter;
-  reconcilesUnknownSend: boolean;
-}>;
-
-export type PreparedMessageToolCatalog = Readonly<{
-  version: number;
-  channels: readonly PreparedMessageToolCatalogEntry[];
-  getChannel: (id: string) => PreparedMessageToolCatalogEntry | undefined;
-}>;
+export type { PreparedMessageToolCatalog } from "../../plugins/prepared-message-tool-catalog.js";
 
 /** Lists message-action adapters from the caller's exact prepared registry. */
-export function listMessageActionDiscoveryChannels(
+export const listMessageActionDiscoveryChannels = (
   preparedMessageToolCatalog?: PreparedMessageToolCatalog,
-) {
-  return (
-    (preparedMessageToolCatalog ?? getPreparedMessageToolCatalog())?.channels ??
-    listChannelPlugins()
-  );
-}
+) =>
+  (preparedMessageToolCatalog ?? getPreparedMessageToolCatalog())?.channels ?? listChannelPlugins();
 
 /**
  * Input used to discover channel message actions for agent tool schemas.

--- a/src/channels/plugins/message-actions.test.ts
+++ b/src/channels/plugins/message-actions.test.ts
@@ -2,6 +2,10 @@
 import { Type } from "typebox";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../../config/config.js";
+import {
+  EMPTY_PREPARED_MESSAGE_TOOL_CATALOG,
+  getPreparedMessageToolCatalog,
+} from "../../plugins/prepared-message-tool-catalog.js";
 import { setActivePluginRegistry } from "../../plugins/runtime.js";
 import { defaultRuntime } from "../../runtime.js";
 import {
@@ -80,6 +84,57 @@ describe("message action capability checks", () => {
 
     expect(channelSupportsMessageCapability({} as OpenClawConfig, "presentation")).toBe(true);
     expect(channelSupportsMessageCapability({} as OpenClawConfig, "delivery-pin")).toBe(true);
+  });
+
+  it("does not replace an explicitly empty prepared channel catalog", () => {
+    activateMessageActionTestRegistry();
+    const cfg = {} as OpenClawConfig;
+
+    expect(
+      channelSupportsMessageCapability(cfg, "presentation", EMPTY_PREPARED_MESSAGE_TOOL_CATALOG),
+    ).toBe(false);
+    expect(
+      resolveChannelMessageToolSchemaProperties({
+        cfg,
+        channel: "demo-buttons",
+        preparedMessageToolCatalog: EMPTY_PREPARED_MESSAGE_TOOL_CATALOG,
+      }),
+    ).toEqual({});
+  });
+
+  it("evaluates prepared discovery against each account context", () => {
+    const base = createChannelTestPluginBase({ id: "demo-account-scoped" });
+    const plugin: ChannelPlugin = {
+      ...base,
+      actions: {
+        describeMessageTool: ({ accountId }) => ({
+          actions: ["send"],
+          capabilities: accountId === "first" ? ["presentation"] : ["delivery-pin"],
+        }),
+      },
+    };
+    setActivePluginRegistry(createTestRegistry([{ pluginId: plugin.id, source: "test", plugin }]));
+    const preparedMessageToolCatalog = getPreparedMessageToolCatalog();
+    const cfg = {} as OpenClawConfig;
+
+    expect(
+      channelSupportsMessageCapabilityForChannel(
+        { cfg, channel: plugin.id, accountId: "first", preparedMessageToolCatalog },
+        "presentation",
+      ),
+    ).toBe(true);
+    expect(
+      channelSupportsMessageCapabilityForChannel(
+        { cfg, channel: plugin.id, accountId: "second", preparedMessageToolCatalog },
+        "presentation",
+      ),
+    ).toBe(false);
+    expect(
+      channelSupportsMessageCapabilityForChannel(
+        { cfg, channel: plugin.id, accountId: "second", preparedMessageToolCatalog },
+        "delivery-pin",
+      ),
+    ).toBe(true);
   });
 
   it("checks per-channel capabilities", () => {

--- a/src/channels/plugins/registry-loaded.ts
+++ b/src/channels/plugins/registry-loaded.ts
@@ -6,6 +6,7 @@
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import type {
   ActiveChannelPluginRuntimeShape,
+  ActivePluginChannelRegistry,
   ActivePluginChannelRegistration,
 } from "../../plugins/channel-registry-state.types.js";
 import {
@@ -55,19 +56,19 @@ function coerceLoadedChannelPlugin(
   return plugin as LoadedChannelPlugin;
 }
 
-function resolveChannelPlugins(): ChannelPluginView {
+function resolveChannelPlugins(registry?: ActivePluginChannelRegistry): ChannelPluginView {
   const snapshot = getActivePluginChannelRegistrySnapshotFromState();
-  const cached = cachedChannelPluginView;
-  if (cached?.snapshot === snapshot) {
-    return cached;
+  const currentRegistry = registry === undefined || registry === snapshot.registry;
+  if (currentRegistry && cachedChannelPluginView?.snapshot === snapshot) {
+    return cachedChannelPluginView;
   }
-  const registry = snapshot.registry;
+  const selectedRegistry = registry ?? snapshot.registry;
 
   const seen = new Set<string>();
   const byId = new Map<string, LoadedChannelPlugin>();
   const entriesById = new Map<string, LoadedChannelPluginEntry>();
-  if (registry && Array.isArray(registry.channels)) {
-    for (const entry of registry.channels) {
+  if (selectedRegistry && Array.isArray(selectedRegistry.channels)) {
+    for (const entry of selectedRegistry.channels) {
       const plugin = coerceLoadedChannelPlugin(entry?.plugin);
       if (!plugin) {
         continue;
@@ -97,15 +98,17 @@ function resolveChannelPlugins(): ChannelPluginView {
     return a.id.localeCompare(b.id);
   });
 
-  // The runtime owns snapshot invalidation across active and pinned registry
-  // changes. Share one derived view until that lifecycle snapshot changes.
-  cachedChannelPluginView = {
-    snapshot,
+  const view = {
+    snapshot: currentRegistry ? snapshot : { registry: selectedRegistry, version: 0 },
     sorted,
     byId,
     entriesById,
   };
-  return cachedChannelPluginView;
+  if (currentRegistry) {
+    // Runtime snapshots invalidate the single active, pinned-registry view.
+    cachedChannelPluginView = view;
+  }
+  return view;
 }
 
 /**
@@ -113,6 +116,13 @@ function resolveChannelPlugins(): ChannelPluginView {
  */
 export function listLoadedChannelPlugins(): LoadedChannelPlugin[] {
   return resolveChannelPlugins().sorted.slice();
+}
+
+/** Lists one exact registry without substituting a pinned or active registry. */
+export function listLoadedChannelPluginsForRegistry(
+  registry: ActivePluginChannelRegistry,
+): ChannelPlugin[] {
+  return resolveChannelPlugins(registry).sorted.slice() as ChannelPlugin[];
 }
 
 /**

--- a/src/plugins/prepared-message-tool-catalog.test.ts
+++ b/src/plugins/prepared-message-tool-catalog.test.ts
@@ -1,5 +1,9 @@
 import { afterEach, describe, expect, it } from "vitest";
-import { resolveCurrentChannelMessageToolDiscoveryAdapter } from "../channels/plugins/message-action-discovery.js";
+import {
+  listMessageActionDiscoveryChannels,
+  resolveCurrentChannelMessageToolDiscoveryAdapter,
+} from "../channels/plugins/message-action-discovery.js";
+import { listChannelPlugins } from "../channels/plugins/registry.js";
 import type { ChannelPlugin } from "../channels/plugins/types.plugin.js";
 import { createChannelTestPluginBase, createTestRegistry } from "../test-utils/channel-plugins.js";
 import {
@@ -32,6 +36,30 @@ function channel(id: string, reconcilesUnknownSend = false): ChannelPlugin {
 
 describe("prepared message-tool catalog", () => {
   afterEach(() => resetPluginRuntimeStateForTest());
+
+  it("preserves canonical channel ordering and first-wins registration", () => {
+    const first = channel("duplicate", true);
+    first.meta.order = 5;
+    const duplicate = channel("duplicate");
+    const prioritized = channel("zeta");
+    prioritized.meta.order = 1;
+    setActivePluginRegistry(
+      createTestRegistry([
+        { pluginId: "alpha", source: "test", plugin: channel("alpha") },
+        { pluginId: "first", source: "test", plugin: first },
+        { pluginId: "duplicate", source: "test", plugin: duplicate },
+        { pluginId: "zeta", source: "test", plugin: prioritized },
+      ]),
+    );
+
+    const prepared = getPreparedMessageToolCatalog();
+
+    expect(prepared?.channels.map((entry) => entry.id)).toEqual(["zeta", "duplicate", "alpha"]);
+    expect(prepared?.channels.map((entry) => entry.id)).toEqual(
+      listChannelPlugins().map((plugin) => plugin.id),
+    );
+    expect(prepared?.getChannel("duplicate")?.reconcilesUnknownSend).toBe(true);
+  });
 
   it("settles one versioned catalog per active channel registry generation", () => {
     const first = createTestRegistry([
@@ -71,9 +99,19 @@ describe("prepared message-tool catalog", () => {
     pinActivePluginChannelRegistry(pinned);
     setActivePluginRegistry(runtime);
 
-    expect(getPreparedMessageToolCatalog()?.channels.map((entry) => entry.id)).toEqual(["alpha"]);
-    expect(
-      getPreparedMessageToolCatalogForRegistry(runtime)?.channels.map((entry) => entry.id),
-    ).toEqual(["beta"]);
+    const pinnedCatalog = getPreparedMessageToolCatalog();
+    const runtimeCatalog = getPreparedMessageToolCatalogForRegistry(runtime);
+
+    expect(pinnedCatalog?.channels.map((entry) => entry.id)).toEqual(["alpha"]);
+    expect(runtimeCatalog?.channels.map((entry) => entry.id)).toEqual(["beta"]);
+    expect(listMessageActionDiscoveryChannels().map((entry) => entry.id)).toEqual(["alpha"]);
+    expect(listMessageActionDiscoveryChannels(runtimeCatalog).map((entry) => entry.id)).toEqual([
+      "beta",
+    ]);
+    expect(resolveCurrentChannelMessageToolDiscoveryAdapter("alpha")?.pluginId).toBe("alpha");
+    expect(resolveCurrentChannelMessageToolDiscoveryAdapter("beta")).toBeNull();
+    expect(resolveCurrentChannelMessageToolDiscoveryAdapter("beta", runtimeCatalog)?.pluginId).toBe(
+      "beta",
+    );
   });
 });

--- a/src/plugins/prepared-message-tool-catalog.ts
+++ b/src/plugins/prepared-message-tool-catalog.ts
@@ -1,11 +1,23 @@
 /** Registry-owned message-tool metadata prepared once per channel registry generation. */
-import type { PreparedMessageToolCatalog } from "../channels/plugins/message-action-discovery.js";
 import { listLoadedChannelPluginsForRegistry } from "../channels/plugins/registry-loaded.js";
+import type { ChannelMessageActionAdapter } from "../channels/plugins/types.core.js";
 import type { PluginRegistry } from "./registry-types.js";
 import {
   getActivePluginChannelRegistrySnapshotFromState,
   type ActivePluginChannelRegistrySnapshot,
 } from "./runtime-channel-state.js";
+
+type PreparedMessageToolCatalogEntry = Readonly<{
+  id: string;
+  actions?: ChannelMessageActionAdapter;
+  reconcilesUnknownSend: boolean;
+}>;
+
+export type PreparedMessageToolCatalog = Readonly<{
+  version: number;
+  channels: readonly PreparedMessageToolCatalogEntry[];
+  getChannel: (id: string) => PreparedMessageToolCatalogEntry | undefined;
+}>;
 
 const catalogsByRegistry = new WeakMap<PluginRegistry, Map<number, PreparedMessageToolCatalog>>();
 const latestCatalogByRegistry = new WeakMap<PluginRegistry, PreparedMessageToolCatalog>();

--- a/src/plugins/prepared-message-tool-catalog.ts
+++ b/src/plugins/prepared-message-tool-catalog.ts
@@ -1,7 +1,6 @@
 /** Registry-owned message-tool metadata prepared once per channel registry generation. */
-import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import type { PreparedMessageToolCatalog } from "../channels/plugins/message-action-discovery.js";
-import { CHAT_CHANNEL_ORDER } from "../channels/registry.js";
+import { listLoadedChannelPluginsForRegistry } from "../channels/plugins/registry-loaded.js";
 import type { PluginRegistry } from "./registry-types.js";
 import {
   getActivePluginChannelRegistrySnapshotFromState,
@@ -16,25 +15,6 @@ export const EMPTY_PREPARED_MESSAGE_TOOL_CATALOG: PreparedMessageToolCatalog = O
   channels: Object.freeze([]),
   getChannel: () => undefined,
 });
-
-function listPreparedChannels(registry: PluginRegistry) {
-  const byId = new Map<string, PluginRegistry["channels"][number]["plugin"]>();
-  (registry.channels ?? []).forEach((registration) => {
-    const id = normalizeOptionalString(registration.plugin.id);
-    if (id && !byId.has(id)) {
-      byId.set(id, registration.plugin);
-    }
-  });
-  return [...byId.values()].toSorted((left, right) => {
-    const leftId = normalizeOptionalString(left.id) ?? "";
-    const rightId = normalizeOptionalString(right.id) ?? "";
-    const leftKnownOrder = CHAT_CHANNEL_ORDER.indexOf(leftId);
-    const rightKnownOrder = CHAT_CHANNEL_ORDER.indexOf(rightId);
-    const leftOrder = left.meta.order ?? (leftKnownOrder === -1 ? 999 : leftKnownOrder);
-    const rightOrder = right.meta.order ?? (rightKnownOrder === -1 ? 999 : rightKnownOrder);
-    return leftOrder === rightOrder ? leftId.localeCompare(rightId) : leftOrder - rightOrder;
-  });
-}
 
 function selectedRegistry(
   snapshot: ActivePluginChannelRegistrySnapshot,
@@ -62,7 +42,7 @@ export function settlePreparedMessageToolCatalog(
     return existing;
   }
   const channels = Object.freeze(
-    listPreparedChannels(registry).map((plugin) =>
+    listLoadedChannelPluginsForRegistry(registry).map((plugin) =>
       Object.freeze({
         id: plugin.id,
         ...(plugin.actions ? { actions: plugin.actions } : {}),


### PR DESCRIPTION
## What Problem This Solves

Channel message-action discovery repeated channel ordering, registration deduplication, and active plugin enumeration even after the runtime had already prepared the exact channel registry generation. Those parallel paths can disagree when a channel registry is pinned, an explicitly empty catalog is authoritative, channels share an id, or plugin actions depend on the current account.

## Why This Change Was Made

Use the existing registry-owned, generation-specific prepared message-tool catalog and the canonical loaded-channel registry view. Declare the catalog types in their canonical owner and preserve their existing public channel-discovery type export; this keeps both runtime and static import graphs acyclic. Preserve first-registered channel precedence, deterministic ordering, loaded override provenance, lightweight bundled discovery, distinct unset versus empty catalogs, and exact pinned versus runtime registry selection. Cache only action adapters; describe actions separately for each live request and account. Production code is net negative: +58/-62.

## User Impact

Channel and agent message actions remain consistent with the enabled runtime plugin registry, including account-scoped capabilities. No config, environment, plugin SDK, storage, or protocol contract is added or changed.

## Evidence

Exact reviewed head: b9ebc73bc50ab70cb9bab79003b862c8f3a51110. The final follow-up is test-only and uses Vitest’s real-module partial mock to preserve every registry export and the existing Slack formatting override.

Remote provider: Blacksmith Testbox. Original full production/gateway proof lease: tbx_01kykh9mzb24b6yhvfh983jtab (stopped). Exact final-head targeted-proof lease: tbx_01kykm20t9b0x2p2eeajzcxgke.

Focused regression command:

    pnpm test src/plugins/prepared-message-tool-catalog.test.ts src/channels/plugins/message-actions.test.ts src/channels/plugins/registry.test.ts src/agents/channel-tools.test.ts src/plugins/runtime.channel-pin.test.ts src/channels/plugins/read-only.test.ts src/agents/tools/message-tool.test.ts

Observed: 7 files, 3 Vitest projects, 221 tests passed. Coverage includes pinned versus runtime registries, authoritative empty catalogs, first-wins ordering, account-scoped actions, disabled and workspace plugins, and the complete 149-test message tool suite.

Exact-final-head remote regression covered all 13 affected/sibling registry-mock/discovery files across five Vitest projects: 359/359 tests passed, including all 78 inbound metadata tests and every existing registry-loaded partial-mock sibling. The remote timing JSON reports exitCode 0.

Exact final-head architecture was independently rerun on the same remote Testbox: `pnpm check:architecture` passed, including zero runtime import cycles, zero Madge cycles, and all deprecated API, Kysely, and database-first guards; timing JSON exitCode 0.

The exact previously failing hosted auto-reply-reply-state-routing CI shard was then reconstructed from `scripts/lib/ci-node-test-plan.mjs` and executed with its real `scripts/ci-run-node-test-shard.mjs` on the exact final pushed head. Result: 44/44 test files and 885/885 tests passed; the exact former Slack case passes; remote timing JSON exitCode 0. A fresh structured Codex autoreview of the final correction reports no accepted or actionable findings (confidence 0.98).

Full remote gates on the production-identical preceding head (the exact final follow-up changes a test mock only):

    pnpm check:architecture
    pnpm check:changed
    pnpm build
    pnpm deadcode:dependencies
    pnpm deadcode:exports

Every command passed. The exact hosted architecture gate reports 0 runtime cycles and 0 Madge cycles. The changed gate includes all four core and plugin typechecks, full 7,873-file extension lint, SDK baseline and plugin-boundary checks, and security guards. The build verifies all 143 public plugin SDK subpaths. Both deadcode scans report zero errors.

Real built-Gateway command:

    pnpm test:startup:gateway --case default --case fiftyPlugins --case fiftyStartupLazyPlugins --runs 1 --warmup 0 --timeout-ms 45000

Each run created a fresh isolated HOME, OPENCLAW_CONFIG_PATH, OPENCLAW_STATE_DIR, and free loopback port. Production-identical built-Gateway terminal proof (the final follow-up changes a test mock only):

    default:            /healthz 16758.4 ms; /readyz 16758.6 ms
    fiftyPlugins:       /healthz 10546.4 ms; /readyz 10546.3 ms
    fiftyStartupLazy:   /healthz 8773.8 ms; /readyz 8773.7 ms

Fresh structured Codex autoreviews: original refactor 0.96; final exact correction 0.98; neither has accepted or actionable findings. AI-assisted, maintainer-requested refactor.



## Exact-head real product-runtime behavior

Ran actual OpenClaw `loadOpenClawPlugins`, bundled Telegram and Discord plugin registration, production `setActivePluginRegistry`, `pinActivePluginChannelRegistry`, generation-specific `getPreparedMessageToolCatalog` / `getPreparedMessageToolCatalogForRegistry`, `listMessageActionDiscoveryChannels`, `listAllChannelSupportedActions`, and per-channel `listChannelSupportedActions` on Blacksmith Testbox tbx_01kyknapj21kakc79w2a00vyss. No mocks, test registry, operator state, external network requests, or real credentials. Exact terminal JSON:

```jsonl
{"case":"active","catalogVersion":1,"channels":["telegram"],"actions":["delete","edit","poll","react","send","topic-create","topic-edit"],"perChannel":{"telegram":["delete","edit","poll","react","send","topic-create","topic-edit"]}}
{"case":"pinned","catalogVersion":2,"channels":["telegram"],"actions":["delete","edit","poll","react","send","topic-create","topic-edit"],"perChannel":{"telegram":["delete","edit","poll","react","send","topic-create","topic-edit"]}}
{"case":"runtime","catalogVersion":2,"channels":["discord"],"actions":["category-create","category-delete","category-edit","channel-create","channel-delete","channel-edit","channel-info","channel-list","channel-move","delete","edit","emoji-list","emoji-upload","event-create","event-list","list-pins","member-info","permissions","pin","poll","react","reactions","read","role-info","search","send","sticker","sticker-upload","thread-create","thread-list","thread-reply","unpin","upload-file","voice-status"],"perChannel":{"discord":["category-create","category-delete","category-edit","channel-create","channel-delete","channel-edit","channel-info","channel-list","channel-move","delete","edit","emoji-list","emoji-upload","event-create","event-list","list-pins","member-info","permissions","pin","poll","react","reactions","read","role-info","search","send","sticker","sticker-upload","thread-create","thread-list","thread-reply","unpin","upload-file","voice-status"]}}
{"case":"explicitly-empty","catalogVersion":0,"channels":[],"actions":[],"perChannel":{}}
{"result":"PASS","productionPluginLoader":true,"actualBundledPlugins":["telegram","discord"],"networkCalls":0,"head":"b9ebc73bc50ab70cb9bab79003b862c8f3a51110"}
```

Every live scenario was asserted in the running production module process. Remote timing JSON `exitCode: 0`.

The unrelated hosted CLI subprocess-contention failure was independently disproved with the real `agentic-cli` CI runner on the exact same head: 182/182 CLI files, 3,569 tests passed, one skipped, including all 52 `help-exit.process.test.ts` cases; remote timing JSON `exitCode: 0`. The failed GitHub jobs were rerun on the same exact reviewed commit and CI run 30332884001 returned `STATUS state=SUCCESS pending=0` / `GREEN`.
