### PR TITLE
fix(ui): keep reconnects, browser tabs, and localized search consistent

### DIFF
--- a/ui/src/app-navigation.test.ts
+++ b/ui/src/app-navigation.test.ts
@@ -238,6 +238,15 @@ describe("settingsSearchTextMatches", () => {
     expect(settingsSearchTextMatches("MCP", "cp")).toBe(false);
     expect(settingsSearchTextMatches("外観設定", "設定")).toBe(true);
   });
+
+  it.each([
+    ["Cámara", "Ca\u0301mara"],
+    ["Ca\u0301mara", "Cámara"],
+    ["Notificación", "Notificacio\u0301n"],
+    ["Notificacio\u0301n", "Notificación"],
+  ])("matches canonically equivalent setting text %j against %j", (value, query) => {
+    expect(settingsSearchTextMatches(value, query)).toBe(true);
+  });
 });
 
 describe("formatDocumentTitle", () => {

--- a/ui/src/app-navigation.ts
+++ b/ui/src/app-navigation.ts
@@ -161,8 +161,8 @@ function settingsSearchHasWordPrefix(value: string, query: string): boolean {
 }
 
 export function settingsSearchTextMatches(value: string, query: string): boolean {
-  const candidate = normalizeLowercaseStringOrEmpty(value);
-  const normalizedQuery = normalizeLowercaseStringOrEmpty(query);
+  const candidate = normalizeLowercaseStringOrEmpty(value).normalize("NFC");
+  const normalizedQuery = normalizeLowercaseStringOrEmpty(query).normalize("NFC");
   if (!normalizedQuery) {
     return false;
   }

--- a/ui/src/app/gateway-store.test.ts
+++ b/ui/src/app/gateway-store.test.ts
@@ -356,6 +356,66 @@ describe("createApplicationGateway connection phase", () => {
     expect(gateway.snapshot.phase).toBe("reconnecting");
   });
 
+  it("ignores presence and event-log callbacks from superseded clients", () => {
+    const { gateway, current } = createStore();
+    gateway.start();
+    current().opts.onHello?.(HELLO);
+    const stale = current();
+
+    gateway.connect();
+    const active = current();
+    active.opts.onHello?.({
+      ...HELLO,
+      snapshot: {
+        presence: [
+          {
+            instanceId: active.instanceId,
+            user: { id: "current-user", name: "Current user" },
+          },
+        ],
+      },
+    });
+
+    stale.opts.onEvent?.({
+      type: "event",
+      event: "presence",
+      payload: {
+        presence: [
+          {
+            instanceId: active.instanceId,
+            user: { id: "stale-user", name: "Stale user" },
+          },
+        ],
+      },
+      seq: 1,
+      stateVersion: { presence: 1, health: 1 },
+    });
+
+    expect(gateway.snapshot.selfUser).toEqual({ id: "current-user", name: "Current user" });
+    expect(gateway.eventLog).toEqual([]);
+
+    active.opts.onEvent?.({
+      type: "event",
+      event: "presence",
+      payload: {
+        presence: [
+          {
+            instanceId: active.instanceId,
+            user: { id: "current-user", name: "Updated current user" },
+          },
+        ],
+      },
+      seq: 2,
+      stateVersion: { presence: 2, health: 1 },
+    });
+
+    expect(gateway.snapshot.selfUser).toEqual({
+      id: "current-user",
+      name: "Updated current user",
+    });
+    expect(gateway.eventLog).toHaveLength(1);
+  });
+
   it("projects only this browser connection's optional presence identity", () => {
     const { gateway, current } = createStore();
     gateway.start();

--- a/ui/src/app/gateway-store.ts
+++ b/ui/src/app/gateway-store.ts
@@ -403,7 +403,13 @@ export function createApplicationGateway(
         });
         connect();
       },
-      onEvent: recordGatewayEvent,
+      onEvent: (event) => {
+        // A replaced socket can still deliver queued events; never let it
+        // project presence or history into the current gateway connection.
+        if (client === nextClient) {
+          recordGatewayEvent(event);
+        }
+      },
     });
     client = nextClient;
     syncClientEvents(nextClient);

--- a/ui/src/components/browser/browser-panel-controller-snapshot-races.test.ts
+++ b/ui/src/components/browser/browser-panel-controller-snapshot-races.test.ts
@@ -5,14 +5,106 @@ import {
   createBrowserPanelTestMetrics,
   createBrowserPanelTestTab,
   createDeferred,
+  createView,
   flushBrowserResponses,
   setupBrowserPanelTestCleanup,
   stubScreenshotMedia,
+  TestBrowserPanelHost,
 } from "./browser-panel-controller-test-support.ts";
+import { BrowserPanelController } from "./browser-panel-controller.ts";
 
 setupBrowserPanelTestCleanup();
 
 describe("BrowserPanelController superseded tab snapshots", () => {
+  it.each([true, false])(
+    "never reselects a closed active tab when refreshing the remaining tabs fails (fallback: %s)",
+    async (hasFallback) => {
+      stubScreenshotMedia();
+      const activeUrl = "https://example.test/active";
+      const fallbackUrl = "https://example.test/fallback";
+      const { client, request } = createBrowserClient(async (envelope) => {
+        if (envelope.method === "DELETE" && envelope.path === "/tabs/active-tab") {
+          return { ok: true };
+        }
+        if (envelope.path === "/tabs") {
+          throw new Error("Tab refresh failed after the active tab was closed");
+        }
+        if (envelope.path === "/screenshot" && envelope.body?.targetId === "fallback-tab") {
+          return { path: "/fresh.png", targetId: "raw-fallback", url: fallbackUrl };
+        }
+        if (envelope.path === "/act") {
+          return createBrowserPanelTestMetrics(fallbackUrl, "Fallback");
+        }
+        throw new Error(`Unexpected browser route: ${envelope.method} ${envelope.path}`);
+      });
+      const controller = createBrowserPanelTestController(client, "active-tab", activeUrl);
+      controller.tabs = [
+        { id: "active-tab", targetId: "raw-active", title: "Active", url: activeUrl },
+        ...(hasFallback
+          ? [
+              {
+                id: "fallback-tab",
+                targetId: "raw-fallback",
+                title: "Fallback",
+                url: fallbackUrl,
+              },
+            ]
+          : []),
+      ];
+
+      await controller.closeTab("active-tab");
+
+      expect(controller.tabs.map((tab) => tab.id)).toEqual(hasFallback ? ["fallback-tab"] : []);
+      expect(controller.activeTargetId).toBe(hasFallback ? "fallback-tab" : null);
+      expect(controller.view?.targetId ?? null).toBe(hasFallback ? "fallback-tab" : null);
+      expect(controller.loading).toBe(false);
+      expect(
+        request.mock.calls.some(([, envelope]) => {
+          const browserRequest = envelope as { path?: string; body?: { targetId?: string } };
+          return (
+            browserRequest.path === "/screenshot" && browserRequest.body?.targetId === "active-tab"
+          );
+        }),
+      ).toBe(false);
+    },
+  );
+
+  it("rejects old-gateway snapshots before the replacement client synchronizes", async () => {
+    const activeUrl = "https://example.test/active";
+    const snapshot = createDeferred<{
+      running: boolean;
+      tabs: ReturnType<typeof createBrowserPanelTestTab>[];
+    }>();
+    const old = createBrowserClient(async (envelope) => {
+      if (envelope.path === "/tabs") {
+        return await snapshot.promise;
+      }
+      throw new Error(`Unexpected old browser route: ${envelope.path}`);
+    });
+    const replacement = createBrowserClient(async (envelope) => {
+      throw new Error(`Unexpected replacement browser route: ${envelope.path}`);
+    });
+    const host = new TestBrowserPanelHost(old.client);
+    const controller = new BrowserPanelController(host);
+    const originalView = createView("active-tab", activeUrl);
+    controller.activeTargetId = "active-tab";
+    controller.view = originalView;
+
+    const refresh = controller.refreshAll();
+    await flushBrowserResponses();
+    host.client = replacement.client;
+    snapshot.resolve({
+      running: true,
+      tabs: [createBrowserPanelTestTab("active-tab", activeUrl, "Active")],
+    });
+    await refresh;
+
+    expect(controller.running).toBeNull();
+    expect(controller.tabs).toEqual([]);
+    expect(controller.view).toBe(originalView);
+    expect(replacement.request).not.toHaveBeenCalled();
+  });
+
   it.each(["before", "after"] as const)(
     "settles loading when a superseded refresh fails %s a background-close snapshot",
     async (olderFailureOrder) => {

--- a/ui/src/components/browser/browser-panel-controller.ts
+++ b/ui/src/components/browser/browser-panel-controller.ts
@@ -435,6 +435,12 @@ export class BrowserPanelController implements ReactiveController {
         }
         return;
       }
+      // DELETE already committed; a failed tab snapshot must not resurrect its
+      // target or make the next screenshot address a tab that no longer exists.
+      this.setState(
+        "tabs",
+        this.tabs.filter((tab) => tab.id !== targetId),
+      );
       const snapshot = await this.refreshTabsOnly(client, () =>
         this.operations.isLive(epoch, client),
       );

--- a/ui/src/components/browser/browser-panel-operation-ownership.ts
+++ b/ui/src/components/browser/browser-panel-operation-ownership.ts
@@ -18,6 +18,7 @@ export interface BrowserPanelControllerHost extends ReactiveControllerHost {
 }
 
 type BrowserPanelInvocation = {
+  readonly client: GatewayBrowserClient;
   epoch: number;
   readonly id: number;
   readonly mutationId: number;
@@ -88,6 +89,7 @@ export class BrowserPanelOperationOwnership {
     this.requestedCapture += 1;
     this.capturePending = false;
     const invocation: BrowserPanelInvocation = {
+      client,
       epoch: this.lifecycleEpoch,
       id: ++this.requestedMutation,
       mutationId: this.requestedMutation,
@@ -156,6 +158,7 @@ export class BrowserPanelOperationOwnership {
   beginSnapshot(client: GatewayBrowserClient): BrowserPanelInvocation {
     const mutationId = this.requestedMutation;
     const invocation: BrowserPanelInvocation = {
+      client,
       epoch: this.lifecycleEpoch,
       id: ++this.requestedSnapshot,
       mutationId,
@@ -173,7 +176,7 @@ export class BrowserPanelOperationOwnership {
     snapshotTargetId: string | null,
   ): boolean {
     if (
-      !this.isLive(invocation.epoch) ||
+      !this.isLive(invocation.epoch, invocation.client) ||
       invocation.id < this.acceptedSnapshot ||
       (!invocation.isCurrent() && snapshotTargetId !== currentTargetId)
     ) {
@@ -185,7 +188,10 @@ export class BrowserPanelOperationOwnership {
 
   /** Older snapshots may capture the same tab unless a user mutation owns it. */
   canCaptureSnapshot(invocation: BrowserPanelInvocation): boolean {
-    return this.isLive(invocation.epoch) && invocation.mutationId === this.requestedMutation;
+    return (
+      this.isLive(invocation.epoch, invocation.client) &&
+      invocation.mutationId === this.requestedMutation
+    );
   }
 
   /** A superseded open may reconcile its created tab, but never own the selected view. */

--- a/ui/src/pages/agents/panels-tools-skills.browser.test.ts
+++ b/ui/src/pages/agents/panels-tools-skills.browser.test.ts
@@ -417,15 +417,21 @@ describe("agents tools panel (browser)", () => {
     expect(group.open).toBe(false);
     expect(tool.open).toBe(false);
 
-    chip.click();
-    await new Promise((resolve) => {
-      requestAnimationFrame(resolve);
-    });
+    const previousUrl = `${window.location.pathname}${window.location.search}${window.location.hash}`;
+    try {
+      chip.click();
+      await new Promise((resolve) => {
+        requestAnimationFrame(resolve);
+      });
 
-    expect(group.open).toBe(true);
-    expect(tool.open).toBe(true);
-
-    container.remove();
+      expect(group.open).toBe(true);
+      expect(tool.open).toBe(true);
+    } finally {
+      // Hash links mutate shared jsdom history; restore the actual prior URL
+      // so a later Settings route never inherits this tool-card deep link.
+      window.history.replaceState({}, "", previousUrl);
+      container.remove();
+    }
   });
 });
 


### PR DESCRIPTION
Closes #115215
Closes #115216
Closes #115217
Closes #115218

## What Problem This Solves

Fixes an issue where users reconnecting or switching Gateways could see a stale connection overwrite their current identity or browser snapshot. Fixes an issue where closing an active browser tab would reselect the deleted tab if the follow-up tab refresh failed. Fixes localized Settings searches that missed visually identical composed and decomposed accented text.

## Why This Change Was Made

Keep each Gateway event, browser snapshot, and screenshot attached to the client that owns it. Retire a successfully deleted browser tab immediately, retain an existing fallback when reconciliation fails, and normalize Settings search terms at the search boundary without changing global text or generated translations.

The first hosted full-suite run also revealed that the existing agent-tools browser test left its clicked URL fragment in shared history, causing three unrelated moved-Settings-route regressions. This PR fixes the contamination at its source: the browser test now restores the exact previous URL in a finally block before the next test runs.

## User Impact

Gateway reconnects no longer display another connection's identity, tabs, or activity. Closing the last or active browser tab cannot resurrect the removed tab. Localized Settings searches consistently match accented text entered by keyboards, input methods, or copy and paste. Full-suite Settings route regressions no longer inherit the agent tool navigation hash.

## Evidence

- Failing-first Blacksmith proof: four owner regressions fail on unchanged main for stale Gateway events, stale browser snapshots, active-tab closure with a fallback, and final-tab closure.
- First hosted full-suite run: independently identified the agent-tool hash leak and all three affected Settings-route assertions; fixed the source cleanup rather than bypassing or relaxing the assertions.
- Exact rebased candidate: seven focused owner and contamination-source suites, 171 tests passing, zero failures.
- Remote pnpm check:changed: UI and core-test typechecking, changed-path lint, formatting, max-lines, dependency and guard checks, and deterministic Control UI i18n verification.
- Real system-Chromium end-to-end: 22 tests across remote-browser screenshot cancellation, native sidebar/navigation, Settings search and focus, and sidebar customization.
- Fresh independent branch autoreview after the suite repair and rebase: patch is correct, 0.92 confidence, no accepted or actionable findings.
- Exact rebased head: 0baa10c2032d52201c63ce3a4ec36d420db7de4a.
- Final delegated Blacksmith proof: https://github.com/openclaw/openclaw/actions/runs/30365615176

Blacksmith delegated success is established by its wrapper exit status and timing JSON; the ephemeral backing Actions session can be marked cancelled during successful Testbox cleanup.