### PR TITLE
fix(ui): stop Workboard draft fields reverting during edits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Workboard draft fields:** keep title, notes, labels, and comment edits local to the open form so parent renders cannot restore stale values or submit an older draft.
 - **Codex native controls:** stop misclassifying valid thinking/fast runtime controls as provider overrides so Codex routes keep their native controls, while provider-native objects and invalid values stay fail-closed. Thanks @VACInc. (#107588)
 - **State snapshot verification:** run SQLite snapshot verification in a separate process so worker-thread file closes no longer drop the Gateway's POSIX WAL locks, eliminating spurious WAL misses and I/O errors. Thanks @VACInc. (#114016)
 - **Reply latency with model policies:** reuse one immutable plugin-metadata snapshot per model-selection run instead of repeating plugin discovery, cutting reply delay when a model policy is configured. Thanks @VACInc. (#114117)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,7 +51,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- **Workboard draft fields:** keep title, notes, labels, and comment edits local to the open form so parent renders cannot restore stale values or submit an older draft.
 - **Codex native controls:** stop misclassifying valid thinking/fast runtime controls as provider overrides so Codex routes keep their native controls, while provider-native objects and invalid values stay fail-closed. Thanks @VACInc. (#107588)
 - **State snapshot verification:** run SQLite snapshot verification in a separate process so worker-thread file closes no longer drop the Gateway's POSIX WAL locks, eliminating spurious WAL misses and I/O errors. Thanks @VACInc. (#114016)
 - **Reply latency with model policies:** reuse one immutable plugin-metadata snapshot per model-selection run instead of repeating plugin discovery, cutting reply delay when a model policy is configured. Thanks @VACInc. (#114117)

--- a/ui/src/e2e/sidebar-customization.e2e.test.ts
+++ b/ui/src/e2e/sidebar-customization.e2e.test.ts
@@ -36,6 +36,15 @@ async function roundedWidth(locator: Locator): Promise<number> {
   return Math.round((await locator.boundingBox())?.width ?? 0);
 }
 
+async function waitForSettingsSidebar(page: Page) {
+  const sidebar = page.locator(".settings-sidebar");
+  const search = sidebar.getByRole("searchbox", { name: "Search settings" });
+  await sidebar.waitFor({ state: "visible" });
+  // The route shell can paint before the takeover controls settle on a loaded CI host.
+  await search.waitFor({ state: "visible" });
+  return { search, sidebar };
+}
+
 function visibleDrawerButton(page: Page) {
   return page.locator(".topbar-nav-toggle:visible, .chat-pane__nav-toggle:visible").first();
 }
@@ -160,12 +169,11 @@ describeControlUiE2e("Control UI sidebar customization mocked Gateway E2E", () =
 
     try {
       await page.goto(`${server.baseUrl}settings/general`);
-      const settingsSidebar = page.locator(".settings-sidebar");
+      const { search: settingsSearchInput, sidebar: settingsSidebar } =
+        await waitForSettingsSidebar(page);
       const settingsSearchShell = settingsSidebar.locator(".settings-sidebar__search");
-      const settingsSearchInput = settingsSidebar.locator(".settings-sidebar__search-input");
       const settingsNav = settingsSidebar.locator(".settings-sidebar__nav");
       const firstSettingsLink = settingsSidebar.locator(".settings-sidebar__item").first();
-      await settingsSidebar.waitFor();
       await expect
         .poll(() =>
           page
@@ -333,8 +341,8 @@ describeControlUiE2e("Control UI sidebar customization mocked Gateway E2E", () =
       await expect.poll(() => identityCard.isVisible()).toBe(true);
       await openSettingsFromIdentity();
       await expect.poll(() => new URL(page.url()).pathname).toBe("/settings/general");
-      const settingsSidebar = page.locator(".settings-sidebar");
-      await expect.poll(() => settingsSidebar.isVisible()).toBe(true);
+      const { search: settingsSearch, sidebar: settingsSidebar } =
+        await waitForSettingsSidebar(page);
       await expect.poll(() => sidebar.isVisible()).toBe(false);
       await expect
         .poll(() =>
@@ -347,12 +355,8 @@ describeControlUiE2e("Control UI sidebar customization mocked Gateway E2E", () =
       await captureUiProof(page, "01a-settings-takeover.png");
       await captureSettingsSidebarProof(settingsSidebar, "01a-settings-search-initial.png");
       await holdUiProof(page);
-      const settingsSearch = settingsSidebar.getByRole("searchbox", {
-        name: "Search settings",
-      });
       const settingsLinks = settingsSidebar.locator(".settings-sidebar__item");
       const allSettingsLabels = await trimmedTextContents(settingsLinks);
-      await expect.poll(() => settingsSearch.isVisible()).toBe(true);
       await expect
         .poll(() =>
           settingsSearch.evaluate((input) => {

--- a/ui/src/pages/workboard/view-card-modal.ts
+++ b/ui/src/pages/workboard/view-card-modal.ts
@@ -28,6 +28,36 @@ const workboardCardModalTitleId = "workboard-card-modal-title";
 const workboardCardModalDescriptionId = "workboard-card-modal-description";
 export const workboardCardModalId = "workboard-card-modal";
 
+// Keep keystroke state local to the form. A parent render can restore stale
+// controlled values before the next field is edited or the draft is submitted.
+function syncDraftTextInput(
+  state: WorkboardUiState,
+  form: HTMLFormElement,
+  input: HTMLInputElement | HTMLTextAreaElement,
+  draftActionsBusy: boolean,
+) {
+  if (input.classList.contains("workboard-draft__title")) {
+    state.draftTitle = input.value;
+  } else if (input.classList.contains("workboard-draft__notes")) {
+    state.draftNotes = input.value;
+  } else if (input.classList.contains("workboard-draft__labels")) {
+    state.draftLabels = input.value;
+  } else if (input.classList.contains("workboard-comments__input")) {
+    state.draftCommentBody = input.value;
+  } else {
+    return;
+  }
+
+  const draftSubmit = form.querySelector<HTMLButtonElement>(".workboard-draft__submit");
+  if (draftSubmit) {
+    draftSubmit.disabled = draftActionsBusy || !state.draftTitle.trim();
+  }
+  const commentSubmit = form.querySelector<HTMLButtonElement>(".workboard-comments__submit");
+  if (commentSubmit) {
+    commentSubmit.disabled = draftActionsBusy || !state.draftCommentBody.trim();
+  }
+}
+
 function defineTemplate(
   id: WorkboardTemplateId,
   draftKey: string,
@@ -168,6 +198,17 @@ export function renderCardModal(props: WorkboardProps) {
         id=${workboardCardModalId}
         class="workboard-draft"
         aria-busy=${draftActionsBusy ? "true" : "false"}
+        @input=${(event: InputEvent) => {
+          const input = event.target;
+          if (input instanceof HTMLInputElement || input instanceof HTMLTextAreaElement) {
+            syncDraftTextInput(
+              state,
+              event.currentTarget as HTMLFormElement,
+              input,
+              draftActionsBusy,
+            );
+          }
+        }}
         @submit=${(event: SubmitEvent) => {
           event.preventDefault();
           if (draftActionsBusy) {
@@ -238,10 +279,6 @@ export function renderCardModal(props: WorkboardProps) {
                 placeholder=${t("workboard.titlePlaceholder")}
                 ?disabled=${draftActionsBusy}
                 .value=${state.draftTitle}
-                @input=${(event: InputEvent) => {
-                  state.draftTitle = (event.currentTarget as HTMLInputElement).value;
-                  props.onRequestUpdate?.();
-                }}
               />
             </label>
             <label class="workboard-field">
@@ -251,10 +288,6 @@ export function renderCardModal(props: WorkboardProps) {
                 placeholder=${t("workboard.notesPlaceholder")}
                 ?disabled=${draftActionsBusy}
                 .value=${state.draftNotes}
-                @input=${(event: InputEvent) => {
-                  state.draftNotes = (event.currentTarget as HTMLTextAreaElement).value;
-                  props.onRequestUpdate?.();
-                }}
               ></textarea>
             </label>
           </div>
@@ -306,14 +339,10 @@ export function renderCardModal(props: WorkboardProps) {
             <label class="workboard-field workboard-field--wide">
               <span>${t("workboard.fieldLabels")}</span>
               <input
-                class="input"
+                class="input workboard-draft__labels"
                 placeholder=${t("workboard.labelsPlaceholder")}
                 ?disabled=${draftActionsBusy}
                 .value=${state.draftLabels}
-                @input=${(event: InputEvent) => {
-                  state.draftLabels = (event.currentTarget as HTMLInputElement).value;
-                  props.onRequestUpdate?.();
-                }}
               />
             </label>
           </div>
@@ -339,14 +368,10 @@ export function renderCardModal(props: WorkboardProps) {
                     maxlength="2000"
                     ?disabled=${draftActionsBusy}
                     .value=${state.draftCommentBody}
-                    @input=${(event: InputEvent) => {
-                      state.draftCommentBody = (event.currentTarget as HTMLTextAreaElement).value;
-                      props.onRequestUpdate?.();
-                    }}
                   ></textarea>
                   <div class="workboard-modal__actions">
                     <button
-                      class="btn"
+                      class="btn workboard-comments__submit"
                       type="button"
                       ?disabled=${draftActionsBusy || !state.draftCommentBody.trim()}
                       @click=${() => {
@@ -365,7 +390,10 @@ export function renderCardModal(props: WorkboardProps) {
             : nothing}
         </div>
         <div class="workboard-modal__actions">
-          <button class="btn primary" ?disabled=${draftActionsBusy || !state.draftTitle.trim()}>
+          <button
+            class="btn primary workboard-draft__submit"
+            ?disabled=${draftActionsBusy || !state.draftTitle.trim()}
+          >
             ${editing ? t("common.save") : t("common.create")}
           </button>
           <button

--- a/ui/src/pages/workboard/workboard.e2e.test.ts
+++ b/ui/src/pages/workboard/workboard.e2e.test.ts
@@ -105,6 +105,16 @@ async function chooseWorkboardSelectFieldOption(
   }, optionValue);
 }
 
+async function setWorkboardDraftField(
+  scope: Page | Locator,
+  label: string,
+  value: string,
+): Promise<void> {
+  const input = scope.getByLabel(label);
+  await input.fill(value);
+  await expect.poll(() => input.inputValue()).toBe(value);
+}
+
 async function waitForRequests(
   gateway: MockGatewayControls,
   method: string,
@@ -440,10 +450,10 @@ describeControlUiE2e("Control UI Workboard mocked Gateway E2E", () => {
       const createDialog = writable.page.getByRole("dialog", { name: "New card" });
       const createForm = writable.page.locator('openclaw-modal-dialog[label="New card"]');
       await expect.poll(() => createDialog.isVisible()).toBe(true);
-      await createForm.getByLabel("Title").fill(createdCard.title);
-      await createForm.getByLabel("Notes").fill(createdCard.notes ?? "");
+      await setWorkboardDraftField(createForm, "Title", createdCard.title);
+      await setWorkboardDraftField(createForm, "Notes", createdCard.notes ?? "");
       await chooseWorkboardSelectOption(createForm, "Thread", linkedSessionName);
-      await createForm.getByLabel("Labels").fill("ui, proof");
+      await setWorkboardDraftField(createForm, "Labels", "ui, proof");
       await captureScreenshot(writable.page, artifacts, "02-create-dialog");
       const createBefore = (await writableGateway.getRequests("workboard.cards.create")).length;
       await createForm.getByRole("button", { name: /^Create$/u }).click();
@@ -495,10 +505,10 @@ describeControlUiE2e("Control UI Workboard mocked Gateway E2E", () => {
       const editDialog = writable.page.getByRole("dialog", { name: "Edit card" });
       const editForm = writable.page.locator('openclaw-modal-dialog[label="Edit card"]');
       await expect.poll(() => editDialog.isVisible()).toBe(true);
-      await editForm.getByLabel("Title").fill(editedCard.title);
-      await editForm.getByLabel("Notes").fill(editedCard.notes ?? "");
+      await setWorkboardDraftField(editForm, "Title", editedCard.title);
+      await setWorkboardDraftField(editForm, "Notes", editedCard.notes ?? "");
       await chooseWorkboardSelectOption(editForm, "Priority", "High");
-      await editForm.getByLabel("Labels").fill("ui, proof, e2e");
+      await setWorkboardDraftField(editForm, "Labels", "ui, proof, e2e");
       const updateBeforeEdit = (await writableGateway.getRequests("workboard.cards.update")).length;
       await editForm.getByRole("button", { name: /^Save$/u }).click();
       const editRequest = await waitForNextRequest(


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Workboard users editing a card could have a recently entered title, notes, labels, or comment silently restored to an older value when the modal rerendered. Under load, the stale value could then be submitted; the CI reproduction changed labels to `ui, proof, e2e` but sent `ui, proof`, and another run retained only the first four characters of edited notes.

## Why This Change Was Made

The open form now owns keystroke synchronization for all draft text fields and updates the two dependent submit-button states locally. This removes parent-page rerenders from the keystroke path while retaining parent updates for structural changes such as template, status, priority, agent, and thread selection.

The browser regression verifies every filled field before submission, so a stale render fails at the actual ownership boundary instead of surfacing later as a mismatched Gateway request.

The full UI-E2E lane then exposed a separate deterministic timing defect in the sidebar test: the settings takeover shell can paint before its accessible search control settles on a loaded runner. A shared readiness helper now waits for both states at every affected call site, replacing the short `expect.poll` race without hiding a control that never appears.

## User Impact

Workboard card and comment edits remain exactly as entered until they are submitted or cancelled, including when other modal controls cause the surrounding page to update.

## Evidence

- Before fix, the strengthened real Chromium flow reproduced stale controlled values on Testbox: labels remained `ui, proof` instead of `ui, proof, e2e`, and notes could stop at `Acce`.
- After fix, five consecutive real Chromium runs passed the full create/edit/move/reload/read-only scenario on Blacksmith Testbox `tbx_01kym2nzfhvvhdf3jtfrze4dg7`.
- Focused Workboard surface: 100 tests passed.
- Exact-head CI run https://github.com/openclaw/openclaw/actions/runs/30351834389 proved all Workboard E2E scenarios passed; the only failure was the unrelated sidebar takeover readiness assertion at `sidebar-customization.e2e.test.ts:355`.
- After hardening that readiness boundary, five consecutive Chromium repetitions passed all 11 sidebar-customization scenarios on Blacksmith Testbox `tbx_01kym9k4bxaz5z8p1kxjpc4kks`, run https://github.com/openclaw/openclaw/actions/runs/30357142855.
- `git diff --check` and targeted oxfmt passed.
- Fresh Codex autoreview on exact head `7cf93a5c2ba4f87f1eded7120f2ae50ab909dd8d` reported no accepted or actionable findings with 0.96 confidence.

## Risk Checklist

- User-visible behavior: Workboard draft edits stop reverting.
- Config, env, migration, persistence: no changes.
- Security, auth, network, dependencies: no changes.
- Test hardening: waits for the actual accessible control, so a missing control still fails.

AI-assisted.
