### PR TITLE
fix(signal): preserve original filenames in outbound attachments

### DIFF
--- a/extensions/signal/src/client-container.real-server.test.ts
+++ b/extensions/signal/src/client-container.real-server.test.ts
@@ -3,8 +3,11 @@
 // by the request deadline, not only by the per-chunk idle guard. This exercises the
 // production containerRpcRequest -> containerRestRequest -> readSignalRestText path
 // without mocking fetch, unlike the fake-timer unit tests.
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
 import http from "node:http";
 import type { AddressInfo } from "node:net";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import { containerRpcRequest } from "./client-container.js";
 
@@ -95,4 +98,99 @@ describe("signal REST real-server deadline", () => {
     );
     expect(result).toEqual({ versions: ["v1"], build: 2 });
   });
+
+  it.each([
+    {
+      stagedFilename: "report---a1b2c3d4-5678-90ab-cdef-1234567890ab.jpg",
+      expectedFilename: "report.jpg",
+    },
+    {
+      stagedFilename: "quarter;final---a1b2c3d4-5678-90ab-cdef-1234567890ab.jpg",
+      expectedFilename: "quarter_final.jpg",
+    },
+    {
+      stagedFilename: "first;middle;last---a1b2c3d4-5678-90ab-cdef-1234567890ab.jpg",
+      expectedFilename: "first_middle_last.jpg",
+    },
+    {
+      stagedFilename: "quarter,final---a1b2c3d4-5678-90ab-cdef-1234567890ab.jpg",
+      expectedFilename: "quarter_final.jpg",
+    },
+    {
+      stagedFilename: "first,middle,last---a1b2c3d4-5678-90ab-cdef-1234567890ab.jpg",
+      expectedFilename: "first_middle_last.jpg",
+    },
+    {
+      stagedFilename: "hash#name---a1b2c3d4-5678-90ab-cdef-1234567890ab.jpg",
+      expectedFilename: "hash_name.jpg",
+    },
+    {
+      stagedFilename: "mixed;comma,hash#name---a1b2c3d4-5678-90ab-cdef-1234567890ab.jpg",
+      expectedFilename: "mixed_comma_hash_name.jpg",
+    },
+    { stagedFilename: "quarter;final.jpg", expectedFilename: "quarter_final.jpg" },
+    { stagedFilename: "quarter,final.jpg", expectedFilename: "quarter_final.jpg" },
+    { stagedFilename: "hash#name.jpg", expectedFilename: "hash_name.jpg" },
+    {
+      stagedFilename: "quarter final---a1b2c3d4-5678-90ab-cdef-1234567890ab.jpg",
+      expectedFilename: "quarter final.jpg",
+    },
+  ])(
+    "posts the provider-safe original filename $expectedFilename",
+    async ({ stagedFilename, expectedFilename }) => {
+      let receivedPayload: unknown;
+      const server = await startServer((req, res) => {
+        if (req.method !== "POST" || req.url !== "/v2/send") {
+          res.writeHead(404);
+          res.end();
+          return;
+        }
+
+        const chunks: Buffer[] = [];
+        req.on("data", (chunk: Buffer | string) => {
+          chunks.push(typeof chunk === "string" ? Buffer.from(chunk) : chunk);
+        });
+        req.on("end", () => {
+          receivedPayload = JSON.parse(Buffer.concat(chunks).toString("utf8"));
+          res.writeHead(200, { "content-type": "application/json" });
+          res.end(JSON.stringify({ timestamp: "1735689600000" }));
+        });
+      });
+
+      const mediaDir = await mkdtemp(join(tmpdir(), "signal-real-filename-"));
+      const content = Buffer.from([0xff, 0xd8, 0xff, 0xe0]);
+      const stagedFile = join(mediaDir, stagedFilename);
+
+      try {
+        await writeFile(stagedFile, content);
+        await expect(
+          containerRpcRequest(
+            "send",
+            {
+              account: "+14259798283",
+              recipient: ["+15550001111"],
+              message: "Photo",
+              attachments: [stagedFile],
+            },
+            { baseUrl: server.baseUrl, timeoutMs: 1_000 },
+          ),
+        ).resolves.toEqual({ timestamp: 1735689600000 });
+
+        expect(receivedPayload).toEqual({
+          message: "Photo",
+          number: "+14259798283",
+          recipients: ["+15550001111"],
+          base64_attachments: [
+            `data:image/jpeg;filename=${expectedFilename};base64,${content.toString("base64")}`,
+          ],
+        });
+        const attachment = (receivedPayload as { base64_attachments: [string] })
+          .base64_attachments[0];
+        const decoded = await (await fetch(attachment)).arrayBuffer();
+        expect(Buffer.from(decoded)).toEqual(content);
+      } finally {
+        await rm(mediaDir, { recursive: true, force: true });
+      }
+    },
+  );
 });

