### PR TITLE
fix(providers): prevent idle timeouts during hidden reasoning

### DIFF
--- a/packages/ai/src/providers/openai-completions.test.ts
+++ b/packages/ai/src/providers/openai-completions.test.ts
@@ -3,11 +3,14 @@ import type { ChatCompletionChunk } from "openai/resources/chat/completions.js";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { configureAiTransportHost } from "../host.js";
 import type { Context, Model, SimpleStreamOptions, TextContent } from "../types.js";
+import { onLlmRequestActivity } from "../utils/llm-request-activity.js";
 import { SYSTEM_PROMPT_CACHE_BOUNDARY } from "../utils/system-prompt-cache-boundary.js";
 
 type DeepPartial<T> = { [P in keyof T]?: DeepPartial<T[P]> };
 type OpenAICompatibleDelta = DeepPartial<ChatCompletionChunk["choices"][number]["delta"]> & {
   reasoning_content?: string;
+  reasoning?: string;
+  reasoning_text?: string;
 };
 type OpenAICompatibleChoice = Omit<
   DeepPartial<ChatCompletionChunk["choices"][number]>,
@@ -1429,6 +1432,40 @@ describe("openai-completions stop-reason tool-call guard", () => {
     expect(visibleText).toBe("");
     expect(result.content.some((block) => block.type === "thinking")).toBe(false);
   });
