### PR TITLE
fix(gateway): let crash-looping channels reach their give-up state

### DIFF
--- a/docs/gateway/health.md
+++ b/docs/gateway/health.md
@@ -40,6 +40,7 @@ health commands above for live connectivity checks.
 - `channels.<provider>.healthMonitor.enabled`: disable health-monitor restarts for a specific channel while leaving global monitoring enabled.
 - `channels.<provider>.accounts.<accountId>.healthMonitor.enabled`: multi-account override that wins over the channel-level setting.
 - These per-channel overrides apply to the built-in channels that expose them today: Discord, Google Chat, iMessage, IRC, Microsoft Teams, Signal, Slack, Telegram, and WhatsApp.
+- A crashing channel is recovered by its own auto-restart backoff first (`auto-restart attempt N/10` in the logs). The health monitor stays out of the way until that ladder ends with `giving up after 10 restart attempts`, then takes over as the last restart owner.
 
 ## Uptime monitoring
 

--- a/src/gateway/channel-health-monitor.test.ts
+++ b/src/gateway/channel-health-monitor.test.ts
@@ -22,6 +22,7 @@ function createMockChannelManager(overrides?: Partial<ChannelManager>): ChannelM
     markChannelLoggedOut: vi.fn(),
     isHealthMonitorEnabled: vi.fn(() => true),
     isManuallyStopped: vi.fn(() => false),
+    isAutoRestartScheduled: vi.fn(() => false),
     resetRestartAttempts: vi.fn(),
     ...overrides,
   };
@@ -589,6 +590,38 @@ describe("channel-health-monitor", () => {
 
     expect(manager.stopChannel).toHaveBeenCalledTimes(1);
     expect(manager.startChannel).toHaveBeenCalledTimes(2);
+    monitor.stop();
+  });
+
+  it("defers to the channel supervisor while its own auto-restart is scheduled", async () => {
+    let autoRestartScheduled = true;
+    const manager = createSnapshotManager(
+      {
+        whatsapp: {
+          default: {
+            ...managedStoppedAccount("Another process owns this WhatsApp connection."),
+            linked: true,
+            restartPending: true,
+            reconnectAttempts: 5,
+          },
+        },
+      },
+      { isAutoRestartScheduled: vi.fn(() => autoRestartScheduled) },
+    );
+
+    const monitor = await startAndRunCheck(manager);
+    expect(manager.startChannel).not.toHaveBeenCalled();
+    // Deferring must not burn the attempt ladder the supervisor is still walking.
+    expect(manager.resetRestartAttempts).not.toHaveBeenCalled();
+
+    await advanceHealthCheck();
+    expect(manager.startChannel).not.toHaveBeenCalled();
+
+    // Once the supervisor gives up it no longer owns recovery, so the monitor
+    // becomes the account's last restart owner again.
+    autoRestartScheduled = false;
+    await advanceHealthCheck();
+    expect(manager.startChannel).toHaveBeenCalledWith("whatsapp", "default");
     monitor.stop();
   });
 

--- a/src/gateway/channel-health-monitor.ts
+++ b/src/gateway/channel-health-monitor.ts
@@ -149,6 +149,13 @@ export function startChannelHealthMonitor(deps: ChannelHealthMonitorDeps): Chann
             );
             continue;
           }
