### PR TITLE
fix: PowerShell completion loses short flags and nested commands

### DIFF
--- a/src/cli/completion-cli.test.ts
+++ b/src/cli/completion-cli.test.ts
@@ -1,5 +1,6 @@
 // Completion CLI tests cover shell completion command generation and install output.
 import { spawnSync } from "node:child_process";
+import { existsSync } from "node:fs";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
@@ -64,6 +65,55 @@ printf '%s\\n' "\${COMPREPLY[@]}"
   expect(result.stderr).toBe("");
   expect(result.status).toBe(0);
   return result.stdout.split("\n").filter(Boolean);
+}
+
+function findPowerShell(): string | null {
+  const executable = process.platform === "win32" ? "pwsh.exe" : "pwsh";
+  const candidates = [
+    process.env.OPENCLAW_TEST_PWSH,
+    ...(process.env.PATH ?? "")
+      .split(path.delimiter)
+      .filter(Boolean)
+      .map((directory) => path.join(directory, executable)),
+  ];
+  return (
+    candidates.find((candidate): candidate is string =>
+      Boolean(candidate && existsSync(candidate)),
+    ) ?? null
+  );
+}
+
+const powerShellPath = findPowerShell();
+const itWithPowerShell = powerShellPath ? it : it.skip;
+
+function runGeneratedPowerShellCompletion(program: Command, commandLine: string): string[] {
+  if (!powerShellPath) {
+    throw new Error("PowerShell is unavailable");
+  }
+
+  const script = getCompletionScript("powershell", program);
+  const quotedCommandLine = commandLine.replaceAll("'", "''");
+  const result = spawnSync(
+    powerShellPath,
+    [
+      "-NoLogo",
+      "-NoProfile",
+      "-NonInteractive",
+      "-Command",
+      `${script}
+$line = '${quotedCommandLine}'
+[System.Management.Automation.CommandCompletion]::CompleteInput($line, $line.Length, $null).CompletionMatches | ForEach-Object { $_.CompletionText }
+`,
+    ],
+    { encoding: "utf8" },
+  );
+
+  if (result.error) {
+    throw result.error;
+  }
+  expect(result.stderr).toBe("");
+  expect(result.status).toBe(0);
+  return result.stdout.split(/\r?\n/).filter(Boolean);
 }
 
 describe("completion-cli", () => {
@@ -150,7 +200,7 @@ describe("completion-cli", () => {
     expect(script).toContain("if ($commandPath -eq 'gateway') {");
     expect(script).toContain("if ($commandPath -eq 'gateway status') {");
     expect(script).not.toContain("if ($commandPath -eq 'openclaw gateway') {");
-    expect(script).toContain("$completions = @('status','restart','--force','--token')");
+    expect(script).toContain("$completions = @('status','restart','--force','-t','--token')");
     expect(script).not.toContain("'-t,'");
   });
 
@@ -163,6 +213,55 @@ describe("completion-cli", () => {
     expect(getCompletionScript("powershell", commandsOnly)).toContain("$completions = @('status')");
     expect(getCompletionScript("powershell", optionsOnly)).toContain("$completions = @('--json')");
     expect(getCompletionScript("powershell", empty)).toContain("$completions = @()");
+  });
+
+  it("preserves documented short and long completion flags in PowerShell", () => {
+    const script = getCompletionScript("powershell", createDocumentedCompletionProgram());
+
+    expect(script).toContain("'-v','--verbose'");
+    expect(script).toContain("'--force','-t','--token'");
+    expect(script).toContain("'-s','--shell','-i','--install','--write-state','-y','--yes'");
+  });
+
+  itWithPowerShell("completes root short and long flags in real PowerShell", () => {
+    const completions = runGeneratedPowerShellCompletion(
+      createDocumentedCompletionProgram(),
+      "openclaw -",
+    );
+
+    expect(completions).toEqual(expect.arrayContaining(["-v", "--verbose", "--status-json"]));
+  });
+
+  itWithPowerShell("completes documented nested short and long flags in real PowerShell", () => {
+    const completions = runGeneratedPowerShellCompletion(
+      createDocumentedCompletionProgram(),
+      "openclaw completion -",
+    );
+
+    expect(completions).toEqual(
+      expect.arrayContaining(["-s", "--shell", "-i", "--install", "-y", "--yes", "--write-state"]),
+    );
+  });
+
+  itWithPowerShell.each([
+    ["a long flag", "openclaw gateway --token secret st"],
+    ["a short flag", "openclaw gateway -t secret st"],
+    ["an inline long value", "openclaw gateway --token=secret st"],
+    ["an inline short value", "openclaw gateway -t=secret st"],
+    ["a preceding boolean flag", "openclaw gateway --force --token secret st"],
+  ])("keeps real PowerShell nested completions after %s", (_name, commandLine) => {
+    expect(runGeneratedPowerShellCompletion(createCompletionProgram(), commandLine)).toEqual([
+      "status",
+    ]);
+  });
+
+  itWithPowerShell.each([
+    ["-v", ["-v"]],
+    ["--v", ["--verbose"]],
+  ])("filters real PowerShell root flag aliases for %s", (prefix, expected) => {
+    expect(
+      runGeneratedPowerShellCompletion(createDocumentedCompletionProgram(), `openclaw ${prefix}`),
+    ).toEqual(expected);
   });
 
   it("generates fish completions for root and nested command contexts", () => {
@@ -408,5 +507,26 @@ printf '%s\\n' "\${COMPREPLY[@]}"
     expect(script).toContain("$completions = @('infer','capability','cron','--profile')");
     expect(script).toContain("if ($commandPath -eq 'capability') {");
     expect(script).toContain("if ($commandPath -eq 'cron create') {");
+  });
+
+  it("tracks PowerShell command paths past inherited value-taking flags", () => {
+    const script = getCompletionScript("powershell", createAliasedCompletionProgram());
+
+    expect(script).toContain("$valueOptions = @('--profile')");
+    expect(script).toContain("switch ($candidatePath)");
+    expect(script).toContain("'cron create'");
+    expect(script).toContain("'--profile','--at'");
+  });
+
+  itWithPowerShell.each([
+    ["a global option", "openclaw --profile work cron create --a"],
+    ["an inline global option", "openclaw --profile=work cron create --a"],
+    ["repeated global options", "openclaw --profile first --profile second cron create --a"],
+    ["an inherited option after the parent", "openclaw cron --profile work create --a"],
+    ["the canonical nested command", "openclaw --profile work cron add --a"],
+  ])("completes real PowerShell nested aliases after %s", (_name, commandLine) => {
+    expect(runGeneratedPowerShellCompletion(createAliasedCompletionProgram(), commandLine)).toEqual(
+      ["--at"],
+    );
   });
 });

