### PR TITLE
fix(channels): report a channel that cannot receive as unhealthy instead of connected

### DIFF
--- a/docs/docs_map.md
+++ b/docs/docs_map.md
@@ -3648,6 +3648,7 @@ Do not edit it by hand; run `pnpm docs:map:gen`.
   - H2: Quick checks
   - H2: Deep diagnostics
   - H2: Health monitor config
+  - H2: Inbound ingress health
   - H2: Uptime monitoring
   - H3: Monitoring service setup examples
   - H2: When something fails

--- a/docs/gateway/health.md
+++ b/docs/gateway/health.md
@@ -42,6 +42,15 @@ health commands above for live connectivity checks.
 - These per-channel overrides apply to the built-in channels that expose them today: Discord, Google Chat, iMessage, IRC, Microsoft Teams, Signal, Slack, Telegram, and WhatsApp.
 - A crashing channel is recovered by its own auto-restart backoff first (`auto-restart attempt N/10` in the logs). The health monitor stays out of the way until that ladder ends with `giving up after 10 restart attempts`, then takes over as the last restart owner.
 
+## Inbound ingress health
+
+Channel connectivity and inbound admission are separate failure domains. A channel can hold a healthy transport connection — sending replies normally — while its durable ingress queue is unavailable, so not a single inbound message is admitted.
+
+- When a channel cannot open its durable ingress queue, its start fails and the gateway records the account as unable to receive. `openclaw channels status` reports `Channel cannot admit inbound events; its durable ingress queue is unavailable. Outbound may still work.`
+- Such an account is **unhealthy** regardless of transport state, and readiness reports it as failing.
+- The health monitor deliberately does **not** restart it. A denied or unusable ingress queue is a capability or configuration problem that a restart cannot fix, and the channel's own backoff ladder has already tried. The log line is `health-monitor: skipping restart, channel cannot admit inbound events`.
+- Channels that never report ingress state are unaffected: absence means "no signal", never "broken". There is no traffic-staleness heuristic, so a genuinely quiet channel is never marked unhealthy for having received nothing.
+
 ## Uptime monitoring
 
 External uptime monitoring services should use the dedicated `/health` endpoint, not `/v1/chat/completions`.

--- a/docs/gateway/health.md
+++ b/docs/gateway/health.md
@@ -47,8 +47,9 @@ health commands above for live connectivity checks.
 Channel connectivity and inbound admission are separate failure domains. A channel can hold a healthy transport connection — sending replies normally — while its durable ingress queue is unavailable, so not a single inbound message is admitted.
 
 - When a channel cannot open its durable ingress queue, its start fails and the gateway records the account as unable to receive. `openclaw channels status` reports `Channel cannot admit inbound events; its durable ingress queue is unavailable. Outbound may still work.`
-- Such an account is **unhealthy** regardless of transport state, and readiness reports it as failing.
-- The health monitor deliberately does **not** restart it. A denied or unusable ingress queue is a capability or configuration problem that a restart cannot fix, and the channel's own backoff ladder has already tried. The log line is `health-monitor: skipping restart, channel cannot admit inbound events`.
+- Such an account is **unhealthy** regardless of transport state, and readiness reports it as failing. Previously it reported `health: healthy` and the health monitor never touched it.
+- Recovery stays automatic. The ingress verdict describes the account's last start attempt and is cleared by the next one, so the ordinary restart path is also how a transient queue-open failure recovers. Those restarts log as `health-monitor: restarting (reason: ingress-unavailable)` instead of the generic `stuck`.
+- If the restarts keep repeating, the cause is not transient. Check the logged ingress failure: a plugin denied the `openChannelIngressQueue` capability, for example, needs operator action rather than another restart.
 - Channels that never report ingress state are unaffected: absence means "no signal", never "broken". There is no traffic-staleness heuristic, so a genuinely quiet channel is never marked unhealthy for having received nothing.
 
 ## Uptime monitoring

--- a/src/channels/account-snapshot-fields.ts
+++ b/src/channels/account-snapshot-fields.ts
@@ -284,6 +284,9 @@ export function projectSafeChannelAccountSnapshotFields(
       : {}),
     ...(statusState ? { statusState } : {}),
     ...(healthState ? { healthState } : {}),
+    // Only a proven-dead ingress crosses this boundary; `false`/absent both mean
+    // "nothing known", so never project a negative and invent a healthy claim.
+    ...(readBoolean(record, "ingressUnavailable") === true ? { ingressUnavailable: true } : {}),
     ...(readBoolean(record, "terminalDisconnect") !== undefined
       ? { terminalDisconnect: readBoolean(record, "terminalDisconnect") }
       : {}),

