### PR TITLE
fix(ui): surface sidebar/camera/dictation/message-width in settings search

### DIFF
--- a/ui/src/pages/config/settings-search.test.ts
+++ b/ui/src/pages/config/settings-search.test.ts
@@ -31,6 +31,44 @@ describe("findSettingsSearchBlocks", () => {
     ]);
   });
 
+  it("finds sidebar and session-observer appearance controls", () => {
+    const matches = findSettingsSearchBlocks({
+      query: "session observer",
+      schema: { type: "object", properties: {} },
+      value: {},
+      uiHints: {},
+    });
+
+    expect(matches).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          routeId: "appearance",
+          hash: "#settings-appearance-sidebar",
+        }),
+      ]),
+    );
+  });
+
+  it("finds chat camera, dictation, and message-width appearance controls", () => {
+    for (const query of ["camera", "dictation", "message width"]) {
+      const matches = findSettingsSearchBlocks({
+        query,
+        schema: { type: "object", properties: {} },
+        value: {},
+        uiHints: {},
+      });
+
+      expect(matches).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            routeId: "appearance",
+            hash: "#settings-appearance-chat",
+          }),
+        ]),
+      );
+    }
+  });
+
   it("matches schema sections to their owning settings page", () => {
     const matches = findSettingsSearchBlocks({
       query: "mcp",

--- a/ui/src/pages/config/settings-search.ts
+++ b/ui/src/pages/config/settings-search.ts
@@ -137,6 +137,19 @@ const APPEARANCE_SETTINGS_BLOCKS = {
     ],
     aliases: "scale",
   },
+  sidebar: {
+    routeId: "appearance",
+    labelKey: "configView.sidebarPrefs.title",
+    search: "?section=__appearance__",
+    hash: `#${APPEARANCE_SETTINGS_TARGET_IDS.sidebar}`,
+    searchKeys: [
+      "configView.sidebarPrefs.title",
+      "configView.sidebarPrefs.liveActivity",
+      "configView.sessionObserver.title",
+      "configView.sessionObserver.toggle",
+    ],
+    aliases: "sidebar session observer live activity utility nav customize pin",
+  },
   chat: {
     routeId: "appearance",
     labelKey: "configView.chatPrefs.title",
@@ -159,9 +172,14 @@ const APPEARANCE_SETTINGS_BLOCKS = {
       "chat.catalogOpenTargetTerminal",
       "chat.composer.microphoneInput",
       "chat.composer.systemDefaultMicrophone",
+      "chat.composer.cameraInput",
+      "chat.composer.systemDefaultCamera",
+      "chat.composer.noCameras",
+      "configView.chatPrefs.messageWidth",
+      "configView.chatPrefs.messageWidthHint",
     ],
     aliases:
-      "keyboard enter follow-up followup steer queue microphone voice audio input codex claude terminal viewer",
+      "keyboard enter follow-up followup steer queue microphone voice audio input camera dictation message width codex claude terminal viewer",
   },
   connection: {
     routeId: "appearance",


### PR DESCRIPTION
## What Problem This Solves

The Control UI Appearance Settings search catalog omitted the existing Sidebar / session-observer preferences and the existing Chat camera, dictation, and message-width controls. Searching for `session observer`, `camera`, `dictation`, or `message width` returned nothing, so users could not discover or deep-link to those existing appearance controls.

This adds a `sidebar` block and expands the `chat` block in the static settings search catalog so those existing controls resolve to their appearance sections and deep links.

Fixes #114981.

## Evidence

- Two regression tests in `settings-search.test.ts`: searching `session observer` resolves to the appearance sidebar block (`#settings-appearance-sidebar`), and searching `camera`, `dictation`, and `message width` each resolve to the appearance chat block (`#settings-appearance-chat`).
- Full `settings-search` suite: 16/16 pass (`pnpm test ui/src/pages/config/settings-search.test.ts`), including the existing es-locale `modelo` test (no regression).
- `oxfmt --check` and `oxlint` clean on both changed files.

## Changes

- `ui/src/pages/config/settings-search.ts`: added a `sidebar` entry to `APPEARANCE_SETTINGS_BLOCKS` (resolves to `#settings-appearance-sidebar`, searchKeys for the sidebar + session-observer labels, aliases for sidebar/session-observer/live-activity); expanded the `chat` entry's `searchKeys` with `chat.composer.cameraInput` / `systemDefaultCamera` / `noCameras` and `configView.chatPrefs.messageWidth` / `messageWidthHint`, and added `camera dictation message width` to its aliases.
- `ui/src/pages/config/settings-search.test.ts`: two regression tests covering the previously-missing sidebar/session-observer and chat camera/dictation/message-width search hits.

No i18n strings were added or changed — the catalog now references existing keys already used by the appearance controls.
