### PR TITLE
fix(android): label Wear talk controls

### DIFF
--- a/apps/android/wear/src/main/java/ai/openclaw/wear/WearScreens.kt
+++ b/apps/android/wear/src/main/java/ai/openclaw/wear/WearScreens.kt
@@ -500,6 +500,7 @@ private fun VoiceHomeMode(
   onOpenThread: () -> Unit,
 ) {
   val colors = OpenClawWearTheme.colors
+  val talkContentDescription = stringResource(R.string.talk)
   val realtimeActive = realtimeTalk.active || realtimeCapturing
   val ttsOnly = speaking && !realtimeActive
   val state =
@@ -603,6 +604,7 @@ private fun VoiceHomeMode(
             Modifier
               .align(Alignment.Center)
               .size(92.dp)
+              .semantics { contentDescription = talkContentDescription }
               .combinedClickable(
                 enabled = !dictatePreview,
                 role = Role.Button,
@@ -710,6 +712,7 @@ private fun ThreadVoiceMode(
   onRealtimeTalk: () -> Unit,
 ) {
   val colors = OpenClawWearTheme.colors
+  val talkContentDescription = stringResource(R.string.talk)
   val listState = rememberTransformingLazyColumnState()
   val coroutineScope = rememberCoroutineScope()
   val visibleConversation = conversation.takeLast(VISIBLE_REALTIME_ENTRY_COUNT)
@@ -855,7 +858,9 @@ private fun ThreadVoiceMode(
               width = 1.dp,
               color = colors.voiceAccent,
               shape = CircleShape,
-            ).clickable(
+            ).semantics {
+              contentDescription = talkContentDescription
+            }.clickable(
               enabled = realtimeActive || (inputEnabled && !actionBusy),
               role = Role.Button,
               onClick = onRealtimeTalk,


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Wear OS users relying on TalkBack would encounter two unlabeled icon-only Talk controls in the voice home and thread views.

## Why This Change Was Made

Both Talk controls now expose the existing localized `talk` string through Compose semantics while retaining their current button roles and interaction behavior.

## User Impact

TalkBack can announce the Talk action in the selected Wear OS language instead of presenting an unnamed control.

## Evidence

- Wear compile passed.
- Android lint and ktlint passed.
- Android i18n verification passed.
- `git diff --check` passed.
- Fresh branch autoreview found no accepted or actionable findings.
- No physical-device TalkBack proof was run; the current Wear module has no focused Compose semantics test seam.
