### PR TITLE
fix(telegram): suppress link previews in streamed replies

### DIFF
--- a/docs/channels/telegram.md
+++ b/docs/channels/telegram.md
@@ -389,7 +389,7 @@ curl "https://api.telegram.org/bot<bot_token>/getUpdates"
 
     Default: off, for client compatibility — some current Desktop, Web, Android, and third-party clients render accepted rich messages as unsupported. Keep this off unless every client used with the bot can render them. `/status` shows whether the current session has rich messages on or off.
 
-    Link previews are on by default. `channels.telegram.linkPreview: false` disables automatic entity detection for rich text.
+    Link previews are on by default. `channels.telegram.linkPreview: false` suppresses preview cards for standard and streamed text, and disables automatic entity detection for rich text.
 
   </Accordion>
 

--- a/extensions/telegram/src/bot-message-dispatch-draft.ts
+++ b/extensions/telegram/src/bot-message-dispatch-draft.ts
@@ -114,7 +114,6 @@ export function createTelegramDraftController(params: {
           text,
           richMessage: buildTelegramRichMarkdown(text, {
             tableMode: params.tableMode,
-            skipEntityDetection: params.telegramCfg.linkPreview === false,
           }),
         }
       : {
@@ -133,6 +132,7 @@ export function createTelegramDraftController(params: {
           replyToMessageId: params.draftReplyToMessageId,
           replyToMode: params.replyToMode,
           richMessages: params.telegramCfg.richMessages,
+          linkPreview: params.telegramCfg.linkPreview,
           minInitialChars: params.streamMode === "progress" ? 0 : DRAFT_MIN_INITIAL_CHARS,
           renderText: renderStreamText,
           onRetainedPage: (page) => {

--- a/extensions/telegram/src/bot-message-dispatch.delivery-basics.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.delivery-basics.test.ts
@@ -368,6 +368,23 @@ describeTelegramDispatch("dispatchTelegramMessage delivery-basics", () => {
     expectRecordFields((delivery.replies as Array<unknown>)[0], { replyToId: "1001" });
   });
 
+  it("passes the configured link-preview policy to the draft stream owner", async () => {
+    const draftStream = createDraftStream();
+    createTelegramDraftStream.mockReturnValue(draftStream);
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(async ({ dispatcherOptions }) => {
+      await dispatcherOptions.deliver({ text: "See https://example.com" }, { kind: "final" });
+      return { queuedFinal: true };
+    });
+    deliverReplies.mockResolvedValue({ delivered: true });
+
+    await dispatchWithContext({
+      context: createContext(),
+      telegramCfg: { linkPreview: false },
+    });
+
+    expectDraftStreamParams({ linkPreview: false });
+  });
+
   it("passes native quote candidates for explicit reply targets", async () => {
     dispatchReplyWithBufferedBlockDispatcher.mockImplementation(async ({ dispatcherOptions }) => {
       await dispatcherOptions.deliver({ text: "Hello", replyToId: "9001" }, { kind: "final" });

--- a/extensions/telegram/src/draft-stream.test.ts
+++ b/extensions/telegram/src/draft-stream.test.ts
@@ -1171,6 +1171,62 @@ describe("createTelegramDraftStream", () => {
     });
   });
 
+  it("preserves disabled link previews across plain draft sends and edits", async () => {
+    const api = createMockDraftApi();
+    const stream = createDraftStream(api, { linkPreview: false });
+    const previewOptions = { link_preview_options: { is_disabled: true } };
+
+    stream.update("First https://example.com");
+    await stream.flush();
+    expectPreviewSend(api, "First https://example.com", previewOptions);
+
+    stream.update("Second https://example.com");
+    await stream.flush();
+    expectPreviewEdit(api, "Second https://example.com", previewOptions);
+  });
+
+  it("preserves disabled link previews across HTML and plain fallback draft requests", async () => {
+    const api = createMockDraftApi();
+    api.sendMessage
+      .mockRejectedValueOnce(new Error("can't parse entities: unsupported tag"))
+      .mockResolvedValueOnce({ message_id: 17 });
+    const stream = createDraftStream(api, { linkPreview: false });
+    const previewOptions = { link_preview_options: { is_disabled: true } };
+
+    stream.updatePreview({ text: "<b>First https://example.com</b>", parseMode: "HTML" });
+    await stream.flush();
+    expect(api.sendMessage).toHaveBeenNthCalledWith(1, 123, "<b>First https://example.com</b>", {
+      parse_mode: "HTML",
+      ...previewOptions,
+    });
+    expect(api.sendMessage).toHaveBeenNthCalledWith(
+      2,
+      123,
+      "First https://example.com",
+      previewOptions,
+    );
+
+    api.editMessageText
+      .mockRejectedValueOnce(new Error("can't parse entities: unsupported tag"))
+      .mockResolvedValueOnce(true);
+    stream.updatePreview({ text: "<b>Second https://example.com</b>", parseMode: "HTML" });
+    await stream.flush();
+    expect(api.editMessageText).toHaveBeenNthCalledWith(
+      1,
+      123,
+      17,
+      "<b>Second https://example.com</b>",
+      { parse_mode: "HTML", ...previewOptions },
+    );
+    expect(api.editMessageText).toHaveBeenNthCalledWith(
+      2,
+      123,
+      17,
+      "Second https://example.com",
+      previewOptions,
+    );
+  });
+
   it("uses rich send and edit for previews when explicitly enabled", async () => {
     const api = createMockDraftApi();
     const stream = createDraftStream(api, { richMessages: true });
@@ -1214,6 +1270,51 @@ describe("createTelegramDraftStream", () => {
     expect(plain).toContain("Claude Opus");
     expect(warn).toHaveBeenCalledWith(
       expect.stringContaining("rich-degrade=plain-fallback:rich-entity-invalid"),
+    );
+  });
+
+  it("owns disabled link detection across rich drafts and their plain fallbacks", async () => {
+    const api = createMockDraftApi();
+    api.raw.sendRichMessage.mockRejectedValueOnce(
+      new Error("400: Bad Request: RICH_MESSAGE_URL_INVALID"),
+    );
+    api.raw.editMessageText.mockRejectedValueOnce(
+      new Error("400: Bad Request: RICH_MESSAGE_URL_INVALID"),
+    );
+    const stream = createDraftStream(api, { linkPreview: false, richMessages: true });
+    const previewOptions = { link_preview_options: { is_disabled: true } };
+
+    stream.updatePreview({
+      text: "First https://example.com",
+      richMessage: { blocks: [{ type: "paragraph", text: "First https://example.com" }] },
+    });
+    await stream.flush();
+
+    const richSend = api.raw.sendRichMessage.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(richSend).not.toHaveProperty("link_preview_options");
+    expect(richSend.rich_message).toEqual({
+      blocks: [{ type: "paragraph", text: "First https://example.com" }],
+      skip_entity_detection: true,
+    });
+    expect(api.sendMessage).toHaveBeenCalledWith(123, "First https://example.com", previewOptions);
+
+    stream.updatePreview({
+      text: "Second https://example.com",
+      richMessage: { blocks: [{ type: "paragraph", text: "Second https://example.com" }] },
+    });
+    await stream.flush();
+
+    const richEdit = api.raw.editMessageText.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(richEdit).not.toHaveProperty("link_preview_options");
+    expect(richEdit.rich_message).toEqual({
+      blocks: [{ type: "paragraph", text: "Second https://example.com" }],
+      skip_entity_detection: true,
+    });
+    expect(api.editMessageText).toHaveBeenCalledWith(
+      123,
+      17,
+      "Second https://example.com",
+      previewOptions,
     );
   });
 

--- a/extensions/telegram/src/draft-stream.ts
+++ b/extensions/telegram/src/draft-stream.ts
@@ -137,11 +137,12 @@ function planTelegramDraftPages(
   preview: TelegramDraftPreview,
   maxChars: number,
   richMessages: boolean,
+  disableLinkPreviews: boolean,
 ): PlannedTelegramDraftPage[] {
   if (richMessages) {
     const previewRich = preview.richMessage;
     if (previewRich) {
-      const skipEntityDetection = previewRich.skip_entity_detection === true;
+      const skipEntityDetection = disableLinkPreviews || previewRich.skip_entity_detection === true;
       return splitTelegramRichBlocks(previewRich.blocks, {
         textLimit: maxChars,
       }).map((blocks) => {
@@ -157,7 +158,9 @@ function planTelegramDraftPages(
         };
       });
     }
-    const plan = buildTelegramRichMarkdownPlan(preview.text);
+    const plan = buildTelegramRichMarkdownPlan(preview.text, {
+      skipEntityDetection: disableLinkPreviews,
+    });
     // Every page carries the plan's document-level skip flag: the render already
     // committed to that linkify decision, so per-page re-derivation would leave
     // unprotected file refs in pages without the skip trigger.
@@ -185,7 +188,10 @@ function planTelegramDraftPages(
           text: preview.text,
           sourceText: preview.text,
           sourceTextMode: "markdown",
-          richMessage: { blocks: [{ type: "paragraph", text: preview.text }] },
+          richMessage: {
+            blocks: [{ type: "paragraph", text: preview.text }],
+            ...(planSkip ? { skip_entity_detection: true } : {}),
+          },
         },
       ];
     }
@@ -234,6 +240,7 @@ export function createTelegramDraftStream(params: {
   replyToMessageId?: number;
   replyToMode?: ReplyToMode;
   richMessages?: boolean;
+  linkPreview?: boolean;
   throttleMs?: number;
   /** Minimum chars before sending first message (debounce for push notifications) */
   minInitialChars?: number;
@@ -252,6 +259,18 @@ export function createTelegramDraftStream(params: {
   const throttleMs = Math.max(250, params.throttleMs ?? DEFAULT_THROTTLE_MS);
   const minInitialChars = params.minInitialChars;
   const chatId = params.chatId;
+  const linkPreviewOptions =
+    params.linkPreview === false ? ({ is_disabled: true } as const) : undefined;
+  const withTextLinkPreviewOptions = <T extends Record<string, unknown>>(requestParams: T) =>
+    linkPreviewOptions
+      ? { ...requestParams, link_preview_options: linkPreviewOptions }
+      : requestParams;
+  const editPlainMessageText = (messageId: number, text: string) =>
+    linkPreviewOptions
+      ? params.api.editMessageText(chatId, messageId, text, {
+          link_preview_options: linkPreviewOptions,
+        })
+      : params.api.editMessageText(chatId, messageId, text);
   const threadParams = buildTelegramThreadParams(params.thread);
   const replyToMessageId = normalizeTelegramReplyToMessageId(params.replyToMessageId);
   const initialSendMessageParams =
@@ -377,14 +396,22 @@ export function createTelegramDraftStream(params: {
           throw err;
         }
         return {
-          message: await params.api.sendMessage(chatId, fallbackPlan.plainText, sendMessageParams),
+          message: await params.api.sendMessage(
+            chatId,
+            fallbackPlan.plainText,
+            withTextLinkPreviewOptions(sendMessageParams),
+          ),
           snapshot: fallbackSnapshot(fallbackPlan.plainText),
         };
       }
     }
     if (page.sourceTextMode !== "html") {
       return {
-        message: await params.api.sendMessage(chatId, page.text, sendMessageParams),
+        message: await params.api.sendMessage(
+          chatId,
+          page.text,
+          withTextLinkPreviewOptions(sendMessageParams),
+        ),
         snapshot: page,
       };
     }
@@ -392,7 +419,7 @@ export function createTelegramDraftStream(params: {
       return {
         message: await params.api.sendMessage(chatId, page.sourceText, {
           parse_mode: "HTML" as const,
-          ...sendMessageParams,
+          ...withTextLinkPreviewOptions(sendMessageParams),
         }),
         snapshot: page,
       };
@@ -401,7 +428,11 @@ export function createTelegramDraftStream(params: {
         throw err;
       }
       return {
-        message: await params.api.sendMessage(chatId, page.text, sendMessageParams),
+        message: await params.api.sendMessage(
+          chatId,
+          page.text,
+          withTextLinkPreviewOptions(sendMessageParams),
+        ),
         snapshot: fallbackSnapshot(page.text),
       };
     }
@@ -436,23 +467,24 @@ export function createTelegramDraftStream(params: {
           if (!fallbackPlan) {
             throw err;
           }
-          await params.api.editMessageText(chatId, targetMessageId, fallbackPlan.plainText);
+          await editPlainMessageText(targetMessageId, fallbackPlan.plainText);
           acceptedSnapshot = fallbackSnapshot(fallbackPlan.plainText);
         }
       } else if (page.sourceTextMode === "html") {
         try {
           await params.api.editMessageText(chatId, targetMessageId, page.sourceText, {
             parse_mode: "HTML" as const,
+            ...(linkPreviewOptions ? { link_preview_options: linkPreviewOptions } : {}),
           });
         } catch (err) {
           if (!isTelegramHtmlParseError(err)) {
             throw err;
           }
-          await params.api.editMessageText(chatId, targetMessageId, page.text);
+          await editPlainMessageText(targetMessageId, page.text);
           acceptedSnapshot = fallbackSnapshot(page.text);
         }
       } else {
-        await params.api.editMessageText(chatId, targetMessageId, page.sourceText);
+        await editPlainMessageText(targetMessageId, page.sourceText);
       }
       if (sendGeneration === generation && streamMessageId === targetMessageId) {
         streamMessageSnapshot = acceptedSnapshot;
@@ -634,10 +666,12 @@ export function createTelegramDraftStream(params: {
         : (params.renderText?.(trimmed) ?? { text: trimmed });
     // Render once, then split the transport HTML so page boundaries preserve
     // open fences, indentation, and nested tags.
+    // A retained finalPagePlan is created below only from policy-normalized pages.
+    // Reuse those exact pages on retry so rendering and linkify policy cannot drift.
     const pages =
       streamState.final && finalPagePlan
         ? finalPagePlan.pages
-        : planTelegramDraftPages(fullPreview, maxChars, richMessages);
+        : planTelegramDraftPages(fullPreview, maxChars, richMessages, params.linkPreview === false);
     const firstPage = pages[0];
     if (!firstPage) {
       return false;


### PR DESCRIPTION
Closes #111525

## What Problem This Solves

Fixes an issue where Telegram users with `channels.telegram.linkPreview: false` would still see URL preview cards on replies delivered through draft streaming. When the streamed text already matched the final answer, that draft was finalized in place and the unwanted preview remained visible.

## Why This Change Was Made

The draft stream now owns the preview policy for its complete lifecycle. It applies Telegram's `link_preview_options` to every standard text send, edit, HTML retry, and rich-to-plain fallback, while translating the same policy to rich messages through `skip_entity_detection`. The controller only passes the configured policy, removing the prior partial rich-only handling.

## User Impact

Disabling Telegram link previews now works consistently for ordinary delivery and all streamed reply modes, including in-place finalization and rich-message fallback.

## Evidence

- Exact refreshed head `13e081ccb2a`: Testbox run [30379123420](https://github.com/openclaw/openclaw/actions/runs/30379123420) passed 111 focused draft-stream and dispatch tests.
- Changed gate [30379412747](https://github.com/openclaw/openclaw/actions/runs/30379412747) passed formatting, extension production/test types, lint, plugin boundaries, import cycles, database-first checks, and repository guards.
- Regression coverage includes plain sends/edits, HTML retry, rich messages, rich fallback, and controller forwarding.
- Telegram Bot API 10.2 and grammY 1.45.1 contracts were verified: standard text uses `link_preview_options`; rich messages use `skip_entity_detection`.
- Fresh Codex autoreview on exact head: clean, no accepted/actionable findings, 0.92 confidence.
- Earlier Mantis attempts ended in capture-infrastructure failures before a candidate verdict. A new exact-head Telegram Desktop proof will follow CI on the repaired workflow.

AI-assisted; I reviewed the implementation, Telegram transport contract, current-main integration, focused tests, changed gate, and final autoreview.
