### PR TITLE
perf(pr): stop small reviews from spending uncached REST quota

### DIFF
--- a/scripts/pr-lib/worktree.sh
+++ b/scripts/pr-lib/worktree.sh
@@ -91,30 +91,62 @@ enter_worktree() {
 pr_meta_json() {
   local pr="$1"
   local metadata files expected_file_count actual_file_count head_before head_after
-  metadata=$(gh pr view "$pr" --json number,title,state,isDraft,author,baseRefName,headRefName,headRefOid,headRepository,headRepositoryOwner,url,body,labels,assignees,reviewRequests,changedFiles,additions,deletions,statusCheckRollup)
+  metadata=$(gh pr view "$pr" --json number,title,state,isDraft,author,baseRefName,headRefName,headRefOid,headRepository,headRepositoryOwner,url,body,labels,assignees,reviewRequests,changedFiles,additions,deletions,statusCheckRollup,files)
   head_before=$(printf '%s\n' "$metadata" | jq -r .headRefOid)
+  expected_file_count=$(printf '%s\n' "$metadata" | jq -r .changedFiles)
 
-  # Raw `gh pr view --json files` stops at 100 entries. Paginate REST so
-  # review guards see every path, then fail closed on head or API drift.
-  if ! files=$(
-    set -o pipefail
-    gh api --paginate "repos/{owner}/{repo}/pulls/$pr/files?per_page=100" |
-      jq -cs '
-        add
-        | map({
-            path: .filename,
+  # `gh pr view --json files` is cacheable but stops at 100 entries. Use it
+  # when complete; only large or incomplete responses spend uncached REST quota.
+  files='[]'
+  if [ "$expected_file_count" -le 100 ]; then
+    files=$(printf '%s\n' "$metadata" | jq -c '
+      .files
+      | if type == "array"
+          and all(.[];
+            (.path | type == "string")
+            and (.additions | type == "number")
+            and (.deletions | type == "number")
+            and (.changeType | type == "string" and length > 0)
+          )
+        then map({
+            path: .path,
             additions: .additions,
             deletions: .deletions,
             changeType: (
-              if .status == "removed" then "DELETED"
-              else (.status | ascii_upcase)
+              if (.changeType | ascii_downcase) == "removed"
+                or (.changeType | ascii_downcase) == "deleted"
+              then "DELETED"
+              else (.changeType | ascii_upcase)
               end
             )
           })
-      '
-  ); then
-    echo "Failed to collect paginated PR file metadata for #$pr." >&2
-    return 1
+        else []
+        end
+    ' 2>/dev/null || printf '[]')
+  fi
+
+  actual_file_count=$(printf '%s\n' "$files" | jq -r 'length')
+  if [ "$actual_file_count" -ne "$expected_file_count" ]; then
+    if ! files=$(
+      set -o pipefail
+      gh api --paginate "repos/{owner}/{repo}/pulls/$pr/files?per_page=100" |
+        jq -cs '
+          add
+          | map({
+              path: .filename,
+              additions: .additions,
+              deletions: .deletions,
+              changeType: (
+                if .status == "removed" then "DELETED"
+                else (.status | ascii_upcase)
+                end
+              )
+            })
+        '
+    ); then
+      echo "Failed to collect paginated PR file metadata for #$pr." >&2
+      return 1
+    fi
   fi
 
   head_after=$(gh pr view "$pr" --json headRefOid | jq -r .headRefOid)
@@ -123,7 +155,6 @@ pr_meta_json() {
     return 1
   fi
 
-  expected_file_count=$(printf '%s\n' "$metadata" | jq -r .changedFiles)
   if ! actual_file_count=$(
     printf '%s\n' "$files" |
       jq -er 'if type == "array" then length else error("expected an array") end'

--- a/test/scripts/pr-metadata.test.ts
+++ b/test/scripts/pr-metadata.test.ts
@@ -17,7 +17,25 @@ set -euo pipefail
 
 if [ "$1" = "pr" ] && [ "$2" = "view" ]; then
   if [[ "$*" == *changedFiles* ]]; then
-    printf '{"number":42,"url":"https://example.test/pr/42","headRefOid":"head-a","changedFiles":%s}\n' "\${FAKE_CHANGED_FILES:-101}"
+    jq -nc --argjson changedFiles "\${FAKE_CHANGED_FILES:-101}" --argjson fileCount "\${FAKE_GRAPHQL_FILE_COUNT:-100}" --argjson includeChangeType "\${FAKE_GRAPHQL_CHANGE_TYPE:-true}" '
+      {
+        number: 42,
+        url: "https://example.test/pr/42",
+        headRefOid: "head-a",
+        changedFiles: $changedFiles,
+        files: [
+          range(0; $fileCount)
+          | ({
+              path: ("src/graphql-file-" + (tostring) + ".ts"),
+              additions: 1,
+              deletions: 0,
+              originalPath: ""
+            } + if $includeChangeType then {
+              changeType: (if . == ($fileCount - 1) then "removed" else "modified" end)
+            } else {} end)
+        ]
+      }
+    '
   else
     printf '{"headRefOid":"%s"}\n' "\${FAKE_HEAD_AFTER:-head-a}"
   fi
@@ -26,6 +44,10 @@ fi
 
 if [ "$1" = "api" ] && [ "$2" = "--paginate" ]; then
   [ "$3" = 'repos/{owner}/{repo}/pulls/42/files?per_page=100' ] || { echo "unexpected endpoint: $3" >&2; exit 4; }
+  if [ "\${FAKE_REST_FILE_COUNT:-101}" = "2" ]; then
+    jq -nc '[range(0; 2) | {filename: ("src/file-" + (tostring) + ".ts"), status: (if . == 1 then "removed" else "modified" end), additions: 1, deletions: 0}]'
+    exit 0
+  fi
   jq -nc '[range(0; 100) | {filename: ("src/file-" + (tostring) + ".ts"), status: "modified", additions: 1, deletions: 0}]'
   if [ "\${FAKE_FILES_API_FAILURE:-0}" = "1" ]; then
     echo "files API failed" >&2
@@ -45,7 +67,14 @@ exit 2
 
 function readPrMetadata(
   fakeGhDir: string,
-  options: { changedFiles?: string; filesApiFailure?: boolean; headAfter?: string } = {},
+  options: {
+    changedFiles?: string;
+    filesApiFailure?: boolean;
+    graphqlChangeType?: boolean;
+    graphqlFileCount?: string;
+    headAfter?: string;
+    restFileCount?: string;
+  } = {},
 ) {
   return spawnSync(
     "bash",
@@ -56,7 +85,10 @@ function readPrMetadata(
         ...process.env,
         FAKE_CHANGED_FILES: options.changedFiles ?? "101",
         FAKE_FILES_API_FAILURE: options.filesApiFailure ? "1" : "0",
+        FAKE_GRAPHQL_CHANGE_TYPE: options.graphqlChangeType === false ? "false" : "true",
+        FAKE_GRAPHQL_FILE_COUNT: options.graphqlFileCount ?? "100",
         FAKE_HEAD_AFTER: options.headAfter ?? "head-a",
+        FAKE_REST_FILE_COUNT: options.restFileCount ?? "101",
         PATH: `${fakeGhDir}:${process.env.PATH}`,
       },
       encoding: "utf8",
@@ -71,6 +103,42 @@ afterEach(() => {
 });
 
 describe("PR metadata", () => {
+  it("uses cacheable GraphQL file metadata when the complete list fits", () => {
+    const result = readPrMetadata(createFakeGh(), {
+      changedFiles: "2",
+      filesApiFailure: true,
+      graphqlFileCount: "2",
+    });
+
+    expect(result.status).toBe(0);
+    expect(result.stderr).toBe("");
+    const metadata = JSON.parse(result.stdout) as {
+      files: Array<{ changeType: string; path: string }>;
+    };
+    expect(metadata.files).toEqual([
+      { path: "src/graphql-file-0.ts", additions: 1, deletions: 0, changeType: "MODIFIED" },
+      { path: "src/graphql-file-1.ts", additions: 1, deletions: 0, changeType: "DELETED" },
+    ]);
+  });
+
+  it("falls back to REST when cacheable file metadata lacks change types", () => {
+    const result = readPrMetadata(createFakeGh(), {
+      changedFiles: "2",
+      graphqlChangeType: false,
+      graphqlFileCount: "2",
+      restFileCount: "2",
+    });
+
+    expect(result.status).toBe(0);
+    const metadata = JSON.parse(result.stdout) as {
+      files: Array<{ changeType: string; path: string }>;
+    };
+    expect(metadata.files).toEqual([
+      { path: "src/file-0.ts", additions: 1, deletions: 0, changeType: "MODIFIED" },
+      { path: "src/file-1.ts", additions: 1, deletions: 0, changeType: "DELETED" },
+    ]);
+  });
+
   it("paginates all changed files and preserves the GraphQL file shape", () => {
     const result = readPrMetadata(createFakeGh());
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where every `scripts/pr review-init` bypassed the shared GitHub cache and spent direct REST quota to paginate changed files, even when the PR had only a handful of files and `gh pr view --json files` already returned the complete list. Exhausted direct quota then blocked the entire native landing workflow until reset.

## Why This Change Was Made

PR metadata now uses the cacheable GraphQL file list when the reported count is at most 100 and every file has the complete typed shape. Large, truncated, malformed, or older-CLI responses still fall back to the existing paginated REST path, with the same head-drift and count validation.

## User Impact

Most PR review and landing initialization no longer spends uncached REST quota, reducing latency and avoiding quota stalls. Large PRs and incomplete client responses preserve the current exhaustive fail-closed behavior.

## Evidence

- Live incident: a four-file PR landing was blocked until the direct REST quota reset because the wrapper unconditionally called the paginated files endpoint.
- Live post-fix proof on PR #115199: `pr_meta_json 115199` returned the exact two-file typed GraphQL list while an instrumentation guard made any `pulls/115199/files` REST call fail with exit 97. The command exited 0 and the guard never fired.
- Live returned head: `939878c2348b2f4c5dbb6b6860c346b6e63fa2de`; files: `scripts/pr-lib/worktree.sh` and `test/scripts/pr-metadata.test.ts`, both `MODIFIED` with exact additions/deletions.
- Added coverage proving a complete two-file GraphQL response succeeds even when the REST endpoint is configured to fail.
- Added compatibility coverage proving GraphQL responses without `changeType` fall back to REST instead of weakening deletion classification.
- Existing 101-file pagination, incomplete-response, API-failure, and head-drift tests remain covered.
- `pnpm test test/scripts/pr-metadata.test.ts` — 6 passed on Blacksmith Testbox `tbx_01kymc4jc055dfmpf8b9nfh7wd`.
- `pnpm check:changed` — passed test-root typecheck, script lint, formatting, declaration contracts, and repository guards on the same Testbox.
- Exact-head CI run `30361211077` — green.
- Autoreview (`gpt-5.6-sol`, high) — first pass found and fixed the older-CLI `changeType` gap; final pass clean with no accepted/actionable findings.

The branch remains behind `main` without conflicts. Per repository landing policy, behind-main drift is advisory; `scripts/pr merge-run` will perform the strict App-owned test merge against current `main` rather than rewriting this already-green exact head solely for drift.
