### PR TITLE
fix(code-mode): bound and simplify worker lifecycles

### DIFF
--- a/src/agents/code-mode-controller-source.ts
+++ b/src/agents/code-mode-controller-source.ts
@@ -1,0 +1,238 @@
+/** Sandboxed guest globals and host bridge for Code Mode QuickJS cells. */
+import { CODE_MODE_SWARM_CONTROLLER_SOURCE } from "./code-mode-swarm-controller-source.js";
+
+export const CODE_MODE_CONTROLLER_SOURCE = String.raw`
+(() => {
+  const output = [];
+  const pending = new Map();
+  const catalog = Array.isArray(globalThis.__openclawCatalog) ? globalThis.__openclawCatalog : [];
+  const apiFiles = Array.isArray(globalThis.__openclawApiFiles) ? globalThis.__openclawApiFiles : [];
+  const namespaceDescriptors = Array.isArray(globalThis.__openclawNamespaces) ? globalThis.__openclawNamespaces : [];
+  const hostRequest = globalThis.__openclawHostRequest;
+  delete globalThis.__openclawHostRequest;
+  const bridgeSequences = new Map();
+
+  function safe(value) {
+    if (value === undefined) return null;
+    try {
+      return JSON.parse(JSON.stringify(value));
+    } catch {
+      if (value instanceof Error) {
+        return { name: value.name, message: value.message };
+      }
+      if (value === null) return null;
+      const type = typeof value;
+      if (type === "string" || type === "number" || type === "boolean") return value;
+      return String(value);
+    }
+  }
+
+  function asText(value) {
+    if (typeof value === "string") return value;
+    const encoded = JSON.stringify(safe(value));
+    return typeof encoded === "string" ? encoded : String(value);
+  }
+
+  function request(method, args) {
+    const methodName = String(method);
+    const sequence = (bridgeSequences.get(methodName) ?? 0) + 1;
+    bridgeSequences.set(methodName, sequence);
+    const bridgeId = "bridge:" + methodName + ":" + String(sequence);
+    const id = String(hostRequest(methodName, JSON.stringify(safe(args ?? [])), bridgeId));
+    return new Promise((resolve, reject) => {
+      pending.set(id, { resolve, reject });
+    });
+  }
+
+  ${CODE_MODE_SWARM_CONTROLLER_SOURCE}
+
+  function namespaceFunction(namespaceId, path) {
+    const callablePath = Object.freeze((Array.isArray(path) ? path : []).map((entry) => String(entry)));
+    return (...args) => request("namespace", [namespaceId, callablePath, args]);
+  }
+
+  function deserializeNamespaceValue(namespaceId, value) {
+    if (!value || typeof value !== "object") return null;
+    if (value.kind === "function") {
+      return namespaceFunction(namespaceId, Array.isArray(value.path) ? value.path.slice() : []);
+    }
+    if (value.kind === "array") {
+      return Object.freeze((Array.isArray(value.items) ? value.items : []).map((item) => deserializeNamespaceValue(namespaceId, item)));
+    }
+    if (value.kind === "object") {
+      const object = Object.create(null);
+      for (const entry of Array.isArray(value.entries) ? value.entries : []) {
+        const key = Array.isArray(entry) && typeof entry[0] === "string" ? entry[0] : "";
+        if (!key) continue;
+        Object.defineProperty(object, key, {
+          value: deserializeNamespaceValue(namespaceId, entry[1]),
+          enumerable: true,
+        });
+      }
+      return Object.freeze(object);
+    }
+    return safe(value.value);
+  }
+
+  function settle(id, ok, payload) {
+    const entry = pending.get(String(id));
+    if (!entry) return false;
+    pending.delete(String(id));
+    let parsed = null;
+    try {
+      parsed = JSON.parse(String(payload));
+    } catch {
+      parsed = String(payload);
+    }
+    if (ok) {
+      entry.resolve(parsed);
+    } else {
+      const error = new Error(typeof parsed === "string" ? parsed : parsed?.message ?? "nested tool failed");
+      entry.reject(error);
+    }
+    return true;
+  }
+
+  function nodeHandle(descriptor) {
+    const handle = Object.create(null);
+    Object.defineProperties(handle, {
+      id: { value: descriptor.id, enumerable: true },
+      name: { value: descriptor.name, enumerable: true },
+      invoke: {
+        value: (command, params) => request("nodes", ["invoke", descriptor.id, command, params]),
+        enumerable: true,
+      },
+    });
+    if (typeof descriptor.listDirCommand === "string") {
+      Object.defineProperty(handle, "listDir", {
+        value: (path) => request("nodes", ["invoke", descriptor.id, descriptor.listDirCommand, { path }]),
+        enumerable: true,
+      });
+    }
+    return Object.freeze(handle);
+  }
+
+  const nodes = Object.freeze({
+    list: () => request("nodes", ["list"]),
+    get: async (idOrName) => nodeHandle(await request("nodes", ["get", idOrName])),
+  });
+
+  const baseTools = Object.create(null);
+  Object.defineProperties(baseTools, {
+    search: { value: (query, options) => request("search", [query, options]), enumerable: true },
+    describe: { value: (id) => request("describe", [id]), enumerable: true },
+    call: { value: (id, input) => request("call", [id, input]), enumerable: true },
+    callValue: { value: (id, input) => request("callValue", [id, input]), enumerable: true },
+  });
+  const skills = Object.freeze({
+    list: () => request("skillsList", []),
+    read: (name) => request("skillsRead", [name]),
+  });
+
+  if (globalThis.__openclawSwarmEnabled === true) {
+    Object.defineProperties(globalThis, {
+      agents: {
+        value: Object.freeze({ run: runAgent }),
+        enumerable: true,
+      },
+      phase: { value: (title) => swarmNote("phase", title), enumerable: true },
+      log: { value: (message) => swarmNote("log", message), enumerable: true },
+    });
+  }
+
+  function normalizeApiPath(value) {
+    const text = String(value ?? "").trim().replace(/^\/+/, "");
+    if (!text || text.split("/").some((segment) => !segment || segment === "." || segment === "..")) {
+      throw new Error("invalid API file path");
+    }
+    return text;
+  }
+
+  const apiFileMap = new Map();
+  for (const file of apiFiles) {
+    if (!file || typeof file !== "object") continue;
+    const path = typeof file.path === "string" ? file.path : "";
+    const content = typeof file.content === "string" ? file.content : "";
+    if (!path || !content) continue;
+    apiFileMap.set(path, Object.freeze({
+      path,
+      content,
+      description: typeof file.description === "string" ? file.description : undefined,
+      bytes: file.bytes,
+    }));
+  }
+  const api = Object.freeze({
+    list: async (prefix = "") => {
+      // list takes a directory prefix, so tolerate a trailing slash (API.list("mcp/"))
+      // that read's exact-path normalizer would otherwise reject as an empty segment.
+      const rawPrefix = prefix == null ? "" : String(prefix).trim().replace(/\/+$/, "");
+      const normalizedPrefix = rawPrefix === "" ? "" : normalizeApiPath(rawPrefix);
+      const files = [...apiFileMap.values()]
+        .filter((file) => !normalizedPrefix || file.path === normalizedPrefix || file.path.startsWith(normalizedPrefix.replace(/\/?$/, "/")))
+        .map((file) => Object.freeze({
+          path: file.path,
+          description: file.description,
+          bytes: file.bytes,
+        }));
+      return { files };
+    },
+    read: async (path) => {
+      const normalizedPath = normalizeApiPath(path);
+      const file = apiFileMap.get(normalizedPath);
+      if (!file) throw new Error("Unknown API file: " + normalizedPath);
+      return file;
+    },
+  });
+
+  const safeNameCounts = new Map();
+  for (const tool of catalog) {
+    const name = typeof tool?.name === "string" ? tool.name : "";
+    if (!/^[A-Za-z_$][A-Za-z0-9_$]*$/.test(name)) continue;
+    safeNameCounts.set(name, (safeNameCounts.get(name) ?? 0) + 1);
+  }
+  for (const tool of catalog) {
+    const name = typeof tool?.name === "string" ? tool.name : "";
+    const id = typeof tool?.id === "string" ? tool.id : "";
+    if (!id || safeNameCounts.get(name) !== 1 || Object.prototype.hasOwnProperty.call(baseTools, name)) {
+      continue;
+    }
+    Object.defineProperty(baseTools, name, {
+      value: (input) => request("callValue", [id, input]),
+      enumerable: true,
+    });
+  }
+
+  const namespaceGlobals = Object.create(null);
+  for (const descriptor of namespaceDescriptors) {
+    const id = typeof descriptor?.id === "string" ? descriptor.id : "";
+    const globalName = typeof descriptor?.globalName === "string" ? descriptor.globalName : "";
+    if (!id || !/^[A-Za-z_$][A-Za-z0-9_$]*$/.test(globalName)) continue;
+    const scope = deserializeNamespaceValue(id, descriptor.scope);
+    Object.defineProperty(namespaceGlobals, globalName, {
+      value: scope,
+      enumerable: true,
+    });
+    const existingGlobal = Object.getOwnPropertyDescriptor(globalThis, globalName);
+    if (existingGlobal && existingGlobal.configurable === false) continue;
+    Object.defineProperty(globalThis, globalName, {
+      value: scope,
+      enumerable: true,
+      configurable: true,
+    });
+  }
+
+  Object.defineProperties(globalThis, {
+    ALL_TOOLS: { value: Object.freeze(catalog.slice()), enumerable: true },
+    API: { value: api, enumerable: true },
+    nodes: { value: nodes, enumerable: true },
+    namespaces: { value: Object.freeze(namespaceGlobals), enumerable: true },
+    skills: { value: skills, enumerable: true },
+    tools: { value: Object.freeze(baseTools), enumerable: true },
+    text: { value: (value) => output.push({ type: "text", text: asText(value) }), enumerable: true },
+    json: { value: (value) => output.push({ type: "json", value: safe(value) }), enumerable: true },
+    yield_control: { value: (reason) => request("yield", [reason]), enumerable: true },
+    __openclawSettleBridge: { value: settle },
+    __openclawTakeOutput: { value: () => output.splice(0) },
+  });
+})();
+`;

