### PR TITLE
refactor(android): remove unused Wear voice button

### DIFF
--- a/apps/android/wear/src/main/java/ai/openclaw/wear/WearScreens.kt
+++ b/apps/android/wear/src/main/java/ai/openclaw/wear/WearScreens.kt
@@ -1826,43 +1826,6 @@ private fun ActionButton(
 }
 
 @Composable
-private fun CompactVoiceButton(
-  label: String,
-  enabled: Boolean,
-  onClick: () -> Unit,
-  modifier: Modifier = Modifier,
-) {
-  val colors = OpenClawWearTheme.colors
-  Button(
-    onClick = onClick,
-    enabled = enabled,
-    colors =
-      ButtonDefaults.buttonColors(
-        containerColor = colors.surfaceRaised,
-        contentColor = colors.text,
-        disabledContainerColor = colors.surface,
-        disabledContentColor = colors.textMuted,
-      ),
-    modifier =
-      modifier.border(
-        width = 1.dp,
-        color = if (enabled) colors.borderStrong else colors.border,
-        shape = RoundedCornerShape(24.dp),
-      ),
-    label = {
-      Text(
-        text = label,
-        modifier = Modifier.fillMaxWidth(),
-        fontSize = 12.sp,
-        fontWeight = FontWeight.SemiBold,
-        textAlign = TextAlign.Center,
-        maxLines = 1,
-      )
-    },
-  )
-}
-
-@Composable
 private fun SecondaryButton(
   label: String,
   enabled: Boolean,


### PR DESCRIPTION
## What Problem This Solves

Removes an unused Wear UI composable that has no caller or tooling entry point.

## Why This Change Was Made

`CompactVoiceButton` was introduced with the restored Wear companion surface but was never referenced. This deletes the private dead implementation without changing any rendered Wear screen or public contract.

## User Impact

No user-visible behavior changes. The Wear app carries less unused UI code.

## Evidence

- Repository-wide search: `CompactVoiceButton` had one occurrence, its private definition
- Blacksmith Testbox `tbx_01kykvhjmd8cdyr38fv94xn6fj`:
  - `:wear:ktlintCheck`
  - `:wear:testDebugUnitTest`
  - `:wear:assembleDebug`
- `pnpm check:changed`: passed on the same Testbox
- `git diff --check`: passed
- Autoreview: clean, correctness 0.99
- Stable patch ID remained identical after rebasing onto current `origin/main`
