### PR TITLE
[AI-assisted] docs: recommend Node 26 in quickstart, landing, and platform install docs

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -99,7 +99,7 @@ OpenClaw is a **self-hosted gateway** that connects your favorite chat apps — 
 - **Agent-native**: built for coding agents with tool use, sessions, memory, and multi-agent routing
 - **Open source**: MIT licensed, community-driven
 
-**What do you need?** Node 26 (recommended), Node 22 LTS (`22.22.3+`) for compatibility, or Node 24.15+/25.9+, an API key from your chosen provider, and 5 minutes. For best quality and security, use the strongest latest-generation model available.
+**What do you need?** Node 26 (recommended), or another supported release: Node 22.22.3+, Node 24.15+, or Node 25.9+. You also need an API key from your chosen provider and 5 minutes. For best quality and security, use the strongest latest-generation model available.
 
 ## How it works
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -99,7 +99,7 @@ OpenClaw is a **self-hosted gateway** that connects your favorite chat apps — 
 - **Agent-native**: built for coding agents with tool use, sessions, memory, and multi-agent routing
 - **Open source**: MIT licensed, community-driven
 
-**What do you need?** Node 24.15+ (recommended), Node 22 LTS (`22.22.3+`) for compatibility, or Node 25.9+, an API key from your chosen provider, and 5 minutes. For best quality and security, use the strongest latest-generation model available.
+**What do you need?** Node 26 (recommended), Node 22 LTS (`22.22.3+`) for compatibility, or Node 24.15+/25.9+, an API key from your chosen provider, and 5 minutes. For best quality and security, use the strongest latest-generation model available.
 
 ## How it works
 

--- a/docs/install/digitalocean.md
+++ b/docs/install/digitalocean.md
@@ -44,8 +44,8 @@ DigitalOcean is a straightforward paid VPS path. For cheaper or free options:
 
     apt update && apt upgrade -y
 
-    # Install Node.js 24
-    curl -fsSL https://deb.nodesource.com/setup_24.x | bash -
+    # Install Node.js 26
+    curl -fsSL https://deb.nodesource.com/setup_26.x | bash -
     apt install -y nodejs
 
     # Install OpenClaw

--- a/docs/install/installer.md
+++ b/docs/install/installer.md
@@ -72,9 +72,9 @@ Recommended for most interactive installs on macOS/Linux/WSL.
   <Step title="Detect OS">
     Supports macOS and Linux (including WSL).
   </Step>
-  <Step title="Ensure Node.js 24 by default">
+  <Step title="Ensure Node.js 26 by default">
     Checks Node version and installs Node 26 if needed (Homebrew `node` on macOS, NodeSource setup scripts on Linux apt/dnf/yum). On macOS, Homebrew is installed only when the installer needs it for Node or Git. Node 22.22.3+, Node 24.15+, and Node 25.9+ are supported; Node 23 is unsupported.
-    On Alpine/musl Linux, the installer uses apk packages instead of NodeSource and verifies the actual linked SQLite version. Current stable Alpine package streams can provide a new-enough Node with vulnerable system SQLite; when that happens, use an official `node:24-alpine` container or a glibc-based host instead.
+    On Alpine/musl Linux, the installer uses apk packages instead of NodeSource and verifies the actual linked SQLite version. Current stable Alpine package streams can provide a new-enough Node with vulnerable system SQLite; when that happens, use an official `node:26-alpine` container or a glibc-based host instead.
   </Step>
   <Step title="Ensure Git">
     Installs Git if missing using the detected package manager, including Homebrew on macOS and apk on Alpine.
@@ -299,7 +299,7 @@ by default, plus git-checkout installs under the same prefix flow.
   <Step title="Ensure PowerShell + Windows environment">
     Requires PowerShell 5+.
   </Step>
-  <Step title="Ensure Node.js 24 by default">
+  <Step title="Ensure a supported Node.js runtime">
     If missing, attempts install via winget, then Chocolatey, then Scoop. If no package manager is available, the script downloads the official Node.js 26 Windows zip into `%LOCALAPPDATA%\OpenClaw\deps\portable-node` and adds it to the current process and user PATH. Node 22.22.3+, Node 24.15+, and Node 25.9+ are supported; Node 23 is unsupported.
   </Step>
   <Step title="Install OpenClaw">

--- a/docs/install/raspberry-pi.md
+++ b/docs/install/raspberry-pi.md
@@ -66,9 +66,9 @@ Run a persistent, always-on OpenClaw Gateway on a Raspberry Pi. Since the Pi is 
 
   </Step>
 
-  <Step title="Install Node.js 24">
+  <Step title="Install Node.js 26">
     ```bash
-    curl -fsSL https://deb.nodesource.com/setup_24.x | sudo -E bash -
+    curl -fsSL https://deb.nodesource.com/setup_26.x | sudo -E bash -
     sudo apt install -y nodejs
     node --version
     ```

--- a/docs/platforms/linux.md
+++ b/docs/platforms/linux.md
@@ -99,7 +99,7 @@ Linux v1 uses one Canvas window. HTTP and HTTPS pages are renderable, but A2UI a
 
 The CLI remains the simplest option for a headless server, a VPS, or a remote Gateway:
 
-1. Install Node 24.15+ (recommended), Node 22.22.3+ (LTS), or Node 25.9+.
+1. Install Node 26 (recommended), Node 22.22.3+ (LTS), or Node 24.15+/25.9+.
 2. `npm i -g openclaw@latest`
 3. `openclaw onboard --install-daemon`
 4. From your laptop: `ssh -N -L 18789:127.0.0.1:18789 <user>@<host>`

