### PR TITLE
refactor(qa-channel): reuse shared toErrorObject coercion

### DIFF
--- a/extensions/qa-channel/src/bus-client.coercion.test.ts
+++ b/extensions/qa-channel/src/bus-client.coercion.test.ts
@@ -1,0 +1,49 @@
+// Regression test: qa-bus client coerces non-Error readByteStreamWithLimit
+// rejections through the shared toErrorObject (the "Non-Error rejection"
+// fallback at the postJson rejection handler). Real HTTP errors are Error
+// instances (Node/undici wrap them), so the non-Error coercion branch is
+// exercised by injecting a non-Error rejection from readByteStreamWithLimit.
+import { createServer } from "node:http";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("openclaw/plugin-sdk/response-limit-runtime", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("openclaw/plugin-sdk/response-limit-runtime")>();
+  return {
+    ...actual,
+    // Reject with a non-Error value so the toErrorObject coercion branch fires.
+    readByteStreamWithLimit: vi.fn().mockRejectedValue({ code: 500, status: "server_error" }),
+  };
+});
+
+import { sendQaBusMessage } from "./bus-client.js";
+
+describe("qa-bus client non-Error rejection coercion", () => {
+  it("coerces non-Error readByteStreamWithLimit rejections via the shared toErrorObject", async () => {
+    const server = await new Promise<ReturnType<typeof createServer>>((resolve) => {
+      const s = createServer((_req, res) => {
+        res.writeHead(200, { "Content-Type": "application/json" });
+        res.end("{}");
+      });
+      s.listen(0, "127.0.0.1", () => resolve(s));
+    });
+    const port = (server.address() as { port: number }).port;
+    try {
+      const thrown = await sendQaBusMessage({
+        baseUrl: `http://127.0.0.1:${port}`,
+        accountId: "acct-a",
+        to: "dest",
+        text: "hi",
+      }).catch((err: unknown) => err);
+      // The shared toErrorObject wraps the non-Error value with its fallback
+      // message and copies enumerable fields (code, status) onto the Error.
+      expect(thrown).toBeInstanceOf(Error);
+      const thrownErr = thrown as Error & { code?: unknown; status?: unknown };
+      expect(thrownErr.message).toBe("Non-Error rejection");
+      expect(thrownErr.code).toBe(500);
+      expect(thrownErr.status).toBe("server_error");
+    } finally {
+      server.close();
+    }
+  });
+});

--- a/extensions/qa-channel/src/bus-client.ts
+++ b/extensions/qa-channel/src/bus-client.ts
@@ -1,6 +1,7 @@
 // Qa Channel plugin module implements bus client behavior.
 import http from "node:http";
 import https from "node:https";
+import { toErrorObject } from "openclaw/plugin-sdk/error-runtime";
 import { resolvePositiveTimerTimeoutMs } from "openclaw/plugin-sdk/number-runtime";
 import { readProviderJsonResponse } from "openclaw/plugin-sdk/provider-http";
 import {
@@ -120,7 +121,7 @@ async function postJson<T>(
             resolve(parsed as T);
           },
           (error: unknown) => {
-            reject(toLintErrorObject(error, "Non-Error rejection"));
+            reject(toErrorObject(error, "Non-Error rejection"));
           },
         );
         response.on("error", reject);
@@ -279,18 +280,4 @@ export async function getQaBusState(baseUrl: string): Promise<QaBusStateSnapshot
   } finally {
     await release();
   }
-}
-
-function toLintErrorObject(value: unknown, fallbackMessage: string): Error {
-  if (value instanceof Error) {
-    return value;
-  }
-  if (typeof value === "string") {
-    return new Error(value);
-  }
-  const error = new Error(fallbackMessage, { cause: value });
-  if ((typeof value === "object" && value !== null) || typeof value === "function") {
-    Object.assign(error, value);
-  }
-  return error;
 }


### PR DESCRIPTION
## What Problem This Solves

`extensions/qa-channel/src/bus-client.ts` carried a private `toLintErrorObject(value, fallbackMessage)` helper that coerces a non-`Error` rejection into an `Error` at the `postJson` rejection handler. The exact same 11-line implementation is copy-pasted across **10 modules** in the tree (acpx, codex, copilot, discord, line, lobster, memory-core, ollama, qa-channel, whatsapp), while an identical `toErrorObject` is already re-exported from `openclaw/plugin-sdk/error-runtime`. Keeping the qa-channel copy separate means any fix to the coercion logic has to be mirrored here too - the copy can silently drift.

## Why This Change Was Made

