### PR TITLE
fix(macos): stop in-place update from respawning itself forever

### DIFF
--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -25843,7 +25843,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 6404,
+      "line": 6407,
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "No chat messages yet",
       "surface": "apple",
@@ -25851,7 +25851,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 6466,
+      "line": 6469,
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "Connecting…",
       "surface": "apple",
@@ -25859,7 +25859,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 6466,
+      "line": 6469,
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "Reconnecting…",
       "surface": "apple",
@@ -25867,7 +25867,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 8813,
+      "line": 8816,
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "Approval",
       "surface": "apple",
@@ -25875,7 +25875,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 8813,
+      "line": 8816,
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "This approval was already",
       "surface": "apple",
@@ -25883,7 +25883,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 8819,
+      "line": 8822,
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "This approval was already set to Always Allow.",
       "surface": "apple",
@@ -25891,7 +25891,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 8820,
+      "line": 8823,
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "Approval set to Always Allow.",
       "surface": "apple",
@@ -25899,7 +25899,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 10155,
+      "line": 10193,
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "\\(urlText.prefix(500))…",
       "surface": "apple",

--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -29859,7 +29859,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 217,
+      "line": 224,
       "path": "apps/macos/Sources/OpenClaw/ApplicationRelocator.swift",
       "source": "OpenClaw couldn’t be installed in Applications. Move it there manually, then open that copy.",
       "surface": "apple",
@@ -29867,7 +29867,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 907,
+      "line": 927,
       "path": "apps/macos/Sources/OpenClaw/ApplicationRelocator.swift",
       "source": "Replace the older OpenClaw in Applications?",
       "surface": "apple",
@@ -29875,7 +29875,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 908,
+      "line": 928,
       "path": "apps/macos/Sources/OpenClaw/ApplicationRelocator.swift",
       "source": "Install OpenClaw in Applications?",
       "surface": "apple",
@@ -29883,7 +29883,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 910,
+      "line": 930,
       "path": "apps/macos/Sources/OpenClaw/ApplicationRelocator.swift",
       "source": "This copy is newer than the installed app. OpenClaw will replace it and reopen from Applications.",
       "surface": "apple",
@@ -29891,7 +29891,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 911,
+      "line": 931,
       "path": "apps/macos/Sources/OpenClaw/ApplicationRelocator.swift",
       "source": "OpenClaw will copy itself to Applications and reopen there so updates and launch at login stay reliable.",
       "surface": "apple",
@@ -29899,7 +29899,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 913,
+      "line": 933,
       "path": "apps/macos/Sources/OpenClaw/ApplicationRelocator.swift",
       "source": "Install and Relaunch",
       "surface": "apple",
@@ -29907,7 +29907,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 913,
+      "line": 933,
       "path": "apps/macos/Sources/OpenClaw/ApplicationRelocator.swift",
       "source": "Replace and Relaunch",
       "surface": "apple",
@@ -29915,7 +29915,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 938,
+      "line": 958,
       "path": "apps/macos/Sources/OpenClaw/ApplicationRelocator.swift",
       "source": "OpenClaw is installed in Applications, but couldn’t reopen automatically. Open it there manually.",
       "surface": "apple",

--- a/apps/macos/README.md
+++ b/apps/macos/README.md
@@ -61,6 +61,20 @@ DISABLE_LIBRARY_VALIDATION=1 scripts/package-mac-app.sh
 This adds `com.apple.security.cs.disable-library-validation` to app entitlements.
 Use for local dev only; keep off for release builds.
 
+## Swift tests fail to load Sparkle (dev only)
+
+`swift test` can build fine and then die in `dlopen` with
+`Library not loaded: @rpath/Sparkle.framework/Versions/B/Sparkle`. Setting
+`DYLD_FRAMEWORK_PATH` does **not** fix it: SwiftPM runs the bundle through
+`swiftpm-xctest-helper` inside Xcode, which is SIP-signed, so dyld strips every
+`DYLD_*` variable from its environment. Put the framework on a path dyld already
+searches instead:
+
+```bash
+ln -sfn ../Sparkle.framework \
+  apps/macos/.build/out/Products/Debug/PackageFrameworks/Sparkle.framework
+```
+
 ## Useful env flags
 
 - `SIGN_IDENTITY="Apple Development: Your Name (TEAMID)"`

