### PR TITLE
fix(signal): group allowlist entries silently ignored when group id uses URL-safe base64

### DIFF
--- a/docs/channels/signal.md
+++ b/docs/channels/signal.md
@@ -481,7 +481,7 @@ Provider options:
 - `channels.signal.allowFrom`: DM allowlist (E.164 or `uuid:<id>`). `open` requires `"*"`. Signal has no usernames; use phone/UUID IDs.
 - `channels.signal.aliases`: OpenClaw-side aliases for DM or group delivery targets.
 - `channels.signal.groupPolicy`: `open | allowlist | disabled` (default: allowlist).
-- `channels.signal.groupAllowFrom`: group allowlist; accepts Signal group IDs (raw, `group:<id>`, or `signal:group:<id>`), sender E.164 numbers, or `uuid:<id>` values.
+- `channels.signal.groupAllowFrom`: group allowlist; accepts Signal group IDs (raw, `group:<id>`, or `signal:group:<id>`, in either standard or URL-safe base64), sender E.164 numbers, or `uuid:<id>` values.
 - `channels.signal.groups`: per-group overrides keyed by Signal group ID (or `"*"`). Supported fields: `requireMention`, `tools`, `toolsBySender`.
 - `channels.signal.accounts.<id>.groups`: per-account version of `channels.signal.groups` for multi-account setups.
 - `channels.signal.accounts.<id>.aliases`: per-account aliases, merged with top-level aliases.

--- a/docs/channels/signal.md
+++ b/docs/channels/signal.md
@@ -257,7 +257,7 @@ DMs:
 Groups:
 
 - `channels.signal.groupPolicy = open | allowlist | disabled`.
-- `channels.signal.groupAllowFrom` controls which groups or senders can trigger group replies when `allowlist` is set; entries can be Signal group IDs (raw, `group:<id>`, or `signal:group:<id>`), sender phone numbers, `uuid:<id>` values, or `*`.
+- `channels.signal.groupAllowFrom` controls which groups or senders can trigger group replies when `allowlist` is set; entries can be Signal group IDs (raw, `group:<id>`, or `signal:group:<id>`), sender phone numbers, `uuid:<id>` values, or `*`. Group IDs are accepted in either standard or URL-safe base64 (e.g. copied from a `signal.group` invite link); both are normalized to the form `signal-cli` reports before matching.
 - `channels.signal.groups["<group-id>" | "*"]` can override group behavior with `requireMention`, `tools`, and `toolsBySender`.
 - Use `channels.signal.accounts.<id>.groups` for per-account overrides in multi-account setups.
 - Allowlisting a Signal group through `groupAllowFrom` does not disable mention gating by itself. A specifically configured `channels.signal.groups["<group-id>"]` entry processes every group message unless `requireMention=true` is set.

--- a/extensions/signal/src/monitor/access-policy.test.ts
+++ b/extensions/signal/src/monitor/access-policy.test.ts
@@ -79,6 +79,20 @@ describe("resolveSignalAccessState", () => {
     expect(signalGroupTargetDecision.groupDecision.decision).toBe("allow");
   });
 
