### PR TITLE
fix(release): use harness cwd for package install

### DIFF
--- a/.github/workflows/openclaw-live-and-e2e-checks-reusable.yml
+++ b/.github/workflows/openclaw-live-and-e2e-checks-reusable.yml
@@ -2000,7 +2000,11 @@ jobs:
         if: steps.plan.outputs.needs_package == '1' && inputs.package_artifact_id != ''
         env:
           CI: "true"
-        run: pnpm --dir .release-harness install --frozen-lockfile --prefer-offline --ignore-scripts
+        # Corepack resolves packageManager from the process cwd before pnpm can
+        # process --dir. Keep this in the trusted harness so a frozen candidate
+        # pin cannot select a different pnpm binary for its harness install.
+        working-directory: .release-harness
+        run: pnpm install --frozen-lockfile --prefer-offline --ignore-scripts
 
       - name: Validate OpenClaw package artifact identity
         id: input_package_artifact

--- a/test/scripts/release-no-push-workflow.test.ts
+++ b/test/scripts/release-no-push-workflow.test.ts
@@ -676,7 +676,8 @@ describe("release validation no-push transport", () => {
     });
     expect(step(dockerProducer, "Install trusted package validation dependencies")).toMatchObject({
       if: "steps.plan.outputs.needs_package == '1' && inputs.package_artifact_id != ''",
-      run: "pnpm --dir .release-harness install --frozen-lockfile --prefer-offline --ignore-scripts",
+      "working-directory": ".release-harness",
+      run: "pnpm install --frozen-lockfile --prefer-offline --ignore-scripts",
     });
     expect(validatePackage.env).toMatchObject({
       EXPECTED_PACKAGE_FILE_NAME: "${{ inputs.package_file_name }}",


### PR DESCRIPTION
## What Problem This Solves

Fixes a release-validation failure where Docker package preparation for a frozen candidate aborts before any candidate code runs. The candidate pins pnpm 11.2 while the trusted release harness pins 11.15; launching `pnpm --dir .release-harness` from the candidate root makes Corepack select the candidate pin first.

Related: Full Release Validation run 30268409027.

## Why This Change Was Made

Run the trusted harness dependency install with `.release-harness` as the process working directory. Corepack then resolves the trusted harness manifest before pnpm receives its arguments. The focused workflow contract test asserts that working directory and command.

## User Impact

Extended-stable release validation can prepare its trusted Docker/package harness for older frozen candidates with a different pnpm pin, instead of failing before the intended release checks execute.

## Evidence

- Failing job: [Plugin Prerelease Docker preparation](https://github.com/openclaw/openclaw/actions/runs/30268944239/job/89987100360) selected candidate pnpm 11.2 and rejected the harness 11.15 requirement.
- Direct repro against the exact candidate and harness manifests: candidate-root invocation fails with pnpm 11.2; the same invocation from `.release-harness` reports pnpm 11.15.
- `git diff --check` passed.
- Fresh `autoreview --mode uncommitted` passed with no actionable findings.
- Hosted CI is required for the focused workflow test because this worktree has no dependencies and the local Testbox CLI is not authenticated.