--- a/apps/macos/Sources/OpenClaw/ApplicationRelocator.swift
+++ b/apps/macos/Sources/OpenClaw/ApplicationRelocator.swift
@@ -59,6 +59,12 @@ enum ApplicationRelocator {
         case relaunch
     }
 
+    enum ReplacementHandoffOutcome: Equatable, Sendable {
+        case ready
+        case rejected
+        case unresponsive
+    }
+
     enum RelaunchStrategy: Equatable, Sendable {
         case openAfterTermination
         case externalSupervisor
@@ -105,6 +111,7 @@ enum ApplicationRelocator {
     private static var bundleReplacementRecoveryTask: Task<Void, Never>?
     private static var bundleReplacementCheckPending = false
     private static var bundleReplacementHandoffInProgress = false
+    private static var replacementHandoffRetry = ReplacementHandoffRetryPolicy()
     private static var inheritedReplacementSupervisor: KeepAliveSupervisor?
     private static var supervisorRestorationWatcher: Process?
     private static var authenticatedReplacementSourceBundleURL: URL?
@@ -543,6 +550,9 @@ extension ApplicationRelocator {
         self.bundleReplacementSnapshot = nil
         self.bundleReplacementCheckPending = false
         self.bundleReplacementHandoffInProgress = false
+        // Rearming monitoring rebuilds the snapshot this policy bounds, so a stale
+        // give-up must not survive into the new watch.
+        self.replacementHandoffRetry = ReplacementHandoffRetryPolicy()
 
         let bundleURL = monitoredBundleURL.standardizedFileURL
         guard bundleURL.pathExtension == "app",
@@ -634,6 +644,13 @@ extension ApplicationRelocator {
                         try? await Task.sleep(for: .milliseconds(250))
                         continue
                     }
+                    guard self.replacementHandoffRetry.allowsAttempt(for: launchCodeDirectoryHash) else {
+                        // Terminal for this replacement. Drop the pending flag too, or the
+                        // defer below rearms and revalidates the whole bundle on every
+                        // later directory event.
+                        self.bundleReplacementCheckPending = false
+                        return
+                    }
                     self.bundleReplacementCheckPending = false
                     self.logger.notice("Installed app changed; relaunching trusted replacement")
                     self.bundleReplacementHandoffInProgress = true
@@ -642,9 +659,12 @@ extension ApplicationRelocator {
                         launchReference: launchReference,
                         codeDirectoryHash: launchCodeDirectoryHash)
                     if !scheduled {
-                        self.bundleReplacementHandoffInProgress = false
-                        try? await Task.sleep(for: .seconds(1))
-                        continue
+                        // A spawn failure is a failed attempt too, so it spends the same
+                        // budget. Its rearm rides this task's defer, because the retry's
+                        // own bundleDirectoryDidChange call no-ops while we still own
+                        // bundleReplacementRecoveryTask.
+                        await self.recordFailedReplacementHandoff(codeDirectoryHash: launchCodeDirectoryHash)
+                        return
                     }
                     return
                 }
@@ -1005,20 +1025,20 @@ extension ApplicationRelocator {
         }
 
         Task { @MainActor in
-            let handoffStatus = await Task.detached(priority: .utility) {
-                self.awaitReplacementHandoff(on: spawned.readyDescriptor)
+            let handoffOutcome = await Task.detached(priority: .utility) {
+                self.awaitReplacementHandoff(
+                    on: spawned.readyDescriptor,
+                    childProcessIdentifier: spawned.processIdentifier)
             }.value
             Darwin.close(spawned.readyDescriptor)
-            guard handoffStatus == "READY" else {
+            guard handoffOutcome == .ready else {
                 Darwin.kill(spawned.processIdentifier, SIGKILL)
                 await Task.detached(priority: .utility) {
                     self.reapProcess(spawned.processIdentifier)
                 }.value
-                self.logger.error("Trusted replacement did not complete its authenticated handoff")
-                self.bundleReplacementHandoffInProgress = false
-                self.bundleReplacementCheckPending = true
-                try? await Task.sleep(for: .seconds(1))
-                self.bundleDirectoryDidChange()
+                self.logger.error(
+                    "Trusted replacement handoff failed: \(String(describing: handoffOutcome), privacy: .public)")
+                await self.recordFailedReplacementHandoff(codeDirectoryHash: codeDirectoryHash)
                 return
             }
             self.cancelSupervisorRestorationWatcher()
@@ -1026,6 +1046,25 @@ extension ApplicationRelocator {
             NSApp.terminate(nil)
         }
         return true
+    }
+
+    private static func recordFailedReplacementHandoff(codeDirectoryHash: Data) async {
+        switch self.replacementHandoffRetry.recordFailure(for: codeDirectoryHash) {
+        case let .retry(delay):
+            // Hold the in-progress flag across the cooldown. Releasing it before the
+            // sleep lets a burst of directory events start the next attempt at once,
+            // skipping every backoff and burning the budget a transient failure needs.
+            try? await Task.sleep(for: delay)
+            self.bundleReplacementHandoffInProgress = false
+            self.bundleReplacementCheckPending = true
+            self.bundleDirectoryDidChange()
+        case .giveUp:
+            // Terminal: keep the current process running and stop rearming, so the
+            // user is never left without an app.
+            self.bundleReplacementHandoffInProgress = false
+            self.bundleReplacementCheckPending = false
+            self.logger.error("Abandoning replacement after repeated handoff failures")
+        }
     }
 
     private static func spawnReplacement(
@@ -1137,15 +1176,41 @@ extension ApplicationRelocator {
         return (processIdentifier, readDescriptor)
     }
 
-    private nonisolated static func awaitReplacementHandoff(on descriptor: Int32) -> String? {
-        var event = pollfd(fd: descriptor, events: Int16(POLLIN | POLLHUP), revents: 0)
-        guard poll(&event, 1, 10000) > 0 else { return nil }
-        var bytes = [UInt8](repeating: 0, count: 16)
-        let count = bytes.withUnsafeMutableBytes { buffer in
-            Darwin.read(descriptor, buffer.baseAddress, buffer.count)
+    nonisolated static func awaitReplacementHandoff(
+        on descriptor: Int32,
+        childProcessIdentifier: pid_t,
+        hangCeiling: Duration = .seconds(120)) -> ReplacementHandoffOutcome
+    {
+        let clock = ContinuousClock()
+        let deadline = clock.now.advanced(by: hangCeiling)
+        while clock.now < deadline {
+            var event = pollfd(fd: descriptor, events: Int16(POLLIN), revents: 0)
+            let pollResult = poll(&event, 1, 250)
+            if pollResult < 0 {
+                if errno == EINTR {
+                    continue
+                }
+                return .rejected
+            }
+            if pollResult > 0 {
+                var bytes = [UInt8](repeating: 0, count: 16)
+                let count = bytes.withUnsafeMutableBytes { buffer in
+                    Darwin.read(descriptor, buffer.baseAddress, buffer.count)
+                }
+                guard count > 0 else { return .rejected }
+                return String(bytes: bytes.prefix(count), encoding: .utf8) == "READY" ? .ready : .rejected
+            }
+
+            // The ceiling detects a wedged live child, not slow startup. A dead child
+            // is rejected promptly, while a healthy child retains the full ceiling.
+            if Darwin.kill(childProcessIdentifier, 0) < 0, errno == ESRCH {
+                return .rejected
+            }
         }
-        guard count > 0 else { return nil }
-        return String(bytes: bytes.prefix(count), encoding: .utf8)
+        if Darwin.kill(childProcessIdentifier, 0) < 0, errno == ESRCH {
+            return .rejected
+        }
+        return .unresponsive
     }
 
     private nonisolated static func reapProcess(_ processIdentifier: pid_t) {

--- a/apps/macos/Sources/OpenClaw/ReplacementHandoffRetryPolicy.swift
+++ b/apps/macos/Sources/OpenClaw/ReplacementHandoffRetryPolicy.swift
@@ -1,0 +1,44 @@
+import Foundation
+
+/// Bounds replacement handoff retries because each attempt launches the full app and validates the entire bundle.
+/// An unbounded loop adds load that prolongs startup; terminal give-up keeps the old app running instead.
+struct ReplacementHandoffRetryPolicy: Equatable, Sendable {
+    enum Decision: Equatable, Sendable {
+        case retry(after: Duration)
+        case giveUp
+    }
+
+    static let maximumAttempts = 5
+    static let initialRetryDelay: Duration = .seconds(2)
+    static let maximumRetryDelay: Duration = .seconds(30)
+    static let backoffMultiplier = 2
+
+    // Give-up is keyed on the replacement's code-directory hash, not on a bare
+    // counter: abandoning one broken build must never lock the app out of a later
+    // fixed one, which arrives as a different hash and so earns a fresh budget.
+    private var replacement: Data?
+    private var failureCount = 0
+
+    func allowsAttempt(for replacement: Data) -> Bool {
+        self.replacement != replacement || self.failureCount < Self.maximumAttempts
+    }
+
+    mutating func recordFailure(for replacement: Data) -> Decision {
+        if self.replacement != replacement {
+            self.replacement = replacement
+            self.failureCount = 0
+        }
+        guard self.failureCount < Self.maximumAttempts else { return .giveUp }
+
+        self.failureCount += 1
+        guard self.failureCount < Self.maximumAttempts else { return .giveUp }
+
+        var delaySeconds = Int(Self.initialRetryDelay.components.seconds)
+        for _ in 1..<self.failureCount {
+            delaySeconds = min(
+                delaySeconds * Self.backoffMultiplier,
+                Int(Self.maximumRetryDelay.components.seconds))
+        }
+        return .retry(after: .seconds(delaySeconds))
+    }
+}

--- a/apps/macos/Tests/OpenClawIPCTests/ApplicationRelocatorTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/ApplicationRelocatorTests.swift
@@ -1,3 +1,4 @@
+import Darwin
 import Foundation
 @testable import OpenClaw
 import Testing
@@ -219,6 +220,137 @@ struct ApplicationRelocatorTests {
         )
 
         #expect(action == .relaunch)
+    }
+
+    @Test
+    func `repeated handoff failures exhaust the retry budget`() {
+        let replacement = Data([20])
+        var policy = ReplacementHandoffRetryPolicy()
+        let decisions = (0..<ReplacementHandoffRetryPolicy.maximumAttempts).map { _ in
+            policy.recordFailure(for: replacement)
+        }
+        let retryCount = decisions.count { decision in
+            if case .retry = decision { true } else { false }
+        }
+
+        #expect(retryCount == ReplacementHandoffRetryPolicy.maximumAttempts - 1)
+        #expect(decisions.last == .giveUp)
+    }
+
+    @Test
+    func `exhausted handoff budget is terminal and idempotent`() {
+        let replacement = Data([21])
+        var policy = ReplacementHandoffRetryPolicy()
+        for _ in 0..<ReplacementHandoffRetryPolicy.maximumAttempts {
+            _ = policy.recordFailure(for: replacement)
+        }
+
+        #expect(!policy.allowsAttempt(for: replacement))
+        #expect(policy.recordFailure(for: replacement) == .giveUp)
+    }
+
+    @Test
+    func `handoff retry backoff increases without exceeding its cap`() {
+        let replacement = Data([22])
+        var policy = ReplacementHandoffRetryPolicy()
+        let delays = (0..<ReplacementHandoffRetryPolicy.maximumAttempts).compactMap { _ -> Duration? in
+            if case let .retry(after: delay) = policy.recordFailure(for: replacement) {
+                return delay
+            }
+            return nil
+        }
+
+        #expect(delays.first == ReplacementHandoffRetryPolicy.initialRetryDelay)
+        #expect(delays.allSatisfy { $0 <= ReplacementHandoffRetryPolicy.maximumRetryDelay })
+        for (earlier, later) in zip(delays, delays.dropFirst()) {
+            #expect(earlier < later)
+        }
+    }
+
+    @Test
+    func `different replacement hash resets the handoff retry budget`() {
+        let failingReplacement = Data([23])
+        let fixedReplacement = Data([24])
+        var policy = ReplacementHandoffRetryPolicy()
+        for _ in 0..<ReplacementHandoffRetryPolicy.maximumAttempts {
+            _ = policy.recordFailure(for: failingReplacement)
+        }
+
+        #expect(policy.allowsAttempt(for: fixedReplacement))
+        #expect(policy.recordFailure(for: fixedReplacement) == .retry(
+            after: ReplacementHandoffRetryPolicy.initialRetryDelay
+        ))
+    }
+
+    @Test
+    func `replacement handoff accepts ready child`() throws {
+        var descriptors = try self.makePipe()
+        let child = try self.launchSleepProcess()
+        defer {
+            self.closePipe(&descriptors)
+            self.terminateAndWait(child)
+        }
+        try self.write("READY", to: descriptors.write)
+
+        #expect(ApplicationRelocator.awaitReplacementHandoff(
+            on: descriptors.read,
+            childProcessIdentifier: child.processIdentifier
+        ) == .ready)
+    }
+
+    @Test
+    func `replacement handoff rejects failure response`() throws {
+        var descriptors = try self.makePipe()
+        let child = try self.launchSleepProcess()
+        defer {
+            self.closePipe(&descriptors)
+            self.terminateAndWait(child)
+        }
+        try self.write("FAIL", to: descriptors.write)
+
+        #expect(ApplicationRelocator.awaitReplacementHandoff(
+            on: descriptors.read,
+            childProcessIdentifier: child.processIdentifier
+        ) == .rejected)
+    }
+
+    @Test
+    func `replacement handoff promptly rejects closed pipe from dead child`() throws {
+        var descriptors = try self.makePipe()
+        let child = Process()
+        child.executableURL = URL(fileURLWithPath: "/usr/bin/true")
+        try child.run()
+        Darwin.close(descriptors.write)
+        descriptors.write = -1
+        child.waitUntilExit()
+        defer { self.closePipe(&descriptors) }
+
+        let startedAt = ContinuousClock.now
+        let outcome = ApplicationRelocator.awaitReplacementHandoff(
+            on: descriptors.read,
+            childProcessIdentifier: child.processIdentifier,
+            hangCeiling: .seconds(120)
+        )
+
+        #expect(outcome == .rejected)
+        #expect(ContinuousClock.now - startedAt < .seconds(5))
+    }
+
+    @Test
+    func `replacement handoff reports live silent child as unresponsive`() throws {
+        var descriptors = try self.makePipe()
+        let child = try self.launchSleepProcess()
+        defer {
+            self.closePipe(&descriptors)
+            self.terminateAndWait(child)
+        }
+
+        #expect(ApplicationRelocator.awaitReplacementHandoff(
+            on: descriptors.read,
+            childProcessIdentifier: child.processIdentifier,
+            hangCeiling: .milliseconds(750)
+        ) == .unresponsive)
+        #expect(Darwin.kill(child.processIdentifier, 0) == 0)
     }
 
     @Test
