### PR TITLE
test(memory): align QMD alias identity fixture

### DIFF
--- a/extensions/memory-core/src/session-search-visibility.qmd.test.ts
+++ b/extensions/memory-core/src/session-search-visibility.qmd.test.ts
@@ -245,7 +245,7 @@ describe("filterMemorySearchHitsBySessionVisibility for QMD", () => {
     expect(filtered).toEqual([copiedHit]);
   });
 
-  it("denies mapped QMD hits whose transcript file also has a shared group alias", async () => {
+  it("denies mapped QMD hits whose transcript identity also has a shared group alias", async () => {
     combinedSessionStore = {
       "agent:main:telegram:direct:owner": {
         sessionId: "current",
@@ -259,10 +259,9 @@ describe("filterMemorySearchHitsBySessionVisibility for QMD", () => {
         sessionFile: "/tmp/sessions/shared-transcript.jsonl",
         chatType: "direct",
       },
-      // Same transcript file exposed under a group alias with a different
-      // sessionId: session-id alias resolution alone would miss this.
+      // The canonical transcript identity is also exposed through a group alias.
       "agent:main:telegram:group:team": {
-        sessionId: "group-alias-id",
+        sessionId: "actual-session-id",
         updatedAt: 1,
         sessionFile: "/tmp/sessions/shared-transcript.jsonl",
         chatType: "group",

--- a/extensions/memory-core/src/session-search-visibility.ts
+++ b/extensions/memory-core/src/session-search-visibility.ts
@@ -257,9 +257,8 @@ export async function filterMemorySearchHitsBySessionVisibility(params: {
   };
 
   const expandRecallAliasKeys = (keys: string[]): string[] => {
-    // Alias resolution by session id can miss a group/channel alias that shares
-    // the same transcript file under a different session id. Recall must judge
-    // every alias, so expand candidates by stored transcript identity.
+    // Recall must judge every store key for the canonical transcript identity,
+    // including group/channel aliases that were not in the initial key set.
     const expanded = new Set(keys);
     for (const key of keys) {
       const entry = combinedSessionStore[key];


### PR DESCRIPTION
## What Problem This Solves

Fixes a stale QMD visibility fixture that modeled transcript aliases by a removed file-era path identity instead of canonical session identity.

## Why This Change Was Made

The privacy test now models direct and group aliases sharing the same canonical session ID and still requires fail-closed denial. The production edit only updates the invariant comment.

## User Impact

No product behavior changes. The privacy regression test now exercises a reachable SQLite-backed session shape.

## Evidence

- Exact PR head `1b9a791930cd8d9f9d8b4831c6376736fdaeaef2`: hosted CI run [30352562823](https://github.com/openclaw/openclaw/actions/runs/30352562823) passed, including `openclaw/ci-gate`.
- Focused memory dreaming, startup catch-up, and QMD visibility: 86/86 passed on Blacksmith Testbox run [30352177382](https://github.com/openclaw/openclaw/actions/runs/30352177382).
- Inspectable alias-denial proof: Blacksmith Testbox run [30353342887](https://github.com/openclaw/openclaw/actions/runs/30353342887) passed 11/11 QMD visibility tests with the verbose case `denies mapped QMD hits whose transcript identity also has a shared group alias` (7 ms).
- Formatting, `git diff --check`, and autoreview passed.

## ClawSweeper rank-up moves

- Real behavior proof: applied via the linked verbose Testbox run above.
- Current-main refresh: delegated to the required repo-native `scripts/pr prepare-run` landing step after exact-head hosted gates. No manual rebase is used because the landing wrapper owns base refresh and patch-identity proof.
