### PR TITLE
fix(doctor): stop repeated bundledDiscovery migration noise on beta

### DIFF
--- a/src/infra/state-migrations.config-machine-state.test.ts
+++ b/src/infra/state-migrations.config-machine-state.test.ts
@@ -196,4 +196,36 @@ describe("legacy config machine-state migration", () => {
 
     expect(readControlUiDeviceAuthMigrationState({ env })).toBeUndefined();
   });
+
+  it("does not re-report inferred bundledDiscovery on second pass with beta version", () => {
+    const stateDir = mkdtempSync(join(tmpdir(), "openclaw-config-machine-state-"));
+    const env = { ...process.env, OPENCLAW_STATE_DIR: stateDir };
+
+    // First pass: infer compat and write to SQLite
+    const firstResult = migrateLegacyConfigMachineState({
+      env,
+      config: {
+        meta: { lastTouchedVersion: "2026.7.2-beta.5" },
+        plugins: { allow: ["telegram"] },
+      },
+    });
+    expect(firstResult.changes).toContain(
+      "Migrated plugins.bundledDiscovery → shared SQLite state",
+    );
+    expect(readConfigMachineState("plugins.bundledDiscovery", { env })).toBe("compat");
+
+    // Second pass (simulating a new CLI process): should not report kept
+    const secondResult = migrateLegacyConfigMachineState({
+      env,
+      config: {
+        meta: { lastTouchedVersion: "2026.7.2-beta.5" },
+        plugins: { allow: ["telegram"] },
+      },
+    });
+    expect(secondResult.changes).not.toContain(
+      "Kept existing shared SQLite plugins.bundledDiscovery state",
+    );
+    // Canonical value is preserved
+    expect(readConfigMachineState("plugins.bundledDiscovery", { env })).toBe("compat");
+  });
 });

