### PR TITLE
fix(exec): prevent cancelled node commands from running

### DIFF
--- a/src/agents/bash-tools.exec-host-node-phases.cancellation.test.ts
+++ b/src/agents/bash-tools.exec-host-node-phases.cancellation.test.ts
@@ -1,0 +1,77 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const callGatewayTool = vi.hoisted(() =>
+  vi.fn(async () => ({
+    payload: { success: true, stdout: "ok", stderr: "", exitCode: 0 },
+  })),
+);
+
+vi.mock("./tools/gateway.js", () => ({ callGatewayTool }));
+
+import { invokeNodeSystemRunDirect } from "./bash-tools.exec-host-node-phases.js";
+
+type DirectNodeRun = Parameters<typeof invokeNodeSystemRunDirect>[0];
+
+function createDirectNodeRun(signal?: AbortSignal): DirectNodeRun {
+  return {
+    request: {
+      command: "tool --version",
+      workdir: "/tmp/work",
+      env: {},
+      security: "full",
+      ask: "off",
+      defaultTimeoutSec: 30,
+      approvalRunningNoticeMs: 0,
+      warnings: [],
+      ...(signal ? { signal } : {}),
+    },
+    target: {
+      nodeId: "node-1",
+      argv: ["tool", "--version"],
+      env: undefined,
+      invokeTimeoutMs: 30_000,
+      runTimeoutSec: 30,
+      supportsSystemRunPrepare: true,
+    },
+  };
+}
+
+describe("direct node run cancellation", () => {
+  beforeEach(() => {
+    callGatewayTool.mockClear();
+  });
+
+  it("forwards the original cancellation signal to the gateway", async () => {
+    const controller = new AbortController();
+
+    await invokeNodeSystemRunDirect(createDirectNodeRun(controller.signal));
+
+    expect(callGatewayTool).toHaveBeenCalledWith(
+      "node.invoke",
+      { timeoutMs: 30_000 },
+      expect.objectContaining({ command: "system.run" }),
+      { signal: controller.signal },
+    );
+  });
+
+  it("preserves the original gateway call when no signal is supplied", async () => {
+    await invokeNodeSystemRunDirect(createDirectNodeRun());
+
+    expect(callGatewayTool).toHaveBeenCalledWith(
+      "node.invoke",
+      { timeoutMs: 30_000 },
+      expect.objectContaining({ command: "system.run" }),
+    );
+  });
+
+  it("never dispatches a direct node run after cancellation", async () => {
+    const controller = new AbortController();
+    const reason = new Error("cancelled before direct node dispatch");
+    controller.abort(reason);
+
+    await expect(invokeNodeSystemRunDirect(createDirectNodeRun(controller.signal))).rejects.toBe(
+      reason,
+    );
+    expect(callGatewayTool).not.toHaveBeenCalled();
+  });
+});

