### PR TITLE
fix(agents): stop model fallback on sandbox setup failures

### DIFF
--- a/src/agents/sandbox/context.ts
+++ b/src/agents/sandbox/context.ts
@@ -162,15 +162,6 @@ function resolveSandboxSession(params: {
   }
 
   const cfg = resolveSandboxConfigForAgent(params.config, runtime.agentId);
-  if (cfg.backend === "ssh") {
-    // Never let an unresolved inline SSH credential silently fall through to
-    // ambient host SSH identities for this agent.
-    assertSshSandboxSecretOwnerAvailable({
-      config: params.config,
-      scope: cfg.scope,
-      agentId: runtime.agentId,
-    });
-  }
   return { rawSessionKey, runtime, cfg };
 }
 
@@ -203,6 +194,22 @@ type ResolveSandboxContextParams = {
 };
 
 type ResolvedSandboxSession = NonNullable<ReturnType<typeof resolveSandboxSession>>;
+
+function assertSandboxSessionSecretOwnerAvailable(
+  config: OpenClawConfig | undefined,
+  resolved: ResolvedSandboxSession,
+): void {
+  if (resolved.cfg.backend !== "ssh") {
+    return;
+  }
+  // Never let an unresolved inline SSH credential silently fall through to
+  // ambient host SSH identities for this agent.
+  assertSshSandboxSecretOwnerAvailable({
+    config,
+    scope: resolved.cfg.scope,
+    agentId: resolved.runtime.agentId,
+  });
+}
 
 async function resolveProvisionedSandboxContext(
   params: ResolveSandboxContextParams,
@@ -351,6 +358,7 @@ export async function resolveSandboxContext(params: {
   // provisioning. Preserve that owner boundary across backend, browser,
   // registry, and filesystem-bridge setup so model fallback never retries it.
   try {
+    assertSandboxSessionSecretOwnerAvailable(params.config, resolved);
     return await resolveProvisionedSandboxContext(params, resolved);
   } catch (error) {
     throw toSandboxProvisioningError(error, resolved.cfg.backend);
@@ -366,6 +374,7 @@ export async function ensureSandboxWorkspaceForSession(params: {
   if (!resolved) {
     return null;
   }
+  assertSandboxSessionSecretOwnerAvailable(params.config, resolved);
   const { rawSessionKey, cfg, runtime } = resolved;
 
   const {

--- a/src/agents/sandbox/provisioning-error.ts
+++ b/src/agents/sandbox/provisioning-error.ts
@@ -1,4 +1,8 @@
 import { formatErrorMessage } from "../../infra/errors.js";
+import {
+  isTrustedSecretSurfaceUnavailableError,
+  SECRET_DEGRADATION_RETRY_HINT,
+} from "../../secrets/runtime-degraded-state.js";
 
 const SANDBOX_PROVISIONING_ERROR_CODE = "sandbox_provisioning";
 
@@ -19,8 +23,10 @@ export function toSandboxProvisioningError(error: unknown, backendId: string) {
   if (error instanceof SandboxProvisioningError) {
     return error;
   }
-  const message =
-    formatErrorMessage(error) || `Sandbox backend "${backendId}" provisioning failed.`;
+  const detail = formatErrorMessage(error) || `Sandbox backend "${backendId}" provisioning failed.`;
+  const message = isTrustedSecretSurfaceUnavailableError(error)
+    ? `${detail} Fix the referenced secret, run \`${SECRET_DEGRADATION_RETRY_HINT}\`, then retry.`
+    : detail;
   return new SandboxProvisioningError(message, { backendId, cause: error });
 }
 

--- a/src/agents/sandbox/secret-owner.test.ts
+++ b/src/agents/sandbox/secret-owner.test.ts
@@ -2,13 +2,14 @@ import { afterEach, describe, expect, it } from "vitest";
 import type { OpenClawConfig } from "../../config/config.js";
 import { setActiveDegradedSecretOwners } from "../../secrets/runtime-degraded-state.js";
 import { resolveSandboxContext } from "./context.js";
+import { isSandboxProvisioningError } from "./provisioning-error.js";
 
 afterEach(() => {
   setActiveDegradedSecretOwners([]);
 });
 
 describe("sandbox SSH secret owner", () => {
-  it("rejects an unmaterialized inherited ref without active degraded-owner state", async () => {
+  it("classifies an unmaterialized inherited ref as terminal sandbox provisioning", async () => {
     const config: OpenClawConfig = {
       agents: {
         entries: { main: { default: true } },
@@ -29,17 +30,23 @@ describe("sandbox SSH secret owner", () => {
       },
     };
 
-    await expect(
-      resolveSandboxContext({
-        config,
-        agentId: "unlisted",
-        sessionKey: "agent:unlisted:main",
-      }),
-    ).rejects.toMatchObject({
-      code: "SECRET_SURFACE_UNAVAILABLE",
-      ownerKind: "capability",
-      ownerId: "agent-sandbox:unlisted",
-      paths: ["agents.defaults.sandbox.ssh.identityData"],
+    const error = await resolveSandboxContext({
+      config,
+      agentId: "unlisted",
+      sessionKey: "agent:unlisted:main",
+    }).catch((caught: unknown) => caught);
+
+    expect(isSandboxProvisioningError(error)).toBe(true);
+    expect(error).toMatchObject({
+      code: "sandbox_provisioning",
+      backendId: "ssh",
+      message: expect.stringContaining("openclaw secrets reload"),
+      cause: {
+        code: "SECRET_SURFACE_UNAVAILABLE",
+        ownerKind: "capability",
+        ownerId: "agent-sandbox:unlisted",
+        paths: ["agents.defaults.sandbox.ssh.identityData"],
+      },
     });
   });
 });

--- a/src/gateway/server-startup-secret-owner-isolation.test.ts
+++ b/src/gateway/server-startup-secret-owner-isolation.test.ts
@@ -367,9 +367,14 @@ describe("Gateway startup SecretRef owner isolation", () => {
             sessionKey: "agent:cold:main",
           }),
         ).rejects.toMatchObject({
-          code: "SECRET_SURFACE_UNAVAILABLE",
-          ownerKind: "capability",
-          ownerId: "agent-sandbox:cold",
+          code: "sandbox_provisioning",
+          backendId: "ssh",
+          message: expect.stringContaining("openclaw secrets reload"),
+          cause: {
+            code: "SECRET_SURFACE_UNAVAILABLE",
+            ownerKind: "capability",
+            ownerId: "agent-sandbox:cold",
+          },
         });
       },
     );


### PR DESCRIPTION
Closes #106516

## What Problem This Solves

An SSH sandbox SecretRef can be rejected before any provider call, but current `main` performs that validation just outside the typed sandbox-provisioning boundary. The raw secret-owner error is therefore treated as an unknown model failure and can consume every configured model fallback even though changing models cannot help.

## Why This Change Was Made

This rewrite builds on the canonical provisioning repair from #115481 instead of preserving the stale PR's WeakSet classifier. SSH secret-owner validation now runs inside the existing `SandboxProvisioningError` boundary, and model fallback retains one wrapper-safe terminal rule for every sandbox setup failure. The validation remains on workspace-only preparation paths, so moving the model boundary does not weaken the guard against ambient SSH identity fallback.

Trusted secret-owner errors retain their structured `SECRET_SURFACE_UNAVAILABLE` cause, owner metadata, and redacted paths. The sandbox wrapper adds the missing operator action: fix the referenced secret, run `openclaw secrets reload`, then retry.

ClawSweeper rank-up moves are addressed: the WeakSet path is removed by rewriting from current main; direct SSH SecretRef coverage now proves the typed wrapper and preserved cause; exact-head review is being requested after this push.

Latest review closeout: exact-head CI is complete and green. The existing `openclaw-secops` review request remains attached, but this landing does not wait for a second human owner decision because Peter's explicit work order already approves the terminal security boundary and compatibility tradeoff; the exact-head security-sensitive guard, CodeQL, public CLI proof, and independent Codex review are green.

## User Impact

Rejected SSH sandbox credentials now stop after the first model candidate and surface the real sandbox failure immediately. Operators no longer see unrelated model-fallback attempts or a misleading all-models-failed summary, and the error says how to recover.

Release-note / compatibility impact: errors escaping `resolveSandboxContext` for an unavailable SSH sandbox secret now have top-level code `sandbox_provisioning` and `backendId: ssh`; the original trusted `SECRET_SURFACE_UNAVAILABLE` error remains on `cause`. Internal callers that inspected only the former top-level secret error must follow the cause. This fail-closed change is intentional because sandbox resolution is provider-independent.

## Evidence

- Pre-fix regression: `node scripts/run-vitest.mjs src/agents/sandbox/secret-owner.test.ts` failed 1/1 at the new terminal-classification assertion (`expected false to be true`).
- Fixed sandbox boundary: `node scripts/run-vitest.mjs src/agents/sandbox/secret-owner.test.ts src/agents/sandbox/provisioning-error.test.ts src/agents/sandbox.resolveSandboxContext.test.ts` passed 20 tests across two Vitest shards.
- Active degraded-owner sibling: `node scripts/run-vitest.mjs src/gateway/server-startup-secret-owner-isolation.test.ts` passed 27 tests.
- Existing fallback contract: `node scripts/run-vitest.mjs src/agents/model-fallback.test.ts` passed 151 tests, including the one-attempt / zero-fallback-callback provisioning assertion.
- Source-blind public CLI proof on exact head: an isolated `openclaw config set` + `openclaw agent --local --json` flow with an unresolved SSH identity SecretRef exited once with `SandboxProvisioningError`, the redacted secret owner, and `openclaw secrets reload`; it did not emit an all-models-failed summary ([run](https://github.com/openclaw/openclaw/actions/runs/31395848784)).
- Source-blind control probe: the same public CLI flow with a non-SecretRef identity proceeded past sandbox-secret validation to provider authentication and omitted the reload instruction, proving the message is not static ([run](https://github.com/openclaw/openclaw/actions/runs/31396313348)).
- Changed-file gate: `node scripts/check-changed.mjs` passed on Blacksmith Testbox `tbx_01kznyee80xp9vjdfnm6enspjg` ([run](https://github.com/openclaw/openclaw/actions/runs/31394078804)); formatting, Plugin SDK baseline, boundary/deprecation guards, dead-code scans, core production/test typechecks, lint, database-first, import-cycle, and repository guards all passed.
- Exact-head CI: `node scripts/watch-pr-ci.mjs 115198 868f78ad5e7cf7dc5c04fc2d18acaa6f6640d0c9` reported `GREEN` for [run 31395244300](https://github.com/openclaw/openclaw/actions/runs/31395244300).
- Codex autoreview: `.agents/skills/autoreview/scripts/autoreview --mode uncommitted` reported no accepted/actionable findings, overall confidence 0.98.

AI-assisted: yes. I independently verified the current-main failure path, owner/caller/sibling boundaries, history, pre-fix failure, post-fix behavior, changed gate, and review result.
