### PR TITLE
fix(android): respect locale in compact labels

### DIFF
--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -13435,7 +13435,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 223,
+      "line": 227,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatTurnRecap.kt",
       "source": "1 token",
       "surface": "android",
@@ -13443,7 +13443,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 225,
+      "line": 229,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatTurnRecap.kt",
       "source": "$count tokens",
       "surface": "android",
@@ -13451,7 +13451,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 235,
+      "line": 239,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatTurnRecap.kt",
       "source": "Done in $duration",
       "surface": "android",
@@ -13459,7 +13459,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 253,
+      "line": 271,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatTurnRecap.kt",
       "source": "${decimal(count / 1_000_000.0)}M",
       "surface": "android",
@@ -13467,7 +13467,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 260,
+      "line": 278,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatTurnRecap.kt",
       "source": "${thousands}k",
       "surface": "android",

--- a/apps/android/CHANGELOG.md
+++ b/apps/android/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+Uses the selected locale for Wear OS uppercase labels and compact token-count decimals.
+
 Fixes secondary Gateway sessions disconnecting during temporary discovery gaps and preserves manual TLS when reopening saved Gateways and Control UI pages.
 
 Prevents delayed Wear OS requests from a previous phone from blocking or corrupting the newly selected phone session.

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatTurnRecap.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatTurnRecap.kt
@@ -12,7 +12,10 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.unit.dp
+import java.math.RoundingMode
+import java.text.NumberFormat
 import java.util.Locale
 
 internal data class TurnRecap(
@@ -216,9 +219,10 @@ internal class TurnRecapResolver(
 @Composable
 internal fun ChatTurnRecapRow(recap: TurnRecap) {
   val duration = formatLocalizedChatDurationCompact(recap.runtimeMs.coerceAtLeast(1_000L))
+  val locale = LocalConfiguration.current.locales[0]
   val tokens =
     recap.outputTokens?.let { count ->
-      val format = turnRecapTokenFormat(count)
+      val format = turnRecapTokenFormat(count, locale)
       if (format.singular) {
         nativeStringResource("1 token")
       } else {
@@ -243,10 +247,24 @@ internal fun ChatTurnRecapRow(recap: TurnRecap) {
   }
 }
 
-internal fun turnRecapTokenFormat(count: Long): TurnRecapTokenFormat = TurnRecapTokenFormat(singular = count == 1L, count = formatCompactTokenCount(count))
+internal fun turnRecapTokenFormat(
+  count: Long,
+  locale: Locale = Locale.getDefault(),
+): TurnRecapTokenFormat = TurnRecapTokenFormat(singular = count == 1L, count = formatCompactTokenCount(count, locale))
 
-internal fun formatCompactTokenCount(count: Long): String {
-  fun decimal(value: Double): String = String.format(Locale.US, "%.1f", value).removeSuffix(".0")
+internal fun formatCompactTokenCount(
+  count: Long,
+  locale: Locale = Locale.getDefault(),
+): String {
+  val decimalFormat =
+    NumberFormat.getNumberInstance(locale).apply {
+      isGroupingUsed = false
+      minimumFractionDigits = 0
+      maximumFractionDigits = 1
+      roundingMode = RoundingMode.HALF_UP
+    }
+
+  fun decimal(value: Double): String = decimalFormat.format(value)
 
   fun millions(): String {
     val value = decimal(count / 1_000_000.0)
@@ -257,7 +275,7 @@ internal fun formatCompactTokenCount(count: Long): String {
     count >= 1_000_000L -> millions()
     count >= 1_000L -> {
       val thousands = decimal(count / 1_000.0)
-      if (thousands == "1000") millions() else nativeString("\${thousands}k", thousands)
+      if (count >= 999_950L) millions() else nativeString("\${thousands}k", thousands)
     }
     else -> count.toString()
   }

--- a/apps/android/app/src/test/java/ai/openclaw/app/ui/chat/ChatTurnRecapResolverTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/ui/chat/ChatTurnRecapResolverTest.kt
@@ -5,6 +5,7 @@ import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Test
+import java.util.Locale
 
 class ChatTurnRecapResolverTest {
   private val session = "agent:main:main"
@@ -292,8 +293,10 @@ class ChatTurnRecapResolverTest {
   fun formatsZeroOneAndCompactTokenCounts() {
     assertEquals(TurnRecapTokenFormat(singular = false, count = "0"), turnRecapTokenFormat(0L))
     assertEquals(TurnRecapTokenFormat(singular = true, count = "1"), turnRecapTokenFormat(1L))
-    assertEquals("1.2k", formatCompactTokenCount(1_234L))
-    assertEquals("1M", formatCompactTokenCount(999_999L))
+    assertEquals("1.2k", formatCompactTokenCount(1_234L, Locale.US))
+    assertEquals("1.3k", formatCompactTokenCount(1_250L, Locale.US))
+    assertEquals("1,2k", formatCompactTokenCount(1_234L, Locale.GERMANY))
+    assertEquals("١M", formatCompactTokenCount(999_999L, Locale.forLanguageTag("ar")))
   }
 
   private fun transcript(

--- a/apps/android/wear/src/main/java/ai/openclaw/wear/OpenClawTileService.kt
+++ b/apps/android/wear/src/main/java/ai/openclaw/wear/OpenClawTileService.kt
@@ -49,7 +49,14 @@ class OpenClawTileService :
                 protoLayoutResourceId = "openclaw_core_mascot",
               )
             },
-            labelContent = { text(getString(R.string.talk).uppercase().layoutString) },
+            labelContent = {
+              text(
+                wearUppercase(
+                  getString(R.string.talk),
+                  resources.configuration.locales[0],
+                ).layoutString,
+              )
+            },
             secondaryLabelContent = { text(getString(R.string.tile_phone_proxy).layoutString) },
           )
         },

--- a/apps/android/wear/src/main/java/ai/openclaw/wear/WearLocaleText.kt
+++ b/apps/android/wear/src/main/java/ai/openclaw/wear/WearLocaleText.kt
@@ -1,0 +1,13 @@
+package ai.openclaw.wear
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.platform.LocalConfiguration
+import java.util.Locale
+
+@Composable
+internal fun localizedWearUppercase(value: String): String = wearUppercase(value, LocalConfiguration.current.locales[0])
+
+internal fun wearUppercase(
+  value: String,
+  locale: Locale = Locale.getDefault(),
+): String = value.uppercase(locale)

--- a/apps/android/wear/src/main/java/ai/openclaw/wear/WearScreens.kt
+++ b/apps/android/wear/src/main/java/ai/openclaw/wear/WearScreens.kt
@@ -1082,11 +1082,13 @@ private fun RealtimeTalkBubble(entry: WearRealtimeTalkEntry) {
   ) {
     Text(
       text =
-        if (isUser) {
-          stringResource(R.string.you)
-        } else {
-          stringResource(R.string.agent)
-        }.uppercase(),
+        localizedWearUppercase(
+          if (isUser) {
+            stringResource(R.string.you)
+          } else {
+            stringResource(R.string.agent)
+          },
+        ),
       color = if (isUser) foreground.copy(alpha = 0.72f) else colors.textMuted,
       fontSize = 9.sp,
       fontWeight = FontWeight.Bold,
@@ -1102,7 +1104,7 @@ private fun RealtimeTalkBubble(entry: WearRealtimeTalkEntry) {
     )
     if (entry.streaming) {
       Text(
-        text = stringResource(R.string.live).uppercase(),
+        text = localizedWearUppercase(stringResource(R.string.live)),
         color = colors.warning,
         fontSize = 9.sp,
         fontWeight = FontWeight.Bold,
@@ -1292,7 +1294,7 @@ private fun OpenClawHeader(pageLabel: String) {
     horizontalAlignment = Alignment.CenterHorizontally,
   ) {
     Text(
-      text = stringResource(R.string.app_name).uppercase(),
+      text = localizedWearUppercase(stringResource(R.string.app_name)),
       color = colors.text,
       fontSize = 16.sp,
       fontWeight = FontWeight.Bold,
@@ -1301,7 +1303,7 @@ private fun OpenClawHeader(pageLabel: String) {
       maxLines = 1,
     )
     Text(
-      text = pageLabel.uppercase(),
+      text = localizedWearUppercase(pageLabel),
       color = colors.textMuted,
       fontSize = 10.sp,
       fontWeight = FontWeight.SemiBold,
@@ -1396,7 +1398,7 @@ private fun ContextPickerRow(
       horizontalAlignment = Alignment.CenterHorizontally,
     ) {
       Text(
-        text = label.uppercase(),
+        text = localizedWearUppercase(label),
         color = OpenClawWearTheme.colors.textMuted,
         fontSize = 8.sp,
         fontWeight = FontWeight.Bold,
@@ -1531,11 +1533,13 @@ private fun MessageBubble(message: WearChatMessage) {
   ) {
     Text(
       text =
-        when (message.chatRole) {
-          WearChatRole.USER -> stringResource(R.string.you)
-          WearChatRole.ASSISTANT -> stringResource(R.string.agent)
-          WearChatRole.SYSTEM -> stringResource(R.string.system)
-        }.uppercase(),
+        localizedWearUppercase(
+          when (message.chatRole) {
+            WearChatRole.USER -> stringResource(R.string.you)
+            WearChatRole.ASSISTANT -> stringResource(R.string.agent)
+            WearChatRole.SYSTEM -> stringResource(R.string.system)
+          },
+        ),
       color = if (isUser) foreground.copy(alpha = 0.72f) else colors.textMuted,
       fontSize = 9.sp,
       fontWeight = FontWeight.Bold,
@@ -1565,7 +1569,7 @@ private fun StreamingBubble(text: String) {
         .padding(horizontal = 12.dp, vertical = 9.dp),
   ) {
     Text(
-      text = stringResource(R.string.agent_working).uppercase(),
+      text = localizedWearUppercase(stringResource(R.string.agent_working)),
       color = colors.warning,
       fontSize = 9.sp,
       fontWeight = FontWeight.Bold,
@@ -1607,7 +1611,7 @@ private fun ConnectionPanel(snapshot: WearConversationSnapshot) {
       )
       Spacer(modifier = Modifier.size(7.dp))
       Text(
-        text = stringResource(R.string.connection).uppercase(),
+        text = localizedWearUppercase(stringResource(R.string.connection)),
         color = colors.textMuted,
         fontSize = 10.sp,
         fontWeight = FontWeight.Bold,
@@ -1638,7 +1642,7 @@ private fun ConnectionPanel(snapshot: WearConversationSnapshot) {
 private fun PhoneBoundaryPanel() {
   Panel {
     Text(
-      text = stringResource(R.string.security_boundary).uppercase(),
+      text = localizedWearUppercase(stringResource(R.string.security_boundary)),
       color = OpenClawWearTheme.colors.textMuted,
       fontSize = 10.sp,
       fontWeight = FontWeight.Bold,
@@ -1674,7 +1678,7 @@ private fun ThemeModeSelector(
         .padding(horizontal = 12.dp),
   ) {
     Text(
-      text = stringResource(R.string.appearance).uppercase(),
+      text = localizedWearUppercase(stringResource(R.string.appearance)),
       color = colors.textMuted,
       fontSize = 10.sp,
       fontWeight = FontWeight.SemiBold,

--- a/apps/android/wear/src/test/java/ai/openclaw/wear/WearLocaleTextTest.kt
+++ b/apps/android/wear/src/test/java/ai/openclaw/wear/WearLocaleTextTest.kt
@@ -1,0 +1,12 @@
+package ai.openclaw.wear
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import java.util.Locale
+
+class WearLocaleTextTest {
+  @Test
+  fun `uppercases labels with the active locale`() {
+    assertEquals("İLETİŞİM", wearUppercase("iletişim", Locale.forLanguageTag("tr")))
+  }
+}


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Android compact token counts always used a dot decimal and Wear OS uppercase labels used locale-invariant casing. This produced incorrect output for locales such as German, Arabic, and Turkish.

## Why This Change Was Made

Compact token formatting now uses the active app locale while preserving the previous half-up rounding and numeric million rollover. Wear OS routes visible uppercase labels through one locale-aware helper shared by Compose screens and the Tile service.

## User Impact

Android users see locale-correct decimal separators and digits in compact token counts. Wear OS labels use correct locale casing, including Turkish dotted capital I.

## Evidence

- `ChatTurnRecapResolverTest` passed (22 tests), including German decimal, Arabic digit, and half-up tie cases
- `WearLocaleTextTest` passed
- `:app:ktlintCheck` and `:wear:ktlintCheck` passed
- native app localization inventory verification passed with stable IDs preserved
- `git diff --check`
- fresh autoreview: no accepted/actionable findings
