### PR TITLE
fix(openai): preserve failed Responses terminal usage

### DIFF
--- a/packages/ai/src/providers/openai-responses-shared.test.ts
+++ b/packages/ai/src/providers/openai-responses-shared.test.ts
@@ -1611,8 +1611,25 @@ describe("processResponsesStream", () => {
     expect(lifecycleOutput.errorMessage).toBe("Provider incomplete_reason: content_filter");
   });
 
-  it("preserves failed terminal response details", async () => {
+  it("preserves failed terminal response details and accounting", async () => {
+    const model = {
+      ...nativeOpenAIModel,
+      cost: { input: 5, output: 30, cacheRead: 0.5, cacheWrite: 6.25 },
+    } satisfies Model<"openai-responses">;
     const output = createAssistantOutput();
+    const resolveServiceTier = vi.fn(
+      (
+        responseTier: ResponseCreateParamsStreaming["service_tier"],
+        requestTier: ResponseCreateParamsStreaming["service_tier"],
+      ) => responseTier ?? requestTier,
+    );
+    const applyServiceTierPricing = vi.fn(
+      (usage: AssistantMessage["usage"], tier: ResponseCreateParamsStreaming["service_tier"]) => {
+        if (tier === "priority") {
+          usage.cost.total *= 2;
+        }
+      },
+    );
 
     await expect(
       processResponsesStream(
@@ -1622,20 +1639,46 @@ describe("processResponsesStream", () => {
             response: {
               id: "resp_failed",
               status: "failed",
+              model: "gpt-5.6-luna",
+              service_tier: "priority",
               error: { code: "server_error", message: "provider failed" },
+              usage: {
+                input_tokens: 21,
+                output_tokens: 4,
+                total_tokens: 25,
+                input_tokens_details: { cached_tokens: 6, cache_write_tokens: 2 },
+                output_tokens_details: { reasoning_tokens: 3 },
+              },
             },
           },
         ]),
         output,
         new AssistantMessageEventStream(),
-        nativeOpenAIModel,
+        model,
+        { serviceTier: "default", resolveServiceTier, applyServiceTierPricing },
       ),
     ).rejects.toThrow("server_error: provider failed");
 
     expect(output).toMatchObject({
       responseId: "resp_failed",
+      responseModel: "gpt-5.6-luna",
       stopReason: "stop",
+      usage: {
+        input: 13,
+        output: 4,
+        cacheRead: 6,
+        cacheWrite: 2,
+        reasoningTokens: 3,
+        totalTokens: 25,
+      },
     });
+    expect(output.usage.cost.input).toBeCloseTo(0.000065, 10);
+    expect(output.usage.cost.output).toBeCloseTo(0.00012, 10);
+    expect(output.usage.cost.cacheRead).toBeCloseTo(0.000003, 10);
+    expect(output.usage.cost.cacheWrite).toBeCloseTo(0.0000125, 10);
+    expect(output.usage.cost.total).toBeCloseTo(0.000401, 10);
+    expect(resolveServiceTier).toHaveBeenCalledWith("priority", "default");
+    expect(applyServiceTierPricing).toHaveBeenCalledWith(output.usage, "priority");
   });
 
   it("rejects streams that end without a terminal response event", async () => {

--- a/packages/ai/src/providers/openai-responses-terminal-usage.ts
+++ b/packages/ai/src/providers/openai-responses-terminal-usage.ts
@@ -1,10 +1,10 @@
 /**
  * Canonical mapping for terminal OpenAI Responses events.
  *
- * `response.completed` and `response.incomplete` are both terminal and both carry usage, so every
- * Responses path — the package-side stream processor and the agent-side transport — finalizes
- * through the helpers here. Keeping one owner prevents the two from drifting on token buckets,
- * service-tier pricing, or future terminal-event semantics.
+ * `response.completed`, `response.incomplete`, and `response.failed` are terminal and can carry
+ * usage, so every Responses path finalizes through the helpers here. Keeping one owner prevents
+ * package and managed transports from drifting on token buckets, service-tier pricing, or future
+ * terminal-event semantics.
  */
 import type OpenAI from "openai";
 import type { StopReason, Usage } from "../types.js";

--- a/packages/ai/src/transports/openai-responses-stream-internal.ts
+++ b/packages/ai/src/transports/openai-responses-stream-internal.ts
@@ -134,7 +134,7 @@ export async function processResponsesStream<TApi extends Api>(
   const reasoningBlocksById = new Map<string, ResponsesThinkingBlock>();
   const outputItemContentIndexes = createResponsesOutputContentIndex();
   const startedTextBlocksByItemId = new Map<string, TextBlockReference>();
-  let terminalResponseEvent: "finalized" | "failed" | undefined;
+  let terminalResponseEvent: "finalized" | undefined;
   let lastTextBlock: TextBlockReference | null = null;
   const blocks = output.content;
   const compactionTracker = createCompactionTracker(output, model, options);
@@ -255,22 +255,23 @@ export async function processResponsesStream<TApi extends Api>(
       }
     }
   };
-  const { finalizeResponse, recoverTerminalOutput } = createResponsesTerminalController({
-    output,
-    stream,
-    model,
-    options,
-    reasoningBlocksById,
-    startedTextBlocksByItemId,
-    outputItemContentIndexes,
-    getLastTextBlock: () => lastTextBlock,
-    setLastTextBlock: (block) => {
-      lastTextBlock = block;
-    },
-    markFinalized: () => {
-      terminalResponseEvent = "finalized";
-    },
-  });
+  const { finalizeResponse, finalizeFailedResponse, recoverTerminalOutput } =
+    createResponsesTerminalController({
+      output,
+      stream,
+      model,
+      options,
+      reasoningBlocksById,
+      startedTextBlocksByItemId,
+      outputItemContentIndexes,
+      getLastTextBlock: () => lastTextBlock,
+      setLastTextBlock: (block) => {
+        lastTextBlock = block;
+      },
+      markFinalized: () => {
+        terminalResponseEvent = "finalized";
+      },
+    });
 
   const guardedStream = adaptResponsesStream(
     withFirstStreamEventTimeout(openaiStream, {
@@ -708,9 +709,7 @@ export async function processResponsesStream<TApi extends Api>(
           event as unknown as Record<string, unknown>,
           model,
         );
-        if (failure.responseId) {
-          output.responseId = failure.responseId;
-        }
+        finalizeFailedResponse(event.response, failure.responseId);
         throw new ResponsesStreamFailure(failure, event.response);
       }
     }

--- a/packages/ai/src/transports/openai-responses-stream-terminal-internal.ts
+++ b/packages/ai/src/transports/openai-responses-stream-terminal-internal.ts
@@ -298,16 +298,14 @@ export function createResponsesTerminalController(params: {
       }
     }
   };
-  const finalizeResponse = (
+  const finalizeTerminalFacts = (
     response: Extract<
       ResponseStreamEvent,
-      { type: "response.completed" | "response.incomplete" }
+      { type: "response.completed" | "response.incomplete" | "response.failed" }
     >["response"],
-    terminalEventType: "response.completed" | "response.incomplete",
+    responseId = response.id,
   ) => {
-    params.markFinalized();
-    backfillReasoning(response.output ?? []);
-    output.responseId = response.id || output.responseId;
+    output.responseId = responseId || output.responseId;
     output.responseModel = response.model?.trim() || undefined;
     const usage = mapResponsesTerminalUsage(response.usage);
     const reasoningTokens = readResponsesReasoningTokens(response.usage);
@@ -325,6 +323,17 @@ export function createResponsesTerminalController(params: {
         : (response.service_tier ?? options.serviceTier);
       options.applyServiceTierPricing(output.usage, tier);
     }
+  };
+  const finalizeResponse = (
+    response: Extract<
+      ResponseStreamEvent,
+      { type: "response.completed" | "response.incomplete" }
+    >["response"],
+    terminalEventType: "response.completed" | "response.incomplete",
+  ) => {
+    params.markFinalized();
+    backfillReasoning(response.output ?? []);
+    finalizeTerminalFacts(response);
     const terminal = resolveResponsesTerminalStopReason({
       status: response.status,
       terminalEventType,
@@ -334,5 +343,5 @@ export function createResponsesTerminalController(params: {
     output.stopReason = terminal.stopReason;
     output.errorMessage = terminal.errorMessage;
   };
-  return { finalizeResponse, recoverTerminalOutput };
+  return { finalizeResponse, finalizeFailedResponse: finalizeTerminalFacts, recoverTerminalOutput };
 }

--- a/src/agents/openai-transport-stream.failed-sse.test.ts
+++ b/src/agents/openai-transport-stream.failed-sse.test.ts
@@ -1,0 +1,149 @@
+import { createServer, type Server } from "node:http";
+import {
+  createAzureOpenAIResponsesTransportStreamFn,
+  createOpenAIResponsesTransportStreamFn,
+} from "@openclaw/ai/transports";
+import type { Model } from "openclaw/plugin-sdk/llm";
+import { describe, expect, it } from "vitest";
+
+const responsesTransports = [
+  {
+    api: "openai-responses" as const,
+    provider: "openai",
+    createStream: createOpenAIResponsesTransportStreamFn,
+  },
+  {
+    api: "azure-openai-responses" as const,
+    provider: "azure-openai",
+    createStream: createAzureOpenAIResponsesTransportStreamFn,
+  },
+] as const;
+
+async function createResponsesSseServer(event: Record<string, unknown>): Promise<{
+  server: Server;
+  baseUrl: string;
+  requestPaths: string[];
+}> {
+  const requestPaths: string[] = [];
+  const server = createServer((request, response) => {
+    requestPaths.push(request.url ?? "");
+    request.resume();
+    request.on("end", () => {
+      response.writeHead(200, {
+        "content-type": "text/event-stream; charset=utf-8",
+        "cache-control": "no-cache",
+        connection: "keep-alive",
+      });
+      response.write(`event: ${String(event.type)}\ndata: ${JSON.stringify(event)}\n\n`);
+      response.end();
+    });
+  });
+
+  await new Promise<void>((resolve, reject) => {
+    const onError = (error: Error) => reject(error);
+    server.once("error", onError);
+    server.listen(0, "127.0.0.1", () => {
+      server.off("error", onError);
+      resolve();
+    });
+  });
+  const address = server.address();
+  if (!address || typeof address === "string") {
+    server.close();
+    throw new Error("Missing Responses loopback server address");
+  }
+  return { server, baseUrl: `http://127.0.0.1:${address.port}/v1`, requestPaths };
+}
+
+async function closeResponsesSseServer(server: Server): Promise<void> {
+  server.closeAllConnections();
+  await new Promise<void>((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+}
+
+describe("failed Responses loopback SSE", () => {
+  it.each(responsesTransports)(
+    "preserves failed $api terminal facts over the real SDK stream",
+    async (transport) => {
+      const { server, baseUrl, requestPaths } = await createResponsesSseServer({
+        type: "response.failed",
+        sequence_number: 0,
+        response: {
+          id: "resp-failed-usage-sse",
+          model: "gpt-5.6-luna",
+          status: "failed",
+          error: { code: "server_error", message: "provider failed after consuming tokens" },
+          output: [],
+          usage: {
+            input_tokens: 21,
+            output_tokens: 4,
+            total_tokens: 25,
+            input_tokens_details: { cached_tokens: 6, cache_write_tokens: 2 },
+            output_tokens_details: { reasoning_tokens: 3 },
+          },
+        },
+      });
+
+      try {
+        const model = {
+          id: "gpt-5.6-luna",
+          name: "GPT-5.6 Luna",
+          api: transport.api,
+          provider: transport.provider,
+          baseUrl,
+          reasoning: true,
+          input: ["text"],
+          cost: { input: 5, output: 30, cacheRead: 0.5, cacheWrite: 6.25 },
+          contextWindow: 128_000,
+          maxTokens: 4_096,
+        } satisfies Model;
+
+        const stream = await transport.createStream()(
+          model,
+          {
+            messages: [{ role: "user", content: "Report failed usage", timestamp: 0 }],
+            tools: [],
+          },
+          { apiKey: "test-key", maxRetries: 0 },
+        );
+        const events = [];
+        for await (const event of stream) {
+          events.push(event);
+        }
+
+        expect(requestPaths).toHaveLength(1);
+        expect(requestPaths[0]).toMatch(/^\/v1\/responses(?:\?|$)/);
+        expect(events.map((event) => event.type)).toEqual(["start", "error"]);
+        const terminal = events.at(-1);
+        expect(terminal).toMatchObject({
+          type: "error",
+          reason: "error",
+          error: {
+            responseId: "resp-failed-usage-sse",
+            responseModel: "gpt-5.6-luna",
+            stopReason: "error",
+            errorMessage: "server_error: provider failed after consuming tokens",
+            usage: {
+              input: 13,
+              output: 4,
+              cacheRead: 6,
+              cacheWrite: 2,
+              reasoningTokens: 3,
+              totalTokens: 25,
+            },
+          },
+        });
+        if (terminal?.type === "error") {
+          expect(terminal.error.usage.cost.input).toBeCloseTo(0.000065, 10);
+          expect(terminal.error.usage.cost.output).toBeCloseTo(0.00012, 10);
+          expect(terminal.error.usage.cost.cacheRead).toBeCloseTo(0.000003, 10);
+          expect(terminal.error.usage.cost.cacheWrite).toBeCloseTo(0.0000125, 10);
+          expect(terminal.error.usage.cost.total).toBeCloseTo(0.0002005, 10);
+        }
+      } finally {
+        await closeResponsesSseServer(server);
+      }
+    },
+  );
+});

--- a/src/scripts/test-projects.test.ts
+++ b/src/scripts/test-projects.test.ts
@@ -340,6 +340,7 @@ describe("test-projects args", () => {
         includePatterns: [
           "src/agents/openai-transport-stream.base.test.ts",
           "src/agents/openai-transport-stream.deepseek-and-shaping.test.ts",
+          "src/agents/openai-transport-stream.failed-sse.test.ts",
           "src/agents/openai-transport-stream.incomplete-output.test.ts",
           "src/agents/openai-transport-stream.incomplete-sse.test.ts",
           "src/agents/openai-transport-stream.inline-reasoning-and-tool-calls.test.ts",


### PR DESCRIPTION
Closes #114201
Related: #114204

## What Problem This Solves

Failed OpenAI and Azure OpenAI Responses turns discarded the provider's final token usage, cache, reasoning, model, and pricing facts. The authoritative `response.failed` snapshot was thrown before shared terminal accounting ran, so error events incorrectly reported zero usage after tokens had been consumed.

## Why This Change Was Made

The shared Responses terminal controller now records authoritative terminal facts for completed, incomplete, and failed responses through one canonical path. Failed responses retain the existing error lifecycle: they are never marked complete, never recover terminal output, and never emit a success event. The cancellation ordering from #113801 is unchanged.

This rewrite preserves current output identity/order validation, response-model capture, compaction behavior, and cancellation ordering. Production delta is +39/-31; the net eight lines establish the single owner boundary for failed terminal facts. No config, environment, public/plugin API, protocol, dependency, persistence, retry, or compatibility surface changes.

## User Impact

Failed shared Responses-stream turns retain their real input, output, cache-read, cache-write, reasoning-token, response-model, total-token, cost, and service-tier pricing data while still surfacing exactly once as provider errors.

## Evidence

The pinned `openai@6.49.0` source defines `ResponseFailedEvent.response` as the full `Response`, whose usage includes input, output, total, cache-read, cache-write, and reasoning fields.

Fail-before regression:

```text
$ node scripts/run-vitest.mjs packages/ai/src/providers/openai-responses-shared.test.ts
Test Files  1 failed (1)
Tests       1 failed | 81 passed (82)
Expected   input/output/cacheRead/cacheWrite/total = 13/4/6/2/25
Received   input/output/cacheRead/cacheWrite/total = 0/0/0/0/0
```

Pass-after owner and real-SDK transport proof:

```text
$ node scripts/run-vitest.mjs packages/ai/src/providers/openai-responses-shared.test.ts packages/ai/src/transports/openai-responses-stream-terminal-recovery.test.ts packages/ai/src/transports/openai-responses-stream-parity.test.ts packages/ai/src/providers/openai-chatgpt-responses-streaming.test.ts src/agents/openai-transport-stream.failed-sse.test.ts src/agents/openai-transport-stream.incomplete-sse.test.ts
Test Files  4 passed (4) + 2 passed (2)
Tests       145 passed + 4 passed = 149 passed
```

The loopback regression sends genuine SSE through the pinned OpenAI SDK for OpenAI and Azure factories. Each produces `start,error` with no `done`, preserves provider error/response identity, and records input=13, output=4, cacheRead=6, cacheWrite=2, reasoning=3, total=25 with priced cost.

The first rebased exact-head CI run correctly exposed one branch-caused tooling assertion: adding `openai-transport-stream.failed-sse.test.ts` expanded the filename-prefix sibling set, but `src/scripts/test-projects.test.ts` expected the old list. The assertion now explicitly includes the regression. Two unchanged local attempts timed out in that file's unrelated 120s `beforeAll` filesystem warmup before running any of 85 tests; no timeout was raised. Exact-head CI is required to prove the corrected assertion in the environment where it originally reached the failure.

```text
$ node scripts/check-changed.mjs
[check:changed] lanes=core, coreTests
typecheck core/core tests PASS
oxfmt PASS; oxlint 0 warnings, 0 errors
dead export scans 0 entries; runtime import cycles 0
Blacksmith Testbox tbx_01kzknhx470sm5d7nvnxkc1883
Actions run 31323797637
exitCode 0

$ .agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main --stream-engine-output
autoreview clean: no accepted/actionable findings reported
overall: patch is correct (0.98)

$ .agents/skills/autoreview/scripts/autoreview --mode local --stream-engine-output
autoreview clean: no accepted/actionable findings reported
overall: patch is correct (0.99)
```

ClawSweeper rank-up moves were applied: the fix preserves terminal-output safeguards, and canonical-controller plus OpenAI/Azure real-SDK loopback regressions were rerun against the current dependency graph.

AI-assisted; implementation, dependency source, fail-before proof, callers/siblings, focused tests, changed gates, and independent review were verified.
