### PR TITLE
fix(docs): prevent fenced code from blocking translation retries

### DIFF
--- a/scripts/docs-i18n/doc_mode_test.go
+++ b/scripts/docs-i18n/doc_mode_test.go
@@ -1209,6 +1209,38 @@ func TestValidateDocChunkTranslationAllowsTranslatedProseInIsolatedIndentedFence
 	}
 }
 
+func TestValidateDocChunkTranslationAllowsDedentedCodeInIndentedFence(t *testing.T) {
+	t.Parallel()
+
+	sourceFence := "    ```typescript\n" +
+		"const plugin = createPlugin<Account>({\n" +
+		"  // Account resolution belongs on `config`.\n" +
+		"  notify: (code) => `Pairing code: ${code}`,\n" +
+		"});\n" +
+		"    ```\n"
+	translatedFence := "    ```typescript\n" +
+		"const plugin = createPlugin<Account>({\n" +
+		"  // La resolución de cuentas pertenece a `config`.\n" +
+		"  notify: (code) => `Código de emparejamiento: ${code}`,\n" +
+		"});\n" +
+		"    ```\n"
+
+	if err := validateDocChunkTranslation(sourceFence, translatedFence); err != nil {
+		t.Fatalf("expected translated pure fenced chunk to validate, got %v", err)
+	}
+
+	source := "<Example>\n" + sourceFence + "    Run `openclaw doctor` after editing.\n</Example>\n"
+	translated := "<Example>\n" + translatedFence + "    Ejecuta `openclaw doctor` después de editar.\n</Example>\n"
+	if err := validateDocChunkTranslation(source, translated); err != nil {
+		t.Fatalf("expected translated component fence and preserved trailing inline code to validate, got %v", err)
+	}
+	changedTrailingCode := strings.Replace(translated, "`openclaw doctor`", "`openclaw fix`", 1)
+	err := validateDocChunkTranslation(source, changedTrailingCode)
+	if err == nil || !strings.Contains(err.Error(), "inline code mismatch") {
+		t.Fatalf("expected changed inline code after the fence to be rejected, got %v", err)
+	}
+}
+
 func TestValidateDocChunkTranslationRejectsChangedCodeInSplitComponentBody(t *testing.T) {
 	t.Parallel()
 

--- a/scripts/docs-i18n/markdown_segments.go
+++ b/scripts/docs-i18n/markdown_segments.go
@@ -182,6 +182,11 @@ func markdownListParentItemPath(list *ast.List) string {
 }
 
 func extractMarkdownInlineCodeValues(body string) []string {
+	if _, opening, _, _, _, ok := splitPureFencedDocSection(body); ok {
+		if _, validOpening := parseMarkdownLiteralFenceOpening(opening); validOpening {
+			return nil
+		}
+	}
 	parseSource := []byte(normalizeDocComponentsForMarkdownParse(body))
 	fencedRanges := markdownClosedLiteralFenceByteRanges(string(parseSource))
 	doc := goldmark.New(goldmark.WithExtensions(extension.GFM)).Parser().Parse(text.NewReader(parseSource))


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where full docs translation runs could repeatedly fail when translated prose inside an indented fenced code block contained backticks. The validator treated those code-fence values as protected inline code, so valid translated comments and template strings were rejected.

## Why This Change Was Made

Pure literal fenced chunks now bypass Markdown inline-code extraction. Mixed chunks still use the existing validator, so protected inline code after a fence remains immutable.

## User Impact

Docs translation retries can complete for pages containing translated comments or template strings inside fenced examples without weakening inline-code checks elsewhere.

## Evidence

- Production failure: Translate Full run `30187722394` failed affected locale shards on inline-code validation.
- Regression coverage accepts translated comments and template strings inside an indented TypeScript fence.
- Regression coverage preserves validation for trailing inline code and rejects a changed `openclaw doctor` command.
- `go test ./...`
- `go vet ./...`
- `git diff --check`
- Mandatory autoreview passed after narrowing the implementation to the pure-fence case.

Companion workflow recovery PR: https://github.com/openclaw/docs/pull/119
