### PR TITLE
fix(ui): deflake chat-composer thinking slider by keeping optimistic session patches in the capability snapshot

### DIFF
--- a/ui/src/lib/sessions/index.ts
+++ b/ui/src/lib/sessions/index.ts
@@ -213,6 +213,10 @@ export type SessionCapability = {
   create: (params?: SessionCreateParams) => Promise<string | null>;
   patch: SessionPatchRoute;
   setModelOverride: (key: string, value: string | null | undefined) => void;
+  /** Applies optimistic row fields to the published snapshot so mid-flight
+   * publishes (e.g. a refresh's loading flip) cannot revert them before the
+   * post-mutation canonical list lands. */
+  patchRowLocal: (key: string, patch: Partial<GatewaySessionRow>) => void;
   /** True while a just-created work session is waiting for its canonical placement row. */
   isPreparedWorkSession: (key: string) => boolean;
   pullRequestSummary: (key: string) => SessionCatalogPullRequestSummary | undefined;
@@ -961,6 +965,31 @@ export function createSessionCapability(gateway: SessionGateway): SessionCapabil
       modelOverrides[normalizedKey] = normalizedValue;
     }
     publish({ ...state, modelOverrides });
+  };
+
+  // Optimistic session-settings patches (thinking level, speed) must live in
+  // the published capability snapshot, not only in consumer copies: every
+  // publish replaces consumer state wholesale, so a copy-only patch reverts on
+  // the next loading flip until the post-patch canonical list arrives. The
+  // revert window loses keyboard commits on the reasoning slider (flaky UI).
+  const patchRowLocal = (key: string, patch: Partial<GatewaySessionRow>) => {
+    const result = state.result;
+    const normalizedKey = key.trim();
+    if (!result || !normalizedKey) {
+      return;
+    }
+    let changed = false;
+    const sessions = result.sessions.map((row) => {
+      if (row.key !== normalizedKey) {
+        return row;
+      }
+      changed = true;
+      return { ...row, ...patch };
+    });
+    if (!changed) {
+      return;
+    }
+    publish({ ...state, result: { ...result, sessions } });
   };
 
   const rollbackPendingModelPatches = () => {
@@ -1962,6 +1991,7 @@ export function createSessionCapability(gateway: SessionGateway): SessionCapabil
     create,
     patch,
     setModelOverride,
+    patchRowLocal,
     isPreparedWorkSession(key) {
       return preparedWorkSessionKeys.has(key.trim());
     },

--- a/ui/src/pages/chat/chat-session.ts
+++ b/ui/src/pages/chat/chat-session.ts
@@ -264,6 +264,12 @@ function patchSessionRow(
   sessionKey: string,
   patch: Partial<SessionsListResult["sessions"][number]>,
 ) {
+  // Mirror into the capability snapshot first: publishes replace the host copy
+  // wholesale, so without the mirror any mid-flight publish reverts this patch
+  // until the post-patch list refresh lands (visible slider snap-back that can
+  // swallow the next keyboard commit). The host copy still updates directly so
+  // hosts without a live capability subscription stay coherent.
+  host.sessions.patchRowLocal(sessionKey, patch);
   const current = host.sessionsResult;
   if (!current) {
     return;

--- a/ui/src/pages/chat/chat-view.test.ts
+++ b/ui/src/pages/chat/chat-view.test.ts
@@ -5027,6 +5027,7 @@ describe("chat model controls", () => {
       ),
       refresh: async () => {},
       setModelOverride: vi.fn(),
+      patchRowLocal: vi.fn(),
     };
     const host = {
       client: {},
@@ -5096,6 +5097,7 @@ describe("chat model controls", () => {
       ),
       refresh: async () => {},
       setModelOverride: vi.fn(),
+      patchRowLocal: vi.fn(),
     };
     const host = {
       client: {},
@@ -5148,6 +5150,7 @@ describe("chat model controls", () => {
       ),
       refresh: async () => {},
       setModelOverride: vi.fn(),
+      patchRowLocal: vi.fn(),
     };
     const host = {
       client: {},
@@ -5213,6 +5216,7 @@ describe("chat model controls", () => {
           });
         },
         refresh: async () => {},
+        patchRowLocal: () => {},
       },
     } as unknown as Parameters<typeof switchChatFastMode>[0];
 


### PR DESCRIPTION
## What Problem This Solves

The `chat-composer-redesign.e2e.test.ts` thinking-slider assertion flaked on hosted CI and disrupted two unrelated PR landings today (PR #114906, run 30329967721 / job 90182941629; a similar new-session-page flake hit PR #114695 earlier). The failing poll waits for a `sessions.patch` with `thinkingLevel: "low"` after pressing `Home` then `ArrowRight` on the reasoning slider — on slow runners that patch is never sent.

Underneath the flake is a real product race: chat keeps optimistic thinking-level / fast-mode row patches only in the host copy of the session list (`patchSessionRow` in `ui/src/pages/chat/chat-session.ts`), while the sessions capability's published snapshot still has the old row. The capability's post-patch list refresh starts with a `loading: true` publish that republishes that stale snapshot, and the session-data-controller replaces the host copy wholesale — reverting the slider to the inherited default ("Default (High)", index 3) until the refreshed canonical list lands and the chat layer re-applies the patch. A keystroke landing inside that revert window is swallowed: `ArrowRight` at the max index fires no `change` event, so no `thinkingLevel: "low"` patch is ever committed. Users can also see this as a brief slider snap-back after releasing it.

## Why This Change Was Made

Root-cause fix instead of a timeout bump: optimistic session-settings row patches now live in the capability's published snapshot, matching how model overrides already work (`setModelOverride` / `pendingModelPatches` exist for exactly this reason). `patchSessionRow` mirrors the fields via a new `SessionCapability.patchRowLocal` before updating the host copy, so every intermediate publish carries the patch and the revert window is structurally gone. The e2e test itself is unchanged.

The sibling new-session-page flake seen on PR #114695 does **not** share this mechanism — the new-session composer commits thinking level to local draft state (`ui/src/pages/new-session/model-control.ts`) with no `sessions.patch` involved — so it is intentionally left out of this bounded pass.

## User Impact

- The reasoning slider no longer flicks back to the inherited default for a beat after committing a level (or speed) change, and rapid keyboard adjustments are no longer swallowed mid-flight.
- CI: the `checks-ui-e2e` thinking-slider flake that blocked unrelated landings is fixed at the source.

## Evidence

Diagnosis was instrumented, not guessed: a temporary in-page spy hooked the slider's `value` property setter, attribute mutations, and WebSocket frames under 20x CDP CPU throttling. Before the fix, the timeline shows `sessions.patch(off)` response → `sessions.list` request → **`prop-set "3"` + `aria-valuetext "Default (High)"`** (the revert) → list response → `prop-set "0"` (re-apply). After the fix, the same instrumented run is monotonic: 3→0 stays 0 across the patch response and both list refreshes, then 0→1 stays 1 — no revert render at all.

- CI failure grounding: run 30329967721, job 90182941629 — `AssertionError: expected false to be true` at `ui/src/e2e/chat-composer-redesign.e2e.test.ts:231` (`Matcher did not succeed in time` at line 221), i.e. no `thinkingLevel: "low"` patch observed.
- Repeat-proof: `node scripts/run-vitest.mjs ui/src/e2e/chat-composer-redesign.e2e.test.ts` in a bounded 5x shell loop — 5/5 runs, 6/6 tests green each run (plus additional instrumented throttled runs during diagnosis).
- Focused units: `chat-view.test.ts`, `chat-send.test.ts`, `lib/sessions/index.test.ts`, `list-options.test.ts` — 470 tests green.
- `node scripts/check-changed.mjs` (lanes `coreTests`, `ui`) delegated to Blacksmith Testbox and passed.
- Autoreview (Codex, `--mode uncommitted`): clean, no accepted/actionable findings.
