### PR TITLE
fix: Fish completion suggests options from the wrong command

### DIFF
--- a/src/cli/completion-cli.test.ts
+++ b/src/cli/completion-cli.test.ts
@@ -67,6 +67,42 @@ printf '%s\\n' "\${COMPREPLY[@]}"
   return result.stdout.split("\n").filter(Boolean);
 }
 
+function findFish(): string | null {
+  const executable = process.platform === "win32" ? "fish.exe" : "fish";
+  const candidates = (process.env.PATH ?? "")
+    .split(path.delimiter)
+    .filter(Boolean)
+    .map((directory) => path.join(directory, executable));
+  return candidates.find((candidate) => existsSync(candidate)) ?? null;
+}
+
+const fishPath = findFish();
+const itWithFish = fishPath ? it : it.skip;
+
+function runGeneratedFishCompletion(program: Command, commandLine: string): string[] {
+  if (!fishPath) {
+    throw new Error("Fish is unavailable");
+  }
+
+  const script = getCompletionScript("fish", program);
+  const quotedCommandLine = commandLine.replaceAll("'", "\\'");
+  const result = spawnSync(
+    fishPath,
+    ["--no-config", "--command", `${script}\ncomplete --do-complete '${quotedCommandLine}'`],
+    { encoding: "utf8", timeout: 15_000 },
+  );
+
+  if (result.error) {
+    throw result.error;
+  }
+  expect(result.stderr).toBe("");
+  expect(result.status).toBe(0);
+  return result.stdout
+    .split(/\r?\n/)
+    .filter(Boolean)
+    .map((completion) => completion.split("\t")[0] ?? completion);
+}
+
 function findPowerShell(): string | null {
   const executable = process.platform === "win32" ? "pwsh.exe" : "pwsh";
   const candidates = [
@@ -281,6 +317,50 @@ describe("completion-cli", () => {
     );
     expect(script).toContain("__openclaw_command_path_matches gateway -- -t --token");
     expect(script).toContain("if contains -- $flag $value_options");
+  });
+
+  it("distinguishes Fish child command paths from positional arguments", () => {
+    const script = getCompletionScript("fish", createCompletionProgram());
+
+    expect(script).toContain('switch "$candidate_path"');
+    expect(script).toContain("'gateway status'");
+  });
+
+  itWithFish.each([
+    ["the exact nested command", "openclaw gateway status -"],
+    ["a separate long option value", "openclaw gateway --token secret status -"],
+    ["a separate short option value", "openclaw gateway -t secret status -"],
+    ["an inline long option value", "openclaw gateway --token=secret status -"],
+    ["an inline short option value", "openclaw gateway -t=secret status -"],
+    ["a parent boolean option", "openclaw gateway --force status -"],
+  ])("keeps real Fish completions scoped after %s", (_name, commandLine) => {
+    expect(runGeneratedFishCompletion(createCompletionProgram(), commandLine)).toEqual(["--json"]);
+  });
+
+  itWithFish.each([
+    ["a positional argument", "openclaw gateway status query -"],
+    ["multiple positional arguments", "openclaw gateway status first second -"],
+    ["a positional argument named like a sibling", "openclaw gateway status restart -"],
+    ["a long option and positional argument", "openclaw gateway --token secret status query -"],
+    ["an inline option and positional argument", "openclaw gateway --token=secret status query -"],
+  ])("keeps real Fish leaf options after %s", (_name, commandLine) => {
+    const program = createCompletionProgram();
+    const gateway = program.commands.find((command) => command.name() === "gateway");
+    const status = gateway?.commands.find((command) => command.name() === "status");
+    if (!status) {
+      throw new Error("Gateway status command is unavailable");
+    }
+    status.argument("[query...]", "Search query");
+
+    expect(runGeneratedFishCompletion(program, commandLine)).toEqual(["--json"]);
+  });
+
+  itWithFish("preserves documented short and long completion flags in real Fish", () => {
+    expect(
+      runGeneratedFishCompletion(createDocumentedCompletionProgram(), "openclaw completion -"),
+    ).toEqual(
+      expect.arrayContaining(["-s", "--shell", "-i", "--install", "-y", "--yes", "--write-state"]),
+    );
   });
 
   it("scopes fish value-taking option skips to the active command path", () => {
@@ -499,6 +579,46 @@ printf '%s\\n' "\${COMPREPLY[@]}"
     expect(script).toContain(
       "complete -c openclaw -n \"__openclaw_command_path_matches cron create -- --profile --at\" -l at -d 'Schedule time'",
     );
+  });
+
+  itWithFish.each([
+    ["an aliased nested command", "openclaw cron create -"],
+    ["a canonical nested command", "openclaw cron add -"],
+    ["a global profile", "openclaw --profile work cron create -"],
+    ["an inline global profile", "openclaw --profile=work cron create -"],
+    ["repeated global profiles", "openclaw --profile first --profile second cron create -"],
+    ["an inherited global profile", "openclaw cron --profile work create -"],
+    ["a parent long option", "openclaw cron --timezone UTC create -"],
+    ["a parent short option", "openclaw cron -z UTC create -"],
+    ["an inline parent option", "openclaw cron --timezone=UTC create -"],
+    ["a parent boolean option", "openclaw cron --verbose create -"],
+  ])("keeps real Fish alias completions scoped after %s", (_name, commandLine) => {
+    const program = createAliasedCompletionProgram();
+    const cron = program.commands.find((command) => command.name() === "cron");
+    if (!cron) {
+      throw new Error("Cron command is unavailable");
+    }
+    cron.option("-z, --timezone <zone>", "Time zone").option("--verbose", "Verbose output");
+
+    expect(runGeneratedFishCompletion(program, commandLine)).toEqual(["--at"]);
+  });
+
+  itWithFish.each([
+    ["an aliased positional argument", "openclaw cron create meeting -"],
+    ["a canonical positional argument", "openclaw cron add meeting -"],
+    ["a profiled positional argument", "openclaw --profile work cron create meeting -"],
+    ["a parent option and positional argument", "openclaw cron -z UTC create meeting -"],
+  ])("keeps real Fish alias options after %s", (_name, commandLine) => {
+    const program = createAliasedCompletionProgram();
+    const cron = program.commands.find((command) => command.name() === "cron");
+    const add = cron?.commands.find((command) => command.name() === "add");
+    if (!cron || !add) {
+      throw new Error("Cron add command is unavailable");
+    }
+    cron.option("-z, --timezone <zone>", "Time zone");
+    add.argument("[label...]", "Job label");
+
+    expect(runGeneratedFishCompletion(program, commandLine)).toEqual(["--at"]);
   });
 
   it("completes aliases and alias command paths in PowerShell", () => {

--- a/src/cli/completion-cli.ts
+++ b/src/cli/completion-cli.ts
@@ -93,7 +93,22 @@ function collectFishPathOptionFlags(
   return [...flags];
 }
 
-function generateFishPathHelper(rootCmd: string): string {
+function generateFishPathHelper(rootCmd: string, program: Command): string {
+  const knownCommandPaths = collectBashCompletionContexts(program, [])
+    .flatMap((context) => context.pathVariants)
+    .map((pathSegments) => `'${pathSegments.join(" ").replaceAll("'", "'\\''")}'`)
+    .join(" ");
+  const rejectDescendantCommands = knownCommandPaths
+    ? `
+  if test (count $command_tokens) -gt (count $expected)
+    set -l next_index (math (count $expected) + 1)
+    set -l candidate_path (string join " " $expected $command_tokens[$next_index])
+    switch "$candidate_path"
+      case ${knownCommandPaths}
+        return 1
+    end
+  end`
+    : "";
   // Fish needs a helper to ignore option values while matching nested command paths.
   return `
 function __${rootCmd}_command_path_matches
@@ -137,6 +152,7 @@ function __${rootCmd}_command_path_matches
       return 1
     end
   end
+${rejectDescendantCommands}
   return 0
 end
 `;
@@ -604,7 +620,7 @@ ${commandPathCases}
 
 function generateFishCompletion(program: Command): string {
   const rootCmd = program.name();
-  const segments: string[] = [generateFishPathHelper(rootCmd)];
+  const segments: string[] = [generateFishPathHelper(rootCmd, program)];
 
   const visit = (cmd: Command, parentVariants: string[][]) => {
     // One condition per alias-expanded parent path so completion keeps working


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Fish users completing a nested OpenClaw command received options and subcommands from its ancestors. For example, `openclaw gateway status -` suggested ancestor-only flags such as `--force` even though they do not belong to `gateway status`. Profiled, aliased, and inline-option command lines were affected.

## Why This Change Was Made

Reuse the canonical Commander command-path inventory already used by Bash completion. Reject ancestor completions only when the next token is a known descendant command; keep actual positional arguments eligible so search and similar commands still complete their options.

## User Impact

Fish users receive only options and subcommands relevant to the active command. Nested aliases, global profiles, separate and inline option values, Boolean options, and options following positional search terms all continue to complete correctly. Bash, PowerShell, Zsh, completion caching, and installation are unchanged.

## Evidence

- Red first: 17 failures in actual Linux Fish for ancestor leakage, canonical and aliased command paths, root profiles, separate/inline options, and parent flags.
- Independent-review follow-up: 10 positional-argument failures reproduced and corrected before publishing; final independent autoreview is clean.
- Final remote regression: 340 tests passing across Fish, Bash, real PowerShell, gateway option collisions, route/argv handling, read-only configuration, and machine-readable JSON.
- Actual shell coverage: no skipped Fish tests; all original ancestor, alias, profile, inline, and positional-operand cases pass.
- Production changed-file checks: `pnpm check:changed -- src/cli/completion-cli.ts src/cli/completion-cli.test.ts`, including formatting, lint, core and test typecheck, API, plugin, dependency, schema, database, import-cycle and security guards.
- Full production `pnpm build` succeeds.
- Real source and packaged acceptance: 30 cases, including four-shell script generation and actual Fish execution of gateway nested options, split/inline profiles, token values, search positional operands, and documented completion flags.
- Fresh independent `autoreview --mode uncommitted`: clean, no accepted/actionable findings.

## Inspectable Real Fish Transcript

The following fresh transcript invokes the exact reviewed Fish generator from `03f9b55d63fbdd690153806b8ff535bdac219cf8` against actual Fish. The Commander command tree exercises the same gateway and variadic-search contracts as the added real-shell regression tests. Each suggestion array below is returned by real `fish --no-config --command`; it is not a mocked parser.

```text
$ fish --version
fish, version 4.8.1

$ fish --no-config --command '…; complete --do-complete "openclaw gateway status -"'
{"suggestions":["--json"],"forbiddenAncestorFlagsAbsent":["--force"]}

$ fish --no-config --command '…; complete --do-complete "openclaw --profile work gateway status -"'
{"suggestions":["--json"],"forbiddenAncestorFlagsAbsent":["--force"]}

$ fish --no-config --command '…; complete --do-complete "openclaw --profile=work gateway status -"'
{"suggestions":["--json"],"forbiddenAncestorFlagsAbsent":["--force"]}

$ fish --no-config --command '…; complete --do-complete "openclaw gateway --token secret status -"'
{"suggestions":["--json"],"forbiddenAncestorFlagsAbsent":["--force"]}

$ fish --no-config --command '…; complete --do-complete "openclaw gateway --token=secret status -"'
{"suggestions":["--json"],"forbiddenAncestorFlagsAbsent":["--force"]}

$ fish --no-config --command '…; complete --do-complete "openclaw gw st -"'
{"suggestions":["--json"],"forbiddenAncestorFlagsAbsent":["--force"]}

$ fish --no-config --command '…; complete --do-complete "openclaw skills search lobster -"'
{"suggestions":["--json"],"forbiddenAncestorFlagsAbsent":[]}

$ fish --no-config --command '…; complete --do-complete "openclaw skills search first second -"'
{"suggestions":["--json"],"forbiddenAncestorFlagsAbsent":[]}

$ fish --no-config --command '…; complete --do-complete "openclaw --profile work skills search lobster -"'
{"suggestions":["--json"],"forbiddenAncestorFlagsAbsent":[]}

PASS 9/9 real Fish completions against reviewed source generator
```

The independent Linux production acceptance additionally built the actual OpenClaw package, generated all four shell scripts from both the real source entry point and `openclaw.mjs`, and invoked real Fish against both generated full-product scripts:

```text
fish, version 3.7.0
PASS source real Fish "openclaw gateway status -"
PASS source real Fish "openclaw --profile work gateway status -"
PASS source real Fish "openclaw --profile=work gateway status -"
PASS source real Fish "openclaw gateway --token secret status -"
PASS source real Fish "openclaw gateway --token=secret status -"
PASS source real Fish "openclaw gateway status --j"
PASS source real Fish "openclaw skills search lobster -"
PASS source real Fish "openclaw skills search first second -"
PASS source real Fish "openclaw --profile work skills search lobster -"
PASS source real Fish "openclaw completion -"
PASS source real Fish "openclaw completion --s"
PASS packaged real Fish "openclaw gateway status -"
PASS packaged real Fish "openclaw --profile work gateway status -"
PASS packaged real Fish "openclaw --profile=work gateway status -"
PASS packaged real Fish "openclaw gateway --token secret status -"
PASS packaged real Fish "openclaw gateway --token=secret status -"
PASS packaged real Fish "openclaw gateway status --j"
PASS packaged real Fish "openclaw skills search lobster -"
PASS packaged real Fish "openclaw skills search first second -"
PASS packaged real Fish "openclaw --profile work skills search lobster -"
PASS packaged real Fish "openclaw completion -"
PASS packaged real Fish "openclaw completion --s"
PASS source and packaged Fish completion: 30 real process cases
blacksmith run summary sync=delegated command=6m38.519s total=6m38.686s exit=0
```

## Current Main Compatibility

Verified against latest `origin/main` at `981a3dfad302de15cc867e89f45661a63eefe80d`. `git log 64991433137f838f3aa9ec405d828b3f6168edfc..origin/main -- src/cli/completion-cli.ts src/cli/completion-cli.test.ts` is empty: no newer main commit modifies either touched owner. GitHub confirms `mergeable: MERGEABLE`. In accordance with repository policy, do not rebase solely for moving-main drift: preserve the independently reviewed, fully built, exact-head-tested commit and let the protected maintainer landing workflow merge it against current main.
