### PR TITLE
fix(msteams): display readable filenames for URL-hosted attachments [AI-assisted]

### DIFF
--- a/extensions/msteams/src/media-helpers.test.ts
+++ b/extensions/msteams/src/media-helpers.test.ts
@@ -102,6 +102,17 @@ describe("msteams media-helpers", () => {
       expect(await extractFilename("https://example.com/images/2024/photo.png")).toBe("photo.png");
     });
 
+    it.each([
+      ["https://example.com/files/My%20report.pdf", "My report.pdf"],
+      ["https://example.com/files/r%C3%A9sum%C3%A9.pdf", "résumé.pdf"],
+      ["https://example.com/files/100%25.png", "100%.png"],
+      ["https://example.com/files/bad%ZZ.pdf", "bad%ZZ.pdf"],
+      ["https://example.com/files/folder%2Fsecret.png", "folder%2Fsecret.png"],
+      ["https://example.com/files/folder%5Csecret.png", "folder%5Csecret.png"],
+    ])("preserves the safe display filename from %s", async (url, expected) => {
+      expect(await extractFilename(url)).toBe(expected);
+    });
+
     it("handles URLs without extension by deriving from MIME", async () => {
       // Now defaults to application/octet-stream → .bin fallback
       expect(await extractFilename("https://example.com/images/photo")).toBe("photo.bin");

--- a/extensions/msteams/src/media-helpers.ts
+++ b/extensions/msteams/src/media-helpers.ts
@@ -45,8 +45,24 @@ export async function extractFilename(url: string): Promise<string> {
   // Try to extract from URL pathname
   try {
     const pathname = new URL(url).pathname;
-    const basename = path.basename(pathname);
-    const existingExt = getFileExtension(pathname);
+    let basename = path.basename(pathname);
+    if (basename.includes("%")) {
+      try {
+        const decodedBasename = decodeURIComponent(basename);
+        // Attachment names are display values; never turn escaped delimiters
+        // into a different filesystem or URL path.
+        if (
+          !decodedBasename.includes("/") &&
+          !decodedBasename.includes("\\") &&
+          !decodedBasename.includes("\0")
+        ) {
+          basename = decodedBasename;
+        }
+      } catch {
+        // Keep malformed percent escapes as the original literal filename.
+      }
+    }
+    const existingExt = getFileExtension(basename);
     if (basename && existingExt) {
       return basename;
     }

--- a/extensions/msteams/src/messenger.test.ts
+++ b/extensions/msteams/src/messenger.test.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import { SILENT_REPLY_TOKEN } from "openclaw/plugin-sdk/reply-chunking";
 import type { PluginRuntime } from "openclaw/plugin-sdk/runtime-store";
 import { resolvePreferredOpenClawTmpDir } from "openclaw/plugin-sdk/temp-path";
+import { withServer } from "openclaw/plugin-sdk/test-env";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { StoredConversationReference } from "./conversation-store.js";
 const graphUploadMockState = vi.hoisted(() => ({
@@ -760,6 +761,56 @@ describe("msteams messenger", () => {
       expect(requireAiGeneratedEntity(activity.entities).additionalType).toEqual([
         "AIGeneratedContent",
       ]);
+    });
+
+    it("sends decoded attachment filenames over the Bot Framework HTTP transport", async () => {
+      const receivedAttachments: Array<{ name: string; contentUrl: string }> = [];
+
+      await withServer(
+        (request, response) => {
+          const chunks: Buffer[] = [];
+          request.on("data", (chunk: Buffer) => chunks.push(Buffer.from(chunk)));
+          request.on("end", () => {
+            const activity = JSON.parse(Buffer.concat(chunks).toString("utf8")) as {
+              attachments?: Array<{ name: string; contentUrl: string }>;
+            };
+            receivedAttachments.push(
+              ...(activity.attachments ?? []).map(({ name, contentUrl }) => ({ name, contentUrl })),
+            );
+            response.writeHead(200, { "content-type": "application/json" });
+            response.end(JSON.stringify({ id: `message-${receivedAttachments.length}` }));
+          });
+        },
+        async (baseUrl) => {
+          const app = createMockApp({
+            createFn: async (activity) => {
+              const response = await fetch(`${baseUrl}/v3/conversations/test/activities`, {
+                method: "POST",
+                headers: { "content-type": "application/json" },
+                body: JSON.stringify(activity),
+              });
+              return await response.json();
+            },
+          });
+          const encodedNames = ["My%20report.pdf", "r%C3%A9sum%C3%A9.pdf", "100%25.png"];
+
+          await sendMSTeamsMessages({
+            replyStyle: "top-level",
+            app,
+            appId: "app123",
+            conversationRef: baseRef,
+            messages: encodedNames.map((name) => ({
+              mediaUrl: `${baseUrl}/files/${name}`,
+            })),
+          });
+
+          expect(receivedAttachments).toEqual([
+            { name: "My report.pdf", contentUrl: `${baseUrl}/files/My%20report.pdf` },
+            { name: "résumé.pdf", contentUrl: `${baseUrl}/files/r%C3%A9sum%C3%A9.pdf` },
+            { name: "100%.png", contentUrl: `${baseUrl}/files/100%25.png` },
+          ]);
+        },
+      );
     });
 
     it("preserves mention entities alongside AI entity", async () => {


### PR DESCRIPTION
Closes #115124

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where Microsoft Teams users sending URL-hosted files or images would see percent-encoded attachment names instead of the original readable filename. URLs containing spaces, non-ASCII characters, or literal percent signs appeared in Teams as `My%20report.pdf`, `r%C3%A9sum%C3%A9.pdf`, or `100%25.png`.

## Why This Change Was Made

Decode only the Teams-private display basename before building the existing Bot Framework attachment. Keep the encoded `contentUrl` unchanged, preserve malformed percent escapes, and refuse decoded path separators or NUL bytes. No channel contract, credentials, configuration, dependencies, provider, or plugin SDK is changed.

## User Impact

Teams attachment and file-card names now display `My report.pdf`, `résumé.pdf`, and `100%.png` while the original content URL and existing media routing remain unchanged.

## Evidence

Production-path before/after proof uses the actual `sendMSTeamsMessages` entry point and real `fetch` to post Bot Framework activity JSON to a localhost HTTP server.

Before:

```text
name: "My%20report.pdf"
name: "r%C3%A9sum%C3%A9.pdf"
name: "100%25.png"

Test Files  2 failed (2)
Tests       4 failed | 74 passed (78)
```

After:

```text
name: "My report.pdf"
name: "résumé.pdf"
name: "100%.png"

Focused:    2 passed (2); 78 passed (78)
Full Teams: 79 passed (79); 1,193 passed (1,193)
```

Validation on hosted Ubuntu:

- `pnpm test extensions/msteams/src/media-helpers.test.ts extensions/msteams/src/messenger.test.ts`
- `pnpm test extensions/msteams`
- `pnpm check:changed -- extensions/msteams/src/media-helpers.ts extensions/msteams/src/media-helpers.test.ts extensions/msteams/src/messenger.test.ts` — formatting, both extension TypeScript lanes, lint, plugin-boundary, dependency, database, media, and runtime-cycle checks passed.
- `git diff --cached --check` — passed before commit.
- `.agents/skills/autoreview/scripts/autoreview --mode commit --commit HEAD --thinking xhigh` — clean; TruffleHog clean; no actionable findings.
- Hosted run: https://github.com/openclaw/openclaw/actions/runs/30346577637.
- Official Microsoft contract: [Teams send and receive files](https://learn.microsoft.com/en-us/microsoftteams/platform/bots/how-to/bots-filesv4#message-activity-with-file-attachment-example), [Microsoft Graph chatMessageAttachment](https://learn.microsoft.com/en-us/graph/api/resources/chatmessageattachment?view=graph-rest-1.0).
- AI-assisted; independently reproduced, reviewed, and validated against real localhost HTTP.
