### PR TITLE
fix(docs): preserve localized navigation route parity

### DIFF
--- a/docs/.i18n/README.md
+++ b/docs/.i18n/README.md
@@ -40,8 +40,8 @@ Generated locale trees and live translation memory now live in the publish repo:
 ## Files in this folder
 
 - `glossary.<lang>.json` — preferred term mappings used as prompt guidance.
-- `zh-Hans-navigation.json` — curated zh-Hans Mintlify locale navigation reinserted into the publish repo during sync.
-- `ar-navigation.json`, `de-navigation.json`, `es-navigation.json`, `fr-navigation.json`, `id-navigation.json`, `it-navigation.json`, `ja-navigation.json`, `ko-navigation.json`, `pl-navigation.json`, `pt-BR-navigation.json`, and `tr-navigation.json` — starter locale metadata kept alongside the source repo, but the publish sync now clones the full English nav tree for clone-en locales so translated pages are visible in Mintlify without hand-maintaining per-locale nav JSON.
+- `zh-Hans-navigation.json` — curated zh-Hans tab and group labels overlaid onto the current English navigation tree during publish sync.
+- `ar-navigation.json`, `de-navigation.json`, `es-navigation.json`, `fr-navigation.json`, `id-navigation.json`, `it-navigation.json`, `ja-navigation.json`, `ko-navigation.json`, `pl-navigation.json`, `pt-BR-navigation.json`, and `tr-navigation.json` — starter locale labels kept alongside the source repo. Publish sync clones the full English navigation tree, prefixes locale routes, and overlays translated labels by matching shared page anchors.
 - `<lang>.tm.jsonl` — translation memory keyed by workflow + model + text hash.
 
 In this repo, generated locale TM files such as `docs/.i18n/zh-CN.tm.jsonl`, `docs/.i18n/zh-TW.tm.jsonl`, `docs/.i18n/ja-JP.tm.jsonl`, `docs/.i18n/es.tm.jsonl`, `docs/.i18n/pt-BR.tm.jsonl`, `docs/.i18n/ko.tm.jsonl`, `docs/.i18n/de.tm.jsonl`, `docs/.i18n/fr.tm.jsonl`, `docs/.i18n/ar.tm.jsonl`, `docs/.i18n/it.tm.jsonl`, `docs/.i18n/vi.tm.jsonl`, `docs/.i18n/nl.tm.jsonl`, `docs/.i18n/fa.tm.jsonl`, `docs/.i18n/tr.tm.jsonl`, `docs/.i18n/uk.tm.jsonl`, `docs/.i18n/id.tm.jsonl`, `docs/.i18n/pl.tm.jsonl`, and `docs/.i18n/th.tm.jsonl` are intentionally no longer committed.

--- a/scripts/docs-sync-publish.d.mts
+++ b/scripts/docs-sync-publish.d.mts
@@ -13,6 +13,13 @@ export function parseArgs(argv: unknown): {
 export function resolveClawHubRepoPath(value?: string, options?: Record<string, unknown>): string;
 /** Reports locale pages whose canonical source page no longer exists without deleting them. */
 export function reportOrphanLocaleDocs(targetDocsDir: string): number;
+/** Applies translated tab and group labels without replacing canonical page routes. */
+export function applyLocaleNavLabelOverlay(
+  fullNav: Record<string, unknown>,
+  labelOverlay: Record<string, unknown>,
+): Record<string, unknown>;
+/** Composes the publish docs configuration with generated locale navigation. */
+export function composeDocsConfig(): Record<string, unknown>;
 /**
  * Mirrors ClawHub docs into the target docs tree.
  */

--- a/scripts/docs-sync-publish.mjs
+++ b/scripts/docs-sync-publish.mjs
@@ -400,14 +400,101 @@ function cloneEnglishLanguageNav(englishNav, locale) {
   };
 }
 