--- a/extensions/signal/src/client-container.test.ts
+++ b/extensions/signal/src/client-container.test.ts
@@ -912,6 +912,78 @@ describe("containerSendMessage", () => {
     await fs.rm(tmpDir, { recursive: true });
   });
 
+  it.each([
+    {
+      stagedFilename: "report---a1b2c3d4-5678-90ab-cdef-1234567890ab.jpg",
+      expectedFilename: "report.jpg",
+    },
+    {
+      stagedFilename: "quarter;final---a1b2c3d4-5678-90ab-cdef-1234567890ab.jpg",
+      expectedFilename: "quarter_final.jpg",
+    },
+    {
+      stagedFilename: "first;middle;last---a1b2c3d4-5678-90ab-cdef-1234567890ab.jpg",
+      expectedFilename: "first_middle_last.jpg",
+    },
+    {
+      stagedFilename: "quarter,final---a1b2c3d4-5678-90ab-cdef-1234567890ab.jpg",
+      expectedFilename: "quarter_final.jpg",
+    },
+    {
+      stagedFilename: "first,middle,last---a1b2c3d4-5678-90ab-cdef-1234567890ab.jpg",
+      expectedFilename: "first_middle_last.jpg",
+    },
+    {
+      stagedFilename: "hash#name---a1b2c3d4-5678-90ab-cdef-1234567890ab.jpg",
+      expectedFilename: "hash_name.jpg",
+    },
+    {
+      stagedFilename: "mixed;comma,hash#name---a1b2c3d4-5678-90ab-cdef-1234567890ab.jpg",
+      expectedFilename: "mixed_comma_hash_name.jpg",
+    },
+    { stagedFilename: "quarter;final.jpg", expectedFilename: "quarter_final.jpg" },
+    { stagedFilename: "quarter,final.jpg", expectedFilename: "quarter_final.jpg" },
+    { stagedFilename: "hash#name.jpg", expectedFilename: "hash_name.jpg" },
+    {
+      stagedFilename: "quarter final---a1b2c3d4-5678-90ab-cdef-1234567890ab.jpg",
+      expectedFilename: "quarter final.jpg",
+    },
+  ])(
+    "restores the provider-safe original attachment filename $expectedFilename",
+    async ({ stagedFilename, expectedFilename }) => {
+      const fs = await import("node:fs/promises");
+      const os = await import("node:os");
+      const path = await import("node:path");
+
+      const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "signal-test-"));
+      try {
+        const stagedFile = path.join(tmpDir, stagedFilename);
+        const content = Buffer.from([0xff, 0xd8, 0xff, 0xe0]);
+        await fs.writeFile(stagedFile, content);
+
+        mockFetch.mockResolvedValue({
+          ok: true,
+          status: 200,
+          ...bodyStream(JSON.stringify({})),
+        });
+
+        await containerSendMessage({
+          baseUrl: "http://localhost:8080",
+          account: "+14259798283",
+          recipients: ["+15550001111"],
+          message: "Photo",
+          attachments: [stagedFile],
+        });
+
+        expect(parseFetchBody().base64_attachments).toEqual([
+          `data:image/jpeg;filename=${expectedFilename};base64,${content.toString("base64")}`,
+        ]);
+      } finally {
+        await fs.rm(tmpDir, { recursive: true, force: true });
+      }
+    },
+  );
+
   it("rejects outbound attachments that exceed the size cap", async () => {
     const fs = await import("node:fs/promises");
     const os = await import("node:os");

--- a/extensions/signal/src/client-container.ts
+++ b/extensions/signal/src/client-container.ts
@@ -6,10 +6,13 @@
  * to keep the two modes cleanly isolated.
  */
 
-import nodePath from "node:path";
 import { toErrorObject } from "openclaw/plugin-sdk/error-runtime";
 import { resolveFetch } from "openclaw/plugin-sdk/fetch-runtime";
-import { detectMime, parseMediaContentLength } from "openclaw/plugin-sdk/media-runtime";
+import {
+  detectMime,
+  extractOriginalFilename,
+  parseMediaContentLength,
+} from "openclaw/plugin-sdk/media-runtime";
 import {
   parseStrictNonNegativeInteger,
   resolveTimerTimeoutMs,
@@ -554,7 +557,8 @@ async function filesToBase64DataUris(
     });
     remainingBytes -= buffer.byteLength;
     const mime = (await detectMime({ buffer, filePath })) ?? "application/octet-stream";
-    const filename = nodePath.basename(filePath);
+    // Signal splits on semicolons; commas and fragments break RFC 2397 attachment data.
+    const filename = extractOriginalFilename(filePath).replace(/[,;#]/g, "_");
     const b64 = buffer.toString("base64");
     results.push(`data:${mime};filename=${filename};base64,${b64}`);
   }


### PR DESCRIPTION
## What Problem This Solves

Salvages existing Signal PR #115107: attachments sent through the signal-cli REST container exposed OpenClaw's internal staged UUID suffix instead of their original filename. Three genuine filename delimiter failures also remained: semicolons truncate the provider's filename metadata, commas corrupt the decoded data-URI bytes, and hash characters turn the payload into a URL fragment.

## Why This Change Was Made

Repair the single canonical Signal attachment serializer instead of adding transport wrappers or alternate send paths. Reuse the existing public media-runtime original-filename owner, then replace only the three characters independently proven unsafe by the pinned provider parser and real WHATWG data-URI decoding. Normal spaces, Unicode filenames, attachment MIME detection, byte budgets, and the existing provider contract remain intact. The production change is seven additions and three deletions, net four lines.

Preserves original contributor ZengWen-DT's existing PR work and co-author credit. The previous unrelated Signal installer blocker was fixed on the frozen baseline by #115270; this candidate includes no installer change.

## User Impact

Signal recipients see the original user-facing attachment filename rather than an internal UUID-staging name. Filenames containing semicolons, commas, hash characters, or combinations of them still reach the Signal provider with intact original JPEG bytes instead of truncating, silently corrupting the attachment, or failing delivery.

## Evidence

- Existing PR only: https://github.com/openclaw/openclaw/pull/115107; original draft head e150c8162574374490ac5e1a537265648d4e7f8a; retained commit trailer Co-authored-by: ZengWen-DT <ceng.wen@xydigit.com>.
- Frozen baseline fdcb321bfaaadb5a1e7d123b6be7a934980f8b12; immutable candidate 9f5c7624f0ee792d60b98573366cbd2b76827462; exact candidate tree 7c23708adcdde90423370cc40ace5a5019628c2a.
- Current main 7e78de747b8a64d52f30aee948b697bf4c528691 leaves every Signal owner, caller, media-store, SDK barrel, package manifest, and lockfile byte-identical; clean synthetic merge tree 79edddd9ee2b9eed46122f051745a15526b287ff.
- Pinned upstream signal-cli-rest-api Go parser at commit 54507eba20904238dd4db8056b4529bd3199dbd2 demonstrably splits filename metadata on semicolons. Independent exhaustive 128-ASCII WHATWG decoding and a second 34-character probe show commas corrupt decoded bytes and hash characters abort fragment-tainted data-URI decoding.
- Frozen baseline real localhost /v2/send was RED for staged UUID/semicolon cases; successive authentic RED matrices independently exposed commas and then hash characters. Final real HTTP matrix covers staged/direct filenames, repeated/mixed delimiters, original UUID stripping, spaces, exact serialized provider payloads, and exact decoded JPEG bytes ff d8 ff e0.
- Fresh isolated Blacksmith Testbox run https://github.com/openclaw/openclaw/actions/runs/30680814341 verified exact candidate tree, owner-relative physical string-width 8.2.2, pnpm tsgo:extensions, pnpm tsgo:extensions:test, 184/184 focused tests (49 media-store, 79 Signal owner, 42 installer, 14 real HTTP), the complete 43-file Signal owner suite with 772/772 passing, type-aware oxlint, oxfmt, and git diff --check. Final marker SIGNAL_QA400_ALL_GATES_GREEN; wrapper exit 0; owned lease stopped and direct status verified completed.
- Full-branch genuine autoreview through P3 and genuine TruffleHog: zero P0/P1/P2/P3 findings, patch is correct, confidence 0.96. Three fresh independent blind reviewers separately returned P0=0/P1=0/P2=0/P3=0.

No auth, security policy, public SDK, configuration, protocol, persistence, SQLite schema, installer implementation, retry, or timeout changes.
