### PR TITLE
fix(mattermost): prevent hook-controlled replies from leaking previews

### DIFF
--- a/extensions/mattermost/src/mattermost/monitor-turn.ts
+++ b/extensions/mattermost/src/mattermost/monitor-turn.ts
@@ -6,6 +6,7 @@ import {
   buildChannelProgressDraftLineForEntry,
   createChannelProgressDraftCompositor,
 } from "openclaw/plugin-sdk/channel-outbound";
+import { getGlobalHookRunner } from "openclaw/plugin-sdk/plugin-runtime";
 import type { finalizeInboundContext } from "openclaw/plugin-sdk/reply-runtime";
 import { resolveInboundLastRouteSessionKey } from "openclaw/plugin-sdk/routing";
 import type { MattermostPost } from "./client.js";
@@ -96,10 +97,18 @@ export async function dispatchMattermostInboundTurn(
       accountId: account.accountId,
       typing: baseReplyPipeline.typing,
     });
-  const draftPreviewEnabled = account.streamingMode !== "off";
-  const draftToolProgressEnabled = shouldUpdateMattermostDraftToolProgress(account);
+  // Provider drafts are visible before outbound modifiers run. Keep them off whenever a hook
+  // can rewrite or cancel so the original payload cannot escape the durable delivery gate.
+  const hookRunner = getGlobalHookRunner();
+  const allowProviderPreview = !(
+    (hookRunner?.hasHooks("reply_payload_sending") ?? false) ||
+    (hookRunner?.hasHooks("message_sending") ?? false)
+  );
+  const draftPreviewEnabled = allowProviderPreview && account.streamingMode !== "off";
+  const draftToolProgressEnabled =
+    draftPreviewEnabled && shouldUpdateMattermostDraftToolProgress(account);
   const suppressDefaultToolProgressMessages =
