### PR TITLE
fix: stop model transport tests from stalling CI

### DIFF
--- a/src/agents/openai-transport-stream.streaming.test.ts
+++ b/src/agents/openai-transport-stream.streaming.test.ts
@@ -89,12 +89,12 @@ describe("openai transport stream", () => {
   it.each([
     {
       api: "openai-responses" as const,
-      provider: "openai",
+      provider: "custom-openai",
       createStream: createOpenAIResponsesTransportStreamFn,
     },
     {
       api: "azure-openai-responses" as const,
-      provider: "azure-openai",
+      provider: "azure-openai-responses-devdiv",
       createStream: createAzureOpenAIResponsesTransportStreamFn,
     },
     {


### PR DESCRIPTION
## What Problem This Solves

Resolves an issue where otherwise unrelated contributor and maintainer pull requests can fail the `checks-node-compact-large-4` model shard because synthetic loopback transport tests cold-load the real OpenAI or Azure provider plugin and leave serial model-catalog tests close to their 120-second limit.

## Why This Change Was Made

Use the synthetic provider identities already present in the OpenAI streaming test and Azure test harness for the two localhost-only Responses fixtures. The real OpenAI and Azure SDK transport factories, loopback HTTP 500, request timeout, `x-stainless-timeout` header and zero-retry assertions all remain unchanged. This avoids real-provider plugin discovery without changing production behavior, provider configuration, timeouts, CI routing or workflows.

## User Impact

Maintainers and contributors get reliable existing model-shard CI. No shipped runtime, provider, configuration or user-facing behavior changes.

## Evidence

- Measured the same Linux Blacksmith Testbox before and after: OpenAI Responses loopback case `83,460 ms -> 308 ms`; full streaming file `49 passed` in `4.153 s`.
- Final exact canonical shared CI shard, with no isolation or routing changes: `53 files passed; 1,204 tests passed`; streaming `49 passed` in `6.164 s`, OpenAI `504 ms`, Azure `414 ms`, completions `512 ms`; model-catalog visibility `10 passed` in `253 ms`.
- `pnpm check:changed`: passed all guards, formatting, core-test TypeScript, and lint (`0 warnings, 0 errors`).
- Existing planner and routing regression suites: `3 files passed; 346 tests passed`.
- Fresh Codex extra-high-reasoning autoreview and TruffleHog: clean, no actionable findings.
- AI-assisted (Codex); implementation and runtime/plugin ownership reviewed.
