### PR TITLE
fix(slack): keep previews with custom outbound identity

### DIFF
--- a/docs/channels/slack.md
+++ b/docs/channels/slack.md
@@ -1440,6 +1440,7 @@ Slack native progress task cards are opt-in for progress mode. Set `channels.sla
 - A reply thread must be available for native text streaming and Slack assistant thread status to appear. Thread selection still follows `replyToMode`.
 - Channel, group-chat, and top-level DM roots can still use the normal draft preview when native streaming is unavailable or no reply thread exists.
 - Top-level Slack DMs stay off-thread by default, so they do not show Slack's thread-style native stream/status preview; OpenClaw posts and edits a draft preview in the DM instead.
+- Custom outbound username/icon settings keep portable previews enabled. OpenClaw keeps the preview app-authored so partial/block previews can be removed before a separately customized final; progress mode may instead collapse the app-authored draft into a receipt. Slack does not allow impersonated messages to be deleted.
 - Media and non-text payloads fall back to normal delivery.
 - Media/error finals cancel pending preview edits; eligible text/block finals flush only when they can edit the preview in place.
 - If streaming fails mid-reply, OpenClaw falls back to normal delivery for remaining payloads.

--- a/extensions/slack/src/delivery-trace.test.ts
+++ b/extensions/slack/src/delivery-trace.test.ts
@@ -250,11 +250,8 @@ const slackTraceScenarios: Record<SlackTraceScenarioName, readonly DeliveryTrace
     { kind: "idle" },
   ],
   // Edit-preview tier: native transport ineligible → draft post + throttled
-  // chat.update, and the final promotes the draft in place. The custom-identity
-  // flavor of this tier is structurally unreachable: dispatch.ts disables the
-  // draft stream whenever a custom identity is set because chat.update cannot
-  // preserve custom authorship (identity turns instead deliver one final
-  // chat.postMessage), so no golden exists for it.
+  // chat.update, and the final promotes the draft in place. Custom identity uses
+  // a disposable app-authored draft plus a separate customized final instead.
   "preview-edit-fallback": [
     { kind: "reply-start" },
     { kind: "partial", text: PREVIEW_PARTIAL_ONE },

--- a/extensions/slack/src/monitor/message-handler/dispatch-progress.ts
+++ b/extensions/slack/src/monitor/message-handler/dispatch-progress.ts
@@ -58,6 +58,7 @@ export function createSlackProgressRuntime(runtimeParams: {
     account,
     cfg,
     ctx,
+    hasSlackCustomIdentity,
     message,
     prepared,
     replyPlan,
@@ -78,7 +79,9 @@ export function createSlackProgressRuntime(runtimeParams: {
         token: ctx.botToken,
         accountId: account.accountId,
         ...(prepared.eventScope ? { eventScope: prepared.eventScope } : {}),
-        identity: slackIdentity,
+        // Impersonated Slack messages cannot be deleted. Keep the temporary
+        // preview app-authored and apply custom identity only to final delivery.
+        ...(!hasSlackCustomIdentity && slackIdentity ? { identity: slackIdentity } : {}),
         ...(slackMessageMetadata ? { metadata: slackMessageMetadata } : {}),
         maxChars: Math.min(ctx.textLimit, SLACK_TEXT_LIMIT),
         resolveThreadTs: () => {

--- a/extensions/slack/src/monitor/message-handler/dispatch-setup.ts
+++ b/extensions/slack/src/monitor/message-handler/dispatch-setup.ts
@@ -288,14 +288,10 @@ export async function createSlackDispatchSetup(prepared: PreparedSlackMessage) {
     streamingEnabled,
     threadTs: streamThreadHint,
   });
-  // chat.update cannot preserve custom authorship. Use native streaming when
-  // possible; otherwise keep identity intact with one final postMessage.
-  const shouldUseDraftStream =
-    !hasSlackCustomIdentity &&
-    shouldInitializeSlackDraftStream({
-      previewStreamingEnabled,
-      useStreaming,
-    });
+  const shouldUseDraftStream = shouldInitializeSlackDraftStream({
+    previewStreamingEnabled,
+    useStreaming,
+  });
   const blockStreamingEnabled = resolveChannelStreamingBlockEnabled(account.config);
   const disableBlockStreaming = sourceRepliesAreToolOnly
     ? true
@@ -343,6 +339,7 @@ export async function createSlackDispatchSetup(prepared: PreparedSlackMessage) {
     slackStreaming,
     streamThreadHint,
     previewStreamingEnabled,
+    hasSlackCustomIdentity,
     shouldUseDraftStream,
     disableBlockStreaming,
     useStreaming,

--- a/extensions/slack/src/monitor/message-handler/dispatch.preview-fallback.test.ts
+++ b/extensions/slack/src/monitor/message-handler/dispatch.preview-fallback.test.ts
@@ -1159,15 +1159,101 @@ describe("dispatchPreparedSlackMessage preview fallback", () => {
     expectDeliverReplyCall(0, FINAL_REPLY_TEXT);
   });
 
-  it("uses the relay identity when the agent has no explicit Slack identity", async () => {
-    const relayIdentity = { username: "Nik Team Claw" };
+  it("uses a disposable portable preview before custom-identity final delivery", async () => {
+    const relayIdentity = { username: "Nik Team Claw", iconEmoji: ":robot_face:" };
+    const draftStream = {
+      ...createDraftStreamStub(),
+      clear: vi.fn(noopAsync),
+      discardPending: vi.fn(noopAsync),
+    };
+    createSlackDraftStreamMock.mockReturnValueOnce(draftStream);
 
     await dispatchPreparedSlackMessage(createPreparedSlackMessage({ relayIdentity }));
 
-    expect(createSlackDraftStreamMock).not.toHaveBeenCalled();
+    expect(createSlackDraftStreamMock).toHaveBeenCalledWith(
+      expect.not.objectContaining({ identity: expect.anything() }),
+    );
     expect(finalizeSlackPreviewEditMock).not.toHaveBeenCalled();
+    expect(draftStream.discardPending).toHaveBeenCalled();
+    expect(draftStream.clear).toHaveBeenCalledTimes(1);
     expect(deliverRepliesMock).toHaveBeenCalledTimes(1);
     expectDeliverReplyCall(0, FINAL_REPLY_TEXT, { identity: relayIdentity });
+  });
+
+  it("clears a disposable preview before custom-identity media delivery", async () => {
+    const relayIdentity = {
+      username: "Nik Team Claw",
+      iconUrl: "https://example.com/claw.png",
+    };
+    const draftStream = {
+      ...createDraftStreamStub(),
+      clear: vi.fn(noopAsync),
+      discardPending: vi.fn(noopAsync),
+    };
+    createSlackDraftStreamMock.mockReturnValueOnce(draftStream);
+    mockedDispatchSequence = [
+      {
+        kind: "final",
+        payload: { text: "Photo", mediaUrl: "https://example.com/a.png" },
+      },
+    ];
+
+    await dispatchPreparedSlackMessage(createPreparedSlackMessage({ relayIdentity }));
+
+    expect(createSlackDraftStreamMock).toHaveBeenCalledWith(
+      expect.not.objectContaining({ identity: expect.anything() }),
+    );
+    expect(draftStream.discardPending).toHaveBeenCalled();
+    expect(draftStream.clear).toHaveBeenCalledTimes(1);
+    expect(finalizeSlackPreviewEditMock).not.toHaveBeenCalled();
+    expect(deliverRepliesMock).toHaveBeenCalledTimes(1);
+    const params = requireRecord(
+      requireMockCall(deliverRepliesMock, 0, "deliver replies")[0],
+      "deliver replies params",
+    );
+    expectRecordFields(params, { replyThreadTs: THREAD_TS, identity: relayIdentity });
+    expect(params.replies).toEqual([{ text: "Photo", mediaUrl: "https://example.com/a.png" }]);
+  });
+
+  it("restores TTS text before custom-identity supplement delivery", async () => {
+    const relayIdentity = { username: "Nik Team Claw" };
+    const draftStream = {
+      ...createDraftStreamStub(),
+      clear: vi.fn(noopAsync),
+      discardPending: vi.fn(noopAsync),
+    };
+    createSlackDraftStreamMock.mockReturnValueOnce(draftStream);
+    mockedDispatchSequence = [
+      {
+        kind: "final",
+        payload: {
+          mediaUrl: "https://example.com/tts.mp3",
+          audioAsVoice: true,
+          spokenText: "Spoken answer",
+          ttsSupplement: { spokenText: "Spoken answer" },
+        },
+      },
+    ];
+
+    await dispatchPreparedSlackMessage(createPreparedSlackMessage({ relayIdentity }));
+
+    expect(finalizeSlackPreviewEditMock).not.toHaveBeenCalled();
+    expect(draftStream.discardPending).toHaveBeenCalled();
+    expect(draftStream.clear).toHaveBeenCalledTimes(1);
+    const params = requireRecord(
+      requireMockCall(deliverRepliesMock, 0, "deliver replies")[0],
+      "deliver replies params",
+    );
+    expectRecordFields(params, { replyThreadTs: THREAD_TS, identity: relayIdentity });
+    expect(params.replies).toEqual([
+      {
+        text: "Spoken answer",
+        mediaUrl: "https://example.com/tts.mp3",
+        audioAsVoice: true,
+        spokenText: "Spoken answer",
+        ttsSupplement: { spokenText: "Spoken answer" },
+      },
+    ]);
   });
 
   it("uses supported native Slack streaming authorship when a custom identity is active", async () => {

--- a/extensions/slack/src/monitor/message-handler/dispatch.ts
+++ b/extensions/slack/src/monitor/message-handler/dispatch.ts
@@ -46,6 +46,7 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
     cfg,
     ctx,
     disableBlockStreaming,
+    hasSlackCustomIdentity,
     hasRepliedRef,
     message,
     messageSentHookContext,
@@ -195,6 +196,7 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
       info.kind === "final" &&
       ttsSupplement &&
       draftStream &&
+      !hasSlackCustomIdentity &&
       !draftPreviewCommitted.value &&
       !delivery.observedFinalReplyDelivery &&
       previewStreamingEnabled &&
@@ -280,6 +282,7 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
             : undefined,
         buildFinalEdit: () => {
           if (
+            hasSlackCustomIdentity ||
             !previewStreamingEnabled ||
             (reply.hasMedia && !ttsSupplement) ||
             payload.isError ||

--- a/src/agents/model-catalog-visibility.test.ts
+++ b/src/agents/model-catalog-visibility.test.ts
@@ -9,6 +9,7 @@ import {
   resolveLogicalVisibleModelCatalog,
 } from "./model-catalog-visibility.js";
 import type { ModelCatalogEntry } from "./model-catalog.types.js";
+import { createModelVisibilityPolicy } from "./model-visibility-policy.js";
 import { openAIModelCatalogRoutePolicy } from "./openai-model-routes.js";
 
 describe("resolveLogicalVisibleModelCatalog", () => {
@@ -100,6 +101,16 @@ describe("resolveLogicalVisibleModelCatalog", () => {
         },
       },
     } as OpenClawConfig;
+    // This unit test covers configured-row retention, not runtime plugin
+    // discovery. Keep fake provider refs on the deterministic static path.
+    const policy = createModelVisibilityPolicy({
+      cfg,
+      catalog,
+      defaultProvider: "demo",
+      defaultModel: "primary",
+      allowManifestNormalization: false,
+      allowPluginNormalization: false,
+    });
 
     const result = await resolveLogicalVisibleModelCatalog({
       cfg,
@@ -107,6 +118,7 @@ describe("resolveLogicalVisibleModelCatalog", () => {
       defaultProvider: "demo",
       defaultModel: "primary",
       view: "configured",
+      policy,
       routePolicy: openAIModelCatalogRoutePolicy,
       evaluateEntry: evaluateAvailableEntry,
     });


### PR DESCRIPTION
Closes #107861

Supersedes #107888 while preserving @goutamadwant's contribution as co-author.

## What Problem This Solves

Fixes an issue where Slack users with a custom outbound username or icon lost portable draft-preview streaming whenever native streaming was unavailable. Final replies still arrived, but long-running top-level DM work appeared stalled.

## Why This Change Was Made

Portable preview selection now follows the configured streaming mode regardless of custom identity. The temporary preview remains app-authored so Slack allows OpenClaw to edit and remove it; final text, media, and TTS delivery is sent separately with the configured custom username/icon and is never promoted in place from the app-authored draft.

This matches Slack's published API contract: `chat.postMessage` accepts `username`, `icon_url`, and `icon_emoji`; `chat.update` does not; and `chat.delete` explicitly cannot delete impersonated messages.

## User Impact

Custom Slack agent names and avatars now coexist with live portable previews. Partial/block previews are removed before the custom final, while progress mode may retain an app-authored progress receipt. No configuration or migration change is required.

## CI Baseline Repair

The first exact-head CI run exposed an unrelated deterministic timeout in `model-catalog-visibility.test.ts`: a configured-row unit case used fake `demo/*` refs but still invoked runtime plugin/manifest normalization. The test now supplies an explicit static-normalization policy, preserving the configured-model behavior under test while keeping runtime discovery out of the unit fixture. This follows `src/agents/AGENTS.md` and fixes the red baseline without changing production behavior.

## Evidence

- Focused Slack streaming/delivery proof: 3 files and 137 tests passed.
- Focused model-catalog isolation proof: 10/10 passed on Blacksmith Testbox `tbx_01kym23a9tk6mz33mjqar8ercz`; the formerly timed-out case completed in 1 ms ([run](https://github.com/openclaw/openclaw/actions/runs/30348252341)).
- Full changed gate passed on Blacksmith Testbox `tbx_01kym287fepjf076x28eyhv0vv`, including core/extension test typecheck, full core and extension lint, dependency pins, plugin boundaries, storage guards, and import-cycle checks ([run](https://github.com/openclaw/openclaw/actions/runs/30348442168)).
- Authorized live Slack proof on the unchanged Slack implementation commit `080de97be3a4a29caa899541f9454a919a8b51fb`; the current head adds only the test-isolation commit. Redacted boolean/count observations:
  - app-authored draft created: true
  - draft updated in place: true
  - disposable draft deleted: true
  - custom final present: true
  - custom username matched: true
  - custom icon matched: true
  - exactly one final post: true
- Fresh Codex autoreview for the test isolation: no accepted/actionable findings, confidence 0.96.
- Slack streaming docs explain the app-authored preview/custom-final ownership split.
