### PR TITLE
feat(ui): redesign Ask OpenClaw — mascot, shared surface, dockable panel

### DIFF
--- a/scripts/control-ui-mock-dev.ts
+++ b/scripts/control-ui-mock-dev.ts
@@ -4,7 +4,13 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import qrcode from "qrcode";
 import { createServer, type Plugin, type ViteDevServer } from "vite";
-import type { UserProfile } from "../packages/gateway-protocol/src/index.js";
+import type {
+  SystemAgentChatHistoryResult,
+  SystemAgentChatQuestion,
+  SystemAgentChatResult,
+  SystemChangesListResult,
+  UserProfile,
+} from "../packages/gateway-protocol/src/index.js";
 import { expectDefined } from "../packages/normalization-core/src/expect.js";
 import { applySharedChannelFieldHelp } from "../src/config/schema.channel-field-help.js";
 import { applyConfigTierHints, applyResolvedConfigTierHints } from "../src/config/schema.tiers.js";
@@ -65,6 +71,7 @@ const NARRATION_DEMO_SESSION_KEY = "agent:main:sidebar-narration-demo";
 const NARRATION_DEMO_RUN_ID = "mock-sidebar-narration-run";
 const OBSERVER_DEMO_SESSION_KEY = "agent:main:session-observer-demo";
 const OBSERVER_DEMO_RUN_ID = "mock-session-observer-run";
