### PR TITLE
fix(cli): reject incomplete infer model overrides

### DIFF
--- a/src/cli/capability-cli.test.ts
+++ b/src/cli/capability-cli.test.ts
@@ -2979,6 +2979,34 @@ describe("capability cli", () => {
     expect(firstEmbeddingProviderCall()?.model).toBe("text-embedding-3-large");
   });
 
+  it.each([
+    {
+      name: "embedding create",
+      argv: ["capability", "embedding", "create", "--text", "hello"],
+    },
+    {
+      name: "image generate",
+      argv: ["capability", "image", "generate", "--prompt", "portrait"],
+    },
+    {
+      name: "image edit",
+      argv: ["capability", "image", "edit", "--file", "photo.png", "--prompt", "crop it"],
+    },
+    {
+      name: "video generate",
+      argv: ["capability", "video", "generate", "--prompt", "clip"],
+    },
+  ])("rejects malformed model refs before $name provider dispatch", async ({ argv }) => {
+    for (const model of ["openai/", "/gpt-4.1-mini"]) {
+      await expect(runCap(...argv, "--model", model, "--json")).rejects.toThrow("exit 1");
+      expectRuntimeErrorContains("Model overrides must use the form <provider/model>.");
+      expect(mocks.resolveCommandConfigWithSecrets).not.toHaveBeenCalled();
+      expect(mocks.createEmbeddingProvider).not.toHaveBeenCalled();
+      expect(mocks.generateImage).not.toHaveBeenCalled();
+      expect(mocks.generateVideo).not.toHaveBeenCalled();
+    }
+  });
+
   it("cleans provider auth profiles and usage stats on logout", async () => {
     mocks.loadAuthProfileStoreForRuntime.mockReturnValue({
       profiles: {

--- a/src/cli/capability-cli/embedding.ts
+++ b/src/cli/capability-cli/embedding.ts
@@ -16,8 +16,8 @@ import {
   formatEnvelopeForText,
   providerHasGenericConfig,
   providerSummaryText,
+  requireProviderModelOverride,
   resolveLocalCapabilityRuntimeConfig,
-  resolveModelRefOverride,
 } from "./shared.js";
 
 async function closeEmbeddingProviderWithRetry(provider: {
@@ -40,18 +40,19 @@ async function runMemoryEmbeddingCreate(params: {
   provider?: string;
   model?: string;
 }) {
+  const modelRef = requireProviderModelOverride(params.model);
   const cfg = await resolveLocalCapabilityRuntimeConfig({
     commandName: "infer embedding create",
     targetIds: getMemoryEmbeddingCommandSecretTargetIds(),
   });
-  const modelRef = resolveModelRefOverride(params.model);
-  const requestedProvider = normalizeOptionalString(params.provider) || modelRef.provider || "auto";
+  const requestedProvider =
+    normalizeOptionalString(params.provider) || modelRef?.provider || "auto";
   const result = await createEmbeddingProvider({
     config: cfg,
     agentDir: resolveAgentDir(cfg, resolveDefaultAgentId(cfg)),
     provider: requestedProvider,
     fallback: "none",
-    model: modelRef.model ?? "",
+    model: modelRef?.model ?? "",
   });
   if (!result.provider) {
     throw new Error(result.providerUnavailableReason ?? "No embedding provider available.");

--- a/src/cli/capability-cli/image.ts
+++ b/src/cli/capability-cli/image.ts
@@ -64,6 +64,7 @@ async function runImageGenerate(params: {
   output?: string;
   timeoutMs?: number;
 }) {
+  requireProviderModelOverride(params.model);
   const cfg = await resolveLocalCapabilityRuntimeConfig({
     commandName: `infer ${params.capability}`,
     targetIds: getModelsCommandSecretTargetIds(),

--- a/src/cli/capability-cli/video.ts
+++ b/src/cli/capability-cli/video.ts
@@ -109,6 +109,7 @@ async function runVideoGenerate(params: {
   watermark?: boolean;
   timeoutMs?: number;
 }) {
+  requireProviderModelOverride(params.model);
   const cfg = await resolveLocalCapabilityRuntimeConfig({
     commandName: "infer video.generate",
     targetIds: getModelsCommandSecretTargetIds(),


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users running `openclaw infer embedding create`, `image generate`/`edit`, or `video generate` with an incomplete explicit model reference such as `openai/` or `/model` would silently fall through to provider/default selection instead of receiving a model-reference error.

## Why This Change Was Made

The affected CLI entry points now apply the existing strict `<provider/model>` validator before resolving command secrets, loading configuration, reading image inputs, or dispatching to a provider. The media runtimes keep their broader internal model-selection contract; strictness stays at the CLI surface that documents provider-qualified overrides.

## User Impact

Malformed explicit model overrides now fail immediately and consistently across infer generation commands. Valid overrides and omitted `--model` values keep their existing behavior.

Release-note context: reject incomplete explicit model references in infer embedding, image generation/edit, and video generation commands instead of silently using defaults.

## Evidence

- Reproduced on the pre-fix base: `openai/` reached provider/default selection in embedding, image generation, and video generation.
- Source-runner stress after the fix: 200/200 malformed commands rejected at 8-way concurrency; 0 provider dispatches, 0 SQLite lock failures, 0 stdout responses.
- Credential-aware startup soak: all 34 Molty inference credential variables present; 20 cold plus 50 warm waves at 8-way concurrency returned valid JSON for all 560 `infer ... providers` starts.
- Blacksmith Testbox `tbx_01kymfs0w9ebra9bj77fjezw48`: `src/cli/capability-cli.test.ts` passed 129/129 tests on exact head.
- Blacksmith Testbox changed gate passed on exact head: core/core-test typecheck, changed-file lint, API/boundary/dependency, database-first, import-cycle, and runtime safety guards.
- Testbox run: https://github.com/openclaw/openclaw/actions/runs/30365291064
- Post-rebase Codex autoreview: clean, no accepted/actionable findings.
