### PR TITLE
fix(plugins): keep bulk updates on the beta channel

### DIFF
--- a/docs/cli/plugins.md
+++ b/docs/cli/plugins.md
@@ -454,7 +454,7 @@ Updates apply to tracked plugin installs in the managed plugin index and tracked
 
   </Accordion>
   <Accordion title="Beta channel updates">
-    Targeted `openclaw plugins update <id-or-npm-spec>` reuses the tracked plugin spec unless you pass a new spec. Bulk `openclaw plugins update --all` uses the configured `update.channel` when it syncs trusted official plugin records to the official catalog target, so beta-channel installs can stay on the beta release line instead of being silently normalized to stable/latest.
+    Targeted `openclaw plugins update <id-or-npm-spec>` reuses the tracked plugin spec unless you pass a new spec. Bulk `openclaw plugins update --all` uses the canonical registry-channel resolver when it syncs trusted official plugin records to the official catalog target. An installed beta core therefore keeps official plugins on the beta release line when `update.channel` is unset, matching the core updater instead of silently normalizing them to stable/latest. Explicit `beta`, `dev`, and `extended-stable` selections retain their existing precedence.
 
     `openclaw update` also knows the active OpenClaw update channel: on the beta channel, default-line npm and ClawHub plugin records try `@beta` first. They fall back to the recorded default/latest spec if no plugin beta release exists; npm plugins also fall back when the beta package exists but fails install validation. That fallback is reported as a warning and does not fail the core update. Exact versions and explicit tags stay pinned to that selector for targeted updates.
 

--- a/docs/plugins/manage-plugins.md
+++ b/docs/plugins/manage-plugins.md
@@ -176,9 +176,11 @@ runs.
 `openclaw plugins update --all` is the bulk maintenance path. It still
 respects ordinary tracked install specs, but trusted official OpenClaw
 plugin records sync to the current official catalog target instead of
-staying pinned to a stale exact official package; when `update.channel` is
-`beta`, that sync prefers the beta release line. Use a targeted
-`update <plugin-id>` to keep an exact or tagged official spec untouched.
+staying pinned to a stale exact official package. The canonical channel
+resolver uses both `update.channel` and the installed core version, so an
+installed beta core with no configured channel keeps official plugins on the
+beta release line. Use a targeted `update <plugin-id>` to keep an exact or
+tagged official spec untouched.
 
 For npm installs, pass an explicit package spec to switch the tracked
 record:

--- a/src/cli/plugins-cli.update.test.ts
+++ b/src/cli/plugins-cli.update.test.ts
@@ -3,7 +3,9 @@ import path from "node:path";
 import { Command } from "commander";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
+import { resolveRegistryUpdateChannel } from "../infra/update-channels.js";
 import { CLAWHUB_INSTALL_ERROR_CODE } from "../plugins/clawhub-error-codes.js";
