### PR TITLE
feat(claws): adopt portable profiles and native bootstrap

### DIFF
--- a/docs/cli/claws.md
+++ b/docs/cli/claws.md
@@ -11,7 +11,7 @@ title: "Claws"
 
 A Claw is a versioned setup for one new OpenClaw agent. It can describe the
 agent's portable identity, workspace files, skills, plugins, MCP servers, and
-cron jobs. Harness-specific agent settings may be carried in a referenced
+cron jobs. Harness-specific agent settings may be carried in a conventional
 package profile. A Claw does not replace or modify an existing agent.
 
 Claws are experimental. Their schema, command output, and lifecycle may change.
@@ -27,8 +27,8 @@ separate registry track and are not part of this command surface yet.
 
 ## Create a Claw package
 
-A package contains `package.json`, a `CLAW.md` manifest, and any profiles or
-workspace sidecars referenced by that manifest:
+A package contains `package.json`, a `CLAW.md` manifest, and any conventional
+profiles, bootstrap instructions, or portable assets used by that manifest:
 
 ```json
 {
@@ -49,8 +49,6 @@ schemaVersion: 1
 agent:
   id: incident-triage
   name: Incident triage
-metadata:
-  openclaw.config: profiles/openclaw.yml
 workspace:
   bootstrapFiles: {}
 packages: []
@@ -64,10 +62,13 @@ You review incoming incidents, identify severity and ownership, and leave a
 concise handoff with evidence.
 ```
 
-`metadata` is a string-to-string map for portable consumer hints. OpenClaw's
-`openclaw.config` key points to an optional, package-relative YAML profile. The
-exported default is `profiles/openclaw.yml`; the pointer is normative, so a
-package may choose another safe relative `.yml` or `.yaml` path.
+OpenClaw automatically discovers the optional `profiles/openclaw.yml` file.
+There is no manifest pointer. Other harnesses may discover their own
+conventional profile, such as `profiles/codex.yml`, without changing the
+portable manifest.
+
+Experimental packages that used `metadata.openclaw.config` must move that file
+to `profiles/openclaw.yml` and remove the metadata entry.
 
 ```yaml
 schemaVersion: 1
@@ -87,13 +88,13 @@ agent:
 
 This profile exists only inside the Claw package. OpenClaw validates and uses it
 while inspecting, adding, updating, and exporting that Claw; it is not copied
-to the user's normal OpenClaw configuration path. Other harnesses can ignore
-the namespaced metadata key and consume the portable manifest fields.
+to the user's normal OpenClaw configuration path. Other harnesses consume the
+portable manifest and interpret only their own conventional profile.
 
 The same strict version 1 schema continues to accept grouped JSON manifests.
-Grouped JSON uses the same `metadata.openclaw.config` pointer rather than
-embedding a second copy of the OpenClaw profile. The remaining schema fragments
-on this page use JSON, with equivalent keys available in `CLAW.md` frontmatter.
+Grouped JSON discovers the same conventional profile rather than embedding a
+second copy of the OpenClaw settings. The remaining schema fragments on this
+page use JSON, with equivalent keys available in `CLAW.md` frontmatter.
 
 The OpenClaw package profile may select any built-in tool profile registered by
 the running OpenClaw version, then refine it with `alsoAllow`, `deny`, and
@@ -105,7 +106,7 @@ and opt into cross-conversation memory with `rememberAcrossConversations`.
 Declaring the `sessions` source requires that opt-in.
 Host policy still constrains these settings, and Claws do not carry custom
 profile definitions, providers, credentials, bindings, or local memory paths.
-The referenced profile is limited to 256 KiB, must be JSON-compatible YAML, may
+The conventional profile is limited to 256 KiB, must be JSON-compatible YAML, may
 not use aliases, anchors, tags, or merge keys, and must be a regular,
 non-symlinked, non-hardlinked file inside the package.
 
@@ -134,6 +135,21 @@ workspace-relative targets:
   }
 }
 ```
+
+Additional files are the portable asset mechanism. Authors may organize package
+sources under directories such as `assets/`, `schemas/`, `templates/`, and
+`examples/`, then map them into the new agent workspace with
+`workspace.files`. Apply records those destinations as managed files; update
+reconciles unchanged managed assets, and remove preserves modified or
+user-owned files.
+
+An optional package-root `BOOTSTRAP.md` supplies conversational first-run
+instructions. OpenClaw seeds it into the new agent workspace and records
+progress through the native workspace bootstrap state. Once the agent consumes
+or removes it, Claw update does not recreate it. Root `BOOTSTRAP.md` therefore
+cannot also be declared through `workspace.files`. Claw removal deletes an
+unchanged, still-pending package bootstrap after verifying its recorded digest;
+it preserves edited bootstrap content and files created during onboarding.
 
 Skills and plugins use exact ClawHub versions:
 
@@ -236,10 +252,11 @@ defaults collide with local state. For disposable profiles and parallel validati
 pass an explicit `--workspace`; `OPENCLAW_STATE_DIR` relocates runtime state but
 does not change the default workspace location.
 
-Adding a Claw creates the new agent and workspace configuration, writes declared
-workspace files, installs or reuses declared skill and plugin artifacts, and
-records package, MCP, and cron provenance. Existing files are not overwritten,
-and retries fail closed when owned content drifted.
+Adding a Claw creates the new agent and workspace configuration, seeds optional
+first-run instructions, writes declared workspace assets, installs or reuses
+declared skill and plugin artifacts, and records package, MCP, and cron
+provenance. Existing files are not overwritten, and retries fail closed when
+owned content drifted.
 
 ## Inspect installed state
 
