### PR TITLE
fix(auto-reply): suppress fallback for accepted busy turns

### DIFF
--- a/src/auto-reply/reply/agent-runner-direct-runtime-config.test.ts
+++ b/src/auto-reply/reply/agent-runner-direct-runtime-config.test.ts
@@ -8,6 +8,10 @@ import type { TemplateContext } from "../templating.js";
 import { SILENT_REPLY_TOKEN } from "../tokens.js";
 import { createTestFollowupRun } from "./agent-runner.test-fixtures.js";
 import type { QueueSettings } from "./queue.js";
+import {
+  REPLY_OPERATION_RUN_STATE,
+  type ReplyOperationRunState,
+} from "./reply-operation-run-state.js";
 import type { ReplyOperation } from "./reply-run-registry.js";
 import { createMockTypingController } from "./test-helpers.js";
 
@@ -605,9 +609,13 @@ describe("runReplyAgent runtime config", () => {
       shouldFollowup: true,
       isActive: true,
     });
+    const runState: ReplyOperationRunState = {};
+    replyParams.opts = { [REPLY_OPERATION_RUN_STATE]: runState };
+    enqueueFollowupRunMock.mockReturnValueOnce(true);
 
     await expect(runReplyAgent(replyParams)).resolves.toBeUndefined();
 
+    expect(runState.admission).toEqual({ status: "accepted", mode: "followup" });
     expect(resolveQueuedReplyExecutionConfigMock).not.toHaveBeenCalled();
     expect(enqueueFollowupRunMock).toHaveBeenCalledTimes(1);
     const enqueueCall = enqueueFollowupRunMock.mock.calls.at(0);

