### PR TITLE
refactor(agents): collapse the client-tool catalog branch

### DIFF
--- a/src/agents/embedded-agent-runner/run/attempt-client-tools.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-client-tools.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it } from "vitest";
+import type { OpenClawConfig } from "../../../config/types.openclaw.js";
+import { applyCodeModeCatalog, createCodeModeTools } from "../../code-mode.js";
+import { createStubTool } from "../../test-helpers/agent-tool-stubs.js";
+import {
+  applyToolSearchCatalog,
+  createToolSearchCatalogRef,
+  TOOL_SEARCH_RAW_TOOL_NAME,
+} from "../../tool-search.js";
+import { prepareEmbeddedAttemptClientTools } from "./attempt-client-tools.js";
+
+const CODE_MODE_CONFIG: OpenClawConfig = { tools: { codeMode: true, toolSearch: false } };
+const TOOL_SEARCH_CONFIG: OpenClawConfig = {
+  tools: { codeMode: false, toolSearch: { enabled: true, mode: "tools" } },
+};
+const CATALOGS_DISABLED_CONFIG: OpenClawConfig = {
+  tools: { codeMode: false, toolSearch: false },
+};
+
+function clientTool(name: string) {
+  return {
+    type: "function" as const,
+    function: { name, description: `client ${name}`, parameters: { type: "object" } },
+  };
+}
+
+/**
+ * Seeds `catalogRef.current` the way the runner does before client tools are
+ * appended; without a registered catalog the append is a no-op and both
+ * branches look identical.
+ */
+function seedCatalog(mode: "code-mode" | "tool-search", config: OpenClawConfig) {
+  const catalogRef = createToolSearchCatalogRef();
+  // A catalog only registers when its own control tools are present, so the
+  // seed has to carry them exactly as the runner's tool surface does.
+  const controlTools =
+    mode === "code-mode"
+      ? createCodeModeTools({
+          config,
+          catalogRef,
+          executeTool: async () => ({ content: [], details: {} }),
+        })
+      : [createStubTool(TOOL_SEARCH_RAW_TOOL_NAME)];
+  const seedParams = {
+    tools: [...controlTools, createStubTool("seeded_target")],
+    config,
+    sessionId: "session",
+    sessionKey: "session-key",
+    agentId: "main",
+    runId: "run",
+    catalogRef,
+  };
+  const seeded =
+    mode === "code-mode" ? applyCodeModeCatalog(seedParams) : applyToolSearchCatalog(seedParams);
+  // Guard the fixture itself: an unregistered catalog would make the append a
+  // no-op and every assertion below would pass for the wrong reason.
+  expect(seeded.catalogRegistered).toBe(true);
+  return catalogRef;
+}
+
+function prepare(input: {
+  codeModeControlsEnabledForRun: boolean;
+  attemptConfig: OpenClawConfig;
+  toolSearchRuntimeConfig: OpenClawConfig;
+  catalogRef: ReturnType<typeof createToolSearchCatalogRef>;
+}) {
+  return prepareEmbeddedAttemptClientTools({
+    attempt: {
+      config: input.attemptConfig,
+      sessionId: "session",
+      runId: "run",
+    },
+    catalogToolHookContext: undefined,
+    codeModeControlsEnabledForRun: input.codeModeControlsEnabledForRun,
+    deferredDirectoryToolsCallable: false,
+    effectiveTools: [],
+    replaySafetyOptions: { declaredReplaySafe: () => undefined },
+    sandboxEnabled: false,
+    sandboxSessionKey: "session-key",
+    sessionAgentId: "main",
+    toolSearchCatalogRef: input.catalogRef,
+    toolSearchRuntimeConfig: input.toolSearchRuntimeConfig,
+    uncompactedEffectiveTools: [],
+    clientTools: [clientTool("client_probe")],
+  } as unknown as Parameters<typeof prepareEmbeddedAttemptClientTools>[0]);
+}
+
+describe("prepareEmbeddedAttemptClientTools", () => {
+  it("hides client tools behind the code-mode catalog when code mode is engaged", () => {
+    const catalogRef = seedCatalog("code-mode", CODE_MODE_CONFIG);
+
+    const result = prepare({
+      codeModeControlsEnabledForRun: true,
+      attemptConfig: CODE_MODE_CONFIG,
+      // Deliberately catalog-disabled: the code-mode branch must not read this.
+      toolSearchRuntimeConfig: CATALOGS_DISABLED_CONFIG,
+      catalogRef,
+    });
+
+    expect(result.clientToolDefs).toEqual([]);
+    expect(result.allCustomTools).toEqual([]);
+  });
+
+  it("hides client tools behind the tool-search catalog when code mode is not engaged", () => {
+    const catalogRef = seedCatalog("tool-search", TOOL_SEARCH_CONFIG);
+
+    const result = prepare({
+      codeModeControlsEnabledForRun: false,
+      // Deliberately catalog-disabled: the tool-search branch must not read this.
+      attemptConfig: CATALOGS_DISABLED_CONFIG,
+      toolSearchRuntimeConfig: TOOL_SEARCH_CONFIG,
+      catalogRef,
+    });
+
+    expect(result.clientToolDefs).toEqual([]);
+    expect(result.allCustomTools).toEqual([]);
+  });
+
+  it("keeps client tools directly callable when neither catalog is engaged", () => {
+    const catalogRef = seedCatalog("tool-search", TOOL_SEARCH_CONFIG);
+
+    const result = prepare({
+      codeModeControlsEnabledForRun: false,
+      attemptConfig: TOOL_SEARCH_CONFIG,
+      toolSearchRuntimeConfig: CATALOGS_DISABLED_CONFIG,
+      catalogRef,
+    });
+
+    expect(result.clientToolDefs.map((tool) => tool.name)).toEqual(["client_probe"]);
+  });
+});

