### PR TITLE
refactor(ollama): reuse shared toErrorObject coercion

### DIFF
--- a/extensions/ollama/src/setup.test.ts
+++ b/extensions/ollama/src/setup.test.ts
@@ -827,6 +827,44 @@ describe("ollama setup", () => {
       }
     });
 
+    it("coerces non-Error model-pull stream rejections via the shared toErrorObject", async () => {
+      const progress = { update: vi.fn(), stop: vi.fn() };
+      const prompter = {
+        progress: vi.fn(() => progress),
+      } as unknown as WizardPrompter;
+      const fetchMock = vi.fn(async (input: string | URL | Request) => {
+        const url = requestUrl(input);
+        if (url.endsWith("/api/tags")) {
+          return jsonResponse({ models: [] });
+        }
+        if (url.endsWith("/api/pull")) {
+          return new Response(
+            new ReadableStream<Uint8Array>({
+              start(controller) {
+                controller.error({ code: 500, status: "server_error" });
+              },
+            }),
+            { status: 200 },
+          );
+        }
+        throw new Error(`Unexpected fetch: ${url}`);
+      });
+      vi.stubGlobal("fetch", fetchMock);
+
+      const result = await ensureOllamaModelPulled({
+        config: createDefaultOllamaConfig("ollama/gemma4"),
+        model: "ollama/gemma4",
+        prompter,
+      }).catch((err: unknown) => err);
+
+      expect(result).toBeInstanceOf(Error);
+      expect((result as Error).name).toBe("WizardCancelledError");
+      expect((result as Error).message).toBe("Failed to download selected Ollama model");
+      // The non-Error stream rejection is coerced by the shared toErrorObject with its
+      // "Non-Error rejection" fallback message, which surfaces in the progress stop text.
+      expect(progress.stop).toHaveBeenCalledWith(expect.stringContaining("Non-Error rejection"));
+    });
+
     it("skips pull when model is already available", async () => {
       const prompter = {} as unknown as WizardPrompter;
 

--- a/extensions/ollama/src/setup.ts
+++ b/extensions/ollama/src/setup.ts
@@ -1,4 +1,4 @@
-import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
+import { formatErrorMessage, toErrorObject } from "openclaw/plugin-sdk/error-runtime";
 // Ollama setup module handles plugin onboarding behavior.
 import { expectDefined } from "openclaw/plugin-sdk/expect-runtime";
 import type {
@@ -216,7 +216,7 @@ async function readOllamaPullChunkWithIdleTimeout(
       (err: unknown) => {
         clear();
         if (!timedOut) {
-          reject(toLintErrorObject(err, "Non-Error rejection"));
+          reject(toErrorObject(err, "Non-Error rejection"));
         }
       },
     );
@@ -952,17 +952,4 @@ export async function ensureOllamaModelPulled(params: {
   }
 }
 
-function toLintErrorObject(value: unknown, fallbackMessage: string): Error {
-  if (value instanceof Error) {
-    return value;
-  }
-  if (typeof value === "string") {
-    return new Error(value);
-  }
-  const error = new Error(fallbackMessage, { cause: value });
-  if ((typeof value === "object" && value !== null) || typeof value === "function") {
-    Object.assign(error, value);
-  }
-  return error;
-}
 /* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */


### PR DESCRIPTION
## What Problem This Solves

`extensions/ollama/src/setup.ts` carried a private `toLintErrorObject(value, fallbackMessage)` helper that coerces a non-`Error` rejection into an `Error`. The exact same 11-line implementation is copy-pasted across **10 modules** in the tree (acpx, codex, copilot, discord, line, lobster, memory-core, ollama, qa-channel, whatsapp), while an identical `toErrorObject` is already re-exported from `openclaw/plugin-sdk/error-runtime`. Keeping the ollama copy separate means any fix to the coercion logic has to be mirrored here too - the copy can silently drift.

## Why This Change Was Made

- Delete the local `toLintErrorObject` and import the shared `toErrorObject` from the existing `openclaw/plugin-sdk/error-runtime` facade. Ollama already imported `formatErrorMessage` from that same module, so the import is extended, not added.
- Update the single call site (`reject(toErrorObject(err, "Non-Error rejection"))` inside `readOllamaPullChunkWithIdleTimeout`) to use the shared helper.
- Add a regression test in the `ensureOllamaModelPulled` suite that drives the real pull path with a stream that rejects with a non-`Error` value and asserts the coercion surfaces.
- The shared and local bodies are **byte-identical**, so this is a pure behavior-preserving extraction: `deletions ≥ additions` on the source file (+2 / −15).

This follows the exact pattern already merged for telegram, matrix, slack, signal, packages, and browser (`refactor(*): reuse shared error coercion`). The remaining 9 copies can follow in separate per-module PRs.

## User Impact

None at runtime. The Ollama model-pull stream's rejection-coercion path behaves identically: `Error` rejections pass through, strings become `new Error(string)`, and other values become `new Error(fallback, { cause })` with enumerable fields copied. The setup file also shrinks by 13 lines, helping its grandfathered `oxlint-disable max-lines` budget.

## Note on the `toErrorObject` facade export

`openclaw/plugin-sdk/error-runtime` **does** export `toErrorObject`. It was added to the re-export list in **#113229** (`refactor(browser): reuse shared error coercion`, merged 2026-07-24) at `src/plugin-sdk/error-runtime.ts:25`, which re-exports from `src/infra/errors.ts:74`, which re-exports from `@openclaw/normalization-core/error-coercion`. CI's `check-prod-types` and `check-additional-extension-package-boundary` both pass at the PR head, confirming the import resolves; vincentkoc's merged #113589 uses the identical import. (A stale local bundled dist built before #113229 lacks the re-export and can produce a false-positive `tsgo` error locally; CI builds fresh.)

## Evidence

- `node scripts/run-vitest.mjs extensions/ollama/src/setup.test.ts` - 39/39 passed (was 38; +1 regression test)
- `node scripts/run-vitest.mjs extensions/ollama/src/setup.non-interactive-auth.test.ts` - 3/3 passed
- `node scripts/run-vitest.mjs packages/normalization-core/src/error-coercion.test.ts` - 8/8 passed (shared helper's own suite)
- `oxlint extensions/ollama/src` - clean
- `oxfmt --check extensions/ollama/src` - "All matched files use the correct format."
- `git diff --check` - clean
- CI: `check-prod-types`, `check-test-types`, `check-lint`, `check-additional-extension-package-boundary`, `check-guards`, `Real behavior proof` all pass at the PR head

Related implementation pattern: #113589 (`refactor(telegram): reuse shared error coercion`)

Real behavior proof at exact PR head `d8c62b5df38fe44041ec63556599dad097f8ca0f` (rebased onto latest main `29b6f562546`; ollama source unchanged by the rebase, so the proof output is identical):

```text
=== real-runtime model-pull stream rejection (tsx, not vitest mock) ===
Runs the REAL ensureOllamaModelPulled (extensions/ollama/src/setup.ts) via tsx
against a local Ollama-protocol HTTP server. /api/tags returns an empty list
(forces a pull); /api/pull streams one NDJSON chunk then errors mid-stream
(server destroys the response). The rejection flows through the REAL call site
reject(toErrorObject(err, "Non-Error rejection")) inside
readOllamaPullChunkWithIdleTimeout, is caught in pullOllamaModelCore, and
surfaces as a "Failed to download <model>: ..." progress stop plus a
WizardCancelledError thrown to the caller.

$ tsx scripts/proof/ollama-real-setup-proof.mjs
=== Part 2: real model-pull stream rejection via real ensureOllamaModelPulled ===
local Ollama-protocol server baseUrl: http://127.0.0.1:44992
progress calls:
  [update] Downloading gemma4 - pulling part - 1%
  [stop] Failed to download gemma4: terminated | other side closed | UND_ERR_SOCKET
thrown error: WizardCancelledError: Failed to download selected Ollama model
verdict: pull-stream rejection handled by real runtime (toErrorObject call site exercised)

The "Failed to download gemma4: ..." progress stop text is produced by
pullOllamaModelCore's catch (formatErrorMessage of the coerced error) -> the
toErrorObject call site on the rejection handler was exercised by real runtime
I/O, not a vi.mock. (Ollama Cloud does not expose /api/pull, so the pull path
is local-only; a real local Ollama-protocol endpoint is the faithful way to
exercise it. Cloud /api/tags reachability + bearer auth were separately
confirmed: HTTP 200 with models minimax-m3, glm-5.1, gemma4:31b, ... — token
redacted.)

=== regression test: non-Error coercion branch (the defensive path) ===
The non-Error stream-rejection branch (controller.error(nonError) ->
toErrorObject Object.assign coercion -> "Non-Error rejection" fallback) is
covered by a committed vitest test, since real HTTP errors are Error instances
(undici wraps them) and only a synthetic stream can reject with a non-Error:

$ node scripts/run-vitest.mjs extensions/ollama/src/setup.test.ts \
    -t "coerces non-Error model-pull stream rejections" --reporter=verbose
 ✓ |extension-providers| extensions/ollama/src/setup.test.ts >
     ollama setup > ensureOllamaModelPulled >
     coerces non-Error model-pull stream rejections via the shared toErrorObject 133ms
 Test Files  1 passed (1)
      Tests  1 passed | 38 skipped (39)
 asserts: result is WizardCancelledError("Failed to download selected Ollama model")
          + progress.stop contains "Non-Error rejection" (toErrorObject fallback)

=== full ollama setup suite (no regressions) ===
$ node scripts/run-vitest.mjs extensions/ollama/src/setup.test.ts
 Test Files  1 passed (1)
      Tests  39 passed (39)

=== duplication before this PR: 10 identical toLintErrorObject copies ===
extensions/acpx/src/runtime-turn.ts
extensions/codex/src/app-server/plugin-approval-roundtrip.ts
extensions/copilot/src/event-bridge.ts
extensions/discord/src/monitor.gateway.ts
extensions/line/src/bot-handlers.ts
extensions/lobster/src/lobster-runner.ts
extensions/memory-core/src/memory/manager.ts
extensions/ollama/src/setup.ts            <- removed by this PR
extensions/qa-channel/src/bus-client.ts
extensions/whatsapp/src/session.ts
```

AI-assisted: Codex