+          // The channel supervisor owns the account while its own backoff restart
+          // is in flight. Restarting here cannot start anything (the supervisor
+          // still holds the account task) and only resets the attempt ladder, so
+          // a crash-looping channel would never reach its give-up terminal state.
+          if (channelManager.isAutoRestartScheduled(channelId as ChannelId, accountId)) {
+            continue;
+          }
 
           const record = restartRecords.get(key) ?? {
             lastRestartAt: 0,

--- a/src/gateway/server-channels.test.ts
+++ b/src/gateway/server-channels.test.ts
@@ -322,6 +322,33 @@ describe("server-channels auto restart", () => {
     expect(startAccount).toHaveBeenCalledTimes(11);
   });
 
+  it("claims auto-restart ownership between crash-loop attempts", async () => {
+    const startAccount = vi.fn(async () => {});
+    installTestRegistry(createTestPlugin({ startAccount }));
+    const manager = createManager();
+
+    await manager.startChannels();
+    await flushMicrotasks();
+
+    // The health monitor must see the supervisor own recovery here, otherwise it
+    // resets the attempt ladder and the give-up below never happens.
+    expect(manager.isAutoRestartScheduled("discord", DEFAULT_ACCOUNT_ID)).toBe(true);
+
+    // A competing restart request cannot help while the supervisor holds the
+    // account task; it returns without booting anything.
+    const startsBeforeRequest = startAccount.mock.calls.length;
+    await manager.startChannel("discord", DEFAULT_ACCOUNT_ID);
+    expect(startAccount).toHaveBeenCalledTimes(startsBeforeRequest);
+
+    await advanceTimersUntil(
+      () => startAccount.mock.calls.length >= 11,
+      "expected crash-loop restarts to reach the maximum attempt cap",
+      { stepMs: 10, maxMs: 500 },
+    );
+
+    expect(manager.isAutoRestartScheduled("discord", DEFAULT_ACCOUNT_ID)).toBe(false);
+  });
+
   it("aborts the crashed task's signal before starting its replacement", async () => {
     const signals: AbortSignal[] = [];
     const startAccount = vi.fn(async (ctx: ChannelGatewayContext<TestAccount>) => {

--- a/src/gateway/server-channels.ts
+++ b/src/gateway/server-channels.ts
@@ -254,6 +254,7 @@ export type ChannelManager = {
   isAmbientAutostartSuppressed: (channelId: string) => boolean;
   markChannelLoggedOut: (channelId: ChannelId, cleared: boolean, accountId?: string) => void;
   isManuallyStopped: (channelId: ChannelId, accountId: string) => boolean;
+  isAutoRestartScheduled: (channelId: ChannelId, accountId: string) => boolean;
   resetRestartAttempts: (channelId: ChannelId, accountId: string) => void;
   isHealthMonitorEnabled: (channelId: ChannelId, accountId: string) => boolean;
 };
@@ -276,6 +277,11 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
   const manuallyStopped = new Set<string>();
   const recoveryStopTimedOut = new Set<string>();
   const recoveryStartRequested = new Set<string>();
+  // Accounts whose crash recovery is already owned by the retry supervisor below
+  // (backoff sleep plus its replacement start). `restartPending` cannot answer
+  // this: the timed-out-stop recovery sets it too, and that one needs the health
+  // monitor to keep driving it.
+  const pendingAutoRestarts = new Set<string>();
   let autostartSuppression: ChannelAutostartSuppression | null = null;
   let ambientAutostartSuppressedChannelIds = new Set(
     opts.ambientAutostartSuppressedChannelIds ?? [],
@@ -873,6 +879,7 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
                 restartPending: true,
                 reconnectAttempts: restart.attempts,
               });
+              pendingAutoRestarts.add(rKey);
               try {
                 await sleepWithAbort(retry.delayMs, retry.signal);
                 if (manuallyStopped.has(rKey)) {
@@ -893,6 +900,8 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
                 });
               } catch {
                 // abort or startup failure — next crash will retry
+              } finally {
+                pendingAutoRestarts.delete(rKey);
               }
             })
             .finally(() => {
@@ -1216,7 +1225,11 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
     return manuallyStopped.has(restartKey(channelId, accountId));
   };
 
-  const resetRestartAttemptsForTest = (channelId: ChannelId, accountId: string): void => {
+  const isAutoRestartScheduled = (channelId: ChannelId, accountId: string): boolean => {
+    return pendingAutoRestarts.has(restartKey(channelId, accountId));
+  };
+
+  const resetRestartAttempts = (channelId: ChannelId, accountId: string): void => {
     restarts.delete(restartKey(channelId, accountId));
   };
 
@@ -1236,7 +1249,8 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
       ambientAutostartSuppressedChannelIds.has(channelId),
     markChannelLoggedOut,
     isManuallyStopped: isManuallyStoppedFlag,
-    resetRestartAttempts: resetRestartAttemptsForTest,
+    isAutoRestartScheduled,
+    resetRestartAttempts,
     isHealthMonitorEnabled,
   };
 }

--- a/src/gateway/server/readiness.test.ts
+++ b/src/gateway/server/readiness.test.ts
@@ -40,6 +40,7 @@ function createManager(snapshot: ChannelRuntimeSnapshot): ChannelManager {
     markChannelLoggedOut: vi.fn(),
     isHealthMonitorEnabled: vi.fn(() => true),
     isManuallyStopped: vi.fn(() => false),
+    isAutoRestartScheduled: vi.fn(() => false),
     resetRestartAttempts: vi.fn(),
   };
 }


