### PR TITLE
improve(codex): reduce long-history prompt allocations

### DIFF
--- a/extensions/codex/src/app-server/image-payload-sanitizer.test.ts
+++ b/extensions/codex/src/app-server/image-payload-sanitizer.test.ts
@@ -24,6 +24,87 @@ describe("Codex app-server image payload sanitizer", () => {
     expect(invalidInlineImageText("codex user input")).toContain("invalid inline image data");
   });
 
+  it("returns image-free history by identity", () => {
+    const content = [{ type: "text", text: "hello" }];
+    const message = { role: "user", content, metadata: { retained: true } };
+    const history = [message];
+
+    const sanitized = sanitizeCodexHistoryImagePayloads(history, "codex mirrored history");
+
+    expect(sanitized).toBe(history);
+    expect(sanitized[0]).toBe(message);
+    expect(sanitized[0]?.content).toBe(content);
+  });
+
+  it("copies only ancestors of a repaired image", () => {
+    const untouched = { role: "assistant", content: [{ type: "text", text: "kept" }] };
+    const invalidImage = {
+      role: "toolResult",
+      content: [{ type: "input_image", image_url: "data:image/png;base64,not base64!" }],
+    };
+    const history = [untouched, invalidImage];
+
+    const sanitized = sanitizeCodexHistoryImagePayloads(history, "codex mirrored history");
+
+    expect(sanitized).not.toBe(history);
+    expect(sanitized[0]).toBe(untouched);
+    expect(sanitized[1]).not.toBe(invalidImage);
+    expect(sanitized[1]?.content).toEqual([
+      {
+        type: "input_text",
+        text: "[codex mirrored history] omitted image payload: invalid inline image data",
+      },
+    ]);
+  });
+
+  it("preserves canonical image records and unknown metadata by identity", () => {
+    const nativeImage = {
+      type: "image",
+      mimeType: "image/png",
+      data: PNG_1X1,
+      detail: "original",
+      metadata: { retained: true },
+    };
+    const camelImage = {
+      type: "inputImage",
+      imageUrl: `data:image/png;base64,${PNG_1X1}`,
+      detail: "high",
+    };
+    const snakeImage = {
+      type: "input_image",
+      image_url: "https://example.test/image.png",
+      detail: "low",
+    };
+    const history = [nativeImage, camelImage, snakeImage];
+
+    const sanitized = sanitizeCodexHistoryImagePayloads(history, "codex mirrored history");
+
+    expect(sanitized).toBe(history);
+    expect(sanitized[0]).toBe(nativeImage);
+    expect(sanitized[1]).toBe(camelImage);
+    expect(sanitized[2]).toBe(snakeImage);
+  });
+
+  it("preserves unknown metadata when canonicalizing an image record", () => {
+    const metadata = { retained: true };
+    const image = {
+      type: "image",
+      mimeType: "image/jpeg",
+      data: PNG_1X1,
+      detail: "original",
+      metadata,
+    };
+
+    const sanitized = sanitizeCodexHistoryImagePayloads(image, "codex mirrored history");
+
+    expect(sanitized).not.toBe(image);
+    expect(sanitized).toEqual({
+      ...image,
+      mimeType: "image/png",
+    });
+    expect(sanitized.metadata).toBe(metadata);
+  });
+
   it("scrubs invalid image blocks from mirrored history values", () => {
     expect(
       sanitizeCodexHistoryImagePayloads(

--- a/extensions/codex/src/app-server/image-payload-sanitizer.ts
+++ b/extensions/codex/src/app-server/image-payload-sanitizer.ts
@@ -33,21 +33,26 @@ function sanitizeImageContentRecord(
     const commaIndex = imageUrl.indexOf(",");
     const metadata = imageUrl.slice(INLINE_IMAGE_DATA_URL_PREFIX.length, commaIndex);
     const mime = metadata.split(";")[0] ?? mimeType;
-    return { ...record, mimeType: mime, data: imageUrl.slice(commaIndex + 1) };
+    const data = imageUrl.slice(commaIndex + 1);
+    return record.mimeType === mime && record.data === data
+      ? record
+      : { ...record, mimeType: mime, data };
   }
 
   if (record.type === "inputImage" && typeof record.imageUrl === "string") {
     const imageUrl = sanitizeInlineImageDataUrl(record.imageUrl);
-    return imageUrl
-      ? { ...record, imageUrl }
-      : { type: "inputText", text: invalidInlineImageText(label) };
+    if (!imageUrl) {
+      return { type: "inputText", text: invalidInlineImageText(label) };
+    }
+    return imageUrl === record.imageUrl ? record : { ...record, imageUrl };
   }
 
   if (record.type === "input_image" && typeof record.image_url === "string") {
     const imageUrl = sanitizeInlineImageDataUrl(record.image_url);
-    return imageUrl
-      ? { ...record, image_url: imageUrl }
-      : { type: "input_text", text: invalidInlineImageText(label) };
+    if (!imageUrl) {
+      return { type: "input_text", text: invalidInlineImageText(label) };
+    }
+    return imageUrl === record.image_url ? record : { ...record, image_url: imageUrl };
   }
 
   return undefined;
@@ -56,7 +61,18 @@ function sanitizeImageContentRecord(
 /** Recursively sanitizes all Codex history image shapes while preserving unknown structure. */
 export function sanitizeCodexHistoryImagePayloads<T>(value: T, label: string): T {
   if (Array.isArray(value)) {
-    return value.map((entry) => sanitizeCodexHistoryImagePayloads(entry, label)) as T;
+    let next: unknown[] | undefined;
+    for (let index = 0; index < value.length; index += 1) {
+      const entry = value[index];
+      const sanitized = sanitizeCodexHistoryImagePayloads(entry, label);
+      if (!Object.is(sanitized, entry)) {
+        // Preserve every untouched branch by identity; only ancestors of an
+        // actual image repair should allocate during long-history replay.
+        next ??= value.slice();
+        next[index] = sanitized;
+      }
+    }
+    return (next ?? value) as T;
   }
   if (!isRecord(value)) {
     return value;
@@ -67,9 +83,14 @@ export function sanitizeCodexHistoryImagePayloads<T>(value: T, label: string): T
     return imageRecord as T;
   }
 
-  const next: Record<string, unknown> = {};
-  for (const [key, child] of Object.entries(value)) {
-    next[key] = sanitizeCodexHistoryImagePayloads(child, label);
+  let next: Record<string, unknown> | undefined;
+  for (const key of Object.keys(value)) {
+    const child = value[key];
+    const sanitized = sanitizeCodexHistoryImagePayloads(child, label);
+    if (!Object.is(sanitized, child)) {
+      next ??= { ...value };
+      next[key] = sanitized;
+    }
   }
-  return next as T;
+  return (next ?? value) as T;
 }

--- a/src/agents/embedded-agent-runner/run/attempt.prompt-helpers.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.prompt-helpers.test.ts
@@ -287,6 +287,81 @@ describe("resolvePromptBuildHookResult drain cache", () => {
     forgetPromptBuildDrainCacheForRun("tools-allow-run");
   });
 
+  it("isolates prompt-build message mutation across repeated rebuilds", async () => {
+    hostHookStateMocks.drainPluginNextTurnInjectionContext.mockReset().mockResolvedValue({
+      queuedInjections: [],
+    });
+    const messages = [
+      {
+        role: "user",
+        content: [{ type: "text", text: "authoritative" }],
+        metadata: { retained: true },
+      },
+    ];
+    const observedTexts: unknown[] = [];
+    const runBeforePromptBuild = vi.fn(async (event: { messages: unknown[] }) => {
+      const message = event.messages[0] as {
+        content: Array<{ text: string }>;
+        metadata: { retained: boolean };
+      };
+      observedTexts.push(message.content[0]?.text);
+      message.content[0]!.text = "mutated by plugin";
+      message.metadata.retained = false;
+      return undefined;
+    });
+    const hookRunner = {
+      hasHooks: vi.fn((hookName: string) => hookName === "before_prompt_build"),
+      runBeforePromptBuild,
+    };
+
+    await resolvePromptBuildHookResult({
+      config: {},
+      prompt: "hi",
+      messages,
+      hookCtx: {},
+      hookRunner,
+    });
+    await resolvePromptBuildHookResult({
+      config: {},
+      prompt: "hi again",
+      messages,
+      hookCtx: {},
+      hookRunner,
+    });
+
+    expect(observedTexts).toEqual(["authoritative", "authoritative"]);
+    expect(messages).toEqual([
+      {
+        role: "user",
+        content: [{ type: "text", text: "authoritative" }],
+        metadata: { retained: true },
+      },
+    ]);
+  });
+
+  it("does not clone history when no message-bearing prompt hook applies", async () => {
+    hostHookStateMocks.drainPluginNextTurnInjectionContext.mockReset().mockResolvedValue({
+      queuedInjections: [],
+    });
+    const structuredCloneSpy = vi.spyOn(globalThis, "structuredClone");
+    const hookRunner = {
+      hasHooks: vi.fn((hookName: string) => hookName === "heartbeat_prompt_contribution"),
+      runHeartbeatPromptContribution: vi.fn(async () => undefined),
+      runBeforePromptBuild: vi.fn(async () => undefined),
+    };
+
+    await resolvePromptBuildHookResult({
+      config: {},
+      prompt: "hi",
+      messages: [{ role: "user", content: "history" }],
+      hookCtx: { trigger: "user" },
+      hookRunner,
+    });
+
+    expect(structuredCloneSpy).not.toHaveBeenCalled();
+    structuredCloneSpy.mockRestore();
+  });
+
   it("does not drain global injections or heartbeat contributions for commitment-only runs", async () => {
     hostHookStateMocks.drainPluginNextTurnInjectionContext.mockReset();
     const runAgentTurnPrepare = vi.fn(async () => ({ prependContext: "turn policy" }));

--- a/src/agents/embedded-agent-runner/run/attempt.prompt-helpers.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.prompt-helpers.ts
@@ -125,15 +125,23 @@ export async function resolvePromptBuildHookResult(params: {
   if (runId && !commitmentOnly && !cachedInjections) {
     rememberDrainedInjections(runId, queuedContext.queuedInjections);
   }
+  const runsTurnPrepare = Boolean(
+    params.hookRunner?.runAgentTurnPrepare && params.hookRunner.hasHooks("agent_turn_prepare"),
+  );
+  const runsPromptBuild = Boolean(params.hookRunner?.hasHooks("before_prompt_build"));
+  // Message-bearing plugins receive a fresh deep snapshot for every rebuild.
+  // Without an applicable hook, retaining authoritative history avoids a full copy.
+  const hookMessages =
+    runsTurnPrepare || runsPromptBuild ? structuredClone(params.messages) : params.messages;
   // Hook ordering mirrors the prompt assembly boundary: queued injections first,
   // then prepare/heartbeat contributions, then prompt-build hooks.
   const turnPrepareResult =
-    params.hookRunner?.runAgentTurnPrepare && params.hookRunner.hasHooks("agent_turn_prepare")
+    runsTurnPrepare && params.hookRunner?.runAgentTurnPrepare
       ? await params.hookRunner
           .runAgentTurnPrepare(
             {
               prompt: params.prompt,
-              messages: params.messages,
+              messages: hookMessages,
               queuedInjections: queuedContext.queuedInjections,
             },
             params.hookCtx,
@@ -162,20 +170,21 @@ export async function resolvePromptBuildHookResult(params: {
             return undefined;
           })
       : undefined;
-  const promptBuildResult = params.hookRunner?.hasHooks("before_prompt_build")
-    ? await params.hookRunner
-        .runBeforePromptBuild(
-          {
-            prompt: params.prompt,
-            messages: params.messages,
-          },
-          params.hookCtx,
-        )
-        .catch((hookErr: unknown) => {
-          log.warn(`before_prompt_build hook failed: ${String(hookErr)}`);
-          return undefined;
-        })
-    : undefined;
+  const promptBuildResult =
+    runsPromptBuild && params.hookRunner
+      ? await params.hookRunner
+          .runBeforePromptBuild(
+            {
+              prompt: params.prompt,
+              messages: hookMessages,
+            },
+            params.hookCtx,
+          )
+          .catch((hookErr: unknown) => {
+            log.warn(`before_prompt_build hook failed: ${String(hookErr)}`);
+            return undefined;
+          })
+      : undefined;
   return {
     systemPrompt: promptBuildResult?.systemPrompt,
     ...(promptBuildResult?.toolsAllow !== undefined


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where rebuilding prompts from long Codex histories allocated copies of every array and object during image sanitization, then cloned the complete history even when no message-bearing plugin hook could run. Phaedrus observed roughly 38 MiB and 72 ms for the prompt clone on one long production history.

## Why This Change Was Made

The Codex sanitizer now uses copy-on-write traversal, retaining unchanged branches by identity while still repairing malformed images and preserving supported image shapes and unknown metadata. Prompt assembly still gives message-bearing hooks a fresh deep snapshot on every rebuild, but skips the clone when neither `agent_turn_prepare` nor `before_prompt_build` applies.

The hook contract and sequential hook semantics are unchanged. This does not alter transcript loading or message mirroring.

## User Impact

Long Codex sessions perform substantially less allocation during prompt rebuilding when history images are already valid, especially when no message-bearing prompt hook is installed. Plugins still cannot mutate authoritative history, and malformed image payloads are still repaired.

## Evidence

Blacksmith Testbox proof used realistic 16,000-message histories with 1,024-character payloads over five measured iterations:

| Actual owner path | Baseline median | Candidate median | RSS delta proxy |
| --- | ---: | ---: | ---: |
| Image-free sanitizer | 7.794 ms | 1.328 ms | 24.35 MiB → 2.91 MiB |
| Image-bearing sanitizer | 7.838 ms | 1.403 ms | 26.30 MiB → 3.14 MiB |
| Prompt owner, no message hook | 22.914 ms | 0.084 ms | 161.93 MiB → approximately 0 MiB |

The message-hook path remained isolated (21.452 ms candidate median) and passed mutation assertions on every rebuild.

- Exact-head focused tests: 25 passed across the prompt helper and Codex sanitizer
- Invalid-image replacement, URL-backed image shapes, metadata retention, copy-on-write identity, and repeated plugin mutation isolation covered
- Remote `pnpm check:changed`: passed formatting, API/boundary/storage guards, core and extension typechecks, lint, and import-cycle checks
- Benchmark/proof run: https://github.com/openclaw/openclaw/actions/runs/30335842147
- Exact-head focused run: https://github.com/openclaw/openclaw/actions/runs/30339337580
- Autoreview: clean, no accepted/actionable findings
- AI-assisted: yes; I reviewed and understand the implementation
