### PR TITLE
fix(ci): compare env ratchet at branch fork

### DIFF
--- a/scripts/check-env-var-count.mjs
+++ b/scripts/check-env-var-count.mjs
@@ -77,7 +77,15 @@ function readBaseBudget(root, ref) {
   if (resolved.status !== 0) {
     throw new Error(`Could not resolve env-var count base ref: ${ref}`);
   }
-  const entry = execFileSync("git", ["ls-tree", "--name-only", ref, "--", BUDGET_PATH], {
+  const mergeBase = spawnSync("git", ["merge-base", "HEAD", ref], {
+    cwd: root,
+    encoding: "utf8",
+  });
+  const baselineRef = mergeBase.stdout.trim();
+  if (mergeBase.status !== 0 || !baselineRef) {
+    throw new Error(`Could not resolve env-var count merge base for: ${ref}`);
+  }
+  const entry = execFileSync("git", ["ls-tree", "--name-only", baselineRef, "--", BUDGET_PATH], {
     cwd: root,
     encoding: "utf8",
   }).trim();
@@ -85,7 +93,10 @@ function readBaseBudget(root, ref) {
     return null;
   }
   return parseBudget(
-    execFileSync("git", ["show", `${ref}:${BUDGET_PATH}`], { cwd: root, encoding: "utf8" }),
+    execFileSync("git", ["show", `${baselineRef}:${BUDGET_PATH}`], {
+      cwd: root,
+      encoding: "utf8",
+    }),
   );
 }
 

--- a/test/scripts/check-env-var-count.test.ts
+++ b/test/scripts/check-env-var-count.test.ts
@@ -73,6 +73,46 @@ describe("check-env-var-count", () => {
     expect(() => main(["--base", "missing"], root)).toThrow(/Could not resolve/u);
   });
 
+  it("compares against the fork budget when the base branch later shrinks", () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-env-count-fork-"));
+    tempDirs.push(root);
+    fs.mkdirSync(path.join(root, "config"), { recursive: true });
+    fs.mkdirSync(path.join(root, "src"), { recursive: true });
+    fs.writeFileSync(path.join(root, "config/env-var-count-budget.txt"), "2\n");
+    fs.writeFileSync(
+      path.join(root, "src/runtime.ts"),
+      "process.env.OPENCLAW_ONE; process.env.OPENCLAW_TWO;\n",
+    );
+    execFileSync("git", ["init"], { cwd: root, stdio: "ignore" });
+    execFileSync("git", ["add", "."], { cwd: root, stdio: "ignore" });
+    execFileSync(
+      "git",
+      ["-c", "user.name=OpenClaw", "-c", "user.email=test@openclaw.local", "commit", "-m", "base"],
+      { cwd: root, stdio: "ignore" },
+    );
+    execFileSync("git", ["branch", "release"], { cwd: root, stdio: "ignore" });
+    fs.writeFileSync(path.join(root, "config/env-var-count-budget.txt"), "1\n");
+    fs.writeFileSync(path.join(root, "src/runtime.ts"), "process.env.OPENCLAW_ONE;\n");
+    execFileSync("git", ["add", "."], { cwd: root, stdio: "ignore" });
+    execFileSync(
+      "git",
+      [
+        "-c",
+        "user.name=OpenClaw",
+        "-c",
+        "user.email=test@openclaw.local",
+        "commit",
+        "-m",
+        "shrink main",
+      ],
+      { cwd: root, stdio: "ignore" },
+    );
+    execFileSync("git", ["branch", "moving-main"], { cwd: root, stdio: "ignore" });
+    execFileSync("git", ["checkout", "release"], { cwd: root, stdio: "ignore" });
+
+    expect(() => main(["--base", "moving-main"], root)).not.toThrow();
+  });
+
   it("rejects growth above the budget", () => {
     const root = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-env-count-grow-"));
     tempDirs.push(root);


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where long-lived release branches fail the environment-variable ratchet after `main` independently lowers its budget.

## Why This Change Was Made

The checker now compares the branch budget with the merge-base budget rather than the moving base-branch tip. It still rejects growth relative to the branch fork.

## User Impact

Release and maintenance branches no longer receive false ratchet failures from unrelated cleanup that landed later on `main`.

## Evidence

- Focused checker tests: 9/9 passed.
- Current-main env check: `519/519`.
- Formatting, `git diff --check`, and autoreview passed.
- Exact-head hosted CI: [run 30352562806](https://github.com/openclaw/openclaw/actions/runs/30352562806) passed.
- Repo-native Testbox-backed `prepare-run` passed at `d3fa8ef15b0e410e56f452baaa7dd773a113fa58`.

### Real release-branch proof

The current release branch forks from `d894a235e88dd4fa9b262e09e2df7f0f9427ddba`, where the budget is 520. Current `main` has independently lowered its budget to 519. Running the exact checker on the unchanged release branch succeeds against the moving base:

```text
$ git rev-parse HEAD
44ae9c7626ff157e893bd30bd510737b05737ff3
$ git merge-base HEAD origin/main
d894a235e88dd4fa9b262e09e2df7f0f9427ddba
$ node scripts/check-env-var-count.mjs --base origin/main
OPENCLAW_* count 520/520
```

In a disposable worktree, a committed post-fork change increased the branch budget to 521 and added one counted name. The same command still rejects that real branch growth against the fork budget:

```text
$ git rev-parse HEAD
bd636d2622c2c9aeeecfd12bf53fa78d27ec8e28
$ git merge-base HEAD origin/main
d894a235e88dd4fa9b262e09e2df7f0f9427ddba
$ node scripts/check-env-var-count.mjs --base origin/main
OPENCLAW_* budget grew from 520 to 521
```

The second commit exists only in the disposable proof worktree and was never pushed.
