### PR TITLE
fix(tui): recover from transient session subscription failures

### DIFF
--- a/src/tui/tui-pty-harness-fixture-test-support.ts
+++ b/src/tui/tui-pty-harness-fixture-test-support.ts
@@ -3,6 +3,7 @@ import { readFile, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
 import { TUI_PTY_GAP_HISTORY_FIXTURE_SCRIPT } from "./tui-pty-gap-fixture-test-support.js";
+import { TUI_PTY_SESSION_SUBSCRIPTION_FIXTURE_SCRIPT } from "./tui-pty-subscription-fixture-test-support.js";
 import { sleep, type PtyRun } from "./tui-pty-test-support.js";
 
 export async function writeTuiPtyFixtureScript(dir: string) {
@@ -118,7 +119,6 @@ export async function writeTuiPtyFixtureScript(dir: string) {
         connection = { url: "pty-fixture://local" };
         onEvent?: TuiBackend["onEvent"];
         onConnected?: TuiBackend["onConnected"];
-        onDisconnected?: TuiBackend["onDisconnected"];
         onGap?: TuiBackend["onGap"];
 
         start() {
@@ -128,6 +128,8 @@ export async function writeTuiPtyFixtureScript(dir: string) {
         stop() {
           record("stop");
         }
+
+        ${TUI_PTY_SESSION_SUBSCRIPTION_FIXTURE_SCRIPT}
 
         async sendChat(opts: Parameters<TuiBackend["sendChat"]>[0]) {
           record("sendChat", {

--- a/src/tui/tui-pty-harness.e2e.test.ts
+++ b/src/tui/tui-pty-harness.e2e.test.ts
@@ -190,6 +190,34 @@ describe.sequential("TUI PTY harness", () => {
     STARTUP_TEST_TIMEOUT_MS,
   );
 
+  it.each([{ failures: 1 }, { failures: 2 }])(
+    "bounds session subscription recovery after $failures startup failures",
+    async ({ failures }) => {
+      const subscriptionFixture = await startTuiFixture({
+        env: { OPENCLAW_TUI_PTY_SUBSCRIBE_FAILURES: String(failures) },
+      });
+      try {
+        await subscriptionFixture.run.waitForOutput("local ready | idle", STARTUP_TIMEOUT_MS);
+        const entries = await readFixtureLog(subscriptionFixture.logPath);
+        expect(entries.filter((entry) => entry.method === "subscribeSessionEvents")).toHaveLength(
+          2,
+        );
+        expect(entries.filter((entry) => entry.method === "subscribeSessionFailure")).toHaveLength(
+          failures,
+        );
+
+        await subscriptionFixture.run.write("after subscription recovery proof\r");
+        await subscriptionFixture.run.waitForOutput(
+          "PTY_RESPONSE: after subscription recovery proof",
+          STARTUP_TIMEOUT_MS,
+        );
+      } finally {
+        await subscriptionFixture.cleanup();
+      }
+    },
+    STARTUP_TEST_TIMEOUT_MS,
+  );
+
   it("refreshes pending approvals before loading history", async () => {
     await fixture.waitForLogEntry((entry) => entry.method === "listPluginApprovals");
     await fixture.waitForLogEntry((entry) => entry.method === "listTaskSuggestions");

--- a/src/tui/tui-pty-subscription-fixture-test-support.ts
+++ b/src/tui/tui-pty-subscription-fixture-test-support.ts
@@ -1,0 +1,14 @@
+// Keeps bounded session-subscription failure injection outside the shared PTY fixture.
+export const TUI_PTY_SESSION_SUBSCRIPTION_FIXTURE_SCRIPT = `
+  private sessionSubscriptionAttempts = 0;
+
+  async subscribeSessionEvents() {
+    record("subscribeSessionEvents");
+    const configuredFailures = Number(process.env.OPENCLAW_TUI_PTY_SUBSCRIBE_FAILURES ?? 0);
+    if (this.sessionSubscriptionAttempts++ < configuredFailures) {
+      record("subscribeSessionFailure");
+      throw new Error("fixture session subscription unavailable");
+    }
+    return { subscribed: true };
+  }
+`;

--- a/src/tui/tui.ts
+++ b/src/tui/tui.ts
@@ -1674,13 +1674,21 @@ export async function runTui(opts: RunTuiOptions): Promise<TuiResult> {
       setActivityStatus("starting up");
     }
     void (async () => {
-      try {
-        await client.subscribeSessionEvents?.();
-      } catch (err) {
-        if (!ownsConnection()) {
-          return;
+      for (let attempt = 0; attempt < 2; attempt += 1) {
+        try {
+          await client.subscribeSessionEvents?.();
+          break;
+        } catch (err) {
+          if (!ownsConnection()) {
+            return;
+          }
+          // Subscription is idempotent; recover one transient Gateway failure
+          // without leaving this connected TUI permanently unsubscribed.
+          if (attempt === 0) {
+            continue;
+          }
+          chatLog.addSystem(`session event subscribe failed: ${formatTuiErrorMessage(err)}`);
         }
-        chatLog.addSystem(`session event subscribe failed: ${formatTuiErrorMessage(err)}`);
       }
       if (!ownsConnection()) {
         return;


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users opening or reconnecting the terminal UI could permanently stop receiving session and cross-client conversation updates after one transient Gateway session-subscription failure, even though the connection and chat startup otherwise succeeded.

## Why This Change Was Made

The Gateway session subscription is idempotent. Retry it exactly once within the existing generation-owned connection bootstrap, preserve stale-reconnect cancellation, and retain the existing visible error after a persistent failure. Extract the bounded failure injector into its own PTY fixture module to respect the shared-fixture line limit.

## User Impact

The TUI automatically recovers from a transient Gateway subscription failure. Persistent failures remain bounded and visible, and the terminal remains usable.

## Evidence

Real-terminal regression, before fix:

    transient failure: expected 2 subscription attempts, received 1 — FAIL
    persistent failure: expected 2 subscription attempts, received 1 — FAIL

Final real-terminal regression:

    1 simulated failure: 2 attempts, successful recovery, subsequent prompt renders — PASS
    2 simulated failures: exactly 2 attempts, startup remains usable — PASS

Final proof on Blacksmith Testbox tbx_01kykmeq9mmd2zsgatd0f9s3ed:

- Type-aware TUI lint: PASS.
- Full changed gate, including typecheck and repository guards: PASS.
- Focused real-terminal subscription regressions: 2 PASS.
- Complete TUI suite: 897 PASS across 35 files.
- Full real-terminal, local-backend, and real-Gateway suite: 61 PASS.
- Prior stress soak: three complete 59-case terminal/Gateway passes, followed by three targeted 9-case real-Gateway race passes.
- Fresh independent autoreview: clean; no actionable findings.

### Gateway subscription contract

The current Gateway handler in src/gateway/server-methods/sessions-subscriptions.ts:19 adds the current connection id to the session event subscriber registry and returns subscribed for that same connection. src/gateway/server-startup-finish.ts:262 wires this to the canonical session subscriber owner. Repeating sessions.subscribe for the same connected client is therefore idempotent. The final full PTY run independently proved one-failure recovery, two-failure bounded exhaustion, subsequent prompt delivery, Gateway restart/reconnect, and all 61 real-terminal cases on the reviewed commit. The exact-head hosted CI is green: https://github.com/openclaw/openclaw/actions/runs/30335692969.
