### PR TITLE
fix(process): keep long-running commands alive across oversized timeouts

### DIFF
--- a/src/process/supervisor/supervisor.timeout-overflow.test.ts
+++ b/src/process/supervisor/supervisor.timeout-overflow.test.ts
@@ -1,0 +1,238 @@
+// Oversized process deadlines must never wrap into immediate Node timers.
+import { performance } from "node:perf_hooks";
+import { MAX_TIMER_TIMEOUT_MS } from "@openclaw/normalization-core/number-coercion";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../test-utils/deferred.js";
+import { createProcessSupervisor } from "./supervisor.js";
+import type { SpawnProcessAdapter } from "./types.js";
+
+const { createChildAdapterMock, createPtyAdapterMock } = vi.hoisted(() => ({
+  createChildAdapterMock: vi.fn(),
+  createPtyAdapterMock: vi.fn(),
+}));
+
+vi.mock("./adapters/child.js", () => ({
+  createChildAdapter: createChildAdapterMock,
+}));
+
+vi.mock("./adapters/pty.js", () => ({
+  createPtyAdapter: createPtyAdapterMock,
+}));
+
+type TimeoutTestAdapter = SpawnProcessAdapter<NodeJS.Signals | null> & {
+  emitStdout: (chunk: string) => void;
+  killMock: ReturnType<typeof vi.fn>;
+  disposeMock: ReturnType<typeof vi.fn>;
+  settle: () => void;
+};
+
+function createTimeoutTestAdapter(): TimeoutTestAdapter {
+  const completion = createDeferred<{ code: number | null; signal: NodeJS.Signals | null }>();
+  let stdoutListener: ((chunk: string) => void) | undefined;
+  const killMock = vi.fn((signal?: NodeJS.Signals) => {
+    completion.resolve({ code: null, signal: signal ?? null });
+  });
+  const disposeMock = vi.fn();
+
+  return {
+    pid: 1234,
+    onStdout: (listener) => {
+      stdoutListener = listener;
+    },
+    onStderr: () => undefined,
+    wait: async () => completion.promise,
+    kill: killMock,
+    dispose: disposeMock,
+    emitStdout: (chunk) => stdoutListener?.(chunk),
+    killMock,
+    disposeMock,
+    settle: () => completion.resolve({ code: 0, signal: null }),
+  };
+}
+
+const oversizedTimeouts = [
+  { durationName: "the first overflowing Node delay", durationMs: 2 ** 31 },
+  { durationName: "the maximum safe integer", durationMs: Number.MAX_SAFE_INTEGER },
+] as const;
+
+const deadlineCases = [
+  {
+    deadlineName: "overall deadline",
+    timeoutField: "timeoutMs",
+    reason: "overall-timeout",
+    refreshOutput: false,
+  },
+  {
+    deadlineName: "silent-output deadline",
+    timeoutField: "noOutputTimeoutMs",
+    reason: "no-output-timeout",
+    refreshOutput: false,
+  },
+  {
+    deadlineName: "refreshed output deadline",
+    timeoutField: "noOutputTimeoutMs",
+    reason: "no-output-timeout",
+    refreshOutput: true,
+  },
+] as const;
+
+describe("process supervisor oversized timer deadlines", () => {
+  beforeEach(() => {
+    createChildAdapterMock.mockReset();
+    createPtyAdapterMock.mockReset();
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.clearAllTimers();
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  for (const mode of ["child", "pty"] as const) {
+    describe(`${mode} processes`, () => {
+      for (const { durationName, durationMs } of oversizedTimeouts) {
+        describe(durationName, () => {
+          it.each(deadlineCases)(
+            "bounds the $deadlineName",
+            async ({ timeoutField, reason, refreshOutput }) => {
+              const adapter = createTimeoutTestAdapter();
+              const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout");
+              const adapterMock = mode === "child" ? createChildAdapterMock : createPtyAdapterMock;
+              adapterMock.mockResolvedValue(adapter);
+
+              const supervisor = createProcessSupervisor();
+              const commonInput = {
+                backendId: "test",
+                sessionId: `timeout-overflow-${mode}`,
+                [timeoutField]: durationMs,
+              };
+              const run = await supervisor.spawn(
+                mode === "child"
+                  ? { ...commonInput, mode: "child", argv: [process.execPath, "-e", ""] }
+                  : { ...commonInput, mode: "pty", ptyCommand: "printf running" },
+              );
+
+              try {
+                expect(setTimeoutSpy.mock.calls.map(([, delay]) => delay)).toEqual([
+                  MAX_TIMER_TIMEOUT_MS,
+                ]);
+
+                await vi.advanceTimersByTimeAsync(1);
+                expect(adapter.killMock).not.toHaveBeenCalled();
+
+                if (refreshOutput) {
+                  adapter.emitStdout("still running");
+                  expect(setTimeoutSpy.mock.calls.map(([, delay]) => delay)).toEqual([
+                    MAX_TIMER_TIMEOUT_MS,
+                    MAX_TIMER_TIMEOUT_MS,
+                  ]);
+                }
+
+                await vi.advanceTimersByTimeAsync(
+                  refreshOutput ? MAX_TIMER_TIMEOUT_MS - 1 : MAX_TIMER_TIMEOUT_MS - 2,
+                );
+                expect(adapter.killMock).not.toHaveBeenCalled();
+
+                await vi.advanceTimersByTimeAsync(1);
+                expect(adapter.killMock).not.toHaveBeenCalled();
+
+                const remainingIntervalMs = Math.min(
+                  durationMs - MAX_TIMER_TIMEOUT_MS,
+                  MAX_TIMER_TIMEOUT_MS,
+                );
+                expect(setTimeoutSpy.mock.calls.map(([, delay]) => delay)).toEqual(
+                  refreshOutput
+                    ? [MAX_TIMER_TIMEOUT_MS, MAX_TIMER_TIMEOUT_MS, remainingIntervalMs]
+                    : [MAX_TIMER_TIMEOUT_MS, remainingIntervalMs],
+                );
+
+                if (durationMs === Number.MAX_SAFE_INTEGER) {
+                  adapter.settle();
+                  await expect(run.wait()).resolves.toMatchObject({
+                    reason: "exit",
+                    timedOut: false,
+                    noOutputTimedOut: false,
+                  });
+                  expect(adapter.killMock).not.toHaveBeenCalled();
+                  expect(adapter.disposeMock).toHaveBeenCalledTimes(1);
+                  expect(vi.getTimerCount()).toBe(0);
+                  return;
+                }
+
+                await vi.advanceTimersByTimeAsync(remainingIntervalMs - 1);
+                expect(adapter.killMock).not.toHaveBeenCalled();
+                await vi.advanceTimersByTimeAsync(1);
+                await expect(run.wait()).resolves.toMatchObject({
+                  reason,
+                  timedOut: true,
+                  noOutputTimedOut: reason === "no-output-timeout",
+                });
+                expect(adapter.killMock).toHaveBeenCalledTimes(1);
+                expect(adapter.disposeMock).toHaveBeenCalledTimes(1);
+                expect(vi.getTimerCount()).toBe(0);
+              } finally {
+                adapter.settle();
+                await run.wait();
+              }
+            },
+          );
+        });
+      }
+
+      it.each(deadlineCases)(
+        "preserves the $deadlineName when an intermediate timer fires late",
+        async ({ timeoutField, reason, refreshOutput }) => {
+          const initialNowMs = 1_000;
+          const trailingDurationMs = 10 * 60_000;
+          const callbackLatenessMs = 9 * 60_000;
+          const nowSpy = vi.spyOn(performance, "now").mockReturnValue(initialNowMs);
+          const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout");
+          const adapter = createTimeoutTestAdapter();
+          const adapterMock = mode === "child" ? createChildAdapterMock : createPtyAdapterMock;
+          adapterMock.mockResolvedValue(adapter);
+
+          const commonInput = {
+            backendId: "test",
+            sessionId: `late-timeout-${mode}`,
+            [timeoutField]: MAX_TIMER_TIMEOUT_MS + trailingDurationMs,
+          };
+          const run = await createProcessSupervisor().spawn(
+            mode === "child"
+              ? { ...commonInput, mode: "child", argv: [process.execPath, "-e", ""] }
+              : { ...commonInput, mode: "pty", ptyCommand: "printf running" },
+          );
+
+          try {
+            if (refreshOutput) {
+              adapter.emitStdout("still running");
+            }
+
+            nowSpy.mockReturnValue(initialNowMs + MAX_TIMER_TIMEOUT_MS + callbackLatenessMs);
+            await vi.advanceTimersByTimeAsync(MAX_TIMER_TIMEOUT_MS);
+            expect(adapter.killMock).not.toHaveBeenCalled();
+            expect(setTimeoutSpy.mock.calls.map(([, delay]) => delay)).toEqual(
+              refreshOutput
+                ? [MAX_TIMER_TIMEOUT_MS, MAX_TIMER_TIMEOUT_MS, 60_000]
+                : [MAX_TIMER_TIMEOUT_MS, 60_000],
+            );
+
+            nowSpy.mockReturnValue(initialNowMs + MAX_TIMER_TIMEOUT_MS + trailingDurationMs);
+            await vi.advanceTimersByTimeAsync(60_000);
+            await expect(run.wait()).resolves.toMatchObject({
+              reason,
+              timedOut: true,
+              noOutputTimedOut: reason === "no-output-timeout",
+            });
+            expect(adapter.killMock).toHaveBeenCalledTimes(1);
+            expect(adapter.disposeMock).toHaveBeenCalledTimes(1);
+            expect(vi.getTimerCount()).toBe(0);
+          } finally {
+            adapter.settle();
+            await run.wait();
+          }
+        },
+      );
+    });
+  }
+});

--- a/src/process/supervisor/supervisor.ts
+++ b/src/process/supervisor/supervisor.ts
@@ -2,6 +2,7 @@
 import crypto from "node:crypto";
 import { performance } from "node:perf_hooks";
 import { expectDefined } from "@openclaw/normalization-core";
+import { resolveTimerTimeoutMs } from "@openclaw/normalization-core/number-coercion";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { sliceUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import { getShellConfig } from "../../agents/shell-utils.js";
@@ -41,7 +42,7 @@ const loadSupervisorLogRuntime = createLazyRuntimeModule(
   () => import("./supervisor-log.runtime.js"),
 );
 
-function clampTimeout(value?: number): number | undefined {
+function normalizeTimeoutDuration(value?: number): number | undefined {
   if (typeof value !== "number" || !Number.isFinite(value) || value <= 0) {
     return undefined;
   }
@@ -217,8 +218,8 @@ export function createProcessSupervisor(): ProcessSupervisor {
     const captureOutput = input.captureOutput !== false;
     const maxCapturedOutputChars = clampCapturedOutputChars(input.maxCapturedOutputChars);
 
-    const overallTimeoutMs = clampTimeout(input.timeoutMs);
-    const noOutputTimeoutMs = clampTimeout(input.noOutputTimeoutMs);
+    const overallTimeoutMs = normalizeTimeoutDuration(input.timeoutMs);
+    const noOutputTimeoutMs = normalizeTimeoutDuration(input.noOutputTimeoutMs);
     let overallTimeoutDeadlineMs: number | null = null;
     let noOutputTimeoutDeadlineMs: number | null = null;
 
@@ -238,6 +239,32 @@ export function createProcessSupervisor(): ProcessSupervisor {
     };
     startingRun.cancel = requestCancel;
 
+    // Node timers cannot hold the full duration of a long-running deadline.
+    // Re-arm bounded intervals so the requested deadline is never shortened.
+    const scheduleTimeout = (
+      reason: "overall-timeout" | "no-output-timeout",
+      remainingMs: number,
+      deadlineMs: number,
+    ): NodeJS.Timeout => {
+      const intervalMs = resolveTimerTimeoutMs(remainingMs, 1);
+      return setTimeout(() => {
+        if (settled) {
+          return;
+        }
+        const nextRemainingMs = Math.min(remainingMs - intervalMs, deadlineMs - performance.now());
+        if (nextRemainingMs <= 0) {
+          requestCancel(reason);
+          return;
+        }
+        const nextTimer = scheduleTimeout(reason, nextRemainingMs, deadlineMs);
+        if (reason === "overall-timeout") {
+          timeoutTimer = nextTimer;
+        } else {
+          noOutputTimer = nextTimer;
+        }
+      }, intervalMs);
+    };
+
     const touchOutput = () => {
       registry.touchOutput(runId);
       if (!noOutputTimeoutMs || settled) {
@@ -247,9 +274,11 @@ export function createProcessSupervisor(): ProcessSupervisor {
       if (noOutputTimer) {
         clearTimeout(noOutputTimer);
       }
-      noOutputTimer = setTimeout(() => {
-        requestCancel("no-output-timeout");
-      }, noOutputTimeoutMs);
+      noOutputTimer = scheduleTimeout(
+        "no-output-timeout",
+        noOutputTimeoutMs,
+        noOutputTimeoutDeadlineMs,
+      );
     };
 
     try {
@@ -327,15 +356,19 @@ export function createProcessSupervisor(): ProcessSupervisor {
 
       if (overallTimeoutMs) {
         overallTimeoutDeadlineMs = performance.now() + overallTimeoutMs;
-        timeoutTimer = setTimeout(() => {
-          requestCancel("overall-timeout");
-        }, overallTimeoutMs);
+        timeoutTimer = scheduleTimeout(
+          "overall-timeout",
+          overallTimeoutMs,
+          overallTimeoutDeadlineMs,
+        );
       }
       if (noOutputTimeoutMs) {
         noOutputTimeoutDeadlineMs = performance.now() + noOutputTimeoutMs;
-        noOutputTimer = setTimeout(() => {
-          requestCancel("no-output-timeout");
-        }, noOutputTimeoutMs);
+        noOutputTimer = scheduleTimeout(
+          "no-output-timeout",
+          noOutputTimeoutMs,
+          noOutputTimeoutDeadlineMs,
+        );
       }
 
       adapter.onStdout((chunk) => {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users running a long-lived supervised command, PTY session, CLI task, or scheduled command could have an otherwise healthy process terminated almost immediately when its overall or no-output timeout exceeded Node's maximum timer delay. Initial and output-refreshed watchdogs were both affected.

## Why This Change Was Made

Keep each requested logical deadline intact and schedule it in bounded intervals through OpenClaw's existing timer-normalization contract. Recompute each interval against the absolute deadline so a delayed event-loop callback cannot extend the timeout. Child and PTY adapters, cancellation, cleanup, and normal short timeouts continue through their existing supervisor-owned path.

## User Impact

Long-running commands and sessions no longer time out after approximately one millisecond when configured with a legitimate large timeout. The complete requested deadline remains intact, even if an intermediate timer fires late.

## Evidence

This change is AI-assisted and independently reviewed. No private session transcript is included.

Actual before-fix output on clean `main`:

```text
pnpm test src/process/supervisor/supervisor.timeout-overflow.test.ts
Test Files  1 failed (1)
     Tests  12 failed (12)

AssertionError: expected [ 2147483648 ] to deeply equal [ 2147000000 ]
AssertionError: expected [ 9007199254740991 ] to deeply equal [ 2147000000 ]
```

Actual final output:

```text
pnpm test src/process/supervisor/supervisor.timeout-overflow.test.ts
Test Files  1 passed (1)
     Tests  18 passed (18)

Cross-subsystem tests: 237 passed across 13 files and 5 Vitest shards.
Repeated final stress: 20/20 iterations; 360/360 checks passed.
pnpm check:changed -- src/process/supervisor/supervisor.ts src/process/supervisor/supervisor.timeout-overflow.test.ts
Result: PASS (core and test typechecks, lint, format, architecture, import cycles,
dependencies, schema, and repository guards).
autoreview --mode uncommitted
Result: no findings; patch is correct.
```

Linux remote proof: Blacksmith Testbox `tbx_01kymdztmeffd3kgx8d7dpvmt5`. Clean rebase preserved reviewed green stable patch identity `83374fb8bce3cb1a2dfaf4c7acec742f0d298304`.