### PR TITLE
fix(ui): refresh MCP pin controls when canPinMcpApps changes

### DIFF
--- a/ui/src/pages/chat/components/chat-thread.measure.test.ts
+++ b/ui/src/pages/chat/components/chat-thread.measure.test.ts
@@ -7,23 +7,14 @@
 // pane width and overlapping the bubbles in the dashboard chat dock.
 import { render } from "lit";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import * as chatThreadBuild from "../chat-thread-build.ts";
-import { buildCachedChatItems, resetChatThreadState } from "../chat-thread.ts";
+import { resetChatThreadState } from "../chat-thread.ts";
 import { createTestTranscript } from "../chat-view.test-helpers.ts";
-import {
-  renderChatThread,
-  resetChatThreadPresentationState,
-  resetChatThreadSessionPresentationState,
-} from "./chat-thread.ts";
+import { renderChatThread, resetChatThreadPresentationState } from "./chat-thread.ts";
 
 const observedElements = new Set<Element>();
-const resizeObservers = new Set<RecordingResizeObserver>();
 
 class RecordingResizeObserver implements ResizeObserver {
   private readonly targets = new Set<Element>();
-  constructor(private readonly callback: ResizeObserverCallback) {
-    resizeObservers.add(this);
-  }
   observe(target: Element): void {
     this.targets.add(target);
     observedElements.add(target);
@@ -37,39 +28,20 @@ class RecordingResizeObserver implements ResizeObserver {
       observedElements.delete(target);
     }
     this.targets.clear();
-    resizeObservers.delete(this);
-  }
-  emit(width: number, height: number): void {
-    const entries = [...this.targets].map(
-      (target) =>
-        ({
-          target,
-          borderBoxSize: [{ inlineSize: width, blockSize: height }],
-        }) as unknown as ResizeObserverEntry,
-    );
-    if (entries.length > 0) {
-      this.callback(entries, this);
-    }
   }
 }
 
