### PR TITLE
fix(memory-core): restore dreaming session ingestion for SQLite transcripts

### DIFF
--- a/extensions/memory-core/src/dreaming-phases.ts
+++ b/extensions/memory-core/src/dreaming-phases.ts
@@ -50,6 +50,7 @@ import {
   writeMemoryCoreWorkspaceEntries,
 } from "./dreaming-state.js";
 import { textSimilarity as snippetSimilarity } from "./memory/tokenize.js";
+import { buildCorpusSessionEntryOptions } from "./session-corpus-entry-options.js";
 import {
   filterLiveShortTermRecallEntries,
   filterFreshLightDreamingEntries,
@@ -695,12 +696,10 @@ async function collectSessionIngestionBatches(params: {
   const sessionFiles: Array<{
     agentId: string;
     absolutePath: string;
-    generatedByDreamingNarrative: boolean;
-    generatedByCronRun: boolean;
+    entryOptions: ReturnType<typeof buildCorpusSessionEntryOptions>;
     sessionId: string;
     sessionPath: string;
     transcriptSource?: "sqlite";
-    updatedAtMs?: number;
   }> = [];
   for (const agentId of agentIds) {
     for (const entry of await listSessionTranscriptCorpusEntriesForAgent(agentId)) {
@@ -716,15 +715,15 @@ async function collectSessionIngestionBatches(params: {
       sessionFiles.push({
         agentId,
         absolutePath,
-        generatedByDreamingNarrative: entry.generatedByDreamingNarrative === true,
-        generatedByCronRun: entry.generatedByCronRun === true,
+        // SQLite corpus entries address transcripts by store identity, not by
+        // path, so the resolved options must travel with the file.
+        entryOptions: buildCorpusSessionEntryOptions(entry),
         sessionId: entry.sessionId,
         sessionPath:
           entry.transcriptSource === "sqlite"
             ? buildSqliteDreamingSessionPath(entry.agentId, entry.sessionId)
             : sessionPathForFile(absolutePath),
         ...(entry.transcriptSource === "sqlite" ? { transcriptSource: "sqlite" as const } : {}),
-        ...(entry.updatedAtMs !== undefined ? { updatedAtMs: entry.updatedAtMs } : {}),
       });
     }
   }
@@ -755,11 +754,7 @@ async function collectSessionIngestionBatches(params: {
     let fingerprint: { mtimeMs: number; size: number };
     let entry: Awaited<ReturnType<typeof buildSessionEntry>>;
     if (file.transcriptSource === "sqlite") {
-      entry = await buildSessionEntry(file.absolutePath, {
-        generatedByDreamingNarrative: file.generatedByDreamingNarrative,
-        generatedByCronRun: file.generatedByCronRun,
-        ...(file.updatedAtMs !== undefined ? { updatedAtMs: file.updatedAtMs } : {}),
-      });
+      entry = await buildSessionEntry(file.absolutePath, file.entryOptions);
       if (!entry) {
         if (previous) {
           changed = true;
@@ -799,10 +794,7 @@ async function collectSessionIngestionBatches(params: {
         continue;
       }
 
-      entry = await buildSessionEntry(file.absolutePath, {
-        generatedByDreamingNarrative: file.generatedByDreamingNarrative,
-        generatedByCronRun: file.generatedByCronRun,
-      });
+      entry = await buildSessionEntry(file.absolutePath, file.entryOptions);
       if (!entry) {
         continue;
       }

--- a/extensions/memory-core/src/memory/manager-session-sync-ops.ts
+++ b/extensions/memory-core/src/memory/manager-session-sync-ops.ts
@@ -26,6 +26,7 @@ import {
   type MemorySyncParams,
 } from "openclaw/plugin-sdk/memory-core-host-engine-storage";
 import { normalizeAgentId } from "openclaw/plugin-sdk/routing";
+import { buildCorpusSessionEntryOptions } from "../session-corpus-entry-options.js";
 import { shouldSyncSessionsForReindex } from "./manager-session-reindex.js";
 import {
   resolveMemorySessionStartupDirtyFiles,
@@ -58,22 +59,6 @@ export abstract class MemoryManagerSessionSyncOps extends MemoryManagerWatchOps 
 
   protected legacyExtensionlessSessionPathForIdentity(agentId: string, sessionId: string): string {
     return path.join("sessions", normalizeAgentId(agentId), sessionId).replace(/\\/g, "/");
-  }
-
-  protected buildSessionEntryOptions(entry: SessionTranscriptCorpusEntry) {
-    return {
-      generatedByDreamingNarrative: entry.generatedByDreamingNarrative === true,
-      generatedByCronRun: entry.generatedByCronRun === true,
-      ...(entry.transcriptSource === "sqlite" && entry.storePath
-        ? {
-            agentId: entry.agentId,
-            sessionId: entry.sessionId,
-            storePath: entry.storePath,
-          }
-        : {}),
-      ...(entry.sessionKey ? { sessionKey: entry.sessionKey } : {}),
-      ...(entry.updatedAtMs !== undefined ? { updatedAtMs: entry.updatedAtMs } : {}),
-    };
   }
 
   protected ensureSessionListener() {
@@ -147,7 +132,7 @@ export abstract class MemoryManagerSessionSyncOps extends MemoryManagerWatchOps 
             if (corpusEntry.transcriptSource === "sqlite") {
               return statSessionEntrySync(
                 corpusEntry.sessionFile,
-                this.buildSessionEntryOptions(corpusEntry),
+                buildCorpusSessionEntryOptions(corpusEntry),
               );
             }
             const file = corpusEntry.sessionFile;

--- a/extensions/memory-core/src/memory/manager-source-sync-ops.ts
+++ b/extensions/memory-core/src/memory/manager-source-sync-ops.ts
@@ -16,6 +16,7 @@ import {
   MEMORY_INDEX_FTS_TABLE,
   runWithConcurrency,
 } from "openclaw/plugin-sdk/memory-core-host-engine-storage";
+import { buildCorpusSessionEntryOptions } from "../session-corpus-entry-options.js";
 import { MemoryManagerSessionSyncOps } from "./manager-session-sync-ops.js";
 import { resolveMemorySessionSyncPlan } from "./manager-session-sync-state.js";
 import {
@@ -337,7 +338,7 @@ export abstract class MemoryManagerSourceSyncOps extends MemoryManagerSessionSyn
                 const corpusEntry = corpusEntryByPath.get(absPath);
                 const entry = await buildSessionEntry(
                   absPath,
-                  corpusEntry ? this.buildSessionEntryOptions(corpusEntry) : undefined,
+                  corpusEntry ? buildCorpusSessionEntryOptions(corpusEntry) : undefined,
                 );
                 if (!entry) {
                   if (params.progress) {
@@ -412,7 +413,7 @@ export abstract class MemoryManagerSourceSyncOps extends MemoryManagerSessionSyn
         const corpusEntry = corpusEntryByPath.get(absPath);
         const entry = await buildSessionEntry(
           absPath,
-          corpusEntry ? this.buildSessionEntryOptions(corpusEntry) : undefined,
+          corpusEntry ? buildCorpusSessionEntryOptions(corpusEntry) : undefined,
         );
         if (!entry) {
           if (params.progress) {

--- a/extensions/memory-core/src/memory/manager-sync-ops.startup-catchup.test.ts
+++ b/extensions/memory-core/src/memory/manager-sync-ops.startup-catchup.test.ts
@@ -364,7 +364,6 @@ describe("session startup catch-up", () => {
       sessionKey,
       storePath,
       entry: {
-        sessionFile: marker,
         sessionId,
         updatedAt: params.updatedAt ?? 10,
       },
@@ -400,8 +399,8 @@ describe("session startup catch-up", () => {
       },
     ]);
 
-    await expect(harness.catchUp()).resolves.toEqual([session.marker]);
-    expect(harness.getDirtyArchiveFiles()).toEqual([session.marker]);
+    await expect(harness.catchUp()).resolves.toEqual([session.sessionKey]);
+    expect(harness.getDirtyArchiveFiles()).toEqual([session.sessionKey]);
     expect(harness.isSessionsDirty()).toBe(true);
     expect(harness.syncCalls).toEqual([{ reason: "session-startup-catchup" }]);
   });
@@ -460,8 +459,8 @@ describe("session startup catch-up", () => {
       },
     ]);
 
-    await expect(harness.markStartupDirtyFiles()).resolves.toEqual([session.marker]);
-    expect(harness.getDirtyArchiveFiles()).toEqual([session.marker]);
+    await expect(harness.markStartupDirtyFiles()).resolves.toEqual([session.sessionKey]);
+    expect(harness.getDirtyArchiveFiles()).toEqual([session.sessionKey]);
     expect(harness.isSessionsDirty()).toBe(true);
     expect(harness.syncCalls).toEqual([]);
   });
@@ -623,7 +622,7 @@ describe("session startup catch-up", () => {
     await harness.processPendingSessionDeltas();
     await Promise.resolve();
 
-    expect(harness.getDirtyArchiveFiles()).toEqual([session.marker]);
+    expect(harness.getDirtyArchiveFiles()).toEqual([session.sessionKey]);
     expect(harness.syncCalls).toEqual([{ reason: "session-delta" }]);
   });
 
@@ -675,7 +674,6 @@ describe("session startup catch-up", () => {
       sessionKey,
       storePath,
       entry: {
-        sessionFile: marker,
         sessionId,
         updatedAt: 10,
       },

--- a/extensions/memory-core/src/memory/qmd-session-exporter.ts
+++ b/extensions/memory-core/src/memory/qmd-session-exporter.ts
@@ -21,6 +21,7 @@ import {
   replaceQmdSessionArtifactMappings,
   type QmdSessionArtifactMapping,
 } from "../qmd-session-artifacts.js";
+import { buildCorpusSessionEntryOptions } from "../session-corpus-entry-options.js";
 import { sanitizeQmdCollectionNameSegment } from "./qmd-collection-metadata.js";
 
 const log = createSubsystemLogger("memory");
@@ -133,19 +134,10 @@ export class QmdSessionExporter {
         keep.add(target);
         continue;
       }
-      const entry = await buildSessionEntry(sessionFile, {
-        generatedByDreamingNarrative: corpusEntry.generatedByDreamingNarrative === true,
-        generatedByCronRun: corpusEntry.generatedByCronRun === true,
-        ...(corpusEntry.transcriptSource === "sqlite" && corpusEntry.storePath
-          ? {
-              agentId: corpusEntry.agentId,
-              sessionId: corpusEntry.sessionId,
-              storePath: corpusEntry.storePath,
-            }
-          : {}),
-        ...(corpusEntry.sessionKey ? { sessionKey: corpusEntry.sessionKey } : {}),
-        ...(corpusEntry.updatedAtMs !== undefined ? { updatedAtMs: corpusEntry.updatedAtMs } : {}),
-      });
+      const entry = await buildSessionEntry(
+        sessionFile,
+        buildCorpusSessionEntryOptions(corpusEntry),
+      );
       if (!entry || (cutoff && entry.mtimeMs < cutoff)) {
         continue;
       }

--- a/extensions/memory-core/src/session-corpus-entry-options.ts
+++ b/extensions/memory-core/src/session-corpus-entry-options.ts
@@ -1,0 +1,24 @@
+// Memory Core plugin module maps session transcript corpus entries onto
+// buildSessionEntry/statSessionEntrySync options.
+import type { SessionTranscriptCorpusEntry } from "openclaw/plugin-sdk/memory-core-host-engine-qmd";
+
+/**
+ * SQLite-backed corpus entries carry a session store key in `sessionFile`, not a
+ * transcript path, so every consumer must forward the agent/session/store identity
+ * or `buildSessionEntry` silently falls back to a filesystem read and returns null.
+ */
+export function buildCorpusSessionEntryOptions(entry: SessionTranscriptCorpusEntry) {
+  return {
+    generatedByDreamingNarrative: entry.generatedByDreamingNarrative === true,
+    generatedByCronRun: entry.generatedByCronRun === true,
+    ...(entry.transcriptSource === "sqlite" && entry.storePath
+      ? {
+          agentId: entry.agentId,
+          sessionId: entry.sessionId,
+          storePath: entry.storePath,
+        }
+      : {}),
+    ...(entry.sessionKey ? { sessionKey: entry.sessionKey } : {}),
+    ...(entry.updatedAtMs !== undefined ? { updatedAtMs: entry.updatedAtMs } : {}),
+  };
+}

--- a/extensions/memory-core/src/session-search-visibility.qmd.test.ts
+++ b/extensions/memory-core/src/session-search-visibility.qmd.test.ts
@@ -17,7 +17,9 @@ import { asOpenClawConfig } from "./tools.test-helpers.js";
 type TestSessionEntry = {
   sessionId: string;
   updatedAt: number;
-  sessionFile: string;
+  // Retired locator field: persisted entries no longer carry it, so visibility
+  // fixtures that model current stores omit it.
+  sessionFile?: string;
   chatType?: "direct" | "group" | "channel";
   origin?: { chatType?: "direct" | "group" | "channel" };
 };
@@ -245,26 +247,23 @@ describe("filterMemorySearchHitsBySessionVisibility for QMD", () => {
     expect(filtered).toEqual([copiedHit]);
   });
 
-  it("denies mapped QMD hits whose transcript file also has a shared group alias", async () => {
+  it("denies mapped QMD hits whose transcript also has a shared group alias", async () => {
     combinedSessionStore = {
       "agent:main:telegram:direct:owner": {
         sessionId: "current",
         updatedAt: 2,
-        sessionFile: "/tmp/sessions/current.jsonl",
         chatType: "direct",
       },
       "agent:main:explicit:laptop": {
         sessionId: "actual-session-id",
         updatedAt: 1,
-        sessionFile: "/tmp/sessions/shared-transcript.jsonl",
         chatType: "direct",
       },
-      // Same transcript file exposed under a group alias with a different
-      // sessionId: session-id alias resolution alone would miss this.
+      // Same transcript identity exposed under a group alias: the artifact maps
+      // to one private key, so recall must still judge every alias of it.
       "agent:main:telegram:group:team": {
-        sessionId: "group-alias-id",
+        sessionId: "actual-session-id",
         updatedAt: 1,
-        sessionFile: "/tmp/sessions/shared-transcript.jsonl",
         chatType: "group",
       },
     };

--- a/extensions/memory-core/src/session-search-visibility.ts
+++ b/extensions/memory-core/src/session-search-visibility.ts
@@ -250,9 +250,9 @@ export async function filterMemorySearchHitsBySessionVisibility(params: {
   };
 
   const expandRecallAliasKeys = (keys: string[]): string[] => {
-    // Alias resolution by session id can miss a group/channel alias that shares
-    // the same transcript file under a different session id. Recall must judge
-    // every alias, so expand candidates by stored transcript identity.
+    // Hit-key resolution can return one key for a transcript that is also
+    // reachable through a group/channel alias. Recall must judge every alias, so
+    // expand candidates by stored transcript identity before checking privacy.
     const expanded = new Set(keys);
     for (const key of keys) {
       const entry = combinedSessionStore[key];


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where agents with dreaming enabled would silently stop learning from their own conversations: the dreaming sweep ingested **zero** session transcripts, so `memory/.dreams/session-corpus/` was never written and light/REM dreaming had nothing to summarize. Memory recall, dream diaries, and short-term promotion all lost their session input while reporting success.

The same class of breakage also affected memory startup catch-up and QMD session export for SQLite-backed transcripts.

## Why This Change Was Made

`refactor(sessions): remove file-era transcript runtime` (#113233, `4273ca9dbd9`) retired the `sessionFile` locator on session store entries — it is now stripped on both read and write by `projectCanonicalSessionEntryShape` (`src/config/sessions/store-entry-shape.ts:38`). Consequently `listSessionTranscriptCorpusEntriesForAgentSync` addresses live SQLite transcripts by **session store key** and ships the real identity out of band on the corpus entry (`agentId`, `sessionId`, `storePath`, `sessionKey`).

That PR migrated three memory-core consumers to forward the identity but missed a fourth: `extensions/memory-core/src/dreaming-phases.ts`. Without the identity, `buildSessionEntry()` cannot resolve an SQLite target from a bare session key, falls through to a filesystem read of a string that is not a path, and returns `null` — a silent no-op, not an error.

Rather than paste the identity block a fourth time, this PR derives the options once from the corpus entry (`buildCorpusSessionEntryOptions`) and uses that single helper from every consumer, so the next consumer cannot forget the identity. Non-test LOC goes down.

Two test files still encoded the retired file-era identity and were retargeted onto the canonical one:

- `manager-sync-ops.startup-catchup.test.ts` wrote `entry.sessionFile` (a field the store discards) and asserted the `sqlite:<agent>:<id>:<store>` marker as the dirty-file identity. Corpus identity for SQLite sessions is the session key; the marker remains supported as sync **input** and two other tests still prove that.
- `session-search-visibility.qmd.test.ts` proved a fail-closed group-alias denial via two entries sharing a `sessionFile` path under **different** session ids. #113233 removed that path-based aliasing from `isSameStoredTranscript`, and the state is now unreachable: SQLite transcript identity is `(agentId, sessionId)`, so aliases of one transcript necessarily share a session id. The test now models the reachable alias shape, keeping fail-closed coverage on the mapped-QMD route.

A comment in `expandRecallAliasKeys` still described the removed file-path aliasing; corrected in passing.

## User Impact

Agents with dreaming enabled resume ingesting their session transcripts, so dream diaries, light/REM summaries, short-term promotion, and memory recall of past conversations work again. Memory startup catch-up and QMD session export pick up SQLite-backed transcripts correctly. No config, schema, or API change; no migration needed.

## Evidence

**Regression provenance (bisect, verified at exact commits):**

| Ref | `dreaming-phases` | `startup-catchup` + `visibility.qmd` |
| --- | --- | --- |
| `6559e3f3b94` (parent of #113233) | 47 passed | 32 passed |
| `4273ca9dbd9` (#113233) | **12 failed**, 35 passed | **4 failed**, 28 passed |
| `c1dcabce150` (recent `main`) | **12 failed**, 35 passed | **4 failed**, 28 passed |

All 16 failures appear at `4273ca9dbd9` and are still present on `main`. Blamed PR #113233, authored and merged by @steipete on 2026-07-27.

**After this change** (macOS, `node scripts/run-vitest.mjs`):

```
extensions/memory-core/src/dreaming-phases.test.ts                    47 passed
extensions/memory-core/src/memory/manager-sync-ops.startup-catchup.test.ts  21 passed
extensions/memory-core/src/session-search-visibility.qmd.test.ts      11 passed
extensions/memory-core (full plugin suite)          Test Files 73 passed | Tests 1125 passed
```

Four unrelated files (`tools.test.ts`, `tools.citations.test.ts`, `manager.legacy-migration-cleanup.test.ts`, `manager.watcher-config.test.ts`) hit the 150s per-test timeout on the first full-suite run under heavy local contention; re-run in isolation they pass 102/102.

`oxfmt` and `scripts/run-oxlint.mjs` clean on every touched file. Codex autoreview (`gpt-5.6-sol`, xhigh) on the commit: `autoreview clean: no accepted/actionable findings reported`.

**CI gap worth a maintainer decision (not changed here):** `vitest.full-extensions.config.ts` is listed in `EXCLUDED_FULL_SUITE_SHARDS` in `scripts/lib/ci-node-test-plan.mjs`, so extension tests reach CI only through the PR changed-files lane. A change that breaks an extension test without touching that extension's files ships green and stays green on `main` indefinitely — which is exactly what happened here for months. Worth a periodic full-extensions run or a narrower always-on lane; filed for maintainer judgement rather than changed in this PR.
