### PR TITLE
fix: prevent cron and gateway stress-run timeouts

### DIFF
--- a/scripts/test-projects.test-support.mjs
+++ b/scripts/test-projects.test-support.mjs
@@ -4251,11 +4251,7 @@ function classifyTarget(arg, cwd) {
   }
   if (isPathAtOrUnder(relative, "src/agents")) {
     // Focused runs must preserve the full suite's isolated harness and hook-timeout contracts.
-    if (
-      relative === "src/agents" ||
-      relative === AGENTS_EMBEDDED_AGENT_TEST_ROOT ||
-      isGlobTarget(relative)
-    ) {
+    if (relative === "src/agents" || relative === AGENTS_EMBEDDED_AGENT_TEST_ROOT) {
       return "agent";
     }
     if (agentsEmbeddedIncompleteTurnTestFiles.includes(relative)) {
@@ -4268,10 +4264,14 @@ function classifyTarget(arg, cwd) {
       return "agentEmbeddedRun";
     }
     if (isPathAtOrUnder(relative, AGENTS_EMBEDDED_AGENT_TEST_ROOT)) {
-      return "agentEmbedded";
+      return isGlobTarget(relative) ? "agent" : "agentEmbedded";
     }
     if (isPathAtOrUnder(relative, "src/agents/tools")) {
       return "agentTools";
+    }
+    if (isGlobTarget(relative)) {
+      const owner = relative.slice("src/agents/".length).split("/", 1)[0];
+      return isGlobTarget(owner) ? "agent" : "agentSupport";
     }
     return isFileLikeTarget(relative) && path.posix.dirname(relative) === "src/agents"
       ? "agentCore"

--- a/scripts/test-projects.test-support.mjs
+++ b/scripts/test-projects.test-support.mjs
@@ -8,6 +8,8 @@ import os from "node:os";
 import path from "node:path";
 import {
   agentsCoreIsolatedTestFiles,
+  agentsEmbeddedIncompleteTurnTestFiles,
+  agentsEmbeddedOverflowCompactionTestFiles,
   isAgentsCoreIsolatedTestFile,
 } from "../test/vitest/vitest.agents-paths.mjs";
 import { isChannelSurfaceTestFile } from "../test/vitest/vitest.channel-paths.mjs";
@@ -88,6 +90,7 @@ import {
 } from "./run-vitest.mjs";
 
 const DEFAULT_VITEST_CONFIG = "test/vitest/vitest.unit.config.ts";
+const AGENTS_EMBEDDED_AGENT_TEST_ROOT = "src/agents/embedded-agent-runner";
 const AGENTS_CORE_ISOLATED_VITEST_CONFIG = "test/vitest/vitest.agents-core-isolated.config.ts";
 const AGENTS_CORE_VITEST_CONFIG = "test/vitest/vitest.agents-core.config.ts";
 const AGENTS_EMBEDDED_AGENT_VITEST_CONFIG = "test/vitest/vitest.agents-embedded-agent.config.ts";
@@ -4247,7 +4250,32 @@ function classifyTarget(arg, cwd) {
     return "autoReply";
   }
   if (isPathAtOrUnder(relative, "src/agents")) {
-    return "agent";
+    // Focused runs must preserve the full suite's isolated harness and hook-timeout contracts.
+    if (
+      relative === "src/agents" ||
+      relative === AGENTS_EMBEDDED_AGENT_TEST_ROOT ||
+      isGlobTarget(relative)
+    ) {
+      return "agent";
+    }
+    if (agentsEmbeddedIncompleteTurnTestFiles.includes(relative)) {
+      return "agentEmbeddedIncompleteTurn";
+    }
+    if (agentsEmbeddedOverflowCompactionTestFiles.includes(relative)) {
+      return "agentEmbeddedOverflowCompaction";
+    }
+    if (isPathAtOrUnder(relative, `${AGENTS_EMBEDDED_AGENT_TEST_ROOT}/run`)) {
+      return "agentEmbeddedRun";
+    }
+    if (isPathAtOrUnder(relative, AGENTS_EMBEDDED_AGENT_TEST_ROOT)) {
+      return "agentEmbedded";
+    }
+    if (isPathAtOrUnder(relative, "src/agents/tools")) {
+      return "agentTools";
+    }
+    return isFileLikeTarget(relative) && path.posix.dirname(relative) === "src/agents"
+      ? "agentCore"
+      : "agentSupport";
   }
   if (isPathAtOrUnder(relative, "src/plugins")) {
     return "plugin";
@@ -4409,6 +4437,27 @@ export function buildVitestRunPlans(
 
   const groupedTargets = new Map();
   for (const targetArg of activeTargetArgs) {
+    if (!watchMode && toRepoRelativeTarget(targetArg, cwd) === AGENTS_EMBEDDED_AGENT_TEST_ROOT) {
+      // The recursive parent spans four harness owners; keep every isolated project intact.
+      const embeddedTargetsByKind = [
+        ["agentEmbedded", [`${AGENTS_EMBEDDED_AGENT_TEST_ROOT}/*.test.ts`]],
+        ["agentEmbeddedIncompleteTurn", agentsEmbeddedIncompleteTurnTestFiles],
+        ["agentEmbeddedOverflowCompaction", agentsEmbeddedOverflowCompactionTestFiles],
+        ["agentEmbeddedRun", [`${AGENTS_EMBEDDED_AGENT_TEST_ROOT}/run`]],
+      ];
+
+      for (const [kind, targets] of embeddedTargetsByKind) {
+        const current = groupedTargets.get(kind) ?? [];
+        for (const target of targets) {
+          if (!current.includes(target)) {
+            current.push(target);
+          }
+        }
+        groupedTargets.set(kind, current);
+      }
+      continue;
+    }
+
     const kind = classifyTarget(targetArg, cwd);
     const current = groupedTargets.get(kind) ?? [];
     current.push(targetArg);

--- a/src/gateway/server/ws-connection.startup.test.ts
+++ b/src/gateway/server/ws-connection.startup.test.ts
@@ -13,6 +13,7 @@ import {
   GATEWAY_STARTUP_PENDING_CLOSE_CAUSE,
   GATEWAY_STARTUP_UNAVAILABLE_REASON,
 } from "../../../packages/gateway-protocol/src/startup-unavailable.js";
+import { createDeferred } from "../../test-utils/deferred.js";
 import { attachGatewayWsConnectionHandler } from "./ws-connection.js";
 import {
   attachGatewayWsForTest,
@@ -25,10 +26,28 @@ describe("attachGatewayWsConnectionHandler startup readiness", () => {
   it.each([GATEWAY_STARTUP_CLOSE_CODE, 1006])(
     "keeps startup-unavailable close code %i at debug level",
     async (observedCloseCode) => {
-      const sent: unknown[] = [];
+      const responseReceived = createDeferred<{
+        type?: unknown;
+        id?: unknown;
+        ok?: unknown;
+        error?: {
+          code?: unknown;
+          retryable?: unknown;
+          retryAfterMs?: unknown;
+          details?: unknown;
+        };
+      }>();
       const socket = createGatewayWsTestSocket({
         onSend: (data) => {
-          sent.push(JSON.parse(data));
+          const frame = JSON.parse(data) as unknown;
+          if (
+            typeof frame === "object" &&
+            frame !== null &&
+            (frame as { type?: unknown }).type === "res" &&
+            (frame as { id?: unknown }).id === "connect-1"
+          ) {
+            responseReceived.resolve(frame);
+          }
         },
       });
       const logWsControl = createGatewayWsTestLogger();
@@ -65,37 +84,8 @@ describe("attachGatewayWsConnectionHandler startup readiness", () => {
         }),
       );
 
-      await vi.waitFor(() => {
-        expect(
-          sent.some(
-            (frame) =>
-              typeof frame === "object" &&
-              frame !== null &&
-              (frame as { type?: unknown; id?: unknown; ok?: unknown }).type === "res" &&
-              (frame as { id?: unknown }).id === "connect-1",
-          ),
-        ).toBe(true);
-      });
-
-      const response = sent.find(
-        (frame) =>
-          typeof frame === "object" &&
-          frame !== null &&
-          (frame as { type?: unknown; id?: unknown }).type === "res" &&
-          (frame as { id?: unknown }).id === "connect-1",
-      ) as
-        | {
-            type?: unknown;
-            id?: unknown;
-            ok?: unknown;
-            error?: {
-              code?: unknown;
-              retryable?: unknown;
-              retryAfterMs?: unknown;
-              details?: unknown;
-            };
-          }
-        | undefined;
+      // The handler is lazy-loaded; wait for its actual frame instead of a one-second poll.
+      const response = await responseReceived.promise;
       expect(response?.type).toBe("res");
       expect(response?.id).toBe("connect-1");
       expect(response?.ok).toBe(false);

--- a/src/scripts/test-projects.test.ts
+++ b/src/scripts/test-projects.test.ts
@@ -97,7 +97,7 @@ describe("test-projects args", () => {
   it("keeps split test entries in their owner configs", () => {
     expect(buildVitestRunPlans(["src/agents/openai-transport-stream.base.test.ts"])).toEqual([
       {
-        config: "test/vitest/vitest.agents.config.ts",
+        config: "test/vitest/vitest.agents-core.config.ts",
         forwardedArgs: [],
         includePatterns: ["src/agents/openai-transport-stream.base.test.ts"],
         watchMode: false,
@@ -116,7 +116,7 @@ describe("test-projects args", () => {
   it("expands a test filename prefix into standalone sibling suites", () => {
     expect(buildVitestRunPlans(["src/agents/openai-transport-stream"])).toEqual([
       {
-        config: "test/vitest/vitest.agents.config.ts",
+        config: "test/vitest/vitest.agents-core.config.ts",
         forwardedArgs: [],
         includePatterns: [
           "src/agents/openai-transport-stream.base.test.ts",
@@ -373,10 +373,10 @@ describe("test-projects args", () => {
     ]);
   });
 
-  it("routes agents targets to the agents config", () => {
+  it("routes agent tool targets to the agents-tools config", () => {
     expect(buildVitestRunPlans(["src/agents/tools/image-tool.test.ts"])).toEqual([
       {
-        config: "test/vitest/vitest.agents.config.ts",
+        config: "test/vitest/vitest.agents-tools.config.ts",
         forwardedArgs: [],
         includePatterns: ["src/agents/tools/image-tool.test.ts"],
         watchMode: false,

--- a/test/scripts/test-projects.test.ts
+++ b/test/scripts/test-projects.test.ts
@@ -2735,6 +2735,29 @@ describe("scripts/test-projects changed-target routing", () => {
     ]);
   });
 
+  it.each([
+    [
+      "src/agents/embedded-agent-runner/run/*.test.ts",
+      "test/vitest/vitest.agents-embedded-agent-run.config.ts",
+    ],
+    ["src/agents/runtime-plan/**/*.test.ts", "test/vitest/vitest.agents-support.config.ts"],
+    ["src/agents/tools/**/*.test.ts", "test/vitest/vitest.agents-tools.config.ts"],
+  ])("routes focused agent glob %s to its owning shard", (target, config) => {
+    const plans = buildVitestRunPlans([target]);
+
+    expect(plans).toEqual(
+      expect.arrayContaining([
+        {
+          config,
+          forwardedArgs: [],
+          includePatterns: [target],
+          watchMode: false,
+        },
+      ]),
+    );
+    expect(plans.map((plan) => plan.config)).not.toContain("test/vitest/vitest.agents.config.ts");
+  });
+
   it("keeps mixed embedded-agent and cron-tool targets in their owning shards", () => {
     const embeddedTest = "src/agents/embedded-agent-runner/run.before-agent-reply-cron.test.ts";
     const cronToolTest = "src/agents/tools/cron-tool.pacing.test.ts";

--- a/test/scripts/test-projects.test.ts
+++ b/test/scripts/test-projects.test.ts
@@ -2631,6 +2631,130 @@ describe("scripts/test-projects changed-target routing", () => {
     },
   );
 
+  it.each([
+    ["src/agents/agent-scope.test.ts", "test/vitest/vitest.agents-core.config.ts"],
+    [
+      "src/agents/embedded-agent-runner/run.before-agent-reply-cron.test.ts",
+      "test/vitest/vitest.agents-embedded-agent.config.ts",
+    ],
+    [
+      "src/agents/embedded-agent-runner/run.incomplete-turn.test.ts",
+      "test/vitest/vitest.agents-embedded-agent-incomplete-turn.config.ts",
+    ],
+    [
+      "src/agents/embedded-agent-runner/run.overflow-compaction.test.ts",
+      "test/vitest/vitest.agents-embedded-agent-overflow-compaction.config.ts",
+    ],
+    [
+      "src/agents/embedded-agent-runner/run/attempt.abort-race.test.ts",
+      "test/vitest/vitest.agents-embedded-agent-run.config.ts",
+    ],
+    ["src/agents/runtime-plan/tools.test.ts", "test/vitest/vitest.agents-support.config.ts"],
+    ["src/agents/tools/cron-tool.pacing.test.ts", "test/vitest/vitest.agents-tools.config.ts"],
+  ])("routes focused agent test %s to its owning shard", (testFile, config) => {
+    expect(buildVitestRunPlans([testFile])).toEqual([
+      {
+        config,
+        forwardedArgs: [],
+        includePatterns: [testFile],
+        watchMode: false,
+      },
+    ]);
+  });
+
+  it.each([
+    [
+      "src/agents/embedded-agent-runner/run",
+      "test/vitest/vitest.agents-embedded-agent-run.config.ts",
+    ],
+    ["src/agents/runtime-plan", "test/vitest/vitest.agents-support.config.ts"],
+    ["src/agents/tools", "test/vitest/vitest.agents-tools.config.ts"],
+  ])("routes focused agent directory %s to its owning shard", (directory, config) => {
+    const plans = buildVitestRunPlans([directory]);
+
+    expect(plans).toEqual(
+      expect.arrayContaining([
+        {
+          config,
+          forwardedArgs: [],
+          includePatterns: [`${directory}/**/*.test.ts`],
+          watchMode: false,
+        },
+      ]),
+    );
+    expect(plans.map((plan) => plan.config)).not.toContain(
+      "test/vitest/vitest.agents-core.config.ts",
+    );
+  });
+
+  it("splits the embedded-agent parent directory across every isolated harness", () => {
+    const root = "src/agents/embedded-agent-runner";
+    const plans = buildVitestRunPlans([root]);
+
+    expect(plans).toEqual(
+      expect.arrayContaining([
+        {
+          config: "test/vitest/vitest.agents-embedded-agent.config.ts",
+          forwardedArgs: [],
+          includePatterns: [`${root}/*.test.ts`],
+          watchMode: false,
+        },
+        {
+          config: "test/vitest/vitest.agents-embedded-agent-incomplete-turn.config.ts",
+          forwardedArgs: [],
+          includePatterns: [`${root}/run.incomplete-turn.test.ts`],
+          watchMode: false,
+        },
+        {
+          config: "test/vitest/vitest.agents-embedded-agent-overflow-compaction.config.ts",
+          forwardedArgs: [],
+          includePatterns: [`${root}/run.overflow-compaction.test.ts`],
+          watchMode: false,
+        },
+        {
+          config: "test/vitest/vitest.agents-embedded-agent-run.config.ts",
+          forwardedArgs: [],
+          includePatterns: [`${root}/run/**/*.test.ts`],
+          watchMode: false,
+        },
+      ]),
+    );
+    expect(plans.map((plan) => plan.config)).not.toContain("test/vitest/vitest.agents.config.ts");
+  });
+
+  it("keeps the broad agent test glob in the all-agents shard", () => {
+    const target = "src/agents/**/*.test.ts";
+
+    expect(buildVitestRunPlans([target])).toEqual([
+      {
+        config: "test/vitest/vitest.agents.config.ts",
+        forwardedArgs: [],
+        includePatterns: [target],
+        watchMode: false,
+      },
+    ]);
+  });
+
+  it("keeps mixed embedded-agent and cron-tool targets in their owning shards", () => {
+    const embeddedTest = "src/agents/embedded-agent-runner/run.before-agent-reply-cron.test.ts";
+    const cronToolTest = "src/agents/tools/cron-tool.pacing.test.ts";
+
+    expect(buildVitestRunPlans([embeddedTest, cronToolTest])).toEqual([
+      {
+        config: "test/vitest/vitest.agents-embedded-agent.config.ts",
+        forwardedArgs: [],
+        includePatterns: [embeddedTest],
+        watchMode: false,
+      },
+      {
+        config: "test/vitest/vitest.agents-tools.config.ts",
+        forwardedArgs: [],
+        includePatterns: [cronToolTest],
+        watchMode: false,
+      },
+    ]);
+  });
+
   it("routes Docker E2E script targets to their owner tooling tests", () => {
     const targets = [
       "scripts/e2e/kitchen-sink-plugin-docker.sh",


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where focused or concurrent cron, Workboard, and gateway stress runs could falsely time out or miss the agent tests they were intended to execute. Embedded-agent, tool, support, and specially isolated agent tests were collapsed into the generic project. Gateway startup also raced a cold lazy WebSocket handler against a one-second poll.

## Why This Change Was Made

Route focused files, directories, and owner-local globs through the existing canonical agent harnesses. Expand the mixed embedded-agent directory into its four isolated projects; preserve broad agent globs and watch mode. Wait for the actual Gateway response using the existing deferred primitive. This changes test ownership and synchronization, not production Gateway, SQLite, configuration, or protocol behavior.

## User Impact

Cron, Workboard, Gateway, and agent test runs select their real owner and retain the correct isolation and timeout contract. Cold Gateway startup no longer fails from an unrelated polling deadline.

## Evidence

Rebased and independently reproved on fresh main; reviewed head: `2905eaa46282263ccfe9e7c4cc25cf6a6e6b145e`.

Remote Linux, provider `blacksmith-testbox`, lease `tbx_01kymsye2kxre68p6cvdzycrg5`:

```text
pnpm test test/scripts/test-projects.test.ts \
  src/scripts/test-projects.test.ts \
  src/gateway/server/ws-connection.startup.test.ts \
  test/scripts/sqlite-sessions-transcripts-flip-proof.e2e.test.ts \
  -- --reporter=verbose

tooling: 2 files, 333 tests passed
gateway startup: 1 file, 2 tests passed
live isolated SQLite/session Gateway lifecycle: 1 file, 1 test passed
[test] passed 3 Vitest shards
Blacksmith timing JSON: exitCode=0, runStatus=succeeded
```

The former failing `check-sqlite-session-flip-proof` scenario now passes on this exact rebased source, including real isolated gateway startup, migration, restart, concurrent session operations, and SQLite-first transcript invariants.

Fresh independent review:

```text
autoreview --mode branch --base origin/main
trufflehog: clean
autoreview clean: no accepted/actionable findings reported
overall: patch is correct
```

The broader preceding campaign also passed 340 distinct cron, Workboard, Gateway, tasks, agent, skills, CLI, and UI test files; 61 real-Chromium tests; and six isolated-Gateway scheduling scenarios. The direct terminal proof above is the current-head landing evidence.