### PR TITLE
fix: full release validation avoids embedded-agent shard stalls

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2051,8 +2051,8 @@ jobs:
           OPENCLAW_NODE_TEST_INCLUDE_PATTERNS_JSON: ${{ toJson(matrix.includePatterns) }}
           OPENCLAW_NODE_TEST_TARGETS_JSON: ${{ toJson(matrix.targets) }}
           # Frozen targets can carry integration hooks whose cold setup exceeds
-          # the current defaults on shared release runners. Keep Vitest and its
-          # no-output watchdog above Vitest so it cannot preempt hook diagnostics.
+          # the current defaults on shared release runners. Keep the no-output
+          # watchdog above Vitest so it cannot preempt hook diagnostics.
           OPENCLAW_NODE_TEST_VITEST_ARGS_JSON: ${{ needs.preflight.outputs.compatibility_target == 'true' && '["--hookTimeout=600000"]' || '[]' }}
           OPENCLAW_VITEST_SHARD_NAME: ${{ matrix.shard_name }}
           OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS: ${{ needs.preflight.outputs.compatibility_target == 'true' && '660000' || '300000' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2051,10 +2051,11 @@ jobs:
           OPENCLAW_NODE_TEST_INCLUDE_PATTERNS_JSON: ${{ toJson(matrix.includePatterns) }}
           OPENCLAW_NODE_TEST_TARGETS_JSON: ${{ toJson(matrix.targets) }}
           # Frozen targets can carry integration hooks whose cold setup exceeds
-          # the current 120-second default on shared release runners.
-          OPENCLAW_NODE_TEST_VITEST_ARGS_JSON: ${{ needs.preflight.outputs.compatibility_target == 'true' && '["--hookTimeout=300000"]' || '[]' }}
+          # the current defaults on shared release runners. Keep Vitest and its
+          # no-output watchdog above Vitest so it cannot preempt hook diagnostics.
+          OPENCLAW_NODE_TEST_VITEST_ARGS_JSON: ${{ needs.preflight.outputs.compatibility_target == 'true' && '["--hookTimeout=600000"]' || '[]' }}
           OPENCLAW_VITEST_SHARD_NAME: ${{ matrix.shard_name }}
-          OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS: "300000"
+          OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS: ${{ needs.preflight.outputs.compatibility_target == 'true' && '660000' || '300000' }}
           OPENCLAW_VITEST_NO_OUTPUT_RETRY: "1"
           OPENCLAW_NODE_TEST_PLAN_CONCURRENCY: ${{ matrix.plan_concurrency }}
         shell: bash

--- a/scripts/lib/ci-node-test-plan.mjs
+++ b/scripts/lib/ci-node-test-plan.mjs
@@ -31,9 +31,10 @@ const GATEWAY_STARTUP_HEALTH_RUNTIME_ENV = {
   OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS: "60000",
 };
 // The first embedded-agent file owns 157 serial tests and can stay quiet for
-// more than five minutes on a cold GitHub-hosted 4-vCPU fork runner.
+// more than five minutes on a cold GitHub-hosted fork runner. Keep the outer
+// watchdog above the scoped 600-second hook budget so it cannot preempt Vitest.
 const AGENTS_EMBEDDED_AGENT_ENV = {
-  OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS: "420000",
+  OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS: "660000",
 };
 const MAX_BUNDLED_NODE_TEST_PATTERNS = 64;
 // PR-only bundles trade a little serial work for fewer ephemeral runner registrations.

--- a/test/scripts/ci-node-test-plan.test.ts
+++ b/test/scripts/ci-node-test-plan.test.ts
@@ -304,7 +304,7 @@ describe("scripts/lib/ci-node-test-plan.mjs", () => {
     );
     expect(embeddedAgentJob?.groups).toHaveLength(1);
     expect(embeddedAgentJob?.groups[0]?.env).toEqual({
-      OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS: "420000",
+      OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS: "660000",
     });
     expect(
       compact

--- a/test/scripts/ci-node-test-plan.test.ts
+++ b/test/scripts/ci-node-test-plan.test.ts
@@ -1004,7 +1004,7 @@ describe("scripts/lib/ci-node-test-plan.mjs", () => {
       {
         checkName: "checks-node-agentic-agents-embedded",
         configs: ["test/vitest/vitest.agents-embedded-agent.config.ts"],
-        env: { OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS: "420000" },
+        env: { OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS: "660000" },
         requiresDist: false,
         runner: DEFAULT_NODE_TEST_RUNNER,
         shardName: "agentic-agents-embedded",

--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -4548,12 +4548,14 @@ printf '%s\n' "\${CURL_SUCCESS_IP:-203.0.113.7}"
       'shard.groups?.some((group) => group.shard_name.startsWith("core-tooling"))',
     );
     expect(nodeTestJob["timeout-minutes"]).toBe("${{ matrix.timeout_minutes || 60 }}");
-    expect(runStep.env.OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS).toBe("300000");
+    expect(runStep.env.OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS).toBe(
+      "${{ needs.preflight.outputs.compatibility_target == 'true' && '660000' || '300000' }}",
+    );
     expect(runStep.env.OPENCLAW_VITEST_NO_OUTPUT_RETRY).toBe("1");
     expect(runStep.env.OPENCLAW_NODE_TEST_ENV_JSON).toBe("${{ toJson(matrix.env) }}");
     expect(runStep.env.OPENCLAW_NODE_TEST_TARGETS_JSON).toBe("${{ toJson(matrix.targets) }}");
     expect(runStep.env.OPENCLAW_NODE_TEST_VITEST_ARGS_JSON).toBe(
-      "${{ needs.preflight.outputs.compatibility_target == 'true' && '[\"--hookTimeout=300000\"]' || '[]' }}",
+      "${{ needs.preflight.outputs.compatibility_target == 'true' && '[\"--hookTimeout=600000\"]' || '[]' }}",
     );
     expect(runStep.env.JOB_CONTEXT_JSON).toBe("${{ toJSON(job) }}");
     // Shard execution policy lives in the unit-tested wrapper script. Frozen

--- a/test/vitest-projects-config.test.ts
+++ b/test/vitest-projects-config.test.ts
@@ -123,6 +123,10 @@ describe("projects vitest config", () => {
     );
   });
 
+  it("keeps the embedded-agent cold-hook budget explicit", () => {
+    expect(requireTestConfig(createAgentsEmbeddedVitestConfig()).hookTimeout).toBe(600_000);
+  });
+
   it("honors explicit worker caps in CI vitest lanes", () => {
     expect(
       resolveSharedVitestWorkerConfig({

--- a/test/vitest/vitest.agents-embedded-agent.config.ts
+++ b/test/vitest/vitest.agents-embedded-agent.config.ts
@@ -7,6 +7,8 @@ export function createAgentsEmbeddedVitestConfig(env?: Record<string, string | u
     dir: "src/agents",
     env,
     fileParallelism: false,
+    // Cold shared harness imports exceed the generic limit on 2-vCPU hosted release runners.
+    hookTimeout: 600_000,
     name: "agents-embedded-agent",
   });
 }

--- a/test/vitest/vitest.scoped-config.ts
+++ b/test/vitest/vitest.scoped-config.ts
@@ -208,6 +208,7 @@ export function createScopedVitestConfig(
     isolate?: boolean;
     name?: string;
     fileParallelism?: boolean;
+    hookTimeout?: number;
     intersectIncludeFile?: boolean;
     pool?: "forks" | "threads";
     passWithNoTests?: boolean;
@@ -272,6 +273,7 @@ export function createScopedVitestConfig(
       ...(options?.fileParallelism === undefined
         ? {}
         : { fileParallelism: options.fileParallelism }),
+      ...(options?.hookTimeout === undefined ? {} : { hookTimeout: options.hookTimeout }),
       ...(scopedGroupOrder === undefined
         ? {}
         : {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Full Release Validation's GitHub-hosted CI child could spend ten minutes with no Vitest output in the embedded-agent shard, then fail after two watchdog terminations.

## Why This Change Was Made

The embedded-agent suite intentionally shares a non-isolated module graph, so its existing whole-config ordering is preserved. Its plan and scoped Vitest config declare the measured cold-run budgets. Frozen-target workflow dispatches now allow 600-second hooks with a 660-second outer watchdog, while ordinary targets keep the standard 300-second watchdog.

## User Impact

No product behavior changes. Full Release Validation can complete the cold embedded-agent suite on constrained GitHub-hosted runners without weakening watchdogs elsewhere.

## Evidence

- Reproduced in hosted release CI: https://github.com/openclaw/openclaw/actions/runs/30332926946/job/90191803761 and https://github.com/openclaw/openclaw/actions/runs/30334269843/job/90195822885.
- Both runs stalled for 300 seconds, retried, stalled another 300 seconds, and exited 143 without a test assertion failure.
- Hosted diagnostics measured multiple cold embedded-agent hooks above the generic 120-second limit.
- The first 600-second proof exposed a workflow-owned `--hookTimeout=300000` override; the final workflow aligns that frozen-target override and gives the outer watchdog 60 seconds of grace.
- Focused planner/config/workflow proof passed: 128 tests passed, 1 platform skip.
- The two measured overflow suites passed 67/67 in 323 seconds and 38/38 in 187 seconds.
- Targeted formatting and `git diff --check` passed.
- Autoreview passed with no accepted or actionable findings.
- Exact-head GitHub-hosted release-gate proof: https://github.com/openclaw/openclaw/actions/runs/30341472506/job/90217958857 — `checks-node-agentic-agents-embedded` passed in 16m41s on `e1c1257610f66241792de6487c5472dc3f5f7cc8`.