### PR DESCRIPTION
Related: #110802
Related: #111572

## What Problem This Solves

Fixes an issue where operators running a channel that keeps crashing (observed on a live gateway with WhatsApp) would see the channel reconnect forever, with `health-monitor: restarting (reason: stopped)` repeating every 15 minutes, instead of the channel giving up and staying stopped for operator attention.

Two independent restart owners were fighting over the same account. The channel's own supervised auto-restart ladder (`auto-restart attempt N/10`, exponential backoff up to 5 minutes, then `giving up after 10 restart attempts`) sleeps between attempts, during which the account snapshot reports `running: false`. The gateway health monitor read that as `not-running` and force-restarted the account.

That "restart" did nothing useful: the supervisor still owned the account task, so the start returned early without booting anything. Its only real effect was `resetRestartAttempts`, which wipes the retry supervisor — so the next crash restarted the ladder at attempt 1. Because the monitor's cooldown (2 x 5-minute cycles) is shorter than the time the ladder needs to walk to attempt 10 (~25 minutes of backoff alone), the give-up terminal state was unreachable by construction for any channel that keeps crashing.

## Why This Change Was Made

The channel supervisor is the owner of crash recovery while its backoff restart is in flight; the health monitor is the owner of last resort once the supervisor has given up. This change makes that boundary explicit: `ChannelManager` now reports `isAutoRestartScheduled`, tracked around the supervisor's backoff sleep and its replacement start, and the health monitor skips those accounts entirely — no restart, no attempt-ladder reset, no cooldown or hourly-budget consumption.

`restartPending` could not answer this question: the timed-out-stop recovery path sets it too, and that one genuinely needs the health monitor to keep driving it (the existing `continuingPendingRestart` cooldown bypass). The new flag is set only by the supervisor's own retry branch, so the two recovery owners stay distinguishable.

Also renamed `resetRestartAttemptsForTest` to `resetRestartAttempts`: it is production code called by the health monitor, not a test hook.

Sibling restart surfaces were checked and are unaffected. Config reload (`src/gateway/server-reload-channel-restart.ts`) and the `channels.start`/`channels.stop` RPCs always stop the account first, which aborts the supervisor's retry signal and clears the new flag through its `finally`, so an operator- or config-driven takeover still wins immediately.

#110802 independently reports the "health monitor logs restarting but nothing restarts" half of this on Telegram. That report also describes an account whose supervisor stops retrying entirely, which this change does not address, so it stays open. #111572 tracks the separate timed-out-stop wedge; the monitor only reaches `stopChannel` for an account that is running, which is never true while the supervisor sleeps, so that recovery path keeps its existing cooldown bypass.

## User Impact

A channel that crash-loops now walks its full backoff ladder and stops with `giving up after 10 restart attempts`, which is the intended, visible failure state. Operators see the real diagnosis instead of an endless reconnect loop, and the health monitor no longer logs restarts it did not perform. For transport-level channels such as WhatsApp this also removes an unbounded stream of reconnect/handshake cycles against a session that cannot connect.

No config, protocol, or storage surface changes. Healthy channels, the `disconnected`/`stale-socket`/`stuck` restart paths, and the timed-out-stop recovery path are unchanged.

## Evidence

