### PR TITLE
fix: prevent node gateway hangs and runaway local inference

### DIFF
--- a/extensions/browser/chrome-extension/modules/copilot-gateway.js
+++ b/extensions/browser/chrome-extension/modules/copilot-gateway.js
@@ -19,6 +19,8 @@ const CLIENT_ID = GATEWAY_CLIENT_IDS.BROWSER_COPILOT;
 const CLIENT_MODE = GATEWAY_CLIENT_MODES.UI;
 const ROLE = "operator";
 const SCOPES = ["operator.read", "operator.write"];
+// Keep browser opening bounded by the Gateway's default preauth deadline.
+const COPILOT_GATEWAY_OPENING_TIMEOUT_MS = 15_000;
 export function isDefinitiveGatewayRejection(error) {
   return error instanceof GatewayProtocolRequestError;
 }
@@ -57,14 +59,56 @@ export async function waitForCopilotGatewayReady(client, gatewayScope) {
 
 function createBrowserSocket(url, handlers, WebSocketImpl) {
   const socket = new WebSocketImpl(url);
-  socket.addEventListener("open", handlers.open);
+  let opening = true;
+  let openingTimedOut = false;
+  let openingTimer;
+  const finishOpening = () => {
+    opening = false;
+    if (openingTimer !== undefined) {
+      clearTimeout(openingTimer);
+      openingTimer = undefined;
+    }
+  };
+  socket.addEventListener("open", () => {
+    finishOpening();
+    handlers.open();
+  });
   socket.addEventListener("message", (event) => handlers.message(String(event.data)));
-  socket.addEventListener("close", (event) => handlers.close(event.code, event.reason));
-  socket.addEventListener("error", () => handlers.error(new Error("Gateway WebSocket error")));
+  socket.addEventListener("close", (event) => {
+    finishOpening();
+    handlers.close(event.code, event.reason ?? "");
+  });
+  socket.addEventListener("error", () => {
+    finishOpening();
+    if (!openingTimedOut) {
+      handlers.error(new Error("Gateway WebSocket error"));
+    }
+  });
+  openingTimer = setTimeout(() => {
+    openingTimer = undefined;
+    if (!opening) {
+      return;
+    }
+    opening = false;
+    openingTimedOut = true;
+    try {
+      handlers.error(
+        new Error(
+          `Gateway WebSocket opening timed out after ${COPILOT_GATEWAY_OPENING_TIMEOUT_MS}ms`,
+        ),
+      );
+    } finally {
+      socket.close();
+    }
+  }, COPILOT_GATEWAY_OPENING_TIMEOUT_MS);
   return {
     isOpen: () => socket.readyState === WebSocketImpl.OPEN,
     send: (data) => socket.send(data),
-    close: (code, reason) => socket.close(code, reason),
+    close: (code, reason) => {
+      finishOpening();
+      // Browsers reject client-initiated policy close 1008; 4008 is wire-safe.
+      socket.close(code === 1008 ? 4008 : code, reason);
+    },
   };
 }
 

--- a/extensions/browser/chrome-extension/modules/copilot-gateway.test.ts
+++ b/extensions/browser/chrome-extension/modules/copilot-gateway.test.ts
@@ -54,14 +54,19 @@ function controllableStorageArea() {
 class FakeWebSocket {
   static OPEN = 1;
   static instances: FakeWebSocket[] = [];
+  static autoOpen = true;
 
   readyState = 0;
   sent: Array<Record<string, unknown>> = [];
+  closeCalls: Array<{ code: number; reason: string }> = [];
   private listeners = new Map<string, Set<(event: Record<string, unknown>) => void>>();
 
   constructor() {
     FakeWebSocket.instances.push(this);
     queueMicrotask(() => {
+      if (!FakeWebSocket.autoOpen || this.readyState === 3) {
+        return;
+      }
       this.readyState = FakeWebSocket.OPEN;
       this.emit("open", {});
     });
@@ -78,9 +83,13 @@ class FakeWebSocket {
   }
 
   close(code = 1000, reason = "") {
+    if (code !== 1000 && (code < 3000 || code > 4999)) {
+      throw new DOMException("Invalid WebSocket close code", "InvalidAccessError");
+    }
     if (this.readyState === 3) {
       return;
     }
+    this.closeCalls.push({ code, reason });
     this.readyState = 3;
     queueMicrotask(() => this.emit("close", { code, reason }));
   }
@@ -303,6 +312,78 @@ describe("browser copilot Gateway custody", () => {
     } finally {
       releaseClear?.();
       client.stop();
+      vi.unstubAllGlobals();
+    }
+  });
+
+  it("reconnects after a malformed challenge with a browser-valid policy close", async () => {
+    vi.useFakeTimers();
+    FakeWebSocket.instances = [];
+    FakeWebSocket.autoOpen = true;
+    vi.stubGlobal("chrome", { runtime: { getManifest: () => ({ version: "test" }) } });
+    vi.stubGlobal("navigator", { language: "en", userAgent: "copilot-test" });
+    const client = new CopilotGatewayClient({
+      storage: storageArea(),
+      WebSocketImpl: FakeWebSocket as never,
+    });
+
+    try {
+      client.start("ws://127.0.0.1:28789/");
+      await vi.advanceTimersByTimeAsync(0);
+      const first = FakeWebSocket.instances[0];
+      expect(first).toBeDefined();
+
+      first?.message({ type: "event", event: "connect.challenge", payload: {} });
+      await vi.advanceTimersByTimeAsync(0);
+
+      expect(first?.closeCalls).toContainEqual({
+        code: 4008,
+        reason: "connect challenge missing nonce",
+      });
+
+      await vi.advanceTimersByTimeAsync(1_000);
+      expect(FakeWebSocket.instances).toHaveLength(2);
+    } finally {
+      client.stop();
+      FakeWebSocket.autoOpen = true;
+      vi.useRealTimers();
+      vi.unstubAllGlobals();
+    }
+  });
+
+  it("closes and reconnects when the browser socket never opens", async () => {
+    vi.useFakeTimers();
+    FakeWebSocket.instances = [];
+    FakeWebSocket.autoOpen = false;
+    vi.stubGlobal("chrome", { runtime: { getManifest: () => ({ version: "test" }) } });
+    vi.stubGlobal("navigator", { language: "en", userAgent: "copilot-test" });
+    const client = new CopilotGatewayClient({
+      storage: storageArea(),
+      WebSocketImpl: FakeWebSocket as never,
+    });
+    const statuses: Array<Record<string, unknown>> = [];
+    client.onStatus((status) => {
+      statuses.push(status);
+    });
+
+    try {
+      client.start("ws://127.0.0.1:28789/");
+      await vi.advanceTimersByTimeAsync(15_000);
+
+      expect(statuses).toContainEqual(
+        expect.objectContaining({
+          state: "error",
+          label: "Gateway WebSocket opening timed out after 15000ms",
+        }),
+      );
+      expect(FakeWebSocket.instances[0]?.closeCalls).toEqual([{ code: 1000, reason: "" }]);
+
+      await vi.advanceTimersByTimeAsync(1_000);
+      expect(FakeWebSocket.instances).toHaveLength(2);
+    } finally {
+      client.stop();
+      FakeWebSocket.autoOpen = true;
+      vi.useRealTimers();
       vi.unstubAllGlobals();
     }
   });

--- a/src/cli/nodes-cli.coverage.test.ts
+++ b/src/cli/nodes-cli.coverage.test.ts
@@ -271,6 +271,60 @@ describe("nodes-cli coverage", () => {
   });
 
   it.each([
+    ["--priority", "urgent"],
+    ["--priority", "timesensitive"],
+    ["--delivery", "desktop"],
+  ])("rejects unsupported %s %s before calling the gateway", async (flag, value) => {
+    await withSuppressedStderr(async () => {
+      await expect(
+        sharedProgram.parseAsync(
+          ["nodes", "notify", "--node", "mac-1", "--title", "Ping", flag, value],
+          { from: "user" },
+        ),
+      ).rejects.toMatchObject({ code: "commander.invalidArgument" });
+    });
+
+    expect(callGateway).not.toHaveBeenCalled();
+    expect(lastNodeInvokeCall).toBeNull();
+  });
+
+  it.each(["passive", "active", "timeSensitive"])(
+    "forwards the supported %s notification priority",
+    async (priority) => {
+      const invoke = await runNodesCommand([
+        "nodes",
+        "notify",
+        "--node",
+        "mac-1",
+        "--title",
+        "Ping",
+        "--priority",
+        priority,
+      ]);
+
+      expect(invoke.params?.params).toMatchObject({ priority, delivery: "system" });
+    },
+  );
+
+  it.each(["system", "overlay", "auto"])(
+    "forwards the supported %s notification delivery mode",
+    async (delivery) => {
+      const invoke = await runNodesCommand([
+        "nodes",
+        "notify",
+        "--node",
+        "mac-1",
+        "--title",
+        "Ping",
+        "--delivery",
+        delivery,
+      ]);
+
+      expect(invoke.params?.params).toMatchObject({ delivery });
+    },
+  );
+
+  it.each([
     {
       label: "a custom node invoke timeout",
       args: [

--- a/src/cli/nodes-cli/register.camera.ts
+++ b/src/cli/nodes-cli/register.camera.ts
@@ -73,7 +73,12 @@ export function registerNodesCameraCommands(nodes: Command) {
             typeof res.payload === "object" && res.payload !== null
               ? (res.payload as { devices?: unknown })
               : {};
-          const devices = Array.isArray(payload.devices) ? payload.devices : [];
+          const devices = Array.isArray(payload.devices)
+            ? payload.devices.filter(
+                (device): device is Record<string, unknown> =>
+                  typeof device === "object" && device !== null && !Array.isArray(device),
+              )
+            : [];
 
           if (opts.json) {
             defaultRuntime.writeJson(devices);

--- a/src/cli/nodes-cli/register.notify.ts
+++ b/src/cli/nodes-cli/register.notify.ts
@@ -1,6 +1,6 @@
 // Local notification command for paired nodes.
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
-import type { Command } from "commander";
+import { type Command, Option } from "commander";
 import { randomIdempotencyKey } from "../../gateway/call.js";
 import { defaultRuntime } from "../../runtime.js";
 import { getNodesTheme, runNodesCommand } from "./cli-utils.js";
@@ -22,8 +22,18 @@ export function registerNodesNotifyCommand(nodes: Command) {
       .option("--title <text>", "Notification title")
       .option("--body <text>", "Notification body")
       .option("--sound <name>", "Notification sound")
-      .option("--priority <passive|active|timeSensitive>", "Notification priority")
-      .option("--delivery <system|overlay|auto>", "Delivery mode", "system")
+      .addOption(
+        new Option("--priority <passive|active|timeSensitive>", "Notification priority").choices([
+          "passive",
+          "active",
+          "timeSensitive",
+        ]),
+      )
+      .addOption(
+        new Option("--delivery <system|overlay|auto>", "Delivery mode")
+          .choices(["system", "overlay", "auto"])
+          .default("system"),
+      )
       .option("--invoke-timeout <ms>", "Node invoke timeout in ms (default 15000)", "15000")
       .action(async (opts: NodesRpcOpts) => {
         await runNodesCommand("notify", async () => {

--- a/src/cli/program.nodes-media.e2e.test.ts
+++ b/src/cli/program.nodes-media.e2e.test.ts
@@ -127,6 +127,33 @@ describe("cli program (nodes media)", () => {
     vi.clearAllMocks();
   });
 
+  it("keeps valid cameras when a node also reports malformed device records", async () => {
+    const camera = { id: "front", name: "Front Camera", position: "front" };
+    mockNodeGateway("camera.list", { devices: [null, 7, "invalid", [], camera] });
+
+    await runNodesCommand(["nodes", "camera", "list", "--node", "ios-node"]);
+
+    expect(runtime.log.mock.calls.flat().join("\n")).toContain("Front Camera");
+    expect(runtime.error).not.toHaveBeenCalled();
+  });
+
+  it("omits malformed camera device records from JSON output", async () => {
+    const camera = { id: "front", name: "Front Camera", position: "front" };
+    mockNodeGateway("camera.list", { devices: [null, 7, "invalid", [], camera] });
+
+    await runNodesCommand(["nodes", "camera", "list", "--node", "ios-node", "--json"]);
+
+    expect(runtime.writeJson).toHaveBeenCalledWith([camera]);
+  });
+
+  it("reports no cameras when every returned device record is malformed", async () => {
+    mockNodeGateway("camera.list", { devices: [null, 7, "invalid", []] });
+
+    await runNodesCommand(["nodes", "camera", "list", "--node", "ios-node"]);
+
+    expect(runtime.log).toHaveBeenCalledWith(expect.stringContaining("No cameras reported."));
+  });
+
   it("runs nodes camera snap and prints two MEDIA paths", async () => {
     mockNodeGateway("camera.snap", { format: "jpg", base64: "aGk=", width: 1, height: 1 });
 

--- a/src/gateway/node-invoke-plugin-policy.test.ts
+++ b/src/gateway/node-invoke-plugin-policy.test.ts
@@ -275,6 +275,88 @@ describe("applyPluginNodeInvokePolicy", () => {
     });
   });
 
+  it.each([5_000, 0])(
+    "bounds plugin timeout override %i by the remaining invocation deadline",
+    async (overrideTimeoutMs) => {
+      setDangerousDemoCommandRegistry([
+        createDemoPolicy((ctx: OpenClawPluginNodeInvokePolicyContext) =>
+          ctx.invokeNode({ timeoutMs: overrideTimeoutMs }),
+        ),
+      ]);
+      const { context, invoke } = createContext();
+      const controller = new AbortController();
+
+      const result = await applyPluginNodeInvokePolicy({
+        context,
+        client: null,
+        nodeSession: createNodeSession(),
+        command: DEMO_COMMAND,
+        params: DEMO_PARAMS,
+        timeoutMs: 1_000,
+        signal: controller.signal,
+        resolveRemainingTimeoutMs: () => 250,
+      });
+
+      expect(result).toMatchObject({ ok: true });
+      expect(invoke).toHaveBeenCalledWith(
+        expect.objectContaining({ timeoutMs: 250, signal: controller.signal }),
+      );
+    },
+  );
+
+  it("marks plugin-owned work dispatched before calling the node transport", async () => {
+    setDangerousDemoCommandRegistry([
+      createDemoPolicy((ctx: OpenClawPluginNodeInvokePolicyContext) => ctx.invokeNode()),
+    ]);
+    const { context, invoke } = createContext();
+    const dispatchOrder: string[] = [];
+    invoke.mockImplementationOnce(async () => {
+      dispatchOrder.push("node transport");
+      return {
+        ok: true,
+        payload: { ok: true, value: 1 },
+        payloadJSON: null,
+        error: null,
+      };
+    });
+
+    const result = await applyPluginNodeInvokePolicy({
+      context,
+      client: null,
+      nodeSession: createNodeSession(),
+      command: DEMO_COMMAND,
+      params: DEMO_PARAMS,
+      onNodeCommandDispatched: () => dispatchOrder.push("dispatched"),
+    });
+
+    expect(result).toMatchObject({ ok: true });
+    expect(dispatchOrder).toStrictEqual(["dispatched", "node transport"]);
+  });
+
+  it("rejects expired plugin-owned work without dispatching it", async () => {
+    setDangerousDemoCommandRegistry([
+      createDemoPolicy((ctx: OpenClawPluginNodeInvokePolicyContext) => ctx.invokeNode()),
+    ]);
+    const { context, invoke } = createContext();
+
+    const result = await applyPluginNodeInvokePolicy({
+      context,
+      client: null,
+      nodeSession: createNodeSession(),
+      command: DEMO_COMMAND,
+      params: DEMO_PARAMS,
+      timeoutMs: 1_000,
+      resolveRemainingTimeoutMs: () => 0,
+    });
+
+    expect(result).toMatchObject({
+      ok: false,
+      code: "TIMEOUT",
+      details: { nodeCommandDispatched: false },
+    });
+    expect(invoke).not.toHaveBeenCalled();
+  });
+
   it("rechecks command authorization immediately before plugin transport dispatch", async () => {
     let allowCommand = true;
     setDangerousDemoCommandRegistry([

--- a/src/gateway/node-invoke-plugin-policy.ts
+++ b/src/gateway/node-invoke-plugin-policy.ts
@@ -189,6 +189,9 @@ export async function applyPluginNodeInvokePolicy(params: {
     threadId?: unknown;
   };
   timeoutMs?: number;
+  signal?: AbortSignal;
+  resolveRemainingTimeoutMs?: () => number | undefined;
+  onNodeCommandDispatched?: () => void;
   idempotencyKey?: string;
   isInvocationCurrent?: () => boolean | Promise<boolean>;
 }): Promise<OpenClawPluginNodeInvokePolicyResult | null> {
@@ -264,9 +267,25 @@ export async function applyPluginNodeInvokePolicy(params: {
         details: { command: params.command, reason: allowed.reason },
       };
     }
+    const remainingTimeoutMs = params.resolveRemainingTimeoutMs?.();
+    if (remainingTimeoutMs === 0 && params.timeoutMs !== 0) {
+      return {
+        ok: false,
+        code: "TIMEOUT",
+        message: "node invoke timed out",
+      };
+    }
+    const requestedTimeoutMs = override.timeoutMs ?? params.timeoutMs;
+    const timeoutMs =
+      typeof remainingTimeoutMs === "number" && remainingTimeoutMs > 0
+        ? typeof requestedTimeoutMs === "number" && requestedTimeoutMs > 0
+          ? Math.min(requestedTimeoutMs, remainingTimeoutMs)
+          : remainingTimeoutMs
+        : requestedTimeoutMs;
     // Once the registry owns the request, any failure is ambiguous to callers:
     // the node may have acted before the response was lost or rejected.
     nodeCommandDispatched = true;
+    params.onNodeCommandDispatched?.();
     const res = await params.context.nodeRegistry.invoke({
       nodeId: params.nodeSession.nodeId,
       expectedConnId: params.nodeSession.connId,
@@ -275,7 +294,8 @@ export async function applyPluginNodeInvokePolicy(params: {
         : {}),
       command: params.command,
       params: override.params ?? params.params,
-      timeoutMs: override.timeoutMs ?? params.timeoutMs,
+      timeoutMs,
+      ...(params.signal ? { signal: params.signal } : {}),
       idempotencyKey: override.idempotencyKey ?? params.idempotencyKey,
     });
     if (!res.ok) {

--- a/src/gateway/node-registry.invoke-stream.ts
+++ b/src/gateway/node-registry.invoke-stream.ts
@@ -249,12 +249,6 @@ export class NodeInvokeStreamController {
   }
 
   private sendInvokeCancel(requestId: string, pending: PendingInvoke): void {
-    // Cancel frames belong to the streaming-invoke contract only. Legacy
-    // single-result invokes must keep their pre-streaming wire behavior
-    // byte-identical, so timeouts there stay silent as before.
-    if (!pending.onProgress) {
-      return;
-    }
     this.options.sendCancel(requestId, pending);
   }
 }

--- a/src/gateway/node-registry.test.ts
+++ b/src/gateway/node-registry.test.ts
@@ -7,6 +7,7 @@ import {
   MAX_TIMER_TIMEOUT_MS,
 } from "@openclaw/normalization-core/number-coercion";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { GATEWAY_CLIENT_IDS } from "../../packages/gateway-protocol/src/client-info.js";
 import { getCurrentActiveNodeContext, setActiveNodeContext } from "../infra/active-node-context.js";
 import { onDiagnosticEvent, resetDiagnosticEventsForTest } from "../infra/diagnostic-events.js";
 import { createEmptyPluginRegistry } from "../plugins/registry-empty.js";
@@ -1388,6 +1389,79 @@ describe("gateway/node-registry", () => {
         chunk: "late",
       }),
     ).toBe(false);
+  });
+
+  it.each(["mcp.tools.call.v1", "system.run"])(
+    "forwards cancellation of first-party non-streaming %s calls",
+    async (command) => {
+      const registry = createNodeRegistry();
+      const frames = registerNode(registry, { clientId: GATEWAY_CLIENT_IDS.NODE_HOST });
+      const controller = new AbortController();
+      const invoke = registry.invoke({
+        nodeId: "node-1",
+        command,
+        timeoutMs: 1_000,
+        signal: controller.signal,
+      });
+      const request = JSON.parse(frames[0] ?? "{}") as { payload?: { id?: string } };
+
+      controller.abort();
+
+      await expect(invoke).resolves.toMatchObject({
+        ok: false,
+        error: { code: "ABORTED" },
+      });
+      expect(JSON.parse(frames[1] ?? "{}")).toMatchObject({
+        event: "node.invoke.cancel",
+        payload: { invokeId: request.payload?.id, nodeId: "node-1" },
+      });
+    },
+  );
+
+  it.each(["mcp.tools.call.v1", "system.run"])(
+    "forwards timeouts of first-party non-streaming %s calls",
+    async (command) => {
+      vi.useFakeTimers();
+      try {
+        const registry = createNodeRegistry();
+        const frames = registerNode(registry, { clientId: GATEWAY_CLIENT_IDS.NODE_HOST });
+        const invoke = registry.invoke({ nodeId: "node-1", command, timeoutMs: 100 });
+        const request = JSON.parse(frames[0] ?? "{}") as { payload?: { id?: string } };
+
+        await vi.advanceTimersByTimeAsync(100);
+
+        await expect(invoke).resolves.toMatchObject({
+          ok: false,
+          error: { code: "TIMEOUT" },
+        });
+        expect(JSON.parse(frames[1] ?? "{}")).toMatchObject({
+          event: "node.invoke.cancel",
+          payload: { invokeId: request.payload?.id, nodeId: "node-1" },
+        });
+      } finally {
+        vi.useRealTimers();
+      }
+    },
+  );
+
+  it("preserves legacy non-streaming node cancellation behavior", async () => {
+    const registry = createNodeRegistry();
+    const frames = registerNode(registry);
+    const controller = new AbortController();
+    const invoke = registry.invoke({
+      nodeId: "node-1",
+      command: "system.run",
+      timeoutMs: 1_000,
+      signal: controller.signal,
+    });
+
+    controller.abort();
+
+    await expect(invoke).resolves.toMatchObject({
+      ok: false,
+      error: { code: "ABORTED" },
+    });
+    expect(frames).toHaveLength(1);
   });
 
   it("cancels the node when a streamed progress consumer fails", async () => {

--- a/src/gateway/node-registry.ts
+++ b/src/gateway/node-registry.ts
@@ -7,6 +7,7 @@ import {
   resolveExpiresAtMsFromDurationMs,
   resolveTimerTimeoutMs,
 } from "@openclaw/normalization-core/number-coercion";
+import { GATEWAY_CLIENT_IDS } from "../../packages/gateway-protocol/src/client-info.js";
 // NodeSession is plugin-SDK-reachable; importing these types from the
 // gateway-protocol index would retain the whole ProtocolSchemas registry in
 // the public plugin-sdk dts (check-plugin-sdk-exports guards this).
@@ -257,7 +258,13 @@ export class NodeRegistry {
     pendingInvokes: this.pendingInvokes,
     sendCancel: (requestId, pending) => {
       const node = this.nodesById.get(pending.nodeId);
-      if (!node || node.connId !== pending.connId) {
+      // Older nodes only negotiated streamed cancellation. The authenticated
+      // first-party host also aborts ordinary shell, MCP, and inference calls.
+      if (
+        !node ||
+        node.connId !== pending.connId ||
+        (!pending.onProgress && node.clientId !== GATEWAY_CLIENT_IDS.NODE_HOST)
+      ) {
         return;
       }
       this.sendEventToSession(node, "node.invoke.cancel", {

--- a/src/gateway/server-methods/nodes.invoke-deadline.ts
+++ b/src/gateway/server-methods/nodes.invoke-deadline.ts
@@ -1,0 +1,44 @@
+import { MAX_TIMER_TIMEOUT_MS } from "@openclaw/normalization-core/number-coercion";
+
+export const NODE_INVOKE_DEADLINE_EXPIRED = Symbol("node invoke deadline expired");
+
+/** Bounds node pairing, wake, policy, and transport preparation by one absolute deadline. */
+export async function awaitNodeInvokeWithinDeadline<T>(
+  operation: () => Promise<T>,
+  deadlineAtMs: number | undefined,
+): Promise<T | typeof NODE_INVOKE_DEADLINE_EXPIRED> {
+  if (deadlineAtMs === undefined) {
+    return await operation();
+  }
+  if (Math.max(0, deadlineAtMs - Date.now()) === 0) {
+    return NODE_INVOKE_DEADLINE_EXPIRED;
+  }
+
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    // Arm the timer before plugin or push code can synchronously consume the
+    // budget; timer callbacks alone cannot establish an absolute deadline.
+    const deadline = new Promise<typeof NODE_INVOKE_DEADLINE_EXPIRED>((resolve) => {
+      // Node overflows long timer delays, so rearm against the real deadline.
+      const waitForDeadline = () => {
+        const remainingMs = Math.max(0, deadlineAtMs - Date.now());
+        if (remainingMs === 0) {
+          resolve(NODE_INVOKE_DEADLINE_EXPIRED);
+          return;
+        }
+        timer = setTimeout(waitForDeadline, Math.min(remainingMs, MAX_TIMER_TIMEOUT_MS));
+      };
+      waitForDeadline();
+    });
+    return await Promise.race([
+      deadline,
+      operation().then((result) =>
+        Date.now() >= deadlineAtMs ? NODE_INVOKE_DEADLINE_EXPIRED : result,
+      ),
+    ]);
+  } finally {
+    if (timer !== undefined) {
+      clearTimeout(timer);
+    }
+  }
+}

--- a/src/gateway/server-methods/nodes.invoke-foreground.ts
+++ b/src/gateway/server-methods/nodes.invoke-foreground.ts
@@ -1,0 +1,32 @@
+import {
+  normalizeLowercaseStringOrEmpty,
+  normalizeOptionalString,
+} from "@openclaw/normalization-core/string-coerce";
+import { isForegroundRestrictedPluginNodeCommand } from "../node-command-policy.js";
+
+/** Queues only commands that iOS explicitly rejected as requiring the foreground. */
+export function shouldQueueAsPendingForegroundAction(params: {
+  platform?: string;
+  command: string;
+  error: unknown;
+}): boolean {
+  const platform = normalizeLowercaseStringOrEmpty(params.platform);
+  if (!platform.startsWith("ios") && !platform.startsWith("ipados")) {
+    return false;
+  }
+  if (
+    !isForegroundRestrictedPluginNodeCommand(params.command) &&
+    !params.command.startsWith("camera.") &&
+    !params.command.startsWith("screen.") &&
+    !params.command.startsWith("talk.")
+  ) {
+    return false;
+  }
+  const error =
+    params.error && typeof params.error === "object"
+      ? (params.error as { code?: unknown; message?: unknown })
+      : null;
+  const code = normalizeOptionalString(error?.code)?.toUpperCase() ?? "";
+  const message = normalizeOptionalString(error?.message)?.toUpperCase() ?? "";
+  return code === "NODE_BACKGROUND_UNAVAILABLE" || message.includes("BACKGROUND_UNAVAILABLE");
+}

--- a/src/gateway/server-methods/nodes.invoke-wake.test.ts
+++ b/src/gateway/server-methods/nodes.invoke-wake.test.ts
@@ -5,6 +5,7 @@ import { expectDefined } from "@openclaw/normalization-core";
 import { MAX_TIMER_TIMEOUT_MS } from "@openclaw/normalization-core/number-coercion";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { ErrorCodes } from "../../../packages/gateway-protocol/src/index.js";
+import * as nodeInvokePluginPolicy from "../node-invoke-plugin-policy.js";
 import {
   captureNodeWakeLifecycle,
   clearNodeWakeState,
@@ -355,6 +356,7 @@ async function invokeNode(params: {
       command: string;
       params?: unknown;
       timeoutMs?: number;
+      signal?: AbortSignal;
       idempotencyKey?: string;
       expectedPairingGeneration?: string;
     }) => Promise<{
@@ -1156,10 +1158,293 @@ describe("node.invoke APNs wake path", () => {
     expectRecordFields(mockArg(nodeRegistry.invoke, 0, 0), "node invoke payload", {
       nodeId: "ios-node-reconnect",
       command: "camera.capture",
+      timeoutMs: 4_700,
     });
     const call = firstRespondCall(respond);
     expect(call[0]).toBe(true);
     expectRecordFields(call[1], "respond payload", { ok: true, nodeId: "ios-node-reconnect" });
+  });
+
+  it("stops waking an offline node when the invoke deadline expires", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
+    const nodeId = "ios-node-short-invoke-deadline";
+    mockDirectWakeConfig(nodeId);
+    const nodeRegistry = createMissingNodeRegistry();
+
+    const pending = invokeNode({
+      nodeRegistry,
+      requestParams: { nodeId, idempotencyKey: "idem-short-invoke-deadline", timeoutMs: 100 },
+    });
+
+    await vi.advanceTimersByTimeAsync(100);
+
+    expect(firstRespondCall(await pending)).toMatchObject([
+      false,
+      undefined,
+      {
+        message: "TIMEOUT: node invoke timed out",
+        details: { nodeError: { code: "TIMEOUT" } },
+      },
+    ]);
+    expect(mocks.sendApnsBackgroundWake).toHaveBeenCalledTimes(1);
+    expect(mocks.sendApnsAlert).not.toHaveBeenCalled();
+    expect(nodeRegistry.invoke).not.toHaveBeenCalled();
+  });
+
+  it("times out when initial node pairing capture remains in flight", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
+    mocks.captureNodePairingGeneration.mockImplementation(() => new Promise<never>(() => {}));
+    const nodeRegistry = createMissingNodeRegistry();
+
+    const pending = invokeNode({
+      nodeRegistry,
+      requestParams: {
+        nodeId: "ios-node-stalled-pairing-capture",
+        idempotencyKey: "idem-stalled-pairing-capture",
+        timeoutMs: 100,
+      },
+    });
+
+    await vi.advanceTimersByTimeAsync(100);
+
+    expect(firstRespondCall(await pending)).toMatchObject([
+      false,
+      undefined,
+      {
+        message: "TIMEOUT: node invoke timed out",
+        details: { nodeError: { code: "TIMEOUT" } },
+      },
+    ]);
+    expect(nodeRegistry.invoke).not.toHaveBeenCalled();
+    expect(mocks.sendApnsBackgroundWake).not.toHaveBeenCalled();
+  });
+
+  it("times out when a node pairing recheck remains in flight", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
+    const nodeId = "ios-node-stalled-pairing-recheck";
+    mocks.isNodePairingGenerationCurrent.mockImplementation(() => new Promise<never>(() => {}));
+    const session: TestNodeSession = {
+      nodeId,
+      connId: "stalled-pairing-conn",
+      commands: ["camera.capture"],
+      platform: "iOS 26.4.0",
+    };
+    const nodeRegistry = {
+      get: vi.fn(() => session),
+      invoke: vi.fn().mockResolvedValue({ ok: true }),
+    };
+
+    const pending = invokeNode({
+      nodeRegistry,
+      requestParams: { nodeId, idempotencyKey: "idem-stalled-pairing-recheck", timeoutMs: 100 },
+    });
+
+    await vi.advanceTimersByTimeAsync(100);
+
+    expect(firstRespondCall(await pending)).toMatchObject([
+      false,
+      undefined,
+      {
+        message: "TIMEOUT: node invoke timed out",
+        details: { nodeError: { code: "TIMEOUT" } },
+      },
+    ]);
+    expect(nodeRegistry.invoke).not.toHaveBeenCalled();
+  });
+
+  it("preserves dispatched plugin work when its pairing recheck times out", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
+    const nodeId = "ios-node-dispatched-plugin-pairing-timeout";
+    mocks.isNodePairingGenerationCurrent.mockImplementation(() => new Promise<never>(() => {}));
+    const session: TestNodeSession = {
+      nodeId,
+      connId: "dispatched-plugin-conn",
+      commands: ["camera.capture"],
+      platform: "iOS 26.4.0",
+    };
+    const nodeRegistry = {
+      get: vi.fn(() => session),
+      invoke: vi.fn().mockResolvedValue({ ok: true, payload: { ok: true }, payloadJSON: null }),
+    };
+    const applyPolicy = vi
+      .spyOn(nodeInvokePluginPolicy, "applyPluginNodeInvokePolicy")
+      .mockImplementation(async (params) => {
+        params.onNodeCommandDispatched?.();
+        await params.context.nodeRegistry.invoke({
+          nodeId: params.nodeSession.nodeId,
+          expectedConnId: params.nodeSession.connId,
+          command: params.command,
+          params: params.params,
+          timeoutMs: params.timeoutMs,
+          idempotencyKey: params.idempotencyKey,
+        });
+        return { ok: true, payload: { ok: true }, payloadJSON: null };
+      });
+
+    try {
+      const pending = invokeNode({
+        nodeRegistry,
+        requestParams: {
+          nodeId,
+          idempotencyKey: "idem-dispatched-plugin-pairing-timeout",
+          timeoutMs: 100,
+        },
+      });
+
+      await vi.advanceTimersByTimeAsync(100);
+
+      expect(firstRespondCall(await pending)).toMatchObject([
+        false,
+        undefined,
+        {
+          message: "TIMEOUT: node invoke timed out",
+          details: {
+            nodeError: { code: "TIMEOUT" },
+            nodeCommandDispatched: true,
+          },
+        },
+      ]);
+      expect(nodeRegistry.invoke).toHaveBeenCalledOnce();
+    } finally {
+      applyPolicy.mockRestore();
+    }
+  });
+
+  it("returns on the invoke deadline when an APNs wake remains in flight", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
+    const nodeId = "ios-node-stalled-apns-deadline";
+    mockDirectWakeConfig(nodeId);
+    let releaseWake: (() => void) | undefined;
+    mocks.sendApnsBackgroundWake.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          releaseWake = () =>
+            resolve({
+              ok: true,
+              status: 200,
+              tokenSuffix: "1234abcd",
+              topic: "ai.openclaw.ios",
+              environment: "sandbox",
+              transport: "direct",
+            });
+        }),
+    );
+    const nodeRegistry = createMissingNodeRegistry();
+
+    const pending = invokeNode({
+      nodeRegistry,
+      requestParams: { nodeId, idempotencyKey: "idem-stalled-apns-deadline", timeoutMs: 100 },
+    });
+
+    await vi.advanceTimersByTimeAsync(100);
+
+    expect(firstRespondCall(await pending)).toMatchObject([
+      false,
+      undefined,
+      {
+        message: "TIMEOUT: node invoke timed out",
+        details: { nodeError: { code: "TIMEOUT" } },
+      },
+    ]);
+    expect(nodeRegistry.invoke).not.toHaveBeenCalled();
+    expect(mocks.sendApnsBackgroundWake).toHaveBeenCalledOnce();
+
+    releaseWake?.();
+    await vi.advanceTimersByTimeAsync(0);
+  });
+
+  it("rejects wake results that resolve after the absolute invoke deadline", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
+    const nodeId = "ios-node-late-apns-wake-result";
+    mockDirectWakeConfig(nodeId);
+    mocks.sendApnsBackgroundWake.mockImplementation(async () => {
+      vi.setSystemTime(101);
+      return {
+        ok: true,
+        status: 200,
+        tokenSuffix: "1234abcd",
+        topic: "ai.openclaw.ios",
+        environment: "sandbox",
+        transport: "direct",
+      };
+    });
+    const nodeRegistry = createMissingNodeRegistry();
+
+    const respond = await invokeNode({
+      nodeRegistry,
+      requestParams: { nodeId, idempotencyKey: "idem-late-apns-wake-result", timeoutMs: 100 },
+    });
+
+    expect(firstRespondCall(respond)).toMatchObject([
+      false,
+      undefined,
+      {
+        message: "TIMEOUT: node invoke timed out",
+        details: { nodeError: { code: "TIMEOUT" } },
+      },
+    ]);
+    expect(nodeRegistry.invoke).not.toHaveBeenCalled();
+  });
+
+  it("preserves invoke deadlines beyond the maximum Node.js timer delay", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
+    const nodeId = "ios-node-long-invoke-deadline";
+    mockDirectWakeConfig(nodeId);
+    let releaseWake: (() => void) | undefined;
+    mocks.sendApnsBackgroundWake.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          releaseWake = () =>
+            resolve({
+              ok: true,
+              status: 200,
+              tokenSuffix: "1234abcd",
+              topic: "ai.openclaw.ios",
+              environment: "sandbox",
+              transport: "direct",
+            });
+        }),
+    );
+    const nodeRegistry = createMissingNodeRegistry();
+    let invocationSettled = false;
+    const pending = invokeNode({
+      nodeRegistry,
+      requestParams: {
+        nodeId,
+        idempotencyKey: "idem-long-invoke-deadline",
+        timeoutMs: MAX_TIMER_TIMEOUT_MS + 100,
+      },
+    });
+    void pending.then(() => {
+      invocationSettled = true;
+    });
+
+    await vi.advanceTimersByTimeAsync(MAX_TIMER_TIMEOUT_MS);
+
+    expect(invocationSettled).toBe(false);
+    expect(mocks.sendApnsBackgroundWake).toHaveBeenCalledOnce();
+    expect(nodeRegistry.invoke).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(100);
+
+    expect(firstRespondCall(await pending)).toMatchObject([
+      false,
+      undefined,
+      {
+        message: "TIMEOUT: node invoke timed out",
+        details: { nodeError: { code: "TIMEOUT" } },
+      },
+    ]);
+
+    releaseWake?.();
+    await vi.advanceTimersByTimeAsync(0);
   });
 
   it("rejects a command revoked while waiting for a node to reconnect", async () => {
@@ -1467,7 +1752,11 @@ describe("node.invoke APNs wake path", () => {
 
     const invokePromise = invokeNode({
       nodeRegistry,
-      requestParams: { nodeId: "ios-node-throttle", idempotencyKey: "idem-throttle-1" },
+      requestParams: {
+        nodeId: "ios-node-throttle",
+        idempotencyKey: "idem-throttle-1",
+        timeoutMs: 0,
+      },
     });
     await vi.advanceTimersByTimeAsync(20_000);
     await invokePromise;
@@ -1709,6 +1998,52 @@ describe("node.invoke APNs wake path", () => {
       false,
       undefined,
       { details: { code: "NOT_CONNECTED" } },
+    ]);
+  });
+
+  it("cancels dispatched node work when its pairing generation is revoked", async () => {
+    const nodeId = "ios-node-revoked-during-dispatch";
+    let pairingCurrent = true;
+    mocks.isNodePairingGenerationCurrent.mockImplementation(async () => pairingCurrent);
+    const session: TestNodeSession = {
+      nodeId,
+      connId: "revoked-conn",
+      commands: ["camera.capture"],
+      platform: "iOS 26.4.0",
+    };
+    const nodeRegistry = {
+      get: vi.fn(() => session),
+      invoke: vi.fn(
+        (payload: { signal?: AbortSignal }) =>
+          new Promise<{ ok: false; error: { code: string; message: string } }>((resolve) => {
+            payload.signal?.addEventListener(
+              "abort",
+              () => resolve({ ok: false, error: { code: "ABORTED", message: "cancelled" } }),
+              { once: true },
+            );
+          }),
+      ),
+    };
+
+    const pending = invokeNode({
+      nodeRegistry,
+      requestParams: { nodeId, idempotencyKey: "idem-revoked-during-dispatch" },
+    });
+    await vi.waitFor(() => expect(nodeRegistry.invoke).toHaveBeenCalledTimes(1));
+    const signal = requireRecord(mockArg(nodeRegistry.invoke, 0, 0), "node invoke payload").signal;
+    if (!(signal instanceof AbortSignal)) {
+      throw new Error("expected dispatched node work to receive an abort signal");
+    }
+    expect(signal.aborted).toBe(false);
+
+    pairingCurrent = false;
+    invalidateNodeWakeState(nodeId);
+
+    expect(signal.aborted).toBe(true);
+    expect(firstRespondCall(await pending)).toMatchObject([
+      false,
+      undefined,
+      { details: { code: "PAIRING_CHANGED" } },
     ]);
   });
 

--- a/src/gateway/server-methods/nodes.invoke.ts
+++ b/src/gateway/server-methods/nodes.invoke.ts
@@ -1,4 +1,5 @@
 import { randomUUID } from "node:crypto";
+import { MAX_TIMER_TIMEOUT_MS } from "@openclaw/normalization-core/number-coercion";
 import {
   normalizeLowercaseStringOrEmpty,
   normalizeOptionalString,
@@ -57,7 +58,49 @@ const TALK_PTT_COMMANDS = new Set([
   "talk.ptt.cancel",
   "talk.ptt.once",
 ]);
+const NODE_WAKE_INVOKE_DEADLINE_EXPIRED = Symbol("node wake invoke deadline expired");
 const talkPttEventSeqBySessionId = new Map<string, number>();
+
+async function awaitNodeWakeWithinInvokeDeadline<T>(
+  operation: () => Promise<T>,
+  deadlineAtMs: number | undefined,
+): Promise<T | typeof NODE_WAKE_INVOKE_DEADLINE_EXPIRED> {
+  if (deadlineAtMs === undefined) {
+    return await operation();
+  }
+  const remainingMs = Math.max(0, deadlineAtMs - Date.now());
+  if (remainingMs === 0) {
+    return NODE_WAKE_INVOKE_DEADLINE_EXPIRED;
+  }
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    // Arm the timer before plugin or push code can synchronously consume the
+    // budget; Node timer callbacks alone cannot establish absolute deadlines.
+    const deadline = new Promise<typeof NODE_WAKE_INVOKE_DEADLINE_EXPIRED>((resolve) => {
+      // Node silently overflows long timers; reschedule against the absolute
+      // deadline so a valid long request never expires or disappears early.
+      const waitForDeadline = () => {
+        const remainingMs = Math.max(0, deadlineAtMs - Date.now());
+        if (remainingMs === 0) {
+          resolve(NODE_WAKE_INVOKE_DEADLINE_EXPIRED);
+          return;
+        }
+        timer = setTimeout(waitForDeadline, Math.min(remainingMs, MAX_TIMER_TIMEOUT_MS));
+      };
+      waitForDeadline();
+    });
+    return await Promise.race([
+      deadline,
+      operation().then((result) =>
+        Date.now() >= deadlineAtMs ? NODE_WAKE_INVOKE_DEADLINE_EXPIRED : result,
+      ),
+    ]);
+  } finally {
+    if (timer !== undefined) {
+      clearTimeout(timer);
+    }
+  }
+}
 
 function isForegroundRestrictedIosCommand(command: string): boolean {
   return (
@@ -225,8 +268,43 @@ export const nodeInvokeHandlers: GatewayRequestHandlers = {
       );
       return;
     }
+    const invokeDeadlineAtMs =
+      typeof p.timeoutMs === "number" && p.timeoutMs > 0 ? Date.now() + p.timeoutMs : undefined;
+    let pluginNodeCommandDispatched = false;
+    const resolveRemainingInvokeTimeoutMs = () =>
+      invokeDeadlineAtMs === undefined ? p.timeoutMs : Math.max(0, invokeDeadlineAtMs - Date.now());
+    const respondIfInvokeExpired = (includeDispatchState = false) => {
+      if (invokeDeadlineAtMs === undefined || resolveRemainingInvokeTimeoutMs() !== 0) {
+        return false;
+      }
+      if (pluginNodeCommandDispatched || includeDispatchState) {
+        respond(
+          false,
+          undefined,
+          errorShape(ErrorCodes.UNAVAILABLE, "TIMEOUT: node invoke timed out", {
+            details: {
+              nodeError: { code: "TIMEOUT", message: "node invoke timed out" },
+              nodeCommandDispatched: pluginNodeCommandDispatched,
+            },
+          }),
+        );
+        return true;
+      }
+      respondUnavailableOnNodeInvokeError(respond, {
+        ok: false,
+        error: { code: "TIMEOUT", message: "node invoke timed out" },
+      });
+      return true;
+    };
     await respondUnavailableOnThrow(respond, async () => {
-      const generation = await captureNodePairingGeneration(nodeId);
+      const generation = await awaitNodeWakeWithinInvokeDeadline(
+        () => captureNodePairingGeneration(nodeId),
+        invokeDeadlineAtMs,
+      );
+      if (generation === NODE_WAKE_INVOKE_DEADLINE_EXPIRED) {
+        respondIfInvokeExpired();
+        return;
+      }
       if (!generation) {
         respondPairingChanged(respond);
         return;
@@ -234,12 +312,24 @@ export const nodeInvokeHandlers: GatewayRequestHandlers = {
       const wakeLifecycle = captureNodeWakeLifecycle(nodeId, generation.key);
       try {
         const continuePairingWork = async (): Promise<boolean> => {
-          if (await isNodePairingWorkCurrent({ nodeId, generation, lifecycle: wakeLifecycle })) {
+          const pairingCurrent = await awaitNodeWakeWithinInvokeDeadline(
+            () => isNodePairingWorkCurrent({ nodeId, generation, lifecycle: wakeLifecycle }),
+            invokeDeadlineAtMs,
+          );
+          if (pairingCurrent === NODE_WAKE_INVOKE_DEADLINE_EXPIRED) {
+            respondIfInvokeExpired();
+            return false;
+          }
+          if (pairingCurrent) {
             return true;
           }
           respondPairingChanged(respond);
           return false;
         };
+
+        if (respondIfInvokeExpired()) {
+          return;
+        }
 
         const cfg = context.getRuntimeConfig();
         let nodeSession = resolveDispatchableNodeSession(
@@ -252,20 +342,37 @@ export const nodeInvokeHandlers: GatewayRequestHandlers = {
             `node wake start node=${nodeId} req=${wakeReqId} command=${command}`,
           );
 
-          const wake = await maybeWakeNodeWithApns(nodeId, {
-            cfg,
-            lifecycle: wakeLifecycle,
-            generation,
-          });
+          // Wake attempts can be shared; expire this caller without aborting a
+          // push that another live invocation still owns.
+          const wake = await awaitNodeWakeWithinInvokeDeadline(
+            () =>
+              maybeWakeNodeWithApns(nodeId, {
+                cfg,
+                lifecycle: wakeLifecycle,
+                generation,
+              }),
+            invokeDeadlineAtMs,
+          );
+          if (wake === NODE_WAKE_INVOKE_DEADLINE_EXPIRED) {
+            respondIfInvokeExpired();
+            return;
+          }
           context.logGateway.info(
             `node wake stage=wake1 node=${nodeId} req=${wakeReqId} ` +
               `available=${wake.available} throttled=${wake.throttled} ` +
               `path=${wake.path} durationMs=${wake.durationMs} ` +
               `apnsStatus=${wake.apnsStatus ?? -1} apnsReason=${wake.apnsReason ?? "-"}`,
           );
+          if (respondIfInvokeExpired()) {
+            return;
+          }
           if (wake.available) {
             const waitStartedAtMs = Date.now();
-            const waitTimeoutMs = NODE_WAKE_RECONNECT_WAIT_MS;
+            const remainingTimeoutMs = resolveRemainingInvokeTimeoutMs();
+            const waitTimeoutMs =
+              invokeDeadlineAtMs === undefined
+                ? NODE_WAKE_RECONNECT_WAIT_MS
+                : Math.min(NODE_WAKE_RECONNECT_WAIT_MS, remainingTimeoutMs ?? 0);
             const reconnected = await waitForNodeReconnect({
               nodeId,
               context,
@@ -279,28 +386,43 @@ export const nodeInvokeHandlers: GatewayRequestHandlers = {
                 `reconnected=${reconnected} timeoutMs=${waitTimeoutMs} durationMs=${waitDurationMs}`,
             );
           }
-          if (!(await continuePairingWork())) {
+          if (!(await continuePairingWork()) || respondIfInvokeExpired()) {
             return;
           }
           nodeSession = resolveDispatchableNodeSession(
             context.nodeRegistry.getForPairingGeneration(nodeId, generation.key),
           );
           if (!nodeSession && wake.available) {
-            const retryWake = await maybeWakeNodeWithApns(nodeId, {
-              force: true,
-              cfg,
-              lifecycle: wakeLifecycle,
-              generation,
-            });
+            const retryWake = await awaitNodeWakeWithinInvokeDeadline(
+              () =>
+                maybeWakeNodeWithApns(nodeId, {
+                  force: true,
+                  cfg,
+                  lifecycle: wakeLifecycle,
+                  generation,
+                }),
+              invokeDeadlineAtMs,
+            );
+            if (retryWake === NODE_WAKE_INVOKE_DEADLINE_EXPIRED) {
+              respondIfInvokeExpired();
+              return;
+            }
             context.logGateway.info(
               `node wake stage=wake2 node=${nodeId} req=${wakeReqId} force=true ` +
                 `available=${retryWake.available} throttled=${retryWake.throttled} ` +
                 `path=${retryWake.path} durationMs=${retryWake.durationMs} ` +
                 `apnsStatus=${retryWake.apnsStatus ?? -1} apnsReason=${retryWake.apnsReason ?? "-"}`,
             );
+            if (respondIfInvokeExpired()) {
+              return;
+            }
             if (retryWake.available) {
               const waitStartedAtMs = Date.now();
-              const waitTimeoutMs = NODE_WAKE_RECONNECT_RETRY_WAIT_MS;
+              const remainingTimeoutMs = resolveRemainingInvokeTimeoutMs();
+              const waitTimeoutMs =
+                invokeDeadlineAtMs === undefined
+                  ? NODE_WAKE_RECONNECT_RETRY_WAIT_MS
+                  : Math.min(NODE_WAKE_RECONNECT_RETRY_WAIT_MS, remainingTimeoutMs ?? 0);
               const reconnected = await waitForNodeReconnect({
                 nodeId,
                 context,
@@ -314,7 +436,7 @@ export const nodeInvokeHandlers: GatewayRequestHandlers = {
                   `reconnected=${reconnected} timeoutMs=${waitTimeoutMs} durationMs=${waitDurationMs}`,
               );
             }
-            if (!(await continuePairingWork())) {
+            if (!(await continuePairingWork()) || respondIfInvokeExpired()) {
               return;
             }
             nodeSession = resolveDispatchableNodeSession(
@@ -322,12 +444,23 @@ export const nodeInvokeHandlers: GatewayRequestHandlers = {
             );
           }
           if (!nodeSession) {
+            if (respondIfInvokeExpired()) {
+              return;
+            }
             const totalDurationMs = Math.max(0, Date.now() - wakeFlowStartedAtMs);
-            const nudge = await maybeSendNodeWakeNudge(nodeId, {
-              cfg,
-              lifecycle: wakeLifecycle,
-              generation,
-            });
+            const nudge = await awaitNodeWakeWithinInvokeDeadline(
+              () =>
+                maybeSendNodeWakeNudge(nodeId, {
+                  cfg,
+                  lifecycle: wakeLifecycle,
+                  generation,
+                }),
+              invokeDeadlineAtMs,
+            );
+            if (nudge === NODE_WAKE_INVOKE_DEADLINE_EXPIRED) {
+              respondIfInvokeExpired();
+              return;
+            }
             if (!(await continuePairingWork())) {
               return;
             }
@@ -402,23 +535,41 @@ export const nodeInvokeHandlers: GatewayRequestHandlers = {
           );
           return;
         }
-        const policyResult = await applyPluginNodeInvokePolicy({
-          context,
-          client,
-          nodeSession,
-          command,
-          params: forwardedParams.params,
-          turnSource: {
-            channel: p.turnSourceChannel,
-            to: p.turnSourceTo,
-            accountId: p.turnSourceAccountId,
-            threadId: p.turnSourceThreadId,
-          },
-          timeoutMs: p.timeoutMs,
-          idempotencyKey: p.idempotencyKey,
-          isInvocationCurrent: () =>
-            isNodePairingWorkCurrent({ nodeId, generation, lifecycle: wakeLifecycle }),
-        });
+        if (respondIfInvokeExpired()) {
+          return;
+        }
+        const policyResult = await awaitNodeWakeWithinInvokeDeadline(
+          () =>
+            applyPluginNodeInvokePolicy({
+              context,
+              client,
+              nodeSession,
+              command,
+              params: forwardedParams.params,
+              turnSource: {
+                channel: p.turnSourceChannel,
+                to: p.turnSourceTo,
+                accountId: p.turnSourceAccountId,
+                threadId: p.turnSourceThreadId,
+              },
+              timeoutMs: p.timeoutMs,
+              signal: wakeLifecycle,
+              resolveRemainingTimeoutMs: resolveRemainingInvokeTimeoutMs,
+              onNodeCommandDispatched: () => {
+                // Deadline races must retain transport ownership so a command
+                // already handed to the node is never advertised as retry-safe.
+                pluginNodeCommandDispatched = true;
+              },
+              idempotencyKey: p.idempotencyKey,
+              isInvocationCurrent: () =>
+                isNodePairingWorkCurrent({ nodeId, generation, lifecycle: wakeLifecycle }),
+            }),
+          invokeDeadlineAtMs,
+        );
+        if (policyResult === NODE_WAKE_INVOKE_DEADLINE_EXPIRED) {
+          respondIfInvokeExpired(true);
+          return;
+        }
         if (!(await continuePairingWork())) {
           return;
         }
@@ -504,13 +655,19 @@ export const nodeInvokeHandlers: GatewayRequestHandlers = {
           );
           return;
         }
+        const dispatchTimeoutMs = resolveRemainingInvokeTimeoutMs();
+        if (invokeDeadlineAtMs !== undefined && dispatchTimeoutMs === 0) {
+          respondIfInvokeExpired();
+          return;
+        }
         const res = await context.nodeRegistry.invoke({
           nodeId,
           expectedConnId: nodeSession.connId,
           expectedPairingGeneration: generation.key,
           command,
           params: forwardedParams.params,
-          timeoutMs: p.timeoutMs,
+          timeoutMs: dispatchTimeoutMs,
+          signal: wakeLifecycle,
           idempotencyKey: p.idempotencyKey,
           ...(sessionKey ? { sessionKey } : {}),
         });

--- a/src/gateway/server-methods/nodes.invoke.ts
+++ b/src/gateway/server-methods/nodes.invoke.ts
@@ -1,9 +1,5 @@
 import { randomUUID } from "node:crypto";
-import { MAX_TIMER_TIMEOUT_MS } from "@openclaw/normalization-core/number-coercion";
-import {
-  normalizeLowercaseStringOrEmpty,
-  normalizeOptionalString,
-} from "@openclaw/normalization-core/string-coerce";
+import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import {
   ErrorCodes,
   errorShape,
@@ -13,11 +9,7 @@ import {
 import { isAdminOnlyNodeInvokeCommand } from "../../infra/node-commands.js";
 import { captureNodePairingGeneration } from "../../infra/node-pairing-state.js";
 import { isForbiddenBrowserProxyMutation } from "../node-browser-proxy-policy.js";
-import {
-  isForegroundRestrictedPluginNodeCommand,
-  isNodeCommandAllowed,
-  resolveNodeCommandAllowlist,
-} from "../node-command-policy.js";
+import { isNodeCommandAllowed, resolveNodeCommandAllowlist } from "../node-command-policy.js";
 import { applyPluginNodeInvokePolicy } from "../node-invoke-plugin-policy.js";
 import { sanitizeNodeInvokeParamsForForwarding } from "../node-invoke-sanitize.js";
 import { enqueuePendingNodeAction, removePendingNodeAction } from "../node-runtime-state.js";
@@ -38,6 +30,11 @@ import {
   respondUnavailableOnThrow,
   safeParseJson,
 } from "./nodes.helpers.js";
+import {
+  awaitNodeInvokeWithinDeadline,
+  NODE_INVOKE_DEADLINE_EXPIRED,
+} from "./nodes.invoke-deadline.js";
+import { shouldQueueAsPendingForegroundAction } from "./nodes.invoke-foreground.js";
 import { toPendingParamsJSON } from "./nodes.pending.js";
 import {
   isNodePairingWorkCurrent,
@@ -58,81 +55,7 @@ const TALK_PTT_COMMANDS = new Set([
   "talk.ptt.cancel",
   "talk.ptt.once",
 ]);
-const NODE_WAKE_INVOKE_DEADLINE_EXPIRED = Symbol("node wake invoke deadline expired");
 const talkPttEventSeqBySessionId = new Map<string, number>();
-
-async function awaitNodeWakeWithinInvokeDeadline<T>(
-  operation: () => Promise<T>,
-  deadlineAtMs: number | undefined,
-): Promise<T | typeof NODE_WAKE_INVOKE_DEADLINE_EXPIRED> {
-  if (deadlineAtMs === undefined) {
-    return await operation();
-  }
-  const remainingMs = Math.max(0, deadlineAtMs - Date.now());
-  if (remainingMs === 0) {
-    return NODE_WAKE_INVOKE_DEADLINE_EXPIRED;
-  }
-  let timer: ReturnType<typeof setTimeout> | undefined;
-  try {
-    // Arm the timer before plugin or push code can synchronously consume the
-    // budget; Node timer callbacks alone cannot establish absolute deadlines.
-    const deadline = new Promise<typeof NODE_WAKE_INVOKE_DEADLINE_EXPIRED>((resolve) => {
-      // Node silently overflows long timers; reschedule against the absolute
-      // deadline so a valid long request never expires or disappears early.
-      const waitForDeadline = () => {
-        const remainingMs = Math.max(0, deadlineAtMs - Date.now());
-        if (remainingMs === 0) {
-          resolve(NODE_WAKE_INVOKE_DEADLINE_EXPIRED);
-          return;
-        }
-        timer = setTimeout(waitForDeadline, Math.min(remainingMs, MAX_TIMER_TIMEOUT_MS));
-      };
-      waitForDeadline();
-    });
-    return await Promise.race([
-      deadline,
-      operation().then((result) =>
-        Date.now() >= deadlineAtMs ? NODE_WAKE_INVOKE_DEADLINE_EXPIRED : result,
-      ),
-    ]);
-  } finally {
-    if (timer !== undefined) {
-      clearTimeout(timer);
-    }
-  }
-}
-
-function isForegroundRestrictedIosCommand(command: string): boolean {
-  return (
-    isForegroundRestrictedPluginNodeCommand(command) ||
-    command.startsWith("camera.") ||
-    command.startsWith("screen.") ||
-    command.startsWith("talk.")
-  );
-}
-
-function shouldQueueAsPendingForegroundAction(params: {
-  platform?: string;
-  command: string;
-  error: unknown;
-}): boolean {
-  // iOS cannot run camera/screen/Talk commands in the background. Queue only
-  // those foreground-only commands when the node explicitly reports that state.
-  const platform = normalizeLowercaseStringOrEmpty(params.platform);
-  if (!platform.startsWith("ios") && !platform.startsWith("ipados")) {
-    return false;
-  }
-  if (!isForegroundRestrictedIosCommand(params.command)) {
-    return false;
-  }
-  const error =
-    params.error && typeof params.error === "object"
-      ? (params.error as { code?: unknown; message?: unknown })
-      : null;
-  const code = normalizeOptionalString(error?.code)?.toUpperCase() ?? "";
-  const message = normalizeOptionalString(error?.message)?.toUpperCase() ?? "";
-  return code === "NODE_BACKGROUND_UNAVAILABLE" || message.includes("BACKGROUND_UNAVAILABLE");
-}
 
 function emitTalkPttNodeEvent(params: {
   context: Pick<GatewayRequestContext, "broadcast">;
@@ -297,11 +220,11 @@ export const nodeInvokeHandlers: GatewayRequestHandlers = {
       return true;
     };
     await respondUnavailableOnThrow(respond, async () => {
-      const generation = await awaitNodeWakeWithinInvokeDeadline(
+      const generation = await awaitNodeInvokeWithinDeadline(
         () => captureNodePairingGeneration(nodeId),
         invokeDeadlineAtMs,
       );
-      if (generation === NODE_WAKE_INVOKE_DEADLINE_EXPIRED) {
+      if (generation === NODE_INVOKE_DEADLINE_EXPIRED) {
         respondIfInvokeExpired();
         return;
       }
@@ -312,11 +235,11 @@ export const nodeInvokeHandlers: GatewayRequestHandlers = {
       const wakeLifecycle = captureNodeWakeLifecycle(nodeId, generation.key);
       try {
         const continuePairingWork = async (): Promise<boolean> => {
-          const pairingCurrent = await awaitNodeWakeWithinInvokeDeadline(
+          const pairingCurrent = await awaitNodeInvokeWithinDeadline(
             () => isNodePairingWorkCurrent({ nodeId, generation, lifecycle: wakeLifecycle }),
             invokeDeadlineAtMs,
           );
-          if (pairingCurrent === NODE_WAKE_INVOKE_DEADLINE_EXPIRED) {
+          if (pairingCurrent === NODE_INVOKE_DEADLINE_EXPIRED) {
             respondIfInvokeExpired();
             return false;
           }
@@ -344,7 +267,7 @@ export const nodeInvokeHandlers: GatewayRequestHandlers = {
 
           // Wake attempts can be shared; expire this caller without aborting a
           // push that another live invocation still owns.
-          const wake = await awaitNodeWakeWithinInvokeDeadline(
+          const wake = await awaitNodeInvokeWithinDeadline(
             () =>
               maybeWakeNodeWithApns(nodeId, {
                 cfg,
@@ -353,7 +276,7 @@ export const nodeInvokeHandlers: GatewayRequestHandlers = {
               }),
             invokeDeadlineAtMs,
           );
-          if (wake === NODE_WAKE_INVOKE_DEADLINE_EXPIRED) {
+          if (wake === NODE_INVOKE_DEADLINE_EXPIRED) {
             respondIfInvokeExpired();
             return;
           }
@@ -393,7 +316,7 @@ export const nodeInvokeHandlers: GatewayRequestHandlers = {
             context.nodeRegistry.getForPairingGeneration(nodeId, generation.key),
           );
           if (!nodeSession && wake.available) {
-            const retryWake = await awaitNodeWakeWithinInvokeDeadline(
+            const retryWake = await awaitNodeInvokeWithinDeadline(
               () =>
                 maybeWakeNodeWithApns(nodeId, {
                   force: true,
@@ -403,7 +326,7 @@ export const nodeInvokeHandlers: GatewayRequestHandlers = {
                 }),
               invokeDeadlineAtMs,
             );
-            if (retryWake === NODE_WAKE_INVOKE_DEADLINE_EXPIRED) {
+            if (retryWake === NODE_INVOKE_DEADLINE_EXPIRED) {
               respondIfInvokeExpired();
               return;
             }
@@ -448,7 +371,7 @@ export const nodeInvokeHandlers: GatewayRequestHandlers = {
               return;
             }
             const totalDurationMs = Math.max(0, Date.now() - wakeFlowStartedAtMs);
-            const nudge = await awaitNodeWakeWithinInvokeDeadline(
+            const nudge = await awaitNodeInvokeWithinDeadline(
               () =>
                 maybeSendNodeWakeNudge(nodeId, {
                   cfg,
@@ -457,7 +380,7 @@ export const nodeInvokeHandlers: GatewayRequestHandlers = {
                 }),
               invokeDeadlineAtMs,
             );
-            if (nudge === NODE_WAKE_INVOKE_DEADLINE_EXPIRED) {
+            if (nudge === NODE_INVOKE_DEADLINE_EXPIRED) {
               respondIfInvokeExpired();
               return;
             }
@@ -538,7 +461,7 @@ export const nodeInvokeHandlers: GatewayRequestHandlers = {
         if (respondIfInvokeExpired()) {
           return;
         }
-        const policyResult = await awaitNodeWakeWithinInvokeDeadline(
+        const policyResult = await awaitNodeInvokeWithinDeadline(
           () =>
             applyPluginNodeInvokePolicy({
               context,
@@ -566,7 +489,7 @@ export const nodeInvokeHandlers: GatewayRequestHandlers = {
             }),
           invokeDeadlineAtMs,
         );
-        if (policyResult === NODE_WAKE_INVOKE_DEADLINE_EXPIRED) {
+        if (policyResult === NODE_INVOKE_DEADLINE_EXPIRED) {
           respondIfInvokeExpired(true);
           return;
         }

--- a/src/gateway/server-methods/nodes.wake.ts
+++ b/src/gateway/server-methods/nodes.wake.ts
@@ -354,7 +354,7 @@ export async function waitForNodeReconnect(params: {
   lifecycle?: NodeWakeLifecycle;
   pairingGeneration?: string;
 }): Promise<boolean> {
-  const timeoutMs = resolveTimerTimeoutMs(params.timeoutMs, NODE_WAKE_RECONNECT_WAIT_MS, 250);
+  const timeoutMs = resolveTimerTimeoutMs(params.timeoutMs, NODE_WAKE_RECONNECT_WAIT_MS, 1);
   const pollMs = resolveTimerTimeoutMs(params.pollMs, NODE_WAKE_RECONNECT_POLL_MS, 50);
   const deadline = Date.now() + timeoutMs;
 
@@ -371,7 +371,7 @@ export async function waitForNodeReconnect(params: {
     if (resolveDispatchableNodeSession(session)) {
       return true;
     }
-    await delayMs(pollMs);
+    await delayMs(Math.min(pollMs, Math.max(0, deadline - Date.now())));
   }
   if (
     params.lifecycle &&

--- a/src/plugins/provider-self-hosted-setup.test.ts
+++ b/src/plugins/provider-self-hosted-setup.test.ts
@@ -147,6 +147,108 @@ function cancelTrackedResponse(init?: ResponseInit): {
 }
 
 describe("discoverOpenAICompatibleLocalModels", () => {
+  it("retains valid models when a provider catalog contains malformed entries", async () => {
+    const release = vi.fn(async () => undefined);
+    fetchWithSsrFGuardMock.mockResolvedValueOnce({
+      response: new Response(
+        JSON.stringify({
+          data: [
+            { id: "valid-a", meta: { n_ctx_train: 32_768 } },
+            null,
+            7,
+            "invalid",
+            [],
+            { id: "valid-b", meta: { n_ctx_train: 65_536 } },
+          ],
+        }),
+        { status: 200 },
+      ),
+      finalUrl: "http://127.0.0.1:8000/v1/models",
+      release,
+    });
+
+    const models = await discoverOpenAICompatibleLocalModels({
+      baseUrl: "http://127.0.0.1:8000/v1",
+      label: "vLLM",
+      discoverRuntimeContext: false,
+      env: {},
+    });
+
+    expect(models).toMatchObject([
+      { id: "valid-a", contextWindow: 32_768 },
+      { id: "valid-b", contextWindow: 65_536 },
+    ]);
+    expect(fetchWithSsrFGuardMock).toHaveBeenCalledOnce();
+    expect(release).toHaveBeenCalledOnce();
+  });
+
+  it.each([null, {}, "invalid"])("rejects a non-array model catalog: %j", async (data) => {
+    const release = vi.fn(async () => undefined);
+    fetchWithSsrFGuardMock.mockResolvedValueOnce({
+      response: new Response(JSON.stringify({ data }), { status: 200 }),
+      finalUrl: "http://127.0.0.1:8000/v1/models",
+      release,
+    });
+
+    await expect(
+      discoverOpenAICompatibleLocalModels({
+        baseUrl: "http://127.0.0.1:8000/v1",
+        label: "vLLM",
+        discoverRuntimeContext: false,
+        env: {},
+      }),
+    ).resolves.toEqual([]);
+    expect(loggerWarnMock).toHaveBeenCalledWith(
+      expect.stringContaining("vLLM discovery: malformed JSON response"),
+    );
+    expect(release).toHaveBeenCalledOnce();
+  });
+
+  it("bounds concurrent llama.cpp runtime probes without truncating its model catalog", async () => {
+    const release = vi.fn(async () => undefined);
+    const data = Array.from({ length: 201 }, (_, index) => ({
+      id: `local/model-${index}`,
+      meta: { n_ctx_train: 32_768 },
+    }));
+    let activePropsRequests = 0;
+    let maximumPropsRequests = 0;
+    fetchWithSsrFGuardMock.mockImplementation(async ({ url }: { url: string }) => {
+      if (url.endsWith("/models")) {
+        return {
+          response: new Response(JSON.stringify({ data }), { status: 200 }),
+          finalUrl: url,
+          release,
+        };
+      }
+      activePropsRequests += 1;
+      maximumPropsRequests = Math.max(maximumPropsRequests, activePropsRequests);
+      await Promise.resolve();
+      activePropsRequests -= 1;
+      return {
+        response: new Response(JSON.stringify({ default_generation_settings: { n_ctx: 16_384 } }), {
+          status: 200,
+        }),
+        finalUrl: url,
+        release,
+      };
+    });
+
+    const models = await discoverOpenAICompatibleLocalModels({
+      baseUrl: "http://127.0.0.1:8080/v1",
+      label: "llama.cpp",
+      env: {},
+    });
+
+    expect(models).toHaveLength(201);
+    expect(models[0]).toMatchObject({ id: "local/model-0", contextTokens: 16_384 });
+    expect(models[199]).toMatchObject({ id: "local/model-199", contextTokens: 16_384 });
+    expect(models[200]).toMatchObject({ id: "local/model-200", contextWindow: 32_768 });
+    expect(models[200]).not.toHaveProperty("contextTokens");
+    expect(maximumPropsRequests).toBeLessThanOrEqual(8);
+    expect(fetchWithSsrFGuardMock).toHaveBeenCalledTimes(201);
+    expect(release).toHaveBeenCalledTimes(201);
+  });
+
   it("discovers a large non-llama.cpp catalog without probing per-model llama.cpp props", async () => {
     const release = vi.fn(async () => undefined);
     const data = Array.from({ length: 500 }, (_, index) => ({

--- a/src/plugins/provider-self-hosted-setup.ts
+++ b/src/plugins/provider-self-hosted-setup.ts
@@ -10,7 +10,11 @@ import { uniqueStrings } from "@openclaw/normalization-core/string-normalization
 import type { ApiKeyCredential, AuthProfileCredential } from "../agents/auth-profiles/types.js";
 import { upsertAuthProfileWithLock } from "../agents/auth-profiles/upsert-with-lock.js";
 import { parseConfiguredModelVisibilityEntries } from "../agents/model-selection-shared.js";
-import { readProviderJsonResponse } from "../agents/provider-http-errors.js";
+import {
+  asObject,
+  readProviderJsonArrayFieldResponse,
+  readProviderJsonResponse,
+} from "../agents/provider-http-errors.js";
 import {
   SELF_HOSTED_DEFAULT_CONTEXT_WINDOW,
   SELF_HOSTED_DEFAULT_COST,
@@ -45,15 +49,8 @@ const log = createSubsystemLogger("plugins/self-hosted-provider-setup");
 // unbounded JSON stream). Cap discovery response bodies before parsing so a
 // hostile or buggy endpoint cannot drive the setup wizard into OOM.
 const SELF_HOSTED_DISCOVERY_JSON_MAX_BYTES = 16 * 1024 * 1024;
-
-type OpenAICompatModelsResponse = {
-  data?: Array<{
-    id?: string;
-    meta?: {
-      n_ctx_train?: unknown;
-    };
-  }>;
-};
+const SELF_HOSTED_RUNTIME_CONTEXT_MAX_MODELS = 200;
+const SELF_HOSTED_RUNTIME_CONTEXT_CONCURRENCY = 8;
 
 type LlamaCppPropsResponse = {
   default_generation_settings?: {
@@ -195,42 +192,53 @@ export async function discoverOpenAICompatibleLocalModels(params: {
         log.warn(`Failed to discover ${params.label} models: ${response.status}`);
         return [];
       }
-      const data = await readSelfHostedDiscoveryJson<OpenAICompatModelsResponse>(
+      const models = await readProviderJsonArrayFieldResponse(
         response,
-        params.label,
+        `${params.label} discovery`,
+        "data",
+        { maxBytes: SELF_HOSTED_DISCOVERY_JSON_MAX_BYTES },
       );
-      const models = data.data ?? [];
       if (models.length === 0) {
         log.warn(`No ${params.label} models found on local instance`);
         return [];
       }
 
-      const discoveredModels = models.flatMap((model) => {
-        const modelId = normalizeOptionalString(model.id);
+      const discoveredModels = models.flatMap((rawModel) => {
+        const model = asObject(rawModel);
+        const modelId = normalizeOptionalString(model?.id);
         if (!modelId) {
           return [];
         }
-        return [{ id: modelId, meta: model.meta }];
+        return [{ id: modelId, meta: asObject(model?.meta) }];
       });
       const runtimeContextTokensByModelId = new Map<string, number>();
       if (params.contextWindow === undefined && params.discoverRuntimeContext !== false) {
         const uniqueModelIds = uniqueStrings(discoveredModels.map((model) => model.id));
-        const runtimeContextTokenResults = await Promise.all(
-          uniqueModelIds.map(
-            async (modelId) =>
-              [
-                modelId,
-                await discoverLlamaCppRuntimeContextTokens({
-                  baseUrl: trimmedBaseUrl,
-                  apiKey: params.apiKey,
-                  modelId: uniqueModelIds.length > 1 ? modelId : undefined,
-                }),
-              ] as const,
-          ),
-        );
-        for (const [modelId, runtimeContextTokens] of runtimeContextTokenResults) {
-          if (runtimeContextTokens) {
-            runtimeContextTokensByModelId.set(modelId, runtimeContextTokens);
+        const probeModelIds = uniqueModelIds.slice(0, SELF_HOSTED_RUNTIME_CONTEXT_MAX_MODELS);
+        // A valid large router catalog must not start hundreds of guarded
+        // fetches at once; unprobed models retain their advertised metadata.
+        for (
+          let offset = 0;
+          offset < probeModelIds.length;
+          offset += SELF_HOSTED_RUNTIME_CONTEXT_CONCURRENCY
+        ) {
+          const runtimeContextTokenResults = await Promise.all(
+            probeModelIds.slice(offset, offset + SELF_HOSTED_RUNTIME_CONTEXT_CONCURRENCY).map(
+              async (modelId) =>
+                [
+                  modelId,
+                  await discoverLlamaCppRuntimeContextTokens({
+                    baseUrl: trimmedBaseUrl,
+                    apiKey: params.apiKey,
+                    modelId: uniqueModelIds.length > 1 ? modelId : undefined,
+                  }),
+                ] as const,
+            ),
+          );
+          for (const [modelId, runtimeContextTokens] of runtimeContextTokenResults) {
+            if (runtimeContextTokens) {
+              runtimeContextTokensByModelId.set(modelId, runtimeContextTokens);
+            }
           }
         }
       }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users running paired nodes, MCP and shell commands, the browser copilot, or local model providers could experience hanging gateway requests, orphaned node work, invalid reconnects, unsafe retries, malformed camera output, or runaway model discovery.

## Why This Change Was Made

Carry one absolute invocation deadline across pairing, APNs wake, reconnect, plugin policy, and node transport; propagate cancellation only to first-party node hosts that support it; preserve command-dispatch ownership for safe retries. Extract reusable deadline and iOS foreground helpers so the gateway handler stays within the repository module limit. Bound self-hosted model probing without losing advertised models and validate external gateway and provider records at their boundaries.

## User Impact

Node commands now time out and cancel predictably, including stalled pairing stores, late wake results, revoked pairings, browser reconnect failures, and timeouts longer than the Node timer limit. CLI camera and notification commands reject malformed records and invalid choices safely. Ollama and compatible self-hosted llama.cpp, vLLM, and SGLang catalog discovery remain bounded and keep all valid models.

## Evidence

- Based on main fe9893d41c2bedd71fd4eb0bb9f0c9c9f79b1be7.
- Remote Blacksmith Testbox tbx_01kymefsjbjvq270r83ersyr4y.
- 531 passing regression tests over 17 gateway, node-host, MCP, shell, CLI, browser, Ollama, streaming, preflight, self-hosted model, and end-to-end test files.
- Adversarial regressions for stalled pairing capture and rechecks, revoked pairing, APNs hangs, absolute-deadline races, Node timer overflow, dispatched plugin retry ownership, 201 advertised self-hosted models, and browser-valid WebSocket closes.
- Direct oxlint passes for all 18 changed core and browser files; gateway handler reduced to 697 lines.
- Fresh independent autoreview clean for both the complete behavior change and extracted helper refactor.
- Paired Ollama QA also exercised using the mock provider; this is deterministic protocol proof, not a claim of real local GPU inference.
- The destructive gateway-restart-inflight-run scenario exposed a separate session SQLite lock-handoff defect. That compatibility-sensitive persistent-state problem is intentionally excluded and needs owner-reviewed follow-up.
- Full Linux check:changed is being rerun on this exact head.