### PR TITLE
fix(twitch): use managed runtime dependencies

### DIFF
--- a/extensions/twitch/package.json
+++ b/extensions/twitch/package.json
@@ -54,6 +54,7 @@
       "setup": { "fields": [] }
     },
     "release": {
+      "bundleRuntimeDependencies": false,
       "publishToClawHub": true,
       "publishToNpm": true
     }


### PR DESCRIPTION
## What Problem This Solves

Fixes Twitch release packaging incorrectly attempting to bundle dependencies that belong to its managed runtime installation.

## Why This Change Was Made

Twitch now explicitly opts out of release-time runtime dependency bundling, matching the package installation contract used by the plugin.

## User Impact

Twitch package validation and installation use the managed dependency path without duplicate bundled runtime payloads.

## Evidence

- Selected Twitch npm release check passed.
- Selected Twitch ClawHub release check passed.
- Package-manifest tests: 10/10 passed.
- Plugin inventory, `git diff --check`, and autoreview passed.
- Exact-head npm package proof produced `@openclaw/twitch@2026.7.2` with all four declared runtime dependencies and no bundled dependency payload or nested `node_modules`.
- A fresh tarball install resolved `@twurple/api-call`, `@twurple/auth`, `@twurple/chat`, and `zod` from the managed npm dependency tree.
- An upgrade from published `@openclaw/twitch@2026.7.2-beta.5` to the exact-head tarball completed and resolved the same managed dependencies.
