### PR TITLE
fix(logging): scale heap-pressure thresholds with V8 limits

### DIFF
--- a/src/logging/diagnostic-memory.test.ts
+++ b/src/logging/diagnostic-memory.test.ts
@@ -156,6 +156,75 @@ describe("diagnostic memory", () => {
     expect(events.map((event) => event.type)).toEqual(["diagnostic.memory.pressure"]);
   });
 
+  it("scales default heap pressure thresholds with enlarged V8 limits", () => {
+    const events: DiagnosticEventPayload[] = [];
+    const stop = onDiagnosticEvent((event) => events.push(event));
+    const gb = 1024 ** 3;
+
+    emitDiagnosticMemorySample({
+      now: 1000,
+      heapSizeLimitBytes: 8 * gb,
+      memoryUsage: memoryUsage({ heapUsed: 2.1 * gb }),
+    });
+    expect(events.filter((event) => event.type === "diagnostic.memory.pressure")).toEqual([]);
+
+    emitDiagnosticMemorySample({
+      now: 2000,
+      heapSizeLimitBytes: 8 * gb,
+      memoryUsage: memoryUsage({ heapUsed: 4.1 * gb }),
+    });
+    emitDiagnosticMemorySample({
+      now: 3000,
+      heapSizeLimitBytes: 8 * gb,
+      memoryUsage: memoryUsage({ heapUsed: 6.1 * gb }),
+    });
+    stop();
+
+    expect(
+      events
+        .filter((event) => event.type === "diagnostic.memory.pressure")
+        .map((event) => ({
+          level: event.level,
+          reason: event.reason,
+          threshold: event.thresholdBytes,
+        })),
+    ).toEqual([
+      { level: "warning", reason: "heap_threshold", threshold: 4 * gb },
+      { level: "critical", reason: "heap_threshold", threshold: 6 * gb },
+    ]);
+  });
+
+  it("scales default heap pressure thresholds down for constrained V8 limits", () => {
+    const events: DiagnosticEventPayload[] = [];
+    const stop = onDiagnosticEvent((event) => events.push(event));
+    const mb = 1024 ** 2;
+
+    emitDiagnosticMemorySample({
+      now: 1000,
+      heapSizeLimitBytes: 1024 * mb,
+      memoryUsage: memoryUsage({ heapUsed: 600 * mb }),
+    });
+    emitDiagnosticMemorySample({
+      now: 2000,
+      heapSizeLimitBytes: 1024 * mb,
+      memoryUsage: memoryUsage({ heapUsed: 800 * mb }),
+    });
+    stop();
+
+    expect(
+      events
+        .filter((event) => event.type === "diagnostic.memory.pressure")
+        .map((event) => ({
+          level: event.level,
+          reason: event.reason,
+          threshold: event.thresholdBytes,
+        })),
+    ).toEqual([
+      { level: "warning", reason: "heap_threshold", threshold: 512 * mb },
+      { level: "critical", reason: "heap_threshold", threshold: 768 * mb },
+    ]);
+  });
+
   it("emits pressure when RSS grows quickly", () => {
     const events: DiagnosticEventPayload[] = [];
     const stop = onDiagnosticEvent((event) => events.push(event));

--- a/src/logging/diagnostic-memory.ts
+++ b/src/logging/diagnostic-memory.ts
@@ -1,4 +1,5 @@
 // Diagnostic memory helpers capture process memory facts for support diagnostics.
+import { getHeapStatistics } from "node:v8";
 import {
   emitInternalDiagnosticEvent as emitDiagnosticEvent,
   type DiagnosticMemoryPressureEvent,
@@ -9,10 +10,15 @@ import { createSubsystemLogger } from "./subsystem.js";
 
 // Diagnostic memory sampler with threshold/growth pressure detection and repeat suppression.
 const MB = 1024 * 1024;
+const GB = 1024 * MB;
 const DEFAULT_RSS_WARNING_BYTES = 1536 * MB;
 const DEFAULT_RSS_CRITICAL_BYTES = 3072 * MB;
 const DEFAULT_HEAP_WARNING_BYTES = 1024 * MB;
 const DEFAULT_HEAP_CRITICAL_BYTES = 2048 * MB;
+const DEFAULT_HEAP_WARNING_RATIO = 0.5;
+const DEFAULT_HEAP_CRITICAL_RATIO = 0.75;
+const DEFAULT_HEAP_WARNING_MAX_BYTES = 4 * GB;
+const DEFAULT_HEAP_CRITICAL_MAX_BYTES = 6 * GB;
 const DEFAULT_RSS_GROWTH_WARNING_BYTES = 512 * MB;
 const DEFAULT_RSS_GROWTH_CRITICAL_BYTES = 1024 * MB;
 const DEFAULT_GROWTH_WINDOW_MS = 10 * 60 * 1000;
@@ -60,12 +66,31 @@ function normalizeMemoryUsage(memory: NodeJS.MemoryUsage): DiagnosticMemoryUsage
 
 function resolveThresholds(
   thresholds?: DiagnosticMemoryThresholds,
+  heapSizeLimitBytes?: number,
 ): Required<DiagnosticMemoryThresholds> {
+  const hasHeapLimit =
+    typeof heapSizeLimitBytes === "number" &&
+    Number.isFinite(heapSizeLimitBytes) &&
+    heapSizeLimitBytes > 0;
+  // Scale both directions with V8's effective limit, but keep a warning/critical
+  // ceiling so very large heaps still surface actionable pressure diagnostics.
+  const heapWarningBytes = hasHeapLimit
+    ? Math.min(
+        Math.floor(heapSizeLimitBytes * DEFAULT_HEAP_WARNING_RATIO),
+        DEFAULT_HEAP_WARNING_MAX_BYTES,
+      )
+    : DEFAULT_HEAP_WARNING_BYTES;
+  const heapCriticalBytes = hasHeapLimit
+    ? Math.min(
+        Math.floor(heapSizeLimitBytes * DEFAULT_HEAP_CRITICAL_RATIO),
+        DEFAULT_HEAP_CRITICAL_MAX_BYTES,
+      )
+    : DEFAULT_HEAP_CRITICAL_BYTES;
   return {
     rssWarningBytes: thresholds?.rssWarningBytes ?? DEFAULT_RSS_WARNING_BYTES,
     rssCriticalBytes: thresholds?.rssCriticalBytes ?? DEFAULT_RSS_CRITICAL_BYTES,
-    heapUsedWarningBytes: thresholds?.heapUsedWarningBytes ?? DEFAULT_HEAP_WARNING_BYTES,
-    heapUsedCriticalBytes: thresholds?.heapUsedCriticalBytes ?? DEFAULT_HEAP_CRITICAL_BYTES,
+    heapUsedWarningBytes: thresholds?.heapUsedWarningBytes ?? heapWarningBytes,
+    heapUsedCriticalBytes: thresholds?.heapUsedCriticalBytes ?? heapCriticalBytes,
     rssGrowthWarningBytes: thresholds?.rssGrowthWarningBytes ?? DEFAULT_RSS_GROWTH_WARNING_BYTES,
     rssGrowthCriticalBytes: thresholds?.rssGrowthCriticalBytes ?? DEFAULT_RSS_GROWTH_CRITICAL_BYTES,
     growthWindowMs: thresholds?.growthWindowMs ?? DEFAULT_GROWTH_WINDOW_MS,
@@ -263,6 +288,7 @@ function logMemoryPressure(params: {
 export function emitDiagnosticMemorySample(options?: {
   now?: number;
   memoryUsage?: NodeJS.MemoryUsage;
+  heapSizeLimitBytes?: number;
   uptimeMs?: number;
   thresholds?: DiagnosticMemoryThresholds;
   emitSample?: boolean;
@@ -274,7 +300,10 @@ export function emitDiagnosticMemorySample(options?: {
   const now = options?.now ?? Date.now();
   const memory = normalizeMemoryUsage(options?.memoryUsage ?? process.memoryUsage());
   const current = { ts: now, memory };
-  const thresholds = resolveThresholds(options?.thresholds);
+  const thresholds = resolveThresholds(
+    options?.thresholds,
+    options?.heapSizeLimitBytes ?? getHeapStatistics().heap_size_limit,
+  );
   const shouldEmitSample = options?.emitSample !== false;
 
   if (shouldEmitSample) {


### PR DESCRIPTION
Closes #104631

## What Problem This Solves

Fixes an issue where gateways launched with an enlarged V8 heap were still classified as critically heap-pressured at the old fixed 2 GiB threshold. A healthy process with an 8 GiB heap could therefore emit a false critical diagnostic despite having roughly 6 GiB of remaining V8 headroom.

## Why This Change Was Made

Default heap warning and critical thresholds now follow 50% and 75% of V8's effective `heap_size_limit`. They are capped at 4 GiB and 6 GiB so very large heaps still produce actionable diagnostics. This scales protection down for constrained heaps as well as up for enlarged heaps.

Explicit threshold overrides are unchanged. RSS thresholds, RSS-growth detection, repeat suppression, event payloads, logging, and stability-bundle behavior are also unchanged.

## User Impact

Operators can size Node's heap for their workload without the gateway reporting false critical heap pressure at 2 GiB, while small heaps still receive proportionally early warning and critical signals.

## Evidence

Blacksmith Testbox `tbx_01kym5mjyez4128g7kygzjab0k`:

- Live Node process with `--max-old-space-size=8192` reported an effective heap limit of `8,791,261,184` bytes. A simulated 2.1 GiB heap sample emitted no pressure event; 4.1 GiB emitted one warning at the capped 4 GiB threshold.
- `pnpm test src/logging/diagnostic-memory.test.ts`: 13 tests passed, including enlarged 8 GiB and constrained 1 GiB heap limits.
- `pnpm check:changed`: core production/test typechecks, targeted lint, formatting, plugin boundaries, architecture guards, import cycles, and remaining changed lanes passed.
- `git diff --check` and targeted oxfmt passed.
- Codex autoreview (`gpt-5.6-sol`, xhigh) reported no accepted/actionable findings with 0.93 confidence.

AI-assisted.
