### PR TITLE
fix: trim trailing whitespace from final reply chunks

### DIFF
--- a/src/auto-reply/chunk.test.ts
+++ b/src/auto-reply/chunk.test.ts
@@ -215,6 +215,14 @@ describe("chunkText", () => {
       },
     },
     {
+      name: "trims trailing whitespace from the final outbound reply chunk",
+      text: "alpha beta   ",
+      limit: 8,
+      assert: (chunks: string[]) => {
+        expect(chunks).toEqual(["alpha", "beta"]);
+      },
+    },
+    {
       name: "falls back to a hard break when no whitespace is present",
       text: "Supercalifragilisticexpialidocious",
       limit: 10,

--- a/src/shared/text-chunking.test.ts
+++ b/src/shared/text-chunking.test.ts
@@ -7,6 +7,8 @@ describe("shared/text-chunking", () => {
     expect(chunkTextByBreakResolver("", 10, () => 5)).toStrictEqual([]);
     expect(chunkTextByBreakResolver("hello", 10, () => 2)).toEqual(["hello"]);
     expect(chunkTextByBreakResolver("hello", 0, () => 2)).toEqual(["hello"]);
+    expect(chunkTextByBreakResolver("hello ", 10, () => 2)).toEqual(["hello "]);
+    expect(chunkTextByBreakResolver("hello ", 0, () => 2)).toEqual(["hello "]);
   });
 
   it("splits at resolver-provided breakpoints and trims separator boundaries", () => {
@@ -37,5 +39,15 @@ describe("shared/text-chunking", () => {
       "abc",
       "def",
     ]);
+  });
+
+  it.each([
+    { text: "  ! ", limit: 2, expected: ["!"] },
+    { text: "a b ", limit: 2, expected: ["a", "b"] },
+    { text: "alpha beta   ", limit: 8, expected: ["alpha", "beta"] },
+  ])("trims trailing whitespace from the final chunk: $text", ({ text, limit, expected }) => {
+    expect(chunkTextByBreakResolver(text, limit, (window) => window.lastIndexOf(" "))).toEqual(
+      expected,
+    );
   });
 });

--- a/src/shared/text-chunking.ts
+++ b/src/shared/text-chunking.ts
@@ -101,8 +101,9 @@ export function chunkTextByBreakResolver(
     const nextStart = Math.min(remaining.length, safeBreakIdx + (brokeOnSeparator ? 1 : 0));
     remaining = remaining.slice(nextStart).trimStart();
   }
-  if (remaining.length) {
-    chunks.push(remaining);
+  const finalChunk = remaining.trimEnd();
+  if (finalChunk.length) {
+    chunks.push(finalChunk);
   }
   return chunks;
 }


### PR DESCRIPTION
Closes #64036

AI-assisted; independently reviewed. Thanks @thanhtoantnt for the original report and minimal reproduction.

## What Problem This Solves

Fixes an issue where users receiving a reply split into multiple messages could see trailing whitespace on its final message chunk, even though every earlier chunk had already been trimmed.

## Why This Change Was Made

Apply the existing chunk-boundary trimming rule to the final remainder in the canonical shared text chunker. Preserve the existing byte-for-byte behavior for messages that do not need splitting; do not change plugin APIs, configuration, or channel ownership.

## User Impact

Chunked replies now end consistently across auto-reply delivery and channel consumers without adding a whitespace-only final message. Messages under the transport limit retain their original whitespace.

## Evidence

Trusted Blacksmith Testbox: `tbx_01kykk7tjx5hz72w7r9tec1qjj`.

- Before the production change, focused regression tests reproduced all three reported failures: `["! "]`, `["a", "b "]`, and `["alpha", "beta   "]`.
- After the change, 277 tests passed across 14 focused files covering shared chunking, auto-reply delivery, the existing public outbound consumer, Markdown, Discord, Telegram, Slack, Matrix, Microsoft Teams, and Signal.
- Real user-output end-to-end proof: an isolated Gateway, `mock-openai`, and `qa-channel` passed both `channel-chat-baseline` and `dm-chat-baseline`.
- Full exact-path `pnpm check:changed` passed, including production and test typechecking, formatting, lint, dependency and plugin boundaries, architecture, and import-cycle checks.
- Independent Codex autoreview completed clean with no actionable findings.

```text
pnpm test src/shared/text-chunking.test.ts src/auto-reply/chunk.test.ts src/plugin-sdk/text-chunking.test.ts packages/markdown-core/src/ir.chunking.test.ts packages/markdown-core/src/render-aware-chunking.test.ts extensions/discord/src/chunk.test.ts extensions/discord/src/draft-chunking.test.ts extensions/slack/src/format.test.ts extensions/telegram/src/format.test.ts extensions/telegram/src/send.chunks.test.ts extensions/msteams/src/format.test.ts extensions/msteams/src/outbound.test.ts extensions/matrix/src/outbound.test.ts extensions/signal/src/format.chunking.test.ts
pnpm openclaw qa suite --provider-mode mock-openai --scenario channel-chat-baseline --scenario dm-chat-baseline --concurrency 1 --output-dir .artifacts/qa-64036-final-chunk
pnpm check:changed -- src/shared/text-chunking.ts src/shared/text-chunking.test.ts src/auto-reply/chunk.test.ts
.agents/skills/autoreview/scripts/autoreview --mode uncommitted --stream-engine-output
```
