### PR TITLE
fix(macos): stop replacement handoff retry storms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,7 +51,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- **macOS app replacement recovery:** bound authenticated handoff launches with load-scaled deadlines and exponential backoff, then stop monitoring or yield to a verified KeepAlive supervisor instead of spawning replacements forever under load. Fixes #114955.
 - **Codex native controls:** stop misclassifying valid thinking/fast runtime controls as provider overrides so Codex routes keep their native controls, while provider-native objects and invalid values stay fail-closed. Thanks @VACInc. (#107588)
 - **State snapshot verification:** run SQLite snapshot verification in a separate process so worker-thread file closes no longer drop the Gateway's POSIX WAL locks, eliminating spurious WAL misses and I/O errors. Thanks @VACInc. (#114016)
 - **Reply latency with model policies:** reuse one immutable plugin-metadata snapshot per model-selection run instead of repeating plugin discovery, cutting reply delay when a model policy is configured. Thanks @VACInc. (#114117)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **macOS app replacement recovery:** bound authenticated handoff launches with load-scaled deadlines and exponential backoff, then stop monitoring or yield to a verified KeepAlive supervisor instead of spawning replacements forever under load. Fixes #114955.
 - **Codex native controls:** stop misclassifying valid thinking/fast runtime controls as provider overrides so Codex routes keep their native controls, while provider-native objects and invalid values stay fail-closed. Thanks @VACInc. (#107588)
 - **State snapshot verification:** run SQLite snapshot verification in a separate process so worker-thread file closes no longer drop the Gateway's POSIX WAL locks, eliminating spurious WAL misses and I/O errors. Thanks @VACInc. (#114016)
 - **Reply latency with model policies:** reuse one immutable plugin-metadata snapshot per model-selection run instead of repeating plugin discovery, cutting reply delay when a model policy is configured. Thanks @VACInc. (#114117)

--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -25843,7 +25843,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 6404,
+      "line": 6407,
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "No chat messages yet",
       "surface": "apple",
@@ -25851,7 +25851,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 6466,
+      "line": 6469,
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "Connecting…",
       "surface": "apple",
@@ -25859,7 +25859,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 6466,
+      "line": 6469,
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "Reconnecting…",
       "surface": "apple",
@@ -25867,7 +25867,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 8813,
+      "line": 8816,
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "Approval",
       "surface": "apple",
@@ -25875,7 +25875,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 8813,
+      "line": 8816,
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "This approval was already",
       "surface": "apple",
@@ -25883,7 +25883,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 8819,
+      "line": 8822,
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "This approval was already set to Always Allow.",
       "surface": "apple",
@@ -25891,7 +25891,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 8820,
+      "line": 8823,
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "Approval set to Always Allow.",
       "surface": "apple",
@@ -25899,7 +25899,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 10155,
+      "line": 10193,
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "\\(urlText.prefix(500))…",
       "surface": "apple",

--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -29859,7 +29859,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 217,
+      "line": 283,
       "path": "apps/macos/Sources/OpenClaw/ApplicationRelocator.swift",
       "source": "OpenClaw couldn’t be installed in Applications. Move it there manually, then open that copy.",
       "surface": "apple",
@@ -29867,7 +29867,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 907,
+      "line": 990,
       "path": "apps/macos/Sources/OpenClaw/ApplicationRelocator.swift",
       "source": "Replace the older OpenClaw in Applications?",
       "surface": "apple",
@@ -29875,7 +29875,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 908,
+      "line": 991,
       "path": "apps/macos/Sources/OpenClaw/ApplicationRelocator.swift",
       "source": "Install OpenClaw in Applications?",
       "surface": "apple",
@@ -29883,7 +29883,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 910,
+      "line": 993,
       "path": "apps/macos/Sources/OpenClaw/ApplicationRelocator.swift",
       "source": "This copy is newer than the installed app. OpenClaw will replace it and reopen from Applications.",
       "surface": "apple",
@@ -29891,7 +29891,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 911,
+      "line": 994,
       "path": "apps/macos/Sources/OpenClaw/ApplicationRelocator.swift",
       "source": "OpenClaw will copy itself to Applications and reopen there so updates and launch at login stay reliable.",
       "surface": "apple",
@@ -29899,7 +29899,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 913,
+      "line": 996,
       "path": "apps/macos/Sources/OpenClaw/ApplicationRelocator.swift",
       "source": "Install and Relaunch",
       "surface": "apple",
@@ -29907,7 +29907,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 913,
+      "line": 996,
       "path": "apps/macos/Sources/OpenClaw/ApplicationRelocator.swift",
       "source": "Replace and Relaunch",
       "surface": "apple",
@@ -29915,7 +29915,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 938,
+      "line": 1021,
       "path": "apps/macos/Sources/OpenClaw/ApplicationRelocator.swift",
       "source": "OpenClaw is installed in Applications, but couldn’t reopen automatically. Open it there manually.",
       "surface": "apple",

--- a/apps/macos/Sources/OpenClaw/ApplicationRelocator.swift
+++ b/apps/macos/Sources/OpenClaw/ApplicationRelocator.swift
@@ -59,6 +59,59 @@ enum ApplicationRelocator {
         case relaunch
     }
 
+    enum ReplacementHandoffFailureAction: Equatable, Sendable {
+        case retry(after: Duration)
+        case stopMonitoring
+        case terminateForSupervisor
+
+        var isTerminal: Bool {
+            switch self {
+            case .retry:
+                false
+            case .stopMonitoring, .terminateForSupervisor:
+                true
+            }
+        }
+    }
+
+    struct ReplacementHandoffPolicy: Equatable, Sendable {
+        let maximumAttempts: Int
+        let initialBackoffSeconds: Int
+        let maximumBackoffSeconds: Int
+        let baseTimeoutMilliseconds: Int32
+        let maximumTimeoutMilliseconds: Int32
+
+        func failureAction(
+            failedAttempt: Int,
+            hasKeepAliveSupervisor: Bool) -> ReplacementHandoffFailureAction
+        {
+            guard failedAttempt < self.maximumAttempts else {
+                return hasKeepAliveSupervisor ? .terminateForSupervisor : .stopMonitoring
+            }
+            let exponent = max(0, failedAttempt - 1)
+            let backoff = min(
+                self.maximumBackoffSeconds,
+                self.initialBackoffSeconds * (1 << exponent))
+            return .retry(after: .seconds(backoff))
+        }
+
+        func timeoutMilliseconds(
+            loadAverage: Double?,
+            activeProcessorCount: Int) -> Int32
+        {
+            guard let loadAverage,
+                  loadAverage.isFinite,
+                  loadAverage > 0,
+                  activeProcessorCount > 0
+            else { return self.baseTimeoutMilliseconds }
+            let loadPerProcessor = loadAverage / Double(activeProcessorCount)
+            let multiplier = min(4, max(1, loadPerProcessor))
+            let scaled = Double(self.baseTimeoutMilliseconds) * multiplier
+            let rounded = ceil(scaled / 5000) * 5000
+            return min(self.maximumTimeoutMilliseconds, Int32(rounded))
+        }
+    }
+
     enum RelaunchStrategy: Equatable, Sendable {
         case openAfterTermination
         case externalSupervisor
@@ -99,15 +152,28 @@ enum ApplicationRelocator {
         let launchCodeDirectoryHash: Data?
     }
 
+    private enum ReplacementScheduleResult {
+        case scheduled
+        case failed(supervisor: KeepAliveSupervisor?)
+    }
+
     private static let logger = Logger(subsystem: "ai.openclaw", category: "app-relocation")
     private static var bundleReplacementSnapshot: BundleReplacementSnapshot?
     private static var bundleReplacementSource: DispatchSourceFileSystemObject?
     private static var bundleReplacementRecoveryTask: Task<Void, Never>?
     private static var bundleReplacementCheckPending = false
     private static var bundleReplacementHandoffInProgress = false
+    private static var bundleReplacementHandoffAttempt = 0
+    private static var bundleReplacementHandoffTargetHash: Data?
     private static var inheritedReplacementSupervisor: KeepAliveSupervisor?
     private static var supervisorRestorationWatcher: Process?
     private static var authenticatedReplacementSourceBundleURL: URL?
+    nonisolated static let replacementHandoffPolicy = ReplacementHandoffPolicy(
+        maximumAttempts: 3,
+        initialBackoffSeconds: 2,
+        maximumBackoffSeconds: 8,
+        baseTimeoutMilliseconds: 15000,
+        maximumTimeoutMilliseconds: 60000)
     private nonisolated static let replacementSourceBundleEnvironmentKey = "OPENCLAW_REPLACEMENT_SOURCE_BUNDLE"
     private nonisolated static let replacementParentPIDEnvironmentKey = "OPENCLAW_REPLACEMENT_PARENT_PID"
     private nonisolated static let replacementCodeHashEnvironmentKey = "OPENCLAW_REPLACEMENT_CODE_HASH"
@@ -543,6 +609,8 @@ extension ApplicationRelocator {
         self.bundleReplacementSnapshot = nil
         self.bundleReplacementCheckPending = false
         self.bundleReplacementHandoffInProgress = false
+        self.bundleReplacementHandoffAttempt = 0
+        self.bundleReplacementHandoffTargetHash = nil
 
         let bundleURL = monitoredBundleURL.standardizedFileURL
         guard bundleURL.pathExtension == "app",
@@ -614,6 +682,8 @@ extension ApplicationRelocator {
                 }.value
                 switch evaluation.action {
                 case .unchanged:
+                    self.bundleReplacementHandoffAttempt = 0
+                    self.bundleReplacementHandoffTargetHash = nil
                     if self.bundleReplacementCheckPending {
                         continue
                     }
@@ -634,18 +704,31 @@ extension ApplicationRelocator {
                         try? await Task.sleep(for: .milliseconds(250))
                         continue
                     }
+                    if self.bundleReplacementHandoffTargetHash != launchCodeDirectoryHash {
+                        self.bundleReplacementHandoffTargetHash = launchCodeDirectoryHash
+                        self.bundleReplacementHandoffAttempt = 0
+                    }
+                    self.bundleReplacementHandoffAttempt += 1
+                    let handoffAttempt = self.bundleReplacementHandoffAttempt
+                    let maximumAttempts = self.replacementHandoffPolicy.maximumAttempts
                     self.bundleReplacementCheckPending = false
-                    self.logger.notice("Installed app changed; relaunching trusted replacement")
+                    self.logger.notice(
+                        "Relaunching trusted replacement (attempt \(handoffAttempt)/\(maximumAttempts))")
                     self.bundleReplacementHandoffInProgress = true
-                    let scheduled = self.scheduleReplacementRelaunch(
+                    let scheduleResult = self.scheduleReplacementRelaunch(
                         at: snapshot.bundleURL,
                         launchReference: launchReference,
-                        codeDirectoryHash: launchCodeDirectoryHash)
-                    if !scheduled {
-                        self.bundleReplacementHandoffInProgress = false
-                        try? await Task.sleep(for: .seconds(1))
-                        continue
+                        codeDirectoryHash: launchCodeDirectoryHash,
+                        attempt: handoffAttempt)
+                    if case let .failed(supervisor) = scheduleResult {
+                        await self.handleReplacementHandoffFailure(
+                            attempt: handoffAttempt,
+                            targetCodeDirectoryHash: launchCodeDirectoryHash,
+                            supervisor: supervisor,
+                            reason: "Could not spawn the trusted replacement")
                     }
+                    // The task defer clears recovery ownership before draining the
+                    // retry check queued by the failure handler.
                     return
                 }
             }
@@ -979,7 +1062,8 @@ extension ApplicationRelocator {
     private static func scheduleReplacementRelaunch(
         at destination: URL,
         launchReference: BundleFileReference,
-        codeDirectoryHash: Data) -> Bool
+        codeDirectoryHash: Data,
+        attempt: Int) -> ReplacementScheduleResult
     {
         let processInfo = ProcessInfo.processInfo
         let activeSupervisor = self.verifiedKeepAliveSupervisor(
@@ -1000,13 +1084,17 @@ extension ApplicationRelocator {
             bootoutTarget: bootoutTarget,
             forwardedArguments: forwardedArguments)
         else {
-            self.logger.error("Could not spawn the trusted replacement")
-            return false
+            return .failed(supervisor: supervisor)
         }
 
+        let timeoutMilliseconds = self.replacementHandoffPolicy.timeoutMilliseconds(
+            loadAverage: self.currentSystemLoadAverage(),
+            activeProcessorCount: processInfo.activeProcessorCount)
         Task { @MainActor in
             let handoffStatus = await Task.detached(priority: .utility) {
-                self.awaitReplacementHandoff(on: spawned.readyDescriptor)
+                self.awaitReplacementHandoff(
+                    on: spawned.readyDescriptor,
+                    timeoutMilliseconds: timeoutMilliseconds)
             }.value
             Darwin.close(spawned.readyDescriptor)
             guard handoffStatus == "READY" else {
@@ -1014,18 +1102,115 @@ extension ApplicationRelocator {
                 await Task.detached(priority: .utility) {
                     self.reapProcess(spawned.processIdentifier)
                 }.value
-                self.logger.error("Trusted replacement did not complete its authenticated handoff")
-                self.bundleReplacementHandoffInProgress = false
-                self.bundleReplacementCheckPending = true
-                try? await Task.sleep(for: .seconds(1))
-                self.bundleDirectoryDidChange()
+                await self.handleReplacementHandoffFailure(
+                    attempt: attempt,
+                    targetCodeDirectoryHash: codeDirectoryHash,
+                    supervisor: supervisor,
+                    reason: "Trusted replacement handoff timed out after \(timeoutMilliseconds) ms")
                 return
             }
             self.cancelSupervisorRestorationWatcher()
             TerminationSignalWatcher.scheduleExitFailsafe()
             NSApp.terminate(nil)
         }
-        return true
+        return .scheduled
+    }
+
+    private static func handleReplacementHandoffFailure(
+        attempt: Int,
+        targetCodeDirectoryHash: Data,
+        supervisor: KeepAliveSupervisor?,
+        reason: String) async
+    {
+        let action = self.replacementHandoffPolicy.failureAction(
+            failedAttempt: attempt,
+            hasKeepAliveSupervisor: supervisor != nil)
+        if action.isTerminal,
+           await self.shouldContinueReplacementRecovery(afterFailedTarget: targetCodeDirectoryHash)
+        {
+            self.bundleReplacementHandoffInProgress = false
+            self.bundleReplacementCheckPending = true
+            self.bundleDirectoryDidChange()
+            return
+        }
+        switch action {
+        case let .retry(delay):
+            self.bundleReplacementCheckPending = true
+            let maximumAttempts = self.replacementHandoffPolicy.maximumAttempts
+            self.logger.error(
+                "Replacement handoff failed: \(reason, privacy: .public); attempt \(attempt)/\(maximumAttempts)")
+            do {
+                try await Task.sleep(for: delay)
+            } catch {
+                return
+            }
+            guard self.bundleReplacementSnapshot != nil else { return }
+            self.bundleReplacementHandoffInProgress = false
+            self.bundleDirectoryDidChange()
+        case .stopMonitoring:
+            self.disableBundleReplacementMonitoring()
+            self.logger.critical(
+                """
+                \(reason, privacy: .public); stopped app replacement monitoring after \(attempt) attempts. \
+                Quit and reopen OpenClaw to load the installed replacement.
+                """)
+        case .terminateForSupervisor:
+            guard let supervisor, self.startSupervisorRestorationWatcher(supervisor) else {
+                self.disableBundleReplacementMonitoring()
+                self.logger.critical(
+                    """
+                    \(reason, privacy: .public); could not schedule verified KeepAlive recovery. \
+                    Stopped app replacement monitoring after \(attempt) attempts.
+                    """)
+                return
+            }
+            self.disableBundleReplacementMonitoring()
+            self.logger.critical(
+                """
+                \(reason, privacy: .public); exiting after \(attempt) attempts so verified KeepAlive supervisor \
+                \(supervisor.label, privacy: .public) can restart the installed app.
+                """)
+            TerminationSignalWatcher.scheduleExitFailsafe()
+            NSApp.terminate(nil)
+        }
+    }
+
+    private static func shouldContinueReplacementRecovery(afterFailedTarget failedTargetHash: Data) async -> Bool {
+        guard self.bundleReplacementCheckPending,
+              let snapshot = self.bundleReplacementSnapshot
+        else { return false }
+        self.bundleReplacementCheckPending = false
+        let evaluation = await Task.detached(priority: .utility) {
+            self.replacementEvaluationOnDisk(for: snapshot)
+        }.value
+        if self.bundleReplacementCheckPending { return true }
+        return self.shouldContinueReplacementRecovery(
+            afterFailedTarget: failedTargetHash,
+            latestAction: evaluation.action,
+            latestTargetHash: evaluation.launchCodeDirectoryHash)
+    }
+
+    nonisolated static func shouldContinueReplacementRecovery(
+        afterFailedTarget failedTargetHash: Data,
+        latestAction: ReplacementAction,
+        latestTargetHash: Data?) -> Bool
+    {
+        switch latestAction {
+        case .unchanged, .waitForTrustedReplacement:
+            true
+        case .relaunch:
+            latestTargetHash != failedTargetHash
+        }
+    }
+
+    private static func disableBundleReplacementMonitoring() {
+        self.bundleReplacementSource?.cancel()
+        self.bundleReplacementSource = nil
+        self.bundleReplacementSnapshot = nil
+        self.bundleReplacementCheckPending = false
+        self.bundleReplacementHandoffInProgress = false
+        self.bundleReplacementHandoffAttempt = 0
+        self.bundleReplacementHandoffTargetHash = nil
     }
 
     private static func spawnReplacement(
@@ -1137,9 +1322,17 @@ extension ApplicationRelocator {
         return (processIdentifier, readDescriptor)
     }
 
-    private nonisolated static func awaitReplacementHandoff(on descriptor: Int32) -> String? {
+    private nonisolated static func currentSystemLoadAverage() -> Double? {
+        var loadAverage = 0.0
+        return getloadavg(&loadAverage, 1) == 1 ? loadAverage : nil
+    }
+
+    private nonisolated static func awaitReplacementHandoff(
+        on descriptor: Int32,
+        timeoutMilliseconds: Int32) -> String?
+    {
         var event = pollfd(fd: descriptor, events: Int16(POLLIN | POLLHUP), revents: 0)
-        guard poll(&event, 1, 10000) > 0 else { return nil }
+        guard poll(&event, 1, timeoutMilliseconds) > 0 else { return nil }
         var bytes = [UInt8](repeating: 0, count: 16)
         let count = bytes.withUnsafeMutableBytes { buffer in
             Darwin.read(descriptor, buffer.baseAddress, buffer.count)

--- a/apps/macos/Sources/OpenClaw/ApplicationRelocator.swift
+++ b/apps/macos/Sources/OpenClaw/ApplicationRelocator.swift
@@ -1176,9 +1176,9 @@ extension ApplicationRelocator {
     }
 
     private static func shouldContinueReplacementRecovery(afterFailedTarget failedTargetHash: Data) async -> Bool {
-        guard self.bundleReplacementCheckPending,
-              let snapshot = self.bundleReplacementSnapshot
-        else { return false }
+        guard let snapshot = self.bundleReplacementSnapshot else { return false }
+        // The coalescing bit can be cleared after an event arrives during the
+        // earlier async evaluation. Terminal actions always revalidate the disk.
         self.bundleReplacementCheckPending = false
         let evaluation = await Task.detached(priority: .utility) {
             self.replacementEvaluationOnDisk(for: snapshot)

--- a/apps/macos/Tests/OpenClawIPCTests/ApplicationRelocatorTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/ApplicationRelocatorTests.swift
@@ -222,6 +222,66 @@ struct ApplicationRelocatorTests {
     }
 
     @Test
+    func `replacement handoff retries back off and stop after three attempts`() {
+        let policy = ApplicationRelocator.replacementHandoffPolicy
+
+        #expect(policy.maximumAttempts == 3)
+        #expect(policy.failureAction(
+            failedAttempt: 1,
+            hasKeepAliveSupervisor: false
+        ) == .retry(after: .seconds(2)))
+        #expect(policy.failureAction(
+            failedAttempt: 2,
+            hasKeepAliveSupervisor: false
+        ) == .retry(after: .seconds(4)))
+        #expect(policy.failureAction(
+            failedAttempt: 3,
+            hasKeepAliveSupervisor: false
+        ) == .stopMonitoring)
+        #expect(policy.failureAction(
+            failedAttempt: 3,
+            hasKeepAliveSupervisor: true
+        ) == .terminateForSupervisor)
+    }
+
+    @Test
+    func `replacement handoff timeout scales with system load`() {
+        let policy = ApplicationRelocator.replacementHandoffPolicy
+
+        #expect(policy.timeoutMilliseconds(loadAverage: nil, activeProcessorCount: 12) == 15000)
+        #expect(policy.timeoutMilliseconds(loadAverage: 12, activeProcessorCount: 12) == 15000)
+        #expect(policy.timeoutMilliseconds(loadAverage: 24, activeProcessorCount: 12) == 30000)
+        #expect(policy.timeoutMilliseconds(loadAverage: 100, activeProcessorCount: 12) == 60000)
+        #expect(policy.timeoutMilliseconds(loadAverage: 100, activeProcessorCount: 0) == 15000)
+    }
+
+    @Test
+    func `replacement arriving during final handoff gets a fresh recovery pass`() {
+        let failedTarget = Data([10])
+
+        #expect(!ApplicationRelocator.shouldContinueReplacementRecovery(
+            afterFailedTarget: failedTarget,
+            latestAction: .relaunch,
+            latestTargetHash: failedTarget
+        ))
+        #expect(ApplicationRelocator.shouldContinueReplacementRecovery(
+            afterFailedTarget: failedTarget,
+            latestAction: .relaunch,
+            latestTargetHash: Data([11])
+        ))
+        #expect(ApplicationRelocator.shouldContinueReplacementRecovery(
+            afterFailedTarget: failedTarget,
+            latestAction: .waitForTrustedReplacement,
+            latestTargetHash: nil
+        ))
+        #expect(ApplicationRelocator.shouldContinueReplacementRecovery(
+            afterFailedTarget: failedTarget,
+            latestAction: .unchanged,
+            latestTargetHash: nil
+        ))
+    }
+
+    @Test
     func `unauthenticated replacement marker cannot bypass duplicate launch rejection`() {
         let forgedHandoff = [
             "OPENCLAW_REPLACEMENT_SOURCE_BUNDLE": "/Applications/OpenClaw.app",


### PR DESCRIPTION
Closes #114955

## What Problem This Solves

Fixes an issue where users replacing a running signed macOS app under heavy system load could trigger an endless launch-and-kill cycle when the replacement did not complete its authenticated startup handoff within 10 seconds.

## Why This Change Was Made

The replacement owner now gives each signed bundle hash three total handoff attempts with exponential backoff and a readiness deadline that scales from 15 to 60 seconds using load per active processor. Exhaustion stops monitoring once; when a verified KeepAlive LaunchAgent owns the app, OpenClaw schedules restoration after the old process exits and deliberately yields restart ownership to that supervisor. A new bundle arriving during the final handoff is always re-evaluated from disk with a fresh budget instead of inheriting the failed target's exhaustion.

The existing DEBUG monitor gate remains intentional: release builds always monitor, while debug builds must opt in with `OPENCLAW_MONITOR_APP_REPLACEMENT=1` so ordinary development rebuilds do not relaunch the app unexpectedly.

Maintainer decision: the macOS owner accepts the three-attempt bounded recovery contract for installed app replacement, with verified-supervisor takeover or explicit manual restart as the terminal outcomes.

## User Impact

Busy Macs no longer amplify a slow replacement launch into a self-perpetuating retry storm. Supervised installations recover through their verified LaunchAgent after the bounded budget, while unsupervised installations leave the old app running and log one actionable critical message asking the user to quit and reopen.

## Evidence

### Live signed-bundle behavior

Run on Peter's MacBook Pro with the current patched executable in a temporary Developer-ID-signed bundle (`ai.openclaw.mac.debug.handoffproof`, team `Y5PE65HELJ`), an isolated state directory, and a signed Mach-O replacement that deliberately withheld `READY`. The real OpenClaw app, service, state, and gateway were not touched.

Unsupervised terminal path under load average about 475 on 16 active CPUs:

```text
23:54:55 Relaunching trusted replacement (attempt 1/3)
23:55:55 handoff timed out after 60000 ms; attempt 1/3
23:55:57 Relaunching trusted replacement (attempt 2/3)
23:56:58 handoff timed out after 60000 ms; attempt 2/3
23:57:05 Relaunching trusted replacement (attempt 3/3)
23:58:05 stopped app replacement monitoring after 3 attempts. Quit and reopen OpenClaw...
```

The old parent PID `42338` remained running, the directory-monitor FD closed, and no fourth replacement process appeared during the following 70 seconds.

Verified KeepAlive terminal path used temporary LaunchAgent `ai.openclaw.mac.handoff-proof`:

```text
00:05:30 handoff timed out after 20000 ms; attempt 1/3
00:05:57 handoff timed out after 25000 ms; attempt 2/3
00:06:21 handoff timed out after 20000 ms; exiting after 3 attempts so verified KeepAlive supervisor ... can restart the installed app
```

Launchd changed the job from old parent PID `43878` to replacement PID `57713`, then reported `state = running`, `runs = 2`, and `last exit code = 0`. The running text image was the canonical replacement path `/tmp/.../supervised/OpenClaw.app/Contents/MacOS/OpenClaw`, signed as bundle identifier `ai.openclaw.mac.debug.handoffproof`, CDHash `0568f69a69c0e53e460c54ac104aacaf3e948c7a`, team `Y5PE65HELJ`.

Cleanup: booted out only the temporary proof label, verified it was absent, stopped every proof PID, and moved the temporary plist and app roots to Trash.

### Automated proof

- macOS Swift 6.2 proof: `swift test --filter ApplicationRelocatorTests` — 24 tests passed, including retry/backoff, load-scaled timeout, and final-handoff target replacement coverage.
- Blacksmith Testbox `tbx_01kykkvvnece3a1qb7tat2szwx`: `corepack pnpm check:changed` — 5 Vitest shards passed (200 tests passed, 37 platform skips); native state schema guard passed.
- `node --import tsx scripts/native-app-i18n.ts verify` — `changed=false`; Android and Apple inventories validated.
- SwiftFormat 0.62.1 and SwiftLint 0.65.0 on the two changed Swift files — clean.
- `git diff --check` — clean.
- Final focused Codex autoreview after terminal on-disk revalidation — no accepted/actionable findings.

AI-assisted: yes. The implementation and tests were produced with Codex and independently reviewed through the repository autoreview gate.
