### PR TITLE
docs: cover Ask OpenClaw page context, dockable panel, and hosted skills/search setup

### DIFF
--- a/docs/cli/openclaw.md
+++ b/docs/cli/openclaw.md
@@ -81,6 +81,9 @@ channels
 channel info slack
 connect slack
 open channel wizard for slack
+configure skills
+configure web search
+open search wizard
 plugins list
 plugins search slack
 plugin install clawhub:openclaw-codex-app-server
@@ -96,7 +99,7 @@ OpenClaw uses typed operations instead of editing config ad hoc.
 
 Read-only operations run immediately: show overview, list agents, list installed plugins, search ClawHub plugins, show model/backend status, run status/health checks, check Gateway reachability, run doctor without interactive fixes, validate config, show the audit-log path.
 
-Starting guided channel setup (`connect telegram`) also runs immediately. Its wizard collects explicit answers and owns the resulting writes.
+Starting a guided setup flow also runs immediately: channel setup (`connect telegram`), workspace skills setup (`configure skills`), and web-search provider setup (`configure web search`). Each hosted wizard collects explicit answers and owns the resulting writes; completions append audit entries and re-validate config. A web-search provider that needs a plugin install writes config only after the install succeeds — a failed or timed-out install stops setup and reports it instead of claiming the provider is configured.
 
 Persistent operations require conversational approval (or `--yes` for a direct command): write config, `config set`, `config set-ref`, setup/onboarding bootstrap, change the default model, start/stop/restart the Gateway, create agents, and install plugins.
 
@@ -142,24 +145,29 @@ Discovery and read-only operations are not included. Secrets never appear in
 change history; config journal records contain changed paths rather than config
 values, and value comparison uses protected fingerprints.
 
-Channel setup can run as a hosted conversation until it reaches a secret. The
-local OpenClaw TUI does not accept sensitive wizard answers because terminal
-chat input is visible. It offers `open channel wizard` immediately, carrying
-the selected channel into the masked terminal wizard; you can also run
-`openclaw channels add --channel <channel>` later.
+Channel and web-search setup can run as hosted conversations until they reach
+a secret. The local OpenClaw TUI does not accept sensitive wizard answers
+because terminal chat input is visible. It offers `open channel wizard`
+(carrying the selected channel) or `open search wizard` immediately, handing
+off to the masked terminal wizard; you can also run
+`openclaw channels add --channel <channel>` or
+`openclaw configure --section web` later.
 
-### Switching to masked channel setup
+### Switching to a masked terminal wizard
 
-The local chat can hand control to the masked channel wizard:
+The local chat can hand control to a masked terminal wizard:
 
 ```text
 open channel wizard for slack
 channel info slack
+open search wizard
 ```
 
 `open channel wizard for <channel>` opens masked channel setup after the chat
 TUI closes. Use `channel info <channel>` first for the channel label, setup
-state, prerequisites summary, and docs link.
+state, prerequisites summary, and docs link. `open search wizard` works the
+same way for web-search provider setup, opening the masked search wizard after
+the chat TUI closes.
 
 OpenClaw never changes provider/auth access from inside its own session: the
 session already depends on that inference route. For model-provider setup or

--- a/docs/cli/setup.md
+++ b/docs/cli/setup.md
@@ -116,6 +116,7 @@ openclaw setup --non-interactive --accept-risk --mode remote --remote-url wss://
 
 ## Notes
 
+- Inside the OpenClaw chat, `configure skills` and `configure web search` run the hosted skills and web-search setup flows; `open search wizard` hands off to the masked terminal wizard when a credential is needed. See [`openclaw setup` operations](/cli/openclaw#operations-and-approval).
 - After baseline setup, run `openclaw onboard` for the full guided journey, `openclaw configure` for targeted changes, or `openclaw channels add` to add channel accounts.
 - If Hermes state is detected, interactive onboarding can offer migration automatically. Import onboarding requires a fresh setup; use [Migrate](/cli/migrate) for dry-run plans, backups, and overwrite mode outside onboarding.
 

--- a/docs/docs_map.md
+++ b/docs/docs_map.md
@@ -1876,7 +1876,7 @@ Do not edit it by hand; run `pnpm docs:map:gen`.
   - H2: Examples
   - H2: Operations and approval
   - H3: Change history
-  - H3: Switching to masked channel setup
+  - H3: Switching to a masked terminal wizard
   - H2: Setup bootstrap
   - H2: AI conversation
   - H3: CLI harness trust model

--- a/docs/start/wizard.md
+++ b/docs/start/wizard.md
@@ -28,6 +28,10 @@ setup, channel pairing, daemon controls, skills, and imports. Run it explicitly
 with `openclaw onboard --classic`; the guided inference picker does not delegate
 into it. After inference passes, OpenClaw can use `open channel wizard for
 <channel>` to hand channel setup that needs secrets to a masked terminal wizard.
+Workspace skills and web search are configured the same conversational way:
+`configure skills` and `configure web search` host those setup flows in the
+chat, and `open search wizard` hands credential entry to the masked terminal
+wizard.
 To change the model provider or its authentication, exit OpenClaw and run
 `openclaw onboard`; OpenClaw does not open guided or classic provider flows.
 
@@ -65,8 +69,9 @@ openclaw agents add <name>
 The classic wizard includes a web search step where you can pick a provider: Brave,
 DuckDuckGo, Exa, Firecrawl, Gemini, Grok, Kimi, MiniMax Search, Ollama Web
 Search, Perplexity, SearXNG, or Tavily. Some need an API key; others are
-key-free. Configure this later with `openclaw configure --section web`. Docs:
-[Web tools](/tools/web).
+key-free. Configure this later with `openclaw configure --section web`, or say
+`configure web search` in the OpenClaw chat to run the same provider setup
+conversationally. Docs: [Web tools](/tools/web).
 </Tip>
 
 ## Guided default

--- a/docs/tools/web.md
+++ b/docs/tools/web.md
@@ -37,6 +37,14 @@ xAI Responses.
     This stores the provider and any needed credential. For API-backed
     providers you can instead set the provider's env var (for example
     `BRAVE_API_KEY`) and skip this step.
