### PR TITLE
fix: restore Fish completion after global CLI options

### DIFF
--- a/src/cli/completion-cli.test.ts
+++ b/src/cli/completion-cli.test.ts
@@ -304,7 +304,7 @@ describe("completion-cli", () => {
     const script = getCompletionScript("fish", createCompletionProgram());
 
     expect(script).toContain(
-      'complete -c openclaw -n "__fish_use_subcommand" -a "gateway" -d \'Gateway commands\'',
+      'complete -c openclaw -n "__openclaw_command_path_matches --" -a "gateway" -d \'Gateway commands\'',
     );
     expect(script).toContain(
       'complete -c openclaw -n "__openclaw_command_path_matches gateway -- -t --token" -a "status" -d \'Show gateway status\'',
@@ -324,6 +324,43 @@ describe("completion-cli", () => {
 
     expect(script).toContain('switch "$candidate_path"');
     expect(script).toContain("'gateway status'");
+  });
+
+  itWithFish.each([
+    ["a separate long root option", "openclaw --profile work g"],
+    ["an inline long root option", "openclaw --profile=work g"],
+    ["a separate short root option", "openclaw -p work g"],
+    ["an inline short root option", "openclaw -p=work g"],
+    ["an attached short root option", "openclaw -pwork g"],
+    ["a separate log-level root option", "openclaw --log-level debug g"],
+    ["an inline log-level root option", "openclaw --log-level=debug g"],
+    ["a separate container root option", "openclaw --container local g"],
+    ["an inline container root option", "openclaw --container=local g"],
+    ["repeated root options", "openclaw --profile first --profile second g"],
+    [
+      "mixed value-taking root options",
+      "openclaw --profile work --log-level debug --container local g",
+    ],
+    ["a preceding boolean root option", "openclaw -v --profile work g"],
+    ["a root option value named like a command", "openclaw --profile gateway g"],
+  ])("completes root commands in real Fish after %s", (_name, commandLine) => {
+    const program = createCompletionProgram()
+      .option("-p, --profile <name>", "Profile")
+      .option("--log-level <level>", "Log level")
+      .option("--container <name>", "Container");
+
+    expect(runGeneratedFishCompletion(program, commandLine)).toContain("gateway");
+  });
+
+  itWithFish.each([
+    ["a separate long root option", "openclaw --profile work --p"],
+    ["an inline long root option", "openclaw --profile=work --p"],
+    ["a separate short root option", "openclaw -p work --p"],
+    ["repeated root options", "openclaw --profile first --profile second --p"],
+  ])("completes root options in real Fish after %s", (_name, commandLine) => {
+    const program = createCompletionProgram().option("-p, --profile <name>", "Profile");
+
+    expect(runGeneratedFishCompletion(program, commandLine)).toContain("--profile");
   });
 
   itWithFish.each([
@@ -383,7 +420,7 @@ describe("completion-cli", () => {
     const fishScript = getCompletionScript("fish", program);
 
     expect(fishScript).toContain(
-      "complete -c openclaw -n \"__fish_use_subcommand\" -l trigger-script -d 'Condition script file, or - for stdin'",
+      "complete -c openclaw -n \"__openclaw_command_path_matches -- --trigger-script --ws --workspace\" -l trigger-script -d 'Condition script file, or - for stdin'",
     );
     expect(fishScript).not.toContain(" -s > ");
     expect(fishScript).toContain(" -l ws -l workspace -d 'Workspace'");
@@ -508,6 +545,18 @@ function createAliasedCompletionProgram(): Command {
 }
 
 describe("completion-cli command aliases", () => {
+  itWithFish.each([
+    ["a canonical root command", "openclaw --profile work inf", "infer"],
+    ["an aliased root command", "openclaw --profile work cap", "capability"],
+    ["an inline profile and alias", "openclaw --profile=work cap", "capability"],
+    ["an alias-shaped profile value", "openclaw --profile capability cap", "capability"],
+    ["a repeated profile and alias", "openclaw --profile first --profile second cap", "capability"],
+  ])("completes real Fish root aliases after %s", (_name, commandLine, expected) => {
+    expect(runGeneratedFishCompletion(createAliasedCompletionProgram(), commandLine)).toContain(
+      expected,
+    );
+  });
+
   it("completes root and nested aliases in zsh lists and dispatch", () => {
     const script = getCompletionScript("zsh", createAliasedCompletionProgram());
 
@@ -568,7 +617,7 @@ printf '%s\\n' "\${COMPREPLY[@]}"
     const script = getCompletionScript("fish", createAliasedCompletionProgram());
 
     expect(script).toContain(
-      'complete -c openclaw -n "__fish_use_subcommand" -a "capability" -d \'Run inference\'',
+      'complete -c openclaw -n "__openclaw_command_path_matches -- --profile" -a "capability" -d \'Run inference\'',
     );
     expect(script).toContain(
       'complete -c openclaw -n "__openclaw_command_path_matches capability -- --profile" -a "embed" -d \'Embed text\'',

--- a/src/cli/completion-cli.ts
+++ b/src/cli/completion-cli.ts
@@ -147,9 +147,11 @@ function __${rootCmd}_command_path_matches
     end
     set -a command_tokens $token
   end
-  for i in (seq (count $expected))
-    if test "$command_tokens[$i]" != "$expected[$i]"
-      return 1
+  if test (count $expected) -gt 0
+    for i in (seq (count $expected))
+      if test "$command_tokens[$i]" != "$expected[$i]"
+        return 1
+      end
     end
   end
 ${rejectDescendantCommands}
@@ -164,7 +166,8 @@ function fishCommandPathCondition(
   parents: readonly string[],
 ): string {
   const valueOptions = collectFishPathOptionFlags(program, parents, true);
-  return `__${rootCmd}_command_path_matches ${parents.join(" ")} -- ${fishWords(valueOptions)}`.trimEnd();
+  const commandPath = parents.length > 0 ? ` ${parents.join(" ")}` : "";
+  return `__${rootCmd}_command_path_matches${commandPath} -- ${fishWords(valueOptions)}`.trimEnd();
 }
 
 async function writeCompletionCache(params: {
@@ -626,9 +629,7 @@ function generateFishCompletion(program: Command): string {
     // One condition per alias-expanded parent path so completion keeps working
     // after the user typed an alias segment.
     const conditions = parentVariants.map((parents) =>
-      parents.length === 0
-        ? "__fish_use_subcommand"
-        : fishCommandPathCondition(program, rootCmd, parents),
+      fishCommandPathCondition(program, rootCmd, parents),
     );
     for (const condition of conditions) {
       // Subcommands (canonical names and aliases)

--- a/ui/src/e2e/sidebar-customization.e2e.test.ts
+++ b/ui/src/e2e/sidebar-customization.e2e.test.ts
@@ -341,6 +341,8 @@ describeControlUiE2e("Control UI sidebar customization mocked Gateway E2E", () =
       await expect.poll(() => identityCard.isVisible()).toBe(true);
       await openSettingsFromIdentity();
       await expect.poll(() => new URL(page.url()).pathname).toBe("/settings/general");
+      // Route changes paint Settings before the previous app sidebar finishes yielding.
+      await sidebar.waitFor({ state: "hidden" });
       const { search: settingsSearch, sidebar: settingsSidebar } =
         await waitForSettingsSidebar(page);
       await expect.poll(() => sidebar.isVisible()).toBe(false);

--- a/ui/src/e2e/terminal-repaint.e2e.test.ts
+++ b/ui/src/e2e/terminal-repaint.e2e.test.ts
@@ -75,6 +75,16 @@ describeControlUiE2e("Control UI terminal repaint", () => {
     try {
       await page.goto(server.baseUrl);
       await gateway.waitForRequest("connect");
+      // The connect request is observable before its response upgrades the lazy terminal panel.
+      // Wait for the advertised surface before exercising the real keyboard shortcut.
+      await page.waitForFunction(
+        () =>
+          (
+            document.querySelector("openclaw-terminal-panel") as
+              | (HTMLElement & { available?: boolean })
+              | null
+          )?.available === true,
+      );
       await page.keyboard.press("Control+Backquote");
       await gateway.waitForRequest("terminal.open");
 

--- a/ui/src/pages/agents/panels-tools-skills.browser.test.ts
+++ b/ui/src/pages/agents/panels-tools-skills.browser.test.ts
@@ -1,11 +1,21 @@
 // Control UI tests cover agents panels tools skills behavior.
 import { render } from "lit";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import type { SkillStatusEntry } from "../../api/types.ts";
 import { renderAgentSkills, renderAgentTools } from "./panels-tools-skills.ts";
 
+let previousBrowserLocation: { state: unknown; url: string };
+
+beforeEach(() => {
+  previousBrowserLocation = {
+    state: window.history.state,
+    url: `${window.location.pathname}${window.location.search}${window.location.hash}`,
+  };
+});
+
 afterEach(() => {
-  window.history.replaceState(null, "", `${window.location.pathname}${window.location.search}`);
+  // Non-isolated UI tests share browser history; restore both its state and URL.
+  window.history.replaceState(previousBrowserLocation.state, "", previousBrowserLocation.url);
 });
 
 function createBaseParams(overrides: Partial<Parameters<typeof renderAgentTools>[0]> = {}) {


### PR DESCRIPTION
## What Problem This Solves

Fish completion silently loses root commands, aliases, and global options after a normal space-separated root option. For example, `openclaw --profile work g` offers filesystem entries but not `gateway`, while the equivalent `openclaw --profile=work g` works. The same defect affects the documented `--log-level` and `--container` options, repeated root options, root aliases, and global-option suggestions.

## Why This Change Was Made

Fish's built-in `__fish_use_subcommand` treats the value of `--profile work` as a subcommand because it cannot know OpenClaw's Commander value-taking options. Reuse OpenClaw's existing command-path-aware Fish matcher for root and nested completion alike. Guard the empty root path before indexing Fish arrays, and derive root value-taking flags directly from the canonical Commander command tree.

This removes the special root completion branch instead of adding a profile-specific exception, new configuration, additional dependency, or parallel completion parser. Production code grows by one net line.

## User Impact

Fish users can complete documented root commands, aliases, and root options after separate or inline profiles, log levels, containers, repeated global options, and command-shaped option values. Existing nested completion, positional skill queries, Bash, Zsh, real PowerShell, completion installation, and machine-readable CLI output remain unchanged.

## Evidence

- Frozen clean main: `fe9893d41c2bedd71fd4eb0bb9f0c9c9f79b1be7`.
- Red first: 12 actual Linux Fish failures against unmodified production, with 68 pre-existing tests passing.
- Final focused and sibling proof: 398 passing tests, including 85 actual-Fish and real-PowerShell completion tests with no skipped Fish cases, 21 coupled Control UI browser/history tests, canonical root-option parsing, argv routing, gateway options, and 18 real machine-output/configuration E2E cases.
- `pnpm check:changed -- src/cli/completion-cli.ts src/cli/completion-cli.test.ts ui/src/pages/agents/panels-tools-skills.browser.test.ts`: formatting, production and test typechecks, lint, dependency pins, plugin boundary/API, schema/database, import-cycle, webhook, and pairing/security guards all pass.
- Complete `pnpm build`, CLI bootstrap, 146 public SDK exports, and Control UI build pass.
- Actual source and packaged acceptance: 52 passing real process cases, with Bash, Zsh, Fish, and PowerShell generation and real Fish execution against both source CLI and `openclaw.mjs`.
- Fresh independent `autoreview --mode uncommitted`: clean; no accepted/actionable findings.
- No added configuration, dependency, SDK, storage, migration, protocol, or environment surface.

## Inspectable Real Fish Proof

Current main, before the fix:

```text
fish, version 3.7.0

FAIL completes root commands in real Fish after a separate long root option
FAIL completes root commands in real Fish after a separate short root option
FAIL completes root commands in real Fish after repeated root options
FAIL completes root commands in real Fish after a preceding boolean root option
FAIL completes root commands in real Fish after a root option value named like a command
FAIL completes root options in real Fish after a separate long root option
FAIL completes root options in real Fish after a separate short root option
FAIL completes root options in real Fish after repeated root options
FAIL completes real Fish root aliases after a canonical root command
FAIL completes real Fish root aliases after an aliased root command
FAIL completes real Fish root aliases after an alias-shaped profile value
FAIL completes real Fish root aliases after a repeated profile and alias

Test Files  1 failed
Tests       12 failed | 68 passed
RED-FIRST CONFIRMED: actual Fish root-command and alias regressions failed on frozen main
```

Actual final source CLI:

```text
PASS source real Fish {"line":"openclaw --profile work g","expected":"gateway","suggestions":["gateway","git-hooks/"],"forbiddenAbsent":[]}
PASS source real Fish {"line":"openclaw --profile=work g","expected":"gateway","suggestions":["gateway","git-hooks/"],"forbiddenAbsent":[]}
PASS source real Fish {"line":"openclaw --log-level debug g","expected":"gateway","suggestions":["gateway","git-hooks/"],"forbiddenAbsent":[]}
PASS source real Fish {"line":"openclaw --container local g","expected":"gateway","suggestions":["gateway","git-hooks/"],"forbiddenAbsent":[]}
PASS source real Fish {"line":"openclaw --profile work --log-level debug --container local g","expected":"gateway","suggestions":["gateway","git-hooks/"],"forbiddenAbsent":[]}
PASS source real Fish {"line":"openclaw --profile gateway g","expected":"gateway","suggestions":["gateway","git-hooks/"],"forbiddenAbsent":[]}
PASS source real Fish {"line":"openclaw --profile work --p","expected":"--profile","suggestions":["--profile"],"forbiddenAbsent":[]}
PASS source real Fish {"line":"openclaw --profile work inf","expected":"infer","suggestions":["infer"],"forbiddenAbsent":[]}
PASS source real Fish {"line":"openclaw --profile work cap","expected":"capability","suggestions":["capability"],"forbiddenAbsent":[]}
PASS source real Fish {"line":"openclaw --profile capability cap","expected":"capability","suggestions":["capability"],"forbiddenAbsent":[]}
PASS source real Fish {"line":"openclaw --profile work gateway status -","expected":"--json","suggestions":["--deep","--json","--no-probe","--password","--require-rpc","--timeout","--token","--url"],"forbiddenAbsent":["--force","--raw-stream","--bind"]}
PASS source real Fish {"line":"openclaw --profile work skills search first second -","expected":"--json","suggestions":["--json","--limit"],"forbiddenAbsent":[]}
```

Actual built, packaged CLI:

```text
PASS packaged real Fish {"line":"openclaw --profile work g","expected":"gateway","suggestions":["gateway","git-hooks/"],"forbiddenAbsent":[]}
PASS packaged real Fish {"line":"openclaw --log-level debug g","expected":"gateway","suggestions":["gateway","git-hooks/"],"forbiddenAbsent":[]}
PASS packaged real Fish {"line":"openclaw --container local g","expected":"gateway","suggestions":["gateway","git-hooks/"],"forbiddenAbsent":[]}
PASS packaged real Fish {"line":"openclaw --profile work --log-level debug --container local g","expected":"gateway","suggestions":["gateway","git-hooks/"],"forbiddenAbsent":[]}
PASS packaged real Fish {"line":"openclaw --profile work --p","expected":"--profile","suggestions":["--profile"],"forbiddenAbsent":[]}
PASS packaged real Fish {"line":"openclaw --profile work cap","expected":"capability","suggestions":["capability"],"forbiddenAbsent":[]}
PASS packaged real Fish {"line":"openclaw --profile work gateway status -","expected":"--json","suggestions":["--deep","--json","--no-probe","--password","--require-rpc","--timeout","--token","--url"],"forbiddenAbsent":["--force","--raw-stream","--bind"]}
PASS packaged real Fish {"line":"openclaw --profile work skills search first second -","expected":"--json","suggestions":["--json","--limit"],"forbiddenAbsent":[]}
PASS source and packaged real Fish completion: 52 real process cases
blacksmith run summary sync=delegated command=9m33.435s total=9m33.487s exit=0
```

## Upstream CI Isolation Repair

The first exact-head hosted run exposed an existing non-isolated Control UI failure in `checks-node-compact-large-4`: the agent tools chip test clicks `#agent-tool-read` and leaks that hash into subsequent Settings routing tests. The production routing code correctly preserves URL hashes, so weakening its assertions would hide the underlying shared-browser-state bug.

This PR repairs the mutation in its actual test owner: capture both `window.history.state` and the complete pathname/search/hash before each agent tools test, then restore both in `afterEach`. This is test-only isolation; no Control UI product runtime changes.

```text
Hosted current-main failure:
FAIL redirects the former Communications channels section
  expected hash ""; received "#agent-tool-read"
FAIL redirects the former Communications broadcast section
  expected hash ""; received "#agent-tool-read"
FAIL redirects the former Agent Defaults models section
  expected hash ""; received "#agent-tool-read"

Final producer-plus-consumer proof:
✓ ui/src/pages/agents/panels-tools-skills.browser.test.ts (8 tests)
✓ ui/src/pages/config/config-page.test.ts (13 tests)
Test Files 2 passed
Tests      21 passed

fish, version 3.7.0
✓ src/cli/completion-cli.test.ts (85 tests; no skipped Fish cases)
✓ all 377 focused CLI, PowerShell, root-option, and JSON E2E regressions
Fresh independent autoreview: clean; browser URL and history.state both restored.
```


## Additional Hosted Chromium E2E Repair

The final exact-head hosted Control UI E2E job uncovered an independent existing test startup race:

- `ui/src/e2e/terminal-repaint.e2e.test.ts:79` timed out waiting for `terminal.open` after issuing the real `Control+Backquote` shortcut.
- The mocked Gateway records `connect` before its response has finished advertising and lazily upgrading the terminal panel. Sending the shortcut in that interval is correctly ignored by the production availability guard.
- The hosted Chromium suite independently established **368 passing tests and this one failing startup-race test**.
- Repair only the owning E2E: wait for the real `openclaw-terminal-panel.available === true` before issuing the unchanged real keyboard shortcut. Keep every repaint digest, hide/show cycle, input assertion, and single-session assertion unchanged; do not alter production terminal behavior or weaken any check.

### Actual Chromium proof against fresh main

The exact E2E test file on freshly pulled canonical `main` and the pull-request base has the same Git blob, `478881a3345c55ee0b5a699498353207fcc92734`. Because the preferred prepared remote browser runner was queued and the direct AWS broker was not configured, the trusted-source fallback used the existing installed local Playwright Chromium and dependencies without installing or reconciling worktree dependencies. The temporary proof patch was removed and canonical `main` was verified clean afterward.

```text
node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts \\
  --configLoader runner ui/src/e2e/terminal-repaint.e2e.test.ts

attempt 1: 1 test passed
attempt 2: 1 test passed
attempt 3: 1 test passed

node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts \\
  --configLoader runner \\
  ui/src/e2e/terminal-repaint.e2e.test.ts \\
  ui/src/e2e/terminal-embedded.e2e.test.ts \\
  ui/src/e2e/terminal-upload.e2e.test.ts \\
  ui/src/e2e/terminal-runtime.e2e.test.ts

Test Files  4 passed (4)
Tests       5 passed (5)
```

Fresh isolated independent review: `autoreview clean: no accepted/actionable findings reported` (correctness confidence 0.96). The additional E2E fix passes `oxfmt --check`, `git diff --check`, three repeated actual Chromium runs, and every focused terminal E2E sibling. Earlier sections document the original **398 passing tests**, full changed-file gate, production build, and 52 real shell scenarios.


## Fresh-Main Rebase and Merge Proof

While exact-head CI was running, `main` independently landed `35f035806baf5bdec0c4d3e366d69679fb83c938` (`fix(ui): avoid duplicate session refreshes during startup`) and introduced a simpler `afterEach` into the same agent-tools test. The branch was rebased onto that latest main and the single overlap was resolved by preserving the more complete before/after history snapshot, including `history.state`, the complete URL, and any preexisting fragment. Upstream startup and session changes are retained unchanged.

Fresh-baseline proof with the exact resolved UI implementations:

```text
node scripts/run-vitest.mjs \\
  ui/src/pages/agents/panels-tools-skills.browser.test.ts \\
  ui/src/pages/config/config-page.test.ts

Test Files  2 passed (2)
Tests       24 passed (24)

node scripts/run-vitest.mjs run \\
  --config test/vitest/vitest.ui-e2e.config.ts \\
  --configLoader runner \\
  ui/src/e2e/terminal-repaint.e2e.test.ts \\
  ui/src/e2e/terminal-embedded.e2e.test.ts \\
  ui/src/e2e/terminal-upload.e2e.test.ts \\
  ui/src/e2e/terminal-runtime.e2e.test.ts

Test Files  4 passed (4)
Tests       5 passed (5)
```

All four final changed files pass the canonical formatter and `git diff --check`. Both the rebased PR checkout and refreshed canonical `main` are clean.


## Additional Chromium Settings-Takeover Repair

A subsequent full protected browser run confirmed the terminal repaint repair and revealed a second existing race in `ui/src/e2e/sidebar-customization.e2e.test.ts:346`: after navigation to `/settings/general`, the Settings sidebar can render before the previous application sidebar has finished yielding. The hosted run passed **368 browser tests** and exposed this single `expected true to be false` failure.

The two-line, test-only fix waits for the actual prior sidebar to become hidden before continuing. It preserves the real menu clicks, URL assertion, visible Settings surface, and original app-sidebar assertion; it changes no production code and does not replace user interaction with mocks or increase test timeouts.

Actual Chromium validation, with both independently observed full-suite failures in one process:

```text
node scripts/run-vitest.mjs run \\
  --config test/vitest/vitest.ui-e2e.config.ts \\
  --configLoader runner \\
  ui/src/e2e/sidebar-customization.e2e.test.ts \\
  ui/src/e2e/terminal-repaint.e2e.test.ts

Test Files  2 passed (2)
Tests       12 passed (12)
```

Fresh independent isolated review: `autoreview clean: no accepted/actionable findings reported` (correctness confidence **0.98**). The exact additional file passes the canonical formatter and staged whitespace validation; canonical main was restored clean after Chromium proof.

## Maintainer Resolution of ClawSweeper Merge Risks

- **Exact-head proof:** all **82 required/applicable hosted checks pass**, zero checks are pending, and zero checks fail on `c0cb550208a6e5264ed894528ccdbac940c5d12d`. The complete Chromium lane now passes the formerly failing terminal and Settings/sidebar user flows.
- **Why retain the three UI-test fixes:** these are independently observed failures in the required CI for the Fish change, not unrelated speculative refactoring. The shared-history producer caused three Settings failures; the terminal shortcut raced true lazy availability; and Settings navigation raced the actual application sidebar. Each correction stays in its owning test, preserves production behavior and all user interactions/assertions, is independently reviewed, and has real-browser or coupled-test proof. Splitting them would reintroduce observed blockers into the required merge gate.
- **Main drift:** the actual overlapping upstream history change was resolved by rebasing while preserving both newer main behavior and complete browser-history restoration. Subsequent unrelated main movement is advisory when GitHub reports a clean merge result; verify the live head and mergeability immediately before repository-native preparation and merge.
