### PR TITLE
fix(discord): require requester identity for privileged tool actions [AI]

### DIFF
--- a/extensions/discord/src/channel.test.ts
+++ b/extensions/discord/src/channel.test.ts
@@ -237,6 +237,26 @@ describe("discordPlugin outbound", () => {
     );
   });
 
+  it("requires trusted requester identity for registered privileged tool actions", () => {
+    expect(
+      discordPlugin.actions?.requiresTrustedRequesterSender?.({
+        action: "channel-delete",
+        toolContext: { currentChannelProvider: "discord" },
+      }),
+    ).toBe(true);
+    expect(
+      discordPlugin.actions?.requiresTrustedRequesterSender?.({
+        action: "channel-delete",
+      }),
+    ).toBe(false);
+    expect(
+      discordPlugin.actions?.requiresTrustedRequesterSender?.({
+        action: "read",
+        toolContext: { currentChannelProvider: "discord" },
+      }),
+    ).toBe(false);
+  });
+
   it("adds Discord mention formatting to agent prompt hints", () => {
     const hints = discordPlugin.agentPrompt?.messageToolHints?.({} as never) ?? [];
 

--- a/extensions/discord/src/channel.ts
+++ b/extensions/discord/src/channel.ts
@@ -199,6 +199,12 @@ const discordMessageActions = {
     resolveRuntimeDiscordMessageActions()?.describeMessageTool?.(ctx) ??
     discordMessageActionsImpl.describeMessageTool?.(ctx) ??
     null,
+  requiresTrustedRequesterSender: (
+    ctx: Parameters<NonNullable<ChannelMessageActionAdapter["requiresTrustedRequesterSender"]>>[0],
+  ) =>
+    resolveRuntimeDiscordMessageActions()?.requiresTrustedRequesterSender?.(ctx) ??
+    discordMessageActionsImpl.requiresTrustedRequesterSender?.(ctx) ??
+    false,
   extractToolSend: (
     ctx: Parameters<NonNullable<ChannelMessageActionAdapter["extractToolSend"]>>[0],
   ) =>


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Prevents privileged Discord tool actions from running without a requester identity when they originate from an agent tool context.

## Why This Change Was Made

The registered Discord action adapter now preserves the channel-owned requester trust check while retaining the existing hot-runtime override and built-in fallback behavior. The change is limited to Discord action dispatch wiring and adds regression coverage at the registered plugin boundary.

## User Impact

Discord operators can expect privileged guild administration actions such as channel deletion to reject tool-driven calls that lack requester identity. Non-privileged actions and non-tool invocations retain their existing behavior.

## Evidence

- `git diff --check`
- `./node_modules/.bin/oxfmt --check extensions/discord/src/channel.ts extensions/discord/src/channel.test.ts`
- `node scripts/run-vitest.mjs extensions/discord/src/channel.test.ts` — 29 tests passed

AI-assisted change. I reviewed the implementation and focused test coverage.
