### PR TITLE
fix(agents): honor models.providers auth mode pin in credential eligibility

### DIFF
--- a/src/agents/agent-auth-discovery.external-cli.test.ts
+++ b/src/agents/agent-auth-discovery.external-cli.test.ts
@@ -113,4 +113,29 @@ describe("resolveAgentCredentialsForDiscovery external CLI scoping", () => {
       },
     });
   });
+
+  it.each(["oauth", "token"] as const)(
+    "skips synthetic api-key fills under a %s provider pin",
+    (auth) => {
+      syntheticAuthMocks.resolveProviderSyntheticAuthWithPlugin.mockReturnValue({
+        apiKey: "synthetic-key",
+      });
+      const cfg = {
+        models: {
+          providers: {
+            fireworks: { auth, baseUrl: "https://example.invalid", models: [] },
+          },
+        },
+      } satisfies OpenClawConfig;
+
+      const credentials = resolveAgentCredentialsForDiscovery("/tmp/openclaw-agent", {
+        config: cfg,
+        env: {},
+        syntheticAuthProviderRefs: ["fireworks"],
+      });
+
+      expect(credentials.fireworks).toBeUndefined();
+      expect(syntheticAuthMocks.resolveProviderSyntheticAuthWithPlugin).not.toHaveBeenCalled();
+    },
+  );
 });

--- a/src/agents/agent-auth-discovery.ts
+++ b/src/agents/agent-auth-discovery.ts
@@ -9,6 +9,7 @@ import {
   addEnvBackedAgentCredentials,
   type AgentDiscoveryAuthLookupOptions,
 } from "./agent-auth-discovery-core.js";
