### PR TITLE
refactor(plugins): read entry-scoped plugin config from api.pluginConfig

### DIFF
--- a/docs/plugins/sdk-runtime.md
+++ b/docs/plugins/sdk-runtime.md
@@ -46,7 +46,9 @@ The mutation helpers return `afterWrite` plus a typed `followUp` summary so call
 Use `current()`, a passed-in `cfg`, `mutateConfigFile(...)`, or
 `replaceConfigFile(...)` for runtime config access and writes.
 
-For direct SDK imports, prefer the focused config subpaths over the broad `openclaw/plugin-sdk/config-runtime` compatibility barrel: `config-contracts` for types, `runtime-config-snapshot` for current process snapshots, and `config-mutation` for writes. Read entry-scoped values from `api.pluginConfig`; use a supplied tool context only for its runtime-wide config snapshot, and keep plugin-specific merging at that boundary. Bundled plugin tests should mock these focused subpaths directly instead of mocking the broad compatibility barrel.
+For direct SDK imports, prefer the focused config subpaths over the broad `openclaw/plugin-sdk/config-runtime` compatibility barrel: `config-contracts` for types, `runtime-config-snapshot` for current process snapshots, and `config-mutation` for writes. Read entry-scoped values from `api.pluginConfig`; every `plugins.*` change reloads the plugin and reruns `register(api)` with freshly validated config. The value is validated against the plugin manifest's `configSchema`, with schema defaults applied. Use a supplied tool context only for its runtime-wide config snapshot, and keep plugin-specific merging at that boundary. Bundled plugin tests should mock these focused subpaths directly instead of mocking the broad compatibility barrel.
+
+When a plugin mutates its own config with `mutateConfigFile(...)` and must read the post-write value again inside the same handler, read `api.runtime.config.current()` directly. `api.pluginConfig` refreshes when the resulting plugin reload lands, not during the handler that initiated the write. Codex's `codexPluginsManagementIo` and Active Memory's `/active-memory --global` command are the two legitimate direct-snapshot readers; other plugin config readers should use `api.pluginConfig`.
 
 Internal OpenClaw runtime code follows the same direction: load config once at the CLI, gateway, or process boundary, then pass that value through. Successful mutation writes refresh the process runtime snapshot and advance its internal revision; long-lived caches should key off the runtime-owned cache key instead of serializing config locally. Long-lived runtime modules have a zero-tolerance scanner for ambient `loadConfig()` calls; use a passed `cfg`, a request `context.getRuntimeConfig()`, or `getRuntimeConfig()` at an explicit process boundary.
 
@@ -946,7 +948,7 @@ Beyond `api.runtime`, the API object also provides:
   Current config snapshot (active in-memory runtime snapshot when available).
 </ParamField>
 <ParamField path="api.pluginConfig" type="Record<string, unknown>">
-  Plugin-specific config from `plugins.entries.<id>.config`.
+  Always-current plugin-specific config from `plugins.entries.<id>.config`. Any `plugins.*` change reloads the plugin and supplies a freshly validated value with manifest `configSchema` defaults applied.
 </ParamField>
 <ParamField path="api.logger" type="PluginLogger">
   Scoped logger (`debug`, `info`, `warn`, `error`).