--- a/src/agents/embedded-agent-runner/run/attempt-client-tools.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-client-tools.ts
@@ -131,25 +131,22 @@ export function prepareEmbeddedAttemptClientTools(params: {
         },
       )
     : [];
-  const clientToolSearch = params.codeModeControlsEnabledForRun
-    ? addClientToolsToCodeModeCatalog({
-        tools: clientToolDefs,
-        config: params.attempt.config,
-        sessionId: params.attempt.sessionId,
-        sessionKey: params.sandboxSessionKey,
-        agentId: params.sessionAgentId,
-        runId: params.attempt.runId,
-        catalogRef: params.toolSearchCatalogRef,
-      })
-    : addClientToolsToToolSearchCatalog({
-        tools: clientToolDefs,
-        config: params.toolSearchRuntimeConfig,
-        sessionId: params.attempt.sessionId,
-        sessionKey: params.sandboxSessionKey,
-        agentId: params.sessionAgentId,
-        runId: params.attempt.runId,
-        catalogRef: params.toolSearchCatalogRef,
-      });
+  const addClientToolsToCatalog = params.codeModeControlsEnabledForRun
+    ? addClientToolsToCodeModeCatalog
+    : addClientToolsToToolSearchCatalog;
+  const clientToolSearch = addClientToolsToCatalog({
+    tools: clientToolDefs,
+    // Mirrors applyAgentToolSurfaceCatalog: code mode reads the base config,
+    // tool search reads the run's resolved tool-search runtime config.
+    config: params.codeModeControlsEnabledForRun
+      ? params.attempt.config
+      : params.toolSearchRuntimeConfig,
+    sessionId: params.attempt.sessionId,
+    sessionKey: params.sandboxSessionKey,
+    agentId: params.sessionAgentId,
+    runId: params.attempt.runId,
+    catalogRef: params.toolSearchCatalogRef,
+  });
   clientToolDefs = clientToolSearch.tools;
   if (clientToolSearch.compacted) {
     log.info(


### PR DESCRIPTION
## What Problem This Solves

Follow-up to #115189, which collapsed the duplicated code-mode vs tool-search
decision into one resolver. This is the last place that restated part of that
decision by hand.

`prepareEmbeddedAttemptClientTools` selected between two client-tool catalog
appenders by writing the same seven-field argument object twice. The branches
differ only in which appender runs and which config it reads, so the repetition
carried no information — and the config asymmetry it encodes (code mode reads
the base config, tool search reads the run's resolved tool-search runtime
config) had no test anywhere, which is the kind of mistake that stays silent.

## Why This Change Was Made

Select the appender and the config first, then build the arguments once. That is
the same shape `applyAgentToolSurfaceCatalog` already uses for the main tool
surface, so both catalog call sites now read alike.

Explicit non-goal: no new shared helper. Unlike #115189 this is a single call
site, and the gate itself is already shared — this function receives
`codeModeControlsEnabledForRun` from `resolveAgentToolSurfacePlan`. A helper here
would add an exported surface that removes no duplication, which the root
AGENTS.md rules out. The remaining coupling is documented with a comment
pointing at its sibling instead.

## User Impact

None. Behavior is unchanged on every path; this is a readability and coverage
change.

## Evidence

Behavior-neutral refactor plus new coverage for a previously untested helper.

- `node scripts/run-vitest.mjs src/agents/embedded-agent-runner/run/attempt-client-tools.test.ts` — 3 tests passed
- `node scripts/run-vitest.mjs src/agents/tool-search.test.ts src/agents/embedded-agent-runner/run/attempt-session.test.ts` — 92 tests passed (nearest existing coverage of the appenders and the runner surface)

The new test was mutation-checked rather than assumed useful. Two findings from
that, both fixed before this PR:

1. The first draft passed 3/3 while proving nothing. A catalog only registers
   when its own control tools are present, so the fixture registered none and the
   client-tool append was inert. The fixture now asserts
   `seeded.catalogRegistered === true` so an inert append cannot pass for the
   right reason.
2. With that fixed, inverting the production config asymmetry (making both
   branches read `toolSearchRuntimeConfig`) fails exactly the code-mode case and
   no others, which is the guard this test exists to provide.

Each test gives the branch under exercise a catalog-disabled config for the side
it must *not* read, so reading the wrong config cannot pass.
