### PR TITLE
fix(release): accept advisory runtime gaps

### DIFF
--- a/scripts/validate-qa-runtime-pair-summary.mjs
+++ b/scripts/validate-qa-runtime-pair-summary.mjs
@@ -119,10 +119,12 @@ function requireRuntimePairScenario(scenario, index) {
   }
 
   if (scenario.status === "pass") {
+    const hasTwoPassingCells = openclaw.status === "pass" && codex.status === "pass";
+    const hasAdvisoryCodexGap =
+      parity.drift === "structural" && openclaw.status === "pass" && isExplicitCodexGap(codex);
     if (
       parity.drift === "failure-mode" ||
-      openclaw.status !== "pass" ||
-      codex.status !== "pass" ||
+      (!hasTwoPassingCells && !hasAdvisoryCodexGap) ||
       !isPassableCell(openclaw) ||
       !isPassableCell(codex)
     ) {

--- a/test/scripts/validate-qa-runtime-pair-summary.test.ts
+++ b/test/scripts/validate-qa-runtime-pair-summary.test.ts
@@ -18,6 +18,7 @@ type RuntimeCell = {
 type ScenarioParams = {
   name: string;
   status: CellStatus;
+  drift?: "none" | "structural" | "failure-mode";
   openclawStatus?: CellStatus;
   codexStatus?: CellStatus;
   codexDetails?: string;
@@ -39,7 +40,7 @@ function scenario(params: ScenarioParams) {
     status: params.status,
     runtimeParity: {
       scenarioId,
-      drift: params.status === "pass" ? "none" : "failure-mode",
+      drift: params.drift ?? (params.status === "pass" ? "none" : "failure-mode"),
       cells: {
         openclaw: cell("openclaw", params.openclawStatus ?? "pass"),
         codex: cell("codex", params.codexStatus ?? "pass", params.codexDetails),
@@ -146,6 +147,94 @@ describe("frozen QA runtime-pair summary validation", () => {
       failed: 0,
       skipped: 2,
     });
+  });
+
+  it("accepts a tracked Codex harness gap kept advisory by the current classifier", () => {
+    const advisoryGap = scenario({
+      name: "tracked advisory gap",
+      status: "pass",
+      drift: "structural",
+      codexStatus: "skip",
+      codexDetails: "known-harness-gap exec: tracked\ntracking: #80319",
+    });
+
+    const fixture = summary([advisoryGap]);
+    expect(validateQaRuntimePairSummary(fixture)).toEqual({
+      total: 1,
+      passed: 1,
+      failed: 0,
+      skipped: 0,
+    });
+
+    const reportSummary = {
+      runtimePair: ["openclaw", "codex"],
+      totalScenarios: 1,
+      passedScenarios: 1,
+      failedScenarios: 0,
+      scenarios: [
+        {
+          name: "tracked advisory gap",
+          status: "pass",
+          drift: "structural",
+          driftDetails: undefined,
+          openclawStatus: "pass",
+          codexStatus: "pass",
+        },
+      ],
+      failures: [],
+      pass: true,
+    };
+    const markdown =
+      "# OpenClaw Runtime Parity Report — openclaw vs codex\n\n- Verdict: pass\n\n### tracked advisory gap\n\n- status: pass\n- drift: structural\n- openclaw: pass (0 tool calls)\n- codex: pass (0 tool calls)\n";
+    expect(validateQaRuntimePairReport(fixture, reportSummary, markdown)).toMatchObject({
+      total: 1,
+      passed: 1,
+    });
+  });
+
+  it("rejects malformed or unsafe advisory gap evidence", () => {
+    const buildAdvisoryGap = () => {
+      const advisoryGap = scenario({
+        name: "tracked advisory gap",
+        status: "pass",
+        drift: "structural",
+        codexStatus: "skip",
+        codexDetails: "known-harness-gap exec: tracked\ntracking: #80319",
+      });
+      return advisoryGap;
+    };
+
+    const unannotated = buildAdvisoryGap();
+    unannotated.runtimeParity.cells.codex.details = "implementation unavailable";
+    expect(() => validateQaRuntimePairSummary(summary([unannotated]))).toThrow(
+      "reports pass without two passing, passable runtime cells",
+    );
+
+    const pairedSkip = buildAdvisoryGap();
+    pairedSkip.runtimeParity.cells.openclaw.status = "skip";
+    expect(() => validateQaRuntimePairSummary(summary([pairedSkip]))).toThrow(
+      "reports pass without two passing, passable runtime cells",
+    );
+
+    const hardError = buildAdvisoryGap();
+    hardError.runtimeParity.cells.codex.runtimeErrorClass = "auth";
+    expect(() => validateQaRuntimePairSummary(summary([hardError]))).toThrow(
+      "reports pass without two passing, passable runtime cells",
+    );
+
+    const missingResult = buildAdvisoryGap();
+    missingResult.runtimeParity.cells.codex.toolCalls.push({
+      errorClass: "tool-result-missing",
+    });
+    expect(() => validateQaRuntimePairSummary(summary([missingResult]))).toThrow(
+      "reports pass without two passing, passable runtime cells",
+    );
+
+    const failureMode = buildAdvisoryGap();
+    failureMode.runtimeParity.drift = "failure-mode";
+    expect(() => validateQaRuntimePairSummary(summary([failureMode]))).toThrow(
+      "reports pass without two passing, passable runtime cells",
+    );
   });
 
   const rejectedSkips: Array<


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Full Release Validation rejected an otherwise passing QA runtime-pair lane when Codex reported an explicitly tracked, passable harness gap and OpenClaw passed the scenario.

## Why This Change Was Made

The canonical runtime-pair classifier intentionally keeps this one-sided known harness gap advisory, but the trusted evidence validator still required both raw cells to be literal passes. The validator now accepts only the existing advisory shape: structural drift, OpenClaw pass, explicit tracked Codex gap, and two otherwise passable cells. Hard errors, missing tool results, unannotated skips, paired skips, and failure-mode drift remain blocking.

## User Impact

No product behavior changes. Release validation can consume the canonical QA classifier output without falsely failing green runtime scenarios.

## Evidence

- Full Release Validation parent 30347454178 exposed the mismatch in Release Checks child 30348309167, job 90239775210. All 27 candidate runtime-pair scenarios passed; only trusted evidence validation failed.
- After-fix real-artifact proof: commit `704274f64ae81cbe758726454aaa355d32eec599` validated the exact downloaded summary plus JSON/Markdown report bytes from failed run 30348309167. Output: `Validated 27 runtime-pair scenarios (27 passed, 0 explicit Codex-native harness gaps).` Exit 0.
- Blacksmith Testbox run 30350737646: focused validator tests passed 14/14.
- Negative boundary proof in that suite rejects unannotated gaps, paired skips, hard auth/runtime errors, missing tool results, failure-mode drift, count/manifest drift, and arbitrary target overrides.
- Exact oxfmt check and `git diff --check` passed.
- Autoreview completed with no actionable findings.
