### PR TITLE
perf(ui): flip sessions instantly and drop redundant switch RPCs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,7 +51,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- **Control UI session switching:** flip sidebar-selected sessions immediately without blocking on full-list resolution, reuse same-agent metadata and avatars, and overlap transcript subscription handoff to avoid redundant switch requests and blank flashes.
 - **Codex native controls:** stop misclassifying valid thinking/fast runtime controls as provider overrides so Codex routes keep their native controls, while provider-native objects and invalid values stay fail-closed. Thanks @VACInc. (#107588)
 - **State snapshot verification:** run SQLite snapshot verification in a separate process so worker-thread file closes no longer drop the Gateway's POSIX WAL locks, eliminating spurious WAL misses and I/O errors. Thanks @VACInc. (#114016)
 - **Reply latency with model policies:** reuse one immutable plugin-metadata snapshot per model-selection run instead of repeating plugin discovery, cutting reply delay when a model policy is configured. Thanks @VACInc. (#114117)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Control UI session switching:** flip sidebar-selected sessions immediately without blocking on full-list resolution, reuse same-agent metadata and avatars, and overlap transcript subscription handoff to avoid redundant switch requests and blank flashes.
 - **Codex native controls:** stop misclassifying valid thinking/fast runtime controls as provider overrides so Codex routes keep their native controls, while provider-native objects and invalid values stay fail-closed. Thanks @VACInc. (#107588)
 - **State snapshot verification:** run SQLite snapshot verification in a separate process so worker-thread file closes no longer drop the Gateway's POSIX WAL locks, eliminating spurious WAL misses and I/O errors. Thanks @VACInc. (#114016)
 - **Reply latency with model policies:** reuse one immutable plugin-metadata snapshot per model-selection run instead of repeating plugin discovery, cutting reply delay when a model policy is configured. Thanks @VACInc. (#114117)

--- a/ui/src/app/assistant-identity.ts
+++ b/ui/src/app/assistant-identity.ts
@@ -13,6 +13,16 @@ type PersistedLocalAssistantIdentities = {
   agentId?: unknown;
 };
 
+type AssistantIdentityCacheEntry =
+  | { kind: "result"; result: AssistantIdentity | null; cachedAt: number }
+  | { kind: "pending"; pending: Promise<AssistantIdentity | null> };
+
+const ASSISTANT_IDENTITY_CACHE_TTL_MS = 60_000;
+const assistantIdentityCache = new WeakMap<
+  GatewayBrowserClient,
+  Map<string, AssistantIdentityCacheEntry>
+>();
+
 function parseLocalAssistantAvatarMap(raw: string): {
   avatars: Record<string, string>;
   legacyAvatar: string | null;
@@ -69,26 +79,66 @@ export function loadLocalAssistantIdentity(opts?: {
   }
 }
 
-export async function fetchAssistantIdentity(
-  client: GatewayBrowserClient,
-  sessionKey?: string,
-): Promise<AssistantIdentity | null> {
-  const result = await client.request<Partial<AssistantIdentity>>(
-    "agent.identity.get",
-    sessionKey?.trim() ? { sessionKey: sessionKey.trim() } : {},
-  );
-  if (!result) {
-    return null;
+export function invalidateAssistantIdentityCache(client: GatewayBrowserClient | null): void {
+  if (client) {
+    assistantIdentityCache.delete(client);
   }
-  const identity = normalizeAssistantIdentity(result);
-  const localAvatar = loadLocalAssistantIdentity({ agentId: identity.agentId }).avatar;
-  return localAvatar
-    ? {
-        ...identity,
-        avatar: localAvatar,
-        avatarSource: localAvatar,
-        avatarStatus: "data",
-        avatarReason: null,
+}
+
+export function fetchAssistantIdentity(
+  client: GatewayBrowserClient,
+  agentId: string,
+): Promise<AssistantIdentity | null> {
+  let cache = assistantIdentityCache.get(client);
+  if (!cache) {
+    cache = new Map();
+    assistantIdentityCache.set(client, cache);
+  }
+  const key = agentId.trim();
+  const cached = cache.get(key);
+  if (cached?.kind === "result" && Date.now() - cached.cachedAt < ASSISTANT_IDENTITY_CACHE_TTL_MS) {
+    return Promise.resolve(cached.result);
+  }
+  if (cached?.kind === "result") {
+    cache.delete(key);
+  }
+  if (cached?.kind === "pending") {
+    return cached.pending;
+  }
+  const pending = client
+    .request<Partial<AssistantIdentity> | null>("agent.identity.get", { agentId: key })
+    .then((result) => {
+      if (!result) {
+        return null;
       }
-    : identity;
+      const identity = normalizeAssistantIdentity(result);
+      const localAvatar = loadLocalAssistantIdentity({ agentId: identity.agentId }).avatar;
+      return localAvatar
+        ? {
+            ...identity,
+            avatar: localAvatar,
+            avatarSource: localAvatar,
+            avatarStatus: "data" as const,
+            avatarReason: null,
+          }
+        : identity;
+    })
+    .then(
+      (result) => {
+        const current = cache.get(key);
+        if (current?.kind === "pending" && current.pending === pending) {
+          cache.set(key, { kind: "result", result, cachedAt: Date.now() });
+        }
+        return result;
+      },
+      (error: unknown) => {
+        const current = cache.get(key);
+        if (current?.kind === "pending" && current.pending === pending) {
+          cache.delete(key);
+        }
+        throw error;
+      },
+    );
+  cache.set(key, { kind: "pending", pending });
+  return pending;
 }

--- a/ui/src/components/app-sidebar-base.ts
+++ b/ui/src/components/app-sidebar-base.ts
@@ -11,6 +11,8 @@ import {
 } from "../app/context.ts";
 import type { CatalogOpenTarget } from "../app/settings.ts";
 import type { ThemeMode } from "../app/theme.ts";
+import { prepareSessionNavigationHandoff } from "../lib/sessions/navigation-handoff.ts";
+import { SESSION_NAVIGATION_KEY_PARAM } from "../lib/sessions/route-navigation.ts";
 import { parseAgentSessionKey } from "../lib/sessions/session-key.ts";
 import { OpenClawLightDomContentsElement } from "../lit/openclaw-element.ts";
 import type { NewSessionTarget } from "../pages/new-session/location.ts";
@@ -73,5 +75,21 @@ export abstract class AppSidebarBase extends OpenClawLightDomContentsElement {
       sessionKey,
       agentId: parseAgentSessionKey(sessionKey)?.agentId ?? fallbackAgentId,
     });
+  }
+
+  prepareSessionNavigation(sessionKey: string, pathname: string): void {
+    if (this.context) {
+      prepareSessionNavigationHandoff(this.context.gateway, pathname, sessionKey);
+    }
+  }
+
+  protected bindLiteralSession(
+    sessionKey: string,
+    fallbackAgentId: string,
+    options: ApplicationNavigationOptions,
+  ): void {
+    if (!new URLSearchParams(options.search ?? "").has(SESSION_NAVIGATION_KEY_PARAM)) {
+      this.setApplicationSession(sessionKey, fallbackAgentId);
+    }
   }
 }

--- a/ui/src/components/app-sidebar-session-navigation.ts
+++ b/ui/src/components/app-sidebar-session-navigation.ts
@@ -294,9 +294,11 @@ export class AppSidebarSessionNavigationElement extends AppSidebarBase {
       row: this.findSidebarSessionByKey(sessionKey),
       mainKey: this.sessionMainKey(),
       preferenceDerivedFace: true,
+      navigationKey: sessionKey,
     });
-    this.setApplicationSession(sessionKey, this.selectedAgentIdForSessions());
+    this.prepareSessionNavigation(sessionKey, target.options.pathname);
     this.onNavigate?.(face, target.options);
+    this.bindLiteralSession(sessionKey, this.selectedAgentIdForSessions(), target.options);
   };
 
   /** Collapsed zones keep full rows for true header counts and status dots. */

--- a/ui/src/e2e/chat-composer-redesign.e2e.test.ts
+++ b/ui/src/e2e/chat-composer-redesign.e2e.test.ts
@@ -761,8 +761,9 @@ describeControlUiE2e("Control UI chat composer redesign", () => {
         .toContain("GPT-5.5");
       expect(await gateway.getRequests("chat.metadata")).toHaveLength(0);
 
-      // Startup metadata now owns the initial catalog, so there is no unconditional
-      // parallel refresh. Exercise the same-agent pane refresh path explicitly.
+      // Startup metadata now owns the same-agent cache. A config change invalidates
+      // that cache, so the next pane refresh still exercises the failure fallback.
+      await gateway.emitGatewayEvent("config.changed", {});
       await page.locator("openclaw-chat-pane").evaluate((pane) => {
         (pane as HTMLElement & { sessionKey: string }).sessionKey = "agent:main:refreshed";
       });

--- a/ui/src/e2e/chat-flow.navigation-presentation.e2e.test.ts
+++ b/ui/src/e2e/chat-flow.navigation-presentation.e2e.test.ts
@@ -624,6 +624,82 @@ suite.define(() => {
     }
   });
 
+  it("flips a sidebar short route before any list refresh and refreshes only for an outbox", async () => {
+    const context = await newBrowserContext({
+      locale: "en-US",
+      serviceWorkers: "block",
+      viewport: { height: 900, width: 1280 },
+    });
+    const page = await context.newPage();
+    const firstKey = "agent:main:thread:aaaaaaaa-1111-4111-8111-111111111111";
+    const secondKey = "agent:main:thread:bbbbbbbb-2222-4222-8222-222222222222";
+    const sessions = chatSessionListResponse([
+      { key: firstKey, kind: "direct", label: "Instant A", updatedAt: 2 },
+      { key: secondKey, kind: "direct", label: "Instant B", updatedAt: 1 },
+    ]);
+    const gateway = await installMockGateway(page, {
+      methodResponses: { "sessions.list": sessions },
+      sessionKey: firstKey,
+    });
+
+    try {
+      await page.goto(`${server.baseUrl}chat`);
+      await page.locator(`.sidebar-recent-session[data-session-key="${secondKey}"]`).waitFor();
+      await page.locator(".chat-pane__session-title").getByText("Instant A").waitFor();
+      await page.waitForTimeout(500);
+      const initialListCount = (await gateway.getRequests("sessions.list")).length;
+      const initialMetadataCount = (await gateway.getRequests("chat.metadata")).length;
+      await gateway.deferNext("sessions.list");
+
+      await page
+        .locator(
+          `.sidebar-recent-session[data-session-key="${secondKey}"] a.sidebar-recent-session__link`,
+        )
+        .click();
+      await page.locator(".chat-pane__session-title").getByText("Instant B").waitFor();
+      const emptyOutboxListRequests = (await gateway.getRequests("sessions.list")).slice(
+        initialListCount,
+      );
+      expect(emptyOutboxListRequests).toHaveLength(0);
+      expect(await gateway.getRequests("chat.metadata")).toHaveLength(initialMetadataCount);
+      const emptyOutboxListCount = initialListCount + emptyOutboxListRequests.length;
+
+      await page.locator("openclaw-chat-pane").evaluate((pane, targetKey) => {
+        const state = (
+          pane as HTMLElement & {
+            state: {
+              chatQueueByScope: Record<string, unknown[]>;
+            };
+          }
+        ).state;
+        state.chatQueueByScope[`${targetKey}\u0000agent:main`] = [
+          {
+            id: "queued-before-switch",
+            text: "flush after idle reconciliation",
+            createdAt: Date.now(),
+            sendState: "waiting-idle",
+            sessionKey: targetKey,
+            agentId: "main",
+          },
+        ];
+      }, firstKey);
+      await page
+        .locator(
+          `.sidebar-recent-session[data-session-key="${firstKey}"] a.sidebar-recent-session__link`,
+        )
+        .click();
+      await page.locator(".chat-pane__session-title").getByText("Instant A").waitFor();
+      await expect
+        .poll(async () => (await gateway.getRequests("sessions.list")).length)
+        .toBe(emptyOutboxListCount + 1);
+      if (emptyOutboxListRequests.length === 0) {
+        await gateway.resolveDeferred("sessions.list", sessions);
+      }
+    } finally {
+      await closeBrowserContext(context);
+    }
+  });
+
   it("keeps derived sidebar titles and accessible state after session patch refreshes", async () => {
     const context = await suite.newBrowserContext({
       locale: "en-US",
@@ -810,8 +886,8 @@ suite.define(() => {
     }
   });
 
-  it("renders the visible authenticated assistant avatar after switching sessions", async () => {
-    const context = await suite.newBrowserContext({
+  it("keeps the authenticated assistant avatar stable across same-agent switches", async () => {
+    const context = await newBrowserContext({
       locale: "en-US",
       serviceWorkers: "block",
       viewport: { height: 900, width: 1280 },
@@ -821,24 +897,22 @@ suite.define(() => {
       "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAusB9Wl2nPcAAAAASUVORK5CYII=",
       "base64",
     );
-    let avatarRequestCount = 0;
     await page.route(/\/avatar\/main\?meta=1$/, (route) =>
       route.fulfill({
         contentType: "application/json",
         body: JSON.stringify({ avatarUrl: "/avatar/main", avatarStatus: "local" }),
       }),
     );
-    await page.route(/\/avatar\/main$/, (route) => {
-      avatarRequestCount += 1;
-      return route.fulfill({ contentType: "image/png", body: avatarBody });
-    });
+    await page.route(/\/avatar\/main$/, (route) =>
+      route.fulfill({ contentType: "image/png", body: avatarBody }),
+    );
     await installMockGateway(page, {
       methodResponses: { "sessions.list": chatSessionListResponse() },
       sessionKey: "agent:main:session-a",
     });
 
     try {
-      await page.goto(`${suite.server.baseUrl}chat`);
+      await page.goto(`${server.baseUrl}chat`);
       const documentMarker = await page.evaluate(() => {
         const marker = crypto.randomUUID();
         (window as Window & { __openclawAvatarTestDocument?: string })[
@@ -849,8 +923,6 @@ suite.define(() => {
       const avatar = page.locator("img.agent-chat__welcome-avatar");
       await avatar.waitFor({ state: "visible" });
       await expect.poll(() => avatar.getAttribute("src")).toMatch(/^blob:/);
-      const initialAvatarSrc = await avatar.getAttribute("src");
-      const initialRequestCount = avatarRequestCount;
 
       const sessionRow = (sessionKey: string) =>
         page.locator(`.sidebar-recent-session[data-session-key="${sessionKey}"]`);
@@ -859,12 +931,8 @@ suite.define(() => {
       await expect
         .poll(() => sessionB.getAttribute("class"))
         .toContain("sidebar-recent-session--active");
-      await expect.poll(() => avatarRequestCount).toBeGreaterThan(initialRequestCount);
-      await expect.poll(() => avatar.getAttribute("src")).not.toBe(initialAvatarSrc);
       await expect.poll(() => avatar.getAttribute("src")).toMatch(/^blob:/);
       await expect.poll(() => avatar.isVisible()).toBe(true);
-      const sessionBAvatarSrc = await avatar.getAttribute("src");
-      const sessionBRequestCount = avatarRequestCount;
 
       const sessionA = sessionRow("agent:main:session-a");
       await sessionA.locator("a.sidebar-recent-session__link").click();
@@ -872,8 +940,6 @@ suite.define(() => {
         .poll(() => sessionA.getAttribute("class"))
         .toContain("sidebar-recent-session--active");
 
-      await expect.poll(() => avatarRequestCount).toBeGreaterThan(sessionBRequestCount);
-      await expect.poll(() => avatar.getAttribute("src")).not.toBe(sessionBAvatarSrc);
       await expect.poll(() => avatar.getAttribute("src")).toMatch(/^blob:/);
       await expect.poll(() => avatar.isVisible()).toBe(true);
       expect(
@@ -885,7 +951,7 @@ suite.define(() => {
         ),
       ).toBe(documentMarker);
     } finally {
-      await suite.closeBrowserContext(context);
+      await closeBrowserContext(context);
     }
   });
 });

--- a/ui/src/e2e/chat-flow.navigation-presentation.e2e.test.ts
+++ b/ui/src/e2e/chat-flow.navigation-presentation.e2e.test.ts
@@ -625,7 +625,7 @@ suite.define(() => {
   });
 
   it("flips a sidebar short route before any list refresh and refreshes only for an outbox", async () => {
-    const context = await newBrowserContext({
+    const context = await suite.newBrowserContext({
       locale: "en-US",
       serviceWorkers: "block",
       viewport: { height: 900, width: 1280 },
@@ -643,7 +643,7 @@ suite.define(() => {
     });
 
     try {
-      await page.goto(`${server.baseUrl}chat`);
+      await page.goto(`${suite.server.baseUrl}chat`);
       await page.locator(`.sidebar-recent-session[data-session-key="${secondKey}"]`).waitFor();
       await page.locator(".chat-pane__session-title").getByText("Instant A").waitFor();
       await page.waitForTimeout(500);
@@ -696,7 +696,7 @@ suite.define(() => {
         await gateway.resolveDeferred("sessions.list", sessions);
       }
     } finally {
-      await closeBrowserContext(context);
+      await suite.closeBrowserContext(context);
     }
   });
 
@@ -887,7 +887,7 @@ suite.define(() => {
   });
 
   it("keeps the authenticated assistant avatar stable across same-agent switches", async () => {
-    const context = await newBrowserContext({
+    const context = await suite.newBrowserContext({
       locale: "en-US",
       serviceWorkers: "block",
       viewport: { height: 900, width: 1280 },
@@ -912,7 +912,7 @@ suite.define(() => {
     });
 
     try {
-      await page.goto(`${server.baseUrl}chat`);
+      await page.goto(`${suite.server.baseUrl}chat`);
       const documentMarker = await page.evaluate(() => {
         const marker = crypto.randomUUID();
         (window as Window & { __openclawAvatarTestDocument?: string })[
@@ -951,7 +951,7 @@ suite.define(() => {
         ),
       ).toBe(documentMarker);
     } finally {
-      await closeBrowserContext(context);
+      await suite.closeBrowserContext(context);
     }
   });
 });

--- a/ui/src/lib/sessions/navigation-handoff.ts
+++ b/ui/src/lib/sessions/navigation-handoff.ts
@@ -1,0 +1,33 @@
+type SessionNavigationHandoff = {
+  pathname: string;
+  sessionKey: string;
+};
+
+const SESSION_NAVIGATION_HANDOFF_TTL_MS = 2_000;
+const sessionNavigationHandoffs = new WeakMap<object, SessionNavigationHandoff>();
+
+export function prepareSessionNavigationHandoff(
+  owner: object,
+  pathname: string,
+  sessionKey: string,
+): void {
+  const handoff = { pathname, sessionKey };
+  sessionNavigationHandoffs.set(owner, handoff);
+  globalThis.setTimeout(() => {
+    if (sessionNavigationHandoffs.get(owner) === handoff) {
+      sessionNavigationHandoffs.delete(owner);
+    }
+  }, SESSION_NAVIGATION_HANDOFF_TTL_MS);
+}
+
+export function consumeSessionNavigationHandoff(
+  owner: object,
+  pathname: string,
+): string | undefined {
+  const handoff = sessionNavigationHandoffs.get(owner);
+  if (!handoff || handoff.pathname !== pathname) {
+    return undefined;
+  }
+  sessionNavigationHandoffs.delete(owner);
+  return handoff.sessionKey;
+}

--- a/ui/src/lib/sessions/route-navigation.test.ts
+++ b/ui/src/lib/sessions/route-navigation.test.ts
@@ -5,6 +5,7 @@ import {
   resolveSessionPreferredFace,
   resolveSessionPreferredFaceForKey,
   SESSION_FACE_PREFERENCE_PARAM,
+  SESSION_NAVIGATION_KEY_PARAM,
   sessionNavigationTarget,
 } from "./route-navigation.ts";
 
@@ -107,7 +108,10 @@ describe("sessionNavigationTarget", () => {
     });
 
     expect(target.href).toBe("/chat/main/release-notes-12345678");
-    expect(target.options).toEqual({ pathname: "/chat/main/release-notes-12345678" });
+    expect(target.options).toEqual({
+      pathname: "/chat/main/release-notes-12345678",
+      search: `?${SESSION_NAVIGATION_KEY_PARAM}=${encodeURIComponent(row.key)}`,
+    });
   });
 
   it("treats another agent's cached global row as uncached", () => {

--- a/ui/src/lib/sessions/route-navigation.ts
+++ b/ui/src/lib/sessions/route-navigation.ts
@@ -16,6 +16,9 @@ import {
 } from "./session-key.ts";
 
 export const SESSION_FACE_PREFERENCE_PARAM = "__openclawSessionFacePreference";
+export const SESSION_NAVIGATION_KEY_PARAM = "__openclawSessionKey";
+const SESSION_KEY_UUID_SUFFIX_RE =
+  /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/iu;
 
 type ContextSessionNavigationTargetParams<TRouteId extends string> = {
   context: ApplicationContext<TRouteId>;
@@ -28,6 +31,7 @@ type ContextSessionNavigationTargetParams<TRouteId extends string> = {
   mainKey?: never;
   shortIdLength?: number;
   preferenceDerivedFace?: boolean;
+  navigationKey?: string;
 };
 
 type ExplicitSessionNavigationTargetParams = {
@@ -41,6 +45,7 @@ type ExplicitSessionNavigationTargetParams = {
   shortIdLength?: number;
   agentId?: never;
   preferenceDerivedFace?: boolean;
+  navigationKey?: string;
 };
 
 type SessionNavigationTarget = {
@@ -172,6 +177,12 @@ export function sessionNavigationTarget<TRouteId extends string>(
   const navigationParams = new URLSearchParams(search ?? "");
   if (params.preferenceDerivedFace && !row) {
     navigationParams.set(SESSION_FACE_PREFERENCE_PARAM, "1");
+  }
+  const navigationKey = params.navigationKey?.trim() || row?.key;
+  if (navigationKey && SESSION_KEY_UUID_SUFFIX_RE.test(navigationKey)) {
+    // Sidebar navigation already owns the full row. Carry its key only through the
+    // in-app location so the short route never has to rediscover it from sessions.list.
+    navigationParams.set(SESSION_NAVIGATION_KEY_PARAM, navigationKey);
   }
   const serializedNavigation = navigationParams.toString();
   const options = serializedNavigation

--- a/ui/src/pages/chat/chat-avatar.test.ts
+++ b/ui/src/pages/chat/chat-avatar.test.ts
@@ -3,7 +3,7 @@
 import { render } from "lit";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { setAvatarGatewayOrigin } from "../../lib/identity-avatar.ts";
-import { refreshChatAvatar, renderChatAvatar } from "./chat-avatar.ts";
+import { invalidateChatAvatarCache, refreshChatAvatar, renderChatAvatar } from "./chat-avatar.ts";
 
 function renderAvatar(params: Parameters<typeof renderChatAvatar>) {
   const container = document.createElement("div");
@@ -146,6 +146,155 @@ describe("refreshChatAvatar", () => {
     await expect(refresh).resolves.toBeUndefined();
     expect(host.chatAvatarUrl).toBeNull();
     expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it("reuses the same-agent avatar without clearing or refetching it", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ avatarUrl: "/avatar/main", avatarStatus: "local" }),
+      })
+      .mockResolvedValueOnce({ ok: true, blob: async () => new Blob(["avatar"]) });
+    vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
+    vi.spyOn(URL, "createObjectURL").mockReturnValue("blob:main-avatar");
+
+    const host = createHost();
+    host.sessionKey = "agent:main:first";
+    await refreshChatAvatar(host);
+    expect(host.chatAvatarUrl).toBe("blob:main-avatar");
+
+    host.sessionKey = "agent:main:second";
+    const refresh = refreshChatAvatar(host);
+    expect(host.chatAvatarUrl).toBe("blob:main-avatar");
+    await refresh;
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(host.chatAvatarUrl).toBe("blob:main-avatar");
+  });
+
+  it("keeps an expired same-agent avatar visible while refreshing it", async () => {
+    const now = vi.spyOn(Date, "now").mockReturnValue(1_000);
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ avatarUrl: "/avatar/main", avatarStatus: "local" }),
+      })
+      .mockResolvedValueOnce({ ok: true, blob: async () => new Blob(["first"]) })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ avatarUrl: "/avatar/main", avatarStatus: "local" }),
+      })
+      .mockResolvedValueOnce({ ok: true, blob: async () => new Blob(["second"]) });
+    vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
+    vi.spyOn(URL, "createObjectURL")
+      .mockReturnValueOnce("blob:first-avatar")
+      .mockReturnValueOnce("blob:second-avatar");
+
+    const host = createHost();
+    host.sessionKey = "agent:main:first";
+    await refreshChatAvatar(host);
+    now.mockReturnValue(61_001);
+    host.sessionKey = "agent:main:second";
+
+    const refresh = refreshChatAvatar(host);
+    expect(host.chatAvatarUrl).toBe("blob:first-avatar");
+    await refresh;
+
+    expect(fetchMock).toHaveBeenCalledTimes(4);
+    expect(host.chatAvatarUrl).toBe("blob:second-avatar");
+  });
+
+  it("restores an expired avatar after a failed refresh and retries it", async () => {
+    const now = vi.spyOn(Date, "now").mockReturnValue(1_000);
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ avatarUrl: "/avatar/main" }) })
+      .mockResolvedValueOnce({ ok: true, blob: async () => new Blob(["first"]) })
+      .mockResolvedValueOnce({ ok: false })
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ avatarUrl: "/avatar/main" }) })
+      .mockResolvedValueOnce({ ok: true, blob: async () => new Blob(["second"]) });
+    vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
+    vi.spyOn(URL, "createObjectURL")
+      .mockReturnValueOnce("blob:first-avatar")
+      .mockReturnValueOnce("blob:second-avatar");
+    const host = createHost();
+
+    await refreshChatAvatar(host);
+    now.mockReturnValue(61_001);
+    await refreshChatAvatar(host);
+    expect(host.chatAvatarUrl).toBe("blob:first-avatar");
+
+    await refreshChatAvatar(host);
+    expect(fetchMock).toHaveBeenCalledTimes(5);
+    expect(host.chatAvatarUrl).toBe("blob:second-avatar");
+  });
+
+  it("lets the newest same-agent waiter apply a shared avatar fetch", async () => {
+    let resolveBlob: (blob: Blob) => void = () => undefined;
+    const blob = new Promise<Blob>((resolve) => {
+      resolveBlob = resolve;
+    });
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ avatarUrl: "/avatar/main" }) })
+      .mockResolvedValueOnce({ ok: true, blob: async () => await blob });
+    vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
+    vi.spyOn(URL, "createObjectURL").mockReturnValue("blob:shared-avatar");
+    const revokeObjectURL = vi.spyOn(URL, "revokeObjectURL");
+    const host = createHost();
+    host.sessionKey = "agent:main:first";
+
+    const first = refreshChatAvatar(host);
+    await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
+    host.sessionKey = "agent:main:second";
+    const second = refreshChatAvatar(host);
+    resolveBlob(new Blob(["avatar"]));
+    await Promise.all([first, second]);
+
+    expect(host.chatAvatarUrl).toBe("blob:shared-avatar");
+    expect(revokeObjectURL).not.toHaveBeenCalled();
+  });
+
+  it("retries a failed local avatar download", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ avatarUrl: "/avatar/main" }) })
+      .mockResolvedValueOnce({ ok: false })
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ avatarUrl: "/avatar/main" }) })
+      .mockResolvedValueOnce({ ok: true, blob: async () => new Blob(["avatar"]) });
+    vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
+    vi.spyOn(URL, "createObjectURL").mockReturnValue("blob:retried-avatar");
+    const host = createHost();
+
+    await refreshChatAvatar(host);
+    expect(host.chatAvatarUrl).toBeNull();
+    await refreshChatAvatar(host);
+
+    expect(fetchMock).toHaveBeenCalledTimes(4);
+    expect(host.chatAvatarUrl).toBe("blob:retried-avatar");
+  });
+
+  it("invalidates a cached avatar before configuration refresh", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ avatarUrl: "/avatar/main" }) })
+      .mockResolvedValueOnce({ ok: true, blob: async () => new Blob(["first"]) })
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ avatarUrl: "/avatar/main" }) })
+      .mockResolvedValueOnce({ ok: true, blob: async () => new Blob(["second"]) });
+    vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
+    vi.spyOn(URL, "createObjectURL")
+      .mockReturnValueOnce("blob:first-avatar")
+      .mockReturnValueOnce("blob:second-avatar");
+    const host = createHost();
+
+    await refreshChatAvatar(host);
+    invalidateChatAvatarCache(host);
+    await refreshChatAvatar(host);
+
+    expect(fetchMock).toHaveBeenCalledTimes(4);
+    expect(host.chatAvatarUrl).toBe("blob:second-avatar");
   });
 });
 