--- a/src/channels/message/ingress-monitor.test.ts
+++ b/src/channels/message/ingress-monitor.test.ts
@@ -522,8 +522,9 @@ describe("channel ingress monitor", () => {
     expect((startError as Error).cause).toBe(denial);
     expect(isChannelIngressUnavailableError(startError)).toBe(true);
     // A channel plugin is free to wrap the start failure in its own error.
-    expect(isChannelIngressUnavailableError(new Error("slack start failed", { cause: startError })))
-      .toBe(true);
+    expect(
+      isChannelIngressUnavailableError(new Error("slack start failed", { cause: startError })),
+    ).toBe(true);
     expect(isChannelIngressUnavailableError(denial)).toBe(false);
     expect(monitor.isRunning()).toBe(false);
     // An armed poll timer would have retried the denied factory many times over this window.

--- a/src/channels/message/ingress-monitor.test.ts
+++ b/src/channels/message/ingress-monitor.test.ts
@@ -8,6 +8,10 @@ import {
   type ChannelIngressMonitorLifecycle,
 } from "./ingress-monitor.js";
 import { createChannelIngressQueue, type ChannelIngressQueue } from "./ingress-queue.js";
+import {
+  ChannelIngressUnavailableError,
+  isChannelIngressUnavailableError,
+} from "./ingress-unavailable.js";
 
 type RawEvent = { id: string; lane: string; text: string };
 type StoredEvent = { version: 1; rawEvent: string };
@@ -504,7 +508,23 @@ describe("channel ingress monitor", () => {
     const onError = vi.fn();
     const monitor = createMonitor(queueFactory, vi.fn(), undefined, onError, undefined, 1);
 
-    expect(() => monitor.start()).toThrow(denial);
+    // The typed rethrow is the gateway's only way to tell dead inbound apart from
+    // an ordinary channel crash; the denial stays reachable as the cause.
+    const startError = (() => {
+      try {
+        monitor.start();
+        return expect.unreachable("start must fail while the durable queue is denied");
+      } catch (error) {
+        return error;
+      }
+    })();
+    expect(startError).toBeInstanceOf(ChannelIngressUnavailableError);
+    expect((startError as Error).cause).toBe(denial);
+    expect(isChannelIngressUnavailableError(startError)).toBe(true);
+    // A channel plugin is free to wrap the start failure in its own error.
+    expect(isChannelIngressUnavailableError(new Error("slack start failed", { cause: startError })))
+      .toBe(true);
+    expect(isChannelIngressUnavailableError(denial)).toBe(false);
     expect(monitor.isRunning()).toBe(false);
     // An armed poll timer would have retried the denied factory many times over this window.
     await sleep(25);

--- a/src/channels/message/ingress-monitor.ts
+++ b/src/channels/message/ingress-monitor.ts
@@ -7,11 +7,11 @@ import {
   type CreateChannelIngressDrainOptions,
 } from "./ingress-drain.js";
 import type { ChannelIngressQueue, ChannelIngressQueueClaim } from "./ingress-queue.js";
-import { ChannelIngressUnavailableError } from "./ingress-unavailable.js";
 import {
   DEFAULT_INGRESS_RETRY_DEAD_LETTER_MIN_AGE_MS,
   DEFAULT_INGRESS_RETRY_MAX_ATTEMPTS,
 } from "./ingress-retry-policy.js";
+import { ChannelIngressUnavailableError } from "./ingress-unavailable.js";
 
 const DEFAULT_APPEND_RETRY_DELAYS_MS = [0, 100, 300] as const;
 

--- a/src/channels/message/ingress-monitor.ts
+++ b/src/channels/message/ingress-monitor.ts
@@ -7,6 +7,7 @@ import {
   type CreateChannelIngressDrainOptions,
 } from "./ingress-drain.js";
 import type { ChannelIngressQueue, ChannelIngressQueueClaim } from "./ingress-queue.js";
+import { ChannelIngressUnavailableError } from "./ingress-unavailable.js";
 import {
   DEFAULT_INGRESS_RETRY_DEAD_LETTER_MIN_AGE_MS,
   DEFAULT_INGRESS_RETRY_MAX_ATTEMPTS,
@@ -603,8 +604,17 @@ export function createChannelIngressMonitor<TRaw, TBody, TStoredPayload, TMetada
       }
       // Open the durable queue before arming the poll timer. A monitor without a queue can
       // neither admit nor drain, so channel start must fail through the caller instead of
-      // running a timer that reports the same unrecoverable error on every tick.
-      getQueue();
+      // running a timer that reports the same unrecoverable error on every tick. The typed
+      // rethrow is what lets the gateway record the failure as dead ingress rather than as
+      // one more anonymous channel crash.
+      try {
+        getQueue();
+      } catch (error) {
+        throw new ChannelIngressUnavailableError(
+          `Channel ingress queue is unavailable: ${formatErrorMessage(error)}`,
+          { cause: error },
+        );
+      }
       running = true;
       pollTimer = setInterval(requestDrain, options.pollIntervalMs);
       pollTimer.unref?.();

--- a/src/channels/message/ingress-unavailable.ts
+++ b/src/channels/message/ingress-unavailable.ts
@@ -1,0 +1,30 @@
+/**
+ * Typed marker for "this channel cannot admit a single inbound event".
+ *
+ * Lives in its own module so the gateway supervisor can classify a channel
+ * start failure without importing the whole ingress monitor onto its hot path.
+ */
+import { collectErrorGraphCandidates, extractErrorCode } from "../../infra/errors.js";
+
+export const CHANNEL_INGRESS_UNAVAILABLE_CODE = "CHANNEL_INGRESS_UNAVAILABLE";
+
+/** Raised when a channel's durable ingress queue cannot be opened. */
+export class ChannelIngressUnavailableError extends Error {
+  readonly code = CHANNEL_INGRESS_UNAVAILABLE_CODE;
+
+  constructor(message: string, options?: { cause?: unknown }) {
+    super(message, options);
+    this.name = "ChannelIngressUnavailableError";
+  }
+}
+
+/**
+ * Matches on the stable `code` across the whole `cause` chain rather than
+ * `instanceof`. Channel plugins are free to wrap a start failure in their own
+ * error, and duplicate module instances would defeat a prototype check.
+ */
+export function isChannelIngressUnavailableError(error: unknown): boolean {
+  return collectErrorGraphCandidates(error, (current) => [current.cause]).some(
+    (candidate) => extractErrorCode(candidate) === CHANNEL_INGRESS_UNAVAILABLE_CODE,
+  );
+}

--- a/src/channels/message/ingress-unavailable.ts
+++ b/src/channels/message/ingress-unavailable.ts
@@ -6,7 +6,7 @@
  */
 import { collectErrorGraphCandidates, extractErrorCode } from "../../infra/errors.js";
 
-export const CHANNEL_INGRESS_UNAVAILABLE_CODE = "CHANNEL_INGRESS_UNAVAILABLE";
+const CHANNEL_INGRESS_UNAVAILABLE_CODE = "CHANNEL_INGRESS_UNAVAILABLE";
 
 /** Raised when a channel's durable ingress queue cannot be opened. */
 export class ChannelIngressUnavailableError extends Error {

--- a/src/channels/plugins/types.core.ts
+++ b/src/channels/plugins/types.core.ts
@@ -168,6 +168,12 @@ export type ChannelAccountSnapshot = {
   stateReason?: string;
   lastError?: string | null;
   healthState?: string;
+  /**
+   * Inbound admission, which is a different failure domain from `connected`.
+   * Optional-`true` on purpose: there is no `false` to mistake for "unknown",
+   * so the 20+ channels that never report ingress at all stay unaffected.
+   */
+  ingressUnavailable?: true;
   terminalDisconnect?: boolean;
   lastStartAt?: number | null;
   lastStopAt?: number | null;

--- a/src/gateway/channel-health-monitor.test.ts
+++ b/src/gateway/channel-health-monitor.test.ts
@@ -365,23 +365,10 @@ describe("channel-health-monitor", () => {
     await expectNoRestart(manager);
   });
 
-  it("does not restart a channel whose ingress monitor could not start", async () => {
-    // Restarting cannot reopen a denied durable queue; looping here would burn the
-    // per-hour restart budget forever instead of leaving the failure visible.
-    const manager = createSnapshotManager({
-      slack: {
-        default: {
-          running: false,
-          enabled: true,
-          configured: true,
-          ingressUnavailable: true,
-        },
-      },
-    });
-    await expectNoRestart(manager);
-  });
-
-  it("does not restart a running channel with a live socket but dead ingress", async () => {
+  it("restarts a running channel with a live socket but dead ingress", async () => {
+    // A restart is the only way to re-prove ingress, so recovery from a transient
+    // queue-open failure must stay automatic. Without the ingress dimension this
+    // account evaluated as healthy and was never touched at all.
     const manager = createSnapshotManager({
       slack: {
         default: {
@@ -393,7 +380,10 @@ describe("channel-health-monitor", () => {
         },
       },
     });
-    await expectNoRestart(manager);
+    const monitor = await startAndRunCheck(manager);
+    expect(manager.stopChannel).toHaveBeenCalledWith("slack", "default", { manual: false });
+    expect(manager.startChannel).toHaveBeenCalledWith("slack", "default");
+    monitor.stop();
   });
 
   it("restarts a stopped channel without terminalDisconnect", async () => {

--- a/src/gateway/channel-health-monitor.test.ts
+++ b/src/gateway/channel-health-monitor.test.ts
@@ -365,6 +365,37 @@ describe("channel-health-monitor", () => {
     await expectNoRestart(manager);
   });
 
+  it("does not restart a channel whose ingress monitor could not start", async () => {
+    // Restarting cannot reopen a denied durable queue; looping here would burn the
+    // per-hour restart budget forever instead of leaving the failure visible.
+    const manager = createSnapshotManager({
+      slack: {
+        default: {
+          running: false,
+          enabled: true,
+          configured: true,
+          ingressUnavailable: true,
+        },
+      },
+    });
+    await expectNoRestart(manager);
+  });
+
+  it("does not restart a running channel with a live socket but dead ingress", async () => {
+    const manager = createSnapshotManager({
+      slack: {
+        default: {
+          running: true,
+          connected: true,
+          enabled: true,
+          configured: true,
+          ingressUnavailable: true,
+        },
+      },
+    });
+    await expectNoRestart(manager);
+  });
+
   it("restarts a stopped channel without terminalDisconnect", async () => {
     const manager = createSnapshotManager({
       whatsapp: {

--- a/src/gateway/channel-health-monitor.ts
+++ b/src/gateway/channel-health-monitor.ts
@@ -149,6 +149,16 @@ export function startChannelHealthMonitor(deps: ChannelHealthMonitorDeps): Chann
             );
             continue;
           }
+          // Dead ingress is a capability/config failure, not a stuck runtime. The
+          // channel supervisor already ran its bounded restart ladder against it;
+          // repeating that here would restart forever at the per-hour cap and never
+          // recover. Stay unhealthy and visible so an operator fixes the cause.
+          if (health.reason === "ingress-unavailable") {
+            log.warn?.(
+              `[${channelId}:${accountId}] health-monitor: skipping restart, channel cannot admit inbound events`,
+            );
+            continue;
+          }
           // The channel supervisor owns the account while its own backoff restart
           // is in flight. Restarting here cannot start anything (the supervisor
           // still holds the account task) and only resets the attempt ladder, so

--- a/src/gateway/channel-health-monitor.ts
+++ b/src/gateway/channel-health-monitor.ts
@@ -149,16 +149,6 @@ export function startChannelHealthMonitor(deps: ChannelHealthMonitorDeps): Chann
             );
             continue;
           }
-          // Dead ingress is a capability/config failure, not a stuck runtime. The
-          // channel supervisor already ran its bounded restart ladder against it;
-          // repeating that here would restart forever at the per-hour cap and never
-          // recover. Stay unhealthy and visible so an operator fixes the cause.
-          if (health.reason === "ingress-unavailable") {
-            log.warn?.(
-              `[${channelId}:${accountId}] health-monitor: skipping restart, channel cannot admit inbound events`,
-            );
-            continue;
-          }
           // The channel supervisor owns the account while its own backoff restart
           // is in flight. Restarting here cannot start anything (the supervisor
           // still holds the account task) and only resets the attempt ladder, so

--- a/src/gateway/channel-health-policy.test.ts
+++ b/src/gateway/channel-health-policy.test.ts
@@ -286,6 +286,19 @@ describe("evaluateChannelHealth", () => {
       expect(evaluation).toEqual({ healthy: false, reason: "ingress-unavailable" });
     });
 
+    it("leaves a stopped account on its lifecycle reason", () => {
+      // Readiness deliberately keeps a restart-backoff window green, so the ingress
+      // dimension must not shadow not-running and start flapping it.
+      const evaluation = evaluateHealth({
+        running: false,
+        enabled: true,
+        configured: true,
+        restartPending: true,
+        ingressUnavailable: true,
+      });
+      expect(evaluation).toEqual({ healthy: false, reason: "not-running" });
+    });
+
     it("outranks a busy short-circuit so an in-flight run cannot hide dead ingress", () => {
       const evaluation = evaluateHealth(
         connectedAccount({ ingressUnavailable: true, activeRuns: 1, lastRunActivityAt: 99_000 }),
@@ -319,7 +332,7 @@ describe("evaluateChannelHealth", () => {
 
     it("stays healthy for a disabled account so unmanaged still wins", () => {
       const evaluation = evaluateHealth({
-        running: false,
+        running: true,
         enabled: false,
         configured: true,
         ingressUnavailable: true,

--- a/src/gateway/channel-health-policy.test.ts
+++ b/src/gateway/channel-health-policy.test.ts
@@ -286,9 +286,10 @@ describe("evaluateChannelHealth", () => {
       expect(evaluation).toEqual({ healthy: false, reason: "ingress-unavailable" });
     });
 
-    it("leaves a stopped account on its lifecycle reason", () => {
-      // Readiness deliberately keeps a restart-backoff window green, so the ingress
-      // dimension must not shadow not-running and start flapping it.
+    it("keeps the ingress reason for the stopped state a failed start lands in", () => {
+      // server-channels records the verdict only after the start task rejects, so
+      // this is the shape the real failure has. Collapsing it into not-running
+      // would throw the cause away exactly where it matters.
       const evaluation = evaluateHealth({
         running: false,
         enabled: true,
@@ -296,7 +297,7 @@ describe("evaluateChannelHealth", () => {
         restartPending: true,
         ingressUnavailable: true,
       });
-      expect(evaluation).toEqual({ healthy: false, reason: "not-running" });
+      expect(evaluation).toEqual({ healthy: false, reason: "ingress-unavailable" });
     });
 
     it("outranks a busy short-circuit so an in-flight run cannot hide dead ingress", () => {
@@ -332,7 +333,7 @@ describe("evaluateChannelHealth", () => {
 
     it("stays healthy for a disabled account so unmanaged still wins", () => {
       const evaluation = evaluateHealth({
-        running: true,
+        running: false,
         enabled: false,
         configured: true,
         ingressUnavailable: true,

--- a/src/gateway/channel-health-policy.test.ts
+++ b/src/gateway/channel-health-policy.test.ts
@@ -341,6 +341,14 @@ describe("resolveChannelRestartReason", () => {
     expect(reason).toBe("gave-up");
   });
 
+  it("maps dead ingress to its own reason instead of stuck", () => {
+    const reason = resolveChannelRestartReason(
+      runningAccount({ connected: true, ingressUnavailable: true }),
+      { healthy: false, reason: "ingress-unavailable" },
+    );
+    expect(reason).toBe("ingress-unavailable");
+  });
+
   it("maps disconnected to disconnected instead of stuck", () => {
     const reason = resolveChannelRestartReason(
       runningAccount({

--- a/src/gateway/channel-health-policy.test.ts
+++ b/src/gateway/channel-health-policy.test.ts
@@ -263,6 +263,70 @@ describe("evaluateChannelHealth", () => {
       evaluateHealth({ enabled: true, configured: true, ...snapshot }, { channelId: "whatsapp" }),
     ).toEqual(expected);
   });
+
+  describe("inbound ingress dimension", () => {
+    it("flags a channel whose ingress monitor failed to start, despite a live transport", () => {
+      // The 26h production case: outbound fine, socket connected, zero inbound admitted.
+      const evaluation = evaluateHealth(
+        connectedAccount({
+          ingressUnavailable: true,
+          lastStartAt: 0,
+          lastTransportActivityAt: 99_000,
+        }),
+        { channelId: "slack" },
+      );
+      expect(evaluation).toEqual({ healthy: false, reason: "ingress-unavailable" });
+    });
+
+    it("outranks the startup connect grace so dead ingress is never masked", () => {
+      const evaluation = evaluateHealth(
+        connectedAccount({ ingressUnavailable: true, lastStartAt: 99_000 }),
+        { channelId: "slack" },
+      );
+      expect(evaluation).toEqual({ healthy: false, reason: "ingress-unavailable" });
+    });
+
+    it("outranks a busy short-circuit so an in-flight run cannot hide dead ingress", () => {
+      const evaluation = evaluateHealth(
+        connectedAccount({ ingressUnavailable: true, activeRuns: 1, lastRunActivityAt: 99_000 }),
+        { channelId: "slack" },
+      );
+      expect(evaluation).toEqual({ healthy: false, reason: "ingress-unavailable" });
+    });
+
+    it("keeps a quiet channel with no traffic and no ingress signal healthy", () => {
+      // Guards against a staleness heuristic sneaking in: a genuinely idle channel
+      // must never be restarted merely for having admitted nothing.
+      const evaluation = evaluateHealth(
+        connectedAccount({
+          lastStartAt: 0,
+          lastEventAt: 0,
+          lastInboundAt: null,
+          lastMessageAt: null,
+        }),
+        { now: 10_000_000, channelId: "slack" },
+      );
+      expect(evaluation).toEqual({ healthy: true, reason: "healthy" });
+    });
+
+    it("leaves the 17 socketless channels that publish no connectivity untouched", () => {
+      const evaluation = evaluateHealth(runningAccount({ lastStartAt: 0 }), {
+        now: 10_000_000,
+        channelId: "imessage",
+      });
+      expect(evaluation).toEqual({ healthy: true, reason: "healthy" });
+    });
+
+    it("stays healthy for a disabled account so unmanaged still wins", () => {
+      const evaluation = evaluateHealth({
+        running: false,
+        enabled: false,
+        configured: true,
+        ingressUnavailable: true,
+      });
+      expect(evaluation).toEqual({ healthy: true, reason: "unmanaged" });
+    });
+  });
 });
 
 describe("resolveChannelRestartReason", () => {

--- a/src/gateway/channel-health-policy.ts
+++ b/src/gateway/channel-health-policy.ts
@@ -75,16 +75,17 @@ export function evaluateChannelHealth(
   if (!snapshot.running && snapshot.terminalDisconnect) {
     return { healthy: false, reason: "terminal-disconnect" };
   }
-  if (!snapshot.running) {
-    return { healthy: false, reason: "not-running" };
-  }
   // Transport liveness and inbound admission are independent failure domains: a
-  // running channel can hold a healthy socket and still admit nothing, which every
-  // check below reads as healthy. Deliberately scoped to running accounts so a
-  // stopped one keeps its lifecycle reason and readiness keeps its restart-backoff
-  // grace. Absence is "unknown", never "fine" -- see ChannelAccountSnapshot.
+  // channel can hold a healthy socket and still admit nothing. This outranks the
+  // lifecycle windows below -- including not-running, which is the state a failed
+  // ingress start actually lands in -- so the cause survives instead of collapsing
+  // into a generic crash. Absence is "unknown", never "fine"; readiness owns its
+  // own restart-backoff tolerance in server/readiness.ts.
   if (snapshot.ingressUnavailable === true) {
     return { healthy: false, reason: "ingress-unavailable" };
+  }
+  if (!snapshot.running) {
+    return { healthy: false, reason: "not-running" };
   }
   const activeRuns =
     typeof snapshot.activeRuns === "number" && Number.isFinite(snapshot.activeRuns)

--- a/src/gateway/channel-health-policy.ts
+++ b/src/gateway/channel-health-policy.ts
@@ -19,6 +19,7 @@ type ChannelHealthSnapshot = {
   lastStartAt?: number | null;
   reconnectAttempts?: number;
   mode?: string;
+  ingressUnavailable?: true;
   terminalDisconnect?: boolean;
 };
 
@@ -31,7 +32,8 @@ type ChannelHealthEvaluationReason =
   | "stuck"
   | "startup-connect-grace"
   | "disconnected"
-  | "stale-socket";
+  | "stale-socket"
+  | "ingress-unavailable";
 
 export type ChannelHealthEvaluation = {
   healthy: boolean;
@@ -63,6 +65,14 @@ export function evaluateChannelHealth(
 ): ChannelHealthEvaluation {
   if (!isManagedAccount(snapshot)) {
     return { healthy: true, reason: "unmanaged" };
+  }
+  // Transport liveness and inbound admission are independent failure domains: a
+  // channel can hold a healthy socket and still admit nothing. This outranks every
+  // lifecycle window below because a channel that cannot receive is broken whether
+  // it is running, restarting, or inside its connect grace. Absence is "unknown",
+  // never "fine" -- see `ingressUnavailable` on ChannelAccountSnapshot.
+  if (snapshot.ingressUnavailable === true) {
+    return { healthy: false, reason: "ingress-unavailable" };
   }
   if (!snapshot.running && snapshot.terminalDisconnect) {
     return { healthy: false, reason: "terminal-disconnect" };

--- a/src/gateway/channel-health-policy.ts
+++ b/src/gateway/channel-health-policy.ts
@@ -47,7 +47,13 @@ export type ChannelHealthPolicy = {
   channelConnectGraceMs: number;
 };
 
-type ChannelRestartReason = "gave-up" | "stopped" | "stale-socket" | "stuck" | "disconnected";
+type ChannelRestartReason =
+  | "gave-up"
+  | "stopped"
+  | "stale-socket"
+  | "stuck"
+  | "disconnected"
+  | "ingress-unavailable";
 
 function isManagedAccount(snapshot: ChannelHealthSnapshot): boolean {
   return snapshot.enabled !== false && snapshot.configured !== false && snapshot.linked !== false;
@@ -163,6 +169,12 @@ export function resolveChannelRestartReason(
   // categories, while detailed channel state stays in the health snapshot.
   if (evaluation.reason === "stale-socket") {
     return "stale-socket";
+  }
+  // Restarting is also the only way to re-prove ingress: `ingressUnavailable`
+  // describes the last start attempt and is cleared by the next one. Naming the
+  // reason keeps a repeating restart readable as dead inbound rather than "stuck".
+  if (evaluation.reason === "ingress-unavailable") {
+    return "ingress-unavailable";
   }
   if (evaluation.reason === "not-running") {
     return snapshot.reconnectAttempts && snapshot.reconnectAttempts >= 10 ? "gave-up" : "stopped";

--- a/src/gateway/channel-health-policy.ts
+++ b/src/gateway/channel-health-policy.ts
@@ -72,19 +72,19 @@ export function evaluateChannelHealth(
   if (!isManagedAccount(snapshot)) {
     return { healthy: true, reason: "unmanaged" };
   }
-  // Transport liveness and inbound admission are independent failure domains: a
-  // channel can hold a healthy socket and still admit nothing. This outranks every
-  // lifecycle window below because a channel that cannot receive is broken whether
-  // it is running, restarting, or inside its connect grace. Absence is "unknown",
-  // never "fine" -- see `ingressUnavailable` on ChannelAccountSnapshot.
-  if (snapshot.ingressUnavailable === true) {
-    return { healthy: false, reason: "ingress-unavailable" };
-  }
   if (!snapshot.running && snapshot.terminalDisconnect) {
     return { healthy: false, reason: "terminal-disconnect" };
   }
   if (!snapshot.running) {
     return { healthy: false, reason: "not-running" };
+  }
+  // Transport liveness and inbound admission are independent failure domains: a
+  // running channel can hold a healthy socket and still admit nothing, which every
+  // check below reads as healthy. Deliberately scoped to running accounts so a
+  // stopped one keeps its lifecycle reason and readiness keeps its restart-backoff
+  // grace. Absence is "unknown", never "fine" -- see ChannelAccountSnapshot.
+  if (snapshot.ingressUnavailable === true) {
+    return { healthy: false, reason: "ingress-unavailable" };
   }
   const activeRuns =
     typeof snapshot.activeRuns === "number" && Number.isFinite(snapshot.activeRuns)

--- a/src/gateway/server-channels.test.ts
+++ b/src/gateway/server-channels.test.ts
@@ -361,8 +361,10 @@ describe("server-channels auto restart", () => {
       { stepMs: 10, maxMs: 500 },
     );
 
-    // Health must call this out as dead inbound rather than as one more crash.
-    expect(healthOf(readAccount())).toEqual({
+    // A stopped account keeps its lifecycle reason; the recorded dimension is what
+    // makes the running case call this out as dead inbound instead of healthy.
+    expect(healthOf(readAccount())).toEqual({ healthy: false, reason: "not-running" });
+    expect(healthOf({ ...readAccount(), accountId: DEFAULT_ACCOUNT_ID, running: true })).toEqual({
       healthy: false,
       reason: "ingress-unavailable",
     });

--- a/src/gateway/server-channels.test.ts
+++ b/src/gateway/server-channels.test.ts
@@ -361,10 +361,8 @@ describe("server-channels auto restart", () => {
       { stepMs: 10, maxMs: 500 },
     );
 
-    // A stopped account keeps its lifecycle reason; the recorded dimension is what
-    // makes the running case call this out as dead inbound instead of healthy.
-    expect(healthOf(readAccount())).toEqual({ healthy: false, reason: "not-running" });
-    expect(healthOf({ ...readAccount(), accountId: DEFAULT_ACCOUNT_ID, running: true })).toEqual({
+    // Health must name this dead inbound rather than one more anonymous crash.
+    expect(healthOf(readAccount())).toEqual({
       healthy: false,
       reason: "ingress-unavailable",
     });

--- a/src/gateway/server-channels.test.ts
+++ b/src/gateway/server-channels.test.ts
@@ -2,11 +2,16 @@
  * Server channel lifecycle tests.
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ChannelIngressUnavailableError } from "../channels/message/ingress-unavailable.js";
 import type {
   ChannelAccountLinkState,
   ChannelGatewayContext,
 } from "../channels/plugins/types.adapters.js";
-import type { ChannelId, ChannelPlugin } from "../channels/plugins/types.public.js";
+import type {
+  ChannelAccountSnapshot,
+  ChannelId,
+  ChannelPlugin,
+} from "../channels/plugins/types.public.js";
 import { formatGatewayChannelsStatusLines } from "../commands/channels/status.js";
 import type { GatewayNativeApprovalRuntime } from "../infra/approval-gateway-runtime.types.js";
 import {
@@ -87,6 +92,15 @@ const CHANNEL_APPROVAL_GATEWAY_RUNTIME_CONTEXT_CAPABILITY = "approval.gateway";
 type ApprovalGatewayRequestRuntime = Pick<GatewayNativeApprovalRuntime, "request">;
 
 const createdManagers: Array<{ manager: ChannelManager; channelIds: ChannelId[] }> = [];
+
+function healthOf(account: ChannelAccountSnapshot | undefined) {
+  return evaluateChannelHealth(account ?? {}, {
+    channelId: "discord",
+    now: Date.now() + 60 * 60_000,
+    channelConnectGraceMs: 120_000,
+    staleEventThresholdMs: 30 * 60_000,
+  });
+}
 
 function createTestPlugin(params?: {
   id?: ChannelId;
@@ -329,6 +343,62 @@ describe("server-channels auto restart", () => {
 
     await vi.advanceTimersByTimeAsync(200);
     expect(startAccount).toHaveBeenCalledTimes(11);
+  });
+
+  it("records dead ingress when a channel start fails to arm its ingress monitor", async () => {
+    const startAccount = vi.fn(async () => {
+      throw new ChannelIngressUnavailableError("Channel ingress queue is unavailable: denied");
+    });
+    installTestRegistry(createTestPlugin({ startAccount }));
+    const manager = createManager();
+
+    await manager.startChannels();
+    const readAccount = () =>
+      manager.getRuntimeSnapshot().channelAccounts.discord?.[DEFAULT_ACCOUNT_ID];
+    await advanceTimersUntil(
+      () => readAccount()?.ingressUnavailable === true,
+      "expected the failed ingress start to be recorded on the account",
+      { stepMs: 10, maxMs: 500 },
+    );
+
+    // Health must call this out as dead inbound rather than as one more crash.
+    expect(healthOf(readAccount())).toEqual({
+      healthy: false,
+      reason: "ingress-unavailable",
+    });
+  });
+
+  it("clears a previous lifecycle's dead-ingress verdict once ingress starts again", async () => {
+    let failIngress = true;
+    const startAccount = vi.fn(async () => {
+      if (failIngress) {
+        throw new ChannelIngressUnavailableError("Channel ingress queue is unavailable: denied");
+      }
+      await new Promise(() => {});
+    });
+    installTestRegistry(createTestPlugin({ startAccount }));
+    const manager = createManager();
+    const readAccount = () =>
+      manager.getRuntimeSnapshot().channelAccounts.discord?.[DEFAULT_ACCOUNT_ID];
+
+    await manager.startChannels();
+    await advanceTimersUntil(
+      () => readAccount()?.ingressUnavailable === true,
+      "expected the first start to record dead ingress",
+      { stepMs: 10, maxMs: 500 },
+    );
+
+    // Runtime rows are patch-merged, so a sticky verdict would keep the channel
+    // unhealthy forever after the operator fixed the underlying capability. The
+    // supervisor's own backoff ladder supplies the next start here.
+    failIngress = false;
+    await advanceTimersUntil(
+      () => readAccount()?.running === true && readAccount()?.ingressUnavailable === undefined,
+      "expected a later start to clear the dead-ingress verdict",
+      { stepMs: 10, maxMs: 500 },
+    );
+
+    expect(healthOf(readAccount()).reason).not.toBe("ingress-unavailable");
   });
 
   it("claims auto-restart ownership between crash-loop attempts", async () => {

--- a/src/gateway/server-channels.ts
+++ b/src/gateway/server-channels.ts
@@ -2,6 +2,7 @@
 // Starts, stops, restarts, and snapshots plugin channel account runtimes.
 import { RetrySupervisor } from "../../packages/retry/src/index.js";
 import { getCredentialUnavailableDiagnostics } from "../channels/account-snapshot-fields.js";
+import { isChannelIngressUnavailableError } from "../channels/message/ingress-unavailable.js";
 import { resolveChannelDefaultAccountId } from "../channels/plugins/helpers.js";
 import { type ChannelId, getChannelPlugin, listChannelPlugins } from "../channels/plugins/index.js";
 import type { ChannelAccountSnapshot } from "../channels/plugins/types.public.js";
@@ -709,6 +710,10 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
             restartPending: false,
             lastStartAt: Date.now(),
             lastError: null,
+            // Runtime rows are patch-merged, so a dead-ingress verdict from the
+            // previous lifecycle would outlive the condition it described. Every
+            // start re-proves ingress, so every start must clear it first.
+            ingressUnavailable: undefined,
             reconnectAttempts: preserveRestartAttempts ? (restarts.get(rKey)?.attempts ?? 0) : 0,
           });
           const task = Promise.resolve().then(async () => {
@@ -805,7 +810,14 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
                 return;
               }
               const message = formatErrorMessage(err);
-              setRuntime(channelId, id, { accountId: id, lastError: message });
+              setRuntime(channelId, id, {
+                accountId: id,
+                lastError: message,
+                // A channel that never armed its ingress admission is not "crashed":
+                // outbound may work fine while inbound is silently dead. Record the
+                // distinct dimension so health stops reading a live socket as healthy.
+                ...(isChannelIngressUnavailableError(err) ? { ingressUnavailable: true } : {}),
+              });
               log.error?.(`[${id}] channel exited: ${message}`);
             })
             .then(async () => {

--- a/src/gateway/server/readiness.test.ts
+++ b/src/gateway/server/readiness.test.ts
@@ -329,6 +329,60 @@ describe("createReadinessChecker", () => {
     });
   });
 
+  it("keeps a dead-ingress channel ready while its restart backoff is still pending", () => {
+    // The next start re-proves ingress, so this window gets the same grace as any
+    // other restart handoff rather than flapping readiness on every retry.
+    withReadinessClock(() => {
+      const startedAt = Date.now() - FIVE_MIN_MS;
+      const { readiness } = createReadinessHarness({
+        accounts: {
+          discord: managedAccount({
+            running: false,
+            restartPending: true,
+            ingressUnavailable: true,
+            reconnectAttempts: 3,
+            lastStartAt: startedAt - 30_000,
+            lastStopAt: Date.now() - 5_000,
+          }),
+        },
+      });
+      expect(readiness()).toEqual(readySnapshot());
+    });
+  });
+
+  it("fails readiness for dead ingress once the restart ladder stops retrying", () => {
+    withReadinessClock(() => {
+      const { readiness } = createReadinessHarness({
+        accounts: {
+          discord: managedAccount({
+            running: false,
+            restartPending: false,
+            ingressUnavailable: true,
+            reconnectAttempts: 11,
+          }),
+        },
+      });
+      expect(readiness()).toEqual(failingSnapshot(["discord"]));
+    });
+  });
+
+  it("fails readiness for a running channel whose transport is up but ingress is dead", () => {
+    withReadinessClock(() => {
+      const { readiness } = createReadinessHarness({
+        accounts: {
+          discord: managedAccount({
+            running: true,
+            connected: true,
+            restartPending: true,
+            ingressUnavailable: true,
+            lastStartAt: Date.now() - THIRTY_ONE_MIN_MS,
+          }),
+        },
+      });
+      expect(readiness()).toEqual(failingSnapshot(["discord"]));
+    });
+  });
+
   it("treats stale-socket channels as ready to avoid pulling healthy idle pods", () => {
     withReadinessClock(() => {
       const { readiness } = createLongRunningReadinessHarness({

--- a/src/gateway/server/readiness.ts
+++ b/src/gateway/server/readiness.ts
@@ -38,7 +38,16 @@ function shouldIgnoreReadinessFailure(
   // Channel restarts spend time in backoff with running=false before the next
   // lifecycle re-enters startup grace. Keep readiness green during that handoff
   // window, but still surface hard failures once restart attempts are exhausted.
-  return health.reason === "not-running" && accountSnapshot.restartPending === true;
+  // A failed ingress start lands in the same backoff window, so it gets the same
+  // grace: the next start re-proves ingress, and once the ladder stops setting
+  // restartPending the account stays red instead of hiding dead inbound.
+  const restartableReason =
+    health.reason === "not-running" || health.reason === "ingress-unavailable";
+  return (
+    restartableReason &&
+    accountSnapshot.restartPending === true &&
+    accountSnapshot.running !== true
+  );
 }
 
 /** Create a cached readiness checker over channel runtime health. */

--- a/src/gateway/server/readiness.ts
+++ b/src/gateway/server/readiness.ts
@@ -43,11 +43,9 @@ function shouldIgnoreReadinessFailure(
   // restartPending the account stays red instead of hiding dead inbound.
   const restartableReason =
     health.reason === "not-running" || health.reason === "ingress-unavailable";
-  return (
-    restartableReason &&
-    accountSnapshot.restartPending === true &&
-    accountSnapshot.running !== true
-  );
+  const inRestartHandoff =
+    accountSnapshot.restartPending === true && accountSnapshot.running !== true;
+  return restartableReason && inRestartHandoff;
 }
 
 /** Create a cached readiness checker over channel runtime health. */

--- a/src/infra/channels-status-issues.test.ts
+++ b/src/infra/channels-status-issues.test.ts
@@ -143,6 +143,37 @@ describe("collectChannelStatusIssues", () => {
     });
   });
 
+  it("reports dead ingress even while a restart is pending", () => {
+    mocks.listChannelPlugins.mockReturnValue([createPlugin("slack")]);
+
+    const issues = collectChannelStatusIssues({
+      channelAccounts: {
+        slack: [
+          {
+            accountId: "default",
+            enabled: true,
+            configured: true,
+            running: true,
+            connected: true,
+            restartPending: true,
+            ingressUnavailable: true,
+          },
+        ],
+      },
+    });
+
+    expect(issues).toEqual([
+      {
+        channel: "slack",
+        accountId: "default",
+        kind: "runtime",
+        message:
+          "Channel cannot admit inbound events; its durable ingress queue is unavailable. Outbound may still work.",
+        fix: "check openclaw logs for the ingress failure, then rerun openclaw doctor",
+      },
+    ]);
+  });
+
   it("keeps plugin-specific status issues while adding generic runtime issues", () => {
     const now = Date.now();
     vi.useFakeTimers();

--- a/src/infra/channels-status-issues.ts
+++ b/src/infra/channels-status-issues.ts
@@ -28,6 +28,20 @@ function collectGenericRuntimeStatusIssues(
       continue;
     }
     const accountId = resolveIssueAccountId(account);
+    // Dead ingress outranks the restart-pending short-circuit: a pending restart
+    // cannot fix a channel whose inbound admission is unavailable, and hiding it
+    // behind "status may be stale" is how silent inbound loss stays invisible.
+    if (account.ingressUnavailable === true) {
+      issues.push({
+        channel,
+        accountId,
+        kind: "runtime",
+        message:
+          "Channel cannot admit inbound events; its durable ingress queue is unavailable. Outbound may still work.",
+        fix: "check openclaw logs for the ingress failure, then rerun openclaw doctor",
+      });
+      continue;
+    }
     if (account.restartPending === true) {
       issues.push({
         channel,


### PR DESCRIPTION
Related: #114998, #114970

## What Problem This Solves

Resolves a problem where a channel that could not receive a single message still reported itself as connected and healthy.

Channel health was derived from the transport only. On a production gateway that hid **26+ hours of completely dead inbound Slack** behind `connected, bot:config, app:config, health:healthy`. Outbound kept working the whole time, which is exactly what kept the transport looking fine, and across the entire retained log not one inbound event was admitted. `openclaw channels status` showed nothing wrong, readiness stayed green, and the health monitor never touched the account because it evaluated as healthy.

Slack is the worst case but not a special case: it never publishes `lastTransportActivityAt`, so `evaluateChannelHealth`'s stale-socket check is skipped for it entirely. Nothing else in the health snapshot described inbound at all.

## Why This Change Was Made

Inbound admission is a **separate failure domain** from transport connectivity, so it gets its own health dimension rather than overloading `connected` — which is deliberately tri-state since #114970, with 17 of 27 channel plugins relying on "absent" meaning "no transport signal".

The shared ingress monitor now rethrows a typed `ChannelIngressUnavailableError` when it cannot open its durable queue (#114998 made that failure reach the caller; this makes it *classifiable*). The channel supervisor records it as `ingressUnavailable` on the account, and `evaluateChannelHealth` reports `ingress-unavailable`.

Deliberate boundaries:

- **Absence stays "unknown", never "fine".** The field is `ingressUnavailable?: true` — there is no `false` to collapse into a misleading negative, which is the mistake #114970 had to undo for `connected`. Channels that never report ingress are untouched.
- **No traffic-staleness heuristic.** A genuinely quiet channel must never look unhealthy for having received nothing, so time-since-last-event is not used as a signal. There is a regression test pinning this.
- **Recovery stays automatic, and no new restart loop is introduced.** An earlier revision of this PR suppressed health-monitor restarts for this reason; review caught that it latches a transient queue-open failure into a permanent outage, because the verdict is only cleared by a later start that would then never happen. The restart path is also the recovery path, so it is left alone — it just now logs `reason: ingress-unavailable` instead of the generic `stuck`. The existing `isAutoRestartScheduled` guard still keeps the supervisor the single restart owner during its backoff ladder.
- **Readiness keeps its documented backoff grace,** extended to the ingress reason in `readiness.ts` where that policy already lives, so a retrying channel does not flap readiness. Once the ladder stops setting `restartPending`, the account stays red rather than hiding dead inbound.

Non-goals: no config surface, no protocol change (the account snapshot schema is intentionally schema-light and `additionalProperties: true`), no channel-subsystem refactor.

## User Impact

Operators can now see, and be alerted to, a channel that is silently unable to receive:

- `openclaw channels status` reports `Channel cannot admit inbound events; its durable ingress queue is unavailable. Outbound may still work.`
- The account is unhealthy instead of healthy, and gateway readiness reports it as failing once it stops retrying.
- Health-monitor restarts for this cause name it (`health-monitor: restarting (reason: ingress-unavailable)`), so a repeating restart is readable as dead inbound rather than an anonymous crash.

Channels that do not report ingress state, and quiet channels with no traffic, behave exactly as before.

## Evidence

Focused tests and the changed gate, on Blacksmith Testbox (this worktree has no usable local `node_modules`):

```
pnpm test src/gateway/channel-health-policy.test.ts \
          src/gateway/channel-health-monitor.test.ts \
          src/gateway/server-channels.test.ts \
          src/channels/message/ingress-monitor.test.ts \
          src/infra/channels-status-issues.test.ts \
          src/gateway/server/readiness.test.ts
CI=1 pnpm check:changed
```

New regression coverage, per the two behaviors that matter most:

- `channel-health-policy.test.ts` — a channel with a live transport and dead ingress is unhealthy; **a quiet channel with no traffic and no ingress signal stays healthy**; socketless channels publishing no connectivity are untouched; the ingress reason survives the stopped state a failed start actually lands in.
- `server-channels.test.ts` — the supervisor records the verdict from a typed start failure, and **clears it on the next start** so a repaired failure does not stay latched.
- `readiness.test.ts` — green during restart backoff, red once retries stop, red for a running-but-dead-ingress account.
- `ingress-monitor.test.ts` — `start()` throws the typed error with the original denial as `cause`, and the guard still matches when a plugin wraps it.

At the current head the six suites report **203 tests passed across 6 files**, and `check:changed` is green (conflict markers, env ratchet, max-lines ratchet, changelog attributions, wildcard re-exports, duplicate scan coverage, dependency pin, format). A targeted `-t ingress` run confirmed the new tests actually execute rather than filtering to a zero-test pass.

Codex autoreview (`gpt-5.6-sol`, high) ran to clean. Two of its findings materially changed the design and are described under "Why This Change Was Made".

### Unrelated CI failure, resolved by rebase

An earlier head hit `checks-node-compact-large-4` failing on three `ui/src/pages/config/config-page.test.ts` redirect assertions, which this PR does not touch. Root cause was a cross-file state leak: `ui/src/pages/agents/panels-tools-skills.browser.test.ts` clicks a real `<a href="#agent-tool-read">` and never restored `location.hash`, and shards run with `isolate=false`, so whichever sibling file asserted on the hash next failed depending on shard packing. #115221 landed a file-wide `afterEach` URL reset that fixes it at the polluter, so this branch simply rebases onto it and carries no UI change.

### Known gap, filed separately

`extensions/nostr/src/nostr-ingress.ts:187-194` swallows its own ingress start failure into `options.onError` instead of letting it propagate, so nostr is the one channel of 21 that will still report healthy with dead inbound. Every other durable-ingress channel propagates. Fixing it is a plugin-owner behavior change and is tracked separately, along with a resource leak this work surfaced: `extensions/slack/src/monitor/provider.ts:578` arms ingress outside the `try` that owns teardown, so a throwing ingress start leaks the Bolt app, HTTP handler and undici dispatcher (`extensions/feishu/src/monitor.account.ts:564` has the same shape).