Live gateway logs (`/tmp/openclaw/openclaw-2026-07-2*.log`, read-only inspection, four rotations covering 2026-07-27 and 2026-07-28):

- 198 `health-monitor: restarting (reason: stopped)` lines across `whatsapp:default`, `imessage:default`, and `discord:default`, and **zero** `giving up after N restart attempts` lines.
- Attempt histogram from the busiest rotation: `1/10` x52, `2/10` x40, `3/10` x38, `4/10` x38, `5/10` x30, `6/10` x18, `7/10` x14, `8/10` x2 — 52 ladders started, none finished. Every reset follows a monitor "restart".
- The monitor's restart provably started nothing. Three consecutive WhatsApp cycles: exit `00:05:25` + `in 86s` -> provider start `00:06:51`; exit `00:20:40` + `in 88s` -> start `00:22:08`; exit `00:35:55` + `in 83s` -> start `00:37:18`. Each start matches the supervisor's own scheduled backoff, not the monitor restart logged 10-45s earlier.

After-fix proof on a real gateway (Blacksmith Testbox `tbx_01kykpkht0pkkyhvr09jv4n2ap`, this branch built from source, isolated `OPENCLAW_STATE_DIR`, one Telegram account with an invalid bot token so `startAccount` throws on every boot, `openclaw gateway run` for 35 minutes). The health monitor ran with its shipped defaults (`interval: 300s, startup-grace: 60s`), so five monitor checks landed inside supervisor backoff windows and none of them restarted the account:

```
06:37:21 [health-monitor] started (interval: 300s, startup-grace: 60s, channel-connect-grace: 120s)
06:37:23 [telegram] [default] auto-restart attempt 1/10 in 5s
06:37:29 [telegram] [default] auto-restart attempt 2/10 in 10s
06:37:39 [telegram] [default] auto-restart attempt 3/10 in 22s
06:38:01 [telegram] [default] auto-restart attempt 4/10 in 40s
06:38:41 [telegram] [default] auto-restart attempt 5/10 in 84s
06:40:05 [telegram] [default] auto-restart attempt 6/10 in 175s
06:43:00 [telegram] [default] auto-restart attempt 7/10 in 300s
06:48:00 [telegram] [default] auto-restart attempt 8/10 in 300s
06:53:00 [telegram] [default] auto-restart attempt 9/10 in 300s
06:58:00 [telegram] [default] auto-restart attempt 10/10 in 300s
07:03:00 [telegram] [default] giving up after 10 restart attempts
07:03:25 [health-monitor] [telegram:default] health-monitor: restarting (reason: gave-up)
07:03:25 [telegram] [default] auto-restart attempt 1/10 in 5s
```

Run totals: 1 give-up, 1 health-monitor restart, and that restart's reason is `gave-up`. Both are unreachable on `main`: there the monitor fires `reason: stopped` inside the first backoff window and resets the ladder, which is exactly the 198-to-0 ratio in the production logs above. The handoff is also visible — the monitor waited for the supervisor to release ownership and took over 25 seconds later on its next check.

Focused tests (all green):

- `node scripts/run-vitest.mjs src/gateway/channel-health-monitor.test.ts` — 47 passed, including the new "defers to the channel supervisor while its own auto-restart is scheduled" case (no restart and no attempt-ladder reset while scheduled; restart resumes once the supervisor releases ownership).
- `node scripts/run-vitest.mjs src/gateway/server-channels.test.ts` — 76 passed, including the new "claims auto-restart ownership between crash-loop attempts" case, which also asserts that a competing start request boots nothing while the supervisor holds the account task.
- `node scripts/run-vitest.mjs src/gateway/server/readiness.test.ts src/gateway/channel-health-policy.test.ts` — 42 passed.

Negative control: with the ownership guard removed from the monitor, `channel-health-monitor.test.ts` fails exactly where expected — `1 failed | 46 passed`, `defers to the channel supervisor while its own auto-restart is scheduled`, `expected "vi.fn()" to not be called at all, but actually been called 1 times`.

Hosted CI on `9d8425e` completed green (run 30334088496).
