### PR TITLE
fix(security): harden CodeQL-reported boundaries

### DIFF
--- a/apps/android/app/src/main/assets/katex/renderer.js
+++ b/apps/android/app/src/main/assets/katex/renderer.js
@@ -23,8 +23,12 @@ window.renderMath = async (job) => {
     await new Promise((resolve) => setTimeout(resolve, 0));
     const finalBounds = container.getBoundingClientRect();
     const height = Math.ceil(Math.max(finalBounds.height, container.scrollHeight));
-    ChatMathBridge.onRenderComplete(job.id, width, height, true);
+    window.ChatMathBridge.postMessage(
+      JSON.stringify({ id: job.id, widthCssPx: width, heightCssPx: height, success: true }),
+    );
   } catch (_) {
-    ChatMathBridge.onRenderComplete(job.id, 0, 0, false);
+    window.ChatMathBridge.postMessage(
+      JSON.stringify({ id: job.id, widthCssPx: 0, heightCssPx: 0, success: false }),
+    );
   }
 };

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMathRenderer.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMathRenderer.kt
@@ -7,13 +7,13 @@ import android.content.Context
 import android.content.ContextWrapper
 import android.graphics.Bitmap
 import android.graphics.Canvas
+import android.net.Uri
 import android.os.Bundle
 import android.os.Handler
 import android.os.Looper
 import android.util.LruCache
 import android.view.View
 import android.view.ViewGroup
-import android.webkit.JavascriptInterface
 import android.webkit.RenderProcessGoneDetail
 import android.webkit.WebResourceRequest
 import android.webkit.WebResourceResponse
@@ -43,11 +43,21 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.sp
 import androidx.core.graphics.createBitmap
-import androidx.core.net.toUri
+import androidx.webkit.JavaScriptReplyProxy
+import androidx.webkit.WebMessageCompat
+import androidx.webkit.WebViewAssetLoader
+import androidx.webkit.WebViewCompat
+import androidx.webkit.WebViewFeature
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.booleanOrNull
+import kotlinx.serialization.json.doubleOrNull
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
 import org.json.JSONObject
 import java.io.ByteArrayInputStream
 import java.lang.ref.WeakReference
 import java.util.Locale
+import kotlin.math.ceil
 import android.graphics.Color as AndroidColor
 
 private const val MATH_BITMAP_CACHE_BYTES = 4 * 1024 * 1024
@@ -56,8 +66,11 @@ private const val MATH_RENDER_TIMEOUT_MS = 3000L
 private const val MATH_WIDTH_BUCKET_PX = 64
 private const val MATH_MAX_BITMAP_DIMENSION = 8192
 private const val MATH_MAX_BITMAP_PIXELS = MATH_BITMAP_CACHE_BYTES / 4
-private const val KATEX_ASSET_ROOT = "file:///android_asset/katex/"
+private const val KATEX_ASSET_HOST = "appassets.androidplatform.net"
+private const val KATEX_ORIGIN = "https://$KATEX_ASSET_HOST"
+private const val KATEX_ASSET_ROOT = "$KATEX_ORIGIN/assets/katex/"
 private const val KATEX_SHELL_URL = "${KATEX_ASSET_ROOT}index.html"