-const defaultMessages = [
-  { role: "user", content: "message one", timestamp: 1_000 },
-  { role: "assistant", content: "reply one", timestamp: 2_000 },
-  { role: "user", content: "message two", timestamp: 3_000 },
-  { role: "assistant", content: "reply two", timestamp: 4_000 },
-];
-
-function threadProps(
-  paneId: string,
-  sessionKey = "agent:main:main",
-  messages: unknown[] = defaultMessages,
-) {
+function threadProps(paneId: string) {
   return {
     paneId,
-    sessionKey,
+    sessionKey: "agent:main:main",
     loading: false,
-    messages,
+    messages: [
+      { role: "user", content: "message one", timestamp: 1_000 },
+      { role: "assistant", content: "reply one", timestamp: 2_000 },
+      { role: "user", content: "message two", timestamp: 3_000 },
+      { role: "assistant", content: "reply two", timestamp: 4_000 },
+    ],
     toolMessages: [],
     streamSegments: [],
     stream: null,
@@ -98,7 +70,6 @@ async function flushDeferredRowPrune(): Promise<void> {
 describe("chat transcript row measurement", () => {
   beforeEach(() => {
     observedElements.clear();
-    resizeObservers.clear();
     vi.stubGlobal("ResizeObserver", RecordingResizeObserver);
     // jsdom reports 0x0 rects and offsetHeight 0; keep the virtualizer
     // viewport and measured row sizes non-zero so re-renders keep producing
@@ -157,166 +128,72 @@ describe("chat transcript row measurement", () => {
     }
   });
 
-  it("keeps built row identities across an A to B to A presentation reset", () => {
-    const paneId = "pane-session-items";
-    const messagesA = [{ role: "assistant", content: "session A", timestamp: 1_000 }];
-    const messagesB = [{ role: "assistant", content: "session B", timestamp: 2_000 }];
-    const stableInputs = {
-      paneId,
-      runId: null,
-      toolMessages: [],
-      streamSegments: [],
-      stream: null,
-      streamStartedAt: null,
-      showToolCalls: true,
+  it("rerenders MCP pin controls when canPinMcpApps flips on the same provider", async () => {
+    const provider = {
+      sessionKey: "agent:main:main",
+      canPinWidgets: true,
+      canPinMcpApps: false,
+      pinMcpApp: vi.fn(async () => undefined),
+      snapshot$: {
+        value: {
+          sessionKey: "agent:main:main",
+          revision: 1,
+          tabs: [],
+          widgets: [],
+        },
+        subscribe: () => () => {},
+      },
     };
-    const buildSpy = vi.spyOn(chatThreadBuild, "buildChatItems");
-    const itemsA = buildCachedChatItems({
-      ...stableInputs,
-      sessionKey: "agent:main:session-a",
-      messages: messagesA,
-    });
-
-    resetChatThreadSessionPresentationState(paneId);
-    buildCachedChatItems({
-      ...stableInputs,
-      sessionKey: "agent:main:session-b",
-      messages: messagesB,
-    });
-    resetChatThreadSessionPresentationState(paneId);
-    const restoredItemsA = buildCachedChatItems({
-      ...stableInputs,
-      sessionKey: "agent:main:session-a",
-      messages: messagesA,
-    });
-
-    expect(buildSpy).toHaveBeenCalledTimes(2);
-    expect(restoredItemsA).toBe(itemsA);
-    expect(restoredItemsA.every((item, index) => item === itemsA[index])).toBe(true);
-  });
-
-  it("keeps an unsettled restored offset with its cached session host", () => {
-    const transcript = createTestTranscript();
-    const container = document.body.appendChild(document.createElement("div"));
-    const messages = Array.from({ length: 20 }, (_, index) => ({
-      role: index % 2 === 0 ? "user" : "assistant",
-      content: `message ${index}`,
-      timestamp: index,
-    }));
-    const renderSession = (sessionKey: string) => {
-      render(
-        renderChatThread(threadProps("pane-pending-scroll", sessionKey, messages), transcript),
-        container,
-      );
+    const props = {
+      ...threadProps("pane-mcp-pin"),
+      showToolCalls: false,
+      boardProvider: provider as never,
+      messages: [
+        { role: "user", content: "Show the app", timestamp: 1_000 },
+        {
+          role: "toolResult",
+          toolCallId: "call-mcp-pin",
+          toolName: "demo__show",
+          content: [{ type: "text", text: "ok" }],
+          details: {
+            mcpAppPreview: {
+              kind: "canvas",
+              view: { id: "mcp-app-pin", title: "Demo App" },
+              presentation: { target: "assistant_message", sandbox: "scripts" },
+              mcpApp: {
+                viewId: "mcp-app-pin",
+                serverName: "demo",
+                toolName: "show",
+                uiResourceUri: "ui://demo/app.html",
+                toolCallId: "call-mcp-pin",
+              },
+            },
+          },
+          timestamp: 1_001,
+        },
+        { role: "assistant", content: "Here it is", timestamp: 1_002 },
+      ],
     };
-    renderSession("agent:main:session-a");
-    transcript.hostConnected();
-    transcript.hostUpdated();
-    transcript.scrollToOffset(420);
-    expect(transcript.pendingScrollOffsetFor("agent:main:session-a")).toBe(420);
 
-    renderSession("agent:main:session-b");
-    transcript.hostUpdated();
-    expect(transcript.pendingScrollOffsetFor("agent:main:session-b")).toBeNull();
-
-    renderSession("agent:main:session-a");
-    expect(transcript.pendingScrollOffsetFor("agent:main:session-a")).toBe(420);
-  });
-
-  it("pauses an unmeasurable restore until loading commits an empty transcript", () => {
     const transcript = createTestTranscript();
-    const container = document.body.appendChild(document.createElement("div"));
-    const props = threadProps("pane-loading-scroll", "agent:main:session-a", []);
-    render(renderChatThread({ ...props, loading: true }, transcript), container);
-    transcript.hostConnected();
-    transcript.hostUpdated();
-    transcript.scrollToOffset(420);
-    transcript.hostUpdated();
-
-    expect(transcript.pendingScrollOffsetFor(props.sessionKey)).toBe(420);
-
-    render(renderChatThread(props, transcript), container);
-    transcript.hostUpdated();
-    expect(transcript.pendingScrollOffsetFor(props.sessionKey)).toBeNull();
-  });
-
-  it("settles a restored offset when loaded rows no longer overflow", () => {
-    const frames: FrameRequestCallback[] = [];
-    vi.spyOn(window, "requestAnimationFrame").mockImplementation((callback) => {
-      frames.push(callback);
-      return frames.length;
-    });
-    vi.spyOn(window, "cancelAnimationFrame").mockImplementation(() => undefined);
-    const transcript = createTestTranscript();
-    const container = document.body.appendChild(document.createElement("div"));
-    const props = threadProps("pane-short-scroll", "agent:main:session-a");
-    render(renderChatThread(props, transcript), container);
-    transcript.hostConnected();
-    transcript.hostUpdated();
-    transcript.scrollToOffset(420);
-
-    for (let index = 0; index <= 60; index += 1) {
-      transcript.hostUpdated();
-      for (const frame of frames.splice(0)) {
-        frame(0);
-      }
-    }
-
-    expect(transcript.pendingScrollOffsetFor(props.sessionKey)).toBeNull();
-  });
-
-  it("reuses measured hosts, remeasures width changes, and tears down evictions", async () => {
-    const transcript = createTestTranscript();
-    const container = document.body.appendChild(document.createElement("div"));
-    const renderSession = async (sessionKey: string) => {
-      render(renderChatThread(threadProps("pane-host-cache", sessionKey), transcript), container);
-      transcript.hostUpdated();
-      await flushDeferredRowPrune();
-    };
-    await renderSession("agent:main:session-a");
+    const host = document.body.appendChild(document.createElement("div"));
+    render(renderChatThread(props, transcript), host);
     transcript.hostConnected();
     transcript.hostUpdated();
     await flushDeferredRowPrune();
+    expect(host.querySelector("[data-pin-widget]")).toBeNull();
 
-    type VirtualizerInternals = {
-      itemSizeCache: Map<unknown, number>;
-      measure: () => void;
-    };
-    type SessionHostInternals = {
-      connected: boolean;
-      measureRowRefs: Map<string, unknown>;
-      virtualizerController: { getVirtualizer: () => VirtualizerInternals };
-    };
-    const controllerInternals = transcript as unknown as {
-      sessionVirtualizers: Map<string, SessionHostInternals>;
-    };
-    const hostA = controllerInternals.sessionVirtualizers.get("agent:main:session-a");
-    expect(hostA).toBeDefined();
-    const virtualizerA = hostA?.virtualizerController.getVirtualizer();
-    expect(virtualizerA?.itemSizeCache.size).toBeGreaterThan(0);
-    const measuredSizes = new Map(virtualizerA?.itemSizeCache);
+    // Same provider identity and board revision; only the MCP pin capability flips.
+    provider.canPinMcpApps = true;
+    render(renderChatThread(props, transcript), host);
+    transcript.hostUpdated();
+    await flushDeferredRowPrune();
+    expect(host.querySelector("[data-pin-widget]")).not.toBeNull();
 
-    await renderSession("agent:main:session-b");
-    await renderSession("agent:main:session-a");
-    expect(controllerInternals.sessionVirtualizers.get("agent:main:session-a")).toBe(hostA);
-    expect(virtualizerA?.itemSizeCache).toEqual(measuredSizes);
-
-    const measure = vi.spyOn(virtualizerA as VirtualizerInternals, "measure");
-    for (const observer of resizeObservers) {
-      observer.emit(640, 600);
-    }
-    expect(measure).toHaveBeenCalled();
-
-    await renderSession("agent:main:session-c");
-    await renderSession("agent:main:session-d");
-    expect(controllerInternals.sessionVirtualizers.size).toBe(3);
-    expect(controllerInternals.sessionVirtualizers.has("agent:main:session-b")).toBe(false);
-    expect(hostA?.connected).toBe(false);
-
-    await renderSession("agent:main:session-e");
-    expect(controllerInternals.sessionVirtualizers.has("agent:main:session-a")).toBe(false);
-    expect(hostA?.measureRowRefs.size).toBe(0);
-    transcript.hostDisconnected();
-    expect(observedElements.size).toBe(0);
+    provider.canPinMcpApps = false;
+    render(renderChatThread(props, transcript), host);
+    transcript.hostUpdated();
+    await flushDeferredRowPrune();
+    expect(host.querySelector("[data-pin-widget]")).toBeNull();
   });
 });

--- a/ui/src/pages/chat/components/chat-thread.ts
+++ b/ui/src/pages/chat/components/chat-thread.ts
@@ -64,18 +64,12 @@ import {
 import { DeletedMessages } from "../deleted-messages.ts";
 import { PinnedMessages } from "../pinned-messages.ts";
 import type { RealtimeTalkConversationEntry } from "../realtime-talk-conversation.ts";
-import {
-  getChatSessionScrollPosition,
-  saveChatSessionScrollPosition,
-  type ChatSessionScrollPosition,
-} from "../scroll.ts";
 import { getOrCreateSessionCacheValue } from "../session-cache.ts";
 import type { PlanStatus } from "../tool-stream.ts";
 import { getToolTitlesVersion } from "../tool-titles.ts";
 import { renderBackgroundTasksStatusRow } from "./chat-background-tasks-status.ts";
 import type { BackgroundTasksProps } from "./chat-background-tasks.ts";
 import { renderChatDivider, renderChatNotice } from "./chat-divider.ts";
-import type { ArtifactDownloadResolver } from "./chat-message-media.ts";
 import {
   dismissConfirmedActionPopovers,
   getAssistantAttachmentAvailabilityRenderVersion,
@@ -150,7 +144,6 @@ type ChatThreadProps = {
   fullMessageAgentId?: string;
   localMediaPreviewRoots?: string[];
   assistantAttachmentAuthToken?: string | null;
-  resolveArtifactDownload?: ArtifactDownloadResolver;
   canvasPluginSurfaceUrl?: string | null;
   embedSandboxMode?: EmbedSandboxMode;
   allowExternalEmbedUrls?: boolean;
@@ -198,15 +191,6 @@ const CHAT_TRANSCRIPT_ESTIMATED_ROW_PX = 120;
 const CHAT_TRANSCRIPT_OVERSCAN = 6;
 const CHAT_TRANSCRIPT_END_THRESHOLD_PX = 8;
 const CHAT_TRANSCRIPT_ANNOUNCEMENT_MAX_CHARS = 500;
-// Initial virtual rows can correct their estimates for several frames. Hold a
-// restored offset for ~200ms so those corrections cannot reapply the end anchor.
-const CHAT_TRANSCRIPT_SCROLL_RESTORE_STABLE_FRAMES = 12;
-// A committed short transcript can legitimately remain at maxOffset=0. Give
-// initial measurement one second before treating that zero range as final.
-const CHAT_TRANSCRIPT_ZERO_MAX_SETTLE_FRAMES = 60;
-// Keep the active transcript plus two recent sessions. Eviction always tears
-// down observers first; otherwise a discarded host would leak row observers.
-const CHAT_TRANSCRIPT_VIRTUALIZER_CACHE_LIMIT = 3;
 
 function initialTranscriptRect(host: ReactiveControllerHost) {
   const width = host instanceof HTMLElement ? host.clientWidth : 0;
@@ -235,16 +219,6 @@ class ChatSessionVirtualizerHost implements ReactiveControllerHost {
   private readonly controllers = new Set<ReactiveController>();
   private readonly virtualizerController: VirtualizerController<HTMLDivElement, HTMLElement>;
   private threadInnerElement: HTMLDivElement | null = null;
-  private connected = false;
-  private observedWidth: number | null = null;
-  private contentReady = false;
-  private pendingScrollOffset: {
-    offset: number;
-    stableFrames: number;
-    zeroMaxFrames: number;
-    onSettled?: (position: ChatSessionScrollPosition) => void;
-  } | null = null;
-  private pendingScrollFrame: number | null = null;
   // Lit calls refs before newly rendered nodes are connected. Resolve the
   // scroll parent lazily or a stable ref can permanently capture null.
   private get scrollElement(): HTMLDivElement | null {
@@ -294,37 +268,21 @@ class ChatSessionVirtualizerHost implements ReactiveControllerHost {
   private currentAnnouncementText = "";
   private readonly mcpAppUnmountGate = new McpAppUnmountGate(this);
 
-  constructor(
-    private readonly host: ReactiveControllerHost,
-    initialOffset: number | null = null,
-    onInitialOffsetSettled?: (position: ChatSessionScrollPosition) => void,
-  ) {
+  constructor(private readonly host: ReactiveControllerHost) {
     this.virtualizerController = new VirtualizerController(this, {
       count: 0,
       getScrollElement: () => this.scrollElement,
       estimateSize: () => CHAT_TRANSCRIPT_ESTIMATED_ROW_PX,
       getItemKey: () => "",
       initialRect: initialTranscriptRect(host),
-      initialOffset: initialOffset ?? Number.MAX_SAFE_INTEGER,
+      initialOffset: Number.MAX_SAFE_INTEGER,
       scrollMargin: initialTranscriptScrollMargin(host),
       anchorTo: "end",
       followOnAppend: false,
       observeElementRect: (instance, callback) =>
         observeElementRect(instance, (rect) => {
-          const widthChanged = this.observedWidth !== null && this.observedWidth !== rect.width;
-          this.observedWidth = rect.width;
           this.syncScrollMargin(instance.scrollElement);
           callback(rect);
-          if (widthChanged) {
-            // Cached offscreen sizes belong to the old wrapping width. Reset
-            // them and synchronously seed connected rows to avoid stale overlap.
-            instance.measure();
-            for (const row of this.threadInnerElement?.querySelectorAll<HTMLElement>(
-              ".chat-virtual-row",
-            ) ?? []) {
-              instance.measureElement(row);
-            }
-          }
         }),
       rangeExtractor: (range) => {
         const indexes = defaultRangeExtractor(range);
@@ -343,14 +301,6 @@ class ChatSessionVirtualizerHost implements ReactiveControllerHost {
       scrollEndThreshold: CHAT_TRANSCRIPT_END_THRESHOLD_PX,
       overscan: CHAT_TRANSCRIPT_OVERSCAN,
     });
-    if (initialOffset !== null) {
-      this.pendingScrollOffset = {
-        offset: initialOffset,
-        stableFrames: 0,
-        zeroMaxFrames: 0,
-        onSettled: onInitialOffsetSettled,
-      };
-    }
   }
 
   get updateComplete() {
@@ -374,15 +324,8 @@ class ChatSessionVirtualizerHost implements ReactiveControllerHost {
   }
 
   connect(): void {
-    if (this.connected) {
-      return;
-    }
-    this.connected = true;
     for (const controller of this.controllers) {
       controller.hostConnected?.();
-    }
-    if (this.pendingScrollOffset) {
-      this.host.requestUpdate();
     }
   }
 
@@ -390,32 +333,13 @@ class ChatSessionVirtualizerHost implements ReactiveControllerHost {
     for (const controller of this.controllers) {
       controller.hostUpdated?.();
     }
-    this.applyPendingScrollOffset();
   }
 
   disconnect(): void {
-    if (this.pendingScrollFrame !== null) {
-      cancelAnimationFrame(this.pendingScrollFrame);
-      this.pendingScrollFrame = null;
-    }
-    if (!this.connected) {
-      this.threadInnerElement = null;
-      return;
-    }
-    this.connected = false;
     for (const controller of this.controllers) {
       controller.hostDisconnected?.();
     }
     this.threadInnerElement = null;
-  }
-
-  dispose(): void {
-    this.disconnect();
-    this.measureRowRefs.clear();
-    this.rowKeys = [];
-    this.rowIndexesByKey.clear();
-    this.focusedRowKey = null;
-    this.pendingScrollOffset = null;
   }
 
   render(
@@ -483,42 +407,6 @@ class ChatSessionVirtualizerHost implements ReactiveControllerHost {
 
   scrollToEnd(options: { behavior?: ScrollBehavior } = {}): void {
     this.virtualizerController.getVirtualizer().scrollToEnd(options);
-  }
-
-  scrollToOffset(offset: number): void {
-    if (this.scrollElement) {
-      this.scrollElement.scrollTop = offset;
-    }
-    this.virtualizerController.getVirtualizer().scrollToOffset(offset);
-  }
-
-  getScrollOffset(): number | null {
-    return this.scrollElement?.scrollTop ?? null;
-  }
-
-  getMaxScrollOffset(): number | null {
-    const scrollElement = this.scrollElement;
-    return scrollElement
-      ? Math.max(0, scrollElement.scrollHeight - scrollElement.clientHeight)
-      : null;
-  }
-
-  setContentReady(ready: boolean): void {
-    this.contentReady = ready;
-  }
-
-  restoreScrollOffset(
-    offset: number,
-    onSettled?: (position: ChatSessionScrollPosition) => void,
-  ): void {
-    this.pendingScrollOffset = { offset, stableFrames: 0, zeroMaxFrames: 0, onSettled };
-    if (this.connected) {
-      this.host.requestUpdate();
-    }
-  }
-
-  getPendingScrollOffset(): number | null {
-    return this.pendingScrollOffset?.offset ?? null;
   }
 
   handleFocusIn(event: FocusEvent): void {
@@ -592,129 +480,26 @@ class ChatSessionVirtualizerHost implements ReactiveControllerHost {
       scrollMargin,
     });
   }
-
-  private applyPendingScrollOffset(): void {
-    const pending = this.pendingScrollOffset;
-    if (!pending || !this.connected) {
-      return;
-    }
-    const maxOffset = this.getMaxScrollOffset();
-    if (maxOffset === null) {
-      if (this.contentReady && this.rowKeys.length === 0) {
-        this.settlePendingScroll(0);
-      }
-      return;
-    }
-    if (maxOffset === 0 && pending.offset > 0) {
-      if (this.contentReady && this.rowKeys.length === 0) {
-        this.settlePendingScroll(0);
-      } else if (this.contentReady) {
-        if (pending.zeroMaxFrames >= CHAT_TRANSCRIPT_ZERO_MAX_SETTLE_FRAMES) {
-          this.settlePendingScroll(0);
-          return;
-        }
-        pending.zeroMaxFrames += 1;
-        this.schedulePendingScrollRetry();
-      }
-      return;
-    }
-    pending.zeroMaxFrames = 0;
-    const targetOffset = Math.min(pending.offset, maxOffset);
-    this.scrollToOffset(targetOffset);
-    const currentOffset = this.getScrollOffset();
-    if (currentOffset != null && Math.abs(currentOffset - targetOffset) <= 1) {
-      if (pending.stableFrames >= CHAT_TRANSCRIPT_SCROLL_RESTORE_STABLE_FRAMES) {
-        this.settlePendingScroll(currentOffset);
-      } else {
-        pending.stableFrames += 1;
-        this.schedulePendingScrollRetry();
-      }
-    } else {
-      pending.stableFrames = 0;
-      this.schedulePendingScrollRetry();
-    }
-  }
-
-  private schedulePendingScrollRetry(): void {
-    if (!this.connected || this.pendingScrollFrame !== null) {
-      return;
-    }
-    this.pendingScrollFrame = requestAnimationFrame(() => {
-      this.pendingScrollFrame = null;
-      if (this.connected && this.pendingScrollOffset) {
-        this.host.requestUpdate();
-      }
-    });
-  }
-
-  private settlePendingScroll(scrollTop: number): void {
-    const pending = this.pendingScrollOffset;
-    this.pendingScrollOffset = null;
-    if (!pending) {
-      return;
-    }
-    const maxScrollTop = this.getMaxScrollOffset();
-    pending.onSettled?.({
-      scrollTop,
-      anchorToEnd:
-        maxScrollTop === null
-          ? this.contentReady && this.rowKeys.length === 0
-          : maxScrollTop - scrollTop <= CHAT_TRANSCRIPT_END_THRESHOLD_PX,
-    });
-  }
 }
 
 export class ChatTranscriptController implements ReactiveController {
-  private activeSessionKey: string | null = null;
+  private sessionKey: string | null = null;
   private sessionVirtualizer: ChatSessionVirtualizerHost | null = null;
-  private readonly sessionVirtualizers = new Map<string, ChatSessionVirtualizerHost>();
   private connected = false;
 
   constructor(private readonly host: ReactiveControllerHost) {
     host.addController(this);
   }
 
-  get renderedSessionKey(): string | null {
-    return this.activeSessionKey;
-  }
-
   render(props: ChatThreadProps): TemplateResult {
     if (
       !this.sessionVirtualizer ||
-      this.activeSessionKey === null ||
-      !areUiSessionKeysEquivalent(this.activeSessionKey, props.sessionKey)
+      this.sessionKey === null ||
+      !areUiSessionKeysEquivalent(this.sessionKey, props.sessionKey)
     ) {
       this.sessionVirtualizer?.disconnect();
-      let cachedKey: string | null = null;
-      let nextVirtualizer: ChatSessionVirtualizerHost | null = null;
-      for (const [sessionKey, virtualizer] of this.sessionVirtualizers) {
-        if (areUiSessionKeysEquivalent(sessionKey, props.sessionKey)) {
-          cachedKey = sessionKey;
-          nextVirtualizer = virtualizer;
-          break;
-        }
-      }
-      if (cachedKey !== null && nextVirtualizer) {
-        this.sessionVirtualizers.delete(cachedKey);
-      } else {
-        const savedPosition = getChatSessionScrollPosition(props.paneId, props.sessionKey);
-        const initialOffset = savedPosition?.anchorToEnd
-          ? null
-          : (savedPosition?.scrollTop ?? null);
-        nextVirtualizer = new ChatSessionVirtualizerHost(
-          this.host,
-          initialOffset,
-          initialOffset === null
-            ? undefined
-            : (position) => {
-                saveChatSessionScrollPosition(props.paneId, props.sessionKey, position);
-              },
-        );
-      }
-      this.activeSessionKey = props.sessionKey;
-      this.sessionVirtualizer = nextVirtualizer;
-      this.sessionVirtualizers.set(props.sessionKey, nextVirtualizer);
-      this.evictInactiveVirtualizers();
+      this.sessionKey = props.sessionKey;
+      this.sessionVirtualizer = new ChatSessionVirtualizerHost(this.host);
       if (this.connected) {
         this.sessionVirtualizer.connect();
       }
@@ -724,17 +509,6 @@ export class ChatTranscriptController implements ReactiveController {
 
   scrollToEnd(options: { behavior?: ScrollBehavior } = {}): void {
     this.sessionVirtualizer?.scrollToEnd(options);
-  }
-
-  scrollToOffset(offset: number, onSettled?: (position: ChatSessionScrollPosition) => void): void {
-    this.sessionVirtualizer?.restoreScrollOffset(offset, onSettled);
-  }
-
-  pendingScrollOffsetFor(sessionKey: string): number | null {
-    return this.activeSessionKey !== null &&
-      areUiSessionKeysEquivalent(this.activeSessionKey, sessionKey)
-      ? (this.sessionVirtualizer?.getPendingScrollOffset() ?? null)
-      : null;
   }
 
   handleFocusIn(event: FocusEvent): void {
@@ -756,23 +530,7 @@ export class ChatTranscriptController implements ReactiveController {
 
   hostDisconnected(): void {
     this.connected = false;
-    for (const virtualizer of this.sessionVirtualizers.values()) {
-      virtualizer.disconnect();
-    }
-  }
-
-  private evictInactiveVirtualizers(): void {
-    while (this.sessionVirtualizers.size > CHAT_TRANSCRIPT_VIRTUALIZER_CACHE_LIMIT) {
-      const oldest = this.sessionVirtualizers.entries().next().value as
-        | [string, ChatSessionVirtualizerHost]
-        | undefined;
-      if (!oldest) {
-        return;
-      }
-      const [sessionKey, virtualizer] = oldest;
-      this.sessionVirtualizers.delete(sessionKey);
-      virtualizer.dispose();
-    }
+    this.sessionVirtualizer?.disconnect();
   }
 }
 
@@ -818,7 +576,7 @@ function getPinnedMessageSummary(message: unknown): string {
   return extractTextCached(message) ?? "";
 }
 
-function dismissChatThreadPortals(paneId?: string, owner?: ParentNode): void {
+export function resetChatThreadPresentationState(paneId?: string, owner?: ParentNode) {
   removeReplyContextMenu(paneId);
   if (owner) {
     dismissConfirmedActionPopovers(owner);
@@ -826,21 +584,6 @@ function dismissChatThreadPortals(paneId?: string, owner?: ParentNode): void {
   // The selection popup is body-portaled; pane teardown/route changes must
   // drop it so it cannot outlive the render that owns its callbacks.
   removeChatSelectionPopup();
-}
-
-export function resetChatThreadSessionPresentationState(paneId: string, owner?: ParentNode): void {
-  dismissChatThreadPortals(paneId, owner);
-  const state = threadStates.get(paneId);
-  if (state) {
-    // Search input belongs to the outgoing transcript. Other fields are pane
-    // preferences or dependency memos and invalidate themselves on new props.
-    state.searchOpen = false;
-    state.searchQuery = "";
-  }
-}
-
-export function resetChatThreadPresentationState(paneId?: string, owner?: ParentNode) {
-  dismissChatThreadPortals(paneId, owner);
   if (paneId) {
     threadStates.delete(paneId);
     resetChatThreadState(paneId);
@@ -1473,7 +1216,6 @@ function renderChatThreadContents(
   };
   const hasRealtimeTalkConversation = (props.realtimeTalkConversation?.length ?? 0) > 0;
   const isEmpty = chatItems.length === 0 && !props.loading && !hasRealtimeTalkConversation;
-  transcript.setContentReady(!props.loading);
   // 1:1 sessions drop the avatar gutter entirely; group threads keep avatars
   // as the always-visible identity marker. The canonical session kind decides;
   // the sessions list is capped, so absent/unknown rows classify by key:
@@ -1547,7 +1289,6 @@ function renderChatThreadContents(
       basePath: props.basePath,
       localMediaPreviewRoots: props.localMediaPreviewRoots ?? [],
       assistantAttachmentAuthToken: props.assistantAttachmentAuthToken ?? null,
-      resolveArtifactDownload: props.resolveArtifactDownload,
       canvasPluginSurfaceUrl: props.canvasPluginSurfaceUrl,
       embedSandboxMode: props.embedSandboxMode ?? "scripts",
       allowExternalEmbedUrls: props.allowExternalEmbedUrls ?? false,
@@ -1734,6 +1475,7 @@ function renderChatThreadContents(
     props.gatewayUrl,
     props.boardProvider,
     props.boardProvider?.canPinWidgets,
+    props.boardProvider?.canPinMcpApps,
     props.boardProvider?.snapshot$.value.revision,
     props.fullMessageAgentId,
     showReasoning,


### PR DESCRIPTION
## Summary
- Fixes #114979: existing chat transcript MCP app pin buttons stayed stale when Gateway `canPinMcpApps` flipped on the same board provider/revision.
- Adds `canPinMcpApps` to the chat transcript render dependency list next to `canPinWidgets`.
- Adds a same-provider capability flip regression in `chat-thread.measure.test.ts`.

## Test plan
- [x] `FS_SAFE_NATIVE_MODE=off node node_modules/vitest/vitest.mjs run --config test/vitest/vitest.ui.config.ts ui/src/pages/chat/components/chat-thread.measure.test.ts` (2 passed)
- [x] Same-provider / unchanged-revision capability flip covered by the new measure regression: start with `canPinMcpApps=false` (no Pin), flip to `true` (Pin appears), flip back to `false` (Pin gone).