@@ -486,5 +618,43 @@ struct ApplicationRelocatorTests {
             options: 0
         )
         try data.write(to: url, options: .atomic)
+    }
+
+    private func makePipe() throws -> (read: Int32, write: Int32) {
+        var descriptors = [Int32](repeating: -1, count: 2)
+        try #require(Darwin.pipe(&descriptors) == 0)
+        return (descriptors[0], descriptors[1])
+    }
+
+    private func closePipe(_ descriptors: inout (read: Int32, write: Int32)) {
+        if descriptors.read >= 0 {
+            Darwin.close(descriptors.read)
+            descriptors.read = -1
+        }
+        if descriptors.write >= 0 {
+            Darwin.close(descriptors.write)
+            descriptors.write = -1
+        }
+    }
+
+    private func launchSleepProcess() throws -> Process {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/bin/sleep")
+        process.arguments = ["5"]
+        try process.run()
+        return process
+    }
+
+    private func terminateAndWait(_ process: Process) {
+        Darwin.kill(process.processIdentifier, SIGKILL)
+        process.waitUntilExit()
+    }
+
+    private func write(_ value: String, to descriptor: Int32) throws {
+        let data = Data(value.utf8)
+        let count = data.withUnsafeBytes { buffer in
+            Darwin.write(descriptor, buffer.baseAddress, buffer.count)
+        }
+        try #require(count == data.count)
     }
 }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users updating the macOS app in place would end up with the app
