### PR TITLE
refactor(plugin-sdk): share HTML escaping

### DIFF
--- a/src/plugin-sdk/provider-auth-runtime.test.ts
+++ b/src/plugin-sdk/provider-auth-runtime.test.ts
@@ -74,7 +74,7 @@ describe("plugin-sdk provider-auth-runtime", () => {
       callbackPath: "/callback",
       redirectUri: `http://127.0.0.1:${port}/callback`,
       hostname: "127.0.0.1",
-      successTitle: "OAuth complete",
+      successTitle: `OAuth <complete>&"'`,
       corsOriginAllowlist: ["auth.x.ai", "accounts.x.ai"],
     });
 
@@ -101,6 +101,7 @@ describe("plugin-sdk provider-auth-runtime", () => {
 
     expect(response.status).toBe(200);
     expect(response.headers.get("access-control-allow-origin")).toBe("https://auth.x.ai");
+    await expect(response.text()).resolves.toContain("OAuth &lt;complete&gt;&amp;&quot;&#39;");
     await expect(callback).resolves.toEqual({ code: "code-1", state: "state-1" });
   });
 

--- a/src/plugin-sdk/provider-auth-runtime.ts
+++ b/src/plugin-sdk/provider-auth-runtime.ts
@@ -8,6 +8,7 @@ import { ensureAuthProfileStore } from "../agents/auth-profiles/store.js";
 import { resolveApiKeyForProvider as resolveModelApiKeyForProvider } from "../agents/model-auth.js";
 import { normalizeProviderId } from "../agents/model-selection.js";
 import type { OpenClawConfig } from "../config/config.js";
+import { escapeHtml } from "../shared/html-escape.js";
 import { resolveTimerTimeoutMs } from "../shared/number-coercion.js";
 
 export { resolveEnvApiKey } from "../agents/model-auth-env.js";