+const CUSTODIAN_CHAT_REPLY_DELAY_MS = 600;
 
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 const uiRoot = path.join(repoRoot, "ui");
@@ -1343,6 +1350,53 @@ async function createChatPickerScenario(
   const cronMocks = buildCronMocks(Date.now());
   const channelWizard = buildChannelWizardMocks();
   const configMocks = buildConfigMocks({ swarmEnabled: fixture === "swarm" });
+  const custodianHistory = {
+    turns: [
+      {
+        role: "user",
+        text: "Can you check whether this system is ready?",
+        at: baseTime - 18 * 60_000,
+      },
+      {
+        role: "assistant",
+        text: "Everything important is connected. I’ll keep watching for changes.",
+        at: baseTime - 17 * 60_000,
+      },
+      {
+        role: "user",
+        text: "Please remember that I prefer concise updates.",
+        at: baseTime - 16 * 60_000,
+      },
+    ],
+  } satisfies SystemAgentChatHistoryResult;
+  const custodianChanges = {
+    entries: [
+      {
+        id: "mock-system-agent-model",
+        at: baseTime - 6 * 60_000,
+        kind: "operation",
+        source: "system-agent",
+        summary: "Updated the default model for the main agent",
+        changedPaths: ["agents.defaults.model"],
+      },
+      {
+        id: "mock-plugin-install",
+        at: baseTime - 42 * 60_000,
+        kind: "config-write",
+        source: "plugin-install",
+        summary: "Enabled the Telegram plugin",
+        changedPaths: ["plugins.entries.telegram.enabled"],
+      },
+      {
+        id: "mock-doctor-repair",
+        at: baseTime - 2 * 60 * 60_000,
+        kind: "config-write",
+        source: "doctor",
+        summary: "Repaired a stale channel account reference",
+        changedPaths: ["channels.whatsapp.defaultAccount"],
+      },
+    ],
+  } satisfies SystemChangesListResult;
   return {
     assistantAgentId: "main",
     assistantName: "Molty",
@@ -1351,6 +1405,9 @@ async function createChatPickerScenario(
       "chat.metadata",
       "chat.startup",
       "question.list",
+      "openclaw.changes.list",
+      "openclaw.chat",
+      "openclaw.chat.history",
       "sessions.diff",
       "sessions.files.set",
       "system.info",
@@ -1473,6 +1530,8 @@ async function createChatPickerScenario(
       // (raw persists, hash advances) because config.get ships a raw fixture.
       "config.get": configMocks.get,
       "config.schema": configMocks.schema,
+      "openclaw.chat.history": custodianHistory,
+      "openclaw.changes.list": custodianChanges,
       // The sidebar recovers pending questions through question.list after the
       // hello handshake, so this remains visible after a mock-page refresh.
       "question.list": {
@@ -1997,8 +2056,110 @@ function escapeScriptContent(script: string): string {
   return script.replaceAll("</script", "<\\/script");
 }
 
+/** Adds the one stateful mock surface the generic scenario fixture cannot express. */
+function installControlUiCustodianMock(replyDelayMs: number): void {
+  type MockGatewayControls = {
+    deferNext: (method: string) => void;
+    resolveDeferred: (method: string, payload: unknown) => void;
+  };
+  type MockWindow = Window & {
+    openclawControlUiE2eGateway?: MockGatewayControls;
+  };
+
+  const gateway = (window as MockWindow).openclawControlUiE2eGateway;
+  const MockWebSocket = window.WebSocket;
+  if (!gateway || !MockWebSocket) {
+    return;
+  }
+  const originalSend = MockWebSocket.prototype.send;
+  const sessionTurns = new Map<string, number>();
+  MockWebSocket.prototype.send = function (data): void {
+    let frame: { method?: unknown; params?: unknown; type?: unknown } | null = null;
+    if (typeof data === "string") {
+      try {
+        frame = JSON.parse(data) as typeof frame;
+      } catch {
+        frame = null;
+      }
+    }
+    if (frame?.type !== "req" || frame.method !== "openclaw.chat") {
+      originalSend.call(this, data);
+      return;
+    }
+
+    const params =
+      frame.params && typeof frame.params === "object"
+        ? (frame.params as { message?: unknown; sessionId?: unknown })
+        : {};
+    const sessionId =
+      typeof params.sessionId === "string" && params.sessionId.trim()
+        ? params.sessionId
+        : "control-ui-custodian-mock";
+    const message = typeof params.message === "string" ? params.message : undefined;
+    const turn = sessionTurns.get(sessionId) ?? 0;
+    sessionTurns.set(sessionId, turn + 1);
+    const channelQuestion = {
+      id: "mock-channel-choice",
+      header: "Channel setup",
+      question: "Which channel would you like to work on?",
+      options: [
+        {
+          label: "WhatsApp",
+          reply: "help me connect WhatsApp",
+          description: "Review linking and account status.",
+          recommended: true,
+        },
+        {
+          label: "Telegram",
+          reply: "help me connect Telegram",
+          description: "Review the bot token and delivery status.",
+        },
+        {
+          label: "Discord",
+          reply: "help me connect Discord",
+          description: "Review the bot and server connection.",
+        },
+      ],
+      isOther: true,
+    } satisfies SystemAgentChatQuestion;
+    const response: SystemAgentChatResult = message
+      ? message.toLowerCase().includes("channel")
+        ? {
+            sessionId,
+            reply: "I can help with that.\n\nChoose a channel to continue.",
+            action: "none",
+            question: channelQuestion,
+          }
+        : {
+            sessionId,
+            reply: `I checked the mock system. Everything looks healthy.\n\nThat was demo turn ${turn}.`,
+            action: "none",
+          }
+      : {
+          sessionId,
+          reply:
+            "Hi — I’m OpenClaw, your system caretaker.\n\nAsk me about setup, channels, or recent changes.",
+          action: "none",
+        };
+
+    // Defer before forwarding so the generic gateway records the request but
+    // cannot race its normal immediate response against this stateful reply.
+    gateway.deferNext("openclaw.chat");
+    originalSend.call(this, data);
+    window.setTimeout(
+      () => gateway.resolveDeferred("openclaw.chat", response),
+      message === undefined ? 0 : replyDelayMs,
+    );
+  };
+}
+
+function createCustodianMockInitScript(): string {
+  return `(() => { const __name = (target) => target; (${installControlUiCustodianMock.toString()})(${CUSTODIAN_CHAT_REPLY_DELAY_MS}); })();`;
+}
+
 function createMockGatewayPlugin(scenario: ControlUiMockGatewayScenario): Plugin {
   const initScript = escapeScriptContent(createControlUiMockGatewayInitScript(scenario));
+  const custodianInitScript = escapeScriptContent(createCustodianMockInitScript());
   const bootstrapBody = JSON.stringify(createControlUiMockBootstrapConfig(scenario));
   return {
     configureServer(server) {
@@ -2012,7 +2173,7 @@ function createMockGatewayPlugin(scenario: ControlUiMockGatewayScenario): Plugin
     transformIndexHtml(html) {
       return html.replace(
         "</head>",
-        `    <script data-openclaw-control-ui-mock-gateway>\n${initScript}\n    </script>\n  </head>`,
+        `    <script data-openclaw-control-ui-mock-gateway>\n${initScript}\n${custodianInitScript}\n    </script>\n  </head>`,
       );
     },
   };

--- a/scripts/control-ui-mock-dev.ts
+++ b/scripts/control-ui-mock-dev.ts
@@ -5,6 +5,7 @@ import { fileURLToPath } from "node:url";
 import qrcode from "qrcode";
 import { createServer, type Plugin, type ViteDevServer } from "vite";
 import type {
+  RequestFrame,
   SystemAgentChatHistoryResult,
   SystemAgentChatQuestion,
   SystemAgentChatResult,
@@ -2071,19 +2072,26 @@ function installControlUiCustodianMock(replyDelayMs: number): void {
   if (!gateway || !MockWebSocket) {
     return;
   }
-  const originalSend = MockWebSocket.prototype.send;
+  const sendDescriptor = Object.getOwnPropertyDescriptor(MockWebSocket.prototype, "send");
+  const originalSend = sendDescriptor?.value as WebSocket["send"] | undefined;
+  if (typeof originalSend !== "function") {
+    return;
+  }
+  const sendOriginal = (socket: WebSocket, data: Parameters<WebSocket["send"]>[0]): void => {
+    Reflect.apply(originalSend, socket, [data]);
+  };
   const sessionTurns = new Map<string, number>();
   MockWebSocket.prototype.send = function (data): void {
-    let frame: { method?: unknown; params?: unknown; type?: unknown } | null = null;
+    let frame: RequestFrame | null = null;
     if (typeof data === "string") {
       try {
-        frame = JSON.parse(data) as typeof frame;
+        frame = JSON.parse(data) as RequestFrame;
       } catch {
         frame = null;
       }
     }
     if (frame?.type !== "req" || frame.method !== "openclaw.chat") {
-      originalSend.call(this, data);
+      sendOriginal(this, data);
       return;
     }
 
@@ -2145,7 +2153,7 @@ function installControlUiCustodianMock(replyDelayMs: number): void {
     // Defer before forwarding so the generic gateway records the request but
     // cannot race its normal immediate response against this stateful reply.
     gateway.deferNext("openclaw.chat");
-    originalSend.call(this, data);
+    sendOriginal(this, data);
     window.setTimeout(
       () => gateway.resolveDeferred("openclaw.chat", response),
       message === undefined ? 0 : replyDelayMs,

--- a/ui/src/app/app-host.dock-suppression.test.ts
+++ b/ui/src/app/app-host.dock-suppression.test.ts
@@ -21,7 +21,7 @@ afterEach(() => {
 });
 
 describe("OpenClaw shell dock suppression", () => {
-  it("suppresses docked panels only while a settings route owns the viewport", () => {
+  it("keeps Ask OpenClaw on settings pages and suppresses it only on its full page", () => {
     vi.stubGlobal("localStorage", createStorageMock());
     vi.stubGlobal(
       "matchMedia",
@@ -38,7 +38,7 @@ describe("OpenClaw shell dock suppression", () => {
           assistantAgentId: "main",
           hello: {
             auth: { role: "operator", scopes: ["operator.admin"] },
-            features: { methods: ["terminal.open", "browser.request"] },
+            features: { methods: ["terminal.open", "browser.request", "openclaw.chat"] },
           },
           lastError: null,
           offlineStable: false,
@@ -97,6 +97,23 @@ describe("OpenClaw shell dock suppression", () => {
     expect(
       (
         container.querySelector("openclaw-terminal-panel") as HTMLElement & {
+          suppressed: boolean;
+        }
+      ).suppressed,
+    ).toBe(true);
+    expect(
+      (
+        container.querySelector("openclaw-custodian-panel") as HTMLElement & {
+          suppressed: boolean;
+        }
+      ).suppressed,
+    ).toBe(false);
+
+    shell.routeState = { routeId: "custodian" };
+    renderLit(shell.render(), container);
+    expect(
+      (
+        container.querySelector("openclaw-custodian-panel") as HTMLElement & {
           suppressed: boolean;
         }
       ).suppressed,

--- a/ui/src/app/app-host.test.ts
+++ b/ui/src/app/app-host.test.ts
@@ -11,6 +11,7 @@ import {
 } from "../components/command-palette-contract.ts";
 import {
   BROWSER_PANEL_TOGGLE_EVENT,
+  CUSTODIAN_PANEL_TOGGLE_EVENT,
   TERMINAL_PANEL_TOGGLE_EVENT,
   UI_COMMAND_EVENT,
 } from "../components/panel-toggle-contract.ts";
@@ -86,7 +87,9 @@ type TestOptionalCustomElement = {
 type ShellLazySurfaceState = ShellKeyboardState & {
   browserPanelElement: TestOptionalCustomElement;
   commandPaletteElement: TestOptionalCustomElement;
+  custodianPanelElement: TestOptionalCustomElement;
   handleDeferredBrowserToggle: (event: Event) => void;
+  handleDeferredCustodianToggle: (event: Event) => void;
   handleDeferredTerminalToggle: (event: Event) => void;
   terminalPanelElement: TestOptionalCustomElement;
 };
@@ -215,6 +218,11 @@ type ShellRouteCommitState = {
   activeSessionKey: string;
   didConsiderNativeRouteRestore: boolean;
   updateRouteState: (state: ReturnType<typeof selectShellRouteState>) => void;
+};
+
+type ShellCustodianRouteState = {
+  custodianMinimizeRequestId: number;
+  updateRouteState: (state: { routeId?: RouteId }) => void;
 };
 
 type ShellSessionNavigationState = {
@@ -517,6 +525,19 @@ describe("OpenClaw shell route session commits", () => {
     expect(setSessionKey).toHaveBeenCalledExactlyOnceWith("agent:main:session-b");
     expect(calls).toEqual(["agent:main", "session:agent:main:session-b"]);
   });
+
+  it("retains the custodian leave transition through an unresolved route state", () => {
+    const shell = document.createElement(
+      "openclaw-app-shell",
+    ) as unknown as ShellCustodianRouteState;
+
+    shell.updateRouteState({ routeId: "custodian" });
+    shell.updateRouteState({});
+    expect(shell.custodianMinimizeRequestId).toBe(0);
+
+    shell.updateRouteState({ routeId: "config" });
+    expect(shell.custodianMinimizeRequestId).toBe(1);
+  });
 });
 
 describe("OpenClaw shell server preferences", () => {
@@ -780,11 +801,14 @@ describe("OpenClaw shell keyboard shortcuts", () => {
   it("delivers first panel toggles after their lazy modules load", async () => {
     const terminalElement = createLazyElementSpec("terminal panel");
     const browserElement = createLazyElementSpec("browser panel");
+    const custodianElement = createLazyElementSpec("custodian panel");
     const terminalToggle = vi.fn();
     const browserToggle = vi.fn();
+    const custodianToggle = vi.fn();
     const shell = document.createElement("openclaw-app-shell") as unknown as ShellLazySurfaceState;
     shell.terminalPanelElement = terminalElement;
     shell.browserPanelElement = browserElement;
+    shell.custodianPanelElement = custodianElement;
     shell.runtime = {
       context: {
         gateway: {
@@ -792,7 +816,7 @@ describe("OpenClaw shell keyboard shortcuts", () => {
             phase: "connected",
             hello: {
               auth: { role: "operator", scopes: ["operator.admin"] },
-              features: { methods: ["terminal.open", "browser.request"] },
+              features: { methods: ["terminal.open", "browser.request", "openclaw.chat"] },
             },
           },
         },
@@ -812,6 +836,9 @@ describe("OpenClaw shell keyboard shortcuts", () => {
         if (selector === browserElement.tagName) {
           return { handleToggleRequest: browserToggle };
         }
+        if (selector === custodianElement.tagName) {
+          return { handleToggleRequest: custodianToggle };
+        }
         return null;
       },
     });
@@ -819,13 +846,16 @@ describe("OpenClaw shell keyboard shortcuts", () => {
       detail: { dock: "right", open: true },
     });
     const browserEvent = new CustomEvent(BROWSER_PANEL_TOGGLE_EVENT);
+    const custodianEvent = new CustomEvent(CUSTODIAN_PANEL_TOGGLE_EVENT);
 
     shell.handleDeferredTerminalToggle(terminalEvent);
     shell.handleDeferredBrowserToggle(browserEvent);
+    shell.handleDeferredCustodianToggle(custodianEvent);
 
     await vi.waitFor(() => {
       expect(terminalToggle).toHaveBeenCalledWith(terminalEvent);
       expect(browserToggle).toHaveBeenCalledWith(browserEvent);
+      expect(custodianToggle).toHaveBeenCalledWith(custodianEvent);
     });
   });
 

--- a/ui/src/app/app-host.ts
+++ b/ui/src/app/app-host.ts
@@ -2061,7 +2061,6 @@ class OpenClawShell extends OpenClawLightDomElement {
         <openclaw-custodian-panel
           .available=${custodianPanelAvailable}
           .suppressed=${activeRoute === "custodian"}
-          .activeRoute=${activeRoute}
           .minimizeRequestId=${this.custodianMinimizeRequestId}
         ></openclaw-custodian-panel>
         ${isOptionalElementDefined(this.execApprovalElement)

--- a/ui/src/app/app-host.ts
+++ b/ui/src/app/app-host.ts
@@ -44,6 +44,7 @@ import {
 import { icons } from "../components/icons.ts";
 import {
   BROWSER_PANEL_TOGGLE_EVENT,
+  CUSTODIAN_PANEL_TOGGLE_EVENT,
   isTerminalPanelShortcut,
   TERMINAL_PANEL_TOGGLE_EVENT,
   UI_COMMAND_EVENT,
@@ -91,6 +92,7 @@ import {
   APPROVAL_PAGE_ELEMENT,
   BROWSER_PANEL_ELEMENT,
   COMMAND_PALETTE_ELEMENT,
+  CUSTODIAN_PANEL_ELEMENT,
   EXEC_APPROVAL_ELEMENT,
   ensureOptionalElementForHost,
   isOptionalElementDefined,
@@ -519,6 +521,7 @@ class OpenClawShell extends OpenClawLightDomElement {
   private readonly commandPaletteElement = COMMAND_PALETTE_ELEMENT;
   private readonly terminalPanelElement = TERMINAL_PANEL_ELEMENT;
   private readonly browserPanelElement = BROWSER_PANEL_ELEMENT;
+  private readonly custodianPanelElement = CUSTODIAN_PANEL_ELEMENT;
   private readonly execApprovalElement = EXEC_APPROVAL_ELEMENT;
   @query("openclaw-command-palette") private commandPalette?: CommandPaletteElement;
   @query("openclaw-exec-approval")
@@ -529,6 +532,8 @@ class OpenClawShell extends OpenClawLightDomElement {
   // chat (the app default route) when settings was the entry point.
   private lastWorkspaceLocation: { routeId: RouteId; pathname: string; search: string } | null =
     null;
+  private custodianMinimizeRequestId = 0;
+  private lastConcreteRouteId: RouteId | undefined;
   private agentsListClient: GatewayBrowserClient | null = null;
   private agentsListSource: ApplicationContext["agents"] | null = null;
   private sessionKeyClient: GatewayBrowserClient | null = null;
@@ -733,6 +738,7 @@ class OpenClawShell extends OpenClawLightDomElement {
     window.addEventListener("openclaw:native-new-session", this.handleNativeNewSession);
     window.addEventListener(TERMINAL_PANEL_TOGGLE_EVENT, this.handleDeferredTerminalToggle);
     window.addEventListener(BROWSER_PANEL_TOGGLE_EVENT, this.handleDeferredBrowserToggle);
+    window.addEventListener(CUSTODIAN_PANEL_TOGGLE_EVENT, this.handleDeferredCustodianToggle);
     // Write-through of synced display prefs to config ui.prefs. Server-applied
     // deltas are suppressed so a reconcile never echoes back to the gateway.
     setSettingsChangeListener((previous, next) => {
@@ -769,6 +775,7 @@ class OpenClawShell extends OpenClawLightDomElement {
     window.removeEventListener("openclaw:native-new-session", this.handleNativeNewSession);
     window.removeEventListener(TERMINAL_PANEL_TOGGLE_EVENT, this.handleDeferredTerminalToggle);
     window.removeEventListener(BROWSER_PANEL_TOGGLE_EVENT, this.handleDeferredBrowserToggle);
+    window.removeEventListener(CUSTODIAN_PANEL_TOGGLE_EVENT, this.handleDeferredCustodianToggle);
     this.outboxStoreImport.dispose();
     this.outboxStoreUnsubscribe?.();
     this.outboxStoreUnsubscribe = null;
@@ -1352,6 +1359,17 @@ class OpenClawShell extends OpenClawLightDomElement {
     this.deliverPanelEventAfterLoad(this.browserPanelElement, event);
   };
 
+  private readonly handleDeferredCustodianToggle = (event: Event) => {
+    if (isOptionalElementDefined(this.custodianPanelElement)) {
+      return;
+    }
+    const snapshot = this.context?.gateway?.snapshot;
+    if (!snapshot || isGatewayMethodAdvertised(snapshot, "openclaw.chat") !== true) {
+      return;
+    }
+    this.deliverPanelEventAfterLoad(this.custodianPanelElement, event);
+  };
+
   private readonly handleCommandPaletteSlashCommand = (command: string) => {
     const chatHandler = this.commandPaletteTarget?.owner.isConnected
       ? this.commandPaletteTarget.onSlashCommand
@@ -1433,6 +1451,9 @@ class OpenClawShell extends OpenClawLightDomElement {
       }
       if (isBrowserPanelAvailable(gatewaySnapshot)) {
         preloadOptionalElement(this, this.browserPanelElement);
+      }
+      if (isGatewayMethodAdvertised(gatewaySnapshot, "openclaw.chat") === true) {
+        preloadOptionalElement(this, this.custodianPanelElement);
       }
     }
     if ((context.overlays?.snapshot.approvalQueue.length ?? 0) > 0) {
@@ -1630,6 +1651,12 @@ class OpenClawShell extends OpenClawLightDomElement {
 
   private updateRouteState(routeState: ShellRouteState) {
     this.routeState = routeState;
+    if (routeState.routeId !== undefined) {
+      if (this.lastConcreteRouteId === "custodian" && routeState.routeId !== "custodian") {
+        this.custodianMinimizeRequestId += 1;
+      }
+      this.lastConcreteRouteId = routeState.routeId;
+    }
     const committedRouteId = routeState.committedRouteId;
     const committedPathname = routeState.committedLocation?.pathname ?? "";
     const committedSearch = routeState.committedLocation?.search ?? "";
@@ -1719,6 +1746,8 @@ class OpenClawShell extends OpenClawLightDomElement {
       context.config.current.terminalEnabled ?? false,
     );
     const browserPanelAvailable = isBrowserPanelAvailable(gatewaySnapshot);
+    const custodianPanelAvailable =
+      gatewayConnected && isGatewayMethodAdvertised(gatewaySnapshot, "openclaw.chat") === true;
     const activeRoute = this.routeState.routeId ?? "chat";
     // Plugin tabs share one route; the search picks the active item.
     const activePluginRef =
@@ -1763,8 +1792,8 @@ class OpenClawShell extends OpenClawLightDomElement {
     const uiSettings = loadSettings();
     // The new-session draft shares the chat layout: full-height pane that owns
     // its scrolling and pins the composer dock to the bottom.
-    const chatLikeRoute =
-      isSessionRouteId(activeRoute) || activeRoute === "custodian" || activeRoute === "new-session";
+    const chatLikeRoute = isSessionRouteId(activeRoute) || activeRoute === "new-session";
+    const custodianRoute = activeRoute === "custodian";
     const inlineApproval = isSessionRouteId(activeRoute)
       ? findInlineApproval(overlaySnapshot.approvalQueue, this.activeSessionKey)
       : null;
@@ -1958,9 +1987,9 @@ class OpenClawShell extends OpenClawLightDomElement {
           : nothing}
         <main
           id="control-ui-main"
-          class="content ${chatLikeRoute ? "content--chat" : ""} ${activeRoute === "workboard"
-            ? "content--workboard"
-            : ""}"
+          class="content ${chatLikeRoute ? "content--chat" : ""} ${custodianRoute
+            ? "content--custodian"
+            : ""} ${activeRoute === "workboard" ? "content--workboard" : ""}"
           .tabIndex=${-1}
         >
           ${gatewaySnapshot.hello?.deviceAuthMigration?.pending === true
@@ -2029,6 +2058,12 @@ class OpenClawShell extends OpenClawLightDomElement {
             password: context.gateway.connection.password,
           })}
         ></openclaw-browser-panel>
+        <openclaw-custodian-panel
+          .available=${custodianPanelAvailable}
+          .suppressed=${activeRoute === "custodian"}
+          .activeRoute=${activeRoute}
+          .minimizeRequestId=${this.custodianMinimizeRequestId}
+        ></openclaw-custodian-panel>
         ${isOptionalElementDefined(this.execApprovalElement)
           ? html`<openclaw-exec-approval
               .props=${{

--- a/ui/src/app/lazy-custom-element.ts
+++ b/ui/src/app/lazy-custom-element.ts
@@ -56,6 +56,12 @@ export const BROWSER_PANEL_ELEMENT = {
   loadModule: () => import("../components/browser/browser-panel.ts"),
 } satisfies OptionalCustomElement;
 
+export const CUSTODIAN_PANEL_ELEMENT = {
+  tagName: "openclaw-custodian-panel",
+  label: "custodian panel",
+  loadModule: () => import("../components/custodian/custodian-panel.ts"),
+} satisfies OptionalCustomElement;
+
 // Loaded only for approval document URLs: the approval page pulls the protocol
 // validators (typebox runtime) and must stay out of the normal startup graph.
 export const APPROVAL_PAGE_ELEMENT = {

--- a/ui/src/components/custodian/custodian-panel.test.ts
+++ b/ui/src/components/custodian/custodian-panel.test.ts
@@ -1,0 +1,177 @@
+/* @vitest-environment jsdom */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createContext } from "../../pages/custodian/custodian-page.test-harness.ts";
+import { CustodianSessionStore } from "../../pages/custodian/custodian-session-store.ts";
+import { createApplicationContextProvider } from "../../test-helpers/application-context.ts";
+import { createStorageMock } from "../../test-helpers/storage.ts";
+import { CUSTODIAN_PANEL_TOGGLE_EVENT } from "../panel-toggle-contract.ts";
+import "./custodian-panel.ts";
+
+type TestCustodianPanel = HTMLElement & {
+  activeRoute: string;
+  available: boolean;
+  custodianPanelOpen: boolean;
+  minimizeRequestId: number;
+  store: CustodianSessionStore;
+  suppressed: boolean;
+  updateComplete: Promise<boolean>;
+};
+
+async function mountPanel() {
+  const request = vi.fn().mockResolvedValue({
+    sessionId: "panel-session",
+    reply: "Ready.",
+    action: "none",
+  });
+  const { context } = createContext(request);
+  const provider = createApplicationContextProvider(context);
+  const store = new CustodianSessionStore();
+  const panel = document.createElement("openclaw-custodian-panel") as TestCustodianPanel;
+  panel.store = store;
+  panel.available = true;
+  panel.activeRoute = "custodian";
+  panel.suppressed = true;
+  provider.append(panel);
+  document.body.append(provider);
+  await panel.updateComplete;
+  return { context, panel, request, store };
+}
+
+describe("custodian panel", () => {
+  beforeEach(() => {
+    vi.stubGlobal("localStorage", createStorageMock());
+    vi.stubGlobal(
+      "matchMedia",
+      vi.fn(() => ({
+        matches: true,
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+      })),
+    );
+  });
+
+  afterEach(() => {
+    document.body.replaceChildren();
+    document.documentElement.style.removeProperty("--oc-custodian-reserve-bottom");
+    document.documentElement.style.removeProperty("--oc-custodian-reserve-right");
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it("minimizes a real page conversation into the dock on route leave", async () => {
+    const { context, panel, request, store } = await mountPanel();
+    store.connect(context, "caretaker");
+    await vi.waitFor(() => expect(request).toHaveBeenCalledOnce());
+    store.messages = [
+      { id: 1, role: "assistant", text: "Ready.", at: 1, question: null },
+      { id: 2, role: "user", text: "Check this system", at: 2, question: null },
+    ];
+
+    panel.activeRoute = "config";
+    panel.suppressed = false;
+    panel.minimizeRequestId = 1;
+    await panel.updateComplete;
+
+    expect(panel.custodianPanelOpen).toBe(true);
+    expect(document.documentElement.style.getPropertyValue("--oc-custodian-reserve-right")).toBe(
+      "440px",
+    );
+
+    panel.querySelector<HTMLButtonElement>(".cp-actions .cp-icon:last-child")!.click();
+    await panel.updateComplete;
+    expect(panel.custodianPanelOpen).toBe(false);
+    expect(store.panelClosedByUser).toBe(true);
+
+    panel.activeRoute = "profile";
+    await panel.updateComplete;
+    expect(panel.custodianPanelOpen).toBe(false);
+
+    panel.activeRoute = "custodian";
+    panel.suppressed = true;
+    await panel.updateComplete;
+    expect(store.panelClosedByUser).toBe(false);
+
+    panel.activeRoute = "profile";
+    panel.suppressed = false;
+    panel.minimizeRequestId = 2;
+    await panel.updateComplete;
+    expect(panel.custodianPanelOpen).toBe(true);
+  });
+
+  it("suppresses the dock on the full page and ignores explicit toggles there", async () => {
+    const { panel } = await mountPanel();
+
+    window.dispatchEvent(new CustomEvent(CUSTODIAN_PANEL_TOGGLE_EVENT, { detail: { open: true } }));
+    await panel.updateComplete;
+    expect(panel.custodianPanelOpen).toBe(false);
+
+    panel.activeRoute = "config";
+    panel.suppressed = false;
+    await panel.updateComplete;
+    window.dispatchEvent(new CustomEvent(CUSTODIAN_PANEL_TOGGLE_EVENT, { detail: { open: true } }));
+    await panel.updateComplete;
+    expect(panel.custodianPanelOpen).toBe(true);
+
+    panel.activeRoute = "custodian";
+    panel.suppressed = true;
+    await panel.updateComplete;
+    expect(panel.custodianPanelOpen).toBe(false);
+  });
+
+  it("honors a minimize request when chat becomes available after route leave", async () => {
+    const { context, panel, request, store } = await mountPanel();
+    store.connect(context, "caretaker");
+    await vi.waitFor(() => expect(request).toHaveBeenCalledOnce());
+    store.messages = [{ id: 1, role: "user", text: "Check this system", at: 1, question: null }];
+    panel.available = false;
+    panel.activeRoute = "config";
+    panel.suppressed = false;
+    panel.minimizeRequestId = 1;
+    await panel.updateComplete;
+    expect(panel.custodianPanelOpen).toBe(false);
+
+    panel.available = true;
+    await panel.updateComplete;
+    expect(panel.custodianPanelOpen).toBe(true);
+  });
+
+  it("preserves an onboarding session variant when it minimizes into the dock", async () => {
+    const { context, panel, request, store } = await mountPanel();
+    store.connect(context, "onboarding");
+    await vi.waitFor(() => expect(request).toHaveBeenCalledOnce());
+    store.messages = [
+      { id: 1, role: "assistant", text: "Set up your system", at: 1, question: null },
+      { id: 2, role: "user", text: "Continue setup", at: 2, question: null },
+    ];
+
+    panel.activeRoute = "config";
+    panel.suppressed = false;
+    panel.minimizeRequestId = 1;
+    await panel.updateComplete;
+    const surface = panel.querySelector<HTMLElement & { updateComplete: Promise<boolean> }>(
+      "openclaw-custodian-surface",
+    );
+    await surface?.updateComplete;
+
+    expect(store.activeVariant).toBe("onboarding");
+    expect(request).toHaveBeenCalledOnce();
+    expect(panel.textContent).toContain("Continue setup");
+  });
+
+  it("updates the panel mascot mood with shared sending state", async () => {
+    const { panel, store } = await mountPanel();
+    panel.activeRoute = "config";
+    panel.suppressed = false;
+    window.dispatchEvent(new CustomEvent(CUSTODIAN_PANEL_TOGGLE_EVENT, { detail: { open: true } }));
+    await panel.updateComplete;
+
+    store.sending = true;
+    store.setInput("status");
+    await panel.updateComplete;
+
+    expect(
+      (panel.querySelector(".cp-title openclaw-mascot") as HTMLElement & { mood: string }).mood,
+    ).toBe("thinking");
+  });
+});

--- a/ui/src/components/custodian/custodian-panel.test.ts
+++ b/ui/src/components/custodian/custodian-panel.test.ts
@@ -9,7 +9,6 @@ import { CUSTODIAN_PANEL_TOGGLE_EVENT } from "../panel-toggle-contract.ts";
 import "./custodian-panel.ts";
 
 type TestCustodianPanel = HTMLElement & {
-  activeRoute: string;
   available: boolean;
   custodianPanelOpen: boolean;
   minimizeRequestId: number;
@@ -30,7 +29,6 @@ async function mountPanel() {
   const panel = document.createElement("openclaw-custodian-panel") as TestCustodianPanel;
   panel.store = store;
   panel.available = true;
-  panel.activeRoute = "custodian";
   panel.suppressed = true;
   provider.append(panel);
   document.body.append(provider);
@@ -68,7 +66,6 @@ describe("custodian panel", () => {
       { id: 2, role: "user", text: "Check this system", at: 2, question: null },
     ];
 
-    panel.activeRoute = "config";
     panel.suppressed = false;
     panel.minimizeRequestId = 1;
     await panel.updateComplete;
@@ -81,18 +78,10 @@ describe("custodian panel", () => {
     panel.querySelector<HTMLButtonElement>(".cp-actions .cp-icon:last-child")!.click();
     await panel.updateComplete;
     expect(panel.custodianPanelOpen).toBe(false);
-    expect(store.panelClosedByUser).toBe(true);
 
-    panel.activeRoute = "profile";
-    await panel.updateComplete;
-    expect(panel.custodianPanelOpen).toBe(false);
-
-    panel.activeRoute = "custodian";
     panel.suppressed = true;
     await panel.updateComplete;
-    expect(store.panelClosedByUser).toBe(false);
 
-    panel.activeRoute = "profile";
     panel.suppressed = false;
     panel.minimizeRequestId = 2;
     await panel.updateComplete;
@@ -106,14 +95,12 @@ describe("custodian panel", () => {
     await panel.updateComplete;
     expect(panel.custodianPanelOpen).toBe(false);
 
-    panel.activeRoute = "config";
     panel.suppressed = false;
     await panel.updateComplete;
     window.dispatchEvent(new CustomEvent(CUSTODIAN_PANEL_TOGGLE_EVENT, { detail: { open: true } }));
     await panel.updateComplete;
     expect(panel.custodianPanelOpen).toBe(true);
 
-    panel.activeRoute = "custodian";
     panel.suppressed = true;
     await panel.updateComplete;
     expect(panel.custodianPanelOpen).toBe(false);
@@ -125,7 +112,6 @@ describe("custodian panel", () => {
     await vi.waitFor(() => expect(request).toHaveBeenCalledOnce());
     store.messages = [{ id: 1, role: "user", text: "Check this system", at: 1, question: null }];
     panel.available = false;
-    panel.activeRoute = "config";
     panel.suppressed = false;
     panel.minimizeRequestId = 1;
     await panel.updateComplete;
@@ -145,7 +131,6 @@ describe("custodian panel", () => {
       { id: 2, role: "user", text: "Continue setup", at: 2, question: null },
     ];
 
-    panel.activeRoute = "config";
     panel.suppressed = false;
     panel.minimizeRequestId = 1;
     await panel.updateComplete;
@@ -161,7 +146,6 @@ describe("custodian panel", () => {
 
   it("updates the panel mascot mood with shared sending state", async () => {
     const { panel, store } = await mountPanel();
-    panel.activeRoute = "config";
     panel.suppressed = false;
     window.dispatchEvent(new CustomEvent(CUSTODIAN_PANEL_TOGGLE_EVENT, { detail: { open: true } }));
     await panel.updateComplete;

--- a/ui/src/components/custodian/custodian-panel.ts
+++ b/ui/src/components/custodian/custodian-panel.ts
@@ -1,0 +1,208 @@
+import { html, nothing, type PropertyValues } from "lit";
+import { property } from "lit/decorators.js";
+import { t } from "../../i18n/index.ts";
+import "../openclaw-mascot.ts";
+import { OpenClawLightDomElement } from "../../lit/openclaw-element.ts";
+import {
+  custodianSessionStore,
+  type CustodianSessionStore,
+} from "../../pages/custodian/custodian-session-store.ts";
+import { DockLayoutController } from "../dock-layout-controller.ts";
+import { createDockPanelLayout, type DockPanelSide } from "../dock-panel-layout.ts";
+import { icons } from "../icons.ts";
+import {
+  CUSTODIAN_PANEL_TOGGLE_EVENT,
+  type CustodianPanelToggleDetail,
+} from "../panel-toggle-contract.ts";
+import "../../pages/custodian/custodian-surface.ts";
+import "../../styles/custodian-panel.css";
+
+type CustodianDock = Exclude<DockPanelSide, "left">;
+
+const panelLayout = createDockPanelLayout({
+  storageKey: "openclaw.custodian.panel.v1",
+  minHeight: 240,
+  minWidth: 320,
+  defaultDock: "right",
+  supportedDocks: ["bottom", "right"],
+  defaultHeight: 420,
+  defaultWidth: 440,
+});
+
+export class OpenClawCustodianPanel extends OpenClawLightDomElement {
+  @property({ type: Boolean }) available = false;
+  @property({ type: Boolean }) suppressed = false;
+  @property({ attribute: false }) activeRoute = "";
+  @property({ type: Number }) minimizeRequestId = 0;
+  @property({ attribute: false }) store: CustodianSessionStore = custodianSessionStore;
+
+  private readonly dockLayout = new DockLayoutController(this, {
+    layout: panelLayout,
+    reservationPrefix: "custodian",
+    isAvailable: () => this.available,
+  });
+  private readonly onToggleRequest = (event: Event) => this.handleToggleRequest(event);
+  private handledMinimizeRequestId = 0;
+  private subscribedStore: CustodianSessionStore | null = null;
+  private storeCleanup: (() => void) | null = null;
+
+  override connectedCallback(): void {
+    super.connectedCallback();
+    this.subscribeToStore();
+    window.addEventListener(CUSTODIAN_PANEL_TOGGLE_EVENT, this.onToggleRequest);
+    this.dockLayout.setSuppressed(this.suppressed);
+  }
+
+  override disconnectedCallback(): void {
+    window.removeEventListener(CUSTODIAN_PANEL_TOGGLE_EVENT, this.onToggleRequest);
+    this.storeCleanup?.();
+    this.storeCleanup = null;
+    this.subscribedStore = null;
+    super.disconnectedCallback();
+  }
+
+  override willUpdate(changed: PropertyValues): void {
+    if (changed.has("store")) {
+      this.subscribeToStore();
+    }
+    if (changed.has("suppressed")) {
+      this.dockLayout.setSuppressed(this.suppressed);
+    }
+    if (this.activeRoute === "custodian") {
+      this.store.markCustodianVisited();
+    }
+    if (this.minimizeRequestId > 0 && this.minimizeRequestId !== this.handledMinimizeRequestId) {
+      this.store.markCustodianVisited();
+      if (this.available) {
+        this.handledMinimizeRequestId = this.minimizeRequestId;
+      }
+      if (this.available && this.store.hasRealUserTurn()) {
+        this.dockLayout.setOpen(true);
+      }
+    }
+    if (changed.has("available")) {
+      if (!this.available && this.dockLayout.open) {
+        this.dockLayout.hideWithoutPersisting();
+      } else if (this.available) {
+        this.dockLayout.restoreOpenState();
+      }
+    }
+    this.dockLayout.syncReservation();
+  }
+
+  private subscribeToStore(): void {
+    if (!this.isConnected || this.subscribedStore === this.store) {
+      return;
+    }
+    this.storeCleanup?.();
+    this.subscribedStore = this.store;
+    this.storeCleanup = this.store.subscribe(() => this.requestUpdate());
+  }
+
+  toggle(): void {
+    if (!this.available || this.suppressed) {
+      return;
+    }
+    if (this.dockLayout.open) {
+      this.closePanel();
+    } else {
+      this.store.markPanelClosedByUser(false);
+      this.dockLayout.setOpen(true);
+    }
+  }
+
+  handleToggleRequest(event: Event): void {
+    const detail =
+      event instanceof CustomEvent && typeof event.detail === "object" && event.detail !== null
+        ? (event.detail as CustodianPanelToggleDetail)
+        : null;
+    if (detail?.dock === "right" || detail?.dock === "bottom") {
+      this.dockLayout.setDock(detail.dock, false);
+    }
+    if (detail?.open === false) {
+      this.closePanel();
+      return;
+    }
+    if (detail?.open === true) {
+      if (!this.available || this.suppressed) {
+        return;
+      }
+      this.store.markPanelClosedByUser(false);
+      this.dockLayout.setOpen(true);
+      return;
+    }
+    this.toggle();
+  }
+
+  private closePanel(): void {
+    this.store.markPanelClosedByUser(true);
+    this.dockLayout.setOpen(false);
+  }
+
+  private setDock(dock: CustodianDock): void {
+    this.dockLayout.setDock(dock);
+  }
+
+  get custodianPanelOpen(): boolean {
+    return this.dockLayout.open;
+  }
+
+  override render() {
+    if (!this.available || !this.dockLayout.open) {
+      return nothing;
+    }
+    const dock = this.dockLayout.dock;
+    const style =
+      dock === "bottom" ? `height:${this.dockLayout.height}px` : `width:${this.dockLayout.width}px`;
+    return html`
+      <section class="cp cp--${dock}" style=${style} aria-label=${t("custodian.panel.title")}>
+        ${this.dockLayout.renderResizer("cp", t("custodian.panel.resize"))}
+        <header class="cp-header">
+          <div class="cp-title">
+            <openclaw-mascot
+              .mood=${this.store.sending ? "thinking" : "idle"}
+              .size=${26}
+            ></openclaw-mascot>
+            <strong>${t("custodian.panel.title")}</strong>
+          </div>
+          <div class="cp-actions">
+            <button
+              class="cp-icon"
+              type="button"
+              aria-label=${dock === "bottom"
+                ? t("custodian.panel.dockRight")
+                : t("custodian.panel.dockBottom")}
+              @click=${() => this.setDock(dock === "bottom" ? "right" : "bottom")}
+            >
+              ${dock === "bottom" ? icons.panelRightOpen : icons.panelBottomOpen}
+            </button>
+            <button
+              class="cp-icon"
+              type="button"
+              aria-label=${t("custodian.panel.close")}
+              @click=${() => this.closePanel()}
+            >
+              ${icons.x}
+            </button>
+          </div>
+        </header>
+        <openclaw-custodian-surface
+          .store=${this.store}
+          .onboarding=${this.store.activeVariant === "onboarding"}
+          .newAgentIntent=${this.store.activeVariant === "new-agent"}
+          compact
+        ></openclaw-custodian-surface>
+      </section>
+    `;
+  }
+}
+
+if (!customElements.get("openclaw-custodian-panel")) {
+  customElements.define("openclaw-custodian-panel", OpenClawCustodianPanel);
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "openclaw-custodian-panel": OpenClawCustodianPanel;
+  }
+}

--- a/ui/src/components/custodian/custodian-panel.ts
+++ b/ui/src/components/custodian/custodian-panel.ts
@@ -32,7 +32,6 @@ const panelLayout = createDockPanelLayout({
 export class OpenClawCustodianPanel extends OpenClawLightDomElement {
   @property({ type: Boolean }) available = false;
   @property({ type: Boolean }) suppressed = false;
-  @property({ attribute: false }) activeRoute = "";
   @property({ type: Number }) minimizeRequestId = 0;
   @property({ attribute: false }) store: CustodianSessionStore = custodianSessionStore;
 
@@ -68,11 +67,7 @@ export class OpenClawCustodianPanel extends OpenClawLightDomElement {
     if (changed.has("suppressed")) {
       this.dockLayout.setSuppressed(this.suppressed);
     }
-    if (this.activeRoute === "custodian") {
-      this.store.markCustodianVisited();
-    }
     if (this.minimizeRequestId > 0 && this.minimizeRequestId !== this.handledMinimizeRequestId) {
-      this.store.markCustodianVisited();
       if (this.available) {
         this.handledMinimizeRequestId = this.minimizeRequestId;
       }
@@ -104,9 +99,8 @@ export class OpenClawCustodianPanel extends OpenClawLightDomElement {
       return;
     }
     if (this.dockLayout.open) {
-      this.closePanel();
+      this.dockLayout.setOpen(false);
     } else {
-      this.store.markPanelClosedByUser(false);
       this.dockLayout.setOpen(true);
     }
   }
@@ -120,23 +114,17 @@ export class OpenClawCustodianPanel extends OpenClawLightDomElement {
       this.dockLayout.setDock(detail.dock, false);
     }
     if (detail?.open === false) {
-      this.closePanel();
+      this.dockLayout.setOpen(false);
       return;
     }
     if (detail?.open === true) {
       if (!this.available || this.suppressed) {
         return;
       }
-      this.store.markPanelClosedByUser(false);
       this.dockLayout.setOpen(true);
       return;
     }
     this.toggle();
-  }
-
-  private closePanel(): void {
-    this.store.markPanelClosedByUser(true);
-    this.dockLayout.setOpen(false);
   }
 
   private setDock(dock: CustodianDock): void {
@@ -180,7 +168,7 @@ export class OpenClawCustodianPanel extends OpenClawLightDomElement {
               class="cp-icon"
               type="button"
               aria-label=${t("custodian.panel.close")}
-              @click=${() => this.closePanel()}
+              @click=${() => this.dockLayout.setOpen(false)}
             >
               ${icons.x}
             </button>

--- a/ui/src/components/panel-toggle-contract.ts
+++ b/ui/src/components/panel-toggle-contract.ts
@@ -2,6 +2,7 @@ import type { UiCommandParams } from "@openclaw/gateway-protocol";
 
 export const TERMINAL_PANEL_TOGGLE_EVENT = "openclaw:terminal-toggle";
 export const BROWSER_PANEL_TOGGLE_EVENT = "openclaw:browser-toggle";
+export const CUSTODIAN_PANEL_TOGGLE_EVENT = "openclaw:custodian-toggle";
 export const UI_COMMAND_EVENT = "openclaw:ui-command";
 
 export type UiCommandDetail = UiCommandParams;
@@ -21,6 +22,11 @@ export type BrowserPanelToggleDetail = {
   dock?: "bottom" | "right";
   open?: boolean;
   url?: string;
+};
+
+export type CustodianPanelToggleDetail = {
+  dock?: "bottom" | "right";
+  open?: boolean;
 };
 
 export type PanelToggleElement = HTMLElement & {

--- a/ui/src/i18n/.i18n/raw-copy-baseline.json
+++ b/ui/src/i18n/.i18n/raw-copy-baseline.json
@@ -27,6 +27,13 @@
       "kind": "object-property",
       "name": "label",
       "path": "ui/src/app/lazy-custom-element.ts",
+      "text": "custodian panel"
+    },
+    {
+      "count": 1,
+      "kind": "object-property",
+      "name": "label",
+      "path": "ui/src/app/lazy-custom-element.ts",
       "text": "terminal panel"
     },
     {
@@ -637,13 +644,6 @@
       "name": "placeholder",
       "path": "ui/src/pages/cron/view.ts",
       "text": "default"
-    },
-    {
-      "count": 1,
-      "kind": "html-text",
-      "name": "text",
-      "path": "ui/src/pages/custodian/custodian-page.ts",
-      "text": "OC"
     },
     {
       "count": 1,

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -2031,6 +2031,14 @@ export const en: TranslationMap = {
     sessionRestarted:
       "{error} OpenClaw started a fresh session; earlier messages remain for context.",
     unsupportedGateway: "Update the Gateway to continue setup with OpenClaw.",
+    panel: {
+      title: "OpenClaw",
+      toggle: "Ask OpenClaw",
+      close: "Close Ask OpenClaw",
+      resize: "Resize Ask OpenClaw",
+      dockBottom: "Dock Ask OpenClaw at bottom",
+      dockRight: "Dock Ask OpenClaw at right",
+    },
     history: {
       button: "History",
       title: "Recent changes",

--- a/ui/src/pages/chat/components/chat-session-workspace.test.ts
+++ b/ui/src/pages/chat/components/chat-session-workspace.test.ts
@@ -43,6 +43,25 @@ describe("toggleSessionWorkspace", () => {
   });
 });
 
+describe("custodian panel toggle", () => {
+  it("is available only while the gateway is connected and advertises chat", () => {
+    const state = {
+      client: null,
+      connected: false,
+      handleOpenSidebar: vi.fn(),
+      hello: gatewayHello(["openclaw.chat"]),
+      requestUpdate: vi.fn(),
+      sessionKey: "agent:main:current",
+      sessions: {},
+    } as unknown as SessionWorkspaceHost;
+
+    expect(createSessionWorkspaceProps(state).onToggleCustodian).toBeUndefined();
+
+    state.connected = true;
+    expect(createSessionWorkspaceProps(state).onToggleCustodian).toBeTypeOf("function");
+  });
+});
+
 describe("openSessionWorkspaceFile", () => {
   it("opens Markdown with a canonical Gateway- and pane-scoped draft identity", async () => {
     const handleOpenSidebar = vi.fn();

--- a/ui/src/pages/chat/components/chat-session-workspace.ts
+++ b/ui/src/pages/chat/components/chat-session-workspace.ts
@@ -16,6 +16,7 @@ import {
 import { icons } from "../../../components/icons.ts";
 import {
   BROWSER_PANEL_TOGGLE_EVENT,
+  CUSTODIAN_PANEL_TOGGLE_EVENT,
   TERMINAL_PANEL_TOGGLE_EVENT,
 } from "../../../components/panel-toggle-contract.ts";
 import "../../../components/tooltip.ts";
@@ -60,6 +61,7 @@ export type SessionWorkspaceProps = {
   onOpenArtifact: (artifactId: string) => void;
   onToggleTerminal?: () => void;
   onToggleBrowser?: () => void;
+  onToggleCustodian?: () => void;
   /** Opens the session diff panel; absent when the gateway lacks sessions.diff. */
   onOpenDiff?: () => void;
   diffNotGit?: boolean;
@@ -719,6 +721,10 @@ export function createSessionWorkspaceProps(
           window.dispatchEvent(new CustomEvent(BROWSER_PANEL_TOGGLE_EVENT, {}));
         }
       : undefined,
+    onToggleCustodian:
+      state.connected && isGatewayMethodAdvertised(state, "openclaw.chat") === true
+        ? () => window.dispatchEvent(new CustomEvent(CUSTODIAN_PANEL_TOGGLE_EVENT))
+        : undefined,
     diffNotGit: workspace.list?.gitCheckout === false,
     onOpenDiff:
       isGatewayMethodAdvertised(state, "sessions.diff") === true && state.client
@@ -877,6 +883,20 @@ export function renderSessionWorkspaceRail(
             @click=${sessionWorkspace.onToggleBrowser}
           >
             ${icons.globe}
+          </button>
+        </openclaw-tooltip>
+      `
+    : nothing;
+  const custodianButton = sessionWorkspace.onToggleCustodian
+    ? html`
+        <openclaw-tooltip .content=${t("custodian.panel.toggle")}>
+          <button
+            type="button"
+            class="chat-workspace-rail__terminal"
+            aria-label=${t("custodian.panel.toggle")}
+            @click=${sessionWorkspace.onToggleCustodian}
+          >
+            ${icons.lobster}
           </button>
         </openclaw-tooltip>
       `
@@ -1189,7 +1209,7 @@ export function renderSessionWorkspaceRail(
           <strong>${t("chat.workspaceFiles.files")}</strong>
         </div>
         <div class="chat-workspace-rail__actions">
-          ${diffButton} ${terminalButton} ${browserButton}
+          ${diffButton} ${terminalButton} ${browserButton} ${custodianButton}
           ${sessionWorkspace.narrowLayout
             ? nothing
             : html`

--- a/ui/src/pages/custodian/custodian-page-agent-create.test.ts
+++ b/ui/src/pages/custodian/custodian-page-agent-create.test.ts
@@ -9,11 +9,13 @@ import type {
 } from "../../app/context.ts";
 import { createApplicationContextProvider } from "../../test-helpers/application-context.ts";
 import { waitForFast } from "../../test-helpers/wait-for.ts";
+import { CustodianSessionStore } from "./custodian-session-store.ts";
 import "./custodian-page.ts";
 
 type TestCustodianPage = HTMLElement & {
   onboarding: boolean;
   newAgentIntent: boolean;
+  store: CustodianSessionStore;
   updateComplete: Promise<boolean>;
 };
 
@@ -72,6 +74,7 @@ function createContext(request: ReturnType<typeof vi.fn>) {
 async function mountPage(context: ApplicationContext): Promise<TestCustodianPage> {
   const provider = createApplicationContextProvider(context);
   const page = document.createElement("openclaw-custodian-page") as TestCustodianPage;
+  page.store = new CustodianSessionStore();
   page.onboarding = false;
   page.newAgentIntent = true;
   provider.append(page);

--- a/ui/src/pages/custodian/custodian-page.test-harness.ts
+++ b/ui/src/pages/custodian/custodian-page.test-harness.ts
@@ -13,10 +13,12 @@ import {
   createApplicationContextProvider,
   type ApplicationContextProvider,
 } from "../../test-helpers/application-context.ts";
+import { CustodianSessionStore } from "./custodian-session-store.ts";
 import "./custodian-page.ts";
 
 type TestCustodianPage = HTMLElement & {
   onboarding: boolean;
+  store: CustodianSessionStore;
   updateComplete: Promise<boolean>;
 };
 
@@ -109,6 +111,7 @@ export async function mountPage(
 }> {
   const provider = createApplicationContextProvider(context);
   const page = document.createElement("openclaw-custodian-page") as TestCustodianPage;
+  page.store = new CustodianSessionStore();
   page.onboarding = options.onboarding ?? true;
   provider.append(page);
   document.body.append(provider);

--- a/ui/src/pages/custodian/custodian-page.test.ts
+++ b/ui/src/pages/custodian/custodian-page.test.ts
@@ -52,7 +52,12 @@ describe("custodian page", () => {
     await page.updateComplete;
     const assistantGroup = page.querySelector<HTMLElement>(".chat-group.assistant")!;
     expect(assistantGroup.querySelector("strong")?.textContent).toBe("aboard");
-    expect(assistantGroup.querySelector(".chat-avatar.assistant")?.textContent?.trim()).toBe("OC");
+    expect(
+      assistantGroup
+        .querySelector<HTMLImageElement>("img.chat-avatar.assistant")
+        ?.getAttribute("src"),
+    ).toBe("/favicon.svg");
+    expect(page.querySelector(".custodian__mark openclaw-mascot")).not.toBeNull();
     const card = page.querySelector("openclaw-option-card")!;
     await card.updateComplete;
     expect(page.querySelector(".option-card__choice--recommended")?.textContent).toContain(

--- a/ui/src/pages/custodian/custodian-page.ts
+++ b/ui/src/pages/custodian/custodian-page.ts
@@ -8,7 +8,6 @@ import "../../components/openclaw-mascot.ts";
 import { t } from "../../i18n/index.ts";
 import { isGatewayMethodAdvertised } from "../../lib/gateway-methods.ts";
 import { OpenClawLightDomElement } from "../../lit/openclaw-element.ts";
-import { SubscriptionsController } from "../../lit/subscriptions-controller.ts";
 import "../../styles/custodian.css";
 import { renderCustodianChangeHistory } from "./custodian-history.ts";
 import { custodianSessionStore, type CustodianSessionStore } from "./custodian-session-store.ts";
@@ -37,11 +36,6 @@ export class CustodianPage extends OpenClawLightDomElement {
   private historyRequestEpoch = 0;
   private subscribedStore: CustodianSessionStore | null = null;
   private storeCleanup: (() => void) | null = null;
-  private readonly subscriptions = new SubscriptionsController(this).watch(
-    () => this.context?.gateway,
-    (gateway, notify) => gateway.subscribe(notify),
-    () => this.synchronizeHistoryClient(),
-  );
 
   override connectedCallback(): void {
     super.connectedCallback();
@@ -68,6 +62,7 @@ export class CustodianPage extends OpenClawLightDomElement {
     if (changedProperties.has("store")) {
       this.subscribeToStore();
     }
+    this.synchronizeHistoryClient();
   }
 
   private subscribeToStore(): void {

--- a/ui/src/pages/custodian/custodian-page.ts
+++ b/ui/src/pages/custodian/custodian-page.ts
@@ -1,72 +1,29 @@
 import { consume } from "@lit/context";
-import type {
-  SystemAgentChatParams,
-  SystemAgentChatResult,
-  SystemChangeEntry,
-  SystemChangesListResult,
-} from "@openclaw/gateway-protocol";
+import type { SystemChangeEntry, SystemChangesListResult } from "@openclaw/gateway-protocol";
 import { html, nothing, type PropertyValues } from "lit";
 import { property, state } from "lit/decorators.js";
 import type { GatewayBrowserClient } from "../../api/gateway.ts";
-import { selectApplicationSession } from "../../app/agent-selection.ts";
 import { applicationContext, type ApplicationContext } from "../../app/context.ts";
-import { icons } from "../../components/icons.ts";
+import "../../components/openclaw-mascot.ts";
 import { t } from "../../i18n/index.ts";
 import { isGatewayMethodAdvertised } from "../../lib/gateway-methods.ts";
-import { buildAgentMainSessionKey } from "../../lib/sessions/session-key.ts";
 import { OpenClawLightDomElement } from "../../lit/openclaw-element.ts";
 import { SubscriptionsController } from "../../lit/subscriptions-controller.ts";
-import "../../styles/chat/grouped.css";
-import "../../styles/chat/layout.css";
-import "../../styles/chat/text.css";
 import "../../styles/custodian.css";
-import { renderChatAvatar } from "../chat/chat-avatar.ts";
 import { renderCustodianChangeHistory } from "./custodian-history.ts";
-import { pathForCustodianAgentHandoff } from "./custodian-navigation.ts";
-import * as eventNudgeState from "./event-nudge.ts";
-import {
-  custodianChatParams,
-  isCustodianSessionInvalidatedError,
-  sessionVariant,
-  type CustodianSessionVariant,
-} from "./session-lifecycle.ts";
-import { parseCustodianQuestion, type CustodianStructuredQuestion } from "./structured-question.ts";
-import {
-  createCustodianSessionId,
-  createCustodianTranscriptMessages,
-  custodianErrorMessage,
-  hasUnresolvedCustodianQuestion,
-  readCustodianTranscript,
-  renderCustodianTranscriptEntry,
-  retireCustodianQuestions,
-  type CustodianMessage,
-} from "./transcript.ts";
+import { custodianSessionStore, type CustodianSessionStore } from "./custodian-session-store.ts";
+import "./custodian-surface.ts";
 
-const SYSTEM_AGENT_CHAT_TIMEOUT_MS = 190_000;
 const SYSTEM_CHANGE_PAGE_SIZE = 50;
-const SILENT_REPLY_PATTERN = /^\s*NO_REPLY\s*$/;
 
 export class CustodianPage extends OpenClawLightDomElement {
   @consume({ context: applicationContext, subscribe: true })
   private context!: ApplicationContext;
 
-  /** Onboarding mode shows the Exit setup control; the route view sets this. */
   @property({ attribute: false }) onboarding = false;
-
-  /** New-agent mode starts a creation proposal conversation. */
   @property({ attribute: false }) newAgentIntent = false;
+  @property({ attribute: false }) store: CustodianSessionStore = custodianSessionStore;
 
-  @state() private messages: CustodianMessage[] = [];
-  @state() private input = "";
-  @state() private sending = false;
-  @state() private sensitive = false;
-  @state() private wizardInputPending = false;
-  @state() private questionReplyUncertain = false;
-  @state() private error: string | null = null;
-  @state() private dismissedQuestions = new Set<string>();
-  @state() private answeredQuestions = new Set<string>();
-  @state() private activeClient: GatewayBrowserClient | null = null;
-  @state() private chatAvailable = false;
   @state() private historyAvailable = false;
   @state() private historyOpen = false;
   @state() private historyEntries: SystemChangeEntry[] = [];
@@ -74,262 +31,69 @@ export class CustodianPage extends OpenClawLightDomElement {
   @state() private historyLoading = false;
   @state() private historyLoadingMore = false;
   @state() private historyError: string | null = null;
-  @state() private eventNudge: eventNudgeState.CustodianEventNudge | null = null;
-  @state() private eventNudgePending: eventNudgeState.CustodianEventNudge | null = null;
 
-  private sessionId = createCustodianSessionId();
-  private requestEpoch = 0;
-  private nextMessageId = 1;
-  private retryParams: SystemAgentChatParams | null = null;
-  private sessionVariant: CustodianSessionVariant | null = null;
-  private sessionClient: GatewayBrowserClient | null = null;
-  private sessionOwnershipKey: string | null = null;
-  private sessionStarted = false;
-  private earlierBoundaryAfterId: number | null = null;
-  private lastHelloDeviceToken = "";
-  private eventNudgeClosed = false;
-  private abandonedTurnOutcomeUnknown = false;
   private historyLoaded = false;
+  private historyClient: GatewayBrowserClient | null = null;
+  private historyRequestEpoch = 0;
+  private subscribedStore: CustodianSessionStore | null = null;
+  private storeCleanup: (() => void) | null = null;
   private readonly subscriptions = new SubscriptionsController(this).watch(
     () => this.context?.gateway,
     (gateway, notify) => gateway.subscribe(notify),
-  );
-  private readonly eventSubscriptions = new SubscriptionsController(this).effect(
-    () => this.context?.gateway,
-    (gateway) =>
-      gateway.subscribeEvents((event) => {
-        if (this.onboarding || this.newAgentIntent || this.eventNudgeClosed) {
-          return;
-        }
-        [this.eventNudge, this.eventNudgePending] = eventNudgeState.reconcileCustodianEventNudge(
-          this.eventNudge,
-          this.eventNudgePending,
-          event,
-        );
-      }),
+    () => this.synchronizeHistoryClient(),
   );
 
+  override connectedCallback(): void {
+    super.connectedCallback();
+    this.subscribeToStore();
+  }
+
   override disconnectedCallback(): void {
-    this.requestEpoch += 1;
-    this.subscriptions.clear();
-    this.eventSubscriptions.clear();
+    this.storeCleanup?.();
+    this.storeCleanup = null;
+    this.subscribedStore = null;
     super.disconnectedCallback();
   }
 
-  override updated(changedProperties: PropertyValues): void {
-    this.synchronizeClient();
-    if (changedProperties.has("messages")) {
-      const lastMessage = this.querySelector(".custodian__messages")?.lastElementChild;
-      if (lastMessage instanceof HTMLElement) {
-        lastMessage.scrollIntoView?.({ block: "nearest" });
-      }
-    }
-  }
-
-  /**
-   * Transcript rows are durable and admin-scoped, but the live engine session
-   * owns wizard and approval state. Rotate only that volatile state when its
-   * client or authenticated gateway identity changes.
-   */
-  private currentSessionOwnershipKey(): string {
-    const { gatewayUrl, token, password, bootstrapToken } = this.context.gateway.connection;
-    const auth = this.context.gateway.snapshot.hello?.auth;
-    if (auth) {
-      this.lastHelloDeviceToken = auth.deviceToken ?? "";
-    }
-    return JSON.stringify([gatewayUrl, token, password, bootstrapToken, this.lastHelloDeviceToken]);
-  }
-
-  private startSession(
-    client: GatewayBrowserClient,
-    variant: CustodianSessionVariant,
-    loadTranscript: boolean,
-  ): void {
-    this.sessionId = createCustodianSessionId();
-    this.sessionVariant = variant;
-    this.sessionClient = client;
-    this.sessionOwnershipKey = this.currentSessionOwnershipKey();
-    this.sessionStarted = true;
-    void this.initializeSession(
-      client,
-      { sessionId: this.sessionId, ...custodianChatParams(variant) },
-      loadTranscript,
+  protected override async getUpdateComplete(): Promise<boolean> {
+    const complete = await super.getUpdateComplete();
+    const surface = this.querySelector<HTMLElement & { updateComplete: Promise<boolean> }>(
+      "openclaw-custodian-surface",
     );
+    await surface?.updateComplete;
+    return complete;
   }
 
-  /**
-   * A user turn abandoned mid-flight may already have acted on the gateway.
-   * The unknown-outcome warning must survive rotations and reconnects
-   * independently of retry state (raw text is never retained) until the
-   * operator supersedes it with a new message.
-   */
-  private abandonPendingUserTurn(pendingParams: SystemAgentChatParams | null): void {
-    if (pendingParams?.message === undefined) {
+  override willUpdate(changedProperties: PropertyValues): void {
+    if (changedProperties.has("store")) {
+      this.subscribeToStore();
+    }
+  }
+
+  private subscribeToStore(): void {
+    if (!this.isConnected || this.subscribedStore === this.store) {
       return;
     }
-    this.retryParams = null;
-    this.abandonedTurnOutcomeUnknown = true;
+    this.storeCleanup?.();
+    this.subscribedStore = this.store;
+    this.storeCleanup = this.store.subscribe(() => this.requestUpdate());
   }
 
-  private rotateVolatileSession(
-    client: GatewayBrowserClient,
-    variant: CustodianSessionVariant,
-  ): void {
-    this.answeredQuestions = retireCustodianQuestions(this.messages, this.answeredQuestions);
-    this.retryParams = null;
-    this.input = "";
-    this.sensitive = this.wizardInputPending = this.questionReplyUncertain = false;
-    this.error = null;
-    this.earlierBoundaryAfterId = this.messages.at(-1)?.id ?? null;
-    this.startSession(client, variant, false);
-  }
-
-  private synchronizeClient(): void {
+  private synchronizeHistoryClient(): void {
     const snapshot = this.context.gateway.snapshot;
     const client = snapshot.phase === "connected" ? snapshot.client : null;
-    const chatSupported =
-      client !== null && isGatewayMethodAdvertised(snapshot, "openclaw.chat") === true;
-    const historyAvailable =
+    const available =
       client !== null && isGatewayMethodAdvertised(snapshot, "openclaw.changes.list") === true;
-    if (this.historyAvailable !== historyAvailable) {
-      this.historyAvailable = historyAvailable;
-      if (!historyAvailable) {
-        this.historyOpen = false;
-        this.resetHistory();
-      }
+    if (client !== this.historyClient || available !== this.historyAvailable) {
+      this.historyClient = client;
+      this.historyAvailable = available;
+      this.historyOpen = false;
+      this.resetHistory();
     }
-    const variant = sessionVariant(this.onboarding, this.newAgentIntent);
-    const variantChanged = this.sessionStarted && this.sessionVariant !== variant;
-    const ownershipKey = this.currentSessionOwnershipKey();
-    const clientReplaced =
-      this.sessionStarted &&
-      client !== null &&
-      this.sessionClient !== null &&
-      client !== this.sessionClient;
-    // Ownership boundaries stay armed even while the volatile session is torn
-    // down (e.g. an unsupported replacement): a retained transcript must never
-    // survive an authenticated identity change.
-    const ownershipChanged =
-      this.sessionOwnershipKey !== null && ownershipKey !== this.sessionOwnershipKey;
-    if (
-      client === this.activeClient &&
-      !variantChanged &&
-      !clientReplaced &&
-      !ownershipChanged &&
-      this.chatAvailable === chatSupported
-    ) {
-      return;
-    }
-    const requestWasPending = this.sending && this.retryParams !== null;
-    const pendingParams = requestWasPending ? this.retryParams : null;
-    this.activeClient = client;
-    this.requestEpoch += 1;
-    this.historyOpen = false;
-    this.resetHistory();
-    this.sending = false;
-    this.chatAvailable = false;
-    if (variantChanged || ownershipChanged) {
-      [this.eventNudge, this.eventNudgePending] = [null, null];
-      // A different operator or mode must not inherit the previous context's
-      // abandoned-turn warning; same-ownership paths below preserve it.
-      this.abandonedTurnOutcomeUnknown = false;
-      this.sessionStarted = false;
-      this.clearConversation();
-    } else if (client && clientReplaced) {
-      // A transport replacement keeps the same durable transcript, but do not
-      // create a fresh volatile session until the new client advertises chat.
-      if (!chatSupported) {
-        this.sessionStarted = false;
-        this.abandonPendingUserTurn(pendingParams);
-        this.error = t("custodian.unsupportedGateway");
-        return;
-      }
-      this.chatAvailable = true;
-      // Abandon before rotating: rotation installs the fresh welcome's retry
-      // state, which the abandoned turn's scrub must not clear.
-      this.abandonPendingUserTurn(pendingParams);
-      this.rotateVolatileSession(client, variant);
-      return;
-    } else if (requestWasPending) {
-      if (pendingParams?.message === undefined) {
-        this.error = t("custodian.connectionChanged");
-      }
-      this.abandonPendingUserTurn(pendingParams);
-    }
-    if (!client) {
-      return;
-    }
-    if (!chatSupported) {
-      this.error = t("custodian.unsupportedGateway");
-      return;
-    }
-    this.chatAvailable = true;
-    if (this.sessionStarted) {
-      if (!this.retryParams) {
-        // The abandoned-turn warning renders from its own flag; transient
-        // reconnects only clear stale request errors here.
-        this.error = requestWasPending ? this.error : null;
-      }
-      // This rendered thread owns live questions and turns for the active
-      // session; durable history is projected only during its cold start.
-      return;
-    }
-    this.clearConversation();
-    // Route variants seed their dedicated proposal conversation; the permanent
-    // presence surface gets the normal caretaker greeting instead.
-    this.startSession(client, variant, true);
-  }
-
-  private async initializeSession(
-    client: GatewayBrowserClient,
-    params: SystemAgentChatParams,
-    loadTranscript = true,
-  ): Promise<void> {
-    const epoch = ++this.requestEpoch;
-    this.sending = true;
-    this.error = null;
-    this.retryParams = params;
-    if (loadTranscript) {
-      await this.refreshTranscriptHistory(client, epoch);
-    }
-    if (epoch !== this.requestEpoch || client !== this.activeClient) {
-      return;
-    }
-    await this.requestReply(client, params);
-  }
-
-  private async refreshTranscriptHistory(
-    client: GatewayBrowserClient,
-    epoch: number,
-  ): Promise<void> {
-    if (
-      isGatewayMethodAdvertised(this.context.gateway.snapshot, "openclaw.chat.history") !== true
-    ) {
-      return;
-    }
-    const turns = await readCustodianTranscript(client);
-    if (turns === null || epoch !== this.requestEpoch || client !== this.activeClient) {
-      // History is additive. A transient read failure must not block chat or erase local state.
-      return;
-    }
-    const transcript = createCustodianTranscriptMessages(turns, this.nextMessageId);
-    this.messages = transcript.messages;
-    this.nextMessageId = transcript.nextMessageId;
-    this.earlierBoundaryAfterId = this.messages.at(-1)?.id ?? null;
-  }
-
-  private clearConversation(): void {
-    this.messages = [];
-    this.dismissedQuestions = new Set();
-    this.answeredQuestions = new Set();
-    this.retryParams = null;
-    this.error = null;
-    this.input = "";
-    this.sensitive = this.wizardInputPending = this.questionReplyUncertain = false;
-    this.earlierBoundaryAfterId = null;
   }
 
   private resetHistory(): void {
+    this.historyRequestEpoch += 1;
     this.historyEntries = [];
     this.historyNextCursor = null;
     this.historyLoading = false;
@@ -346,7 +110,7 @@ export class CustodianPage extends OpenClawLightDomElement {
   }
 
   private async loadHistory(reset: boolean): Promise<void> {
-    const client = this.activeClient;
+    const client = this.historyClient;
     const cursor = reset ? undefined : (this.historyNextCursor ?? undefined);
     if (
       !client ||
@@ -357,7 +121,7 @@ export class CustodianPage extends OpenClawLightDomElement {
     ) {
       return;
     }
-    const epoch = this.requestEpoch;
+    const epoch = ++this.historyRequestEpoch;
     if (reset) {
       this.historyLoading = true;
     } else {
@@ -366,8 +130,8 @@ export class CustodianPage extends OpenClawLightDomElement {
     this.historyError = null;
     const isCurrent = () =>
       this.isConnected &&
-      this.activeClient === client &&
-      this.requestEpoch === epoch &&
+      this.historyClient === client &&
+      this.historyRequestEpoch === epoch &&
       this.historyAvailable;
     try {
       const result = await client.request<SystemChangesListResult>("openclaw.changes.list", {
@@ -393,237 +157,29 @@ export class CustodianPage extends OpenClawLightDomElement {
     }
   }
 
-  private appendAssistant(reply: string, question: CustodianStructuredQuestion | null): void {
-    this.messages = [
-      ...this.messages,
-      {
-        id: this.nextMessageId++,
-        role: "assistant",
-        text: reply,
-        at: Date.now(),
-        question,
-      },
-    ];
-  }
-
-  private async requestReply(
-    client: GatewayBrowserClient,
-    params: SystemAgentChatParams,
-  ): Promise<eventNudgeState.CustodianSendOutcome> {
-    const epoch = ++this.requestEpoch;
-    let delivery: eventNudgeState.CustodianSendDelivery = "unsent";
-    this.sending = true;
-    this.error = null;
-    this.retryParams = params;
-    try {
-      const result = await client.request<SystemAgentChatResult>("openclaw.chat", params, {
-        timeoutMs: SYSTEM_AGENT_CHAT_TIMEOUT_MS,
-        onSent: () => (delivery = "sent"),
-      });
-      delivery = "received";
-      if (epoch !== this.requestEpoch || client !== this.activeClient) {
-        return "sent";
-      }
-      this.sessionId = result.sessionId;
-      this.sensitive = result.sensitive === true;
-      this.wizardInputPending = result.wizardInputPending === true;
-      this.retryParams = null;
-      const question = parseCustodianQuestion(result.question);
-      // Match regular chat: NO_REPLY is a delivery sentinel, not transcript content.
-      const silentReply = SILENT_REPLY_PATTERN.test(result.reply);
-      if (!silentReply || question) {
-        this.appendAssistant(silentReply ? "" : result.reply, question);
-      }
-      if (result.action === "open-agent") {
-        let sessionKey = this.context.gateway.snapshot.sessionKey?.trim();
-        if (result.agentId) {
-          const roster = await this.context.agents.refreshList();
-          if (epoch !== this.requestEpoch || client !== this.activeClient) {
-            return "sent";
-          }
-          sessionKey = buildAgentMainSessionKey({
-            agentId: result.agentId,
-            mainKey: roster?.mainKey,
-          });
-          selectApplicationSession({
-            selection: this.context.agentSelection,
-            gateway: this.context.gateway,
-            sessionKey,
-            agentId: result.agentId,
-          });
-        }
-        if (result.agentDraft === "hatch" && sessionKey) {
-          // Preserve the destination session while preloading the localized
-          // birth-sequence opener; draft-only chat routes are intentionally invalid.
-          this.context.navigate("chat", {
-            pathname: pathForCustodianAgentHandoff(this.context, sessionKey),
-            search: `?draft=${encodeURIComponent(t("custodian.hatchDraft"))}`,
-          });
-        } else {
-          this.exitSetup();
-        }
-      } else if (result.action === "exit") {
-        this.exitSetup();
-      }
-      return "sent";
-    } catch (error) {
-      if (epoch === this.requestEpoch && client === this.activeClient) {
-        this.error = custodianErrorMessage(error);
-        if (params.message !== undefined && isCustodianSessionInvalidatedError(error)) {
-          // Adopt a new id before another visible turn; retained rows are not live context.
-          // Welcome requests never rotate, so even a mis-marked outage stops after one attempt.
-          this.rotateVolatileSession(client, sessionVariant(this.onboarding, this.newAgentIntent));
-          this.error = t("custodian.sessionRestarted", { error: custodianErrorMessage(error) });
-        }
-      }
-      // A failed user turn may still have reached the agent and acted; there is
-      // no turn idempotency, so never keep it replayable (or its raw text).
-      if (params.message !== undefined && this.retryParams === params) {
-        this.retryParams = null;
-      }
-      return eventNudgeState.classifyCustodianSendFailure(error, delivery);
-    } finally {
-      if (epoch === this.requestEpoch) {
-        this.sending = false;
-      }
-    }
-  }
-
-  private async send(
-    text = this.input,
-    display?: string,
-    questionReply = this.hasUnresolvedQuestion(),
-  ): Promise<eventNudgeState.CustodianSendOutcome> {
-    // Trim decides emptiness only; sensitive values (credentials) may carry
-    // meaningful whitespace and must reach the agent exactly as entered.
-    const message = this.sensitive ? text : text.trim();
-    const client = this.activeClient;
-    const questionState = [this.answeredQuestions, this.questionReplyUncertain] as const;
-    if (questionReply) {
-      // A failed wizard reply may have arrived, so block nudges until the session outcome is known.
-      this.questionReplyUncertain = true;
-    }
-    if (!message.trim() || !client || !this.chatAvailable || this.sending) {
-      return "rejected";
-    }
-    const displayText = this.sensitive ? t("custodian.sensitiveReply") : (display ?? message);
-    // A new operator turn supersedes any abandoned-turn unknown-outcome warning.
-    this.abandonedTurnOutcomeUnknown = false;
-    this.answeredQuestions = retireCustodianQuestions(this.messages, this.answeredQuestions);
-    this.messages = [
-      ...this.messages,
-      {
-        id: this.nextMessageId++,
-        role: "user",
-        text: displayText,
-        at: Date.now(),
-        question: null,
-      },
-    ];
-    this.input = "";
-    const reply = this.requestReply(client, {
-      sessionId: this.sessionId,
-      ...custodianChatParams(sessionVariant(this.onboarding, this.newAgentIntent), message),
-    });
-    const replyEpoch = this.requestEpoch;
-    const outcome = await reply;
-    if (questionReply && this.requestEpoch === replyEpoch) {
-      this.questionReplyUncertain = eventNudgeState.questionUncertainty(questionState[1], outcome);
-      if (outcome === "rejected") {
-        this.answeredQuestions = questionState[0];
-      }
-    }
-    return outcome;
-  }
-
-  private async sendEventNudge(): Promise<void> {
-    const nudge = this.eventNudge;
-    if (!nudge || this.sensitive || this.hasUnresolvedQuestion()) {
-      return;
-    }
-    this.eventNudgePending = nudge;
-    const outcome = await this.send(nudge.message);
-    if (this.eventNudgePending === nudge) {
-      this.eventNudgePending = null;
-      const consumed = eventNudgeState.shouldConsumeNudge(this.eventNudge, nudge, outcome);
-      [this.eventNudgeClosed, this.eventNudge] = [consumed, consumed ? null : this.eventNudge];
-    }
-  }
-
-  private async dismissQuestion(message: CustodianMessage): Promise<void> {
-    const question = message.question;
-    if (!question) {
-      return;
-    }
-    if (question.skipAction === "exit") {
-      this.exitSetup();
-      return;
-    }
-    // Closed wizard selects accept cancel; open "other" prompts use their visible free-form reply.
-    const outcome = await this.send(
-      question.isOther ? t("optionCard.skip") : "cancel",
-      t("optionCard.skip"),
-      true,
-    );
-    if (outcome !== "rejected" && this.messages.includes(message)) {
-      this.dismissedQuestions = new Set(this.dismissedQuestions).add(
-        `${message.id}:${question.id}`,
-      );
-    }
-  }
-
-  private answerQuestion(message: CustodianMessage, label: string): void {
-    const question = message.question;
-    if (!question) {
-      return;
-    }
-    const option = question.options.find((candidate) => candidate.label === label);
-    // Show the friendly label while sending the canonical reply that the engine parses.
-    void this.send(option?.reply ?? label, label, true);
-  }
-
-  private hasUnresolvedQuestion(): boolean {
-    return hasUnresolvedCustodianQuestion(
-      this.messages,
-      this.dismissedQuestions,
-      this.answeredQuestions,
-      this.wizardInputPending,
-      this.questionReplyUncertain,
-    );
-  }
-
-  private exitSetup(): void {
-    this.context.navigate("chat");
-  }
-
-  private canRetry(): boolean {
-    // Only the welcome request is safely replayable; a user turn has no
-    // idempotency key and may have already acted on the agent side.
-    return this.retryParams !== null && this.retryParams.message === undefined;
-  }
-
-  private retry(): void {
-    const client = this.activeClient;
-    const params = this.retryParams;
-    if (client && params && params.message === undefined && this.chatAvailable && !this.sending) {
-      void this.initializeSession(client, params);
-    }
-  }
-
-  private handleComposerKeydown(event: KeyboardEvent): void {
-    if (event.key !== "Enter" || event.shiftKey || event.isComposing) {
-      return;
-    }
-    event.preventDefault();
-    void this.send();
-  }
-
   override render() {
+    const historyContent =
+      this.historyOpen && this.historyAvailable
+        ? renderCustodianChangeHistory({
+            entries: this.historyEntries,
+            error: this.historyError,
+            loaded: this.historyLoaded,
+            loading: this.historyLoading,
+            loadingMore: this.historyLoadingMore,
+            nextCursor: this.historyNextCursor,
+            onLoad: (reset) => void this.loadHistory(reset),
+          })
+        : nothing;
     return html`
-      <section class="custodian">
-        <header class="custodian__header">
+      <section class="custodian custodian--page">
+        <header class="custodian__header custodian__column">
           <div class="custodian__identity">
-            <div class="custodian__mark" aria-hidden="true">OC</div>
+            <div class="custodian__mark" aria-hidden="true">
+              <openclaw-mascot
+                .mood=${this.store.sending ? "thinking" : "idle"}
+                .size=${38}
+              ></openclaw-mascot>
+            </div>
             <div>
               <h1>${t("custodian.title")}</h1>
               <p>${t(this.onboarding ? "custodian.subtitle" : "custodian.subtitleCaretaker")}</p>
@@ -641,128 +197,24 @@ export class CustodianPage extends OpenClawLightDomElement {
                 </button>`
               : nothing}
             ${this.onboarding
-              ? html`<button class="btn btn--ghost" type="button" @click=${() => this.exitSetup()}>
+              ? html`<button
+                  class="btn btn--ghost"
+                  type="button"
+                  @click=${() => this.store.exitSetup()}
+                >
                   ${t("custodian.exitSetup")}
                 </button>`
               : nothing}
           </div>
         </header>
 
-        <div class="custodian__messages" aria-live="polite">
-          ${!this.onboarding && this.eventNudge && !this.eventNudgePending
-            ? eventNudgeState.renderCustodianEventNudge({
-                nudge: this.eventNudge,
-                disabled:
-                  !this.activeClient ||
-                  !this.chatAvailable ||
-                  this.sending ||
-                  this.sensitive ||
-                  this.hasUnresolvedQuestion(),
-                onSend: () => void this.sendEventNudge(),
-                onDismiss: () => void ([this.eventNudge, this.eventNudgeClosed] = [null, true]),
-              })
-            : nothing}
-          ${this.messages.map((message) => {
-            const questionKey = message.question ? `${message.id}:${message.question.id}` : "";
-            const showQuestion =
-              message.question !== null && !this.dismissedQuestions.has(questionKey);
-            return renderCustodianTranscriptEntry({
-              message,
-              boundaryAfterId: this.earlierBoundaryAfterId,
-              showQuestion,
-              questionDisabled:
-                this.sending || !this.chatAvailable || this.answeredQuestions.has(questionKey),
-              onSelect: (label) => this.answerQuestion(message, label),
-              onSkip: () => void this.dismissQuestion(message),
-            });
-          })}
-          ${this.sending
-            ? html`<div class="chat-group assistant custodian__thinking-row" role="status">
-                ${renderChatAvatar("assistant", { name: t("custodian.title"), avatar: "OC" })}
-                <div class="chat-group-messages custodian__thinking">
-                  <span></span><span></span><span></span>
-                  <span class="sr-only">${t("custodian.thinking")}</span>
-                </div>
-              </div>`
-            : nothing}
-          ${this.abandonedTurnOutcomeUnknown
-            ? html`<div class="custodian__error" role="alert">
-                <span>${t("custodian.connectionChanged")}</span>
-              </div>`
-            : nothing}
-          ${this.error &&
-          !(this.abandonedTurnOutcomeUnknown && this.error === t("custodian.connectionChanged"))
-            ? html`<div class="custodian__error" role="alert">
-                <span>${this.error}</span>
-                ${this.activeClient && this.chatAvailable && this.canRetry()
-                  ? html`<button class="btn btn--sm" type="button" @click=${() => this.retry()}>
-                      ${t("common.retry")}
-                    </button>`
-                  : nothing}
-              </div>`
-            : nothing}
-        </div>
-
-        ${this.historyOpen && this.historyAvailable
-          ? renderCustodianChangeHistory({
-              entries: this.historyEntries,
-              error: this.historyError,
-              loaded: this.historyLoaded,
-              loading: this.historyLoading,
-              loadingMore: this.historyLoadingMore,
-              nextCursor: this.historyNextCursor,
-              onLoad: (reset) => {
-                void this.loadHistory(reset);
-              },
-            })
-          : nothing}
-
-        <div class="agent-chat__composer-shell">
-          <div class="agent-chat__input">
-            <div class="agent-chat__composer-input-row">
-              <div class="agent-chat__composer-combobox">
-                ${this.sensitive
-                  ? html`<input
-                      type="password"
-                      .value=${this.input}
-                      autocomplete="off"
-                      placeholder=${t("custodian.sensitivePlaceholder")}
-                      aria-label=${t("custodian.sensitivePlaceholder")}
-                      ?disabled=${!this.activeClient || !this.chatAvailable || this.sending}
-                      @input=${(event: Event) =>
-                        (this.input = (event.target as HTMLInputElement).value)}
-                      @keydown=${(event: KeyboardEvent) => this.handleComposerKeydown(event)}
-                    />`
-                  : html`<textarea
-                      rows="1"
-                      .value=${this.input}
-                      autocomplete="on"
-                      placeholder=${t("custodian.placeholder")}
-                      aria-label=${t("custodian.placeholder")}
-                      ?disabled=${!this.activeClient || !this.chatAvailable || this.sending}
-                      @input=${(event: Event) =>
-                        (this.input = (event.target as HTMLTextAreaElement).value)}
-                      @keydown=${(event: KeyboardEvent) => this.handleComposerKeydown(event)}
-                    ></textarea>`}
-              </div>
-              <div class="agent-chat__composer-actions">
-                <button
-                  class="chat-send-btn"
-                  type="button"
-                  aria-label=${t("custodian.send")}
-                  ?disabled=${!this.input.trim() ||
-                  !this.activeClient ||
-                  !this.chatAvailable ||
-                  this.sending}
-                  @click=${() => void this.send()}
-                >
-                  ${icons.arrowUp}
-                  <span class="agent-chat__control-label">${t("custodian.send")}</span>
-                </button>
-              </div>
-            </div>
-          </div>
-        </div>
+        <openclaw-custodian-surface
+          class="custodian__column"
+          .store=${this.store}
+          .onboarding=${this.onboarding}
+          .newAgentIntent=${this.newAgentIntent}
+          .historyContent=${historyContent}
+        ></openclaw-custodian-surface>
       </section>
     `;
   }

--- a/ui/src/pages/custodian/custodian-session-store.test.ts
+++ b/ui/src/pages/custodian/custodian-session-store.test.ts
@@ -51,16 +51,6 @@ describe("CustodianSessionStore", () => {
     expect(panelSurfaceUpdates).toHaveBeenCalled();
   });
 
-  it("keeps the explicit panel-close latch until the custodian page is visited", () => {
-    const store = new CustodianSessionStore();
-
-    store.markPanelClosedByUser(true);
-    expect(store.panelClosedByUser).toBe(true);
-
-    store.markCustodianVisited();
-    expect(store.panelClosedByUser).toBe(false);
-  });
-
   it("accepts new event nudges after a conversation variant rotates", async () => {
     const request = vi.fn().mockResolvedValue({
       sessionId: "shared-session",

--- a/ui/src/pages/custodian/custodian-session-store.test.ts
+++ b/ui/src/pages/custodian/custodian-session-store.test.ts
@@ -1,0 +1,94 @@
+/* @vitest-environment jsdom */
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { waitForFast } from "../../test-helpers/wait-for.ts";
+import { createContext } from "./custodian-page.test-harness.ts";
+import { CustodianSessionStore } from "./custodian-session-store.ts";
+
+describe("CustodianSessionStore", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("shares one live session across repeated surface connections", async () => {
+    const request = vi
+      .fn()
+      .mockResolvedValueOnce({
+        sessionId: "shared-session",
+        reply: "Ready.",
+        action: "none",
+      })
+      .mockResolvedValueOnce({
+        sessionId: "shared-session",
+        reply: "Still here.",
+        action: "none",
+      });
+    const { context } = createContext(request);
+    const store = new CustodianSessionStore();
+    const firstSurfaceUpdates = vi.fn();
+    const panelSurfaceUpdates = vi.fn();
+    store.subscribe(firstSurfaceUpdates);
+    store.subscribe(panelSurfaceUpdates);
+
+    store.connect(context, "caretaker");
+    store.connect(context, "caretaker");
+    await waitForFast(() => expect(request).toHaveBeenCalledOnce());
+
+    await store.send("Check this system");
+
+    expect(request).toHaveBeenCalledTimes(2);
+    expect(request.mock.calls[1]?.[1]).toMatchObject({
+      sessionId: "shared-session",
+      message: "Check this system",
+    });
+    expect(store.messages.map((message) => message.text)).toEqual([
+      "Ready.",
+      "Check this system",
+      "Still here.",
+    ]);
+    expect(store.hasRealUserTurn()).toBe(true);
+    expect(firstSurfaceUpdates).toHaveBeenCalled();
+    expect(panelSurfaceUpdates).toHaveBeenCalled();
+  });
+
+  it("keeps the explicit panel-close latch until the custodian page is visited", () => {
+    const store = new CustodianSessionStore();
+
+    store.markPanelClosedByUser(true);
+    expect(store.panelClosedByUser).toBe(true);
+
+    store.markCustodianVisited();
+    expect(store.panelClosedByUser).toBe(false);
+  });
+
+  it("accepts new event nudges after a conversation variant rotates", async () => {
+    const request = vi.fn().mockResolvedValue({
+      sessionId: "shared-session",
+      reply: "Ready.",
+      action: "none",
+    });
+    const { context, emitGatewayEvent } = createContext(request);
+    const store = new CustodianSessionStore();
+    store.connect(context, "caretaker");
+    await waitForFast(() => expect(request).toHaveBeenCalledOnce());
+
+    emitGatewayEvent({
+      event: "health",
+      payload: { configReload: { hotReloadStatus: "disabled" }, channels: {} },
+    });
+    expect(store.eventNudge).not.toBeNull();
+    store.dismissEventNudge();
+    expect(store.eventNudge).toBeNull();
+
+    store.connect(context, "onboarding");
+    await waitForFast(() => expect(request).toHaveBeenCalledTimes(2));
+    store.connect(context, "caretaker");
+    await waitForFast(() => expect(request).toHaveBeenCalledTimes(3));
+    emitGatewayEvent({
+      event: "health",
+      payload: { configReload: { hotReloadStatus: "disabled" }, channels: {} },
+    });
+
+    expect(store.eventNudge).not.toBeNull();
+  });
+});

--- a/ui/src/pages/custodian/custodian-session-store.ts
+++ b/ui/src/pages/custodian/custodian-session-store.ts
@@ -1,0 +1,535 @@
+import type { SystemAgentChatParams, SystemAgentChatResult } from "@openclaw/gateway-protocol";
+import type { GatewayBrowserClient } from "../../api/gateway.ts";
+import { selectApplicationSession } from "../../app/agent-selection.ts";
+import type { ApplicationContext } from "../../app/context.ts";
+import { t } from "../../i18n/index.ts";
+import { isGatewayMethodAdvertised } from "../../lib/gateway-methods.ts";
+import { buildAgentMainSessionKey } from "../../lib/sessions/session-key.ts";
+import { pathForCustodianAgentHandoff } from "./custodian-navigation.ts";
+import * as eventNudgeState from "./event-nudge.ts";
+import {
+  custodianChatParams,
+  isCustodianSessionInvalidatedError,
+  type CustodianSessionVariant,
+} from "./session-lifecycle.ts";
+import { parseCustodianQuestion, type CustodianStructuredQuestion } from "./structured-question.ts";
+import {
+  createCustodianSessionId,
+  createCustodianTranscriptMessages,
+  custodianErrorMessage,
+  hasUnresolvedCustodianQuestion,
+  readCustodianTranscript,
+  retireCustodianQuestions,
+  type CustodianMessage,
+} from "./transcript.ts";
+
+const SYSTEM_AGENT_CHAT_TIMEOUT_MS = 190_000;
+const SILENT_REPLY_PATTERN = /^\s*NO_REPLY\s*$/;
+
+type StoreListener = () => void;
+
+/** One process-local conversation owner shared by the full page and dock surface. */
+export class CustodianSessionStore {
+  messages: CustodianMessage[] = [];
+  input = "";
+  sending = false;
+  sensitive = false;
+  wizardInputPending = false;
+  questionReplyUncertain = false;
+  error: string | null = null;
+  dismissedQuestions = new Set<string>();
+  answeredQuestions = new Set<string>();
+  activeClient: GatewayBrowserClient | null = null;
+  chatAvailable = false;
+  eventNudge: eventNudgeState.CustodianEventNudge | null = null;
+  eventNudgePending: eventNudgeState.CustodianEventNudge | null = null;
+  earlierBoundaryAfterId: number | null = null;
+  abandonedTurnOutcomeUnknown = false;
+  panelClosedByUser = false;
+
+  private context: ApplicationContext | null = null;
+  private variant: CustodianSessionVariant = "caretaker";
+  private sessionVariant: CustodianSessionVariant | null = null;
+  private sessionId = createCustodianSessionId();
+  private requestEpoch = 0;
+  private nextMessageId = 1;
+  private retryParams: SystemAgentChatParams | null = null;
+  private sessionClient: GatewayBrowserClient | null = null;
+  private sessionOwnershipKey: string | null = null;
+  private sessionStarted = false;
+  private lastHelloDeviceToken = "";
+  private eventNudgeClosed = false;
+  private gatewayCleanup: (() => void) | null = null;
+  private eventCleanup: (() => void) | null = null;
+  private readonly listeners = new Set<StoreListener>();
+
+  subscribe(listener: StoreListener): () => void {
+    this.listeners.add(listener);
+    return () => this.listeners.delete(listener);
+  }
+
+  connect(context: ApplicationContext, variant: CustodianSessionVariant): void {
+    const contextChanged = this.context !== context;
+    const variantChanged = this.variant !== variant;
+    if (!contextChanged && !variantChanged) {
+      return;
+    }
+    if (contextChanged) {
+      this.gatewayCleanup?.();
+      this.eventCleanup?.();
+      this.context = context;
+      this.gatewayCleanup = context.gateway.subscribe(() => {
+        this.synchronizeClient();
+        this.emit();
+      });
+      this.eventCleanup = context.gateway.subscribeEvents((event) => {
+        if (this.variant !== "caretaker" || this.eventNudgeClosed) {
+          return;
+        }
+        [this.eventNudge, this.eventNudgePending] = eventNudgeState.reconcileCustodianEventNudge(
+          this.eventNudge,
+          this.eventNudgePending,
+          event,
+        );
+        this.emit();
+      });
+    }
+    this.variant = variant;
+    this.synchronizeClient();
+    this.emit();
+  }
+
+  setInput(value: string): void {
+    this.input = value;
+    this.emit();
+  }
+
+  markPanelClosedByUser(closed: boolean): void {
+    this.panelClosedByUser = closed;
+  }
+
+  markCustodianVisited(): void {
+    this.panelClosedByUser = false;
+  }
+
+  hasRealUserTurn(): boolean {
+    return this.messages.some((message) => message.role === "user");
+  }
+
+  get activeVariant(): CustodianSessionVariant {
+    return this.variant;
+  }
+
+  hasUnresolvedQuestion(): boolean {
+    return hasUnresolvedCustodianQuestion(
+      this.messages,
+      this.dismissedQuestions,
+      this.answeredQuestions,
+      this.wizardInputPending,
+      this.questionReplyUncertain,
+    );
+  }
+
+  canRetry(): boolean {
+    return this.retryParams !== null && this.retryParams.message === undefined;
+  }
+
+  retry(): void {
+    const client = this.activeClient;
+    const params = this.retryParams;
+    if (client && params && params.message === undefined && this.chatAvailable && !this.sending) {
+      void this.initializeSession(client, params);
+    }
+  }
+
+  async send(
+    text = this.input,
+    display?: string,
+    questionReply = this.hasUnresolvedQuestion(),
+  ): Promise<eventNudgeState.CustodianSendOutcome> {
+    // Trim decides emptiness only; sensitive values may carry meaningful whitespace.
+    const message = this.sensitive ? text : text.trim();
+    const client = this.activeClient;
+    const questionState = [this.answeredQuestions, this.questionReplyUncertain] as const;
+    if (questionReply) {
+      this.questionReplyUncertain = true;
+    }
+    if (!message.trim() || !client || !this.chatAvailable || this.sending) {
+      this.emit();
+      return "rejected";
+    }
+    const displayText = this.sensitive ? t("custodian.sensitiveReply") : (display ?? message);
+    this.abandonedTurnOutcomeUnknown = false;
+    this.answeredQuestions = retireCustodianQuestions(this.messages, this.answeredQuestions);
+    this.messages = [
+      ...this.messages,
+      {
+        id: this.nextMessageId++,
+        role: "user",
+        text: displayText,
+        at: Date.now(),
+        question: null,
+      },
+    ];
+    this.input = "";
+    this.emit();
+    const reply = this.requestReply(client, {
+      sessionId: this.sessionId,
+      ...custodianChatParams(this.variant, message),
+    });
+    const replyEpoch = this.requestEpoch;
+    const outcome = await reply;
+    if (questionReply && this.requestEpoch === replyEpoch) {
+      this.questionReplyUncertain = eventNudgeState.questionUncertainty(questionState[1], outcome);
+      if (outcome === "rejected") {
+        this.answeredQuestions = questionState[0];
+      }
+      this.emit();
+    }
+    return outcome;
+  }
+
+  async sendEventNudge(): Promise<void> {
+    const nudge = this.eventNudge;
+    if (!nudge || this.sensitive || this.hasUnresolvedQuestion()) {
+      return;
+    }
+    this.eventNudgePending = nudge;
+    this.emit();
+    const outcome = await this.send(nudge.message);
+    if (this.eventNudgePending === nudge) {
+      this.eventNudgePending = null;
+      const consumed = eventNudgeState.shouldConsumeNudge(this.eventNudge, nudge, outcome);
+      [this.eventNudgeClosed, this.eventNudge] = [consumed, consumed ? null : this.eventNudge];
+      this.emit();
+    }
+  }
+
+  dismissEventNudge(): void {
+    [this.eventNudge, this.eventNudgeClosed] = [null, true];
+    this.emit();
+  }
+
+  async dismissQuestion(message: CustodianMessage): Promise<void> {
+    const question = message.question;
+    if (!question) {
+      return;
+    }
+    if (question.skipAction === "exit") {
+      this.exitSetup();
+      return;
+    }
+    const outcome = await this.send(
+      question.isOther ? t("optionCard.skip") : "cancel",
+      t("optionCard.skip"),
+      true,
+    );
+    if (outcome !== "rejected" && this.messages.includes(message)) {
+      this.dismissedQuestions = new Set(this.dismissedQuestions).add(
+        `${message.id}:${question.id}`,
+      );
+      this.emit();
+    }
+  }
+
+  answerQuestion(message: CustodianMessage, label: string): void {
+    const question = message.question;
+    if (!question) {
+      return;
+    }
+    const option = question.options.find((candidate) => candidate.label === label);
+    void this.send(option?.reply ?? label, label, true);
+  }
+
+  exitSetup(): void {
+    this.context?.navigate("chat");
+  }
+
+  private emit(): void {
+    for (const listener of this.listeners) {
+      listener();
+    }
+  }
+
+  private currentSessionOwnershipKey(): string {
+    const context = this.context;
+    if (!context) {
+      return "";
+    }
+    const { gatewayUrl, token, password, bootstrapToken } = context.gateway.connection;
+    const auth = context.gateway.snapshot.hello?.auth;
+    if (auth) {
+      this.lastHelloDeviceToken = auth.deviceToken ?? "";
+    }
+    return JSON.stringify([gatewayUrl, token, password, bootstrapToken, this.lastHelloDeviceToken]);
+  }
+
+  private startSession(
+    client: GatewayBrowserClient,
+    variant: CustodianSessionVariant,
+    loadTranscript: boolean,
+  ): void {
+    this.sessionId = createCustodianSessionId();
+    this.sessionVariant = variant;
+    this.sessionClient = client;
+    this.sessionOwnershipKey = this.currentSessionOwnershipKey();
+    this.sessionStarted = true;
+    void this.initializeSession(
+      client,
+      { sessionId: this.sessionId, ...custodianChatParams(variant) },
+      loadTranscript,
+    );
+  }
+
+  private abandonPendingUserTurn(pendingParams: SystemAgentChatParams | null): void {
+    if (pendingParams?.message === undefined) {
+      return;
+    }
+    this.retryParams = null;
+    // The gateway may already have acted, so keep the warning without retaining replayable text.
+    this.abandonedTurnOutcomeUnknown = true;
+  }
+
+  private rotateVolatileSession(
+    client: GatewayBrowserClient,
+    variant: CustodianSessionVariant,
+  ): void {
+    this.answeredQuestions = retireCustodianQuestions(this.messages, this.answeredQuestions);
+    this.retryParams = null;
+    this.input = "";
+    this.sensitive = this.wizardInputPending = this.questionReplyUncertain = false;
+    this.error = null;
+    this.earlierBoundaryAfterId = this.messages.at(-1)?.id ?? null;
+    this.startSession(client, variant, false);
+  }
+
+  private synchronizeClient(): void {
+    const context = this.context;
+    if (!context) {
+      return;
+    }
+    const snapshot = context.gateway.snapshot;
+    const client = snapshot.phase === "connected" ? snapshot.client : null;
+    const chatSupported =
+      client !== null && isGatewayMethodAdvertised(snapshot, "openclaw.chat") === true;
+    const variantChanged = this.sessionStarted && this.sessionVariant !== this.variant;
+    const ownershipKey = this.currentSessionOwnershipKey();
+    const clientReplaced =
+      this.sessionStarted &&
+      client !== null &&
+      this.sessionClient !== null &&
+      client !== this.sessionClient;
+    const ownershipChanged =
+      this.sessionOwnershipKey !== null && ownershipKey !== this.sessionOwnershipKey;
+    if (
+      client === this.activeClient &&
+      !variantChanged &&
+      !clientReplaced &&
+      !ownershipChanged &&
+      this.chatAvailable === chatSupported
+    ) {
+      return;
+    }
+    const requestWasPending = this.sending && this.retryParams !== null;
+    const pendingParams = requestWasPending ? this.retryParams : null;
+    this.activeClient = client;
+    this.requestEpoch += 1;
+    this.sending = false;
+    this.chatAvailable = false;
+    if (variantChanged || ownershipChanged) {
+      // A different operator or route mode must never inherit retained live context.
+      [this.eventNudge, this.eventNudgePending] = [null, null];
+      this.eventNudgeClosed = false;
+      this.abandonedTurnOutcomeUnknown = false;
+      this.sessionStarted = false;
+      this.clearConversation();
+    } else if (client && clientReplaced) {
+      if (!chatSupported) {
+        this.sessionStarted = false;
+        this.abandonPendingUserTurn(pendingParams);
+        this.error = t("custodian.unsupportedGateway");
+        return;
+      }
+      this.chatAvailable = true;
+      this.abandonPendingUserTurn(pendingParams);
+      this.rotateVolatileSession(client, this.currentSessionVariant());
+      return;
+    } else if (requestWasPending) {
+      if (pendingParams?.message === undefined) {
+        this.error = t("custodian.connectionChanged");
+      }
+      this.abandonPendingUserTurn(pendingParams);
+    }
+    if (!client) {
+      return;
+    }
+    if (!chatSupported) {
+      this.error = t("custodian.unsupportedGateway");
+      return;
+    }
+    this.chatAvailable = true;
+    if (this.sessionStarted) {
+      if (!this.retryParams) {
+        this.error = requestWasPending ? this.error : null;
+      }
+      return;
+    }
+    this.clearConversation();
+    this.startSession(client, this.currentSessionVariant(), true);
+  }
+
+  private currentSessionVariant(): CustodianSessionVariant {
+    return this.variant;
+  }
+
+  private async initializeSession(
+    client: GatewayBrowserClient,
+    params: SystemAgentChatParams,
+    loadTranscript = true,
+  ): Promise<void> {
+    const epoch = ++this.requestEpoch;
+    this.sending = true;
+    this.error = null;
+    this.retryParams = params;
+    this.emit();
+    if (loadTranscript) {
+      await this.refreshTranscriptHistory(client, epoch);
+    }
+    if (epoch !== this.requestEpoch || client !== this.activeClient) {
+      return;
+    }
+    await this.requestReply(client, params);
+  }
+
+  private async refreshTranscriptHistory(
+    client: GatewayBrowserClient,
+    epoch: number,
+  ): Promise<void> {
+    const context = this.context;
+    if (
+      !context ||
+      isGatewayMethodAdvertised(context.gateway.snapshot, "openclaw.chat.history") !== true
+    ) {
+      return;
+    }
+    const turns = await readCustodianTranscript(client);
+    if (turns === null || epoch !== this.requestEpoch || client !== this.activeClient) {
+      return;
+    }
+    const transcript = createCustodianTranscriptMessages(turns, this.nextMessageId);
+    this.messages = transcript.messages;
+    this.nextMessageId = transcript.nextMessageId;
+    this.earlierBoundaryAfterId = this.messages.at(-1)?.id ?? null;
+    this.emit();
+  }
+
+  private clearConversation(): void {
+    this.messages = [];
+    this.dismissedQuestions = new Set();
+    this.answeredQuestions = new Set();
+    this.retryParams = null;
+    this.error = null;
+    this.input = "";
+    this.sensitive = this.wizardInputPending = this.questionReplyUncertain = false;
+    this.earlierBoundaryAfterId = null;
+  }
+
+  private appendAssistant(reply: string, question: CustodianStructuredQuestion | null): void {
+    this.messages = [
+      ...this.messages,
+      {
+        id: this.nextMessageId++,
+        role: "assistant",
+        text: reply,
+        at: Date.now(),
+        question,
+      },
+    ];
+  }
+
+  private async requestReply(
+    client: GatewayBrowserClient,
+    params: SystemAgentChatParams,
+  ): Promise<eventNudgeState.CustodianSendOutcome> {
+    const context = this.context;
+    if (!context) {
+      return "rejected";
+    }
+    const epoch = ++this.requestEpoch;
+    let delivery: eventNudgeState.CustodianSendDelivery = "unsent";
+    this.sending = true;
+    this.error = null;
+    this.retryParams = params;
+    this.emit();
+    try {
+      const result = await client.request<SystemAgentChatResult>("openclaw.chat", params, {
+        timeoutMs: SYSTEM_AGENT_CHAT_TIMEOUT_MS,
+        onSent: () => (delivery = "sent"),
+      });
+      delivery = "received";
+      if (epoch !== this.requestEpoch || client !== this.activeClient) {
+        return "sent";
+      }
+      this.sessionId = result.sessionId;
+      this.sensitive = result.sensitive === true;
+      this.wizardInputPending = result.wizardInputPending === true;
+      this.retryParams = null;
+      const question = parseCustodianQuestion(result.question);
+      const silentReply = SILENT_REPLY_PATTERN.test(result.reply);
+      if (!silentReply || question) {
+        this.appendAssistant(silentReply ? "" : result.reply, question);
+      }
+      if (result.action === "open-agent") {
+        let sessionKey = context.gateway.snapshot.sessionKey?.trim();
+        if (result.agentId) {
+          const roster = await context.agents.refreshList();
+          if (epoch !== this.requestEpoch || client !== this.activeClient) {
+            return "sent";
+          }
+          sessionKey = buildAgentMainSessionKey({
+            agentId: result.agentId,
+            mainKey: roster?.mainKey,
+          });
+          selectApplicationSession({
+            selection: context.agentSelection,
+            gateway: context.gateway,
+            sessionKey,
+            agentId: result.agentId,
+          });
+        }
+        if (result.agentDraft === "hatch" && sessionKey) {
+          context.navigate("chat", {
+            pathname: pathForCustodianAgentHandoff(context, sessionKey),
+            search: `?draft=${encodeURIComponent(t("custodian.hatchDraft"))}`,
+          });
+        } else {
+          this.exitSetup();
+        }
+      } else if (result.action === "exit") {
+        this.exitSetup();
+      }
+      return "sent";
+    } catch (error) {
+      if (epoch === this.requestEpoch && client === this.activeClient) {
+        this.error = custodianErrorMessage(error);
+        if (params.message !== undefined && isCustodianSessionInvalidatedError(error)) {
+          // Retained transcript rows are display context only; the next turn needs a fresh id.
+          this.rotateVolatileSession(client, this.currentSessionVariant());
+          this.error = t("custodian.sessionRestarted", { error: custodianErrorMessage(error) });
+        }
+      }
+      if (params.message !== undefined && this.retryParams === params) {
+        // User turns have no idempotency key and are never replayed after an ambiguous failure.
+        this.retryParams = null;
+      }
+      return eventNudgeState.classifyCustodianSendFailure(error, delivery);
+    } finally {
+      if (epoch === this.requestEpoch) {
+        this.sending = false;
+      }
+      this.emit();
+    }
+  }
+}
+
+export const custodianSessionStore = new CustodianSessionStore();

--- a/ui/src/pages/custodian/custodian-session-store.ts
+++ b/ui/src/pages/custodian/custodian-session-store.ts
@@ -45,7 +45,6 @@ export class CustodianSessionStore {
   eventNudgePending: eventNudgeState.CustodianEventNudge | null = null;
   earlierBoundaryAfterId: number | null = null;
   abandonedTurnOutcomeUnknown = false;
-  panelClosedByUser = false;
 
   private context: ApplicationContext | null = null;
   private variant: CustodianSessionVariant = "caretaker";
@@ -102,14 +101,6 @@ export class CustodianSessionStore {
   setInput(value: string): void {
     this.input = value;
     this.emit();
-  }
-
-  markPanelClosedByUser(closed: boolean): void {
-    this.panelClosedByUser = closed;
-  }
-
-  markCustodianVisited(): void {
-    this.panelClosedByUser = false;
   }
 
   hasRealUserTurn(): boolean {

--- a/ui/src/pages/custodian/custodian-surface.ts
+++ b/ui/src/pages/custodian/custodian-surface.ts
@@ -1,0 +1,216 @@
+import { consume } from "@lit/context";
+import { html, nothing, type PropertyValues, type TemplateResult } from "lit";
+import { property } from "lit/decorators.js";
+import { applicationContext, type ApplicationContext } from "../../app/context.ts";
+import { controlUiPublicAssetPath } from "../../app/public-assets.ts";
+import { icons } from "../../components/icons.ts";
+import "../../components/openclaw-mascot.ts";
+import { t } from "../../i18n/index.ts";
+import { OpenClawLightDomElement } from "../../lit/openclaw-element.ts";
+import "../../styles/chat/grouped.css";
+import "../../styles/chat/layout.css";
+import "../../styles/chat/text.css";
+import "../../styles/custodian.css";
+import { custodianSessionStore, type CustodianSessionStore } from "./custodian-session-store.ts";
+import * as eventNudgeState from "./event-nudge.ts";
+import { sessionVariant } from "./session-lifecycle.ts";
+import { renderCustodianTranscriptEntry } from "./transcript.ts";
+
+export class CustodianSurface extends OpenClawLightDomElement {
+  @consume({ context: applicationContext, subscribe: true })
+  private context!: ApplicationContext;
+
+  @property({ attribute: false }) store: CustodianSessionStore = custodianSessionStore;
+  @property({ attribute: false }) onboarding = false;
+  @property({ attribute: false }) newAgentIntent = false;
+  @property({ attribute: false }) compact = false;
+  @property({ attribute: false }) historyContent: TemplateResult | typeof nothing = nothing;
+
+  private subscribedStore: CustodianSessionStore | null = null;
+  private storeCleanup: (() => void) | null = null;
+  private lastMessageId: number | null = null;
+
+  override connectedCallback(): void {
+    super.connectedCallback();
+    this.subscribeToStore();
+  }
+
+  override disconnectedCallback(): void {
+    this.storeCleanup?.();
+    this.storeCleanup = null;
+    this.subscribedStore = null;
+    super.disconnectedCallback();
+  }
+
+  protected override async getUpdateComplete(): Promise<boolean> {
+    const complete = await super.getUpdateComplete();
+    await Promise.all(
+      Array.from(
+        this.querySelectorAll<HTMLElement & { updateComplete: Promise<boolean> }>(
+          "openclaw-option-card",
+        ),
+      ).map((card) => card.updateComplete),
+    );
+    return complete;
+  }
+
+  override willUpdate(changedProperties: PropertyValues): void {
+    if (changedProperties.has("store")) {
+      this.subscribeToStore();
+    }
+    this.store.connect(this.context, sessionVariant(this.onboarding, this.newAgentIntent));
+  }
+
+  override updated(): void {
+    const messageId = this.store.messages.at(-1)?.id ?? null;
+    if (messageId !== this.lastMessageId) {
+      this.lastMessageId = messageId;
+      const lastMessage = this.querySelector(".custodian__messages")?.lastElementChild;
+      if (lastMessage instanceof HTMLElement) {
+        lastMessage.scrollIntoView?.({ block: "nearest" });
+      }
+    }
+  }
+
+  private subscribeToStore(): void {
+    if (!this.isConnected || this.subscribedStore === this.store) {
+      return;
+    }
+    this.storeCleanup?.();
+    this.subscribedStore = this.store;
+    this.storeCleanup = this.store.subscribe(() => this.requestUpdate());
+  }
+
+  private handleComposerKeydown(event: KeyboardEvent): void {
+    if (event.key !== "Enter" || event.shiftKey || event.isComposing) {
+      return;
+    }
+    event.preventDefault();
+    void this.store.send();
+  }
+
+  override render() {
+    const store = this.store;
+    const assistantAvatar = controlUiPublicAssetPath("favicon.svg", this.context.basePath);
+    return html`
+      <section class="custodian-surface ${this.compact ? "custodian-surface--panel" : ""}">
+        <div class="custodian__messages" aria-live="polite">
+          ${!this.onboarding && store.eventNudge && !store.eventNudgePending
+            ? eventNudgeState.renderCustodianEventNudge({
+                nudge: store.eventNudge,
+                disabled:
+                  !store.activeClient ||
+                  !store.chatAvailable ||
+                  store.sending ||
+                  store.sensitive ||
+                  store.hasUnresolvedQuestion(),
+                onSend: () => void store.sendEventNudge(),
+                onDismiss: () => store.dismissEventNudge(),
+              })
+            : nothing}
+          ${store.messages.map((message) => {
+            const questionKey = message.question ? `${message.id}:${message.question.id}` : "";
+            const showQuestion =
+              message.question !== null && !store.dismissedQuestions.has(questionKey);
+            return renderCustodianTranscriptEntry({
+              message,
+              boundaryAfterId: store.earlierBoundaryAfterId,
+              assistantAvatar,
+              showQuestion,
+              questionDisabled:
+                store.sending || !store.chatAvailable || store.answeredQuestions.has(questionKey),
+              onSelect: (label) => store.answerQuestion(message, label),
+              onSkip: () => void store.dismissQuestion(message),
+            });
+          })}
+          ${store.sending
+            ? html`<div class="chat-group assistant custodian__thinking-row" role="status">
+                <div class="chat-avatar assistant custodian__mascot-avatar" aria-hidden="true">
+                  <openclaw-mascot mood="thinking" .size=${32}></openclaw-mascot>
+                </div>
+                <div class="chat-group-messages custodian__thinking">
+                  <span></span><span></span><span></span>
+                  <span class="sr-only">${t("custodian.thinking")}</span>
+                </div>
+              </div>`
+            : nothing}
+          ${store.abandonedTurnOutcomeUnknown
+            ? html`<div class="custodian__error" role="alert">
+                <span>${t("custodian.connectionChanged")}</span>
+              </div>`
+            : nothing}
+          ${store.error &&
+          !(store.abandonedTurnOutcomeUnknown && store.error === t("custodian.connectionChanged"))
+            ? html`<div class="custodian__error" role="alert">
+                <span>${store.error}</span>
+                ${store.activeClient && store.chatAvailable && store.canRetry()
+                  ? html`<button class="btn btn--sm" type="button" @click=${() => store.retry()}>
+                      ${t("common.retry")}
+                    </button>`
+                  : nothing}
+              </div>`
+            : nothing}
+        </div>
+
+        ${this.historyContent}
+
+        <div class="agent-chat__composer-shell">
+          <div class="agent-chat__input">
+            <div class="agent-chat__composer-input-row">
+              <div class="agent-chat__composer-combobox">
+                ${store.sensitive
+                  ? html`<input
+                      type="password"
+                      .value=${store.input}
+                      autocomplete="off"
+                      placeholder=${t("custodian.sensitivePlaceholder")}
+                      aria-label=${t("custodian.sensitivePlaceholder")}
+                      ?disabled=${!store.activeClient || !store.chatAvailable || store.sending}
+                      @input=${(event: Event) =>
+                        store.setInput((event.target as HTMLInputElement).value)}
+                      @keydown=${(event: KeyboardEvent) => this.handleComposerKeydown(event)}
+                    />`
+                  : html`<textarea
+                      rows="1"
+                      .value=${store.input}
+                      autocomplete="on"
+                      placeholder=${t("custodian.placeholder")}
+                      aria-label=${t("custodian.placeholder")}
+                      ?disabled=${!store.activeClient || !store.chatAvailable || store.sending}
+                      @input=${(event: Event) =>
+                        store.setInput((event.target as HTMLTextAreaElement).value)}
+                      @keydown=${(event: KeyboardEvent) => this.handleComposerKeydown(event)}
+                    ></textarea>`}
+              </div>
+              <div class="agent-chat__composer-actions">
+                <button
+                  class="chat-send-btn"
+                  type="button"
+                  aria-label=${t("custodian.send")}
+                  ?disabled=${!store.input.trim() ||
+                  !store.activeClient ||
+                  !store.chatAvailable ||
+                  store.sending}
+                  @click=${() => void store.send()}
+                >
+                  ${icons.arrowUp}
+                  <span class="agent-chat__control-label">${t("custodian.send")}</span>
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+    `;
+  }
+}
+
+if (!customElements.get("openclaw-custodian-surface")) {
+  customElements.define("openclaw-custodian-surface", CustodianSurface);
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "openclaw-custodian-surface": CustodianSurface;
+  }
+}

--- a/ui/src/pages/custodian/custodian-surface.ts
+++ b/ui/src/pages/custodian/custodian-surface.ts
@@ -16,7 +16,7 @@ import * as eventNudgeState from "./event-nudge.ts";
 import { sessionVariant } from "./session-lifecycle.ts";
 import { renderCustodianTranscriptEntry } from "./transcript.ts";
 
-export class CustodianSurface extends OpenClawLightDomElement {
+class CustodianSurface extends OpenClawLightDomElement {
   @consume({ context: applicationContext, subscribe: true })
   private context!: ApplicationContext;
 

--- a/ui/src/pages/custodian/transcript.ts
+++ b/ui/src/pages/custodian/transcript.ts
@@ -139,6 +139,7 @@ function renderCustodianEarlierDivider(message: CustodianMessage, boundaryAfterI
 export function renderCustodianTranscriptEntry(params: {
   message: CustodianMessage;
   boundaryAfterId: number | null;
+  assistantAvatar: string;
   showQuestion: boolean;
   questionDisabled: boolean;
   onSelect: (label: string) => void;
@@ -151,7 +152,7 @@ export function renderCustodianTranscriptEntry(params: {
           showReasoning: false,
           showToolCalls: false,
           assistantName: t("custodian.title"),
-          assistantAvatar: "OC",
+          assistantAvatar: params.assistantAvatar,
         })
       : nothing}
     ${renderCustodianEarlierDivider(params.message, params.boundaryAfterId)}

--- a/ui/src/styles/custodian-panel.css
+++ b/ui/src/styles/custodian-panel.css
@@ -1,0 +1,139 @@
+openclaw-custodian-panel {
+  position: fixed;
+  z-index: 60;
+  color: var(--text);
+  font-family: var(--font-sans);
+}
+
+.cp {
+  position: fixed;
+  display: flex;
+  min-width: 0;
+  min-height: 0;
+  flex-direction: column;
+  overflow: hidden;
+  background: var(--bg);
+}
+
+.cp--bottom {
+  right: calc(var(--oc-terminal-reserve-right, 0px) + var(--oc-browser-reserve-right, 0px));
+  bottom: calc(var(--oc-terminal-reserve-bottom, 0px) + var(--oc-browser-reserve-bottom, 0px));
+  left: var(--shell-nav-width, 0);
+  border-top: 1px solid var(--border);
+}
+
+.cp--right {
+  top: var(--shell-topbar-height, 0);
+  right: calc(var(--oc-terminal-reserve-right, 0px) + var(--oc-browser-reserve-right, 0px));
+  bottom: calc(var(--oc-terminal-reserve-bottom, 0px) + var(--oc-browser-reserve-bottom, 0px));
+  border-left: 1px solid var(--border);
+}
+
+.cp-resizer {
+  position: absolute;
+  z-index: 2;
+  background: transparent;
+}
+
+.cp-resizer:hover {
+  background: var(--accent);
+  opacity: 0.5;
+}
+
+.cp-resizer--bottom {
+  top: 0;
+  right: 0;
+  left: 0;
+  height: 5px;
+  cursor: ns-resize;
+}
+
+.cp-resizer--right {
+  top: 0;
+  bottom: 0;
+  left: 0;
+  width: 5px;
+  cursor: ew-resize;
+}
+
+.cp-header {
+  display: flex;
+  min-height: 38px;
+  flex: 0 0 auto;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 0 6px 0 8px;
+  border-bottom: 1px solid var(--border);
+}
+
+.cp-title,
+.cp-actions {
+  display: flex;
+  align-items: center;
+}
+
+.cp-title {
+  min-width: 0;
+  gap: 7px;
+  color: var(--text-strong);
+  font-size: 12px;
+}
+
+.cp-actions {
+  gap: 2px;
+}
+
+.cp-icon {
+  display: inline-flex;
+  width: 28px;
+  height: 28px;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  border: 0;
+  border-radius: 6px;
+  background: transparent;
+  color: var(--muted);
+}
+
+.cp-icon:hover {
+  background: var(--bg-hover);
+  color: var(--text);
+}
+
+.cp-icon svg {
+  width: 15px;
+  height: 15px;
+}
+
+.cp > openclaw-custodian-surface {
+  display: flex;
+  min-height: 0;
+  flex: 1 1 0;
+}
+
+.cp .custodian-surface {
+  width: 100%;
+  min-height: 0;
+  padding: 0 12px 12px;
+}
+
+.cp .custodian__messages {
+  padding-block: 16px;
+}
+
+.cp .custodian__option-card {
+  margin-right: 0;
+  margin-left: 42px;
+}
+
+@media (max-width: 600px) {
+  .cp--right {
+    top: var(--shell-topbar-height, 0);
+    right: 0;
+    bottom: 0;
+    left: 0;
+    width: auto !important;
+  }
+}

--- a/ui/src/styles/custodian.css
+++ b/ui/src/styles/custodian.css
@@ -1,11 +1,29 @@
 .custodian {
   display: grid;
-  grid-template-rows: auto minmax(0, 1fr) auto auto;
-  width: min(860px, 100%);
+  grid-template-rows: auto minmax(0, 1fr);
+  width: 100%;
   height: 100%;
   min-height: 0;
-  margin: 0 auto;
   padding: 18px clamp(16px, 4vw, 36px) 22px;
+}
+
+.custodian__column {
+  width: min(100%, var(--chat-thread-max-width, 48rem));
+  min-width: 0;
+  margin-inline: auto;
+}
+
+.custodian-surface {
+  display: grid;
+  grid-template-rows: minmax(0, 1fr) auto auto;
+  width: 100%;
+  height: 100%;
+  min-height: 0;
+}
+
+.custodian > openclaw-custodian-surface {
+  display: block;
+  height: 100%;
 }
 
 .custodian__header {
@@ -50,14 +68,12 @@
   display: grid;
   width: 38px;
   height: 38px;
+  flex: 0 0 38px;
   place-items: center;
-  border: 1px solid color-mix(in srgb, var(--accent) 60%, var(--border));
-  border-radius: 14px;
-  background: var(--accent-subtle);
-  color: var(--accent);
-  font-size: 11px;
-  font-weight: 800;
-  letter-spacing: -0.04em;
+}
+
+.custodian__mark openclaw-mascot {
+  display: block;
 }
 
 .custodian__messages {
@@ -73,7 +89,7 @@
   align-items: center;
   align-self: flex-start;
   gap: 4px;
-  max-width: min(680px, 96%);
+  max-width: 96%;
   padding: 4px 5px 4px 12px;
   border: 1px solid color-mix(in srgb, var(--warn) 42%, var(--border));
   border-radius: var(--radius-full);
@@ -135,6 +151,21 @@
   gap: 5px;
   width: fit-content;
   padding: 10px 0;
+}
+
+.custodian__mascot-avatar {
+  overflow: visible;
+  background: transparent;
+}
+
+.custodian__mascot-avatar openclaw-mascot {
+  display: block;
+}
+
+.custodian-surface > .agent-chat__composer-shell {
+  width: 100%;
+  max-width: none;
+  margin: 8px 0 0;
 }
 
 .custodian__thinking > span:not(.sr-only) {

--- a/ui/src/styles/layout.css
+++ b/ui/src/styles/layout.css
@@ -219,6 +219,10 @@ html.openclaw-native-web-chrome .shell-chrome-controls {
   padding: 44px clamp(28px, 5vw, 72px) 72px;
 }
 
+.shell--settings:not(.shell--mobile-nav) .content--custodian {
+  padding: 0;
+}
+
 .shell--settings:not(.shell--mobile-nav) .content-header {
   max-height: none;
 }
@@ -3560,9 +3564,13 @@ wa-dropdown.sidebar-identity-menu::part(menu) {
      reshape the content area (shrink it) instead of overlaying the chat. The
      panels set these vars; they are 0 when closed. */
   margin-bottom: calc(
-    var(--oc-terminal-reserve-bottom, 0px) + var(--oc-browser-reserve-bottom, 0px)
+    var(--oc-terminal-reserve-bottom, 0px) + var(--oc-browser-reserve-bottom, 0px) +
+      var(--oc-custodian-reserve-bottom, 0px)
   );
-  margin-right: calc(var(--oc-terminal-reserve-right, 0px) + var(--oc-browser-reserve-right, 0px));
+  margin-right: calc(
+    var(--oc-terminal-reserve-right, 0px) + var(--oc-browser-reserve-right, 0px) +
+      var(--oc-custodian-reserve-right, 0px)
+  );
   transition:
     margin-bottom 0.16s ease,
     margin-right 0.16s ease;
@@ -3592,6 +3600,24 @@ wa-dropdown.sidebar-identity-menu::part(menu) {
 }
 
 .content--chat > openclaw-router-outlet {
+  display: flex;
+  flex: 1 1 0;
+  min-width: 0;
+  min-height: 0;
+}
+
+.content--custodian {
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  padding: 0;
+}
+
+.content--custodian > * + * {
+  margin-top: 0;
+}
+
+.content--custodian > openclaw-router-outlet {
   display: flex;
   flex: 1 1 0;
   min-width: 0;


### PR DESCRIPTION
### What Problem This Solves
The Settings > Ask OpenClaw chat rendered a hardcoded "OC" text avatar, its transcript column (860px) and composer (48rem) were misaligned, and the conversation was trapped inside the settings page — navigating anywhere else abandoned it.

### Why This Change Was Made
Three coherent moves: (1) real OpenClaw artwork — the animated `<openclaw-mascot>` in the header/thinking row (mood `thinking` while a turn is in flight) and the lobster mark on transcript avatars; (2) one centered column driven by `--chat-thread-max-width`, with a dedicated `content--custodian` shell layout replacing the competing settings/chat rules; (3) the chat guts extracted into a module-scoped `CustodianSessionStore` plus reusable `<openclaw-custodian-surface>`, hosted by both the settings page and a new dockable panel (right/bottom, persisted layout, same dock reserve system as the terminal/browser panels). Leaving `/custodian` mid-conversation auto-minimizes the chat into the dock; a lobster toggle joins the workspace rail. The mock dev harness gained `openclaw.chat`/history/changes support so the whole flow is demoable via `pnpm dev:ui:mock`.

### User Impact
Ask OpenClaw looks like OpenClaw and follows you: the same live session renders full-page in Settings or as a dock on any page, with page-context (#114943) resolving "this page" references wherever you are. All existing behavior preserved: session ownership rotation, durable history + "Earlier" divider, question cards, sensitive input masking, hatch/exit handoffs, event nudges.

### Evidence
Before/after and flow captures:
![page](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/custodian-dock-2026-07/01-page-history.png)
![thinking](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/custodian-dock-2026-07/02-thinking.png)
![question](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/custodian-dock-2026-07/03-channel-question.png)
![docked](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/custodian-dock-2026-07/04-docked-conversation.png)
Video: https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/custodian-dock-2026-07/dock-flow.webm
- Focused tests: 74/74 across `ui/src/pages/custodian` and `ui/src/components/custodian`; the broader post-rebase proof also passed 72/72 across custodian, app-host, dock suppression, and workspace rail tests.
- i18n: `pnpm ui:i18n:verify` passes with 4,139 English source keys. The strict generated-catalog check reports expected source-only drift and is advisory here; the post-merge locale refresh workflow owns non-English catalog generation. The source-owned raw-copy baseline records the removed `OC` copy and new `custodian panel` label.
- Live verification via `pnpm dev:ui:mock`: welcome + durable history + divider, thinking mascot, channel question cards, minimize-into-dock on route leave.
- Autoreview (Codex gpt-5.6-sol, high): the code stack was clean; a later chunk raised a variant-contention concern that was rejected after verifying the dock derives its variant from `store.activeVariant` and is suppressed on the full-page route.
- Rebased head proof: #114943 page-context coverage passes; `git diff --check` passes; the i18n diff contains only `ui/src/i18n/locales/en.ts` and the source-owned `ui/src/i18n/.i18n/raw-copy-baseline.json`.
