### PR TITLE
fix: let users clear worktree after Git rediscovery fails

### DIFF
--- a/ui/src/e2e/new-session-page.workspace-validation.e2e.test.ts
+++ b/ui/src/e2e/new-session-page.workspace-validation.e2e.test.ts
@@ -142,7 +142,7 @@ suite.define(() => {
     }
   });
 
-  it("blocks a custom worktree when Git rediscovery is unavailable", async () => {
+  it("allows clearing a custom worktree when Git rediscovery is unavailable", async () => {
     const context = await suite.browser.newContext({ locale: "en-US", serviceWorkers: "block" });
     const page = await context.newPage();
     const gateway = await installMockGateway(page, {
@@ -155,6 +155,7 @@ suite.define(() => {
           defaultBranch: "main",
           repositoryStatus: "git",
         },
+        "sessions.create": { key: "agent:main:custom-worktree-cleared" },
       },
     });
 
@@ -192,11 +193,23 @@ suite.define(() => {
       await expect.poll(() => start.isDisabled()).toBe(true);
       await trigger.click();
       const worktree = place.getByRole("button", { name: "Worktree" });
-      expect(await worktree.isDisabled()).toBe(true);
+      expect(await worktree.isEnabled()).toBe(true);
       expect(await worktree.getAttribute("title")).toBe(
         "Couldn't verify Git for this folder. Choose it again to retry.",
       );
-      expect(await gateway.getRequests("sessions.create")).toHaveLength(0);
+      await worktree.click();
+      await expect.poll(() => trigger.getAttribute("data-worktree")).toBe("false");
+      await expect.poll(() => start.isEnabled()).toBe(true);
+      await page.keyboard.press("Escape");
+
+      await start.click();
+      const create = await gateway.waitForRequest("sessions.create");
+      expect(create.params).toMatchObject({
+        agentId: "main",
+        cwd: TARGET_REPO,
+        message: "do not run directly",
+      });
+      expect(create.params).not.toHaveProperty("worktree");
     } finally {
       await context.close();
     }

--- a/ui/src/e2e/new-session-page.workspace-validation.e2e.test.ts
+++ b/ui/src/e2e/new-session-page.workspace-validation.e2e.test.ts
@@ -258,10 +258,13 @@ suite.define(() => {
       await expect.poll(() => start.isDisabled()).toBe(true);
       await trigger.click();
       const cloud = place.getByRole("button", { name: "Cloud · aws" });
+      const worktree = place.getByRole("button", { name: "Worktree" });
       expect(await cloud.isDisabled()).toBe(true);
       expect(await cloud.getAttribute("title")).toBe(
         "Couldn't verify Git for this folder. Choose it again to retry.",
       );
+      expect(await worktree.getAttribute("aria-pressed")).toBe("true");
+      expect(await worktree.isDisabled()).toBe(true);
       expect(await gateway.getRequests("sessions.create")).toHaveLength(0);
     } finally {
       await context.close();

--- a/ui/src/pages/new-session/place-picker.ts
+++ b/ui/src/pages/new-session/place-picker.ts
@@ -399,7 +399,11 @@ export function renderPlaceSelect(params: {
                         value: "worktree",
                         label: t("newSession.worktree"),
                         checked: params.worktree,
-                        disabled: Boolean(params.cloudProfileId) || !params.worktreeAvailable,
+                        // Failed discovery blocks enabling Worktree, but an existing selection
+                        // must stay actionable so the user can clear the submit-blocking state.
+                        disabled:
+                          Boolean(params.cloudProfileId) ||
+                          (!params.worktreeAvailable && !params.worktree),
                         title: params.cloudProfileId
                           ? t("newSession.cloudRequiresWorktree")
                           : params.worktreeAvailable


### PR DESCRIPTION
Closes #114361

## What Problem This Solves

Fixes an issue where users who explicitly enabled Worktree for a custom Git folder could become unable to start a session when a later Git rediscovery failed. The checked Worktree control became disabled while submit remained blocked, leaving folder replacement or page reload as the only escape.

## Why This Change Was Made

An unavailable repository lookup still prevents enabling Worktree, but an already-checked non-cloud choice remains actionable so the user can clear the invalid selection. Cloud-owned Worktree selections remain checked and disabled.

AI-assisted with Codex. The final two-commit change was independently reviewed with the repository autoreview workflow; no agent transcript is attached.

## User Impact

Users can clear Worktree after a transient or inconclusive Git lookup and continue with an ordinary session in the selected folder. Existing safeguards for unavailable repositories, cloud workers, remembered preferences, and Worktree submission remain unchanged.

## Evidence

- Mocked-Gateway Chromium E2E reproduces the checked unavailable state, confirms submit is blocked, clears Worktree, and verifies `sessions.create` uses the custom `cwd` without Worktree fields.
- Blacksmith Testbox `tbx_01kykgkj8pmx1x7hk7s4ea3ha5` / Actions run `30329582153`: the full new-session E2E file passed `47/47`; `check:changed` passed the selected `coreTests` and `ui` lanes.
- Blacksmith Testbox `tbx_01kykhaceaescnzkhj191jjp7y` / Actions run `30330173291`: `pnpm ui:build`, precompressed asset checks, and Control UI performance checks passed.
- Autoreview reported no accepted or actionable findings.
- Rebased onto current `origin/main`; `git range-diff` marked both commits unchanged.
- No screenshot is included because this changes transient enabled/disabled behavior rather than visual styling; the real-browser assertions cover the visible control and submit states.
