### PR TITLE
refactor(ui): derive page route specs from the route table

### DIFF
--- a/ui/src/app-route-paths.ts
+++ b/ui/src/app-route-paths.ts
@@ -4,7 +4,10 @@ import { isValidWorkboardBoardId } from "@openclaw/workboard-contract";
 import type { BoardFace } from "./lib/board/settings.ts";
 export const INTERNAL_SESSION_PATH_PARAM = "__openclawSessionPath";
 
-const APP_ROUTE_DEFINITIONS = {
+// Exported for the app-routes tree-consistency test: page definitions in
+// ui/src/pages/*/route.ts hand-duplicate these paths/aliases, and a drift
+// would desync routeIdFromPath/base-path inference from actual router matching.
+export const APP_ROUTE_DEFINITIONS = {
   chat: { path: "/chat" },
   dashboard: { path: "/dashboard" },
   dashboards: { path: "/dashboards" },

--- a/ui/src/app-route-paths.ts
+++ b/ui/src/app-route-paths.ts
@@ -4,10 +4,7 @@ import { isValidWorkboardBoardId } from "@openclaw/workboard-contract";
 import type { BoardFace } from "./lib/board/settings.ts";
 export const INTERNAL_SESSION_PATH_PARAM = "__openclawSessionPath";
 
-// Exported for the app-routes tree-consistency test: page definitions in
-// ui/src/pages/*/route.ts hand-duplicate these paths/aliases, and a drift
-// would desync routeIdFromPath/base-path inference from actual router matching.
-export const APP_ROUTE_DEFINITIONS = {
+const APP_ROUTE_DEFINITIONS = {
   chat: { path: "/chat" },
   dashboard: { path: "/dashboard" },
   dashboards: { path: "/dashboards" },
@@ -59,6 +56,18 @@ export const APP_ROUTE_IDS = Object.keys(APP_ROUTE_DEFINITIONS) as RouteId[];
 
 export function isRouteId(routeId: string): routeId is RouteId {
   return routeId in APP_ROUTE_DEFINITIONS;
+}
+
+// Single source for page definitions: ui/src/pages/*/route.ts spreads this
+// into definePage so router matching can never drift from the table that
+// drives routeIdFromPath and base-path inference.
+export function routePageSpec<Id extends RouteId>(
+  routeId: Id,
+): { id: Id; path: string; aliases?: readonly string[] } {
+  const definition = APP_ROUTE_DEFINITIONS[routeId];
+  return "aliases" in definition
+    ? { id: routeId, path: definition.path, aliases: definition.aliases }
+    : { id: routeId, path: definition.path };
 }
 
 export function normalizeBasePath(basePath: string): string {

--- a/ui/src/app-routes.test.ts
+++ b/ui/src/app-routes.test.ts
@@ -1,26 +1,26 @@
 import { describe, expect, it } from "vitest";
-import { APP_ROUTE_DEFINITIONS, APP_ROUTE_IDS } from "./app-route-paths.ts";
-import { APP_ROUTE_TREE } from "./app-routes.ts";
+import { APP_ROUTE_IDS, pathForRoute, routeIdFromPath } from "./app-route-paths.ts";
+import { createApplicationRouter } from "./app-routes.ts";
 
-// Route paths and aliases are declared twice: APP_ROUTE_DEFINITIONS drives
-// routeIdFromPath and base-path inference, while the page definitions in
-// ui/src/pages/*/route.ts drive actual router matching. A drift between them
-// means URLs resolve to a route id the router will not serve (or vice versa),
-// which surfaces as silent deep-link breakage instead of a build error.
-describe("APP_ROUTE_TREE vs APP_ROUTE_DEFINITIONS", () => {
+// Page definitions derive path/aliases from the route table via routePageSpec,
+// so router matching cannot disagree with routeIdFromPath/base-path inference
+// about a registered page. This guards the remaining seam: every table id must
+// be registered with the router exactly once, and no page may reintroduce
+// hand-written paths that shadow the table.
+describe("application router registration", () => {
+  const router = createApplicationRouter();
+
   it("registers every route id exactly once", () => {
-    const treeIds = APP_ROUTE_TREE.map((page) => page.id);
-    expect([...treeIds].toSorted()).toEqual([...APP_ROUTE_IDS].toSorted());
+    const routeIds = router.routes.map((route) => route.id);
+    expect([...routeIds].toSorted()).toEqual([...APP_ROUTE_IDS].toSorted());
   });
 
-  it("declares identical paths and aliases on both sides", () => {
-    for (const page of APP_ROUTE_TREE) {
-      const definition = APP_ROUTE_DEFINITIONS[page.id];
-      expect(page.path, `path for route "${page.id}"`).toBe(definition.path);
-      const definitionAliases = "aliases" in definition ? definition.aliases : [];
-      expect([...(page.aliases ?? [])], `aliases for route "${page.id}"`).toEqual([
-        ...definitionAliases,
-      ]);
+  it("serves the table's canonical paths and aliases", () => {
+    for (const route of router.routes) {
+      expect(route.path, `path for route "${route.id}"`).toBe(pathForRoute(route.id));
+      for (const alias of route.aliases ?? []) {
+        expect(routeIdFromPath(alias, ""), `alias "${alias}"`).toBe(route.id);
+      }
     }
   });
 });

--- a/ui/src/app-routes.test.ts
+++ b/ui/src/app-routes.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import { APP_ROUTE_DEFINITIONS, APP_ROUTE_IDS } from "./app-route-paths.ts";
+import { APP_ROUTE_TREE } from "./app-routes.ts";
+
+// Route paths and aliases are declared twice: APP_ROUTE_DEFINITIONS drives
+// routeIdFromPath and base-path inference, while the page definitions in
+// ui/src/pages/*/route.ts drive actual router matching. A drift between them
+// means URLs resolve to a route id the router will not serve (or vice versa),
+// which surfaces as silent deep-link breakage instead of a build error.
+describe("APP_ROUTE_TREE vs APP_ROUTE_DEFINITIONS", () => {
+  it("registers every route id exactly once", () => {
+    const treeIds = APP_ROUTE_TREE.map((page) => page.id);
+    expect([...treeIds].toSorted()).toEqual([...APP_ROUTE_IDS].toSorted());
+  });
+
+  it("declares identical paths and aliases on both sides", () => {
+    for (const page of APP_ROUTE_TREE) {
+      const definition = APP_ROUTE_DEFINITIONS[page.id];
+      expect(page.path, `path for route "${page.id}"`).toBe(definition.path);
+      const definitionAliases = "aliases" in definition ? definition.aliases : [];
+      expect([...(page.aliases ?? [])], `aliases for route "${page.id}"`).toEqual([
+        ...definitionAliases,
+      ]);
+    }
+  });
+});

--- a/ui/src/app-routes.ts
+++ b/ui/src/app-routes.ts
@@ -53,7 +53,9 @@ export type ApplicationRouter = Router<
 >;
 type AppRoute = PageDefinition<RouteId, ApplicationContext<RouteId>, AppRouteModule>;
 
-const APP_ROUTE_TREE = [
+// Exported for the tree-consistency test only; runtime consumers go through
+// createApplicationRouter.
+export const APP_ROUTE_TREE = [
   ...chatPages,
   custodianPage,
   newSessionPage,

--- a/ui/src/app-routes.ts
+++ b/ui/src/app-routes.ts
@@ -53,9 +53,7 @@ export type ApplicationRouter = Router<
 >;
 type AppRoute = PageDefinition<RouteId, ApplicationContext<RouteId>, AppRouteModule>;
 
-// Exported for the tree-consistency test only; runtime consumers go through
-// createApplicationRouter.
-export const APP_ROUTE_TREE = [
+const APP_ROUTE_TREE = [
   ...chatPages,
   custodianPage,
   newSessionPage,

--- a/ui/src/pages/about/route.ts
+++ b/ui/src/pages/about/route.ts
@@ -1,9 +1,9 @@
 import { definePage } from "@openclaw/uirouter";
 import { html } from "lit";
+import { routePageSpec } from "../../app-route-paths.ts";
 
 export const page = definePage({
-  id: "about",
-  path: "/settings/about",
+  ...routePageSpec("about"),
   component: () =>
     import("./about-page.ts").then(() => ({
       header: true,

--- a/ui/src/pages/activity/route.ts
+++ b/ui/src/pages/activity/route.ts
@@ -1,9 +1,9 @@
 import { definePage } from "@openclaw/uirouter";
 import { html } from "lit";
+import { routePageSpec } from "../../app-route-paths.ts";
 
 export const page = definePage({
-  id: "activity",
-  path: "/activity",
+  ...routePageSpec("activity"),
   component: () =>
     import("./activity-page.ts").then(() => ({
       header: true,

--- a/ui/src/pages/agents/route.ts
+++ b/ui/src/pages/agents/route.ts
@@ -1,6 +1,7 @@
 import type { RouteLocation } from "@openclaw/uirouter";
 import { definePage } from "@openclaw/uirouter";
 import { html } from "lit";
+import { routePageSpec } from "../../app-route-paths.ts";
 import type { ApplicationContext } from "../../app/context.ts";
 import { selectableAgentsList } from "../../lib/agents/display.ts";
 import type { AgentsRouteData } from "./agents-page.ts";
@@ -27,9 +28,7 @@ async function loadAgentsRouteData(
 }
 
 export const page = definePage({
-  id: "agents",
-  path: "/settings/agents",
-  aliases: ["/agents"],
+  ...routePageSpec("agents"),
   loaderDeps: (_context: ApplicationContext, location: RouteLocation) => location.search,
   loader: (context: ApplicationContext, { location }) => loadAgentsRouteData(context, location),
   component: () =>

--- a/ui/src/pages/approvals/route.ts
+++ b/ui/src/pages/approvals/route.ts
@@ -1,9 +1,9 @@
 import { definePage } from "@openclaw/uirouter";
 import { html } from "lit";
+import { routePageSpec } from "../../app-route-paths.ts";
 
 export const page = definePage({
-  id: "approvals",
-  path: "/settings/approvals",
+  ...routePageSpec("approvals"),
   component: () =>
     import("./approvals-page.ts").then(() => ({
       header: true,

--- a/ui/src/pages/apps/route.ts
+++ b/ui/src/pages/apps/route.ts
@@ -1,9 +1,9 @@
 import { definePage } from "@openclaw/uirouter";
 import { html } from "lit";
+import { routePageSpec } from "../../app-route-paths.ts";
 
 export const page = definePage({
-  id: "apps",
-  path: "/apps",
+  ...routePageSpec("apps"),
   component: () =>
     import("./apps-page.ts").then(() => ({
       header: true,

--- a/ui/src/pages/channels/route.ts
+++ b/ui/src/pages/channels/route.ts
@@ -1,5 +1,6 @@
 import { definePage } from "@openclaw/uirouter";
 import { html } from "lit";
+import { routePageSpec } from "../../app-route-paths.ts";
 import type { ApplicationContext } from "../../app/context.ts";
 
 function loadChannelsRoute(context: ApplicationContext) {
@@ -16,9 +17,7 @@ function loadChannelsRoute(context: ApplicationContext) {
 }
 
 export const page = definePage({
-  id: "channels",
-  path: "/settings/channels",
-  aliases: ["/channels"],
+  ...routePageSpec("channels"),
   loader: (context: ApplicationContext) => loadChannelsRoute(context),
   component: () =>
     import("./channels-page.ts").then(() => ({

--- a/ui/src/pages/chat/route.ts
+++ b/ui/src/pages/chat/route.ts
@@ -1,6 +1,7 @@
 import type { RouteLocation } from "@openclaw/uirouter";
 import { definePage } from "@openclaw/uirouter";
 import { html, nothing } from "lit";
+import { routePageSpec } from "../../app-route-paths.ts";
 import type { ApplicationContext } from "../../app/context.ts";
 import { t } from "../../i18n/index.ts";
 import type { BoardFace } from "../../lib/board/settings.ts";
@@ -32,8 +33,7 @@ function renderAmbiguous(data: Extract<ChatRouteData, { kind: "ambiguous" }>) {
 
 function sessionPage(face: BoardFace) {
   return definePage({
-    id: face,
-    path: `/${face}`,
+    ...routePageSpec(face),
     loaderDeps: (_context: ApplicationContext, location: RouteLocation) =>
       `${location.pathname}\u0000${location.search}`,
     loader: async (context: ApplicationContext, { location, signal }) => {

--- a/ui/src/pages/config/route.ts
+++ b/ui/src/pages/config/route.ts
@@ -1,6 +1,7 @@
 import type { RouteLocation } from "@openclaw/uirouter";
 import { definePage } from "@openclaw/uirouter";
 import { html } from "lit";
+import { routePageSpec } from "../../app-route-paths.ts";
 import type { ApplicationContext } from "../../app/context.ts";
 import type { ConfigPageId } from "./config-sections.ts";
 import { configRouteData, type ConfigRouteData } from "./route-data.ts";
@@ -11,11 +12,9 @@ function loadConfigRoute(context: ApplicationContext, location: RouteLocation) {
   return configRouteData(location);
 }
 
-function configPage(id: ConfigPageId, path: string, aliases: readonly string[]) {
+function configPage(id: ConfigPageId) {
   return definePage({
-    id,
-    path,
-    aliases,
+    ...routePageSpec(id),
     loaderDeps: (_context: ApplicationContext, location: RouteLocation) =>
       `${location.search}\u0000${location.hash}`,
     loader: (context: ApplicationContext, { location }) => loadConfigRoute(context, location),
@@ -30,15 +29,15 @@ function configPage(id: ConfigPageId, path: string, aliases: readonly string[]) 
 }
 
 export const pages = [
-  configPage("config", "/settings/general", ["/config"]),
-  configPage("communications", "/settings/communications", ["/communications"]),
-  configPage("appearance", "/settings/appearance", ["/appearance"]),
-  configPage("notifications", "/settings/notifications", []),
-  configPage("security", "/settings/security", []),
-  configPage("automation", "/settings/automation", ["/automation"]),
-  configPage("mcp", "/settings/mcp", ["/mcp"]),
-  configPage("memory", "/settings/memory", []),
-  configPage("infrastructure", "/settings/infrastructure", ["/infrastructure"]),
-  configPage("ai-agents", "/settings/ai-agents", ["/ai-agents"]),
-  configPage("advanced", "/settings/advanced", []),
+  configPage("config"),
+  configPage("communications"),
+  configPage("appearance"),
+  configPage("notifications"),
+  configPage("security"),
+  configPage("automation"),
+  configPage("mcp"),
+  configPage("memory"),
+  configPage("infrastructure"),
+  configPage("ai-agents"),
+  configPage("advanced"),
 ] as const;

--- a/ui/src/pages/connection/route.ts
+++ b/ui/src/pages/connection/route.ts
@@ -1,9 +1,9 @@
 import { definePage } from "@openclaw/uirouter";
 import { html } from "lit";
+import { routePageSpec } from "../../app-route-paths.ts";
 
 export const page = definePage({
-  id: "connection",
-  path: "/settings/connection",
+  ...routePageSpec("connection"),
   component: () =>
     import("./connection-page.ts").then(() => ({
       header: true,

--- a/ui/src/pages/cron/route.ts
+++ b/ui/src/pages/cron/route.ts
@@ -1,9 +1,9 @@
 import { definePage } from "@openclaw/uirouter";
 import { html } from "lit";
+import { routePageSpec } from "../../app-route-paths.ts";
 
 export const page = definePage({
-  id: "cron",
-  path: "/cron",
+  ...routePageSpec("cron"),
   component: () =>
     import("./cron-page.ts").then(() => ({
       header: true,

--- a/ui/src/pages/custodian/route.ts
+++ b/ui/src/pages/custodian/route.ts
@@ -1,5 +1,6 @@
 import type { RouteLocation } from "@openclaw/uirouter";
 import { definePage } from "@openclaw/uirouter";
+import { routePageSpec } from "../../app-route-paths.ts";
 import type { ApplicationContext } from "../../app/context.ts";
 import { resolveOnboardingMode } from "../../app/onboarding-mode.ts";
 
@@ -13,8 +14,7 @@ function resolveCustodianIntent(search: string): CustodianRouteData["intent"] {
 }
 
 export const page = definePage({
-  id: "custodian",
-  path: "/custodian",
+  ...routePageSpec("custodian"),
   loaderDeps: (_context: ApplicationContext, location: RouteLocation) => location.search,
   loader: (_context: ApplicationContext, { location }): CustodianRouteData => ({
     onboarding: resolveOnboardingMode(location.search),

--- a/ui/src/pages/dashboards/route.ts
+++ b/ui/src/pages/dashboards/route.ts
@@ -1,5 +1,6 @@
 import { definePage } from "@openclaw/uirouter";
 import { html } from "lit";
+import { routePageSpec } from "../../app-route-paths.ts";
 import type { ApplicationContext } from "../../app/context.ts";
 import { DEFAULT_SESSION_LIST_QUERY } from "../../lib/sessions/index.ts";
 import { resolveSessionNavigationAgentId } from "../../lib/sessions/route-navigation.ts";
@@ -33,8 +34,7 @@ async function loadDashboardsRoute(context: ApplicationContext): Promise<Dashboa
 }
 
 export const page = definePage({
-  id: "dashboards",
-  path: "/dashboards",
+  ...routePageSpec("dashboards"),
   loaderDeps: (context: ApplicationContext) =>
     `${context.agentSelection.state.scopeId ?? "all"}\u0000${context.sessions.canonicalListRevision}`,
   loader: (context: ApplicationContext) => loadDashboardsRoute(context),

--- a/ui/src/pages/debug/route.ts
+++ b/ui/src/pages/debug/route.ts
@@ -1,9 +1,9 @@
 import { definePage } from "@openclaw/uirouter";
 import { html } from "lit";
+import { routePageSpec } from "../../app-route-paths.ts";
 
 export const page = definePage({
-  id: "debug",
-  path: "/debug",
+  ...routePageSpec("debug"),
   component: () =>
     import("./debug-page.ts").then(() => ({
       header: true,

--- a/ui/src/pages/labs/route.ts
+++ b/ui/src/pages/labs/route.ts
@@ -1,10 +1,10 @@
 import { definePage } from "@openclaw/uirouter";
 import { html } from "lit";
+import { routePageSpec } from "../../app-route-paths.ts";
 import type { ApplicationContext } from "../../app/context.ts";
 
 export const page = definePage({
-  id: "labs",
-  path: "/settings/labs",
+  ...routePageSpec("labs"),
   loader: (context: ApplicationContext) => context.runtimeConfig.ensureLoaded(),
   component: () =>
     import("./labs-page.ts").then(() => ({

--- a/ui/src/pages/lobsterdex/route.ts
+++ b/ui/src/pages/lobsterdex/route.ts
@@ -1,10 +1,9 @@
 import { definePage } from "@openclaw/uirouter";
 import { html } from "lit";
+import { routePageSpec } from "../../app-route-paths.ts";
 
 export const page = definePage({
-  id: "lobsterdex",
-  path: "/settings/lobsterdex",
-  aliases: ["/lobsterdex"],
+  ...routePageSpec("lobsterdex"),
   component: () =>
     import("./lobsterdex-page.ts").then(() => ({
       header: true,

--- a/ui/src/pages/logs/route.ts
+++ b/ui/src/pages/logs/route.ts
@@ -1,9 +1,9 @@
 import { definePage } from "@openclaw/uirouter";
 import { html } from "lit";
+import { routePageSpec } from "../../app-route-paths.ts";
 
 export const page = definePage({
-  id: "logs",
-  path: "/logs",
+  ...routePageSpec("logs"),
   component: () =>
     import("./logs-page.ts").then(() => ({
       header: true,

--- a/ui/src/pages/memory-import/route.ts
+++ b/ui/src/pages/memory-import/route.ts
@@ -1,10 +1,9 @@
 import { definePage } from "@openclaw/uirouter";
 import { html } from "lit";
+import { routePageSpec } from "../../app-route-paths.ts";
 
 export const page = definePage({
-  id: "memory-import",
-  path: "/memory-import",
-  aliases: ["/settings/memory-import"],
+  ...routePageSpec("memory-import"),
   component: () =>
     import("./memory-import-page.ts").then(() => ({
       header: true,

--- a/ui/src/pages/model-providers/route.ts
+++ b/ui/src/pages/model-providers/route.ts
@@ -1,5 +1,6 @@
 import { definePage } from "@openclaw/uirouter";
 import { html } from "lit";
+import { routePageSpec } from "../../app-route-paths.ts";
 import type { ApplicationContext } from "../../app/context.ts";
 import { normalizeAgentId } from "../../lib/sessions/session-key.ts";
 import type { ModelProvidersRouteData } from "./model-providers-page.ts";
@@ -26,9 +27,7 @@ async function loadModelProvidersRouteData(
 }
 
 export const page = definePage({
-  id: "model-providers",
-  path: "/settings/model-providers",
-  aliases: ["/model-providers"],
+  ...routePageSpec("model-providers"),
   loader: loadModelProvidersRouteData,
   component: () =>
     import("./model-providers-page.ts").then(() => ({

--- a/ui/src/pages/model-setup/route.ts
+++ b/ui/src/pages/model-setup/route.ts
@@ -1,6 +1,7 @@
 import type { RouteLocation } from "@openclaw/uirouter";
 import { definePage } from "@openclaw/uirouter";
 import { html } from "lit";
+import { routePageSpec } from "../../app-route-paths.ts";
 import type { ApplicationContext } from "../../app/context.ts";
 import { hasOperatorAdminAccess } from "../../app/operator-access.ts";
 import { t } from "../../i18n/index.ts";
@@ -43,9 +44,7 @@ async function loadModelSetupRouteData(
 }
 
 export const page = definePage({
-  id: "model-setup",
-  path: "/settings/model-setup",
-  aliases: ["/model-setup"],
+  ...routePageSpec("model-setup"),
   // Query-only first-run changes need distinct matches so the completion
   // action cannot retain a cached destination from the previous visit.
   loaderDeps: (_context: ApplicationContext, location: RouteLocation) => location.search,

--- a/ui/src/pages/new-session/route.ts
+++ b/ui/src/pages/new-session/route.ts
@@ -1,6 +1,7 @@
 import type { RouteLocation } from "@openclaw/uirouter";
 import { definePage } from "@openclaw/uirouter";
 import { html } from "lit";
+import { routePageSpec } from "../../app-route-paths.ts";
 import type { ApplicationContext } from "../../app/context.ts";
 import { listSelectableAgents } from "../../lib/agents/display.ts";
 import { normalizeAgentId } from "../../lib/sessions/session-key.ts";
@@ -78,8 +79,7 @@ async function loadNewSessionData(
 }
 
 export const page = definePage({
-  id: "new-session",
-  path: "/new",
+  ...routePageSpec("new-session"),
   loaderDeps: (_context: ApplicationContext, location: RouteLocation) => location.search,
   loader: (context: ApplicationContext, { location }) =>
     loadNewSessionData(context, location.search),

--- a/ui/src/pages/nodes/route.ts
+++ b/ui/src/pages/nodes/route.ts
@@ -1,5 +1,6 @@
 import { definePage } from "@openclaw/uirouter";
 import { html } from "lit";
+import { routePageSpec } from "../../app-route-paths.ts";
 import type { ApplicationContext } from "../../app/context.ts";
 import {
   createInitialNodesState,
@@ -31,9 +32,7 @@ async function loadNodesRouteData(context: ApplicationContext): Promise<NodesRou
 }
 
 export const page = definePage({
-  id: "nodes",
-  path: "/settings/devices",
-  aliases: ["/nodes"],
+  ...routePageSpec("nodes"),
   loader: loadNodesRouteData,
   component: () =>
     import("./nodes-page.ts").then(() => ({

--- a/ui/src/pages/plugin/route.ts
+++ b/ui/src/pages/plugin/route.ts
@@ -1,5 +1,6 @@
 import { definePage } from "@openclaw/uirouter";
 import { html } from "lit";
+import { routePageSpec } from "../../app-route-paths.ts";
 
 type PluginTabRef = {
   pluginId: string;
@@ -27,8 +28,7 @@ export function pluginTabKey(ref: PluginTabRef): string {
 // One static route hosts every plugin-declared tab; the router only supports
 // exact paths, so the tab reference travels in the query.
 export const page = definePage({
-  id: "plugin",
-  path: "/plugin",
+  ...routePageSpec("plugin"),
   loaderDeps: (_context, location) => location.search,
   loader: (_context, options) => pluginTabRefFromSearch(options.location.search),
   component: () =>

--- a/ui/src/pages/plugins/route.ts
+++ b/ui/src/pages/plugins/route.ts
@@ -1,5 +1,6 @@
 import { definePage, type RouteLoaderOptions, type RouteLocation } from "@openclaw/uirouter";
 import { html } from "lit";
+import { routePageSpec } from "../../app-route-paths.ts";
 import type { ApplicationContext } from "../../app/context.ts";
 import { loadPluginCatalog } from "../../lib/plugins/index.ts";
 import type { PluginsRouteData } from "./plugins-page.ts";
@@ -33,8 +34,7 @@ async function loadPluginsRouteData(
 }
 
 export const page = definePage({
-  id: "plugins",
-  path: "/settings/plugins",
+  ...routePageSpec("plugins"),
   // Query-only tab changes need distinct matches; without this the router
   // reuses the cached loader result and the hub keeps the previous tab.
   loaderDeps: (_context: ApplicationContext, location: RouteLocation) =>

--- a/ui/src/pages/profile/route.ts
+++ b/ui/src/pages/profile/route.ts
@@ -1,11 +1,10 @@
 import { definePage } from "@openclaw/uirouter";
 import { html } from "lit";
+import { routePageSpec } from "../../app-route-paths.ts";
 import type { ApplicationContext } from "../../app/context.ts";
 
 export const page = definePage({
-  id: "profile",
-  path: "/settings/profile",
-  aliases: ["/profile"],
+  ...routePageSpec("profile"),
   loader: (context: ApplicationContext) => {
     // Warm the agents list so the hero identity renders without a flash.
     void context.agents.ensureList();

--- a/ui/src/pages/sessions/route.ts
+++ b/ui/src/pages/sessions/route.ts
@@ -1,6 +1,7 @@
 import type { RouteLocation } from "@openclaw/uirouter";
 import { definePage } from "@openclaw/uirouter";
 import { html } from "lit";
+import { routePageSpec } from "../../app-route-paths.ts";
 import type { ApplicationContext } from "../../app/context.ts";
 import {
   DEFAULT_SESSION_LIST_QUERY,
@@ -55,9 +56,7 @@ async function loadSessionsRoute(
 }
 
 export const page = definePage({
-  id: "sessions",
-  path: "/sessions",
-  aliases: ["/settings/sessions"],
+  ...routePageSpec("sessions"),
   loaderDeps: (context: ApplicationContext, location: RouteLocation) => {
     const options = routeOptions(location);
     return `${options.expandedSessionKey ?? ""}\u0000${options.statusFilter}\u0000${context.agentSelection.state.scopeId ?? "all"}`;

--- a/ui/src/pages/skill-workshop/route.ts
+++ b/ui/src/pages/skill-workshop/route.ts
@@ -1,11 +1,11 @@
 import { definePage } from "@openclaw/uirouter";
 import { html } from "lit";
+import { routePageSpec } from "../../app-route-paths.ts";
 import type { ApplicationContext } from "../../app/context.ts";
 import type { SkillWorkshopRouteData } from "./proposals.ts";
 
 export const page = definePage({
-  id: "skill-workshop",
-  path: "/skills/workshop",
+  ...routePageSpec("skill-workshop"),
   component: () =>
     import("./skill-workshop-page.ts").then(() => ({
       render: (data: unknown) => html`

--- a/ui/src/pages/skills/route.ts
+++ b/ui/src/pages/skills/route.ts
@@ -1,5 +1,6 @@
 import { definePage } from "@openclaw/uirouter";
 import { html } from "lit";
+import { routePageSpec } from "../../app-route-paths.ts";
 import type { ApplicationContext } from "../../app/context.ts";
 import { loadSkillStatusReport } from "../../lib/skills/index.ts";
 import type { SkillsRouteData } from "./skills-page.ts";
@@ -50,8 +51,7 @@ async function loadSkillsRouteData(context: ApplicationContext): Promise<SkillsR
 }
 
 export const page = definePage({
-  id: "skills",
-  path: "/skills",
+  ...routePageSpec("skills"),
   loader: loadSkillsRouteData,
   component: () =>
     import("./skills-page.ts").then(() => ({

--- a/ui/src/pages/tasks/route.ts
+++ b/ui/src/pages/tasks/route.ts
@@ -1,9 +1,9 @@
 import { definePage } from "@openclaw/uirouter";
 import { html } from "lit";
+import { routePageSpec } from "../../app-route-paths.ts";
 
 export const page = definePage({
-  id: "tasks",
-  path: "/tasks",
+  ...routePageSpec("tasks"),
   component: () =>
     import("./tasks-page.ts").then(() => ({
       header: true,

--- a/ui/src/pages/usage/route.ts
+++ b/ui/src/pages/usage/route.ts
@@ -1,6 +1,7 @@
 import { definePage } from "@openclaw/uirouter";
 import { html } from "lit";
 import type { CostUsageSummary } from "../../api/types.ts";
+import { routePageSpec } from "../../app-route-paths.ts";
 import type { ApplicationContext } from "../../app/context.ts";
 import {
   formatMissingOperatorReadScopeMessage,
@@ -88,8 +89,7 @@ async function loadUsageRouteData(context: ApplicationContext): Promise<UsageRou
 }
 
 export const page = definePage({
-  id: "usage",
-  path: "/usage",
+  ...routePageSpec("usage"),
   loader: loadUsageRouteData,
   component: () =>
     import("./usage-page.ts").then(() => ({

--- a/ui/src/pages/workboard/route.ts
+++ b/ui/src/pages/workboard/route.ts
@@ -1,6 +1,7 @@
 import type { RouteLocation } from "@openclaw/uirouter";
 import { definePage } from "@openclaw/uirouter";
 import { html } from "lit";
+import { routePageSpec } from "../../app-route-paths.ts";
 import type { ApplicationContext } from "../../app/context.ts";
 import { resolveWorkboardRouteLocation, type WorkboardRouteData } from "./route-location.ts";
 
@@ -22,8 +23,7 @@ async function loadWorkboardRoute(
 }
 
 export const page = definePage({
-  id: "workboard",
-  path: "/workboard",
+  ...routePageSpec("workboard"),
   loaderDeps: (_context: ApplicationContext, location: RouteLocation) =>
     `${location.pathname}\u0000${location.search}`,
   loader: (context: ApplicationContext, { location }) => loadWorkboardRoute(context, location),

--- a/ui/src/pages/worktrees/route.ts
+++ b/ui/src/pages/worktrees/route.ts
@@ -1,10 +1,9 @@
 import { definePage } from "@openclaw/uirouter";
 import { html } from "lit";
+import { routePageSpec } from "../../app-route-paths.ts";
 
 export const page = definePage({
-  id: "worktrees",
-  path: "/worktrees",
-  aliases: ["/settings/worktrees"],
+  ...routePageSpec("worktrees"),
   component: () =>
     import("./worktrees-page.ts").then(() => ({
       header: true,


### PR DESCRIPTION
## What Problem This Solves

Control UI route paths and aliases were declared twice by hand: `APP_ROUTE_DEFINITIONS` in `ui/src/app-route-paths.ts` drives `routeIdFromPath` and base-path inference, while each page's `definePage({ id, path, aliases })` in `ui/src/pages/*/route.ts` drives actual router matching. Nothing guarded the two against drift: updating one side only would make URLs resolve to a route id the router will not serve (or vice versa) — silent deep-link breakage instead of a build/test error. Verified there was no existing guard: `APP_ROUTE_DEFINITIONS` had no consumers outside its module and no test or script compares page definitions to the table.

## Why This Change Was Made

Follow-up hardening from the #115186 investigation, where the duplicated declarations were noticed as an adjacent silent-routing-bug class. The first attempt (a test importing the table and tree) collided with the deadcode gate by design — production Knip intentionally rejects prod-file exports whose only consumers are tests. That pushed the fix to the better shape: a `routePageSpec(routeId)` helper makes the route table the single source, every `ui/src/pages/*/route.ts` spreads it into `definePage`, and the hand-written path/alias literals are deleted. Path/alias drift is now structurally impossible, and a small colocated test guards the remaining seam (registration completeness) through the router's public `routes` surface with zero test-only exports.

## User Impact

None intended at runtime: page ids, paths, and aliases are byte-identical (they now come from the same table `routeIdFromPath` already used). Net −4 LOC with 31 duplicated declarations removed.

## Evidence

- `node scripts/run-vitest.mjs run ui/src/app-routes.test.ts ui/src/app-navigation.test.ts` — new registration test plus all existing route tests green (2 + 74 tests at head).
- Live negative proof of the guard during development: removing the `/agents` alias from the page side failed the tree/table comparison with `aliases for route "agents": expected ["/agents"], got []`.
- Live routing proof on this branch (scratch gateway `ws://[::1]:19790` + vite dev `[::1]:5299`, connected profile): direct loads of canonical `/settings/general`, alias `/config` (configPage spread), alias `/agents` (routePageSpec spread), and the root chat landing all boot the connected shell and render the right pages.
- Delegated Blacksmith Testbox run: `pnpm check:changed` (typecheck core tests, typecheck UI, lint, format, i18n, guards) plus `pnpm test ui/src/app-routes.test.ts ui/src/app-navigation.test.ts` in one lease.
- Codex autoreview (gpt-5.6-sol, xhigh) on the full branch diff: clean — "no accepted/actionable findings" (0.94 correct).
