### PR TITLE
fix(sessions): deliver generated images in agent announcements [AI-assisted]

### DIFF
--- a/src/agents/tools/sessions-send-tool.a2a.test.ts
+++ b/src/agents/tools/sessions-send-tool.a2a.test.ts
@@ -138,6 +138,45 @@ describe("runSessionsSendA2AFlow announce delivery", () => {
     expect(sendParams.message).toBe("Substantive channel reply");
   });
 
+  it.each([
+    {
+      name: "generated media",
+      reply: "Your image is ready.\nMEDIA:./generated.png",
+      expected: {
+        message: "Your image is ready.",
+        mediaUrls: ["./generated.png"],
+        agentId: "orion",
+      },
+    },
+    {
+      name: "a generated voice note",
+      reply: "Your voice note is ready.\nMEDIA:./generated.ogg\n[[audio_as_voice]]",
+      expected: {
+        message: "Your voice note is ready.",
+        mediaUrls: ["./generated.ogg"],
+        agentId: "orion",
+        asVoice: true,
+      },
+    },
+  ])("projects $name into the gateway announcement contract", async ({ reply, expected }) => {
+    vi.mocked(runAgentStep).mockResolvedValueOnce(reply);
+
+    await runSessionsSendA2AFlow({
+      targetSessionKey: "agent:orion:discord:channel:target-room",
+      displayKey: "agent:orion:discord:channel:target-room",
+      message: "Generate the requested media.",
+      announceTimeoutMs: 10_000,
+      maxPingPongTurns: 0,
+      requesterSessionKey: "agent:main:discord:channel:requester-room",
+      requesterChannel: "discord",
+      roundOneReply: "The target agent completed.",
+    });
+
+    const sendParams = requireGatewayCall("send").params as Record<string, unknown>;
+    expect(sendParams).toMatchObject(expected);
+    expect(sendParams).not.toHaveProperty("sessionKey");
+  });
+
   it("bypasses the announce decider for delayed same-session channel replies", async () => {
     vi.mocked(readLatestAssistantReplySnapshot).mockResolvedValueOnce({
       text: "Delayed channel reply",

--- a/src/agents/tools/sessions-send-tool.a2a.ts
+++ b/src/agents/tools/sessions-send-tool.a2a.ts
@@ -7,6 +7,8 @@ import crypto from "node:crypto";
 import type { CallGatewayOptions } from "../../gateway/call.js";
 import { formatErrorMessage } from "../../infra/errors.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
+import { splitMediaFromOutput } from "../../media/parse.js";
+import { parseAgentSessionKey } from "../../sessions/session-key-utils.js";
 import { resolveNestedAgentLaneForSession } from "../lanes.js";
 import {
   type AgentWaitResult,
@@ -53,17 +55,28 @@ async function deliverAnnounceReply(params: {
   announceTarget: AnnounceTarget;
   message: string;
   runContextId: string;
+  targetSessionKey: string;
 }) {
-  const message = params.message.trim();
-  if (!message) {
+  // Gateway chooses media roots before its later outbound directive parse, so
+  // project the media and its producing agent at the announcement boundary.
+  const { text: message, mediaUrls, audioAsVoice } = splitMediaFromOutput(
+    params.message.trim(),
+  );
+  if (!message && !mediaUrls?.length) {
     return;
   }
+  const mediaAgentId = mediaUrls?.length
+    ? parseAgentSessionKey(params.targetSessionKey)?.agentId
+    : undefined;
   try {
     await sessionsSendA2ADeps.callGateway({
       method: "send",
       params: {
         to: params.announceTarget.to,
         message,
+        ...(mediaUrls?.length ? { mediaUrls } : {}),
+        ...(mediaAgentId ? { agentId: mediaAgentId } : {}),
+        ...(audioAsVoice ? { asVoice: true } : {}),
         channel: params.announceTarget.channel,
         accountId: params.announceTarget.accountId,
         threadId: params.announceTarget.threadId,
@@ -167,6 +180,7 @@ export async function runSessionsSendA2AFlow(params: {
         announceTarget,
         message: latestReply,
         runContextId,
+        targetSessionKey: params.targetSessionKey,
       });
       return;
     }
@@ -247,6 +261,7 @@ export async function runSessionsSendA2AFlow(params: {
         announceTarget,
         message: announceReply,
         runContextId,
+        targetSessionKey: params.targetSessionKey,
       });
     }
   } catch (err) {

--- a/src/agents/tools/sessions-send-tool.a2a.ts
+++ b/src/agents/tools/sessions-send-tool.a2a.ts
@@ -59,9 +59,7 @@ async function deliverAnnounceReply(params: {
 }) {
   // Gateway chooses media roots before its later outbound directive parse, so
   // project the media and its producing agent at the announcement boundary.
-  const { text: message, mediaUrls, audioAsVoice } = splitMediaFromOutput(
-    params.message.trim(),
-  );
+  const { text: message, mediaUrls, audioAsVoice } = splitMediaFromOutput(params.message.trim());
   if (!message && !mediaUrls?.length) {
     return;
   }


### PR DESCRIPTION
Closes #112309

## What Problem This Solves

Fixes an issue where generated media from a non-default target agent could be omitted from a `sessions_send` announcement because the announcement reached Gateway delivery without the producing agent's media scope. Voice-note intent was also lost on the same handoff.

## Why This Change Was Made

The announcement owner now projects the canonical media parser result into Gateway's existing structured `mediaUrls`, `agentId`, and `asVoice` fields before Gateway selects media roots. This keeps one channel-generic delivery path, leaves text-only announcements unchanged, and avoids changing transcript routing by not passing a session key.

The latest ClawSweeper rank-up move is applied: `audioAsVoice` is forwarded as Gateway `asVoice` and covered by a focused announcement regression.

## User Impact

Generated images and voice notes from agent workspaces can accompany agent announcements instead of silently degrading to raw directive text or being rejected against the default agent's media roots.

## Evidence

- Before the production change, `OPENCLAW_HEAVY_CHECK_LOCK_SCOPE=worktree node scripts/run-vitest.mjs src/agents/tools/sessions-send-tool.a2a.test.ts` failed 2 of 26 tests: both new cases received raw `MEDIA:` text, with no `mediaUrls`, producer `agentId`, or `asVoice`.
- With the final change, the same command passes 26 of 26 tests.
- `OPENCLAW_HEAVY_CHECK_LOCK_SCOPE=worktree node scripts/run-vitest.mjs src/media/parse.test.ts` passes 108 of 108 tests.
- `OPENCLAW_HEAVY_CHECK_LOCK_SCOPE=worktree node scripts/run-vitest.mjs src/gateway/server-methods/send.test.ts` passes 106 of 106 tests.
- Codex-backed autoreview is clean with no accepted/actionable findings; TruffleHog is clean.
- Production LOC: +15/-2. Tests: +39/-0. The production growth is required at the sessions announcement ownership boundary so media is paired with its producing agent before Gateway media-root authorization.

- Rebased head: `e739df1864b15ccf03db27503a8b14b98421cffb`.
- The former exact-head `check-lint` failure was `oxfmt --check` on `src/agents/tools/sessions-send-tool.a2a.ts`; the file is now formatted without a suppression.
- `OPENCLAW_HEAVY_CHECK_LOCK_SCOPE=worktree node scripts/check-changed.mjs -- src/agents/tools/sessions-send-tool.a2a.ts src/agents/tools/sessions-send-tool.a2a.test.ts` passed on Blacksmith Testbox `tbx_01kzm67t4ez8pfyp0tva5tfcxg` / https://github.com/openclaw/openclaw/actions/runs/31336477707. The dependency pin guard checked 623 declarations with 0 violations; oxfmt matched both files; core/core-test typechecks, oxlint (0 warnings/errors), and repository guards passed.
- Fresh rebased-head Codex-backed autoreview is clean with no accepted/actionable findings; TruffleHog is clean.
- Exact-head CI https://github.com/openclaw/openclaw/actions/runs/31337028363 is green after one failed-job rerun. The first attempt's unrelated `src/infra/device-identity.test.ts` concurrent-creator fixture hit `ERR_SQLITE_ERROR: database disk image is malformed`; the rerun passed. `check-lint` passed on the first attempt.

AI-assisted; reporter credit: @lockhartheavyindustries.



