### PR TITLE
fix: schema-version refusal blames a downgrade that never happened and cannot identify the stale install

### DIFF
--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/ExecApprovalsLegacyMigrationGate.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/ExecApprovalsLegacyMigrationGate.swift
@@ -30,17 +30,13 @@ enum ExecApprovalsLegacyMigrationGate {
                     NSLocalizedDescriptionKey:
                         "Legacy exec approvals exist at \(sourceURL.path). " +
                         // Doctor repairs whichever state directory its own environment resolves to,
-                        // and an app store never shares the CLI's default root, so always scope the
-                        // command; a bare `doctor --fix` would repair a different directory.
-                        "Run `OPENCLAW_STATE_DIR=\(self.shellQuoted(stateDirectoryURL.path)) " +
-                        "openclaw doctor --fix` before using exec approvals.",
+                        // and an app store never shares the CLI's default root, so always name the
+                        // directory; a bare `doctor --fix` would repair a different one. Prose,
+                        // not a `VAR=value cmd` one-liner, so the path needs no shell quoting.
+                        "Run `openclaw doctor --fix` with OPENCLAW_STATE_DIR set to " +
+                        "\(stateDirectoryURL.path) before using exec approvals.",
                 ])
         }
-    }
-
-    /// POSIX single-quote so an app state directory under `Application Support` stays one shell word.
-    private static func shellQuoted(_ value: String) -> String {
-        "'" + value.replacingOccurrences(of: "'", with: "'\\''") + "'"
     }
 
     private static func pathMayExist(_ url: URL) -> Bool {

--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/ExecApprovalsLegacyMigrationGate.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/ExecApprovalsLegacyMigrationGate.swift
@@ -29,25 +29,13 @@ enum ExecApprovalsLegacyMigrationGate {
                 userInfo: [
                     NSLocalizedDescriptionKey:
                         "Legacy exec approvals exist at \(sourceURL.path). " +
-                        "Run `\(self.doctorFixCommand(stateDirectoryURL: stateDirectoryURL))` " +
+                        // Doctor repairs whichever state directory its own environment resolves to,
+                        // and an app store never shares the CLI's default root, so always scope the
+                        // command; a bare `doctor --fix` would repair a different directory.
+                        "Run `OPENCLAW_STATE_DIR=\(stateDirectoryURL.path) openclaw doctor --fix` " +
                         "before using exec approvals.",
                 ])
         }
-    }
-
-    /// Doctor repairs whichever state directory its own environment resolves to, so a bare
-    /// `openclaw doctor --fix` repairs the default root while a scoped install stays blocked.
-    /// Name the directory whenever this store is scoped to a non-default one.
-    private static func doctorFixCommand(stateDirectoryURL: URL) -> String {
-        let defaultStateDirectory = FileManager.default.homeDirectoryForCurrentUser
-            .appendingPathComponent(".openclaw", isDirectory: true)
-        guard
-            stateDirectoryURL.standardizedFileURL.path != defaultStateDirectory.standardizedFileURL
-                .path
-        else {
-            return "openclaw doctor --fix"
-        }
-        return "OPENCLAW_STATE_DIR=\(stateDirectoryURL.path) openclaw doctor --fix"
     }
 
     private static func pathMayExist(_ url: URL) -> Bool {

--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/ExecApprovalsLegacyMigrationGate.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/ExecApprovalsLegacyMigrationGate.swift
@@ -32,10 +32,15 @@ enum ExecApprovalsLegacyMigrationGate {
                         // Doctor repairs whichever state directory its own environment resolves to,
                         // and an app store never shares the CLI's default root, so always scope the
                         // command; a bare `doctor --fix` would repair a different directory.
-                        "Run `OPENCLAW_STATE_DIR=\(stateDirectoryURL.path) openclaw doctor --fix` " +
-                        "before using exec approvals.",
+                        "Run `OPENCLAW_STATE_DIR=\(self.shellQuoted(stateDirectoryURL.path)) " +
+                        "openclaw doctor --fix` before using exec approvals.",
                 ])
         }
