### PR TITLE
refactor(cli): unify configured model rows onto the shared row pipeline

### DIFF
--- a/src/commands/models/list.rows.test.ts
+++ b/src/commands/models/list.rows.test.ts
@@ -456,6 +456,55 @@ describe("appendConfiguredRows", () => {
 
     expect(requireOnlyRow(rows).available).toBeNull();
   });
+
+  it("evaluates configured-row auth with observed routes from the shared snapshot", async () => {
+    const rows: ModelRow[] = [];
+    const evaluateModelAuth = vi.fn(() => ({
+      availability: true,
+      routeResolution: null,
+    }));
+    const catalogEntry = {
+      id: "gpt-5.5",
+      name: "GPT-5.5",
+      provider: "openai",
+      api: "openai-responses" as const,
+      baseUrl: "https://api.openai.com/v1",
+      contextWindow: 400_000,
+      input: ["text" as const],
+    };
+
+    await appendConfiguredRows({
+      rows,
+      entries: [
+        {
+          key: "openai/gpt-5.5",
+          ref: { provider: "openai", model: "gpt-5.5" },
+          tags: new Set(["default"]),
+          aliases: [],
+        },
+      ],
+      catalogSnapshot: { entries: [catalogEntry], routeVariants: [catalogEntry] },
+      context: {
+        cfg: {},
+        agentDir: "/tmp/openclaw-agent",
+        authIndex: { evaluateModelAuth },
+        configuredByKey: new Map(),
+        discoveredKeys: new Set<string>(),
+        filter: {},
+        skipRuntimeModelSuppression: true,
+      },
+    });
+
+    // The same physical routes the catalog rows use must inform configured-row
+    // auth, so both views agree on availability for route-managed models.
+    expect(evaluateModelAuth).toHaveBeenCalledWith(
+      "openai",
+      expect.objectContaining({
+        observedRoutes: [{ api: "openai-responses", baseUrl: "https://api.openai.com/v1" }],
+      }),
+    );
+    expect(requireOnlyRow(rows)).toMatchObject({ key: "openai/gpt-5.5", contextWindow: 400_000 });
+  });
 });
 
 describe("prepared provider catalog projection", () => {

--- a/src/commands/models/list.rows.ts
+++ b/src/commands/models/list.rows.ts
@@ -208,8 +208,9 @@ async function buildRow(params: {
   routeIndex?: ModelCatalogLogicalRouteIndex;
   authEvaluation?: ModelListAuthEvaluation;
   allowAuthAvailabilityOverride?: boolean;
+  configuredEntry?: ConfiguredEntry;
 }): Promise<ModelRow> {
-  const configured = params.context.configuredByKey.get(params.key);
+  const configured = params.configuredEntry ?? params.context.configuredByKey.get(params.key);
   const authRef = toModelAuthRef(params.model, params.routeIndex);
   const authEvaluation =
     params.authEvaluation ??
@@ -299,6 +300,7 @@ async function appendVisibleRow(params: {
   allowAuthAvailabilityOverride?: boolean;
   skipSuppression?: boolean;
   normalizeWithProviderPlugin?: boolean;
+  configuredEntry?: ConfiguredEntry;
 }): Promise<boolean> {
   if (params.seenKeys?.has(params.key)) {
     return false;
@@ -338,6 +340,7 @@ async function appendVisibleRow(params: {
       ...(params.routeIndex ? { routeIndex: params.routeIndex } : {}),
       authEvaluation,
       allowAuthAvailabilityOverride: params.allowAuthAvailabilityOverride,
+      ...(params.configuredEntry ? { configuredEntry: params.configuredEntry } : {}),
     }),
   );
   params.seenKeys?.add(params.key);
@@ -674,47 +677,37 @@ export async function appendConfiguredRows(params: {
             cfg: params.context.cfg,
           })
         : toFallbackConfiguredListModel(entry, params.context.cfg, catalogByKey?.get(entry.key));
-    const model = resolvedModel
-      ? normalizeListRowWithProviderPlugin({ model: resolvedModel, context: params.context })
-      : resolvedModel;
-    if (params.context.filter.local && !model) {
+    if (!resolvedModel) {
+      // Registry-resolved refs can miss entirely; the configured view still
+      // surfaces the ref as a "missing" row so a typo'd fallback is visible.
+      if (!params.context.filter.local) {
+        params.rows.push(
+          toModelRow({
+            key: entry.key,
+            tags: Array.from(entry.tags),
+            aliases: entry.aliases,
+            availableKeys: params.context.availableKeys,
+            authAvailability: undefined,
+          }),
+        );
+      }
       continue;
     }
-    const authEvaluation = model
-      ? params.context.authIndex.evaluateModelAuth(model.provider, toModelAuthRef(model))
-      : undefined;
-    const projectedModel =
-      model && authEvaluation
-        ? projectListRowModel({ model, evaluation: authEvaluation, cfg: params.context.cfg })
-        : model;
-    if (
-      params.context.filter.local &&
-      projectedModel &&
-      !isLocalBaseUrl(projectedModel.baseUrl ?? "")
-    ) {
-      continue;
-    }
-    if (
-      projectedModel &&
-      shouldSuppressListModel({ model: projectedModel, context: params.context })
-    ) {
-      continue;
-    }
-    params.rows.push(
-      toModelRow({
-        model: projectedModel,
-        key: entry.key,
-        tags: Array.from(entry.tags),
-        aliases: entry.aliases,
-        availableKeys: params.context.availableKeys,
-        authAvailability: authEvaluation?.availability,
-        authAvailabilityAuthoritative:
-          Boolean(
-            model && !params.context.discoveredKeys.has(modelKey(model.provider, model.id)),
-          ) ||
-          normalizeProviderIdForAuth(model?.provider ?? entry.ref.provider) === "openai" ||
-          (authEvaluation !== undefined && authEvaluation.routeResolution !== null),
-      }),
-    );
+    // Normalize before the availability decision so the discovered-keys check
+    // uses the same canonical key the registry rows carry.
+    const model = normalizeListRowWithProviderPlugin({
+      model: resolvedModel,
+      context: params.context,
+    });
+    await appendVisibleRow({
+      rows: params.rows,
+      model,
+      key: entry.key,
+      context: params.context,
+      configuredEntry: entry,
+      allowAuthAvailabilityOverride: !params.context.discoveredKeys.has(
+        modelKey(model.provider, model.id),
+      ),
+    });
   }
 }

--- a/src/commands/models/list.rows.ts
+++ b/src/commands/models/list.rows.ts
@@ -664,6 +664,11 @@ export async function appendConfiguredRows(params: {
   const catalogByKey = params.catalogSnapshot
     ? indexModelCatalogEntriesByKey(params.catalogSnapshot)
     : undefined;
+  // Route-aware auth/projection keeps configured rows consistent with the
+  // catalog rows built from the same snapshot two sources later.
+  const routeIndex = params.catalogSnapshot
+    ? createModelCatalogLogicalRouteIndex(params.catalogSnapshot.routeVariants)
+    : undefined;
   for (const entry of params.entries) {
     if (!matchesProviderFilter(params.context, entry.ref.provider)) {
       continue;
@@ -704,6 +709,7 @@ export async function appendConfiguredRows(params: {
       model,
       key: entry.key,
       context: params.context,
+      ...(routeIndex ? { routeIndex } : {}),
       configuredEntry: entry,
       allowAuthAvailabilityOverride: !params.context.discoveredKeys.has(
         modelKey(model.provider, model.id),


### PR DESCRIPTION
## What Problem This Solves

Follow-up to #115190. `appendConfiguredRows` was a hand-rolled parallel copy of the model-list row pipeline: it reimplemented projection (`projectListRowModel`), the local filter, suppression, and the `authAvailabilityAuthoritative` decision that `appendVisibleRow`/`buildRow` already own — each with slightly different phrasing (`buildRow`: `allowAuthAvailabilityOverride || openai || routeResolution !== null`; configured path: `Boolean(model && !discoveredKeys.has(key)) || …`). Two expressions for one intended meaning is exactly the drift class that produced #115190's placeholder-metadata bug; this deletes the second path before it produces a different symptom.

It also fixes a residual inconsistency: configured rows evaluated auth via `toModelAuthRef(model)` with no route index, so route-managed (OpenAI-style) configured rows judged auth blind while the catalog rows built from the same snapshot two sources later judged it route-aware.

## Why This Change Was Made

Commit 1 (`refactor`, behavior-neutral): configured entries resolve their model (registry → catalog → provider config), then route through the shared `appendVisibleRow` with a new explicit `configuredEntry` override for tags/aliases; the only unique behavior kept locally is emitting a `missing: true` row when a registry-resolved ref misses entirely. ~40 lines of duplicated decision logic deleted; one owner for row projection/suppression/availability.

Commit 2 (`feat`): `appendConfiguredRows` builds the logical route index from the shared catalog snapshot's `routeVariants` and threads it into auth evaluation and projection, so configured rows see the same observed routes as catalog rows.

## User Impact

No visible change for typical configurations (live-verified: `kimi/k3 text+image 1049k fallback#1` identical in both views before and after). Route-managed configured rows now get consistent availability verdicts between `openclaw models list` and `--all`.

## Evidence

- `git diff --numstat` vs main: prod file 40+/41− (net −1), +49 test lines.
- New test: configured-row auth receives `observedRoutes` from the shared snapshot (`list.rows.test.ts`).
- `node scripts/run-vitest.mjs src/commands/models/list` — 8 files, 73 tests green (includes #115190's regression test, proving the unification preserves catalog-backed fallback metadata, provider-config precedence, placeholder retention, and single snapshot load).
- `node scripts/run-vitest.mjs src/commands/models.list.e2e.test.ts` — 20/21 locally (see e2e note below); hosted CI is the authoritative run for this lane.
- `tsgo` core + test-src green; oxlint/oxfmt clean; `git diff --check` clean.
- Live proof (isolated `OPENCLAW_STATE_DIR`, kimi plugin + auth): configured and `--all` views byte-identical for kimi rows pre/post refactor.
- Codex autoreview (gpt-5.6-sol, branch vs origin/main): clean, "patch is correct (0.88)", no actionable findings.

Note on e2e: the full `models.list.e2e.test.ts` run went 20/21 locally with one 120s timeout ("models list runs model discovery without auth.json sync") under heavy multi-worktree lock contention; a rerun stalled outright behind the same contention and was terminated. The same file was 21/21 green on this machine earlier today (post-#115190). Hosted CI on this PR's head is the authoritative proof for that lane.
