### PR TITLE
fix(workboard): unassigned cards fail to start from the board's Run button

### DIFF
--- a/ui/src/lib/workboard/execution.ts
+++ b/ui/src/lib/workboard/execution.ts
@@ -1,6 +1,7 @@
 import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import type { GatewayBrowserClient } from "../../api/gateway.ts";
 import { requestSessionCreate } from "../sessions/index.ts";
+import { normalizeAgentId } from "../sessions/session-key.ts";
 import {
   normalizeString,
   replaceCard,
@@ -90,15 +91,23 @@ function sanitizeSessionSegment(value: string | undefined, fallback: string): st
   return (sanitized || fallback).slice(0, 96);
 }
 
-function buildCardTaskSessionKey(card: WorkboardCard): string {
+// Sessions live in per-agent SQLite stores, so an unscoped key has no store to
+// resolve and the run fails. Unassigned cards adopt the gateway's default agent,
+// the same owner the Workboard dispatcher resolves them to, so both surfaces
+// address one session per card. Returns null when no owner is known yet.
+function buildCardTaskSessionKey(
+  card: WorkboardCard,
+  defaultAgentId: string | null | undefined,
+): string | null {
+  // Only a non-empty id is normalized: normalizeAgentId maps blank to "main",
+  // which would silently retarget the card away from the configured default.
+  const owner = card.agentId?.trim() || defaultAgentId?.trim();
+  if (!owner) {
+    return null;
+  }
   const boardId = sanitizeSessionSegment(card.metadata?.automation?.boardId, "default");
   const cardId = sanitizeSessionSegment(card.id, "card");
-  const suffix = `subagent:workboard-${boardId}-${cardId}`;
-  const sessionKey = card.agentId
-    ? `agent:${sanitizeSessionSegment(card.agentId, "agent")}:${suffix}`
-    : suffix;
-  const existing = workboardCardSessionKey(card)?.trim();
-  return existing === sessionKey ? existing : sessionKey;
+  return `agent:${normalizeAgentId(owner)}:subagent:workboard-${boardId}-${cardId}`;
 }
 
 function buildCardRunIdempotencyKey(card: WorkboardCard): string {
@@ -222,6 +231,8 @@ export async function startWorkboardCard(params: {
   host: WorkboardHost;
   client: GatewayBrowserClient | null;
   card: WorkboardCard;
+  /** Gateway default agent, adopted by cards with no explicit assignment. */
+  defaultAgentId?: string | null;
   engine?: WorkboardExecutionEngine;
   mode?: WorkboardExecutionMode;
   requestUpdate?: () => void;
@@ -269,31 +280,36 @@ export async function startWorkboardCard(params: {
         card = preflightCard;
       }
     }
-    const created =
-      mode === "autonomous"
-        ? await params.client.request("agent", {
-            sessionKey: buildCardTaskSessionKey(card),
-            ...(card.agentId ? { agentId: card.agentId } : {}),
-            label: buildCardSessionLabel(card),
-            ...(model ? { model } : {}),
-            message: buildCardPrompt(card),
-            deliver: false,
-            bootstrapContextMode: "lightweight",
-            idempotencyKey: buildCardRunIdempotencyKey(card),
-          })
-        : await requestSessionCreate(params.client, {
-            ...(card.agentId ? { agentId: card.agentId } : {}),
-            label: buildCardSessionLabel(card),
-            ...(model ? { model } : {}),
-          });
+    // Built from the preflight response so the key names the card's current
+    // assignment. Non-null exactly when this is an autonomous start, which is
+    // why the request below branches on the key instead of on `mode`.
+    const autonomousSessionKey =
+      mode === "autonomous" ? buildCardTaskSessionKey(card, params.defaultAgentId) : null;
+    if (mode === "autonomous" && !autonomousSessionKey) {
+      throw new Error("Cannot start an unassigned card until the default agent is known.");
+    }
+    const created = autonomousSessionKey
+      ? await params.client.request("agent", {
+          sessionKey: autonomousSessionKey,
+          ...(card.agentId ? { agentId: card.agentId } : {}),
+          label: buildCardSessionLabel(card),
+          ...(model ? { model } : {}),
+          message: buildCardPrompt(card),
+          deliver: false,
+          bootstrapContextMode: "lightweight",
+          idempotencyKey: buildCardRunIdempotencyKey(card),
+        })
+      : await requestSessionCreate(params.client, {
+          ...(card.agentId ? { agentId: card.agentId } : {}),
+          label: buildCardSessionLabel(card),
+          ...(model ? { model } : {}),
+        });
     const sessionKey =
       isRecord(created) && typeof created.sessionKey === "string" && created.sessionKey.trim()
         ? created.sessionKey.trim()
         : isRecord(created) && typeof created.key === "string" && created.key.trim()
           ? created.key.trim()
-          : mode === "autonomous"
-            ? buildCardTaskSessionKey(card)
-            : null;
+          : autonomousSessionKey;
     const runId =
       isRecord(created) && typeof created.runId === "string" && created.runId.trim()
         ? created.runId.trim()

--- a/ui/src/lib/workboard/index.test.ts
+++ b/ui/src/lib/workboard/index.test.ts
@@ -47,8 +47,14 @@ function requestPatch(client: ReturnType<typeof createClient>, index: number) {
 const sampleCard = createWorkboardCard();
 const sampleSession = createGatewaySession();
 
+// Unscoped shape persisted by cards started before worker keys carried an agent
+// scope. Task discovery still has to match those against scoped ledger keys.
 const sampleTaskSessionKey = "subagent:workboard-default-card-1";
+// Shape an autonomous start builds now: an unassigned card adopts the gateway
+// default agent so the key resolves to that agent's session store.
+const sampleStartedSessionKey = `agent:main:${sampleTaskSessionKey}`;
 const sampleTask = createWorkboardTask();
+const sampleStartedTask = createWorkboardTask({ childSessionKey: sampleStartedSessionKey });
 
 let host: object;
 let state: ReturnType<typeof getWorkboardState>;
@@ -3342,13 +3348,13 @@ describe("workboard controller", () => {
     const running = {
       ...sampleCard,
       status: "running",
-      sessionKey: sampleTaskSessionKey,
+      sessionKey: sampleStartedSessionKey,
       runId: "run-1",
       taskId: "task-1",
     };
     const client = createClient({
-      agent: { sessionKey: sampleTaskSessionKey, runId: "run-1" },
-      "tasks.list": { tasks: [sampleTask] },
+      agent: { sessionKey: sampleStartedSessionKey, runId: "run-1" },
+      "tasks.list": { tasks: [sampleStartedTask] },
       "workboard.cards.update": { card: running },
     });
 
@@ -3356,9 +3362,10 @@ describe("workboard controller", () => {
       host,
       client: client as never,
       card: sampleCard,
+      defaultAgentId: "main",
     });
 
-    expect(sessionKey).toBe(sampleTaskSessionKey);
+    expect(sessionKey).toBe(sampleStartedSessionKey);
     expect(client.request).toHaveBeenNthCalledWith(
       1,
       "workboard.cards.update",
@@ -3371,7 +3378,7 @@ describe("workboard controller", () => {
       2,
       "agent",
       expect.objectContaining({
-        sessionKey: sampleTaskSessionKey,
+        sessionKey: sampleStartedSessionKey,
         label: "Build board (card-1)",
         message: expect.stringContaining("Work on this OpenClaw Workboard card: Build board"),
         idempotencyKey: "workboard:default:card-1:1",
@@ -3397,8 +3404,8 @@ describe("workboard controller", () => {
   it("keeps bounded task session labels on a UTF-16 boundary", async () => {
     const title = `${"a".repeat(499)}🚀tail`;
     const client = createClient({
-      agent: { sessionKey: sampleTaskSessionKey, runId: "run-1" },
-      "tasks.list": { tasks: [sampleTask] },
+      agent: { sessionKey: sampleStartedSessionKey, runId: "run-1" },
+      "tasks.list": { tasks: [sampleStartedTask] },
       "workboard.cards.update": { card: { ...sampleCard, title, status: "running" } },
     });
 
@@ -3406,6 +3413,7 @@ describe("workboard controller", () => {
       host,
       client: client as never,
       card: { ...sampleCard, title },
+      defaultAgentId: "main",
     });
 
     expect(client.request).toHaveBeenNthCalledWith(
@@ -3456,23 +3464,85 @@ describe("workboard controller", () => {
     );
   });
 
+  // Sessions live in per-agent SQLite stores. A bare `subagent:` key has no store
+  // to resolve, so the gateway rejects the run with "Cannot resolve SQLite session
+  // scope without an agent id" and the card never starts.
+  it("scopes an unassigned card's worker session to the default agent", async () => {
+    const running = {
+      ...sampleCard,
+      status: "running",
+      sessionKey: "agent:ops:subagent:workboard-default-card-1",
+      runId: "run-1",
+    } satisfies WorkboardCard;
+    const client = createClient({
+      agent: { runId: "run-1" },
+      "tasks.list": { tasks: [] },
+      "workboard.cards.update": { card: running },
+    });
+
+    const sessionKey = await startWorkboardCard({
+      host,
+      client: client as never,
+      // Card is unassigned; the gateway default agent owns it, matching the
+      // owner the Workboard dispatcher resolves for the same card.
+      card: sampleCard,
+      defaultAgentId: "OPS",
+    });
+
+    expect(sessionKey).toBe("agent:ops:subagent:workboard-default-card-1");
+    expect(client.request).toHaveBeenNthCalledWith(
+      2,
+      "agent",
+      expect.objectContaining({ sessionKey: "agent:ops:subagent:workboard-default-card-1" }),
+    );
+    expect(client.request.mock.calls[1]?.[1]).not.toHaveProperty("agentId");
+  });
+
+  it("fails an unassigned card closed when no default agent is known", async () => {
+    let updateCalls = 0;
+    const client = createClient((method) => {
+      if (method === "workboard.cards.update") {
+        updateCalls += 1;
+        return { card: updateCalls === 1 ? { ...sampleCard, status: "running" } : sampleCard };
+      }
+      return {};
+    });
+
+    const sessionKey = await startWorkboardCard({
+      host,
+      client: client as never,
+      card: sampleCard,
+    });
+
+    expect(sessionKey).toBeNull();
+    expect(client.request).not.toHaveBeenCalledWith("agent", expect.anything());
+    expect(client.request).toHaveBeenNthCalledWith(
+      2,
+      "workboard.cards.update",
+      expect.objectContaining({ patch: expect.objectContaining({ status: "todo" }) }),
+    );
+    expect(getWorkboardState(host).error).toBe(
+      "Cannot start an unassigned card until the default agent is known.",
+    );
+  });
+
   it("waits briefly for task ledger registration after a started run", async () => {
     vi.useFakeTimers();
     const running = {
       ...sampleCard,
       status: "running",
-      sessionKey: sampleTaskSessionKey,
+      sessionKey: sampleStartedSessionKey,
       runId: "run-1",
       taskId: "task-1",
     };
     let taskLists = 0;
     const client = createClient((method) => {
       if (method === "agent") {
-        return { sessionKey: sampleTaskSessionKey, runId: "run-1" };
+        return { sessionKey: sampleStartedSessionKey, runId: "run-1" };
       }
       if (method === "tasks.list") {
         taskLists += 1;
-        return { tasks: taskLists >= 3 ? [sampleTask] : [] };
+        return { tasks: taskLists >= 3 ? [sampleStartedTask] : [] };
       }
       return { card: running };
     });
@@ -3481,11 +3551,12 @@ describe("workboard controller", () => {
       host,
       client: client as never,
       card: sampleCard,
+      defaultAgentId: "main",
     });
     await vi.advanceTimersByTimeAsync(350);
     const sessionKey = await started;
 
-    expect(sessionKey).toBe(sampleTaskSessionKey);
+    expect(sessionKey).toBe(sampleStartedSessionKey);
     expect(taskLists).toBe(3);
     expect(client.request).toHaveBeenLastCalledWith(
       "workboard.cards.update",
@@ -3500,12 +3571,12 @@ describe("workboard controller", () => {
     const running = {
       ...sampleCard,
       status: "running",
-      sessionKey: sampleTaskSessionKey,
+      sessionKey: sampleStartedSessionKey,
       runId: "run-1",
     } satisfies WorkboardCard;
     const client = createClient((method) => {
       if (method === "agent") {
-        return { sessionKey: sampleTaskSessionKey, runId: "run-1" };
+        return { sessionKey: sampleStartedSessionKey, runId: "run-1" };
       }
       if (method === "tasks.list") {
         throw new Error("task ledger unavailable");
@@ -3517,17 +3588,18 @@ describe("workboard controller", () => {
       host,
       client: client as never,
       card: sampleCard,
+      defaultAgentId: "main",
     });
     await vi.advanceTimersByTimeAsync(1000);
     const sessionKey = await started;
 
-    expect(sessionKey).toBe(sampleTaskSessionKey);
+    expect(sessionKey).toBe(sampleStartedSessionKey);
     expect(client.request).not.toHaveBeenCalledWith("chat.abort", expect.anything());
     expect(client.request).toHaveBeenLastCalledWith(
       "workboard.cards.update",
       expect.objectContaining({
         patch: expect.objectContaining({
-          sessionKey: sampleTaskSessionKey,
+          sessionKey: sampleStartedSessionKey,
           runId: "run-1",
           taskId: null,
         }),
@@ -3549,7 +3621,7 @@ describe("workboard controller", () => {
     const running = {
       ...child,
       status: "running",
-      sessionKey: "subagent:workboard-default-child-1",
+      sessionKey: "agent:main:subagent:workboard-default-child-1",
       runId: "run-1",
     } satisfies WorkboardCard;
     const client = createClient((method) => {
@@ -3557,7 +3629,7 @@ describe("workboard controller", () => {
         return { cards: [parent, child], statuses: ["todo", "running", "done"] };
       }
       if (method === "agent") {
-        return { sessionKey: "subagent:workboard-default-child-1", runId: "run-1" };
+        return { sessionKey: "agent:main:subagent:workboard-default-child-1", runId: "run-1" };
       }
       if (method === "tasks.list") {
         return { tasks: [] };
@@ -3571,9 +3643,10 @@ describe("workboard controller", () => {
       host,
       client: client as never,
       card: child,
+      defaultAgentId: "main",
     });
 
-    expect(sessionKey).toBe("subagent:workboard-default-child-1");
+    expect(sessionKey).toBe("agent:main:subagent:workboard-default-child-1");
     expect(client.request).toHaveBeenNthCalledWith(
       1,
       "workboard.cards.update",
@@ -3582,7 +3655,7 @@ describe("workboard controller", () => {
     expect(client.request).toHaveBeenNthCalledWith(
       2,
       "agent",
-      expect.objectContaining({ sessionKey: "subagent:workboard-default-child-1" }),
+      expect.objectContaining({ sessionKey: "agent:main:subagent:workboard-default-child-1" }),
     );
   });
 
@@ -3629,6 +3702,7 @@ describe("workboard controller", () => {
       host,
       client: client as never,
       card: sampleCard,
+      defaultAgentId: "main",
     });
 
     expect(sessionKey).toBeNull();
@@ -3667,10 +3741,10 @@ describe("workboard controller", () => {
         return { card: sampleCard };
       }
       if (method === "agent") {
-        return { sessionKey: sampleTaskSessionKey, runId: "run-1" };
+        return { sessionKey: sampleStartedSessionKey, runId: "run-1" };
       }
       if (method === "tasks.list") {
-        return { tasks: [sampleTask] };
+        return { tasks: [sampleStartedTask] };
       }
       if (method === "chat.abort") {
         return { aborted: true, runIds: ["run-1"] };
@@ -3682,11 +3756,12 @@ describe("workboard controller", () => {
       host,
       client: client as never,
       card: sampleCard,
+      defaultAgentId: "main",
     });
 
     expect(sessionKey).toBeNull();
     expect(client.request).toHaveBeenNthCalledWith(5, "chat.abort", {
-      sessionKey: sampleTaskSessionKey,
+      sessionKey: sampleStartedSessionKey,
       runId: "run-1",
     });
     expect(client.request).toHaveBeenNthCalledWith(
@@ -3807,7 +3882,7 @@ describe("workboard controller", () => {
     const dueRunning = {
       ...dueScheduled,
       status: "running",
-      sessionKey: "subagent:workboard-default-scheduled-3",
+      sessionKey: "agent:main:subagent:workboard-default-scheduled-3",
       runId: "run-due",
       taskId: "task-due",
     } satisfies WorkboardCard;
@@ -3817,7 +3892,7 @@ describe("workboard controller", () => {
       }
       if (method === "agent") {
         return {
-          sessionKey: "subagent:workboard-default-scheduled-3",
+          sessionKey: "agent:main:subagent:workboard-default-scheduled-3",
           runId: "run-due",
         };
       }
@@ -3828,7 +3903,7 @@ describe("workboard controller", () => {
               ...sampleTask,
               id: "task-due",
               taskId: "task-due",
-              childSessionKey: "subagent:workboard-default-scheduled-3",
+              childSessionKey: "agent:main:subagent:workboard-default-scheduled-3",
               runId: "run-due",
             },
           ],
@@ -3846,9 +3921,10 @@ describe("workboard controller", () => {
       host,
       client: dueClient as never,
       card: dueScheduled,
+      defaultAgentId: "main",
     });
 
-    expect(dueSessionKey).toBe("subagent:workboard-default-scheduled-3");
+    expect(dueSessionKey).toBe("agent:main:subagent:workboard-default-scheduled-3");
     expect(dueClient.request).toHaveBeenCalledWith(
       "agent",
       expect.objectContaining({
@@ -3860,12 +3936,12 @@ describe("workboard controller", () => {
   it("starts a Codex execution with an explicit model override", async () => {
     const running = createWorkboardCard({
       status: "running",
-      sessionKey: sampleTaskSessionKey,
+      sessionKey: sampleStartedSessionKey,
       taskId: "task-1",
       execution: createWorkboardExecution({
         id: "card-1:codex",
         model: "openai/gpt-5.6-sol",
-        sessionKey: sampleTaskSessionKey,
+        sessionKey: sampleStartedSessionKey,
         runId: "run-1",
         startedAt: 10,
         updatedAt: 10,
@@ -3878,10 +3954,10 @@ describe("workboard controller", () => {
         return { card: updateCalls === 1 ? { ...sampleCard, status: "running" } : running };
       }
       if (method === "agent") {
-        return { sessionKey: sampleTaskSessionKey, runId: "run-1" };
+        return { sessionKey: sampleStartedSessionKey, runId: "run-1" };
       }
       if (method === "tasks.list") {
-        return { tasks: [sampleTask] };
+        return { tasks: [sampleStartedTask] };
       }
       return {};
     });
@@ -3891,6 +3967,7 @@ describe("workboard controller", () => {
       client: client as never,
       card: sampleCard,
       engine: "codex",
+      defaultAgentId: "main",
     });
 
     expect(client.request).toHaveBeenNthCalledWith(
@@ -3904,7 +3981,7 @@ describe("workboard controller", () => {
       2,
       "agent",
       expect.objectContaining({
-        sessionKey: sampleTaskSessionKey,
+        sessionKey: sampleStartedSessionKey,
         model: "openai/gpt-5.6-sol",
         message: expect.stringContaining("Work on this OpenClaw Workboard card: Build board"),
       }),
@@ -3968,6 +4045,7 @@ describe("workboard controller", () => {
         client: client as never,
         card: previous,
         engine: "codex",
+        defaultAgentId: "main",
       });
 
       expect(client.request).toHaveBeenNthCalledWith(
@@ -4102,7 +4180,7 @@ describe("workboard controller", () => {
     const client = createClient((method) => {
       if (method === "agent") {
         return {
-          sessionKey: sampleTaskSessionKey,
+          sessionKey: sampleStartedSessionKey,
           runStarted: false,
           runError: { message: "provider unavailable" },
         };
@@ -4118,6 +4196,7 @@ describe("workboard controller", () => {
       host,
       client: client as never,
       card: sampleCard,
+      defaultAgentId: "main",
     });
 
     expect(sessionKey).toBeNull();
@@ -4544,6 +4623,7 @@ describe("workboard controller", () => {
       host,
       client: client as never,
       card: remaining,
+      defaultAgentId: "main",
     });
 
     expect(client.request).toHaveBeenNthCalledWith(

--- a/ui/src/pages/workboard/view-card-actions.ts
+++ b/ui/src/pages/workboard/view-card-actions.ts
@@ -324,6 +324,7 @@ export function renderStartExecutionButton(
           host: props.host,
           client: props.client,
           card,
+          defaultAgentId: props.agentsList?.defaultId ?? props.defaultAgentId,
           ...(engine ? { engine } : {}),
           mode,
           requestUpdate: props.onRequestUpdate,


### PR DESCRIPTION
Related: #115119

## What Problem This Solves

Fixes an issue where users who press **Run** on a Workboard card that has no
assigned agent get no worker at all: the card flips to Running, the gateway
rejects the run with `Cannot resolve SQLite session scope without an agent id`,
and the card rolls back with that error in the board's error bar.

The Control UI built the worker session key itself, and for an unassigned card
it produced a bare `subagent:workboard-<board>-<card>` key with no
`agent:<id>:` prefix. Sessions live in per-agent SQLite stores, so an unscoped
key names no store and the run cannot start. Cards with an explicit agent were
unaffected — only the default-agent case was broken.

## Why This Change Was Made

Unassigned cards now adopt the gateway's default agent, the same owner the
Workboard dispatcher resolves for the same card, so both surfaces address one
session per card instead of two different ones. The UI already knows that agent
(`agents.list`'s `defaultId`, with the connect snapshot's `assistantAgentId` as
the fallback used elsewhere on this page), so the resolved id is threaded into
`startWorkboardCard` rather than inferred inside the library.

Letting the gateway pick a session instead was ruled out: `agent` with no
`sessionKey` does not mint a worker session, it falls through to
`resolveExplicitAgentSessionKey` and targets the agent's **main** session
(`src/gateway/server-methods/agent-request-routing.ts:166`), which would post
card prompts into the operator's own chat thread.

The agent id is canonicalized with the UI's `normalizeAgentId`, matching the
dispatcher, so `MAIN` and `main` cannot address two stores. Only a non-empty id
is normalized — `normalizeAgentId` maps blank to `main`, which would silently
retarget a card away from a differently configured default — so a card with no
owner at all fails closed with a readable error instead of starting somewhere
unintended. Manual "Open" starts are untouched; they still create a session
through `sessions.create` and let the gateway name it.

This is the `ui/` half of the same defect #115119 fixes in
`extensions/workboard/src/dispatcher.ts`; it is a separate owner boundary, so it
lands separately. The unscoped-key compat in `task-links.ts` stays: cards
persisted before this fix keep their old keys and still have to match scoped
ledger entries.

## User Impact

Pressing **Run** (or **Run with OpenAI/Claude**) on an unassigned Workboard card
starts a worker instead of failing. Cards already assigned to an agent behave
exactly as before. As a side effect, newly started unassigned cards are now
discoverable through the gateway's exact `tasks.list` session filter rather than
the bounded unfiltered page rotation that unscoped keys required.

## Evidence

Focused tests — `ui/src/lib/workboard/index.test.ts`, 188 passed:

```
node scripts/run-vitest.mjs ui/src/lib/workboard/index.test.ts
```

Two new regression tests cover the defect directly:

- `scopes an unassigned card's worker session to the default agent` — asserts the
  `agent` request carries `agent:ops:subagent:workboard-default-card-1` for a card
  with no `agentId` and a `defaultAgentId` of `OPS`. Against the previous code this
  request carried the bare `subagent:workboard-default-card-1` key that the gateway
  rejects.
- `fails an unassigned card closed when no default agent is known` — asserts no
  `agent` request is sent, the running preflight is rolled back to `todo`, and the
  error surfaces on the board.

Existing autonomous-start cases were updated to the scoped key shape and now pass
the default agent; `starts reassigned cards with the current task session key`
deliberately still passes no default, proving an explicitly assigned card needs
none.

Wider UI suite (432 files / 6197 tests) passed, and `pnpm check:changed`
delegated to Testbox was green: package patch guard, Control UI i18n catalog,
`tsgo` UI + core-test typecheck, and lint over the changed files.

Codex autoreview (`gpt-5.6-sol`, xhigh) on the change bundle: clean, no
accepted/actionable findings.
