### PR TITLE
test(codex): de-flake attempt turn-watch timing tests

### DIFF
--- a/extensions/codex/src/app-server/run-attempt.turn-watches.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.turn-watches.test.ts
@@ -166,6 +166,10 @@ async function runClientCloseScenario(notifications: CodexServerNotification[]) 
 
 describe("createCodexAttemptTurnWatchController", () => {
   it("reschedules the attempt watch when notification progress shortens its timeout", async () => {
+    // Controller-only test, so the watch timers are the sole clock consumer and
+    // can be driven deterministically instead of raced against a real deadline.
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
     const onTimeout = vi.fn();
     const onAbort = vi.fn();
     const controller = createCodexAttemptTurnWatchController({
@@ -197,19 +201,18 @@ describe("createCodexAttemptTurnWatchController", () => {
 
     try {
       controller.armAttemptIdleWatch();
+      // Arms the default 200ms attempt watch at T=0.
       controller.touchActivity("turn:start", { attemptProgress: true });
-      await new Promise((resolve) => {
-        setTimeout(resolve, 20);
-      });
+      await vi.advanceTimersByTimeAsync(20);
+      // Progress at T=20 shortens the budget to 40ms, so the watch must be
+      // rescheduled from T=200 down to T=60 instead of keeping the old timer.
       controller.noteNotificationReceived("response.output_text.delta", {
         attemptProgress: true,
         attemptTimeoutMs: 40,
       });
 
-      await vi.waitFor(() => expect(onAbort).toHaveBeenCalledWith("turn_progress_idle_timeout"), {
-        interval: 5,
-        timeout: 120,
-      });
+      await vi.advanceTimersByTimeAsync(40);
+      expect(onAbort).toHaveBeenCalledWith("turn_progress_idle_timeout");
       expect(onTimeout).toHaveBeenCalledWith(
         expect.objectContaining({
           kind: "progress",
@@ -219,6 +222,7 @@ describe("createCodexAttemptTurnWatchController", () => {
       );
     } finally {
       controller.clearAllTimers();
+      vi.useRealTimers();
     }
   });
 });
@@ -762,16 +766,24 @@ describe("runCodexAppServerAttempt turn watches", () => {
   });
 
   it("keeps a progressing active turn alive beyond the original attempt timeout", async () => {
+    // The attempt watch is armed from `turn:start` inside the attempt, tens of
+    // ms before anything this test can observe, so budget slack cannot be
+    // measured from here. Keep each progress gap an order of magnitude under
+    // the watchdog and drive the phase from wall clock: a loaded runner then
+    // stretches gaps without inverting the ratio into a false idle timeout.
+    const attemptIdleTimeoutMs = 1_000;
+    const progressIntervalMs = 50;
+    const progressPhaseMs = attemptIdleTimeoutMs + 200;
     const harness = createStartedThreadHarness();
     const params = createTestParams();
-    params.timeoutMs = 100;
+    params.timeoutMs = attemptIdleTimeoutMs;
     const onRunProgress = vi.fn();
     params.onRunProgress = onRunProgress;
 
     const run = runCodexAppServerAttempt(params, {
-      turnCompletionIdleTimeoutMs: 300,
-      turnAssistantCompletionIdleTimeoutMs: 300,
-      turnTerminalIdleTimeoutMs: 300,
+      turnCompletionIdleTimeoutMs: attemptIdleTimeoutMs * 3,
+      turnAssistantCompletionIdleTimeoutMs: attemptIdleTimeoutMs * 3,
+      turnTerminalIdleTimeoutMs: attemptIdleTimeoutMs * 3,
     });
     await harness.waitForMethod("turn/start");
     await vi.waitFor(
@@ -782,28 +794,24 @@ describe("runCodexAppServerAttempt turn watches", () => {
       fastWait,
     );
 
-    await new Promise((resolve) => {
-      setTimeout(resolve, 60);
-    });
-    await harness.notify(
-      rawItemCompleted({
-        type: "message",
-        id: "raw-progress-1",
-        role: "assistant",
-        content: [{ type: "output_text", text: "Still working." }],
-      }),
-    );
-    await new Promise((resolve) => {
-      setTimeout(resolve, 60);
-    });
-    await harness.notify(
-      rawItemCompleted({
-        type: "message",
-        id: "raw-progress-2",
-        role: "assistant",
-        content: [{ type: "output_text", text: "Almost done." }],
-      }),
-    );
+    const progressStartedAt = Date.now();
+    let sentProgressNotifications = 0;
+    let progressPhaseElapsedMs = 0;
+    while (progressPhaseElapsedMs < progressPhaseMs) {
+      await new Promise((resolve) => {
+        setTimeout(resolve, progressIntervalMs);
+      });
+      sentProgressNotifications += 1;
+      await harness.notify(
+        rawItemCompleted({
+          type: "message",
+          id: `raw-progress-${sentProgressNotifications}`,
+          role: "assistant",
+          content: [{ type: "output_text", text: "Still working." }],
+        }),
+      );
+      progressPhaseElapsedMs = Date.now() - progressStartedAt;
+    }
 
     expect(harness.request.mock.calls.some(([method]) => method === "turn/interrupt")).toBe(false);
     await harness.completeTurn({ threadId: "thread-1", turnId: "turn-1" });
@@ -815,11 +823,17 @@ describe("runCodexAppServerAttempt turn watches", () => {
       promptError: null,
     });
     expect(harness.request.mock.calls.some(([method]) => method === "turn/interrupt")).toBe(false);
+    // Measured from after turn:start, so this understates the real idle span:
+    // without it the assertions above could pass on a turn that never outlived
+    // the original attempt timeout, i.e. proving nothing.
+    expect(progressPhaseElapsedMs).toBeGreaterThan(attemptIdleTimeoutMs);
     const progressReasons = onRunProgress.mock.calls.map(([info]) => info.reason);
     expect(progressReasons).toContain("turn:start");
+    // One progress reason per notification sent: still exact, just no longer
+    // pinned to a hardcoded count.
     expect(
       progressReasons.filter((reason) => reason === "notification:rawResponseItem/completed"),
-    ).toHaveLength(2);
+    ).toHaveLength(sentProgressNotifications);
   });
 
   it("does not count non-turn app-server requests as turn attempt progress", async () => {
@@ -1162,17 +1176,29 @@ describe("runCodexAppServerAttempt turn watches", () => {
   });
 
   it("counts pending secret user input requests as turn attempt progress", async () => {
+    // `item/tool/requestUserInput` records attempt progress but never suppresses
+    // the attempt watch while pending, so this proves the turn outlives the
+    // deadline `turn:start` alone would have set. That needs
+    // preRequestIdleMs + pendingHoldMs > attemptIdleTimeoutMs > pendingHoldMs;
+    // both bounds are asserted below so load can never make it vacuous.
+    // The two request resets in run-attempt-server-requests.ts land ~20ms apart
+    // (`finally` runs at `return`, not when the bridge promise settles), so this
+    // cannot attribute survival to `:start` over `:response` — it guards the
+    // pair. Mutating either one alone still passes; mutating both fails.
+    const attemptIdleTimeoutMs = 1_000;
+    const preRequestIdleMs = 500;
+    const pendingHoldMs = 700;
     const harness = createStartedThreadHarness();
     const params = createTestParams();
-    params.timeoutMs = 250;
+    params.timeoutMs = attemptIdleTimeoutMs;
     params.onBlockReply = vi.fn();
     const onRunProgress = vi.fn();
     params.onRunProgress = onRunProgress;
 
     const run = runCodexAppServerAttempt(params, {
-      turnCompletionIdleTimeoutMs: 600,
-      turnAssistantCompletionIdleTimeoutMs: 600,
-      turnTerminalIdleTimeoutMs: 600,
+      turnCompletionIdleTimeoutMs: attemptIdleTimeoutMs * 3,
+      turnAssistantCompletionIdleTimeoutMs: attemptIdleTimeoutMs * 3,
+      turnTerminalIdleTimeoutMs: attemptIdleTimeoutMs * 3,
     });
     await harness.waitForMethod("turn/start");
     await vi.waitFor(
@@ -1182,9 +1208,12 @@ describe("runCodexAppServerAttempt turn watches", () => {
         ),
       fastWait,
     );
+    // Later than the attempt's own turn:start, so every span derived from it
+    // understates the real idle time. Safe for the lower bound below.
+    const turnObservedAt = Date.now();
 
     await new Promise((resolve) => {
-      setTimeout(resolve, 75);
+      setTimeout(resolve, preRequestIdleMs);
     });
     const response = harness.handleServerRequest({
       id: "request-user-input",
@@ -1209,11 +1238,19 @@ describe("runCodexAppServerAttempt turn watches", () => {
       },
     });
     await vi.waitFor(() => expect(params.onBlockReply).toHaveBeenCalledTimes(1), fastWait);
+    const pendingStartedAt = Date.now();
     await new Promise((resolve) => {
-      setTimeout(resolve, 125);
+      setTimeout(resolve, pendingHoldMs);
     });
+    const pendingElapsedMs = Date.now() - pendingStartedAt;
 
     expect(harness.request.mock.calls.some(([method]) => method === "turn/interrupt")).toBe(false);
+    // Upper bound: the hold must stay inside one attempt budget, or a fired
+    // watch would be correct behavior rather than the regression under guard.
+    expect(pendingElapsedMs).toBeLessThan(attemptIdleTimeoutMs);
+    // Lower bound: the turn has now outlived the deadline turn:start alone set,
+    // so surviving proves the pending request moved it.
+    expect(Date.now() - turnObservedAt).toBeGreaterThan(attemptIdleTimeoutMs);
     expect(queueActiveRunMessageForTest("session-1", "2")).toBe(true);
     await expect(response).resolves.toEqual({
       answers: { mode: { answers: ["Deep"] } },


### PR DESCRIPTION
## What Problem This Solves

Three timing tests in `extensions/codex/src/app-server/run-attempt.turn-watches.test.ts` race a real wall-clock progress source against a short watchdog budget. This is the same flake class fixed for the OpenAI transport in #115196.

The headline case is `"keeps a progressing active turn alive beyond the original attempt timeout"`. It set `params.timeoutMs = 100` — which is the attempt idle watchdog, floored at 100ms by `run-attempt-turn-state.ts:99` — and paced two `rawResponseItem/completed` notifications with real 60ms sleeps.

The static margin looks like 40ms per gap, but it is much thinner than that. The attempt watch is armed at `turn:start` **inside** the attempt (`run-attempt-active-turn.ts:117-118`), tens of ms before `await harness.waitForMethod("turn/start")` returns, so the test's 60ms sleep is measured from a point the watchdog clock has already passed. Instrumenting the test showed the first gap consuming 66-77ms of the 100ms budget as measured by the test, while the controller reported `idleMs` of 101-130 against `timeoutMs: 100`.

## Why This Change Was Made

The behavior under test is worth keeping, so all three tests are hardened rather than deleted or loosened.

**`:764` progressing turn** — `attemptIdleTimeoutMs` 100 -> 1000 and the progress interval 60ms -> 50ms, moving the gap/budget ratio from ~1.7x to 20x. The fixed `reasoningChunkCount`-style pair of notifications becomes a wall-clock loop that emits progress until the phase exceeds the watchdog, so "the turn outlived the original attempt timeout" holds by construction on a slow runner instead of being an implicit product of two constants. The exact-count assertion is preserved as `toHaveLength(sentProgressNotifications)` — still one progress reason per notification, just no longer pinned to a hardcoded `2`.

**`:1164` pending user input** — this one was both fragile and nearly vacuous: it asserted no interrupt at roughly t=200ms against a 250ms budget, so a correct-but-slow run failed while a broken one could pass. Reading `run-attempt-server-requests.ts` showed a pending `item/tool/requestUserInput` records attempt progress but never suppresses the attempt watch, so the provable property is that the turn outlives the deadline `turn:start` alone would have set. That needs `preRequestIdleMs + pendingHoldMs > attemptIdleTimeoutMs > pendingHoldMs`, and both bounds are now asserted explicitly, so load cannot silently make it vacuous in either direction.

**`:168` reschedule-on-shortened-timeout** — this one drives `createCodexAttemptTurnWatchController` directly with no attempt runtime, so `vi.useFakeTimers()` transfers cleanly from the sibling `attempt-turn-watches.test.ts`. The `vi.waitFor(..., { timeout: 120 })` race against a 40ms deadline is replaced with `advanceTimersByTimeAsync`, making it fully deterministic.

Evaluated and deliberately left alone: `:1016` (`timeoutMs = 500` vs a 60ms sleep, ~8x margin) and `:1096` (`turnCompletionIdleTimeoutMs: 15` exceeded by design, which is already the robust construction). Neither showed risk, and churning them would add diff without removing a failure mode.

## User Impact

None. Test-only change; no production code is touched.

## Evidence

**Codex protocol gate.** Verified the surfaces these tests exercise against sibling `../codex` at `899539c03a` (harness pinned to `@openai/codex` 0.145.0):

- `rawResponseItem/completed` notification — `codex-rs/app-server-protocol/src/protocol/common.rs:1682`
- `item/tool/requestUserInput` server->client request (has both `params` and `response`, so the app-server blocks on our answer) — `codex-rs/app-server-protocol/src/protocol/common.rs:1513-1516`, sent at `codex-rs/app-server-client/src/lib.rs:1866`
- `isSecret` question field — `codex-rs/protocol/src/request_user_input.rs:23-26`
- `turn/interrupt` client->server request — `codex-rs/app-server-protocol/src/protocol/common.rs:843`

**Reproduction.** Clean on an idle machine (5/5 green), so the flake was provoked with 2x CPU saturation (32 busy loops on 16 cores). Before the fix, `-t "keeps a progressing active turn alive"` failed **5 of 6 runs**, every failure identical:

```
codex app-server turn idle timed out waiting for progress
{"idleMs":101,"timeoutMs":100,"lastActivityReason":"turn:start"}
methods=["thread/start","turn/start","turn/interrupt","thread/unsubscribe"]
```

After the fix, the same filter under the same 2x saturation: **6 of 6 green**.

**Mutation proofs** that each test still catches the regression it guards:

| Test | Mutation | Result |
| --- | --- | --- |
| `:764` | `attemptProgress: true` -> `false` at `attempt-notification-state.ts:114` | FAILS |
| `:1164` | remove attempt progress from **both** `run-attempt-server-requests.ts:81` and `:339` | FAILS |
| `:168` | drop `scheduleAttemptIdleWatch()` from `recordAttemptProgress` | FAILS |

One honest limitation, recorded in an inline comment rather than glossed over: mutating `:start` or `:response` **alone** for `:1164` still passes. The two resets land ~20ms apart because `finally` runs when `return` is evaluated, not when the bridge promise settles, so this test guards the pair rather than attributing survival to the pending-request reset specifically. That was true before this change too; it is now written down.

Other proof:

- `node scripts/run-vitest.mjs extensions/codex/src/app-server/run-attempt.turn-watches.test.ts` -> 94 passed
- `node scripts/run-vitest.mjs extensions/codex/src/app-server/attempt-turn-watches.test.ts` -> 29 passed
- `node scripts/check-changed.mjs` -> exit 0 (lint + typecheck, delegated to Blacksmith Testbox `tbx_01kymk7fersgkvx3dvq73e7p14`)
- `oxfmt --check` clean, `git diff --check` clean
- `autoreview --mode uncommitted` (codex / gpt-5.6-sol / xhigh) -> `autoreview clean: no accepted/actionable findings reported`
