### PR TITLE
fix(feishu): restore forwarded interactive card content

### DIFF
--- a/extensions/feishu/src/bot-content.ts
+++ b/extensions/feishu/src/bot-content.ts
@@ -3,6 +3,7 @@ import { parseStrictNonNegativeInteger } from "openclaw/plugin-sdk/number-runtim
 import type { ClawdbotConfig } from "../runtime-api.js";
 import { buildFeishuConversationId } from "./conversation-id.js";
 import { normalizeFeishuExternalKey } from "./external-keys.js";
+import { parseInteractiveCardContent } from "./interactive-message-content.js";
 import { saveMessageResourceFeishu } from "./media.js";
 import { isFeishuBroadcastMention } from "./mention.js";
 import { parsePostContent } from "./post.js";
@@ -165,6 +166,9 @@ export function parseMessageContent(content: string, messageType: string): strin
     if (messageType === "merge_forward") {
       return "[Merged and Forwarded Message - loading...]";
     }
+    if (messageType === "interactive") {
+      return parseInteractiveCardContent(parsed);
+    }
     return content;
   } catch {
     return FEISHU_MEDIA_MESSAGE_TYPES.has(messageType) ? "" : content;
@@ -192,6 +196,8 @@ function formatSubMessageContent(content: string, contentType: string): string {
         return parsed.text || content;
       case "post":
         return parsePostContent(content).textContent;
+      case "interactive":
+        return parseInteractiveCardContent(parsed);
       case "image":
         return "[Image]";
       case "file":
@@ -234,7 +240,12 @@ export function parseMergeForwardContent(params: { content: string; log?: Feishu
   if (!Array.isArray(items) || items.length === 0) {
     return "[Merged and Forwarded Message - no sub-messages]";
   }
-  const subMessages = items.filter((item) => item.upper_message_id);
+  const container = items.find(
+    (item) => item.msg_type === "merge_forward" && !item.upper_message_id,
+  );
+  const subMessages = container
+    ? items.filter((item) => item !== container)
+    : items.filter((item) => item.upper_message_id);
   if (subMessages.length === 0) {
     return "[Merged and Forwarded Message - no sub-messages found]";
   }

--- a/extensions/feishu/src/bot.test.ts
+++ b/extensions/feishu/src/bot.test.ts
@@ -12,7 +12,7 @@ import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
 import type { ClawdbotConfig, PluginRuntime } from "../runtime-api.js";
 import { parseMergeForwardContent } from "./bot-content.js";
 import type { FeishuMessageEvent } from "./bot.js";
-import { handleFeishuMessage } from "./bot.js";
+import { handleFeishuMessage, parseFeishuMessageEvent } from "./bot.js";
 import {
   createFeishuTestConfig,
   createFeishuTestEvent,
@@ -2386,6 +2386,28 @@ describe("handleFeishuMessage command authorization", () => {
     expect(context.BodyForAgent).toBe("[message_id: msg-message-id-line]\nou-msgid: hello");
   });
 
+  it("parses direct interactive webhook content through the canonical card parser", () => {
+    const event = createFeishuTestEvent({
+      messageId: "msg-direct-card",
+      messageType: "interactive",
+      content: JSON.stringify({
+        schema: "2.0",
+        header: { title: { tag: "plain_text", content: "Direct task" } },
+        body: {
+          elements: [
+            {
+              tag: "table",
+              columns: [{ name: "status", display_name: "Status" }],
+              rows: [{ status: "Open" }],
+            },
+          ],
+        },
+      }),
+    });
+
+    expect(parseFeishuMessageEvent(event).content).toBe("Direct task\nStatus\nOpen");
+  });
+
   it("expands merge_forward content from API sub-messages", async () => {
     mockShouldComputeCommandAuthorized.mockReturnValue(false);
     const mockGetMerged = vi.fn().mockResolvedValue({
@@ -2403,6 +2425,29 @@ describe("handleFeishuMessage command authorization", () => {
             msg_type: "file",
             body: { content: JSON.stringify({ file_name: "report.pdf" }) },
             create_time: "2000",
+          },
+          {
+            message_id: "sub-card",
+            msg_type: "interactive",
+            body: {
+              content: JSON.stringify({
+                schema: "2.0",
+                header: { title: { tag: "plain_text", content: "Task summary" } },
+                body: {
+                  elements: [
+                    {
+                      tag: "table",
+                      columns: [
+                        { name: "task", display_name: "Task" },
+                        { name: "owner", display_name: "Owner" },
+                      ],
+                      rows: [{ task: "Investigate", owner: { name: "Alice" } }],
+                    },
+                  ],
+                },
+              }),
+            },
+            create_time: "1500",
           },
           {
             message_id: "sub-1",
@@ -2438,12 +2483,19 @@ describe("handleFeishuMessage command authorization", () => {
     await dispatchMessage({ cfg, event });
 
     expect(mockGetMerged).toHaveBeenCalledWith({
+      params: { card_msg_content_type: "user_card_content" },
       path: { message_id: "msg-merge-forward" },
     });
     const context = mockCallArg<{ BodyForAgent?: string }>(mockFinalizeInboundContext, 0, 0);
     expect(context.BodyForAgent).toContain(
-      "[Merged and Forwarded Messages]\n- alpha\n- [File: report.pdf]",
+      "[Merged and Forwarded Messages]\n" +
+        "- alpha\n" +
+        "- Task summary\n" +
+        "Task | Owner\n" +
+        "Investigate | Alice\n" +
+        "- [File: report.pdf]",
     );
+    expect(context.BodyForAgent).not.toContain("[interactive]");
   });
 
   it("does not partially parse malformed merge_forward create_time values", () => {

--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -431,6 +431,7 @@ export async function handleFeishuMessage(params: {
       // The API returns all sub-messages in the items array
       const client = createFeishuClient(account);
       const response = (await client.im.message.get({
+        params: { card_msg_content_type: "user_card_content" },
         path: { message_id: event.message.message_id },
       })) as { code?: number; data?: { items?: unknown[] } };
 

--- a/extensions/feishu/src/interactive-message-content.test.ts
+++ b/extensions/feishu/src/interactive-message-content.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+import { parseInteractiveCardContent } from "./interactive-message-content.js";
+
+describe("parseInteractiveCardContent", () => {
+  it("renders schema 2 titles and table rows", () => {
+    expect(
+      parseInteractiveCardContent({
+        schema: "2.0",
+        header: { title: { tag: "plain_text", content: "Review ${count}" } },
+        body: {
+          elements: [
+            {
+              tag: "table",
+              columns: [
+                { name: "status", display_name: "Status" },
+                { name: "reviewers", display_name: "Reviewers" },
+              ],
+              rows: [
+                {
+                  status: [{ text: "Open" }, { text: { content: "Priority ${count}" } }],
+                  reviewers: [{ name: "Alice" }, { user_name: "Bob" }],
+                },
+              ],
+            },
+          ],
+        },
+        template_variable: { count: 2 },
+      }),
+    ).toBe("Review 2\nStatus | Reviewers\nOpen, Priority 2 | Alice, Bob");
+  });
+
+  it("renders schema 1 fields and actions through the same parser", () => {
+    expect(
+      parseInteractiveCardContent({
+        header: { title: { tag: "plain_text", content: "Approval" } },
+        elements: [
+          {
+            tag: "div",
+            text: { tag: "lark_md", content: "Request details" },
+            fields: [{ text: { tag: "plain_text", content: "Owner: Alice" } }],
+          },
+          {
+            tag: "action",
+            actions: [
+              { tag: "button", text: { tag: "plain_text", content: "Approve" } },
+              { tag: "button", text: { tag: "plain_text", content: "Reject" } },
+            ],
+          },
+        ],
+      }),
+    ).toBe("Approval\nRequest details\nOwner: Alice\nApprove\nReject");
+  });
+});

--- a/extensions/feishu/src/interactive-message-content.ts
+++ b/extensions/feishu/src/interactive-message-content.ts
@@ -40,6 +40,77 @@ function applyCardTemplateVariables(text: string, variables: Map<string, string>
   });
 }
 
+function normalizeInteractiveValue(value: unknown, variables: Map<string, string>): string {
+  const scalar = normalizeCardTemplateVariable(value);
+  if (scalar !== undefined) {
+    return applyCardTemplateVariables(scalar, variables);
+  }
+  if (Array.isArray(value)) {
+    return value
+      .map((entry) => normalizeInteractiveValue(entry, variables))
+      .filter(Boolean)
+      .join(", ");
+  }
+  if (!isRecord(value)) {
+    return "";
+  }
+  for (const key of [
+    "content",
+    "text",
+    "label",
+    "name",
+    "display_name",
+    "user_name",
+    "user_id",
+    "open_id",
+    "id",
+    "value",
+  ]) {
+    const text = normalizeInteractiveValue(value[key], variables);
+    if (text) {
+      return text;
+    }
+  }
+  return "";
+}
+
+function extractInteractiveTableText(
+  element: Record<string, unknown>,
+  variables: Map<string, string>,
+): string | undefined {
+  if (!Array.isArray(element.columns) || !Array.isArray(element.rows)) {
+    return undefined;
+  }
+  const columns = element.columns.flatMap((column) => {
+    if (!isRecord(column) || typeof column.name !== "string") {
+      return [];
+    }
+    return [
+      {
+        name: column.name,
+        title: typeof column.display_name === "string" ? column.display_name : column.name,
+      },
+    ];
+  });
+  if (columns.length === 0) {
+    return undefined;
+  }
+
+  const lines = [
+    columns.map((column) => applyCardTemplateVariables(column.title, variables)).join(" | "),
+  ];
+  for (const row of element.rows) {
+    if (!isRecord(row)) {
+      continue;
+    }
+    const cells = columns.map((column) => normalizeInteractiveValue(row[column.name], variables));
+    if (cells.some(Boolean)) {
+      lines.push(cells.join(" | "));
+    }
+  }
+  return lines.join("\n");
+}
+
 function extractInteractiveElementText(
   element: unknown,
   variables: Map<string, string>,
@@ -50,16 +121,42 @@ function extractInteractiveElementText(
   const tag = typeof element.tag === "string" ? element.tag : "";
   const text = isRecord(element.text) ? element.text : undefined;
 
-  if (tag === "div" && typeof text?.content === "string") {
-    return applyCardTemplateVariables(text.content, variables);
+  if (tag === "div") {
+    const parts = [normalizeInteractiveValue(element.text, variables)];
+    if (Array.isArray(element.fields)) {
+      parts.push(extractInteractiveElementsText(element.fields, variables));
+    }
+    return parts.filter(Boolean).join("\n") || undefined;
   }
   if ((tag === "markdown" || tag === "lark_md") && typeof element.content === "string") {
     return applyCardTemplateVariables(element.content, variables);
   }
+  if ((tag === "text" || tag === "a" || tag === "button") && element.text !== undefined) {
+    return normalizeInteractiveValue(element.text, variables) || undefined;
+  }
+  if (tag === "at") {
+    const mention = normalizeInteractiveValue(element.user_name ?? element.user_id, variables);
+    return mention ? (mention.startsWith("@") ? mention : `@${mention}`) : undefined;
+  }
   if (tag === "plain_text" && typeof element.content === "string") {
     return applyCardTemplateVariables(element.content, variables);
   }
-  return undefined;
+  if (tag === "table") {
+    return extractInteractiveTableText(element, variables);
+  }
+
+  const nestedText = [
+    element.elements,
+    element.columns,
+    element.children,
+    element.fields,
+    element.actions,
+  ]
+    .filter(Array.isArray)
+    .map((children) => extractInteractiveElementsText(children, variables))
+    .filter(Boolean)
+    .join("\n");
+  return nestedText || (typeof text?.content === "string" ? text.content : undefined);
 }
 
 function extractInteractiveElementsText(
@@ -68,6 +165,17 @@ function extractInteractiveElementsText(
 ): string {
   const texts: string[] = [];
   for (const element of elements) {
+    if (Array.isArray(element)) {
+      const row = element
+        .map((part) => extractInteractiveElementText(part, variables))
+        .filter((part): part is string => Boolean(part))
+        .join(" ")
+        .trim();
+      if (row) {
+        texts.push(row);
+      }
+      continue;
+    }
     const text = extractInteractiveElementText(element, variables);
     if (text !== undefined) {
       texts.push(text);
@@ -100,19 +208,37 @@ function readInteractiveElementArrays(parsed: Record<string, unknown>): unknown[
   return elementArrays;
 }
 
+function readInteractiveCardTitle(
+  parsed: Record<string, unknown>,
+  variables: Map<string, string>,
+): string {
+  if (typeof parsed.title === "string") {
+    return applyCardTemplateVariables(parsed.title, variables).trim();
+  }
+  const header = isRecord(parsed.header) ? parsed.header : undefined;
+  const title = isRecord(header?.title) ? header.title : undefined;
+  return typeof title?.content === "string"
+    ? applyCardTemplateVariables(title.content, variables).trim()
+    : "";
+}
+
 export function parseInteractiveCardContent(parsed: unknown): string {
   if (!isRecord(parsed)) {
     return INTERACTIVE_CARD_FALLBACK_TEXT;
   }
 
   const variables = readCardTemplateVariables(parsed);
+  const title = readInteractiveCardTitle(parsed, variables);
   for (const elements of readInteractiveElementArrays(parsed)) {
     const text = extractInteractiveElementsText(elements, variables);
     if (text) {
-      return text;
+      return title ? `${title}\n${text}` : text;
     }
   }
 
   const postText = parsePostContent(JSON.stringify(parsed)).textContent.trim();
-  return postText && postText !== POST_FALLBACK_TEXT ? postText : INTERACTIVE_CARD_FALLBACK_TEXT;
+  if (postText && postText !== POST_FALLBACK_TEXT) {
+    return postText;
+  }
+  return title || INTERACTIVE_CARD_FALLBACK_TEXT;
 }


### PR DESCRIPTION
Closes #77909

## What Problem This Solves

Feishu merge-forward messages could return an interactive child card whose visible content was discarded as `[interactive]`. The parser also dropped returned children when Feishu omitted the optional `upper_message_id`, which is the response shape reported in #77909.

## Why This Change Was Made

The merge-forward fetch now requests the documented original card JSON with `card_msg_content_type=user_card_content`, matching direct message and thread-history reads. Forwarded and direct webhook cards both route through the existing canonical `interactive-message-content.ts` owner.

That parser now covers the provider shapes required by the report: schema 1 fields/actions and schema 2 titles/tables, including template variables and option/person arrays. The merge-forward parser excludes the known container instead of requiring the SDK's optional `upper_message_id` on every child.

The stale branch's competing 345-line parser, broad locale policy, reference-backed CardKit double-fetch, and unrelated SQLite webhook-test changes were removed. Reference-backed rendering remains out of scope because the pinned SDK type and inspected official contract do not establish that extra-fetch behavior.

## User Impact

Forwarded Feishu table and approval cards now reach the agent as readable content instead of `[interactive]`. Direct interactive webhooks, quoted messages, and thread history use the same parser owner, so the same supported card shape is represented consistently.

## Evidence

- Exact bug on current main before the repair:
  - `extensions/feishu/src/bot-content.ts:208` fell through to `[interactive]`.
  - `extensions/feishu/src/bot.ts:433-435` fetched merge-forward items without `user_card_content`.
- Failing-before parser proof:
  - `node scripts/run-vitest.mjs extensions/feishu/src/interactive-message-content.test.ts`
  - `Test Files 1 failed`; `Tests 2 failed`; `[vitest] FAILED (exit 1)`.
- Failing-before final dispatch proof:
  - `node scripts/run-vitest.mjs extensions/feishu/src/bot.test.ts -- -t 'expands merge_forward content from API sub-messages'`
  - `Test Files 1 failed`; `Tests 1 failed | 98 skipped`; the API call omitted `card_msg_content_type`.
- Final affected proof:
  - `node scripts/run-vitest.mjs extensions/feishu/src/bot.test.ts extensions/feishu/src/interactive-message-content.test.ts extensions/feishu/src/send.test.ts extensions/feishu/src/message-content-loopback.test.ts`
  - `Test Files 4 passed`; `Tests 134 passed`; `[test] passed 1 Vitest shard in 11.08s`.
- Inspectable final agent-visible forwarded body:

```text
[Merged and Forwarded Messages]
- alpha
- Task summary
Task | Owner
Investigate | Alice
- [File: report.pdf]
```

- Pinned dependency contract:
  - `@larksuiteoapi/node-sdk@1.71.1` accepts optional `params.card_msg_content_type` and returns `data.items[]` with optional `msg_type`, `body.content`, and `upper_message_id`.
  - The existing real-SDK loopback suite proves tenant-token exchange, bearer authorization, and the exact `user_card_content` query over HTTP.
- Changed-file gate:
  - `node scripts/check-changed.mjs`
  - Blacksmith Testbox `tbx_01kzkc6hewmv3ffqgxdxvpagtb`
  - https://github.com/openclaw/openclaw/actions/runs/31316535460
  - formatting, plugin boundaries, dead-code, production/test typechecks, changed-file lint, database-first/media guards, and import cycles passed; `exitCode: 0`.
- `git diff --check`: passed.
- Final Codex autoreview: clean after one round; no accepted/actionable findings, confidence 0.98.
- Production LOC: +144/-6; tests: +107/-2. The production growth extends the single canonical card parser with the table/action owner boundary needed to restore actual forwarded content; no second parser remains.

Thanks to @xxtyyq for #77909 and to @liuhao1024, @lzyyzznl, @zhangqueping, and @ZengWen-DT for the earlier investigations.

AI-assisted: yes.