@@ -176,7 +177,7 @@ export async function waitForLocalOAuthCallback(params: {
 }): Promise<OAuthCallbackResult> {
   const hostname = params.hostname ?? "localhost";
   const timeoutMs = resolveTimerTimeoutMs(params.timeoutMs, 1);
-  const escapedSuccessTitle = escapeHtmlText(params.successTitle);
+  const escapedSuccessTitle = escapeHtml(params.successTitle);
   const resolveOAuthCallbackOrigin = buildOAuthCallbackOriginResolver(params.corsOriginAllowlist);
   const hasCorsOriginAllowlist =
     params.corsOriginAllowlist?.some((host) => host.trim().length > 0) ?? false;
@@ -337,15 +338,6 @@ function isHttpOrigin(value: string): boolean {
   } catch {
     return false;
   }
-}
-
-function escapeHtmlText(value: string): string {
-  return value
-    .replace(/&/g, "&amp;")
-    .replace(/</g, "&lt;")
-    .replace(/>/g, "&gt;")
-    .replace(/"/g, "&quot;")
-    .replace(/'/g, "&#39;");
 }
 
 type ResolveApiKeyForProvider = typeof import("../agents/model-auth.js").resolveApiKeyForProvider;

--- a/src/plugin-sdk/provider-oauth-runtime.test.ts
+++ b/src/plugin-sdk/provider-oauth-runtime.test.ts
@@ -3,6 +3,8 @@ import { describe, expect, it } from "vitest";
 import {
   generateOAuthState,
   generatePKCE,
+  oauthErrorHtml,
+  oauthSuccessHtml,
   parseOAuthAuthorizationInput,
   resolveOAuthTokenExpiresAt,
   resolveOAuthTokenLifetimeMs,
@@ -34,6 +36,13 @@ describe("provider OAuth runtime", () => {
     });
     expect(parseOAuthAuthorizationInput(" oauth-code ")).toEqual({ code: "oauth-code" });
     expect(parseOAuthAuthorizationInput("   ")).toEqual({});
+  });
+
+  it("escapes HTML-sensitive OAuth page content", () => {
+    expect(oauthSuccessHtml(`signed in as <user>&"'`)).toContain(
+      "signed in as &lt;user&gt;&amp;&quot;&#39;",
+    );
+    expect(oauthErrorHtml("failed <login>", `details &"'`)).toContain("details &amp;&quot;&#39;");
   });
 
   it("resolves safe OAuth token lifetimes and expiry timestamps", () => {

--- a/src/plugin-sdk/provider-oauth-runtime.ts
+++ b/src/plugin-sdk/provider-oauth-runtime.ts
@@ -6,6 +6,7 @@ import {
   resolveTimerTimeoutMs,
 } from "../../packages/normalization-core/src/number-coercion.js";
 import type { Model } from "../llm/types.js";
+import { escapeHtml } from "../shared/html-escape.js";
 
 // Static OpenClaw lobster mascot; keep shapes in sync with ui/public/favicon.svg.
 const LOGO_SVG = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 120" fill="none" aria-hidden="true"><defs><linearGradient id="lobster-gradient" x1="0%" y1="0%" x2="100%" y2="100%"><stop offset="0%" stop-color="#ff4d4d"/><stop offset="100%" stop-color="#991b1b"/></linearGradient></defs><path fill="url(#lobster-gradient)" d="M60 10 C30 10 15 35 15 55 C15 75 30 95 45 100 L45 110 L55 110 L55 100 C55 100 60 102 65 100 L65 110 L75 110 L75 100 C90 95 105 75 105 55 C105 35 90 10 60 10Z"/><path fill="url(#lobster-gradient)" d="M20 45 C5 40 0 50 5 60 C10 70 20 65 25 55 C28 48 25 45 20 45Z"/><path fill="url(#lobster-gradient)" d="M100 45 C115 40 120 50 115 60 C110 70 100 65 95 55 C92 48 95 45 100 45Z"/><path stroke="#ff4d4d" stroke-width="3" stroke-linecap="round" d="M45 15 Q35 5 30 8"/><path stroke="#ff4d4d" stroke-width="3" stroke-linecap="round" d="M75 15 Q85 5 90 8"/><circle cx="45" cy="35" r="6" fill="#050810"/><circle cx="75" cy="35" r="6" fill="#050810"/><circle cx="46" cy="34" r="2.5" fill="#00e5cc"/><circle cx="76" cy="34" r="2.5" fill="#00e5cc"/></svg>`;
@@ -116,15 +117,6 @@ export interface OAuthProviderInfo {
   name: string;
   /** Whether this provider can currently start OAuth login. */
   available: boolean;
-}
-
-function escapeHtml(value: string): string {
-  return value
-    .replaceAll("&", "&amp;")
-    .replaceAll("<", "&lt;")
-    .replaceAll(">", "&gt;")
-    .replaceAll('"', "&quot;")
-    .replaceAll("'", "&#39;");
 }
 
 function renderOAuthPage(options: {

--- a/src/plugin-sdk/text-utility-runtime.ts
+++ b/src/plugin-sdk/text-utility-runtime.ts
@@ -2,6 +2,8 @@
 import type { BaseProbeResult } from "../channels/plugins/types.public.js";
 import { withTimeout } from "../utils/with-timeout.js";
 
+export { escapeHtml } from "../shared/html-escape.js";
+
 type ChannelProbeResult = BaseProbeResult & { elapsedMs?: number };
 
 /** Run a channel probe with shared timeout, elapsed-time, and error-result handling. */
@@ -27,16 +29,6 @@ export async function runChannelProbe<
     }
     return finish(onError(error));
   }
-}
-
-/** Escapes text for safe insertion into HTML text and quoted attribute values. */
-export function escapeHtml(value: string): string {
-  return value
-    .replaceAll("&", "&amp;")
-    .replaceAll("<", "&lt;")
-    .replaceAll(">", "&gt;")
-    .replaceAll('"', "&quot;")
-    .replaceAll("'", "&#39;");
 }
 
 export {

--- a/src/shared/html-escape.ts
+++ b/src/shared/html-escape.ts
@@ -1,0 +1,9 @@
+/** Escapes text for safe insertion into HTML text and quoted attribute values. */
+export function escapeHtml(value: string): string {
+  return value
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&#39;");
+}


### PR DESCRIPTION
## What Problem This Solves

Three Plugin SDK runtime paths independently implemented the same five-character HTML escaping rule. Keeping separate copies makes security-sensitive renderer behavior easier to drift.

## Why This Change Was Made

This introduces one private shared HTML escaping helper and reuses it from both provider runtimes. The existing public `escapeHtml` export remains unchanged, and the provider runtimes avoid importing the broader text utility runtime.

## User Impact

No user-visible behavior changes. OAuth callback pages preserve their existing escaping while the implementation has one canonical owner.

## Evidence

- Blacksmith Testbox `tbx_01kykzrf1dgkse3yj02hywz5q5`: focused Plugin SDK suites passed, 21/21 tests.
- Same Testbox: `pnpm check:changed` passed, including SDK API/export/surface guards, all affected typecheck and lint lanes, and zero runtime import cycles.
- Autoreview: clean, 0.98 confidence.
- `git diff --check` passed.
