### PR TITLE
fix(agents): prevent repeated Code Mode output across waits

### DIFF
--- a/src/agents/code-mode-execution.ts
+++ b/src/agents/code-mode-execution.ts
@@ -215,6 +215,7 @@ async function settleCodeModeResult(params: {
   runtime: ToolSearchRuntime;
   namespaceRuntime: CodeModeNamespaceRuntime;
   deadlineMs: number;
+  deliveredOutputCount?: number;
   pending?: PendingBridgeState[];
   activeRunId?: string;
   signal?: AbortSignal;
@@ -224,6 +225,7 @@ async function settleCodeModeResult(params: {
   let pending = params.pending ?? [];
   const activeRunId = params.activeRunId ?? `cm_${randomUUID()}`;
   const output = params.output;
+  const deliveredOutputCount = params.deliveredOutputCount ?? 0;
   // One exec/wait call shares a single wall-clock deadline across its initial
   // worker run and this inline settle phase, so auto-draining bridge calls
   // cannot stack a second full `timeoutMs` budget on top of the run that
@@ -235,7 +237,7 @@ async function settleCodeModeResult(params: {
     status: "failed" as const,
     error: "code mode execution aborted",
     code: "aborted" as const,
-    output,
+    output: output.slice(deliveredOutputCount),
     replaySafe: params.replaySafe,
     telemetry: telemetry(params.runtime),
   });
@@ -259,7 +261,7 @@ async function settleCodeModeResult(params: {
           status: "failed" as const,
           error: "restart-safe code mode cannot call namespace tools.",
           code: "invalid_input" as const,
-          output,
+          output: output.slice(deliveredOutputCount),
           replaySafe: true,
           telemetry: telemetry(params.runtime),
         };
@@ -328,6 +330,7 @@ async function settleCodeModeResult(params: {
           runtime: params.runtime,
           namespaceRuntime: params.namespaceRuntime,
           output,
+          deliveredOutputCount,
         });
       }
       // Deliver the settled frontier only. Unresolved sibling promises remain
@@ -379,7 +382,7 @@ async function settleCodeModeResult(params: {
         status: "failed" as const,
         error: "restart-safe code mode cannot call side-effecting tools.",
         code: "invalid_input" as const,
-        output,
+        output: output.slice(deliveredOutputCount),
         replaySafe: true,
         telemetry: telemetry(params.runtime),
       };
@@ -426,6 +429,7 @@ async function settleCodeModeResult(params: {
           runtime: params.runtime,
           namespaceRuntime: params.namespaceRuntime,
           output,
+          deliveredOutputCount,
         });
       } catch (error) {
         cancelPendingBridgeStates(pending);
@@ -444,6 +448,7 @@ async function settleCodeModeResult(params: {
       runtime: params.runtime,
       namespaceRuntime: params.namespaceRuntime,
       output,
+      deliveredOutputCount,
       replaySafe: params.replaySafe,
       settlementMode: result.settlementMode,
       signal: params.signal,
@@ -460,7 +465,7 @@ async function settleCodeModeResult(params: {
   });
   return {
     ...result,
-    output,
+    output: output.slice(deliveredOutputCount),
     replaySafe: params.replaySafe,
     telemetry: telemetry(params.runtime),
   };
@@ -512,7 +517,7 @@ export async function runWait(params: {
           status: "failed" as const,
           error: "code mode execution aborted",
           code: "aborted" as const,
-          output: state.output,
+          output: state.output.slice(state.deliveredOutputCount),
           replaySafe: state.replaySafe,
           telemetry: telemetry(state.runtime),
         };
@@ -527,7 +532,7 @@ export async function runWait(params: {
         reason: codeModeWaitingReason(pending.length > 0 ? pending : state.pending),
         pendingToolCalls: pendingToolCalls(pending.length > 0 ? pending : state.pending),
         replaySafe: state.replaySafe,
-        output: state.output,
+        output: state.output.slice(state.deliveredOutputCount),
         telemetry: telemetry(state.runtime),
       };
     }
@@ -571,6 +576,7 @@ export async function runWait(params: {
       config: state.config,
       runtime: state.runtime,
       namespaceRuntime: state.namespaceRuntime,
+      deliveredOutputCount: state.deliveredOutputCount,
       pending,
       activeRunId: state.runId,
       signal: params.signal,
@@ -586,7 +592,7 @@ export async function runWait(params: {
       status: "failed" as const,
       error: codeModeFailureMessage(error),
       code: codeModeFailureCode(error),
-      output: state.output,
+      output: state.output.slice(state.deliveredOutputCount),
       replaySafe: state.replaySafe,
       telemetry: telemetry(state.runtime),
     };

--- a/src/agents/code-mode-execution.ts
+++ b/src/agents/code-mode-execution.ts
@@ -36,6 +36,7 @@ import {
   settledBridgeRequestsInCompletionOrder,
   snapshotState,
   storeSnapshotState,
+  takeUndeliveredCodeModeRunOutput,
   telemetry,
   waitForPendingBridgeSettlement,
   type PendingBridgeState,
@@ -517,7 +518,7 @@ export async function runWait(params: {
           status: "failed" as const,
           error: "code mode execution aborted",
           code: "aborted" as const,
-          output: state.output.slice(state.deliveredOutputCount),
+          output: takeUndeliveredCodeModeRunOutput(state),
           replaySafe: state.replaySafe,
           telemetry: telemetry(state.runtime),
         };
@@ -532,7 +533,7 @@ export async function runWait(params: {
         reason: codeModeWaitingReason(pending.length > 0 ? pending : state.pending),
         pendingToolCalls: pendingToolCalls(pending.length > 0 ? pending : state.pending),
         replaySafe: state.replaySafe,
-        output: state.output.slice(state.deliveredOutputCount),
+        output: takeUndeliveredCodeModeRunOutput(state),
         telemetry: telemetry(state.runtime),
       };
     }
@@ -592,7 +593,7 @@ export async function runWait(params: {
       status: "failed" as const,
       error: codeModeFailureMessage(error),
       code: codeModeFailureCode(error),
-      output: state.output.slice(state.deliveredOutputCount),
+      output: takeUndeliveredCodeModeRunOutput(state),
       replaySafe: state.replaySafe,
       telemetry: telemetry(state.runtime),
     };

--- a/src/agents/code-mode-state.ts
+++ b/src/agents/code-mode-state.ts
@@ -36,6 +36,8 @@ type CodeModeRunState = {
   // True only when every future bridge call is enforced read-only before execution.
   replaySafe: boolean;
   output: unknown[];
+  // Retain all output for cumulative limits, but never replay blocks already returned to the model.
+  deliveredOutputCount: number;
   createdAt: number;
   expiresAt: number;
   agentWaitRetainUntil?: number;
@@ -195,6 +197,7 @@ export function snapshotState(params: {
   runtime: ToolSearchRuntime;
   namespaceRuntime: CodeModeNamespaceRuntime;
   output: unknown[];
+  deliveredOutputCount?: number;
   replaySafe: boolean;
   settlementMode: CodeModeSettlementMode;
   signal?: AbortSignal;
@@ -322,6 +325,7 @@ export function storeSnapshotState(params: {
   runtime: ToolSearchRuntime;
   namespaceRuntime: CodeModeNamespaceRuntime;
   output: unknown[];
+  deliveredOutputCount?: number;
 }) {
   const now = Date.now();
   const expiresAt = resolveCodeModeSnapshotExpiresAt(now, params.config.snapshotTtlSeconds);
@@ -348,6 +352,7 @@ export function storeSnapshotState(params: {
     settlementMode: params.settlementMode,
     replaySafe: params.replaySafe,
     output: params.output,
+    deliveredOutputCount: params.output.length,
     createdAt: now,
     expiresAt,
     agentWaitRetainUntil,
@@ -361,7 +366,7 @@ export function storeSnapshotState(params: {
     reason: codeModeWaitingReason(params.pending),
     pendingToolCalls: pendingToolCalls(params.pending),
     replaySafe: params.replaySafe,
-    output: params.output,
+    output: params.output.slice(params.deliveredOutputCount ?? 0),
     telemetry: telemetry(params.runtime),
   };
 }

--- a/src/agents/code-mode-state.ts
+++ b/src/agents/code-mode-state.ts
@@ -107,6 +107,13 @@ export function disposeCodeModeRun(runId: string): void {
   scheduleActiveRunExpiry();
 }
 
+/** Advance the snapshot frontier before exposing output to a wait observer. */
+export function takeUndeliveredCodeModeRunOutput(state: CodeModeRunState): unknown[] {
+  const output = state.output.slice(state.deliveredOutputCount);
+  state.deliveredOutputCount = state.output.length;
+  return output;
+}
+
 /** Abort each bridge call whose result has not already reached its guest. */
 export function cancelPendingBridgeStates(pending: readonly PendingBridgeState[]): void {
   for (const entry of pending) {

--- a/src/agents/code-mode.test.ts
+++ b/src/agents/code-mode.test.ts
@@ -2817,6 +2817,17 @@ describe("Code Mode", () => {
     expect(second.status).toBe("waiting");
     expect(second.output).toEqual([]);
     expect(second.pendingToolCalls).toEqual([expect.objectContaining({ method: "callValue" })]);
+
+    const third = resultDetails(
+      await expectDefined(codeModeTools[1], "codeModeTools[1] test invariant").execute(
+        "code-wait-timeout-again",
+        { runId },
+      ),
+    );
+
+    expect(third.status).toBe("waiting");
+    expect(third.output).toEqual([]);
+    expect(third.pendingToolCalls).toEqual([expect.objectContaining({ method: "callValue" })]);
   });
 
   it("does not load TypeScript for plain JavaScript code mode runs", async () => {

--- a/src/agents/code-mode.test.ts
+++ b/src/agents/code-mode.test.ts
@@ -2177,10 +2177,93 @@ describe("Code Mode", () => {
 
     expect(resumed.status).toBe("completed");
     expect(resumed.value).toBe("done");
-    expect(resumed.output).toEqual([
-      { type: "text", text: "before" },
-      { type: "text", text: "after" },
-    ]);
+    expect(resumed.output).toEqual([{ type: "text", text: "after" }]);
+  });
+
+  it("delivers each yielded output block exactly once across repeated waits", async () => {
+    const { config, catalogRef, tools: codeModeTools } = createCodeModeHarness();
+    applyCodeModeCatalog({
+      tools: [...codeModeTools, pluginTool("fake_noop", "Noop")],
+      config,
+      sessionId: "session-code-mode",
+      sessionKey: "agent:main:main",
+      runId: "run-code-mode",
+      catalogRef,
+    });
+
+    const execTool = expectDefined(codeModeTools[0], "Code Mode exec test invariant");
+    const waitTool = expectDefined(codeModeTools[1], "Code Mode wait test invariant");
+    const first = resultDetails(
+      await execTool.execute("code-call-incremental-output", {
+        code: `
+          text("phase 1");
+          await yield_control("first pause");
+          text("phase 2");
+          await yield_control("second pause");
+          text("phase 3");
+          return "done";
+        `,
+      }),
+    );
+
+    expect(first.status).toBe("waiting");
+    expect(first.output).toEqual([{ type: "text", text: "phase 1" }]);
+
+    const second = resultDetails(
+      await waitTool.execute("code-wait-incremental-output-1", { runId: first.runId }),
+    );
+
+    expect(second.status).toBe("waiting");
+    expect(second.output).toEqual([{ type: "text", text: "phase 2" }]);
+
+    const third = resultDetails(
+      await waitTool.execute("code-wait-incremental-output-2", { runId: second.runId }),
+    );
+
+    expect(third.status).toBe("completed");
+    expect(third.value).toBe("done");
+    expect(third.output).toEqual([{ type: "text", text: "phase 3" }]);
+  });
+
+  it("returns only newly emitted output when a resumed guest fails", async () => {
+    const { config, catalogRef, tools: codeModeTools } = createCodeModeHarness();
+    applyCodeModeCatalog({
+      tools: [...codeModeTools, pluginTool("fake_noop", "Noop")],
+      config,
+      sessionId: "session-code-mode",
+      sessionKey: "agent:main:main",
+      runId: "run-code-mode",
+      catalogRef,
+    });
+
+    const first = resultDetails(
+      await expectDefined(codeModeTools[0], "Code Mode exec test invariant").execute(
+        "code-call-incremental-failure",
+        {
+          code: `
+            text("before pause");
+            await yield_control("pause");
+            text("before failure");
+            throw new Error("resumed failure");
+          `,
+        },
+      ),
+    );
+
+    expect(first.status).toBe("waiting");
+    expect(first.output).toEqual([{ type: "text", text: "before pause" }]);
+
+    const second = resultDetails(
+      await expectDefined(codeModeTools[1], "Code Mode wait test invariant").execute(
+        "code-wait-incremental-failure",
+        { runId: first.runId },
+      ),
+    );
+
+    expect(second.status).toBe("failed");
+    expect(second.error).toContain("resumed failure");
+    expect(second.output).toEqual([{ type: "text", text: "before failure" }]);
+    expect(testing.activeRuns.has(first.runId as string)).toBe(false);
   });
 
   it("preserves the original exec identity for tool calls after yield and wait", async () => {
@@ -2701,6 +2784,7 @@ describe("Code Mode", () => {
         "code-call-timeout",
         {
           code: `
+          text("before timeout");
           const fast = tools.fake_fast({});
           const slow = tools.fake_slow({});
           await fast;
@@ -2711,6 +2795,7 @@ describe("Code Mode", () => {
       ),
     );
     expect(first.status).toBe("waiting");
+    expect(first.output).toEqual([{ type: "text", text: "before timeout" }]);
     expect(first.pendingToolCalls).toEqual([expect.objectContaining({ method: "callValue" })]);
     const runId = first.runId;
     expect(typeof runId).toBe("string");
@@ -2730,6 +2815,7 @@ describe("Code Mode", () => {
     );
 
     expect(second.status).toBe("waiting");
+    expect(second.output).toEqual([]);
     expect(second.pendingToolCalls).toEqual([expect.objectContaining({ method: "callValue" })]);
   });
 
@@ -3283,6 +3369,63 @@ describe("Code Mode", () => {
     expect(String(details.error)).toContain("output limit exceeded");
     expect(details.code).toBe("output_limit_exceeded");
     expect(testing.activeRuns.size).toBe(beforeRunCount);
+  });
+
+  it("enforces the cumulative output limit across yielded waits", async () => {
+    const catalogRef = createToolSearchCatalogRef();
+    const config = {
+      tools: {
+        codeMode: {
+          enabled: true,
+          maxOutputBytes: 1024,
+        },
+      },
+    } as never;
+    const ctx = {
+      config,
+      runtimeConfig: config,
+      sessionId: "session-code-mode",
+      sessionKey: "agent:main:main",
+      runId: "run-code-mode",
+      catalogRef,
+    };
+    const tools = createCodeModeTools(ctx);
+    applyCodeModeCatalog({
+      tools: [...tools, pluginTool("fake_noop", "Noop")],
+      config,
+      sessionId: "session-code-mode",
+      sessionKey: "agent:main:main",
+      runId: "run-code-mode",
+      catalogRef,
+    });
+
+    const first = resultDetails(
+      await expectDefined(tools[0], "Code Mode exec test invariant").execute(
+        "code-call-cumulative-output",
+        {
+          code: `
+            text("a".repeat(600));
+            await yield_control("pause");
+            text("b".repeat(600));
+            return "done";
+          `,
+        },
+      ),
+    );
+
+    expect(first.status).toBe("waiting");
+    expect(first.output).toEqual([{ type: "text", text: "a".repeat(600) }]);
+
+    const second = resultDetails(
+      await expectDefined(tools[1], "Code Mode wait test invariant").execute(
+        "code-wait-cumulative-output",
+        { runId: first.runId },
+      ),
+    );
+
+    expect(second.status).toBe("failed");
+    expect(second.code).toBe("output_limit_exceeded");
+    expect(testing.activeRuns.has(first.runId as string)).toBe(false);
   });
 
   it("enforces output limits before auto-draining namespace calls", async () => {


### PR DESCRIPTION
## What Problem This Solves

Agents using Code Mode repeatedly received already-delivered output whenever a suspended program resumed or a `wait` timed out. Successive yields replayed the cumulative transcript, wasting model input tokens and making progress, failures, and timeout polls appear more than once.

## Why This Change Was Made

Keep cumulative output in the existing private snapshot owner so output and result limits remain enforced across the entire program. Record the delivery frontier when publishing a snapshot, advance that frontier when observing a parked run, and return only newly produced output for resumed completion, failures, aborts, timeout polling, and replay-safe validation.

This matches the directly inspected upstream Codex contract: `codex-rs/code-mode/src/cell_actor/mod.rs:164-248` consumes observation output using `std::mem::take`, and `codex-rs/core/tests/suite/code_mode.rs:1603-1742` proves that consecutive observations expose phase 1, phase 2, and phase 3 exactly once.

Headless execution retains its existing single-result behavior. There are no configuration, provider, plugin, protocol, storage, or public-schema changes.

The initial PR also repaired a pre-existing browser-history leak that blocked the synthetic merge-tree CI. Current `main` now fixes that leak independently, so the rebased PR intentionally drops the redundant UI change. The final diff is limited to the three Code Mode owner and regression-test files.

## User Impact

Each Code Mode observation shows only genuinely new output. Multi-yield programs no longer duplicate transcript text or inflate model input. No-progress timeout polling returns empty output, resumed failures retain newly emitted diagnostics, and cumulative output limits still apply across the complete run.

## Evidence

Regression-first Linux proof on Blacksmith Testbox `tbx_01kyme0wjqmjjbjsczqm9gv4kp` against the previous implementation:

```text
FAIL marks yield suspensions and resumes the snapshot with wait
  expected [{ type: "text", text: "after" }]
  received [{ type: "text", text: "before" }, { type: "text", text: "after" }]

FAIL delivers each yielded output block exactly once across repeated waits
  expected [{ type: "text", text: "phase 2" }]
  received [{ type: "text", text: "phase 1" }, { type: "text", text: "phase 2" }]

FAIL reports only unsettled pending tool calls when wait times out
  expected []
  received [{ type: "text", text: "before timeout" }]

Tests  3 failed | 208 passed
```

The exact same three Code Mode files then passed the seven-file Linux stress matrix:

```text
pnpm test \
  src/agents/code-mode.test.ts \
  src/agents/code-mode-worker-lifecycle.test.ts \
  src/agents/code-mode-runtime.test.ts \
  src/agents/code-mode-nodes.test.ts \
  src/agents/code-mode-shell-source.test.ts \
  src/agents/code-mode-swarm.test.ts \
  src/agents/code-mode-headless.test.ts

unit-fast: 1 file, 181 tests passed
agents:    6 files, 393 tests passed
total:     7 files, 574 tests passed
```

Coverage includes repeated yields, timeout polling, resumed guest failures, cross-yield output overflow, worker cleanup and cancellation, headless execution, swarm, node tools, and 130,000 adversarial parser and Unicode inputs.

Refreshed exact-head regression proof after rebasing and removing the UI overlap:

```text
env OPENCLAW_FS_SAFE_NATIVE_MODE=off \
  node scripts/run-vitest.mjs src/agents/code-mode.test.ts \
  -t 'marks yield suspensions|delivers each yielded output|returns only newly emitted output|reports only unsettled pending tool calls|enforces the cumulative output limit'

Test Files  2 passed
Tests       10 passed | 414 skipped
```

The earlier complete Linux changed gate also passed for the byte-identical Code Mode patch:

```text
pnpm check:changed
[check:changed] lanes=core, coreTests
production and core-test typechecks: passed
lint: 0 warnings, 0 errors
plugin boundaries, schemas, import cycles, and formatting: passed
```

The exact previously failing compact CI shard was independently reconstructed from the actual CI planner and passed on Linux:

```text
checks-node-compact-large-4
media:                21 files,   301 tests passed
media understanding:  27 files,   341 tests passed
UI:                  439 files, 6,300 tests passed
isolated UI:           9 files,   207 tests passed
unit-fast:           570 files, 6,789 tests passed
auto-reply:           14 files,   189 tests passed
exit=0
```

Fresh independent review of the exact three-file rebased diff:

```text
.agents/skills/autoreview/scripts/autoreview \
  --mode branch \
  --base b403cb5d50acbcb48f0e9dccb072f5f818c0eef0

trufflehog: clean
autoreview clean: no accepted/actionable findings reported
overall: patch is correct (0.95)
```

Prepared using AI-assisted source inspection, regression-first testing, and an independent structured review; all runtime and upstream Codex contracts were checked against the actual source.
