### PR TITLE
fix(gateway): reject invalid auth.rateLimit fields (maxAttempts/windowMs/lockoutMs)

### DIFF
--- a/src/commands/doctor/shared/legacy-config-migrate.test.ts
+++ b/src/commands/doctor/shared/legacy-config-migrate.test.ts
@@ -3470,14 +3470,39 @@ describe("gateway.auth.rateLimit out-of-range repair migrate", () => {
     ]);
   });
 
-  it("removes fractional gateway.auth.rateLimit.maxAttempts and records a change", () => {
+  it("normalizes a positive fractional gateway.auth.rateLimit.maxAttempts instead of removing it", () => {
+    // 2.5 currently locks on the 3rd failed attempt (resolveIntegerOption
+    // floors it to 2) -- deleting it would silently widen that to the
+    // default of 10, so normalize in place instead.
     const res = migrateLegacyConfigForTest({
       gateway: { auth: { rateLimit: { maxAttempts: 2.5 } } },
     });
 
     expect(res.changes).toStrictEqual([
-      "Removed invalid gateway.auth.rateLimit.maxAttempts (2.5). It must be a positive integer; the gateway will use the default of 10.",
+      "Raised gateway.auth.rateLimit.maxAttempts (2.5) to 2. It must be a positive integer.",
     ]);
+    expect(res.config?.gateway?.auth?.rateLimit).toStrictEqual({ maxAttempts: 2 });
+  });
+
+  it("normalizes a sub-1 positive fractional maxAttempts up to 1, not down to 0", () => {
+    const res = migrateLegacyConfigForTest({
+      gateway: { auth: { rateLimit: { maxAttempts: 0.5 } } },
+    });
+
+    expect(res.changes).toStrictEqual([
+      "Raised gateway.auth.rateLimit.maxAttempts (0.5) to 1. It must be a positive integer.",
+    ]);
+    expect(res.config?.gateway?.auth?.rateLimit).toStrictEqual({ maxAttempts: 1 });
+  });
+
+  it("is idempotent after normalizing a fractional maxAttempts", () => {
+    const first = migrateLegacyConfigForTest({
+      gateway: { auth: { rateLimit: { maxAttempts: 2.5 } } },
+    });
+    expect(first.changes.length).toBe(1);
+
+    const second = migrateLegacyConfigForTest(first.config);
+    expect(second.changes).toStrictEqual([]);
   });
 
   it("removes non-finite gateway.auth.rateLimit.maxAttempts and records a change", () => {
@@ -3496,6 +3521,15 @@ describe("gateway.auth.rateLimit out-of-range repair migrate", () => {
     });
 
     expect(res.config?.gateway?.auth?.rateLimit).toStrictEqual({ windowMs: 60_000 });
+  });
+
+  it("leaves a wrong-type gateway.auth.rateLimit.maxAttempts untouched (not this migration's concern)", () => {
+    const res = migrateLegacyConfigForTest({
+      gateway: { auth: { rateLimit: { maxAttempts: "5" } } },
+    });
+
+    expect(res.config).toBeNull();
+    expect(res.changes).toEqual([]);
   });
 
   it("preserves valid gateway.auth.rateLimit.maxAttempts values", () => {
@@ -3560,9 +3594,9 @@ describe("gateway.auth.rateLimit out-of-range repair migrate", () => {
   });
 
   it("still removes (not raises) a truly invalid windowMs/lockoutMs value", () => {
-    // Non-positive, fractional, or non-finite values have no sensible
-    // "raise to the floor" target -- these still delete+default.
-    for (const bad of [0, -1, 1.5, Number.NaN]) {
+    // Only non-positive or non-finite values have no sensible runtime-
+    // effective target to preserve -- these still delete+default.
+    for (const bad of [0, -1, Number.NaN]) {
       const res = migrateLegacyConfigForTest({
         gateway: { auth: { rateLimit: { windowMs: bad } } },
       });
@@ -3571,6 +3605,38 @@ describe("gateway.auth.rateLimit out-of-range repair migrate", () => {
       ]);
       expect(res.config).not.toHaveProperty("gateway");
     }
+  });
+
+  it("normalizes a positive fractional windowMs/lockoutMs instead of removing it", () => {
+    // 1000.5 currently behaves as 1000ms at runtime (resolveTimerTimeoutMs
+    // floors then clamps to the 1000ms floor) -- deleting it would silently
+    // lengthen it to the 60s/300s defaults, so normalize in place instead.
+    const windowRes = migrateLegacyConfigForTest({
+      gateway: { auth: { rateLimit: { windowMs: 1_000.5 } } },
+    });
+    expect(windowRes.changes).toStrictEqual([
+      "Raised gateway.auth.rateLimit.windowMs (1000.5) to 1000. It must be an integer of at least 1000ms.",
+    ]);
+    expect(windowRes.config?.gateway?.auth?.rateLimit).toStrictEqual({ windowMs: 1_000 });
+
+    // A sub-floor fractional value normalizes straight to the floor.
+    const lockoutRes = migrateLegacyConfigForTest({
+      gateway: { auth: { rateLimit: { lockoutMs: 500.7 } } },
+    });
+    expect(lockoutRes.changes).toStrictEqual([
+      "Raised gateway.auth.rateLimit.lockoutMs (500.7) to 1000. It must be an integer of at least 1000ms.",
+    ]);
+    expect(lockoutRes.config?.gateway?.auth?.rateLimit).toStrictEqual({ lockoutMs: 1_000 });
+  });
+
+  it("is idempotent after normalizing a fractional windowMs/lockoutMs", () => {
+    const first = migrateLegacyConfigForTest({
+      gateway: { auth: { rateLimit: { windowMs: 1_000.5, lockoutMs: 500.7 } } },
+    });
+    expect(first.changes.length).toBe(2);
+
+    const second = migrateLegacyConfigForTest(first.config);
+    expect(second.changes).toStrictEqual([]);
   });
 
   it("is idempotent after raising windowMs/lockoutMs to the floor", () => {
@@ -3599,10 +3665,10 @@ describe("gateway.auth.rateLimit out-of-range repair migrate", () => {
 
     expect(res.changes).toStrictEqual([
       "Removed invalid gateway.auth.rateLimit.maxAttempts (0). It must be a positive integer; the gateway will use the default of 10.",
-      "Removed invalid gateway.auth.rateLimit.windowMs (1.5). It must be an integer of at least 1000ms; the gateway will use the default of 60000.",
+      "Raised gateway.auth.rateLimit.windowMs (1.5) to 1000. It must be an integer of at least 1000ms.",
       "Removed invalid gateway.auth.rateLimit.lockoutMs (NaN). It must be an integer of at least 1000ms; the gateway will use the default of 300000.",
     ]);
-    expect(res.config).not.toHaveProperty("gateway");
+    expect(res.config?.gateway?.auth?.rateLimit).toStrictEqual({ windowMs: 1_000 });
   });
 
   it("preserves other auth keys when removing the whole rateLimit block", () => {

--- a/src/commands/doctor/shared/legacy-config-migrate.test.ts
+++ b/src/commands/doctor/shared/legacy-config-migrate.test.ts
@@ -3538,23 +3538,49 @@ describe("gateway.auth.rateLimit out-of-range repair migrate", () => {
     ]);
   });
 
-  it("removes a positive windowMs/lockoutMs below the 1000ms runtime floor", () => {
-    // 500 is a positive integer -- it previously passed the old "positive
-    // integer" migration check untouched, then got silently rewritten to
-    // 1000ms by the runtime clamp with no visible repair.
+  it("raises a positive windowMs/lockoutMs below the 1000ms floor instead of deleting it", () => {
+    // 500 is a positive integer the runtime would only clamp to 1000ms
+    // anyway -- normalize it in place rather than discarding the operator's
+    // shorter-duration intent for the much larger documented default.
     const windowRes = migrateLegacyConfigForTest({
       gateway: { auth: { rateLimit: { windowMs: 500 } } },
     });
     expect(windowRes.changes).toStrictEqual([
-      "Removed invalid gateway.auth.rateLimit.windowMs (500). It must be an integer of at least 1000ms; the gateway will use the default of 60000.",
+      "Raised gateway.auth.rateLimit.windowMs (500) to 1000. It must be an integer of at least 1000ms.",
     ]);
+    expect(windowRes.config?.gateway?.auth?.rateLimit).toStrictEqual({ windowMs: 1_000 });
 
     const lockoutRes = migrateLegacyConfigForTest({
       gateway: { auth: { rateLimit: { lockoutMs: 999 } } },
     });
     expect(lockoutRes.changes).toStrictEqual([
-      "Removed invalid gateway.auth.rateLimit.lockoutMs (999). It must be an integer of at least 1000ms; the gateway will use the default of 300000.",
+      "Raised gateway.auth.rateLimit.lockoutMs (999) to 1000. It must be an integer of at least 1000ms.",
     ]);
+    expect(lockoutRes.config?.gateway?.auth?.rateLimit).toStrictEqual({ lockoutMs: 1_000 });
+  });
+
+  it("still removes (not raises) a truly invalid windowMs/lockoutMs value", () => {
+    // Non-positive, fractional, or non-finite values have no sensible
+    // "raise to the floor" target -- these still delete+default.
+    for (const bad of [0, -1, 1.5, Number.NaN]) {
+      const res = migrateLegacyConfigForTest({
+        gateway: { auth: { rateLimit: { windowMs: bad } } },
+      });
+      expect(res.changes).toStrictEqual([
+        `Removed invalid gateway.auth.rateLimit.windowMs (${String(bad)}). It must be an integer of at least 1000ms; the gateway will use the default of 60000.`,
+      ]);
+      expect(res.config).not.toHaveProperty("gateway");
+    }
+  });
+
+  it("is idempotent after raising windowMs/lockoutMs to the floor", () => {
+    const first = migrateLegacyConfigForTest({
+      gateway: { auth: { rateLimit: { windowMs: 500, lockoutMs: 999 } } },
+    });
+    expect(first.changes.length).toBe(2);
+
+    const second = migrateLegacyConfigForTest(first.config);
+    expect(second.changes).toStrictEqual([]);
   });
 
   it("preserves gateway.auth.rateLimit.windowMs/lockoutMs values exactly at the 1000ms floor", () => {

--- a/src/commands/doctor/shared/legacy-config-migrate.test.ts
+++ b/src/commands/doctor/shared/legacy-config-migrate.test.ts
@@ -3523,7 +3523,7 @@ describe("gateway.auth.rateLimit out-of-range repair migrate", () => {
     });
 
     expect(res.changes).toStrictEqual([
-      "Removed invalid gateway.auth.rateLimit.windowMs (0). It must be a positive integer; the gateway will use the default of 60000.",
+      "Removed invalid gateway.auth.rateLimit.windowMs (0). It must be an integer of at least 1000ms; the gateway will use the default of 60000.",
     ]);
     expect(res.config).not.toHaveProperty("gateway");
   });
@@ -3534,8 +3534,36 @@ describe("gateway.auth.rateLimit out-of-range repair migrate", () => {
     });
 
     expect(res.changes).toStrictEqual([
-      "Removed invalid gateway.auth.rateLimit.lockoutMs (-1). It must be a positive integer; the gateway will use the default of 300000.",
+      "Removed invalid gateway.auth.rateLimit.lockoutMs (-1). It must be an integer of at least 1000ms; the gateway will use the default of 300000.",
     ]);
+  });
+
+  it("removes a positive windowMs/lockoutMs below the 1000ms runtime floor", () => {
+    // 500 is a positive integer -- it previously passed the old "positive
+    // integer" migration check untouched, then got silently rewritten to
+    // 1000ms by the runtime clamp with no visible repair.
+    const windowRes = migrateLegacyConfigForTest({
+      gateway: { auth: { rateLimit: { windowMs: 500 } } },
+    });
+    expect(windowRes.changes).toStrictEqual([
+      "Removed invalid gateway.auth.rateLimit.windowMs (500). It must be an integer of at least 1000ms; the gateway will use the default of 60000.",
+    ]);
+
+    const lockoutRes = migrateLegacyConfigForTest({
+      gateway: { auth: { rateLimit: { lockoutMs: 999 } } },
+    });
+    expect(lockoutRes.changes).toStrictEqual([
+      "Removed invalid gateway.auth.rateLimit.lockoutMs (999). It must be an integer of at least 1000ms; the gateway will use the default of 300000.",
+    ]);
+  });
+
+  it("preserves gateway.auth.rateLimit.windowMs/lockoutMs values exactly at the 1000ms floor", () => {
+    const res = migrateLegacyConfigForTest({
+      gateway: { auth: { rateLimit: { windowMs: 1_000, lockoutMs: 1_000 } } },
+    });
+
+    expect(res.config).toBeNull();
+    expect(res.changes).toEqual([]);
   });
 
   it("removes multiple invalid fields in one pass and records a change per field", () => {
@@ -3545,8 +3573,8 @@ describe("gateway.auth.rateLimit out-of-range repair migrate", () => {
 
     expect(res.changes).toStrictEqual([
       "Removed invalid gateway.auth.rateLimit.maxAttempts (0). It must be a positive integer; the gateway will use the default of 10.",
-      "Removed invalid gateway.auth.rateLimit.windowMs (1.5). It must be a positive integer; the gateway will use the default of 60000.",
-      "Removed invalid gateway.auth.rateLimit.lockoutMs (NaN). It must be a positive integer; the gateway will use the default of 300000.",
+      "Removed invalid gateway.auth.rateLimit.windowMs (1.5). It must be an integer of at least 1000ms; the gateway will use the default of 60000.",
+      "Removed invalid gateway.auth.rateLimit.lockoutMs (NaN). It must be an integer of at least 1000ms; the gateway will use the default of 300000.",
     ]);
     expect(res.config).not.toHaveProperty("gateway");
   });

--- a/src/commands/doctor/shared/legacy-config-migrate.test.ts
+++ b/src/commands/doctor/shared/legacy-config-migrate.test.ts
@@ -3448,6 +3448,76 @@ describe("gateway.port out-of-range repair migrate", () => {
   });
 });
 
+describe("gateway.auth.rateLimit.maxAttempts out-of-range repair migrate", () => {
+  it("removes non-positive gateway.auth.rateLimit.maxAttempts and records a change", () => {
+    const res = migrateLegacyConfigForTest({
+      gateway: { auth: { rateLimit: { maxAttempts: 0 } } },
+    });
+
+    expect(res.changes).toStrictEqual([
+      "Removed invalid gateway.auth.rateLimit.maxAttempts (0). It must be a positive integer; the gateway will use the default of 10 attempts.",
+    ]);
+    expect(res.config?.gateway?.auth?.rateLimit).toStrictEqual({});
+  });
+
+  it("removes negative gateway.auth.rateLimit.maxAttempts and records a change", () => {
+    const res = migrateLegacyConfigForTest({
+      gateway: { auth: { rateLimit: { maxAttempts: -1 } } },
+    });
+
+    expect(res.changes).toStrictEqual([
+      "Removed invalid gateway.auth.rateLimit.maxAttempts (-1). It must be a positive integer; the gateway will use the default of 10 attempts.",
+    ]);
+  });
+
+  it("removes fractional gateway.auth.rateLimit.maxAttempts and records a change", () => {
+    const res = migrateLegacyConfigForTest({
+      gateway: { auth: { rateLimit: { maxAttempts: 2.5 } } },
+    });
+
+    expect(res.changes).toStrictEqual([
+      "Removed invalid gateway.auth.rateLimit.maxAttempts (2.5). It must be a positive integer; the gateway will use the default of 10 attempts.",
+    ]);
+  });
+
+  it("removes non-finite gateway.auth.rateLimit.maxAttempts and records a change", () => {
+    const res = migrateLegacyConfigForTest({
+      gateway: { auth: { rateLimit: { maxAttempts: Number.NaN } } },
+    });
+
+    expect(res.changes).toStrictEqual([
+      "Removed invalid gateway.auth.rateLimit.maxAttempts (NaN). It must be a positive integer; the gateway will use the default of 10 attempts.",
+    ]);
+  });
+
+  it("preserves other gateway.auth.rateLimit keys when removing maxAttempts", () => {
+    const res = migrateLegacyConfigForTest({
+      gateway: { auth: { rateLimit: { maxAttempts: 0, windowMs: 60_000 } } },
+    });
+
+    expect(res.config?.gateway?.auth?.rateLimit).toStrictEqual({ windowMs: 60_000 });
+  });
+
+  it("preserves valid gateway.auth.rateLimit.maxAttempts values", () => {
+    const res = migrateLegacyConfigForTest({
+      gateway: { auth: { rateLimit: { maxAttempts: 5 } } },
+    });
+
+    expect(res.config).toBeNull();
+    expect(res.changes).toEqual([]);
+  });
+
+  it("is idempotent for out-of-range values", () => {
+    const first = migrateLegacyConfigForTest({
+      gateway: { auth: { rateLimit: { maxAttempts: 0 } } },
+    });
+    expect(first.changes.length).toBe(1);
+
+    const second = migrateLegacyConfigForTest(first.config);
+    expect(second.changes).toStrictEqual([]);
+  });
+});
+
 describe("legacy model compat migrate", () => {
   it("upgrades the retired xAI quality image slug without pinning active aliases", () => {
     const raw = {

--- a/src/commands/doctor/shared/legacy-config-migrate.test.ts
+++ b/src/commands/doctor/shared/legacy-config-migrate.test.ts
@@ -3448,16 +3448,16 @@ describe("gateway.port out-of-range repair migrate", () => {
   });
 });
 
-describe("gateway.auth.rateLimit.maxAttempts out-of-range repair migrate", () => {
+describe("gateway.auth.rateLimit out-of-range repair migrate", () => {
   it("removes non-positive gateway.auth.rateLimit.maxAttempts and records a change", () => {
     const res = migrateLegacyConfigForTest({
       gateway: { auth: { rateLimit: { maxAttempts: 0 } } },
     });
 
     expect(res.changes).toStrictEqual([
-      "Removed invalid gateway.auth.rateLimit.maxAttempts (0). It must be a positive integer; the gateway will use the default of 10 attempts.",
+      "Removed invalid gateway.auth.rateLimit.maxAttempts (0). It must be a positive integer; the gateway will use the default of 10.",
     ]);
-    expect(res.config?.gateway?.auth?.rateLimit).toStrictEqual({});
+    expect(res.config).not.toHaveProperty("gateway");
   });
 
   it("removes negative gateway.auth.rateLimit.maxAttempts and records a change", () => {
@@ -3466,7 +3466,7 @@ describe("gateway.auth.rateLimit.maxAttempts out-of-range repair migrate", () =>
     });
 
     expect(res.changes).toStrictEqual([
-      "Removed invalid gateway.auth.rateLimit.maxAttempts (-1). It must be a positive integer; the gateway will use the default of 10 attempts.",
+      "Removed invalid gateway.auth.rateLimit.maxAttempts (-1). It must be a positive integer; the gateway will use the default of 10.",
     ]);
   });
 
@@ -3476,7 +3476,7 @@ describe("gateway.auth.rateLimit.maxAttempts out-of-range repair migrate", () =>
     });
 
     expect(res.changes).toStrictEqual([
-      "Removed invalid gateway.auth.rateLimit.maxAttempts (2.5). It must be a positive integer; the gateway will use the default of 10 attempts.",
+      "Removed invalid gateway.auth.rateLimit.maxAttempts (2.5). It must be a positive integer; the gateway will use the default of 10.",
     ]);
   });
 
@@ -3486,7 +3486,7 @@ describe("gateway.auth.rateLimit.maxAttempts out-of-range repair migrate", () =>
     });
 
     expect(res.changes).toStrictEqual([
-      "Removed invalid gateway.auth.rateLimit.maxAttempts (NaN). It must be a positive integer; the gateway will use the default of 10 attempts.",
+      "Removed invalid gateway.auth.rateLimit.maxAttempts (NaN). It must be a positive integer; the gateway will use the default of 10.",
     ]);
   });
 
@@ -3515,6 +3515,57 @@ describe("gateway.auth.rateLimit.maxAttempts out-of-range repair migrate", () =>
 
     const second = migrateLegacyConfigForTest(first.config);
     expect(second.changes).toStrictEqual([]);
+  });
+
+  it("removes non-positive gateway.auth.rateLimit.windowMs and records a change", () => {
+    const res = migrateLegacyConfigForTest({
+      gateway: { auth: { rateLimit: { windowMs: 0 } } },
+    });
+
+    expect(res.changes).toStrictEqual([
+      "Removed invalid gateway.auth.rateLimit.windowMs (0). It must be a positive integer; the gateway will use the default of 60000.",
+    ]);
+    expect(res.config).not.toHaveProperty("gateway");
+  });
+
+  it("removes non-positive gateway.auth.rateLimit.lockoutMs and records a change", () => {
+    const res = migrateLegacyConfigForTest({
+      gateway: { auth: { rateLimit: { lockoutMs: -1 } } },
+    });
+
+    expect(res.changes).toStrictEqual([
+      "Removed invalid gateway.auth.rateLimit.lockoutMs (-1). It must be a positive integer; the gateway will use the default of 300000.",
+    ]);
+  });
+
+  it("removes multiple invalid fields in one pass and records a change per field", () => {
+    const res = migrateLegacyConfigForTest({
+      gateway: { auth: { rateLimit: { maxAttempts: 0, windowMs: 1.5, lockoutMs: Number.NaN } } },
+    });
+
+    expect(res.changes).toStrictEqual([
+      "Removed invalid gateway.auth.rateLimit.maxAttempts (0). It must be a positive integer; the gateway will use the default of 10.",
+      "Removed invalid gateway.auth.rateLimit.windowMs (1.5). It must be a positive integer; the gateway will use the default of 60000.",
+      "Removed invalid gateway.auth.rateLimit.lockoutMs (NaN). It must be a positive integer; the gateway will use the default of 300000.",
+    ]);
+    expect(res.config).not.toHaveProperty("gateway");
+  });
+
+  it("preserves other auth keys when removing the whole rateLimit block", () => {
+    const res = migrateLegacyConfigForTest({
+      gateway: { auth: { mode: "token", rateLimit: { windowMs: 0 } } },
+    });
+
+    expect(res.config?.gateway).toEqual({ auth: { mode: "token" } });
+  });
+
+  it("preserves valid gateway.auth.rateLimit.windowMs and lockoutMs values", () => {
+    const res = migrateLegacyConfigForTest({
+      gateway: { auth: { rateLimit: { windowMs: 30_000, lockoutMs: 120_000 } } },
+    });
+
+    expect(res.config).toBeNull();
+    expect(res.changes).toEqual([]);
   });
 });
 

--- a/src/commands/doctor/shared/legacy-config-migrate.test.ts
+++ b/src/commands/doctor/shared/legacy-config-migrate.test.ts
@@ -3274,23 +3274,49 @@ describe("gateway.auth.rateLimit out-of-range repair migrate", () => {
     ]);
   });
 
-  it("removes a positive windowMs/lockoutMs below the 1000ms runtime floor", () => {
-    // 500 is a positive integer -- it previously passed the old "positive
-    // integer" migration check untouched, then got silently rewritten to
-    // 1000ms by the runtime clamp with no visible repair.
+  it("raises a positive windowMs/lockoutMs below the 1000ms floor instead of deleting it", () => {
+    // 500 is a positive integer the runtime would only clamp to 1000ms
+    // anyway -- normalize it in place rather than discarding the operator's
+    // shorter-duration intent for the much larger documented default.
     const windowRes = migrateLegacyConfigForTest({
       gateway: { auth: { rateLimit: { windowMs: 500 } } },
     });
     expect(windowRes.changes).toStrictEqual([
-      "Removed invalid gateway.auth.rateLimit.windowMs (500). It must be an integer of at least 1000ms; the gateway will use the default of 60000.",
+      "Raised gateway.auth.rateLimit.windowMs (500) to 1000. It must be an integer of at least 1000ms.",
     ]);
+    expect(windowRes.config?.gateway?.auth?.rateLimit).toStrictEqual({ windowMs: 1_000 });
 
     const lockoutRes = migrateLegacyConfigForTest({
       gateway: { auth: { rateLimit: { lockoutMs: 999 } } },
     });
     expect(lockoutRes.changes).toStrictEqual([
-      "Removed invalid gateway.auth.rateLimit.lockoutMs (999). It must be an integer of at least 1000ms; the gateway will use the default of 300000.",
+      "Raised gateway.auth.rateLimit.lockoutMs (999) to 1000. It must be an integer of at least 1000ms.",
     ]);
+    expect(lockoutRes.config?.gateway?.auth?.rateLimit).toStrictEqual({ lockoutMs: 1_000 });
+  });
+
+  it("still removes (not raises) a truly invalid windowMs/lockoutMs value", () => {
+    // Non-positive, fractional, or non-finite values have no sensible
+    // "raise to the floor" target -- these still delete+default.
+    for (const bad of [0, -1, 1.5, Number.NaN]) {
+      const res = migrateLegacyConfigForTest({
+        gateway: { auth: { rateLimit: { windowMs: bad } } },
+      });
+      expect(res.changes).toStrictEqual([
+        `Removed invalid gateway.auth.rateLimit.windowMs (${String(bad)}). It must be an integer of at least 1000ms; the gateway will use the default of 60000.`,
+      ]);
+      expect(res.config).not.toHaveProperty("gateway");
+    }
+  });
+
+  it("is idempotent after raising windowMs/lockoutMs to the floor", () => {
+    const first = migrateLegacyConfigForTest({
+      gateway: { auth: { rateLimit: { windowMs: 500, lockoutMs: 999 } } },
+    });
+    expect(first.changes.length).toBe(2);
+
+    const second = migrateLegacyConfigForTest(first.config);
+    expect(second.changes).toStrictEqual([]);
   });
 
   it("preserves gateway.auth.rateLimit.windowMs/lockoutMs values exactly at the 1000ms floor", () => {

--- a/src/commands/doctor/shared/legacy-config-migrate.test.ts
+++ b/src/commands/doctor/shared/legacy-config-migrate.test.ts
@@ -3259,7 +3259,7 @@ describe("gateway.auth.rateLimit out-of-range repair migrate", () => {
     });
 
     expect(res.changes).toStrictEqual([
-      "Removed invalid gateway.auth.rateLimit.windowMs (0). It must be a positive integer; the gateway will use the default of 60000.",
+      "Removed invalid gateway.auth.rateLimit.windowMs (0). It must be an integer of at least 1000ms; the gateway will use the default of 60000.",
     ]);
     expect(res.config).not.toHaveProperty("gateway");
   });
@@ -3270,8 +3270,36 @@ describe("gateway.auth.rateLimit out-of-range repair migrate", () => {
     });
 
     expect(res.changes).toStrictEqual([
-      "Removed invalid gateway.auth.rateLimit.lockoutMs (-1). It must be a positive integer; the gateway will use the default of 300000.",
+      "Removed invalid gateway.auth.rateLimit.lockoutMs (-1). It must be an integer of at least 1000ms; the gateway will use the default of 300000.",
     ]);
+  });
+
+  it("removes a positive windowMs/lockoutMs below the 1000ms runtime floor", () => {
+    // 500 is a positive integer -- it previously passed the old "positive
+    // integer" migration check untouched, then got silently rewritten to
+    // 1000ms by the runtime clamp with no visible repair.
+    const windowRes = migrateLegacyConfigForTest({
+      gateway: { auth: { rateLimit: { windowMs: 500 } } },
+    });
+    expect(windowRes.changes).toStrictEqual([
+      "Removed invalid gateway.auth.rateLimit.windowMs (500). It must be an integer of at least 1000ms; the gateway will use the default of 60000.",
+    ]);
+
+    const lockoutRes = migrateLegacyConfigForTest({
+      gateway: { auth: { rateLimit: { lockoutMs: 999 } } },
+    });
+    expect(lockoutRes.changes).toStrictEqual([
+      "Removed invalid gateway.auth.rateLimit.lockoutMs (999). It must be an integer of at least 1000ms; the gateway will use the default of 300000.",
+    ]);
+  });
+
+  it("preserves gateway.auth.rateLimit.windowMs/lockoutMs values exactly at the 1000ms floor", () => {
+    const res = migrateLegacyConfigForTest({
+      gateway: { auth: { rateLimit: { windowMs: 1_000, lockoutMs: 1_000 } } },
+    });
+
+    expect(res.config).toBeNull();
+    expect(res.changes).toEqual([]);
   });
 
   it("removes multiple invalid fields in one pass and records a change per field", () => {
@@ -3281,8 +3309,8 @@ describe("gateway.auth.rateLimit out-of-range repair migrate", () => {
 
     expect(res.changes).toStrictEqual([
       "Removed invalid gateway.auth.rateLimit.maxAttempts (0). It must be a positive integer; the gateway will use the default of 10.",
-      "Removed invalid gateway.auth.rateLimit.windowMs (1.5). It must be a positive integer; the gateway will use the default of 60000.",
-      "Removed invalid gateway.auth.rateLimit.lockoutMs (NaN). It must be a positive integer; the gateway will use the default of 300000.",
+      "Removed invalid gateway.auth.rateLimit.windowMs (1.5). It must be an integer of at least 1000ms; the gateway will use the default of 60000.",
+      "Removed invalid gateway.auth.rateLimit.lockoutMs (NaN). It must be an integer of at least 1000ms; the gateway will use the default of 300000.",
     ]);
     expect(res.config).not.toHaveProperty("gateway");
   });

--- a/src/commands/doctor/shared/legacy-config-migrate.test.ts
+++ b/src/commands/doctor/shared/legacy-config-migrate.test.ts
@@ -3184,6 +3184,76 @@ describe("gateway.port out-of-range repair migrate", () => {
   });
 });
 
+describe("gateway.auth.rateLimit.maxAttempts out-of-range repair migrate", () => {
+  it("removes non-positive gateway.auth.rateLimit.maxAttempts and records a change", () => {
+    const res = migrateLegacyConfigForTest({
+      gateway: { auth: { rateLimit: { maxAttempts: 0 } } },
+    });
+
+    expect(res.changes).toStrictEqual([
+      "Removed invalid gateway.auth.rateLimit.maxAttempts (0). It must be a positive integer; the gateway will use the default of 10 attempts.",
+    ]);
+    expect(res.config?.gateway?.auth?.rateLimit).toStrictEqual({});
+  });
+
+  it("removes negative gateway.auth.rateLimit.maxAttempts and records a change", () => {
+    const res = migrateLegacyConfigForTest({
+      gateway: { auth: { rateLimit: { maxAttempts: -1 } } },
+    });
+
+    expect(res.changes).toStrictEqual([
+      "Removed invalid gateway.auth.rateLimit.maxAttempts (-1). It must be a positive integer; the gateway will use the default of 10 attempts.",
+    ]);
+  });
+
+  it("removes fractional gateway.auth.rateLimit.maxAttempts and records a change", () => {
+    const res = migrateLegacyConfigForTest({
+      gateway: { auth: { rateLimit: { maxAttempts: 2.5 } } },
+    });
+
+    expect(res.changes).toStrictEqual([
+      "Removed invalid gateway.auth.rateLimit.maxAttempts (2.5). It must be a positive integer; the gateway will use the default of 10 attempts.",
+    ]);
+  });
+
+  it("removes non-finite gateway.auth.rateLimit.maxAttempts and records a change", () => {
+    const res = migrateLegacyConfigForTest({
+      gateway: { auth: { rateLimit: { maxAttempts: Number.NaN } } },
+    });
+
+    expect(res.changes).toStrictEqual([
+      "Removed invalid gateway.auth.rateLimit.maxAttempts (NaN). It must be a positive integer; the gateway will use the default of 10 attempts.",
+    ]);
+  });
+
+  it("preserves other gateway.auth.rateLimit keys when removing maxAttempts", () => {
+    const res = migrateLegacyConfigForTest({
+      gateway: { auth: { rateLimit: { maxAttempts: 0, windowMs: 60_000 } } },
+    });
+
+    expect(res.config?.gateway?.auth?.rateLimit).toStrictEqual({ windowMs: 60_000 });
+  });
+
+  it("preserves valid gateway.auth.rateLimit.maxAttempts values", () => {
+    const res = migrateLegacyConfigForTest({
+      gateway: { auth: { rateLimit: { maxAttempts: 5 } } },
+    });
+
+    expect(res.config).toBeNull();
+    expect(res.changes).toEqual([]);
+  });
+
+  it("is idempotent for out-of-range values", () => {
+    const first = migrateLegacyConfigForTest({
+      gateway: { auth: { rateLimit: { maxAttempts: 0 } } },
+    });
+    expect(first.changes.length).toBe(1);
+
+    const second = migrateLegacyConfigForTest(first.config);
+    expect(second.changes).toStrictEqual([]);
+  });
+});
+
 describe("legacy model compat migrate", () => {
   it("upgrades the retired xAI quality image slug without pinning active aliases", () => {
     const raw = {

--- a/src/commands/doctor/shared/legacy-config-migrate.test.ts
+++ b/src/commands/doctor/shared/legacy-config-migrate.test.ts
@@ -3184,16 +3184,16 @@ describe("gateway.port out-of-range repair migrate", () => {
   });
 });
 
-describe("gateway.auth.rateLimit.maxAttempts out-of-range repair migrate", () => {
+describe("gateway.auth.rateLimit out-of-range repair migrate", () => {
   it("removes non-positive gateway.auth.rateLimit.maxAttempts and records a change", () => {
     const res = migrateLegacyConfigForTest({
       gateway: { auth: { rateLimit: { maxAttempts: 0 } } },
     });
 
     expect(res.changes).toStrictEqual([
-      "Removed invalid gateway.auth.rateLimit.maxAttempts (0). It must be a positive integer; the gateway will use the default of 10 attempts.",
+      "Removed invalid gateway.auth.rateLimit.maxAttempts (0). It must be a positive integer; the gateway will use the default of 10.",
     ]);
-    expect(res.config?.gateway?.auth?.rateLimit).toStrictEqual({});
+    expect(res.config).not.toHaveProperty("gateway");
   });
 
   it("removes negative gateway.auth.rateLimit.maxAttempts and records a change", () => {
@@ -3202,7 +3202,7 @@ describe("gateway.auth.rateLimit.maxAttempts out-of-range repair migrate", () =>
     });
 
     expect(res.changes).toStrictEqual([
-      "Removed invalid gateway.auth.rateLimit.maxAttempts (-1). It must be a positive integer; the gateway will use the default of 10 attempts.",
+      "Removed invalid gateway.auth.rateLimit.maxAttempts (-1). It must be a positive integer; the gateway will use the default of 10.",
     ]);
   });
 
@@ -3212,7 +3212,7 @@ describe("gateway.auth.rateLimit.maxAttempts out-of-range repair migrate", () =>
     });
 
     expect(res.changes).toStrictEqual([
-      "Removed invalid gateway.auth.rateLimit.maxAttempts (2.5). It must be a positive integer; the gateway will use the default of 10 attempts.",
+      "Removed invalid gateway.auth.rateLimit.maxAttempts (2.5). It must be a positive integer; the gateway will use the default of 10.",
     ]);
   });
 
@@ -3222,7 +3222,7 @@ describe("gateway.auth.rateLimit.maxAttempts out-of-range repair migrate", () =>
     });
 
     expect(res.changes).toStrictEqual([
-      "Removed invalid gateway.auth.rateLimit.maxAttempts (NaN). It must be a positive integer; the gateway will use the default of 10 attempts.",
+      "Removed invalid gateway.auth.rateLimit.maxAttempts (NaN). It must be a positive integer; the gateway will use the default of 10.",
     ]);
   });
 
@@ -3251,6 +3251,57 @@ describe("gateway.auth.rateLimit.maxAttempts out-of-range repair migrate", () =>
 
     const second = migrateLegacyConfigForTest(first.config);
     expect(second.changes).toStrictEqual([]);
+  });
+
+  it("removes non-positive gateway.auth.rateLimit.windowMs and records a change", () => {
+    const res = migrateLegacyConfigForTest({
+      gateway: { auth: { rateLimit: { windowMs: 0 } } },
+    });
+
+    expect(res.changes).toStrictEqual([
+      "Removed invalid gateway.auth.rateLimit.windowMs (0). It must be a positive integer; the gateway will use the default of 60000.",
+    ]);
+    expect(res.config).not.toHaveProperty("gateway");
+  });
+
+  it("removes non-positive gateway.auth.rateLimit.lockoutMs and records a change", () => {
+    const res = migrateLegacyConfigForTest({
+      gateway: { auth: { rateLimit: { lockoutMs: -1 } } },
+    });
+
+    expect(res.changes).toStrictEqual([
+      "Removed invalid gateway.auth.rateLimit.lockoutMs (-1). It must be a positive integer; the gateway will use the default of 300000.",
+    ]);
+  });
+
+  it("removes multiple invalid fields in one pass and records a change per field", () => {
+    const res = migrateLegacyConfigForTest({
+      gateway: { auth: { rateLimit: { maxAttempts: 0, windowMs: 1.5, lockoutMs: Number.NaN } } },
+    });
+
+    expect(res.changes).toStrictEqual([
+      "Removed invalid gateway.auth.rateLimit.maxAttempts (0). It must be a positive integer; the gateway will use the default of 10.",
+      "Removed invalid gateway.auth.rateLimit.windowMs (1.5). It must be a positive integer; the gateway will use the default of 60000.",
+      "Removed invalid gateway.auth.rateLimit.lockoutMs (NaN). It must be a positive integer; the gateway will use the default of 300000.",
+    ]);
+    expect(res.config).not.toHaveProperty("gateway");
+  });
+
+  it("preserves other auth keys when removing the whole rateLimit block", () => {
+    const res = migrateLegacyConfigForTest({
+      gateway: { auth: { mode: "token", rateLimit: { windowMs: 0 } } },
+    });
+
+    expect(res.config?.gateway).toEqual({ auth: { mode: "token" } });
+  });
+
+  it("preserves valid gateway.auth.rateLimit.windowMs and lockoutMs values", () => {
+    const res = migrateLegacyConfigForTest({
+      gateway: { auth: { rateLimit: { windowMs: 30_000, lockoutMs: 120_000 } } },
+    });
+
+    expect(res.config).toBeNull();
+    expect(res.changes).toEqual([]);
   });
 });
 

