### PR TITLE
fix(ui): stop modal autofocus steal after the open animation

### DIFF
--- a/test/vitest/vitest.ui-e2e.config.ts
+++ b/test/vitest/vitest.ui-e2e.config.ts
@@ -25,6 +25,11 @@ function createUiE2eVitestConfig(
       ...baseTest,
       environment: "node",
       exclude,
+      // Vitest's expect.poll defaults to a 1s deadline; these polls await real
+      // Chromium renders, which loaded CI runners regularly stall past 1s.
+      // Correctness is the eventual state, so a larger budget only trades
+      // failure latency, not coverage.
+      expect: { poll: { interval: 100, timeout: 15_000 } },
       fileParallelism: false,
       include,
       isolate: true,

--- a/ui/src/components/modal-dialog.test.ts
+++ b/ui/src/components/modal-dialog.test.ts
@@ -77,6 +77,23 @@ describe("openclaw-modal-dialog", () => {
     expect(document.activeElement).toBe(container.querySelector("#autofocus-target"));
   });
 
+  it("keeps focus on a field the user selected when the show animation settles", async () => {
+    render(
+      html`<openclaw-modal-dialog label="Edit">
+        <input id="autofocus-target" autofocus />
+        <textarea id="notes-field"></textarea>
+      </openclaw-modal-dialog>`,
+      container,
+    );
+    const { webAwesomeDialog } = await getRenderedModalDialog(container);
+    const notes = container.querySelector<HTMLTextAreaElement>("#notes-field");
+    notes?.focus();
+
+    webAwesomeDialog.dispatchEvent(new Event("wa-after-show"));
+
+    expect(document.activeElement).toBe(notes);
+  });
+
   it("delegates native modality and light dismissal to Web Awesome", async () => {
     const { webAwesomeDialog, dialog } = await renderModal();
 

--- a/ui/src/components/modal-dialog.ts
+++ b/ui/src/components/modal-dialog.ts
@@ -173,6 +173,14 @@ export class OpenClawModalDialog extends OpenClawLitElement {
     if (!this.isConnected) {
       return;
     }
+    // Both the scheduled show hook and wa-after-show land here, and the second
+    // arrives after the open animation. If focus already moved to a slotted
+    // field (user click, autofill, e2e input), refocusing the autofocus target
+    // would steal it mid-typing; `this` means focus sits on dialog chrome.
+    const active = document.activeElement;
+    if (active instanceof HTMLElement && active !== this && this.contains(active)) {
+      return;
+    }
     const autofocusTarget = this.querySelector<HTMLElement>("[autofocus]");
     autofocusTarget?.focus({ preventScroll: true });
   };


### PR DESCRIPTION
## What Problem This Solves

The `checks-ui-e2e` lane flaked repeatedly on 2026-07-28 (runs 30351573136, 30358455220 attempts 1-4), each time failing exactly one of 104 files, a different test each attempt. Two distinct causes:

1. **Modal autofocus steal (product bug).** `workboard-status-persistence.e2e.test.ts` failed with the Notes text typed into the Title field (`title: "Persisted renamed cardEdited notes survive reopening."`, `notes: "Original notes"`). `workboard.e2e.test.ts` fills the same Edit-card dialog and has flaked identically on other runs.
2. **1-second `expect.poll` deadline.** Vitest's `expect.poll` defaults to a 1s timeout; the lane's ~70 polls await real Chromium renders. On loaded runners a route change or list update regularly stalls past 1s, producing rolling one-off failures (`external-session-catalogs`, `new-session-page.workspace-memory`, `session-management.archive`, `sidebar-customization` — all "Matcher did not succeed in time").

## Why This Change Was Made

**Modal fix:** `openclaw-modal-dialog` focused the slotted `[autofocus]` target twice — once from the scheduled `wa-show` hook and again on `wa-after-show`, which fires only after the open animation completes. If focus had already moved to another field inside the dialog (user click, autofill, or Playwright `fill`, which focuses + selects in page context and then delivers text through the browser input pipeline), the late refocus stole focus mid-fill and the text landed in the autofocus input at its caret — exactly the concatenation the CI diff shows. `handleAfterShow` now skips the refocus when `document.activeElement` is already a slotted descendant (excluding the host itself, which is what `activeElement` reports while native dialog chrome holds focus). Fixes every dialog consumer at the owner boundary instead of patching individual tests with waits.

**Poll budget:** the ui-e2e project config now sets `expect: { poll: { interval: 100, timeout: 15_000 } }`. Correctness in these tests is the eventual UI state, so a larger deadline only trades failure latency for stability — genuine regressions still fail, 14 seconds later. This mirrors Playwright's own auto-wait budgets (its locator waits in the same suite already use 10-30s).

## User Impact

Users who click or tab into another field while a dialog's open animation is still settling no longer lose focus (and keystrokes) back to the autofocus field. CI: closes the Workboard edit-dialog corruption flake and the rolling 1s-poll timeout flake class in `checks-ui-e2e`.

## Evidence

- Regression test "keeps focus on a field the user selected when the show animation settles" fails on the previous code (1 failed / 8 passed) and passes with the fix (9 passed).
- `node scripts/run-vitest.mjs ui/src/components/modal-dialog.test.ts` — 9 passed.
- `node scripts/run-vitest.mjs ui/src/pages/workboard/workboard-status-persistence.e2e.test.ts ui/src/pages/workboard/workboard.e2e.test.ts` — 5 passed (Chromium).
- CI-flaked poll tests pass locally: `external-session-catalogs.e2e.test.ts` (1 passed), `new-session-page.workspace-memory.e2e.test.ts` (7 passed).
- `node scripts/check-changed.mjs -- ui/src/components/modal-dialog.ts ui/src/components/modal-dialog.test.ts` — 0 warnings, 0 errors (delegated Testbox).
- Codex autoreview (`gpt-5.6-sol`, xhigh) on both changes: clean, no actionable findings (0.94 / 0.98).

Companion investigation: the second flake in the original report (`model-catalog-visibility.test.ts` 120s timeout in `agentic-agents-core-models`, run 30346551462 attempt 1 at 09:35 UTC) was already fixed by #115139 (merged 10:37 UTC the same day) — synthetic transport tests cold-loading the real OpenAI/Azure provider plugin pushed serial model-catalog tests over the 120s limit. No further change needed for that one.