+    }
+
+    /// POSIX single-quote so an app state directory under `Application Support` stays one shell word.
+    private static func shellQuoted(_ value: String) -> String {
+        "'" + value.replacingOccurrences(of: "'", with: "'\\''") + "'"
     }
 
     private static func pathMayExist(_ url: URL) -> Bool {

--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/ExecApprovalsLegacyMigrationGate.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/ExecApprovalsLegacyMigrationGate.swift
@@ -29,9 +29,25 @@ enum ExecApprovalsLegacyMigrationGate {
                 userInfo: [
                     NSLocalizedDescriptionKey:
                         "Legacy exec approvals exist at \(sourceURL.path). " +
-                        "Run `openclaw doctor --fix` before using exec approvals.",
+                        "Run `\(self.doctorFixCommand(stateDirectoryURL: stateDirectoryURL))` " +
+                        "before using exec approvals.",
                 ])
         }
+    }
+
+    /// Doctor repairs whichever state directory its own environment resolves to, so a bare
+    /// `openclaw doctor --fix` repairs the default root while a scoped install stays blocked.
+    /// Name the directory whenever this store is scoped to a non-default one.
+    private static func doctorFixCommand(stateDirectoryURL: URL) -> String {
+        let defaultStateDirectory = FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent(".openclaw", isDirectory: true)
+        guard
+            stateDirectoryURL.standardizedFileURL.path != defaultStateDirectory.standardizedFileURL
+                .path
+        else {
+            return "openclaw doctor --fix"
+        }
+        return "OPENCLAW_STATE_DIR=\(stateDirectoryURL.path) openclaw doctor --fix"
     }
 
     private static func pathMayExist(_ url: URL) -> Bool {

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ExecApprovalsSQLiteStoreTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ExecApprovalsSQLiteStoreTests.swift
@@ -213,7 +213,10 @@ struct ExecApprovalsSQLiteStoreTests {
                 _ = try ExecApprovalsSQLiteStore.read(stateDirectoryURL: stateDirectoryURL)
                 Issue.record("Expected pending legacy approvals to refuse SQLite access")
             } catch {
-                #expect(error.localizedDescription.contains("Run `openclaw doctor --fix`"))
+                // A scoped state directory must be named; a bare command repairs the default root.
+                #expect(
+                    error.localizedDescription.contains(
+                        "Run `OPENCLAW_STATE_DIR=\(stateDirectoryURL.path) openclaw doctor --fix`"))
             }
         }
     }

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ExecApprovalsSQLiteStoreTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ExecApprovalsSQLiteStoreTests.swift
@@ -213,10 +213,11 @@ struct ExecApprovalsSQLiteStoreTests {
                 _ = try ExecApprovalsSQLiteStore.read(stateDirectoryURL: stateDirectoryURL)
                 Issue.record("Expected pending legacy approvals to refuse SQLite access")
             } catch {
-                // A scoped state directory must be named; a bare command repairs the default root.
+                // A scoped state directory must be named, and quoted so a path containing
+                // spaces stays one shell word; a bare command repairs the default root.
                 #expect(
                     error.localizedDescription.contains(
-                        "Run `OPENCLAW_STATE_DIR=\(stateDirectoryURL.path) openclaw doctor --fix`"))
+                        "Run `OPENCLAW_STATE_DIR='\(stateDirectoryURL.path)' openclaw doctor --fix`"))
             }
         }
     }

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ExecApprovalsSQLiteStoreTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ExecApprovalsSQLiteStoreTests.swift
@@ -213,11 +213,12 @@ struct ExecApprovalsSQLiteStoreTests {
                 _ = try ExecApprovalsSQLiteStore.read(stateDirectoryURL: stateDirectoryURL)
                 Issue.record("Expected pending legacy approvals to refuse SQLite access")
             } catch {
-                // A scoped state directory must be named, and quoted so a path containing
-                // spaces stays one shell word; a bare command repairs the default root.
+                // The blocked state directory must be named; a bare command repairs the
+                // default root, and an app store never shares the CLI's default root.
                 #expect(
                     error.localizedDescription.contains(
-                        "Run `OPENCLAW_STATE_DIR='\(stateDirectoryURL.path)' openclaw doctor --fix`"))
+                        "Run `openclaw doctor --fix` with OPENCLAW_STATE_DIR set to "
+                            + stateDirectoryURL.path))
             }
         }
     }

