### PR TITLE
fix(tlon): wire autoDiscoverChannels through the settings-store round-trip

### DIFF
--- a/extensions/tlon/src/settings.test.ts
+++ b/extensions/tlon/src/settings.test.ts
@@ -1,0 +1,71 @@
+// Tlon tests cover settings store behavior.
+import { describe, expect, it } from "vitest";
+import { createSettingsManager } from "./settings.js";
+import type { UrbitSSEClient } from "./urbit/sse-client.js";
+
+type SubscriptionHandlers = {
+  event?: (data: unknown) => Promise<void> | void;
+};
+
+function createMockSettingsApi(scryResult: unknown): {
+  api: UrbitSSEClient;
+  emitSettingsEvent: (event: unknown) => Promise<void>;
+} {
+  const handlers: SubscriptionHandlers = {};
+  const api = {
+    async scry() {
+      return scryResult;
+    },
+    async subscribe(params: {
+      app: string;
+      path: string;
+      event?: (data: unknown) => Promise<void> | void;
+    }) {
+      handlers.event = params.event;
+      return 1;
+    },
+  } as unknown as UrbitSSEClient;
+  return {
+    api,
+    emitSettingsEvent: async (event: unknown) => {
+      await handlers.event?.(event);
+    },
+  };
+}
+
+describe("tlon settings store", () => {
+  it("loads autoDiscoverChannels from the settings-store scry response", async () => {
+    const { api } = createMockSettingsApi({
+      all: { moltbot: { tlon: { autoDiscoverChannels: true } } },
+    });
+
+    const manager = createSettingsManager(api);
+    await manager.load();
+
+    // Regression: parseSettingsResponse previously read the dead `autoDiscover`
+    // key, so the live `autoDiscoverChannels` override never reached the monitor.
+    expect(manager.current.autoDiscoverChannels).toBe(true);
+  });
+
+  it("applies live autoDiscoverChannels updates delivered over the subscription", async () => {
+    const { api, emitSettingsEvent } = createMockSettingsApi({
+      all: { moltbot: { tlon: {} } },
+    });
+
+    const manager = createSettingsManager(api);
+    await manager.load();
+    expect(manager.current.autoDiscoverChannels).toBeUndefined();
+
+    await manager.startSubscription();
+    await emitSettingsEvent({
+      "put-entry": {
+        desk: "moltbot",
+        "bucket-key": "tlon",
+        "entry-key": "autoDiscoverChannels",
+        value: false,
+      },
+    });
+
+    expect(manager.current.autoDiscoverChannels).toBe(false);
+  });
+});

--- a/extensions/tlon/src/settings.ts
+++ b/extensions/tlon/src/settings.ts
@@ -34,7 +34,6 @@ export type PendingApproval = {
 export type TlonSettingsStore = {
   groupChannels?: string[];
   dmAllowlist?: string[];
-  autoDiscover?: boolean;
   showModelSig?: boolean;
   autoAcceptDmInvites?: boolean;
   autoDiscoverChannels?: boolean;
@@ -118,7 +117,10 @@ function parseSettingsResponse(raw: unknown): TlonSettingsStore {
     dmAllowlist: Array.isArray(settings.dmAllowlist)
       ? settings.dmAllowlist.filter((x): x is string => typeof x === "string")
       : undefined,
-    autoDiscover: typeof settings.autoDiscover === "boolean" ? settings.autoDiscover : undefined,
+    autoDiscoverChannels:
+      typeof settings.autoDiscoverChannels === "boolean"
+        ? settings.autoDiscoverChannels
+        : undefined,
     showModelSig: typeof settings.showModelSig === "boolean" ? settings.showModelSig : undefined,
     autoAcceptDmInvites:
       typeof settings.autoAcceptDmInvites === "boolean" ? settings.autoAcceptDmInvites : undefined,
@@ -249,8 +251,8 @@ function applySettingsUpdate(
         ? value.filter((x): x is string => typeof x === "string")
         : undefined;
       break;
-    case "autoDiscover":
-      next.autoDiscover = typeof value === "boolean" ? value : undefined;
+    case "autoDiscoverChannels":
+      next.autoDiscoverChannels = typeof value === "boolean" ? value : undefined;
       break;
     case "showModelSig":
       next.showModelSig = typeof value === "boolean" ? value : undefined;


### PR DESCRIPTION
## What Problem This Solves

The Tlon settings-store integration hot-reloads plugin config from any Landscape client without a gateway restart. But `parseSettingsResponse` and `applySettingsUpdate` in `extensions/tlon/src/settings.ts` read/wrote a field named `autoDiscover`, while every other code path — the config schema, the runtime override consumer (`monitor/settings-helpers.ts`), and the settings migration — uses `autoDiscoverChannels`. The parsed value landed in a dead field that nothing reads, so the `autoDiscoverChannels` override the runtime looks for was always `undefined`.

## Why This Change Was Made

- `monitor/settings-helpers.ts:94-99` overrides the file config with `currentSettings.autoDiscoverChannels` and logs `"Using autoDiscoverChannels from settings store"`, but `parseSettingsResponse` never populated that field — so the override never applied and the log never fired.
- `buildTlonSettingsMigrations` writes `autoDiscoverChannels` to the store (`settings-helpers.ts:45-47`), yet the parser ignored it, so `shouldMigrateTlonSetting` stayed true and the migration re-poked the store on every restart.

The fix aligns the field name in `parseSettingsResponse`/`applySettingsUpdate` to `autoDiscoverChannels` and removes the now-unused `autoDiscover` member from `TlonSettingsStore` (nothing writes it to the store; nothing reads it).

## User Impact

Toggling auto-discover-channels via a Landscape client poke now takes effect at runtime without a gateway restart, instead of being silently dropped. The normal path is otherwise unchanged, and the migration stops re-firing once the value round-trips.

## Evidence

- `node scripts/run-vitest.mjs extensions/tlon/src/settings.test.ts` — 2 passed (2) (new regression test: load + subscription round-trip)
- `node_modules/.bin/oxlint -c .oxlintrc.json extensions/tlon/src/settings.ts extensions/tlon/src/settings.test.ts` — clean
- `node_modules/.bin/oxfmt --check extensions/tlon/src/settings.ts extensions/tlon/src/settings.test.ts` — all matched files use the correct format
- `git diff --check` — clean
- Core change: 6 insertions / 4 deletions in `settings.ts` (+ new 71-line regression test)

Real behavior proof at exact PR head `d3a40eae8b2e8c9662e323b5346cca938ed93a9c`, exercising the public `createSettingsManager` production path (`node_modules/.bin/tsx scripts/proof/tlon-settings-autodiscoverchannels.mjs`):

Before (current `main`):

```text
settings-store entry : {"autoDiscoverChannels":true}
manager.current.autoDiscoverChannels = undefined (runtime override consumer reads this field)
---
after live poke autoDiscoverChannels=false:
manager.current.autoDiscoverChannels = undefined
```

After (this PR):

```text
settings-store entry : {"autoDiscoverChannels":true}
manager.current.autoDiscoverChannels = true (runtime override consumer reads this field)
---
after live poke autoDiscoverChannels=false:
manager.current.autoDiscoverChannels = false
```

The regression test confirms the same at the unit level — on `main` it fails (`Tests  2 failed (2)`, `expected undefined to be false`); on this PR head it passes (`Tests  2 passed (2)`).

AI-assisted: Codex
