### PR TITLE
fix(sessions): detect adopted turns across short reads

### DIFF
--- a/extensions/acpx/src/pi-session-upstream-activity.test.ts
+++ b/extensions/acpx/src/pi-session-upstream-activity.test.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs/promises";
+import type { FileHandle } from "node:fs/promises";
 import path from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { createPiStoreFixture } from "./pi-session-catalog.test-support.js";
 import { checkPiUpstreamActivity, linkContinuedPiSession } from "./pi-session-upstream-activity.js";
 
@@ -9,6 +10,7 @@ const originalSessionDir = process.env.PI_CODING_AGENT_SESSION_DIR;
 const originalAgentDir = process.env.PI_CODING_AGENT_DIR;
 
 afterEach(async () => {
+  vi.restoreAllMocks();
   if (originalSessionDir === undefined) {
     delete process.env.PI_CODING_AGENT_SESSION_DIR;
   } else {
@@ -25,6 +27,25 @@ afterEach(async () => {
     }),
   );
 });
+
+async function injectFileShortReads(filePath: string, maxBytes: number): Promise<void> {
+  const handle = await fs.open(filePath, "r");
+  const prototype = Object.getPrototypeOf(handle) as FileHandle;
+  const realRead = Object.getOwnPropertyDescriptor(prototype, "read")?.value;
+  await handle.close();
+  if (typeof realRead !== "function") {
+    throw new Error("FileHandle.read is unavailable");
+  }
+  vi.spyOn(prototype, "read").mockImplementation(function (
+    this: FileHandle,
+    buffer: Buffer,
+    offset: number,
+    length: number,
+    position: number,
+  ) {
+    return Reflect.apply(realRead, this, [buffer, offset, Math.min(length, maxBytes), position]);
+  } as FileHandle["read"]);
+}
 
 describe("Pi session upstream activity", () => {
   it("detects external turns, suppresses own echoes, and confirms deletion", async () => {
@@ -105,6 +126,66 @@ describe("Pi session upstream activity", () => {
           upstreamKind: "pi-cli",
           upstreamRef: { filePath: `/${"x".repeat(10_000)}` },
           marker: { offset: 0 },
+          ownRecentUserTexts: [],
+        },
+      ]),
+    ).resolves.toEqual([]);
+  });
+
+  it("completes bounded scan windows across positional short reads", async () => {
+    const sessionDirectory = await createPiStoreFixture(
+      temporaryDirectories,
+      "hi",
+      "Pi catalog session",
+      { command: "pwd" },
+      true,
+    );
+    const continued = await linkContinuedPiSession("agent:main:pi", "pi-session");
+    const file = path.join(sessionDirectory, "session.jsonl");
+    const marker = continued.upstream!.marker;
+    await fs.appendFile(
+      file,
+      `${JSON.stringify({
+        type: "message",
+        timestamp: "2026-07-13T10:00:05.000Z",
+        message: { role: "user", content: "short-read Pi turn" },
+      })}\n`,
+    );
+    await injectFileShortReads(file, 17);
+    const completeSize = (await fs.stat(file)).size;
+
+    await expect(
+      checkPiUpstreamActivity([
+        {
+          sessionKey: continued.sessionKey,
+          agentId: "main",
+          threadId: "pi-session",
+          hostId: "gateway",
+          upstreamKind: continued.upstream!.kind,
+          upstreamRef: continued.upstream!.ref,
+          marker,
+          ownRecentUserTexts: [],
+        },
+      ]),
+    ).resolves.toEqual([
+      expect.objectContaining({
+        kind: "activity",
+        humanTurns: 1,
+        nextMarker: { offset: completeSize },
+      }),
+    ]);
+
+    await fs.appendFile(file, '{"type":"message"');
+    await expect(
+      checkPiUpstreamActivity([
+        {
+          sessionKey: continued.sessionKey,
+          agentId: "main",
+          threadId: "pi-session",
+          hostId: "gateway",
+          upstreamKind: continued.upstream!.kind,
+          upstreamRef: continued.upstream!.ref,
+          marker: { offset: completeSize },
           ownRecentUserTexts: [],
         },
       ]),

--- a/extensions/acpx/src/pi-session-upstream-activity.ts
+++ b/extensions/acpx/src/pi-session-upstream-activity.ts
@@ -11,6 +11,23 @@ import { readPiSessionFileBaseline } from "./pi-session-store.js";
 
 const MAX_PI_UPSTREAM_SCAN_BYTES = 1024 * 1024;
 
+async function readFileRange(
+  handle: Awaited<ReturnType<typeof fs.open>>,
+  position: number,
+  length: number,
+): Promise<Buffer> {
+  const buffer = Buffer.alloc(length);
+  let offset = 0;
+  while (offset < length) {
+    const { bytesRead } = await handle.read(buffer, offset, length - offset, position + offset);
+    if (bytesRead <= 0) {
+      break;
+    }
+    offset += bytesRead;
+  }
+  return offset === length ? buffer : buffer.subarray(0, offset);
+}
+
 function parseCompletePiRows(tail: Buffer): {
   entries: Record<string, unknown>[];
   classifiedBytes: number;
@@ -132,9 +149,7 @@ async function checkPiSessionUpstreamActivity(
       return undefined;
     }
     const readLength = Math.min(stat.size - markerOffset, MAX_PI_UPSTREAM_SCAN_BYTES);
-    const buffer = Buffer.allocUnsafe(readLength);
-    const { bytesRead } = await handle.read(buffer, 0, buffer.length, markerOffset);
-    const tail = buffer.subarray(0, bytesRead);
+    const tail = await readFileRange(handle, markerOffset, readLength);
     const { entries, classifiedBytes } = parseCompletePiRows(tail);
     if (classifiedBytes === 0) {
       // Never advance past an invalid, partial, or over-cap JSONL row.

--- a/extensions/anthropic/session-upstream-activity.test.ts
+++ b/extensions/anthropic/session-upstream-activity.test.ts
@@ -1,4 +1,5 @@
 import fs from "node:fs/promises";
+import type { FileHandle } from "node:fs/promises";
 import path from "node:path";
 import type { SessionUpstreamProbe } from "openclaw/plugin-sdk/session-catalog";
 import { resolvePreferredOpenClawTmpDir, tempWorkspace } from "openclaw/plugin-sdk/temp-path";
@@ -31,6 +32,25 @@ function row(params: {
     message: { role: params.type, content: params.content },
     ...params.extra,
   });
+}
+
+async function injectFileShortReads(filePath: string, maxBytes: number): Promise<void> {
+  const handle = await fs.open(filePath, "r");
+  const prototype = Object.getPrototypeOf(handle) as FileHandle;
+  const realRead = Object.getOwnPropertyDescriptor(prototype, "read")?.value;
+  await handle.close();
+  if (typeof realRead !== "function") {
+    throw new Error("FileHandle.read is unavailable");
+  }
+  vi.spyOn(prototype, "read").mockImplementation(function (
+    this: FileHandle,
+    buffer: Buffer,
+    offset: number,
+    length: number,
+    position: number,
+  ) {
+    return Reflect.apply(realRead, this, [buffer, offset, Math.min(length, maxBytes), position]);
+  } as FileHandle["read"]);
 }
 
 afterEach(() => {
@@ -117,6 +137,54 @@ describe("Claude upstream activity", () => {
         upstreamKind: "claude-cli",
         upstreamRef: { filePath },
         marker: { size: 3 },
+        ownRecentUserTexts: [],
+      }),
+    ).resolves.toBeUndefined();
+  });
+
+  it("completes bounded scan windows across positional short reads", async () => {
+    await using workspace = await createClaudeUpstreamWorkspace("short-read");
+    const filePath = path.join(workspace.dir, "thread-short-read.jsonl");
+    await fs.writeFile(
+      filePath,
+      `${row({
+        type: "user",
+        content: "short-read prompt",
+        timestamp: "2026-07-13T10:05:00.000Z",
+      })}\n`,
+    );
+    await injectFileShortReads(filePath, 17);
+    const completeSize = (await fs.stat(filePath)).size;
+
+    await expect(
+      checkActivity({
+        sessionKey: "agent:main:adopted:claude-short-read",
+        agentId: "main",
+        threadId: "thread-short-read",
+        hostId: "gateway:local",
+        upstreamKind: "claude-cli",
+        upstreamRef: { filePath },
+        marker: { offset: 0 },
+        ownRecentUserTexts: [],
+      }),
+    ).resolves.toEqual(
+      expect.objectContaining({
+        kind: "activity",
+        humanTurns: 1,
+        nextMarker: { offset: completeSize },
+      }),
+    );
+
+    await fs.appendFile(filePath, '{"type":"user"');
+    await expect(
+      checkActivity({
+        sessionKey: "agent:main:adopted:claude-short-read",
+        agentId: "main",
+        threadId: "thread-short-read",
+        hostId: "gateway:local",
+        upstreamKind: "claude-cli",
+        upstreamRef: { filePath },
+        marker: { offset: completeSize },
         ownRecentUserTexts: [],
       }),
     ).resolves.toBeUndefined();

--- a/extensions/anthropic/session-upstream-activity.ts
+++ b/extensions/anthropic/session-upstream-activity.ts
@@ -13,6 +13,23 @@ import type { ClaudeTranscriptItem } from "./session-catalog-transcript.js";
 const MAX_CLAUDE_UPSTREAM_SCAN_BYTES = 1024 * 1024;
 export const continueOperations = new Map<string, Promise<{ sessionKey: string }>>();
 
+async function readFileRange(
+  handle: Awaited<ReturnType<typeof fs.open>>,
+  position: number,
+  length: number,
+): Promise<Buffer> {
+  const buffer = Buffer.alloc(length);
+  let offset = 0;
+  while (offset < length) {
+    const { bytesRead } = await handle.read(buffer, offset, length - offset, position + offset);
+    if (bytesRead <= 0) {
+      break;
+    }
+    offset += bytesRead;
+  }
+  return offset === length ? buffer : buffer.subarray(0, offset);
+}
+
 async function link(
   sessionKey: string,
   hostId: string,
@@ -133,9 +150,7 @@ async function checkClaudeSessionUpstreamActivity(
       return undefined;
     }
     const readLength = Math.min(stat.size - markerOffset, MAX_CLAUDE_UPSTREAM_SCAN_BYTES);
-    const buffer = Buffer.allocUnsafe(readLength);
-    const { bytesRead } = await handle.read(buffer, 0, buffer.length, markerOffset);
-    const tail = buffer.subarray(0, bytesRead);
+    const tail = await readFileRange(handle, markerOffset, readLength);
     const lastNewline = tail.lastIndexOf(0x0a);
     if (lastNewline < 0) {
       // Cursor movement requires a complete classified row. A row beyond the


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where adopted Claude and Pi sessions could delay detecting an
already-written external user turn when a positional transcript read returned
fewer bytes than requested.

## Why This Change Was Made

Each file-backed provider owner now completes its existing bounded positional
window until the window is full or Node reports EOF. The 1 MiB cap, stat-sized
range snapshot, complete-row cursor rule, truncation behavior, and inode
behavior are unchanged.

The helpers intentionally remain private and identical in the ACPX and
Anthropic plugins. Importing core `src/**` would violate the extension boundary;
exporting the core helper through Plugin SDK would create a new cross-owner
contract for two private bundled consumers.

## User Impact

External turns written to adopted Claude and Pi transcripts are detected in the
current polling tick even when the filesystem returns positive short reads.
Incomplete trailing rows remain deferred until complete.

## Evidence

### Base Red / Head Green

- Base `e0a4146f551bff7359b3a6f2351e119223035df1`: real `FileHandle` reads capped
  at 17 bytes reproduce the defect in both production scanners. Pi returns `[]`;
  Claude returns `undefined`.
- Head `50833b0e228877aa9ae499fdaabd0c67fdb73ee5`: the same focused suites pass
  16/16 tests, including incomplete trailing-row controls.
- Command:
  `node scripts/run-vitest.mjs extensions/anthropic/session-upstream-activity.test.ts extensions/acpx/src/pi-session-upstream-activity.test.ts`

### Dependency Contract

Node 24 documents the requested read length as a maximum and EOF as
`bytesRead === 0`; positive short reads must be accumulated:
https://nodejs.org/docs/latest-v24.x/api/fs.html#filehandlereadbuffer-offset-length-position

### Validation

- Blacksmith Testbox changed-check classification: `extensions`,
  `extensionTests`; production and test typechecks passed.
- Targeted exact-patch Testbox lint: 0 warnings, 0 errors.
  Testbox `tbx_01kzpzkm6jda04bcnw223th2c6`; Actions run
  https://github.com/openclaw/openclaw/actions/runs/31441930630
- P1 autoreview: no accepted or actionable findings.
- Local ClawSweeper on exact head `50833b0e228877aa9ae499fdaabd0c67fdb73ee5`:
  correctness 0.98, A/A/A, sufficient terminal proof, no findings, no rank-up
  moves.
- Hosted exact-head CI: green on attempt 2 of https://github.com/openclaw/openclaw/actions/runs/31443360284. Attempt 1 passed all code, build, lint, test, type, dependency, and boundary jobs; `security-fast` failed before scanning on a runner TLS certificate error. The single failed-job-only retry passed `security-fast` and `openclaw/ci-gate`.

### Root Cause And Owner

Both provider scanners allocated a bounded window but called `FileHandle.read`
only once. A valid positive short read could stop before the first newline,
leaving no complete row to classify and silently deferring the turn.

The architectural owners are:

- `extensions/acpx/src/pi-session-upstream-activity.ts`
- `extensions/anthropic/session-upstream-activity.ts`

### Surface

- Production: +36/-6 (net +30), justified by dependency-contract correctness at
  the two isolated provider owner boundaries.
- Tests: +150/-1 (net +149).
- No config, default, SDK, protocol, auth, security, storage, dependency, docs,
  changelog, or public contract changes.

### Provenance

- Claude scanner: https://github.com/openclaw/openclaw/pull/107009,
  commit `bb6874fddfac2bd77748e86ddd6cf8579110c2b4`.
- Pi scanner: https://github.com/openclaw/openclaw/pull/113957,
  commit `76ee87539e7627637ac5ec7b103aece57b200c94`.
- The defect shipped in `v2026.7.2-beta.1` through `v2026.7.2-beta.7`.

### Alternatives Rejected

- Importing `src/config/sessions/file-range.ts` from plugins violates the
  extension boundary.
- Exporting a new Plugin SDK helper widens the contract for two private bundled
  consumers.
- Retrying at the consumer or advancing past partial rows would mask the owner
  defect or corrupt cursor semantics.

<details>
<summary>Punchcard attestation</summary>

`Punchcard-Session: amber-brook-cedar-se`

`pc1.cHVuY2hjYXJkLXNlcnZlci1yZWNlaXB0LXYxAGF0dF8wMUtaUTBXVlQ5TjBNU1BLQktLWFBNRTZQRwB0bnRfMDFKMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAAdXNyXzAxSjAwMDAwMDAwMDAwMDAwMDAwMDAwMDAxAGRldl8zODZGRjVCMzQxQTI2NzQzQjJDREEzMEY0RAB3cmtfMDFLWlBTS01WMUMzODg1NjQ1TUpDM0VFOEYAc2VzXzAxS1pQU0tQU01RUUJaS0MzVDJCRjNQR0pOAGFtYmVyLWJyb29rLWNlZGFyLXNlAG9wZW5jbGF3L29wZW5jbGF3AAAxMTUxMDYAMWNkZTRiOWE1NTQwNzk1NzEwMjdmOTM2NjdiMTk3ODZiOTAzODc2NDU3MDYyM2ExNGMwZDBjMTlmYWRjZjQ0YQBzaWduaW5nLXYxAE1vV2FHQkU2c1lWN2x6QlYzNFBmNEdrR2J4RmFrNi10VUh3UEtBSG95QkZ4WW5kdWp4SXkyREJydVB5TVd6V1lydTBQdnB2X0hQcE9SYzhVTm9ET0RBADIwMjYtMDgtMTBUMjM6NDI6MzEuMjQxWgA.kuBJg96m9XY9YjhO9bodaZYw0V6Vnk4-xgWNCntXpMw9Qs94kgWE-h-4kYs2ba92XXJHNyfLjEAMTnVCiPaeCQ`

</details>