spawning itself over and over — roughly one full app launch every eleven seconds, for as
long as the machine stayed busy — until someone intervened by hand.

Reproduced live on a MacBook running three concurrent Xcode/Gradle builds (load average
~100). Every replacement the app launched was killed mid-startup and immediately relaunched;
about 25 failed handoffs were logged before an operator broke the cycle manually. Because the
app runs under a `KeepAlive` LaunchAgent, nothing stopped the cycle on its own, and each
retry added the very load that made the next attempt fail — a self-perpetuating loop.

## Why This Change Was Made

The in-place replacement handoff gave each newly launched app a hard-coded 10-second budget to
report readiness over its inherited pipe. That number encodes an assumption about how fast a
machine is: readiness is reported from `applicationDidFinishLaunching`, i.e. after full AppKit
startup plus a bundle-wide code-signature validation, so on a loaded machine a perfectly
healthy replacement simply cannot answer in time. The old app then SIGKILLed it and retried
with no backoff, no attempt cap, and no terminal state.

Three changes, each at the boundary that owns the decision:

- **Readiness is decided by child liveness, not a wall clock.** The wait now polls in short
  slices and treats an exited child (pipe EOF, or the process disappearing) as an immediate
  rejection, while a child that is merely slow keeps its turn. The remaining ceiling is a
  hang detector for a wedged-but-live child, not a startup budget — so a dead child is now
  detected in a quarter second instead of ten, and a slow-but-healthy one is never killed.
  The outcome is a closed union (`ready` / `rejected` / `unresponsive`) instead of an
  optional string that conflated "timed out" with "pipe closed".
