### PR TITLE
fix(channels): stop restart-looping channels that report no transport connectivity

### DIFF
--- a/src/channels/status/account-state.test.ts
+++ b/src/channels/status/account-state.test.ts
@@ -55,6 +55,11 @@ describe("resolveChannelAccountState", () => {
       { kind: "running", linked: true, connected: true, failure: "not linked" },
     ],
     [
+      "running keeps connectivity absent when the transport publishes none",
+      { runtime: { running: true } },
+      { kind: "running", linked: true, connected: undefined, failure: null },
+    ],
+    [
       "stopped owns linkage, connectivity, and failure",
       {},
       { kind: "stopped", linked: true, connected: undefined, failure: null },
@@ -119,6 +124,13 @@ describe("projectChannelAccountState", () => {
     [
       { kind: "running", linked: true, connected: false, failure: null },
       { configured: true, linked: true, running: true, connected: false, lastError: null },
+    ],
+    [
+      // Socketless channels never publish connectivity; a manufactured
+      // `connected: false` here reads as a transport disconnect and makes the
+      // gateway health monitor restart them every cooldown window.
+      { kind: "running", linked: true, failure: null },
+      { configured: true, linked: true, running: true, lastError: null },
     ],
     [
       { kind: "stopped", connected: true, failure: "transport failed" },

--- a/src/channels/status/account-state.ts
+++ b/src/channels/status/account-state.ts
@@ -17,7 +17,7 @@ type ChannelAccountState =
     }
   | { kind: "unconfigured"; reason: string; failure: string | null }
   | { kind: "unlinked"; reason: string; failure: string | null }
-  | { kind: "running"; linked?: true; connected: boolean; failure: string | null }
+  | { kind: "running"; linked?: true; connected?: boolean; failure: string | null }
   | { kind: "stopped"; linked?: true; connected?: boolean; failure: string | null };
 
 type ChannelAccountStateInput = {
@@ -59,7 +59,11 @@ export function resolveChannelAccountState(input: ChannelAccountStateInput): Cha
     return {
       kind: "running",
       linked: input.linked,
-      connected: input.runtime.connected ?? false,
+      // Connectivity is tri-state: absent means the transport publishes none at
+      // all (imessage, signal, sms, ...), which is not a reported disconnect.
+      // Defaulting to false makes `evaluateChannelHealth` return "disconnected"
+      // and the health monitor restart every socketless channel per cooldown.
+      connected: input.runtime.connected,
       failure,
     };
   }
@@ -115,7 +119,7 @@ function projectChannelAccountState(state: ChannelAccountState): {
         configured: true,
         ...(state.linked ? { linked: true } : {}),
         running: true,
-        connected: state.connected,
+        ...(typeof state.connected === "boolean" ? { connected: state.connected } : {}),
         lastError: state.failure,
       };
     case "stopped":

--- a/src/gateway/server-channels.test.ts
+++ b/src/gateway/server-channels.test.ts
@@ -23,6 +23,7 @@ import {
   listActiveDegradedSecretOwners,
   setActiveDegradedSecretOwners,
 } from "../secrets/runtime-degraded-state.js";
+import { evaluateChannelHealth } from "./channel-health-policy.js";
 import { createChannelManager, type ChannelManager } from "./server-channels.js";
 
 const hoisted = vi.hoisted(() => {
@@ -481,6 +482,35 @@ describe("server-channels auto restart", () => {
     expect(account?.running).toBe(false);
     expect(account?.connected).toBe(false);
     expect(account?.lastError).toBeNull();
+  });
+
+  it("keeps a running channel without transport reporting free of a synthetic disconnect", async () => {
+    // Socketless channels (imessage, signal, sms, ...) never publish `connected`.
+    // Projecting a synthetic `false` made the health monitor read them as
+    // disconnected and restart them once per cooldown window forever.
+    const startAccount = vi.fn(async (ctx: ChannelGatewayContext<TestAccount>) => {
+      ctx.setStatus({ accountId: DEFAULT_ACCOUNT_ID, running: true });
+      await new Promise<void>((resolve) => {
+        ctx.abortSignal.addEventListener("abort", () => resolve(), { once: true });
+      });
+    });
+    installTestRegistry(createTestPlugin({ startAccount }));
+    const manager = createManager();
+
+    await manager.startChannels();
+    await flushMicrotasks();
+
+    const account = manager.getRuntimeSnapshot().channelAccounts.discord?.[DEFAULT_ACCOUNT_ID];
+    expect(account?.running).toBe(true);
+    expect(account).not.toHaveProperty("connected");
+    expect(
+      evaluateChannelHealth(account ?? {}, {
+        channelId: "discord",
+        now: Date.now() + 60 * 60_000,
+        channelConnectGraceMs: 120_000,
+        staleEventThresholdMs: 30 * 60_000,
+      }),
+    ).toEqual({ healthy: true, reason: "healthy" });
   });
 
   it("settles every account before surfacing a stop hook failure", async () => {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where operators running any channel that has no socket to report on would see the gateway stop and restart that channel roughly every ten minutes, forever, with no error behind it.

Observed live on a production gateway (`/tmp/openclaw/openclaw-2026-07-28.log`):

```
[imessage:default] health-monitor: restarting (reason: disconnected)  01:14:42
[imessage:default] health-monitor: restarting (reason: disconnected)  01:24:42
[imessage:default] health-monitor: restarting (reason: disconnected)  01:34:42
```

The live account snapshot read `running: true, connected: false, lastError: null` — a disconnect with no transport error behind it, which is only possible if the disconnect was manufactured rather than reported. Zero occurrences of this line exist in pre-regression logs on the same host.

Provenance: `e0a119dabf4` ("fix(channels): own account status in one closed state machine", #114775).

## Why This Change Was Made

Account connectivity is a **tri-state**: `true` (transport reports connected), `false` (transport reports disconnected), and **absent** (the channel publishes no connectivity signal at all). Before `e0a119dabf4`, every write of `connected` in the gateway was guarded by `typeof current.connected === "boolean"` (`e0a119dabf4^:src/gateway/server-channels.ts:417` and `:1151`) — the gateway only ever *cleared* a flag a plugin had itself published, and never invented one.

`e0a119dabf4` moved that projection into `src/channels/status/account-state.ts`. The `stopped` variant kept the tri-state; the `running` variant did not: it resolved `input.runtime.connected ?? false` and the projection emitted the field unconditionally. `applyChannelAccountState` deletes then reassigns the owned fields, so the synthetic `false` was stamped onto every running account's snapshot.

`src/gateway/server-channels.ts` runs that projection inside `getRuntimeSnapshot()`, which the health monitor consumes; `evaluateChannelHealth` treats `connected === false` on a running account as `{healthy: false, reason: "disconnected"}`, which `resolveChannelRestartReason` turns into a stop+start once per cooldown window.

The fix restores the tri-state in the single place it was lost: `running` carries `connected?: boolean`, resolves to `input.runtime?.connected` with no `?? false`, and projects conditionally exactly as the sibling `stopped` case already does. Explicit `true`/`false` from socket-backed channels is unchanged.

Note that the surrounding code was already internally inconsistent with the regression: the SDK's own `buildRuntimeAccountStatusSnapshot` (`src/plugin-sdk/status-helpers.ts:385`) deliberately keeps `connected` absent unless the plugin published a boolean, only for `applyChannelAccountState` to add it back one call later.

**Non-goal / follow-up:** this PR does not invent `connected: true` for the socketless channels — that would be worse than absent, since it would enable the stale-socket check against a transport that has no socket. Whether iMessage should publish real connectivity derived from `watch.subscribe` success is a separate product question for the channel owner.

## User Impact

Operators running iMessage, Signal, SMS, Google Chat, LINE, Microsoft Teams, Nextcloud Talk, Synology Chat, ClickClack, Buzz, Nostr, Tlon, IRC, Zalo, Zalo Personal, or QA Channel stop losing their channel every cooldown window. Message delivery is no longer interrupted by a restart that had no cause.

Channel status surfaces also stop lying: `openclaw channels status` no longer prints `disconnected` for a healthy running channel that simply has nothing to report (`src/commands/channels/status.ts:101` already guards on `typeof account.connected === "boolean"`), and the web UI's Connected row returns to the unknown dash instead of `No` (`ui/src/pages/channels/view.shared.ts:64`).

**Blast radius verified by enumerating all 27 channel plugins** (those whose `openclaw.plugin.json` declares a `channels` array):

- **10 publish a real `connected` boolean** and are unaffected by this change: discord, feishu, matrix, mattermost, qqbot, raft, reef, slack, telegram, whatsapp.
- **17 never publish connectivity** and were permanently "disconnected" while running: buzz, clickclack, googlechat, imessage, irc, line, msteams, nextcloud-talk, nostr, qa-channel, signal, sms, synology-chat, tlon, twitch, zalo, zalouser.

(Twitch's `connected` is on its `ProbeTwitchResult`, surfaced under the separate `probe` field, and zalouser's is a QR-login result shape — neither reaches `setStatus`.)

## Evidence

Behavior proof, not just unit assertions:

- `src/gateway/server-channels.test.ts` — new end-to-end regression: a channel whose `startAccount` only sets `running: true` and never publishes connectivity now yields a snapshot with **no** `connected` key, and `evaluateChannelHealth` on that exact snapshot (past the connect grace) returns `{healthy: true, reason: "healthy"}`. This is the precise composition that produced the restart loop. It fails on `main`.
- `src/channels/status/account-state.test.ts` — two table cases at the fix site: `running` with no runtime connectivity resolves `connected: undefined`, and the projection of a `running` state without `connected` omits the key entirely. The existing case that passes an explicit `connected: false` for a running account is untouched and still asserts `connected: false` is preserved.

Commands run:

```
node scripts/run-vitest.mjs src/channels/status/account-state.test.ts     # 19 passed
node scripts/run-vitest.mjs src/gateway/server-channels.test.ts           # 76 passed
node scripts/check-changed.mjs                                            # delegated to Blacksmith Testbox, exit 0
```

`check:changed` classified lanes `core, coreTests` and ran the full changed-file gate remotely (format, plugin-sdk API baseline, import cycles, dependency pins, ratchets, guards) — Testbox `tbx_01kykmbdpfyk5rvcfsx8f9j9rg`.

Autoreview (Codex `gpt-5.6-sol`, xhigh) returned `autoreview clean: no accepted/actionable findings reported`, summarizing that the change consistently preserves absent connectivity as an unknown/unpublished state for running channels while retaining explicit true/false connectivity values (0.96).

`git diff --numstat` against `origin/main`:

```
12   0   src/channels/status/account-state.test.ts
 7   3   src/channels/status/account-state.ts
30   0   src/gateway/server-channels.test.ts
```

Non-test production LOC: +4/-3.

### After-fix runtime proof (before/after)

Reproduced the loop and its absence by driving the **real** `createChannelManager` and the **real** `startChannelHealthMonitor` in a plain Node process with real timers — not a Vitest run — over a channel that reports `running: true` and never publishes connectivity, exactly like the 17 socketless plugins. Monitor timings were compressed while keeping production ratios (interval 300ms, connect grace 600ms, cooldown 2 cycles, vs. production 5m / 2m / 2 cycles), so 6 seconds covers ~20 monitor cycles.

**Before (production file reverted to `HEAD~1`, i.e. current `main`):**

```
[health-monitor] started (interval: 0s, startup-grace: 0s, channel-connect-grace: 1s)
[health-monitor] [imessage-like:default] health-monitor: restarting (reason: disconnected)
[health-monitor] [imessage-like:default] health-monitor: restarting (reason: disconnected)
... (10 total, capped by maxRestartsPerHour)

snapshot: { "running": true, "connected": false, "lastError": null, ... }
has 'connected' key: true
startAccount calls: 11   stopAccount calls: 10
RESULT: RESTART LOOP
```

**After (this PR):**

```
[health-monitor] started (interval: 0s, startup-grace: 0s, channel-connect-grace: 1s)

snapshot: { "running": true, "lastError": null, ... }
has 'connected' key: false
startAccount calls: 1   stopAccount calls: 0
RESULT: no restart loop
```

The "before" run reproduces the exact production log line (`health-monitor: restarting (reason: disconnected)`) and the exact production snapshot shape (`running: true, connected: false, lastError: null`) from a synthetic channel, confirming the manufactured `false` — not any transport fault — is the sole cause.

Scope note on this proof: the operator's live gateway was **not** touched. It is currently serving four live channels, and restarting it, editing its config, or writing to its state would be a production action taken purely for evidence. The probe above uses the same production modules and the same health monitor against a scratch in-process manager instead, and the probe script itself is untracked scratch (not added to the repo).
