### PR TITLE
fix(ui): add discard escape hatch for stuck cloud-session recovery

### DIFF
--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -573,6 +573,7 @@ export const en: TranslationMap = {
     createFailed: "Couldn't create the thread.",
     createOutcomeUnknown:
       "The Gateway changed while this thread was starting. Check recent threads before starting this task again.",
+    dismissStuckCloudRecovery: "Discard and start over",
     catalogUnavailable: "This thread target is unavailable.",
   },
   dashboardsPage: {

--- a/ui/src/pages/new-session/cloud-recovery-state.test.ts
+++ b/ui/src/pages/new-session/cloud-recovery-state.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it } from "vitest";
-import { PendingCloudRecoveryState } from "./cloud-recovery-state.ts";
+import { isCloudRecoveryStuck, PendingCloudRecoveryState } from "./cloud-recovery-state.ts";
 import { readCloudSessionRecovery } from "./cloud-recovery.ts";
 
 describe("pending cloud recovery state", () => {
@@ -129,5 +129,39 @@ describe("pending cloud recovery state", () => {
     });
     expect(captured?.attachments).not.toBe(pending.attachments);
     expect(captured?.createParams).not.toBe(pending.createParams);
+  });
+});
+
+describe("isCloudRecoveryStuck", () => {
+  it("is stuck only when a cloud create is in flight, the outcome is unknown, and retry is impossible", () => {
+    expect(
+      isCloudRecoveryStuck({ pendingCloud: true, submissionOutcomeUnknown: true, canRetry: false }),
+    ).toBe(true);
+  });
+
+  it("is not stuck when the create can still be retried", () => {
+    expect(
+      isCloudRecoveryStuck({ pendingCloud: true, submissionOutcomeUnknown: true, canRetry: true }),
+    ).toBe(false);
+  });
+
+  it("is not stuck when there is no in-flight cloud create", () => {
+    expect(
+      isCloudRecoveryStuck({
+        pendingCloud: false,
+        submissionOutcomeUnknown: true,
+        canRetry: false,
+      }),
+    ).toBe(false);
+  });
+
+  it("is not stuck when the outcome is still known", () => {
+    expect(
+      isCloudRecoveryStuck({
+        pendingCloud: true,
+        submissionOutcomeUnknown: false,
+        canRetry: false,
+      }),
+    ).toBe(false);
   });
 });

--- a/ui/src/pages/new-session/cloud-recovery-state.ts
+++ b/ui/src/pages/new-session/cloud-recovery-state.ts
@@ -25,6 +25,20 @@ export function resolveScope(
   return { next, changed: !firstBind && snapshot.connected && current !== next };
 }
 
