### PR TITLE
fix(agents): prefer native Windows PowerShell on PATH

### DIFF
--- a/src/agents/shell-utils.test.ts
+++ b/src/agents/shell-utils.test.ts
@@ -486,6 +486,51 @@ describe("getShellConfig on Windows", () => {
     expect(getShellConfig().shell).toBe(pwshPath);
   });
 
+  it("finds pwsh.exe on PATH when PowerShell 7 is not in ProgramFiles", () => {
+    const programFiles = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-pfiles-"));
+    const binDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-bin-"));
+    tempDirs.push(programFiles, binDir);
+    const pwshPath = path.join(binDir, "pwsh.exe");
+    fs.writeFileSync(pwshPath, "");
+    fs.chmodSync(pwshPath, 0o755);
+
+    process.env.ProgramFiles = programFiles;
+    process.env.PATH = binDir;
+    delete process.env.ProgramW6432;
+    delete process.env.SystemRoot;
+    delete process.env.WINDIR;
+
+    expect(getShellConfig().shell).toBe(pwshPath);
+  });
+
+  it("prefers a native pwsh.exe over earlier bare shims, batch wrappers, and PowerShell 5.1", () => {
+    const programFiles = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-pfiles-"));
+    const shimDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-shim-"));
+    const binDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-bin-"));
+    const systemRoot = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-sysroot-"));
+    tempDirs.push(programFiles, shimDir, binDir, systemRoot);
+    const bareShimPath = path.join(shimDir, "pwsh");
+    const pwshPath = path.join(binDir, "pwsh.exe");
+    const batchPath = path.join(binDir, "pwsh.cmd");
+    const powershellDir = path.join(systemRoot, "System32", "WindowsPowerShell", "v1.0");
+    fs.mkdirSync(powershellDir, { recursive: true });
+    fs.writeFileSync(bareShimPath, "");
+    fs.writeFileSync(pwshPath, "");
+    fs.writeFileSync(batchPath, "");
+    fs.writeFileSync(path.join(powershellDir, "powershell.exe"), "");
+    fs.chmodSync(bareShimPath, 0o755);
+    fs.chmodSync(pwshPath, 0o755);
+    fs.chmodSync(batchPath, 0o755);
+
+    process.env.ProgramFiles = programFiles;
+    process.env.SystemRoot = systemRoot;
+    process.env.PATH = [shimDir, binDir].join(path.delimiter);
+    delete process.env.ProgramW6432;
+    delete process.env.WINDIR;
+
+    expect(getShellConfig().shell).toBe(pwshPath);
+  });
+
   it("falls back to Windows PowerShell 5.1 path when pwsh is unavailable", () => {
     const programFiles = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-pfiles-"));
     const sysRoot = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-sysroot-"));

--- a/src/agents/shell-utils.ts
+++ b/src/agents/shell-utils.ts
@@ -267,13 +267,17 @@ function resolveShellFromPath(
     return undefined;
   }
   const entries = envPath.split(path.delimiter).filter(Boolean);
-  for (const entry of entries) {
-    const candidate = path.join(entry, name);
-    try {
-      fs.accessSync(candidate, fs.constants.X_OK);
-      return candidate;
-    } catch {
-      // ignore missing or non-executable entries
+  const executableNames =
+    process.platform === "win32" && !path.extname(name) ? [`${name}.exe`, name] : [name];
+  for (const executableName of executableNames) {
+    for (const entry of entries) {
+      const candidate = path.join(entry, executableName);
+      try {
+        fs.accessSync(candidate, fs.constants.X_OK);
+        return candidate;
+      } catch {
+        // Ignore missing or non-executable entries.
+      }
     }
   }
   return undefined;


### PR DESCRIPTION
Supersedes #111500. Thanks to @labsclaw for identifying the original Windows PowerShell PATH-discovery failure.

AI-assisted.

## What Problem This Solves

Fixes an issue where Windows users with PowerShell 7 installed as `pwsh.exe` on `PATH` would silently run Windows PowerShell 5.1 instead. Microsoft Store, portable, and custom installations are affected when `pwsh.exe` is not under `ProgramFiles`.

## Why This Change Was Made

The existing shared shell resolver now searches all Windows `PATH` entries for a directly launchable native `.exe` before considering extensionless shims. This Windows-only precedence is intentional for every extensionless shell lookup: a bare file cannot be launched as a native Windows executable merely because `fs.accessSync(..., X_OK)` succeeds, since Node documents that `X_OK` behaves like `F_OK` on Windows. Existing bare fallback, explicit executable extensions, POSIX shell lookup, and Windows PowerShell 5.1 fallback remain intact. `.cmd` and `.bat` wrappers are deliberately not selected because the shell may be launched directly through a PTY.

## User Impact

Windows agent and session commands select the installed native PowerShell 7 executable consistently, including when an earlier `PATH` entry contains a Unix-style shim or a `.cmd` wrapper.

## Evidence

Exact reviewed head: `a902ab78f77913fc930e5a4a7de99de29ff9c8db`.

- Red before fix: on current `main`, both production-entrypoint regressions fail on Blacksmith Testbox `tbx_01kykn6j11ntmdjn873qwze6ay`, returning `powershell.exe` or Windows PowerShell 5.1 instead of the actual `PATH/pwsh.exe`: https://github.com/openclaw/openclaw/actions/runs/30333612708.
- Green after fix: `pnpm test src/agents/shell-utils.test.ts src/process/windows-command.test.ts src/infra/executable-path.test.ts` passes all three shell, process, and executable-resolution suites on the same Testbox.
- `pnpm check:changed` passes remote production and test typechecks, changed-file lint and formatting, import cycles, architecture, dependency, and package guards.
- Real native Windows runner: `blacksmith-16vcpu-windows-2025`; `Probe native Windows` and `Run Windows CI tests` both completed successfully with `target_ref=a902ab78f77913fc930e5a4a7de99de29ff9c8db`: https://github.com/openclaw/openclaw/actions/runs/30335348335/job/90198927779.
- Exact-head full CI and merge gate: https://github.com/openclaw/openclaw/actions/runs/30335350832 and https://github.com/openclaw/openclaw/actions/runs/30335350832/job/90200616886, both successful.
- Final exact-head structured autoreview: clean, with no accepted or actionable findings.
- Canonical PR decision: #111500 describes the same bug but currently has zero changed files. This PR retains the original `.exe`-only intent, adds earlier-shim precedence coverage, and supplies current-main red/green, native Windows, and exact-head merge-gate evidence.
