### PR TITLE
fix(matrix): render message history and collapse streamed edits

### DIFF
--- a/extensions/matrix/src/matrix/actions/messages.test.ts
+++ b/extensions/matrix/src/matrix/actions/messages.test.ts
@@ -60,6 +60,34 @@ function createPollStartEvent(params?: {
   };
 }
 
+function createHistoryMessage(params: {
+  eventId: string;
+  body: string;
+  timestamp: number;
+  sender?: string;
+  replaces?: string;
+  omitNewContent?: boolean;
+}): Record<string, unknown> {
+  return {
+    event_id: params.eventId,
+    sender: params.sender ?? "@alice:example.org",
+    type: "m.room.message",
+    origin_server_ts: params.timestamp,
+    content: {
+      msgtype: "m.text",
+      body: params.replaces ? `* ${params.body}` : params.body,
+      ...(params.replaces
+        ? {
+            "m.relates_to": { rel_type: "m.replace", event_id: params.replaces },
+            ...(params.omitNewContent
+              ? {}
+              : { "m.new_content": { msgtype: "m.text", body: params.body } }),
+          }
+        : {}),
+    },
+  };
+}
+
 function createMessagesClient(params: {
   chunk: Array<Record<string, unknown>>;
   hydratedChunk?: Array<Record<string, unknown>>;
@@ -285,6 +313,217 @@ describe("matrix message actions", () => {
     expectRecordFields(result.messages[0], { eventId: "$poll" });
     expect(result.messages[0]?.body).toContain("[Poll]");
     expect(getEvent).toHaveBeenCalledTimes(2);
+  });
+
+  it.each([
+    {
+      direction: "backward",
+      chunk: [
+        createHistoryMessage({
+          eventId: "$edit-new",
+          body: "final text",
+          timestamp: 30,
+          replaces: "$original",
+        }),
+        createHistoryMessage({
+          eventId: "$edit-old",
+          body: "intermediate text",
+          timestamp: 20,
+          replaces: "$original",
+        }),
+        createHistoryMessage({ eventId: "$original", body: "original text", timestamp: 10 }),
+      ],
+      after: undefined,
+    },
+    {
+      direction: "forward",
+      chunk: [
+        createHistoryMessage({ eventId: "$original", body: "original text", timestamp: 10 }),
+        createHistoryMessage({
+          eventId: "$edit-old",
+          body: "intermediate text",
+          timestamp: 20,
+          replaces: "$original",
+        }),
+        createHistoryMessage({
+          eventId: "$edit-new",
+          body: "final text",
+          timestamp: 30,
+          replaces: "$original",
+        }),
+      ],
+      after: "previous-page",
+    },
+  ])("collapses valid Matrix replacements in $direction history", async ({ chunk, after }) => {
+    const { client } = createMessagesClient({ chunk });
+
+    const result = await readMatrixMessages("room:!room:example.org", { client, after });
+
+    expect(result.messages).toEqual([
+      {
+        eventId: "$original",
+        sender: "@alice:example.org",
+        body: "final text",
+        msgtype: "m.text",
+        attachment: undefined,
+        timestamp: 10,
+        relatesTo: undefined,
+      },
+    ]);
+  });
+
+  it("uses the Matrix event-id tie-break for equally timed replacements", async () => {
+    const { client } = createMessagesClient({
+      chunk: [
+        createHistoryMessage({
+          eventId: "$edit-a",
+          body: "earlier tie",
+          timestamp: 20,
+          replaces: "$original",
+        }),
+        createHistoryMessage({
+          eventId: "$edit-z",
+          body: "winning tie",
+          timestamp: 20,
+          replaces: "$original",
+        }),
+        createHistoryMessage({ eventId: "$original", body: "original text", timestamp: 10 }),
+      ],
+    });
+
+    const result = await readMatrixMessages("room:!room:example.org", { client });
+
+    expect(result.messages).toHaveLength(1);
+    expect(result.messages[0]).toMatchObject({ eventId: "$original", body: "winning tie" });
+  });
+
+  it("does not let replacement content change the original event relationship", async () => {
+    const edit = createHistoryMessage({
+      eventId: "$edit",
+      body: "edited text",
+      timestamp: 20,
+      replaces: "$original",
+    });
+    const content = edit.content as Record<string, unknown>;
+    (content["m.new_content"] as Record<string, unknown>)["m.relates_to"] = {
+      rel_type: "m.thread",
+      event_id: "$forged-thread",
+    };
+    const { client } = createMessagesClient({
+      chunk: [
+        edit,
+        createHistoryMessage({ eventId: "$original", body: "original text", timestamp: 10 }),
+      ],
+    });
+
+    const result = await readMatrixMessages("room:!room:example.org", { client });
+
+    expect(result.messages).toHaveLength(1);
+    expect(result.messages[0]).toMatchObject({ eventId: "$original", body: "edited text" });
+    expect(result.messages[0]?.relatesTo).toBeUndefined();
+  });
+
+  it("ignores malformed and cross-sender Matrix replacements", async () => {
+    const { client } = createMessagesClient({
+      chunk: [
+        createHistoryMessage({
+          eventId: "$forged",
+          body: "forged text",
+          timestamp: 40,
+          replaces: "$original",
+          sender: "@mallory:example.org",
+        }),
+        createHistoryMessage({
+          eventId: "$malformed",
+          body: "malformed text",
+          timestamp: 30,
+          replaces: "$original",
+          omitNewContent: true,
+        }),
+        createHistoryMessage({ eventId: "$original", body: "original text", timestamp: 10 }),
+      ],
+    });
+
+    const result = await readMatrixMessages("room:!room:example.org", { client });
+
+    expect(result.messages).toHaveLength(1);
+    expect(result.messages[0]).toMatchObject({ eventId: "$original", body: "original text" });
+  });
+
+  it("preserves a valid edit when its original is on another history page", async () => {
+    const { client } = createMessagesClient({
+      chunk: [
+        createHistoryMessage({
+          eventId: "$edit",
+          body: "cross-page final text",
+          timestamp: 20,
+          replaces: "$original",
+        }),
+      ],
+    });
+
+    const result = await readMatrixMessages("room:!room:example.org", {
+      client,
+      after: "previous-page",
+    });
+
+    expect(result.messages).toHaveLength(1);
+    expect(result.messages[0]).toMatchObject({
+      eventId: "$edit",
+      body: "cross-page final text",
+      relatesTo: { relType: "m.replace", eventId: "$original" },
+    });
+  });
+
+  it("does not revive a redacted original through a replacement event", async () => {
+    const redactedOriginal = createHistoryMessage({
+      eventId: "$original",
+      body: "redacted original",
+      timestamp: 10,
+    });
+    redactedOriginal.unsigned = { redacted_because: {} };
+    const { client } = createMessagesClient({
+      chunk: [
+        createHistoryMessage({
+          eventId: "$edit",
+          body: "redacted edit",
+          timestamp: 20,
+          replaces: "$original",
+        }),
+        redactedOriginal,
+      ],
+    });
+
+    const result = await readMatrixMessages("room:!room:example.org", { client });
+
+    expect(result.messages).toEqual([]);
+  });
+
+  it("applies bundled Matrix replacements to first-page thread roots", async () => {
+    const threadRoot = createHistoryMessage({
+      eventId: "$thread-root",
+      body: "original root",
+      timestamp: 10,
+    });
+    threadRoot.unsigned = {
+      "m.relations": {
+        "m.replace": createHistoryMessage({
+          eventId: "$thread-edit",
+          body: "edited root",
+          timestamp: 20,
+          replaces: "$thread-root",
+        }),
+      },
+    };
+    const { client } = createMessagesClient({ chunk: [], pollRoot: threadRoot });
+
+    const result = await readMatrixMessages("room:!room:example.org", {
+      client,
+      threadId: "$thread-root",
+    });
+
+    expect(result.messages).toHaveLength(1);
+    expect(result.messages[0]).toMatchObject({ eventId: "$thread-root", body: "edited root" });
   });
 
   it("uses hydrated history events so encrypted poll entries can be read", async () => {

--- a/extensions/matrix/src/matrix/actions/messages.ts
+++ b/extensions/matrix/src/matrix/actions/messages.ts
@@ -15,6 +15,63 @@ import {
 
 const MATRIX_THREAD_RELATIONS_START_CURSOR_PREFIX = "openclaw.matrix.thread-relations-start:";
 
+function resolveMatrixReplacementTarget(event: MatrixRawEvent): string | undefined {
+  const relation = event.content["m.relates_to"];
+  if (!relation || typeof relation !== "object") {
+    return undefined;
+  }
+  const replacement = relation as { rel_type?: unknown; event_id?: unknown };
+  return replacement.rel_type === "m.replace" && typeof replacement.event_id === "string"
+    ? replacement.event_id
+    : undefined;
+}
+
+function resolveLatestMatrixReplacements(events: readonly MatrixRawEvent[]) {
+  const pageEventIds = new Set(events.map((event) => event.event_id));
+  const originals = new Map(
+    events
+      .filter(
+        (event) =>
+          event.type === EventType.RoomMessage &&
+          !event.unsigned?.redacted_because &&
+          event.state_key === undefined &&
+          !resolveMatrixReplacementTarget(event),
+      )
+      .map((event) => [event.event_id, event] as const),
+  );
+  const replacements = new Map<string, MatrixRawEvent>();
+
+  for (const event of events) {
+    const targetId = resolveMatrixReplacementTarget(event);
+    const original = targetId ? originals.get(targetId) : undefined;
+    const newContent = event.content["m.new_content"];
+    if (
+      !targetId ||
+      !original ||
+      event.sender !== original.sender ||
+      event.type !== original.type ||
+      event.state_key !== undefined ||
+      event.unsigned?.redacted_because ||
+      !newContent ||
+      typeof newContent !== "object" ||
+      Array.isArray(newContent)
+    ) {
+      continue;
+    }
+
+    const latest = replacements.get(targetId);
+    if (
+      !latest ||
+      event.origin_server_ts > latest.origin_server_ts ||
+      (event.origin_server_ts === latest.origin_server_ts && event.event_id > latest.event_id)
+    ) {
+      replacements.set(targetId, event);
+    }
+  }
+
+  return { pageEventIds, replacements };
+}
+
 export async function sendMatrixMessage(
   to: string,
   content: string | undefined,
@@ -134,6 +191,9 @@ export async function readMatrixMessages(
       resolvedRoom,
       relationPage ? (rootFillsThreadPage ? [] : relationPage.events) : (flatPage?.chunk ?? []),
     );
+    // Matrix edits are separate timeline events; apply only the newest valid,
+    // same-sender replacement so streaming updates cannot duplicate a message.
+    const { pageEventIds, replacements } = resolveLatestMatrixReplacements(hydratedChunk);
     const messages: MatrixMessageSummary[] = [];
     if (threadRootSummary) {
       messages.push(threadRootSummary);
@@ -149,7 +209,37 @@ export async function readMatrixMessages(
         if (threadId && event.event_id === threadId) {
           continue;
         }
-        messages.push(summarizeMatrixRawEvent(event));
+        const replacementTarget = resolveMatrixReplacementTarget(event);
+        if (replacementTarget) {
+          const newContent = event.content["m.new_content"];
+          if (
+            pageEventIds.has(replacementTarget) ||
+            !newContent ||
+            typeof newContent !== "object" ||
+            Array.isArray(newContent)
+          ) {
+            continue;
+          }
+          // Incremental pages can contain an edit without its original; keep
+          // the valid update instead of silently dropping the visible change.
+          messages.push(summarizeMatrixRawEvent(event));
+          continue;
+        }
+        const replacement = replacements.get(event.event_id);
+        const originalRelation = event.content["m.relates_to"];
+        messages.push(
+          summarizeMatrixRawEvent(
+            replacement
+              ? {
+                  ...event,
+                  content: {
+                    ...(replacement.content["m.new_content"] as Record<string, unknown>),
+                    "m.relates_to": originalRelation,
+                  },
+                }
+              : event,
+          ),
+        );
         continue;
       }
       if (!isPollEventType(event.type)) {

--- a/extensions/matrix/src/matrix/actions/summary.test.ts
+++ b/extensions/matrix/src/matrix/actions/summary.test.ts
@@ -98,4 +98,115 @@ describe("summarizeMatrixRawEvent", () => {
     expect(summary.body).toBe("hello");
     expect(summary.attachment).toBeUndefined();
   });
+
+  it("uses the authoritative new content when summarizing Matrix replacements", () => {
+    const summary = summarizeMatrixRawEvent({
+      event_id: "$edit",
+      sender: "@gum:matrix.example.org",
+      type: "m.room.message",
+      origin_server_ts: 456,
+      content: {
+        msgtype: "m.text",
+        body: "* fallback edit",
+        "m.new_content": { msgtype: "m.text", body: "authoritative edit" },
+        "m.relates_to": { rel_type: "m.replace", event_id: "$original" },
+      },
+    });
+
+    expect(summary).toEqual({
+      eventId: "$edit",
+      sender: "@gum:matrix.example.org",
+      body: "authoritative edit",
+      msgtype: "m.text",
+      attachment: undefined,
+      timestamp: 456,
+      relatesTo: { relType: "m.replace", eventId: "$original" },
+    });
+  });
+
+  it("applies the homeserver's bundled replacement to an original event", () => {
+    const summary = summarizeMatrixRawEvent({
+      event_id: "$original",
+      sender: "@gum:matrix.example.org",
+      type: "m.room.message",
+      origin_server_ts: 123,
+      content: { msgtype: "m.text", body: "original text" },
+      unsigned: {
+        "m.relations": {
+          "m.replace": {
+            event_id: "$edit",
+            sender: "@gum:matrix.example.org",
+            type: "m.room.message",
+            origin_server_ts: 456,
+            content: {
+              msgtype: "m.text",
+              body: "* fallback edit",
+              "m.new_content": { msgtype: "m.text", body: "bundled final text" },
+              "m.relates_to": { rel_type: "m.replace", event_id: "$original" },
+            },
+          },
+        },
+      },
+    });
+
+    expect(summary).toMatchObject({
+      eventId: "$original",
+      sender: "@gum:matrix.example.org",
+      body: "bundled final text",
+      timestamp: 123,
+    });
+  });
+
+  it("does not apply another sender's bundled replacement", () => {
+    const summary = summarizeMatrixRawEvent({
+      event_id: "$original",
+      sender: "@gum:matrix.example.org",
+      type: "m.room.message",
+      origin_server_ts: 123,
+      content: { msgtype: "m.text", body: "original text" },
+      unsigned: {
+        "m.relations": {
+          "m.replace": {
+            event_id: "$forged",
+            sender: "@mallory:matrix.example.org",
+            type: "m.room.message",
+            origin_server_ts: 456,
+            content: {
+              "m.new_content": { msgtype: "m.text", body: "forged text" },
+              "m.relates_to": { rel_type: "m.replace", event_id: "$original" },
+            },
+          },
+        },
+      },
+    });
+
+    expect(summary.body).toBe("original text");
+  });
+
+  it("does not apply a redacted bundled replacement", () => {
+    const summary = summarizeMatrixRawEvent({
+      event_id: "$original",
+      sender: "@gum:matrix.example.org",
+      type: "m.room.message",
+      origin_server_ts: 123,
+      content: { msgtype: "m.text", body: "original text" },
+      unsigned: {
+        "m.relations": {
+          "m.replace": {
+            event_id: "$redacted-edit",
+            sender: "@gum:matrix.example.org",
+            type: "m.room.message",
+            origin_server_ts: 456,
+            unsigned: { redacted_because: {} },
+            content: {
+              "m.new_content": { msgtype: "m.text", body: "redacted text" },
+              "m.relates_to": { rel_type: "m.replace", event_id: "$original" },
+            },
+          },
+        },
+      },
+    });
+
+    expect(summary.body).toBe("original text");
+  });
 });

--- a/extensions/matrix/src/matrix/actions/summary.ts
+++ b/extensions/matrix/src/matrix/actions/summary.ts
@@ -11,9 +11,42 @@ import {
   type RoomPinnedEventsEventContent,
 } from "./types.js";
 
+function resolveBundledMatrixReplacementContent(
+  event: MatrixRawEvent,
+): RoomMessageEventContent | undefined {
+  const rawReplacement = event.unsigned?.["m.relations"]?.["m.replace"];
+  if (!rawReplacement || typeof rawReplacement !== "object" || event.state_key !== undefined) {
+    return undefined;
+  }
+  const replacement = rawReplacement as Partial<MatrixRawEvent>;
+  const content = replacement.content;
+  const relation = content?.["m.relates_to"];
+  const newContent = content?.["m.new_content"];
+  if (
+    replacement.sender !== event.sender ||
+    replacement.type !== event.type ||
+    replacement.state_key !== undefined ||
+    replacement.unsigned?.redacted_because ||
+    !relation ||
+    typeof relation !== "object" ||
+    (relation as { rel_type?: unknown }).rel_type !== "m.replace" ||
+    (relation as { event_id?: unknown }).event_id !== event.event_id ||
+    !newContent ||
+    typeof newContent !== "object" ||
+    Array.isArray(newContent)
+  ) {
+    return undefined;
+  }
+  return newContent as RoomMessageEventContent;
+}
+
 export function summarizeMatrixRawEvent(event: MatrixRawEvent): MatrixMessageSummary {
   const content = event.content as RoomMessageEventContent;
   const relates = content["m.relates_to"];
+  const displayContent =
+    relates?.rel_type === "m.replace"
+      ? (content["m.new_content"] ?? content)
+      : (resolveBundledMatrixReplacementContent(event) ?? content);
   let relType: string | undefined;
   let eventId: string | undefined;
   if (relates) {
@@ -35,15 +68,15 @@ export function summarizeMatrixRawEvent(event: MatrixRawEvent): MatrixMessageSum
     eventId: event.event_id,
     sender: event.sender,
     body: resolveMatrixMessageBody({
-      body: content.body,
-      filename: content.filename,
-      msgtype: content.msgtype,
+      body: displayContent.body,
+      filename: displayContent.filename,
+      msgtype: displayContent.msgtype,
     }),
-    msgtype: content.msgtype,
+    msgtype: displayContent.msgtype,
     attachment: resolveMatrixMessageAttachment({
-      body: content.body,
-      filename: content.filename,
-      msgtype: content.msgtype,
+      body: displayContent.body,
+      filename: displayContent.filename,
+      msgtype: displayContent.msgtype,
     }),
     timestamp: event.origin_server_ts,
     relatesTo,

--- a/extensions/matrix/src/tool-actions.test.ts
+++ b/extensions/matrix/src/tool-actions.test.ts
@@ -399,7 +399,45 @@ describe("handleMatrixAction pollVote", () => {
       ok: true,
       roomId: "!room:example",
       threadId: "$thread",
-      messages: [{ eventId: "$message" }],
+      messages: [{ eventId: "$message", id: "$message" }],
+      nextBatch: "next",
+    });
+  });
+
+  it("projects Matrix message summaries for human-readable CLI output", async () => {
+    mocks.readMatrixMessages.mockResolvedValueOnce({
+      messages: [
+        {
+          eventId: "$message",
+          sender: "@alice:example.org",
+          body: "hello from Matrix",
+          msgtype: "m.text",
+          timestamp: 1_750_000_000_000,
+        },
+      ],
+      nextBatch: "next",
+    });
+
+    const result = await handleMatrixAction({ action: "readMessages", roomId: "!room:example" }, {
+      channels: { matrix: { actions: { messages: true } } },
+    } as CoreConfig);
+
+    expect(result.details).toEqual({
+      ok: true,
+      roomId: "!room:example",
+      messages: [
+        {
+          eventId: "$message",
+          sender: "@alice:example.org",
+          body: "hello from Matrix",
+          msgtype: "m.text",
+          timestamp: 1_750_000_000_000,
+          id: "$message",
+          authorTag: "@alice:example.org",
+          content: "hello from Matrix",
+          ts: "2025-06-15T15:06:40.000Z",
+        },
+      ],
       nextBatch: "next",
     });
   });
@@ -489,6 +527,35 @@ describe("handleMatrixAction pollVote", () => {
       cfg,
       accountId: "ops",
       client: mocks.matrixClient,
+    });
+  });
+
+  it("projects pinned Matrix events without removing their original event fields", async () => {
+    const event = {
+      eventId: "$pin",
+      sender: "@alice:example.org",
+      body: "pinned message",
+      timestamp: 1_750_000_000_000,
+    };
+    mocks.listMatrixPins.mockResolvedValueOnce({ pinned: ["$pin"], events: [event] });
+
+    const result = await handleMatrixAction({ action: "listPins", roomId: "!room:example" }, {
+      channels: { matrix: { actions: { pins: true } } },
+    } as CoreConfig);
+
+    expect(result.details).toEqual({
+      ok: true,
+      pinned: ["$pin"],
+      events: [event],
+      pins: [
+        {
+          ...event,
+          id: "$pin",
+          authorTag: "@alice:example.org",
+          content: "pinned message",
+          ts: "2025-06-15T15:06:40.000Z",
+        },
+      ],
     });
   });
 

--- a/extensions/matrix/src/tool-actions.ts
+++ b/extensions/matrix/src/tool-actions.ts
@@ -33,6 +33,7 @@ import {
   voteMatrixPoll,
   verifyMatrixRecoveryKey,
 } from "./matrix/actions.js";
+import type { MatrixMessageSummary } from "./matrix/actions/types.js";
 import { withAuthorizedMatrixReadTarget, type MatrixReadContext } from "./matrix/read-policy.js";
 import type { MatrixClient } from "./matrix/sdk.js";
 import { reactMatrixMessage } from "./matrix/send.js";
@@ -71,6 +72,20 @@ const verificationActions = new Set([
   "verificationBackupStatus",
   "verificationBackupRestore",
 ]);
+
+function projectMatrixMessagesForDisplay(messages: readonly MatrixMessageSummary[]) {
+  return messages.map((message) => ({
+    ...message,
+    ...(message.eventId ? { id: message.eventId } : {}),
+    ...(message.sender ? { authorTag: message.sender } : {}),
+    ...(message.body !== undefined ? { content: message.body } : {}),
+    ...(typeof message.timestamp === "number" &&
+    Number.isFinite(message.timestamp) &&
+    Math.abs(message.timestamp) <= 8_640_000_000_000_000
+      ? { ts: new Date(message.timestamp).toISOString() }
+      : {}),
+  }));
+}
 
 function readRoomId(params: Record<string, unknown>, required = true): string {
   const direct = readStringParam(params, "roomId") ?? readStringParam(params, "channelId");
@@ -320,6 +335,7 @@ export async function handleMatrixAction(
           });
           return {
             ...messages,
+            messages: projectMatrixMessagesForDisplay(messages.messages),
             roomId: target.roomId,
             ...(threadId ? { threadId } : {}),
           };
@@ -362,7 +378,12 @@ export async function handleMatrixAction(
         return jsonResult({ ok: true, pinned: result.pinned });
       }
       const result = await listMatrixPins(target.roomId, actionOpts);
-      return jsonResult({ ok: true, pinned: result.pinned, events: result.events });
+      return jsonResult({
+        ok: true,
+        pinned: result.pinned,
+        events: result.events,
+        pins: projectMatrixMessagesForDisplay(result.events),
+      });
     });
   }
 


### PR DESCRIPTION
Closes #101420
Related: #99057

## What Problem This Solves

Fixes an issue where Matrix users reading room history or pinned messages receive empty Time, Author, Text, and Id columns. Streamed Matrix replies also create multiple visible replacement events for one message.

## Why This Change Was Made

Keep Matrix-specific projection and Matrix replacement semantics inside the Matrix plugin. Preserve all original Matrix JSON fields; project display aliases only at the Matrix action boundary; apply the newest valid same-sender replacement; preserve cross-page edits, bundled homeserver edits, original relationships, thread roots, and redactions.

## User Impact

Matrix message history and pin tables now display their timestamp, sender, text, and event ID. Streamed replies display once with their final text. Existing JSON consumers retain the Matrix-native fields, and malformed, forged, or redacted replacement events cannot override visible history.

## Evidence

- Confirmed the original bug with seven focused failing Matrix regressions before the initial fix.
- Independently reproduced and fixed cross-page replacement, bundled edits, edited thread roots, redaction, and replacement-relationship regressions.
- Final full Matrix plugin lane: `pnpm test:extension matrix` (all 116 Matrix test files pass).
- Final formatting: `pnpm format:check` over all six changed Matrix files.
- Final changed-file gate: `pnpm check:changed -- <six changed Matrix files>`; includes extension and extension-test typechecks, lint, import cycles, max-lines ratchet, dependency pins, and plugin/SDK boundary guards.
- Remote proof: Blacksmith Testbox `tbx_01kykpmdhh20rjw15mp5pb1vwb`; workflow https://github.com/openclaw/openclaw/actions/runs/30332273105 is the earlier proof lease, final lease is independently recorded in validation output.
- Final independent `gpt-5.6-sol` autoreview: clean, no accepted or actionable findings.
- Matrix replacement contract checked against https://spec.matrix.org/latest/client-server-api/#event-replacements .

Thanks @wm0018 for the original report and #99057.