### PR TITLE
fix(slack): bound stalled read-only Web API calls

### DIFF
--- a/docs/channels/slack.md
+++ b/docs/channels/slack.md
@@ -1789,6 +1789,7 @@ Same-chat `/approve` also works in Slack channels and DMs that already support c
 - Channel topic/purpose metadata is treated as untrusted context and can be injected into routing context.
 - Agent View `app_context` entities are validated in Slack relevance order and exposed only as structured untrusted context; an omitted context clears the turn rather than reusing stale entities.
 - Thread starter and initial thread-history context seeding are filtered by configured sender allowlists when applicable.
+- Dedicated Web API reads used for probes, scope discovery, conversation classification, and delivery reconciliation have a 30-second deadline per request attempt. Transient failures can still retry, so the full operation may take longer. Shared Bolt and mutation-capable clients do not receive this default deadline because Slack may commit a mutation before a late response reaches OpenClaw.
 - Block actions, shortcuts, and modal interactions emit structured `Slack interaction: ...` system events with rich payload fields:
   - block actions: selected values, labels, picker values, and `workflow_*` metadata
   - global shortcuts: callback and actor metadata, routed to the actor's direct session

--- a/extensions/slack/src/channel-type.test.ts
+++ b/extensions/slack/src/channel-type.test.ts
@@ -12,6 +12,12 @@ const slackClientMocks = vi.hoisted(() => {
   return {
     conversationsInfo,
     conversationsOpen,
+    createSlackReadClient: vi.fn(() => ({
+      conversations: {
+        info: conversationsInfo,
+        open: conversationsOpen,
+      },
+    })),
     createSlackWebClient: vi.fn(() => ({
       conversations: {
         info: conversationsInfo,
@@ -23,10 +29,12 @@ const slackClientMocks = vi.hoisted(() => {
 const {
   conversationsInfo: conversationsInfoMock,
   conversationsOpen: conversationsOpenMock,
+  createSlackReadClient: createSlackReadClientMock,
   createSlackWebClient: createSlackWebClientMock,
 } = slackClientMocks;
 
 vi.mock("./client.js", () => ({
+  createSlackReadClient: slackClientMocks.createSlackReadClient,
   createSlackWebClient: slackClientMocks.createSlackWebClient,
 }));
 
@@ -34,6 +42,7 @@ describe("resolveSlackChannelType", () => {
   beforeEach(() => {
     conversationsInfoMock.mockReset();
     conversationsOpenMock.mockReset();
+    createSlackReadClientMock.mockClear();
     createSlackWebClientMock.mockClear();
     vi.stubEnv("SLACK_BOT_TOKEN", "");
     vi.stubEnv("SLACK_USER_TOKEN", "");
@@ -108,7 +117,8 @@ describe("resolveSlackChannelType", () => {
       type: "dm",
       user: "U09G2DJ0275",
     });
-    expect(createSlackWebClientMock).toHaveBeenCalledWith("xoxb-test");
+    expect(createSlackReadClientMock).toHaveBeenCalledWith("xoxb-test");
+    expect(createSlackWebClientMock).not.toHaveBeenCalled();
     expect(conversationsInfoMock).toHaveBeenCalledWith({ channel: "D0AEWSDHAQH" });
     expect(conversationsOpenMock).not.toHaveBeenCalled();
   });
@@ -140,6 +150,7 @@ describe("resolveSlackChannelType", () => {
       user: "U09G2DJ0275",
     });
     expect(createSlackWebClientMock).toHaveBeenCalledWith("botB");
+    expect(createSlackReadClientMock).not.toHaveBeenCalled();
     expect(conversationsOpenMock).toHaveBeenCalledWith({
       channel: "D0AEWSDHAQH",
       prevent_creation: true,
@@ -175,6 +186,7 @@ describe("resolveSlackChannelType", () => {
       user: "U09G2DJ0275",
     });
     expect(createSlackWebClientMock).toHaveBeenCalledWith("test-user-token");
+    expect(createSlackReadClientMock).not.toHaveBeenCalled();
     expect(conversationsOpenMock).toHaveBeenCalledWith({
       channel: "D0AEWSDHAQH",
       prevent_creation: true,
@@ -209,7 +221,8 @@ describe("resolveSlackChannelType", () => {
       type: "dm",
       user: "U09G2DJ0275",
     });
-    expect(createSlackWebClientMock).toHaveBeenCalledWith("envUsr");
+    expect(createSlackReadClientMock).toHaveBeenCalledWith("envUsr");
+    expect(createSlackWebClientMock).not.toHaveBeenCalled();
     expect(conversationsInfoMock).toHaveBeenCalledWith({ channel: "D0AEWSDHAQH" });
     expect(conversationsOpenMock).not.toHaveBeenCalled();
   });
@@ -241,6 +254,7 @@ describe("resolveSlackChannelType", () => {
       user: "U09G2DJ0275",
     });
     expect(createSlackWebClientMock).toHaveBeenCalledWith("envBot");
+    expect(createSlackReadClientMock).not.toHaveBeenCalled();
     expect(conversationsOpenMock).toHaveBeenCalledWith({
       channel: "D0AEWSDHAQH",
       prevent_creation: true,
@@ -275,7 +289,8 @@ describe("resolveSlackChannelType", () => {
       type: "group",
       name: "mpdm-alice--bob-1",
     });
-    expect(createSlackWebClientMock).toHaveBeenCalledWith("xoxp-reader");
+    expect(createSlackReadClientMock).toHaveBeenCalledWith("xoxp-reader");
+    expect(createSlackWebClientMock).not.toHaveBeenCalled();
     expect(conversationsInfoMock).toHaveBeenCalledWith({ channel: "C0MPIM" });
   });
 
@@ -319,8 +334,8 @@ describe("resolveSlackChannelType", () => {
       }),
     ).resolves.toMatchObject({ name: "after-rotation" });
 
-    expect(createSlackWebClientMock).toHaveBeenNthCalledWith(1, "xoxb-before");
-    expect(createSlackWebClientMock).toHaveBeenNthCalledWith(2, "xoxb-after");
+    expect(createSlackReadClientMock).toHaveBeenNthCalledWith(1, "xoxb-before");
+    expect(createSlackReadClientMock).toHaveBeenNthCalledWith(2, "xoxb-after");
     expect(conversationsInfoMock).toHaveBeenCalledTimes(2);
   });
 

--- a/extensions/slack/src/channel-type.ts
+++ b/extensions/slack/src/channel-type.ts
@@ -6,7 +6,7 @@ import {
   normalizeOptionalString,
 } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { resolveSlackAccount, resolveSlackOperationToken } from "./accounts.js";
-import { createSlackWebClient } from "./client.js";
+import { createSlackReadClient, createSlackWebClient } from "./client.js";
 import { normalizeAllowListLower } from "./monitor/allow-list.js";
 import type { OpenClawConfig } from "./runtime-api.js";
 
@@ -98,10 +98,10 @@ export async function resolveSlackConversationInfo(params: {
   const configuredInfo = resolveConfiguredSlackConversationInfo({ account, channelId });
   if (token) {
     try {
-      const client = createSlackWebClient(token);
       // Read-only classification stays on conversations.info. conversations.open is
       // write-scoped and must only run when the caller explicitly requests a write.
       if (isNativeImChannel && operation === "write") {
+        const client = createSlackWebClient(token);
         const opened = await client.conversations.open({
           channel: channelId,
           prevent_creation: true,
@@ -117,6 +117,7 @@ export async function resolveSlackConversationInfo(params: {
         }
         return result;
       }
+      const client = createSlackReadClient(token);
       const info = await client.conversations.info({ channel: channelId });
       const channel = info.channel as
         | { is_im?: boolean; is_mpim?: boolean; name?: string; user?: string }

--- a/extensions/slack/src/client-options.ts
+++ b/extensions/slack/src/client-options.ts
@@ -32,7 +32,7 @@ export const SLACK_WRITE_RETRY_OPTIONS: RetryOptions = {
   retries: 0,
 };
 
-const SLACK_LOOKUP_TIMEOUT_MS = 30_000;
+const SLACK_READ_TIMEOUT_MS = 30_000;
 
 const SLACK_LOOKUP_RETRY_OPTIONS: RetryOptions = {
   retries: 0,
@@ -95,6 +95,17 @@ export function resolveSlackWebClientOptions(
   return resolved;
 }
 
+export function resolveSlackReadClientOptions(
+  options: WebClientOptions = {},
+  dispatcher = resolveSlackProxyDispatcher(),
+): WebClientOptions {
+  // The Slack SDK applies timeout per retry attempt. Keep its established read retry
+  // policy, while ensuring any one stalled request eventually releases the caller.
+  const resolved = resolveSlackWebClientOptions(options, dispatcher);
+  resolved.timeout ??= SLACK_READ_TIMEOUT_MS;
+  return resolved;
+}
+
 export function resolveSlackWriteClientOptions(
   options: WebClientOptions = {},
   dispatcher = resolveSlackProxyDispatcher(),
@@ -115,6 +126,6 @@ export function resolveSlackLookupClientOptions(
   // outside the Axios request timeout.
   resolved.rejectRateLimitedCalls = true;
   resolved.retryConfig = SLACK_LOOKUP_RETRY_OPTIONS;
-  resolved.timeout ??= SLACK_LOOKUP_TIMEOUT_MS;
+  resolved.timeout ??= SLACK_READ_TIMEOUT_MS;
   return resolved;
 }

--- a/extensions/slack/src/client.test.ts
+++ b/extensions/slack/src/client.test.ts
@@ -18,6 +18,7 @@ vi.mock("@slack/web-api", () => {
 });
 
 let createSlackWebClient: typeof import("./client.js").createSlackWebClient;
+let createSlackReadClient: typeof import("./client.js").createSlackReadClient;
 let createSlackStartupAuthClient: typeof import("./client.js").createSlackStartupAuthClient;
 let createSlackLookupClient: typeof import("./client.js").createSlackLookupClient;
 let createSlackWriteClient: typeof import("./client.js").createSlackWriteClient;
@@ -99,6 +100,7 @@ beforeAll(async () => {
   ({ resolveSlackProxyDispatcher } = await import("./client-options.js"));
   ({
     createSlackWebClient,
+    createSlackReadClient,
     createSlackStartupAuthClient,
     createSlackLookupClient,
     createSlackWriteClient,
@@ -128,6 +130,35 @@ describe("slack web client config", () => {
     const options = resolveSlackWebClientOptions();
 
     expect(options.retryConfig).toEqual(SLACK_DEFAULT_RETRY_OPTIONS);
+    expect(options.timeout).toBeUndefined();
+  });
+
+  it("applies a 30-second deadline only to dedicated read clients", () => {
+    clearProxyEnvForTest();
+    try {
+      createSlackReadClient("xoxb-read");
+
+      expect(WebClient).toHaveBeenCalledWith("xoxb-read", {
+        retryConfig: SLACK_DEFAULT_RETRY_OPTIONS,
+        timeout: 30_000,
+      });
+    } finally {
+      restoreProxyEnvForTest();
+    }
+  });
+
+  it("preserves an explicit dedicated read deadline", () => {
+    clearProxyEnvForTest();
+    try {
+      createSlackReadClient("xoxb-read", { timeout: 60_000 });
+
+      expect(WebClient).toHaveBeenCalledWith("xoxb-read", {
+        retryConfig: SLACK_DEFAULT_RETRY_OPTIONS,
+        timeout: 60_000,
+      });
+    } finally {
+      restoreProxyEnvForTest();
+    }
   });
 
   it("respects explicit retry config overrides", () => {

--- a/extensions/slack/src/client.ts
+++ b/extensions/slack/src/client.ts
@@ -4,6 +4,7 @@ import { type WebClientOptions, WebClient } from "@slack/web-api";
 import type { SlackLookupClientOptions } from "./client-options.js";
 import {
   resolveSlackLookupClientOptions,
+  resolveSlackReadClientOptions,
   resolveSlackWebClientOptions,
   resolveSlackWriteClientOptions,
   SLACK_WRITE_RETRY_OPTIONS,
@@ -26,7 +27,13 @@ export {
 } from "./client-options.js";
 
 export function createSlackWebClient(token: string, options: WebClientOptions = {}) {
+  // Shared or mixed-operation clients stay timeout-free unless the caller opts in.
+  // Slack can commit a mutation before a late response, so a default deadline is unsafe here.
   return new WebClient(token, resolveSlackWebClientOptions(options));
+}
+
+export function createSlackReadClient(token: string, options: WebClientOptions = {}) {
+  return new WebClient(token, resolveSlackReadClientOptions(options));
 }
 
 export function createSlackStartupAuthClient(token: string, options: WebClientOptions = {}) {

--- a/extensions/slack/src/client.web-api.test.ts
+++ b/extensions/slack/src/client.web-api.test.ts
@@ -5,6 +5,7 @@ import { WebClient } from "@slack/web-api";
 import { afterEach, describe, expect, it } from "vitest";
 import {
   createSlackLookupClient,
+  createSlackReadClient,
   createSlackWebClient,
   getSlackListenerUploadCompletionClient,
 } from "./client.js";
@@ -321,6 +322,29 @@ describe("Slack Web API routing", () => {
 
       expect(result.ok).toBe(true);
       expect(requests).toHaveLength(1);
+    } finally {
+      await server.close();
+    }
+  });
+
+  it("bounds dedicated reads without timing out shared clients", async () => {
+    for (const key of TEST_ENV_KEYS) {
+      delete process.env[key];
+    }
+    const requests: SlackApiRequest[] = [];
+    const server = await startSlackApiServer(requests, 80);
+    try {
+      const options = {
+        retryConfig: { retries: 0 },
+        slackApiUrl: `${server.baseUrl}/api/`,
+      };
+      const readClient = createSlackReadClient("xoxb-read", { ...options, timeout: 20 });
+      const sharedClient = createSlackWebClient("xoxb-shared", options);
+
+      await expect(readClient.auth.test()).rejects.toThrow();
+      await expect(sharedClient.auth.test()).resolves.toMatchObject({ ok: true });
+
+      expect(requests).toHaveLength(2);
     } finally {
       await server.close();
     }

--- a/extensions/slack/src/delivery-trace.test.ts
+++ b/extensions/slack/src/delivery-trace.test.ts
@@ -131,6 +131,7 @@ vi.mock("./client.js", async (importOriginal) => {
   };
   return {
     ...actual,
+    createSlackReadClient: traceClient,
     createSlackWebClient: traceClient,
     createSlackWriteClient: traceClient,
     getSlackWriteClient: traceClient,

--- a/extensions/slack/src/probe.test.ts
+++ b/extensions/slack/src/probe.test.ts
@@ -3,18 +3,18 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { probeSlack } from "./probe.js";
 
 const authTestMock = vi.hoisted(() => vi.fn());
-const createSlackWebClientMock = vi.hoisted(() => vi.fn());
+const createSlackReadClientMock = vi.hoisted(() => vi.fn());
 
 vi.mock("./client.js", () => ({
-  createSlackWebClient: createSlackWebClientMock,
+  createSlackReadClient: createSlackReadClientMock,
 }));
 
 describe("probeSlack", () => {
   beforeEach(() => {
     authTestMock.mockReset();
-    createSlackWebClientMock.mockReset();
+    createSlackReadClientMock.mockReset();
 
-    createSlackWebClientMock.mockReturnValue({
+    createSlackReadClientMock.mockReturnValue({
       auth: {
         test: authTestMock,
       },
@@ -39,7 +39,7 @@ describe("probeSlack", () => {
       bot: { id: "U123", name: "openclaw-bot" },
       team: { id: "T123", name: "OpenClaw" },
     });
-    expect(createSlackWebClientMock).toHaveBeenCalledWith("xoxb-test");
+    expect(createSlackReadClientMock).toHaveBeenCalledWith("xoxb-test", { timeout: 2500 });
   });
 
   it("warns when auth.test looks like a user token in the bot token slot", async () => {

--- a/extensions/slack/src/probe.ts
+++ b/extensions/slack/src/probe.ts
@@ -1,7 +1,7 @@
 // Slack plugin module implements probe behavior.
 import type { BaseProbeResult } from "openclaw/plugin-sdk/channel-contract";
 import { runChannelProbe } from "openclaw/plugin-sdk/text-utility-runtime";
-import { createSlackWebClient } from "./client.js";
+import { createSlackReadClient } from "./client.js";
 import { formatSlackError } from "./errors.js";
 import { formatSlackBotTokenIdentityWarning } from "./token.js";
 
@@ -19,7 +19,7 @@ export async function probeSlack(
   timeoutMs = 2500,
   opts?: { accountId?: string | null; identity?: "bot" | "user" },
 ): Promise<SlackProbe> {
-  const client = createSlackWebClient(token);
+  const client = createSlackReadClient(token, { timeout: timeoutMs });
   return await runChannelProbe(
     timeoutMs,
     async () => {

--- a/extensions/slack/src/scopes.test.ts
+++ b/extensions/slack/src/scopes.test.ts
@@ -1,21 +1,21 @@
 // Slack tests cover scopes plugin behavior.
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const createSlackWebClientMock = vi.hoisted(() => vi.fn());
+const createSlackReadClientMock = vi.hoisted(() => vi.fn());
 
 vi.mock("./client.js", () => ({
-  createSlackWebClient: createSlackWebClientMock,
+  createSlackReadClient: createSlackReadClientMock,
 }));
 
 const { fetchSlackScopes } = await import("./scopes.js");
 
 function mockSlackClient(apiCall: ReturnType<typeof vi.fn>) {
-  createSlackWebClientMock.mockReturnValue({ apiCall });
+  createSlackReadClientMock.mockReturnValue({ apiCall });
 }
 
 describe("fetchSlackScopes", () => {
   beforeEach(() => {
-    createSlackWebClientMock.mockReset();
+    createSlackReadClientMock.mockReset();
   });
 
   it("uses auth.test response metadata scopes for modern bot tokens", async () => {
@@ -31,7 +31,7 @@ describe("fetchSlackScopes", () => {
       scopes: ["chat:write", "im:history"],
       source: "auth.test",
     });
-    expect(createSlackWebClientMock).toHaveBeenCalledWith("xoxb-token", { timeout: 1234 });
+    expect(createSlackReadClientMock).toHaveBeenCalledWith("xoxb-token", { timeout: 1234 });
     expect(apiCall).toHaveBeenCalledTimes(1);
     expect(apiCall).toHaveBeenCalledWith("auth.test");
   });

--- a/extensions/slack/src/scopes.ts
+++ b/extensions/slack/src/scopes.ts
@@ -6,7 +6,7 @@ import {
   normalizeOptionalString,
   sortUniqueStrings,
 } from "openclaw/plugin-sdk/string-coerce-runtime";
-import { createSlackWebClient } from "./client.js";
+import { createSlackReadClient } from "./client.js";
 import { formatSlackError } from "./errors.js";
 
 export type SlackScopesResult = {
@@ -96,7 +96,7 @@ export async function fetchSlackScopes(
   token: string,
   timeoutMs: number,
 ): Promise<SlackScopesResult> {
-  const client = createSlackWebClient(token, { timeout: timeoutMs });
+  const client = createSlackReadClient(token, { timeout: timeoutMs });
   const attempts: SlackScopesMethod[] = ["auth.test", "auth.scopes", "apps.permissions.info"];
   const errors: string[] = [];
 

--- a/extensions/slack/src/send.reconcile.test.ts
+++ b/extensions/slack/src/send.reconcile.test.ts
@@ -8,7 +8,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { reconcileSlackUnknownSend, sendMessageSlack } from "./send.js";
 
 const slackClientMocks = vi.hoisted(() => ({
-  createSlackWebClient: vi.fn(),
+  createSlackReadClient: vi.fn(),
   getSlackWriteClient: vi.fn(),
 }));
 
@@ -16,7 +16,7 @@ vi.mock("./client.js", async (importOriginal) => {
   const actual = await importOriginal<typeof import("./client.js")>();
   return {
     ...actual,
-    createSlackWebClient: slackClientMocks.createSlackWebClient,
+    createSlackReadClient: slackClientMocks.createSlackReadClient,
     getSlackWriteClient: slackClientMocks.getSlackWriteClient,
   };
 });
@@ -105,7 +105,7 @@ async function postWithDeliveryMetadata(params: {
 
 describe("reconcileSlackUnknownSend", () => {
   beforeEach(() => {
-    slackClientMocks.createSlackWebClient.mockReset();
+    slackClientMocks.createSlackReadClient.mockReset();
     slackClientMocks.getSlackWriteClient.mockReset();
   });
 
@@ -345,7 +345,7 @@ describe("reconcileSlackUnknownSend", () => {
       messages: [{ ts: "1782584647.000002", metadata }],
     });
     const writeClient = createSlackReconcileTestClient();
-    slackClientMocks.createSlackWebClient.mockReturnValue(readClient);
+    slackClientMocks.createSlackReadClient.mockReturnValue(readClient);
     slackClientMocks.getSlackWriteClient.mockReturnValue(writeClient);
     const tokenCfg = {
       channels: {
@@ -359,7 +359,7 @@ describe("reconcileSlackUnknownSend", () => {
     await expect(
       reconcileSlackUnknownSend(createUnknownSendContext({ cfg: tokenCfg })),
     ).resolves.toEqual(expect.objectContaining({ status: "sent" }));
-    expect(slackClientMocks.createSlackWebClient).toHaveBeenCalledWith("xoxp-read");
+    expect(slackClientMocks.createSlackReadClient).toHaveBeenCalledWith("xoxp-read");
     expect(slackClientMocks.getSlackWriteClient).toHaveBeenCalledWith("xoxb-write");
     expect(readClient.conversations.history).toHaveBeenCalledOnce();
     expect(writeClient.conversations.history).not.toHaveBeenCalled();
@@ -374,7 +374,7 @@ describe("reconcileSlackUnknownSend", () => {
     writeClient.conversations.history.mockResolvedValueOnce({
       messages: [{ ts: "1782584647.000002", metadata }],
     });
-    slackClientMocks.createSlackWebClient.mockReturnValue(readClient);
+    slackClientMocks.createSlackReadClient.mockReturnValue(readClient);
     slackClientMocks.getSlackWriteClient.mockReturnValue(writeClient);
     const tokenCfg = {
       channels: {
@@ -402,7 +402,7 @@ describe("reconcileSlackUnknownSend", () => {
     writeClient.conversations.history.mockResolvedValueOnce({
       messages: [{ ts: "1782584647.000002", metadata }],
     });
-    slackClientMocks.createSlackWebClient.mockReturnValue(readClient);
+    slackClientMocks.createSlackReadClient.mockReturnValue(readClient);
     slackClientMocks.getSlackWriteClient.mockReturnValue(writeClient);
     const tokenCfg = {
       channels: {

--- a/extensions/slack/src/send.ts
+++ b/extensions/slack/src/send.ts
@@ -39,7 +39,7 @@ import {
   uploadSlackFile,
   withSlackDnsRequestRetry,
 } from "./client-delivery.js";
-import { createSlackTokenCacheKey, createSlackWebClient, getSlackWriteClient } from "./client.js";
+import { createSlackReadClient, createSlackTokenCacheKey, getSlackWriteClient } from "./client.js";
 import { assertSlackDirectSendAllowed } from "./direct-send-admission.js";
 import { chunkSlackMrkdwnText, markdownToSlackMrkdwnChunks } from "./format.js";
 import { SLACK_TEXT_LIMIT } from "./limits.js";
@@ -886,7 +886,7 @@ export async function reconcileSlackUnknownSend(
       retryable: false,
     };
   }
-  const readClient = opts?.client ?? createSlackWebClient(readToken);
+  const readClient = opts?.client ?? createSlackReadClient(readToken);
   const writeClient = opts?.client ?? (writeToken ? getSlackWriteClient(writeToken) : undefined);
   const payloadReplyToId = ctx.payloads[0]?.replyToId;
   const effectiveReplyToId = Object.hasOwn(ctx, "effectiveReplyToId")


### PR DESCRIPTION
Supersedes #107195 while preserving @zw-xysk's contribution as co-author.

## What Problem This Solves

Fixes an issue where Slack status probes, scope discovery, conversation classification, and delivery reconciliation could wait indefinitely when a Slack Web API read stalled.

## Why This Change Was Made

Dedicated read-only clients now have a 30-second deadline per request attempt. Shared Bolt and mutation-capable clients remain timeout-free by default because Slack may commit a mutation before a late response reaches OpenClaw; explicit caller routing prevents the read policy from leaking onto `conversations.open`, assistant thread status, write, or upload paths.

This was rebuilt from current `main` after deep review of #107195 found that its generic factory also had new mutation callers. The implementation matches the exact pinned dependency contracts: `@slack/web-api` 8.0.0 applies `AbortSignal.timeout` per retry attempt, while `@slack/bolt` 5.0.0 forwards `clientOptions` into its shared and listener-scoped WebClients.

## User Impact

Stalled Slack reads now fail within a bounded request attempt instead of hanging forever. Transient failures may still retry, so a complete read operation can take longer than 30 seconds. Slack mutations keep their existing timeout behavior and are not newly exposed to ambiguous timeout failures.

## Evidence

- Focused Slack Vitest: 7 files, 89 tests passed.
- Blacksmith Testbox `tbx_01kykng7crmebmzryz27qnxw00`: extension/docs changed gate passed, including production and test typecheck, extension-wide lint, formatting, dependency pins, plugin boundaries, and import-cycle guards ([run](https://github.com/openclaw/openclaw/actions/runs/30333904784)).
- Controlled Slack-shaped endpoint: the dedicated read client rejected at 30.005 seconds while the shared client completed the same 31-second response at 31.021 seconds.
- Two fresh Codex autoreviews completed with no accepted/actionable findings; final confidence 0.94.
- Slack operational docs now describe the per-attempt deadline, retry behavior, and mutation exception.