--- a/ui/src/pages/chat/chat-avatar.ts
+++ b/ui/src/pages/chat/chat-avatar.ts
@@ -1,6 +1,6 @@
 // Control UI chat module implements chat avatar behavior.
 import { html } from "lit";
-import type { GatewayHelloOk } from "../../api/gateway.ts";
+import type { GatewayBrowserClient, GatewayHelloOk } from "../../api/gateway.ts";
 import { normalizeBasePath } from "../../app-route-paths.ts";
 import { resolveControlUiAuthHeader } from "../../app/control-ui-auth.ts";
 import {
@@ -179,6 +179,7 @@ type ChatAvatarHost = {
   chatAvatarSource?: string | null;
   chatAvatarStatus?: "none" | "local" | "remote" | "data" | null;
   chatAvatarUrl: string | null;
+  client?: GatewayBrowserClient | null;
   connected: boolean;
   hello: GatewayHelloOk | null;
   password?: string | null;
@@ -187,7 +188,33 @@ type ChatAvatarHost = {
 };
 
 const chatAvatarRequestVersions = new WeakMap<object, number>();
-const chatAvatarObjectUrls = new WeakMap<object, string>();
+const chatAvatarDisplayedAgents = new WeakMap<object, string>();
+
+type ChatAvatarSnapshot = {
+  reason: string | null;
+  source: string | null;
+  status: "none" | "local" | "remote" | "data" | null;
+  url: string | null;
+};
+
+type ChatAvatarSnapshotEntry = {
+  kind: "snapshot";
+  snapshot: ChatAvatarSnapshot;
+  cachedAt: number;
+  retired?: ChatAvatarSnapshot[];
+};
+
+type ChatAvatarCacheEntry =
+  | {
+      kind: "pending";
+      pending: Promise<ChatAvatarSnapshot | null>;
+      stale?: ChatAvatarSnapshotEntry;
+    }
+  | ChatAvatarSnapshotEntry;
+
+const CHAT_AVATAR_CACHE_LIMIT = 24;
+const CHAT_AVATAR_CACHE_TTL_MS = 60_000;
+const chatAvatarCaches = new WeakMap<object, Map<string, ChatAvatarCacheEntry>>();
 
 function readHelloDefaultAgentId(host: Pick<ChatAvatarHost, "hello">): string | undefined {
   const snapshot = host.hello?.snapshot as
@@ -196,7 +223,9 @@ function readHelloDefaultAgentId(host: Pick<ChatAvatarHost, "hello">): string | 
   return snapshot?.sessionDefaults?.defaultAgentId?.trim() || undefined;
 }
 
-export function resolveAgentIdForSession(host: ChatAvatarHost): string | null {
+export function resolveAgentIdForSession(
+  host: Pick<ChatAvatarHost, "sessionKey" | "assistantAgentId" | "agentsList" | "hello">,
+): string | null {
   const parsed = parseAgentSessionKey(host.sessionKey);
   if (parsed?.agentId) {
     return parsed.agentId;
@@ -234,12 +263,6 @@ function buildAvatarMetaUrl(basePath: string, agentId: string): string {
 }
 
 function clearChatAvatarUrl(host: ChatAvatarHost) {
-  const key = host as object;
-  const previousBlobUrl = chatAvatarObjectUrls.get(key);
-  if (previousBlobUrl) {
-    URL.revokeObjectURL(previousBlobUrl);
-    chatAvatarObjectUrls.delete(key);
-  }
   host.chatAvatarUrl = null;
 }
 
@@ -251,42 +274,136 @@ function clearChatAvatarState(host: ChatAvatarHost) {
 }
 
 function setChatAvatarUrl(host: ChatAvatarHost, nextUrl: string | null) {
-  const key = host as object;
-  const previousBlobUrl = chatAvatarObjectUrls.get(key);
-  if (previousBlobUrl && previousBlobUrl !== nextUrl) {
-    URL.revokeObjectURL(previousBlobUrl);
-    chatAvatarObjectUrls.delete(key);
-  }
-  if (nextUrl?.startsWith("blob:")) {
-    chatAvatarObjectUrls.set(key, nextUrl);
-  }
   host.chatAvatarUrl = nextUrl;
 }
 
-function setChatAvatarMeta(
+function applyChatAvatarSnapshot(
   host: ChatAvatarHost,
-  data: {
-    avatarSource?: unknown;
-    avatarStatus?: unknown;
-    avatarReason?: unknown;
-  },
-) {
-  const status =
-    data.avatarStatus === "none" ||
-    data.avatarStatus === "local" ||
-    data.avatarStatus === "remote" ||
-    data.avatarStatus === "data"
-      ? data.avatarStatus
-      : null;
-  host.chatAvatarSource =
-    typeof data.avatarSource === "string" && data.avatarSource.trim()
-      ? data.avatarSource.trim()
-      : null;
-  host.chatAvatarStatus = status;
-  host.chatAvatarReason =
-    typeof data.avatarReason === "string" && data.avatarReason.trim()
-      ? data.avatarReason.trim()
-      : null;
+  agentId: string,
+  snapshot: ChatAvatarSnapshot,
+): void {
+  host.chatAvatarSource = snapshot.source;
+  host.chatAvatarStatus = snapshot.status;
+  host.chatAvatarReason = snapshot.reason;
+  setChatAvatarUrl(host, snapshot.url);
+  chatAvatarDisplayedAgents.set(host as object, agentId);
+}
+
+function revokeChatAvatarEntry(entry: ChatAvatarCacheEntry | undefined): void {
+  const snapshots =
+    entry?.kind === "snapshot"
+      ? [entry.snapshot, ...(entry.retired ?? [])]
+      : entry?.stale
+        ? [entry.stale.snapshot, ...(entry.stale.retired ?? [])]
+        : [];
+  for (const snapshot of snapshots) {
+    if (snapshot.url?.startsWith("blob:")) {
+      URL.revokeObjectURL(snapshot.url);
+    }
+  }
+}
+
+function revokeRetiredChatAvatarSnapshots(entry: ChatAvatarSnapshotEntry): void {
+  for (const snapshot of entry.retired ?? []) {
+    if (snapshot.url?.startsWith("blob:")) {
+      URL.revokeObjectURL(snapshot.url);
+    }
+  }
+  entry.retired = undefined;
+}
+
+function isFreshChatAvatarEntry(entry: ChatAvatarSnapshotEntry): boolean {
+  return Date.now() - entry.cachedAt < CHAT_AVATAR_CACHE_TTL_MS;
+}
+
+function clearChatAvatarCache(host: ChatAvatarHost): void {
+  const key = host as object;
+  const cache = chatAvatarCaches.get(key);
+  if (cache) {
+    for (const entry of cache.values()) {
+      revokeChatAvatarEntry(entry);
+    }
+    chatAvatarCaches.delete(key);
+  }
+  chatAvatarDisplayedAgents.delete(key);
+}
+
+export function invalidateChatAvatarCache(host: ChatAvatarHost): void {
+  beginChatAvatarRequest(host);
+  clearChatAvatarCache(host);
+  clearChatAvatarState(host);
+}
+
+function chatAvatarCacheFor(host: ChatAvatarHost): Map<string, ChatAvatarCacheEntry> {
+  const key = host as object;
+  const current = chatAvatarCaches.get(key);
+  if (current) {
+    return current;
+  }
+  const entries = new Map<string, ChatAvatarCacheEntry>();
+  chatAvatarCaches.set(key, entries);
+  return entries;
+}
+
+function rememberChatAvatarEntry(
+  cache: Map<string, ChatAvatarCacheEntry>,
+  agentId: string,
+  entry: ChatAvatarCacheEntry,
+): void {
+  cache.delete(agentId);
+  cache.set(agentId, entry);
+  while (cache.size > CHAT_AVATAR_CACHE_LIMIT) {
+    const oldestAgentId = cache.keys().next().value;
+    if (typeof oldestAgentId !== "string") {
+      break;
+    }
+    const oldest = cache.get(oldestAgentId);
+    cache.delete(oldestAgentId);
+    revokeChatAvatarEntry(oldest);
+  }
+}
+
+function loadChatAvatarSnapshot(
+  host: ChatAvatarHost,
+  cache: Map<string, ChatAvatarCacheEntry>,
+  agentId: string,
+): Promise<ChatAvatarSnapshot | null> {
+  const cached = cache.get(agentId);
+  if (cached?.kind === "snapshot" && isFreshChatAvatarEntry(cached)) {
+    return Promise.resolve(cached.snapshot);
+  }
+  if (cached?.kind === "pending") {
+    return cached.pending;
+  }
+  const stale = cached?.kind === "snapshot" ? cached : undefined;
+  const pending = fetchChatAvatarSnapshot(host, agentId).then((snapshot) => {
+    const current = cache.get(agentId);
+    if (
+      chatAvatarCaches.get(host as object) === cache &&
+      current?.kind === "pending" &&
+      current.pending === pending
+    ) {
+      if (snapshot) {
+        rememberChatAvatarEntry(cache, agentId, {
+          kind: "snapshot",
+          snapshot,
+          cachedAt: Date.now(),
+          ...(stale && stale.snapshot.url !== snapshot.url
+            ? { retired: [stale.snapshot, ...(stale.retired ?? [])] }
+            : {}),
+        });
+      } else if (stale) {
+        rememberChatAvatarEntry(cache, agentId, stale);
+      } else {
+        cache.delete(agentId);
+      }
+    } else if (snapshot?.url?.startsWith("blob:")) {
+      URL.revokeObjectURL(snapshot.url);
+    }
+    return snapshot ?? stale?.snapshot ?? null;
+  });
+  rememberChatAvatarEntry(cache, agentId, { kind: "pending", pending, stale });
+  return pending;
 }
 
 function buildControlUiAuthHeaders(authHeader: string | null): Record<string, string> | undefined {
@@ -307,8 +424,89 @@ function scheduleChatAvatarFetchTimeout(controller: AbortController, label: stri
   );
 }
 
+async function fetchChatAvatarSnapshot(
+  host: ChatAvatarHost,
+  agentId: string,
+): Promise<ChatAvatarSnapshot | null> {
+  const authHeader = resolveControlUiAuthHeader(host);
+  const headers = buildControlUiAuthHeaders(authHeader);
+  const url = buildAvatarMetaUrl(host.basePath, agentId);
+  const metaController = new AbortController();
+  const metaTimeout = scheduleChatAvatarFetchTimeout(metaController, "chat avatar metadata fetch");
+  let data: {
+    avatarUrl?: unknown;
+    avatarSource?: unknown;
+    avatarStatus?: unknown;
+    avatarReason?: unknown;
+  };
+  try {
+    const res = await fetch(url, {
+      method: "GET",
+      ...(headers ? { headers } : {}),
+      signal: metaController.signal,
+    });
+    if (!res.ok) {
+      return null;
+    }
+    data = (await res.json()) as typeof data;
+  } catch {
+    return null;
+  } finally {
+    clearTimeout(metaTimeout);
+  }
+
+  const status =
+    data.avatarStatus === "none" ||
+    data.avatarStatus === "local" ||
+    data.avatarStatus === "remote" ||
+    data.avatarStatus === "data"
+      ? data.avatarStatus
+      : null;
+  const snapshot: ChatAvatarSnapshot = {
+    source:
+      typeof data.avatarSource === "string" && data.avatarSource.trim()
+        ? data.avatarSource.trim()
+        : null,
+    status,
+    reason:
+      typeof data.avatarReason === "string" && data.avatarReason.trim()
+        ? data.avatarReason.trim()
+        : null,
+    url: null,
+  };
+  const avatarUrl = typeof data.avatarUrl === "string" ? data.avatarUrl.trim() : "";
+  if (!avatarUrl || !isRenderableControlUiAvatarUrl(avatarUrl)) {
+    return snapshot;
+  }
+  if (!isLocalControlUiAvatarUrl(avatarUrl)) {
+    return { ...snapshot, url: avatarUrl };
+  }
+  if (!host.connected || resolveAgentIdForSession(host) !== agentId) {
+    return null;
+  }
+
+  const avatarController = new AbortController();
+  const avatarTimeout = scheduleChatAvatarFetchTimeout(avatarController, "chat avatar image fetch");
+  try {
+    const avatarRes = await fetch(avatarUrl, {
+      method: "GET",
+      ...(headers ? { headers } : {}),
+      signal: avatarController.signal,
+    });
+    if (!avatarRes.ok) {
+      return null;
+    }
+    return { ...snapshot, url: URL.createObjectURL(await avatarRes.blob()) };
+  } catch {
+    return null;
+  } finally {
+    clearTimeout(avatarTimeout);
+  }
+}
+
 export async function refreshChatAvatar(host: ChatAvatarHost) {
   if (!host.connected) {
+    clearChatAvatarCache(host);
     clearChatAvatarState(host);
     return;
   }
@@ -321,80 +519,31 @@ export async function refreshChatAvatar(host: ChatAvatarHost) {
     }
     return;
   }
-  clearChatAvatarState(host);
-  const authHeader = resolveControlUiAuthHeader(host);
-  const headers = buildControlUiAuthHeaders(authHeader);
-  const url = buildAvatarMetaUrl(host.basePath, agentId);
-
-  const metaController = new AbortController();
-  const metaTimeout = scheduleChatAvatarFetchTimeout(metaController, "chat avatar metadata fetch");
-  let avatarUrl: string;
-  try {
-    const res = await fetch(url, {
-      method: "GET",
-      ...(headers ? { headers } : {}),
-      signal: metaController.signal,
-    });
-    if (!shouldApplyChatAvatarResult(host, requestVersion, sessionKey, agentId)) {
+  const cache = chatAvatarCacheFor(host);
+  const cached = cache.get(agentId);
+  if (cached?.kind === "snapshot") {
+    rememberChatAvatarEntry(cache, agentId, cached);
+    applyChatAvatarSnapshot(host, agentId, cached.snapshot);
+    revokeRetiredChatAvatarSnapshots(cached);
+    if (isFreshChatAvatarEntry(cached)) {
       return;
     }
-    if (!res.ok) {
-      clearChatAvatarState(host);
-      return;
-    }
-    const data = (await res.json()) as {
-      avatarUrl?: unknown;
-      avatarSource?: unknown;
-      avatarStatus?: unknown;
-      avatarReason?: unknown;
-    };
-    if (!shouldApplyChatAvatarResult(host, requestVersion, sessionKey, agentId)) {
-      return;
-    }
-    setChatAvatarMeta(host, data);
-    avatarUrl = typeof data.avatarUrl === "string" ? data.avatarUrl.trim() : "";
-    if (!avatarUrl || !isRenderableControlUiAvatarUrl(avatarUrl)) {
-      clearChatAvatarUrl(host);
-      return;
-    }
-    if (!isLocalControlUiAvatarUrl(avatarUrl)) {
-      setChatAvatarUrl(host, avatarUrl);
-      return;
-    }
-  } catch {
-    if (shouldApplyChatAvatarResult(host, requestVersion, sessionKey, agentId)) {
-      clearChatAvatarState(host);
-    }
-    return;
-  } finally {
-    clearTimeout(metaTimeout);
   }
-
-  const avatarController = new AbortController();
-  const avatarTimeout = scheduleChatAvatarFetchTimeout(avatarController, "chat avatar image fetch");
-  try {
-    const avatarRes = await fetch(avatarUrl, {
-      method: "GET",
-      ...(headers ? { headers } : {}),
-      signal: avatarController.signal,
-    });
-    if (!avatarRes.ok) {
-      if (shouldApplyChatAvatarResult(host, requestVersion, sessionKey, agentId)) {
-        clearChatAvatarUrl(host);
-      }
-      return;
+  const showingSameAgent = chatAvatarDisplayedAgents.get(host as object) === agentId;
+  if (!showingSameAgent) {
+    clearChatAvatarState(host);
+  }
+  const snapshot = await loadChatAvatarSnapshot(host, cache, agentId);
+  if (!shouldApplyChatAvatarResult(host, requestVersion, sessionKey, agentId)) {
+    return;
+  }
+  if (snapshot) {
+    applyChatAvatarSnapshot(host, agentId, snapshot);
+    const current = cache.get(agentId);
+    if (current?.kind === "snapshot" && current.snapshot === snapshot) {
+      revokeRetiredChatAvatarSnapshots(current);
     }
-    const blobUrl = URL.createObjectURL(await avatarRes.blob());
-    if (!shouldApplyChatAvatarResult(host, requestVersion, sessionKey, agentId)) {
-      URL.revokeObjectURL(blobUrl);
-      return;
-    }
-    setChatAvatarUrl(host, blobUrl);
-  } catch {
-    if (shouldApplyChatAvatarResult(host, requestVersion, sessionKey, agentId)) {
-      clearChatAvatarState(host);
-    }
-  } finally {
-    clearTimeout(avatarTimeout);
+  } else if (!showingSameAgent) {
+    clearChatAvatarState(host);
   }
 }

--- a/ui/src/pages/chat/chat-history.test.ts
+++ b/ui/src/pages/chat/chat-history.test.ts
@@ -4,6 +4,7 @@ import type { GatewayBrowserClient } from "../../api/gateway.ts";
 import {
   loadChatHistory,
   rewindChatHistory,
+  syncSelectedSessionMessageSubscription,
   switchChatHistoryBranch,
   type ChatHistoryResult,
   type ChatState,
@@ -79,6 +80,121 @@ function activeHistory(
     },
   } satisfies ChatHistoryResult;
 }
+
+describe("syncSelectedSessionMessageSubscription", () => {
+  it("starts the new subscription before the previous unsubscribe settles", async () => {
+    let resolveUnsubscribe: () => void = () => undefined;
+    const unsubscribeMessages = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveUnsubscribe = resolve;
+        }),
+    );
+    const subscribeMessages = vi.fn(async (key: string) => ({ key, agentId: null }));
+    const state = createState({ messages: [] }) as TestState & {
+      chatSessionMessageSubscriptionRequestedKey: string;
+      chatSessionMessageSubscription: { key: string; agentId: null } | null;
+      sessions: {
+        subscribeMessages: typeof subscribeMessages;
+        unsubscribeMessages: typeof unsubscribeMessages;
+      };
+    };
+    state.sessionKey = "agent:main:next";
+    state.chatSessionMessageSubscriptionRequestedKey = "agent:main:previous";
+    state.chatSessionMessageSubscription = { key: "agent:main:previous", agentId: null };
+    state.sessions = {
+      setModelOverride: vi.fn(),
+      subscribeMessages,
+      unsubscribeMessages,
+    };
+
+    const sync = syncSelectedSessionMessageSubscription(state as never);
+    await Promise.resolve();
+
+    expect(unsubscribeMessages).toHaveBeenCalledOnce();
+    expect(subscribeMessages).toHaveBeenCalledWith("agent:main:next", { agentId: undefined });
+    expect(state.chatSessionMessageSubscription).toEqual({
+      key: "agent:main:previous",
+      agentId: null,
+    });
+
+    resolveUnsubscribe();
+    await sync;
+    expect(state.chatSessionMessageSubscription).toEqual({
+      key: "agent:main:next",
+      agentId: null,
+    });
+  });
+
+  it("retains the previous subscription when its release fails", async () => {
+    const previous = { key: "agent:main:previous", agentId: null };
+    const subscribed = { key: "agent:main:next", agentId: null };
+    const unsubscribeMessages = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("release failed"))
+      .mockResolvedValueOnce(undefined);
+    const subscribeMessages = vi.fn(async () => subscribed);
+    const state = createState({ messages: [] }) as TestState & {
+      chatSessionMessageSubscriptionRequestedKey: string;
+      chatSessionMessageSubscription: typeof previous | null;
+      sessionsError: string | null;
+    };
+    state.sessionKey = subscribed.key;
+    state.chatSessionMessageSubscriptionRequestedKey = previous.key;
+    state.chatSessionMessageSubscription = previous;
+    state.sessionsError = null;
+    state.sessions = {
+      setModelOverride: vi.fn((_key: string, _value: string | null | undefined) => undefined),
+      subscribeMessages,
+      unsubscribeMessages,
+    };
+
+    await syncSelectedSessionMessageSubscription(state as never);
+
+    expect(state.chatSessionMessageSubscriptionRequestedKey).toBe(previous.key);
+    expect(state.chatSessionMessageSubscription).toBe(previous);
+    expect(state.sessionsError).toContain("release failed");
+    expect(unsubscribeMessages).toHaveBeenNthCalledWith(1, previous);
+    expect(unsubscribeMessages).toHaveBeenNthCalledWith(2, subscribed);
+  });
+
+  it("retains the new subscription when both release attempts fail", async () => {
+    const previous = { key: "agent:main:previous", agentId: null };
+    const subscribed = { key: "agent:main:next", agentId: null };
+    const unsubscribeMessages = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("previous release failed"))
+      .mockRejectedValueOnce(new Error("replacement release failed"))
+      .mockResolvedValueOnce(undefined);
+    const subscribeMessages = vi.fn(async () => subscribed);
+    const state = createState({ messages: [] }) as TestState & {
+      chatSessionMessageSubscriptionRequestedKey: string;
+      chatSessionMessageSubscription: typeof previous | null;
+      sessionsError: string | null;
+    };
+    state.sessionKey = subscribed.key;
+    state.chatSessionMessageSubscriptionRequestedKey = previous.key;
+    state.chatSessionMessageSubscription = previous;
+    state.sessionsError = null;
+    state.sessions = {
+      setModelOverride: vi.fn((_key: string, _value: string | null | undefined) => undefined),
+      subscribeMessages,
+      unsubscribeMessages,
+    };
+
+    await syncSelectedSessionMessageSubscription(state as never);
+
+    expect(state.chatSessionMessageSubscriptionRequestedKey).toBe(subscribed.key);
+    expect(state.chatSessionMessageSubscription).toBe(subscribed);
+    expect(state.sessionsError).toContain("previous release failed");
+    expect(state.sessionsError).toContain("replacement release failed");
+
+    await syncSelectedSessionMessageSubscription(state as never);
+    expect(unsubscribeMessages).toHaveBeenNthCalledWith(3, previous);
+    expect(state.chatSessionMessageSubscriptionRequestedKey).toBe(subscribed.key);
+    expect(state.chatSessionMessageSubscription).toBe(subscribed);
+  });
+});
 
 describe("rewindChatHistory", () => {
   it("clears the cached snapshot, refetches, and returns the composer text", async () => {

--- a/ui/src/pages/chat/chat-history.ts
+++ b/ui/src/pages/chat/chat-history.ts
@@ -96,6 +96,10 @@ const STARTUP_CHAT_HISTORY_RETRY_TIMEOUT_MS = 60_000;
 const chatHistoryRequestVersions = new WeakMap<object, number>();
 const chatBranchRequestVersions = new WeakMap<object, number>();
 const selectedSessionMessageSubscriptionGenerations = new WeakMap<object, number>();
+const pendingSessionMessageSubscriptionReleases = new WeakMap<
+  object,
+  Set<SessionMessageSubscription>
+>();
 
 type ChatHistoryRequestOwnership = {
   version: number;
@@ -599,6 +603,39 @@ function isCurrentSelectedSessionMessageSubscriptionSync(
   );
 }
 
+function rememberPendingSessionMessageSubscriptionRelease(
+  state: ChatSessionMessageSubscriptionState,
+  subscription: SessionMessageSubscription,
+): void {
+  const key = state as object;
+  const pending = pendingSessionMessageSubscriptionReleases.get(key) ?? new Set();
+  pending.add(subscription);
+  pendingSessionMessageSubscriptionReleases.set(key, pending);
+}
+
+async function retryPendingSessionMessageSubscriptionReleases(
+  state: ChatSessionMessageSubscriptionState,
+): Promise<void> {
+  const key = state as object;
+  const pending = pendingSessionMessageSubscriptionReleases.get(key);
+  if (!pending) {
+    return;
+  }
+  await Promise.all(
+    [...pending].map(async (subscription) => {
+      try {
+        await state.sessions.unsubscribeMessages(subscription);
+        pending.delete(subscription);
+      } catch {
+        // Keep the handle for the next synchronization attempt or connection cleanup.
+      }
+    }),
+  );
+  if (pending.size === 0) {
+    pendingSessionMessageSubscriptionReleases.delete(key);
+  }
+}
+
 export async function syncSelectedSessionMessageSubscription(
   state: ChatSessionMessageSubscriptionState,
   opts?: { force?: boolean },
@@ -611,6 +648,7 @@ export async function syncSelectedSessionMessageSubscription(
   if (!nextKey) {
     return;
   }
+  await retryPendingSessionMessageSubscriptionReleases(state);
   const generation = beginSelectedSessionMessageSubscriptionSync(state);
   const previousRequestedKey = normalizeSubscriptionKey(
     state.chatSessionMessageSubscriptionRequestedKey,
@@ -644,19 +682,62 @@ export async function syncSelectedSessionMessageSubscription(
       requestedAgentId: nextSubscriptionAgentId,
     });
   try {
+    let unsubscribePromise: Promise<void> = Promise.resolve();
     if (shouldUnsubscribePrevious && previousSubscription) {
+      unsubscribePromise = state.sessions.unsubscribeMessages(previousSubscription);
+    }
+    const subscribePromise =
+      shouldSubscribe && isCurrent()
+        ? state.sessions.subscribeMessages(nextKey, {
+            agentId: nextSubscriptionAgentId ?? undefined,
+          })
+        : Promise.resolve(null);
+    // Gateway subscriptions are independent canonical-key entries. Overlap the old
+    // release with the new acquire so a session switch pays one RTT, not two.
+    const [unsubscribeResult, subscribeResult] = await Promise.allSettled([
+      unsubscribePromise,
+      subscribePromise,
+    ]);
+    if (unsubscribeResult.status === "rejected") {
+      if (subscribeResult.status === "fulfilled" && subscribeResult.value) {
+        try {
+          await state.sessions.unsubscribeMessages(subscribeResult.value);
+        } catch (replacementReleaseError) {
+          if (isCurrent()) {
+            if (previousSubscription) {
+              // Both live handles stay owned: the replacement becomes active while the
+              // failed previous release remains queued until a later sync releases it.
+              rememberPendingSessionMessageSubscriptionRelease(state, previousSubscription);
+            }
+            state.chatSessionMessageSubscriptionRequestedKey = nextKey;
+            state.chatSessionMessageSubscription = subscribeResult.value;
+            state.sessionsError = `${String(unsubscribeResult.reason)}; replacement release failed: ${String(replacementReleaseError)}`;
+          } else {
+            rememberPendingSessionMessageSubscriptionRelease(state, subscribeResult.value);
+          }
+          return;
+        }
+      }
       if (isCurrent()) {
+        state.sessionsError = String(unsubscribeResult.reason);
+      }
+      return;
+    }
+    if (subscribeResult.status === "rejected") {
+      if (isCurrent() && shouldUnsubscribePrevious) {
         state.chatSessionMessageSubscriptionRequestedKey = null;
         state.chatSessionMessageSubscription = null;
       }
-      await state.sessions.unsubscribeMessages(previousSubscription);
+      throw subscribeResult.reason;
     }
-    if (!shouldSubscribe || !isCurrent()) {
+    const subscribed = subscribeResult.value;
+    if (!subscribed) {
+      if (isCurrent() && shouldUnsubscribePrevious) {
+        state.chatSessionMessageSubscriptionRequestedKey = null;
+        state.chatSessionMessageSubscription = null;
+      }
       return;
     }
-    const subscribed = await state.sessions.subscribeMessages(nextKey, {
-      agentId: nextSubscriptionAgentId ?? undefined,
-    });
     if (!isCurrent()) {
       // Generation advances before awaiting, so only the newest lease can reach assignment below.
       await state.sessions.unsubscribeMessages(subscribed).catch(() => undefined);

--- a/ui/src/pages/chat/chat-pane-context.ts
+++ b/ui/src/pages/chat/chat-pane-context.ts
@@ -5,6 +5,9 @@ import {
   canonicalUiSessionKeyForPersistence,
   clearChatMessagesFromCache,
   hasOperatorAdminAccess,
+  invalidateChatAvatarCache,
+  invalidateAssistantIdentityCache,
+  invalidateChatMetadataCache,
   isGatewayMethodAdvertised,
   loadSettings,
   markQueuedChatSendsWaitingForReconnect,
@@ -160,6 +163,10 @@ export abstract class ChatPaneContext extends ChatPaneLifecycle {
       // A reconnect can retain the browser client. Keep async ownership tied
       // to the logical connection, not only the transport object identity.
       this.connectionGeneration += 1;
+      invalidateChatAvatarCache(state);
+      invalidateAssistantIdentityCache(state.client);
+      state.assistantIdentityRequestVersion += 1;
+      invalidateChatMetadataCache(state);
       this.swarmHydrator?.dispose();
       this.swarmHydrator = null;
       this.builtinBoardSnapshot = null;

--- a/ui/src/pages/chat/chat-pane-deps.ts
+++ b/ui/src/pages/chat/chat-pane-deps.ts
@@ -39,6 +39,7 @@ export type {
   SessionVisibility,
 } from "../../api/types.ts";
 export { findInlineApproval } from "../../app/approval-presentation.ts";
+export { invalidateAssistantIdentityCache } from "../../app/assistant-identity.ts";
 export {
   applicationContext,
   type ApplicationContext,
@@ -158,7 +159,7 @@ export {
   type WorkboardCardChipProps,
 } from "./board-session-surface.ts";
 export { catalogMessageId } from "./catalog-message-id.ts";
-export { refreshChatAvatar } from "./chat-avatar.ts";
+export { invalidateChatAvatarCache, refreshChatAvatar } from "./chat-avatar.ts";
 export { replaceChatAttachmentsFromEditor } from "./attachment-payload-store.ts";
 export type { ChatHistoryPagination } from "./chat-history-pagination.ts";
 export {
@@ -201,6 +202,7 @@ export { handlePageGatewayEvent } from "./chat-state-events.ts";
 export type { ChatPageHost } from "./chat-state-host.ts";
 export { createPageState } from "./chat-state-page.ts";
 export {
+  invalidateChatMetadataCache,
   refreshChatCommands,
   refreshChatMetadata,
   refreshChatModelAuthStatus,

--- a/ui/src/pages/chat/chat-pane-lifecycle.ts
+++ b/ui/src/pages/chat/chat-pane-lifecycle.ts
@@ -13,9 +13,13 @@ import {
   exportChatMarkdown,
   handlePageGatewayEvent,
   handleQuestionPromptEvent,
+  invalidateChatAvatarCache,
+  invalidateAssistantIdentityCache,
+  invalidateChatMetadataCache,
   parseCatalogSessionKey,
   readChatSessionSnapshot,
   readPresenceEntries,
+  refreshChatAvatar,
   refreshPageChat,
   resetChatViewState,
   resolveChatPaneObserverRunId,
@@ -315,6 +319,13 @@ export abstract class ChatPaneLifecycle extends ChatPaneReset {
           }
         }
         if (state) {
+          if (event.event === "config.changed") {
+            invalidateChatAvatarCache(state);
+            invalidateAssistantIdentityCache(state.client);
+            state.assistantIdentityRequestVersion += 1;
+            invalidateChatMetadataCache(state);
+            void refreshChatAvatar(state).finally(() => state.requestUpdate?.());
+          }
           handleQuestionPromptEvent(this.questionPromptState, event);
         }
         if (state && !parseCatalogSessionKey(state.sessionKey)) {

--- a/ui/src/pages/chat/chat-pane-session.ts
+++ b/ui/src/pages/chat/chat-pane-session.ts
@@ -1,6 +1,7 @@
 import { selectApplicationSession } from "../../app/agent-selection.ts";
 import {
   CHAT_COMPOSER_DRAFT_STORAGE_ERROR,
+  applySelectedSessionProjection,
   buildCatalogSessionKey,
   catalogMessageId,
   clampText,
@@ -217,6 +218,9 @@ export abstract class ChatPaneSession extends ChatPaneSuggestions {
       previousDraftRetry,
       previousComposerScope,
     });
+    // The sidebar row is already authoritative enough for first paint: it supplies
+    // the header and run controls while the reset restores any cached transcript.
+    applySelectedSessionProjection(state, nextSessionRow);
     this.reconcileWaitingApprovalSnapshot();
     retryChatComposerMemoryFallback(state, nextSessionKey);
     // Route restoration is the new persistence baseline. An untouched pane
@@ -277,18 +281,20 @@ export abstract class ChatPaneSession extends ChatPaneSuggestions {
       () => this.sendPendingSkillWorkshopRevision(nextSessionKey),
       () => this.sendPendingSkillWorkshopRevision(nextSessionKey),
     );
-    const sessionsRefresh = refreshRouteSessionOptions(state);
-    flushChatQueueAfterIdleSessionReconciliation(
-      state,
-      nextSessionKey,
-      historyLoad,
-      sessionsRefresh,
-      previousSessionsResult,
-      () => void flushChatQueueForEvent(state),
-    );
+    if (state.chatQueue.length > 0) {
+      const sessionsRefresh = refreshRouteSessionOptions(state);
+      flushChatQueueAfterIdleSessionReconciliation(
+        state,
+        nextSessionKey,
+        historyLoad,
+        sessionsRefresh,
+        previousSessionsResult,
+        () => void flushChatQueueForEvent(state),
+      );
+      void sessionsRefresh;
+    }
     void subscriptionSync;
     void historyLoad;
-    void sessionsRefresh;
   }
 
   protected openCatalogSession(key: CatalogSessionKey, state: ChatPageHost) {

--- a/ui/src/pages/chat/chat-state-page.ts
+++ b/ui/src/pages/chat/chat-state-page.ts
@@ -5,6 +5,7 @@ import type { ApplicationContext } from "../../app/context.ts";
 import { loadLocalUserIdentity, loadSettings, patchSettings } from "../../app/settings.ts";
 import { resolveSafeExternalUrl } from "../../lib/open-external-url.ts";
 import { canonicalUiSessionKeyForPersistence } from "../../lib/sessions/session-key.ts";
+import { resolveAgentIdForSession } from "./chat-avatar.ts";
 import { removeQueuedMessage } from "./chat-queue.ts";
 import { attachChatRealtimeActions, createInitialChatRealtimeState } from "./chat-realtime.ts";
 import {
@@ -64,9 +65,18 @@ async function loadPageAssistantIdentity(
   const client = state.client;
   const sessionKey = opts?.sessionKey?.trim() || state.sessionKey.trim();
   const expectedSessionKey = opts?.expectedSessionKey?.trim() || sessionKey;
+  const agentId = resolveAgentIdForSession({
+    sessionKey,
+    assistantAgentId: state.assistantAgentId,
+    agentsList: state.agentsList,
+    hello: state.hello,
+  });
+  if (!agentId) {
+    return;
+  }
   const requestVersion = ++state.assistantIdentityRequestVersion;
   try {
-    const identity = await fetchAssistantIdentity(client, sessionKey);
+    const identity = await fetchAssistantIdentity(client, agentId);
     if (
       state.client !== client ||
       !state.connected ||

--- a/ui/src/pages/chat/chat-state-refresh.ts
+++ b/ui/src/pages/chat/chat-state-refresh.ts
@@ -50,10 +50,81 @@ type ChatMetadataRefreshOptions = {
   requestVersion?: number;
 };
 
+type ChatMetadataCacheEntry =
+  | { kind: "result"; result: ChatMetadataResult }
+  | { kind: "pending"; pending: Promise<ChatMetadataResult> };
+
+const chatMetadataCache = new WeakMap<GatewayBrowserClient, Map<string, ChatMetadataCacheEntry>>();
+
 const EMPTY_CHAT_METADATA_APPLY_RESULT: ChatMetadataApplyResult = {
   commands: false,
   models: false,
 };
+
+function chatMetadataAgentKey(agentId: string | null | undefined): string {
+  return agentId?.trim() ?? "";
+}
+
+function metadataCacheFor(client: GatewayBrowserClient): Map<string, ChatMetadataCacheEntry> {
+  let cache = chatMetadataCache.get(client);
+  if (!cache) {
+    cache = new Map();
+    chatMetadataCache.set(client, cache);
+  }
+  return cache;
+}
+
+function rememberChatMetadata(
+  client: GatewayBrowserClient,
+  agentId: string | null | undefined,
+  result: ChatMetadataResult,
+): void {
+  metadataCacheFor(client).set(chatMetadataAgentKey(agentId), { kind: "result", result });
+}
+
+function loadChatMetadata(
+  client: GatewayBrowserClient,
+  agentId: string | null | undefined,
+): Promise<ChatMetadataResult> {
+  const cache = metadataCacheFor(client);
+  const key = chatMetadataAgentKey(agentId);
+  const cached = cache.get(key);
+  if (cached?.kind === "result") {
+    return Promise.resolve(cached.result);
+  }
+  if (cached?.kind === "pending") {
+    return cached.pending;
+  }
+  const pending = client
+    .request<ChatMetadataResult>("chat.metadata", agentId ? { agentId } : {})
+    .then(
+      (result) => {
+        const current = cache.get(key);
+        if (current?.kind === "pending" && current.pending === pending) {
+          cache.set(key, { kind: "result", result });
+        }
+        return result;
+      },
+      (error: unknown) => {
+        const current = cache.get(key);
+        if (current?.kind === "pending" && current.pending === pending) {
+          cache.delete(key);
+        }
+        throw error;
+      },
+    );
+  cache.set(key, { kind: "pending", pending });
+  return pending;
+}
+
+export function invalidateChatMetadataCache(
+  host: Pick<ChatPageHost, "chatMetadataRequestVersion" | "client">,
+): void {
+  if (host.client) {
+    chatMetadataCache.delete(host.client);
+  }
+  host.chatMetadataRequestVersion += 1;
+}
 
 function scheduleChatMetadataRefresh(callback: () => void) {
   const requestIdleCallback =
@@ -173,10 +244,7 @@ export async function refreshChatMetadata(
       return EMPTY_CHAT_METADATA_APPLY_RESULT;
     }
 
-    const result = await client.request<ChatMetadataResult>(
-      "chat.metadata",
-      agentId ? { agentId } : {},
-    );
+    const result = await loadChatMetadata(client, agentId);
     if (!ownsChatMetadataRequest(request)) {
       return EMPTY_CHAT_METADATA_APPLY_RESULT;
     }
@@ -347,6 +415,7 @@ export function refreshPageChat(host: ChatPageHost, opts?: ChatRefreshOptions) {
           await refreshChatMetadata(host, { requestVersion: startupMetadataRequestVersion });
           return;
         }
+        rememberChatMetadata(client, agentId, metadata);
         const applied = applyChatMetadataResult(host, client, agentId, metadata);
         if (!applied.models || !applied.commands) {
           // chat.startup owns the first metadata load. Fill only omitted fields here;

--- a/ui/src/pages/chat/chat-state.test.ts
+++ b/ui/src/pages/chat/chat-state.test.ts
@@ -21,7 +21,7 @@ import { ChatStateController } from "./chat-state-controller.ts";
 import { handlePageGatewayEvent } from "./chat-state-events.ts";
 import type { ChatPageHost } from "./chat-state-host.ts";
 import { createPageState } from "./chat-state-page.ts";
-import { refreshChatMetadata } from "./chat-state-refresh.ts";
+import { invalidateChatMetadataCache, refreshChatMetadata } from "./chat-state-refresh.ts";
 import {
   resetChatStateForRouteSession,
   retryChatComposerMemoryFallback,
@@ -1755,8 +1755,12 @@ describe("resolveChatAvatarUrl", () => {
 });
 
 describe("loadPageAssistantIdentity", () => {
-  it("loads the identity for the current session after a same-client route switch", async () => {
-    const request = vi.fn().mockResolvedValue({ name: "Second Session", agentId: "main" });
+  it("memoizes identity by agent while fetching a cross-agent switch", async () => {
+    const now = vi.spyOn(Date, "now").mockReturnValue(1_000);
+    const request = vi.fn(async (_method: string, params?: { agentId?: string }) => ({
+      name: params?.agentId === "other" ? "Other Agent" : "Main Agent",
+      agentId: params?.agentId ?? "main",
+    }));
     const client = { request } as unknown as GatewayBrowserClient;
     const context = {
       agents: { state: { agentsList: null }, adoptList: vi.fn() },
@@ -1782,15 +1786,30 @@ describe("loadPageAssistantIdentity", () => {
     );
     state.client = client;
     state.connected = true;
-    state.assistantName = "First Session";
-    state.sessionKey = "agent:main:second";
+    state.assistantName = "Initial";
+    state.sessionKey = "agent:main:first";
 
+    await state.loadAssistantIdentity();
+    state.sessionKey = "agent:main:second";
     await state.loadAssistantIdentity();
 
     expect(request).toHaveBeenCalledWith("agent.identity.get", {
-      sessionKey: "agent:main:second",
+      agentId: "main",
     });
-    expect(state.assistantName).toBe("Second Session");
+    expect(request).toHaveBeenCalledTimes(1);
+    expect(state.assistantName).toBe("Main Agent");
+
+    state.sessionKey = "agent:other:main";
+    await state.loadAssistantIdentity();
+    expect(request).toHaveBeenLastCalledWith("agent.identity.get", { agentId: "other" });
+    expect(request).toHaveBeenCalledTimes(2);
+    expect(state.assistantName).toBe("Other Agent");
+
+    now.mockReturnValue(61_001);
+    state.sessionKey = "agent:main:third";
+    await state.loadAssistantIdentity();
+    expect(request).toHaveBeenCalledTimes(3);
+    expect(request).toHaveBeenLastCalledWith("agent.identity.get", { agentId: "main" });
   });
 });
 
@@ -1852,6 +1871,30 @@ describe("refreshChatMetadata", () => {
       { id: "work-model", name: "Work Model", provider: "openai", available: true },
     ]);
     expect(request).toHaveBeenCalledTimes(1);
+  });
+
+  it("reuses same-agent metadata and fetches a cross-agent catalog", async () => {
+    const request = vi.fn(async (_method: string, params?: { agentId?: string }) => ({
+      commands: [],
+      models: [
+        {
+          id: `${params?.agentId}-model`,
+          name: `${params?.agentId} Model`,
+          provider: "openai",
+        },
+      ],
+    }));
+    const state = createMetadataState(request);
+
+    await refreshChatMetadata(state);
+    state.sessionKey = "agent:work:second";
+    await refreshChatMetadata(state);
+    expect(request).toHaveBeenCalledTimes(1);
+
+    state.sessionKey = "agent:other:main";
+    await refreshChatMetadata(state);
+    expect(request).toHaveBeenCalledTimes(2);
+    expect(request).toHaveBeenLastCalledWith("chat.metadata", { agentId: "other" });
   });
 
   it("ignores metadata after switching to a different agent", async () => {
@@ -1963,6 +2006,7 @@ describe("refreshChatMetadata", () => {
     const state = createMetadataState(request);
 
     const firstRefresh = refreshChatMetadata(state);
+    invalidateChatMetadataCache(state);
     const secondRefresh = refreshChatMetadata(state);
     resolveSecond({
       commands: [],

--- a/ui/src/pages/chat/route-loader-short-cache.ts
+++ b/ui/src/pages/chat/route-loader-short-cache.ts
@@ -31,7 +31,7 @@ function rowMatchesShortTarget(
   return !target.slugHint || controlUiSessionSlug(row.displayName) === target.slugHint;
 }
 
-export type CachedShortSession = {
+type CachedShortSession = {
   sessionKey: string;
   row?: GatewaySessionRow;
 };

--- a/ui/src/pages/chat/route-loader-short-cache.ts
+++ b/ui/src/pages/chat/route-loader-short-cache.ts
@@ -1,0 +1,113 @@
+import { controlUiSessionSlug } from "@openclaw/session-url-contract";
+import type { RouteLocation } from "@openclaw/uirouter";
+import type { GatewaySessionRow } from "../../api/types.ts";
+import type { SessionPathTarget } from "../../app-session-route-paths.ts";
+import type { ApplicationContext } from "../../app/context.ts";
+import {
+  consumeSessionNavigationHandoff,
+  prepareSessionNavigationHandoff,
+} from "../../lib/sessions/navigation-handoff.ts";
+import {
+  findUiSessionRow,
+  SESSION_NAVIGATION_KEY_PARAM,
+} from "../../lib/sessions/route-navigation.ts";
+import { normalizeAgentId, parseAgentSessionKey } from "../../lib/sessions/session-key.ts";
+
+const SESSION_UUID_SUFFIX_RE = /([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})$/iu;
+
+export function sessionKeyUuid(sessionKey: string): string | null {
+  const uuid = parseAgentSessionKey(sessionKey)?.rest.match(SESSION_UUID_SUFFIX_RE)?.[1];
+  return uuid ? uuid.toLowerCase().replaceAll("-", "") : null;
+}
+
+function rowMatchesShortTarget(
+  row: GatewaySessionRow,
+  target: Extract<SessionPathTarget, { kind: "short" }>,
+): boolean {
+  const uuid = sessionKeyUuid(row.key);
+  if (!uuid || !uuid.startsWith(target.shortId.toLowerCase().replaceAll("-", ""))) {
+    return false;
+  }
+  return !target.slugHint || controlUiSessionSlug(row.displayName) === target.slugHint;
+}
+
+export type CachedShortSession = {
+  sessionKey: string;
+  row?: GatewaySessionRow;
+};
+
+export type ShortSessionResolution =
+  | { kind: "not-found" }
+  | { kind: "unique"; session: GatewaySessionRow }
+  | { kind: "ambiguous"; sessions: GatewaySessionRow[]; truncated: boolean };
+
+export function narrowShortResolutionBySlugHint(
+  resolution: ShortSessionResolution,
+  slugHint: string | undefined,
+): ShortSessionResolution {
+  if (resolution.kind !== "ambiguous" || resolution.truncated || !slugHint) {
+    return resolution;
+  }
+  const matched = resolution.sessions.filter(
+    (row) => controlUiSessionSlug(row.displayName) === slugHint,
+  );
+  return matched.length === 1 && matched[0] ? { kind: "unique", session: matched[0] } : resolution;
+}
+
+export function incompleteShortSessionResolution(
+  kind: "exact" | "short" | "slug",
+  sessions: GatewaySessionRow[],
+): ShortSessionResolution {
+  if (kind === "slug" && sessions.length === 0) {
+    // Slugs are best-effort: an incomplete exact-key search must retain the
+    // authoritative literal route, while a bounded zero-match slug is a 404.
+    return { kind: "not-found" };
+  }
+  return { kind: "ambiguous", sessions, truncated: true };
+}
+
+export function requireShortSessionResolution(
+  resolution: ShortSessionResolution | null,
+): ShortSessionResolution {
+  if (!resolution) {
+    throw new Error("Session list unavailable while resolving URL.");
+  }
+  return resolution;
+}
+
+export function findCachedShortSession(
+  context: ApplicationContext,
+  location: RouteLocation,
+  target: Extract<SessionPathTarget, { kind: "short" }>,
+): CachedShortSession | undefined {
+  const locationKey = new URLSearchParams(location.search)
+    .get(SESSION_NAVIGATION_KEY_PARAM)
+    ?.trim();
+  const handoffKey = consumeSessionNavigationHandoff(context.gateway, location.pathname);
+  const carriedKey = locationKey ?? handoffKey;
+  const carriedByCurrentNavigation = Boolean(handoffKey && handoffKey === carriedKey);
+  if (carriedKey) {
+    const preserveLocationKeyForCanonicalReload = () => {
+      if (locationKey) {
+        prepareSessionNavigationHandoff(context.gateway, location.pathname, locationKey);
+      }
+    };
+    const carried = findUiSessionRow(context, carriedKey, target.agentId);
+    if (carried && rowMatchesShortTarget(carried, target)) {
+      preserveLocationKeyForCanonicalReload();
+      return { sessionKey: carried.key, row: carried };
+    }
+    const carriedUuid = sessionKeyUuid(carriedKey);
+    const carriedAgentId = parseAgentSessionKey(carriedKey)?.agentId;
+    if (
+      carriedByCurrentNavigation &&
+      carriedUuid?.startsWith(target.shortId.toLowerCase().replaceAll("-", "")) &&
+      carriedAgentId &&
+      normalizeAgentId(carriedAgentId) === normalizeAgentId(target.agentId)
+    ) {
+      preserveLocationKeyForCanonicalReload();
+      return { sessionKey: carriedKey };
+    }
+  }
+  return undefined;
+}

--- a/ui/src/pages/chat/route-loader.ts
+++ b/ui/src/pages/chat/route-loader.ts
@@ -16,6 +16,7 @@ import {
 import {
   findUiSessionRow,
   SESSION_FACE_PREFERENCE_PARAM,
+  SESSION_NAVIGATION_KEY_PARAM,
 } from "../../lib/sessions/route-navigation.ts";
 import {
   buildAgentMainSessionKey,
@@ -28,13 +29,19 @@ import {
   resolveUiConfiguredMainKey,
   resolveUiGlobalAliasAgentId,
 } from "../../lib/sessions/session-key.ts";
+import {
+  findCachedShortSession,
+  incompleteShortSessionResolution,
+  narrowShortResolutionBySlugHint,
+  requireShortSessionResolution,
+  sessionKeyUuid,
+  type ShortSessionResolution as SessionReferenceResolution,
+} from "./route-loader-short-cache.ts";
 
 const SESSION_REF_SEARCH_LIMIT = 20;
 const SESSION_REF_SEARCH_MAX_PAGES = 5;
 // A uuid's first block is the longest run that is contiguous in both the hyphenated
 // stored key and the hyphen-stripped short id used in URLs.
-const UUID_FIRST_BLOCK_LENGTH = 8;
-const SESSION_UUID_SUFFIX_RE = /([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})$/iu;
 
 type SessionCandidate = {
   agentId: string;
@@ -77,11 +84,6 @@ export function locationWithoutDraft(location: RouteLocation): RouteLocation {
   return { ...location, search: search ? `?${search}` : "" };
 }
 
-type SessionReferenceResolution =
-  | { kind: "not-found" }
-  | { kind: "unique"; session: GatewaySessionRow }
-  | { kind: "ambiguous"; sessions: GatewaySessionRow[]; truncated: boolean };
-
 type SessionReferenceSearch = { agentId: string } & (
   | { kind: "short"; value: string }
   | { kind: "exact"; value: string }
@@ -92,11 +94,6 @@ const resolutionCache = new WeakMap<
   GatewayBrowserClient,
   Map<string, Promise<SessionReferenceResolution | null>>
 >();
-
-function sessionKeyUuid(sessionKey: string): string | null {
-  const uuid = parseAgentSessionKey(sessionKey)?.rest.match(SESSION_UUID_SUFFIX_RE)?.[1];
-  return uuid ? uuid.toLowerCase().replaceAll("-", "") : null;
-}
 
 function uniqueShortIdPrefix(
   value: string,
@@ -166,7 +163,7 @@ function sessionReferenceSearchText(
   // Short ids are compared hyphen-stripped, but the stored key holds a hyphenated uuid,
   // so only its first block survives as a contiguous substring. Anything longer (from a
   // disambiguation link or a canonicalized slug) would match nothing server-side.
-  return search.value.slice(0, UUID_FIRST_BLOCK_LENGTH);
+  return search.value.slice(0, 8);
 }
 
 function sessionReferenceMatches(
@@ -201,31 +198,6 @@ function sessionReferenceMatches(
 // A truncated set is not a tie, it is an unfinished search. Another page could hold the
 // same prefix under the same slug, so settling here would be the guess the bounded search
 // exists to avoid.
-function narrowBySlugHint(
-  resolution: SessionReferenceResolution,
-  slugHint: string | undefined,
-): SessionReferenceResolution {
-  if (resolution.kind !== "ambiguous" || resolution.truncated || !slugHint) {
-    return resolution;
-  }
-  const matched = resolution.sessions.filter(
-    (row) => controlUiSessionSlug(row.displayName) === slugHint,
-  );
-  return matched.length === 1 && matched[0] ? { kind: "unique", session: matched[0] } : resolution;
-}
-
-function incompleteSessionReferenceResolution(
-  search: SessionReferenceSearch,
-  sessions: GatewaySessionRow[],
-): SessionReferenceResolution {
-  if (search.kind === "slug" && sessions.length === 0) {
-    // Slugs are best-effort: the bounded zero-match contract is a 404, while an
-    // incomplete exact-key search must retain the authoritative literal route.
-    return { kind: "not-found" };
-  }
-  return { kind: "ambiguous", sessions, truncated: true };
-}
-
 async function querySessionReference(
   context: ApplicationContext,
   search: SessionReferenceSearch,
@@ -250,15 +222,6 @@ async function querySessionReference(
       cache.delete(cacheKey);
     }
   }
-}
-
-function requireSessionReferenceResolution(
-  resolution: SessionReferenceResolution | null,
-): SessionReferenceResolution {
-  if (!resolution) {
-    throw new Error("Session list unavailable while resolving URL.");
-  }
-  return resolution;
 }
 
 async function querySessionReferencePages(
@@ -294,11 +257,11 @@ async function querySessionReferencePages(
       return session ? { kind: "unique", session } : { kind: "not-found" };
     }
     if (page === SESSION_REF_SEARCH_MAX_PAGES - 1) {
-      return incompleteSessionReferenceResolution(search, sessions);
+      return incompleteShortSessionResolution(search.kind, sessions);
     }
     const nextOffset = result.nextOffset ?? offset + result.sessions.length;
     if (nextOffset <= offset) {
-      return incompleteSessionReferenceResolution(search, sessions);
+      return incompleteShortSessionResolution(search.kind, sessions);
     }
     offset = nextOffset;
   }
@@ -319,8 +282,11 @@ function locationWithoutSearchParam(location: RouteLocation, key: string): Route
   return { ...location, search: search ? `?${search}` : "" };
 }
 
-function locationWithoutFacePreference(location: RouteLocation): RouteLocation {
-  return locationWithoutSearchParam(location, SESSION_FACE_PREFERENCE_PARAM);
+function locationWithoutNavigationHints(location: RouteLocation): RouteLocation {
+  return locationWithoutSearchParam(
+    locationWithoutSearchParam(location, SESSION_FACE_PREFERENCE_PARAM),
+    SESSION_NAVIGATION_KEY_PARAM,
+  );
 }
 
 function preferredFace(row: Pick<GatewaySessionRow, "boardFace">): BoardFace {
@@ -358,7 +324,7 @@ function canonicalMainLocation(
   }
   const pathname = pathForSession(face, parsed.agentId, sessionKey, context.basePath, { mainKey });
   return pathname && pathname !== location.pathname
-    ? { ...locationWithoutFacePreference(location), pathname }
+    ? { ...locationWithoutNavigationHints(location), pathname }
     : null;
 }
 
@@ -379,7 +345,7 @@ function canonicalSessionLocation(params: {
   if (!pathname) {
     return undefined;
   }
-  const location = locationWithoutFacePreference(params.location);
+  const location = locationWithoutNavigationHints(params.location);
   const changed =
     pathname !== params.location.pathname || location.search !== params.location.search;
   return changed ? { ...location, pathname } : null;
@@ -508,7 +474,7 @@ function resolvedMainSessionRouteData(params: {
   if (!pathname) {
     return null;
   }
-  const location = locationWithoutFacePreference(params.location);
+  const location = locationWithoutNavigationHints(params.location);
   const canonicalLocation =
     pathname !== params.location.pathname || location.search !== params.location.search
       ? { ...location, pathname }
@@ -539,7 +505,9 @@ export async function loadChatRoute(
   const catalogKey = catalogSessionKeyFromSearch(routeLocation.search);
   if (target.kind === "main" && catalogKey) {
     const sessionKey = buildCatalogSessionKey(catalogKey);
-    let canonicalLocation = preferenceDerived ? locationWithoutFacePreference(routeLocation) : null;
+    let canonicalLocation = preferenceDerived
+      ? locationWithoutNavigationHints(routeLocation)
+      : null;
     let resolvedFace = face;
     if (preferenceDerived) {
       const resolution = await querySessionReference(
@@ -557,7 +525,7 @@ export async function loadChatRoute(
           { mainKey: configuredMainKey(context) },
         );
         if (pathname) {
-          canonicalLocation = { ...locationWithoutFacePreference(routeLocation), pathname };
+          canonicalLocation = { ...locationWithoutNavigationHints(routeLocation), pathname };
         }
       }
     }
@@ -594,7 +562,7 @@ export async function loadChatRoute(
       }
     }
     const canonicalLocation = preferenceDerived
-      ? locationWithoutFacePreference(routeLocation)
+      ? locationWithoutNavigationHints(routeLocation)
       : null;
     return {
       kind: "session",
@@ -692,7 +660,7 @@ export async function loadChatRoute(
             .catch(() => null)
         : undefined;
     const preferenceLocation = preferenceDerived
-      ? locationWithoutFacePreference(routeLocation)
+      ? locationWithoutNavigationHints(routeLocation)
       : null;
     return {
       kind: "session",
@@ -707,16 +675,31 @@ export async function loadChatRoute(
       ...(canonicalLocationReady ? { canonicalLocationReady } : {}),
     };
   }
-  const resolution = narrowBySlugHint(
-    requireSessionReferenceResolution(
-      await querySessionReference(
-        context,
-        { kind: "short", value: target.shortId, agentId: target.agentId },
-        signal,
-      ),
-    ),
-    target.slugHint,
-  );
+  const cached = findCachedShortSession(context, routeLocation, target);
+  if (cached && !cached.row) {
+    const canonicalLocation = locationWithoutNavigationHints(routeLocation);
+    const canonicalLocationChanged = canonicalLocation.search !== routeLocation.search;
+    return {
+      kind: "session",
+      sessionKey: cached.sessionKey,
+      draft: draftFromLocation(routeLocation),
+      face,
+      ...(target.shortId.length > 8 ? { shortId: target.shortId } : {}),
+      ...(canonicalLocationChanged ? { canonicalLocation } : {}),
+    };
+  }
+  const resolution = cached?.row
+    ? ({ kind: "unique", session: cached.row } as const)
+    : narrowShortResolutionBySlugHint(
+        requireShortSessionResolution(
+          await querySessionReference(
+            context,
+            { kind: "short", value: target.shortId, agentId: target.agentId },
+            signal,
+          ),
+        ),
+        target.slugHint,
+      );
   if (resolution.kind === "not-found") {
     return notFound({ routeId: face });
   }

--- a/ui/src/pages/chat/route-resolution.test.ts
+++ b/ui/src/pages/chat/route-resolution.test.ts
@@ -4,9 +4,11 @@ import type { GatewaySessionRow, SessionsListResult } from "../../api/types.ts";
 import { INTERNAL_SESSION_PATH_PARAM } from "../../app-route-paths.ts";
 import type { ApplicationContext } from "../../app/context.ts";
 import { buildCatalogSessionKey } from "../../lib/sessions/catalog-key.ts";
+import { prepareSessionNavigationHandoff } from "../../lib/sessions/navigation-handoff.ts";
 import {
   resolveSessionPreferredFaceForKey,
   SESSION_FACE_PREFERENCE_PARAM,
+  SESSION_NAVIGATION_KEY_PARAM,
   sessionNavigationTarget,
 } from "../../lib/sessions/route-navigation.ts";
 import { loadChatRoute } from "./route-loader.ts";
@@ -409,6 +411,127 @@ describe("gateway-backed session route resolution", () => {
     // Both ids start with 12345678; the slug says which one, so the short link still
     // resolves instead of bouncing to the chooser.
     expect(loaded).toMatchObject({ kind: "session", sessionKey: rows[1]?.key });
+  });
+
+  it("uses the sidebar-carried full key without issuing a session search", async () => {
+    const storedRow = row({ displayName: "Deploy monitor" });
+    const { context, list } = contextFor(() => result([storedRow]));
+    const target = sessionNavigationTarget({
+      face: "chat",
+      sessionKey: storedRow.key,
+      fallbackAgentId: "roboclaw",
+      row: storedRow,
+    });
+    prepareSessionNavigationHandoff(context.gateway, target.options.pathname, storedRow.key);
+    const loaded = await loadChatRoute(
+      context,
+      { pathname: target.options.pathname, search: "", hash: "" },
+      "chat",
+      new AbortController().signal,
+    );
+
+    expect(loaded).toMatchObject({
+      kind: "session",
+      sessionKey: storedRow.key,
+    });
+    expect(list).not.toHaveBeenCalled();
+  });
+
+  it("prefers the current location key over a residual colliding handoff", async () => {
+    const current = row({
+      key: "agent:roboclaw:thread:12345678-0aaa-4000-8000-000000000001",
+      displayName: "Deploy monitor",
+    });
+    const residual = row({
+      key: "agent:roboclaw:thread:12345678-0bbb-4000-8000-000000000002",
+      displayName: "Deploy monitor",
+    });
+    const { context, list } = contextFor(() => result([current, residual]), [current, residual]);
+    const pathname = "/chat/roboclaw/deploy-monitor-12345678";
+    prepareSessionNavigationHandoff(context.gateway, pathname, residual.key);
+
+    const loaded = await loadChatRoute(
+      context,
+      {
+        pathname,
+        search: `?${SESSION_NAVIGATION_KEY_PARAM}=${encodeURIComponent(current.key)}`,
+        hash: "",
+      },
+      "chat",
+      new AbortController().signal,
+    );
+
+    expect(loaded).toMatchObject({ kind: "session", sessionKey: current.key });
+    expect(list).not.toHaveBeenCalled();
+
+    const canonicalReload = await loadChatRoute(
+      context,
+      { pathname, search: "", hash: "" },
+      "chat",
+      new AbortController().signal,
+    );
+    expect(canonicalReload).toMatchObject({ kind: "session", sessionKey: current.key });
+    expect(list).not.toHaveBeenCalled();
+  });
+
+  it("does not trust a URL-only full key that is absent from cached rows", async () => {
+    const expected = row({
+      key: "agent:roboclaw:thread:12345678-0aaa-4000-8000-000000000001",
+      displayName: "Deploy monitor",
+    });
+    const staleKey = "agent:roboclaw:thread:12345678-0bbb-4000-8000-000000000002";
+    const { context, list } = contextFor(() => result([expected]));
+
+    const loaded = await loadChatRoute(
+      context,
+      {
+        pathname: "/chat/roboclaw/deploy-monitor-12345678",
+        search: `?${SESSION_NAVIGATION_KEY_PARAM}=${encodeURIComponent(staleKey)}`,
+        hash: "",
+      },
+      "chat",
+      new AbortController().signal,
+    );
+
+    expect(loaded).toMatchObject({ kind: "session", sessionKey: expected.key });
+    expect(list).toHaveBeenCalledOnce();
+  });
+
+  it("keeps a cold cached short route on the authoritative resolution path", async () => {
+    const storedRow = row({ displayName: "Deploy monitor" });
+    const { context, list } = contextFor(() => result([storedRow]), [storedRow]);
+
+    const loaded = await loadChatRoute(
+      context,
+      { pathname: "/chat/roboclaw/deploy-monitor-12345678", search: "", hash: "" },
+      "chat",
+      new AbortController().signal,
+    );
+
+    expect(loaded).toMatchObject({ kind: "session", sessionKey: storedRow.key });
+    expect(list).toHaveBeenCalledOnce();
+  });
+
+  it("keeps the gateway ambiguity check when cached rows share the uuid and slug", async () => {
+    const rows = [
+      row({ key: "agent:roboclaw:thread:12345678-0aaa-4000-8000-000000000001" }),
+      row({ key: "agent:roboclaw:thread:12345678-0bbb-4000-8000-000000000002" }),
+    ];
+    const { context, list } = contextFor(() => result(rows), rows);
+
+    const loaded = await loadChatRoute(
+      context,
+      {
+        pathname: "/chat/roboclaw/default-mode-with-rare-surprises-12345678",
+        search: "",
+        hash: "",
+      },
+      "chat",
+      new AbortController().signal,
+    );
+
+    expect(loaded).toMatchObject({ kind: "ambiguous", shortId: "12345678" });
+    expect(list).toHaveBeenCalledOnce();
   });
 
   it("keeps the chooser when the slug matches neither or both tied sessions", async () => {

--- a/ui/src/test-helpers/app-sidebar-cases/basics.ts
+++ b/ui/src/test-helpers/app-sidebar-cases/basics.ts
@@ -6,7 +6,10 @@ import {
   clearSessionBoardAvailability,
   recordSessionBoardAvailability,
 } from "../../lib/board/provider.ts";
-import { SESSION_FACE_PREFERENCE_PARAM } from "../../lib/sessions/route-navigation.ts";
+import {
+  SESSION_FACE_PREFERENCE_PARAM,
+  SESSION_NAVIGATION_KEY_PARAM,
+} from "../../lib/sessions/route-navigation.ts";
 import {
   createGateway,
   createGatewayHarness,
@@ -447,8 +450,11 @@ describe("AppSidebar agent chip", () => {
     ];
     rows.find((row) => row.textContent?.includes("Molty"))?.click();
     // createSessionState stamps ascending updatedAt, so the last key is newest.
-    expect(setSessionKey).toHaveBeenCalledWith(taskKey);
-    expect(onNavigate).toHaveBeenCalledWith("chat", { pathname: "/chat/main/00000002" });
+    expect(setSessionKey).not.toHaveBeenCalled();
+    expect(onNavigate).toHaveBeenCalledWith("chat", {
+      pathname: "/chat/main/00000002",
+      search: `?${SESSION_NAVIGATION_KEY_PARAM}=${encodeURIComponent(taskKey)}`,
+    });
   });
 
   it("keeps agent ids distinct from utility command values", async () => {

--- a/ui/src/test-helpers/app-sidebar-cases/sessions.ts
+++ b/ui/src/test-helpers/app-sidebar-cases/sessions.ts
@@ -404,7 +404,7 @@ describe("AppSidebar session accessibility", () => {
 });
 
 describe("AppSidebar session navigation", () => {
-  it("selects the session's agent before changing the active session", async () => {
+  it("selects a literal session's agent before changing the active session", async () => {
     const gateway = createGateway({} as GatewayBrowserClient);
     const { sidebar, context } = await mountSidebar(
       gateway,


### PR DESCRIPTION
## What Problem This Solves

Clicking a sidebar session in the Control UI did nothing visible until a full-store `sessions.list` RPC resolved: the route loader re-derived the session key the sidebar already had (short-id resolution via `querySessionReference` → `sessions.list{search:<8hex>,...}`), while the router kept the old session rendered. The switch then fired redundant RPCs — a forced `sessions.list` that only feeds an outbox-flush no-op when the queue is empty, per-switch `chat.metadata` + `agent.identity.get` refetching identical bytes for same-agent switches, serial unsubscribe→subscribe (2×RTT), and an avatar clear followed by two serial HTTP fetches (blank flash on every switch).

## Why This Change Was Made

The sidebar has the full session key at click time; blocking navigation on an RPC that re-derives it is pure waterfall. The remaining per-switch RPCs refetch agent-scoped facts that only change on config reload or reconnect.

## User Impact

Sidebar clicks flip the pane immediately (cached transcript or skeleton seeded from the sidebar row's title/preview/status) instead of waiting on a list roundtrip; same-agent switches stop refetching metadata/identity/avatars, so no avatar blank-flash; subscription handoff overlaps instead of serializing.

## Evidence

- A1/D1: committed sidebar selection carries the full key via an internal query hint plus a one-shot, pathname-bound handoff for the canonical clean-URL reload; `kind:"short"` also gets the cached-row shortcut under the safe uuid+slugHint unique-match conditions. Cold/typed short URLs keep the authoritative RPC and ambiguity semantics (regression-tested, chooser behavior preserved).
- A2: forced `sessions.list` skipped when the chat outbox is empty; still issued when non-empty (spy tests both ways).
- A3: `chat.metadata`/`agent.identity.get` memoized per (client, agentId), invalidated on config change + reconnect, built on the existing `chatMetadataRequestVersion` ownership token; cross-agent-switch catalog-clear behavior from #114837 preserved.
- A4: unsubscribe/subscribe fire concurrently; the existing generation guard handles reordering (overlap ordering test).
- A5/D3: bounded per-agent avatar cache; no clear-before-fetch when the cached avatar matches the agent; meta+blob fetches collapsed where possible.
- D2: pane header/skeleton seeded from the already-looked-up sidebar row.
- Validation: full UI e2e sweep 83/83 files, 339/339 tests; focused route/avatar/subscription/sidebar suites; UI prod+test typechecks, oxlint, oxfmt, `git diff --check`; autoreview clean. One pre-existing lightbox threshold flake reproduced on clean main and passed in the final sweep.