+
+  it.each(["reasoning_content", "reasoning", "reasoning_text"] as const)(
+    "reports hidden %s chunks as request activity",
+    async (reasoningField) => {
+      mockChunksRef.chunks = [
+        {
+          id: "chatcmpl-test",
+          choices: [{ index: 0, delta: { [reasoningField]: "private reasoning" } }],
+        },
+        {
+          id: "chatcmpl-test",
+          choices: [{ index: 0, delta: { [reasoningField]: "still private" } }],
+        },
+        makeTextChunk("visible answer"),
+        makeFinishChunk("stop"),
+      ];
+      const abortController = new AbortController();
+      const onActivity = vi.fn();
+      const unsubscribe = onLlmRequestActivity(abortController.signal, onActivity);
+
+      try {
+        const result = await streamOpenAICompletions(model, context, {
+          apiKey: "sk-test",
+          signal: abortController.signal,
+        }).result();
+
+        expect(onActivity).toHaveBeenCalledTimes(mockChunksRef.chunks.length);
+        expect(result.content).toContainEqual({ type: "text", text: "visible answer" });
+        expect(result.content.some((block) => block.type === "thinking")).toBe(false);
+      } finally {
+        unsubscribe();
+      }
+    },
+  );
 
   it("seals the native reasoning block before the answer text begins", async () => {
     // deepseek streams reasoning_content, then switches to content with no

--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -45,6 +45,7 @@ import {
 import { AssistantMessageEventStream } from "../utils/event-stream.js";
 import { headersToRecord } from "../utils/headers.js";
 import { parseStreamingJson } from "../utils/json-parse.js";
+import { notifyLlmRequestActivity } from "../utils/llm-request-activity.js";
 import { formatProviderError } from "../utils/provider-error.js";
 import { createReasoningTagTextPartitioner } from "../utils/reasoning-tag-text-partitioner.js";
 import {
@@ -392,6 +393,9 @@ export const streamOpenAICompletions: StreamFunction<
         if (!chunk || typeof chunk !== "object") {
           continue;
         }
+
+        // Hidden reasoning is still provider progress; keep the idle watchdog alive without exposing it.
+        notifyLlmRequestActivity(options?.signal);
 
         // OpenAI documents ChatCompletionChunk.id as the unique chat completion identifier,
         // and each chunk in a streamed completion carries the same id.

--- a/packages/ai/src/transports/openai-completions-transport.ts
+++ b/packages/ai/src/transports/openai-completions-transport.ts
@@ -33,6 +33,7 @@ import {
 } from "../utils/assistant-text-phase.js";
 import { createAssistantMessageEventStream } from "../utils/event-stream.js";
 import { parseStreamingJson } from "../utils/json-parse.js";
+import { notifyLlmRequestActivity } from "../utils/llm-request-activity.js";
 import { createReasoningTagTextPartitioner } from "../utils/reasoning-tag-text-partitioner.js";
 import {
   createFirstStreamEventAbortController,
@@ -631,6 +632,8 @@ async function processOpenAICompletionsStream(
       await cooperativeScheduler.afterEvent();
       continue;
     }
+    // Hidden reasoning is still provider progress; keep the idle watchdog alive without exposing it.
+    notifyLlmRequestActivity(options?.signal);
     const chunk = rawChunk as ChatCompletionChunk;
     output.responseId ||= chunk.id;
     let hasReasoningUsageActivity = false;

--- a/src/agents/openai-transport-stream.streaming.test.ts
+++ b/src/agents/openai-transport-stream.streaming.test.ts
@@ -6,6 +6,7 @@ import {
   classifyAssistantFailoverReason,
   formatUserFacingAssistantErrorText,
 } from "./embedded-agent-helpers.js";
+import { streamWithIdleTimeout } from "./embedded-agent-runner/run/llm-idle-timeout.js";
 import {
   parseTransportChunkUsage,
   type CapturedStreamEvent,
@@ -180,6 +181,111 @@ describe("openai transport stream", () => {
       });
     }
   });
+
+  it.each(["reasoning_content", "reasoning"] as const)(
+    "keeps hidden local %s streams alive beyond the model idle timeout",
+    async (reasoningField) => {
+      const reasoningChunkCount = 5;
+      const reasoningChunkDelayMs = 35;
+      const idleTimeoutMs = 100;
+      const server = createServer((req, res) => {
+        req.resume();
+        req.on("end", () => {
+          res.writeHead(200, {
+            "content-type": "text/event-stream; charset=utf-8",
+            "cache-control": "no-cache",
+            connection: "keep-alive",
+          });
+
+          let reasoningChunksSent = 0;
+          const writeNextChunk = () => {
+            if (res.destroyed) {
+              return;
+            }
+            if (reasoningChunksSent < reasoningChunkCount) {
+              reasoningChunksSent += 1;
+              const reasoningChunk = {
+                id: "chatcmpl-local-reasoning",
+                object: "chat.completion.chunk",
+                created: 1,
+                model: "nemotron-local",
+                choices: [
+                  {
+                    index: 0,
+                    delta: { [reasoningField]: "private reasoning" },
+                    finish_reason: null,
+                  },
+                ],
+              };
+              res.write(`data: ${JSON.stringify(reasoningChunk)}\n\n`);
+              setTimeout(writeNextChunk, reasoningChunkDelayMs);
+              return;
+            }
+
+            res.write(
+              `data: ${JSON.stringify(makeCompletionsChunk({ role: "assistant", content: "OK" }))}\n\n`,
+            );
+            res.write(`data: ${JSON.stringify(makeCompletionsChunk({}, "stop"))}\n\n`);
+            res.write("data: [DONE]\n\n");
+            res.end();
+          };
+
+          writeNextChunk();
+        });
+      });
+
+      await new Promise<void>((resolve) => {
+        server.listen(0, "127.0.0.1", resolve);
+      });
+      try {
+        const address = server.address();
+        if (!address || typeof address === "string") {
+          throw new Error("Missing loopback server address");
+        }
+        const model = makeCompletionsModel({
+          id: "nemotron-local",
+          name: "Local Nemotron",
+          provider: "inference",
+          baseUrl: `http://127.0.0.1:${address.port}/v1`,
+          reasoning: false,
+        });
+        const onIdleTimeout = vi.fn();
+        const streamFn = streamWithIdleTimeout(
+          createOpenAICompletionsTransportStreamFn(),
+          idleTimeoutMs,
+          onIdleTimeout,
+        );
+        const stream = streamFn(
+          model,
+          {
+            systemPrompt: "system",
+            messages: [{ role: "user", content: "Reply OK", timestamp: Date.now() }],
+            tools: [],
+          } as never,
+          { apiKey: "test-key" } as never,
+        );
+
+        let text = "";
+        let thinking = "";
+        for await (const event of stream as AsyncIterable<{ type: string; delta?: string }>) {
+          if (event.type === "text_delta") {
+            text += event.delta ?? "";
+          }
+          if (event.type === "thinking_delta") {
+            thinking += event.delta ?? "";
+          }
+        }
+
+        expect(text).toBe("OK");
+        expect(thinking).toBe("");
+        expect(onIdleTimeout).not.toHaveBeenCalled();
+      } finally {
+        await new Promise<void>((resolve, reject) => {
+          server.close((error) => (error ? reject(error) : resolve()));
+        });
+      }
+    },
+  );
 
   it("refuses ModelStudio chat streams with no user or assistant payload turns", async () => {
     const model = makeCompletionsModel({


### PR DESCRIPTION
Closes #113323.

## What Problem This Solves

Fixes an issue where users running a local OpenAI-compatible reasoning model would lose active agent turns to `LLM idle timeout` while the provider was continuously streaming hidden reasoning. The failure affects providers such as vLLM when the model is configured with reasoning disabled but its server still sends reasoning-only chat-completion chunks before the visible answer.

## Why This Change Was Made

Notify the existing model-request activity channel for every valid streamed OpenAI-compatible completion chunk, in both the built-in provider and the managed transport. This lets the existing idle watchdog observe genuine provider progress without emitting hidden thinking, weakening timeouts, changing model configuration, expanding the plugin SDK, or adding provider-specific policy. Regression coverage handles the current vLLM `reasoning` field and legacy `reasoning_content` / `reasoning_text` variants. The stream shape is checked against the pinned `openai@6.48.0` implementation and [vLLM's documented streaming reasoning output](https://docs.vllm.ai/en/latest/features/reasoning_outputs/).

## User Impact

Local and OpenAI-compatible reasoning models can finish a long thinking phase and return their normal visible reply without a false idle timeout. Private reasoning remains private, genuine silent-provider timeouts still fire, and configured timeout and fallback behavior remain unchanged.

## Evidence

- Reproduced both failures against the unpatched current main on Blacksmith Testbox `tbx_01kykmwgs3356cawv0yc4vkhyw`: four hidden reasoning chunks produced zero model-activity notifications, and a real `127.0.0.1` HTTP/SSE provider hit the production idle watchdog while reasoning chunks were still arriving.
- After the fix, the same real loopback SSE provider completes successfully beyond the watchdog budget for both `reasoning` and `reasoning_content`, returns `OK`, emits no thinking, and never fires the idle callback.
- `pnpm test packages/ai/src/providers/openai-completions.test.ts` — 59 passing tests, including three hidden reasoning field variants.
- `pnpm test src/agents/openai-transport-stream.streaming.test.ts` — 46 passing tests, including both real HTTP/SSE provider reproductions.
- `pnpm test src/agents/embedded-agent-runner/run/llm-idle-timeout.test.ts` — 123 passing watchdog regressions.
- `pnpm test packages/ai/src/provider-transport-parity.test.ts` — 4 passing provider/transport parity tests.
- `pnpm check:changed` — passed formatting, core and test TypeScript, typed lint, plugin/SDK boundaries, dependency and environment guards, SQLite/storage guards, and runtime import-cycle checks on the same Testbox.
- `.agents/skills/autoreview/scripts/autoreview --mode uncommitted --stream-engine-output` — clean; no actionable findings.

AI-assisted implementation and review.
