### PR TITLE
fix(cli): resolve plugin-catalog metadata for configured models list rows

### DIFF
--- a/src/commands/models/list.configured.test.ts
+++ b/src/commands/models/list.configured.test.ts
@@ -9,6 +9,12 @@ const emptyPluginMetadataSnapshot = vi.hoisted(() => ({
   plugins: [],
 }));
 
+const mocks = vi.hoisted(() => ({
+  loadPreparedModelCatalogSnapshot: vi.fn(),
+  normalizeProviderResolvedModelWithPlugin: vi.fn(() => undefined),
+  shouldSuppressBuiltInModelFromManifest: vi.fn(() => false),
+}));
+
 vi.mock("../../agents/provider-model-normalization.runtime.js", () => ({
   normalizeProviderModelIdWithRuntime: vi.fn(() => {
     throw new Error("runtime model normalization should not load for models list entries");
@@ -19,7 +25,22 @@ vi.mock("../../plugins/current-plugin-metadata-snapshot.js", () => ({
   getCurrentPluginMetadataSnapshot: () => emptyPluginMetadataSnapshot,
 }));
 
+vi.mock("../../agents/prepared-model-catalog.js", () => ({
+  loadPreparedModelCatalogSnapshot: mocks.loadPreparedModelCatalogSnapshot,
+}));
+
+vi.mock("../../agents/model-suppression.js", () => ({
+  shouldSuppressBuiltInModel: vi.fn(() => false),
+  shouldSuppressBuiltInModelFromManifest: mocks.shouldSuppressBuiltInModelFromManifest,
+}));
+
+vi.mock("../../plugins/provider-runtime.js", () => ({
+  normalizeProviderResolvedModelWithPlugin: mocks.normalizeProviderResolvedModelWithPlugin,
+}));
+
 import { resolveConfiguredEntries } from "./list.configured.js";
+import { appendConfiguredModelRowSources } from "./list.row-sources.js";
+import type { ModelRow } from "./list.types.js";
 
 afterEach(() => {
   vi.unstubAllEnvs();
@@ -177,5 +198,95 @@ describe("resolveConfiguredEntries", () => {
     } finally {
       fs.rmSync(root, { recursive: true, force: true });
     }
+  });
+});
+
+describe("configured model list rows", () => {
+  it("renders plugin-catalog metadata for a fallback ref instead of default placeholders", async () => {
+    const catalogEntry = {
+      id: "k3",
+      name: "Kimi K3",
+      provider: "kimi",
+      api: "openai-completions" as const,
+      baseUrl: "https://api.moonshot.ai/v1",
+      contextWindow: 1_048_576,
+      input: ["text", "image"] as const,
+    };
+    // Conflicting catalog metadata for an explicitly configured provider model:
+    // the user's models.providers definition must win over the catalog row.
+    const conflictingCatalogEntry = {
+      id: "own-model",
+      name: "Catalog Own Model",
+      provider: "custom",
+      contextWindow: 999_999,
+      input: ["text", "image"] as const,
+    };
+    mocks.loadPreparedModelCatalogSnapshot.mockResolvedValue({
+      entries: [catalogEntry, conflictingCatalogEntry],
+      routeVariants: [catalogEntry, conflictingCatalogEntry],
+    });
+    const cfg = {
+      agents: {
+        defaults: {
+          model: { primary: "kimi/kimi-for-coding", fallbacks: ["kimi/k3", "custom/own-model"] },
+        },
+      },
+      models: {
+        providers: {
+          custom: {
+            api: "openai-completions" as const,
+            baseUrl: "https://custom.test/v1",
+            models: [
+              {
+                id: "own-model",
+                name: "Own Model",
+                reasoning: false,
+                input: ["text" as const],
+                cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+                contextWindow: 32_000,
+                maxTokens: 8_000,
+              },
+            ],
+          },
+        },
+      },
+    };
+    const { entries } = resolveConfiguredEntries(cfg);
+    const rows: ModelRow[] = [];
+
+    await appendConfiguredModelRowSources({
+      rows,
+      entries,
+      context: {
+        cfg,
+        agentDir: "/tmp/openclaw-agent",
+        authIndex: { evaluateModelAuth: () => ({ availability: true, routeResolution: null }) },
+        configuredByKey: new Map(entries.map((entry) => [entry.key, entry])),
+        discoveredKeys: new Set<string>(),
+        filter: {},
+        skipRuntimeModelSuppression: true,
+      },
+    });
+
+    const fallbackRow = rows.find((row) => row.key === "kimi/k3");
+    expect(fallbackRow).toMatchObject({
+      name: "Kimi K3",
+      input: "text+image",
+      contextWindow: 1_048_576,
+    });
+    expect(fallbackRow?.tags).toContain("fallback#1");
+    // Explicit models.providers metadata beats the conflicting catalog row.
+    expect(rows.find((row) => row.key === "custom/own-model")).toMatchObject({
+      name: "Own Model",
+      input: "text",
+      contextWindow: 32_000,
+    });
+    // Refs the catalog does not know still fall back to the default placeholder row.
+    expect(rows.find((row) => row.key === "kimi/kimi-for-coding")).toMatchObject({
+      input: "text",
+      contextWindow: 200_000,
+    });
+    // The catalog is a single committed generation; configured and catalog rows share one load.
+    expect(mocks.loadPreparedModelCatalogSnapshot).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/commands/models/list.row-sources.ts
+++ b/src/commands/models/list.row-sources.ts
@@ -6,6 +6,7 @@ import {
   appendConfiguredRows,
   appendDiscoveredRows,
   appendPreparedModelCatalogRows,
+  loadListModelCatalogSnapshot,
   type RowBuilderContext,
 } from "./list.rows.js";
 import type { ConfiguredEntry, ModelRow } from "./list.types.js";
@@ -69,7 +70,11 @@ export async function appendConfiguredModelRowSources(params: {
   modelRegistry?: ModelRegistry;
   context: RowBuilderContext;
 }): Promise<void> {
-  await appendConfiguredRows(params);
+  // Configured rows are emitted first for tag ordering, so they must read the
+  // same committed generation the catalog rows below use; otherwise a ref that
+  // only exists in a plugin catalog renders default placeholder metadata.
+  const catalogSnapshot = await loadListModelCatalogSnapshot(params.context);
+  await appendConfiguredRows({ ...params, catalogSnapshot });
   const seenKeys = new Set(params.rows.map((row) => row.key));
   await appendConfiguredProviderRows({
     rows: params.rows,
@@ -80,5 +85,6 @@ export async function appendConfiguredModelRowSources(params: {
     rows: params.rows,
     context: params.context,
     seenKeys,
+    catalogSnapshot,
   });
 }

--- a/src/commands/models/list.rows.ts
+++ b/src/commands/models/list.rows.ts
@@ -424,13 +424,21 @@ function findConfiguredProviderModel(params: {
   });
 }
 
-function toFallbackConfiguredListModel(entry: ConfiguredEntry, cfg: OpenClawConfig): ListRowModel {
+function toFallbackConfiguredListModel(
+  entry: ConfiguredEntry,
+  cfg: OpenClawConfig,
+  catalogEntry?: ModelCatalogEntry,
+): ListRowModel {
+  // Explicit models.providers definitions stay authoritative; the prepared
+  // catalog fills plugin-owned refs so this view matches `--all`, and the
+  // placeholder is a last resort for refs nothing knows.
   return (
     findConfiguredProviderModel({
       cfg,
       provider: entry.ref.provider,
       modelId: entry.ref.model,
-    }) ?? {
+    }) ??
+    (catalogEntry ? toPreparedCatalogListModel(catalogEntry) : undefined) ?? {
       provider: entry.ref.provider,
       id: entry.ref.model,
       name: entry.ref.model,
@@ -438,6 +446,35 @@ function toFallbackConfiguredListModel(entry: ConfiguredEntry, cfg: OpenClawConf
       contextWindow: DEFAULT_CONTEXT_TOKENS,
     }
   );
+}
+
+/** Loads the committed catalog generation shared by every model-list row source. */
+export async function loadListModelCatalogSnapshot(
+  context: RowBuilderContext,
+): Promise<ModelCatalogSnapshot> {
+  const { loadPreparedModelCatalogSnapshot } = await loadPreparedModelCatalogModule();
+  const workspaceDir = context.workspaceDir ?? context.metadataSnapshot?.workspaceDir;
+  return loadPreparedModelCatalogSnapshot({
+    config: context.cfg,
+    ...(context.agentId ? { agentId: context.agentId } : {}),
+    agentDir: context.agentDir,
+    ...(workspaceDir ? { workspaceDir } : {}),
+    readOnly: true,
+  });
+}
+
+/** Indexes a catalog generation by model key so configured refs can reuse its metadata. */
+function indexModelCatalogEntriesByKey(
+  snapshot: ModelCatalogSnapshot,
+): ReadonlyMap<string, ModelCatalogEntry> {
+  const byKey = new Map<string, ModelCatalogEntry>();
+  for (const entry of [...snapshot.entries, ...(snapshot.staticEntries ?? [])]) {
+    const key = modelKey(entry.provider, entry.id);
+    if (!byKey.has(key)) {
+      byKey.set(key, entry);
+    }
+  }
+  return byKey;
 }
 
 /** Appends rows discovered from the loaded model registry. */
@@ -538,20 +575,10 @@ export async function appendAuthenticatedCatalogRows(params: {
   rows: ModelRow[];
   context: RowBuilderContext;
   seenKeys: Set<string>;
+  catalogSnapshot?: ModelCatalogSnapshot;
 }): Promise<void> {
-  const { loadPreparedModelCatalogSnapshot } = await loadPreparedModelCatalogModule();
-  const { entries: catalog, routeVariants } = await loadPreparedModelCatalogSnapshot({
-    config: params.context.cfg,
-    ...(params.context.agentId ? { agentId: params.context.agentId } : {}),
-    agentDir: params.context.agentDir,
-    ...((params.context.workspaceDir ?? params.context.metadataSnapshot?.workspaceDir)
-      ? {
-          workspaceDir:
-            params.context.workspaceDir ?? params.context.metadataSnapshot?.workspaceDir,
-        }
-      : {}),
-    readOnly: true,
-  });
+  const { entries: catalog, routeVariants } =
+    params.catalogSnapshot ?? (await loadListModelCatalogSnapshot(params.context));
   const routeIndex = createModelCatalogLogicalRouteIndex(routeVariants);
   for (const entry of catalog) {
     const model = toPreparedCatalogListModel(entry);
@@ -587,21 +614,7 @@ export async function appendPreparedModelCatalogRows(params: {
   catalogSnapshot?: ModelCatalogSnapshot;
 }): Promise<void> {
   const catalogSnapshot =
-    params.catalogSnapshot ??
-    (await (
-      await loadPreparedModelCatalogModule()
-    ).loadPreparedModelCatalogSnapshot({
-      config: params.context.cfg,
-      ...(params.context.agentId ? { agentId: params.context.agentId } : {}),
-      agentDir: params.context.agentDir,
-      ...((params.context.workspaceDir ?? params.context.metadataSnapshot?.workspaceDir)
-        ? {
-            workspaceDir:
-              params.context.workspaceDir ?? params.context.metadataSnapshot?.workspaceDir,
-          }
-        : {}),
-      readOnly: true,
-    }));
+    params.catalogSnapshot ?? (await loadListModelCatalogSnapshot(params.context));
   const staticEntries = catalogSnapshot.staticEntries ?? [];
   const routeVariants = [...catalogSnapshot.routeVariants];
   const seenRouteVariants = new Set(
@@ -640,9 +653,13 @@ export async function appendConfiguredRows(params: {
   entries: ConfiguredEntry[];
   modelRegistry?: ModelRegistry;
   context: RowBuilderContext;
+  catalogSnapshot?: ModelCatalogSnapshot;
 }): Promise<void> {
   const resolveModelWithRegistry = params.modelRegistry
     ? (await loadModelResolverModule()).resolveModelWithRegistry
+    : undefined;
+  const catalogByKey = params.catalogSnapshot
+    ? indexModelCatalogEntriesByKey(params.catalogSnapshot)
     : undefined;
   for (const entry of params.entries) {
     if (!matchesProviderFilter(params.context, entry.ref.provider)) {
@@ -656,7 +673,7 @@ export async function appendConfiguredRows(params: {
             modelRegistry: params.modelRegistry,
             cfg: params.context.cfg,
           })
-        : toFallbackConfiguredListModel(entry, params.context.cfg);
+        : toFallbackConfiguredListModel(entry, params.context.cfg, catalogByKey?.get(entry.key));
     const model = resolvedModel
       ? normalizeListRowWithProviderPlugin({ model: resolvedModel, context: params.context })
       : resolvedModel;


### PR DESCRIPTION
## What Problem This Solves

`openclaw models list` (the default configured view) and `openclaw models list --all` disagree about plugin-catalog models referenced from `agents.defaults.model.fallbacks`. With `fallbacks: ["kimi/k3"]` and the bundled `kimi` provider plugin authenticated:

```
$ openclaw models list --all | grep '^kimi/k3 '
kimi/k3              text+image 1049k  no  yes  fallback#1

$ openclaw models list | grep '^kimi/k3 '
kimi/k3              text       200k   no  yes  fallback#1     <-- wrong
```

The configured view synthesized a placeholder row (`input: ["text"]`, `contextWindow: DEFAULT_CONTEXT_TOKENS = 200_000`) for any configured/default/fallback ref that is not declared in `cfg.models.providers` — which is exactly the case for plugin-catalog models. Display-only: the runtime resolves the real catalog entry (`contextTokenBudget: 1048576` on a live `openclaw agent --local --model kimi/k3` run).

## Why This Change Was Made

The cheap default view emits configured rows first via `appendConfiguredRows` without a model registry, so `toFallbackConfiguredListModel` fell through to the hardcoded placeholder. The real catalog row was appended later by `appendAuthenticatedCatalogRows` from the prepared catalog snapshot, but by then the key was already in `seenKeys` and got skipped.

Fix: `appendConfiguredModelRowSources` now loads the prepared model catalog snapshot once up front and threads it into both `appendConfiguredRows` (which resolves configured refs against it before falling back to the placeholder) and `appendAuthenticatedCatalogRows` (which previously did its own load) — one catalog load per listing, same committed generation for every row source. Precedence per row: explicit `cfg.models.providers` definition → prepared catalog entry → placeholder, so user-authored provider metadata stays authoritative. The two duplicated inline snapshot-load blocks in `list.rows.ts` are folded into a shared `loadListModelCatalogSnapshot`.

## User Impact

`openclaw models list` now shows the same context window and input modalities as `--all` for plugin-catalog models tagged `default`, `fallback#N`, `image`, or `configured`. Previously users could conclude a fallback model had a 200k text-only budget when the runtime actually uses the full catalog entry (1M+ multimodal for `kimi/k3`).

## Evidence

- Regression test: `src/commands/models/list.configured.test.ts` — drives `resolveConfiguredEntries` → `appendConfiguredModelRowSources` with a plugin-catalog `kimi/k3` in `fallbacks`; asserts `text+image`/`1_048_576`/`fallback#1`, that explicit `models.providers` metadata beats a conflicting catalog row, that unknown refs keep the placeholder, and that the snapshot loads exactly once. Fails against unfixed code with the reported symptom.
- Live proof (isolated `OPENCLAW_STATE_DIR`, kimi plugin enabled, kimi auth present):
  - baseline (fresh build without the fix): `kimi/k3  text  200k  fallback#1` — bug reproduced
  - with fix: `kimi/k3  text+image  1049k  fallback#1` in **both** `models list` and `models list --all`
- `node scripts/run-vitest.mjs src/commands/models/list` — 8 files, 72 tests green
- `node scripts/run-vitest.mjs src/commands/models.list.e2e.test.ts` — 21 tests green
- `tsgo` core + test-src typechecks green; oxfmt/oxlint clean
- Codex autoreview (gpt-5.6-sol): first pass flagged catalog-over-configured precedence; fixed and re-reviewed clean
