### PR TITLE
refactor(ui): share board provider helpers

### DIFF
--- a/ui/src/lib/board/gateway-provider.ts
+++ b/ui/src/lib/board/gateway-provider.ts
@@ -9,13 +9,14 @@ import type {
 import type { GatewayBrowserClient } from "../../api/gateway.ts";
 import { normalizeSessionKeyForUiComparison } from "../sessions/session-key.ts";
 import { BoardMcpAppViewCache } from "./mcp-app-view-cache.ts";
+import { emptyBoardSnapshot, normalizeBoardWidgetTitle } from "./provider-helpers.ts";
 import {
   EventStream,
   ValueSignal,
   type BoardEventStream,
   type BoardSnapshotSignal,
 } from "./provider-signals.ts";
-import type { BoardProvider } from "./provider-types.ts";
+import type { BoardPinMcpAppInput, BoardPinWidgetInput, BoardProvider } from "./provider-types.ts";
 import type { BoardWidgetAppViewState } from "./view-types.ts";
 import { canvasWidgetNameForDocument, mcpAppWidgetNameForViewId } from "./widget-names.ts";
 import {
@@ -24,24 +25,6 @@ import {
 } from "./widget-ticket-lifetime.ts";
 
 type BoardGatewayClient = Pick<GatewayBrowserClient, "request" | "addEventListener">;
-type BoardPinPlacement = {
-  title?: string;
-  name?: string;
-  tabId?: string;
-  size?: "sm" | "md" | "lg" | "xl" | "full";
-  after?: string;
-};
-type BoardPinWidgetInput = BoardPinPlacement & { docId: string };
-type BoardPinMcpAppInput = BoardPinPlacement & { viewId: string };
-
-function emptySnapshot(sessionKey: string): BoardSnapshot {
-  return { sessionKey, revision: 0, tabs: [], widgets: [] };
-}
-
-function boardWidgetTitle(title: string | undefined): string | undefined {
-  const normalized = title?.trim() ?? "";
-  return normalized ? Array.from(normalized).slice(0, 80).join("") : undefined;
-}
 
 export class GatewayBoardProvider implements BoardProvider {
   readonly snapshot$: BoardSnapshotSignal<BoardSnapshot>;
@@ -70,7 +53,7 @@ export class GatewayBoardProvider implements BoardProvider {
     public canMutate = true,
     public canGrant = true,
   ) {
-    this.snapshotSignal = new ValueSignal(emptySnapshot(sessionKey));
+    this.snapshotSignal = new ValueSignal(emptyBoardSnapshot(sessionKey));
     this.snapshot$ = this.snapshotSignal;
     this.events = this.eventStream;
     this.client = client;
@@ -111,7 +94,7 @@ export class GatewayBoardProvider implements BoardProvider {
     this.changedWidgets.clear();
     this.appViews.clear();
     this.snapshotLoaded = false;
-    this.snapshotSignal.set(emptySnapshot(this.sessionKey));
+    this.snapshotSignal.set(emptyBoardSnapshot(this.sessionKey));
     this.subscribe(client);
     if (connected) {
       void this.activate();
@@ -166,7 +149,7 @@ export class GatewayBoardProvider implements BoardProvider {
 
   async pinWidget(input: BoardPinWidgetInput): Promise<void> {
     const name = input.name ?? canvasWidgetNameForDocument(input.docId);
-    const title = boardWidgetTitle(input.title);
+    const title = normalizeBoardWidgetTitle(input.title);
     await this.mutate(
       "board.widget.put",
       {
@@ -190,7 +173,7 @@ export class GatewayBoardProvider implements BoardProvider {
 
   async pinMcpApp(input: BoardPinMcpAppInput): Promise<void> {
     const name = input.name ?? mcpAppWidgetNameForViewId(input.viewId);
-    const title = boardWidgetTitle(input.title);
+    const title = normalizeBoardWidgetTitle(input.title);
     await this.mutate(
       "board.widget.put",
       {

--- a/ui/src/lib/board/provider-helpers.ts
+++ b/ui/src/lib/board/provider-helpers.ts
@@ -1,0 +1,10 @@
+import type { BoardSnapshot } from "@openclaw/gateway-protocol";
+
+export function emptyBoardSnapshot(sessionKey: string): BoardSnapshot {
+  return { sessionKey, revision: 0, tabs: [], widgets: [] };
+}
+
+export function normalizeBoardWidgetTitle(title: string | undefined): string | undefined {
+  const normalized = title?.trim() ?? "";
+  return normalized ? Array.from(normalized).slice(0, 80).join("") : undefined;
+}

--- a/ui/src/lib/board/provider-types.ts
+++ b/ui/src/lib/board/provider-types.ts
@@ -10,8 +10,8 @@ type BoardPinPlacement = {
   after?: string;
 };
 
-type BoardPinWidgetInput = BoardPinPlacement & { docId: string };
-type BoardPinMcpAppInput = BoardPinPlacement & { viewId: string };
+export type BoardPinWidgetInput = BoardPinPlacement & { docId: string };
+export type BoardPinMcpAppInput = BoardPinPlacement & { viewId: string };
 
 export type BoardProvider = {
   readonly sessionKey: string;

--- a/ui/src/lib/board/provider.ts
+++ b/ui/src/lib/board/provider.ts
@@ -12,13 +12,14 @@ import {
 } from "../sessions/session-key.ts";
 import { GatewayBoardProvider } from "./gateway-provider.ts";
 import { applyMockBoardOp, normalizeMockBoardSnapshot } from "./mock-ops.ts";
+import { emptyBoardSnapshot, normalizeBoardWidgetTitle } from "./provider-helpers.ts";
 import {
   EventStream,
   ValueSignal,
   type BoardEventStream,
   type BoardSnapshotSignal,
 } from "./provider-signals.ts";
-import type { BoardProvider } from "./provider-types.ts";
+import type { BoardPinMcpAppInput, BoardPinWidgetInput, BoardProvider } from "./provider-types.ts";
 import type { BoardWidgetAppViewState } from "./view-types.ts";
 import { canvasWidgetNameForDocument, mcpAppWidgetNameForViewId } from "./widget-names.ts";
 export type { BoardCommandEvent };
@@ -28,26 +29,6 @@ export { canvasWidgetNameForDocument, mcpAppWidgetNameForViewId } from "./widget
 export { GatewayBoardProvider } from "./gateway-provider.ts";
 
 type BoardGatewayClient = Pick<GatewayBrowserClient, "request" | "addEventListener">;
-
-type BoardPinPlacement = {
-  title?: string;
-  name?: string;
-  tabId?: string;
-  size?: "sm" | "md" | "lg" | "xl" | "full";
-  after?: string;
-};
-
-type BoardPinWidgetInput = BoardPinPlacement & { docId: string };
-type BoardPinMcpAppInput = BoardPinPlacement & { viewId: string };
-
-function emptySnapshot(sessionKey: string): BoardSnapshot {
-  return { sessionKey, revision: 0, tabs: [], widgets: [] };
-}
-
-function boardWidgetTitle(title: string | undefined): string | undefined {
-  const normalized = title?.trim() ?? "";
-  return normalized ? Array.from(normalized).slice(0, 80).join("") : undefined;
-}
 
 function mockSnapshot(sessionKey: string): BoardSnapshot {
   return {
@@ -113,7 +94,7 @@ class NullProvider implements BoardProvider {
   readonly events: BoardEventStream<BoardCommandEvent> = new EventStream<BoardCommandEvent>();
 
   constructor(readonly sessionKey = "") {
-    this.snapshot$ = new ValueSignal(emptySnapshot(sessionKey));
+    this.snapshot$ = new ValueSignal(emptyBoardSnapshot(sessionKey));
   }
 
   async applyOps(_ops: BoardOp[]): Promise<void> {}
@@ -185,7 +166,7 @@ class MockBoardProvider implements BoardProvider {
   async pinWidget(input: BoardPinWidgetInput): Promise<void> {
     const snapshot = this.snapshotSignal.value;
     const name = input.name ?? canvasWidgetNameForDocument(input.docId);
-    const title = boardWidgetTitle(input.title);
+    const title = normalizeBoardWidgetTitle(input.title);
     const tabId = input.tabId ?? snapshot.tabs[0]?.tabId ?? "main";
     const tabs = snapshot.tabs.length
       ? snapshot.tabs
@@ -219,7 +200,7 @@ class MockBoardProvider implements BoardProvider {
   async pinMcpApp(input: BoardPinMcpAppInput): Promise<void> {
     const snapshot = this.snapshotSignal.value;
     const name = input.name ?? mcpAppWidgetNameForViewId(input.viewId);
-    const title = boardWidgetTitle(input.title);
+    const title = normalizeBoardWidgetTitle(input.title);
     const tabId = input.tabId ?? snapshot.tabs[0]?.tabId ?? "main";
     const tabs = snapshot.tabs.length
       ? snapshot.tabs


### PR DESCRIPTION
## What Problem This Solves

Removes duplicated board-provider types and helper logic that could drift between mock and gateway implementations.

## Why This Change Was Made

The two providers used identical pin input shapes, empty snapshot construction, and title normalization. This centralizes the private helpers and concrete input types inside the board owner directory while keeping the existing `provider.ts` API unchanged.

## User Impact

No user-visible behavior changes. Board pinning and snapshot initialization now share one implementation.

## Evidence

- Production diff: 23 additions, 49 deletions, net -26 lines
- Blacksmith Testbox `tbx_01kykx1zfna8q8kkmamkrn2wyd`: 39/39 focused board tests passed
- `pnpm check:changed`: passed on the same Testbox
- `git diff --check`: passed
- Autoreview: clean, correctness 0.99
- Full patch hash remained identical after rebasing onto current `origin/main`
