### PR TITLE
fix(nodes): node screenshots saved as .png were actually JPEG

### DIFF
--- a/src/agents/tools/nodes-tool-media.ts
+++ b/src/agents/tools/nodes-tool-media.ts
@@ -5,7 +5,10 @@
  */
 import crypto from "node:crypto";
 import { imageMimeFromFormat } from "@openclaw/media-core/mime";
-import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
+import {
+  normalizeLowercaseStringOrEmpty,
+  normalizeOptionalString,
+} from "@openclaw/normalization-core/string-coerce";
 import {
   cameraTempPath,
   parseCameraClipPayload,
@@ -15,6 +18,7 @@ import {
   writeCameraClipPayloadToFile,
   writeCameraPayloadToFile,
 } from "../../cli/nodes-camera.js";
+import { withMediaFileExtension } from "../../cli/nodes-media-utils.js";
 import {
   parseScreenRecordPayload,
   parseScreenSnapshotPayload,
@@ -412,10 +416,9 @@ async function executeScreenRecord({
     idempotencyKey: crypto.randomUUID(),
   });
   const payload = parseScreenRecordPayload(raw?.payload);
-  const filePath =
-    typeof params.outPath === "string" && params.outPath.trim()
-      ? params.outPath.trim()
-      : screenRecordTempPath({ ext: payload.format || "mp4" });
+  const ext = payload.format || "mp4";
+  const outPath = normalizeOptionalString(params.outPath);
+  const filePath = outPath ? withMediaFileExtension(outPath, ext) : screenRecordTempPath({ ext });
   const written = await writeScreenRecordToFile(filePath, payload.base64);
   return {
     content: [{ type: "text", text: `FILE:${written.path}` }],
@@ -449,10 +452,10 @@ async function executeScreenSnapshot({
     throw new Error(`unsupported screen.snapshot format: ${payload.format}`);
   }
   const ext = normalizedFormat === "png" ? "png" : "jpg";
-  const filePath =
-    typeof params.outPath === "string" && params.outPath.trim()
-      ? params.outPath.trim()
-      : screenSnapshotTempPath({ ext });
+  // The node picks the encoding, so a caller-chosen `outPath` extension can
+  // disagree with the bytes; name the artifact after what actually arrived.
+  const outPath = normalizeOptionalString(params.outPath);
+  const filePath = outPath ? withMediaFileExtension(outPath, ext) : screenSnapshotTempPath({ ext });
   const written = await writeScreenSnapshotToFile(filePath, payload.base64);
   return {
     content: [{ type: "text", text: `FILE:${written.path}` }],

--- a/src/agents/tools/nodes-tool-media.ts
+++ b/src/agents/tools/nodes-tool-media.ts
@@ -4,6 +4,7 @@
  * Captures camera/photos/screen media from paired nodes and formats media-safe tool results.
  */
 import crypto from "node:crypto";
+import { extnameFromAnyPath } from "@openclaw/media-core/file-name";
 import { imageMimeFromFormat } from "@openclaw/media-core/mime";
 import {
   normalizeLowercaseStringOrEmpty,
@@ -18,11 +19,12 @@ import {
   writeCameraClipPayloadToFile,
   writeCameraPayloadToFile,
 } from "../../cli/nodes-camera.js";
-import { withMediaFileExtension } from "../../cli/nodes-media-utils.js";
+import { mediaPathMatchesFormat } from "../../cli/nodes-media-utils.js";
 import {
   parseScreenRecordPayload,
   parseScreenSnapshotPayload,
   screenRecordTempPath,
+  screenSnapshotFormatForPath,
   screenSnapshotTempPath,
   writeScreenRecordToFile,
   writeScreenSnapshotToFile,
@@ -418,7 +420,8 @@ async function executeScreenRecord({
   const payload = parseScreenRecordPayload(raw?.payload);
   const ext = payload.format || "mp4";
   const outPath = normalizeOptionalString(params.outPath);
-  const filePath = outPath ? withMediaFileExtension(outPath, ext) : screenRecordTempPath({ ext });
+  assertMediaOutPathFormat({ command: "screen.record", outPath, format: ext });
+  const filePath = outPath ?? screenRecordTempPath({ ext });
   const written = await writeScreenRecordToFile(filePath, payload.base64);
   return {
     content: [{ type: "text", text: `FILE:${written.path}` }],
@@ -440,10 +443,14 @@ async function executeScreenSnapshot({
   const nodeId = await resolveNodeId(gatewayOpts, node);
   const screenIndex = readNonNegativeIntegerParam(params, "screenIndex") ?? 0;
   const maxWidth = readPositiveIntegerParam(params, "maxWidth");
+  const outPath = normalizeOptionalString(params.outPath);
+  // The node owns the encoding choice, so ask for the one the caller's filename
+  // already promises instead of letting the default contradict it.
+  const requestedFormat = outPath ? screenSnapshotFormatForPath(outPath) : undefined;
   const raw = await callGatewayTool<{ payload: unknown }>("node.invoke", gatewayOpts, {
     nodeId,
     command: "screen.snapshot",
-    params: { screenIndex, maxWidth },
+    params: { screenIndex, maxWidth, format: requestedFormat },
     idempotencyKey: crypto.randomUUID(),
   });
   const payload = parseScreenSnapshotPayload(raw?.payload);
@@ -452,10 +459,8 @@ async function executeScreenSnapshot({
     throw new Error(`unsupported screen.snapshot format: ${payload.format}`);
   }
   const ext = normalizedFormat === "png" ? "png" : "jpg";
-  // The node picks the encoding, so a caller-chosen `outPath` extension can
-  // disagree with the bytes; name the artifact after what actually arrived.
-  const outPath = normalizeOptionalString(params.outPath);
-  const filePath = outPath ? withMediaFileExtension(outPath, ext) : screenSnapshotTempPath({ ext });
+  assertMediaOutPathFormat({ command: "screen.snapshot", outPath, format: ext });
+  const filePath = outPath ?? screenSnapshotTempPath({ ext });
   const written = await writeScreenSnapshotToFile(filePath, payload.base64);
   return {
     content: [{ type: "text", text: `FILE:${written.path}` }],
@@ -471,6 +476,26 @@ async function executeScreenSnapshot({
       },
     },
   };
+}
+
+/**
+ * Refuses to write media whose bytes contradict the caller's filename.
+ *
+ * `outPath` is workspace-guarded before this tool runs and that guard
+ * alias-checks the exact final segment, so the extension cannot be corrected
+ * here; the caller has to name the artifact for what it is.
+ */
+function assertMediaOutPathFormat(params: {
+  command: string;
+  outPath?: string;
+  format: string;
+}): void {
+  if (!params.outPath || mediaPathMatchesFormat(params.outPath, params.format)) {
+    return;
+  }
+  throw new Error(
+    `${params.command} returned ${params.format}; outPath must use a matching extension (got ${extnameFromAnyPath(params.outPath)})`,
+  );
 }
 
 function requireString(params: Record<string, unknown>, key: string): string {

--- a/src/agents/tools/nodes-tool.test.ts
+++ b/src/agents/tools/nodes-tool.test.ts
@@ -161,6 +161,7 @@ describe("createNodesTool screen_record duration guardrails", () => {
     nodeUtilsMocks.resolveNodeId.mockClear();
     nodeUtilsMocks.resolveNode.mockClear();
     screenMocks.parseScreenRecordPayload.mockClear();
+    screenMocks.screenRecordTempPath.mockClear();
     screenMocks.writeScreenRecordToFile.mockClear();
     screenMocks.parseScreenSnapshotPayload.mockClear();
     screenMocks.screenSnapshotTempPath.mockClear();
@@ -479,6 +480,85 @@ describe("createNodesTool screen_record duration guardrails", () => {
         },
       },
     });
+  });
+
+  it("names a caller-supplied outPath after the encoding the node returned", async () => {
+    gatewayMocks.callGatewayTool.mockResolvedValue({ payload: { ok: true } });
+    screenMocks.parseScreenSnapshotPayload.mockReturnValueOnce({
+      base64: "ZmFrZQ==",
+      format: "jpeg",
+      screenIndex: 0,
+      width: 1600,
+      height: 1049,
+    });
+    screenMocks.writeScreenSnapshotToFile.mockImplementationOnce(async (filePath: string) => ({
+      path: filePath,
+    }));
+    const tool = createNodesTool();
+
+    const result = await tool.execute("call-snapshot", {
+      action: "screen_snapshot",
+      node: "miniclaw",
+      outPath: "/workspace/miniclaw-screen-2026-07-28.png",
+    });
+
+    // The node encodes JPEG by default; a `.png` request must not mislabel it.
+    expect(screenMocks.writeScreenSnapshotToFile).toHaveBeenCalledWith(
+      "/workspace/miniclaw-screen-2026-07-28.jpg",
+      "ZmFrZQ==",
+    );
+    expect(screenMocks.screenSnapshotTempPath).not.toHaveBeenCalled();
+    expect(result.content).toEqual([
+      { type: "text", text: "FILE:/workspace/miniclaw-screen-2026-07-28.jpg" },
+    ]);
+  });
+
+  it("keeps a caller-supplied outPath whose extension already matches the encoding", async () => {
+    gatewayMocks.callGatewayTool.mockResolvedValue({ payload: { ok: true } });
+    screenMocks.parseScreenSnapshotPayload.mockReturnValueOnce({
+      base64: "ZmFrZQ==",
+      format: "jpeg",
+      screenIndex: 0,
+      width: 1600,
+      height: 1049,
+    });
+    screenMocks.writeScreenSnapshotToFile.mockImplementationOnce(async (filePath: string) => ({
+      path: filePath,
+    }));
+    const tool = createNodesTool();
+
+    await tool.execute("call-snapshot", {
+      action: "screen_snapshot",
+      node: "miniclaw",
+      outPath: "/workspace/shot.jpeg",
+    });
+
+    expect(screenMocks.writeScreenSnapshotToFile).toHaveBeenCalledWith(
+      "/workspace/shot.jpeg",
+      "ZmFrZQ==",
+    );
+  });
+
+  it("names a screen_record outPath after the returned container format", async () => {
+    gatewayMocks.callGatewayTool.mockResolvedValue({ payload: { ok: true } });
+    screenMocks.writeScreenRecordToFile.mockImplementationOnce(async (filePath: string) => ({
+      path: filePath,
+    }));
+    const tool = createNodesTool();
+
+    const result = await tool.execute("call-record", {
+      action: "screen_record",
+      node: "miniclaw",
+      durationMs: 1000,
+      outPath: "/workspace/clip.mov",
+    });
+
+    expect(screenMocks.writeScreenRecordToFile).toHaveBeenCalledWith(
+      "/workspace/clip.mp4",
+      "ZmFrZQ==",
+    );
+    expect(screenMocks.screenRecordTempPath).not.toHaveBeenCalled();
+    expect(result.content).toEqual([{ type: "text", text: "FILE:/workspace/clip.mp4" }]);
   });
 
   it("rejects unsupported screen.snapshot response formats before writing", async () => {

--- a/src/agents/tools/nodes-tool.test.ts
+++ b/src/agents/tools/nodes-tool.test.ts
@@ -62,7 +62,9 @@ const screenMocks = vi.hoisted(() => ({
     hasAudio: true,
   })),
   screenRecordTempPath: vi.fn(() => "/tmp/screen-record.mp4"),
-  writeScreenRecordToFile: vi.fn(async () => ({ path: "/tmp/screen-record.mp4" })),
+  writeScreenRecordToFile: vi.fn(async (_filePath: string) => ({
+    path: "/tmp/screen-record.mp4",
+  })),
   parseScreenSnapshotPayload: vi.fn(() => ({
     base64: "ZmFrZQ==",
     format: "png",
@@ -70,8 +72,17 @@ const screenMocks = vi.hoisted(() => ({
     width: 1920,
     height: 1080,
   })),
+  // Mirrors nodes-screen's mapping; the real contract is covered in nodes-camera.test.ts.
+  screenSnapshotFormatForPath: vi.fn((filePath: string) => {
+    if (filePath.toLowerCase().endsWith(".png")) {
+      return "png";
+    }
+    return /\.jpe?g$/iu.test(filePath) ? "jpeg" : undefined;
+  }),
   screenSnapshotTempPath: vi.fn(() => "/tmp/screen-snapshot.png"),
-  writeScreenSnapshotToFile: vi.fn(async () => ({ path: "/tmp/screen-snapshot.png" })),
+  writeScreenSnapshotToFile: vi.fn(async (_filePath: string) => ({
+    path: "/tmp/screen-snapshot.png",
+  })),
 }));
 
 vi.mock("./gateway.js", () => ({
@@ -99,6 +110,7 @@ vi.mock("../../cli/nodes-screen.js", () => ({
   screenRecordTempPath: screenMocks.screenRecordTempPath,
   writeScreenRecordToFile: screenMocks.writeScreenRecordToFile,
   parseScreenSnapshotPayload: screenMocks.parseScreenSnapshotPayload,
+  screenSnapshotFormatForPath: screenMocks.screenSnapshotFormatForPath,
   screenSnapshotTempPath: screenMocks.screenSnapshotTempPath,
   writeScreenSnapshotToFile: screenMocks.writeScreenSnapshotToFile,
 }));
@@ -460,7 +472,7 @@ describe("createNodesTool screen_record duration guardrails", () => {
       | undefined;
     expect(call?.[0]).toBe("node.invoke");
     expect(call?.[2].command).toBe("screen.snapshot");
-    expect(call?.[2].params).toEqual({ screenIndex: 1, maxWidth: 1200 });
+    expect(call?.[2].params).toEqual({ screenIndex: 1, maxWidth: 1200, format: undefined });
     expect(screenMocks.parseScreenSnapshotPayload).toHaveBeenCalledWith({ ok: true });
     expect(screenMocks.screenSnapshotTempPath).toHaveBeenCalledWith({ ext: "png" });
     expect(screenMocks.writeScreenSnapshotToFile).toHaveBeenCalledWith(
@@ -482,15 +494,8 @@ describe("createNodesTool screen_record duration guardrails", () => {
     });
   });
 
-  it("names a caller-supplied outPath after the encoding the node returned", async () => {
+  it("requests the encoding a caller-supplied outPath already promises", async () => {
     gatewayMocks.callGatewayTool.mockResolvedValue({ payload: { ok: true } });
-    screenMocks.parseScreenSnapshotPayload.mockReturnValueOnce({
-      base64: "ZmFrZQ==",
-      format: "jpeg",
-      screenIndex: 0,
-      width: 1600,
-      height: 1049,
-    });
     screenMocks.writeScreenSnapshotToFile.mockImplementationOnce(async (filePath: string) => ({
       path: filePath,
     }));
@@ -502,19 +507,66 @@ describe("createNodesTool screen_record duration guardrails", () => {
       outPath: "/workspace/miniclaw-screen-2026-07-28.png",
     });
 
-    // The node encodes JPEG by default; a `.png` request must not mislabel it.
+    // Without this the node falls back to its own default (JPEG on macOS) and a
+    // `.png` request quietly receives JPEG bytes.
+    const call = gatewayMocks.callGatewayTool.mock.calls[0] as
+      | [string, unknown, { params?: { format?: unknown } }]
+      | undefined;
+    expect(call?.[2].params?.format).toBe("png");
+    // The workspace guard alias-checked this exact path; it is written verbatim.
     expect(screenMocks.writeScreenSnapshotToFile).toHaveBeenCalledWith(
-      "/workspace/miniclaw-screen-2026-07-28.jpg",
+      "/workspace/miniclaw-screen-2026-07-28.png",
       "ZmFrZQ==",
     );
     expect(screenMocks.screenSnapshotTempPath).not.toHaveBeenCalled();
     expect(result.content).toEqual([
-      { type: "text", text: "FILE:/workspace/miniclaw-screen-2026-07-28.jpg" },
+      { type: "text", text: "FILE:/workspace/miniclaw-screen-2026-07-28.png" },
     ]);
   });
 
-  it("keeps a caller-supplied outPath whose extension already matches the encoding", async () => {
+  it("requests jpeg for .jpg and .jpeg output paths", async () => {
     gatewayMocks.callGatewayTool.mockResolvedValue({ payload: { ok: true } });
+    const outPaths = ["/workspace/shot.jpg", "/workspace/shot.jpeg"];
+    for (const _ of outPaths) {
+      screenMocks.parseScreenSnapshotPayload.mockReturnValueOnce({
+        base64: "ZmFrZQ==",
+        format: "jpeg",
+        screenIndex: 0,
+        width: 1600,
+        height: 1049,
+      });
+      screenMocks.writeScreenSnapshotToFile.mockImplementationOnce(async (filePath: string) => ({
+        path: filePath,
+      }));
+    }
+    const tool = createNodesTool();
+
+    for (const outPath of outPaths) {
+      await tool.execute("call-snapshot", {
+        action: "screen_snapshot",
+        node: "miniclaw",
+        outPath,
+      });
+    }
+
+    for (const call of gatewayMocks.callGatewayTool.mock.calls) {
+      expect((call as [string, unknown, { params?: { format?: unknown } }])[2].params?.format).toBe(
+        "jpeg",
+      );
+    }
+    expect(screenMocks.writeScreenSnapshotToFile).toHaveBeenCalledWith(
+      "/workspace/shot.jpg",
+      "ZmFrZQ==",
+    );
+    expect(screenMocks.writeScreenSnapshotToFile).toHaveBeenCalledWith(
+      "/workspace/shot.jpeg",
+      "ZmFrZQ==",
+    );
+  });
+
+  it("refuses to write snapshot bytes that contradict the outPath extension", async () => {
+    gatewayMocks.callGatewayTool.mockResolvedValue({ payload: { ok: true } });
+    // A node that ignores the requested format must not silently mislabel the file.
     screenMocks.parseScreenSnapshotPayload.mockReturnValueOnce({
       base64: "ZmFrZQ==",
       format: "jpeg",
@@ -522,43 +574,31 @@ describe("createNodesTool screen_record duration guardrails", () => {
       width: 1600,
       height: 1049,
     });
-    screenMocks.writeScreenSnapshotToFile.mockImplementationOnce(async (filePath: string) => ({
-      path: filePath,
-    }));
     const tool = createNodesTool();
 
-    await tool.execute("call-snapshot", {
-      action: "screen_snapshot",
-      node: "miniclaw",
-      outPath: "/workspace/shot.jpeg",
-    });
-
-    expect(screenMocks.writeScreenSnapshotToFile).toHaveBeenCalledWith(
-      "/workspace/shot.jpeg",
-      "ZmFrZQ==",
-    );
+    await expect(
+      tool.execute("call-snapshot", {
+        action: "screen_snapshot",
+        node: "miniclaw",
+        outPath: "/workspace/shot.png",
+      }),
+    ).rejects.toThrow("screen.snapshot returned jpg; outPath must use a matching extension");
+    expect(screenMocks.writeScreenSnapshotToFile).not.toHaveBeenCalled();
   });
 
-  it("names a screen_record outPath after the returned container format", async () => {
+  it("refuses to write recording bytes that contradict the outPath extension", async () => {
     gatewayMocks.callGatewayTool.mockResolvedValue({ payload: { ok: true } });
-    screenMocks.writeScreenRecordToFile.mockImplementationOnce(async (filePath: string) => ({
-      path: filePath,
-    }));
     const tool = createNodesTool();
 
-    const result = await tool.execute("call-record", {
-      action: "screen_record",
-      node: "miniclaw",
-      durationMs: 1000,
-      outPath: "/workspace/clip.mov",
-    });
-
-    expect(screenMocks.writeScreenRecordToFile).toHaveBeenCalledWith(
-      "/workspace/clip.mp4",
-      "ZmFrZQ==",
-    );
-    expect(screenMocks.screenRecordTempPath).not.toHaveBeenCalled();
-    expect(result.content).toEqual([{ type: "text", text: "FILE:/workspace/clip.mp4" }]);
+    await expect(
+      tool.execute("call-record", {
+        action: "screen_record",
+        node: "miniclaw",
+        durationMs: 1000,
+        outPath: "/workspace/clip.mov",
+      }),
+    ).rejects.toThrow("screen.record returned mp4; outPath must use a matching extension");
+    expect(screenMocks.writeScreenRecordToFile).not.toHaveBeenCalled();
   });
 
   it("rejects unsupported screen.snapshot response formats before writing", async () => {

--- a/src/cli/nodes-camera.test.ts
+++ b/src/cli/nodes-camera.test.ts
@@ -535,8 +535,11 @@ describe("nodes screen helpers", () => {
     );
   });
 
-  it("builds screen snapshot temp path", () => {
-    expect(screenSnapshotTempPath({ tmpDir: "/tmp", id: "id1" })).toBe(
+  it("builds screen snapshot temp path from the reported format", () => {
+    expect(screenSnapshotTempPath({ ext: "jpg", tmpDir: "/tmp", id: "id1" })).toBe(
+      path.join("/tmp", "openclaw-screen-snapshot-id1.jpg"),
+    );
+    expect(screenSnapshotTempPath({ ext: "png", tmpDir: "/tmp", id: "id1" })).toBe(
       path.join("/tmp", "openclaw-screen-snapshot-id1.png"),
     );
   });

--- a/src/cli/nodes-camera.test.ts
+++ b/src/cli/nodes-camera.test.ts
@@ -35,6 +35,7 @@ let writeBase64ToFile: typeof import("./nodes-camera.js").writeBase64ToFile;
 let parseScreenRecordPayload: typeof import("./nodes-screen.js").parseScreenRecordPayload;
 let parseScreenSnapshotPayload: typeof import("./nodes-screen.js").parseScreenSnapshotPayload;
 let screenRecordTempPath: typeof import("./nodes-screen.js").screenRecordTempPath;
+let screenSnapshotFormatForPath: typeof import("./nodes-screen.js").screenSnapshotFormatForPath;
 let screenSnapshotTempPath: typeof import("./nodes-screen.js").screenSnapshotTempPath;
 let writeScreenRecordToFile: typeof import("./nodes-screen.js").writeScreenRecordToFile;
 let writeScreenSnapshotToFile: typeof import("./nodes-screen.js").writeScreenSnapshotToFile;
@@ -88,6 +89,7 @@ describe("nodes camera helpers", () => {
       parseScreenRecordPayload,
       parseScreenSnapshotPayload,
       screenRecordTempPath,
+      screenSnapshotFormatForPath,
       screenSnapshotTempPath,
       writeScreenRecordToFile,
       writeScreenSnapshotToFile,
@@ -533,6 +535,16 @@ describe("nodes screen helpers", () => {
     expect(() => parseScreenSnapshotPayload({ format: "png" })).toThrow(
       /invalid screen\.snapshot payload/i,
     );
+  });
+
+  it("maps a snapshot output path to the encoding the node should produce", () => {
+    expect(screenSnapshotFormatForPath("/workspace/shot.png")).toBe("png");
+    expect(screenSnapshotFormatForPath("/workspace/shot.PNG")).toBe("png");
+    expect(screenSnapshotFormatForPath("/workspace/shot.jpg")).toBe("jpeg");
+    expect(screenSnapshotFormatForPath("/workspace/shot.jpeg")).toBe("jpeg");
+    // Nothing recognizable is claimed, so the node's own default should stand.
+    expect(screenSnapshotFormatForPath("/workspace/shot")).toBeUndefined();
+    expect(screenSnapshotFormatForPath("/workspace/shot.webp")).toBeUndefined();
   });
 
   it("builds screen snapshot temp path from the reported format", () => {

--- a/src/cli/nodes-media-utils.test.ts
+++ b/src/cli/nodes-media-utils.test.ts
@@ -5,8 +5,8 @@ import {
   asNumber,
   asRecord,
   asString,
+  mediaPathMatchesFormat,
   resolveTempPathParts,
-  withMediaFileExtension,
 } from "./nodes-media-utils.js";
 
 describe("cli/nodes-media-utils", () => {
@@ -30,19 +30,22 @@ describe("cli/nodes-media-utils", () => {
     expect(resolveTempPathParts({ ext: ".jpg", tmpDir: "/tmp", id: "id2" }).ext).toBe(".jpg");
   });
 
-  it("renames a media path to the extension matching the reported format", () => {
-    expect(withMediaFileExtension("/out/shot.png", "jpg")).toBe("/out/shot.jpg");
-    expect(withMediaFileExtension("/out/clip.mov", "mp4")).toBe("/out/clip.mp4");
-    expect(withMediaFileExtension("/out/shot", "png")).toBe("/out/shot.png");
-    expect(withMediaFileExtension("C:\\out\\shot.png", "jpeg")).toBe("C:\\out\\shot.jpg");
+  it("detects media paths that contradict the reported format", () => {
+    expect(mediaPathMatchesFormat("/out/shot.png", "jpg")).toBe(false);
+    expect(mediaPathMatchesFormat("/out/clip.mov", "mp4")).toBe(false);
+    expect(mediaPathMatchesFormat("C:\\out\\shot.png", "jpeg")).toBe(false);
   });
 
-  it("leaves matching, equivalent, and unrecognizable formats alone", () => {
-    expect(withMediaFileExtension("/out/shot.png", "png")).toBe("/out/shot.png");
-    // `jpeg` and `jpg` are the same encoding; do not churn the caller's spelling.
-    expect(withMediaFileExtension("/out/shot.jpeg", "jpeg")).toBe("/out/shot.jpeg");
-    expect(withMediaFileExtension("/out/shot.jpeg", "jpg")).toBe("/out/shot.jpeg");
-    expect(withMediaFileExtension("/out/shot.png", "png/../escape")).toBe("/out/shot.png");
-    expect(withMediaFileExtension("/out/shot.png", "")).toBe("/out/shot.png");
+  it("accepts matching, equivalent, extensionless, and unrecognizable cases", () => {
+    expect(mediaPathMatchesFormat("/out/shot.png", "png")).toBe(true);
+    // `jpeg` and `jpg` are the same encoding; neither spelling contradicts it.
+    expect(mediaPathMatchesFormat("/out/shot.jpeg", "jpeg")).toBe(true);
+    expect(mediaPathMatchesFormat("/out/shot.jpeg", "jpg")).toBe(true);
+    expect(mediaPathMatchesFormat("/out/shot.jpg", "jpeg")).toBe(true);
+    // A name without an extension claims nothing about the bytes.
+    expect(mediaPathMatchesFormat("/out/shot", "png")).toBe(true);
+    expect(mediaPathMatchesFormat("/workspace/", "jpg")).toBe(true);
+    expect(mediaPathMatchesFormat("/out/shot.png", "png/../escape")).toBe(true);
+    expect(mediaPathMatchesFormat("/out/shot.png", "")).toBe(true);
   });
 });

--- a/src/cli/nodes-media-utils.test.ts
+++ b/src/cli/nodes-media-utils.test.ts
@@ -6,6 +6,7 @@ import {
   asRecord,
   asString,
   resolveTempPathParts,
+  withMediaFileExtension,
 } from "./nodes-media-utils.js";
 
 describe("cli/nodes-media-utils", () => {
@@ -27,5 +28,21 @@ describe("cli/nodes-media-utils", () => {
       ext: ".png",
     });
     expect(resolveTempPathParts({ ext: ".jpg", tmpDir: "/tmp", id: "id2" }).ext).toBe(".jpg");
+  });
+
+  it("renames a media path to the extension matching the reported format", () => {
+    expect(withMediaFileExtension("/out/shot.png", "jpg")).toBe("/out/shot.jpg");
+    expect(withMediaFileExtension("/out/clip.mov", "mp4")).toBe("/out/clip.mp4");
+    expect(withMediaFileExtension("/out/shot", "png")).toBe("/out/shot.png");
+    expect(withMediaFileExtension("C:\\out\\shot.png", "jpeg")).toBe("C:\\out\\shot.jpg");
+  });
+
+  it("leaves matching, equivalent, and unrecognizable formats alone", () => {
+    expect(withMediaFileExtension("/out/shot.png", "png")).toBe("/out/shot.png");
+    // `jpeg` and `jpg` are the same encoding; do not churn the caller's spelling.
+    expect(withMediaFileExtension("/out/shot.jpeg", "jpeg")).toBe("/out/shot.jpeg");
+    expect(withMediaFileExtension("/out/shot.jpeg", "jpg")).toBe("/out/shot.jpeg");
+    expect(withMediaFileExtension("/out/shot.png", "png/../escape")).toBe("/out/shot.png");
+    expect(withMediaFileExtension("/out/shot.png", "")).toBe("/out/shot.png");
   });
 });

--- a/src/cli/nodes-media-utils.ts
+++ b/src/cli/nodes-media-utils.ts
@@ -21,24 +21,26 @@ function normalizeMediaExtension(value: string): string | undefined {
 }
 
 /**
- * Returns `filePath` carrying the extension that matches `format`.
+ * True when `filePath` does not contradict media encoded as `format`.
  *
  * Callers choose an output path before the node reports how it encoded the
- * media, so the requested name can disagree with the bytes. Everything that
- * dispatches on extension — viewers, uploads, content-type headers, channel
- * attachment handling — mislabels the artifact when that happens. An
- * unrecognizable format leaves the caller's path untouched.
+ * media, so the name can end up describing bytes it never received. Everything
+ * that dispatches on extension — viewers, uploads, content-type headers,
+ * channel attachment handling — is misled when that happens. A path with no
+ * extension claims nothing and is therefore accepted.
+ *
+ * This only compares; it never rewrites the path. Output paths reach the media
+ * writers already workspace-guarded, and that guard alias-checks the exact
+ * final segment, so swapping the extension afterwards would write to a name
+ * nothing validated.
  */
-export function withMediaFileExtension(filePath: string, format: string): string {
-  const desired = normalizeMediaExtension(format);
-  if (!desired) {
-    return filePath;
-  }
+export function mediaPathMatchesFormat(filePath: string, format: string): boolean {
   const current = extnameFromAnyPath(filePath);
-  if (normalizeMediaExtension(current) === desired) {
-    return filePath;
+  if (!current) {
+    return true;
   }
-  return `${filePath.slice(0, filePath.length - current.length)}${desired}`;
+  const desired = normalizeMediaExtension(format);
+  return !desired || normalizeMediaExtension(current) === desired;
 }
 
 export function resolveTempPathParts(opts: { ext: string; tmpDir?: string; id?: string }): {

--- a/src/cli/nodes-media-utils.ts
+++ b/src/cli/nodes-media-utils.ts
@@ -1,6 +1,7 @@
 // Media utility adapters for node CLI commands and temporary media outputs.
 import { randomUUID } from "node:crypto";
 import fs from "node:fs";
+import { extnameFromAnyPath } from "@openclaw/media-core/file-name";
 import { resolvePreferredOpenClawTmpDir } from "../infra/tmp-openclaw-dir.js";
 export { asFiniteNumber as asNumber } from "../../packages/normalization-core/src/number-coercion.js";
 import { readStringValue } from "../../packages/normalization-core/src/string-coerce.js";
@@ -8,6 +9,37 @@ export { asRecord } from "../../packages/normalization-core/src/record-coerce.js
 export { asBoolean } from "../utils/boolean.js";
 
 export const asString = readStringValue;
+
+function normalizeMediaExtension(value: string): string | undefined {
+  const raw = (value.startsWith(".") ? value.slice(1) : value).toLowerCase();
+  if (!/^[a-z0-9][a-z0-9_-]{0,15}$/u.test(raw)) {
+    return undefined;
+  }
+  // `jpeg` and `jpg` name one encoding; collapse them so a caller-supplied
+  // `.jpeg` is not rewritten to `.jpg` for no reason.
+  return raw === "jpeg" ? ".jpg" : `.${raw}`;
+}
+
+/**
+ * Returns `filePath` carrying the extension that matches `format`.
+ *
+ * Callers choose an output path before the node reports how it encoded the
+ * media, so the requested name can disagree with the bytes. Everything that
+ * dispatches on extension — viewers, uploads, content-type headers, channel
+ * attachment handling — mislabels the artifact when that happens. An
+ * unrecognizable format leaves the caller's path untouched.
+ */
+export function withMediaFileExtension(filePath: string, format: string): string {
+  const desired = normalizeMediaExtension(format);
+  if (!desired) {
+    return filePath;
+  }
+  const current = extnameFromAnyPath(filePath);
+  if (normalizeMediaExtension(current) === desired) {
+    return filePath;
+  }
+  return `${filePath.slice(0, filePath.length - current.length)}${desired}`;
+}
 
 export function resolveTempPathParts(opts: { ext: string; tmpDir?: string; id?: string }): {
   ext: string;

--- a/src/cli/nodes-screen.ts
+++ b/src/cli/nodes-screen.ts
@@ -1,5 +1,6 @@
 // Screen-recording payload helpers for node media commands.
 import * as path from "node:path";
+import { extnameFromAnyPath } from "@openclaw/media-core/file-name";
 import { writeBase64ToFile } from "./nodes-camera.js";
 import { asRecord, asString, resolveTempPathParts } from "./nodes-media-utils.js";
 
@@ -73,6 +74,22 @@ export function parseScreenSnapshotPayload(value: unknown): ScreenSnapshotPayloa
     width: typeof obj.width === "number" ? obj.width : undefined,
     height: typeof obj.height === "number" ? obj.height : undefined,
   };
+}
+
+/**
+ * Maps a caller-chosen snapshot path to the encoding the node should produce.
+ *
+ * `screen.snapshot` lets the node pick its encoding, so asking for the one the
+ * filename already promises is what keeps the name and the bytes in agreement.
+ * Returns undefined when the path claims nothing recognizable and the node's
+ * own default should stand.
+ */
+export function screenSnapshotFormatForPath(filePath: string): "png" | "jpeg" | undefined {
+  const ext = extnameFromAnyPath(filePath).toLowerCase();
+  if (ext === ".png") {
+    return "png";
+  }
+  return ext === ".jpg" || ext === ".jpeg" ? "jpeg" : undefined;
 }
 
 /** Build the temp output path for a screen snapshot artifact. */

--- a/src/cli/nodes-screen.ts
+++ b/src/cli/nodes-screen.ts
@@ -76,8 +76,10 @@ export function parseScreenSnapshotPayload(value: unknown): ScreenSnapshotPayloa
 }
 
 /** Build the temp output path for a screen snapshot artifact. */
-export function screenSnapshotTempPath(opts: { ext?: string; tmpDir?: string; id?: string }) {
-  const { tmpDir, id, ext } = resolveTempPathParts({ ...opts, ext: opts.ext ?? ".png" });
+export function screenSnapshotTempPath(opts: { ext: string; tmpDir?: string; id?: string }) {
+  // No default extension: the node chooses the encoding, and assuming PNG here
+  // is how a JPEG snapshot ends up named `.png`.
+  const { tmpDir, id, ext } = resolveTempPathParts(opts);
   return path.join(tmpDir, `openclaw-screen-snapshot-${id}${ext}`);
 }
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where an agent asking a paired node for a screenshot at a `.png`
path would receive a file that is actually JPEG.

Observed on a live gateway: `openclaw__nodes(action: "screen_snapshot")` wrote
`~/.openclaw/workspace/miniclaw-screen-2026-07-28.png`, and `file` reports
`JPEG image data, JFIF standard 1.01, ... baseline, precision 8, 1600x1049`.
The image is valid and renders fine — the name is simply wrong. Anything that
dispatches on extension (viewers, uploads, content-type headers, channel
attachment handling) then treats it as the wrong type.

## Why This Change Was Made

`screen.snapshot` lets the node choose its encoding. The macOS node defaults to
JPEG (`ScreenSnapshotService.snapshot` → `format ?? .jpeg`) and reports the
choice back in the payload, but the agent tool never forwarded a `format`
request and wrote a caller-supplied `outPath` verbatim. So the caller named the
file and the node picked the bytes, with nothing reconciling them.

**The node does report its encoding**, so no protocol change is needed and no
byte sniffing is involved. The tool now asks the node for the encoding the
caller's filename already promises (`.png` → `png`, `.jpg`/`.jpeg` → `jpeg`),
which resolves the disagreement at the source. When `outPath` is omitted, the
temp filename keeps coming from the reported format, and
`screenSnapshotTempPath` loses its `.png` default — that default was the same
"assume PNG" assumption in another spot.

Renaming the caller's path to match the returned format was the obvious
alternative and is deliberately **not** what this does. `outPath` is
workspace-guarded before the tool runs (`applyNodesToolWorkspaceGuard` →
`assertSandboxPath`), and that guard alias-checks the *exact* final segment.
Swapping `.mov` for `.mp4` afterwards would write to a name nothing validated,
so a sibling symlink could carry the write outside the workspace under
`workspaceOnly`. The guarded path is therefore written byte for byte, and if the
returned encoding still contradicts the extension — a node that ignores the
requested format — the tool refuses to write rather than mislabel.

Sibling capture paths, checked before fixing the one that was observed:

- `screen_record` takes an `outPath` too and gets the same refusal. It pins
  `format: "mp4"` on the request, so no format negotiation applies.
- `camera_snap`, `camera_clip`, and `photos_latest` accept no `outPath` at all
  and already build their filename from the payload format
  (`cameraTempPath({ ext: isJpeg ? "jpg" : "png" })`). Unaffected.
- The `nodes screen record` CLI keeps honoring `--out` as typed: the format is
  pinned by the command, so the extension is the user's own explicit choice
  rather than a guess about an encoding they could not know.

## User Impact

A screenshot saved to `shot.png` is now really a PNG, and one saved to
`shot.jpg` is really a JPEG. Files land where the caller asked, with names that
match their contents.

If a node ignores the requested format, the tool now fails with
`screen.snapshot returned jpg; outPath must use a matching extension (got .png)`
instead of silently writing mislabeled bytes.

### Capture width when a `.png` name selects PNG

Requesting PNG means the node encodes PNG, so the node's PNG defaults apply.
This is a **general `screen.snapshot` contract, not a macOS quirk** — both
shipped implementations resolve the cap per format, independently and
identically:

```swift
// apps/macos/Sources/OpenClaw/ScreenSnapshotService.swift:147
let resolvedMaxWidth = maxWidth.flatMap { $0 > 0 ? $0 : nil } ?? (format == .png ? 900 : 1600)
```

```ts
// extensions/cua-computer/src/commands.ts:403
const maxWidth = params.maxWidth ?? (format === "png" ? 900 : 1_600);
```

So a `.png` outPath without an explicit `maxWidth` yields an image capped at 900
points wide, against 1600 for the JPEG default. Measured on the Linux node in the
proof run below: 900x506 for PNG against 1600x900 for JPEG, off the same
1920x1080 display.

**Decision: keep the node's default; do not send a compensating `maxWidth`.**
The per-format cap is node-owned policy, and it exists to bound a *lossless*
payload that travels base64-encoded inside a gateway RPC. Overriding it from the
agent tool would duplicate node policy in core, hardcode a literal both node
implementations already own, and defeat that payload bound on every
implementation at once. Callers who want the larger capture pass `maxWidth`,
which is already in the tool schema.

Worth stating plainly: nothing that was PNG changes size. Before this PR a
`.png` request produced a *JPEG* at 1600, so there was never a 1600-wide PNG to
lose. What changes is that a mislabeled JPEG becomes a real PNG at the node's
own PNG default.

## Evidence

### Before — live gateway, read-only

`file ~/.openclaw/workspace/miniclaw-screen-2026-07-28.png` →
`JPEG image data, JFIF standard 1.01 ... 1600x1049`.

### After — end to end on a real paired node

Linux Crabbox lease (AWS `c7a.8xlarge`, Ubuntu, Xvfb `:99` at 1920x1080) running
this PR's head `9ece77eb5afd` built from source (`OpenClaw 2026.7.2 (9ece77e)`).
A real gateway process on an isolated `OPENCLAW_STATE_DIR` and a non-default
port, plus a real `openclaw node run` node host in its own state dir, paired and
approved through `openclaw nodes pending` / `openclaw nodes approve`.

The node's `screen.snapshot` is fulfilled by the bundled `cua-computer` plugin
against `cua-driver 0.10.0` — a second, independent implementation of the
command, so this exercises the protocol contract rather than one app's behavior.

Approved node surface:

```
{'nodeId': '564320a7...', 'displayName': 'crabbox-linux-node',
 'connected': True, 'paired': True, 'platform': 'linux'}
  commands: [..., 'screen.snapshot', ...]
```

**1. The node's own default is JPEG — the precondition for the bug.**
`openclaw nodes invoke --command screen.snapshot --params '{}'`:

```
{"reportedFormat": "jpeg", "width": 1600, "height": 900, "bytes": 149672,
 "magic": "ffd8ffc000110803", "sniffed": "JPEG"}
```

**2. The node honors an explicit `format`.**

```
format=png  -> {"reportedFormat": "png",  "width": 900,  "height": 506,
                "bytes": 123191, "magic": "89504e470d0a1a0a", "sniffed": "PNG"}
format=jpeg -> {"reportedFormat": "jpeg", "width": 1600, "height": 900,
                "bytes": 149608, "magic": "ffd8ffc000110803", "sniffed": "JPEG"}
```

**3. The changed agent tool, end to end.** The real `nodes` tool wrapped in
`applyNodesToolWorkspaceGuard` under `workspaceOnly` policy — the same wrapping
the agent runtime applies — driven against the live gateway and live node:

```
##### guarded outPath .../workspace/proof-shot.png
content: [{"type":"text","text":"FILE:/work/crabbox/proof/state-gw/workspace/proof-shot.png"}]
details: {"path":".../proof-shot.png","format":"png","width":900,"height":506,...}

##### guarded outPath .../workspace/proof-shot.jpg
details: {"path":".../proof-shot.jpg","format":"jpeg","width":1600,"height":900,...}

##### guarded outPath .../workspace/proof-shot.jpeg
details: {"path":".../proof-shot.jpeg","format":"jpeg","width":1600,"height":900,...}

##### no outPath (node picks its own default encoding)
content: [{"type":"text","text":"FILE:/tmp/openclaw/openclaw-screen-snapshot-ad67999e-....jpg"}]
```

**4. `file` on the bytes that actually landed on disk.**

```
proof-shot.png:  PNG image data, 900 x 506, 8-bit/color RGBA, non-interlaced
proof-shot.jpg:  JPEG image data
proof-shot.jpeg: JPEG image data
/tmp/openclaw/openclaw-screen-snapshot-ad67999e-....jpg: JPEG image data
```

The `.png` file is PNG. The guarded paths were written byte for byte — the tool
never renamed them. With no `outPath`, the temp filename came from the reported
format (`.jpg`), which is the second half of the fix: `screenSnapshotTempPath`
used to default to `.png` regardless of what the node returned.

The only branch not exercised live is the refusal, which needs a node that
ignores a `format` its own params struct declares; that is covered by unit tests
for both `screen.snapshot` and `screen.record`.

### Tests and gates

Regression tests in `src/agents/tools/nodes-tool.test.ts`,
`src/cli/nodes-media-utils.test.ts`, and `src/cli/nodes-camera.test.ts` cover:
the `.png` outPath sending `format: "png"` and writing the guarded path
unchanged; `.jpg`/`.jpeg` both requesting `jpeg`; a contradicting result being
refused for both snapshot and recording before any write; extensionless and
unrecognized paths leaving the node's default alone; and the temp path coming
from the reported format.

Blacksmith Testbox `pnpm test src/agents/tools/nodes-tool.test.ts
src/cli/nodes-camera.test.ts src/cli/nodes-media-utils.test.ts` — 3 files,
108 tests passed, exit 0. (Local `node_modules` in the authoring worktree is
stale, so tests ran remotely.)

Gates: `node scripts/check-changed.mjs` delegated to Testbox, exit 0.

Review: fresh Codex autoreview (`gpt-5.6-sol`, xhigh). The first pass caught a
directory-shaped-path hazard and the second caught the workspace-guard bypass in
the original rename-the-path approach — that finding is why this PR requests the
format instead of rewriting the path. Final run on the committed branch:
`autoreview clean: no accepted/actionable findings reported`.
