### PR TITLE
fix(synology-chat): stop enabling the channel from half a credential pair

### DIFF
--- a/extensions/synology-chat/package.json
+++ b/extensions/synology-chat/package.json
@@ -19,6 +19,10 @@
       "id": "synology-chat",
       "configuredState": {
         "env": {
+          "allOf": [
+            "SYNOLOGY_CHAT_TOKEN",
+            "SYNOLOGY_CHAT_INCOMING_URL"
+          ],
           "anyOf": [
             "SYNOLOGY_CHAT_TOKEN",
             "SYNOLOGY_CHAT_INCOMING_URL",

--- a/scripts/lib/official-external-channel-catalog.json
+++ b/scripts/lib/official-external-channel-catalog.json
@@ -2056,6 +2056,10 @@
           "id": "synology-chat",
           "configuredState": {
             "env": {
+              "allOf": [
+                "SYNOLOGY_CHAT_TOKEN",
+                "SYNOLOGY_CHAT_INCOMING_URL"
+              ],
               "anyOf": [
                 "SYNOLOGY_CHAT_TOKEN",
                 "SYNOLOGY_CHAT_INCOMING_URL",

--- a/src/config/channel-configured.test.ts
+++ b/src/config/channel-configured.test.ts
@@ -1,5 +1,6 @@
 // Covers channel-configured checks from bootstrap and plugin metadata.
 import { describe, expect, it, vi } from "vitest";
+import { getChannelEnvVars } from "../secrets/channel-env-vars.js";
 import { isChannelConfigured } from "./channel-configured.js";
 
 vi.mock("../channels/plugins/bootstrap-registry.js", () => ({
@@ -42,6 +43,47 @@ describe("isChannelConfigured", () => {
         MATTERMOST_URL: "https://mattermost.example.test",
       }),
     ).toBe(true);
+  });
+
+  it("requires both Synology Chat token and incoming URL env vars through the package metadata seam", () => {
+    // The remaining Synology env vars are display or tuning knobs with defaults
+    // (nasHost -> "localhost", botName -> "OpenClaw"), so none of them proves an
+    // account exists. They stay declared as alternatives only so env-var
+    // discovery keeps knowing their names.
+    expect(isChannelConfigured({}, "synology-chat", { SYNOLOGY_NAS_HOST: "nas.example.com" })).toBe(
+      false,
+    );
+    expect(isChannelConfigured({}, "synology-chat", { OPENCLAW_BOT_NAME: "MyBot" })).toBe(false);
+    expect(isChannelConfigured({}, "synology-chat", { SYNOLOGY_RATE_LIMIT: "30" })).toBe(false);
+    expect(isChannelConfigured({}, "synology-chat", { SYNOLOGY_ALLOWED_USER_IDS: "1,2" })).toBe(
+      false,
+    );
+    expect(isChannelConfigured({}, "synology-chat", { SYNOLOGY_CHAT_TOKEN: "token" })).toBe(false);
+    expect(
+      isChannelConfigured({}, "synology-chat", {
+        SYNOLOGY_CHAT_INCOMING_URL: "https://nas.example.com/webapi/incoming",
+      }),
+    ).toBe(false);
+    expect(
+      isChannelConfigured({}, "synology-chat", {
+        SYNOLOGY_CHAT_TOKEN: "token",
+        SYNOLOGY_CHAT_INCOMING_URL: "https://nas.example.com/webapi/incoming",
+      }),
+    ).toBe(true);
+  });
+
+  it("keeps every Synology Chat env var discoverable after narrowing the probe", () => {
+    // Env-var discovery reads the union of allOf and anyOf, and it feeds the
+    // shell-env expected keys plus the workspace dotenv blocklist. Narrowing the
+    // configured-state probe must not shrink that surface.
+    expect(getChannelEnvVars("synology-chat")).toEqual([
+      "SYNOLOGY_CHAT_TOKEN",
+      "SYNOLOGY_CHAT_INCOMING_URL",
+      "SYNOLOGY_NAS_HOST",
+      "SYNOLOGY_ALLOWED_USER_IDS",
+      "SYNOLOGY_RATE_LIMIT",
+      "OPENCLAW_BOT_NAME",
+    ]);
   });
 
   it("still falls back to generic config presence for channels without a custom hook", () => {

--- a/src/config/plugin-auto-enable.core.test.ts
+++ b/src/config/plugin-auto-enable.core.test.ts
@@ -365,6 +365,26 @@ describe("applyPluginAutoEnable core", () => {
     expect(result.changes).toStrictEqual([]);
   });
 
+  it("does not auto-enable Synology Chat from half of its credential pair", () => {
+    const partial = applyPluginAutoEnable({
+      config: {},
+      env: makeIsolatedEnv({ SYNOLOGY_CHAT_TOKEN: "token" }),
+    });
+
+    expect(partial.config.channels?.["synology-chat"]).toBeUndefined();
+    expect(partial.changes).toStrictEqual([]);
+
+    const complete = applyPluginAutoEnable({
+      config: {},
+      env: makeIsolatedEnv({
+        SYNOLOGY_CHAT_TOKEN: "token",
+        SYNOLOGY_CHAT_INCOMING_URL: "https://nas.example.com/webapi/incoming",
+      }),
+    });
+
+    expect(complete.config.channels?.["synology-chat"]?.enabled).toBe(true);
+  });
+
   it("stores auto-enable reasons in a null-prototype dictionary", () => {
     const result = applyPluginAutoEnable({
       config: {


### PR DESCRIPTION
## Summary

**Prompt request:** Make env-based configured-state detection for Synology Chat require
both of the channel's declared credentials rather than any one declared variable, so a
partial environment no longer auto-enables it, while keeping every declared variable discoverable for `.env`
protection and shell-env expectations. Explicitly persisted channel config is not
affected and keeps winning.

**Proof target:** Show that a half credential pair -- or a tuning knob on its own -- no
longer reports the channel as configured and no longer auto-enables it, that a complete
pair still does both, and that the generated catalog now declares the pair as required.

- Problem: the channel's configured-state metadata lists its credentials under `anyOf`, so
  any single declared variable is enough to report it configured and auto-enable it.
- Why it matters: the channel is switched on in an environment that cannot complete the
  direction it has no credential for, and it fails quietly rather than staying out of the
  way until setup is finished.
- What changed: the manifest now declares the credential pair under `allOf`, the generated
  catalog is regenerated to match, and two regression tests pin both the narrowed predicate
  and the unchanged env-var list.

## What Problem This Solves

Setting just `SYNOLOGY_CHAT_TOKEN`, or just `SYNOLOGY_CHAT_INCOMING_URL`, is enough for the
auto-enable path to persist `channels["synology-chat"].enabled = true`. The channel is then switched on
while holding only one side of its transport -- the two variables are named for the outbound
token and the inbound webhook URL respectively. What the capture establishes is the
unintended enablement itself; what the channel then does at runtime with a missing half is
outside this PR and was not exercised.

The knob cases in the capture below are not extra scope; they are the observable extent of
the same defect. The same is true of variables that are not credentials at all. `SYNOLOGY_NAS_HOST`,
`SYNOLOGY_RATE_LIMIT` and `SYNOLOGY_ALLOWED_USER_IDS` are tuning knobs, and
`OPENCLAW_BOT_NAME` is not Synology-specific -- yet each one alone puts the channel into
configured state. The before/after capture below shows all four of those cases flipping
from `configured: true` to `configured: false`.

## Why This Change Was Made

The configured-state probe in `src/channels/plugins/package-state-probes.ts` documents its
own contract: "`allOf` expresses required credentials; `anyOf` expresses alternatives where
at least one non-empty value proves package state." It evaluates
`allOf.every(...) && (anyOf.length === 0 || anyOf.some(...))`, so an empty `allOf` leaves
`anyOf.some` as the only test.

Synology Chat declared only `anyOf`. Other bundled channels already draw the distinction --
`irc` declares `allOf: [IRC_HOST, IRC_NICK]` and `mattermost` declares
`allOf: [MATTERMOST_BOT_TOKEN, MATTERMOST_URL]`. Synology Chat needs its two credentials
just as jointly and was left on `anyOf`.

## Fix

Declare `allOf: [SYNOLOGY_CHAT_TOKEN, SYNOLOGY_CHAT_INCOMING_URL]` in
`extensions/synology-chat/package.json` and leave `anyOf` untouched, then regenerate
`scripts/lib/official-external-channel-catalog.json` with `pnpm channels:catalog:gen` so the
shipped catalog carries the same contract.

`anyOf` is left exactly as it was, for two separate reasons.

The predicate is `allOf.every(...) && (anyOf.length === 0 || anyOf.some(...))`. Because
`anyOf` is non-empty, its `some` arm still has to be satisfied. Keeping the two credentials
listed there means they satisfy it themselves, so the net predicate is exactly "both
credentials present". Had they been removed from `anyOf`, the predicate would have become
"both credentials **and** at least one tuning knob", which is stricter than intended.
The capture below shows this holding: the `full-credential-pair` case carries `envKeys`
of exactly the two credentials and no knob, and reports `configured: true` after the
change.

Keeping the knobs there matters for a different reason: env-var discovery in
`src/secrets/channel-env-vars.ts` reads the **union** of `allOf` and `anyOf`, and that list
feeds the shell-env expected keys and the workspace dotenv blocklist. Dropping the knobs
would shrink that surface. (Dropping the credentials from `anyOf` alone would not, since
they would still be in `allOf` — that half of the duplication is about the predicate, not
about discovery.) Naming the credentials in both lists means `anyOf.some` is satisfied whenever
`allOf.every` holds, so the net predicate is the pair and no variable stops being
recognized. No production TypeScript changes: the evaluator already supports `allOf`, and
only the declaration was missing.

The catalog is a second sink for the same contract --
`src/plugins/official-external-plugin-bundled-catalogs.ts` imports it directly, and it is
listed in `package.json` `files` -- both readable in-tree rather than shown by the capture --
so regenerating it is part of the fix rather than a follow-up.
The generator copies each extension's `configuredState` into the catalog, so the two
credentials appear in both `allOf` and `anyOf` there as well -- the capture shows the
catalog's own `allOf` and `anyOf`, and the manifest side of the comparison is in the diff. That duplication is deliberate, not a generation artifact: it is what
keeps env-var discovery seeing the same variable set while the predicate narrows.

## Tests

Two regression tests, 62 lines, no new test files:

- `src/config/channel-configured.test.ts` pins the narrowed predicate: each half of the pair
  and each non-credential knob no longer reports configured, and the complete pair still
  does.
- `src/config/plugin-auto-enable.core.test.ts` pins the consequence: a half pair no longer
  persists `channels["synology-chat"]`.

The env-var list is pinned alongside the predicate so a later cleanup cannot trade one for
the other unnoticed.

Local `pnpm check:changed --base upstream/main` on the changed lanes is green, run with
`upstream/main` resolved to `70abd88e03e0` -- the same base the capture was taken
against -- on candidate `858b3fcb4ebb`: 4 Vitest shards, 391 tests passed, 0 failed,
plus the bundled-channel config metadata and tooling lanes that the two changed data
files select.

## User Impact

This changes env-based detection only. Where the channel's state is inferred from the
environment, Synology Chat now counts as configured once both `SYNOLOGY_CHAT_TOKEN` and
`SYNOLOGY_CHAT_INCOMING_URL` are present, so a partial environment no longer auto-enables
it. An install that already has `channels.synology-chat.enabled: true` written into its
config is unaffected and stays enabled regardless of which credentials are present.

Operators who already have both credentials see no change. Operators whose earlier run
already persisted `channels.synology-chat.enabled: true` keep that channel enabled after
upgrading, because explicit config wins before env probing. That precedence is existing
behavior this PR does not modify; it lives ahead of the env probe in the same resolver.
The two regressions added here do not assert it -- both exercise environment-derived
state, which is the only thing this change moves -- so treat the persisted-config path as
unchanged rather than as newly covered. No migration is included on purpose -- nothing can safely distinguish a
previously auto-enabled channel from one the operator enabled deliberately.

No environment variable stops being recognized, so `.env` protection and shell-env
expectations are unchanged.

## Evidence

`extensions/synology-chat/package.json` (+4) and
`scripts/lib/official-external-channel-catalog.json` (+4), plus two regression tests (+62).
70 lines added, none removed. Captured at head `858b3fcb4ebb` against base `70abd88e03e0`.

### Real behavior proof

Behavior addressed: whether a Synology Chat environment that holds only part of the
channel's declared variables reports the channel as configured, and is therefore
auto-enabled.
Real environment tested: Linux x86_64, node v24.18.0, candidate at `858b3fcb4ebb`
against base `70abd88e03e0`

`./problem.md` below is the runner's problem statement for this work item. Its content is
the text reproduced under "What Problem This Solves" above, and it affects only the prose
header of the generated summary, not what the harness executes.

Exact steps or command run after this patch:

```sh
# The harness drives these production modules, resolved from whichever
# worktree it runs in. Confirm they are present before proving:
ls src/config/channel-configured.ts src/channels/plugins/package-state-probes.ts src/secrets/channel-env-vars.ts src/config/plugin-auto-enable.ts

clawproof work start synology-configured-state-credential-pair --baseline 70abd88e03e07e827e2b142e4e93bd5ec9f506e3
git -C ~/.clawproof/work-items/synology-configured-state-credential-pair/after reset --hard 858b3fcb4ebb350da256d70937e8efac0e00f8fc
clawproof build plan synology-configured-state-credential-pair --worktree before --apply
clawproof build plan synology-configured-state-credential-pair --worktree after --apply
clawproof prove synology-configured-state-credential-pair --scenario default --final --problem-file ./problem.md   # the statement reproduced under 'What Problem This Solves'
ocw proof import synology-configured-state-credential-pair
```

Before (pre-fix):

```text
===== BEFORE (baseline 70abd88e03e0, unfixed source) =====
--- harness.stderr ---
[harness: importing [REDACTED:path]/before/src/config/channel-configured.ts]
[harness: importing [REDACTED:path]/before/src/channels/plugins/package-state-probes.ts]
[harness: importing [REDACTED:path]/before/src/secrets/channel-env-vars.ts]
[harness: importing [REDACTED:path]/before/src/config/plugin-auto-enable.ts]
[harness: extension probe: {"channelDeclaresConfiguredState":true,"bundledChannelsWithConfiguredState":21,"knownEnvVars":["SYNOLOGY_CHAT_TOKEN","SYNOLOGY_CHAT_INCOMING_URL","SYNOLOGY_NAS_HOST","SYNOLOGY_ALLOWED_USER_IDS","SYNOLOGY_RATE_LIMIT","OPENCLAW_BOT_NAME"]}]
[harness: shipped catalog probe: {"catalogEntries":28,"requiredCredentials":[],"rawAnyOf":["SYNOLOGY_CHAT_TOKEN","SYNOLOGY_CHAT_INCOMING_URL","SYNOLOGY_NAS_HOST","SYNOLOGY_ALLOWED_USER_IDS","SYNOLOGY_RATE_LIMIT","OPENCLAW_BOT_NAME"]}]
[harness: running token-only]
[harness: running incoming-url-only]
[harness: running full-credential-pair]
[harness: running nas-host-knob-only]
[harness: running rate-limit-knob-only]
[harness: running allowlist-knob-only]
[harness: running generic-bot-name-only]
[harness: running no-env]
--- harness.stdout ---
{
  "modulesUnderTest": [
    "src/config/channel-configured.ts",
    "src/channels/plugins/package-state-probes.ts",
    "src/secrets/channel-env-vars.ts",
    "src/config/plugin-auto-enable.ts"
  ],
  "extensionProbe": {
    "channelDeclaresConfiguredState": true,
    "bundledChannelsWithConfiguredState": 21,
    "knownEnvVars": [
      "SYNOLOGY_CHAT_TOKEN",
      "SYNOLOGY_CHAT_INCOMING_URL",
      "SYNOLOGY_NAS_HOST",
      "SYNOLOGY_ALLOWED_USER_IDS",
      "SYNOLOGY_RATE_LIMIT",
      "OPENCLAW_BOT_NAME"
    ]
  },
  "shippedCatalogProbe": {
    "catalogEntries": 28,
    "requiredCredentials": [],
    "rawAnyOf": [
      "SYNOLOGY_CHAT_TOKEN",
      "SYNOLOGY_CHAT_INCOMING_URL",
      "SYNOLOGY_NAS_HOST",
      "SYNOLOGY_ALLOWED_USER_IDS",
      "SYNOLOGY_RATE_LIMIT",
      "OPENCLAW_BOT_NAME"
    ]
  },
  "results": [
    {
      "case": "token-only",
      "configured": true,
      "autoEnableWrites": "{\"enabled\":true}",
      "envKeys": [
        "SYNOLOGY_CHAT_TOKEN"
      ],
      "expectConfiguredAfterFix": false,
      "error": null
    },
    {
      "case": "incoming-url-only",
      "configured": true,
      "autoEnableWrites": "{\"enabled\":true}",
      "envKeys": [
        "SYNOLOGY_CHAT_INCOMING_URL"
      ],
      "expectConfiguredAfterFix": false,
      "error": null
    },
    {
      "case": "full-credential-pair",
      "configured": true,
      "autoEnableWrites": "{\"enabled\":true}",
      "envKeys": [
        "SYNOLOGY_CHAT_INCOMING_URL",
        "SYNOLOGY_CHAT_TOKEN"
      ],
      "expectConfiguredAfterFix": true,
      "error": null
    },
    {
      "case": "nas-host-knob-only",
      "configured": true,
      "autoEnableWrites": "{\"enabled\":true}",
      "envKeys": [
        "SYNOLOGY_NAS_HOST"
      ],
      "expectConfiguredAfterFix": false,
      "error": null
    },
    {
      "case": "rate-limit-knob-only",
      "configured": true,
      "autoEnableWrites": "{\"enabled\":true}",
      "envKeys": [
        "SYNOLOGY_RATE_LIMIT"
      ],
      "expectConfiguredAfterFix": false,
      "error": null
    },
    {
      "case": "allowlist-knob-only",
      "configured": true,
      "autoEnableWrites": "{\"enabled\":true}",
      "envKeys": [
        "SYNOLOGY_ALLOWED_USER_IDS"
      ],
      "expectConfiguredAfterFix": false,
      "error": null
    },
    {
      "case": "generic-bot-name-only",
      "configured": true,
      "autoEnableWrites": "{\"enabled\":true}",
      "envKeys": [
        "OPENCLAW_BOT_NAME"
      ],
      "expectConfiguredAfterFix": false,
      "error": null
    },
    {
      "case": "no-env",
      "configured": false,
      "autoEnableWrites": null,
      "envKeys": [],
      "expectConfiguredAfterFix": false,
      "error": null
    }
  ]
}

```

Evidence after fix:

```text
===== AFTER (candidate 858b3fcb4ebb, fix applied) =====
--- harness.stderr ---
[harness: importing [REDACTED:path]/after/src/config/channel-configured.ts]
[harness: importing [REDACTED:path]/after/src/channels/plugins/package-state-probes.ts]
[harness: importing [REDACTED:path]/after/src/secrets/channel-env-vars.ts]
[harness: importing [REDACTED:path]/after/src/config/plugin-auto-enable.ts]
[harness: extension probe: {"channelDeclaresConfiguredState":true,"bundledChannelsWithConfiguredState":21,"knownEnvVars":["SYNOLOGY_CHAT_TOKEN","SYNOLOGY_CHAT_INCOMING_URL","SYNOLOGY_NAS_HOST","SYNOLOGY_ALLOWED_USER_IDS","SYNOLOGY_RATE_LIMIT","OPENCLAW_BOT_NAME"]}]
[harness: shipped catalog probe: {"catalogEntries":28,"requiredCredentials":["SYNOLOGY_CHAT_TOKEN","SYNOLOGY_CHAT_INCOMING_URL"],"rawAnyOf":["SYNOLOGY_CHAT_TOKEN","SYNOLOGY_CHAT_INCOMING_URL","SYNOLOGY_NAS_HOST","SYNOLOGY_ALLOWED_USER_IDS","SYNOLOGY_RATE_LIMIT","OPENCLAW_BOT_NAME"]}]
[harness: running token-only]
[harness: running incoming-url-only]
[harness: running full-credential-pair]
[harness: running nas-host-knob-only]
[harness: running rate-limit-knob-only]
[harness: running allowlist-knob-only]
[harness: running generic-bot-name-only]
[harness: running no-env]
--- harness.stdout ---
{
  "modulesUnderTest": [
    "src/config/channel-configured.ts",
    "src/channels/plugins/package-state-probes.ts",
    "src/secrets/channel-env-vars.ts",
    "src/config/plugin-auto-enable.ts"
  ],
  "extensionProbe": {
    "channelDeclaresConfiguredState": true,
    "bundledChannelsWithConfiguredState": 21,
    "knownEnvVars": [
      "SYNOLOGY_CHAT_TOKEN",
      "SYNOLOGY_CHAT_INCOMING_URL",
      "SYNOLOGY_NAS_HOST",
      "SYNOLOGY_ALLOWED_USER_IDS",
      "SYNOLOGY_RATE_LIMIT",
      "OPENCLAW_BOT_NAME"
    ]
  },
  "shippedCatalogProbe": {
    "catalogEntries": 28,
    "requiredCredentials": [
      "SYNOLOGY_CHAT_TOKEN",
      "SYNOLOGY_CHAT_INCOMING_URL"
    ],
    "rawAnyOf": [
      "SYNOLOGY_CHAT_TOKEN",
      "SYNOLOGY_CHAT_INCOMING_URL",
      "SYNOLOGY_NAS_HOST",
      "SYNOLOGY_ALLOWED_USER_IDS",
      "SYNOLOGY_RATE_LIMIT",
      "OPENCLAW_BOT_NAME"
    ]
  },
  "results": [
    {
      "case": "token-only",
      "configured": false,
      "autoEnableWrites": null,
      "envKeys": [
        "SYNOLOGY_CHAT_TOKEN"
      ],
      "expectConfiguredAfterFix": false,
      "error": null
    },
    {
      "case": "incoming-url-only",
      "configured": false,
      "autoEnableWrites": null,
      "envKeys": [
        "SYNOLOGY_CHAT_INCOMING_URL"
      ],
      "expectConfiguredAfterFix": false,
      "error": null
    },
    {
      "case": "full-credential-pair",
      "configured": true,
      "autoEnableWrites": "{\"enabled\":true}",
      "envKeys": [
        "SYNOLOGY_CHAT_INCOMING_URL",
        "SYNOLOGY_CHAT_TOKEN"
      ],
      "expectConfiguredAfterFix": true,
      "error": null
    },
    {
      "case": "nas-host-knob-only",
      "configured": false,
      "autoEnableWrites": null,
      "envKeys": [
        "SYNOLOGY_NAS_HOST"
      ],
      "expectConfiguredAfterFix": false,
      "error": null
    },
    {
      "case": "rate-limit-knob-only",
      "configured": false,
      "autoEnableWrites": null,
      "envKeys": [
        "SYNOLOGY_RATE_LIMIT"
      ],
      "expectConfiguredAfterFix": false,
      "error": null
    },
    {
      "case": "allowlist-knob-only",
      "configured": false,
      "autoEnableWrites": null,
      "envKeys": [
        "SYNOLOGY_ALLOWED_USER_IDS"
      ],
      "expectConfiguredAfterFix": false,
      "error": null
    },
    {
      "case": "generic-bot-name-only",
      "configured": false,
      "autoEnableWrites": null,
      "envKeys": [
        "OPENCLAW_BOT_NAME"
      ],
      "expectConfiguredAfterFix": false,
      "error": null
    },
    {
      "case": "no-env",
      "configured": false,
      "autoEnableWrites": null,
      "envKeys": [],
      "expectConfiguredAfterFix": false,
      "error": null
    }
  ]
}
```

Observed result after fix: on the unfixed baseline, seven of the eight environment states
report `configured: true` -- both half-pairs, all three tuning knobs, the generic
`OPENCLAW_BOT_NAME`, and the complete pair itself; only a fully empty environment reports
false. Each of those seven also persists `{"enabled":true}` for the channel through
auto-enable, so the consequence and not just the predicate is visible. After the change
only `full-credential-pair` reports true and writes that entry; the other seven report
false and write nothing. The shipped catalog probe moves from `requiredCredentials: []` to
`requiredCredentials: [SYNOLOGY_CHAT_TOKEN, SYNOLOGY_CHAT_INCOMING_URL]` while
`catalogEntries` stays at 28 on both sides. The probe reads the catalog's own declaration;
the manifest side of that comparison is in the diff, so parity between the two sinks is
checkable by the reader rather than asserted by the capture.
What was not tested: no Synology NAS and no network are involved. The defect is entirely in
configured-state resolution and the auto-enable decision that follows it, so the harness
drives the real `isChannelConfigured` and `applyPluginAutoEnable` against the declarations
each side ships and never contacts a Synology deployment. Runtime delivery behavior once the
channel is enabled is unchanged by this PR and was not exercised, and neither are the
downstream consumers of the discovery list -- the capture shows the list itself is
unchanged, not what `.env` protection and shell-env expectations then do with it.

Complete harness (kept with the work item in my working tree, not part of the diff). ClawProof runs this same file on both sides; the only difference is the
working directory, which is why the import paths in the capture differ by `before/` and
`after/` and nothing else does:

```js
// Before/after harness for the ClawProof lane.
//
// What is under test: whether the Synology Chat channel reports "configured"
// from half a credential pair. The channel declares its configured-state
// contract in two shipped places -- the extension manifest and the generated
// official catalog -- and `package-state-probes.ts` already evaluates both
// `allOf` (required) and `anyOf` (alternatives). This file is byte-identical on
// both sides and reads only those two declarations plus the production modules
// below, so any difference in its output comes from the declarations rather
// than from the harness. It never learns which side it is running on.
//
// Contract with ClawProof: resolve every production module from process.cwd()
// and never from a path handed in per side. Print one JSON object to stdout;
// diagnostics go to stderr.

import path from "node:path";
import { pathToFileURL } from "node:url";

const CHANNEL_CONFIGURED = "src/config/channel-configured.ts";
const PACKAGE_STATE_PROBES = "src/channels/plugins/package-state-probes.ts";
const CHANNEL_ENV_VARS = "src/secrets/channel-env-vars.ts";
const PLUGIN_AUTO_ENABLE = "src/config/plugin-auto-enable.ts";
const MODULES_UNDER_TEST = [
  CHANNEL_CONFIGURED,
  PACKAGE_STATE_PROBES,
  CHANNEL_ENV_VARS,
  PLUGIN_AUTO_ENABLE,
];

const note = (msg) => process.stderr.write(`[harness: ${msg}]\n`);

const load = async (rel) => {
  const modulePath = path.resolve(process.cwd(), rel);
  note(`importing ${modulePath}`);
  return await import(pathToFileURL(modulePath).href);
};

const { isChannelConfigured } = await load(CHANNEL_CONFIGURED);
const { listBundledChannelIdsForPackageState } = await load(PACKAGE_STATE_PROBES);
const { getChannelEnvVars } = await load(CHANNEL_ENV_VARS);
const { applyPluginAutoEnable } = await load(PLUGIN_AUTO_ENABLE);

// Read back what the shipped extension manifest actually declares for this
// channel. These values come from the real catalog walk over the worktree's
// bundled extensions -- nothing here states them, so their presence in the
// output is what shows the run read a real manifest rather than a fixture.
const configuredStateChannels = listBundledChannelIdsForPackageState("configuredState");
const extensionProbe = {
  channelDeclaresConfiguredState: configuredStateChannels.includes("synology-chat"),
  bundledChannelsWithConfiguredState: configuredStateChannels.length,
  knownEnvVars: getChannelEnvVars("synology-chat"),
};
note(`extension probe: ${JSON.stringify(extensionProbe)}`);

// The contract has a second sink. Consumers that resolve plugins through the
// generated official catalog read this checked-in file rather than walking the
// extension directory, and it ships in `package.json` `files`. Reading it here
// keeps the proof honest about whether the fix reached both sinks or only the
// one the probe above happens to use.
const catalog = (
  await import(
    pathToFileURL(path.resolve(process.cwd(), "scripts/lib/official-external-channel-catalog.json"))
      .href,
    { with: { type: "json" } }
  )
).default;
const catalogEntries = Array.isArray(catalog) ? catalog : (catalog.entries ?? []);
const catalogEntry = catalogEntries.find(
  (entry) => entry?.openclaw?.channel?.id === "synology-chat",
);
if (!catalogEntry) {
  // Fail loud rather than reporting an empty contract, which would read as
  // "nothing is required" on both sides and quietly turn a broken probe into
  // apparent evidence.
  throw new Error(
    `shipped catalog probe found no synology-chat entry among ${catalogEntries.length} entries`,
  );
}
const catalogEnv = catalogEntry?.openclaw?.channel?.configuredState?.env ?? {};
const shippedCatalogProbe = {
  catalogEntries: catalogEntries.length,
  requiredCredentials: catalogEnv.allOf ?? [],
  // Raw `anyOf`, not a list of ways to configure the channel on its own: once
  // `allOf` is populated a value from here only counts alongside it.
  rawAnyOf: catalogEnv.anyOf ?? [],
};
note(`shipped catalog probe: ${JSON.stringify(shippedCatalogProbe)}`);

// One entry per scenario. Every state except `full-credential-pair` and `no-env`
// is an instance of the same defect: a single value from the manifest's `anyOf`
// -- half a credential pair, a tuning knob, or the generic bot name -- is enough
// to report the channel configured before the fix. `full-credential-pair` is the
// control that must keep reporting true, and `no-env` is the floor that was
// already false.
const scenarios = [
  { case: "token-only", env: { SYNOLOGY_CHAT_TOKEN: "t" }, expectConfiguredAfterFix: false },
  {
    case: "incoming-url-only",
    env: { SYNOLOGY_CHAT_INCOMING_URL: "https://nas.example.com/x" },
    expectConfiguredAfterFix: false,
  },
  {
    case: "full-credential-pair",
    env: {
      SYNOLOGY_CHAT_TOKEN: "t",
      SYNOLOGY_CHAT_INCOMING_URL: "https://nas.example.com/x",
    },
    expectConfiguredAfterFix: true,
  },
  { case: "nas-host-knob-only", env: { SYNOLOGY_NAS_HOST: "nas.example.com" }, expectConfiguredAfterFix: false },
  { case: "rate-limit-knob-only", env: { SYNOLOGY_RATE_LIMIT: "30" }, expectConfiguredAfterFix: false },
  { case: "allowlist-knob-only", env: { SYNOLOGY_ALLOWED_USER_IDS: "1,2" }, expectConfiguredAfterFix: false },
  // `OPENCLAW_BOT_NAME` is not Synology-specific at all -- it is the generic bot
  // display name. It sits in the manifest's `anyOf`, so before the fix an
  // operator who never touched Synology could still have the channel reported
  // as configured. This is the widest reach of the same defect.
  { case: "generic-bot-name-only", env: { OPENCLAW_BOT_NAME: "MyBot" }, expectConfiguredAfterFix: false },
  { case: "no-env", env: {}, expectConfiguredAfterFix: false },
];

const results = [];
for (const scenario of scenarios) {
  note(`running ${scenario.case}`);
  let observed = {};
  let error = null;
  try {
    // The real production probe, called the way config/setup call it.
    const autoEnabled = applyPluginAutoEnable({ config: {}, env: scenario.env })
      ?.config?.channels?.["synology-chat"];
    observed = {
      configured: isChannelConfigured({}, "synology-chat", scenario.env),
      autoEnableWrites: autoEnabled ? JSON.stringify(autoEnabled) : null,
      envKeys: Object.keys(scenario.env).toSorted(),
    };
  } catch (err) {
    error = err instanceof Error ? err.message : String(err);
  }
  results.push({
    case: scenario.case,
    ...observed,
    expectConfiguredAfterFix: scenario.expectConfiguredAfterFix,
    error,
  });
}

process.stdout.write(
  `${JSON.stringify(
    { modulesUnderTest: MODULES_UNDER_TEST, extensionProbe, shippedCatalogProbe, results },
    null,
    2,
  )}\n`,
);
```

## Non-Scope

Named explicitly so the boundary is reviewable:

1. **Other channels' configured-state metadata.** Of the bundled channels that declare
   `configuredState.env`, only `buzz`, `irc`, `mattermost` and this one use `allOf`. That
   inventory is readable from the generated catalog changed here -- every entry's
   `openclaw.channel.configuredState.env` in
   `scripts/lib/official-external-channel-catalog.json` -- so it can be re-derived without
   trusting this sentence. Whether
   each remaining channel's keys are a required set or genuine alternatives is a per-channel
   owner question, so this PR changes one channel.
2. **Migration for already auto-enabled installs.** Explicit persisted config keeps winning;
   see User Impact for why no migration is included.
3. **How credential requirements are expressed.** The `allOf` / `anyOf` vocabulary and its
   evaluator are unchanged; this PR only fills in a declaration the vocabulary already
   supports.
4. **Runtime delivery behavior.** Nothing about what the channel does once enabled.

## Known limitations

- The proof exercises configured-state resolution, not a live Synology deployment. That is
  the whole surface of the defect, but it does mean no NAS was contacted.
- Installs that were auto-enabled by the old predicate stay enabled until the persisted
  setting is changed or the channel is disabled by hand. Persisted config wins over env
  probing, and nothing can distinguish a channel the old behavior switched on from one the
  operator chose, so this PR narrows detection going forward and does not repair
  environments the previous predicate already acted on.
- The capture is pinned to head `858b3fcb4ebb`. A rebase invalidates it, and it would need
  re-taking on the landing head.
