### PR TITLE
fix(tui): order delayed prompts before completed replies

### DIFF
--- a/src/tui/components/chat-log-run-state.test.ts
+++ b/src/tui/components/chat-log-run-state.test.ts
@@ -1,0 +1,141 @@
+// Covers canonical assistant-run ownership and live transcript identity.
+import { describe, expect, it } from "vitest";
+import { normalizeTestText } from "../../../test/helpers/normalize-text.js";
+import { ChatLog } from "./chat-log.js";
+
+describe("ChatLog run state", () => {
+  it("keeps revised snapshots scoped to their own concurrent assistant run", () => {
+    const chatLog = new ChatLog(40);
+
+    chatLog.updateAssistant("Obsolete first reply.", "run-first");
+    chatLog.updateAssistant("Preserved second reply.", "run-second");
+    chatLog.startTool("first-tool", "read_file", { path: "first.txt" }, "run-first");
+    chatLog.updateAssistant("Revised first reply.", "run-first");
+    chatLog.updateAssistant("Preserved second reply.\n\nSecond continuation.", "run-second");
+
+    const rendered = normalizeTestText(chatLog.render(120).join("\n"));
+    expect(rendered).not.toContain("Obsolete first reply.");
+    expect(rendered.split("Revised first reply.")).toHaveLength(2);
+    expect(rendered.split("Preserved second reply.")).toHaveLength(2);
+    expect(rendered.split("Second continuation.")).toHaveLength(2);
+    expect(rendered.indexOf("Preserved second reply.")).toBeLessThan(
+      rendered.indexOf("Second continuation."),
+    );
+  });
+
+  it("infers tool ownership from the only streaming run after another run finalizes", () => {
+    const chatLog = new ChatLog(40);
+
+    chatLog.finalizeAssistant("Completed first reply.", "run-first");
+    chatLog.updateAssistant("Streaming second reply.", "run-second");
+    chatLog.startTool("second-tool", "read_file", { path: "second.txt" });
+    chatLog.addLiveUser("Delayed second prompt.", {
+      messageId: "second-user",
+      runId: "run-second",
+    });
+
+    const rendered = normalizeTestText(chatLog.render(120).join("\n"));
+    expect(rendered.indexOf("Completed first reply.")).toBeLessThan(
+      rendered.indexOf("Delayed second prompt."),
+    );
+    expect(rendered.indexOf("Delayed second prompt.")).toBeLessThan(
+      rendered.indexOf("Streaming second reply."),
+    );
+    expect(rendered.indexOf("Streaming second reply.")).toBeLessThan(rendered.indexOf("Read File"));
+  });
+
+  it("keeps a replacement final reply anchored when its previous reply is pruned", () => {
+    const chatLog = new ChatLog(20);
+
+    chatLog.finalizeAssistant("Previous completed reply.", "run-replaced");
+    for (let index = 0; index < 19; index += 1) {
+      chatLog.addSystem(`Retained notice ${index}.`);
+    }
+    chatLog.finalizeAssistant("Replacement completed reply.", "run-replaced");
+    chatLog.addLiveUser("Delayed replacement prompt.", {
+      messageId: "replacement-user",
+      runId: "run-replaced",
+    });
+
+    const rendered = normalizeTestText(chatLog.render(120).join("\n"));
+    expect(chatLog.children).toHaveLength(20);
+    expect(rendered).not.toContain("Previous completed reply.");
+    expect(rendered.indexOf("Delayed replacement prompt.")).toBeLessThan(
+      rendered.indexOf("Replacement completed reply."),
+    );
+  });
+
+  it("infers active tool ownership after another finalized run leaves scrollback", () => {
+    const chatLog = new ChatLog(20);
+
+    chatLog.finalizeAssistant("Evicted completed reply.", "run-evicted");
+    chatLog.updateAssistant("Surviving streamed reply.", "run-active");
+    for (let index = 0; index < 18; index += 1) {
+      chatLog.addSystem(`Retained notice ${index}.`);
+    }
+    chatLog.startTool("active-tool", "read_file", { path: "active.txt" });
+    chatLog.addLiveUser("Delayed active prompt.", {
+      messageId: "active-user",
+      runId: "run-active",
+    });
+
+    const rendered = normalizeTestText(chatLog.render(120).join("\n"));
+    expect(chatLog.children).toHaveLength(20);
+    expect(rendered).not.toContain("Evicted completed reply.");
+    expect(rendered.indexOf("Delayed active prompt.")).toBeLessThan(
+      rendered.indexOf("Surviving streamed reply."),
+    );
+    expect(rendered.indexOf("Surviving streamed reply.")).toBeLessThan(
+      rendered.indexOf("Read File"),
+    );
+  });
+
+  it("restores adopted historical users in their subsequent live-event order", () => {
+    const chatLog = new ChatLog(40);
+
+    chatLog.addUser("Historical first prompt.", {
+      messageId: "historical-first",
+      messageSeq: 1,
+    });
+    chatLog.addUser("Historical second prompt.", {
+      messageId: "historical-second",
+      messageSeq: 2,
+    });
+    chatLog.addLiveUser("Second prompt updated first.", {
+      messageId: "historical-second",
+      messageSeq: 3,
+    });
+    chatLog.addLiveUser("First prompt updated second.", {
+      messageId: "historical-first",
+      messageSeq: 4,
+    });
+
+    chatLog.clearAll({ preserveLiveUsers: true });
+    chatLog.restoreLiveUsers();
+
+    const rendered = normalizeTestText(chatLog.render(120).join("\n"));
+    expect(chatLog.children).toHaveLength(2);
+    expect(rendered.indexOf("Second prompt updated first.")).toBeLessThan(
+      rendered.indexOf("First prompt updated second."),
+    );
+  });
+
+  it("keeps the latest known live sequence when history adopts a prompt without one", () => {
+    const chatLog = new ChatLog(40);
+
+    chatLog.addLiveUser("Original live prompt.", {
+      messageId: "shared-user",
+      messageSeq: 3,
+    });
+    chatLog.addUser("Persisted shared prompt.", { messageId: "shared-user" });
+    chatLog.addLiveUser("Updated shared prompt.", { messageId: "shared-user" });
+
+    chatLog.clearAll({ preserveLiveUsers: true });
+    chatLog.restoreLiveUsers(3);
+    expect(chatLog.children).toHaveLength(0);
+
+    chatLog.restoreLiveUsers(4);
+    expect(chatLog.children).toHaveLength(1);
+    expect(normalizeTestText(chatLog.render(120).join("\n"))).toContain("Updated shared prompt.");
+  });
+});

--- a/src/tui/components/chat-log.test.ts
+++ b/src/tui/components/chat-log.test.ts
@@ -874,6 +874,173 @@ describe("ChatLog", () => {
     },
   );
 