+/**
+ * A cloud create is stuck when its outcome is unknown and it can no longer be
+ * retried (for example the Gateway changed mid-create, so the in-flight create
+ * cannot be confirmed or replayed). In that dead-end the draft is locked with
+ * no escape short of closing the tab, so the caller offers a discard action.
+ */
+export function isCloudRecoveryStuck(params: {
+  pendingCloud: boolean;
+  submissionOutcomeUnknown: boolean;
+  canRetry: boolean;
+}): boolean {
+  return params.pendingCloud && params.submissionOutcomeUnknown && !params.canRetry;
+}
+
 export class PendingCloudRecoveryState {
   sessionKey = "";
   messageId = "";

--- a/ui/src/pages/new-session/new-session-page.ts
+++ b/ui/src/pages/new-session/new-session-page.ts
@@ -27,7 +27,11 @@ import { prepareInitialUserMessageHandoff } from "../chat/initial-turn-handoff.t
 import { NewSessionAttachmentDraft } from "./attachment-draft.ts";
 import * as catalog from "./catalog-target.ts";
 import { CloudProfileDiscovery, selectProfiles } from "./cloud-profile-discovery.ts";
-import { PendingCloudRecoveryState, resolveScope } from "./cloud-recovery-state.ts";
+import {
+  isCloudRecoveryStuck,
+  PendingCloudRecoveryState,
+  resolveScope,
+} from "./cloud-recovery-state.ts";
 import { advanceCloudDraftSession } from "./cloud-submit.ts";
 import {
   NewSessionComposerTextareaController,
@@ -1594,10 +1598,7 @@ class NewSessionPage extends OpenClawLightDomElement {
       <div class="new-session-page__draft" aria-busy=${String(this.submitting)}>
         ${this.renderTargetBar()}
         ${worktreeNameInvalid ? renderDraftError(t("newSession.worktreeNameInvalid")) : nothing}
-        ${this.error ? renderDraftError(this.error) : nothing}
-        ${this.submissionOutcomeUnknown
-          ? renderDraftError(t("newSession.createOutcomeUnknown"))
-          : nothing}
+        ${this.error ? renderDraftError(this.error) : nothing} ${this.renderCreateOutcomeUnknown()}
         ${renderNewSessionDraftComposer({
           agent: this.selectedAgent(),
           agentId: this.agentId,
@@ -1626,6 +1627,35 @@ class NewSessionPage extends OpenClawLightDomElement {
           onSubmit: () => void this.submit(),
         })}
       </div>
+    `;
+  }
+
+  /** Outcome-unknown error, with a discard escape hatch when the cloud create is stuck. */
+  private renderCreateOutcomeUnknown() {
+    if (!this.submissionOutcomeUnknown) {
+      return nothing;
+    }
+    const error = renderDraftError(t("newSession.createOutcomeUnknown"));
+    if (
+      !isCloudRecoveryStuck({
+        pendingCloud: Boolean(this.pendingCloud.sessionKey),
+        submissionOutcomeUnknown: this.submissionOutcomeUnknown,
+        canRetry: this.canSubmit(),
+      })
+    ) {
+      return error;
+    }
+    // The create cannot be retried (e.g. the Gateway changed mid-create), so the
+    // draft would stay locked until the tab closes. Let the user discard it.
+    return html`
+      ${error}
+      <button
+        type="button"
+        class="btn btn--sm btn--ghost new-session-page__recovery-dismiss"
+        @click=${() => this.clearPendingCloudRecovery()}
+      >
+        ${t("newSession.dismissStuckCloudRecovery")}
+      </button>
     `;
   }
 


### PR DESCRIPTION
## What Problem This Solves

When a cloud thread create is interrupted by a Gateway change (for example a restart while the create is in flight), the new-session page persists a recovery record in `sessionStorage` and shows:

> The Gateway changed while this thread was starting. Check recent threads before starting this task again.

If the create can no longer be retried (`retryAllowed` cleared by the transport loss, or the Gateway identity no longer matches), the draft is **locked with no escape**:

- `pendingCloud.sessionKey` is set, so every input and the cloud target selector are disabled (`new-session-page.ts` gates many controls on `pendingCloud.sessionKey`).
- `resetDraft()` deliberately *preserves* an in-flight `pendingCloud` (`new-session-page.ts`).
- The Gateway-identity-changed auto-reset (`new-session-page.ts`) only fires when `gatewayUrl`/`recoveryScope` no longer match — a plain restart keeps the same identity, so it does not fire.
- There is no dismiss affordance.

So the user cannot select a cloud target again until they close the browser tab (clearing `sessionStorage`).

## Why This Change Was Made

Add a discard escape hatch for this dead-end. When a cloud create is in flight, its outcome is unknown, and it cannot be retried, render a **"Discard and start over"** button next to the outcome-unknown error. It calls the existing `clearPendingCloudRecovery()` (which clears the persisted recovery and resets `submissionOutcomeUnknown`), unlocking the draft and the cloud selector.

- `cloud-recovery-state.ts`: extract `isCloudRecoveryStuck({ pendingCloud, submissionOutcomeUnknown, canRetry })` — a pure predicate (true only for the dead-end) so the condition is unit-testable without the Lit component.
- `new-session-page.ts`: `renderCreateOutcomeUnknown()` renders the error plus the discard button only when `isCloudRecoveryStuck` is true; when retry is still possible, only the error shows (the Start button already retries).
- `en.ts`: `newSession.dismissStuckCloudRecovery = "Discard and start over"` (English source only; foreign bundles are generated).

The discard is intentionally shown only when retry is impossible, so it never competes with the normal retry path.

## User Impact

A cloud thread start that gets wedged by a Gateway change no longer requires closing the tab. The user sees a "Discard and start over" button, clicks it, and can immediately select a cloud target and start again.

## Evidence

- `pnpm --dir ui test cloud-recovery-state` — 9 passed, including 4 new `isCloudRecoveryStuck` cases (stuck only when in-flight + outcome unknown + not retryable).
- `pnpm --dir ui test cloud-` — 55 passed across the cloud flow tests (no regression).
- `pnpm ui:i18n:verify` — clean (keys=4139).
- `pnpm tsgo:ui` and `oxlint` — clean for the changed files.

Note: this is a UI-source change; it takes effect in the served Control UI only after `pnpm ui:build`. Local `$autoreview` could not run (no codex/claude/trufflehog CLIs on this machine); relying on CI + review.
