### PR TITLE
test(agents): de-flake hidden-reasoning idle timeout streaming test

### DIFF
--- a/src/agents/openai-transport-stream.streaming.test.ts
+++ b/src/agents/openai-transport-stream.streaming.test.ts
@@ -276,9 +276,15 @@ describe("openai transport stream", () => {
   it.each(["reasoning_content", "reasoning"] as const)(
     "keeps hidden local %s streams alive beyond the model idle timeout",
     async (reasoningField) => {
-      const reasoningChunkCount = 5;
-      const reasoningChunkDelayMs = 35;
-      const idleTimeoutMs = 100;
+      // The regression under guard is "hidden reasoning stops resetting the idle
+      // watchdog", so the hidden phase has to outlast idleTimeoutMs or a broken
+      // build would pass. Pace chunks far below that budget instead of near it:
+      // a loaded runner stretches every inter-chunk gap, and one gap wider than
+      // the timeout inverts the ratio into a false idle timeout.
+      const idleTimeoutMs = 1_000;
+      const reasoningChunkDelayMs = 5;
+      const hiddenReasoningDurationMs = idleTimeoutMs + 200;
+      let hiddenReasoningElapsedMs = 0;
       const server = createServer((req, res) => {
         req.resume();
         req.on("end", () => {
@@ -288,13 +294,13 @@ describe("openai transport stream", () => {
             connection: "keep-alive",
           });
 
-          let reasoningChunksSent = 0;
+          const hiddenReasoningStartedAt = Date.now();
           const writeNextChunk = () => {
             if (res.destroyed) {
               return;
             }
-            if (reasoningChunksSent < reasoningChunkCount) {
-              reasoningChunksSent += 1;
+            hiddenReasoningElapsedMs = Date.now() - hiddenReasoningStartedAt;
+            if (hiddenReasoningElapsedMs < hiddenReasoningDurationMs) {
               const reasoningChunk = {
                 id: "chatcmpl-local-reasoning",
                 object: "chat.completion.chunk",
@@ -370,6 +376,9 @@ describe("openai transport stream", () => {
         expect(text).toBe("OK");
         expect(thinking).toBe("");
         expect(onIdleTimeout).not.toHaveBeenCalled();
+        // Without this the assertions above could pass on a run whose hidden
+        // phase never reached the watchdog deadline, i.e. proving nothing.
+        expect(hiddenReasoningElapsedMs).toBeGreaterThan(idleTimeoutMs);
       } finally {
         await new Promise<void>((resolve, reject) => {
           server.close((error) => (error ? reject(error) : resolve()));


### PR DESCRIPTION
## What Problem This Solves

`src/agents/openai-transport-stream.streaming.test.ts` had a load-dependent flaky test: `it.each(["reasoning_content", "reasoning"])("keeps hidden local %s streams alive beyond the model idle timeout")`.

The test stood up a loopback SSE server that wrote a hidden-reasoning chunk every `reasoningChunkDelayMs = 35` against `idleTimeoutMs = 100` — a margin of only 2.9x. On a loaded runner any single inter-chunk gap over 100ms trips `createIdleTimeoutError` in `src/agents/embedded-agent-runner/run/llm-idle-timeout.ts:434`, and the test fails with `Error: LLM idle timeout (0s): no response from model`. The loopback server and the client under test share one event loop, so an event-loop stall longer than the idle budget delays chunk delivery past the client's own watchdog deadline.

Observed on unrelated PR #115158, job `checks-node-compact-small-14`: https://github.com/openclaw/openclaw/actions/runs/30353766831/job/90257210602

## Why This Change Was Made

The behavior under test — hidden reasoning deltas keep the idle watchdog alive without surfacing as `thinking_delta` — is worth keeping, so the fix hardens the assertion instead of deleting coverage.

Two changes, both in the test:

1. **Widen the interval/timeout ratio from 2.9x to 200x.** `idleTimeoutMs` goes 100 -> 1000 and `reasoningChunkDelayMs` goes 35 -> 5. A false failure now requires a ~1s single-turn event-loop stall instead of a ~65ms one.
2. **Make the "outlasts the timeout" invariant explicit and self-checked.** The server previously wrote a fixed `reasoningChunkCount = 5`, so the hidden phase duration was an implicit product of two constants. It is now driven by wall clock (`hiddenReasoningDurationMs = idleTimeoutMs + 200`), and the test asserts `hiddenReasoningElapsedMs > idleTimeoutMs`. Without that assertion the other assertions could pass on a run whose hidden phase never reached the watchdog deadline — i.e. pass while proving nothing.

Sibling surfaces were checked. This file has no other idle-timeout case, and the `streamWithIdleTimeout` unit coverage in `src/agents/embedded-agent-runner/run/llm-idle-timeout.test.ts` already drives every timing assertion with `vi.useFakeTimers()` plus `advanceTimersByTimeAsync`, so it is not exposed to this class. Same for the `withFirstStreamEventTimeout` coverage in `packages/ai`. Unrelated instances of the pattern were found in `extensions/codex/src/app-server/run-attempt.turn-watches.test.ts` (real 60ms sleeps against a `timeoutMs = 100` attempt watchdog) and `extensions/vydra/shared.test.ts:209`; those are a different owner boundary and are left as follow-up rather than expanding this PR.

## User Impact

None. Test-only change; no production code is touched.

## Evidence

Reproduced deterministically on a loaded local machine on clean `origin/main` — 4/4 instances failed (the file runs in both the `agents-support` and `agents-core-isolated` projects):

```
node scripts/run-vitest.mjs src/agents/openai-transport-stream.streaming.test.ts -t "idle timeout"
Tests  4 failed | 94 skipped (98)
Error: LLM idle timeout (0s): no response from model
```

After the fix, on the same loaded machine, 5 consecutive runs green:

```
for i in 1 2 3 4 5; do node scripts/run-vitest.mjs src/agents/openai-transport-stream.streaming.test.ts -t "idle timeout"; done
run 1..5: Test Files 2 passed (2) | Tests 4 passed | 94 skipped (98)
```

**Mutation proof that the coverage still bites.** Temporarily removing `notifyLlmRequestActivity(options?.signal)` at `packages/ai/src/transports/openai-completions-transport.ts:639` — the exact line this test guards — fails all 4 instances with `Error: LLM idle timeout (1s): no response from model`. The change was reverted; only the test file is modified in this PR.

Full file and adjacent surface:

- `node scripts/run-vitest.mjs src/agents/openai-transport-stream.streaming.test.ts` -> 49 passed
- `node scripts/run-vitest.mjs src/agents/embedded-agent-runner/run/llm-idle-timeout.test.ts` -> 123 passed
- `node scripts/check-changed.mjs` -> exit 0 (typecheck core tests + lint, delegated to Blacksmith Testbox `tbx_01kymbgq1xrsajwqv20xphefrc`)
- `oxfmt --check` clean, `git diff --check` clean
- `autoreview --mode uncommitted` (codex / gpt-5.6-sol / xhigh) -> `autoreview clean: no accepted/actionable findings reported`
