### PR TITLE
perf(gateway): single-entry reads and config-keyed projections for chat startup

### DIFF
--- a/src/config/sessions/session-accessor.entry.ts
+++ b/src/config/sessions/session-accessor.entry.ts
@@ -10,6 +10,7 @@ import { resolveAgentMainSessionKey } from "./main-session.js";
 import { resolveStorePath } from "./paths.js";
 import { clearPluginOwnedSessionState } from "./plugin-host-cleanup.js";
 import {
+  listSqliteSessionChildEntriesReadOnly as listSessionChildEntriesReadOnly,
   listSqliteSessionEntries,
   listSqliteSessionEntriesReadOnly as listSessionEntriesReadOnly,
   listSqliteSessionEntryKeysReadOnly as listSessionEntryKeysReadOnly,
@@ -51,6 +52,7 @@ export { clearPluginOwnedSessionState };
 // SQLite is the only runtime session store. Re-export its canonical entry
 // operations directly instead of maintaining a second pass-through layer.
 export {
+  listSessionChildEntriesReadOnly,
   listSessionEntriesReadOnly,
   listSessionEntryKeysReadOnly,
   loadExactSessionEntry,

--- a/src/config/sessions/session-accessor.sqlite-entry.ts
+++ b/src/config/sessions/session-accessor.sqlite-entry.ts
@@ -84,6 +84,37 @@ type ResolvedSqliteSessionEntry = {
   normalizedKey: string;
 };
 
+const childSessionKeysByEntrySnapshot = new WeakMap<
+  Map<string, SessionEntry>,
+  Map<string, string[]>
+>();
+
+function getChildSessionKeysByParent(entries: Map<string, SessionEntry>): Map<string, string[]> {
+  const cached = childSessionKeysByEntrySnapshot.get(entries);
+  if (cached) {
+    return cached;
+  }
+  const childKeysByParent = new Map<string, Set<string>>();
+  for (const [sessionKey, entry] of entries) {
+    for (const rawParentKey of [entry.spawnedBy, entry.parentSessionKey]) {
+      const parentKey = rawParentKey?.trim();
+      if (!parentKey || parentKey === sessionKey) {
+        continue;
+      }
+      const childKeys = childKeysByParent.get(parentKey) ?? new Set<string>();
+      childKeys.add(sessionKey);
+      childKeysByParent.set(parentKey, childKeys);
+    }
+  }
+  // The parsed entry snapshot is replaced whenever SQLite's validity token changes.
+  // Keying the derived index by that identity keeps repeated single-row reads cheap and current.
+  const indexedChildKeys = new Map(
+    [...childKeysByParent].map(([parentKey, childKeys]) => [parentKey, [...childKeys]]),
+  );
+  childSessionKeysByEntrySnapshot.set(entries, indexedChildKeys);
+  return indexedChildKeys;
+}
+
 /** Resolves one canonical entry and its proven aliases without materializing the store. */
 export function resolveSqliteSessionEntry(
   scope: SessionAccessScope,
@@ -179,6 +210,27 @@ export function loadExactSqliteSessionEntryReadOnly(
         entry: scope.clone === false ? result.value : cloneSessionEntry(result.value),
       }
     : undefined;
+}
+
+/** Lists direct child rows without cloning or rebuilding the complete session store. */
+export function listSqliteSessionChildEntriesReadOnly(
+  scope: SessionAccessScope,
+): SessionEntrySummary[] {
+  const resolved = resolveSqliteScope(scope);
+  const result = withOpenClawAgentDatabaseReadOnly((database) => {
+    const snapshot = readSessionEntrySnapshot(database, resolved, scope.readConsistency);
+    const childKeys = getChildSessionKeysByParent(snapshot.entries).get(resolved.sessionKey) ?? [];
+    return childKeys.flatMap((sessionKey) => {
+      if (isInternalSessionEffectsKey(sessionKey)) {
+        return [];
+      }
+      const entry = snapshot.entries.get(sessionKey);
+      return entry
+        ? [{ sessionKey, entry: scope.clone === false ? entry : cloneSessionEntry(entry) }]
+        : [];
+    });
+  }, toDatabaseOptions(resolved));
+  return result.found ? result.value : [];
 }
 
 /** Resolves the persisted session key for a SQLite transcript session id. */

--- a/src/config/sessions/session-accessor.sqlite.ts
+++ b/src/config/sessions/session-accessor.sqlite.ts
@@ -1,6 +1,7 @@
 // Stable SQLite accessor surface. Domain owners live in the focused modules below.
 export {
   listSqliteSessionEntries,
+  listSqliteSessionChildEntriesReadOnly,
   listSqliteSessionEntriesReadOnly,
   listSqliteSessionEntryKeysReadOnly,
   listSqliteSessionEntriesByStatus,

--- a/src/config/sessions/session-accessor.ts
+++ b/src/config/sessions/session-accessor.ts
@@ -121,6 +121,7 @@ export type {
 } from "./session-accessor.entry-mutation.js";
 export {
   clearPluginOwnedSessionState,
+  listSessionChildEntriesReadOnly,
   listSessionEntries,
   listSessionEntriesReadOnly,
   listSessionEntryKeysReadOnly,

--- a/src/gateway/server-methods/chat-history-budget.ts
+++ b/src/gateway/server-methods/chat-history-budget.ts
@@ -100,11 +100,11 @@ export function enforceChatHistoryFinalBudget(params: { messages: unknown[]; max
 export function reportOmittedChatHistory(params: {
   originalMessages: unknown[];
   finalMessages: unknown[];
-  normalizedBytes: number;
+  getNormalizedBytes: () => number;
   maxHistoryBytes: number;
   logDebug: (message: string) => void;
 }): number {
-  const { originalMessages, finalMessages, normalizedBytes, maxHistoryBytes, logDebug } = params;
+  const { originalMessages, finalMessages, getNormalizedBytes, maxHistoryBytes, logDebug } = params;
   const survivors = new Set(finalMessages);
   let omittedCount = 0;
   for (const message of originalMessages) {
@@ -119,7 +119,7 @@ export function reportOmittedChatHistory(params: {
   logLargePayload({
     surface: "gateway.chat.history",
     action: "truncated",
-    bytes: normalizedBytes,
+    bytes: getNormalizedBytes(),
     limitBytes: maxHistoryBytes,
     count: omittedCount,
     reason: "chat_history_budget",

--- a/src/gateway/server-methods/chat-history-handler.ts
+++ b/src/gateway/server-methods/chat-history-handler.ts
@@ -14,17 +14,17 @@ import {
   resolveDefaultAgentId,
   resolveSessionAgentId,
 } from "../../agents/agent-scope.js";
-import { modelCatalogBrowseRequiresFullDiscovery } from "../../agents/model-catalog-browse.js";
 import type { ModelCatalogEntry, ModelCatalogSnapshot } from "../../agents/model-catalog.types.js";
 import { resolveSwarmConfig } from "../../agents/swarm-config.js";
-import { hashRuntimeConfigValue } from "../../config/runtime-snapshot.js";
 import {
   isSessionTranscriptProjectionUnavailableError,
   resolveTranscriptSessionKeyBySessionId,
 } from "../../config/sessions/session-accessor.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
-import { measureDiagnosticsTimelineSpan } from "../../infra/diagnostics-timeline.js";
-import { formatErrorMessage } from "../../infra/errors.js";
+import {
+  measureDiagnosticsTimelineSpan,
+  measureDiagnosticsTimelineSpanSync,
+} from "../../infra/diagnostics-timeline.js";
 import { jsonUtf8Bytes } from "../../infra/json-utf8-bytes.js";
 import { normalizeAgentId, scopeLegacySessionKeyToAgent } from "../../routing/session-key.js";
 import { listGatewayAgentsBasic } from "../agent-list.js";
@@ -34,7 +34,6 @@ import {
 } from "../chat-abort.js";
 import { resolveEffectiveChatHistoryMaxChars } from "../chat-display-projection.js";
 import { getMaxChatHistoryMessagesBytes } from "../server-constants.js";
-import type { GatewayModelCatalogSnapshot } from "../server-model-catalog.types.js";
 import { capArrayByJsonBytes } from "../session-transcript-readers.js";
 import {
   buildGatewaySessionInfo,
@@ -58,6 +57,10 @@ import {
   readChatHistoryMessageSeq,
 } from "./chat-history-pages.js";
 import { resolveRequestedChatAgentId, validateChatSelectedAgent } from "./chat-origin-routing.js";
+import {
+  buildMemoizedChatStartupMetadataResult,
+  listMemoizedChatStartupAgents,
+} from "./chat-startup-projection-memo.js";
 import { normalizeOptionalChatText as normalizeOptionalText } from "./chat-text-normalization.js";
 import {
   loadOptionalServerMethodModelCatalogSnapshot,
@@ -78,17 +81,6 @@ type ChatMetadataResult = {
   models?: unknown[];
   swarmEnabled: boolean;
 };
-
-function runtimeConfigsMatch(left: OpenClawConfig, right: OpenClawConfig): boolean {
-  if (left === right) {
-    return true;
-  }
-  try {
-    return hashRuntimeConfigValue(left) === hashRuntimeConfigValue(right);
-  } catch {
-    return false;
-  }
-}
 
 async function handleChatMetadataRequest({
   params,
@@ -157,54 +149,6 @@ async function buildChatMetadataResult(params: {
   };
 }
 
-async function buildChatStartupMetadataResult(params: {
-  cfg: OpenClawConfig;
-  context: GatewayRequestContext;
-  agentId: string;
-  modelCatalog: GatewayModelCatalogSnapshot | undefined;
-  catalogProjector?: ReturnType<
-    (typeof import("./models-list-result.js"))["createGatewayAgentModelCatalogProjector"]
-  >;
-}): Promise<ChatMetadataResult | undefined> {
-  if (!params.modelCatalog) {
-    return undefined;
-  }
-  if (modelCatalogBrowseRequiresFullDiscovery({ cfg: params.cfg, view: "configured" })) {
-    return undefined;
-  }
-  try {
-    const { buildModelsListResult } = await import("./models-list-result.js");
-    const currentConfig = params.context.getRuntimeConfig();
-    if (
-      params.modelCatalog.agentId !== params.agentId ||
-      !runtimeConfigsMatch(currentConfig, params.cfg)
-    ) {
-      return undefined;
-    }
-    const models = await buildModelsListResult({
-      context: params.context,
-      agentId: params.agentId,
-      params: { view: "configured" },
-      preloadedCatalog: {
-        agentId: params.agentId,
-        config: currentConfig,
-        snapshot: params.modelCatalog,
-      },
-      preloadedOnly: true,
-      ...(params.catalogProjector ? { catalogProjector: params.catalogProjector } : {}),
-    });
-    return {
-      ...models,
-      swarmEnabled: resolveSwarmConfig(params.cfg, params.agentId).enabled,
-    };
-  } catch (err) {
-    params.context.logGateway.debug(
-      `chat.startup continuing without metadata: ${formatErrorMessage(err)}`,
-    );
-    return undefined;
-  }
-}
-
 async function buildChatStartupModelCatalogProjection(params: {
   cfg: OpenClawConfig;
   snapshot: ModelCatalogSnapshot;
@@ -239,6 +183,8 @@ async function buildChatStartupModelCatalogProjection(params: {
     return projector;
   };
   const agentIds = new Set([params.sessionAgentId, params.defaultAgentId].map(normalizeAgentId));
+  // Agents-list catalogs are profile-neutral. Session auth shapes only the separate
+  // sessionCatalogProjector below, so switching sessions cannot alter this map.
   if (params.includeAgentsList) {
     for (const agent of listGatewayAgentsBasic(params.cfg).agents) {
       agentIds.add(agent.id);
@@ -271,7 +217,7 @@ async function buildChatStartupModelCatalogProjection(params: {
 
 // The UI fills metadata gaps as soon as chat.startup returns, so history never waits
 // beyond this budget for a catalog snapshot that requires slower discovery.
-const CHAT_STARTUP_OPTIONAL_MODEL_CATALOG_TIMEOUT_MS = 25;
+const CHAT_OPTIONAL_MODEL_CATALOG_TIMEOUT_MS = 25;
 function resolveChatHistoryNextOffset(params: {
   messages: unknown[];
   totalMessages: number;
@@ -362,16 +308,25 @@ async function handleChatHistoryRequest({
     );
     return;
   }
+  const requestConfig = context.getRuntimeConfig();
   const agentIdOverride = normalizeOptionalText((params as { agentId?: string }).agentId);
   const requestedAgentId = resolveRequestedChatAgentId({
-    cfg: (context as { getRuntimeConfig?: () => OpenClawConfig }).getRuntimeConfig?.(),
+    cfg: requestConfig,
     requestedSessionKey: sessionKey,
     agentId: agentIdOverride,
   });
   const sessionLoadOptions = requestedAgentId ? { agentId: requestedAgentId } : undefined;
-  const { cfg, storePath, store, entry, canonicalKey } = loadSessionEntryReadOnly(
-    sessionKey,
-    sessionLoadOptions,
+  const { cfg, storePath, store, entry, canonicalKey } = measureDiagnosticsTimelineSpanSync(
+    `gateway.${method}.session_entry`,
+    () =>
+      loadSessionEntryReadOnly(sessionKey, {
+        ...sessionLoadOptions,
+        includeStoreChildEntries: true,
+      }),
+    {
+      config: requestConfig,
+      phase: method,
+    },
   );
   const selectedAgent = validateChatSelectedAgent({
     cfg,
@@ -408,30 +363,23 @@ async function handleChatHistoryRequest({
       return;
     }
   }
-  const startupModelCatalogLoad =
-    method === "chat.startup"
-      ? startOptionalServerMethodModelCatalogSnapshotLoad(context, { agentId: sessionAgentId })
-      : undefined;
+  const optionalModelCatalogLoad = startOptionalServerMethodModelCatalogSnapshotLoad(context, {
+    agentId: sessionAgentId,
+  });
   const modelCatalogPromise = measureDiagnosticsTimelineSpan(
     `gateway.${method}.model_catalog`,
     () =>
-      startupModelCatalogLoad
-        ? loadOptionalServerMethodModelCatalogSnapshot(context, method, {
-            logOnceKey: "chat.startup",
-            startedLoad: startupModelCatalogLoad,
-            timeoutMs: CHAT_STARTUP_OPTIONAL_MODEL_CATALOG_TIMEOUT_MS,
-          })
-        : loadOptionalServerMethodModelCatalogSnapshot(context, method, {
-            loadParams: { agentId: sessionAgentId },
-          }),
+      loadOptionalServerMethodModelCatalogSnapshot(context, method, {
+        logOnceKey: method,
+        startedLoad: optionalModelCatalogLoad,
+        timeoutMs: CHAT_OPTIONAL_MODEL_CATALOG_TIMEOUT_MS,
+      }),
     {
       config: cfg,
       phase: method,
     },
   );
-  if (startupModelCatalogLoad) {
-    void modelCatalogPromise.catch(() => undefined);
-  }
+  void modelCatalogPromise.catch(() => undefined);
   const sessionId = requestedSessionId ?? entry?.sessionId;
   const historyEntry =
     requestedSessionId && requestedSessionId !== entry?.sessionId ? undefined : entry;
@@ -442,19 +390,32 @@ async function handleChatHistoryRequest({
   const effectiveMaxChars = resolveEffectiveChatHistoryMaxChars(cfg, maxChars);
   let historyPage: Awaited<ReturnType<typeof readChatHistoryPage>>;
   try {
-    historyPage = await readChatHistoryPage({
-      entry: historyEntry,
-      provider: resolvedSessionModel.provider,
-      sessionId,
-      storePath,
-      sessionAgentId,
-      canonicalKey,
-      max,
-      maxHistoryBytes,
-      effectiveMaxChars,
-      offset,
-      messageId,
-    });
+    historyPage = await measureDiagnosticsTimelineSpan(
+      `gateway.${method}.history_page`,
+      () =>
+        readChatHistoryPage({
+          entry: historyEntry,
+          provider: resolvedSessionModel.provider,
+          sessionId,
+          storePath,
+          sessionAgentId,
+          canonicalKey,
+          max,
+          maxHistoryBytes,
+          effectiveMaxChars,
+          offset,
+          messageId,
+        }),
+      {
+        config: cfg,
+        phase: method,
+        attributes: {
+          limit: max,
+          hasMessageId: Boolean(messageId),
+          hasOffset: offset !== undefined,
+        },
+      },
+    );
   } catch (error) {
     if (!isSessionTranscriptProjectionUnavailableError(error)) {
       throw error;
@@ -516,7 +477,7 @@ async function handleChatHistoryRequest({
   reportOmittedChatHistory({
     originalMessages: normalized,
     finalMessages: bounded.messages,
-    normalizedBytes: jsonUtf8Bytes(normalized),
+    getNormalizedBytes: () => jsonUtf8Bytes(normalized),
     maxHistoryBytes,
     logDebug: (message) => context.logGateway.debug(message),
   });
@@ -525,41 +486,90 @@ async function handleChatHistoryRequest({
   const catalogConfig = catalogOwnedBySessionAgent ? modelCatalogSnapshot.config : cfg;
   const modelCatalog = catalogOwnedBySessionAgent ? modelCatalogSnapshot.entries : undefined;
   const defaultAgentId = resolveDefaultAgentId(catalogConfig);
-  const startupCatalogProjection =
-    method === "chat.startup" && catalogOwnedBySessionAgent
-      ? await buildChatStartupModelCatalogProjection({
-          cfg: catalogConfig,
-          snapshot: modelCatalogSnapshot,
-          sessionAgentId,
-          sessionEntry: entry,
-          defaultAgentId,
-          includeAgentsList: includeAgentsList === true,
-        })
-      : undefined;
+  let startupCatalogProjection:
+    | Awaited<ReturnType<typeof buildChatStartupModelCatalogProjection>>
+    | undefined;
+  let startupMetadata: ChatMetadataResult | undefined;
+  let startupAgentsList: ReturnType<typeof listAgentsForGateway> | undefined;
+  if (method === "chat.startup") {
+    const includeSystem = hasGatewayClientCap(client?.connect.caps, GATEWAY_CLIENT_CAPS.AGENT_KIND);
+    const startupProjections = await measureDiagnosticsTimelineSpan(
+      `gateway.${method}.startup_projections`,
+      async () => {
+        const catalogProjection = catalogOwnedBySessionAgent
+          ? await buildChatStartupModelCatalogProjection({
+              cfg: catalogConfig,
+              snapshot: modelCatalogSnapshot,
+              sessionAgentId,
+              sessionEntry: entry,
+              defaultAgentId,
+              includeAgentsList: includeAgentsList === true,
+            })
+          : undefined;
+        const metadata =
+          includeMetadata && catalogOwnedBySessionAgent
+            ? await buildMemoizedChatStartupMetadataResult({
+                cfg: catalogConfig,
+                context,
+                agentId: sessionAgentId,
+                modelCatalog: modelCatalogSnapshot,
+                sessionEntry: entry,
+                ...(catalogProjection
+                  ? { catalogProjector: catalogProjection.sessionCatalogProjector }
+                  : {}),
+              })
+            : undefined;
+        const agentsList = includeAgentsList
+          ? catalogProjection && modelCatalog && modelCatalogSnapshot
+            ? listMemoizedChatStartupAgents({
+                cfg,
+                context,
+                includeSystem,
+                catalogSnapshot: modelCatalogSnapshot,
+                modelCatalog,
+                modelCatalogByAgentId: catalogProjection.modelCatalogByAgentId,
+              })
+            : listAgentsForGateway(cfg, modelCatalog, { includeSystem })
+          : undefined;
+        return { agentsList, catalogProjection, metadata };
+      },
+      {
+        config: cfg,
+        phase: method,
+        attributes: {
+          agentId: sessionAgentId,
+          includeSystem,
+        },
+      },
+    );
+    startupCatalogProjection = startupProjections.catalogProjection;
+    startupMetadata = startupProjections.metadata;
+    startupAgentsList = startupProjections.agentsList;
+  }
   const sessionModelCatalog = startupCatalogProjection?.sessionModelCatalog ?? modelCatalog;
   const defaultModelCatalog =
     startupCatalogProjection?.modelCatalogByAgentId.get(normalizeAgentId(defaultAgentId)) ??
     modelCatalog;
-  const startupMetadata = includeMetadata
-    ? await buildChatStartupMetadataResult({
-        cfg: catalogConfig,
-        context,
-        agentId: sessionAgentId,
-        modelCatalog: modelCatalogSnapshot,
-        ...(startupCatalogProjection
-          ? { catalogProjector: startupCatalogProjection.sessionCatalogProjector }
-          : {}),
-      })
-    : undefined;
-  const sessionInfo = buildGatewaySessionInfo({
-    cfg,
-    storePath,
-    store,
-    key: canonicalKey,
-    entry,
-    agentId: selectedAgent.agentId,
-    modelCatalog: sessionModelCatalog,
-  });
+  const sessionInfo = measureDiagnosticsTimelineSpanSync(
+    `gateway.${method}.session_info`,
+    () =>
+      buildGatewaySessionInfo({
+        cfg,
+        storePath,
+        store,
+        key: canonicalKey,
+        entry,
+        agentId: selectedAgent.agentId,
+        modelCatalog: sessionModelCatalog,
+      }),
+    {
+      config: cfg,
+      phase: method,
+      attributes: {
+        storeEntries: Object.keys(store).length,
+      },
+    },
+  );
   const activeRunAgentId =
     canonicalKey === "global" ? (selectedAgent.agentId ?? defaultAgentId) : selectedAgent.agentId;
   const activeRunState = resolveVisibleActiveSessionRunState({
@@ -614,19 +624,7 @@ async function handleChatHistoryRequest({
     fastMode: entry?.fastMode,
     verboseLevel,
     ...(boundedInFlightRun ? { inFlightRun: boundedInFlightRun } : {}),
-    ...(includeAgentsList
-      ? {
-          agentsList: listAgentsForGateway(cfg, modelCatalog, {
-            ...(startupCatalogProjection
-              ? { modelCatalogByAgentId: startupCatalogProjection.modelCatalogByAgentId }
-              : {}),
-            includeSystem: hasGatewayClientCap(
-              client?.connect.caps,
-              GATEWAY_CLIENT_CAPS.AGENT_KIND,
-            ),
-          }),
-        }
-      : {}),
+    ...(includeAgentsList && startupAgentsList ? { agentsList: startupAgentsList } : {}),
     ...(startupMetadata ? { metadata: startupMetadata } : {}),
   };
   respond(true, payload);

--- a/src/gateway/server-methods/chat-history-omission-logging.test.ts
+++ b/src/gateway/server-methods/chat-history-omission-logging.test.ts
@@ -5,7 +5,7 @@
 // production helpers and capture the real diagnostic event bus output.
 
 import { expectDefined } from "@openclaw/normalization-core";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { onDiagnosticEvent } from "../../infra/diagnostic-events.js";
 import type { DiagnosticPayloadLargeEvent } from "../../infra/diagnostic-events.js";
 import { capArrayByJsonBytes } from "../session-transcript-readers.js";
@@ -42,7 +42,7 @@ function runHistoryBudgetPipeline(params: {
     const emittedCount = reportOmittedChatHistory({
       originalMessages: messages,
       finalMessages: bounded.messages,
-      normalizedBytes: Buffer.byteLength(JSON.stringify(messages), "utf8"),
+      getNormalizedBytes: () => Buffer.byteLength(JSON.stringify(messages), "utf8"),
       maxHistoryBytes,
       logDebug: () => {},
     });
@@ -81,14 +81,18 @@ describe("chat.history truncation logging (real diagnostic bus)", () => {
   });
 
   it("emits no diagnostic when nothing is omitted", () => {
-    const result = runHistoryBudgetPipeline({
-      messages: [textMessage("user", "hello"), textMessage("assistant", "hi")],
+    const messages = [textMessage("user", "hello"), textMessage("assistant", "hi")];
+    const getNormalizedBytes = vi.fn(() => Buffer.byteLength(JSON.stringify(messages), "utf8"));
+    const emittedCount = reportOmittedChatHistory({
+      originalMessages: messages,
+      finalMessages: messages,
+      getNormalizedBytes,
       maxHistoryBytes: 1_000_000,
-      perMessageHardCap: 1_000_000,
+      logDebug: () => {},
     });
 
-    expect(result.events).toHaveLength(0);
-    expect(result.emittedCount).toBe(0);
+    expect(emittedCount).toBe(0);
+    expect(getNormalizedBytes).not.toHaveBeenCalled();
   });
 
   it("counts a replaced-then-trimmed message once, not twice", () => {

--- a/src/gateway/server-methods/chat-startup-projection-memo.ts
+++ b/src/gateway/server-methods/chat-startup-projection-memo.ts
@@ -1,0 +1,206 @@
+// Config-keyed chat.startup projections shared across session switches.
+import { modelCatalogBrowseRequiresFullDiscovery } from "../../agents/model-catalog-browse.js";
+import type { ModelCatalogEntry } from "../../agents/model-catalog.types.js";
+import { resolveSwarmConfig } from "../../agents/swarm-config.js";
+import { hashRuntimeConfigValue } from "../../config/runtime-snapshot.js";
+import type { SessionEntry } from "../../config/sessions.js";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { formatErrorMessage } from "../../infra/errors.js";
+import { normalizeAgentId } from "../../routing/session-key.js";
+import type { GatewayModelCatalogSnapshot } from "../server-model-catalog.types.js";
+import { listAgentsForGateway } from "../session-utils.js";
+import type { GatewayRequestContext } from "./types.js";
+
+type ChatMetadataResult = {
+  commands?: unknown[];
+  models?: unknown[];
+  swarmEnabled: boolean;
+};
+
+type CatalogProjector = ReturnType<
+  (typeof import("./models-list-result.js"))["createGatewayAgentModelCatalogProjector"]
+>;
+
+type ChatStartupProjectionMemo = {
+  config: OpenClawConfig;
+  catalogEntries: ModelCatalogEntry[];
+  catalogRouteVariants: ModelCatalogEntry[];
+  agentsListByKey: Map<string, ReturnType<typeof listAgentsForGateway>>;
+  metadataByKey: Map<string, ChatMetadataResult>;
+};
+
+const CHAT_STARTUP_METADATA_CACHE_MAX_ENTRIES = 32;
+
+const chatStartupProjectionMemoByContext = new WeakMap<
+  GatewayRequestContext,
+  ChatStartupProjectionMemo
+>();
+
+function runtimeConfigsMatch(left: OpenClawConfig, right: OpenClawConfig): boolean {
+  if (left === right) {
+    return true;
+  }
+  try {
+    return hashRuntimeConfigValue(left) === hashRuntimeConfigValue(right);
+  } catch {
+    return false;
+  }
+}
+
+function getChatStartupProjectionMemo(
+  context: GatewayRequestContext,
+  config: OpenClawConfig,
+  modelCatalog: GatewayModelCatalogSnapshot,
+): ChatStartupProjectionMemo {
+  const current = chatStartupProjectionMemoByContext.get(context);
+  if (
+    current &&
+    current.catalogEntries === modelCatalog.entries &&
+    current.catalogRouteVariants === modelCatalog.routeVariants &&
+    runtimeConfigsMatch(current.config, config)
+  ) {
+    return current;
+  }
+  // Config and prepared-catalog arrays are stable until their owners publish a new generation.
+  // Replace the context-local memo when either changes so auth/catalog refreshes cannot go stale.
+  const next = {
+    config,
+    catalogEntries: modelCatalog.entries,
+    catalogRouteVariants: modelCatalog.routeVariants,
+    agentsListByKey: new Map(),
+    metadataByKey: new Map(),
+  };
+  chatStartupProjectionMemoByContext.set(context, next);
+  return next;
+}
+
+function setChatStartupMetadataMemo(
+  memo: ChatStartupProjectionMemo,
+  key: string,
+  value: ChatMetadataResult,
+): void {
+  memo.metadataByKey.delete(key);
+  memo.metadataByKey.set(key, value);
+  if (memo.metadataByKey.size <= CHAT_STARTUP_METADATA_CACHE_MAX_ENTRIES) {
+    return;
+  }
+  const oldestKey = memo.metadataByKey.keys().next().value;
+  if (oldestKey) {
+    memo.metadataByKey.delete(oldestKey);
+  }
+}
+
+function resolveChatStartupMetadataMemoKey(params: {
+  agentId: string;
+  sessionEntry: SessionEntry | undefined;
+}): string {
+  return [
+    normalizeAgentId(params.agentId),
+    params.sessionEntry?.authProfileOverride?.trim() ?? "",
+    params.sessionEntry?.authProfileOverrideSource ?? "",
+    params.sessionEntry?.authProfileOverrideCompactionCount ?? "",
+  ].join("\0");
+}
+
+async function buildChatStartupMetadataResult(params: {
+  cfg: OpenClawConfig;
+  context: GatewayRequestContext;
+  agentId: string;
+  modelCatalog: GatewayModelCatalogSnapshot | undefined;
+  catalogProjector?: CatalogProjector;
+}): Promise<ChatMetadataResult | undefined> {
+  if (!params.modelCatalog) {
+    return undefined;
+  }
+  if (modelCatalogBrowseRequiresFullDiscovery({ cfg: params.cfg, view: "configured" })) {
+    return undefined;
+  }
+  try {
+    const { buildModelsListResult } = await import("./models-list-result.js");
+    const currentConfig = params.context.getRuntimeConfig();
+    if (
+      params.modelCatalog.agentId !== params.agentId ||
+      !runtimeConfigsMatch(currentConfig, params.cfg)
+    ) {
+      return undefined;
+    }
+    const models = await buildModelsListResult({
+      context: params.context,
+      agentId: params.agentId,
+      params: { view: "configured" },
+      preloadedCatalog: {
+        agentId: params.agentId,
+        config: currentConfig,
+        snapshot: params.modelCatalog,
+      },
+      preloadedOnly: true,
+      ...(params.catalogProjector ? { catalogProjector: params.catalogProjector } : {}),
+    });
+    return {
+      ...models,
+      swarmEnabled: resolveSwarmConfig(params.cfg, params.agentId).enabled,
+    };
+  } catch (err) {
+    params.context.logGateway.debug(
+      `chat.startup continuing without metadata: ${formatErrorMessage(err)}`,
+    );
+    return undefined;
+  }
+}
+
+export async function buildMemoizedChatStartupMetadataResult(params: {
+  cfg: OpenClawConfig;
+  context: GatewayRequestContext;
+  agentId: string;
+  modelCatalog: GatewayModelCatalogSnapshot;
+  sessionEntry: SessionEntry | undefined;
+  catalogProjector?: CatalogProjector;
+}): Promise<ChatMetadataResult | undefined> {
+  if (!runtimeConfigsMatch(params.context.getRuntimeConfig(), params.cfg)) {
+    chatStartupProjectionMemoByContext.delete(params.context);
+    return undefined;
+  }
+  const memo = getChatStartupProjectionMemo(params.context, params.cfg, params.modelCatalog);
+  const key = resolveChatStartupMetadataMemoKey(params);
+  const cached = memo.metadataByKey.get(key);
+  if (cached) {
+    memo.metadataByKey.delete(key);
+    memo.metadataByKey.set(key, cached);
+    return cached;
+  }
+  const result = await buildChatStartupMetadataResult(params);
+  if (result && runtimeConfigsMatch(params.context.getRuntimeConfig(), params.cfg)) {
+    setChatStartupMetadataMemo(memo, key, result);
+  }
+  return result;
+}
+
+export function listMemoizedChatStartupAgents(params: {
+  cfg: OpenClawConfig;
+  context: GatewayRequestContext;
+  includeSystem: boolean;
+  catalogSnapshot: GatewayModelCatalogSnapshot;
+  modelCatalog: ModelCatalogEntry[];
+  modelCatalogByAgentId: ReadonlyMap<string, ModelCatalogEntry[]>;
+}): ReturnType<typeof listAgentsForGateway> {
+  const buildAgentsList = () =>
+    listAgentsForGateway(params.cfg, params.modelCatalog, {
+      modelCatalogByAgentId: params.modelCatalogByAgentId,
+      includeSystem: params.includeSystem,
+    });
+  if (
+    !runtimeConfigsMatch(params.context.getRuntimeConfig(), params.cfg) ||
+    !runtimeConfigsMatch(params.catalogSnapshot.config, params.cfg)
+  ) {
+    return buildAgentsList();
+  }
+  const memo = getChatStartupProjectionMemo(params.context, params.cfg, params.catalogSnapshot);
+  const key = params.includeSystem ? "include-system" : "agents-only";
+  const cached = memo.agentsListByKey.get(key);
+  if (cached) {
+    return cached;
+  }
+  const agentsList = buildAgentsList();
+  memo.agentsListByKey.set(key, agentsList);
+  return agentsList;
+}

--- a/src/gateway/server-methods/chat.directive-tags.test.ts
+++ b/src/gateway/server-methods/chat.directive-tags.test.ts
@@ -1669,7 +1669,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
 
     expect(mockState.loadSessionEntryCalls).toContainEqual({
       rawKey: "agent:work:main",
-      opts: { agentId: "work" },
+      opts: { agentId: "work", includeStoreChildEntries: true },
     });
   });
 

--- a/src/gateway/server-methods/sessions-subscriptions.ts
+++ b/src/gateway/server-methods/sessions-subscriptions.ts
@@ -10,7 +10,7 @@ import { canReviewOperatorApproval } from "../operator-approval-authorization.js
 import { APPROVALS_SCOPE } from "../operator-scopes.js";
 import { resolveRequestedSessionAgentId as resolveRequestedGlobalAgentId } from "../session-create-service.js";
 import { sessionObserverScopeKey } from "../session-observer-model.js";
-import { loadSessionEntryReadOnly } from "../session-utils.js";
+import { resolveSessionStoreKey } from "../session-utils.js";
 import { requireSessionKey } from "./sessions-shared.js";
 import type { GatewayRequestHandlers } from "./types.js";
 import { assertValidParams } from "./validation.js";
@@ -65,7 +65,11 @@ export const sessionSubscriptionHandlers: GatewayRequestHandlers = {
       return;
     }
     const requestedAgentId = requestedAgent.agentId;
-    const { canonicalKey } = loadSessionEntryReadOnly(key, { agentId: requestedAgentId });
+    const canonicalKey = resolveSessionStoreKey({
+      cfg,
+      sessionKey: key,
+      ...(requestedAgentId ? { storeAgentId: requestedAgentId } : {}),
+    });
     const subscriptionKey = sessionObserverScopeKey(
       canonicalKey,
       requestedAgentId ?? resolveDefaultAgentId(cfg),
@@ -146,7 +150,11 @@ export const sessionSubscriptionHandlers: GatewayRequestHandlers = {
       return;
     }
     const requestedAgentId = requestedAgent.agentId;
-    const { canonicalKey } = loadSessionEntryReadOnly(key, { agentId: requestedAgentId });
+    const canonicalKey = resolveSessionStoreKey({
+      cfg,
+      sessionKey: key,
+      ...(requestedAgentId ? { storeAgentId: requestedAgentId } : {}),
+    });
     const subscriptionKey = sessionObserverScopeKey(
       canonicalKey,
       requestedAgentId ?? resolveDefaultAgentId(cfg),

--- a/src/gateway/server-methods/sessions.abort-agent-scope.test.ts
+++ b/src/gateway/server-methods/sessions.abort-agent-scope.test.ts
@@ -753,7 +753,6 @@ describe("sessions.abort agent scope", () => {
   });
 
   it("infers selected-agent global subscriptions from agent-prefixed aliases", async () => {
-    loadSessionEntryMock.mockImplementationOnce(() => ({ canonicalKey: "global" }));
     const subscribeSessionMessageEvents = vi.fn();
     const context = createContext({
       globalScope: true,
@@ -769,7 +768,7 @@ describe("sessions.abort agent scope", () => {
       },
     );
 
-    expect(loadSessionEntryMock).toHaveBeenCalledWith("agent:work:main", { agentId: "work" });
+    expect(loadSessionEntryMock).not.toHaveBeenCalled();
     expect(subscribeSessionMessageEvents).toHaveBeenCalledWith(
       "conn-work-alias",
       "agent:work:global",

--- a/src/gateway/server-methods/sessions.messages-subscribe-approvals.test.ts
+++ b/src/gateway/server-methods/sessions.messages-subscribe-approvals.test.ts
@@ -43,6 +43,7 @@ function createContext(params: {
   replay?: SessionApprovalReplay;
   replayError?: Error;
   globalScope?: boolean;
+  mainKey?: string;
   agents?: Array<{ id: string; default?: boolean }>;
 }) {
   const rollbackSubscription = vi.fn();
@@ -57,7 +58,14 @@ function createContext(params: {
   const context = {
     getRuntimeConfig: () => ({
       agents: { list: params.agents ?? [{ id: "main", default: true }] },
-      ...(params.globalScope ? { session: { scope: "global" as const } } : {}),
+      ...(params.globalScope || params.mainKey
+        ? {
+            session: {
+              ...(params.globalScope ? { scope: "global" as const } : {}),
+              ...(params.mainKey ? { mainKey: params.mainKey } : {}),
+            },
+          }
+        : {}),
     }),
     listSessionPendingApprovals,
     logGateway: { error: logError },
@@ -95,11 +103,9 @@ async function subscribe(params: {
 describe("sessions.messages.subscribe approval opt-in", () => {
   beforeEach(() => {
     loadSessionEntryMock.mockReset();
-    loadSessionEntryMock.mockImplementation((sessionKey: string) => ({ canonicalKey: sessionKey }));
   });
 
   it("allows an admin without a paired device and uses the exact scoped subscription key", async () => {
-    loadSessionEntryMock.mockReturnValueOnce({ canonicalKey: "global" });
     const approvalReplay = {
       sessionKey: "agent:work:global",
       updatedAtMs: 42,
@@ -113,7 +119,7 @@ describe("sessions.messages.subscribe approval opt-in", () => {
     });
 
     const respond = await subscribe({
-      body: { key: "agent:work:main", includeApprovals: true },
+      body: { key: "global", agentId: "work", includeApprovals: true },
       client: createClient({ scopes: ["operator.admin"], connId: " conn-admin " }),
       context,
     });
@@ -134,10 +140,10 @@ describe("sessions.messages.subscribe approval opt-in", () => {
       { subscribed: true, key: "global", approvalReplay },
       undefined,
     );
+    expect(loadSessionEntryMock).not.toHaveBeenCalled();
   });
 
   it("allows a paired device with approval scope", async () => {
-    loadSessionEntryMock.mockReturnValueOnce({ canonicalKey: "agent:main:child" });
     const approvalReplay = {
       sessionKey: "agent:main:child",
       updatedAtMs: 43,
@@ -197,7 +203,6 @@ describe("sessions.messages.subscribe approval opt-in", () => {
   });
 
   it("keeps the non-approval response shape and skips replay", async () => {
-    loadSessionEntryMock.mockReturnValueOnce({ canonicalKey: "agent:main:child" });
     const { context, listSessionPendingApprovals, subscribeSessionMessageEvents } = createContext(
       {},
     );
@@ -220,6 +225,27 @@ describe("sessions.messages.subscribe approval opt-in", () => {
       undefined,
     );
     expect(respond.mock.calls[0]?.[1]).not.toHaveProperty("approvalReplay");
+  });
+
+  it("canonicalizes configured main aliases without loading the session store", async () => {
+    const { context, subscribeSessionMessageEvents } = createContext({ mainKey: "work" });
+
+    const respond = await subscribe({
+      body: { key: "main" },
+      client: createClient({ scopes: ["operator.read"] }),
+      context,
+    });
+
+    expect(subscribeSessionMessageEvents).toHaveBeenCalledWith(
+      "conn-approval-reviewer",
+      "agent:main:work",
+    );
+    expect(respond).toHaveBeenCalledWith(
+      true,
+      { subscribed: true, key: "agent:main:work" },
+      undefined,
+    );
+    expect(loadSessionEntryMock).not.toHaveBeenCalled();
   });
 
   it.each([

--- a/src/gateway/server.chat.gateway-server-chat-b.test.ts
+++ b/src/gateway/server.chat.gateway-server-chat-b.test.ts
@@ -718,6 +718,90 @@ describe("gateway server chat", () => {
     });
   });
 
+  test("chat.startup memoizes config projections and invalidates them on config change", async () => {
+    const sessionDir = autoCleanupTempDirs.make("openclaw-gw-");
+    testState.sessionStorePath = path.join(sessionDir, "sessions.json");
+    testState.agentConfig = {
+      model: { primary: "test-provider/memo-model" },
+      models: { "test-provider/memo-model": {} },
+    };
+    testState.agentsConfig = {
+      list: [{ id: "main", default: true, name: "Before reload" }],
+    };
+    clearConfigCache();
+    try {
+      await writeSessionStore({
+        entries: { main: { sessionId: "sess-main", updatedAt: Date.now() } },
+      });
+      let catalog = [{ id: "memo-model", name: "Memo Model", provider: "test-provider" }];
+      let runtimeConfig = getRuntimeConfig();
+      let catalogConfig = runtimeConfig;
+      const context = createDirectChatContext({
+        getRuntimeConfig: () => runtimeConfig,
+        loadGatewayModelCatalogSnapshot: vi.fn(async () => {
+          return {
+            agentId: "main",
+            agentDir: "/tmp/chat-memo-agent",
+            workspaceDir: "/tmp/chat-memo-workspace",
+            config: catalogConfig,
+            entries: catalog,
+            routeVariants: catalog,
+          };
+        }),
+      });
+      const { chatHandlers } = await import("./server-methods/chat.js");
+      const requestStartup = async () => {
+        const responses: Array<{ ok: boolean; payload?: unknown }> = [];
+        await expectDefined(
+          chatHandlers["chat.startup"],
+          'chatHandlers["chat.startup"] test invariant',
+        )({
+          req: {
+            type: "req",
+            id: `startup-memo-${responses.length}`,
+            method: "chat.startup",
+            params: { sessionKey: "main" },
+          },
+          params: { sessionKey: "main" },
+          client: null,
+          isWebchatConnect: () => false,
+          respond: ((ok, payload) => responses.push({ ok, payload })) as RespondFn,
+          context,
+        });
+        expect(responses[0]?.ok).toBe(true);
+        return responses[0]?.payload as {
+          agentsList?: { agents?: Array<{ id?: string; name?: string }> };
+          metadata?: { models?: Array<{ id?: string; name?: string }> };
+        };
+      };
+
+      const first = await requestStartup();
+      const second = await requestStartup();
+      expect(second.agentsList).toBe(first.agentsList);
+      expect(second.metadata).toBe(first.metadata);
+
+      runtimeConfig = { ...runtimeConfig, logging: { level: "debug" } };
+      const staleCatalog = await requestStartup();
+      expect(staleCatalog.metadata).toBeUndefined();
+
+      catalogConfig = runtimeConfig;
+      const afterReload = await requestStartup();
+      expect(afterReload.agentsList).not.toBe(first.agentsList);
+      expect(afterReload.agentsList).not.toBe(staleCatalog.agentsList);
+      expect(afterReload.metadata).not.toBe(first.metadata);
+
+      catalog = [{ id: "memo-model", name: "Refreshed Memo Model", provider: "test-provider" }];
+      const afterCatalogRefresh = await requestStartup();
+      expect(afterCatalogRefresh.agentsList).not.toBe(afterReload.agentsList);
+      expect(afterCatalogRefresh.metadata).not.toBe(afterReload.metadata);
+    } finally {
+      testState.agentConfig = undefined;
+      testState.agentsConfig = undefined;
+      testState.sessionStorePath = undefined;
+      clearConfigCache();
+    }
+  });
+
   test("chat.startup omits model metadata from a fallback owner", async () => {
     const config = {
       agents: {
@@ -967,6 +1051,61 @@ describe("gateway server chat", () => {
       expect(payload?.sessionInfo?.sessionId).toBe("sess-main");
       expect(payload?.agentsList?.agents?.map((agent) => agent.id)).toContain("main");
       expect(payload?.metadata).toBeUndefined();
+    } finally {
+      testState.sessionStorePath = undefined;
+    }
+  });
+
+  test("chat.history degrades promptly when the optional model catalog is slow", async () => {
+    const sessionDir = autoCleanupTempDirs.make("openclaw-gw-");
+    try {
+      testState.sessionStorePath = path.join(sessionDir, "sessions.json");
+      await writeSessionStore({
+        entries: {
+          main: {
+            sessionId: "sess-main",
+            modelProvider: "test-provider",
+            model: "slow-catalog-model",
+            updatedAt: Date.now(),
+          },
+        },
+      });
+      const catalog =
+        createDeferred<
+          Awaited<ReturnType<GatewayRequestContext["loadGatewayModelCatalogSnapshot"]>>
+        >();
+      const responses: Array<{ ok: boolean; payload?: unknown; error?: unknown }> = [];
+      const context = createDirectChatContext({
+        loadGatewayModelCatalogSnapshot: vi
+          .fn<GatewayRequestContext["loadGatewayModelCatalogSnapshot"]>()
+          .mockReturnValue(catalog.promise),
+        getRuntimeConfig: () => ({}),
+      });
+      const { chatHandlers } = await import("./server-methods/chat.js");
+
+      await expectDefined(
+        chatHandlers["chat.history"],
+        'chatHandlers["chat.history"] test invariant',
+      )({
+        req: {
+          type: "req",
+          id: "history-slow-catalog",
+          method: "chat.history",
+          params: { sessionKey: "main" },
+        },
+        params: { sessionKey: "main" },
+        client: null,
+        isWebchatConnect: () => false,
+        respond: ((ok, payload, error) => responses.push({ ok, payload, error })) as RespondFn,
+        context,
+      });
+
+      expect(context.loadGatewayModelCatalogSnapshot).toHaveBeenCalledTimes(1);
+      expect(responses).toHaveLength(1);
+      expect(responses[0]?.ok).toBe(true);
+      expect(
+        (responses[0]?.payload as { sessionInfo?: { sessionId?: string } })?.sessionInfo?.sessionId,
+      ).toBe("sess-main");
     } finally {
       testState.sessionStorePath = undefined;
     }

--- a/src/gateway/session-utils-core.ts
+++ b/src/gateway/session-utils-core.ts
@@ -280,7 +280,7 @@ export function shouldKeepStoreOnlyChildLink(entry: SessionEntry, now: number): 
 }
 
 type SingleRowChildSessionCandidateCacheEntry = {
-  store: Record<string, SessionEntry>;
+  entriesByKey: Map<string, SessionEntry>;
   childSessionCandidatesByParentKey: Map<string, string[]>;
 };
 
@@ -328,6 +328,17 @@ function buildStoreChildSessionCandidateIndex(
   return childSessionsByKey;
 }
 
+function singleRowChildSessionCacheMatches(
+  cached: SingleRowChildSessionCandidateCacheEntry,
+  store: Record<string, SessionEntry>,
+): boolean {
+  const entries = Object.entries(store);
+  return (
+    entries.length === cached.entriesByKey.size &&
+    entries.every(([key, entry]) => cached.entriesByKey.get(key) === entry)
+  );
+}
+
 export function getSingleRowChildSessionCandidates(params: {
   storePath: string;
   store: Record<string, SessionEntry> | null | undefined;
@@ -336,12 +347,14 @@ export function getSingleRowChildSessionCandidates(params: {
     return new Map();
   }
   const cached = singleRowChildSessionCandidateCache.get(params.storePath);
-  if (cached?.store === params.store) {
+  if (cached && singleRowChildSessionCacheMatches(cached, params.store)) {
     return cached.childSessionCandidatesByParentKey;
   }
   const childSessionCandidatesByParentKey = buildStoreChildSessionCandidateIndex(params.store);
   rememberSingleRowChildSessionCandidateCacheEntry(params.storePath, {
-    store: params.store,
+    // Exact read-only lookups rebuild a sparse record but borrow stable entry objects
+    // from the SQLite snapshot. Compare those identities so the derived index survives.
+    entriesByKey: new Map(Object.entries(params.store)),
     childSessionCandidatesByParentKey,
   });
   return childSessionCandidatesByParentKey;

--- a/src/gateway/session-utils-search.ts
+++ b/src/gateway/session-utils-search.ts
@@ -160,6 +160,7 @@ export function loadGatewaySessionRow(
   const now = options?.now ?? Date.now();
   const { cfg, storePath, store, entry, canonicalKey } = loadSessionEntryReadOnly(sessionKey, {
     clone: false,
+    includeStoreChildEntries: true,
     ...(options?.agentId ? { agentId: options.agentId } : {}),
   });
   if (!entry) {

--- a/src/gateway/session-utils-store-lookup.ts
+++ b/src/gateway/session-utils-store-lookup.ts
@@ -9,8 +9,10 @@ import {
   type SessionStoreTarget,
 } from "../config/sessions.js";
 import {
+  listSessionChildEntriesReadOnly,
   listSessionEntries as listAccessorSessionEntries,
   listSessionEntriesReadOnly as listAccessorSessionEntriesReadOnly,
+  loadExactSessionEntryReadOnly,
 } from "../config/sessions/session-accessor.js";
 import type { SessionEntryListScope } from "../config/sessions/session-accessor.types.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
@@ -131,12 +133,13 @@ function loadGatewaySessionLookupStore(
   options: {
     readOnly?: boolean;
     cache?: GatewaySessionStoreCache;
+    exactKeys?: readonly string[];
     projection?: SessionEntryListScope["projection"];
   } = {},
 ): Record<string, SessionEntry> {
   const cache = options.cache;
   const cacheKey = cache
-    ? `${storePath}\u0000${agentId ?? ""}\u0000${clone === false ? "0" : "1"}\u0000${options.readOnly ? "1" : "0"}\u0000${options.projection ?? "full"}`
+    ? `${storePath}\u0000${agentId ?? ""}\u0000${clone === false ? "0" : "1"}\u0000${options.readOnly ? "1" : "0"}\u0000${options.projection ?? "full"}\u0000${options.exactKeys?.join("\u0001") ?? ""}`
     : "";
   if (cache) {
     const cached = cache.get(cacheKey);
@@ -153,9 +156,28 @@ function loadGatewaySessionLookupStoreUncached(
   storePath: string,
   clone: boolean | undefined,
   agentId?: string,
-  options: { readOnly?: boolean; projection?: SessionEntryListScope["projection"] } = {},
+  options: {
+    exactKeys?: readonly string[];
+    readOnly?: boolean;
+    projection?: SessionEntryListScope["projection"];
+  } = {},
 ): Record<string, SessionEntry> {
   try {
+    if (options.exactKeys) {
+      const store: Record<string, SessionEntry> = {};
+      for (const sessionKey of options.exactKeys) {
+        const match = loadExactSessionEntryReadOnly({
+          ...(agentId ? { agentId } : {}),
+          clone: false,
+          sessionKey,
+          storePath,
+        });
+        if (match) {
+          store[match.sessionKey] = match.entry;
+        }
+      }
+      return store;
+    }
     const listEntries = options.readOnly
       ? listAccessorSessionEntriesReadOnly
       : listAccessorSessionEntries;
@@ -181,6 +203,7 @@ function resolveGatewaySessionStoreLookup(params: {
   initialStore?: Record<string, SessionEntry>;
   projection?: SessionEntryListScope["projection"];
   readOnly?: boolean;
+  exactRead?: boolean;
   storeCache?: GatewaySessionStoreCache;
   targetDiscoveryCache?: GatewaySessionStoreDiscoveryCache;
 }): {
@@ -210,6 +233,7 @@ function resolveGatewaySessionStoreLookup(params: {
   const loadStore = (target: SessionStoreTarget) =>
     loadGatewaySessionLookupStore(target.storePath, params.clone, target.agentId, {
       readOnly: params.readOnly || !configured,
+      ...(params.exactRead ? { exactKeys: scanTargets } : {}),
       ...(params.projection ? { projection: params.projection } : {}),
       ...(params.storeCache ? { cache: params.storeCache } : {}),
     });
@@ -260,6 +284,7 @@ function resolveExplicitDeletedLegacyMainStoreTarget(params: {
   clone?: boolean;
   projection?: SessionEntryListScope["projection"];
   readOnly?: boolean;
+  exactRead?: boolean;
   storeCache?: GatewaySessionStoreCache;
   targetDiscoveryCache?: GatewaySessionStoreDiscoveryCache;
 }): GatewaySessionStoreTargetWithStore | null {
@@ -303,6 +328,7 @@ function resolveExplicitDeletedLegacyMainStoreTarget(params: {
     }
     const store = loadGatewaySessionLookupStore(target.storePath, params.clone, target.agentId, {
       readOnly: true,
+      ...(params.exactRead ? { exactKeys: lookupSeeds } : {}),
       ...(params.projection ? { projection: params.projection } : {}),
       ...(params.storeCache ? { cache: params.storeCache } : {}),
     });
@@ -342,6 +368,8 @@ export function resolveGatewaySessionStoreTargetWithStore(params: {
   clone?: boolean;
   projection?: SessionEntryListScope["projection"];
   readOnly?: boolean;
+  exactRead?: boolean;
+  includeStoreChildEntries?: boolean;
   store?: Record<string, SessionEntry>;
   storeCache?: GatewaySessionStoreCache;
   targetDiscoveryCache?: GatewaySessionStoreDiscoveryCache;
@@ -352,12 +380,13 @@ export function resolveGatewaySessionStoreTargetWithStore(params: {
     key,
     clone: params.clone,
     readOnly: params.readOnly,
+    exactRead: params.exactRead,
     ...(params.projection ? { projection: params.projection } : {}),
     ...(params.storeCache ? { storeCache: params.storeCache } : {}),
     ...(params.targetDiscoveryCache ? { targetDiscoveryCache: params.targetDiscoveryCache } : {}),
   });
   if (explicitDeletedMainTarget) {
-    return explicitDeletedMainTarget;
+    return includeDirectChildEntries(explicitDeletedMainTarget, params.includeStoreChildEntries);
   }
 
   const requestedAgentId = normalizeOptionalString(params.agentId);
@@ -377,16 +406,20 @@ export function resolveGatewaySessionStoreTargetWithStore(params: {
     // owners may materialize the process-lifetime incognito database.
     const store = loadGatewaySessionLookupStore(storePath, params.clone, agentId, {
       readOnly: true,
+      ...(params.exactRead ? { exactKeys: [canonicalKey] } : {}),
       ...(params.projection ? { projection: params.projection } : {}),
       ...(params.storeCache ? { cache: params.storeCache } : {}),
     });
-    return {
-      agentId,
-      storePath,
-      canonicalKey,
-      storeKeys: [canonicalKey],
-      store,
-    };
+    return includeDirectChildEntries(
+      {
+        agentId,
+        storePath,
+        canonicalKey,
+        storeKeys: [canonicalKey],
+        store,
+      },
+      params.includeStoreChildEntries,
+    );
   }
   const { storePath, store } = resolveGatewaySessionStoreLookup({
     cfg: params.cfg,
@@ -395,6 +428,7 @@ export function resolveGatewaySessionStoreTargetWithStore(params: {
     agentId,
     clone: params.clone,
     readOnly: params.readOnly,
+    exactRead: params.exactRead,
     initialStore: params.store,
     ...(params.projection ? { projection: params.projection } : {}),
     ...(params.storeCache ? { storeCache: params.storeCache } : {}),
@@ -402,19 +436,50 @@ export function resolveGatewaySessionStoreTargetWithStore(params: {
   });
   if (canonicalKey === "global" || canonicalKey === "unknown") {
     const storeKeys = key && key !== canonicalKey ? [canonicalKey, key] : [key];
-    return { agentId, storePath, canonicalKey, storeKeys, store };
+    return includeDirectChildEntries(
+      { agentId, storePath, canonicalKey, storeKeys, store },
+      params.includeStoreChildEntries,
+    );
   }
 
   const storeKeys = new Set<string>(
     buildGatewaySessionStoreScanTargets({ cfg: params.cfg, key, canonicalKey, agentId }),
   );
-  return {
-    agentId,
-    storePath,
-    canonicalKey,
-    storeKeys: Array.from(storeKeys),
-    store,
-  };
+  return includeDirectChildEntries(
+    {
+      agentId,
+      storePath,
+      canonicalKey,
+      storeKeys: Array.from(storeKeys),
+      store,
+    },
+    params.includeStoreChildEntries,
+  );
+}
+
+function includeDirectChildEntries(
+  target: GatewaySessionStoreTargetWithStore,
+  include: boolean | undefined,
+): GatewaySessionStoreTargetWithStore {
+  if (!include) {
+    return target;
+  }
+  try {
+    const parentKeys = new Set([target.canonicalKey, ...target.storeKeys]);
+    for (const parentKey of parentKeys) {
+      for (const { sessionKey, entry } of listSessionChildEntriesReadOnly({
+        agentId: target.agentId,
+        clone: false,
+        sessionKey: parentKey,
+        storePath: target.storePath,
+      })) {
+        target.store[sessionKey] = entry;
+      }
+    }
+  } catch {
+    // Match the existing read-only lookup contract: unavailable stores degrade to no rows.
+  }
+  return target;
 }
 
 export function resolveGatewaySessionStoreTarget(params: {

--- a/src/gateway/session-utils-store.ts
+++ b/src/gateway/session-utils-store.ts
@@ -121,7 +121,7 @@ function readAcpMetaForDeletedAgentCheck(params: {
 
 function loadSessionEntryWithMode(
   sessionKey: string,
-  opts: { agentId?: string; clone?: boolean } | undefined,
+  opts: { agentId?: string; clone?: boolean; includeStoreChildEntries?: boolean } | undefined,
   readOnly: boolean,
 ) {
   const cfg = getRuntimeConfig();
@@ -131,17 +131,27 @@ function loadSessionEntryWithMode(
     key,
     ...(opts?.clone === false ? { clone: false } : {}),
     ...(opts?.agentId ? { agentId: opts.agentId } : {}),
-    ...(readOnly ? { readOnly: true } : {}),
+    ...(readOnly
+      ? {
+          exactRead: true,
+          readOnly: true,
+          ...(opts?.includeStoreChildEntries ? { includeStoreChildEntries: true } : {}),
+        }
+      : {}),
   });
   const storePath = target.storePath;
   const store = target.store;
   const freshestMatch = resolveFreshestSessionStoreMatchFromStoreKeys(store, target.storeKeys);
   const legacyKey = freshestMatch?.key !== target.canonicalKey ? freshestMatch?.key : undefined;
+  const entry =
+    readOnly && opts?.clone !== false && freshestMatch?.entry
+      ? structuredClone(freshestMatch.entry)
+      : freshestMatch?.entry;
   return {
     cfg,
     storePath,
     store,
-    entry: freshestMatch?.entry,
+    entry,
     canonicalKey: target.canonicalKey,
     storeKeys: target.storeKeys,
     legacyKey,
@@ -154,7 +164,7 @@ export function loadSessionEntry(sessionKey: string, opts?: { agentId?: string; 
 
 export function loadSessionEntryReadOnly(
   sessionKey: string,
-  opts?: { agentId?: string; clone?: boolean },
+  opts?: { agentId?: string; clone?: boolean; includeStoreChildEntries?: boolean },
 ) {
   return loadSessionEntryWithMode(sessionKey, opts, true);
 }

--- a/src/gateway/session-utils.test.ts
+++ b/src/gateway/session-utils.test.ts
@@ -10,6 +10,8 @@ import type { OpenClawConfig } from "../config/config.js";
 import type { SessionEntry } from "../config/sessions.js";
 import {
   appendTranscriptMessageSync,
+  listSessionChildEntriesReadOnly,
+  listSessionEntriesReadOnly,
   replaceSessionEntry,
 } from "../config/sessions/session-accessor.js";
 import { resolveSqliteTargetFromSessionStorePath } from "../config/sessions/session-sqlite-target.js";
@@ -23,6 +25,7 @@ import { normalizeSessionDeliveryState } from "../utils/delivery-context.shared.
 import { registerSessionAutomationSource } from "./session-automation-index.js";
 import { buildGatewaySessionEventFields } from "./session-event-payload.js";
 import { capArrayByJsonBytes } from "./session-transcript-readers.js";
+import { buildSingleRowStoreChildSessionsByKey } from "./session-utils-projection.js";
 import {
   canonicalizeSpawnedByForAgent,
   buildGatewaySessionRow,
@@ -1953,6 +1956,131 @@ describe("gateway session utils", () => {
 
         expect(loaded.entry).toBeUndefined();
         expect(fs.existsSync(path.join(stateDir, "agents", "missing"))).toBe(false);
+      });
+    } finally {
+      resetConfigRuntimeState();
+    }
+  });
+
+  test("loadSessionEntryReadOnly clones only the selected row and direct children", async () => {
+    resetConfigRuntimeState();
+    try {
+      await withStateDirEnv("session-utils-exact-read-only-", async ({ stateDir }) => {
+        const storePath = path.join(stateDir, "agents", "main", "sessions", "sessions.json");
+        const cfg = {
+          session: { mainKey: "main", store: storePath },
+          agents: { list: [{ id: "main", default: true }] },
+        } as OpenClawConfig;
+        const parentKey = "agent:main:main";
+        const childKey = "agent:main:child";
+        const now = Date.now();
+        await seedSessionEntries(storePath, {
+          [parentKey]: { sessionId: "parent", updatedAt: now },
+          [childKey]: { sessionId: "child", spawnedBy: parentKey, updatedAt: now + 1 },
+          ...Object.fromEntries(
+            Array.from({ length: 40 }, (_, index) => [
+              `agent:main:unrelated-${index}`,
+              { sessionId: `unrelated-${index}`, updatedAt: now + index + 2 },
+            ]),
+          ),
+        });
+        setRuntimeConfigSnapshot(cfg, cfg);
+        expect(
+          listSessionEntriesReadOnly({ agentId: "main", storePath }).map((item) => item.sessionKey),
+        ).toContain(childKey);
+        const cloneSpy = vi.spyOn(globalThis, "structuredClone");
+        try {
+          expect(loadSessionEntryReadOnly(childKey, { clone: false }).entry).toMatchObject({
+            sessionId: "child",
+            spawnedBy: parentKey,
+          });
+          expect(
+            listSessionChildEntriesReadOnly({
+              agentId: "main",
+              clone: false,
+              sessionKey: parentKey,
+              storePath,
+            }).map((item) => item.sessionKey),
+          ).toEqual([childKey]);
+          const loaded = loadSessionEntryReadOnly("main", {
+            includeStoreChildEntries: true,
+          });
+
+          expect(loaded.entry?.sessionId).toBe("parent");
+          expect(Object.keys(loaded.store).toSorted()).toEqual([childKey, parentKey]);
+          expect(loaded.entry).not.toBe(loaded.store[parentKey]);
+          expect(cloneSpy).toHaveBeenCalledTimes(1);
+        } finally {
+          cloneSpy.mockRestore();
+        }
+      });
+    } finally {
+      resetConfigRuntimeState();
+    }
+  });
+
+  test("single-row child candidates reuse stable entry identities across sparse stores", () => {
+    const parentKey = "agent:main:main";
+    let spawnedByReads = 0;
+    const parent = { sessionId: "parent", updatedAt: 1 } as SessionEntry;
+    const child = {
+      sessionId: "child",
+      updatedAt: Date.now(),
+      get spawnedBy() {
+        spawnedByReads += 1;
+        return parentKey;
+      },
+    } as SessionEntry;
+    const storePath = "/tmp/openclaw-single-row-child-cache";
+
+    const first = buildSingleRowStoreChildSessionsByKey({
+      store: { [parentKey]: parent, "agent:main:child": child },
+      storePath,
+      key: parentKey,
+      now: Date.now(),
+    });
+    const second = buildSingleRowStoreChildSessionsByKey({
+      store: { [parentKey]: parent, "agent:main:child": child },
+      storePath,
+      key: parentKey,
+      now: Date.now(),
+    });
+
+    expect(first.get(parentKey)).toEqual(["agent:main:child"]);
+    expect(second.get(parentKey)).toEqual(["agent:main:child"]);
+    expect(spawnedByReads).toBe(1);
+  });
+
+  test("loadSessionEntryReadOnly keeps children linked through a main alias", async () => {
+    resetConfigRuntimeState();
+    try {
+      await withStateDirEnv("session-utils-exact-alias-children-", async ({ stateDir }) => {
+        const storePath = path.join(stateDir, "agents", "main", "sessions", "sessions.json");
+        const cfg = {
+          session: { mainKey: "work", store: storePath },
+          agents: { list: [{ id: "main", default: true }] },
+        } as OpenClawConfig;
+        const legacyParentKey = "agent:main:main";
+        const childKey = "agent:main:child";
+        const now = Date.now();
+        await seedSessionEntries(storePath, {
+          [legacyParentKey]: { sessionId: "parent", updatedAt: now },
+          [childKey]: {
+            sessionId: "child",
+            spawnedBy: legacyParentKey,
+            updatedAt: now + 1,
+          },
+        });
+        setRuntimeConfigSnapshot(cfg, cfg);
+
+        const loaded = loadSessionEntryReadOnly("main", {
+          clone: false,
+          includeStoreChildEntries: true,
+        });
+
+        expect(loaded.canonicalKey).toBe("agent:main:work");
+        expect(loaded.entry?.sessionId).toBe("parent");
+        expect(loaded.store[childKey]?.spawnedBy).toBe(legacyParentKey);
       });
     } finally {
       resetConfigRuntimeState();

--- a/src/tui/embedded-backend.test.ts
+++ b/src/tui/embedded-backend.test.ts
@@ -936,7 +936,10 @@ describe("EmbeddedTuiBackend", () => {
       sessionId: "session-work-global",
       messages: [],
     });
-    expect(loadSessionEntryMock).toHaveBeenCalledWith("global", { agentId: "work" });
+    expect(loadSessionEntryMock).toHaveBeenCalledWith("global", {
+      agentId: "work",
+      includeStoreChildEntries: true,
+    });
   });
 
   it("uses reset-archive fallback for embedded TUI history reads", async () => {

--- a/src/tui/embedded-backend.ts
+++ b/src/tui/embedded-backend.ts
@@ -604,7 +604,7 @@ export class EmbeddedTuiBackend implements TuiBackend {
     const loadOptions = opts.agentId ? { agentId: opts.agentId } : undefined;
     const { cfg, storePath, store, entry, canonicalKey } = loadSessionEntryReadOnly(
       opts.sessionKey,
-      loadOptions,
+      { ...loadOptions, includeStoreChildEntries: true },
     );
     const sessionId = entry?.sessionId;
     const sessionAgentId = resolveSessionAgentId({


### PR DESCRIPTION
## What Problem This Solves

On team.openclaw.ai (~800 sessions, 3 agents), session switching pays 210-310ms warm for `chat.history`/`chat.startup` and ~93ms for `sessions.messages.subscribe`. A read-only cost map traced the slices: subscribe loads the whole session store to extract one config-derivable canonical key; `chat.history` structuredClones every store entry (O(800)) for a single-entry lookup, which also defeats the identity-keyed child-session index; `chat.startup` rebuilds pure config projections (agents list with per-agent git-checkout `existsSync` walks, startup metadata) per call; the model-catalog join uses the 750ms default budget instead of chat.startup's 25ms discipline; and an omission log serializes the full normalized payload per call even when nothing was omitted.

## Why This Change Was Made

Each switch re-derived facts that are stable across calls (canonical keys, config projections) or paid store-wide costs for single-row needs. Fixing at the owning layers removes the cost for every caller rather than special-casing the chat path.

## User Impact

Session switching gets materially faster server-side: subscribe drops to config-only derivation (~0 store cost), chat.history stops cloning the store per call, chat.startup serves memoized projections, and history responses no longer block up to 750ms on a slow model catalog.

## Evidence

- B4: five diagnostics spans (`session_entry`, `model_catalog`, `history_page`, `startup_projections`, `session_info`) make remaining latency attributable.
- B1: subscribe/unsubscribe derive canonicalKey via `resolveSessionStoreKey` config-only; regression test proves no store load (spy), alias keys included.
- B2: single-entry reads use `loadExactSqliteSessionEntryReadOnly`-backed exact access, clone only the selected entry, preserve alias-linked children, and make the child-session candidate index actually hit (it previously always missed on fresh store identities). Consumer audit: borrowed entries feed read-only row builders only; default callers keep cloned entries; explicit `clone:false` callers keep their borrowed contract.
- B3: agents list + startup metadata memoized on runtime-config identity (client caps in key, reload-race protection).
- B5: chat.history joins the catalog with the same early-start + 25ms budget as chat.startup; degraded fields follow the existing contract.
- B6: omission-log bytes computed only when an omission occurred.
- Validation: 1,664 tests across the 40-file sweep, 228/228 in final affected suites, core typechecks, oxlint/oxfmt clean. Testbox run: https://github.com/openclaw/openclaw/actions/runs/30335162730. Autoreview: six findings fixed, one rejected with proof.
