### PR TITLE
docs(browser): correct Docker sandbox setup

### DIFF
--- a/docs/gateway/config-agents.md
+++ b/docs/gateway/config-agents.md
@@ -791,7 +791,7 @@ Optional sandboxing for the embedded agent. See [Sandboxing](/gateway/sandboxing
           vncPort: 5900,
           noVncPort: 6080,
           headless: false,
-          enableNoVnc: true,
+          noVncEnabled: true,
           allowHostControl: false,
           autoStart: true,
           autoStartTimeoutMs: 12000,
@@ -921,8 +921,8 @@ Codex app-server turns in an active OpenClaw sandbox use this same egress settin
 
 **`docker.binds`** mounts additional host directories; global and per-agent binds are merged.
 
-**Sandboxed browser** (`sandbox.browser.enabled`, default `false`): Chromium + CDP in a container. noVNC URL injected into system prompt. Does not require `browser.enabled` in `openclaw.json`.
-noVNC observer access uses VNC auth by default and OpenClaw emits a short-lived token URL (instead of exposing the password in the shared URL).
+**Sandboxed browser** (`sandbox.browser.enabled`, default `false`): Chromium + CDP in a container. Does not require `browser.enabled` in `openclaw.json`.
+noVNC observer access is password-protected and brokered through a one-time, authenticated bootstrap URL. The observer URL is deliberately omitted from model-visible system prompt context.
 
 - `allowHostControl: false` (default) blocks sandboxed sessions from targeting the host browser.
 - `network` defaults to `openclaw-sandbox-browser` (dedicated bridge network). Set to `bridge` only when you explicitly want global bridge connectivity. `"host"` is blocked here too.

--- a/docs/gateway/sandboxing.md
+++ b/docs/gateway/sandboxing.md
@@ -397,7 +397,7 @@ If you installed OpenClaw via `npm install -g openclaw`, use the inline `docker 
     scripts/sandbox-browser-setup.sh
     ```
 
-    From an npm install, build using [`scripts/docker/sandbox/Dockerfile.browser`](https://github.com/openclaw/openclaw/blob/main/scripts/docker/sandbox/Dockerfile.browser) from the repository.
+    The npm package does not include the browser Dockerfile or entrypoint. Use a source checkout to build this image.
 
   </Step>
 </Steps>
@@ -432,7 +432,7 @@ image or `sandbox.docker.env`.
     - `--password-store=basic`
     - `--use-mock-keychain`
     - `--headless=new` when `browser.headless` is enabled.
-    - `--no-sandbox --disable-setuid-sandbox` when `browser.noSandbox` is enabled.
+    - `--no-sandbox --disable-setuid-sandbox` (always enabled in the sandbox browser container).
     - `--disable-3d-apis`, `--disable-gpu`, `--disable-software-rasterizer` by default; these graphics-hardening flags help containers without GPU support. Set `OPENCLAW_BROWSER_DISABLE_GRAPHICS_FLAGS=0` if your workload needs WebGL or other 3D features.
     - `--disable-extensions` by default; set `OPENCLAW_BROWSER_DISABLE_EXTENSIONS=0` for extension-reliant flows.
     - `--renderer-process-limit=2` by default; controlled by `OPENCLAW_BROWSER_RENDERER_PROCESS_LIMIT=<N>`, where `0` keeps Chromium's default.

--- a/docs/help/faq.md
+++ b/docs/help/faq.md
@@ -387,8 +387,7 @@ First-run Q&A - install, onboard, auth routes, subscriptions, initial failures -
 
     - Persist `/home/node` with `OPENCLAW_HOME_VOLUME` so caches survive.
     - Bake system deps into the image with `OPENCLAW_IMAGE_APT_PACKAGES`.
-    - Install Playwright browsers via the bundled CLI: `node /app/node_modules/playwright-core/cli.js install chromium`.
-    - Set `PLAYWRIGHT_BROWSERS_PATH` and persist that path.
+    - Bake Playwright Chromium and its system dependencies into the image with `OPENCLAW_INSTALL_BROWSER=1`.
 
     Docs: [Docker](/install/docker), [Browser](/tools/browser).
 

--- a/docs/install/docker.md
+++ b/docs/install/docker.md
@@ -508,12 +508,7 @@ If you installed from the older `scripts/shell-helpers/clawdock-helpers.sh` path
     2. **Bake system deps**: `export OPENCLAW_IMAGE_APT_PACKAGES="git curl jq"`
     3. **Bake Python deps**: `export OPENCLAW_IMAGE_PIP_PACKAGES="requests==2.32.5 humanize==4.14.0"`
     4. **Bake Playwright Chromium**: `export OPENCLAW_INSTALL_BROWSER=1`, or use the official `-browser` image tag
-    5. **Or install Playwright browsers into a persisted volume**:
-       ```bash
-       docker compose run --rm openclaw-cli \
-         node /app/node_modules/playwright-core/cli.js install chromium
-       ```
-    6. **Persist browser downloads**: use `OPENCLAW_HOME_VOLUME` or `OPENCLAW_EXTRA_MOUNTS`. OpenClaw auto-detects the image's Playwright-managed Chromium on Linux.
+    5. **Persist browser downloads and caches**: use `OPENCLAW_HOME_VOLUME` or `OPENCLAW_EXTRA_MOUNTS`. OpenClaw auto-detects the image's Playwright-managed Chromium on Linux.
 
   </Accordion>
 

--- a/docs/tools/browser-control.md
+++ b/docs/tools/browser-control.md
@@ -147,17 +147,11 @@ For custom images, bake Chromium into the image:
 OPENCLAW_INSTALL_BROWSER=1 ./scripts/docker/setup.sh
 ```
 
-For an existing image, install through the bundled CLI instead:
-
-```bash
-docker compose run --rm openclaw-cli \
-  node /app/node_modules/playwright-core/cli.js install chromium
-```
-
-To persist browser downloads, set `PLAYWRIGHT_BROWSERS_PATH` (for example,
-`/home/node/.cache/ms-playwright`) and make sure `/home/node` is persisted via
-`OPENCLAW_HOME_VOLUME` or a bind mount. OpenClaw auto-detects the persisted
-Chromium on Linux. See [Docker](/install/docker).
+The browser also needs system libraries, so installing Chromium in a one-off
+Compose container is not durable. Rebuild the image with
+`OPENCLAW_INSTALL_BROWSER=1` instead. To persist browser downloads and other
+caches, persist `/home/node` with `OPENCLAW_HOME_VOLUME` or a bind mount. See
+[Docker](/install/docker).
 
 ## How it works (internal)
 


### PR DESCRIPTION
## What Problem This Solves

Fixes browser and sandbox documentation that referenced a retired noVNC key, claimed the observer URL was model-visible, suggested a non-durable Playwright install in a throwaway Compose container, and implied npm packages include sandbox-browser image inputs.

## Why This Change Was Made

Aligns the docs with the current runtime and packaging contracts: `noVncEnabled`, authenticated one-time observer bootstrap outside model-visible prompt context, browser dependencies baked into Docker images, and source-checkout-only sandbox browser image builds.

## User Impact

Operators get commands and configuration examples that work after container recreation and no longer depend on files absent from the npm package.

## Evidence

- `node scripts/check-docs-mdx.mjs docs/gateway/config-agents.md docs/gateway/sandboxing.md docs/help/faq.md docs/install/docker.md docs/tools/browser-control.md`
- `node scripts/docs-link-audit.mjs` (6,274 internal links, 0 broken)
- `node scripts/check-docs-i18n-glossary.mjs`
- `./node_modules/.bin/oxfmt --check ...`
- `git diff --check`
- autoreview clean (0.89)
- verified npm package allowlist excludes `scripts/docker/sandbox/Dockerfile.browser` and `scripts/sandbox-browser-entrypoint.sh`
- verified sandbox prompt projection omits `noVncUrl` while the bridge consumes one-time authenticated observer tokens
- verified the Docker build installs Playwright Chromium with `--with-deps` at image build time
