### PR TITLE
fix(plugins): report missing plugin modules as missing, not boundary escapes

### DIFF
--- a/src/channels/plugins/bundled.ts
+++ b/src/channels/plugins/bundled.ts
@@ -329,7 +329,6 @@ function loadGeneratedBundledChannelModule(params: {
     return loadChannelPluginModule({
       modulePath,
       rootDir: boundaryRoot,
-      boundaryRootDir: boundaryRoot,
     });
   } catch (error) {
     const canRetryWithCachedLoader =

--- a/src/channels/plugins/module-loader.test.ts
+++ b/src/channels/plugins/module-loader.test.ts
@@ -7,7 +7,7 @@ import { fileURLToPath } from "node:url";
 import { importFreshModule } from "openclaw/plugin-sdk/test-fixtures";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { isJavaScriptModulePath } from "../../plugins/native-module-require.js";
-import { resolveExistingPluginModulePath } from "./module-loader.js";
+import { loadChannelPluginModule, resolveExistingPluginModulePath } from "./module-loader.js";
 
 const tempDirs: string[] = [];
 const testRequire = createRequire(import.meta.url);
@@ -49,6 +49,34 @@ describe("channel plugin module loader helpers", () => {
     expect(isJavaScriptModulePath("/tmp/entry.js")).toBe(true);
     expect(isJavaScriptModulePath("/tmp/entry.MJS")).toBe(true);
     expect(isJavaScriptModulePath("/tmp/entry.ts")).toBe(false);
+  });
+
+  it("reports a missing plugin module as not found instead of a boundary escape", () => {
+    const rootDir = createTempDir();
+    const modulePath = path.join(rootDir, "dist", "extensions", "demo", "auth-presence.js");
+
+    let thrown: unknown;
+    try {
+      loadChannelPluginModule({ modulePath, rootDir });
+    } catch (error) {
+      thrown = error;
+    }
+
+    expect(thrown).toBeInstanceOf(Error);
+    expect((thrown as Error).message).toBe(`plugin module path not found: ${modulePath}`);
+    expect((thrown as Error).message).not.toContain("escapes");
+    expect(((thrown as Error).cause as NodeJS.ErrnoException | undefined)?.code).toBe("ENOENT");
+  });
+
+  it("still reports a module outside the plugin root as a boundary escape", () => {
+    const rootDir = createTempDir();
+    const outsideDir = createTempDir();
+    const modulePath = path.join(outsideDir, "evil.cjs");
+    fs.writeFileSync(modulePath, "module.exports = { ok: true };\n", "utf8");
+
+    expect(() => loadChannelPluginModule({ modulePath, rootDir })).toThrow(
+      `plugin module path escapes plugin root or fails alias checks: ${modulePath}`,
+    );
   });
 
   it("uses native require for eligible JavaScript modules without creating Jiti", async () => {

--- a/src/channels/plugins/module-loader.ts
+++ b/src/channels/plugins/module-loader.ts
@@ -6,7 +6,7 @@
 import fs from "node:fs";
 import { createRequire } from "node:module";
 import path from "node:path";
-import { openRootFileSync } from "../../infra/boundary-file-read.js";
+import { describeRootFileOpenFailure, openRootFileSync } from "../../infra/boundary-file-read.js";
 import { isJavaScriptModulePath } from "../../plugins/native-module-require.js";
 import {
   getCachedPluginModuleLoader,
@@ -96,23 +96,28 @@ export function resolveExistingPluginModulePath(rootDir: string, specifier: stri
 
 /**
  * Loads a channel plugin module after enforcing plugin-root file boundaries.
+ *
+ * `rootDir` is always the plugin's own directory, so the containment failure is
+ * reported against that one root; no caller boundary override exists.
  */
-export function loadChannelPluginModule(params: {
-  modulePath: string;
-  rootDir: string;
-  boundaryRootDir?: string;
-  boundaryLabel?: string;
-}): unknown {
+export function loadChannelPluginModule(params: { modulePath: string; rootDir: string }): unknown {
+  const boundaryLabel = "plugin root";
   const opened = openRootFileSync({
     absolutePath: params.modulePath,
-    rootPath: params.boundaryRootDir ?? params.rootDir,
-    boundaryLabel: params.boundaryLabel ?? "plugin root",
+    rootPath: params.rootDir,
+    boundaryLabel,
     rejectHardlinks: false,
     skipLexicalRootCheck: true,
   });
   if (!opened.ok) {
     throw new Error(
-      `${params.boundaryLabel ?? "plugin"} module path escapes plugin root or fails alias checks`,
+      describeRootFileOpenFailure({
+        failure: opened,
+        subject: "plugin module path",
+        boundaryLabel,
+        filePath: params.modulePath,
+      }),
+      { cause: opened.error },
     );
   }
   const safePath = opened.path;

--- a/src/channels/plugins/package-state-probes.test.ts
+++ b/src/channels/plugins/package-state-probes.test.ts
@@ -13,6 +13,7 @@ const listChannelCatalogEntriesMock = vi.hoisted(() => vi.fn());
 const isBundledSourceOverlayPathMock = vi.hoisted(() =>
   vi.fn((_params: { sourcePath: string }) => false),
 );
+const probeLogWarnMock = vi.hoisted(() => vi.fn());
 const tempDirs: string[] = [];
 
 vi.mock("../../plugins/channel-catalog-registry.js", () => ({
@@ -21,6 +22,16 @@ vi.mock("../../plugins/channel-catalog-registry.js", () => ({
 vi.mock("../../plugins/bundled-source-overlays.js", () => ({
   isBundledSourceOverlayPath: isBundledSourceOverlayPathMock,
 }));
+vi.mock("../../logging/subsystem.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../logging/subsystem.js")>();
+  return {
+    ...actual,
+    createSubsystemLogger: (subsystem: string) => ({
+      ...actual.createSubsystemLogger(subsystem),
+      warn: probeLogWarnMock,
+    }),
+  };
+});
 
 function makeBundledChannelCatalogEntry(params: {
   pluginId: string;
@@ -52,6 +63,7 @@ beforeEach(() => {
   listChannelCatalogEntriesMock.mockReset();
   isBundledSourceOverlayPathMock.mockReset();
   isBundledSourceOverlayPathMock.mockReturnValue(false);
+  probeLogWarnMock.mockReset();
 });
 
 afterEach(() => {
@@ -295,6 +307,42 @@ describe("channel package-state probes", () => {
         cfg: {},
       }),
     ).toBe(true);
+  });
+
+  it("reports a missing built package-state artifact as not found, not a boundary escape", () => {
+    // Reproduces a rebuild window: the catalog root is the built plugin dir while
+    // `dist/extensions/<id>` has not been re-emitted yet.
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-package-state-missing-"));
+    tempDirs.push(root);
+    const builtRoot = path.join(root, "dist", "extensions", "matrix");
+    fs.mkdirSync(builtRoot, { recursive: true });
+
+    listChannelCatalogEntriesMock.mockReturnValue([
+      {
+        pluginId: "matrix",
+        origin: "bundled",
+        rootDir: builtRoot,
+        channel: {
+          id: "matrix",
+          persistedAuthState: {
+            specifier: "./auth-presence",
+            exportName: "hasAnyMatrixAuth",
+          },
+        },
+      } satisfies PluginChannelCatalogEntry,
+    ]);
+
+    expect(
+      hasBundledChannelPackageState({
+        metadataKey: "persistedAuthState",
+        channelId: "matrix",
+        cfg: {},
+      }),
+    ).toBe(false);
+    const warning = String(probeLogWarnMock.mock.calls.at(0)?.[0] ?? "");
+    expect(warning).toContain("failed to load persistedAuthState checker for matrix");
+    expect(warning).toContain(`plugin module path not found: ${builtRoot}`);
+    expect(warning).not.toContain("escapes plugin root");
   });
 
   it("tries dist-runtime package-state probes before falling back to source", () => {

--- a/src/infra/boundary-file-read.test.ts
+++ b/src/infra/boundary-file-read.test.ts
@@ -17,7 +17,7 @@ describe("root file open shim", () => {
   });
 
   it("separates missing, unreadable, and boundary-violating open failures", () => {
-    const describe_ = (failure: upstream.RootFileOpenFailure) =>
+    const messageFor = (failure: upstream.RootFileOpenFailure) =>
       shim.describeRootFileOpenFailure({
         failure,
         subject: "plugin entry path",
@@ -26,14 +26,14 @@ describe("root file open shim", () => {
       });
 
     expect(
-      describe_({
+      messageFor({
         ok: false,
         reason: "path",
         error: Object.assign(new Error("nope"), { code: "ENOENT" }),
       }),
     ).toBe("plugin entry path not found: /plugins/demo/index.js");
     expect(
-      describe_({
+      messageFor({
         ok: false,
         reason: "path",
         error: Object.assign(new Error("nope"), { code: "ENOTDIR" }),
@@ -41,17 +41,17 @@ describe("root file open shim", () => {
     ).toBe("plugin entry path not found: /plugins/demo/index.js");
     // fs-safe also reports symlink loops as `path`; those are unreadable, not absent.
     expect(
-      describe_({
+      messageFor({
         ok: false,
         reason: "path",
         error: Object.assign(new Error("loop"), { code: "ELOOP" }),
       }),
     ).toBe("plugin entry path could not be read (ELOOP): /plugins/demo/index.js");
-    expect(describe_({ ok: false, reason: "validation" })).toBe(
+    expect(messageFor({ ok: false, reason: "validation" })).toBe(
       "plugin entry path escapes plugin root or fails alias checks: /plugins/demo/index.js",
     );
     expect(
-      describe_({
+      messageFor({
         ok: false,
         reason: "io",
         error: Object.assign(new Error("io"), { code: "EACCES" }),

--- a/src/infra/boundary-file-read.test.ts
+++ b/src/infra/boundary-file-read.test.ts
@@ -16,6 +16,49 @@ describe("root file open shim", () => {
     expect(shim.openRootFileSync).toBe(upstream.openRootFileSync);
   });
 
+  it("separates missing, unreadable, and boundary-violating open failures", () => {
+    const describe_ = (failure: upstream.RootFileOpenFailure) =>
+      shim.describeRootFileOpenFailure({
+        failure,
+        subject: "plugin entry path",
+        boundaryLabel: "plugin root",
+        filePath: "/plugins/demo/index.js",
+      });
+
+    expect(
+      describe_({
+        ok: false,
+        reason: "path",
+        error: Object.assign(new Error("nope"), { code: "ENOENT" }),
+      }),
+    ).toBe("plugin entry path not found: /plugins/demo/index.js");
+    expect(
+      describe_({
+        ok: false,
+        reason: "path",
+        error: Object.assign(new Error("nope"), { code: "ENOTDIR" }),
+      }),
+    ).toBe("plugin entry path not found: /plugins/demo/index.js");
+    // fs-safe also reports symlink loops as `path`; those are unreadable, not absent.
+    expect(
+      describe_({
+        ok: false,
+        reason: "path",
+        error: Object.assign(new Error("loop"), { code: "ELOOP" }),
+      }),
+    ).toBe("plugin entry path could not be read (ELOOP): /plugins/demo/index.js");
+    expect(describe_({ ok: false, reason: "validation" })).toBe(
+      "plugin entry path escapes plugin root or fails alias checks: /plugins/demo/index.js",
+    );
+    expect(
+      describe_({
+        ok: false,
+        reason: "io",
+        error: Object.assign(new Error("io"), { code: "EACCES" }),
+      }),
+    ).toBe("plugin entry path could not be read (EACCES): /plugins/demo/index.js");
+  });
+
   it("preserves the existing overflow error for fs-safe descriptor reads", async () => {
     const dir = tempDirs.make("openclaw-boundary-file-read-");
     const filePath = path.join(dir, "oversized.txt");

--- a/src/infra/boundary-file-read.ts
+++ b/src/infra/boundary-file-read.ts
@@ -1,8 +1,10 @@
 // Exposes root-scoped file open helpers with fs-safe defaults.
 import "./fs-safe-defaults.js";
 import {
+  matchRootFileOpenFailure as matchRootFileOpenFailureFsSafe,
   readFileDescriptorBounded as readFileDescriptorBoundedFsSafe,
   readFileDescriptorBoundedSync as readFileDescriptorBoundedSyncFsSafe,
+  type RootFileOpenFailure,
 } from "@openclaw/fs-safe/advanced";
 import { FsSafeError } from "@openclaw/fs-safe/errors";
 
@@ -16,6 +18,43 @@ export {
   type RootFileOpenFailure,
   type RootFileOpenResult,
 } from "@openclaw/fs-safe/advanced";
+
+// fs-safe folds ENOENT, ENOTDIR, and ELOOP into its `path` reason. Only the
+// first two mean the artifact is absent; a symlink loop is an unreadable path.
+const MISSING_PATH_ERROR_CODES: ReadonlySet<string> = new Set(["ENOENT", "ENOTDIR"]);
+
+function readFailureErrorCode(error: unknown): string | undefined {
+  const code = error && typeof error === "object" ? (error as { code?: unknown }).code : undefined;
+  return typeof code === "string" && code ? code : undefined;
+}
+
+/**
+ * Describes a root-scoped open failure without collapsing every cause into a
+ * containment violation. Only `validation` means the path failed the boundary or
+ * alias check; a missing artifact or an unreadable descriptor is an ordinary
+ * operational state, and reporting those as escapes sends operators hunting a
+ * security incident that never happened.
+ */
+export function describeRootFileOpenFailure(params: {
+  failure: RootFileOpenFailure;
+  subject: string;
+  boundaryLabel: string;
+  filePath: string;
+}): string {
+  const unreadable = (code?: string) =>
+    `${params.subject} could not be read${code ? ` (${code})` : ""}: ${params.filePath}`;
+  return matchRootFileOpenFailureFsSafe(params.failure, {
+    path: (failure) => {
+      const code = readFailureErrorCode(failure.error);
+      return code && !MISSING_PATH_ERROR_CODES.has(code)
+        ? unreadable(code)
+        : `${params.subject} not found: ${params.filePath}`;
+    },
+    validation: () =>
+      `${params.subject} escapes ${params.boundaryLabel} or fails alias checks: ${params.filePath}`,
+    fallback: (failure) => unreadable(readFailureErrorCode(failure.error)),
+  });
+}
 
 function preserveOpenClawOverflowError(error: unknown, maxBytes: number): never {
   if (error instanceof FsSafeError && error.code === "too-large") {

--- a/src/plugins/bundled-capability-runtime.ts
+++ b/src/plugins/bundled-capability-runtime.ts
@@ -1,7 +1,7 @@
 /** Loads capability providers from bundled plugin public runtime artifacts. */
 import fs from "node:fs";
 import { fileURLToPath } from "node:url";
-import { openRootFileSync } from "../infra/boundary-file-read.js";
+import { describeRootFileOpenFailure, openRootFileSync } from "../infra/boundary-file-read.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import {
   withBundledPluginEnablementCompat,
@@ -277,10 +277,11 @@ export function loadBundledCapabilityRuntimeRegistry(params: {
       workspaceDir: candidate.workspaceDir,
     });
 
+    const boundaryLabel = record.source === candidate.source ? "plugin root" : "repo root";
     const opened = openRootFileSync({
       absolutePath: record.source,
       rootPath: record.source === candidate.source ? candidate.rootDir : repoRoot,
-      boundaryLabel: record.source === candidate.source ? "plugin root" : "repo root",
+      boundaryLabel,
       rejectHardlinks: false,
       skipLexicalRootCheck: true,
     });
@@ -288,7 +289,12 @@ export function loadBundledCapabilityRuntimeRegistry(params: {
       recordCapabilityLoadError(
         registry,
         record,
-        "plugin entry path escapes plugin root or fails alias checks",
+        describeRootFileOpenFailure({
+          failure: opened,
+          subject: "plugin entry path",
+          boundaryLabel,
+          filePath: record.source,
+        }),
       );
       continue;
     }

--- a/src/plugins/loader-channel-runtime.ts
+++ b/src/plugins/loader-channel-runtime.ts
@@ -1,6 +1,6 @@
 import fs from "node:fs";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
-import { openRootFileSync } from "../infra/boundary-file-read.js";
+import { describeRootFileOpenFailure, openRootFileSync } from "../infra/boundary-file-read.js";
 import type { NormalizedPluginsConfig } from "./config-state.js";
 import {
   channelPluginIdBelongsToManifest,
@@ -114,7 +114,14 @@ export function loadSetupRuntimeChannelCandidate(params: {
       skipLexicalRootCheck: true,
     });
     if (!runtimeOpened.ok) {
-      params.pushPluginLoadError("plugin entry path escapes plugin root or fails alias checks");
+      params.pushPluginLoadError(
+        describeRootFileOpenFailure({
+          failure: runtimeOpened,
+          subject: "plugin entry path",
+          boundaryLabel: "plugin root",
+          filePath: runtimeModuleSource,
+        }),
+      );
       return true;
     }
     const safeRuntimeSource = runtimeOpened.path;

--- a/src/plugins/loader-cli-registry.ts
+++ b/src/plugins/loader-cli-registry.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import type { GatewayRequestHandler } from "../gateway/server-methods/types.js";
-import { openRootFileSync } from "../infra/boundary-file-read.js";
+import { describeRootFileOpenFailure, openRootFileSync } from "../infra/boundary-file-read.js";
 import { resolveUserPath } from "../utils.js";
 import { buildPluginApi } from "./api-builder.js";
 import {
@@ -224,7 +224,14 @@ export async function loadOpenClawPluginCliRegistry(
       skipLexicalRootCheck: true,
     });
     if (!opened.ok) {
-      pushPluginLoadError("plugin entry path escapes plugin root or fails alias checks");
+      pushPluginLoadError(
+        describeRootFileOpenFailure({
+          failure: opened,
+          subject: "plugin entry path",
+          boundaryLabel: "plugin root",
+          filePath: sourceForCliMetadata,
+        }),
+      );
       continue;
     }
     const safeSource = opened.path;

--- a/src/plugins/loader-runtime-candidate.ts
+++ b/src/plugins/loader-runtime-candidate.ts
@@ -1,5 +1,5 @@
 import fs from "node:fs";
-import { openRootFileSync } from "../infra/boundary-file-read.js";
+import { describeRootFileOpenFailure, openRootFileSync } from "../infra/boundary-file-read.js";
 import { inspectBundleMcpRuntimeSupport } from "./bundle-mcp.js";
 import {
   resolveEffectiveEnableState,
@@ -372,7 +372,14 @@ export function loadRuntimePluginCandidate(params: {
     skipLexicalRootCheck: true,
   });
   if (!opened.ok) {
-    pushPluginLoadError("plugin entry path escapes plugin root or fails alias checks");
+    pushPluginLoadError(
+      describeRootFileOpenFailure({
+        failure: opened,
+        subject: "plugin entry path",
+        boundaryLabel: "plugin root",
+        filePath: moduleLoadSource,
+      }),
+    );
     return;
   }
   const safeSource = opened.path;


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where operators reading gateway logs were told a plugin had
violated its security boundary when in fact a plugin file was simply missing.

On a live gateway, `[channels] failed to load persistedAuthState checker for
matrix: plugin module path escapes plugin root or fails alias checks` was logged
11 times. Matrix had not escaped anything: `dist/extensions/matrix/` was being
re-emitted by a build at that moment, so the artifact did not exist yet. The
warnings stopped by themselves once the build finished, but they read as a
containment violation and cost real triage time. While the message was
appearing, Matrix's linked/auth status was unknowable.

## Why This Change Was Made

`openRootFileSync` already returns a classified failure — `path` (ENOENT /
ENOTDIR / ELOOP), `validation` (containment, alias, type, or hardlink
rejection), or `io`. Five plugin loader call sites discarded that classification
and reported a single hardcoded "escapes plugin root or fails alias checks"
string for every failure, so absence and I/O errors were indistinguishable from
an actual escape.

A shared `describeRootFileOpenFailure` helper in `src/infra/boundary-file-read.ts`
now maps the failure onto three distinct messages and every site includes the
offending path. Missing is reserved for `ENOENT`/`ENOTDIR`; a symlink loop
reports as unreadable rather than absent, because fs-safe folds `ELOOP` into the
same `path` reason.

**The containment check itself is untouched.** No boundary is loosened, widened,
or special-cased — `openRootFileSync` is called with the same arguments and a
genuine escape still produces the same wording it always did. Only the reported
reason changes.

Two dead parameters on `loadChannelPluginModule` are removed in the same change:
no caller ever passed `boundaryLabel`, and the single caller that passed
`boundaryRootDir` set it equal to `rootDir`. `resolveBundledChannelBoundaryRoot`
always resolves to the plugin's own directory, so there is exactly one root and
one correct label.

Non-goal: this does not add a dist→source fallback when a built artifact is
missing. A built plugin root is meant to be self-contained, and the transient
build window is not a state to paper over.

## User Impact

Operators triaging gateway logs get an accurate reason. A missing plugin
artifact now reads `plugin module path not found: <path>`, an unreadable one
reads `plugin entry path could not be read (EACCES): <path>`, and only a real
containment or alias failure reads `escapes plugin root`. Errors also carry the
underlying cause, and every message names the path involved.

No behavior change for plugin loading itself: the same files load, the same
files are rejected.

## Evidence

After-fix behavior on this branch, captured on a Blacksmith Testbox
([run](https://github.com/openclaw/openclaw/actions/runs/30345262635)) against a
throwaway `/tmp` plugin root. Ephemeral `mkdtemp` paths only; no real plugin
roots, endpoints, credentials, or private identifiers:

```
plugin root: <TMP>/dist/extensions/matrix

1. built artifact not yet emitted (the production case)
  -> plugin module path not found: /tmp/probe-MHtVzh/dist/extensions/matrix/auth-presence.js
     cause: ENOENT

2. module outside the plugin root (genuine escape)
  -> plugin module path escapes plugin root or fails alias checks: /tmp/probe-MHtVzh/elsewhere/evil.cjs
     cause: none

3. artifact present
  -> loaded {"ok":true}
```

Case 1 is the shape that produced the 11 production warnings; before this change
it read `plugin module path escapes plugin root or fails alias checks`. Case 2
confirms a genuine escape keeps the original wording, so the security signal is
not diluted. Case 3 confirms loading is unaffected.

Root cause confirmed on the affected host, read-only:

- All 11 warnings fall between `01:03:35` and `01:05:10` local; `dist/extensions/matrix`
  was written at `01:05:18`. None after.
- Replaying the exact resolution on that host after the build finished
  (`loadChannelPluginModule` against the same catalog `rootDir`
  `dist/extensions/matrix`, specifier `./auth-presence`) loads cleanly and
  exports `hasAnyMatrixAuth` — the manifest and the boundary check were both
  correct all along.
- fs-safe `openPinnedFileSync` returns `{ ok: false, reason: "path" }` for
  `ENOENT`, which the old code rendered as an escape.

Regression tests:

- `src/infra/boundary-file-read.test.ts` — the classifier separates
  ENOENT/ENOTDIR (missing), ELOOP (unreadable), `io` (unreadable, coded), and
  `validation` (boundary escape).
- `src/channels/plugins/module-loader.test.ts` — a missing module reports "not
  found" with an `ENOENT` cause; a module outside the plugin root still reports
  the escape.
- `src/channels/plugins/package-state-probes.test.ts` — reproduces the observed
  scenario end to end: built catalog root with a not-yet-emitted artifact
  produces `failed to load persistedAuthState checker for matrix: plugin module
  path not found: …` and never says `escapes plugin root`.

Local: `node scripts/run-vitest.mjs src/infra/boundary-file-read.test.ts
src/channels/plugins/module-loader.test.ts
src/channels/plugins/package-state-probes.test.ts src/channels/plugins/bundled`
— 4 files, 43 tests passed.

Gates: `node scripts/check-changed.mjs` delegated to Blacksmith Testbox,
exit 0 (import-cycle, sidecar-loader, database-first, pairing, webhook and
related guards all green).

Review: fresh Codex autoreview (`gpt-5.6-sol`, xhigh) — first pass raised the
ELOOP misclassification and the boundary-label question, both addressed above;
rerun returned `autoreview clean: no accepted/actionable findings reported`.
