### PR TITLE
fix(memory): preserve QMD search hits when result rows are malformed

### DIFF
--- a/extensions/memory-core/src/memory/qmd-manager.test.ts
+++ b/extensions/memory-core/src/memory/qmd-manager.test.ts
@@ -5794,6 +5794,67 @@ describe("QmdMemoryManager", () => {
     await manager.close();
   });
 
+  it("preserves valid qmd memory search hits when result arrays contain malformed entries", async () => {
+    configureQmd();
+
+    spawnMock.mockImplementation((_cmd: string, args: string[]) => {
+      if (args[0] === "search") {
+        const child = createMockChild({ autoClose: false });
+        emitAndClose(
+          child,
+          "stdout",
+          JSON.stringify([
+            null,
+            "noise",
+            1,
+            [{ file: "qmd://workspace-main/notes/nested.md", score: 1 }],
+            {
+              file: "qmd://workspace-main/notes/welcome.md",
+              score: 0.8,
+              snippet: "@@ -4,1\nfirst valid hit",
+            },
+            false,
+            {
+              file: "qmd://workspace-main/memory/facts.md",
+              score: 0.6,
+              snippet: "@@ -2,1\nsecond valid hit",
+            },
+          ]),
+        );
+        return child;
+      }
+      return createMockChild();
+    });
+
+    const { manager } = await createManager();
+    try {
+      await expect(
+        manager.search("valid hit", { sessionKey: "agent:main:slack:dm:u123" }),
+      ).resolves.toEqual([
+        {
+          path: "notes/welcome.md",
+          startLine: 4,
+          endLine: 4,
+          score: 0.8,
+          snippet: "@@ -4,1\nfirst valid hit",
+          source: "memory",
+          provenance: expectedQmdProvenance("untrusted"),
+        },
+        {
+          path: "memory/facts.md",
+          startLine: 2,
+          endLine: 2,
+          score: 0.6,
+          snippet: "@@ -2,1\nsecond valid hit",
+          source: "memory",
+          provenance: expectedQmdProvenance("untrusted"),
+        },
+      ]);
+    } finally {
+      await manager.close();
+    }
+  });
+
   it("returns collection-scoped qmd paths when session exports live under the workspace qmd directory", async () => {
     workspaceDir = path.join(stateDir, "agents", agentId);
     await fs.mkdir(workspaceDir, { recursive: true });

--- a/packages/memory-host-sdk/src/host/qmd-process.real.test.ts
+++ b/packages/memory-host-sdk/src/host/qmd-process.real.test.ts
@@ -5,6 +5,7 @@ import os from "node:os";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
 import { runCliCommand } from "./qmd-process.js";
+import { parseQmdQueryJson } from "./qmd-query-parser.js";
 
 type ProcessTreePids = {
   parent: number;
@@ -109,6 +110,38 @@ describe("runCliCommand real process UTF-8 framing", () => {
       stdout: '{"value":"猫"}\n',
       stderr: "path: 猫 denied\n",
     });
+  }, 10_000);
+});
+
+describe("runCliCommand real QMD query result validation", () => {
+  it("preserves valid hits from real process output containing malformed entries", async () => {
+    const payload = JSON.stringify([
+      null,
+      "noise",
+      1,
+      [{ docid: "nested", score: 1 }],
+      { docid: "first", score: 0.8 },
+      false,
+      { docid: "second", score: 0.6 },
+    ]);
+    const { stdout, stderr } = await runCliCommand({
+      commandSummary: "real qmd query result validation fixture",
+      spawnInvocation: {
+        command: process.execPath,
+        argv: ["-e", `process.stdout.write(${JSON.stringify(payload)})`],
+      },
+      env: process.env,
+      cwd: process.cwd(),
+      timeoutMs: 5_000,
+      maxOutputChars: 10_000,
+    });
+
+    const results = parseQmdQueryJson(stdout, stderr);
+    expect(results).toEqual([
+      { docid: "first", score: 0.8 },
+      { docid: "second", score: 0.6 },
+    ]);
+    expect(results.map((result) => result.docid)).toEqual(["first", "second"]);
   }, 10_000);
 });
 

--- a/packages/memory-host-sdk/src/host/qmd-query-parser.test.ts
+++ b/packages/memory-host-sdk/src/host/qmd-query-parser.test.ts
@@ -14,6 +14,44 @@ describe("parseQmdQueryJson", () => {
     ]);
   });
 