@@ -250,7 +267,8 @@ openclaw doctor
 ```
 
 `status` compares the installed agent and its recorded workspace, package, MCP,
-and cron provenance with current state. It reports incomplete installs, missing
+and cron provenance with current state. It also reports whether native
+first-run bootstrap remains pending. It reports incomplete installs, missing
 resources, and drift without changing local state. `openclaw doctor` adds
 Claw-specific diagnostics for incomplete ownership records, unsafe managed
 files, and cron jobs that cannot be corroborated with live Gateway inventory.

--- a/src/agents/workspace-state-store.test.ts
+++ b/src/agents/workspace-state-store.test.ts
@@ -5,6 +5,7 @@ import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
   closeOpenClawStateDatabaseForTest,
+  openExistingOpenClawStateDatabaseReadOnly,
   openOpenClawStateDatabase,
 } from "../state/openclaw-state-db.js";
 import { resolveOpenClawStateSqlitePath } from "../state/openclaw-state-db.paths.js";
@@ -255,6 +256,57 @@ describe("workspace state store", () => {
     expect(resolveWorkspaceStateIdentity(alias)).not.toStrictEqual(identity);
     expect(readWorkspaceStateSnapshot(alias).identity).toStrictEqual(identity);
     expect(clearExpiredWorkspaceStateForVanishedWorkspace(alias, 2_000)).toBe(false);
+  });
+
+  it("registers missing aliases in the caller-selected state database", () => {
+    const dir = workspaceDir();
+    const alias = testState!.path("workspace-link");
+    const env = {
+      ...process.env,
+      OPENCLAW_STATE_DIR: testState!.path("custom-state"),
+    };
+    fs.symlinkSync(dir, alias, process.platform === "win32" ? "junction" : "dir");
+    const identity = resolveWorkspaceStateIdentity(dir);
+    mergeWorkspaceSetupState(dir, { bootstrapSeededAt: "2026-07-16T01:00:00.000Z" }, 1_000, {
+      env,
+    });
+
+    expect(readWorkspaceStateSnapshot(alias, { env }).identity).toStrictEqual(identity);
+    fs.unlinkSync(alias);
+
+    expect(readWorkspaceStateSnapshot(alias, { env }).identity).toStrictEqual(identity);
+    expect(readWorkspaceStateSnapshot(alias, { env }).setupExists).toBe(true);
+    expect(resolveOpenClawStateSqlitePath(env)).not.toBe(resolveOpenClawStateSqlitePath());
+    expect(readWorkspaceStateSnapshot(alias).setupExists).toBe(false);
+  });
+
+  it("does not register missing aliases through a read-only database", async () => {
+    const dir = workspaceDir();
+    const alias = testState!.path("workspace-link");
+    const env = {
+      ...process.env,
+      OPENCLAW_STATE_DIR: testState!.path("custom-state"),
+    };
+    mergeWorkspaceSetupState(dir, { bootstrapSeededAt: "2026-07-16T01:00:00.000Z" }, 1_000, {
+      env,
+    });
+    closeOpenClawStateDatabaseForTest();
+    fs.symlinkSync(dir, alias, process.platform === "win32" ? "junction" : "dir");
+    const database = await openExistingOpenClawStateDatabaseReadOnly({ env });
+    if (!database) {
+      throw new Error("expected read-only database");
+    }
+
+    try {
+      expect(readWorkspaceStateSnapshot(alias, { database, env, readOnly: true }).setupExists).toBe(
+        true,
+      );
+    } finally {
+      database.walMaintenance.close();
+    }
+    fs.unlinkSync(alias);
+
+    expect(readWorkspaceStateSnapshot(alias, { env }).setupExists).toBe(false);
   });
 
   it("fails closed when a persisted symlink alias is repointed", () => {

--- a/src/agents/workspace-state-store.ts
+++ b/src/agents/workspace-state-store.ts
@@ -11,6 +11,7 @@ import type { DB as OpenClawStateKyselyDatabase } from "../state/openclaw-state-
 import {
   openOpenClawStateDatabase,
   runOpenClawStateWriteTransaction,
+  type OpenClawStateDatabaseOptions,
 } from "../state/openclaw-state-db.js";
 import { resolveOpenClawStateSqlitePath } from "../state/openclaw-state-db.paths.js";
 import { resolveUserPath } from "../utils.js";
@@ -363,8 +364,11 @@ function readSnapshotFromDatabase(params: {
   };
 }
 
-export function readWorkspaceStateSnapshot(workspaceDir: string): WorkspaceStateSnapshot {
-  const database = openOpenClawStateDatabase();
+export function readWorkspaceStateSnapshot(
+  workspaceDir: string,
+  options: OpenClawStateDatabaseOptions = {},
+): WorkspaceStateSnapshot {
+  const database = openOpenClawStateDatabase(options);
   const initial = runSqliteDeferredTransactionSync(database.db, () => {
     const resolution = resolveWorkspaceIdentityFromDatabase({ workspaceDir, database });
     return {
@@ -374,6 +378,7 @@ export function readWorkspaceStateSnapshot(workspaceDir: string): WorkspaceState
   });
   if (
     initial.resolution.missingAliasKeys.length === 0 ||
+    options.readOnly ||
     (!initial.snapshot.setupExists && !initial.snapshot.attestation)
   ) {
     return initial.snapshot;
@@ -408,13 +413,14 @@ export function readWorkspaceStateSnapshot(workspaceDir: string): WorkspaceState
       });
     }
     return snapshot;
-  });
+  }, options);
 }
 
 export function mergeWorkspaceSetupState(
   workspaceDir: string,
   next: Partial<Omit<WorkspaceSetupState, "version">>,
   nowMs = Date.now(),
+  options: OpenClawStateDatabaseOptions = {},
 ): WorkspaceSetupState {
   assertCanonicalIntegerTimestamp(nowMs, "setup update");
   if (next.bootstrapSeededAt) {
@@ -464,7 +470,7 @@ export function mergeWorkspaceSetupState(
       updatedAtMs: nowMs,
     });
     return merged;
-  });
+  }, options);
 }
 
 export function replaceWorkspaceAttestation(params: {

--- a/src/agents/workspace.ts
+++ b/src/agents/workspace.ts
@@ -7,12 +7,13 @@ import { createHash } from "node:crypto";
 import syncFs from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
+import { setTimeout as delay } from "node:timers/promises";
 import { Minimatch } from "minimatch";
 import { extractFrontmatterBlock } from "../../packages/markdown-core/src/frontmatter.js";
 import type { ChatType } from "../channels/chat-type.js";
 import { openRootFileFollowingParents } from "../infra/boundary-file-read.js";
 import { sameFileIdentity, type FileIdentityStat } from "../infra/fs-safe-advanced.js";
-import { pathExists } from "../infra/fs-safe.js";
+import { FsSafeError, pathExists, root as fsSafeRoot } from "../infra/fs-safe.js";
 import { isPathInside } from "../infra/path-guards.js";
 import { retryAsync } from "../infra/retry.js";
 import {
@@ -22,6 +23,7 @@ import {
 import { runCommandWithTimeout } from "../process/exec.js";
 import { isCronSessionKey, isSubagentSessionKey } from "../routing/session-key.js";
 import { deriveSessionChatTypeFromKey } from "../sessions/session-chat-type-shared.js";
+import type { OpenClawStateDatabaseOptions } from "../state/openclaw-state-db.js";
 import { resolveUserPath } from "../utils.js";
 import {
   MAX_WORKSPACE_BOOTSTRAP_FILE_BYTES,
@@ -130,6 +132,7 @@ export function workspaceFilesShareSourceIdentity(left: object, right: object): 
 async function readWorkspaceFileWithGuards(params: {
   filePath: string;
   workspaceDir: string;
+  useCache?: boolean;
 }): Promise<WorkspaceGuardedReadResult> {
   try {
     // A transient FS race (EAGAIN/EWOULDBLOCK/EINTR under load) on the open or
@@ -159,15 +162,18 @@ async function readWorkspaceFileWithGuards(params: {
 
         const identity = workspaceFileIdentity(opened.stat, opened.path);
         const sourceIdentity = [opened.path, opened.stat, identity] as const;
-        const cached = workspaceFileCache.get(params.filePath);
-        if (cached && cached.identity === identity) {
+        const cached =
+          params.useCache === false ? undefined : workspaceFileCache.get(params.filePath);
+        if (cached?.identity === identity) {
           syncFs.closeSync(opened.fd);
           return { ok: true, content: cached.content, sourceIdentity };
         }
 
         try {
           const content = await readWorkspaceBootstrapFile(opened.fd);
-          workspaceFileCache.set(params.filePath, { content, identity });
+          if (params.useCache !== false) {
+            workspaceFileCache.set(params.filePath, { content, identity });
+          }
           return { ok: true, content, sourceIdentity };
         } finally {
           syncFs.closeSync(opened.fd);
@@ -664,8 +670,11 @@ async function workspaceSetupStateHasSurvivalEvidence(params: {
   ].every((fileName) => generatedHashes.has(fileName));
 }
 
-function readCanonicalWorkspaceStateSnapshot(dir: string): WorkspaceStateSnapshot {
-  const snapshot = readWorkspaceStateSnapshot(dir);
+function readCanonicalWorkspaceStateSnapshot(
+  dir: string,
+  options: OpenClawStateDatabaseOptions = {},
+): WorkspaceStateSnapshot {
+  const snapshot = readWorkspaceStateSnapshot(dir, options);
   assertNoUnmigratedWorkspaceState({
     workspaceDir: dir,
   });
@@ -679,9 +688,10 @@ export async function isWorkspaceSetupCompleted(dir: string): Promise<boolean> {
 
 export async function resolveWorkspaceBootstrapStatus(
   dir: string,
+  options: OpenClawStateDatabaseOptions = {},
 ): Promise<"pending" | "complete"> {
   const resolvedDir = resolveUserPath(dir);
-  const state = readCanonicalWorkspaceStateSnapshot(resolvedDir).setup;
+  const state = readCanonicalWorkspaceStateSnapshot(resolvedDir, options).setup;
   if (typeof state.setupCompletedAt === "string" && state.setupCompletedAt.trim().length > 0) {
     return "complete";
   }
@@ -691,6 +701,148 @@ export async function resolveWorkspaceBootstrapStatus(
     return "complete";
   }
   return "pending";
+}
+
+export class WorkspaceBootstrapSeedConflictError extends Error {
+  constructor(message: string, options?: ErrorOptions) {
+    super(message, options);
+    this.name = "WorkspaceBootstrapSeedConflictError";
+  }
+}
+
+export async function seedWorkspaceBootstrap(params: {
+  dir: string;
+  content: Buffer;
+  nowMs?: number;
+  stateOptions?: OpenClawStateDatabaseOptions;
+}): Promise<"seeded" | "already-seeded" | "consumed"> {
+  if (params.content.byteLength > MAX_WORKSPACE_BOOTSTRAP_FILE_BYTES) {
+    throw new WorkspaceBootstrapSeedConflictError(
+      `BOOTSTRAP.md exceeds ${MAX_WORKSPACE_BOOTSTRAP_FILE_BYTES} bytes.`,
+    );
+  }
+  let text: string;
+  try {
+    text = new TextDecoder("utf-8", { fatal: true }).decode(params.content);
+  } catch {
+    throw new WorkspaceBootstrapSeedConflictError("BOOTSTRAP.md must be valid UTF-8.");
+  }
+  if (text.trim().length === 0) {
+    throw new WorkspaceBootstrapSeedConflictError("BOOTSTRAP.md must not be empty.");
+  }
+
+  const dir = resolveUserPath(params.dir);
+  const bootstrapPath = path.join(dir, DEFAULT_BOOTSTRAP_FILENAME);
+  const initialState = readCanonicalWorkspaceStateSnapshot(dir, params.stateOptions).setup;
+  if (initialState.setupCompletedAt) {
+    return "consumed";
+  }
+  const bootstrapExists = await pathExists(bootstrapPath);
+  if (initialState.bootstrapSeededAt && !bootstrapExists) {
+    return "consumed";
+  }
+
+  await fs.mkdir(dir, { recursive: true });
+  const workspaceRoot = await fsSafeRoot(dir, {
+    hardlinks: "reject",
+    maxBytes: MAX_WORKSPACE_BOOTSTRAP_FILE_BYTES,
+    symlinks: "reject",
+  });
+  let created = false;
+  if (!bootstrapExists) {
+    try {
+      await workspaceRoot.write(DEFAULT_BOOTSTRAP_FILENAME, params.content, {
+        overwrite: false,
+      });
+      created = true;
+    } catch (error) {
+      const alreadyExists =
+        (error as NodeJS.ErrnoException).code === "EEXIST" ||
+        (error instanceof FsSafeError && error.code === "already-exists");
+      if (!alreadyExists) {
+        throw error;
+      }
+    }
+  }
+
+  if (!created) {
+    await retryAsync(
+      async () => {
+        let statBefore: syncFs.Stats;
+        try {
+          statBefore = await fs.stat(bootstrapPath);
+        } catch (error) {
+          throw new WorkspaceBootstrapSeedConflictError(
+            "Existing BOOTSTRAP.md could not be read safely.",
+            { cause: error },
+          );
+        }
+        const existing = await readWorkspaceFileWithGuards({
+          filePath: bootstrapPath,
+          workspaceDir: dir,
+          useCache: false,
+        });
+        if (!existing.ok) {
+          throw new WorkspaceBootstrapSeedConflictError(
+            "Existing BOOTSTRAP.md could not be read safely.",
+          );
+        }
+        if (!Buffer.from(existing.content, "utf8").equals(params.content)) {
+          throw new WorkspaceBootstrapSeedConflictError(
+            "Existing BOOTSTRAP.md differs from the consented Claw bootstrap.",
+          );
+        }
+        await delay(20);
+        let statAfter: syncFs.Stats;
+        try {
+          statAfter = await fs.stat(bootstrapPath);
+        } catch (error) {
+          throw new WorkspaceBootstrapSeedConflictError(
+            "Existing BOOTSTRAP.md could not be read safely.",
+            { cause: error },
+          );
+        }
+        if (
+          statBefore.size !== statAfter.size ||
+          statBefore.mtimeMs !== statAfter.mtimeMs ||
+          statAfter.size !== params.content.byteLength
+        ) {
+          throw new WorkspaceBootstrapSeedConflictError(
+            "Existing BOOTSTRAP.md write has not stabilized.",
+          );
+        }
+        const stable = await readWorkspaceFileWithGuards({
+          filePath: bootstrapPath,
+          workspaceDir: dir,
+          useCache: false,
+        });
+        if (!stable.ok || !Buffer.from(stable.content, "utf8").equals(params.content)) {
+          throw new WorkspaceBootstrapSeedConflictError(
+            "Existing BOOTSTRAP.md differs from the consented Claw bootstrap.",
+          );
+        }
+      },
+      {
+        attempts: 5,
+        minDelayMs: 20,
+        maxDelayMs: 80,
+        shouldRetry: (error) => error instanceof WorkspaceBootstrapSeedConflictError,
+      },
+    );
+  }
+
+  if (!initialState.bootstrapSeededAt) {
+    const nowMs = params.nowMs ?? Date.now();
+    mergeWorkspaceSetupState(
+      dir,
+      {
+        bootstrapSeededAt: new Date(nowMs).toISOString(),
+      },
+      nowMs,
+      params.stateOptions,
+    );
+  }
+  return created ? "seeded" : "already-seeded";
 }
 
 export async function isWorkspaceBootstrapPending(dir: string): Promise<boolean> {

--- a/src/claws/add.ts
+++ b/src/claws/add.ts
@@ -13,6 +13,7 @@ import { DEFAULT_AGENT_ID, normalizeAgentId } from "../routing/session-key.js";
 import type { RuntimeEnv } from "../runtime.js";
 import type { OpenClawStateDatabaseOptions } from "../state/openclaw-state-db.js";
 import { resolveUserPath } from "../utils.js";
+import { ClawBootstrapWriteError, seedClawPackageBootstrap } from "./bootstrap.js";
 import {
   ClawCronInstallError,
   installClawCronJobs,
@@ -54,6 +55,7 @@ type ClawAddApplyOptions = OpenClawStateDatabaseOptions & {
   installPackages?: typeof installClawPackages;
   installMcpServers?: typeof installClawMcpServers;
   installCronJobs?: typeof installClawCronJobs;
+  seedPackageBootstrap?: typeof seedClawPackageBootstrap;
   cronGateway?: Pick<ClawCronGateway, "add" | "list" | "waitUntilAgentAvailable">;
   nowMs?: number;
 };
@@ -93,9 +95,15 @@ type ClawAddResult = {
 function hasUnsupportedMutationActions(plan: ClawAddPlan): boolean {
   return plan.actions.some(
     (action) =>
-      !["agent", "workspace", "workspaceFile", "package", "mcpServer", "cronJob"].includes(
-        action.kind,
-      ),
+      ![
+        "agent",
+        "workspace",
+        "bootstrap",
+        "workspaceFile",
+        "package",
+        "mcpServer",
+        "cronJob",
+      ].includes(action.kind),
   );
 }
 
@@ -300,6 +308,27 @@ export async function applyClawAddPlan(
       }
       throw new ClawAddMutationError("provenance_failed", (error as Error).message);
     }
+  }
+
+  try {
+    await (options.seedPackageBootstrap ?? seedClawPackageBootstrap)(plan, {
+      ...options,
+      ...(options.nowMs !== undefined ? { nowMs: options.nowMs } : {}),
+    });
+  } catch (error) {
+    return partialResult({
+      plan,
+      installRecord,
+      workspaceCreated,
+      configCommitted,
+      packages,
+      installStatus: "workspace_ready",
+      error: {
+        code: error instanceof ClawBootstrapWriteError ? error.code : "bootstrap_write_failed",
+        message: error instanceof Error ? error.message : String(error),
+      },
+      nowMs: options.nowMs,
+    });
   }
 
   try {

--- a/src/claws/bootstrap.test.ts
+++ b/src/claws/bootstrap.test.ts
@@ -1,0 +1,526 @@
+import { mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
+import { MAX_WORKSPACE_BOOTSTRAP_FILE_BYTES } from "../agents/workspace-bootstrap-read.js";
+import { readWorkspaceStateSnapshot } from "../agents/workspace-state-store.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
+import { applyClawAddPlan } from "./add.js";
+import { seedClawPackageBootstrap } from "./bootstrap.js";
+import { applyClawRemovePlan, buildClawRemovePlan, readClawStatus } from "./lifecycle-state.js";
+import { buildClawAddPlan } from "./lifecycle.js";
+import {
+  persistClawInstallRecord,
+  readClawInstallRecord,
+  updateClawInstallRecord,
+} from "./provenance.js";
+import { readClawManifestFile } from "./reader.js";
+import { parseClawManifest } from "./schema.js";
+
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+
+afterEach(() => closeOpenClawStateDatabaseForTest());
+
+async function createPackage(bootstrap = "# First run\n\nAsk which repositories matter.\n") {
+  const root = tempDirs.make("openclaw-claw-bootstrap-");
+  await mkdir(root, { recursive: true });
+  await writeFile(
+    join(root, "package.json"),
+    JSON.stringify({
+      name: "@acme/bootstrap-worker",
+      version: "1.0.0",
+      openclaw: { claw: "CLAW.md" },
+    }),
+    "utf8",
+  );
+  await writeFile(
+    join(root, "CLAW.md"),
+    [
+      "---",
+      "schemaVersion: 1",
+      "agent:",
+      "  id: bootstrap-worker",
+      "---",
+      "",
+      "# Bootstrap Worker",
+      "",
+      "Help with selected repositories.",
+    ].join("\n"),
+    "utf8",
+  );
+  await writeFile(join(root, "BOOTSTRAP.md"), bootstrap, "utf8");
+  return root;
+}
+
+describe("package-root BOOTSTRAP.md", () => {
+  it("integrity-binds bootstrap and plans a distinct native action", async () => {
+    const root = await createPackage();
+    const first = await readClawManifestFile(root);
+    expect(first).toMatchObject({
+      ok: true,
+      packageBootstrap: {
+        sourcePath: "BOOTSTRAP.md",
+        digest: expect.stringMatching(/^sha256:[a-f0-9]{64}$/),
+      },
+    });
+    if (!first.ok || !first.packageBootstrap) {
+      throw new Error("expected package bootstrap");
+    }
+    const plan = await buildClawAddPlan({
+      manifest: first.manifest,
+      clawMarkdownBody: first.clawMarkdownBody,
+      packageBootstrap: first.packageBootstrap,
+      source: first.source,
+      context: { workspace: join(root, "workspace") },
+    });
+    expect(plan.actions).toContainEqual(
+      expect.objectContaining({
+        kind: "bootstrap",
+        id: "BOOTSTRAP.md",
+        action: "write",
+        digest: first.packageBootstrap.digest,
+        details: expect.objectContaining({ lifecycle: "native-seed-once" }),
+      }),
+    );
+
+    await writeFile(join(root, "BOOTSTRAP.md"), "# Changed\n", "utf8");
+    const second = await readClawManifestFile(root);
+    expect(second.ok).toBe(true);
+    if (!second.ok) {
+      throw new Error("expected changed package to parse");
+    }
+    expect(second.source.integrity).not.toBe(first.source.integrity);
+  });
+
+  it("seeds native state once and never recreates a consumed bootstrap", async () => {
+    const root = await createPackage();
+    const read = await readClawManifestFile(root);
+    if (!read.ok || !read.packageBootstrap) {
+      throw new Error("expected package bootstrap");
+    }
+    const workspace = join(root, "workspace");
+    const env = { OPENCLAW_STATE_DIR: join(root, "state") };
+    const plan = await buildClawAddPlan({
+      manifest: read.manifest,
+      clawMarkdownBody: read.clawMarkdownBody,
+      packageBootstrap: read.packageBootstrap,
+      source: read.source,
+      context: { workspace },
+    });
+    let config: OpenClawConfig = {};
+    const added = await applyClawAddPlan(plan, {
+      env,
+      nowMs: 1_000,
+      consentPlanIntegrity: plan.planIntegrity,
+      commitConfig: async (transform) => {
+        config = transform(config);
+      },
+    });
+
+    expect(added.status).toBe("complete");
+    await expect(readFile(join(workspace, "BOOTSTRAP.md"), "utf8")).resolves.toContain(
+      "which repositories",
+    );
+    expect(readWorkspaceStateSnapshot(workspace, { env }).setup).toMatchObject({
+      bootstrapSeededAt: new Date(1_000).toISOString(),
+    });
+    await expect(readClawStatus("bootstrap-worker", { env, config })).resolves.toMatchObject({
+      summary: { pendingBootstrap: 1 },
+      records: [{ bootstrapState: "pending" }],
+    });
+
+    await rm(join(workspace, "BOOTSTRAP.md"));
+    await expect(seedClawPackageBootstrap(plan, { env, nowMs: 2_000 })).resolves.toBe("consumed");
+    await expect(readFile(join(workspace, "BOOTSTRAP.md"), "utf8")).rejects.toThrow();
+    await expect(readClawStatus("bootstrap-worker", { env, config })).resolves.toMatchObject({
+      summary: { pendingBootstrap: 0 },
+      records: [{ bootstrapState: "complete" }],
+    });
+  });
+
+  it("keeps a failed pre-publication bootstrap seed removable", async () => {
+    const root = await createPackage();
+    const read = await readClawManifestFile(root);
+    if (!read.ok || !read.packageBootstrap) {
+      throw new Error("expected package bootstrap");
+    }
+    const workspace = join(root, "workspace");
+    const env = { OPENCLAW_STATE_DIR: join(root, "state") };
+    const plan = await buildClawAddPlan({
+      manifest: read.manifest,
+      clawMarkdownBody: read.clawMarkdownBody,
+      packageBootstrap: read.packageBootstrap,
+      source: read.source,
+      context: { workspace },
+    });
+    let config: OpenClawConfig = {};
+
+    const added = await applyClawAddPlan(plan, {
+      env,
+      nowMs: 1_000,
+      consentPlanIntegrity: plan.planIntegrity,
+      commitConfig: async (transform) => {
+        config = transform(config);
+      },
+      seedPackageBootstrap: async () => {
+        throw new Error("seed failed");
+      },
+    });
+
+    expect(added).toMatchObject({
+      status: "partial",
+      configCommitted: false,
+      error: { code: "bootstrap_write_failed" },
+    });
+    expect(config).toEqual({});
+    expect(readWorkspaceStateSnapshot(workspace, { env }).setup.bootstrapSeededAt).toBeUndefined();
+    await expect(readFile(join(workspace, "BOOTSTRAP.md"), "utf8")).rejects.toThrow();
+    await expect(readClawStatus("bootstrap-worker", { env, config })).resolves.toMatchObject({
+      records: [
+        {
+          bootstrapState: "missing",
+          bootstrap: { state: "missing", path: "BOOTSTRAP.md" },
+        },
+      ],
+    });
+  });
+
+  it("does not expose the agent while package bootstrap seeding is in flight", async () => {
+    const root = await createPackage();
+    const read = await readClawManifestFile(root);
+    if (!read.ok || !read.packageBootstrap) {
+      throw new Error("expected package bootstrap");
+    }
+    const workspace = join(root, "workspace");
+    const env = { OPENCLAW_STATE_DIR: join(root, "state") };
+    const addPlan = await buildClawAddPlan({
+      manifest: read.manifest,
+      clawMarkdownBody: read.clawMarkdownBody,
+      packageBootstrap: read.packageBootstrap,
+      source: read.source,
+      context: { workspace },
+    });
+    let config: OpenClawConfig = {};
+    let releaseSeed!: () => void;
+    const seedReleased = new Promise<void>((resolve) => {
+      releaseSeed = resolve;
+    });
+    let reportSeedStarted!: () => void;
+    const seedStarted = new Promise<void>((resolve) => {
+      reportSeedStarted = resolve;
+    });
+
+    const addPromise = applyClawAddPlan(addPlan, {
+      env,
+      consentPlanIntegrity: addPlan.planIntegrity,
+      commitConfig: async (transform) => {
+        config = transform(config);
+      },
+      seedPackageBootstrap: async (plan, options) => {
+        reportSeedStarted();
+        await seedReleased;
+        return seedClawPackageBootstrap(plan, options);
+      },
+    });
+
+    await seedStarted;
+    expect(config.agents?.entries?.["bootstrap-worker"]).toBeUndefined();
+    releaseSeed();
+
+    await expect(addPromise).resolves.toMatchObject({
+      status: "complete",
+      configCommitted: true,
+    });
+    await expect(readFile(join(workspace, "BOOTSTRAP.md"), "utf8")).resolves.toContain(
+      "which repositories",
+    );
+  });
+
+  it("removes a seeded partial install when the later configuration commit fails", async () => {
+    const root = await createPackage();
+    const read = await readClawManifestFile(root);
+    if (!read.ok || !read.packageBootstrap) {
+      throw new Error("expected package bootstrap");
+    }
+    const workspace = join(root, "workspace");
+    const env = { OPENCLAW_STATE_DIR: join(root, "state") };
+    const addPlan = await buildClawAddPlan({
+      manifest: read.manifest,
+      clawMarkdownBody: read.clawMarkdownBody,
+      packageBootstrap: read.packageBootstrap,
+      source: read.source,
+      context: { workspace },
+    });
+
+    const added = await applyClawAddPlan(addPlan, {
+      env,
+      consentPlanIntegrity: addPlan.planIntegrity,
+      commitConfig: async () => {
+        throw new Error("config failed");
+      },
+    });
+
+    expect(added).toMatchObject({
+      status: "partial",
+      configCommitted: false,
+      error: { code: "config_commit_failed" },
+    });
+    await expect(readFile(join(workspace, "BOOTSTRAP.md"), "utf8")).resolves.toContain(
+      "which repositories",
+    );
+    await expect(readClawStatus("bootstrap-worker", { env, config: {} })).resolves.toMatchObject({
+      records: [{ install: { status: "workspace_ready" }, bootstrapState: "pending" }],
+    });
+    const removePlan = await buildClawRemovePlan("bootstrap-worker", { env, config: {} });
+    expect(removePlan.blockers).toEqual([]);
+    expect(removePlan.actions).toContainEqual(
+      expect.objectContaining({
+        kind: "bootstrap",
+        action: "delete",
+        blocked: false,
+        details: expect.objectContaining({ expectedState: "pending" }),
+      }),
+    );
+
+    const removed = await applyClawRemovePlan(removePlan, {
+      env,
+      config: {},
+      consentPlanIntegrity: removePlan.planIntegrity,
+      commitConfig: async (transform) => {
+        transform({});
+      },
+      purgeSessions: async () => undefined,
+      trashPath: async () => true,
+    });
+
+    expect(removed).toMatchObject({
+      status: "complete",
+      bootstrap: { path: "BOOTSTRAP.md", action: "deleted" },
+    });
+    expect(readClawInstallRecord("bootstrap-worker", { env })).toBeUndefined();
+  });
+
+  it("omits bootstrap from update-style target plans", async () => {
+    const root = await createPackage();
+    const read = await readClawManifestFile(root);
+    if (!read.ok || !read.packageBootstrap) {
+      throw new Error("expected package bootstrap");
+    }
+    const plan = await buildClawAddPlan({
+      manifest: read.manifest,
+      packageBootstrap: read.packageBootstrap,
+      includePackageBootstrap: false,
+      source: read.source,
+      context: { workspace: join(root, "workspace") },
+    });
+
+    expect(plan.actions.some((action) => action.kind === "bootstrap")).toBe(false);
+  });
+
+  it("preserves bootstrap provenance when update omits the seed-once action", async () => {
+    const root = await createPackage();
+    const read = await readClawManifestFile(root);
+    if (!read.ok || !read.packageBootstrap) {
+      throw new Error("expected package bootstrap");
+    }
+    const env = { OPENCLAW_STATE_DIR: join(root, "state") };
+    const context = { workspace: join(root, "workspace") };
+    const addPlan = await buildClawAddPlan({
+      manifest: read.manifest,
+      packageBootstrap: read.packageBootstrap,
+      source: read.source,
+      context,
+    });
+    const initial = persistClawInstallRecord(addPlan, { env });
+    const updatePlan = await buildClawAddPlan({
+      manifest: read.manifest,
+      packageBootstrap: read.packageBootstrap,
+      includePackageBootstrap: false,
+      source: read.source,
+      context,
+    });
+
+    updateClawInstallRecord(updatePlan, { env });
+
+    expect(readClawInstallRecord("bootstrap-worker", { env })?.bootstrap).toEqual(
+      initial.bootstrap,
+    );
+  });
+
+  it("removes an unchanged pending bootstrap with the Claw", async () => {
+    const root = await createPackage();
+    const read = await readClawManifestFile(root);
+    if (!read.ok || !read.packageBootstrap) {
+      throw new Error("expected package bootstrap");
+    }
+    const workspace = join(root, "workspace");
+    const env = { OPENCLAW_STATE_DIR: join(root, "state") };
+    const addPlan = await buildClawAddPlan({
+      manifest: read.manifest,
+      packageBootstrap: read.packageBootstrap,
+      source: read.source,
+      context: { workspace },
+    });
+    let config: OpenClawConfig = {};
+    await applyClawAddPlan(addPlan, {
+      env,
+      consentPlanIntegrity: addPlan.planIntegrity,
+      commitConfig: async (transform) => {
+        config = transform(config);
+      },
+    });
+
+    const removePlan = await buildClawRemovePlan("bootstrap-worker", { env, config });
+    expect(removePlan.actions).toContainEqual(
+      expect.objectContaining({ kind: "bootstrap", action: "delete", blocked: false }),
+    );
+    expect(removePlan.actions).toContainEqual(
+      expect.objectContaining({ kind: "workspace", action: "trash" }),
+    );
+    const removed = await applyClawRemovePlan(removePlan, {
+      env,
+      config,
+      consentPlanIntegrity: removePlan.planIntegrity,
+      commitConfig: async (transform) => {
+        config = transform(config);
+      },
+      purgeSessions: async () => undefined,
+      trashPath: async () => true,
+    });
+
+    expect(removed).toMatchObject({
+      status: "complete",
+      bootstrap: { path: "BOOTSTRAP.md", action: "deleted" },
+    });
+    await expect(readFile(join(workspace, "BOOTSTRAP.md"), "utf8")).rejects.toThrow();
+  });
+
+  it("removes an unchanged large pending bootstrap within the native size limit", async () => {
+    const content = "# First run\n\n" + "x".repeat(1024 * 1024 + 32);
+    expect(Buffer.byteLength(content)).toBeLessThanOrEqual(MAX_WORKSPACE_BOOTSTRAP_FILE_BYTES);
+    const root = await createPackage(content);
+    const read = await readClawManifestFile(root);
+    if (!read.ok || !read.packageBootstrap) {
+      throw new Error("expected package bootstrap");
+    }
+    const workspace = join(root, "workspace");
+    const env = { OPENCLAW_STATE_DIR: join(root, "state") };
+    const addPlan = await buildClawAddPlan({
+      manifest: read.manifest,
+      packageBootstrap: read.packageBootstrap,
+      source: read.source,
+      context: { workspace },
+    });
+    let config: OpenClawConfig = {};
+    await applyClawAddPlan(addPlan, {
+      env,
+      consentPlanIntegrity: addPlan.planIntegrity,
+      commitConfig: async (transform) => {
+        config = transform(config);
+      },
+    });
+
+    await expect(readClawStatus("bootstrap-worker", { env, config })).resolves.toMatchObject({
+      records: [{ bootstrapState: "pending" }],
+    });
+    const removePlan = await buildClawRemovePlan("bootstrap-worker", { env, config });
+    expect(removePlan.actions).toContainEqual(
+      expect.objectContaining({ kind: "bootstrap", action: "delete", blocked: false }),
+    );
+    const removed = await applyClawRemovePlan(removePlan, {
+      env,
+      config,
+      consentPlanIntegrity: removePlan.planIntegrity,
+      commitConfig: async (transform) => {
+        config = transform(config);
+      },
+      purgeSessions: async () => undefined,
+      trashPath: async () => true,
+    });
+
+    expect(removed).toMatchObject({
+      status: "complete",
+      bootstrap: { path: "BOOTSTRAP.md", action: "deleted" },
+    });
+    await expect(readFile(join(workspace, "BOOTSTRAP.md"), "utf8")).rejects.toThrow();
+  });
+
+  it("preserves a locally modified pending bootstrap and its workspace", async () => {
+    const root = await createPackage();
+    const read = await readClawManifestFile(root);
+    if (!read.ok || !read.packageBootstrap) {
+      throw new Error("expected package bootstrap");
+    }
+    const workspace = join(root, "workspace");
+    const env = { OPENCLAW_STATE_DIR: join(root, "state") };
+    const addPlan = await buildClawAddPlan({
+      manifest: read.manifest,
+      packageBootstrap: read.packageBootstrap,
+      source: read.source,
+      context: { workspace },
+    });
+    let config: OpenClawConfig = {};
+    await applyClawAddPlan(addPlan, {
+      env,
+      consentPlanIntegrity: addPlan.planIntegrity,
+      commitConfig: async (transform) => {
+        config = transform(config);
+      },
+    });
+    await writeFile(join(workspace, "BOOTSTRAP.md"), "# My edited onboarding\n", "utf8");
+
+    const removePlan = await buildClawRemovePlan("bootstrap-worker", { env, config });
+    expect(removePlan.actions).toContainEqual(
+      expect.objectContaining({ kind: "bootstrap", action: "retain", blocked: false }),
+    );
+    expect(removePlan.actions).toContainEqual(
+      expect.objectContaining({ kind: "workspace", action: "retain" }),
+    );
+    const removed = await applyClawRemovePlan(removePlan, {
+      env,
+      config,
+      consentPlanIntegrity: removePlan.planIntegrity,
+      commitConfig: async (transform) => {
+        config = transform(config);
+      },
+      purgeSessions: async () => undefined,
+      trashPath: async () => true,
+    });
+
+    expect(removed).toMatchObject({
+      status: "complete",
+      bootstrap: { path: "BOOTSTRAP.md", action: "retainedModified" },
+    });
+    await expect(readFile(join(workspace, "BOOTSTRAP.md"), "utf8")).resolves.toContain(
+      "My edited onboarding",
+    );
+  });
+
+  it("rejects an empty package bootstrap", async () => {
+    const root = await createPackage(" \n\t");
+
+    await expect(readClawManifestFile(root)).resolves.toMatchObject({
+      ok: false,
+      diagnostics: [expect.objectContaining({ code: "package_bootstrap_empty" })],
+    });
+  });
+
+  it("reserves root BOOTSTRAP.md for the native seed-once lifecycle", () => {
+    const result = parseClawManifest({
+      schemaVersion: 1,
+      agent: { id: "bootstrap-worker" },
+      workspace: {
+        files: [{ source: "assets/BOOTSTRAP.md", path: "BOOTSTRAP.md" }],
+      },
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.diagnostics).toContainEqual(
+      expect.objectContaining({
+        path: "$.workspace.files[0].path",
+        message: expect.stringContaining("native seed-once lifecycle"),
+      }),
+    );
+  });
+});

--- a/src/claws/bootstrap.ts
+++ b/src/claws/bootstrap.ts
@@ -1,0 +1,99 @@
+import { createHash } from "node:crypto";
+import { realpath } from "node:fs/promises";
+import { isAbsolute, relative, resolve, sep } from "node:path";
+import { MAX_WORKSPACE_BOOTSTRAP_FILE_BYTES } from "../agents/workspace-bootstrap-read.js";
+import { DEFAULT_BOOTSTRAP_FILENAME, seedWorkspaceBootstrap } from "../agents/workspace.js";
+import { root as fsSafeRoot } from "../infra/fs-safe.js";
+import type { OpenClawStateDatabaseOptions } from "../state/openclaw-state-db.js";
+import type { ClawAddPlan } from "./types.js";
+
+export class ClawBootstrapWriteError extends Error {
+  constructor(
+    readonly code: string,
+    message: string,
+  ) {
+    super(message);
+    this.name = "ClawBootstrapWriteError";
+  }
+}
+
+function contentDigest(content: Uint8Array): string {
+  return `sha256:${createHash("sha256").update(content).digest("hex")}`;
+}
+
+function containedRelativePath(root: string, path: string): string | undefined {
+  const child = relative(root, path);
+  if (child === ".." || child.startsWith(`..${sep}`) || isAbsolute(child)) {
+    return undefined;
+  }
+  return child;
+}
+
+export async function seedClawPackageBootstrap(
+  plan: ClawAddPlan,
+  options: {
+    nowMs?: number;
+    seedBootstrap?: typeof seedWorkspaceBootstrap;
+  } & OpenClawStateDatabaseOptions = {},
+): Promise<"seeded" | "already-seeded" | "consumed" | undefined> {
+  const actions = plan.actions.filter((action) => action.kind === "bootstrap");
+  if (actions.length === 0) {
+    return undefined;
+  }
+  if (actions.length !== 1) {
+    throw new ClawBootstrapWriteError(
+      "bootstrap_plan_invalid",
+      "A Claw add plan may contain only one package bootstrap action.",
+    );
+  }
+  const action = actions[0];
+  if (!action) {
+    throw new ClawBootstrapWriteError(
+      "bootstrap_plan_invalid",
+      "The package bootstrap action is missing.",
+    );
+  }
+  if (!action.source || !action.digest) {
+    throw new ClawBootstrapWriteError(
+      "bootstrap_plan_invalid",
+      "The package bootstrap action lacks source integrity.",
+    );
+  }
+
+  const packageRoot = await realpath(resolve(plan.claw.packageRoot));
+  const sourcePath = resolve(action.source);
+  const sourceRelative = containedRelativePath(packageRoot, sourcePath);
+  if (!sourceRelative) {
+    throw new ClawBootstrapWriteError(
+      "bootstrap_source_escape",
+      "BOOTSTRAP.md must remain inside the Claw package.",
+    );
+  }
+  const sourceRoot = await fsSafeRoot(packageRoot);
+  const read = await sourceRoot.read(sourceRelative, {
+    hardlinks: "reject",
+    maxBytes: MAX_WORKSPACE_BOOTSTRAP_FILE_BYTES,
+    symlinks: "reject",
+  });
+  if (resolve(read.realPath) !== sourcePath || contentDigest(read.buffer) !== action.digest) {
+    throw new ClawBootstrapWriteError(
+      "bootstrap_source_changed",
+      "BOOTSTRAP.md changed after consent; run add --dry-run again.",
+    );
+  }
+
+  const expectedTarget = resolve(plan.agent.workspace, DEFAULT_BOOTSTRAP_FILENAME);
+  if (resolve(action.target) !== expectedTarget) {
+    throw new ClawBootstrapWriteError(
+      "bootstrap_target_changed",
+      "The package bootstrap target is not the new agent workspace root.",
+    );
+  }
+
+  return (options.seedBootstrap ?? seedWorkspaceBootstrap)({
+    dir: plan.agent.workspace,
+    content: read.buffer,
+    ...(options.nowMs !== undefined ? { nowMs: options.nowMs } : {}),
+    stateOptions: options,
+  });
+}

--- a/src/claws/export.test.ts
+++ b/src/claws/export.test.ts
@@ -1,7 +1,9 @@
-import { mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { createHash } from "node:crypto";
+import { mkdir, readFile, rm, stat, writeFile } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
+import { MAX_WORKSPACE_BOOTSTRAP_FILE_BYTES } from "../agents/workspace-bootstrap-read.js";
 import type { McpServerConfig } from "../config/types.mcp.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
@@ -24,7 +26,10 @@ afterEach(() => {
 async function installedFixture(
   options: {
     avatar?: string;
+    extraWorkspaceFileContent?: Buffer;
     extraWorkspaceFiles?: string[];
+    packageBootstrap?: boolean;
+    packageBootstrapContent?: Buffer;
     soulContent?: string | Buffer;
     withPackage?: boolean;
   } = {},
@@ -36,7 +41,7 @@ async function installedFixture(
   await writeFile(join(root, "source", "reference", "policy.md"), content("policy"));
   for (const path of options.extraWorkspaceFiles ?? []) {
     await mkdir(join(root, "source", dirname(path)), { recursive: true });
-    await writeFile(join(root, "source", path), content(path));
+    await writeFile(join(root, "source", path), options.extraWorkspaceFileContent ?? content(path));
   }
   const parsed = parseClawManifest({
     schemaVersion: 1,
@@ -45,7 +50,6 @@ async function installedFixture(
       name: "Worker",
       ...(options.avatar ? { identity: { avatar: options.avatar } } : {}),
     },
-    metadata: { "openclaw.config": "profiles/openclaw.yml" },
     workspace: {
       bootstrapFiles: { "SOUL.md": { source: "source/SOUL.md" } },
       files: [
@@ -105,9 +109,26 @@ async function installedFixture(
     integrity: "sha256:manifest",
     byteLength: 100,
   };
+  const packageBootstrapContent =
+    options.packageBootstrapContent ??
+    Buffer.from("# First run\n\nReview the repository map first.\n");
+  const packageBootstrapPath = join(root, "BOOTSTRAP.md");
+  if (options.packageBootstrap) {
+    await writeFile(packageBootstrapPath, packageBootstrapContent);
+  }
   const plan = await buildClawAddPlan({
     manifest: parsed.manifest,
     source,
+    ...(options.packageBootstrap
+      ? {
+          packageBootstrap: {
+            sourcePath: "BOOTSTRAP.md",
+            realPath: packageBootstrapPath,
+            byteLength: packageBootstrapContent.byteLength,
+            digest: `sha256:${createHash("sha256").update(packageBootstrapContent).digest("hex")}`,
+          },
+        }
+      : {}),
     openClawProfile,
     context: { workspace: join(root, "workspace-worker") },
   });
@@ -200,7 +221,6 @@ describe("exportClawAgent", () => {
       manifest: {
         schemaVersion: 1,
         agent: { id: "worker", name: "Worker" },
-        metadata: { "openclaw.config": "profiles/openclaw.yml" },
         workspace: {
           bootstrapFiles: {},
           files: [{ source: "workspace/reference/policy.md", path: "reference/policy.md" }],
@@ -268,6 +288,11 @@ describe("exportClawAgent", () => {
       throw new Error(JSON.stringify(exported.diagnostics));
     }
     expect(exported.clawMarkdownBody?.toString("utf8")).toBe("managed soul\n");
+    expect(exported.manifest.metadata).toEqual({});
+    expect(exported.openClawProfile).toMatchObject({
+      schemaVersion: 1,
+      agent: { tools: { profile: "coding" } },
+    });
     expect(exported.manifest.workspace.bootstrapFiles).not.toHaveProperty("SOUL.md");
     await expect(readFile(join(out, "profiles", "openclaw.yml"), "utf8")).resolves.toContain(
       "profile: coding",
@@ -288,6 +313,127 @@ describe("exportClawAgent", () => {
         sourceMcpServers: fixture.sourceMcpServers,
       }),
     ).rejects.toMatchObject({ code: "workspace_files_drifted" });
+  });
+
+  it("exports a pending package bootstrap as package-root BOOTSTRAP.md", async () => {
+    const fixture = await installedFixture({ packageBootstrap: true });
+    const out = join(fixture.root, "exported-bootstrap");
+
+    const result = await exportClawAgent("worker", out, {
+      env: fixture.env,
+      config: fixture.config,
+      packageDeps: fixture.packageDeps,
+      sourceMcpServers: fixture.sourceMcpServers,
+    });
+
+    expect(result.filesWritten).toContain("BOOTSTRAP.md");
+    await expect(readFile(join(out, "BOOTSTRAP.md"), "utf8")).resolves.toContain("repository map");
+    const exported = await readClawManifestFile(out);
+    expect(exported.ok).toBe(true);
+    if (!exported.ok) {
+      throw new Error(JSON.stringify(exported.diagnostics));
+    }
+    expect(exported.packageBootstrap).toMatchObject({
+      sourcePath: "BOOTSTRAP.md",
+      byteLength: "# First run\n\nReview the repository map first.\n".length,
+    });
+  });
+
+  it("rejects bootstrap content replaced after ownership inspection", async () => {
+    const fixture = await installedFixture({ packageBootstrap: true, withPackage: true });
+    const out = join(fixture.root, "exported-replaced-bootstrap");
+
+    await expect(
+      exportClawAgent("worker", out, {
+        env: fixture.env,
+        config: fixture.config,
+        packageDeps: {
+          ...fixture.packageDeps,
+          planSkill: async () => {
+            await writeFile(
+              join(fixture.plan.agent.workspace, "BOOTSTRAP.md"),
+              "# Replaced\n\nUnrecorded instructions.\n",
+            );
+            return await fixture.packageDeps.planSkill();
+          },
+        },
+        sourceMcpServers: fixture.sourceMcpServers,
+      }),
+    ).rejects.toMatchObject({ code: "bootstrap_drifted" });
+    await expect(stat(out)).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it("does not export native bootstrap content without package ownership", async () => {
+    const fixture = await installedFixture();
+    await writeFile(
+      join(fixture.plan.agent.workspace, "BOOTSTRAP.md"),
+      "# First run\n\nOperator-authored onboarding.\n",
+    );
+    const out = join(fixture.root, "exported-native-bootstrap");
+
+    const result = await exportClawAgent("worker", out, {
+      env: fixture.env,
+      config: fixture.config,
+      packageDeps: fixture.packageDeps,
+      sourceMcpServers: fixture.sourceMcpServers,
+    });
+
+    expect(result.filesWritten).not.toContain("BOOTSTRAP.md");
+    await expect(readFile(join(out, "BOOTSTRAP.md"))).rejects.toMatchObject({ code: "ENOENT" });
+    const exported = await readClawManifestFile(out);
+    expect(exported.ok).toBe(true);
+    if (!exported.ok) {
+      throw new Error(JSON.stringify(exported.diagnostics));
+    }
+    expect(exported.packageBootstrap).toBeUndefined();
+  });
+
+  it("exports a large pending package bootstrap within the native size limit", async () => {
+    const content = Buffer.from("# First run\n\n" + "x".repeat(1024 * 1024 + 32));
+    expect(content.byteLength).toBeLessThanOrEqual(MAX_WORKSPACE_BOOTSTRAP_FILE_BYTES);
+    const fixture = await installedFixture({
+      packageBootstrap: true,
+      packageBootstrapContent: content,
+    });
+    const out = join(fixture.root, "exported-large-bootstrap");
+
+    const result = await exportClawAgent("worker", out, {
+      env: fixture.env,
+      config: fixture.config,
+      packageDeps: fixture.packageDeps,
+      sourceMcpServers: fixture.sourceMcpServers,
+    });
+
+    expect(result.filesWritten).toContain("BOOTSTRAP.md");
+    await expect(readFile(join(out, "BOOTSTRAP.md"))).resolves.toEqual(content);
+    await expect(stat(join(out, "BOOTSTRAP.md"))).resolves.toMatchObject({
+      size: content.byteLength,
+    });
+  });
+
+  it("keeps pending package bootstrap outside the managed workspace aggregate", async () => {
+    const workspaceContent = Buffer.alloc(900 * 1024, "w");
+    const bootstrapContent = Buffer.alloc(1536 * 1024, "b");
+    const fixture = await installedFixture({
+      extraWorkspaceFiles: ["one.md", "two.md", "three.md"],
+      extraWorkspaceFileContent: workspaceContent,
+      packageBootstrap: true,
+      packageBootstrapContent: bootstrapContent,
+    });
+    const out = join(fixture.root, "exported-independent-bootstrap-quota");
+
+    const result = await exportClawAgent("worker", out, {
+      env: fixture.env,
+      config: fixture.config,
+      packageDeps: fixture.packageDeps,
+      sourceMcpServers: fixture.sourceMcpServers,
+    });
+
+    expect(result.filesWritten).toContain("BOOTSTRAP.md");
+    await expect(readFile(join(out, "BOOTSTRAP.md"))).resolves.toEqual(bootstrapContent);
+    for (const path of ["one.md", "two.md", "three.md"]) {
+      await expect(readFile(join(out, "workspace", path))).resolves.toEqual(workspaceContent);
+    }
   });
 
   it("exports a whitespace-only SOUL.md as an explicit workspace file", async () => {

--- a/src/claws/export.ts
+++ b/src/claws/export.ts
@@ -5,6 +5,7 @@ import { dirname, relative, resolve, sep } from "node:path";
 import { stringify as stringifyYaml } from "yaml";
 import { listAgentEntries, resolveAgentWorkspaceDir } from "../agents/agent-scope.js";
 import { openLocalAgentAvatarFile } from "../agents/identity-avatar-file.js";
+import { MAX_WORKSPACE_BOOTSTRAP_FILE_BYTES } from "../agents/workspace-bootstrap-read.js";
 import { normalizeConfiguredMcpServers } from "../config/mcp-config-normalize.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { readFileDescriptorBoundedSync } from "../infra/boundary-file-read.js";
@@ -357,6 +358,19 @@ export async function exportClawAgent(
   if (avatar.sidecar && !managedPaths.has(avatar.sidecar.path)) {
     contents.push(avatar.sidecar);
   }
+  let pendingPackageBootstrap: Buffer | undefined;
+  if (record.install.bootstrap && record.bootstrapState === "pending") {
+    pendingPackageBootstrap = await workspace.readBytes("BOOTSTRAP.md", {
+      maxBytes: MAX_WORKSPACE_BOOTSTRAP_FILE_BYTES,
+    });
+    const contentDigest = `sha256:${createHash("sha256").update(pendingPackageBootstrap).digest("hex")}`;
+    if (contentDigest !== record.install.bootstrap.contentDigest) {
+      throw new ClawExportError(
+        "bootstrap_drifted",
+        "Cannot export BOOTSTRAP.md because it changed during ownership inspection.",
+      );
+    }
+  }
   const bootstrapFiles: ClawManifest["workspace"]["bootstrapFiles"] = {};
   const files: ClawManifest["workspace"]["files"] = [];
   for (const file of contents) {
@@ -378,7 +392,6 @@ export async function exportClawAgent(
   const manifest: ClawManifest = {
     schemaVersion: CLAW_SCHEMA_VERSION,
     agent: portableAgent(agent, avatar.source),
-    ...(openClawProfile ? { metadata: { "openclaw.config": openClawProfilePath } } : {}),
     workspace: { bootstrapFiles, files },
     packages: record.packages
       .map((pkg) => ({
@@ -477,6 +490,9 @@ export async function exportClawAgent(
         ...contents,
         ...(clawMarkdownBody ? [{ path: "CLAW.md#body", content: clawMarkdownBody }] : []),
         ...(openClawProfileRaw ? [{ path: openClawProfilePath, content: openClawProfileRaw }] : []),
+        ...(pendingPackageBootstrap
+          ? [{ path: "BOOTSTRAP.md", content: pendingPackageBootstrap }]
+          : []),
       ]),
       type: "module",
       openclaw: { claw: "CLAW.md" },
@@ -487,6 +503,10 @@ export async function exportClawAgent(
     filesWritten.push("package.json");
     await output.write("CLAW.md", clawMarkdownRaw, { overwrite: false });
     filesWritten.push("CLAW.md");
+    if (pendingPackageBootstrap) {
+      await output.write("BOOTSTRAP.md", pendingPackageBootstrap, { overwrite: false });
+      filesWritten.push("BOOTSTRAP.md");
+    }
   } catch (error) {
     await rm(target, { recursive: true, force: true }).catch(() => undefined);
     throw new ClawExportError(

--- a/src/claws/lifecycle-bootstrap-removal.ts
+++ b/src/claws/lifecycle-bootstrap-removal.ts
@@ -1,0 +1,60 @@
+import { MAX_WORKSPACE_BOOTSTRAP_FILE_BYTES } from "../agents/workspace-bootstrap-read.js";
+import { removeClawWorkspaceFile, type RemovedWorkspaceFile } from "./lifecycle-delete-support.js";
+import type { ClawRemovePlanAction } from "./lifecycle-remove-contract.js";
+import type { ClawStatusRecord } from "./lifecycle-status.js";
+
+export function clawBootstrapStateBlocksRemove(record: ClawStatusRecord): boolean {
+  return Boolean(
+    record.install.bootstrap &&
+    (record.bootstrap.state === "unsafe" || record.bootstrap.state === "unknown"),
+  );
+}
+
+export function planClawBootstrapRemoval(
+  record: ClawStatusRecord,
+): ClawRemovePlanAction | undefined {
+  if (!record.install.bootstrap) {
+    return undefined;
+  }
+  const blocked = clawBootstrapStateBlocksRemove(record);
+  return {
+    kind: "bootstrap",
+    id: record.bootstrap.path,
+    action: record.bootstrap.state === "pending" ? "delete" : "retain",
+    target: `${record.bootstrap.workspace}:${record.bootstrap.path}`,
+    blocked,
+    details: {
+      expectedState: record.bootstrap.state,
+      contentDigest: record.install.bootstrap.contentDigest,
+      sourcePath: record.install.bootstrap.sourcePath,
+      lifecycle: "native-seed-once",
+    },
+    ...(record.bootstrap.state === "modified"
+      ? { reason: "Local bootstrap content changed; preserve the file." }
+      : record.bootstrap.state === "complete"
+        ? { reason: "Native onboarding already consumed the bootstrap." }
+        : {}),
+  };
+}
+
+export async function removeClawBootstrap(
+  record: ClawStatusRecord,
+): Promise<RemovedWorkspaceFile | undefined> {
+  if (!record.install.bootstrap) {
+    return undefined;
+  }
+  if (record.bootstrap.state === "pending") {
+    return removeClawWorkspaceFile(
+      {
+        workspace: record.bootstrap.workspace,
+        path: record.bootstrap.path,
+        contentDigest: record.install.bootstrap.contentDigest,
+        state: "unchanged",
+      },
+      MAX_WORKSPACE_BOOTSTRAP_FILE_BYTES,
+    );
+  }
+  return record.bootstrap.state === "modified"
+    ? { path: record.bootstrap.path, action: "retainedModified" }
+    : { path: record.bootstrap.path, action: "missing" };
+}

--- a/src/claws/lifecycle-delete-support.ts
+++ b/src/claws/lifecycle-delete-support.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import type { DatabaseSync } from "node:sqlite";
 import { findOverlappingWorkspaceAgentIds } from "../agents/agent-delete-safety.js";
 import { listAgentEntries, resolveAgentDir } from "../agents/agent-scope.js";
+import { MAX_WORKSPACE_BOOTSTRAP_FILE_BYTES } from "../agents/workspace-bootstrap-read.js";
 import {
   prepareLegacyWorkspaceStateReset,
   removeLegacyWorkspaceStateForReset,
@@ -11,7 +12,12 @@ import {
 import {
   deleteWorkspaceState,
   prepareWorkspaceStateDeletion,
+  readWorkspaceStateSnapshot,
 } from "../agents/workspace-state-store.js";
+import {
+  DEFAULT_BOOTSTRAP_FILENAME,
+  resolveWorkspaceBootstrapStatus,
+} from "../agents/workspace.js";
 import { pruneAgentConfig } from "../commands/agents.config.js";
 import { moveToTrash } from "../commands/onboard-helpers.js";
 import { resolveSessionTranscriptsDirForAgent } from "../config/sessions.js";
@@ -285,10 +291,17 @@ export const clawRemoveQuietRuntime: RuntimeEnv = {
   },
 };
 
-type ClawRemovableWorkspaceFile = PersistedClawWorkspaceFile & {
+type DigestOwnedWorkspaceFile = Pick<
+  PersistedClawWorkspaceFile,
+  "workspace" | "path" | "contentDigest"
+>;
+
+type DigestOwnedWorkspaceFileStatus = {
   state: "unchanged" | "modified" | "missing" | "unsafe";
   message?: string;
 };
+
+type ClawRemovableWorkspaceFile = DigestOwnedWorkspaceFile & DigestOwnedWorkspaceFileStatus;
 
 export type RemovedWorkspaceFile = {
   path: string;
@@ -301,35 +314,110 @@ export type ClawManagedFileStatus = PersistedClawWorkspaceFile & {
   message?: string;
 };
 
-export async function inspectClawWorkspaceFile(
-  record: PersistedClawWorkspaceFile,
-): Promise<ClawManagedFileStatus> {
+export type ClawBootstrapStatus = {
+  state: "pending" | "complete" | "modified" | "missing" | "unsafe" | "unknown";
+  workspace: string;
+  path: string;
+  sourcePath?: string;
+  contentDigest?: string;
+  message?: string;
+};
+
+async function inspectDigestOwnedWorkspaceFile(
+  record: DigestOwnedWorkspaceFile,
+  maxBytes = 1024 * 1024,
+): Promise<DigestOwnedWorkspaceFileStatus> {
   try {
     const workspace = await fsSafeRoot(record.workspace, {
       hardlinks: "reject",
-      maxBytes: 1024 * 1024,
+      maxBytes,
       symlinks: "reject",
     });
     if (!(await workspace.exists(record.path))) {
-      return { ...record, state: "missing" };
+      return { state: "missing" };
     }
-    const content = await workspace.readBytes(record.path, { maxBytes: 1024 * 1024 });
+    const content = await workspace.readBytes(record.path, { maxBytes });
     const digest = `sha256:${createHash("sha256").update(content).digest("hex")}`;
-    return { ...record, state: digest === record.contentDigest ? "unchanged" : "modified" };
+    return {
+      state: digest === record.contentDigest ? "unchanged" : "modified",
+    };
   } catch (error) {
     if ((error as NodeJS.ErrnoException).code === "ENOENT") {
-      return { ...record, state: "missing" };
+      return { state: "missing" };
     }
     return {
-      ...record,
       state: "unsafe",
       message: error instanceof Error ? error.message : String(error),
     };
   }
 }
 
+export async function inspectClawWorkspaceFile(
+  record: PersistedClawWorkspaceFile,
+): Promise<ClawManagedFileStatus> {
+  return { ...record, ...(await inspectDigestOwnedWorkspaceFile(record)) };
+}
+
+export async function inspectClawBootstrap(
+  install: PersistedClawInstall,
+  options: OpenClawStateDatabaseOptions,
+): Promise<ClawBootstrapStatus> {
+  const nativeState = await resolveWorkspaceBootstrapStatus(install.workspace, options);
+  const setupState = readWorkspaceStateSnapshot(install.workspace, options).setup;
+  const base = {
+    workspace: install.workspace,
+    path: DEFAULT_BOOTSTRAP_FILENAME,
+    ...install.bootstrap,
+  };
+  const nativeBootstrapConsumed =
+    typeof setupState.setupCompletedAt === "string" ||
+    typeof setupState.bootstrapSeededAt === "string";
+  if (nativeState === "complete" && (!install.bootstrap || nativeBootstrapConsumed)) {
+    return { ...base, state: "complete" };
+  }
+  if (!install.bootstrap) {
+    return { ...base, state: nativeState };
+  }
+  const bootstrapSeedingPending =
+    install.status === "pending" ||
+    install.status === "partial" ||
+    install.status === "workspace_ready";
+  if (bootstrapSeedingPending) {
+    try {
+      await fs.lstat(install.workspace);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+        return { ...base, state: "missing" };
+      }
+    }
+  }
+  const inspected = await inspectDigestOwnedWorkspaceFile(
+    {
+      workspace: install.workspace,
+      path: DEFAULT_BOOTSTRAP_FILENAME,
+      contentDigest: install.bootstrap.contentDigest,
+    },
+    MAX_WORKSPACE_BOOTSTRAP_FILE_BYTES,
+  );
+  if (inspected.state === "unchanged") {
+    return { ...base, state: "pending" };
+  }
+  if (inspected.state === "modified" || inspected.state === "unsafe") {
+    return {
+      ...base,
+      state: inspected.state,
+      ...(inspected.message ? { message: inspected.message } : {}),
+    };
+  }
+  if (bootstrapSeedingPending) {
+    return { ...base, state: "missing" };
+  }
+  return { ...base, state: "unknown", message: "BOOTSTRAP.md disappeared during inspection." };
+}
+
 export async function removeClawWorkspaceFile(
   record: ClawRemovableWorkspaceFile,
+  maxBytes = 1024 * 1024,
 ): Promise<RemovedWorkspaceFile> {
   if (record.state === "missing") {
     return { path: record.path, action: "missing" };
@@ -340,7 +428,7 @@ export async function removeClawWorkspaceFile(
   try {
     const workspace = await fsSafeRoot(record.workspace, {
       hardlinks: "reject",
-      maxBytes: 1024 * 1024,
+      maxBytes,
       symlinks: "reject",
     });
     if (!(await workspace.exists(record.path))) {
@@ -348,7 +436,7 @@ export async function removeClawWorkspaceFile(
     }
     const stagedPath = `${record.path}.openclaw-claw-remove-${randomUUID()}`;
     await workspace.move(record.path, stagedPath, { overwrite: false });
-    const content = await workspace.readBytes(stagedPath, { maxBytes: 1024 * 1024 });
+    const content = await workspace.readBytes(stagedPath, { maxBytes });
     const digest = `sha256:${createHash("sha256").update(content).digest("hex")}`;
     if (digest !== record.contentDigest) {
       await workspace.move(stagedPath, record.path, { overwrite: false });

--- a/src/claws/lifecycle-remove-contract.ts
+++ b/src/claws/lifecycle-remove-contract.ts
@@ -13,6 +13,7 @@ export type ClawRemovePlanAction = {
     | "sessionTranscripts"
     | "scheduledJob"
     | "workspaceFile"
+    | "bootstrap"
     | "packageRef"
     | "mcpServer"
     | "cronJob"

--- a/src/claws/lifecycle-state.ts
+++ b/src/claws/lifecycle-state.ts
@@ -15,6 +15,11 @@ import {
   type ClawCronGateway,
 } from "./cron.js";
 import {
+  clawBootstrapStateBlocksRemove,
+  planClawBootstrapRemoval,
+  removeClawBootstrap,
+} from "./lifecycle-bootstrap-removal.js";
+import {
   claimClawAgentConfigRemoval,
   digestClawAgentRemovalSurface,
   type ConfigCommit,
@@ -64,6 +69,7 @@ type ClawRemoveResult = {
   status: "complete" | "partial";
   agentId: string;
   agentRemoved: boolean;
+  bootstrap?: RemovedWorkspaceFile;
   workspaceFiles: RemovedWorkspaceFile[];
   packages: ClawPackageRemovalResult[];
   mcpServers: RemovedMcpServer[];
@@ -109,6 +115,12 @@ export async function buildClawRemovePlan(
         message: `${file.path}: ${file.message ?? "unsafe file"}`,
       });
     }
+  }
+  if (record && clawBootstrapStateBlocksRemove(record)) {
+    blockers.push({
+      code: "bootstrap_cleanup_uncertain",
+      message: `BOOTSTRAP.md has ${record.bootstrap.state} ownership state and must be reconciled before removal.`,
+    });
   }
   for (const server of record?.mcpServers ?? []) {
     if (server.state === "pending") {
@@ -157,12 +169,18 @@ export async function buildClawRemovePlan(
       record.install.agentId,
       record.install.workspace,
     );
-    const workspaceHasModifiedFiles = record.workspaceFiles.some(
-      (file) => file.state === "modified",
-    );
+    const workspaceHasModifiedFiles =
+      record.workspaceFiles.some((file) => file.state === "modified") ||
+      record.bootstrap.state === "modified";
+    const trackedWorkspacePaths = [
+      ...record.workspaceFiles.map((file) => file.path),
+      ...(record.install.bootstrap && record.bootstrap.state === "pending"
+        ? [record.bootstrap.path]
+        : []),
+    ];
     const workspaceHasUntrackedEntries = await workspaceContainsUntrackedEntries(
       record.install.workspace,
-      record.workspaceFiles.map((file) => file.path),
+      trackedWorkspacePaths,
     );
     const attachedJobs = readAttachedCronJobs(record.install.agentId, options);
     const ownedSchedulerJobIds = new Set(
@@ -292,6 +310,10 @@ export async function buildClawRemovePlan(
           ? { reason: "Local content changed; preserve the file." }
           : {}),
       });
+    }
+    const bootstrapAction = planClawBootstrapRemoval(record);
+    if (bootstrapAction) {
+      actions.push(bootstrapAction);
     }
     actions.push(...packagePlan.actions);
     const unmatchedMcpSelectors = new Set(mcpCleanup?.selected ?? []);
@@ -435,6 +457,7 @@ export async function applyClawRemovePlan(
   if (
     !record ||
     record.agentState === "modified" ||
+    clawBootstrapStateBlocksRemove(record) ||
     record.workspaceFiles.some((file) => file.state === "unsafe") ||
     record.mcpServers.some((server) => server.state === "pending")
   ) {
@@ -625,9 +648,13 @@ export async function applyClawRemovePlan(
   for (const file of record.workspaceFiles) {
     workspaceFiles.push(await removeClawWorkspaceFile(file));
   }
+  const bootstrap = await removeClawBootstrap(record);
   const cleanupErrors = workspaceFiles
     .filter((file) => file.action === "error")
     .map((file) => file.message ?? `Could not remove ${file.path}.`);
+  if (bootstrap?.action === "error") {
+    cleanupErrors.push(bootstrap.message ?? `Could not remove ${bootstrap.path}.`);
+  }
   if (cleanupErrors.length === 0 && cleanupTargets && committedNextConfig) {
     const workspaceHasRemainingEntries = await workspaceContainsUntrackedEntries(
       cleanupTargets.workspaceDir,
@@ -642,6 +669,7 @@ export async function applyClawRemovePlan(
         trashPath: options.trashPath,
         retainWorkspace:
           workspaceHasRemainingEntries ||
+          bootstrap?.action === "retainedModified" ||
           workspaceFiles.some((file) => file.action === "retainedModified"),
       })),
     );
@@ -658,6 +686,7 @@ export async function applyClawRemovePlan(
     status: complete ? "complete" : "partial",
     agentId: plan.agentId,
     agentRemoved,
+    ...(bootstrap ? { bootstrap } : {}),
     workspaceFiles,
     packages,
     mcpServers,

--- a/src/claws/lifecycle-status.ts
+++ b/src/claws/lifecycle-status.ts
@@ -8,10 +8,12 @@ import { readClawCronRefs, type PersistedClawCronRef } from "./cron.js";
 import { digestClawAgentConfig } from "./lifecycle-config-removal.js";
 import {
   ClawRemoveError,
+  inspectClawBootstrap,
   inspectClawWorkspaceFile,
   readAllClawWorkspaceFiles,
   synthesizeOrphanInstall,
   type ClawManagedFileStatus,
+  type ClawBootstrapStatus,
 } from "./lifecycle-delete-support.js";
 import {
   digestClawMcpServer,
@@ -42,6 +44,8 @@ export type ClawStatusRecord = {
   install: PersistedClawInstall;
   orphaned?: boolean;
   agentState: "present" | "modified" | "missing";
+  bootstrapState: ClawBootstrapStatus["state"];
+  bootstrap: ClawBootstrapStatus;
   workspaceFiles: ClawManagedFileStatus[];
   packages: ClawPackageInspection[];
   mcpServers: ClawMcpServerStatus[];
@@ -56,6 +60,7 @@ type ClawStatusResult = {
   summary: {
     claws: number;
     partial: number;
+    pendingBootstrap: number;
     missingAgents: number;
     driftedFiles: number;
     packageRefs: number;
@@ -148,6 +153,13 @@ export async function readClawStatus(
     const workspaceFiles = installAgentIds.has(install.agentId)
       ? readClawWorkspaceFiles(install.agentId, options)
       : allWorkspaceFiles.filter((file) => file.agentId === install.agentId);
+    const bootstrap = installAgentIds.has(install.agentId)
+      ? await inspectClawBootstrap(install, options)
+      : {
+          state: "unknown" as const,
+          workspace: install.workspace,
+          path: "BOOTSTRAP.md" as const,
+        };
     records.push({
       install,
       ...(installAgentIds.has(install.agentId) ? {} : { orphaned: true }),
@@ -156,6 +168,8 @@ export async function readClawStatus(
         : digestClawAgentConfig(agent) === install.agentConfigDigest
           ? "present"
           : "modified",
+      bootstrapState: bootstrap.state,
+      bootstrap,
       workspaceFiles: await Promise.all(workspaceFiles.map(inspectClawWorkspaceFile)),
       packages: await Promise.all(
         packageRefs.map((packageRef) =>
@@ -177,6 +191,7 @@ export async function readClawStatus(
     summary: {
       claws: records.length,
       partial: records.filter((record) => record.install.status !== "complete").length,
+      pendingBootstrap: records.filter((record) => record.bootstrapState === "pending").length,
       missingAgents: records.filter((record) => record.agentState === "missing").length,
       driftedFiles: records
         .flatMap((record) => record.workspaceFiles)

--- a/src/claws/lifecycle.ts
+++ b/src/claws/lifecycle.ts
@@ -24,6 +24,7 @@ import {
   type ClawOpenClawProfile,
   type ClawPackage,
   type ClawSourceIdentity,
+  type ClawWorkspaceSourceSnapshot,
 } from "./types.js";
 
 const AGENT_ID_PATTERN = /^[a-z][a-z0-9_-]{0,63}$/;
@@ -194,6 +195,8 @@ async function inspectWorkspaceFileAction(params: {
 export async function buildClawAddPlan(params: {
   manifest: ClawManifest;
   clawMarkdownBody?: Buffer;
+  packageBootstrap?: ClawWorkspaceSourceSnapshot;
+  includePackageBootstrap?: boolean;
   openClawProfile?: ClawOpenClawProfile;
   source: ClawSourceIdentity;
   diagnostics?: ClawDiagnostic[];
@@ -302,6 +305,27 @@ export async function buildClawAddPlan(params: {
       ? { reason: `Workspace ${JSON.stringify(workspace)} already exists.` }
       : {}),
   });
+
+  if (params.packageBootstrap && params.includePackageBootstrap !== false) {
+    actions.push({
+      kind: "bootstrap",
+      id: "BOOTSTRAP.md",
+      action: "write",
+      target: resolve(workspace, "BOOTSTRAP.md"),
+      source: params.packageBootstrap.realPath,
+      digest: params.packageBootstrap.digest,
+      details: {
+        sourcePath: params.packageBootstrap.sourcePath,
+        byteLength: params.packageBootstrap.byteLength,
+        expectedState: "absent-or-native-consumed",
+        lifecycle: "native-seed-once",
+      },
+      blocked: workspaceBlocked,
+      ...(workspaceBlocked
+        ? { reason: `Workspace ${JSON.stringify(workspace)} already exists.` }
+        : {}),
+    });
+  }
 
   const pendingWorkspaceFiles: PendingWorkspaceFileAction[] = [];
   async function addWorkspaceFileInspection(fileParams: {
@@ -629,7 +653,10 @@ export async function buildClawAddPlan(params: {
       totalActions: actions.length,
       agentActions: actions.filter((action) => action.kind === "agent").length,
       workspaceActions: actions.filter(
-        (action) => action.kind === "workspace" || action.kind === "workspaceFile",
+        (action) =>
+          action.kind === "workspace" ||
+          action.kind === "bootstrap" ||
+          action.kind === "workspaceFile",
       ).length,
       packageActions: actions.filter((action) => action.kind === "package").length,
       mcpServerActions: actions.filter((action) => action.kind === "mcpServer").length,

--- a/src/claws/openclaw-profile.test.ts
+++ b/src/claws/openclaw-profile.test.ts
@@ -71,7 +71,7 @@ describe("OpenClaw profile schema", () => {
 });
 
 describe("OpenClaw profile reader", () => {
-  it("loads and integrity-binds a metadata-referenced profile", async () => {
+  it("loads and integrity-binds the conventional profile", async () => {
     const root = tempDirs.make("openclaw-claw-profile-");
     await mkdir(join(root, "profiles"));
     await writeFile(
@@ -85,17 +85,9 @@ describe("OpenClaw profile reader", () => {
     );
     await writeFile(
       join(root, "CLAW.md"),
-      [
-        "---",
-        "schemaVersion: 1",
-        "agent:",
-        "  id: triage",
-        "metadata:",
-        "  openclaw.config: profiles/openclaw.yml",
-        "---",
-        "",
-        "# GitHub Triage",
-      ].join("\n"),
+      ["---", "schemaVersion: 1", "agent:", "  id: triage", "---", "", "# GitHub Triage"].join(
+        "\n",
+      ),
       "utf8",
     );
     const profilePath = join(root, "profiles", "openclaw.yml");
@@ -116,9 +108,6 @@ describe("OpenClaw profile reader", () => {
     const first = await readClawManifestFile(root);
     expect(first).toMatchObject({
       ok: true,
-      manifest: {
-        metadata: { "openclaw.config": "profiles/openclaw.yml" },
-      },
       openClawProfile: {
         schemaVersion: 1,
         agent: {
@@ -151,7 +140,6 @@ describe("OpenClaw profile reader", () => {
       JSON.stringify({
         schemaVersion: 1,
         agent: { id: "triage" },
-        metadata: { "openclaw.config": "profiles/openclaw.yml" },
       }),
       "utf8",
     );
@@ -175,7 +163,6 @@ describe("OpenClaw profile reader", () => {
       JSON.stringify({
         schemaVersion: 1,
         agent: { id: "triage" },
-        metadata: { "openclaw.config": "profiles/openclaw.yml" },
       }),
       "utf8",
     );
@@ -190,8 +177,8 @@ describe("OpenClaw profile reader", () => {
     });
   });
 
-  it("rejects an escaping profile path", async () => {
-    const root = tempDirs.make("openclaw-claw-profile-path-");
+  it("fails closed for a retired metadata profile pointer", async () => {
+    const root = tempDirs.make("openclaw-claw-profile-pointer-");
     const path = join(root, "openclaw.claw.json");
     await writeFile(
       path,
@@ -202,54 +189,34 @@ describe("OpenClaw profile reader", () => {
       }),
       "utf8",
     );
+    await writeFile(join(root, "openclaw.yml"), "schemaVersion: 1\nagent: {}\n", "utf8");
 
     const result = await readClawManifestFile(path);
 
     expect(result).toMatchObject({
       ok: false,
-      diagnostics: [expect.objectContaining({ code: "invalid_openclaw_profile_path" })],
+      diagnostics: [
+        expect.objectContaining({
+          code: "legacy_openclaw_profile_pointer",
+          path: "$.metadata.openclaw.config",
+        }),
+      ],
     });
   });
 
-  it("rejects a backslash profile path", async () => {
-    const root = tempDirs.make("openclaw-claw-profile-backslash-path-");
+  it("does not inspect profiles owned by other harnesses", async () => {
+    const root = tempDirs.make("openclaw-claw-foreign-profile-");
+    await mkdir(join(root, "profiles"));
     const path = join(root, "openclaw.claw.json");
-    await writeFile(
-      path,
-      JSON.stringify({
-        schemaVersion: 1,
-        agent: { id: "triage" },
-        metadata: { "openclaw.config": "profiles\\openclaw.yml" },
-      }),
-      "utf8",
-    );
+    await writeFile(path, JSON.stringify({ schemaVersion: 1, agent: { id: "triage" } }), "utf8");
+    await writeFile(join(root, "profiles", "codex.yml"), Buffer.alloc(300 * 1024, "x"));
 
     const result = await readClawManifestFile(path);
 
-    expect(result).toMatchObject({
-      ok: false,
-      diagnostics: [expect.objectContaining({ code: "invalid_openclaw_profile_path" })],
-    });
-  });
-
-  it("rejects an empty declared profile path", async () => {
-    const root = tempDirs.make("openclaw-claw-profile-empty-path-");
-    const path = join(root, "openclaw.claw.json");
-    await writeFile(
-      path,
-      JSON.stringify({
-        schemaVersion: 1,
-        agent: { id: "triage" },
-        metadata: { "openclaw.config": "" },
-      }),
-      "utf8",
-    );
-
-    const result = await readClawManifestFile(path);
-
-    expect(result).toMatchObject({
-      ok: false,
-      diagnostics: [expect.objectContaining({ code: "invalid_openclaw_profile_path" })],
-    });
+    expect(result).toMatchObject({ ok: true });
+    if (!result.ok) {
+      throw new Error("expected foreign profile to remain opaque");
+    }
+    expect(result.openClawProfile).toBeUndefined();
   });
 });

--- a/src/claws/openclaw-profile.ts
+++ b/src/claws/openclaw-profile.ts
@@ -1,11 +1,11 @@
-// Safe loader for package-local OpenClaw profiles referenced by Claw metadata.
+// Safe loader for the conventional package-local OpenClaw profile.
 import { isScalar, parseDocument, visit } from "yaml";
 import { FsSafeError, root as fsSafeRoot } from "../infra/fs-safe.js";
-import { isSafeClawRelativePath } from "./schema-portability.js";
 import { parseClawOpenClawProfile } from "./schema.js";
-import type { ClawDiagnostic, ClawManifest, ClawOpenClawProfile } from "./types.js";
+import type { ClawDiagnostic, ClawOpenClawProfile } from "./types.js";
 
 const MAX_PROFILE_BYTES = 256 * 1024;
+const CLAW_PROFILE_PATH = "profiles/openclaw.yml";
 
 function diagnostic(code: string, message: string, path = "$"): ClawDiagnostic {
   return { level: "error", code, phase: "parse", path, message };
@@ -84,30 +84,27 @@ async function readProfileFile(packageRoot: string, path: string): Promise<Buffe
 
 export async function readClawOpenClawProfile(params: {
   packageRoot: string;
-  manifest: ClawManifest;
+  metadata?: Record<string, string>;
 }): Promise<
   | { ok: true; profile?: ClawOpenClawProfile; raw?: Buffer; path?: string }
   | { ok: false; diagnostics: ClawDiagnostic[] }
 > {
-  const declaredPath = params.manifest.metadata?.["openclaw.config"];
-  if (declaredPath === undefined) {
-    return { ok: true };
-  }
-  if (
-    declaredPath.includes("\\") ||
-    !isSafeClawRelativePath(declaredPath) ||
-    !/\.ya?ml$/i.test(declaredPath)
-  ) {
+  if (Object.hasOwn(params.metadata ?? {}, "openclaw.config")) {
     return {
       ok: false,
       diagnostics: [
         diagnostic(
-          "invalid_openclaw_profile_path",
-          "metadata.openclaw.config must reference a forward-slash package-relative .yml or .yaml file.",
+          "legacy_openclaw_profile_pointer",
+          "metadata.openclaw.config is no longer supported; move the profile to profiles/openclaw.yml and remove the metadata entry.",
           "$.metadata.openclaw.config",
         ),
       ],
     };
+  }
+  const declaredPath = CLAW_PROFILE_PATH;
+  const packageFiles = await fsSafeRoot(params.packageRoot);
+  if (!(await packageFiles.exists(declaredPath))) {
+    return { ok: true };
   }
 
   let raw: Buffer;
@@ -132,7 +129,7 @@ export async function readClawOpenClawProfile(params: {
             : tooLarge
               ? `The OpenClaw profile exceeds ${MAX_PROFILE_BYTES} bytes.`
               : `Could not read ${declaredPath}: ${(error as Error).message}`,
-          "$.metadata.openclaw.config",
+          "$.profiles.openclaw",
         ),
       ],
     };
@@ -148,7 +145,7 @@ export async function readClawOpenClawProfile(params: {
       ok: false,
       diagnostics: parsed.diagnostics.map((entry) => ({
         ...entry,
-        path: `$.metadata.openclaw.config${entry.path.slice(1)}`,
+        path: `$.profiles.openclaw${entry.path.slice(1)}`,
       })),
     };
   }

--- a/src/claws/provenance-bootstrap.ts
+++ b/src/claws/provenance-bootstrap.ts
@@ -1,0 +1,26 @@
+import type { DatabaseSync } from "node:sqlite";
+import { tableHasColumn } from "../state/openclaw-state-db-schema-helpers.js";
+
+export function selectClawBootstrapProvenanceColumns(db: DatabaseSync): string {
+  const sourcePath = tableHasColumn(db, "claw_installs", "bootstrap_source_path")
+    ? "bootstrap_source_path"
+    : "NULL AS bootstrap_source_path";
+  const contentDigest = tableHasColumn(db, "claw_installs", "bootstrap_content_digest")
+    ? "bootstrap_content_digest"
+    : "NULL AS bootstrap_content_digest";
+  return `${sourcePath}, ${contentDigest}`;
+}
+
+export function clawBootstrapProvenanceFromRow(row: {
+  bootstrap_source_path: string | null;
+  bootstrap_content_digest: string | null;
+}) {
+  return row.bootstrap_source_path && row.bootstrap_content_digest
+    ? {
+        bootstrap: {
+          sourcePath: row.bootstrap_source_path,
+          contentDigest: row.bootstrap_content_digest,
+        },
+      }
+    : {};
+}

--- a/src/claws/provenance.ts
+++ b/src/claws/provenance.ts
@@ -7,6 +7,10 @@ import {
   runOpenClawStateWriteTransaction,
   type OpenClawStateDatabaseOptions,
 } from "../state/openclaw-state-db.js";
+import {
+  clawBootstrapProvenanceFromRow,
+  selectClawBootstrapProvenanceColumns,
+} from "./provenance-bootstrap.js";
 import type { ClawAddPlan, ClawPackage, ResolvedClawPackage } from "./types.js";
 
 const CLAW_INSTALL_RECORD_SCHEMA_VERSION = "openclaw.clawInstallRecord.v1" as const;
@@ -34,6 +38,8 @@ type ClawInstallRow = {
   workspace: string;
   agent_config_digest: string;
   agent_owned_paths_json: string;
+  bootstrap_source_path: string | null;
+  bootstrap_content_digest: string | null;
   status: ClawInstallStatus;
   added_at_ms: number | bigint;
   updated_at_ms: number | bigint;
@@ -48,6 +54,7 @@ export type PersistedClawInstall = {
   workspace: string;
   agentConfigDigest: string;
   agentOwnedPaths: string[];
+  bootstrap?: { sourcePath: string; contentDigest: string };
   status: ClawInstallStatus;
   addedAtMs: number;
   updatedAtMs: number;
@@ -69,6 +76,8 @@ type InstallRow = {
   workspace: string;
   agent_config_digest: string;
   agent_owned_paths_json: string;
+  bootstrap_source_path: string | null;
+  bootstrap_content_digest: string | null;
   status: ClawInstallStatus;
   added_at_ms: number | bigint;
   updated_at_ms: number | bigint;
@@ -95,6 +104,7 @@ function rowToInstall(row: InstallRow): PersistedClawInstall {
     workspace: row.workspace,
     agentConfigDigest: row.agent_config_digest,
     agentOwnedPaths: JSON.parse(row.agent_owned_paths_json) as string[],
+    ...clawBootstrapProvenanceFromRow(row),
     status: row.status,
     addedAtMs: Number(row.added_at_ms),
     updatedAtMs: Number(row.updated_at_ms),
@@ -107,6 +117,14 @@ function digestAgentConfig(plan: ClawAddPlan): string {
 
 function agentOwnedPaths(plan: ClawAddPlan): string[] {
   return plan.actions.filter((action) => action.kind === "agent").map((action) => action.target);
+}
+
+function bootstrapProvenance(plan: ClawAddPlan) {
+  const action = plan.actions.find((candidate) => candidate.kind === "bootstrap");
+  const sourcePath = action?.details?.sourcePath;
+  return action && typeof sourcePath === "string" && action.digest
+    ? { sourcePath, contentDigest: action.digest }
+    : undefined;
 }
 
 function rowToRecord(row: ClawInstallRow): PersistedClawInstall {
@@ -130,6 +148,7 @@ function rowToRecord(row: ClawInstallRow): PersistedClawInstall {
     workspace: row.workspace,
     agentConfigDigest: row.agent_config_digest,
     agentOwnedPaths: JSON.parse(row.agent_owned_paths_json) as string[],
+    ...clawBootstrapProvenanceFromRow(row),
     status: row.status,
     addedAtMs: Number(row.added_at_ms),
     updatedAtMs: Number(row.updated_at_ms),
@@ -137,12 +156,14 @@ function rowToRecord(row: ClawInstallRow): PersistedClawInstall {
 }
 
 function selectClawInstallRow(db: DatabaseSync, agentId: string): ClawInstallRow | undefined {
+  const bootstrapColumns = selectClawBootstrapProvenanceColumns(db);
   return db /* sqlite-allow-raw: this Claw prototype state-table read is scoped to one owned row. */
     .prepare(
       `SELECT agent_id, schema_version, source_kind, claw_name, claw_version,
               package_root, manifest_path, integrity_kind, integrity, source_byte_length,
               manifest_schema_version, plan_integrity, workspace, agent_config_digest,
