### PR TITLE
test(ui): share pauseVirtualClock e2e helper and de-flake marquee hover-delay asserts

### DIFF
--- a/ui/src/e2e/chat-flow.navigation-presentation.e2e.test.ts
+++ b/ui/src/e2e/chat-flow.navigation-presentation.e2e.test.ts
@@ -7,6 +7,7 @@ import {
   createChatFlowE2eSuite,
   expectDefined,
   installMockGateway,
+  pauseVirtualClock,
   requireRecord,
   sidebarSessionOrder,
   waitForChatScrollIdle,
@@ -839,20 +840,29 @@ suite.define(() => {
       }));
       expect(layout.scrollWidth, JSON.stringify(layout)).toBeGreaterThan(layout.clientWidth);
 
+      // Freeze the clock so the 500ms hover-intent delay elapses only via
+      // runFor; a ticking clock let slow runners start the marquee before the
+      // "not yet scrolling" asserts below.
+      await pauseVirtualClock(page);
       await recentRow.dispatchEvent("mouseenter");
       await page.clock.runFor(250);
       expect(await recentLabel.evaluate((label) => label.classList.value)).not.toContain(
         "hover-marquee--scrolling",
       );
       await recentRow.dispatchEvent("mouseleave");
+      // 250 + 300 exceeds the hover delay: only the leave-cancel keeps it off.
       await page.clock.runFor(300);
       expect(await recentLabel.evaluate((label) => label.classList.value)).not.toContain(
         "hover-marquee--scrolling",
       );
       await recentRow.dispatchEvent("mouseenter");
+      await page.clock.runFor(500);
       await expect
         .poll(() => recentLabel.evaluate((label) => label.classList.value), { timeout: 1_500 })
         .toContain("hover-marquee--scrolling");
