### PR TITLE
fix(ui): prevent order-dependent Workboard dashboard failures

### DIFF
--- a/ui/src/pages/chat/board-session-surface.test.ts
+++ b/ui/src/pages/chat/board-session-surface.test.ts
@@ -7,6 +7,7 @@ import type { BoardTab } from "../../lib/board/types.ts";
 import { renderBoardFaceToggle, renderBoardSessionSurface } from "./board-session-surface.ts";
 
 const containers: HTMLElement[] = [];
+let previousUrl = "/";
 
 function createContainer() {
   const container = document.createElement("div");
@@ -19,9 +20,12 @@ afterEach(() => {
   for (const container of containers.splice(0)) {
     container.remove();
   }
+  // UI files share jsdom; leaking mockBoard turns later gateway boards into mocks.
+  window.history.replaceState({}, "", previousUrl);
 });
 
 beforeEach(() => {
+  previousUrl = `${window.location.pathname}${window.location.search}${window.location.hash}`;
   window.history.replaceState({}, "", "/?mockBoard=1");
 });
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an intermittent Control UI test failure where running chat-board and Workboard dashboard tests together caused the dashboard to stop requesting `board.get`, never attach its real Gateway provider, and fail provider-disposal assertions. This surfaced during a fresh 280-file cron, Workboard, gateway, task, CLI, and Control UI stress campaign on `main`; isolated reruns incorrectly appeared healthy.

## Why This Change Was Made

The non-isolated UI Vitest project intentionally shares its jsdom environment. The chat-board surface test enabled `?mockBoard=1` before every test but never restored the original URL, so later Workboard dashboard tests sometimes silently selected a mock board provider instead of the requested real Gateway client. Save the original path, query, and hash and restore them in the test that changes them. Production board-provider behavior is unchanged.

## User Impact

No production behavior changes. Developers and CI get deterministic, order-independent Workboard and Gateway board coverage, avoiding false failures that can obscure real scheduling, dispatch, and dashboard regressions.

## Evidence

AI-assisted. Fresh `main` baseline: `20eda756fae6599bc9d776815016f555a64d77d6`.

Before: the eight-shard, 280-file mixed stress run failed in `ui/src/pages/workboard/workboard-card-dashboard.test.ts` because `board.get` was called zero times and the real provider lease was never acquired. The same six UI files passed independently, demonstrating the file-order-dependent shared-state leak.

After, on the same isolated Blacksmith Testbox:

- The original mixed campaign passed all **280 test files across 8 shards**: `CHAOS_FIXED_ALL_8_SHARDS_PASSED FILES 280`.
- Six deliberately shuffled runs each passed all **6 files / 70 tests**: `WORKBOARD_MOCK_ISOLATION_ALL_6_SHUFFLED_PASSES_OK`.
- Real system Chromium passed **12 browser files / 61 tests**, including Workboard create/edit/move/reload, routing and persistence, dispatched-session/dashboard links, board widgets, Gateway reconnects, and cron filters: `Test Files 12 passed (12); Tests 61 passed (61)`.
- Six real isolated-Gateway scheduling scenarios passed with a `mock-openai` provider; the generated QA summary was independently verified: `QA_ARTIFACT_SUMMARY {"total":6,"passed":6,"failed":0,"skipped":0,"missing":[]}`.
- Remote `pnpm check:changed -- ui/src/pages/chat/board-session-surface.test.ts` passed, including conflict guards, formatting, dependency guards, UI i18n validation, TypeScript, and lint: `QA_ARTIFACT_AND_CHANGED_GATE_PASSED`.
- Independent `.agents/skills/autoreview/scripts/autoreview --mode uncommitted`: `autoreview clean: no accepted/actionable findings reported`.

ClawSweeper's review reported sufficient behavior proof but could not complete its own source read because its sandbox returned `bwrap: loopback: Failed RTM_NEWADDR: Operation not permitted`. Its requested source/history rank-up check has been completed independently against the real maintained checkout and exact PR head: `ui/AGENTS.md`, `test/vitest/vitest.ui.config.ts` (`isolate: false`), the changing hooks in `ui/src/pages/chat/board-session-surface.test.ts`, the downstream assertions in `ui/src/pages/workboard/workboard-card-dashboard.test.ts`, the production consumer in `ui/src/pages/workboard/workboard-card-dashboard.ts`, and the mock-selection and lease ownership in `ui/src/lib/board/provider.ts`. `git blame -L 13,30 -- ui/src/pages/chat/board-session-surface.test.ts` confirms the existing history and original `mockBoard` mutation (`06480d767cef`). Native `scripts/pr review-checkout-main`, `review-checkout-pr`, and `review-validate-artifacts` independently verified the current-main baseline and exact head; the validated recommendation is `READY FOR /prepare-pr`, with zero findings. No source or history inspection is outstanding.

The owned Testbox was stopped after proof. No browser recordings, QA artifacts, production files, configuration, or unrelated changes are included in the PR.
