### PR TITLE
fix: add beta channel label to update banner

### DIFF
--- a/ui/src/components/sidebar-update-card.test.ts
+++ b/ui/src/components/sidebar-update-card.test.ts
@@ -312,4 +312,26 @@ describe("SidebarUpdateCard", () => {
 
     expect(element.querySelector(".sidebar-update-card")?.textContent).toContain("v3.0.0");
   });
+
+  it("labels beta channel updates with a (beta) suffix", async () => {
+    const element = await mount({
+      currentVersion: "1.0.0",
+      latestVersion: "2.0.0",
+      channel: "beta",
+    });
+    expect(element.querySelector(".sidebar-update-card__text")?.textContent).toContain(
+      "v2.0.0 (beta)",
+    );
+  });
+
+  it("does not add beta label for stable channel updates", async () => {
+    const element = await mount({
+      currentVersion: "1.0.0",
+      latestVersion: "2.0.0",
+      channel: "stable",
+    });
+    const text = element.querySelector(".sidebar-update-card__text")?.textContent ?? "";
+    expect(text).toContain("v2.0.0");
+    expect(text).not.toContain("(beta)");
+  });
 });

--- a/ui/src/components/sidebar-update-card.ts
+++ b/ui/src/components/sidebar-update-card.ts
@@ -107,6 +107,9 @@ class SidebarUpdateCard extends OpenClawLightDomContentsElement {
       : this.nativeUpdateAvailable
         ? t("chat.sidebar.updateMacAndGateway")
         : t("chat.sidebar.updateGateway");
+    const versionLabel = update.channel === "beta"
+      ? `v${update.latestVersion} (beta)`
+      : `v${update.latestVersion}`;
     return html`
       <div class="sidebar-update-card" role="status" aria-live="polite">
         <button
@@ -120,7 +123,7 @@ class SidebarUpdateCard extends OpenClawLightDomContentsElement {
           }}
         >
           <span class="sidebar-update-card__icon" aria-hidden="true">${icons.download}</span>
-          <span class="sidebar-update-card__text">${title} · v${update.latestVersion}</span>
+          <span class="sidebar-update-card__text">${title} · ${versionLabel}</span>
         </button>
         <button
           class="sidebar-update-card__dismiss"

--- a/ui/src/components/sidebar-update-card.ts
+++ b/ui/src/components/sidebar-update-card.ts
@@ -107,9 +107,10 @@ class SidebarUpdateCard extends OpenClawLightDomContentsElement {
       : this.nativeUpdateAvailable
         ? t("chat.sidebar.updateMacAndGateway")
         : t("chat.sidebar.updateGateway");
-    const versionLabel = update.channel === "beta"
-      ? `v${update.latestVersion} (beta)`
-      : `v${update.latestVersion}`;
+    const versionLabel =
+      update.channel === "beta"
+        ? `v${update.latestVersion} ${t("chat.sidebar.betaChannel")}`
+        : `v${update.latestVersion}`;
     return html`
       <div class="sidebar-update-card" role="status" aria-live="polite">
         <button

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -4207,6 +4207,7 @@ export const en: TranslationMap = {
       updateAvailable: "Update available",
       updateMacAndGateway: "Update Mac app + Gateway",
       updateGateway: "Update Gateway",
+      betaChannel: "(beta)",
       allSessions: "All threads",
       threads: "Threads",
       groups: "Groups",


### PR DESCRIPTION
## Summary

This PR fixes #114969 by adding a clear beta channel indicator to the Control UI update banner.

## Changes
- Modify `sidebar-update-card.ts` to append `(beta)` suffix to the version label when the update channel is `beta`
- Stable channel updates remain unchanged (no `(beta)` label)
- Add two regression tests: one for beta channel display, one for stable channel verification

## Testing
- [x] Added unit tests for beta and stable channel label behavior
- [x] Follows existing code style and patterns in the codebase
- [x] Minimal change - only affects display logic, no behavioral changes

## Screenshots

**Before:** `Update Gateway · v2026.7.2` (no beta indication)

**After:** `Update Gateway · v2026.7.2-beta.5 (beta)`

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally
- [x] This is a minimal, focused change