+      // Resume real time: the snap-back below is a compositor-driven CSS
+      // transition, not a fake-timer callback.
+      await page.clock.resume();
       await recentRow.dispatchEvent("mouseleave");
       await expect
         .poll(

--- a/ui/src/e2e/chat-flow.test-support.ts
+++ b/ui/src/e2e/chat-flow.test-support.ts
@@ -8,6 +8,7 @@ import {
   controlUiSessionPath,
   controlUiSessionUrl,
   installMockGateway,
+  pauseVirtualClock,
   type MockGatewayRequest,
 } from "../test-helpers/control-ui-e2e.ts";
 import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
@@ -18,6 +19,7 @@ export {
   controlUiSessionPath,
   controlUiSessionUrl,
   installMockGateway,
+  pauseVirtualClock,
 };
 
 export const managedImageCacheProofDir = path.join(

--- a/ui/src/e2e/chat-run-lifecycle.e2e.test.ts
+++ b/ui/src/e2e/chat-run-lifecycle.e2e.test.ts
@@ -7,6 +7,7 @@ import { CHAT_RUN_STATUS_TOAST_DURATION_MS } from "../pages/chat/run-lifecycle.t
 import {
   canRunPlaywrightChromium,
   installMockGateway,
+  pauseVirtualClock,
   resolvePlaywrightChromiumExecutablePath,
   startControlUiE2eServer,
   type ControlUiE2eServer,
@@ -109,10 +110,9 @@ describeControlUiE2e("Control UI chat run lifecycle", () => {
     await currentPage.goto(`${server?.baseUrl ?? ""}chat`);
     await currentPage.getByText("saved 875.3k tokens", { exact: true }).waitFor();
     await currentPage.locator(".agent-chat__input textarea").fill("keep working");
-    // Pause the virtual clock before sending: the working timer starts at the
-    // send click, and an unpaused installed clock still ticks in real time,
-    // letting slow CI inflate the fast-forwarded "2m 57s" to "2m 59s".
-    await currentPage.clock.pauseAt((await currentPage.evaluate(() => Date.now())) + 5_000);
+    // The working timer starts at the send click; pause first so the elapsed
+    // reading is exactly the fastForward below, not inflated by real time.
+    await pauseVirtualClock(currentPage);
     await currentPage.getByRole("button", { name: "Send message" }).click();
     await gateway.waitForRequest("chat.send");
     await currentPage.locator(".chat-working-indicator").waitFor();

--- a/ui/src/e2e/mantis-chat-proof.e2e.test.ts
+++ b/ui/src/e2e/mantis-chat-proof.e2e.test.ts
@@ -6,6 +6,7 @@ import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import {
   canRunPlaywrightChromium,
   installMockGateway,
+  pauseVirtualClock,
   resolvePlaywrightChromiumExecutablePath,
   startControlUiE2eServer,
   type ControlUiE2eServer,
@@ -96,10 +97,9 @@ describeMantisWebUiChat("Mantis Control UI web chat proof", () => {
       await page.goto(`${server.baseUrl}chat`);
       await page.getByText("Mantis web UI proof is ready.").waitFor({ timeout: 10_000 });
       await page.locator(".agent-chat__composer-combobox textarea").fill(prompt);
-      // Pause the virtual clock before sending: the working timer starts at the
-      // send click, and an unpaused installed clock still ticks in real time,
-      // letting slow CI inflate the fast-forwarded "2m 57s" to "2m 59s".
-      await page.clock.pauseAt((await page.evaluate(() => Date.now())) + 5_000);
+      // The working timer starts at the send click; pause first so the elapsed
+      // reading is exactly the fastForward below, not inflated by real time.
+      await pauseVirtualClock(page);
       await page.getByRole("button", { name: "Send message" }).click();
 
       const sendRequest = await gateway.waitForRequest("chat.send");

--- a/ui/src/test-helpers/control-ui-e2e.ts
+++ b/ui/src/test-helpers/control-ui-e2e.ts
@@ -201,6 +201,16 @@ export function canRunPlaywrightChromium(chromiumExecutablePath: string): boolea
   return spawnSync(chromiumExecutablePath, ["--version"], { stdio: "ignore" }).status === 0;
 }
 
+// Pause an installed virtual clock slightly ahead of its current time so
+// elapsed time advances only through clock.runFor/fastForward. Without this,
+// page.clock.install() keeps ticking at real-time rate, and slow runners break
+// assertions that a virtual deadline has or has not elapsed yet (#115187). The
+// headroom keeps the pauseAt target ahead of the still-ticking clock between
+// the Date.now() read and the pause; jumping to it fires nothing relevant.
+export async function pauseVirtualClock(page: Page): Promise<void> {
+  await page.clock.pauseAt((await page.evaluate(() => Date.now())) + 5_000);
+}
+
 export async function startControlUiE2eServer(
   buildInfo: ControlUiBuildInfo = {
     version: "2026.7.10",


### PR DESCRIPTION
## What Problem This Solves

PR #115187 fixed a `checks-ui-e2e` flake where `page.clock.install()` without a pause let real CI seconds leak into a virtual-time assertion (`expected '2m 57s', received '2m 59s'`). A follow-up audit of every `page.clock` user in `ui/src/e2e` found one more latent instance of the same class, plus two inline copies of the subtle pause logic worth centralizing.

The latent flake: the marquee test in `ui/src/e2e/chat-flow.navigation-presentation.e2e.test.ts` dispatches `mouseenter`, advances the virtual clock 250ms, and asserts the marquee is **not yet** scrolling against a 500ms hover-intent delay (`MARQUEE_HOVER_DELAY_MS` in `ui/src/lib/hover-marquee.ts`). With an unpaused installed clock, more than 250ms of real time between the hover and the assert starts the marquee early and fails the test — the same non-monotone-assertion mechanism as #115187, just with 250ms headroom instead of 0.

All other clock users in the suite (github-link-hovercard, login-gate, session-management.groups, claude-sessions, agent-select-avatar-timeout, approval-page, lobster-pet) make monotone assertions ("after enough time, X happened" / "still nothing after extra time") or already pause/fix the time, which extra real ticking cannot flip; they are intentionally untouched.

## Why This Change Was Made

- New shared helper `pauseVirtualClock(page)` in `ui/src/test-helpers/control-ui-e2e.ts` owns the non-obvious boundary logic (pause slightly ahead of the current virtual time so the `pauseAt` target stays ahead of the still-ticking clock). Three call sites now share it instead of copying it.
- `mantis-chat-proof.e2e.test.ts` and `chat-run-lifecycle.e2e.test.ts` migrate their inline copies from #115187 onto the helper.
- The marquee test freezes the clock for the hover-delay window, which also strengthens it: the "still not scrolling after `mouseleave` + 300ms" assert now proves the leave-cancel (250+300 > 500 would have fired the marquee otherwise), and the scroll-start assert becomes a deterministic `runFor(500)` instead of a 1.5s real-time poll. The clock then `resume()`s before the snap-back assert, which depends on a compositor-driven CSS transition, not fake timers.

## User Impact

None — test-only. Removes the remaining latent instance of the #115187 flake class from `checks-ui-e2e`.

## Evidence

All three affected specs pass:

```text
$ node scripts/run-vitest.mjs ui/src/e2e/mantis-chat-proof.e2e.test.ts ui/src/e2e/chat-run-lifecycle.e2e.test.ts
 Test Files  2 passed (2)
      Tests  5 passed (5)

$ node scripts/run-vitest.mjs ui/src/e2e/chat-flow.navigation-presentation.e2e.test.ts
 Test Files  1 passed (1)
      Tests  11 passed (11)
```

**Determinism proof (before/after with simulated CI slowness).** Injecting a real `await page.waitForTimeout(400)` after the marquee `mouseenter` (more than the pre-fix 250ms headroom) reproduces the latent flake on the pre-fix code and passes with this PR:

Before (pre-fix marquee code, 400ms delay injected):

```text
 FAIL  |ui-e2e| ui/src/e2e/chat-flow.navigation-presentation.e2e.test.ts > Control UI mocked Gateway E2E > keeps long sidebar labels clipped after a session switch
AssertionError: expected 'sidebar-recent-session__name hover-ma…' not to contain 'hover-marquee--scrolling'
Expected: "hover-marquee--scrolling"
Received: "sidebar-recent-session__name hover-marquee hover-marquee--scrolling"
 Test Files  1 failed (1)
      Tests  1 failed | 10 passed (11)
```

After (this PR, same 400ms delay injected):

```text
 Test Files  1 passed (1)
      Tests  11 passed (11)
```

- Codex autoreview (`gpt-5.6-sol`, xhigh): clean, "patch is correct (0.94)".
