### PR TITLE
fix(usage): show current MiniMax quota windows

### DIFF
--- a/src/infra/provider-usage.fetch.minimax.test.ts
+++ b/src/infra/provider-usage.fetch.minimax.test.ts
@@ -18,6 +18,7 @@ async function expectMinimaxUsageResult(params: {
   });
 
   const result = await fetchMinimaxUsage("key", 5000, mockFetch);
+  expect(result.error).toBeUndefined();
   expect(result.plan).toBe(params.expected.plan);
   expect(result.windows).toEqual(params.expected.windows);
 }
@@ -280,6 +281,152 @@ describe("fetchMinimaxUsage", () => {
       expected: {
         plan: "Coding Plan · MiniMax-M*",
         windows: [{ label: "4h", usedPercent: 0.8333333333333334, resetAt: 1_774_195_200_000 }],
+      },
+    },
+    {
+      name: "normalizes current MiniMax percentage-only general and weekly windows",
+      payload: {
+        model_remains: [
+          {
+            model_name: "general",
+            start_time: "1784386800000",
+            end_time: "1784404800000",
+            current_interval_total_count: 0,
+            current_interval_usage_count: 0,
+            current_interval_remaining_percent: 97,
+            current_interval_status: 1,
+            weekly_start_time: "1783900800000",
+            weekly_end_time: "1784505600000",
+            current_weekly_total_count: 0,
+            current_weekly_usage_count: 0,
+            current_weekly_remaining_percent: 77,
+            current_weekly_status: 1,
+          },
+          {
+            model_name: "video",
+            start_time: 1_784_332_800_000,
+            end_time: 1_784_419_200_000,
+            current_interval_total_count: 0,
+            current_interval_usage_count: 0,
+            current_interval_remaining_percent: 100,
+            current_interval_status: 3,
+            weekly_start_time: 1_783_900_800_000,
+            weekly_end_time: 1_784_505_600_000,
+            current_weekly_total_count: 0,
+            current_weekly_usage_count: 0,
+            current_weekly_remaining_percent: 100,
+            current_weekly_status: 3,
+          },
+        ],
+        base_resp: { status_code: 0, status_msg: "success" },
+      },
+      expected: {
+        plan: "Coding Plan · general",
+        windows: [
+          { label: "5h", usedPercent: 3, resetAt: 1_784_404_800_000 },
+          { label: "Week", usedPercent: 23, resetAt: 1_784_505_600_000 },
+        ],
+      },
+    },
+    {
+      name: "prefers current MiniMax remaining percentages over legacy count math",
+      payload: {
+        model_remains: [
+          {
+            model_name: "general",
+            startTime: 1_784_386_800_000,
+            endTime: 1_784_404_800_000,
+            currentIntervalTotalCount: 100,
+            currentIntervalUsageCount: 90,
+            currentIntervalRemainingPercent: 1,
+            currentIntervalStatus: 1,
+            weeklyStartTime: 1_783_900_800_000,
+            weeklyEndTime: 1_784_505_600_000,
+            currentWeeklyTotalCount: 0,
+            currentWeeklyUsageCount: 0,
+            currentWeeklyRemainingPercent: 100,
+            currentWeeklyStatus: 3,
+          },
+        ],
+        base_resp: { status_code: 0, status_msg: "success" },
+      },
+      expected: {
+        plan: "Coding Plan · general",
+        windows: [{ label: "5h", usedPercent: 99, resetAt: 1_784_404_800_000 }],
+      },
+    },
+    {
+      name: "omits an unlimited current window while preserving a bounded weekly window",
+      payload: {
+        model_remains: [
+          {
+            model_name: "general",
+            start_time: 1_784_386_800_000,
+            end_time: 1_784_404_800_000,
+            current_interval_total_count: 0,
+            current_interval_usage_count: 0,
+            current_interval_remaining_percent: 100,
+            current_interval_status: 3,
+            weekly_start_time: 1_783_900_800_000,
+            weekly_end_time: 1_784_505_600_000,
+            current_weekly_total_count: 0,
+            current_weekly_usage_count: 0,
+            current_weekly_remaining_percent: 50,
+            current_weekly_status: 1,
+          },
+        ],
+        base_resp: { status_code: 0, status_msg: "success" },
+      },
+      expected: {
+        plan: "Coding Plan · general",
+        windows: [{ label: "Week", usedPercent: 50, resetAt: 1_784_505_600_000 }],
+      },
+    },
+    {
+      name: "returns a valid empty snapshot when all MiniMax windows are unlimited",
+      payload: {
+        model_remains: [
+          {
+            model_name: "general",
+            current_interval_total_count: 0,
+            current_interval_usage_count: 0,
+            current_interval_remaining_percent: 100,
+            current_interval_status: 3,
+            current_weekly_total_count: 0,
+            current_weekly_usage_count: 0,
+            current_weekly_remaining_percent: 100,
+            current_weekly_status: 3,
+          },
+        ],
+        base_resp: { status_code: 0, status_msg: "success" },
+      },
+      expected: {
+        plan: "Coding Plan · general",
+        windows: [],
+      },
+    },
+    {
+      name: "prefers an exhausted bounded row over an earlier unlimited fallback row",
+      payload: {
+        model_remains: [
+          {
+            model_name: "video",
+            current_interval_remaining_percent: 100,
+            current_interval_status: 3,
+          },
+          {
+            model_name: "other-bounded-model",
+            start_time: 1_784_386_800_000,
+            end_time: 1_784_404_800_000,
+            current_interval_remaining_percent: 0,
+            current_interval_status: 2,
+          },
+        ],
+        base_resp: { status_code: 0, status_msg: "success" },
+      },
+      expected: {
+        plan: "Coding Plan · other-bounded-model",
+        windows: [{ label: "5h", usedPercent: 100, resetAt: 1_784_404_800_000 }],
       },
     },
     {

--- a/src/infra/provider-usage.fetch.minimax.ts
+++ b/src/infra/provider-usage.fetch.minimax.ts
@@ -61,10 +61,42 @@ const PERCENT_KEYS = [
   "usageRatio",
 ] as const;
 
-// MiniMax's usage_percent / usagePercent fields report the remaining quota
-// as a percentage, not the consumed quota. Treat them as "remaining percent"
-// and invert to get usedPercent. Count-based fromCounts always takes priority.
+// Legacy usage_percent / usagePercent fields report remaining quota, not consumption.
+// Generic payloads keep count priority; canonical model rows opt into the provider's
+// dedicated remaining-percent fields as their authoritative values.
 const REMAINING_PERCENT_KEYS = ["usage_percent", "usagePercent"] as const;
+
+const CURRENT_INTERVAL_TOTAL_KEYS = [
+  "current_interval_total_count",
+  "currentIntervalTotalCount",
+] as const;
+const CURRENT_INTERVAL_REMAINING_KEYS = [
+  "current_interval_usage_count",
+  "currentIntervalUsageCount",
+] as const;
+const CURRENT_INTERVAL_REMAINING_PERCENT_KEYS = [
+  "current_interval_remaining_percent",
+  "currentIntervalRemainingPercent",
+] as const;
+const CURRENT_INTERVAL_STATUS_KEYS = ["current_interval_status", "currentIntervalStatus"] as const;
+const CURRENT_WEEKLY_TOTAL_KEYS = [
+  "current_weekly_total_count",
+  "currentWeeklyTotalCount",
+] as const;
+const CURRENT_WEEKLY_REMAINING_KEYS = [
+  "current_weekly_usage_count",
+  "currentWeeklyUsageCount",
+] as const;
+const CURRENT_WEEKLY_REMAINING_PERCENT_KEYS = [
+  "current_weekly_remaining_percent",
+  "currentWeeklyRemainingPercent",
+] as const;
+const CURRENT_WEEKLY_STATUS_KEYS = ["current_weekly_status", "currentWeeklyStatus"] as const;
+const MODEL_REMAINING_PERCENT_KEYS = [
+  ...CURRENT_INTERVAL_REMAINING_PERCENT_KEYS,
+  ...CURRENT_WEEKLY_REMAINING_PERCENT_KEYS,
+] as const;
+const NO_USAGE_KEYS = [] as const;
 
 const USED_KEYS = [
   "used",
@@ -195,6 +227,10 @@ function parseEpoch(value: unknown): number | undefined {
     return asDateTimestampMs(timestampMs);
   }
   if (typeof value === "string" && value.trim()) {
+    const numeric = parseFiniteNumber(value);
+    if (numeric !== undefined) {
+      return parseEpoch(numeric);
+    }
     const parsed = Date.parse(value);
     return asDateTimestampMs(parsed);
   }
@@ -207,7 +243,7 @@ function hasAny(record: Record<string, unknown>, keys: readonly string[]): boole
 
 function scoreUsageRecord(record: Record<string, unknown>): number {
   let score = 0;
-  if (hasAny(record, PERCENT_KEYS)) {
+  if (hasAny(record, PERCENT_KEYS) || hasAny(record, MODEL_REMAINING_PERCENT_KEYS)) {
     score += 4;
   }
   if (hasAny(record, TOTAL_KEYS)) {
@@ -303,10 +339,38 @@ function deriveWindowLabel(payload: Record<string, unknown>): string {
   return "5h";
 }
 
-function deriveUsedPercent(payload: Record<string, unknown>): number | null {
-  const total = pickNumber(payload, TOTAL_KEYS);
-  let used = pickNumber(payload, USED_KEYS);
-  const remaining = pickNumber(payload, REMAINING_KEYS);
+function deriveUsedPercent(
+  payload: Record<string, unknown>,
+  keys: {
+    total?: readonly string[];
+    used?: readonly string[];
+    remaining?: readonly string[];
+    percent?: readonly string[];
+    remainingPercent?: readonly string[];
+    remainingPercentUnit?: "percent" | "ratio-or-percent";
+    preferRemainingPercent?: boolean;
+  } = {},
+): number | null {
+  const remainingPercentRaw = pickNumber(payload, keys.remainingPercent ?? REMAINING_PERCENT_KEYS);
+  const remainingPercentUnit = keys.remainingPercentUnit ?? "ratio-or-percent";
+  const fromRemainingPercent =
+    remainingPercentRaw === undefined
+      ? null
+      : clampPercent(
+          100 -
+            clampPercent(
+              remainingPercentUnit === "ratio-or-percent" && remainingPercentRaw <= 1
+                ? remainingPercentRaw * 100
+                : remainingPercentRaw,
+            ),
+        );
+  if (keys.preferRemainingPercent === true && fromRemainingPercent !== null) {
+    return fromRemainingPercent;
+  }
+
+  const total = pickNumber(payload, keys.total ?? TOTAL_KEYS);
+  let used = pickNumber(payload, keys.used ?? USED_KEYS);
+  const remaining = pickNumber(payload, keys.remaining ?? REMAINING_KEYS);
   if (used === undefined && remaining !== undefined && total !== undefined) {
     used = total - remaining;
   }
@@ -321,51 +385,124 @@ function deriveUsedPercent(payload: Record<string, unknown>): number | null {
     return fromCounts;
   }
 
-  const percentRaw = pickNumber(payload, PERCENT_KEYS);
+  const percentRaw = pickNumber(payload, keys.percent ?? PERCENT_KEYS);
   if (percentRaw !== undefined) {
     return clampPercent(percentRaw <= 1 ? percentRaw * 100 : percentRaw);
   }
 
   // usage_percent / usagePercent in MiniMax's API represents remaining quota,
   // not consumed quota. Invert to get usedPercent.
-  const remainingPercentRaw = pickNumber(payload, REMAINING_PERCENT_KEYS);
-  if (remainingPercentRaw !== undefined) {
-    const remainingNormalized = clampPercent(
-      remainingPercentRaw <= 1 ? remainingPercentRaw * 100 : remainingPercentRaw,
-    );
-    return clampPercent(100 - remainingNormalized);
+  if (fromRemainingPercent !== null) {
+    return fromRemainingPercent;
   }
 
   return null;
 }
 
-// Prefer the entry whose model_name matches a chat/text model (e.g. "MiniMax-M*")
-// and that has a non-zero current_interval_total_count.  Models with total_count === 0
-// (speech, video, image) are not relevant to the coding-plan budget.
+function hasModelUsageEvidence(record: Record<string, unknown>): boolean {
+  return (
+    hasAny(record, MODEL_REMAINING_PERCENT_KEYS) ||
+    (pickNumber(record, CURRENT_INTERVAL_TOTAL_KEYS) ?? 0) > 0 ||
+    (pickNumber(record, CURRENT_WEEKLY_TOTAL_KEYS) ?? 0) > 0
+  );
+}
+
+function isChatModelUsageRecord(record: Record<string, unknown>): boolean {
+  const name = normalizeLowercaseStringOrEmpty(
+    typeof record.model_name === "string" ? record.model_name : "",
+  );
+  return name === "general" || name.startsWith("minimax-m");
+}
+
+function isBoundedMinimaxStatus(status: number | undefined): boolean {
+  return status === 1 || status === 2;
+}
+
+function isBoundedModelUsageRecord(record: Record<string, unknown>): boolean {
+  return (
+    isBoundedMinimaxStatus(pickNumber(record, CURRENT_INTERVAL_STATUS_KEYS)) ||
+    isBoundedMinimaxStatus(pickNumber(record, CURRENT_WEEKLY_STATUS_KEYS))
+  );
+}
+
+// MiniMax's current API uses `general` for the chat quota and can report zero counts
+// with authoritative percentage fields. Prefer that owner before status-based fallbacks.
 function pickChatModelRemains(modelRemains: unknown[]): Record<string, unknown> | undefined {
-  const records = modelRemains.filter(isRecord);
+  const records = modelRemains.filter(isRecord).filter(hasModelUsageEvidence);
   if (records.length === 0) {
     return undefined;
   }
 
-  const chatRecord = records.find((r) => {
-    const name = typeof r.model_name === "string" ? r.model_name : "";
-    const total = parseFiniteNumber(r.current_interval_total_count);
-    return (
-      normalizeLowercaseStringOrEmpty(name).startsWith("minimax-m") &&
-      total !== undefined &&
-      total > 0
-    );
-  });
+  return (
+    records.find(isChatModelUsageRecord) ?? records.find(isBoundedModelUsageRecord) ?? records[0]
+  );
+}
 
-  if (chatRecord) {
-    return chatRecord;
+function pickEpoch(record: Record<string, unknown>, keys: readonly string[]): number | undefined {
+  for (const key of keys) {
+    const parsed = parseEpoch(record[key]);
+    if (parsed !== undefined) {
+      return parsed;
+    }
+  }
+  return undefined;
+}
+
+function shouldExposeMinimaxWindow(
+  record: Record<string, unknown>,
+  statusKeys: readonly string[],
+): boolean {
+  // MiniMax status 3 is unlimited. UsageWindow cannot represent infinity, so a 0%-used
+  // bounded bar would be misleading; legacy rows without status remain visible.
+  return pickNumber(record, statusKeys) !== 3;
+}
+
+function deriveMinimaxModelWindows(record: Record<string, unknown>): {
+  recognized: boolean;
+  windows: UsageWindow[];
+} {
+  const windows: UsageWindow[] = [];
+  const currentUsedPercent = deriveUsedPercent(record, {
+    total: CURRENT_INTERVAL_TOTAL_KEYS,
+    used: NO_USAGE_KEYS,
+    remaining: CURRENT_INTERVAL_REMAINING_KEYS,
+    percent: NO_USAGE_KEYS,
+    remainingPercent: CURRENT_INTERVAL_REMAINING_PERCENT_KEYS,
+    remainingPercentUnit: "percent",
+    preferRemainingPercent: true,
+  });
+  if (
+    currentUsedPercent !== null &&
+    shouldExposeMinimaxWindow(record, CURRENT_INTERVAL_STATUS_KEYS)
+  ) {
+    windows.push({
+      label: deriveWindowLabel(record),
+      usedPercent: currentUsedPercent,
+      resetAt: pickEpoch(record, ["end_time", "endTime"]),
+    });
   }
 
-  return records.find((r) => {
-    const total = parseFiniteNumber(r.current_interval_total_count);
-    return total !== undefined && total > 0;
+  const weeklyUsedPercent = deriveUsedPercent(record, {
+    total: CURRENT_WEEKLY_TOTAL_KEYS,
+    used: NO_USAGE_KEYS,
+    remaining: CURRENT_WEEKLY_REMAINING_KEYS,
+    percent: NO_USAGE_KEYS,
+    remainingPercent: CURRENT_WEEKLY_REMAINING_PERCENT_KEYS,
+    remainingPercentUnit: "percent",
+    preferRemainingPercent: true,
   });
+  if (weeklyUsedPercent !== null && shouldExposeMinimaxWindow(record, CURRENT_WEEKLY_STATUS_KEYS)) {
+    windows.push({
+      label: "Week",
+      usedPercent: weeklyUsedPercent,
+      resetAt: pickEpoch(record, ["weekly_end_time", "weeklyEndTime"]),
+    });
+  }
+
+  return {
+    recognized: currentUsedPercent !== null || weeklyUsedPercent !== null,
+    windows,
+  };
 }
 
 function resolveMinimaxUsageUrl(baseUrl?: string): string {
@@ -445,42 +582,45 @@ export async function fetchMinimaxUsage(
   const chatRemains = modelRemains ? pickChatModelRemains(modelRemains) : undefined;
 
   const usageSource = chatRemains ?? payload;
-  const candidates = collectUsageCandidates(usageSource);
   let usageRecord: Record<string, unknown> = usageSource;
-  let usedPercent: number | null = null;
-  for (const candidate of candidates) {
-    const candidatePercent = deriveUsedPercent(candidate);
-    if (candidatePercent !== null) {
-      usageRecord = candidate;
-      usedPercent = candidatePercent;
-      break;
+  const modelUsage = chatRemains ? deriveMinimaxModelWindows(chatRemains) : undefined;
+  let windows = modelUsage?.windows ?? [];
+  if (modelUsage?.recognized !== true) {
+    const candidates = collectUsageCandidates(usageSource);
+    let usedPercent: number | null = null;
+    for (const candidate of candidates) {
+      const candidatePercent = deriveUsedPercent(candidate);
+      if (candidatePercent !== null) {
+        usageRecord = candidate;
+        usedPercent = candidatePercent;
+        break;
+      }
     }
-  }
-  if (usedPercent === null) {
-    usedPercent = deriveUsedPercent(usageSource);
-  }
-  if (usedPercent === null) {
-    return {
-      provider: "minimax",
-      displayName: PROVIDER_LABELS.minimax,
-      windows: [],
-      error: "Unsupported response shape",
-    };
-  }
+    if (usedPercent === null) {
+      usedPercent = deriveUsedPercent(usageSource);
+    }
+    if (usedPercent === null) {
+      return {
+        provider: "minimax",
+        displayName: PROVIDER_LABELS.minimax,
+        windows: [],
+        error: "Unsupported response shape",
+      };
+    }
 
-  const resetAt =
-    parseEpoch(pickString(usageRecord, RESET_KEYS)) ??
-    parseEpoch(pickNumber(usageRecord, RESET_KEYS)) ??
-    parseEpoch(pickString(payload, RESET_KEYS)) ??
-    parseEpoch(pickNumber(payload, RESET_KEYS));
-  const windowLabel = chatRemains ? deriveWindowLabel(chatRemains) : deriveWindowLabel(usageRecord);
-  const windows: UsageWindow[] = [
-    {
-      label: windowLabel,
-      usedPercent,
-      resetAt,
-    },
-  ];
+    const resetAt =
+      parseEpoch(pickString(usageRecord, RESET_KEYS)) ??
+      parseEpoch(pickNumber(usageRecord, RESET_KEYS)) ??
+      parseEpoch(pickString(payload, RESET_KEYS)) ??
+      parseEpoch(pickNumber(payload, RESET_KEYS));
+    windows = [
+      {
+        label: deriveWindowLabel(usageRecord),
+        usedPercent,
+        resetAt,
+      },
+    ];
+  }
 
   const modelName =
     chatRemains && typeof chatRemains.model_name === "string" ? chatRemains.model_name : undefined;


### PR DESCRIPTION
Closes #110887

Thanks @pitcockchris79 for the current response fixture and endpoint diagnosis.

## What Problem This Solves

Fixes an issue where users with current MiniMax Token Plan responses could see the wrong quota family or `Unsupported response shape` in status and usage views when chat quota rows used `model_name: "general"`, percentage-only limits, or zero count fields.

## Why This Change Was Made

MiniMax model quota rows now normalize through one provider-specific path: prefer the `general`/MiniMax chat row, treat the official current and weekly remaining-percent fields as authoritative 0–100 percentages, preserve legacy count payloads, parse numeric-string epochs, and emit only bounded status 1/2 windows. Status-3 unlimited windows are recognized but omitted because OpenClaw's bounded usage-bar contract cannot represent infinity.

Configured Global or CN origins still flow from the MiniMax plugin owner into the shared fetcher; no endpoint, config, or public API surface was added.

## User Impact

MiniMax status and Usage now show the correct bounded chat quota window instead of selecting a video row, dropping percentage-only plans, or inventing a 0%-used bar for unlimited quota. Current responses can expose both the active interval and weekly window when both are bounded.

## Evidence

Official upstream contract checked at MiniMax CLI commit `3615170a2e26ec6003c4550cd1324b55ec8ad677`:

- https://github.com/MiniMax-AI/cli/blob/3615170a2e26ec6003c4550cd1324b55ec8ad677/src/types/api.ts
- https://github.com/MiniMax-AI/cli/blob/3615170a2e26ec6003c4550cd1324b55ec8ad677/src/output/quota-table.ts
- https://github.com/MiniMax-AI/cli/blob/3615170a2e26ec6003c4550cd1324b55ec8ad677/src/client/endpoints.ts

Redacted live proof with the approved MiniMax key:

- Global origin: HTTP 200, `base_resp.status_code=0`; `general` and `video` rows carried current/weekly percent, timestamps, and status fields.
- CN origin: provider status 2049 for this Global key, confirming configured-origin propagation must remain authoritative.
- Before: `{"error":null,"windowCount":1,"windowLabels":["24h"],"planPresent":true}` (the generic selector chose the wrong quota family).
- After: `{"error":null,"windowCount":1,"windowLabels":["5h"],"planPresent":true}` (the chat row is selected; this account's weekly status is unlimited and therefore intentionally omitted).

Focused and integration proof on final head `bb20b35dd94af5e5a1d4cf81e82f5c1b390f61d9`:

- MiniMax fetcher: 25 tests passed, including percentage-only, 1%-remaining, unlimited-empty, numeric-string epoch, and exhausted-row cases.
- MiniMax plugin owner: 19 tests passed, including configured Global origin propagation.
- Provider usage integration: 6 tests passed.
- Core production and test tsgo passed.
- Targeted oxlint and oxfmt passed.
- Conflict, env-count, max-lines, changelog attribution, deprecated-API, import-cycle, and database-first guards passed.

Blacksmith Testbox could not provision because its workflow fetch was rate-limited (HTTP 429); per maintainer policy the equivalent trusted-source lanes were run locally without dependency reconciliation. Final autoreview: clean, no accepted/actionable findings after five in-scope hardening cycles.
