### PR TITLE
fix: retain ACPX process lease ownership across reconnects

### DIFF
--- a/extensions/acpx/src/process-lease.test.ts
+++ b/extensions/acpx/src/process-lease.test.ts
@@ -12,6 +12,7 @@ import {
   openAcpxProcessLeaseStateStore,
   OPENCLAW_ACPX_LEASE_ID_ARG,
   OPENCLAW_GATEWAY_INSTANCE_ID_ARG,
+  readAcpxProcessLeaseIdentity,
   withAcpxLeaseEnvironment,
   type AcpxProcessLease,
 } from "./process-lease.js";
@@ -111,5 +112,31 @@ describe("withAcpxLeaseEnvironment", () => {
         "gateway-test",
       ].join(" "),
     );
+  });
+});
+
+describe("readAcpxProcessLeaseIdentity", () => {
+  it("reads quoted portable lease wrapper args", () => {
+    expect(
+      readAcpxProcessLeaseIdentity(
+        [
+          "node /tmp/openclaw/acpx/codex-acp-wrapper.mjs",
+          OPENCLAW_ACPX_LEASE_ID_ARG,
+          "'lease test'",
+          OPENCLAW_GATEWAY_INSTANCE_ID_ARG,
+          '"gateway test"',
+        ].join(" "),
+      ),
+    ).toEqual({
+      leaseId: "lease test",
+      gatewayInstanceId: "gateway test",
+    });
+  });
+
+  it("rejects incomplete lease identity", () => {
+    expect(
+      readAcpxProcessLeaseIdentity(`node wrapper.mjs ${OPENCLAW_ACPX_LEASE_ID_ARG} lease-test`),
+    ).toBeUndefined();
+    expect(readAcpxProcessLeaseIdentity(undefined)).toBeUndefined();
   });
 });

--- a/extensions/acpx/src/process-lease.ts
+++ b/extensions/acpx/src/process-lease.ts
@@ -7,12 +7,33 @@ import type {
   OpenKeyedStoreOptions,
   PluginStateKeyedStore,
 } from "openclaw/plugin-sdk/plugin-state-runtime";
+import { splitCommandParts } from "./command-line.js";
 import { ACPX_PROCESS_LEASE_MAX_ENTRIES, ACPX_PROCESS_LEASE_NAMESPACE } from "./state.js";
 
 /** CLI argument carrying the ACPX process lease id. */
 export const OPENCLAW_ACPX_LEASE_ID_ARG = "--openclaw-acpx-lease-id";
 /** CLI argument carrying the owning gateway instance id. */
 export const OPENCLAW_GATEWAY_INSTANCE_ID_ARG = "--openclaw-gateway-instance-id";
+
+export type AcpxProcessLeaseIdentity = {
+  leaseId: string;
+  gatewayInstanceId: string;
+};
+
+/** Read OpenClaw lease identity from a generated wrapper command. */
+export function readAcpxProcessLeaseIdentity(
+  command: string | undefined,
+): AcpxProcessLeaseIdentity | undefined {
+  const parts = splitCommandParts(command?.trim() ?? "");
+  const leaseIndex = parts.lastIndexOf(OPENCLAW_ACPX_LEASE_ID_ARG);
+  const gatewayIndex = parts.lastIndexOf(OPENCLAW_GATEWAY_INSTANCE_ID_ARG);
+  const leaseId = leaseIndex >= 0 ? parts[leaseIndex + 1]?.trim() : "";
+  const gatewayInstanceId = gatewayIndex >= 0 ? parts[gatewayIndex + 1]?.trim() : "";
+  if (!leaseId || !gatewayInstanceId) {
+    return undefined;
+  }
+  return { leaseId, gatewayInstanceId };
+}
 
 /** Lifecycle state for a tracked ACPX wrapper process. */
 type AcpxProcessLeaseState = "open" | "closing" | "closed" | "lost";

--- a/extensions/acpx/src/process-reaper.test.ts
+++ b/extensions/acpx/src/process-reaper.test.ts
@@ -93,7 +93,7 @@ describe("process reaper", () => {
     expect(result).toEqual({
       inspectedPids: [],
       terminatedPids: [],
-      skippedReason: "unverified-root",
+      skippedReason: "process-list-unavailable",
     });
     expect(killSpy).not.toHaveBeenCalled();
   });
@@ -214,7 +214,7 @@ describe("process reaper", () => {
     expect(result).toEqual({
       inspectedPids: [],
       terminatedPids: [],
-      skippedReason: "unverified-root",
+      skippedReason: "process-list-unavailable",
     });
     expect(killed).toStrictEqual([]);
   });

