### PR TITLE
fix(ui): keep streamed media pinned to the chat

### DIFF
--- a/src/cli/mcp-cli.oauth.test.ts
+++ b/src/cli/mcp-cli.oauth.test.ts
@@ -1,0 +1,254 @@
+// MCP CLI OAuth tests cover credential status, login callbacks, and logout behavior.
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import * as mcpHttpFetch from "../agents/mcp-http-fetch.js";
+import { withTempHome } from "../config/home-env.test-harness.js";
+import { getFreePort } from "../test-utils/ports.js";
+import {
+  cleanupMcpCliTestState,
+  clearMcpOAuthCredentials,
+  createWorkspace,
+  lastLogLine,
+  mockLog,
+  readMcpOAuthCredentialsStatus,
+  resetMcpCliTestState,
+  runMcpCommand,
+  runMcpOAuthLogin,
+} from "./mcp-cli.test-harness.js";
+
+type RunMcpOAuthLogin = typeof import("../agents/mcp-oauth.js").runMcpOAuthLogin;
+
+describe("mcp cli OAuth", () => {
+  beforeEach(() => {
+    resetMcpCliTestState();
+  });
+
+  afterEach(async () => {
+    await cleanupMcpCliTestState();
+  });
+
+  it("includes OAuth credential status in MCP status output", async () => {
+    await withTempHome("openclaw-cli-mcp-home-", async () => {
+      const workspaceDir = await createWorkspace();
+      vi.spyOn(process, "cwd").mockReturnValue(workspaceDir);
+      readMcpOAuthCredentialsStatus.mockResolvedValueOnce({
+        hasTokens: true,
+        requiresAuthorization: false,
+        hasClientInformation: true,
+        hasCodeVerifier: false,
+        hasDiscoveryState: true,
+        hasLastAuthorizationUrl: true,
+      });
+
+      await runMcpCommand([
+        "mcp",
+        "set",
+        "docs",
+        '{"url":"https://mcp.example.com","transport":"streamable-http","auth":"oauth"}',
+      ]);
+      mockLog.mockClear();
+
+      await runMcpCommand(["mcp", "status", "--json"]);
+
+      expect(JSON.parse(lastLogLine()).servers[0]).toMatchObject({
+        name: "docs",
+        auth: "oauth",
+        authStatus: {
+          hasTokens: true,
+          requiresAuthorization: false,
+          hasClientInformation: true,
+          hasCodeVerifier: false,
+          hasDiscoveryState: true,
+          hasLastAuthorizationUrl: true,
+        },
+      });
+    });
+  });
+
+  it("surfaces required OAuth authorization in status and doctor", async () => {
+    await withTempHome("openclaw-cli-mcp-home-", async () => {
+      const workspaceDir = await createWorkspace();
+      vi.spyOn(process, "cwd").mockReturnValue(workspaceDir);
+      readMcpOAuthCredentialsStatus.mockResolvedValue({
+        hasTokens: true,
+        requiresAuthorization: true,
+        hasClientInformation: true,
+        hasCodeVerifier: false,
+        hasDiscoveryState: true,
+        hasLastAuthorizationUrl: true,
+      });
+
+      await runMcpCommand([
+        "mcp",
+        "set",
+        "docs",
+        '{"url":"https://mcp.example.com","transport":"streamable-http","auth":"oauth"}',
+      ]);
+      mockLog.mockClear();
+
+      await runMcpCommand(["mcp", "status", "--verbose"]);
+
+      const statusLines = mockLog.mock.calls.map((call) => String(call[0]));
+      expect(statusLines).toContain("- docs: streamable-http oauth authorization-required");
+      expect(statusLines).toContain("  oauth: tokens=yes authorization=required client=yes");
+
+      mockLog.mockClear();
+      await runMcpCommand(["mcp", "doctor", "--json"]);
+
+      expect(JSON.parse(lastLogLine())).toMatchObject({
+        ok: true,
+        servers: [
+          {
+            name: "docs",
+            ok: true,
+            issues: [
+              {
+                level: "warning",
+                message:
+                  "OAuth credentials require additional authorization; run openclaw mcp login docs",
+              },
+            ],
+          },
+        ],
+      });
+    });
+  });
+
+  it("configures enablement, timeouts, and OAuth login", async () => {
+    await withTempHome("openclaw-cli-mcp-home-", async () => {
+      const workspaceDir = await createWorkspace();
+      vi.spyOn(process, "cwd").mockReturnValue(workspaceDir);
+      const buildMcpHttpFetch = vi.spyOn(mcpHttpFetch, "buildMcpHttpFetch");
+      runMcpOAuthLogin.mockResolvedValueOnce("authorized");
+
+      await runMcpCommand([
+        "mcp",
+        "set",
+        "docs",
+        '{"url":"https://mcp.example.com","transport":"streamable-http"}',
+      ]);
+      await runMcpCommand([
+        "mcp",
+        "configure",
+        "docs",
+        "--disable",
+        "--timeout",
+        "9",
+        "--auth",
+        "oauth",
+      ]);
+      await runMcpCommand(["mcp", "login", "docs", "--code", "abc123"]);
+
+      expect(buildMcpHttpFetch).toHaveBeenCalledWith(
+        expect.objectContaining({
+          resourceUrl: "https://mcp.example.com",
+          timeoutMs: 9_000,
+        }),
+      );
+      expect(runMcpOAuthLogin).toHaveBeenCalledWith({
+        serverName: "docs",
+        serverUrl: "https://mcp.example.com",
+        config: undefined,
+        fetchFn: expect.any(Function),
+        authorizationCode: "abc123",
+        onAuthorizationUrl: expect.any(Function),
+      });
+
+      mockLog.mockClear();
+      await runMcpCommand(["mcp", "status", "--json"]);
+      expect(JSON.parse(lastLogLine()).servers[0]).toMatchObject({
+        name: "docs",
+        enabled: false,
+        ok: false,
+        requestTimeoutMs: 9_000,
+        auth: "oauth",
+      });
+    });
+  });
+
+  it("captures the browser redirect before completing OAuth login", async () => {
+    await withTempHome("openclaw-cli-mcp-home-", async () => {
+      const workspaceDir = await createWorkspace();
+      const port = await getFreePort();
+      const redirectUrl = `http://127.0.0.1:${port}/oauth/callback`;
+      const authUrl = new URL("https://auth.example.com/authorize");
+      authUrl.searchParams.set("state", "state-1");
+      authUrl.searchParams.set("redirect_uri", redirectUrl);
+      vi.spyOn(process, "cwd").mockReturnValue(workspaceDir);
+
+      await runMcpCommand([
+        "mcp",
+        "set",
+        "docs",
+        JSON.stringify({
+          url: "https://mcp.example.com",
+          transport: "streamable-http",
+          auth: "oauth",
+          oauth: { redirectUrl },
+        }),
+      ]);
+      mockLog.mockClear();
+      let capturedCode: string | undefined;
+      runMcpOAuthLogin.mockImplementationOnce(async (params: Parameters<RunMcpOAuthLogin>[0]) => {
+        const code = await params.onAuthorizationUrl?.(authUrl);
+        capturedCode = typeof code === "string" ? code : undefined;
+        return "authorized";
+      });
+
+      const login = runMcpCommand(["mcp", "login", "docs"]);
+      await vi.waitFor(() => expect(mockLog).toHaveBeenCalledWith(authUrl.toString()));
+      const response = await fetch(`${redirectUrl}?code=browser-code&state=state-1`);
+      expect(response.status).toBe(200);
+      await expect(response.text()).resolves.toContain("MCP OAuth complete");
+      await login;
+
+      expect(capturedCode).toBe("browser-code");
+      expect(lastLogLine()).toBe('MCP OAuth credentials saved for "docs".');
+      expect(mockLog).toHaveBeenCalledWith(
+        "If the browser redirect cannot reach this machine, stop this command and run openclaw mcp login docs --code <code>.",
+      );
+    });
+  });
+
+  it("clears stored OAuth credentials on logout", async () => {
+    await withTempHome("openclaw-cli-mcp-home-", async () => {
+      const workspaceDir = await createWorkspace();
+      vi.spyOn(process, "cwd").mockReturnValue(workspaceDir);
+
+      await runMcpCommand([
+        "mcp",
+        "set",
+        "docs",
+        '{"url":"https://mcp.example.com","transport":"streamable-http","auth":"oauth"}',
+      ]);
+      clearMcpOAuthCredentials.mockClear();
+      await runMcpCommand(["mcp", "logout", "docs"]);
+
+      expect(clearMcpOAuthCredentials).toHaveBeenCalledWith({
+        serverName: "docs",
+        serverUrl: "https://mcp.example.com",
+      });
+      expect(lastLogLine()).toBe('MCP OAuth credentials cleared for "docs".');
+    });
+  });
+
+  it("clears stored OAuth credentials after auth is removed", async () => {
+    await withTempHome("openclaw-cli-mcp-home-", async () => {
+      const workspaceDir = await createWorkspace();
+      vi.spyOn(process, "cwd").mockReturnValue(workspaceDir);
+
+      await runMcpCommand([
+        "mcp",
+        "set",
+        "docs",
+        '{"url":"https://mcp.example.com","transport":"streamable-http"}',
+      ]);
+      clearMcpOAuthCredentials.mockClear();
+      await runMcpCommand(["mcp", "logout", "docs"]);
+
+      expect(clearMcpOAuthCredentials).toHaveBeenCalledWith({
+        serverName: "docs",
+        serverUrl: "https://mcp.example.com",
+      });
+    });
+  });
+});

