### PR TITLE
fix(kimi): engage code mode for Kimi Code K3 under tools.codeMode auto

### DIFF
--- a/docs/tools/code-mode.md
+++ b/docs/tools/code-mode.md
@@ -305,6 +305,7 @@ Bundled provider catalogs currently flag these models as `"preferred"`:
 | anthropic | `claude-fable-5`, `claude-opus-5`, `claude-sonnet-5`, `claude-mythos-5`, `claude-opus-4-8`, `claude-haiku-4-5`                               |
 | deepseek  | `deepseek-v4-pro`, `deepseek-v4-flash`                                                                                                       |
 | google    | `gemini-3-flash-preview`, `gemini-3.1-pro-preview`, `gemini-3.1-flash-lite`, `gemini-3.5-flash`, `gemini-3.5-flash-lite`, `gemini-3.6-flash` |
+| kimi      | `k3`, `k3-256k`                                                                                                                              |
 | minimax   | `MiniMax-M3`                                                                                                                                 |
 | moonshot  | `kimi-k3`                                                                                                                                    |
 | openai    | `gpt-5.6`, `gpt-5.6-sol`, `gpt-5.6-terra`, `gpt-5.6-luna`, `gpt-5.5`, `gpt-5.5-pro`                                                          |

--- a/extensions/kimi-coding/provider-catalog.test.ts
+++ b/extensions/kimi-coding/provider-catalog.test.ts
@@ -31,6 +31,7 @@ describe("kimi provider catalog", () => {
       cost: { input: 3, output: 15, cacheRead: 0.3, cacheWrite: 0 },
       contextWindow: 1_048_576,
       maxTokens: 131_072,
+      compat: { codeMode: "preferred" },
     });
     expect(provider.models.find((model) => model.id === "k3-256k")).toMatchObject({
       name: "Kimi K3 (256k)",
@@ -47,6 +48,7 @@ describe("kimi provider catalog", () => {
       cost: { input: 3, output: 15, cacheRead: 0.3, cacheWrite: 0 },
       contextWindow: 262_144,
       maxTokens: 131_072,
+      compat: { codeMode: "preferred" },
     });
     expect(provider.models.find((model) => model.id === "kimi-for-coding-highspeed")).toMatchObject(
       {
@@ -56,6 +58,10 @@ describe("kimi provider catalog", () => {
         maxTokens: 32_768,
       },
     );
+    // K2.7 stays unflagged, matching the sibling `moonshot` catalog where only K3 is preferred.
+    for (const id of ["kimi-for-coding", "kimi-for-coding-highspeed"]) {
+      expect(provider.models.find((model) => model.id === id)?.compat?.codeMode).toBeUndefined();
+    }
   });
 
   it("normalizes legacy Kimi coding model ids to the stable API model id", () => {

--- a/extensions/kimi-coding/provider-catalog.ts
+++ b/extensions/kimi-coding/provider-catalog.ts
@@ -38,6 +38,12 @@ const KIMI_K3_THINKING_LEVEL_MAP = {
   max: "max",
 } satisfies NonNullable<ModelDefinitionConfig["thinkingLevelMap"]>;
 const KIMI_CODING_INPUT = ["text", "image"] satisfies NonNullable<ModelDefinitionConfig["input"]>;
+// K3 is the same model the `moonshot` provider ships as `kimi-k3`, which declares
+// `codeMode: "preferred"`. Without this the subscription surface silently drops out of
+// `tools.codeMode: "auto"` while the API surface engages it.
+const KIMI_K3_COMPAT = {
+  codeMode: "preferred",
+} satisfies NonNullable<ModelDefinitionConfig["compat"]>;
 
 export function buildKimiCodingProvider(): ModelProviderConfig {
   return {
@@ -70,6 +76,7 @@ export function buildKimiCodingProvider(): ModelProviderConfig {
         name: id === "k3" ? "Kimi K3" : "Kimi K3 (256k)",
         reasoning: true,
         thinkingLevelMap: { ...KIMI_K3_THINKING_LEVEL_MAP },
+        compat: { ...KIMI_K3_COMPAT },
         input: [...KIMI_CODING_INPUT],
         cost: KIMI_K3_COST,
         contextWindow: id === "k3" ? KIMI_K3_CONTEXT_WINDOW : KIMI_CODING_DEFAULT_CONTEXT_WINDOW,


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users running Kimi Code through the bundled `kimi` provider with `tools.codeMode: "auto"` never got code mode, while the exact same underlying model reached through the `moonshot` provider did.

`moonshot` declares `compat.codeMode: "preferred"` for `kimi-k3` (`extensions/moonshot/openclaw.plugin.json:91`), but the Kimi Code subscription catalog (`kimi/k3`, `kimi/k3-256k`) declared no compat at all. Since `"auto"` engages only for models whose catalog flags `codeMode: "preferred"` (`src/agents/code-mode-runtime.ts:194-206`), the subscription surface silently fell back to full direct tool exposure with no warning and no config error.

## Why This Change Was Made

K3 is one model with two provider front doors. The capability tier is a property of the model, so both catalogs must agree; otherwise `"auto"` becomes a coin flip that depends on which credential the operator happens to use. K2.7 (`kimi-for-coding`, `kimi-for-coding-highspeed`) stays unflagged, matching `moonshot`'s unflagged `kimi-k2.7-code`, so the asymmetry that remains is intentional and now asserted by a test.

## User Impact

Operators on a Kimi Code subscription who set `tools.codeMode: "auto"` now get code mode on `kimi/k3` and `kimi/k3-256k`, matching `moonshot/kimi-k3`. No behavior change for `tools.codeMode` unset (default off) or `true` (already engaged for every tool-capable model). No config migration needed.

This is an intentional compatibility change: an operator already running `kimi/k3` with `"auto"` moves from the direct tool surface to the code-mode bridge on upgrade. That is the point of the fix — it makes the subscription surface behave like the API surface for the same model — but it is a real behavior change for existing users, so it is called out explicitly here.

## Evidence

### After-fix runtime proof (this head, `46df671bdbe`)

Run on a real Kimi Code subscription key against `https://api.kimi.com/coding/v1`, embedded agent (`openclaw agent --local --model kimi/k3 --json`), isolated `OPENCLAW_STATE_DIR` per case, prompt requiring a genuinely unguessable tool result (`sysctl -n hw.model; sw_vers -productVersion`):

| `tools.codeMode` | `codeModeEngaged` | runtime evidence | answer correct |
| --- | --- | --- | --- |
| unset (default) | `false` | `assistantTurns: 2`, no `bridgeCalls`, direct tool surface | yes |
| `"auto"` (after this change) | `true` | `assistantTurns: 6`, `bridgeCalls: {search: 1, describe: 2, call: 1}` | yes |

Both cases returned the same correct machine-specific values, so the surface difference is real rather than the model guessing:

```
Mac16,6
27.0
```

The `"auto"` row is exactly what this PR flips, and the `unset` row in the same session confirms the intended compatibility boundary is unchanged.

### Pre-fix baseline (before this change)

| `tools.codeMode` | `codeModeEngaged` | runtime evidence |
| --- | --- | --- |
| unset (default) | `false` | `toolSummary: {calls: 1, tools: ["exec"], failures: 0}`, direct tool surface |
| `"auto"` (before this change) | `false` | falls through to direct `exec`; no `code-mode:` catalog line |
| `true` | `true` | log `code-mode: cataloged 50 tools behind exec/wait`; `bridgeCalls: {search: 0, describe: 0, call: 2}` |

`isCodeModeEngagedForModel` reads `compat.codeMode === "preferred"`, which `kimi/k3` did not carry before this change.

### Catalog and local checks

Live catalog check against `GET https://api.kimi.com/coding/v1/models` confirms the shipped ids are current: `kimi-for-coding`, `kimi-for-coding-highspeed`, `k3` (1,048,576 ctx), `k3-256k`.

Focused Vitest now passes locally on this head:

```
node scripts/run-vitest.mjs extensions/kimi-coding/provider-catalog.test.ts
Test Files  1 passed (1)
     Tests  2 passed (2)
```

`git diff --check` clean; `oxfmt --check` clean on both touched TypeScript files. Hosted CI green on this head (run `30336715493`); `Workflow Sanity` needed a rerun after an infrastructure fetch timeout and is green on attempt 2.

Autoreview (Codex `gpt-5.6-sol`, thinking `xhigh`): clean, no accepted or actionable findings.