+import { VERSION } from "../version.js";
 import {
   loadConfig,
   notifyGatewayPluginMetadataChanged,
@@ -1187,6 +1189,28 @@ describe("plugins cli update", () => {
     expect(updateParams.syncOfficialPluginInstalls).toBe(true);
     expect(updateParams.officialPluginUpdateChannel).toBe("beta");
     expect(updateParams.updateChannel).toBeUndefined();
+  });
+
+  it("infers the official catalog channel from the installed core for update --all", async () => {
+    const config = createTrackedPluginConfig({
+      pluginId: "codex",
+      spec: "@openclaw/codex",
+      resolvedName: "@openclaw/codex",
+    });
+    loadConfig.mockReturnValue(config);
+    setInstalledPluginIndexInstallRecords(config.plugins?.installs ?? {});
+    updateNpmInstalledPlugins.mockResolvedValue({
+      config,
+      changed: false,
+      outcomes: [],
+    });
+
+    await runPluginsCommand(["plugins", "update", "--all"]);
+
+    const updateParams = expectSingleCallParams(updateNpmInstalledPlugins);
+    expect(updateParams.officialPluginUpdateChannel).toBe(
+      resolveRegistryUpdateChannel({ currentVersion: VERSION }),
+    );
   });
 
   it("passes extended-stable channel and installed core version to update --all", async () => {

--- a/src/cli/plugins-update-command.ts
+++ b/src/cli/plugins-update-command.ts
@@ -19,7 +19,7 @@ import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { PluginInstallRecord } from "../config/types.plugins.js";
 import { readHookInstalls } from "../hooks/installs.js";
 import { updateNpmInstalledHookPacks } from "../hooks/update.js";
-import { normalizeUpdateChannel } from "../infra/update-channels.js";
+import { normalizeUpdateChannel, resolveRegistryUpdateChannel } from "../infra/update-channels.js";
 import {
   containsConfigIncludeDirective,
   resolveCombinedPluginAndHookConfigMutationPreflight,
@@ -343,7 +343,10 @@ async function runPluginUpdateCommandUnlocked(params: RunPluginUpdateCommandPara
           specOverrides: pluginSelection.specOverrides,
           dryRun: params.opts.dryRun,
           officialPluginUpdateChannel: params.opts.all
-            ? (normalizeUpdateChannel(cfg.update?.channel) ?? undefined)
+            ? resolveRegistryUpdateChannel({
+                configChannel: normalizeUpdateChannel(cfg.update?.channel),
+                currentVersion: VERSION,
+              })
             : undefined,
           syncOfficialPluginInstalls: params.opts.all ? true : undefined,
           coreVersion: VERSION,


### PR DESCRIPTION
Closes #115081
Related: #96831, #94083, #84256

AI-assisted: yes. Maintainer-reviewed and repaired on the contributor branch.

## What Problem This Solves

Fixes an issue where operators running a beta OpenClaw release without an explicit `update.channel` could have `openclaw plugins update --all` select stable official plugin packages, recreating plugin/core version drift immediately after beta alignment.

## Why This Change Was Made

The bulk trusted-official path now uses the existing registry-channel resolver with both the configured channel and installed core version. An installed beta therefore keeps beta official packages when the channel is unset, matching the core updater. Existing explicit `beta`, `dev`, and `extended-stable` handling remains intact; targeted plugin updates, third-party packages, and exact/tagged targeted specs are unchanged.

The maintainer pass also updates the plugin-management docs so the documented bulk-update contract matches runtime behavior.

## User Impact

Beta operators can safely use `openclaw plugins update --all` without first writing an explicit channel setting. Stable installations remain on stable, extended-stable keeps its exact-core contract, and targeted updates retain their recorded selector.

## Evidence

Before the fix on OpenClaw `2026.7.2-beta.5`, the bulk dry run proposed downgrades such as:

```text
Would update codex: 2026.7.2-beta.5 -> 2026.7.1-1.
Would update discord: 2026.7.2-beta.5 -> 2026.7.1.
```

Exact-head real behavior proof ran in an isolated Blacksmith Testbox home against live npm metadata. It installed `@openclaw/codex@2026.7.2-beta.5`, left `update.channel` unset, then ran the patched bulk dry-run path:

```text
codex is up to date (2026.7.2-beta.5).
```

No `Would update codex:` downgrade was emitted.

Final reviewed head: `26bf0ea736089ef0ae45299bc8b8fce827942a86`
Frozen base: `efec26b2dfab49845b45edcdc47281f2574328a0`

Validation:

```text
pnpm test src/cli/plugins-cli.update.test.ts src/infra/update-channels.test.ts src/plugins/install-channel-specs.test.ts
Result: 98 passed

pnpm check:changed -- src/cli/plugins-update-command.ts src/cli/plugins-cli.update.test.ts docs/cli/plugins.md docs/plugins/manage-plugins.md
Result: passed (core/type/test typecheck, lint, dead exports, boundaries, guards)

pnpm docs:list
pnpm format:docs:check
pnpm format:check src/cli/plugins-update-command.ts src/cli/plugins-cli.update.test.ts docs/cli/plugins.md docs/plugins/manage-plugins.md
Result: passed

autoreview --mode branch --base efec26b2dfab49845b45edcdc47281f2574328a0
Result: clean; no accepted/actionable findings; TruffleHog clean
```

Final frozen-base Testbox smoke: https://github.com/openclaw/openclaw/actions/runs/30419839766