-    shouldSuppressMattermostDefaultToolProgressMessages(account);
+    draftPreviewEnabled && shouldSuppressMattermostDefaultToolProgressMessages(account);
   const draftStream = draftPreviewEnabled
     ? createMattermostDraftStream({
         client,

--- a/extensions/mattermost/src/mattermost/monitor.inbound-system-event.test.ts
+++ b/extensions/mattermost/src/mattermost/monitor.inbound-system-event.test.ts
@@ -88,6 +88,7 @@ const mockState = vi.hoisted(() => ({
   dispatchInboundMessage: vi.fn(),
   enqueueSystemEvent: vi.fn(),
   fetchMattermostMe: vi.fn(),
+  getGlobalHookRunner: vi.fn(),
   registerMattermostMonitorSlashCommands: vi.fn(),
   registerPluginHttpRoute: vi.fn(),
   recordMattermostThreadParticipation: vi.fn(),
@@ -97,6 +98,11 @@ const mockState = vi.hoisted(() => ({
   runtimeCore: undefined as unknown,
   sendMessageMattermost: vi.fn(),
   updateMattermostPost: vi.fn(),
+}));
+
+vi.mock("openclaw/plugin-sdk/plugin-runtime", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("openclaw/plugin-sdk/plugin-runtime")>()),
+  getGlobalHookRunner: mockState.getGlobalHookRunner,
 }));
 
 vi.mock("openclaw/plugin-sdk/reply-runtime", async (importOriginal) => {
@@ -487,6 +493,7 @@ describe("mattermost inbound user posts", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockState.abortController = undefined;
+    mockState.getGlobalHookRunner.mockReturnValue(null);
     mockState.runtimeCore = createRuntimeCore(testConfig);
     mockState.createMattermostClient.mockReturnValue({});
     mockState.createMattermostDraftStream.mockReturnValue({
@@ -1326,6 +1333,82 @@ describe("mattermost inbound user posts", () => {
     const replyOptions = mockState.dispatchInboundMessage.mock.calls.at(0)?.[0].replyOptions;
     expect(replyOptions?.disableBlockStreaming).toBe(false);
     expect(replyOptions?.preserveProgressCallbackStartOrder).toBeUndefined();
+  });
+
+  it("preserves provider previews for observer-only hooks", async () => {
+    mockState.getGlobalHookRunner.mockReturnValue({
+      hasHooks: vi.fn((hookName: string) => hookName === "message_sent"),
+    });
+    const socket = new FakeWebSocket();
+    const abortController = new AbortController();
+    mockState.abortController = abortController;
+
+    const monitor = monitorMattermostProvider({
+      config: testConfig,
+      runtime: testRuntime(),
+      abortSignal: abortController.signal,
+      webSocketFactory: () => socket,
+    });
+
+    await vi.waitFor(() => {
+      expect(socket.openListenerCount).toBeGreaterThan(0);
+    });
+    socket.emitOpen();
+
+    await emitMattermostChannelPost(socket, {
+      id: "post-observer-hook-preview",
+      message: "show a preview",
+    });
+    socket.emitClose(1000);
+    await monitor;
+
+    expect(mockState.createMattermostDraftStream).toHaveBeenCalledTimes(1);
+    const replyOptions = mockState.dispatchInboundMessage.mock.calls.at(0)?.[0].replyOptions;
+    expect(replyOptions?.disableBlockStreaming).toBe(true);
+    expect(replyOptions?.preserveProgressCallbackStartOrder).toBe(true);
+  });
+
+  it.each([
+    { label: "reply_payload_sending", hooks: ["reply_payload_sending"] },
+    { label: "message_sending", hooks: ["message_sending"] },
+    {
+      label: "both modifying hooks",
+      hooks: ["reply_payload_sending", "message_sending"],
+    },
+  ])("suppresses provider previews when $label is registered", async ({ hooks }) => {
+    const registeredHooks = new Set(hooks);
+    mockState.getGlobalHookRunner.mockReturnValue({
+      hasHooks: vi.fn((hookName: string) => registeredHooks.has(hookName)),
+    });
+    const socket = new FakeWebSocket();
+    const abortController = new AbortController();
+    mockState.abortController = abortController;
+
+    const monitor = monitorMattermostProvider({
+      config: testConfig,
+      runtime: testRuntime(),
+      abortSignal: abortController.signal,
+      webSocketFactory: () => socket,
+    });
+
+    await vi.waitFor(() => {
+      expect(socket.openListenerCount).toBeGreaterThan(0);
+    });
+    socket.emitOpen();
+
+    await emitMattermostChannelPost(socket, {
+      id: `post-${hooks.join("-")}-preview`,
+      message: "do not expose this preview",
+    });
+    socket.emitClose(1000);
+    await monitor;
+
+    expect(mockState.createMattermostDraftStream).not.toHaveBeenCalled();
+    const replyOptions = mockState.dispatchInboundMessage.mock.calls.at(0)?.[0].replyOptions;
+    expect(replyOptions?.disableBlockStreaming).toBeUndefined();
+    expect(replyOptions?.preserveProgressCallbackStartOrder).toBeUndefined();
+    expect(replyOptions?.allowProgressCallbacksWhenSourceDeliverySuppressed).toBeUndefined();
+    expect(replyOptions?.onObservedReplyDelivery).toBeUndefined();
   });
 
   it("preserves text-tool-text boundaries while grouping interleaved tool updates", async () => {


### PR DESCRIPTION
Related: #92374

## What Problem This Solves

Fixes an issue where Mattermost users with outbound modifying hooks enabled could see
the original model text in a streaming preview before a hook rewrote it. If either hook
cancelled the reply, that original preview could remain visible even though no final
reply was sent.

## Why This Change Was Made

Mattermost now suppresses provider-visible draft, reasoning, and tool-progress previews
for turns where either `reply_payload_sending` or `message_sending` is registered. The
final payload still uses the existing outbound lifecycle, while deployments with no
modifier or observer-only hooks retain normal previews. When previews are suppressed,
normal core progress behavior remains available.

This stays at the Mattermost provider-preview owner. It adds no core policy, public SDK
surface, configuration, protocol, storage, dependency, or cleanup workaround.

## User Impact

Hook-controlled Mattermost replies no longer flash or retain content that a hook later
rewrites or cancels. Mattermost streaming behavior is unchanged when modifying hooks are
not registered.

## Evidence

Frozen current-main base: `021e1457e807f47ef3535db74638700e9b0090c6`.

Before the fix, real disposable Mattermost/Gateway/OpenAI runs showed:

- [rewrite](https://crabbox.openclaw.ai/portal/runs/run_3a2b40d8a483): original preview visible before a separate rewritten final;
- [reply-payload cancellation](https://crabbox.openclaw.ai/portal/runs/run_247271c7c3ff): original preview remained, no final;
- [message-sending cancellation](https://crabbox.openclaw.ai/portal/runs/run_349e01b35025): original preview remained, no final.

With this candidate:

- [no-hook control](https://crabbox.openclaw.ai/portal/runs/run_e89003092a33): preview remained enabled and finalized in place with the same provider post ID;
- [rewrite](https://crabbox.openclaw.ai/portal/runs/run_317a7720f961): no original preview, exact RPS → MS order, one rewritten final;
- [reply-payload cancellation](https://crabbox.openclaw.ai/portal/runs/run_c9d8fd5388e2): hook once, no preview, no final, zero non-input provider posts;
- [message-sending cancellation](https://crabbox.openclaw.ai/portal/runs/run_cd0aad8d082b): hooks once each, no preview, no final, zero non-input provider posts.

Additional validation:

- focused inbound-turn tests: 19 passed;
- complete Mattermost plugin suite: 642 passed across 46 files;
- targeted formatting and extension-aware lint: passed;
- extension production and test type lanes: passed;
- fresh Codex autoreview: no accepted/actionable findings (0.97 confidence);
- PR CI: required `openclaw/ci-gate` passed; 47 successful checks, zero failures or pending checks;
- sanitized live-artifact credential-pattern scan: clean.

The automated browser stopped at Mattermost's `/landing` chooser, so the live verdicts
use authoritative provider API readback and sanitized hook traces rather than claiming
browser UI observation.

AI-assisted: yes. I understand and validated the change.