--- a/src/commands/doctor/shared/legacy-config-migrations.runtime.gateway.ts
+++ b/src/commands/doctor/shared/legacy-config-migrations.runtime.gateway.ts
@@ -35,6 +35,14 @@ function isBelowDurationFloorConfigValue(value: unknown): boolean {
   );
 }
 
+// A persisted positive integer below the floor (e.g. windowMs: 500) is a
+// currently-accepted setting the runtime would only floor to 1000ms anyway --
+// raise it in place instead of discarding the operator's shorter-duration
+// intent for the much larger documented default.
+function isPositiveIntegerConfigValue(value: unknown): boolean {
+  return typeof value === "number" && Number.isInteger(value) && value > 0;
+}
+
 const GATEWAY_AUTH_RATE_LIMIT_MAX_ATTEMPTS_OOB_RULE: LegacyConfigRule = {
   path: ["gateway", "auth", "rateLimit", "maxAttempts"],
   message:
@@ -45,14 +53,14 @@ const GATEWAY_AUTH_RATE_LIMIT_MAX_ATTEMPTS_OOB_RULE: LegacyConfigRule = {
 const GATEWAY_AUTH_RATE_LIMIT_WINDOW_MS_OOB_RULE: LegacyConfigRule = {
   path: ["gateway", "auth", "rateLimit", "windowMs"],
   message:
-    'gateway.auth.rateLimit.windowMs must be an integer of at least 1000ms and will be removed to avoid startup failure. Run "openclaw doctor --fix".',
+    'gateway.auth.rateLimit.windowMs must be an integer of at least 1000ms; a smaller positive integer will be raised to 1000ms, other invalid values will be removed. Run "openclaw doctor --fix".',
   match: isBelowDurationFloorConfigValue,
 };
 
 const GATEWAY_AUTH_RATE_LIMIT_LOCKOUT_MS_OOB_RULE: LegacyConfigRule = {
   path: ["gateway", "auth", "rateLimit", "lockoutMs"],
   message:
-    'gateway.auth.rateLimit.lockoutMs must be an integer of at least 1000ms and will be removed to avoid startup failure. Run "openclaw doctor --fix".',
+    'gateway.auth.rateLimit.lockoutMs must be an integer of at least 1000ms; a smaller positive integer will be raised to 1000ms, other invalid values will be removed. Run "openclaw doctor --fix".',
   match: isBelowDurationFloorConfigValue,
 };
 
@@ -246,6 +254,10 @@ export const LEGACY_CONFIG_MIGRATIONS_RUNTIME_GATEWAY: LegacyConfigMigrationSpec
         fallback: number;
         isInvalid: (value: unknown) => boolean;
         requirement: string;
+        // Duration fields only: a positive integer below this floor is
+        // raised in place instead of deleted+defaulted (see
+        // isPositiveIntegerConfigValue above).
+        floorMs?: number;
       }> = [
         {
           key: "maxAttempts",
@@ -258,16 +270,26 @@ export const LEGACY_CONFIG_MIGRATIONS_RUNTIME_GATEWAY: LegacyConfigMigrationSpec
           fallback: DEFAULT_WINDOW_MS,
           isInvalid: isBelowDurationFloorConfigValue,
           requirement: `an integer of at least ${GATEWAY_AUTH_RATE_LIMIT_DURATION_FLOOR_MS}ms`,
+          floorMs: GATEWAY_AUTH_RATE_LIMIT_DURATION_FLOOR_MS,
         },
         {
           key: "lockoutMs",
           fallback: DEFAULT_LOCKOUT_MS,
           isInvalid: isBelowDurationFloorConfigValue,
           requirement: `an integer of at least ${GATEWAY_AUTH_RATE_LIMIT_DURATION_FLOOR_MS}ms`,
+          floorMs: GATEWAY_AUTH_RATE_LIMIT_DURATION_FLOOR_MS,
         },
       ];
-      for (const { key, fallback, isInvalid, requirement } of repairs) {
+      for (const { key, fallback, isInvalid, requirement, floorMs } of repairs) {
         const value = rateLimit[key];
+        if (floorMs !== undefined && isPositiveIntegerConfigValue(value) && value < floorMs) {
+          rateLimit[key] = floorMs;
+          changes.push(
+            `Raised gateway.auth.rateLimit.${key} (${String(value)}) to ${floorMs}. ` +
+              `It must be ${requirement}.`,
+          );
+          continue;
+        }
         if (!isInvalid(value)) {
           continue;
         }

--- a/src/commands/doctor/shared/legacy-config-migrations.runtime.gateway.ts
+++ b/src/commands/doctor/shared/legacy-config-migrations.runtime.gateway.ts
@@ -13,13 +13,35 @@ import {
   type LegacyConfigRule,
 } from "../../../config/legacy.shared.js";
 import { DEFAULT_GATEWAY_PORT } from "../../../config/paths.js";
-import { DEFAULT_MAX_ATTEMPTS } from "../../../gateway/auth-rate-limit.js";
+import {
+  DEFAULT_LOCKOUT_MS,
+  DEFAULT_MAX_ATTEMPTS,
+  DEFAULT_WINDOW_MS,
+} from "../../../gateway/auth-rate-limit.js";
+
+function isNonPositiveIntegerConfigValue(value: unknown): boolean {
+  return typeof value === "number" && (!Number.isInteger(value) || value <= 0);
+}
 
 const GATEWAY_AUTH_RATE_LIMIT_MAX_ATTEMPTS_OOB_RULE: LegacyConfigRule = {
   path: ["gateway", "auth", "rateLimit", "maxAttempts"],
   message:
     'gateway.auth.rateLimit.maxAttempts must be a positive integer and will be removed to avoid startup failure. Run "openclaw doctor --fix".',
-  match: (value) => typeof value === "number" && (!Number.isInteger(value) || value <= 0),
+  match: isNonPositiveIntegerConfigValue,
+};
+
+const GATEWAY_AUTH_RATE_LIMIT_WINDOW_MS_OOB_RULE: LegacyConfigRule = {
+  path: ["gateway", "auth", "rateLimit", "windowMs"],
+  message:
+    'gateway.auth.rateLimit.windowMs must be a positive integer and will be removed to avoid startup failure. Run "openclaw doctor --fix".',
+  match: isNonPositiveIntegerConfigValue,
+};
+
+const GATEWAY_AUTH_RATE_LIMIT_LOCKOUT_MS_OOB_RULE: LegacyConfigRule = {
+  path: ["gateway", "auth", "rateLimit", "lockoutMs"],
+  message:
+    'gateway.auth.rateLimit.lockoutMs must be a positive integer and will be removed to avoid startup failure. Run "openclaw doctor --fix".',
+  match: isNonPositiveIntegerConfigValue,
 };
 
 const GATEWAY_PORT_OOB_RULE: LegacyConfigRule = {
@@ -192,26 +214,52 @@ export const LEGACY_CONFIG_MIGRATIONS_RUNTIME_GATEWAY: LegacyConfigMigrationSpec
     },
   }),
   defineLegacyConfigMigration({
-    id: "gateway.auth.rateLimit.max-attempts-oob-repair",
+    id: "gateway.auth.rateLimit-oob-repair",
     describe:
-      "Remove non-positive-integer gateway.auth.rateLimit.maxAttempts to avoid post-schema-tightening startup failures",
-    legacyRules: [GATEWAY_AUTH_RATE_LIMIT_MAX_ATTEMPTS_OOB_RULE],
+      "Remove non-positive-integer gateway.auth.rateLimit fields to avoid post-schema-tightening startup failures",
+    legacyRules: [
+      GATEWAY_AUTH_RATE_LIMIT_MAX_ATTEMPTS_OOB_RULE,
+      GATEWAY_AUTH_RATE_LIMIT_WINDOW_MS_OOB_RULE,
+      GATEWAY_AUTH_RATE_LIMIT_LOCKOUT_MS_OOB_RULE,
+    ],
     apply: (raw, changes) => {
       const gateway = getRecord(raw.gateway);
       const auth = getRecord(gateway?.auth);
       const rateLimit = getRecord(auth?.rateLimit);
-      if (!rateLimit || !Object.hasOwn(rateLimit, "maxAttempts")) {
+      if (!gateway || !auth || !rateLimit) {
         return;
       }
-      const maxAttempts = rateLimit.maxAttempts;
-      if (typeof maxAttempts !== "number" || (Number.isInteger(maxAttempts) && maxAttempts > 0)) {
-        return;
+      const repairs: Array<{ key: "maxAttempts" | "windowMs" | "lockoutMs"; fallback: number }> = [
+        { key: "maxAttempts", fallback: DEFAULT_MAX_ATTEMPTS },
+        { key: "windowMs", fallback: DEFAULT_WINDOW_MS },
+        { key: "lockoutMs", fallback: DEFAULT_LOCKOUT_MS },
+      ];
+      for (const { key, fallback } of repairs) {
+        const value = rateLimit[key];
+        if (!isNonPositiveIntegerConfigValue(value)) {
+          continue;
+        }
+        delete rateLimit[key];
+        changes.push(
+          `Removed invalid gateway.auth.rateLimit.${key} (${String(value)}). ` +
+            `It must be a positive integer; the gateway will use the default of ${fallback}.`,
+        );
       }
-      delete rateLimit.maxAttempts;
-      changes.push(
-        `Removed invalid gateway.auth.rateLimit.maxAttempts (${String(maxAttempts)}). ` +
-          `It must be a positive integer; the gateway will use the default of ${DEFAULT_MAX_ATTEMPTS} attempts.`,
-      );
+      if (Object.keys(rateLimit).length > 0) {
+        auth.rateLimit = rateLimit;
+      } else {
+        delete auth.rateLimit;
+      }
+      if (Object.keys(auth).length > 0) {
+        gateway.auth = auth;
+      } else {
+        delete gateway.auth;
+      }
+      if (Object.keys(gateway).length > 0) {
+        raw.gateway = gateway;
+      } else {
+        delete raw.gateway;
+      }
     },
   }),
   defineLegacyConfigMigration({

--- a/src/commands/doctor/shared/legacy-config-migrations.runtime.gateway.ts
+++ b/src/commands/doctor/shared/legacy-config-migrations.runtime.gateway.ts
@@ -23,6 +23,18 @@ function isNonPositiveIntegerConfigValue(value: unknown): boolean {
   return typeof value === "number" && (!Number.isInteger(value) || value <= 0);
 }
 
+// windowMs/lockoutMs runtime-clamp to a 1000ms floor (see auth-rate-limit.ts).
+// A persisted positive integer below that floor must still be migrated, or it
+// would pass schema validation and then be silently lengthened at runtime.
+const GATEWAY_AUTH_RATE_LIMIT_DURATION_FLOOR_MS = 1_000;
+
+function isBelowDurationFloorConfigValue(value: unknown): boolean {
+  return (
+    typeof value === "number" &&
+    (!Number.isInteger(value) || value < GATEWAY_AUTH_RATE_LIMIT_DURATION_FLOOR_MS)
+  );
+}
+
 const GATEWAY_AUTH_RATE_LIMIT_MAX_ATTEMPTS_OOB_RULE: LegacyConfigRule = {
   path: ["gateway", "auth", "rateLimit", "maxAttempts"],
   message:
@@ -33,15 +45,15 @@ const GATEWAY_AUTH_RATE_LIMIT_MAX_ATTEMPTS_OOB_RULE: LegacyConfigRule = {
 const GATEWAY_AUTH_RATE_LIMIT_WINDOW_MS_OOB_RULE: LegacyConfigRule = {
   path: ["gateway", "auth", "rateLimit", "windowMs"],
   message:
-    'gateway.auth.rateLimit.windowMs must be a positive integer and will be removed to avoid startup failure. Run "openclaw doctor --fix".',
-  match: isNonPositiveIntegerConfigValue,
+    'gateway.auth.rateLimit.windowMs must be an integer of at least 1000ms and will be removed to avoid startup failure. Run "openclaw doctor --fix".',
+  match: isBelowDurationFloorConfigValue,
 };
 
 const GATEWAY_AUTH_RATE_LIMIT_LOCKOUT_MS_OOB_RULE: LegacyConfigRule = {
   path: ["gateway", "auth", "rateLimit", "lockoutMs"],
   message:
-    'gateway.auth.rateLimit.lockoutMs must be a positive integer and will be removed to avoid startup failure. Run "openclaw doctor --fix".',
-  match: isNonPositiveIntegerConfigValue,
+    'gateway.auth.rateLimit.lockoutMs must be an integer of at least 1000ms and will be removed to avoid startup failure. Run "openclaw doctor --fix".',
+  match: isBelowDurationFloorConfigValue,
 };
 
 const GATEWAY_PORT_OOB_RULE: LegacyConfigRule = {
@@ -229,20 +241,40 @@ export const LEGACY_CONFIG_MIGRATIONS_RUNTIME_GATEWAY: LegacyConfigMigrationSpec
       if (!gateway || !auth || !rateLimit) {
         return;
       }
-      const repairs: Array<{ key: "maxAttempts" | "windowMs" | "lockoutMs"; fallback: number }> = [
-        { key: "maxAttempts", fallback: DEFAULT_MAX_ATTEMPTS },
-        { key: "windowMs", fallback: DEFAULT_WINDOW_MS },
-        { key: "lockoutMs", fallback: DEFAULT_LOCKOUT_MS },
+      const repairs: Array<{
+        key: "maxAttempts" | "windowMs" | "lockoutMs";
+        fallback: number;
+        isInvalid: (value: unknown) => boolean;
+        requirement: string;
+      }> = [
+        {
+          key: "maxAttempts",
+          fallback: DEFAULT_MAX_ATTEMPTS,
+          isInvalid: isNonPositiveIntegerConfigValue,
+          requirement: "a positive integer",
+        },
+        {
+          key: "windowMs",
+          fallback: DEFAULT_WINDOW_MS,
+          isInvalid: isBelowDurationFloorConfigValue,
+          requirement: `an integer of at least ${GATEWAY_AUTH_RATE_LIMIT_DURATION_FLOOR_MS}ms`,
+        },
+        {
+          key: "lockoutMs",
+          fallback: DEFAULT_LOCKOUT_MS,
+          isInvalid: isBelowDurationFloorConfigValue,
+          requirement: `an integer of at least ${GATEWAY_AUTH_RATE_LIMIT_DURATION_FLOOR_MS}ms`,
+        },
       ];
-      for (const { key, fallback } of repairs) {
+      for (const { key, fallback, isInvalid, requirement } of repairs) {
         const value = rateLimit[key];
-        if (!isNonPositiveIntegerConfigValue(value)) {
+        if (!isInvalid(value)) {
           continue;
         }
         delete rateLimit[key];
         changes.push(
           `Removed invalid gateway.auth.rateLimit.${key} (${String(value)}). ` +
-            `It must be a positive integer; the gateway will use the default of ${fallback}.`,
+            `It must be ${requirement}; the gateway will use the default of ${fallback}.`,
         );
       }
       if (Object.keys(rateLimit).length > 0) {

--- a/src/commands/doctor/shared/legacy-config-migrations.runtime.gateway.ts
+++ b/src/commands/doctor/shared/legacy-config-migrations.runtime.gateway.ts
@@ -35,12 +35,12 @@ function isBelowDurationFloorConfigValue(value: unknown): boolean {
   );
 }
 
-// A persisted positive integer below the floor (e.g. windowMs: 500) is a
-// currently-accepted setting the runtime would only floor to 1000ms anyway --
-// raise it in place instead of discarding the operator's shorter-duration
-// intent for the much larger documented default.
-function isPositiveIntegerConfigValue(value: unknown): boolean {
-  return typeof value === "number" && Number.isInteger(value) && value > 0;
+// A positive finite value (integer or fractional) always has a well-defined
+// runtime-effective value -- see resolveIntegerOption / resolveTimerTimeoutMs
+// in auth-rate-limit.ts, which floor (and, for durations, clamp) exactly
+// this way regardless of whether the input was already an integer.
+function isPositiveFiniteConfigValue(value: unknown): value is number {
+  return typeof value === "number" && Number.isFinite(value) && value > 0;
 }
 
 const GATEWAY_AUTH_RATE_LIMIT_MAX_ATTEMPTS_OOB_RULE: LegacyConfigRule = {
@@ -252,45 +252,57 @@ export const LEGACY_CONFIG_MIGRATIONS_RUNTIME_GATEWAY: LegacyConfigMigrationSpec
       const repairs: Array<{
         key: "maxAttempts" | "windowMs" | "lockoutMs";
         fallback: number;
-        isInvalid: (value: unknown) => boolean;
         requirement: string;
-        // Duration fields only: a positive integer below this floor is
-        // raised in place instead of deleted+defaulted (see
-        // isPositiveIntegerConfigValue above).
-        floorMs?: number;
+        // Any positive finite value (integer or fractional) has a
+        // well-defined runtime-effective value -- see resolveIntegerOption
+        // and resolveTimerTimeoutMs in auth-rate-limit.ts, which floor and
+        // then clamp exactly this way. Normalize to that value in place
+        // instead of deleting, so intent (e.g. a stricter fractional
+        // threshold) survives the schema-tightening migration. Only
+        // non-positive or non-finite input has no sensible target and still
+        // deletes+defaults below.
+        normalizePositiveFinite: (value: number) => number;
       }> = [
         {
           key: "maxAttempts",
           fallback: DEFAULT_MAX_ATTEMPTS,
-          isInvalid: isNonPositiveIntegerConfigValue,
           requirement: "a positive integer",
+          normalizePositiveFinite: (value) => Math.max(1, Math.floor(value)),
         },
         {
           key: "windowMs",
           fallback: DEFAULT_WINDOW_MS,
-          isInvalid: isBelowDurationFloorConfigValue,
           requirement: `an integer of at least ${GATEWAY_AUTH_RATE_LIMIT_DURATION_FLOOR_MS}ms`,
-          floorMs: GATEWAY_AUTH_RATE_LIMIT_DURATION_FLOOR_MS,
+          normalizePositiveFinite: (value) =>
+            Math.max(GATEWAY_AUTH_RATE_LIMIT_DURATION_FLOOR_MS, Math.floor(value)),
         },
         {
           key: "lockoutMs",
           fallback: DEFAULT_LOCKOUT_MS,
-          isInvalid: isBelowDurationFloorConfigValue,
           requirement: `an integer of at least ${GATEWAY_AUTH_RATE_LIMIT_DURATION_FLOOR_MS}ms`,
-          floorMs: GATEWAY_AUTH_RATE_LIMIT_DURATION_FLOOR_MS,
+          normalizePositiveFinite: (value) =>
+            Math.max(GATEWAY_AUTH_RATE_LIMIT_DURATION_FLOOR_MS, Math.floor(value)),
         },
       ];
-      for (const { key, fallback, isInvalid, requirement, floorMs } of repairs) {
+      for (const { key, fallback, requirement, normalizePositiveFinite } of repairs) {
         const value = rateLimit[key];
-        if (floorMs !== undefined && isPositiveIntegerConfigValue(value) && value < floorMs) {
-          rateLimit[key] = floorMs;
+        if (isPositiveFiniteConfigValue(value)) {
+          const normalized = normalizePositiveFinite(value);
+          if (normalized === value) {
+            continue;
+          }
+          rateLimit[key] = normalized;
           changes.push(
-            `Raised gateway.auth.rateLimit.${key} (${String(value)}) to ${floorMs}. ` +
+            `Raised gateway.auth.rateLimit.${key} (${String(value)}) to ${normalized}. ` +
               `It must be ${requirement}.`,
           );
           continue;
         }
-        if (!isInvalid(value)) {
+        if (typeof value !== "number") {
+          // Not this migration's concern: an absent key or a wrong-type
+          // value (string/boolean/etc.) is a schema type mismatch, not the
+          // numeric-range issue this migration repairs -- leave it for
+          // normal schema validation to surface.
           continue;
         }
         delete rateLimit[key];

--- a/src/commands/doctor/shared/legacy-config-migrations.runtime.gateway.ts
+++ b/src/commands/doctor/shared/legacy-config-migrations.runtime.gateway.ts
@@ -13,6 +13,14 @@ import {
   type LegacyConfigRule,
 } from "../../../config/legacy.shared.js";
 import { DEFAULT_GATEWAY_PORT } from "../../../config/paths.js";
+import { DEFAULT_MAX_ATTEMPTS } from "../../../gateway/auth-rate-limit.js";
+
+const GATEWAY_AUTH_RATE_LIMIT_MAX_ATTEMPTS_OOB_RULE: LegacyConfigRule = {
+  path: ["gateway", "auth", "rateLimit", "maxAttempts"],
+  message:
+    'gateway.auth.rateLimit.maxAttempts must be a positive integer and will be removed to avoid startup failure. Run "openclaw doctor --fix".',
+  match: (value) => typeof value === "number" && (!Number.isInteger(value) || value <= 0),
+};
 
 const GATEWAY_PORT_OOB_RULE: LegacyConfigRule = {
   path: ["gateway", "port"],
@@ -180,6 +188,29 @@ export const LEGACY_CONFIG_MIGRATIONS_RUNTIME_GATEWAY: LegacyConfigMigrationSpec
       changes.push(
         `Removed out-of-range gateway.port (${String(port)}). ` +
           `Valid TCP ports are 1–65535; the gateway will use the default port ${DEFAULT_GATEWAY_PORT}.`,
+      );
+    },
+  }),
+  defineLegacyConfigMigration({
+    id: "gateway.auth.rateLimit.max-attempts-oob-repair",
+    describe:
+      "Remove non-positive-integer gateway.auth.rateLimit.maxAttempts to avoid post-schema-tightening startup failures",
+    legacyRules: [GATEWAY_AUTH_RATE_LIMIT_MAX_ATTEMPTS_OOB_RULE],
+    apply: (raw, changes) => {
+      const gateway = getRecord(raw.gateway);
+      const auth = getRecord(gateway?.auth);
+      const rateLimit = getRecord(auth?.rateLimit);
+      if (!rateLimit || !Object.hasOwn(rateLimit, "maxAttempts")) {
+        return;
+      }
+      const maxAttempts = rateLimit.maxAttempts;
+      if (typeof maxAttempts !== "number" || (Number.isInteger(maxAttempts) && maxAttempts > 0)) {
+        return;
+      }
+      delete rateLimit.maxAttempts;
+      changes.push(
+        `Removed invalid gateway.auth.rateLimit.maxAttempts (${String(maxAttempts)}). ` +
+          `It must be a positive integer; the gateway will use the default of ${DEFAULT_MAX_ATTEMPTS} attempts.`,
       );
     },
   }),

--- a/src/commands/doctor/shared/legacy-config-migrations.runtime.gateway.ts
+++ b/src/commands/doctor/shared/legacy-config-migrations.runtime.gateway.ts
@@ -35,6 +35,14 @@ function isBelowDurationFloorConfigValue(value: unknown): boolean {
   );
 }
 
+// A persisted positive integer below the floor (e.g. windowMs: 500) is a
+// currently-accepted setting the runtime would only floor to 1000ms anyway --
+// raise it in place instead of discarding the operator's shorter-duration
+// intent for the much larger documented default.
+function isPositiveIntegerConfigValue(value: unknown): boolean {
+  return typeof value === "number" && Number.isInteger(value) && value > 0;
+}
+
 const GATEWAY_AUTH_RATE_LIMIT_MAX_ATTEMPTS_OOB_RULE: LegacyConfigRule = {
   path: ["gateway", "auth", "rateLimit", "maxAttempts"],
   message:
@@ -45,14 +53,14 @@ const GATEWAY_AUTH_RATE_LIMIT_MAX_ATTEMPTS_OOB_RULE: LegacyConfigRule = {
 const GATEWAY_AUTH_RATE_LIMIT_WINDOW_MS_OOB_RULE: LegacyConfigRule = {
   path: ["gateway", "auth", "rateLimit", "windowMs"],
   message:
-    'gateway.auth.rateLimit.windowMs must be an integer of at least 1000ms and will be removed to avoid startup failure. Run "openclaw doctor --fix".',
+    'gateway.auth.rateLimit.windowMs must be an integer of at least 1000ms; a smaller positive integer will be raised to 1000ms, other invalid values will be removed. Run "openclaw doctor --fix".',
   match: isBelowDurationFloorConfigValue,
 };
 
 const GATEWAY_AUTH_RATE_LIMIT_LOCKOUT_MS_OOB_RULE: LegacyConfigRule = {
   path: ["gateway", "auth", "rateLimit", "lockoutMs"],
   message:
-    'gateway.auth.rateLimit.lockoutMs must be an integer of at least 1000ms and will be removed to avoid startup failure. Run "openclaw doctor --fix".',
+    'gateway.auth.rateLimit.lockoutMs must be an integer of at least 1000ms; a smaller positive integer will be raised to 1000ms, other invalid values will be removed. Run "openclaw doctor --fix".',
   match: isBelowDurationFloorConfigValue,
 };
 
@@ -192,6 +200,10 @@ export const LEGACY_CONFIG_MIGRATIONS_RUNTIME_GATEWAY: LegacyConfigMigrationSpec
         fallback: number;
         isInvalid: (value: unknown) => boolean;
         requirement: string;
+        // Duration fields only: a positive integer below this floor is
+        // raised in place instead of deleted+defaulted (see
+        // isPositiveIntegerConfigValue above).
+        floorMs?: number;
       }> = [
         {
           key: "maxAttempts",
@@ -204,16 +216,26 @@ export const LEGACY_CONFIG_MIGRATIONS_RUNTIME_GATEWAY: LegacyConfigMigrationSpec
           fallback: DEFAULT_WINDOW_MS,
           isInvalid: isBelowDurationFloorConfigValue,
           requirement: `an integer of at least ${GATEWAY_AUTH_RATE_LIMIT_DURATION_FLOOR_MS}ms`,
+          floorMs: GATEWAY_AUTH_RATE_LIMIT_DURATION_FLOOR_MS,
         },
         {
           key: "lockoutMs",
           fallback: DEFAULT_LOCKOUT_MS,
           isInvalid: isBelowDurationFloorConfigValue,
           requirement: `an integer of at least ${GATEWAY_AUTH_RATE_LIMIT_DURATION_FLOOR_MS}ms`,
+          floorMs: GATEWAY_AUTH_RATE_LIMIT_DURATION_FLOOR_MS,
         },
       ];
-      for (const { key, fallback, isInvalid, requirement } of repairs) {
+      for (const { key, fallback, isInvalid, requirement, floorMs } of repairs) {
         const value = rateLimit[key];
+        if (floorMs !== undefined && isPositiveIntegerConfigValue(value) && value < floorMs) {
+          rateLimit[key] = floorMs;
+          changes.push(
+            `Raised gateway.auth.rateLimit.${key} (${String(value)}) to ${floorMs}. ` +
+              `It must be ${requirement}.`,
+          );
+          continue;
+        }
         if (!isInvalid(value)) {
           continue;
         }

--- a/src/commands/doctor/shared/legacy-config-migrations.runtime.gateway.ts
+++ b/src/commands/doctor/shared/legacy-config-migrations.runtime.gateway.ts
@@ -23,6 +23,18 @@ function isNonPositiveIntegerConfigValue(value: unknown): boolean {
   return typeof value === "number" && (!Number.isInteger(value) || value <= 0);
 }
 
+// windowMs/lockoutMs runtime-clamp to a 1000ms floor (see auth-rate-limit.ts).
+// A persisted positive integer below that floor must still be migrated, or it
+// would pass schema validation and then be silently lengthened at runtime.
+const GATEWAY_AUTH_RATE_LIMIT_DURATION_FLOOR_MS = 1_000;
+
+function isBelowDurationFloorConfigValue(value: unknown): boolean {
+  return (
+    typeof value === "number" &&
+    (!Number.isInteger(value) || value < GATEWAY_AUTH_RATE_LIMIT_DURATION_FLOOR_MS)
+  );
+}
+
 const GATEWAY_AUTH_RATE_LIMIT_MAX_ATTEMPTS_OOB_RULE: LegacyConfigRule = {
   path: ["gateway", "auth", "rateLimit", "maxAttempts"],
   message:
@@ -33,15 +45,15 @@ const GATEWAY_AUTH_RATE_LIMIT_MAX_ATTEMPTS_OOB_RULE: LegacyConfigRule = {
 const GATEWAY_AUTH_RATE_LIMIT_WINDOW_MS_OOB_RULE: LegacyConfigRule = {
   path: ["gateway", "auth", "rateLimit", "windowMs"],
   message:
-    'gateway.auth.rateLimit.windowMs must be a positive integer and will be removed to avoid startup failure. Run "openclaw doctor --fix".',
-  match: isNonPositiveIntegerConfigValue,
+    'gateway.auth.rateLimit.windowMs must be an integer of at least 1000ms and will be removed to avoid startup failure. Run "openclaw doctor --fix".',
+  match: isBelowDurationFloorConfigValue,
 };
 
 const GATEWAY_AUTH_RATE_LIMIT_LOCKOUT_MS_OOB_RULE: LegacyConfigRule = {
   path: ["gateway", "auth", "rateLimit", "lockoutMs"],
   message:
-    'gateway.auth.rateLimit.lockoutMs must be a positive integer and will be removed to avoid startup failure. Run "openclaw doctor --fix".',
-  match: isNonPositiveIntegerConfigValue,
+    'gateway.auth.rateLimit.lockoutMs must be an integer of at least 1000ms and will be removed to avoid startup failure. Run "openclaw doctor --fix".',
+  match: isBelowDurationFloorConfigValue,
 };
 
 const GATEWAY_PORT_OOB_RULE: LegacyConfigRule = {
@@ -175,20 +187,40 @@ export const LEGACY_CONFIG_MIGRATIONS_RUNTIME_GATEWAY: LegacyConfigMigrationSpec
       if (!gateway || !auth || !rateLimit) {
         return;
       }
-      const repairs: Array<{ key: "maxAttempts" | "windowMs" | "lockoutMs"; fallback: number }> = [
-        { key: "maxAttempts", fallback: DEFAULT_MAX_ATTEMPTS },
-        { key: "windowMs", fallback: DEFAULT_WINDOW_MS },
-        { key: "lockoutMs", fallback: DEFAULT_LOCKOUT_MS },
+      const repairs: Array<{
+        key: "maxAttempts" | "windowMs" | "lockoutMs";
+        fallback: number;
+        isInvalid: (value: unknown) => boolean;
+        requirement: string;
+      }> = [
+        {
+          key: "maxAttempts",
+          fallback: DEFAULT_MAX_ATTEMPTS,
+          isInvalid: isNonPositiveIntegerConfigValue,
+          requirement: "a positive integer",
+        },
+        {
+          key: "windowMs",
+          fallback: DEFAULT_WINDOW_MS,
+          isInvalid: isBelowDurationFloorConfigValue,
+          requirement: `an integer of at least ${GATEWAY_AUTH_RATE_LIMIT_DURATION_FLOOR_MS}ms`,
+        },
+        {
+          key: "lockoutMs",
+          fallback: DEFAULT_LOCKOUT_MS,
+          isInvalid: isBelowDurationFloorConfigValue,
+          requirement: `an integer of at least ${GATEWAY_AUTH_RATE_LIMIT_DURATION_FLOOR_MS}ms`,
+        },
       ];
-      for (const { key, fallback } of repairs) {
+      for (const { key, fallback, isInvalid, requirement } of repairs) {
         const value = rateLimit[key];
-        if (!isNonPositiveIntegerConfigValue(value)) {
+        if (!isInvalid(value)) {
           continue;
         }
         delete rateLimit[key];
         changes.push(
           `Removed invalid gateway.auth.rateLimit.${key} (${String(value)}). ` +
-            `It must be a positive integer; the gateway will use the default of ${fallback}.`,
+            `It must be ${requirement}; the gateway will use the default of ${fallback}.`,
         );
       }
       if (Object.keys(rateLimit).length > 0) {

--- a/src/commands/doctor/shared/legacy-config-migrations.runtime.gateway.ts
+++ b/src/commands/doctor/shared/legacy-config-migrations.runtime.gateway.ts
@@ -13,13 +13,35 @@ import {
   type LegacyConfigRule,
 } from "../../../config/legacy.shared.js";
 import { DEFAULT_GATEWAY_PORT } from "../../../config/paths.js";
-import { DEFAULT_MAX_ATTEMPTS } from "../../../gateway/auth-rate-limit.js";
+import {
+  DEFAULT_LOCKOUT_MS,
+  DEFAULT_MAX_ATTEMPTS,
+  DEFAULT_WINDOW_MS,
+} from "../../../gateway/auth-rate-limit.js";
+
+function isNonPositiveIntegerConfigValue(value: unknown): boolean {
+  return typeof value === "number" && (!Number.isInteger(value) || value <= 0);
+}
 
 const GATEWAY_AUTH_RATE_LIMIT_MAX_ATTEMPTS_OOB_RULE: LegacyConfigRule = {
   path: ["gateway", "auth", "rateLimit", "maxAttempts"],
   message:
     'gateway.auth.rateLimit.maxAttempts must be a positive integer and will be removed to avoid startup failure. Run "openclaw doctor --fix".',
-  match: (value) => typeof value === "number" && (!Number.isInteger(value) || value <= 0),
+  match: isNonPositiveIntegerConfigValue,
+};
+
+const GATEWAY_AUTH_RATE_LIMIT_WINDOW_MS_OOB_RULE: LegacyConfigRule = {
+  path: ["gateway", "auth", "rateLimit", "windowMs"],
+  message:
+    'gateway.auth.rateLimit.windowMs must be a positive integer and will be removed to avoid startup failure. Run "openclaw doctor --fix".',
+  match: isNonPositiveIntegerConfigValue,
+};
+
+const GATEWAY_AUTH_RATE_LIMIT_LOCKOUT_MS_OOB_RULE: LegacyConfigRule = {
+  path: ["gateway", "auth", "rateLimit", "lockoutMs"],
+  message:
+    'gateway.auth.rateLimit.lockoutMs must be a positive integer and will be removed to avoid startup failure. Run "openclaw doctor --fix".',
+  match: isNonPositiveIntegerConfigValue,
 };
 
 const GATEWAY_PORT_OOB_RULE: LegacyConfigRule = {
@@ -138,26 +160,52 @@ export const LEGACY_CONFIG_MIGRATIONS_RUNTIME_GATEWAY: LegacyConfigMigrationSpec
     },
   }),
   defineLegacyConfigMigration({
-    id: "gateway.auth.rateLimit.max-attempts-oob-repair",
+    id: "gateway.auth.rateLimit-oob-repair",
     describe:
-      "Remove non-positive-integer gateway.auth.rateLimit.maxAttempts to avoid post-schema-tightening startup failures",
-    legacyRules: [GATEWAY_AUTH_RATE_LIMIT_MAX_ATTEMPTS_OOB_RULE],
+      "Remove non-positive-integer gateway.auth.rateLimit fields to avoid post-schema-tightening startup failures",
+    legacyRules: [
+      GATEWAY_AUTH_RATE_LIMIT_MAX_ATTEMPTS_OOB_RULE,
+      GATEWAY_AUTH_RATE_LIMIT_WINDOW_MS_OOB_RULE,
+      GATEWAY_AUTH_RATE_LIMIT_LOCKOUT_MS_OOB_RULE,
+    ],
     apply: (raw, changes) => {
       const gateway = getRecord(raw.gateway);
       const auth = getRecord(gateway?.auth);
       const rateLimit = getRecord(auth?.rateLimit);
-      if (!rateLimit || !Object.hasOwn(rateLimit, "maxAttempts")) {
+      if (!gateway || !auth || !rateLimit) {
         return;
       }
-      const maxAttempts = rateLimit.maxAttempts;
-      if (typeof maxAttempts !== "number" || (Number.isInteger(maxAttempts) && maxAttempts > 0)) {
-        return;
+      const repairs: Array<{ key: "maxAttempts" | "windowMs" | "lockoutMs"; fallback: number }> = [
+        { key: "maxAttempts", fallback: DEFAULT_MAX_ATTEMPTS },
+        { key: "windowMs", fallback: DEFAULT_WINDOW_MS },
+        { key: "lockoutMs", fallback: DEFAULT_LOCKOUT_MS },
+      ];
+      for (const { key, fallback } of repairs) {
+        const value = rateLimit[key];
+        if (!isNonPositiveIntegerConfigValue(value)) {
+          continue;
+        }
+        delete rateLimit[key];
+        changes.push(
+          `Removed invalid gateway.auth.rateLimit.${key} (${String(value)}). ` +
+            `It must be a positive integer; the gateway will use the default of ${fallback}.`,
+        );
       }
-      delete rateLimit.maxAttempts;
-      changes.push(
-        `Removed invalid gateway.auth.rateLimit.maxAttempts (${String(maxAttempts)}). ` +
-          `It must be a positive integer; the gateway will use the default of ${DEFAULT_MAX_ATTEMPTS} attempts.`,
-      );
+      if (Object.keys(rateLimit).length > 0) {
+        auth.rateLimit = rateLimit;
+      } else {
+        delete auth.rateLimit;
+      }
+      if (Object.keys(auth).length > 0) {
+        gateway.auth = auth;
+      } else {
+        delete gateway.auth;
+      }
+      if (Object.keys(gateway).length > 0) {
+        raw.gateway = gateway;
+      } else {
+        delete raw.gateway;
+      }
     },
   }),
   defineLegacyConfigMigration({

--- a/src/commands/doctor/shared/legacy-config-migrations.runtime.gateway.ts
+++ b/src/commands/doctor/shared/legacy-config-migrations.runtime.gateway.ts
@@ -13,6 +13,14 @@ import {
   type LegacyConfigRule,
 } from "../../../config/legacy.shared.js";
 import { DEFAULT_GATEWAY_PORT } from "../../../config/paths.js";
+import { DEFAULT_MAX_ATTEMPTS } from "../../../gateway/auth-rate-limit.js";
+
+const GATEWAY_AUTH_RATE_LIMIT_MAX_ATTEMPTS_OOB_RULE: LegacyConfigRule = {
+  path: ["gateway", "auth", "rateLimit", "maxAttempts"],
+  message:
+    'gateway.auth.rateLimit.maxAttempts must be a positive integer and will be removed to avoid startup failure. Run "openclaw doctor --fix".',
+  match: (value) => typeof value === "number" && (!Number.isInteger(value) || value <= 0),
+};
 
 const GATEWAY_PORT_OOB_RULE: LegacyConfigRule = {
   path: ["gateway", "port"],
@@ -126,6 +134,29 @@ export const LEGACY_CONFIG_MIGRATIONS_RUNTIME_GATEWAY: LegacyConfigMigrationSpec
       changes.push(
         `Removed out-of-range gateway.port (${String(port)}). ` +
           `Valid TCP ports are 1–65535; the gateway will use the default port ${DEFAULT_GATEWAY_PORT}.`,
+      );
+    },
+  }),
+  defineLegacyConfigMigration({
+    id: "gateway.auth.rateLimit.max-attempts-oob-repair",
+    describe:
+      "Remove non-positive-integer gateway.auth.rateLimit.maxAttempts to avoid post-schema-tightening startup failures",
+    legacyRules: [GATEWAY_AUTH_RATE_LIMIT_MAX_ATTEMPTS_OOB_RULE],
+    apply: (raw, changes) => {
+      const gateway = getRecord(raw.gateway);
+      const auth = getRecord(gateway?.auth);
+      const rateLimit = getRecord(auth?.rateLimit);
+      if (!rateLimit || !Object.hasOwn(rateLimit, "maxAttempts")) {
+        return;
+      }
+      const maxAttempts = rateLimit.maxAttempts;
+      if (typeof maxAttempts !== "number" || (Number.isInteger(maxAttempts) && maxAttempts > 0)) {
+        return;
+      }
+      delete rateLimit.maxAttempts;
+      changes.push(
+        `Removed invalid gateway.auth.rateLimit.maxAttempts (${String(maxAttempts)}). ` +
+          `It must be a positive integer; the gateway will use the default of ${DEFAULT_MAX_ATTEMPTS} attempts.`,
       );
     },
   }),

--- a/src/config/validation.policy.test.ts
+++ b/src/config/validation.policy.test.ts
@@ -433,23 +433,62 @@ describe("config validation ambient heartbeat ownership", () => {
 });
 
 describe("config validation gateway.auth.rateLimit policy", () => {
-  it("rejects non-positive-integer maxAttempts/windowMs/lockoutMs", () => {
-    for (const field of ["maxAttempts", "windowMs", "lockoutMs"] as const) {
-      // 0 previously slipped through and silently disabled auth throttling.
+  it("rejects a non-positive-integer maxAttempts", () => {
+    // 0 previously slipped through and silently disabled auth throttling.
+    const zero = validateConfigObjectRaw({ gateway: { auth: { rateLimit: { maxAttempts: 0 } } } });
+    expect(zero.ok).toBe(false);
+    if (!zero.ok) {
+      const issue = requireIssue(zero.issues, "gateway.auth.rateLimit.maxAttempts");
+      expect(issue.message).toContain("expected number to be >0");
+    }
+
+    // NaN/fractional values previously bypassed the maxAttempts comparison entirely.
+    const fractional = validateConfigObjectRaw({
+      gateway: { auth: { rateLimit: { maxAttempts: 1.5 } } },
+    });
+    expect(fractional.ok).toBe(false);
+
+    const valid = validateConfigObjectRaw({
+      gateway: { auth: { rateLimit: { maxAttempts: 5 } } },
+    });
+    expect(valid.ok).toBe(true);
+  });
+
+  it("rejects windowMs/lockoutMs below the 1000ms runtime floor", () => {
+    // The runtime clamps both fields to a 1000ms minimum (see auth-rate-limit.ts);
+    // the schema must reject anything the runtime would otherwise silently
+    // lengthen, so a persisted sub-second value never survives unmigrated.
+    for (const field of ["windowMs", "lockoutMs"] as const) {
       const zero = validateConfigObjectRaw({ gateway: { auth: { rateLimit: { [field]: 0 } } } });
       expect(zero.ok).toBe(false);
       if (!zero.ok) {
         const issue = requireIssue(zero.issues, `gateway.auth.rateLimit.${field}`);
-        expect(issue.message).toContain("expected number to be >0");
+        expect(issue.message).toContain("expected number to be >=1000");
       }
 
-      // NaN/fractional values previously bypassed the maxAttempts comparison entirely.
       const fractional = validateConfigObjectRaw({
         gateway: { auth: { rateLimit: { [field]: 1.5 } } },
       });
       expect(fractional.ok).toBe(false);
 
-      const valid = validateConfigObjectRaw({ gateway: { auth: { rateLimit: { [field]: 5 } } } });
+      // 999 is the exact boundary the runtime floor would otherwise silently rewrite.
+      const belowFloor = validateConfigObjectRaw({
+        gateway: { auth: { rateLimit: { [field]: 999 } } },
+      });
+      expect(belowFloor.ok).toBe(false);
+      if (!belowFloor.ok) {
+        const issue = requireIssue(belowFloor.issues, `gateway.auth.rateLimit.${field}`);
+        expect(issue.message).toContain("expected number to be >=1000");
+      }
+
+      const atFloor = validateConfigObjectRaw({
+        gateway: { auth: { rateLimit: { [field]: 1_000 } } },
+      });
+      expect(atFloor.ok).toBe(true);
+
+      const valid = validateConfigObjectRaw({
+        gateway: { auth: { rateLimit: { [field]: 30_000 } } },
+      });
       expect(valid.ok).toBe(true);
     }
   });

--- a/src/config/validation.policy.test.ts
+++ b/src/config/validation.policy.test.ts
@@ -431,3 +431,26 @@ describe("config validation ambient heartbeat ownership", () => {
     expect(heartbeatOwnerWarnings(cfg)).toEqual([]);
   });
 });
+
+describe("config validation gateway.auth.rateLimit policy", () => {
+  it("rejects non-positive-integer maxAttempts/windowMs/lockoutMs", () => {
+    for (const field of ["maxAttempts", "windowMs", "lockoutMs"] as const) {
+      // 0 previously slipped through and silently disabled auth throttling.
+      const zero = validateConfigObjectRaw({ gateway: { auth: { rateLimit: { [field]: 0 } } } });
+      expect(zero.ok).toBe(false);
+      if (!zero.ok) {
+        const issue = requireIssue(zero.issues, `gateway.auth.rateLimit.${field}`);
+        expect(issue.message).toContain("expected number to be >0");
+      }
+
+      // NaN/fractional values previously bypassed the maxAttempts comparison entirely.
+      const fractional = validateConfigObjectRaw({
+        gateway: { auth: { rateLimit: { [field]: 1.5 } } },
+      });
+      expect(fractional.ok).toBe(false);
+
+      const valid = validateConfigObjectRaw({ gateway: { auth: { rateLimit: { [field]: 5 } } } });
+      expect(valid.ok).toBe(true);
+    }
+  });
+});

--- a/src/config/validation.policy.test.ts
+++ b/src/config/validation.policy.test.ts
@@ -238,23 +238,62 @@ describe("config validation gateway.port policy", () => {
 });
 
 describe("config validation gateway.auth.rateLimit policy", () => {
-  it("rejects non-positive-integer maxAttempts/windowMs/lockoutMs", () => {
-    for (const field of ["maxAttempts", "windowMs", "lockoutMs"] as const) {
-      // 0 previously slipped through and silently disabled auth throttling.
+  it("rejects a non-positive-integer maxAttempts", () => {
+    // 0 previously slipped through and silently disabled auth throttling.
+    const zero = validateConfigObjectRaw({ gateway: { auth: { rateLimit: { maxAttempts: 0 } } } });
+    expect(zero.ok).toBe(false);
+    if (!zero.ok) {
+      const issue = requireIssue(zero.issues, "gateway.auth.rateLimit.maxAttempts");
+      expect(issue.message).toContain("expected number to be >0");
+    }
+
+    // NaN/fractional values previously bypassed the maxAttempts comparison entirely.
+    const fractional = validateConfigObjectRaw({
+      gateway: { auth: { rateLimit: { maxAttempts: 1.5 } } },
+    });
+    expect(fractional.ok).toBe(false);
+
+    const valid = validateConfigObjectRaw({
+      gateway: { auth: { rateLimit: { maxAttempts: 5 } } },
+    });
+    expect(valid.ok).toBe(true);
+  });
+
+  it("rejects windowMs/lockoutMs below the 1000ms runtime floor", () => {
+    // The runtime clamps both fields to a 1000ms minimum (see auth-rate-limit.ts);
+    // the schema must reject anything the runtime would otherwise silently
+    // lengthen, so a persisted sub-second value never survives unmigrated.
+    for (const field of ["windowMs", "lockoutMs"] as const) {
       const zero = validateConfigObjectRaw({ gateway: { auth: { rateLimit: { [field]: 0 } } } });
       expect(zero.ok).toBe(false);
       if (!zero.ok) {
         const issue = requireIssue(zero.issues, `gateway.auth.rateLimit.${field}`);
-        expect(issue.message).toContain("expected number to be >0");
+        expect(issue.message).toContain("expected number to be >=1000");
       }
 
-      // NaN/fractional values previously bypassed the maxAttempts comparison entirely.
       const fractional = validateConfigObjectRaw({
         gateway: { auth: { rateLimit: { [field]: 1.5 } } },
       });
       expect(fractional.ok).toBe(false);
 
-      const valid = validateConfigObjectRaw({ gateway: { auth: { rateLimit: { [field]: 5 } } } });
+      // 999 is the exact boundary the runtime floor would otherwise silently rewrite.
+      const belowFloor = validateConfigObjectRaw({
+        gateway: { auth: { rateLimit: { [field]: 999 } } },
+      });
+      expect(belowFloor.ok).toBe(false);
+      if (!belowFloor.ok) {
+        const issue = requireIssue(belowFloor.issues, `gateway.auth.rateLimit.${field}`);
+        expect(issue.message).toContain("expected number to be >=1000");
+      }
+
+      const atFloor = validateConfigObjectRaw({
+        gateway: { auth: { rateLimit: { [field]: 1_000 } } },
+      });
+      expect(atFloor.ok).toBe(true);
+
+      const valid = validateConfigObjectRaw({
+        gateway: { auth: { rateLimit: { [field]: 30_000 } } },
+      });
       expect(valid.ok).toBe(true);
     }
   });

--- a/src/config/validation.policy.test.ts
+++ b/src/config/validation.policy.test.ts
@@ -236,3 +236,26 @@ describe("config validation gateway.port policy", () => {
     expect(min.ok).toBe(true);
   });
 });
+
+describe("config validation gateway.auth.rateLimit policy", () => {
+  it("rejects non-positive-integer maxAttempts/windowMs/lockoutMs", () => {
+    for (const field of ["maxAttempts", "windowMs", "lockoutMs"] as const) {
+      // 0 previously slipped through and silently disabled auth throttling.
+      const zero = validateConfigObjectRaw({ gateway: { auth: { rateLimit: { [field]: 0 } } } });
+      expect(zero.ok).toBe(false);
+      if (!zero.ok) {
+        const issue = requireIssue(zero.issues, `gateway.auth.rateLimit.${field}`);
+        expect(issue.message).toContain("expected number to be >0");
+      }
+
+      // NaN/fractional values previously bypassed the maxAttempts comparison entirely.
+      const fractional = validateConfigObjectRaw({
+        gateway: { auth: { rateLimit: { [field]: 1.5 } } },
+      });
+      expect(fractional.ok).toBe(false);
+
+      const valid = validateConfigObjectRaw({ gateway: { auth: { rateLimit: { [field]: 5 } } } });
+      expect(valid.ok).toBe(true);
+    }
+  });
+});

--- a/src/config/zod-schema.gateway.test.ts
+++ b/src/config/zod-schema.gateway.test.ts
@@ -1,0 +1,48 @@
+// Covers gateway config schema parsing, including auth rate-limit bounds.
+import { describe, expect, it } from "vitest";
+import { GatewayConfigSchema } from "./zod-schema.gateway.js";
+
+type SchemaParseResult = {
+  success: boolean;
+  error?: { issues: Array<{ path: Array<string | number | symbol> }> };
+};
+
+function expectSchemaSuccess(result: SchemaParseResult): void {
+  expect(result.success).toBe(true);
+}
+
+function expectSchemaFailurePath(result: SchemaParseResult, expectedPathPrefix: string): void {
+  expect(result.success).toBe(false);
+  if (result.success || !result.error) {
+    throw new Error(`Expected schema validation to fail at ${expectedPathPrefix}.`);
+  }
+  const joined = result.error.issues.map((issue) => issue.path.join("."));
+  expect(joined.some((path) => path.startsWith(expectedPathPrefix))).toBe(true);
+}
+
+describe("GatewayConfigSchema auth.rateLimit", () => {
+  it("accepts a positive integer maxAttempts", () => {
+    expectSchemaSuccess(GatewayConfigSchema.safeParse({ auth: { rateLimit: { maxAttempts: 5 } } }));
+  });
+
+  it("rejects zero maxAttempts (would lock out on the first failed attempt)", () => {
+    expectSchemaFailurePath(
+      GatewayConfigSchema.safeParse({ auth: { rateLimit: { maxAttempts: 0 } } }),
+      "auth.rateLimit.maxAttempts",
+    );
+  });
+
+  it("rejects negative maxAttempts", () => {
+    expectSchemaFailurePath(
+      GatewayConfigSchema.safeParse({ auth: { rateLimit: { maxAttempts: -1 } } }),
+      "auth.rateLimit.maxAttempts",
+    );
+  });
+
+  it("rejects fractional maxAttempts", () => {
+    expectSchemaFailurePath(
+      GatewayConfigSchema.safeParse({ auth: { rateLimit: { maxAttempts: 2.5 } } }),
+      "auth.rateLimit.maxAttempts",
+    );
+  });
+});

--- a/src/config/zod-schema.gateway.ts
+++ b/src/config/zod-schema.gateway.ts
@@ -129,8 +129,8 @@ export const GatewayConfigSchema = z
         rateLimit: z
           .strictObject({
             maxAttempts: z.number().int().positive().optional(),
-            windowMs: z.number().optional(),
-            lockoutMs: z.number().optional(),
+            windowMs: z.number().int().positive().optional(),
+            lockoutMs: z.number().int().positive().optional(),
             exemptLoopback: z.boolean().optional(),
           })
           .optional(),

--- a/src/config/zod-schema.gateway.ts
+++ b/src/config/zod-schema.gateway.ts
@@ -128,7 +128,7 @@ export const GatewayConfigSchema = z
         identityScopes: z.record(z.string().min(1), z.array(OperatorScopeSchema)).optional(),
         rateLimit: z
           .strictObject({
-            maxAttempts: z.number().optional(),
+            maxAttempts: z.number().int().positive().optional(),
             windowMs: z.number().optional(),
             lockoutMs: z.number().optional(),
             exemptLoopback: z.boolean().optional(),

--- a/src/config/zod-schema.gateway.ts
+++ b/src/config/zod-schema.gateway.ts
@@ -129,8 +129,11 @@ export const GatewayConfigSchema = z
         rateLimit: z
           .strictObject({
             maxAttempts: z.number().int().positive().optional(),
-            windowMs: z.number().int().positive().optional(),
-            lockoutMs: z.number().int().positive().optional(),
+            // Runtime clamps both fields to a 1000ms floor (see auth-rate-limit.ts);
+            // a lower accepted minimum here would let a persisted sub-second value
+            // pass validation and then be silently lengthened at runtime.
+            windowMs: z.number().int().min(1_000).optional(),
+            lockoutMs: z.number().int().min(1_000).optional(),
             exemptLoopback: z.boolean().optional(),
           })
           .optional(),

--- a/src/config/zod-schema.gateway.ts
+++ b/src/config/zod-schema.gateway.ts
@@ -61,8 +61,11 @@ export const GatewayConfigSchema = z
         rateLimit: z
           .strictObject({
             maxAttempts: z.number().int().positive().optional(),
-            windowMs: z.number().int().positive().optional(),
-            lockoutMs: z.number().int().positive().optional(),
+            // Runtime clamps both fields to a 1000ms floor (see auth-rate-limit.ts);
+            // a lower accepted minimum here would let a persisted sub-second value
+            // pass validation and then be silently lengthened at runtime.
+            windowMs: z.number().int().min(1_000).optional(),
+            lockoutMs: z.number().int().min(1_000).optional(),
             exemptLoopback: z.boolean().optional(),
           })
           .optional(),

--- a/src/config/zod-schema.gateway.ts
+++ b/src/config/zod-schema.gateway.ts
@@ -61,8 +61,8 @@ export const GatewayConfigSchema = z
         rateLimit: z
           .strictObject({
             maxAttempts: z.number().int().positive().optional(),
-            windowMs: z.number().optional(),
-            lockoutMs: z.number().optional(),
+            windowMs: z.number().int().positive().optional(),
+            lockoutMs: z.number().int().positive().optional(),
             exemptLoopback: z.boolean().optional(),
           })
           .optional(),

--- a/src/config/zod-schema.gateway.ts
+++ b/src/config/zod-schema.gateway.ts
@@ -60,7 +60,7 @@ export const GatewayConfigSchema = z
         allowTailscale: z.boolean().optional(),
         rateLimit: z
           .strictObject({
-            maxAttempts: z.number().optional(),
+            maxAttempts: z.number().int().positive().optional(),
             windowMs: z.number().optional(),
             lockoutMs: z.number().optional(),
             exemptLoopback: z.boolean().optional(),

--- a/src/gateway/auth-rate-limit.test.ts
+++ b/src/gateway/auth-rate-limit.test.ts
@@ -242,6 +242,34 @@ describe("auth rate limiter", () => {
     expect(limiter.size()).toBe(expectedSize);
   });
 
+  it.each([
+    { value: 0, effectiveMaxAttempts: 1 },
+    { value: -2, effectiveMaxAttempts: 1 },
+    { value: 1.9, effectiveMaxAttempts: 1 },
+    { value: 2.9, effectiveMaxAttempts: 2 },
+    { value: Number.NaN, effectiveMaxAttempts: 10 },
+    { value: Number.POSITIVE_INFINITY, effectiveMaxAttempts: 10 },
+  ])(
+    "normalizes maxAttempts value $value instead of locking out before any failure",
+    ({ value, effectiveMaxAttempts }) => {
+      limiter = createAuthRateLimiter({
+        maxAttempts: value,
+        windowMs: 60_000,
+        lockoutMs: 60_000,
+        pruneIntervalMs: 0,
+      });
+
+      const ip = "10.0.5.1";
+      for (let i = 0; i < effectiveMaxAttempts - 1; i++) {
+        limiter.recordFailure(ip);
+      }
+      expect(limiter.check(ip).allowed).toBe(true);
+
+      limiter.recordFailure(ip);
+      expect(limiter.check(ip).allowed).toBe(false);
+    },
+  );
+
   it("treats ipv4 and ipv4-mapped ipv6 forms as the same client", () => {
     limiter = createAuthRateLimiter({ maxAttempts: 1, windowMs: 60_000, lockoutMs: 60_000 });
     limiter.recordFailure("1.2.3.4");

--- a/src/gateway/auth-rate-limit.test.ts
+++ b/src/gateway/auth-rate-limit.test.ts
@@ -270,6 +270,23 @@ describe("auth rate limiter", () => {
     },
   );
 
+  it("does not disable the sliding window when windowMs is 0", () => {
+    // windowMs: 0 made slideWindow's cutoff equal `now`, wiping every recorded
+    // attempt on the very next check before maxAttempts could ever be reached.
+    limiter = createAuthRateLimiter({ maxAttempts: 2, windowMs: 0, lockoutMs: 60_000 });
+    limiter.recordFailure("10.0.6.1");
+    limiter.recordFailure("10.0.6.1");
+    expect(limiter.check("10.0.6.1").allowed).toBe(false);
+  });
+
+  it("does not disable the lockout duration when lockoutMs is 0", () => {
+    limiter = createAuthRateLimiter({ maxAttempts: 1, windowMs: 60_000, lockoutMs: 0 });
+    limiter.recordFailure("10.0.6.2");
+    const result = limiter.check("10.0.6.2");
+    expect(result.allowed).toBe(false);
+    expect(result.retryAfterMs).toBeGreaterThan(0);
+  });
+
   it("treats ipv4 and ipv4-mapped ipv6 forms as the same client", () => {
     limiter = createAuthRateLimiter({ maxAttempts: 1, windowMs: 60_000, lockoutMs: 60_000 });
     limiter.recordFailure("1.2.3.4");

--- a/src/gateway/auth-rate-limit.test.ts
+++ b/src/gateway/auth-rate-limit.test.ts
@@ -287,6 +287,22 @@ describe("auth rate limiter", () => {
     expect(result.retryAfterMs).toBeGreaterThan(0);
   });
 
+  it("clamps a non-positive windowMs to a 1s floor, not the generic 1ms minimum", () => {
+    // A 1ms floor is real-clock-flaky: two sequential recordFailure() calls
+    // can legitimately land more than 1ms apart. Assert the actual clamp
+    // deterministically with fake timers instead of relying on real timing.
+    vi.useFakeTimers();
+    try {
+      limiter = createAuthRateLimiter({ maxAttempts: 2, windowMs: 0, lockoutMs: 60_000 });
+      limiter.recordFailure("10.0.6.3");
+      vi.advanceTimersByTime(999);
+      limiter.recordFailure("10.0.6.3");
+      expect(limiter.check("10.0.6.3").allowed).toBe(false);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("treats ipv4 and ipv4-mapped ipv6 forms as the same client", () => {
     limiter = createAuthRateLimiter({ maxAttempts: 1, windowMs: 60_000, lockoutMs: 60_000 });
     limiter.recordFailure("1.2.3.4");

--- a/src/gateway/auth-rate-limit.test.ts
+++ b/src/gateway/auth-rate-limit.test.ts
@@ -241,6 +241,34 @@ describe("auth rate limiter", () => {
     expect(limiter.size()).toBe(expectedSize);
   });
 
+  it.each([
+    { value: 0, effectiveMaxAttempts: 1 },
+    { value: -2, effectiveMaxAttempts: 1 },
+    { value: 1.9, effectiveMaxAttempts: 1 },
+    { value: 2.9, effectiveMaxAttempts: 2 },
+    { value: Number.NaN, effectiveMaxAttempts: 10 },
+    { value: Number.POSITIVE_INFINITY, effectiveMaxAttempts: 10 },
+  ])(
+    "normalizes maxAttempts value $value instead of locking out before any failure",
+    ({ value, effectiveMaxAttempts }) => {
+      limiter = createAuthRateLimiter({
+        maxAttempts: value,
+        windowMs: 60_000,
+        lockoutMs: 60_000,
+        pruneIntervalMs: 0,
+      });
+
+      const ip = "10.0.5.1";
+      for (let i = 0; i < effectiveMaxAttempts - 1; i++) {
+        limiter.recordFailure(ip);
+      }
+      expect(limiter.check(ip).allowed).toBe(true);
+
+      limiter.recordFailure(ip);
+      expect(limiter.check(ip).allowed).toBe(false);
+    },
+  );
+
   it("treats ipv4 and ipv4-mapped ipv6 forms as the same client", () => {
     limiter = createAuthRateLimiter({ maxAttempts: 1, windowMs: 60_000, lockoutMs: 60_000 });
     limiter.recordFailure("1.2.3.4");

--- a/src/gateway/auth-rate-limit.test.ts
+++ b/src/gateway/auth-rate-limit.test.ts
@@ -269,6 +269,23 @@ describe("auth rate limiter", () => {
     },
   );
 
+  it("does not disable the sliding window when windowMs is 0", () => {
+    // windowMs: 0 made slideWindow's cutoff equal `now`, wiping every recorded
+    // attempt on the very next check before maxAttempts could ever be reached.
+    limiter = createAuthRateLimiter({ maxAttempts: 2, windowMs: 0, lockoutMs: 60_000 });
+    limiter.recordFailure("10.0.6.1");
+    limiter.recordFailure("10.0.6.1");
+    expect(limiter.check("10.0.6.1").allowed).toBe(false);
+  });
+
+  it("does not disable the lockout duration when lockoutMs is 0", () => {
+    limiter = createAuthRateLimiter({ maxAttempts: 1, windowMs: 60_000, lockoutMs: 0 });
+    limiter.recordFailure("10.0.6.2");
+    const result = limiter.check("10.0.6.2");
+    expect(result.allowed).toBe(false);
+    expect(result.retryAfterMs).toBeGreaterThan(0);
+  });
+
   it("treats ipv4 and ipv4-mapped ipv6 forms as the same client", () => {
     limiter = createAuthRateLimiter({ maxAttempts: 1, windowMs: 60_000, lockoutMs: 60_000 });
     limiter.recordFailure("1.2.3.4");

--- a/src/gateway/auth-rate-limit.test.ts
+++ b/src/gateway/auth-rate-limit.test.ts
@@ -286,6 +286,22 @@ describe("auth rate limiter", () => {
     expect(result.retryAfterMs).toBeGreaterThan(0);
   });
 
+  it("clamps a non-positive windowMs to a 1s floor, not the generic 1ms minimum", () => {
+    // A 1ms floor is real-clock-flaky: two sequential recordFailure() calls
+    // can legitimately land more than 1ms apart. Assert the actual clamp
+    // deterministically with fake timers instead of relying on real timing.
+    vi.useFakeTimers();
+    try {
+      limiter = createAuthRateLimiter({ maxAttempts: 2, windowMs: 0, lockoutMs: 60_000 });
+      limiter.recordFailure("10.0.6.3");
+      vi.advanceTimersByTime(999);
+      limiter.recordFailure("10.0.6.3");
+      expect(limiter.check("10.0.6.3").allowed).toBe(false);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("treats ipv4 and ipv4-mapped ipv6 forms as the same client", () => {
     limiter = createAuthRateLimiter({ maxAttempts: 1, windowMs: 60_000, lockoutMs: 60_000 });
     limiter.recordFailure("1.2.3.4");

--- a/src/gateway/auth-rate-limit.ts
+++ b/src/gateway/auth-rate-limit.ts
@@ -133,7 +133,7 @@ export function isAuthRateLimitClientExempt(
 // Defaults
 // ---------------------------------------------------------------------------
 
-const DEFAULT_MAX_ATTEMPTS = 10;
+export const DEFAULT_MAX_ATTEMPTS = 10;
 const DEFAULT_WINDOW_MS = 60_000; // 1 minute
 const DEFAULT_LOCKOUT_MS = 300_000; // 5 minutes
 const PRUNE_INTERVAL_MS = 60_000; // prune stale entries every minute

--- a/src/gateway/auth-rate-limit.ts
+++ b/src/gateway/auth-rate-limit.ts
@@ -179,8 +179,12 @@ function resolvePruneIntervalMs(value: number | undefined): number {
 
 export function createAuthRateLimiter(config?: RateLimitConfig): AuthRateLimiter {
   const maxAttempts = resolveIntegerOption(config?.maxAttempts, DEFAULT_MAX_ATTEMPTS, { min: 1 });
-  const windowMs = resolveTimerTimeoutMs(config?.windowMs, DEFAULT_WINDOW_MS);
-  const lockoutMs = resolveTimerTimeoutMs(config?.lockoutMs, DEFAULT_LOCKOUT_MS);
+  // A 1ms floor (this helper's generic default) is real-clock-flaky here: two
+  // sequential recordFailure() calls can legitimately land more than 1ms
+  // apart, so slideWindow would evict the first attempt before the second is
+  // recorded. 1s cannot realistically be raced by same-request-cycle timing.
+  const windowMs = resolveTimerTimeoutMs(config?.windowMs, DEFAULT_WINDOW_MS, 1_000);
+  const lockoutMs = resolveTimerTimeoutMs(config?.lockoutMs, DEFAULT_LOCKOUT_MS, 1_000);
   const exemptLoopback = config?.exemptLoopback ?? true;
   const pruneIntervalMs = resolvePruneIntervalMs(config?.pruneIntervalMs);
   const maxEntries = resolveIntegerOption(config?.maxEntries, DEFAULT_MAX_ENTRIES, { min: 1 });

--- a/src/gateway/auth-rate-limit.ts
+++ b/src/gateway/auth-rate-limit.ts
@@ -134,8 +134,8 @@ export function isAuthRateLimitClientExempt(
 // ---------------------------------------------------------------------------
 
 export const DEFAULT_MAX_ATTEMPTS = 10;
-const DEFAULT_WINDOW_MS = 60_000; // 1 minute
-const DEFAULT_LOCKOUT_MS = 300_000; // 5 minutes
+export const DEFAULT_WINDOW_MS = 60_000; // 1 minute
+export const DEFAULT_LOCKOUT_MS = 300_000; // 5 minutes
 const PRUNE_INTERVAL_MS = 60_000; // prune stale entries every minute
 const DEFAULT_MAX_ENTRIES = 10_000;
 const LOOPBACK_FAILURE_DELAY_BASE_MS = 250;
@@ -179,8 +179,8 @@ function resolvePruneIntervalMs(value: number | undefined): number {
 
 export function createAuthRateLimiter(config?: RateLimitConfig): AuthRateLimiter {
   const maxAttempts = resolveIntegerOption(config?.maxAttempts, DEFAULT_MAX_ATTEMPTS, { min: 1 });
-  const windowMs = resolveTimerTimeoutMs(config?.windowMs, DEFAULT_WINDOW_MS, 0);
-  const lockoutMs = resolveTimerTimeoutMs(config?.lockoutMs, DEFAULT_LOCKOUT_MS, 0);
+  const windowMs = resolveTimerTimeoutMs(config?.windowMs, DEFAULT_WINDOW_MS);
+  const lockoutMs = resolveTimerTimeoutMs(config?.lockoutMs, DEFAULT_LOCKOUT_MS);
   const exemptLoopback = config?.exemptLoopback ?? true;
   const pruneIntervalMs = resolvePruneIntervalMs(config?.pruneIntervalMs);
   const maxEntries = resolveIntegerOption(config?.maxEntries, DEFAULT_MAX_ENTRIES, { min: 1 });

--- a/src/gateway/auth-rate-limit.ts
+++ b/src/gateway/auth-rate-limit.ts
@@ -178,7 +178,7 @@ function resolvePruneIntervalMs(value: number | undefined): number {
 }
 
 export function createAuthRateLimiter(config?: RateLimitConfig): AuthRateLimiter {
-  const maxAttempts = config?.maxAttempts ?? DEFAULT_MAX_ATTEMPTS;
+  const maxAttempts = resolveIntegerOption(config?.maxAttempts, DEFAULT_MAX_ATTEMPTS, { min: 1 });
   const windowMs = resolveTimerTimeoutMs(config?.windowMs, DEFAULT_WINDOW_MS, 0);
   const lockoutMs = resolveTimerTimeoutMs(config?.lockoutMs, DEFAULT_LOCKOUT_MS, 0);
   const exemptLoopback = config?.exemptLoopback ?? true;

--- a/src/gateway/auth-rate-limit.ts
+++ b/src/gateway/auth-rate-limit.ts
@@ -108,7 +108,7 @@ export interface AuthRateLimiter {
 // Defaults
 // ---------------------------------------------------------------------------
 
-const DEFAULT_MAX_ATTEMPTS = 10;
+export const DEFAULT_MAX_ATTEMPTS = 10;
 const DEFAULT_WINDOW_MS = 60_000; // 1 minute
 const DEFAULT_LOCKOUT_MS = 300_000; // 5 minutes
 const PRUNE_INTERVAL_MS = 60_000; // prune stale entries every minute

--- a/src/gateway/auth-rate-limit.ts
+++ b/src/gateway/auth-rate-limit.ts
@@ -109,8 +109,8 @@ export interface AuthRateLimiter {
 // ---------------------------------------------------------------------------
 
 export const DEFAULT_MAX_ATTEMPTS = 10;
-const DEFAULT_WINDOW_MS = 60_000; // 1 minute
-const DEFAULT_LOCKOUT_MS = 300_000; // 5 minutes
+export const DEFAULT_WINDOW_MS = 60_000; // 1 minute
+export const DEFAULT_LOCKOUT_MS = 300_000; // 5 minutes
 const PRUNE_INTERVAL_MS = 60_000; // prune stale entries every minute
 const DEFAULT_MAX_ENTRIES = 10_000;
 const LOOPBACK_FAILURE_DELAY_BASE_MS = 250;
@@ -154,8 +154,8 @@ function resolvePruneIntervalMs(value: number | undefined): number {
 
 export function createAuthRateLimiter(config?: RateLimitConfig): AuthRateLimiter {
   const maxAttempts = resolveIntegerOption(config?.maxAttempts, DEFAULT_MAX_ATTEMPTS, { min: 1 });
-  const windowMs = resolveTimerTimeoutMs(config?.windowMs, DEFAULT_WINDOW_MS, 0);
-  const lockoutMs = resolveTimerTimeoutMs(config?.lockoutMs, DEFAULT_LOCKOUT_MS, 0);
+  const windowMs = resolveTimerTimeoutMs(config?.windowMs, DEFAULT_WINDOW_MS);
+  const lockoutMs = resolveTimerTimeoutMs(config?.lockoutMs, DEFAULT_LOCKOUT_MS);
   const exemptLoopback = config?.exemptLoopback ?? true;
   const pruneIntervalMs = resolvePruneIntervalMs(config?.pruneIntervalMs);
   const maxEntries = resolveIntegerOption(config?.maxEntries, DEFAULT_MAX_ENTRIES, { min: 1 });

--- a/src/gateway/auth-rate-limit.ts
+++ b/src/gateway/auth-rate-limit.ts
@@ -154,8 +154,12 @@ function resolvePruneIntervalMs(value: number | undefined): number {
 
 export function createAuthRateLimiter(config?: RateLimitConfig): AuthRateLimiter {
   const maxAttempts = resolveIntegerOption(config?.maxAttempts, DEFAULT_MAX_ATTEMPTS, { min: 1 });
-  const windowMs = resolveTimerTimeoutMs(config?.windowMs, DEFAULT_WINDOW_MS);
-  const lockoutMs = resolveTimerTimeoutMs(config?.lockoutMs, DEFAULT_LOCKOUT_MS);
+  // A 1ms floor (this helper's generic default) is real-clock-flaky here: two
+  // sequential recordFailure() calls can legitimately land more than 1ms
+  // apart, so slideWindow would evict the first attempt before the second is
+  // recorded. 1s cannot realistically be raced by same-request-cycle timing.
+  const windowMs = resolveTimerTimeoutMs(config?.windowMs, DEFAULT_WINDOW_MS, 1_000);
+  const lockoutMs = resolveTimerTimeoutMs(config?.lockoutMs, DEFAULT_LOCKOUT_MS, 1_000);
   const exemptLoopback = config?.exemptLoopback ?? true;
   const pruneIntervalMs = resolvePruneIntervalMs(config?.pruneIntervalMs);
   const maxEntries = resolveIntegerOption(config?.maxEntries, DEFAULT_MAX_ENTRIES, { min: 1 });

--- a/src/gateway/auth-rate-limit.ts
+++ b/src/gateway/auth-rate-limit.ts
@@ -153,7 +153,7 @@ function resolvePruneIntervalMs(value: number | undefined): number {
 }
 
 export function createAuthRateLimiter(config?: RateLimitConfig): AuthRateLimiter {
-  const maxAttempts = config?.maxAttempts ?? DEFAULT_MAX_ATTEMPTS;
+  const maxAttempts = resolveIntegerOption(config?.maxAttempts, DEFAULT_MAX_ATTEMPTS, { min: 1 });
   const windowMs = resolveTimerTimeoutMs(config?.windowMs, DEFAULT_WINDOW_MS, 0);
   const lockoutMs = resolveTimerTimeoutMs(config?.lockoutMs, DEFAULT_LOCKOUT_MS, 0);
   const exemptLoopback = config?.exemptLoopback ?? true;


### PR DESCRIPTION
## What Problem This Solves

`gateway.auth.rateLimit.maxAttempts` accepted `0`, negative numbers, fractions,
or non-finite values (`NaN`/`Infinity`) with no schema validation. Setting
`maxAttempts: 0` (a natural way to try to write "no extra limit") instead locks
out a client's IP after exactly **one** failed authentication attempt, with no
config-load error to warn the operator — turning a rate-limit tuning knob into
a self-inflicted denial of service on the Gateway's own auth surface. Passing
`NaN`/`Infinity` goes the other way inside `createAuthRateLimiter`'s `check()`:
`remaining = Math.max(0, maxAttempts - attempts.length)` propagates `NaN`
through the comparison, making `allowed` `false` unconditionally once any
attempt is recorded — a silent fail-closed lockout that never actually sets
`lockedUntil`.

## Why This Change Was Made

Every other numeric limit/timeout field in this same schema file
(`contextWindow`, `maxTokens`, port bounds, etc.) is already constrained with
`.int().positive()` / `.int().min(1)`; `rateLimit.maxAttempts` was the one
outlier accepting any finite number. This change:

- Adds `.int().positive()` to `maxAttempts` in `GatewayConfigSchema`, so
  invalid config is rejected at load time with a clear validation error
  instead of silently producing broken runtime behavior.
- Clamps `maxAttempts` inside `createAuthRateLimiter` itself via the
  `resolveIntegerOption` helper already used two lines below for
  `maxEntries`, so the shared limiter function is robust regardless of
  caller (it has three call sites in this file, not all of which necessarily
  go through the zod-validated config path).

**Update — scope broadened to `windowMs`/`lockoutMs` too:** while reconciling
with an earlier, overlapping PR of mine (#112428, now closed as superseded by
this one), it turned out the same missing-validation root cause applies to
the two sibling fields, which this PR originally left out of scope:

- `windowMs: 0` makes `slideWindow`'s cutoff equal `now`, so the sliding-window
  filter wipes every recorded attempt on the very next check — failed logins
  are recorded but never accumulate toward the limit.
- `lockoutMs: 0` collapses the lockout duration to zero, so a "locked" client
  is immediately unlocked again.

Same fix shape as `maxAttempts` at first: `.int().positive()` added to both
fields in the schema, and the runtime resolver's explicit `, 0` minimum
override dropped. **Note:** dropping straight to `resolveTimerTimeoutMs`'s
generic default minimum (1ms) turned out to be real-clock-flaky — verified by
running a bare reproduction repeatedly and seeing it fail intermittently,
because two sequential `recordFailure()` calls can legitimately land more
than 1ms apart in real (non-fake-timer) execution, so the sliding window
would evict the first attempt before the second was recorded. Used an
explicit 1000ms floor instead (confirmed non-flaky across 20 repeated
real-clock runs); no legitimate config would ever want a sub-second
window/lockout regardless.

**Update per ClawSweeper review (schema/runtime floor mismatch):** raising
the runtime floor to 1000ms without also raising the schema/migration
minimum left a gap — `.positive()` still accepted any value from 1 to 999,
so a persisted `windowMs: 500` would pass schema validation and the
migration untouched, then get silently rewritten to 1000ms by the runtime
clamp on every startup, changing an operator's configured policy with no
error or visible repair. Tightened the schema to `.int().min(1_000)` for
`windowMs`/`lockoutMs` (`maxAttempts` is unaffected — it has no duration
semantics, still `.int().positive()`), and extended the doctor migration so
a positive-but-below-the-floor value is also repaired, with an accurate
"at least 1000ms" message. Added schema and migration test coverage for the
exact 999/1000 boundary.

**Update per ClawSweeper review (migration deleted a currently-valid value):**
the schema/floor-alignment migration above still deleted a persisted positive
`windowMs`/`lockoutMs` below 1000ms and replaced it with the 60000ms/300000ms
default, even though the runtime clamp would only floor it to 1000ms — e.g. an
operator's `windowMs: 500` (accepted by current releases) became `60000` on
upgrade, a 120x change instead of the minimal 2x correction the new floor
actually requires. Changed the migration to raise a positive integer below
the floor to 1000ms in place, instead of deleting it. Deletion+default is now
reserved for values with no sensible floor target: non-positive, fractional,
or non-finite. `maxAttempts` is unaffected — it has no duration semantics, so
there's no floor to raise to; it still deletes+defaults on any invalid value.

**Update per ClawSweeper review:** the stricter schema alone could reject a
persisted config that current releases accept, with no recovery path. Added
`gateway.auth.rateLimit-oob-repair`, a legacy config migration in
`src/commands/doctor/shared/legacy-config-migrations.runtime.gateway.ts` that
mirrors the existing `gateway.port-oob-repair` migration exactly: it removes
non-positive-integer `maxAttempts`/`windowMs`/`lockoutMs` values (one small
per-field loop covering all three) from the persisted config before schema
validation runs (both during `openclaw doctor --fix` and automatically during
normal startup preflight, same as the port migration), so an existing
installation falls back to the documented defaults (10 / 60000ms / 300000ms)
instead of failing to load. `DEFAULT_MAX_ATTEMPTS`/`DEFAULT_WINDOW_MS`/
`DEFAULT_LOCKOUT_MS` are now exported from `auth-rate-limit.ts` so the
migration message can cite the exact fallback values, matching how
`DEFAULT_GATEWAY_PORT` is already surfaced for the port migration.

**Update per ClawSweeper review (migration still deleted positive fractional
settings):** the delete→normalize fix above only covered positive **integer**
values below the 1000ms floor (e.g. `windowMs: 500`). A positive **fractional**
value — `maxAttempts: 2.5`, `windowMs: 1000.5`, `lockoutMs: 500.7` — still hit
the delete+default branch, even though `resolveIntegerOption`/
`resolveTimerTimeoutMs` already floor (and, for durations, clamp) fractional
input at runtime today. Concretely: a saved `maxAttempts: 2.5` currently locks
on the 3rd failed attempt; deleting it on migration silently widened that to
the default of 10 attempts — a real weakening of an active auth threshold,
flagged by ClawSweeper as a security concern. Unified the "raise a sub-floor
integer" and "delete a fractional value" branches into one: any positive
finite value (integer or fractional) now normalizes to its runtime-effective
integer (`Math.max(1, Math.floor(v))` for `maxAttempts`,
`Math.max(1000, Math.floor(v))` for `windowMs`/`lockoutMs`) instead of being
deleted. Deletion+default is now reserved for genuinely non-positive or
non-finite input, matching ClawSweeper's exact recommendation. A wrong-type
value (e.g. a string) is left untouched, same as before — caught this as a
regression in my own first pass at the refactor (the naive version would have
started silently deleting those too) and added a regression test for it.

## User Impact

Operators can no longer misconfigure `gateway.auth.rateLimit.maxAttempts`,
`.windowMs`, or `.lockoutMs` into an accidental self-DoS lockout, a silently
disabled rate limiter, or an effectively-permanent lockout via a non-finite
value — the config is rejected up front with a clear error, and the runtime
limiter falls back to sane values even if constructed with a bad literal from
another call site.

## Evidence

- Base: rebased onto current `upstream/main` at `4da57168d3c1970419e93e59a91e65466518231b` (2026-08-26; previous base was `cfa98bdf0` from 2026-07-29). Rebase hit one conflict, in `src/config/validation.policy.test.ts` — two unrelated `describe` blocks (an upstream "ambient heartbeat ownership" suite and this PR's `gateway.auth.rateLimit policy` suite) both appended at the same insertion point; resolved by keeping both blocks, no logic conflict. Re-ran the full pipeline from scratch post-rebase rather than trusting the clean auto-merge of the other 5 files (`legacy-config-migrate.test.ts`, `legacy-config-migrations.runtime.gateway.ts`, `zod-schema.gateway.ts`, `auth-rate-limit.test.ts`, `auth-rate-limit.ts`).
- Negative-control (red on pre-fix code, confirmed by temporarily reverting
  the production-code files to their `upstream/main` versions and re-running
  the new tests):
  - `normalizes maxAttempts value 1.9` / `2.9` / `NaN` / `Infinity` — all 4
    failed against the pre-fix `createAuthRateLimiter`, matching the reported
    bug (fractional values used the raw un-floored threshold; `NaN`/`Infinity`
    produced permanently-`false` `allowed` via `Math.max(0, NaN)`).
  - New schema tests (`zod-schema.gateway.test.ts`) fail with pre-fix schema
    (no constraint) and pass after adding `.int().positive()`.
  - All 6 new doctor-migration tests fail with the pre-migration file and pass
    after adding `gateway.auth.rateLimit.max-attempts-oob-repair`.
- windowMs/lockoutMs broadening — negative-control (red on the 1000ms-floor
  commit's parent, confirmed the same way): all `windowMs`/`lockoutMs` schema,
  runtime, and doctor-migration tests fail without the fix. A separate
  negative control on the 1000ms floor itself: the new
  `clamps a non-positive windowMs to a 1s floor, not the generic 1ms minimum`
  fake-timer test fails against the intermediate commit that used the generic
  1ms floor, and passes after the explicit 1000ms floor.
- Schema/migration floor-alignment fix — negative-control (red on the parent
  commit, before this fix): the new
  `removes a positive windowMs/lockoutMs below the 1000ms runtime floor`
  migration test and boundary schema tests (999 rejected, 1000 accepted) fail
  against the pre-fix schema/migration (which still only checked "positive
  integer"), confirmed by reverting just the two prod files and re-running.
- Migration delete→normalize fix — negative-control (red on the parent
  commit): the new
  `raises a positive windowMs/lockoutMs below the 1000ms floor instead of
  deleting it` test fails against the pre-fix migration (which reported
  "Removed invalid ... the gateway will use the default of 60000" instead of
  "Raised ... to 1000"), confirmed by reverting just the migration file and
  re-running.
- Green on this PR's head (`f5370080`), rebased onto current `upstream/main`:
  - `node scripts/run-vitest.mjs src/gateway/auth-rate-limit.test.ts src/config/zod-schema.gateway.test.ts src/config/validation.policy.test.ts src/commands/doctor/shared/legacy-config-migrate.test.ts` → 245/245 passed.
  - `./node_modules/.bin/oxfmt --check` on all touched files: clean.
  - `./node_modules/.bin/oxlint -c .oxlintrc.json` on all touched files: clean (0 findings).
  - `pnpm tsgo:core` (production-code typecheck): clean, no errors.
  - `pnpm check:import-cycles`: 0 cycles (new cross-import from doctor
    migrations into `gateway/auth-rate-limit.js`).
- Competing open PR scan: none found referencing this file/behavior (#112428
  was mine, from an earlier session; closed as superseded by this PR).
- **Real production-path proof** (imports the actual schema, actual runtime
  limiter, and actual doctor migration directly — no mocks; run via
  `tsx`/`node --import tsx` against this PR's head):

  ```
  === 1. Schema rejects a persisted invalid maxAttempts (would have silently loaded before) ===
  maxAttempts=0 -> ok=false auth.rateLimit.maxAttempts: Too small: expected number to be >0
  maxAttempts=-1 -> ok=false auth.rateLimit.maxAttempts: Too small: expected number to be >0
  maxAttempts=2.5 -> ok=false auth.rateLimit.maxAttempts: Invalid input: expected int, received number

  === 2. Runtime limiter behavior BEFORE proof (direct construction bypassing schema) ===
  maxAttempts:0 config -> after exactly 1 failed login, check() = {"allowed":false,"remaining":0,"retryAfterMs":59999}
  CONFIRMS BUG: IP locked out after a single failed attempt.

  === 3. Doctor migration repairs an existing persisted config with the invalid value ===
  before: {"gateway":{"auth":{"rateLimit":{"maxAttempts":0,"windowMs":60000}}}}
  after:  {"gateway":{"auth":{"rateLimit":{"windowMs":60000}}}}
  changes: [
    'Removed invalid gateway.auth.rateLimit.maxAttempts (0). It must be a positive integer; the gateway will use the default of 10 attempts.'
  ]
  re-validated post-migration config ok = true
  ```

  And the genuine pre-fix negative control, run against `upstream/main`'s
  version of the same two files, showing the schema silently accepting
  invalid values, and a direct (non-schema) call with `maxAttempts: NaN`
  permanently denying every request via `Math.max(0, NaN)` — a fail-closed
  variant of the same missing-validation root cause:

  ```
  === PRE-FIX: schema accepts what it should reject ===
  maxAttempts=0 -> ok=true
  maxAttempts=-1 -> ok=true
  maxAttempts=2.5 -> ok=true
  maxAttempts=NaN -> ok=false

  === PRE-FIX: NaN maxAttempts silently disables rate limiting via check()'s Math.max(0,NaN) ===
  after 5 failed attempts, check() = {"allowed":false,"remaining":null,"retryAfterMs":0}
  ```

  (`remaining:null` here is `JSON.stringify` rendering the actual `NaN` value.
  `NaN` itself is rejected by zod's `z.number()` — the fail-closed lockout is
  reachable only through a direct, non-schema-validated call to
  `createAuthRateLimiter`, which is exactly the gap the runtime-level
  `resolveIntegerOption` clamp in this PR closes.)

  Same real-production-path method for the `windowMs`/`lockoutMs` broadening,
  against this PR's head:

  ```
  === 1. Schema rejects invalid windowMs/lockoutMs (previously silently accepted) ===
  windowMs=0 -> ok=false auth.rateLimit.windowMs: Too small: expected number to be >0
  windowMs=-5 -> ok=false auth.rateLimit.windowMs: Too small: expected number to be >0
  lockoutMs=0 -> ok=false auth.rateLimit.lockoutMs: Too small: expected number to be >0
  lockoutMs=1.5 -> ok=false auth.rateLimit.lockoutMs: Invalid input: expected int, received number

  === 2. Runtime limiter: windowMs:0 previously wiped every recorded attempt on the next check ===
  windowMs:0, after 2 failures against maxAttempts:2 -> check() = {"allowed":false,"remaining":0,"retryAfterMs":60000}
  FIXED: lockout still triggers. (Confirmed non-flaky: ran 20x consecutively, 20/20 correctly locked.)

  === 3. Doctor migration repairs an existing persisted config with all three invalid fields ===
  before: {"gateway":{"auth":{"rateLimit":{"maxAttempts":0,"windowMs":1.5,"lockoutMs":null}}}}
  after:  {}
  changes: [
    'Removed invalid gateway.auth.rateLimit.maxAttempts (0). It must be a positive integer; the gateway will use the default of 10.',
    'Removed invalid gateway.auth.rateLimit.windowMs (1.5). It must be a positive integer; the gateway will use the default of 60000.',
    'Removed invalid gateway.auth.rateLimit.lockoutMs (NaN). It must be a positive integer; the gateway will use the default of 300000.'
  ]
  ```

  Genuine pre-fix negative control for the `windowMs:0` case, run against
  `upstream/main`'s version of `auth-rate-limit.ts`:

  ```
  === PRE-FIX: windowMs:0 wipes attempts on the very next check ===
  windowMs:0, after 2 failures against maxAttempts:2 -> check() = {"allowed":true,"remaining":2,"retryAfterMs":0}
  ```

  Both recorded failures were silently wiped; the client was never locked out
  despite reaching `maxAttempts`.

  Real production-path proof for the schema/migration floor-alignment fix,
  against this PR's head:

  ```
  === 1. Schema now rejects the 1-999ms gap the runtime would have silently rewritten ===
  windowMs=1 -> ok=false Too small: expected number to be >=1000
  windowMs=500 -> ok=false Too small: expected number to be >=1000
  windowMs=999 -> ok=false Too small: expected number to be >=1000
  windowMs=1000 -> ok=true

  === 2. Doctor migration now repairs a persisted sub-floor value instead of leaving it to be silently rewritten ===
  before: {"gateway":{"auth":{"rateLimit":{"windowMs":500,"lockoutMs":999}}}}
  after:  {}
  changes: [
    'Removed invalid gateway.auth.rateLimit.windowMs (500). It must be an integer of at least 1000ms; the gateway will use the default of 60000.',
    'Removed invalid gateway.auth.rateLimit.lockoutMs (999). It must be an integer of at least 1000ms; the gateway will use the default of 300000.'
  ]
  ```

  Real production-path proof for the delete→normalize fix, against this PR's
  final head — a positive sub-floor value is now raised in place, and a truly
  invalid value still deletes+defaults:

  ```
  === 1. Positive sub-floor value: now NORMALIZED (preserves operator intent), not deleted ===
  before: windowMs=500, lockoutMs=999
  after:  {"gateway":{"auth":{"rateLimit":{"windowMs":1000,"lockoutMs":1000}}}}
  changes: [
    'Raised gateway.auth.rateLimit.windowMs (500) to 1000. It must be an integer of at least 1000ms.',
    'Raised gateway.auth.rateLimit.lockoutMs (999) to 1000. It must be an integer of at least 1000ms.'
  ]

  === 2. Truly invalid value: still deleted+defaulted (no sensible floor target) ===
  before: windowMs=0, lockoutMs=NaN
  after:  {}
  changes: [
    'Removed invalid gateway.auth.rateLimit.windowMs (0). It must be an integer of at least 1000ms; the gateway will use the default of 60000.',
    'Removed invalid gateway.auth.rateLimit.lockoutMs (NaN). It must be an integer of at least 1000ms; the gateway will use the default of 300000.'
  ]
  ```

Real production-path proof for the fractional-preservation fix, against this
PR's final head (`603e8654d`) — a positive fractional value is now normalized
to its runtime-effective integer, not deleted, and the migrated config passes
the actual Gateway schema validator (`validateConfigObjectWithPlugins`, the
same function used by `doctor --fix` and normal startup preflight):

```
=== BEFORE migration: real Gateway schema validation of the raw persisted config ===
ok: false

=== doctor --fix upgrade path: migrateLegacyConfig (real function, not a test helper) ===
changes: [
  "Raised gateway.auth.rateLimit.maxAttempts (2.5) to 2. It must be a positive integer.",
  "Raised gateway.auth.rateLimit.windowMs (1000.5) to 1000. It must be an integer of at least 1000ms.",
  "Raised gateway.auth.rateLimit.lockoutMs (500.7) to 1000. It must be an integer of at least 1000ms."
]
migrated gateway.auth.rateLimit: {"maxAttempts":2,"windowMs":1000,"lockoutMs":1000}

=== AFTER migration: real Gateway schema validation of the migrated config ===
ok: true

=== Regression check: wrong-type value left untouched ===
changes: []
config unchanged (null = no migration applied): null
```

Genuine pre-fix negative control, run the same way against the version of
`legacy-config-migrations.runtime.gateway.ts` still on `upstream/main`
(temporarily reverted via `git stash push -- <file>`, then restored):

```
=== doctor --fix upgrade path (PRE-FIX) ===
changes: [
  "Removed invalid gateway.auth.rateLimit.maxAttempts (2.5). It must be a positive integer; the gateway will use the default of 10.",
  "Removed invalid gateway.auth.rateLimit.windowMs (1000.5). It must be an integer of at least 1000ms; the gateway will use the default of 60000.",
  "Removed invalid gateway.auth.rateLimit.lockoutMs (500.7). It must be an integer of at least 1000ms; the gateway will use the default of 300000."
]
migrated gateway.auth.rateLimit: undefined
```

Confirms the reported bug exactly: a saved `maxAttempts: 2.5` (locks on the
3rd failure) silently became the default of 10 on upgrade.

Full scoped pipeline re-run post-rebase, on the final head:
- `npx vitest run src/gateway/auth-rate-limit.test.ts src/config/zod-schema.gateway.test.ts src/config/validation.policy.test.ts src/commands/doctor/shared/legacy-config-migrate.test.ts` → 372/372 passed (6 test files).
- `./node_modules/.bin/oxlint -c .oxlintrc.json` on all touched files: clean.
- `./node_modules/.bin/oxfmt --check` on all touched files: clean.
- `pnpm tsgo:core`: clean, no errors.

## What Was Not Tested

Full `pnpm build`/full monorepo test suite was not run locally (this repo's
own tooling routes full/broad suites to remote CI/Testbox); scoped
vitest + typecheck + lint on the exact touched files were run instead.

AI-assisted: yes, built with Claude Code. Implementation was read, the exact
bug mechanism traced through `check()`/`recordFailure()`, and behavior
validated via the red→green tests above before this PR was opened.