--- a/src/cli/mcp-cli.test-harness.ts
+++ b/src/cli/mcp-cli.test-harness.ts
@@ -1,0 +1,113 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { Command } from "commander";
+import { vi } from "vitest";
+import { registerMcpCli } from "./mcp-cli.js";
+
+type CreateSessionMcpRuntime =
+  typeof import("../agents/agent-bundle-mcp-runtime.js").createSessionMcpRuntime;
+
+const mocks = vi.hoisted(() => {
+  const runtime = {
+    log: vi.fn(),
+    error: vi.fn(),
+    exit: vi.fn((code: number) => {
+      throw new Error(`__exit__:${code}`);
+    }),
+    writeJson: vi.fn((value: unknown, space = 2) => {
+      runtime.log(JSON.stringify(value, null, space > 0 ? space : undefined));
+    }),
+  };
+  return {
+    runtime,
+    serveOpenClawChannelMcp: vi.fn(),
+    clearMcpOAuthCredentials: vi.fn(),
+    readMcpOAuthCredentialsStatus: vi.fn(),
+    runMcpOAuthLogin: vi.fn(),
+    createSessionMcpRuntimeOverride: undefined as CreateSessionMcpRuntime | undefined,
+  };
+});
+
+export const mockLog = mocks.runtime.log;
+export const mockError = mocks.runtime.error;
+export const serveOpenClawChannelMcp = mocks.serveOpenClawChannelMcp;
+export const clearMcpOAuthCredentials = mocks.clearMcpOAuthCredentials;
+export const readMcpOAuthCredentialsStatus = mocks.readMcpOAuthCredentialsStatus;
+export const runMcpOAuthLogin = mocks.runMcpOAuthLogin;
+
+vi.mock("../runtime.js", () => ({
+  defaultRuntime: mocks.runtime,
+}));
+
+vi.mock("../mcp/channel-server.js", () => ({
+  serveOpenClawChannelMcp: mocks.serveOpenClawChannelMcp,
+}));
+
+vi.mock("../agents/mcp-oauth.js", () => ({
+  clearMcpOAuthCredentials: mocks.clearMcpOAuthCredentials,
+  readMcpOAuthCredentialsStatus: mocks.readMcpOAuthCredentialsStatus,
+  runMcpOAuthLogin: mocks.runMcpOAuthLogin,
+}));
+
+vi.mock("../agents/agent-bundle-mcp-runtime.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../agents/agent-bundle-mcp-runtime.js")>();
+  return {
+    ...actual,
+    createSessionMcpRuntime: (params: Parameters<CreateSessionMcpRuntime>[0]) =>
+      mocks.createSessionMcpRuntimeOverride?.(params) ?? actual.createSessionMcpRuntime(params),
+  };
+});
+
+const tempDirs: string[] = [];
+let sharedProgram: Command;
+
+export async function createWorkspace(): Promise<string> {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-cli-mcp-"));
+  tempDirs.push(dir);
+  return dir;
+}
+
+export async function runMcpCommand(args: string[]) {
+  if (!sharedProgram) {
+    sharedProgram = new Command();
+    sharedProgram.exitOverride();
+    registerMcpCli(sharedProgram);
+  }
+  await sharedProgram.parseAsync(args, { from: "user" });
+}
+
+export function setCreateSessionMcpRuntimeOverride(override: CreateSessionMcpRuntime): void {
+  mocks.createSessionMcpRuntimeOverride = override;
+}
+
+export function lastLogLine(): string {
+  return lastRuntimeLine(mockLog);
+}
+
+export function lastErrorLine(): string {
+  return lastRuntimeLine(mockError);
+}
+
+function lastRuntimeLine(mock: typeof mockLog): string {
+  const call = mock.mock.calls[mock.mock.calls.length - 1];
+  return String(call?.[0] ?? "");
+}
+
+export function resetMcpCliTestState(): void {
+  vi.clearAllMocks();
+  mocks.createSessionMcpRuntimeOverride = undefined;
+  readMcpOAuthCredentialsStatus.mockResolvedValue({
+    hasTokens: false,
+    requiresAuthorization: false,
+    hasClientInformation: false,
+    hasCodeVerifier: false,
+    hasDiscoveryState: false,
+    hasLastAuthorizationUrl: false,
+  });
+}
+
+export async function cleanupMcpCliTestState(): Promise<void> {
+  vi.restoreAllMocks();
+  await Promise.all(tempDirs.splice(0).map((dir) => fs.rm(dir, { recursive: true, force: true })));
+}

--- a/src/cli/mcp-cli.test.ts
+++ b/src/cli/mcp-cli.test.ts
@@ -4,7 +4,6 @@ import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { withTempHome } from "../config/home-env.test-harness.js";
 import { createDeferred } from "../shared/deferred.js";