--- a/src/auto-reply/reply/agent-runner-run.ts
+++ b/src/auto-reply/reply/agent-runner-run.ts
@@ -294,6 +294,9 @@ export async function runReplyAgent(
       },
     );
     if (steerOutcome.queued) {
+      if (replyOperationRunState) {
+        replyOperationRunState.admission = { status: "accepted", mode: "steer" };
+      }
       activeReplyOperation?.recordActivity();
       try {
         await turnAdoptionLifecycle?.onAdopted();
@@ -386,6 +389,9 @@ export async function runReplyAgent(
     if (!enqueued) {
       typing.cleanup();
       return undefined;
+    }
+    if (replyOperationRunState) {
+      replyOperationRunState.admission = { status: "accepted", mode: "followup" };
     }
     // The queue must stay dormant while the active owner can still collect
     // messages. Registering after enqueue closes the owner-clear race.

--- a/src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts
+++ b/src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts
@@ -437,12 +437,14 @@ function requireBuiltChannelSourceTurnId(
 
 describe("runReplyAgent active steering", () => {
   it("dispatches a declined steer once with its source-turn identity", async () => {
+    const runState: ReplyOperationRunState = {};
     state.beforeAgentReplyHasHooksMock.mockImplementation(
       (hookName) => hookName === "before_agent_reply",
     );
     state.beforeAgentReplyRunMock.mockResolvedValue(undefined);
     state.queueEmbeddedAgentMessageMock.mockReturnValueOnce(true);
     const { run, sourceTurnId } = createMinimalRun({
+      opts: { [REPLY_OPERATION_RUN_STATE]: runState },
       isActive: true,
       isStreaming: true,
       shouldSteer: true,
@@ -464,6 +466,7 @@ describe("runReplyAgent active steering", () => {
 
     await expect(run()).resolves.toBeUndefined();
 
+    expect(runState.admission).toEqual({ status: "accepted", mode: "steer" });
     expect(state.beforeAgentReplyRunMock).toHaveBeenCalledOnce();
     expect(state.beforeAgentReplyRunMock).toHaveBeenCalledWith(
       { cleanedBody: "hello" },

--- a/src/auto-reply/reply/dispatch-from-config.execute.ts
+++ b/src/auto-reply/reply/dispatch-from-config.execute.ts
@@ -21,6 +21,7 @@ import {
 import { extendPreparedDispatchState } from "./dispatch-from-config.phase-state.js";
 import type { PrepareDispatchExecutionReadyState } from "./dispatch-from-config.prepare-execution.js";
 import { waitForReplyDispatcherIdle } from "./reply-dispatcher.js";
+import { REPLY_OPERATION_RUN_STATE } from "./reply-operation-run-state.js";
 
 export async function executeDispatch(state: PrepareDispatchExecutionReadyState) {
   const {
@@ -74,6 +75,7 @@ export async function executeDispatch(state: PrepareDispatchExecutionReadyState)
     recordRoutedBlockReplyDelivery,
     replyConfig,
     replyContextAccountId,
+    replyOperationRunState,
     replyResolver,
     replyRoute,
     resolveToolDeliveryPayload,
@@ -124,6 +126,7 @@ export async function executeDispatch(state: PrepareDispatchExecutionReadyState)
               ctx,
               {
                 ...getReplyOptions(),
+                [REPLY_OPERATION_RUN_STATE]: replyOperationRunState,
                 sourceReplyDeliveryMode,
                 sessionPromptSourceReplyDeliveryMode: sessionStableSourceReplyDeliveryMode,
                 ...({

--- a/src/auto-reply/reply/dispatch-from-config.finalize.ts
+++ b/src/auto-reply/reply/dispatch-from-config.finalize.ts
@@ -51,6 +51,7 @@ export async function finalizeDispatchAndAudit(state: ExecuteDispatchReadyState)
     recordAgentDispatchCompleted,
     recordProcessed,
     replyResult,
+    replyOperationRunState,
     replyRoute,
     routeReplyToOriginating,
     sendFinalPayload,
@@ -292,6 +293,7 @@ export async function finalizeDispatchAndAudit(state: ExecuteDispatchReadyState)
   await waitForPendingDirectBlockReplyDelivery(getDispatchAbortSignal());
   let counts = dispatcher.getQueuedCounts();
   let noVisibleReplyFallbackDelivered = false;
+  const replyAcceptedByActiveRun = replyOperationRunState.admission?.status === "accepted";
   // Visible agent turns must never end silently: empty model completions get a
   // core fallback final. emptyFinalAllowedAsSilent is the only sanctioned silence.
   // Routed streamed blocks bypass dispatcher counts, so blockCount and the
@@ -302,6 +304,7 @@ export async function finalizeDispatchAndAudit(state: ExecuteDispatchReadyState)
     sourceReplyDeliveryMode !== "message_tool_only" &&
     !sawVisibleFinalDelivery &&
     !getObservedReplyDelivery() &&
+    !replyAcceptedByActiveRun &&
     !emptyFinalAllowedAsSilent &&
     !sawDedupedAgainstBlock &&
     !hasDeliveredRoutedBlockReply() &&
@@ -377,6 +380,7 @@ export async function finalizeDispatchAndAudit(state: ExecuteDispatchReadyState)
       ...(!sawVisibleFinalDelivery &&
       !noVisibleReplyFallbackDelivered &&
       !getObservedReplyDelivery() &&
+      !replyAcceptedByActiveRun &&
       !emptyFinalAllowedAsSilent
         ? { noVisibleReplyFallbackEligible: true }
         : {}),

--- a/src/auto-reply/reply/dispatch-from-config.gather.ts
+++ b/src/auto-reply/reply/dispatch-from-config.gather.ts
@@ -46,6 +46,10 @@ import { resolveEffectiveReplyRoute } from "./effective-reply-route.js";
 import type { ReplySessionBinding } from "./get-reply.types.js";
 import { finalizeInboundContext, isFinalizedInboundContext } from "./inbound-context.js";
 import { hasInboundAudio } from "./inbound-media.js";
+import {
+  resolveReplyOperationRunState,
+  type ReplyOperationRunState,
+} from "./reply-operation-run-state.js";
 import { replyRunRegistry } from "./reply-run-registry.js";
 import { isReplyProfilerEnabled } from "./reply-timing-tracker.js";
 import { resolveRoutedDeliveryThreadId } from "./routed-delivery-thread.js";
@@ -61,6 +65,8 @@ export async function gatherDispatchRequest(
   const normalizedParams = ctx === params.ctx ? params : { ...params, ctx };
   const state = { params: normalizedParams, messageAuditTerminal };
   const { cfg, dispatcher } = normalizedParams;
+  const replyOperationRunState: ReplyOperationRunState =
+    resolveReplyOperationRunState(normalizedParams.replyOptions) ?? {};
   if (params.replyOptions?.abortSignal?.aborted) {
     messageAuditTerminal?.note("skipped", { reason: "reply_operation_aborted" });
     return {
@@ -453,6 +459,7 @@ export async function gatherDispatchRequest(
       inboundAudio,
       sessionTtsAuto,
       workspaceDir,
+      replyOperationRunState,
       completeDispatchReplyOperation,
       dispatchHookDispatcher,
       ensureDispatchReplyOperation,

--- a/src/auto-reply/reply/dispatch-from-config.hooks-and-send-policy.test-utils.ts
+++ b/src/auto-reply/reply/dispatch-from-config.hooks-and-send-policy.test-utils.ts
@@ -31,6 +31,7 @@ import {
   describe2BeforeEach0,
 } from "./dispatch-from-config.test-harness.js";
 import { PROVIDER_CONVERSATION_STATE_ERROR_USER_MESSAGE } from "./provider-request-error-classifier.js";
+import { resolveReplyOperationRunState } from "./reply-operation-run-state.js";
 import { buildTestCtx } from "./test-ctx.js";
 
 beforeAll(globalBeforeAll0);
@@ -423,6 +424,37 @@ describe("sendPolicy deny — suppress delivery, not processing (#53328)", () =>
       noVisibleReplyFallbackDelivered: true,
     });
     expect(result.noVisibleReplyFallbackEligible).toBeUndefined();
+  });
+
+  it("does not treat an active-run accepted turn as an empty completion", async () => {
+    setNoAbort();
+    const dispatcher = createDispatcher();
+    const replyResolver = vi.fn(async (_ctx: MsgContext, opts?: GetReplyOptions) => {
+      const runState = resolveReplyOperationRunState(opts);
+      if (!runState) {
+        throw new Error("expected reply operation run state");
+      }
+      runState.admission = { status: "accepted", mode: "followup" };
+      return undefined;
+    });
+
+    const result = await dispatchReplyFromConfig({
+      ctx: buildTestCtx({
+        Surface: "telegram",
+        Provider: "telegram",
+        SessionKey: "agent:main:telegram:direct:test",
+      }),
+      cfg: emptyConfig,
+      dispatcher,
+      replyResolver,
+    });
+
+    expect(replyResolver).toHaveBeenCalledOnce();
+    expect(dispatcher.sendFinalReply).not.toHaveBeenCalled();
+    expect(result).toEqual({
+      queuedFinal: false,
+      counts: { tool: 0, block: 0, final: 0 },
+    });
   });
 
   it("delivers fallback for mentioned group turns even when group silence is allowed", async () => {

--- a/src/auto-reply/reply/get-reply.types.ts
+++ b/src/auto-reply/reply/get-reply.types.ts
@@ -5,6 +5,7 @@ import type { GetReplyOptions } from "../get-reply-options.types.js";
 import type { ReplyPayload } from "../reply-payload.js";
 import type { MsgContext } from "../templating.js";
 import type { QueueMode } from "./queue/types.js";
+import type { ReplyOptionsWithOperationRunState } from "./reply-operation-run-state.js";
 import type { ReplyOperation } from "./reply-run-registry.js";
 
 export type ReplySessionBinding = {
@@ -31,7 +32,8 @@ type InternalReplySessionOptions = {
 
 export type InternalGetReplyOptions = GetReplyOptions &
   InternalReplySessionOptions &
-  ReplyOptionsWithHeartbeatRunScope;
+  ReplyOptionsWithHeartbeatRunScope &
+  ReplyOptionsWithOperationRunState;
 
 export function shouldBridgeCliPreambleEvents(opts: InternalGetReplyOptions | undefined): boolean {
   return opts?.commentaryProgressEnabled === true || opts?.progressPreambleEnabled === true;

--- a/src/auto-reply/reply/reply-operation-run-state.ts
+++ b/src/auto-reply/reply/reply-operation-run-state.ts
@@ -1,5 +1,6 @@
 type ReplyOperationAdmissionSnapshot =
   | { status: "owned" }
+  | { status: "accepted"; mode: "steer" | "followup" }
   | { status: "skipped"; reason: "active-run" | "aborted" | "lifecycle-invalidated" };
 
 export type ReplyOperationRunState = {
@@ -10,7 +11,7 @@ export type ReplyOperationRunState = {
 // heartbeat cleanup never infers it from whichever operation is active later.
 export const REPLY_OPERATION_RUN_STATE = Symbol("openclaw.replyOperationRunState");
 
-type ReplyOptionsWithOperationRunState = {
+export type ReplyOptionsWithOperationRunState = {
   [REPLY_OPERATION_RUN_STATE]?: ReplyOperationRunState;
 };
 


### PR DESCRIPTION
## Summary

### High Level TLDR

When a second message is accepted by an already-running agent—either steered into the active run or queued as a follow-up—the current dispatch returns no immediate reply by design. Finalization mistook that accepted turn for an empty model completion and sent the generic “No reply was generated...” fallback. This patch carries an in-memory accepted-admission marker through the existing reply invocation and suppresses that false fallback until the accepted work produces its normal reply.

Closes #115171.

## Root Cause

The concrete before path is:

1. A visible channel turn owns the session reply lane.
2. A second message arrives while that run is active.
3. `runReplyAgent` successfully steers the message or `enqueueFollowupRun(...)` accepts it for deferred execution.
4. `runReplyAgent` returns `undefined` because no immediate second-dispatch payload should be sent.
5. `finalizeDispatchAndAudit` sees zero reply counts and no observed delivery, cannot distinguish accepted busy-run work from a genuinely empty model completion, and emits `NO_VISIBLE_REPLY_FALLBACK_TEXT`.
6. That erroneous newer visible fallback can advance the foreground freshness fence and suppress the first run's real completed answer as stale.

Source proof on current `main`:

- Successful steering returns `undefined` from `agent-runner-run.ts`.
- Successful follow-up enqueue also returns `undefined`.
- The no-visible-reply gate in `dispatch-from-config.finalize.ts` previously had no admission-state input.
- `reply-operation-run-state.ts` already carries invocation-local admission facts for heartbeat ownership; this patch extends that internal contract rather than adding a new global registry or delivery mechanism.

No model failure occurs on the affected path. The second turn was accepted by active-run processing.

## What changed

- Create or reuse one per-dispatch `ReplyOperationRunState`.
- Pass the same object through the internal reply-options symbol.
- Record `{ status: "accepted", mode: "steer" }` only after steering succeeds.
- Record `{ status: "accepted", mode: "followup" }` only after follow-up enqueue succeeds.
- Exclude an accepted active-run turn from both the core generic-fallback gate and the channel-level fallback-eligibility flag.
- Leave rejected, deduplicated, aborted, and queue-overflow admissions unchanged.

## User impact

Rapid consecutive messages no longer receive a false model-failure notice merely because the newer message was accepted by the active run. The existing foreground-fence policy is unchanged; this removes the erroneous newer visible delivery that could make the earlier real answer lose that fence.

Genuine empty model completions still receive the existing fallback.

## Real behavior proof

### Observed before behavior

A real Telegram direct conversation reproduced the sequence: a second message sent while the first was still active received the generic no-reply fallback; the first answer appeared only after the subsequent interaction. The private screenshot is not attached because it contains chat/account identifiers.

Redacted Gateway correlation from a second live recurrence:

```text
08:06:49  first inbound turn received
08:08:12  second inbound turn received while the first agent run remained active
08:08:14  second dispatch completed in 1.2s with no agent-turn/model timing
08:08:14  one outbound text send completed (the generic fallback observed in chat)
08:12:56  first agent turn completed after 365s
08:12:57  first dispatch logged "visible channel turn dispatched with no queued reply payloads"
```

This establishes the patch boundary directly: the second dispatch produced a visible fallback without running a model, then the earlier real completion had no queued visible payload.

### After-patch focused proof

Commands:

```text
pnpm vitest run \
  src/auto-reply/reply/agent-runner-direct-runtime-config.test.ts \
  src/auto-reply/reply/dispatch-from-config.test.ts

node scripts/run-vitest.mjs run \
  --config test/vitest/vitest.e2e.config.ts \
  src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts \
  -t "dispatches a declined steer once with its source-turn identity"
```

Copied results from rebased head `12e0379e2aa5`:

```text
Test Files  2 passed (2)
Tests       305 passed (305)

Test Files  1 passed (1)
Tests       1 passed | 119 skipped (120)
```

Observed after behavior:

- A successful real `enqueueFollowupRun` mock path stamps `accepted/followup`.
- A successful steering path stamps `accepted/steer`.
- Dispatch finalization receives that same state object.
- An accepted active-run turn queues no generic fallback and does not advertise channel-level fallback eligibility.
- The existing direct empty-completion tests still deliver the generic fallback.

### Live deployment state

The patch was deployed as an `oc-update --skip-codex` overlay to a real multi-channel Gateway on 2026-07-28. The wrapper rebuilt from source and reported:

```text
applied: #115181 fix(auto-reply): suppress fallback for accepted busy turns
Replacement Gateway verified
oc-update completed successfully
```

Independent post-update checks observed the replacement service active/running, `NRestarts=0`, port 18789 listening, configuration audit clean, and RPC read healthy on version `2026.7.2`.

The deployed pre-rebase commit and refreshed PR commit have the same stable patch ID (`40db31cbf7686f9302fb37e790f2cb9a0496676b`), so the behavior-changing diff is identical. A fresh two-message channel reproduction after deployment remains pending; no claim of live after-fix channel proof is made yet.

## Verification

```text
pnpm vitest run src/auto-reply/reply/agent-runner-direct-runtime-config.test.ts src/auto-reply/reply/dispatch-from-config.test.ts
node scripts/run-vitest.mjs run --config test/vitest/vitest.e2e.config.ts src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts -t "dispatches a declined steer once with its source-turn identity"
pnpm exec oxlint --type-aware <all changed TypeScript files>
pnpm tsgo:core
git diff --check origin/main...HEAD
```

- Rebased cleanly onto upstream `main` `5087e654773`; refreshed head `12e0379e2aa5`.
- Focused tests: 306 passed.
- Targeted type-aware Oxlint: passed.
- Core TypeScript check: passed.
- `git diff --check`: passed.
- Secret scan: clean.
- Fable review via Claude CLI found the initially missed successful-steer sibling path; it was incorporated.
- Final mandatory independent review after that correction: clean, no actionable findings, correctness confidence 0.91.
- Performance: no waits, network calls, storage operations, timers, retries, polling, or model work were added. The hot-path cost is one small invocation-local object when absent, two synchronous property writes on accepted busy paths, and one property read during finalization.

## What was not tested

- The exact after-patch two-message Telegram sequence has not yet been repeated on a live channel. The overlay is now deployed, but fresh visible proof requires sending real user messages while a model turn is active.
- The full `agent-runner.runreplyagent.e2e.test.ts` file is not green on current `main` in this environment: 53 failures include default-agent session-key errors and two existing 120-second cases. The exact changed steering case passes in isolation, and the two focused suites pass.
- A follow-up accepted and later removed by configured queue-overflow policy remains owned by queue policy and may be silent; this patch does not redefine queue-drop UX.
- Rejected/deduplicated enqueues are not marked accepted. Their fallback policy is intentionally unchanged and should be evaluated separately from this observed successful-admission bug.

## AI Assistance

Codex traced and implemented the admission/finalization contract. Fable reviewed the first patch via Claude CLI and identified the successful-steer sibling path; that finding was addressed before the final clean review.
