### PR TITLE
fix(imessage): threaded replies are dropped when the Messages bridge stalls

### DIFF
--- a/extensions/imessage/src/send.test.ts
+++ b/extensions/imessage/src/send.test.ts
@@ -377,6 +377,63 @@ describe("sendMessageIMessage receipts", () => {
     expect(result.receipt.parts[0]?.replyToId).toBeUndefined();
   });
 
+  it("resends unthreaded when a threaded send times out and the reply did not land", async () => {
+    const sendParams: Array<Record<string, unknown>> = [];
+    const client = {
+      request: vi.fn(async (_method: string, params: Record<string, unknown>) => {
+        sendParams.push(params);
+        if (params.reply_to) {
+          // A stalled bridge reports a timeout, not "threading unsupported",
+          // so the #99638 matcher does not catch it.
+          throw new Error("Timed out waiting for response to 'send-message'");
+        }
+        return { guid: "p:0/imsg-timeout-fallback" };
+      }),
+      stop: vi.fn(async () => {}),
+    } as unknown as IMessageRpcClient;
+
+    const result = await sendMessageIMessage("chat_id:42", "hello", {
+      config: IMESSAGE_TEST_CFG,
+      client,
+      conversationReadOrigin: "direct-operator",
+      replyToId: "reply-1",
+      // Nothing landed while the bridge was stalled.
+      resolveSentMessageGuidImpl: async () => undefined,
+    });
+
+    expect(sendParams).toHaveLength(2);
+    expect(sendParams[0]).toHaveProperty("reply_to", "reply-1");
+    expect(sendParams[1]).not.toHaveProperty("reply_to");
+    expect(result.messageId).toBe("p:0/imsg-timeout-fallback");
+    expect(result.sentText).toBe("hello");
+    expect(result.receipt.replyToId).toBeUndefined();
+  });
+
+  it("does not resend when a threaded send times out but the reply did land", async () => {
+    const sendParams: Array<Record<string, unknown>> = [];
+    const client = {
+      request: vi.fn(async (_method: string, params: Record<string, unknown>) => {
+        sendParams.push(params);
+        throw new Error("Timed out waiting for response to 'send-message'");
+      }),
+      stop: vi.fn(async () => {}),
+    } as unknown as IMessageRpcClient;
+
+    const result = await sendMessageIMessage("chat_id:42", "hello", {
+      config: IMESSAGE_TEST_CFG,
+      client,
+      conversationReadOrigin: "direct-operator",
+      replyToId: "reply-1",
+      // The bridge stalled on the response but the message was delivered.
+      resolveSentMessageGuidImpl: async () => "p:0/imsg-already-landed",
+    });
+
+    // Exactly one attempt: retrying here would duplicate the delivered reply.
+    expect(sendParams).toHaveLength(1);
+    expect(sendParams[0]).toHaveProperty("reply_to", "reply-1");
+    expect(result.messageId).toBe("p:0/imsg-already-landed");
+  });
+
   it("resends a media reply unthreaded when threaded replies are unsupported (#99638)", async () => {
     const sendParams: Array<Record<string, unknown>> = [];
     const client = {

--- a/extensions/imessage/src/send.ts
+++ b/extensions/imessage/src/send.ts
@@ -461,7 +461,15 @@ function resolveIMessageCliFailure(result: Record<string, unknown>): string | nu
 
 function isIMessageRpcSendTimeout(error: unknown): boolean {
   const message = error instanceof Error ? error.message : String(error);
-  return /imsg rpc timeout \(send\)/i.test(message);
+  return (
+    // Our own client-side deadline on the send request.
+    /imsg rpc timeout \(send\)/i.test(message) ||
+    // imsg reports a stalled IMCore bridge with its own wording
+    // ("Timed out waiting for response to 'send-message'", see imsg
+    // Sources/IMsgCore/IMsgBridgeProtocol.swift). Without this, a bridge
+    // stall is an unclassified error and skips every send recovery path.
+    /timed out waiting for response to '(?:send[-_]?message|send)'/i.test(message)
+  );
 }
 
 async function runIMessageCliJson(
@@ -885,6 +893,39 @@ export async function sendMessageIMessage(
           timeoutMs,
         });
         effectiveReplyToId = undefined;
+      } else if (resolvedReplyToId && !filePath && isIMessageRpcSendTimeout(error)) {
+        // A stalled bridge makes a threaded send time out rather than report
+        // that threading is unsupported, so the #99638 fallback above never
+        // fires. imsg rethrows for reply_to sends instead of falling through
+        // to its plain-send path, so the reply is dropped after the full send
+        // timeout. Confirm the reply did not land, then resend it unthreaded.
+        if (
+          !canCheckSentMessageAfterRpcTimeout({
+            dbPath: chatDbLookupPath,
+            resolveSentMessageGuidImpl: opts.resolveSentMessageGuidImpl,
+          })
+        ) {
+          // Without a way to check, a retry could duplicate a reply that did
+          // land while the bridge was stalled. Surface the timeout instead.
+          throw error;
+        }
+        const landedGuid = await resolveFallbackSentMessageGuid({
+          dbPath: chatDbLookupPath,
+          target,
+          text: message,
+          sentAfterMs: sendStartedAtMs,
+          resolveSentMessageGuidImpl: opts.resolveSentMessageGuidImpl,
+        });
+        if (landedGuid) {
+          result = { guid: landedGuid, status: "sent" };
+        } else {
+          const plainParams = { ...params };
+          delete plainParams.reply_to;
+          result = await client.request<Record<string, unknown>>("send", plainParams, {
+            timeoutMs,
+          });
+          effectiveReplyToId = undefined;
+        }
       } else if (filePath || !isIMessageRpcSendTimeout(error)) {
         throw error;
       } else if (


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where a user replying in an iMessage thread would get no reply from the agent, and the agent's session would sit blocked for ~150 seconds, when the Messages bridge stalls on the send.

The agent's message is not delivered at all. The failed attempt surfaces in Messages as a `Message: <id> failed` bubble, and the session is unresponsive for the full send timeout before the tool reports `Timed out waiting for response to 'send-message'`.

Observed twice on a production gateway, 8 days apart (2026-07-19 and 2026-07-27), both times on a threaded reply to a valid, recent inbound message.

## Why This Change Was Made

Two gaps combine so that a stalled bridge drops the reply entirely:

1. `isIMessageRpcSendTimeout` only matched our own client-side label, `imsg rpc timeout (send)`. When the IMCore bridge itself stalls, imsg raises `Timed out waiting for response to 'send-message'` ([IMsgBridgeProtocol.swift](https://github.com/steipete/imsg/blob/main/Sources/IMsgCore/IMsgBridgeProtocol.swift)). That wording matched neither the timeout check nor `isThreadedReplyUnsupportedError`, so the error fell straight through to `throw` and skipped **every** send recovery path — including the existing approval-prompt GUID recovery, which is unrelated to threading.

2. The `#99638` plain-send fallback only fires for `isThreadedReplyUnsupportedError`. A stalled bridge reports a timeout instead, so a threaded send got no fallback. On the imsg side, `RPCServer+Handlers.swift` rethrows when `selectedMessageGuid != nil` rather than falling through to its plain-send path, so a threaded reply fails hard where the identical send without `reply_to` would have been delivered.

This classifies the bridge's timeout wording as a send timeout, and adds a guarded recovery for threaded text sends: check whether the reply actually landed before resending it unthreaded.

Deliberate boundaries:

- **No blind retry.** If the reply did land while the bridge was stalled, the recovered GUID is kept and nothing is resent.
- **No retry when delivery cannot be verified.** Without a chat-DB check or `resolveSentMessageGuidImpl`, the timeout is surfaced rather than risking a duplicate.
- **Text sends only.** File sends keep the existing throw path, matching the surrounding code.
- Threading is dropped only on the fallback attempt; the receipt reflects the unthreaded send that was actually delivered, consistent with `#99638`.

## User Impact

A threaded reply now gets delivered (unthreaded) instead of being silently dropped when the Messages bridge stalls. The agent no longer has to notice the failure and resend by hand, and operators stop seeing `Message: <id> failed` bubbles for replies that could have been delivered.

Because the bridge's timeout wording is now classified correctly, the pre-existing approval-prompt GUID recovery also engages on bridge stalls, where it previously did not.

## Evidence

**Pre-fix incident (root cause, production 2026-07-27)**

Reply tool call and its result, from the agent transcript:

```json
{ "action": "reply", "message": "…", "messageId": "1755" }
→ { "status": "error", "tool": "message",
    "error": "Timed out waiting for response to 'send-message'" }
```

- `04:17:45Z` send starts → `04:20:16Z` tool errors. Gateway logged `stalled session … reason=blocked_tool_call activeTool=message` at `04:20:03Z`, `lastProgressAge=138s`.
- The reply reference was valid: short id `1755` → `AF95BE16-…`, `isFromMe: false`, recorded `04:16:29Z`, 76s before the send. `DEFAULT_IMESSAGE_SEND_TIMEOUT_MS` is `150_000`, matching the observed block exactly.
- The agent then self-recovered with a plain `imsg send --chat-id 3 --text …` (no `--reply-to`), which succeeded — confirming the transport was healthy and only the threaded path was stuck.

**Deterministic proof of the changed path** (`extensions/imessage/src/send.test.ts`)

Both new tests fail on `main` — the bridge timeout wording is unclassified, so the error propagates and no retry occurs:

- `resends unthreaded when a threaded send times out and the reply did not land` — asserts 2 attempts, the second without `reply_to`, and that the text is delivered.
- `does not resend when a threaded send times out but the reply did land` — asserts exactly 1 attempt and that the recovered GUID is returned, proving no duplicate.

**Test results**

- `extensions/imessage/src/send.test.ts` — 54 passed
- full `extensions/imessage/src` suite — 47 files, 806 tests, all passing
- `oxfmt --check` clean on both touched files; `git diff --check` clean
- Codex autoreview (`gpt-5.6-sol`, high): clean, no accepted findings, `patch is correct (0.91)`; TruffleHog clean

**Proof gap, stated plainly:** the exact-path runtime failure is pre-fix incident evidence from a production gateway; I have not reproduced a live bridge stall against the patched build, since forcing an IMCore stall on a production Messages bridge is not a safe fault injection. The changed branch is covered deterministically by the two tests above.

AI-assisted.