+  it.each([20, 40])(
+    "reserves a delayed prompt slot when one run fills all %i scrollback components",
+    (capacity) => {
+      const chatLog = new ChatLog(capacity);
+      const runId = `full-run-${capacity}`;
+      let assistantText = "";
+
+      for (let index = 0; index < capacity; index += 1) {
+        assistantText += `${index === 0 ? "" : "\n\n"}Assistant segment ${index}.`;
+        chatLog.updateAssistant(assistantText, runId);
+        if (index < capacity - 1) {
+          chatLog.startTool(
+            `${runId}-tool-${index}`,
+            "read_file",
+            { path: `segment-${index}.txt` },
+            runId,
+          );
+          chatLog.clearTools();
+        }
+      }
+      chatLog.finalizeAssistant(assistantText, runId);
+
+      const prompt = { messageId: `${runId}-user`, runId };
+      chatLog.addLiveUser("Delayed prompt before a full reply.", prompt);
+      chatLog.addLiveUser("Delayed prompt before a full reply.", prompt);
+
+      const rendered = normalizeTestText(chatLog.render(120).join("\n"));
+      expect(chatLog.children).toHaveLength(capacity);
+      expect(rendered.match(/Delayed prompt before a full reply\./g)).toHaveLength(1);
+      expect(rendered.indexOf("Delayed prompt before a full reply.")).toBeLessThan(
+        rendered.indexOf("Assistant segment 0."),
+      );
+      expect(rendered).toContain(`Assistant segment ${capacity - 1}.`);
+    },
+  );
+
+  it.each([20, 40])(
+    "retains an executing tool while reserving a delayed prompt at capacity %i",
+    (capacity) => {
+      const chatLog = new ChatLog(capacity);
+      const runId = `active-tool-${capacity}`;
+      let assistantText = "";
+
+      for (let index = 0; index < capacity - 1; index += 1) {
+        assistantText += `${index === 0 ? "" : "\n\n"}Running reply segment ${index}.`;
+        chatLog.updateAssistant(assistantText, runId);
+        chatLog.startTool(
+          `${runId}-previous-tool-${index}`,
+          "read_file",
+          { path: `previous-${index}.txt` },
+          runId,
+        );
+        chatLog.clearTools();
+      }
+
+      const activeToolId = `${runId}-active-tool`;
+      chatLog.startTool(activeToolId, "read_file", { path: "still-running.txt" }, runId);
+      chatLog.addLiveUser("Delayed prompt during active tool.", {
+        messageId: `${runId}-user`,
+        runId,
+      });
+      chatLog.updateToolResult(
+        activeToolId,
+        { content: [{ type: "text", text: "Visible partial tool output." }] },
+        { partial: true },
+      );
+
+      let rendered = normalizeTestText(chatLog.render(120).join("\n"));
+      expect(chatLog.children).toHaveLength(capacity);
+      expect(rendered).toContain("Visible partial tool output.");
+      expect(rendered.indexOf("Delayed prompt during active tool.")).toBeLessThan(
+        rendered.indexOf("Running reply segment 0."),
+      );
+
+      chatLog.updateToolResult(activeToolId, {
+        content: [{ type: "text", text: "Visible final tool output." }],
+      });
+      rendered = normalizeTestText(chatLog.render(120).join("\n"));
+      expect(rendered).toContain("Visible final tool output.");
+      expect(chatLog.children).toHaveLength(capacity);
+    },
+  );
+
+  it.each([20, 40])(
+    "preserves both a streaming reply and an executing tool at full capacity %i",
+    (capacity) => {
+      const chatLog = new ChatLog(capacity);
+      const runId = `live-components-${capacity}`;
+      chatLog.updateAssistant("First preserved live reply.", runId);
+
+      const activeToolId = `${runId}-active-tool`;
+      for (let index = 0; index < capacity - 2; index += 1) {
+        const toolId = index === 0 ? activeToolId : `${runId}-completed-tool-${index}`;
+        chatLog.startTool(toolId, "read_file", { path: `live-tool-${index}.txt` }, runId);
+        if (index > 0) {
+          chatLog.updateToolResult(toolId, {
+            content: [{ type: "text", text: `Completed historical tool ${index}.` }],
+          });
+        }
+      }
+      chatLog.updateAssistant(
+        "First preserved live reply.\n\nStreaming reply remains visible.",
+        runId,
+      );
+
+      chatLog.addLiveUser("Delayed prompt during live components.", {
+        messageId: `${runId}-user`,
+        runId,
+      });
+      chatLog.updateToolResult(
+        activeToolId,
+        { content: [{ type: "text", text: "Live tool progress remains visible." }] },
+        { partial: true },
+      );
+      chatLog.updateAssistant("First preserved live reply.\n\nUpdated streaming reply.", runId);
+
+      const rendered = normalizeTestText(chatLog.render(120).join("\n"));
+      expect(chatLog.children).toHaveLength(capacity);
+      expect(rendered.match(/Delayed prompt during live components\./g)).toHaveLength(1);
+      expect(rendered.indexOf("Delayed prompt during live components.")).toBeLessThan(
+        rendered.indexOf("First preserved live reply."),
+      );
+      expect(rendered).toContain("Live tool progress remains visible.");
+      expect(rendered).toContain("Updated streaming reply.");
+      expect(rendered).not.toContain("Completed historical tool 1.");
+    },
+  );
+
+  it.each([20, 40])(
+    "evicts a completed first segment before an executing tool at capacity %i",
+    (capacity) => {
+      const chatLog = new ChatLog(capacity);
+      const runId = `only-completed-anchor-${capacity}`;
+      chatLog.updateAssistant("Only completed reply segment.", runId);
+
+      for (let index = 0; index < capacity - 2; index += 1) {
+        chatLog.startTool(
+          `${runId}-active-tool-${index}`,
+          "read_file",
+          { path: `active-only-${index}.txt` },
+          runId,
+        );
+      }
+      chatLog.updateAssistant("Only completed reply segment.\n\nProtected live reply.", runId);
+      chatLog.addLiveUser("Delayed prompt before concurrent tools.", {
+        messageId: `${runId}-user`,
+        runId,
+      });
+
+      for (const index of [0, capacity - 3]) {
+        chatLog.updateToolResult(
+          `${runId}-active-tool-${index}`,
+          { content: [{ type: "text", text: `Protected active tool ${index}.` }] },
+          { partial: true },
+        );
+      }
+
+      const rendered = normalizeTestText(chatLog.render(120).join("\n"));
+      expect(chatLog.children).toHaveLength(capacity);
+      expect(rendered.match(/Delayed prompt before concurrent tools\./g)).toHaveLength(1);
+      expect(rendered).not.toContain("Only completed reply segment.");
+      expect(rendered).toContain("Protected live reply.");
+      expect(rendered).toContain("Protected active tool 0.");
+      expect(rendered).toContain(`Protected active tool ${capacity - 3}.`);
+    },
+  );
+
   it("deduplicates authoritative user events and adopts the matching pending prompt", () => {
     const chatLog = new ChatLog(40);
     chatLog.addPendingUser("shared-run", "Persisted prompt.");

--- a/src/tui/components/chat-log.test.ts
+++ b/src/tui/components/chat-log.test.ts
@@ -825,6 +825,55 @@ describe("ChatLog", () => {
       }
     },
   );
+
+  it.each([
+    { capacity: 20, eviction: "first-assistant", evictedComponents: 1 },
+    { capacity: 40, eviction: "first-assistant", evictedComponents: 1 },
+    { capacity: 20, eviction: "all-assistants", evictedComponents: 3 },
+    { capacity: 40, eviction: "all-assistants", evictedComponents: 3 },
+  ])(
+    "orders a delayed prompt before owned tools after $eviction eviction at capacity $capacity",
+    ({ capacity, eviction, evictedComponents }) => {
+      const chatLog = new ChatLog(capacity);
+      const runId = `evicted-${eviction}-${capacity}`;
+
+      chatLog.updateAssistant("First evicted reply segment.", runId);
+      chatLog.startTool(`${runId}-first-tool`, "read_file", { path: "first-shared.txt" }, runId);
+      chatLog.updateAssistant("First evicted reply segment.\n\nLast evicted reply segment.", runId);
+      chatLog.startTool(`${runId}-last-tool`, "read_file", { path: "last-shared.txt" }, runId);
+      chatLog.finalizeAssistant(
+        "First evicted reply segment.\n\nLast evicted reply segment.",
+        runId,
+      );
+
+      while (chatLog.children.length < capacity) {
+        chatLog.addSystem(`Retained notice ${chatLog.children.length}.`);
+      }
+      for (let index = 0; index < evictedComponents; index += 1) {
+        chatLog.addSystem(`Evicting notice ${index}.`);
+      }
+
+      const prompt = { messageId: `${runId}-user`, runId };
+      chatLog.addLiveUser("Delayed prompt before surviving tools.", prompt);
+      chatLog.addLiveUser("Delayed prompt before surviving tools.", prompt);
+
+      const rendered = normalizeTestText(chatLog.render(120).join("\n"));
+      expect(chatLog.children).toHaveLength(capacity);
+      expect(rendered.match(/Delayed prompt before surviving tools\./g)).toHaveLength(1);
+      expect(rendered.indexOf("Delayed prompt before surviving tools.")).toBeLessThan(
+        rendered.indexOf("last-shared.txt"),
+      );
+      if (eviction === "first-assistant") {
+        expect(rendered.indexOf("Delayed prompt before surviving tools.")).toBeLessThan(
+          rendered.indexOf("first-shared.txt"),
+        );
+        expect(rendered).toContain("Last evicted reply segment.");
+      } else {
+        expect(rendered).not.toContain("Last evicted reply segment.");
+      }
+    },
+  );
+
   it("deduplicates authoritative user events and adopts the matching pending prompt", () => {
     const chatLog = new ChatLog(40);
     chatLog.addPendingUser("shared-run", "Persisted prompt.");

--- a/src/tui/components/chat-log.test.ts
+++ b/src/tui/components/chat-log.test.ts
@@ -760,6 +760,71 @@ describe("ChatLog", () => {
     expect(chatLog.render(120).join("\n")).not.toContain("evicted tool must stay detached");
   });
 
+  it.each([
+    { phase: "streaming", capacity: 20 },
+    { phase: "streaming", capacity: 40 },
+    { phase: "finished", capacity: 20 },
+    { phase: "finished", capacity: 40 },
+    { phase: "tool-streaming", capacity: 20 },
+    { phase: "tool-streaming", capacity: 40 },
+    { phase: "tool-finished", capacity: 20 },
+    { phase: "tool-finished", capacity: 40 },
+    { phase: "tool-finished-direct", capacity: 20 },
+    { phase: "tool-finished-direct", capacity: 40 },
+    { phase: "tool-finished-no-tail", capacity: 20 },
+    { phase: "tool-finished-no-tail", capacity: 40 },
+    { phase: "tool-finished-retracted-tail", capacity: 20 },
+    { phase: "tool-finished-retracted-tail", capacity: 40 },
+  ])(
+    "orders a delayed prompt before a $phase reply at capacity $capacity",
+    ({ phase, capacity }) => {
+      const chatLog = new ChatLog(capacity);
+      const runId = `shared-${phase}-${capacity}`;
+      chatLog.updateAssistant("First reply segment.", runId);
+
+      if (phase.startsWith("tool-")) {
+        chatLog.startTool(`${runId}-tool`, "read_file", { path: "shared.txt" });
+        if (
+          phase === "tool-streaming" ||
+          phase === "tool-finished" ||
+          phase === "tool-finished-retracted-tail"
+        ) {
+          chatLog.updateAssistant("First reply segment.\n\nLast reply segment.", runId);
+        }
+      }
+      if (phase === "finished" || phase.startsWith("tool-finished")) {
+        chatLog.finalizeAssistant(
+          phase.startsWith("tool-") &&
+            phase !== "tool-finished-no-tail" &&
+            phase !== "tool-finished-retracted-tail"
+            ? "First reply segment.\n\nLast reply segment."
+            : "First reply segment.",
+          runId,
+        );
+      }
+      while (chatLog.children.length < capacity) {
+        chatLog.addSystem(`Old notice ${chatLog.children.length}.`);
+      }
+
+      const prompt = { messageId: `${runId}-user`, runId };
+      chatLog.addLiveUser("Authoritative shared prompt.", prompt);
+      chatLog.addLiveUser("Authoritative shared prompt.", prompt);
+
+      const rendered = normalizeTestText(chatLog.render(120).join("\n"));
+      expect(chatLog.children).toHaveLength(capacity);
+      expect(rendered.match(/Authoritative shared prompt\./g)).toHaveLength(1);
+      expect(rendered.indexOf("Authoritative shared prompt.")).toBeLessThan(
+        rendered.indexOf("First reply segment."),
+      );
+      if (
+        phase.startsWith("tool-") &&
+        phase !== "tool-finished-no-tail" &&
+        phase !== "tool-finished-retracted-tail"
+      ) {
+        expect(rendered).toContain("Last reply segment.");
+      }
+    },
+  );
   it("deduplicates authoritative user events and adopts the matching pending prompt", () => {
     const chatLog = new ChatLog(40);
     chatLog.addPendingUser("shared-run", "Persisted prompt.");

--- a/src/tui/components/chat-log.ts
+++ b/src/tui/components/chat-log.ts
@@ -22,6 +22,7 @@ export class ChatLog extends Container {
   private readonly maxComponents: number;
   private toolById = new Map<string, ToolExecutionComponent>();
   private toolRunIds = new Map<string, string>();
+  private activeTools = new Set<ToolExecutionComponent>();
   private streamingRuns = new Map<string, AssistantMessageComponent>();
   private frozenAssistants = new Map<string, Set<AssistantMessageComponent>>();
   private finalizedAssistants = new Map<string, Set<AssistantMessageComponent>>();
@@ -54,6 +55,7 @@ export class ChatLog extends Container {
       if (tool === component) {
         this.toolById.delete(toolId);
         this.toolRunIds.delete(toolId);
+        this.activeTools.delete(tool);
       }
     }
     for (const [runId, message] of this.streamingRuns.entries()) {
@@ -130,6 +132,7 @@ export class ChatLog extends Container {
     this.clear();
     this.toolById.clear();
     this.toolRunIds.clear();
+    this.activeTools.clear();
     this.streamingRuns.clear();
     this.frozenAssistants.clear();
     this.finalizedAssistants.clear();
@@ -163,6 +166,7 @@ export class ChatLog extends Container {
     }
     this.toolById.clear();
     this.toolRunIds.clear();
+    this.activeTools.clear();
   }
 
   restoreLiveUsers(beforeMessageSeq?: number) {
@@ -314,10 +318,49 @@ export class ChatLog extends Container {
       protectedComponents.has(entry),
     );
     if (firstRunComponentIndex >= 0) {
+      const firstRunComponent = this.children[firstRunComponentIndex];
       // Scrollback may evict early reply segments before a peer prompt arrives;
       // anchor before the earliest surviving reply or tool from the same run.
       this.repeatableSystemMessage = null;
       this.children.splice(firstRunComponentIndex, 0, component);
+      if (protectedComponents.size > this.maxComponents) {
+        // Prefer completed history, but keep the sole reply when only tools
+        // remain: dropping it would leave a prompt with no visible response.
+        const streaming = options.runId ? this.streamingRuns.get(options.runId) : undefined;
+        const evictable =
+          this.children.find(
+            (entry) =>
+              entry !== firstRunComponent &&
+              entry !== streaming &&
+              entry instanceof AssistantMessageComponent &&
+              protectedComponents.has(entry),
+          ) ??
+          this.children.find(
+            (entry) =>
+              entry !== firstRunComponent &&
+              entry instanceof ToolExecutionComponent &&
+              !this.activeTools.has(entry) &&
+              protectedComponents.has(entry),
+          ) ??
+          (streaming &&
+          firstRunComponent instanceof AssistantMessageComponent &&
+          firstRunComponent !== streaming
+            ? firstRunComponent
+            : undefined) ??
+          (firstRunComponent instanceof ToolExecutionComponent &&
+          !this.activeTools.has(firstRunComponent)
+            ? firstRunComponent
+            : undefined) ??
+          this.children.find(
+            (entry) =>
+              entry !== firstRunComponent &&
+              entry instanceof ToolExecutionComponent &&
+              protectedComponents.has(entry),
+          );
+        if (evictable) {
+          protectedComponents.delete(evictable);
+        }
+      }
       this.pruneOverflow(protectedComponents);
       return component;
     }
@@ -587,6 +630,7 @@ export class ChatLog extends Container {
     const component = new ToolExecutionComponent(toolName, args);
     component.setExpanded(this.toolsExpanded);
     this.toolById.set(toolCallId, component);
+    this.activeTools.add(component);
     if (owningRunId) {
       this.toolRunIds.set(toolCallId, owningRunId);
     }
@@ -604,9 +648,11 @@ export class ChatLog extends Container {
       return;
     }
     if (opts?.partial) {
+      this.activeTools.add(existing);
       existing.setPartialResult(result as Record<string, unknown>);
       return;
     }
+    this.activeTools.delete(existing);
     existing.setResult(result as Record<string, unknown>, {
       isError: opts?.isError,
     });

--- a/src/tui/components/chat-log.ts
+++ b/src/tui/components/chat-log.ts
@@ -24,6 +24,7 @@ export class ChatLog extends Container {
   private toolRunIds = new Map<string, string>();
   private streamingRuns = new Map<string, AssistantMessageComponent>();
   private frozenAssistants = new Map<string, Set<AssistantMessageComponent>>();
+  private finalizedAssistants = new Map<string, Set<AssistantMessageComponent>>();
   private committedAssistantText = new Map<string, string>();
   private latestAssistantText = new Map<string, string>();
   private liveUsers = new Map<string, UserMessageComponent>();
@@ -61,6 +62,12 @@ export class ChatLog extends Container {
       }
     }
     if (component instanceof AssistantMessageComponent) {
+      for (const [runId, messages] of this.finalizedAssistants.entries()) {
+        messages.delete(component);
+        if (messages.size === 0) {
+          this.finalizedAssistants.delete(runId);
+        }
+      }
       for (const [runId, messages] of this.frozenAssistants.entries()) {
         messages.delete(component);
         if (messages.size === 0) {
@@ -125,6 +132,7 @@ export class ChatLog extends Container {
     this.toolRunIds.clear();
     this.streamingRuns.clear();
     this.frozenAssistants.clear();
+    this.finalizedAssistants.clear();
     this.committedAssistantText.clear();
     this.latestAssistantText.clear();
     if (opts?.preserveLiveUsers) {
@@ -285,9 +293,12 @@ export class ChatLog extends Container {
     const component = new UserMessageComponent(text);
     this.liveUsers.set(options.messageId, component);
     const frozen = options.runId ? this.frozenAssistants.get(options.runId) : undefined;
+    const finalized = options.runId ? this.finalizedAssistants.get(options.runId) : undefined;
     const assistant =
       frozen?.values().next().value ??
-      (options.runId ? this.streamingRuns.get(options.runId) : undefined);
+      (options.runId
+        ? (this.streamingRuns.get(options.runId) ?? finalized?.values().next().value)
+        : undefined);
     const assistantIndex = assistant ? this.children.indexOf(assistant) : -1;
     if (assistant && assistantIndex >= 0) {
       // Transcript broadcasts can trail the first delta; insert their prompt
@@ -297,6 +308,16 @@ export class ChatLog extends Container {
       this.children.splice(assistantIndex, 0, component);
       const protectedComponents = new Set<Component>([component, assistant]);
       if (options.runId) {
+        for (const segment of frozen ?? []) {
+          protectedComponents.add(segment);
+        }
+        const streaming = this.streamingRuns.get(options.runId);
+        if (streaming) {
+          protectedComponents.add(streaming);
+        }
+        for (const segment of finalized ?? []) {
+          protectedComponents.add(segment);
+        }
         for (const [toolId, tool] of this.toolById) {
           if (this.toolRunIds.get(toolId) === options.runId) {
             protectedComponents.add(tool);
@@ -440,6 +461,7 @@ export class ChatLog extends Container {
 
   startAssistant(text: string, runId?: string) {
     const effectiveRunId = this.resolveRunId(runId);
+    this.finalizedAssistants.delete(effectiveRunId);
     this.latestAssistantText.set(effectiveRunId, text);
     const segmentText = this.resolveAssistantSegment(effectiveRunId, text);
     const existing = this.streamingRuns.get(effectiveRunId);
@@ -481,25 +503,43 @@ export class ChatLog extends Container {
     const effectiveRunId = this.resolveRunId(runId);
     const segmentText = this.resolveAssistantSegment(effectiveRunId, text);
     const existing = this.streamingRuns.get(effectiveRunId);
+    const finalized = new Set(this.frozenAssistants.get(effectiveRunId) ?? []);
+    let lastAssistant: AssistantMessageComponent | undefined;
     this.frozenAssistants.delete(effectiveRunId);
     this.committedAssistantText.delete(effectiveRunId);
     this.latestAssistantText.delete(effectiveRunId);
     if (existing) {
       if (segmentText) {
         existing.setText(segmentText);
+        lastAssistant = existing;
       } else {
         this.removeChild(existing);
       }
       this.streamingRuns.delete(effectiveRunId);
-      return;
+    } else if (segmentText) {
+      const component = new AssistantMessageComponent(segmentText);
+      this.appendNonSystem(component);
+      lastAssistant = component;
     }
-    if (segmentText) {
-      this.appendNonSystem(new AssistantMessageComponent(segmentText));
+
+    if (lastAssistant) {
+      finalized.add(lastAssistant);
+    }
+    for (const segment of finalized) {
+      if (!this.children.includes(segment)) {
+        finalized.delete(segment);
+      }
+    }
+    if (finalized.size > 0) {
+      // Persisted peer prompts can trail finalization; retain every surviving
+      // reply segment so full scrollback cannot evict the tool-split tail.
+      this.finalizedAssistants.set(effectiveRunId, finalized);
     }
   }
 
   dropAssistant(runId?: string) {
     const effectiveRunId = this.resolveRunId(runId);
+    this.finalizedAssistants.delete(effectiveRunId);
     for (const component of this.frozenAssistants.get(effectiveRunId) ?? []) {
       this.removeChild(component);
     }

--- a/src/tui/components/chat-log.ts
+++ b/src/tui/components/chat-log.ts
@@ -23,18 +23,26 @@ type TrackedTool = {
   active: boolean;
 };
 
+type TrackedAssistantRun = {
+  streaming?: AssistantMessageComponent;
+  frozen: Set<AssistantMessageComponent>;
+  finalized: Set<AssistantMessageComponent>;
+  committedText?: string;
+  latestText?: string;
+};
+
+type TrackedLiveUser = {
+  component: UserMessageComponent;
+  messageSeq?: number;
+  live: boolean;
+};
+
 /** Scrollback container that tracks pending users, streaming assistant runs, tools, and notices. */
 export class ChatLog extends Container {
   private readonly maxComponents: number;
   private tools = new Map<string, TrackedTool>();
-  private streamingRuns = new Map<string, AssistantMessageComponent>();
-  private frozenAssistants = new Map<string, Set<AssistantMessageComponent>>();
-  private finalizedAssistants = new Map<string, Set<AssistantMessageComponent>>();
-  private committedAssistantText = new Map<string, string>();
-  private latestAssistantText = new Map<string, string>();
-  private liveUsers = new Map<string, UserMessageComponent>();
-  private liveUserSequences = new Map<string, number>();
-  private liveEventUserIds = new Set<string>();
+  private assistantRuns = new Map<string, TrackedAssistantRun>();
+  private liveUsers = new Map<string, TrackedLiveUser>();
   private pendingUsers = new Map<
     string,
     {
@@ -60,23 +68,14 @@ export class ChatLog extends Container {
         this.tools.delete(toolId);
       }
     }
-    for (const [runId, message] of this.streamingRuns.entries()) {
-      if (message === component) {
-        this.streamingRuns.delete(runId);
-      }
-    }
     if (component instanceof AssistantMessageComponent) {
-      for (const [runId, messages] of this.finalizedAssistants.entries()) {
-        messages.delete(component);
-        if (messages.size === 0) {
-          this.finalizedAssistants.delete(runId);
+      for (const [runId, run] of this.assistantRuns.entries()) {
+        if (run.streaming === component) {
+          run.streaming = undefined;
         }
-      }
-      for (const [runId, messages] of this.frozenAssistants.entries()) {
-        messages.delete(component);
-        if (messages.size === 0) {
-          this.frozenAssistants.delete(runId);
-        }
+        run.frozen.delete(component);
+        run.finalized.delete(component);
+        this.releaseAssistantRunIfEmpty(runId, run);
       }
     }
     for (const [runId, entry] of this.pendingUsers.entries()) {
@@ -85,10 +84,8 @@ export class ChatLog extends Container {
       }
     }
     for (const [messageId, user] of this.liveUsers.entries()) {
-      if (user === component) {
+      if (user.component === component) {
         this.liveUsers.delete(messageId);
-        this.liveUserSequences.delete(messageId);
-        this.liveEventUserIds.delete(messageId);
       }
     }
     for (const [runId, entry] of this.pendingSystemNotices.entries()) {
@@ -131,7 +128,7 @@ export class ChatLog extends Container {
 
     // Keep live output and the sole reply; completed run history is the
     // first choice when a delayed prompt needs a bounded scrollback slot.
-    const streaming = runId ? this.streamingRuns.get(runId) : undefined;
+    const streaming = runId ? this.assistantRuns.get(runId)?.streaming : undefined;
     const completedTools = new Set<ToolExecutionComponent>();
     for (const tool of this.tools.values()) {
       if (!tool.active) {
@@ -185,24 +182,17 @@ export class ChatLog extends Container {
   clearAll(opts?: { preservePendingUsers?: boolean; preserveLiveUsers?: boolean }) {
     this.clear();
     this.tools.clear();
-    this.streamingRuns.clear();
-    this.frozenAssistants.clear();
-    this.finalizedAssistants.clear();
-    this.committedAssistantText.clear();
-    this.latestAssistantText.clear();
+    this.assistantRuns.clear();
     if (opts?.preserveLiveUsers) {
       // History rows are authoritative snapshots, not in-flight live events.
       // Keeping them would resurrect deleted or switched-away transcript branches.
-      for (const messageId of this.liveUsers.keys()) {
-        if (!this.liveEventUserIds.has(messageId)) {
+      for (const [messageId, user] of this.liveUsers.entries()) {
+        if (!user.live) {
           this.liveUsers.delete(messageId);
-          this.liveUserSequences.delete(messageId);
         }
       }
     } else {
       this.liveUsers.clear();
-      this.liveUserSequences.clear();
-      this.liveEventUserIds.clear();
     }
     this.pendingSystemNotices.clear();
     this.btwMessage = null;
@@ -222,22 +212,20 @@ export class ChatLog extends Container {
   restoreLiveUsers(beforeMessageSeq?: number) {
     // Rebuilt history replaces matching IDs in addUser; only live prompts
     // missing from a stale snapshot are restored before the next canonical row.
-    for (const messageId of this.liveEventUserIds) {
-      const component = this.liveUsers.get(messageId);
-      if (!component) {
-        this.liveEventUserIds.delete(messageId);
+    for (const user of this.liveUsers.values()) {
+      if (!user.live) {
         continue;
       }
-      if (this.children.includes(component)) {
+      if (this.children.includes(user.component)) {
         continue;
       }
       if (beforeMessageSeq !== undefined) {
-        const messageSeq = this.liveUserSequences.get(messageId);
+        const messageSeq = user.messageSeq;
         if (messageSeq === undefined || messageSeq >= beforeMessageSeq) {
           continue;
         }
       }
-      this.appendNonSystem(component);
+      this.appendNonSystem(user.component);
     }
   }
 
@@ -314,48 +302,64 @@ export class ChatLog extends Container {
   addUser(text: string, options?: { messageId?: string; messageSeq?: number }) {
     const component = new UserMessageComponent(text);
     if (options?.messageId) {
-      this.liveUsers.set(options.messageId, component);
+      const previous = this.liveUsers.get(options.messageId);
       // Once authoritative history contains this identity it is no longer a
       // missing live event and must not survive a later deletion or branch.
-      this.liveEventUserIds.delete(options.messageId);
-      if (options.messageSeq !== undefined) {
-        this.liveUserSequences.set(options.messageId, options.messageSeq);
-      }
+      this.liveUsers.set(options.messageId, {
+        component,
+        messageSeq: options.messageSeq ?? previous?.messageSeq,
+        live: false,
+      });
     }
     this.appendNonSystem(component);
   }
 
   addLiveUser(text: string, options: { messageId: string; messageSeq?: number; runId?: string }) {
-    this.liveEventUserIds.add(options.messageId);
-    if (options.messageSeq !== undefined) {
-      this.liveUserSequences.set(options.messageId, options.messageSeq);
-    }
     const existing = this.liveUsers.get(options.messageId);
     if (existing) {
-      existing.setText(text);
-      return existing;
+      if (!existing.live) {
+        // A historical identity becomes live in event order, not its old
+        // snapshot order; restoration must preserve the new canonical order.
+        this.liveUsers.delete(options.messageId);
+        this.liveUsers.set(options.messageId, existing);
+      }
+      existing.live = true;
+      if (options.messageSeq !== undefined) {
+        existing.messageSeq = options.messageSeq;
+      }
+      existing.component.setText(text);
+      return existing.component;
     }
 
     const pending = options.runId ? this.pendingUsers.get(options.runId) : undefined;
     if (pending && options.runId && pending.text === text) {
       pending.component.setText(text);
       this.pendingUsers.delete(options.runId);
-      this.liveUsers.set(options.messageId, pending.component);
+      this.liveUsers.set(options.messageId, {
+        component: pending.component,
+        messageSeq: options.messageSeq,
+        live: true,
+      });
       return pending.component;
     }
 
     const component = new UserMessageComponent(text);
-    this.liveUsers.set(options.messageId, component);
+    this.liveUsers.set(options.messageId, {
+      component,
+      messageSeq: options.messageSeq,
+      live: true,
+    });
     const protectedComponents = new Set<Component>([component]);
     if (options.runId) {
-      for (const segment of this.frozenAssistants.get(options.runId) ?? []) {
+      const run = this.assistantRuns.get(options.runId);
+      for (const segment of run?.frozen ?? []) {
         protectedComponents.add(segment);
       }
-      const streaming = this.streamingRuns.get(options.runId);
+      const streaming = run?.streaming;
       if (streaming) {
         protectedComponents.add(streaming);
       }
-      for (const segment of this.finalizedAssistants.get(options.runId) ?? []) {
+      for (const segment of run?.finalized ?? []) {
         protectedComponents.add(segment);
       }
       for (const tool of this.tools.values()) {
@@ -467,9 +471,48 @@ export class ChatLog extends Container {
     return runId ?? "default";
   }
 
+  private getAssistantRun(runId: string): TrackedAssistantRun {
+    let run = this.assistantRuns.get(runId);
+    if (!run) {
+      run = {
+        frozen: new Set(),
+        finalized: new Set(),
+      };
+      this.assistantRuns.set(runId, run);
+    }
+    return run;
+  }
+
+  private releaseAssistantRunIfEmpty(runId: string, run: TrackedAssistantRun) {
+    if (
+      !run.streaming &&
+      run.frozen.size === 0 &&
+      run.finalized.size === 0 &&
+      run.committedText === undefined &&
+      run.latestText === undefined
+    ) {
+      this.assistantRuns.delete(runId);
+    }
+  }
+
+  private resolveSingleStreamingRunId(): string | undefined {
+    let streamingRunId: string | undefined;
+    for (const [runId, run] of this.assistantRuns) {
+      if (!run.streaming) {
+        continue;
+      }
+      if (streamingRunId !== undefined) {
+        return undefined;
+      }
+      streamingRunId = runId;
+    }
+    return streamingRunId;
+  }
+
   private resolveAssistantSegment(runId: string, text: string) {
-    const committed = this.committedAssistantText.get(runId);
-    if (!committed) {
+    const run = this.assistantRuns.get(runId);
+    const committed = run?.committedText;
+    if (!run || !committed) {
       return text;
     }
     if (text.startsWith(committed)) {
@@ -478,56 +521,53 @@ export class ChatLog extends Container {
 
     // A revised provider snapshot cannot be split at an obsolete tool boundary.
     // Drop obsolete segments so the authoritative replacement lands after the tools.
-    const frozen = this.frozenAssistants.get(runId);
-    if (!frozen?.size) {
+    if (!run.frozen.size) {
       return text;
     }
-    for (const component of frozen) {
+    for (const component of run.frozen) {
       this.removeChild(component);
     }
-    this.frozenAssistants.delete(runId);
-    const streaming = this.streamingRuns.get(runId);
-    if (streaming) {
-      this.removeChild(streaming);
-      this.streamingRuns.delete(runId);
+    run.frozen.clear();
+    if (run.streaming) {
+      this.removeChild(run.streaming);
+      run.streaming = undefined;
     }
-    this.committedAssistantText.delete(runId);
+    run.committedText = undefined;
     return text;
   }
 
   // Tool rows freeze earlier cumulative text so later deltas render below the tool.
   private freezeStreamingAssistants() {
-    for (const [runId, component] of this.streamingRuns) {
-      let frozen = this.frozenAssistants.get(runId);
-      if (!frozen) {
-        frozen = new Set();
-        this.frozenAssistants.set(runId, frozen);
+    for (const run of this.assistantRuns.values()) {
+      if (!run.streaming) {
+        continue;
       }
-      frozen.add(component);
-      this.committedAssistantText.set(runId, this.latestAssistantText.get(runId) ?? "");
+      run.frozen.add(run.streaming);
+      run.committedText = run.latestText ?? "";
+      run.streaming = undefined;
     }
-    this.streamingRuns.clear();
   }
 
   startAssistant(text: string, runId?: string) {
     const effectiveRunId = this.resolveRunId(runId);
-    this.finalizedAssistants.delete(effectiveRunId);
-    this.latestAssistantText.set(effectiveRunId, text);
+    const run = this.getAssistantRun(effectiveRunId);
+    run.finalized.clear();
+    run.latestText = text;
     const segmentText = this.resolveAssistantSegment(effectiveRunId, text);
-    const existing = this.streamingRuns.get(effectiveRunId);
+    const existing = run.streaming;
     if (existing) {
       existing.setText(segmentText);
       return existing;
     }
     const component = new AssistantMessageComponent(segmentText);
-    this.streamingRuns.set(effectiveRunId, component);
+    run.streaming = component;
     this.appendNonSystem(component);
     return component;
   }
 
   reserveAssistantSlot(runId?: string) {
     const effectiveRunId = this.resolveRunId(runId);
-    const existing = this.streamingRuns.get(effectiveRunId);
+    const existing = this.assistantRuns.get(effectiveRunId)?.streaming;
     if (existing) {
       return existing;
     }
@@ -536,11 +576,12 @@ export class ChatLog extends Container {
 
   updateAssistant(text: string, runId?: string) {
     const effectiveRunId = this.resolveRunId(runId);
-    this.latestAssistantText.set(effectiveRunId, text);
+    const run = this.getAssistantRun(effectiveRunId);
+    run.latestText = text;
     const segmentText = this.resolveAssistantSegment(effectiveRunId, text);
-    const existing = this.streamingRuns.get(effectiveRunId);
+    const existing = run.streaming;
     if (!existing) {
-      if (!segmentText && this.committedAssistantText.has(effectiveRunId)) {
+      if (!segmentText && run.committedText !== undefined) {
         return;
       }
       this.startAssistant(text, runId);
@@ -551,13 +592,14 @@ export class ChatLog extends Container {
 
   finalizeAssistant(text: string, runId?: string) {
     const effectiveRunId = this.resolveRunId(runId);
+    const run = this.getAssistantRun(effectiveRunId);
     const segmentText = this.resolveAssistantSegment(effectiveRunId, text);
-    const existing = this.streamingRuns.get(effectiveRunId);
-    const finalized = new Set(this.frozenAssistants.get(effectiveRunId) ?? []);
+    const existing = run.streaming;
+    const finalized = new Set(run.frozen);
     let lastAssistant: AssistantMessageComponent | undefined;
-    this.frozenAssistants.delete(effectiveRunId);
-    this.committedAssistantText.delete(effectiveRunId);
-    this.latestAssistantText.delete(effectiveRunId);
+    run.frozen.clear();
+    run.committedText = undefined;
+    run.latestText = undefined;
     if (existing) {
       if (segmentText) {
         existing.setText(segmentText);
@@ -565,7 +607,7 @@ export class ChatLog extends Container {
       } else {
         this.removeChild(existing);
       }
-      this.streamingRuns.delete(effectiveRunId);
+      run.streaming = undefined;
     } else if (segmentText) {
       const component = new AssistantMessageComponent(segmentText);
       this.appendNonSystem(component);
@@ -583,25 +625,25 @@ export class ChatLog extends Container {
     if (finalized.size > 0) {
       // Persisted peer prompts can trail finalization; retain every surviving
       // reply segment so full scrollback cannot evict the tool-split tail.
-      this.finalizedAssistants.set(effectiveRunId, finalized);
+      run.finalized = finalized;
+      this.assistantRuns.set(effectiveRunId, run);
     }
+    this.releaseAssistantRunIfEmpty(effectiveRunId, run);
   }
 
   dropAssistant(runId?: string) {
     const effectiveRunId = this.resolveRunId(runId);
-    this.finalizedAssistants.delete(effectiveRunId);
-    for (const component of this.frozenAssistants.get(effectiveRunId) ?? []) {
-      this.removeChild(component);
-    }
-    this.frozenAssistants.delete(effectiveRunId);
-    this.committedAssistantText.delete(effectiveRunId);
-    this.latestAssistantText.delete(effectiveRunId);
-    const existing = this.streamingRuns.get(effectiveRunId);
-    if (!existing) {
+    const run = this.assistantRuns.get(effectiveRunId);
+    if (!run) {
       return;
     }
-    this.removeChild(existing);
-    this.streamingRuns.delete(effectiveRunId);
+    for (const component of run.frozen) {
+      this.removeChild(component);
+    }
+    if (run.streaming) {
+      this.removeChild(run.streaming);
+    }
+    this.assistantRuns.delete(effectiveRunId);
   }
 
   showBtw(params: { question: string; text: string; isError?: boolean }) {
@@ -637,8 +679,7 @@ export class ChatLog extends Container {
       existing.component.setArgs(args);
       return existing.component;
     }
-    const owningRunId =
-      runId ?? (this.streamingRuns.size === 1 ? this.streamingRuns.keys().next().value : undefined);
+    const owningRunId = runId ?? this.resolveSingleStreamingRunId();
     this.freezeStreamingAssistants();
     const component = new ToolExecutionComponent(toolName, args);
     component.setExpanded(this.toolsExpanded);

--- a/src/tui/components/chat-log.ts
+++ b/src/tui/components/chat-log.ts
@@ -17,12 +17,16 @@ type RepeatableSystemMessage = {
   count: number;
 };
 
+type TrackedTool = {
+  component: ToolExecutionComponent;
+  runId?: string;
+  active: boolean;
+};
+
 /** Scrollback container that tracks pending users, streaming assistant runs, tools, and notices. */
 export class ChatLog extends Container {
   private readonly maxComponents: number;
-  private toolById = new Map<string, ToolExecutionComponent>();
-  private toolRunIds = new Map<string, string>();
-  private activeTools = new Set<ToolExecutionComponent>();
+  private tools = new Map<string, TrackedTool>();
   private streamingRuns = new Map<string, AssistantMessageComponent>();
   private frozenAssistants = new Map<string, Set<AssistantMessageComponent>>();
   private finalizedAssistants = new Map<string, Set<AssistantMessageComponent>>();
@@ -51,11 +55,9 @@ export class ChatLog extends Container {
 
   // Pruning must clear side maps so future stream/tool updates do not target detached components.
   private dropComponentReferences(component: Component) {
-    for (const [toolId, tool] of this.toolById.entries()) {
-      if (tool === component) {
-        this.toolById.delete(toolId);
-        this.toolRunIds.delete(toolId);
-        this.activeTools.delete(tool);
+    for (const [toolId, tool] of this.tools.entries()) {
+      if (tool.component === component) {
+        this.tools.delete(toolId);
       }
     }
     for (const [runId, message] of this.streamingRuns.entries()) {
@@ -118,6 +120,58 @@ export class ChatLog extends Container {
     }
   }
 
+  private reserveLiveUserSlot(
+    protectedComponents: Set<Component>,
+    firstRunComponent: Component | undefined,
+    runId?: string,
+  ) {
+    if (protectedComponents.size <= this.maxComponents) {
+      return;
+    }
+
+    // Keep live output and the sole reply; completed run history is the
+    // first choice when a delayed prompt needs a bounded scrollback slot.
+    const streaming = runId ? this.streamingRuns.get(runId) : undefined;
+    const completedTools = new Set<ToolExecutionComponent>();
+    for (const tool of this.tools.values()) {
+      if (!tool.active) {
+        completedTools.add(tool.component);
+      }
+    }
+    const evictable =
+      this.children.find(
+        (entry) =>
+          entry !== firstRunComponent &&
+          entry !== streaming &&
+          entry instanceof AssistantMessageComponent &&
+          protectedComponents.has(entry),
+      ) ??
+      this.children.find(
+        (entry) =>
+          entry !== firstRunComponent &&
+          entry instanceof ToolExecutionComponent &&
+          completedTools.has(entry) &&
+          protectedComponents.has(entry),
+      ) ??
+      (streaming &&
+      firstRunComponent instanceof AssistantMessageComponent &&
+      firstRunComponent !== streaming
+        ? firstRunComponent
+        : undefined) ??
+      (firstRunComponent instanceof ToolExecutionComponent && completedTools.has(firstRunComponent)
+        ? firstRunComponent
+        : undefined) ??
+      this.children.find(
+        (entry) =>
+          entry !== firstRunComponent &&
+          entry instanceof ToolExecutionComponent &&
+          protectedComponents.has(entry),
+      );
+    if (evictable) {
+      protectedComponents.delete(evictable);
+    }
+  }
+
   private append(component: Component) {
     this.addChild(component);
     this.pruneOverflow();
@@ -130,9 +184,7 @@ export class ChatLog extends Container {
 
   clearAll(opts?: { preservePendingUsers?: boolean; preserveLiveUsers?: boolean }) {
     this.clear();
-    this.toolById.clear();
-    this.toolRunIds.clear();
-    this.activeTools.clear();
+    this.tools.clear();
     this.streamingRuns.clear();
     this.frozenAssistants.clear();
     this.finalizedAssistants.clear();
@@ -161,12 +213,10 @@ export class ChatLog extends Container {
   }
 
   clearTools() {
-    for (const tool of this.toolById.values()) {
-      this.removeChild(tool);
+    for (const tool of this.tools.values()) {
+      this.removeChild(tool.component);
     }
-    this.toolById.clear();
-    this.toolRunIds.clear();
-    this.activeTools.clear();
+    this.tools.clear();
   }
 
   restoreLiveUsers(beforeMessageSeq?: number) {
@@ -308,9 +358,9 @@ export class ChatLog extends Container {
       for (const segment of this.finalizedAssistants.get(options.runId) ?? []) {
         protectedComponents.add(segment);
       }
-      for (const [toolId, tool] of this.toolById) {
-        if (this.toolRunIds.get(toolId) === options.runId) {
-          protectedComponents.add(tool);
+      for (const tool of this.tools.values()) {
+        if (tool.runId === options.runId) {
+          protectedComponents.add(tool.component);
         }
       }
     }
@@ -323,44 +373,7 @@ export class ChatLog extends Container {
       // anchor before the earliest surviving reply or tool from the same run.
       this.repeatableSystemMessage = null;
       this.children.splice(firstRunComponentIndex, 0, component);
-      if (protectedComponents.size > this.maxComponents) {
-        // Prefer completed history, but keep the sole reply when only tools
-        // remain: dropping it would leave a prompt with no visible response.
-        const streaming = options.runId ? this.streamingRuns.get(options.runId) : undefined;
-        const evictable =
-          this.children.find(
-            (entry) =>
-              entry !== firstRunComponent &&
-              entry !== streaming &&
-              entry instanceof AssistantMessageComponent &&
-              protectedComponents.has(entry),
-          ) ??
-          this.children.find(
-            (entry) =>
-              entry !== firstRunComponent &&
-              entry instanceof ToolExecutionComponent &&
-              !this.activeTools.has(entry) &&
-              protectedComponents.has(entry),
-          ) ??
-          (streaming &&
-          firstRunComponent instanceof AssistantMessageComponent &&
-          firstRunComponent !== streaming
-            ? firstRunComponent
-            : undefined) ??
-          (firstRunComponent instanceof ToolExecutionComponent &&
-          !this.activeTools.has(firstRunComponent)
-            ? firstRunComponent
-            : undefined) ??
-          this.children.find(
-            (entry) =>
-              entry !== firstRunComponent &&
-              entry instanceof ToolExecutionComponent &&
-              protectedComponents.has(entry),
-          );
-        if (evictable) {
-          protectedComponents.delete(evictable);
-        }
-      }
+      this.reserveLiveUserSlot(protectedComponents, firstRunComponent, options.runId);
       this.pruneOverflow(protectedComponents);
       return component;
     }
@@ -619,21 +632,17 @@ export class ChatLog extends Container {
   }
 
   startTool(toolCallId: string, toolName: string, args: unknown, runId?: string) {
-    const existing = this.toolById.get(toolCallId);
+    const existing = this.tools.get(toolCallId);
     if (existing) {
-      existing.setArgs(args);
-      return existing;
+      existing.component.setArgs(args);
+      return existing.component;
     }
     const owningRunId =
       runId ?? (this.streamingRuns.size === 1 ? this.streamingRuns.keys().next().value : undefined);
     this.freezeStreamingAssistants();
     const component = new ToolExecutionComponent(toolName, args);
     component.setExpanded(this.toolsExpanded);
-    this.toolById.set(toolCallId, component);
-    this.activeTools.add(component);
-    if (owningRunId) {
-      this.toolRunIds.set(toolCallId, owningRunId);
-    }
+    this.tools.set(toolCallId, { component, runId: owningRunId, active: true });
     this.appendNonSystem(component);
     return component;
   }
@@ -643,25 +652,25 @@ export class ChatLog extends Container {
     result: unknown,
     opts?: { isError?: boolean; partial?: boolean },
   ) {
-    const existing = this.toolById.get(toolCallId);
+    const existing = this.tools.get(toolCallId);
     if (!existing) {
       return;
     }
     if (opts?.partial) {
-      this.activeTools.add(existing);
-      existing.setPartialResult(result as Record<string, unknown>);
+      existing.active = true;
+      existing.component.setPartialResult(result as Record<string, unknown>);
       return;
     }
-    this.activeTools.delete(existing);
-    existing.setResult(result as Record<string, unknown>, {
+    existing.active = false;
+    existing.component.setResult(result as Record<string, unknown>, {
       isError: opts?.isError,
     });
   }
 
   setToolsExpanded(expanded: boolean) {
     this.toolsExpanded = expanded;
-    for (const tool of this.toolById.values()) {
-      tool.setExpanded(expanded);
+    for (const tool of this.tools.values()) {
+      tool.component.setExpanded(expanded);
     }
   }
 }

--- a/src/tui/components/chat-log.ts
+++ b/src/tui/components/chat-log.ts
@@ -292,38 +292,32 @@ export class ChatLog extends Container {
 
     const component = new UserMessageComponent(text);
     this.liveUsers.set(options.messageId, component);
-    const frozen = options.runId ? this.frozenAssistants.get(options.runId) : undefined;
-    const finalized = options.runId ? this.finalizedAssistants.get(options.runId) : undefined;
-    const assistant =
-      frozen?.values().next().value ??
-      (options.runId
-        ? (this.streamingRuns.get(options.runId) ?? finalized?.values().next().value)
-        : undefined);
-    const assistantIndex = assistant ? this.children.indexOf(assistant) : -1;
-    if (assistant && assistantIndex >= 0) {
-      // Transcript broadcasts can trail the first delta; insert their prompt
-      // before the existing reply. Preserve both when full scrollback evicts
-      // older components so the newly recovered prompt cannot disappear.
-      this.repeatableSystemMessage = null;
-      this.children.splice(assistantIndex, 0, component);
-      const protectedComponents = new Set<Component>([component, assistant]);
-      if (options.runId) {
-        for (const segment of frozen ?? []) {
-          protectedComponents.add(segment);
-        }
-        const streaming = this.streamingRuns.get(options.runId);
-        if (streaming) {
-          protectedComponents.add(streaming);
-        }
-        for (const segment of finalized ?? []) {
-          protectedComponents.add(segment);
-        }
-        for (const [toolId, tool] of this.toolById) {
-          if (this.toolRunIds.get(toolId) === options.runId) {
-            protectedComponents.add(tool);
-          }
+    const protectedComponents = new Set<Component>([component]);
+    if (options.runId) {
+      for (const segment of this.frozenAssistants.get(options.runId) ?? []) {
+        protectedComponents.add(segment);
+      }
+      const streaming = this.streamingRuns.get(options.runId);
+      if (streaming) {
+        protectedComponents.add(streaming);
+      }
+      for (const segment of this.finalizedAssistants.get(options.runId) ?? []) {
+        protectedComponents.add(segment);
+      }
+      for (const [toolId, tool] of this.toolById) {
+        if (this.toolRunIds.get(toolId) === options.runId) {
+          protectedComponents.add(tool);
         }
       }
+    }
+    const firstRunComponentIndex = this.children.findIndex((entry) =>
+      protectedComponents.has(entry),
+    );
+    if (firstRunComponentIndex >= 0) {
+      // Scrollback may evict early reply segments before a peer prompt arrives;
+      // anchor before the earliest surviving reply or tool from the same run.
+      this.repeatableSystemMessage = null;
+      this.children.splice(firstRunComponentIndex, 0, component);
       this.pruneOverflow(protectedComponents);
       return component;
     }


### PR DESCRIPTION
## What Problem This Solves

Fixes shared-terminal transcript corruption when authoritative peer prompts arrive after completed replies, tool calls, or full scrollback. Prevents delayed prompts, streaming assistant output, active tool results, and cross-client messages from being reordered, duplicated, evicted, or detached from their owning run.

## Why This Change Was Made

Replace nine independently synchronized transcript collections with three canonical typed registries:

- `TrackedAssistantRun`: owns streaming, frozen and finalized components plus committed and latest text for one run.
- `TrackedTool`: owns the rendered tool, run identity and active/completed lifecycle.
- `TrackedLiveUser`: owns the user component, monotonic transcript sequence and live/history status.

Keep delayed-prompt insertion and bounded eviction inside `ChatLog`, retain the earliest surviving same-run component, preserve active tools and sole replies, restore historical identities in actual live-event order, and retain the last known sequence when history lacks it.

Rebased onto current `main`; the previous Control UI test conflict is resolved by retaining `main`'s stronger existing browser-history cleanup. The final PR touches only TUI production and regression tests.

## User Impact

Shared TUI sessions preserve correct cross-client transcript order, full-scroll capacity, concurrent streaming replies, live and final tool output, session recovery, and canonical history restoration without stale or contradictory lifecycle state.

## Evidence

Final reviewed head: `82535add729ff6ae60fcc5dcc11be55e4e5dcd54`.

Real remote Linux proof: Blacksmith Testbox `tbx_01kymrct5s2tfmy86e9h2brfbq`.

```text
Complete TUI suite:
  36 files passed
  975 tests passed

Real PTY, local backend and Gateway:
  2 files passed
  64 tests passed

Real cross-client Gateway observation:
  transport: real Gateway WebSocket
  terminal: real PTY
  externalMessageRendered: true
  followupRendered: true
  returnedToIdle: true

Exact three-file Linux changed gate:
  core and core-test typechecks: passed
  type-aware changed-file lint: passed
  format and max-lines: passed
  plugin boundaries and SDK contracts: passed
  runtime import cycles: 0
  exitCode: 0

Five independent adversarial rounds:
  36 permutations per round
  180/180 checks passed

Adjacent assistant/event/session regressions:
  276 tests passed

Control UI regression proof:
  24 tests passed

Fresh independent gpt-5.6-sol review:
  trufflehog: clean
  no accepted/actionable findings
  overall: patch is correct
```

ClawSweeper rank-up moves addressed: rebased onto current `main`, resolved the UI merge conflict without retaining an unrelated UI diff, reran the full transcript and PTY matrices, and recorded exact final-head behavior evidence. Required exact-head hosted CI remains the merge gate.