### PR TITLE
fix(doctor): mock new cron runtime policy export

### DIFF
--- a/src/commands/doctor-config-preflight.state-migration.test.ts
+++ b/src/commands/doctor-config-preflight.state-migration.test.ts
@@ -121,9 +121,6 @@ const makeStartupConvergenceResult = vi.hoisted(
       ...overrides,
     }),
 );
-const collectCronCodexRuntimePolicyTargetsReadOnly = vi.hoisted(() =>
-  vi.fn(async () => ({ targets: [], warnings: [] })),
-);
 const readConfigFileSnapshot = vi.hoisted(() =>
   vi.fn(async () => ({
     exists: true,
@@ -148,7 +145,6 @@ vi.mock("./doctor-state-migrations.js", () => ({
 vi.mock("./doctor/cron/legacy-repair.js", () => ({
   collectCronCodexRuntimePolicyTargetsReadOnly,
   repairLegacyCronStoreWithoutPrompt,
-  collectCronCodexRuntimePolicyTargetsReadOnly,
 }));
 
 vi.mock("../infra/startup-migration-checkpoint.js", () => ({

--- a/src/commands/doctor-config-preflight.state-migration.test.ts
+++ b/src/commands/doctor-config-preflight.state-migration.test.ts
@@ -121,6 +121,9 @@ const makeStartupConvergenceResult = vi.hoisted(
       ...overrides,
     }),
 );
+const collectCronCodexRuntimePolicyTargetsReadOnly = vi.hoisted(() =>
+  vi.fn(async () => ({ targets: [], warnings: [] })),
+);
 const readConfigFileSnapshot = vi.hoisted(() =>
   vi.fn(async () => ({
     exists: true,
@@ -145,6 +148,7 @@ vi.mock("./doctor-state-migrations.js", () => ({
 vi.mock("./doctor/cron/legacy-repair.js", () => ({
   collectCronCodexRuntimePolicyTargetsReadOnly,
   repairLegacyCronStoreWithoutPrompt,
+  collectCronCodexRuntimePolicyTargetsReadOnly,
 }));
 
 vi.mock("../infra/startup-migration-checkpoint.js", () => ({

--- a/src/commands/doctor.fast-path-mocks.ts
+++ b/src/commands/doctor.fast-path-mocks.ts
@@ -55,6 +55,10 @@ vi.mock("./doctor-usage-cost-cache.js", () => ({
 
 vi.mock("./doctor/cron/index.js", () => ({
   maybeRepairLegacyCronStore: vi.fn().mockResolvedValue(undefined),
+  collectCronCodexRuntimePolicyTargetsReadOnly: vi.fn().mockResolvedValue({
+    targets: [],
+    warnings: [],
+  }),
   noteLegacyWhatsAppCrontabHealthCheck: vi.fn().mockResolvedValue(undefined),
 }));
 


### PR DESCRIPTION
## What Problem This Solves

Doctor config preflight tests needed to mock the new read-only cron runtime policy collector export, otherwise the state-migration coverage would fail as the cron module interface evolved.

## Evidence

Ran the affected doctor test file under the repository-required Node runtime (`v22.22.3`) with the repo Vitest wrapper:

```text
D:\Users\10302323.WIN-DKIA1GKAIRP\node-portable\node-v22.22.3-win-x64\node.exe scripts/run-vitest.mjs run --config test/vitest/vitest.commands.config.ts src/commands/doctor-config-preflight.state-migration.test.ts

RUN  v4.1.9 D:/code/open-source/openclaw-doctor-only

 Test Files  1 passed (1)
      Tests  23 passed (23)
   Start at  20:15:51
   Duration  29.15s (transform 20.72s, setup 3.77s, import 23.31s, tests 1.01s, environment 0ms)
```