### PR TITLE
fix(memory): avoid phantom continuation pages after a final newline

### DIFF
--- a/extensions/memory-core/src/memory/qmd-manager.test.ts
+++ b/extensions/memory-core/src/memory/qmd-manager.test.ts
@@ -5849,9 +5849,9 @@ describe("QmdMemoryManager", () => {
       const readResult = await manager.readFile({ relPath: result.path });
       expect(readResult).toEqual({
         path: "qmd/sessions-main/session-1.md",
-        text: "# Session session-1\n\nsession canary\n",
+        text: "# Session session-1\n\nsession canary",
         from: 1,
-        lines: 4,
+        lines: 3,
       });
     } finally {
       lstatSpy.mockRestore();

--- a/packages/memory-host-sdk/src/host/read-file-shared.ts
+++ b/packages/memory-host-sdk/src/host/read-file-shared.ts
@@ -113,6 +113,10 @@ export function buildMemoryReadResult(params: {
   suggestReadFallback?: boolean;
 }): MemoryReadResult {
   const fileLines = params.content.split("\n");
+  // A terminal newline is a delimiter, not an additional readable source line.
+  if (fileLines.at(-1) === "") {
+    fileLines.pop();
+  }
   const start = normalizePositiveInteger(params.from, 1);
   const requestedCount = normalizePositiveInteger(
     params.lines ?? params.defaultLines,

--- a/packages/memory-host-sdk/src/host/read-file.test.ts
+++ b/packages/memory-host-sdk/src/host/read-file.test.ts
@@ -19,6 +19,106 @@ async function createDirectorySymlink(target: string, linkPath: string): Promise
 }
 
 describe("readMemoryFile", () => {
+  it.each([
+    {
+      name: "an empty file",
+      content: "",
+      from: 1,
+      lines: 2,
+      expected: { text: "", from: 1, lines: 0 },
+    },
+    {
+      name: "an exact LF-terminated page",
+      content: "one\ntwo\n",
+      from: 1,
+      lines: 2,
+      expected: { text: "one\ntwo", from: 1, lines: 2 },
+    },
+    {
+      name: "an exact CRLF-terminated page",
+      content: "one\r\ntwo\r\n",
+      from: 1,
+      lines: 2,
+      expected: { text: "one\r\ntwo\r", from: 1, lines: 2 },
+    },
+    {
+      name: "an intentional trailing blank line",
+      content: "one\n\n",
+      from: 1,
+      lines: 2,
+      expected: { text: "one\n", from: 1, lines: 2 },
+    },
+    {
+      name: "multiple intentional trailing blank lines",
+      content: "one\n\n\n",
+      from: 1,
+      lines: 3,
+      expected: { text: "one\n\n", from: 1, lines: 3 },
+    },
+    {
+      name: "an intentional interior blank line",
+      content: "one\n\ntwo\n",
+      from: 1,
+      lines: 3,
+      expected: { text: "one\n\ntwo", from: 1, lines: 3 },
+    },
+    {
+      name: "an offset ending at the final LF-terminated line",
+      content: "one\ntwo\n",
+      from: 2,
+      lines: 1,
+      expected: { text: "two", from: 2, lines: 1 },
+    },
+    {
+      name: "an offset beyond the final LF-terminated line",
+      content: "one\ntwo\n",
+      from: 3,
+      lines: 1,
+      expected: { text: "", from: 3, lines: 0 },
+    },
+    {
+      name: "a genuine continuation before the final LF-terminated line",
+      content: "one\ntwo\n",
+      from: 1,
+      lines: 1,
+      expected: {
+        text: "one\n\n[More content available. Use from=2 to continue.]",
+        from: 1,
+        lines: 1,
+        truncated: true,
+        nextFrom: 2,
+      },
+    },
+    {
+      name: "a page without a final newline",
+      content: "one\ntwo",
+      from: 1,
+      lines: 2,
+      expected: { text: "one\ntwo", from: 1, lines: 2 },
+    },
+  ])("reads $name without a phantom continuation page", async (testCase) => {
+    const tmpRoot = await fs.mkdtemp(path.join(os.tmpdir(), "memory-read-pagination-"));
+    try {
+      const workspaceDir = path.join(tmpRoot, "workspace");
+      const relPath = "memory/pagination.md";
+      const absPath = path.join(workspaceDir, relPath);
+      await fs.mkdir(path.dirname(absPath), { recursive: true });
+      await fs.writeFile(absPath, testCase.content, "utf-8");
+
+      await expect(
+        readMemoryFile({
+          workspaceDir,
+          extraPaths: [],
+          relPath,
+          from: testCase.from,
+          lines: testCase.lines,
+        }),
+      ).resolves.toEqual({ ...testCase.expected, path: relPath });
+    } finally {
+      await fs.rm(tmpRoot, { recursive: true, force: true });
+    }
+  });
+
   it("returns empty text for missing files under extra path directories", async () => {
     const tmpRoot = await fs.mkdtemp(path.join(os.tmpdir(), "memory-read-file-"));
     try {


### PR DESCRIPTION
Closes #114313\n\n## What Problem This Solves\n\nFixes phantom continuation pages when memory files end in a newline. Before this change, an exact-size memory_get read reports more content even though the file has ended, and an empty memory file reports one line.\n\n## Why This Change Was Made\n\nA terminal newline is a delimiter, not an extra source line. Remove exactly the synthetic final element from the existing shared memory reader while preserving meaningful interior and trailing blank lines, actual continuation cursors, final CRLF content, existing line budgets, and the QMD streaming reader contract. Update the QMD session-export integration fixture that had encoded the phantom line as expected behavior. No new configuration, fallbacks, files, migrations, SQLite schema changes, public SDK shapes, or plugin dependencies.\n\n## User Impact\n\nMemory reads and memory_get no longer advertise empty continuation pages, miscount empty files, or append spurious continuation text. Intentional blank lines and genuine continuation pages remain readable.\n\n## Evidence\n\n- Reproduced 8 failing cases on trusted Blacksmith Testbox using actual temporary Markdown files and the production secure readMemoryFile path: empty files; exact LF and CRLF pages; intentional trailing and interior blank lines; final-line and past-EOF offsets.\n- Final adjacent product proof: 295 passing tests across actual filesystem memory reads (13), shared memory shaping (4), QMD memory manager (162), memory_get tool and citations (28), memory CLI (75), and indexed-memory file management (13).\n- Existing QMD integration verified against current main and corrected to expect 3 real source lines, matching its streaming reader, instead of the synthetic fourth line.\n- Repository changed-code checks reached and passed the core, core-test, and extension-test typechecks, formatting, plugin boundaries, package guards, and public SDK baseline on trusted Blacksmith Testbox.\n- Both directly affected core files passed repository-configured core oxlint; the affected QMD integration test passed repository-configured extension oxlint; all 3 changed files passed repository formatting.\n- Full broad whole-repository lint was not completed on the CPU-throttled Testbox; the required pull-request hosted CI supplies the final whole-repository gate.\n- Fresh independent Codex autoreview: clean; no accepted or actionable findings.\n- AI-assisted implementation and review.\n\nCredits @kevin2966n for reporting #114313 and their existing broader contributor draft #114319, which is intentionally left open and unchanged.