### PR TITLE
fix: speed up doctor on large SQLite state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,7 +51,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- **SQLite open performance:** verify each state and agent database once on healthy opens and reserve per-table integrity scans for repairing detected index corruption, reducing doctor and update time on large deployments without weakening corruption checks.
 - **Codex native controls:** stop misclassifying valid thinking/fast runtime controls as provider overrides so Codex routes keep their native controls, while provider-native objects and invalid values stay fail-closed. Thanks @VACInc. (#107588)
 - **State snapshot verification:** run SQLite snapshot verification in a separate process so worker-thread file closes no longer drop the Gateway's POSIX WAL locks, eliminating spurious WAL misses and I/O errors. Thanks @VACInc. (#114016)
 - **Reply latency with model policies:** reuse one immutable plugin-metadata snapshot per model-selection run instead of repeating plugin discovery, cutting reply delay when a model policy is configured. Thanks @VACInc. (#114117)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **SQLite open performance:** verify each state and agent database once on healthy opens and reserve per-table integrity scans for repairing detected index corruption, reducing doctor and update time on large deployments without weakening corruption checks.
 - **Codex native controls:** stop misclassifying valid thinking/fast runtime controls as provider overrides so Codex routes keep their native controls, while provider-native objects and invalid values stay fail-closed. Thanks @VACInc. (#107588)
 - **State snapshot verification:** run SQLite snapshot verification in a separate process so worker-thread file closes no longer drop the Gateway's POSIX WAL locks, eliminating spurious WAL misses and I/O errors. Thanks @VACInc. (#114016)
 - **Reply latency with model policies:** reuse one immutable plugin-metadata snapshot per model-selection run instead of repeating plugin discovery, cutting reply delay when a model policy is configured. Thanks @VACInc. (#114117)

--- a/src/infra/sqlite-index-schema.test.ts
+++ b/src/infra/sqlite-index-schema.test.ts
@@ -1,6 +1,9 @@
 import { DatabaseSync } from "node:sqlite";
 import { describe, expect, it } from "vitest";
-import { repairCanonicalSqliteIndexes } from "./sqlite-index-schema.js";
+import {
+  repairCanonicalSqliteIndexes,
+  verifyAndRepairCanonicalSqliteIndexes,
+} from "./sqlite-index-schema.js";
 
 const CANONICAL_SCHEMA = `
   CREATE TABLE records (
@@ -25,13 +28,50 @@ function createDatabase(): DatabaseSync {
   return db;
 }
 
+function tracePreparedSql(database: DatabaseSync): {
+  database: DatabaseSync;
+  statements: string[];
+} {
+  const statements: string[] = [];
+  return {
+    database: new Proxy(database, {
+      get(target, property) {
+        if (property === "prepare") {
+          return (sql: string) => {
+            statements.push(sql);
+            return target.prepare(sql);
+          };
+        }
+        const value = Reflect.get(target, property, target) as unknown;
+        return typeof value === "function" ? value.bind(target) : value;
+      },
+    }) as DatabaseSync,
+    statements,
+  };
+}
+
 describe("repairCanonicalSqliteIndexes", () => {
+  it("runs one whole-file integrity check for healthy indexes", () => {
+    const db = createDatabase();
+    try {
+      const traced = tracePreparedSql(db);
+
+      verifyAndRepairCanonicalSqliteIndexes(traced.database, "test database", CANONICAL_SCHEMA);
+
+      expect(traced.statements.filter((sql) => sql.startsWith("PRAGMA integrity_check"))).toEqual([
+        "PRAGMA integrity_check;",
+      ]);
+    } finally {
+      db.close();
+    }
+  });
+
   it("does not rewrite an already canonical index", () => {
     const db = createDatabase();
     try {
       const before = db.prepare("PRAGMA schema_version").get();
 
-      repairCanonicalSqliteIndexes(db, "test database", CANONICAL_SCHEMA);
+      verifyAndRepairCanonicalSqliteIndexes(db, "test database", CANONICAL_SCHEMA);
 
       expect(db.prepare("PRAGMA schema_version").get()).toEqual(before);
     } finally {
@@ -159,7 +199,7 @@ describe("repairCanonicalSqliteIndexes", () => {
           .all(),
       ).toEqual([]);
 
-      repairCanonicalSqliteIndexes(db, "test database", CANONICAL_SCHEMA);
+      verifyAndRepairCanonicalSqliteIndexes(db, "test database", CANONICAL_SCHEMA);
 
       expect(db.prepare("PRAGMA integrity_check").get()).toEqual({ integrity_check: "ok" });
       expect(

--- a/src/infra/sqlite-index-schema.ts
+++ b/src/infra/sqlite-index-schema.ts
@@ -19,6 +19,47 @@ type SqliteIndexListRow = {
   unique: number;
 };
 
+type RepairCanonicalSqliteIndexesOptions = {
+  /**
+   * A recognized schema migration may add a column before recreating its
+   * canonical index. No other repair failure is deferred.
+   */
+  allowMissingColumns?: boolean;
+  /** Keep index repair atomic with the caller's whole-schema validation. */
+  validateAfterRepair?: () => void;
+  verifyPhysicalIntegrity?: boolean;
+};
+
+/**
+ * Verify the whole file once, then use table scans only to locate repairable
+ * index damage. Healthy opens must not multiply integrity work by table count.
+ */
+export function verifyAndRepairCanonicalSqliteIndexes(
+  db: DatabaseSync,
+  databaseLabel: string,
+  schemaSql: string,
+  options: Omit<RepairCanonicalSqliteIndexesOptions, "verifyPhysicalIntegrity"> = {},
+): string[] {
+  let integrityFailure: Error | undefined;
+  try {
+    assertSqliteIntegrity(db, databaseLabel);
+  } catch (error) {
+    if (!(error instanceof Error) || !isTerminalSqliteIntegrityError(error)) {
+      throw error;
+    }
+    integrityFailure = error;
+  }
+
+  const repairedIndexes = repairCanonicalSqliteIndexes(db, databaseLabel, schemaSql, {
+    ...options,
+    verifyPhysicalIntegrity: integrityFailure !== undefined,
+  });
+  if (integrityFailure && repairedIndexes.length === 0) {
+    throw integrityFailure;
+  }
+  return repairedIndexes;
+}
+
 /**
  * Restore every named index when SQLite's IF NOT EXISTS semantics preserve a
  * same-name definition or b-tree that no longer matches the committed schema.
@@ -27,16 +68,7 @@ export function repairCanonicalSqliteIndexes(
   db: DatabaseSync,
   databaseLabel: string,
   schemaSql: string,
-  options: {
-    /**
-     * A recognized schema migration may add a column before recreating its
-     * canonical index. No other repair failure is deferred.
-     */
-    allowMissingColumns?: boolean;
-    /** Keep index repair atomic with the caller's whole-schema validation. */
-    validateAfterRepair?: () => void;
-    verifyPhysicalIntegrity?: boolean;
-  } = {},
+  options: RepairCanonicalSqliteIndexesOptions = {},
 ): string[] {
   const indexes = getCanonicalSqliteNamedIndexContracts(schemaSql);
   const indexesByTable = new Map<string, CanonicalSqliteNamedIndexContract[]>();

--- a/src/infra/sqlite-index-schema.ts
+++ b/src/infra/sqlite-index-schema.ts
@@ -54,6 +54,8 @@ export function verifyAndRepairCanonicalSqliteIndexes(
     ...options,
     verifyPhysicalIntegrity: integrityFailure !== undefined,
   });
+  // A non-empty repair result already passed table and whole-file integrity
+  // checks inside the repair savepoint, so it supersedes the initial failure.
   if (integrityFailure && repairedIndexes.length === 0) {
     throw integrityFailure;
   }

--- a/src/state/openclaw-agent-db-schema.ts
+++ b/src/state/openclaw-agent-db-schema.ts
@@ -1,7 +1,10 @@
 import type { DatabaseSync } from "node:sqlite";
 import { migrateMemoryIndexSourcesIdentity } from "../../packages/memory-host-sdk/src/host/memory-schema.js";
 import { executeSqliteQuerySync, getNodeSqliteKysely } from "../infra/kysely-sync.js";
-import { repairCanonicalSqliteIndexes } from "../infra/sqlite-index-schema.js";
+import {
+  repairCanonicalSqliteIndexes,
+  verifyAndRepairCanonicalSqliteIndexes,
+} from "../infra/sqlite-index-schema.js";
 import { assertSqliteIntegrity } from "../infra/sqlite-integrity.js";
 import { migrateSqliteSchemaToStrictInTransaction } from "../infra/sqlite-strict.js";
 import { runSqliteImmediateTransactionSync } from "../infra/sqlite-transaction.js";
@@ -470,17 +473,13 @@ export function assertAgentDatabaseIntegrityBeforeMutation(
       toVersion: OPENCLAW_AGENT_SCHEMA_VERSION,
     });
   }
-  // Named indexes are repairable; the full schema assertion below must run
-  // after this repair while still rejecting table and constraint drift.
-  const rebuiltIndexes =
-    userVersion === OPENCLAW_AGENT_SCHEMA_VERSION
-      ? repairCanonicalSqliteIndexes(database, pathname, OPENCLAW_AGENT_SCHEMA_SQL, {
-          allowMissingColumns: true,
-          validateAfterRepair: () =>
-            assertOpenClawAgentCurrentRuntimeSchema(database, { agentId, pathname }),
-        })
-      : [];
-  if (rebuiltIndexes.length === 0) {
+  if (userVersion === OPENCLAW_AGENT_SCHEMA_VERSION) {
+    verifyAndRepairCanonicalSqliteIndexes(database, pathname, OPENCLAW_AGENT_SCHEMA_SQL, {
+      allowMissingColumns: true,
+      validateAfterRepair: () =>
+        assertOpenClawAgentCurrentRuntimeSchema(database, { agentId, pathname }),
+    });
+  } else {
     // Every physical open proves the full file before schema mutation or exposure.
     assertSqliteIntegrity(database, pathname);
   }

--- a/src/state/openclaw-state-db.ts
+++ b/src/state/openclaw-state-db.ts
@@ -10,7 +10,10 @@ import {
 } from "../infra/kysely-sync.js";
 import { openNodeSqliteDatabase } from "../infra/node-sqlite.js";
 import type { SqliteFileGeneration } from "../infra/sqlite-file-generation.js";
-import { repairCanonicalSqliteIndexes } from "../infra/sqlite-index-schema.js";
+import {
+  repairCanonicalSqliteIndexes,
+  verifyAndRepairCanonicalSqliteIndexes,
+} from "../infra/sqlite-index-schema.js";
 import {
   assertSqliteIntegrity,
   confirmSqliteFileIntegrity,
@@ -463,14 +466,12 @@ function assertStateDatabaseIntegrityBeforeMutation(
       toVersion: OPENCLAW_STATE_SCHEMA_VERSION,
     });
   }
-  const rebuiltIndexes =
-    userVersion === OPENCLAW_STATE_SCHEMA_VERSION
-      ? repairCanonicalSqliteIndexes(database, pathname, OPENCLAW_STATE_SCHEMA_SQL, {
-          allowMissingColumns: true,
-          validateAfterRepair: () => assertCurrentStateRuntimeSchema(database, pathname),
-        })
-      : [];
-  if (rebuiltIndexes.length === 0) {
+  if (userVersion === OPENCLAW_STATE_SCHEMA_VERSION) {
+    verifyAndRepairCanonicalSqliteIndexes(database, pathname, OPENCLAW_STATE_SCHEMA_SQL, {
+      allowMissingColumns: true,
+      validateAfterRepair: () => assertCurrentStateRuntimeSchema(database, pathname),
+    });
+  } else {
     // Every physical open proves the full file before schema mutation or exposure.
     assertSqliteIntegrity(database, pathname);
   }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where operators updating or repairing a deployment with large SQLite state could wait several minutes for `openclaw doctor` because every healthy state and agent database ran one partial integrity scan per indexed table before repeating a full-database scan.

## Why This Change Was Made

Current-schema opens now run the authoritative full integrity and foreign-key checks first. Table-scoped integrity scans run only after terminal corruption is detected, where they remain necessary to locate and rebuild repairable index b-trees. Migration paths, quarantine behavior, schema validation, and post-repair full verification are unchanged.

SQLite documents that the whole-database form checks table and index ordering, missing or surplus index entries, constraints, freelist consistency, and page ownership. The table argument is a partial integrity check limited to that table and its associated indexes, so repeating every partial check adds work but no healthy-path coverage beyond the full check.

## User Impact

`openclaw doctor` and update flows avoid table-count-amplified SQLite scans on healthy databases. Large deployments should spend roughly one full scan per database instead of one scan per indexed table plus another full scan, while preserving automatic repair for detected index corruption.

## Evidence

- Production symptom: repeated supported updates spent 168-189 seconds in the doctor step while reporting slow agent database opens and SQLite transaction holds.
- Blacksmith focused helper proof: 15/15 tests passed on `tbx_01kykp3cc2hyh3bvth8kgd6p12`.
- Blacksmith state/agent regression proof: 206 tests passed, 6 skipped on `tbx_01kykp6mc0m1kz31qzwk9y0125`, including physically drifted index repair.
- Blacksmith changed-scope gate: passed in 5m39s on `tbx_01kykpkjsejvsx589w4n99wzzd`, covering formatting, core and core-test typechecks, lint, database-first guards, schema-version guards, and import-cycle checks.
- Final branch Codex autoreview (`gpt-5.6-sol`, xhigh): no accepted/actionable findings, patch correct with 0.91 confidence after explicitly tracing the post-repair whole-file verification.
- `git diff --check`: passed.
- Final Blacksmith focused rerun after clarifying that invariant: 15/15 tests passed on `tbx_01kykx1zcr71381fmv9jwhbp1d`.
- Operator-level proof was attempted twice after review: Blacksmith failed workflow dispatch with HTTP 500 before allocation; owned AWS lease `cbx_8f49cff7692b` accepted SSH but never reached its bootstrap-ready contract after 10 minutes, so no repository code ran and the lease was stopped.

Maintainer decision: accept the exact query-shape regression, the physically corrupted-index recovery test, the full state/agent suites, and exact-head CI as sufficient pre-merge evidence. The patch changes no schema, migration, quarantine, or persisted shape. Measure the supported production updater's Doctor step as the post-merge live confirmation rather than bypassing a failed remote-box readiness guard.
