### PR TITLE
fix(codex): reduce native hook relay startup latency

### DIFF
--- a/scripts/check-kysely-guardrails.mjs
+++ b/scripts/check-kysely-guardrails.mjs
@@ -77,6 +77,9 @@ const rawSqliteAllowPathGroups = {
     "src/state/openclaw-agent-db-readonly.ts",
     "src/state/openclaw-state-db-readonly.ts",
   ],
+  "cold-process read-only relay lookup avoids the shared state writer lifecycle": [
+    "src/agents/harness/native-hook-relay-client-store.ts",
+  ],
   "read-only schema preflight and integrity verification access": [
     "src/state/openclaw-database-preflight.ts",
     "src/state/openclaw-database-verify.worker.ts",

--- a/src/agents/harness/native-hook-relay-bridge-record.ts
+++ b/src/agents/harness/native-hook-relay-bridge-record.ts
@@ -1,0 +1,46 @@
+export type NativeHookRelayBridgeRecord = {
+  relayId: string;
+  pid: number;
+  hostname: "127.0.0.1";
+  port: number;
+  token: string;
+  expiresAtMs: number;
+};
+
+type NativeHookRelayBridgeRow = {
+  relay_id: unknown;
+  pid: unknown;
+  hostname: unknown;
+  port: unknown;
+  token: unknown;
+  expires_at_ms: unknown;
+};
+
+/** Validate and convert a persisted native relay locator row. */
+export function readNativeHookRelayBridgeRecordRow(
+  row: NativeHookRelayBridgeRow | undefined,
+): NativeHookRelayBridgeRecord | undefined {
+  if (
+    !row ||
+    typeof row.relay_id !== "string" ||
+    row.relay_id.length === 0 ||
+    !Number.isSafeInteger(row.pid) ||
+    row.hostname !== "127.0.0.1" ||
+    !Number.isSafeInteger(row.port) ||
+    Number(row.port) <= 0 ||
+    Number(row.port) > 65_535 ||
+    typeof row.token !== "string" ||
+    row.token.length === 0 ||
+    !Number.isSafeInteger(row.expires_at_ms)
+  ) {
+    return undefined;
+  }
+  return {
+    relayId: row.relay_id,
+    pid: Number(row.pid),
+    hostname: row.hostname,
+    port: Number(row.port),
+    token: row.token,
+    expiresAtMs: Number(row.expires_at_ms),
+  };
+}

--- a/src/agents/harness/native-hook-relay-bridge.ts
+++ b/src/agents/harness/native-hook-relay-bridge.ts
@@ -1,13 +1,10 @@
 import { randomUUID } from "node:crypto";
-import {
-  createServer,
-  request as httpRequest,
-  type IncomingMessage,
-  type ServerResponse,
-} from "node:http";
-import { toErrorObject } from "../../infra/errors.js";
+import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
-import { DEFAULT_RELAY_TIMEOUT_MS } from "./native-hook-relay-command.js";
+import {
+  isNativeHookRelayBridgeStaleRegistrationError,
+  NATIVE_HOOK_RELAY_BRIDGE_STALE_REGISTRATION_ERROR,
+} from "./native-hook-relay-client.js";
 import { nativeHookRelayState } from "./native-hook-relay-state.js";
 import {
   clearNativeHookRelayBridgeRecordsForTests,
@@ -20,7 +17,6 @@ import {
 } from "./native-hook-relay-store.js";
 import type {
   ActiveNativeHookRelayRegistration,
-  InvokeNativeHookRelayBridgeParams,
   InvokeNativeHookRelayParams,
   NativeHookRelayBridgeRegistration,
   NativeHookRelayProcessResponse,
@@ -29,18 +25,17 @@ import type {
 import {
   isJsonObject,
   normalizePositiveInteger,
-  readNativeHookRelayEvent,
-  readNativeHookRelayProvider,
   readNonEmptyString,
 } from "./native-hook-relay-utils.js";
 
 const MAX_NATIVE_HOOK_BRIDGE_BODY_BYTES = 5_000_000;
-const MAX_NATIVE_HOOK_BRIDGE_RESPONSE_BYTES = 5_000_000;
-const NATIVE_HOOK_BRIDGE_RETRY_INTERVAL_MS = 25;
-export const NATIVE_HOOK_BRIDGE_REPLACEMENT_RECORD_GRACE_MS = 250;
-export const NATIVE_HOOK_RELAY_BRIDGE_STALE_REGISTRATION_ERROR =
-  "native hook relay bridge stale registration";
 const log = createSubsystemLogger("agents/harness/native-hook-relay");
+
+export {
+  isRetryableNativeHookRelayBridgeLookupError,
+  NATIVE_HOOK_BRIDGE_REPLACEMENT_RECORD_GRACE_MS,
+  NATIVE_HOOK_RELAY_BRIDGE_STALE_REGISTRATION_ERROR,
+} from "./native-hook-relay-client.js";
 
 const { relays, relayBridges } = nativeHookRelayState;
 
@@ -304,17 +299,6 @@ function writeNativeHookRelayBridgeJson(
   res.end(body);
 }
 
-function readNativeHookRelayBridgeRecord(
-  relayId: string,
-  stateDbPath?: string,
-): NativeHookRelayBridgeRecord {
-  const record = readNativeHookRelayBridgeRecordIfExists(relayId, stateDbPath);
-  if (!record) {
-    throw new Error("native hook relay bridge not found");
-  }
-  return record;
-}
-
 export function readNativeHookRelayBridgeRecordIfExists(
   relayId: string,
   stateDbPath?: string,
@@ -325,166 +309,6 @@ export function readNativeHookRelayBridgeRecordIfExists(
     log.debug("failed to read native hook relay bridge record", { error, relayId });
   }
   return undefined;
-}
-
-export async function invokeNativeHookRelayBridge(
-  params: InvokeNativeHookRelayBridgeParams,
-): Promise<NativeHookRelayProcessResponse> {
-  const provider = readNativeHookRelayProvider(params.provider);
-  const relayId = readNonEmptyString(params.relayId, "relayId");
-  const event = readNativeHookRelayEvent(params.event);
-  const timeoutMs = normalizePositiveInteger(params.timeoutMs, DEFAULT_RELAY_TIMEOUT_MS);
-  const registrationTimeoutMs = normalizePositiveInteger(params.registrationTimeoutMs, timeoutMs);
-  const startedAt = Date.now();
-  let lastError: unknown = new Error("native hook relay bridge not found");
-  while (Date.now() - startedAt < timeoutMs) {
-    try {
-      const record = readNativeHookRelayBridgeRecord(relayId, params.stateDbPath);
-      if (Date.now() > record.expiresAtMs) {
-        throw new Error("native hook relay bridge expired");
-      }
-      return await postNativeHookRelayBridgeRecord({
-        record,
-        timeoutMs: Math.max(1, timeoutMs - (Date.now() - startedAt)),
-        payload: {
-          provider,
-          relayId,
-          event,
-          generation: params.generation,
-          rawPayload: params.rawPayload,
-        },
-      });
-    } catch (error) {
-      lastError = error;
-      if (
-        error instanceof Error &&
-        error.message === "native hook relay bridge not found" &&
-        Date.now() - startedAt >= registrationTimeoutMs
-      ) {
-        break;
-      }
-      if (
-        !isRetryableNativeHookRelayBridgeLookupError({
-          error,
-          elapsedMs: Date.now() - startedAt,
-        })
-      ) {
-        break;
-      }
-      await delay(
-        Math.min(NATIVE_HOOK_BRIDGE_RETRY_INTERVAL_MS, timeoutMs - (Date.now() - startedAt)),
-      );
-    }
-  }
-  throw lastError instanceof Error ? lastError : new Error(String(lastError));
-}
-
-function postNativeHookRelayBridgeRecord(params: {
-  record: NativeHookRelayBridgeRecord;
-  timeoutMs: number;
-  payload: InvokeNativeHookRelayParams;
-}): Promise<NativeHookRelayProcessResponse> {
-  const body = JSON.stringify(params.payload);
-  return new Promise((resolve, reject) => {
-    let settled = false;
-    const resolveOnce = (value: NativeHookRelayProcessResponse) => {
-      if (!settled) {
-        settled = true;
-        resolve(value);
-      }
-    };
-    const rejectOnce = (error: unknown) => {
-      if (!settled) {
-        settled = true;
-        reject(toErrorObject(error, "Non-Error rejection"));
-      }
-    };
-    const req = httpRequest(
-      {
-        hostname: params.record.hostname,
-        method: "POST",
-        path: "/invoke",
-        port: params.record.port,
-        timeout: params.timeoutMs,
-        headers: {
-          authorization: `Bearer ${params.record.token}`,
-          "content-type": "application/json",
-          "content-length": Buffer.byteLength(body),
-        },
-      },
-      (res) => {
-        let responseText = "";
-        let responseBytes = 0;
-        res.setEncoding("utf8");
-        res.on("data", (chunk) => {
-          const chunkText = typeof chunk === "string" ? chunk : String(chunk);
-          responseBytes += Buffer.byteLength(chunkText);
-          if (responseBytes > MAX_NATIVE_HOOK_BRIDGE_RESPONSE_BYTES) {
-            rejectOnce(new Error("native hook relay bridge response too large"));
-            res.destroy();
-            return;
-          }
-          responseText += chunkText;
-        });
-        res.on("error", rejectOnce);
-        res.on("end", () => {
-          if (settled) {
-            return;
-          }
-          try {
-            const parsed = JSON.parse(responseText) as
-              | { ok: true; result: NativeHookRelayProcessResponse }
-              | { ok: false; error?: string };
-            if (parsed.ok) {
-              resolveOnce(parsed.result);
-              return;
-            }
-            rejectOnce(new Error(parsed.error || "native hook relay bridge failed"));
-          } catch (error) {
-            rejectOnce(error);
-          }
-        });
-      },
-    );
-    req.on("timeout", () => {
-      req.destroy(new Error("native hook relay bridge timed out"));
-    });
-    req.on("error", rejectOnce);
-    req.end(body);
-  });
-}
-
-function isRetryableNativeHookRelayBridgeError(error: unknown): boolean {
-  const code = (error as NodeJS.ErrnoException).code;
-  return (
-    code === "ENOENT" ||
-    code === "ECONNREFUSED" ||
-    code === "EAGAIN" ||
-    (error instanceof Error && error.message === "native hook relay bridge not found")
-  );
-}
-
-export function isRetryableNativeHookRelayBridgeLookupError(params: {
-  error: unknown;
-  elapsedMs: number;
-}): boolean {
-  return (
-    isRetryableNativeHookRelayBridgeError(params.error) ||
-    (params.elapsedMs < NATIVE_HOOK_BRIDGE_REPLACEMENT_RECORD_GRACE_MS &&
-      isNativeHookRelayBridgeStaleRegistrationError(params.error))
-  );
-}
-
-export function isNativeHookRelayBridgeStaleRegistrationError(error: unknown): boolean {
-  return (
-    error instanceof Error && error.message === NATIVE_HOOK_RELAY_BRIDGE_STALE_REGISTRATION_ERROR
-  );
-}
-
-function delay(ms: number): Promise<void> {
-  return new Promise((resolve) => {
-    setTimeout(resolve, Math.max(0, ms));
-  });
 }
 
 export function clearNativeHookRelayBridgesForTests(): void {

--- a/src/agents/harness/native-hook-relay-client-store.ts
+++ b/src/agents/harness/native-hook-relay-client-store.ts
@@ -1,0 +1,57 @@
+import path from "node:path";
+import type { DatabaseSync } from "node:sqlite";
+import {
+  clearNodeSqliteKyselyCacheForDatabase,
+  executeSqliteQueryTakeFirstSync,
+  getNodeSqliteKysely,
+} from "../../infra/kysely-sync.js";
+import { openNodeSqliteDatabase } from "../../infra/node-sqlite.js";
+import {
+  createNewerSqliteSchemaVersionError,
+  readSqliteUserVersion,
+} from "../../infra/sqlite-user-version.js";
+import {
+  OPENCLAW_SQLITE_BUSY_TIMEOUT_MS,
+  OPENCLAW_STATE_SCHEMA_VERSION,
+} from "../../state/openclaw-state-db-contract.js";
+import type { DB as OpenClawStateKyselyDatabase } from "../../state/openclaw-state-db.generated.js";
+import { resolveOpenClawStateSqlitePath } from "../../state/openclaw-state-db.paths.js";
+import {
+  readNativeHookRelayBridgeRecordRow,
+  type NativeHookRelayBridgeRecord,
+} from "./native-hook-relay-bridge-record.js";
+
+type NativeHookRelayBridgeDatabase = Pick<OpenClawStateKyselyDatabase, "native_hook_relay_bridges">;
+
+function assertSupportedSchemaVersion(db: DatabaseSync, pathname: string): void {
+  const userVersion = readSqliteUserVersion(db);
+  if (userVersion > OPENCLAW_STATE_SCHEMA_VERSION) {
+    throw createNewerSqliteSchemaVersionError(
+      "OpenClaw state database",
+      pathname,
+      userVersion,
+      OPENCLAW_STATE_SCHEMA_VERSION,
+    );
+  }
+}
+
+/** Read one native relay locator without loading the shared-state writer lifecycle. */
+export function readNativeHookRelayClientBridgeRecord(params: {
+  relayId: string;
+  stateDbPath?: string;
+}): NativeHookRelayBridgeRecord | undefined {
+  const pathname = path.resolve(params.stateDbPath ?? resolveOpenClawStateSqlitePath());
+  const db = openNodeSqliteDatabase(pathname, { readOnly: true });
+  try {
+    db.exec(`PRAGMA busy_timeout = ${OPENCLAW_SQLITE_BUSY_TIMEOUT_MS};`);
+    assertSupportedSchemaVersion(db, pathname);
+    const query = getNodeSqliteKysely<NativeHookRelayBridgeDatabase>(db)
+      .selectFrom("native_hook_relay_bridges")
+      .selectAll()
+      .where("relay_id", "=", params.relayId);
+    return readNativeHookRelayBridgeRecordRow(executeSqliteQueryTakeFirstSync(db, query));
+  } finally {
+    clearNodeSqliteKyselyCacheForDatabase(db);
+    db.close();
+  }
+}

--- a/src/agents/harness/native-hook-relay-client.ts
+++ b/src/agents/harness/native-hook-relay-client.ts
@@ -1,0 +1,212 @@
+import { request as httpRequest } from "node:http";
+import { toErrorObject } from "../../infra/errors.js";
+import { readNativeHookRelayClientBridgeRecord } from "./native-hook-relay-client-store.js";
+import { DEFAULT_RELAY_TIMEOUT_MS } from "./native-hook-relay-constants.js";
+import { codexNativeHookRelayResponseCodec } from "./native-hook-relay-response-codec.js";
+import type {
+  InvokeNativeHookRelayBridgeParams,
+  InvokeNativeHookRelayParams,
+  NativeHookRelayProcessResponse,
+} from "./native-hook-relay-types.js";
+import {
+  normalizePositiveInteger,
+  readNativeHookRelayEvent,
+  readNativeHookRelayProvider,
+  readNonEmptyString,
+} from "./native-hook-relay-utils.js";
+
+const MAX_NATIVE_HOOK_BRIDGE_RESPONSE_BYTES = 5_000_000;
+const NATIVE_HOOK_BRIDGE_RETRY_INTERVAL_MS = 25;
+export const NATIVE_HOOK_BRIDGE_REPLACEMENT_RECORD_GRACE_MS = 250;
+export const NATIVE_HOOK_RELAY_BRIDGE_STALE_REGISTRATION_ERROR =
+  "native hook relay bridge stale registration";
+
+/** Invoke a registered native relay through its read-only SQLite locator. */
+export async function invokeNativeHookRelayBridge(
+  params: InvokeNativeHookRelayBridgeParams,
+): Promise<NativeHookRelayProcessResponse> {
+  const provider = readNativeHookRelayProvider(params.provider);
+  const relayId = readNonEmptyString(params.relayId, "relayId");
+  const event = readNativeHookRelayEvent(params.event);
+  const timeoutMs = normalizePositiveInteger(params.timeoutMs, DEFAULT_RELAY_TIMEOUT_MS);
+  const registrationTimeoutMs = normalizePositiveInteger(params.registrationTimeoutMs, timeoutMs);
+  const startedAt = Date.now();
+  let lastError: unknown = new Error("native hook relay bridge not found");
+  while (Date.now() - startedAt < timeoutMs) {
+    try {
+      const record = readNativeHookRelayClientBridgeRecord({
+        relayId,
+        stateDbPath: params.stateDbPath,
+      });
+      if (!record) {
+        throw new Error("native hook relay bridge not found");
+      }
+      if (Date.now() > record.expiresAtMs) {
+        throw new Error("native hook relay bridge expired");
+      }
+      return await postNativeHookRelayBridgeRecord({
+        record,
+        timeoutMs: Math.max(1, timeoutMs - (Date.now() - startedAt)),
+        payload: {
+          provider,
+          relayId,
+          event,
+          generation: params.generation,
+          rawPayload: params.rawPayload,
+        },
+      });
+    } catch (error) {
+      lastError = error;
+      const elapsedMs = Date.now() - startedAt;
+      if (
+        error instanceof Error &&
+        error.message === "native hook relay bridge not found" &&
+        elapsedMs >= registrationTimeoutMs
+      ) {
+        break;
+      }
+      if (!isRetryableNativeHookRelayBridgeLookupError({ error, elapsedMs })) {
+        break;
+      }
+      await delay(Math.min(NATIVE_HOOK_BRIDGE_RETRY_INTERVAL_MS, timeoutMs - elapsedMs));
+    }
+  }
+  throw lastError instanceof Error ? lastError : new Error(String(lastError));
+}
+
+function postNativeHookRelayBridgeRecord(params: {
+  record: {
+    hostname: "127.0.0.1";
+    port: number;
+    token: string;
+  };
+  timeoutMs: number;
+  payload: InvokeNativeHookRelayParams;
+}): Promise<NativeHookRelayProcessResponse> {
+  const body = JSON.stringify(params.payload);
+  return new Promise((resolve, reject) => {
+    let settled = false;
+    const resolveOnce = (value: NativeHookRelayProcessResponse) => {
+      if (!settled) {
+        settled = true;
+        resolve(value);
+      }
+    };
+    const rejectOnce = (error: unknown) => {
+      if (!settled) {
+        settled = true;
+        reject(toErrorObject(error, "Non-Error rejection"));
+      }
+    };
+    const req = httpRequest(
+      {
+        hostname: params.record.hostname,
+        method: "POST",
+        path: "/invoke",
+        port: params.record.port,
+        timeout: params.timeoutMs,
+        headers: {
+          authorization: `Bearer ${params.record.token}`,
+          "content-type": "application/json",
+          "content-length": Buffer.byteLength(body),
+        },
+      },
+      (res) => {
+        let responseText = "";
+        let responseBytes = 0;
+        res.setEncoding("utf8");
+        res.on("data", (chunk) => {
+          const chunkText = typeof chunk === "string" ? chunk : String(chunk);
+          responseBytes += Buffer.byteLength(chunkText);
+          if (responseBytes > MAX_NATIVE_HOOK_BRIDGE_RESPONSE_BYTES) {
+            rejectOnce(new Error("native hook relay bridge response too large"));
+            res.destroy();
+            return;
+          }
+          responseText += chunkText;
+        });
+        res.on("error", rejectOnce);
+        res.on("end", () => {
+          if (settled) {
+            return;
+          }
+          try {
+            const parsed = JSON.parse(responseText) as
+              | { ok: true; result: NativeHookRelayProcessResponse }
+              | { ok: false; error?: string };
+            if (parsed.ok) {
+              resolveOnce(parsed.result);
+              return;
+            }
+            rejectOnce(new Error(parsed.error || "native hook relay bridge failed"));
+          } catch (error) {
+            rejectOnce(error);
+          }
+        });
+      },
+    );
+    req.on("timeout", () => {
+      req.destroy(new Error("native hook relay bridge timed out"));
+    });
+    req.on("error", rejectOnce);
+    req.end(body);
+  });
+}
+
+function isRetryableNativeHookRelayBridgeError(error: unknown): boolean {
+  const code = (error as NodeJS.ErrnoException).code;
+  return (
+    code === "ENOENT" ||
+    code === "ECONNREFUSED" ||
+    code === "EAGAIN" ||
+    (error instanceof Error && error.message === "native hook relay bridge not found")
+  );
+}
+
+export function isRetryableNativeHookRelayBridgeLookupError(params: {
+  error: unknown;
+  elapsedMs: number;
+}): boolean {
+  return (
+    isRetryableNativeHookRelayBridgeError(params.error) ||
+    (params.elapsedMs < NATIVE_HOOK_BRIDGE_REPLACEMENT_RECORD_GRACE_MS &&
+      isNativeHookRelayBridgeStaleRegistrationError(params.error))
+  );
+}
+
+/** Detect a stale locator response that must not fall back to the Gateway. */
+export function isNativeHookRelayBridgeStaleRegistrationError(error: unknown): boolean {
+  return (
+    error instanceof Error && error.message === NATIVE_HOOK_RELAY_BRIDGE_STALE_REGISTRATION_ERROR
+  );
+}
+
+/** Render the provider response used when both relay transports are unavailable. */
+export function renderNativeHookRelayUnavailableResponse(params: {
+  provider: unknown;
+  event: unknown;
+  preToolUseUnavailable?: unknown;
+  message?: string;
+}): NativeHookRelayProcessResponse {
+  readNativeHookRelayProvider(params.provider);
+  const event = readNativeHookRelayEvent(params.event);
+  const message = params.message?.trim() || "Native hook relay unavailable";
+  if (event === "pre_tool_use") {
+    // The cold CLI cannot reconstruct relay policy after lookup fails. Fail
+    // closed unless the generated command recorded that no local policy exists.
+    if (params.preToolUseUnavailable === "noop") {
+      return codexNativeHookRelayResponseCodec.renderNoopResponse();
+    }
+    return codexNativeHookRelayResponseCodec.renderPreToolUseBlockResponse(message);
+  }
+  if (event === "permission_request") {
+    return codexNativeHookRelayResponseCodec.renderPermissionDecisionResponse("deny", message);
+  }
+  return codexNativeHookRelayResponseCodec.renderNoopResponse();
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(resolve, Math.max(0, ms));
+  });
+}

--- a/src/agents/harness/native-hook-relay-codec.ts
+++ b/src/agents/harness/native-hook-relay-codec.ts
@@ -1,5 +1,6 @@
 import { stableStringify } from "../stable-stringify.js";
 import { normalizeToolName } from "../tool-policy.js";
+import { codexNativeHookRelayResponseCodec } from "./native-hook-relay-response-codec.js";
 import type {
   JsonValue,
   NativeHookRelayInvocation,
@@ -27,22 +28,7 @@ const nativeHookRelayProviderAdapters: Record<
     normalizeMetadata: normalizeCodexHookMetadata,
     readToolInput: readCodexToolInput,
     readToolResponse: readCodexToolResponse,
-    renderNoopResponse: () => {
-      // Codex treats empty stdout plus exit 0 as no decision/no additional context.
-      return { stdout: "", stderr: "", exitCode: 0 };
-    },
-    renderPreToolUseBlockResponse: (reason, failureDisposition) => ({
-      stdout: `${JSON.stringify({
-        hookSpecificOutput: {
-          hookEventName: "PreToolUse",
-          permissionDecision: "deny",
-          permissionDecisionReason: reason,
-        },
-      })}\n`,
-      stderr: "",
-      exitCode: 0,
-      ...(failureDisposition ? { failureDisposition } : {}),
-    }),
+    ...codexNativeHookRelayResponseCodec,
     renderBeforeAgentFinalizeReviseResponse: (reason) => ({
       stdout: `${JSON.stringify({
         decision: "block",
@@ -55,22 +41,6 @@ const nativeHookRelayProviderAdapters: Record<
       stdout: `${JSON.stringify({
         continue: false,
         ...(reason?.trim() ? { stopReason: reason.trim() } : {}),
-      })}\n`,
-      stderr: "",
-      exitCode: 0,
-    }),
-    renderPermissionDecisionResponse: (decision, message) => ({
-      stdout: `${JSON.stringify({
-        hookSpecificOutput: {
-          hookEventName: "PermissionRequest",
-          decision:
-            decision === "allow"
-              ? { behavior: "allow" }
-              : {
-                  behavior: "deny",
-                  message: message?.trim() || "Denied by OpenClaw",
-                },
-        },
       })}\n`,
       stderr: "",
       exitCode: 0,

--- a/src/agents/harness/native-hook-relay-command.ts
+++ b/src/agents/harness/native-hook-relay-command.ts
@@ -1,14 +1,13 @@
 import { existsSync } from "node:fs";
 import path from "node:path";
 import { resolveOpenClawPackageRootSync } from "../../infra/openclaw-root.js";
+import { DEFAULT_RELAY_TIMEOUT_MS } from "./native-hook-relay-constants.js";
 import type { NativeHookRelayEvent, NativeHookRelayProvider } from "./native-hook-relay-types.js";
 import {
   normalizeOptionalPositiveInteger,
   normalizePositiveInteger,
   shellQuoteArgs,
 } from "./native-hook-relay-utils.js";
-
-export const DEFAULT_RELAY_TIMEOUT_MS = 5_000;
 
 function resolveNativeHookRelayNicePrefix(value: number | false | undefined): string[] {
   if (process.platform === "win32" || value === false || value === undefined) {

--- a/src/agents/harness/native-hook-relay-constants.ts
+++ b/src/agents/harness/native-hook-relay-constants.ts
@@ -1,0 +1,1 @@
+export const DEFAULT_RELAY_TIMEOUT_MS = 5_000;

--- a/src/agents/harness/native-hook-relay-response-codec.ts
+++ b/src/agents/harness/native-hook-relay-response-codec.ts
@@ -1,0 +1,47 @@
+import type { NativeHookRelayProcessResponse } from "./native-hook-relay-types.js";
+
+/** Render the native Codex hook responses shared by server and cold client paths. */
+export const codexNativeHookRelayResponseCodec = {
+  renderNoopResponse(): NativeHookRelayProcessResponse {
+    // Codex treats empty stdout plus exit 0 as no decision/no additional context.
+    return { stdout: "", stderr: "", exitCode: 0 };
+  },
+  renderPreToolUseBlockResponse(
+    reason: string,
+    failureDisposition?: NativeHookRelayProcessResponse["failureDisposition"],
+  ): NativeHookRelayProcessResponse {
+    return {
+      stdout: `${JSON.stringify({
+        hookSpecificOutput: {
+          hookEventName: "PreToolUse",
+          permissionDecision: "deny",
+          permissionDecisionReason: reason,
+        },
+      })}\n`,
+      stderr: "",
+      exitCode: 0,
+      ...(failureDisposition ? { failureDisposition } : {}),
+    };
+  },
+  renderPermissionDecisionResponse(
+    decision: "allow" | "deny",
+    message?: string,
+  ): NativeHookRelayProcessResponse {
+    return {
+      stdout: `${JSON.stringify({
+        hookSpecificOutput: {
+          hookEventName: "PermissionRequest",
+          decision:
+            decision === "allow"
+              ? { behavior: "allow" }
+              : {
+                  behavior: "deny",
+                  message: message?.trim() || "Denied by OpenClaw",
+                },
+        },
+      })}\n`,
+      stderr: "",
+      exitCode: 0,
+    };
+  },
+};

--- a/src/agents/harness/native-hook-relay-store.ts
+++ b/src/agents/harness/native-hook-relay-store.ts
@@ -9,15 +9,12 @@ import {
   openOpenClawStateDatabase,
   runOpenClawStateWriteTransaction,
 } from "../../state/openclaw-state-db.js";
+import {
+  readNativeHookRelayBridgeRecordRow,
+  type NativeHookRelayBridgeRecord,
+} from "./native-hook-relay-bridge-record.js";
 
-export type NativeHookRelayBridgeRecord = {
-  relayId: string;
-  pid: number;
-  hostname: "127.0.0.1";
-  port: number;
-  token: string;
-  expiresAtMs: number;
-};
+export type { NativeHookRelayBridgeRecord } from "./native-hook-relay-bridge-record.js";
 
 type NativeHookRelayBridgePruneResult = {
   relayId: string;
@@ -46,32 +43,12 @@ type NativeHookRelayBridgeStoreOptions = {
 function readNativeHookRelayBridgeSnapshot(
   row: NativeHookRelayBridgeRow | undefined,
 ): NativeHookRelayBridgeSnapshot | undefined {
-  if (
-    !row ||
-    typeof row.relay_id !== "string" ||
-    row.relay_id.length === 0 ||
-    !Number.isSafeInteger(row.pid) ||
-    row.hostname !== "127.0.0.1" ||
-    !Number.isSafeInteger(row.port) ||
-    row.port <= 0 ||
-    row.port > 65_535 ||
-    typeof row.token !== "string" ||
-    row.token.length === 0 ||
-    !Number.isSafeInteger(row.expires_at_ms) ||
-    !Number.isSafeInteger(row.updated_at_ms)
-  ) {
+  const record = readNativeHookRelayBridgeRecordRow(row);
+  if (!record || !row || !Number.isSafeInteger(row.updated_at_ms)) {
     return undefined;
   }
-  const { token } = row;
   return {
-    record: {
-      relayId: row.relay_id,
-      pid: row.pid,
-      hostname: row.hostname,
-      port: row.port,
-      token,
-      expiresAtMs: row.expires_at_ms,
-    },
+    record,
     updatedAtMs: row.updated_at_ms,
   };
 }

--- a/src/agents/harness/native-hook-relay.test.ts
+++ b/src/agents/harness/native-hook-relay.test.ts
@@ -16,6 +16,7 @@ import { patchPluginSessionExtension } from "../../plugins/host-hook-state.js";
 import { createEmptyPluginRegistry } from "../../plugins/registry-empty.js";
 import { setActivePluginRegistry } from "../../plugins/runtime.js";
 import { resolveOpenClawStateSqlitePath } from "../../state/openclaw-state-db.paths.js";
+import { invokeNativeHookRelayBridge } from "./native-hook-relay-client.js";
 import {
   deleteNativeHookRelayBridgeRecordIfOwned,
   readNativeHookRelayBridgeRecord,
@@ -27,7 +28,6 @@ import {
   buildNativeHookRelayCommand,
   hasNativeHookRelayInvocation,
   invokeNativeHookRelay,
-  invokeNativeHookRelayBridge,
   registerNativeHookRelay,
   resolveNativeHookRelayDeferredToolApproval,
 } from "./native-hook-relay.js";

--- a/src/agents/harness/native-hook-relay.ts
+++ b/src/agents/harness/native-hook-relay.ts
@@ -64,8 +64,6 @@ import {
   snapshotNativeHookRelayPayload,
 } from "./native-hook-relay-utils.js";
 
-export { invokeNativeHookRelayBridge } from "./native-hook-relay-bridge.js";
-export { isNativeHookRelayBridgeStaleRegistrationError } from "./native-hook-relay-bridge.js";
 export { buildNativeHookRelayCommand } from "./native-hook-relay-command.js";
 export { resolveNativeHookRelayDeferredToolApproval } from "./native-hook-relay-permissions.js";
 export type {
@@ -343,31 +341,6 @@ export function hasNativeHookRelayInvocation(params: {
       invocation.event === params.event &&
       invocation.toolUseId === toolUseId,
   );
-}
-
-export function renderNativeHookRelayUnavailableResponse(params: {
-  provider: unknown;
-  event: unknown;
-  preToolUseUnavailable?: unknown;
-  message?: string;
-}): NativeHookRelayProcessResponse {
-  const provider = readNativeHookRelayProvider(params.provider);
-  const event = readNativeHookRelayEvent(params.event);
-  const adapter = getNativeHookRelayProviderAdapter(provider);
-  const message = params.message?.trim() || "Native hook relay unavailable";
-  if (event === "pre_tool_use") {
-    // The standalone CLI cannot reconstruct the originating registration after
-    // relay lookup fails, so unavailable PreToolUse must fail closed unless the
-    // generated command explicitly recorded that no before-tool policy existed.
-    if (params.preToolUseUnavailable === "noop") {
-      return adapter.renderNoopResponse(event);
-    }
-    return adapter.renderPreToolUseBlockResponse(message);
-  }
-  if (event === "permission_request") {
-    return adapter.renderPermissionDecisionResponse("deny", message);
-  }
-  return adapter.renderNoopResponse(event);
 }
 
 function recordNativeHookRelayInvocation(invocation: NativeHookRelayInvocation): void {

--- a/src/cli/native-hook-relay-cli.import-boundary.test.ts
+++ b/src/cli/native-hook-relay-cli.import-boundary.test.ts
@@ -1,0 +1,54 @@
+// Native relay hooks are cold processes, so their direct path must not load server runtimes.
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+const repoRoot = path.resolve(import.meta.dirname, "../..");
+
+function readSource(relativePath: string): string {
+  return readFileSync(path.join(repoRoot, relativePath), "utf8");
+}
+
+describe("native hook relay CLI import boundary", () => {
+  it("loads only the client relay owner before Gateway fallback", () => {
+    const cli = readSource("src/cli/native-hook-relay-cli.ts");
+
+    expect(cli).toContain('from "../agents/harness/native-hook-relay-client.js"');
+    expect(cli).not.toContain('from "../agents/harness/native-hook-relay.js"');
+    expect(cli).not.toMatch(/import\s+\{\s*callGateway\s*\}\s+from\s+"..\/gateway\/call\.js"/u);
+    expect(cli).toContain('import("../gateway/call.js")');
+  });
+
+  it("dispatches the hidden relay before loading the general CLI", () => {
+    const entry = readSource("src/entry.ts");
+    const relayDispatch = entry.indexOf('import("./cli/native-hook-relay-cli.js")');
+    const generalCli = entry.indexOf('import("./cli/run-main.js")');
+
+    expect(relayDispatch).toBeGreaterThan(-1);
+    expect(generalCli).toBeGreaterThan(relayDispatch);
+  });
+
+  it("keeps server, event, permission, and writable state owners out of the client", () => {
+    const clientGraph = [
+      "src/agents/harness/native-hook-relay-client.ts",
+      "src/agents/harness/native-hook-relay-client-store.ts",
+      "src/agents/harness/native-hook-relay-bridge-record.ts",
+      "src/agents/harness/native-hook-relay-constants.ts",
+      "src/agents/harness/native-hook-relay-response-codec.ts",
+    ]
+      .map(readSource)
+      .join("\n");
+
+    for (const forbiddenImport of [
+      "native-hook-relay-bridge.js",
+      "native-hook-relay-events.js",
+      "native-hook-relay-permissions.js",
+      "native-hook-relay-state.js",
+      "native-hook-relay-store.js",
+      "openclaw-state-db.js",
+      "gateway/call.js",
+    ]) {
+      expect(clientGraph).not.toContain(forbiddenImport);
+    }
+  });
+});

--- a/src/cli/native-hook-relay-cli.test.ts
+++ b/src/cli/native-hook-relay-cli.test.ts
@@ -1,7 +1,7 @@
 // Native hook relay CLI tests cover relay command registration and runtime delegation.
 import { PassThrough, Readable, Writable } from "node:stream";
 import { describe, expect, it, vi } from "vitest";
-import { runNativeHookRelayCli } from "./native-hook-relay-cli.js";
+import { runNativeHookRelayCli, runNativeHookRelayCliFromArgv } from "./native-hook-relay-cli.js";
 
 function createReadableTextStream(text: string): NodeJS.ReadableStream {
   return Readable.from([text]);
@@ -21,6 +21,49 @@ function createWritableTextBuffer(): NodeJS.WritableStream & { text: () => strin
 }
 
 describe("native hook relay CLI", () => {
+  it("parses the internal cold-path argument vector", async () => {
+    const invokeBridge = vi.fn(async () => ({ stdout: "", stderr: "", exitCode: 0 }));
+
+    await expect(
+      runNativeHookRelayCliFromArgv(
+        [
+          "node",
+          "openclaw.mjs",
+          "hooks",
+          "relay",
+          "--provider=codex",
+          "--relay-id",
+          "relay-1",
+          "--state-db",
+          "/tmp/profile/state/openclaw.sqlite",
+          "--generation",
+          "generation-1",
+          "--event",
+          "pre_tool_use",
+          "--pre-tool-use-unavailable",
+          "noop",
+          "--timeout",
+          "1234",
+        ],
+        {
+          stdin: createReadableTextStream("{}"),
+          invokeBridge: invokeBridge as never,
+        },
+      ),
+    ).resolves.toBe(0);
+
+    expect(invokeBridge).toHaveBeenCalledWith(
+      expect.objectContaining({
+        provider: "codex",
+        relayId: "relay-1",
+        stateDbPath: "/tmp/profile/state/openclaw.sqlite",
+        generation: "generation-1",
+        event: "pre_tool_use",
+        timeoutMs: expect.any(Number),
+      }),
+    );
+  });
+
   it("passes the explicit state database path to direct bridge lookup", async () => {
     const invokeBridge = vi.fn(async () => ({ stdout: "", stderr: "", exitCode: 0 }));
 

--- a/src/cli/native-hook-relay-cli.ts
+++ b/src/cli/native-hook-relay-cli.ts
@@ -3,9 +3,9 @@ import {
   invokeNativeHookRelayBridge,
   isNativeHookRelayBridgeStaleRegistrationError,
   renderNativeHookRelayUnavailableResponse,
-  type NativeHookRelayProcessResponse,
-} from "../agents/harness/native-hook-relay.js";
-import { callGateway } from "../gateway/call.js";
+} from "../agents/harness/native-hook-relay-client.js";
+import type { NativeHookRelayProcessResponse } from "../agents/harness/native-hook-relay-types.js";
+import type { CallGatewayOptions } from "../gateway/call.js";
 import { ADMIN_SCOPE } from "../gateway/method-scopes.js";
 import { setSafeTimeout } from "../utils/timer-delay.js";
 import { parseTimeoutMsWithFallback } from "./parse-timeout.js";
@@ -28,8 +28,20 @@ type NativeHookRelayCliDeps = {
   stdout?: NodeJS.WritableStream;
   stderr?: NodeJS.WritableStream;
   invokeBridge?: typeof invokeNativeHookRelayBridge;
-  callGateway?: typeof callGateway;
+  callGateway?: CallGateway;
 };
+
+type CallGateway = <T = Record<string, unknown>>(opts: CallGatewayOptions) => Promise<T>;
+
+const NATIVE_HOOK_RELAY_VALUE_FLAGS = {
+  "--provider": "provider",
+  "--relay-id": "relayId",
+  "--state-db": "stateDb",
+  "--generation": "generation",
+  "--event": "event",
+  "--pre-tool-use-unavailable": "preToolUseUnavailable",
+  "--timeout": "timeout",
+} as const satisfies Record<string, keyof NativeHookRelayCliOptions>;
 
 type NativeHookRelayDeadline = {
   expiresAtMs: number;
@@ -45,6 +57,37 @@ class NativeHookRelayDeadlineError extends Error {
   }
 }
 
+/** Parse and run the internal native relay directly from the process argument vector. */
+export async function runNativeHookRelayCliFromArgv(
+  argv: string[],
+  deps: NativeHookRelayCliDeps = {},
+): Promise<number> {
+  return await runNativeHookRelayCli(parseNativeHookRelayCliOptions(argv), deps);
+}
+
+function parseNativeHookRelayCliOptions(argv: string[]): NativeHookRelayCliOptions {
+  const relayIndex = argv.findIndex((arg, index) => arg === "relay" && argv[index - 1] === "hooks");
+  if (relayIndex < 0) {
+    throw new Error("native hook relay command path is required");
+  }
+  const opts: NativeHookRelayCliOptions = {};
+  for (let index = relayIndex + 1; index < argv.length; index += 1) {
+    const rawFlag = argv[index] ?? "";
+    const equalsIndex = rawFlag.indexOf("=");
+    const flag = equalsIndex > 0 ? rawFlag.slice(0, equalsIndex) : rawFlag;
+    const key = NATIVE_HOOK_RELAY_VALUE_FLAGS[flag as keyof typeof NATIVE_HOOK_RELAY_VALUE_FLAGS];
+    if (!key) {
+      throw new Error(`unknown native hook relay option: ${rawFlag}`);
+    }
+    const value = equalsIndex > 0 ? rawFlag.slice(equalsIndex + 1) : argv[++index];
+    if (!value) {
+      throw new Error(`native hook relay option ${flag} requires a value`);
+    }
+    opts[key] = value;
+  }
+  return opts;
+}
+
 /** Run one native hook relay invocation from stdin JSON to stdout/stderr response streams. */
 export async function runNativeHookRelayCli(
   opts: NativeHookRelayCliOptions,
@@ -54,7 +97,7 @@ export async function runNativeHookRelayCli(
   const stdout = deps.stdout ?? process.stdout;
   const stderr = deps.stderr ?? process.stderr;
   const invokeBridge = deps.invokeBridge ?? invokeNativeHookRelayBridge;
-  const callGatewayFn = deps.callGateway ?? callGateway;
+  const callGatewayFn = deps.callGateway ?? callGatewayLazy;
   const provider = readRequiredOption(opts.provider, "provider");
   const relayId = readRequiredOption(opts.relayId, "relay-id");
   const generation = opts.generation?.trim() || undefined;
@@ -156,6 +199,11 @@ export async function runNativeHookRelayCli(
   } finally {
     deadline.dispose();
   }
+}
+
+async function callGatewayLazy<T = Record<string, unknown>>(opts: CallGatewayOptions): Promise<T> {
+  const { callGateway } = await import("../gateway/call.js");
+  return await callGateway<T>(opts);
 }
 
 function readRequiredOption(value: string | undefined, name: string): string {

--- a/src/cli/respawn-policy.ts
+++ b/src/cli/respawn-policy.ts
@@ -29,7 +29,7 @@ const GATEWAY_RUN_VALUE_FLAGS = [
 
 const INTERACTIVE_TTY_COMMANDS = new Set(["tui", "terminal", "chat"]);
 
-function isNativeHookRelayArgv(argv: string[]): boolean {
+export function isNativeHookRelayArgv(argv: string[]): boolean {
   const { commandPath } = resolveCliArgvInvocation(argv);
   return commandPath[0] === "hooks" && commandPath[1] === "relay";
 }

--- a/src/entry.ts
+++ b/src/entry.ts
@@ -6,13 +6,14 @@ import { fileURLToPath } from "node:url";
 import { format } from "node:util";
 import { isRootHelpInvocation } from "./cli/argv.js";
 import { parseCliContainerArgs, resolveCliContainerTarget } from "./cli/container-target.js";
-import { runCliWithExitFinalization } from "./cli/one-shot-exit.js";
+import { requestExitAfterOneShotOutput, runCliWithExitFinalization } from "./cli/one-shot-exit.js";
 import {
   tryOutputPrecomputedCommandHelp,
   type PrecomputedCommandHelpDeps,
 } from "./cli/precomputed-help.js";
 import { applyCliProfileEnv, parseCliProfileArgs } from "./cli/profile.js";
 import type { RootHelpRenderOptions } from "./cli/program/root-help.js";
+import { isNativeHookRelayArgv } from "./cli/respawn-policy.js";
 import {
   configureGatewayStartupTraceConsoleFormatting,
   createGatewayStartupTrace,
@@ -29,6 +30,7 @@ import { normalizeEnv } from "./infra/env.js";
 import { isMainModule } from "./infra/is-main.js";
 import { ensureOpenClawExecMarkerOnProcess } from "./infra/openclaw-exec-env.js";
 import { installProcessWarningFilter } from "./infra/warning-filter.js";
+import { defaultRuntime } from "./runtime.js";
 
 const ENTRY_WRAPPER_PAIRS = [
   { wrapperBasename: "openclaw.mjs", entryBasename: "entry.js" },
@@ -266,6 +268,13 @@ export async function tryHandlePrecomputedCommandHelpFastPath(
 async function runMainOrRootHelp(argv: string[]): Promise<void> {
   await runCliWithExitFinalization({
     run: async () => {
+      if (isNativeHookRelayArgv(argv) && !argv.includes("--help") && !argv.includes("-h")) {
+        const { runNativeHookRelayCliFromArgv } = await import("./cli/native-hook-relay-cli.js");
+        const exitCode = await runNativeHookRelayCliFromArgv(argv);
+        process.exitCode = exitCode;
+        requestExitAfterOneShotOutput(defaultRuntime, exitCode);
+        return;
+      }
       if (await tryHandleRootHelpFastPath(argv)) {
         await flushEntryStartupTraceForEarlyReturn(argv);
         return;


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users running Codex native hooks could wait several seconds before every pre- or post-tool hook while the relay process loaded most of the OpenClaw server graph and consumed hundreds of MiB.

## Why This Change Was Made

The hidden relay command now dispatches before the general CLI, reads its bridge locator through a client-only read-only SQLite owner, and loads the Gateway caller only when direct relay fallback is needed. Direct relay, Gateway fallback, timeout, stale-generation, permission, unavailable-response, and one-shot exit semantics remain unchanged; this adds no config or public SDK surface.

## User Impact

Codex native hooks begin tool execution substantially faster and with much lower memory use. In a fresh-process Blacksmith comparison, median relay time fell from 4,022.03 ms to 197.46 ms and median maximum RSS fell from 791,640 KiB to 147,060 KiB.

## Evidence

- Blacksmith Testbox: https://github.com/openclaw/openclaw/actions/runs/30339781561
- Installed CLI + real SQLite locator/HTTP relay, three cold runs per build:
  - loaded graph: 3,571 modules / 31,488,106 bytes → 453 / 2,308,767
  - median wall: 4,022.03 ms → 197.46 ms
  - median user CPU: 5,190 ms → 210 ms
  - median system CPU: 430 ms → 40 ms
  - median max RSS: 791,640 KiB → 147,060 KiB
- 148 focused assertions passed across relay/store semantics, CLI boundaries, entry dispatch, and process lifecycle.
- `pnpm build` passed.
- `pnpm check:changed` passed, including core/test typechecks, lint, cycle, schema, and boundary guards.
- Thermonuclear maintainability review and two autoreview passes completed with no remaining findings.

AI-assisted with Codex; the implementation and evidence were reviewed before submission.
