### PR TITLE
fix(cron): allow no-timeout scheduled jobs in Control UI

### DIFF
--- a/ui/src/e2e/cron-filters.e2e.test.ts
+++ b/ui/src/e2e/cron-filters.e2e.test.ts
@@ -442,6 +442,80 @@ describeControlUiE2e("Control UI cron mocked Gateway E2E", () => {
     }
   });
 
+  it("creates and edits agent-turn jobs with an explicit zero timeout", async () => {
+    const existingJob = {
+      ...cronJob("existing-no-timeout", "Existing no-timeout task", {
+        kind: "every",
+        everyMs: 60_000,
+      }),
+      sessionTarget: "isolated",
+      wakeMode: "now",
+      payload: {
+        kind: "agentTurn",
+        message: "Continue until the existing task finishes",
+        timeoutSeconds: 0,
+      },
+    };
+    const context = await browser.newContext({
+      locale: "en-US",
+      serviceWorkers: "block",
+      viewport: { height: 900, width: 1_280 },
+    });
+    const page = await context.newPage();
+    const gateway = await installMockGateway(page, {
+      methodResponses: {
+        "cron.add": { id: "created-no-timeout" },
+        "cron.update": { id: existingJob.id },
+        "cron.list": cronListResponse([existingJob]),
+        "cron.runs": cronRunsResponse([]),
+        "cron.status": { enabled: true, jobs: 1, nextWakeAtMs: null },
+      },
+    });
+
+    try {
+      await page.goto(`${server.baseUrl}cron`);
+      await jobTitle(page, existingJob.name).waitFor({ timeout: 10_000 });
+
+      await page.locator('[data-test-id="cron-new-task"]').click();
+      await page.locator("#cron-name").fill("Created no-timeout task");
+      await page.locator("#cron-payload-text").fill("Continue until the new task finishes");
+      await page.locator("details.cron-advanced > summary").click();
+      await page.locator("#cron-timeout-seconds").fill("0");
+      await page.locator('[data-test-id="cron-submit"]').click();
+
+      const addRequest = await gateway.waitForRequest("cron.add");
+      expect(requestParams(addRequest)).toMatchObject({
+        name: "Created no-timeout task",
+        payload: {
+          kind: "agentTurn",
+          message: "Continue until the new task finishes",
+          timeoutSeconds: 0,
+        },
+      });
+
+      await jobTitle(page, existingJob.name).waitFor({ timeout: 10_000 });
+      await jobTitle(page, existingJob.name).click();
+      await page.locator("details.cron-advanced > summary").click();
+      expect(await page.locator("#cron-timeout-seconds").inputValue()).toBe("0");
+      await page.locator("#cron-payload-text").fill("Continue until the edited task finishes");
+      await page.locator('[data-test-id="cron-submit"]').click();
+
+      const updateRequest = await gateway.waitForRequest("cron.update");
+      expect(requestParams(updateRequest)).toMatchObject({
+        id: existingJob.id,
+        patch: {
+          payload: {
+            kind: "agentTurn",
+            message: "Continue until the edited task finishes",
+            timeoutSeconds: 0,
+          },
+        },
+      });
+    } finally {
+      await context.close();
+    }
+  });
+
   it("defaults recurring jobs converted to one-time cleanup", async () => {
     const existingJob = {
       ...cronJob("recurring-to-once", "Recurring retention", { kind: "every", everyMs: 60_000 }),

--- a/ui/src/lib/cron/index.test.ts
+++ b/ui/src/lib/cron/index.test.ts
@@ -215,6 +215,75 @@ describe("cron controller", () => {
     expect(normalized.deliveryMode).toBe("announce");
   });
 
+  it.each([
+    ["cron.add", null],
+    ["cron.update", "no-timeout-job"],
+  ] as const)("preserves an explicit zero timeout in %s payloads", async (method, editingJobId) => {
+    const request = vi.fn(async (requestedMethod: string) => {
+      if (requestedMethod === method) {
+        return { id: editingJobId ?? "no-timeout-job" };
+      }
+      if (requestedMethod === "cron.list") {
+        return { jobs: [] };
+      }
+      if (requestedMethod === "cron.status") {
+        return { enabled: true, jobs: 0, nextWakeAtMs: null };
+      }
+      return {};
+    });
+    const state = createState({
+      client: { request } as unknown as CronState["client"],
+      cronEditingJobId: editingJobId,
+      cronForm: {
+        ...DEFAULT_CRON_FORM,
+        name: "No timeout",
+        payloadText: "Run until complete",
+        timeoutSeconds: "0",
+      },
+    });
+
+    expect(await addCronJob(state)).toEqual({ saved: true, jobId: "no-timeout-job" });
+
+    const call = findRequestCall(request.mock.calls, method);
+    const job = method === "cron.update" ? requestPatch(call) : requestPayload(call);
+    expectNestedRecordFields(job, "payload", {
+      kind: "agentTurn",
+      message: "Run until complete",
+      timeoutSeconds: 0,
+    });
+  });
+
+  it.each(["", "   "])("omits an inherited timeout from cron.add: %j", async (timeoutSeconds) => {
+    const request = vi.fn(async (method: string) => {
+      if (method === "cron.add") {
+        return { id: "inherited-timeout-job" };
+      }
+      if (method === "cron.list") {
+        return { jobs: [] };
+      }
+      if (method === "cron.status") {
+        return { enabled: true, jobs: 0, nextWakeAtMs: null };
+      }
+      return {};
+    });
+    const state = createState({
+      client: { request } as unknown as CronState["client"],
+      cronForm: {
+        ...DEFAULT_CRON_FORM,
+        name: "Inherited timeout",
+        payloadText: "Use the default timeout",
+        timeoutSeconds,
+      },
+    });
+
+    expect(await addCronJob(state)).toEqual({ saved: true, jobId: "inherited-timeout-job" });
+    const payload = requireRecord(
+      requestPayload(findRequestCall(request.mock.calls, "cron.add")).payload,
+      "cron.add agent payload",
+    );
+    expect(payload).not.toHaveProperty("timeoutSeconds");
+  });
+
   it("forwards webhook delivery in cron.add payload", async () => {
     const request = vi.fn(async (method: string, _payload?: unknown) => {
       if (method === "cron.add") {
@@ -832,6 +901,26 @@ describe("cron controller", () => {
     expect(state.cronForm.deliveryChannel).toBe("telegram");
     expect(state.cronForm.deliveryTo).toBe("123");
     expect(state.cronForm.deliveryAccountId).toBe("bot-2");
+  });
+
+  it("preserves an explicit zero timeout when opening an existing job", () => {
+    const state = createState();
+    const job: CronJob = {
+      id: "no-timeout-job",
+      name: "No timeout",
+      enabled: true,
+      createdAtMs: 0,
+      updatedAtMs: 0,
+      schedule: { kind: "every", everyMs: 60_000 },
+      sessionTarget: "isolated",
+      wakeMode: "now",
+      payload: { kind: "agentTurn", message: "Run until complete", timeoutSeconds: 0 },
+      state: {},
+    };
+
+    startCronEdit(state, job);
+
+    expect(state.cronForm.timeoutSeconds).toBe("0");
   });
 
   it("preserves command payloads when editing Control UI metadata", async () => {
@@ -1676,7 +1765,7 @@ describe("cron controller", () => {
       cronExpr: "",
       payloadKind: "agentTurn",
       payloadText: "",
-      timeoutSeconds: "0",
+      timeoutSeconds: "-1",
       deliveryMode: "webhook",
       deliveryTo: "ftp://bad",
     });
@@ -1686,6 +1775,34 @@ describe("cron controller", () => {
     expect(errors.timeoutSeconds).toBe("cron.errors.timeoutInvalid");
     expect(errors.deliveryTo).toBe("cron.errors.webhookUrlInvalid");
   });
+
+  it.each(["0", " 0 ", "0.25", "", "   "])(
+    "accepts non-negative and inherited agent-turn timeouts: %j",
+    (timeoutSeconds) => {
+      const errors = validateCronForm({
+        ...DEFAULT_CRON_FORM,
+        name: "Valid timeout",
+        payloadText: "Run until complete",
+        timeoutSeconds,
+      });
+
+      expect(errors.timeoutSeconds).toBeUndefined();
+    },
+  );
+
+  it.each(["-1", "-0.25", "NaN", "Infinity", "not-a-number"])(
+    "rejects invalid agent-turn timeouts: %j",
+    (timeoutSeconds) => {
+      const errors = validateCronForm({
+        ...DEFAULT_CRON_FORM,
+        name: "Invalid timeout",
+        payloadText: "Run until complete",
+        timeoutSeconds,
+      });
+
+      expect(errors.timeoutSeconds).toBe("cron.errors.timeoutInvalid");
+    },
+  );
 
   it.each(["0x10", "1e3", "+1", String(Number.MAX_SAFE_INTEGER), "0.000001"])(
     "rejects invalid recurring amounts before submit: %s",

--- a/ui/src/lib/cron/index.ts
+++ b/ui/src/lib/cron/index.ts
@@ -328,8 +328,8 @@ export function validateCronForm(form: CronFormState): CronFieldErrors {
   if (!form.payloadLocked && form.payloadKind === "agentTurn") {
     const timeoutRaw = form.timeoutSeconds.trim();
     if (timeoutRaw) {
-      const timeout = toNumber(timeoutRaw, 0);
-      if (timeout <= 0) {
+      const timeout = toNumber(timeoutRaw, Number.NaN);
+      if (!Number.isFinite(timeout) || timeout < 0) {
         errors.timeoutSeconds = "cron.errors.timeoutInvalid";
       }
     }
@@ -920,9 +920,12 @@ function buildCronPayload(form: CronFormState) {
   if (thinking) {
     payload.thinking = thinking;
   }
-  const timeoutSeconds = toNumber(form.timeoutSeconds, 0);
-  if (timeoutSeconds > 0) {
-    payload.timeoutSeconds = timeoutSeconds;
+  const timeoutRaw = form.timeoutSeconds.trim();
+  if (timeoutRaw) {
+    const timeoutSeconds = toNumber(timeoutRaw, Number.NaN);
+    if (Number.isFinite(timeoutSeconds) && timeoutSeconds >= 0) {
+      payload.timeoutSeconds = timeoutSeconds;
+    }
   }
   if (form.payloadLightContext) {
     payload.lightContext = true;


### PR DESCRIPTION
Closes #41272

## What Problem This Solves

Fixes an issue where users creating or editing an agent-turn automation in Control UI could not enter `0` to disable the task timeout, even though the Gateway and cron scheduler already support that value. Save became disabled, and an explicit zero could not reach the Gateway.

## Why This Change Was Made

Aligns the existing cron form with the Gateway's non-negative, finite timeout contract. An explicitly entered `0` is preserved in both create and update payloads; blank fields continue to inherit the configured default, while negative and non-finite values remain invalid. This changes only the Control UI cron controller and its focused tests.

## User Impact

Users can create, reopen, and update a no-timeout agent automation entirely from Control UI. Existing inherited and positive or fractional timeout behavior is unchanged.

## Evidence

- Real Chromium regression reproduced the reported bug before the fix: entering `0` left the actual cron Save button disabled.
- The same Chromium/WebSocket test passes after the fix and captures both `cron.add` and `cron.update` requests with `payload.timeoutSeconds: 0`; it also verifies that reopening a persisted job displays `0`.
- All 140 cron controller and form-view tests pass, including explicit zero, inherited blank values, persisted edit initialization, fractional values, and rejection of negative or non-finite input.
- All 8 real-browser cron/Gateway scenarios pass.
- All 122 cron normalization, timeout-policy, and fake-clock scheduler regressions pass, including the existing actual no-timeout execution test.
- `pnpm check:changed` passes on Blacksmith Testbox, including Control UI and core-test type checks, formatting, translations, dependency guards, and zero-warning lint.
- Fresh Codex xhigh `autoreview --mode uncommitted` is clean, including TruffleHog secret scanning. AI-assisted; reviewed against the existing Gateway contract and the original issue.
