### PR TITLE
fix(qa-lab): filter unsupported profile channels

### DIFF
--- a/extensions/qa-lab/src/cli.runtime.test.ts
+++ b/extensions/qa-lab/src/cli.runtime.test.ts
@@ -2,6 +2,7 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import { isCrablineServerChannel, OPENCLAW_CRABLINE_DEFAULT_CHANNEL } from "@openclaw/crabline";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { QaScenarioPack } from "./scenario-catalog.js";
 
@@ -573,6 +574,18 @@ describe("qa cli runtime", () => {
     const suiteArgs = mockFirstObjectArg(runQaSuite);
     expect(suiteArgs.channelDriver).toBe("crabline");
     expect(suiteArgs.scenarioIds).toContain("channel-top-level-reply-shape");
+    const scenarioById = new Map(
+      readQaScenarioPack().scenarios.map((scenario) => [scenario.id, scenario]),
+    );
+    expect(
+      (suiteArgs.scenarioIds as string[]).every((scenarioId) => {
+        const scenario = scenarioById.get(scenarioId);
+        return (
+          scenario?.execution.kind !== "flow" ||
+          isCrablineServerChannel(scenario.execution.channel ?? OPENCLAW_CRABLINE_DEFAULT_CHANNEL)
+        );
+      }),
+    ).toBe(true);
     expect(suiteArgs.scenarioIds).not.toEqual(
       expect.arrayContaining([
         "instruction-followthrough-repo-contract",

--- a/extensions/qa-lab/src/cli.runtime.ts
+++ b/extensions/qa-lab/src/cli.runtime.ts
@@ -2,6 +2,7 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import {
+  isCrablineServerChannel,
   OPENCLAW_CRABLINE_DEFAULT_CHANNEL,
   resolveOpenClawCrablineChannelDriverSelection,
 } from "@openclaw/crabline";
@@ -720,6 +721,8 @@ export async function runQaProfileCommand(opts: QaProfileCommandOptions) {
     channelDriver: profileReport.channelDriver,
     defaultChannel:
       profileReport.channelDriver === "crabline" ? OPENCLAW_CRABLINE_DEFAULT_CHANNEL : undefined,
+    supportsChannel:
+      profileReport.channelDriver === "crabline" ? isCrablineServerChannel : undefined,
   });
   if (requestedScenarioIds.length > 0 && executionSelection.excludedScenarios.length > 0) {
     const exclusions = executionSelection.excludedScenarios

--- a/extensions/qa-lab/src/profile-planning.ts
+++ b/extensions/qa-lab/src/profile-planning.ts
@@ -114,6 +114,7 @@ export function resolveQaRunProfileExecutionSelection(params: {
   channel?: string | null;
   defaultChannel?: string;
   claudeCliAuthMode?: QaCliBackendAuthMode;
+  supportsChannel?: (channel: string) => boolean;
 }): QaRunProfileExecutionSelection {
   const selectedScenarios: QaSeedScenarioWithSource[] = [];
   const excludedScenarios: QaRunProfileExecutionSelection["excludedScenarios"] = [];
@@ -123,19 +124,30 @@ export function resolveQaRunProfileExecutionSelection(params: {
     if (scenario.execution.channel === "qa-channel" && params.channelDriver !== "qa-channel") {
       reasons.push("channelDriver=qa-channel");
     }
+    const effectiveChannel =
+      params.channelDriver === "qa-channel"
+        ? "qa-channel"
+        : (params.channel ?? scenario.execution.channel ?? params.defaultChannel);
     reasons.push(
       ...describeQaProviderLaneMismatches({
         scenario,
         providerMode: params.providerMode,
         primaryModel: params.primaryModel,
         channelDriver: params.channelDriver,
-        channel:
-          params.channelDriver === "qa-channel"
-            ? "qa-channel"
-            : (params.channel ?? scenario.execution.channel ?? params.defaultChannel),
+        channel: effectiveChannel,
         claudeCliAuthMode: params.claudeCliAuthMode,
       }),
     );
+    if (
+      reasons.length === 0 &&
+      scenario.execution.kind === "flow" &&
+      params.channelDriver !== "qa-channel" &&
+      effectiveChannel &&
+      params.supportsChannel &&
+      !params.supportsChannel(effectiveChannel)
+    ) {
+      reasons.push(`unsupported ${params.channelDriver} channel=${effectiveChannel}`);
+    }
     if (reasons.length > 0) {
       excludedScenarios.push({ scenario, reasons: uniqueStrings(reasons) });
     } else {

--- a/extensions/qa-lab/src/run-config.ts
+++ b/extensions/qa-lab/src/run-config.ts
@@ -367,6 +367,7 @@ export function resolveQaLabRunPlan(params: {
     channelDriver: selection.channelDriver,
     channel: selection.channel,
     defaultChannel: selection.channelDriver === "crabline" ? params.defaultChannel : undefined,
+    supportsChannel: params.supportsChannel,
   });
   exclusions.push(
     ...profileExecution.excludedScenarios.map(({ scenario, reasons }) => ({
@@ -385,29 +386,7 @@ export function resolveQaLabRunPlan(params: {
       reasons: ["runtimePair requires execution.kind=flow"],
     })),
   );
-  let selectedScenarios = runtimePairSupport.selectedScenarios;
-  if (selection.channelDriver !== "qa-channel" && params.supportsChannel) {
-    const unsupportedChannelScenarios = selectedScenarios.flatMap((scenario) => {
-      const channel = effectiveChannelForScenario({
-        scenario,
-        selection,
-        defaultChannel: params.defaultChannel,
-      });
-      if (scenario.execution.kind !== "flow") {
-        return [];
-      }
-      return channel !== null && !params.supportsChannel?.(channel) ? [{ scenario, channel }] : [];
-    });
-    const unsupportedIds = new Set(unsupportedChannelScenarios.map(({ scenario }) => scenario.id));
-    exclusions.push(
-      ...unsupportedChannelScenarios.map(({ scenario, channel }) => ({
-        scenarioId: scenario.id,
-        executionKind: scenario.execution.kind,
-        reasons: [`unsupported ${selection.channelDriver} channel=${channel}`],
-      })),
-    );
-    selectedScenarios = selectedScenarios.filter((scenario) => !unsupportedIds.has(scenario.id));
-  }
+  const selectedScenarios = runtimePairSupport.selectedScenarios;
   if (membership.categories.length === 0) {
     errors.push(`QA run profile ${selection.profile} did not resolve any taxonomy categories.`);
   }


### PR DESCRIPTION
Closes #115025

## What Problem This Solves

Fixes an issue where QA operators running the documented `smoke-ci` profile would abort before scenario execution when taxonomy membership included a Discord-only flow scenario that the selected Crabline driver cannot run.

## Why This Change Was Made

Profile execution planning now accepts the same driver-capability predicate already used by the QA Lab server run plan. The CLI supplies Crabline's exported `isCrablineServerChannel` contract, and the server path delegates its existing filter to the shared planner instead of maintaining a second selection pass.

The change filters only flow scenarios after provider/model/channel-lane compatibility succeeds. Test-file scenarios and explicit incompatibility diagnostics keep their existing behavior.

## User Impact

`openclaw qa run --qa-profile smoke-ci` skips taxonomy scenarios that cannot run on Crabline instead of failing while the mixed-channel suite is being created.

## Evidence

- Before fix, exact command on `0778c397fe44a90c2d710a4ea90a9423fc11e7b4`:
  - `QA run profile: smoke-ci; categories: 10; scenarios: 92`
  - aborted with `--channel ... got "discord"`
  - Testbox: https://github.com/openclaw/openclaw/actions/runs/30334583637
- After fix, the same command resolved 91 runnable scenarios and entered the Telegram partition instead of aborting:
  - Testbox: https://github.com/openclaw/openclaw/actions/runs/30335218818
  - The broader profile later exposed separate scenario failures and a WhatsApp readiness timeout; this PR does not claim a fully green smoke profile.
- Focused tests: `node scripts/run-vitest.mjs extensions/qa-lab/src/cli.runtime.test.ts extensions/qa-lab/src/run-config.test.ts`
  - 2 files, 134 tests passed.
- Changed gate: all classified `extensions`, `extensionTests`, and `docs` checks passed locally, including production/test typechecks, targeted lint, Plugin SDK API baseline, plugin boundaries, database-first guard, and runtime cycle check.
  - Blacksmith delegation was attempted twice but failed before scheduling with workflow-fetch HTTP 429, so trusted-source policy fell back to local execution.
- Autoreview: clean, no accepted/actionable findings; TruffleHog clean.
- Dependency contract checked directly in `@openclaw/crabline` source/types: supported channels are owned by `isCrablineServerChannel`.

## Root Cause And Provenance

PR #112838, merged July 27, 2026, moved CLI profile selection onto the shared planner without passing the channel-support predicate already used by the QA Lab server path. Code author and merger: @RomneyDa.

AI-assisted implementation and validation.
