### PR TITLE
fix(macos): localize privacy permission prompts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **macOS privacy prompts:** package translated permission descriptions for every shipped locale, including screen capture and location prompts, instead of falling back to English system dialogs.
 - **Codex native controls:** stop misclassifying valid thinking/fast runtime controls as provider overrides so Codex routes keep their native controls, while provider-native objects and invalid values stay fail-closed. Thanks @VACInc. (#107588)
 - **State snapshot verification:** run SQLite snapshot verification in a separate process so worker-thread file closes no longer drop the Gateway's POSIX WAL locks, eliminating spurious WAL misses and I/O errors. Thanks @VACInc. (#114016)
 - **Reply latency with model policies:** reuse one immutable plugin-metadata snapshot per model-selection run instead of repeating plugin discovery, cutting reply delay when a model policy is configured. Thanks @VACInc. (#114117)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,7 +51,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- **macOS privacy prompts:** package translated permission descriptions for every shipped locale, including screen capture and location prompts, instead of falling back to English system dialogs.
 - **Codex native controls:** stop misclassifying valid thinking/fast runtime controls as provider overrides so Codex routes keep their native controls, while provider-native objects and invalid values stay fail-closed. Thanks @VACInc. (#107588)
 - **State snapshot verification:** run SQLite snapshot verification in a separate process so worker-thread file closes no longer drop the Gateway's POSIX WAL locks, eliminating spurious WAL misses and I/O errors. Thanks @VACInc. (#114016)
 - **Reply latency with model policies:** reuse one immutable plugin-metadata snapshot per model-selection run instead of repeating plugin discovery, cutting reply delay when a model policy is configured. Thanks @VACInc. (#114117)

--- a/scripts/apple-app-i18n.ts
+++ b/scripts/apple-app-i18n.ts
@@ -38,6 +38,7 @@ const INFLECTED_COUNT_SEGMENT_RE =
 const INFLECTED_COUNT_MARKER = "](inflect: true)";
 const IOS_CATALOG_PATH = "apps/ios/Resources/Localizable.xcstrings";
 const MACOS_CATALOG_PATH = "apps/macos/Sources/OpenClaw/Resources/Localizable.xcstrings";
+const MACOS_INFO_PLIST_PATH = "apps/macos/Sources/OpenClaw/Resources/Info.plist";
 const IOS_CONTRADICTIONS_PATH = "apps/.i18n/apple-translation-contradictions.json";
 const NATIVE_SOURCE_PATH = "apps/.i18n/native-source.json";
 const NATIVE_TRANSLATIONS_DIR = "apps/.i18n/native";
@@ -88,6 +89,7 @@ const IOS_INFO_PLIST_TARGETS = [
     sourcePath: "apps/ios/ActivityWidget/Info.plist",
   },
 ] as const;
+const INFO_PLIST_LOCALIZABLE_KEYS = new Set(["NSScreenCaptureDescription"]);
 const AMBIGUOUS_RUNTIME_INTERPOLATIONS = [
   {
     label: "interpolated localized resource",
@@ -493,7 +495,10 @@ function parseInfoPlistStrings(source: string): Array<{ key: string; source: str
       key: decodeXml(match[1] ?? ""),
       source: decodeXml(match[2] ?? ""),
     }))
-    .filter((entry) => entry.key.endsWith("UsageDescription"));
+    .filter(
+      (entry) =>
+        entry.key.endsWith("UsageDescription") || INFO_PLIST_LOCALIZABLE_KEYS.has(entry.key),
+    );
 }
 
 type InfoPlistTranslation = {
@@ -538,6 +543,36 @@ export function infoPlistTranslationCandidates(
       .filter((entry) => entry.id === sourceId && entry.source === source)
       .map((entry) => entry.translated) ?? []
   );
+}
+
+function infoPlistSourceIds(nativeSource: NativeSourceArtifact): Map<string, string> {
+  return new Map(
+    nativeSource.entries
+      .filter((entry) => entry.kind === "plist-string")
+      .map((entry) => [[entry.path, entry.source].join("\u0000"), entry.id]),
+  );
+}
+
+function renderInfoPlistStrings(
+  sourcePath: string,
+  sourceEntries: ReadonlyArray<{ key: string; source: string }>,
+  sourceIds: ReadonlyMap<string, string>,
+  artifact: NativeTranslationArtifact | undefined,
+  existing: ReadonlyMap<string, InfoPlistTranslation> = new Map(),
+): string {
+  const lines = sourceEntries.map(({ key, source }) => {
+    const sourceId = sourceIds.get([sourcePath, source].join("\u0000"));
+    if (!sourceId) {
+      throw new Error(`missing native InfoPlist source id for ${sourcePath}:${key}`);
+    }
+    const candidates = infoPlistTranslationCandidates(artifact, sourceId, source);
+    const value = selectInfoPlistTranslation(source, candidates, existing.get(key));
+    return [
+      `/* OpenClaw source: ${stringsLiteral(source)} */`,
+      `${stringsLiteral(key)} = ${stringsLiteral(value)};`,
+    ].join("\n");
+  });
+  return `${lines.join("\n")}\n`;
 }
 
 async function readOptionalFile(filePath: string): Promise<string | null> {
@@ -843,11 +878,7 @@ async function syncIosInfoPlist(write: boolean): Promise<number> {
   const nativeSource = JSON.parse(
     await readFile(path.join(ROOT, NATIVE_SOURCE_PATH), "utf8"),
   ) as NativeSourceArtifact;
-  const sourceIds = new Map(
-    nativeSource.entries
-      .filter((entry) => entry.kind === "plist-string")
-      .map((entry) => [[entry.path, entry.source].join("\u0000"), entry.id]),
-  );
+  const sourceIds = infoPlistSourceIds(nativeSource);
   let checked = 0;
   for (const target of IOS_INFO_PLIST_TARGETS) {
     const sourceEntries = parseInfoPlistStrings(
@@ -864,19 +895,13 @@ async function syncIosInfoPlist(write: boolean): Promise<number> {
       const existingSource = await readOptionalFile(outputPath);
       const existing = parseStringsFile(existingSource ?? "");
       const artifact = translations.find((candidate) => candidate.locale === locale);
-      const lines = sourceEntries.map(({ key, source }) => {
-        const sourceId = sourceIds.get([target.sourcePath, source].join("\u0000"));
-        if (!sourceId) {
-          throw new Error(`missing native InfoPlist source id for ${target.sourcePath}:${key}`);
-        }
-        const candidates = infoPlistTranslationCandidates(artifact, sourceId, source);
-        const value = selectInfoPlistTranslation(source, candidates, existing.get(key));
-        return [
-          `/* OpenClaw source: ${stringsLiteral(source)} */`,
-          `${stringsLiteral(key)} = ${stringsLiteral(value)};`,
-        ].join("\n");
-      });
-      const expected = `${lines.join("\n")}\n`;
+      const expected = renderInfoPlistStrings(
+        target.sourcePath,
+        sourceEntries,
+        sourceIds,
+        artifact,
+        existing,
+      );
       if (existingSource !== expected) {
         if (!write) {
           throw new Error(
@@ -1016,6 +1041,15 @@ export async function compileMacosLocalizations(outputDir: string) {
   if (!catalog.strings) {
     throw new Error(`invalid Apple string catalog: ${MACOS_CATALOG_PATH}`);
   }
+  const [nativeSource, translations, infoPlistSource] = await Promise.all([
+    readFile(path.join(ROOT, NATIVE_SOURCE_PATH), "utf8").then(
+      (source) => JSON.parse(source) as NativeSourceArtifact,
+    ),
+    readNativeTranslations(),
+    readFile(path.join(ROOT, MACOS_INFO_PLIST_PATH), "utf8"),
+  ]);
+  const sourceIds = infoPlistSourceIds(nativeSource);
+  const infoPlistEntries = parseInfoPlistStrings(infoPlistSource);
 
   for (const locale of REQUIRED_LOCALES) {
     const localeDir = APPLE_LOCALE_DIRECTORIES[locale] ?? locale;
@@ -1033,6 +1067,16 @@ export async function compileMacosLocalizations(outputDir: string) {
       });
     await mkdir(lprojDir, { recursive: true });
     await writeFile(path.join(lprojDir, "Localizable.strings"), `${lines.join("\n")}\n`, "utf8");
+    if (locale !== "en") {
+      const artifact = translations.find((candidate) => candidate.locale === locale);
+      const infoPlistStrings = renderInfoPlistStrings(
+        MACOS_INFO_PLIST_PATH,
+        infoPlistEntries,
+        sourceIds,
+        artifact,
+      );
+      await writeFile(path.join(lprojDir, "InfoPlist.strings"), infoPlistStrings, "utf8");
+    }
   }
 }
 

--- a/test/scripts/apple-app-i18n.test.ts
+++ b/test/scripts/apple-app-i18n.test.ts
@@ -605,12 +605,42 @@ describe("Apple app i18n catalogs", () => {
         "utf8",
       );
       expect(turkish).toContain('"General" = "Genel";');
+      const frenchInfoPlist = await readFile(
+        path.join(outputDir, "fr.lproj", "InfoPlist.strings"),
+        "utf8",
+      );
+      expect(frenchInfoPlist).toContain(
+        '"NSUserNotificationUsageDescription" = "OpenClaw a besoin de l’autorisation d’envoyer des notifications pour afficher des alertes concernant les actions de l’agent.";',
+      );
+      expect(frenchInfoPlist).toContain('"NSScreenCaptureDescription" = ');
+      expect(frenchInfoPlist).toContain('"NSLocationUsageDescription" = ');
+      expect(frenchInfoPlist).toContain('"NSLocationWhenInUseUsageDescription" = ');
+      expect(frenchInfoPlist).toContain('"NSLocationAlwaysAndWhenInUseUsageDescription" = ');
       await expect(
         readFile(path.join(outputDir, "zh-Hans.lproj", "Localizable.strings"), "utf8"),
       ).resolves.toContain('"Save" = ');
       await expect(
         readFile(path.join(outputDir, "ja.lproj", "Localizable.strings"), "utf8"),
       ).resolves.toContain('"Run now" = ');
+      for (const localeDir of ["ja", "zh-Hans", "zh-Hant"]) {
+        await expect(
+          readFile(path.join(outputDir, `${localeDir}.lproj`, "InfoPlist.strings"), "utf8"),
+        ).resolves.toContain('"NSCameraUsageDescription" = ');
+      }
+      const localizedDirectories = await readdir(outputDir, { withFileTypes: true });
+      const infoPlistFiles = await Promise.all(
+        localizedDirectories
+          .filter((entry) => entry.isDirectory() && entry.name.endsWith(".lproj"))
+          .map(async (entry) => {
+            try {
+              await readFile(path.join(outputDir, entry.name, "InfoPlist.strings"), "utf8");
+              return entry.name;
+            } catch {
+              return null;
+            }
+          }),
+      );
+      expect(infoPlistFiles.filter(Boolean)).toHaveLength(APPLE_I18N_LOCALES.length);
     } finally {
       await rm(outputDir, { force: true, recursive: true });
     }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where macOS users running OpenClaw in a non-English locale would still see English-only system permission prompts.

## Why This Change Was Made

The existing Apple localization compiler now emits package-time `InfoPlist.strings` beside each translated macOS catalog. It reuses the stable native translation IDs and the same translation selection path as iOS, including the legacy `NSScreenCaptureDescription` privacy key.

## User Impact

macOS privacy dialogs for notifications, screen capture, camera, location, local network, microphone, speech recognition, automation, and reminders can use all 21 shipped translations.

## Evidence

- `node scripts/run-vitest.mjs test/scripts/apple-app-i18n.test.ts` (16 tests passed)
- `node --import tsx scripts/apple-app-i18n.ts check`
- package-time compile produced 21 `InfoPlist.strings` files; every file passed `plutil -lint`
- `oxfmt --check` and `git diff --check`
- fresh autoreview: no accepted/actionable findings
