### PR TITLE
fix(feishu): inspect canonical doctor transcripts

### DIFF
--- a/extensions/feishu/src/doctor.test.ts
+++ b/extensions/feishu/src/doctor.test.ts
@@ -4,7 +4,6 @@ import os from "node:os";
 import path from "node:path";
 import { DatabaseSync } from "node:sqlite";
 import {
-  formatSqliteSessionFileMarker,
   listSessionEntries,
   normalizeSessionDeliveryState,
   type SessionEntry,
@@ -106,11 +105,29 @@ function readStoreEntries(target: string, agentId = "main"): Record<string, Sess
   );
 }
 
-function writeTranscript(sessionId: string, lines: unknown[], agentId = "main"): string {
+function writeLegacyTranscript(sessionId: string, lines: unknown[], agentId = "main"): string {
   const target = path.join(sessionsDir(agentId), `${sessionId}.jsonl`);
   fs.mkdirSync(path.dirname(target), { recursive: true });
   fs.writeFileSync(target, `${lines.map((line) => JSON.stringify(line)).join("\n")}\n`);
   return target;
+}
+
+async function seedTranscriptMessages(params: {
+  agentId?: string;
+  sessionId: string;
+  sessionKey: string;
+  storePath: string;
+  contents: string[];
+}): Promise<void> {
+  for (const content of params.contents) {
+    await appendSessionTranscriptMessageByIdentity({
+      agentId: params.agentId ?? "main",
+      sessionId: params.sessionId,
+      sessionKey: params.sessionKey,
+      storePath: params.storePath,
+      message: { role: "user", content },
+    });
+  }
 }
 
 function sessionHeader(sessionId: string) {
@@ -163,13 +180,18 @@ describe("Feishu doctor state repair", () => {
     fs.mkdirSync(feishuDedupDir, { recursive: true });
     fs.writeFileSync(path.join(feishuDedupDir, "default.json"), JSON.stringify({ msg1: 1 }));
 
-    writeTranscript("sess-ok", [sessionHeader("sess-ok"), userMessage("hello")]);
-    await writeStore({
-      "agent:main:feishu:direct:ou_user": {
+    const sessionKey = "agent:main:feishu:direct:ou_user";
+    const targetStorePath = await writeStore({
+      [sessionKey]: {
         sessionId: "sess-ok",
-        sessionFile: "sess-ok.jsonl",
         updatedAt: Date.now(),
       },
+    });
+    await seedTranscriptMessages({
+      sessionId: "sess-ok",
+      sessionKey,
+      storePath: targetStorePath,
+      contents: ["hello"],
     });
 
     const result = await runFeishuDoctorSequence({
@@ -181,21 +203,23 @@ describe("Feishu doctor state repair", () => {
     expect(result).toEqual({ changeNotes: [], warningNotes: [] });
   });
 
-  it("keeps custom-store sessions with canonical absolute transcripts", async () => {
+  it("keeps custom-store sessions with canonical transcript events", async () => {
     const customStorePath = path.join(stateDir(), "custom-sessions", "sessions.json");
-    const transcriptPath = writeTranscript("sess-abs", [
-      sessionHeader("sess-abs"),
-      userMessage("hello"),
-    ]);
+    const sessionKey = "agent:main:feishu:direct:ou_user";
     await upsertSessionEntry({
       agentId: "main",
       storePath: customStorePath,
-      sessionKey: "agent:main:feishu:direct:ou_user",
+      sessionKey,
       entry: {
         sessionId: "sess-abs",
-        sessionFile: transcriptPath,
         updatedAt: Date.now(),
       },
+    });
+    await seedTranscriptMessages({
+      sessionId: "sess-abs",
+      sessionKey,
+      storePath: customStorePath,
+      contents: ["hello"],
     });
 
     const result = await runFeishuDoctorSequence({
@@ -210,11 +234,11 @@ describe("Feishu doctor state repair", () => {
     expect(result).toEqual({ changeNotes: [], warningNotes: [] });
   });
 
-  it("keeps SQLite-backed Feishu session rows without file inspection", async () => {
+  it("does not fall back to legacy files for canonical Feishu session rows", async () => {
     await writeStore({
       "agent:main:feishu:direct:ou_user": {
         sessionId: "sess-sqlite",
-        sessionFile: `sqlite:main:sess-sqlite:${storePath()}`,
+        sessionFile: "missing-legacy-transcript.jsonl",
         updatedAt: Date.now(),
       },
     });
@@ -238,23 +262,15 @@ describe("Feishu doctor state repair", () => {
       sessionKey,
       entry: {
         sessionId,
-        sessionFile: formatSqliteSessionFileMarker({
-          agentId: "main",
-          sessionId,
-          storePath: targetStorePath,
-        }),
         updatedAt: Date.now(),
       },
     });
-    for (const content of ["", "", ""]) {
-      await appendSessionTranscriptMessageByIdentity({
-        agentId: "main",
-        sessionId,
-        sessionKey,
-        storePath: targetStorePath,
-        message: { role: "user", content },
-      });
-    }
+    await seedTranscriptMessages({
+      sessionId,
+      sessionKey,
+      storePath: targetStorePath,
+      contents: ["", "", ""],
+    });
 
     const result = await runFeishuDoctorSequence({
       cfg: feishuConfig(),
@@ -285,11 +301,6 @@ describe("Feishu doctor state repair", () => {
       sessionKey,
       entry: {
         sessionId,
-        sessionFile: formatSqliteSessionFileMarker({
-          agentId: "main",
-          sessionId,
-          storePath: targetStorePath,
-        }),
         updatedAt: Date.now(),
       },
     });
@@ -314,20 +325,18 @@ describe("Feishu doctor state repair", () => {
   });
 
   it("keeps Feishu sessions with separated blank user messages", async () => {
-    writeTranscript("sess-separated-blanks", [
-      sessionHeader("sess-separated-blanks"),
-      userMessage(""),
-      userMessage("hello"),
-      userMessage(""),
-      userMessage("world"),
-      userMessage(""),
-    ]);
-    await writeStore({
-      "agent:main:feishu:direct:ou_user": {
+    const sessionKey = "agent:main:feishu:direct:ou_user";
+    const targetStorePath = await writeStore({
+      [sessionKey]: {
         sessionId: "sess-separated-blanks",
-        sessionFile: "sess-separated-blanks.jsonl",
         updatedAt: Date.now(),
       },
+    });
+    await seedTranscriptMessages({
+      sessionId: "sess-separated-blanks",
+      sessionKey,
+      storePath: targetStorePath,
+      contents: ["", "hello", "", "world", ""],
     });
 
     const result = await runFeishuDoctorSequence({
@@ -361,16 +370,18 @@ describe("Feishu doctor state repair", () => {
     fs.mkdirSync(feishuDedupDir, { recursive: true });
     fs.writeFileSync(path.join(feishuDedupDir, "default.json"), "{");
 
-    const transcriptPath = writeTranscript("sess-ok", [
-      sessionHeader("sess-ok"),
-      userMessage("hello"),
-    ]);
+    const sessionKey = "agent:main:feishu:direct:ou_user";
     const targetStorePath = await writeStore({
-      "agent:main:feishu:direct:ou_user": {
+      [sessionKey]: {
         sessionId: "sess-ok",
-        sessionFile: "sess-ok.jsonl",
         updatedAt: Date.now(),
       },
+    });
+    await seedTranscriptMessages({
+      sessionId: "sess-ok",
+      sessionKey,
+      storePath: targetStorePath,
+      contents: ["hello"],
     });
 
     const result = await runFeishuDoctorSequence({
@@ -384,8 +395,15 @@ describe("Feishu doctor state repair", () => {
     expect(result.changeNotes.join("\n")).toContain("Removed 0 Feishu-scoped session entries");
 
     const store = readStoreEntries(targetStorePath);
-    expect(store["agent:main:feishu:direct:ou_user"]).toBeDefined();
-    expect(fs.existsSync(transcriptPath)).toBe(true);
+    expect(store[sessionKey]).toBeDefined();
+    await expect(
+      readSessionTranscriptEvents({
+        agentId: "main",
+        sessionId: "sess-ok",
+        sessionKey,
+        storePath: targetStorePath,
+      }),
+    ).resolves.toHaveLength(2);
 
     expect(fs.existsSync(path.join(stateDir(), "feishu"))).toBe(true);
     expect(fs.existsSync(path.join(stateDir(), "feishu", "dedup", "default.json"))).toBe(false);
@@ -399,22 +417,13 @@ describe("Feishu doctor state repair", () => {
     );
   });
 
-  it("archives only unhealthy Feishu direct sessions while preserving state, config, and other sessions", async () => {
+  it("removes only unhealthy Feishu direct sessions while preserving state, config, and other sessions", async () => {
     const feishuDedupDir = path.join(stateDir(), "feishu", "dedup");
     fs.mkdirSync(feishuDedupDir, { recursive: true });
     fs.writeFileSync(path.join(feishuDedupDir, "default.json"), JSON.stringify({ msg1: 1 }));
 
-    const transcriptPath = writeTranscript("sess-bad", [
-      sessionHeader("sess-bad"),
-      userMessage(""),
-      userMessage(""),
-      userMessage(""),
-    ]);
-    const trajectoryPath = path.join(sessionsDir(), "sess-bad.trajectory.jsonl");
-    const trajectoryIndexPath = path.join(sessionsDir(), "sess-bad.trajectory-path.json");
-    fs.writeFileSync(trajectoryPath, "{}\n");
-    fs.writeFileSync(trajectoryIndexPath, "{}\n");
-    const acpTranscriptPath = writeTranscript("sess-acp-bad", [
+    const sessionKey = "agent:main:feishu:direct:ou_user";
+    const acpTranscriptPath = writeLegacyTranscript("sess-acp-bad", [
       sessionHeader("sess-acp-bad"),
       userMessage(""),
       userMessage(""),
@@ -422,9 +431,8 @@ describe("Feishu doctor state repair", () => {
     ]);
 
     const targetStorePath = await writeStore({
-      "agent:main:feishu:direct:ou_user": {
+      [sessionKey]: {
         sessionId: "sess-bad",
-        sessionFile: "sess-bad.jsonl",
         updatedAt: Date.now(),
       },
       "agent:codex:acp:binding:feishu:default:abc123": {
@@ -439,6 +447,12 @@ describe("Feishu doctor state repair", () => {
         sessionId: "sess-discord",
         updatedAt: Date.now(),
       },
+    });
+    await seedTranscriptMessages({
+      sessionId: "sess-bad",
+      sessionKey,
+      storePath: targetStorePath,
+      contents: ["", "", ""],
     });
 
     const result = await runFeishuDoctorSequence({
@@ -467,26 +481,24 @@ describe("Feishu doctor state repair", () => {
     ).toBe(true);
 
     const store = readStoreEntries(targetStorePath);
-    expect(store["agent:main:feishu:direct:ou_user"]).toBeUndefined();
+    expect(store[sessionKey]).toBeUndefined();
     expect(store["agent:codex:acp:binding:feishu:default:abc123"]).toBeDefined();
     expect(store["agent:main:discord:direct:user"]).toBeDefined();
 
-    expect(fs.existsSync(transcriptPath)).toBe(false);
     expect(fs.existsSync(acpTranscriptPath)).toBe(true);
-    expect(fs.existsSync(trajectoryPath)).toBe(false);
-    expect(fs.existsSync(trajectoryIndexPath)).toBe(false);
-    const archivedNames = fs.readdirSync(sessionsDir());
-    expect(archivedNames.some((name) => name.startsWith("sess-bad.jsonl.deleted."))).toBe(true);
-    expect(
-      archivedNames.some((name) => name.startsWith("sess-bad.trajectory.jsonl.deleted.")),
-    ).toBe(true);
-    expect(
-      archivedNames.some((name) => name.startsWith("sess-bad.trajectory-path.json.deleted.")),
-    ).toBe(true);
+    await expect(
+      readSessionTranscriptEvents({
+        agentId: "main",
+        sessionId: "sess-bad",
+        sessionKey,
+        storePath: targetStorePath,
+      }),
+    ).resolves.toEqual([]);
   });
 
   it("preserves locked harness sessions while repairing ordinary Feishu sessions", async () => {
     const targetStorePath = storePath();
+    const feishuSessionKey = "agent:main:feishu:direct:ou_user";
     await upsertSessionEntry({
       agentId: "main",
       storePath: targetStorePath,
@@ -504,11 +516,17 @@ describe("Feishu doctor state repair", () => {
     await upsertSessionEntry({
       agentId: "main",
       storePath: targetStorePath,
-      sessionKey: "agent:main:feishu:direct:ou_user",
+      sessionKey: feishuSessionKey,
       entry: {
         sessionId: "sess-feishu-bad",
         updatedAt: 1,
       },
+    });
+    await seedTranscriptMessages({
+      sessionId: "sess-feishu-bad",
+      sessionKey: feishuSessionKey,
+      storePath: targetStorePath,
+      contents: ["", "", ""],
     });
 
     const result = await runFeishuDoctorSequence({
@@ -521,7 +539,7 @@ describe("Feishu doctor state repair", () => {
     expect(result.changeNotes.join("\n")).toContain("Removed 1 Feishu-scoped session entry");
     const store = readStoreEntries(targetStorePath);
     expect(store["agent:main:ordinary-codex-locked"]).toBeDefined();
-    expect(store["agent:main:feishu:direct:ou_user"]).toBeUndefined();
+    expect(store[feishuSessionKey]).toBeUndefined();
   });
 
   it("backs up SQLite session stores before removing migrated Feishu sessions", async () => {
@@ -535,6 +553,12 @@ describe("Feishu doctor state repair", () => {
         sessionId: "sess-migrated-bad",
         updatedAt: Date.now(),
       },
+    });
+    await seedTranscriptMessages({
+      sessionId: "sess-migrated-bad",
+      sessionKey,
+      storePath: targetStorePath,
+      contents: ["", "", ""],
     });
 
     expect(fs.existsSync(targetStorePath)).toBe(false);
@@ -578,12 +602,12 @@ describe("Feishu doctor state repair", () => {
         updatedAt: Date.now(),
       },
     });
-    await appendSessionTranscriptMessageByIdentity({
+    await seedTranscriptMessages({
       agentId: "support",
       sessionId: "sess-support-bad",
       sessionKey,
       storePath: customStorePath,
-      message: { role: "user", content: "unhealthy migrated Feishu session" },
+      contents: ["", "", ""],
     });
 
     expect(fs.existsSync(customStorePath)).toBe(false);
@@ -626,16 +650,10 @@ describe("Feishu doctor state repair", () => {
   });
 
   it("archives unhealthy default-scope sessions when metadata identifies Feishu", async () => {
-    const transcriptPath = writeTranscript("sess-default-feishu-bad", [
-      sessionHeader("sess-default-feishu-bad"),
-      userMessage(""),
-      userMessage(""),
-      userMessage(""),
-    ]);
+    const sessionKey = "agent:main:main";
     const targetStorePath = await writeStore({
-      "agent:main:main": {
+      [sessionKey]: {
         sessionId: "sess-default-feishu-bad",
-        sessionFile: "sess-default-feishu-bad.jsonl",
         updatedAt: Date.now(),
         origin: { provider: "feishu", from: "feishu:ou_user" },
         route: { channel: "feishu", target: { to: "ou_user", chatType: "direct" } },
@@ -646,6 +664,12 @@ describe("Feishu doctor state repair", () => {
         origin: { provider: "discord" },
       },
     });
+    await seedTranscriptMessages({
+      sessionId: "sess-default-feishu-bad",
+      sessionKey,
+      storePath: targetStorePath,
+      contents: ["", "", ""],
+    });
 
     const result = await runFeishuDoctorSequence({
       cfg: feishuConfig(),
@@ -655,8 +679,15 @@ describe("Feishu doctor state repair", () => {
 
     expect(result.warningNotes).toEqual([]);
     const store = readStoreEntries(targetStorePath);
-    expect(store["agent:main:main"]).toBeUndefined();
+    expect(store[sessionKey]).toBeUndefined();
     expect(store["agent:main:main-non-feishu"]).toBeDefined();
-    expect(fs.existsSync(transcriptPath)).toBe(false);
+    await expect(
+      readSessionTranscriptEvents({
+        agentId: "main",
+        sessionId: "sess-default-feishu-bad",
+        sessionKey,
+        storePath: targetStorePath,
+      }),
+    ).resolves.toEqual([]);
   });
 });

--- a/extensions/feishu/src/doctor.ts
+++ b/extensions/feishu/src/doctor.ts
@@ -13,7 +13,6 @@ import {
   deleteSessionEntry,
   listSessionEntries,
   loadTranscriptEventsSync,
-  parseSqliteSessionFileMarker,
   resolveSessionStoreBackupPaths,
   resolveStorePath,
 } from "openclaw/plugin-sdk/session-store-runtime";
@@ -121,10 +120,6 @@ function existsFile(filePath: string): boolean {
 
 function resolveFeishuAgentSessionsDir(agentId: string): string {
   return path.join(resolveStateDir(), "agents", normalizeAgentId(agentId), "sessions");
-}
-
-function isSqliteTranscriptMarker(value: string): boolean {
-  return parseSqliteSessionFileMarker(value) !== undefined;
 }
 
 function safeReadDir(dir: string): fs.Dirent[] {
@@ -346,24 +341,6 @@ function resolveSessionTranscriptCandidates(params: {
     return true;
   };
 
-  if (
-    typeof params.entry.sessionId === "string" &&
-    /^[a-z0-9][a-z0-9._-]{0,127}$/i.test(params.entry.sessionId)
-  ) {
-    let addedExplicitCandidate = false;
-    if (typeof params.entry.sessionFile === "string" && params.entry.sessionFile.trim()) {
-      const explicitSessionFile = params.entry.sessionFile.trim();
-      if (isSqliteTranscriptMarker(explicitSessionFile)) {
-        return [];
-      }
-      addedExplicitCandidate = addSafeCandidate(explicitSessionFile);
-    }
-    if (!addedExplicitCandidate) {
-      candidates.add(path.join(sessionsDir, `${params.entry.sessionId}.jsonl`));
-    }
-    return [...candidates].toSorted();
-  }
-
   if (typeof params.entry.sessionFile === "string" && params.entry.sessionFile.trim()) {
     addSafeCandidate(params.entry.sessionFile.trim());
   }
@@ -518,44 +495,33 @@ function inspectSessionTranscript(params: {
   return inspectTranscriptEntries({ ...params, entries, malformedLines });
 }
 
-function inspectSqliteSessionTranscript(params: {
+function inspectCanonicalSessionTranscript(params: {
   agentId: string;
+  sessionId: string;
   sessionKey: string;
   storePath: string;
-  entry: FeishuSessionEntry;
 }): FeishuDoctorFinding | null {
-  if (typeof params.entry.sessionFile !== "string") {
-    return null;
-  }
-  const marker = parseSqliteSessionFileMarker(params.entry.sessionFile);
-  if (!marker) {
-    return null;
-  }
-  const sessionId =
-    typeof params.entry.sessionId === "string" && params.entry.sessionId.trim()
-      ? params.entry.sessionId.trim()
-      : marker.sessionId;
   let entries: unknown[];
   try {
     entries = loadTranscriptEventsSync({
-      agentId: marker.agentId,
-      sessionId,
+      agentId: params.agentId,
+      sessionId: params.sessionId,
       sessionKey: params.sessionKey,
-      storePath: marker.storePath,
+      storePath: params.storePath,
     });
   } catch {
     return {
       kind: "invalid-session-transcript",
       sessionKey: params.sessionKey,
       storePath: params.storePath,
-      path: params.entry.sessionFile,
+      path: params.storePath,
       reason: "unreadable",
     };
   }
   return inspectTranscriptEntries({
     sessionKey: params.sessionKey,
     storePath: params.storePath,
-    transcriptPath: params.entry.sessionFile,
+    transcriptPath: params.storePath,
     allowMissingSessionHeader: true,
     entries,
   });
@@ -567,9 +533,15 @@ function collectFeishuSessionFindings(params: {
   storePath: string;
   entry: FeishuSessionEntry;
 }): FeishuDoctorFinding[] {
-  const sqliteFinding = inspectSqliteSessionTranscript(params);
-  if (sqliteFinding) {
-    return [sqliteFinding];
+  const sessionId = typeof params.entry.sessionId === "string" ? params.entry.sessionId.trim() : "";
+  if (sessionId) {
+    const finding = inspectCanonicalSessionTranscript({
+      agentId: params.agentId,
+      sessionId,
+      sessionKey: params.sessionKey,
+      storePath: params.storePath,
+    });
+    return finding ? [finding] : [];
   }
   const transcriptCandidates = resolveSessionTranscriptCandidates(params);
   const existing = transcriptCandidates.filter(existsFile);


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Feishu doctor could miss canonical SQLite-backed session transcripts because it still expected retired file-era session markers.

## Why This Change Was Made

The doctor now inspects canonical transcript events using agent, session, session-key, and store-path identity. Legacy JSONL inspection remains only for actual legacy candidates.

## User Impact

Feishu doctor can diagnose current SQLite sessions without requiring a retired `sessionFile` marker.

## Evidence

- Full Release Validation exposed the failure on the beta.6 release branch.
- Focused Feishu doctor tests: 13/13 passed on Blacksmith Testbox.
- Formatting and `git diff --check` passed.
- Autoreview findings requesting legacy marker authority were rejected because canonical runtime state deliberately removes that field.
