### PR TITLE
fix(matrix): suppress previews for modifying hooks

### DIFF
--- a/extensions/matrix/src/matrix/monitor/handler.test.ts
+++ b/extensions/matrix/src/matrix/monitor/handler.test.ts
@@ -53,6 +53,15 @@ const resolveMatrixMentionsForBodyMock = vi.hoisted(() =>
     };
   }),
 );
+const getGlobalHookRunnerMock = vi.hoisted(() => vi.fn());
+
+vi.mock("openclaw/plugin-sdk/plugin-runtime", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("openclaw/plugin-sdk/plugin-runtime")>();
+  return {
+    ...actual,
+    getGlobalHookRunner: getGlobalHookRunnerMock,
+  };
+});
 
 vi.mock("../send.js", () => ({
   editMessageMatrix: editMessageMatrixMock,
@@ -116,6 +125,7 @@ async function writeMatrixSessionMeta(
 beforeEach(() => {
   sessionBindingTesting.resetSessionBindingAdaptersForTests();
   installMatrixMonitorTestRuntime();
+  getGlobalHookRunnerMock.mockReset().mockReturnValue(null);
   prepareMatrixSingleTextMock.mockReset().mockImplementation((text: string) => {
     const trimmedText = text.trim();
     return {
@@ -2985,6 +2995,53 @@ describe("matrix monitor handler draft streaming", () => {
     expectFinalizedPreviewEdit("$draft1", "Single block");
     expect(deliverMatrixRepliesMock).not.toHaveBeenCalled();
     expect(redactEventMock).not.toHaveBeenCalled();
+    await finish();
+  });
+
+  it("preserves provider previews for observer-only hooks", async () => {
+    getGlobalHookRunnerMock.mockReturnValue({
+      hasHooks: vi.fn((hookName: string) => hookName === "message_sent"),
+    });
+    const { dispatch } = createStreamingHarness({ streaming: "partial" });
+    const { deliver, opts, finish } = await dispatch();
+
+    opts.onPartialReply?.({ text: "Visible preview" });
+    await waitForMatrixState(() => {
+      expect(sendSingleTextMessageMatrixMock).toHaveBeenCalledTimes(1);
+    });
+    await deliver({ text: "Visible preview" }, { kind: "final" });
+
+    expectEditLiveFlag("$draft1", "Visible preview", false);
+    expect(deliverMatrixRepliesMock).not.toHaveBeenCalled();
+    await finish();
+  });
+
+  it.each([
+    { label: "reply_payload_sending", hooks: ["reply_payload_sending"] },
+    { label: "message_sending", hooks: ["message_sending"] },
+    {
+      label: "both modifying hooks",
+      hooks: ["reply_payload_sending", "message_sending"],
+    },
+  ])("suppresses provider previews when $label is registered", async ({ hooks }) => {
+    const registered = new Set(hooks);
+    getGlobalHookRunnerMock.mockReturnValue({
+      hasHooks: vi.fn((hookName: string) => registered.has(hookName)),
+    });
+    const { dispatch } = createStreamingHarness({
+      previewToolProgressEnabled: true,
+      streaming: "progress",
+    });
+    const { deliver, opts, finish } = await dispatch();
+
+    expect(opts.onPartialReply).toBeUndefined();
+    expect(opts.onToolStart).toBeUndefined();
+    expect(opts.suppressDefaultToolProgressMessages).toBeUndefined();
+    await deliver({ text: "Durable final" }, { kind: "final" });
+
+    expect(sendSingleTextMessageMatrixMock).not.toHaveBeenCalled();
+    expect(editMessageMatrixMock).not.toHaveBeenCalled();
+    expect(deliverMatrixRepliesMock).toHaveBeenCalledTimes(1);
     await finish();
   });
 

--- a/extensions/matrix/src/matrix/monitor/handler.ts
+++ b/extensions/matrix/src/matrix/monitor/handler.ts
@@ -5,6 +5,7 @@ import {
 } from "openclaw/plugin-sdk/channel-inbound";
 import { resolveChannelContextVisibilityMode } from "openclaw/plugin-sdk/context-visibility-runtime";
 import { KeyedAsyncQueue } from "openclaw/plugin-sdk/keyed-async-queue";
+import { getGlobalHookRunner } from "openclaw/plugin-sdk/plugin-runtime";
 import { resolveInboundLastRouteSessionKey } from "openclaw/plugin-sdk/routing";
 import { resolvePinnedMainDmOwnerFromAllowlist } from "openclaw/plugin-sdk/security-runtime";
 import { resolveStorePath } from "openclaw/plugin-sdk/session-store-runtime";
@@ -388,9 +389,16 @@ export function createMatrixRoomMessageHandler(params: MatrixMonitorHandlerParam
           });
         },
       });
+      // Matrix drafts are provider-visible before outbound modifiers run. Keep them off when a
+      // hook can rewrite or cancel so the original payload cannot escape the delivery gate.
+      const hookRunner = getGlobalHookRunner();
+      const allowProviderPreview = !(
+        (hookRunner?.hasHooks("reply_payload_sending") ?? false) ||
+        (hookRunner?.hasHooks("message_sending") ?? false)
+      );
       const draftController = await createMatrixDraftController({
-        streaming,
-        previewToolProgressEnabled,
+        streaming: allowProviderPreview ? streaming : "off",
+        previewToolProgressEnabled: allowProviderPreview && previewToolProgressEnabled,
         replyToMode,
         messageId,
         threadTarget,


### PR DESCRIPTION
Related: #92374

## What Problem This Solves

Fixes an issue where Matrix users could briefly see original agent reply content before an installed outbound hook rewrote or cancelled that reply. Matrix draft and progress events were provider-visible before `reply_payload_sending` and `message_sending` ran; cancellation cleanup happened only after disclosure.

## Why This Change Was Made

Matrix now keeps provider previews enabled for normal and observer-only turns, but disables answer, plan, and tool-progress drafts whenever either modifier-capable outbound hook is registered. Authoritative final payloads continue through the existing Matrix dispatcher and delivery path.

This is intentionally Matrix-owned and adds no core policy, public Plugin SDK surface, configuration, protocol, storage, migration, dependency, or post-send compensation.

## User Impact

Matrix deployments that use outbound rewrite or cancellation hooks no longer expose pre-hook reply content through drafts. Deployments with no modifying hooks—or only observer hooks such as `message_sent`—retain normal Matrix streaming previews.

## Evidence

AI-assisted: yes. I understand and reviewed the implementation and its provider-visible behavior.

Current PR head: `18a3b243451563442bb0c765f3beff7da0e7ce4e`. The branch was deliberately rebased once from frozen base `faa7b2fe11328993ee4b540c28507ec159911e22` onto integration base `c3fba2bb200dce2032ede088f49d57d5d585cbea`. `git range-diff` found the product commit unchanged, and no intervening commit touched the Matrix preview/finalization owner surface.

### Live disposable Matrix/Tuwunel

Production Matrix plugin + Gateway, maintained QA Lab transport, real disposable Tuwunel protocol. This is not an external public homeserver. [Frozen candidate Testbox run](https://github.com/openclaw/openclaw/actions/runs/30334430092). [Rebased-head Testbox run](https://github.com/openclaw/openclaw/actions/runs/30368049852).

| Scenario | Frozen `main` | Candidate |
|---|---|---|
| No hooks | Preview created and finalized | Preview created and finalized |
| Observer-only | Preview created and finalized | Preview created and finalized |
| RPS + MS rewrite | Original draft event visible before rewritten final | RPS once → MS once; rewritten final `$55V1bzYLVXDeGwsRFExE5dup2FkH0relxsmNPf2dhME`; no preview |
| RPS cancellation | Original draft visible, then redacted; no final | RPS once; no preview, redaction, final, or false `message_sent` |
| MS cancellation | Original draft visible, then redacted; no final | RPS once → MS once; no preview, redaction, final, or false `message_sent` |

Additional real-protocol candidate scenarios passed:

- native thread-root preservation;
- generated-image/media delivery;
- encrypted basic reply;
- encrypted thread relation preservation;
- encrypted image upload/download and model vision path.

The rebased head repeated the rewrite path against real Tuwunel: `reply_payload_sending` once → `message_sending` once, rewritten provider final `$PLbbMdBbcaoZ6Oyd0qEknNo5np8-kJMTj8aOofQSDiw`, zero preview events, and zero redactions. Its product diff hash exactly matched the frozen candidate: `4e7f4bf161f5d4e3d0cf83d06d96edc3ab5405c9c4c64286285b232ad07f96df`.

The current Matrix E2EE QA harness still seeds the retired file-backed IDB snapshot and omits an exact nested array replacement path. The E2EE rows used a validation-only overlay that removes that obsolete seed and supplies `channels.matrix.accounts.sut.groupAllowFrom`; neither harness repair is included in this product PR.

### Deterministic and build proof

- `pnpm test extensions/matrix/src/matrix/monitor/handler.test.ts extensions/matrix/src/matrix/draft-stream.test.ts src/channels/message/lifecycle.test.ts` — 157/157 passed on the rebased head.
- `pnpm check:changed` — passed extension production/test types, format, lint, boundary/API, cycle, and database-first guards on the rebased head.
- `pnpm build` — passed on the rebased head.
- `git diff --check` — passed.
- Fresh branch autoreview — clean; no accepted/actionable findings, 0.93 “patch is correct.”
