### PR TITLE
perf(ui): keep chat render state alive across session switches

### DIFF
--- a/ui/src/components/markdown.ts
+++ b/ui/src/components/markdown.ts
@@ -86,7 +86,9 @@ const sanitizeOptions = {
 let hooksInstalled = false;
 const MARKDOWN_CHAR_LIMIT = 140_000;
 const MARKDOWN_PARSE_LIMIT = 40_000;
-const MARKDOWN_CACHE_LIMIT = 200;
+// Covers several message-heavy sessions during rapid switching. Only inputs
+// up to 50k characters enter this 500-entry LRU, keeping memory bounded.
+const MARKDOWN_CACHE_LIMIT = 500;
 const MARKDOWN_CACHE_MAX_CHARS = 50_000;
 const DOCS_ORIGIN = "https://docs.openclaw.ai";
 const DOCS_ROOT_SEGMENTS = new Set([

--- a/ui/src/e2e/chat-flow.history-recovery.e2e.test.ts
+++ b/ui/src/e2e/chat-flow.history-recovery.e2e.test.ts
@@ -306,7 +306,9 @@ suite.define(() => {
       });
 
       await sessionB.click();
-      await page.getByText(/^recent retained message 140\n/).waitFor({ timeout: 10_000 });
+      // Returning preserves the reading position at the loaded-history start;
+      // the user can still use the normal jump-to-end control for message 140.
+      await page.getByText(/^older retained message 1\n/).waitFor({ timeout: 10_000 });
       await new Promise<void>((resolve) => {
         setTimeout(resolve, 800);
       });

--- a/ui/src/e2e/chat-flow.navigation-presentation.e2e.test.ts
+++ b/ui/src/e2e/chat-flow.navigation-presentation.e2e.test.ts
@@ -9,11 +9,128 @@ import {
   installMockGateway,
   requireRecord,
   sidebarSessionOrder,
+  waitForChatScrollIdle,
 } from "./chat-flow.test-support.ts";
 
 const suite = createChatFlowE2eSuite();
 
 suite.define(() => {
+  it("restores a scrolled session after switching away while new messages arrive", async () => {
+    const context = await suite.newBrowserContext({
+      locale: "en-US",
+      serviceWorkers: "block",
+      viewport: { height: 720, width: 1280 },
+    });
+    const page = await context.newPage();
+    const sessionA = "agent:main:session-a";
+    const sessionB = "agent:main:session-b";
+    const messages = (label: string, count: number) =>
+      Array.from({ length: count }, (_, index) => ({
+        role: index % 2 === 0 ? "user" : "assistant",
+        content: `${label} message ${index}: ${"wrapped transcript content ".repeat(8)}`,
+        timestamp: 1_000 + index,
+        __openclaw: { seq: index + 1 },
+      }));
+    const response = (sessionKey: string, transcript: unknown[]) => ({
+      messages: transcript,
+      sessionId: `${sessionKey}:backing`,
+      thinkingLevel: null,
+    });
+    const responseCases = (messagesA: unknown[], messagesB = messages("B", 30)) => ({
+      cases: [
+        { match: { sessionKey: sessionA }, response: response(sessionA, messagesA) },
+        { match: { sessionKey: sessionB }, response: response(sessionB, messagesB) },
+      ],
+    });
+    const initialMessagesA = messages("A", 70);
+    const initialResponses = responseCases(initialMessagesA);
+    const gateway = await installMockGateway(page, {
+      methodResponses: {
+        "chat.history": initialResponses,
+        "chat.startup": initialResponses,
+        "sessions.list": chatSessionListResponse(),
+      },
+      sessionKey: sessionA,
+    });
+
+    try {
+      await page.goto(`${suite.server.baseUrl}chat`);
+      await waitForChatScrollIdle(page);
+      const thread = page.locator(".chat-thread");
+      await expect.poll(() => thread.count()).toBe(1);
+      const initialDistance = await thread.evaluate((element) => {
+        const transcript = element as HTMLElement;
+        return transcript.scrollHeight - transcript.scrollTop - transcript.clientHeight;
+      });
+      expect(initialDistance).toBeLessThanOrEqual(8);
+      const storedScrollTop = await thread.evaluate((element) => {
+        const transcript = element as HTMLElement;
+        transcript.scrollTop = Math.floor((transcript.scrollHeight - transcript.clientHeight) / 3);
+        transcript.dispatchEvent(new Event("scroll", { bubbles: true }));
+        return transcript.scrollTop;
+      });
+      expect(storedScrollTop).toBeGreaterThan(0);
+
+      const sessionLink = (sessionKey: string) =>
+        page.locator(
+          `.sidebar-recent-session[data-session-key="${sessionKey}"] a.sidebar-recent-session__link`,
+        );
+      await sessionLink(sessionB).click();
+      await expect.poll(() => new URL(page.url()).pathname).toBe(controlUiSessionPath(sessionB));
+      await waitForChatScrollIdle(page);
+      const firstVisitDistance = await thread.evaluate((element) => {
+        const transcript = element as HTMLElement;
+        return transcript.scrollHeight - transcript.scrollTop - transcript.clientHeight;
+      });
+      expect(firstVisitDistance).toBeLessThanOrEqual(8);
+
+      const messagesAWithNewTail = messages("A", 78);
+      const updatedResponses = responseCases(messagesAWithNewTail);
+      await gateway.setMethodResponse("chat.history", updatedResponses);
+      await gateway.setMethodResponse("chat.startup", updatedResponses);
+      const historyRequestsBeforeReturn = (await gateway.getRequests("chat.history")).length;
+      await sessionLink(sessionA).click();
+      await expect.poll(() => new URL(page.url()).pathname).toBe(controlUiSessionPath(sessionA));
+      await expect
+        .poll(async () => (await gateway.getRequests("chat.history")).length)
+        .toBeGreaterThan(historyRequestsBeforeReturn);
+      await waitForChatScrollIdle(page);
+
+      const restored = await thread.evaluate((element) => {
+        const transcript = element as HTMLElement;
+        return {
+          distanceFromBottom:
+            transcript.scrollHeight - transcript.scrollTop - transcript.clientHeight,
+          scrollTop: transcript.scrollTop,
+        };
+      });
+      expect(
+        Math.abs(restored.scrollTop - storedScrollTop),
+        JSON.stringify({ restored, storedScrollTop }),
+      ).toBeLessThanOrEqual(120);
+      expect(restored.distanceFromBottom).toBeGreaterThan(8);
+
+      const messagesBWithNewTail = messages("B", 36);
+      const endAnchoredResponses = responseCases(messagesAWithNewTail, messagesBWithNewTail);
+      await gateway.setMethodResponse("chat.history", endAnchoredResponses);
+      await gateway.setMethodResponse("chat.startup", endAnchoredResponses);
+      const historyRequestsBeforeEndReturn = (await gateway.getRequests("chat.history")).length;
+      await sessionLink(sessionB).click();
+      await expect.poll(() => new URL(page.url()).pathname).toBe(controlUiSessionPath(sessionB));
+      await expect
+        .poll(async () => (await gateway.getRequests("chat.history")).length)
+        .toBeGreaterThan(historyRequestsBeforeEndReturn);
+      await waitForChatScrollIdle(page);
+      const endAnchoredDistance = await thread.evaluate((element) => {
+        const transcript = element as HTMLElement;
+        return transcript.scrollHeight - transcript.scrollTop - transcript.clientHeight;
+      });
+      expect(endAnchoredDistance).toBeLessThanOrEqual(8);
+    } finally {
+      await suite.closeBrowserContext(context);
+    }
+  });
+
   it("renders always-on pane headers without desktop topbar chrome", async () => {
     const context = await suite.newBrowserContext({
       locale: "en-US",

--- a/ui/src/pages/chat/chat-pane-base.ts
+++ b/ui/src/pages/chat/chat-pane-base.ts
@@ -32,6 +32,7 @@ import {
   type ChatHistoryPagination,
   type ChatMessageCache,
   type ChatPageHost,
+  type ChatSessionScrollPosition,
   type ChatPaneHeaderAction,
   type ChatSessionSharingState,
   type ControlUiSessionBranch,
@@ -362,6 +363,9 @@ export abstract class ChatPaneBase extends OpenClawLightDomElement {
   protected abstract applyApplicationConfig(config: ChatPageContext["config"]["current"]): void;
   protected abstract applySessionsState(state: ChatPageContext["sessions"]["state"]): void;
   protected abstract cancelHeaderRename(): void;
-  protected abstract resetOlderMessagesViewport(): void;
+  protected abstract resetOlderMessagesViewport(
+    nextSessionKey?: string,
+  ): ChatSessionScrollPosition | null;
+  protected abstract restoreOlderMessagesViewport(sessionKey: string, scrollTop: number): void;
   protected abstract sendPendingSkillWorkshopRevision(expectedSessionKey: string): void;
 }

--- a/ui/src/pages/chat/chat-pane-deps.ts
+++ b/ui/src/pages/chat/chat-pane-deps.ts
@@ -272,7 +272,6 @@ export {
 export type { SessionDiscussionPanelConfig } from "./components/session-discussion-panel.ts";
 export {
   ChatTranscriptController,
-  resetChatThreadPresentationState,
   resetChatThreadSessionPresentationState,
 } from "./components/chat-thread.ts";
 export { WIDGET_PROMPT_EVENT, type WidgetPromptEventDetail } from "./components/chat-tool-cards.ts";

--- a/ui/src/pages/chat/chat-pane-deps.ts
+++ b/ui/src/pages/chat/chat-pane-deps.ts
@@ -273,6 +273,7 @@ export type { SessionDiscussionPanelConfig } from "./components/session-discussi
 export {
   ChatTranscriptController,
   resetChatThreadPresentationState,
+  resetChatThreadSessionPresentationState,
 } from "./components/chat-thread.ts";
 export { WIDGET_PROMPT_EVENT, type WidgetPromptEventDetail } from "./components/chat-tool-cards.ts";
 export {
@@ -289,7 +290,14 @@ export {
   reconcileStaleChatRunAfterSessionStatePublication,
   replayPendingChatAbort,
 } from "./run-lifecycle.ts";
-export { scheduleChatScroll } from "./scroll.ts";
+export {
+  captureChatSessionScrollPosition,
+  getChatSessionScrollPosition,
+  restoreChatScroll,
+  saveChatSessionScrollPosition,
+  scheduleChatScroll,
+  type ChatSessionScrollPosition,
+} from "./scroll.ts";
 export {
   clearChatMessagesFromCache,
   readChatSessionSnapshot,

--- a/ui/src/pages/chat/chat-pane-history.test.ts
+++ b/ui/src/pages/chat/chat-pane-history.test.ts
@@ -13,6 +13,8 @@ import type { SessionCapability } from "../../lib/sessions/index.ts";
 import "./chat-pane.ts";
 import { loadChatHistory } from "./chat-history.ts";
 import type { ChatPageHost } from "./chat-state-host.ts";
+import type { AfterCommitEffect } from "./render-lifecycle.ts";
+import type { ChatSessionScrollPosition } from "./scroll.ts";
 
 type TestChatPane = HTMLElement & {
   catalogMessages: unknown[];
@@ -37,6 +39,13 @@ type TestChatPane = HTMLElement & {
   hasOlderMessages: () => boolean;
   loadingOlder: boolean;
   olderOffsetsSeen: Set<number>;
+  resetOlderMessagesViewport: (nextSessionKey?: string) => ChatSessionScrollPosition | null;
+  restoreOlderMessagesViewport: (sessionKey: string, scrollTop: number) => void;
+  transcriptScrollTop: number | null;
+  transcript: {
+    activeSessionKey: string | null;
+    pendingScrollOffsetFor: (sessionKey: string) => number | null;
+  };
 };
 
 function createDeferred<T>() {
@@ -99,6 +108,16 @@ function createTestChatPane(params: { client: GatewayBrowserClient; sessions: Se
     sidebarLayout: { columns: [] },
     chatScrollGeneration: 0,
     chatScrollCommitCleanup: null,
+    chatScrollFrame: null,
+    chatScrollGuardFrame: null,
+    chatLastScrollTop: 0,
+    chatLastScrollHeight: 0,
+    chatHasAutoScrolled: false,
+    chatUserNearBottom: true,
+    chatFollowLocked: false,
+    chatNewMessagesBelow: false,
+    chatIsProgrammaticScroll: false,
+    chatProgrammaticScrollTarget: 0,
     handleChatScroll: vi.fn(),
     renderLifecycle: { afterCommit: () => () => {}, invalidate: () => {} },
   } as unknown as ChatPageHost;
@@ -158,6 +177,83 @@ function nativeHistorySeq(message: unknown): number | undefined {
 }
 
 describe("chat pane native history pagination", () => {
+  it("restores a saved per-session viewport while first visits keep the end anchor", () => {
+    const client = { request: vi.fn() } as unknown as GatewayBrowserClient;
+    const { pane, state } = createTestChatPane({ client, sessions: {} as SessionCapability });
+    const thread = document.createElement("div");
+    thread.className = "chat-thread";
+    Object.defineProperty(thread, "scrollHeight", { configurable: true, value: 2_600 });
+    Object.defineProperty(thread, "clientHeight", { configurable: true, value: 500 });
+    thread.scrollTop = 420;
+    pane.append(thread);
+    pane.transcript.activeSessionKey = state.sessionKey;
+
+    expect(pane.resetOlderMessagesViewport("agent:main:session-b")).toBeNull();
+    state.sessionKey = "agent:main:session-b";
+    pane.transcript.activeSessionKey = state.sessionKey;
+    thread.scrollTop = 80;
+    expect(pane.resetOlderMessagesViewport("agent:main:current")).toEqual({
+      scrollTop: 420,
+      anchorToEnd: false,
+    });
+
+    state.sessionKey = "agent:main:current";
+    pane.transcript.activeSessionKey = state.sessionKey;
+    let commitEffect: AfterCommitEffect | undefined;
+    state.renderLifecycle.afterCommit = vi.fn((effect: AfterCommitEffect) => {
+      commitEffect = effect;
+      return vi.fn();
+    });
+    pane.restoreOlderMessagesViewport(state.sessionKey, 420);
+    commitEffect?.(vi.fn());
+
+    expect(thread.scrollTop).toBe(420);
+    expect(pane.transcriptScrollTop).toBe(420);
+    expect(state.chatHasAutoScrolled).toBe(true);
+    expect(state.chatFollowLocked).toBe(true);
+    expect(state.chatNewMessagesBelow).toBe(true);
+
+    // A rapid second switch sees a transient DOM top of zero while the
+    // logical restore is still pending; it must retain the logical 420px.
+    thread.scrollTop = 0;
+    const pendingScrollOffset = vi
+      .spyOn(pane.transcript, "pendingScrollOffsetFor")
+      .mockReturnValue(420);
+    expect(pane.resetOlderMessagesViewport("agent:main:session-b")).toEqual({
+      scrollTop: 80,
+      anchorToEnd: false,
+    });
+    pendingScrollOffset.mockRestore();
+    state.sessionKey = "agent:main:session-b";
+    pane.transcript.activeSessionKey = state.sessionKey;
+    expect(pane.resetOlderMessagesViewport("agent:main:current")).toEqual({
+      scrollTop: 420,
+      anchorToEnd: false,
+    });
+  });
+
+  it("restores through equivalent default-main session keys", () => {
+    const client = { request: vi.fn() } as unknown as GatewayBrowserClient;
+    const { pane, state } = createTestChatPane({ client, sessions: {} as SessionCapability });
+    state.sessionKey = "agent:main:main";
+    const thread = document.createElement("div");
+    thread.className = "chat-thread";
+    Object.defineProperty(thread, "scrollHeight", { configurable: true, value: 2_600 });
+    Object.defineProperty(thread, "clientHeight", { configurable: true, value: 500 });
+    pane.append(thread);
+    let commitEffect: AfterCommitEffect | undefined;
+    state.renderLifecycle.afterCommit = vi.fn((effect: AfterCommitEffect) => {
+      commitEffect = effect;
+      return vi.fn();
+    });
+
+    pane.restoreOlderMessagesViewport("main", 420);
+    commitEffect?.(vi.fn());
+
+    expect(thread.scrollTop).toBe(420);
+    expect(pane.transcriptScrollTop).toBe(420);
+  });
+
   it("does not request older rows from a complete imported snapshot", () => {
     const client = { request: vi.fn() } as unknown as GatewayBrowserClient;
     const { pane, state } = createTestChatPane({ client, sessions: {} as SessionCapability });

--- a/ui/src/pages/chat/chat-pane-history.ts
+++ b/ui/src/pages/chat/chat-pane-history.ts
@@ -1,6 +1,9 @@
 import {
+  areUiSessionKeysEquivalent,
   COMMAND_PALETTE_TARGET_EVENT,
   announceCatalogSessionContinued,
+  captureChatSessionScrollPosition,
+  getChatSessionScrollPosition,
   loadChatHistory,
   loadOlderChatHistoryPage,
   parseAgentSessionKey,
@@ -8,13 +11,16 @@ import {
   persistChatComposerState,
   resolveChatHistoryPagination,
   replaceChatAttachmentsFromEditor,
+  restoreChatScroll,
   rewindChatHistory,
+  saveChatSessionScrollPosition,
   scheduleChatScroll,
   scopedAgentParamsForSession,
   switchChatHistoryBranch,
   visibleSessionMatches,
   type CatalogSessionKey,
   type ChatHistoryPagination,
+  type ChatSessionScrollPosition,
   type CommandPaletteTargetDetail,
   type SessionsCatalogContinueResult,
 } from "./chat-pane-deps.ts";
@@ -46,7 +52,30 @@ export abstract class ChatPaneHistory extends ChatPaneSession {
     return pagination.hasMore && !state.chatLoading;
   }
 
-  protected resetOlderMessagesViewport(): void {
+  protected resetOlderMessagesViewport(nextSessionKey?: string): ChatSessionScrollPosition | null {
+    let restoredPosition: ChatSessionScrollPosition | null = null;
+    const state = this.state;
+    if (nextSessionKey && state) {
+      const root = this.querySelector<HTMLElement>(".chat-thread");
+      const outgoingSessionKey = root ? this.transcript.renderedSessionKey : state.sessionKey;
+      const pendingScrollTop = outgoingSessionKey
+        ? this.transcript.pendingScrollOffsetFor(outgoingSessionKey)
+        : null;
+      const outgoingPosition =
+        pendingScrollTop !== null
+          ? { scrollTop: pendingScrollTop, anchorToEnd: false }
+          : root
+            ? captureChatSessionScrollPosition(root)
+            : this.transcriptScrollTop !== null
+              ? { scrollTop: this.transcriptScrollTop, anchorToEnd: false }
+              : null;
+      if (outgoingSessionKey && outgoingPosition) {
+        saveChatSessionScrollPosition(this.paneId, outgoingSessionKey, outgoingPosition);
+      }
+    }
+    if (nextSessionKey) {
+      restoredPosition = getChatSessionScrollPosition(this.paneId, nextSessionKey) ?? null;
+    }
     this.olderLoadGeneration += 1;
     this.loadingOlder = false;
     this.historyObserverArmed = false;
@@ -58,11 +87,62 @@ export abstract class ChatPaneHistory extends ChatPaneSession {
       window.clearTimeout(this.historyIntentTimer);
       this.historyIntentTimer = null;
     }
-    this.transcriptScrollTop = null;
+    this.transcriptScrollTop = restoredPosition?.scrollTop ?? null;
     this.olderCursorsSeen.clear();
     this.olderOffsetsSeen.clear();
     this.nativePaginationSnapshot = null;
     this.clearHistoryObserver();
+    return restoredPosition;
+  }
+
+  protected restoreOlderMessagesViewport(sessionKey: string, scrollTop: number): void {
+    const state = this.state;
+    if (!state || !areUiSessionKeysEquivalent(state.sessionKey, sessionKey)) {
+      return;
+    }
+    const generation = this.olderLoadGeneration;
+    state.renderLifecycle.afterCommit((complete) => {
+      try {
+        if (
+          this.state !== state ||
+          !areUiSessionKeysEquivalent(state.sessionKey, sessionKey) ||
+          this.olderLoadGeneration !== generation
+        ) {
+          return;
+        }
+        const root = this.querySelector<HTMLElement>(".chat-thread");
+        if (root) {
+          restoreChatScroll(state, root, scrollTop);
+          // The outer scroller can still be zero-height on this commit. Let
+          // the virtualizer reconcile the logical target as rows are measured.
+          this.transcript.scrollToOffset(scrollTop, (settledPosition) => {
+            if (
+              this.state !== state ||
+              !areUiSessionKeysEquivalent(state.sessionKey, sessionKey) ||
+              this.olderLoadGeneration !== generation
+            ) {
+              return;
+            }
+            const settledRoot = this.querySelector<HTMLElement>(".chat-thread");
+            if (!settledRoot) {
+              return;
+            }
+            this.transcriptScrollTop = restoreChatScroll(
+              state,
+              settledRoot,
+              settledPosition.scrollTop,
+            );
+            saveChatSessionScrollPosition(this.paneId, sessionKey, {
+              ...settledPosition,
+              scrollTop: this.transcriptScrollTop,
+            });
+          });
+          this.transcriptScrollTop = scrollTop;
+        }
+      } finally {
+        complete();
+      }
+    });
   }
 
   protected clearHistoryObserver(): void {
@@ -153,6 +233,19 @@ export abstract class ChatPaneHistory extends ChatPaneSession {
     const previousScrollTop = this.transcriptScrollTop;
     if (root) {
       this.transcriptScrollTop = root.scrollTop;
+      const renderedSessionKey = this.transcript.renderedSessionKey;
+      const stateSessionKey = this.state?.sessionKey;
+      if (
+        renderedSessionKey &&
+        stateSessionKey &&
+        areUiSessionKeysEquivalent(renderedSessionKey, stateSessionKey)
+      ) {
+        saveChatSessionScrollPosition(
+          this.paneId,
+          renderedSessionKey,
+          captureChatSessionScrollPosition(root),
+        );
+      }
     }
     const hasUpwardIntent =
       !this.loadingOlder &&

--- a/ui/src/pages/chat/chat-pane-session.ts
+++ b/ui/src/pages/chat/chat-pane-session.ts
@@ -17,7 +17,7 @@ import {
   refreshChatMetadata,
   refreshRouteSessionOptions,
   resetChatStateForRouteSession,
-  resetChatThreadPresentationState,
+  resetChatThreadSessionPresentationState,
   retryChatComposerMemoryFallback,
   resolveChatAgentId,
   resolveSessionDisplayName,
@@ -174,13 +174,13 @@ export abstract class ChatPaneSession extends ChatPaneSuggestions {
     // Close old-session listener owners before the next render detaches their
     // DOM; thread-global portals and caches are reset separately.
     dismissConfirmedActionPopovers(this);
-    resetChatThreadPresentationState(this.paneId);
+    resetChatThreadSessionPresentationState(this.paneId);
     this.sessionDiscussionOpenUrls.clear();
     const previousSessionKey = state.sessionKey;
     // An in-progress title edit belongs to the previous session; committing
     // it against the newly routed row would rename the wrong session.
     this.cancelHeaderRename();
-    this.resetOlderMessagesViewport();
+    const restoredPosition = this.resetOlderMessagesViewport(nextSessionKey);
     const catalogKey = parseCatalogSessionKey(nextSessionKey);
     const previousAgentId = resolveChatAgentId(state);
     const previousSessionsResult = state.sessionsResult;
@@ -266,7 +266,11 @@ export abstract class ChatPaneSession extends ChatPaneSuggestions {
         return;
       }
       state.requestUpdate();
-      scheduleChatScroll(state, true);
+      if (restoredPosition === null || restoredPosition.anchorToEnd) {
+        scheduleChatScroll(state, true);
+      } else {
+        this.restoreOlderMessagesViewport(nextSessionKey, restoredPosition.scrollTop);
+      }
     };
     void historyLoad.then(scheduleHistoryScroll, scheduleHistoryScroll);
     void historyLoad.then(

--- a/ui/src/pages/chat/chat-thread.test.ts
+++ b/ui/src/pages/chat/chat-thread.test.ts
@@ -1,10 +1,10 @@
 // @vitest-environment node
 // Control UI tests cover build chat items behavior.
 import { expectDefined } from "@openclaw/normalization-core";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { markInboundContextLabel } from "../../../../src/auto-reply/reply/inbound-context-marker.js";
 import type { MessageGroup } from "../../lib/chat/chat-types.ts";
-import { extractToolCardsCached as extractToolCards } from "../../lib/chat/tool-cards.ts";
+import * as toolCards from "../../lib/chat/tool-cards.ts";
 import {
   assistantGroupCanOwnActiveRunStatus,
   buildCachedChatItems,
@@ -18,6 +18,8 @@ import {
 } from "./chat-thread.ts";
 import { rememberLiveTerminalRun } from "./terminal-message-identity.ts";
 import { resolveChatProjectionRunId } from "./tool-stream.ts";
+
+const { extractToolCardsCached: extractToolCards } = toolCards;
 
 describe("assistantGroupCanOwnActiveRunStatus", () => {
   const group = (message: Record<string, unknown>): MessageGroup => ({
@@ -3308,6 +3310,36 @@ describe("buildCachedChatItems", () => {
 });
 
 describe("tool expansion state", () => {
+  it("skips the tool-card walk when the item array identity is unchanged", () => {
+    resetChatThreadState();
+    const group: MessageGroup = {
+      kind: "group",
+      key: "assistant-stable",
+      role: "assistant",
+      messages: [
+        {
+          key: "assistant-stable",
+          message: { role: "assistant", content: "No tools in this row" },
+        },
+      ],
+      timestamp: 1,
+      isStreaming: false,
+    };
+    const items = [group];
+    const extractSpy = vi.spyOn(toolCards, "extractToolCardsCached");
+    try {
+      syncToolCardExpansionState("identity-stable", items, false);
+      const callsAfterFirstSync = extractSpy.mock.calls.length;
+
+      syncToolCardExpansionState("identity-stable", items, false);
+
+      expect(callsAfterFirstSync).toBeGreaterThan(0);
+      expect(extractSpy).toHaveBeenCalledTimes(callsAfterFirstSync);
+    } finally {
+      extractSpy.mockRestore();
+    }
+  });
+
   it("expands already-visible tool cards when auto-expand turns on", () => {
     resetChatThreadState();
     const group: MessageGroup = {
@@ -3501,6 +3533,18 @@ describe("thread item cache", () => {
     resetChatThreadState("pane-a");
     expect(buildCachedChatItems({ ...paneA })).not.toBe(paneAItems);
     expect(buildCachedChatItems({ ...paneB })).toBe(paneBItems);
+  });
+
+  it("evicts the least-recently-used session after 20 cached transcripts", () => {
+    resetChatThreadState();
+    const paneId = "pane-lru";
+    const firstInput = createProps({ paneId, sessionKey: "session-0" });
+    const first = buildCachedChatItems(firstInput);
+    for (let index = 1; index <= 20; index += 1) {
+      buildCachedChatItems(createProps({ paneId, sessionKey: `session-${index}` }));
+    }
+
+    expect(buildCachedChatItems(firstInput)).not.toBe(first);
   });
 });
 

--- a/ui/src/pages/chat/chat-thread.ts
+++ b/ui/src/pages/chat/chat-thread.ts
@@ -14,7 +14,11 @@ import { areUiSessionKeysEquivalent } from "../../lib/sessions/session-key.ts";
 import { resetWorkingProgress } from "./chat-progress.ts";
 import { buildChatItems, type BuildChatItemsProps } from "./chat-thread-build.ts";
 import { sanitizeStreamText } from "./chat-thread-items.ts";
-import { getOrCreateSessionCacheValue, setSessionCacheValue } from "./session-cache.ts";
+import {
+  getOrCreateSessionCacheValue,
+  getSessionCacheValue,
+  setSessionCacheValue,
+} from "./session-cache.ts";
 
 export { isPendingSendMessage, persistedMessageEntryId } from "./chat-thread-items.ts";
 export {
@@ -38,6 +42,7 @@ const expandedToolCardsBySession = new Map<string, Map<string, boolean>>();
 const expandedUserMessagesBySession = new Map<string, Map<string, boolean>>();
 const initializedToolCardsBySession = new Map<string, Set<string>>();
 const lastAutoExpandPrefBySession = new Map<string, boolean>();
+const lastToolCardItemsBySession = new Map<string, readonly (ChatItem | MessageGroup)[]>();
 
 export function resetChatThreadState(paneId?: string): void {
   if (paneId) {
@@ -50,6 +55,7 @@ export function resetChatThreadState(paneId?: string): void {
   expandedUserMessagesBySession.clear();
   initializedToolCardsBySession.clear();
   lastAutoExpandPrefBySession.clear();
+  lastToolCardItemsBySession.clear();
 }
 
 function sameMessageGroup(previous: MessageGroup, next: MessageGroup): boolean {
@@ -380,12 +386,16 @@ function getInitializedToolCards(sessionKey: string): Set<string> {
 
 export function syncToolCardExpansionState(
   sessionKey: string,
-  items: Array<ChatItem | MessageGroup>,
+  items: readonly (ChatItem | MessageGroup)[],
   autoExpandToolCalls: boolean,
 ): void {
   const expanded = getExpandedToolCards(sessionKey);
   const initialized = getInitializedToolCards(sessionKey);
-  const previousAutoExpand = lastAutoExpandPrefBySession.get(sessionKey) ?? false;
+  const previousItems = getSessionCacheValue(lastToolCardItemsBySession, sessionKey);
+  const previousAutoExpand = getSessionCacheValue(lastAutoExpandPrefBySession, sessionKey) ?? false;
+  if (previousItems === items && previousAutoExpand === autoExpandToolCalls) {
+    return;
+  }
   const currentToolCardIds = new Set<string>();
   for (const item of items) {
     if (item.kind !== "group") {
@@ -419,5 +429,6 @@ export function syncToolCardExpansionState(
       expanded.set(toolCardId, true);
     }
   }
-  lastAutoExpandPrefBySession.set(sessionKey, autoExpandToolCalls);
+  setSessionCacheValue(lastToolCardItemsBySession, sessionKey, items);
+  setSessionCacheValue(lastAutoExpandPrefBySession, sessionKey, autoExpandToolCalls);
 }

--- a/ui/src/pages/chat/chat-view.test.ts
+++ b/ui/src/pages/chat/chat-view.test.ts
@@ -48,6 +48,7 @@ import {
 } from "./components/chat-model-controls.ts";
 import {
   resetChatThreadPresentationState,
+  resetChatThreadSessionPresentationState,
   toggleChatThreadSearch,
 } from "./components/chat-thread.ts";
 import { renderWelcomeState } from "./components/chat-welcome.ts";
@@ -1886,7 +1887,7 @@ describe("per-pane chat presentation state", () => {
     expect(paneB.querySelector(".agent-chat__search-bar")).toBeNull();
 
     toggleChatThreadSearch("pane-b", vi.fn());
-    resetChatThreadPresentationState("pane-a");
+    resetChatThreadSessionPresentationState("pane-a");
     renderPane(paneA, "pane-a", "");
     renderPane(paneB, "pane-b", "");
     expect(paneA.querySelector(".agent-chat__search-bar")).toBeNull();

--- a/ui/src/pages/chat/components/chat-thread.measure.test.ts
+++ b/ui/src/pages/chat/components/chat-thread.measure.test.ts
@@ -7,14 +7,23 @@
 // pane width and overlapping the bubbles in the dashboard chat dock.
 import { render } from "lit";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { resetChatThreadState } from "../chat-thread.ts";
+import * as chatThreadBuild from "../chat-thread-build.ts";
+import { buildCachedChatItems, resetChatThreadState } from "../chat-thread.ts";
 import { createTestTranscript } from "../chat-view.test-helpers.ts";
-import { renderChatThread, resetChatThreadPresentationState } from "./chat-thread.ts";
+import {
+  renderChatThread,
+  resetChatThreadPresentationState,
+  resetChatThreadSessionPresentationState,
+} from "./chat-thread.ts";
 
 const observedElements = new Set<Element>();
+const resizeObservers = new Set<RecordingResizeObserver>();
 
 class RecordingResizeObserver implements ResizeObserver {
   private readonly targets = new Set<Element>();
+  constructor(private readonly callback: ResizeObserverCallback) {
+    resizeObservers.add(this);
+  }
   observe(target: Element): void {
     this.targets.add(target);
     observedElements.add(target);
@@ -28,20 +37,39 @@ class RecordingResizeObserver implements ResizeObserver {
       observedElements.delete(target);
     }
     this.targets.clear();
+    resizeObservers.delete(this);
+  }
+  emit(width: number, height: number): void {
+    const entries = [...this.targets].map(
+      (target) =>
+        ({
+          target,
+          borderBoxSize: [{ inlineSize: width, blockSize: height }],
+        }) as unknown as ResizeObserverEntry,
+    );
+    if (entries.length > 0) {
+      this.callback(entries, this);
+    }
   }
 }
 
-function threadProps(paneId: string) {
+const defaultMessages = [
+  { role: "user", content: "message one", timestamp: 1_000 },
+  { role: "assistant", content: "reply one", timestamp: 2_000 },
+  { role: "user", content: "message two", timestamp: 3_000 },
+  { role: "assistant", content: "reply two", timestamp: 4_000 },
+];
+
+function threadProps(
+  paneId: string,
+  sessionKey = "agent:main:main",
+  messages: unknown[] = defaultMessages,
+) {
   return {
     paneId,
-    sessionKey: "agent:main:main",
+    sessionKey,
     loading: false,
-    messages: [
-      { role: "user", content: "message one", timestamp: 1_000 },
-      { role: "assistant", content: "reply one", timestamp: 2_000 },
-      { role: "user", content: "message two", timestamp: 3_000 },
-      { role: "assistant", content: "reply two", timestamp: 4_000 },
-    ],
+    messages,
     toolMessages: [],
     streamSegments: [],
     stream: null,
@@ -70,6 +98,7 @@ async function flushDeferredRowPrune(): Promise<void> {
 describe("chat transcript row measurement", () => {
   beforeEach(() => {
     observedElements.clear();
+    resizeObservers.clear();
     vi.stubGlobal("ResizeObserver", RecordingResizeObserver);
     // jsdom reports 0x0 rects and offsetHeight 0; keep the virtualizer
     // viewport and measured row sizes non-zero so re-renders keep producing
@@ -126,5 +155,168 @@ describe("chat transcript row measurement", () => {
     for (const row of chatRows) {
       expect(observedElements.has(row)).toBe(false);
     }
+  });
+
+  it("keeps built row identities across an A to B to A presentation reset", () => {
+    const paneId = "pane-session-items";
+    const messagesA = [{ role: "assistant", content: "session A", timestamp: 1_000 }];
+    const messagesB = [{ role: "assistant", content: "session B", timestamp: 2_000 }];
+    const stableInputs = {
+      paneId,
+      runId: null,
+      toolMessages: [],
+      streamSegments: [],
+      stream: null,
+      streamStartedAt: null,
+      showToolCalls: true,
+    };
+    const buildSpy = vi.spyOn(chatThreadBuild, "buildChatItems");
+    const itemsA = buildCachedChatItems({
+      ...stableInputs,
+      sessionKey: "agent:main:session-a",
+      messages: messagesA,
+    });
+
+    resetChatThreadSessionPresentationState(paneId);
+    buildCachedChatItems({
+      ...stableInputs,
+      sessionKey: "agent:main:session-b",
+      messages: messagesB,
+    });
+    resetChatThreadSessionPresentationState(paneId);
+    const restoredItemsA = buildCachedChatItems({
+      ...stableInputs,
+      sessionKey: "agent:main:session-a",
+      messages: messagesA,
+    });
+
+    expect(buildSpy).toHaveBeenCalledTimes(2);
+    expect(restoredItemsA).toBe(itemsA);
+    expect(restoredItemsA.every((item, index) => item === itemsA[index])).toBe(true);
+  });
+
+  it("keeps an unsettled restored offset with its cached session host", () => {
+    const transcript = createTestTranscript();
+    const container = document.body.appendChild(document.createElement("div"));
+    const messages = Array.from({ length: 20 }, (_, index) => ({
+      role: index % 2 === 0 ? "user" : "assistant",
+      content: `message ${index}`,
+      timestamp: index,
+    }));
+    const renderSession = (sessionKey: string) => {
+      render(
+        renderChatThread(threadProps("pane-pending-scroll", sessionKey, messages), transcript),
+        container,
+      );
+    };
+    renderSession("agent:main:session-a");
+    transcript.hostConnected();
+    transcript.hostUpdated();
+    transcript.scrollToOffset(420);
+    expect(transcript.pendingScrollOffsetFor("agent:main:session-a")).toBe(420);
+
+    renderSession("agent:main:session-b");
+    transcript.hostUpdated();
+    expect(transcript.pendingScrollOffsetFor("agent:main:session-b")).toBeNull();
+
+    renderSession("agent:main:session-a");
+    expect(transcript.pendingScrollOffsetFor("agent:main:session-a")).toBe(420);
+  });
+
+  it("pauses an unmeasurable restore until loading commits an empty transcript", () => {
+    const transcript = createTestTranscript();
+    const container = document.body.appendChild(document.createElement("div"));
+    const props = threadProps("pane-loading-scroll", "agent:main:session-a", []);
+    render(renderChatThread({ ...props, loading: true }, transcript), container);
+    transcript.hostConnected();
+    transcript.hostUpdated();
+    transcript.scrollToOffset(420);
+    transcript.hostUpdated();
+
+    expect(transcript.pendingScrollOffsetFor(props.sessionKey)).toBe(420);
+
+    render(renderChatThread(props, transcript), container);
+    transcript.hostUpdated();
+    expect(transcript.pendingScrollOffsetFor(props.sessionKey)).toBeNull();
+  });
+
+  it("settles a restored offset when loaded rows no longer overflow", () => {
+    const frames: FrameRequestCallback[] = [];
+    vi.spyOn(window, "requestAnimationFrame").mockImplementation((callback) => {
+      frames.push(callback);
+      return frames.length;
+    });
+    vi.spyOn(window, "cancelAnimationFrame").mockImplementation(() => undefined);
+    const transcript = createTestTranscript();
+    const container = document.body.appendChild(document.createElement("div"));
+    const props = threadProps("pane-short-scroll", "agent:main:session-a");
+    render(renderChatThread(props, transcript), container);
+    transcript.hostConnected();
+    transcript.hostUpdated();
+    transcript.scrollToOffset(420);
+
+    for (let index = 0; index <= 60; index += 1) {
+      transcript.hostUpdated();
+      for (const frame of frames.splice(0)) {
+        frame(0);
+      }
+    }
+
+    expect(transcript.pendingScrollOffsetFor(props.sessionKey)).toBeNull();
+  });
+
+  it("reuses measured hosts, remeasures width changes, and tears down evictions", async () => {
+    const transcript = createTestTranscript();
+    const container = document.body.appendChild(document.createElement("div"));
+    const renderSession = async (sessionKey: string) => {
+      render(renderChatThread(threadProps("pane-host-cache", sessionKey), transcript), container);
+      transcript.hostUpdated();
+      await flushDeferredRowPrune();
+    };
+    await renderSession("agent:main:session-a");
+    transcript.hostConnected();
+    transcript.hostUpdated();
+    await flushDeferredRowPrune();
+
+    type VirtualizerInternals = {
+      itemSizeCache: Map<unknown, number>;
+      measure: () => void;
+    };
+    type SessionHostInternals = {
+      connected: boolean;
+      measureRowRefs: Map<string, unknown>;
+      virtualizerController: { getVirtualizer: () => VirtualizerInternals };
+    };
+    const controllerInternals = transcript as unknown as {
+      sessionVirtualizers: Map<string, SessionHostInternals>;
+    };
+    const hostA = controllerInternals.sessionVirtualizers.get("agent:main:session-a");
+    expect(hostA).toBeDefined();
+    const virtualizerA = hostA?.virtualizerController.getVirtualizer();
+    expect(virtualizerA?.itemSizeCache.size).toBeGreaterThan(0);
+    const measuredSizes = new Map(virtualizerA?.itemSizeCache);
+
+    await renderSession("agent:main:session-b");
+    await renderSession("agent:main:session-a");
+    expect(controllerInternals.sessionVirtualizers.get("agent:main:session-a")).toBe(hostA);
+    expect(virtualizerA?.itemSizeCache).toEqual(measuredSizes);
+
+    const measure = vi.spyOn(virtualizerA as VirtualizerInternals, "measure");
+    for (const observer of resizeObservers) {
+      observer.emit(640, 600);
+    }
+    expect(measure).toHaveBeenCalled();
+
+    await renderSession("agent:main:session-c");
+    await renderSession("agent:main:session-d");
+    expect(controllerInternals.sessionVirtualizers.size).toBe(3);
+    expect(controllerInternals.sessionVirtualizers.has("agent:main:session-b")).toBe(false);
+    expect(hostA?.connected).toBe(false);
+
+    await renderSession("agent:main:session-e");
+    expect(controllerInternals.sessionVirtualizers.has("agent:main:session-a")).toBe(false);
+    expect(hostA?.measureRowRefs.size).toBe(0);
+    transcript.hostDisconnected();
+    expect(observedElements.size).toBe(0);
   });
 });

--- a/ui/src/pages/chat/components/chat-thread.ts
+++ b/ui/src/pages/chat/components/chat-thread.ts
@@ -64,6 +64,11 @@ import {
 import { DeletedMessages } from "../deleted-messages.ts";
 import { PinnedMessages } from "../pinned-messages.ts";
 import type { RealtimeTalkConversationEntry } from "../realtime-talk-conversation.ts";
+import {
+  getChatSessionScrollPosition,
+  saveChatSessionScrollPosition,
+  type ChatSessionScrollPosition,
+} from "../scroll.ts";
 import { getOrCreateSessionCacheValue } from "../session-cache.ts";
 import type { PlanStatus } from "../tool-stream.ts";
 import { getToolTitlesVersion } from "../tool-titles.ts";
@@ -191,6 +196,15 @@ const CHAT_TRANSCRIPT_ESTIMATED_ROW_PX = 120;
 const CHAT_TRANSCRIPT_OVERSCAN = 6;
 const CHAT_TRANSCRIPT_END_THRESHOLD_PX = 8;
 const CHAT_TRANSCRIPT_ANNOUNCEMENT_MAX_CHARS = 500;
+// Initial virtual rows can correct their estimates for several frames. Hold a
+// restored offset for ~200ms so those corrections cannot reapply the end anchor.
+const CHAT_TRANSCRIPT_SCROLL_RESTORE_STABLE_FRAMES = 12;
+// A committed short transcript can legitimately remain at maxOffset=0. Give
+// initial measurement one second before treating that zero range as final.
+const CHAT_TRANSCRIPT_ZERO_MAX_SETTLE_FRAMES = 60;
+// Keep the active transcript plus two recent sessions. Eviction always tears
+// down observers first; otherwise a discarded host would leak row observers.
+const CHAT_TRANSCRIPT_VIRTUALIZER_CACHE_LIMIT = 3;
 
 function initialTranscriptRect(host: ReactiveControllerHost) {
   const width = host instanceof HTMLElement ? host.clientWidth : 0;
@@ -219,6 +233,16 @@ class ChatSessionVirtualizerHost implements ReactiveControllerHost {
   private readonly controllers = new Set<ReactiveController>();
   private readonly virtualizerController: VirtualizerController<HTMLDivElement, HTMLElement>;
   private threadInnerElement: HTMLDivElement | null = null;
+  private connected = false;
+  private observedWidth: number | null = null;
+  private contentReady = false;
+  private pendingScrollOffset: {
+    offset: number;
+    stableFrames: number;
+    zeroMaxFrames: number;
+    onSettled?: (position: ChatSessionScrollPosition) => void;
+  } | null = null;
+  private pendingScrollFrame: number | null = null;
   // Lit calls refs before newly rendered nodes are connected. Resolve the
   // scroll parent lazily or a stable ref can permanently capture null.
   private get scrollElement(): HTMLDivElement | null {
@@ -268,21 +292,37 @@ class ChatSessionVirtualizerHost implements ReactiveControllerHost {
   private currentAnnouncementText = "";
   private readonly mcpAppUnmountGate = new McpAppUnmountGate(this);
 
-  constructor(private readonly host: ReactiveControllerHost) {
+  constructor(
+    private readonly host: ReactiveControllerHost,
+    initialOffset: number | null = null,
+    onInitialOffsetSettled?: (position: ChatSessionScrollPosition) => void,
+  ) {
     this.virtualizerController = new VirtualizerController(this, {
       count: 0,
       getScrollElement: () => this.scrollElement,
       estimateSize: () => CHAT_TRANSCRIPT_ESTIMATED_ROW_PX,
       getItemKey: () => "",
       initialRect: initialTranscriptRect(host),
-      initialOffset: Number.MAX_SAFE_INTEGER,
+      initialOffset: initialOffset ?? Number.MAX_SAFE_INTEGER,
       scrollMargin: initialTranscriptScrollMargin(host),
       anchorTo: "end",
       followOnAppend: false,
       observeElementRect: (instance, callback) =>
         observeElementRect(instance, (rect) => {
+          const widthChanged = this.observedWidth !== null && this.observedWidth !== rect.width;
+          this.observedWidth = rect.width;
           this.syncScrollMargin(instance.scrollElement);
           callback(rect);
+          if (widthChanged) {
+            // Cached offscreen sizes belong to the old wrapping width. Reset
+            // them and synchronously seed connected rows to avoid stale overlap.
+            instance.measure();
+            for (const row of this.threadInnerElement?.querySelectorAll<HTMLElement>(
+              ".chat-virtual-row",
+            ) ?? []) {
+              instance.measureElement(row);
+            }
+          }
         }),
       rangeExtractor: (range) => {
         const indexes = defaultRangeExtractor(range);
@@ -301,6 +341,14 @@ class ChatSessionVirtualizerHost implements ReactiveControllerHost {
       scrollEndThreshold: CHAT_TRANSCRIPT_END_THRESHOLD_PX,
       overscan: CHAT_TRANSCRIPT_OVERSCAN,
     });
+    if (initialOffset !== null) {
+      this.pendingScrollOffset = {
+        offset: initialOffset,
+        stableFrames: 0,
+        zeroMaxFrames: 0,
+        onSettled: onInitialOffsetSettled,
+      };
+    }
   }
 
   get updateComplete() {
@@ -324,8 +372,15 @@ class ChatSessionVirtualizerHost implements ReactiveControllerHost {
   }
 
   connect(): void {
+    if (this.connected) {
+      return;
+    }
+    this.connected = true;
     for (const controller of this.controllers) {
       controller.hostConnected?.();
+    }
+    if (this.pendingScrollOffset) {
+      this.host.requestUpdate();
     }
   }
 
@@ -333,13 +388,32 @@ class ChatSessionVirtualizerHost implements ReactiveControllerHost {
     for (const controller of this.controllers) {
       controller.hostUpdated?.();
     }
+    this.applyPendingScrollOffset();
   }
 
   disconnect(): void {
+    if (this.pendingScrollFrame !== null) {
+      cancelAnimationFrame(this.pendingScrollFrame);
+      this.pendingScrollFrame = null;
+    }
+    if (!this.connected) {
+      this.threadInnerElement = null;
+      return;
+    }
+    this.connected = false;
     for (const controller of this.controllers) {
       controller.hostDisconnected?.();
     }
     this.threadInnerElement = null;
+  }
+
+  dispose(): void {
+    this.disconnect();
+    this.measureRowRefs.clear();
+    this.rowKeys = [];
+    this.rowIndexesByKey.clear();
+    this.focusedRowKey = null;
+    this.pendingScrollOffset = null;
   }
 
   render(
@@ -407,6 +481,42 @@ class ChatSessionVirtualizerHost implements ReactiveControllerHost {
 
   scrollToEnd(options: { behavior?: ScrollBehavior } = {}): void {
     this.virtualizerController.getVirtualizer().scrollToEnd(options);
+  }
+
+  scrollToOffset(offset: number): void {
+    if (this.scrollElement) {
+      this.scrollElement.scrollTop = offset;
+    }
+    this.virtualizerController.getVirtualizer().scrollToOffset(offset);
+  }
+
+  getScrollOffset(): number | null {
+    return this.scrollElement?.scrollTop ?? null;
+  }
+
+  getMaxScrollOffset(): number | null {
+    const scrollElement = this.scrollElement;
+    return scrollElement
+      ? Math.max(0, scrollElement.scrollHeight - scrollElement.clientHeight)
+      : null;
+  }
+
+  setContentReady(ready: boolean): void {
+    this.contentReady = ready;
+  }
+
+  restoreScrollOffset(
+    offset: number,
+    onSettled?: (position: ChatSessionScrollPosition) => void,
+  ): void {
+    this.pendingScrollOffset = { offset, stableFrames: 0, zeroMaxFrames: 0, onSettled };
+    if (this.connected) {
+      this.host.requestUpdate();
+    }
+  }
+
+  getPendingScrollOffset(): number | null {
+    return this.pendingScrollOffset?.offset ?? null;
   }
 
   handleFocusIn(event: FocusEvent): void {
@@ -480,26 +590,129 @@ class ChatSessionVirtualizerHost implements ReactiveControllerHost {
       scrollMargin,
     });
   }
+
+  private applyPendingScrollOffset(): void {
+    const pending = this.pendingScrollOffset;
+    if (!pending || !this.connected) {
+      return;
+    }
+    const maxOffset = this.getMaxScrollOffset();
+    if (maxOffset === null) {
+      if (this.contentReady && this.rowKeys.length === 0) {
+        this.settlePendingScroll(0);
+      }
+      return;
+    }
+    if (maxOffset === 0 && pending.offset > 0) {
+      if (this.contentReady && this.rowKeys.length === 0) {
+        this.settlePendingScroll(0);
+      } else if (this.contentReady) {
+        if (pending.zeroMaxFrames >= CHAT_TRANSCRIPT_ZERO_MAX_SETTLE_FRAMES) {
+          this.settlePendingScroll(0);
+          return;
+        }
+        pending.zeroMaxFrames += 1;
+        this.schedulePendingScrollRetry();
+      }
+      return;
+    }
+    pending.zeroMaxFrames = 0;
+    const targetOffset = Math.min(pending.offset, maxOffset);
+    this.scrollToOffset(targetOffset);
+    const currentOffset = this.getScrollOffset();
+    if (currentOffset != null && Math.abs(currentOffset - targetOffset) <= 1) {
+      if (pending.stableFrames >= CHAT_TRANSCRIPT_SCROLL_RESTORE_STABLE_FRAMES) {
+        this.settlePendingScroll(currentOffset);
+      } else {
+        pending.stableFrames += 1;
+        this.schedulePendingScrollRetry();
+      }
+    } else {
+      pending.stableFrames = 0;
+      this.schedulePendingScrollRetry();
+    }
+  }
+
+  private schedulePendingScrollRetry(): void {
+    if (!this.connected || this.pendingScrollFrame !== null) {
+      return;
+    }
+    this.pendingScrollFrame = requestAnimationFrame(() => {
+      this.pendingScrollFrame = null;
+      if (this.connected && this.pendingScrollOffset) {
+        this.host.requestUpdate();
+      }
+    });
+  }
+
+  private settlePendingScroll(scrollTop: number): void {
+    const pending = this.pendingScrollOffset;
+    this.pendingScrollOffset = null;
+    if (!pending) {
+      return;
+    }
+    const maxScrollTop = this.getMaxScrollOffset();
+    pending.onSettled?.({
+      scrollTop,
+      anchorToEnd:
+        maxScrollTop === null
+          ? this.contentReady && this.rowKeys.length === 0
+          : maxScrollTop - scrollTop <= CHAT_TRANSCRIPT_END_THRESHOLD_PX,
+    });
+  }
 }
 
 export class ChatTranscriptController implements ReactiveController {
-  private sessionKey: string | null = null;
+  private activeSessionKey: string | null = null;
   private sessionVirtualizer: ChatSessionVirtualizerHost | null = null;
+  private readonly sessionVirtualizers = new Map<string, ChatSessionVirtualizerHost>();
   private connected = false;
 
   constructor(private readonly host: ReactiveControllerHost) {
     host.addController(this);
   }
 
+  get renderedSessionKey(): string | null {
+    return this.activeSessionKey;
+  }
+
   render(props: ChatThreadProps): TemplateResult {
     if (
       !this.sessionVirtualizer ||
-      this.sessionKey === null ||
-      !areUiSessionKeysEquivalent(this.sessionKey, props.sessionKey)
+      this.activeSessionKey === null ||
+      !areUiSessionKeysEquivalent(this.activeSessionKey, props.sessionKey)
     ) {
       this.sessionVirtualizer?.disconnect();
-      this.sessionKey = props.sessionKey;
-      this.sessionVirtualizer = new ChatSessionVirtualizerHost(this.host);
+      let cachedKey: string | null = null;
+      let nextVirtualizer: ChatSessionVirtualizerHost | null = null;
+      for (const [sessionKey, virtualizer] of this.sessionVirtualizers) {
+        if (areUiSessionKeysEquivalent(sessionKey, props.sessionKey)) {
+          cachedKey = sessionKey;
+          nextVirtualizer = virtualizer;
+          break;
+        }
+      }
+      if (cachedKey !== null && nextVirtualizer) {
+        this.sessionVirtualizers.delete(cachedKey);
+      } else {
+        const savedPosition = getChatSessionScrollPosition(props.paneId, props.sessionKey);
+        const initialOffset = savedPosition?.anchorToEnd
+          ? null
+          : (savedPosition?.scrollTop ?? null);
+        nextVirtualizer = new ChatSessionVirtualizerHost(
+          this.host,
+          initialOffset,
+          initialOffset === null
+            ? undefined
+            : (position) => {
+                saveChatSessionScrollPosition(props.paneId, props.sessionKey, position);
+              },
+        );
+      }
+      this.activeSessionKey = props.sessionKey;
+      this.sessionVirtualizer = nextVirtualizer;
+      this.sessionVirtualizers.set(props.sessionKey, nextVirtualizer);
+      this.evictInactiveVirtualizers();
       if (this.connected) {
         this.sessionVirtualizer.connect();
       }
@@ -509,6 +722,17 @@ export class ChatTranscriptController implements ReactiveController {
 
   scrollToEnd(options: { behavior?: ScrollBehavior } = {}): void {
     this.sessionVirtualizer?.scrollToEnd(options);
+  }
+
+  scrollToOffset(offset: number, onSettled?: (position: ChatSessionScrollPosition) => void): void {
+    this.sessionVirtualizer?.restoreScrollOffset(offset, onSettled);
+  }
+
+  pendingScrollOffsetFor(sessionKey: string): number | null {
+    return this.activeSessionKey !== null &&
+      areUiSessionKeysEquivalent(this.activeSessionKey, sessionKey)
+      ? (this.sessionVirtualizer?.getPendingScrollOffset() ?? null)
+      : null;
   }
 
   handleFocusIn(event: FocusEvent): void {
@@ -530,7 +754,23 @@ export class ChatTranscriptController implements ReactiveController {
 
   hostDisconnected(): void {
     this.connected = false;
-    this.sessionVirtualizer?.disconnect();
+    for (const virtualizer of this.sessionVirtualizers.values()) {
+      virtualizer.disconnect();
+    }
+  }
+
+  private evictInactiveVirtualizers(): void {
+    while (this.sessionVirtualizers.size > CHAT_TRANSCRIPT_VIRTUALIZER_CACHE_LIMIT) {
+      const oldest = this.sessionVirtualizers.entries().next().value as
+        | [string, ChatSessionVirtualizerHost]
+        | undefined;
+      if (!oldest) {
+        return;
+      }
+      const [sessionKey, virtualizer] = oldest;
+      this.sessionVirtualizers.delete(sessionKey);
+      virtualizer.dispose();
+    }
   }
 }
 
@@ -576,7 +816,7 @@ function getPinnedMessageSummary(message: unknown): string {
   return extractTextCached(message) ?? "";
 }
 
-export function resetChatThreadPresentationState(paneId?: string, owner?: ParentNode) {
+function dismissChatThreadPortals(paneId?: string, owner?: ParentNode): void {
   removeReplyContextMenu(paneId);
   if (owner) {
     dismissConfirmedActionPopovers(owner);
@@ -584,6 +824,21 @@ export function resetChatThreadPresentationState(paneId?: string, owner?: Parent
   // The selection popup is body-portaled; pane teardown/route changes must
   // drop it so it cannot outlive the render that owns its callbacks.
   removeChatSelectionPopup();
+}
+
+export function resetChatThreadSessionPresentationState(paneId: string, owner?: ParentNode): void {
+  dismissChatThreadPortals(paneId, owner);
+  const state = threadStates.get(paneId);
+  if (state) {
+    // Search input belongs to the outgoing transcript. Other fields are pane
+    // preferences or dependency memos and invalidate themselves on new props.
+    state.searchOpen = false;
+    state.searchQuery = "";
+  }
+}
+
+export function resetChatThreadPresentationState(paneId?: string, owner?: ParentNode) {
+  dismissChatThreadPortals(paneId, owner);
   if (paneId) {
     threadStates.delete(paneId);
     resetChatThreadState(paneId);
@@ -1216,6 +1471,7 @@ function renderChatThreadContents(
   };
   const hasRealtimeTalkConversation = (props.realtimeTalkConversation?.length ?? 0) > 0;
   const isEmpty = chatItems.length === 0 && !props.loading && !hasRealtimeTalkConversation;
+  transcript.setContentReady(!props.loading);
   // 1:1 sessions drop the avatar gutter entirely; group threads keep avatars
   // as the always-visible identity marker. The canonical session kind decides;
   // the sessions list is capped, so absent/unknown rows classify by key:

--- a/ui/src/pages/chat/scroll.test.ts
+++ b/ui/src/pages/chat/scroll.test.ts
@@ -3,8 +3,11 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { RenderLifecycle } from "./render-lifecycle.ts";
 import {
   cancelChatScroll,
+  getChatSessionScrollPosition,
   handleChatScroll,
   resetChatScroll,
+  restoreChatScroll,
+  saveChatSessionScrollPosition,
   scheduleChatScroll,
 } from "./scroll.ts";
 
@@ -275,6 +278,70 @@ describe("scheduleChatScroll", () => {
 
     // On initial load, force should work regardless
     expect(container.scrollTop).toBe(container.scrollHeight);
+  });
+
+  it("restores a session viewport and does not force-jump when new messages arrive", async () => {
+    const { host, container } = createScrollHost({
+      scrollHeight: 2400,
+      scrollTop: 2000,
+      clientHeight: 400,
+    });
+
+    expect(restoreChatScroll(host, container as unknown as HTMLElement, 1500)).toBe(1500);
+    expect(host.chatHasAutoScrolled).toBe(true);
+    expect(host.chatFollowLocked).toBe(true);
+    expect(host.chatNewMessagesBelow).toBe(true);
+
+    container.scrollHeight = 2600;
+    scheduleChatScroll(host, true);
+    await host.updateComplete;
+
+    expect(container.scrollTop).toBe(1500);
+    expect(host.chatNewMessagesBelow).toBe(true);
+  });
+
+  it("locks a restored virtual viewport before its scroll height is measurable", () => {
+    const { host, container } = createScrollHost({
+      scrollHeight: 0,
+      scrollTop: 0,
+      clientHeight: 400,
+    });
+
+    expect(restoreChatScroll(host, container as unknown as HTMLElement, 600)).toBe(0);
+    expect(host.chatFollowLocked).toBe(true);
+    expect(host.chatNewMessagesBelow).toBe(true);
+
+    saveChatSessionScrollPosition("settled-pane", "settled-session", {
+      scrollTop: 600,
+      anchorToEnd: false,
+    });
+    expect(restoreChatScroll(host, container as unknown as HTMLElement, 0)).toBe(0);
+    saveChatSessionScrollPosition("settled-pane", "settled-session", {
+      scrollTop: 0,
+      anchorToEnd: true,
+    });
+    expect(getChatSessionScrollPosition("settled-pane", "settled-session")).toEqual({
+      scrollTop: 0,
+      anchorToEnd: true,
+    });
+    expect(host.chatFollowLocked).toBe(false);
+    expect(host.chatNewMessagesBelow).toBe(false);
+  });
+
+  it("keeps only the newest equivalent session-key scroll position", () => {
+    saveChatSessionScrollPosition("alias-pane", "main", {
+      scrollTop: 100,
+      anchorToEnd: false,
+    });
+    saveChatSessionScrollPosition("alias-pane", "agent:main:main", {
+      scrollTop: 200,
+      anchorToEnd: false,
+    });
+
+    expect(getChatSessionScrollPosition("alias-pane", "main")).toEqual({
+      scrollTop: 200,
+      anchorToEnd: false,
+    });
   });
 
   it("uses force=true on initial load even after a previous follow lock", async () => {

--- a/ui/src/pages/chat/scroll.ts
+++ b/ui/src/pages/chat/scroll.ts
@@ -1,10 +1,90 @@
 // Control UI module implements app scroll behavior.
+import { areUiSessionKeysEquivalent } from "../../lib/sessions/session-key.ts";
 import type { RenderLifecycle } from "./render-lifecycle.ts";
+import { getSessionCacheValue, setSessionCacheValue } from "./session-cache.ts";
 
 /** Distance (px) from the bottom within which we consider the user "near bottom". */
 const NEAR_BOTTOM_THRESHOLD = 450;
 const LATEST_MESSAGE_THRESHOLD = 1;
 const FOLLOW_REACQUIRE_THRESHOLD = 8;
+// Route navigation may replace a pane element while retaining its logical id.
+// Bound both dimensions so those short-lived owners cannot leak scroll state.
+const MAX_CACHED_TRANSCRIPT_SCROLL_PANES = 8;
+export type ChatSessionScrollPosition = {
+  scrollTop: number;
+  anchorToEnd: boolean;
+};
+
+const transcriptScrollTopByPane = new Map<string, Map<string, ChatSessionScrollPosition>>();
+
+function getPaneScrollTops(paneId: string): Map<string, ChatSessionScrollPosition> {
+  const existing = transcriptScrollTopByPane.get(paneId);
+  if (existing) {
+    transcriptScrollTopByPane.delete(paneId);
+    transcriptScrollTopByPane.set(paneId, existing);
+    return existing;
+  }
+  const created = new Map<string, ChatSessionScrollPosition>();
+  transcriptScrollTopByPane.set(paneId, created);
+  while (transcriptScrollTopByPane.size > MAX_CACHED_TRANSCRIPT_SCROLL_PANES) {
+    const oldest = transcriptScrollTopByPane.keys().next().value;
+    if (typeof oldest !== "string") {
+      break;
+    }
+    transcriptScrollTopByPane.delete(oldest);
+  }
+  return created;
+}
+
+export function getChatSessionScrollPosition(
+  paneId: string,
+  sessionKey: string,
+): ChatSessionScrollPosition | undefined {
+  const scrollTops = getPaneScrollTops(paneId);
+  const exact = getSessionCacheValue(scrollTops, sessionKey);
+  if (exact !== undefined) {
+    return exact;
+  }
+  for (const [cachedKey, position] of scrollTops) {
+    if (!areUiSessionKeysEquivalent(cachedKey, sessionKey)) {
+      continue;
+    }
+    scrollTops.delete(cachedKey);
+    setSessionCacheValue(scrollTops, sessionKey, position);
+    return position;
+  }
+  return undefined;
+}
+
+export function saveChatSessionScrollPosition(
+  paneId: string,
+  sessionKey: string,
+  position: ChatSessionScrollPosition,
+): void {
+  const scrollTops = getPaneScrollTops(paneId);
+  for (const cachedKey of scrollTops.keys()) {
+    if (areUiSessionKeysEquivalent(cachedKey, sessionKey)) {
+      scrollTops.delete(cachedKey);
+    }
+  }
+  setSessionCacheValue(scrollTops, sessionKey, {
+    scrollTop: Math.max(0, position.scrollTop),
+    anchorToEnd: position.anchorToEnd,
+  });
+}
+
+export function captureChatSessionScrollPosition(target: {
+  scrollHeight: number;
+  scrollTop: number;
+  clientHeight: number;
+}): ChatSessionScrollPosition {
+  const maxScrollTop = Math.max(0, target.scrollHeight - target.clientHeight);
+  const scrollTop = Math.min(Math.max(0, target.scrollTop), maxScrollTop);
+  return {
+    scrollTop,
+    anchorToEnd: maxScrollTop - scrollTop <= FOLLOW_REACQUIRE_THRESHOLD,
+  };
+}
 
 type ChatScrollHost = {
   renderLifecycle: RenderLifecycle;
@@ -217,6 +297,29 @@ export function handleChatScroll(host: ChatScrollHost, event: Event): void {
     container.scrollHeight - container.clientHeight > LATEST_MESSAGE_THRESHOLD &&
       distanceFromBottom > LATEST_MESSAGE_THRESHOLD,
   );
+}
+
+export function restoreChatScroll(
+  host: ChatScrollHost,
+  target: HTMLElement,
+  scrollTop: number,
+): number {
+  cancelChatScroll(host);
+  const maxScrollTop = Math.max(0, target.scrollHeight - target.clientHeight);
+  target.scrollTop = Math.min(Math.max(0, scrollTop), maxScrollTop);
+  const restoredScrollTop = target.scrollTop;
+  const distanceFromBottom = maxScrollTop - restoredScrollTop;
+  host.chatLastScrollTop = restoredScrollTop;
+  host.chatLastScrollHeight = target.scrollHeight;
+  host.chatHasAutoScrolled = true;
+  // A virtualized transcript may not expose its final scroll height yet. Keep
+  // the restored viewport locked until the requested offset becomes reachable.
+  host.chatFollowLocked = scrollTop > maxScrollTop || distanceFromBottom > LATEST_MESSAGE_THRESHOLD;
+  host.chatUserNearBottom = !host.chatFollowLocked && distanceFromBottom < NEAR_BOTTOM_THRESHOLD;
+  host.chatIsProgrammaticScroll = false;
+  host.chatProgrammaticScrollTarget = restoredScrollTop;
+  setNewMessagesBelow(host, host.chatFollowLocked);
+  return restoredScrollTop;
 }
 
 export function resetChatScroll(host: ChatScrollHost): void {


### PR DESCRIPTION
## What Problem This Solves

Switching sessions A→B→A in the Control UI rebuilds session A's entire chat item list, discards every measured row height (visible reflow as the virtualizer re-estimates at 120px then corrects), and always jumps to the end of the transcript. The per-session caches already exist — the switch path deleted them: `resetChatThreadPresentationState` dropped the whole per-pane item map, `ChatTranscriptController` constructed a fresh virtualizer host per session change, and `resetOlderMessagesViewport` nulled the scroll position.

## Why This Change Was Made

Cache retention makes switch-back render from warm state in the same frame instead of rebuilding: stable row identities (no Lit re-stamping), preserved measurements (no reflow), and restored reading position.

## User Impact

Switching back to a recently viewed session is instant and visually stable, and it returns to where you were reading instead of jumping to the end (deliberate, user-visible improvement). First visits still anchor to the end; new-message arrival doesn't force-jump a restored viewport.

## Evidence

- Switch now resets only transient fields (searchOpen/searchQuery, menus/popovers) and keeps per-session item caches; A→B→A reuses built items (build-spy regression) with stable row identities.
- Bounded 3-host virtualizer LRU inside the controller: inactive hosts disconnect their ResizeObservers, eviction fully disposes refs (leak assertion), pane width change triggers remeasure.
- Scroll restore: bounded 8-pane × 20-session LRU distinguishing fixed positions from end anchoring; restored sessions skip the forced end-scroll; virtualized late-height case kept locked until the offset is reachable (commented).
- Markdown LRU 200 → 500 with the existing 50k-char entry cap to stop cross-session thrash (bound documented).
- `syncToolCardExpansionState` skips the full-transcript walk when the items array identity is unchanged (spy test).
- Validation: 1,505 tests (grep-selected suites) + 73 browser tests + 222 final focused regressions; UI tsgo, oxlint, oxfmt, git diff --check clean; autoreview clean (one finding rejected with threshold proof).