+private const val KATEX_BRIDGE_NAME = "ChatMathBridge"
 
 internal data class ChatMathRenderKey(
   val latex: String,
@@ -286,6 +299,47 @@ private data class RenderStyle(
 private val ChatMathRenderRequest.renderStyle: RenderStyle
   get() = RenderStyle(textColor = textColor, fontSizePx = fontSizePx, density = density)
 
+internal data class ChatMathRenderMessage(
+  val id: String,
+  val widthCssPx: Double,
+  val heightCssPx: Double,
+  val success: Boolean,
+)
+
+internal fun parseChatMathRenderMessage(payload: String?): ChatMathRenderMessage? =
+  runCatching {
+    val value = Json.parseToJsonElement(payload.orEmpty()).jsonObject
+    val id =
+      value["id"]
+        ?.jsonPrimitive
+        ?.takeIf { primitive -> primitive.isString }
+        ?.content
+        ?: return@runCatching null
+    val widthCssPx = value["widthCssPx"]?.jsonPrimitive?.doubleOrNull ?: return@runCatching null
+    val heightCssPx = value["heightCssPx"]?.jsonPrimitive?.doubleOrNull ?: return@runCatching null
+    val success = value["success"]?.jsonPrimitive?.booleanOrNull ?: return@runCatching null
+    ChatMathRenderMessage(
+      id = id,
+      widthCssPx = widthCssPx,
+      heightCssPx = heightCssPx,
+      success = success,
+    )
+  }.getOrNull()
+
+internal fun bitmapDimension(
+  cssPixels: Double,
+  density: Float,
+): Int? {
+  val scale = density.toDouble()
+  if (!cssPixels.isFinite() || cssPixels <= 0.0 || !scale.isFinite() || scale <= 0.0) return null
+  if (cssPixels > MATH_MAX_BITMAP_DIMENSION.toDouble() / scale) return null
+  val pixels = ceil(cssPixels * scale)
+  return pixels
+    .takeIf { value ->
+      value.isFinite() && value in 1.0..MATH_MAX_BITMAP_DIMENSION.toDouble()
+    }?.toInt()
+}
+
 /** Process-singleton entry point. Its sole WebView and all queue state stay on the main thread. */
 internal object ChatMathRenderer {
   private val handler = Handler(Looper.getMainLooper())
@@ -332,6 +386,11 @@ private class ChatMathWebViewBackend(
   host: ViewGroup,
 ) : ChatMathRenderBackend<Bitmap> {
   private val mainHandler = Handler(Looper.getMainLooper())
+  private val assetLoader =
+    WebViewAssetLoader
+      .Builder()
+      .addPathHandler("/assets/", WebViewAssetLoader.AssetsPathHandler(application))
+      .build()
   private var ready = false
   private var nextRenderId = 0L
   private var active: ActiveRender? = null
@@ -376,7 +435,10 @@ private class ChatMathWebViewBackend(
     request: ChatMathRenderRequest,
     completion: (ChatMathRenderResult<Bitmap>) -> Unit,
   ) {
-    if (host.get() == null) {
+    if (
+      host.get() == null ||
+        !WebViewFeature.isFeatureSupported(WebViewFeature.WEB_MESSAGE_LISTENER)
+    ) {
       completion(ChatMathRenderResult.TransientFailure)
       return
     }
@@ -389,73 +451,88 @@ private class ChatMathWebViewBackend(
   // rejects every URL outside the asset root, and receives LaTeX as a JSON value rather than HTML.
   @SuppressLint("SetJavaScriptEnabled")
   @Suppress("DEPRECATION")
-  private fun createWebView(context: Context): WebView =
-    WebView(context).apply {
-      alpha = 0f
-      visibility = View.VISIBLE
-      isClickable = false
-      setBackgroundColor(AndroidColor.TRANSPARENT)
-      setLayerType(View.LAYER_TYPE_SOFTWARE, null)
-      setWillNotDraw(false)
-      settings.apply {
-        javaScriptEnabled = true
-        allowFileAccess = true
-        allowContentAccess = false
-        allowFileAccessFromFileURLs = false
-        allowUniversalAccessFromFileURLs = false
-        blockNetworkLoads = true
-        domStorageEnabled = false
-        databaseEnabled = false
-        cacheMode = WebSettings.LOAD_NO_CACHE
-        mixedContentMode = WebSettings.MIXED_CONTENT_NEVER_ALLOW
-        offscreenPreRaster = true
-      }
-      addJavascriptInterface(RenderBridge(), "ChatMathBridge")
-      webViewClient =
-        object : WebViewClient() {
-          override fun shouldInterceptRequest(
-            view: WebView?,
-            request: WebResourceRequest?,
-          ): WebResourceResponse? {
-            val url = request?.url?.toString().orEmpty()
-            return if (isAllowedAssetUrl(url)) null else emptyResponse()
-          }
-
-          override fun shouldOverrideUrlLoading(
-            view: WebView?,
-            request: WebResourceRequest?,
-          ): Boolean = !isAllowedAssetUrl(request?.url?.toString().orEmpty())
-
-          override fun onPageFinished(
-            view: WebView?,
-            url: String?,
-          ) {
-            if (url == KATEX_SHELL_URL) {
-              ready = true
-              evaluateActiveRender()
-            }
-          }
-
-          override fun onRenderProcessGone(
-            view: WebView,
-            detail: RenderProcessGoneDetail,
-          ): Boolean {
-            if (webView !== view) return true
-            val interrupted = active
-            active = null
-            ready = false
-            (view.parent as? ViewGroup)?.removeView(view)
-            view.destroy()
-            mainHandler.post {
-              webView = createWebView(application)
-              attachWebView(webView)
-              interrupted?.completion?.invoke(ChatMathRenderResult.TransientFailure)
-            }
-            return true
-          }
+  private fun createWebView(context: Context): WebView {
+    val view =
+      WebView(context).apply {
+        alpha = 0f
+        visibility = View.VISIBLE
+        isClickable = false
+        setBackgroundColor(AndroidColor.TRANSPARENT)
+        setLayerType(View.LAYER_TYPE_SOFTWARE, null)
+        setWillNotDraw(false)
+        settings.apply {
+          javaScriptEnabled = true
+          allowFileAccess = false
+          allowContentAccess = false
+          allowFileAccessFromFileURLs = false
+          allowUniversalAccessFromFileURLs = false
+          blockNetworkLoads = true
+          domStorageEnabled = false
+          databaseEnabled = false
+          cacheMode = WebSettings.LOAD_NO_CACHE
+          mixedContentMode = WebSettings.MIXED_CONTENT_NEVER_ALLOW
+          offscreenPreRaster = true
         }
-      loadUrl(KATEX_SHELL_URL)
+        webViewClient =
+          object : WebViewClient() {
+            override fun shouldInterceptRequest(
+              view: WebView?,
+              request: WebResourceRequest?,
+            ): WebResourceResponse? {
+              val url = request?.url ?: return emptyResponse()
+              if (!isAllowedAssetUrl(url)) return emptyResponse()
+              return assetLoader.shouldInterceptRequest(url) ?: emptyResponse()
+            }
+
+            override fun shouldOverrideUrlLoading(
+              view: WebView?,
+              request: WebResourceRequest?,
+            ): Boolean = !isAllowedAssetUrl(request?.url)
+
+            override fun onPageFinished(
+              view: WebView?,
+              url: String?,
+            ) {
+              if (
+                url == KATEX_SHELL_URL &&
+                  WebViewFeature.isFeatureSupported(WebViewFeature.WEB_MESSAGE_LISTENER)
+              ) {
+                ready = true
+                evaluateActiveRender()
+              }
+            }
+
+            override fun onRenderProcessGone(
+              view: WebView,
+              detail: RenderProcessGoneDetail,
+            ): Boolean {
+              if (webView !== view) return true
+              val interrupted = active
+              active = null
+              ready = false
+              (view.parent as? ViewGroup)?.removeView(view)
+              removeRenderMessageListener(view)
+              view.destroy()
+              mainHandler.post {
+                webView = createWebView(application)
+                attachWebView(webView)
+                interrupted?.completion?.invoke(ChatMathRenderResult.TransientFailure)
+              }
+              return true
+            }
+          }
+      }
+    if (WebViewFeature.isFeatureSupported(WebViewFeature.WEB_MESSAGE_LISTENER)) {
+      WebViewCompat.addWebMessageListener(
+        view,
+        KATEX_BRIDGE_NAME,
+        setOf(KATEX_ORIGIN),
+        RenderMessageBridge(),
+      )
+      view.loadUrl(KATEX_SHELL_URL)
     }
+    return view
+  }
 
   private fun attachWebView(view: WebView) {
     val currentHost = host.get() ?: return
@@ -497,32 +574,31 @@ private class ChatMathWebViewBackend(
     webView.evaluateJavascript("window.renderMath($payload);", null)
   }
 
-  private inner class RenderBridge {
-    @JavascriptInterface
-    fun onRenderComplete(
-      id: String,
-      widthCssPx: Double,
-      heightCssPx: Double,
-      success: Boolean,
+  private inner class RenderMessageBridge : WebViewCompat.WebMessageListener {
+    override fun onPostMessage(
+      view: WebView,
+      message: WebMessageCompat,
+      sourceOrigin: Uri,
+      isMainFrame: Boolean,
+      replyProxy: JavaScriptReplyProxy,
     ) {
+      if (!isMainFrame || !isTrustedKatexOrigin(sourceOrigin)) return
+      val renderMessage = parseChatMathRenderMessage(message.data) ?: return
       mainHandler.post {
-        val render = active?.takeIf { item -> item.id == id } ?: return@post
+        val render = active?.takeIf { item -> item.id == renderMessage.id } ?: return@post
         val density = render.request.density
-        if (!success) {
+        if (!renderMessage.success) {
           active = null
           render.completion(ChatMathRenderResult.Failure)
           return@post
         }
-        val width =
-          kotlin.math
-            .ceil(widthCssPx * density)
-            .toInt()
-            .coerceAtLeast(1)
-        val height =
-          kotlin.math
-            .ceil(heightCssPx * density)
-            .toInt()
-            .coerceAtLeast(1)
+        val width = bitmapDimension(renderMessage.widthCssPx, density)
+        val height = bitmapDimension(renderMessage.heightCssPx, density)
+        if (width == null || height == null) {
+          active = null
+          render.completion(ChatMathRenderResult.Failure)
+          return@post
+        }
         if (!isSafeBitmapSize(width, height)) {
           active = null
           render.completion(ChatMathRenderResult.Failure)
@@ -536,7 +612,7 @@ private class ChatMathWebViewBackend(
         webView.layout(0, 0, width, height)
         webView.scrollTo(0, 0)
         webView.postVisualStateCallback(
-          id.toLong(),
+          render.id.toLong(),
           object : WebView.VisualStateCallback() {
             override fun onComplete(requestId: Long) {
               val current = active?.takeIf { item -> item.id == requestId.toString() } ?: return
@@ -564,6 +640,12 @@ private class ChatMathWebViewBackend(
     }
   }
 
+  private fun removeRenderMessageListener(view: WebView) {
+    if (WebViewFeature.isFeatureSupported(WebViewFeature.WEB_MESSAGE_LISTENER)) {
+      WebViewCompat.removeWebMessageListener(view, KATEX_BRIDGE_NAME)
+    }
+  }
+
   private data class ActiveRender(
     val id: String,
     val request: ChatMathRenderRequest,
@@ -578,14 +660,13 @@ private tailrec fun Context.findActivity(): Activity? =
     else -> null
   }
 
-private fun isAllowedAssetUrl(url: String): Boolean =
-  runCatching {
-    val uri = url.toUri()
-    uri.scheme == "file" &&
-      uri.host.isNullOrEmpty() &&
-      uri.path.orEmpty().startsWith("/android_asset/katex/") &&
-      uri.pathSegments.none { segment -> segment == ".." }
-  }.getOrDefault(false)
+private fun isTrustedKatexOrigin(uri: Uri): Boolean = uri.scheme == "https" && uri.host == KATEX_ASSET_HOST && uri.port == -1
+
+private fun isAllowedAssetUrl(uri: Uri?): Boolean =
+  uri != null &&
+    isTrustedKatexOrigin(uri) &&
+    uri.path.orEmpty().startsWith("/assets/katex/") &&
+    uri.pathSegments.none { segment -> segment == ".." }
 
 private fun emptyResponse(): WebResourceResponse = WebResourceResponse("text/plain", Charsets.UTF_8.name(), ByteArrayInputStream(ByteArray(0)))
 

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMathRenderer.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMathRenderer.kt
@@ -437,7 +437,7 @@ private class ChatMathWebViewBackend(
   ) {
     if (
       host.get() == null ||
-        !WebViewFeature.isFeatureSupported(WebViewFeature.WEB_MESSAGE_LISTENER)
+      !WebViewFeature.isFeatureSupported(WebViewFeature.WEB_MESSAGE_LISTENER)
     ) {
       completion(ChatMathRenderResult.TransientFailure)
       return
@@ -495,7 +495,7 @@ private class ChatMathWebViewBackend(
             ) {
               if (
                 url == KATEX_SHELL_URL &&
-                  WebViewFeature.isFeatureSupported(WebViewFeature.WEB_MESSAGE_LISTENER)
+                WebViewFeature.isFeatureSupported(WebViewFeature.WEB_MESSAGE_LISTENER)
               ) {
                 ready = true
                 evaluateActiveRender()

--- a/apps/android/app/src/test/java/ai/openclaw/app/ui/chat/ChatMathRendererTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/ui/chat/ChatMathRendererTest.kt
@@ -2,6 +2,7 @@ package ai.openclaw.app.ui.chat
 
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertNull
 import org.junit.Test
 
 class ChatMathRendererTest {
@@ -121,6 +122,33 @@ class ChatMathRendererTest {
     assertEquals(emptyList<ChatMathRenderResult<String>>(), retryResults)
     harness.backend.complete(ChatMathRenderResult.Success("fresh"))
     assertEquals(listOf(ChatMathRenderResult.Success("fresh")), retryResults)
+  }
+
+  @Test
+  fun parsesStructuredRenderCompletionMessages() {
+    assertEquals(
+      ChatMathRenderMessage(
+        id = "7",
+        widthCssPx = 12.5,
+        heightCssPx = 8.0,
+        success = true,
+      ),
+      parseChatMathRenderMessage(
+        """{"id":"7","widthCssPx":12.5,"heightCssPx":8,"success":true}""",
+      ),
+    )
+    assertNull(parseChatMathRenderMessage("""{"id":"7"}"""))
+  }
+
+  @Test
+  fun bitmapDimensionsRejectNonFiniteNonPositiveAndOversizedValues() {
+    assertEquals(25, bitmapDimension(cssPixels = 12.5, density = 2f))
+    assertNull(bitmapDimension(cssPixels = Double.NaN, density = 1f))
+    assertNull(bitmapDimension(cssPixels = Double.POSITIVE_INFINITY, density = 1f))
+    assertNull(bitmapDimension(cssPixels = 0.0, density = 1f))
+    assertNull(bitmapDimension(cssPixels = 1.0, density = Float.NaN))
+    assertNull(bitmapDimension(cssPixels = 8193.0, density = 1f))
+    assertNull(bitmapDimension(cssPixels = 4097.0, density = 2f))
   }
 
   private class RenderHarness {

--- a/extensions/qa-lab/src/confidence-report.test.ts
+++ b/extensions/qa-lab/src/confidence-report.test.ts
@@ -132,6 +132,32 @@ describe("qa confidence report", () => {
     expect(report.lanes[1]).toMatchObject({ id: "optional-missing", status: "missing" });
   });
 
+  it("escapes backslashes before Markdown table delimiters", async () => {
+    const report = await buildQaConfidenceReport({
+      manifest: {
+        version: 1,
+        profile: "codex-100",
+        lanes: [
+          {
+            id: "missing",
+            title: "Missing",
+            kind: "qa-suite-summary",
+            artifact: "missing/qa-suite-summary.json",
+            required: true,
+            missingVerdict: "environment-blocked",
+            missingReason: String.raw`path\|fallback unavailable`,
+          },
+        ],
+      },
+      artifactRoot: tempRoot,
+      generatedAt: "2026-05-13T00:00:00.000Z",
+    });
+
+    expect(renderQaConfidenceMarkdownReport(report)).toContain(
+      String.raw`path\\\|fallback unavailable`,
+    );
+  });
+
   it("fails strict global pass when any lane is blocked, missing, unknown, or classified failed", async () => {
     await writeJson("classified/qa-suite-summary.json", {
       counts: { total: 1, passed: 0, skipped: 0, failed: 1 },

--- a/extensions/qa-lab/src/confidence-report.ts
+++ b/extensions/qa-lab/src/confidence-report.ts
@@ -954,7 +954,7 @@ function formatVerdict(lane: QaConfidenceLaneResult): string {
 }
 
 function escapeTableCell(value: string): string {
-  return value.replace(/\|/gu, "\\|").replace(/\s+/gu, " ").trim();
+  return value.replace(/\\/gu, "\\\\").replace(/\|/gu, "\\|").replace(/\s+/gu, " ").trim();
 }
 
 export function renderQaConfidenceMarkdownReport(report: QaConfidenceReport): string {

--- a/extensions/qa-lab/src/tool-coverage-report.test.ts
+++ b/extensions/qa-lab/src/tool-coverage-report.test.ts
@@ -142,7 +142,7 @@ describe("qa tool coverage report", () => {
             capabilityLayer: "codex-native-workspace",
             required: true,
             tracking: "#80236",
-            reason: "tracked | runtime drift",
+            reason: String.raw`tracked \| runtime drift`,
             codexDefaultImpact: "P2 | default",
             qaImpact: "P1 | confidence",
             action: "fix | backfill",
@@ -158,7 +158,7 @@ describe("qa tool coverage report", () => {
     expect(markdown).toContain("P2 \\| default");
     expect(markdown).toContain("P1 \\| confidence");
     expect(markdown).toContain("fix \\| backfill");
-    expect(markdown).toContain("#80236 tracked \\| runtime drift");
+    expect(markdown).toContain(String.raw`#80236 tracked \\\| runtime drift`);
   });
 
   it("keeps tracking metadata independent from required coverage metrics", () => {

--- a/extensions/qa-lab/src/tool-coverage-report.ts
+++ b/extensions/qa-lab/src/tool-coverage-report.ts
@@ -385,5 +385,5 @@ export function renderQaToolCoverageMarkdownReport(report: QaToolCoverageReport)
 }
 
 function escapeTableCell(value: string): string {
-  return value.replace(/\|/gu, "\\|").replace(/\s+/gu, " ").trim();
+  return value.replace(/\\/gu, "\\\\").replace(/\|/gu, "\\|").replace(/\s+/gu, " ").trim();
 }

--- a/scripts/transitive-manifest-risk-report.mjs
+++ b/scripts/transitive-manifest-risk-report.mjs
@@ -48,7 +48,7 @@ function isAllowedPinnedSpec(spec) {
 }
 
 function encodePackageName(name) {
-  return name.startsWith("@") ? name.replace("/", "%2f") : name;
+  return encodeURIComponent(name).replace(/^%40/u, "@");
 }
 
 function resolveRegistryBaseUrl() {

--- a/test/scripts/transitive-manifest-risk-report.test.ts
+++ b/test/scripts/transitive-manifest-risk-report.test.ts
@@ -238,7 +238,7 @@ describe("transitive-manifest-risk-report", () => {
 
     expect(fetchCalls).toEqual([
       {
-        url: "https://registry.example.test/@scope%2fpackage",
+        url: "https://registry.example.test/@scope%2Fpackage",
         accept: "application/json",
         signal: expect.any(AbortSignal),
       },


### PR DESCRIPTION
## What Problem This Solves

Fixes seven CodeQL findings where generated Markdown could preserve control syntax, package names could flow into report links without URL encoding, bitmap dimensions could be unbounded, and Android math rendering retained broader WebView bridges and file access than the renderer needs.

## Why This Change Was Made

Escapes Markdown control characters at the report boundary, encodes package names before building links, bounds bitmap dimensions before allocation, and narrows the Android renderer to HTTPS app assets plus an exact-origin WebMessage listener. Focused regressions cover each boundary. AndroidX feature support is checked directly at listener registration, readiness, render entry, and listener removal so supported WebViews use the narrowed path and unsupported WebViews fail closed.

## User Impact

Generated QA and dependency-risk reports are safer with untrusted labels and package names. Android math rendering keeps the same output while removing file URL access and the general JavaScript interface surface.

## Maintainer Decision

Approve the fail-closed WebView policy. OpenClaw Android requires API 31, while the AndroidX WebMessage listener API predates that platform floor; the runtime feature check still protects devices with an unexpectedly stale provider. When the feature is unavailable, `ChatMathBlock` renders the original LaTeX through `ChatMathFallback` as a visible code block. Content is preserved, the app does not crash, and the removed broad JavaScript bridge is not reintroduced as a compatibility fallback.

## Evidence

- CodeQL alerts addressed: #560, #561, #563, #599, #600, #601, #605
- QA/report focused Vitest: 54 tests passed
- fresh `check:changed` on rebased head: passed on Blacksmith Testbox
- Android `:app:ktlintCheck` and `ChatMathRendererTest`: passed on Blacksmith Testbox
- Android focused proof: https://github.com/openclaw/openclaw/actions/runs/30339818804
- Android `:app:lintPlayDebug`: 69 tasks passed on exact patch after the CI lint finding
- Android lint proof: https://github.com/openclaw/openclaw/actions/runs/30341596352
- final autoreview: clean after direct AndroidX feature guards
- signed head: `b1a4d5edaa0acbd38af4d576a3cc61967f1cfe2c`
- `git diff --check`: passed

Alert context:
- https://github.com/openclaw/openclaw/security/code-scanning/560
- https://github.com/openclaw/openclaw/security/code-scanning/561
- https://github.com/openclaw/openclaw/security/code-scanning/563
- https://github.com/openclaw/openclaw/security/code-scanning/599
- https://github.com/openclaw/openclaw/security/code-scanning/600
- https://github.com/openclaw/openclaw/security/code-scanning/601
- https://github.com/openclaw/openclaw/security/code-scanning/605

AI-assisted: yes; the complete implementation and proof were maintainer-reviewed.
