### PR TITLE
fix(compaction): enforce transcript byte guard for Codex sessions

### DIFF
--- a/src/agents/embedded-agent-runner/compact.hooks.test.ts
+++ b/src/agents/embedded-agent-runner/compact.hooks.test.ts
@@ -3944,6 +3944,73 @@ describe("compactEmbeddedAgentSession hooks (ownsCompaction engine)", () => {
     });
   });
 
+  it("routes host transcript byte preflight through OpenClaw compaction for Codex sessions", async () => {
+    hookRunner.hasHooks.mockReturnValue(true);
+    contextEngineCompactMock.mockResolvedValueOnce({
+      ok: true,
+      compacted: true,
+      result: {
+        summary: "engine-summary",
+        firstKeptEntryId: "entry-1",
+        tokensBefore: 120,
+        tokensAfter: 50,
+        sessionId: "session-2",
+        sessionTarget: {
+          agentId: "main",
+          sessionId: "session-2",
+          sessionKey: TEST_SESSION_KEY,
+          storePath: "/tmp/sessions.json",
+        },
+      },
+    } as never);
+
+    const result = await compactEmbeddedAgentSession(
+      wrappedCompactionArgs({
+        provider: "openai",
+        model: "gpt-5.5",
+        agentHarnessId: "codex",
+        modelSelectionLocked: true,
+        trigger: "budget",
+        forcePreflight: true,
+        preflightRequired: true,
+        preflightCompactionTrigger: "transcript_bytes",
+        config: {
+          agents: {
+            defaults: {
+              compaction: {
+                truncateAfterCompaction: true,
+              },
+            },
+          },
+        },
+      }),
+    );
+
+    expect(result.ok).toBe(true);
+    expect(result.compacted).toBe(true);
+    expect(result.result).toMatchObject({
+      sessionId: "session-2",
+    });
+    expect(contextEngineCompactMock).toHaveBeenCalledTimes(1);
+    const compactArg = mockCallArg(contextEngineCompactMock) as {
+      runtimeContext?: Record<string, unknown>;
+    };
+    expectRecordFields(compactArg.runtimeContext, {
+      agentHarnessId: "codex",
+      preflightCompactionTrigger: "transcript_bytes",
+    });
+    expect(maybeCompactAgentHarnessSessionMock).not.toHaveBeenCalled();
+    expect(hookRunner.runAfterCompaction).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sessionFile: TEST_SESSION_KEY,
+        previousSessionId: "session-1",
+      }),
+      expect.objectContaining({
+        sessionId: "session-2",
+      }),
+    );
+  });
+
   it("continues forcing engine-owned manual compaction with manual force reason", async () => {
     const result = await compactEmbeddedAgentSession(wrappedCompactionArgs({ trigger: "manual" }));
 

--- a/src/agents/embedded-agent-runner/compact.queued.ts
+++ b/src/agents/embedded-agent-runner/compact.queued.ts
@@ -388,13 +388,21 @@ async function compactResolvedContextEngine(
     preparedRuntimePlan: params.runtimePlan,
     selectedHarnessRuntime: params.modelSelectionLocked === true ? lockedHarnessRuntime : undefined,
   });
+  // Native harness compaction cannot rotate OpenClaw's host transcript. Keep
+  // model locks authoritative for native compaction while letting a host-byte
+  // preflight reach the context engine and carry the binding to its successor.
+  const hostTranscriptBytePreflight = params.preflightCompactionTrigger === "transcript_bytes";
   const lockedNativeHarness =
-    params.modelSelectionLocked === true && selectedHarnessRuntime !== "openclaw";
-  const attemptNativeHarnessCompaction = shouldAttemptNativeHarnessCompaction({
-    provider: ceProvider,
-    nativeHarnessCompaction: resolvedCompactionTarget.nativeHarnessCompaction,
-    selectedHarnessRuntime,
-  });
+    !hostTranscriptBytePreflight &&
+    params.modelSelectionLocked === true &&
+    selectedHarnessRuntime !== "openclaw";
+  const attemptNativeHarnessCompaction =
+    !hostTranscriptBytePreflight &&
+    shouldAttemptNativeHarnessCompaction({
+      provider: ceProvider,
+      nativeHarnessCompaction: resolvedCompactionTarget.nativeHarnessCompaction,
+      selectedHarnessRuntime,
+    });
   let effectiveRuntimeModel: ProviderRuntimeModel | undefined;
   let preparedHarnessRuntime = selectedHarnessRuntime;
   let preparedParams = params;

--- a/src/auto-reply/reply/agent-runner-memory.test.ts
+++ b/src/auto-reply/reply/agent-runner-memory.test.ts
@@ -2176,6 +2176,69 @@ describe("runMemoryFlushIfNeeded", () => {
     expect(compactEmbeddedAgentSessionMock).not.toHaveBeenCalled();
   });
 
+  it("enforces the active transcript byte fuse for persisted Codex runtime sessions", async () => {
+    const sessionFile = path.join(rootDir, "large-codex-session.jsonl");
+    await fs.writeFile(
+      sessionFile,
+      `${JSON.stringify({ message: { role: "user", content: "x".repeat(256) } })}\n`,
+      "utf8",
+    );
+    const sessionEntry: SessionEntry = {
+      sessionId: "session",
+      transcriptPath: sessionFile,
+      updatedAt: Date.now(),
+      totalTokens: 347_000,
+      totalTokensFresh: true,
+      agentHarnessId: "codex",
+      compactionCount: 0,
+    };
+    const sessionStore = { main: sessionEntry };
+
+    const entry = await runPreflightCompactionIfNeeded({
+      cfg: {
+        models: {
+          providers: {
+            openai: { models: [{ id: "gpt-5.5", contextWindow: 350_000 }] },
+          },
+        },
+        agents: {
+          defaults: {
+            compaction: {
+              truncateAfterCompaction: true,
+              maxActiveTranscriptBytes: "10b",
+            },
+          },
+        },
+      } as never,
+      followupRun: createTestFollowupRun({
+        provider: "openai",
+        model: "gpt-5.5",
+        sessionId: "session",
+        sessionFile,
+        sessionKey: "main",
+      }),
+      defaultModel: "gpt-5.5",
+      sessionEntry,
+      sessionStore,
+      sessionKey: "main",
+      storePath: path.join(rootDir, "sessions.json"),
+      isHeartbeat: false,
+      replyOperation: createReplyOperation(),
+    });
+
+    expect(entry?.compactionCount).toBe(1);
+    expect(compactEmbeddedAgentSessionMock).toHaveBeenCalledTimes(1);
+    expect(requireCompactEmbeddedAgentSessionCall()).toMatchObject({
+      sessionId: "session",
+      sessionFile,
+      agentHarnessId: "codex",
+      trigger: "budget",
+      forcePreflight: true,
+      preflightRequired: true,
+      preflightCompactionTrigger: "transcript_bytes",
+    });
+  });
+
   it("skips preflight compaction for compatible CLI session runtime pins", async () => {
     cliBackendsTesting.setDepsForTest({
       resolveRuntimeCliBackends: () => [

--- a/src/auto-reply/reply/agent-runner-memory.test.ts
+++ b/src/auto-reply/reply/agent-runner-memory.test.ts
@@ -2176,13 +2176,20 @@ describe("runMemoryFlushIfNeeded", () => {
     expect(compactEmbeddedAgentSessionMock).not.toHaveBeenCalled();
   });
 
-  it("enforces the active transcript byte fuse for persisted Codex runtime sessions", async () => {
+  it("enforces the 8 MB transcript fuse and adopts Codex successor continuity", async () => {
+    const maxActiveTranscriptBytes = 8 * 1024 * 1024;
     const sessionFile = path.join(rootDir, "large-codex-session.jsonl");
     await fs.writeFile(
       sessionFile,
-      `${JSON.stringify({ message: { role: "user", content: "x".repeat(256) } })}\n`,
+      `${JSON.stringify({
+        message: {
+          role: "user",
+          content: "x".repeat(maxActiveTranscriptBytes + 1),
+        },
+      })}\n`,
       "utf8",
     );
+    expect((await fs.stat(sessionFile)).size).toBeGreaterThan(maxActiveTranscriptBytes);
     const sessionEntry: SessionEntry = {
       sessionId: "session",
       transcriptPath: sessionFile,
@@ -2193,6 +2200,23 @@ describe("runMemoryFlushIfNeeded", () => {
       compactionCount: 0,
     };
     const sessionStore = { main: sessionEntry };
+    const storePath = path.join(rootDir, "sessions.json");
+    const followupRun = createTestFollowupRun({
+      provider: "openai",
+      model: "gpt-5.5",
+      sessionId: "session",
+      sessionFile,
+      sessionKey: "main",
+    });
+    const replyOperation = createReplyOperation();
+    compactEmbeddedAgentSessionMock.mockResolvedValueOnce({
+      ok: true,
+      compacted: true,
+      result: {
+        tokensAfter: 42,
+        sessionId: "session-rotated",
+      },
+    });
 
     const entry = await runPreflightCompactionIfNeeded({
       cfg: {
@@ -2205,28 +2229,32 @@ describe("runMemoryFlushIfNeeded", () => {
           defaults: {
             compaction: {
               truncateAfterCompaction: true,
-              maxActiveTranscriptBytes: "10b",
+              maxActiveTranscriptBytes: "8mb",
             },
           },
         },
       } as never,
-      followupRun: createTestFollowupRun({
-        provider: "openai",
-        model: "gpt-5.5",
-        sessionId: "session",
-        sessionFile,
-        sessionKey: "main",
-      }),
+      followupRun,
       defaultModel: "gpt-5.5",
       sessionEntry,
       sessionStore,
       sessionKey: "main",
-      storePath: path.join(rootDir, "sessions.json"),
+      storePath,
       isHeartbeat: false,
-      replyOperation: createReplyOperation(),
+      replyOperation,
     });
 
+    expect(entry?.sessionId).toBe("session-rotated");
     expect(entry?.compactionCount).toBe(1);
+    expect(followupRun.run.sessionId).toBe("session-rotated");
+    expect(followupRun.run.sessionFile).toBe("main");
+    expect(replyOperation.updateSessionId).toHaveBeenCalledWith("session-rotated");
+    expect(refreshQueuedFollowupSessionMock).toHaveBeenCalledWith({
+      key: "main",
+      previousSessionId: "session",
+      nextSessionId: "session-rotated",
+      nextSessionFile: "main",
+    });
     expect(compactEmbeddedAgentSessionMock).toHaveBeenCalledTimes(1);
     expect(requireCompactEmbeddedAgentSessionCall()).toMatchObject({
       sessionId: "session",

--- a/src/auto-reply/reply/agent-runner-memory.ts
+++ b/src/auto-reply/reply/agent-runner-memory.ts
@@ -800,23 +800,13 @@ export async function runPreflightCompactionIfNeeded(params: {
   if (params.isHeartbeat || isCli) {
     return entry ?? params.sessionEntry;
   }
-  if (
-    followupUsesCodexRuntime({
-      cfg: params.cfg,
-      followupRun: params.followupRun,
-      sessionEntry: entry,
-      sessionKey: params.sessionKey,
-      runtimePolicySessionKey: params.runtimePolicySessionKey,
-    })
-  ) {
-    // Codex runtime sessions should reach Codex with their real thread state.
-    // Its harness owns automatic compaction; OpenClaw preflight compaction is
-    // only for non-Codex embedded runtimes.
-    logVerbose(
-      `preflightCompaction skipped: sessionKey=${params.sessionKey} runtime=codex reason=codex_native_auto_compaction`,
-    );
-    return entry ?? params.sessionEntry;
-  }
+  const usesCodexRuntime = followupUsesCodexRuntime({
+    cfg: params.cfg,
+    followupRun: params.followupRun,
+    sessionEntry: entry,
+    sessionKey: params.sessionKey,
+    runtimePolicySessionKey: params.runtimePolicySessionKey,
+  });
 
   const compactionSessionKey = params.sessionKey ?? params.followupRun.run.sessionKey;
   if (!compactionSessionKey) {
@@ -878,7 +868,7 @@ export async function runPreflightCompactionIfNeeded(params: {
   const maxActiveTranscriptBytes = resolveMaxActiveTranscriptBytes(params.cfg);
   const shouldCheckActiveTranscriptBytes = typeof maxActiveTranscriptBytes === "number";
   const transcriptUsageTokens =
-    typeof freshPersistedTokens === "number" && !freshNeedsOutputRead
+    usesCodexRuntime || (typeof freshPersistedTokens === "number" && !freshNeedsOutputRead)
       ? undefined
       : await estimatePromptTokensFromSessionTranscript({
           agentId: compactionAgentId,
@@ -905,6 +895,17 @@ export async function runPreflightCompactionIfNeeded(params: {
     typeof activeTranscriptBytes === "number" &&
     typeof maxActiveTranscriptBytes === "number" &&
     activeTranscriptBytes >= maxActiveTranscriptBytes;
+  if (usesCodexRuntime && !shouldCompactByTranscriptBytes) {
+    // Codex owns token-pressure compaction for its native thread, while
+    // OpenClaw still owns the host transcript file and its byte-size fuse.
+    logVerbose(
+      `preflightCompaction skipped: sessionKey=${params.sessionKey} runtime=codex ` +
+        `reason=codex_native_auto_compaction ` +
+        `activeTranscriptBytes=${activeTranscriptBytes ?? "undefined"} ` +
+        `maxActiveTranscriptBytes=${maxActiveTranscriptBytes ?? "undefined"}`,
+    );
+    return entry ?? params.sessionEntry;
+  }
   const stalePersistedPromptTokens =
     hasPersistedTotalTokens && entry.totalTokensFresh !== false
       ? Math.floor(persistedTotalTokens)
@@ -951,14 +952,16 @@ export async function runPreflightCompactionIfNeeded(params: {
       `sizeTrigger=${shouldCompactByTranscriptBytes}`,
   );
 
-  const shouldCompactByTokens = shouldRunPreflightCompaction({
-    entry,
-    tokenCount: tokenCountForCompaction,
-    contextWindowTokens,
-    reserveTokensFloor,
-    softThresholdTokens,
-    minimumThresholdTokens: serverCompactionThreshold,
-  });
+  const shouldCompactByTokens =
+    !usesCodexRuntime &&
+    shouldRunPreflightCompaction({
+      entry,
+      tokenCount: tokenCountForCompaction,
+      contextWindowTokens,
+      reserveTokensFloor,
+      softThresholdTokens,
+      minimumThresholdTokens: serverCompactionThreshold,
+    });
   const shouldCompact = shouldCompactByTokens || shouldCompactByTranscriptBytes;
   if (!shouldCompact) {
     return entry ?? params.sessionEntry;


### PR DESCRIPTION
Closes #115192

## What Problem This Solves

Fixes an issue where Codex-backed sessions could continue growing past
`agents.defaults.compaction.maxActiveTranscriptBytes` because OpenClaw skipped
all preflight compaction for the Codex runtime. In the reported canary, a
9.44 MB active transcript accepted another turn despite an 8 MB limit and did
not rotate.

## Why This Change Was Made

Codex continues to own token-pressure compaction for its native model thread.
OpenClaw now still evaluates its host-transcript byte fuse for Codex sessions
and routes only that byte-triggered preflight through the OpenClaw context
engine. The host compaction successor is then exposed to the existing
`after_compaction` hook so the Codex plugin can adopt its thread binding.

The byte-trigger path also bypasses the native-harness compaction attempt and
the locked-native early return. Model-selection locks remain authoritative for
all other native compaction paths.

## User Impact

Operators can rely on `maxActiveTranscriptBytes` for Codex-backed sessions as
well as OpenClaw-native sessions. Codex's normal token compaction and native
thread bootstrap behavior are unchanged.

## Evidence

- Before: a live 9.44 MB Codex-backed OpenClaw transcript exceeded an 8 MB
  limit without rotation; logs reported
  `reason=codex_native_auto_compaction`.
- Focused OpenClaw tests: 178 passed
  (`agent-runner-memory.test.ts`, `compact.hooks.test.ts`), including the new
  persisted-Codex byte-fuse and locked-Codex host-compaction cases.
- Codex plugin binding tests: 26 passed (`extensions/codex/index.test.ts`).
- `OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 pnpm check:changed`: passed locally,
  including formatting, core/core-test typechecks, changed-file lint, plugin
  boundaries, schema guards, and zero runtime import cycles.
- Separate focused `oxlint`, `tsgo:core`, `tsgo:core:test`, and import-cycle
  checks passed.
- The configured Blacksmith Testbox delegation could not start on this host
  because no functional `crabbox` binary was available; CI remains the remote
  Linux proof.
- Verified the native Codex compaction contract against upstream Codex commit
  `e597169e9a783156e50ae9765d891a3dd74df064`: `thread/compact/start` submits
  native `Op::Compact` and reports completion through compaction item events.
- No runtime configuration, deployment, or live session was mutated.

AI-assisted implementation; manually reviewed against the OpenClaw/Codex
runtime ownership boundary.
