### PR TITLE
fix(state): accept pre-provenance agent DBs missing memory chunk metadata columns

### DIFF
--- a/src/state/openclaw-agent-db-schema-helpers.ts
+++ b/src/state/openclaw-agent-db-schema-helpers.ts
@@ -50,7 +50,14 @@ const AGENT_SCHEMA_COMPATIBILITY = {
     STANDING_INTENTS_FTS_TABLE,
     ...STANDING_INTENTS_FTS_SHADOW_TABLES,
   ],
-  allowedMissingColumns: ["standing_intents.creator_sender"],
+  // Pre-provenance agent DBs lack the importance/triggers columns; memory-core's
+  // lazy ensure ALTERs them in on first memory use, so accept their absence here
+  // or every existing deployment fails doctor and rolls back its update.
+  allowedMissingColumns: [
+    "standing_intents.creator_sender",
+    "memory_index_chunks.importance",
+    "memory_index_chunks.triggers",
+  ],
   allowedColumnDefinitions: {
     "conversations.delivery_target": ["delivery_target TEXT NOT NULL DEFAULT ''"],
   },

--- a/src/state/openclaw-agent-standing-intents-schema.test.ts
+++ b/src/state/openclaw-agent-standing-intents-schema.test.ts
@@ -22,6 +22,8 @@ const PROVENANCE_TRIGGER_START =
 const PROVENANCE_TRIGGER_END = "CREATE INDEX IF NOT EXISTS idx_memory_embedding_cache_updated_at";
 const STANDING_CREATOR_COLUMN =
   "  creator_sender TEXT CHECK (creator_sender IS NULL OR length(trim(creator_sender)) > 0),\n";
+const MEMORY_CHUNK_METADATA_COLUMNS =
+  ",\n  importance INTEGER CHECK (importance IS NULL OR importance BETWEEN 1 AND 10),\n  triggers TEXT";
 
 function removeSchemaSection(schema: string, startMarker: string, endMarker: string): string {
   const start = schema.indexOf(startMarker);
@@ -50,6 +52,13 @@ function schemaWithoutStandingIntentCreator(): string {
     throw new Error("standing-intent creator column missing in test fixture");
   }
   return OPENCLAW_AGENT_SCHEMA_SQL.replace(STANDING_CREATOR_COLUMN, "");
+}
+
+function schemaWithoutMemoryChunkMetadata(): string {
+  if (!OPENCLAW_AGENT_SCHEMA_SQL.includes(MEMORY_CHUNK_METADATA_COLUMNS)) {
+    throw new Error("memory chunk metadata columns missing in test fixture");
+  }
+  return OPENCLAW_AGENT_SCHEMA_SQL.replace(MEMORY_CHUNK_METADATA_COLUMNS, "");
 }
 
 describe("additive memory agent schemas", () => {
@@ -224,6 +233,38 @@ describe("additive memory agent schemas", () => {
       expect(() =>
         ensureOpenClawAgentDatabaseSchema(db, { agentId: "main", path: databasePath }),
       ).not.toThrow();
+    } finally {
+      db.close();
+    }
+  });
+
+  it("accepts pre-provenance databases missing the memory chunk metadata columns", async () => {
+    tempDir = await fs.realpath(
+      await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-chunk-metadata-schema-")),
+    );
+    const databasePath = path.join(tempDir, "openclaw-agent.sqlite");
+    const db = openNodeSqliteDatabase(databasePath);
+    try {
+      db.exec(schemaWithoutMemoryChunkMetadata());
+      db.exec(`PRAGMA user_version = ${OPENCLAW_AGENT_SCHEMA_VERSION};`);
+      db.prepare(
+        `INSERT INTO schema_meta (
+          meta_key, role, schema_version, agent_id, app_version, created_at, updated_at
+        ) VALUES ('primary', 'agent', ?, 'main', 'test', 1, 1)`,
+      ).run(OPENCLAW_AGENT_SCHEMA_VERSION);
+
+      // Regression: shipped pre-provenance agent DBs must pass the canonical
+      // check before memory-core's lazy ensure ALTERs the columns in, or every
+      // existing deployment fails doctor and the updater rolls back.
+      expect(() =>
+        ensureOpenClawAgentDatabaseSchema(db, { agentId: "main", path: databasePath }),
+      ).not.toThrow();
+      expect(
+        db
+          .prepare("SELECT name FROM pragma_table_info('memory_index_chunks')")
+          .all()
+          .map((row) => (row as { name: string }).name),
+      ).not.toContain("importance");
     } finally {
       db.close();
     }


### PR DESCRIPTION
## What Problem This Solves

#114819 (provenance-gated memory, `28630a9a`) added `importance` and `triggers` columns to the existing `memory_index_chunks` table in the canonical agent schema, relying on memory-core's lazy `ALTER TABLE` to add them on first memory use — but did not add them to `allowedMissingColumns` in `AGENT_SCHEMA_COMPATIBILITY` (unlike the sibling `standing_intents.creator_sender`, which it did allowlist). Every pre-existing agent DB now fails the canonical schema check with `SQLite schema is incomplete or noncanonical ... column definitions differ for memory_index_chunks`, `openclaw doctor` errors, and the git-channel updater rolls back. Main is effectively upgrade-broken for all existing deployments.

## Why This Change Was Made

Observed live in production: both Hetzner hosts (openclaw-team, openclaw-clawsweeper) failed their 10:08/10:18 UTC hourly update cycles with exactly this doctor error across every agent DB (roboclaw, main, mantis, molty, molty-forum, openclaw, tideclaw) and rolled back to their prior SHAs. The timers stay red until this lands.

## User Impact

Existing installs can update again; the doctor gate accepts pre-provenance DBs and memory-core's existing lazy ensure upgrades them on first memory use, matching the repo's additive-surface policy (no schema-version bump).

## Evidence

- Two-line fix following the exact `standing_intents.creator_sender` precedent in the same object; comment documents the contract.
- New regression test in `src/state/openclaw-agent-standing-intents-schema.test.ts` builds a pre-provenance DB (canonical schema minus the two columns) and proves `ensureOpenClawAgentDatabaseSchema` accepts it without the columns present.
- `node scripts/run-vitest.mjs src/state/openclaw-agent-standing-intents-schema.test.ts` → 4 passed; `src/state/openclaw-agent-db.test.ts` → 89 passed; `pnpm check:test-types` green; Codex autoreview clean.
- Production journals (both hosts, redacted): updater step `✗ openclaw doctor — SQLite schema is incomplete or noncanonical for .../agents/<id>/agent/openclaw-agent.sqlite: column definitions differ for memory_index_chunks`, followed by clean rollback.