--- a/src/agents/code-mode-execution.ts
+++ b/src/agents/code-mode-execution.ts
@@ -17,6 +17,7 @@ import {
   toToolSearchConfig,
   type CodeModeConfig,
   type CodeModeLanguage,
+  type CodeModeSettlementMode,
   type CodeModeWorkerResult,
   type SettledBridgeRequest,
 } from "./code-mode-runtime.js";
@@ -36,6 +37,7 @@ import {
   snapshotState,
   storeSnapshotState,
   telemetry,
+  waitForPendingBridgeSettlement,
   type PendingBridgeState,
 } from "./code-mode-state.js";
 import { normalizeCodeModeWorkerResult, runCodeModeWorker } from "./code-mode-worker.js";
@@ -156,29 +158,28 @@ function usableResumeBudgetMs(deadlineMs: number, config: CodeModeConfig): numbe
 }
 
 async function waitForPending(
-  pending: PendingBridgeState[],
+  pending: readonly PendingBridgeState[],
+  settlementMode: CodeModeSettlementMode,
   timeoutMs: number,
   signal?: AbortSignal,
-  waitForAll = false,
 ): Promise<boolean> {
   // Abort wins even over already-settled requests: callers treat `false` as
   // "do not resume the guest", which is what a cancelled exec/wait needs.
   if (signal?.aborted) {
     return false;
   }
-  if (!waitForAll && pending.some((entry) => entry.settled)) {
-    return true;
-  }
-  const pendingPromises = pending.filter((entry) => !entry.settled).map((entry) => entry.promise);
-  if (pendingPromises.length === 0) {
+  const required = pendingBridgeStatesForSettlement(pending, settlementMode);
+  if (
+    required.length === 0 ||
+    (settlementMode.kind === "awaiting" && required.some((entry) => entry.settled)) ||
+    required.every((entry) => entry.settled)
+  ) {
     return true;
   }
   let timer: ReturnType<typeof setTimeout> | undefined;
   let onAbort: (() => void) | undefined;
   try {
-    const bridgeReady = waitForAll
-      ? Promise.all(pendingPromises).then(() => true)
-      : Promise.race(pendingPromises).then(() => true);
+    const bridgeReady = waitForPendingBridgeSettlement(pending, settlementMode).then(() => true);
     return await Promise.race([
       bridgeReady,
       new Promise<boolean>((resolve) => {
@@ -296,10 +297,10 @@ async function settleCodeModeResult(params: {
         }),
       );
       const ready = await waitForPending(
-        pendingBridgeStatesForSettlement(pending, result.settlementMode),
+        pending,
+        result.settlementMode,
         remainingMs,
         params.signal,
-        result.settlementMode.kind === "draining",
       );
       const resumeBudgetMs = ready
         ? usableResumeBudgetMs(settleDeadline, params.config)
@@ -496,10 +497,10 @@ export async function runWait(params: {
   const deadlineMs = Date.now() + state.config.timeoutMs;
   try {
     const ready = await waitForPending(
-      pendingBridgeStatesForSettlement(state.pending, state.settlementMode),
+      state.pending,
+      state.settlementMode,
       Math.max(1, deadlineMs - Date.now()),
       params.signal,
-      state.settlementMode.kind === "draining",
     );
     const resumeBudgetMs = ready ? usableResumeBudgetMs(deadlineMs, state.config) : undefined;
     if (!ready || resumeBudgetMs === undefined) {

--- a/src/agents/code-mode-headless.test.ts
+++ b/src/agents/code-mode-headless.test.ts
@@ -622,6 +622,20 @@ describe("headless Code Mode", () => {
     expect(nodesTool.execute).toHaveBeenCalledOnce();
   });
 
+  it("fails an awaiting promise without bridge work before resuming a worker", async () => {
+    const result = expectFailed(
+      await runCodeModeScriptHeadless({
+        ctx: createHeadlessHarness(),
+        code: "await new Promise(() => {}); return true;",
+        wallClockMs: 5_000,
+      }),
+    );
+
+    expect(result.code).toBe("internal_error");
+    expect(result.error).toContain("pending without host work");
+    expect(result.toolCallCount).toBe(0);
+  });
+
   it("bounds output and returned values across separate worker legs", async () => {
     const tool = fakeTool("output_boundary", async () => jsonResult({ ok: true }));
 

--- a/src/agents/code-mode-headless.test.ts
+++ b/src/agents/code-mode-headless.test.ts
@@ -601,6 +601,46 @@ describe("headless Code Mode", () => {
     expect(tool.execute).toHaveBeenCalledOnce();
   });
 
+  it("counts first-class node operations against the headless tool budget", async () => {
+    const nodesTool = fakeTool("nodes", async () => jsonResult({ nodes: [] }));
+
+    const result = expectFailed(
+      await runCodeModeScriptHeadless({
+        ctx: createHeadlessHarness([nodesTool]),
+        code: `
+          await nodes.list();
+          await nodes.list();
+          return true;
+        `,
+        maxToolCalls: 1,
+        wallClockMs: 5_000,
+      }),
+    );
+
+    expect(result.code).toBe("tool_budget_exceeded");
+    expect(result.toolCallCount).toBe(2);
+    expect(nodesTool.execute).toHaveBeenCalledOnce();
+  });
+
+  it("bounds output and returned values across separate worker legs", async () => {
+    const tool = fakeTool("output_boundary", async () => jsonResult({ ok: true }));
+
+    const result = expectFailed(
+      await runCodeModeScriptHeadless({
+        ctx: createHeadlessHarness([tool]),
+        code: `
+          text("x".repeat(700));
+          await tools.call("openclaw:core:output_boundary", {});
+          return "y".repeat(700);
+        `,
+        overrides: { maxOutputBytes: 1_024 },
+      }),
+    );
+
+    expect(result.code).toBe("output_limit_exceeded");
+    expect(tool.execute).toHaveBeenCalledOnce();
+  });
+
   it("honors cron payload tool budgets above the old headless cap", async () => {
     const tool = fakeTool("budgeted", async () => jsonResult({ ok: true }));
     const result = expectCompleted(

--- a/src/agents/code-mode-headless.ts
+++ b/src/agents/code-mode-headless.ts
@@ -32,6 +32,7 @@ import {
   createPendingBridgeStates,
   pendingBridgeStatesForSettlement,
   settledBridgeRequestsInCompletionOrder,
+  waitForPendingBridgeSettlement,
   type PendingBridgeState,
 } from "./code-mode-state.js";
 import {
@@ -301,6 +302,7 @@ export async function runCodeModeScriptHeadless(params: {
         (request) =>
           request.method === "call" ||
           request.method === "callValue" ||
+          request.method === "nodes" ||
           request.method === "namespace",
       ).length;
       toolCallCount += requestedToolCalls;
@@ -333,29 +335,13 @@ export async function runCodeModeScriptHeadless(params: {
           toolCallCount,
         });
       }
-      // Detached calls belong to an already-completed guest and must all run;
-      // an awaiting guest resumes at its actual first settled frontier.
-      const bridgeFrontier =
-        result.settlementMode.kind === "awaiting"
-          ? Promise.race(frontierPending.map((entry) => entry.promise))
-          : Promise.all(frontierPending.map((entry) => entry.promise)).then((settled) => {
-              const first = settled[0];
-              if (!first) {
-                throw new Error("code mode is waiting without pending bridge requests");
-              }
-              return first;
-            });
-      const firstSettled = await awaitHeadlessDeadline({
-        promise: bridgeFrontier,
+      await awaitHeadlessDeadline({
+        promise: waitForPendingBridgeSettlement(pending, result.settlementMode),
         deadline,
         signal: abortScope.signal,
       });
       const settledRequests = settledBridgeRequestsInCompletionOrder(pending);
-      if (!settledRequests.some((entry) => entry.id === firstSettled.id)) {
-        settledRequests.push(firstSettled);
-      }
-      const settledIds = new Set(settledRequests.map((entry) => entry.id));
-      pending = pending.filter((entry) => !settledIds.has(entry.id));
+      pending = pending.filter((entry) => !entry.settled);
       result = normalizeCodeModeWorkerResult(
         await runHeadlessWorkerLeg({
           input: {

--- a/src/agents/code-mode-headless.ts
+++ b/src/agents/code-mode-headless.ts
@@ -298,6 +298,8 @@ export async function runCodeModeScriptHeadless(params: {
       enforceSnapshotPayloadLimits({ snapshotBytes: result.snapshotBytes, config, output });
       const pendingIds = new Set(pending.map((entry) => entry.id));
       const newRequests = result.pendingRequests.filter((request) => !pendingIds.has(request.id));
+      // Node discovery invokes the generic nodes tool for live status too;
+      // excluding list/get would bypass the same headless tool-call budget.
       const requestedToolCalls = newRequests.filter(
         (request) =>
           request.method === "call" ||

--- a/src/agents/code-mode-runtime.ts
+++ b/src/agents/code-mode-runtime.ts
@@ -1,5 +1,4 @@
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
-import type { Result } from "@openclaw/normalization-core/result";
 import { uniqueValues } from "@openclaw/normalization-core/string-normalization";
 import { parse, tokenizer } from "acorn";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
@@ -12,6 +11,7 @@ import {
   CODE_MODE_SHELL_SOURCE_ERROR,
   isShellLikeCodeModeSource,
 } from "./code-mode-shell-source.js";
+import type { CodeModeWorkerResult as WorkerThreadCodeModeResult } from "./code-mode-worker-types.js";
 import type { ToolSearchConfig, ToolSearchToolContext } from "./tool-search.js";
 import { asToolParamsRecord, ToolInputError } from "./tools/common.js";
 
@@ -50,27 +50,11 @@ export type CodeModeConfig = {
   maxSearchLimit: number;
 };
 
-type CodeModeBridgeMethod =
-  | "search"
-  | "describe"
-  | "call"
-  | "callValue"
-  | "nodes"
-  | "yield"
-  | "namespace"
-  | "agentSpawn"
-  | "agentWait"
-  | "skillsList"
-  | "skillsRead"
-  | "swarmNote";
-
-export type PendingBridgeRequest = {
-  id: string;
-  method: CodeModeBridgeMethod;
-  args: unknown[];
-};
-
-export type SettledBridgeRequest = { id: string } & Result<unknown, string>;
+export type {
+  CodeModeSettlementMode,
+  PendingBridgeRequest,
+  SettledBridgeRequest,
+} from "./code-mode-worker-types.js";
 
 export type CodeModeFailureCode =
   | "aborted"
@@ -96,23 +80,8 @@ export type CodeModeHeadlessResult =
       toolCallCount: number;
     };
 
-export type CodeModeSettlementMode =
-  | { kind: "awaiting" }
-  | { kind: "draining"; requiredRequestIds: string[] };
-
 export type CodeModeWorkerResult =
-  | {
-      status: "completed";
-      value: unknown;
-      output: unknown[];
-    }
-  | {
-      status: "waiting";
-      snapshotBytes: Uint8Array;
-      pendingRequests: PendingBridgeRequest[];
-      settlementMode: CodeModeSettlementMode;
-      output: unknown[];
-    }
+  | Extract<WorkerThreadCodeModeResult, { status: "completed" | "waiting" }>
   | {
       status: "failed";
       error: string;
@@ -333,7 +302,11 @@ export function enforceResultLimit(params: {
   config: CodeModeConfig;
 }): void {
   enforceOutputLimit(params.output, params.config);
-  if (params.value !== undefined && jsonByteLength(params.value) > params.config.maxOutputBytes) {
+  const outputBytes = params.output.length > 0 ? jsonByteLength(params.output) : 0;
+  if (
+    params.value !== undefined &&
+    outputBytes + jsonByteLength(params.value) > params.config.maxOutputBytes
+  ) {
     throw new CodeModeLimitError("output_limit_exceeded", "code mode output limit exceeded");
   }
 }

--- a/src/agents/code-mode-state.ts
+++ b/src/agents/code-mode-state.ts
@@ -50,6 +50,32 @@ export const activeRuns = new Map<string, CodeModeRunState>();
 export const resumingRunIds = new Set<string>();
 let activeRunReservations = 0;
 let nextPendingBridgeSettlementSequence = 0;
+let activeRunExpiryTimer: ReturnType<typeof setTimeout> | undefined;
+
+// One unreferenced timer owns parked snapshots even when no later exec or wait
+// arrives; otherwise expired runs keep their VM bytes and live tool calls.
+function scheduleActiveRunExpiry(): void {
+  if (activeRunExpiryTimer) {
+    clearTimeout(activeRunExpiryTimer);
+    activeRunExpiryTimer = undefined;
+  }
+  let nextExpiresAt = Number.POSITIVE_INFINITY;
+  for (const state of activeRuns.values()) {
+    nextExpiresAt = Math.min(nextExpiresAt, state.expiresAt);
+  }
+  if (!Number.isFinite(nextExpiresAt)) {
+    return;
+  }
+  activeRunExpiryTimer = setTimeout(
+    () => {
+      activeRunExpiryTimer = undefined;
+      removeExpiredRuns();
+      scheduleActiveRunExpiry();
+    },
+    Math.max(1, nextExpiresAt - Date.now()),
+  );
+  activeRunExpiryTimer.unref?.();
+}
 
 export function removeExpiredRuns(now = Date.now()): void {
   for (const [runId, state] of activeRuns) {
@@ -76,6 +102,7 @@ export function disposeCodeModeRun(runId: string): void {
   cancelPendingBridgeStates(state?.pending ?? []);
   activeRuns.delete(runId);
   resumingRunIds.delete(runId);
+  scheduleActiveRunExpiry();
 }
 
 /** Abort each bridge call whose result has not already reached its guest. */
@@ -99,14 +126,37 @@ export function settledBridgeRequestsInCompletionOrder(
 
 /** Keep every dispatched bridge call required until its guest has received the result. */
 export function pendingBridgeStatesForSettlement(
-  pending: PendingBridgeState[],
+  pending: readonly PendingBridgeState[],
   settlementMode: CodeModeSettlementMode,
-): PendingBridgeState[] {
+): readonly PendingBridgeState[] {
   if (settlementMode.kind === "awaiting") {
     return pending;
   }
   const requiredRequestIds = new Set(settlementMode.requiredRequestIds);
   return pending.filter((entry) => requiredRequestIds.has(entry.id));
+}
+
+/** Await the shared guest frontier without guessing native Promise ownership. */
+export function waitForPendingBridgeSettlement(
+  pending: readonly PendingBridgeState[],
+  settlementMode: CodeModeSettlementMode,
+): Promise<void> {
+  const required = pendingBridgeStatesForSettlement(pending, settlementMode);
+  if (
+    required.length === 0 ||
+    (settlementMode.kind === "awaiting" && required.some((entry) => entry.settled))
+  ) {
+    return Promise.resolve();
+  }
+  const outstanding = required.filter((entry) => !entry.settled);
+  if (outstanding.length === 0) {
+    return Promise.resolve();
+  }
+  const settlement =
+    settlementMode.kind === "draining"
+      ? Promise.all(outstanding.map((entry) => entry.promise))
+      : Promise.race(outstanding.map((entry) => entry.promise));
+  return settlement.then(() => undefined);
 }
 
 function resolveCodeModeSnapshotExpiresAt(now: number, ttlSeconds: number): number | undefined {
@@ -222,37 +272,37 @@ export function createPendingBridgeStates(params: {
     const signal = params.signal
       ? AbortSignal.any([params.signal, abortController.signal])
       : abortController.signal;
-    const promise = runBridgeRequest({
-      runtime: params.runtime,
-      namespaceRuntime: params.namespaceRuntime,
-      parentToolCallId: params.parentToolCallId,
-      codeModeRunId: params.codeModeRunId,
-      ctx: params.ctx,
-      request,
-      signal,
-      onUpdate: params.onUpdate,
-    });
     const state: PendingBridgeState = {
       ...request,
-      promise,
-      cancel: () => abortController.abort(),
-    };
-    void promise.then((settled) => {
-      state.settledSequence = ++nextPendingBridgeSettlementSequence;
-      state.settled = settled;
-      if (state.method === "agentWait" && params.activeRunId) {
-        const active = activeRuns.get(params.activeRunId);
-        if (active?.pending.includes(state)) {
-          const renewed = resolveCodeModeSnapshotExpiresAt(
-            Date.now(),
-            active.config.snapshotTtlSeconds,
-          );
-          if (renewed !== undefined) {
-            active.expiresAt = renewed;
+      promise: runBridgeRequest({
+        runtime: params.runtime,
+        namespaceRuntime: params.namespaceRuntime,
+        parentToolCallId: params.parentToolCallId,
+        codeModeRunId: params.codeModeRunId,
+        ctx: params.ctx,
+        request,
+        signal,
+        onUpdate: params.onUpdate,
+      }).then((settled) => {
+        state.settledSequence = ++nextPendingBridgeSettlementSequence;
+        state.settled = settled;
+        if (state.method === "agentWait" && params.activeRunId) {
+          const active = activeRuns.get(params.activeRunId);
+          if (active?.pending.includes(state)) {
+            const renewed = resolveCodeModeSnapshotExpiresAt(
+              Date.now(),
+              active.config.snapshotTtlSeconds,
+            );
+            if (renewed !== undefined) {
+              active.expiresAt = renewed;
+              scheduleActiveRunExpiry();
+            }
           }
         }
-      }
-    });
+        return settled;
+      }),
+      cancel: () => abortController.abort(),
+    };
     return state;
   });
 }
@@ -302,6 +352,7 @@ export function storeSnapshotState(params: {
     runtime: params.runtime,
     namespaceRuntime: params.namespaceRuntime,
   });
+  scheduleActiveRunExpiry();
   return {
     status: "waiting" as const,
     runId: params.runId,

--- a/src/agents/code-mode-state.ts
+++ b/src/agents/code-mode-state.ts
@@ -142,6 +142,8 @@ export function waitForPendingBridgeSettlement(
   settlementMode: CodeModeSettlementMode,
 ): Promise<void> {
   const required = pendingBridgeStatesForSettlement(pending, settlementMode);
+  // Workers reject hostless pending guests; headless execution also validates
+  // the frontier before reaching this shared settlement helper.
   if (
     required.length === 0 ||
     (settlementMode.kind === "awaiting" && required.some((entry) => entry.settled))

--- a/src/agents/code-mode-worker-lifecycle.test.ts
+++ b/src/agents/code-mode-worker-lifecycle.test.ts
@@ -1,0 +1,181 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createCodeModeNamespaceRuntime } from "./code-mode-namespaces.js";
+import { resolveCodeModeConfig, toToolSearchConfig } from "./code-mode-runtime.js";
+import {
+  activeRuns,
+  disposeCodeModeRun,
+  storeSnapshotState,
+  type PendingBridgeState,
+} from "./code-mode-state.js";
+import { runCodeModeWorker } from "./code-mode-worker.js";
+import {
+  createToolSearchCatalogRef,
+  registerHeadlessToolSearchCatalog,
+  ToolSearchRuntime,
+} from "./tool-search.js";
+
+const EXPIRING_RUN_ID = "cm_worker_lifecycle_expiry";
+
+function parkExpiringRun(method: "callValue" | "agentWait"): ReturnType<typeof vi.fn> {
+  const rawConfig = {
+    tools: { codeMode: { enabled: true, snapshotTtlSeconds: 1 } },
+  } as never;
+  const config = resolveCodeModeConfig(rawConfig);
+  const catalogRef = createToolSearchCatalogRef();
+  registerHeadlessToolSearchCatalog({ catalogRef, tools: [] });
+  const ctx = { config: rawConfig, runtimeConfig: rawConfig, catalogRef };
+  const runtime = new ToolSearchRuntime(ctx, toToolSearchConfig(config));
+  const cancel = vi.fn();
+  const pending: PendingBridgeState = {
+    id: `bridge:${method}:1`,
+    method,
+    args: method === "agentWait" ? ["collector-1"] : ["openclaw:core:slow", {}],
+    promise: new Promise(() => {}),
+    cancel,
+  };
+
+  storeSnapshotState({
+    runId: EXPIRING_RUN_ID,
+    replayId: "cm_replay_lifecycle",
+    pending: [pending],
+    replaySafe: false,
+    settlementMode: { kind: "awaiting" },
+    snapshotBytes: new Uint8Array([1]),
+    parentToolCallId: "code-mode-lifecycle",
+    ctx,
+    config,
+    runtime,
+    namespaceRuntime: createCodeModeNamespaceRuntime(),
+    output: [],
+  });
+  return cancel;
+}
+
+afterEach(() => {
+  disposeCodeModeRun(EXPIRING_RUN_ID);
+  vi.useRealTimers();
+});
+
+describe("Code Mode worker lifecycle", () => {
+  it("honors an already-aborted execution before starting a worker", async () => {
+    const config = resolveCodeModeConfig({ tools: { codeMode: true } } as never);
+    const controller = new AbortController();
+    controller.abort();
+
+    const result = await runCodeModeWorker(
+      {
+        kind: "exec",
+        source: "return true;",
+        config,
+        catalog: [],
+      },
+      10_000,
+      undefined,
+      controller.signal,
+    );
+
+    expect(result).toMatchObject({
+      status: "failed",
+      code: "aborted",
+      error: "code mode execution aborted",
+      output: [],
+    });
+  });
+
+  it("shares a compiled QuickJS module with isolated worker threads", async () => {
+    const config = resolveCodeModeConfig({ tools: { codeMode: true } } as never);
+    const workerUrl = new URL(
+      `data:text/javascript,${encodeURIComponent(`
+        import { parentPort, workerData } from "node:worker_threads";
+        parentPort.postMessage({
+          status: "completed",
+          value: workerData.wasmModule instanceof WebAssembly.Module,
+          output: [],
+        });
+      `)}`,
+    );
+
+    const results = await Promise.all(
+      Array.from({ length: 4 }, () =>
+        runCodeModeWorker(
+          {
+            kind: "exec",
+            source: "return true;",
+            config,
+            catalog: [],
+          },
+          10_000,
+          workerUrl,
+        ),
+      ),
+    );
+
+    expect(results).toEqual(
+      Array.from({ length: 4 }, () => ({
+        status: "completed",
+        value: true,
+        output: [],
+      })),
+    );
+  });
+
+  it.each([
+    { label: "returned values", source: 'return "x".repeat(2_048);' },
+    { label: "completed output", source: 'text("x".repeat(2_048)); return true;' },
+    {
+      label: "combined output and returned values",
+      source: 'text("x".repeat(700)); return "y".repeat(700);',
+    },
+    {
+      label: "suspended output",
+      source: 'text("x".repeat(2_048)); await yield_control("pause"); return true;',
+    },
+    { label: "failed output", source: 'text("x".repeat(2_048)); throw new Error("boom");' },
+  ])("rejects oversized $label before sending it across worker threads", async ({ source }) => {
+    const config = resolveCodeModeConfig({
+      tools: { codeMode: { enabled: true, maxOutputBytes: 1_024 } },
+    } as never);
+
+    const result = await runCodeModeWorker(
+      {
+        kind: "exec",
+        source,
+        config,
+        catalog: [],
+      },
+      10_000,
+    );
+
+    expect(result.status).toBe("failed");
+    if (result.status !== "failed") {
+      return;
+    }
+    expect(result.code).toBe("output_limit_exceeded");
+    expect(result.error).toBe("code mode output limit exceeded");
+    expect(result.output).toEqual([]);
+  });
+
+  it("expires an idle suspended snapshot and aborts its outstanding tool", async () => {
+    vi.useFakeTimers({ toFake: ["Date", "setTimeout", "clearTimeout"] });
+    const cancel = parkExpiringRun("callValue");
+
+    expect(activeRuns.has(EXPIRING_RUN_ID)).toBe(true);
+    await vi.advanceTimersByTimeAsync(1_000);
+
+    expect(activeRuns.has(EXPIRING_RUN_ID)).toBe(false);
+    expect(cancel).toHaveBeenCalledOnce();
+  });
+
+  it("retains an active collector only within its bounded snapshot TTL windows", async () => {
+    vi.useFakeTimers({ toFake: ["Date", "setTimeout", "clearTimeout"] });
+    const cancel = parkExpiringRun("agentWait");
+
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(activeRuns.has(EXPIRING_RUN_ID)).toBe(true);
+    expect(cancel).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(3_000);
+    expect(activeRuns.has(EXPIRING_RUN_ID)).toBe(false);
+    expect(cancel).toHaveBeenCalledOnce();
+  });
+});

--- a/src/agents/code-mode-worker-types.ts
+++ b/src/agents/code-mode-worker-types.ts
@@ -18,6 +18,7 @@ type CodeModeBridgeMethod =
 export type CodeModeConfig = {
   timeoutMs: number;
   memoryLimitBytes: number;
+  maxOutputBytes: number;
   maxPendingToolCalls: number;
   maxSnapshotBytes: number;
 };
@@ -61,7 +62,11 @@ export type CodeModeWorkerInput =
       pendingRequests?: PendingBridgeRequest[];
     };
 
-type CodeModeSettlementMode =
+export type CodeModeWorkerPayload = CodeModeWorkerInput & {
+  wasmModule: WebAssembly.Module;
+};
+
+export type CodeModeSettlementMode =
   | { kind: "awaiting" }
   | { kind: "draining"; requiredRequestIds: string[] };
 
@@ -85,6 +90,7 @@ export type CodeModeWorkerResult =
         | "invalid_input"
         | "runtime_unavailable"
         | "timeout"
+        | "output_limit_exceeded"
         | "snapshot_limit_exceeded"
         | "internal_error";
       output: unknown[];

--- a/src/agents/code-mode-worker-types.ts
+++ b/src/agents/code-mode-worker-types.ts
@@ -44,7 +44,7 @@ export type CodeModeNamespaceDescriptor = {
   scope: SerializedCodeModeNamespaceValue;
 };
 
-export type CodeModeWorkerInput =
+type CodeModeWorkerInput =
   | {
       kind: "exec";
       source: string;

--- a/src/agents/code-mode-worker.ts
+++ b/src/agents/code-mode-worker.ts
@@ -13,9 +13,16 @@ import {
 let quickJsWasmModulePromise: Promise<WebAssembly.Module> | undefined;
 
 function getQuickJsWasmModule(): Promise<WebAssembly.Module> {
-  quickJsWasmModulePromise ??= readFile(
-    createRequire(import.meta.url).resolve("quickjs-wasi/quickjs.wasm"),
-  ).then((bytes) => WebAssembly.compile(bytes));
+  quickJsWasmModulePromise ??= Promise.resolve()
+    .then(() => createRequire(import.meta.url).resolve("quickjs-wasi/quickjs.wasm"))
+    .then((wasmPath) => readFile(wasmPath))
+    .then((bytes) => WebAssembly.compile(bytes))
+    .catch((error: unknown) => {
+      // Failed initialization is transient host state, not a process-wide
+      // verdict; later runs must retry without bypassing their watchdog.
+      quickJsWasmModulePromise = undefined;
+      throw error;
+    });
   return quickJsWasmModulePromise;
 }
 

--- a/src/agents/code-mode-worker.ts
+++ b/src/agents/code-mode-worker.ts
@@ -1,3 +1,5 @@
+import { readFile } from "node:fs/promises";
+import { createRequire } from "node:module";
 import path from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import { Worker } from "node:worker_threads";
@@ -7,6 +9,15 @@ import {
   type CodeModeFailureCode,
   type CodeModeWorkerResult,
 } from "./code-mode-runtime.js";
+
+let quickJsWasmModulePromise: Promise<WebAssembly.Module> | undefined;
+
+function getQuickJsWasmModule(): Promise<WebAssembly.Module> {
+  quickJsWasmModulePromise ??= readFile(
+    createRequire(import.meta.url).resolve("quickjs-wasi/quickjs.wasm"),
+  ).then((bytes) => WebAssembly.compile(bytes));
+  return quickJsWasmModulePromise;
+}
 
 export function resolveCodeModeWorkerUrl(currentModuleUrl: string): URL {
   const currentPath = fileURLToPath(currentModuleUrl);
@@ -66,15 +77,7 @@ export async function runCodeModeWorker(
   const sourceWorkerExecArgv = resolvedWorkerUrl.pathname.endsWith(".ts")
     ? ["--import", "tsx"]
     : undefined;
-  let worker: Worker;
-  try {
-    worker = new Worker(resolvedWorkerUrl, {
-      workerData,
-      execArgv: sourceWorkerExecArgv,
-    });
-  } catch (error) {
-    return failedCodeModeWorkerResult(error, "runtime_unavailable");
-  }
+  let worker: Worker | undefined;
   let timer: ReturnType<typeof setTimeout> | undefined;
   let onAbort: (() => void) | undefined;
   try {
@@ -88,7 +91,6 @@ export async function runCodeModeWorker(
         resolve(result);
       };
       timer = setTimeout(() => {
-        void worker.terminate();
         finish({
           status: "failed",
           error: "code mode worker timeout exceeded",
@@ -97,7 +99,6 @@ export async function runCodeModeWorker(
         });
       }, timeoutMs);
       onAbort = () => {
-        void worker.terminate();
         const abortReason = signal?.reason;
         finish({
           status: "failed",
@@ -112,32 +113,55 @@ export async function runCodeModeWorker(
       signal?.addEventListener("abort", onAbort, { once: true });
       if (signal?.aborted) {
         onAbort();
+        return;
       }
-      worker.once("message", (message: unknown) => {
-        void worker.terminate();
-        const result = isRecord(message)
-          ? (message as CodeModeWorkerResult)
-          : ({
-              status: "failed",
-              error: "invalid code mode worker response",
-              code: "internal_error",
-              output: [],
-            } satisfies CodeModeWorkerResult);
-        finish(normalizeCodeModeWorkerResult(result));
-      });
-      worker.once("error", (error) => {
-        finish(failedCodeModeWorkerResult(error, "runtime_unavailable"));
-      });
-      worker.once("exit", (code) => {
-        // A clean exit without a response is still unavailable; `finish` keeps
-        // the normal message-then-exit sequence from replacing a real result.
-        finish(
-          failedCodeModeWorkerResult(
-            new Error(`code mode worker exited with code ${code} before returning a result`),
-            "runtime_unavailable",
-          ),
-        );
-      });
+
+      // Compilation is part of the same execution deadline. A timed-out or
+      // aborted initialization must never create a worker after settlement.
+      void getQuickJsWasmModule().then(
+        (wasmModule) => {
+          if (settled) {
+            return;
+          }
+          try {
+            worker = new Worker(resolvedWorkerUrl, {
+              workerData: isRecord(workerData) ? { ...workerData, wasmModule } : workerData,
+              execArgv: sourceWorkerExecArgv,
+            });
+          } catch (error) {
+            finish(failedCodeModeWorkerResult(error, "runtime_unavailable"));
+            return;
+          }
+
+          worker.once("message", (message: unknown) => {
+            const result = isRecord(message)
+              ? (message as CodeModeWorkerResult)
+              : ({
+                  status: "failed",
+                  error: "invalid code mode worker response",
+                  code: "internal_error",
+                  output: [],
+                } satisfies CodeModeWorkerResult);
+            finish(normalizeCodeModeWorkerResult(result));
+          });
+          worker.once("error", (error) => {
+            finish(failedCodeModeWorkerResult(error, "runtime_unavailable"));
+          });
+          worker.once("exit", (code) => {
+            // A clean exit without a response is still unavailable; `finish`
+            // prevents normal message-then-exit from replacing a real result.
+            finish(
+              failedCodeModeWorkerResult(
+                new Error(`code mode worker exited with code ${code} before returning a result`),
+                "runtime_unavailable",
+              ),
+            );
+          });
+        },
+        (error: unknown) => {
+          finish(failedCodeModeWorkerResult(error, "runtime_unavailable"));
+        },
+      );
     });
   } finally {
     if (timer) {
@@ -146,6 +170,7 @@ export async function runCodeModeWorker(
     if (onAbort) {
       signal?.removeEventListener("abort", onAbort);
     }
+    await worker?.terminate();
   }
 }
 

--- a/src/agents/code-mode.ts
+++ b/src/agents/code-mode.ts
@@ -335,8 +335,6 @@ export function addClientToolsToCodeModeCatalog(params: {
 }
 
 /** Test-only hooks and state accessors for Code Mode worker orchestration. */
-
-/** Test-only hooks and state accessors for Code Mode worker orchestration. */
 const testing = {
   activeRuns,
   resumingRunIds,

--- a/src/agents/code-mode.worker.ts
+++ b/src/agents/code-mode.worker.ts
@@ -1,26 +1,20 @@
 /**
  * QuickJS worker for Code Mode guest execution and suspended VM snapshots.
  */
-import { readFile } from "node:fs/promises";
-import { createRequire } from "node:module";
 import { parentPort, workerData } from "node:worker_threads";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { EvalFlags, JSException, QuickJS, type JSValueHandle } from "quickjs-wasi";
+import { CODE_MODE_CONTROLLER_SOURCE } from "./code-mode-controller-source.js";
 import { toCodeModeJsonSafe as toJsonSafe } from "./code-mode-json.js";
 import type { CodeModeApiVirtualFile } from "./code-mode-namespaces.js";
-import { CODE_MODE_SWARM_CONTROLLER_SOURCE } from "./code-mode-swarm-controller-source.js";
 import type {
   CodeModeConfig,
   CodeModeNamespaceDescriptor,
-  CodeModeWorkerInput,
+  CodeModeWorkerPayload,
   CodeModeWorkerResult,
   PendingBridgeRequest,
   SettledBridgeRequest,
 } from "./code-mode-worker-types.js";
-const require = createRequire(import.meta.url);
-const QUICKJS_WASM_PATH = require.resolve("quickjs-wasi/quickjs.wasm");
-let quickJsWasmModulePromise: Promise<WebAssembly.Module> | undefined;
-
 class CodeModeWorkerFailure extends Error {
   readonly code: Extract<CodeModeWorkerResult, { status: "failed" }>["code"];
 
@@ -66,13 +60,6 @@ type VmRun = {
   didTimeout: () => boolean;
 };
 
-function getQuickJsWasmModule(): Promise<WebAssembly.Module> {
-  quickJsWasmModulePromise ??= readFile(QUICKJS_WASM_PATH).then((bytes) =>
-    WebAssembly.compile(bytes),
-  );
-  return quickJsWasmModulePromise;
-}
-
 // QuickJS error stacks are backtrace frames only ("    at file:line:col"), with
 // no leading "Name: message" header like V8. Returning .stack alone therefore
 // dropped the actual cause, surfacing failures to the model as a bare location
@@ -95,242 +82,6 @@ function errorMessage(error: unknown): string {
   }
   return String(error);
 }
-
-const CONTROLLER_SOURCE = String.raw`
-(() => {
-  const output = [];
-  const pending = new Map();
-  const catalog = Array.isArray(globalThis.__openclawCatalog) ? globalThis.__openclawCatalog : [];
-  const apiFiles = Array.isArray(globalThis.__openclawApiFiles) ? globalThis.__openclawApiFiles : [];
-  const namespaceDescriptors = Array.isArray(globalThis.__openclawNamespaces) ? globalThis.__openclawNamespaces : [];
-  const hostRequest = globalThis.__openclawHostRequest;
-  delete globalThis.__openclawHostRequest;
-  const bridgeSequences = new Map();
-
-  function safe(value) {
-    if (value === undefined) return null;
-    try {
-      return JSON.parse(JSON.stringify(value));
-    } catch {
-      if (value instanceof Error) {
-        return { name: value.name, message: value.message };
-      }
-      if (value === null) return null;
-      const type = typeof value;
-      if (type === "string" || type === "number" || type === "boolean") return value;
-      return String(value);
-    }
-  }
-
-  function asText(value) {
-    if (typeof value === "string") return value;
-    const encoded = JSON.stringify(safe(value));
-    return typeof encoded === "string" ? encoded : String(value);
-  }
-
-  function request(method, args) {
-    const methodName = String(method);
-    const sequence = (bridgeSequences.get(methodName) ?? 0) + 1;
-    bridgeSequences.set(methodName, sequence);
-    const bridgeId = "bridge:" + methodName + ":" + String(sequence);
-    const id = String(hostRequest(methodName, JSON.stringify(safe(args ?? [])), bridgeId));
-    return new Promise((resolve, reject) => {
-      pending.set(id, { resolve, reject });
-    });
-  }
-
-  ${CODE_MODE_SWARM_CONTROLLER_SOURCE}
-
-  function namespaceFunction(namespaceId, path) {
-    const callablePath = Object.freeze((Array.isArray(path) ? path : []).map((entry) => String(entry)));
-    return (...args) => request("namespace", [namespaceId, callablePath, args]);
-  }
-
-  function deserializeNamespaceValue(namespaceId, value) {
-    if (!value || typeof value !== "object") return null;
-    if (value.kind === "function") {
-      return namespaceFunction(namespaceId, Array.isArray(value.path) ? value.path.slice() : []);
-    }
-    if (value.kind === "array") {
-      return Object.freeze((Array.isArray(value.items) ? value.items : []).map((item) => deserializeNamespaceValue(namespaceId, item)));
-    }
-    if (value.kind === "object") {
-      const object = Object.create(null);
-      for (const entry of Array.isArray(value.entries) ? value.entries : []) {
-        const key = Array.isArray(entry) && typeof entry[0] === "string" ? entry[0] : "";
-        if (!key) continue;
-        Object.defineProperty(object, key, {
-          value: deserializeNamespaceValue(namespaceId, entry[1]),
-          enumerable: true,
-        });
-      }
-      return Object.freeze(object);
-    }
-    return safe(value.value);
-  }
-
-  function settle(id, ok, payload) {
-    const entry = pending.get(String(id));
-    if (!entry) return false;
-    pending.delete(String(id));
-    let parsed = null;
-    try {
-      parsed = JSON.parse(String(payload));
-    } catch {
-      parsed = String(payload);
-    }
-    if (ok) {
-      entry.resolve(parsed);
-    } else {
-      const error = new Error(typeof parsed === "string" ? parsed : parsed?.message ?? "nested tool failed");
-      entry.reject(error);
-    }
-    return true;
-  }
-
-  function nodeHandle(descriptor) {
-    const handle = Object.create(null);
-    Object.defineProperties(handle, {
-      id: { value: descriptor.id, enumerable: true },
-      name: { value: descriptor.name, enumerable: true },
-      invoke: {
-        value: (command, params) => request("nodes", ["invoke", descriptor.id, command, params]),
-        enumerable: true,
-      },
-    });
-    if (typeof descriptor.listDirCommand === "string") {
-      Object.defineProperty(handle, "listDir", {
-        value: (path) => request("nodes", ["invoke", descriptor.id, descriptor.listDirCommand, { path }]),
-        enumerable: true,
-      });
-    }
-    return Object.freeze(handle);
-  }
-
-  const nodes = Object.freeze({
-    list: () => request("nodes", ["list"]),
-    get: async (idOrName) => nodeHandle(await request("nodes", ["get", idOrName])),
-  });
-
-  const baseTools = Object.create(null);
-  Object.defineProperties(baseTools, {
-    search: { value: (query, options) => request("search", [query, options]), enumerable: true },
-    describe: { value: (id) => request("describe", [id]), enumerable: true },
-    call: { value: (id, input) => request("call", [id, input]), enumerable: true },
-    callValue: { value: (id, input) => request("callValue", [id, input]), enumerable: true },
-  });
-  const skills = Object.freeze({
-    list: () => request("skillsList", []),
-    read: (name) => request("skillsRead", [name]),
-  });
-
-  if (globalThis.__openclawSwarmEnabled === true) {
-    Object.defineProperties(globalThis, {
-      agents: {
-        value: Object.freeze({ run: runAgent }),
-        enumerable: true,
-      },
-      phase: { value: (title) => swarmNote("phase", title), enumerable: true },
-      log: { value: (message) => swarmNote("log", message), enumerable: true },
-    });
-  }
-
-  function normalizeApiPath(value) {
-    const text = String(value ?? "").trim().replace(/^\/+/, "");
-    if (!text || text.split("/").some((segment) => !segment || segment === "." || segment === "..")) {
-      throw new Error("invalid API file path");
-    }
-    return text;
-  }
-
-  const apiFileMap = new Map();
-  for (const file of apiFiles) {
-    if (!file || typeof file !== "object") continue;
-    const path = typeof file.path === "string" ? file.path : "";
-    const content = typeof file.content === "string" ? file.content : "";
-    if (!path || !content) continue;
-    apiFileMap.set(path, Object.freeze({
-      path,
-      content,
-      description: typeof file.description === "string" ? file.description : undefined,
-      bytes: file.bytes,
-    }));
-  }
-  const api = Object.freeze({
-    list: async (prefix = "") => {
-      // list takes a directory prefix, so tolerate a trailing slash (API.list("mcp/"))
-      // that read's exact-path normalizer would otherwise reject as an empty segment.
-      const rawPrefix = prefix == null ? "" : String(prefix).trim().replace(/\/+$/, "");
-      const normalizedPrefix = rawPrefix === "" ? "" : normalizeApiPath(rawPrefix);
-      const files = [...apiFileMap.values()]
-        .filter((file) => !normalizedPrefix || file.path === normalizedPrefix || file.path.startsWith(normalizedPrefix.replace(/\/?$/, "/")))
-        .map((file) => Object.freeze({
-          path: file.path,
-          description: file.description,
-          bytes: file.bytes,
-        }));
-      return { files };
-    },
-    read: async (path) => {
-      const normalizedPath = normalizeApiPath(path);
-      const file = apiFileMap.get(normalizedPath);
-      if (!file) throw new Error("Unknown API file: " + normalizedPath);
-      return file;
-    },
-  });
-
-  const safeNameCounts = new Map();
-  for (const tool of catalog) {
-    const name = typeof tool?.name === "string" ? tool.name : "";
-    if (!/^[A-Za-z_$][A-Za-z0-9_$]*$/.test(name)) continue;
-    safeNameCounts.set(name, (safeNameCounts.get(name) ?? 0) + 1);
-  }
-  for (const tool of catalog) {
-    const name = typeof tool?.name === "string" ? tool.name : "";
-    const id = typeof tool?.id === "string" ? tool.id : "";
-    if (!id || safeNameCounts.get(name) !== 1 || Object.prototype.hasOwnProperty.call(baseTools, name)) {
-      continue;
-    }
-    Object.defineProperty(baseTools, name, {
-      value: (input) => request("callValue", [id, input]),
-      enumerable: true,
-    });
-  }
-
-  const namespaceGlobals = Object.create(null);
-  for (const descriptor of namespaceDescriptors) {
-    const id = typeof descriptor?.id === "string" ? descriptor.id : "";
-    const globalName = typeof descriptor?.globalName === "string" ? descriptor.globalName : "";
-    if (!id || !/^[A-Za-z_$][A-Za-z0-9_$]*$/.test(globalName)) continue;
-    const scope = deserializeNamespaceValue(id, descriptor.scope);
-    Object.defineProperty(namespaceGlobals, globalName, {
-      value: scope,
-      enumerable: true,
-    });
-    const existingGlobal = Object.getOwnPropertyDescriptor(globalThis, globalName);
-    if (existingGlobal && existingGlobal.configurable === false) continue;
-    Object.defineProperty(globalThis, globalName, {
-      value: scope,
-      enumerable: true,
-      configurable: true,
-    });
-  }
-
-  Object.defineProperties(globalThis, {
-    ALL_TOOLS: { value: Object.freeze(catalog.slice()), enumerable: true },
-    API: { value: api, enumerable: true },
-    nodes: { value: nodes, enumerable: true },
-    namespaces: { value: Object.freeze(namespaceGlobals), enumerable: true },
-    skills: { value: skills, enumerable: true },
-    tools: { value: Object.freeze(baseTools), enumerable: true },
-    text: { value: (value) => output.push({ type: "text", text: asText(value) }), enumerable: true },
-    json: { value: (value) => output.push({ type: "json", value: safe(value) }), enumerable: true },
-    yield_control: { value: (reason) => request("yield", [reason]), enumerable: true },
-    __openclawSettleBridge: { value: settle },
-    __openclawTakeOutput: { value: () => output.splice(0) },
-  });
-})();
-`;
 
 function buildUserSource(code: string): string {
   return `globalThis.__openclawResult = (async () => {\n${code}\n})()`;
@@ -394,6 +145,7 @@ function createHostRequestHandler(params: {
 }
 
 async function createVm(params: {
+  wasmModule: WebAssembly.Module;
   catalog: unknown[];
   apiFiles: CodeModeApiVirtualFile[];
   namespaces: CodeModeNamespaceDescriptor[];
@@ -405,7 +157,7 @@ async function createVm(params: {
   let timedOut = false;
   const deadlineReached = () => Date.now() - startedAt >= params.config.timeoutMs;
   const vm = await QuickJS.create({
-    wasm: await getQuickJsWasmModule(),
+    wasm: params.wasmModule,
     memoryLimit: params.config.memoryLimitBytes,
     timezoneOffset: 0,
     interruptHandler: () => {
@@ -433,11 +185,12 @@ async function createVm(params: {
       config: params.config,
     }),
   ).consume((hostRequest) => vm.global.setProp("__openclawHostRequest", hostRequest));
-  vm.evalCode(CONTROLLER_SOURCE, "openclaw-code-mode:controller.js").dispose();
+  vm.evalCode(CODE_MODE_CONTROLLER_SOURCE, "openclaw-code-mode:controller.js").dispose();
   return { vm, didTimeout: () => timedOut || deadlineReached() };
 }
 
 async function restoreVm(params: {
+  wasmModule: WebAssembly.Module;
   snapshotBytes: Uint8Array;
   config: CodeModeConfig;
   pendingRequests: PendingBridgeRequest[];
@@ -447,7 +200,7 @@ async function restoreVm(params: {
   const deadlineReached = () => Date.now() - startedAt >= params.config.timeoutMs;
   const snapshot = QuickJS.deserializeSnapshot(params.snapshotBytes);
   const vm = await QuickJS.restore(snapshot, {
-    wasm: await getQuickJsWasmModule(),
+    wasm: params.wasmModule,
     memoryLimit: params.config.memoryLimitBytes,
     timezoneOffset: 0,
     interruptHandler: () => {
@@ -483,14 +236,43 @@ function takeOutputSafely(vm: QuickJS): unknown[] {
   }
 }
 
+function enforceWorkerOutputLimit(
+  value: unknown,
+  config: CodeModeConfig,
+  consumedBytes = 0,
+): number {
+  const bytes = Buffer.byteLength(JSON.stringify(toJsonSafe(value)) ?? "null", "utf8");
+  if (consumedBytes + bytes > config.maxOutputBytes) {
+    throw new CodeModeWorkerFailure("output_limit_exceeded", "code mode output limit exceeded");
+  }
+  return bytes;
+}
+
 function throwWorkerFailureWithOutput(params: {
   error: unknown;
   didTimeout: () => boolean;
   output: unknown[];
   vm: QuickJS;
+  config: CodeModeConfig;
 }): never {
   const timedOut = params.didTimeout() || isQuickJsInterruptedError(params.error);
   const failureOutput = params.output.length > 0 ? params.output : takeOutputSafely(params.vm);
+  if (
+    params.error instanceof CodeModeWorkerFailure &&
+    params.error.code === "output_limit_exceeded"
+  ) {
+    throw new CodeModeWorkerFailureWithOutput(params.error.code, params.error.message, [], {
+      cause: params.error,
+    });
+  }
+  try {
+    enforceWorkerOutputLimit(failureOutput, params.config);
+  } catch (error) {
+    if (error instanceof CodeModeWorkerFailure) {
+      throw new CodeModeWorkerFailureWithOutput(error.code, error.message, [], { cause: error });
+    }
+    throw error;
+  }
   if (timedOut) {
     throw new CodeModeWorkerFailureWithOutput(
       "timeout",
@@ -581,6 +363,7 @@ async function runVmExecution(params: {
     params.prepare();
     params.vm.executePendingJobs();
     output = takeOutput(params.vm);
+    const outputBytes = enforceWorkerOutputLimit(output, params.config);
     const resultHandle = params.vm.global.getProp("__openclawResult");
     try {
       const promisePending = resultHandle.isPromise && resultHandle.promiseState === 0;
@@ -601,9 +384,11 @@ async function runVmExecution(params: {
           config: params.config,
         });
       }
+      const value = await readCompletedResult(params.vm, resultHandle);
+      enforceWorkerOutputLimit(value, params.config, output.length > 0 ? outputBytes : 0);
       return {
         status: "completed",
-        value: await readCompletedResult(params.vm, resultHandle),
+        value,
         output,
       };
     } finally {
@@ -615,15 +400,17 @@ async function runVmExecution(params: {
       didTimeout: params.didTimeout,
       output,
       vm: params.vm,
+      config: params.config,
     });
   } finally {
     params.vm.dispose();
   }
 }
 
-async function runExec(input: Extract<CodeModeWorkerInput, { kind: "exec" }>) {
+async function runExec(input: Extract<CodeModeWorkerPayload, { kind: "exec" }>) {
   const pendingRequests: PendingBridgeRequest[] = [];
   const { vm, didTimeout } = await createVm({
+    wasmModule: input.wasmModule,
     catalog: input.catalog,
     apiFiles: input.apiFiles ?? [],
     namespaces: input.namespaces,
@@ -646,11 +433,12 @@ async function runExec(input: Extract<CodeModeWorkerInput, { kind: "exec" }>) {
   });
 }
 
-async function runResume(input: Extract<CodeModeWorkerInput, { kind: "resume" }>) {
+async function runResume(input: Extract<CodeModeWorkerPayload, { kind: "resume" }>) {
   // Restored promises keep their original bridge ids; do not redispatch calls
   // that are still running when a faster sibling resumes this snapshot.
   const pendingRequests: PendingBridgeRequest[] = [...(input.pendingRequests ?? [])];
   const { vm, didTimeout } = await restoreVm({
+    wasmModule: input.wasmModule,
     snapshotBytes: input.snapshotBytes,
     config: input.config,
     pendingRequests,
@@ -683,9 +471,13 @@ async function runResume(input: Extract<CodeModeWorkerInput, { kind: "resume" }>
   });
 }
 
+function isQuickJsWasmModule(value: unknown): value is WebAssembly.Module {
+  return Object.prototype.toString.call(value) === "[object WebAssembly.Module]";
+}
+
 async function main(): Promise<CodeModeWorkerResult> {
   const input = workerData as unknown;
-  if (!isRecord(input) || !isRecord(input.config)) {
+  if (!isRecord(input) || !isRecord(input.config) || !isQuickJsWasmModule(input.wasmModule)) {
     return {
       status: "failed",
       error: "invalid code mode worker input",
@@ -697,6 +489,7 @@ async function main(): Promise<CodeModeWorkerResult> {
     if (input.kind === "exec" && typeof input.source === "string") {
       return await runExec({
         kind: "exec",
+        wasmModule: input.wasmModule,
         source: input.source,
         config: input.config as CodeModeConfig,
         catalog: Array.isArray(input.catalog) ? input.catalog : [],
@@ -710,6 +503,7 @@ async function main(): Promise<CodeModeWorkerResult> {
     if (input.kind === "resume" && input.snapshotBytes instanceof Uint8Array) {
       return await runResume({
         kind: "resume",
+        wasmModule: input.wasmModule,
         snapshotBytes: input.snapshotBytes,
         config: input.config as CodeModeConfig,
         settledRequests: Array.isArray(input.settledRequests)


### PR DESCRIPTION
Related: #114884

## What Problem This Solves

Fixes an issue where users running Code Mode could pay a fresh QuickJS/WebAssembly compilation on every execution and resume, exceed node-operation or cross-thread output budgets, retain expired suspended runs until unrelated activity, or outlive an execution deadline during worker initialization.

## Why This Change Was Made

Compile QuickJS once in the process and transfer the compiled WebAssembly module into isolated workers; cover module initialization, execution, cancellation, and termination with one watchdog. Use one canonical bridge-settlement contract for interactive and headless execution, enforce a single output-and-result budget before crossing worker threads and across suspended legs, schedule bounded idle-run cleanup, and extract the guest controller without changing its runtime. Preserve the first-class `skills.list()` and `skills.read()` APIs added concurrently on `main`, including bridge validation and replay safety. Keep caller requests separate from the internal compiled-module worker payload.

## User Impact

Code Mode and headless/cron scripts run faster, respect configured limits consistently, release inactive snapshots and pending tools automatically, terminate promptly on cancellation, and keep first-class tools, nodes, swarm, MCP, and skill access working.

## Evidence

- Fresh independent Codex autoreview against the final rebased branch; all accepted findings resolved.
- Blacksmith Testbox: six real-worker Code Mode suites, 390 passing tests, including interactive execution, headless/cron, nodes, swarm, suspension/resumption, worker lifecycle, and the newly landed first-class skills tests.
- 130,000 adversarial JavaScript, regular-expression, module-loader, and Unicode parser inputs.
- Focused regressions for compiled-module sharing, pre-aborted workers, returned values, completed/suspended/failed output, aggregate output and returned values, aggregate budgets across worker legs, expired snapshot cancellation, bounded collector retention, and node tool budgets.
- Blacksmith Testbox: production/core and core-test TypeScript checks; changed-file oxlint; complete packaged `pnpm build`, CLI-bootstrap validation, plugin SDK exports, Control UI bundle and sidecar checks.
- Blacksmith Testbox: `deadcode:dependencies`, `deadcode:unused-files`, and `deadcode:exports` all pass with zero unused entries.
- Regression proof: headless guest promises without host work fail immediately without worker churn; synchronous and transient WebAssembly initialization failures retain the watchdog and retry instead of poisoning the shared cache.
- Measured original five-suite baseline: 376 tests in 25.61 seconds; post-refactor stress run before concurrent upstream skills additions: 387 tests in 21.08 seconds.
- Directly inspected upstream Codex commit `3418498f01422f5f650ea645d4bd19e05c3a9616`: `codex-rs/core/src/tools/code_mode/execute_handler.rs`, `codex-rs/core/src/tools/code_mode/wait_handler.rs`, `codex-rs/code-mode/src/cell_actor/mod.rs`, `codex-rs/code-mode/src/cell_actor/callbacks.rs`, `codex-rs/code-mode/src/session_runtime/mod.rs`, and `codex-rs/code-mode-protocol/src/runtime.rs`.
- AI-assisted.


### Inspectable final-head real-worker proof

Final reviewed head: `1cfb44030e3a617518b389bd3edd5a7ba641b373`. Blacksmith Testbox `harbor-crayfish-4977` ran the real `quickjs-wasi` worker against the final commit; the following is directly observed verbose output:

```text
$ pnpm test src/agents/code-mode-worker-lifecycle.test.ts \
    src/agents/code-mode-headless.test.ts --reporter=verbose

PASS honors an already-aborted execution before starting a worker                 18ms
PASS shares a compiled QuickJS module with isolated worker threads               36ms
PASS rejects oversized returned values before sending across worker threads       79ms
PASS rejects oversized completed output before sending across worker threads      70ms
PASS rejects oversized combined output and returned values before worker IPC      72ms
PASS rejects oversized suspended output before sending across worker threads      70ms
PASS rejects oversized failed output before sending across worker threads         74ms
PASS expires an idle suspended snapshot and aborts its outstanding tool             3ms
PASS retains an active collector only within bounded snapshot TTL windows           1ms
PASS counts first-class node operations against the headless tool budget          125ms
PASS fails an awaiting promise without bridge work before resuming a worker        62ms
PASS bounds output and returned values across separate worker legs                125ms
PASS enforces one wall-clock deadline across worker and tool legs                  83ms
PASS terminates an in-flight worker leg when aborted                              105ms
PASS classifies caller aborts before the worker leg as aborted                      1ms
PASS keeps worker-leg wall-clock expiry classified as timeout                     106ms

Test Files  2 passed (2)
Tests      72 passed (72)
Exit        0
```

The complete final-head run also passes `6` files / `390` tests and `130,000` adversarial parser cases. The packaged runtime build, production and test typechecks, focused lint, `deadcode:dependencies`, `deadcode:unused-files`, and `deadcode:exports` all pass with zero unused entries. The nodes-discovery budget is deliberate and source-verified: `runNodesBridge -> listCodeModeNodes -> callNodesTool -> runtime.callValue("openclaw:core:nodes", ...)` performs a real gateway tool invocation even for `nodes.list()` and `nodes.get()`.