### PR TITLE
fix(memory-core): dream diary stays empty because narrative sessions have no agent scope

### DIFF
--- a/extensions/memory-core/src/dreaming-narrative.test.ts
+++ b/extensions/memory-core/src/dreaming-narrative.test.ts
@@ -23,6 +23,7 @@ import {
   readRecentDreamDiaryEntries,
   removeBackfillDiaryEntries,
   runDetachedDreamNarrative,
+  runDreamNarrative,
   writeBackfillDiaryEntries,
 } from "./dreaming-narrative.js";
 import { createMemoryCoreTestHarness } from "./test-helpers.js";
@@ -413,9 +414,11 @@ describe("generateAndAppendDreamNarrative", () => {
     const logger = createMockLogger();
     const nowMs = Date.parse("2026-04-05T03:00:00Z");
     const workspaceHash = createHash("sha1").update(workspaceDir).digest("hex").slice(0, 12);
-    const expectedSessionKey = `dreaming-narrative-light-${workspaceHash}`;
+    const expectedRunKey = `dreaming-narrative-light-${workspaceHash}`;
+    const expectedSessionKey = `agent:main:${expectedRunKey}`;
 
     await generateAndAppendDreamNarrative({
+      agentId: "main",
       subagent,
       workspaceDir,
       data: {
@@ -430,7 +433,8 @@ describe("generateAndAppendDreamNarrative", () => {
 
     expect(subagent.run).toHaveBeenCalledOnce();
     const runOptions = mockObjectArg(subagent.run, "subagent run");
-    expect(runOptions.idempotencyKey).toBe(`${expectedSessionKey}-${nowMs}`);
+    // The runId stays unscoped so the orphan-transcript scrub marker keeps matching.
+    expect(runOptions.idempotencyKey).toBe(`${expectedRunKey}-${nowMs}`);
     expect(runOptions.sessionKey).toBe(expectedSessionKey);
     expect(runOptions.lane).toBe(`dreaming-narrative:${expectedSessionKey}`);
     expect(runOptions.lightContext).toBe(true);
@@ -442,6 +446,38 @@ describe("generateAndAppendDreamNarrative", () => {
     const content = await fs.readFile(path.join(workspaceDir, "DREAMS.md"), "utf-8");
     expect(content).toContain("The repository whispered of forgotten endpoints.");
     expect(logger.info).toHaveBeenCalled();
+  });
+
+  // Regression: unscoped narrative session keys cannot be resolved to a per-agent SQLite
+  // store, so every subagent call failed with "Cannot resolve SQLite session scope without
+  // an agent id" and the whole dreaming pipeline produced nothing.
+  it("scopes narrative sessions to the workspace's owning agent", async () => {
+    const workspaceDir = await createTempWorkspace("openclaw-dreaming-narrative-");
+    const subagent = createMockSubagent("The night shift agent kept its own notebook.");
+    const logger = createMockLogger();
+    const nowMs = Date.parse("2026-04-05T03:00:00Z");
+    const workspaceHash = createHash("sha1").update(workspaceDir).digest("hex").slice(0, 12);
+    const runKey = `dreaming-narrative-rem-${workspaceHash}`;
+
+    await generateAndAppendDreamNarrative({
+      agentId: "researcher",
+      subagent,
+      workspaceDir,
+      data: { phase: "rem", snippets: ["The index remembered a second agent."] },
+      nowMs,
+      timezone: "UTC",
+      logger,
+    });
+
+    expect(mockObjectArg(subagent.run, "subagent run").sessionKey).toBe(
+      `agent:researcher:${runKey}`,
+    );
+    expect(mockObjectArg(subagent.deleteSession, "delete session")).toEqual({
+      sessionKey: `agent:researcher:${runKey}`,
+    });
+    // The scrub marker keys off the runId, which must stay free of the agent scope.
+    expect(mockObjectArg(subagent.run, "subagent run").idempotencyKey).toBe(`${runKey}-${nowMs}`);
+    expectLogExcludes(logger.warn, "narrative generation failed");
   });
 
   it("waits for persisted assistant text before falling back", async () => {
@@ -465,6 +501,7 @@ describe("generateAndAppendDreamNarrative", () => {
       const logger = createMockLogger();
 
       const operation = generateAndAppendDreamNarrative({
+        agentId: "main",
         subagent,
         workspaceDir,
         data: {
@@ -503,6 +540,7 @@ describe("generateAndAppendDreamNarrative", () => {
       const logger = createMockLogger();
 
       const operation = generateAndAppendDreamNarrative({
+        agentId: "main",
         subagent,
         workspaceDir,
         data: {
@@ -533,10 +571,11 @@ describe("generateAndAppendDreamNarrative", () => {
     const logger = createMockLogger();
     const nowMs = Date.parse("2026-04-05T03:00:00Z");
     const workspaceHash = createHash("sha1").update(workspaceDir).digest("hex").slice(0, 12);
-    const expectedSessionKey = `dreaming-narrative-light-${workspaceHash}`;
+    const expectedSessionKey = `agent:main:dreaming-narrative-light-${workspaceHash}`;
     const retrySessionKey = `${expectedSessionKey}-retry-1`;
 
     await generateAndAppendDreamNarrative({
+      agentId: "main",
       subagent,
       workspaceDir,
       data: {
@@ -585,10 +624,11 @@ describe("generateAndAppendDreamNarrative", () => {
     const logger = createMockLogger();
     const nowMs = Date.parse("2026-04-05T03:00:00Z");
     const workspaceHash = createHash("sha1").update(workspaceDir).digest("hex").slice(0, 12);
-    const expectedSessionKey = `dreaming-narrative-rem-${workspaceHash}`;
+    const expectedSessionKey = `agent:main:dreaming-narrative-rem-${workspaceHash}`;
     const retrySessionKey = `${expectedSessionKey}-retry-1`;
 
     await generateAndAppendDreamNarrative({
+      agentId: "main",
       subagent,
       workspaceDir,
       data: {
@@ -631,6 +671,7 @@ describe("generateAndAppendDreamNarrative", () => {
     const logger = createMockLogger();
 
     await generateAndAppendDreamNarrative({
+      agentId: "main",
       subagent,
       workspaceDir,
       data: {
@@ -653,6 +694,7 @@ describe("generateAndAppendDreamNarrative", () => {
     const logger = createMockLogger();
 
     await generateAndAppendDreamNarrative({
+      agentId: "main",
       subagent,
       workspaceDir,
       data: { phase: "light", snippets: [] },
@@ -674,6 +716,7 @@ describe("generateAndAppendDreamNarrative", () => {
     const logger = createMockLogger();
 
     await generateAndAppendDreamNarrative({
+      agentId: "main",
       subagent,
       workspaceDir,
       data: { phase: "deep", snippets: ["some memory"] },
@@ -705,6 +748,7 @@ describe("generateAndAppendDreamNarrative", () => {
     ];
 
     await generateAndAppendDreamNarrative({
+      agentId: "main",
       subagent,
       workspaceDir,
       data: { phase: "deep", snippets: sensitiveSnippets },
@@ -728,6 +772,7 @@ describe("generateAndAppendDreamNarrative", () => {
     const logger = createMockLogger();
 
     await generateAndAppendDreamNarrative({
+      agentId: "main",
       subagent,
       workspaceDir,
       data: { phase: "rem", snippets: ["some memory"] },
@@ -750,15 +795,19 @@ describe("generateAndAppendDreamNarrative", () => {
     const logger = createMockLogger();
 
     await generateAndAppendDreamNarrative({
+      agentId: "main",
       subagent,
       workspaceDir,
       data: { phase: "rem", snippets: ["pattern surfaced"] },
       logger,
     });
 
-    // Should not throw.
-    expect(logger.warn).toHaveBeenCalled();
-    await expectPathMissing(path.join(workspaceDir, "DREAMS.md"));
+    // Should not throw, and an unexpected failure still leaves a dated diary trace
+    // instead of silently skipping the entry.
+    expectLogIncludes(logger.warn, "narrative generation failed");
+    const content = await fs.readFile(path.join(workspaceDir, "DREAMS.md"), "utf-8");
+    expect(content).not.toContain("pattern surfaced");
+    expect(content).toContain("A memory trace surfaced, but details were unavailable in this run.");
   });
 
   it("falls back to a local narrative when subagent runtime is request-scoped", async () => {
@@ -769,6 +818,7 @@ describe("generateAndAppendDreamNarrative", () => {
     const logger = createMockLogger();
 
     await generateAndAppendDreamNarrative({
+      agentId: "main",
       subagent,
       workspaceDir,
       data: { phase: "light", snippets: ["API endpoints need authentication"] },
@@ -801,6 +851,7 @@ describe("generateAndAppendDreamNarrative", () => {
     const logger = createMockLogger();
 
     await generateAndAppendDreamNarrative({
+      agentId: "main",
       subagent,
       workspaceDir,
       data: { phase: "deep", snippets: [], promotions: ["A durable candidate surfaced."] },
@@ -829,14 +880,20 @@ describe("generateAndAppendDreamNarrative", () => {
     const logger = createMockLogger();
 
     await generateAndAppendDreamNarrative({
+      agentId: "main",
       subagent,
       workspaceDir,
       data: { phase: "deep", snippets: ["should not persist"] },
       logger,
     });
 
-    await expectPathMissing(path.join(workspaceDir, "DREAMS.md"));
+    // A spoofed code must not be treated as the request-scoped runtime, so this stays on the
+    // unexpected-failure path: warn plus a generic fallback entry, never the request-scoped info.
     expectLogIncludes(logger.warn, "narrative generation failed");
+    expectLogExcludes(logger.info, "request-scoped");
+    const content = await fs.readFile(path.join(workspaceDir, "DREAMS.md"), "utf-8");
+    expect(content).not.toContain("should not persist");
+    expect(content).toContain("A memory trace surfaced, but details were unavailable in this run.");
   });
 
   it("cleans up session even on failure", async () => {
@@ -846,6 +903,7 @@ describe("generateAndAppendDreamNarrative", () => {
     const logger = createMockLogger();
 
     await generateAndAppendDreamNarrative({
+      agentId: "main",
       subagent,
       workspaceDir,
       data: { phase: "light", snippets: ["memory fragment"] },
@@ -918,6 +976,7 @@ describe("generateAndAppendDreamNarrative", () => {
     const logger = createMockLogger();
 
     await generateAndAppendDreamNarrative({
+      agentId: "main",
       subagent,
       workspaceDir,
       data: { phase: "light", snippets: ["memory fragment"] },
@@ -1003,6 +1062,7 @@ describe("generateAndAppendDreamNarrative", () => {
     const logger = createMockLogger();
 
     await generateAndAppendDreamNarrative({
+      agentId: "main",
       subagent,
       workspaceDir,
       data: { phase: "light", snippets: ["memory fragment"] },
@@ -1037,6 +1097,7 @@ describe("generateAndAppendDreamNarrative", () => {
     const nowMs = Date.parse("2026-04-05T03:00:00Z");
 
     await generateAndAppendDreamNarrative({
+      agentId: "main",
       subagent,
       workspaceDir: firstWorkspaceDir,
       data: { phase: "light", snippets: ["first workspace fragment"] },
@@ -1044,6 +1105,7 @@ describe("generateAndAppendDreamNarrative", () => {
       logger,
     });
     await generateAndAppendDreamNarrative({
+      agentId: "main",
       subagent,
       workspaceDir: secondWorkspaceDir,
       data: { phase: "light", snippets: ["second workspace fragment"] },
@@ -1063,6 +1125,36 @@ describe("generateAndAppendDreamNarrative", () => {
     );
     expect(deleteKeys.filter((key: string) => key === firstSessionKey)).toHaveLength(2);
     expect(deleteKeys.filter((key: string) => key === secondSessionKey)).toHaveLength(2);
+  });
+});
+
+describe("runDreamNarrative", () => {
+  it("keeps the sweep alive with a local fallback when no owning agent is known", async () => {
+    const workspaceDir = await createTempWorkspace("openclaw-dreaming-narrative-");
+    const subagent = {
+      run: vi.fn(),
+      waitForRun: vi.fn(),
+      getSessionMessages: vi.fn(),
+      deleteSession: vi.fn(),
+    };
+    const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+
+    await runDreamNarrative({
+      subagent,
+      workspaceDir,
+      data: { phase: "light", snippets: ["An ownerless sweep still leaves a trace."] },
+      nowMs: Date.parse("2026-04-05T03:00:00Z"),
+      timezone: "UTC",
+      logger,
+    });
+
+    // No agent means no resolvable session store, so the subagent is never called.
+    expect(subagent.run).not.toHaveBeenCalled();
+    expect(subagent.deleteSession).not.toHaveBeenCalled();
+    const content = await fs.readFile(path.join(workspaceDir, "DREAMS.md"), "utf-8");
+    expect(content).not.toContain("An ownerless sweep still leaves a trace.");
+    expect(content).toContain("A memory trace surfaced, but details were unavailable in this run.");
+    expectLogIncludes(logger.info, "no owning agent id");
   });
 });
 
@@ -1115,6 +1207,7 @@ describe("runDetachedDreamNarrative", () => {
 
     for (const [i, workspaceDir] of workspaceDirs.entries()) {
       runDetachedDreamNarrative({
+        agentId: "main",
         subagent,
         workspaceDir,
         data: { phase: "light", snippets: [`fragment-${i}`] },
@@ -1174,6 +1267,7 @@ describe("runDetachedDreamNarrative", () => {
 
     for (let i = 0; i < 5; i += 1) {
       runDetachedDreamNarrative({
+        agentId: "main",
         subagent,
         workspaceDir,
         data: { phase: "light", snippets: [`fragment-${i}`] },
@@ -1226,6 +1320,7 @@ describe("runDetachedDreamNarrative", () => {
 
     try {
       runDetachedDreamNarrative({
+        agentId: "main",
         subagent,
         workspaceDir,
         data: { phase: "light", snippets: ["fragment"] },
@@ -1237,6 +1332,12 @@ describe("runDetachedDreamNarrative", () => {
 
       expect(subagent.run).toHaveBeenCalledOnce();
       expect(unhandled).not.toHaveBeenCalled();
+      // Settle the detached fallback write before the fixture workspace is torn down.
+      await vi.waitFor(async () => {
+        expect(await fs.readFile(path.join(workspaceDir, "DREAMS.md"), "utf-8")).toContain(
+          "A memory trace surfaced, but details were unavailable in this run.",
+        );
+      });
     } finally {
       process.off("unhandledRejection", unhandled);
     }

--- a/extensions/memory-core/src/dreaming-narrative.test.ts
+++ b/extensions/memory-core/src/dreaming-narrative.test.ts
@@ -19,10 +19,8 @@ import { appendSqliteSessionTranscriptEventForTest } from "openclaw/plugin-sdk/s
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   dedupeDreamDiaryEntries,
-  generateAndAppendDreamNarrative,
   readRecentDreamDiaryEntries,
   removeBackfillDiaryEntries,
-  runDetachedDreamNarrative,
   runDreamNarrative,
   writeBackfillDiaryEntries,
 } from "./dreaming-narrative.js";
@@ -385,7 +383,7 @@ describe("dream diary file behavior", () => {
   });
 });
 
-describe("generateAndAppendDreamNarrative", () => {
+describe("runDreamNarrative", () => {
   function createMockSubagent(responseText: string) {
     return {
       run: vi.fn().mockResolvedValue({ runId: "run-123" }),
@@ -417,7 +415,7 @@ describe("generateAndAppendDreamNarrative", () => {
     const expectedRunKey = `dreaming-narrative-light-${workspaceHash}`;
     const expectedSessionKey = `agent:main:${expectedRunKey}`;
 
-    await generateAndAppendDreamNarrative({
+    await runDreamNarrative({
       agentId: "main",
       subagent,
       workspaceDir,
@@ -459,7 +457,7 @@ describe("generateAndAppendDreamNarrative", () => {
     const workspaceHash = createHash("sha1").update(workspaceDir).digest("hex").slice(0, 12);
     const runKey = `dreaming-narrative-rem-${workspaceHash}`;
 
-    await generateAndAppendDreamNarrative({
+    await runDreamNarrative({
       agentId: "researcher",
       subagent,
       workspaceDir,
@@ -500,7 +498,7 @@ describe("generateAndAppendDreamNarrative", () => {
         });
       const logger = createMockLogger();
 
-      const operation = generateAndAppendDreamNarrative({
+      const operation = runDreamNarrative({
         agentId: "main",
         subagent,
         workspaceDir,
@@ -539,7 +537,7 @@ describe("generateAndAppendDreamNarrative", () => {
       const subagent = createMockSubagent("");
       const logger = createMockLogger();
 
-      const operation = generateAndAppendDreamNarrative({
+      const operation = runDreamNarrative({
         agentId: "main",
         subagent,
         workspaceDir,
@@ -574,7 +572,7 @@ describe("generateAndAppendDreamNarrative", () => {
     const expectedSessionKey = `agent:main:dreaming-narrative-light-${workspaceHash}`;
     const retrySessionKey = `${expectedSessionKey}-retry-1`;
 
-    await generateAndAppendDreamNarrative({
+    await runDreamNarrative({
       agentId: "main",
       subagent,
       workspaceDir,
@@ -627,7 +625,7 @@ describe("generateAndAppendDreamNarrative", () => {
     const expectedSessionKey = `agent:main:dreaming-narrative-rem-${workspaceHash}`;
     const retrySessionKey = `${expectedSessionKey}-retry-1`;
 
-    await generateAndAppendDreamNarrative({
+    await runDreamNarrative({
       agentId: "main",
       subagent,
       workspaceDir,
@@ -670,7 +668,7 @@ describe("generateAndAppendDreamNarrative", () => {
     );
     const logger = createMockLogger();
 
-    await generateAndAppendDreamNarrative({
+    await runDreamNarrative({
       agentId: "main",
       subagent,
       workspaceDir,
@@ -693,7 +691,7 @@ describe("generateAndAppendDreamNarrative", () => {
     const subagent = createMockSubagent("Should not appear.");
     const logger = createMockLogger();
 
-    await generateAndAppendDreamNarrative({
+    await runDreamNarrative({
       agentId: "main",
       subagent,
       workspaceDir,
@@ -715,7 +713,7 @@ describe("generateAndAppendDreamNarrative", () => {
     subagent.waitForRun.mockResolvedValue({ status: "timeout" });
     const logger = createMockLogger();
 
-    await generateAndAppendDreamNarrative({
+    await runDreamNarrative({
       agentId: "main",
       subagent,
       workspaceDir,
@@ -747,7 +745,7 @@ describe("generateAndAppendDreamNarrative", () => {
       "Session: 2026-05-22 00:02:16 GMT+1: Session Key: agent:main:dashboard:secret",
     ];
 
-    await generateAndAppendDreamNarrative({
+    await runDreamNarrative({
       agentId: "main",
       subagent,
       workspaceDir,
@@ -771,7 +769,7 @@ describe("generateAndAppendDreamNarrative", () => {
     subagent.deleteSession.mockRejectedValue(new Error("still active"));
     const logger = createMockLogger();
 
-    await generateAndAppendDreamNarrative({
+    await runDreamNarrative({
       agentId: "main",
       subagent,
       workspaceDir,
@@ -794,7 +792,7 @@ describe("generateAndAppendDreamNarrative", () => {
     );
     const logger = createMockLogger();
 
-    await generateAndAppendDreamNarrative({
+    await runDreamNarrative({
       agentId: "main",
       subagent,
       workspaceDir,
@@ -817,7 +815,7 @@ describe("generateAndAppendDreamNarrative", () => {
     subagent.run.mockRejectedValue(new RequestScopedSubagentRuntimeError());
     const logger = createMockLogger();
 
-    await generateAndAppendDreamNarrative({
+    await runDreamNarrative({
       agentId: "main",
       subagent,
       workspaceDir,
@@ -850,7 +848,7 @@ describe("generateAndAppendDreamNarrative", () => {
     subagent.run.mockRejectedValue(crossBoundaryError);
     const logger = createMockLogger();
 
-    await generateAndAppendDreamNarrative({
+    await runDreamNarrative({
       agentId: "main",
       subagent,
       workspaceDir,
@@ -879,7 +877,7 @@ describe("generateAndAppendDreamNarrative", () => {
     });
     const logger = createMockLogger();
 
-    await generateAndAppendDreamNarrative({
+    await runDreamNarrative({
       agentId: "main",
       subagent,
       workspaceDir,
@@ -902,7 +900,7 @@ describe("generateAndAppendDreamNarrative", () => {
     subagent.getSessionMessages.mockRejectedValue(new Error("fetch failed"));
     const logger = createMockLogger();
 
-    await generateAndAppendDreamNarrative({
+    await runDreamNarrative({
       agentId: "main",
       subagent,
       workspaceDir,
@@ -975,7 +973,7 @@ describe("generateAndAppendDreamNarrative", () => {
     const subagent = createMockSubagent("The repository whispered of forgotten endpoints.");
     const logger = createMockLogger();
 
-    await generateAndAppendDreamNarrative({
+    await runDreamNarrative({
       agentId: "main",
       subagent,
       workspaceDir,
@@ -1061,7 +1059,7 @@ describe("generateAndAppendDreamNarrative", () => {
     const subagent = createMockSubagent("A forgotten endpoint hummed in the dark.");
     const logger = createMockLogger();
 
-    await generateAndAppendDreamNarrative({
+    await runDreamNarrative({
       agentId: "main",
       subagent,
       workspaceDir,
@@ -1096,7 +1094,7 @@ describe("generateAndAppendDreamNarrative", () => {
     const logger = createMockLogger();
     const nowMs = Date.parse("2026-04-05T03:00:00Z");
 
-    await generateAndAppendDreamNarrative({
+    await runDreamNarrative({
       agentId: "main",
       subagent,
       workspaceDir: firstWorkspaceDir,
@@ -1104,7 +1102,7 @@ describe("generateAndAppendDreamNarrative", () => {
       nowMs,
       logger,
     });
-    await generateAndAppendDreamNarrative({
+    await runDreamNarrative({
       agentId: "main",
       subagent,
       workspaceDir: secondWorkspaceDir,
@@ -1128,7 +1126,7 @@ describe("generateAndAppendDreamNarrative", () => {
   });
 });
 
-describe("runDreamNarrative", () => {
+describe("runDreamNarrative ownership gate", () => {
   it("keeps the sweep alive with a local fallback when no owning agent is known", async () => {
     const workspaceDir = await createTempWorkspace("openclaw-dreaming-narrative-");
     const subagent = {
@@ -1158,7 +1156,7 @@ describe("runDreamNarrative", () => {
   });
 });
 
-describe("runDetachedDreamNarrative", () => {
+describe("runDreamNarrative detached dispatch", () => {
   type Deferred<T> = { promise: Promise<T>; resolve: (v: T) => void };
   function deferred<T>(): Deferred<T> {
     let resolve: ((v: T) => void) | undefined;
@@ -1206,13 +1204,14 @@ describe("runDetachedDreamNarrative", () => {
     const logger = createMockLogger();
 
     for (const [i, workspaceDir] of workspaceDirs.entries()) {
-      runDetachedDreamNarrative({
+      void runDreamNarrative({
         agentId: "main",
         subagent,
         workspaceDir,
         data: { phase: "light", snippets: [`fragment-${i}`] },
         nowMs: Date.parse("2026-04-28T03:00:00Z"),
         logger,
+        detached: true,
       });
     }
 
@@ -1266,13 +1265,14 @@ describe("runDetachedDreamNarrative", () => {
     const logger = createMockLogger();
 
     for (let i = 0; i < 5; i += 1) {
-      runDetachedDreamNarrative({
+      void runDreamNarrative({
         agentId: "main",
         subagent,
         workspaceDir,
         data: { phase: "light", snippets: [`fragment-${i}`] },
         nowMs: Date.parse("2026-04-28T03:00:00Z"),
         logger,
+        detached: true,
       });
     }
 
@@ -1319,13 +1319,14 @@ describe("runDetachedDreamNarrative", () => {
     process.on("unhandledRejection", unhandled);
 
     try {
-      runDetachedDreamNarrative({
+      void runDreamNarrative({
         agentId: "main",
         subagent,
         workspaceDir,
         data: { phase: "light", snippets: ["fragment"] },
         nowMs: Date.parse("2026-04-28T03:00:00Z"),
         logger,
+        detached: true,
       });
 
       await drainMicrotasks();

--- a/extensions/memory-core/src/dreaming-narrative.test.ts
+++ b/extensions/memory-core/src/dreaming-narrative.test.ts
@@ -126,14 +126,6 @@ async function flushNarrativeSettleTimers<T>(operation: Promise<T>): Promise<T> 
   return operation;
 }
 
-async function expectPathMissing(targetPath: string): Promise<void> {
-  const accessResult = await fs
-    .access(targetPath)
-    .then(() => "exists")
-    .catch((error: unknown) => (error as { code?: unknown }).code);
-  expect(accessResult).toBe("ENOENT");
-}
-
 afterEach(() => {
   vi.restoreAllMocks();
   restoreNarrativeTestEnv();

--- a/extensions/memory-core/src/dreaming-narrative.test.ts
+++ b/extensions/memory-core/src/dreaming-narrative.test.ts
@@ -1159,6 +1159,36 @@ describe("runDreamNarrative ownership gate", () => {
     expectLogIncludes(logger.info, "no owning agent id");
   });
 
+  it("queues the ownerless fallback through detached dispatch", async () => {
+    const workspaceDir = await createTempWorkspace("openclaw-dreaming-narrative-");
+    const subagent = {
+      run: vi.fn(),
+      waitForRun: vi.fn(),
+      getSessionMessages: vi.fn(),
+      deleteSession: vi.fn(),
+    };
+    const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+
+    // A detached cron sweep must not await the diary write, so the ownerless fallback rides
+    // the same limiter as the subagent path instead of blocking inline.
+    await runDreamNarrative({
+      subagent,
+      workspaceDir,
+      data: { phase: "light", snippets: ["A detached ownerless sweep still leaves a trace."] },
+      nowMs: Date.parse("2026-04-05T03:00:00Z"),
+      timezone: "UTC",
+      logger,
+      detached: true,
+    });
+
+    expect(subagent.run).not.toHaveBeenCalled();
+    await vi.waitFor(async () => {
+      expect(await fs.readFile(path.join(workspaceDir, "DREAMS.md"), "utf-8")).toContain(
+        "A memory trace surfaced, but details were unavailable in this run.",
+      );
+    });
+  });
+
   it("stays a no-op for an ownerless sweep with nothing to narrate", async () => {
     const workspaceDir = await createTempWorkspace("openclaw-dreaming-narrative-");
     const subagent = {

--- a/extensions/memory-core/src/dreaming-narrative.test.ts
+++ b/extensions/memory-core/src/dreaming-narrative.test.ts
@@ -126,6 +126,14 @@ async function flushNarrativeSettleTimers<T>(operation: Promise<T>): Promise<T> 
   return operation;
 }
 
+async function expectPathMissing(targetPath: string): Promise<void> {
+  const accessResult = await fs
+    .access(targetPath)
+    .then(() => "exists")
+    .catch((error: unknown) => (error as { code?: unknown }).code);
+  expect(accessResult).toBe("ENOENT");
+}
+
 afterEach(() => {
   vi.restoreAllMocks();
   restoreNarrativeTestEnv();
@@ -404,8 +412,8 @@ describe("runDreamNarrative", () => {
     const logger = createMockLogger();
     const nowMs = Date.parse("2026-04-05T03:00:00Z");
     const workspaceHash = createHash("sha1").update(workspaceDir).digest("hex").slice(0, 12);
-    const expectedRunKey = `dreaming-narrative-light-${workspaceHash}`;
-    const expectedSessionKey = `agent:main:${expectedRunKey}`;
+    const expectedRunKey = `dreaming-narrative-main-light-${workspaceHash}`;
+    const expectedSessionKey = `agent:main:dreaming-narrative-light-${workspaceHash}`;
 
     await runDreamNarrative({
       agentId: "main",
@@ -423,8 +431,9 @@ describe("runDreamNarrative", () => {
 
     expect(subagent.run).toHaveBeenCalledOnce();
     const runOptions = mockObjectArg(subagent.run, "subagent run");
-    // The runId stays unscoped so the orphan-transcript scrub marker keeps matching.
+    // The runId keeps the scrub marker's `dreaming-narrative-` prefix ahead of the agent scope.
     expect(runOptions.idempotencyKey).toBe(`${expectedRunKey}-${nowMs}`);
+    expect(runOptions.idempotencyKey).toMatch(/^dreaming-narrative-/);
     expect(runOptions.sessionKey).toBe(expectedSessionKey);
     expect(runOptions.lane).toBe(`dreaming-narrative:${expectedSessionKey}`);
     expect(runOptions.lightContext).toBe(true);
@@ -447,7 +456,7 @@ describe("runDreamNarrative", () => {
     const logger = createMockLogger();
     const nowMs = Date.parse("2026-04-05T03:00:00Z");
     const workspaceHash = createHash("sha1").update(workspaceDir).digest("hex").slice(0, 12);
-    const runKey = `dreaming-narrative-rem-${workspaceHash}`;
+    const sessionSuffix = `dreaming-narrative-rem-${workspaceHash}`;
 
     await runDreamNarrative({
       agentId: "researcher",
@@ -460,13 +469,16 @@ describe("runDreamNarrative", () => {
     });
 
     expect(mockObjectArg(subagent.run, "subagent run").sessionKey).toBe(
-      `agent:researcher:${runKey}`,
+      `agent:researcher:${sessionSuffix}`,
     );
     expect(mockObjectArg(subagent.deleteSession, "delete session")).toEqual({
-      sessionKey: `agent:researcher:${runKey}`,
+      sessionKey: `agent:researcher:${sessionSuffix}`,
     });
-    // The scrub marker keys off the runId, which must stay free of the agent scope.
-    expect(mockObjectArg(subagent.run, "subagent run").idempotencyKey).toBe(`${runKey}-${nowMs}`);
+    // The runId names its owning agent too, so two agents sharing a workspace cannot collide
+    // on one run; the scrub marker still matches because the agent scope follows the prefix.
+    expect(mockObjectArg(subagent.run, "subagent run").idempotencyKey).toBe(
+      `dreaming-narrative-researcher-rem-${workspaceHash}-${nowMs}`,
+    );
     expectLogExcludes(logger.warn, "narrative generation failed");
   });
 
@@ -1145,6 +1157,31 @@ describe("runDreamNarrative ownership gate", () => {
     expect(content).not.toContain("An ownerless sweep still leaves a trace.");
     expect(content).toContain("A memory trace surfaced, but details were unavailable in this run.");
     expectLogIncludes(logger.info, "no owning agent id");
+  });
+
+  it("stays a no-op for an ownerless sweep with nothing to narrate", async () => {
+    const workspaceDir = await createTempWorkspace("openclaw-dreaming-narrative-");
+    const subagent = {
+      run: vi.fn(),
+      waitForRun: vi.fn(),
+      getSessionMessages: vi.fn(),
+      deleteSession: vi.fn(),
+    };
+    const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+
+    await runDreamNarrative({
+      subagent,
+      workspaceDir,
+      data: { phase: "light", snippets: [] },
+      nowMs: Date.parse("2026-04-05T03:00:00Z"),
+      timezone: "UTC",
+      logger,
+    });
+
+    // Empty narrative data is a no-op with or without an owner; the ownership fallback must
+    // not invent a diary entry for material that never existed.
+    expect(subagent.run).not.toHaveBeenCalled();
+    await expectPathMissing(path.join(workspaceDir, "DREAMS.md"));
   });
 });
 

--- a/extensions/memory-core/src/dreaming-narrative.ts
+++ b/extensions/memory-core/src/dreaming-narrative.ts
@@ -843,9 +843,7 @@ export type DreamNarrativeRequest = {
   logger: Logger;
 };
 
-export async function generateAndAppendDreamNarrative(
-  params: DreamNarrativeRequest,
-): Promise<void> {
+async function generateAndAppendDreamNarrative(params: DreamNarrativeRequest): Promise<void> {
   const nowMs = Number.isFinite(params.nowMs) ? (params.nowMs as number) : Date.now();
 
   if (params.data.snippets.length === 0 && !params.data.promotions?.length) {
@@ -1044,7 +1042,7 @@ export async function generateAndAppendDreamNarrative(
 const DETACHED_NARRATIVE_CONCURRENCY = 3;
 const detachedNarrativeLimit = pLimit(DETACHED_NARRATIVE_CONCURRENCY);
 
-export function runDetachedDreamNarrative(params: DreamNarrativeRequest): void {
+function runDetachedDreamNarrative(params: DreamNarrativeRequest): void {
   queueMicrotask(() => {
     void detachedNarrativeLimit(() => generateAndAppendDreamNarrative(params)).catch(() => {
       // Detached narratives intentionally swallow errors — callers (cron

--- a/extensions/memory-core/src/dreaming-narrative.ts
+++ b/extensions/memory-core/src/dreaming-narrative.ts
@@ -177,8 +177,8 @@ export async function appendFallbackNarrativeEntry(params: {
   }
 }
 
-function buildNarrativeAttemptSessionKey(baseSessionKey: string, attempt: number): string {
-  return attempt === 0 ? baseSessionKey : `${baseSessionKey}-retry-${attempt}`;
+function buildNarrativeAttemptKey(baseKey: string, attempt: number): string {
+  return attempt === 0 ? baseKey : `${baseKey}-retry-${attempt}`;
 }
 
 function isConfiguredModelUnavailableNarrativeError(raw: string): boolean {
@@ -230,6 +230,7 @@ function formatNarrativeTerminalStatus(params: { status: string; error?: string 
 async function startNarrativeRunOrFallback(params: {
   subagent: SubagentSurface;
   sessionKey: string;
+  runKey: string;
   message: string;
   data: NarrativePhaseData;
   workspaceDir: string;
@@ -240,7 +241,9 @@ async function startNarrativeRunOrFallback(params: {
 }): Promise<string | null> {
   try {
     const run = await params.subagent.run({
-      idempotencyKey: `${params.sessionKey}-${params.nowMs}`,
+      // The gateway uses the idempotency key as the runId, and the orphan-transcript
+      // scrub matches runIds by DREAMING_TRANSCRIPT_RUN_MARKER — keep it unscoped.
+      idempotencyKey: `${params.runKey}-${params.nowMs}`,
       sessionKey: params.sessionKey,
       message: params.message,
       ...(params.model ? { model: params.model } : {}),
@@ -267,14 +270,29 @@ async function startNarrativeRunOrFallback(params: {
 }
 
 /**
- * Build the deterministic subagent session key used for dream narratives.
+ * Deterministic narrative identity, also the runId prefix `scrubDreamingNarrativeArtifacts`
+ * matches through DREAMING_TRANSCRIPT_RUN_MARKER. Keep it free of the agent scope so the
+ * marker stays stable no matter which agent owns the workspace.
  */
-function buildNarrativeSessionKey(params: {
+function buildNarrativeRunKey(params: {
   workspaceDir: string;
   phase: NarrativePhaseData["phase"];
 }): string {
   const workspaceHash = createHash("sha1").update(params.workspaceDir).digest("hex").slice(0, 12);
-  return `dreaming-narrative-${params.phase}-${workspaceHash}`;
+  return `${DREAMING_SESSION_KEY_PREFIX}${params.phase}-${workspaceHash}`;
+}
+
+/**
+ * Build the deterministic subagent session key used for dream narratives.
+ * Sessions live in per-agent SQLite stores, so the key must name its owning agent;
+ * an unscoped key cannot be resolved to a store and the whole run fails.
+ */
+function buildNarrativeSessionKey(params: {
+  agentId: string;
+  workspaceDir: string;
+  phase: NarrativePhaseData["phase"];
+}): string {
+  return `agent:${params.agentId}:${buildNarrativeRunKey(params)}`;
 }
 
 // ── Prompt building ────────────────────────────────────────────────────
@@ -813,7 +831,9 @@ async function scrubDreamingNarrativeArtifacts(logger: Logger): Promise<void> {
   }
 }
 
-export async function generateAndAppendDreamNarrative(params: {
+export type DreamNarrativeRequest = {
+  /** Agent that owns this workspace; the narrative session lives in its SQLite store. */
+  agentId: string;
   subagent: SubagentSurface;
   workspaceDir: string;
   data: NarrativePhaseData;
@@ -821,14 +841,23 @@ export async function generateAndAppendDreamNarrative(params: {
   timezone?: string;
   model?: string;
   logger: Logger;
-}): Promise<void> {
+};
+
+export async function generateAndAppendDreamNarrative(
+  params: DreamNarrativeRequest,
+): Promise<void> {
   const nowMs = Number.isFinite(params.nowMs) ? (params.nowMs as number) : Date.now();
 
   if (params.data.snippets.length === 0 && !params.data.promotions?.length) {
     return;
   }
 
+  const runKey = buildNarrativeRunKey({
+    workspaceDir: params.workspaceDir,
+    phase: params.data.phase,
+  });
   const sessionKey = buildNarrativeSessionKey({
+    agentId: params.agentId,
     workspaceDir: params.workspaceDir,
     phase: params.data.phase,
   });
@@ -840,7 +869,8 @@ export async function generateAndAppendDreamNarrative(params: {
       const attemptModels = params.model ? [params.model, undefined] : [undefined];
 
       for (const [attemptIndex, attemptModel] of attemptModels.entries()) {
-        const attemptSessionKey = buildNarrativeAttemptSessionKey(sessionKey, attemptIndex);
+        const attemptSessionKey = buildNarrativeAttemptKey(sessionKey, attemptIndex);
+        const attemptRunKey = buildNarrativeAttemptKey(runKey, attemptIndex);
         const attempt = { sessionKey: attemptSessionKey, runId: null as string | null };
         attempts.push(attempt);
 
@@ -859,6 +889,7 @@ export async function generateAndAppendDreamNarrative(params: {
           const runId = await startNarrativeRunOrFallback({
             subagent: params.subagent,
             sessionKey: attemptSessionKey,
+            runKey: attemptRunKey,
             message,
             data: params.data,
             workspaceDir: params.workspaceDir,
@@ -959,10 +990,20 @@ export async function generateAndAppendDreamNarrative(params: {
         `memory-core: dream diary entry written for ${params.data.phase} phase [workspace=${params.workspaceDir}].`,
       );
     } catch (err) {
-      // Narrative generation is best-effort — never fail the parent phase.
+      // Narrative generation is best-effort — never fail the parent phase. Still write the
+      // fallback entry the terminal-status and empty-text branches write, so an unexpected
+      // failure leaves a visible diary trace instead of an untouched DREAMS.md.
       params.logger.warn(
         `memory-core: narrative generation failed for ${params.data.phase} phase: ${formatErrorMessage(err)}`,
       );
+      await appendFallbackNarrativeEntry({
+        workspaceDir: params.workspaceDir,
+        data: params.data,
+        nowMs,
+        timezone: params.timezone,
+        logger: params.logger,
+        reason: `the narrative run failed (${formatErrorMessage(err)})`,
+      });
     } finally {
       // Only cleanup after a run was accepted. Request-scoped fallback writes a
       // local diary entry without creating a subagent session.
@@ -1003,9 +1044,7 @@ export async function generateAndAppendDreamNarrative(params: {
 const DETACHED_NARRATIVE_CONCURRENCY = 3;
 const detachedNarrativeLimit = pLimit(DETACHED_NARRATIVE_CONCURRENCY);
 
-export function runDetachedDreamNarrative(
-  params: Parameters<typeof generateAndAppendDreamNarrative>[0],
-): void {
+export function runDetachedDreamNarrative(params: DreamNarrativeRequest): void {
   queueMicrotask(() => {
     void detachedNarrativeLimit(() => generateAndAppendDreamNarrative(params)).catch(() => {
       // Detached narratives intentionally swallow errors — callers (cron
@@ -1014,5 +1053,32 @@ export function runDetachedDreamNarrative(
       // generateAndAppendDreamNarrative.
     });
   });
+}
+
+/**
+ * Single entry point for every dreaming phase. Cron sweeps detach so a stalled diary run
+ * cannot hold the sweep open; heartbeat sweeps await so the phase reports the outcome.
+ * A sweep without an owning agent still runs; only the subagent narrative is unavailable.
+ */
+export async function runDreamNarrative(
+  params: Omit<DreamNarrativeRequest, "agentId"> & { agentId?: string; detached?: boolean },
+): Promise<void> {
+  const { agentId, detached, ...rest } = params;
+  if (!agentId) {
+    // Narrative sessions are stored per agent, so an ownerless sweep cannot start one.
+    // Write the local diary fallback instead of skipping the entry without a trace.
+    await appendFallbackNarrativeEntry({
+      ...rest,
+      nowMs: Number.isFinite(rest.nowMs) ? (rest.nowMs as number) : Date.now(),
+      reason: "the dreaming sweep has no owning agent id",
+    });
+    return;
+  }
+  const request = { ...rest, agentId };
+  if (detached) {
+    runDetachedDreamNarrative(request);
+    return;
+  }
+  await generateAndAppendDreamNarrative(request);
 }
 /* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */

--- a/extensions/memory-core/src/dreaming-narrative.ts
+++ b/extensions/memory-core/src/dreaming-narrative.ts
@@ -269,17 +269,23 @@ async function startNarrativeRunOrFallback(params: {
   }
 }
 
+function buildNarrativeWorkspaceHash(workspaceDir: string): string {
+  return createHash("sha1").update(workspaceDir).digest("hex").slice(0, 12);
+}
+
 /**
- * Deterministic narrative identity, also the runId prefix `scrubDreamingNarrativeArtifacts`
- * matches through DREAMING_TRANSCRIPT_RUN_MARKER. Keep it free of the agent scope so the
- * marker stays stable no matter which agent owns the workspace.
+ * Deterministic run identity, which the gateway also uses as the runId.
+ * The agent scope goes after `DREAMING_SESSION_KEY_PREFIX` so the orphan-transcript scrub
+ * keeps matching DREAMING_TRANSCRIPT_RUN_MARKER, while two agents that share one workspace
+ * cannot collide on a run they own through different agent-scoped sessions.
  */
 function buildNarrativeRunKey(params: {
+  agentId: string;
   workspaceDir: string;
   phase: NarrativePhaseData["phase"];
 }): string {
-  const workspaceHash = createHash("sha1").update(params.workspaceDir).digest("hex").slice(0, 12);
-  return `${DREAMING_SESSION_KEY_PREFIX}${params.phase}-${workspaceHash}`;
+  const workspaceHash = buildNarrativeWorkspaceHash(params.workspaceDir);
+  return `${DREAMING_SESSION_KEY_PREFIX}${params.agentId}-${params.phase}-${workspaceHash}`;
 }
 
 /**
@@ -292,7 +298,8 @@ function buildNarrativeSessionKey(params: {
   workspaceDir: string;
   phase: NarrativePhaseData["phase"];
 }): string {
-  return `agent:${params.agentId}:${buildNarrativeRunKey(params)}`;
+  const workspaceHash = buildNarrativeWorkspaceHash(params.workspaceDir);
+  return `agent:${params.agentId}:${DREAMING_SESSION_KEY_PREFIX}${params.phase}-${workspaceHash}`;
 }
 
 // ── Prompt building ────────────────────────────────────────────────────
@@ -844,13 +851,10 @@ export type DreamNarrativeRequest = {
 };
 
 async function generateAndAppendDreamNarrative(params: DreamNarrativeRequest): Promise<void> {
+  // `runDreamNarrative` is the only entry point and already dropped empty narrative data.
   const nowMs = Number.isFinite(params.nowMs) ? (params.nowMs as number) : Date.now();
-
-  if (params.data.snippets.length === 0 && !params.data.promotions?.length) {
-    return;
-  }
-
   const runKey = buildNarrativeRunKey({
+    agentId: params.agentId,
     workspaceDir: params.workspaceDir,
     phase: params.data.phase,
   });
@@ -1062,6 +1066,11 @@ export async function runDreamNarrative(
   params: Omit<DreamNarrativeRequest, "agentId"> & { agentId?: string; detached?: boolean },
 ): Promise<void> {
   const { agentId, detached, ...rest } = params;
+  // Nothing to narrate is a no-op on every path; checking ownership first would let an
+  // ownerless empty sweep append a diary entry for material that never existed.
+  if (rest.data.snippets.length === 0 && !rest.data.promotions?.length) {
+    return;
+  }
   if (!agentId) {
     // Narrative sessions are stored per agent, so an ownerless sweep cannot start one.
     // Write the local diary fallback instead of skipping the entry without a trace.

--- a/extensions/memory-core/src/dreaming-narrative.ts
+++ b/extensions/memory-core/src/dreaming-narrative.ts
@@ -1041,18 +1041,17 @@ async function generateAndAppendDreamNarrative(params: DreamNarrativeRequest): P
 // write-lock while it runs and burns a model slot, which caused lock
 // contention (>30 s) and cascading narrative timeouts (#73198).
 //
-// `runDetachedDreamNarrative` caps total in-flight detached narratives across
+// `runDetachedNarrativeJob` caps total in-flight detached narratives across
 // phases/workspaces so cron sweeps cannot exhaust model and session-lock slots.
 const DETACHED_NARRATIVE_CONCURRENCY = 3;
 const detachedNarrativeLimit = pLimit(DETACHED_NARRATIVE_CONCURRENCY);
 
-function runDetachedDreamNarrative(params: DreamNarrativeRequest): void {
+function runDetachedNarrativeJob(job: () => Promise<void>): void {
   queueMicrotask(() => {
-    void detachedNarrativeLimit(() => generateAndAppendDreamNarrative(params)).catch(() => {
+    void detachedNarrativeLimit(job).catch(() => {
       // Detached narratives intentionally swallow errors — callers (cron
       // sweeps) cannot recover, and surfacing here would only cause noisy
-      // unhandled rejections. Logging happens inside
-      // generateAndAppendDreamNarrative.
+      // unhandled rejections. Logging happens inside the job itself.
     });
   });
 }
@@ -1071,21 +1070,21 @@ export async function runDreamNarrative(
   if (rest.data.snippets.length === 0 && !rest.data.promotions?.length) {
     return;
   }
-  if (!agentId) {
-    // Narrative sessions are stored per agent, so an ownerless sweep cannot start one.
-    // Write the local diary fallback instead of skipping the entry without a trace.
-    await appendFallbackNarrativeEntry({
-      ...rest,
-      nowMs: Number.isFinite(rest.nowMs) ? (rest.nowMs as number) : Date.now(),
-      reason: "the dreaming sweep has no owning agent id",
-    });
-    return;
-  }
-  const request = { ...rest, agentId };
+  // Narrative sessions are stored per agent, so an ownerless sweep cannot start one.
+  // Write the local diary fallback instead of skipping the entry without a trace, and
+  // keep it on the same dispatch so a detached cron sweep never awaits a diary write.
+  const job = agentId
+    ? () => generateAndAppendDreamNarrative({ ...rest, agentId })
+    : () =>
+        appendFallbackNarrativeEntry({
+          ...rest,
+          nowMs: Number.isFinite(rest.nowMs) ? (rest.nowMs as number) : Date.now(),
+          reason: "the dreaming sweep has no owning agent id",
+        });
   if (detached) {
-    runDetachedDreamNarrative(request);
+    runDetachedNarrativeJob(job);
     return;
   }
-  await generateAndAppendDreamNarrative(request);
+  await job();
 }
 /* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */

--- a/extensions/memory-core/src/dreaming-phases.test.ts
+++ b/extensions/memory-core/src/dreaming-phases.test.ts
@@ -289,6 +289,7 @@ function createHarness(
       },
     };
     await runDreamingSweepPhases({
+      agentId: "main",
       workspaceDir: activeWorkspace,
       pluginConfig: selectedPluginConfig,
       cfg: resolvedConfig,
@@ -514,9 +515,10 @@ describe("memory-core dreaming phases", () => {
     };
     const nowMs = Date.parse("2026-04-05T10:05:00.000Z");
     const workspaceHash = createHash("sha1").update(workspaceDir).digest("hex").slice(0, 12);
-    const expectedSessionKey = `dreaming-narrative-light-${workspaceHash}`;
+    const expectedSessionKey = `agent:main:dreaming-narrative-light-${workspaceHash}`;
 
     await runDreamingSweepPhases({
+      agentId: "main",
       workspaceDir,
       cfg: testConfig,
       pluginConfig: resolveMemoryDreamingPluginConfig(testConfig),
@@ -584,6 +586,7 @@ describe("memory-core dreaming phases", () => {
 
     await expect(
       runDreamingSweepPhases({
+        agentId: "main",
         workspaceDir,
         cfg: testConfig,
         pluginConfig: resolveMemoryDreamingPluginConfig(testConfig),
@@ -818,6 +821,7 @@ describe("memory-core dreaming phases", () => {
     };
 
     await runDreamingSweepPhases({
+      agentId: "main",
       workspaceDir,
       cfg: testConfig,
       pluginConfig: resolveMemoryDreamingPluginConfig(testConfig),
@@ -3046,6 +3050,7 @@ describe("memory-core dreaming phases", () => {
     await withDreamingTestClock(async () => {
       setDreamingTestTime();
       await runDreamingSweepPhases({
+        agentId: "main",
         workspaceDir,
         pluginConfig: {
           dreaming: {

--- a/extensions/memory-core/src/dreaming-phases.ts
+++ b/extensions/memory-core/src/dreaming-phases.ts
@@ -34,10 +34,10 @@ import {
 } from "./dreaming-ingestion-state.js";
 import { writeDailyDreamingPhaseBlock } from "./dreaming-markdown.js";
 import {
-  generateAndAppendDreamNarrative,
+  type DreamNarrativeRequest,
   readRecentDreamDiaryEntries,
   type NarrativePhaseData,
-  runDetachedDreamNarrative,
+  runDreamNarrative,
 } from "./dreaming-narrative.js";
 import { formatErrorMessage } from "./dreaming-shared.js";
 import {
@@ -1761,12 +1761,13 @@ export function previewRemDreaming(params: {
 }
 
 async function runLightDreaming(params: {
+  agentId?: string;
   workspaceDir: string;
   cfg?: DreamingHostConfig;
   primaryWorkspaceDir?: string;
   config: LightDreamingConfig;
   logger: Logger;
-  subagent?: Parameters<typeof generateAndAppendDreamNarrative>[0]["subagent"];
+  subagent?: DreamNarrativeRequest["subagent"];
   detachNarratives?: boolean;
   nowMs?: number;
 }): Promise<void> {
@@ -1844,37 +1845,28 @@ async function runLightDreaming(params: {
       ...(themes.length > 0 ? { themes } : {}),
       ...(recentDiaryEntries.length > 0 ? { recentDiaryEntries } : {}),
     };
-    if (params.detachNarratives) {
-      runDetachedDreamNarrative({
-        subagent: params.subagent,
-        workspaceDir: params.workspaceDir,
-        data,
-        nowMs,
-        timezone: params.config.timezone,
-        model: params.config.execution?.model,
-        logger: params.logger,
-      });
-    } else {
-      await generateAndAppendDreamNarrative({
-        subagent: params.subagent,
-        workspaceDir: params.workspaceDir,
-        data,
-        nowMs,
-        timezone: params.config.timezone,
-        model: params.config.execution?.model,
-        logger: params.logger,
-      });
-    }
+    await runDreamNarrative({
+      agentId: params.agentId,
+      subagent: params.subagent,
+      workspaceDir: params.workspaceDir,
+      data,
+      nowMs,
+      timezone: params.config.timezone,
+      model: params.config.execution?.model,
+      logger: params.logger,
+      detached: params.detachNarratives,
+    });
   }
 }
 
 async function runRemDreaming(params: {
+  agentId?: string;
   workspaceDir: string;
   cfg?: DreamingHostConfig;
   primaryWorkspaceDir?: string;
   config: RemDreamingConfig;
   logger: Logger;
-  subagent?: Parameters<typeof generateAndAppendDreamNarrative>[0]["subagent"];
+  subagent?: DreamNarrativeRequest["subagent"];
   detachNarratives?: boolean;
   nowMs?: number;
 }): Promise<void> {
@@ -1959,36 +1951,32 @@ async function runRemDreaming(params: {
               .filter(Boolean),
       ...(themes.length > 0 ? { themes } : {}),
     };
-    if (params.detachNarratives) {
-      runDetachedDreamNarrative({
-        subagent: params.subagent,
-        workspaceDir: params.workspaceDir,
-        data,
-        nowMs,
-        timezone: params.config.timezone,
-        model: params.config.execution?.model,
-        logger: params.logger,
-      });
-    } else {
-      await generateAndAppendDreamNarrative({
-        subagent: params.subagent,
-        workspaceDir: params.workspaceDir,
-        data,
-        nowMs,
-        timezone: params.config.timezone,
-        model: params.config.execution?.model,
-        logger: params.logger,
-      });
-    }
+    await runDreamNarrative({
+      agentId: params.agentId,
+      subagent: params.subagent,
+      workspaceDir: params.workspaceDir,
+      data,
+      nowMs,
+      timezone: params.config.timezone,
+      model: params.config.execution?.model,
+      logger: params.logger,
+      detached: params.detachNarratives,
+    });
   }
 }
 
 export async function runDreamingSweepPhases(params: {
+  /**
+   * Agent that owns this workspace; narrative subagent sessions are stored under it.
+   * Absent only when no roster or triggering agent can be attributed, which downgrades
+   * narratives to the local diary fallback without stopping the sweep.
+   */
+  agentId?: string;
   workspaceDir: string;
   pluginConfig?: Record<string, unknown>;
   cfg?: DreamingHostConfig;
   logger: Logger;
-  subagent?: Parameters<typeof generateAndAppendDreamNarrative>[0]["subagent"];
+  subagent?: DreamNarrativeRequest["subagent"];
   detachNarratives?: boolean;
   nowMs?: number;
 }): Promise<void> {
@@ -2002,6 +1990,7 @@ export async function runDreamingSweepPhases(params: {
   if (light.enabled && light.limit > 0) {
     try {
       await runLightDreaming({
+        agentId: params.agentId,
         workspaceDir: params.workspaceDir,
         cfg: params.cfg,
         config: light,
@@ -2030,6 +2019,7 @@ export async function runDreamingSweepPhases(params: {
   if (rem.enabled && rem.limit > 0) {
     try {
       await runRemDreaming({
+        agentId: params.agentId,
         workspaceDir: params.workspaceDir,
         cfg: params.cfg,
         config: rem,

--- a/extensions/memory-core/src/dreaming.test.ts
+++ b/extensions/memory-core/src/dreaming.test.ts
@@ -25,6 +25,12 @@ import {
 } from "./dreaming.js";
 import { createMemoryCoreTestHarness } from "./test-helpers.js";
 
+// `runDreamingSweepPhases` is the only binding the dreaming trigger imports from this module.
+const runDreamingSweepPhasesMock = vi.hoisted(() => vi.fn(async () => {}));
+vi.mock("./dreaming-phases.js", () => ({
+  runDreamingSweepPhases: runDreamingSweepPhasesMock,
+}));
+
 const constants = {
   MANAGED_DREAMING_CRON_NAME: MANAGED_MEMORY_DREAMING_CRON_NAME,
   MANAGED_DREAMING_CRON_TAG: MANAGED_MEMORY_DREAMING_CRON_TAG,
@@ -250,7 +256,7 @@ function getBeforeAgentReplyHandler(
   onMock: ReturnType<typeof vi.fn>,
 ): (
   event: { cleanedBody: string },
-  ctx: { trigger?: string; workspaceDir?: string; sessionKey?: string },
+  ctx: { agentId?: string; trigger?: string; workspaceDir?: string; sessionKey?: string },
 ) => Promise<unknown> {
   const call = onMock.mock.calls.find(([eventName]) => eventName === "before_agent_reply");
   if (!call) {
@@ -258,7 +264,7 @@ function getBeforeAgentReplyHandler(
   }
   return call[1] as (
     event: { cleanedBody: string },
-    ctx: { trigger?: string; workspaceDir?: string; sessionKey?: string },
+    ctx: { agentId?: string; trigger?: string; workspaceDir?: string; sessionKey?: string },
   ) => Promise<unknown>;
 }
 
@@ -1904,6 +1910,73 @@ describe("gateway startup reconciliation", () => {
         handled: true,
         reason: "memory-core: short-term dreaming disabled",
       });
+    } finally {
+      clearInternalHooks();
+    }
+  });
+
+  // Regression: the sweep dropped the agent id entirely, so narrative subagent sessions used
+  // unscoped keys that no per-agent SQLite store could resolve and every phase failed.
+  it("sweeps each workspace as its owning agent rather than the roster default", async () => {
+    clearInternalHooks();
+    const workspaceDir = await createTempWorkspace("openclaw-dreaming-owner-");
+    const logger = createLogger();
+    const harness = createCronHarness();
+    const onMock = vi.fn();
+    runDreamingSweepPhasesMock.mockClear();
+    const api: DreamingPluginApiTestDouble = {
+      config: {
+        agents: {
+          defaults: { workspace: workspaceDir },
+        },
+        plugins: {
+          entries: {
+            "memory-core": {
+              config: {
+                dreaming: {
+                  enabled: true,
+                  limit: 5,
+                  phases: {
+                    light: { enabled: false },
+                    rem: { enabled: false },
+                  },
+                },
+              },
+            },
+          },
+        },
+      } as OpenClawConfig,
+      pluginConfig: {},
+      logger,
+      runtime: {},
+      on: onMock,
+    };
+
+    try {
+      registerShortTermPromotionDreamingForTest(api);
+      await triggerGatewayStart(onMock, {
+        config: api.config,
+        getCron: () => harness.cron,
+      });
+
+      const beforeAgentReply = getBeforeAgentReplyHandler(onMock);
+      await beforeAgentReply(
+        { cleanedBody: constants.DREAMING_SYSTEM_EVENT_TEXT },
+        {
+          trigger: "cron",
+          agentId: "researcher",
+          workspaceDir,
+          sessionKey: "agent:researcher:cron:memory-dreaming",
+        },
+      );
+
+      expect(runDreamingSweepPhasesMock).toHaveBeenCalledTimes(1);
+      const sweepArgs = expectDefined(
+        runDreamingSweepPhasesMock.mock.calls[0],
+        "dreaming sweep call",
+      )[0] as { agentId: string; workspaceDir: string };
+      expect(sweepArgs.agentId).toBe("researcher");
+      expect(sweepArgs.workspaceDir).toBe(workspaceDir);
     } finally {
       clearInternalHooks();
     }

--- a/extensions/memory-core/src/dreaming.test.ts
+++ b/extensions/memory-core/src/dreaming.test.ts
@@ -26,7 +26,9 @@ import {
 import { createMemoryCoreTestHarness } from "./test-helpers.js";
 
 // `runDreamingSweepPhases` is the only binding the dreaming trigger imports from this module.
-const runDreamingSweepPhasesMock = vi.hoisted(() => vi.fn(async () => {}));
+const runDreamingSweepPhasesMock = vi.hoisted(() =>
+  vi.fn(async (_params: { agentId?: string; workspaceDir: string }) => {}),
+);
 vi.mock("./dreaming-phases.js", () => ({
   runDreamingSweepPhases: runDreamingSweepPhasesMock,
 }));
@@ -1974,7 +1976,7 @@ describe("gateway startup reconciliation", () => {
       const sweepArgs = expectDefined(
         runDreamingSweepPhasesMock.mock.calls[0],
         "dreaming sweep call",
-      )[0] as { agentId: string; workspaceDir: string };
+      )[0];
       expect(sweepArgs.agentId).toBe("researcher");
       expect(sweepArgs.workspaceDir).toBe(workspaceDir);
     } finally {

--- a/extensions/memory-core/src/dreaming.ts
+++ b/extensions/memory-core/src/dreaming.ts
@@ -500,6 +500,8 @@ async function reconcileShortTermDreamingCronJob(params: {
 async function runShortTermDreamingPromotionIfTriggered(params: {
   cleanedBody: string;
   trigger?: string;
+  /** Agent whose heartbeat/cron turn triggered the sweep. */
+  agentId?: string;
   workspaceDir?: string;
   cfg?: OpenClawConfig;
   config: ShortTermPromotionDreamingConfig;
@@ -519,22 +521,38 @@ async function runShortTermDreamingPromotionIfTriggered(params: {
   const recencyHalfLifeDays =
     params.config.recencyHalfLifeDays ?? DEFAULT_MEMORY_DREAMING_RECENCY_HALF_LIFE_DAYS;
   const fallbackWorkspaceDir = normalizeTrimmedString(params.workspaceDir);
-  const workspaceCandidates = params.cfg
-    ? resolveMemoryDreamingWorkspaces(params.cfg, {
-        primaryWorkspaceDir: fallbackWorkspaceDir,
-        primaryAgentId: "main",
-      }).map((entry) => entry.workspaceDir)
-    : [];
+  // Narrative subagent sessions live in per-agent SQLite stores, so every swept workspace
+  // carries its owning agent. The triggering agent owns whatever the roster cannot attribute.
+  const triggerAgentId = normalizeLowercaseStringOrEmpty(params.agentId);
   const seenWorkspaces = new Set<string>();
-  const workspaces = workspaceCandidates.filter((workspaceDir) => {
-    if (seenWorkspaces.has(workspaceDir)) {
-      return false;
+  const workspaces: Array<{ agentId?: string; workspaceDir: string }> = [];
+  const addWorkspace = (workspaceDir: string, agentId: string): void => {
+    if (!workspaceDir || seenWorkspaces.has(workspaceDir)) {
+      return;
     }
     seenWorkspaces.add(workspaceDir);
-    return true;
-  });
+    workspaces.push({ ...(agentId ? { agentId } : {}), workspaceDir });
+  };
+  // The triggering agent wins its own workspace; otherwise sort so a workspace shared by
+  // several agents always resolves the same owner across sweeps.
+  const resolveWorkspaceOwnerAgentId = (agentIds: readonly string[]): string => {
+    if (triggerAgentId && agentIds.includes(triggerAgentId)) {
+      return triggerAgentId;
+    }
+    return agentIds.toSorted()[0] ?? triggerAgentId;
+  };
+  if (params.cfg) {
+    for (const entry of resolveMemoryDreamingWorkspaces(params.cfg, {
+      primaryWorkspaceDir: fallbackWorkspaceDir,
+      // Attribute the hook's own workspace to the agent whose turn triggered the sweep;
+      // the host falls back to the roster default agent when the turn has no id.
+      ...(triggerAgentId ? { primaryAgentId: triggerAgentId } : {}),
+    })) {
+      addWorkspace(entry.workspaceDir, resolveWorkspaceOwnerAgentId(entry.agentIds));
+    }
+  }
   if (workspaces.length === 0 && fallbackWorkspaceDir) {
-    workspaces.push(fallbackWorkspaceDir);
+    addWorkspace(fallbackWorkspaceDir, triggerAgentId);
   }
   if (workspaces.length === 0) {
     params.logger.warn(
@@ -560,7 +578,7 @@ async function runShortTermDreamingPromotionIfTriggered(params: {
   const detachNarratives = params.trigger === "cron";
   const [
     { writeDeepDreamingReport },
-    { appendFallbackNarrativeEntry, generateAndAppendDreamNarrative, runDetachedDreamNarrative },
+    { appendFallbackNarrativeEntry, runDreamNarrative },
     { runDreamingSweepPhases },
     {
       applyShortTermPromotions,
@@ -573,10 +591,11 @@ async function runShortTermDreamingPromotionIfTriggered(params: {
     import("./dreaming-phases.js"),
     import("./short-term-promotion.js"),
   ]);
-  for (const workspaceDir of workspaces) {
+  for (const { agentId, workspaceDir } of workspaces) {
     const sweepNowMs = Date.now();
     try {
       await runDreamingSweepPhases({
+        agentId,
         workspaceDir,
         pluginConfig,
         cfg: params.cfg,
@@ -685,18 +704,9 @@ async function runShortTermDreamingPromotionIfTriggered(params: {
             logger: params.logger,
             reason: "subagent runtime is unavailable",
           });
-        } else if (detachNarratives) {
-          runDetachedDreamNarrative({
-            subagent: params.subagent,
-            workspaceDir,
-            data,
-            nowMs: sweepNowMs,
-            timezone: params.config.timezone,
-            model: params.config.execution?.model,
-            logger: params.logger,
-          });
         } else {
-          await generateAndAppendDreamNarrative({
+          await runDreamNarrative({
+            agentId,
             subagent: params.subagent,
             workspaceDir,
             data,
@@ -704,6 +714,7 @@ async function runShortTermDreamingPromotionIfTriggered(params: {
             timezone: params.config.timezone,
             model: params.config.execution?.model,
             logger: params.logger,
+            detached: detachNarratives,
           });
         }
       }
@@ -723,9 +734,14 @@ async function runShortTermDreamingPromotionIfTriggered(params: {
       });
     }
   }
-  params.logger.info(
-    `memory-core: dreaming promotion complete (workspaces=${workspaces.length}, candidates=${totalCandidates}, applied=${totalApplied}, failed=${failedWorkspaces}).`,
-  );
+  // A summary that reads identically whether the sweep worked or failed everywhere is how
+  // a broken pipeline stays unnoticed; escalate when no workspace produced anything.
+  const summary = `memory-core: dreaming promotion complete (workspaces=${workspaces.length}, candidates=${totalCandidates}, applied=${totalApplied}, failed=${failedWorkspaces}).`;
+  if (failedWorkspaces === workspaces.length) {
+    params.logger.warn(summary);
+  } else {
+    params.logger.info(summary);
+  }
 
   return { handled: true, reason: "memory-core: short-term dreaming processed" };
 }
@@ -980,6 +996,7 @@ export function registerShortTermPromotionDreaming(api: OpenClawPluginApi): void
       return await runShortTermDreamingPromotionIfTriggered({
         cleanedBody: event.cleanedBody,
         trigger: ctx.trigger,
+        agentId: ctx.agentId,
         workspaceDir: ctx.workspaceDir,
         cfg: currentConfig,
         config,


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where operators running memory dreaming would get an empty dream diary: every scheduled sleep phase failed and `DREAMS.md` silently stopped growing, while the logs still reported `memory-core: dreaming promotion complete`.

On a live gateway, one day of logs contained 58 `memory-core: narrative pre-cleanup failed ...`, 58 `memory-core: narrative generation failed for <phase> phase: Cannot resolve SQLite session scope without an agent id` (46 REM, 8 light, 4 deep), 46 `dreaming promotion complete`, and zero diary entries or fallbacks. An operator skimming the log sees a completion line every three minutes and no sign that the pipeline is producing nothing.

## Why This Change Was Made

Dreaming narratives ran their subagent under an unscoped session key, `dreaming-narrative-<phase>-<workspace-hash>`. Sessions live in per-agent SQLite stores (`agents/<id>/agent/openclaw-agent.sqlite`), so a key with no `agent:<id>:` prefix has no store to resolve. The plugin runtime checks session ownership before any gateway dispatch — `assertSessionIdentitiesOwned` for `subagent.run` and `assertStoredSessionEntryOwned` for `subagent.deleteSession` in `src/plugins/registry-runtime.ts` — and both call `getSessionEntry({ sessionKey })` with no agent scope, which reaches `resolveSqliteScope` in `src/config/sessions/session-accessor.sqlite-scope.ts` and throws.

The caller was wrong, not the resolver. Defaulting the resolver would route one agent's dreaming session into whichever agent happens to be the roster default, and the implicit-main fallback was deliberately removed in #112678. The agent id was available the whole time and was being discarded upstream: `resolveMemoryDreamingWorkspaces` returns `{ workspaceDir, agentIds }` and `dreaming.ts` mapped the agent ids away, while the `before_agent_reply` hook context already carries `ctx.agentId` for the triggering turn. The sibling ingestion path in `dreaming-phases.ts` already resolves agents per workspace, and `scrubDreamingNarrativeArtifacts` already iterates `agents/<id>` directories, so per-agent ownership was the established contract on every surface except the write path.

The sweep now carries an owning agent per workspace — the triggering agent when it owns that workspace, otherwise a deterministic sorted pick — and narrative session keys become `agent:<id>:dreaming-narrative-<phase>-<hash>`. The runId stays unscoped so the `DREAMING_TRANSCRIPT_RUN_MARKER` orphan-transcript scrub keeps matching. Two silent-failure paths are closed alongside it: an unexpected narrative exception now writes the same dated fallback diary entry that the terminal-status and empty-text branches already write, so a failed run leaves a visible trace in the artifact users actually read; and the promotion summary logs at `warn` rather than `info` when every workspace failed. A sweep that genuinely has no attributable agent still runs its phases and promotion and downgrades only the narrative, so ownership is never a reason to skip memory work.

The three duplicated detach/await narrative dispatch blocks across the deep, light, and REM phases collapse into one `runDreamNarrative` entry point, which is where the ownership gate lives.

## User Impact

Dream diaries start filling again. Narratives run as the agent that owns the workspace, so a non-default agent's diary run no longer lands in another agent's session store. When a narrative genuinely cannot run, `DREAMS.md` gets a dated fallback entry instead of nothing, and a sweep where every workspace failed no longer looks like success in the log. No config or schema change.

## Evidence

Root cause confirmed directly against the resolver, with both key shapes, before writing the fix:

- `resolveSqliteScope({ sessionKey: "dreaming-narrative-rem-abc123def456" })` throws `Cannot resolve SQLite session scope without an agent id` — the exact production message.
- `resolveSqliteScope({ sessionKey: "agent:researcher:dreaming-narrative-rem-abc123def456" })` resolves `agentId: "researcher"`.

### Changed-lane proof: `main` baseline vs. this branch

Rebased onto `main` at `20eda756fae`. The two files that decide the changed extension lane were run **twice on one Blacksmith Testbox lease** (`tbx_01kym8fn8nmh0j198wb4ahf7ha`, Linux) at `073c9b833ff` — first with all six touched files reverted to `origin/main` so the tree was byte-identical to `main`, then with this branch's files restored:

```
pnpm test extensions/memory-core/src/dreaming-phases.test.ts \
          extensions/memory-core/src/memory/manager-sync-ops.startup-catchup.test.ts

origin/main baseline   Test Files  2 passed (2)   Tests  75 passed (75)
this branch  (head)    Test Files  2 passed (2)   Tests  75 passed (75)
```

Both sides are green, and hosted CI on `073c9b833ff` was green including `checks-node-changed-1` and `openclaw/ci-gate`.

**This supersedes the earlier "12 pre-existing ingestion failures" note in this PR, which is now obsolete.** That paragraph described the branch's original base, `50a97288dd0`, which predates `feat(memory): provenance-gated memory with dreaming on by default` (#114819, `28630a9a650`) by about 83 minutes. #114819 restored the SQLite transcript identity that `dreaming-phases.ts` ingestion had been dropping — it now forwards `agentId`/`sessionId`/`storePath`/`sessionKey`/`updatedAtMs`/`sessionKind` into `buildSessionEntry` (`extensions/memory-core/src/dreaming-phases.ts:876`). The red lane was a stale base, not a defect in this change, and the same repair is why #115111 was closed.

### Focused regression tests

Same lease, at head `d76116009c5`:

```
pnpm test extensions/memory-core/src/dreaming-narrative.test.ts \
          extensions/memory-core/src/dreaming.test.ts \
          extensions/memory-core/src/dreaming-phases.test.ts \
          extensions/memory-core/src/memory/manager-sync-ops.startup-catchup.test.ts
Test Files  4 passed (4)
     Tests  140 passed (140)
```

New regression coverage:

- `scopes narrative sessions to the workspace's owning agent` — a non-default agent id produces `agent:researcher:dreaming-narrative-rem-<hash>` for `run` and `deleteSession`, while `idempotencyKey` stays unscoped so the transcript scrub marker still matches.
- `sweeps each workspace as its owning agent rather than the roster default` — a cron turn from `researcher` sweeps that workspace as `researcher`, not the lexicographically first roster agent.
- `keeps the sweep alive with a local fallback when no owning agent is known` — the subagent is never called and a fallback diary entry is written.
- `stays a no-op for an ownerless sweep with nothing to narrate` — the ownership fallback must not invent a diary entry for material that never existed.
- `queues the ownerless fallback through detached dispatch` — a detached cron sweep is never held open by the fallback diary write.
- The unexpected-failure tests now assert a dated fallback entry instead of an untouched `DREAMS.md`.
- The run-key assertion now pins `dreaming-narrative-<agent>-<phase>-<hash>` and separately asserts the `dreaming-narrative-` prefix the scrub marker depends on.

### ClawSweeper rank-up moves

- *"Resolve the session-transcript-ingestion failures or obtain an explicit maintainer decision"* — **moot.** Those failures no longer exist on `main`; #114819 repaired the ingestion path. The `origin/main` baseline run above is the proof, and no maintainer exception is needed.
- *"Attach redacted after-fix gateway output showing the scoped narrative session and a resulting `DREAMS.md` entry"* — **not attached.** The before-side is already a real production observation (one live gateway day: 58 `narrative generation failed ... Cannot resolve SQLite session scope without an agent id`, 46 `dreaming promotion complete`, zero diary entries). Reproducing the after-side end to end needs a gateway with a real per-agent SQLite store, a populated transcript corpus, the managed dreaming cron firing, and a live model turn; that is disproportionate for a change whose entire behavioral surface is the session key handed to `subagent.run`/`deleteSession`, which is asserted directly against both key shapes on the real resolver above and in the new tests. Recording this as a conscious skip rather than manufacturing weaker evidence for it.

Review: `autoreview --mode branch --base origin/main --engine codex` (gpt-5.6-sol, xhigh), re-run after the rebase. Earlier rounds accepted two findings — the primary workspace was still attributed to a hardcoded `main`, and requiring an owner initially dropped ownerless workspaces from the sweep entirely. The post-rebase round accepted two more, fixed in `1878fa8ebab`:

- **Run id collided across agent scopes.** Splitting the run key from the session key left the runId agent-free, so two agents sharing a workspace could produce the same gateway runId while owning different agent-scoped sessions. The agent scope now sits *after* the `dreaming-narrative-` prefix (`dreaming-narrative-<agent>-<phase>-<hash>`), which keeps `DREAMING_TRANSCRIPT_RUN_MARKER` matching.
- **Ownership gate ran ahead of the empty-input no-op.** An ownerless sweep with no snippets and no promotions appended a generic "memory trace" diary entry, while the identical request with an agent id wrote nothing. The empty-data guard moved to the top of `runDreamNarrative`, which is now the single place it lives.

A third round accepted one more, fixed in `d76116009c5`: the ownerless fallback `await`ed its diary write even when the caller asked for detached dispatch, so a cron sweep could be held open by a slow workspace filesystem — exactly what `detachNarratives` exists to prevent. Both branches now build a job and share one dispatch, and `runDetachedNarrativeJob` takes the job rather than a request. Fourth round: `autoreview clean: no accepted/actionable findings reported` (`patch is correct`, 0.9).

Non-test LOC is +80. The growth buys the ownership gate, the run/session identity split, and the failure-path fallback write; it is paid for partly by collapsing three duplicated detach/await dispatch blocks (deep, light, REM) into one entry point.

Follow-ups filed, not folded in: #115166 (QMD session export omits `sessionKind`; a shared corpus-options helper fixes the drift) and #115167 (startup-catchup fixtures still write the retired `sessionFile` locator).
