### PR TITLE
fix(imessage): deliver service-qualified media to existing chats [AI-assisted]

### DIFF
--- a/extensions/imessage/src/send.test.ts
+++ b/extensions/imessage/src/send.test.ts
@@ -1793,6 +1793,63 @@ describe("sendMessageIMessage receipts", () => {
     );
   });
 
+  it("resolves service-qualified remote media through the canonical send RPC", async () => {
+    const client = createClient({
+      guid: "p:0/remote-resolved-media",
+      chat_guid: "any;-;+15550004567",
+      service: "iMessage",
+    });
+    const createClientForAccount = vi.fn(async () => client);
+    const withRemoteFile = vi.fn(
+      async (params: { use: (remotePath: string) => Promise<Record<string, unknown>> }) =>
+        await params.use("/tmp/openclaw-imessage-safe/photo.png"),
+    );
+
+    const result = await sendMessageIMessage("imessage:+15550004567", "", {
+      config: {
+        channels: {
+          imessage: {
+            accounts: {
+              default: {
+                remoteHost: "work@messages-b",
+              },
+            },
+          },
+        },
+      },
+      mediaUrl: "/gateway/photo.png",
+      resolveAttachmentImpl: async () => ({ path: "/gateway/photo.png" }),
+      createClient: createClientForAccount,
+      withRemoteFile: withRemoteFile as never,
+    });
+
+    expect(withRemoteFile).toHaveBeenCalledWith(
+      expect.objectContaining({
+        remoteHost: "work@messages-b",
+        localPath: "/gateway/photo.png",
+      }),
+    );
+    expect(getClientMocks(client).request).toHaveBeenCalledWith(
+      "send",
+      expect.objectContaining({
+        to: "+15550004567",
+        file: "/tmp/openclaw-imessage-safe/photo.png",
+        service: "imessage",
+      }),
+      expect.any(Object),
+    );
+    expect(getClientMocks(client).request).not.toHaveBeenCalledWith(
+      "send.attachment",
+      expect.anything(),
+      expect.anything(),
+    );
+    expect(result).toMatchObject({
+      messageId: "p:0/remote-resolved-media",
+      chatGuid: "any;-;+15550004567",
+      service: "imessage",
+    });
+  });
+
   it("auto-detects a wrapper-only remote account for raw db paths and media staging", async () => {
     const cliPath = createOutboundMediaFile(
       "imsg-legacy-ssh",
@@ -2503,10 +2560,14 @@ describe("sendMessageIMessage receipts", () => {
   });
 
   it("preserves explicit SMS service for bare-handle media sends", async () => {
-    const client = createClient({ message_id: 12345 });
-    const runCliJson = vi.fn().mockResolvedValueOnce({ messageId: "p:0/sms-media-guid" });
+    const client = createClient({
+      guid: "p:0/sms-media-guid",
+      chat_guid: "SMS;-;+15550004567",
+      service: "SMS",
+    });
+    const runCliJson = vi.fn();
 
-    await sendMessageIMessage("+15550004567", "", {
+    const result = await sendMessageIMessage("+15550004567", "", {
       config: IMESSAGE_TEST_CFG,
       client,
       service: "sms",
@@ -2515,23 +2576,38 @@ describe("sendMessageIMessage receipts", () => {
       runCliJson,
     });
 
-    expect(runCliJson.mock.calls[0]?.[0]).toEqual([
-      "send-attachment",
-      "--chat",
-      "SMS;-;+15550004567",
-      "--file",
-      "/tmp/image.png",
-      "--transport",
-      "auto",
-    ]);
-    expect(getClientMocks(client).request).not.toHaveBeenCalled();
+    expect(runCliJson).not.toHaveBeenCalled();
+    expect(getClientMocks(client).request).toHaveBeenCalledWith(
+      "send",
+      expect.objectContaining({
+        to: "+15550004567",
+        file: "/tmp/image.png",
+        service: "sms",
+      }),
+      expect.any(Object),
+    );
+    expect(result).toMatchObject({
+      messageId: "p:0/sms-media-guid",
+      chatGuid: "SMS;-;+15550004567",
+      service: "sms",
+    });
+    expect(
+      findLatestIMessageEntryForChat({
+        accountId: "default",
+        chatGuid: "SMS;-;+15550004567",
+      }),
+    ).toEqual(expect.objectContaining({ messageId: "p:0/sms-media-guid", isFromMe: true }));
   });
 
   it("preserves configured iMessage service for bare-handle media sends", async () => {
-    const client = createClient({ message_id: 12345 });
-    const runCliJson = vi.fn().mockResolvedValueOnce({ messageId: "p:0/imessage-media-guid" });
+    const client = createClient({
+      guid: "p:0/imessage-media-guid",
+      chat_guid: "any;-;+15550004567",
+      service: "iMessage",
+    });
+    const runCliJson = vi.fn();
 
-    await sendMessageIMessage("+15550004567", "", {
+    const result = await sendMessageIMessage("+15550004567", "", {
       config: {
         channels: {
           imessage: {
@@ -2549,14 +2625,55 @@ describe("sendMessageIMessage receipts", () => {
       runCliJson,
     });
 
-    expect(runCliJson.mock.calls[0]?.[0]).toEqual([
+    expect(runCliJson).not.toHaveBeenCalled();
+    expect(getClientMocks(client).request).toHaveBeenCalledWith(
+      "send",
+      expect.objectContaining({
+        to: "+15550004567",
+        file: "/tmp/image.png",
+        service: "imessage",
+      }),
+      expect.any(Object),
+    );
+    expect(result).toMatchObject({
+      messageId: "p:0/imessage-media-guid",
+      chatGuid: "any;-;+15550004567",
+      service: "imessage",
+    });
+    expect(
+      findLatestIMessageEntryForChat({
+        accountId: "default",
+        chatIdentifier: "iMessage;-;+15550004567",
+      }),
+    ).toEqual(
+      expect.objectContaining({
+        messageId: "p:0/imessage-media-guid",
+        chatGuid: "any;-;+15550004567",
+        isFromMe: true,
+      }),
+    );
+  });
+
+  it("preserves explicit bridge delivery for a new service-qualified media chat", async () => {
+    const client = createClient({ guid: "should-not-send" });
+    const runCliJson = vi.fn().mockResolvedValueOnce({ messageGuid: "p:0/bridge-media-guid" });
+
+    await sendMessageIMessage("imessage:+15550004567", "", {
+      config: { channels: { imessage: { sendTransport: "bridge" } } },
+      client,
+      mediaUrl: "/tmp/image.png",
+      resolveAttachmentImpl: async () => ({ path: "/tmp/image.png", contentType: "image/png" }),
+      runCliJson,
+    });
+
+    expect(runCliJson).toHaveBeenCalledWith([
       "send-attachment",
       "--chat",
       "iMessage;-;+15550004567",
       "--file",
       "/tmp/image.png",
       "--transport",
-      "auto",
+      "dylib",
     ]);
     expect(getClientMocks(client).request).not.toHaveBeenCalled();
   });
@@ -2648,9 +2765,13 @@ describe("sendMessageIMessage receipts", () => {
     expect(fs.readdirSync(openClawState.statePath("media", "outbound"))).toHaveLength(1);
   });
 
-  it("sends DM handle media captions as attachment plus follow-up text", async () => {
-    const client = createClient({ guid: "p:0/caption-guid" });
-    const runCliJson = vi.fn().mockResolvedValueOnce({ messageGuid: "p:0/dm-media-guid" });
+  it("sends service-qualified DM media and its caption through the resolved RPC chat", async () => {
+    const client = createClient({
+      guid: "p:0/caption-guid",
+      chat_guid: "any;-;+15550004567",
+      service: "iMessage",
+    });
+    const runCliJson = vi.fn();
     const onDeliveryResult = vi.fn();
 
     const result = await sendMessageIMessage("imessage:+15550004567", "caption", {
@@ -2662,39 +2783,30 @@ describe("sendMessageIMessage receipts", () => {
       onDeliveryResult,
     });
 
-    expect(runCliJson).toHaveBeenCalledTimes(1);
-    const captionAttachmentArgs = runCliJson.mock.calls[0]?.[0] as string[];
-    expect(captionAttachmentArgs[0]).toBe("send-attachment");
-    expect(captionAttachmentArgs[1]).toBe("--chat");
-    expect(captionAttachmentArgs[2]).toBe("iMessage;-;+15550004567");
-    expect(captionAttachmentArgs.slice(3)).toEqual([
-      "--file",
-      "/tmp/image.png",
-      "--transport",
-      "auto",
-    ]);
+    expect(runCliJson).not.toHaveBeenCalled();
     expect(getClientMocks(client).request).toHaveBeenCalledWith(
       "send",
       expect.objectContaining({
         to: "+15550004567",
         text: "caption",
+        file: "/tmp/image.png",
+        service: "imessage",
       }),
       expect.any(Object),
     );
-    expect(result.sentText).toBe("caption");
-    expect(result.receipt.platformMessageIds).toEqual(["p:0/dm-media-guid", "p:0/caption-guid"]);
-    expect(result.receipt.parts.map((part) => part.kind)).toEqual(["media", "text"]);
-    expect(onDeliveryResult).toHaveBeenCalledWith(
-      expect.objectContaining({
-        messageId: "p:0/dm-media-guid",
-        messageIds: ["p:0/dm-media-guid"],
-        receipt: expect.objectContaining({ platformMessageIds: ["p:0/dm-media-guid"] }),
-      }),
-    );
+    expect(result).toMatchObject({
+      messageId: "p:0/caption-guid",
+      sentText: "caption",
+      chatGuid: "any;-;+15550004567",
+      service: "imessage",
+    });
+    expect(result.receipt.platformMessageIds).toEqual(["p:0/caption-guid"]);
+    expect(result.receipt.parts.map((part) => part.kind)).toEqual(["media"]);
+    expect(onDeliveryResult).not.toHaveBeenCalled();
     expect(
       hasPersistedIMessageEcho({
         scope: "default:imessage:+15550004567",
-        messageId: "p:0/dm-media-guid",
+        messageId: "p:0/caption-guid",
       }),
     ).toBe(true);
   });
@@ -2707,7 +2819,7 @@ describe("sendMessageIMessage receipts", () => {
 
     let observedError: unknown;
     try {
-      await sendMessageIMessage("imessage:+15550004567", "caption", {
+      await sendMessageIMessage("+15550004567", "caption", {
         config: IMESSAGE_TEST_CFG,
         client,
         mediaUrl: "/tmp/image.png",
@@ -2764,7 +2876,7 @@ describe("sendMessageIMessage receipts", () => {
     });
 
     await expect(
-      sendMessageIMessage("imessage:+15550004567", "caption", {
+      sendMessageIMessage("+15550004567", "caption", {
         config: IMESSAGE_TEST_CFG,
         client,
         mediaUrl: "/tmp/image.png",

--- a/extensions/imessage/src/send.ts
+++ b/extensions/imessage/src/send.ts
@@ -618,6 +618,16 @@ async function trySendAttachmentForTarget(params: {
       "iMessage voice messages require bridge transport; AppleScript cannot send native voice notes. Set sendTransport to bridge or auto.",
     );
   }
+  // Service-qualified handles are not existing chat GUIDs. Let imsg's canonical
+  // send RPC resolve them; explicit bridge and native voice retain bridge semantics.
+  if (
+    params.target.kind === "handle" &&
+    !params.audioAsVoice &&
+    params.sendTransport !== "bridge" &&
+    (params.service === "sms" || params.service === "imessage")
+  ) {
+    return null;
+  }
   if (params.remoteHost && params.sendTransport === "applescript") {
     return null;
   }

--- a/extensions/imessage/src/test-plugin.test.ts
+++ b/extensions/imessage/src/test-plugin.test.ts
@@ -598,7 +598,7 @@ describe("createIMessageTestPlugin", () => {
         const result = await sendDurableMessageBatch({
           cfg,
           channel: "imessage",
-          to: "imessage:+15550004567",
+          to: "+15550004567",
           durability: "required",
           mediaAccess,
           deps: { imessage: nativeSend },
@@ -678,7 +678,7 @@ describe("createIMessageTestPlugin", () => {
         const result = await sendDurableMessageBatch({
           cfg,
           channel: "imessage",
-          to: "imessage:+15550004567",
+          to: "+15550004567",
           durability: "required",
           mediaAccess: { localRoots: [workspaceDir], workspaceDir, readFile },
           deps: { imessage: nativeSend },


### PR DESCRIPTION
Closes #111999.

## What Problem This Solves

OpenClaw treated a service-qualified iMessage/SMS handle as if it were an existing Messages chat GUID. For ordinary local media it passed synthetic `iMessage;-;<handle>` / `SMS;-;<handle>` strings directly to one-shot `send-attachment`; the newer remote-host path repeated the same synthesis for `send.attachment`. When the real existing conversation was stored under another GUID such as `any;-;<handle>`, attachment delivery could silently fail.

## Why This Change Was Made

Both local and remote ordinary non-voice handle media with a concrete SMS/iMessage service now fall through to the existing canonical `imsg rpc` `send` path. That path already carries `to`, effective service, file, caption, region, transport, remote staging, and formatting; upstream `imsg` resolves real direct-chat candidates and returns authoritative `chat_guid` and service facts, which OpenClaw already records in the result and reply cache.

Explicit `sendTransport: "bridge"` remains on the one-shot attachment path so a new service-qualified conversation can still be materialized. Native voice remains there because AppleScript/generic media semantics cannot preserve the voice flag. Explicit chat IDs/GUIDs, automatic-service handles, national-format handles, chat identifiers, threaded media, and custody/partial-delivery behavior remain covered.

This is iMessage transport-owned target resolution; no core target parser, config, storage, default, or Plugin SDK surface changes.

Production LOC: +10/-0. Tests: +159/-47.

## User Impact

Generated images and other ordinary attachments sent to explicitly selected iMessage or SMS direct conversations are delivered through the real existing chat, locally or through a remote Messages host. Captions travel with the same media send, and the provider-resolved chat GUID/service are retained for subsequent message actions.

## Evidence

- Before the production change: `node scripts/run-vitest.mjs extensions/imessage/src/send.test.ts` failed exactly 4 new routing assertions while 80 sibling tests passed. Local SMS/configured-iMessage/caption paths invoked the synthetic one-shot attachment route; the remote path invoked `send.attachment` with `chat_identifier: iMessage;-;<handle>`.
- After the production change and two fixture corrections for existing cache/custody semantics: the identical command passed 1 file / 84 tests.
- Initial exact-head CI exposed two higher-level durable-delivery tests that still used service-qualified targets to exercise the old two-send custody path. Moving those fixtures to the unchanged auto-handle path preserved every custody/partial-delivery assertion; `node scripts/run-vitest.mjs extensions/imessage/src/send.test.ts extensions/imessage/src/test-plugin.test.ts` then passed 2 files / 105 tests.
- The regression coverage asserts local SMS and iMessage routing, remote file staging, combined caption delivery, provider-returned `chat_guid`/service, reply-cache persistence, explicit-bridge preservation, and unchanged auto-handle custody failures.
- `node scripts/check-changed.mjs` passed after the implementation on Blacksmith Testbox `tbx_01kzk6aec757jc2wrgx6fdpnb8` (Actions `31312191891`) and again after the CI test correction on `tbx_01kzk78zj0zbxeyp9qpqvgrb6j` (Actions `31312894889`).
- `.agents/skills/autoreview/scripts/autoreview --mode uncommitted` completed clean after the implementation and again after the test-only CI correction; neither round reported accepted/actionable findings.

Dependency contracts were inspected directly at `imsg` commit `e22dfad8e54ef5ae9ef8b64a3db05f0ce25cd52c`:

- `BridgeAttachmentCommand.swift` documents `--chat` as a chat GUID and forwards it unchanged; it performs no handle-to-chat resolution.
- `RPCServer+Handlers.swift` accepts direct `to + service + file`, resolves existing chat candidates, and returns real `chat_guid`/service.
- `ChatTargetResolver.swift` tries service-aware candidates including the `any;-;` form for iMessage handles.
- `RPCServer+BridgeMessageHandlers.swift` confirms `send.attachment` expects an existing chat identifier/GUID; it is not the canonical direct-handle resolver.

Behavior-validator contract: ordinary local and remote service-qualified media must use RPC `send` with the original handle/service/file, preserve captions, expose provider chat/service facts, and keep explicit bridge/voice controls. All contract clauses pass through the real OpenClaw sender boundary with deterministic provider responses.

Native proof gap: no real Messages recipient/account destination was approved for this session, so I did not send a private message, touch a live Messages database, or claim the focused boundary suite as native readback proof. The prior ClawSweeper review explicitly treats real behavior proof as not required for this maintainer-authored PR; this gap is recorded rather than silently bypassed.

The distinct announce-path media loss in #112309 is not fixed or closed by this PR.

AI-assisted: yes; current-main local/remote paths, upstream Swift contracts, provider-fact/cache behavior, red/green proof, and sibling controls were independently inspected.