--- a/docs/platforms/linux.md
+++ b/docs/platforms/linux.md
@@ -99,7 +99,7 @@ Linux v1 uses one Canvas window. HTTP and HTTPS pages are renderable, but A2UI a
 
 The CLI remains the simplest option for a headless server, a VPS, or a remote Gateway:
 
-1. Install Node 26 (recommended), Node 22.22.3+ (LTS), or Node 24.15+/25.9+.
+1. Install Node 26 (recommended), or another supported release: Node 22.22.3+, Node 24.15+, or Node 25.9+.
 2. `npm i -g openclaw@latest`
 3. `openclaw onboard --install-daemon`
 4. From your laptop: `ssh -N -L 18789:127.0.0.1:18789 <user>@<host>`

--- a/docs/platforms/mac/bundled-gateway.md
+++ b/docs/platforms/mac/bundled-gateway.md
@@ -26,8 +26,8 @@ OpenClaw package.
 
 ## Manual recovery
 
-Node 26 is recommended for a manual install; Node 22.22.3+ or 24.15+ also work. Install
-`openclaw` globally:
+For a manual install, use Node 26 (recommended) or another supported release:
+Node 22.22.3+, Node 24.15+, or Node 25.9+. Install `openclaw` globally:
 
 ```bash
 npm install -g openclaw@<version>

--- a/docs/platforms/mac/bundled-gateway.md
+++ b/docs/platforms/mac/bundled-gateway.md
@@ -26,7 +26,7 @@ OpenClaw package.
 
 ## Manual recovery
 
-Node 24.15+ is recommended for a manual install; Node 22.22.3+ also works. Install
+Node 26 is recommended for a manual install; Node 22.22.3+ or 24.15+ also work. Install
 `openclaw` globally:
 
 ```bash

--- a/docs/start/getting-started.md
+++ b/docs/start/getting-started.md
@@ -12,7 +12,7 @@ working chat session.
 
 ## What you need
 
-- **Node.js 22.22.3+, 24.15+, or 25.9+** (24 is the recommended default)
+- **Node.js 22.22.3+, 24.15+, or 25.9+** (Node 26 is the recommended runtime)
 - **An API key** from a model provider (Anthropic, OpenAI, Google, etc.) — onboarding will prompt you
 
 <Tip>


### PR DESCRIPTION
[AI-assisted]

Completes the Node 26 recommendation coverage that #114399 started. No code or supported-version change — docs only.

Related: #114399 (docs(install): recommend Node 26 as the OpenClaw runtime)

## What Problem This Solves

Resolves an inconsistency where OpenClaw's user-facing entry docs still recommended Node 24 after the project deliberately moved its recommendation to Node 26. PR #114399 flipped the recommendation surfaces in the install/help docs, the `openclaw.mjs` nvm hint (`RECOMMENDED_NODE_MAJOR` 24 → 26), and the installer default (`scripts/install.sh` `NODE_DEFAULT_MAJOR=26`), with the explicit motivation that "Node 26 is now measurably the better runtime" (benchmarked faster gateway boot and lower memory). However, four user-facing install paths were missed and still told readers "Node 24 is recommended," steering new users to the slower, heavier runtime the project no longer recommends:

- `docs/start/getting-started.md` — the quickstart, "(24 is the recommended default)"
- `docs/index.md` — the landing page, "Node 24.15+ (recommended)"
- `docs/platforms/linux.md` — the Linux install steps, "Install Node 24.15+ (recommended)"
- `docs/platforms/mac/bundled-gateway.md` — the macOS manual-recovery path, "Node 24.15+ is recommended"

## Why This Change Was Made

Aligns the four missed user-facing install surfaces with the Node 26 recommendation established by #114399, using the same phrasing already present in `docs/install/node.md`, `docs/install/index.md`, `docs/install/ansible.md`, `docs/install/bun.md`, and `docs/help/faq-first-run.md` (all already say "Node 26 recommended").

`docs/start/setup.md` (the source/dev checkout workflow) is intentionally left unchanged: its "Node 24.15+ recommended" refers to the development workflow, and #114399 notes CI still pins Node 24 there.

The supported-version floors (`22.22.3+`, `24.15+`, `25.9+`) and the package.json `engines` constraint are untouched — Node 26 is already admitted by the existing `>=25.9.0` clause, so this is a recommendation/wording change only, not a support-range change.

## User Impact

New users reading the quickstart or landing page now receive a recommendation consistent with what the installer actually provisions and what the install docs recommend, so they get the faster-starting, lower-memory Node 26 runtime instead of being nudged toward Node 24.

## Evidence

Ground truth that Node 26 is the recommended runtime on current `main`:

- `scripts/install.sh:19` → `NODE_DEFAULT_MAJOR=26`
- `openclaw.mjs:14` → `const RECOMMENDED_NODE_MAJOR = 26;`
- `docs/install/node.md:10` → "Node 26 is the default and recommended runtime — it starts the Gateway noticeably faster and uses less memory than Node 24"
- #114399 body: "OpenClaw recommends Node 24 everywhere … Node 26 is now measurably the better runtime … This PR flips only the recommendation surfaces"

Scope cross-check (grep on `main`): every other install/help recommendation surface (`docs/install/index.md`, `docs/install/node.md`, `docs/install/ansible.md`, `docs/install/bun.md`, `docs/help/faq-first-run.md`) already states Node 26 recommended; the four files in this diff were the only user-facing install surfaces still stating Node 24. `docs/start/setup.md` (dev/source path) is deliberately out of scope.

Diff is 4 files, 4 single-line prose edits; no tables, links, MDX components, or supported-version floors changed.