--- a/docs/reference/database-schemas.md
+++ b/docs/reference/database-schemas.md
@@ -82,7 +82,13 @@ Since 2026.7.2, `openclaw update` refuses to install a release that cannot open 
 
 ### The Gateway refuses to start with a newer schema version error
 
-A newer OpenClaw build wrote your databases, and the running build is older. The error and the Gateway startup log name the build that owns the database (`app_version`). Install that version or newer, or use one of the options above. Do not edit the database to silence the error.
+A newer OpenClaw build wrote your databases, and the running build is older. The error names the refusing install — release version, commit, and install root — plus the schema it supports and the schema it found.
+
+Act on the install root, not the version. One release version string spans many `main` commits and several schema levels, so two installs can both call themselves `2026.7.2` and support different schemas. A prerelease version may not exist on the `latest` npm tag at all: check `npm view openclaw dist-tags` before reinstalling, because the tag carrying the schema you need may be `beta`, and reinstalling from `latest` can move you further away.
+
+A linked source checkout is the case where the commit misleads: `openclaw --version` reports the checkout's git HEAD, but the code actually executing is whatever `dist/` was last built. If the install root is a checkout, rebuild it (`pnpm build`) before concluding the version is wrong.
+
+Open the database with a build that supports its schema, or point the older build at a separate `OPENCLAW_STATE_DIR`. Do not edit the database to silence the error.
 
 ### A database is quarantined after integrity verification failed
 

--- a/src/infra/exec-approvals-migration-gate.ts
+++ b/src/infra/exec-approvals-migration-gate.ts
@@ -6,26 +6,23 @@ import { resolveExecApprovalsPath } from "./exec-approvals-config.js";
 const DOCTOR_CLAIM_SUFFIX = ".doctor-importing";
 const legacyPresenceCache = new Map<string, boolean>();
 
-/** POSIX single-quote so a state directory containing spaces stays one shell word. */
-function shellQuoteStateDir(stateDir: string): string {
-  return `'${stateDir.replaceAll("'", "'\\''")}'`;
-}
-
 /**
  * Doctor repairs whichever state directory its own environment resolves to, so a bare
  * `openclaw doctor --fix` repairs the default root while a scoped install stays blocked.
- * Name the directory whenever this process is scoped to a non-default one.
+ * Name the directory whenever this process is scoped to a non-default one. Say it in
+ * prose rather than as a `VAR=value cmd` one-liner, which no Windows shell accepts.
  */