-              agent_owned_paths_json, status, added_at_ms, updated_at_ms
+              agent_owned_paths_json, ${bootstrapColumns},
+              status, added_at_ms, updated_at_ms
          FROM claw_installs
         WHERE agent_id = ?`,
     )
@@ -170,6 +191,7 @@ function isSameInstallAttempt(
   agentConfigDigest: string,
   ownedPaths: string[],
 ): boolean {
+  const bootstrap = bootstrapProvenance(plan);
   return (
     row.schema_version === CLAW_INSTALL_RECORD_SCHEMA_VERSION &&
     row.source_kind === plan.claw.kind &&
@@ -184,7 +206,9 @@ function isSameInstallAttempt(
     row.plan_integrity === plan.planIntegrity &&
     row.workspace === plan.agent.workspace &&
     row.agent_config_digest === agentConfigDigest &&
-    row.agent_owned_paths_json === JSON.stringify(ownedPaths)
+    row.agent_owned_paths_json === JSON.stringify(ownedPaths) &&
+    row.bootstrap_source_path === (bootstrap?.sourcePath ?? null) &&
+    row.bootstrap_content_digest === (bootstrap?.contentDigest ?? null)
   );
 }
 
@@ -196,6 +220,7 @@ export function persistClawInstallRecord(
   const status = options.status ?? "complete";
   const agentConfigDigest = digestAgentConfig(plan);
   const ownedPaths = agentOwnedPaths(plan);
+  const bootstrap = bootstrapProvenance(plan);
   return runOpenClawStateWriteTransaction(({ db }) => {
     const existing = selectClawInstallRow(db, plan.agent.finalId);
     if (existing) {
@@ -217,13 +242,13 @@ export function persistClawInstallRecord(
          agent_id, schema_version, source_kind, claw_name, claw_version,
          package_root, manifest_path, integrity_kind, integrity, source_byte_length,
          manifest_schema_version, plan_integrity, workspace, agent_config_digest,
-         agent_owned_paths_json,
+         agent_owned_paths_json, bootstrap_source_path, bootstrap_content_digest,
          status, added_at_ms, updated_at_ms
        ) VALUES (
          @agent_id, @schema_version, @source_kind, @claw_name, @claw_version,
          @package_root, @manifest_path, @integrity_kind, @integrity, @source_byte_length,
          @manifest_schema_version, @plan_integrity, @workspace, @agent_config_digest,
-         @agent_owned_paths_json,
+         @agent_owned_paths_json, @bootstrap_source_path, @bootstrap_content_digest,
          @status, @added_at_ms, @updated_at_ms
        )`,
     ).run({
@@ -242,6 +267,8 @@ export function persistClawInstallRecord(
       workspace: plan.agent.workspace,
       agent_config_digest: agentConfigDigest,
       agent_owned_paths_json: JSON.stringify(ownedPaths),
+      bootstrap_source_path: bootstrap?.sourcePath ?? null,
+      bootstrap_content_digest: bootstrap?.contentDigest ?? null,
       status,
       added_at_ms: nowMs,
       updated_at_ms: nowMs,
@@ -255,6 +282,7 @@ export function persistClawInstallRecord(
       workspace: plan.agent.workspace,
       agentConfigDigest,
       agentOwnedPaths: ownedPaths,
+      ...(bootstrap ? { bootstrap } : {}),
       status,
       addedAtMs: nowMs,
       updatedAtMs: nowMs,
@@ -318,6 +346,7 @@ export function readClawInstallRecords(
   options: OpenClawStateDatabaseOptions = {},
 ): PersistedClawInstall[] {
   const database = openOpenClawStateDatabase(options);
+  const bootstrapColumns = selectClawBootstrapProvenanceColumns(database.db);
   // sqlite-allow-raw: read-only Claw install inventory ordered by stable agent id.
   const rows =
     database.db /* sqlite-allow-raw: read-only Claw install inventory ordered by stable agent id. */
@@ -325,7 +354,8 @@ export function readClawInstallRecords(
         `SELECT schema_version, source_kind, claw_name, claw_version, package_root,
               manifest_path, integrity_kind, integrity, source_byte_length,
               manifest_schema_version, plan_integrity, agent_id, workspace,
-              agent_config_digest, agent_owned_paths_json, status, added_at_ms,
+              agent_config_digest, agent_owned_paths_json, ${bootstrapColumns},
+              status, added_at_ms,
               updated_at_ms
          FROM claw_installs
         ORDER BY agent_id`,
@@ -393,6 +423,7 @@ export function updateClawInstallRecord(
   const ownedAgentPaths = plan.actions
     .filter((action) => action.kind === "agent")
     .map((action) => action.target);
+  const bootstrap = bootstrapProvenance(plan) ?? current.bootstrap;
   runOpenClawStateWriteTransaction(({ db }) => {
     const result = db /* sqlite-allow-raw: Claw install provenance compare-and-swap write. */
       .prepare(
@@ -410,6 +441,8 @@ export function updateClawInstallRecord(
                 workspace = @workspace,
                 agent_config_digest = @agent_config_digest,
                 agent_owned_paths_json = @agent_owned_paths_json,
+                bootstrap_source_path = @bootstrap_source_path,
+                bootstrap_content_digest = @bootstrap_content_digest,
                 status = @status,
                 updated_at_ms = @updated_at_ms
           WHERE agent_id = @agent_id
@@ -431,6 +464,8 @@ export function updateClawInstallRecord(
         workspace: plan.agent.workspace,
         agent_config_digest: agentConfigDigest,
         agent_owned_paths_json: JSON.stringify(ownedAgentPaths),
+        bootstrap_source_path: bootstrap?.sourcePath ?? null,
+        bootstrap_content_digest: bootstrap?.contentDigest ?? null,
         status,
         updated_at_ms: updatedAtMs,
         expected_claw_version: options.expectedClaw?.version ?? current.claw.version,
@@ -451,6 +486,7 @@ export function updateClawInstallRecord(
     workspace: plan.agent.workspace,
     agentConfigDigest,
     agentOwnedPaths: ownedAgentPaths,
+    ...(bootstrap ? { bootstrap } : {}),
     status,
     addedAtMs: current.addedAtMs,
     updatedAtMs,

--- a/src/claws/reader.ts
+++ b/src/claws/reader.ts
@@ -3,6 +3,7 @@ import { createHash } from "node:crypto";
 import { realpath, stat } from "node:fs/promises";
 import { basename, dirname, isAbsolute, relative, resolve, sep } from "node:path";
 import { isScalar, parseDocument, visit } from "yaml";
+import { MAX_WORKSPACE_BOOTSTRAP_FILE_BYTES } from "../agents/workspace-bootstrap-read.js";
 import { assertNoSymlinkParents } from "../infra/fs-safe-advanced.js";
 import { FsSafeError, root as fsSafeRoot, type OpenResult } from "../infra/fs-safe.js";
 import { readClawOpenClawProfile } from "./openclaw-profile.js";
@@ -33,7 +34,6 @@ type ResolvedClawSource = Omit<ClawSourceIdentity, "integrity" | "integrityKind"
 };
 
 const CLAW_MARKDOWN_FILENAME = "CLAW.md";
-
 const MAX_CLAW_PACKAGE_JSON_BYTES = 256 * 1024;
 
 async function readBoundedFile(path: string, maxBytes: number): Promise<Buffer> {
@@ -102,6 +102,7 @@ async function buildDevelopmentSnapshot(params: {
       integrity: string;
       byteLength: number;
       workspaceSources: ClawWorkspaceSourceSnapshot[];
+      packageBootstrap?: ClawWorkspaceSourceSnapshot;
     }
   | { ok: false; diagnostics: ClawDiagnostic[] }
 > {
@@ -128,6 +129,54 @@ async function buildDevelopmentSnapshot(params: {
     add("package.json", packageJson);
   }
 
+  const sourceRoot = await fsSafeRoot(params.source.packageRoot);
+  let packageBootstrap: ClawWorkspaceSourceSnapshot | undefined;
+  if (await sourceRoot.exists("BOOTSTRAP.md")) {
+    try {
+      const read = await sourceRoot.read("BOOTSTRAP.md", {
+        hardlinks: "reject",
+        maxBytes: MAX_WORKSPACE_BOOTSTRAP_FILE_BYTES,
+        nonBlockingRead: true,
+        symlinks: "reject",
+      });
+      const text = new TextDecoder("utf-8", { fatal: true }).decode(read.buffer);
+      if (text.trim().length === 0) {
+        return {
+          ok: false,
+          diagnostics: [
+            fileDiagnostic(
+              "package_bootstrap_empty",
+              "Package-root BOOTSTRAP.md must contain first-run instructions.",
+              "$.bootstrap",
+            ),
+          ],
+        };
+      }
+      const digest = `sha256:${createHash("sha256").update(read.buffer).digest("hex")}`;
+      add("bootstrap:BOOTSTRAP.md", read.buffer);
+      packageBootstrap = {
+        sourcePath: "BOOTSTRAP.md",
+        realPath: read.realPath,
+        byteLength: read.buffer.byteLength,
+        digest,
+      };
+    } catch (error) {
+      const tooLarge = error instanceof FsSafeError && error.code === "too-large";
+      return {
+        ok: false,
+        diagnostics: [
+          fileDiagnostic(
+            tooLarge ? "package_bootstrap_too_large" : "package_bootstrap_invalid",
+            tooLarge
+              ? `Package-root BOOTSTRAP.md exceeds ${MAX_WORKSPACE_BOOTSTRAP_FILE_BYTES} bytes.`
+              : `Package-root BOOTSTRAP.md must be a safe UTF-8 regular file: ${(error as Error).message}`,
+            "$.bootstrap",
+          ),
+        ],
+      };
+    }
+  }
+
   const declaredSources = [
     ...Object.values(params.manifest.workspace.bootstrapFiles)
       .filter((entry): entry is { source: string } => entry !== undefined)
@@ -135,7 +184,6 @@ async function buildDevelopmentSnapshot(params: {
     ...params.manifest.workspace.files.map((entry) => entry.source),
   ].toSorted((left, right) => Buffer.compare(Buffer.from(left), Buffer.from(right)));
 
-  const sourceRoot = await fsSafeRoot(params.source.packageRoot);
   const openedSources: Array<{ sourcePath: string; opened: OpenResult }> = [];
   const workspaceSources: ClawWorkspaceSourceSnapshot[] = [];
   try {
@@ -220,7 +268,13 @@ async function buildDevelopmentSnapshot(params: {
     await Promise.all(openedSources.map(({ opened }) => opened[Symbol.asyncDispose]()));
   }
 
-  return { ok: true, integrity: `sha256:${hash.digest("hex")}`, byteLength, workspaceSources };
+  return {
+    ok: true,
+    integrity: `sha256:${hash.digest("hex")}`,
+    byteLength,
+    workspaceSources,
+    ...(packageBootstrap ? { packageBootstrap } : {}),
+  };
 }
 
 function parsePackageJson(value: unknown): PackageJson | undefined {
@@ -561,7 +615,7 @@ export async function readClawManifestFile(path: string): Promise<ClawReadResult
   }
   const profile = await readClawOpenClawProfile({
     packageRoot: sourceResult.source.packageRoot,
-    manifest: parsed.manifest,
+    metadata: parsed.manifest.metadata,
   });
   if (!profile.ok) {
     return profile;
@@ -592,9 +646,13 @@ export async function readClawManifestFile(path: string): Promise<ClawReadResult
     ok: true,
     manifest: parsed.manifest,
     ...(hasMarkdownBody ? { clawMarkdownBody: manifestResult.body } : {}),
+    ...(snapshot.packageBootstrap ? { packageBootstrap: snapshot.packageBootstrap } : {}),
     ...(profile.profile ? { openClawProfile: profile.profile } : {}),
     source,
-    snapshot: { workspaceSources: snapshot.workspaceSources },
+    snapshot: {
+      workspaceSources: snapshot.workspaceSources,
+      ...(snapshot.packageBootstrap ? { packageBootstrap: snapshot.packageBootstrap } : {}),
+    },
     diagnostics: parsed.diagnostics,
   };
 }

--- a/src/claws/schema.ts
+++ b/src/claws/schema.ts
@@ -414,6 +414,14 @@ const manifestSchema = z
     }
     manifest.workspace.files.forEach((file, index) => {
       const destinationKey = portableClawPathKey(file.path);
+      if (destinationKey === portableClawPathKey("BOOTSTRAP.md")) {
+        ctx.addIssue({
+          code: "custom",
+          path: ["workspace", "files", index, "path"],
+          message:
+            "Package-root BOOTSTRAP.md uses the native seed-once lifecycle and cannot be a managed workspace destination.",
+        });
+      }
       if (conflictsWithClawPath(workspaceTargets, destinationKey)) {
         ctx.addIssue({
           code: "custom",

--- a/src/claws/types.ts
+++ b/src/claws/types.ts
@@ -173,6 +173,7 @@ export type ClawWorkspaceSourceSnapshot = {
 
 type ClawSourceSnapshot = {
   workspaceSources: ClawWorkspaceSourceSnapshot[];
+  packageBootstrap?: ClawWorkspaceSourceSnapshot;
 };
 
 export type ClawReadResult =
@@ -180,6 +181,7 @@ export type ClawReadResult =
       ok: true;
       manifest: ClawManifest;
       clawMarkdownBody?: Buffer;
+      packageBootstrap?: ClawWorkspaceSourceSnapshot;
       openClawProfile?: ClawOpenClawProfile;
       source: ClawSourceIdentity;
       snapshot: ClawSourceSnapshot;
@@ -191,7 +193,7 @@ export type ClawReadResult =
     };
 
 export type ClawAddPlanAction = {
-  kind: "agent" | "workspace" | "workspaceFile" | "package" | "mcpServer" | "cronJob";
+  kind: "agent" | "workspace" | "bootstrap" | "workspaceFile" | "package" | "mcpServer" | "cronJob";
   id: string;
   action: "create" | "write" | "install" | "configure" | "schedule";
   target: string;

--- a/src/claws/update-apply.ts
+++ b/src/claws/update-apply.ts
@@ -181,6 +181,7 @@ export async function applyClawUpdatePlan(
   const targetAddPlan = await buildAddPlan({
     manifest: params.targetManifest,
     clawMarkdownBody: params.targetClawMarkdownBody,
+    includePackageBootstrap: false,
     openClawProfile: params.targetOpenClawProfile,
     source: params.targetSource,
     context: {

--- a/src/claws/update-plan.test.ts
+++ b/src/claws/update-plan.test.ts
@@ -6,6 +6,7 @@ import { afterEach, describe, expect, it } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import type { McpServerConfig } from "../config/types.mcp.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { requireNodeSqlite } from "../infra/node-sqlite.js";
 import {
   closeOpenClawStateDatabaseForTest,
   openOpenClawStateDatabase,
@@ -130,6 +131,38 @@ function targetSource(root: string, version: string, integrity: string): ClawSou
 }
 
 describe("buildClawUpdatePlan", () => {
+  it("reads pre-bootstrap-column v6 state without mutating it", async () => {
+    const current = await fixture();
+    closeOpenClawStateDatabaseForTest();
+    const databasePath = resolveOpenClawStateSqlitePath(current.env);
+    const sqlite = requireNodeSqlite();
+    const database = new sqlite.DatabaseSync(databasePath);
+    try {
+      database.exec(`
+        ALTER TABLE claw_installs DROP COLUMN bootstrap_source_path;
+        ALTER TABLE claw_installs DROP COLUMN bootstrap_content_digest;
+      `);
+    } finally {
+      database.close();
+    }
+    const beforeBytes = await readFile(databasePath);
+    const beforeStat = await stat(databasePath);
+
+    const plan = await buildClawUpdatePlan({
+      agentId: "worker",
+      targetManifest: current.manifest,
+      targetSource: current.source,
+      config: current.config,
+      sourceMcpServers: current.config.mcp?.servers ?? {},
+      stateOptions: { env: current.env },
+      packagePreflight,
+    });
+
+    expect(plan).toMatchObject({ found: true, agentId: "worker", blockers: [] });
+    expect((await readFile(databasePath)).equals(beforeBytes)).toBe(true);
+    expect((await stat(databasePath)).mtimeMs).toBe(beforeStat.mtimeMs);
+  });
+
   it("plans missing package restoration without mutating state", async () => {
     const current = await fixture();
     const beforeConfig = structuredClone(current.config);

--- a/src/claws/update-plan.ts
+++ b/src/claws/update-plan.ts
@@ -206,6 +206,7 @@ export async function buildClawUpdatePlan(params: {
     const targetPlan = await buildClawAddPlan({
       manifest: params.targetManifest,
       clawMarkdownBody: params.targetClawMarkdownBody,
+      includePackageBootstrap: false,
       openClawProfile: params.targetOpenClawProfile,
       source: params.targetSource,
       diagnostics: params.diagnostics,

--- a/src/cli/claws-cli.runtime.ts
+++ b/src/cli/claws-cli.runtime.ts
@@ -265,6 +265,7 @@ export async function runClawsAddCommand(
   let plan = await buildClawAddPlan({
     manifest: result.manifest,
     clawMarkdownBody: result.clawMarkdownBody,
+    packageBootstrap: result.packageBootstrap,
     openClawProfile: result.openClawProfile,
     source: result.source,
     diagnostics: result.diagnostics,
@@ -283,6 +284,7 @@ export async function runClawsAddCommand(
     plan = await buildClawAddPlan({
       manifest: result.manifest,
       clawMarkdownBody: result.clawMarkdownBody,
+      packageBootstrap: result.packageBootstrap,
       openClawProfile: result.openClawProfile,
       source: result.source,
       diagnostics: result.diagnostics,
@@ -400,7 +402,7 @@ export async function runClawsStatusCommand(
         `${record.install.agentId}: ${record.install.claw.name}@${record.install.claw.version} (${record.install.status})`,
       );
       runtime.log(
-        `  Agent: ${record.agentState}; files: ${record.workspaceFiles.length}; packages: ${record.packages.length}`,
+        `  Agent: ${record.agentState}; bootstrap: ${record.bootstrapState}; files: ${record.workspaceFiles.length}; packages: ${record.packages.length}`,
       );
     }
   }

--- a/src/cli/claws-cli.test.ts
+++ b/src/cli/claws-cli.test.ts
@@ -499,7 +499,6 @@ describe("claws cli", () => {
       JSON.stringify({
         schemaVersion: 1,
         agent: { id: "demo-agent" },
-        metadata: { "openclaw.config": "profiles/openclaw.yml" },
         mcpServers: {
           docs: {
             command: "node",

--- a/src/commands/doctor-state-sqlite-compact.test.ts
+++ b/src/commands/doctor-state-sqlite-compact.test.ts
@@ -88,6 +88,19 @@ function seedStateDatabase(params: {
   return sqlitePath;
 }
 
+function dropBootstrapProvenanceColumns(sqlitePath: string): void {
+  const sqlite = requireNodeSqlite();
+  const database = new sqlite.DatabaseSync(sqlitePath);
+  try {
+    database.exec(`
+      ALTER TABLE claw_installs DROP COLUMN bootstrap_source_path;
+      ALTER TABLE claw_installs DROP COLUMN bootstrap_content_digest;
+    `);
+  } finally {
+    database.close();
+  }
+}
+
 function readPragma(database: DatabaseSync, name: string): number {
   const row = database.prepare(`PRAGMA ${name};`).get() as Record<string, unknown>;
   return Number(row[name] ?? Object.values(row)[0]);
@@ -168,6 +181,27 @@ describe("runDoctorStateSqliteCompact", () => {
     expect(report.after.pageSizeBytes).toBeGreaterThan(0);
     expect(report.reclaimedBytes).toBeGreaterThan(0);
     expect(report.integrityCheck).toBe("ok");
+  });
+
+  it("compacts pre-bootstrap-column v6 state without migrating it", async () => {
+    const env = createStateEnv();
+    const sqlitePath = seedStateDatabase({ env, withBloat: true });
+    dropBootstrapProvenanceColumns(sqlitePath);
+
+    const report = await runDoctorStateSqliteCompact({ env });
+
+    expectCompletedReport(report);
+    const sqlite = requireNodeSqlite();
+    const database = new sqlite.DatabaseSync(sqlitePath, { readOnly: true });
+    try {
+      const columns = database.prepare("PRAGMA table_info(claw_installs)").all() as Array<{
+        name?: unknown;
+      }>;
+      expect(columns.map((column) => column.name)).not.toContain("bootstrap_source_path");
+      expect(columns.map((column) => column.name)).not.toContain("bootstrap_content_digest");
+    } finally {
+      database.close();
+    }
   });
 
   it("clears authoritative quarantine after compaction", async () => {

--- a/src/commands/doctor-state-sqlite-compact.ts
+++ b/src/commands/doctor-state-sqlite-compact.ts
@@ -7,6 +7,7 @@ import {
   clearOpenClawStateDatabaseOpenFailure,
   ensureOpenClawStatePermissions,
   isOpenClawStateDatabaseOpen,
+  STATE_READ_ONLY_COMPATIBLE_MISSING_COLUMNS,
 } from "../state/openclaw-state-db.js";
 import { resolveOpenClawStateSqlitePath } from "../state/openclaw-state-db.paths.js";
 import {
@@ -85,7 +86,10 @@ export async function runDoctorStateSqliteCompact(
         ...(deps.busyTimeoutMs !== undefined ? { busyTimeoutMs: deps.busyTimeoutMs } : {}),
         sqlitePath,
         validateBeforeMutation: (database) =>
-          assertOpenClawStateDatabaseForMaintenance(database, { pathname: sqlitePath }),
+          assertOpenClawStateDatabaseForMaintenance(database, {
+            pathname: sqlitePath,
+            allowedMissingColumns: STATE_READ_ONLY_COMPATIBLE_MISSING_COLUMNS,
+          }),
       });
       return {
         ...compact,

--- a/src/state/openclaw-state-db-maintenance.ts
+++ b/src/state/openclaw-state-db-maintenance.ts
@@ -125,7 +125,7 @@ export function assertOpenClawStateDatabaseOwner(
 /** Require the canonical shared-state owner and schema before offline file maintenance. */
 export function assertOpenClawStateDatabaseForMaintenance(
   database: DatabaseSync,
-  options: { pathname: string },
+  options: { pathname: string; allowedMissingColumns?: readonly string[] },
 ): void {
   const userVersion = readSqliteUserVersion(database);
   if (userVersion > OPENCLAW_STATE_SCHEMA_VERSION) {
@@ -157,7 +157,12 @@ export function assertOpenClawStateDatabaseForMaintenance(
     database,
     options.pathname,
     OPENCLAW_STATE_SCHEMA_SQL,
-    OPENCLAW_STATE_MAINTENANCE_SCHEMA_COMPATIBILITY,
+    options.allowedMissingColumns
+      ? {
+          ...OPENCLAW_STATE_MAINTENANCE_SCHEMA_COMPATIBILITY,
+          allowedMissingColumns: options.allowedMissingColumns,
+        }
+      : OPENCLAW_STATE_MAINTENANCE_SCHEMA_COMPATIBILITY,
   );
 }
 

--- a/src/state/openclaw-state-db-schema-additive.ts
+++ b/src/state/openclaw-state-db-schema-additive.ts
@@ -94,6 +94,8 @@ function backfillLegacyManagedImageRoots(db: DatabaseSync): void {
 }
 
 export function ensureAdditiveStateColumns(db: DatabaseSync): void {
+  ensureColumn(db, "claw_installs", "bootstrap_source_path TEXT");
+  ensureColumn(db, "claw_installs", "bootstrap_content_digest TEXT");
   if (ensureColumn(db, "claw_package_refs", "updated_at_ms INTEGER NOT NULL DEFAULT 0")) {
     db.exec("UPDATE claw_package_refs SET updated_at_ms = installed_at_ms;");
   }

--- a/src/state/openclaw-state-db.generated.d.ts
+++ b/src/state/openclaw-state-db.generated.d.ts
@@ -279,6 +279,8 @@ export interface ClawInstalls {
   agent_config_digest: string;
   agent_id: string;
   agent_owned_paths_json: string;
+  bootstrap_content_digest: string | null;
+  bootstrap_source_path: string | null;
   claw_name: string;
   claw_version: string;
   integrity: string;

--- a/src/state/openclaw-state-db.test.ts
+++ b/src/state/openclaw-state-db.test.ts
@@ -1859,6 +1859,107 @@ INSERT INTO macos_port_guardian_records VALUES (4242, 18789, '/usr/bin/ssh', 're
     );
   });
 
+  it("repairs same-version Claw bootstrap columns before runtime schema validation", () => {
+    const stateDir = createTempStateDir();
+    const env = { OPENCLAW_STATE_DIR: stateDir };
+    const databasePath = materializeCurrentStateDatabase(stateDir);
+
+    const { DatabaseSync } = requireNodeSqlite();
+    const shippedSchema = new DatabaseSync(databasePath);
+    try {
+      shippedSchema.exec(`
+        ALTER TABLE claw_installs DROP COLUMN bootstrap_source_path;
+        ALTER TABLE claw_installs DROP COLUMN bootstrap_content_digest;
+      `);
+      expect(readSqliteNumberPragma(shippedSchema, "user_version")).toBe(
+        OPENCLAW_STATE_SCHEMA_VERSION,
+      );
+    } finally {
+      shippedSchema.close();
+    }
+
+    const reopened = openOpenClawStateDatabase({ env });
+    const columns = reopened.db.prepare("PRAGMA table_info(claw_installs)").all() as Array<{
+      name: string;
+    }>;
+    expect(columns.map((column) => column.name)).toEqual(
+      expect.arrayContaining(["bootstrap_source_path", "bootstrap_content_digest"]),
+    );
+    expect(normalizeSqliteSchemaShapeSql(collectSqliteSchemaShape(reopened.db))).toEqual(
+      normalizeSqliteSchemaShapeSql(createInitialStateSchemaShape()),
+    );
+  });
+
+  it("repairs same-version Claw bootstrap columns with physical index drift", () => {
+    const stateDir = createTempStateDir();
+    const env = { OPENCLAW_STATE_DIR: stateDir };
+    const databasePath = materializeCurrentStateDatabase(stateDir);
+
+    const { DatabaseSync } = requireNodeSqlite();
+    const shippedSchema = new DatabaseSync(databasePath);
+    try {
+      shippedSchema.exec(`
+        ALTER TABLE claw_installs DROP COLUMN bootstrap_source_path;
+        ALTER TABLE claw_installs DROP COLUMN bootstrap_content_digest;
+      `);
+    } finally {
+      shippedSchema.close();
+    }
+    createTaskRunStatusIndexPhysicalDrift(databasePath);
+
+    const reopened = openOpenClawStateDatabase({ env });
+    const columns = reopened.db.prepare("PRAGMA table_info(claw_installs)").all() as Array<{
+      name: string;
+    }>;
+    expect(columns.map((column) => column.name)).toEqual(
+      expect.arrayContaining(["bootstrap_source_path", "bootstrap_content_digest"]),
+    );
+    expect(reopened.db.prepare("PRAGMA integrity_check").get()).toEqual({
+      integrity_check: "ok",
+    });
+    expect(
+      reopened.db
+        .prepare(
+          "SELECT task_id FROM task_runs INDEXED BY idx_task_runs_status WHERE status = 'running'",
+        )
+        .all(),
+    ).toEqual([{ task_id: "task-index-repair" }]);
+  });
+
+  it("does not add Claw bootstrap columns before rejecting unrelated index corruption", () => {
+    const stateDir = createTempStateDir();
+    const env = { OPENCLAW_STATE_DIR: stateDir };
+    const databasePath = materializeCurrentStateDatabase(stateDir);
+
+    const { DatabaseSync } = requireNodeSqlite();
+    const shippedSchema = new DatabaseSync(databasePath);
+    try {
+      shippedSchema.exec(`
+        ALTER TABLE claw_installs DROP COLUMN bootstrap_source_path;
+        ALTER TABLE claw_installs DROP COLUMN bootstrap_content_digest;
+      `);
+    } finally {
+      shippedSchema.close();
+    }
+    createUnsafeIndexDrift(databasePath);
+
+    expect(() => openOpenClawStateDatabase({ env })).toThrow(
+      /integrity_check failed.*missing from index unsafe_index_records_value/iu,
+    );
+
+    const preserved = new DatabaseSync(databasePath, { readOnly: true });
+    try {
+      const columns = preserved.prepare("PRAGMA table_info(claw_installs)").all() as Array<{
+        name: string;
+      }>;
+      expect(columns.map((column) => column.name)).not.toEqual(
+        expect.arrayContaining(["bootstrap_source_path", "bootstrap_content_digest"]),
+      );
+    } finally {
+      preserved.close();
+    }
+  });
+
   it("repairs physical ordinary-index drift before cold-open reads", () => {
     const stateDir = createTempStateDir();
     const env = { OPENCLAW_STATE_DIR: stateDir };

--- a/src/state/openclaw-state-db.ts
+++ b/src/state/openclaw-state-db.ts
@@ -84,6 +84,10 @@ export {
   OPENCLAW_SQLITE_BUSY_TIMEOUT_MS,
   OPENCLAW_STATE_SCHEMA_VERSION,
 };
+export const STATE_READ_ONLY_COMPATIBLE_MISSING_COLUMNS = [
+  "claw_installs.bootstrap_source_path",
+  "claw_installs.bootstrap_content_digest",
+] as const;
 export type {
   OpenClawStateDatabase,
   OpenClawStateDatabaseOptions,
@@ -419,6 +423,7 @@ function ensureSchema(db: DatabaseSync, pathname: string): void {
           repairCanonicalSqliteIndexes(db, pathname, OPENCLAW_STATE_SCHEMA_SQL, {
             verifyPhysicalIntegrity: false,
           });
+          ensureAdditiveStateColumns(db);
           assertCurrentStateRuntimeSchema(db, pathname);
         } else if (previousVersion === 5) {
           assertOpenClawStateDatabaseV5ForMigration(db, { pathname });
@@ -505,7 +510,10 @@ export async function openExistingOpenClawStateDatabaseReadOnly(
     assertSupportedSchemaVersion(db, pathname);
     assertSqliteIntegrity(db, pathname);
     if (readSqliteUserVersion(db) === OPENCLAW_STATE_SCHEMA_VERSION) {
-      assertOpenClawStateDatabaseForMaintenance(db, { pathname });
+      assertOpenClawStateDatabaseForMaintenance(db, {
+        pathname,
+        allowedMissingColumns: STATE_READ_ONLY_COMPATIBLE_MISSING_COLUMNS,
+      });
     }
   } catch (error) {
     try {
@@ -544,9 +552,18 @@ export async function openExistingOpenClawStateDatabaseReadOnly(
   };
 }
 
-function assertCurrentStateRuntimeSchema(database: DatabaseSync, pathname: string): void {
+function assertCurrentStateRuntimeSchema(
+  database: DatabaseSync,
+  pathname: string,
+  options: { allowedMissingColumns?: readonly string[] } = {},
+): void {
   assertCanonicalStateSchemaShape(database, pathname);
-  assertOpenClawStateDatabaseForMaintenance(database, { pathname });
+  assertOpenClawStateDatabaseForMaintenance(database, {
+    pathname,
+    ...(options.allowedMissingColumns
+      ? { allowedMissingColumns: options.allowedMissingColumns }
+      : {}),
+  });
 }
 
 function assertStateDatabaseIntegrityBeforeMutation(
@@ -571,8 +588,12 @@ function assertStateDatabaseIntegrityBeforeMutation(
   if (userVersion === OPENCLAW_STATE_SCHEMA_VERSION) {
     verifyAndRepairCanonicalSqliteIndexes(database, pathname, OPENCLAW_STATE_SCHEMA_SQL, {
       allowMissingColumns: true,
-      validateAfterRepair: () => assertCurrentStateRuntimeSchema(database, pathname),
+      validateAfterRepair: () =>
+        assertCurrentStateRuntimeSchema(database, pathname, {
+          allowedMissingColumns: STATE_READ_ONLY_COMPATIBLE_MISSING_COLUMNS,
+        }),
     });
+    ensureAdditiveStateColumns(database);
   } else {
     // Every physical open proves the full file before schema mutation or exposure.
     assertSqliteIntegrity(database, pathname);

--- a/src/state/openclaw-state-schema.sql
+++ b/src/state/openclaw-state-schema.sql
@@ -2123,6 +2123,8 @@ CREATE TABLE IF NOT EXISTS claw_installs (
   workspace TEXT NOT NULL UNIQUE,
   agent_config_digest TEXT NOT NULL,
   agent_owned_paths_json TEXT NOT NULL,
+  bootstrap_source_path TEXT,
+  bootstrap_content_digest TEXT,
   status TEXT NOT NULL CHECK (
     status IN ('pending', 'workspace_ready', 'config_committed', 'complete', 'partial')
   ),


### PR DESCRIPTION
Related: [OpenClaw RFC #48](https://github.com/openclaw/rfcs/pull/48), [OpenClaw RFC #52](https://github.com/openclaw/rfcs/pull/52)

## Scope

This PR adds the first slice of the revised experimental Claws application lifecycle behind `OPENCLAW_EXPERIMENTAL_CLAWS=1`.

It defines how a portable Claw package can describe OpenClaw-specific runtime settings and native first-run bootstrap content without making those details part of the portable manifest core.

## What This Covers

- Reads an optional OpenClaw profile from the conventional package path `profiles/openclaw.yml`.
- Keeps foreign harness profiles opaque; OpenClaw validates only the OpenClaw profile it owns.
- Fails closed on retired OpenClaw metadata pointers with actionable migration diagnostics.
- Supports package-root `BOOTSTRAP.md` as native seed-once onboarding content.
- Includes bootstrap bytes in source integrity and consented `claws add` planning.
- Records bootstrap provenance on the root Claw install record.
- Reports pending, complete, modified, unsafe, and unknown bootstrap state through Claw status inspection.
- Preserves consumed bootstrap during update so onboarding is not recreated after first use.
- Removes only digest-identical pending bootstrap content and preserves edited content/workspaces.
- Keeps portable workspace assets on existing `workspace.files` and managed-file lifecycle semantics.
- Persists workspace setup state and aliases in the caller-selected OpenClaw state database, including custom state-dir paths.
- Avoids alias writes when callers intentionally use read-only state database handles.

Schema version 1 remains the launch contract for this slice.

## Maintainer Contract

Per maintainer direction, OpenClaw owns `profiles/openclaw.yml` as the conventional OpenClaw package profile path and rejects retired `metadata.openclaw.config` pointers. The portable `CLAW.md` manifest stays harness-neutral; harness-native settings live in conventional package-local profile files.

## User Impact

With the experimental flag enabled, operators can inspect, add, status, update, and remove Claws that carry:

- portable `CLAW.md` metadata;
- an optional OpenClaw runtime profile;
- portable workspace files; and
- native conversational bootstrap content.

All mutations remain consented through `claws add --dry-run` / `--plan-integrity`, and status/remove continue to respect OpenClaw ownership and digest checks.

## Safety Model

- OpenClaw-specific configuration stays in the OpenClaw profile instead of expanding the portable manifest core.
- Bootstrap content is seed-once and provenance-tracked; update does not recreate consumed onboarding.
- Remove deletes only content still matching the recorded digest.
- Workspace identity and alias state follow the selected state database, including custom state directories and read-only status/update callers.
- Concurrent bootstrap seed attempts tolerate the expected create race only after verifying stable, digest-identical target content.

## Evidence

Validated on WSL2 Ubuntu with Node 24.15.0. Current PR head: `cf7e57f6e3f3495ba21f276bbb1109f3190460ef`.

Passed:

- `git diff --check origin/main...HEAD`
- changed-file `oxfmt --check` across 27 PR files
- changed-file `oxlint --deny-warnings` across 25 non-generated TypeScript PR files
- `node scripts/run-vitest.mjs src/claws/bootstrap.test.ts src/agents/workspace-state-store.test.ts src/claws/openclaw-profile.test.ts src/cli/claws-cli.test.ts --reporter=dot`
- `pnpm db:kysely:check`
- `pnpm check:max-lines-ratchet --base origin/main`
- `pnpm deadcode:dependencies`
- Source CLI real behavior proof for add/status/remove with isolated `HOME`, `OPENCLAW_CONFIG_PATH`, `OPENCLAW_HOME`, and `OPENCLAW_STATE_DIR`
- Source-module concurrent bootstrap seed proof: two simultaneous seed attempts returned `already-seeded` and `seeded`, and target digest matched the consented source digest

Known caveat:

- `pnpm tsgo:core` currently fails on `origin/main`-owned boundary-file type errors outside this PR's changed files: `rejectSymlinks` is passed by existing callers but is not present on `OpenRootFileParams` / `OpenRootFileSyncParams`.

## Real Behavior Proof

Exact head: `cf7e57f6e3f3495ba21f276bbb1109f3190460ef`.

Source CLI lifecycle transcript, using `node --import tsx src/entry.ts` and an isolated temp state dir:

```text
HEAD cf7e57f6e3f3495ba21f276bbb1109f3190460ef
state [temp]/openclaw-claws-proof-state-FDBcJp
claws add src/claws/fixtures/workspace-agent.claw.json --dry-run --json
schemaVersion=openclaw.clawAddPlan.v1 dryRun=true mutationAllowed=false
summary={ totalActions: 5, agentActions: 1, workspaceActions: 4, packageActions: 0, mcpServerActions: 0, cronJobActions: 0, blockedActions: 0, capabilityEscalations: 0 }
blockers=[]
planIntegrity=sha256:9111b1f354c3d2c435d86fbe7c6ee08cbe15d9ca80ecbd2910d8cad1e613c2cf

claws add src/claws/fixtures/workspace-agent.claw.json --yes --plan-integrity <above> --json
schemaVersion=openclaw.clawAddResult.v1 status=complete

claws status workspace-agent --json
schemaVersion=openclaw.clawStatus.v1
summary={ claws: 1, partial: 0, pendingBootstrap: 0, missingAgents: 0, driftedFiles: 0, packageRefs: 0, missingPackages: 0, driftedPackages: 0, incompletePackages: 0, mcpServerRefs: 0, driftedMcpServers: 0, unresolvedMcpServerRefs: 0, cronRefs: 0, unresolvedCronRefs: 0 }
records=[{ agentId: workspace-agent, agentState: present, driftedFiles: 0 }]

claws remove workspace-agent --dry-run --json
schemaVersion=openclaw.clawRemovePlan.v1 mutationAllowed=false agentId=workspace-agent blockers=[]
planIntegrity=sha256:9af84d331e2772a87dc4c734199af4f98be34580ab83863188b2988d9ea90098

claws remove workspace-agent --yes --plan-integrity <above> --json
schemaVersion=openclaw.clawRemoveResult.v1 status=complete agentId=workspace-agent agentRemoved=true
```

Concurrent package-root bootstrap seed proof on the same exact head:

```json
{
  "head": "cf7e57f6e3f3495ba21f276bbb1109f3190460ef",
  "tempRoot": "[temp]/openclaw-claws-concurrent-proof-AiSCkQ",
  "planIntegrity": "sha256:582963001f82c35cc3bcc9c978419df73cd1cedc02ede042f7a263dace809da6",
  "sourceDigest": "sha256:50b39aa82fb446f8d5fbc70cc52c4c14d69a22febc1f9e7ff011b0e0edbf82fe",
  "concurrentResults": ["already-seeded", "seeded"],
  "targetDigest": "sha256:50b39aa82fb446f8d5fbc70cc52c4c14d69a22febc1f9e7ff011b0e0edbf82fe",
  "targetMatchesSource": true,
  "bootstrapSeededAt": "1970-01-01T00:00:01.000Z"
}
```

## Stack Position

This is the first PR in the revised Claws application track. [#115962](https://github.com/openclaw/openclaw/pull/115962) builds on it with schema-v1 harness-native extensions and managed application content. Gateway and Control UI support follow in [#112808](https://github.com/openclaw/openclaw/pull/112808) and [#112828](https://github.com/openclaw/openclaw/pull/112828).

The standalone `npx claws` adapter remains a separate reference-engine track and is not required by this package format.



Latest proof refresh: https://github.com/openclaw/openclaw/pull/115237#issuecomment-5208298200











