### PR TITLE
refactor(google-meet): reuse OAuth option resolver

### DIFF
--- a/extensions/google-meet/src/cli-command-context.ts
+++ b/extensions/google-meet/src/cli-command-context.ts
@@ -46,10 +46,6 @@ export type GoogleMeetCliCommandContext = {
     accessToken: string;
     configuredMeeting?: string;
   }) => Promise<{ meeting: string; calendarEvent?: GoogleMeetCalendarLookupResult }>;
-  resolveCreateTokenOptions: (
-    config: GoogleMeetConfig,
-    options: CreateOptions,
-  ) => GoogleMeetOAuthTokenOptions;
   resolveArtifactTokenOptions: (
     config: GoogleMeetConfig,
     options: MeetArtifactOptions,

--- a/extensions/google-meet/src/cli-space-commands.ts
+++ b/extensions/google-meet/src/cli-space-commands.ts
@@ -26,7 +26,6 @@ export function registerGoogleMeetCreateCommands(context: GoogleMeetCliCommandCo
     callGateway,
     operationTimeoutMs,
     hasCreateOAuth,
-    resolveCreateTokenOptions,
     resolveMeetingInput,
     resolveOAuthTokenOptions,
   } = context;
@@ -148,7 +147,7 @@ export function registerGoogleMeetCreateCommands(context: GoogleMeetCliCommandCo
         return;
       }
       const token = await resolveGoogleMeetAccessToken(
-        resolveCreateTokenOptions(params.config, options),
+        resolveOAuthTokenOptions(params.config, options),
       );
       const result = await createGoogleMeetSpace({
         accessToken: token.accessToken,

--- a/extensions/google-meet/src/cli.ts
+++ b/extensions/google-meet/src/cli.ts
@@ -136,25 +136,6 @@ async function resolveMeetingForToken(params: {
     : { meeting };
 }
 
-function resolveCreateTokenOptions(
-  config: GoogleMeetConfig,
-  options: CreateOptions,
-): {
-  clientId?: string;
-  clientSecret?: string;
-  refreshToken?: string;
-  accessToken?: string;
-  expiresAt?: number;
-} {
-  return {
-    clientId: options.clientId?.trim() || config.oauth.clientId,
-    clientSecret: options.clientSecret?.trim() || config.oauth.clientSecret,
-    refreshToken: options.refreshToken?.trim() || config.oauth.refreshToken,
-    accessToken: options.accessToken?.trim() || config.oauth.accessToken,
-    expiresAt: parseOptionalNumber(options.expiresAt) ?? config.oauth.expiresAt,
-  };
-}
-
 function resolveArtifactTokenOptions(
   config: GoogleMeetConfig,
   options: MeetArtifactOptions,
@@ -291,7 +272,6 @@ export function registerGoogleMeetCli(params: {
     resolveOAuthTokenOptions,
     resolveTokenOptions,
     resolveMeetingForToken,
-    resolveCreateTokenOptions,
     resolveArtifactTokenOptions,
     hasCreateOAuth,
   };


### PR DESCRIPTION
## What Problem This Solves

Removes duplicate Google Meet OAuth option resolution from the create command path.

## Why This Change Was Made

Create and space commands applied the same trimming, config fallback, and expiry parsing logic through separate functions. The create path now uses the existing private resolver, and the redundant context slot is removed.

## User Impact

No CLI or token behavior changes. Google Meet commands now share one OAuth option precedence implementation.

## Evidence

- Production diff: 1 addition, 26 deletions
- Blacksmith Testbox `tbx_01kykynsvje09t3p26j5fvcz06`: Google Meet create tests passed, 10/10
- `pnpm check:changed`: passed on the same Testbox, including extension production/test typechecks
- `git diff --check`: passed
- Autoreview: clean
- Stable patch ID remained identical after rebasing onto current `origin/main`
