### PR TITLE
fix(qa-lab): exclude incompatible channel scenarios

### DIFF
--- a/extensions/qa-lab/src/run-config.test.ts
+++ b/extensions/qa-lab/src/run-config.test.ts
@@ -314,6 +314,52 @@ describe("qa run config", () => {
     );
   });
 
+  it("excludes live-only and unsupported thread scenarios from Crabline plans", () => {
+    const catalog = readQaScenarioPack();
+    const scenarioIds = new Set([
+      "matrix-approval-channel-target-both",
+      "matrix-approval-deny-reaction",
+      "matrix-approval-exec-metadata-chunked",
+      "matrix-approval-exec-metadata-single-event",
+      "matrix-approval-plugin-metadata-single-event",
+      "matrix-approval-thread-target",
+      "matrix-mxid-prefixed-command-block",
+      "slack-codex-approval-exec-native",
+      "slack-codex-approval-plugin-native",
+      "thread-follow-up",
+      "thread-isolation",
+    ]);
+    const selected = catalog.scenarios.filter((scenario) => scenarioIds.has(scenario.id));
+
+    const execution = resolveQaRunProfileExecutionSelection({
+      scenarios: selected,
+      providerMode: "mock-openai",
+      primaryModel: "mock-openai/gpt-5.6-luna",
+      channelDriver: "crabline",
+      defaultChannel: "telegram",
+      supportsChannel: () => true,
+    });
+
+    expect(execution.selectedScenarios).toEqual([]);
+    expect(
+      Object.fromEntries(
+        execution.excludedScenarios.map(({ scenario, reasons }) => [scenario.id, reasons]),
+      ),
+    ).toEqual({
+      "matrix-approval-channel-target-both": ["channelDriver=live"],
+      "matrix-approval-deny-reaction": ["channelDriver=live"],
+      "matrix-approval-exec-metadata-chunked": ["channelDriver=live"],
+      "matrix-approval-exec-metadata-single-event": ["channelDriver=live"],
+      "matrix-approval-plugin-metadata-single-event": ["channelDriver=live"],
+      "matrix-approval-thread-target": ["channelDriver=live"],
+      "matrix-mxid-prefixed-command-block": ["channelDriver=live"],
+      "slack-codex-approval-exec-native": ["channelDriver=live"],
+      "slack-codex-approval-plugin-native": ["channelDriver=live"],
+      "thread-follow-up": ["channel=qa-channel|slack|matrix"],
+      "thread-isolation": ["channel=qa-channel|slack|matrix"],
+    });
+  });
+
   it("resolves mixed execution kinds and reports runtime-pair-lane exclusions", () => {
     const catalog = readQaScenarioPack();
     const scorecardReport = readQaScorecardTaxonomyReport(catalog.scenarios);

--- a/extensions/qa-lab/src/scenario-catalog-channels.test.ts
+++ b/extensions/qa-lab/src/scenario-catalog-channels.test.ts
@@ -50,6 +50,19 @@ describe("qa scenario catalog channel contracts", () => {
     }
   });
 
+  it("marks live transport modules as live-driver-only", () => {
+    for (const scenarioId of [
+      "matrix-approval-exec-metadata-single-event",
+      "matrix-mxid-prefixed-command-block",
+      "slack-codex-approval-exec-native",
+      "slack-codex-approval-plugin-native",
+    ]) {
+      expect(readQaScenarioExecutionConfig(scenarioId)?.requiredChannelDriver, scenarioId).toBe(
+        "live",
+      );
+    }
+  });
+
   it("isolates scenarios that own asynchronous transport state", () => {
     const channelBaseline = requireFlowScenario(readQaScenarioById("channel-chat-baseline"));
     const subagentFanout = requireFlowScenario(readQaScenarioById("subagent-fanout-synthesis"));

--- a/extensions/qa-lab/src/scenario-catalog.test.ts
+++ b/extensions/qa-lab/src/scenario-catalog.test.ts
@@ -896,11 +896,12 @@ describe("qa scenario catalog", () => {
     }
   });
 
-  it("keeps portable thread relation flows free of a channel requirement", () => {
+  it("keeps portable thread relation flows on channels with native thread semantics", () => {
     for (const scenarioId of ["thread-follow-up", "thread-isolation"]) {
-      const scenario = readQaScenarioById(scenarioId);
+      const scenario = requireFlowScenario(readQaScenarioById(scenarioId));
 
       expect(scenario.execution.channel, scenarioId).toBeUndefined();
+      expect(scenario.execution.channels, scenarioId).toEqual(["qa-channel", "slack", "matrix"]);
     }
   });
 

--- a/extensions/qa-lab/src/scenario-catalog.ts
+++ b/extensions/qa-lab/src/scenario-catalog.ts
@@ -453,6 +453,20 @@ export function readQaScenarioPack(): QaScenarioPack {
         parsedScenario.execution ?? {},
         relativePath,
       );
+      const requiredChannelDriver = qaScenarioModuleFlow.resolveRequiredChannelDriver(
+        parsedScenarioFile.flow,
+      );
+      const configuredChannelDriver =
+        execution.kind === "flow" ? execution.config?.requiredChannelDriver : undefined;
+      if (
+        requiredChannelDriver &&
+        configuredChannelDriver !== undefined &&
+        configuredChannelDriver !== requiredChannelDriver
+      ) {
+        throw new Error(
+          `${relativePath}: live transport module requires channelDriver=${requiredChannelDriver}`,
+        );
+      }
       const flow = qaScenarioModuleFlow.resolveFlow(
         parsedScenarioFile.flow,
         parsedScenarioFile.title,
@@ -463,6 +477,14 @@ export function readQaScenarioPack(): QaScenarioPack {
         sourcePath: relativePath,
         execution: {
           ...execution,
+          ...(requiredChannelDriver && execution.kind === "flow"
+            ? {
+                config: {
+                  ...execution.config,
+                  requiredChannelDriver,
+                },
+              }
+            : {}),
           ...(flow ? { flow } : {}),
         },
       } satisfies QaSeedScenarioWithSource;

--- a/extensions/qa-lab/src/scenario-lane.test.ts
+++ b/extensions/qa-lab/src/scenario-lane.test.ts
@@ -76,6 +76,7 @@ describe("QA scenario lane matching", () => {
       runtimePairLane: "core",
       config: {
         requiredProviderMode: "live-frontier",
+        requiredChannelDriver: "live",
         requiredProvider: "claude-cli",
         requiredModel: "claude-sonnet-4-6",
         authMode: "subscription",
@@ -93,6 +94,7 @@ describe("QA scenario lane matching", () => {
       }),
     ).toEqual([
       "providerMode=live-frontier",
+      "channelDriver=live",
       "channel=matrix",
       "provider=claude-cli",
       "model=claude-sonnet-4-6",
@@ -125,6 +127,32 @@ describe("QA scenario lane matching", () => {
         primaryModel: "openai/gpt-5.6-luna",
         channelDriver: "live",
         channel: "telegram",
+      }),
+    ).toBe(true);
+  });
+
+  it("enforces an explicit channel driver contract", () => {
+    const scenario = makeQaSuiteTestScenario("live-only", {
+      channel: "matrix",
+      config: { requiredChannelDriver: "live" },
+    });
+
+    expect(
+      describeQaProviderLaneMismatches({
+        scenario,
+        providerMode: "mock-openai",
+        primaryModel: "mock-openai/gpt-5.6-luna",
+        channelDriver: "crabline",
+        channel: "matrix",
+      }),
+    ).toEqual(["channelDriver=live"]);
+    expect(
+      scenarioMatchesQaProviderLane({
+        scenario,
+        providerMode: "mock-openai",
+        primaryModel: "mock-openai/gpt-5.6-luna",
+        channelDriver: "live",
+        channel: "matrix",
       }),
     ).toBe(true);
   });

--- a/extensions/qa-lab/src/scenario-lane.ts
+++ b/extensions/qa-lab/src/scenario-lane.ts
@@ -24,6 +24,10 @@ export function describeQaProviderLaneMismatches(params: {
     mismatches.push(`providerMode=${requiredProviderMode}`);
   }
   const effectiveChannelDriver = params.channelDriver ?? "qa-channel";
+  const requiredChannelDriver = normalizeQaConfigString(config.requiredChannelDriver);
+  if (requiredChannelDriver && effectiveChannelDriver !== requiredChannelDriver) {
+    mismatches.push(`channelDriver=${requiredChannelDriver}`);
+  }
   const effectiveChannel =
     effectiveChannelDriver === "qa-channel"
       ? "qa-channel"

--- a/extensions/qa-lab/src/scenario-module-flow.ts
+++ b/extensions/qa-lab/src/scenario-module-flow.ts
@@ -16,6 +16,16 @@ const qaFlowExecutionShape = {
 type QaScenarioModuleFlow = z.infer<typeof qaFlowModuleSchema>;
 type QaScenarioFlowShape = { steps: unknown[] };
 
+function resolveRequiredChannelDriver(
+  flow: QaScenarioFlowShape | QaScenarioModuleFlow | undefined,
+): "live" | undefined {
+  // Modules under live-transports consume adapter-prepared runtime context.
+  // Crabline implements normalized transport only and cannot supply that context.
+  return flow && "module" in flow && flow.module.startsWith("./live-transports/")
+    ? "live"
+    : undefined;
+}
+
 function normalizeQaScenarioFileMetadata<
   T extends { objective?: string; successCriteria?: string[] },
 >(scenario: T, title: string) {
@@ -71,5 +81,6 @@ export const qaScenarioModuleFlow = {
   moduleSchema: qaFlowModuleSchema,
   executionShape: qaFlowExecutionShape,
   normalizeMetadata: normalizeQaScenarioFileMetadata,
+  resolveRequiredChannelDriver,
   resolveFlow: resolveQaScenarioFileFlow,
 };

--- a/extensions/qa-lab/src/suite-planning.test.ts
+++ b/extensions/qa-lab/src/suite-planning.test.ts
@@ -873,14 +873,15 @@ describe("qa suite planning helpers", () => {
     ).toEqual(["live-selected"]);
   });
 
-  it("keeps implicit scenario membership identical across channel drivers", () => {
+  it("filters implicit scenarios that require another channel driver", () => {
     const scenarios = [
       makeQaSuiteTestScenario("generic"),
+      makeQaSuiteTestScenario("live-only", {
+        channel: "telegram",
+        config: { requiredChannelDriver: "live" },
+      }),
       makeQaSuiteTestScenario("telegram", {
         channel: "telegram",
-      }),
-      makeQaSuiteTestScenario("matrix", {
-        channel: "matrix",
       }),
     ];
 
@@ -894,7 +895,7 @@ describe("qa suite planning helpers", () => {
       }).map((scenario) => scenario.id);
 
     expect(selectForDriver("crabline")).toEqual(["generic", "telegram"]);
-    expect(selectForDriver("live")).toEqual(selectForDriver("crabline"));
+    expect(selectForDriver("live")).toEqual(["generic", "live-only", "telegram"]);
   });
 
   it("rejects explicitly requested scenarios that do not match the current lane", () => {

--- a/qa/scenarios/channels/thread-follow-up.yaml
+++ b/qa/scenarios/channels/thread-follow-up.yaml
@@ -23,6 +23,7 @@ scenario:
     - extensions/qa-lab/src/live-transports/matrix/adapter.runtime.ts
   execution:
     kind: flow
+    channels: [qa-channel, slack, matrix]
     summary: Send a deterministic follow-up through the shared host and require native thread relation evidence.
     config:
       rootMarker: QA-THREAD-ROOT-OK

--- a/qa/scenarios/channels/thread-isolation.yaml
+++ b/qa/scenarios/channels/thread-isolation.yaml
@@ -21,6 +21,7 @@ scenario:
     - extensions/qa-lab/src/live-transports/matrix/adapter.runtime.ts
   execution:
     kind: flow
+    channels: [qa-channel, slack, matrix]
     summary: Establish a thread, then require a fresh top-level reply without stale relation metadata.
     config:
       threadMarker: QA-THREAD-ISOLATION-THREAD-OK


### PR DESCRIPTION
Closes #115052

## What Problem This Solves

Fixes an issue where maintainers running taxonomy-backed multi-channel QA profiles would get deterministic false failures when live-only Matrix and Slack scenarios, or unsupported thread scenarios, were scheduled on Crabline.

## Why This Change Was Made

The shared scenario catalog now derives the existing `requiredChannelDriver` contract for live-transport flow modules, and the shared lane planner enforces that contract before execution. Portable thread scenarios are explicitly limited to channels with the required native thread semantics.

## User Impact

QA profiles no longer waste retries and runner time on channel/driver combinations that cannot execute. Explicit incompatible selections fail during planning instead of surfacing as misleading product regressions.

## Evidence

- Before: https://github.com/openclaw/openclaw/actions/runs/30335218818 reported seven Matrix failures, two retried Slack failures, and a Telegram thread failure from incompatible scenario selection.
- Original exact-patch Blacksmith Testbox proof: https://github.com/openclaw/openclaw/actions/runs/30342518491 passed 5 focused files / 124 tests, targeted extension lint, and the import-cycle guard. Command time: 3m15.363s; total: 3m47.237s.
- Current rebased patch: 5 focused files / 124 tests passed locally in 9.81s using the task-owned compatible dependency tree after Blacksmith Testbox remained queued and direct AWS Crabbox reported no configured broker session.
- `check:changed`: every guard, formatting, SDK contract, plugin-boundary, and database-first lane passed. Its first typecheck attempt exposed only sparse-checkout omissions; after materializing the task worktree, the failed full typecheck surface passed.
- Rebase proof: patch ID `437655db37c9cffab7565e4b647c28431a4fb2ae` remained identical on current `main`.
- Final branch autoreview: clean, no accepted/actionable findings; correctness 0.92.
- AI-assisted: yes; implementation and proof reviewed by the maintainer.