- **Retries are bounded by an explicit policy.** `ReplacementHandoffRetryPolicy` is a small
  pure value type: five attempts with exponential backoff (2 s, 4 s, 8 s, 16 s, capped at
  30 s), then a terminal give-up. It is keyed on the replacement's code-directory hash, so
  abandoning one broken build does not lock the app out of a later, fixed one.
- **Giving up fails safe.** On the terminal decision the app stops re-arming the relaunch
  path and keeps the currently running process alive. The guarded invariant is that a failed
  handoff must never leave the user with no running app, and must never retry forever.

The same recovery loop had a second, independent unbounded path — an outright spawn failure
slept a flat second and retried forever without even incrementing its attempt counter. That
path now routes through the same policy.

Non-goal: the `waitForTrustedReplacement` disk poll in the same loop is deliberately left
alone. It never spawns or kills anything, so it cannot amplify load; it is a passive wait for
an atomic bundle swap to finish.

## User Impact

An in-place update that cannot complete its handoff now backs off, tries a bounded number of
times, and then stops with a clear log line — leaving the app you are already running up and
usable. Previously it would relaunch itself indefinitely, degrading the machine further with
every attempt and requiring manual intervention.

Users on healthy machines see no change; users on busy machines should now see the update
succeed at all, because a slow-but-working replacement is no longer killed for being slow.