--- a/extensions/acpx/src/process-reaper.ts
+++ b/extensions/acpx/src/process-reaper.ts
@@ -66,7 +66,11 @@ export type AcpxProcessCleanupDeps = {
 type AcpxProcessCleanupResult = {
   inspectedPids: number[];
   terminatedPids: number[];
-  skippedReason?: "missing-root" | "not-openclaw-owned" | "unverified-root";
+  skippedReason?:
+    | "missing-root"
+    | "not-openclaw-owned"
+    | "process-list-unavailable"
+    | "unverified-root";
 };
 
 /** Result from startup orphan reaping. */
@@ -343,7 +347,11 @@ export async function cleanupOpenClawOwnedAcpxProcessTree(params: {
   try {
     processes = await (params.deps?.listProcesses ?? listPlatformProcesses)();
   } catch {
-    processes = [];
+    return {
+      inspectedPids: [],
+      terminatedPids: [],
+      skippedReason: "process-list-unavailable",
+    };
   }
 
   const listedTree = collectProcessTree(processes, rootPid);

--- a/extensions/acpx/src/runtime.test.ts
+++ b/extensions/acpx/src/runtime.test.ts
@@ -44,6 +44,7 @@ function makeRuntime(
     runTurn: AcpRuntime["runTurn"];
     getCapabilities: NonNullable<AcpRuntime["getCapabilities"]>;
     getStatus: NonNullable<AcpRuntime["getStatus"]>;
+    setMode: NonNullable<AcpRuntime["setMode"]>;
     setConfigOption: NonNullable<AcpRuntime["setConfigOption"]>;
     isHealthy(): boolean;
     probeAvailability(): Promise<void>;
@@ -88,6 +89,7 @@ function makeRuntime(
           runTurn: AcpRuntime["runTurn"];
           getCapabilities: NonNullable<AcpRuntime["getCapabilities"]>;
           getStatus: NonNullable<AcpRuntime["getStatus"]>;
+          setMode: NonNullable<AcpRuntime["setMode"]>;
           setConfigOption: NonNullable<AcpRuntime["setConfigOption"]>;
           isHealthy(): boolean;
           probeAvailability(): Promise<void>;
@@ -1752,11 +1754,11 @@ describe("AcpxRuntime fresh reset wrapper", () => {
     ]);
   });
 
-  it("records ACPX process leases without persisting lease-specific agent commands", async () => {
+  it("persists ACPX process lease identity for later wrapper reconnects", async () => {
     const savedRecords: Record<string, unknown>[] = [];
     const launchCommands: string[] = [];
     const baseStore: TestSessionStore = {
-      load: vi.fn(async () => undefined),
+      load: vi.fn(async () => savedRecords.at(-1)),
       save: vi.fn(async (record) => {
         savedRecords.push(record);
       }),
@@ -1806,7 +1808,7 @@ describe("AcpxRuntime fresh reset wrapper", () => {
     expect(lease?.wrapperPath).toBe("/tmp/openclaw/acpx/codex-acp-wrapper.mjs");
     expect(launchCommands[0]).toContain(OPENCLAW_ACPX_LEASE_ID_ARG);
     expect(launchCommands[0]).toContain(OPENCLAW_GATEWAY_INSTANCE_ID_ARG);
-    expect(savedRecords[0]?.agentCommand).toBe(CODEX_ACP_WRAPPER_COMMAND);
+    expect(savedRecords[0]?.agentCommand).toBe(launchCommands[0]);
     expect(savedRecords[0]?.openclawGatewayInstanceId).toBe("gateway-test");
     expect(savedRecords[0]?.openclawLeaseId).toBe(lease?.leaseId);
   });
@@ -1856,18 +1858,31 @@ describe("AcpxRuntime fresh reset wrapper", () => {
   });
 
   it("keeps reusable persistent ACP launch commands stable across ensures", async () => {
+    const leasedCommand = `${CODEX_ACP_WRAPPER_COMMAND} ${OPENCLAW_ACPX_LEASE_ID_ARG} lease-existing ${OPENCLAW_GATEWAY_INSTANCE_ID_ARG} gateway-test`;
     const baseStore: TestSessionStore = {
       load: vi.fn(async () => ({
         name: "agent:codex:acp:binding:test",
         acpxRecordId: "record-1",
         acpSessionId: "session-1",
-        agentCommand: CODEX_ACP_WRAPPER_COMMAND,
+        agentCommand: leasedCommand,
         cwd: "/tmp",
         closed: false,
+        pid: 777,
       })),
       save: vi.fn(async () => {}),
     };
     const leaseStore = makeLeaseStore();
+    leaseStore.leases.set("lease-existing", {
+      leaseId: "lease-existing",
+      gatewayInstanceId: "gateway-test",
+      sessionKey: "agent:codex:acp:binding:test",
+      wrapperRoot: "/tmp/openclaw/acpx",
+      wrapperPath: "/tmp/openclaw/acpx/codex-acp-wrapper.mjs",
+      rootPid: 777,
+      commandHash: "hash",
+      startedAt: 1,
+      state: "open",
+    });
     const { runtime, delegate } = makeRuntime(baseStore, {
       openclawGatewayInstanceId: "gateway-test",
       openclawProcessLeaseStore: leaseStore.store,
@@ -1898,8 +1913,634 @@ describe("AcpxRuntime fresh reset wrapper", () => {
       mode: "persistent",
     });
 
-    expect(resolvedCommands).toEqual([CODEX_ACP_WRAPPER_COMMAND]);
+    expect(resolvedCommands).toEqual([leasedCommand]);
     expect(leaseStore.store.save).not.toHaveBeenCalled();
+  });
+
+  it("recreates a missing sidecar with the persisted lease identity", async () => {
+    const leasedCommand = `${CODEX_ACP_WRAPPER_COMMAND} ${OPENCLAW_ACPX_LEASE_ID_ARG} lease-missing ${OPENCLAW_GATEWAY_INSTANCE_ID_ARG} gateway-test`;
+    let savedRecord: Record<string, unknown> = {
+      name: "agent:codex:acp:binding:test",
+      acpxRecordId: "record-1",
+      acpSessionId: "session-1",
+      agentCommand: leasedCommand,
+      cwd: "/tmp",
+      closed: false,
+    };
+    const baseStore: TestSessionStore = {
+      load: vi.fn(async () => savedRecord),
+      save: vi.fn(async (record) => {
+        savedRecord = record;
+      }),
+    };
+    const leaseStore = makeLeaseStore();
+    const { runtime, delegate, wrappedStore } = makeRuntime(baseStore, {
+      openclawGatewayInstanceId: "gateway-test",
+      openclawProcessLeaseStore: leaseStore.store,
+      openclawWrapperRoot: "/tmp/openclaw/acpx",
+      agentRegistry: {
+        resolve: (agentName: string) =>
+          agentName === "codex" ? CODEX_ACP_WRAPPER_COMMAND : agentName,
+        list: () => ["codex"],
+      },
+    });
+    vi.spyOn(delegate, "ensureSession").mockImplementation(async (input) => {
+      const command = (
+        runtime as unknown as { scopedAgentRegistry: { resolve(agent: string): string } }
+      ).scopedAgentRegistry.resolve("codex");
+      await wrappedStore.save({ ...savedRecord, agentCommand: command, pid: 777 });
+      return {
+        sessionKey: input.sessionKey,
+        backend: "acpx",
+        runtimeSessionName: input.sessionKey,
+      };
+    });
+
+    await runtime.ensureSession({
+      sessionKey: "agent:codex:acp:binding:test",
+      agent: "codex",
+      mode: "persistent",
+    });
+
+    expect(savedRecord.agentCommand).toBe(leasedCommand);
+    expect(leaseStore.leases.get("lease-missing")).toMatchObject({
+      leaseId: "lease-missing",
+      rootPid: 777,
+    });
+    expect(leaseStore.leases.size).toBe(1);
+  });
+
+  it("does not reuse commands leased by another gateway instance", async () => {
+    const foreignCommand = `${CODEX_ACP_WRAPPER_COMMAND} ${OPENCLAW_ACPX_LEASE_ID_ARG} lease-foreign ${OPENCLAW_GATEWAY_INSTANCE_ID_ARG} gateway-foreign`;
+    let savedRecord: Record<string, unknown> = {
+      name: "agent:codex:acp:binding:test",
+      acpxRecordId: "record-1",
+      acpSessionId: "session-1",
+      agentCommand: foreignCommand,
+      cwd: "/tmp",
+      closed: false,
+      pid: 777,
+    };
+    const baseStore: TestSessionStore = {
+      load: vi.fn(async () => savedRecord),
+      save: vi.fn(async (record) => {
+        savedRecord = record;
+      }),
+    };
+    const leaseStore = makeLeaseStore();
+    const { runtime, delegate, wrappedStore } = makeRuntime(baseStore, {
+      openclawGatewayInstanceId: "gateway-test",
+      openclawProcessLeaseStore: leaseStore.store,
+      openclawWrapperRoot: "/tmp/openclaw/acpx",
+      agentRegistry: {
+        resolve: (agentName: string) =>
+          agentName === "codex" ? CODEX_ACP_WRAPPER_COMMAND : agentName,
+        list: () => ["codex"],
+      },
+    });
+    const resolvedCommands: string[] = [];
+    vi.spyOn(delegate, "ensureSession").mockImplementation(async (input) => {
+      const command = (
+        runtime as unknown as { scopedAgentRegistry: { resolve(agent: string): string } }
+      ).scopedAgentRegistry.resolve("codex");
+      resolvedCommands.push(command);
+      await wrappedStore.save({
+        name: input.sessionKey,
+        agentCommand: command,
+        cwd: "/tmp",
+        pid: 888,
+      });
+      return {
+        sessionKey: input.sessionKey,
+        backend: "acpx",
+        runtimeSessionName: input.sessionKey,
+      };
+    });
+
+    await runtime.ensureSession({
+      sessionKey: "agent:codex:acp:binding:test",
+      agent: "codex",
+      mode: "persistent",
+    });
+
+    expect(resolvedCommands[0]).not.toBe(foreignCommand);
+    expect(resolvedCommands[0]).toContain(`${OPENCLAW_GATEWAY_INSTANCE_ID_ARG} gateway-test`);
+    expect(savedRecord.pid).toBe(888);
+    expect(leaseStore.leases.size).toBe(1);
+  });
+
+  it("serializes concurrent persistent ensures for one session", async () => {
+    let savedRecord: Record<string, unknown> | undefined;
+    const baseStore: TestSessionStore = {
+      load: vi.fn(async () => savedRecord),
+      save: vi.fn(async (record) => {
+        savedRecord = record;
+      }),
+    };
+    const leaseStore = makeLeaseStore();
+    const { runtime, delegate, wrappedStore } = makeRuntime(baseStore, {
+      openclawGatewayInstanceId: "gateway-test",
+      openclawProcessLeaseStore: leaseStore.store,
+      openclawWrapperRoot: "/tmp/openclaw/acpx",
+      agentRegistry: {
+        resolve: (agentName: string) =>
+          agentName === "codex" ? CODEX_ACP_WRAPPER_COMMAND : agentName,
+        list: () => ["codex"],
+      },
+    });
+    let releaseFirst!: () => void;
+    const firstBlocked = new Promise<void>((resolve) => {
+      releaseFirst = resolve;
+    });
+    let entered = 0;
+    let active = 0;
+    let maxActive = 0;
+    const resolvedCommands: string[] = [];
+    const ensure = vi.spyOn(delegate, "ensureSession").mockImplementation(async (input) => {
+      entered += 1;
+      active += 1;
+      maxActive = Math.max(maxActive, active);
+      const command = (
+        runtime as unknown as { scopedAgentRegistry: { resolve(agent: string): string } }
+      ).scopedAgentRegistry.resolve("codex");
+      resolvedCommands.push(command);
+      if (entered === 1) {
+        await wrappedStore.save({
+          name: input.sessionKey,
+          acpSessionId: "session-1",
+          agentCommand: command,
+          cwd: "/tmp",
+          pid: 777,
+        });
+        await firstBlocked;
+      } else if (savedRecord) {
+        await wrappedStore.save(savedRecord);
+      }
+      active -= 1;
+      return {
+        sessionKey: input.sessionKey,
+        backend: "acpx",
+        runtimeSessionName: input.sessionKey,
+      };
+    });
+    const ensureInput = {
+      sessionKey: "agent:codex:acp:binding:test",
+      agent: "codex",
+      mode: "persistent" as const,
+    };
+
+    const first = runtime.ensureSession(ensureInput);
+    while (ensure.mock.calls.length === 0) {
+      await Promise.resolve();
+    }
+    const second = runtime.ensureSession(ensureInput);
+    await Promise.resolve();
+    expect(ensure).toHaveBeenCalledTimes(1);
+
+    releaseFirst();
+    await Promise.all([first, second]);
+
+    expect(maxActive).toBe(1);
+    expect(resolvedCommands[1]).toBe(resolvedCommands[0]);
+    expect(leaseStore.leases.size).toBe(1);
+  });
+
+  it("adopts legacy persistent commands before their next reconnect", async () => {
+    let savedRecord: Record<string, unknown> = {
+      name: "agent:codex:acp:binding:test",
+      acpxRecordId: "record-1",
+      acpSessionId: "session-1",
+      agentCommand: CODEX_ACP_WRAPPER_COMMAND,
+      cwd: "/tmp",
+      closed: false,
+      pid: 777,
+    };
+    const baseStore: TestSessionStore = {
+      load: vi.fn(async () => savedRecord),
+      save: vi.fn(async (record) => {
+        savedRecord = record;
+      }),
+    };
+    const leaseStore = makeLeaseStore();
+    const { runtime, delegate, wrappedStore } = makeRuntime(baseStore, {
+      openclawGatewayInstanceId: "gateway-test",
+      openclawProcessLeaseStore: leaseStore.store,
+      openclawWrapperRoot: "/tmp/openclaw/acpx",
+      agentRegistry: {
+        resolve: (agentName: string) =>
+          agentName === "codex" ? CODEX_ACP_WRAPPER_COMMAND : agentName,
+        list: () => ["codex"],
+      },
+    });
+    const resolvedCommands: string[] = [];
+    vi.spyOn(delegate, "ensureSession").mockImplementation(async (input) => {
+      resolvedCommands.push(
+        (
+          runtime as unknown as { scopedAgentRegistry: { resolve(agent: string): string } }
+        ).scopedAgentRegistry.resolve("codex"),
+      );
+      await wrappedStore.save(savedRecord);
+      return {
+        sessionKey: input.sessionKey,
+        backend: "acpx",
+        runtimeSessionName: input.sessionKey,
+      };
+    });
+
+    await runtime.ensureSession({
+      sessionKey: "agent:codex:acp:binding:test",
+      agent: "codex",
+      mode: "persistent",
+    });
+
+    expect(resolvedCommands).toEqual([CODEX_ACP_WRAPPER_COMMAND]);
+    expect(savedRecord.agentCommand).toContain(OPENCLAW_ACPX_LEASE_ID_ARG);
+    expect(savedRecord.agentCommand).toContain(OPENCLAW_GATEWAY_INSTANCE_ID_ARG);
+    expect(savedRecord.pid).toBeUndefined();
+    expect(leaseStore.leases.size).toBe(0);
+
+    await wrappedStore.save({ ...savedRecord, pid: 888 });
+
+    const [lease] = Array.from(leaseStore.leases.values());
+    expect(lease?.leaseId).toBe(savedRecord.openclawLeaseId);
+    expect(lease?.rootPid).toBe(888);
+  });
+
+  it("removes pending process leases when a fresh launch fails", async () => {
+    const baseStore: TestSessionStore = {
+      load: vi.fn(async () => undefined),
+      save: vi.fn(async () => {}),
+    };
+    const leaseStore = makeLeaseStore();
+    const { runtime, delegate } = makeRuntime(baseStore, {
+      openclawGatewayInstanceId: "gateway-test",
+      openclawProcessLeaseStore: leaseStore.store,
+      openclawWrapperRoot: "/tmp/openclaw/acpx",
+      agentRegistry: {
+        resolve: (agentName: string) =>
+          agentName === "codex" ? CODEX_ACP_WRAPPER_COMMAND : agentName,
+        list: () => ["codex"],
+      },
+    });
+    vi.spyOn(delegate, "ensureSession").mockRejectedValue(new Error("launch failed"));
+
+    await expect(
+      runtime.ensureSession({
+        sessionKey: "agent:codex:acp:binding:test",
+        agent: "codex",
+        mode: "persistent",
+      }),
+    ).rejects.toThrow("launch failed");
+
+    expect(leaseStore.leases.size).toBe(0);
+    expect(leaseStore.store.markState).toHaveBeenCalledWith(expect.any(String), "lost");
+  });
+
+  it("preserves promoted process leases when session setup later fails", async () => {
+    let savedRecord: Record<string, unknown> | undefined;
+    const baseStore: TestSessionStore = {
+      load: vi.fn(async () => savedRecord),
+      save: vi.fn(async (record) => {
+        savedRecord = record;
+      }),
+    };
+    const leaseStore = makeLeaseStore();
+    const { runtime, delegate, wrappedStore } = makeRuntime(baseStore, {
+      openclawGatewayInstanceId: "gateway-test",
+      openclawProcessLeaseStore: leaseStore.store,
+      openclawWrapperRoot: "/tmp/openclaw/acpx",
+      agentRegistry: {
+        resolve: (agentName: string) =>
+          agentName === "codex" ? CODEX_ACP_WRAPPER_COMMAND : agentName,
+        list: () => ["codex"],
+      },
+    });
+    vi.spyOn(delegate, "ensureSession").mockImplementation(async (input) => {
+      const command = (
+        runtime as unknown as { scopedAgentRegistry: { resolve(agent: string): string } }
+      ).scopedAgentRegistry.resolve("codex");
+      await wrappedStore.save({
+        name: input.sessionKey,
+        agentCommand: command,
+        cwd: "/tmp",
+        pid: 777,
+      });
+      throw new Error("setup failed after spawn");
+    });
+
+    await expect(
+      runtime.ensureSession({
+        sessionKey: "agent:codex:acp:binding:test",
+        agent: "codex",
+        mode: "persistent",
+      }),
+    ).rejects.toThrow("setup failed after spawn");
+
+    const [lease] = Array.from(leaseStore.leases.values());
+    expect(lease?.rootPid).toBe(777);
+    expect(leaseStore.leases.size).toBe(1);
+  });
+
+  it("restores a pending process lease before runTurn reconnects", async () => {
+    const leasedCommand = `${CODEX_ACP_WRAPPER_COMMAND} ${OPENCLAW_ACPX_LEASE_ID_ARG} lease-turn-reconnect ${OPENCLAW_GATEWAY_INSTANCE_ID_ARG} gateway-test`;
+    const baseStore: TestSessionStore = {
+      load: vi.fn(async () => ({
+        name: "agent:codex:acp:binding:test",
+        agentCommand: leasedCommand,
+      })),
+      save: vi.fn(async () => {}),
+    };
+    const leaseStore = makeLeaseStore();
+    const { runtime, delegate } = makeRuntime(baseStore, {
+      openclawGatewayInstanceId: "gateway-test",
+      openclawProcessLeaseStore: leaseStore.store,
+      openclawWrapperRoot: "/tmp/openclaw/acpx",
+    });
+    vi.spyOn(delegate, "runTurn").mockImplementation(async function* () {
+      expect(leaseStore.leases.get("lease-turn-reconnect")).toMatchObject({
+        rootPid: 0,
+        sessionKey: "agent:codex:acp:binding:test",
+      });
+      yield { type: "status", text: "reconnecting" };
+    });
+
+    for await (const event of runtime.runTurn({
+      handle: {
+        sessionKey: "agent:codex:acp:binding:test",
+        backend: "acpx",
+        runtimeSessionName: "agent:codex:acp:binding:test",
+      },
+      text: "Reply exactly OK",
+      mode: "prompt",
+      requestId: "turn-reconnect",
+    })) {
+      void event;
+    }
+    expect(leaseStore.leases.size).toBe(0);
+  });
+
+  it("retires runTurn pending leases when handle resolution fails", async () => {
+    const leasedCommand = `${CODEX_ACP_WRAPPER_COMMAND} ${OPENCLAW_ACPX_LEASE_ID_ARG} lease-turn-resolution ${OPENCLAW_GATEWAY_INSTANCE_ID_ARG} gateway-test`;
+    let loads = 0;
+    const baseStore: TestSessionStore = {
+      load: vi.fn(async () => {
+        loads += 1;
+        if (loads >= 2) {
+          throw new Error("session load failed");
+        }
+        return {
+          name: "agent:codex:acp:binding:test",
+          agentCommand: leasedCommand,
+        };
+      }),
+      save: vi.fn(async () => {}),
+    };
+    const leaseStore = makeLeaseStore();
+    const { runtime } = makeRuntime(baseStore, {
+      openclawGatewayInstanceId: "gateway-test",
+      openclawProcessLeaseStore: leaseStore.store,
+      openclawWrapperRoot: "/tmp/openclaw/acpx",
+    });
+
+    await expect(async () => {
+      for await (const event of runtime.runTurn({
+        handle: {
+          sessionKey: "agent:codex:acp:binding:test",
+          backend: "acpx",
+          runtimeSessionName: "agent:codex:acp:binding:test",
+        },
+        text: "Reply exactly OK",
+        mode: "prompt",
+        requestId: "turn-resolution",
+      })) {
+        void event;
+      }
+    }).rejects.toThrow("session load failed");
+
+    expect(leaseStore.leases.size).toBe(0);
+  });
+
+  it("restores a pending process lease before startTurn reconnects", async () => {
+    const leasedCommand = `${CODEX_ACP_WRAPPER_COMMAND} ${OPENCLAW_ACPX_LEASE_ID_ARG} lease-start-reconnect ${OPENCLAW_GATEWAY_INSTANCE_ID_ARG} gateway-test`;
+    const baseStore: TestSessionStore = {
+      load: vi.fn(async () => ({
+        name: "agent:codex:acp:binding:test",
+        agentCommand: leasedCommand,
+      })),
+      save: vi.fn(async () => {}),
+    };
+    const leaseStore = makeLeaseStore();
+    const { runtime, delegate } = makeRuntime(baseStore, {
+      openclawGatewayInstanceId: "gateway-test",
+      openclawProcessLeaseStore: leaseStore.store,
+      openclawWrapperRoot: "/tmp/openclaw/acpx",
+    });
+    vi.spyOn(delegate, "startTurn").mockImplementation((input) => {
+      expect(leaseStore.leases.get("lease-start-reconnect")).toMatchObject({
+        rootPid: 0,
+        sessionKey: "agent:codex:acp:binding:test",
+      });
+      return {
+        requestId: input.requestId,
+        events: (async function* () {})(),
+        result: Promise.resolve({ status: "completed" }),
+        cancel: vi.fn(async () => {}),
+        closeStream: vi.fn(async () => {}),
+      };
+    });
+
+    const turn = runtime.startTurn({
+      handle: {
+        sessionKey: "agent:codex:acp:binding:test",
+        backend: "acpx",
+        runtimeSessionName: "agent:codex:acp:binding:test",
+      },
+      text: "Reply exactly OK",
+      mode: "prompt",
+      requestId: "start-reconnect",
+    });
+
+    await expect(turn.result).resolves.toEqual({ status: "completed" });
+    expect(leaseStore.leases.size).toBe(0);
+  });
+
+  it("tracks control-operation reconnects without leaving pending leases", async () => {
+    const leasedCommand = `${CODEX_ACP_WRAPPER_COMMAND} ${OPENCLAW_ACPX_LEASE_ID_ARG} lease-control-reconnect ${OPENCLAW_GATEWAY_INSTANCE_ID_ARG} gateway-test`;
+    const baseStore: TestSessionStore = {
+      load: vi.fn(async () => ({
+        name: "agent:codex:acp:binding:test",
+        agentCommand: leasedCommand,
+      })),
+      save: vi.fn(async () => {}),
+    };
+    const leaseStore = makeLeaseStore();
+    const { runtime, delegate } = makeRuntime(baseStore, {
+      openclawGatewayInstanceId: "gateway-test",
+      openclawProcessLeaseStore: leaseStore.store,
+      openclawWrapperRoot: "/tmp/openclaw/acpx",
+    });
+    vi.spyOn(delegate, "setMode").mockImplementation(async () => {
+      expect(leaseStore.leases.get("lease-control-reconnect")).toMatchObject({
+        rootPid: 0,
+        sessionKey: "agent:codex:acp:binding:test",
+      });
+    });
+
+    await runtime.setMode({
+      handle: {
+        sessionKey: "agent:codex:acp:binding:test",
+        backend: "acpx",
+        runtimeSessionName: "agent:codex:acp:binding:test",
+      },
+      mode: "plan",
+    });
+
+    expect(leaseStore.leases.size).toBe(0);
+  });
+
+  it("keeps a shared pending lease until the last concurrent operation finishes", async () => {
+    const leasedCommand = `${CODEX_ACP_WRAPPER_COMMAND} ${OPENCLAW_ACPX_LEASE_ID_ARG} lease-concurrent-operations ${OPENCLAW_GATEWAY_INSTANCE_ID_ARG} gateway-test`;
+    const baseStore: TestSessionStore = {
+      load: vi.fn(async () => ({
+        name: "agent:codex:acp:binding:test",
+        agentCommand: leasedCommand,
+      })),
+      save: vi.fn(async () => {}),
+    };
+    const leaseStore = makeLeaseStore();
+    const { runtime, delegate } = makeRuntime(baseStore, {
+      openclawGatewayInstanceId: "gateway-test",
+      openclawProcessLeaseStore: leaseStore.store,
+      openclawWrapperRoot: "/tmp/openclaw/acpx",
+    });
+    let markTurnStarted!: () => void;
+    const turnStarted = new Promise<void>((resolve) => {
+      markTurnStarted = resolve;
+    });
+    let releaseTurn!: () => void;
+    const turnBlocked = new Promise<void>((resolve) => {
+      releaseTurn = resolve;
+    });
+    vi.spyOn(delegate, "runTurn").mockImplementation(async function* () {
+      markTurnStarted();
+      await turnBlocked;
+      yield { type: "status", text: "completed" };
+    });
+    vi.spyOn(delegate, "setMode").mockResolvedValue(undefined);
+    const handle = {
+      sessionKey: "agent:codex:acp:binding:test",
+      backend: "acpx" as const,
+      runtimeSessionName: "agent:codex:acp:binding:test",
+    };
+    const turn = (async () => {
+      for await (const event of runtime.runTurn({
+        handle,
+        text: "Reply exactly OK",
+        mode: "prompt",
+        requestId: "turn-concurrent-operations",
+      })) {
+        void event;
+      }
+    })();
+    await turnStarted;
+
+    await runtime.setMode({ handle, mode: "plan" });
+
+    expect(leaseStore.leases.get("lease-concurrent-operations")).toMatchObject({
+      rootPid: 0,
+    });
+    releaseTurn();
+    await turn;
+    expect(leaseStore.leases.size).toBe(0);
+  });
+
+  it("retires close pending leases when cleanup fails", async () => {
+    const leasedCommand = `${CODEX_ACP_WRAPPER_COMMAND} ${OPENCLAW_ACPX_LEASE_ID_ARG} lease-close-failure ${OPENCLAW_GATEWAY_INSTANCE_ID_ARG} gateway-test`;
+    const baseStore: TestSessionStore = {
+      load: vi.fn(async () => ({
+        name: "agent:codex:acp:binding:test",
+        agentCommand: leasedCommand,
+      })),
+      save: vi.fn(async () => {}),
+    };
+    const leaseStore = makeLeaseStore();
+    const { runtime, delegate } = makeRuntime(baseStore, {
+      openclawGatewayInstanceId: "gateway-test",
+      openclawProcessLeaseStore: leaseStore.store,
+      openclawWrapperRoot: "/tmp/openclaw/acpx",
+    });
+    vi.spyOn(delegate, "close").mockResolvedValue(undefined);
+    vi.spyOn(
+      runtime as unknown as {
+        cleanupProcessTreeForRecord: () => Promise<void>;
+      },
+      "cleanupProcessTreeForRecord",
+    ).mockRejectedValue(new Error("cleanup failed"));
+
+    await expect(
+      runtime.close({
+        handle: {
+          sessionKey: "agent:codex:acp:binding:test",
+          backend: "acpx",
+          runtimeSessionName: "agent:codex:acp:binding:test",
+        },
+        reason: "user-close",
+      }),
+    ).rejects.toThrow("cleanup failed");
+
+    expect(leaseStore.leases.size).toBe(0);
+  });
+
+  it("preserves PID-bearing close leases when cleanup fails", async () => {
+    const leasedCommand = `${CODEX_ACP_WRAPPER_COMMAND} ${OPENCLAW_ACPX_LEASE_ID_ARG} lease-close-live ${OPENCLAW_GATEWAY_INSTANCE_ID_ARG} gateway-test`;
+    const baseStore: TestSessionStore = {
+      load: vi.fn(async () => ({
+        name: "agent:codex:acp:binding:test",
+        agentCommand: leasedCommand,
+        pid: 777,
+      })),
+      save: vi.fn(async () => {}),
+    };
+    const leaseStore = makeLeaseStore();
+    leaseStore.leases.set("lease-close-live", {
+      leaseId: "lease-close-live",
+      gatewayInstanceId: "gateway-test",
+      sessionKey: "agent:codex:acp:binding:test",
+      wrapperRoot: "/tmp/openclaw/acpx",
+      wrapperPath: "/tmp/openclaw/acpx/codex-acp-wrapper.mjs",
+      rootPid: 777,
+      commandHash: "hash",
+      startedAt: 1,
+      state: "open",
+    });
+    const { runtime, delegate } = makeRuntime(baseStore, {
+      openclawGatewayInstanceId: "gateway-test",
+      openclawProcessLeaseStore: leaseStore.store,
+      openclawWrapperRoot: "/tmp/openclaw/acpx",
+    });
+    vi.spyOn(delegate, "close").mockResolvedValue(undefined);
+    vi.spyOn(
+      runtime as unknown as {
+        cleanupProcessTreeForRecord: () => Promise<void>;
+      },
+      "cleanupProcessTreeForRecord",
+    ).mockRejectedValue(new Error("cleanup failed"));
+
+    await expect(
+      runtime.close({
+        handle: {
+          sessionKey: "agent:codex:acp:binding:test",
+          backend: "acpx",
+          runtimeSessionName: "agent:codex:acp:binding:test",
+        },
+        reason: "user-close",
+      }),
+    ).rejects.toThrow("cleanup failed");
+
+    expect(leaseStore.leases.get("lease-close-live")).toMatchObject({
+      rootPid: 777,
+      state: "open",
+    });
   });
 
   it("merges sidecar lease ids into loaded ACPX session records", async () => {

--- a/extensions/acpx/src/runtime.test.ts
+++ b/extensions/acpx/src/runtime.test.ts
@@ -2475,6 +2475,57 @@ describe("AcpxRuntime fresh reset wrapper", () => {
     expect(leaseStore.leases.size).toBe(0);
   });
 
+  it("preserves a promoted PID when the session record save fails", async () => {
+    const leasedCommand = `${CODEX_ACP_WRAPPER_COMMAND} ${OPENCLAW_ACPX_LEASE_ID_ARG} lease-partial-save ${OPENCLAW_GATEWAY_INSTANCE_ID_ARG} gateway-test`;
+    const savedRecord: Record<string, unknown> = {
+      name: "agent:codex:acp:binding:test",
+      agentCommand: leasedCommand,
+      pid: 777,
+    };
+    const baseStore: TestSessionStore = {
+      load: vi.fn(async () => savedRecord),
+      save: vi.fn(async () => {
+        throw new Error("session save failed");
+      }),
+    };
+    const leaseStore = makeLeaseStore();
+    leaseStore.leases.set("lease-partial-save", {
+      leaseId: "lease-partial-save",
+      gatewayInstanceId: "gateway-test",
+      sessionKey: "agent:codex:acp:binding:test",
+      wrapperRoot: "/tmp/openclaw/acpx",
+      wrapperPath: "/tmp/openclaw/acpx/codex-acp-wrapper.mjs",
+      rootPid: 777,
+      commandHash: "hash",
+      startedAt: 1,
+      state: "open",
+    });
+    const { runtime, delegate, wrappedStore } = makeRuntime(baseStore, {
+      openclawGatewayInstanceId: "gateway-test",
+      openclawProcessLeaseStore: leaseStore.store,
+      openclawWrapperRoot: "/tmp/openclaw/acpx",
+    });
+    vi.spyOn(delegate, "setMode").mockImplementation(async () => {
+      await wrappedStore.save({ ...savedRecord, pid: 888 });
+    });
+
+    await expect(
+      runtime.setMode({
+        handle: {
+          sessionKey: "agent:codex:acp:binding:test",
+          backend: "acpx",
+          runtimeSessionName: "agent:codex:acp:binding:test",
+        },
+        mode: "plan",
+      }),
+    ).rejects.toThrow("session save failed");
+
+    expect(leaseStore.leases.get("lease-partial-save")).toMatchObject({
+      rootPid: 888,
+      state: "open",
+    });
+  });
+
   it("keeps a shared pending lease until the last concurrent operation finishes", async () => {
     const leasedCommand = `${CODEX_ACP_WRAPPER_COMMAND} ${OPENCLAW_ACPX_LEASE_ID_ARG} lease-concurrent-operations ${OPENCLAW_GATEWAY_INSTANCE_ID_ARG} gateway-test`;
     const baseStore: TestSessionStore = {
@@ -2928,6 +2979,61 @@ describe("AcpxRuntime fresh reset wrapper", () => {
     ).rejects.toThrow("cleanup failed");
 
     expect(leaseStore.leases.get("lease-close-live")).toMatchObject({
+      rootPid: 777,
+      state: "open",
+    });
+  });
+
+  it("keeps close leases retryable when process listing is unavailable", async () => {
+    const leasedCommand = `${CODEX_ACP_WRAPPER_COMMAND} ${OPENCLAW_ACPX_LEASE_ID_ARG} lease-close-process-list ${OPENCLAW_GATEWAY_INSTANCE_ID_ARG} gateway-test`;
+    const baseStore: TestSessionStore = {
+      load: vi.fn(async () => ({
+        name: "agent:codex:acp:binding:test",
+        agentCommand: leasedCommand,
+        pid: 777,
+      })),
+      save: vi.fn(async () => {}),
+    };
+    const leaseStore = makeLeaseStore();
+    leaseStore.leases.set("lease-close-process-list", {
+      leaseId: "lease-close-process-list",
+      gatewayInstanceId: "gateway-test",
+      sessionKey: "agent:codex:acp:binding:test",
+      wrapperRoot: "/tmp/openclaw/acpx",
+      wrapperPath: "/tmp/openclaw/acpx/codex-acp-wrapper.mjs",
+      rootPid: 777,
+      commandHash: "hash",
+      startedAt: 1,
+      state: "open",
+    });
+    const { runtime, delegate } = makeRuntime(
+      baseStore,
+      {
+        openclawGatewayInstanceId: "gateway-test",
+        openclawProcessLeaseStore: leaseStore.store,
+        openclawWrapperRoot: "/tmp/openclaw/acpx",
+      },
+      {
+        openclawProcessCleanup: {
+          listProcesses: vi.fn(async () => {
+            throw new Error("process listing unavailable");
+          }),
+          sleep: vi.fn(async () => {}),
+        },
+      },
+    );
+    vi.spyOn(delegate, "close").mockResolvedValue(undefined);
+
+    await runtime.close({
+      handle: {
+        sessionKey: "agent:codex:acp:binding:test",
+        backend: "acpx",
+        runtimeSessionName: "agent:codex:acp:binding:test",
+      },
+      reason: "user-close",
+    });
+
+    expect(leaseStore.leases.get("lease-close-process-list")).toMatchObject({
       rootPid: 777,
       state: "open",
     });

--- a/extensions/acpx/src/runtime.test.ts
+++ b/extensions/acpx/src/runtime.test.ts
@@ -2029,6 +2029,40 @@ describe("AcpxRuntime fresh reset wrapper", () => {
     expect(leaseStore.leases.size).toBe(1);
   });
 
+  it("rejects reconnect operations for commands leased by another gateway", async () => {
+    const foreignCommand = `${CODEX_ACP_WRAPPER_COMMAND} ${OPENCLAW_ACPX_LEASE_ID_ARG} lease-foreign-operation ${OPENCLAW_GATEWAY_INSTANCE_ID_ARG} gateway-foreign`;
+    const baseStore: TestSessionStore = {
+      load: vi.fn(async () => ({
+        name: "agent:codex:acp:binding:test",
+        agentCommand: foreignCommand,
+      })),
+      save: vi.fn(async () => {}),
+    };
+    const leaseStore = makeLeaseStore();
+    const { runtime, delegate } = makeRuntime(baseStore, {
+      openclawGatewayInstanceId: "gateway-test",
+      openclawProcessLeaseStore: leaseStore.store,
+      openclawWrapperRoot: "/tmp/openclaw/acpx",
+    });
+    const setMode = vi.spyOn(delegate, "setMode").mockResolvedValue(undefined);
+
+    await expect(
+      runtime.setMode({
+        handle: {
+          sessionKey: "agent:codex:acp:binding:test",
+          backend: "acpx",
+          runtimeSessionName: "agent:codex:acp:binding:test",
+        },
+        mode: "plan",
+      }),
+    ).rejects.toMatchObject({
+      code: "ACP_TURN_FAILED",
+      message: "ACPX process lease lease-foreign-operation belongs to another gateway",
+    });
+    expect(setMode).not.toHaveBeenCalled();
+    expect(leaseStore.leases.size).toBe(0);
+  });
+
   it("serializes concurrent persistent ensures for one session", async () => {
     let savedRecord: Record<string, unknown> | undefined;
     const baseStore: TestSessionStore = {
@@ -2279,6 +2313,49 @@ describe("AcpxRuntime fresh reset wrapper", () => {
     expect(leaseStore.leases.size).toBe(0);
   });
 
+  it("restores a missing sidecar from the persisted lease PID", async () => {
+    const leasedCommand = `${CODEX_ACP_WRAPPER_COMMAND} ${OPENCLAW_ACPX_LEASE_ID_ARG} lease-live-reconnect ${OPENCLAW_GATEWAY_INSTANCE_ID_ARG} gateway-test`;
+    const baseStore: TestSessionStore = {
+      load: vi.fn(async () => ({
+        name: "agent:codex:acp:binding:test",
+        agentCommand: leasedCommand,
+        pid: 777,
+      })),
+      save: vi.fn(async () => {}),
+    };
+    const leaseStore = makeLeaseStore();
+    const { runtime, delegate } = makeRuntime(baseStore, {
+      openclawGatewayInstanceId: "gateway-test",
+      openclawProcessLeaseStore: leaseStore.store,
+      openclawWrapperRoot: "/tmp/openclaw/acpx",
+    });
+    vi.spyOn(delegate, "runTurn").mockImplementation(async function* () {
+      expect(leaseStore.leases.get("lease-live-reconnect")).toMatchObject({
+        rootPid: 777,
+        sessionKey: "agent:codex:acp:binding:test",
+      });
+      yield { type: "status", text: "connected" };
+    });
+
+    for await (const event of runtime.runTurn({
+      handle: {
+        sessionKey: "agent:codex:acp:binding:test",
+        backend: "acpx",
+        runtimeSessionName: "agent:codex:acp:binding:test",
+      },
+      text: "Reply exactly OK",
+      mode: "prompt",
+      requestId: "turn-live-reconnect",
+    })) {
+      void event;
+    }
+
+    expect(leaseStore.leases.get("lease-live-reconnect")).toMatchObject({
+      rootPid: 777,
+      state: "open",
+    });
+  });
+
   it("retires runTurn pending leases when handle resolution fails", async () => {
     const leasedCommand = `${CODEX_ACP_WRAPPER_COMMAND} ${OPENCLAW_ACPX_LEASE_ID_ARG} lease-turn-resolution ${OPENCLAW_GATEWAY_INSTANCE_ID_ARG} gateway-test`;
     let loads = 0;
@@ -2451,6 +2528,319 @@ describe("AcpxRuntime fresh reset wrapper", () => {
     });
     releaseTurn();
     await turn;
+    expect(leaseStore.leases.size).toBe(0);
+  });
+
+  it("retires an old lease after the session record switches identity", async () => {
+    const oldCommand = `${CODEX_ACP_WRAPPER_COMMAND} ${OPENCLAW_ACPX_LEASE_ID_ARG} lease-old-operation ${OPENCLAW_GATEWAY_INSTANCE_ID_ARG} gateway-test`;
+    const newCommand = `${CODEX_ACP_WRAPPER_COMMAND} ${OPENCLAW_ACPX_LEASE_ID_ARG} lease-new-session ${OPENCLAW_GATEWAY_INSTANCE_ID_ARG} gateway-test`;
+    let savedRecord: Record<string, unknown> = {
+      name: "agent:codex:acp:binding:test",
+      agentCommand: oldCommand,
+      pid: 777,
+    };
+    const baseStore: TestSessionStore = {
+      load: vi.fn(async () => savedRecord),
+      save: vi.fn(async (record) => {
+        savedRecord = record;
+      }),
+    };
+    const leaseStore = makeLeaseStore();
+    leaseStore.leases.set("lease-old-operation", {
+      leaseId: "lease-old-operation",
+      gatewayInstanceId: "gateway-test",
+      sessionKey: "agent:codex:acp:binding:test",
+      wrapperRoot: "/tmp/openclaw/acpx",
+      wrapperPath: "/tmp/openclaw/acpx/codex-acp-wrapper.mjs",
+      rootPid: 777,
+      commandHash: "hash",
+      startedAt: 1,
+      state: "open",
+    });
+    const { runtime, delegate } = makeRuntime(baseStore, {
+      openclawGatewayInstanceId: "gateway-test",
+      openclawProcessLeaseStore: leaseStore.store,
+      openclawWrapperRoot: "/tmp/openclaw/acpx",
+    });
+    let markTurnStarted!: () => void;
+    const turnStarted = new Promise<void>((resolve) => {
+      markTurnStarted = resolve;
+    });
+    let releaseTurn!: () => void;
+    const turnBlocked = new Promise<void>((resolve) => {
+      releaseTurn = resolve;
+    });
+    vi.spyOn(delegate, "runTurn").mockImplementation(async function* () {
+      markTurnStarted();
+      await turnBlocked;
+      yield { type: "status", text: "completed" };
+    });
+    const handle = {
+      sessionKey: "agent:codex:acp:binding:test",
+      backend: "acpx" as const,
+      runtimeSessionName: "agent:codex:acp:binding:test",
+    };
+    const turn = (async () => {
+      for await (const event of runtime.runTurn({
+        handle,
+        text: "Reply exactly OK",
+        mode: "prompt",
+        requestId: "turn-old-operation",
+      })) {
+        void event;
+      }
+    })();
+    await turnStarted;
+
+    savedRecord = {
+      name: handle.sessionKey,
+      agentCommand: newCommand,
+      pid: 888,
+    };
+    releaseTurn();
+    await turn;
+
+    expect(leaseStore.leases.has("lease-old-operation")).toBe(false);
+    expect(leaseStore.store.markState).toHaveBeenCalledWith("lease-old-operation", "lost");
+  });
+
+  it("keeps launch ownership while a concurrent reconnect operation is active", async () => {
+    let savedRecord: Record<string, unknown> | undefined;
+    const baseStore: TestSessionStore = {
+      load: vi.fn(async () => savedRecord),
+      save: vi.fn(async (record) => {
+        savedRecord = record;
+      }),
+    };
+    const leaseStore = makeLeaseStore();
+    const { runtime, delegate, wrappedStore } = makeRuntime(baseStore, {
+      openclawGatewayInstanceId: "gateway-test",
+      openclawProcessLeaseStore: leaseStore.store,
+      openclawWrapperRoot: "/tmp/openclaw/acpx",
+      agentRegistry: {
+        resolve: (agentName: string) =>
+          agentName === "codex" ? CODEX_ACP_WRAPPER_COMMAND : agentName,
+        list: () => ["codex"],
+      },
+    });
+    let markLaunchPersisted!: () => void;
+    const launchPersisted = new Promise<void>((resolve) => {
+      markLaunchPersisted = resolve;
+    });
+    let failLaunch!: () => void;
+    const launchBlocked = new Promise<void>((resolve) => {
+      failLaunch = resolve;
+    });
+    vi.spyOn(delegate, "ensureSession").mockImplementation(async (input) => {
+      const command = (
+        runtime as unknown as { scopedAgentRegistry: { resolve(agent: string): string } }
+      ).scopedAgentRegistry.resolve("codex");
+      await wrappedStore.save({
+        name: input.sessionKey,
+        agentCommand: command,
+        cwd: "/tmp",
+      });
+      markLaunchPersisted();
+      await launchBlocked;
+      throw new Error("launch failed");
+    });
+    let markControlStarted!: () => void;
+    const controlStarted = new Promise<void>((resolve) => {
+      markControlStarted = resolve;
+    });
+    let releaseControl!: () => void;
+    const controlBlocked = new Promise<void>((resolve) => {
+      releaseControl = resolve;
+    });
+    vi.spyOn(delegate, "setMode").mockImplementation(async () => {
+      markControlStarted();
+      await controlBlocked;
+    });
+    const sessionKey = "agent:codex:acp:binding:test";
+    const handle = {
+      sessionKey,
+      backend: "acpx" as const,
+      runtimeSessionName: sessionKey,
+    };
+    const launch = runtime.ensureSession({
+      sessionKey,
+      agent: "codex",
+      mode: "persistent",
+    });
+    await launchPersisted;
+    const control = runtime.setMode({ handle, mode: "plan" });
+    await controlStarted;
+
+    failLaunch();
+    await expect(launch).rejects.toThrow("launch failed");
+
+    const leaseId = String(savedRecord?.openclawLeaseId);
+    expect(leaseStore.leases.get(leaseId)).toMatchObject({
+      leaseId,
+      rootPid: 0,
+    });
+    releaseControl();
+    await control;
+    expect(leaseStore.leases.size).toBe(0);
+  });
+
+  it("serializes last-owner retirement with the next lease acquisition", async () => {
+    const leasedCommand = `${CODEX_ACP_WRAPPER_COMMAND} ${OPENCLAW_ACPX_LEASE_ID_ARG} lease-retirement-race ${OPENCLAW_GATEWAY_INSTANCE_ID_ARG} gateway-test`;
+    const baseStore: TestSessionStore = {
+      load: vi.fn(async () => ({
+        name: "agent:codex:acp:binding:test",
+        agentCommand: leasedCommand,
+      })),
+      save: vi.fn(async () => {}),
+    };
+    const leaseStore = makeLeaseStore();
+    let leaseLoads = 0;
+    let markRetirementStarted!: () => void;
+    const retirementStarted = new Promise<void>((resolve) => {
+      markRetirementStarted = resolve;
+    });
+    let releaseRetirement!: () => void;
+    const retirementBlocked = new Promise<void>((resolve) => {
+      releaseRetirement = resolve;
+    });
+    leaseStore.store.load.mockImplementation(async (leaseId: string) => {
+      leaseLoads += 1;
+      if (leaseLoads === 2) {
+        markRetirementStarted();
+        await retirementBlocked;
+      }
+      return leaseStore.leases.get(leaseId) as never;
+    });
+    const { runtime, delegate } = makeRuntime(baseStore, {
+      openclawGatewayInstanceId: "gateway-test",
+      openclawProcessLeaseStore: leaseStore.store,
+      openclawWrapperRoot: "/tmp/openclaw/acpx",
+    });
+    vi.spyOn(delegate, "runTurn").mockImplementation(async function* () {
+      yield { type: "status", text: "completed" };
+    });
+    const setMode = vi.spyOn(delegate, "setMode").mockResolvedValue(undefined);
+    const handle = {
+      sessionKey: "agent:codex:acp:binding:test",
+      backend: "acpx" as const,
+      runtimeSessionName: "agent:codex:acp:binding:test",
+    };
+    const turn = (async () => {
+      for await (const event of runtime.runTurn({
+        handle,
+        text: "Reply exactly OK",
+        mode: "prompt",
+        requestId: "turn-retirement-race",
+      })) {
+        void event;
+      }
+    })();
+    await retirementStarted;
+
+    const control = runtime.setMode({ handle, mode: "plan" });
+    await Promise.resolve();
+    expect(setMode).not.toHaveBeenCalled();
+    releaseRetirement();
+
+    await turn;
+    await control;
+    expect(setMode).toHaveBeenCalledTimes(1);
+    expect(leaseStore.store.save).toHaveBeenCalledTimes(2);
+    expect(leaseStore.leases.size).toBe(0);
+  });
+
+  it("rechecks a reusable sidecar after the prior owner retires it", async () => {
+    const leasedCommand = `${CODEX_ACP_WRAPPER_COMMAND} ${OPENCLAW_ACPX_LEASE_ID_ARG} lease-reusable-race ${OPENCLAW_GATEWAY_INSTANCE_ID_ARG} gateway-test`;
+    const sessionKey = "agent:codex:acp:binding:test";
+    const baseStore: TestSessionStore = {
+      load: vi.fn(async () => ({
+        name: sessionKey,
+        acpSessionId: "session-1",
+        agentCommand: leasedCommand,
+        cwd: "/tmp",
+      })),
+      save: vi.fn(async () => {}),
+    };
+    const leaseStore = makeLeaseStore();
+    leaseStore.leases.set("lease-reusable-race", {
+      leaseId: "lease-reusable-race",
+      gatewayInstanceId: "gateway-test",
+      sessionKey,
+      wrapperRoot: "/tmp/openclaw/acpx",
+      wrapperPath: "/tmp/openclaw/acpx/codex-acp-wrapper.mjs",
+      rootPid: 0,
+      commandHash: "hash",
+      startedAt: 1,
+      state: "open",
+    });
+    let leaseLoads = 0;
+    let markRetirementStarted!: () => void;
+    const retirementStarted = new Promise<void>((resolve) => {
+      markRetirementStarted = resolve;
+    });
+    let releaseRetirement!: () => void;
+    const retirementBlocked = new Promise<void>((resolve) => {
+      releaseRetirement = resolve;
+    });
+    leaseStore.store.load.mockImplementation(async (leaseId: string) => {
+      leaseLoads += 1;
+      if (leaseLoads === 2) {
+        markRetirementStarted();
+        await retirementBlocked;
+      }
+      return leaseStore.leases.get(leaseId) as never;
+    });
+    const { runtime, delegate } = makeRuntime(baseStore, {
+      openclawGatewayInstanceId: "gateway-test",
+      openclawProcessLeaseStore: leaseStore.store,
+      openclawWrapperRoot: "/tmp/openclaw/acpx",
+      agentRegistry: {
+        resolve: (agentName: string) =>
+          agentName === "codex" ? CODEX_ACP_WRAPPER_COMMAND : agentName,
+        list: () => ["codex"],
+      },
+    });
+    vi.spyOn(delegate, "runTurn").mockImplementation(async function* () {
+      yield { type: "status", text: "completed" };
+    });
+    vi.spyOn(delegate, "ensureSession").mockImplementation(async (input) => {
+      expect(leaseStore.leases.get("lease-reusable-race")).toMatchObject({
+        rootPid: 0,
+        sessionKey,
+      });
+      return {
+        sessionKey: input.sessionKey,
+        backend: "acpx",
+        runtimeSessionName: input.sessionKey,
+      };
+    });
+    const handle = {
+      sessionKey,
+      backend: "acpx" as const,
+      runtimeSessionName: sessionKey,
+    };
+    const turn = (async () => {
+      for await (const event of runtime.runTurn({
+        handle,
+        text: "Reply exactly OK",
+        mode: "prompt",
+        requestId: "turn-reusable-race",
+      })) {
+        void event;
+      }
+    })();
+    await retirementStarted;
+
+    const ensure = runtime.ensureSession({
+      sessionKey,
+      agent: "codex",
+      mode: "persistent",
+    });
+    releaseRetirement();
+
+    await turn;
+    await ensure;
+    expect(leaseStore.store.save).toHaveBeenCalledTimes(1);
     expect(leaseStore.leases.size).toBe(0);
   });
 

--- a/extensions/acpx/src/runtime.ts
+++ b/extensions/acpx/src/runtime.ts
@@ -37,6 +37,7 @@ import {
   readAcpxProcessLeaseIdentity,
   withAcpxLeaseEnvironment,
   type AcpxProcessLease,
+  type AcpxProcessLeaseIdentity,
   type AcpxProcessLeaseStore,
 } from "./process-lease.js";
 import {
@@ -800,6 +801,7 @@ export class AcpxRuntime implements AcpRuntime {
   private readonly processLeaseStore: AcpxProcessLeaseStore | undefined;
   private readonly launchLeaseScope = new AsyncLocalStorage<AcpxLaunchLeaseContext | undefined>();
   private readonly ensureSessionTails = new Map<string, Promise<void>>();
+  private readonly processLeaseTransitionTails = new Map<string, Promise<void>>();
   private readonly processLeaseOperationCounts = new Map<string, number>();
   private readonly cwd: string;
 
@@ -1018,24 +1020,9 @@ export class AcpxRuntime implements AcpRuntime {
     ) {
       return await params.run();
     }
+    const processLeaseStore = this.processLeaseStore;
     const reusableIdentity = readAcpxProcessLeaseIdentity(params.reusableCommand);
-    const reusableLease =
-      reusableIdentity?.gatewayInstanceId === this.gatewayInstanceId
-        ? await this.processLeaseStore.load(reusableIdentity.leaseId)
-        : undefined;
-    const reusableLeaseMatches =
-      !reusableLease ||
-      (reusableLease.gatewayInstanceId === this.gatewayInstanceId &&
-        reusableLease.sessionKey === params.sessionKey &&
-        reusableLease.wrapperRoot === this.wrapperRoot);
-    if (reusableIdentity?.gatewayInstanceId === this.gatewayInstanceId && !reusableLeaseMatches) {
-      throw new AcpRuntimeError(
-        "ACP_SESSION_INIT_FAILED",
-        `ACPX process lease ${reusableIdentity.leaseId} belongs to another session`,
-      );
-    }
-    const canReuseLeaseIdentity =
-      reusableIdentity?.gatewayInstanceId === this.gatewayInstanceId && reusableLeaseMatches;
+    const canReuseLeaseIdentity = reusableIdentity?.gatewayInstanceId === this.gatewayInstanceId;
     const leaseId = canReuseLeaseIdentity ? reusableIdentity.leaseId : createAcpxProcessLeaseId();
     const leasedCommand = withAcpxLeaseEnvironment({
       command: params.command,
@@ -1054,12 +1041,29 @@ export class AcpxRuntime implements AcpRuntime {
     // Reuse-only adoption cannot spawn: readReusablePersistentSessionCommand
     // mirrors upstream's exact reuse policy. Persist the new command first and
     // let the next reconnect create its matching pending lease.
-    const ownsPendingLease =
-      !reusableLease && (!params.reusableCommand || params.reusableCommand === leasedCommand);
-    if (ownsPendingLease) {
+    await this.retainProcessLeaseOperation(launch, async () => {
+      const reusableLease = canReuseLeaseIdentity
+        ? await processLeaseStore.load(launch.leaseId)
+        : undefined;
+      if (
+        reusableLease &&
+        (reusableLease.gatewayInstanceId !== launch.gatewayInstanceId ||
+          reusableLease.sessionKey !== launch.sessionKey ||
+          reusableLease.wrapperRoot !== launch.wrapperRoot)
+      ) {
+        throw new AcpRuntimeError(
+          "ACP_SESSION_INIT_FAILED",
+          `ACPX process lease ${launch.leaseId} belongs to another session`,
+        );
+      }
+      const ownsPendingLease =
+        !reusableLease && (!params.reusableCommand || params.reusableCommand === leasedCommand);
+      if (!ownsPendingLease) {
+        return;
+      }
       // The pending lease is written before acpx can spawn. The session-store
-      // save fills in the PID, or this owner deletes the row on launch failure.
-      await this.processLeaseStore.save({
+      // save fills in the PID, or the last owner deletes it on launch failure.
+      await processLeaseStore.save({
         leaseId: launch.leaseId,
         gatewayInstanceId: launch.gatewayInstanceId,
         sessionKey: launch.sessionKey,
@@ -1070,131 +1074,191 @@ export class AcpxRuntime implements AcpRuntime {
         startedAt: Date.now(),
         state: "open",
       });
-    }
+    });
     try {
       const result = await this.launchLeaseScope.run(launch, params.run);
-      const record = await this.sessionStore.load(params.sessionKey);
-      if (!readRecordAgentPid(record)) {
-        await this.processLeaseStore.markState(launch.leaseId, "lost");
-      }
+      await this.finalizeProcessLeaseForSession(params.sessionKey, launch);
       return result;
     } catch (error) {
-      if (ownsPendingLease) {
-        await this.retirePendingProcessLease(launch);
-      }
+      await this.retirePendingProcessLease(launch);
       throw error;
     }
   }
 
   private async prepareProcessLeaseForOperation(
     handle: AcpRuntimeHandle,
-  ): Promise<OpenClawLeaseSessionMetadata | undefined> {
+  ): Promise<AcpxProcessLeaseIdentity | undefined> {
     if (!this.processLeaseStore || !this.gatewayInstanceId || !this.wrapperRoot) {
       return undefined;
     }
+    const processLeaseStore = this.processLeaseStore;
+    const wrapperRoot = this.wrapperRoot;
     const record = await this.sessionStore.load(handle.acpxRecordId ?? handle.sessionKey);
+    const recordPid = readRecordAgentPid(record);
     const command = readAgentCommandFromRecord(record);
     const identity = readAcpxProcessLeaseIdentity(command);
     if (
       !command ||
-      identity?.gatewayInstanceId !== this.gatewayInstanceId ||
       !isOpenClawLeaseAwareAcpxProcessCommand({
         command,
-        wrapperRoot: this.wrapperRoot,
+        wrapperRoot,
       })
     ) {
       return undefined;
     }
-    const existing = await this.processLeaseStore.load(identity.leaseId);
-    if (existing) {
+    if (!identity) {
+      return undefined;
+    }
+    if (identity.gatewayInstanceId !== this.gatewayInstanceId) {
+      throw new AcpRuntimeError(
+        "ACP_TURN_FAILED",
+        `ACPX process lease ${identity.leaseId} belongs to another gateway`,
+      );
+    }
+    await this.retainProcessLeaseOperation(identity, async () => {
+      const existing = await processLeaseStore.load(identity.leaseId);
+      if (!existing) {
+        // Preserve a PID already persisted with this lease identity. Otherwise
+        // reconnect starts from a pending row until upstream saves its new PID.
+        await processLeaseStore.save({
+          leaseId: identity.leaseId,
+          gatewayInstanceId: identity.gatewayInstanceId,
+          sessionKey: handle.sessionKey,
+          wrapperRoot,
+          wrapperPath: extractGeneratedWrapperPath(command),
+          rootPid: recordPid ?? 0,
+          commandHash: hashAcpxProcessCommand(command),
+          startedAt: Date.now(),
+          state: "open",
+        });
+        return;
+      }
       if (
         existing.gatewayInstanceId !== identity.gatewayInstanceId ||
         existing.sessionKey !== handle.sessionKey ||
-        existing.wrapperRoot !== this.wrapperRoot
+        existing.wrapperRoot !== wrapperRoot
       ) {
         throw new AcpRuntimeError(
           "ACP_TURN_FAILED",
           `ACPX process lease ${identity.leaseId} belongs to another session`,
         );
       }
-      this.retainProcessLeaseOperation(identity);
-      return identity;
-    }
-    // Reconnect can spawn before upstream persists its replacement PID. A
-    // pending row makes startup cleanup scan the owned wrapper root if we exit.
-    await this.processLeaseStore.save({
-      leaseId: identity.leaseId,
-      gatewayInstanceId: identity.gatewayInstanceId,
-      sessionKey: handle.sessionKey,
-      wrapperRoot: this.wrapperRoot,
-      wrapperPath: extractGeneratedWrapperPath(command),
-      rootPid: 0,
-      commandHash: hashAcpxProcessCommand(command),
-      startedAt: Date.now(),
-      state: "open",
     });
-    this.retainProcessLeaseOperation(identity);
     return identity;
   }
 
-  private retainProcessLeaseOperation(identity: OpenClawLeaseSessionMetadata): void {
-    this.processLeaseOperationCounts.set(
-      identity.leaseId,
-      (this.processLeaseOperationCounts.get(identity.leaseId) ?? 0) + 1,
-    );
+  private async runSerializedProcessLeaseTransition<T>(
+    leaseId: string,
+    run: () => Promise<T>,
+  ): Promise<T> {
+    const previous = this.processLeaseTransitionTails.get(leaseId) ?? Promise.resolve();
+    let release!: () => void;
+    const current = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const tail = previous.then(() => current);
+    this.processLeaseTransitionTails.set(leaseId, tail);
+    await previous;
+    try {
+      return await run();
+    } finally {
+      release();
+      if (this.processLeaseTransitionTails.get(leaseId) === tail) {
+        this.processLeaseTransitionTails.delete(leaseId);
+      }
+    }
   }
 
-  private releaseProcessLeaseOperation(
-    identity: OpenClawLeaseSessionMetadata | undefined,
-  ): boolean {
+  private async retainProcessLeaseOperation(
+    identity: AcpxProcessLeaseIdentity,
+    prepare: () => Promise<void>,
+  ): Promise<void> {
+    await this.runSerializedProcessLeaseTransition(identity.leaseId, async () => {
+      await prepare();
+      this.processLeaseOperationCounts.set(
+        identity.leaseId,
+        (this.processLeaseOperationCounts.get(identity.leaseId) ?? 0) + 1,
+      );
+    });
+  }
+
+  private async releaseProcessLeaseOperation(
+    identity: AcpxProcessLeaseIdentity | undefined,
+    finalize: () => Promise<void>,
+  ): Promise<void> {
     if (!identity) {
-      return false;
+      return;
     }
-    const count = this.processLeaseOperationCounts.get(identity.leaseId) ?? 0;
-    if (count > 1) {
-      this.processLeaseOperationCounts.set(identity.leaseId, count - 1);
-      return false;
-    }
-    this.processLeaseOperationCounts.delete(identity.leaseId);
-    return true;
+    await this.runSerializedProcessLeaseTransition(identity.leaseId, async () => {
+      const count = this.processLeaseOperationCounts.get(identity.leaseId) ?? 0;
+      if (count > 1) {
+        this.processLeaseOperationCounts.set(identity.leaseId, count - 1);
+        return;
+      }
+      if (count === 0) {
+        return;
+      }
+      // Keep the zero-owner check and retirement in one lease-local transition.
+      // Otherwise a reconnect can retain a row while an older owner deletes it.
+      this.processLeaseOperationCounts.delete(identity.leaseId);
+      await finalize();
+    });
   }
 
   private async finalizeProcessLeaseForOperation(
     handle: AcpRuntimeHandle,
-    identity: OpenClawLeaseSessionMetadata | undefined,
+    identity: AcpxProcessLeaseIdentity | undefined,
   ): Promise<void> {
-    if (!identity || !this.processLeaseStore || !this.releaseProcessLeaseOperation(identity)) {
+    await this.finalizeProcessLeaseForSession(handle.acpxRecordId ?? handle.sessionKey, identity);
+  }
+
+  private async finalizeProcessLeaseForSession(
+    sessionId: string,
+    identity: AcpxProcessLeaseIdentity | undefined,
+  ): Promise<void> {
+    if (!identity || !this.processLeaseStore) {
       return;
     }
-    const lease = await this.processLeaseStore.load(identity.leaseId);
-    if (!lease || lease.gatewayInstanceId !== identity.gatewayInstanceId) {
-      return;
-    }
-    if (lease.rootPid <= 0) {
-      await this.processLeaseStore.markState(identity.leaseId, "lost");
-      return;
-    }
-    try {
-      const record = await this.sessionStore.load(handle.acpxRecordId ?? handle.sessionKey);
-      if (!readRecordAgentPid(record)) {
-        await this.processLeaseStore.markState(identity.leaseId, "lost");
+    const processLeaseStore = this.processLeaseStore;
+    await this.releaseProcessLeaseOperation(identity, async () => {
+      const lease = await processLeaseStore.load(identity.leaseId);
+      if (!lease || lease.gatewayInstanceId !== identity.gatewayInstanceId) {
+        return;
       }
-    } catch {
-      // Preserve a PID-bearing lease for startup verification when record reload
-      // fails; deleting it here could lose the only cleanup identity.
-    }
+      if (lease.rootPid <= 0) {
+        await processLeaseStore.markState(identity.leaseId, "lost");
+        return;
+      }
+      try {
+        const record = await this.sessionStore.load(sessionId);
+        const recordIdentity = readAcpxProcessLeaseIdentity(readAgentCommandFromRecord(record));
+        if (
+          recordIdentity?.leaseId !== identity.leaseId ||
+          recordIdentity.gatewayInstanceId !== identity.gatewayInstanceId ||
+          readRecordAgentPid(record) !== lease.rootPid
+        ) {
+          await processLeaseStore.markState(identity.leaseId, "lost");
+        }
+      } catch {
+        // Preserve a PID-bearing lease for startup verification when record reload
+        // fails; deleting it here could lose the only cleanup identity.
+      }
+    });
   }
 
   private async retirePendingProcessLease(
-    identity: OpenClawLeaseSessionMetadata | undefined,
+    identity: AcpxProcessLeaseIdentity | undefined,
   ): Promise<void> {
-    if (!identity || !this.processLeaseStore || !this.releaseProcessLeaseOperation(identity)) {
+    if (!identity || !this.processLeaseStore) {
       return;
     }
-    const lease = await this.processLeaseStore.load(identity.leaseId);
-    if (lease?.gatewayInstanceId === identity.gatewayInstanceId && lease.rootPid <= 0) {
-      await this.processLeaseStore.markState(identity.leaseId, "lost");
-    }
+    const processLeaseStore = this.processLeaseStore;
+    await this.releaseProcessLeaseOperation(identity, async () => {
+      const lease = await processLeaseStore.load(identity.leaseId);
+      if (lease?.gatewayInstanceId === identity.gatewayInstanceId && lease.rootPid <= 0) {
+        await processLeaseStore.markState(identity.leaseId, "lost");
+      }
+    });
   }
 
   private async runWithProcessLeaseForHandle<T>(
@@ -1211,7 +1275,7 @@ export class AcpxRuntime implements AcpRuntime {
 
   private async finalizeProcessLeaseAfter<T>(
     handle: AcpRuntimeHandle,
-    identityPromise: Promise<OpenClawLeaseSessionMetadata | undefined>,
+    identityPromise: Promise<AcpxProcessLeaseIdentity | undefined>,
     resultPromise: Promise<T>,
   ): Promise<T> {
     try {

--- a/extensions/acpx/src/runtime.ts
+++ b/extensions/acpx/src/runtime.ts
@@ -34,6 +34,7 @@ import { splitCommandParts } from "./command-line.js";
 import {
   createAcpxProcessLeaseId,
   hashAcpxProcessCommand,
+  readAcpxProcessLeaseIdentity,
   withAcpxLeaseEnvironment,
   type AcpxProcessLease,
   type AcpxProcessLeaseStore,
@@ -102,7 +103,9 @@ type AcpxLaunchLeaseContext = {
   gatewayInstanceId: string;
   sessionKey: string;
   wrapperRoot: string;
-  stableCommand?: string;
+  stableCommand: string;
+  resolvedCommand: string;
+  leasedCommand: string;
 };
 
 const CODEX_WRAPPER_STDERR_LOG_PREFIX = "codex-acp-wrapper.stderr";
@@ -255,6 +258,7 @@ function createResetAwareSessionStore(
     gatewayInstanceId?: string;
     leaseStore?: AcpxProcessLeaseStore;
     launchScope?: AsyncLocalStorage<AcpxLaunchLeaseContext | undefined>;
+    wrapperRoot?: string;
   },
 ): ResetAwareSessionStore {
   const freshSessionKeys = new Set<string>();
@@ -287,40 +291,69 @@ function createResetAwareSessionStore(
       let recordToSave = record;
       const launch = params?.launchScope?.getStore();
       const sessionName = readSessionRecordName(record);
-      const rootPid = readRecordAgentPid(record);
       const agentCommand = readRecordAgentCommand(record);
-      const stableAgentCommand = launch?.stableCommand ?? agentCommand;
+      const leasedCommand = launch?.leasedCommand ?? agentCommand;
+      const leaseIdentity = launch ?? readAcpxProcessLeaseIdentity(leasedCommand);
       if (
-        launch &&
         params?.leaseStore &&
-        sessionName === launch.sessionKey &&
-        rootPid &&
-        stableAgentCommand
+        params.gatewayInstanceId &&
+        params.wrapperRoot &&
+        (!launch || sessionName === launch.sessionKey) &&
+        leasedCommand &&
+        leaseIdentity?.gatewayInstanceId === params.gatewayInstanceId &&
+        isOpenClawLeaseAwareAcpxProcessCommand({
+          command: leasedCommand,
+          wrapperRoot: params.wrapperRoot,
+        })
       ) {
-        const lease: AcpxProcessLease = {
-          leaseId: launch.leaseId,
-          gatewayInstanceId: launch.gatewayInstanceId,
-          sessionKey: launch.sessionKey,
-          wrapperRoot: launch.wrapperRoot,
-          wrapperPath: extractGeneratedWrapperPath(stableAgentCommand),
-          rootPid,
-          commandHash: hashAcpxProcessCommand(stableAgentCommand),
-          startedAt: Date.now(),
-          state: "open",
-        };
-        await params.leaseStore.save(lease);
-        recordToSave = withOpenClawLeaseSessionMetadata(
-          {
-            ...record,
-            // ACPX uses agentCommand as reuse identity. Lease metadata belongs to
-            // our sidecar record, so keep the persisted command stable.
-            agentCommand: stableAgentCommand,
-          },
-          {
-            openclawLeaseId: launch.leaseId,
-            openclawGatewayInstanceId: launch.gatewayInstanceId,
-          },
-        );
+        const existing = await params.leaseStore.load(leaseIdentity.leaseId);
+        const ownsExisting =
+          !existing ||
+          (existing.gatewayInstanceId === leaseIdentity.gatewayInstanceId &&
+            existing.sessionKey === sessionName &&
+            existing.wrapperRoot === params.wrapperRoot);
+        if (ownsExisting) {
+          const adoptingLease = Boolean(launch && launch.resolvedCommand !== launch.leasedCommand);
+          const lifecycleRecord = adoptingLease
+            ? {
+                ...record,
+                // A reused legacy record can carry the previous wrapper PID. Clear
+                // it before persisting the new lease so reconnect cannot claim it.
+                pid: undefined,
+                processId: undefined,
+                agentStartedAt: undefined,
+              }
+            : record;
+          const rootPid = readRecordAgentPid(lifecycleRecord);
+          if (rootPid) {
+            await params.leaseStore.save({
+              leaseId: leaseIdentity.leaseId,
+              gatewayInstanceId: leaseIdentity.gatewayInstanceId,
+              sessionKey: sessionName,
+              wrapperRoot: params.wrapperRoot,
+              wrapperPath: extractGeneratedWrapperPath(leasedCommand),
+              rootPid,
+              ...(existing?.rootPid === rootPid && existing.processGroupId
+                ? { processGroupId: existing.processGroupId }
+                : {}),
+              commandHash: hashAcpxProcessCommand(leasedCommand),
+              startedAt: existing?.rootPid === rootPid ? existing.startedAt : Date.now(),
+              state: "open",
+            });
+          }
+          recordToSave = withOpenClawLeaseSessionMetadata(
+            {
+              ...lifecycleRecord,
+              // ACPX reconnects from the persisted command, so lease identity must
+              // remain in that reuse key until the session lifecycle is terminal.
+              agentCommand: leasedCommand,
+            },
+            {
+              openclawLeaseId: leaseIdentity.leaseId,
+              openclawGatewayInstanceId: leaseIdentity.gatewayInstanceId,
+            },
+          );
+        }
       }
       await baseStore.save(recordToSave);
       if (sessionName) {
@@ -766,6 +799,8 @@ export class AcpxRuntime implements AcpRuntime {
   private readonly gatewayInstanceId: string | undefined;
   private readonly processLeaseStore: AcpxProcessLeaseStore | undefined;
   private readonly launchLeaseScope = new AsyncLocalStorage<AcpxLaunchLeaseContext | undefined>();
+  private readonly ensureSessionTails = new Map<string, Promise<void>>();
+  private readonly processLeaseOperationCounts = new Map<string, number>();
   private readonly cwd: string;
 
   constructor(options: OpenClawAcpxRuntimeOptions, testOptions?: AcpxRuntimeTestOptions) {
@@ -783,6 +818,7 @@ export class AcpxRuntime implements AcpRuntime {
       gatewayInstanceId: this.gatewayInstanceId,
       leaseStore: this.processLeaseStore,
       launchScope: this.launchLeaseScope,
+      wrapperRoot: this.wrapperRoot,
     });
     this.agentRegistry = options.agentRegistry;
     this.scopedAgentRegistry = createModelScopedAgentRegistry({
@@ -909,7 +945,9 @@ export class AcpxRuntime implements AcpRuntime {
     if (!launch) {
       return command;
     }
-    launch.stableCommand = command;
+    if (command === launch.stableCommand) {
+      return launch.resolvedCommand;
+    }
     return withAcpxLeaseEnvironment({
       command,
       leaseId: launch.leaseId,
@@ -917,42 +955,58 @@ export class AcpxRuntime implements AcpRuntime {
     });
   }
 
-  private async canReuseStablePersistentSession(params: {
+  private async readReusablePersistentSessionCommand(params: {
     sessionKey: string;
     mode: Parameters<AcpRuntime["ensureSession"]>[0]["mode"];
     cwd: string | undefined;
     command: string | undefined;
     resumeSessionId: string | undefined;
-  }): Promise<boolean> {
+  }): Promise<string | undefined> {
     if (params.mode !== "persistent" || !params.command) {
-      return false;
+      return undefined;
     }
     const existing = await this.sessionStore.load(params.sessionKey);
     if (!existing || readRecordResetOnNextEnsure(existing)) {
-      return false;
+      return undefined;
     }
     const recordCwd = readRecordCwd(existing);
     if (!recordCwd || resolvePath(recordCwd) !== resolvePath(params.cwd?.trim() || this.cwd)) {
-      return false;
+      return undefined;
     }
-    if (readRecordAgentCommand(existing) !== params.command) {
-      return false;
+    const recordCommand = readRecordAgentCommand(existing);
+    if (!recordCommand) {
+      return undefined;
+    }
+    const leaseIdentity = readAcpxProcessLeaseIdentity(recordCommand);
+    if (leaseIdentity && leaseIdentity.gatewayInstanceId !== this.gatewayInstanceId) {
+      return undefined;
+    }
+    const stableRecordCommand = leaseIdentity
+      ? withAcpxLeaseEnvironment({
+          command: params.command,
+          leaseId: leaseIdentity.leaseId,
+          gatewayInstanceId: leaseIdentity.gatewayInstanceId,
+        })
+      : params.command;
+    if (recordCommand !== stableRecordCommand) {
+      return undefined;
     }
     const existingSessionId =
       typeof existing === "object" && existing !== null
         ? (existing as { acpSessionId?: unknown }).acpSessionId
         : undefined;
-    return !params.resumeSessionId || existingSessionId === params.resumeSessionId;
+    return !params.resumeSessionId || existingSessionId === params.resumeSessionId
+      ? recordCommand
+      : undefined;
   }
 
   private async runWithLaunchLease<T>(params: {
     sessionKey: string;
     command: string | undefined;
-    enabled?: boolean;
+    reusableCommand?: string;
     run: () => Promise<T>;
   }): Promise<T> {
     if (
-      params.enabled === false ||
       !params.command ||
       !this.wrapperRoot ||
       !this.gatewayInstanceId ||
@@ -964,27 +1018,230 @@ export class AcpxRuntime implements AcpRuntime {
     ) {
       return await params.run();
     }
+    const reusableIdentity = readAcpxProcessLeaseIdentity(params.reusableCommand);
+    const reusableLease =
+      reusableIdentity?.gatewayInstanceId === this.gatewayInstanceId
+        ? await this.processLeaseStore.load(reusableIdentity.leaseId)
+        : undefined;
+    const reusableLeaseMatches =
+      !reusableLease ||
+      (reusableLease.gatewayInstanceId === this.gatewayInstanceId &&
+        reusableLease.sessionKey === params.sessionKey &&
+        reusableLease.wrapperRoot === this.wrapperRoot);
+    if (reusableIdentity?.gatewayInstanceId === this.gatewayInstanceId && !reusableLeaseMatches) {
+      throw new AcpRuntimeError(
+        "ACP_SESSION_INIT_FAILED",
+        `ACPX process lease ${reusableIdentity.leaseId} belongs to another session`,
+      );
+    }
+    const canReuseLeaseIdentity =
+      reusableIdentity?.gatewayInstanceId === this.gatewayInstanceId && reusableLeaseMatches;
+    const leaseId = canReuseLeaseIdentity ? reusableIdentity.leaseId : createAcpxProcessLeaseId();
+    const leasedCommand = withAcpxLeaseEnvironment({
+      command: params.command,
+      leaseId,
+      gatewayInstanceId: this.gatewayInstanceId,
+    });
     const launch: AcpxLaunchLeaseContext = {
-      leaseId: createAcpxProcessLeaseId(),
+      leaseId,
       gatewayInstanceId: this.gatewayInstanceId,
       sessionKey: params.sessionKey,
       wrapperRoot: this.wrapperRoot,
       stableCommand: params.command,
+      resolvedCommand: params.reusableCommand ?? leasedCommand,
+      leasedCommand,
     };
-    // The pending lease is written before acpx spawns. The session-store save
-    // path fills in the live PID after acpx connects and exposes the process.
+    // Reuse-only adoption cannot spawn: readReusablePersistentSessionCommand
+    // mirrors upstream's exact reuse policy. Persist the new command first and
+    // let the next reconnect create its matching pending lease.
+    const ownsPendingLease =
+      !reusableLease && (!params.reusableCommand || params.reusableCommand === leasedCommand);
+    if (ownsPendingLease) {
+      // The pending lease is written before acpx can spawn. The session-store
+      // save fills in the PID, or this owner deletes the row on launch failure.
+      await this.processLeaseStore.save({
+        leaseId: launch.leaseId,
+        gatewayInstanceId: launch.gatewayInstanceId,
+        sessionKey: launch.sessionKey,
+        wrapperRoot: launch.wrapperRoot,
+        wrapperPath: extractGeneratedWrapperPath(leasedCommand),
+        rootPid: 0,
+        commandHash: hashAcpxProcessCommand(leasedCommand),
+        startedAt: Date.now(),
+        state: "open",
+      });
+    }
+    try {
+      const result = await this.launchLeaseScope.run(launch, params.run);
+      const record = await this.sessionStore.load(params.sessionKey);
+      if (!readRecordAgentPid(record)) {
+        await this.processLeaseStore.markState(launch.leaseId, "lost");
+      }
+      return result;
+    } catch (error) {
+      if (ownsPendingLease) {
+        await this.retirePendingProcessLease(launch);
+      }
+      throw error;
+    }
+  }
+
+  private async prepareProcessLeaseForOperation(
+    handle: AcpRuntimeHandle,
+  ): Promise<OpenClawLeaseSessionMetadata | undefined> {
+    if (!this.processLeaseStore || !this.gatewayInstanceId || !this.wrapperRoot) {
+      return undefined;
+    }
+    const record = await this.sessionStore.load(handle.acpxRecordId ?? handle.sessionKey);
+    const command = readAgentCommandFromRecord(record);
+    const identity = readAcpxProcessLeaseIdentity(command);
+    if (
+      !command ||
+      identity?.gatewayInstanceId !== this.gatewayInstanceId ||
+      !isOpenClawLeaseAwareAcpxProcessCommand({
+        command,
+        wrapperRoot: this.wrapperRoot,
+      })
+    ) {
+      return undefined;
+    }
+    const existing = await this.processLeaseStore.load(identity.leaseId);
+    if (existing) {
+      if (
+        existing.gatewayInstanceId !== identity.gatewayInstanceId ||
+        existing.sessionKey !== handle.sessionKey ||
+        existing.wrapperRoot !== this.wrapperRoot
+      ) {
+        throw new AcpRuntimeError(
+          "ACP_TURN_FAILED",
+          `ACPX process lease ${identity.leaseId} belongs to another session`,
+        );
+      }
+      this.retainProcessLeaseOperation(identity);
+      return identity;
+    }
+    // Reconnect can spawn before upstream persists its replacement PID. A
+    // pending row makes startup cleanup scan the owned wrapper root if we exit.
     await this.processLeaseStore.save({
-      leaseId: launch.leaseId,
-      gatewayInstanceId: launch.gatewayInstanceId,
-      sessionKey: launch.sessionKey,
-      wrapperRoot: launch.wrapperRoot,
-      wrapperPath: extractGeneratedWrapperPath(params.command),
+      leaseId: identity.leaseId,
+      gatewayInstanceId: identity.gatewayInstanceId,
+      sessionKey: handle.sessionKey,
+      wrapperRoot: this.wrapperRoot,
+      wrapperPath: extractGeneratedWrapperPath(command),
       rootPid: 0,
-      commandHash: hashAcpxProcessCommand(params.command),
+      commandHash: hashAcpxProcessCommand(command),
       startedAt: Date.now(),
       state: "open",
     });
-    return await this.launchLeaseScope.run(launch, params.run);
+    this.retainProcessLeaseOperation(identity);
+    return identity;
+  }
+
+  private retainProcessLeaseOperation(identity: OpenClawLeaseSessionMetadata): void {
+    this.processLeaseOperationCounts.set(
+      identity.leaseId,
+      (this.processLeaseOperationCounts.get(identity.leaseId) ?? 0) + 1,
+    );
+  }
+
+  private releaseProcessLeaseOperation(
+    identity: OpenClawLeaseSessionMetadata | undefined,
+  ): boolean {
+    if (!identity) {
+      return false;
+    }
+    const count = this.processLeaseOperationCounts.get(identity.leaseId) ?? 0;
+    if (count > 1) {
+      this.processLeaseOperationCounts.set(identity.leaseId, count - 1);
+      return false;
+    }
+    this.processLeaseOperationCounts.delete(identity.leaseId);
+    return true;
+  }
+
+  private async finalizeProcessLeaseForOperation(
+    handle: AcpRuntimeHandle,
+    identity: OpenClawLeaseSessionMetadata | undefined,
+  ): Promise<void> {
+    if (!identity || !this.processLeaseStore || !this.releaseProcessLeaseOperation(identity)) {
+      return;
+    }
+    const lease = await this.processLeaseStore.load(identity.leaseId);
+    if (!lease || lease.gatewayInstanceId !== identity.gatewayInstanceId) {
+      return;
+    }
+    if (lease.rootPid <= 0) {
+      await this.processLeaseStore.markState(identity.leaseId, "lost");
+      return;
+    }
+    try {
+      const record = await this.sessionStore.load(handle.acpxRecordId ?? handle.sessionKey);
+      if (!readRecordAgentPid(record)) {
+        await this.processLeaseStore.markState(identity.leaseId, "lost");
+      }
+    } catch {
+      // Preserve a PID-bearing lease for startup verification when record reload
+      // fails; deleting it here could lose the only cleanup identity.
+    }
+  }
+
+  private async retirePendingProcessLease(
+    identity: OpenClawLeaseSessionMetadata | undefined,
+  ): Promise<void> {
+    if (!identity || !this.processLeaseStore || !this.releaseProcessLeaseOperation(identity)) {
+      return;
+    }
+    const lease = await this.processLeaseStore.load(identity.leaseId);
+    if (lease?.gatewayInstanceId === identity.gatewayInstanceId && lease.rootPid <= 0) {
+      await this.processLeaseStore.markState(identity.leaseId, "lost");
+    }
+  }
+
+  private async runWithProcessLeaseForHandle<T>(
+    handle: AcpRuntimeHandle,
+    run: () => Promise<T>,
+  ): Promise<T> {
+    const identity = await this.prepareProcessLeaseForOperation(handle);
+    try {
+      return await run();
+    } finally {
+      await this.finalizeProcessLeaseForOperation(handle, identity);
+    }
+  }
+
+  private async finalizeProcessLeaseAfter<T>(
+    handle: AcpRuntimeHandle,
+    identityPromise: Promise<OpenClawLeaseSessionMetadata | undefined>,
+    resultPromise: Promise<T>,
+  ): Promise<T> {
+    try {
+      return await resultPromise;
+    } finally {
+      await this.finalizeProcessLeaseForOperation(handle, await identityPromise);
+    }
+  }
+
+  private async runSerializedSessionEnsure<T>(
+    sessionKey: string,
+    run: () => Promise<T>,
+  ): Promise<T> {
+    const key = sessionKey.trim() || sessionKey;
+    const previous = this.ensureSessionTails.get(key) ?? Promise.resolve();
+    let release!: () => void;
+    const current = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const tail = previous.then(() => current);
+    this.ensureSessionTails.set(key, tail);
+    await previous;
+    try {
+      return await run();
+    } finally {
+      release();
+      if (this.ensureSessionTails.get(key) === tail) {
+        this.ensureSessionTails.delete(key);
+      }
+    }
   }
 
   private async withCodexWrapperDiagnostics<T>(params: {
@@ -1100,6 +1357,14 @@ export class AcpxRuntime implements AcpRuntime {
   async ensureSession(
     input: Parameters<AcpRuntime["ensureSession"]>[0],
   ): Promise<OpenClawRuntimeHandle> {
+    return await this.runSerializedSessionEnsure(input.sessionKey, () =>
+      this.ensureSessionUnlocked(input),
+    );
+  }
+
+  private async ensureSessionUnlocked(
+    input: Parameters<AcpRuntime["ensureSession"]>[0],
+  ): Promise<OpenClawRuntimeHandle> {
     assertSupportedRuntimeSessionMode(input.mode);
     const command = resolveAgentCommand({
       agentName: input.agent,
@@ -1141,19 +1406,19 @@ export class AcpxRuntime implements AcpRuntime {
       codexModelOverride && command
         ? appendCodexAcpConfigOverrides(command, codexModelOverride)
         : command;
-    const shouldStartWithLease = !(await this.canReuseStablePersistentSession({
+    const reusableCommand = await this.readReusablePersistentSessionCommand({
       sessionKey: input.sessionKey,
       mode: input.mode,
       cwd: input.cwd,
       command: stableLaunchCommand,
       resumeSessionId: input.resumeSessionId,
-    }));
+    });
 
     const handle = !codexModelOverride
       ? await this.runWithLaunchLease({
           sessionKey: ensureInput.sessionKey,
           command: stableLaunchCommand,
-          enabled: shouldStartWithLease,
+          reusableCommand,
           run: () =>
             this.withCodexWrapperDiagnostics({
               command: stableLaunchCommand,
@@ -1164,7 +1429,7 @@ export class AcpxRuntime implements AcpRuntime {
       : await this.runWithLaunchLease({
           sessionKey: input.sessionKey,
           command: stableLaunchCommand,
-          enabled: shouldStartWithLease,
+          reusableCommand,
           run: () =>
             this.codexAcpModelOverrideScope.run(codexModelOverride, () =>
               this.withCodexWrapperDiagnostics({
@@ -1178,9 +1443,11 @@ export class AcpxRuntime implements AcpRuntime {
   }
 
   async *runTurn(input: Parameters<AcpRuntime["runTurn"]>[0]): AsyncIterable<AcpRuntimeEvent> {
-    const command = await this.resolveCommandForHandle(input.handle);
-    const delegate = await this.resolveDelegateForHandle(input.handle);
+    const turnLease = await this.prepareProcessLeaseForOperation(input.handle);
+    let command: string | undefined;
     try {
+      command = await this.resolveCommandForHandle(input.handle);
+      const delegate = await this.resolveDelegateForHandle(input.handle);
       for await (const event of delegate.runTurn(withOpenClawManagedTurnTimeout(input))) {
         if (
           event.type !== "error" ||
@@ -1212,6 +1479,8 @@ export class AcpxRuntime implements AcpRuntime {
       throw new AcpRuntimeError("ACP_TURN_FAILED", `Internal error: ${stderrTail}`, {
         cause: error,
       });
+    } finally {
+      await this.finalizeProcessLeaseForOperation(input.handle, turnLease);
     }
   }
 
@@ -1220,10 +1489,12 @@ export class AcpxRuntime implements AcpRuntime {
       this.readCodexTurnFailureStderr({
         handle: input.handle,
       });
+    const turnLeasePromise = this.prepareProcessLeaseForOperation(input.handle);
     const turnPromise = Promise.all([
+      turnLeasePromise,
       this.resolveCommandForHandle(input.handle),
       this.resolveDelegateForHandle(input.handle),
-    ]).then(async ([command, delegate]) => {
+    ]).then(async ([, command, delegate]) => {
       try {
         return {
           command,
@@ -1283,41 +1554,45 @@ export class AcpxRuntime implements AcpRuntime {
           }
         },
       },
-      result: turnPromise.then(async ({ command, turn }): Promise<AcpRuntimeTurnResult> => {
-        try {
-          const result = await turn.result;
-          if (
-            result.status !== "failed" ||
-            !isCodexAcpCommand(command) ||
-            !isGenericInternalAcpErrorMessage(result.error.message)
-          ) {
-            return result;
+      result: this.finalizeProcessLeaseAfter(
+        input.handle,
+        turnLeasePromise,
+        turnPromise.then(async ({ command, turn }): Promise<AcpRuntimeTurnResult> => {
+          try {
+            const result = await turn.result;
+            if (
+              result.status !== "failed" ||
+              !isCodexAcpCommand(command) ||
+              !isGenericInternalAcpErrorMessage(result.error.message)
+            ) {
+              return result;
+            }
+            const stderrTail = await this.readCodexTurnFailureStderr({ handle: input.handle });
+            if (!stderrTail) {
+              return result;
+            }
+            return {
+              status: "failed",
+              error: {
+                ...result.error,
+                code: "ACP_TURN_FAILED",
+                message: `Internal error: ${stderrTail}`,
+              },
+            };
+          } catch (error) {
+            if (!isCodexAcpCommand(command) || !isGenericInternalAcpError(error)) {
+              throw error;
+            }
+            const stderrTail = await this.readCodexTurnFailureStderr({ handle: input.handle });
+            if (!stderrTail) {
+              throw error;
+            }
+            throw new AcpRuntimeError("ACP_TURN_FAILED", `Internal error: ${stderrTail}`, {
+              cause: error,
+            });
           }
-          const stderrTail = await this.readCodexTurnFailureStderr({ handle: input.handle });
-          if (!stderrTail) {
-            return result;
-          }
-          return {
-            status: "failed",
-            error: {
-              ...result.error,
-              code: "ACP_TURN_FAILED",
-              message: `Internal error: ${stderrTail}`,
-            },
-          };
-        } catch (error) {
-          if (!isCodexAcpCommand(command) || !isGenericInternalAcpError(error)) {
-            throw error;
-          }
-          const stderrTail = await this.readCodexTurnFailureStderr({ handle: input.handle });
-          if (!stderrTail) {
-            throw error;
-          }
-          throw new AcpRuntimeError("ACP_TURN_FAILED", `Internal error: ${stderrTail}`, {
-            cause: error,
-          });
-        }
-      }),
+        }),
+      ),
       cancel(inputArgs?: { reason?: string }) {
         return turnPromise.then(({ turn }) => turn.cancel(inputArgs));
       },
@@ -1342,10 +1617,18 @@ export class AcpxRuntime implements AcpRuntime {
 
   async setMode(input: Parameters<NonNullable<AcpRuntime["setMode"]>>[0]): Promise<void> {
     const delegate = await this.resolveDelegateForHandle(input.handle);
-    await delegate.setMode(input);
+    await this.runWithProcessLeaseForHandle(input.handle, () => delegate.setMode(input));
   }
 
   async setConfigOption(
+    input: Parameters<NonNullable<AcpRuntime["setConfigOption"]>>[0],
+  ): Promise<void> {
+    await this.runWithProcessLeaseForHandle(input.handle, () =>
+      this.setConfigOptionUnlocked(input),
+    );
+  }
+
+  private async setConfigOptionUnlocked(
     input: Parameters<NonNullable<AcpRuntime["setConfigOption"]>>[0],
   ): Promise<void> {
     const delegate = await this.resolveDelegateForHandle(input.handle);
@@ -1415,26 +1698,37 @@ export class AcpxRuntime implements AcpRuntime {
   }
 
   async close(input: Parameters<AcpRuntime["close"]>[0]): Promise<void> {
-    const record = await this.sessionStore.load(
-      input.handle.acpxRecordId ?? input.handle.sessionKey,
-    );
-    let closeSucceeded;
-    const delegate = this.resolveDelegateForLoadedRecord(input.handle, record);
+    const closeLease = await this.prepareProcessLeaseForOperation(input.handle);
+    let cleanupSucceeded = false;
     try {
-      await delegate.close({
-        handle: input.handle,
-        reason: input.reason,
-        discardPersistentState: input.discardPersistentState,
-      });
-      closeSucceeded = true;
+      const record = await this.sessionStore.load(
+        input.handle.acpxRecordId ?? input.handle.sessionKey,
+      );
+      let closeSucceeded;
+      const delegate = this.resolveDelegateForLoadedRecord(input.handle, record);
+      try {
+        await delegate.close({
+          handle: input.handle,
+          reason: input.reason,
+          discardPersistentState: input.discardPersistentState,
+        });
+        closeSucceeded = true;
+      } finally {
+        await this.cleanupProcessTreeForRecord(input.handle, record);
+        cleanupSucceeded = true;
+      }
+      if (closeSucceeded) {
+        this.releaseManagedToolsDelegateForSession(input.handle.sessionKey);
+      }
+      if (closeSucceeded && input.discardPersistentState) {
+        this.sessionStore.markFresh(input.handle.sessionKey);
+      }
     } finally {
-      await this.cleanupProcessTreeForRecord(input.handle, record);
-    }
-    if (closeSucceeded) {
-      this.releaseManagedToolsDelegateForSession(input.handle.sessionKey);
-    }
-    if (closeSucceeded && input.discardPersistentState) {
-      this.sessionStore.markFresh(input.handle.sessionKey);
+      if (cleanupSucceeded) {
+        await this.finalizeProcessLeaseForOperation(input.handle, closeLease);
+      } else {
+        await this.retirePendingProcessLease(closeLease);
+      }
     }
   }
 }

--- a/extensions/acpx/src/runtime.ts
+++ b/extensions/acpx/src/runtime.ts
@@ -1234,8 +1234,7 @@ export class AcpxRuntime implements AcpRuntime {
         const recordIdentity = readAcpxProcessLeaseIdentity(readAgentCommandFromRecord(record));
         if (
           recordIdentity?.leaseId !== identity.leaseId ||
-          recordIdentity.gatewayInstanceId !== identity.gatewayInstanceId ||
-          readRecordAgentPid(record) !== lease.rootPid
+          recordIdentity.gatewayInstanceId !== identity.gatewayInstanceId
         ) {
           await processLeaseStore.markState(identity.leaseId, "lost");
         }
@@ -1379,9 +1378,11 @@ export class AcpxRuntime implements AcpRuntime {
       });
       await this.processLeaseStore?.markState(
         lease.leaseId,
-        result.terminatedPids.length > 0 || result.skippedReason === "missing-root"
-          ? "closed"
-          : "lost",
+        result.skippedReason === "process-list-unavailable"
+          ? "open"
+          : result.terminatedPids.length > 0 || result.skippedReason === "missing-root"
+            ? "closed"
+            : "lost",
       );
       return;
     }

--- a/extensions/acpx/src/service.test.ts
+++ b/extensions/acpx/src/service.test.ts
@@ -421,6 +421,46 @@ describe("createAcpxRuntimeService", () => {
     await service.stop?.(ctx);
   });
 
+  it("keeps PID-bearing leases when startup process listing is unavailable", async () => {
+    const workspaceDir = await makeTempDir();
+    const ctx = createServiceContext(workspaceDir);
+    const runtime = createMockRuntime();
+    const wrapperRoot = path.join(ctx.stateDir, "acpx");
+    await openGatewayInstanceStore(ctx).register(ACPX_GATEWAY_INSTANCE_KEY, {
+      instanceId: "gw-test",
+      createdAt: 1,
+    });
+    const lease: AcpxProcessLease = {
+      leaseId: "lease-process-list-unavailable",
+      gatewayInstanceId: "gw-test",
+      sessionKey: "agent:codex:acp:test",
+      wrapperRoot,
+      wrapperPath: path.join(wrapperRoot, "codex-acp-wrapper.mjs"),
+      rootPid: 101,
+      commandHash: "hash",
+      startedAt: 1,
+      state: "open",
+    };
+    await openProcessLeaseStore(ctx).register(lease.leaseId, lease);
+    cleanupOpenClawOwnedAcpxProcessTreeMock.mockResolvedValueOnce({
+      inspectedPids: [],
+      terminatedPids: [],
+      skippedReason: "process-list-unavailable",
+    });
+    const service = createAcpxRuntimeService(ctx, {
+      runtimeFactory: () => runtime as never,
+    });
+
+    await service.start(ctx);
+
+    await expect(openProcessLeaseStore(ctx).lookup(lease.leaseId)).resolves.toMatchObject({
+      leaseId: lease.leaseId,
+      rootPid: 101,
+      state: "open",
+    });
+    await service.stop?.(ctx);
+  });
+
   it("runs wrapper-root orphan cleanup before dropping pending ACPX leases", async () => {
     const workspaceDir = await makeTempDir();
     const ctx = createServiceContext(workspaceDir);

--- a/extensions/acpx/src/service.ts
+++ b/extensions/acpx/src/service.ts
@@ -312,7 +312,11 @@ async function reapOpenAcpxProcessLeases(params: {
     terminatedPids.push(...result.terminatedPids);
     await params.leaseStore.markState(
       lease.leaseId,
-      result.terminatedPids.length > 0 ? "closed" : "lost",
+      result.skippedReason === "process-list-unavailable"
+        ? "open"
+        : result.terminatedPids.length > 0
+          ? "closed"
+          : "lost",
     );
   }
   return { inspectedPids, terminatedPids };


### PR DESCRIPTION
## What Problem This Solves

Persistent ACPX sessions could reconnect with the stable wrapper command after OpenClaw had stripped its lease arguments from the persisted `agentCommand`. The replacement wrapper then ran outside the original lease identity, leaving stale ownership behind and making later cleanup unable to verify the current process.

Fixes #115177.

## Why This Change Was Made

Current main already deletes terminal `closed` and `lost` lease rows, so adding a periodic reaper would treat the symptom and introduce recurring process-table work. This change instead keeps one OpenClaw-owned lease identity with the persistent session, updates its PID when ACPX saves a replacement process, serializes overlapping ownership transitions, and retires abandoned leases at existing lifecycle boundaries.

The ownership checks continue to reject foreign gateway/session identities and preserve PID-reuse safety. Direct plugin-local ACP adapter commands remain outside lease injection.

## User Impact

Persistent ACPX sessions can reconnect without losing process ownership, reducing stale wrapper processes and lease state after crashes, timeouts, or reconnects without adding background polling.

Thanks @shakkernerd.

## Evidence

- Focused ACPX process-lease, runtime, and service tests passed in Blacksmith Testbox.
- `pnpm check:changed` passed on the exact pushed head.
- Exact-head autoreview completed without a remaining blocker.
- Coverage includes initial launch, reconnect/PID replacement, concurrent operations, failed launch, terminal cleanup, foreign ownership, stale identity, and unaffected direct-command behavior.
- `git diff --check` and the branch worktree are clean.
