### PR TITLE
fix: project visible session transcripts

### DIFF
--- a/src/agents/openclaw-tools.sessions.test.ts
+++ b/src/agents/openclaw-tools.sessions.test.ts
@@ -725,9 +725,7 @@ describe("sessions tools", () => {
     expect(details.messages).toContainEqual(
       expect.objectContaining({ provider: "openclaw", model: "gateway-injected" }),
     );
-    expect(details.messages).toContainEqual(
-      expect.objectContaining({ provider: "openclaw", model: "delivery-mirror" }),
-    );
+    expect(JSON.stringify(details.messages)).not.toContain("delivery-mirror");
 
     const withTools = await tool.execute("call4", {
       sessionKey: "main",

--- a/src/agents/tools/sessions-history-tool.test.ts
+++ b/src/agents/tools/sessions-history-tool.test.ts
@@ -105,6 +105,40 @@ function readMessageId(message: unknown): string | undefined {
   return typeof id === "string" ? id : undefined;
 }
 
+function createHistoryToolWithMessages(messages: unknown[]) {
+  return createSessionsHistoryTool({
+    agentSessionKey: "agent:alfred:whatsapp:group:120363425559039020@g.us",
+    config: {},
+    callGateway: async <T = Record<string, unknown>>(request: CallGatewayRequest): Promise<T> => {
+      if (request.method === "chat.history") {
+        return { messages } as T;
+      }
+      return {} as T;
+    },
+  });
+}
+
+function extractVisibleText(message: unknown): string | undefined {
+  if (!message || typeof message !== "object") {
+    return undefined;
+  }
+  const content = (message as { content?: unknown }).content;
+  if (typeof content === "string") {
+    return content;
+  }
+  if (!Array.isArray(content)) {
+    return undefined;
+  }
+  return content
+    .map((block) =>
+      block && typeof block === "object" && typeof (block as { text?: unknown }).text === "string"
+        ? (block as { text: string }).text
+        : undefined,
+    )
+    .filter((value): value is string => typeof value === "string")
+    .join("\n");
+}
+
 describe("sessions_history redaction", () => {
   beforeAll(async () => {
     previousConfigPath = process.env.OPENCLAW_CONFIG_PATH;
@@ -434,6 +468,120 @@ describe("sessions_history redaction", () => {
       hasMore: true,
       totalMessages: 10,
     });
+  });
+
+  it("projects visible WhatsApp group sends without delivery artifacts by default", async () => {
+    const deliveredText = "Here is the Amazon link: https://example.test/item";
+    const tool = createHistoryToolWithMessages([
+      {
+        role: "user",
+        content: [{ type: "text", text: "Can you send the Amazon link?" }],
+      },
+      {
+        role: "assistant",
+        provider: "openclaw",
+        model: "delivery-mirror",
+        content: [{ type: "text", text: deliveredText }],
+      },
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "toolCall",
+            id: "call-message-wa",
+            name: "message",
+            arguments: { action: "send", message: deliveredText },
+          },
+        ],
+      },
+      {
+        role: "toolResult",
+        toolName: "message",
+        toolCallId: "call-message-wa",
+        content: { ok: true, messageId: "wamid.1" },
+      },
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "Sent the Amazon link in WhatsApp." }],
+      },
+    ]);
+
+    const result = await tool.execute("call-wa-history", {
+      sessionKey: "agent:alfred:whatsapp:group:120363425559039020@g.us",
+    });
+    const details = result.details as { messages?: unknown[] };
+
+    expect(details.messages?.map(extractVisibleText)).toEqual([
+      "Can you send the Amazon link?",
+      deliveredText,
+    ]);
+    expect(details.messages).not.toContainEqual(
+      expect.objectContaining({ provider: "openclaw", model: "delivery-mirror" }),
+    );
+    expect(JSON.stringify(details.messages)).not.toContain('"type":"toolCall"');
+    expect(JSON.stringify(details.messages)).not.toContain("Sent the Amazon link in WhatsApp.");
+
+    const withTools = await tool.execute("call-wa-history-tools", {
+      sessionKey: "agent:alfred:whatsapp:group:120363425559039020@g.us",
+      includeTools: true,
+    });
+    const withToolsDetails = withTools.details as { messages?: unknown[] };
+    expect(withToolsDetails.messages).toContainEqual(
+      expect.objectContaining({ provider: "openclaw", model: "delivery-mirror" }),
+    );
+    expect(JSON.stringify(withToolsDetails.messages)).toContain("toolCall");
+  });
+
+  it("keeps standalone delivery mirrors when a later synthetic mirror has identical text", async () => {
+    const repeatedText = "Done.";
+    const tool = createHistoryToolWithMessages([
+      { role: "user", content: [{ type: "text", text: "Send the first redacted update." }] },
+      {
+        role: "assistant",
+        provider: "openclaw",
+        model: "delivery-mirror",
+        content: [{ type: "text", text: repeatedText }],
+      },
+      { role: "user", content: [{ type: "text", text: "Send the second redacted update." }] },
+      {
+        role: "assistant",
+        provider: "openclaw",
+        model: "delivery-mirror",
+        content: [{ type: "text", text: repeatedText }],
+      },
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "toolCall",
+            id: "call-message-repeated",
+            name: "message",
+            arguments: { action: "send", message: repeatedText },
+          },
+        ],
+      },
+      {
+        role: "toolResult",
+        toolName: "message",
+        toolCallId: "call-message-repeated",
+        content: { ok: true, messageId: "wamid.2" },
+      },
+      { role: "assistant", content: [{ type: "text", text: "Sent the update in WhatsApp." }] },
+    ]);
+
+    const result = await tool.execute("call-wa-history-repeated", {
+      sessionKey: "agent:alfred:whatsapp:group:120363425559039020@g.us",
+    });
+    const messages = ((result.details as { messages?: unknown[] }).messages ?? []) as unknown[];
+
+    expect(messages.map(extractVisibleText)).toEqual([
+      "Send the first redacted update.",
+      repeatedText,
+      "Send the second redacted update.",
+      repeatedText,
+    ]);
+    expect(JSON.stringify(messages)).not.toContain("delivery-mirror");
+    expect(JSON.stringify(messages)).not.toContain("openclawMessageToolMirror");
   });
 
   it("honors a scoped incarnation grant through the sandbox visibility clamp", async () => {

--- a/src/agents/tools/sessions-history-tool.ts
+++ b/src/agents/tools/sessions-history-tool.ts
@@ -482,7 +482,9 @@ export function createSessionsHistoryTool(opts?: {
       const rawMessages = Array.isArray(result?.messages) ? result.messages : [];
       const selectedMessages = includeTools
         ? rawMessages
-        : projectVisibleChatTranscriptMessages(rawMessages);
+        : projectVisibleChatTranscriptMessages(rawMessages, {
+            stripDeliveryMirrorMetadata: true,
+          });
       const sanitizedMessages = selectedMessages.map((message) => sanitizeHistoryMessage(message));
       const contentTruncated = sanitizedMessages.some((entry) => entry.truncated);
       const contentRedacted = sanitizedMessages.some((entry) => entry.redacted);

--- a/src/agents/tools/sessions-history-tool.ts
+++ b/src/agents/tools/sessions-history-tool.ts
@@ -10,6 +10,7 @@ import { getRuntimeConfig } from "../../config/config.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { callGateway } from "../../gateway/call.js";
 import { capArrayByJsonBytes } from "../../gateway/session-transcript-readers.js";
+import { projectVisibleChatTranscriptMessages } from "../../gateway/visible-chat-transcript.js";
 import { jsonUtf8Bytes } from "../../infra/json-utf8-bytes.js";
 import { redactToolPayloadText } from "../../logging/redact.js";
 import { truncateUtf16Safe } from "../../utils.js";
@@ -19,7 +20,6 @@ import {
   describeSessionsHistoryTool,
   SESSIONS_HISTORY_TOOL_DISPLAY_SUMMARY,
 } from "../tool-description-presets.js";
-import { stripToolMessages } from "./chat-history-text.js";
 import type { AnyAgentTool } from "./common.js";
 import {
   jsonResult,
@@ -480,7 +480,9 @@ export function createSessionsHistoryTool(opts?: {
           }),
       });
       const rawMessages = Array.isArray(result?.messages) ? result.messages : [];
-      const selectedMessages = includeTools ? rawMessages : stripToolMessages(rawMessages);
+      const selectedMessages = includeTools
+        ? rawMessages
+        : projectVisibleChatTranscriptMessages(rawMessages);
       const sanitizedMessages = selectedMessages.map((message) => sanitizeHistoryMessage(message));
       const contentTruncated = sanitizedMessages.some((entry) => entry.truncated);
       const contentRedacted = sanitizedMessages.some((entry) => entry.redacted);

--- a/src/agents/tools/sessions-list-tool.test.ts
+++ b/src/agents/tools/sessions-list-tool.test.ts
@@ -64,6 +64,27 @@ function getSessionsListDetails(result: { details?: unknown }): SessionsListDeta
   return result.details as SessionsListDetails;
 }
 
+function extractVisibleText(message: unknown): string | undefined {
+  if (!message || typeof message !== "object") {
+    return undefined;
+  }
+  const content = (message as { content?: unknown }).content;
+  if (typeof content === "string") {
+    return content;
+  }
+  if (!Array.isArray(content)) {
+    return undefined;
+  }
+  return content
+    .map((block) =>
+      block && typeof block === "object" && typeof (block as { text?: unknown }).text === "string"
+        ? (block as { text: string }).text
+        : undefined,
+    )
+    .filter((value): value is string => typeof value === "string")
+    .join("\n");
+}
+
 describe("sessions-list-tool", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -369,6 +390,151 @@ describe("sessions-list-tool", () => {
       pinned: false,
     });
     expect(getSessionsListDetails(result).sessions?.[0]).not.toHaveProperty("archivedAt");
+  });
+
+  it("projects visible WhatsApp group sends in hydrated messages", async () => {
+    const deliveredText = "Here is the Amazon link: https://example.test/item";
+    mocks.gatewayCall.mockImplementation(async (opts: unknown) => {
+      const request = opts as { method?: string };
+      if (request.method === "sessions.list") {
+        return {
+          path: "/tmp/sessions.json",
+          sessions: [
+            {
+              key: "agent:main:whatsapp:group:120363425559039020@g.us",
+              kind: "group",
+              sessionId: "sess-wa",
+            },
+          ],
+        };
+      }
+      if (request.method === "chat.history") {
+        return {
+          messages: [
+            { role: "user", content: [{ type: "text", text: "Can you send the Amazon link?" }] },
+            {
+              role: "assistant",
+              provider: "openclaw",
+              model: "delivery-mirror",
+              content: [{ type: "text", text: deliveredText }],
+            },
+            {
+              role: "assistant",
+              content: [
+                {
+                  type: "toolCall",
+                  id: "call-message-wa",
+                  name: "message",
+                  arguments: { action: "send", message: deliveredText },
+                },
+              ],
+            },
+            {
+              role: "toolResult",
+              toolName: "message",
+              toolCallId: "call-message-wa",
+              content: { ok: true, messageId: "wamid.1" },
+            },
+            {
+              role: "assistant",
+              content: [{ type: "text", text: "Sent the Amazon link in WhatsApp." }],
+            },
+          ],
+        };
+      }
+      return {};
+    });
+
+    const result = await createSessionsListTool({ config: VALID_CONFIG }).execute("call-list-wa", {
+      messageLimit: 5,
+    });
+    const messages = getSessionsListDetails(result).sessions?.[0]?.messages ?? [];
+
+    expect(messages.map(extractVisibleText)).toEqual([
+      "Can you send the Amazon link?",
+      deliveredText,
+    ]);
+    expect(messages).not.toContainEqual(
+      expect.objectContaining({ provider: "openclaw", model: "delivery-mirror" }),
+    );
+    expect(JSON.stringify(messages)).not.toContain('"type":"toolCall"');
+    expect(JSON.stringify(messages)).not.toContain("Sent the Amazon link in WhatsApp.");
+  });
+
+  it("keeps repeated identical standalone delivery mirrors in hydrated messages", async () => {
+    const repeatedText = "Done.";
+    mocks.gatewayCall.mockImplementation(async (opts: unknown) => {
+      const request = opts as { method?: string };
+      if (request.method === "sessions.list") {
+        return {
+          path: "/tmp/sessions.json",
+          sessions: [
+            {
+              key: "agent:main:whatsapp:group:120363425559039020@g.us",
+              kind: "group",
+              sessionId: "sess-wa-repeated",
+            },
+          ],
+        };
+      }
+      if (request.method === "chat.history") {
+        return {
+          messages: [
+            { role: "user", content: [{ type: "text", text: "Send the first redacted update." }] },
+            {
+              role: "assistant",
+              provider: "openclaw",
+              model: "delivery-mirror",
+              content: [{ type: "text", text: repeatedText }],
+            },
+            { role: "user", content: [{ type: "text", text: "Send the second redacted update." }] },
+            {
+              role: "assistant",
+              provider: "openclaw",
+              model: "delivery-mirror",
+              content: [{ type: "text", text: repeatedText }],
+            },
+            {
+              role: "assistant",
+              content: [
+                {
+                  type: "toolCall",
+                  id: "call-message-repeated",
+                  name: "message",
+                  arguments: { action: "send", message: repeatedText },
+                },
+              ],
+            },
+            {
+              role: "toolResult",
+              toolName: "message",
+              toolCallId: "call-message-repeated",
+              content: { ok: true, messageId: "wamid.2" },
+            },
+            {
+              role: "assistant",
+              content: [{ type: "text", text: "Sent the update in WhatsApp." }],
+            },
+          ],
+        };
+      }
+      return {};
+    });
+
+    const result = await createSessionsListTool({ config: VALID_CONFIG }).execute(
+      "call-list-wa-repeated",
+      { messageLimit: 7 },
+    );
+    const messages = getSessionsListDetails(result).sessions?.[0]?.messages ?? [];
+
+    expect(messages.map(extractVisibleText)).toEqual([
+      "Send the first redacted update.",
+      repeatedText,
+      "Send the second redacted update.",
+      repeatedText,
+    ]);
+    expect(JSON.stringify(messages)).not.toContain("delivery-mirror");
+    expect(JSON.stringify(messages)).not.toContain("openclawMessageToolMirror");
   });
 
   it.each([

--- a/src/agents/tools/sessions-list-tool.test.ts
+++ b/src/agents/tools/sessions-list-tool.test.ts
@@ -56,6 +56,7 @@ type SessionsListDetails = {
     archived?: boolean;
     pinned?: boolean;
     stateVersion?: number;
+    messages?: unknown[];
     [key: string]: unknown;
   }>;
 };

--- a/src/agents/tools/sessions-list-tool.ts
+++ b/src/agents/tools/sessions-list-tool.ts
@@ -449,7 +449,9 @@ export function createSessionsListTool(opts?: {
               params: { sessionKey: target.resolvedKey, limit: messageLimit },
             });
             const rawMessages = Array.isArray(history?.messages) ? history.messages : [];
-            const filtered = projectVisibleChatTranscriptMessages(rawMessages);
+            const filtered = projectVisibleChatTranscriptMessages(rawMessages, {
+              stripDeliveryMirrorMetadata: true,
+            });
             target.row.messages =
               filtered.length > messageLimit ? filtered.slice(-messageLimit) : filtered;
           },

--- a/src/agents/tools/sessions-list-tool.ts
+++ b/src/agents/tools/sessions-list-tool.ts
@@ -15,6 +15,7 @@ import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { callGateway } from "../../gateway/call.js";
 import { readSessionTitleFieldsFromTranscriptAsync } from "../../gateway/session-transcript-title-reader.js";
 import { deriveSessionTitle } from "../../gateway/session-utils.js";
+import { projectVisibleChatTranscriptMessages } from "../../gateway/visible-chat-transcript.js";
 import { isIncognitoSessionKey, resolveAgentIdFromSessionKey } from "../../routing/session-key.js";
 import { getSessionStateVersions } from "../../sessions/session-state-events.js";
 import { resolveDefaultAgentId } from "../agent-scope-config.js";
@@ -27,7 +28,6 @@ import {
   describeSessionVisibilityScope,
   SESSIONS_LIST_TOOL_DISPLAY_SUMMARY,
 } from "../tool-description-presets.js";
-import { stripToolMessages } from "./chat-history-text.js";
 import type { AnyAgentTool } from "./common.js";
 import {
   jsonResult,
@@ -449,7 +449,7 @@ export function createSessionsListTool(opts?: {
               params: { sessionKey: target.resolvedKey, limit: messageLimit },
             });
             const rawMessages = Array.isArray(history?.messages) ? history.messages : [];
-            const filtered = stripToolMessages(rawMessages);
+            const filtered = projectVisibleChatTranscriptMessages(rawMessages);
             target.row.messages =
               filtered.length > messageLimit ? filtered.slice(-messageLimit) : filtered;
           },

--- a/src/gateway/session-transcript-title-reader.ts
+++ b/src/gateway/session-transcript-title-reader.ts
@@ -15,6 +15,7 @@ import {
   toTranscriptReadScope,
   type ResolvedTranscriptReadTarget,
 } from "./session-transcript-readers.js";
+import { projectVisibleChatTranscriptMessages } from "./visible-chat-transcript.js";
 
 type SessionTitleFields = {
   firstUserMessage: string | null;
@@ -84,10 +85,19 @@ function findFirstTitleUserMessage(
 }
 
 function findLastMessageText(entries: readonly SessionTranscriptMessageEvent[]): string | null {
-  return (
-    entries.toReversed().map(sqliteMessageEventWithSeq).map(extractMessageText).find(Boolean) ??
-    null
-  );
+  const messages = entries.map(sqliteMessageEventWithSeq);
+  const projected = projectVisibleChatTranscriptMessages(messages, { stripEnvelope: false });
+  for (const message of projected.toReversed()) {
+    const role = extractMessageRole(message);
+    if (role !== "user" && role !== "assistant") {
+      continue;
+    }
+    const text = extractMessageText(message);
+    if (text) {
+      return text;
+    }
+  }
+  return null;
 }
 
 function readSqliteTitleFields(

--- a/src/gateway/visible-chat-transcript.ts
+++ b/src/gateway/visible-chat-transcript.ts
@@ -205,6 +205,8 @@ export function projectVisibleChatTranscriptMessages(
       return true;
     })
     .map((message) =>
-      options?.stripDeliveryMirrorMetadata === true ? stripDeliveryMirrorMetadata(message) : message,
+      options?.stripDeliveryMirrorMetadata === true
+        ? stripDeliveryMirrorMetadata(message)
+        : message,
     );
 }

--- a/src/gateway/visible-chat-transcript.ts
+++ b/src/gateway/visible-chat-transcript.ts
@@ -1,0 +1,208 @@
+// Visible chat transcript projection for agent-facing history/list surfaces.
+// Raw transcript bookkeeping remains on disk; these helpers shape what looks like chat.
+import {
+  isOpenClawDeliveryMirrorAssistantMessage,
+  isOpenClawMessageToolMirrorAssistantMessage,
+} from "../shared/transcript-only-openclaw-assistant.js";
+import { projectChatDisplayMessages } from "./chat-display-projection.js";
+
+function extractTextContent(message: unknown): string | undefined {
+  if (!message || typeof message !== "object" || Array.isArray(message)) {
+    return undefined;
+  }
+  const entry = message as { content?: unknown; text?: unknown };
+  if (typeof entry.text === "string") {
+    return entry.text;
+  }
+  if (typeof entry.content === "string") {
+    return entry.content;
+  }
+  if (!Array.isArray(entry.content)) {
+    return undefined;
+  }
+  const parts: string[] = [];
+  for (const block of entry.content) {
+    if (!block || typeof block !== "object" || Array.isArray(block)) {
+      return undefined;
+    }
+    const typed = block as { type?: unknown; text?: unknown };
+    if (typed.type !== "text" && typed.type !== "input_text" && typed.type !== "output_text") {
+      return undefined;
+    }
+    if (typeof typed.text === "string") {
+      parts.push(typed.text);
+    }
+  }
+  return parts.length > 0 ? parts.join("\n") : undefined;
+}
+
+function isTerminalSourceDeliveryConfirmation(message: unknown): boolean {
+  if (!message || typeof message !== "object" || Array.isArray(message)) {
+    return false;
+  }
+  if ((message as { role?: unknown }).role !== "assistant") {
+    return false;
+  }
+  const text = extractTextContent(message)?.trim();
+  if (!text) {
+    return false;
+  }
+  return /^Sent\b.+\bin\s+(?:WhatsApp|Telegram|Discord|Slack|Signal|SMS|iMessage|the chat)\.?$/i.test(
+    text,
+  );
+}
+
+function isToolHistoryBlockType(type: unknown): boolean {
+  if (typeof type !== "string") {
+    return false;
+  }
+  const normalized = type.trim().toLowerCase();
+  return (
+    normalized === "toolcall" ||
+    normalized === "tool_call" ||
+    normalized === "tooluse" ||
+    normalized === "tool_use" ||
+    normalized === "toolresult" ||
+    normalized === "tool_result"
+  );
+}
+
+function isAssistantToolOnlyMessage(message: Record<string, unknown>): boolean {
+  if (message.role !== "assistant" || !Array.isArray(message.content)) {
+    return false;
+  }
+  return (
+    message.content.length > 0 &&
+    message.content.every(
+      (block) =>
+        block &&
+        typeof block === "object" &&
+        !Array.isArray(block) &&
+        isToolHistoryBlockType((block as { type?: unknown }).type),
+    )
+  );
+}
+
+function isToolArtifactMessage(message: Record<string, unknown>): boolean {
+  const role = typeof message.role === "string" ? message.role.toLowerCase().replace(/_/g, "") : "";
+  return (
+    role === "tool" ||
+    role === "toolresult" ||
+    role === "function" ||
+    isAssistantToolOnlyMessage(message)
+  );
+}
+
+function normalizeMirrorText(message: unknown): string | undefined {
+  const text = extractTextContent(message)?.trim();
+  return text ? text : undefined;
+}
+
+function markSegmentReplacedDeliveryMirrors(
+  segment: Array<{ index: number; message: Record<string, unknown> }>,
+  replacedIndexes: Set<number>,
+): void {
+  if (segment.length === 0) {
+    return;
+  }
+  const syntheticMirrorCounts = new Map<string, number>();
+  const deliveryMirrorIndexes = new Map<string, number[]>();
+  for (const { index, message } of segment) {
+    const text = normalizeMirrorText(message);
+    if (!text) {
+      continue;
+    }
+    if (isOpenClawMessageToolMirrorAssistantMessage(message)) {
+      syntheticMirrorCounts.set(text, (syntheticMirrorCounts.get(text) ?? 0) + 1);
+      continue;
+    }
+    if (isOpenClawDeliveryMirrorAssistantMessage(message)) {
+      const indexes = deliveryMirrorIndexes.get(text) ?? [];
+      indexes.push(index);
+      deliveryMirrorIndexes.set(text, indexes);
+    }
+  }
+  for (const [text, count] of syntheticMirrorCounts) {
+    const indexes = deliveryMirrorIndexes.get(text);
+    if (!indexes?.length) {
+      continue;
+    }
+    for (const index of indexes.slice(-count)) {
+      replacedIndexes.add(index);
+    }
+  }
+}
+
+function replacedDeliveryMirrorIndexes(messages: Array<Record<string, unknown>>): Set<number> {
+  const replacedIndexes = new Set<number>();
+  let segment: Array<{ index: number; message: Record<string, unknown> }> = [];
+  for (let index = 0; index < messages.length; index += 1) {
+    const message = messages[index]!;
+    if (message.role === "user") {
+      markSegmentReplacedDeliveryMirrors(segment, replacedIndexes);
+      segment = [];
+    }
+    segment.push({ index, message });
+  }
+  markSegmentReplacedDeliveryMirrors(segment, replacedIndexes);
+  return replacedIndexes;
+}
+
+function stripDeliveryMirrorMetadata(message: Record<string, unknown>): Record<string, unknown> {
+  if (!isOpenClawDeliveryMirrorAssistantMessage(message)) {
+    return message;
+  }
+  const { provider, model, openclawDeliveryMirror, ...visible } = message;
+  void provider;
+  void model;
+  void openclawDeliveryMirror;
+  return visible;
+}
+
+export function projectVisibleChatTranscriptMessages(
+  messages: unknown[],
+  options?: { maxChars?: number; stripEnvelope?: boolean },
+): Array<Record<string, unknown>> {
+  const projected = projectChatDisplayMessages(messages, options);
+  const replacedMirrorIndexes = replacedDeliveryMirrorIndexes(projected);
+  const deliveryEvidenceIndexes = new Set<number>();
+  const withoutToolArtifacts = projected.filter((message, index) => {
+    if (isToolArtifactMessage(message)) {
+      deliveryEvidenceIndexes.add(index);
+      return false;
+    }
+    if (!isOpenClawDeliveryMirrorAssistantMessage(message)) {
+      return true;
+    }
+    deliveryEvidenceIndexes.add(index);
+    return !replacedMirrorIndexes.has(index);
+  });
+
+  let sawDeliveryEvidence = false;
+  let visibleIndex = 0;
+  return withoutToolArtifacts
+    .filter((message) => {
+      while (visibleIndex < projected.length && projected[visibleIndex] !== message) {
+        if (deliveryEvidenceIndexes.has(visibleIndex)) {
+          sawDeliveryEvidence = true;
+        }
+        visibleIndex += 1;
+      }
+      if (deliveryEvidenceIndexes.has(visibleIndex)) {
+        sawDeliveryEvidence = true;
+      }
+      visibleIndex += 1;
+      if (isOpenClawMessageToolMirrorAssistantMessage(message)) {
+        sawDeliveryEvidence = true;
+        return true;
+      }
+      if (sawDeliveryEvidence && isTerminalSourceDeliveryConfirmation(message)) {
+        return false;
+      }
+      if (message.role === "user") {
+        sawDeliveryEvidence = false;
+      }
+      return true;
+    })
+    .map(stripDeliveryMirrorMetadata);
+}

--- a/src/gateway/visible-chat-transcript.ts
+++ b/src/gateway/visible-chat-transcript.ts
@@ -161,7 +161,7 @@ function stripDeliveryMirrorMetadata(message: Record<string, unknown>): Record<s
 
 export function projectVisibleChatTranscriptMessages(
   messages: unknown[],
-  options?: { maxChars?: number; stripEnvelope?: boolean },
+  options?: { maxChars?: number; stripEnvelope?: boolean; stripDeliveryMirrorMetadata?: boolean },
 ): Array<Record<string, unknown>> {
   const projected = projectChatDisplayMessages(messages, options);
   const replacedMirrorIndexes = replacedDeliveryMirrorIndexes(projected);
@@ -204,5 +204,7 @@ export function projectVisibleChatTranscriptMessages(
       }
       return true;
     })
