### PR TITLE
test(ui): stop the agents tools panel leaking its anchor fragment

### DIFF
--- a/ui/src/pages/agents/panels-tools-skills.browser.test.ts
+++ b/ui/src/pages/agents/panels-tools-skills.browser.test.ts
@@ -1,8 +1,19 @@
 // Control UI tests cover agents panels tools skills behavior.
 import { render } from "lit";
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
 import type { SkillStatusEntry } from "../../api/types.ts";
 import { renderAgentSkills, renderAgentTools } from "./panels-tools-skills.ts";
+
+// Clicking a runtime chip drives `panels-tools-skills.ts` to set the window
+// fragment to that tool's anchor. The repo `ui` shard runs this file in the
+// shared jsdom graph (`test/vitest/vitest.ui.config.ts`, isolate:false), so a
+// fragment left behind leaks into any later file that asserts on the ambient
+// hash.
+afterEach(() => {
+  if (window.location.hash) {
+    window.history.replaceState(null, "", `${window.location.pathname}${window.location.search}`);
+  }
+});
 
 function createBaseParams(overrides: Partial<Parameters<typeof renderAgentTools>[0]> = {}) {
   return {


### PR DESCRIPTION
## What Problem This Solves

Three `ConfigPage moved section routes` cases in
`ui/src/pages/config/config-page.test.ts` fail intermittently, asserting the
preserved URL fragment is empty but receiving `#agent-tool-read`:

```
- "hash": "",
+ "hash": "#agent-tool-read",
```

The fragment is not produced by that file. `ui/src/pages/agents/panels-tools-skills.browser.test.ts`
clicks a runtime chip, which drives `panels-tools-skills.ts` to set the window
fragment to that tool's anchor (`agent-tool-${id}`), and never restores it.

The repo `ui` shard runs both files in one shared jsdom graph:
`test/vitest/vitest.ui.config.ts` sets `environment: "jsdom"` and
`isolate: false`, and its `ui/src/**/*.test.ts` glob matches `.browser.test.ts`
files. (`ui/vitest.config.ts` splits browser tests into their own project, but
that is the UI-local dev config, not what the shard runs.) So whenever shard
packing places `config-page.test.ts` after the panels file, it reads the leaked
fragment and fails.

## Why This Change Was Made

`isolate: false` is a deliberate speed contract for this 339-file shard, which
puts the burden on any test that mutates shared global state to restore it. The
fix is one `afterEach` in the file that sets the fragment, restoring the
location to its path and query.

Fixing the mutator rather than the assertion is the ownership-correct half: the
victim is not doing anything wrong by asserting on the ambient fragment, and any
future file that asserts on it would hit the same leak.

## User Impact

None for users. Removes an intermittent CI failure whose cause was in a
different file from the one that failed, which is expensive to diagnose.

## Evidence

Observed failure, `checks-node-compact-large-4` on run 30364441274. The shard log
shows both files under the same `ui` project with the polluter immediately
before the victim:

```
✓  ui  ui/src/pages/agents/panels-tools-skills.browser.test.ts (8 tests) 183ms
❯  ui  ui/src/pages/config/config-page.test.ts (16 tests | 3 failed) 17ms
```

The leaked value matches `agent-tool-${safe}` in
`ui/src/pages/agents/panels-tools-skills.ts:136` with `safe = "read"`, and the
write is `nextUrl.hash = anchorId` at line 169 of the same file.

With the fix, both files pass when run together in the failing order:

```
node scripts/run-vitest.mjs \
  ui/src/pages/agents/panels-tools-skills.browser.test.ts \
  ui/src/pages/config/config-page.test.ts
Test Files  2 passed (2)
     Tests  24 passed (24)
```

Proof gap, stated rather than papered over: I could not complete a local
*pre-fix* reproduction. Two attempts timed out on the repo's local heavy-check
lock, held by a concurrent worktree, and I did not displace another agent's
running check. The pre-fix evidence is therefore the CI log above rather than a
local red run; this PR's own CI is the end-to-end confirmation.

## Follow-up considered and not taken

A blanket location reset in the shared `ui` setup file would fix this whole class
rather than one instance. Not done here: it changes shared setup semantics for
339 files and could mask genuine navigation bugs. Worth a separate discussion if
this class recurs.
