### PR TITLE
fix(i18n): refresh native source baseline

### DIFF
--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -25843,7 +25843,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 6404,
+      "line": 6407,
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "No chat messages yet",
       "surface": "apple",
@@ -25851,7 +25851,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 6466,
+      "line": 6469,
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "Connecting…",
       "surface": "apple",
@@ -25859,7 +25859,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 6466,
+      "line": 6469,
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "Reconnecting…",
       "surface": "apple",
@@ -25867,7 +25867,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 8813,
+      "line": 8816,
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "Approval",
       "surface": "apple",
@@ -25875,7 +25875,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 8813,
+      "line": 8816,
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "This approval was already",
       "surface": "apple",
@@ -25883,7 +25883,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 8819,
+      "line": 8822,
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "This approval was already set to Always Allow.",
       "surface": "apple",
@@ -25891,7 +25891,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 8820,
+      "line": 8823,
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "Approval set to Always Allow.",
       "surface": "apple",
@@ -25899,7 +25899,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 10155,
+      "line": 10193,
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "\\(urlText.prefix(500))…",
       "surface": "apple",


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where release validation and the Native App Locale Refresh workflow failed after native source line movements left the stable-ID inventory stale.

## Why This Change Was Made

Regenerates the canonical native source inventory from current `main`. The stable IDs and source strings are unchanged; only eight recorded source-line offsets move.

## User Impact

No direct user-visible change. Release validation and native locale automation can proceed from a current inventory.

## Evidence

- `node --import tsx scripts/native-app-i18n.ts baseline --write`
- `node --import tsx scripts/native-app-i18n.ts check`
- `git diff --check`
- autoreview: clean, no accepted/actionable findings
- Reproduced in Native App Locale Refresh run `30335378281`: locale workers failed before translation with inventory drift.