+
+    You can also configure search by talking to
+    [OpenClaw](/cli/openclaw): say `configure web search` in `openclaw setup`
+    or in the Control UI's **Settings → Ask OpenClaw** chat. The hosted flow
+    owns provider choice and credential entry — API keys are masked in the
+    browser, and the terminal chat hands off to the masked wizard via
+    `open search wizard`.
+
   </Step>
   <Step title="Use it">
     ```javascript

--- a/docs/web/control-ui.md
+++ b/docs/web/control-ui.md
@@ -146,7 +146,13 @@ Theme, theme mode, text size, language, and chat display preferences sync throug
 
 ## OpenClaw system care
 
-Open **Settings → Ask OpenClaw** to talk to the system setup and repair agent. Outside onboarding, this page can show at most one dismissible event chip per visit. It stays silent for routine Gateway traffic and reacts only to health snapshots that report a disabled configuration reloader, a configured channel disconnect/degradation, a failed channel probe, or unavailable channel credentials. A newer event replaces the pending chip only when it is more severe; dismissing or using the chip silences event prompts for that visit. Clicking the chip sends its diagnosis question as a real `openclaw.chat` message, so the transcript records the request and OpenClaw performs the diagnosis. Onboarding never shows these event chips.
+Open **Settings → Ask OpenClaw** to talk to the system setup and repair agent. The page renders a centered chat with the animated OpenClaw mascot, which switches to a thinking pose while a turn is in flight. The conversation is not trapped in Settings: the lobster button in the thread workspace rail toggles the same live session as a dockable panel (right or bottom, with placement and size persisted in the browser profile), and leaving the full page mid-conversation automatically minimizes the chat into that dock so the session follows you. The dock hides itself while the full Ask OpenClaw page is open.
+
+Each chat message carries the Control UI page you are currently viewing as an untrusted ambient hint, so requests like "configure this channel" or "why is this page empty?" resolve against the page you are looking at.
+
+Guided channel setup, workspace skills setup, and web-search provider setup run as hosted wizards inside the chat: wizard steps render as structured question cards, secret steps mask input in the browser, and every applied write is approved, audited, and re-validated. If a chosen web-search provider needs a plugin install and that install fails, setup stops and reports the failure instead of pretending the provider is configured. See [`openclaw setup`](/cli/openclaw) for the operation and approval contract.
+
+Outside onboarding, this page can show at most one dismissible event chip per visit. It stays silent for routine Gateway traffic and reacts only to health snapshots that report a disabled configuration reloader, a configured channel disconnect/degradation, a failed channel probe, or unavailable channel credentials. A newer event replaces the pending chip only when it is more severe; dismissing or using the chip silences event prompts for that visit. Clicking the chip sends its diagnosis question as a real `openclaw.chat` message, so the transcript records the request and OpenClaw performs the diagnosis. Onboarding never shows these event chips.
 
 ## Manage plugins
 


### PR DESCRIPTION
### What Problem This Solves

Three merged PRs changed user-visible Ask OpenClaw behavior with no docs coverage: #114943 (ambient page context from the Control UI), #115123 (mascot avatars, centered layout, dockable Ask OpenClaw panel with minimize-on-leave, lobster toggle in the thread workspace rail), and #115130 (hosted `configure skills` / `configure web search` wizards in chat, honest `SearchSetupResult` failure reporting, `open search wizard` terminal handoff). The pages named in the #115130 docs follow-up were stale.

### Why This Change Was Made

Repo rule: docs change with behavior. This is the coordinator-owned docs follow-up promised in #115130's PR body, covering all three landings in one scoped docs pass:

- `docs/web/control-ui.md`: the OpenClaw system care section now describes the mascot/centered chat, the dockable panel (right/bottom, persisted, lobster toggle in the thread workspace rail, auto-minimize into the dock when leaving the page mid-conversation), the per-message ambient page hint, and the hosted channel/skills/search wizards with masked secret input and honest install-failure reporting.
- `docs/cli/openclaw.md`: guided-setup operations now list `configure skills` and `configure web search` alongside `connect <channel>`, document the install-failure honesty contract, and the masked-wizard handoff section covers `open search wizard` (heading generalized to "Switching to a masked terminal wizard"; no inbound anchor links existed).
- `docs/cli/setup.md`, `docs/start/wizard.md`, `docs/tools/web.md`: cross-references to the conversational skills/search setup paths and the masked-wizard handoff.

### User Impact

Docs-only. Users can now discover that Ask OpenClaw follows them as a dockable panel, that "this page" references resolve from ambient page context, and that skills and web-search setup run as in-chat conversations with a masked terminal handoff for secrets.

### Evidence

- Behavior verified against source, not PR prose: command grammar in `src/system-agent/operations-parse.ts` (`configure skills`, `configure web search`, `open search wizard`), CLI sensitive-step handoff in `src/system-agent/chat-engine.ts`, `SearchSetupResult` union in `src/flows/search-setup.ts`, page-context sanitizer in `src/gateway/server-methods/system-agent-chat-params.ts`, dock/minimize logic in `ui/src/components/custodian/custodian-panel.ts` and `ui/src/app/app-host.ts`.
- `git diff --check` clean; `oxfmt --check` clean on all five pages; internal links stay root-relative per docs guide; no front-matter titles changed (i18n glossary guard unaffected).
- Checked for inbound links to the renamed heading anchor: none.