## Evidence

Regression tests in `apps/macos/Tests/OpenClawIPCTests/ApplicationRelocatorTests.swift`.
They fail against the previous code and pass on this branch.

Bounded-retry proof (this is the regression test for the reported loop):
- repeated failures for the same replacement produce a bounded number of retries and then
  `giveUp`, asserted against the policy's own cap rather than a magic number
- the exhausted budget is terminal and idempotent — `allowsAttempt` stays false and further
  failures keep returning `giveUp`, so nothing can re-arm the spawn
- backoff delays strictly increase and never exceed the cap
- a different replacement hash resets the budget, so a fixed build is not locked out

Liveness proof, using a real pipe and real child processes:
- a child that writes `READY` is accepted; one that writes `FAIL` is rejected
- a child that exits and closes the pipe is rejected in well under five seconds even when
  handed a 120-second ceiling — the proof that a dead child is detected by liveness rather
  than by burning the clock
- a live, silent child hits the ceiling as `unresponsive` and is still alive afterwards —
  the proof that the wait itself never kills a slow-but-healthy replacement

On code size: prod grows ~100 lines net (56 in `ApplicationRelocator`, 44 for the new policy
type), tests 170. That buys the deletion of reachable paths rather than another mode. It removes
the `sleep(1) + continue` loop-back edge into `while !Task.isCancelled`, removes the implicit
infinite re-arm cycle, and removes a semantic sentinel where `nil` meant both "timed out" and
"pipe closed". The recovery loop still has exactly three actions — the terminal state is an *exit*
from `.relaunch`, not a fourth mode — and the readiness result went from two conflated meanings to
three explicit ones.

