### PR TITLE
fix(mac): stop keychain prompt storms from gateway profile reads

### DIFF
--- a/apps/macos/Sources/OpenClaw/GatewayConnectionSupport.swift
+++ b/apps/macos/Sources/OpenClaw/GatewayConnectionSupport.swift
@@ -11,7 +11,15 @@ struct GatewayRouteChangedAfterDispatchError: LocalizedError, Sendable {
 }
 
 enum GatewayActivationBindingKeyStore {
+    // Dev builds carry a different code signature; creating the release item
+    // would poison its Keychain ACL and make the shipped app demand the login
+    // keychain password on every read. DEBUG is a config heuristic, not a
+    // signing check — same accepted tradeoff as MacGatewayProfileStore.service.
+    #if DEBUG
+    private static let service = "ai.openclaw.onboarding-route-binding.debug"
+    #else
     private static let service = "ai.openclaw.onboarding-route-binding"
+    #endif
     private static let account = "credential-binding-v1"
     private static let byteCount = 32
 

--- a/apps/macos/Sources/OpenClaw/MacGatewayProfiles.swift
+++ b/apps/macos/Sources/OpenClaw/MacGatewayProfiles.swift
@@ -55,9 +55,25 @@ actor MacGatewayProfileStore {
         var password: String?
     }
 
+    // Dev builds carry a different code signature; creating the release item
+    // would poison its Keychain ACL and make the shipped app demand the login
+    // keychain password on every read. DEBUG is a config heuristic, not a
+    // signing check: it covers swift build/Xcode dev runs, the observed
+    // poisoning path. Release-config ad-hoc builds stay out of scope; running
+    // those against saved Keychain items is already unsupported.
+    #if DEBUG
+    private static let service = "ai.openclaw.gateway-profiles.debug"
+    #else
     private static let service = "ai.openclaw.gateway-profiles"
+    #endif
     private static let registryAccount = "registry-v1"
     private static let currentLegacyPrimaryMigrationVersion = 1
+
+    /// Registry reads are prompt-bearing: when this binary is missing from the
+    /// item's ACL, every SecItemCopyMatching raises a login-keychain dialog, and
+    /// catalog refreshes fire per control-channel state change. Cache the one
+    /// registry for the process lifetime; saves keep it coherent.
+    private var cachedRegistry: Registry?
 
     static func migratingLegacyPrimaryConnection(
         root: [String: Any],
@@ -152,8 +168,14 @@ actor MacGatewayProfileStore {
     }
 
     private func loadRegistry() throws -> Registry {
-        guard let data = try Self.load(account: Self.registryAccount) else { return Registry() }
-        return try Self.decodeRegistry(data)
+        if let cachedRegistry { return cachedRegistry }
+        let registry: Registry = if let data = try Self.load(account: Self.registryAccount) {
+            try Self.decodeRegistry(data)
+        } else {
+            Registry()
+        }
+        self.cachedRegistry = registry
+        return registry
     }
 
     private func loadRegistryMigratingLegacyPrimary() throws -> Registry {
@@ -173,6 +195,7 @@ actor MacGatewayProfileStore {
 
     private func saveRegistry(_ registry: Registry) throws {
         try Self.save(JSONEncoder().encode(registry), account: Self.registryAccount)
+        self.cachedRegistry = registry
     }
 
     private static func decodeRegistry(_ data: Data) throws -> Registry {


### PR DESCRIPTION
## What Problem This Solves

The Mac app can trigger a rapid-fire storm of login-keychain password dialogs for `ai.openclaw.gateway-profiles`. Two compounding causes:

1. `MacGatewayProfileStore` re-read its Keychain registry item on every gateway catalog refresh, and `DashboardManager` refreshes that catalog on every `controlChannelStateDidChange`, `openclawConfigDidChange`, and profile-store notification. A flapping/reconnecting gateway connection means one `SecItemCopyMatching` per state transition.
2. When the item's ACL does not include the running binary's code signature — which happens once a differently-signed dev build (`swift build` / Xcode Debug) has created the item — every one of those reads raises a password prompt, and a plain "Allow" only grants a single access. The result: enter the password, and the dialog is back within seconds.

## Why This Change Was Made

- **Cache:** `MacGatewayProfileStore` now caches the decoded registry for the process lifetime (single-slot, actor-owned; saves update the cache after a successful Keychain commit). Reads collapse to one per process regardless of control-channel churn. Profile metadata is process-stable per the repo's runtime-cache policy; cross-process live sync was never provided (the change notification is process-local).
- **Hardening:** DEBUG builds now use `.debug`-suffixed Keychain service names for both Mac app stores (`ai.openclaw.gateway-profiles`, `ai.openclaw.onboarding-route-binding`), so dev runs can no longer create/own the release items and poison their ACLs. DEBUG is a build-config heuristic, not a signing check — that tradeoff is documented at both service declarations; Release-config ad-hoc runs against saved Keychain items are already unsupported.

## User Impact

No more repeating login-keychain password dialogs from OpenClaw when the gateway connection flaps. At most one Keychain access per app launch; dev builds stop corrupting the shipped app's Keychain item ACLs going forward. Dev builds start with an isolated (empty) profile registry, which re-imports the primary remote connection from config via the existing legacy migration (live-proven below).

## Evidence

### Live before/after behavior proof (real macOS run, real login keychain)

Setup: debug binary from this branch, isolated `OPENCLAW_STATE_DIR` with `gateway.mode=remote` pointing at `ws://127.0.0.1:59999`, where a local TCP listener accepts and immediately drops every connection — a permanently flapping gateway. A `DYLD_INSERT_LIBRARIES` interpose shim logs every `SecItemCopyMatching` call the app makes (each such read raises a login-keychain password dialog when the item's ACL excludes the binary — the reported storm).

**After (this PR, head `97c51754aaa`), 100-second window:**

```
--- connection attempts during window:
     161
--- all keychain reads:
   1 [keychain-spy] SecItemCopyMatching service=ai.openclaw.onboarding-route-binding.debug
   1 [keychain-spy] SecItemCopyMatching service=ai.openclaw.gateway-profiles.debug
```

161 gateway reconnect cycles → exactly **one** profile-registry Keychain read for the whole session. Reproduced twice (second run with no listener: same single read).

**Before (parent commit `HEAD~1` built with only the service literals renamed to an isolated `.proof` namespace so the run cannot touch the operator's real items; read-count logic identical), same 100-second scenario:**

```
--- connection attempts during window:
      42
--- gateway-profiles keychain reads (pre-fix):
5
```

Plus a separate short pre-fix run showing 2 registry reads within 25 s of startup. Pre-fix, registry reads keep accruing with connection churn — each one a password dialog on an ACL-poisoned item; post-fix the count is capped at one per process.

### DEBUG-transition and migration recovery proof

- The after-fix binary queries only `.debug` services (spy log above); the release items are never touched by dev runs.
- Fresh `.debug` namespace + existing remote config → the legacy primary migration imported the connection on first read. Item created in the real login keychain: `security find-generic-password -s ai.openclaw.gateway-profiles.debug` → `acct="registry-v1"`, `svce="ai.openclaw.gateway-profiles.debug"`.
- Registry payload captured in-process (redacted): `{"profiles":[{"credentials":{"token":"<redacted-token>"},"profile":{"url":"ws://127.0.0.1:59999/","id":"manual-6d3c...","name":"127.0.0.1"}}],"legacyPrimaryMigrationVersion":1,"version":1}` — the documented recovery path works: a dev setup that loses its unsuffixed items re-imports the primary connection from `openclaw.json`.
- Deliberately not reproduced: literal password dialogs (that would require ACL-poisoning the operator's real keychain and answering modal prompts). The dialog count equals the prompt-bearing read count measured above.

### Owner decision

The DEBUG Keychain-namespace transition (dev builds start from an isolated registry and recover the primary connection via the existing config migration) is intentional and accepted by the macOS owner (@steipete), who requested this fix and the hardening.

### Static proof

- `swift build --target OpenClaw`: Build complete.
- `swiftformat --lint` + `swiftlint --strict` clean on both touched files.
- Full Swift test lane: hosted PR CI (green on head `97c51754aaa`); the local SPM harness cannot dlopen the Sparkle-linked test bundle from a stale `.build/out`.
- Codex autoreview (gpt-5.6-sol, xhigh): clean — "no accepted/actionable findings"; the DEBUG-vs-signing boundary was reviewed and consciously accepted, documented in code comments.
