### PR TITLE
feat(openshell): support control-plane workspace selection

### DIFF
--- a/docs/gateway/openshell.md
+++ b/docs/gateway/openshell.md
@@ -22,6 +22,7 @@ workspace sync mode.
 - `openshell` CLI on `PATH` (or a custom path via
   `plugins.entries.openshell.config.command`)
 - OpenSSH client available on the Gateway host
+- OpenShell `v0.0.88` or newer when configuring an OpenShell workspace
 - An OpenShell account with sandbox access
 - OpenClaw Gateway running on the host
 
@@ -68,6 +69,15 @@ openclaw sandbox explain
 ## Workspace modes
 
 This is the most important OpenShell decision.
+
+OpenShell also has a control-plane resource named a **workspace**. That is
+separate from the filesystem workspace described below: it scopes sandboxes,
+providers, policies, inference routes, and membership. Set
+`plugins.entries.openshell.config.workspace` to use an existing non-default
+OpenShell workspace. The plugin does not create OpenShell workspaces or manage
+their membership. When this setting is unset, the plugin preserves the
+OpenShell CLI's ambient `OPENSHELL_WORKSPACE` selection, or the CLI's `default`
+fallback when no ambient selection exists.
 
 ### mirror (default)
 
@@ -124,6 +134,7 @@ All OpenShell config lives under `plugins.entries.openshell.config`:
 | `from`                    | `string`                 | `"openclaw"`  | Sandbox source for first-time create                                                   |
 | `gateway`                 | `string`                 | unset         | OpenShell gateway name (top-level `--gateway`)                                         |
 | `gatewayEndpoint`         | `string`                 | unset         | OpenShell gateway endpoint (top-level `--gateway-endpoint`)                            |
+| `workspace`               | `string`                 | unset         | Existing OpenShell control-plane workspace used for every CLI operation                |
 | `policy`                  | `string`                 | unset         | OpenShell policy ID for sandbox creation                                               |
 | `providers`               | `string[]`               | `[]`          | Provider names attached at sandbox creation (deduped, one `--provider` flag per entry) |
 | `gpu`                     | `boolean`                | `false`       | Request GPU resources (`--gpu`)                                                        |
@@ -135,6 +146,19 @@ All OpenShell config lives under `plugins.entries.openshell.config`:
 `remoteWorkspaceDir` and `remoteAgentWorkspaceDir` must be absolute paths and
 stay under the managed roots `/sandbox` or `/agent`; other absolute paths are
 rejected.
+
+`workspace` must match OpenShell's current workspace-name contract: 1-19
+lowercase alphanumeric characters or single hyphens, with no leading,
+trailing, or consecutive hyphen. Create it first with
+`openshell workspace create --name <name>`. OpenShell rejects sandbox
+operations when the selected workspace does not exist or is being deleted.
+Set it to `"default"` to override an ambient non-default Workspace explicitly.
+
+The setting applies to every OpenShell sandbox managed by this plugin instance;
+it cannot select different OpenShell workspaces per OpenClaw agent or session.
+Changing it does not migrate existing sandboxes. Delete OpenClaw's OpenShell
+sandboxes while the old workspace is still configured, then change the setting
+and restart the Gateway.
 
 Sandbox-level settings (`mode`, `scope`, `workspaceAccess`) live under
 `agents.defaults.sandbox` like any backend. See
@@ -228,6 +252,7 @@ Sandbox-level settings (`mode`, `scope`, `workspaceAccess`) live under
           mode: "remote",
           gateway: "lab",
           gatewayEndpoint: "https://lab.example",
+          workspace: "research",
           policy: "strict",
         },
       },
@@ -303,6 +328,8 @@ filesystem must permit the writes. `sandbox.docker.network`,
 ## Current limitations
 
 - Sandbox browser is not supported on the OpenShell backend.
+- One plugin instance uses one OpenShell workspace; per-agent or per-session
+  OpenShell workspace selection is not supported.
 - `sandbox.docker.binds` does not apply to OpenShell; sandbox creation fails
   if binds are configured.
 - Docker-specific runtime knobs under `sandbox.docker.*` (other than `env`)
@@ -313,8 +340,9 @@ filesystem must permit the writes. `sandbox.docker.network`,
 
 ## How it works
 
-1. OpenClaw runs `sandbox get` for the sandbox name (with any configured
-   `--gateway`/`--gateway-endpoint`); if that fails it creates one with
+1. OpenClaw runs `sandbox get` for the sandbox name (with the selected
+   OpenShell workspace and any configured `--gateway`/`--gateway-endpoint`); if
+   that fails it creates one in the same OpenShell workspace with
    `sandbox create`, passing `--name`, `--from`, `--policy` when set, `--gpu`
    when enabled, `--auto-providers`/`--no-auto-providers`, and one
    `--provider` flag per configured provider.