--- a/extensions/active-memory/index.ts
+++ b/extensions/active-memory/index.ts
@@ -5,7 +5,7 @@ import { resolveAgentDir, resolveAgentWorkspaceDir } from "openclaw/plugin-sdk/a
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import {
   normalizePluginsConfig,
-  resolveLivePluginConfigObject,
+  resolvePluginConfigObject,
 } from "openclaw/plugin-sdk/plugin-config-runtime";
 import { definePluginEntry, type OpenClawPluginApi } from "openclaw/plugin-sdk/plugin-entry";
 import {
@@ -113,14 +113,14 @@ export default definePluginEntry({
     };
     warnDeprecatedModelFallbackPolicy(api.pluginConfig);
     const refreshLiveConfigFromRuntime = () => {
-      const livePluginConfig = resolveLivePluginConfigObject(
-        api.runtime.config?.current
-          ? () => api.runtime.config.current() as OpenClawConfig
-          : undefined,
-        "active-memory",
-        api.pluginConfig as Record<string, unknown>,
-      );
       const liveConfig = readCurrentConfig();
+      // `/active-memory --global` rereads this right after mutating its own
+      // `plugins.entries.active-memory.config` block. The reload that refreshes
+      // `api.pluginConfig` lands after the handler, so the post-write value has to
+      // come from the runtime snapshot or the command observes its own stale config.
+      const livePluginConfig = liveConfig
+        ? resolvePluginConfigObject(liveConfig, "active-memory")
+        : api.pluginConfig;
       const fallbackConfig = {};
       const effectivePluginConfig =
         liveConfig && !isActiveMemoryPluginEnabled(liveConfig)

--- a/extensions/codex/index.test.ts
+++ b/extensions/codex/index.test.ts
@@ -261,7 +261,7 @@ describe("codex plugin", () => {
     ["supervision is disabled", { enabled: false }],
     ["supervision is enabled", { enabled: true }],
   ] as const)(
-    "keeps live user-home appServer config for an auto-enabled Codex entry when %s",
+    "keeps user-home appServer config from api.pluginConfig when %s",
     (_label, supervision) => {
       const registerTool = vi.fn();
       plugin.register(
@@ -270,21 +270,11 @@ describe("codex plugin", () => {
           name: "Codex",
           source: "test",
           config: {},
-          pluginConfig: {},
-          // No explicit plugins.entries.codex.enabled: core auto-enables the
-          // plugin from this config block, so the harness must keep honoring it.
-          runtime: createCodexTestRuntime(() => ({
-            plugins: {
-              entries: {
-                codex: {
-                  config: {
-                    appServer: { homeScope: "user" },
-                    ...(supervision ? { supervision } : {}),
-                  },
-                },
-              },
-            },
-          })),
+          pluginConfig: {
+            appServer: { homeScope: "user" },
+            ...(supervision ? { supervision } : {}),
+          },
+          runtime: createCodexTestRuntime(),
           registerAgentHarness: vi.fn(),
           registerCommand: vi.fn(),
           registerMediaUnderstandingProvider: vi.fn(),
@@ -300,185 +290,9 @@ describe("codex plugin", () => {
       ) as
         | [(context: { senderIsOwner?: boolean }) => { name: string } | null, { name: string }]
         | undefined;
-      // codex_threads exists only while user-home scope or supervision is live,
-      // so it proves the plugin config survived the enable-state resolution.
       expect(registration?.[0]({ senderIsOwner: true })?.name).toBe("codex_threads");
     },
   );
-
-  it("drops live plugin config when the Codex entry is explicitly disabled", () => {
-    const registerTool = vi.fn();
-    plugin.register(
-      createTestPluginApi({
-        id: "codex",
-        name: "Codex",
-        source: "test",
-        config: {},
-        pluginConfig: {},
-        runtime: createCodexTestRuntime(() => ({
-          plugins: {
-            entries: {
-              codex: {
-                enabled: false,
-                config: { appServer: { homeScope: "user" } },
-              },
-            },
-          },
-        })),
-        registerAgentHarness: vi.fn(),
-        registerCommand: vi.fn(),
-        registerMediaUnderstandingProvider: vi.fn(),
-        registerMigrationProvider: vi.fn(),
-        registerProvider: vi.fn(),
-        registerTool,
-        on: vi.fn(),
-      }),
-    );
-
-    const registration = registerTool.mock.calls.find(
-      ([, options]) => options?.name === "codex_threads",
-    ) as
-      | [(context: { senderIsOwner?: boolean }) => { name: string } | null, { name: string }]
-      | undefined;
-    expect(registration?.[0]({ senderIsOwner: true })).toBeNull();
-  });
-
-  it("activates from live supervision config through a normalized Codex entry id", () => {
-    const registerTool = vi.fn();
-    plugin.register(
-      createTestPluginApi({
-        id: "codex",
-        name: "Codex",
-        source: "test",
-        config: {},
-        pluginConfig: {},
-        runtime: createCodexTestRuntime(() => ({
-          plugins: {
-            entries: {
-              " CODEX ": {
-                config: { supervision: { enabled: true } },
-              },
-            },
-          },
-        })),
-        registerAgentHarness: vi.fn(),
-        registerCommand: vi.fn(),
-        registerMediaUnderstandingProvider: vi.fn(),
-        registerMigrationProvider: vi.fn(),
-        registerProvider: vi.fn(),
-        registerTool,
-        on: vi.fn(),
-      }),
-    );
-
-    expect(registerTool.mock.calls.some(([, options]) => Array.isArray(options?.names))).toBe(true);
-  });
-
-  it.each([
-    ["plugin entry is removed", { plugins: { entries: {} } }],
-    [
-      "plugin entry is disabled",
-      {
-        plugins: {
-          entries: {
-            codex: { enabled: false, config: { supervision: { enabled: true } } },
-          },
-        },
-      },
-    ],
-    [
-      "global plugin loading is disabled",
-      {
-        plugins: {
-          enabled: false,
-          entries: {
-            codex: { enabled: true, config: { supervision: { enabled: true } } },
-          },
-        },
-      },
-    ],
-    [
-      "a restrictive allowlist omits Codex",
-      {
-        plugins: {
-          allow: ["other-plugin"],
-          entries: {
-            codex: { enabled: true, config: { supervision: { enabled: true } } },
-          },
-        },
-      },
-    ],
-    [
-      "the denylist blocks Codex",
-      {
-        plugins: {
-          deny: ["codex"],
-          entries: {
-            codex: { enabled: true, config: { supervision: { enabled: true } } },
-          },
-        },
-      },
-    ],
-    [
-      "supervision is explicitly disabled",
-      {
-        plugins: {
-          entries: {
-            codex: { enabled: true, config: { supervision: { enabled: false } } },
-          },
-        },
-      },
-    ],
-  ] as const)("revokes supervision live when %s", async (_label, revokedConfig) => {
-    const registerTool = vi.fn();
-    let liveConfig: unknown = {
-      plugins: {
-        entries: {
-          codex: { enabled: true, config: { supervision: { enabled: true } } },
-        },
-      },
-    };
-    plugin.register(
-      createTestPluginApi({
-        id: "codex",
-        name: "Codex",
-        source: "test",
-        config: {},
-        pluginConfig: { supervision: { enabled: true } },
-        runtime: createCodexTestRuntime(() => liveConfig),
-        registerAgentHarness: vi.fn(),
-        registerCommand: vi.fn(),
-        registerMediaUnderstandingProvider: vi.fn(),
-        registerMigrationProvider: vi.fn(),
-        registerProvider: vi.fn(),
-        registerTool,
-        on: vi.fn(),
-      }),
-    );
-    const registration = registerTool.mock.calls.find(([, options]) =>
-      Array.isArray(options?.names),
-    ) as
-      | [
-          (context: { senderIsOwner?: boolean }) => Array<{
-            name: string;
-            execute(callId: string, params: object): Promise<unknown>;
-          }>,
-          { names: string[] },
-        ]
-      | undefined;
-    const probe = registration?.[0]({ senderIsOwner: true }).find(
-      (tool) => tool.name === "codex_endpoint_probe",
-    );
-    if (!probe) {
-      throw new Error("missing Codex endpoint probe tool");
-    }
-
-    liveConfig = revokedConfig;
-
-    await expect(probe.execute("probe", {})).rejects.toThrow(
-      "Codex supervision is disabled in the codex plugin config.",
-    );
-  });
 
   it("registers with capture APIs that do not expose conversation binding hooks yet", () => {
     const registerProvider = vi.fn();
@@ -819,24 +633,15 @@ describe("codex plugin", () => {
     expect(typeof harness.authBinding?.fingerprint).toBe("function");
   });
 
-  it("passes live Codex plugin config into public Codex app-server attempts", async () => {
+  it("passes api.pluginConfig into public Codex app-server attempts", async () => {
     const registerAgentHarness = vi.fn();
-    const liveConfig = {
-      plugins: {
-        entries: {
-          codex: {
-            enabled: true,
-            config: {
-              codexPlugins: {
-                enabled: true,
-                plugins: {
-                  "google-calendar": {
-                    marketplaceName: "openai-curated",
-                    pluginName: "google-calendar",
-                  },
-                },
-              },
-            },
+    const pluginConfig = {
+      codexPlugins: {
+        enabled: true,
+        plugins: {
+          "google-calendar": {
+            marketplaceName: "openai-curated",
+            pluginName: "google-calendar",
           },
         },
       },
@@ -847,8 +652,8 @@ describe("codex plugin", () => {
         name: "Codex",
         source: "test",
         config: {},
-        pluginConfig: { codexPlugins: { enabled: false } },
-        runtime: createCodexTestRuntime(() => liveConfig),
+        pluginConfig,
+        runtime: createCodexTestRuntime(),
         registerAgentHarness,
         registerCommand: vi.fn(),
         registerMediaUnderstandingProvider: vi.fn(),
@@ -869,7 +674,7 @@ describe("codex plugin", () => {
       { prompt: "calendar" },
       {
         bindingStore: expect.any(Object),
-        pluginConfig: liveConfig.plugins.entries.codex.config,
+        pluginConfig,
         nativeHookRelay: { enabled: true },
       },
     );

--- a/extensions/codex/index.ts
+++ b/extensions/codex/index.ts
@@ -4,11 +4,6 @@
  */
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { mutateConfigFile } from "openclaw/plugin-sdk/config-mutation";
-import {
-  normalizePluginsConfig,
-  resolveEffectiveEnableState,
-  resolveLivePluginConfigObject,
-} from "openclaw/plugin-sdk/plugin-config-runtime";
 import { definePluginEntry } from "openclaw/plugin-sdk/plugin-entry";
 import type { PluginStateSyncKeyedStore } from "openclaw/plugin-sdk/plugin-state-runtime";
 import { registerCodexCliMetadata } from "./cli-metadata.js";
@@ -64,40 +59,10 @@ export default definePluginEntry({
   register(api) {
     const resolveCurrentConfig = () =>
       api.runtime.config?.current ? (api.runtime.config.current() as OpenClawConfig) : undefined;
-    const resolvePluginConfig = (resolveConfig: () => OpenClawConfig | undefined) => {
-      const liveConfig = resolveConfig();
-      // Codex plugin config can change at runtime. A missing live entry is an
-      // explicit removal, while an unavailable runtime snapshot uses startup config.
-      if (!liveConfig) {
-        return api.pluginConfig;
-      }
-      const livePluginConfig = resolveLivePluginConfigObject(
-        () => liveConfig,
-        "codex",
-        api.pluginConfig as Record<string, unknown>,
-      );
-      const enabled = resolveEffectiveEnableState({
-        id: "codex",
-        origin: "bundled",
-        config: normalizePluginsConfig(liveConfig.plugins),
-        rootConfig: liveConfig,
-        // Core auto-enables this bundled plugin whenever the operator declares a
-        // codex config block, so a live block is the plugin-side default. Gating
-        // on a feature flag (supervision) here would silently drop unrelated
-        // harness settings such as appServer.homeScope; feature gates belong in
-        // the feature's own surface (see requireSupervisionEnabled).
-        enabledByDefault: livePluginConfig !== undefined,
-      }).enabled;
-      if (!enabled) {
-        return undefined;
-      }
-      return livePluginConfig;
-    };
-    const resolveCurrentPluginConfig = () => resolvePluginConfig(resolveCurrentConfig);
     if (api.registrationMode === "full") {
       const realtimeBrowserSession = configureCodexRealtimeBrowserSession({
         getConfig: resolveCurrentConfig,
-        getPluginConfig: resolveCurrentPluginConfig,
+        getPluginConfig: () => api.pluginConfig,
       });
       api.registerHttpRoute({
         path: CODEX_REALTIME_OFFER_PATH,
@@ -153,11 +118,11 @@ export default definePluginEntry({
     const bindingStore = createLazyCodexAppServerBindingStore(lazyBindingStateStore);
     registerCodexCliMetadata(api);
     const sessionCatalogControl = createCodexSessionCatalogControl({
-      getPluginConfig: resolveCurrentPluginConfig,
+      getPluginConfig: () => api.pluginConfig,
       getRuntimeConfig: resolveCurrentConfig,
     });
     const sessionCatalogEnabled =
-      readCodexPluginConfig(resolveCurrentPluginConfig()).sessionCatalog?.enabled !== false;
+      readCodexPluginConfig(api.pluginConfig).sessionCatalog?.enabled !== false;
     if (sessionCatalogEnabled) {
       codexSessionCatalogRuntime.register({
         api,
@@ -172,7 +137,7 @@ export default definePluginEntry({
     for (const policy of createCodexSessionCatalogNodeInvokePolicies()) {
       api.registerNodeInvokePolicy(policy);
     }
-    if (readCodexPluginConfig(resolveCurrentPluginConfig()).supervision?.enabled === true) {
+    if (readCodexPluginConfig(api.pluginConfig).supervision?.enabled === true) {
       api.registerTool(
         (context) => {
           if (context.senderIsOwner !== true) {
@@ -184,7 +149,7 @@ export default definePluginEntry({
             context.config ??
             resolveCurrentConfig();
           return createCodexSupervisionTools({
-            getPluginConfig: () => resolvePluginConfig(resolveToolRuntimeConfig),
+            getPluginConfig: () => api.pluginConfig,
             getRuntimeConfig: resolveToolRuntimeConfig,
             senderIsOwner: context.senderIsOwner,
           });
@@ -197,7 +162,7 @@ export default definePluginEntry({
         bindingStore,
         sessionCatalogControl,
         resolveConfig: resolveCurrentConfig,
-        resolvePluginConfig: resolveCurrentPluginConfig,
+        resolvePluginConfig: () => api.pluginConfig,
         runtime: api.runtime,
       }),
     );
@@ -205,7 +170,7 @@ export default definePluginEntry({
       buildCodexMediaUnderstandingProvider({ pluginConfig: api.pluginConfig }),
     );
     api.registerWebSearchProvider(
-      createCodexWebSearchProvider({ resolvePluginConfig: resolveCurrentPluginConfig }),
+      createCodexWebSearchProvider({ resolvePluginConfig: () => api.pluginConfig }),
     );
     api.registerMigrationProvider(buildCodexMigrationProvider({ runtime: api.runtime }));
     api.registerTool(
@@ -214,7 +179,7 @@ export default definePluginEntry({
           bindingStore,
           context,
           runtime: api.runtime,
-          getPluginConfig: resolveCurrentPluginConfig,
+          getPluginConfig: () => api.pluginConfig,
         }),
       { name: "codex_threads" },
     );
@@ -234,7 +199,7 @@ export default definePluginEntry({
     api.registerCommand(
       createCodexCommand({
         pluginConfig: api.pluginConfig,
-        resolvePluginConfig: resolveCurrentPluginConfig,
+        resolvePluginConfig: () => api.pluginConfig,
         deps: {
           bindingStore,
           listCodexCliSessionsOnNode: (params) =>
@@ -303,7 +268,7 @@ export default definePluginEntry({
     api.on("inbound_claim", (event, ctx) =>
       codexConversationBindingRuntime.handleInboundClaim(event, ctx, {
         bindingStore,
-        pluginConfig: resolveCurrentPluginConfig(),
+        pluginConfig: api.pluginConfig,
         config: resolveCurrentConfig(),
         resumeCodexCliSessionOnNode: (params) =>
           resumeCodexCliSessionOnNode({ runtime: api.runtime, ...params }),

--- a/extensions/diffs/src/plugin.ts
+++ b/extensions/diffs/src/plugin.ts
@@ -1,7 +1,6 @@
 // Diffs plugin module implements plugin behavior.
 import fs from "node:fs";
 import path from "node:path";
-import { resolveLivePluginConfigObject } from "openclaw/plugin-sdk/plugin-config-runtime";
 import {
   resolvePreferredOpenClawTmpDir,
   type OpenClawConfig,
@@ -36,19 +35,10 @@ export function registerDiffsPlugin(api: OpenClawPluginApi): void {
     }),
     logger: api.logger,
   });
-  const resolveCurrentPluginConfig = () =>
-    resolveLivePluginConfigObject(
-      api.runtime.config?.current
-        ? () => api.runtime.config.current() as OpenClawConfig
-        : undefined,
-      "diffs",
-      api.pluginConfig as Record<string, unknown>,
-    ) ?? {};
   const resolveCurrentAccessConfig = () => {
     const currentConfig = (api.runtime.config?.current?.() ?? api.config) as OpenClawConfig;
-    const pluginConfig = resolveCurrentPluginConfig();
     return {
-      allowRemoteViewer: resolveDiffsPluginSecurity(pluginConfig).allowRemoteViewer,
+      allowRemoteViewer: resolveDiffsPluginSecurity(api.pluginConfig).allowRemoteViewer,
       trustedProxies: currentConfig.gateway?.trustedProxies,
       allowRealIpFallback: currentConfig.gateway?.allowRealIpFallback === true,
     };
@@ -57,12 +47,11 @@ export function registerDiffsPlugin(api: OpenClawPluginApi): void {
 
   api.registerTool(
     (ctx) => {
-      const pluginConfig = resolveCurrentPluginConfig();
       return createDiffsTool({
         api,
         store,
-        defaults: resolveDiffsPluginDefaults(pluginConfig),
-        viewerBaseUrl: resolveDiffsPluginViewerBaseUrl(pluginConfig),
+        defaults: resolveDiffsPluginDefaults(api.pluginConfig),
+        viewerBaseUrl: resolveDiffsPluginViewerBaseUrl(api.pluginConfig),
         languagePackAvailable: resolveDiffsLanguagePackAvailability(api),
         context: ctx,
       });

--- a/extensions/memory-lancedb/index.ts
+++ b/extensions/memory-lancedb/index.ts
@@ -9,9 +9,7 @@ import {
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { createLazyRuntimeModule } from "openclaw/plugin-sdk/lazy-runtime";
 import { readFiniteNumberParam, readPositiveIntegerParam } from "openclaw/plugin-sdk/param-readers";
-import { resolveLivePluginConfigObject } from "openclaw/plugin-sdk/plugin-config-runtime";
 import { isIncognitoSessionKey, normalizeAgentId } from "openclaw/plugin-sdk/routing";
-import { asOptionalRecord as asRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import { Type } from "typebox";
 import { definePluginEntry, type OpenClawPluginApi } from "./api.js";
@@ -105,7 +103,6 @@ export default definePluginEntry({
     const dbPath = cfg.dbPath!;
     const resolvedDbPath = dbPath.includes("://") ? dbPath : api.resolvePath(dbPath);
     const { model, dimensions } = cfg.embedding;
-    const disabledHookCfg = { ...cfg, autoCapture: false, autoRecall: false };
 
     const vectorDim = dimensions ?? vectorDimsForModel(model);
     const db = new MemoryDB(resolvedDbPath, vectorDim, cfg.storageOptions);
@@ -132,38 +129,6 @@ export default definePluginEntry({
         return normalizeAgentId(rawAgentId);
       }
       return resolveConfiguredDefaultAgentId(resolveRuntimeConfig());
-    };
-    const resolveCurrentHookConfig = () => {
-      const runtimePluginConfig = resolveLivePluginConfigObject(
-        api.runtime.config?.current
-          ? () => api.runtime.config.current() as OpenClawConfig
-          : undefined,
-        "memory-lancedb",
-        api.pluginConfig as Record<string, unknown>,
-      );
-      if (!runtimePluginConfig) {
-        return disabledHookCfg;
-      }
-      return memoryConfigSchema.parse({
-        embedding: {
-          provider: cfg.embedding.provider,
-          apiKey: cfg.embedding.apiKey,
-          model: cfg.embedding.model,
-          ...(cfg.embedding.baseUrl ? { baseUrl: cfg.embedding.baseUrl } : {}),
-          ...(typeof cfg.embedding.dimensions === "number"
-            ? { dimensions: cfg.embedding.dimensions }
-            : {}),
-          ...asRecord(runtimePluginConfig.embedding),
-        },
-        ...(cfg.dreaming ? { dreaming: cfg.dreaming } : {}),
-        dbPath: cfg.dbPath,
-        autoCapture: cfg.autoCapture,
-        autoRecall: cfg.autoRecall,
-        captureMaxChars: cfg.captureMaxChars,
-        recallMaxChars: cfg.recallMaxChars,
-        ...(cfg.storageOptions ? { storageOptions: cfg.storageOptions } : {}),
-        ...asRecord(runtimePluginConfig),
-      });
     };
     const readMemoryRecallCooldown = (agentId: string): { error: string } | undefined => {
       const memoryRecallCooldown = memoryRecallCooldowns.get(agentId);
@@ -216,7 +181,6 @@ export default definePluginEntry({
             const query = rawParams.query as string;
             const limit = readPositiveIntegerParam(rawParams, "limit") ?? 5;
 
-            const currentCfg = resolveCurrentHookConfig();
             const cooldown = readMemoryRecallCooldown(agentId);
             if (cooldown) {
               return buildMemoryRecallUnavailableResult(cooldown.error);
@@ -229,7 +193,7 @@ export default definePluginEntry({
                   let vector: number[];
                   try {
                     vector = await embeddings.embed(
-                      normalizeRecallQuery(query, currentCfg.recallMaxChars),
+                      normalizeRecallQuery(query, cfg.recallMaxChars),
                       { timeoutMs: DEFAULT_TOOL_RECALL_TIMEOUT_MS },
                     );
                   } catch (error) {
@@ -433,9 +397,8 @@ export default definePluginEntry({
             }
 
             if (query) {
-              const currentCfg = resolveCurrentHookConfig();
               const vector = await embeddings.embed(
-                normalizeRecallQuery(query, currentCfg.recallMaxChars),
+                normalizeRecallQuery(query, cfg.recallMaxChars),
               );
               const results = await db.search(agentId, vector, 5, 0.7);
 
@@ -491,8 +454,7 @@ export default definePluginEntry({
     registerMemoryCli(api, db, embeddings, resolveCliAgentId, cfg.recallMaxChars);
 
     api.on("before_prompt_build", async (event, ctx) => {
-      const currentCfg = resolveCurrentHookConfig();
-      if (!currentCfg.autoRecall) {
+      if (!cfg.autoRecall) {
         return undefined;
       }
       const agentId = resolveEnabledAgentId(ctx.agentId);
@@ -509,7 +471,7 @@ export default definePluginEntry({
             extractLatestUserText(Array.isArray(event.messages) ? event.messages : []) ??
               event.prompt,
           ),
-          currentCfg.recallMaxChars,
+          cfg.recallMaxChars,
         );
         if (!recallQuery) {
           return undefined;
@@ -558,8 +520,7 @@ export default definePluginEntry({
     });
 
     api.on("agent_end", async (event, ctx) => {
-      const currentCfg = resolveCurrentHookConfig();
-      if (!currentCfg.autoCapture || isIncognitoSessionKey(ctx.sessionKey)) {
+      if (!cfg.autoCapture || isIncognitoSessionKey(ctx.sessionKey)) {
         return;
       }
       const agentId = resolveEnabledAgentId(ctx.agentId);
@@ -590,8 +551,8 @@ export default definePluginEntry({
               if (
                 !sanitized ||
                 !shouldCapture(sanitized, {
-                  customTriggers: currentCfg.customTriggers,
-                  maxChars: currentCfg.captureMaxChars,
+                  customTriggers: cfg.customTriggers,
+                  maxChars: cfg.captureMaxChars,
                 })
               ) {
                 continue;

--- a/extensions/onepassword/index.ts
+++ b/extensions/onepassword/index.ts
@@ -1,10 +1,4 @@
 import path from "node:path";
-import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
-import {
-  normalizePluginsConfig,
-  resolveEffectiveEnableState,
-  resolveLivePluginConfigObject,
-} from "openclaw/plugin-sdk/plugin-config-runtime";
 import { definePluginEntry } from "openclaw/plugin-sdk/plugin-entry";
 import type { AuditRow, PendingAuthorization, StandingGrant } from "./src/broker.js";
 import { OnePasswordBroker } from "./src/broker.js";
@@ -22,27 +16,6 @@ export default definePluginEntry({
     "1Password SecretRef resolver and curated agent broker with approval policy and SQLite audit history.",
   register(api) {
     const startupConfig = parseOnePasswordConfig(api.pluginConfig);
-    const resolveCurrentConfig = () => {
-      const liveConfig = api.runtime.config?.current
-        ? (api.runtime.config.current() as OpenClawConfig)
-        : undefined;
-      if (!liveConfig) {
-        return startupConfig;
-      }
-      const livePluginConfig = resolveLivePluginConfigObject(
-        () => liveConfig,
-        "onepassword",
-        api.pluginConfig as Record<string, unknown> | undefined,
-      );
-      const enabled = resolveEffectiveEnableState({
-        id: "onepassword",
-        origin: "bundled",
-        config: normalizePluginsConfig(liveConfig.plugins),
-        rootConfig: liveConfig,
-        enabledByDefault: livePluginConfig !== undefined,
-      }).enabled;
-      return enabled ? parseOnePasswordConfig(livePluginConfig) : undefined;
-    };
     const grants = api.runtime.state.openKeyedStore<StandingGrant>({
       namespace: "grants",
       // Evicting the oldest grant is fail-closed: that agent must approve again.
@@ -68,7 +41,7 @@ export default definePluginEntry({
     );
     let cachedOpClient: { key: string; client: OpClient } | undefined;
     const resolveCurrentOpClient = () => {
-      const config = resolveCurrentConfig();
+      const config = parseOnePasswordConfig(api.pluginConfig);
       const key = JSON.stringify([config?.opBin ?? null, config?.opTimeoutMs ?? 15_000]);
       if (cachedOpClient?.key === key) {
         return cachedOpClient.client;
@@ -84,7 +57,7 @@ export default definePluginEntry({
     };
     const broker = startupConfig
       ? new OnePasswordBroker({
-          resolveConfig: resolveCurrentConfig,
+          resolveConfig: () => parseOnePasswordConfig(api.pluginConfig),
           opClient: {
             getItem: (params) => resolveCurrentOpClient().getItem(params),
           },
@@ -98,7 +71,7 @@ export default definePluginEntry({
         const { registerOnePasswordSecretRefCommands } = await import("./src/secret-ref-cli.js");
         registerOnePasswordCommands({
           program,
-          resolveConfig: resolveCurrentConfig,
+          resolveConfig: () => parseOnePasswordConfig(api.pluginConfig),
           resolveOpClient: resolveCurrentOpClient,
           auditStore: audit,
           registerAdditionalCommands: (command) =>

--- a/extensions/thread-ownership/index.ts
+++ b/extensions/thread-ownership/index.ts
@@ -1,5 +1,4 @@
 // Thread Ownership plugin entrypoint registers its OpenClaw integration.
-import { resolveLivePluginConfigObject } from "openclaw/plugin-sdk/plugin-config-runtime";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { escapeRegExp } from "openclaw/plugin-sdk/text-utility-runtime";
 import {
@@ -85,16 +84,7 @@ export default definePluginEntry({
   register(api: OpenClawPluginApi) {
     const resolveCurrentState = () => {
       const currentConfig = (api.runtime.config?.current?.() ?? api.config) as OpenClawConfig;
-      const livePluginCfg = resolveLivePluginConfigObject(
-        api.runtime.config?.current
-          ? () => api.runtime.config.current() as OpenClawConfig
-          : undefined,
-        "thread-ownership",
-        isThreadOwnershipConfig(api.pluginConfig)
-          ? (api.pluginConfig as Record<string, unknown>)
-          : undefined,
-      );
-      const pluginCfg = isThreadOwnershipConfig(livePluginCfg) ? livePluginCfg : {};
+      const pluginCfg = isThreadOwnershipConfig(api.pluginConfig) ? api.pluginConfig : {};
       return {
         currentConfig,
         forwarderUrl: (

--- a/src/plugin-sdk/plugin-config-runtime.ts
+++ b/src/plugin-sdk/plugin-config-runtime.ts
@@ -26,14 +26,7 @@ export function resolvePluginConfigObject(
     : undefined;
 }
 
-/**
- * Resolves live plugin config through a loader, falling back to startup config when unavailable.
- *
- * @deprecated Read `api.pluginConfig` instead: every `plugins.*` change reloads the plugin and
- * reruns `register(api)` with freshly validated config, so the loader indirection is redundant.
- * Retained because this subpath stays public until 2026-10-30 for dist-excluded official plugins
- * that consume it from the installed core; removing the named export would fail their module load.
- */
+/** Resolves live plugin config through a loader, falling back to startup config when unavailable. */
 export function resolveLivePluginConfigObject(
   runtimeConfigLoader: (() => OpenClawConfig | undefined) | undefined,
   pluginId: string,

--- a/src/plugin-sdk/plugin-config-runtime.ts
+++ b/src/plugin-sdk/plugin-config-runtime.ts
@@ -26,7 +26,14 @@ export function resolvePluginConfigObject(
     : undefined;
 }
 
-/** Resolves live plugin config through a loader, falling back to startup config when unavailable. */
+/**
+ * Resolves live plugin config through a loader, falling back to startup config when unavailable.
+ *
+ * @deprecated Read `api.pluginConfig` instead: every `plugins.*` change reloads the plugin and
+ * reruns `register(api)` with freshly validated config, so the loader indirection is redundant.
+ * Retained because this subpath stays public until 2026-10-30 for dist-excluded official plugins
+ * that consume it from the installed core; removing the named export would fail their module load.
+ */
 export function resolveLivePluginConfigObject(
   runtimeConfigLoader: (() => OpenClawConfig | undefined) | undefined,
   pluginId: string,

--- a/src/plugins/compat/plugin-sdk-subpath-records.ts
+++ b/src/plugins/compat/plugin-sdk-subpath-records.ts
@@ -165,11 +165,13 @@ export const BUNDLED_ONLY_PUBLIC_PLUGIN_SDK_SUBPATH_RECORDS =
       introduced: "2026-07-15",
       deprecated: "2026-07-15",
       warningStarts: "2026-07-15",
-      removeAfter: "2026-07-30",
+      removeAfter: subpath === "plugin-config-runtime" ? "2026-10-30" : "2026-07-30",
       replacement:
         subpath === "tool-plugin"
           ? "retain the public subpath until plugin authoring has a nonexecuting static metadata replacement for `defineToolPlugin`"
-          : `${documented?.replacement ?? "define and document a public replacement"}; retain the public subpath until the 2026-07-30 window closes and official plugin consumers migrate`,
+          : subpath === "plugin-config-runtime"
+            ? "use `api.pluginConfig` for entry-scoped config; retain the public subpath because 15 external official plugins (amazon-bedrock, amazon-bedrock-mantle, codex, diffs, discord, irc, line, matrix, mattermost, memory-lancedb, nextcloud-talk, signal, slack, voice-call, and whatsapp) are excluded from the core dist and consume it from the installed core, while `src/plugins/contracts/config-boundary-guard.test.ts` still recommends `requireRuntimeConfig` from this subpath as the correct narrow import. `requireRuntimeConfig` and `mergeDeep` do not have named replacements yet"
+            : `${documented?.replacement ?? "define and document a public replacement"}; retain the public subpath until the 2026-07-30 window closes and official plugin consumers migrate`,
       docsPath:
         subpath === "tool-plugin"
           ? "/plugins/tool-plugins"

--- a/src/plugins/compat/registry.test.ts
+++ b/src/plugins/compat/registry.test.ts
@@ -102,7 +102,6 @@ describe("plugin compatibility registry", () => {
     expect(records.map((record) => record.code)).toEqual([
       "plugin-sdk-media-understanding-public-demotion",
       "plugin-sdk-memory-host-core-public-demotion",
-      "plugin-sdk-plugin-config-runtime-public-demotion",
       "plugin-sdk-tool-plugin-public-demotion",
       "agent-harness-sdk-alias",
     ]);

--- a/src/plugins/contracts/boundary-invariants.test.ts
+++ b/src/plugins/contracts/boundary-invariants.test.ts
@@ -53,11 +53,10 @@ const BUNDLED_TYPED_HOOK_REGISTRATION_GUARDS = {
   readonly string[]
 >;
 const BUNDLED_LIVE_CONFIG_HOOK_GUARDS = {
-  "extensions/active-memory/index.ts": ["resolveLivePluginConfigObject(", '"active-memory"'],
-  "extensions/codex/index.ts": ["resolveLivePluginConfigObject(", '"codex"'],
+  "extensions/active-memory/index.ts": ['resolvePluginConfigObject(liveConfig, "active-memory")'],
+  "extensions/codex/index.ts": ["getPluginConfig: () => api.pluginConfig"],
   "extensions/diffs/src/plugin.ts": [
-    "resolveLivePluginConfigObject(",
-    '"diffs"',
+    "resolveDiffsPluginSecurity(api.pluginConfig)",
     "api.runtime.config?.current?.() ?? api.config",
   ],
   "extensions/memory-core/src/dreaming.ts": [
@@ -65,16 +64,10 @@ const BUNDLED_LIVE_CONFIG_HOOK_GUARDS = {
     "resolveMemoryDreamingPluginConfig(startupCfg)",
     "api.runtime.config?.current?.() ?? api.config",
   ],
-  "extensions/memory-lancedb/index.ts": ["resolveLivePluginConfigObject(", '"memory-lancedb"'],
-  "extensions/onepassword/index.ts": [
-    "resolveLivePluginConfigObject(",
-    "resolveEffectiveEnableState(",
-    '"onepassword"',
-    "api.runtime.config?.current",
-  ],
+  "extensions/memory-lancedb/index.ts": ["memoryConfigSchema.parse(api.pluginConfig)"],
+  "extensions/onepassword/index.ts": ["parseOnePasswordConfig(api.pluginConfig)"],
   "extensions/thread-ownership/index.ts": [
-    "resolveLivePluginConfigObject(",
-    '"thread-ownership"',
+    "isThreadOwnershipConfig(api.pluginConfig)",
     "api.runtime.config?.current?.() ?? api.config",
   ],
 } as const satisfies Record<string, readonly string[]>;

--- a/test/scripts/plugin-boundary-report.test.ts
+++ b/test/scripts/plugin-boundary-report.test.ts
@@ -60,8 +60,10 @@ describe("plugin-boundary-report", () => {
       "agent-harness-sdk-alias",
       "plugin-sdk-media-understanding-public-demotion",
       "plugin-sdk-memory-host-core-public-demotion",
-      "plugin-sdk-plugin-config-runtime-public-demotion",
       "plugin-sdk-tool-plugin-public-demotion",
+      // Sorted by removeAfter first, so the 2026-10-30 plugin-config-runtime
+      // window lands after the 2026-07-30 group.
+      "plugin-sdk-plugin-config-runtime-public-demotion",
     ]);
     for (const record of summary.compat?.removalPending ?? []) {
       expect(record.removeAfter).toMatch(/^\d{4}-\d{2}-\d{2}$/u);


### PR DESCRIPTION
## What Problem This Solves

This PR set out to remove duplicated bundled-plugin config lookups by replacing execution-time reads with the registration-scoped `api.pluginConfig` snapshot.

The rewrite is stopped pending maintainer decision because those values do not have the same lifetime. Current main intentionally uses live reads to revoke or change behavior in already-created tools, hooks, HTTP handlers, and broker objects after runtime config changes.

## Why This Change Was Made

No current-main rewrite is being pushed from this repair pass. Landing the stale branch would change behavior: `api.pluginConfig` is assigned once when the plugin API is built, while `resolveLivePluginConfigObject` calls the current runtime loader on every read. Gateway hot reload publishes the new runtime state before it prepares and swaps the replacement plugin runtime, and objects already held by an active run are not retroactively rebound.

The maintainer decision is whether config revocation must continue to affect already-created plugin objects immediately, or whether plugin registry replacement becomes the sole freshness boundary. The latter requires an explicit lifecycle/drain contract and security review; it cannot be introduced as a behavior-neutral refactor.

The public `plugin-config-runtime` compatibility window is not part of this decision. PR #115862 already superseded this branch's stale date and retains the shipped subpath through 2026-12-01. That current-main contract must remain untouched.

## User Impact

No change is landed. Preserving current behavior avoids a window where a previously created Codex supervision tool, Diffs remote-viewer handler, 1Password broker, memory hook, or thread-routing hook continues under stale policy after the operator revokes or changes it.

## Evidence

- `src/plugins/api-builder.ts:187-200` assigns `api.pluginConfig` as a plain registration-time property.
- `src/plugins/loader-runtime-candidate.ts:521-534` passes validated config when a plugin registers.
- `src/gateway/server-reload-hot.ts:162-189` publishes the new runtime state before `src/gateway/server-core-runtime.ts:489-514` prepares and swaps the replacement plugin runtime.
- `extensions/codex/index.test.ts:481-529` constructs a supervision tool, changes runtime config after registration, and proves that the existing tool rejects execution for removed, disabled, allow/deny-blocked, and supervision-disabled states. The stale branch deletes this regression.
- Equivalent same-instance live-config coverage remains in Diffs, Memory LanceDB, 1Password, Thread Ownership, and Active Memory tests; weakening those assertions is not proof of neutral behavior.
- The Codex dependency contract was checked directly at `openai/codex` commit `57f42a81131ccf5933e7ec5dc659c381eeb5d72b`: `codex-rs/app-server-protocol/src/protocol/v2/thread.rs:57-95` carries per-thread config, and `codex-rs/app-server/src/request_processors/thread_processor.rs:983-1077,1145-1171` consumes and loads those overrides when starting a thread. A stale OpenClaw closure can therefore start Codex work with stale settings; the dependency does not refresh OpenClaw plugin policy on its own.
- Current main's boundary contract explicitly keeps long-lived bundled handlers on live runtime config lookups in `src/plugins/contracts/boundary-invariants.test.ts:409-418`.

Decision-gate outcome: stopped without merging or weakening tests.
