### PR TITLE
fix(ui): stop route aliases from hijacking base-path inference on settings deep links

### DIFF
--- a/ui/src/app-navigation.test.ts
+++ b/ui/src/app-navigation.test.ts
@@ -707,6 +707,23 @@ describe("inferBasePathFromPathname", () => {
     expect(inferBasePathFromPathname("/index.html")).toBe("");
     expect(inferBasePathFromPathname("/ui/index.html")).toBe("/ui");
   });
+
+  it("never infers a route namespace as a mount base", () => {
+    // "/settings/config" is not a route; matching the "/config" alias must not
+    // rescope the page to base "/settings" or reconnect state and assets break.
+    expect(inferBasePathFromPathname("/settings/config")).toBe("");
+    expect(inferBasePathFromPathname("/settings/config/")).toBe("");
+    expect(inferBasePathFromPathname("/settings/chat/main")).toBe("");
+    // A leaf route is equally not a mount directory.
+    expect(inferBasePathFromPathname("/custodian/config")).toBe("");
+    // Nested unknown segments below a route namespace stay root-mounted too.
+    expect(inferBasePathFromPathname("/settings/other/config")).toBe("");
+    expect(inferBasePathFromPathname("/settings/")).toBe("");
+    expect(inferBasePathFromPathname("/skills/")).toBe("");
+    // Real mount directories that merely contain a route-suffix keep working.
+    expect(inferBasePathFromPathname("/ui/config")).toBe("/ui");
+    expect(inferBasePathFromPathname("/ui/settings/general")).toBe("/ui");
+  });
 });
 
 describe("plugin tabs route", () => {

--- a/ui/src/app-route-paths.ts
+++ b/ui/src/app-route-paths.ts
@@ -152,6 +152,40 @@ export function routeIdFromPath(pathname: string, basePath = ""): RouteId | null
   return null;
 }
 
+function collectRoutePaths(): string[] {
+  return APP_ROUTE_IDS.flatMap((routeId) => {
+    const definition = APP_ROUTE_DEFINITIONS[routeId];
+    const paths: string[] = [definition.path];
+    if ("aliases" in definition) {
+      paths.push(...definition.aliases);
+    }
+    return paths;
+  });
+}
+
+// A candidate mount base that is a registered route ("/custodian"), or that
+// sits at or below a multi-segment route namespace ("/settings", including
+// "/settings/other"), is really a root-mounted deep link whose suffix happens
+// to match a route path or alias. Descendants of leaf routes stay valid mount
+// directories so "/apps/openclaw" keeps working. Inference is a last-resort
+// fallback for pages served without the injected base path (vite dev, static
+// hosting); accepted tradeoff: namespaces nested under a real mount prefix
+// ("/ui/settings/other/config") are not rescued here.
+function isRouteOwnedBasePath(basePath: string): boolean {
+  const routePaths = collectRoutePaths().map((path) => normalizePath(path));
+  if (routePaths.includes(basePath)) {
+    return true;
+  }
+  const segments = basePath.split("/").filter(Boolean);
+  for (let count = 1; count <= segments.length; count += 1) {
+    const ancestor = `/${segments.slice(0, count).join("/")}`;
+    if (routePaths.some((path) => path.startsWith(`${ancestor}/`))) {
+      return true;
+    }
+  }
+  return false;
+}
+
 export function inferBasePathFromPathname(pathname: string): string {
   const isMountRoot = pathname.trim().endsWith("/");
   const normalizedPath = normalizePath(pathname);
@@ -162,14 +196,7 @@ export function inferBasePathFromPathname(pathname: string): string {
     return "";
   }
   const segments = normalizedPath.split("/").filter(Boolean);
-  const routePaths = APP_ROUTE_IDS.flatMap((routeId) => {
-    const definition = APP_ROUTE_DEFINITIONS[routeId];
-    const paths: string[] = [definition.path];
-    if ("aliases" in definition) {
-      paths.push(...definition.aliases);
-    }
-    return paths;
-  });
+  const routePaths = collectRoutePaths();
   for (let index = 0; index < segments.length; index += 1) {
     const candidate = `/${segments.slice(index).join("/")}`;
     const routePath = routePaths.find((path) => normalizePath(path) === candidate);
@@ -189,9 +216,20 @@ export function inferBasePathFromPathname(pathname: string): string {
     ) {
       return "";
     }
-    return index ? `/${segments.slice(0, index).join("/")}` : "";
+    if (index === 0) {
+      return "";
+    }
+    const basePath = `/${segments.slice(0, index).join("/")}`;
+    // Mis-inferring a route-owned base ("/settings/config" -> "/settings" via
+    // the "/config" alias) rescopes stored gateway settings and asset URLs, so
+    // a connected browser deep-links straight into the login gate.
+    return isRouteOwnedBasePath(basePath) ? "" : basePath;
   }
-  return isMountRoot && segments.length ? `/${segments.join("/")}` : "";
+  if (!isMountRoot || segments.length === 0) {
+    return "";
+  }
+  const mountRootBase = `/${segments.join("/")}`;
+  return isRouteOwnedBasePath(mountRootBase) ? "" : mountRootBase;
 }
 
 export function locationForRoute(routeId: RouteId, basePath: string): RouteLocation {

--- a/ui/src/app/settings.node.test.ts
+++ b/ui/src/app/settings.node.test.ts
@@ -125,6 +125,24 @@ describe("loadSettings default gateway URL derivation", () => {
     vi.unstubAllGlobals();
   });
 
+  it("keeps IPv6 dev-page default gateway hosts dialable", () => {
+    setTestLocation({ protocol: "http:", host: "[::1]:5173", pathname: "/" });
+    // A vite client script marks the page as dev, which reroutes the default
+    // gateway to port 18789 via formatHostWithPort.
+    vi.stubGlobal("document", {
+      querySelector: (selector: string) => (selector.includes("@vite/client") ? {} : null),
+      documentElement: { getAttribute: () => null },
+    } as unknown as Document);
+
+    try {
+      expect(loadSettings().gatewayUrl).toBe("ws://[::1]:18789");
+    } finally {
+      // The document stub is unique to this test; drop it before the shared
+      // afterEach persistence pass instead of leaving it to unstubAllGlobals.
+      vi.unstubAllGlobals();
+    }
+  });
+
   it("uses configured base path and normalizes trailing slash", () => {
     setTestLocation({
       protocol: "https:",

--- a/ui/src/app/settings.ts
+++ b/ui/src/app/settings.ts
@@ -225,7 +225,10 @@ function isViteDevPage(): boolean {
 }
 
 function formatHostWithPort(hostname: string, port: string): string {
-  const normalizedHost = hostname.includes(":") ? `[${hostname}]` : hostname;
+  // location.hostname already carries brackets for IPv6 literals; wrapping
+  // again would produce an undialable ws://[[::1]]:port default.
+  const needsBrackets = hostname.includes(":") && !hostname.startsWith("[");
+  const normalizedHost = needsBrackets ? `[${hostname}]` : hostname;
   return `${normalizedHost}:${port}`;
 }
 


### PR DESCRIPTION
## What Problem This Solves

Deep-loading `http://localhost:5173/settings/config` in the Control UI (vite dev, or any page served without the injected base path) rendered the standalone "Gateway Dashboard" login form with "Could not connect", even though the browser had valid stored gateway settings and an approved device identity. A direct load of `/settings/connection` (or `/`) reconnected fine.

Root cause: `/settings/config` is not a registered route, but `inferBasePathFromPathname` matched its `/config` suffix against the `config` route's `/config` alias and inferred `"/settings"` as a mount base. That rescoped everything derived from the page URL: the gateway-selection pointer (`openclaw.control.currentGateway.v1:<pageUrl>`) missed, so boot fell back to the default gateway URL (`ws://localhost:18789`), dialed the wrong place, failed, and pinned the login gate. Asset URLs and the bootstrap-config fetch broke the same way (broken logo on the gate). Reproduced deterministically on a clean profile; it is long-standing behavior, not a same-day regression — whether it "worked" depended on whether a stray selection pointer existed under the `.../settings` page scope in localStorage. #114828 was investigated and is not involved.

## Why This Change Was Made

A candidate mount base that is a registered route ("/custodian"), or that sits at or below a multi-segment route namespace ("/settings", "/settings/other"), can never be a real mount directory — treating it as one silently disconnects the browser from its stored gateway. Root interpretation must win so every settings deep link boots through the same reconnect path. Descendants of leaf routes ("/apps/openclaw") remain valid mount bases, preserving the documented mount inference contract.

Also fixes `deriveDefaultGatewayUrl` double-bracketing IPv6 literal hostnames (`ws://[[::1]]:18789`), observed on the same boot path during the live repro.

## User Impact

All `/settings/*` deep links (known or unknown) now reconnect uniformly with stored settings and device identity: real routes render their page, unknown paths land on the connected default view. No more surprise login gate with "Could not connect" for `/settings/config`-style URLs. IPv6-hosted dev pages get a dialable default gateway URL.

## Evidence

- Live repro before fix (vite dev on `[::1]:5299` + scratch gateway on `19790`, clean profile, connected once, device approved): fresh-tab `/settings/connection` reconnects; fresh-tab `/settings/config` boots the login gate showing the default `ws://[[::1]]:18789` instead of the stored gateway, and localStorage gains a fabricated `currentGateway.v1:ws://[::1]:5299/settings` pointer.
- Live after fix: fresh-tab `/settings/config` boots the connected shell against the stored gateway; `/settings/connection` and `/settings/general` unchanged.
- `node scripts/run-vitest.mjs run ui/src/app-navigation.test.ts ui/src/app/settings.node.test.ts` — 115 tests green, including new regression tests for `/settings/config`, `/settings/config/`, `/settings/chat/main`, `/settings/`, `/custodian/config`, `/settings/other/config`, and preserved mount cases (`/ui/config`, `/ui/settings/general`, `/apps/openclaw/sessions`).
- `node scripts/check-changed.mjs` delegated to Blacksmith Testbox: typecheck core tests, typecheck UI, lint, format, i18n verify all green (exit 0).
- Codex autoreview (gpt-5.6-sol, xhigh): two accepted findings fixed (leaf-route bases, nested namespace bases); final remaining finding consciously rejected as pre-existing behavior for namespaces nested under a real mount prefix (`/ui/settings/other/config`), which real deployments never hit because served pages get the injected base path; tradeoff documented inline.
