### PR TITLE
fix: keep gateway nodes and local inference reliable under stress

### DIFF
--- a/extensions/ollama/src/node-inference.test.ts
+++ b/extensions/ollama/src/node-inference.test.ts
@@ -27,7 +27,10 @@ async function withOllamaServer<T>(
     chatRequests: Record<string, unknown>[],
     showRequests: string[],
   ) => Promise<T>,
-  options?: { models: Array<Record<string, unknown>> },
+  options?: {
+    models: Array<Record<string, unknown>>;
+    loadedModels?: Array<Record<string, unknown>>;
+  },
 ): Promise<T> {
   const chatRequests: Record<string, unknown>[] = [];
   const showRequests: string[] = [];
@@ -72,7 +75,7 @@ async function withOllamaServer<T>(
       return;
     }
     if (request.url === "/api/ps") {
-      response.end(JSON.stringify({ models: [{ name: "chat:large" }] }));
+      response.end(JSON.stringify({ models: options?.loadedModels ?? [{ name: "chat:large" }] }));
       return;
     }
     if (request.url === "/api/show") {
@@ -191,6 +194,29 @@ describe("Ollama node host inference", () => {
         expect(showRequests).toHaveLength(201);
       },
       { models },
+    );
+  });
+
+  it("discovers a loaded local model beyond the completion model limit", async () => {
+    const models = [
+      ...Array.from({ length: 200 }, (_, index) => ({ name: `chat-${index}:latest` })),
+      { name: "chat:loaded", size: 500 },
+    ];
+
+    await withOllamaServer(
+      async (baseUrl, _chatRequests, showRequests) => {
+        const result = JSON.parse(await commandByName(baseUrl, OLLAMA_MODELS_COMMAND).handle()) as {
+          provider: string;
+          models: Array<{ name: string; loaded: boolean }>;
+        };
+
+        expect(result.provider).toBe("ollama");
+        expect(result.models).toHaveLength(200);
+        expect(result.models[0]).toMatchObject({ name: "chat:loaded", loaded: true });
+        expect(showRequests[0]).toBe("chat:loaded");
+        expect(showRequests).toHaveLength(200);
+      },
+      { models, loadedModels: [{ name: "chat:loaded" }] },
     );
   });
 