-import { writeProbeMcpServer } from "./mcp-cli.test-support.js";
 import {
   cleanupMcpCliTestState,
   clearMcpOAuthCredentials,
@@ -19,6 +18,7 @@ import {
   setCreateSessionMcpRuntimeOverride,
   serveOpenClawChannelMcp,
 } from "./mcp-cli.test-harness.js";
+import { writeProbeMcpServer } from "./mcp-cli.test-support.js";
 
 describe("mcp cli", () => {
   beforeEach(() => {

--- a/src/cli/mcp-cli.test.ts
+++ b/src/cli/mcp-cli.test.ts
@@ -1,124 +1,32 @@
 // MCP CLI tests cover MCP command registration and server configuration behavior.
 import fs from "node:fs/promises";
-import os from "node:os";
 import path from "node:path";
-import { Command } from "commander";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import * as mcpHttpFetch from "../agents/mcp-http-fetch.js";
 import { withTempHome } from "../config/home-env.test-harness.js";
 import { createDeferred } from "../shared/deferred.js";
-import { getFreePort } from "../test-utils/ports.js";
-import { registerMcpCli } from "./mcp-cli.js";
 import { writeProbeMcpServer } from "./mcp-cli.test-support.js";
-
-type CreateSessionMcpRuntime =
-  typeof import("../agents/agent-bundle-mcp-runtime.js").createSessionMcpRuntime;
-type RunMcpOAuthLogin = typeof import("../agents/mcp-oauth.js").runMcpOAuthLogin;
-
-const mocks = vi.hoisted(() => {
-  const runtime = {
-    log: vi.fn(),
-    error: vi.fn(),
-    exit: vi.fn((code: number) => {
-      throw new Error(`__exit__:${code}`);
-    }),
-    writeJson: vi.fn((value: unknown, space = 2) => {
-      runtime.log(JSON.stringify(value, null, space > 0 ? space : undefined));
-    }),
-  };
-  return {
-    runtime,
-    serveOpenClawChannelMcp: vi.fn(),
-    clearMcpOAuthCredentials: vi.fn(),
-    readMcpOAuthCredentialsStatus: vi.fn(),
-    runMcpOAuthLogin: vi.fn(),
-    createSessionMcpRuntimeOverride: undefined as CreateSessionMcpRuntime | undefined,
-  };
-});
-
-const defaultRuntime = mocks.runtime;
-const mockLog = defaultRuntime.log;
-const mockError = defaultRuntime.error;
-const serveOpenClawChannelMcp = mocks.serveOpenClawChannelMcp;
-const clearMcpOAuthCredentials = mocks.clearMcpOAuthCredentials;
-const readMcpOAuthCredentialsStatus = mocks.readMcpOAuthCredentialsStatus;
-const runMcpOAuthLogin = mocks.runMcpOAuthLogin;
-
-vi.mock("../runtime.js", () => ({
-  defaultRuntime: mocks.runtime,
-}));
-
-vi.mock("../mcp/channel-server.js", () => ({
-  serveOpenClawChannelMcp: mocks.serveOpenClawChannelMcp,
-}));
-
-vi.mock("../agents/mcp-oauth.js", () => ({
-  clearMcpOAuthCredentials: mocks.clearMcpOAuthCredentials,
-  readMcpOAuthCredentialsStatus: mocks.readMcpOAuthCredentialsStatus,
-  runMcpOAuthLogin: mocks.runMcpOAuthLogin,
-}));
-
-vi.mock("../agents/agent-bundle-mcp-runtime.js", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("../agents/agent-bundle-mcp-runtime.js")>();
-  return {
-    ...actual,
-    createSessionMcpRuntime: (params: Parameters<CreateSessionMcpRuntime>[0]) =>
-      mocks.createSessionMcpRuntimeOverride?.(params) ?? actual.createSessionMcpRuntime(params),
-  };
-});
-
-const tempDirs: string[] = [];
-
-async function createWorkspace(): Promise<string> {
-  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-cli-mcp-"));
-  tempDirs.push(dir);
-  return dir;
-}
-
-let sharedProgram: Command;
-
-async function runMcpCommand(args: string[]) {
-  await sharedProgram.parseAsync(args, { from: "user" });
-}
-
-function lastLogLine(): string {
-  return lastRuntimeLine(mockLog);
-}
-
-function lastErrorLine(): string {
-  return lastRuntimeLine(mockError);
-}
-
-function lastRuntimeLine(mock: typeof mockLog): string {
-  const call = mock.mock.calls[mock.mock.calls.length - 1];
-  return String(call?.[0] ?? "");
-}
+import {
+  cleanupMcpCliTestState,
+  clearMcpOAuthCredentials,
+  createWorkspace,
+  lastErrorLine,
+  lastLogLine,
+  mockError,
+  mockLog,
+  readMcpOAuthCredentialsStatus,
+  resetMcpCliTestState,
+  runMcpCommand,
+  setCreateSessionMcpRuntimeOverride,
+  serveOpenClawChannelMcp,
+} from "./mcp-cli.test-harness.js";
 
 describe("mcp cli", () => {
-  if (!sharedProgram) {
-    sharedProgram = new Command();
-    sharedProgram.exitOverride();
-    registerMcpCli(sharedProgram);
-  }
-
   beforeEach(() => {
-    vi.clearAllMocks();
-    mocks.createSessionMcpRuntimeOverride = undefined;
-    readMcpOAuthCredentialsStatus.mockResolvedValue({
-      hasTokens: false,
-      requiresAuthorization: false,
-      hasClientInformation: false,
-      hasCodeVerifier: false,
-      hasDiscoveryState: false,
-      hasLastAuthorizationUrl: false,
-    });
+    resetMcpCliTestState();
   });
 
   afterEach(async () => {
-    vi.restoreAllMocks();
-    await Promise.all(
-      tempDirs.splice(0).map((dir) => fs.rm(dir, { recursive: true, force: true })),
-    );
+    await cleanupMcpCliTestState();
   });
 
   it("sets and shows a configured MCP server", async () => {
@@ -301,7 +209,7 @@ describe("mcp cli", () => {
       const configPath = path.join(home, ".openclaw", "openclaw.json");
       vi.spyOn(process, "cwd").mockReturnValue(workspaceDir);
       let probeTimeoutMs: unknown;
-      mocks.createSessionMcpRuntimeOverride = (params) => {
+      setCreateSessionMcpRuntimeOverride((params) => {
         probeTimeoutMs = params.cfg?.mcp?.servers?.["hung-default"]?.connectionTimeoutMs;
         return {
           sessionId: params.sessionId,
@@ -329,7 +237,7 @@ describe("mcp cli", () => {
           callTool: async () => ({ content: [] }),
           dispose: async () => {},
         };
-      };
+      });
 
       await expect(
         runMcpCommand(["mcp", "add", "hung-default", "--command", process.execPath]),
@@ -474,232 +382,6 @@ describe("mcp cli", () => {
       expect(verboseOutput).toContain("launch: node server.mjs --api-key *** --token=***");
       expect(verboseOutput).not.toContain("test-api-key");
       expect(verboseOutput).not.toContain("test-token");
-    });
-  });
-
-  it("includes OAuth credential status in MCP status output", async () => {
-    await withTempHome("openclaw-cli-mcp-home-", async () => {
-      const workspaceDir = await createWorkspace();
-      vi.spyOn(process, "cwd").mockReturnValue(workspaceDir);
-      readMcpOAuthCredentialsStatus.mockResolvedValueOnce({
-        hasTokens: true,
-        requiresAuthorization: false,
-        hasClientInformation: true,
-        hasCodeVerifier: false,
-        hasDiscoveryState: true,
-        hasLastAuthorizationUrl: true,
-      });
-
-      await runMcpCommand([
-        "mcp",
-        "set",
-        "docs",
-        '{"url":"https://mcp.example.com","transport":"streamable-http","auth":"oauth"}',
-      ]);
-      mockLog.mockClear();
-
-      await runMcpCommand(["mcp", "status", "--json"]);
-
-      expect(JSON.parse(lastLogLine()).servers[0]).toMatchObject({
-        name: "docs",
-        auth: "oauth",
-        authStatus: {
-          hasTokens: true,
-          requiresAuthorization: false,
-          hasClientInformation: true,
-          hasCodeVerifier: false,
-          hasDiscoveryState: true,
-          hasLastAuthorizationUrl: true,
-        },
-      });
-    });
-  });
-
-  it("surfaces required OAuth authorization in status and doctor", async () => {
-    await withTempHome("openclaw-cli-mcp-home-", async () => {
-      const workspaceDir = await createWorkspace();
-      vi.spyOn(process, "cwd").mockReturnValue(workspaceDir);
-      readMcpOAuthCredentialsStatus.mockResolvedValue({
-        hasTokens: true,
-        requiresAuthorization: true,
-        hasClientInformation: true,
-        hasCodeVerifier: false,
-        hasDiscoveryState: true,
-        hasLastAuthorizationUrl: true,
-      });
-
-      await runMcpCommand([
-        "mcp",
-        "set",
-        "docs",
-        '{"url":"https://mcp.example.com","transport":"streamable-http","auth":"oauth"}',
-      ]);
-      mockLog.mockClear();
-
-      await runMcpCommand(["mcp", "status", "--verbose"]);
-
-      const statusLines = mockLog.mock.calls.map((call) => String(call[0]));
-      expect(statusLines).toContain("- docs: streamable-http oauth authorization-required");
-      expect(statusLines).toContain("  oauth: tokens=yes authorization=required client=yes");
-
-      mockLog.mockClear();
-      await runMcpCommand(["mcp", "doctor", "--json"]);
-
-      expect(JSON.parse(lastLogLine())).toMatchObject({
-        ok: true,
-        servers: [
-          {
-            name: "docs",
-            ok: true,
-            issues: [
-              {
-                level: "warning",
-                message:
-                  "OAuth credentials require additional authorization; run openclaw mcp login docs",
-              },
-            ],
-          },
-        ],
-      });
-    });
-  });
-
-  it("configures enablement, timeouts, and OAuth login", async () => {
-    await withTempHome("openclaw-cli-mcp-home-", async () => {
-      const workspaceDir = await createWorkspace();
-      vi.spyOn(process, "cwd").mockReturnValue(workspaceDir);
-      const buildMcpHttpFetch = vi.spyOn(mcpHttpFetch, "buildMcpHttpFetch");
-      runMcpOAuthLogin.mockResolvedValueOnce("authorized");
-
-      await runMcpCommand([
-        "mcp",
-        "set",
-        "docs",
-        '{"url":"https://mcp.example.com","transport":"streamable-http"}',
-      ]);
-      await runMcpCommand([
-        "mcp",
-        "configure",
-        "docs",
-        "--disable",
-        "--timeout",
-        "9",
-        "--auth",
-        "oauth",
-      ]);
-      await runMcpCommand(["mcp", "login", "docs", "--code", "abc123"]);
-
-      expect(buildMcpHttpFetch).toHaveBeenCalledWith(
-        expect.objectContaining({
-          resourceUrl: "https://mcp.example.com",
-          timeoutMs: 9_000,
-        }),
-      );
-      expect(runMcpOAuthLogin).toHaveBeenCalledWith({
-        serverName: "docs",
-        serverUrl: "https://mcp.example.com",
-        config: undefined,
-        fetchFn: expect.any(Function),
-        authorizationCode: "abc123",
-        onAuthorizationUrl: expect.any(Function),
-      });
-
-      mockLog.mockClear();
-      await runMcpCommand(["mcp", "status", "--json"]);
-      expect(JSON.parse(lastLogLine()).servers[0]).toMatchObject({
-        name: "docs",
-        enabled: false,
-        ok: false,
-        requestTimeoutMs: 9_000,
-        auth: "oauth",
-      });
-    });
-  });
-
-  it("captures the browser redirect before completing OAuth login", async () => {
-    await withTempHome("openclaw-cli-mcp-home-", async () => {
-      const workspaceDir = await createWorkspace();
-      const port = await getFreePort();
-      const redirectUrl = `http://127.0.0.1:${port}/oauth/callback`;
-      const authUrl = new URL("https://auth.example.com/authorize");
-      authUrl.searchParams.set("state", "state-1");
-      authUrl.searchParams.set("redirect_uri", redirectUrl);
-      vi.spyOn(process, "cwd").mockReturnValue(workspaceDir);
-
-      await runMcpCommand([
-        "mcp",
-        "set",
-        "docs",
-        JSON.stringify({
-          url: "https://mcp.example.com",
-          transport: "streamable-http",
-          auth: "oauth",
-          oauth: { redirectUrl },
-        }),
-      ]);
-      mockLog.mockClear();
-      let capturedCode: string | undefined;
-      runMcpOAuthLogin.mockImplementationOnce(async (params: Parameters<RunMcpOAuthLogin>[0]) => {
-        const code = await params.onAuthorizationUrl?.(authUrl);
-        capturedCode = typeof code === "string" ? code : undefined;
-        return "authorized";
-      });
-
-      const login = runMcpCommand(["mcp", "login", "docs"]);
-      await vi.waitFor(() => expect(mockLog).toHaveBeenCalledWith(authUrl.toString()));
-      const response = await fetch(`${redirectUrl}?code=browser-code&state=state-1`);
-      expect(response.status).toBe(200);
-      await expect(response.text()).resolves.toContain("MCP OAuth complete");
-      await login;
-
-      expect(capturedCode).toBe("browser-code");
-      expect(lastLogLine()).toBe('MCP OAuth credentials saved for "docs".');
-      expect(mockLog).toHaveBeenCalledWith(
-        "If the browser redirect cannot reach this machine, stop this command and run openclaw mcp login docs --code <code>.",
-      );
-    });
-  });
-
-  it("clears stored OAuth credentials on logout", async () => {
-    await withTempHome("openclaw-cli-mcp-home-", async () => {
-      const workspaceDir = await createWorkspace();
-      vi.spyOn(process, "cwd").mockReturnValue(workspaceDir);
-
-      await runMcpCommand([
-        "mcp",
-        "set",
-        "docs",
-        '{"url":"https://mcp.example.com","transport":"streamable-http","auth":"oauth"}',
-      ]);
-      clearMcpOAuthCredentials.mockClear();
-      await runMcpCommand(["mcp", "logout", "docs"]);
-
-      expect(clearMcpOAuthCredentials).toHaveBeenCalledWith({
-        serverName: "docs",
-        serverUrl: "https://mcp.example.com",
-      });
-      expect(lastLogLine()).toBe('MCP OAuth credentials cleared for "docs".');
-    });
-  });
-
-  it("clears stored OAuth credentials after auth is removed", async () => {
-    await withTempHome("openclaw-cli-mcp-home-", async () => {
-      const workspaceDir = await createWorkspace();
-      vi.spyOn(process, "cwd").mockReturnValue(workspaceDir);
-
-      await runMcpCommand([
-        "mcp",
-        "set",
-        "docs",
-        '{"url":"https://mcp.example.com","transport":"streamable-http"}',
-      ]);
-      clearMcpOAuthCredentials.mockClear();
-      await runMcpCommand(["mcp", "logout", "docs"]);
-
-      expect(clearMcpOAuthCredentials).toHaveBeenCalledWith({
-        serverName: "docs",
-        serverUrl: "https://mcp.example.com",
-      });
     });
   });
 

--- a/ui/src/e2e/chat-flow.streaming.e2e.test.ts
+++ b/ui/src/e2e/chat-flow.streaming.e2e.test.ts
@@ -1,3 +1,5 @@
+import { mkdir } from "node:fs/promises";
+import path from "node:path";
 import { expect, it } from "vitest";
 import {
   chatThreadDistanceFromBottom,
@@ -13,6 +15,110 @@ import {
 const suite = createChatFlowE2eSuite();
 
 suite.define(() => {
+  it("keeps streamed audio and video metadata pinned without overriding manual scroll", async () => {
+    const artifactDir = process.env.OPENCLAW_UI_E2E_ARTIFACT_DIR?.trim();
+    const context = await suite.newBrowserContext({
+      locale: "en-US",
+      serviceWorkers: "block",
+      viewport: { height: 900, width: 1280 },
+    });
+    const page = await context.newPage();
+    const baseTs = Date.now() - 100_000;
+    const historyMessages = Array.from({ length: 50 }, (_, index) => ({
+      content: [
+        {
+          text: `Existing transcript message ${index}\n${"Existing streamed history.\n".repeat(5)}`,
+          type: "text",
+        },
+      ],
+      role: index % 2 === 0 ? "user" : "assistant",
+      timestamp: baseTs + index,
+    }));
+    const gateway = await installMockGateway(page, { historyMessages });
+
+    try {
+      await page.goto(`${suite.server.baseUrl}chat`);
+      await page.getByText("Existing transcript message 49", { exact: false }).waitFor({
+        timeout: 10_000,
+      });
+      await waitForChatScrollIdle(page);
+
+      const prompt = "stream a voice note and video";
+      await page.locator(".agent-chat__composer-combobox textarea").fill(prompt);
+      await page.getByRole("button", { name: "Send message" }).click();
+      const sendRequest = await gateway.waitForRequest("chat.send");
+      const runId = requireString(
+        requireRecord(sendRequest.params).idempotencyKey,
+        "chat send idempotency key",
+      );
+      await gateway.emitChatFinal({
+        runId,
+        text:
+          "Here is the narrated update.\n" +
+          "MEDIA:https://example.com/voice.ogg\n" +
+          "MEDIA:https://example.com/clip.mp4",
+      });
+
+      for (const selector of ["audio", "video"]) {
+        const media = page.locator(`.chat-thread ${selector}`);
+        await media.waitFor({ state: "attached", timeout: 10_000 });
+        await waitForChatScrollIdle(page);
+        expect(await chatThreadDistanceFromBottom(page)).toBeLessThanOrEqual(8);
+
+        const scrollGeneration = await media.evaluate((element) => {
+          const pane = document.querySelector("openclaw-chat-pane") as
+            | (HTMLElement & { state?: { chatScrollGeneration?: number } })
+            | null;
+          const before = pane?.state?.chatScrollGeneration;
+          element.style.display = "block";
+          element.style.height = "480px";
+          element.dispatchEvent(new Event("loadedmetadata", { bubbles: true }));
+          return { after: pane?.state?.chatScrollGeneration, before };
+        });
+
+        expect(scrollGeneration.after).toBeGreaterThan(scrollGeneration.before ?? -1);
+        await expect
+          .poll(() => chatThreadDistanceFromBottom(page), { timeout: 10_000 })
+          .toBeLessThanOrEqual(8);
+      }
+
+      if (artifactDir) {
+        await mkdir(artifactDir, { recursive: true });
+        await page.screenshot({
+          fullPage: true,
+          path: path.join(artifactDir, "streamed-media-pinned.png"),
+        });
+      }
+
+      const media = await page.locator(".chat-thread audio").elementHandle();
+      if (!media) {
+        throw new Error("expected rendered assistant audio");
+      }
+      await page.locator(".chat-thread").evaluate((element) => {
+        const thread = element as HTMLElement;
+        thread.scrollTop = Math.max(0, thread.scrollHeight - thread.clientHeight - 120);
+        thread.dispatchEvent(new Event("scroll", { bubbles: true }));
+      });
+      expect(await chatThreadDistanceFromBottom(page)).toBeGreaterThan(8);
+      await media.evaluate((element) => {
+        element.style.height = "600px";
+        element.dispatchEvent(new Event("loadedmetadata", { bubbles: true }));
+      });
+      await expect
+        .poll(() => chatThreadDistanceFromBottom(page), { timeout: 10_000 })
+        .toBeGreaterThan(8);
+
+      if (artifactDir) {
+        await page.screenshot({
+          fullPage: true,
+          path: path.join(artifactDir, "streamed-media-manual-scroll.png"),
+        });
+      }
+    } finally {
+      await suite.closeBrowserContext(context);
+    }
+  });
+
   it("renders stable markdown during a streaming chat turn and finalizes the tail", async () => {
     const context = await suite.newBrowserContext({
       locale: "en-US",

--- a/ui/src/e2e/chat-flow.streaming.e2e.test.ts
+++ b/ui/src/e2e/chat-flow.streaming.e2e.test.ts
@@ -94,12 +94,24 @@ suite.define(() => {
       if (!media) {
         throw new Error("expected rendered assistant audio");
       }
-      await page.locator(".chat-thread").evaluate((element) => {
-        const thread = element as HTMLElement;
-        thread.scrollTop = Math.max(0, thread.scrollHeight - thread.clientHeight - 120);
-        thread.dispatchEvent(new Event("scroll", { bubbles: true }));
-      });
-      expect(await chatThreadDistanceFromBottom(page)).toBeGreaterThan(8);
+      const thread = page.locator(".chat-thread");
+      await thread.hover();
+      await page.mouse.wheel(0, -240);
+      await expect
+        .poll(() => chatThreadDistanceFromBottom(page), { timeout: 10_000 })
+        .toBeGreaterThan(8);
+      await expect
+        .poll(
+          () =>
+            page.locator("openclaw-chat-pane").evaluate((element) => {
+              const pane = element as HTMLElement & {
+                state?: { chatFollowLocked?: boolean };
+              };
+              return pane.state?.chatFollowLocked;
+            }),
+          { timeout: 10_000 },
+        )
+        .toBe(true);
       await media.evaluate((element) => {
         element.style.height = "600px";
         element.dispatchEvent(new Event("loadedmetadata", { bubbles: true }));

--- a/ui/src/e2e/chat-flow.streaming.e2e.test.ts
+++ b/ui/src/e2e/chat-flow.streaming.e2e.test.ts
@@ -1,6 +1,7 @@
 import { mkdir } from "node:fs/promises";
 import path from "node:path";
 import { expect, it } from "vitest";
+import { CHAT_TRANSCRIPT_END_THRESHOLD_PX } from "../pages/chat/scroll.ts";
 import {
   chatThreadDistanceFromBottom,
   createChatFlowE2eSuite,
@@ -59,28 +60,50 @@ suite.define(() => {
           "MEDIA:https://example.com/clip.mp4",
       });
 
-      for (const selector of ["audio", "video"]) {
-        const media = page.locator(`.chat-thread ${selector}`);
+      const thread = page.locator(".chat-thread");
+      const growMedia = async (selector: "audio" | "video", height: number) => {
+        const media = thread.locator(selector);
         await media.waitFor({ state: "attached", timeout: 10_000 });
         await waitForChatScrollIdle(page);
-        expect(await chatThreadDistanceFromBottom(page)).toBeLessThanOrEqual(8);
-
-        const scrollGeneration = await media.evaluate((element) => {
-          const pane = document.querySelector("openclaw-chat-pane") as
-            | (HTMLElement & { state?: { chatScrollGeneration?: number } })
-            | null;
-          const before = pane?.state?.chatScrollGeneration;
-          element.style.display = "block";
-          element.style.height = "480px";
-          element.dispatchEvent(new Event("loadedmetadata", { bubbles: true }));
-          return { after: pane?.state?.chatScrollGeneration, before };
-        });
-
-        expect(scrollGeneration.after).toBeGreaterThan(scrollGeneration.before ?? -1);
+        const scrollHeightBefore = await thread.evaluate((element) => element.scrollHeight);
+        await media.evaluate(
+          (element, { mediaKind, nextHeight }) => {
+            const layoutOwner =
+              mediaKind === "video"
+                ? element.closest<HTMLElement>(".chat-assistant-video-frame")
+                : element.closest<HTMLElement>("openclaw-chat-audio-player");
+            if (!layoutOwner) {
+              throw new Error(`expected assistant ${mediaKind} layout owner`);
+            }
+            layoutOwner.style.display = "block";
+            layoutOwner.style.height = `${nextHeight}px`;
+            layoutOwner.style.minHeight = `${nextHeight}px`;
+            if (mediaKind === "video") {
+              layoutOwner.style.maxHeight = "none";
+              element.style.height = "100%";
+              element.style.maxHeight = "none";
+            }
+            element.dispatchEvent(new Event("loadedmetadata", { bubbles: true }));
+          },
+          { mediaKind: selector, nextHeight: height },
+        );
         await expect
-          .poll(() => chatThreadDistanceFromBottom(page), { timeout: 10_000 })
-          .toBeLessThanOrEqual(8);
-      }
+          .poll(() => thread.evaluate((element) => element.scrollHeight), { timeout: 10_000 })
+          .toBeGreaterThan(scrollHeightBefore);
+        await waitForChatScrollIdle(page);
+      };
+
+      await growMedia("audio", 320);
+      await expect
+        .poll(() => chatThreadDistanceFromBottom(page), { timeout: 10_000 })
+        .toBeLessThanOrEqual(CHAT_TRANSCRIPT_END_THRESHOLD_PX);
+      expect(await page.getByRole("button", { name: "Scroll to latest" }).count()).toBe(0);
+
+      await growMedia("video", 480);
+      await expect
+        .poll(() => chatThreadDistanceFromBottom(page), { timeout: 10_000 })
+        .toBeLessThanOrEqual(CHAT_TRANSCRIPT_END_THRESHOLD_PX);
+      expect(await page.getByRole("button", { name: "Scroll to latest" }).count()).toBe(0);
 
       if (artifactDir) {
         await mkdir(artifactDir, { recursive: true });
@@ -90,35 +113,28 @@ suite.define(() => {
         });
       }
 
-      const media = await page.locator(".chat-thread audio").elementHandle();
-      if (!media) {
-        throw new Error("expected rendered assistant audio");
-      }
-      const thread = page.locator(".chat-thread");
       await thread.hover();
-      await page.mouse.wheel(0, -240);
+      await page.mouse.wheel(0, -600);
       await expect
         .poll(() => chatThreadDistanceFromBottom(page), { timeout: 10_000 })
-        .toBeGreaterThan(8);
+        .toBeGreaterThan(CHAT_TRANSCRIPT_END_THRESHOLD_PX);
+      const scrollToLatest = page.getByRole("button", { name: "Scroll to latest" });
+      await scrollToLatest.waitFor({ state: "visible", timeout: 10_000 });
+      await waitForChatScrollIdle(page);
+      const readingScrollTop = await thread.evaluate((element) => element.scrollTop);
+
+      await growMedia("audio", 720);
+      await expect
+        .poll(() => chatThreadDistanceFromBottom(page), { timeout: 10_000 })
+        .toBeGreaterThan(CHAT_TRANSCRIPT_END_THRESHOLD_PX);
       await expect
         .poll(
-          () =>
-            page.locator("openclaw-chat-pane").evaluate((element) => {
-              const pane = element as HTMLElement & {
-                state?: { chatFollowLocked?: boolean };
-              };
-              return pane.state?.chatFollowLocked;
-            }),
+          async () =>
+            Math.abs((await thread.evaluate((element) => element.scrollTop)) - readingScrollTop),
           { timeout: 10_000 },
         )
-        .toBe(true);
-      await media.evaluate((element) => {
-        element.style.height = "600px";
-        element.dispatchEvent(new Event("loadedmetadata", { bubbles: true }));
-      });
-      await expect
-        .poll(() => chatThreadDistanceFromBottom(page), { timeout: 10_000 })
-        .toBeGreaterThan(8);
+        .toBeLessThanOrEqual(1);
+      await scrollToLatest.waitFor({ state: "visible", timeout: 10_000 });
 
       if (artifactDir) {
         await page.screenshot({
@@ -126,6 +142,12 @@ suite.define(() => {
           path: path.join(artifactDir, "streamed-media-manual-scroll.png"),
         });
       }
+
+      await scrollToLatest.click();
+      await expect
+        .poll(() => chatThreadDistanceFromBottom(page), { timeout: 10_000 })
+        .toBeLessThanOrEqual(CHAT_TRANSCRIPT_END_THRESHOLD_PX);
+      await scrollToLatest.waitFor({ state: "detached", timeout: 10_000 });
     } finally {
       await suite.closeBrowserContext(context);
     }

--- a/ui/src/e2e/chat-flow.streaming.e2e.test.ts
+++ b/ui/src/e2e/chat-flow.streaming.e2e.test.ts
@@ -52,17 +52,33 @@ suite.define(() => {
         requireRecord(sendRequest.params).idempotencyKey,
         "chat send idempotency key",
       );
-      await gateway.emitChatFinal({
+      const mediaText =
+        "Here is the narrated update.\n" +
+        "MEDIA:https://example.com/voice.ogg\n" +
+        "MEDIA:https://example.com/clip.mp4";
+      await gateway.emitGatewayEvent("chat", {
+        deltaText: mediaText,
+        message: {
+          content: [{ text: mediaText, type: "text" }],
+          role: "assistant",
+          timestamp: Date.now(),
+        },
         runId,
-        text:
-          "Here is the narrated update.\n" +
-          "MEDIA:https://example.com/voice.ogg\n" +
-          "MEDIA:https://example.com/clip.mp4",
+        sessionKey: "main",
+        state: "delta",
       });
 
       const thread = page.locator(".chat-thread");
-      const growMedia = async (selector: "audio" | "video", height: number) => {
-        const media = thread.locator(selector);
+      const activeStream = thread.locator(".chat-bubble.streaming");
+      await activeStream.waitFor({ state: "visible", timeout: 10_000 });
+      const stopGenerating = page.getByRole("button", { name: "Stop generating" });
+      await stopGenerating.waitFor({ state: "visible", timeout: 10_000 });
+      const growMedia = async (
+        selector: "audio" | "video",
+        height: number,
+        presentation: "active" | "committed" = "active",
+      ) => {
+        const media = (presentation === "active" ? activeStream : thread).locator(selector);
         await media.waitFor({ state: "attached", timeout: 10_000 });
         await waitForChatScrollIdle(page);
         const scrollHeightBefore = await thread.evaluate((element) => element.scrollHeight);
@@ -94,12 +110,14 @@ suite.define(() => {
       };
 
       await growMedia("audio", 320);
+      await stopGenerating.waitFor({ state: "visible", timeout: 10_000 });
       await expect
         .poll(() => chatThreadDistanceFromBottom(page), { timeout: 10_000 })
         .toBeLessThanOrEqual(CHAT_TRANSCRIPT_END_THRESHOLD_PX);
       expect(await page.getByRole("button", { name: "Scroll to latest" }).count()).toBe(0);
 
       await growMedia("video", 480);
+      await stopGenerating.waitFor({ state: "visible", timeout: 10_000 });
       await expect
         .poll(() => chatThreadDistanceFromBottom(page), { timeout: 10_000 })
         .toBeLessThanOrEqual(CHAT_TRANSCRIPT_END_THRESHOLD_PX);
@@ -124,6 +142,7 @@ suite.define(() => {
       const readingScrollTop = await thread.evaluate((element) => element.scrollTop);
 
       await growMedia("audio", 720);
+      await stopGenerating.waitFor({ state: "visible", timeout: 10_000 });
       await expect
         .poll(() => chatThreadDistanceFromBottom(page), { timeout: 10_000 })
         .toBeGreaterThan(CHAT_TRANSCRIPT_END_THRESHOLD_PX);
@@ -148,6 +167,16 @@ suite.define(() => {
         .poll(() => chatThreadDistanceFromBottom(page), { timeout: 10_000 })
         .toBeLessThanOrEqual(CHAT_TRANSCRIPT_END_THRESHOLD_PX);
       await scrollToLatest.waitFor({ state: "detached", timeout: 10_000 });
+      await stopGenerating.waitFor({ state: "visible", timeout: 10_000 });
+
+      await gateway.emitChatFinal({ runId, text: mediaText });
+      await activeStream.waitFor({ state: "detached", timeout: 10_000 });
+      await stopGenerating.waitFor({ state: "detached", timeout: 10_000 });
+      await growMedia("video", 800, "committed");
+      await expect
+        .poll(() => chatThreadDistanceFromBottom(page), { timeout: 10_000 })
+        .toBeLessThanOrEqual(CHAT_TRANSCRIPT_END_THRESHOLD_PX);
+      expect(await scrollToLatest.count()).toBe(0);
     } finally {
       await suite.closeBrowserContext(context);
     }

--- a/ui/src/pages/chat/chat-pane-render.ts
+++ b/ui/src/pages/chat/chat-pane-render.ts
@@ -466,7 +466,7 @@ export class ChatPane extends ChatPaneHeader {
       },
       onChatScroll: (event) => this.handleTranscriptScroll(event),
       onHistoryIntent: (event) => this.handleTranscriptHistoryIntent(event),
-      // Media metadata can change height after commit; honor the existing follow lock.
+      // Metadata can resize a committed row; re-enter the scroll owner so the follow lock wins.
       onAssistantAttachmentLoaded: () => scheduleChatScroll(state),
       getDraft: () => state.chatMessage,
       onDraftChange: state.handleChatDraftChange,

--- a/ui/src/pages/chat/chat-pane-render.ts
+++ b/ui/src/pages/chat/chat-pane-render.ts
@@ -60,6 +60,7 @@ import {
   revealSessionWorkspaceFile,
 } from "./components/chat-session-workspace.ts";
 import { hasAbortableSessionRun } from "./run-lifecycle.ts";
+import { scheduleChatScroll } from "./scroll.ts";
 import {
   SIDEBAR_NARROW_BREAKPOINT_PX,
   activatePanel,
@@ -465,6 +466,8 @@ export class ChatPane extends ChatPaneHeader {
       },
       onChatScroll: (event) => this.handleTranscriptScroll(event),
       onHistoryIntent: (event) => this.handleTranscriptHistoryIntent(event),
+      // Media metadata can change height after commit; honor the existing follow lock.
+      onAssistantAttachmentLoaded: () => scheduleChatScroll(state),
       getDraft: () => state.chatMessage,
       onDraftChange: state.handleChatDraftChange,
       onRequestUpdate: state.requestUpdate,

--- a/ui/src/pages/chat/chat-view.test.ts
+++ b/ui/src/pages/chat/chat-view.test.ts
@@ -2149,9 +2149,7 @@ describe("chat transcript rendering cache", () => {
       onOpenWorkspaceFile,
     };
 
-    vi.mocked(chatThread.buildCachedChatItems).mockReturnValue([
-      { kind: "stream-run", key: "stream-run:media", parts: [streamPart] },
-    ] as ReturnType<typeof chatThread.buildCachedChatItems>);
+    vi.mocked(chatThread.buildCachedChatItems).mockReturnValue([streamPart]);
     renderChatView({ ...mediaProps, canAbort: true });
 
     expect(vi.mocked(chatMessage.renderStreamGroup).mock.calls.at(-1)?.[1]).toMatchObject(expected);

--- a/ui/src/pages/chat/chat-view.test.ts
+++ b/ui/src/pages/chat/chat-view.test.ts
@@ -2102,6 +2102,92 @@ describe("chat transcript rendering cache", () => {
     });
   });
 
+  it("passes the shared assistant media contract to active streams and continuations", () => {
+    const onAssistantAttachmentLoaded = vi.fn();
+    const onRequestUpdate = vi.fn();
+    const onRequestOpenImage = vi.fn(() => 7);
+    const onOpenImage = vi.fn();
+    const onOpenWorkspaceFile = vi.fn();
+    const resolveArtifactDownload = vi.fn();
+    const mediaProps = {
+      sessionKey: "agent:media:main",
+      fullMessageAgentId: "media",
+      basePath: "/control",
+      localMediaPreviewRoots: ["/tmp/media"],
+      assistantAttachmentAuthToken: "attachment-token",
+      resolveArtifactDownload,
+      canvasPluginSurfaceUrl: "https://example.com/canvas",
+      embedSandboxMode: "strict" as const,
+      allowExternalEmbedUrls: true,
+      onAssistantAttachmentLoaded,
+      onRequestUpdate,
+      onRequestOpenImage,
+      onOpenImage,
+      onOpenWorkspaceFile,
+    };
+    const streamPart = {
+      kind: "stream" as const,
+      key: "stream:media:live",
+      text: "MEDIA:https://example.com/voice.ogg",
+      startedAt: 1,
+      isStreaming: true,
+    };
+    const expected = {
+      sessionKey: mediaProps.sessionKey,
+      agentId: mediaProps.fullMessageAgentId,
+      runActive: true,
+      basePath: mediaProps.basePath,
+      localMediaPreviewRoots: mediaProps.localMediaPreviewRoots,
+      assistantAttachmentAuthToken: mediaProps.assistantAttachmentAuthToken,
+      resolveArtifactDownload,
+      canvasPluginSurfaceUrl: mediaProps.canvasPluginSurfaceUrl,
+      embedSandboxMode: mediaProps.embedSandboxMode,
+      allowExternalEmbedUrls: true,
+      onAssistantAttachmentLoaded,
+      onRequestUpdate,
+      onRequestOpenImage,
+      onOpenWorkspaceFile,
+    };
+
+    vi.mocked(chatThread.buildCachedChatItems).mockReturnValue([
+      { kind: "stream-run", key: "stream-run:media", parts: [streamPart] },
+    ] as ReturnType<typeof chatThread.buildCachedChatItems>);
+    renderChatView({ ...mediaProps, canAbort: true });
+
+    expect(vi.mocked(chatMessage.renderStreamGroup).mock.calls.at(-1)?.[1]).toMatchObject(expected);
+    expect(vi.mocked(chatMessage.renderStreamGroup).mock.calls.at(-1)?.[1]?.onOpenImage).toEqual(
+      expect.any(Function),
+    );
+
+    const reply = {
+      kind: "group" as const,
+      key: "group:assistant:media",
+      role: "assistant",
+      messages: [
+        {
+          key: "message:assistant:media",
+          message: { role: "assistant", content: "Interim answer", timestamp: 1 },
+        },
+      ],
+      timestamp: 1,
+      isStreaming: false,
+    };
+    vi.mocked(chatThread.buildCachedChatItems).mockReturnValue([
+      reply,
+      { kind: "reading-indicator", key: "reading:media", startedAt: 1 },
+    ] as ReturnType<typeof chatThread.buildCachedChatItems>);
+    renderMessageGroupMock.mockClear();
+    renderChatView({
+      ...mediaProps,
+      canAbort: true,
+      messages: [{ role: "assistant", content: "Interim answer", timestamp: 1 }],
+    });
+
+    expect(renderMessageGroupMock.mock.calls.at(-1)?.[1].activeContinuation?.options).toMatchObject(
+      expected,
+    );
+  });
+
   it("rebuilds transcript items when the transcript reference changes", () => {
     const toolMessages: unknown[] = [];
     const streamSegments: Array<{ text: string; ts: number }> = [];

--- a/ui/src/pages/chat/components/chat-message-stream.ts
+++ b/ui/src/pages/chat/components/chat-message-stream.ts
@@ -22,11 +22,29 @@ export type StreamGroupPart = Extract<
   { kind: "stream" } | { kind: "reading-indicator" } | { kind: "question" } | { kind: "plan" }
 >;
 
-export type StreamGroupOptions = {
+type StreamMessageOptions = Pick<
+  Parameters<typeof renderGroupedMessage>[2],
+  | "sessionKey"
+  | "boardProvider"
+  | "agentId"
+  | "runActive"
+  | "onRequestUpdate"
+  | "canvasPluginSurfaceUrl"
+  | "basePath"
+  | "localMediaPreviewRoots"
+  | "assistantAttachmentAuthToken"
+  | "resolveArtifactDownload"
+  | "onAssistantAttachmentLoaded"
+  | "onRequestOpenImage"
+  | "onOpenImage"
+  | "embedSandboxMode"
+  | "allowExternalEmbedUrls"
+  | "onOpenWorkspaceFile"
+>;
+
+export type StreamGroupOptions = StreamMessageOptions & {
   onOpenSidebar?: (content: SidebarContent) => void;
   assistant?: AssistantIdentity;
-  basePath?: string;
-  authToken?: string | null;
   planStatus?: PlanStatus | null;
   planActive?: boolean;
   startupPhase?: ChatRunStartupPhase;
@@ -70,7 +88,26 @@ export function renderStreamGroupParts(
                 timestamp: part.startedAt,
               },
               part.key,
-              { isStreaming: part.isStreaming, showReasoning: false },
+              {
+                isStreaming: part.isStreaming,
+                showReasoning: false,
+                sessionKey: opts.sessionKey,
+                boardProvider: opts.boardProvider,
+                agentId: opts.agentId,
+                runActive: opts.runActive,
+                onRequestUpdate: opts.onRequestUpdate,
+                canvasPluginSurfaceUrl: opts.canvasPluginSurfaceUrl,
+                basePath: opts.basePath,
+                localMediaPreviewRoots: opts.localMediaPreviewRoots,
+                assistantAttachmentAuthToken: opts.assistantAttachmentAuthToken,
+                resolveArtifactDownload: opts.resolveArtifactDownload,
+                onAssistantAttachmentLoaded: opts.onAssistantAttachmentLoaded,
+                onRequestOpenImage: opts.onRequestOpenImage,
+                onOpenImage: opts.onOpenImage,
+                embedSandboxMode: opts.embedSandboxMode,
+                allowExternalEmbedUrls: opts.allowExternalEmbedUrls,
+                onOpenWorkspaceFile: opts.onOpenWorkspaceFile,
+              },
               opts.onOpenSidebar,
             ),
   );
@@ -80,7 +117,7 @@ export function renderStreamGroupParts(
 // arrives as several stream segments renders under a single avatar/footer
 // instead of flashing a separate avatar+bubble per segment (#63956).
 export function renderStreamGroup(parts: StreamGroupPart[], opts: StreamGroupOptions = {}) {
-  const { assistant, basePath, authToken } = opts;
+  const { assistant, basePath, assistantAttachmentAuthToken } = opts;
   const name = assistant?.name ?? "Assistant";
   // Footer (sender + time) anchors to the earliest streamed segment; a run that
   // is only the reading indicator has no timestamp and therefore no footer.
@@ -92,7 +129,7 @@ export function renderStreamGroup(parts: StreamGroupPart[], opts: StreamGroupOpt
   const workingOnly = parts.every((part) => part.kind !== "stream");
   const avatar = workingOnly
     ? nothing
-    : renderChatAvatar("assistant", assistant, undefined, basePath, authToken);
+    : renderChatAvatar("assistant", assistant, undefined, basePath, assistantAttachmentAuthToken);
   const groupClass = `chat-group assistant${workingOnly ? " chat-group--working" : ""}${footerStartedAt !== null ? " chat-group--with-footer" : ""}`;
 
   return html`

--- a/ui/src/pages/chat/components/chat-message.test.ts
+++ b/ui/src/pages/chat/components/chat-message.test.ts
@@ -3057,6 +3057,41 @@ describe("grouped chat rendering", () => {
     expect(onAssistantAttachmentLoaded).toHaveBeenCalledTimes(2);
   });
 
+  it("notifies when streamed audio and video attachment metadata loads", async () => {
+    const container = document.body.appendChild(document.createElement("div"));
+    container.dataset.mediaPlayerTestFixture = "";
+    const onAssistantAttachmentLoaded = vi.fn();
+
+    render(
+      renderStreamGroup(
+        [
+          {
+            kind: "stream",
+            key: "stream:media:live",
+            text:
+              "Streaming audio and video\n" +
+              "MEDIA:https://example.com/voice.ogg\n" +
+              "MEDIA:https://example.com/clip.mp4",
+            startedAt: 1,
+            isStreaming: true,
+          },
+        ],
+        { onAssistantAttachmentLoaded },
+      ),
+      container,
+    );
+
+    const audioPlayer = await requireAudioPlayer(container);
+    expectElement(audioPlayer, "audio", HTMLAudioElement).dispatchEvent(
+      new Event("loadedmetadata", { bubbles: true }),
+    );
+    expectElement(container, "video", HTMLVideoElement).dispatchEvent(
+      new Event("loadedmetadata", { bubbles: true }),
+    );
+
+    expect(onAssistantAttachmentLoaded).toHaveBeenCalledTimes(2);
+  });
+
   it("checks local assistant audio against server metadata while preview roots load", async () => {
     const source = `/home/node/.openclaw/media/outbound/${crypto.randomUUID()}.mp3`;
     const fetchMock = vi.fn(async (url: string, init?: RequestInit) => {

--- a/ui/src/pages/chat/components/chat-thread.ts
+++ b/ui/src/pages/chat/components/chat-thread.ts
@@ -1604,6 +1604,29 @@ function renderChatThreadContents(
     { parts: StreamGroupPart[]; options: StreamGroupOptions }
   >();
   const turnRecapByGroupKey = new Map<string, TurnRecap>();
+  const sharedMessageRenderOptions = {
+    onOpenSidebar: props.onOpenSidebar,
+    sessionKey: props.sessionKey,
+    boardProvider: props.boardProvider,
+    agentId: props.fullMessageAgentId,
+    runActive: props.runActive,
+    onOpenWorkspaceFile: props.onOpenWorkspaceFile,
+    onRequestUpdate: requestUpdate,
+    basePath: props.basePath,
+    localMediaPreviewRoots: props.localMediaPreviewRoots ?? [],
+    assistantAttachmentAuthToken: props.assistantAttachmentAuthToken ?? null,
+    resolveArtifactDownload: props.resolveArtifactDownload,
+    onAssistantAttachmentLoaded: props.onAssistantAttachmentLoaded,
+    onRequestOpenImage: props.onRequestOpenImage,
+    onOpenImage: props.onOpenImage,
+    canvasPluginSurfaceUrl: props.canvasPluginSurfaceUrl,
+    embedSandboxMode: props.embedSandboxMode ?? "scripts",
+    allowExternalEmbedUrls: props.allowExternalEmbedUrls ?? false,
+  } satisfies StreamGroupOptions;
+  const streamGroupOptions = {
+    ...sharedMessageRenderOptions,
+    assistant: assistantIdentity,
+  } satisfies StreamGroupOptions;
   const renderGroupOptions = (item: MessageGroup, onDelete: () => void) => {
     const lastMessage = item.messages.at(-1)?.message;
     const rewindEntryId =
@@ -1611,14 +1634,9 @@ function renderChatThreadContents(
         ? persistedMessageEntryId(lastMessage)
         : null;
     return {
-      onOpenSidebar: props.onOpenSidebar,
-      onOpenWorkspaceFile: props.onOpenWorkspaceFile,
-      sessionKey: props.sessionKey,
-      boardProvider: props.boardProvider,
-      agentId: props.fullMessageAgentId,
+      ...sharedMessageRenderOptions,
       showReasoning,
       showToolCalls: props.showToolCalls,
-      runActive: props.runActive,
       autoExpandToolCalls: Boolean(props.autoExpandToolCalls),
       isToolMessageExpanded: (messageId: string) => expandedToolCards.get(messageId),
       onToggleToolMessageExpanded: (messageId: string, expanded?: boolean) => {
@@ -1639,23 +1657,12 @@ function renderChatThreadContents(
       onToggleAssistantMessageExpanded: toggleAssistantMessageExpanded,
       isToolExpanded: (toolCardId: string) => expandedToolCards.get(toolCardId) ?? false,
       onToggleToolExpanded: toggleToolCardExpanded,
-      onRequestUpdate: requestUpdate,
-      onAssistantAttachmentLoaded: props.onAssistantAttachmentLoaded,
-      onRequestOpenImage: props.onRequestOpenImage,
-      onOpenImage: props.onOpenImage,
       assistantName: props.assistantName,
       assistantAvatar: assistantIdentity.avatar,
       userId: props.userId ?? null,
       userName: props.userName ?? null,
       userAvatar: props.userAvatar ?? null,
       showAvatarGutter: !isDirectThread,
-      basePath: props.basePath,
-      localMediaPreviewRoots: props.localMediaPreviewRoots ?? [],
-      assistantAttachmentAuthToken: props.assistantAttachmentAuthToken ?? null,
-      resolveArtifactDownload: props.resolveArtifactDownload,
-      canvasPluginSurfaceUrl: props.canvasPluginSurfaceUrl,
-      embedSandboxMode: props.embedSandboxMode ?? "scripts",
-      allowExternalEmbedUrls: props.allowExternalEmbedUrls ?? false,
       contextWindow: threadContextWindow,
       onReply: props.onSetReply,
       onDelete: props.readOnly ? undefined : onDelete,
@@ -1716,16 +1723,13 @@ function renderChatThreadContents(
     }
     if (item.kind === "stream-run") {
       return renderStreamGroup(item.parts, {
+        ...streamGroupOptions,
         questionPrompts,
         planStatus: props.planStatus,
         planActive: Boolean(props.runActive),
         startupPhase: props.startupStatus?.phase,
         waitingApproval: props.waitingApproval,
         runOutputTokens: props.runOutputTokens,
-        onOpenSidebar: props.onOpenSidebar,
-        assistant: assistantIdentity,
-        basePath: props.basePath,
-        authToken: props.assistantAttachmentAuthToken ?? null,
       });
     }
     if (item.kind === "work-group") {
@@ -1804,6 +1808,7 @@ function renderChatThreadContents(
     activeContinuationByGroupKey.set(previous.key, {
       parts: item.parts,
       options: {
+        ...streamGroupOptions,
         planStatus: props.planStatus,
         planActive: Boolean(props.runActive),
         startupPhase: props.startupStatus?.phase,

--- a/ui/src/pages/chat/components/chat-thread.ts
+++ b/ui/src/pages/chat/components/chat-thread.ts
@@ -72,6 +72,7 @@ import { DeletedMessages } from "../deleted-messages.ts";
 import { PinnedMessages } from "../pinned-messages.ts";
 import type { RealtimeTalkConversationEntry } from "../realtime-talk-conversation.ts";
 import {
+  CHAT_TRANSCRIPT_END_THRESHOLD_PX,
   getChatSessionScrollPosition,
   saveChatSessionScrollPosition,
   type ChatSessionScrollPosition,
@@ -209,7 +210,6 @@ type ChatTranscriptAnnouncement = {
 
 const CHAT_TRANSCRIPT_ESTIMATED_ROW_PX = 120;
 const CHAT_TRANSCRIPT_OVERSCAN = 6;
-const CHAT_TRANSCRIPT_END_THRESHOLD_PX = 8;
 const CHAT_TRANSCRIPT_ANNOUNCEMENT_MAX_CHARS = 500;
 // Initial virtual rows can correct their estimates for several frames. Hold a
 // restored offset for ~200ms so those corrections cannot reapply the end anchor.

--- a/ui/src/pages/chat/scroll.test.ts
+++ b/ui/src/pages/chat/scroll.test.ts
@@ -2,6 +2,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { RenderLifecycle } from "./render-lifecycle.ts";
 import {
+  CHAT_TRANSCRIPT_END_THRESHOLD_PX,
   cancelChatScroll,
   getChatSessionScrollPosition,
   handleChatScroll,
@@ -68,6 +69,24 @@ function createScrollEvent(scrollHeight: number, scrollTop: number, clientHeight
   } as unknown as Event;
 }
 
+function installAnimationFrameQueue() {
+  const callbacks: FrameRequestCallback[] = [];
+  vi.spyOn(window, "requestAnimationFrame").mockImplementation((callback) => {
+    callbacks.push(callback);
+    return callbacks.length;
+  });
+  return {
+    callbacks,
+    runNext(timestamp = 0) {
+      const callback = callbacks.shift();
+      if (!callback) {
+        throw new Error("expected a queued animation frame");
+      }
+      callback(timestamp);
+    },
+  };
+}
+
 /* ------------------------------------------------------------------ */
 /*  handleChatScroll – threshold tests                                 */
 /* ------------------------------------------------------------------ */
@@ -105,12 +124,20 @@ describe("handleChatScroll", () => {
     expect(host.chatUserNearBottom).toBe(false);
   });
 
-  it("shows the scroll-to-bottom affordance after any scroll away from latest", () => {
+  it("shows the scroll-to-bottom affordance only beyond the shared end boundary", () => {
     const { host } = createScrollHost({});
     host.chatLastScrollTop = 1600;
 
-    handleChatScroll(host, createScrollEvent(2000, 1598, 400));
+    handleChatScroll(
+      host,
+      createScrollEvent(2000, 1600 - CHAT_TRANSCRIPT_END_THRESHOLD_PX + 0.5, 400),
+    );
+    expect(host.chatNewMessagesBelow).toBe(false);
 
+    handleChatScroll(
+      host,
+      createScrollEvent(2000, 1600 - CHAT_TRANSCRIPT_END_THRESHOLD_PX - 0.5, 400),
+    );
     expect(host.chatNewMessagesBelow).toBe(true);
   });
 
@@ -692,11 +719,7 @@ describe("programmatic scroll guard", () => {
   });
 
   it("keeps the affordance hidden after the first smooth-scroll guard frame", async () => {
-    const frameCallbacks: FrameRequestCallback[] = [];
-    vi.spyOn(window, "requestAnimationFrame").mockImplementation((callback) => {
-      frameCallbacks.push(callback);
-      return frameCallbacks.length;
-    });
+    const frames = installAnimationFrameQueue();
     const { host, container } = createScrollHost({
       scrollHeight: 2000,
       scrollTop: 500,
@@ -710,11 +733,11 @@ describe("programmatic scroll guard", () => {
 
     scheduleChatScroll(host, true, true, { source: "manual" });
     await host.updateComplete;
-    frameCallbacks.shift()?.(0);
+    frames.runNext();
 
     expect(host.chatIsProgrammaticScroll).toBe(true);
     expect(host.chatNewMessagesBelow).toBe(false);
-    frameCallbacks.shift()?.(16);
+    frames.runNext(16);
     expect(host.chatIsProgrammaticScroll).toBe(true);
 
     handleChatScroll(host, createScrollEvent(2000, 900, 400));
@@ -724,11 +747,7 @@ describe("programmatic scroll guard", () => {
   });
 
   it("stops a smooth manual scroll after the user scrolls up", async () => {
-    const frameCallbacks: FrameRequestCallback[] = [];
-    vi.spyOn(window, "requestAnimationFrame").mockImplementation((callback) => {
-      frameCallbacks.push(callback);
-      return frameCallbacks.length;
-    });
+    const frames = installAnimationFrameQueue();
     const { host, container } = createScrollHost({
       scrollHeight: 2000,
       scrollTop: 500,
@@ -741,13 +760,54 @@ describe("programmatic scroll guard", () => {
 
     scheduleChatScroll(host, true, true, { source: "manual" });
     await host.updateComplete;
-    frameCallbacks.shift()?.(0);
+    frames.runNext();
     container.scrollTop = 400;
 
     handleChatScroll(host, createScrollEvent(2000, 400, 400));
 
     expect(host.chatIsProgrammaticScroll).toBe(false);
     expect(container.scrollTop).toBe(400);
+  });
+
+  it("settles a delegated end scroll at the shared boundary", async () => {
+    const frames = installAnimationFrameQueue();
+    const scrollHeight = 2000;
+    const clientHeight = 400;
+    const maxScrollTop = scrollHeight - clientHeight;
+    const beyondEnd = maxScrollTop - CHAT_TRANSCRIPT_END_THRESHOLD_PX - 0.5;
+    const withinEnd = maxScrollTop - CHAT_TRANSCRIPT_END_THRESHOLD_PX + 0.5;
+    const { host, container } = createScrollHost({
+      scrollHeight,
+      scrollTop: beyondEnd,
+      clientHeight,
+    });
+    host.chatHasAutoScrolled = true;
+    host.chatUserNearBottom = true;
+    host.chatScrollToEnd = vi.fn();
+
+    scheduleChatScroll(host);
+    await host.updateComplete;
+    frames.runNext();
+
+    expect(host.chatScrollToEnd).toHaveBeenCalledWith({ behavior: "auto" });
+    expect(host.chatIsProgrammaticScroll).toBe(true);
+    frames.runNext(16);
+    expect(host.chatIsProgrammaticScroll).toBe(true);
+    expect(frames.callbacks).toHaveLength(1);
+
+    container.scrollTop = withinEnd;
+    frames.runNext(32);
+    expect(host.chatIsProgrammaticScroll).toBe(false);
+    expect(frames.callbacks).toHaveLength(0);
+
+    host.chatLastScrollTop = withinEnd;
+    handleChatScroll(host, createScrollEvent(scrollHeight, beyondEnd, clientHeight));
+    expect(host.chatFollowLocked).toBe(true);
+    expect(host.chatNewMessagesBelow).toBe(true);
+
+    handleChatScroll(host, createScrollEvent(scrollHeight, withinEnd, clientHeight));
+    expect(host.chatFollowLocked).toBe(false);
+    expect(host.chatNewMessagesBelow).toBe(false);
   });
 
   it("suppressed programmatic scroll event does not mutate chatNewMessagesBelow", () => {

--- a/ui/src/pages/chat/scroll.ts
+++ b/ui/src/pages/chat/scroll.ts
@@ -5,8 +5,8 @@ import { getSessionCacheValue, setSessionCacheValue } from "./session-cache.ts";
 
 /** Distance (px) from the bottom within which we consider the user "near bottom". */
 const NEAR_BOTTOM_THRESHOLD = 450;
-const LATEST_MESSAGE_THRESHOLD = 1;
-const FOLLOW_REACQUIRE_THRESHOLD = 8;
+/** Shared semantic boundary for treating the transcript as settled at its end. */
+export const CHAT_TRANSCRIPT_END_THRESHOLD_PX = 8;
 // Route navigation may replace a pane element while retaining its logical id.
 // Bound both dimensions so those short-lived owners cannot leak scroll state.
 const MAX_CACHED_TRANSCRIPT_SCROLL_PANES = 8;
@@ -82,7 +82,7 @@ export function captureChatSessionScrollPosition(target: {
   const scrollTop = Math.min(Math.max(0, target.scrollTop), maxScrollTop);
   return {
     scrollTop,
-    anchorToEnd: maxScrollTop - scrollTop <= FOLLOW_REACQUIRE_THRESHOLD,
+    anchorToEnd: maxScrollTop - scrollTop <= CHAT_TRANSCRIPT_END_THRESHOLD_PX,
   };
 }
 
@@ -157,7 +157,7 @@ function scheduleProgrammaticScrollGuardClear(
       return;
     }
     const distanceFromBottom = target.scrollHeight - target.scrollTop - target.clientHeight;
-    if (waitForTarget && distanceFromBottom > LATEST_MESSAGE_THRESHOLD) {
+    if (waitForTarget && distanceFromBottom > CHAT_TRANSCRIPT_END_THRESHOLD_PX) {
       host.chatScrollGuardFrame = requestAnimationFrame(check);
       return;
     }
@@ -285,17 +285,17 @@ export function handleChatScroll(host: ChatScrollHost, event: Event): void {
     host.chatIsProgrammaticScroll = false;
   }
   const distanceFromBottom = container.scrollHeight - container.scrollTop - container.clientHeight;
-  if (isUserScrollUp && distanceFromBottom > FOLLOW_REACQUIRE_THRESHOLD) {
+  if (isUserScrollUp && distanceFromBottom > CHAT_TRANSCRIPT_END_THRESHOLD_PX) {
     host.chatFollowLocked = true;
-  } else if (distanceFromBottom <= FOLLOW_REACQUIRE_THRESHOLD) {
+  } else if (distanceFromBottom <= CHAT_TRANSCRIPT_END_THRESHOLD_PX) {
     host.chatFollowLocked = false;
   }
   host.chatUserNearBottom = !host.chatFollowLocked && distanceFromBottom < NEAR_BOTTOM_THRESHOLD;
 
   setNewMessagesBelow(
     host,
-    container.scrollHeight - container.clientHeight > LATEST_MESSAGE_THRESHOLD &&
-      distanceFromBottom > LATEST_MESSAGE_THRESHOLD,
+    container.scrollHeight - container.clientHeight > CHAT_TRANSCRIPT_END_THRESHOLD_PX &&
+      distanceFromBottom > CHAT_TRANSCRIPT_END_THRESHOLD_PX,
   );
 }
 
@@ -314,7 +314,8 @@ export function restoreChatScroll(
   host.chatHasAutoScrolled = true;
   // A virtualized transcript may not expose its final scroll height yet. Keep
   // the restored viewport locked until the requested offset becomes reachable.
-  host.chatFollowLocked = scrollTop > maxScrollTop || distanceFromBottom > LATEST_MESSAGE_THRESHOLD;
+  host.chatFollowLocked =
+    scrollTop > maxScrollTop || distanceFromBottom > CHAT_TRANSCRIPT_END_THRESHOLD_PX;
   host.chatUserNearBottom = !host.chatFollowLocked && distanceFromBottom < NEAR_BOTTOM_THRESHOLD;
   host.chatIsProgrammaticScroll = false;
   host.chatProgrammaticScrollTarget = restoredScrollTop;


### PR DESCRIPTION
## What Problem This Solves

The Control UI could stop short of the newest response when delayed audio or video metadata increased transcript height. The initial repair covered committed assistant messages; the remaining active-stream owner gap is now repaired so media growth follows consistently before and after finalization. #104843 remains related closed history.

## Why This Change Was Made

The scroll root cause was a split transcript-end contract: outer policy treated 1px as the end while the TanStack virtualizer used 8px, and delayed media metadata did not always re-enter the canonical `scheduleChatScroll` owner. One exported `CHAT_TRANSCRIPT_END_THRESHOLD_PX = 8` contract now governs both layers and committed-message metadata routes through that scheduler.

Active stream bubbles and active continuations now receive the same session/media/auth/render contract as committed groups, including `onAssistantAttachmentLoaded`. No timers, retries, or parallel scroll path were added; real wheel scrollback still wins and “Scroll to latest” remains explicit recovery.

Separately, an MCP test-only repair splits OAuth CLI coverage into a shared harness and dedicated test file to satisfy the required lint gate. It changes no MCP production behavior and preserves main’s canonical probe-support helper.

## User Impact

Media stays pinned while the response is still streaming and after it commits. Users who scroll upward remain at their reading position, see the latest-message affordance, and can deliberately return to the end. The MCP change affects tests only.

## Evidence

Exact head: `4b6d1a5dd0f9fc48dd5b33d90759cc14db0aad2f`.

Active-stream and scroll proof:

- Chat-message + chat-view + scroll — 433/433 passed.
- Focused Playwright-managed Chromium active-stream media scenario — 1/1 passed.
- Complete `ui/src/e2e/chat-flow.streaming.e2e.test.ts` — 10/10 passed.
- UI tsgo, targeted lint, formatting, and diff-check — passed.
- Fresh combined structured review — clean, no accepted/actionable findings.
- After final drift reconciliation, focused scroll proof — 40/40 passed.

MCP test-only red-main proof:

- MCP CLI tests — 37/37 passed.
- Targeted MCP lint, core test tsgo, formatter check, and diff-check — passed.

Former exact-head blockers now pass before push:

- `pnpm protocol:check` — passed; generated protocol outputs match the repository and no generated diff remains.
- `pnpm plugin-sdk:api:check` — passed; `docs/.generated/plugin-sdk-api-baseline.sha256` is current.
- `git diff --check origin/main...HEAD` — clean.

The final range-diff preserves main’s unrelated read-only delete guard; the scroll, active-stream, and MCP changes remain coherent and otherwise patch-identical.

Observed browser geometry during an active stream:

- “Stop generating” remained visible while delayed audio/video growth kept transcript-end distance `<= 8px` with no latest-message affordance.
- A real wheel-up moved distance to `> 8px`, showed the affordance, and later active-stream media growth changed reading `scrollTop` by `<= 1px`.
- Clicking “Scroll to latest” returned distance to `<= 8px` and hid the affordance while the run remained active.
- After finalization, further committed video growth also remained `<= 8px` with no affordance.

Sanitized screenshots remain ignored under `.artifacts/control-ui-e2e/webchat-media-metadata-scroll` and are not committed. Remote proof infrastructure was unavailable, so trusted-source local fallback proof was used; exact-head hosted CI remains authoritative.

Production LOC: +83/-37 (net +46). Tests and test harnesses: +750/-351 (net +399). Production growth is the shared scroll contract plus active-stream owner wiring; MCP growth is test-only organization.