+  it("preserves valid result objects and their order while dropping malformed entries", () => {
+    expect(
+      parseQmdQueryJson(
+        JSON.stringify([
+          null,
+          "noise",
+          1,
+          [{ docid: "nested", score: 1 }],
+          { docid: "first", score: 0.8, start_line: 3, end_line: 4 },
+          false,
+          { docid: "second", score: 0.6, snippet: "second hit" },
+        ]),
+        "",
+      ),
+    ).toEqual([
+      { docid: "first", score: 0.8, startLine: 3, endLine: 4 },
+      { docid: "second", score: 0.6, snippet: "second hit" },
+    ]);
+  });
+
+  it.each([
+    { name: "null", entries: [null] },
+    { name: "a string", entries: ["noise"] },
+    { name: "a number", entries: [1] },
+    { name: "a boolean", entries: [false] },
+    { name: "a nested array", entries: [[{ docid: "nested", score: 1 }]] },
+    { name: "mixed malformed values", entries: [null, "noise", 1, false, ["nested"]] },
+  ])("rejects a nonempty result array containing only $name", ({ entries }) => {
+    expect(() => parseQmdQueryJson(JSON.stringify(entries), "")).toThrow(
+      /qmd query returned invalid JSON/i,
+    );
+  });
+
+  it("preserves empty result arrays and valid result objects without optional fields", () => {
+    expect(parseQmdQueryJson("[]", "")).toStrictEqual([]);
+    expect(parseQmdQueryJson("[{}]", "")).toEqual([{}]);
+  });
+
   it("extracts embedded result arrays from noisy stdout", () => {
     const results = parseQmdQueryJson(
       `initializing
@@ -23,6 +61,15 @@ complete`,
       "",
     );
     expect(results).toEqual([{ docid: "abc", score: 0.5 }]);
+  });
+
+  it("skips a malformed standalone array before a valid noisy result array", () => {
+    expect(
+      parseQmdQueryJson(
+        'initializing\n[null, "noise", 1, ["nested"]]\n[{"docid":"abc","score":0.5}]',
+        "",
+      ),
+    ).toEqual([{ docid: "abc", score: 0.5 }]);
   });
 
   it.each([

--- a/packages/memory-host-sdk/src/host/qmd-query-parser.ts
+++ b/packages/memory-host-sdk/src/host/qmd-query-parser.ts
@@ -94,11 +94,14 @@ function parseQmdQueryResultArray(raw: string): QmdQueryResult[] | null {
     if (!Array.isArray(parsed)) {
       return null;
     }
-    return parsed.map((item) => {
-      if (typeof item !== "object" || item === null) {
-        return item as QmdQueryResult;
-      }
-      const record = item as Record<string, unknown>;
+    const records = parsed.filter(
+      (item): item is Record<string, unknown> =>
+        typeof item === "object" && item !== null && !Array.isArray(item),
+    );
+    if (parsed.length > 0 && records.length === 0) {
+      return null;
+    }
+    return records.map((record) => {
       const docid = typeof record.docid === "string" ? record.docid : undefined;
       const score =
         typeof record.score === "number" && Number.isFinite(record.score)


### PR DESCRIPTION
Closes #114315

## What Problem This Solves

Fixes an issue where users searching QMD-backed memory would see the search crash when QMD returns null, primitive values, or nested arrays alongside valid search hits.

## Why This Change Was Made

Validate each QMD result once at its canonical memory host SDK parser boundary. Preserve every valid result object and its original ordering, skip malformed entries, keep valid empty results and objects unchanged, and preserve the existing invalid-JSON error for a nonempty response with no valid objects. No provider, config, SQLite, SDK surface, or compatibility change is introduced.

## User Impact

QMD-backed memory searches continue to return all valid hits instead of crashing when external QMD output contains malformed rows. Existing no-results markers, line metadata, noisy-output extraction, and error diagnostics remain unchanged.

## Evidence

- Before the change, the actual production QmdMemoryManager.search regression fails with "Cannot read properties of null (reading collection)" while its other 162 manager tests pass.
- Before the change, genuine child-process QMD output and canonical parser tests reproduce nine malformed-result failures.
- After the change, 219 of 219 targeted and sibling tests pass remotely across all three Vitest projects, including the real child process, all 163 production-manager tests, all parser normalization and noisy-output cases, and all QMD process tests.
- The complete unscoped remote pnpm check:changed gate passes: all three core/core-test/extension-test typechecks; all repository-wide core and extension lint; format; SDK and plugin boundaries; schema, database, security, dependency, and import-cycle guards.
- A fresh independent Codex autoreview at extra-high reasoning reports no accepted or actionable findings.
- The four touched baseline files were verified against current main immediately before publication.

## Contributor Credit

Thanks to @kevin2966n for reporting and investigating #114315. The original broader six-issue draft #114319 is intentionally preserved and remains open; this PR addresses only the independently reproduced QMD result-parser issue.

AI-assisted: implemented and independently reviewed with Codex.