-function formatDoctorFixCommand(filePath: string): string {
+function doctorFixInstruction(filePath: string): string {
+  const command = "Run `openclaw doctor --fix`";
   return process.env.OPENCLAW_STATE_DIR?.trim()
-    ? `OPENCLAW_STATE_DIR=${shellQuoteStateDir(path.dirname(filePath))} openclaw doctor --fix`
-    : "openclaw doctor --fix";
+    ? `${command} with OPENCLAW_STATE_DIR set to ${path.dirname(filePath)}`
+    : command;
 }
 
 export class ExecApprovalsMigrationRequiredError extends Error {
   constructor(filePath: string) {
     super(
-      `Legacy exec approvals exist at ${filePath}. Run \`${formatDoctorFixCommand(filePath)}\` before using exec approvals.`,
+      `Legacy exec approvals exist at ${filePath}. ${doctorFixInstruction(filePath)} before using exec approvals.`,
     );
     this.name = "ExecApprovalsMigrationRequiredError";
   }

--- a/src/infra/exec-approvals-migration-gate.ts
+++ b/src/infra/exec-approvals-migration-gate.ts
@@ -6,6 +6,11 @@ import { resolveExecApprovalsPath } from "./exec-approvals-config.js";
 const DOCTOR_CLAIM_SUFFIX = ".doctor-importing";
 const legacyPresenceCache = new Map<string, boolean>();
 
+/** POSIX single-quote so a state directory containing spaces stays one shell word. */
+function shellQuoteStateDir(stateDir: string): string {
+  return `'${stateDir.replaceAll("'", "'\\''")}'`;
+}
+
 /**
  * Doctor repairs whichever state directory its own environment resolves to, so a bare
  * `openclaw doctor --fix` repairs the default root while a scoped install stays blocked.
@@ -13,7 +18,7 @@ const legacyPresenceCache = new Map<string, boolean>();
  */
 function formatDoctorFixCommand(filePath: string): string {
   return process.env.OPENCLAW_STATE_DIR?.trim()
-    ? `OPENCLAW_STATE_DIR=${path.dirname(filePath)} openclaw doctor --fix`
+    ? `OPENCLAW_STATE_DIR=${shellQuoteStateDir(path.dirname(filePath))} openclaw doctor --fix`
     : "openclaw doctor --fix";
 }
 

--- a/src/infra/exec-approvals-migration-gate.ts
+++ b/src/infra/exec-approvals-migration-gate.ts
@@ -1,14 +1,26 @@
 // Blocks runtime use while retired exec approval state still awaits Doctor import.
 import fs from "node:fs";
+import path from "node:path";
 import { resolveExecApprovalsPath } from "./exec-approvals-config.js";
 
 const DOCTOR_CLAIM_SUFFIX = ".doctor-importing";
 const legacyPresenceCache = new Map<string, boolean>();
 
+/**
+ * Doctor repairs whichever state directory its own environment resolves to, so a bare
+ * `openclaw doctor --fix` repairs the default root while a scoped install stays blocked.
+ * Name the directory whenever this process is scoped to a non-default one.
+ */
+function formatDoctorFixCommand(filePath: string): string {
+  return process.env.OPENCLAW_STATE_DIR?.trim()
+    ? `OPENCLAW_STATE_DIR=${path.dirname(filePath)} openclaw doctor --fix`
+    : "openclaw doctor --fix";
+}
+
 export class ExecApprovalsMigrationRequiredError extends Error {
   constructor(filePath: string) {
     super(
-      `Legacy exec approvals exist at ${filePath}. Run \`openclaw doctor --fix\` before using exec approvals.`,
+      `Legacy exec approvals exist at ${filePath}. Run \`${formatDoctorFixCommand(filePath)}\` before using exec approvals.`,
     );
     this.name = "ExecApprovalsMigrationRequiredError";
   }

--- a/src/infra/exec-approvals-store.test.ts
+++ b/src/infra/exec-approvals-store.test.ts
@@ -396,6 +396,20 @@ describe("exec approvals SQLite store", () => {
     expect(() => loadExecApprovals()).toThrow(ExecApprovalsMigrationRequiredError);
   });
 
+  it("scopes the doctor command to the blocked state directory", () => {
+    // A bare `openclaw doctor --fix` repairs the default root, leaving a scoped
+    // install blocked by the same file it was told to repair (#115008).
+    const stateDir = process.env.OPENCLAW_STATE_DIR;
+    if (!stateDir) {
+      throw new Error("missing test state dir");
+    }
+    const error = new ExecApprovalsMigrationRequiredError(
+      path.join(stateDir, "exec-approvals.json"),
+    );
+
+    expect(error.message).toContain(`OPENCLAW_STATE_DIR=${stateDir} openclaw doctor --fix`);
+  });
+
   it.each([
     [true, false, false],
     [false, true, false],

--- a/src/infra/exec-approvals-store.test.ts
+++ b/src/infra/exec-approvals-store.test.ts
@@ -407,18 +407,11 @@ describe("exec approvals SQLite store", () => {
       path.join(stateDir, "exec-approvals.json"),
     );
 
-    expect(error.message).toContain(`OPENCLAW_STATE_DIR='${stateDir}' openclaw doctor --fix`);
-  });
-
-  it("keeps a spaced state directory one shell word", () => {
-    // macOS app state lives under "Application Support"; an unquoted path would
-    // word-split and make the prescribed command repair the wrong directory.
-    const stateDir = path.join(process.env.OPENCLAW_STATE_DIR ?? "", "Application Support");
-    const error = new ExecApprovalsMigrationRequiredError(
-      path.join(stateDir, "exec-approvals.json"),
+    // Prose, not `VAR=value cmd`: no Windows shell accepts that form, and a path
+    // containing spaces would need shell-specific quoting to survive a paste.
+    expect(error.message).toContain(
+      `Run \`openclaw doctor --fix\` with OPENCLAW_STATE_DIR set to ${stateDir}`,
     );
-
-    expect(error.message).toContain(`OPENCLAW_STATE_DIR='${stateDir}' openclaw doctor --fix`);
   });
 
   it.each([

--- a/src/infra/exec-approvals-store.test.ts
+++ b/src/infra/exec-approvals-store.test.ts
@@ -407,7 +407,18 @@ describe("exec approvals SQLite store", () => {
       path.join(stateDir, "exec-approvals.json"),
     );
 
-    expect(error.message).toContain(`OPENCLAW_STATE_DIR=${stateDir} openclaw doctor --fix`);
+    expect(error.message).toContain(`OPENCLAW_STATE_DIR='${stateDir}' openclaw doctor --fix`);
+  });
+
+  it("keeps a spaced state directory one shell word", () => {
+    // macOS app state lives under "Application Support"; an unquoted path would
+    // word-split and make the prescribed command repair the wrong directory.
+    const stateDir = path.join(process.env.OPENCLAW_STATE_DIR ?? "", "Application Support");
+    const error = new ExecApprovalsMigrationRequiredError(
+      path.join(stateDir, "exec-approvals.json"),
+    );
+
+    expect(error.message).toContain(`OPENCLAW_STATE_DIR='${stateDir}' openclaw doctor --fix`);
   });
 
   it.each([

--- a/src/infra/sqlite-user-version.test.ts
+++ b/src/infra/sqlite-user-version.test.ts
@@ -1,7 +1,9 @@
 // Tests for SQLite user_version pragma helper.
 import { describe, expect, it } from "vitest";
+import { VERSION } from "../version.js";
 import {
   createNewerSqliteSchemaVersionError,
+  describeRunningOpenClawBuild,
   readSqliteUserVersion,
 } from "./sqlite-user-version.js";
 
@@ -55,5 +57,32 @@ describe("createNewerSqliteSchemaVersionError", () => {
 
     expect(error.name).toBe("SqliteSchemaVersionError");
     expect(error.message).toContain("https://docs.openclaw.ai/reference/database-schemas");
+  });
+
+  it("names the refusing install and both schema versions", () => {
+    const error = createNewerSqliteSchemaVersionError("test database", "/tmp/test.sqlite", 12, 11);
+
+    expect(error.message).toContain("uses newer schema version 12");
+    expect(error.message).toContain("this build supports 11");
+    expect(error.message).toContain(describeRunningOpenClawBuild());
+    expect(error.message).toContain("supports schema 12 or newer");
+  });
+
+  it("does not assert a downgrade the operator never performed", () => {
+    // Two builds sharing one release version can support different schemas (#115008).
+    // Telling the operator to upgrade or stop downgrading is unactionable and often wrong.
+    const error = createNewerSqliteSchemaVersionError("test database", "/tmp/test.sqlite", 12, 11);
+
+    expect(error.message).not.toContain("Do not downgrade");
+    expect(error.message).not.toContain("Upgrade OpenClaw");
+  });
+});
+
+describe("describeRunningOpenClawBuild", () => {
+  it("reports the version and the install root operators can act on", () => {
+    const described = describeRunningOpenClawBuild();
+
+    expect(described).toContain(VERSION);
+    expect(described).toContain("installed at ");
   });
 });

--- a/src/infra/sqlite-user-version.ts
+++ b/src/infra/sqlite-user-version.ts
@@ -1,3 +1,8 @@
+import { OPENCLAW_DATABASE_SCHEMA_DOCS_URL } from "../state/openclaw-state-db-contract.js";
+import { VERSION } from "../version.js";
+import { resolveCommitHash } from "./git-commit.js";
+import { resolveOpenClawPackageRootSync } from "./openclaw-root.js";
+
 type SqliteUserVersionReader = {
   prepare: (sql: string) => { get: () => unknown };
 };
@@ -7,6 +12,19 @@ export function readSqliteUserVersion(db: SqliteUserVersionReader): number {
   return Number(row?.user_version ?? 0);
 }
 
+/**
+ * Name the refusing install the way `--version` does, plus the root it runs from.
+ * The path is the only part an operator can always act on: one release version
+ * string spans many commits, and a linked source checkout reports its git HEAD
+ * even when the built output actually executing is older.
+ */
+export function describeRunningOpenClawBuild(moduleUrl = import.meta.url): string {
+  const commit = resolveCommitHash({ moduleUrl });
+  const root = resolveOpenClawPackageRootSync({ moduleUrl });
+  const identity = commit ? `OpenClaw ${VERSION} (${commit})` : `OpenClaw ${VERSION}`;
+  return root ? `${identity} installed at ${root}` : identity;
+}
+
 export function createNewerSqliteSchemaVersionError(
   databaseLabel: string,
   pathname: string,
@@ -14,7 +32,11 @@ export function createNewerSqliteSchemaVersionError(
   supportedVersion: number,
 ): Error {
   const error = new Error(
-    `${databaseLabel} ${pathname} uses newer schema version ${schemaVersion}; this OpenClaw build supports ${supportedVersion}. Upgrade OpenClaw before opening this database. Do not downgrade OpenClaw or modify the database. To run this older build, use a separate state directory or restore a compatible backup. See https://docs.openclaw.ai/reference/database-schemas.`,
+    `${databaseLabel} ${pathname} uses newer schema version ${schemaVersion}; this build supports ${supportedVersion}. ` +
+      `Refused by ${describeRunningOpenClawBuild()}. ` +
+      "Identify installs by that path: one version string spans many builds, and a linked source checkout reports its git HEAD even when its built output is older. " +
+      `Run a build that supports schema ${schemaVersion} or newer against this state directory — rebuild or update the install above — or point this build at a different OPENCLAW_STATE_DIR. ` +
+      `See ${OPENCLAW_DATABASE_SCHEMA_DOCS_URL}.`,
   );
   error.name = "SqliteSchemaVersionError";
   return error;

--- a/src/infra/sqlite-user-version.ts
+++ b/src/infra/sqlite-user-version.ts
@@ -18,7 +18,8 @@ export function readSqliteUserVersion(db: SqliteUserVersionReader): number {
  * string spans many commits, and a linked source checkout reports its git HEAD
  * even when the built output actually executing is older.
  */
-export function describeRunningOpenClawBuild(moduleUrl = import.meta.url): string {
+export function describeRunningOpenClawBuild(): string {
+  const moduleUrl = import.meta.url;
   const commit = resolveCommitHash({ moduleUrl });
   const root = resolveOpenClawPackageRootSync({ moduleUrl });
   const identity = commit ? `OpenClaw ${VERSION} (${commit})` : `OpenClaw ${VERSION}`;

--- a/src/state/openclaw-database-preflight.ts
+++ b/src/state/openclaw-database-preflight.ts
@@ -7,7 +7,10 @@ import {
   getNodeSqliteKysely,
 } from "../infra/kysely-sync.js";
 import { openNodeSqliteDatabase } from "../infra/node-sqlite.js";
-import { readSqliteUserVersion } from "../infra/sqlite-user-version.js";
+import {
+  describeRunningOpenClawBuild,
+  readSqliteUserVersion,
+} from "../infra/sqlite-user-version.js";
 import type { OpenClawSchemaVersions } from "./openclaw-schema-versions.js";
 import type { DB as OpenClawStateKyselyDatabase } from "./openclaw-state-db.generated.js";
 import {
@@ -44,7 +47,8 @@ type AgentRegistryDatabase = Pick<OpenClawStateKyselyDatabase, "agent_databases"
 export class OpenClawDatabaseSchemaPreflightError extends Error {
   constructor(readonly incompatibleDatabases: readonly IncompatibleOpenClawDatabase[]) {
     super(
-      `Gateway refused startup because ${incompatibleDatabases.length} OpenClaw database schema(s) are newer than this build. See ${OPENCLAW_DATABASE_SCHEMA_DOCS_URL}.`,
+      `Gateway refused startup because ${incompatibleDatabases.length} OpenClaw database schema(s) are newer than this build. ` +
+        `Refused by ${describeRunningOpenClawBuild()}. See ${OPENCLAW_DATABASE_SCHEMA_DOCS_URL}.`,
     );
     this.name = "OpenClawDatabaseSchemaPreflightError";
   }


### PR DESCRIPTION
Related: #115008

## What Problem This Solves

Fixes an issue where operators hitting a newer-schema database refusal were sent down a path that makes their install worse. The error asserted a downgrade that never happened ("Do not downgrade OpenClaw") and prescribed an action the operator could not carry out ("Upgrade OpenClaw before opening this database"), while giving them nothing to identify *which* install was stale.

On the reporting host, three state-schema levels (4, 5, and 6) were all produced by builds that call themselves `2026.7.2`. `2026.7.2` is not a published stable release — npm `latest` is `2026.7.1-2`, which is *older* than what was installed — so an operator following "Upgrade OpenClaw" via Homebrew or `npm i -g openclaw@latest` performs a silent downgrade, moving further from the schema the database requires while the error keeps telling them not to downgrade.

A second, smaller misdirection sits on the same machine. `ExecApprovalsMigrationRequiredError` tells the operator to run `openclaw doctor --fix` without naming the state directory. A bare invocation repairs the default `~/.openclaw` root, so a node scoped to `OPENCLAW_STATE_DIR=~/.openclaw-clawmac-node` stays blocked by the very file the command was supposed to import, with the command reporting success.

## Why This Change Was Made

The fail-closed schema gate is correct and is unchanged; only its diagnostics change. The refusal now names the install root it was refused by, states both schema versions, and directs the operator at that install rather than at an abstract "newer version".

Choosing the install root as the primary identifier is deliberate. Investigating the reported host showed the stale build was not a second install at all: `/opt/homebrew/bin/openclaw` is a pnpm global link to a single source checkout whose `src/` declares schema 5 while its `dist/` (built nine days earlier) compiles schema 4. `resolveCommitHash` prefers the checkout's git HEAD over `dist/build-info.json`, so `--version` reports the commit of code that is not executing — printing the commit alone would have swapped one misleading identifier for another. The path is the part that is always actionable, so the message leads with it and explicitly calls out the stale-`dist` case.

The exec-approvals gate and its Swift sibling now name the blocked directory whenever the store is scoped to a non-default state root, leaving the common default-root case unchanged. The directory is stated in prose ("with OPENCLAW_STATE_DIR set to …") rather than as a `VAR=value cmd` one-liner: no Windows shell accepts that form, and the macOS app's own state root lives under `Application Support`, so a pasted one-liner would word-split on the space and repair the wrong directory.

## User Impact

Operators who hit a schema refusal can act on it. The message names the install that refused, what it supports, what it found, and that a linked checkout may need rebuilding rather than reinstalling — instead of telling them to undo a downgrade they never performed. Anyone blocked by a legacy `exec-approvals.json` under a scoped `OPENCLAW_STATE_DIR` now gets a command that targets the directory that is actually blocked.

Behavior is otherwise unchanged: the same databases are refused under the same conditions, and no schema version moves.

## Evidence

**Live reproduction of the misleading error**, on the reported host, against the Mac node's state directory:

```
$ OPENCLAW_STATE_DIR=~/.openclaw-clawmac-node openclaw nodes list
Config health-state write failed: OpenClaw state database
/Users/steipete/.openclaw-clawmac-node/state/openclaw.sqlite uses newer schema version 5;
this OpenClaw build supports 4. Upgrade OpenClaw before opening this database.
Do not downgrade OpenClaw or modify the database. ...
```

**Root cause of that host's "stale build"** — one install, source and `dist/` disagreeing:

```
$ readlink /opt/homebrew/global/v11/60d9-19f59c296b4/node_modules/openclaw
../../../../../../Users/steipete/Projects/openclaw-main

$ grep -o 'OPENCLAW_STATE_SCHEMA_VERSION = [0-9]*' ~/Projects/openclaw-main/src/state/openclaw-state-db-contract.ts
OPENCLAW_STATE_SCHEMA_VERSION = 5
$ grep -o 'OPENCLAW_STATE_SCHEMA_VERSION = [0-9]*' ~/Projects/openclaw-main/dist/openclaw-state-db-*.js
OPENCLAW_STATE_SCHEMA_VERSION = 4

$ openclaw --version
OpenClaw 2026.7.2 (6b80b01)      # commit of src/, not of the dist/ being executed
```

### After the fix, on a scoped install

Both changed messages captured from real CLI invocations against a scoped `OPENCLAW_STATE_DIR`, running this branch. Paths abbreviated as `<state-dir>` / `<install-root>`; nothing else edited.

**Schema refusal** — a state database one version ahead of what this build supports:

```
$ OPENCLAW_STATE_DIR=<state-dir> openclaw nodes list
SqliteSchemaVersionError: OpenClaw state database <state-dir>/state/openclaw.sqlite
uses newer schema version 7; this build supports 6.
Refused by OpenClaw 2026.7.2 (e64a3ce) installed at <install-root>.
Identify installs by that path: one version string spans many builds, and a linked
source checkout reports its git HEAD even when its built output is older.
Run a build that supports schema 7 or newer against this state directory — rebuild
or update the install above — or point this build at a different OPENCLAW_STATE_DIR.
See https://docs.openclaw.ai/reference/database-schemas.
```

The refusal now names the install root, both schema numbers, and the stale-`dist` case. It no longer claims a downgrade happened or tells the operator to upgrade.

**Exec-approvals gate, end to end** — staged from the reporting host's *actual* backed-up node state (its real `exec-approvals.json` plus its real schema-5 `state/openclaw.sqlite`, which had no `exec_approvals_config` row):

```
$ OPENCLAW_STATE_DIR=<state-dir> openclaw approvals get
Legacy exec approvals exist at <state-dir>/exec-approvals.json.
Run `openclaw doctor --fix` with OPENCLAW_STATE_DIR set to <state-dir>
before using exec approvals.

$ OPENCLAW_STATE_DIR=<state-dir> openclaw doctor --fix --yes --non-interactive
  - Exec approvals: legacy JSON → shared SQLite state
  Imported legacy exec approvals into shared SQLite state.
  Removed retired exec approvals JSON after recording its migration decision.
exit 0

$ OPENCLAW_STATE_DIR=<state-dir> openclaw approvals get
Approvals
  Target     local
  Path       <state-dir>/state/openclaw.sqlite#exec_approvals_config
  State      stored
  Defaults   security=allowlist, ask=on-miss, askFallback=deny, autoAllowSkills=off
  Agents     1
  Allowlist  5

$ sqlite3 <state-dir>/state/openclaw.sqlite 'select count(*) from exec_approvals_config'
1
```

The gate fires naming the blocked directory, `doctor --fix` scoped to that directory imports the file and removes it, and the gate stops firing — the real policy (1 agent, 5 allowlist entries) is now served from SQLite.

That last sequence is also why this PR deliberately does not touch the importer. `migrateLegacyExecApprovals` (`src/infra/state-migrations.exec-approvals.ts`) already exists and works; it is reached from the `mode: "doctor"` step list in `src/infra/state-migrations.doctor.ts` via `src/flows/doctor-health-contributions.ts`. It never ran on the reporting host only because `doctor --fix` aborts on the schema gate first — which is the misdirection this PR fixes.

**Focused tests**: `src/infra/sqlite-user-version.test.ts` (build identity, both schema versions, and explicit assertions that the message no longer says "Do not downgrade" or "Upgrade OpenClaw") and `src/infra/exec-approvals-store.test.ts` (the instruction names the blocked state directory). The Swift gate test asserts the same for the app store.

**Checks**: `pnpm check:changed` green on Blacksmith Testbox (`tbx_01kymhg675k5z4pkmad9bdfzra`, exit 0 — typecheck, oxlint, import cycles, plugin-boundary, database-first legacy-store guard); CI on the PR head.

**Review**: fresh Codex autoreview (`gpt-5.6-sol`, xhigh) over the branch diff. It caught two real defects in earlier revisions of this PR that are now fixed: an unquoted `OPENCLAW_STATE_DIR=<path>` one-liner that word-splits on the macOS app's `Application Support` root, and the fact that no Windows shell accepts `VAR=value cmd` at all. Both are resolved by stating the directory in prose. The final run reports no accepted or actionable findings.
