### PR TITLE
fix(channels): Slack stops receiving messages while reporting healthy when its plugin is not a trusted install

### DIFF
--- a/docs/plugins/sdk-runtime.md
+++ b/docs/plugins/sdk-runtime.md
@@ -775,7 +775,7 @@ two-party event loops that do not go through the shared inbound reply runner.
     `openChannelIngressDrain(...)` opens the core channel-agnostic worker over that queue (or creates a queue when none is supplied). The drain owns stale-claim recovery, per-lane claim serialization, complete-at-adoption or complete-on-dispatch-return, retry/dead-letter disposition, optional pre-adoption supersede, and claim→adoption stall timeout. Wire claim ownership into reply generation with `turnAdoptionLifecycle` (via `bindIngressLifecycleToReplyOptions` from `plugin-sdk/channel-outbound`). Channel plugins keep accept-side enqueue, lane derivation, non-retryable classification, and any supersede authorization policy.
 
     <Warning>
-    `openBlobStore`, `openKeyedStore`, `openSyncKeyedStore`, `withLease`, `openChannelIngressQueue`, and `openChannelIngressDrain` are available only to bundled plugins and trusted official plugin installations in this release.
+    `openBlobStore`, `openKeyedStore`, `openSyncKeyedStore`, `withLease`, `openChannelIngressQueue`, and `openChannelIngressDrain` are available only to bundled plugins and trusted official plugin installations in this release. The rejection names the plugin id and the origin it loaded from; a channel plugin loaded from `plugins.load.paths` or an unofficial install is untrusted, so its ingress monitor fails channel start instead of running without a durable queue.
     </Warning>
 
   </Accordion>

--- a/src/channels/message/ingress-monitor.test.ts
+++ b/src/channels/message/ingress-monitor.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
 import { closeOpenClawStateDatabaseForTest } from "../../state/openclaw-state-db.js";
