### PR TITLE
fix(ci): keep fork embedded-agent shard alive on cold runners

### DIFF
--- a/scripts/lib/ci-node-test-plan.mjs
+++ b/scripts/lib/ci-node-test-plan.mjs
@@ -30,6 +30,11 @@ const GATEWAY_STARTUP_CORE_RUNNER = DEFAULT_NODE_TEST_RUNNER;
 const GATEWAY_STARTUP_HEALTH_RUNTIME_ENV = {
   OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS: "60000",
 };
+// The first embedded-agent file owns 157 serial tests and can stay quiet for
+// more than five minutes on a cold GitHub-hosted 4-vCPU fork runner.
+const AGENTS_EMBEDDED_AGENT_ENV = {
+  OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS: "420000",
+};
 const MAX_BUNDLED_NODE_TEST_PATTERNS = 64;
 // PR-only bundles trade a little serial work for fewer ephemeral runner registrations.
 // Keep runner classes and subprocess isolation intact while bounding each combined job.
@@ -71,7 +76,9 @@ const COMPACT_GROUP_SECONDS_HINTS = new Map([
   ["agentic-agents-core-runtime", 79],
   ["agentic-agents-core-subagents", 32],
   ["agentic-agents-core-tools", 52],
-  ["agentic-agents-embedded", 57],
+  // A cold fork run is about 430s and emits no file result for most of its
+  // first five minutes. Keep this whole-config whale in its own compact job.
+  ["agentic-agents-embedded", 430],
   ["agentic-agents-support", 105],
   ["agentic-agents-tools", 42],
   ["agentic-cli", 72],
@@ -1183,6 +1190,7 @@ const SPLIT_NODE_SHARDS = new Map([
       {
         shardName: "agentic-agents-embedded",
         configs: ["test/vitest/vitest.agents-embedded-agent.config.ts"],
+        env: AGENTS_EMBEDDED_AGENT_ENV,
         requiresDist: false,
       },
       {

--- a/scripts/pr-lib/review.sh
+++ b/scripts/pr-lib/review.sh
@@ -160,7 +160,10 @@ review_artifacts_init() {
   local meta_number head_sha
   meta_number=$(jq -r '.number' .local/pr-meta.json)
   head_sha=$(jq -r '.headRefOid' .local/pr-meta.json)
-  if [ "$meta_number" != "$pr" ] || ! printf '%s' "$head_sha" | rg -q '^[0-9a-f]{40}$'; then
+  # Bash regex, not rg: this guard runs inside fork-PR CI test harnesses on
+  # GitHub-hosted runners without ripgrep, where a missing rg (exit 127) would
+  # misreport a valid head SHA as an identity mismatch.
+  if [ "$meta_number" != "$pr" ] || ! [[ "$head_sha" =~ ^[0-9a-f]{40}$ ]]; then
     echo "Review artifacts init failed: .local/pr-meta.json describes PR #$meta_number at '$head_sha', not PR #$pr. Re-run: scripts/pr review-init $pr"
     exit 1
   fi

--- a/src/agents/embedded-agent-runner/run.incomplete-turn.test.ts
+++ b/src/agents/embedded-agent-runner/run.incomplete-turn.test.ts
@@ -50,6 +50,10 @@ const SETTLED_TOOL_TERMINAL_CONTINUATION_INSTRUCTION =
 
 let runEmbeddedAgent: typeof import("./run.js").runEmbeddedAgent;
 
+// Cold GitHub-hosted fork runners can spend more than five minutes loading and
+// warming this broad harness before the first test reports progress.
+const COLD_FORK_RUNNER_HOOK_TIMEOUT_MS = 420_000;
+
 function resolveIncompleteTurnPayloadText(
   params: Omit<Parameters<typeof resolveIncompleteTurnPayloadTextCore>[0], "externalAbort"> & {
     externalAbort?: boolean;
@@ -64,7 +68,7 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
   beforeAll(async () => {
     ({ runEmbeddedAgent } = await loadRunOverflowCompactionHarness());
     await warmRunOverflowCompactionHarness(runEmbeddedAgent);
-  }, 300_000);
+  }, COLD_FORK_RUNNER_HOOK_TIMEOUT_MS);
 
   beforeEach(() => {
     resetRunOverflowCompactionHarnessMocks();

--- a/test/scripts/ci-node-test-plan.test.ts
+++ b/test/scripts/ci-node-test-plan.test.ts
@@ -299,6 +299,13 @@ describe("scripts/lib/ci-node-test-plan.mjs", () => {
         .flatMap((shard) => shard.groups)
         .find((group) => group.shard_name === "agentic-control-plane-startup-health-runtime")?.env,
     ).toEqual({ OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS: "60000" });
+    const embeddedAgentJob = compact.find((shard) =>
+      shard.groups.some((group) => group.shard_name === "agentic-agents-embedded"),
+    );
+    expect(embeddedAgentJob?.groups).toHaveLength(1);
+    expect(embeddedAgentJob?.groups[0]?.env).toEqual({
+      OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS: "420000",
+    });
     expect(
       compact
         .filter((shard) => shard.groups.some((group) => !group.includePatterns))
@@ -997,6 +1004,7 @@ describe("scripts/lib/ci-node-test-plan.mjs", () => {
       {
         checkName: "checks-node-agentic-agents-embedded",
         configs: ["test/vitest/vitest.agents-embedded-agent.config.ts"],
+        env: { OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS: "420000" },
         requiresDist: false,
         runner: DEFAULT_NODE_TEST_RUNNER,
         shardName: "agentic-agents-embedded",


### PR DESCRIPTION
Related: #114777

## What Problem This Solves

Fixes an issue where every fork pull request that falls back to the compact full Node matrix can fail `checks-node-compact-large-2` on GitHub-hosted `ubuntu-24.04`. The `agentic-agents-embedded` project produces no reporter output while its first 157-test file runs, so cold four-core runners can cross the global 300-second no-output watchdog and exit 143 even though Vitest is still making progress.

## Why This Change Was Made

The embedded-agent whole-config group now carries a narrowly scoped seven-minute no-output budget and an honest 430-second compact-planner weight, which gives the known long first file enough cold-runner headroom and keeps the group in its own compact job. The same heavyweight file's setup hook now uses the matching seven-minute cap; the first fork proof got past the watchdog and exposed that separate five-minute hook limit. These changes do not widen either timeout for other shards. The PR also folds the fork-harness-safe Bash SHA validation from #114777 because that commit has not landed on `main`.

The diagnosis compared the last green four-core fork run with two failing fork runs and reproduced the project from a full Linux clone. The last green run was already silent for 269 seconds and completed the full project in 429 seconds; both failing runs reached the 300-second kill twice. A same-host timing bisect became progressively faster as filesystem state warmed and incorrectly pointed at an unrelated UI-only commit, while warmed current `main` fell from 220 seconds to 133 seconds for the heavyweight file. That rules out an attributable embedded-agent deadlock or deterministic product regression and identifies cold-runner/cache variance around a stale CI threshold.

## User Impact

Fork contributors can get a valid CI result again instead of an infrastructure-owned exit 143. There is no product runtime or user-visible behavior change.

## Evidence

- Failure: [run 30328377693 / job 90182649954](https://github.com/openclaw/openclaw/actions/runs/30328377693/job/90182649954) and [run 30331244182 / job 90186821703](https://github.com/openclaw/openclaw/actions/runs/30331244182/job/90186821703) both killed `agentic-agents-embedded` after two 300-second silent attempts.
- Last green four-core fork baseline: [run 30261226113 / job 89964964317](https://github.com/openclaw/openclaw/actions/runs/30261226113/job/89964964317) was silent for 269 seconds in `run.incomplete-turn.test.ts` and finished the project in 428.55 seconds.
- First fork proof: [run 30337828822](https://github.com/openclaw/openclaw/actions/runs/30337828822) passed the former no-output boundary, then exposed the same file's independent `beforeAll` timeout at 300 seconds. The follow-up aligns that hook with the group budget.
- Exact-head fork proof: [run 30339535472 / job 90211859071](https://github.com/openclaw/openclaw/actions/runs/30339535472/job/90211859071) passed on GitHub-hosted 4-vCPU Ubuntu. The first file completed in 311.14 seconds, the embedded project passed 131 files / 2,191 tests in 593.98 seconds, and `openclaw/ci-gate` was green.
- Full Testbox/Linux four-core proof: 130 files and 2,188 tests passed in 355.31 seconds through the exact shard runner; Testbox `tbx_01kyknt23rz9vp0xj501z7x0y1`, [run 30334202719](https://github.com/openclaw/openclaw/actions/runs/30334202719).
- Focused follow-up proof: all 157 heavyweight-file tests passed in 236.83 seconds on fresh Testbox `tbx_01kykte8vdabnkcbevcnrhd6g8`, [run 30339050739](https://github.com/openclaw/openclaw/actions/runs/30339050739).
- Focused planner/runner/PR-artifact proof: 62 tests passed; targeted formatting clean.
- `pnpm check:changed` passed on Testbox `tbx_01kykrap8r9a39rqps6gyzqfd7`, [run 30336707558](https://github.com/openclaw/openclaw/actions/runs/30336707558).
- Fresh Codex autoreview: no accepted/actionable findings; patch correct at 0.96 confidence.
- Follow-up Codex autoreview: no accepted/actionable findings; hook-timeout patch correct at 0.99 confidence.
- Final combined-branch Codex autoreview: no accepted/actionable findings; patch correct at 0.97 confidence.

## Rank-up Move Disposition

The optional refresh against current `main` is intentionally skipped. The branch is conflict-free, and the intervening `main` commits do not touch these four CI/test-harness files. OpenClaw's landing workflow treats behind-main drift as advisory and validates the actual merge result during `prepare-run`; retaining the exact patch head also preserves the complete hosted fork proof above.

AI-assisted: yes. I reviewed the implementation and the evidence above.

## Rank-up moves

- Current-main refresh: the head was rebased immediately before exact-head run 30339535472. I am not rewriting the fork branch again for unrelated, conflict-free behind-main drift; repo-native prepare and the App-owned strict test-merge gate validate the current merge result before landing.
