### PR TITLE
test: align release validation fixtures

### DIFF
--- a/extensions/qa-lab/src/coverage-report.test.ts
+++ b/extensions/qa-lab/src/coverage-report.test.ts
@@ -232,7 +232,7 @@ describe("qa coverage report", () => {
     ).toContainEqual({
       coverageId: TEST_BROWSER_COVERAGE_ID,
       kind: "playwright",
-      path: "ui/src/e2e/chat-flow.e2e.test.ts",
+      path: "ui/src/e2e/chat-flow.messaging.e2e.test.ts",
       role: "primary",
       scenarioRefs: ["qa/scenarios/ui/control-ui-chat-flow-playwright.yaml"],
     });
@@ -389,22 +389,27 @@ describe("qa coverage report", () => {
       "- tools.tool-invocation-and-execution (tools / Tool Invocation and Execution; partial): profiles: all, release; coverage IDs:",
     );
     expect(report).toContain(
-      "primary:playwright:ui/src/e2e/chat-flow.e2e.test.ts (control-ui.gateway-hosted-ui-control)",
+      "primary:playwright:ui/src/e2e/chat-flow.messaging.e2e.test.ts (control-ui.gateway-hosted-ui-control)",
     );
     expect(report).not.toContain("### Unknown Scenario Coverage IDs");
   });
 
   it("renders Playwright matches as qa suite targets", () => {
-    const matches = findQaScenarioMatches(readQaScenarioPack().scenarios, "chat-flow.e2e");
+    const matches = findQaScenarioMatches(
+      readQaScenarioPack().scenarios,
+      "chat-flow.messaging.e2e",
+    );
     const report = renderQaScenarioMatchesMarkdownReport({
-      query: "chat-flow.e2e",
+      query: "chat-flow.messaging.e2e",
       matches,
     });
 
     expect(report).toContain(
       "- Suite command: `pnpm openclaw qa suite --scenario control-ui-chat-flow-playwright`",
     );
-    expect(report).toContain("  - execution: playwright ui/src/e2e/chat-flow.e2e.test.ts");
+    expect(report).toContain(
+      "  - execution: playwright ui/src/e2e/chat-flow.messaging.e2e.test.ts",
+    );
     expect(report).not.toContain("Native test refs");
   });
 
@@ -468,7 +473,7 @@ describe("qa coverage report", () => {
   });
 
   it("splits qa suite targets when matches mix execution kinds", () => {
-    const playwrightExecutionPath = "ui/src/e2e/chat-flow.e2e.test.ts";
+    const playwrightExecutionPath = "ui/src/e2e/chat-flow.messaging.e2e.test.ts";
     const flowScenario = scenarioWithCoverage({
       primary: [TEST_EXECUTABLE_COVERAGE_ID],
     });
@@ -552,7 +557,7 @@ describe("qa coverage report", () => {
           primary: [TEST_BROWSER_COVERAGE_ID],
           sourcePath: "qa/scenarios/ui/control-ui-chat-flow-playwright.yaml",
           executionKind: "playwright",
-          executionPath: "ui/src/e2e/chat-flow.e2e.test.ts",
+          executionPath: "ui/src/e2e/chat-flow.messaging.e2e.test.ts",
         }),
       ],
     });
