### PR TITLE
fix(ui): remove stale Saved status from Notifications

### DIFF
--- a/ui/src/e2e/config-form-guidance.e2e.test.ts
+++ b/ui/src/e2e/config-form-guidance.e2e.test.ts
@@ -27,6 +27,42 @@ const uiProofArtifactDir = path.join(
 let browser: Browser;
 let server: ControlUiE2eServer;
 
+function notificationStatusConfigMocks() {
+  const config = { ui: { prefs: { theme: "claw" } } };
+  return {
+    "config.get": {
+      appliedConfigHash: "notification-status-e2e",
+      config,
+      configRevisionHash: "notification-status-e2e",
+      hash: "notification-status-e2e",
+      issues: [],
+      raw: JSON.stringify(config),
+      valid: true,
+    },
+    "config.schema": {
+      generatedAt: "2026-07-28T00:00:00.000Z",
+      schema: {
+        type: "object",
+        properties: {
+          ui: {
+            type: "object",
+            title: "UI",
+            properties: {
+              prefs: {
+                type: "object",
+                title: "Prefs",
+                properties: { theme: { type: "string", title: "Theme" } },
+              },
+            },
+          },
+        },
+      },
+      uiHints: { "ui.prefs.theme": { advanced: false } },
+      version: "e2e",
+    },
+  };
+}
+
 describeControlUiE2e("Control UI config form guidance mocked Gateway E2E", () => {
   beforeAll(async () => {
     if (!chromiumAvailable) {
@@ -230,6 +266,59 @@ describeControlUiE2e("Control UI config form guidance mocked Gateway E2E", () =>
           animations: "disabled",
           fullPage: true,
           path: path.join(uiProofArtifactDir, "04-advanced-collapsed-final.png"),
+        });
+      }
+    } finally {
+      await context.close();
+    }
+  });
+
+  it("keeps a settled autosave quiet on Notifications", async () => {
+    const context = await browser.newContext({
+      colorScheme: "dark",
+      locale: "en-US",
+      serviceWorkers: "block",
+      viewport: { height: 1000, width: 1440 },
+    });
+    const page = await context.newPage();
+    const gateway = await installMockGateway(page, {
+      methodResponses: notificationStatusConfigMocks(),
+    });
+
+    try {
+      const response = await page.goto(`${server.baseUrl}settings/appearance`);
+      expect(response?.status()).toBe(200);
+      await page.getByRole("radio", { name: "UI", exact: true }).click();
+
+      const themeInput = page
+        .locator(".settings-row")
+        .filter({ hasText: "Theme" })
+        .locator("input.settings-input");
+      await expect.poll(() => themeInput.count()).toBe(1);
+      await themeInput.fill("knot");
+      await gateway.waitForRequest("config.set");
+      await page.getByRole("button", { name: "Restart & apply", exact: true }).click();
+      await gateway.waitForRequest("config.apply");
+
+      await page.getByRole("link", { name: "Notifications", exact: true }).click();
+      await page.getByRole("heading", { name: "Push notifications", exact: true }).waitFor();
+
+      const section = page.locator("#settings-communications-notifications");
+      await expect.poll(() => page.locator(".config-toolbar").count()).toBe(0);
+      await expect.poll(() => page.getByText("Saved", { exact: true }).count()).toBe(0);
+      await expect
+        .poll(() => section.locator(".settings-section__header .settings-status").count())
+        .toBe(1);
+      await expect
+        .poll(() => section.locator(".settings-section__header").textContent())
+        .toContain("Ready");
+
+      if (captureUiProofEnabled) {
+        await mkdir(uiProofArtifactDir, { recursive: true });
+        await page.screenshot({
+          animations: "disabled",
+          fullPage: true,
+          path: path.join(uiProofArtifactDir, "05-notifications-ready-aligned.png"),
         });
       }
     } finally {

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -1420,7 +1420,6 @@ export const en: TranslationMap = {
     open: "Open",
     applying: "Applying…",
     autoSaveSaving: "Saving…",
-    autoSaveSaved: "Saved",
     autoSaveFailed: "Save failed",
     autoSaveConflict: "Settings changed elsewhere",
     retry: "Retry",

--- a/ui/src/pages/config/memory-dreaming-page.ts
+++ b/ui/src/pages/config/memory-dreaming-page.ts
@@ -144,8 +144,7 @@ class MemoryDreamingSettings extends OpenClawLightDomElement {
 
   /**
    * These knobs autosave like the schema editor, so the tab owns the same
-   * status line and restart banner the embedded editor renders on the other
-   * tabs; without them a saved edit looks like nothing happened.
+   * active-write/failure status and restart banner as the other tabs.
    */
   private renderWriteStatus() {
     const runtimeConfig = this.context.runtimeConfig;

--- a/ui/src/pages/config/quick.test.ts
+++ b/ui/src/pages/config/quick.test.ts
@@ -299,6 +299,10 @@ describe("renderQuickSettings", () => {
     render(renderQuickSettings(createProps()), container);
     expect(container.querySelector(".config-toolbar__status")).toBeNull();
 
+    render(renderQuickSettings(createProps({ configAutoSaveStatus: "saved" })), container);
+    expect(container.querySelector(".config-toolbar__status")).toBeNull();
+    expect(container.textContent).not.toContain("Saved");
+
     render(renderQuickSettings(createProps({ configAutoSaveStatus: "saving" })), container);
     expect(container.querySelector(".config-toolbar__status")?.textContent?.trim()).toBe("Saving…");
 

--- a/ui/src/pages/config/view-status.ts
+++ b/ui/src/pages/config/view-status.ts
@@ -44,9 +44,9 @@ export function renderConfigApplyBanner(props: ConfigApplyBannerProps) {
 }
 
 /**
- * Inline autosave status shared by the schema editor and Quick Settings:
- * Saving…/Saved plus the failure recoveries (Retry re-submits, conflict only
- * offers a discarding reload so the draft cannot clobber another writer).
+ * Inline autosave status shared by the schema editor and Quick Settings.
+ * Successful autosave returns to quiet; only an active write or actionable
+ * failure remains visible.
  */
 export function renderConfigAutoSaveStatus(props: {
   status: ConfigAutoSaveStatus;
@@ -57,7 +57,7 @@ export function renderConfigAutoSaveStatus(props: {
     case "saving":
       return renderSettingsStatus({ kind: "accent", label: t("configView.autoSaveSaving") });
     case "saved":
-      return renderSettingsStatus({ kind: "ok", label: t("configView.autoSaveSaved") });
+      return nothing;
     case "error":
       return html`
         ${renderSettingsStatus({ kind: "danger", label: t("configView.autoSaveFailed") })}

--- a/ui/src/pages/config/view.browser.test.ts
+++ b/ui/src/pages/config/view.browser.test.ts
@@ -408,7 +408,7 @@ describe("config view", () => {
     expect(container.querySelector(".config-toolbar__status .settings-status")).toBeNull();
   });
 
-  it("renders the inline autosave status and retries failed saves", () => {
+  it("renders active and failed autosave status while keeping success quiet", () => {
     const onSave = vi.fn();
     const { container } = renderConfigView({ autoSaveStatus: "saving", onSave });
     const status = queryRequired(container, ".config-toolbar__status", HTMLElement);
@@ -418,11 +418,8 @@ describe("config view", () => {
     ).toBe(true);
 
     const saved = renderConfigView({ autoSaveStatus: "saved" });
-    expect([
-      ...queryRequired(saved.container, ".config-toolbar__status .settings-status", HTMLElement)
-        .classList,
-    ]).toContain("settings-status--ok");
-    expect(saved.container.textContent).toContain("Saved");
+    expect(saved.container.querySelector(".config-toolbar__status .settings-status")).toBeNull();
+    expect(saved.container.textContent).not.toContain("Saved");
 
     const failed = renderConfigView({ autoSaveStatus: "error", onSave });
     const failedStatus = queryRequired(failed.container, ".config-toolbar__status", HTMLElement);
@@ -712,15 +709,15 @@ describe("config view", () => {
     const onWebPushSubscribe = vi.fn();
     const { container } = renderConfigView({
       activeSection: "__notifications__",
-      includeSections: ["channels", "messages", "__notifications__"],
+      autoSaveStatus: "saved",
+      includeSections: ["__notifications__"],
       includeVirtualSections: true,
+      showModeToggle: false,
+      showRootTab: false,
       onWebPushSubscribe,
       schema: {
         type: "object",
-        properties: {
-          channels: { type: "object", properties: {} },
-          messages: { type: "object", properties: {} },
-        },
+        properties: {},
       },
       webPush: {
         supported: true,
@@ -731,6 +728,8 @@ describe("config view", () => {
     });
 
     const card = queryRequired(container, "#settings-communications-notifications", HTMLElement);
+    expect(container.querySelector(".config-toolbar")).toBeNull();
+    expect(container.textContent).not.toContain("Saved");
     expect(
       card.querySelector(".settings-section__actions .settings-status")?.textContent?.trim(),
     ).toBe("Ready");


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Settings → Notifications could show a persistent `Saved` autosave status above the section-owned `Ready` status. The two unrelated indicators occupied separate rows, looked misaligned, and made a completed background save feel like durable page state.

## Why This Change Was Made

A successful autosave now returns to quiet. Active `Saving…`, save failures with Retry, cross-writer conflicts with Reload, and the separate restart-required banner remain visible because they are active or actionable. The Notifications `Ready` state stays in the Push notifications section header, where it already belongs.

This is AI-assisted work. I reviewed the shared autosave renderer, all of its Settings consumers, the Notifications status owner, and the final diff.

## User Impact

Notifications no longer shows a stale `Saved` row. `Ready` aligns with the Push notifications heading, while users still get feedback during writes and whenever intervention is required.

## Evidence

- Reproduced the Saved/Ready split in the existing Chrome session against OpenClaw 2026.7.2.
- Focused config/Quick Settings tests: 58 passed.
- Mocked real-Chromium Control UI E2E: 3 passed, including a same-session autosave → apply → Notifications flow that verifies no Saved status or config toolbar and confirms Ready remains in the section header.
- Blacksmith Testbox `tbx_01kykk2mamhedx8y31tyfehrcj`: focused Chromium E2E passed; `check:changed` passed UI/core-test typechecks, scoped lint, formatting, guards, and i18n verification; production `ui:build` and performance budgets passed. [Run 30331693391](https://github.com/openclaw/openclaw/actions/runs/30331693391)
- Source-blind behavior contract passed for settled autosave feedback and Notifications status ownership.
- Codex autoreview (`gpt-5.6-sol`, xhigh): clean, no accepted/actionable findings.

[Before/after visual evidence](https://github.com/openclaw/openclaw/pull/114957#issuecomment-5100396916) shows the Saved/Ready split and the corrected section-owned Ready layout.