--- a/src/agents/bash-tools.exec-host-node-phases.ts
+++ b/src/agents/bash-tools.exec-host-node-phases.ts
@@ -397,19 +397,21 @@ export async function invokeNodeSystemRunDirect(params: {
   target: NodeExecutionTarget;
 }): Promise<AgentToolResult<ExecToolDetails>> {
   const startedAt = Date.now();
-  const raw = await callGatewayTool(
-    "node.invoke",
-    { timeoutMs: params.target.invokeTimeoutMs },
-    buildNodeSystemRunInvoke({
-      target: params.target,
-      command: params.target.argv,
-      rawCommand: params.request.command,
-      cwd: params.request.workdir,
-      agentId: params.request.agentId,
-      sessionKey: params.request.sessionKey,
-      notifyOnExit: params.request.notifyOnExit,
-    }),
-  );
+  const invoke = buildNodeSystemRunInvoke({
+    target: params.target,
+    command: params.target.argv,
+    rawCommand: params.request.command,
+    cwd: params.request.workdir,
+    agentId: params.request.agentId,
+    sessionKey: params.request.sessionKey,
+    notifyOnExit: params.request.notifyOnExit,
+  });
+  params.request.signal?.throwIfAborted();
+  const raw = params.request.signal
+    ? await callGatewayTool("node.invoke", { timeoutMs: params.target.invokeTimeoutMs }, invoke, {
+        signal: params.request.signal,
+      })
+    : await callGatewayTool("node.invoke", { timeoutMs: params.target.invokeTimeoutMs }, invoke);
   return formatNodeRunToolResult({
     raw,
     startedAt,

--- a/src/agents/bash-tools.exec-host-node.cancellation.test.ts
+++ b/src/agents/bash-tools.exec-host-node.cancellation.test.ts
@@ -1,0 +1,249 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ExecAsk, ExecSecurity } from "../infra/exec-approvals.js";
+import type { ExecAutoReviewer } from "../infra/exec-auto-review.js";
+import { createDeferred } from "../test-utils/deferred.js";
+import type { ExecuteNodeHostCommandParams } from "./bash-tools.exec-host-node.types.js";
+
+type NodeApprovalPolicy = Awaited<
+  ReturnType<typeof import("./bash-tools.exec-host-shared.js").resolveExecHostApprovalContext>
+>;
+
+const mocks = vi.hoisted(() => ({
+  analyzeNodeApprovalRequirement: vi.fn(),
+  callGatewayTool: vi.fn(
+    async (
+      _method: string,
+      _options: unknown,
+      _params?: { command?: string },
+      _extra?: { scopes?: string[]; signal?: AbortSignal },
+    ) => ({ payload: { success: true, stdout: "ok", exitCode: 0 } }),
+  ),
+  invokeNodeSystemRunDirect: vi.fn(),
+  registerNodeApproval: vi.fn(async () => undefined),
+  requiresExecApproval: vi.fn(),
+  resolveExecHostApprovalContext: vi.fn(),
+}));
+
+vi.mock("../infra/exec-approvals.js", () => ({
+  maxAsk: (left: ExecAsk, right: ExecAsk) => {
+    const priority: Record<ExecAsk, number> = { off: 0, "on-miss": 1, always: 2 };
+    return priority[left] >= priority[right] ? left : right;
+  },
+  requiresExecApproval: mocks.requiresExecApproval,
+  resolveExecApprovalAllowedDecisions: vi.fn(() => ["allow-once", "allow-always", "deny"]),
+  resolveExecApprovalUnavailableDecisions: vi.fn(() => []),
+}));
+
+vi.mock("../infra/exec-auto-review.js", () => ({
+  defaultExecAutoReviewer: vi.fn(),
+  resolveExecAutoReviewDecision: vi.fn(async (reviewer: ExecAutoReviewer, input) =>
+    reviewer(input),
+  ),
+}));
+
+vi.mock("./bash-tools.exec-approval-request.js", () => ({
+  buildExecApprovalRequesterContext: vi.fn(() => ({})),
+  buildExecApprovalTurnSourceContext: vi.fn(() => ({})),
+  registerExecApprovalRequestForHostOrThrow: mocks.registerNodeApproval,
+}));
+
+vi.mock("./bash-tools.exec-host-node-phases.js", () => ({
+  analyzeNodeApprovalRequirement: mocks.analyzeNodeApprovalRequirement,
+  buildNodeSystemRunInvoke: vi.fn(() => ({ command: "system.run" })),
+  formatNodeRunToolResult: vi.fn(() => ({
+    content: [],
+    details: { status: "completed" },
+  })),
+  invokeNodeSystemRunDirect: mocks.invokeNodeSystemRunDirect,
+  prepareNodeSystemRun: vi.fn(async () => ({
+    plan: {},
+    argv: ["tool", "--version"],
+    rawCommand: "tool --version",
+    transportRawCommand: "tool --version",
+    cwd: "/tmp/work",
+    agentId: "agent",
+    sessionKey: "agent:main:main",
+  })),
+  resolveNodeExecutionTarget: vi.fn(async () => ({
+    nodeId: "node-1",
+    argv: ["tool", "--version"],
+    invokeTimeoutMs: 30_000,
+    supportsSystemRunPrepare: true,
+  })),
+  shouldSkipNodeApprovalPrepare: vi.fn(
+    (policy: { hostSecurity: ExecSecurity; hostAsk: ExecAsk }) =>
+      policy.hostSecurity === "full" && policy.hostAsk === "off",
+  ),
+}));
+
+vi.mock("./bash-tools.exec-host-shared.js", () => ({
+  resolveExecHostApprovalContext: mocks.resolveExecHostApprovalContext,
+}));
+
+vi.mock("./bash-process-registry.js", () => ({ tail: vi.fn((text: string) => text) }));
+
+vi.mock("./bash-tools.exec-runtime.js", () => ({
+  DEFAULT_NOTIFY_TAIL_CHARS: 1_000,
+  createApprovalSlug: vi.fn(() => "approval"),
+  normalizeNotifyOutput: vi.fn((text: string) => text),
+}));
+
+vi.mock("./embedded-agent-runner/run/abortable.js", () => ({
+  abortable: vi.fn(async (_signal: AbortSignal, pending: Promise<unknown>) => pending),
+}));
+
+vi.mock("./tools/gateway.js", () => ({ callGatewayTool: mocks.callGatewayTool }));
+
+import { executeNodeHostCommand } from "./bash-tools.exec-host-node.js";
+
+function createPolicy(security: ExecSecurity, ask: ExecAsk): NodeApprovalPolicy {
+  return {
+    approvals: {
+      path: "",
+      socketPath: "",
+      token: "",
+      defaults: { security, ask, askFallback: "deny", autoAllowSkills: false },
+      agent: { security, ask, askFallback: "deny", autoAllowSkills: false },
+      agentSources: { security: null, ask: null, askFallback: null },
+      allowlist: [],
+      file: { version: 1, agents: {} },
+    },
+    hostSecurity: security,
+    hostAsk: ask,
+    askFallback: "deny",
+  };
+}
+
+function createRequest(overrides: Partial<ExecuteNodeHostCommandParams>) {
+  return {
+    command: "tool --version",
+    workdir: "/tmp/work",
+    env: {},
+    security: "full",
+    ask: "off",
+    defaultTimeoutSec: 30,
+    approvalRunningNoticeMs: 0,
+    warnings: [],
+    agentId: "agent",
+    sessionKey: "agent:main:main",
+    ...overrides,
+  } satisfies ExecuteNodeHostCommandParams;
+}
+
+describe("node-host dispatch cancellation", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.resolveExecHostApprovalContext.mockReset();
+    mocks.requiresExecApproval.mockImplementation(({ ask }: { ask: ExecAsk }) => ask !== "off");
+    mocks.analyzeNodeApprovalRequirement.mockResolvedValue({
+      analysisOk: true,
+      allowlistSatisfied: false,
+      durableApprovalSatisfied: false,
+      nodeApprovalPolicyKnown: true,
+      nodeSecurity: "allowlist",
+      nodeAsk: "on-miss",
+      inlineEvalHit: null,
+      requiresSecurityAuditSuppressionApproval: false,
+      autoReviewArgv: ["tool", "--version"],
+      allowAlwaysPersistence: { kind: "patterns", patterns: [] },
+    });
+    mocks.invokeNodeSystemRunDirect.mockResolvedValue({
+      content: [],
+      details: { status: "completed" },
+    });
+  });
+
+  it.each([
+    { name: "direct full/off", security: "full", ask: "off", autoReview: false },
+    {
+      name: "auto-reviewed allowlist",
+      security: "allowlist",
+      ask: "on-miss",
+      autoReview: true,
+    },
+  ] as const)("never dispatches $name after cancellation during final policy", async (scenario) => {
+    const controller = new AbortController();
+    const reason = new Error("cancelled during final node dispatch policy");
+    const policy = createPolicy(scenario.security, scenario.ask);
+    const checkpoint = createDeferred<NodeApprovalPolicy>();
+    mocks.resolveExecHostApprovalContext
+      .mockResolvedValueOnce(policy)
+      .mockReturnValueOnce(checkpoint.promise);
+    const reviewer: ExecAutoReviewer = async () => ({
+      decision: "allow-once",
+      risk: "low",
+      rationale: "safe command",
+    });
+
+    const result = executeNodeHostCommand(
+      createRequest({
+        security: scenario.security,
+        ask: scenario.ask,
+        autoReview: scenario.autoReview,
+        autoReviewer: reviewer,
+        signal: controller.signal,
+      }),
+    );
+
+    await vi.waitFor(() => expect(mocks.resolveExecHostApprovalContext).toHaveBeenCalledTimes(2));
+    controller.abort(reason);
+    checkpoint.resolve(policy);
+
+    await expect(result).rejects.toBe(reason);
+    expect(mocks.invokeNodeSystemRunDirect).not.toHaveBeenCalled();
+    expect(
+      mocks.callGatewayTool.mock.calls.some(
+        ([method, , params]) => method === "node.invoke" && params?.command === "system.run",
+      ),
+    ).toBe(false);
+    expect(mocks.registerNodeApproval).toHaveBeenCalledTimes(scenario.autoReview ? 1 : 0);
+  });
+
+  it("forwards cancellation without removing auto-reviewed execution scopes", async () => {
+    const controller = new AbortController();
+    mocks.resolveExecHostApprovalContext.mockResolvedValue(createPolicy("allowlist", "on-miss"));
+    const reviewer: ExecAutoReviewer = async () => ({
+      decision: "allow-once",
+      risk: "low",
+      rationale: "safe command",
+    });
+
+    await executeNodeHostCommand(
+      createRequest({
+        security: "allowlist",
+        ask: "on-miss",
+        autoReview: true,
+        autoReviewer: reviewer,
+        signal: controller.signal,
+      }),
+    );
+
+    expect(mocks.callGatewayTool).toHaveBeenCalledWith(
+      "node.invoke",
+      { timeoutMs: 30_000 },
+      expect.objectContaining({ command: "system.run" }),
+      { scopes: ["operator.write", "operator.approvals"], signal: controller.signal },
+    );
+  });
+
+  it("forwards cancellation for prepared commands that need no approval", async () => {
+    const controller = new AbortController();
+    mocks.resolveExecHostApprovalContext.mockResolvedValue(createPolicy("allowlist", "off"));
+
+    await executeNodeHostCommand(
+      createRequest({
+        security: "allowlist",
+        ask: "off",
+        signal: controller.signal,
+      }),
+    );
+
+    expect(mocks.callGatewayTool).toHaveBeenCalledWith(
+      "node.invoke",
+      { timeoutMs: 30_000 },
+      expect.objectContaining({ command: "system.run" }),
+      { signal: controller.signal },
+    );
+    expect(mocks.registerNodeApproval).not.toHaveBeenCalled();
+  });
+});