@@ -568,7 +573,7 @@ describe("qa coverage report", () => {
       {
         coverageId: TEST_BROWSER_COVERAGE_ID,
         kind: "playwright",
-        path: "ui/src/e2e/chat-flow.e2e.test.ts",
+        path: "ui/src/e2e/chat-flow.messaging.e2e.test.ts",
         role: "primary",
         scenarioRefs: ["qa/scenarios/ui/control-ui-chat-flow-playwright.yaml"],
       },

--- a/extensions/qa-lab/src/scenario-catalog.test.ts
+++ b/extensions/qa-lab/src/scenario-catalog.test.ts
@@ -243,7 +243,7 @@ describe("qa scenario catalog", () => {
     if (scenario.execution.kind !== "playwright") {
       throw new Error(`expected Playwright scenario, got ${scenario.execution.kind}`);
     }
-    expect(scenario.execution.path).toBe("ui/src/e2e/chat-flow.e2e.test.ts");
+    expect(scenario.execution.path).toBe("ui/src/e2e/chat-flow.messaging.e2e.test.ts");
     expect(scenario.execution.testNamePattern).toBe(
       "sends a chat turn through the GUI and renders the final Gateway event",
     );

--- a/extensions/qa-lab/src/suite-runtime-agent-session.test.ts
+++ b/extensions/qa-lab/src/suite-runtime-agent-session.test.ts
@@ -3,7 +3,6 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import {
   loadTranscriptEventsSync,
-  parseSqliteSessionFileMarker,
   upsertSessionEntry,
 } from "openclaw/plugin-sdk/session-store-runtime";
 import { appendSessionTranscriptMessageByIdentity } from "openclaw/plugin-sdk/session-transcript-runtime";
@@ -281,11 +280,6 @@ describe("qa suite runtime agent session helpers", () => {
         origin: { label: "Seeded QA transcript" },
       },
     });
-    expect(parseSqliteSessionFileMarker(sessionStore[sessionKey]?.sessionFile)).toMatchObject({
-      agentId: "qa",
-      sessionId,
-    });
-
     const transcriptEvents = loadTranscriptEventsSync({
       agentId: "qa",
       env: qaSessionEnv(tempRoot),

--- a/extensions/telegram/src/bot.create-telegram-bot.test.ts
+++ b/extensions/telegram/src/bot.create-telegram-bot.test.ts
@@ -17,7 +17,10 @@ import type { GetReplyOptions, MsgContext } from "openclaw/plugin-sdk/reply-runt
 import { withEnvAsync } from "openclaw/plugin-sdk/test-env";
 import { sanitizeTerminalText } from "openclaw/plugin-sdk/test-fixtures";
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
-import { telegramBotInfoForTest } from "./bot.create-telegram-bot.test-support.js";
+import {
+  createTelegramNativeCommandTestDeps,
+  telegramBotInfoForTest,
+} from "./bot.create-telegram-bot.test-support.js";
 import {
   createTelegramCallbackContext,
   runTelegramTestMiddlewareChain,
@@ -438,7 +441,10 @@ describe("createTelegramBot", () => {
       createTelegramBotBase({
         botInfo: telegramBotInfoForTest,
         ...opts,
-        telegramDeps: telegramBotDepsForTest,
+        telegramDeps: {
+          ...telegramBotDepsForTest,
+          ...createTelegramNativeCommandTestDeps(dispatchReplyWithBufferedBlockDispatcher),
+        },
       });
     pluginStateTestRuntime.resetPluginStateStoreForTests({ closeDatabase: false });
   });

--- a/extensions/telegram/src/bot.test.ts
+++ b/extensions/telegram/src/bot.test.ts
@@ -634,16 +634,17 @@ describe("createTelegramBot", () => {
         telegram: { dmPolicy: "open", allowFrom: ["*"] },
       },
     });
-    const telegramDeps = {
-      ...telegramBotDepsForTest,
-      ...createTelegramNativeCommandTestDeps(dispatchReplyWithBufferedBlockDispatcher),
-    };
-    createTelegramBot = (opts) =>
-      createTelegramBotBase({
+    createTelegramBot = (opts) => {
+      const telegramDeps = {
+        ...telegramBotDepsForTest,
+        ...createTelegramNativeCommandTestDeps(dispatchReplyWithBufferedBlockDispatcher),
+      };
+      return createTelegramBotBase({
         botInfo: telegramBotInfoForTest,
         ...opts,
         telegramDeps,
       });
+    };
   });
 
   it("starts with retired includeGroupHistoryContext still present in raw config", async () => {

--- a/extensions/telegram/src/send.test.ts
+++ b/extensions/telegram/src/send.test.ts
@@ -52,7 +52,8 @@ const {
   probeVideoDimensions,
 } = getTelegramSendTestMocks();
 const telegramSendModule = await importTelegramSendModule();
-const { resetLogger, setLoggerOverride } = await import("openclaw/plugin-sdk/runtime-env");
+const { getChildLogger, resetLogger, setLoggerOverride } =
+  await import("openclaw/plugin-sdk/runtime-env");
 const {
   buildInlineKeyboard,
   createForumTopicTelegram,
@@ -405,8 +406,17 @@ function captureInfoLogs(): string {
   return logFile;
 }
 
-function capturedLogText(logFile: string): string {
-  return fs.existsSync(logFile) ? fs.readFileSync(logFile, "utf8") : "";
+async function capturedLogText(logFile: string): Promise<string> {
+  const marker = `telegram-send-log-capture-ready=${logCaptureCounter}`;
+  getChildLogger({ module: "telegram-send-test" }).info(marker);
+  let content = "";
+  // File logging is FIFO but asynchronous. Seeing this later marker proves all
+  // records from the send attempt are durable before positive or negative checks.
+  await vi.waitFor(() => {
+    content = fs.existsSync(logFile) ? fs.readFileSync(logFile, "utf8") : "";
+    expect(content).toContain(marker);
+  });
+  return content;
 }
 
 afterEach(() => {
@@ -1200,7 +1210,7 @@ describe("sendMessageTelegram", () => {
 
     const richMessage = botRawApi.sendRichMessage.mock.calls[0]?.[0]?.rich_message;
     expect(richMessage?.blocks?.some((block: InputRichBlock) => block.type === "pre")).toBe(true);
-    expect(capturedLogText(logFile)).toContain("rich-degrade=table-ascii");
+    expect(await capturedLogText(logFile)).toContain("rich-degrade=table-ascii");
   });
 
   it("skips rich entity detection for provider-prefixed email text", async () => {
@@ -3511,7 +3521,7 @@ describe("sendMessageTelegram", () => {
       silent: true,
     });
 
-    const logs = capturedLogText(logFile);
+    const logs = await capturedLogText(logFile);
     expect(logs).toContain("outbound send ok");
     expect(logs).toContain("accountId=ops");
     expect(logs).toContain(`chatId=${chatId}`);
@@ -3548,7 +3558,7 @@ describe("sendMessageTelegram", () => {
       parse_mode: "HTML",
       message_thread_id: 271,
     });
-    const logs = capturedLogText(logFile);
+    const logs = await capturedLogText(logFile);
     expect(logs).not.toContain("outbound send ok");
     expect(logs).not.toContain(body);
   });
@@ -3582,7 +3592,7 @@ describe("sendMessageTelegram", () => {
       messageThreadId: 45,
     });
 
-    const logs = capturedLogText(logFile);
+    const logs = await capturedLogText(logFile);
     expect(logs).toContain("outbound send ok");
     expect(logs).toContain("accountId=ops");
     expect(logs).toContain(`chatId=${chatId}`);
@@ -3631,7 +3641,7 @@ describe("sendMessageTelegram", () => {
         message_thread_id: 271,
       },
     );
-    const logs = capturedLogText(logFile);
+    const logs = await capturedLogText(logFile);
     expect(logs).not.toContain("outbound send ok");
   });
 

--- a/src/plugin-sdk/test-helpers/provider-discovery-contract.ts
+++ b/src/plugin-sdk/test-helpers/provider-discovery-contract.ts
@@ -7,7 +7,7 @@ import {
 } from "../../test-utils/plugin-registration.js";
 import type { AuthProfileStore, OpenClawConfig } from "../provider-auth.js";
 
-const resolveCopilotApiTokenMock = vi.hoisted(() => vi.fn());
+const resolveCopilotRuntimeAuthMock = vi.hoisted(() => vi.fn());
 const buildVllmProviderMock = vi.hoisted(() => vi.fn());
 const buildSglangProviderMock = vi.hoisted(() => vi.fn());
 const ensureAuthProfileStoreMock = vi.hoisted(() => vi.fn());
@@ -189,7 +189,7 @@ function installDiscoveryHooks(state: DiscoveryState, options: DiscoveryContract
         const actual = await vi.importActual<object>(options.githubCopilotRegisterRuntimeModuleId!);
         return {
           ...actual,
-          resolveCopilotApiToken: resolveCopilotApiTokenMock,
+          resolveCopilotRuntimeAuth: resolveCopilotRuntimeAuthMock,
         };
       });
     }
@@ -262,7 +262,7 @@ function installDiscoveryHooks(state: DiscoveryState, options: DiscoveryContract
 
   afterEach(() => {
     vi.restoreAllMocks();
-    resolveCopilotApiTokenMock.mockReset();
+    resolveCopilotRuntimeAuthMock.mockReset();
     buildVllmProviderMock.mockReset();
     buildSglangProviderMock.mockReset();
     ensureAuthProfileStoreMock.mockReset();
@@ -306,10 +306,10 @@ export function describeGithubCopilotProviderDiscoveryContract(params: {
     });
 
     it("keeps env-token base URL resolution provider-owned", async () => {
-      resolveCopilotApiTokenMock.mockResolvedValueOnce({
-        token: "copilot-api-token",
+      resolveCopilotRuntimeAuthMock.mockResolvedValueOnce({
+        apiKey: "copilot-api-token",
+        source: "validated:https://api.github.com/copilot_internal/user",
         baseUrl: "https://copilot-proxy.example.com",
-        expiresAt: Date.now() + 60_000,
       });
 
       await expect(
@@ -327,7 +327,7 @@ export function describeGithubCopilotProviderDiscoveryContract(params: {
         },
       });
       const copilotCall = requireRecord(
-        resolveCopilotApiTokenMock.mock.calls.at(0)?.[0],
+        resolveCopilotRuntimeAuthMock.mock.calls.at(0)?.[0],
         "copilot token params",
       );
       expect(copilotCall.githubToken).toBe("github-env-token");

--- a/src/plugins/memory-embedding-provider-runtime.test.ts
+++ b/src/plugins/memory-embedding-provider-runtime.test.ts
@@ -109,21 +109,25 @@ describe("memory embedding provider runtime resolution", () => {
   it("uses registered adapters through a configured provider api", () => {
     const ollamaAdapter = createCapabilityAdapter("ollama");
     registerMemoryEmbeddingProvider(ollamaAdapter);
-
-    expect(
-      runtimeModule.getMemoryEmbeddingProvider("ollama-gpu1", {
-        models: {
-          providers: {
-            "ollama-gpu1": {
-              api: "ollama",
-              baseUrl: "http://ollama-host:11435",
-              models: [],
-            },
+    const config = {
+      models: {
+        providers: {
+          "ollama-gpu1": {
+            api: "ollama",
+            baseUrl: "http://ollama-host:11435",
+            models: [],
           },
         },
-      } as never),
-    ).toBe(ollamaAdapter);
-    expect(mocks.resolvePluginCapabilityProvider).not.toHaveBeenCalled();
+      },
+    } as never;
+
+    expect(runtimeModule.getMemoryEmbeddingProvider("ollama-gpu1", config)).toBe(ollamaAdapter);
+    expect(mocks.resolvePluginCapabilityProvider).toHaveBeenCalledTimes(1);
+    expect(mocks.resolvePluginCapabilityProvider).toHaveBeenCalledWith({
+      key: "memoryEmbeddingProviders",
+      providerId: "ollama-gpu1",
+      cfg: config,
+    });
   });
 
   it("prefers registered adapters over declared capability fallback adapters with the same id", () => {


### PR DESCRIPTION
## What Problem This Solves

Fixes stale release-validation fixtures that failed after canonical memory, provider-auth, QA scenario, Telegram dependency, and asynchronous logging changes.

## Why This Change Was Made

The tests now use current runtime contracts: configured memory adapters still resolve capabilities, GitHub Copilot discovery returns runtime auth, QA uses the renamed messaging scenario and canonical transcript identity, Telegram bot tests isolate native-command dependencies, and file-log assertions await an ordered flush marker.

## User Impact

No product behavior changes. Full extension and release validation no longer fail on retired fixture assumptions or asynchronous log timing.

## Evidence

- [Memory, GitHub Copilot, and QA focused Testbox run](https://github.com/openclaw/openclaw/actions/runs/30352068681): memory 5/5, Copilot discovery 3/3, QA Lab 78/78.
- [Telegram bot isolation Testbox run](https://github.com/openclaw/openclaw/actions/runs/30352140431): 246/246.
- [Telegram send logging Testbox run](https://github.com/openclaw/openclaw/actions/runs/30352004118): 176/176.
- Exact-head hosted CI: [run 30352562798](https://github.com/openclaw/openclaw/actions/runs/30352562798).
- Formatting, `git diff --check`, and per-change autoreview passed.

## Maintainer Verification

Reviewed against current `main` and the scoped plugin, Telegram, agent, and test guidance. The current memory lookup owner (`src/plugins/embedding-provider-runtime-shared.ts`), Copilot runtime-auth owner (`extensions/github-copilot/runtime-auth.ts` and `register.runtime.ts`), QA scenario/session contracts, Telegram native-command test seam, and FIFO asynchronous logger transport all match the refreshed fixtures. Repo-native review artifacts validate with zero findings and a `READY FOR /prepare-pr` recommendation.
