### PR TITLE
fix(codex): preserve startup diagnostics on initialize timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Codex app-server startup diagnostics:** include the bounded, redacted app-server stderr tail in initialize-timeout errors so SQLite and other startup failures remain actionable instead of collapsing to a generic timeout.
 - **Codex native controls:** stop misclassifying valid thinking/fast runtime controls as provider overrides so Codex routes keep their native controls, while provider-native objects and invalid values stay fail-closed. Thanks @VACInc. (#107588)
 - **State snapshot verification:** run SQLite snapshot verification in a separate process so worker-thread file closes no longer drop the Gateway's POSIX WAL locks, eliminating spurious WAL misses and I/O errors. Thanks @VACInc. (#114016)
 - **Reply latency with model policies:** reuse one immutable plugin-metadata snapshot per model-selection run instead of repeating plugin discovery, cutting reply delay when a model policy is configured. Thanks @VACInc. (#114117)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,7 +51,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- **Codex app-server startup diagnostics:** include the bounded, redacted app-server stderr tail in initialize-timeout errors so SQLite and other startup failures remain actionable instead of collapsing to a generic timeout.
 - **Codex native controls:** stop misclassifying valid thinking/fast runtime controls as provider overrides so Codex routes keep their native controls, while provider-native objects and invalid values stay fail-closed. Thanks @VACInc. (#107588)
 - **State snapshot verification:** run SQLite snapshot verification in a separate process so worker-thread file closes no longer drop the Gateway's POSIX WAL locks, eliminating spurious WAL misses and I/O errors. Thanks @VACInc. (#114016)
 - **Reply latency with model policies:** reuse one immutable plugin-metadata snapshot per model-selection run instead of repeating plugin discovery, cutting reply delay when a model policy is configured. Thanks @VACInc. (#114117)

--- a/extensions/codex/src/app-server/attempt-startup.test.ts
+++ b/extensions/codex/src/app-server/attempt-startup.test.ts
@@ -597,6 +597,7 @@ describe("startCodexAttemptThread", () => {
         'import readline from "node:readline";',
         "const [requestLogPath, pidPath] = process.argv.slice(2);",
         'fs.writeFileSync(pidPath, String(process.pid), "utf8");',
+        'process.stderr.write("Error: failed to initialize sqlite state runtime token=secret-value\\n");',
         "const lines = readline.createInterface({ input: process.stdin });",
         'lines.on("line", (line) => {',
         "  const message = JSON.parse(line);",
@@ -623,7 +624,9 @@ describe("startCodexAttemptThread", () => {
         skipStartSpy: true,
       });
 
-      await expect(run).rejects.toThrow("codex app-server initialize timed out");
+      await expect(run).rejects.toThrow(
+        'codex app-server initialize timed out; stderr="Error: failed to initialize sqlite state runtime token=<redacted>"',
+      );
 
       const requestMethods = (await fs.readFile(requestLogPath, "utf8")).trim().split(/\r?\n/u);
       expect(requestMethods).toEqual(["initialize"]);

--- a/extensions/codex/src/app-server/client.ts
+++ b/extensions/codex/src/app-server/client.ts
@@ -355,6 +355,11 @@ export class CodexAppServerClient {
     return this.runtimeIdentity ? { ...this.runtimeIdentity } : undefined;
   }
 
+  /** Returns a bounded, redacted stderr diagnostic from the app-server process. */
+  getStderrDiagnostic(): string | undefined {
+    return redactCodexAppServerLinePreview(this.stderrTail) || undefined;
+  }
+
   /** Stable generation id for this exact physical client instance. */
   getInstanceId(): string {
     return this.instanceId;

--- a/extensions/codex/src/app-server/shared-client.test.ts
+++ b/extensions/codex/src/app-server/shared-client.test.ts
@@ -715,6 +715,22 @@ describe("shared Codex app-server client", () => {
     expect(startSpy).toHaveBeenCalledTimes(2);
   });
 
+  it("includes redacted app-server stderr when shared initialize times out", async () => {
+    const harness = createClientHarness();
+    vi.spyOn(CodexAppServerClient, "start").mockReturnValue(harness.client);
+
+    const models = listCodexAppServerModels({ timeoutMs: 100 });
+    await vi.waitFor(() => expect(harness.writes.length).toBeGreaterThanOrEqual(1));
+    harness.process.stderr.write(
+      'Error: failed to initialize sqlite state runtime token="secret-value"\n',
+    );
+
+    await expect(models).rejects.toThrow(
+      'codex app-server initialize timed out; stderr="Error: failed to initialize sqlite state runtime token=\\"<redacted>\\""',
+    );
+    expect(harness.process.stdin.destroyed).toBe(true);
+  });
+
   it("keeps shared startup alive for a caller with a longer initialize timeout", async () => {
     const harness = createClientHarness();
     const startSpy = vi.spyOn(CodexAppServerClient, "start").mockReturnValue(harness.client);
@@ -794,6 +810,20 @@ describe("shared Codex app-server client", () => {
 
     await expect(createIsolatedCodexAppServerClient({ timeoutMs: 5 })).rejects.toThrow(
       "codex app-server initialize timed out",
+    );
+    expect(harness.process.stdin.destroyed).toBe(true);
+  });
+
+  it("includes redacted app-server stderr when isolated initialize times out", async () => {
+    const harness = createClientHarness();
+    vi.spyOn(CodexAppServerClient, "start").mockReturnValue(harness.client);
+
+    const client = createIsolatedCodexAppServerClient({ timeoutMs: 100 });
+    await vi.waitFor(() => expect(harness.writes.length).toBeGreaterThanOrEqual(1));
+    harness.process.stderr.write("state database is locked access_token=secret-value\n");
+
+    await expect(client).rejects.toThrow(
+      'codex app-server initialize timed out; stderr="state database is locked access_token=<redacted>"',
     );
     expect(harness.process.stdin.destroyed).toBe(true);
   });

--- a/extensions/codex/src/app-server/shared-client.ts
+++ b/extensions/codex/src/app-server/shared-client.ts
@@ -39,6 +39,8 @@ import { withTimeout } from "./timeout.js";
 
 export type { CodexAppServerPreparedAuth } from "./auth-bridge.js";
 
+const CODEX_APP_SERVER_INITIALIZE_TIMEOUT_MESSAGE = "codex app-server initialize timed out";
+
 type SharedCodexAppServerClientEntry = {
   client?: CodexAppServerClient;
   startup?: SharedCodexAppServerClientStartup;
@@ -619,6 +621,8 @@ async function acquireSharedCodexAppServerClient(
       remainingTimeoutMs,
       startup.initialized,
       options?.abandonSignal,
+      CODEX_APP_SERVER_INITIALIZE_TIMEOUT_MESSAGE,
+      () => buildCodexAppServerInitializeTimeoutError(entry.client),
     );
     const client = await withCodexAppServerAcquireDeadline(
       timeoutMs,
@@ -657,7 +661,8 @@ async function withCodexAppServerAcquireDeadline<T>(
   timeoutMs: number, // First: fail before the caller starts its promise argument.
   promise: Promise<T>,
   signal?: AbortSignal,
-  timeoutMessage = "codex app-server initialize timed out",
+  timeoutMessage = CODEX_APP_SERVER_INITIALIZE_TIMEOUT_MESSAGE,
+  timeoutErrorFactory?: () => CodexAppServerStartupError,
 ): Promise<T> {
   if (signal?.aborted) {
     throw new CodexAppServerStartupError("aborted", "codex app-server initialize aborted");
@@ -666,7 +671,7 @@ async function withCodexAppServerAcquireDeadline<T>(
     promise,
     timeoutMs,
     timeoutMessage,
-    () => new CodexAppServerStartupError("timed_out", timeoutMessage),
+    () => timeoutErrorFactory?.() ?? new CodexAppServerStartupError("timed_out", timeoutMessage),
   );
   if (!signal) {
     return await timed;
@@ -677,6 +682,18 @@ async function withCodexAppServerAcquireDeadline<T>(
     signal.addEventListener("abort", onAbort, { once: true });
     timed.then(resolve, reject).finally(() => signal.removeEventListener("abort", onAbort));
   });
+}
+
+function buildCodexAppServerInitializeTimeoutError(
+  client: CodexAppServerClient | undefined,
+): CodexAppServerStartupError {
+  const stderr = client?.getStderrDiagnostic();
+  return new CodexAppServerStartupError(
+    "timed_out",
+    stderr
+      ? `${CODEX_APP_SERVER_INITIALIZE_TIMEOUT_MESSAGE}; stderr=${JSON.stringify(stderr)}`
+      : CODEX_APP_SERVER_INITIALIZE_TIMEOUT_MESSAGE,
+  );
 }
 
 function resolveRemainingAcquireTimeout(timeoutMs: number, startedAt: number): number {
@@ -847,6 +864,8 @@ async function startInitializedCodexAppServerClient(params: {
         resolveRemainingAcquireTimeout(timeoutMs, acquireStartedAt),
         (initialize = client.initialize()),
         params.abandonSignal,
+        CODEX_APP_SERVER_INITIALIZE_TIMEOUT_MESSAGE,
+        () => buildCodexAppServerInitializeTimeoutError(client),
       );
     } catch (error) {
       client.close();


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users running the Codex harness would receive only `codex app-server initialize timed out` when the app-server had already emitted an actionable startup diagnostic, such as a SQLite state-runtime failure.

## Why This Change Was Made

The app-server client already retains a bounded, redacted stderr tail for process-exit errors. Initialize-timeout errors now reuse that same safe diagnostic instead of discarding it, while preserving the existing generic timeout message when stderr is empty. Shared and isolated startup paths use the same behavior; retry and failover classification are unchanged.

## User Impact

Operators can see the real bounded startup diagnostic directly in timeout errors and cron failure reports without enabling debug logging or reconstructing the app-server process lifecycle. Secret-shaped stderr values remain redacted.

## Evidence

- Reproduced the old behavior with a real stdio child that emits a SQLite-style startup error and stalls during `initialize`; the pre-fix test received only the generic timeout.
- After the fix, the same real child-process path produced this bounded terminal error while still terminating the stalled child:

  ```text
  codex app-server initialize timed out; stderr="Error: failed to initialize sqlite state runtime token=<redacted>"
  ```

- `pnpm test extensions/codex/src/app-server/shared-client.test.ts extensions/codex/src/app-server/client.test.ts extensions/codex/src/app-server/attempt-startup.test.ts` — 105 passed.
- `pnpm check:changed` — passed extension production/test typechecks, targeted lint, formatting, plugin boundaries, SDK baseline, and repository guards on Blacksmith Testbox.
- Autoreview (`gpt-5.6-sol`, high) — clean; no accepted/actionable findings.
- Direct dependency inspection: Codex initializes its SQLite runtime before the JSON-RPC transport becomes usable (`../codex/codex-rs/app-server/src/lib.rs:599`), while the `initialize` request itself only validates client metadata and sends the response (`../codex/codex-rs/app-server/src/request_processors/initialize_processor.rs:44`). Codex's SQLite connections use a five-second busy timeout (`../codex/codex-rs/state/src/sqlite.rs:244`).
