### PR TITLE
refactor(workboard): tidy Control UI card execution helpers

### DIFF
--- a/ui/src/lib/workboard/execution.ts
+++ b/ui/src/lib/workboard/execution.ts
@@ -1,6 +1,7 @@
 import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import type { GatewayBrowserClient } from "../../api/gateway.ts";
 import { requestSessionCreate } from "../sessions/index.ts";
+import { normalizeAgentId } from "../sessions/session-key.ts";
 import {
   normalizeString,
   replaceCard,
@@ -94,11 +95,11 @@ function buildCardTaskSessionKey(card: WorkboardCard): string {
   const boardId = sanitizeSessionSegment(card.metadata?.automation?.boardId, "default");
   const cardId = sanitizeSessionSegment(card.id, "card");
   const suffix = `subagent:workboard-${boardId}-${cardId}`;
-  const sessionKey = card.agentId
-    ? `agent:${sanitizeSessionSegment(card.agentId, "agent")}:${suffix}`
-    : suffix;
-  const existing = workboardCardSessionKey(card)?.trim();
-  return existing === sessionKey ? existing : sessionKey;
+  const agentId = card.agentId?.trim();
+  // Unassigned cards stay unscoped on purpose: the gateway canonicalizes a bare
+  // suffix onto the configured default agent, while normalizeAgentId maps an
+  // empty id to "main" and would target the wrong agent when the default differs.
+  return agentId ? `agent:${normalizeAgentId(agentId)}:${suffix}` : suffix;
 }
 
 function buildCardRunIdempotencyKey(card: WorkboardCard): string {
@@ -174,29 +175,31 @@ async function findTaskForStartedRun(params: {
   return null;
 }
 
+function workboardRunWasAborted(result: unknown): boolean {
+  return (
+    isRecord(result) &&
+    (result.aborted === true || (Array.isArray(result.runIds) && result.runIds.length > 0))
+  );
+}
+
 async function abortWorkboardSessionRun(params: {
   client: GatewayBrowserClient;
   sessionKey: string;
   runId?: string;
 }): Promise<boolean> {
-  let abortResult = await params.client.request("chat.abort", {
+  const targetedAbort = await params.client.request("chat.abort", {
     sessionKey: params.sessionKey,
     ...(params.runId ? { runId: params.runId } : {}),
   });
-  let aborted =
-    isRecord(abortResult) &&
-    (abortResult.aborted === true ||
-      (Array.isArray(abortResult.runIds) && abortResult.runIds.length > 0));
-  if (!aborted && params.runId) {
-    abortResult = await params.client.request("chat.abort", {
-      sessionKey: params.sessionKey,
-    });
-    aborted =
-      isRecord(abortResult) &&
-      (abortResult.aborted === true ||
-        (Array.isArray(abortResult.runIds) && abortResult.runIds.length > 0));
+  const aborted = workboardRunWasAborted(targetedAbort);
+  if (aborted || !params.runId) {
+    return aborted;
   }
-  return aborted;
+  // A card run id that no longer names the live run aborts nothing, so retry
+  // session-wide before reporting failure; otherwise Stop strands an active run.
+  return workboardRunWasAborted(
+    await params.client.request("chat.abort", { sessionKey: params.sessionKey }),
+  );
 }
 
 function taskIsActive(task: WorkboardTaskSummary | undefined): task is WorkboardTaskSummary {

--- a/ui/src/lib/workboard/index.test.ts
+++ b/ui/src/lib/workboard/index.test.ts
@@ -3456,6 +3456,37 @@ describe("workboard controller", () => {
     );
   });
 
+  // Cards persist whatever agent id they were created with, so the worker key
+  // canonicalizes it: "Codex-Main" and "codex-main" name one session, not two.
+  it("canonicalizes a card's agent id in the worker session key", async () => {
+    const expectedSessionKey = "agent:codex-main:subagent:workboard-default-card-1";
+    const mixedCase = { ...sampleCard, agentId: "Codex-Main" } satisfies WorkboardCard;
+    const running = {
+      ...mixedCase,
+      status: "running",
+      sessionKey: expectedSessionKey,
+      runId: "run-1",
+    } satisfies WorkboardCard;
+    const client = createClient({
+      agent: { runId: "run-1" },
+      "tasks.list": { tasks: [] },
+      "workboard.cards.update": { card: running },
+    });
+
+    const sessionKey = await startWorkboardCard({
+      host,
+      client: client as never,
+      card: mixedCase,
+    });
+
+    expect(sessionKey).toBe(expectedSessionKey);
+    expect(client.request).toHaveBeenNthCalledWith(
+      2,
+      "agent",
+      expect.objectContaining({ sessionKey: expectedSessionKey }),
+    );
+  });
+
   it("waits briefly for task ledger registration after a started run", async () => {
     vi.useFakeTimers();
     const running = {


### PR DESCRIPTION
Related: #115158 (closed — its premise did not reproduce)

## What Problem This Solves

No user-visible problem. This is a maintenance change to `ui/src/lib/workboard/execution.ts`, the Control UI helper behind the Workboard card Run/Stop buttons, cleaning up three things that made the file hard to reason about while investigating a suspected session-scoping bug there:

1. `buildCardTaskSessionKey` ended with a branch that returned the same value on both arms (`return existing === sessionKey ? existing : sessionKey`), which reads as if a persisted key could win but never does.
2. `abortWorkboardSessionRun` repeated a four-line "did the abort take effect" predicate verbatim and reassigned two `let` bindings to express one retry.
3. The worker session key built the agent segment with the file-local `sanitizeSessionSegment`, which does not lowercase, while the Control UI already owns `normalizeAgentId` for exactly this. A card created as `Codex-Main` therefore produced `agent:Codex-Main:…` where every other UI surface names `agent:codex-main:…`.

## Why This Change Was Made

The dead branch is deleted, the abort predicate is extracted to `workboardRunWasAborted` so the targeted-then-session-wide retry reads as two returns instead of two reassignments, and the agent segment now goes through `normalizeAgentId`.

The one deliberate non-change is documented in a comment: cards with **no** `agentId` keep producing a bare `subagent:workboard-<board>-<card>` suffix. Scoping them looked tempting, but `normalizeAgentId` maps an empty id to `"main"`, so forcing a prefix would target `main` rather than the configured default agent. The gateway already canonicalizes a bare suffix onto the real default via `canonicalizeSessionKeyForAgent` (`src/gateway/session-store-key.ts:144`), so leaving it alone is both correct and simpler. That comment exists so the next reader does not repeat the mistake #115158 made.

Behavior is unchanged apart from the agent-segment casing, and even that is invisible end-to-end: `parseAgentSessionKey` lowercases before parsing, and the card persists the canonical key the gateway returns rather than the one the UI built.

Scope is deliberately one file. The same key format is also built in `extensions/workboard/src/dispatcher.ts`; unifying those is a cross-owner-boundary change and #115119 is currently in flight there, so it is left alone.

## User Impact

None. No user-facing behavior, config, or API surface changes.

## Evidence

`node scripts/run-vitest.mjs ui/src/lib/workboard/index.test.ts` — 187 passed, including the existing coverage for the abort retry (`stopWorkboardCard` asserts `chat.abort` with `runId` followed by `chat.abort` without it when the first reports `aborted: false`), which is what pins the refactored control flow.

One test added, `canonicalizes a card's agent id in the worker session key`, asserting a card with `agentId: "Codex-Main"` starts `agent:codex-main:subagent:workboard-default-card-1`. I verified it is a real regression test by reverting the single line to `sanitizeSessionSegment` and re-running: it fails, and passes again once restored.

`node scripts/check-changed.mjs` (delegated to Testbox, exit 0): package patch guard, Control UI i18n catalog, `tsgo` UI + core-test typecheck, and oxlint over the changed files — `0 warnings and 0 errors`.

Codex autoreview (`gpt-5.6-sol`, xhigh) on the change bundle: clean, no accepted or actionable findings.

`git diff --numstat` is +22/-19 in production code, and five of those added lines are the comments above, so the code itself shrinks.

### Live behavior proof

Driven through the real `startWorkboardCard` / `stopWorkboardCard` helpers against a real Gateway (isolated `OPENCLAW_STATE_DIR`, loopback port, workboard plugin loaded, two configured agents `codex-main` and `main`), using the repo's own gateway client as transport — not a mock:

```
=== card assigned to mixed-case agent 'Codex-Main' ===
card.agentId         = "Codex-Main"
UI sent  sessionKey  = "agent:codex-main:subagent:workboard-default-966bd23e-…"
UI sent  agentId     = "Codex-Main"
gateway resolved to  = "agent:codex-main:subagent:workboard-default-966bd23e-…"
state.error          = null
chat.abort calls     = 1

=== unassigned card (deliberately left unscoped) ===
card.agentId         = undefined
UI sent  sessionKey  = "subagent:workboard-default-40519295-…"
gateway resolved to  = "agent:codex-main:subagent:workboard-default-40519295-…"
state.error          = null
chat.abort calls     = 1

=== sessions.list (workboard worker sessions) ===
  agent:codex-main:subagent:workboard-default-40519295-…
  agent:codex-main:subagent:workboard-default-966bd23e-…
```

Two things this pins down. The assigned card exercises the one changed line end to end: the UI emits the canonicalized `agent:codex-main:…` key while still sending the raw `agentId: "Codex-Main"`, the Gateway accepts both, and the run lands in that agent's session store. The refactored Stop path issues its single `chat.abort` in both cases.

The unassigned card is the more interesting one. In this config the resolved default agent is `codex-main`, and the bare suffix correctly canonicalizes onto it. Had this PR "completed" the job by scoping unassigned cards client-side, `normalizeAgentId` would have mapped the empty id to `"main"` and sent the run to the wrong agent — the mistake the closed #115158 made, here shown concretely rather than argued.
