### PR TITLE
fix(codex): finalize settled turns with historical prompt pairs

### DIFF
--- a/extensions/codex/src/app-server/settled-turn-context.test.ts
+++ b/extensions/codex/src/app-server/settled-turn-context.test.ts
@@ -79,6 +79,122 @@ describe("captureCodexSettledTurnFinalizationContext", () => {
     expect(context?.messages).not.toBe(historyMessages);
   });
 
+  it("keeps the later canonical prompt from an exact historical prompt pair", async () => {
+    const prior = message({ role: "user", content: "Earlier context." }, "turn-1:prompt");
+    const settledMessages = settledTurn();
+    const mirroredPrompt = message(
+      {
+        role: "user",
+        content: "Send it.",
+        idempotencyKey: "run-2:user",
+        __openclaw: { rowOwner: "codex-mirror" },
+      },
+      "turn-2:prompt",
+    );
+    const canonicalPrompt = message(
+      {
+        role: "user",
+        content: "Send it.",
+        idempotencyKey: "run-2:user",
+        __openclaw: { rowOwner: "session-manager" },
+      },
+      "turn-2:prompt",
+    );
+    const historyMessages = [
+      prior,
+      mirroredPrompt,
+      canonicalPrompt,
+      settledMessages[1]!,
+      settledMessages[2]!,
+    ];
+
+    const context = await captureContext({
+      historyMessages,
+      mirroredMessages: settledMessages,
+      settledMessages,
+      turnId: "turn-2",
+    });
+
+    expect(context).toEqual({
+      source: "openclaw-transcript",
+      messages: [prior, canonicalPrompt, settledMessages[1]!, settledMessages[2]!],
+    });
+  });
+
+  it.each([
+    {
+      name: "missing idempotency key",
+      pair: [
+        message({ role: "user", content: "Send it." }, "turn-2:prompt"),
+        message({ role: "user", content: "Send it." }, "turn-2:prompt"),
+      ],
+    },
+    {
+      name: "different idempotency keys",
+      pair: [
+        message(
+          { role: "user", content: "Send it.", idempotencyKey: "run-2:user" },
+          "turn-2:prompt",
+        ),
+        message(
+          { role: "user", content: "Send it.", idempotencyKey: "other:user" },
+          "turn-2:prompt",
+        ),
+      ],
+    },
+    {
+      name: "payload drift",
+      pair: [
+        message(
+          { role: "user", content: "Send it.", idempotencyKey: "run-2:user" },
+          "turn-2:prompt",
+        ),
+        message(
+          { role: "user", content: "Send something else.", idempotencyKey: "run-2:user" },
+          "turn-2:prompt",
+        ),
+      ],
+    },
+    {
+      name: "non-prompt identity",
+      pair: [
+        message({ role: "user", content: "Send it.", idempotencyKey: "run-2:user" }, "turn-2:user"),
+        message({ role: "user", content: "Send it.", idempotencyKey: "run-2:user" }, "turn-2:user"),
+      ],
+    },
+  ])("fails closed for a canonical-looking pair with $name", async ({ pair }) => {
+    const settledMessages = settledTurn();
+    await expect(
+      captureContext({
+        historyMessages: [...pair, settledMessages[1]!, settledMessages[2]!],
+        mirroredMessages: settledMessages,
+        settledMessages,
+        turnId: "turn-2",
+      }),
+    ).resolves.toBeUndefined();
+  });
+
+  it("fails closed for non-adjacent or repeated canonical prompt identities", async () => {
+    const settledMessages = settledTurn();
+    const prompt = () =>
+      message({ role: "user", content: "Send it.", idempotencyKey: "run-2:user" }, "turn-2:prompt");
+    const separator = message({ role: "assistant", content: "unrelated" }, "turn-1:assistant");
+
+    for (const historyMessages of [
+      [prompt(), separator, prompt(), settledMessages[1]!, settledMessages[2]!],
+      [prompt(), prompt(), prompt(), settledMessages[1]!, settledMessages[2]!],
+    ]) {
+      await expect(
+        captureContext({
+          historyMessages,
+          mirroredMessages: settledMessages,
+          settledMessages,
+          turnId: "turn-2",
+        }),
+      ).resolves.toBeUndefined();
+    }
+  });
+
   it.each([
     {
       name: "missing current prompt",

--- a/extensions/codex/src/app-server/settled-turn-context.ts
+++ b/extensions/codex/src/app-server/settled-turn-context.ts
@@ -10,6 +10,60 @@ import { readMirrorIdentity } from "./upstream-prompt-provenance.js";
 
 type SettledTurnFinalizationContext = EmbeddedRunAttemptResult["settledTurnFinalizationContext"];
 
+function readMessageIdempotencyKey(message: AgentMessage): string | undefined {
+  const value = (message as unknown as { idempotencyKey?: unknown }).idempotencyKey;
+  return typeof value === "string" && value ? value : undefined;
+}
+
+function isCanonicalPromptPair(previous: AgentMessage, current: AgentMessage): boolean {
+  const identity = readMirrorIdentity(current);
+  const idempotencyKey = readMessageIdempotencyKey(current);
+  return (
+    previous.role === "user" &&
+    current.role === "user" &&
+    identity?.endsWith(":prompt") === true &&
+    readMirrorIdentity(previous) === identity &&
+    Boolean(idempotencyKey) &&
+    readMessageIdempotencyKey(previous) === idempotencyKey &&
+    serializeCodexMirrorSourceEvidence(previous) === serializeCodexMirrorSourceEvidence(current)
+  );
+}
+
+function normalizeCanonicalPromptPairs(
+  messages: readonly AgentMessage[],
+): { messages: AgentMessage[]; identities: Map<string, number> } | undefined {
+  const normalized: AgentMessage[] = [];
+  const identityIndexes = new Map<string, number>();
+  const normalizedPairIdentities = new Set<string>();
+  for (const message of messages) {
+    const identity = readMirrorIdentity(message);
+    if (!identity) {
+      normalized.push(message);
+      continue;
+    }
+    const existingIndex = identityIndexes.get(identity);
+    if (existingIndex === undefined) {
+      normalized.push(message);
+      identityIndexes.set(identity, normalized.length - 1);
+      continue;
+    }
+    const previous = normalized[existingIndex];
+    if (
+      !previous ||
+      existingIndex !== normalized.length - 1 ||
+      normalizedPairIdentities.has(identity) ||
+      !isCanonicalPromptPair(previous, message)
+    ) {
+      return undefined;
+    }
+    // The later row is the SessionManager node used by subsequent parent
+    // links. Keep it in the finalizer projection without changing stored rows.
+    normalized[existingIndex] = message;
+    normalizedPairIdentities.add(identity);
+  }
+  return { messages: normalized, identities: identityIndexes };
+}
+
 function collectUniqueMessageIdentities(
   messages: readonly AgentMessage[],
 ): Map<string, number> | undefined {
@@ -59,11 +113,12 @@ function buildCodexSettledTurnFinalizationContext(params: {
     return undefined;
   }
 
-  const historyIdentities = collectUniqueMessageIdentities(params.historyMessages);
+  const normalizedHistory = normalizeCanonicalPromptPairs(params.historyMessages);
   const mirroredIdentities = collectUniqueMessageIdentities(params.mirroredMessages);
-  if (!historyIdentities || !mirroredIdentities) {
+  if (!normalizedHistory || !mirroredIdentities) {
     return undefined;
   }
+  const historyIdentities = normalizedHistory.identities;
   const mirroredBoundaryIndex = mirroredIdentities.get(boundaryIdentity);
   if (mirroredBoundaryIndex === undefined) {
     return undefined;
@@ -86,7 +141,7 @@ function buildCodexSettledTurnFinalizationContext(params: {
     const identity = readMirrorIdentity(mirroredMessage);
     const historyIndex = identity ? historyIdentities.get(identity) : undefined;
     const historyMessage =
-      historyIndex === undefined ? undefined : params.historyMessages[historyIndex];
+      historyIndex === undefined ? undefined : normalizedHistory.messages[historyIndex];
     if (
       historyIndex === undefined ||
       historyIndex <= previousHistoryIndex ||
@@ -103,7 +158,7 @@ function buildCodexSettledTurnFinalizationContext(params: {
   // Clone before returning so later transcript/cache mutation cannot change the
   // exact application evidence authorized for the isolated finalization turn.
   const messages = Object.freeze(
-    structuredClone(params.historyMessages.slice(0, historyBoundaryIndex + 1)),
+    structuredClone(normalizedHistory.messages.slice(0, historyBoundaryIndex + 1)),
   );
   return { source: "openclaw-transcript", messages };
 }

--- a/extensions/codex/src/app-server/settled-turn-finalization.sqlite.test.ts
+++ b/extensions/codex/src/app-server/settled-turn-finalization.sqlite.test.ts
@@ -1,0 +1,201 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import type {
+  AgentMessage,
+  EmbeddedRunAttemptParams,
+} from "openclaw/plugin-sdk/agent-harness-runtime";
+import type { Model } from "openclaw/plugin-sdk/llm";
+import { upsertSessionEntry } from "openclaw/plugin-sdk/session-store-runtime";
+import {
+  appendSessionTranscriptMessageByIdentity,
+  readSessionTranscriptEvents,
+} from "openclaw/plugin-sdk/session-transcript-runtime";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { EmbeddedRunAttemptResult } from "./attempt-terminal.js";
+import { captureCodexSettledTurnFinalizationContext } from "./settled-turn-context.js";
+import { attachCodexMirrorIdentity } from "./upstream-prompt-provenance.js";
+
+const mocks = vi.hoisted(() => ({
+  runBounded: vi.fn(),
+}));
+
+vi.mock("./bounded-turn.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("./bounded-turn.js")>()),
+  runBoundedCodexAppServerTurn: mocks.runBounded,
+}));
+
+const { runCodexSettledTurnFinalization } = await import("./settled-turn-finalizer.js");
+
+const tempDirs: string[] = [];
+
+afterEach(async () => {
+  mocks.runBounded.mockReset();
+  for (const dir of tempDirs.splice(0)) {
+    await fs.rm(dir, { recursive: true, force: true });
+  }
+});
+
+function message(value: unknown, identity: string): AgentMessage {
+  return attachCodexMirrorIdentity(value as AgentMessage, identity);
+}
+
+describe("Codex settled-turn finalization with historical SQLite prompt pairs", () => {
+  it("returns one visible reply without replaying the settled side effect", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-codex-settled-sqlite-"));
+    tempDirs.push(root);
+    const target = {
+      agentId: "main",
+      sessionId: "session-historical-pair",
+      sessionKey: "agent:main:session-historical-pair",
+      storePath: path.join(root, "openclaw-agent.sqlite"),
+    };
+    const sessionFile = `sqlite:${target.agentId}:${target.sessionId}:${target.storePath}`;
+    await upsertSessionEntry({
+      ...target,
+      entry: { sessionFile, sessionId: target.sessionId, updatedAt: 1 },
+    });
+
+    const idempotencyKey = "run-side-effect:user";
+    const mirroredPrompt = message(
+      { role: "user", content: "Send the update.", idempotencyKey, timestamp: 1 },
+      "turn-side-effect:prompt",
+    );
+    const canonicalPrompt = structuredClone(mirroredPrompt);
+    const toolCall = message(
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "toolCall",
+            id: "call-side-effect",
+            name: "message",
+            arguments: { target: "alice" },
+          },
+        ],
+        timestamp: 2,
+      },
+      "turn-side-effect:tool:call-side-effect:call",
+    );
+    const toolResult = message(
+      {
+        role: "toolResult",
+        toolCallId: "call-side-effect",
+        toolName: "message",
+        content: [{ type: "text", text: "sent once" }],
+        timestamp: 3,
+      },
+      "turn-side-effect:tool:call-side-effect:result",
+    );
+    const seeded = [
+      { eventId: "mirror-prompt", parentId: null, message: mirroredPrompt },
+      {
+        eventId: "canonical-prompt",
+        parentId: "mirror-prompt",
+        message: canonicalPrompt,
+        idempotencyLookup: "caller-checked" as const,
+      },
+      { eventId: "tool-call", parentId: "canonical-prompt", message: toolCall },
+      { eventId: "tool-result", parentId: "tool-call", message: toolResult },
+    ];
+    for (const entry of seeded) {
+      await appendSessionTranscriptMessageByIdentity({ ...target, ...entry, cwd: root });
+    }
+
+    const settledMessages = [canonicalPrompt, toolCall, toolResult];
+    const context = await captureCodexSettledTurnFinalizationContext({
+      ...target,
+      sessionFile,
+      mirroredMessages: settledMessages,
+      settledMessages,
+      turnId: "turn-side-effect",
+    });
+    expect(context?.messages).toEqual(settledMessages);
+
+    mocks.runBounded.mockResolvedValue({
+      text: "FINALIZED-WITHOUT-REPLAY",
+      items: [],
+      model: "gpt-5.4",
+      usage: { input: 5, output: 4, cacheRead: 0, cacheWrite: 0, total: 9 },
+    });
+    const attempt = {
+      prompt: "Produce the final user-visible answer now.",
+      ...target,
+      sessionFile,
+      sessionTarget: { storePath: target.storePath },
+      workspaceDir: root,
+      runId: "run-side-effect",
+      timeoutMs: 5_000,
+      provider: "codex",
+      modelId: "gpt-5.4",
+      model: {
+        id: "gpt-5.4",
+        provider: "codex",
+        api: "openai-chatgpt-responses",
+      } as Model,
+      authStorage: {} as never,
+      authProfileStore: { version: 1, profiles: {} },
+      modelRegistry: {} as never,
+      thinkLevel: "low",
+    } as EmbeddedRunAttemptParams;
+    const settledAttempt = {
+      terminal: { kind: "ok" },
+      sessionIdUsed: target.sessionId,
+      messagesSnapshot: settledMessages,
+      settledTurnFinalizationContext: context,
+      lastAssistant: undefined,
+      assistantTexts: [],
+      toolMetas: [{ toolName: "message", replaySafe: false }],
+      didSendViaMessagingTool: true,
+      messagingToolSentTexts: ["update"],
+      messagingToolSentMediaUrls: [],
+      messagingToolSentTargets: [],
+      toolMediaUrls: [],
+      toolAudioAsVoice: false,
+      hasToolMediaBlockReply: false,
+      successfulCronAdds: 0,
+      cloudCodeAssistFormatError: false,
+      replayMetadata: { hadPotentialSideEffects: true, replaySafe: false },
+      currentAttemptReplayMetadata: { hadPotentialSideEffects: true, replaySafe: false },
+      itemLifecycle: { startedCount: 1, completedCount: 1, activeCount: 0 },
+    } as EmbeddedRunAttemptResult;
+
+    const result = await runCodexSettledTurnFinalization(
+      { attempt, settledAttempt },
+      { pluginConfig: {} },
+    );
+
+    expect(result.assistant.content).toEqual([{ type: "text", text: "FINALIZED-WITHOUT-REPLAY" }]);
+    expect(mocks.runBounded).toHaveBeenCalledOnce();
+    expect(mocks.runBounded).toHaveBeenCalledWith(
+      expect.objectContaining({
+        requireNoExternalCapabilities: true,
+        historyItems: [
+          expect.objectContaining({ type: "message", role: "user" }),
+          expect.objectContaining({ type: "function_call", call_id: "call-side-effect" }),
+          expect.objectContaining({ type: "function_call_output", call_id: "call-side-effect" }),
+        ],
+      }),
+    );
+
+    const events = (await readSessionTranscriptEvents(target)) as Array<{
+      id?: string;
+      parentId?: string | null;
+      message?: AgentMessage;
+      type?: string;
+    }>;
+    const messages = events.filter((event) => event.type === "message");
+    expect(messages.map(({ id, parentId }) => ({ id, parentId }))).toEqual([
+      { id: "mirror-prompt", parentId: null },
+      { id: "canonical-prompt", parentId: "mirror-prompt" },
+      { id: "tool-call", parentId: "canonical-prompt" },
+      { id: "tool-result", parentId: "tool-call" },
+      { id: expect.any(String), parentId: "tool-result" },
+    ]);
+    expect(messages.filter((event) => event.message?.role === "toolResult")).toHaveLength(1);
+    expect(messages.at(-1)?.message).toMatchObject({
+      role: "assistant",
+      content: [{ type: "text", text: "FINALIZED-WITHOUT-REPLAY" }],
+    });
+  });
+});


### PR DESCRIPTION
<!--
Optional linked context:
Add a visible `Closes #<issue-number>` or `Related: #<issue-number>` line
below this comment.

Required PR title:
type: user-facing description
Use a parenthesized scope only when it adds clarity:
fix(auth): login redirect loops when session cookie is expired

Types: feat, fix, improve, refactor, docs, chore.
For fixes, describe the user-visible symptom and trigger:
fix: task list fails to load when user has no environments
Avoid implementation details such as:
fix: add null check to task query
-->

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where Codex users with a historical canonical prompt pair in
their SQLite transcript could complete a side-effecting tool call but receive
no final visible reply. Every eligible settled turn reread the transcript, then
rejected finalization because the two parent-linked prompt rows shared one
mirror identity.

## Why This Change Was Made

Settled-turn capture now normalizes only the proven safe pair shape: two
adjacent user prompts with the same `:prompt` mirror identity, the same
non-empty idempotency key, and identical source evidence. It retains the later
SessionManager row in the read-only finalizer projection, so stored parent
links remain intact. Non-adjacent, repeated, payload-divergent, non-prompt, or
idempotency-divergent duplicates still fail closed.

The change deliberately does not mutate historical transcripts, delete either
SQLite row, add a schema migration, or weaken general identity validation.
Preventing future pairs belongs to a broader cross-owner identity reservation
contract and is not included here.

AI-assisted: implementation and validation were completed with Codex, followed
by the repository autoreview skill.

## User Impact

Affected Codex sessions can now produce one visible terminal reply after a
settled tool-only turn without replaying the completed tool side effect.
Unproven duplicate transcript shapes remain ineligible for finalization.

## Evidence

- Seeded a real per-agent SQLite transcript with the historical pair and exact
  parent chain: mirror prompt -> canonical prompt -> tool call -> tool result.
- On unmodified `main`, capture returned no finalization context, so the
  finalizer could not run.
- With this patch, the actual capture and finalizer owner path produced
  `FINALIZED-WITHOUT-REPLAY`, called the capability-disabled bounded finalizer
  once, preserved every seeded parent link, appended the final assistant after
  the tool result, and kept exactly one tool-result row.
- Focused remote proof: 3 files, 27 tests passed.
- Remote `pnpm check:changed`: full fail-safe lanes passed, including project
  typecheck, lint, import cycles, formatting, plugin boundaries, and
  database-first guards.
- Autoreview: clean, no accepted/actionable findings, 0.96 confidence.
- Crabbox proof: Blacksmith Testbox
  `tbx_01kykra3jjwat9508yw01fxhty` (`tidal-crab-32df`),
  https://github.com/openclaw/openclaw/actions/runs/30336687540.
