### PR TITLE
fix(config): guard config unset against deleting plugin-install records

### DIFF
--- a/src/cli/config-cli-runner.ts
+++ b/src/cli/config-cli-runner.ts
@@ -141,6 +141,18 @@ export function assertConfigPathIsNotAutoManaged(path: PathSegment[]): void {
   }
 }
 
+/**
+ * Rejects a mutation targeting a plugin-index-managed record (`plugins.installs.*`). Mirrors the
+ * guard runConfigOperations enforces for set/patch/--dry-run, but as a path check so the real
+ * `config unset` path (which writes via replaceConfigFile, bypassing runConfigOperations) enforces
+ * it too instead of silently deleting plugin-index-managed records.
+ */
+export function assertConfigPathIsNotPluginInstallRecord(path: PathSegment[]): void {
+  if (pathStartsWith(path, PLUGIN_INSTALL_RECORD_PATH_PREFIX)) {
+    throw new Error(formatPluginInstallConfigSetError());
+  }
+}
+
 function pruneInactiveGatewayAuthCredentials(params: {
   root: Record<string, unknown>;
   operations: ConfigSetOperation[];

--- a/src/cli/config-cli.test.ts
+++ b/src/cli/config-cli.test.ts
@@ -911,6 +911,22 @@ describe("config cli", () => {
       );
     });
 
+    it("rejects deleting plugin install records via real config unset (not just --dry-run)", async () => {
+      const resolved = {
+        plugins: {
+          installs: { "openclaw-web-search": { spec: "@ollama/openclaw-web-search@0.2.2" } },
+        },
+      } as unknown as OpenClawConfig;
+      setSnapshot(resolved, resolved);
+
+      await expect(
+        runConfigCommand(["config", "unset", 'plugins.installs["openclaw-web-search"]']),
+      ).rejects.toThrow(ExitError);
+
+      expect(mockWriteConfigFile).not.toHaveBeenCalled();
+      expectErrorIncludes("openclaw plugins install <spec>");
+    });
+
     it("rejects plugin install record config updates", async () => {
       await expect(
         runConfigCommand([

--- a/src/cli/config-cli.ts
+++ b/src/cli/config-cli.ts
@@ -38,6 +38,7 @@ import {
 } from "./config-cli-path.js";
 import {
   assertConfigPathIsNotAutoManaged,
+  assertConfigPathIsNotPluginInstallRecord,
   configApplyHintForOperations,
   handleConfigMutationError,
   runConfigOperations,
@@ -202,6 +203,7 @@ export async function runConfigUnset(opts: {
     }
     const parsedPath = parseConfigSetPath(opts.path);
     assertConfigPathIsNotAutoManaged(parsedPath);
+    assertConfigPathIsNotPluginInstallRecord(parsedPath);
     const snapshot = await loadValidConfig(runtime);
     // Mutate resolved config so runtime defaults never leak into the authored file.
     const next = structuredClone(snapshot.resolved) as Record<string, unknown>;


### PR DESCRIPTION
## What Problem This Solves

`openclaw config unset plugins.installs.<id>` silently **deletes a plugin's install record** — and `openclaw config unset plugins.installs` wipes them all — even though `config set`, `config patch`, and even `config unset --dry-run` all **reject** touching `plugins.installs.*` (plugin-index-managed records). So the dry-run says it's blocked, but the real command quietly performs the destructive change.

## Why This Change Was Made

`config set`/`patch` (and `unset --dry-run`) route through `runConfigOperations`, which guards `plugins.installs.*`:

```ts
if (operations.some(({ requestedPath }) => pathStartsWith(requestedPath, PLUGIN_INSTALL_RECORD_PATH_PREFIX))) {
  throw new Error(formatPluginInstallConfigSetError());
}
```

But the real (non-dry-run) `config unset` path (`src/cli/config-cli.ts`, `runConfigUnset`) writes via `replaceConfigFile` **directly**, never calling `runConfigOperations` — so it bypasses that guard entirely. `runConfigUnset` already has an early sibling guard for auto-managed `meta.*` paths (`assertConfigPathIsNotAutoManaged`); the plugin-install guard was simply missing.

## User Impact

`config unset plugins.installs.<id>` (and `plugins.installs`) now fails fast with the same "manage plugins via `openclaw plugins install/update`" message that `set`/`patch`/`--dry-run` produce, instead of silently corrupting the plugin index. No change to any non-`plugins.installs` unset.

## Evidence

Reproduce-first test added to `config-cli.test.ts` (beside the existing `set`-rejection test): with a `plugins.installs["openclaw-web-search"]` record present, a real `config unset` of it must reject and must not write.

Before (fix reverted) — the unset silently succeeds and writes the config with the record removed:
```
× rejects deleting plugin install records via real config unset (not just --dry-run)
  (unset resolves without throwing; mockWriteConfigFile was called)
```
After (fix applied):
```
Test Files  1 passed (1)
     Tests  146 passed (146)
```

## The fix

An exported early path-guard `assertConfigPathIsNotPluginInstallRecord(path)` in `config-cli-runner.ts` (reusing the existing `PLUGIN_INSTALL_RECORD_PATH_PREFIX` + `pathStartsWith`), called in `runConfigUnset` right beside the existing `assertConfigPathIsNotAutoManaged`.

**Note for maintainers:** guards the real unset path before any config load, matching the sibling auto-managed guard and the set/patch/dry-run behavior. Minimal.