-    .map(stripDeliveryMirrorMetadata);
+    .map((message) =>
+      options?.stripDeliveryMirrorMetadata === true ? stripDeliveryMirrorMetadata(message) : message,
+    );
 }


### PR DESCRIPTION
## What Problem This Solves

Replacement for closed-unmerged PR #97303.

Visible session surfaces can expose internal delivery artifacts as if they were normal chat: tool-call-only assistant rows, `toolResult` rows, raw `provider=openclaw` / `model=delivery-mirror` transcript bookkeeping, and terminal confirmations like `Sent ... in WhatsApp.` These pollute `sessions_history(includeTools=false)`, hydrated `sessions_list` messages, and last-message previews.

MC: `js7chanc5ewxg2jwf6aqwbmdt989g9fj`.

## Summary

- Add a shared visible-chat transcript projection helper.
- Use it for `sessions_history(includeTools=false)`.
- Use it for hydrated `sessions_list(messageLimit=...)` messages.
- Use it for transcript-derived last-message previews.
- Preserve raw records for replay/debugging and `includeTools=true`.
- Preserve delivered assistant text from standalone delivery mirrors, but strip delivery-mirror metadata from visible rows.
- Suppress terminal source-delivery confirmations when prior delivery/tool evidence exists in the same visible segment.
- Keep repeated identical delivered text visible without letting a later message-tool send hide an earlier standalone delivery.