Note for the next person who runs these tests locally, since the failure is misleading:
`swift test` can build cleanly and then die in `dlopen` with
`Library not loaded: @rpath/Sparkle.framework/Versions/B/Sparkle`. The obvious fix,
`DYLD_FRAMEWORK_PATH`, is the one that cannot work — SwiftPM runs the bundle through
`swiftpm-xctest-helper` inside Xcode, which is SIP-signed, so dyld strips every `DYLD_*` variable
from its environment. Symlinking the framework into `PackageFrameworks/` (already on dyld's search
list) is the working answer. Written up in `apps/macos/README.md` next to the existing Sparkle
dev-workaround section.

Sibling-surface audit: every relaunch/respawn/supervision path under `apps/macos/Sources` was
swept for the same unbounded-retry shape. The node host worker shared it — zero delay when the
worker crashed *after* becoming ready, because the coordinator's backoff only covered the
failed-to-start path — and was independently fixed in #114974 while this PR was in review.
`RemoteTunnelManager`'s SSH restart still uses a fixed 2 s delay with no escalation or cap and is
filed as follow-up rather than bundled here, since it is a different subsystem with its own risk.
`GatewayProcessManager`, `NodeServiceManager`, `GatewayConnection`, `GatewayDiscoveryModel` and
the Sparkle path were checked and are already bounded.

A fourth member of the family lives outside this repo area and outside a Swift-only sweep, and is
being scoped separately: on a permanent `AUTH_TOKEN_MISMATCH` the gateway client correctly
classifies the failure as terminal (`packages/gateway-client/src/reconnect-policy.ts:38-40`), the
node-host runner converts that terminal pause into `exit(1)` for supervisor restart
(`src/node-host/runner.ts:99-107`), and the supervisor is launchd with `KeepAlive=true` and a fixed
10 s `ThrottleInterval` (`src/daemon/launchd-plist.ts:335`), which cannot express "do not restart
me." Same shape as this bug: a correctly-bounded retry at layer N defeated by an unbounded
respawner at layer N+1.

This branch also carries two mechanical commits regenerating `apps/.i18n/native-source.json` via
`pnpm native:i18n:baseline`. The first covers line-number offsets from this change; the second
additionally repairs stale `apps/ios/Sources/Model/NodeAppModel.swift` offsets left behind by
7838c6a6fd4 on `main`, which fails the `native-i18n` gate for every PR until regenerated. Neither
commit adds, removes, or rewords a string — the entire diff is line numbers.