--- a/src/agents/bash-tools.exec-host-node.ts
+++ b/src/agents/bash-tools.exec-host-node.ts
@@ -183,6 +183,7 @@ export async function executeNodeHostCommand(
           strictInlineEval: params.strictInlineEval,
         }),
     });
+    params.signal?.throwIfAborted();
     return await invokeNodeSystemRunDirect({ request: params, target });
   }
 
@@ -702,12 +703,18 @@ export async function executeNodeHostCommand(
       inlineEvalHit === null &&
       !requiresSecurityAuditSuppressionApproval,
   });
+  params.signal?.throwIfAborted();
   const raw =
     (inlineApprovedByAsk || inlineApprovalSource) && inlineApprovalId
       ? await callGatewayTool("node.invoke", { timeoutMs: target.invokeTimeoutMs }, invoke, {
           scopes: APPROVED_NODE_INVOKE_SCOPES,
+          ...(params.signal ? { signal: params.signal } : {}),
         })
-      : await callGatewayTool("node.invoke", { timeoutMs: target.invokeTimeoutMs }, invoke);
+      : params.signal
+        ? await callGatewayTool("node.invoke", { timeoutMs: target.invokeTimeoutMs }, invoke, {
+            signal: params.signal,
+          })
+        : await callGatewayTool("node.invoke", { timeoutMs: target.invokeTimeoutMs }, invoke);
   return formatNodeRunToolResult({
     raw,
     startedAt,


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where cancelling a direct, prepared, or automatically reviewed remote-node command could still execute that command if cancellation arrived during the final asynchronous policy check or while the gateway request was in flight.

## Why This Change Was Made

Recheck the originating AbortSignal immediately after the final policy checkpoint and forward that same signal through both direct and foreground node gateway calls. Preserve the existing least-privilege approval scopes, original unsignalled gateway call shape, and deliberately detached human-approval follow-ups.

## User Impact

Cancelling an agent run now prevents a not-yet-dispatched node command from starting and allows an in-flight node request to terminate. Automatic review, normal execution, manual approvals, command output, and existing no-signal integrations keep their original behavior.

## Evidence

Executed on Linux Blacksmith Testbox `tbx_01kym86yfsdtap240ayndnv4k6`. Secrets and unrelated local output are omitted.

### Before: cancellation still dispatches

```text
$ pnpm test src/agents/bash-tools.exec-host-node.cancellation.test.ts
FAIL src/agents/bash-tools.exec-host-node.cancellation.test.ts (3 tests | 3 failed)
× never dispatches 'direct full/off' after cancellation during final policy
  AssertionError: promise resolved { details: { status: 'completed' } } instead of rejecting
× never dispatches 'auto-reviewed allowlist' after cancellation during final policy
  AssertionError: promise resolved { details: { status: 'completed' } } instead of rejecting
× forwards cancellation without removing auto-reviewed execution scopes
  AssertionError: node.invoke gateway options omitted the caller AbortSignal
Test Files  1 failed (1)
Tests       3 failed (3)
```

### After: cancellation blocks dispatch and reaches the real gateway

```text
$ pnpm test src/agents/bash-tools.exec-host-node.cancellation.test.ts \
            src/agents/bash-tools.exec-host-node-phases.cancellation.test.ts
✓ node-host dispatch cancellation (4 tests)
  ✓ never dispatches direct full/off after cancellation during final policy
  ✓ never dispatches auto-reviewed allowlist after cancellation during final policy
  ✓ forwards cancellation without removing auto-reviewed execution scopes
  ✓ forwards cancellation for prepared commands that need no approval
✓ direct node run cancellation (3 tests)
  ✓ forwards the original cancellation signal to the gateway
  ✓ preserves the original gateway call when no signal is supplied
  ✓ never dispatches a direct node run after cancellation
Test Files  2 passed (2)
Tests       7 passed (7)
```

### Race stress, sibling integration, and full gate

```text
$ for iteration in 1 ... 20; do pnpm test <both cancellation suites>; done
[node-cancellation-stress] iteration 1/20
...
[node-cancellation-stress] iteration 20/20
20/20 passed; 140/140 focused regression checks passed

$ pnpm test <25 process, gateway, node, cron, CLI and auto-review test files>
unit-fast:             2 passed
unit-fast-isolated:   81 passed
gateway-core:        195 passed
process:              74 passed
agents:              667 passed
total:             1,019 passed; 0 failed

$ pnpm check:changed -- \
    src/agents/bash-tools.exec-host-node.ts \
    src/agents/bash-tools.exec-host-node-phases.ts \
    src/agents/bash-tools.exec-host-node.cancellation.test.ts \
    src/agents/bash-tools.exec-host-node-phases.cancellation.test.ts
core production types: passed
core test types:       passed
core changed lint:     passed
formatting/max-lines:  passed
dependency/plugin boundaries and import cycles: passed
runtime and state guards: passed
exitCode=0

$ autoreview --mode uncommitted --stream-engine-output
findings: []
overall_correctness: patch is correct
autoreview clean: no accepted/actionable findings reported
```

The original regressions were reproduced against main `64991433137f838f3aa9ec405d828b3f6168edfc`. The branch was rebased onto freshly pulled main before publication; stable Git patch IDs before and after rebase are both `0f1796174f862a89ce063bea3c06e48f693c03cf`. `git diff --name-status 64991433137f838f3aa9ec405d828b3f6168edfc origin/main -- <all four changed files>` was empty. The native `scripts/pr` prepare/merge workflow revalidates the current main and exact hosted CI; following root policy, unrelated moving-main drift is advisory and is not grounds for repeatedly rebasing and retriggering green CI.

AI-assisted; behavior, sibling ownership, failing-before/passing-after proof, cancellation boundaries, and the exact final patch were independently reviewed.