## Evidence

Passed locally on branch `harvey/visible-transcript-projection-replacement` at `1009099745e`:

```bash
./node_modules/.bin/vitest --config test/vitest/vitest.agents.config.ts run src/agents/tools/sessions-history-tool.test.ts src/agents/tools/sessions-list-tool.test.ts -t "projects visible WhatsApp|keeps standalone delivery mirrors|keeps repeated identical standalone"
# Test Files 2 passed; Tests 4 passed, 34 skipped

./node_modules/.bin/vitest --config test/vitest/vitest.gateway.config.ts run src/gateway/session-utils.fs.test.ts -t "projects visible message-tool sends|handles repeated identical delivery text"
# Test Files 3 passed; Tests 6 passed, 213 skipped

git diff --check
# clean

node scripts/run-tsgo.mjs -p tsconfig.core.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core.tsbuildinfo
# clean

node scripts/check-extension-package-tsc-boundary.mjs --mode=compile
# extension package boundary check passed; compiled plugins: 125
```

Full focused file command note:

```bash
node scripts/test-projects.mjs src/agents/tools/sessions-history-tool.test.ts src/agents/tools/sessions-list-tool.test.ts src/gateway/session-utils.fs.test.ts
```

Earlier local full focused file run caveat: gateway shard passed all 73 tests. The agents shard passed the new visible-projection regressions, but three pre-existing scoped-access tests failed under local Node `22.22.0` because OpenClaw's SQLite guard requires Node `22.22.3+`, `24.15.0+`, or `25.9.0+`.

## Relationship To #97303

PR #97303 is closed unmerged at head `d1184d7c01cbd8b27fd1de0cf2af370c1349df1b`; current `origin/main` does not contain that head. This PR ports the accepted behavior forward onto current `main` instead of reopening the stale branch.
