### PR TITLE
fix(ui): clarify chat startup status labels

### DIFF
--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -3963,8 +3963,8 @@ export const en: TranslationMap = {
     startupStatus: {
       preparingWorkspace: "Preparing workspace…",
       provisioningEnvironment: "Provisioning environment…",
-      preparingContext: "Preparing context…",
-      startingModel: "Starting model…",
+      preparingContext: "Preparing this turn…",
+      startingModel: "Waiting for a response…",
     },
     outputTokens: "{count} output tokens",
     archivedSessionDisabled: "This session is archived. Unarchive it to continue the conversation.",

--- a/ui/src/pages/chat/components/chat-message.test.ts
+++ b/ui/src/pages/chat/components/chat-message.test.ts
@@ -1614,18 +1614,22 @@ describe("grouped chat rendering", () => {
     expect(container.querySelector(".chat-tasks-status__claw")).toBeNull();
   });
 
-  it("renders the active startup phase with elapsed time", () => {
+  it.each([
+    ["provisioning_environment", "Provisioning environment…"],
+    ["preparing_context", "Preparing this turn…"],
+    ["starting_model", "Waiting for a response…"],
+  ] as const)("renders the %s startup phase with elapsed time", (startupPhase, label) => {
     const container = document.createElement("div");
 
     render(
       renderStreamGroup([{ kind: "reading-indicator", key: "reading", startedAt: 1_000 }], {
-        startupPhase: "provisioning_environment",
+        startupPhase,
       }),
       container,
     );
 
     expect(container.querySelector(".chat-working-indicator__status")?.textContent).toContain(
-      "Provisioning environment…",
+      label,
     );
     expect(container.querySelector(".chat-working-indicator__elapsed")).not.toBeNull();
     expect(


### PR DESCRIPTION
## What Problem This Solves

The Control UI displayed “Preparing context” and “Starting model” on every turn. Those labels can imply that conversation history is being rebuilt or that a new model/thread is starting, even during normal per-turn startup.

## Why This Is The Best Shape

Keep the existing startup phases and telemetry intact, but describe the visible user action instead:

- “Preparing this turn…”
- “Waiting for a response…”

This avoids hiding real progress while removing thread-rotation and context-reset implications from routine turns.

## User Impact

Chat startup progress remains visible without suggesting that OpenClaw is replacing the conversation or restarting the model on every message.

## Evidence

- Focused UI test: 3 passed
- Control UI i18n verification: passed
- Changed-surface checks, UI typecheck, lint, and formatting: passed
- Fresh branch autoreview: no actionable findings
- Remote focused test: https://github.com/openclaw/openclaw/actions/runs/30338374605
- Remote changed gate: https://github.com/openclaw/openclaw/actions/runs/30337891324

No screenshot is included because this is a string-only change with no layout or styling change; the rendered labels are covered by DOM assertions.