### PR TITLE
fix: full release validation supports GitHub-hosted Ubuntu

### DIFF
--- a/test/scripts/pr-review-artifact-validation.test.ts
+++ b/test/scripts/pr-review-artifact-validation.test.ts
@@ -13,6 +13,16 @@ const describePosix = process.platform === "win32" ? describe.skip : describe;
 const REVIEWED_PR = 42;
 const REVIEWED_HEAD = "b".repeat(40);
 const REVIEWED_IDENTITY_LINE = `Review artifact for PR #${REVIEWED_PR} at ${REVIEWED_HEAD}`;
+const REVIEW_SHELL_COMMAND_SURFACE = [
+  "rg() {",
+  '  if [ "${1-}" = "-F" ]; then',
+  "    shift",
+  '    command grep -F "$@"',
+  "  else",
+  '    command grep -E "$@"',
+  "  fi",
+  "}",
+].join("\n");
 
 function validReview() {
   return {
@@ -111,6 +121,7 @@ function runValidation(
       [
         "set -euo pipefail",
         'source "$1"',
+        REVIEW_SHELL_COMMAND_SURFACE,
         'fixture_root="$2"',
         'enter_worktree() { cd "$fixture_root"; }',
         'require_artifact() { [ -s "$1" ]; }',
@@ -136,6 +147,7 @@ function runReviewShellFunction(fixtureRoot: string, invocation: string) {
       [
         "set -euo pipefail",
         'source "$1"',
+        REVIEW_SHELL_COMMAND_SURFACE,
         'fixture_root="$2"',
         'enter_worktree() { cd "$fixture_root"; }',
         'require_artifact() { [ -s "$1" ]; }',
@@ -212,6 +224,23 @@ function runMergeVerification(checks: "api-error" | "invalid-json" | "no-require
 }
 
 describePosix("scripts/pr review artifact validation", () => {
+  it("supplies direct review.sh consumers with the ripgrep command surface", () => {
+    const fixtureRoot = tempDirs.make("openclaw-pr-review-rg-surface-");
+    const target = join(fixtureRoot, "target.txt");
+    writeFileSync(target, `prefix ${REVIEWED_HEAD} suffix\n`);
+
+    const result = runReviewShellFunction(
+      fixtureRoot,
+      [
+        'test "$(type -t rg)" = "function"',
+        `printf '%s\\n' '${REVIEWED_HEAD}' | rg -q '^[0-9a-f]{40}$'`,
+        `rg -F -q '${REVIEWED_HEAD}' '${target}'`,
+      ].join("\n"),
+    );
+
+    expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(0);
+  });
+
   it("accepts a valid review artifact", () => {
     const result = runValidation(validReview());
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Full Release Validation's manually dispatched CI run failed on GitHub-hosted Ubuntu when the PR review artifact tests sourced the maintainer shell library without the required ripgrep command surface.

## Why This Change Was Made

The production `scripts/pr` wrapper still requires and preflights real ripgrep. The direct-source test harness now provides the same two ripgrep forms exercised by `review.sh`, preserving the production dependency boundary while making the focused shell tests self-contained on the release runner.

## User Impact

No product behavior changes. Release validation can complete its core tooling shard on the GitHub-hosted workflow-dispatch runner.

## Evidence

- Failing release parent: https://github.com/openclaw/openclaw/actions/runs/30331722204
- Failing CI child: https://github.com/openclaw/openclaw/actions/runs/30331858304
- Failed job: https://github.com/openclaw/openclaw/actions/runs/30331858304/job/90188675887
- Focused proof: `node scripts/run-vitest.mjs test/scripts/pr-review-artifact-validation.test.ts` — 30/30 passed.
- Post-fix GitHub-hosted release-gate proof: https://github.com/openclaw/openclaw/actions/runs/30332926946/job/90191803708 — `checks-node-core-tooling-1` passed on exact head `b84babc994881a22d965b6bd319aebf4c9efa696`, including the previously failing review-artifact validation shard.
- `git diff --check` passed.
- Autoreview passed with no accepted or actionable findings.