+import { isAmbientCredentialAllowedByProviderAuthPin } from "./auth-profiles/ambient-auth.js";
 import type { ExternalCliAuthDiscovery } from "./auth-profiles/external-cli-discovery.js";
 import {
   ensureAuthProfileStore,
@@ -70,6 +71,19 @@ export function resolveAgentCredentialsForDiscovery(
     options?.syntheticAuthProviderRefs ?? resolveRuntimeSyntheticAuthProviderRefs();
   for (const provider of syntheticAuthProviderRefs) {
     if (credentials[provider]) {
+      continue;
+    }
+    if (
+      !isAmbientCredentialAllowedByProviderAuthPin({
+        config: options?.config,
+        authAliasLookupParams: {
+          ...(options?.env ? { env: options.env } : {}),
+          ...(options?.workspaceDir ? { workspaceDir: options.workspaceDir } : {}),
+        },
+        provider,
+        type: "api_key",
+      })
+    ) {
       continue;
     }
     // Synthetic auth is a plugin/runtime fallback. Only fill empty providers so

--- a/src/agents/auth-profiles/ambient-auth.ts
+++ b/src/agents/auth-profiles/ambient-auth.ts
@@ -1,0 +1,34 @@
+/** Provider auth-pin policy for credentials discovered outside OpenClaw storage. */
+import { findNormalizedProviderValue } from "@openclaw/model-catalog-core/provider-id";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import {
+  type ProviderAuthAliasLookupParams,
+  resolveProviderIdForAuth,
+} from "../provider-auth-aliases.js";
+import type { AuthProfileCredential } from "./types.js";
+
+/** Returns whether ambient credential material agrees with a provider's declared auth mode. */
+export function isAmbientCredentialAllowedByProviderAuthPin(params: {
+  config?: OpenClawConfig;
+  authAliasLookupParams?: Omit<ProviderAuthAliasLookupParams, "config">;
+  provider: string;
+  type: AuthProfileCredential["type"];
+}): boolean {
+  const providers = params.config?.models?.providers;
+  const direct = findNormalizedProviderValue(providers, params.provider);
+  const providerAuthKey = resolveProviderIdForAuth(params.provider, {
+    config: params.config,
+    ...params.authAliasLookupParams,
+  });
+  const auth = direct?.auth ?? findNormalizedProviderValue(providers, providerAuthKey)?.auth;
+  if (auth === "api-key") {
+    return params.type === "api_key";
+  }
+  if (auth === "oauth") {
+    return params.type === "oauth" || params.type === "token";
+  }
+  if (auth === "token") {
+    return params.type === "token";
+  }
+  return auth === undefined;
+}

--- a/src/agents/auth-profiles/external-auth.ts
+++ b/src/agents/auth-profiles/external-auth.ts
@@ -6,6 +6,7 @@
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import type { ProviderExternalAuthProfile } from "../../plugins/provider-external-auth.types.js";
 import { resolveExternalAuthProfilesWithPlugins } from "../../plugins/provider-runtime.js";
+import { isAmbientCredentialAllowedByProviderAuthPin } from "./ambient-auth.js";
 import { cloneAuthProfileStore } from "./clone.js";
 import { CLAUDE_CLI_PROFILE_ID, MINIMAX_CLI_PROFILE_ID } from "./constants.js";
 import * as externalCliSync from "./external-cli-sync.js";
@@ -53,6 +54,33 @@ function normalizeExternalAuthProfile(
   };
 }
 
+function resolveExplicitProfileIds(values: Iterable<string> | undefined): Set<string> | undefined {
+  if (values === undefined) {
+    return undefined;
+  }
+  return new Set(Array.from(values, (value) => value.trim()).filter((value) => value.length > 0));
+}
+
+function isExternalAuthProfileAllowed(
+  profile: ProviderExternalAuthProfile,
+  store: AuthProfileStore,
+  config: OpenClawConfig | undefined,
+  explicitProfileIds: ReadonlySet<string> | undefined,
+  env: NodeJS.ProcessEnv,
+): boolean {
+  // A provider pin protects its declared auth from ambient takeover. Stored and explicitly
+  // bound profiles deliberately keep precedence; see runtime-plan/prepare-auth.test.ts.
+  if (store.profiles[profile.profileId] || explicitProfileIds?.has(profile.profileId)) {
+    return true;
+  }
+  return isAmbientCredentialAllowedByProviderAuthPin({
+    config,
+    authAliasLookupParams: { env },
+    provider: profile.credential.provider,
+    type: profile.credential.type,
+  });
+}
+
 function resolveExternalAuthProfileMap(params: {
   store: AuthProfileStore;
   agentDir?: string;
@@ -75,13 +103,25 @@ function resolveExternalAuthProfileMap(params: {
   });
 
   const resolved: ExternalAuthProfileMap = new Map();
+  const explicitProfileIds = resolveExplicitProfileIds(params.externalCli?.externalCliProfileIds);
   const cliProfiles =
     externalCliSync.resolveExternalCliAuthProfiles?.(params.store, {
       allowKeychainPrompt: params.externalCli?.allowKeychainPrompt,
       providerIds: params.externalCli?.externalCliProviderIds,
-      profileIds: params.externalCli?.externalCliProfileIds,
+      profileIds: explicitProfileIds,
     }) ?? [];
   for (const profile of cliProfiles) {
+    if (
+      !isExternalAuthProfileAllowed(
+        profile,
+        params.store,
+        params.externalCli?.config,
+        explicitProfileIds,
+        env,
+      )
+    ) {
+      continue;
+    }
     resolved.set(profile.profileId, {
       profileId: profile.profileId,
       credential: profile.credential,
@@ -91,6 +131,17 @@ function resolveExternalAuthProfileMap(params: {
   for (const rawProfile of profiles) {
     const profile = normalizeExternalAuthProfile(rawProfile);
     if (!profile) {
+      continue;
+    }
+    if (
+      !isExternalAuthProfileAllowed(
+        profile,
+        params.store,
+        params.externalCli?.config,
+        explicitProfileIds,
+        env,
+      )
+    ) {
       continue;
     }
     resolved.set(profile.profileId, profile);
@@ -159,13 +210,19 @@ export function syncPersistedExternalCliAuthProfiles(
   if (!hasPersistableExternalCliSyncCandidate(store, params)) {
     return store;
   }
+  const env = params?.env ?? process.env;
+  const explicitProfileIds = resolveExplicitProfileIds(params?.externalCliProfileIds);
   const cliProfiles =
     externalCliSync.resolveExternalCliAuthProfiles?.(store, {
       allowKeychainPrompt: params?.allowKeychainPrompt,
       providerIds: params?.externalCliProviderIds,
-      profileIds: params?.externalCliProfileIds,
+      profileIds: explicitProfileIds,
     }) ?? [];
-  const persistedProfiles = cliProfiles.filter((profile) => profile.persistence === "persisted");
+  const persistedProfiles = cliProfiles.filter(
+    (profile) =>
+      profile.persistence === "persisted" &&
+      isExternalAuthProfileAllowed(profile, store, params?.config, explicitProfileIds, env),
+  );
   if (persistedProfiles.length === 0) {
     return store;
   }

--- a/src/agents/auth-profiles/external-oauth.test.ts
+++ b/src/agents/auth-profiles/external-oauth.test.ts
@@ -5,6 +5,8 @@
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { ProviderExternalAuthProfile } from "../../plugins/types.js";
+import { resolveAgentCredentialMapFromStore } from "../agent-auth-credentials.js";
+import { addEnvBackedAgentCredentials } from "../agent-auth-discovery-core.js";
 import { overlayExternalAuthProfiles } from "./external-auth.js";
 import { testing } from "./external-auth.test-support.js";
 import { readExternalCliBootstrapCredential } from "./external-cli-sync.js";
@@ -107,6 +109,54 @@ describe("auth external oauth helpers", () => {
     expect(readCodexCliCredentialsCachedMock).toHaveBeenCalledTimes(1);
   });
 
+  it("keeps ambient Codex OAuth from outranking an env key under an api-key pin", () => {
+    const cfg = {
+      models: {
+        providers: {
+          openai: { auth: "api-key" as const, baseUrl: "https://api.openai.com/v1", models: [] },
+        },
+      },
+    };
+    readCodexCliCredentialsCachedMock.mockReturnValueOnce(
+      createCredential({ expires: createUsableOAuthExpiry() }),
+    );
+
+    const store = overlayExternalAuthProfiles(createStore(), {
+      config: cfg,
+      externalCliProviderIds: ["openai"],
+    });
+    const ambientOnly = resolveAgentCredentialMapFromStore(store, { config: cfg });
+    const credentials = addEnvBackedAgentCredentials(ambientOnly, {
+      config: cfg,
+      env: { OPENAI_API_KEY: "env-api-key" },
+    });
+
+    expect(readCodexCliCredentialsCachedMock).toHaveBeenCalledTimes(1);
+    expect(store.profiles["openai:default"]).toBeUndefined();
+    expect(ambientOnly.openai).toBeUndefined();
+    expect(credentials.openai).toEqual({ type: "api_key", key: "env-api-key" });
+  });
+
+  it("keeps explicitly requested external profiles outside the ambient pin", () => {
+    const cfg = {
+      models: {
+        providers: {
+          openai: { auth: "api-key" as const, baseUrl: "https://api.openai.com/v1", models: [] },
+        },
+      },
+    };
+    readCodexCliCredentialsCachedMock.mockReturnValueOnce(
+      createCredential({ expires: createUsableOAuthExpiry() }),
+    );
+
+    const store = overlayExternalAuthProfiles(createStore(), {
+      config: cfg,
+      externalCliProfileIds: ["openai:default"],
+    });
+
+    expect(store.profiles["openai:default"]?.type).toBe("oauth");
+  });
+
   it("does not bootstrap arbitrary named OpenAI OAuth profiles from the Codex CLI account", () => {
     readCodexCliCredentialsCachedMock.mockReturnValueOnce(
       createCredential({
@@ -178,6 +228,19 @@ describe("auth external oauth helpers", () => {
       createStore({
         "openai:default": tokenlessCredential,
       }),
+      {
+        config: {
+          models: {
+            providers: {
+              openai: {
+                auth: "api-key",
+                baseUrl: "https://api.openai.com/v1",
+                models: [],
+              },
+            },
+          },
+        },
+      },
     );
 
     const overlaidProfile = overlaid.profiles["openai:default"];

--- a/src/agents/auth-profiles/order.test.ts
+++ b/src/agents/auth-profiles/order.test.ts
@@ -45,10 +45,36 @@ vi.mock("./external-auth.js", () => ({
 
 import {
   isStoredCredentialCompatibleWithAuthProvider,
+  resolveAuthProfileEligibility,
   resolveAuthProfileOrder,
   resolveAuthProfileOrderWithMetadata,
 } from "./order.js";
 import { markAuthProfileSuccess } from "./profiles.js";
+
+function createMixedModeStore(): AuthProfileStore {
+  return {
+    version: 1,
+    profiles: {
+      "fixture-provider:oauth": {
+        type: "oauth",
+        provider: "fixture-provider",
+        access: "oauth-access",
+        refresh: "oauth-refresh",
+        expires: Date.now() + 60_000,
+      },
+      "fixture-provider:token": {
+        type: "token",
+        provider: "fixture-provider",
+        token: "bearer-token",
+      },
+      "fixture-provider:api-key": {
+        type: "api_key",
+        provider: "fixture-provider",
+        key: "api-key",
+      },
+    },
+  };
+}
 
 describe("resolveAuthProfileOrder", () => {
   beforeEach(() => {
@@ -75,6 +101,130 @@ describe("resolveAuthProfileOrder", () => {
     });
 
     expect(order).toEqual(["fixture-provider:default"]);
+  });
+
+  it.each([
+    ["api-key", ["fixture-provider:api-key"]],
+    ["oauth", ["fixture-provider:oauth", "fixture-provider:token"]],
+    ["token", ["fixture-provider:token"]],
+  ] as const)("honors the %s provider auth-mode pin", (auth, expected) => {
+    const cfg = {
+      models: {
+        providers: {
+          "fixture-provider": { auth, baseUrl: "https://example.invalid", models: [] },
+        },
+      },
+    } satisfies OpenClawConfig;
+    const store = createMixedModeStore();
+
+    expect(resolveAuthProfileOrder({ cfg, store, provider: "fixture-provider" })).toEqual(expected);
+  });
+
+  it("reports credentials excluded by a provider auth-mode pin as mode mismatches", () => {
+    const cfg = {
+      models: {
+        providers: {
+          "fixture-provider": {
+            auth: "api-key",
+            baseUrl: "https://example.invalid",
+            models: [],
+          },
+        },
+      },
+    } satisfies OpenClawConfig;
+
+    expect(
+      resolveAuthProfileEligibility({
+        cfg,
+        store: createMixedModeStore(),
+        provider: "fixture-provider",
+        profileId: "fixture-provider:oauth",
+      }),
+    ).toEqual({ eligible: false, reasonCode: "mode_mismatch" });
+  });
+
+  it("keeps OAuth-preferred ordering when the provider has no auth-mode pin", () => {
+    expect(
+      resolveAuthProfileOrder({ store: createMixedModeStore(), provider: "fixture-provider" }),
+    ).toEqual(["fixture-provider:oauth", "fixture-provider:token", "fixture-provider:api-key"]);
+  });
+
+  it("fails closed when the provider auth-mode pin excludes every stored credential", () => {
+    const store = createMixedModeStore();
+    delete store.profiles["fixture-provider:token"];
+    delete store.profiles["fixture-provider:api-key"];
+
+    expect(
+      resolveAuthProfileOrder({
+        cfg: {
+          models: {
+            providers: {
+              "fixture-provider": {
+                auth: "api-key",
+                baseUrl: "https://example.invalid",
+                models: [],
+              },
+            },
+          },
+        },
+        store,
+        provider: "fixture-provider",
+      }),
+    ).toEqual([]);
+  });
+
+  it("keeps configured AWS SDK profiles eligible without stored credentials", () => {
+    const cfg = {
+      auth: {
+        profiles: {
+          "amazon-bedrock:default": { provider: "amazon-bedrock", mode: "aws-sdk" },
+        },
+      },
+      models: {
+        providers: {
+          "amazon-bedrock": {
+            auth: "aws-sdk",
+            baseUrl: "https://bedrock-runtime.us-east-1.amazonaws.com",
+            models: [],
+          },
+        },
+      },
+    } satisfies OpenClawConfig;
+    const store: AuthProfileStore = { version: 1, profiles: {} };
+
+    expect(
+      resolveAuthProfileEligibility({
+        cfg,
+        store,
+        provider: "amazon-bedrock",
+        profileId: "amazon-bedrock:default",
+      }),
+    ).toEqual({ eligible: true, reasonCode: "ok" });
+    expect(resolveAuthProfileOrder({ cfg, store, provider: "amazon-bedrock" })).toEqual([
+      "amazon-bedrock:default",
+    ]);
+  });
+
+  it("honors a normalized canonical auth-mode pin for an aliased provider", () => {
+    const cfg = {
+      models: {
+        providers: {
+          "FIXTURE-PROVIDER": {
+            auth: "api-key",
+            baseUrl: "https://example.invalid",
+            models: [],
+          },
+        },
+      },
+    } satisfies OpenClawConfig;
+
+    expect(
+      resolveAuthProfileOrder({
+        cfg,
+        store: createMixedModeStore(),
+        provider: "FIXTURE-PROVIDER-PLAN",
+      }),
+    ).toEqual(["fixture-provider:api-key"]);
   });
 
   it("uses canonical provider auth order for alias providers", async () => {

--- a/src/agents/auth-profiles/order.test.ts
+++ b/src/agents/auth-profiles/order.test.ts
@@ -9,6 +9,7 @@ import path from "node:path";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { resetProviderAuthAliasMapCacheForTest } from "../provider-auth-aliases.test-support.js";
+import { isAmbientCredentialAllowedByProviderAuthPin } from "./ambient-auth.js";
 import { saveAuthProfileStore } from "./store.js";
 import type { AuthProfileStore } from "./types.js";
 
@@ -51,31 +52,6 @@ import {
 } from "./order.js";
 import { markAuthProfileSuccess } from "./profiles.js";
 
-function createMixedModeStore(): AuthProfileStore {
-  return {
-    version: 1,
-    profiles: {
-      "fixture-provider:oauth": {
-        type: "oauth",
-        provider: "fixture-provider",
-        access: "oauth-access",
-        refresh: "oauth-refresh",
-        expires: Date.now() + 60_000,
-      },
-      "fixture-provider:token": {
-        type: "token",
-        provider: "fixture-provider",
-        token: "bearer-token",
-      },
-      "fixture-provider:api-key": {
-        type: "api_key",
-        provider: "fixture-provider",
-        key: "api-key",
-      },
-    },
-  };
-}
-
 describe("resolveAuthProfileOrder", () => {
   beforeEach(() => {
     resetProviderAuthAliasMapCacheForTest();
@@ -103,24 +79,7 @@ describe("resolveAuthProfileOrder", () => {
     expect(order).toEqual(["fixture-provider:default"]);
   });
 
-  it.each([
-    ["api-key", ["fixture-provider:api-key"]],
-    ["oauth", ["fixture-provider:oauth", "fixture-provider:token"]],
-    ["token", ["fixture-provider:token"]],
-  ] as const)("honors the %s provider auth-mode pin", (auth, expected) => {
-    const cfg = {
-      models: {
-        providers: {
-          "fixture-provider": { auth, baseUrl: "https://example.invalid", models: [] },
-        },
-      },
-    } satisfies OpenClawConfig;
-    const store = createMixedModeStore();
-
-    expect(resolveAuthProfileOrder({ cfg, store, provider: "fixture-provider" })).toEqual(expected);
-  });
-
-  it("reports credentials excluded by a provider auth-mode pin as mode mismatches", () => {
+  it("does not apply the provider auth pin to stored profiles", () => {
     const cfg = {
       models: {
         providers: {
@@ -132,45 +91,50 @@ describe("resolveAuthProfileOrder", () => {
         },
       },
     } satisfies OpenClawConfig;
-
-    expect(
-      resolveAuthProfileEligibility({
-        cfg,
-        store: createMixedModeStore(),
-        provider: "fixture-provider",
-        profileId: "fixture-provider:oauth",
-      }),
-    ).toEqual({ eligible: false, reasonCode: "mode_mismatch" });
-  });
-
-  it("keeps OAuth-preferred ordering when the provider has no auth-mode pin", () => {
-    expect(
-      resolveAuthProfileOrder({ store: createMixedModeStore(), provider: "fixture-provider" }),
-    ).toEqual(["fixture-provider:oauth", "fixture-provider:token", "fixture-provider:api-key"]);
-  });
-
-  it("fails closed when the provider auth-mode pin excludes every stored credential", () => {
-    const store = createMixedModeStore();
-    delete store.profiles["fixture-provider:token"];
-    delete store.profiles["fixture-provider:api-key"];
+    const store: AuthProfileStore = {
+      version: 1,
+      profiles: {
+        "fixture-provider:oauth": {
+          type: "oauth",
+          provider: "fixture-provider",
+          access: "oauth-access",
+          refresh: "oauth-refresh",
+          expires: Date.now() + 60_000,
+        },
+        "fixture-provider:api-key": {
+          type: "api_key",
+          provider: "fixture-provider",
+          key: "api-key",
+        },
+      },
+    };
 
     expect(
       resolveAuthProfileOrder({
-        cfg: {
-          models: {
-            providers: {
-              "fixture-provider": {
-                auth: "api-key",
-                baseUrl: "https://example.invalid",
-                models: [],
-              },
-            },
-          },
-        },
+        cfg,
         store,
         provider: "fixture-provider",
       }),
-    ).toEqual([]);
+    ).toEqual(["fixture-provider:oauth", "fixture-provider:api-key"]);
+  });
+
+  it("applies provider auth pins to ambient credentials through auth aliases", () => {
+    const cfg = {
+      models: {
+        providers: {
+          "fixture-provider": { auth: "oauth", baseUrl: "https://example.invalid", models: [] },
+          "fixture-provider-plan": { baseUrl: "https://example.invalid", models: [] },
+        },
+      },
+    } satisfies OpenClawConfig;
+
+    expect(
+      isAmbientCredentialAllowedByProviderAuthPin({
+        config: cfg,
+        provider: "fixture-provider-plan",
+        type: "api_key",
+      }),
+    ).toBe(false);
   });
 
   it("keeps configured AWS SDK profiles eligible without stored credentials", () => {
@@ -203,28 +167,6 @@ describe("resolveAuthProfileOrder", () => {
     expect(resolveAuthProfileOrder({ cfg, store, provider: "amazon-bedrock" })).toEqual([
       "amazon-bedrock:default",
     ]);
-  });
-
-  it("honors a normalized canonical auth-mode pin for an aliased provider", () => {
-    const cfg = {
-      models: {
-        providers: {
-          "FIXTURE-PROVIDER": {
-            auth: "api-key",
-            baseUrl: "https://example.invalid",
-            models: [],
-          },
-        },
-      },
-    } satisfies OpenClawConfig;
-
-    expect(
-      resolveAuthProfileOrder({
-        cfg,
-        store: createMixedModeStore(),
-        provider: "FIXTURE-PROVIDER-PLAN",
-      }),
-    ).toEqual(["fixture-provider:api-key"]);
   });
 
   it("uses canonical provider auth order for alias providers", async () => {

--- a/src/agents/auth-profiles/order.ts
+++ b/src/agents/auth-profiles/order.ts
@@ -188,7 +188,7 @@ export function isConfiguredAwsSdkAuthProfileForProvider(params: {
   ) {
     return false;
   }
-  return providerAllowsAwsSdkAuth(params.cfg, params.provider);
+  return providerAllowsAwsSdkAuth(params.cfg, providerAuthKey);
 }
 
 /** Resolves whether a profile can be used for a provider right now. */
@@ -248,6 +248,20 @@ export function resolveAuthProfileEligibility(params: {
         return { eligible: false, reasonCode: "mode_mismatch" };
       }
     }
+  }
+  const providerAuthMode = resolveProviderAuthMode(params.cfg, providerAuthKey);
+  // The provider pin constrains credential class; ignoring it can pair a credential
+  // with the wrong transport selected from the same provider config.
+  const matchesProviderAuthMode =
+    providerAuthMode === "api-key"
+      ? cred.type === "api_key"
+      : providerAuthMode === "oauth"
+        ? cred.type === "oauth" || cred.type === "token"
+        : providerAuthMode === "token"
+          ? cred.type === "token"
+          : true;
+  if (!matchesProviderAuthMode) {
+    return { eligible: false, reasonCode: "mode_mismatch" };
   }
   const credentialEligibility = evaluateStoredCredentialEligibility({
     credential: cred,

--- a/src/agents/auth-profiles/order.ts
+++ b/src/agents/auth-profiles/order.ts
@@ -249,20 +249,6 @@ export function resolveAuthProfileEligibility(params: {
       }
     }
   }
-  const providerAuthMode = resolveProviderAuthMode(params.cfg, providerAuthKey);
-  // The provider pin constrains credential class; ignoring it can pair a credential
-  // with the wrong transport selected from the same provider config.
-  const matchesProviderAuthMode =
-    providerAuthMode === "api-key"
-      ? cred.type === "api_key"
-      : providerAuthMode === "oauth"
-        ? cred.type === "oauth" || cred.type === "token"
-        : providerAuthMode === "token"
-          ? cred.type === "token"
-          : true;
-  if (!matchesProviderAuthMode) {
-    return { eligible: false, reasonCode: "mode_mismatch" };
-  }
   const credentialEligibility = evaluateStoredCredentialEligibility({
     credential: cred,
     now: params.now,

--- a/src/agents/embedded-agent-runner/run/auth-plan.auth-pin.test.ts
+++ b/src/agents/embedded-agent-runner/run/auth-plan.auth-pin.test.ts
@@ -6,7 +6,7 @@ import type { OpenClawConfig } from "../../../config/types.openclaw.js";
 import type { OAuthCredential } from "../../auth-profiles.js";
 import { testing as externalAuthTesting } from "../../auth-profiles/external-auth.test-support.js";
 import { prepareAgentRuntimeAuth } from "../../runtime-plan/prepare-auth.js";
-import { loadEmbeddedRunAuthProfileStore } from "./auth-plan.js";
+import { testing as authPlanTesting } from "./auth-plan.test-support.js";
 
 const readCodexCliCredentialsCachedMock = vi.hoisted(() =>
   vi.fn<(_options?: unknown) => OAuthCredential | null>(() => null),
@@ -49,7 +49,7 @@ describe("embedded run auth plan provider pin", () => {
     } as OpenClawConfig;
     vi.stubEnv("OPENAI_API_KEY", "platform-api-key");
 
-    const authProfileStore = loadEmbeddedRunAuthProfileStore({
+    const authProfileStore = authPlanTesting.loadEmbeddedRunAuthProfileStore({
       agentDir,
       config,
       externalCliProviderIds: ["openai"],

--- a/src/agents/embedded-agent-runner/run/auth-plan.auth-pin.test.ts
+++ b/src/agents/embedded-agent-runner/run/auth-plan.auth-pin.test.ts
@@ -43,7 +43,7 @@ describe("embedded run auth plan provider pin", () => {
     const config = {
       models: {
         providers: {
-          openai: { auth: "api-key" },
+          openai: { auth: "api-key", baseUrl: "", models: [] },
         },
       },
     } as OpenClawConfig;

--- a/src/agents/embedded-agent-runner/run/auth-plan.auth-pin.test.ts
+++ b/src/agents/embedded-agent-runner/run/auth-plan.auth-pin.test.ts
@@ -1,0 +1,79 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../../../config/types.openclaw.js";
+import type { OAuthCredential } from "../../auth-profiles.js";
+import { testing as externalAuthTesting } from "../../auth-profiles/external-auth.test-support.js";
+import { prepareAgentRuntimeAuth } from "../../runtime-plan/prepare-auth.js";
+import { loadEmbeddedRunAuthProfileStore } from "./auth-plan.js";
+
+const readCodexCliCredentialsCachedMock = vi.hoisted(() =>
+  vi.fn<(_options?: unknown) => OAuthCredential | null>(() => null),
+);
+
+vi.mock("../../cli-credentials.js", () => ({
+  readClaudeCliCredentialsCached: () => null,
+  readCodexCliCredentialsCached: readCodexCliCredentialsCachedMock,
+  readMiniMaxCliCredentialsCached: () => null,
+}));
+
+describe("embedded run auth plan provider pin", () => {
+  let agentDir: string;
+
+  beforeEach(async () => {
+    agentDir = await mkdtemp(join(tmpdir(), "openclaw-auth-pin-"));
+    readCodexCliCredentialsCachedMock.mockReset().mockReturnValue({
+      type: "oauth",
+      provider: "openai",
+      access: "codex-access-token",
+      refresh: "codex-refresh-token",
+      expires: Date.now() + 30 * 60_000,
+    });
+    externalAuthTesting.setResolveExternalAuthProfilesForTest(() => []);
+  });
+
+  afterEach(async () => {
+    externalAuthTesting.resetResolveExternalAuthProfilesForTest();
+    vi.unstubAllEnvs();
+    await rm(agentDir, { recursive: true, force: true });
+  });
+
+  it("keeps ambient Codex OAuth behind an OpenAI api-key pin", () => {
+    const config = {
+      models: {
+        providers: {
+          openai: { auth: "api-key" },
+        },
+      },
+    } as OpenClawConfig;
+    vi.stubEnv("OPENAI_API_KEY", "platform-api-key");
+
+    const authProfileStore = loadEmbeddedRunAuthProfileStore({
+      agentDir,
+      config,
+      externalCliProviderIds: ["openai"],
+    });
+    expect(authProfileStore.profiles["openai:default"]).toBeUndefined();
+    const prepared = prepareAgentRuntimeAuth({
+      provider: "openai",
+      modelId: "gpt-5.6-luna",
+      modelApi: "openai-chatgpt-responses",
+      modelBaseUrl: "https://chatgpt.com/backend-api/codex",
+      config,
+      env: process.env,
+      agentDir,
+      authProfileStore,
+    });
+
+    expect(prepared.attempts[0]).toMatchObject({
+      kind: "direct",
+      plan: {
+        selectedAuthMode: "api-key",
+        modelRoute: {
+          authRequirement: "api-key",
+        },
+      },
+    });
+  });
+});

--- a/src/agents/embedded-agent-runner/run/auth-plan.test-support.ts
+++ b/src/agents/embedded-agent-runner/run/auth-plan.test-support.ts
@@ -1,0 +1,21 @@
+import "./auth-plan.js";
+import type { AuthProfileStore } from "../../auth-profiles.js";
+import type { RunEmbeddedAgentParams } from "./params.js";
+
+type EmbeddedRunAuthPlanTestApi = {
+  loadEmbeddedRunAuthProfileStore(params: {
+    agentDir: string;
+    config: RunEmbeddedAgentParams["config"];
+    externalCliProviderIds: Iterable<string>;
+  }): AuthProfileStore;
+};
+
+function getTestApi(): EmbeddedRunAuthPlanTestApi {
+  return (globalThis as Record<PropertyKey, unknown>)[
+    Symbol.for("openclaw.embeddedRunAuthPlanTestApi")
+  ] as EmbeddedRunAuthPlanTestApi;
+}
+
+export const testing: EmbeddedRunAuthPlanTestApi = {
+  loadEmbeddedRunAuthProfileStore: (params) => getTestApi().loadEmbeddedRunAuthProfileStore(params),
+};

--- a/src/agents/embedded-agent-runner/run/auth-plan.ts
+++ b/src/agents/embedded-agent-runner/run/auth-plan.ts
@@ -21,6 +21,20 @@ import type { RunEmbeddedAgentParams } from "./params.js";
 type ModelResolution = Awaited<ReturnType<typeof resolveModelAsync>>;
 type RuntimeModel = NonNullable<ModelResolution["model"]>;
 
+export function loadEmbeddedRunAuthProfileStore(params: {
+  agentDir: string;
+  config: RunEmbeddedAgentParams["config"];
+  externalCliProviderIds: Iterable<string>;
+}): AuthProfileStore {
+  // Provider pins own ambient overlays at this loader seam. Genuinely stored profiles and
+  // explicit bindings remain available for the cross-class contracts in prepare-auth.test.ts.
+  return ensureAuthProfileStore(params.agentDir, {
+    config: params.config,
+    externalCliProviderIds: params.externalCliProviderIds,
+    allowKeychainPrompt: false,
+  });
+}
+
 export async function prepareEmbeddedRunAuthPlan(params: {
   runParams: RunEmbeddedAgentParams;
   provider: string;
@@ -86,18 +100,20 @@ export async function prepareEmbeddedRunAuthPlan(params: {
   params.markStage?.("scope");
 
   const attemptAuthProfileStore = usesOpenAIAuthRouting
-    ? ensureAuthProfileStore(params.agentDir, {
+    ? loadEmbeddedRunAuthProfileStore({
+        agentDir: params.agentDir,
+        config: runParams.config,
         externalCliProviderIds: [OPENAI_PROVIDER_ID],
-        allowKeychainPrompt: false,
       })
     : initialPluginHarnessOwnsTransport
       ? ensureAuthProfileStoreWithoutExternalProfiles(params.agentDir, {
           allowKeychainPrompt: false,
         })
       : externalCliAuthScope.providerIds
-        ? ensureAuthProfileStore(params.agentDir, {
+        ? loadEmbeddedRunAuthProfileStore({
+            agentDir: params.agentDir,
+            config: runParams.config,
             externalCliProviderIds: externalCliAuthScope.providerIds,
-            allowKeychainPrompt: false,
           })
         : (noExternalAuthStore ??
           ensureAuthProfileStoreWithoutExternalProfiles(params.agentDir, {

--- a/src/agents/embedded-agent-runner/run/auth-plan.ts
+++ b/src/agents/embedded-agent-runner/run/auth-plan.ts
@@ -21,7 +21,7 @@ import type { RunEmbeddedAgentParams } from "./params.js";
 type ModelResolution = Awaited<ReturnType<typeof resolveModelAsync>>;
 type RuntimeModel = NonNullable<ModelResolution["model"]>;
 
-export function loadEmbeddedRunAuthProfileStore(params: {
+function loadEmbeddedRunAuthProfileStore(params: {
   agentDir: string;
   config: RunEmbeddedAgentParams["config"];
   externalCliProviderIds: Iterable<string>;
@@ -33,6 +33,13 @@ export function loadEmbeddedRunAuthProfileStore(params: {
     externalCliProviderIds: params.externalCliProviderIds,
     allowKeychainPrompt: false,
   });
+}
+
+// Test-only seam access mirrors external-auth.ts; the config-threading regression
+// must stay provable without composing a full embedded runner.
+if (process.env.VITEST || process.env.NODE_ENV === "test") {
+  (globalThis as Record<PropertyKey, unknown>)[Symbol.for("openclaw.embeddedRunAuthPlanTestApi")] =
+    { loadEmbeddedRunAuthProfileStore };
 }
 
 export async function prepareEmbeddedRunAuthPlan(params: {


### PR DESCRIPTION
## What Problem This Solves

`models.providers.<id>.auth` declares a provider's auth mechanism (documented: `"aws-sdk"` for Bedrock, `"api-key"` for Bedrock Mantle), but ambient credential discovery ignores it. Live repro on a real OpenAI API key: fresh state dir, config pin `{"models":{"providers":{"openai":{"auth":"api-key"}}}}`, env `OPENAI_API_KEY` set, and `~/.codex/auth.json` present in HOME → the gateway imported the ambient Codex ChatGPT OAuth as an external auth profile, `orderProfilesByMode`'s oauth-first preference put it ahead of the api-key credential, and every model call routed via `api=openai-chatgpt-responses`, silently overriding the explicit pin.

## Why This Change Was Made

The pin's shipped semantics (encoded in `src/agents/runtime-plan/prepare-auth.test.ts` contracts) are: it describes the provider entry's own auth material; user-stored profiles and explicit provider `apiKey` profile bindings deliberately outrank it. Those contracts are preserved untouched. What the pin must constrain is **ambient** credential material — external-CLI imports (codex/claude CLI) and synthetic plugin fills — which no user ever stored or bound.

Three-part fix:
- New `isAmbientCredentialAllowedByProviderAuthPin` (`src/agents/auth-profiles/ambient-auth.ts`): maps the pin to allowed ambient credential classes (`api-key` → `api_key`; `oauth` → `oauth`/`token`; `token` → `token`; `aws-sdk` → none), resolved against the canonical auth provider identity.
- `src/agents/auth-profiles/external-auth.ts`: external-CLI profile resolution and persistence skip ambient profiles whose class contradicts the pin, unless the profile is genuinely user-stored or explicitly requested; `src/agents/agent-auth-discovery.ts` applies the same gate to synthetic fills.
- `src/agents/embedded-agent-runner/run/auth-plan.ts`: the embedded runtime now threads `config` into the external-auth overlay — previously the gate could never see the pin on this path, which is exactly where the live hijack happened (companion/utility runs).

Fail closed: a pinned provider whose only credentials are contradicting ambient material resolves to no usable auth and surfaces the provider's missing-auth message. Also includes a small consistency fix: `isConfiguredAwsSdkAuthProfileForProvider` resolves the pin against the canonical provider key.

## User Impact

Setting `models.providers.<id>.auth` now actually protects the declared route: an explicit api-key pin keeps ambient ChatGPT/Codex OAuth from silently hijacking OpenAI traffic onto the ChatGPT backend (and generically for any provider/CLI import). Stored profiles, explicit bindings, and `auth.order` behave exactly as before.

## Evidence

- Red-then-green production-composition repro (`src/agents/embedded-agent-runner/run/auth-plan.auth-pin.test.ts`): embedded-run auth loading with a stubbed codex-cli external profile + env api-key + the pin asserted `subscription` (ChatGPT route) on the pre-fix HEAD and asserts `api-key` after the fix.
- Contract preservation: `src/agents/runtime-plan/prepare-auth.test.ts` untouched and green (stored profiles and explicit bindings still outrank the pin).
- Suites green: `node scripts/run-vitest.mjs src/agents/auth-profiles src/agents/runtime-plan src/agents/agent-auth-discovery.external-cli.test.ts` plus rewritten `order.test.ts` and new `external-oauth.test.ts` ambient cases.
- Live before/after on a real OpenAI API key (isolated dev gateway, fresh `OPENCLAW_STATE_DIR`, real HOME with `~/.codex/auth.json`, pin `"auth": "api-key"`, env key): pre-fix all model calls logged `api=openai-chatgpt-responses`; post-fix all model calls log `api=openai-responses` and a companion ask answers normally via the platform key.
- Autoreview (Codex, gpt-5.6-sol, xhigh): clean, "patch is correct (0.98)", no accepted/actionable findings.
