### PR TITLE
fix: stabilize concurrent infer provider workflows

### DIFF
--- a/src/cli/capability-cli.test.ts
+++ b/src/cli/capability-cli.test.ts
@@ -108,7 +108,9 @@ const mocks = vi.hoisted(() => ({
     model: "gpt-4.1-mini",
   })),
   generateImage: vi.fn(),
+  listRuntimeImageGenerationProviders: vi.fn(() => []),
   generateVideo: vi.fn(),
+  listRuntimeVideoGenerationProviders: vi.fn(() => []),
   transcribeAudioFile: vi.fn(async () => ({ text: "meeting notes" })),
   textToSpeech: vi.fn(async () => ({
     success: true,
@@ -119,6 +121,8 @@ const mocks = vi.hoisted(() => ({
     attempts: [],
   })),
   setTtsProvider: vi.fn(),
+  getTtsProvider: vi.fn(() => "openai"),
+  listSpeechProviders: vi.fn(() => []),
   setTtsPersona: vi.fn(),
   resolveTtsConfig: vi.fn(() => ({})),
   resolveExplicitTtsOverrides: vi.fn(
@@ -370,17 +374,17 @@ vi.mock("../plugin-sdk/memory-core-bundled-runtime.js", () => ({
 
 vi.mock("../image-generation/runtime.js", () => ({
   generateImage: (...args: unknown[]) => mocks.generateImage(...args),
-  listRuntimeImageGenerationProviders: vi.fn(() => []),
+  listRuntimeImageGenerationProviders: mocks.listRuntimeImageGenerationProviders,
 }));
 
 vi.mock("../video-generation/runtime.js", () => ({
   generateVideo: mocks.generateVideo,
-  listRuntimeVideoGenerationProviders: vi.fn(() => []),
+  listRuntimeVideoGenerationProviders: mocks.listRuntimeVideoGenerationProviders,
 }));
 
 vi.mock("../tts/tts.js", () => ({
   getTtsPersona: vi.fn(() => undefined),
-  getTtsProvider: vi.fn(() => "openai"),
+  getTtsProvider: mocks.getTtsProvider,
   listTtsPersonas: vi.fn(() => []),
   listSpeechVoices: vi.fn(async () => []),
   resolveTtsConfig:
@@ -396,7 +400,7 @@ vi.mock("../tts/tts.js", () => ({
 
 vi.mock("../tts/provider-registry.js", () => ({
   canonicalizeSpeechProviderId: vi.fn((provider: string) => provider),
-  listSpeechProviders: vi.fn(() => []),
+  listSpeechProviders: mocks.listSpeechProviders,
   normalizeSpeechProviderId: vi.fn(
     (provider: string | undefined) => provider?.trim().toLowerCase() || undefined,
   ),
@@ -554,12 +558,20 @@ describe("capability cli", () => {
     mocks.describePreparedImageWithModel.mockClear();
     mocks.describeImageFileWithModel.mockClear();
     mocks.generateImage.mockReset();
+    mocks.listRuntimeImageGenerationProviders.mockReset().mockReturnValue([]);
     mocks.generateVideo.mockReset();
+    mocks.listRuntimeVideoGenerationProviders.mockReset().mockReturnValue([]);
     mocks.transcribeAudioFile.mockClear();
     mocks.textToSpeech.mockClear();
     mocks.setTtsProvider.mockClear();
+    mocks.getTtsProvider.mockReset().mockReturnValue("openai");
+    mocks.listSpeechProviders.mockReset().mockReturnValue([]);
     mocks.resolveExplicitTtsOverrides.mockClear();
-    mocks.getProviderEnvVars.mockClear();
+    mocks.getProviderEnvVars
+      .mockReset()
+      .mockImplementation((providerId: string) => [
+        `${providerId.toUpperCase().replaceAll("-", "_")}_API_KEY`,
+      ]);
     mocks.buildMediaUnderstandingRegistry.mockReset().mockReturnValue(new Map());
     mocks.inspectLocalAudioSelection.mockReset().mockResolvedValue({ candidates: [], entries: [] });
     mocks.convertHeicToJpeg.mockClear();
@@ -1108,6 +1120,30 @@ describe("capability cli", () => {
       expect(mocks.completeWithPreparedSimpleCompletionModel).not.toHaveBeenCalled();
       expect(mocks.callGateway).not.toHaveBeenCalled();
       expect(mocks.runtime.writeJson).not.toHaveBeenCalled();
+    },
+  );
+
+  it.each(["local", "gateway"] as const)(
+    "rejects malformed explicit model refs before %s dispatch",
+    async (transport) => {
+      await expect(
+        runCap(
+          "capability",
+          "model",
+          "run",
+          "--model",
+          "not-a-provider/",
+          "--prompt",
+          "hello",
+          ...(transport === "gateway" ? ["--gateway"] : []),
+          "--json",
+        ),
+      ).rejects.toThrow("exit 1");
+
+      expectRuntimeErrorContains("Model overrides must use the form <provider/model>.");
+      expect(mocks.prepareSimpleCompletionModelForAgent).not.toHaveBeenCalled();
+      expect(mocks.completeWithPreparedSimpleCompletionModel).not.toHaveBeenCalled();
+      expect(mocks.callGateway).not.toHaveBeenCalled();
     },
   );
 
@@ -3141,6 +3177,77 @@ describe("capability cli", () => {
         capabilities: ["audio"],
         defaultModels: { audio: "whisper-large-v3-turbo" },
       },
+    ]);
+  });
+
+  it("marks env-backed image providers as configured", async () => {
+    vi.stubEnv("FAL_KEY", "fal-test-key");
+    mocks.getProviderEnvVars.mockReturnValueOnce(["FAL_KEY"]);
+    mocks.listRuntimeImageGenerationProviders.mockReturnValueOnce([
+      { id: "fal", label: "fal", defaultModel: "fal-ai/flux", models: [] },
+    ] as never);
+
+    await runCap("capability", "image", "providers", "--json");
+
+    expect(firstJsonOutput()).toMatchObject([
+      { id: "fal", available: true, configured: true, selected: false },
+    ]);
+  });
+
+  it("marks env-backed video generation and description providers as configured", async () => {
+    vi.stubEnv("RUNWAYML_API_SECRET", "runway-test-key");
+    vi.stubEnv("GEMINI_API_KEY", "gemini-test-key");
+    mocks.getProviderEnvVars.mockImplementation((providerId: string) =>
+      providerId === "runway" ? ["RUNWAYML_API_SECRET"] : ["GEMINI_API_KEY"],
+    );
+    mocks.listRuntimeVideoGenerationProviders.mockReturnValueOnce([
+      { id: "runway", label: "Runway", defaultModel: "gen4", models: [] },
+    ] as never);
+    mocks.buildMediaUnderstandingRegistry.mockReturnValueOnce(
+      new Map([
+        [
+          "google",
+          {
+            id: "google",
+            capabilities: ["video"],
+            defaultModels: { video: "gemini-3-flash-preview" },
+          },
+        ],
+      ]),
+    );
+
+    await runCap("capability", "video", "providers", "--json");
+
+    expect(firstJsonOutput()).toMatchObject({
+      generation: [{ id: "runway", configured: true }],
+      description: [{ id: "google", configured: true }],
+    });
+  });
+
+  it("marks env-backed TTS providers as configured", async () => {
+    vi.stubEnv("XAI_API_KEY", "xai-test-key");
+    mocks.getProviderEnvVars.mockReturnValueOnce(["XAI_API_KEY"]);
+    mocks.listSpeechProviders.mockReturnValueOnce([
+      { id: "xai", label: "xAI", models: [], voices: [] },
+    ] as never);
+
+    await runCap("capability", "tts", "providers", "--local", "--json");
+
+    expect(firstJsonOutput()).toMatchObject({
+      providers: [{ id: "xai", configured: true, selected: false }],
+    });
+  });
+
+  it("marks env-backed embedding providers as configured", async () => {
+    vi.stubEnv("DEEPINFRA_API_KEY", "deepinfra-test-key");
+    mocks.listMemoryEmbeddingProviders.mockReturnValueOnce([
+      { id: "deepinfra", defaultModel: "BAAI/bge-m3", transport: "remote" },
+    ]);
+
+    await runCap("capability", "embedding", "providers", "--json");
+
+    expect(firstJsonOutput()).toMatchObject([
+      { id: "deepinfra", configured: true, selected: false },
     ]);
   });
 

--- a/src/cli/capability-cli/model.ts
+++ b/src/cli/capability-cli/model.ts
@@ -45,8 +45,8 @@ import {
   formatEnvelopeForText,
   providerHasGenericConfig,
   providerSummaryText,
+  requireProviderModelOverride,
   resolveLocalCapabilityRuntimeConfig,
-  resolveModelRefOverride,
   resolveSelectedProviderFromModelRef,
   resolveTransport,
 } from "./shared.js";
@@ -169,6 +169,7 @@ async function runModelRun(params: {
   thinking?: ThinkLevel;
   transport: CapabilityTransport;
 }) {
+  const explicitModelOverride = requireProviderModelOverride(params.model);
   const cfg =
     params.transport === "local"
       ? await resolveLocalCapabilityRuntimeConfig({
@@ -182,10 +183,7 @@ async function runModelRun(params: {
     cfg,
     preserveAuthProfile: params.transport === "local",
   });
-  const explicitModelOverride = resolveModelRefOverride(params.model);
-  const hasExplicitProviderModelOverride = Boolean(
-    params.model?.trim() && explicitModelOverride.provider && explicitModelOverride.model,
-  );
+  const hasExplicitProviderModelOverride = Boolean(explicitModelOverride);
   const imageFiles = await readModelRunImageFiles(params.files);
   const messageContent =
     imageFiles.length > 0
@@ -274,7 +272,7 @@ async function runModelRun(params: {
     } satisfies CapabilityEnvelope;
   }
 
-  const { provider, model } = resolveModelRefOverride(modelRef);
+  const { provider, model } = requireProviderModelOverride(modelRef) ?? {};
   // Provider/model overrides require trusted-operator scope. Use the backend
   // shared-secret lane so local gateway smokes do not depend on paired CLI device scopes.
   const hasModelOverride = Boolean(provider || model);

--- a/src/cli/capability-cli/shared.ts
+++ b/src/cli/capability-cli/shared.ts
@@ -14,6 +14,7 @@ import {
   parseStrictPositiveInteger,
 } from "../../infra/parse-finite-number.js";
 import { writeRuntimeJson, defaultRuntime, type RuntimeEnv } from "../../runtime.js";
+import { getProviderEnvVars } from "../../secrets/provider-env-vars.js";
 import { resolveCommandConfigWithSecrets } from "../command-config-resolution.js";
 import { parseTimeoutMsWithFallback } from "../parse-timeout.js";
 import type { CapabilityEnvelope, CapabilityTransport } from "./metadata.js";
@@ -114,9 +115,13 @@ export function providerHasGenericConfig(params: {
   const modelsProviders = (params.cfg.models?.providers ?? {}) as Record<string, unknown>;
   const pluginEntries = (params.cfg.plugins?.entries ?? {}) as Record<string, { config?: unknown }>;
   const ttsProviders = (params.cfg.tts?.providers ?? {}) as Record<string, unknown>;
-  const envConfigured = (params.envVars ?? []).some((envVar) =>
-    Boolean(process.env[envVar]?.trim()),
-  );
+  const envVars =
+    params.envVars ??
+    getProviderEnvVars(params.providerId, {
+      config: params.cfg,
+      includeUntrustedWorkspacePlugins: false,
+    });
+  const envConfigured = envVars.some((envVar) => Boolean(process.env[envVar]?.trim()));
   return (
     getAuthProfileIdsForProvider(params.cfg, params.providerId).length > 0 ||
     hasOwnKeys(modelsProviders[params.providerId]) ||

--- a/src/state/openclaw-state-db.test.ts
+++ b/src/state/openclaw-state-db.test.ts
@@ -3961,6 +3961,37 @@ INSERT INTO macos_port_guardian_records VALUES (4242, 18789, '/usr/bin/ssh', 're
     expect(journalMode?.journal_mode?.toLowerCase()).toBe("wal");
   });
 
+  it("configures the busy timeout before a doctor schema repair transaction", () => {
+    const stateDir = createTempStateDir();
+    const options = { env: { OPENCLAW_STATE_DIR: stateDir } };
+    openOpenClawStateDatabase(options);
+    closeOpenClawStateDatabaseForTest();
+    const { DatabaseSync } = requireNodeSqlite();
+    const originalExec = Object.getOwnPropertyDescriptor(DatabaseSync.prototype, "exec")?.value as
+      | ((this: import("node:sqlite").DatabaseSync, sql: string) => void)
+      | undefined;
+    if (!originalExec) {
+      throw new Error("DatabaseSync.exec descriptor is unavailable");
+    }
+    const statements: string[] = [];
+    vi.spyOn(DatabaseSync.prototype, "exec").mockImplementation(function (
+      this: import("node:sqlite").DatabaseSync,
+      sql: string,
+    ) {
+      statements.push(sql);
+      return originalExec.call(this, sql);
+    });
+
+    expect(repairOpenClawStateDatabaseSchema(options).warnings).toEqual([]);
+
+    const timeoutIndex = statements.findIndex((sql) =>
+      sql.includes(`PRAGMA busy_timeout = ${OPENCLAW_SQLITE_BUSY_TIMEOUT_MS}`),
+    );
+    const transactionIndex = statements.indexOf("BEGIN IMMEDIATE");
+    expect(timeoutIndex).toBeGreaterThanOrEqual(0);
+    expect(transactionIndex).toBeGreaterThan(timeoutIndex);
+  });
+
   it("uses rollback journaling for shared state databases on NFS-backed volumes", () => {
     const stateDir = createTempStateDir();
     const statfs = vi.spyOn(fs, "statfsSync").mockReturnValue(statfsFixture(0x6969));

--- a/src/state/openclaw-state-db.ts
+++ b/src/state/openclaw-state-db.ts
@@ -178,6 +178,7 @@ export function repairOpenClawStateDatabaseSchema(options: OpenClawStateDatabase
   const db = openNodeSqliteDatabase(pathname);
   const rebuiltIndexNames = new Set<string>();
   try {
+    db.exec(`PRAGMA busy_timeout = ${OPENCLAW_SQLITE_BUSY_TIMEOUT_MS};`);
     assertSupportedSchemaVersion(db, pathname);
     db.exec("PRAGMA foreign_keys = OFF;");
     const changes = runSqliteImmediateTransactionSync(


### PR DESCRIPTION
## What Problem This Solves

Fixes issues where `openclaw infer model run` could silently ignore a malformed explicit model ref and call the default provider, env-backed image/video/TTS/embedding providers appeared unconfigured, and repeated concurrent infer commands against one populated state directory emitted SQLite transaction lock warnings.

## Why This Change Was Made

Explicit model refs are now validated before either local or gateway dispatch. Generic provider status resolves canonical provider environment metadata while retaining the existing untrusted-workspace-plugin filter, and shared-state schema repair configures the established SQLite busy timeout on its connection before beginning the repair transaction.

## User Impact

Malformed explicit infer model selections fail before making a provider request, provider inventories accurately reflect available environment credentials across capability families, and concurrent infer inspection can share a populated state database without leaking avoidable lock-contention warnings.

## Evidence

- Before: `infer model run --model not-a-provider/ ...` succeeded through the default OpenAI route. After: it exits nonzero before transport dispatch.
- Before: four repeated seven-process warm-state provider waves emitted SQLite lock-wait failures across model, image, audio, TTS, video, web, and embedding inspection. After: three equivalent shared-state waves emitted zero lock warnings.
- Before: image and video reported no configured providers and local TTS reported only the active default despite 34 relevant credentials being present. After: the same built-product probe reported 9 configured image providers, 8 TTS providers, 14 video providers, and 2 embedding providers.
- Broad credential-backed stress: 115 commands covered cold and populated state, cancellation and immediate recovery, malformed/timeout recovery, and a 42-call mixed live pool. 32 live routes completed; remaining failures were provider auth/capacity or source-only/local-runtime availability, not process or JSON-envelope failures.
- Focused Blacksmith Testbox proof (`tbx_01kym88q5byr0d9z5n1g2ab0qd`): 105 state-database tests and 125 infer CLI tests passed.
- Blacksmith `pnpm check:changed` passed, including core/core-test typechecks, lint, formatting, schema-version and database-first guards, and import-cycle checks.
- Blacksmith full `pnpm build` passed.
- Final Codex autoreview (`gpt-5.6-sol`, xhigh): no accepted/actionable findings; patch correct with 0.86 confidence.

AI-assisted: implemented and stress-tested with Codex; maintainer reviewed the behavior, code paths, and proof above.
