### PR TITLE
fix(ui): prevent duplicate Workboard widget loads and card moves

### DIFF
--- a/src/gateway/sessions-history-http.test.ts
+++ b/src/gateway/sessions-history-http.test.ts
@@ -963,8 +963,12 @@ describe("session history HTTP endpoints", () => {
       await expectHistoryEventTexts(stream, ["first message", "second message"]);
 
       emitSessionTranscriptUpdate({
-        sessionFile: `sqlite:main:sess-main:${storePath}`,
-        sessionKey: "agent:main:main",
+        target: {
+          agentId: AGENT_ID,
+          sessionId: "sess-main",
+          sessionKey: "agent:main:main",
+          storePath,
+        },
         message: makeTranscriptAssistantMessage({ text: "rewound branch message" }),
         messageId: "msg-rewound",
         messageSeq: 1,

--- a/ui/src/lib/board/widgets/workboard-widget.ts
+++ b/ui/src/lib/board/widgets/workboard-widget.ts
@@ -290,13 +290,6 @@ export abstract class WorkboardWidgetElement extends OpenClawLightDomElement {
     const refresh = (async () => {
       try {
         await loadSharedWorkboardCards(client, sharedRuntime);
-        if (
-          generation !== this.refreshGeneration ||
-          client !== this.client ||
-          sharedRuntime !== this.sharedRuntime
-        ) {
-          return;
-        }
       } catch (error) {
         if (generation === this.refreshGeneration && client === this.client) {
           this.error = error instanceof Error ? error.message : String(error);

--- a/ui/src/lib/board/widgets/workboard-widget.ts
+++ b/ui/src/lib/board/widgets/workboard-widget.ts
@@ -15,6 +15,108 @@ import {
 } from "../../workboard/types.ts";
 import type { BoardViewWidget } from "../view-types.ts";
 
+type SharedWorkboardWidgetRuntime = {
+  host: WorkboardHost;
+  listeners: Set<(snapshot: ReturnType<typeof normalizeCardsPayload>) => void>;
+  loadPromise?: Promise<ReturnType<typeof normalizeCardsPayload>>;
+};
+
+type SharedWorkboardWidgetSubscription = {
+  listeners: Set<() => void>;
+  unsubscribe: () => void;
+};
+
+const sharedWorkboardWidgetRuntimes = new WeakMap<
+  GatewayBrowserClient,
+  SharedWorkboardWidgetRuntime
+>();
+const sharedWorkboardWidgetSubscriptions = new WeakMap<
+  ApplicationContext["gateway"],
+  SharedWorkboardWidgetSubscription
+>();
+
+function acquireWorkboardWidgetRuntime(
+  client: GatewayBrowserClient,
+  listener: (snapshot: ReturnType<typeof normalizeCardsPayload>) => void,
+): SharedWorkboardWidgetRuntime {
+  let runtime = sharedWorkboardWidgetRuntimes.get(client);
+  if (!runtime) {
+    runtime = { host: {}, listeners: new Set() };
+    sharedWorkboardWidgetRuntimes.set(client, runtime);
+  }
+  runtime.listeners.add(listener);
+  return runtime;
+}
+
+function releaseWorkboardWidgetRuntime(
+  client: GatewayBrowserClient,
+  runtime: SharedWorkboardWidgetRuntime,
+  listener: (snapshot: ReturnType<typeof normalizeCardsPayload>) => void,
+): void {
+  runtime.listeners.delete(listener);
+  if (runtime.listeners.size === 0 && sharedWorkboardWidgetRuntimes.get(client) === runtime) {
+    sharedWorkboardWidgetRuntimes.delete(client);
+  }
+}
+
+function loadSharedWorkboardCards(
+  client: GatewayBrowserClient,
+  runtime: SharedWorkboardWidgetRuntime,
+): Promise<ReturnType<typeof normalizeCardsPayload>> {
+  if (runtime.loadPromise) {
+    return runtime.loadPromise;
+  }
+  // Every widget on a Gateway shares one in-flight snapshot; a board change
+  // must not multiply full-card-list requests by the visible widget count.
+  const load = client.request("workboard.cards.list", {}).then(normalizeCardsPayload);
+  runtime.loadPromise = load;
+  const releaseLoad = () => {
+    if (runtime.loadPromise === load) {
+      runtime.loadPromise = undefined;
+    }
+  };
+  void load.then((snapshot) => {
+    releaseLoad();
+    // A change can arrive after another widget started its snapshot request.
+    // Broadcast the eventual post-change reload so idle widgets cannot stay stale.
+    for (const listener of runtime.listeners) {
+      listener(snapshot);
+    }
+  }, releaseLoad);
+  return load;
+}
+
+function subscribeToSharedWorkboardChanges(
+  gateway: ApplicationContext["gateway"],
+  listener: () => void,
+): () => void {
+  let subscription = sharedWorkboardWidgetSubscriptions.get(gateway);
+  if (!subscription) {
+    const listeners = new Set<() => void>();
+    const unsubscribe = gateway.subscribeEvents((event) => {
+      if (event.event !== WORKBOARD_CHANGED_EVENT || gateway.snapshot.phase !== "connected") {
+        return;
+      }
+      for (const onChange of listeners) {
+        onChange();
+      }
+    });
+    subscription = { listeners, unsubscribe };
+    sharedWorkboardWidgetSubscriptions.set(gateway, subscription);
+  }
+  subscription.listeners.add(listener);
+  return () => {
+    subscription.listeners.delete(listener);
+    if (
+      subscription.listeners.size === 0 &&
+      sharedWorkboardWidgetSubscriptions.get(gateway) === subscription
+    ) {
+      subscription.unsubscribe();
+      sharedWorkboardWidgetSubscriptions.delete(gateway);
+    }
+  };
+}
+
 export abstract class WorkboardWidgetElement extends OpenClawLightDomElement {
   @consume({ context: applicationContext, subscribe: true })
   protected context?: ApplicationContext;
@@ -34,19 +136,28 @@ export abstract class WorkboardWidgetElement extends OpenClawLightDomElement {
   private allCards: WorkboardCard[] = [];
   private workboardHost: WorkboardHost = {};
   private client: GatewayBrowserClient | null = null;
+  private sharedRuntime: SharedWorkboardWidgetRuntime | null = null;
   private refreshGeneration = 0;
   private refreshPromise: Promise<void> | null = null;
   private refreshPending = false;
+  private readonly applySharedSnapshot = (
+    snapshot: ReturnType<typeof normalizeCardsPayload>,
+  ): void => {
+    this.allCards = snapshot.cards;
+    this.cards = snapshot.cards.filter(isActiveWorkboardCard);
+    this.statuses = snapshot.statuses;
+    this.loaded = true;
+    this.error = "";
+    this.requestRender();
+  };
   private readonly subscriptions = new SubscriptionsController(this).effect(
     () => this.context?.gateway,
     (gateway) => {
       const sync = () => this.syncGateway(gateway.snapshot);
       sync();
       const unsubscribeSnapshot = gateway.subscribe(sync);
-      const unsubscribeEvents = gateway.subscribeEvents((event) => {
-        if (event.event === WORKBOARD_CHANGED_EVENT && gateway.snapshot.phase === "connected") {
-          void this.refresh(true);
-        }
+      const unsubscribeEvents = subscribeToSharedWorkboardChanges(gateway, () => {
+        void this.refresh(true);
       });
       return () => {
         unsubscribeSnapshot();
@@ -67,10 +178,14 @@ export abstract class WorkboardWidgetElement extends OpenClawLightDomElement {
   }
 
   override disconnectedCallback(): void {
+    if (this.client && this.sharedRuntime) {
+      releaseWorkboardWidgetRuntime(this.client, this.sharedRuntime, this.applySharedSnapshot);
+    }
     this.refreshGeneration += 1;
     this.refreshPromise = null;
     this.refreshPending = false;
     this.client = null;
+    this.sharedRuntime = null;
     this.allCards = [];
     this.cards = [];
     this.workboardHost = {};
@@ -130,10 +245,16 @@ export abstract class WorkboardWidgetElement extends OpenClawLightDomElement {
     if (this.client === nextClient) {
       return;
     }
+    if (this.client && this.sharedRuntime) {
+      releaseWorkboardWidgetRuntime(this.client, this.sharedRuntime, this.applySharedSnapshot);
+    }
     this.client = nextClient;
     // Pending mutation state belongs to its connection; never let its completion
     // block or replace cards loaded through the next Gateway client.
-    this.workboardHost = {};
+    this.sharedRuntime = nextClient
+      ? acquireWorkboardWidgetRuntime(nextClient, this.applySharedSnapshot)
+      : null;
+    this.workboardHost = this.sharedRuntime?.host ?? {};
     this.allCards = [];
     this.cards = [];
     this.refreshGeneration += 1;
@@ -151,7 +272,8 @@ export abstract class WorkboardWidgetElement extends OpenClawLightDomElement {
 
   private async refresh(force = false): Promise<void> {
     const client = this.client;
-    if (!client || (!force && this.loaded)) {
+    const sharedRuntime = this.sharedRuntime;
+    if (!client || !sharedRuntime || (!force && this.loaded)) {
       return;
     }
     if (this.refreshPromise) {
@@ -167,14 +289,14 @@ export abstract class WorkboardWidgetElement extends OpenClawLightDomElement {
     this.requestRender();
     const refresh = (async () => {
       try {
-        const normalized = normalizeCardsPayload(await client.request("workboard.cards.list", {}));
-        if (generation !== this.refreshGeneration || client !== this.client) {
+        await loadSharedWorkboardCards(client, sharedRuntime);
+        if (
+          generation !== this.refreshGeneration ||
+          client !== this.client ||
+          sharedRuntime !== this.sharedRuntime
+        ) {
           return;
         }
-        this.allCards = normalized.cards;
-        this.cards = normalized.cards.filter(isActiveWorkboardCard);
-        this.statuses = normalized.statuses;
-        this.loaded = true;
       } catch (error) {
         if (generation === this.refreshGeneration && client === this.client) {
           this.error = error instanceof Error ? error.message : String(error);

--- a/ui/src/lib/board/widgets/workboard.test.ts
+++ b/ui/src/lib/board/widgets/workboard.test.ts
@@ -115,6 +115,131 @@ afterEach(() => {
 });
 
 describe("Workboard plugin widgets", () => {
+  it("shares the initial card load between widgets on the same gateway", async () => {
+    const request = vi.fn(async (method: string) => {
+      if (method === "workboard.cards.list") {
+        return { cards, statuses: ["ready", "running", "done"] };
+      }
+      throw new Error(`Unexpected method: ${method}`);
+    });
+    const mini = document.createElement("openclaw-workboard-mini-widget");
+    mini.widget = pluginWidget("workboard:mini", { boardId: "ops" });
+    const card = document.createElement("openclaw-workboard-card-widget");
+    card.widget = pluginWidget("workboard:card", { cardId: "card-ready" });
+    const context = createContext(request);
+    const unsubscribeEvents = vi.fn();
+    const subscribeEvents = vi.fn(() => unsubscribeEvents);
+    Reflect.set(context.gateway, "subscribeEvents", subscribeEvents);
+    const provider = createApplicationContextProvider(context);
+    provider.append(mini, card);
+    document.body.append(provider);
+
+    await vi.waitFor(() => {
+      expect(mini.textContent).toContain("Running card");
+      expect(card.textContent).toContain("Ready card");
+    });
+
+    expect(request.mock.calls.filter(([method]) => method === "workboard.cards.list")).toHaveLength(
+      1,
+    );
+    expect(subscribeEvents).toHaveBeenCalledOnce();
+
+    mini.remove();
+    expect(unsubscribeEvents).not.toHaveBeenCalled();
+    card.remove();
+    expect(unsubscribeEvents).toHaveBeenCalledOnce();
+  });
+
+  it("deduplicates concurrent moves of the same card across widgets", async () => {
+    const pendingMove = deferred<unknown>();
+    const request = vi.fn(async (method: string) => {
+      if (method === "workboard.cards.list") {
+        return { cards, statuses: ["ready", "running", "done"] };
+      }
+      if (method === "workboard.cards.move") {
+        return await pendingMove.promise;
+      }
+      throw new Error(`Unexpected method: ${method}`);
+    });
+    const first = document.createElement("openclaw-workboard-card-widget");
+    first.widget = pluginWidget("workboard:card", { cardId: "card-ready" });
+    const second = document.createElement("openclaw-workboard-card-widget");
+    second.widget = pluginWidget("workboard:card", { cardId: "card-ready" });
+    const provider = createApplicationContextProvider(createContext(request));
+    provider.append(first, second);
+    document.body.append(provider);
+
+    await vi.waitFor(() => {
+      expect(first.querySelector("select")).not.toBeNull();
+      expect(second.querySelector("select")).not.toBeNull();
+    });
+
+    for (const widget of [first, second]) {
+      const select = widget.querySelector("select")!;
+      select.value = "running";
+      select.dispatchEvent(new Event("change"));
+    }
+
+    try {
+      expect(
+        request.mock.calls.filter(([method]) => method === "workboard.cards.move"),
+      ).toHaveLength(1);
+    } finally {
+      pendingMove.resolve({
+        card: { ...cards[0], status: "running", position: 3000 },
+      });
+    }
+  });
+
+  it("broadcasts a post-change refresh to widgets sharing an older in-flight load", async () => {
+    const staleLoad = deferred<unknown>();
+    const freshCards = cards.map((card) =>
+      card.id === "card-ready" ? { ...card, title: "Updated ready card" } : card,
+    );
+    const request = vi.fn(async (method: string) => {
+      if (method !== "workboard.cards.list") {
+        throw new Error(`Unexpected method: ${method}`);
+      }
+      if (request.mock.calls.length === 2) {
+        return await staleLoad.promise;
+      }
+      return {
+        cards: request.mock.calls.length === 1 ? cards : freshCards,
+        statuses: ["ready", "running", "done"],
+      };
+    });
+    const events: {
+      listener?: Parameters<ApplicationContext["gateway"]["subscribeEvents"]>[0];
+    } = {};
+    const mini = document.createElement("openclaw-workboard-mini-widget");
+    mini.widget = pluginWidget("workboard:mini", { boardId: "ops" });
+    const card = document.createElement("openclaw-workboard-card-widget");
+    card.widget = pluginWidget("workboard:card", { cardId: "card-ready" });
+    const provider = createApplicationContextProvider(createContext(request, events));
+    provider.append(mini, card);
+    document.body.append(provider);
+
+    await vi.waitFor(() => {
+      expect(mini.textContent).toContain("Ready card");
+      expect(card.textContent).toContain("Ready card");
+    });
+
+    (Reflect.get(mini, "retryLoad") as () => void).call(mini);
+    await vi.waitFor(() => expect(request).toHaveBeenCalledTimes(2));
+    events.listener?.({
+      type: "event",
+      event: "plugin.workboard.changed",
+      payload: { epoch: "epoch-shared", revision: 2 },
+    });
+    staleLoad.resolve({ cards, statuses: ["ready", "running", "done"] });
+
+    await vi.waitFor(() => expect(request).toHaveBeenCalledTimes(3));
+    await vi.waitFor(() => {
+      expect(mini.textContent).toContain("Updated ready card");
+      expect(card.textContent).toContain("Updated ready card");
+    });
+  });
+
   it("renders a card and moves it through the shared mutation helper", async () => {
     const request = vi.fn(async (method: string) => {
       if (method === "workboard.cards.list") {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users showing multiple Workboard widgets on the same dashboard caused duplicated full-board requests and event subscriptions, conflicting same-card moves, and stale widgets after a board change arrived during an existing load.

## Why This Change Was Made

Use a reference-counted gateway-scoped widget runtime, one shared event subscription, one in-flight card-list request, shared per-card mutation state, and snapshot fanout to every active widget. Drop shared ownership when the final widget disconnects and preserve reconnect generation boundaries. Update the related gateway-history regression to emit the canonical, storage-neutral transcript target.

## User Impact

Multiple dashboard widgets now stay synchronized, avoid redundant Gateway load and subscriptions, prevent double card moves, and display the correct post-change snapshot. Cron/session history regressions no longer hang for 120 seconds on retired SQLite marker input.

## Evidence

AI-assisted: Codex.

### Before: current-main multi-widget failures

```text
ui/src/lib/board/widgets/workboard.test.ts (16 tests | 2 failed)
× shares the initial card load between widgets on the same gateway
  AssertionError: expected [ Array(2) ] to have a length of 1 but got 2
× deduplicates concurrent moves of the same card across widgets
  AssertionError: expected [ …(2) ] to have a length of 1 but got 2
```

The same current-main run reproduced the gateway regression:

```text
FAIL src/gateway/sessions-history-http.test.ts
× refreshes SSE history for non-monotonic carried sequence 120007ms
Error: Test timed out in 120000ms.
```

### After: real shared-widget behavior

The actual two-widget regression mounts a mini widget and a card widget inside the same application context, spies on `workboard.cards.list` and `gateway.subscribeEvents`, and verifies one request, one shared subscription, and exactly one unsubscribe only after removing the last widget. The same-card regression dispatches both real DOM `change` events while the first gateway move remains unresolved and verifies exactly one `workboard.cards.move`. A third regression emits the real `plugin.workboard.changed` event while one widget owns a deferred stale load and verifies both real rendered widgets display the broadcast fresh card.

```text
✓ ui/src/lib/board/widgets/workboard.test.ts (17 tests)
  ✓ shares the initial card load between widgets on the same gateway
  ✓ deduplicates concurrent moves of the same card across widgets
  ✓ broadcasts a post-change refresh to widgets sharing an older in-flight load

✓ ui/src/pages/workboard/workboard-card-dashboard.test.ts (5 tests)
✓ ui/src/lib/workboard/live-refresh.test.ts (8 tests)
✓ src/gateway/session-history-state.test.ts (21 tests)
✓ src/gateway/sessions-history-http.test.ts (29 tests)
  ✓ refreshes SSE history for non-monotonic carried sequence 451ms
✓ src/cron/service/timer.timeout-watchdog.test.ts (11 tests)
✓ src/cron/service/ops.run-admission-cleanup.test.ts (20 tests)
[test] passed 4 Vitest shards
```

### Real Chromium behavior

```text
$ pnpm test:ui:e2e <9 Workboard, dashboard, session, and cron files>
[ui-e2e] Using system Chromium at /usr/bin/chromium-browser.
✓ workboard.e2e.test.ts (3 tests)
  ✓ persists Workboard create, edit, running move, lifecycle sync,
    reload, and read-only state
✓ workboard-routing.e2e.test.ts (3 tests)
✓ workboard-status-persistence.e2e.test.ts (2 tests)
✓ cron-filters.e2e.test.ts (7 tests)
✓ session-management.e2e.test.ts (21 tests)
✓ session-ownership.e2e.test.ts
✓ session-dashboard.e2e.test.ts
✓ session-list-filter.e2e.test.ts (3 tests)
✓ board-fixture.e2e.test.ts (3 tests)
Test Files  9 passed (9)
     Tests  57 passed (57)
```

### Real isolated gateway and scheduler

```json
{"requested":["cron-empty-response-after-write-recovery","cron-natural-fire-no-duplicate","cron-one-minute-ping","cron-single-run-no-duplicate","cron-condition-watcher","heartbeat-active-hours"],"missing":[],"counts":{"total":6,"passed":6,"failed":0,"skipped":0},"provider":"mock-openai"}
```

These scenarios use an actual isolated OpenClaw gateway and scheduler; only the model provider is mocked.

### Broader stress and independent review

```text
203-file mixed cron/gateway/tasks/Workboard/UI stress:
[test] passed 9 Vitest shards

Repeated mixed scheduler/gateway/Workboard race stress:
FRESH_MAIN_RACE_PASS 1/5
FRESH_MAIN_RACE_PASS 2/5
FRESH_MAIN_RACE_PASS 3/5
FRESH_MAIN_RACE_PASS 4/5
FRESH_MAIN_RACE_PASS 5/5
26 focused race files per pass

autoreview clean: no accepted/actionable findings reported
```

The current `main` baseline was independently refreshed and inspected using the protected `scripts/pr review-init` and `review-checkout-main` workflow. The branch intentionally remains on its frozen, CI-proven base until native `prepare-run`, rather than invalidating exact-head evidence solely because `main` advanced.