--- a/src/cli/completion-cli.ts
+++ b/src/cli/completion-cli.ts
@@ -516,11 +516,23 @@ function generatePowerShellCompletion(program: Command): string {
   const segments: string[] = [];
   const formatPowerShellArray = (entries: string[]) =>
     entries.length > 0 ? `@(${entries.map((entry) => `'${entry}'`).join(",")})` : "@()";
+  const rootValueOptions = completionOptionFlags(program.options, true);
+  const contexts = collectBashCompletionContexts(program, rootValueOptions);
+  const commandPathCases = contexts
+    .flatMap((context) =>
+      context.pathVariants.map(
+        (pathSegments) => `            '${pathSegments.join(" ")}' {
+                $commandPath = $candidatePath
+                $valueOptions = ${formatPowerShellArray(context.valueOptions)}
+            }`,
+      ),
+    )
+    .join("\n");
 
   const visit = (cmd: Command, pathVariants: string[][]) => {
     // Command completion for this level
     const subCommands = cmd.commands.flatMap((c) => commandNameVariants(c));
-    const options = cmd.options.map((option) => preferredCompletionFlag(option));
+    const options = cmd.options.flatMap((option) => completionFlags(option));
     const allCompletions = formatPowerShellArray([...subCommands, ...options]);
 
     if ([...subCommands, ...options].length > 0) {
@@ -554,22 +566,31 @@ Register-ArgumentCompleter -Native -CommandName ${rootCmd} -ScriptBlock {
     
     $commandElements = $commandAst.CommandElements
     $commandPath = ""
-    
-    # Reconstruct command path (simple approximation)
-    # Skip the executable name
+    $valueOptions = ${formatPowerShellArray(rootValueOptions)}
+
+    # Skip option values so global and nested flags cannot hide the command path.
     for ($i = 1; $i -lt $commandElements.Count; $i++) {
         $element = $commandElements[$i].Extent.Text
-        if ($element -like "-*") { break }
-        if ($i -eq $commandElements.Count - 1 -and $wordToComplete -ne "") { break } # Don't include current word being typed
-        $commandPath += "$element "
+        if ($i -eq $commandElements.Count - 1 -and $wordToComplete -ne "") { break }
+        if ($element -like "-*") {
+            $flag = ($element -split '=', 2)[0]
+            if ($element -notlike '*=*' -and $valueOptions -contains $flag) {
+                $i++
+            }
+            continue
+        }
+
+        $candidatePath = if ($commandPath -eq '') { $element } else { "$commandPath $element" }
+        switch ($candidatePath) {
+${commandPathCases}
+        }
     }
-    $commandPath = $commandPath.Trim()
     
     # Root command
     if ($commandPath -eq "") {
          $completions = ${formatPowerShellArray([
            ...program.commands.flatMap((command) => commandNameVariants(command)),
-           ...program.options.map((option) => preferredCompletionFlag(option)),
+           ...program.options.flatMap((option) => completionFlags(option)),
          ])}
          $completions | Where-Object { $_ -like "$wordToComplete*" } | ForEach-Object {
             [System.Management.Automation.CompletionResult]::new($_, $_, 'ParameterName', $_)


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where PowerShell users could not complete documented short options or nested CLI commands after global profile options, option values, or command aliases. For example, `openclaw completion -s` did not suggest `-s`, and `openclaw --profile work cron create --a` could not suggest `--at`.

## Why This Change Was Made

Reuse the existing Bash command-context and inherited-value-option model to reconstruct PowerShell command paths. Emit both Commander option spellings, preserve canonical and aliased command paths, and skip separate or inline option values without changing the Bash, Fish, Zsh, configuration, installation, or update contracts.

## User Impact

PowerShell completion now offers documented short and long options and keeps completing nested commands after global profiles, repeated options, inline values, boolean flags, and command aliases. Source checkouts and packaged installations behave consistently.

## Evidence

- Red first: 5 failing regressions on current `main`, including actual PowerShell failures for root flags, nested flags, and profiled command aliases.
- Green: 297 CLI, routing, argument, shell-completion, configuration, update-status, and real-process JSON regressions.
- Real PowerShell: 14 focused cases covering short/long aliases, prefix filtering, separate and inline values, repeated and inherited global options, boolean flags, canonical commands, and nested aliases.
- Remote source and production-package proof: 16 real CLI/shell cases, including generation for Bash, Zsh, Fish, and PowerShell and installed-script execution of both generated PowerShell completers.
- `pnpm check:changed -- src/cli/completion-cli.ts src/cli/completion-cli.test.ts` passes formatting, core and test type-checks, lint, plugin boundaries, API baselines, security, state-schema and import-cycle guards.
- Full production `pnpm build` passes.
- Fresh independent `autoreview --mode uncommitted`: clean, no accepted or actionable findings.
