### PR TITLE
fix(agents): reject execCommand's promise on AbortSignal cancellation

### DIFF
--- a/src/agents/sessions/exec.test.ts
+++ b/src/agents/sessions/exec.test.ts
@@ -239,6 +239,43 @@ describe("execCommand", () => {
     expect(result.killed).toBe(true);
   });
 
+  it("rejects instead of resolving when the caller's AbortSignal fires", async () => {
+    // ctx.exec's documented cancellation contract is AbortSignal semantics: a
+    // cancelled run must reject, not resolve as if it had completed normally
+    // (matches the sibling find/grep session tools' abort handling).
+    const child = createStubChild();
+    const wait = createDeferred<number | null>();
+    spawnMock.mockReturnValue(child);
+    completionMock.mockReturnValue(wait.promise);
+    const { execCommand } = await import("./exec.js");
+
+    const controller = new AbortController();
+    const resultPromise = execCommand("cmd", [], "/tmp", { signal: controller.signal });
+    controller.abort();
+    expect(killProcessTreeMock).toHaveBeenCalledWith(1234, {
+      detached: process.platform !== "win32",
+      graceMs: 5000,
+    });
+
+    wait.resolve(0);
+    await expect(resultPromise).rejects.toThrow("Operation aborted");
+  });
+
+  it("still resolves a timeout-triggered kill (not treated as caller abort)", async () => {
+    vi.useFakeTimers();
+    const child = createStubChild();
+    const wait = createDeferred<number | null>();
+    spawnMock.mockReturnValue(child);
+    completionMock.mockReturnValue(wait.promise);
+    const { execCommand } = await import("./exec.js");
+
+    const resultPromise = execCommand("cmd", [], "/tmp", { timeout: 10 });
+    await vi.advanceTimersByTimeAsync(10);
+    wait.resolve(null);
+
+    await expect(resultPromise).resolves.toMatchObject({ killed: true });
+  });
+
   it("does not crash when stdout or stderr emit an error event", async () => {
     const child = createStubChild();
     const wait = createDeferred<number | null>();

--- a/src/agents/sessions/exec.test.ts
+++ b/src/agents/sessions/exec.test.ts
@@ -261,6 +261,27 @@ describe("execCommand", () => {
     await expect(resultPromise).rejects.toThrow("Operation aborted");
   });
 
+  it("rejects on abort even if the child never reports completion", async () => {
+    // The caller must not wait on child exit to see the rejection: killing
+    // a stuck process (or one still inside killProcessTree's grace period)
+    // can take arbitrarily long, and the promise must settle at abort
+    // time, not at eventual-exit time. Deliberately never resolves the
+    // deferred child completion, unlike the sibling test above. A short
+    // explicit timeout makes a regression fail fast instead of consuming
+    // vitest's full default budget.
+    const child = createStubChild();
+    const wait = createDeferred<number | null>();
+    spawnMock.mockReturnValue(child);
+    completionMock.mockReturnValue(wait.promise);
+    const { execCommand } = await import("./exec.js");
+
+    const controller = new AbortController();
+    const resultPromise = execCommand("cmd", [], "/tmp", { signal: controller.signal });
+    controller.abort();
+
+    await expect(resultPromise).rejects.toThrow("Operation aborted");
+  }, 2_000);
+
   it("rejects immediately without spawning when the signal is already aborted", async () => {
     // Sibling session tools (find/grep) never spawn work for a signal that was
     // already aborted before the call; execCommand must match that contract

--- a/src/agents/sessions/exec.test.ts
+++ b/src/agents/sessions/exec.test.ts
@@ -261,6 +261,20 @@ describe("execCommand", () => {
     await expect(resultPromise).rejects.toThrow("Operation aborted");
   });
 
+  it("rejects immediately without spawning when the signal is already aborted", async () => {
+    // Sibling session tools (find/grep) never spawn work for a signal that was
+    // already aborted before the call; execCommand must match that contract
+    // instead of spawning a process only to immediately kill it.
+    const controller = new AbortController();
+    controller.abort();
+    const { execCommand } = await import("./exec.js");
+
+    await expect(execCommand("cmd", [], "/tmp", { signal: controller.signal })).rejects.toThrow(
+      "Operation aborted",
+    );
+    expect(spawnMock).not.toHaveBeenCalled();
+  });
+
   it("still resolves a timeout-triggered kill (not treated as caller abort)", async () => {
     vi.useFakeTimers();
     const child = createStubChild();

--- a/src/agents/sessions/exec.ts
+++ b/src/agents/sessions/exec.ts
@@ -88,7 +88,7 @@ export async function execCommand(
   cwd: string,
   options?: ExecOptions,
 ): Promise<ExecResult> {
-  return new Promise((resolve) => {
+  return new Promise((resolve, reject) => {
     const proc = spawnCommand([command, ...args], {
       buffer: false,
       cwd,
@@ -103,6 +103,10 @@ export async function execCommand(
     const stdoutDecoder = new StringDecoder("utf8");
     const stderrDecoder = new StringDecoder("utf8");
     let killed = false;
+    // Caller cancellation (vs. an internal timeout/output-limit kill) must reject,
+    // matching AbortSignal convention and this module's sibling tools (find/grep);
+    // resolving here would let callers mistake a cancelled run for a completed one.
+    let abortedBySignal = false;
     let timeoutId: NodeJS.Timeout | undefined;
     let forceKillTimer: NodeJS.Timeout | undefined;
     let settled = false;
@@ -127,7 +131,11 @@ export async function execCommand(
         clearTimeout(forceKillTimer);
       }
       if (options?.signal) {
-        options.signal.removeEventListener("abort", killProcess);
+        options.signal.removeEventListener("abort", abortRequested);
+      }
+      if (abortedBySignal) {
+        reject(new Error("Operation aborted"));
+        return;
       }
       const stdoutBeforeFlush = stdout.truncatedChars;
       stdout = appendCapturedOutput(stdout, stdoutDecoder.end(), maxOutputChars, truncateOutput);
@@ -179,11 +187,15 @@ export async function execCommand(
     };
 
     // Handle abort signal
+    const abortRequested = () => {
+      abortedBySignal = true;
+      killProcess();
+    };
     if (options?.signal) {
       if (options.signal.aborted) {
-        killProcess();
+        abortRequested();
       } else {
-        options.signal.addEventListener("abort", killProcess, { once: true });
+        options.signal.addEventListener("abort", abortRequested, { once: true });
       }
     }
 

--- a/src/agents/sessions/exec.ts
+++ b/src/agents/sessions/exec.ts
@@ -15,7 +15,11 @@ const FORCE_KILL_GRACE_MS = 5000;
  * Options for executing shell commands.
  */
 export interface ExecOptions {
-  /** AbortSignal to cancel the command */
+  /**
+   * AbortSignal to cancel the command. Firing this signal rejects the
+   * returned promise with an "Operation aborted" error (the process is
+   * killed first); it never resolves as a completed/killed result.
+   */
   signal?: AbortSignal;
   /** Timeout in milliseconds */
   timeout?: number;
@@ -35,6 +39,7 @@ export interface ExecResult {
   stderrTruncatedChars?: number;
   outputLimitExceeded?: "stdout" | "stderr";
   code: number;
+  /** True when `timeout` or the output-limit guard killed the process. Caller-initiated `signal` cancellation rejects instead of resolving here. */
   killed: boolean;
 }
 

--- a/src/agents/sessions/exec.ts
+++ b/src/agents/sessions/exec.ts
@@ -94,6 +94,10 @@ export async function execCommand(
   options?: ExecOptions,
 ): Promise<ExecResult> {
   return new Promise((resolve, reject) => {
+    if (options?.signal?.aborted) {
+      reject(new Error("Operation aborted"));
+      return;
+    }
     const proc = spawnCommand([command, ...args], {
       buffer: false,
       cwd,
@@ -191,18 +195,14 @@ export async function execCommand(
       }
     };
 
-    // Handle abort signal
+    // Handle abort signal. Already-aborted signals are rejected before spawning
+    // (see top of this Promise executor), so by this point the signal, if any,
+    // is guaranteed not yet aborted -- only a later `abort` event can fire.
     const abortRequested = () => {
       abortedBySignal = true;
       killProcess();
     };
-    if (options?.signal) {
-      if (options.signal.aborted) {
-        abortRequested();
-      } else {
-        options.signal.addEventListener("abort", abortRequested, { once: true });
-      }
-    }
+    options?.signal?.addEventListener("abort", abortRequested, { once: true });
 
     // Handle timeout
     if (options?.timeout && options.timeout > 0) {

--- a/src/agents/sessions/exec.ts
+++ b/src/agents/sessions/exec.ts
@@ -112,13 +112,14 @@ export async function execCommand(
     const stdoutDecoder = new StringDecoder("utf8");
     const stderrDecoder = new StringDecoder("utf8");
     let killed = false;
-    // Caller cancellation (vs. an internal timeout/output-limit kill) must reject,
-    // matching AbortSignal convention and this module's sibling tools (find/grep);
-    // resolving here would let callers mistake a cancelled run for a completed one.
-    let abortedBySignal = false;
     let timeoutId: NodeJS.Timeout | undefined;
     let forceKillTimer: NodeJS.Timeout | undefined;
     let settled = false;
+    // Distinct from `settled`: abortRequested() now settles the caller's
+    // promise immediately, before the OS process has actually exited, so the
+    // SIGKILL-fallback guard in killProcess() needs its own signal for "has
+    // the process actually exited" rather than "has the promise settled".
+    let processExited = false;
     const maxOutputChars = clampMaxOutputChars(options?.maxOutputChars);
     const truncateOutput = options?.maxOutputChars !== undefined;
     let outputLimitExceeded: "stdout" | "stderr" | undefined;
@@ -129,6 +130,7 @@ export async function execCommand(
       }
     };
     const finish = (code: number) => {
+      processExited = true;
       if (settled) {
         return;
       }
@@ -141,10 +143,6 @@ export async function execCommand(
       }
       if (options?.signal) {
         options.signal.removeEventListener("abort", abortRequested);
-      }
-      if (abortedBySignal) {
-        reject(new Error("Operation aborted"));
-        return;
       }
       const stdoutBeforeFlush = stdout.truncatedChars;
       stdout = appendCapturedOutput(stdout, stdoutDecoder.end(), maxOutputChars, truncateOutput);
@@ -186,7 +184,7 @@ export async function execCommand(
         } else {
           proc.kill("SIGTERM");
           forceKillTimer = setTimeout(() => {
-            if (!settled) {
+            if (!processExited) {
               proc.kill("SIGKILL");
             }
           }, FORCE_KILL_GRACE_MS);
@@ -198,9 +196,24 @@ export async function execCommand(
     // Handle abort signal. Already-aborted signals are rejected before spawning
     // (see top of this Promise executor), so by this point the signal, if any,
     // is guaranteed not yet aborted -- only a later `abort` event can fire.
+    //
+    // Settle the caller here, not in `finish()`: `finish()` only runs once the
+    // child process actually exits, so a caller cancelling mid-grace-period
+    // (killProcessTree's SIGTERM-then-SIGKILL window, or a genuinely stuck
+    // process) would otherwise stay pending well past the point they cancelled.
+    // Don't clear `forceKillTimer` here -- that timer's SIGKILL fallback must
+    // keep running against the real OS process regardless of promise state.
     const abortRequested = () => {
-      abortedBySignal = true;
       killProcess();
+      if (settled) {
+        return;
+      }
+      settled = true;
+      if (timeoutId) {
+        clearTimeout(timeoutId);
+      }
+      options?.signal?.removeEventListener("abort", abortRequested);
+      reject(new Error("Operation aborted"));
     };
     options?.signal?.addEventListener("abort", abortRequested, { once: true });
 

--- a/src/agents/sessions/extensions/types.ts
+++ b/src/agents/sessions/extensions/types.ts
@@ -1330,7 +1330,7 @@ export interface ExtensionAPI {
   /** Set or clear a label on an entry. Labels are user-defined markers for bookmarking/navigation. */
   setLabel(entryId: string, label: string | undefined): void;
 
-  /** Execute a shell command. */
+  /** Execute a shell command. `options.signal` cancellation rejects the promise; it does not resolve a killed result. */
   exec(command: string, args: string[], options?: ExecOptions): Promise<ExecResult>;
 
   /** Get the list of currently active tool names. */


### PR DESCRIPTION
## What Problem This Solves

`execCommand` in `src/agents/sessions/exec.ts` — the implementation behind the
documented public plugin-SDK method `ExtensionContext.exec()` — kills the
child process tree when the caller's `AbortSignal` fires, but the wrapping
`Promise` still **resolves** as if the command had completed normally
(`{ code, killed: true, stdout, stderr }`). Extension/plugin code written the
standard way —
`try { const r = await ctx.exec(cmd, args, { signal }); ...; } catch (e) { /* handle cancellation */ }`
— never enters its `catch` block on cancellation and can go on to treat a
truncated/partial result as a completed run.

## Why This Change Was Made

This is the one outlier in its own file: sibling command-wrapper tools in the
same session-tools family (`src/agents/sessions/tools/find.ts`,
`src/agents/sessions/tools/grep.ts`) already reject with
`new Error("Operation aborted")` when their `signal` fires, matching standard
`AbortSignal`/`AbortController` convention (e.g. `fetch()`). `execCommand` is
brought in line with that existing in-repo pattern.

The fix only changes behavior for caller-initiated cancellation via
`options.signal`. An internal timeout-triggered kill (`options.timeout`) or an
output-limit-exceeded kill continues to **resolve** exactly as before (with
`killed: true`) — that existing, tested behavior is unrelated to the
cancellation-contract bug and is left untouched.

**Update per ClawSweeper review:** this is a plugin-facing contract change, so
per the review's own recommended option ("adopt rejection semantics ... with
focused compatibility documentation or tests proving timeout and output-limit
behavior remain distinct") the contract is now stated explicitly rather than
left implicit: `ExecOptions.signal`, `ExecResult.killed`, and
`ExtensionContext.exec` in `extensions/types.ts` now document that caller
cancellation rejects and is distinct from a timeout/output-limit kill, which
still resolves. No behavior change from the prior commit — this is
documentation only, backed by the test added in this PR that already asserts
both paths independently.

On the compatibility question itself: neither `docs/` nor `CHANGELOG.md`
mention any intentional "resolves on cancel" contract for `ctx.exec()` — it
was never a documented public behavior, only an inconsistency relative to the
rest of its own file's sibling tools (`find.ts`/`grep.ts`), which already
reject on abort. There is no evidence this repo has shipped guidance telling
extension authors to expect a resolved `killed: true` result on cancellation.

**Second update per ClawSweeper review:** a real P1 caught by the reviewer —
an `AbortSignal` that was already aborted *before* `execCommand()` was called
still spawned the child process, then immediately killed it via the existing
`if (options.signal.aborted)` branch. That's still correct in terms of
promise settlement (it did reject), but it's wasteful and inconsistent with
`find.ts`, which never spawns anything for a signal that's already aborted at
call time. Moved the aborted check to the very top of the Promise executor,
before `spawnCommand()` runs. The later aborted-at-entry branch inside the
abort-listener setup became dead code as a result (nothing awaits between the
new top-of-function check and that point, so the signal cannot flip states
in between) and was removed along with it.

**Third update per ClawSweeper review:** another real finding — `abortRequested()`
killed the child process but only rejected via `finish()`, which is reached
from the child's own completion callbacks (i.e. only once the OS process has
actually exited). `killProcessTree`'s SIGTERM-then-SIGKILL grace window (or a
genuinely stuck process) meant a caller who cancelled could stay pending well
past the point they called `abort()`, instead of getting the documented
prompt rejection. Moved the `reject()` call into `abortRequested()` itself,
guarded by the same `settled` flag `finish()` uses.

This required separating "has the promise settled" from "has the process
actually exited": the SIGKILL-fallback timer used to check `!settled` to
decide whether the process was already gone, but that's no longer true the
instant `abortRequested()` fires. Added a dedicated `processExited` flag, set
only from `finish()` (reached only via the child's real completion), and
switched the fallback check to it — otherwise the SIGKILL safety net would
silently stop firing for the plain-`kill()` (non-tree) path whenever abort
fires mid-grace-period, which I caught by tracing the flag's other use sites
before committing, not by the test suite (none of the mocked tests exercise
that specific fallback timer).

## User Impact

Extensions/plugins that call `ctx.exec(...)` with an `AbortSignal` and handle
cancellation via `catch` now actually see the rejection when a run is
cancelled — promptly, not after the killed process eventually exits — instead
of silently receiving a result that looks like a normal completion, or
waiting out a kill grace period. Timeout- and output-limit-triggered kills
are unaffected.

## Evidence

- Base: rebased onto current `upstream/main` at `48b3c1ea00e9825dfbc8cfdcee52be762b415ae9`.
- Negative-control (red on pre-fix code, confirmed by temporarily reverting
  `exec.ts` to its `upstream/main` version and re-running the new test):
  - `rejects instead of resolving when the caller's AbortSignal fires` fails
    against pre-fix code: promise resolves
    `{ code: 1, killed: true, stdout: '', stderr: '' }` instead of rejecting.
- Immediate-reject fix — negative-control (red on the parent commit): the new
  `rejects on abort even if the child never reports completion` test (which
  deliberately never resolves the mocked child's deferred completion) times
  out against the pre-fix code — the promise genuinely never settles, so the
  test fails with `Test timed out in 120000ms` rather than a clean assertion
  failure, itself direct proof of the bug (confirmed by reverting just
  `exec.ts` and re-running). Passes in ~10ms after the fix.
- Green on this PR's head (`6fc196cd`, rebased onto current `upstream/main`):
  - `node scripts/run-vitest.mjs src/agents/sessions/exec.test.ts` → 13/13
    passed: abort-rejects, already-aborted-doesn't-spawn, rejects-even-if-
    child-never-completes (2s explicit timeout so a regression fails fast),
    and a timeout-still-resolves regression test confirming the existing
    timeout/output-limit-kill behavior is unchanged.
  - `./node_modules/.bin/oxfmt --check` on touched files: clean.
  - `./node_modules/.bin/oxlint -c .oxlintrc.json` on touched files: clean (0 findings).
  - `pnpm tsgo:core` (production-code typecheck): clean, no errors.
- Competing open PR scan: none found referencing this file/behavior.
- **Real runtime proof** — an actual `bash sleep 30` child process, a real
  `AbortController`, no `vi.mock`/`spawnCommand` stub (run via a throwaway
  unmocked vitest test against this PR's head, then deleted before commit;
  `console.log` output shown with `--reporter=verbose`):

  ```
  PROOF spawned real child pid=244882 alive=true
  PROOF promise REJECTED as expected
  PROOF child pid=244882 alive after abort=false
  PROOF timeout result: {"stdout":"","stderr":"","code":1,"killed":true}
  ```

  The same harness run against `upstream/main`'s pre-fix `exec.ts` (negative
  control, real process again):

  ```
  AssertionError: promise resolved "{ stdout: '', stderr: '', …(5) }" instead of rejecting
  + {
  +   "code": 1,
  +   "killed": true,
  +   ...
  + }
  ```

- For the already-aborted-signal fix specifically: tried a real-process check
  first (`pgrep -c sleep` before/after) but it's not a discriminating proof —
  both the old and new code converge to zero running processes within
  milliseconds (old code spawns then immediately kills; new code never
  spawns), so a process-count snapshot can't tell them apart and I'm not
  including it as evidence. The precise proof for this specific claim is the
  mocked assertion, which checks the actual call, not a timing-sensitive
  side effect: `rejects immediately without spawning when the signal is
  already aborted` asserts `spawnMock` is never invoked, and fails against
  the pre-fix code (throwing `Cannot read properties of undefined (reading
  'then')` from the unconfigured mock, since the old code path does call
  spawn) and passes after the fix.

Real timing proof for the immediate-reject fix — an actual real `sleep 30`
child process (no mocks), measuring wall-clock time from `abort()` to the
promise settling (throwaway test, deleted before commit):

```
PROOF elapsed from abort() to rejection: 1ms
```

Genuine pre-fix negative control, same harness against `upstream/main`'s
version of `exec.ts` — the promise had not rejected by the time the check
ran (`rejectedAt` stayed `0`, well past what a "prompt" rejection would take):

```
AssertionError: expected 0 to be greater than 0
```

## What Was Not Tested

Full `pnpm build`/full monorepo test suite was not run locally (this repo's
own tooling routes full/broad suites to remote CI/Testbox); scoped
vitest + typecheck + lint on the exact touched files were run instead. No
live extension/plugin was loaded into a running gateway — the real-process
proof above exercises `execCommand` directly with a genuine child process and
`AbortController` (not mocked), but `ExtensionContext.exec`'s call-through in
`extensions/loader.ts` is a one-line passthrough with no additional logic, so
it was not separately re-verified through a live plugin load.

AI-assisted: yes, built with Claude Code. Implementation was read, the
abort-vs-timeout-vs-output-limit kill paths were traced end-to-end, and
behavior validated via the red→green test above before this PR was opened.