+import { sleep } from "../../utils/sleep.js";
 import {
   createChannelIngressMonitor,
   type ChannelIngressMonitorDeliveryResult,
@@ -27,7 +28,7 @@ async function withQueue<T>(
 }
 
 function createMonitor(
-  queue: ChannelIngressQueue<StoredEvent>,
+  queue: ChannelIngressQueue<StoredEvent> | (() => ChannelIngressQueue<StoredEvent>),
   deliver: (
     raw: RawEvent,
     lifecycle: ChannelIngressMonitorLifecycle,
@@ -491,6 +492,30 @@ describe("channel ingress monitor", () => {
       expect(deliver).toHaveBeenCalledOnce();
       await recovered.stop();
     });
+  });
+
+  it("fails start once when the durable queue cannot be opened", async () => {
+    const denial = new Error(
+      'openChannelIngressQueue is only available for trusted plugins in this release. Plugin "slack" loaded with origin "config"',
+    );
+    const queueFactory = vi.fn((): ChannelIngressQueue<StoredEvent> => {
+      throw denial;
+    });
+    const onError = vi.fn();
+    const monitor = createMonitor(queueFactory, vi.fn(), undefined, onError, undefined, 1);
+
+    expect(() => monitor.start()).toThrow(denial);
+    expect(monitor.isRunning()).toBe(false);
+    // An armed poll timer would have retried the denied factory many times over this window.
+    await sleep(25);
+    expect(queueFactory).toHaveBeenCalledOnce();
+    expect(onError).not.toHaveBeenCalled();
+
+    // Accepted transport input still fails closed rather than being silently dropped.
+    await expect(monitor.admit({ id: "event-denied", lane: "a", text: "hello" })).rejects.toBe(
+      denial,
+    );
+    await monitor.stop();
   });
 
   it("can defer delivery-idle waiting to a channel-owned shutdown grace", async () => {

--- a/src/channels/message/ingress-monitor.ts
+++ b/src/channels/message/ingress-monitor.ts
@@ -601,6 +601,10 @@ export function createChannelIngressMonitor<TRaw, TBody, TStoredPayload, TMetada
       if (running || stopped || isAborted()) {
         return;
       }
+      // Open the durable queue before arming the poll timer. A monitor without a queue can
+      // neither admit nor drain, so channel start must fail through the caller instead of
+      // running a timer that reports the same unrecoverable error on every tick.
+      getQueue();
       running = true;
       pollTimer = setInterval(requestDrain, options.pollIntervalMs);
       pollTimer.unref?.();

--- a/src/plugin-state/plugin-state-store.runtime.test.ts
+++ b/src/plugin-state/plugin-state-store.runtime.test.ts
@@ -264,7 +264,7 @@ describe("plugin runtime state proxy", () => {
     ).toThrow("openKeyedStore is only available for trusted plugins");
     expect(() =>
       api.runtime.state.openSyncKeyedStore({ namespace: "runtime", maxEntries: 10 }),
-    ).toThrow("openKeyedStore is only available for trusted plugins");
+    ).toThrow("openSyncKeyedStore is only available for trusted plugins");
     expect(() =>
       api.runtime.state.openBlobStore({
         namespace: "runtime",
@@ -285,6 +285,17 @@ describe("plugin runtime state proxy", () => {
         async () => undefined,
       ),
     ).toThrow("withLease is only available for trusted plugins");
+  });
+
+  it("names the denied capability, plugin, and origin for channel ingress queues", () => {
+    const registry = createTestPluginRegistry();
+    const record = createPluginRecord("slack", "config");
+    registry.registry.plugins.push(record);
+    const api = registry.createApi(record, { config: {} });
+
+    expect(() => api.runtime.state.openChannelIngressQueue()).toThrow(
+      /openChannelIngressQueue is only available for trusted plugins in this release\. Plugin "slack" loaded with origin "config"/,
+    );
   });
 
   it("rejects untrusted global plugins", () => {

--- a/src/plugins/registry-runtime.ts
+++ b/src/plugins/registry-runtime.ts
@@ -540,15 +540,19 @@ export function createPluginRuntimeResolver(state: PluginRegistryState) {
             methodName:
               | "openBlobStore"
               | "openKeyedStore"
+              | "openSyncKeyedStore"
               | "withLease"
+              | "openChannelIngressQueue"
               | "openChannelIngressDrain",
           ) => {
             const record =
               pluginRuntimeRecordById.get(pluginId) ??
               registry.plugins.find((entry) => entry.id === pluginId);
             if (record?.origin !== "bundled" && record?.trustedOfficialInstall !== true) {
+              // Name the denied plugin and its origin: several plugins share this gate, and a
+              // bare capability name cannot tell an operator which install needs replacing.
               throw new Error(
-                `${methodName} is only available for trusted plugins in this release.`,
+                `${methodName} is only available for trusted plugins in this release. Plugin "${pluginId}" loaded with origin "${record?.origin ?? "unknown"}"; reinstall it from its official npm package or ClawHub listing to enable trusted plugin state.`,
               );
             }
           };
@@ -567,7 +571,7 @@ export function createPluginRuntimeResolver(state: PluginRegistryState) {
             openSyncKeyedStore: <T>(
               options: OpenKeyedStoreOptions,
             ): PluginStateSyncKeyedStore<T> => {
-              assertPluginStateAllowed("openKeyedStore");
+              assertPluginStateAllowed("openSyncKeyedStore");
               return createPluginStateSyncKeyedStore<T>(pluginId, options);
             },
             withLease: <T>(
@@ -580,7 +584,7 @@ export function createPluginRuntimeResolver(state: PluginRegistryState) {
             openChannelIngressQueue: <TPayload, TMetadata = unknown, TCompletedMetadata = unknown>(
               options?: Omit<Parameters<typeof createChannelIngressQueue>[0], "channelId">,
             ) => {
-              assertPluginStateAllowed("openKeyedStore");
+              assertPluginStateAllowed("openChannelIngressQueue");
               const stateDir = options?.stateDir ?? baseState.resolveStateDir();
               return createChannelIngressQueue<TPayload, TMetadata, TCompletedMetadata>({
                 ...options,


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where operators running a channel plugin that is not a trusted install
would have that channel silently stop receiving messages while the gateway kept
reporting it as connected and healthy, and while the gateway log filled with one
"ingress drain failed" line per second, forever.

Observed on a production gateway (latest `main`, Slack over Socket Mode):

- `slack ingress drain failed: openKeyedStore is only available for trusted plugins in this release.`
- ~3,550 occurrences per hour, sustained — 59-60/min, exactly the Slack ingress poll interval — in every hour of the retained log window (26+ hours; 5,904 in the current file alone).
- Logged at **INFO** (`logLevelId: 3`) despite saying "failed", so nothing could ever alert on it.
- Channel status simultaneously reported `enabled, configured, running, connected, health:healthy`.
- Not one inbound Slack event was processed in the entire retained window; only `slack socket mode connected` appears.

The apparent 04:00:00.833Z onset was a red herring: the host rotates logs at local
midnight (UTC-4), the first line of the new file is 04:00:00.450Z, and the previous
day's file opens at 04:00:00.333Z with the same error. The condition was continuous.

## Why This Change Was Made

`openChannelIngressQueue` is documented as available only to bundled plugins and
trusted official installs. Slack ships as an official external plugin
(`@openclaw/slack`), so a copy loaded through `plugins.load.paths` from a source
checkout is correctly untrusted and the capability is correctly denied. The denial is
not the defect — the handling of it is.

`createChannelIngressMonitor` resolved its durable queue lazily, so `start()` armed the
poll timer without ever touching the queue. Every subsequent tick called the throwing
factory again, and the shared pump routed the rejection into `onError`, which channels
wire to their ordinary log. A permanently unusable monitor therefore presented as an
endless stream of low-severity noise instead of a failed channel: no drain, no
admission, no visible failure.

The monitor now opens the queue before arming the poll timer, so a monitor that cannot
work fails channel start through the caller — the existing path for "this channel could
not start" — rather than running a timer that reports the same unrecoverable error
86,400 times a day. This is shared behavior across the 18 channel plugins built on this
monitor; for a bundled or trusted install the factory never throws and nothing changes.

The trust gate itself was also misreporting: `openChannelIngressQueue` and
`openSyncKeyedStore` both announced themselves as `openKeyedStore`, and the message
named neither the plugin nor where it was loaded from — so the log blamed an API Slack
never calls, on an unnamed plugin. It now names the denied capability, the plugin id,
its origin, and the remediation.

Deliberately not changed: the trust classification. Widening it to silence the log
would hand shared-state access to any sideloaded plugin. The correct operator fix is to
install the plugin from its official npm package or ClawHub listing.

## User Impact

A channel plugin that cannot open its durable ingress queue now fails to start with an
actionable error naming the plugin, its origin, and how to fix it, instead of appearing
healthy while dropping every inbound message and writing ~86k INFO log lines a day.
Trusted and bundled channels are unaffected.

Operational remedy for anyone already in this state: install the plugin properly so it
carries an install record and a trusted origin — for Slack, `openclaw plugins install
@openclaw/slack` — then remove the corresponding `plugins.load.paths` entry from
`openclaw.json` and restart the gateway. Inbound delivery resumes once the plugin loads
with a trusted origin. This change makes that state loud rather than silent; it does not
by itself restore a source-linked install.

Known confound when verifying on a live workspace: if several hosts connect with the
same Slack app token, Slack shards Socket Mode events across those connections and
delivers each event to only one of them. The affected gateway logged
`slack socket mode reports 9 active connections for this Slack app`. A tester can see
events vanish for reasons unrelated to ingress, so confirm a single active connection
before drawing conclusions.

## Evidence

### After-fix runtime proof

Real Node process against the production seams — `createPluginRegistry` builds a plugin
record with `origin: "config"` exactly as the affected host loads Slack, the queue
factory is the same `api.runtime.state.openChannelIngressQueue({ accountId })` call the
Slack plugin makes at `extensions/slack/src/monitor/ingress.ts:235`, and the monitor uses
Slack's 1000 ms `pollIntervalMs`. Isolated `OPENCLAW_STATE_DIR`, no credentials, no
network, nothing redacted because nothing sensitive is produced.

**Before (this branch reverted to `main` behavior) — reproduces the production symptom:**

```
t+18268ms plugin record: id=slack origin=config trustedOfficialInstall=undefined
t+18269ms monitor.start() returned normally; isRunning=true
t+18269ms [INFO] slack ingress drain failed: openChannelIngressQueue is only available for trusted plugins in this release. Plugin "slack" ...
t+19272ms [INFO] slack ingress drain failed: openChannelIngressQueue is only available for trusted plugins in this release. Plugin "slack" ...
t+20276ms [INFO] slack ingress drain failed: openChannelIngressQueue is only available for trusted plugins in this release. Plugin "slack" ...
t+21278ms [INFO] slack ingress drain failed: openChannelIngressQueue is only available for trusted plugins in this release. Plugin "slack" ...
t+22279ms [INFO] slack ingress drain failed: openChannelIngressQueue is only available for trusted plugins in this release. Plugin "slack" ...
t+23280ms [INFO] slack ingress drain failed: openChannelIngressQueue is only available for trusted plugins in this release. Plugin "slack" ...
t+23369ms --- 5s window closed ---
t+23369ms drain-error lines emitted: 6
t+23370ms start() threw: no
t+23772ms admit() failed closed: openChannelIngressQueue is only available for trusted plugin...
```

One line per second, `isRunning=true`, inbound silently rejected — the same shape as the
production log.

**After (this branch):**

```
t+11875ms plugin record: id=slack origin=config trustedOfficialInstall=undefined
t+11876ms monitor.start() THREW; isRunning=false
t+11876ms [channel start failure] openChannelIngressQueue is only available for trusted plugins in this release. Plugin "slack" loaded with origin "config"; reinstall it from its official npm package or ClawHub listing to enable trusted plugin state.
t+16977ms --- 5s window closed ---
t+16977ms drain-error lines emitted: 0
t+16977ms start() threw: yes
t+17380ms admit() failed closed: openChannelIngressQueue is only available for trusted plugin...
```

One actionable failure naming the plugin, its origin, and the remedy; zero interval spam.

**Trusted path unchanged** — same script, same branch, `origin: "bundled"`:

```
t+ 9923ms plugin record: id=slack origin=bundled trustedOfficialInstall=undefined
t+ 9925ms monitor.start() returned normally; isRunning=true
t+15027ms --- 5s window closed ---
t+15027ms drain-error lines emitted: 0
t+15027ms start() threw: no
t+15037ms admit() accepted the event (inbound would be processed)
```

The queue opens, the monitor runs, and an inbound event is admitted. This is the path all
18 channel plugins on the shared monitor take for a bundled or trusted-official install,
and it is byte-identical to `main`.

Remaining gap: no live Slack round trip. Restoring inbound on the affected host requires
installing `@openclaw/slack` as a trusted package on a production gateway, which is a
configuration change outside this PR.

### Other proof

- Live production log analysis on the affected gateway: per-hour histogram of the error
  across the full retained window (2026-07-27T04Z through 2026-07-28T05Z) showing a flat
  ~3,550/hour with no onset boundary, plus the log-rotation timestamps that explain the
  apparent 04:00 trigger.
- New regression test in `src/channels/message/ingress-monitor.test.ts`: `start()`
  throws, the monitor does not run, the factory is invoked exactly once across a window
  covering 25 poll ticks, `onError` is never called, and `admit()` still fails closed.
  This test fails on `main`, where `start()` returns cleanly and the timer spins.
- New regression test in `src/plugin-state/plugin-state-store.runtime.test.ts` locking
  the denial message to the actual capability name plus the plugin id and origin; the
  existing `openSyncKeyedStore` assertion was corrected from `openKeyedStore`.
- Focused suites green via `node scripts/run-vitest.mjs`.
- `node scripts/check-changed.mjs` green on Blacksmith Testbox (typecheck core, typecheck
  core tests, lint, format, plugin boundaries, SDK contract manifest).
- Codex autoreview clean.
