### PR TITLE
fix(openai): honor per-turn timeout and retry controls

### DIFF
--- a/packages/ai/src/transports/openai-completions-transport.ts
+++ b/packages/ai/src/transports/openai-completions-transport.ts
@@ -334,7 +334,10 @@ export function createOpenAICompletionsTransportStreamFn(): StreamFn {
         firstEventAbort = createFirstStreamEventAbortController(options?.signal);
         const responseStream = (await client.chat.completions.create(
           params as never,
-          buildOpenAISdkRequestOptions(model, firstEventAbort.signal),
+          buildOpenAISdkRequestOptions(model, firstEventAbort.signal, {
+            timeoutMs: options?.timeoutMs,
+            maxRetries: options?.maxRetries,
+          }),
         )) as unknown as AsyncIterable<ChatCompletionChunk>;
         stream.push({ type: "start", partial: output as never });
         await processOpenAICompletionsStream(responseStream, output, model, stream, {

--- a/packages/ai/src/transports/openai-responses-client.ts
+++ b/packages/ai/src/transports/openai-responses-client.ts
@@ -190,11 +190,11 @@ function createResponsesTransportExecutor(config: ResponsesTransportExecutorOpti
         }
         const requestStartedAt = Date.now();
         firstEventAbort = createFirstStreamEventAbortController(options?.signal);
-        const requestOptions = buildOpenAISdkRequestOptions(
-          model,
-          firstEventAbort.signal,
-          config.streamRequest ? { stream: true } : undefined,
-        );
+        const requestOptions = buildOpenAISdkRequestOptions(model, firstEventAbort.signal, {
+          stream: config.streamRequest,
+          timeoutMs: options?.timeoutMs,
+          maxRetries: options?.maxRetries,
+        });
         emitModelTransportDebug(
           log,
           `[responses] start provider=${model.provider} api=${model.api} model=${model.id} ` +

--- a/packages/ai/src/transports/openai-transport-params.session-header.test.ts
+++ b/packages/ai/src/transports/openai-transport-params.session-header.test.ts
@@ -1,7 +1,10 @@
 import type { Context, Model } from "@openclaw/llm-core";
 import { describe, expect, it } from "vitest";
 import { OPENAI_PROMPT_CACHE_KEY_MAX_LENGTH } from "../providers/openai-prompt-cache.js";
-import { buildOpenAIClientHeaders } from "./openai-transport-params.js";
+import {
+  buildOpenAIClientHeaders,
+  buildOpenAISdkRequestOptions,
+} from "./openai-transport-params.js";
 
 const codexModel = {
   id: "gpt-5.6-luna",
@@ -33,5 +36,29 @@ describe("buildOpenAIClientHeaders session_id affinity header", () => {
   it("passes short session ids through unchanged", () => {
     const headers = buildOpenAIClientHeaders(codexModel, context, undefined, undefined, "abc-123");
     expect(headers.session_id).toBe("abc-123");
+  });
+});
+
+describe("buildOpenAISdkRequestOptions turn controls", () => {
+  const model = {
+    id: "gpt-5.6-luna",
+    provider: "openai",
+    api: "openai-responses",
+    baseUrl: "https://api.openai.com/v1",
+  } as Model;
+
+  it("forwards an explicit turn timeout and zero retries to the SDK", () => {
+    const signal = new AbortController().signal;
+
+    expect(
+      buildOpenAISdkRequestOptions(model, signal, {
+        timeoutMs: 1_234,
+        maxRetries: 0,
+      }),
+    ).toEqual({ signal, timeout: 1_234, maxRetries: 0 });
+  });
+
+  it("does not add a retry policy when the turn does not specify one", () => {
+    expect(buildOpenAISdkRequestOptions(model)).toBeUndefined();
   });
 });

--- a/packages/ai/src/transports/openai-transport-params.ts
+++ b/packages/ai/src/transports/openai-transport-params.ts
@@ -225,8 +225,8 @@ export function buildOpenAIClientHeaders(
   return resolvedHeaders;
 }
 
-function resolveOpenAISdkTimeoutMs(model: Model): number | undefined {
-  return resolveModelRequestTimeoutMs(model, undefined);
+function resolveOpenAISdkTimeoutMs(model: Model, timeoutMs?: number): number | undefined {
+  return resolveModelRequestTimeoutMs(model, timeoutMs);
 }
 
 export function buildOpenAISdkClientOptions(model: Model): { timeout?: number } {
@@ -237,20 +237,28 @@ export function buildOpenAISdkClientOptions(model: Model): { timeout?: number } 
 export function buildOpenAISdkRequestOptions(
   model: Model,
   signal?: AbortSignal,
-  options?: { stream?: boolean },
-): { signal?: AbortSignal; timeout?: number; headers?: Record<string, string> } | undefined {
-  const timeout = resolveOpenAISdkTimeoutMs(model);
+  options?: { stream?: boolean; timeoutMs?: number; maxRetries?: number },
+):
+  | {
+      signal?: AbortSignal;
+      timeout?: number;
+      maxRetries?: number;
+      headers?: Record<string, string>;
+    }
+  | undefined {
+  const timeout = resolveOpenAISdkTimeoutMs(model, options?.timeoutMs);
   const headers =
     options?.stream === true && usesNativeOpenAICodexResponsesBackend(model)
       ? { Accept: "text/event-stream" }
       : undefined;
-  if (timeout === undefined && !signal && !headers) {
+  if (timeout === undefined && options?.maxRetries === undefined && !signal && !headers) {
     return undefined;
   }
   return {
     ...(headers ? { headers } : {}),
     ...(signal ? { signal } : {}),
     ...(timeout !== undefined ? { timeout } : {}),
+    ...(options?.maxRetries !== undefined ? { maxRetries: options.maxRetries } : {}),
   };
 }
 

--- a/src/agents/openai-transport-stream.streaming.test.ts
+++ b/src/agents/openai-transport-stream.streaming.test.ts
@@ -1,5 +1,9 @@
 import { createServer } from "node:http";
-import { createOpenAICompletionsTransportStreamFn } from "@openclaw/ai/transports";
+import {
+  createAzureOpenAIResponsesTransportStreamFn,
+  createOpenAICompletionsTransportStreamFn,
+  createOpenAIResponsesTransportStreamFn,
+} from "@openclaw/ai/transports";
 import type { Model } from "openclaw/plugin-sdk/llm";
 import { describe, expect, it, vi } from "vitest";
 import {
@@ -79,6 +83,85 @@ describe("openai transport stream", () => {
         undefined,
       ),
     ).toBeUndefined();
+  });
+
+  it.each([
+    {
+      api: "openai-responses" as const,
+      provider: "openai",
+      createStream: createOpenAIResponsesTransportStreamFn,
+    },
+    {
+      api: "azure-openai-responses" as const,
+      provider: "azure-openai",
+      createStream: createAzureOpenAIResponsesTransportStreamFn,
+    },
+    {
+      api: "openai-completions" as const,
+      provider: "openai",
+      createStream: createOpenAICompletionsTransportStreamFn,
+    },
+  ])("honors turn timeout and zero retries over real $api HTTP", async (transport) => {
+    const capturedTimeouts: Array<string | undefined> = [];
+    const server = createServer((request, response) => {
+      const timeout = request.headers["x-stainless-timeout"];
+      capturedTimeouts.push(Array.isArray(timeout) ? timeout[0] : timeout);
+      request.resume();
+      request.on("end", () => {
+        response.writeHead(500, { "content-type": "application/json" });
+        response.end(
+          JSON.stringify({
+            error: { type: "server_error", message: "turn retry regression" },
+          }),
+        );
+      });
+    });
+
+    await new Promise<void>((resolve) => {
+      server.listen(0, "127.0.0.1", resolve);
+    });
+    try {
+      const address = server.address();
+      if (!address || typeof address === "string") {
+        throw new Error("Missing loopback server address");
+      }
+
+      const model = {
+        id: "gpt-5.6-luna",
+        name: "GPT-5.6 Luna",
+        api: transport.api,
+        provider: transport.provider,
+        baseUrl: `http://127.0.0.1:${address.port}/v1`,
+        reasoning: false,
+        input: ["text"],
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 128_000,
+        maxTokens: 4_096,
+        requestTimeoutMs: 900_000,
+      } satisfies Model & { requestTimeoutMs: number };
+
+      const stream = await transport.createStream()(
+        model,
+        {
+          messages: [{ role: "user", content: "Reply OK", timestamp: Date.now() }],
+          tools: [],
+        },
+        { apiKey: "test-key", timeoutMs: 1_234, maxRetries: 0 },
+      );
+
+      const eventTypes: string[] = [];
+      for await (const event of stream) {
+        eventTypes.push(event.type);
+      }
+
+      expect(eventTypes).toContain("error");
+      // The SDK advertises request timeouts in whole seconds on the wire.
+      expect(capturedTimeouts).toEqual(["1"]);
+    } finally {
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()));
+      });
+    }
   });
 
   it("streams OpenAI-compatible loopback requests with the configured SDK timeout", async () => {


### PR DESCRIPTION
Closes #114203
Related: #114204

## What Problem This Solves

Fixes an issue where users selecting an explicit per-turn request timeout or zero SDK retries would still receive the model-level 900-second timeout and the OpenAI SDK default retries across OpenAI Responses, Azure OpenAI Responses, and OpenAI-compatible Chat Completions.

Thanks to @kevin2966n for reporting #114203 and identifying the shared transport fix in #114204. This is the narrow, current-main replacement for the timeout/retry portion only. It deliberately does not close, supersede, or modify #114204, #114200, #114201, or #114202.

## Why This Change Was Made

Carry the existing timeoutMs and maxRetries turn controls into the existing OpenAI SDK request-options owner, then pass them from the shared Responses/Azure executor and Chat Completions transport. Preserve the model-level timeout fallback, streaming request headers, and the SDK default retry policy when a turn does not set maxRetries. No new configuration, provider API, plugin SDK contract, dependency, or Codex behavior.

## User Impact

An explicitly selected request timeout takes precedence for all three OpenAI-compatible transports, and maxRetries: 0 makes exactly one request even when the provider returns a retryable HTTP 500.

## Evidence

- Real before/after SDK HTTP proof on Linux Blacksmith Testbox tbx_01kykmdgpzqdch3bfm3dgava4r: before, all three transport families made three requests and sent x-stainless-timeout: 900; after, each made one request and sent x-stainless-timeout: 1, the official OpenAI SDK whole-second encoding of a 1,234 ms timeout.
- Exact shared request-options regression proves timeout: 1234 and maxRetries: 0, and a separate case preserves the SDK default when maxRetries is not set.
- pnpm check:changed: passed all formatting, core and core-test typechecking, lint, dependency, plugin-boundary, schema, and security-related repository guards.
- pnpm test packages/ai/src/transports/openai-transport-params.session-header.test.ts src/agents/openai-transport-stream.streaming.test.ts: 51 passed, including all three real HTTP transport cases.
- Fresh rebased-head Codex autoreview: no accepted or actionable findings; TruffleHog clean.
- Exact upstream SDK dependency contract verified against openai/openai-node v6.48.0.
