### PR TITLE
fix(agents): stop cancelled runs from spawning zombie agent loops

### DIFF
--- a/src/agents/embedded-agent-runner/run/attempt-stream-runtime-prepare.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-stream-runtime-prepare.test.ts
@@ -228,6 +228,25 @@ describe("prepareEmbeddedAttemptStreamRuntime", () => {
     expect(mocks.withOwnedSessionTranscriptWrites).toHaveBeenCalledOnce();
   });
 
+  it.each([
+    { label: "external cancellation", message: "run cancelled" },
+    { label: "run timeout", message: "run timed out" },
+  ])("does not start a prompt after $label", async ({ message }) => {
+    const fixture = createFixture();
+    const runtime = await prepareEmbeddedAttemptStreamRuntime(fixture.input);
+    const reason = new Error(message);
+    const abortError = new Error(message, { cause: reason });
+    abortError.name = "AbortError";
+    fixture.input.runAbortController.abort(reason);
+    mocks.abortable.mockImplementationOnce((_signal, _promise) => Promise.reject(abortError));
+
+    await expect(runtime.promptActiveSession("must not start")).rejects.toBe(abortError);
+
+    expect(fixture.activeSession.prompt).not.toHaveBeenCalled();
+    expect(fixture.trackPromptSettlePromise).not.toHaveBeenCalled();
+    expect(mocks.abortable).toHaveBeenCalledOnce();
+  });
+
   it("flushes pending tool results and disposes the session when history preparation fails", async () => {
     const fixture = createFixture({ aborted: true });
     const failure = new Error("history failed");

--- a/src/agents/embedded-agent-runner/run/attempt-stream-runtime-prepare.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-stream-runtime-prepare.ts
@@ -137,9 +137,14 @@ export async function prepareEmbeddedAttemptStreamRuntime(input: {
     prompt: string,
     options?: Parameters<typeof activeSession.prompt>[1],
   ): Promise<void> =>
-    withOwnedSessionTranscriptWrites(input.ownedTranscriptWriteContext, async () =>
-      abortable(input.trackPromptSettlePromise(activeSession.prompt(prompt, options))),
-    );
+    withOwnedSessionTranscriptWrites(input.ownedTranscriptWriteContext, async () => {
+      // Prompting starts its own agent loop; reject before creating a loop that
+      // an already-aborted attempt can no longer cancel.
+      if (input.runAbortController.signal.aborted) {
+        return abortable(Promise.resolve());
+      }
+      return abortable(input.trackPromptSettlePromise(activeSession.prompt(prompt, options)));
+    });
   const onBlockReply = attempt.onBlockReply
     ? bindOwnedSessionTranscriptWrites(input.ownedTranscriptWriteContext, attempt.onBlockReply)
     : undefined;


### PR DESCRIPTION
Closes #74859

AI-assisted. Thanks to @zhumengzhu for the deterministic original report.

## What Problem This Solves

Fixes an issue where cancelling or timing out an agent turn immediately before its prompt starts could create an orphaned background agent loop. The visible turn had already ended, but the orphan could continue making model calls and accumulate unbounded cost.

## Why This Change Was Made

The embedded prompt owner now checks the existing run abort signal before evaluating the session prompt. Already-aborted turns are rejected through the existing tagged abortable helper, preserving canonical abort classification, reason propagation, transcript ownership, terminal precedence, and normal prompt behavior. No provider, configuration, dependency, public API, or retry behavior changes.

## User Impact

Rapid interrupt-mode messages and run timeouts can no longer start a zombie model loop after their owning turn is already cancelled. Healthy agent turns, timeout classification, and normal follow-up replies remain unchanged.

## Evidence

- Red-before-fix on fresh main 32a390f4e4512a60543699f802772b7c3f34b240: the new external-cancellation and run-timeout regressions both failed because activeSession.prompt was invoked after abort; the original two tests passed.
- Green-after-fix on the same isolated Linux Testbox tbx_01kykny6bye89tdvhpdpgc4hm4: 55 tests passed across the prompt boundary, abortable helper, external abort, prompt submission, execution cleanup, and canonical agent-run terminal outcome.
- Real product proof: isolated Gateway, mock OpenAI-compatible provider, Crabline Telegram transport, and native stop/recovery scenario all passed. The scenario starts an actual delayed agent turn, aborts it with /stop, verifies the abort acknowledgement, and proves that the next user turn succeeds. QA evidence: .artifacts/qa-e2e/issue-74859-native-stop/qa-evidence.json.
- Full Linux changed gate passed on the same Testbox: core and test typechecks, targeted formatting, core lint, plugin/SDK boundaries, import cycles, storage guards, and dependency/config ratchets.
- Fresh independent Codex autoreview passed with no accepted or actionable findings; confidence 0.93. TruffleHog scan passed.
- Focused command: pnpm test src/agents/embedded-agent-runner/run/attempt-stream-runtime-prepare.test.ts src/agents/embedded-agent-runner/run/abortable.test.ts src/agents/embedded-agent-runner/run/attempt-abort.test.ts src/agents/embedded-agent-runner/run/attempt-prompt-submit.test.ts src/agents/embedded-agent-runner/run/attempt-execution-settle.test.ts src/agents/agent-run-terminal-outcome.test.ts.
- Real behavior command: pnpm openclaw qa suite --scenario native-command-session-target --provider-mode mock-openai --channel-driver crabline --channel telegram --output-dir .artifacts/qa-e2e/issue-74859-native-stop.
- Final gate: corepack pnpm check:changed.