### PR TITLE
fix(apple): localize gateway discovery status

### DIFF
--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -35474,16 +35474,16 @@
       "id": "native.apple.de453cb637c46670"
     },
     {
-      "kind": "conditional-branch",
-      "line": 190,
+      "kind": "ui-localized-call",
+      "line": 193,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "1 gateway found on your network — click to choose it.",
       "surface": "apple",
       "id": "native.apple.9ab228a4cb7d4403"
     },
     {
-      "kind": "conditional-branch",
-      "line": 191,
+      "kind": "ui-localized-call",
+      "line": 194,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "\\(count) gateways found on your network — click to choose one.",
       "surface": "apple",
@@ -35491,7 +35491,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 205,
+      "line": 208,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "No gateways found on your network yet.",
       "surface": "apple",
@@ -35499,7 +35499,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 208,
+      "line": 211,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Look again",
       "surface": "apple",
@@ -35507,7 +35507,7 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 213,
+      "line": 216,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Retry discovery (Bonjour + Tailscale DNS-SD).",
       "surface": "apple",
@@ -35515,7 +35515,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 242,
+      "line": 245,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Advanced…",
       "surface": "apple",
@@ -35523,7 +35523,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 360,
+      "line": 363,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Remote connection",
       "surface": "apple",
@@ -35531,7 +35531,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 362,
+      "line": 365,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Verify OpenClaw can reach this gateway.",
       "surface": "apple",
@@ -35539,7 +35539,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 375,
+      "line": 378,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Check connection",
       "surface": "apple",
@@ -35547,7 +35547,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 417,
+      "line": 420,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Advanced options",
       "surface": "apple",
@@ -35555,7 +35555,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 417,
+      "line": 420,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Hide advanced options",
       "surface": "apple",
@@ -35563,7 +35563,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 436,
+      "line": 439,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Gateway token",
       "surface": "apple",
@@ -35571,7 +35571,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 439,
+      "line": 442,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Paste the token from your gateway",
       "surface": "apple",
@@ -35579,7 +35579,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 446,
+      "line": 449,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Only needed when the gateway requires token auth.",
       "surface": "apple",
@@ -35587,7 +35587,7 @@
     },
     {
       "kind": "ui-call-concatenated",
-      "line": 455,
+      "line": 458,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "The current gateway.remote.token value is not plain text. OpenClaw for macOS cannot use it directly; enter a plaintext token here to replace it.",
       "surface": "apple",
@@ -35595,7 +35595,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 473,
+      "line": 476,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Transport",
       "surface": "apple",
@@ -35603,7 +35603,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 474,
+      "line": 477,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "SSH tunnel",
       "surface": "apple",
@@ -35611,7 +35611,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 475,
+      "line": 478,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Direct (ws/wss)",
       "surface": "apple",
@@ -35619,7 +35619,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 483,
+      "line": 486,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Gateway URL",
       "surface": "apple",
@@ -35627,7 +35627,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 486,
+      "line": 489,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "wss://gateway.example.ts.net",
       "surface": "apple",
@@ -35635,7 +35635,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 493,
+      "line": 496,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "SSH target",
       "surface": "apple",
@@ -35643,7 +35643,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 513,
+      "line": 516,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Identity file",
       "surface": "apple",
@@ -35651,7 +35651,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 516,
+      "line": 519,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "/Users/you/.ssh/id_ed25519",
       "surface": "apple",
@@ -35659,7 +35659,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 521,
+      "line": 524,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Project root",
       "surface": "apple",
@@ -35667,7 +35667,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 524,
+      "line": 527,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "/home/you/Projects/openclaw",
       "surface": "apple",
@@ -35675,7 +35675,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 529,
+      "line": 532,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "CLI path",
       "surface": "apple",
@@ -35683,7 +35683,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 532,
+      "line": 535,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "/Applications/OpenClaw.app/.../openclaw",
       "surface": "apple",
@@ -35691,7 +35691,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 543,
+      "line": 546,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Tip: use Tailscale Serve so the gateway has a valid HTTPS cert.",
       "surface": "apple",
@@ -35699,7 +35699,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 544,
+      "line": 547,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Tip: keep Tailscale enabled so your gateway stays reachable.",
       "surface": "apple",
@@ -35707,7 +35707,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 558,
+      "line": 561,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Checking remote gateway…",
       "surface": "apple",
@@ -35715,7 +35715,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 690,
+      "line": 693,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": " · ssh \\(parsed.port)",
       "surface": "apple",
@@ -35723,7 +35723,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 759,
+      "line": 762,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Grant permissions",
       "surface": "apple",
@@ -35731,7 +35731,7 @@
     },
     {
       "kind": "ui-call-concatenated",
-      "line": 766,
+      "line": 769,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "These macOS permissions let OpenClaw automate apps and capture context on this Mac. Status updates automatically.",
       "surface": "apple",
@@ -35739,7 +35739,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 801,
+      "line": 804,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Getting things ready",
       "surface": "apple",
@@ -35747,7 +35747,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 812,
+      "line": 815,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Install OpenClaw",
       "surface": "apple",
@@ -35755,7 +35755,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 819,
+      "line": 822,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Prepare the Mac node",
       "surface": "apple",
@@ -35763,7 +35763,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 819,
+      "line": 822,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Start the background service",
       "surface": "apple",
@@ -35771,7 +35771,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 821,
+      "line": 824,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Runs inside the app and uses its macOS permissions.",
       "surface": "apple",
@@ -35779,7 +35779,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 822,
+      "line": 825,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Runs quietly and starts again after a restart.",
       "surface": "apple",
@@ -35787,7 +35787,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 825,
+      "line": 828,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Ready for the next step",
       "surface": "apple",
@@ -35795,7 +35795,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 827,
+      "line": 830,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Once ready, this Mac connects to your selected Gateway.",
       "surface": "apple",
@@ -35803,7 +35803,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 828,
+      "line": 831,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Once the service answers, you’ll connect your AI.",
       "surface": "apple",
@@ -35811,7 +35811,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 833,
+      "line": 836,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "The Gateway didn’t start",
       "surface": "apple",
@@ -35819,7 +35819,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 836,
+      "line": 839,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Try again",
       "surface": "apple",
@@ -35827,7 +35827,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 927,
+      "line": 930,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "You’re all set!",
       "surface": "apple",
@@ -35835,7 +35835,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 930,
+      "line": 933,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Finish opens the chat — say hi to your new agent.",
       "surface": "apple",
@@ -35843,7 +35843,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 938,
+      "line": 941,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Configure later",
       "surface": "apple",
@@ -35851,7 +35851,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 939,
+      "line": 942,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Pick Local or Remote in Settings → General whenever you’re ready.",
       "surface": "apple",
@@ -35859,7 +35859,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 946,
+      "line": 949,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Remote gateway checklist",
       "surface": "apple",
@@ -35867,7 +35867,7 @@
     },
     {
       "kind": "ui-named-argument-multiline",
-      "line": 947,
+      "line": 950,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "On your gateway host: install/update the `openclaw` package and make sure credentials exist\n(typically `~/.openclaw/credentials/oauth.json`). Then connect again if needed.",
       "surface": "apple",
@@ -35875,7 +35875,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 956,
+      "line": 959,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Open the menu bar panel",
       "surface": "apple",
@@ -35883,7 +35883,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 957,
+      "line": 960,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Click the OpenClaw menu bar icon for the compact chat panel and status.",
       "surface": "apple",
@@ -35891,7 +35891,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 960,
+      "line": 963,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Connect Discord, Slack, Telegram, WhatsApp, …",
       "surface": "apple",
@@ -35899,7 +35899,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 961,
+      "line": 964,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Open Settings → Channels to link channels and monitor status.",
       "surface": "apple",
@@ -35907,7 +35907,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 963,
+      "line": 966,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Open Settings → Channels",
       "surface": "apple",
@@ -35915,7 +35915,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 968,
+      "line": 971,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Try Voice Wake",
       "surface": "apple",
@@ -35923,7 +35923,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 969,
+      "line": 972,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Enable Voice Wake in Settings for hands-free commands with a live transcript overlay.",
       "surface": "apple",
@@ -35931,7 +35931,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 972,
+      "line": 975,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Use the panel + Canvas",
       "surface": "apple",
@@ -35939,7 +35939,7 @@
     },
     {
       "kind": "ui-named-argument-concatenated",
-      "line": 973,
+      "line": 976,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Open the compact chat panel; the agent can show previews and richer visuals in Canvas.",
       "surface": "apple",
@@ -35947,7 +35947,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 977,
+      "line": 980,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Give your agent more powers",
       "surface": "apple",
@@ -35955,7 +35955,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 978,
+      "line": 981,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Enable optional skills (Peekaboo, oracle, camsnap, …) from Settings → Skills.",
       "surface": "apple",
@@ -35963,7 +35963,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 980,
+      "line": 983,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Open Settings → Skills",
       "surface": "apple",
@@ -35971,7 +35971,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 985,
+      "line": 988,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Launch at login",
       "surface": "apple",
@@ -35979,7 +35979,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1012,
+      "line": 1015,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Skills included",
       "surface": "apple",
@@ -35987,7 +35987,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1019,
+      "line": 1022,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Refresh",
       "surface": "apple",
@@ -35995,7 +35995,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1028,
+      "line": 1031,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Couldn’t load skills from the Gateway.",
       "surface": "apple",
@@ -36003,7 +36003,7 @@
     },
     {
       "kind": "ui-call-concatenated",
-      "line": 1031,
+      "line": 1034,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Make sure the Gateway is running and connected, then hit Refresh (or open Settings → Skills).",
       "surface": "apple",
@@ -36011,7 +36011,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1037,
+      "line": 1040,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Details: \\(error)",
       "surface": "apple",
@@ -36019,7 +36019,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1043,
+      "line": 1046,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "No skills reported yet.",
       "surface": "apple",
@@ -42490,20 +42490,52 @@
       "id": "native.apple.2ace7dd34f4ca3a2"
     },
     {
-      "kind": "conditional-branch",
-      "line": 7,
+      "kind": "ui-localized-call",
+      "line": 6,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayDiscoveryStatusText.swift",
       "source": "Idle",
       "surface": "apple",
       "id": "native.apple.a825441f646eb195"
     },
     {
-      "kind": "conditional-branch",
-      "line": 7,
+      "kind": "ui-localized-call",
+      "line": 10,
+      "path": "apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayDiscoveryStatusText.swift",
+      "source": "Stopped",
+      "surface": "apple",
+      "id": "native.apple.a2fc153a4aa36cda"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 23,
+      "path": "apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayDiscoveryStatusText.swift",
+      "source": "Failed",
+      "surface": "apple",
+      "id": "native.apple.ba2d6adb6ce70b40"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 32,
+      "path": "apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayDiscoveryStatusText.swift",
+      "source": "Waiting",
+      "surface": "apple",
+      "id": "native.apple.f343c1f83109a369"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 53,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayDiscoveryStatusText.swift",
       "source": "Setup",
       "surface": "apple",
       "id": "native.apple.0cb1206714c2bf4d"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 56,
+      "path": "apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayDiscoveryStatusText.swift",
+      "source": "Searching…",
+      "surface": "apple",
+      "id": "native.apple.e6c1304a30abf56e"
     },
     {
       "kind": "conditional-branch",

--- a/apps/ios/Sources/Gateway/GatewayDiscoveryModel.swift
+++ b/apps/ios/Sources/Gateway/GatewayDiscoveryModel.swift
@@ -45,7 +45,7 @@ final class GatewayDiscoveryModel {
     }
 
     var gateways: [DiscoveredGateway] = []
-    var statusText: String = "Idle"
+    var statusText: String = GatewayDiscoveryStatusText.idle
     private(set) var debugLog: [DebugLogEntry] = []
 
     private var browsers: [String: NWBrowser] = [:]
@@ -125,7 +125,7 @@ final class GatewayDiscoveryModel {
         self.gatewaysByDomain = [:]
         self.statesByDomain = [:]
         self.gateways = []
-        self.statusText = "Stopped"
+        self.statusText = GatewayDiscoveryStatusText.stopped
     }
 
     private func recomputeGateways() {

--- a/apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift
+++ b/apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift
@@ -184,11 +184,14 @@ extension OnboardingView {
     }
 
     private var remoteChoiceSubtitle: String {
-        let count = gatewayDiscovery.gateways.count
+        Self.remoteChoiceSubtitle(discoveredGatewayCount: gatewayDiscovery.gateways.count)
+    }
+
+    static func remoteChoiceSubtitle(discoveredGatewayCount count: Int) -> String {
         if count > 0 {
             return count == 1
-                ? "1 gateway found on your network — click to choose it."
-                : "\(count) gateways found on your network — click to choose one."
+                ? String(localized: "1 gateway found on your network — click to choose it.")
+                : String(localized: "\(count) gateways found on your network — click to choose one.")
         }
         return "For advanced setups — use a gateway that runs elsewhere."
     }

--- a/apps/macos/Sources/OpenClawDiscovery/GatewayDiscoveryModel.swift
+++ b/apps/macos/Sources/OpenClawDiscovery/GatewayDiscoveryModel.swift
@@ -69,7 +69,7 @@ public final class GatewayDiscoveryModel {
     }
 
     public var gateways: [DiscoveredGateway] = []
-    public var statusText: String = "Idle"
+    public var statusText: String = GatewayDiscoveryStatusText.idle
 
     private var browsers: [String: NWBrowser] = [:]
     private var resultsByDomain: [String: Set<NWBrowser.Result>] = [:]
@@ -170,7 +170,7 @@ public final class GatewayDiscoveryModel {
         self.tailscaleServeFallbackTask = nil
         self.tailscaleServeFallbackGateways = []
         self.gateways = []
-        self.statusText = "Stopped"
+        self.statusText = GatewayDiscoveryStatusText.stopped
     }
 
     private func mapWideAreaBeacons(_ beacons: [WideAreaGatewayBeacon], domain: String) -> [DiscoveredGateway] {

--- a/apps/macos/Tests/OpenClawIPCTests/OnboardingViewSmokeTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/OnboardingViewSmokeTests.swift
@@ -32,6 +32,15 @@ private func makeOnboardingResumeDefaults() throws -> (UserDefaults, String) {
 @Suite(.serialized)
 @MainActor
 struct OnboardingViewSmokeTests {
+    @Test func `discovered gateway summary uses localized runtime strings`() {
+        #expect(
+            OnboardingView.remoteChoiceSubtitle(discoveredGatewayCount: 1) ==
+                "1 gateway found on your network — click to choose it.")
+        #expect(
+            OnboardingView.remoteChoiceSubtitle(discoveredGatewayCount: 2) ==
+                "2 gateways found on your network — click to choose one.")
+    }
+
     @Test func `onboarding view builds body`() {
         let state = AppState(preview: true)
         let view = OnboardingView(

--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayDiscoveryStatusText.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayDiscoveryStatusText.swift
@@ -2,9 +2,17 @@ import Foundation
 import Network
 
 public enum GatewayDiscoveryStatusText {
+    public static var idle: String {
+        String(localized: "Idle")
+    }
+
+    public static var stopped: String {
+        String(localized: "Stopped")
+    }
+
     public static func make(states: [NWBrowser.State], hasBrowsers: Bool) -> String {
         if states.isEmpty {
-            return hasBrowsers ? "Setup" : "Idle"
+            return hasBrowsers ? String(localized: "Setup") : self.idle
         }
 
         if let failed = states.first(where: { state in
@@ -12,7 +20,7 @@ public enum GatewayDiscoveryStatusText {
             return false
         }) {
             if case let .failed(err) = failed {
-                return "Failed: \(err)"
+                return "\(String(localized: "Failed")): \(err)"
             }
         }
 
@@ -21,7 +29,7 @@ public enum GatewayDiscoveryStatusText {
             return false
         }) {
             if case let .waiting(err) = waiting {
-                return "Waiting: \(err)"
+                return "\(String(localized: "Waiting")): \(err)"
             }
         }
 
@@ -32,7 +40,7 @@ public enum GatewayDiscoveryStatusText {
                 false
             }
         }) {
-            return "Searching…"
+            return String(localized: "Searching…")
         }
 
         if states.contains(where: {
@@ -42,9 +50,9 @@ public enum GatewayDiscoveryStatusText {
                 false
             }
         }) {
-            return "Setup"
+            return String(localized: "Setup")
         }
 
-        return "Searching…"
+        return String(localized: "Searching…")
     }
 }

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/GatewayDiscoveryStatusTextTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/GatewayDiscoveryStatusTextTests.swift
@@ -1,0 +1,28 @@
+import Network
+import Testing
+@testable import OpenClawKit
+
+struct GatewayDiscoveryStatusTextTests {
+    @Test func `discovery states return localized presentation copy`() {
+        #expect(GatewayDiscoveryStatusText.make(states: [], hasBrowsers: false) == "Idle")
+        #expect(GatewayDiscoveryStatusText.make(states: [], hasBrowsers: true) == "Setup")
+        #expect(GatewayDiscoveryStatusText.make(states: [.ready], hasBrowsers: true) == "Searching…")
+        #expect(GatewayDiscoveryStatusText.stopped == "Stopped")
+    }
+
+    @Test func `discovery failures preserve network error detail`() {
+        let failedError = NWError.posix(.ETIMEDOUT)
+        let waitingError = NWError.posix(.ENETDOWN)
+        let failed = GatewayDiscoveryStatusText.make(
+            states: [.failed(failedError)],
+            hasBrowsers: true)
+        let waiting = GatewayDiscoveryStatusText.make(
+            states: [.waiting(waitingError)],
+            hasBrowsers: true)
+
+        #expect(failed.hasPrefix("Failed: "))
+        #expect(failed.hasSuffix(String(describing: failedError)))
+        #expect(waiting.hasPrefix("Waiting: "))
+        #expect(waiting.hasSuffix(String(describing: waitingError)))
+    }
+}

--- a/scripts/apple-app-i18n.ts
+++ b/scripts/apple-app-i18n.ts
@@ -42,6 +42,8 @@ const IOS_CONTRADICTIONS_PATH = "apps/.i18n/apple-translation-contradictions.jso
 const NATIVE_SOURCE_PATH = "apps/.i18n/native-source.json";
 const NATIVE_TRANSLATIONS_DIR = "apps/.i18n/native";
 const SHARED_CHAT_UI_SOURCE_PREFIX = "apps/shared/OpenClawKit/Sources/OpenClawChatUI/";
+const SHARED_GATEWAY_DISCOVERY_STATUS_SOURCE =
+  "apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayDiscoveryStatusText.swift";
 const IOS_SOURCE_PREFIXES = [
   "apps/ios/",
   SHARED_CHAT_UI_SOURCE_PREFIX,
@@ -65,6 +67,7 @@ const IOS_CATALOG_EXCLUSIONS = new Set([
 const MACOS_SOURCE_PREFIXES = [
   "apps/macos/Sources/OpenClaw/",
   SHARED_CHAT_UI_SOURCE_PREFIX,
+  SHARED_GATEWAY_DISCOVERY_STATUS_SOURCE,
 ] as const;
 const MACOS_CATALOG_EXCLUSIONS = new Set([
   // Product names are intentionally verbatim.

--- a/test/scripts/apple-app-i18n.test.ts
+++ b/test/scripts/apple-app-i18n.test.ts
@@ -68,6 +68,29 @@ describe("Apple app i18n catalogs", () => {
     expect(APPLE_I18N_LOCALES).toEqual(NATIVE_I18N_LOCALES);
   });
 
+  it("derives shared discovery status coverage into the iOS catalog", async () => {
+    const inventory = JSON.parse(await readFile("apps/.i18n/native-source.json", "utf8")) as {
+      entries: Array<{
+        id: string;
+        kind: string;
+        line: number;
+        path: string;
+        source: string;
+        surface: string;
+      }>;
+      version: number;
+    };
+    const build = buildIosCatalog(
+      { sourceLanguage: "en", strings: {}, version: "1.0" },
+      inventory,
+      [],
+    );
+
+    expect(Object.keys(build.catalog.strings ?? {})).toEqual(
+      expect.arrayContaining(["Searching…", "Stopped", "Waiting"]),
+    );
+  });
+
   it("derives broad macOS catalog coverage from the native source inventory", async () => {
     const inventory = JSON.parse(await readFile("apps/.i18n/native-source.json", "utf8")) as {
       entries: Array<{

--- a/test/scripts/apple-app-i18n.test.ts
+++ b/test/scripts/apple-app-i18n.test.ts
@@ -95,8 +95,11 @@ describe("Apple app i18n catalogs", () => {
         "Enable debug tools",
         "Everyday OpenClaw app behavior.",
         "General",
+        "Searching…",
         "Shelling",
+        "Stopped",
         "Voice Wake requires macOS 26 or newer",
+        "Waiting",
       ]),
     );
     expect(keys).not.toContain("OpenClaw");


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where iOS and macOS users with a non-English system language would still see English gateway discovery states and discovered-gateway onboarding summaries.

## Why This Change Was Made

Gateway discovery state copy now uses runtime localization in the shared Apple owner, and the macOS onboarding count summaries use their existing localized catalog entries. Catalog generation covers the shared discovery status owner for both iOS and macOS, with regression tests locking both derived catalogs. Translated and platform-generated outputs remain owned by the native locale refresh workflow.

## User Impact

Idle, stopped, setup, failure, waiting, searching, and discovered-gateway summary copy can follow the selected Apple system language on both iOS and macOS.

## Evidence

- `GatewayDiscoveryStatusTextTests`: 2 focused tests passed.
- `OnboardingViewSmokeTests`: 28 focused tests passed.
- Apple catalog generator tests: 17 passed, including iOS and macOS shared discovery ownership.
- Native app i18n extraction/check passed across 21 translated locales during generation.
- Current head passes the CI changed-scope classifier and `git diff --check`.
- Targeted SwiftFormat and oxfmt checks passed.
- Fresh autoreview found the missing explicit iOS ownership proof; the focused test was added and the rerun was clean with no accepted or actionable findings.
