### PR TITLE
fix: finish completed tool work after empty final responses

### DIFF
--- a/extensions/codex/src/app-server/bounded-turn.test.ts
+++ b/extensions/codex/src/app-server/bounded-turn.test.ts
@@ -104,6 +104,7 @@ function createClientFactory(
     errorBeforeCompletion?: { message: string; willRetry: boolean };
     terminalStatus?: "completed" | "interrupted";
     assistantDelta?: string;
+    emptyAnswer?: boolean;
     completeTurn?: boolean;
   } = {},
 ) {
@@ -209,7 +210,9 @@ function createClientFactory(
               turn: {
                 ...completedTurnResult().turn,
                 status: options.terminalStatus ?? "completed",
-                ...(options.terminalStatus === "interrupted" ? { items: [] } : {}),
+                ...(options.terminalStatus === "interrupted" || options.emptyAnswer
+                  ? { items: [] }
+                  : {}),
               },
             },
           });
@@ -328,6 +331,42 @@ describe("runBoundedCodexAppServerTurn settled finalization isolation", () => {
         requireNoExternalCapabilities: true,
       }),
     ).resolves.toMatchObject({ text: "The message was sent successfully." });
+  });
+
+  it("can return a completed turn without text when the finalization caller opts in", async () => {
+    const fake = createClientFactory({ emptyAnswer: true });
+
+    await expect(
+      runBoundedCodexAppServerTurn({
+        model: { mode: "required", id: "gpt-5.4" },
+        timeoutMs: 5_000,
+        options: { clientFactory: fake.factory },
+        taskLabel: "settled-turn finalization",
+        developerInstructions: "Finalize only.",
+        input: [{ type: "text", text: "Produce the final answer.", text_elements: [] }],
+        requiredModalities: ["text"],
+        isolation: "private-stdio",
+        requireNoExternalCapabilities: true,
+        allowEmptyText: true,
+      }),
+    ).resolves.toMatchObject({ text: "", model: "gpt-5.4" });
+  });
+
+  it("rejects a completed turn without text for ordinary bounded callers", async () => {
+    const fake = createClientFactory({ emptyAnswer: true });
+
+    await expect(
+      runBoundedCodexAppServerTurn({
+        model: { mode: "required", id: "gpt-5.4" },
+        timeoutMs: 5_000,
+        options: { clientFactory: fake.factory },
+        taskLabel: "hosted search",
+        developerInstructions: "Search only.",
+        input: [{ type: "text", text: "Find the answer.", text_elements: [] }],
+        requiredModalities: ["text"],
+        isolation: "private-stdio",
+      }),
+    ).rejects.toThrow("hosted search turn returned no text");
   });
 
   it("still fails on a terminal error notification", async () => {

--- a/extensions/codex/src/app-server/bounded-turn.ts
+++ b/extensions/codex/src/app-server/bounded-turn.ts
@@ -108,6 +108,8 @@ type CodexBoundedTurnParams = {
   threadConfig?: JsonObject;
   historyItems?: JsonValue[];
   requireNoExternalCapabilities?: boolean;
+  /** Finalizer-only: preserve a completed turn whose protocol carries no answer item. */
+  allowEmptyText?: boolean;
 };
 
 export async function runBoundedCodexAppServerTurn(
@@ -278,7 +280,11 @@ async function runBoundedCodexAppServerTurnInWorkspace(
         { timeoutMs, signal: abortController.signal },
       );
     }
-    const collector = createCodexBoundedTurnCollector(thread.thread.id, params.taskLabel);
+    const collector = createCodexBoundedTurnCollector(
+      thread.thread.id,
+      params.taskLabel,
+      params.allowEmptyText === true,
+    );
     const cleanup = client.addNotificationHandler(collector.handleNotification);
     const requestCleanup = client.addRequestHandler(
       createCodexBoundedApprovalHandler(params.taskLabel),
@@ -478,7 +484,11 @@ async function resolveCodexBoundedTurnModel(params: {
   return model;
 }
 
-function createCodexBoundedTurnCollector(threadId: string, taskLabel: string) {
+function createCodexBoundedTurnCollector(
+  threadId: string,
+  taskLabel: string,
+  allowEmptyText: boolean,
+) {
   let turnId: string | undefined;
   let completedTurn: CodexTurn | undefined;
   let promptError: string | undefined;
@@ -595,7 +605,7 @@ function createCodexBoundedTurnCollector(threadId: string, taskLabel: string) {
         .join("\n\n")
         .trim();
       const text = (itemText || deltaText).trim();
-      if (!text) {
+      if (!text && !allowEmptyText) {
         throw new Error(`Codex app-server ${taskLabel} turn returned no text.`);
       }
       return { text, items, ...(responseUsage ? { usage: responseUsage } : {}) };

--- a/extensions/codex/src/app-server/settled-turn-finalizer.test.ts
+++ b/extensions/codex/src/app-server/settled-turn-finalizer.test.ts
@@ -211,7 +211,7 @@ describe("runCodexSettledTurnFinalization", () => {
     expect(normalizeUsage(result.assistant.usage)?.reasoningTokens).toBe(3);
   });
 
-  it("rejects an empty final answer before transcript mutation", async () => {
+  it("returns an empty completed final answer for lifecycle classification", async () => {
     mocks.runBounded.mockResolvedValue({ text: " ", items: [], model: "gpt-5.4" });
 
     await expect(
@@ -219,7 +219,7 @@ describe("runCodexSettledTurnFinalization", () => {
         { attempt: createAttempt(), settledAttempt: createSettledAttempt() },
         {},
       ),
-    ).rejects.toThrow("completed without a visible answer");
+    ).resolves.toMatchObject({ assistant: { content: [{ type: "text", text: "" }] } });
     expect(mocks.mirror).not.toHaveBeenCalled();
   });
 

--- a/extensions/codex/src/app-server/settled-turn-finalizer.ts
+++ b/extensions/codex/src/app-server/settled-turn-finalizer.ts
@@ -50,6 +50,7 @@ export async function runCodexSettledTurnFinalization(
     isolation: "private-stdio",
     historyItems,
     requireNoExternalCapabilities: true,
+    allowEmptyText: true,
   });
   let promptEchoSeen = false;
   let unexpectedItem: CodexThreadItem | undefined;
@@ -79,7 +80,17 @@ export async function runCodexSettledTurnFinalization(
     );
   }
   const text = bounded.text.trim();
-  if (!text || isSilentReplyText(text)) {
+  if (!text) {
+    return {
+      assistant: createAssistantMessage(attempt, "", {
+        tokenUsage: bounded.usage,
+        aborted: false,
+        promptError: null,
+      }),
+      ...(bounded.usage ? { usage: bounded.usage } : {}),
+    };
+  }
+  if (isSilentReplyText(text)) {
     throw new Error("Codex settled-turn finalization completed without a visible answer");
   }
 

--- a/src/agents/embedded-agent-runner/delivery-evidence.ts
+++ b/src/agents/embedded-agent-runner/delivery-evidence.ts
@@ -86,6 +86,16 @@ export function hasCompletedSourceReplyDeliveryEvidence(
   );
 }
 
+/** Returns whether messaging-tool evidence completes the current source reply. */
+export function hasCompletedMessagingToolDeliveryEvidence(
+  result: AgentDeliveryEvidence & SourceReplyDeliveryEvidence & ExplicitFinalSourceReplyEvidence,
+): boolean {
+  return (
+    resolveExplicitFinalSourceReplyDeliveryEvidence(result) ??
+    hasMessagingToolDeliveryEvidence(result)
+  );
+}
+
 /** Returns whether delivery evidence completes the current interactive turn. */
 export function hasCompletedTerminalDeliveryEvidence(
   result: AgentDeliveryEvidence & SourceReplyDeliveryEvidence & ExplicitFinalSourceReplyEvidence,

--- a/src/agents/embedded-agent-runner/run-loop.ts
+++ b/src/agents/embedded-agent-runner/run-loop.ts
@@ -558,10 +558,13 @@ export async function runPreparedEmbeddedLoop(
         terminalState: resolvedTerminalState,
         attemptCompactionCount: terminalAttemptCompactionCount,
         prepared: terminalPrepared,
-        finalizationAttempted: settledTurnFinalizationAttempted,
+        finalizationOutcome: settledTurnFinalizationOutcome,
       } = finalizedTerminal;
       lastRunPromptUsage = finalizedTerminal.lastRunPromptUsage;
-      if (finalizedTerminal.finalizationSucceeded) {
+      if (
+        settledTurnFinalizationOutcome === "answered" ||
+        settledTurnFinalizationOutcome === "completed-empty"
+      ) {
         assistantProfileFailureReason = null;
       }
 
@@ -650,7 +653,7 @@ export async function runPreparedEmbeddedLoop(
         attemptAuthProfileStore,
         apiKeyInfo: getApiKeyInfo(),
         agentHarnessId: agentHarness.id,
-        settledTurnFinalizationAttempted,
+        settledTurnFinalizationOutcome,
         pluginHarnessOwnsTransport,
         pluginHarnessOwnsAuthBootstrap,
         reportedModelRef,

--- a/src/agents/embedded-agent-runner/run.incomplete-turn.test-support.ts
+++ b/src/agents/embedded-agent-runner/run.incomplete-turn.test-support.ts
@@ -426,7 +426,7 @@ export async function runIncompleteTurnOwnerHarness(params: OwnerHarnessParams) 
       attemptAuthProfileStore: { version: 1, profiles: {} },
       apiKeyInfo: null,
       agentHarnessId: selectedHarness.id,
-      settledTurnFinalizationAttempted: finalized.finalizationAttempted,
+      settledTurnFinalizationOutcome: finalized.finalizationOutcome,
       pluginHarnessOwnsTransport: false,
       pluginHarnessOwnsAuthBootstrap: false,
       reportedModelRef: prepared.reportedModelRef,

--- a/src/agents/embedded-agent-runner/run.incomplete-turn.test.ts
+++ b/src/agents/embedded-agent-runner/run.incomplete-turn.test.ts
@@ -1319,7 +1319,7 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
     expectNoWarnMessageWith("settled post-tool turn lacked a final answer");
   });
 
-  it("keeps the original failed-tool warning if finalization fails (#118274)", async () => {
+  it("keeps the original failed-tool warning if finalization completes empty (#118274)", async () => {
     const toolUseAssistant = makeLastAssistant({
       stopReason: "toolUse",
       content: [{ type: "toolCall", id: "tool_1", name: "exec", arguments: {} }],
@@ -1344,8 +1344,9 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
       .mockResolvedValueOnce(
         makeAttemptResult({
           assistantTexts: [],
-          promptError: new Error("finalizer provider failure"),
-          promptErrorSource: "prompt",
+          lastAssistant: makeLastAssistant(),
+          currentAttemptAssistant: makeLastAssistant(),
+          currentAttemptCompletedAssistant: makeLastAssistant(),
         }),
       );
     mockedBuildEmbeddedRunPayloads.mockReturnValue([warning]);
@@ -1354,7 +1355,7 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
 
     expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(2);
     expect(result.payloads?.[0]).toEqual(warning);
-    expectWarnMessageWith("settled-turn finalization failed closed");
+    expectWarnMessageWith("settled-turn finalization completed without a visible answer");
   });
 
   it("preserves the incomplete-turn failure when the selected harness cannot finalize safely", async () => {
@@ -1411,6 +1412,17 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
         assistantTexts: [],
         toolMetas: [{ toolName: "write", meta: "path=note.txt" }],
         itemLifecycle: { startedCount: 1, completedCount: 1, activeCount: 0 },
+        didSendViaMessagingTool: true,
+        messagingToolSentTexts: ["Writing note.txt…"],
+        messagingToolSentTargets: [
+          {
+            tool: "message",
+            provider: "telegram",
+            to: "chat:123",
+            text: "Writing note.txt…",
+            sourceReplyFinal: false,
+          },
+        ],
         lastAssistant: emptyStopAssistant,
         currentAttemptAssistant: emptyStopAssistant,
       });
@@ -1483,7 +1495,7 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
     expectNoWarnMessageWith("settled post-tool turn lacked a final answer");
   });
 
-  it("surfaces failure without cascading when the settled-tool continuation is also empty", async () => {
+  it("records silent success when the settled-tool finalization completes empty", async () => {
     const emptyStopAssistant = makeLastAssistant();
     mockedClassifyFailoverReason.mockReturnValue(null);
     mockedRunEmbeddedAttempt.mockImplementationOnce(async (attemptParams) => {
@@ -1512,12 +1524,14 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
     );
 
     expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(2);
-    expect(result.payloads?.[0]).toMatchObject({ isError: true });
-    expect(result.payloads?.[0]?.text).toContain(
-      "some tool actions may have already been executed",
-    );
+    expect(result.payloads).toBeUndefined();
+    expect(result.meta.error).toBeUndefined();
+    expect(result.meta.terminalReplyKind).toBeUndefined();
+    expect(result.meta.finalAssistantVisibleText).toBeUndefined();
+    expect(result.meta.finalAssistantRawText).toBeUndefined();
+    expect(result.meta.stopReason).toBe("stop");
     expectNoWarnMessageWith("empty response detected");
-    expectWarnMessageWith("settled-turn finalization failed closed");
+    expectWarnMessageWith("settled-turn finalization completed without a visible answer");
   });
 
   it.each([
@@ -2583,6 +2597,44 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
       expect(instruction).toContain(SETTLED_TOOL_TERMINAL_CONTINUATION_INSTRUCTION);
       expect(instruction).toContain(
         "If any tool failed, state that failure plainly and do not claim it succeeded.",
+      );
+    },
+  );
+
+  it.each([
+    { label: "progress", sourceReplyFinal: false, expectedFinalization: true },
+    { label: "final reply", sourceReplyFinal: true, expectedFinalization: false },
+    { label: "legacy unmarked send", sourceReplyFinal: undefined, expectedFinalization: false },
+  ])(
+    "handles $label delivery evidence before settled finalization",
+    ({ sourceReplyFinal, expectedFinalization }) => {
+      const emptyStopAssistant = makeLastAssistant();
+      const instruction = resolveSettledToolTerminalContinuationInstruction(
+        makeSettledContinuationParams(
+          {
+            assistantTexts: [],
+            toolMetas: [{ toolName: "write" }],
+            itemLifecycle: { startedCount: 1, completedCount: 1, activeCount: 0 },
+            didSendViaMessagingTool: true,
+            messagingToolSentTexts: ["Writing note.txt…"],
+            messagingToolSentTargets: [
+              {
+                tool: "message",
+                provider: "telegram",
+                to: "chat:123",
+                text: "Writing note.txt…",
+                sourceReplyFinal,
+              },
+            ],
+            lastAssistant: emptyStopAssistant,
+            currentAttemptAssistant: emptyStopAssistant,
+          },
+          { allowEmptyStopContinuation: true },
+        ),
+      );
+
+      expect(instruction).toBe(
+        expectedFinalization ? SETTLED_TOOL_TERMINAL_CONTINUATION_INSTRUCTION : null,
       );
     },
   );

--- a/src/agents/embedded-agent-runner/run/backend.ts
+++ b/src/agents/embedded-agent-runner/run/backend.ts
@@ -5,10 +5,7 @@ import {
   runAgentHarnessAttempt,
   runAgentHarnessSettledTurnFinalization,
 } from "../../harness/selection.js";
-import type {
-  AgentHarness,
-  AgentHarnessSettledTurnFinalizationResult,
-} from "../../harness/types.js";
+import type { AgentHarness } from "../../harness/types.js";
 import { settleRequesterAfterSessionSpawns } from "../../subagent-registry.js";
 import type { EmbeddedRunAttemptParams, EmbeddedRunAttemptResult } from "./types.js";
 
@@ -41,6 +38,6 @@ export async function runEmbeddedSettledTurnFinalizationWithBackend(
   params: EmbeddedRunAttemptParams,
   settledAttempt: EmbeddedRunAttemptResult,
   harness: AgentHarness,
-): Promise<AgentHarnessSettledTurnFinalizationResult> {
+) {
   return runAgentHarnessSettledTurnFinalization(params, settledAttempt, harness);
 }

--- a/src/agents/embedded-agent-runner/run/incomplete-turn.ts
+++ b/src/agents/embedded-agent-runner/run/incomplete-turn.ts
@@ -20,6 +20,7 @@ import { hasOnlyAssistantReasoningContent } from "../../replay-turn-classificati
 import type { AgentMessage } from "../../runtime/index.js";
 import {
   hasCommittedMessagingToolDeliveryEvidence,
+  hasCompletedMessagingToolDeliveryEvidence,
   hasMessagingToolDeliveryEvidence,
 } from "../delivery-evidence.js";
 import { isZeroUsageEmptyStopAssistantTurn } from "../empty-assistant-turn.js";
@@ -864,7 +865,7 @@ export function resolveSettledToolTerminalContinuationInstruction(params: {
   ) {
     return null;
   }
-  if (hasMessagingToolDeliveryEvidence(params.attempt)) {
+  if (hasCompletedMessagingToolDeliveryEvidence(params.attempt)) {
     return null;
   }
   if (

--- a/src/agents/embedded-agent-runner/run/settled-turn-finalization.ts
+++ b/src/agents/embedded-agent-runner/run/settled-turn-finalization.ts
@@ -87,8 +87,7 @@ export async function prepareTerminalWithSettledTurnFinalization(input: {
       ...initial,
       prepared,
       lastRunPromptUsage,
-      finalizationAttempted: false,
-      finalizationSucceeded: false,
+      finalizationOutcome: "not-attempted" as const,
     };
   }
   const settledFailureSignal = prepared.failureSignal;
@@ -100,13 +99,38 @@ export async function prepareTerminalWithSettledTurnFinalization(input: {
       `provider=${errorContext.provider}/${errorContext.model} — running isolated finalization`,
   );
   try {
-    attempt = await runPreparedSettledTurnFinalization({
+    const finalization = await runPreparedSettledTurnFinalization({
       attempt: input.finalization.preparedAttempt,
       settledAttempt: initial.attempt,
       harness: input.finalization.harness,
       prompt,
       noteLaneTaskProgress: input.finalization.noteLaneTaskProgress,
     });
+    if (finalization.outcome === "empty") {
+      mergeUsageIntoAccumulator(input.terminalBase.usageAccumulator, finalization.result.usage);
+      lastRunPromptUsage = finalization.result.usage ?? lastRunPromptUsage;
+      log.warn(
+        `settled-turn finalization completed without a visible answer: runId=${runParams.runId} sessionId=${runParams.sessionId} ` +
+          `provider=${errorContext.provider}/${errorContext.model} — recording completed-empty outcome`,
+      );
+      const emptyAssistant = finalization.result.assistant;
+      const completedEmptyAttempt = {
+        ...initial.attempt,
+        lastAssistant: emptyAssistant,
+        currentAttemptAssistant: emptyAssistant,
+        currentAttemptCompletedAssistant: emptyAssistant,
+      };
+      return {
+        ...initial,
+        attempt: completedEmptyAttempt,
+        attemptAssistant: emptyAssistant,
+        currentAttemptCompletedAssistant: emptyAssistant,
+        prepared,
+        lastRunPromptUsage,
+        finalizationOutcome: "completed-empty" as const,
+      };
+    }
+    attempt = finalization.attempt;
     mergeUsageIntoAccumulator(input.terminalBase.usageAccumulator, attempt.attemptUsage);
     mergeAttemptRunStatsIntoAccumulator(input.terminalBase.usageAccumulator, attempt);
     lastRunPromptUsage = attempt.attemptUsage ?? lastRunPromptUsage;
@@ -139,8 +163,7 @@ export async function prepareTerminalWithSettledTurnFinalization(input: {
       sessionFileUsed: attempt.sessionFileUsed,
       prepared,
       lastRunPromptUsage,
-      finalizationAttempted: true,
-      finalizationSucceeded: true,
+      finalizationOutcome: "answered" as const,
     };
   } catch (error) {
     log.warn(
@@ -151,8 +174,7 @@ export async function prepareTerminalWithSettledTurnFinalization(input: {
       ...initial,
       prepared,
       lastRunPromptUsage,
-      finalizationAttempted: true,
-      finalizationSucceeded: false,
+      finalizationOutcome: "failed" as const,
     };
   }
 }
@@ -163,9 +185,15 @@ async function runPreparedSettledTurnFinalization(input: {
   harness: AgentHarness;
   prompt: string;
   noteLaneTaskProgress: () => void;
-}): Promise<EmbeddedRunAttemptResult> {
+}): Promise<
+  | { outcome: "answered"; attempt: EmbeddedRunAttemptResult }
+  | {
+      outcome: "empty";
+      result: AgentHarnessSettledTurnFinalizationResult;
+    }
+> {
   return await withEmbeddedRunLaneProgressHeartbeat(input.noteLaneTaskProgress, async () => {
-    const result = await runEmbeddedSettledTurnFinalizationWithBackend(
+    const finalization = await runEmbeddedSettledTurnFinalizationWithBackend(
       {
         ...input.attempt,
         operation: "settled-tool-finalization",
@@ -177,12 +205,18 @@ async function runPreparedSettledTurnFinalization(input: {
       input.settledAttempt,
       input.harness,
     );
-    return buildSettledTurnFinalizationAttemptResult({
-      result,
-      settledAttempt: input.settledAttempt,
-      prompt: input.prompt,
-      agentHarnessId: input.attempt.agentHarnessId,
-    });
+    if (finalization.outcome === "empty") {
+      return finalization;
+    }
+    return {
+      outcome: "answered",
+      attempt: buildSettledTurnFinalizationAttemptResult({
+        result: finalization.result,
+        settledAttempt: input.settledAttempt,
+        prompt: input.prompt,
+        agentHarnessId: input.attempt.agentHarnessId,
+      }),
+    };
   });
 }
 

--- a/src/agents/embedded-agent-runner/run/terminal-resolution.ts
+++ b/src/agents/embedded-agent-runner/run/terminal-resolution.ts
@@ -191,7 +191,7 @@ export async function resolveEmbeddedRunTerminal(input: {
   attemptAuthProfileStore: AuthProfileStore;
   apiKeyInfo: ResolvedProviderAuth | null;
   agentHarnessId: string;
-  settledTurnFinalizationAttempted: boolean;
+  settledTurnFinalizationOutcome: "not-attempted" | "answered" | "completed-empty" | "failed";
   pluginHarnessOwnsTransport: boolean;
   pluginHarnessOwnsAuthBootstrap: boolean;
   reportedModelRef: { provider: string; model: string };
@@ -223,7 +223,7 @@ export async function resolveEmbeddedRunTerminal(input: {
   const payloadCount = payloadsForTerminalPath?.length ?? 0;
   // A failed isolated finalization is terminal for this user turn. Do not let
   // its settled side effects cascade into any ordinary retry family.
-  const settledTurnFinalizationAttempted = input.settledTurnFinalizationAttempted;
+  const settledTurnFinalizationAttempted = input.settledTurnFinalizationOutcome !== "not-attempted";
   const emptyAssistantReplyIsSilent = shouldTreatEmptyAssistantReplyAsSilent({
     allowEmptyAssistantReplyAsSilent: runParams.allowEmptyAssistantReplyAsSilent,
     terminalReplyExpectation: runParams.terminalReplyExpectation,
@@ -309,16 +309,17 @@ export async function resolveEmbeddedRunTerminal(input: {
     );
     return { action: "retry" };
   }
-  const incompleteTurnText = emptyAssistantReplyIsSilent
-    ? null
-    : resolveIncompleteTurnPayloadText({
-        payloadCount,
-        aborted: terminalAborted,
-        externalAbort: externalAbort || signalOwnedInterruption,
-        timedOut: terminalTimedOut,
-        hadPotentialSideEffects: input.replayState.hadPotentialSideEffects,
-        attempt,
-      });
+  const incompleteTurnText =
+    emptyAssistantReplyIsSilent || input.settledTurnFinalizationOutcome === "completed-empty"
+      ? null
+      : resolveIncompleteTurnPayloadText({
+          payloadCount,
+          aborted: terminalAborted,
+          externalAbort: externalAbort || signalOwnedInterruption,
+          timedOut: terminalTimedOut,
+          hadPotentialSideEffects: input.replayState.hadPotentialSideEffects,
+          attempt,
+        });
   const incompleteTurnFallbackSafe = Boolean(
     incompleteTurnText &&
     !terminalInterrupted &&

--- a/src/agents/harness/lifecycle.test.ts
+++ b/src/agents/harness/lifecycle.test.ts
@@ -259,7 +259,39 @@ describe("AgentHarness lifecycle runner", () => {
     await flushDiagnosticEvents();
     diagnostics.unsubscribe();
 
-    expect(result.assistant.content).toEqual([{ type: "text", text: "done" }]);
+    expect(result.outcome).toBe("answered");
+    if (result.outcome === "answered") {
+      expect(result.result.assistant.content).toEqual([{ type: "text", text: "done" }]);
+    }
+    expect(diagnostics.events.map(({ event }) => event.type)).toEqual([
+      "harness.run.started",
+      "harness.run.completed",
+    ]);
+  });
+
+  it("records a normally completed empty finalization without emitting an error", async () => {
+    const params = createAttemptParams();
+    const harness: AgentHarness = {
+      id: "codex",
+      label: "Codex",
+      pluginId: "codex-plugin",
+      supports: () => ({ supported: true }),
+      runAttempt: async () => createAttemptResult(),
+    };
+    const diagnostics = captureDiagnosticEvents();
+    const emptyAssistant = { ...createFinalAssistant(), content: [] };
+
+    const result = await runAgentHarnessLifecycleFinalization(harness, params, async () => ({
+      assistant: emptyAssistant,
+      usage: { input: 1, output: 0, total: 1 },
+    }));
+    await flushDiagnosticEvents();
+    diagnostics.unsubscribe();
+
+    expect(result).toMatchObject({
+      outcome: "empty",
+      result: { assistant: emptyAssistant, usage: { input: 1, output: 0, total: 1 } },
+    });
     expect(diagnostics.events.map(({ event }) => event.type)).toEqual([
       "harness.run.started",
       "harness.run.completed",

--- a/src/agents/harness/lifecycle.ts
+++ b/src/agents/harness/lifecycle.ts
@@ -32,6 +32,7 @@ import {
 import type { EmbeddedRunAttemptResult } from "../embedded-agent-runner/run/types.js";
 import { recordAgentHarnessPreflightOwner } from "./errors.js";
 import { applyAgentHarnessResultClassification } from "./result-classification.js";
+import { EmptySettledTurnFinalizationError } from "./settled-turn-finalization-outcome.js";
 import { assertSettledTurnFinalizationResult } from "./settled-turn-finalization-result.js";
 import type {
   AgentHarness,
@@ -41,6 +42,10 @@ import type {
 } from "./types.js";
 
 type AgentHarnessCanonicalAttemptResult = EmbeddedRunAttemptResult;
+
+type AgentHarnessLifecycleFinalizationOutcome =
+  | { outcome: "answered"; result: AgentHarnessSettledTurnFinalizationResult }
+  | { outcome: "empty"; result: AgentHarnessSettledTurnFinalizationResult };
 
 type AgentHarnessLifecyclePhase = DiagnosticHarnessRunErrorEvent["phase"];
 type AgentRunCompletedOutcome = "completed" | "aborted" | "blocked" | "error";
@@ -374,7 +379,7 @@ export async function runAgentHarnessLifecycleFinalization(
   harness: AgentHarness,
   params: AgentHarnessAttemptParams,
   execute: () => Promise<AgentHarnessSettledTurnFinalizationResult>,
-): Promise<AgentHarnessSettledTurnFinalizationResult> {
+): Promise<AgentHarnessLifecycleFinalizationOutcome> {
   let phase: AgentHarnessLifecyclePhase = "prepare";
   const startedAt = Date.now();
   const activeHarnessTrace = getActiveDiagnosticTraceContext();
@@ -395,12 +400,25 @@ export async function runAgentHarnessLifecycleFinalization(
       phase = "send";
       const rawResult = await execute();
       phase = "resolve";
-      return assertSettledTurnFinalizationResult(rawResult);
+      try {
+        return {
+          outcome: "answered" as const,
+          result: assertSettledTurnFinalizationResult(rawResult),
+        };
+      } catch (error) {
+        if (error instanceof EmptySettledTurnFinalizationError) {
+          return { outcome: "empty" as const, result: error.result };
+        }
+        throw error;
+      }
     };
     const rawResult = agentRunTrace
       ? await runWithDiagnosticTraceContext(agentRunTrace, runAndValidate)
       : await runAndValidate();
-    const result = withFallbackFinalizationDiagnosticTrace(rawResult, activeHarnessTrace);
+    const result = {
+      ...rawResult,
+      result: withFallbackFinalizationDiagnosticTrace(rawResult.result, activeHarnessTrace),
+    };
     if (agentRunTrace) {
       emitTrustedDiagnosticEvent({
         type: "run.completed",
@@ -411,7 +429,11 @@ export async function runAgentHarnessLifecycleFinalization(
     }
     emitTrustedDiagnosticEvent({
       type: "harness.run.completed",
-      ...agentHarnessDiagnosticBase(harness, params, result.diagnosticTrace ?? activeHarnessTrace),
+      ...agentHarnessDiagnosticBase(
+        harness,
+        params,
+        result.result.diagnosticTrace ?? activeHarnessTrace,
+      ),
       durationMs: Date.now() - startedAt,
       outcome: "completed",
       itemLifecycle: { startedCount: 0, completedCount: 0, activeCount: 0 },

--- a/src/agents/harness/selection.test.ts
+++ b/src/agents/harness/selection.test.ts
@@ -485,7 +485,10 @@ describe("runAgentHarnessAttempt", () => {
     await expect(
       runAgentHarnessSettledTurnFinalization(params, settledAttempt, harness),
     ).resolves.toMatchObject({
-      assistant: { content: [{ type: "text", text: "final answer" }] },
+      outcome: "answered",
+      result: {
+        assistant: { content: [{ type: "text", text: "final answer" }] },
+      },
     });
     expect(runAttempt).not.toHaveBeenCalled();
     expect(hostAuthorityActive).toBe(false);

--- a/src/agents/harness/selection.ts
+++ b/src/agents/harness/selection.ts
@@ -57,12 +57,7 @@ import {
   resolveAgentHarnessPreparedAuthSupport,
   resolveAgentHarnessPreparedRouteSupport,
 } from "./support.js";
-import type {
-  AgentHarness,
-  AgentHarnessSettledTurnFinalizationResult,
-  AgentHarnessSupport,
-  AgentHarnessSupportContext,
-} from "./types.js";
+import type { AgentHarness, AgentHarnessSupport, AgentHarnessSupportContext } from "./types.js";
 
 const log = createSubsystemLogger("agents/harness");
 export { resolveAgentHarnessPolicy } from "./policy.js";
@@ -479,7 +474,7 @@ export async function runAgentHarnessSettledTurnFinalization(
   params: EmbeddedRunAttemptParams,
   settledAttempt: EmbeddedRunAttemptResult,
   harness: AgentHarness,
-): Promise<AgentHarnessSettledTurnFinalizationResult> {
+) {
   const internalParams = params as EmbeddedRunAttemptParams & {
     systemAgentTool?: SystemAgentToolOptions;
   };

--- a/src/agents/harness/settled-turn-finalization-outcome.ts
+++ b/src/agents/harness/settled-turn-finalization-outcome.ts
@@ -1,0 +1,9 @@
+import type { AgentHarnessSettledTurnFinalizationResult } from "./types.js";
+
+/** A normally stopped finalizer exhausted its visible answer without failing or using tools. */
+export class EmptySettledTurnFinalizationError extends Error {
+  constructor(readonly result: AgentHarnessSettledTurnFinalizationResult) {
+    super("Settled-turn finalization completed without a visible answer");
+    this.name = "EmptySettledTurnFinalizationError";
+  }
+}

--- a/src/agents/harness/settled-turn-finalization-result.test.ts
+++ b/src/agents/harness/settled-turn-finalization-result.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import type { AssistantMessage } from "../../llm/types.js";
 import type { EmbeddedRunAttemptResult } from "../embedded-agent-runner/run/types.js";
+import { EmptySettledTurnFinalizationError } from "./settled-turn-finalization-outcome.js";
 import {
   assertSettledTurnFinalizationResult,
   projectSettledTurnFinalizationAttemptResult,
@@ -77,12 +78,18 @@ describe("assertSettledTurnFinalizationResult", () => {
     ).toThrow("returned a tool call");
   });
 
-  it("rejects an empty answer", () => {
-    expect(() =>
-      assertSettledTurnFinalizationResult({
-        assistant: assistantMessage([{ type: "text", text: "  " }]),
-      }),
-    ).toThrow("without a visible answer");
+  it("classifies a normally completed empty answer", () => {
+    const result = {
+      assistant: assistantMessage([{ type: "text", text: "  " }]),
+    };
+
+    try {
+      assertSettledTurnFinalizationResult(result);
+      throw new Error("expected completed-empty classification");
+    } catch (error) {
+      expect(error).toBeInstanceOf(EmptySettledTurnFinalizationError);
+      expect((error as EmptySettledTurnFinalizationError).result).toBe(result);
+    }
   });
 
   it("rejects an intentionally silent answer", () => {

--- a/src/agents/harness/settled-turn-finalization-result.ts
+++ b/src/agents/harness/settled-turn-finalization-result.ts
@@ -1,6 +1,7 @@
 import { isSilentReplyText } from "../../auto-reply/tokens.js";
 import { normalizeAgentRunAttemptTerminal } from "../agent-run-terminal-outcome.js";
 import { resolveFinalAssistantVisibleText } from "../embedded-agent-runner/run/helpers.js";
+import { EmptySettledTurnFinalizationError } from "./settled-turn-finalization-outcome.js";
 import type {
   AgentHarnessAttemptResult,
   AgentHarnessSettledTurnFinalizationResult,
@@ -61,7 +62,10 @@ export function resolveSettledTurnFinalizationText(
   result: AgentHarnessSettledTurnFinalizationResult,
 ): string {
   const text = resolveFinalAssistantVisibleText(result.assistant);
-  if (!text || isSilentReplyText(text)) {
+  if (!text) {
+    throw new EmptySettledTurnFinalizationError(result);
+  }
+  if (isSilentReplyText(text)) {
     throw new Error("Settled-turn finalization completed without a visible answer");
   }
   return text;


### PR DESCRIPTION
Closes #111764
Related: #108738, #110565

## What Problem This Solves

A settled tool turn can run its isolated, tool-disabled finalizer successfully and still receive a normal completed response with no visible text. Current main turns that valid completed-empty result into an exception, classifies finalization as failed, and surfaces the generic “Agent couldn't generate a response” warning even though the tool work completed.

The secondary failure was at the continuation gate: any messaging-tool send suppressed finalization, so an explicit `sourceReplyFinal: false` progress update could be mistaken for the terminal source reply.

## Why This Change Was Made

This rewrite preserves the private lifecycle outcome introduced on the prior branch but applies Peter's explicit product decision: completed-empty is silent success.

- The harness lifecycle distinguishes `answered` from `empty` only after a normally stopped, capability-free finalizer. Empty is a completed diagnostic outcome, not a harness error. Explicit `NO_REPLY`, tool calls, interruption, provider errors, compaction, and capability activity remain rejected.
- The embedded terminal path carries `completed-empty` as a closed finalization fact, returns no payload, no `NO_REPLY`, no filler assistant text, and no `meta.error`. Run-entry's existing terminal owner records canonical `completed/ok` plus terminal reply disposition `empty`.
- Existing authoritative tool-error payloads and `failureSignal` win over empty completion, so a real failed tool remains visible and is never relabeled successful.
- The finalizer gate uses explicit final/progress messaging evidence while preserving legacy unmarked-send semantics. Marked progress permits finalization; marked final and legacy sends do not.
- `agent-run-terminal-outcome.ts` remains the sole terminal precedence owner. No new terminal reason or downstream status inference was added.

The Codex integration opts into empty text only for the isolated settled-turn finalizer. Ordinary bounded Codex callers still reject an empty response, and an empty finalizer result is not mirrored into transcript history.

## User Impact

When settled tool work completes and the isolated finalizer also completes without text, OpenClaw delivers nothing while recording a truthful completed-empty internal outcome. There is no fabricated summary in delivery, transcripts, or prompt history. Progress messages no longer suppress a required finalizer. Real provider, timeout, abort, and failed-tool outcomes remain honest.

No configuration, default, public/plugin API, protocol version, SQLite schema, or authorization policy changes.

## Evidence

- Pre-fix lifecycle owner: `node scripts/run-vitest.mjs src/agents/harness/settled-turn-finalization-result.test.ts src/agents/harness/lifecycle.test.ts src/agents/embedded-agent-runner/run.incomplete-turn.test.ts` failed the completed-empty classifier because main emitted a generic `Error` instead of the private lifecycle outcome.
- Pre-fix embedded owner: `node scripts/run-vitest.mjs src/agents/embedded-agent-runner/run.incomplete-turn.test.ts` reported 4 failures / 171 passing: completed-empty became the generic tool-side-effect warning, failed-tool fallback was misclassified, marked progress blocked finalization, and a settled continuation was skipped.
- Passing-after on head `7d374a0c5c5fd3bf0bb469dc5b6a2200771bfed0`: the expanded focused command covering validator, lifecycle, selection, embedded owner, Codex bounded turn, and Codex finalizer passed 347 tests across 4 Vitest shards.
- Exact-head CI exposed one stale sibling assertion in `src/agents/harness/selection.test.ts`; it now asserts the new `outcome: "answered"` plus nested result shape while retaining the original assistant-content contract.
- `node scripts/check-changed.mjs` passed on Blacksmith Testbox `tbx_01kzpk7dz62srswem488tvqsm9` (Actions run 31425511650): env ratchet `503/503`, Plugin SDK baseline unchanged, all four typecheck lanes, core/extension lint, boundaries, dead exports, and database-first guards passed.
- Codex-backed autoreview completed in one round with no accepted/actionable findings (0.93 confidence).
- Production LOC: +149/-52. Tests: +155/-22. The production growth establishes one private closed lifecycle outcome across generic and Codex harnesses while retaining the existing canonical terminal/reply owners.
- Direct pinned Codex inspection at `rust-v0.147.0`: `codex-rs/app-server/src/thread_state.rs:158-170` records a final item only for nonblank final text; `codex-rs/app-server/src/bespoke_event_handling.rs:1276-1301` serializes a missing final item as an empty item list; and `codex-rs/app-server/src/bespoke_event_handling.rs:1470-1497` still emits `TurnStatus::Completed` when there is no error.
- ClawSweeper rank-up moves are resolved: Peter explicitly chose silent completed-empty success; the branch was rebased onto green main; direct Codex source was inspected; exact-head required CI is watched to completion before prepare.