--- a/extensions/ollama/src/node-inference.ts
+++ b/extensions/ollama/src/node-inference.ts
@@ -188,12 +188,16 @@ async function discoverOllamaNodeModels(
   const localModels = discovered.models.filter(
     (model) => !model.remote_host?.trim() && !isOllamaCloudModel(model.name),
   );
-  const [models, loadedNames] = await Promise.all([
-    // Paired nodes must positively confirm completion; unlike provider catalogs,
-    // failed or legacy show probes must never expose unrunnable remote commands.
-    enrichOllamaCompletionModels(apiBase, localModels, { requireCompletionCapability: true }),
-    fetchLoadedModelNames(apiBase),
-  ]);
+  const loadedNames = await fetchLoadedModelNames(apiBase);
+  // Probe loaded models before the bounded catalog can hide already-runnable node models.
+  const prioritizedModels = localModels.toSorted(
+    (left, right) => Number(loadedNames.has(right.name)) - Number(loadedNames.has(left.name)),
+  );
+  // Paired nodes must positively confirm completion; unlike provider catalogs,
+  // failed or legacy show probes must never expose unrunnable remote commands.
+  const models = await enrichOllamaCompletionModels(apiBase, prioritizedModels, {
+    requireCompletionCapability: true,
+  });
   const rows = models
     .map((model): NodeModel => {
       const details = model.details;

--- a/extensions/sglang/models.ts
+++ b/extensions/sglang/models.ts
@@ -15,6 +15,7 @@ export async function buildSglangProvider(params?: {
     baseUrl,
     apiKey: params?.apiKey,
     label: SGLANG_PROVIDER_LABEL,
+    discoverRuntimeContext: false,
   });
   return {
     baseUrl,

--- a/extensions/vllm/models.ts
+++ b/extensions/vllm/models.ts
@@ -15,6 +15,7 @@ export async function buildVllmProvider(params?: {
     baseUrl,
     apiKey: params?.apiKey,
     label: VLLM_PROVIDER_LABEL,
+    discoverRuntimeContext: false,
   });
   return {
     baseUrl,

--- a/qa/scenarios/models/ollama-paired-node-inference.yaml
+++ b/qa/scenarios/models/ollama-paired-node-inference.yaml
@@ -1,0 +1,30 @@
+title: Ollama paired-node local inference regression
+
+scenario:
+  id: ollama-paired-node-inference
+  surface: models
+  category: agent-runtime.local-and-self-hosted-providers
+  coverage:
+    secondary:
+      - gateway.node-capabilities
+      - gateway.remote-host-commands
+      - agent-runtime.tool-capability-flags
+      - agent-runtime.local-smoke-checks
+      - agent-runtime.local-failure-handling
+  objective: Verify paired-node Ollama discovery and inference with the provider-owned deterministic local test server.
+  successCriteria:
+    - Embedding and cloud models are excluded from local chat discovery.
+    - A chat model after 200 embedding-only models remains discoverable.
+    - Loaded local chat models sort first.
+    - Only Gateway-authorized node commands are invoked.
+    - Bounded local chat returns the expected response and usage.
+  docsRefs:
+    - docs/providers/ollama.md
+    - docs/nodes/index.md
+  codeRefs:
+    - extensions/ollama/src/node-inference.ts
+    - extensions/ollama/src/node-inference.test.ts
+  execution:
+    kind: vitest
+    path: extensions/ollama/src/node-inference.test.ts
+    summary: Run deterministic fake-Ollama paired-node discovery, authorization, model-selection, and bounded-chat regression tests.

--- a/src/cli/node-cli/daemon.test.ts
+++ b/src/cli/node-cli/daemon.test.ts
@@ -200,6 +200,31 @@ describe("runNodeDaemonStatus", () => {
     mocks.service.readRuntime.mockReset().mockResolvedValue({ status: "running" });
   });
 
+  it("reports a failed service check instead of claiming the node is not installed", async () => {
+    mocks.service.isLoaded.mockRejectedValue(new Error("systemd unavailable"));
+
+    await runNodeDaemonStatus();
+
+    expect(mocks.runtime.error).toHaveBeenCalledWith(
+      "Node service check failed: Error: systemd unavailable",
+    );
+    expect(mocks.runtime.exit).toHaveBeenCalledWith(1);
+    expect(stdout()).not.toContain("not loaded");
+    expect(stdout()).not.toContain("openclaw node install");
+  });
+
+  it("reports a failed service check as JSON without inventing node status", async () => {
+    mocks.service.isLoaded.mockRejectedValue(new Error("systemd unavailable"));
+
+    await runNodeDaemonStatus({ json: true });
+
+    expect(mocks.runtime.writeJson).toHaveBeenCalledWith({
+      error: "Node service check failed: Error: systemd unavailable",
+    });
+    expect(mocks.runtime.exit).toHaveBeenCalledWith(1);
+    expect(mocks.runtime.error).not.toHaveBeenCalled();
+  });
+
   it("keeps missing service-unit status on stderr and prints recovery hints on stdout", async () => {
     mocks.service.readRuntime.mockResolvedValue({ status: "stopped", missingUnit: true });
 

--- a/src/cli/node-cli/daemon.ts
+++ b/src/cli/node-cli/daemon.ts
@@ -215,8 +215,20 @@ export async function runNodeDaemonStop(opts: NodeDaemonLifecycleOptions = {}) {
 export async function runNodeDaemonStatus(opts: NodeDaemonStatusOptions = {}) {
   const json = Boolean(opts.json);
   const service = resolveNodeService();
-  const [loaded, command, runtime] = await Promise.all([
-    service.isLoaded({ env: process.env }).catch(() => false),
+  let loaded: boolean;
+  try {
+    loaded = await service.isLoaded({ env: process.env });
+  } catch (error) {
+    const message = `Node service check failed: ${String(error)}`;
+    if (json) {
+      defaultRuntime.writeJson({ error: message });
+    } else {
+      defaultRuntime.error(message);
+    }
+    defaultRuntime.exit(1);
+    return;
+  }
+  const [command, runtime] = await Promise.all([
     service.readCommand(process.env).catch(() => null),
     service
       .readRuntime(process.env)

--- a/src/node-host/invoke.mcp.test.ts
+++ b/src/node-host/invoke.mcp.test.ts
@@ -132,6 +132,7 @@ describe("mcp.tools.call.v1", () => {
       { signal: controller.signal },
     );
     await vi.waitFor(() => expect(callMcpTool).toHaveBeenCalledOnce());
+    expect(callMcpTool.mock.calls[0]?.[0].signal).toBe(controller.signal);
 
     controller.abort();
     resolveTool?.({ content: [{ type: "text", text: "stale MCP result" }] });

--- a/src/node-host/invoke.ts
+++ b/src/node-host/invoke.ts
@@ -720,7 +720,7 @@ async function dispatchInvoke(
   }
 
   if (command === NODE_MCP_TOOLS_CALL_COMMAND) {
-    await handleMcpToolsCall(frame, client, mcpManager);
+    await handleMcpToolsCall(frame, client, mcpManager, runtime.signal);
     return;
   }
 
@@ -1009,6 +1009,7 @@ async function handleMcpToolsCall(
   frame: NodeInvokeRequestPayload,
   client: NodeHostClient,
   mcpManager: NodeHostMcpManager | undefined,
+  signal?: AbortSignal,
 ): Promise<void> {
   if (!mcpManager) {
     await sendErrorResult(client, frame, "MCP_SERVER_UNAVAILABLE", "node host MCP is unavailable");
@@ -1025,6 +1026,7 @@ async function handleMcpToolsCall(
     const result = await mcpManager.callMcpTool({
       ...params,
       timeoutMs: frame.timeoutMs ?? undefined,
+      ...(signal ? { signal } : {}),
     });
     if (result.isError) {
       await sendErrorResult(client, frame, "MCP_TOOL_ERROR", mcpToolErrorMessage(result));

--- a/src/node-host/mcp.test.ts
+++ b/src/node-host/mcp.test.ts
@@ -18,7 +18,7 @@ function tool(name: string, description?: string): Tool {
 function createClient(params?: {
   connectError?: Error;
   tools?: Tool[];
-  call?: (options?: { timeout?: number }) => Promise<CallToolResult>;
+  call?: (options?: { timeout?: number; signal?: AbortSignal }) => Promise<CallToolResult>;
 }) {
   return {
     onclose: undefined as (() => void) | undefined,
@@ -32,7 +32,7 @@ function createClient(params?: {
       async (
         _input: unknown,
         _schema?: undefined,
-        options?: { timeout?: number },
+        options?: { timeout?: number; signal?: AbortSignal },
       ): Promise<CallToolResult> =>
         params?.call ? await params.call(options) : { content: [{ type: "text", text: "ok" }] },
     ),
@@ -204,6 +204,44 @@ describe("node host MCP manager", () => {
       false,
     );
     expect(Buffer.byteLength(JSON.stringify(manager.descriptors))).toBeLessThan(10 * 1024 * 1024);
+    await manager.close();
+  });
+
+  it("cancels an in-flight MCP tool when its node invocation is aborted", async () => {
+    const controller = new AbortController();
+    const client = createClient({
+      tools: [tool("slow")],
+      call: async (options) =>
+        await new Promise<CallToolResult>((_resolve, reject) => {
+          options?.signal?.addEventListener(
+            "abort",
+            () => {
+              const reason = options.signal?.reason;
+              reject(reason instanceof Error ? reason : new Error("node invocation canceled"));
+            },
+            { once: true },
+          );
+        }),
+    });
+    const manager = await startNodeHostMcpManager(
+      { docs: { command: "docs" } },
+      { createClient: () => client, resolveTransport: () => transport, warn: vi.fn() },
+    );
+
+    const pending = manager.callMcpTool({
+      server: "docs",
+      tool: "slow",
+      signal: controller.signal,
+    });
+    await vi.waitFor(() => expect(client.callTool).toHaveBeenCalledOnce());
+    expect(client.callTool).toHaveBeenCalledWith({ name: "slow", arguments: {} }, undefined, {
+      timeout: 120_000,
+      signal: controller.signal,
+    });
+
+    controller.abort(new Error("node invocation canceled"));
+
+    await expect(pending).rejects.toMatchObject({ code: "MCP_TOOL_ERROR" });
     await manager.close();
   });
 

--- a/src/node-host/mcp.ts
+++ b/src/node-host/mcp.ts
@@ -40,7 +40,7 @@ type NodeHostMcpClient = {
   callTool(
     params: { name: string; arguments?: Record<string, unknown> },
     resultSchema?: undefined,
-    options?: { timeout?: number },
+    options?: { timeout?: number; signal?: AbortSignal },
   ): Promise<CallToolResult>;
   close(): Promise<void>;
 };
@@ -84,6 +84,7 @@ export type NodeHostMcpManager = {
     tool: string;
     arguments?: Record<string, unknown>;
     timeoutMs?: number;
+    signal?: AbortSignal;
   }): Promise<CallToolResult>;
   close(): Promise<void>;
 };
@@ -397,6 +398,7 @@ export async function startNodeHostMcpManager(
           undefined,
           {
             timeout: Math.min(resolveCallTimeoutMs(params.timeoutMs), session.toolCallTimeoutMs),
+            ...(params.signal ? { signal: params.signal } : {}),
           },
         );
       } catch (error) {

--- a/src/plugins/provider-self-hosted-setup.test.ts
+++ b/src/plugins/provider-self-hosted-setup.test.ts
@@ -147,6 +147,32 @@ function cancelTrackedResponse(init?: ResponseInit): {
 }
 
 describe("discoverOpenAICompatibleLocalModels", () => {
+  it("discovers a large non-llama.cpp catalog without probing per-model llama.cpp props", async () => {
+    const release = vi.fn(async () => undefined);
+    const data = Array.from({ length: 500 }, (_, index) => ({
+      id: `Qwen/model-${index}`,
+      meta: { n_ctx_train: 32_768 },
+    }));
+    fetchWithSsrFGuardMock.mockResolvedValueOnce({
+      response: new Response(JSON.stringify({ data }), { status: 200 }),
+      finalUrl: "http://127.0.0.1:8000/v1/models",
+      release,
+    });
+
+    const models = await discoverOpenAICompatibleLocalModels({
+      baseUrl: "http://127.0.0.1:8000/v1",
+      label: "vLLM",
+      discoverRuntimeContext: false,
+      env: {},
+    });
+
+    expect(models).toHaveLength(500);
+    expect(models[0]).toMatchObject({ id: "Qwen/model-0", contextWindow: 32_768 });
+    expect(models[499]).toMatchObject({ id: "Qwen/model-499", contextWindow: 32_768 });
+    expect(fetchWithSsrFGuardMock).toHaveBeenCalledOnce();
+    expect(release).toHaveBeenCalledOnce();
+  });
+
   it("labels malformed discovery JSON in the warning", async () => {
     const release = vi.fn(async () => undefined);
     fetchWithSsrFGuardMock.mockResolvedValueOnce({

--- a/src/plugins/provider-self-hosted-setup.ts
+++ b/src/plugins/provider-self-hosted-setup.ts
@@ -167,6 +167,7 @@ export async function discoverOpenAICompatibleLocalModels(params: {
   apiKey?: string;
   label: string;
   contextWindow?: number;
+  discoverRuntimeContext?: boolean;
   maxTokens?: number;
   env?: NodeJS.ProcessEnv;
 }): Promise<ModelDefinitionConfig[]> {
@@ -212,7 +213,7 @@ export async function discoverOpenAICompatibleLocalModels(params: {
         return [{ id: modelId, meta: model.meta }];
       });
       const runtimeContextTokensByModelId = new Map<string, number>();
-      if (params.contextWindow === undefined) {
+      if (params.contextWindow === undefined && params.discoverRuntimeContext !== false) {
         const uniqueModelIds = uniqueStrings(discoveredModels.map((model) => model.id));
         const runtimeContextTokenResults = await Promise.all(
           uniqueModelIds.map(


### PR DESCRIPTION
## What Problem This Solves

Fixes issues where users connecting a node to a gateway could leave cancelled MCP inference and tools running, see an inaccessible node service incorrectly reported as not installed, lose an already-loaded Ollama model from large catalogs, or trigger hundreds of unsupported llama.cpp discovery requests against vLLM and SGLang.

## Why This Change Was Made

Propagate the existing node invocation AbortSignal into the verified MCP SDK request, prioritize loaded Ollama models before the bounded capability probe, fail node status closed in text and JSON, and let non-llama.cpp providers opt out of llama.cpp runtime-context discovery without changing existing defaults. Add a permanent executable paired-node Ollama QA scenario with secondary-only coverage claims.

AI-assisted; independently reviewed with no accepted or actionable findings.

## User Impact

Gateway nodes stop cooperating MCP work on cancellation; node status reports real service-manager failures; already-running local Ollama models stay discoverable; and large vLLM/SGLang catalogs complete with one model-discovery request instead of an unnecessary request per model.

## Evidence

Frozen baseline: 20eda756fae6599bc9d776815016f555a64d77d6. Actual Blacksmith Testbox lease: tbx_01kym882qc38gw03c2f0fk8x5g.

### Before-fix cancellation reproduction

The new SDK-facing and node-dispatch regressions were first run against unchanged production source and both failed:

```text
FAIL src/node-host/invoke.mcp.test.ts
does not publish an MCP result after its invocation is canceled
AssertionError: expected undefined to be AbortSignal { aborted: false }

FAIL src/node-host/mcp.test.ts
cancels an in-flight MCP tool when its node invocation is aborted
Expected call options: { timeout: 120000, signal: AbortSignal }
Received call options: { timeout: 120000 }

Test Files  2 failed (2)
Tests       2 failed | 13 passed (15)
```

### Direct installed SDK contract

Personally inspected the actual installed @modelcontextprotocol/sdk version 1.30.0, rather than relying on mocks or wrappers:

```text
node_modules/@modelcontextprotocol/sdk/package.json
  version: 1.30.0

node_modules/@modelcontextprotocol/sdk/dist/esm/shared/protocol.d.ts:61-76
  export type RequestOptions = {
    signal?: AbortSignal;
    timeout?: number;
  }

node_modules/@modelcontextprotocol/sdk/dist/esm/client/index.d.ts:431
  callTool(params, resultSchema?, options?: RequestOptions)

node_modules/@modelcontextprotocol/sdk/dist/esm/client/index.js:479
  return this.request({ method: "tools/call", params }, resultSchema, options)

node_modules/@modelcontextprotocol/sdk/dist/esm/shared/protocol.js:610-710
  options.signal.throwIfAborted()
  options.signal.addEventListener("abort", ...)
  sends notifications/cancelled with the original requestId and reason

node_modules/@modelcontextprotocol/sdk/dist/esm/shared/protocol.js:20-30,169-176
  remote CancelledNotificationSchema aborts the matching server request controller
```

Thus the patch cancels the cooperating remote MCP tool, not merely its local result.

### After-fix isolated paired-node and mixed QA evidence

Real remote command:

```text
pnpm openclaw qa suite --provider-mode mock-openai --fail-fast --concurrency 4
  --scenario ollama-paired-node-inference
  --scenario gateway-smoke
  --scenario mcp-gateway-connect-startup-retry
  --scenario model-switch-follow-up
  --scenario model-switch-tool-continuity
  --scenario provider-http-503-visible-failure
  --output-dir .artifacts/qa-e2e/node-local-inference-verified-20eda756
```

Independently parsed and asserted both real QA evidence files:

```json
{
  "counts": { "total": 6, "passed": 6, "failed": 0, "skipped": 0 },
  "providerMode": "mock-openai",
  "results": {
    "model-switch-follow-up": "pass",
    "model-switch-tool-continuity": "pass",
    "ollama-paired-node-inference": "pass",
    "provider-http-503-visible-failure": "pass",
    "gateway-smoke": "pass",
    "mcp-gateway-connect-startup-retry": "pass"
  }
}
```

The Ollama scenario runs its actual provider-owned 127.0.0.1 fake server and verifies the loaded 201st completion-capable model is returned first after exactly 200 capability probes. Gateway and MCP smoke scenarios start isolated real gateway children; model-switch and provider-error scenarios use the explicitly declared mock provider.

### Full regression and gate output

```text
node and local inference stress pass 1: 54 passed, 0 failed
node and local inference stress pass 2: 54 passed, 0 failed
node and local inference stress pass 3: 54 passed, 0 failed

Broad node/gateway/local-provider/QA matrix:
  10 Vitest shards; more than 1,100 tests passed
  node host, node CLI, paired-node gateway/wake, browser gateway,
  Ollama, LM Studio, vLLM, SGLang, llama.cpp, QA catalog

pnpm check:changed
  full project typecheck: pass
  oxlint core: 0 warnings, 0 errors
  oxlint extensions: 0 warnings, 0 errors
  oxlint scripts: 0 warnings, 0 errors
  plugin SDK API baseline: pass
  plugin boundaries: pass
  database-first guard: pass
  formatting: pass
  runtime import cycles: 0
  exitCode: 0
```

Fresh independent autoreview: no accepted or actionable findings.

### Separate discovered baseline issue

Creative stress also reproduced a separate gateway-restart-inflight-run baseline failure: the existing QA helper terminates an active gateway and its SQLite session-write lease before restart recovery. It is intentionally not masked or included; changing shutdown semantics or SQLite fencing requires a separately reviewed persistence-safe fix.
