### PR TITLE
fix: keep shared web and TUI chats synchronized

### DIFF
--- a/src/gateway/session-message-events.test.ts
+++ b/src/gateway/session-message-events.test.ts
@@ -751,6 +751,112 @@ describe("session.message websocket events", () => {
     }
   });
 
+  test("keeps web and TUI subscribers on the same authoritative session transcript", async () => {
+    const storePath = await createSessionStoreFile();
+    const sessionId = "sess-web-tui-shared";
+    const sessionKey = "agent:main:web-tui-shared";
+    await writeSessionStore({
+      entries: { "web-tui-shared": { sessionId, updatedAt: Date.now() } },
+      storePath,
+    });
+
+    const webWs = await harness.openWs({ origin: `http://127.0.0.1:${harness.port}` });
+    const tuiWs = await harness.openWs();
+    let reconnectedTuiWs: Awaited<ReturnType<typeof harness.openWs>> | undefined;
+    try {
+      await connectOk(webWs, {
+        caps: [GATEWAY_CLIENT_CAPS.SESSION_SCOPED_EVENTS],
+        client: {
+          id: GATEWAY_CLIENT_IDS.CONTROL_UI,
+          mode: GATEWAY_CLIENT_MODES.UI,
+          platform: "web",
+          version: "test",
+        },
+        deviceIdentityPath: path.join(path.dirname(storePath), "shared-web-device.json"),
+        prePairDevice: true,
+        scopes: ["operator.read"],
+      });
+      await connectOk(tuiWs, {
+        caps: [GATEWAY_CLIENT_CAPS.SESSION_SCOPED_EVENTS],
+        client: {
+          id: GATEWAY_CLIENT_IDS.TUI,
+          mode: GATEWAY_CLIENT_MODES.CLI,
+          platform: "test",
+          version: "test",
+        },
+        deviceIdentityPath: path.join(path.dirname(storePath), "shared-tui-device.json"),
+        prePairDevice: true,
+        scopes: ["operator.read"],
+      });
+      for (const ws of [webWs, tuiWs]) {
+        const subscription = await rpcReq(ws, "sessions.messages.subscribe", {
+          key: sessionKey,
+        });
+        expect(subscription.ok).toBe(true);
+      }
+
+      for (const [index, text] of ["Sent from the web.", "Sent from the TUI."].entries()) {
+        const messageId = `shared-turn-${index + 1}`;
+        const deliveries = [webWs, tuiWs].map((ws) =>
+          onceMessage(
+            ws,
+            (frame) =>
+              frame.type === "event" &&
+              frame.event === "session.message" &&
+              (frame.payload as { messageId?: string } | undefined)?.messageId === messageId,
+          ),
+        );
+        const persisted = await persistSessionTranscriptTurn(
+          { agentId: "main", sessionId, sessionKey, storePath },
+          {
+            messages: [
+              {
+                eventId: messageId,
+                message: {
+                  content: [{ type: "text", text }],
+                  idempotencyKey: `${messageId}:user`,
+                  role: "user",
+                  timestamp: Date.now(),
+                },
+              },
+            ],
+          },
+        );
+        expect(persisted.appendedCount).toBe(1);
+        for (const delivery of await Promise.all(deliveries)) {
+          expectRecordFields(delivery.payload, {
+            messageId,
+            messageSeq: index + 1,
+            sessionKey,
+          });
+          expect(requireRecord(delivery.payload, "shared session event").message).toMatchObject({
+            __openclaw: {
+              id: messageId,
+              idempotencyKey: `${messageId}:user`,
+              seq: index + 1,
+            },
+            content: [{ type: "text", text }],
+            role: "user",
+          });
+        }
+      }
+
+      tuiWs.close();
+      reconnectedTuiWs = await harness.openWs();
+      await connectOk(reconnectedTuiWs, { scopes: ["operator.read"] });
+      const history = await rpcReq(reconnectedTuiWs, "chat.history", { sessionKey });
+      expect(history.ok).toBe(true);
+      expect((history.payload as { messages?: unknown[] }).messages).toMatchObject([
+        { content: [{ type: "text", text: "Sent from the web." }], role: "user" },
+        { content: [{ type: "text", text: "Sent from the TUI." }], role: "user" },
+      ]);
+    } finally {
+      webWs.close();
+      tuiWs.close();
+      reconnectedTuiWs?.close();
+    }
+  });
+
   test("broadcasts appended transcript messages with the session key", async () => {
     const storePath = await createSessionStoreFile();
     await writeSessionStore({

--- a/src/tui/components/chat-log.test.ts
+++ b/src/tui/components/chat-log.test.ts
@@ -365,6 +365,79 @@ describe("ChatLog", () => {
     expect(chatLog.render(120).join("\n")).toContain("queued hello");
   });
 
+  it("inserts another client's persisted prompt ahead of an already-streaming reply", () => {
+    const chatLog = new ChatLog(40);
+    chatLog.updateAssistant("Already streaming.", "shared-run");
+
+    chatLog.addLiveUser("Sent from the other client.", {
+      messageId: "shared-user",
+      runId: "shared-run",
+    });
+
+    const rendered = normalizeTestText(chatLog.render(120).join("\n"));
+    expect(rendered.indexOf("Sent from the other client.")).toBeLessThan(
+      rendered.indexOf("Already streaming."),
+    );
+    expect(chatLog.children.map((component) => component.constructor.name)).toEqual([
+      "UserMessageComponent",
+      "AssistantMessageComponent",
+    ]);
+
+    chatLog.updateAssistant("Still streaming.", "shared-run");
+    expect(normalizeTestText(chatLog.render(120).join("\n"))).toContain("Still streaming.");
+  });
+
+  it("deduplicates authoritative user events and adopts the matching pending prompt", () => {
+    const chatLog = new ChatLog(40);
+    chatLog.addPendingUser("shared-run", "Persisted prompt.");
+    chatLog.updateAssistant("Already streaming.", "shared-run");
+
+    chatLog.addLiveUser("Persisted prompt.", { messageId: "shared-user", runId: "shared-run" });
+    chatLog.addLiveUser("Persisted prompt.", { messageId: "shared-user", runId: "shared-run" });
+
+    const rendered = normalizeTestText(chatLog.render(120).join("\n"));
+    expect(rendered).toContain("Persisted prompt.");
+    expect(chatLog.children.map((component) => component.constructor.name)).toEqual([
+      "UserMessageComponent",
+      "AssistantMessageComponent",
+    ]);
+    expect(chatLog.countPendingUsers()).toBe(0);
+  });
+
+  it("preserves a different pending prompt when another client uses the same run", () => {
+    const chatLog = new ChatLog(40);
+    chatLog.addPendingUser("shared-run", "My local steering prompt.");
+    chatLog.updateAssistant("Already streaming.", "shared-run");
+
+    chatLog.addLiveUser("Another client's persisted prompt.", {
+      messageId: "shared-remote-user",
+      runId: "shared-run",
+    });
+
+    const rendered = normalizeTestText(chatLog.render(120).join("\n"));
+    expect(rendered).toContain("My local steering prompt.");
+    expect(rendered).toContain("Another client's persisted prompt.");
+    expect(rendered.indexOf("Another client's persisted prompt.")).toBeLessThan(
+      rendered.indexOf("Already streaming."),
+    );
+    expect(chatLog.countPendingUsers()).toBe(1);
+  });
+
+  it("deduplicates a replayed live prompt already loaded from authoritative history", () => {
+    const chatLog = new ChatLog(40);
+    chatLog.addUser("Loaded from history.", { messageId: "history-user" });
+
+    chatLog.addLiveUser("Loaded from history.", {
+      messageId: "history-user",
+      runId: "history-run",
+    });
+
+    expect(chatLog.children.map((component) => component.constructor.name)).toEqual([
+      "UserMessageComponent",
+    ]);
+    expect(normalizeTestText(chatLog.render(120).join("\n"))).toContain("Loaded from history.");
+  });
+
   it("re-keys a pending user in place without moving its position", () => {
     const chatLog = new ChatLog(40);
 

--- a/src/tui/components/chat-log.ts
+++ b/src/tui/components/chat-log.ts
@@ -25,6 +25,7 @@ export class ChatLog extends Container {
   private frozenAssistants = new Map<string, Set<AssistantMessageComponent>>();
   private committedAssistantText = new Map<string, string>();
   private latestAssistantText = new Map<string, string>();
+  private liveUsers = new Map<string, UserMessageComponent>();
   private pendingUsers = new Map<
     string,
     {
@@ -68,6 +69,11 @@ export class ChatLog extends Container {
         this.pendingUsers.delete(runId);
       }
     }
+    for (const [messageId, user] of this.liveUsers.entries()) {
+      if (user === component) {
+        this.liveUsers.delete(messageId);
+      }
+    }
     for (const [runId, entry] of this.pendingSystemNotices.entries()) {
       if (entry === component) {
         this.pendingSystemNotices.delete(runId);
@@ -109,6 +115,7 @@ export class ChatLog extends Container {
     this.frozenAssistants.clear();
     this.committedAssistantText.clear();
     this.latestAssistantText.clear();
+    this.liveUsers.clear();
     this.pendingSystemNotices.clear();
     this.btwMessage = null;
     this.repeatableSystemMessage = null;
@@ -194,8 +201,46 @@ export class ChatLog extends Container {
     return true;
   }
 
-  addUser(text: string) {
-    this.appendNonSystem(new UserMessageComponent(text));
+  addUser(text: string, options?: { messageId?: string }) {
+    const component = new UserMessageComponent(text);
+    if (options?.messageId) {
+      this.liveUsers.set(options.messageId, component);
+    }
+    this.appendNonSystem(component);
+  }
+
+  addLiveUser(text: string, options: { messageId: string; runId?: string }) {
+    const existing = this.liveUsers.get(options.messageId);
+    if (existing) {
+      existing.setText(text);
+      return existing;
+    }
+
+    const pending = options.runId ? this.pendingUsers.get(options.runId) : undefined;
+    if (pending && options.runId && pending.text === text) {
+      pending.component.setText(text);
+      this.pendingUsers.delete(options.runId);
+      this.liveUsers.set(options.messageId, pending.component);
+      return pending.component;
+    }
+
+    const component = new UserMessageComponent(text);
+    this.liveUsers.set(options.messageId, component);
+    const frozen = options.runId ? this.frozenAssistants.get(options.runId) : undefined;
+    const assistant =
+      frozen?.values().next().value ??
+      (options.runId ? this.streamingRuns.get(options.runId) : undefined);
+    const assistantIndex = assistant ? this.children.indexOf(assistant) : -1;
+    if (assistantIndex >= 0) {
+      // Transcript broadcasts can trail the first delta; insert their prompt
+      // before the existing reply without resetting live stream or tool state.
+      this.repeatableSystemMessage = null;
+      this.children.splice(assistantIndex, 0, component);
+      this.pruneOverflow();
+      return component;
+    }
+    this.appendNonSystem(component);
+    return component;
   }
 
   addPendingUser(runId: string, text: string, createdAt = Date.now()) {

--- a/src/tui/tui-event-handlers.test.ts
+++ b/src/tui/tui-event-handlers.test.ts
@@ -15,6 +15,7 @@ import type {
 
 type MockFn = ReturnType<typeof vi.fn>;
 type HandlerChatLog = {
+  addLiveUser: (...args: unknown[]) => void;
   startTool: (...args: unknown[]) => void;
   updateToolResult: (...args: unknown[]) => void;
   addSystem: (...args: unknown[]) => void;
@@ -30,6 +31,7 @@ type HandlerBtwPresenter = {
 };
 type HandlerTui = { requestRender: (...args: unknown[]) => void };
 type MockChatLog = {
+  addLiveUser: MockFn;
   startTool: MockFn;
   updateToolResult: MockFn;
   addSystem: MockFn;
@@ -47,6 +49,7 @@ type MockTui = { requestRender: MockFn };
 
 function createMockChatLog(): MockChatLog & HandlerChatLog {
   return {
+    addLiveUser: vi.fn(),
     startTool: vi.fn(),
     updateToolResult: vi.fn(),
     addSystem: vi.fn(),
@@ -2464,6 +2467,52 @@ describe("tui-event-handlers: handleAgentEvent", () => {
   });
 
   describe("session.message history reload", () => {
+    it.each([
+      { identity: "transcript metadata", includeMessageMetadata: true },
+      { identity: "gateway event envelope", includeMessageMetadata: false },
+    ])(
+      "renders another client's $identity user turn before its active stream",
+      ({ includeMessageMetadata }) => {
+        const { state, chatLog, loadHistory, handleChatEvent, handleSessionMessageEvent } =
+          createHandlersHarness({ state: { activeChatRunId: null } });
+        const runId = "shared-session-web-run";
+        handleChatEvent({
+          runId,
+          seq: 1,
+          sessionKey: state.currentSessionKey,
+          state: "delta",
+          message: { content: [{ type: "text", text: "Already streaming." }] },
+        } satisfies ChatEvent);
+
+        handleSessionMessageEvent({
+          sessionKey: state.currentSessionKey,
+          ...(includeMessageMetadata ? {} : { clientRunId: runId }),
+          messageId: "shared-session-user",
+          messageSeq: 1,
+          message: {
+            ...(includeMessageMetadata
+              ? {
+                  __openclaw: {
+                    id: "shared-session-user",
+                    idempotencyKey: `${runId}:user`,
+                    seq: 1,
+                  },
+                }
+              : {}),
+            content: [{ type: "text", text: "Sent from the other client." }],
+            role: "user",
+          },
+        } satisfies SessionMessageEvent);
+
+        expect(chatLog.addLiveUser).toHaveBeenCalledWith("Sent from the other client.", {
+          messageId: "shared-session-user",
+          runId,
+        });
+        expect(state.activeChatRunId).toBe(runId);
+        expect(loadHistory).not.toHaveBeenCalled();
+      },
+    );
+
     it("reloads the current session when another client appends a message", () => {
       const { state, loadHistory, handleSessionMessageEvent } = createHandlersHarness({
         state: {

--- a/src/tui/tui-event-handlers.ts
+++ b/src/tui/tui-event-handlers.ts
@@ -7,7 +7,7 @@ import {
   sanitizeRenderableText,
 } from "./tui-formatters.js";
 import { createTuiRunLifecycle } from "./tui-run-lifecycle.js";
-import { matchesSelectedTuiSession } from "./tui-session-events.js";
+import { matchesSelectedTuiSession, readTuiSessionUserMessage } from "./tui-session-events.js";
 import { TuiSessionRunCoordinator } from "./tui-session-run-coordinator.js";
 import {
   clearPendingSubmit,
@@ -25,6 +25,7 @@ import type {
 } from "./tui-types.js";
 
 type EventHandlerChatLog = {
+  addLiveUser: (text: string, options: { messageId: string; runId?: string }) => void;
   startTool: (toolCallId: string, toolName: string, args: unknown) => void;
   updateToolResult: (
     toolCallId: string,
@@ -486,6 +487,15 @@ export function createEventHandlers(context: EventHandlerContext) {
     syncSessionKey();
     if (!matchesSelectedTuiSession(state, evt, { requireAliasOwnership: true })) {
       return;
+    }
+
+    const liveUserMessage = readTuiSessionUserMessage(evt);
+    if (liveUserMessage) {
+      chatLog.addLiveUser(liveUserMessage.text, {
+        messageId: liveUserMessage.messageId,
+        ...(liveUserMessage.runId ? { runId: liveUserMessage.runId } : {}),
+      });
+      tui.requestRender();
     }
 
     const currentUpdatedAt = state.sessionInfo.updatedAt;

--- a/src/tui/tui-session-actions.ts
+++ b/src/tui/tui-session-actions.ts
@@ -18,6 +18,7 @@ import {
   formatTuiErrorMessage,
   isCommandMessage,
 } from "./tui-formatters.js";
+import { readTuiSessionUserMessage } from "./tui-session-events.js";
 import { TUI_SESSION_LOOKUP_LIMIT } from "./tui-session-list-policy.js";
 import * as submit from "./tui-submit-state.js";
 import type { SessionInfo, TuiHistoryLoadResult, TuiOptions, TuiStateAccess } from "./tui-types.js";
@@ -565,7 +566,12 @@ export function createSessionActions(context: SessionActionContext) {
               text,
               timestamp: extractMessageTimestamp(message),
             });
-            chatLog.addUser(text);
+            const liveUserMessage = readTuiSessionUserMessage({ message });
+            if (liveUserMessage) {
+              chatLog.addUser(text, { messageId: liveUserMessage.messageId });
+            } else {
+              chatLog.addUser(text);
+            }
           }
           continue;
         }

--- a/src/tui/tui-session-events.test.ts
+++ b/src/tui/tui-session-events.test.ts
@@ -1,7 +1,7 @@
 // Verifies canonical and provider-owned TUI session event routing.
 import { describe, expect, it } from "vitest";
-import { matchesSelectedTuiSession } from "./tui-session-events.js";
-import type { TuiStateAccess } from "./tui-types.js";
+import { matchesSelectedTuiSession, readTuiSessionUserMessage } from "./tui-session-events.js";
+import type { SessionMessageEvent, TuiStateAccess } from "./tui-types.js";
 
 function makeState(overrides?: Partial<TuiStateAccess>): TuiStateAccess {
   return {
@@ -106,5 +106,52 @@ describe("matchesSelectedTuiSession", () => {
     expect(matchesSelectedTuiSession(state, {})).toBe(false);
     expect(matchesSelectedTuiSession(state, { sessionKey: "  " })).toBe(false);
     expect(matchesSelectedTuiSession(state, { sessionKey: "agent:main:other" })).toBe(false);
+  });
+});
+
+describe("readTuiSessionUserMessage", () => {
+  it("recovers the durable prompt identity and owning chat run", () => {
+    expect(
+      readTuiSessionUserMessage({
+        sessionKey: "agent:main:main",
+        messageId: "user-1",
+        message: {
+          __openclaw: { id: "user-1", idempotencyKey: "run-1:user", seq: 1 },
+          content: [{ type: "text", text: "shared prompt" }],
+          role: "user",
+        },
+      } satisfies SessionMessageEvent),
+    ).toEqual({ messageId: "user-1", runId: "run-1", text: "shared prompt" });
+  });
+
+  it("uses the authoritative transcript sequence when no message id is available", () => {
+    expect(
+      readTuiSessionUserMessage({
+        messageSeq: 7,
+        message: { content: "shared prompt", idempotencyKey: "run-7:user", role: "user" },
+      }),
+    ).toEqual({ messageId: "seq:7", runId: "run-7", text: "shared prompt" });
+  });
+
+  it("recovers the owning chat run from a metadata-free gateway envelope", () => {
+    expect(
+      readTuiSessionUserMessage({
+        clientRunId: "run-envelope",
+        messageId: "user-envelope",
+        message: { content: "shared prompt", role: "user" },
+      } satisfies SessionMessageEvent),
+    ).toEqual({ messageId: "user-envelope", runId: "run-envelope", text: "shared prompt" });
+  });
+
+  it("rejects assistant and identity-free transcript messages", () => {
+    expect(
+      readTuiSessionUserMessage({
+        messageId: "assistant-1",
+        message: { content: "reply", role: "assistant" },
+      }),
+    ).toBeNull();
+    expect(
+      readTuiSessionUserMessage({ message: { content: "unidentified", role: "user" } }),
+    ).toBeNull();
   });
 });

--- a/src/tui/tui-session-events.ts
+++ b/src/tui/tui-session-events.ts
@@ -1,12 +1,56 @@
 // Routes Gateway and embedded events to the exact selected TUI conversation.
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
 import { agentSessionKeysMatchByRequestKey, parseAgentSessionKey } from "../routing/session-key.js";
-import type { TuiStateAccess } from "./tui-types.js";
+import { extractTextFromMessage } from "./tui-formatters.js";
+import type { SessionMessageEvent, TuiStateAccess } from "./tui-types.js";
 
 type TuiSessionEvent = {
   sessionKey?: string;
   agentId?: string;
 };
+
+/** Reads the durable user identity without mistaking another run's prompt for this one. */
+export function readTuiSessionUserMessage(event: SessionMessageEvent): {
+  text: string;
+  messageId: string;
+  runId?: string;
+} | null {
+  const message = event.message;
+  if (!message || typeof message !== "object" || Array.isArray(message)) {
+    return null;
+  }
+  const record = message as Record<string, unknown>;
+  if (record.role !== "user") {
+    return null;
+  }
+  const marker = record["__openclaw"];
+  const metadata =
+    marker && typeof marker === "object" && !Array.isArray(marker)
+      ? (marker as Record<string, unknown>)
+      : null;
+  const sequence = event.messageSeq ?? metadata?.seq;
+  const messageId =
+    (typeof event.messageId === "string" && event.messageId.trim() ? event.messageId : undefined) ??
+    (typeof metadata?.id === "string" && metadata.id.trim() ? metadata.id : undefined) ??
+    (typeof sequence === "number" && Number.isSafeInteger(sequence) && sequence > 0
+      ? `seq:${sequence}`
+      : undefined);
+  const text = extractTextFromMessage(record);
+  if (!messageId || !text) {
+    return null;
+  }
+  const clientRunId =
+    typeof event.clientRunId === "string" && event.clientRunId.trim()
+      ? event.clientRunId
+      : undefined;
+  const idempotencyValue = clientRunId ?? metadata?.idempotencyKey ?? record.idempotencyKey;
+  const idempotencyKey =
+    typeof idempotencyValue === "string" && idempotencyValue.trim() ? idempotencyValue : undefined;
+  const runId = idempotencyKey?.endsWith(":user")
+    ? idempotencyKey.slice(0, -":user".length)
+    : idempotencyKey;
+  return { messageId, text, ...(runId ? { runId } : {}) };
+}
 
 /** Preserves opaque peer IDs while guarding canonical, global, and alias ownership. */
 export function matchesSelectedTuiSession(

--- a/src/tui/tui-types.ts
+++ b/src/tui/tui-types.ts
@@ -72,6 +72,10 @@ export type SessionMessageEvent = {
   agentId?: string;
   sessionId?: string;
   updatedAt?: number | null;
+  clientRunId?: string;
+  message?: unknown;
+  messageId?: string;
+  messageSeq?: number;
 };
 
 export type AgentEvent = {

--- a/ui/src/e2e/chat-flow.messaging.e2e.test.ts
+++ b/ui/src/e2e/chat-flow.messaging.e2e.test.ts
@@ -68,6 +68,329 @@ suite.define(() => {
     }
   });
 
+  it("adopts a browser-local prompt from a metadata-free gateway event without duplication", async () => {
+    const context = await suite.newBrowserContext({
+      locale: "en-US",
+      serviceWorkers: "block",
+      viewport: { height: 900, width: 1280 },
+    });
+    const page = await context.newPage();
+    const gateway = await installMockGateway(page, { historyMessages: [] });
+    const prompt = "Keep my browser-local prompt synchronized.";
+
+    try {
+      await page.goto(`${suite.server.baseUrl}chat`);
+      await page.locator(".agent-chat__composer-combobox textarea").fill(prompt);
+      await page.getByRole("button", { name: "Send message" }).click();
+
+      const request = await gateway.waitForRequest("chat.send");
+      const runId = requireString(requireRecord(request.params).idempotencyKey, "chat run id");
+      const userRow = page.locator(".chat-group.user", { hasText: prompt });
+      await userRow.waitFor({ timeout: 10_000 });
+
+      await gateway.emitGatewayEvent("session.message", {
+        activeRunIds: [runId],
+        clientRunId: runId,
+        hasActiveRun: true,
+        message: {
+          content: [{ text: prompt, type: "text" }],
+          role: "user",
+          timestamp: Date.now(),
+        },
+        messageId: "browser-local-authoritative-user",
+        messageSeq: 1,
+        session: {
+          activeRunIds: [runId],
+          hasActiveRun: true,
+          key: "main",
+          kind: "direct",
+          status: "running",
+          updatedAt: Date.now(),
+        },
+        sessionKey: "main",
+      });
+
+      await expect.poll(() => userRow.count()).toBe(1);
+      const finalText = "Browser prompt stayed synchronized.";
+      await gateway.setHistoryMessages([
+        {
+          __openclaw: {
+            id: "browser-local-authoritative-user",
+            idempotencyKey: `${runId}:user`,
+            seq: 1,
+          },
+          content: [{ text: prompt, type: "text" }],
+          role: "user",
+          timestamp: Date.now(),
+        },
+        {
+          __openclaw: { id: "browser-local-authoritative-assistant", seq: 2 },
+          content: [{ text: finalText, type: "text" }],
+          role: "assistant",
+          timestamp: Date.now(),
+        },
+      ]);
+      await gateway.emitChatFinal({ runId, text: finalText });
+      await page.locator(".chat-group.assistant .chat-text", { hasText: finalText }).waitFor({
+        timeout: 10_000,
+      });
+      await expect.poll(() => userRow.count()).toBe(1);
+    } finally {
+      await suite.closeBrowserContext(context);
+    }
+  });
+
+  it.each([
+    { identity: "transcript metadata", includeMessageMetadata: true },
+    { identity: "gateway event envelope", includeMessageMetadata: false },
+  ])(
+    "keeps another client's $identity user turn ahead of its already-streaming reply",
+    async ({ includeMessageMetadata }) => {
+      const context = await suite.newBrowserContext({
+        locale: "en-US",
+        serviceWorkers: "block",
+        viewport: { height: 900, width: 1280 },
+      });
+      const page = await context.newPage();
+      const gateway = await installMockGateway(page, { historyMessages: [] });
+      const runId = "shared-session-tui-run";
+      const prompt = "Sent from the other client.";
+      const secondPrompt = "A distinct turn in the same shared run.";
+      const partial = "Streaming into both clients.";
+      const userMessage = {
+        ...(includeMessageMetadata
+          ? { __openclaw: { id: "shared-session-user", idempotencyKey: `${runId}:user`, seq: 1 } }
+          : {}),
+        content: [{ text: prompt, type: "text" }],
+        role: "user",
+        timestamp: Date.now(),
+      };
+      const secondUserMessage = {
+        ...(includeMessageMetadata
+          ? {
+              __openclaw: {
+                id: "shared-session-second-user",
+                idempotencyKey: `${runId}:user`,
+                seq: 2,
+              },
+            }
+          : {}),
+        content: [{ text: secondPrompt, type: "text" }],
+        role: "user",
+        timestamp: Date.now(),
+      };
+
+      try {
+        await page.goto(`${suite.server.baseUrl}chat`);
+        await gateway.waitForRequest("chat.startup");
+        await gateway.setHistoryMessages([userMessage]);
+        await gateway.emitGatewayEvent("chat", {
+          deltaText: partial,
+          message: {
+            content: [{ text: partial, type: "text" }],
+            role: "assistant",
+            timestamp: Date.now(),
+          },
+          runId,
+          seq: 1,
+          sessionKey: "main",
+          state: "delta",
+        });
+        await page.locator(".chat-bubble.streaming", { hasText: partial }).waitFor({
+          timeout: 10_000,
+        });
+
+        const sharedUserEvent = {
+          activeRunIds: [runId],
+          ...(includeMessageMetadata ? {} : { clientRunId: runId }),
+          hasActiveRun: true,
+          message: userMessage,
+          messageId: "shared-session-user",
+          messageSeq: 1,
+          session: {
+            activeRunIds: [runId],
+            hasActiveRun: true,
+            key: "main",
+            kind: "direct",
+            status: "running",
+            updatedAt: Date.now(),
+          },
+          sessionKey: "main",
+        };
+        await gateway.emitGatewayEvent("session.message", sharedUserEvent);
+
+        const userRow = page.locator(".chat-group.user", { hasText: prompt });
+        await userRow.waitFor({ timeout: 10_000 });
+        expect(await userRow.count()).toBe(1);
+        await gateway.emitGatewayEvent("session.message", sharedUserEvent);
+        await expect.poll(() => userRow.count()).toBe(1);
+        await gateway.emitGatewayEvent("session.message", {
+          ...sharedUserEvent,
+          message: secondUserMessage,
+          messageId: "shared-session-second-user",
+          messageSeq: 2,
+        });
+        const secondUserRow = page.locator(".chat-group.user", { hasText: secondPrompt });
+        await secondUserRow.waitFor({ timeout: 10_000 });
+        await expect.poll(() => userRow.count()).toBe(1);
+        await expect.poll(() => secondUserRow.count()).toBe(1);
+        await expect
+          .poll(() =>
+            page.locator(".chat-thread-inner").evaluate(
+              (thread, texts) => {
+                const user = Array.from(thread.querySelectorAll(".chat-group.user")).find((row) =>
+                  row.textContent?.includes(texts.prompt),
+                );
+                const assistant = Array.from(
+                  thread.querySelectorAll(".chat-bubble.streaming"),
+                ).find((row) => row.textContent?.includes(texts.partial));
+                return Boolean(
+                  user &&
+                  assistant &&
+                  user.compareDocumentPosition(assistant) & Node.DOCUMENT_POSITION_FOLLOWING,
+                );
+              },
+              { partial, prompt },
+            ),
+          )
+          .toBe(true);
+
+        const finalText = "Both clients stayed synchronized.";
+        await gateway.setHistoryMessages([
+          {
+            ...userMessage,
+            __openclaw: {
+              id: "shared-session-user",
+              idempotencyKey: `${runId}:user`,
+              seq: 1,
+            },
+          },
+          {
+            ...secondUserMessage,
+            __openclaw: {
+              id: "shared-session-second-user",
+              idempotencyKey: `${runId}:user`,
+              seq: 2,
+            },
+          },
+          {
+            __openclaw: { id: "shared-session-assistant", seq: 3 },
+            content: [{ text: finalText, type: "text" }],
+            role: "assistant",
+            timestamp: Date.now(),
+          },
+        ]);
+        await gateway.emitChatFinal({ runId, text: finalText });
+        await page.locator(".chat-group.assistant .chat-text", { hasText: finalText }).waitFor({
+          timeout: 10_000,
+        });
+        await expect.poll(() => userRow.count()).toBe(1);
+        await expect.poll(() => secondUserRow.count()).toBe(1);
+      } finally {
+        await suite.closeBrowserContext(context);
+      }
+    },
+  );
+
+  it("inserts a delayed persisted prompt ahead of an already-finalized reply", async () => {
+    const context = await suite.newBrowserContext({
+      locale: "en-US",
+      serviceWorkers: "block",
+      viewport: { height: 900, width: 1280 },
+    });
+    const page = await context.newPage();
+    const gateway = await installMockGateway(page, { historyMessages: [] });
+    const runId = "shared-session-finalized-run";
+    const prompt = "The persisted prompt arrived after the final.";
+    const finalText = "The reply was already finished.";
+    const userMessage = {
+      __openclaw: { id: "finalized-run-user", idempotencyKey: `${runId}:user`, seq: 1 },
+      content: [{ text: prompt, type: "text" }],
+      role: "user",
+      timestamp: Date.now(),
+    };
+    const assistantMessage = {
+      __openclaw: { id: "finalized-run-assistant", seq: 2 },
+      content: [{ text: finalText, type: "text" }],
+      role: "assistant",
+      timestamp: Date.now(),
+    };
+
+    try {
+      await page.goto(`${suite.server.baseUrl}chat`);
+      await gateway.waitForRequest("chat.startup");
+      await gateway.emitGatewayEvent("chat", {
+        deltaText: finalText,
+        message: {
+          content: [{ text: finalText, type: "text" }],
+          role: "assistant",
+          timestamp: Date.now(),
+        },
+        runId,
+        seq: 1,
+        sessionKey: "main",
+        state: "delta",
+      });
+      await page.locator(".chat-bubble.streaming", { hasText: finalText }).waitFor({
+        timeout: 10_000,
+      });
+      await gateway.emitChatFinal({ runId, text: finalText });
+      await page.locator(".chat-group.assistant .chat-text", { hasText: finalText }).waitFor({
+        timeout: 10_000,
+      });
+      await gateway.setHistoryMessages([userMessage, assistantMessage]);
+      await gateway.deferNext("chat.history");
+      await gateway.emitGatewayEvent("session.message", {
+        activeRunIds: [],
+        clientRunId: runId,
+        hasActiveRun: false,
+        message: userMessage,
+        messageId: "finalized-run-user",
+        messageSeq: 1,
+        session: {
+          activeRunIds: [],
+          hasActiveRun: false,
+          key: "main",
+          kind: "direct",
+          status: "done",
+          updatedAt: Date.now(),
+        },
+        sessionKey: "main",
+      });
+
+      await expect
+        .poll(() =>
+          page.locator(".chat-thread-inner").evaluate(
+            (thread, texts) => {
+              const user = Array.from(thread.querySelectorAll(".chat-group.user")).find((row) =>
+                row.textContent?.includes(texts.prompt),
+              );
+              const assistant = Array.from(thread.querySelectorAll(".chat-group.assistant")).find(
+                (row) => row.textContent?.includes(texts.finalText),
+              );
+              return Boolean(
+                user &&
+                assistant &&
+                user.compareDocumentPosition(assistant) & Node.DOCUMENT_POSITION_FOLLOWING,
+              );
+            },
+            { finalText, prompt },
+          ),
+        )
+        .toBe(true);
+      await gateway.resolveDeferred("chat.history", {
+        messages: [userMessage, assistantMessage],
+        sessionId: "control-ui-e2e-session",
+        thinkingLevel: null,
+      });
+      await expect
+        .poll(() => page.locator(".chat-group.user", { hasText: prompt }).count())
+        .toBe(1);
+    } finally {
+      await suite.closeBrowserContext(context);
+    }
+  });
+
   it("keeps a browser-local prompt before a clock-skewed Gateway reply", async () => {
     const context = await suite.newBrowserContext({
       locale: "en-US",

--- a/ui/src/pages/chat/chat-state-events.ts
+++ b/ui/src/pages/chat/chat-state-events.ts
@@ -44,7 +44,10 @@ import {
 } from "./run-lifecycle.ts";
 import { preserveQueuedUserTurn, retireSteeredChipsForTerminalRun } from "./steer-lifecycle.ts";
 import { isAckedSteeredChip } from "./steered-chip.ts";
-import { rememberAuthoritativeTerminal } from "./terminal-message-identity.ts";
+import {
+  isLiveTerminalForRun,
+  rememberAuthoritativeTerminal,
+} from "./terminal-message-identity.ts";
 import { handleAgentEvent, handleSessionOperationEvent } from "./tool-stream.ts";
 
 function sessionMessageMatchesChat(
@@ -52,6 +55,126 @@ function sessionMessageMatchesChat(
   event: NonNullable<ReturnType<typeof readSessionChangedEvent>>,
 ): boolean {
   return chatScopedEventSessionMatches(state, event.key, event.agentId ?? undefined);
+}
+
+type LiveUserMessageIdentity = {
+  id: string | null;
+  idempotencyKey: string | null;
+  sequence: number | null;
+};
+
+function readLiveUserMessageIdentity(message: unknown): LiveUserMessageIdentity | null {
+  if (!message || typeof message !== "object" || Array.isArray(message)) {
+    return null;
+  }
+  const record = message as Record<string, unknown>;
+  if (record.role !== "user") {
+    return null;
+  }
+  const marker = record["__openclaw"];
+  const metadata =
+    marker && typeof marker === "object" && !Array.isArray(marker)
+      ? (marker as Record<string, unknown>)
+      : null;
+  const id = typeof metadata?.id === "string" && metadata.id.trim() ? metadata.id : null;
+  const idempotencyValue = metadata?.idempotencyKey ?? record.idempotencyKey;
+  const idempotencyKey =
+    typeof idempotencyValue === "string" && idempotencyValue.trim() ? idempotencyValue : null;
+  const sequence =
+    typeof metadata?.seq === "number" && Number.isSafeInteger(metadata.seq) && metadata.seq > 0
+      ? metadata.seq
+      : null;
+  return { id, idempotencyKey, sequence };
+}
+
+function applyLiveUserMessage(state: ChatPageHost, payload: unknown): void {
+  if (!payload || typeof payload !== "object" || Array.isArray(payload)) {
+    return;
+  }
+  const event = payload as {
+    clientRunId?: unknown;
+    message?: unknown;
+    messageId?: unknown;
+    messageSeq?: unknown;
+  };
+  const sourceMessage = event.message;
+  const sourceIdentity = readLiveUserMessageIdentity(sourceMessage);
+  if (!sourceIdentity) {
+    return;
+  }
+  const eventId =
+    typeof event.messageId === "string" && event.messageId.trim() ? event.messageId : null;
+  const clientRunId =
+    typeof event.clientRunId === "string" && event.clientRunId.trim() ? event.clientRunId : null;
+  const eventSequence =
+    typeof event.messageSeq === "number" &&
+    Number.isSafeInteger(event.messageSeq) &&
+    event.messageSeq > 0
+      ? event.messageSeq
+      : null;
+  const incoming: LiveUserMessageIdentity = {
+    ...sourceIdentity,
+    id: eventId ?? sourceIdentity.id,
+    idempotencyKey: sourceIdentity.idempotencyKey ?? clientRunId,
+    sequence: eventSequence ?? sourceIdentity.sequence,
+  };
+  if (!incoming || (!incoming.id && !incoming.idempotencyKey && incoming.sequence === null)) {
+    return;
+  }
+  const sourceRecord = sourceMessage as Record<string, unknown>;
+  const marker = sourceRecord["__openclaw"];
+  const sourceMetadata =
+    marker && typeof marker === "object" && !Array.isArray(marker)
+      ? (marker as Record<string, unknown>)
+      : {};
+  const message = {
+    ...sourceRecord,
+    __openclaw: {
+      ...sourceMetadata,
+      ...(incoming.id ? { id: incoming.id } : {}),
+      ...(incoming.idempotencyKey ? { idempotencyKey: incoming.idempotencyKey } : {}),
+      ...(incoming.sequence !== null ? { seq: incoming.sequence } : {}),
+    },
+  };
+  const incomingText = extractText(sourceMessage);
+  const existingIndex = state.chatMessages.findIndex((candidate) => {
+    const existing = readLiveUserMessageIdentity(candidate);
+    return Boolean(
+      existing &&
+      ((incoming.id && incoming.id === existing.id) ||
+        (incoming.sequence !== null && incoming.sequence === existing.sequence) ||
+        (incoming.idempotencyKey &&
+          existing.id === null &&
+          existing.sequence === null &&
+          existing.idempotencyKey &&
+          incomingText !== null &&
+          extractText(candidate) === incomingText &&
+          (incoming.idempotencyKey === existing.idempotencyKey ||
+            incoming.idempotencyKey === `${existing.idempotencyKey}:user` ||
+            `${incoming.idempotencyKey}:user` === existing.idempotencyKey))),
+    );
+  });
+  if (existingIndex < 0) {
+    const ownerRunId = clientRunId ?? incoming.idempotencyKey;
+    const terminalIndex = ownerRunId
+      ? state.chatMessages.findIndex((candidate) =>
+          isLiveTerminalForRun(
+            candidate,
+            ownerRunId.endsWith(":user") ? ownerRunId.slice(0, -":user".length) : ownerRunId,
+          ),
+        )
+      : -1;
+    // A persisted prompt can trail either a live stream or its already
+    // materialized terminal; both projections must retain transcript order.
+    state.chatMessages =
+      terminalIndex < 0
+        ? [...state.chatMessages, message]
+        : state.chatMessages.toSpliced(terminalIndex, 0, message);
+    return;
+  }
+  if (state.chatMessages[existingIndex] !== message) {
+    state.chatMessages = state.chatMessages.toSpliced(existingIndex, 1, message);
+  }
 }
 
 function selectedGlobalEventAgentId(state: ChatPageHost, agentId: string | null): string {
@@ -121,6 +244,7 @@ function handleSessionMessageEvent(state: ChatPageHost, payload: unknown) {
   }
   const matchesChat = sessionMessageMatchesChat(state, event);
   if (matchesChat) {
+    applyLiveUserMessage(state, payload);
     void loadChatBranches(state);
   }
   if (matchesChat && event.archived !== null) {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users opening the same chat in the Control UI and TUI would see an assistant reply before the prompt that started it, lose a simultaneous prompt, or receive duplicated turns when authoritative transcript events arrived late, were replayed, or carried identity only in their Gateway envelope.

## Why This Change Was Made

Both clients now project Gateway-owned user messages immediately using durable message identity, safely reconcile only matching optimistic prompts, preserve multiple distinct turns in a shared run, and insert delayed prompts before streaming or already-finalized replies. The TUI also indexes restored transcript history so reconnect replay cannot duplicate a persisted turn.

## User Impact

The same session remains synchronized in the browser and TUI while either client sends messages. Prompts and replies appear once, in transcript order, throughout streaming, steering, finalization, and reconnect.

## Evidence

Reproduced the original failure in real Chromium: an already-visible cross-client assistant stream had no corresponding user prompt. Verified the fix on PR head `782e4cd5824ef3d548847e633f9530b086b90d33` using Node 26.

Real Chromium, all affected chat and reconnect flows:

```text
node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner \
  ui/src/e2e/chat-flow.messaging.e2e.test.ts \
  ui/src/e2e/chat-flow.streaming.e2e.test.ts \
  ui/src/e2e/chat-flow.history-recovery.e2e.test.ts \
  ui/src/e2e/chat-send-pending-handoff.e2e.test.ts \
  ui/src/e2e/chat-run-lifecycle.e2e.test.ts \
  ui/src/e2e/plan-replay-reconnect.e2e.test.ts

Test Files  6 passed (6)
     Tests  37 passed (37)
```

Real authenticated Control UI and TUI Gateway clients, SQLite-backed transcript persistence, matching event order, reconnect history, and affected client tests:

```text
node scripts/test-projects.mjs \
  src/gateway/session-message-events.test.ts \
  src/gateway/server-chat.agent-events.test.ts \
  src/tui/components/chat-log.test.ts \
  src/tui/tui-event-handlers.test.ts \
  src/tui/tui-session-actions.test.ts \
  src/tui/tui-session-events.test.ts \
  src/tui/tui-session-run-coordinator.test.ts \
  ui/src/pages/chat/chat-gateway.test.ts \
  ui/src/pages/chat/chat-history.test.ts \
  ui/src/pages/chat/run-lifecycle.test.ts

Gateway: 153 passed
TUI:     247 passed
UI:      202 passed
Total:   602 passed
```

```text
OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 node scripts/check-changed.mjs

PASS core, coreTests, and ui lanes:
- core, core-test, and UI typechecks
- full core/UI lint and changed-file formatting
- runtime, plugin, import-cycle, and database boundaries
- configuration, package, and schema ratchets
```

The Chromium regressions independently exercise transcript-only and envelope-only identity, replay of the same message, distinct prompts on the same run, protection of unrelated optimistic prompts, and a prompt arriving after its assistant final. Independent full-branch autoreview: clean, with no accepted or actionable findings.

AI-assisted (Codex).