### PR TITLE
fix(whatsapp): classify outbound media by filename extension when contentType is absent

### DIFF
--- a/extensions/whatsapp/src/outbound-media-contract.test.ts
+++ b/extensions/whatsapp/src/outbound-media-contract.test.ts
@@ -1,0 +1,32 @@
+// Outbound media kind inference: a buffer with a real fileName but no contentType must be
+// classified by its filename extension, not sent as a generic document (regression).
+import { describe, expect, it } from "vitest";
+import { prepareWhatsAppOutboundMedia } from "./outbound-media-contract.js";
+
+describe("prepareWhatsAppOutboundMedia kind inference from filename", () => {
+  it("classifies a buffer video by extension when contentType is absent", async () => {
+    const result = await prepareWhatsAppOutboundMedia({
+      buffer: Buffer.from("x"),
+      fileName: "clip.mp4",
+    });
+    expect(result.kind).toBe("video");
+  });
+
+  it("classifies a buffer image by extension when contentType is absent", async () => {
+    const result = await prepareWhatsAppOutboundMedia({
+      buffer: Buffer.from("x"),
+      fileName: "photo.png",
+    });
+    expect(result.kind).toBe("image");
+  });
+
+  it("uses the native voice mimetype for an audio buffer named .ogg (not octet-stream)", async () => {
+    const result = await prepareWhatsAppOutboundMedia({
+      buffer: Buffer.from("x"),
+      kind: "audio",
+      fileName: "voice.ogg",
+    });
+    expect(result.kind).toBe("audio");
+    expect(result.mimetype).toMatch(/ogg|opus/i);
+  });
+});

--- a/extensions/whatsapp/src/outbound-media-contract.ts
+++ b/extensions/whatsapp/src/outbound-media-contract.ts
@@ -1,7 +1,11 @@
 // Whatsapp plugin module implements outbound media contract behavior.
 import path from "node:path";
 import { sanitizeForPlainText } from "openclaw/plugin-sdk/channel-outbound";
-import { mediaKindFromMime, normalizeMimeType } from "openclaw/plugin-sdk/media-mime";
+import {
+  mediaKindFromMime,
+  mimeTypeFromFilePath,
+  normalizeMimeType,
+} from "openclaw/plugin-sdk/media-mime";
 import type { MediaKind } from "openclaw/plugin-sdk/media-mime";
 import {
   MEDIA_FFMPEG_MAX_AUDIO_DURATION_SECS,
@@ -127,9 +131,16 @@ function inferWhatsAppMediaKind(
     return media.kind;
   }
   const inferredKind = mediaKindFromMime(normalizeMimeType(media.contentType));
-  return !inferredKind || inferredKind === "sticker" || inferredKind === "unknown"
-    ? "document"
-    : inferredKind;
+  if (inferredKind && inferredKind !== "sticker" && inferredKind !== "unknown") {
+    return inferredKind;
+  }
+  // A buffer upload often carries a real fileName but no contentType; fall back to the filename
+  // extension so a voice.ogg / clip.mp4 / song.mp3 is not misclassified as a generic document.
+  const kindFromName = mediaKindFromMime(mimeTypeFromFilePath(media.fileName));
+  if (kindFromName && kindFromName !== "sticker" && kindFromName !== "unknown") {
+    return kindFromName;
+  }
+  return "document";
 }
 
 function normalizeWhatsAppLoadedMedia(
@@ -138,7 +149,12 @@ function normalizeWhatsAppLoadedMedia(
 ): CanonicalWhatsAppLoadedMedia {
   const kind = inferWhatsAppMediaKind(media);
   const mimetype =
-    kind === "audio" && isWhatsAppNativeVoiceAudio({ contentType: media.contentType, mediaUrl })
+    kind === "audio" &&
+    isWhatsAppNativeVoiceAudio({
+      contentType: media.contentType,
+      fileName: media.fileName,
+      mediaUrl,
+    })
       ? WHATSAPP_VOICE_MIMETYPE
       : (media.contentType ?? "application/octet-stream");
   const fileName =


### PR DESCRIPTION
## What Problem This Solves

When an agent sends outbound WhatsApp media as a **buffer** with a real filename but no explicit content-type — e.g. a `voice.ogg` voice note, a `clip.mp4` video, a `song.mp3` — it is classified as a generic **document** and delivered as a file attachment instead of a voice note / video / audio.

## Why This Change Was Made

`inferWhatsAppMediaKind` (`extensions/whatsapp/src/outbound-media-contract.ts`) derived the kind from `media.kind` and `media.contentType` only:

```ts
const inferredKind = mediaKindFromMime(normalizeMimeType(media.contentType));
return !inferredKind || inferredKind === "sticker" || inferredKind === "unknown" ? "document" : inferredKind;
```

`media.fileName` was ignored, and `mediaKindFromMime(undefined)` is `undefined` for a buffer with no content-type — so the code fell through to `"document"`. The buffer `upload-file` path sets `contentType` only from an explicit param, never from the filename, so a filename-only upload always hit this.

The sibling channel **Feishu** already resolves media kind from *both* extension and MIME; WhatsApp was the outlier. Its own `isWhatsAppNativeVoiceAudio` was even given a `fileName` param and checks `.ogg`/`.opus`, but the gating `inferWhatsAppMediaKind` ignored the filename and the normalize step didn't pass it through.

## User Impact

A `voice.ogg` / `clip.mp4` / `song.mp3` buffer now sends as a voice note / video / audio respectively, and a `.ogg`/`.opus` audio buffer gets the native voice mimetype. Media with an explicit `kind` or a valid `contentType` is unchanged.

## Evidence

Reproduce-first test added (`outbound-media-contract.test.ts`), driving the exported `prepareWhatsAppOutboundMedia`:

Before (fix reverted):
```
× classifies a buffer video by extension when contentType is absent
  AssertionError: expected 'document' to be 'video'
× classifies a buffer image by extension when contentType is absent
  AssertionError: expected 'document' to be 'image'
```
After (fix applied):
```
Test Files  1 passed (1)
     Tests  3 passed (3)
```

## The fix

Fall back to the filename extension (reusing media-core's `mimeTypeFromFilePath`) when `media.kind` is unset and the content-type is inconclusive, and pass `fileName` into the native-voice check so a `.ogg`/`.opus` buffer resolves to the voice mimetype.

**Note for maintainers:** provider-agnostic, mirrors the Feishu resolution pattern, and reuses the shared `mimeTypeFromFilePath` helper — no new extension list.