--- a/src/infra/state-migrations.config-machine-state.ts
+++ b/src/infra/state-migrations.config-machine-state.ts
@@ -3,6 +3,7 @@ import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { compareOpenClawVersions } from "../config/version.js";
 import {
   importConfigMachineState,
+  readConfigMachineState,
   updateConfigMachineState,
 } from "../state/config-machine-state.js";
 import {
@@ -57,7 +58,22 @@ export function migrateLegacyConfigMachineState(params: {
       compareOpenClawVersions(meta.lastTouchedVersion, BUNDLED_DISCOVERY_STATE_CUTOVER_VERSION) ===
         -1)
   ) {
-    entries.push(["plugins.bundledDiscovery", "compat"]);
+    // Only infer compat when the canonical SQLite row does not already exist.
+    // Beta versions (e.g. 2026.7.2-beta.5) are treated by SemVer as older than
+    // the cutover release (2026.7.2), so the inference re-fires on every new
+    // CLI process.  Checking for an existing canonical value here avoids
+    // re-reporting the already-preserved state as a Doctor change.
+    let hasCanonicalState = false;
+    try {
+      hasCanonicalState =
+        readConfigMachineState("plugins.bundledDiscovery", { env: params.env }) !== undefined;
+    } catch {
+      // SQLite temporarily unavailable — fall through to infer compat;
+      // importConfigMachineState below will handle it.
+    }
+    if (!hasCanonicalState) {
+      entries.push(["plugins.bundledDiscovery", "compat"]);
+    }
   }
   const tts = record(raw.tts);
   if (tts && Object.hasOwn(tts, "prefsPath")) {


### PR DESCRIPTION
## What Problem This Solves

Doctor preflight and `openclaw status --deep` repeatedly report a no-op `plugins.bundledDiscovery` migration as an auto-migrated legacy state change on every beta CLI process, creating misleading log noise and unnecessary concern that every restart is re-running a migration.

- **Problem**: On beta versions (SemVer prerelease `< 2026.7.2`), `migrateLegacyConfigMachineState` re-infers `plugins.bundledDiscovery = "compat"` on every new process. The entry always hits the SQLite `kept` path, which is then reported as a Doctor change — even though no state actually changed.
- **Solution**: Skip the inferred compat candidate when the canonical SQLite row already exists. A `try/catch` guards against temporary SQLite unavailability.
- **What changed**: `src/infra/state-migrations.config-machine-state.ts` (inference gate), `src/infra/state-migrations.config-machine-state.test.ts` (regression test)
- **What did NOT change**: Explicit `plugins.bundledDiscovery` handling, `importConfigMachineState` behavior, keeping/reporting logic for other migration entries, any other Doctor migration source

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Fixes #115151
- [x] This PR fixes a bug or regression

## Motivation

Fixes #115151. The bug is fully resolved: after this patch, beta users will no longer see repeated "Kept existing shared SQLite plugins.bundledDiscovery state" messages on every CLI process restart.

Beta versions (e.g. `2026.7.2-beta.5`) are treated by SemVer as older than the cutover release `2026.7.2`: `compareOpenClawVersions("2026.7.2-beta.5", "2026.7.2")` returns `-1`. This means the `else if` inference branch in `migrateLegacyConfigMachineState` fires on every new CLI process for any user on a beta version with a non-empty plugin allowlist. The result always goes into `importConfigMachineState`'s `kept` bucket (the SQLite row already exists), and the caller reports every kept key as a Doctor change. No data corruption was observed, but the repeated "Auto-migrated legacy state" message is misleading and causes unnecessary concern.

## Evidence

- **Behavior addressed**: No-op `plugins.bundledDiscovery` migration reported as a Doctor change on every beta CLI process restart
- **Real environment tested**: Linux x86_64, Node.js v22.22.3, branch `fix/repeated-bundled-discovery-115151`
- **Exact steps or command run after this patch**:

```bash
node --import tsx <<'NODE'
// Test: First pass infers compat, second pass shows no Doctor changes
const stateDir = mkdtempSync(...);  // fresh temp state dir
const env = { ...process.env, OPENCLAW_STATE_DIR: stateDir };

// First call: should infer and write "compat"
migrateLegacyConfigMachineState({
  env,
  config: { meta: { lastTouchedVersion: "2026.7.2-beta.5" }, plugins: { allow: ["telegram"] } },
});
// → changes: ["Migrated plugins.bundledDiscovery → shared SQLite state"]
// → SQLite: "compat"

// Second call (simulates new CLI process): should report no changes
migrateLegacyConfigMachineState({
  env,
  config: { meta: { lastTouchedVersion: "2026.7.2-beta.5" }, plugins: { allow: ["telegram"] } },
});
// → changes: []  ← the fix!
NODE
```

- **Evidence after fix**:

```console
╔══════════════════════════════════════════════════════════╗
║  Scenario: Beta version preflight converges after fix     ║
╚══════════════════════════════════════════════════════════╝

─── Step 1: First pass (infer canon, write to SQLite) ───
  changes: ["Migrated plugins.bundledDiscovery → shared SQLite state"]
  warnings: []
  SQLite plugins.bundledDiscovery: "compat"

─── Step 2: Second pass (simulate new CLI process) ───
  changes: []
  warnings: []
  SQLite plugins.bundledDiscovery: "compat"

─── Verdict ───
  Second pass reports bundledDiscovery as a Doctor change: ✅ NO (FIXED)
  Canonical value preserved: ✅ YES

╔══════════════════════════════════════════════════════════╗
║  Control: Fresh SQLite still infers compat on first run  ║
╚══════════════════════════════════════════════════════════╝
  changes: ["Migrated plugins.bundledDiscovery → shared SQLite state"]
  SQLite plugins.bundledDiscovery: "compat"
  First-run inference works: ✅
```

- **Observed result after fix**:
  1. First pass with fresh SQLite still infers `compat` and writes it — no regression for first-time migration
  2. Second pass (new process, same config) returns `changes: []` — no misleading Doctor output
  3. Canonical SQLite value is preserved correctly
  4. All 11 existing + new tests pass (`Test Files 1 passed (1), Tests 11 passed (11)`)
- **What was not tested**: Other beta prerelease variants (`2026.7.2-beta.10`, `2026.7.2-rc.1`); other migration sources for the same repeated-kept pattern; browser or mobile app UI flows

## Root Cause

```
Provenance:
  introduced by: PR #111527 (edecdbd05ef) — config-surface reduction tranche 3
                 moved bundledDiscovery inference into migrateLegacyConfigMachineState
  made visible by: 2026.7.2-beta.5 release — first beta after cutover
  carried forward by: PR #112558 (7eec1345f98) — device-auth migration, left logic unchanged
  Confidence: clear
```

The version comparison `compareOpenClawVersions(meta.lastTouchedVersion, "2026.7.2") === -1` follows SemVer rules where prerelease (`2026.7.2-beta.5`) < release (`2026.7.2`). This causes the inference to re-fire on every new CLI process for beta users.

## Regression Test Plan

| Test | Coverage |
|------|----------|
| `state-migrations.config-machine-state.test.ts` | New `"does not re-report inferred bundledDiscovery on second pass with beta version"`: first pass writes compat, second pass returns `changes: []` |

Existing tests unaffected (all pass):
- Unstamped allowlist → infers compat ✅
- Pre-cutover version (2026.1.1) → infers compat ✅
- Post-cutover version (2026.7.2) → no inference ✅
- Explicit bundledDiscovery in config → imported correctly ✅

## User-visible / Behavior Changes

Beta users will no longer see the "Auto-migrated legacy state: Kept existing shared SQLite plugins.bundledDiscovery state" message on every `openclaw status --deep` or `openclaw gateway restart`. The canonical value is preserved identically.

## Security Impact

- [x] New permissions/capabilities? No
- [x] Secrets/tokens handling changed? No
- [x] New/changed network calls? No
- [x] Command/tool execution surface changed? No
- [x] Data access scope changed? No

## Human Verification

- **Verified scenarios**: Beta version + non-empty allowlist + pre-existing canonical SQLite state; fresh SQLite + beta version (first-run inference)
- **Edge cases checked**: SQLite temporarily unavailable (try/catch fallback); explicit `plugins.bundledDiscovery` config path (not affected); empty allowlist (inference not triggered); other migration entries (kept reporting unchanged)
- **What you did NOT verify**: Other migration sources for the same pattern; production gateway startup with real plugins

## Compatibility / Migration

- [x] Backward compatible? Yes — inference behavior unchanged for first-run scenarios
- [x] Config/env changes? No
- [ ] Migration needed? No

## Best-fix Verdict

- **Best fix**: Yes — skipping the inference at the source when canonical state already exists is the most targeted and self-documenting approach
- **Refactor needed**: No — the fix is a focused 12-line addition
- **Alternative considered**: (1) Only report `result.imported` in changes, not `result.kept` — would suppress useful kept reporting for explicit fields. (2) Track whether entry was inferred vs explicit and filter — more complex, no benefit over current approach

## AI Assistance

- **AI-assisted**: Yes
- **Co-Authored-By**: Claude <noreply@anthropic.com>
- **Human confirmed understanding of code changes**: Yes
- **AI prompts / session excerpts**: Analysis → design (self-critique → v2 with try/catch + test assertion fixes) → implementation → verification

## Risks and Mitigations

- **Highest risk area**: If `readConfigMachineState` throws (corrupt SQLite, permission error), the try/catch ensures compat is still inferred (safe fallback)
- **Mitigation**: The try/catch block catches all errors and falls through to the existing inference path
- **Compatibility**: No breaking change — existing users on stable releases (`>= 2026.7.2`) are not affected; beta users see the same canonical value, just without the misleading Doctor output

---

Fixes #115151