- Delete the local `toLintErrorObject` and import the shared `toErrorObject` from `openclaw/plugin-sdk/error-runtime`.
- Update the single call site (`reject(toErrorObject(error, "Non-Error rejection"))` inside `postJson`'s `readQaBusNodeJsonResponse` rejection handler) to use the shared helper.
- Add a regression test (`bus-client.coercion.test.ts`) that injects a non-`Error` `readByteStreamWithLimit` rejection and asserts the shared `toErrorObject` coercion surfaces.
- The shared and local bodies are **byte-identical**, so this is a pure behavior-preserving extraction: `deletions ≥ additions` (+1 / −13 on the source file).

This follows the exact pattern already merged for telegram, matrix, slack, signal, packages, browser (`refactor(*): reuse shared error coercion`) and ollama (#115116). The remaining copies can follow in separate per-module PRs.

## User Impact

None at runtime. The qa-bus client's response-read rejection path behaves identically: `Error` rejections pass through, strings become `new Error(string)`, and other values become `new Error(fallback, { cause })` with enumerable fields copied.

## Note on the `toErrorObject` facade export

`openclaw/plugin-sdk/error-runtime` **does** export `toErrorObject`. It was added to the re-export list in **#113229** (`refactor(browser): reuse shared error coercion`, merged 2026-07-24) at `src/plugin-sdk/error-runtime.ts:25`, which re-exports from `src/infra/errors.ts:74` -> `@openclaw/normalization-core/error-coercion`. CI's `check-prod-types` and `check-additional-extension-package-boundary` both pass at the PR head; #113589 and #115116 use the identical import. (A stale local bundled dist built before #113229 lacks the re-export and can produce a false-positive `tsgo` error locally; CI builds fresh.)

## Evidence

- `node scripts/run-vitest.mjs extensions/qa-channel/src/bus-client.test.ts` - 11/11 passed (existing real-server suite, incl. "rejects malformed JSON responses" which exercises the call site)
- `node scripts/run-vitest.mjs extensions/qa-channel/src/bus-client.coercion.test.ts` - 1/1 passed (new non-Error coercion regression test)
- `oxlint extensions/qa-channel/src` - clean
- `oxfmt --check extensions/qa-channel/src` - "All matched files use the correct format."
- `git diff --check` - clean

Related implementation pattern: #113589 (`refactor(telegram): reuse shared error coercion`), #115116 (ollama, same vein)

Real behavior proof at exact PR head `6300de13b959d16c4fa605753c0c2ddb04663ba7`:

```text
=== real-runtime qa-bus client (tsx, not vitest mock) ===
Runs the REAL sendQaBusMessage (extensions/qa-channel/src/bus-client.ts) via
tsx against a local qa-bus HTTP server whose /v1/outbound/message response is
malformed JSON. readQaBusNodeJsonResponse rejects -> postJson's rejection
handler `reject(toErrorObject(error, "Non-Error rejection"))` fires (the real
call site) -> sendQaBusMessage throws the coerced Error.

$ tsx scripts/proof/qa-channel-real-setup-proof.mjs
=== real qa-bus client (tsx) against local server with malformed JSON ===
baseUrl: http://127.0.0.1:4122
thrown: Error: qa-bus /v1/outbound/message: malformed JSON response
verdict: toErrorObject call site exercised by real runtime (readQaBusNodeJsonResponse rejected -> reject(toErrorObject(error, 'Non-Error rejection')))

=== non-Error coercion branch (the defensive path) ===
Real HTTP errors are Error instances (Node/undici wrap server-destroy errors),
so the non-Error coercion branch is covered by a committed test that injects a
non-Error readByteStreamWithLimit rejection:

$ node scripts/run-vitest.mjs extensions/qa-channel/src/bus-client.coercion.test.ts
 ✓ qa-bus client non-Error rejection coercion >
   coerces non-Error readByteStreamWithLimit rejections via the shared toErrorObject
 Test Files  1 passed (1)
      Tests  1 passed (1)
 asserts: thrown is Error, message "Non-Error rejection" (toErrorObject fallback),
          code=500, status="server_error" (Object.assign copied enumerable fields)

=== existing real-server suite (Error-passthrough path, no regressions) ===
$ node scripts/run-vitest.mjs extensions/qa-channel/src/bus-client.test.ts
 Test Files  1 passed (1)
      Tests  11 passed (11)
 (incl. "rejects malformed JSON responses instead of throwing from the stream
  callback" -> pollQaBus rejects "qa-bus /v1/poll: malformed JSON response",
  exercising the same toErrorObject call site via a real local server)

=== duplication before this PR: 10 identical toLintErrorObject copies ===
extensions/acpx/src/runtime-turn.ts
extensions/codex/src/app-server/plugin-approval-roundtrip.ts
extensions/copilot/src/event-bridge.ts
extensions/discord/src/monitor.gateway.ts
extensions/line/src/bot-handlers.ts
extensions/lobster/src/lobster-runner.ts
extensions/memory-core/src/memory/manager.ts
extensions/ollama/src/setup.ts            <- #115116
extensions/qa-channel/src/bus-client.ts   <- removed by this PR
extensions/whatsapp/src/session.ts
```

AI-assisted: Codex
