### PR TITLE
fix(ui): hide Cron mutations from read-only operators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,7 +51,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- **Cron read-only operator controls:** hide and guard administrator-only create, edit, run, clone, pause, and remove actions for operators without `operator.admin`, while preserving automation status, selection, history, and filtering. Fixes #114980.
 - **Codex native controls:** stop misclassifying valid thinking/fast runtime controls as provider overrides so Codex routes keep their native controls, while provider-native objects and invalid values stay fail-closed. Thanks @VACInc. (#107588)
 - **State snapshot verification:** run SQLite snapshot verification in a separate process so worker-thread file closes no longer drop the Gateway's POSIX WAL locks, eliminating spurious WAL misses and I/O errors. Thanks @VACInc. (#114016)
 - **Reply latency with model policies:** reuse one immutable plugin-metadata snapshot per model-selection run instead of repeating plugin discovery, cutting reply delay when a model policy is configured. Thanks @VACInc. (#114117)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Cron read-only operator controls:** hide and guard administrator-only create, edit, run, clone, pause, and remove actions for operators without `operator.admin`, while preserving automation status, selection, history, and filtering. Fixes #114980.
 - **Codex native controls:** stop misclassifying valid thinking/fast runtime controls as provider overrides so Codex routes keep their native controls, while provider-native objects and invalid values stay fail-closed. Thanks @VACInc. (#107588)
 - **State snapshot verification:** run SQLite snapshot verification in a separate process so worker-thread file closes no longer drop the Gateway's POSIX WAL locks, eliminating spurious WAL misses and I/O errors. Thanks @VACInc. (#114016)
 - **Reply latency with model policies:** reuse one immutable plugin-metadata snapshot per model-selection run instead of repeating plugin discovery, cutting reply delay when a model policy is configured. Thanks @VACInc. (#114117)

--- a/ui/src/e2e/cron-filters.e2e.test.ts
+++ b/ui/src/e2e/cron-filters.e2e.test.ts
@@ -240,6 +240,70 @@ describeControlUiE2e("Control UI cron mocked Gateway E2E", () => {
     }
   });
 
+  it("keeps read-only operators on Cron browse and history surfaces", async () => {
+    const readOnlyJob = cronJob(
+      "read-only-job",
+      "Read-only nightly digest",
+      { kind: "cron", expr: "0 1 * * *", tz: "UTC" },
+      { lastRunStatus: "ok", lastRunAtMs: Date.parse("2026-05-29T08:10:00.000Z") },
+    );
+    const context = await browser.newContext({
+      locale: "en-US",
+      serviceWorkers: "block",
+      viewport: { height: 900, width: 1_280 },
+    });
+    const page = await context.newPage();
+    const gateway = await installMockGateway(page, {
+      operatorScopes: ["operator.read"],
+      methodResponses: {
+        "cron.list": cronListResponse([readOnlyJob]),
+        "cron.runs": cronRunsResponse([
+          {
+            ts: 1,
+            jobId: readOnlyJob.id,
+            jobName: readOnlyJob.name,
+            status: "ok",
+            summary: "Read-only history remains available",
+          },
+        ]),
+        "cron.status": { enabled: true, jobs: 1, nextWakeAtMs: null },
+      },
+    });
+
+    try {
+      await page.goto(`${server.baseUrl}cron`);
+      await jobTitle(page, readOnlyJob.name).waitFor({ timeout: 10_000 });
+      await page.getByRole("note").filter({ hasText: "Browsing only" }).waitFor();
+
+      await expect.poll(() => page.locator('[data-test-id="cron-new-task"]').count()).toBe(0);
+      await expect
+        .poll(() => page.locator(`[data-test-id="cron-row-run-${readOnlyJob.id}"]`).count())
+        .toBe(0);
+      await expect
+        .poll(() => page.locator(`[data-test-id="cron-row-toggle-${readOnlyJob.id}"]`).count())
+        .toBe(0);
+      await expect.poll(() => page.locator("wa-dropdown.cron-job-menu").count()).toBe(0);
+      await expect.poll(() => page.locator("[data-suggestion]").count()).toBe(0);
+      expect(await page.locator(".cron-filter-popover__trigger").count()).toBe(1);
+
+      await jobTitle(page, readOnlyJob.name).click();
+      await page.locator("fieldset.cron-editor:disabled").waitFor();
+      await expect.poll(() => page.locator('[data-test-id="cron-run-now"]').count()).toBe(0);
+      await expect.poll(() => page.locator('[data-test-id="cron-submit"]').count()).toBe(0);
+      await expect.poll(() => page.locator(".cron-editor-actions").count()).toBe(0);
+
+      await page.locator('[data-test-id="cron-detail-tab-history"]').click();
+      await page.getByText("Read-only history remains available", { exact: true }).waitFor();
+
+      const mutationMethods = new Set(["cron.add", "cron.remove", "cron.run", "cron.update"]);
+      expect(
+        (await gateway.getRequests()).filter((request) => mutationMethods.has(request.method)),
+      ).toHaveLength(0);
+    } finally {
+      await context.close();
+    }
+  });
+
   it("keeps the newest visible overview when an older history search resolves last", async () => {
     const context = await browser.newContext({
       locale: "en-US",

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -4706,6 +4706,7 @@ export const en: TranslationMap = {
     ru: "Русский (Russian)",
   },
   cron: {
+    adminRequired: "Browsing only. Automation changes require operator.admin access.",
     tabs: {
       filterLabel: "Automation status",
       all: "All",

--- a/ui/src/pages/cron/cron-page.test.ts
+++ b/ui/src/pages/cron/cron-page.test.ts
@@ -371,6 +371,61 @@ describe("CronPage editor state sync", () => {
     await waitForCronPage(() => expect(page.cron.cronEditingJobId).toBeNull());
     await waitForCronPage(() => expect(page.cron.cronRunsScope).toBe("all"));
   });
+
+  it("renders read-only controls and rejects a stale admin action after a scope downgrade", async () => {
+    const job = {
+      id: "job-1",
+      name: "Nightly digest",
+      enabled: true,
+      createdAtMs: 0,
+      updatedAtMs: 0,
+      schedule: { kind: "every", everyMs: 60_000 },
+      sessionTarget: "isolated",
+      wakeMode: "now",
+      payload: { kind: "agentTurn", message: "digest" },
+    };
+    const request = vi.fn(async (method: string) => {
+      if (method === "cron.list") {
+        return { jobs: [job], total: 1, offset: 0, hasMore: false };
+      }
+      if (method === "cron.runs") {
+        return { entries: [], total: 0, offset: 0, hasMore: false };
+      }
+      if (method === "models.list") {
+        return { models: [] };
+      }
+      return {};
+    });
+    const gateway = createGateway({ request } as unknown as GatewayBrowserClient, true);
+    const page = createPage(createContext(gateway), { render: true });
+
+    await waitForCronPage(() =>
+      expect(page.querySelector('[data-test-id="cron-row-run-job-1"]')).not.toBeNull(),
+    );
+    const staleRunButton = page.querySelector(
+      '[data-test-id="cron-row-run-job-1"]',
+    ) as HTMLButtonElement;
+
+    gateway.emitSnapshot({
+      hello: { auth: { role: "operator", scopes: ["operator.read"] } } as never,
+    });
+    staleRunButton.click();
+    page.requestUpdate();
+    await page.updateComplete;
+
+    expect(request.mock.calls.some(([method]) => method === "cron.run")).toBe(false);
+    expect(page.textContent).toContain("Browsing only");
+    expect(page.querySelector('[data-test-id="cron-new-task"]')).toBeNull();
+    expect(page.querySelector('[data-test-id="cron-row-run-job-1"]')).toBeNull();
+    expect(page.querySelector('[data-test-id="cron-row-job-1"]')).not.toBeNull();
+
+    (page.querySelector('[data-test-id="cron-row-job-1"]') as HTMLElement).click();
+    await waitForCronPage(() =>
+      expect(page.querySelector(".cron-editor")?.matches(":disabled")).toBe(true),
+    );
+    expect(page.querySelector('[data-test-id="cron-submit"]')).toBeNull();
+    expect(page.querySelector('[data-test-id="cron-detail-tab-history"]')).not.toBeNull();
+  });
 });
 
 describe("CronPage lifecycle", () => {

--- a/ui/src/pages/cron/cron-page.ts
+++ b/ui/src/pages/cron/cron-page.ts
@@ -4,6 +4,7 @@ import { state } from "lit/decorators.js";
 import type { AgentsListResult, CronJob } from "../../api/types.ts";
 import { titleForRoute } from "../../app-navigation.ts";
 import { applicationContext, type ApplicationContext } from "../../app/context.ts";
+import { hasOperatorAdminAccess } from "../../app/operator-access.ts";
 import { renderAgentScopeControl } from "../../components/agent-scope-control.ts";
 import { renderSettingsWorkspace } from "../../components/settings-workspace.ts";
 import {
@@ -253,6 +254,19 @@ class CronPage extends OpenClawLightDomElement {
     }
   }
 
+  private get canManageCron() {
+    return hasOperatorAdminAccess(this.context.gateway.snapshot.hello?.auth ?? null);
+  }
+
+  private runCronAdminTask<T>(task: (cronState: CronState) => Promise<T>): void {
+    // Scope can change between render and click after a reconnect. Recheck at
+    // dispatch so a stale control cannot send an admin-only Gateway request.
+    if (!this.canManageCron) {
+      return;
+    }
+    void this.runCronTask(task);
+  }
+
   private patchForm(patch: Partial<CronFormState>) {
     this.cron.cronForm = normalizeCronFormState({ ...this.cron.cronForm, ...patch });
     this.cron.cronFieldErrors = validateCronForm(this.cron.cronForm);
@@ -274,6 +288,9 @@ class CronPage extends OpenClawLightDomElement {
   }
 
   private openCreate(patch?: Partial<CronFormState>) {
+    if (!this.canManageCron) {
+      return;
+    }
     cancelCronEdit(this.cron);
     this.cron.cronCreateOpen = true;
     if (patch) {
@@ -284,6 +301,9 @@ class CronPage extends OpenClawLightDomElement {
   }
 
   private cloneJob(job: CronJob) {
+    if (!this.canManageCron) {
+      return;
+    }
     // A clone is a prefilled create: the editor submits cron.add, not update.
     startCronClone(this.cron, job);
     this.cron.cronCreateOpen = true;
@@ -302,7 +322,7 @@ class CronPage extends OpenClawLightDomElement {
   }
 
   private submitForm(options: { runNow?: boolean } = {}) {
-    void this.runCronTask(async (cronState) => {
+    this.runCronAdminTask(async (cronState) => {
       const editingJobId = cronState.cronEditingJobId;
       const result = await addCronJob(cronState);
       if (!result.saved) {
@@ -343,6 +363,7 @@ class CronPage extends OpenClawLightDomElement {
       agentsList: this.agentsList,
       modelSuggestions: this.cronModelSuggestions,
     });
+    const canManage = this.canManageCron;
     return html`
       <section class="content-header">
         <div>
@@ -358,6 +379,7 @@ class CronPage extends OpenClawLightDomElement {
           basePath: this.context.basePath,
           agentId: fallbackAgentId,
           loading: this.cron.cronLoading,
+          canManage,
           status: this.cron.cronStatus,
           failingCount: this.cron.cronFailingCount,
           agentScoped: this.cron.cronAgentId !== null,
@@ -416,7 +438,7 @@ class CronPage extends OpenClawLightDomElement {
           onClosePanel: () => this.closePanel(),
           onClone: (job) => this.cloneJob(job),
           onToggle: (job, enabled) =>
-            void this.runCronTask(async (cronState) => {
+            this.runCronAdminTask(async (cronState) => {
               const updated = await toggleCronJob(cronState, job, enabled);
               // Header pause/resume must not be undone by a later Save: the
               // editor form still carries the pre-toggle enabled value. Sync
@@ -427,9 +449,9 @@ class CronPage extends OpenClawLightDomElement {
               }
             }),
           onRun: (job, mode) =>
-            void this.runCronTask((cronState) => runCronJob(cronState, job.id, mode ?? "force")),
+            this.runCronAdminTask((cronState) => runCronJob(cronState, job.id, mode ?? "force")),
           onRemove: (job) =>
-            void this.runCronTask(async (cronState) => {
+            this.runCronAdminTask(async (cronState) => {
               await removeCronJob(cronState, job);
               // Removing the selected task drops the panel back to overview;
               // the runs scope must follow or recent activity stays empty.

--- a/ui/src/pages/cron/view.test.ts
+++ b/ui/src/pages/cron/view.test.ts
@@ -27,6 +27,7 @@ function createProps(overrides: Partial<CronProps> = {}): CronProps {
     basePath: "",
     agentId: "main",
     loading: false,
+    canManage: true,
     jobsLoadingMore: false,
     status: null,
     failingCount: null,
@@ -989,6 +990,32 @@ describe("cron view editor", () => {
         new CustomEvent("wa-tab-show", { detail: { name: "history" }, bubbles: true }),
       );
     expect(onDetailTabChange).toHaveBeenCalledWith("history");
+  });
+
+  it("keeps read-only operators on browse surfaces without mutation controls", () => {
+    const onSelectJob = vi.fn();
+    const job = createJob("job-1", { name: "Nightly digest" });
+    const list = renderView({ canManage: false, jobs: [job], jobsTotal: 1, onSelectJob });
+
+    expect(list.textContent).toContain("Browsing only");
+    expect(list.querySelector('[data-test-id="cron-new-task"]')).toBeNull();
+    expect(list.querySelector('[data-test-id="cron-row-run-job-1"]')).toBeNull();
+    expect(list.querySelector('[data-test-id="cron-row-toggle-job-1"]')).toBeNull();
+    expect(list.querySelector("wa-dropdown.cron-job-menu")).toBeNull();
+    expect(list.querySelector("[data-suggestion]")).toBeNull();
+
+    getElement(list, '[data-test-id="cron-row-job-1"]', HTMLDivElement).click();
+    expect(onSelectJob).toHaveBeenCalledWith(job);
+
+    const detail = renderView({ canManage: false, jobs: [job], editingJobId: job.id });
+    expect(detail.textContent).toContain("Browsing only");
+    expect(detail.querySelector('[data-test-id="cron-run-now"]')).toBeNull();
+    expect(detail.querySelector('[data-test-id="cron-toggle-enabled"]')).toBeNull();
+    expect(detail.querySelector("wa-dropdown.cron-job-menu")).toBeNull();
+    expect(detail.querySelector('[data-test-id="cron-submit"]')).toBeNull();
+    expect(detail.querySelector(".cron-editor-actions")).toBeNull();
+    expect(getElement(detail, ".cron-editor", HTMLFieldSetElement).disabled).toBe(true);
+    expect(detail.querySelector('[data-test-id="cron-detail-tab-history"]')).not.toBeNull();
   });
 
   it("locks the editor and back navigation while a save is pending", () => {

--- a/ui/src/pages/cron/view.ts
+++ b/ui/src/pages/cron/view.ts
@@ -53,6 +53,7 @@ type CronProps = {
   basePath: string;
   agentId: string;
   loading: boolean;
+  canManage: boolean;
   jobsLoadingMore: boolean;
   status: CronStatus | null;
   failingCount: number | null;
@@ -375,6 +376,12 @@ export function renderCron(props: CronProps) {
   `;
 }
 
+function renderAdminRequired(props: CronProps) {
+  return props.canManage
+    ? nothing
+    : html`<div class="callout warning" role="note">${t("cron.adminRequired")}</div>`;
+}
+
 // ── List view ──
 
 const ENABLED_TABS: Array<{ value: CronJobsEnabledFilter; labelKey: string }> = [
@@ -395,6 +402,7 @@ function renderListView(props: CronProps) {
     props.jobsEnabledFilter !== "all";
   const children = [
     renderSettingsSection({}, renderCronStats(props)),
+    renderAdminRequired(props),
     props.status && !props.status.enabled
       ? html`
           <div class="cron-error-banner" data-test-id="cron-scheduler-banner">
@@ -418,7 +426,7 @@ function renderListView(props: CronProps) {
             )
           : [
               renderSettingsSection({}, renderJobsTable(props, hasAnyJobsFilters)),
-              hasAnyJobsFilters ? nothing : renderSuggestions(props),
+              hasAnyJobsFilters || !props.canManage ? nothing : renderSuggestions(props),
             ]}
       </div>
     `,
@@ -490,14 +498,18 @@ function renderToolbar(props: CronProps, hasAdvancedJobsFilters: boolean) {
         >
           ${icon("refresh")}
         </button>
-        <button
-          type="button"
-          class="btn primary btn--sm cron-new-task"
-          data-test-id="cron-new-task"
-          @click=${() => props.onOpenCreate()}
-        >
-          ${icon("plus")} ${t("cron.list.newTask")}
-        </button>
+        ${props.canManage
+          ? html`
+              <button
+                type="button"
+                class="btn primary btn--sm cron-new-task"
+                data-test-id="cron-new-task"
+                @click=${() => props.onOpenCreate()}
+              >
+                ${icon("plus")} ${t("cron.list.newTask")}
+              </button>
+            `
+          : nothing}
       </div>
     </div>
   `;
@@ -702,22 +714,26 @@ function renderJobRow(job: CronJob, props: CronProps) {
         @click=${(e: Event) => e.stopPropagation()}
         @keydown=${(e: Event) => e.stopPropagation()}
       >
-        <button
-          type="button"
-          class="btn btn--sm btn--ghost cron-row-run"
-          data-test-id=${`cron-row-run-${job.id}`}
-          title=${t("cron.actions.runNow")}
-          aria-label=${t("cron.actions.runNow")}
-          ?disabled=${props.busy}
-          @click=${() => props.onRun(job, "force")}
-        >
-          ${icon("play")}
-        </button>
-        ${renderEnabledSwitch(props, job, {
-          compact: true,
-          testId: `cron-row-toggle-${job.id}`,
-        })}
-        ${renderJobMenu(props, job)}
+        ${props.canManage
+          ? html`
+              <button
+                type="button"
+                class="btn btn--sm btn--ghost cron-row-run"
+                data-test-id=${`cron-row-run-${job.id}`}
+                title=${t("cron.actions.runNow")}
+                aria-label=${t("cron.actions.runNow")}
+                ?disabled=${props.busy}
+                @click=${() => props.onRun(job, "force")}
+              >
+                ${icon("play")}
+              </button>
+              ${renderEnabledSwitch(props, job, {
+                compact: true,
+                testId: `cron-row-toggle-${job.id}`,
+              })}
+              ${renderJobMenu(props, job)}
+            `
+          : nothing}
       </span>
     </div>
   `;
@@ -839,6 +855,7 @@ function renderDetailView(props: CronProps, mode: CronPanelMode) {
       </div>
     `,
     renderDetailHeader(props, mode, selectedJob),
+    renderAdminRequired(props),
     hasDetailTabs ? renderDetailTabs(props) : nothing,
     props.error ? html`<div class="cron-error-banner">${props.error}</div>` : nothing,
     html`
@@ -882,12 +899,14 @@ function renderDetailHeader(props: CronProps, mode: CronPanelMode, selectedJob?:
       <div class="cron-detail-header__copy">
         <div class="cron-detail-title">${title}</div>
         <div class="cron-detail-meta">
-          ${mode === "job" && selectedJob ? renderEnabledSwitch(props, selectedJob) : nothing}
+          ${mode === "job" && selectedJob && props.canManage
+            ? renderEnabledSwitch(props, selectedJob)
+            : nothing}
           <span class="cron-detail-sub">${subtitle}</span>
         </div>
       </div>
       <div class="cron-detail-actions">
-        ${mode === "job" && selectedJob
+        ${mode === "job" && selectedJob && props.canManage
           ? html`
               <button
                 type="button"
@@ -956,7 +975,7 @@ function renderEditor(props: CronProps, mode: CronPanelMode) {
   const selectedDeliveryMode =
     props.form.deliveryMode === "announce" && !supportsAnnounce ? "none" : props.form.deliveryMode;
   const blockingFields = collectBlockingFields(props.fieldErrors, props.form, selectedDeliveryMode);
-  const blockedByValidation = !props.busy && blockingFields.length > 0;
+  const blockedByValidation = props.canManage && !props.busy && blockingFields.length > 0;
   const submitDisabledReason =
     blockedByValidation && !props.canSubmit
       ? blockingFields.length === 1
@@ -964,7 +983,11 @@ function renderEditor(props: CronProps, mode: CronPanelMode) {
         : t("cron.form.fixFieldsPlural", { count: String(blockingFields.length) })
       : "";
   return html`
-    <fieldset class="cron-editor" ?disabled=${props.busy} aria-busy=${String(props.busy)}>
+    <fieldset
+      class="cron-editor"
+      ?disabled=${props.busy || !props.canManage}
+      aria-busy=${String(props.busy)}
+    >
       ${renderPromptSection(props, { payloadLocked, isAgentTurn })} ${renderGeneralSection(props)}
       ${renderScheduleSection(props)}
       ${renderDeliverySection(props, { supportsAnnounce, selectedDeliveryMode })}
@@ -996,38 +1019,44 @@ function renderEditor(props: CronProps, mode: CronPanelMode) {
             </div>
           `
         : nothing}
-      <div class="cron-editor-actions">
-        <button
-          class="btn primary"
-          data-test-id="cron-submit"
-          ?disabled=${props.busy || !props.canSubmit}
-          @click=${props.onSubmit}
-        >
-          ${props.busy
-            ? t("cron.form.saving")
-            : mode === "job"
-              ? t("cron.form.saveChanges")
-              : t("cron.form.createTask")}
-        </button>
-        ${mode === "create"
-          ? html`
+      ${props.canManage
+        ? html`
+            <div class="cron-editor-actions">
               <button
-                class="btn"
-                data-test-id="cron-submit-run"
+                class="btn primary"
+                data-test-id="cron-submit"
                 ?disabled=${props.busy || !props.canSubmit}
-                @click=${props.onSubmitRunNow}
+                @click=${props.onSubmit}
               >
-                ${t("cron.form.createAndRun")}
+                ${props.busy
+                  ? t("cron.form.saving")
+                  : mode === "job"
+                    ? t("cron.form.saveChanges")
+                    : t("cron.form.createTask")}
               </button>
-            `
-          : nothing}
-        <button class="btn" ?disabled=${props.busy} @click=${props.onClosePanel}>
-          ${t("cron.form.cancel")}
-        </button>
-        ${submitDisabledReason
-          ? html` <div class="cron-submit-reason" aria-live="polite">${submitDisabledReason}</div> `
-          : nothing}
-      </div>
+              ${mode === "create"
+                ? html`
+                    <button
+                      class="btn"
+                      data-test-id="cron-submit-run"
+                      ?disabled=${props.busy || !props.canSubmit}
+                      @click=${props.onSubmitRunNow}
+                    >
+                      ${t("cron.form.createAndRun")}
+                    </button>
+                  `
+                : nothing}
+              <button class="btn" ?disabled=${props.busy} @click=${props.onClosePanel}>
+                ${t("cron.form.cancel")}
+              </button>
+              ${submitDisabledReason
+                ? html`<div class="cron-submit-reason" aria-live="polite">
+                    ${submitDisabledReason}
+                  </div>`
+                : nothing}
+            </div>
+          `
+        : nothing}
     </fieldset>
   `;
 }

--- a/ui/src/test-helpers/control-ui-e2e.ts
+++ b/ui/src/test-helpers/control-ui-e2e.ts
@@ -121,6 +121,8 @@ export type ControlUiMockGatewayScenario = {
     provider: string;
     available?: boolean;
   }>;
+  /** Operator scopes returned by the mocked connect handshake. */
+  operatorScopes?: string[];
   sessionKey?: string;
   /** Initial gateway-owned custom group catalog (sessions.groups.*), in order. */
   sessionGroups?: string[];
@@ -324,6 +326,13 @@ function normalizeScenario(
     inFlightRun: scenario.inFlightRun ?? null,
     presenceUsers: scenario.presenceUsers ?? [],
     models: scenario.models ?? [{ id: "gpt-5.5", name: "gpt-5.5", provider: "openai" }],
+    operatorScopes: scenario.operatorScopes ?? [
+      "operator.admin",
+      "operator.read",
+      "operator.write",
+      "operator.approvals",
+      "operator.pairing",
+    ],
     repeatingSessionEvents: scenario.repeatingSessionEvents ?? { events: [] },
     sessionInfo: scenario.sessionInfo ?? null,
     sessionArchiveFiltering: scenario.sessionArchiveFiltering ?? false,
@@ -985,13 +994,7 @@ function installControlUiMockGateway(input: {
           auth: {
             ...(deviceAuthMigrationPending ? {} : { deviceToken: scenario.deviceToken }),
             role: "operator",
-            scopes: [
-              "operator.admin",
-              "operator.read",
-              "operator.write",
-              "operator.approvals",
-              "operator.pairing",
-            ],
+            scopes: scenario.operatorScopes,
           },
           features: {
             capabilities: scenario.featureCapabilities,


### PR DESCRIPTION
Closes #114980

## What Problem This Solves

Fixes an issue where operators with only `operator.read` or `operator.write` saw Cron create, edit, run, clone, pause, and remove controls even though the Gateway requires `operator.admin` for every mutation. Each visible action could only fail with a missing-scope error.

## Why This Change Was Made

The Cron page now derives management capability from the existing operator-admin helper and carries that fact through one view boundary. Read-only operators keep status, filters, task selection, settings inspection, and run history, while every mutation entry point is hidden or disabled. The page also rechecks the current scope at dispatch so a stale control retained across reconnect cannot send an administrator-only request.

## User Impact

Read-only operators get an honest browsing experience instead of controls that deterministically fail. Administrators retain the existing full Cron workflow.

## Evidence

- Local Chromium E2E after Testbox recorder hydration failed: `cron-filters.e2e.test.ts` — 8 tests passed, including a real `operator.read` handshake, visible list/detail/history assertions, and zero Cron mutation requests.
- Focused DOM/controller proof: `cron-page.test.ts` + `view.test.ts` — 53 tests passed, including the reconnect scope-downgrade race.
- Testbox changed gate: formatting, Control UI i18n, core/UI types, lint, dependency and repository guards passed at the rebased head.
- Autoreview: Codex clean, no accepted/actionable findings.
- Before/after screenshots use deterministic mock data and the same 1440×900 viewport; no private data or credentials.

### Before / after

| Current `main`: read-only operator sees admin controls | This PR: honest read-only list |
| --- | --- |
| ![Before: Cron list exposes New automation, run, pause, menu, and starter actions](https://artifacts.openclaw.ai/pr/115091/cron-readonly/a9ae5669ac3/before-list.png) | ![After: Cron list preserves browsing and filters while hiding admin actions](https://artifacts.openclaw.ai/pr/115091/cron-readonly/a9ae5669ac3/after-list.png) |

| Current `main`: editable detail with Run now and Save | This PR: disabled settings with history access |
| --- | --- |
| ![Before: Cron detail exposes edit, run, toggle, and save controls](https://artifacts.openclaw.ai/pr/115091/cron-readonly/a9ae5669ac3/before-detail.png) | ![After: Cron detail presents read-only settings and keeps run history available](https://artifacts.openclaw.ai/pr/115091/cron-readonly/a9ae5669ac3/after-detail.png) |

AI-assisted; I reviewed the implementation and understand the capability and dispatch boundaries.