-function composeLocaleNav(locale, englishNav) {
-  if (locale.navMode === "clone-en") {
-    return cloneEnglishLanguageNav(englishNav, locale);
+function collectNavPages(entry, pages = new Set()) {
+  if (typeof entry === "string") {
+    pages.add(entry);
+    return pages;
   }
-  return readJson(path.join(SOURCE_DOCS_DIR, ".i18n", locale.navFile));
+  if (Array.isArray(entry)) {
+    for (const item of entry) {
+      collectNavPages(item, pages);
+    }
+    return pages;
+  }
+  if (!entry || typeof entry !== "object") {
+    return pages;
+  }
+  if (typeof entry.page === "string") {
+    pages.add(entry.page);
+  }
+  collectNavPages(entry.pages, pages);
+  collectNavPages(entry.groups, pages);
+  collectNavPages(entry.tabs, pages);
+  return pages;
 }
 
-function composeDocsConfig() {
+function findBestNavMatchIndex(candidates, overlayEntry, excludedIndexes = new Set()) {
+  const overlayPages = collectNavPages(overlayEntry);
+  let bestIndex = -1;
+  let bestScore = 0;
+  for (const [index, candidate] of candidates.entries()) {
+    if (excludedIndexes.has(index)) {
+      continue;
+    }
+    const candidatePages = collectNavPages(candidate);
+    let score = 0;
+    for (const page of overlayPages) {
+      if (candidatePages.has(page)) {
+        score += 1;
+      }
+    }
+    if (score > bestScore) {
+      bestIndex = index;
+      bestScore = score;
+    }
+  }
+  return bestIndex;
+}
+
+export function applyLocaleNavLabelOverlay(fullNav, labelOverlay) {
+  const tabs = Array.isArray(fullNav.tabs)
+    ? fullNav.tabs.map((tab) => ({
+        ...tab,
+        groups: Array.isArray(tab.groups) ? tab.groups.map((group) => ({ ...group })) : tab.groups,
+      }))
+    : fullNav.tabs;
+  const composed = { ...fullNav, tabs };
+  if (!Array.isArray(tabs) || !Array.isArray(labelOverlay?.tabs)) {
+    return composed;
+  }
+
+  for (const overlayTab of labelOverlay.tabs) {
+    const tabIndex = findBestNavMatchIndex(tabs, overlayTab);
+    if (tabIndex < 0) {
+      continue;
+    }
+    const tab = tabs[tabIndex];
+    if (typeof overlayTab.tab === "string") {
+      tab.tab = overlayTab.tab;
+    }
+    if (!Array.isArray(tab.groups) || !Array.isArray(overlayTab.groups)) {
+      continue;
+    }
+    const matchedGroupIndexes = new Set();
+    for (const overlayGroup of overlayTab.groups) {
+      const groupIndex = findBestNavMatchIndex(tab.groups, overlayGroup, matchedGroupIndexes);
+      if (groupIndex >= 0 && typeof overlayGroup.group === "string") {
+        tab.groups[groupIndex].group = overlayGroup.group;
+        matchedGroupIndexes.add(groupIndex);
+      }
+    }
+  }
+  return composed;
+}
+
+function composeLocaleNav(locale, englishNav) {
+  const cloned = cloneEnglishLanguageNav(englishNav, locale);
+  if (!locale.navFile) {
+    return cloned;
+  }
+  const overlayPath = path.join(SOURCE_DOCS_DIR, ".i18n", locale.navFile);
+  if (!fs.existsSync(overlayPath)) {
+    return cloned;
+  }
+  return applyLocaleNavLabelOverlay(cloned, readJson(overlayPath));
+}
+
+export function composeDocsConfig() {
   const sourceConfig = readJson(SOURCE_CONFIG_PATH);
   const languages = sourceConfig?.navigation?.languages;
 

--- a/test/scripts/docs-sync-publish.test.ts
+++ b/test/scripts/docs-sync-publish.test.ts
@@ -2,7 +2,35 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
-import { parseArgs, reportOrphanLocaleDocs } from "../../scripts/docs-sync-publish.mjs";
+import {
+  composeDocsConfig,
+  parseArgs,
+  reportOrphanLocaleDocs,
+} from "../../scripts/docs-sync-publish.mjs";
+
+function collectPages(entry: unknown, pages: string[] = []): string[] {
+  if (typeof entry === "string") {
+    pages.push(entry);
+    return pages;
+  }
+  if (Array.isArray(entry)) {
+    for (const item of entry) {
+      collectPages(item, pages);
+    }
+    return pages;
+  }
+  if (!entry || typeof entry !== "object") {
+    return pages;
+  }
+  const record = entry as Record<string, unknown>;
+  if (typeof record.page === "string") {
+    pages.push(record.page);
+  }
+  collectPages(record.pages, pages);
+  collectPages(record.groups, pages);
+  collectPages(record.tabs, pages);
+  return pages;
+}
 
 describe("docs-sync-publish", () => {
   it("parses docs sync provenance args", () => {
@@ -67,5 +95,40 @@ describe("docs-sync-publish", () => {
     } finally {
       fs.rmSync(docsDir, { recursive: true, force: true });
     }
+  });
+
+  it("keeps generated locale navigation aligned with English routes", () => {
+    const config = composeDocsConfig() as {
+      navigation: {
+        languages: Array<{
+          language: string;
+          tabs: Array<{ tab: string; groups?: Array<{ group: string }> }>;
+        }>;
+      };
+    };
+    const english = config.navigation.languages.find((entry) => entry.language === "en");
+    const simplifiedChinese = config.navigation.languages.find(
+      (entry) => entry.language === "zh-Hans",
+    );
+    const german = config.navigation.languages.find((entry) => entry.language === "de");
+
+    expect(english).toBeDefined();
+    expect(simplifiedChinese).toBeDefined();
+    expect(german).toBeDefined();
+
+    const englishWithoutClawHub = {
+      ...english,
+      tabs: english!.tabs.filter((tab) => tab.tab !== "ClawHub"),
+    };
+    const expectedZhPages = collectPages(englishWithoutClawHub)
+      .map((page) => `zh-CN/${page}`)
+      .toSorted();
+    expect(collectPages(simplifiedChinese).toSorted()).toEqual(expectedZhPages);
+    expect(simplifiedChinese!.tabs[0]?.tab).toBe("快速开始");
+    expect(simplifiedChinese!.tabs[0]?.groups?.[0]?.group).toBe("首页");
+
+    expect(collectPages(german)).toHaveLength(collectPages(englishWithoutClawHub).length);
+    expect(german!.tabs[0]?.tab).toBe("Loslegen");
+    expect(german!.tabs[0]?.groups?.[0]?.group).toBe("Überblick");
   });
 });


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Simplified Chinese docs navigation omitted hundreds of current pages, while generated locale navigation could retain stale page lists or English labels.

## Why This Change Was Made

Publish sync now always clones the current canonical English navigation routes, prefixes them for each generated locale, and overlays translated tab and group labels by matching shared page anchors. Locale metadata can translate labels without owning or replacing the route tree.

## User Impact

Localized docs keep complete navigation coverage as English docs evolve. Simplified Chinese no longer loses current pages, and locales with starter navigation metadata retain translated labels without hand-maintaining duplicate route lists.

## Evidence

- `node scripts/run-vitest.mjs test/scripts/docs-sync-publish.test.ts`: 4 tests passed.
- Generated config proof: `zh-Hans`, `de`, `ja`, and `es` each contain all 551 canonical non-ClawHub pages.
- Representative labels remain localized: `快速开始`, `Loslegen`, `はじめに`, and `Comenzar`.
- `node scripts/docs-list.js`: passed.
- `git diff --check`: passed.
- Fresh branch autoreview: clean, no accepted or actionable findings.