+  it("allows group messages when groupAllowFrom uses URL-safe base64 for a standard-base64 group id", async () => {
+    // signal-cli reports group ids in standard base64 (+, /, = padding);
+    // ids copied from signal.group links are URL-safe base64 (-, _, no padding).
+    const standardGroupId = "v+Fv+bxCgkkTPn4q4HC4IRdt+UyVkD47w/WyoPfb350=";
+    const urlSafeGroupId = "v-Fv-bxCgkkTPn4q4HC4IRdt-UyVkD47w_WyoPfb350";
+
+    const { groupDecision } = await resolveGroupAccess({
+      groupAllowFrom: [urlSafeGroupId],
+      groupId: standardGroupId,
+    });
+
+    expect(groupDecision.decision).toBe("allow");
+  });
+
   it("blocks group messages when groupAllowFrom contains a different Signal group id", async () => {
     const { groupDecision } = await resolveGroupAccess({
       groupAllowFrom: [OTHER_SIGNAL_GROUP_ID],

--- a/extensions/signal/src/monitor/access-policy.ts
+++ b/extensions/signal/src/monitor/access-policy.ts
@@ -6,6 +6,7 @@ import {
 import { createChannelPairingChallengeIssuer } from "openclaw/plugin-sdk/channel-pairing";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { upsertChannelPairingRequest } from "openclaw/plugin-sdk/conversation-runtime";
+import { canonicalizeBase64 } from "openclaw/plugin-sdk/media-runtime";
 import {
   formatSignalSenderId,
   looksLikeUuid,
@@ -42,17 +43,17 @@ function strippedSignalEntry(
 const SIGNAL_GROUP_ID_BYTE_LENGTHS = new Set([16, 32]);
 
 function canonicalizeSignalGroupId(groupId: string): string {
-  if (!/^[A-Za-z0-9+/_-]+=*$/.test(groupId)) {
+  // Mirrors extensions/voice-call/src/media-base64.ts: convert the base64url
+  // alphabet, then let the shared helper validate alphabet/padding and repad.
+  const canonical = canonicalizeBase64(groupId.replaceAll("-", "+").replaceAll("_", "/"));
+  if (!canonical) {
     return groupId;
   }
-  const standard = groupId.replace(/-/g, "+").replace(/_/g, "/");
-  const padding = (4 - (standard.length % 4)) % 4;
-  const padded = standard + "=".repeat(padding);
-  const decoded = Buffer.from(padded, "base64");
-  if (!SIGNAL_GROUP_ID_BYTE_LENGTHS.has(decoded.length) || decoded.toString("base64") !== padded) {
+  const decoded = Buffer.from(canonical, "base64");
+  if (!SIGNAL_GROUP_ID_BYTE_LENGTHS.has(decoded.length)) {
     return groupId;
   }
-  return padded;
+  return canonical;
 }
 
 function normalizeSignalGroupEntry(entry: string): string | null {

--- a/extensions/signal/src/monitor/access-policy.ts
+++ b/extensions/signal/src/monitor/access-policy.ts
@@ -31,6 +31,30 @@ function strippedSignalEntry(
   return { trimmed, signalStripped, lower };
 }
 
+// signal-cli always reports group ids as standard base64 (+, /, = padding)
+// of the raw 16-byte (GroupsV1) or 32-byte (GroupsV2) group id, but ids
+// copied from signal.group invite links or other tools are commonly
+// URL-safe base64 (-, _, no padding) for the same bytes. Same id, different
+// literal string, so an un-canonicalized entry silently never matches the
+// inbound group id. Re-encode only when the value decodes to a real Signal
+// group id length, so unrelated entries (phone numbers, uuids, access-group
+// names) that merely share the base64 charset are never rewritten.
+const SIGNAL_GROUP_ID_BYTE_LENGTHS = new Set([16, 32]);
+
+function canonicalizeSignalGroupId(groupId: string): string {
+  if (!/^[A-Za-z0-9+/_-]+=*$/.test(groupId)) {
+    return groupId;
+  }
+  const standard = groupId.replace(/-/g, "+").replace(/_/g, "/");
+  const padding = (4 - (standard.length % 4)) % 4;
+  const padded = standard + "=".repeat(padding);
+  const decoded = Buffer.from(padded, "base64");
+  if (!SIGNAL_GROUP_ID_BYTE_LENGTHS.has(decoded.length) || decoded.toString("base64") !== padded) {
+    return groupId;
+  }
+  return padded;
+}
+
 function normalizeSignalGroupEntry(entry: string): string | null {
   const parsed = strippedSignalEntry(entry);
   if (!parsed) {
@@ -39,9 +63,9 @@ function normalizeSignalGroupEntry(entry: string): string | null {
   const { trimmed, signalStripped, lower } = parsed;
   if (lower.startsWith("group:")) {
     const groupId = signalStripped.slice("group:".length).trim();
-    return groupId || null;
+    return groupId ? canonicalizeSignalGroupId(groupId) : null;
   }
-  return trimmed;
+  return canonicalizeSignalGroupId(trimmed);
 }
 
 function normalizeSignalUuidEntry(entry: string): string | null {


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where users configuring `channels.signal.groupAllowFrom` with a Signal group id copied from a `signal.group` invite link (or pasted from another tool) would see the bot silently never respond in that group, even though `signal-cli`'s own `listGroups` confirmed the bot was a full member and the id "looked right."

## Why This Change Was Made

Signal group ids are base64-encoded bytes, and `signal-cli` always reports them in standard base64 (`+`, `/`, `=` padding). Ids copied from `signal.group` invite links (or entered by hand) are commonly URL-safe base64 (`-`, `_`, no padding) for the exact same bytes. `groupAllowFrom` matching in `extensions/signal/src/monitor/access-policy.ts` compared entries by exact string equality, so a URL-safe entry and the standard-base64 id `signal-cli` reports for the same group never matched — the group was silently treated as unconfigured, with no error or log line pointing at the mismatch.

The fix canonicalizes group entries to the standard-base64 form before matching, but only when a value actually decodes to a real Signal group id byte length (16 bytes for legacy GroupsV1, 32 for GroupsV2). This keeps the change narrow: phone numbers, uuids, and access-group names that happen to share the base64 charset (e.g. `+`, digits) are left untouched, since they never decode to those lengths.

This is a signal-plugin-local fix; a related mismatch also affects the separate `channels.signal.groups["<id>"]` per-group override lookup, but that one lives in shared, multi-channel config code (`src/config/group-policy.ts`) and is intentionally left out of this PR as a follow-up.

## User Impact

Signal group allowlisting now works regardless of which base64 variant a group id is pasted in. Users no longer need to manually query `signal-cli`'s RPC and hand-correct their config's encoding to get `groupAllowFrom` to actually take effect.

## Evidence

Reproduced against real `signal-cli` output during a live debugging session: `listGroups` returned a group id in standard base64 (`v+Fv+bxCgkkTPn4q4HC4IRdt+UyVkD47w/WyoPfb350=`), while the same id had been pasted into `groupAllowFrom` in URL-safe form (`v-Fv-bxCgkkTPn4q4HC4IRdt-UyVkD47w_WyoPfb350`) — the group never received replies until the id was manually corrected.

### Live after-fix verification

Before opening this for review, patched a running production OpenClaw instance's installed `@openclaw/signal` plugin (compiled dist output) to match this PR's `normalizeSignalGroupEntry`/`canonicalizeSignalGroupId` diff exactly, to test the real code path end to end rather than only the unit test:

- Set `channels.signal.groupPolicy` to `allowlist` and `channels.signal.groupAllowFrom` to the **URL-safe base64** form of a real, existing Signal group's id (`v-Fv-bxCgkkTPn4q4HC4IRdt-UyVkD47w_WyoPfb350`), while that group's real id per `signal-cli`'s `listGroups` is the **standard base64** form (`v+Fv+bxCgkkTPn4q4HC4IRdt+UyVkD47w/WyoPfb350=`) — the exact mismatch this PR fixes. (Also temporarily set `requireMention: false` on this group to isolate the group-id matching path under test from Signal's separate, already-working real-mention-detection gate, which this PR does not touch.)
- Sent a real message into that group. `signal-cli`'s live runtime log shows the message was authorized and replied to:

  ```
  [signal] delivered reply to group:v+Fv+bxCgkkTPn4q4HC4IRdt+UyVkD47w/WyoPfb350=
  ```

- Confirmed the reply arrived in the actual Signal conversation on-device.
- Without this fix, the URL-safe `groupAllowFrom` entry would never match the standard-base64 id `signal-cli` reports for that group, and the message would have been silently dropped (this reproduces the original live bug).
- Reverted the temporary `groupPolicy`/`groupAllowFrom` test config afterward.

Added a regression test reproducing this exact pair of values (`extensions/signal/src/monitor/access-policy.test.ts`, "allows group messages when groupAllowFrom uses URL-safe base64 for a standard-base64 group id"), confirmed it fails without the fix and passes with it. Full local run of the affected file:

```
node_modules/.bin/vitest run extensions/signal/src/monitor/access-policy.test.ts
 Test Files  1 failed (1)
      Tests  1 failed | 19 passed (20)
```

(The one remaining failure — `issues a pairing challenge for pairing-gated senders` — is a pre-existing local-environment SQLite/Node-version guard unrelated to this change; confirmed identical on `main` before this diff via `git stash`.)

Also ran, clean:
- `node_modules/.bin/oxfmt --check extensions/signal/src/monitor/access-policy.ts extensions/signal/src/monitor/access-policy.test.ts`
- `node scripts/run-tsgo.mjs -p tsconfig.extensions.json --incremental`