### PR TITLE
fix(slack): stop cyclic directory pagination

### DIFF
--- a/extensions/slack/src/channel.test.ts
+++ b/extensions/slack/src/channel.test.ts
@@ -37,19 +37,21 @@ vi.mock("./send.runtime.js", () => ({
 
 vi.mock("./client.js", async () => {
   const actual = await vi.importActual<typeof import("./client.js")>("./client.js");
+  const createClient = () => ({
+    assistant: {
+      threads: {
+        setStatus: assistantThreadsSetStatusMock,
+      },
+    },
+    conversations: {
+      info: conversationsInfoMock,
+      open: conversationsOpenMock,
+    },
+  });
   return {
     ...actual,
-    createSlackWebClient: vi.fn(() => ({
-      assistant: {
-        threads: {
-          setStatus: assistantThreadsSetStatusMock,
-        },
-      },
-      conversations: {
-        info: conversationsInfoMock,
-        open: conversationsOpenMock,
-      },
-    })),
+    createSlackReadClient: vi.fn(createClient),
+    createSlackWebClient: vi.fn(createClient),
   };
 });
 

--- a/extensions/slack/src/cursor-pages.test.ts
+++ b/extensions/slack/src/cursor-pages.test.ts
@@ -1,0 +1,89 @@
+// Slack tests cover cursor pagination behavior.
+import { describe, expect, it, vi } from "vitest";
+import { collectSlackCursorPages } from "./cursor-pages.js";
+
+type MockPage = {
+  items: string[];
+  response_metadata?: { next_cursor?: string };
+};
+
+function collect(fetchPage: (cursor?: string) => Promise<MockPage>) {
+  return collectSlackCursorPages<string, MockPage>({
+    fetchPage,
+    collectPageItems: (response) => response.items,
+  });
+}
+
+describe("collectSlackCursorPages", () => {
+  it("collects a single page without a cursor", async () => {
+    const fetchPage = vi.fn().mockResolvedValue({ items: ["a", "b"] });
+
+    await expect(collect(fetchPage)).resolves.toEqual(["a", "b"]);
+    expect(fetchPage).toHaveBeenCalledOnce();
+    expect(fetchPage).toHaveBeenCalledWith(undefined);
+  });
+
+  it("collects pages while cursors advance", async () => {
+    const fetchPage = vi
+      .fn()
+      .mockResolvedValueOnce({
+        items: ["a"],
+        response_metadata: { next_cursor: "cursor-1" },
+      })
+      .mockResolvedValueOnce({
+        items: ["b"],
+        response_metadata: { next_cursor: "cursor-2" },
+      })
+      .mockResolvedValueOnce({ items: ["c"], response_metadata: { next_cursor: "" } });
+
+    await expect(collect(fetchPage)).resolves.toEqual(["a", "b", "c"]);
+    expect(fetchPage.mock.calls).toEqual([[undefined], ["cursor-1"], ["cursor-2"]]);
+  });
+
+  it("rejects a repeated cursor before another request", async () => {
+    const fetchPage = vi.fn().mockResolvedValue({
+      items: [],
+      response_metadata: { next_cursor: "cursor-loop" },
+    });
+
+    await expect(collect(fetchPage)).rejects.toThrow(
+      "Slack cursor pagination repeated a cursor after 2 pages",
+    );
+    expect(fetchPage).toHaveBeenCalledTimes(2);
+  });
+
+  it("rejects a multi-cursor cycle", async () => {
+    const fetchPage = vi
+      .fn()
+      .mockResolvedValueOnce({ items: [], response_metadata: { next_cursor: "cursor-a" } })
+      .mockResolvedValueOnce({ items: [], response_metadata: { next_cursor: "cursor-b" } })
+      .mockResolvedValueOnce({ items: [], response_metadata: { next_cursor: "cursor-a" } });
+
+    await expect(collect(fetchPage)).rejects.toThrow(
+      "Slack cursor pagination repeated a cursor after 3 pages",
+    );
+    expect(fetchPage).toHaveBeenCalledTimes(3);
+  });
+
+  it("treats a whitespace-only cursor as terminal", async () => {
+    const fetchPage = vi.fn().mockResolvedValue({
+      items: ["done"],
+      response_metadata: { next_cursor: "   " },
+    });
+
+    await expect(collect(fetchPage)).resolves.toEqual(["done"]);
+    expect(fetchPage).toHaveBeenCalledOnce();
+  });
+
+  it("enforces the advancing-cursor page backstop", async () => {
+    const fetchPage = vi.fn(async (cursor?: string) => ({
+      items: [],
+      response_metadata: { next_cursor: String(Number(cursor ?? "0") + 1) },
+    }));
+
+    await expect(collect(fetchPage)).rejects.toThrow(
+      "Slack cursor pagination exceeded 10000 pages",
+    );
+    expect(fetchPage).toHaveBeenCalledTimes(10_000);
+  });
+});

--- a/extensions/slack/src/cursor-pages.ts
+++ b/extensions/slack/src/cursor-pages.ts
@@ -2,6 +2,10 @@ type SlackCursorResponse = {
   response_metadata?: { next_cursor?: string };
 };
 
+// Slack documents an empty cursor as the only normal termination signal. This
+// backstop is deliberately far above any plausible channel or user directory.
+const SLACK_CURSOR_PAGE_LIMIT = 10_000;
+
 export async function collectSlackCursorPages<
   TItem,
   TResponse extends SlackCursorResponse,
@@ -11,10 +15,21 @@ export async function collectSlackCursorPages<
 }): Promise<TItem[]> {
   const items: TItem[] = [];
   let cursor: string | undefined;
-  do {
+  const seenCursors = new Set<string>();
+
+  for (let pageCount = 1; pageCount <= SLACK_CURSOR_PAGE_LIMIT; pageCount += 1) {
     const response = await params.fetchPage(cursor);
     items.push(...params.collectPageItems(response));
-    cursor = response.response_metadata?.next_cursor?.trim() || undefined;
-  } while (cursor);
-  return items;
+    const nextCursor = response.response_metadata?.next_cursor?.trim() || undefined;
+    if (!nextCursor) {
+      return items;
+    }
+    if (seenCursors.has(nextCursor)) {
+      throw new Error(`Slack cursor pagination repeated a cursor after ${pageCount} pages`);
+    }
+    seenCursors.add(nextCursor);
+    cursor = nextCursor;
+  }
+
+  throw new Error(`Slack cursor pagination exceeded ${SLACK_CURSOR_PAGE_LIMIT} pages`);
 }

--- a/extensions/slack/src/monitor.test-helpers.ts
+++ b/extensions/slack/src/monitor.test-helpers.ts
@@ -2,11 +2,16 @@ import fs from "node:fs";
 import path from "node:path";
 import type { ChannelRuntimeSurface } from "openclaw/plugin-sdk/channel-contract";
 // Slack helper module supports monitor helpers behavior.
-import { closeOpenClawStateDatabaseForTest } from "openclaw/plugin-sdk/plugin-state-test-runtime";
+import type { PluginRuntime } from "openclaw/plugin-sdk/core";
+import {
+  closeOpenClawStateDatabaseForTest,
+  createChannelIngressQueueForTests,
+} from "openclaw/plugin-sdk/plugin-state-test-runtime";
 import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
 import { resolvePreferredOpenClawTmpDir } from "openclaw/plugin-sdk/temp-path";
 import { vi } from "vitest";
 import type { Mock } from "vitest";
+import { setSlackRuntime } from "./runtime.js";
 
 type SlackHandler = (args: unknown) => Promise<void>;
 type SlackMiddleware = (args: { next: () => Promise<void> } & Record<string, unknown>) => unknown;
@@ -317,10 +322,24 @@ export function resetSlackTestState(config: Record<string, unknown> = defaultSla
   if (lastSlackTestStateDir) {
     fs.rmSync(lastSlackTestStateDir, { recursive: true, force: true });
   }
-  lastSlackTestStateDir = fs.realpathSync(
+  const stateDir = fs.realpathSync(
     fs.mkdtempSync(path.join(resolvePreferredOpenClawTmpDir(), "openclaw-slack-monitor-state-")),
   );
-  process.env.OPENCLAW_STATE_DIR = lastSlackTestStateDir;
+  lastSlackTestStateDir = stateDir;
+  process.env.OPENCLAW_STATE_DIR = stateDir;
+  setSlackRuntime({
+    state: {
+      openChannelIngressQueue: (
+        options?: Omit<Parameters<typeof createChannelIngressQueueForTests>[0], "channelId">,
+      ) =>
+        createChannelIngressQueueForTests({
+          ...options,
+          channelId: "slack",
+          stateDir: options?.stateDir ?? stateDir,
+        }),
+      resolveStateDir: () => stateDir,
+    },
+  } as unknown as PluginRuntime);
   slackTestState.config = config;
   slackTestState.appConstructorArgs = undefined;
   slackTestState.socketModeLogger = undefined;

--- a/extensions/slack/src/monitor/provider.reconnect-loop.test.ts
+++ b/extensions/slack/src/monitor/provider.reconnect-loop.test.ts
@@ -8,7 +8,9 @@ const slackTestState = getSlackTestState();
 describe("slack socket reconnect loop", () => {
   beforeEach(() => {
     resetSlackTestState();
-    vi.useFakeTimers();
+    // Reconnect backoff uses timeouts. Keep ingress polling and SQLite WAL intervals
+    // real so runAllTimersAsync cannot turn periodic maintenance into an infinite loop.
+    vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
   });
 
   afterEach(() => {


### PR DESCRIPTION
Supersedes #107959 while preserving @zw-xysk's contribution as co-author.

## What Problem This Solves

Fixes an issue where Slack channel or user directory resolution could run forever if `conversations.list` or `users.list` returned a repeated, non-advancing cursor.

## Why This Change Was Made

The shared Slack cursor collector now rejects any repeated cursor before issuing another request and retains a 10,000-page emergency backstop for an endlessly advancing malformed sequence. The guard lives in the helper used by both directory callers, preserves legitimate pagination of any realistic size, and avoids including Slack's opaque cursor value in errors.

This matches the exact pinned `@slack/web-api` 8.0.0 and official Slack contracts: pagination continues while `response_metadata.next_cursor` is non-empty, and the SDK paginator does not detect cycles on its own.

## User Impact

Slack allowlist and directory lookups now fail explicitly instead of hanging forever when pagination is malformed. Normal multi-page channel and user directories are unchanged.

## Evidence

- Focused helper/caller proof on Blacksmith Testbox: 3 files and 13 tests passed.
- The real 10,000-page advancing-cursor test executes the production helper and completes in 13 ms; the submitted copied-string pseudo-test was removed.
- Initial Blacksmith Testbox `tbx_01kykv04eytyzpp64kbs690kn2`: full extension changed gate passed ([run](https://github.com/openclaw/openclaw/actions/runs/30339667243)).
- Exact-head CI exposed a pre-existing Slack test-order dependency after `createSlackReadClient` landed. The fixup now mocks both client factories and gives monitor tests their own isolated ingress runtime.
- Fixup Blacksmith Testbox `tbx_01kykw9adx2zktzfx86ngvfe9c`: 100 targeted Slack tests and the full extension changed gate passed ([run](https://github.com/openclaw/openclaw/actions/runs/30341178112)).
- Exact-head CI then exposed reconnect tests fast-forwarding SQLite's periodic WAL timer. The follow-up limits fake timers to reconnect timeouts; `tbx_01kykx64c6wzf5c6pqm3wr6q8p` passed 105 targeted Slack tests and the full changed gate ([run](https://github.com/openclaw/openclaw/actions/runs/30342250019)).
- Fresh Codex autoreviews for the behavior patch and test-runtime fixup reported no accepted/actionable findings.

No docs or config update is needed: this changes only malformed-response failure behavior and adds no operator-controlled surface.
