### PR TITLE
test(ui): pause fake clock before send so working-timer e2e assertions are deterministic

### DIFF
--- a/ui/src/e2e/chat-run-lifecycle.e2e.test.ts
+++ b/ui/src/e2e/chat-run-lifecycle.e2e.test.ts
@@ -109,6 +109,10 @@ describeControlUiE2e("Control UI chat run lifecycle", () => {
     await currentPage.goto(`${server?.baseUrl ?? ""}chat`);
     await currentPage.getByText("saved 875.3k tokens", { exact: true }).waitFor();
     await currentPage.locator(".agent-chat__input textarea").fill("keep working");
+    // Pause the virtual clock before sending: the working timer starts at the
+    // send click, and an unpaused installed clock still ticks in real time,
+    // letting slow CI inflate the fast-forwarded "2m 57s" to "2m 59s".
+    await currentPage.clock.pauseAt((await currentPage.evaluate(() => Date.now())) + 5_000);
     await currentPage.getByRole("button", { name: "Send message" }).click();
     await gateway.waitForRequest("chat.send");
     await currentPage.locator(".chat-working-indicator").waitFor();

--- a/ui/src/e2e/mantis-chat-proof.e2e.test.ts
+++ b/ui/src/e2e/mantis-chat-proof.e2e.test.ts
@@ -96,6 +96,10 @@ describeMantisWebUiChat("Mantis Control UI web chat proof", () => {
       await page.goto(`${server.baseUrl}chat`);
       await page.getByText("Mantis web UI proof is ready.").waitFor({ timeout: 10_000 });
       await page.locator(".agent-chat__composer-combobox textarea").fill(prompt);
+      // Pause the virtual clock before sending: the working timer starts at the
+      // send click, and an unpaused installed clock still ticks in real time,
+      // letting slow CI inflate the fast-forwarded "2m 57s" to "2m 59s".
+      await page.clock.pauseAt((await page.evaluate(() => Date.now())) + 5_000);
       await page.getByRole("button", { name: "Send message" }).click();
 
       const sendRequest = await gateway.waitForRequest("chat.send");


### PR DESCRIPTION
## What Problem This Solves

`ui/src/e2e/mantis-chat-proof.e2e.test.ts` has a flaky timing assertion: on PR #115123's `checks-ui-e2e` attempt 2 (2026-07-28, unrelated branch) it failed with `expected '2m 57s', received '2m 59s'`. The sibling test in `ui/src/e2e/chat-run-lifecycle.e2e.test.ts` ("shows compaction savings and live working time") has the identical pattern and the same latent flake.

## Why This Change Was Made

Both tests install a fake Playwright clock but never pause it. `page.clock.install()` keeps the virtual clock ticking at real-time rate until it is paused, and the working indicator's `startMs` is captured from the page's `Date.now()` at the send click (queue item `createdAt`, min-reduced in `ui/src/pages/chat/chat-progress.ts`). So the elapsed value the test asserts is `fastForward(177_000)` **plus** however many real seconds CI took between the send click and the `fastForward` call — on a slow runner that inflates "2m 57s" to "2m 59s".

The fix pauses the virtual clock (`page.clock.pauseAt(now + 5s)`) immediately before the send click, so virtual time advances only through `fastForward` and the elapsed reading is exactly 177s, deterministically. This matches the existing repo pattern in `ui/src/e2e/lobster-pet.e2e.test.ts`.

## User Impact

None — test-only change. CI's `checks-ui-e2e` lane stops flaking on this assertion.

## Evidence

Both changed specs pass locally:

```text
$ node scripts/run-vitest.mjs ui/src/e2e/mantis-chat-proof.e2e.test.ts
 Test Files  1 passed (1)
      Tests  1 passed (1)

$ node scripts/run-vitest.mjs ui/src/e2e/chat-run-lifecycle.e2e.test.ts
 Test Files  1 passed (1)
      Tests  4 passed (4)
```

**Determinism proof (before/after with simulated CI slowness).** Injecting a real-time `await page.waitForTimeout(2_500)` between the send click and `fastForward(177_000)` simulates the slow-runner gap that caused the observed CI failure.

Before (pause removed, delay injected) — reproduces the exact flake class from PR #115123's `checks-ui-e2e`:

```text
 FAIL  |ui-e2e| ui/src/e2e/mantis-chat-proof.e2e.test.ts > Mantis Control UI web chat proof > sends a chat message and captures visible browser proof
AssertionError: expected '3m 1s' to be '2m 57s' // Object.is equality

Expected: "2m 57s"
Received: "3m 1s"

 ❯ ui/src/e2e/mantis-chat-proof.e2e.test.ts:123:10
 Test Files  1 failed (1)
      Tests  1 failed (1)
```

(The received value exceeds 2.5s of injected delay because the unpaused clock also ticks during the send/waitFor steps — the same mechanism that produced "2m 59s" on CI.)

After (this PR's pause in place, same 2.5s delay injected) — deterministic:

```text
$ node scripts/run-vitest.mjs ui/src/e2e/mantis-chat-proof.e2e.test.ts
 Test Files  1 passed (1)
      Tests  1 passed (1)
   Duration  9.38s
```

- CI: full PR run green on head `d4a8882db42b0a26191226aecdd5e908036b9d67`, including `checks-ui-e2e` (https://github.com/openclaw/openclaw/actions/runs/30359089731).
- Codex autoreview (`gpt-5.6-sol`, xhigh): clean, "patch is correct (0.96)".
