### PR TITLE
refactor(plugins): remove dead provider test reset

### DIFF
--- a/src/plugins/provider-runtime.test.ts
+++ b/src/plugins/provider-runtime.test.ts
@@ -361,7 +361,6 @@ describe("provider-runtime", () => {
   beforeEach(() => {
     resetPluginRuntimeStateForTest();
     providerRuntimeTesting.clearProviderRuntimePluginCacheForTest();
-    providerRuntimeTesting.resetExternalAuthFallbackWarningCacheForTest();
     resolvePluginProvidersMock.mockReset();
     resolvePluginProvidersMock.mockReturnValue([]);
     isPluginProvidersLoadInFlightMock.mockReset();

--- a/src/plugins/provider-runtime.ts
+++ b/src/plugins/provider-runtime.ts
@@ -155,11 +155,8 @@ export {
   wrapProviderStreamFn,
 };
 
-function resetExternalAuthFallbackWarningCacheForTest(): void {}
-
 export const testing = {
   clearProviderRuntimePluginCacheForTest,
-  resetExternalAuthFallbackWarningCacheForTest,
 } as const;
 
 function resolveProviderPluginsForCatalogHooks(params: {


### PR DESCRIPTION
## What Problem This Solves

Removes a stale provider-runtime test reset that no longer resets any state.

## Why This Change Was Made

The external-auth fallback warning cache was removed previously, leaving an empty test-only function and its sole caller behind. This deletes that dead seam while retaining the real provider runtime cache reset.

## User Impact

No user-visible behavior changes. Tests no longer call a no-op compatibility remnant.

## Evidence

- `src/plugins/provider-runtime.test.ts`: 62 tests passed on Blacksmith Testbox `tbx_01kykscx91cgb1jncy92h4s9tt`
- `pnpm check:changed`: passed on the same Testbox
- `git diff --check`: passed
- Autoreview: clean, correctness 0.99
- Stable patch ID remained identical after rebasing onto current `origin/main`