--- a/extensions/openshell/README.md
+++ b/extensions/openshell/README.md
@@ -4,6 +4,14 @@ Official NVIDIA OpenShell sandbox backend for OpenClaw.
 
 This plugin lets OpenClaw use OpenShell-managed sandboxes with mirrored local workspaces and SSH command execution.
 
+Configuring an OpenShell workspace requires OpenShell `v0.0.88` or newer. The
+plugin supports OpenShell control-plane workspaces through
+`plugins.entries.openshell.config.workspace`; this is separate from OpenClaw's
+local/remote filesystem workspace mode. The setting applies to the whole plugin
+instance, not individual agents or sessions. When unset, the plugin preserves
+the OpenShell CLI's ambient `OPENSHELL_WORKSPACE` selection, or its `default`
+fallback when no ambient selection exists.
+
 ## Install
 
 ```bash

--- a/extensions/openshell/openclaw.plugin.json
+++ b/extensions/openshell/openclaw.plugin.json
@@ -25,6 +25,12 @@
         "type": "string",
         "minLength": 1
       },
+      "workspace": {
+        "type": "string",
+        "minLength": 1,
+        "maxLength": 19,
+        "pattern": "^[a-z0-9]+(?:-[a-z0-9]+)*$"
+      },
       "from": {
         "type": "string",
         "minLength": 1
@@ -77,6 +83,10 @@
     "gatewayEndpoint": {
       "label": "Gateway Endpoint",
       "help": "Optional OpenShell gateway endpoint passed as --gateway-endpoint."
+    },
+    "workspace": {
+      "label": "OpenShell Workspace",
+      "help": "Existing OpenShell control-plane workspace for sandboxes, providers, policies, and inference routes. When unset, preserves the OpenShell CLI's ambient workspace selection."
     },
     "from": {
       "label": "Sandbox Source",

--- a/extensions/openshell/src/cli.ts
+++ b/extensions/openshell/src/cli.ts
@@ -26,6 +26,9 @@ function buildOpenShellBaseArgv(config: ResolvedOpenShellPluginConfig): string[]
   if (config.gatewayEndpoint) {
     argv.push("--gateway-endpoint", config.gatewayEndpoint);
   }
+  if (config.workspace) {
+    argv.push("--workspace", config.workspace);
+  }
   return argv;
 }
 

--- a/extensions/openshell/src/config.test.ts
+++ b/extensions/openshell/src/config.test.ts
@@ -10,6 +10,7 @@ describe("openshell plugin config", () => {
       command: "openshell",
       gateway: undefined,
       gatewayEndpoint: undefined,
+      workspace: undefined,
       from: "openclaw",
       policy: undefined,
       providers: [],
@@ -52,6 +53,7 @@ describe("openshell plugin config", () => {
       command: "openshell",
       gateway: undefined,
       gatewayEndpoint: undefined,
+      workspace: undefined,
       from: "openclaw",
       policy: undefined,
       providers: [],
@@ -70,6 +72,17 @@ describe("openshell plugin config", () => {
       }),
     ).toThrow("mode must be one of mirror, remote");
   });
+
+  it("accepts an OpenShell workspace name", () => {
+    expect(resolveOpenShellPluginConfig({ workspace: "team-1" }).workspace).toBe("team-1");
+  });
+
+  it.each(["Team", "-team", "team-", "team--one", "abcdefghijklmnopqrst"])(
+    "rejects invalid OpenShell workspace name %s",
+    (workspace) => {
+      expect(() => resolveOpenShellPluginConfig({ workspace })).toThrow(/workspace must/);
+    },
+  );
 
   it("rejects timeouts beyond Node's safe timer range", () => {
     expect(() =>

--- a/extensions/openshell/src/config.ts
+++ b/extensions/openshell/src/config.ts
@@ -13,6 +13,7 @@ type OpenShellPluginConfig = {
   command?: string;
   gateway?: string;
   gatewayEndpoint?: string;
+  workspace?: string;
   from?: string;
   policy?: string;
   providers?: string[];
@@ -28,6 +29,7 @@ export type ResolvedOpenShellPluginConfig = {
   command: string;
   gateway?: string;
   gatewayEndpoint?: string;
+  workspace?: string;
   from: string;
   policy?: string;
   providers: string[];
@@ -66,11 +68,22 @@ function normalizeProviders(value: string[] | undefined): string[] {
 const nonEmptyTrimmedString = (message: string) =>
   z.string({ error: message }).trim().min(1, { error: message });
 
+const openShellWorkspaceName = z
+  .string({ error: "workspace must be a valid OpenShell workspace name" })
+  .trim()
+  .min(1, { error: "workspace must be a valid OpenShell workspace name" })
+  .max(19, { error: "workspace must be at most 19 characters" })
+  .regex(/^[a-z0-9]+(?:-[a-z0-9]+)*$/, {
+    error:
+      "workspace must contain lowercase alphanumeric characters or single hyphens and must not start or end with a hyphen",
+  });
+
 const OpenShellPluginConfigSchema = z.strictObject({
   mode: z.enum(["mirror", "remote"], { error: "mode must be one of mirror, remote" }).optional(),
   command: nonEmptyTrimmedString("command must be a non-empty string").optional(),
   gateway: nonEmptyTrimmedString("gateway must be a non-empty string").optional(),
   gatewayEndpoint: nonEmptyTrimmedString("gatewayEndpoint must be a non-empty string").optional(),
+  workspace: openShellWorkspaceName.optional(),
   from: nonEmptyTrimmedString("from must be a non-empty string").optional(),
   policy: nonEmptyTrimmedString("policy must be a non-empty string").optional(),
   providers: z
@@ -155,6 +168,7 @@ export function resolveOpenShellPluginConfig(value: unknown): ResolvedOpenShellP
       command: DEFAULT_COMMAND,
       gateway: undefined,
       gatewayEndpoint: undefined,
+      workspace: undefined,
       from: DEFAULT_SOURCE,
       policy: undefined,
       providers: [],
@@ -178,6 +192,7 @@ export function resolveOpenShellPluginConfig(value: unknown): ResolvedOpenShellP
     command: cfg.command ?? DEFAULT_COMMAND,
     gateway: cfg.gateway,
     gatewayEndpoint: cfg.gatewayEndpoint,
+    workspace: cfg.workspace,
     from: cfg.from ?? DEFAULT_SOURCE,
     policy: cfg.policy,
     providers: normalizeProviders(cfg.providers),

--- a/extensions/openshell/src/openshell-core.test.ts
+++ b/extensions/openshell/src/openshell-core.test.ts
@@ -158,6 +158,7 @@ describe("openshell cli helpers", () => {
           command: openshellCommand,
           gateway: "alice",
           gatewayEndpoint: "http://openshell.openshell-alice.svc.cluster.local:8080",
+          workspace: "research",
         }),
       },
       args: ["sandbox", "get", "demo"],
@@ -172,19 +173,43 @@ describe("openshell cli helpers", () => {
       "alice",
       "--gateway-endpoint",
       "http://openshell.openshell-alice.svc.cluster.local:8080",
+      "--workspace",
+      "research",
       "sandbox",
       "get",
       "demo",
     ]);
   });
 
+  it("preserves the ambient workspace when workspace is not configured", async () => {
+    process.env.OPENSHELL_WORKSPACE = "ambient";
+    const openshellCommand = await makeExecutable({
+      name: "openshell",
+      script: ["#!/bin/sh", `printf '%s\\n' "$OPENSHELL_WORKSPACE|$*" >> "__LOG__"`, "exit 0"].join(
+        "\n",
+      ),
+    });
+
+    await runOpenShellCli({
+      context: {
+        sandboxName: "demo",
+        config: resolveOpenShellPluginConfig({ command: openshellCommand }),
+      },
+      args: ["sandbox", "get", "demo"],
+    });
+
+    await expect(fs.readFile(process.env.OPEN_SHELL_CLI_TEST_LOG as string, "utf8")).resolves.toBe(
+      "ambient|sandbox get demo\n",
+    );
+  });
+
   it.runIf(process.platform !== "win32")(
-    "adds direct gateway endpoints to generated ssh proxy configs",
+    "preserves workspace selection when adding a direct gateway endpoint",
     async () => {
       const configText = [
-        "Host openshell-demo",
+        "Host openshell-demo.research",
         "    User sandbox",
-        "    ProxyCommand /usr/local/bin/openshell ssh-proxy --gateway-name alice --name demo",
+        "    ProxyCommand /usr/local/bin/openshell ssh-proxy --gateway-name alice --name demo --workspace research",
         "",
       ].join("\n");
 
@@ -192,9 +217,10 @@ describe("openshell cli helpers", () => {
         readOpenShellSshConfig({
           configText,
           gatewayEndpoint: "http://openshell.openshell-alice.svc.cluster.local:8080",
+          workspace: "research",
         }),
       ).resolves.toContain(
-        "ProxyCommand /usr/local/bin/openshell ssh-proxy --gateway-name alice --name demo --server 'http://openshell.openshell-alice.svc.cluster.local:8080'",
+        "ProxyCommand /usr/local/bin/openshell ssh-proxy --gateway-name alice --name demo --workspace research --server 'http://openshell.openshell-alice.svc.cluster.local:8080'",
       );
     },
   );
@@ -746,6 +772,7 @@ async function makeExecutable(params: { name: string; script: string }): Promise
 async function readOpenShellSshConfig(params: {
   configText: string;
   gatewayEndpoint: string;
+  workspace?: string;
 }): Promise<string> {
   const command = await makeExecutable({
     name: "openshell-ssh-config",
@@ -762,6 +789,7 @@ async function readOpenShellSshConfig(params: {
       config: resolveOpenShellPluginConfig({
         command,
         gatewayEndpoint: params.gatewayEndpoint,
+        workspace: params.workspace,
       }),
     },
   });


### PR DESCRIPTION
## What Problem This Solves

OpenShell now supports control-plane Workspaces, but the OpenClaw sandbox plugin could only use the OpenShell CLI's ambient or default Workspace. Users could not explicitly place OpenClaw-managed sandboxes, providers, policies, and inference routes in an existing non-default OpenShell Workspace.

## Why This Change Was Made

This adds a validated `plugins.entries.openshell.config.workspace` setting. When configured, the plugin passes `--workspace <name>` to every OpenShell CLI operation. OpenShell v0.0.88 and newer serialize that selection into the generated SSH host alias and `ssh-proxy --workspace <name>` route, so lifecycle calls, command execution, and transfers resolve the same Workspace.

When the setting is omitted, OpenClaw passes no new flag or environment override. Existing installations therefore retain their ambient `OPENSHELL_WORKSPACE` behavior, including OpenShell's `default` fallback when no ambient selection exists.

The change keeps OpenShell's control-plane Workspace separate from OpenClaw's existing mirror/remote filesystem workspace modes. It does not create Workspaces, manage membership, migrate existing sandboxes, or add per-agent/per-session selection.

AI-assisted implementation; I reviewed the resulting code and behavior.

## User Impact

Users can explicitly run OpenClaw sandboxes in an existing non-default OpenShell Workspace. Existing configurations are unchanged. Configuring `workspace`, including explicitly selecting `default`, requires OpenShell v0.0.88 or newer.

## Evidence

- Rebased onto current `main`.
- Homebrew OpenShell `0.0.92` with a local Podman-backed gateway at `https://127.0.0.1:17670` using mTLS.
- Confirmed `default` and `openclaw-test` were active, then configured the plugin with `workspace: "openclaw-test"`.
- Built the exact PR source into a local Podman OpenClaw runtime and ran a live Codex OAuth turn with `openai/gpt-5.5`. Structured output reported `agentHarnessId: "codex"`, `authMode: "auth-profile"`, and no model fallback.
- The live turn executed in the OpenShell sandbox and read back its marker:

```text
sandbox-oc-dd4c3a6956c1e9d6
/sandbox
WORKSPACE_ROUTE_OK
```

- OpenShell listed the sandbox only in the configured Workspace:

```json
{
  "name": "oc-dd4c3a6956c1e9d6",
  "phase": "Ready",
  "workspace": "openclaw-test"
}
```

The same `sandbox list` command returned `[]` for `--workspace default`.

- The generated SSH route retained the configured Workspace:

```text
Host openshell-oc-dd4c3a6956c1e9d6.openclaw-test
ProxyCommand /opt/homebrew/bin/openshell ssh-proxy --gateway-name openshell --name oc-dd4c3a6956c1e9d6 --workspace openclaw-test
```

- A subsequent OpenShell download through `--workspace openclaw-test` returned `/sandbox/workspace-route-proof.txt` with exact contents `WORKSPACE_ROUTE_OK`.

UI screenshot:
<img width="1290" height="390" alt="Screenshot 2026-07-28 at 2 26 34 PM" src="https://github.com/user-attachments/assets/0acd04a0-f52b-464c-bd26-98c7dec09db9" />

- Focused Testbox proof:

```text
Test Files  2 passed (2)
Tests       57 passed (57)
```

- `node scripts/check-changed.mjs` passed on Blacksmith Testbox ([run](https://github.com/openclaw/openclaw/actions/runs/30362679672)), including formatting, config/env ratchets, plugin boundaries, extension production/test typechecks, extension lint, database-first guards, and runtime import-cycle checks.
- `git diff --check` passed.
- Autoreview: clean, no accepted/actionable findings; overall correctness `patch is correct` with confidence `0.94`.
