### PR TITLE
fix(mcp): keep resource-only servers available after unknown methods

### DIFF
--- a/src/agents/agent-bundle-mcp-runtime.test.ts
+++ b/src/agents/agent-bundle-mcp-runtime.test.ts
@@ -1728,15 +1728,35 @@ process.on("SIGINT", shutdown);`,
     }
   });
 
-  it("keeps resource-only MCP servers available for utility tools", async () => {
+  it.each([
+    {
+      name: "resource-only servers reporting method not found",
+      capabilities: { resources: { listChanged: true } },
+      listToolsMethodNotFound: true,
+      listToolsJsonRpcErrorMessage: undefined,
+    },
+    {
+      name: "resource-only servers reporting unknown method",
+      capabilities: { resources: { listChanged: true } },
+      listToolsMethodNotFound: false,
+      listToolsJsonRpcErrorMessage: "Unknown method",
+    },
+    {
+      name: "prompt-only servers reporting unknown method",
+      capabilities: { prompts: { listChanged: true } },
+      listToolsMethodNotFound: false,
+      listToolsJsonRpcErrorMessage: "Unknown method",
+    },
+  ])("keeps $name available for utility tools", async (testCase) => {
     const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "bundle-mcp-resource-only-"));
     const serverPath = path.join(tempDir, "resource-only.mjs");
     const logPath = path.join(tempDir, "server.log");
     await writeListToolsMcpServer({
       filePath: serverPath,
       logPath,
-      capabilities: { resources: { listChanged: true } },
-      listToolsMethodNotFound: true,
+      capabilities: testCase.capabilities,
+      listToolsMethodNotFound: testCase.listToolsMethodNotFound,
+      listToolsJsonRpcErrorMessage: testCase.listToolsJsonRpcErrorMessage,
     });
 
     const runtime = await getOrCreateSessionMcpRuntime({
@@ -1762,9 +1782,53 @@ process.on("SIGINT", shutdown);`,
       expect(catalog.servers.notes).toMatchObject({
         serverName: "notes",
         toolCount: 0,
-        resources: { listChanged: true },
+        ...testCase.capabilities,
       });
+      expect(catalog.diagnostics ?? []).toEqual([]);
       await waitForFileText(logPath, "recv initialize", LIST_TOOLS_SERVER_LOG_TIMEOUT_MS);
+    } finally {
+      await runtime.dispose();
+      await fs.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("does not suppress unknown tools/list methods from tools-capable MCP servers", async () => {
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "bundle-mcp-tools-unknown-method-"));
+    const serverPath = path.join(tempDir, "tools-unknown-method.mjs");
+    const logPath = path.join(tempDir, "server.log");
+    await writeListToolsMcpServer({
+      filePath: serverPath,
+      logPath,
+      capabilities: { tools: {}, resources: { listChanged: true } },
+      listToolsJsonRpcErrorMessage: "Unknown method",
+    });
+
+    const runtime = await getOrCreateSessionMcpRuntime({
+      sessionId: "session-tools-unknown-method",
+      sessionKey: "agent:test:session-tools-unknown-method",
+      workspaceDir: "/workspace",
+      cfg: {
+        mcp: {
+          servers: {
+            notes: {
+              command: process.execPath,
+              args: [serverPath],
+            },
+          },
+        },
+      },
+    });
+
+    try {
+      const catalog = await runtime.getCatalog();
+
+      expect(catalog.servers).toEqual({});
+      expect(catalog.tools).toEqual([]);
+      expect(catalog.diagnostics?.[0]).toMatchObject({
+        serverName: "notes",
+        message: expect.stringContaining("Unknown method"),
+      });
+      await waitForFileText(logPath, "recv tools/list", LIST_TOOLS_SERVER_LOG_TIMEOUT_MS);
     } finally {
       await runtime.dispose();
       await fs.rm(tempDir, { recursive: true, force: true });

--- a/src/agents/agent-bundle-mcp-runtime.ts
+++ b/src/agents/agent-bundle-mcp-runtime.ts
@@ -183,7 +183,7 @@ function isMcpMethodNotFoundError(error: unknown): boolean {
     return true;
   }
   const message = String(error);
-  return message.includes("-32601") || /method not found/i.test(message);
+  return message.includes("-32601") || /\b(?:method not found|unknown method)\b/i.test(message);
 }
 
 async function listAllToolsBestEffort(params: {


### PR DESCRIPTION
Closes #111940

## What Problem This Solves

Fixes an issue where users configuring resource-only or prompt-only MCP servers would lose access to the server when it reports unsupported tools/list requests as -32000 Unknown method.

## Why This Change Was Made

Recognize the common nonstandard Unknown method spelling only through the existing unsupported-method classifier. The current capability gate remains authoritative, so servers advertising tools still surface their tools/list failures instead of being silently accepted.

## User Impact

Resource-only and prompt-only MCP servers remain connected and available for utility tools when they do not implement optional tool discovery. Errors from tools-capable MCP servers continue to appear in catalog diagnostics.

## Evidence

- Reproduced both failures using real spawned stdio MCP servers: before the fix, 80 tests passed and the new resource-only and prompt-only cases failed; the tools-capable negative case passed.
- Remote Linux proof: `pnpm test src/agents/agent-bundle-mcp-runtime.test.ts` — all 82 tests passed after the fix.
- Remote Linux changed gate: `pnpm check:changed` — passed, including core and core-test type checks, formatting, lint, plugin boundaries, dependency pins, and database guards.
- Fresh structured `autoreview --mode uncommitted` — clean, no actionable findings.
- Verified the installed MCP SDK error behavior and upstream Codex MCP source before changing compatibility behavior.
- AI-assisted implementation and review.