### PR TITLE
fix(discord): keep reasoning replies within the message length limit

### DIFF
--- a/extensions/discord/src/chunk.test.ts
+++ b/extensions/discord/src/chunk.test.ts
@@ -235,6 +235,56 @@ describe("chunkDiscordText", () => {
     for (const chunk of chunks) {
       const underscoreCount = (chunk.match(/_/g) || []).length;
       expect(underscoreCount % 2).toBe(0);
+      expect(chunk.length).toBeLessThanOrEqual(80);
+    }
+  });
+
+  it("reserves the Discord transport limit for reasoning italic markers", () => {
+    const maxChars = 2000;
+    const text = `Reasoning:\n_${"a".repeat(maxChars * 2)}_`;
+
+    const chunks = chunkDiscordText(text, { maxChars, maxLines: 50 });
+
+    expect(chunks.length).toBeGreaterThan(1);
+    for (const chunk of chunks) {
+      expect(chunk.length).toBeLessThanOrEqual(maxChars);
+      expect((chunk.match(/_/g) || []).length % 2).toBe(0);
+    }
+  });
+
+  it("keeps newline-mode reasoning chunks within the Discord transport limit", () => {
+    const maxChars = 2000;
+    const text = `Reasoning:\n_${"a".repeat(maxChars * 2)}_`;
+
+    const chunks = chunkDiscordTextWithMode(text, {
+      chunkMode: "newline",
+      maxChars,
+      maxLines: 50,
+    });
+
+    expect(chunks.length).toBeGreaterThan(1);
+    expect(chunks.every((chunk) => chunk.length <= maxChars)).toBe(true);
+  });
+
+  it.each([1, 2, 3, 4, 20])("never exceeds a %i-character reasoning chunk limit", (maxChars) => {
+    const text = `Reasoning:\n_${"abcdef".repeat(8)}_`;
+
+    const chunks = chunkDiscordText(text, { maxChars, maxLines: 50 });
+
+    expect(chunks.length).toBeGreaterThan(1);
+    expect(chunks.every((chunk) => chunk.length <= maxChars)).toBe(true);
+  });
+
+  it("does not split surrogate pairs when reserving reasoning italic markers", () => {
+    const text = `Reasoning:\n_${"😀".repeat(24)}_`;
+    const maxChars = 4;
+
+    const chunks = chunkDiscordText(text, { maxChars, maxLines: 50 });
+
+    expect(chunks.every((chunk) => chunk.length <= maxChars)).toBe(true);
+    for (const chunk of chunks) {
+      expect(chunk).not.toMatch(/[\uD800-\uDBFF](?![\uDC00-\uDFFF])/u);
+      expect(chunk).not.toMatch(/(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/u);
     }
   });
 

--- a/extensions/discord/src/chunk.ts
+++ b/extensions/discord/src/chunk.ts
@@ -25,7 +25,13 @@ type OpenFence = {
 
 const DEFAULT_MAX_CHARS = 2000;
 const DEFAULT_MAX_LINES = 17;
+const REASONING_ITALICS_MARKER_CHARS = 2;
+const MIN_REASONING_ITALICS_CHUNK_CHARS = 4;
 const FENCE_RE = /^( {0,3})(`{3,}|~{3,})(.*)$/;
+
+function hasReasoningItalics(text: string): boolean {
+  return /^(?:Reasoning:|Thinking\.{0,3})\n+_/u.test(text) && text.trimEnd().endsWith("_");
+}
 
 function resolveDiscordChunkLimit(value: unknown, fallback: number) {
   return resolveIntegerOption(value, fallback, { min: 1 });
@@ -98,7 +104,7 @@ function closeFenceIfNeeded(text: string, openFence: OpenFence | null, maxChars:
  * while keeping fenced code blocks balanced across chunks.
  */
 function chunkDiscordText(text: string, opts: ChunkDiscordTextOpts = {}): string[] {
-  const maxChars = resolveDiscordChunkLimit(opts.maxChars, DEFAULT_MAX_CHARS);
+  const hardMaxChars = resolveDiscordChunkLimit(opts.maxChars, DEFAULT_MAX_CHARS);
   const maxLines = resolveDiscordChunkLimit(opts.maxLines, DEFAULT_MAX_LINES);
 
   const body = text ?? "";
@@ -106,10 +112,17 @@ function chunkDiscordText(text: string, opts: ChunkDiscordTextOpts = {}): string
     return [];
   }
 
-  const alreadyOk = body.length <= maxChars && countLines(body) <= maxLines;
+  const alreadyOk = body.length <= hardMaxChars && countLines(body) <= maxLines;
   if (alreadyOk) {
     return [body];
   }
+
+  // Reasoning rebalancing can add an opening and closing marker to each chunk.
+  // Reserve both before splitting so the rendered payload still fits Discord.
+  const maxChars =
+    hardMaxChars >= MIN_REASONING_ITALICS_CHUNK_CHARS && hasReasoningItalics(body)
+      ? hardMaxChars - REASONING_ITALICS_MARKER_CHARS
+      : hardMaxChars;
 
   const lines = body.split("\n");
   const chunks: string[] = [];
@@ -216,7 +229,7 @@ function chunkDiscordText(text: string, opts: ChunkDiscordTextOpts = {}): string
     }
   }
 
-  return rebalanceReasoningItalics(text, chunks);
+  return rebalanceReasoningItalics(text, chunks, hardMaxChars);
 }
 
 export function chunkDiscordTextWithMode(
@@ -248,14 +261,12 @@ export function chunkDiscordTextWithMode(
 // When Discord chunking splits the message, we close italics at the end of
 // each chunk and reopen at the start of the next so every chunk renders
 // consistently.
-function rebalanceReasoningItalics(source: string, chunks: string[]): string[] {
-  if (chunks.length <= 1) {
+function rebalanceReasoningItalics(source: string, chunks: string[], maxChars: number): string[] {
+  if (chunks.length <= 1 || maxChars < MIN_REASONING_ITALICS_CHUNK_CHARS) {
     return chunks;
   }
 
-  const opensWithReasoningItalics =
-    /^(?:Reasoning:|Thinking\.{0,3})\n+_/u.test(source) && source.trimEnd().endsWith("_");
-  if (!opensWithReasoningItalics) {
+  if (!hasReasoningItalics(source)) {
     return chunks;
   }
 

--- a/extensions/discord/src/send.webhook.chunk-limit.test.ts
+++ b/extensions/discord/src/send.webhook.chunk-limit.test.ts
@@ -1,0 +1,84 @@
+import { createServer } from "node:http";
+import type { AddressInfo } from "node:net";
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import { describe, expect, it, vi } from "vitest";
+import { chunkDiscordTextWithMode } from "./chunk.js";
+import { sendWebhookMessageDiscord } from "./send.webhook.js";
+
+describe("Discord reasoning chunk delivery", () => {
+  it("sends only transport-sized reasoning chunks to the real HTTP adapter", async () => {
+    const maxChars = 2000;
+    const receivedContents: string[] = [];
+    const server = createServer((request, response) => {
+      let body = "";
+      request.setEncoding("utf8");
+      request.on("data", (part: string) => {
+        body += part;
+      });
+      request.on("end", () => {
+        const payload = JSON.parse(body) as { content: string };
+        receivedContents.push(payload.content);
+        response.setHeader("content-type", "application/json");
+        if (payload.content.length > maxChars) {
+          response.writeHead(400);
+          response.end(JSON.stringify({ code: 50035, message: "Invalid Form Body" }));
+          return;
+        }
+        response.end(
+          JSON.stringify({
+            id: String(receivedContents.length),
+            channel_id: "123",
+          }),
+        );
+      });
+    });
+
+    await new Promise<void>((resolve) => {
+      server.listen(0, "127.0.0.1", resolve);
+    });
+    const address = server.address() as AddressInfo;
+    const realFetch = globalThis.fetch.bind(globalThis);
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockImplementation((input, init) => {
+      const original =
+        typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
+      const target = new URL(original);
+      target.protocol = "http:";
+      target.host = `127.0.0.1:${address.port}`;
+      return realFetch(target, init);
+    });
+
+    try {
+      const chunks = chunkDiscordTextWithMode(`Reasoning:\n_${"a".repeat(maxChars * 2)}_`, {
+        chunkMode: "length",
+        maxChars,
+        maxLines: 50,
+      });
+      const cfg = { channels: { discord: { token: "Bot test-token" } } } as OpenClawConfig;
+
+      for (const chunk of chunks) {
+        await sendWebhookMessageDiscord(chunk, {
+          cfg,
+          webhookId: "123",
+          webhookToken: "test-token",
+          wait: true,
+        });
+      }
+
+      expect(receivedContents).toEqual(chunks);
+      expect(receivedContents.length).toBeGreaterThan(1);
+      expect(receivedContents.every((content) => content.length <= maxChars)).toBe(true);
+    } finally {
+      fetchSpy.mockRestore();
+      server.closeAllConnections();
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => {
+          if (error) {
+            reject(error);
+            return;
+          }
+          resolve();
+        });
+      });
+    }
+  });
+});


### PR DESCRIPTION
Related: #102911
Related: #103166

## What Problem This Solves

Fixes an issue where Discord users receiving a long italicized reasoning or thinking reply would lose the reply when Markdown balancing added characters after the message had already been split to Discord's hard 2,000-character content limit.

## Why This Change Was Made

Reserve both reasoning-italic markers before chunking, and gracefully omit synthetic balancing when a pathological one-, two-, or three-character limit cannot represent a complete marker pair and a Unicode code point. Preserve existing fenced-code reservation, surrogate-pair safety, newline chunking, message references, webhook behavior, and configuration. The distinct fence-rendering issue and contributor fix in #102911 and #103166 remain open and are not superseded by this change.

## User Impact

Long Discord reasoning and thinking replies are delivered successfully instead of exceeding the Discord message content limit and being rejected. Existing ordinary replies, fenced code blocks, and Markdown formatting retain their current behavior.

## Evidence

- Discord Create Message documents the hard 2,000-character content contract: https://docs.discord.com/developers/resources/message#create-message
- Before: the actual built production Discord chunker returns chunk lengths `[21,20,20,20,20,20,19]` for a 20-character limit after italic balancing.
- After: a real loopback HTTP server rejects content over 2,000 characters with Discord-style HTTP 400; production `sendWebhookMessageDiscord` successfully posts every actual chunk and every received JSON body remains at or below 2,000 characters.
- Blacksmith Testbox `tbx_01kykxrcz83mqagnaz8k1q2hbf`: eight focused Discord files, **70 passing tests**, including production HTTP delivery, the 2,000-character boundary, newline mode, hard limits 1/2/3/4/20, astral Unicode, existing fence guards, webhook proxies, Markdown, and reply delivery.
- Complete path-scoped `pnpm check:changed` on the same Linux Testbox: **passed**, including formatting, extension and extension-test types, lint, plugin boundaries, policy guards, and runtime import cycles.
- Fresh Codex autoreview: **clean**, correctness confidence **0.93**; TruffleHog clean.
- No new configuration, public SDK, authentication, retry, provider, or webhook-timeout surface.

AI-assisted; reviewed against the production Discord adapter and official Discord message contract.
