### PR TITLE
fix(tui): preserve shared prompts when scrollback is full

### DIFF
--- a/src/tui/components/chat-log.test.ts
+++ b/src/tui/components/chat-log.test.ts
@@ -387,6 +387,38 @@ describe("ChatLog", () => {
     expect(normalizeTestText(chatLog.render(120).join("\n"))).toContain("Still streaming.");
   });
 
+  it("preserves a delayed shared prompt and its active reply when scrollback is full", () => {
+    const chatLog = new ChatLog(20);
+    chatLog.updateAssistant("Already streaming.", "shared-run");
+    for (let index = 0; index < 19; index += 1) {
+      chatLog.addSystem(`Older notice ${index}.`);
+    }
+
+    chatLog.addLiveUser("Sent from the other client.", {
+      messageId: "shared-overflow-user",
+      runId: "shared-run",
+    });
+    chatLog.addLiveUser("Sent from the other client.", {
+      messageId: "shared-overflow-user",
+      runId: "shared-run",
+    });
+
+    const rendered = normalizeTestText(chatLog.render(120).join("\n"));
+    expect(chatLog.children).toHaveLength(20);
+    expect(rendered).toContain("Sent from the other client.");
+    expect(rendered).toContain("Already streaming.");
+    expect(rendered).not.toContain("Older notice 0.");
+    expect(rendered.match(/Sent from the other client\./g)).toHaveLength(1);
+    expect(rendered.indexOf("Sent from the other client.")).toBeLessThan(
+      rendered.indexOf("Already streaming."),
+    );
+
+    chatLog.updateAssistant("Still streaming after overflow.", "shared-run");
+    expect(normalizeTestText(chatLog.render(120).join("\n"))).toContain(
+      "Still streaming after overflow.",
+    );
+  });
+
   it("deduplicates authoritative user events and adopts the matching pending prompt", () => {
     const chatLog = new ChatLog(40);
     chatLog.addPendingUser("shared-run", "Persisted prompt.");

--- a/src/tui/components/chat-log.ts
+++ b/src/tui/components/chat-log.ts
@@ -87,9 +87,11 @@ export class ChatLog extends Container {
     }
   }
 
-  private pruneOverflow() {
+  private pruneOverflow(protectedComponents?: ReadonlySet<Component>) {
     while (this.children.length > this.maxComponents) {
-      const oldest = this.children[0];
+      const oldest = protectedComponents
+        ? this.children.find((component) => !protectedComponents.has(component))
+        : this.children[0];
       if (!oldest) {
         return;
       }
@@ -231,12 +233,13 @@ export class ChatLog extends Container {
       frozen?.values().next().value ??
       (options.runId ? this.streamingRuns.get(options.runId) : undefined);
     const assistantIndex = assistant ? this.children.indexOf(assistant) : -1;
-    if (assistantIndex >= 0) {
+    if (assistant && assistantIndex >= 0) {
       // Transcript broadcasts can trail the first delta; insert their prompt
-      // before the existing reply without resetting live stream or tool state.
+      // before the existing reply. Preserve both when full scrollback evicts
+      // older components so the newly recovered prompt cannot disappear.
       this.repeatableSystemMessage = null;
       this.children.splice(assistantIndex, 0, component);
-      this.pruneOverflow();
+      this.pruneOverflow(new Set([component, assistant]));
       return component;
     }
     this.appendNonSystem(component);


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users sharing a TUI conversation with another client would lose that other client's delayed prompt once the terminal scrollback reached its component limit. The assistant response remained visible, making the synchronized conversation look as if it had no user message.

## Why This Change Was Made

The new shared-chat synchronization inserts an authoritative prompt immediately before its already-streaming assistant. At full capacity, ordinary oldest-first eviction immediately removed that newly inserted prompt. Protect both the prompt and its owning assistant during that insertion only, and evict the oldest genuinely unprotected component instead. Keep all other chat-log pruning, run state, and component limits unchanged.

## User Impact

Busy, long-running shared TUI sessions retain both the other client's prompt and its live assistant reply in the correct order, without duplicate prompts or unbounded scrollback.

## Evidence

Fresh main, before fix:

    20-component scrollback + active stream + delayed cross-client prompt
    expected: Sent from the other client.
    received: Already streaming. (prompt immediately pruned)
    result: FAIL

Final regression on the reviewed patch:

    delayed prompt stays visible and precedes its active reply: PASS
    duplicate authoritative replay appears exactly once: PASS
    oldest unprotected notice is evicted: PASS
    component count remains exactly 20: PASS
    assistant continues streaming after overflow: PASS

Blacksmith Testbox tbx_01kym6yazh45w0wd8we3cfpe9p:

- complete chat-log regression suite: 35 passing tests;
- complete TUI suite: 908 passing tests across 35 files;
- full real-terminal, local-backend, and real-Gateway suite: 61 passing tests;
- full changed gate, typecheck, formatting, and repository guards: PASS;
- type-aware TUI lint: PASS;
- fresh independent autoreview: clean, no accepted or actionable findings;
- prior fresh-main stress soak: three full-screen terminal-race passes and two real-Gateway race passes, after the full 907-test TUI baseline and 61-case Gateway baseline.

### Additional live Gateway contract proof

The actual web and TUI websocket regression in src/gateway/session-message-events.test.ts also passes independently in all three configured Gateway projects on Blacksmith Testbox tbx_01kym6yazh45w0wd8we3cfpe9p. It connects real web and TUI subscribers to one authoritative transcript, persists turns from both clients, verifies matching session.message delivery, reconnects the TUI client, and verifies the complete chat.history result. This supplements the 61 passing full-screen terminal scenarios and proves that the owner-local scrollback fix does not change Gateway synchronization.
