### PR TITLE
fix(scripts): materialize PR worktrees before gates

### DIFF
--- a/scripts/pr-lib/worktree.sh
+++ b/scripts/pr-lib/worktree.sh
@@ -29,6 +29,16 @@ EOF
   return 1
 }
 
+ensure_full_pr_worktree_checkout() {
+  local sparse_checkout
+  sparse_checkout=$(git config --bool core.sparseCheckout 2>/dev/null || true)
+  if [ "$sparse_checkout" = "true" ]; then
+    # Prepare gates build the whole repository. Inherited sparse settings can
+    # omit tracked transitive inputs and turn healthy PRs into false failures.
+    git sparse-checkout disable
+  fi
+}
+
 enter_worktree() {
   local pr="$1"
   local reset_to_main="${2:-false}"
@@ -81,6 +91,7 @@ enter_worktree() {
     return 1
   fi
 
+  ensure_full_pr_worktree_checkout
   git fetch origin main
   if [ "$reset_to_main" = "true" ]; then
     git checkout -B "temp/pr-$pr" origin/main

--- a/src/agents/provider-local-service.test.ts
+++ b/src/agents/provider-local-service.test.ts
@@ -820,6 +820,9 @@ describe("provider local service", () => {
     const tempDir = tempDirs.make("openclaw-local-service-failed-unref-");
     const servicePidPath = path.join(tempDir, "service.pid");
     const moduleUrl = new URL("./provider-local-service.ts", import.meta.url).href;
+    // The assertion targets diagnostic-pipe cleanup after failed readiness.
+    // Give the nested Node child enough startup time under loaded CI.
+    const failedServiceReadyTimeoutMs = 5_000;
     const serviceScript = [
       `const fs=require("node:fs");`,
       `fs.writeFileSync(${JSON.stringify(servicePidPath)},String(process.pid));`,
@@ -837,7 +840,7 @@ describe("provider local service", () => {
       `    service: {`,
       `      command: process.execPath,`,
       `      args: ["-e", ${JSON.stringify(serviceScript)}],`,
-      `      readyTimeoutMs: 100,`,
+      `      readyTimeoutMs: ${failedServiceReadyTimeoutMs},`,
       `    },`,
       `  });`,
       `} catch {}`,

--- a/test/scripts/pr-operation-lock.test.ts
+++ b/test/scripts/pr-operation-lock.test.ts
@@ -96,6 +96,22 @@ function createRepo(nestedName?: string) {
   return dir;
 }
 
+function addTrackedUiConfig(repoDir: string) {
+  const configDir = join(repoDir, "ui", "config");
+  mkdirSync(configDir, { recursive: true });
+  writeFileSync(join(configDir, "control-ui-chunking.ts"), "export const chunking = true;\n");
+  execFileSync("git", ["add", "ui/config/control-ui-chunking.ts"], { cwd: repoDir });
+  execFileSync("git", ["commit", "-qm", "add ui config"], { cwd: repoDir });
+}
+
+function setSparseCheckout(repoDir: string) {
+  execFileSync("git", ["sparse-checkout", "init", "--no-cone"], { cwd: repoDir });
+  execFileSync("git", ["sparse-checkout", "set", "--no-cone", "--stdin"], {
+    cwd: repoDir,
+    input: "/*\n!/*/\n/base.txt\n",
+  });
+}
+
 function bashSource(repoDir: string, supervised = false) {
   return [
     "set -euo pipefail",
@@ -2191,6 +2207,54 @@ describePosix("scripts/pr per-PR operation lock", () => {
         encoding: "utf8",
       }).trim(),
     ).toBe("temp/pr-43");
+  });
+
+  it("materializes a new PR worktree inherited from a sparse checkout", () => {
+    const repoDir = createRepo();
+    addTrackedUiConfig(repoDir);
+    execFileSync("git", ["remote", "add", "origin", repoDir], { cwd: repoDir });
+    setSparseCheckout(repoDir);
+    const worktreeDir = join(repoDir, ".worktrees", "pr-44");
+
+    const result = runLockShell(repoDir, [
+      "ensure_gh_api_auth() { return 0; }",
+      "enter_worktree 44",
+    ]);
+
+    expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(0);
+    expect(existsSync(join(worktreeDir, "ui", "config", "control-ui-chunking.ts"))).toBe(true);
+    expect(
+      execFileSync("git", ["config", "--bool", "core.sparseCheckout"], {
+        cwd: worktreeDir,
+        encoding: "utf8",
+      }).trim(),
+    ).toBe("false");
+  });
+
+  it("materializes an existing sparse PR worktree before reuse", () => {
+    const repoDir = createRepo();
+    addTrackedUiConfig(repoDir);
+    execFileSync("git", ["remote", "add", "origin", repoDir], { cwd: repoDir });
+    const worktreeDir = join(repoDir, ".worktrees", "pr-45");
+    execFileSync("git", ["worktree", "add", "-q", "-b", "temp/pr-45", worktreeDir], {
+      cwd: repoDir,
+    });
+    setSparseCheckout(worktreeDir);
+    expect(existsSync(join(worktreeDir, "ui", "config", "control-ui-chunking.ts"))).toBe(false);
+
+    const result = runLockShell(repoDir, [
+      "ensure_gh_api_auth() { return 0; }",
+      "enter_worktree 45",
+    ]);
+
+    expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(0);
+    expect(existsSync(join(worktreeDir, "ui", "config", "control-ui-chunking.ts"))).toBe(true);
+    expect(
+      execFileSync("git", ["config", "--bool", "core.sparseCheckout"], {
+        cwd: worktreeDir,
+        encoding: "utf8",
+      }).trim(),
+    ).toBe("false");
   });
 
   it("refuses a symlink alias to another registered worktree", () => {

--- a/ui/src/pages/config/config-page.test.ts
+++ b/ui/src/pages/config/config-page.test.ts
@@ -29,6 +29,7 @@ function deferred<T>() {
 let localStorageMock: Storage;
 
 beforeEach(() => {
+  window.history.replaceState({}, "", "/");
   vi.spyOn(realtimeTalk, "switchActiveRealtimeTalkCameras").mockImplementation(
     switchActiveRealtimeTalkCameras,
   );


### PR DESCRIPTION
Fixes #115118

## What Problem This Solves

Fixes an issue where maintainers running `scripts/pr prepare-run` from a sparse canonical checkout would get false build failures because the script-owned PR worktree inherited an incomplete sparse set.

## Why This Change Was Made

After `enter_worktree` proves containment in the registered `.worktrees/pr-<number>` checkout, it now disables sparse checkout before fetching, resetting branches, or running gates. The invariant applies to both newly created and reused PR worktrees.

Exact-head CI also exposed two unrelated current-`main` test failures that would otherwise keep the landing gate red:

- The nested local-service fixture had only 100 ms to write its PID file under runner load. It now uses the existing 5-second readiness budget.
- Config route migration tests inherited another UI test's browser hash. The fixture now resets jsdom history before each test while runtime hash-preservation behavior remains unchanged.

## User Impact

Maintainers can use the repo-native review, prepare, and merge workflow from sparse canonical checkouts without missing tracked build inputs. Product runtime behavior is unchanged.

## Evidence

- Before: PR #115087 preparation failed with `UNRESOLVED_IMPORT` for tracked `ui/config/control-ui-chunking.ts`; the PR worktree reported `core.sparseCheckout=true` and the path carried the skip-worktree marker.
- Focused local proof: `test/scripts/pr-operation-lock.test.ts` passed 61 tests with 1 skipped, including new and reused sparse-worktree regressions.
- Blacksmith Testbox changed gate: action https://github.com/openclaw/openclaw/actions/runs/30347051498, command 3m10.593s, total 3m42.128s, exit 0.
- Blacksmith Testbox fixture proof: action https://github.com/openclaw/openclaw/actions/runs/30360068414, 22 tests passed; command 5m55.413s, total 6m27.953s.
- Focused UI proof: `ui/src/pages/config/config-page.test.ts` passed 16 tests; targeted formatting passed.
- CI action https://github.com/openclaw/openclaw/actions/runs/30364425304 reproduced the leaked-hash failures: 3 failed assertions after 6,313 tests passed in the shard.
- Current exact-head CI: https://github.com/openclaw/openclaw/actions/runs/30365698536.
- `bash -n scripts/pr-lib/worktree.sh`, targeted formatting, and `git diff --check` passed.
- Final branch and uncommitted autoreviews: clean, no accepted/actionable findings.
