### PR TITLE
fix(slack): bound response_url body inspection

### DIFF
--- a/extensions/slack/src/monitor/replies.test.ts
+++ b/extensions/slack/src/monitor/replies.test.ts
@@ -680,6 +680,55 @@ describe("deliverSlackSlashReplies chunking", () => {
     expect(fallback.mrkdwn).toBe(false);
   });
 
+  it("does not repeat a response_url mutation when body inspection stalls", async () => {
+    vi.useFakeTimers();
+    try {
+      const cancel = vi.fn(async () => undefined);
+      const response = {
+        status: 200,
+        body: {
+          getReader: () => ({
+            read: async () => await new Promise<never>(() => {}),
+            cancel,
+            releaseLock: () => {},
+          }),
+        },
+      };
+      const respond = vi.fn(async () => response);
+
+      const delivery = deliverSlackSlashReplies({
+        replies: [
+          {
+            channelData: {
+              slack: {
+                blocks: [
+                  {
+                    type: "data_visualization",
+                    title: "Revenue mix",
+                    chart: {
+                      type: "pie",
+                      segments: [{ label: "Product", value: 60 }],
+                    },
+                  },
+                ],
+              },
+            },
+          },
+        ],
+        respond,
+        ephemeral: true,
+        textLimit: 8000,
+      });
+      await vi.advanceTimersByTimeAsync(30_000);
+
+      await expect(delivery).resolves.toBeUndefined();
+      expect(respond).toHaveBeenCalledTimes(1);
+      expect(cancel).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("uses complete 40k blockless chunks for oversized native-only fallback", async () => {
     const respond = vi.fn(async () => undefined);
     const caption = "c".repeat(41_000);

--- a/extensions/slack/src/native-data-blocks.test.ts
+++ b/extensions/slack/src/native-data-blocks.test.ts
@@ -1,5 +1,5 @@
 import { Response as UndiciResponse } from "undici";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import {
   appendSlackNativeDataFallbackText,
   buildSlackNativeDataAccessibilityText,
@@ -76,6 +76,54 @@ describe("Slack native data blocks", () => {
         statusCode: 500,
       }),
     ).toBe(false);
+  });
+
+  it("bounds stalled response_url body inspection and cancels its reader", async () => {
+    vi.useFakeTimers();
+    try {
+      const cancel = vi.fn(async () => undefined);
+      const releaseLock = vi.fn();
+      const response = {
+        status: 200,
+        body: {
+          getReader: () => ({
+            read: async () => await new Promise<never>(() => {}),
+            cancel,
+            releaseLock,
+          }),
+        },
+      };
+
+      const inspection = isSlackInvalidBlocksResponse(response);
+      await vi.advanceTimersByTimeAsync(30_000);
+
+      await expect(inspection).resolves.toBe(false);
+      expect(cancel).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("bounds oversized response_url bodies and cancels after the prefix", async () => {
+    const cancel = vi.fn(async () => undefined);
+    const releaseLock = vi.fn();
+    const response = {
+      status: 200,
+      body: {
+        getReader: () => ({
+          read: async () => ({
+            done: false,
+            value: new TextEncoder().encode("x".repeat(32 * 1024)),
+          }),
+          cancel,
+          releaseLock,
+        }),
+      },
+    };
+
+    await expect(isSlackInvalidBlocksResponse(response)).resolves.toBe(false);
+    expect(cancel).toHaveBeenCalledTimes(1);
+    expect(releaseLock).toHaveBeenCalledTimes(1);
   });
 
   it("appends mixed native data in block order without collapsing repeated blocks", () => {

--- a/extensions/slack/src/native-data-blocks.ts
+++ b/extensions/slack/src/native-data-blocks.ts
@@ -1,4 +1,5 @@
 // Shared detection and text fallback for Slack's native chart and table blocks.
+import { readResponseTextLimited } from "openclaw/plugin-sdk/provider-http";
 import { renderSlackBlockFallbackText } from "./blocks-fallback.js";
 import {
   hasSlackDataTableBlock,
@@ -13,6 +14,8 @@ import {
 
 export const SLACK_MALFORMED_NATIVE_DATA_FALLBACK =
   "Slack could not render this chart or table data.";
+const SLACK_RESPONSE_URL_BODY_LIMIT_BYTES = 16 * 1024;
+const SLACK_RESPONSE_URL_BODY_TIMEOUT_MS = 30_000;
 
 function asRecord(value: unknown): Record<string, unknown> | undefined {
   return value && typeof value === "object" && !Array.isArray(value)
@@ -51,21 +54,28 @@ export function isSlackInvalidBlocksError(error: unknown): boolean {
 
 type SlackResponseLike = {
   status: number;
-  clone: () => { text: () => Promise<string> };
 };
 
 function isSlackResponseLike(value: unknown): value is SlackResponseLike {
   const record = asRecord(value);
-  return typeof record?.status === "number" && typeof record.clone === "function";
+  const body = asRecord(record?.body);
+  return (
+    typeof record?.status === "number" &&
+    (typeof record.arrayBuffer === "function" || typeof body?.getReader === "function")
+  );
 }
 
-/** Inspect Bolt 5's native response_url Response without consuming the caller's body. */
+/** Consume Bolt 5's native response_url body under strict time and byte bounds. */
 export async function isSlackInvalidBlocksResponse(response: unknown): Promise<boolean> {
   if (!isSlackResponseLike(response)) {
     return isSlackInvalidBlocksError(response);
   }
   try {
-    const body = await response.clone().text();
+    const body = await readResponseTextLimited(
+      response as Response,
+      SLACK_RESPONSE_URL_BODY_LIMIT_BYTES,
+      { timeoutMs: SLACK_RESPONSE_URL_BODY_TIMEOUT_MS },
+    );
     if (body.trim().toLowerCase() === "invalid_blocks") {
       return true;
     }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Slack slash-command delivery could hang indefinitely or buffer an unbounded body after a successful `response_url` mutation while checking for `invalid_blocks`.

## Why This Change Was Made

Response-body inspection now consumes at most 16 KiB with a 30-second deadline and cancels the reader on either boundary. The mutation itself is still attempted only once.

## User Impact

Slack native chart and table replies no longer leave delivery stuck on a stalled or oversized `response_url` body.

## Evidence

- `pnpm exec tsx proof-live.ts` imported the production Slack response inspector against a loopback HTTP boundary. A 15,026-byte valid body still matched; the base revision remained pending on oversized and stalled bodies, while this change stopped at 16 KiB and timed out the stall.
- `pnpm exec vitest run extensions/slack/src/native-data-blocks.test.ts extensions/slack/src/monitor/replies.test.ts`: 55 tests passed.

```text
base 958dc13f032:
near-limit: result=true bytes=15026
oversized: pending elapsedMs=1003
oversized-boundary: serverClosed=true chunks=47
stalled: pending elapsedMs=31006

after:
near-limit: result=true bytes=15026
oversized: result=false elapsedMs=66
oversized-boundary: serverClosed=true chunks=4
stalled: result=false elapsedMs=30003
```

<details>
<summary>proof-live.ts</summary>

```ts
import { createServer } from "node:http";
import { setTimeout as delay } from "node:timers/promises";
import { pathToFileURL } from "node:url";

async function main() {
  const moduleUrl = pathToFileURL(
    `${process.cwd()}/extensions/slack/src/native-data-blocks.ts`,
  ).href;
  const { isSlackInvalidBlocksResponse } = await import(moduleUrl);

  let oversizedClosed = false;
  let oversizedChunks = 0;
  const server = createServer((request, response) => {
    if (request.url === "/near-limit") {
      response.end(`${" ".repeat(15_000)}{"error":"invalid_blocks"}`);
      return;
    }
    if (request.url === "/oversized") {
      response.writeHead(200);
      const interval = setInterval(() => {
        oversizedChunks += 1;
        response.write("x".repeat(4 * 1024));
      }, 20);
      response.on("close", () => {
        oversizedClosed = true;
        clearInterval(interval);
      });
      return;
    }
    response.writeHead(200);
    response.flushHeaders();
  });

  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
  const address = server.address();
  if (!address || typeof address === "string") {
    throw new Error("loopback server did not expose a TCP port");
  }
  const baseUrl = `http://127.0.0.1:${String(address.port)}`;

  async function inspectWithWatchdog(path: string, watchdogMs: number) {
    const controller = new AbortController();
    const response = await fetch(`${baseUrl}${path}`, { signal: controller.signal });
    const startedAt = Date.now();
    const inspection = isSlackInvalidBlocksResponse(response);
    const result = await Promise.race([
      inspection.then((value: boolean) => ({ kind: "result" as const, value })),
      delay(watchdogMs).then(() => ({ kind: "pending" as const })),
    ]);
    const elapsedMs = Date.now() - startedAt;
    if (result.kind === "pending") {
      controller.abort();
      await inspection;
    }
    return { ...result, elapsedMs };
  }

  try {
    const nearLimitResponse = await fetch(`${baseUrl}/near-limit`);
    console.log(
      `near-limit: result=${String(await isSlackInvalidBlocksResponse(nearLimitResponse))} bytes=15026`,
    );

    const oversized = await inspectWithWatchdog("/oversized", 1_000);
    await delay(50);
    console.log(
      `oversized: ${oversized.kind === "result" ? `result=${String(oversized.value)}` : "pending"} elapsedMs=${String(oversized.elapsedMs)}`,
    );
    console.log(
      `oversized-boundary: serverClosed=${String(oversizedClosed)} chunks=${String(oversizedChunks)}`,
    );

    const stalled = await inspectWithWatchdog("/stalled", 31_000);
    console.log(
      `stalled: ${stalled.kind === "result" ? `result=${String(stalled.value)}` : "pending"} elapsedMs=${String(stalled.elapsedMs)}`,
    );
  } finally {
    server.closeAllConnections();
    await new Promise<void>((resolve, reject) =>
      server.close((error) => (error ? reject(error) : resolve())),
    );
  }
}

void main().catch((error: unknown) => {
  console.error(error);
  process.exitCode = 1;
});
```

</details>

AI-assisted: built with Codex
