### PR TITLE
feat(memory): backfill past sessions from Control UI

### DIFF
--- a/extensions/memory-core/index.ts
+++ b/extensions/memory-core/index.ts
@@ -26,6 +26,7 @@ import { buildMemoryFlushPlan } from "./src/flush-plan.js";
 import type { MemoryCoreAcquireLocalService } from "./src/memory/embedding-local-service.js";
 import type { MemoryCoreRuntimeHost } from "./src/memory/runtime-host.js";
 import { buildPromptSection } from "./src/prompt-section.js";
+import { registerSessionBackfillGatewayMethods } from "./src/session-backfill-gateway.js";
 
 type MemoryToolsModule = typeof import("./src/tools.js");
 type StandingIntentToolModule = typeof import("./src/standing-intents-tool.js");
@@ -320,6 +321,7 @@ export default definePluginEntry({
     );
     const memoryRuntime = createLazyMemoryRuntime(host);
     registerShortTermPromotionDreaming(api);
+    registerSessionBackfillGatewayMethods(api);
     registerMemoryManagerWarmup(api, memoryRuntime);
     api.registerMemoryCapability({
       promptBuilder: buildPromptSection,

--- a/extensions/memory-core/src/session-backfill-gateway.test.ts
+++ b/extensions/memory-core/src/session-backfill-gateway.test.ts
@@ -1,0 +1,214 @@
+import type { GatewayRequestHandlerOptions } from "openclaw/plugin-sdk/gateway-runtime";
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk/plugin-entry";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  registerSessionBackfillGatewayMethods,
+  SESSION_BACKFILL_GATEWAY_METHODS,
+} from "./session-backfill-gateway.js";
+import { executeSessionBackfill, executeSessionBackfillBatch } from "./session-backfill.js";
+
+vi.mock("./session-backfill.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("./session-backfill.js")>()),
+  executeSessionBackfill: vi.fn(),
+  executeSessionBackfillBatch: vi.fn(),
+}));
+
+type RegisteredMethod = {
+  handler: (options: GatewayRequestHandlerOptions) => Promise<void>;
+  scope: string | undefined;
+};
+
+const executeMock = vi.mocked(executeSessionBackfill);
+const executeBatchMock = vi.mocked(executeSessionBackfillBatch);
+
+function createHarness(config?: Record<string, unknown>) {
+  const methods = new Map<string, RegisteredMethod>();
+  const runtimeConfig =
+    config !== undefined
+      ? config
+      : {
+          agents: {
+            list: [{ id: "main", default: true, workspace: "/tmp/main-workspace" }],
+          },
+        };
+  const api = {
+    runtime: {
+      config: { current: () => runtimeConfig },
+      agent: {
+        resolveAgentWorkspaceDir: vi.fn(() => "/tmp/main-workspace"),
+      },
+    },
+    registerGatewayMethod(
+      method: string,
+      handler: RegisteredMethod["handler"],
+      options?: { scope?: string },
+    ) {
+      methods.set(method, { handler, scope: options?.scope });
+    },
+  } as unknown as OpenClawPluginApi;
+  registerSessionBackfillGatewayMethods(api);
+  return { api, methods };
+}
+
+async function invoke(method: RegisteredMethod, params: unknown) {
+  const respond = vi.fn();
+  await method.handler({ params, respond } as unknown as GatewayRequestHandlerOptions);
+  return respond;
+}
+
+describe("session backfill gateway methods", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("registers read preview and admin mutation methods", () => {
+    const { methods } = createHarness();
+    expect([...methods.entries()].map(([name, value]) => [name, value.scope])).toEqual([
+      [SESSION_BACKFILL_GATEWAY_METHODS.preview, "operator.read"],
+      [SESSION_BACKFILL_GATEWAY_METHODS.apply, "operator.admin"],
+      [SESSION_BACKFILL_GATEWAY_METHODS.rollback, "operator.admin"],
+    ]);
+  });
+
+  it("validates preview params and returns at most three samples per day", async () => {
+    const { methods } = createHarness();
+    executeBatchMock.mockResolvedValueOnce({
+      result: {
+        agentId: "main",
+        workspaceDir: "/tmp/main-workspace",
+        applied: false,
+        rem: false,
+        days: [
+          {
+            day: "2026-07-01",
+            candidateCount: 4,
+            topCandidates: ["one", "two", "three", "four"],
+          },
+        ],
+        candidateCount: 4,
+        stagedEntries: 0,
+        writtenDiaryEntries: 0,
+        replacedDiaryEntries: 0,
+      },
+      continuation: { advanced: false, hasMore: true },
+    });
+    const preview = methods.get(SESSION_BACKFILL_GATEWAY_METHODS.preview)!;
+    const respond = await invoke(preview, {
+      agentId: "main",
+      from: "2026-07-01",
+      to: "2026-07-31",
+      limitDays: 14,
+    });
+
+    expect(executeBatchMock).toHaveBeenCalledWith({
+      agentId: "main",
+      from: "2026-07-01",
+      to: "2026-07-31",
+      limitDays: 14,
+      workspaceDir: "/tmp/main-workspace",
+    });
+    expect(respond).toHaveBeenCalledWith(true, {
+      days: 1,
+      candidates: 4,
+      perDay: [{ day: "2026-07-01", candidateCount: 4, sample: ["one", "two", "three"] }],
+      staged: 0,
+      truncated: true,
+    });
+  });
+
+  it("rejects invalid ranges and unknown params before executing", async () => {
+    const { methods } = createHarness();
+    const preview = methods.get(SESSION_BACKFILL_GATEWAY_METHODS.preview)!;
+    const invalidRange = await invoke(preview, {
+      agentId: "main",
+      from: "2026-08-01",
+      to: "2026-07-01",
+    });
+    const unexpected = await invoke(preview, { agentId: "main", archiveFiles: [] });
+
+    expect(executeMock).not.toHaveBeenCalled();
+    expect(invalidRange.mock.calls[0]?.[2]).toMatchObject({
+      code: "INVALID_REQUEST",
+      message: "from must not be after to.",
+    });
+    expect(unexpected.mock.calls[0]?.[2]).toMatchObject({
+      code: "INVALID_REQUEST",
+      message: "unexpected parameter: archiveFiles",
+    });
+  });
+
+  it("rejects unknown agents as invalid requests", async () => {
+    const { methods } = createHarness();
+    const respond = await invoke(methods.get(SESSION_BACKFILL_GATEWAY_METHODS.preview)!, {
+      agentId: "missing",
+    });
+
+    expect(executeMock).not.toHaveBeenCalled();
+    expect(respond.mock.calls[0]?.[2]).toMatchObject({
+      code: "INVALID_REQUEST",
+      message: 'Unknown agent id "missing".',
+    });
+  });
+
+  it("allows only the implicit default agent when no roster is configured", async () => {
+    const { methods } = createHarness({});
+    const preview = methods.get(SESSION_BACKFILL_GATEWAY_METHODS.preview)!;
+    const missing = await invoke(preview, { agentId: "missing" });
+
+    expect(missing.mock.calls[0]?.[2]).toMatchObject({
+      code: "INVALID_REQUEST",
+      message: 'Unknown agent id "missing".',
+    });
+  });
+
+  it("applies a chunk with cursor progress and rolls back by agent", async () => {
+    const { methods } = createHarness();
+    executeBatchMock.mockResolvedValueOnce({
+      result: {
+        agentId: "main",
+        workspaceDir: "/tmp/main-workspace",
+        applied: true,
+        rem: false,
+        days: [{ day: "2026-07-01", candidateCount: 2, topCandidates: ["one", "two"] }],
+        candidateCount: 2,
+        stagedEntries: 1,
+        writtenDiaryEntries: 1,
+        replacedDiaryEntries: 0,
+      },
+      continuation: { advanced: true, hasMore: false },
+    });
+    executeMock.mockResolvedValueOnce({
+      agentId: "main",
+      workspaceDir: "/tmp/main-workspace",
+      applied: false,
+      rem: false,
+      days: [],
+      candidateCount: 0,
+      stagedEntries: 0,
+      writtenDiaryEntries: 0,
+      replacedDiaryEntries: 0,
+      rollback: { removedDiaryEntries: 3, removedStagedEntries: 2 },
+    });
+
+    const applyRespond = await invoke(methods.get(SESSION_BACKFILL_GATEWAY_METHODS.apply)!, {
+      agentId: "main",
+      limitDays: 14,
+    });
+    expect(applyRespond).toHaveBeenCalledWith(
+      true,
+      expect.objectContaining({
+        days: 1,
+        candidates: 2,
+        staged: 1,
+        cursor: { advanced: true, exhausted: false, hasMore: false },
+      }),
+    );
+    const rollbackRespond = await invoke(methods.get(SESSION_BACKFILL_GATEWAY_METHODS.rollback)!, {
+      agentId: "main",
+    });
+    expect(rollbackRespond).toHaveBeenCalledWith(true, {
+      removedDiaryEntries: 3,
+      removedStagedEntries: 2,
+    });
+  });
+});

--- a/extensions/memory-core/src/session-backfill-gateway.test.ts
+++ b/extensions/memory-core/src/session-backfill-gateway.test.ts
@@ -1,10 +1,7 @@
 import type { GatewayRequestHandlerOptions } from "openclaw/plugin-sdk/gateway-runtime";
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk/plugin-entry";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import {
-  registerSessionBackfillGatewayMethods,
-  SESSION_BACKFILL_GATEWAY_METHODS,
-} from "./session-backfill-gateway.js";
+import { registerSessionBackfillGatewayMethods } from "./session-backfill-gateway.js";
 import { executeSessionBackfill, executeSessionBackfillBatch } from "./session-backfill.js";
 
 vi.mock("./session-backfill.js", async (importOriginal) => ({
@@ -20,6 +17,11 @@ type RegisteredMethod = {
 
 const executeMock = vi.mocked(executeSessionBackfill);
 const executeBatchMock = vi.mocked(executeSessionBackfillBatch);
+const SESSION_BACKFILL_GATEWAY_METHODS = {
+  preview: "memory.sessionBackfill.preview",
+  apply: "memory.sessionBackfill.apply",
+  rollback: "memory.sessionBackfill.rollback",
+} as const;
 
 function createHarness(config?: Record<string, unknown>) {
   const methods = new Map<string, RegisteredMethod>();

--- a/extensions/memory-core/src/session-backfill-gateway.ts
+++ b/extensions/memory-core/src/session-backfill-gateway.ts
@@ -1,0 +1,224 @@
+import { readPositiveIntegerParam, readStringParam } from "openclaw/plugin-sdk/channel-actions";
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import {
+  ErrorCodes,
+  errorShape,
+  type GatewayRequestHandlerOptions,
+} from "openclaw/plugin-sdk/gateway-runtime";
+import { resolveSessionAgentIds } from "openclaw/plugin-sdk/memory-core-host-runtime-core";
+import { resolveMemoryRemDreamingConfig } from "openclaw/plugin-sdk/memory-core-host-status";
+import { resolvePluginConfigObject } from "openclaw/plugin-sdk/plugin-config-runtime";
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk/plugin-entry";
+import { normalizeAgentId } from "openclaw/plugin-sdk/routing";
+import {
+  executeSessionBackfill,
+  executeSessionBackfillBatch,
+  normalizeSessionBackfillSelection,
+  type RunSessionBackfillParams,
+  type SessionBackfillResult,
+} from "./session-backfill.js";
+
+export const SESSION_BACKFILL_GATEWAY_METHODS = {
+  preview: "memory.sessionBackfill.preview",
+  apply: "memory.sessionBackfill.apply",
+  rollback: "memory.sessionBackfill.rollback",
+} as const;
+
+type SessionBackfillGatewayParams = Pick<
+  RunSessionBackfillParams,
+  "agentId" | "from" | "to" | "limitDays"
+>;
+
+export type SessionBackfillGatewayResult = {
+  days: number;
+  candidates: number;
+  perDay: Array<{ day: string; candidateCount: number; sample: string[] }>;
+  staged: number;
+  truncated?: boolean;
+  cursor?: {
+    advanced: boolean;
+    exhausted: boolean;
+    hasMore: boolean;
+  };
+};
+
+class InvalidSessionBackfillRequestError extends Error {}
+
+function paramsRecord(value: unknown): Record<string, unknown> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error("params must be an object.");
+  }
+  return value as Record<string, unknown>;
+}
+
+function assertOnlyKeys(params: Record<string, unknown>, allowed: ReadonlySet<string>): void {
+  const unexpected = Object.keys(params).filter((key) => !allowed.has(key));
+  if (unexpected.length > 0) {
+    throw new Error(`unexpected parameter: ${unexpected[0]}`);
+  }
+}
+
+function readOptionalString(params: Record<string, unknown>, key: "from" | "to") {
+  const raw = params[key];
+  if (raw !== undefined && typeof raw !== "string") {
+    throw new Error(`${key} must be a string.`);
+  }
+  return readStringParam(params, key);
+}
+
+function readGatewayParams(value: unknown): SessionBackfillGatewayParams {
+  const params = paramsRecord(value);
+  assertOnlyKeys(params, new Set(["agentId", "from", "to", "limitDays"]));
+  const agentId = normalizeAgentId(readStringParam(params, "agentId", { required: true }));
+  const selection = normalizeSessionBackfillSelection(
+    {
+      from: readOptionalString(params, "from"),
+      to: readOptionalString(params, "to"),
+      limitDays: readPositiveIntegerParam(params, "limitDays"),
+    },
+    { from: "from", to: "to", limitDays: "limitDays" },
+  );
+  return { agentId, ...selection };
+}
+
+function readRollbackParams(value: unknown): { agentId: string } {
+  const params = paramsRecord(value);
+  assertOnlyKeys(params, new Set(["agentId"]));
+  return {
+    agentId: normalizeAgentId(readStringParam(params, "agentId", { required: true })),
+  };
+}
+
+function resolveExecutionContext(api: OpenClawPluginApi, agentId: string) {
+  const config = api.runtime.config.current() as OpenClawConfig;
+  const configuredAgentIds = (config.agents?.list ?? []).map((entry) => normalizeAgentId(entry.id));
+  if (configuredAgentIds.length === 0) {
+    configuredAgentIds.push(resolveSessionAgentIds({ config }).sessionAgentId);
+  }
+  if (!configuredAgentIds.includes(agentId)) {
+    throw new InvalidSessionBackfillRequestError(`Unknown agent id "${agentId}".`);
+  }
+  const workspaceDir = api.runtime.agent.resolveAgentWorkspaceDir(config, agentId);
+  const remConfig = resolveMemoryRemDreamingConfig({
+    cfg: config,
+    pluginConfig: resolvePluginConfigObject(config, "memory-core"),
+  });
+  return {
+    workspaceDir,
+    ...(remConfig.timezone !== undefined ? { timezone: remConfig.timezone } : {}),
+  };
+}
+
+function gatewayResult(
+  result: SessionBackfillResult,
+  options: {
+    includeCursor: boolean;
+    continuation: { advanced: boolean; hasMore: boolean };
+  },
+): SessionBackfillGatewayResult {
+  return {
+    days: result.days.length,
+    candidates: result.candidateCount,
+    perDay: result.days.map((day) => ({
+      day: day.day,
+      candidateCount: day.candidateCount,
+      sample: day.topCandidates.slice(0, 3),
+    })),
+    staged: result.stagedEntries,
+    ...(!options.includeCursor ? { truncated: options.continuation.hasMore } : {}),
+    ...(options.includeCursor
+      ? {
+          cursor: {
+            advanced: options.continuation.advanced,
+            exhausted: result.candidateCount === 0 && !options.continuation.hasMore,
+            hasMore: options.continuation.hasMore,
+          },
+        }
+      : {}),
+  };
+}
+
+function respondInvalid(respond: GatewayRequestHandlerOptions["respond"], error: unknown): void {
+  const message = error instanceof Error ? error.message : String(error);
+  respond(false, undefined, errorShape(ErrorCodes.INVALID_REQUEST, message));
+}
+
+function respondUnavailable(
+  respond: GatewayRequestHandlerOptions["respond"],
+  error: unknown,
+): void {
+  const message = error instanceof Error ? error.message : String(error);
+  respond(false, undefined, errorShape(ErrorCodes.UNAVAILABLE, message));
+}
+
+export function registerSessionBackfillGatewayMethods(api: OpenClawPluginApi): void {
+  const registerBackfill = (
+    method: (typeof SESSION_BACKFILL_GATEWAY_METHODS)["preview" | "apply"],
+    apply: boolean,
+  ) => {
+    api.registerGatewayMethod(
+      method,
+      async ({ params, respond }: GatewayRequestHandlerOptions) => {
+        let request: SessionBackfillGatewayParams;
+        try {
+          request = readGatewayParams(params);
+        } catch (error) {
+          respondInvalid(respond, error);
+          return;
+        }
+        try {
+          const context = resolveExecutionContext(api, request.agentId);
+          const execution = await executeSessionBackfillBatch({
+            ...request,
+            ...context,
+            ...(apply ? { apply: true } : {}),
+          });
+          respond(
+            true,
+            gatewayResult(execution.result, {
+              includeCursor: apply,
+              continuation: execution.continuation,
+            }),
+          );
+        } catch (error) {
+          if (error instanceof InvalidSessionBackfillRequestError) {
+            respondInvalid(respond, error);
+          } else {
+            respondUnavailable(respond, error);
+          }
+        }
+      },
+      { scope: apply ? "operator.admin" : "operator.read" },
+    );
+  };
+
+  registerBackfill(SESSION_BACKFILL_GATEWAY_METHODS.preview, false);
+  registerBackfill(SESSION_BACKFILL_GATEWAY_METHODS.apply, true);
+  api.registerGatewayMethod(
+    SESSION_BACKFILL_GATEWAY_METHODS.rollback,
+    async ({ params, respond }: GatewayRequestHandlerOptions) => {
+      let request: { agentId: string };
+      try {
+        request = readRollbackParams(params);
+      } catch (error) {
+        respondInvalid(respond, error);
+        return;
+      }
+      try {
+        const context = resolveExecutionContext(api, request.agentId);
+        const result = await executeSessionBackfill({ ...request, ...context, rollback: true });
+        respond(true, {
+          removedDiaryEntries: result.rollback?.removedDiaryEntries ?? 0,
+          removedStagedEntries: result.rollback?.removedStagedEntries ?? 0,
+        });
+      } catch (error) {
+        if (error instanceof InvalidSessionBackfillRequestError) {
+          respondInvalid(respond, error);
+        } else {
+          respondUnavailable(respond, error);
+        }
+      }
+    },
+    { scope: "operator.admin" },
+  );
+}

--- a/extensions/memory-core/src/session-backfill-gateway.ts
+++ b/extensions/memory-core/src/session-backfill-gateway.ts
@@ -18,7 +18,7 @@ import {
   type SessionBackfillResult,
 } from "./session-backfill.js";
 
-export const SESSION_BACKFILL_GATEWAY_METHODS = {
+const SESSION_BACKFILL_GATEWAY_METHODS = {
   preview: "memory.sessionBackfill.preview",
   apply: "memory.sessionBackfill.apply",
   rollback: "memory.sessionBackfill.rollback",
@@ -29,7 +29,7 @@ type SessionBackfillGatewayParams = Pick<
   "agentId" | "from" | "to" | "limitDays"
 >;
 
-export type SessionBackfillGatewayResult = {
+type SessionBackfillGatewayResult = {
   days: number;
   candidates: number;
   perDay: Array<{ day: string; candidateCount: number; sample: string[] }>;

--- a/extensions/memory-core/src/session-backfill.test.ts
+++ b/extensions/memory-core/src/session-backfill.test.ts
@@ -10,7 +10,11 @@ import { appendSessionTranscriptMessageByIdentity } from "openclaw/plugin-sdk/se
 import { formatSqliteSessionFileMarker } from "openclaw/plugin-sdk/sqlite-runtime-testing";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { writeBackfillDiaryEntries } from "./dreaming-narrative.js";
-import { runSessionBackfill } from "./session-backfill.js";
+import {
+  executeSessionBackfill,
+  executeSessionBackfillBatch,
+  runSessionBackfill,
+} from "./session-backfill.js";
 import { readShortTermRecallEntries } from "./short-term-promotion.js";
 import { createMemoryCoreTestHarness } from "./test-helpers.js";
 
@@ -88,6 +92,10 @@ afterEach(() => {
 });
 
 describe("runSessionBackfill", () => {
+  it("keeps the CLI export on the canonical shared executor", () => {
+    expect(runSessionBackfill).toBe(executeSessionBackfill);
+  });
+
   it("keeps REM preview mode mutually exclusive with apply", async () => {
     const workspaceDir = await createIsolatedWorkspace("rem-apply-");
 
@@ -150,6 +158,38 @@ describe("runSessionBackfill", () => {
     });
 
     expect(result.days.map((day) => day.day)).toEqual(["2026-01-01", "2026-01-02"]);
+  });
+
+  it("reports authoritative continuation across bounded apply batches", async () => {
+    const workspaceDir = await createIsolatedWorkspace("continuation-");
+    await seedCanonicalTranscript(
+      "continuation",
+      ["2026-01-01", "2026-01-02", "2026-01-03"].map((day) => ({
+        role: "user" as const,
+        content: `Continuation note for ${day}`,
+        timestamp: `${day}T12:00:00.000Z`,
+        owner: true,
+      })),
+    );
+    const run = () =>
+      executeSessionBackfillBatch({
+        agentId: "main",
+        workspaceDir,
+        apply: true,
+        limitDays: 2,
+        timezone: "UTC",
+      });
+
+    const first = await run();
+    const second = await run();
+    const exhausted = await run();
+
+    expect(first.result.days.map((day) => day.day)).toEqual(["2026-01-01", "2026-01-02"]);
+    expect(first.continuation).toEqual({ advanced: true, hasMore: true });
+    expect(second.result.days.map((day) => day.day)).toEqual(["2026-01-03"]);
+    expect(second.continuation).toEqual({ advanced: true, hasMore: false });
+    expect(exhausted.result.candidateCount).toBe(0);
+    expect(exhausted.continuation).toEqual({ advanced: false, hasMore: false });
   });
 
   it("does not advance the cursor past messages excluded by a date range", async () => {

--- a/extensions/memory-core/src/session-backfill.ts
+++ b/extensions/memory-core/src/session-backfill.ts
@@ -96,7 +96,7 @@ type SessionBackfillCollection = {
   scans: SessionBackfillScan[];
 };
 
-export type SessionBackfillDay = {
+type SessionBackfillDay = {
   day: string;
   candidateCount: number;
   topCandidates: string[];
@@ -118,12 +118,12 @@ export type SessionBackfillResult = {
   };
 };
 
-export type SessionBackfillContinuation = {
+type SessionBackfillContinuation = {
   advanced: boolean;
   hasMore: boolean;
 };
 
-export type SessionBackfillExecution = {
+type SessionBackfillExecution = {
   result: SessionBackfillResult;
   continuation: SessionBackfillContinuation;
 };

--- a/extensions/memory-core/src/session-backfill.ts
+++ b/extensions/memory-core/src/session-backfill.ts
@@ -96,13 +96,13 @@ type SessionBackfillCollection = {
   scans: SessionBackfillScan[];
 };
 
-type SessionBackfillDay = {
+export type SessionBackfillDay = {
   day: string;
   candidateCount: number;
   topCandidates: string[];
 };
 
-type SessionBackfillResult = {
+export type SessionBackfillResult = {
   agentId: string;
   workspaceDir: string;
   applied: boolean;
@@ -118,7 +118,17 @@ type SessionBackfillResult = {
   };
 };
 
-type RunSessionBackfillParams = {
+export type SessionBackfillContinuation = {
+  advanced: boolean;
+  hasMore: boolean;
+};
+
+export type SessionBackfillExecution = {
+  result: SessionBackfillResult;
+  continuation: SessionBackfillContinuation;
+};
+
+export type RunSessionBackfillParams = {
   agentId: string;
   workspaceDir: string;
   from?: string;
@@ -155,6 +165,32 @@ function resolveLimitDays(value: number | undefined): number {
     throw new Error("--limit-days must be a positive integer.");
   }
   return value;
+}
+
+export function normalizeSessionBackfillSelection(
+  params: Pick<RunSessionBackfillParams, "from" | "to" | "limitDays">,
+  labels: { from: string; to: string; limitDays: string } = {
+    from: "--from",
+    to: "--to",
+    limitDays: "--limit-days",
+  },
+): { from?: string; to?: string; limitDays: number } {
+  const from = normalizeMemoryDay(params.from, labels.from);
+  const to = normalizeMemoryDay(params.to, labels.to);
+  if (from !== undefined && to !== undefined && from > to) {
+    throw new Error(`${labels.from} must not be after ${labels.to}.`);
+  }
+  let limitDays: number;
+  try {
+    limitDays = resolveLimitDays(params.limitDays);
+  } catch {
+    throw new Error(`${labels.limitDays} must be a positive integer.`);
+  }
+  return {
+    ...(from !== undefined ? { from } : {}),
+    ...(to !== undefined ? { to } : {}),
+    limitDays,
+  };
 }
 
 function sourceFromCorpusEntry(entry: SessionTranscriptCorpusEntry): SessionBackfillSource | null {
@@ -551,9 +587,9 @@ async function applySessionBackfillDays(params: {
   return Math.max(0, after.length - before.length);
 }
 
-export async function runSessionBackfill(
+async function executeSessionBackfillCore(
   params: RunSessionBackfillParams,
-): Promise<SessionBackfillResult> {
+): Promise<SessionBackfillExecution> {
   const workspaceDir = params.workspaceDir.trim();
   if (!workspaceDir) {
     throw new Error("Memory session-backfill requires a resolvable workspace directory.");
@@ -571,28 +607,26 @@ export async function runSessionBackfill(
       removeGroundedShortTermCandidates({ workspaceDir }),
     ]);
     return {
-      agentId: params.agentId,
-      workspaceDir,
-      applied: false,
-      rem: false,
-      days: [],
-      candidateCount: 0,
-      stagedEntries: 0,
-      writtenDiaryEntries: 0,
-      replacedDiaryEntries: 0,
-      rollback: {
-        removedDiaryEntries: diary.removed,
-        removedStagedEntries: staged.removed,
+      result: {
+        agentId: params.agentId,
+        workspaceDir,
+        applied: false,
+        rem: false,
+        days: [],
+        candidateCount: 0,
+        stagedEntries: 0,
+        writtenDiaryEntries: 0,
+        replacedDiaryEntries: 0,
+        rollback: {
+          removedDiaryEntries: diary.removed,
+          removedStagedEntries: staged.removed,
+        },
       },
+      continuation: { advanced: false, hasMore: false },
     };
   }
 
-  const from = normalizeMemoryDay(params.from, "--from");
-  const to = normalizeMemoryDay(params.to, "--to");
-  if (from !== undefined && to !== undefined && from > to) {
-    throw new Error("--from must not be after --to.");
-  }
-  const limitDays = resolveLimitDays(params.limitDays);
+  const { from, to, limitDays } = normalizeSessionBackfillSelection(params);
   const state = await readSessionIngestionState(workspaceDir);
   const sources = await listSessionBackfillSources({
     agentId: params.agentId,
@@ -612,6 +646,17 @@ export async function runSessionBackfill(
     .map((day) => ({ day, candidates: collected.byDay.get(day) ?? [] }));
   const days = selectedDays.map((entry) => summarizeDay(entry.day, entry.candidates));
   const candidateCount = days.reduce((sum, day) => sum + day.candidateCount, 0);
+  // Scans retain every unseen in-range candidate before batch caps, so comparing their full
+  // hash set with the selected batch makes continuation authoritative across day/file caps.
+  const selectedHashes = new Set(
+    selectedDays.flatMap((day) => day.candidates.map((candidate) => candidate.hash)),
+  );
+  const continuation = {
+    advanced: Boolean(params.apply) && candidateCount > 0,
+    hasMore: collected.scans.some((scan) =>
+      scan.candidates.some((candidate) => !selectedHashes.has(candidate.hash)),
+    ),
+  };
   let writtenDiaryEntries = 0;
   let replacedDiaryEntries = 0;
   let stagedEntries = 0;
@@ -667,14 +712,32 @@ export async function runSessionBackfill(
   }
 
   return {
-    agentId: params.agentId,
-    workspaceDir,
-    applied: Boolean(params.apply),
-    rem: Boolean(params.rem),
-    days,
-    candidateCount,
-    stagedEntries,
-    writtenDiaryEntries,
-    replacedDiaryEntries,
+    result: {
+      agentId: params.agentId,
+      workspaceDir,
+      applied: Boolean(params.apply),
+      rem: Boolean(params.rem),
+      days,
+      candidateCount,
+      stagedEntries,
+      writtenDiaryEntries,
+      replacedDiaryEntries,
+    },
+    continuation,
   };
 }
+
+export async function executeSessionBackfill(
+  params: RunSessionBackfillParams,
+): Promise<SessionBackfillResult> {
+  return (await executeSessionBackfillCore(params)).result;
+}
+
+export async function executeSessionBackfillBatch(
+  params: RunSessionBackfillParams,
+): Promise<SessionBackfillExecution> {
+  return await executeSessionBackfillCore(params);
+}
+
+// Preserve the CLI-facing name while every caller shares the same executor.
+export { executeSessionBackfill as runSessionBackfill };

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -1993,6 +1993,39 @@ export const en: TranslationMap = {
     agent: "Destination agent",
     replaceExisting: "Replace existing imports",
     replaceHint: "Preview conflicts again and preserve item backups before replacement.",
+    backfill: {
+      title: "From past sessions",
+      subtitle:
+        "Stage trusted memories from earlier agent sessions. Dreaming promotes the useful ones into long-term memory.",
+      dateRange: "Session date range",
+      dateRangeHint: "Leave either date blank to scan the full available range.",
+      from: "From",
+      to: "To",
+      actions: "Backfill",
+      preview: "Preview",
+      previewing: "Previewing…",
+      apply: "Apply",
+      applying: "Applying…",
+      rollback: "Rollback",
+      previewSummary: "{candidates} candidates across {days} days",
+      previewTruncated:
+        "This preview shows the first bounded batch. Apply continues through the remaining candidates.",
+      candidateCount: "{count} candidates",
+      noCandidates: "No new trusted session candidates were found.",
+      progress: "Processed {days} days · {staged} staged",
+      processedCandidates: "{count} session candidates processed",
+      processedDayCountOne: "{count} day processed",
+      processedDayCount: "{count} days processed",
+      complete: "{count} staged; promotion happens via dreaming",
+      rollbackConfirmTitle: "Rollback session backfill?",
+      rollbackConfirmDescription:
+        "Remove diary entries and staged memories created by session backfill for this agent.",
+      rollbackWarning:
+        "Tracked session cursors stay in place, so removed entries will not be staged again.",
+      rollbackComplete: "Session backfill rolled back",
+      rollbackCounts: "{diary} diary entries and {staged} staged entries removed",
+      unavailable: "Session backfill is unavailable on this Gateway.",
+    },
   },
   onboarding: {
     memoryImport: {

--- a/ui/src/pages/memory-import/memory-import-page.test.ts
+++ b/ui/src/pages/memory-import/memory-import-page.test.ts
@@ -458,4 +458,135 @@ describe("MemoryImportPage", () => {
     expect(request.mock.calls[1]?.[1]).toMatchObject({ agentId: "writer" });
     expect(page.querySelector("[data-test-id='memory-import-confirm']")).toBeNull();
   });
+
+  it("previews past-session candidates with the selected date range", async () => {
+    const request = vi.fn(async (method: string) => {
+      if (method === "migrations.memory.plan") {
+        return createPlan();
+      }
+      if (method === "memory.sessionBackfill.preview") {
+        return {
+          days: 1,
+          candidates: 2,
+          staged: 0,
+          truncated: true,
+          perDay: [
+            { day: "2026-07-01", candidateCount: 2, sample: ["First memory", "Second memory"] },
+          ],
+        };
+      }
+      throw new Error(`unexpected method: ${method}`);
+    });
+    const page = await mountPage(createContext(request));
+    await waitForMemoryImport(() =>
+      expect(page.querySelector("[data-test-id='memory-backfill-preview']")).not.toBeNull(),
+    );
+    const dates = page.querySelectorAll<HTMLInputElement>(
+      ".memory-import__backfill-dates input[type='date']",
+    );
+    dates[0]!.value = "2026-07-01";
+    dates[0]!.dispatchEvent(new Event("input", { bubbles: true }));
+    dates[1]!.value = "2026-07-31";
+    dates[1]!.dispatchEvent(new Event("input", { bubbles: true }));
+    page.querySelector<HTMLButtonElement>("[data-test-id='memory-backfill-preview']")?.click();
+
+    await waitForMemoryImport(() => expect(page.textContent).toContain("First memory"));
+    expect(page.textContent).toContain("preview shows the first bounded batch");
+    expect(request.mock.calls.at(-1)).toEqual([
+      "memory.sessionBackfill.preview",
+      { agentId: "research", from: "2026-07-01", to: "2026-07-31", limitDays: 14 },
+    ]);
+  });
+
+  it("applies backfill chunks until a call returns zero new candidates", async () => {
+    let applyCalls = 0;
+    const request = vi.fn(async (method: string) => {
+      if (method === "migrations.memory.plan") {
+        return createPlan();
+      }
+      if (method === "memory.sessionBackfill.apply") {
+        applyCalls += 1;
+        if (applyCalls === 1) {
+          return {
+            days: 2,
+            candidates: 3,
+            staged: 2,
+            perDay: [{ day: "2026-07-01", candidateCount: 3, sample: [] }],
+            cursor: { advanced: true, exhausted: false, hasMore: true },
+          };
+        }
+        if (applyCalls === 2) {
+          return {
+            days: 1,
+            candidates: 1,
+            staged: 1,
+            perDay: [{ day: "2026-07-01", candidateCount: 1, sample: [] }],
+            cursor: { advanced: true, exhausted: false, hasMore: false },
+          };
+        }
+        return {
+          days: 0,
+          candidates: 0,
+          staged: 0,
+          perDay: [],
+          cursor: { advanced: false, exhausted: true, hasMore: false },
+        };
+      }
+      throw new Error(`unexpected method: ${method}`);
+    });
+    const page = await mountPage(createContext(request));
+    await waitForMemoryImport(() =>
+      expect(page.querySelector("[data-test-id='memory-backfill-apply']")).not.toBeNull(),
+    );
+    page.querySelector<HTMLButtonElement>("[data-test-id='memory-backfill-apply']")?.click();
+
+    await waitForMemoryImport(() =>
+      expect(page.textContent).toContain("3 staged; promotion happens via dreaming"),
+    );
+    expect(applyCalls).toBe(3);
+    expect(page.textContent).toContain("4 session candidates processed");
+    expect(page.textContent).toContain("1 day processed");
+
+    const from = page.querySelector<HTMLInputElement>(
+      ".memory-import__backfill-dates input[type='date']",
+    );
+    if (!from) {
+      throw new Error("expected backfill from-date input");
+    }
+    from.value = "2026-07-01";
+    from.dispatchEvent(new Event("input", { bubbles: true }));
+    await page.updateComplete;
+    expect(page.textContent).not.toContain("3 staged; promotion happens via dreaming");
+  });
+
+  it("confirms rollback and surfaces gateway errors", async () => {
+    const request = vi.fn(async (method: string) => {
+      if (method === "migrations.memory.plan") {
+        return createPlan();
+      }
+      if (method === "memory.sessionBackfill.rollback") {
+        throw new Error("rollback unavailable");
+      }
+      throw new Error(`unexpected method: ${method}`);
+    });
+    const page = await mountPage(createContext(request));
+    await waitForMemoryImport(() =>
+      expect(page.querySelector("[data-test-id='memory-backfill-rollback']")).not.toBeNull(),
+    );
+    page.querySelector<HTMLButtonElement>("[data-test-id='memory-backfill-rollback']")?.click();
+    await waitForMemoryImport(() =>
+      expect(
+        page.querySelector("[data-test-id='memory-backfill-rollback-confirm']"),
+      ).not.toBeNull(),
+    );
+    page
+      .querySelector<HTMLButtonElement>("[data-test-id='memory-backfill-rollback-confirm']")
+      ?.click();
+
+    await waitForMemoryImport(() => expect(page.textContent).toContain("rollback unavailable"));
+    expect(request.mock.calls.at(-1)).toEqual([
+      "memory.sessionBackfill.rollback",
+      { agentId: "research" },
+    ]);
+  });
 });

--- a/ui/src/pages/memory-import/memory-import-page.ts
+++ b/ui/src/pages/memory-import/memory-import-page.ts
@@ -10,9 +10,17 @@ import { titleForRoute } from "../../app-navigation.ts";
 import { applicationContext, type ApplicationContext } from "../../app/context.ts";
 import { renderSettingsWorkspace } from "../../components/settings-workspace.ts";
 import { listSelectableAgents } from "../../lib/agents/display.ts";
+import { isGatewayMethodAdvertised } from "../../lib/gateway-methods.ts";
 import { OpenClawLightDomElement } from "../../lit/openclaw-element.ts";
 import { SubscriptionsController } from "../../lit/subscriptions-controller.ts";
-import { renderMemoryImport } from "./view.ts";
+import {
+  renderMemoryImport,
+  type SessionBackfillGatewayResult,
+  type SessionBackfillProgress,
+  type SessionBackfillRollbackResult,
+} from "./view.ts";
+
+const SESSION_BACKFILL_BATCH_DAYS = 14;
 
 type PendingMemoryImport = {
   providerId: string;
@@ -51,8 +59,17 @@ export class MemoryImportPage extends OpenClawLightDomElement {
   @state() private pendingImport: PendingMemoryImport | null = null;
   @state() private applyError: string | null = null;
   @state() private lastResults: Record<string, MigrationsMemoryApplyResult> = {};
+  @state() private backfillFrom = "";
+  @state() private backfillTo = "";
+  @state() private backfillBusy: "preview" | "apply" | "rollback" | null = null;
+  @state() private backfillError: string | null = null;
+  @state() private backfillPreview: SessionBackfillGatewayResult | null = null;
+  @state() private backfillProgress: SessionBackfillProgress | null = null;
+  @state() private backfillRollbackResult: SessionBackfillRollbackResult | null = null;
+  @state() private backfillRollbackPending = false;
 
   private applyEpoch = 0;
+  private backfillEpoch = 0;
   private lastPlanValue: {
     client: NonNullable<ApplicationContext["gateway"]["snapshot"]["client"]>;
     agentId: string;
@@ -102,6 +119,9 @@ export class MemoryImportPage extends OpenClawLightDomElement {
           previous.overwrite !== value.overwrite)
       ) {
         this.resetMutationState({ preserveAttemptedImport: previous.client !== value.client });
+        if (previous.client !== value.client || previous.agentId !== value.agentId) {
+          this.resetBackfillState();
+        }
       }
       this.lastPlanValue = value;
       const { plan } = value;
@@ -117,6 +137,7 @@ export class MemoryImportPage extends OpenClawLightDomElement {
   override disconnectedCallback() {
     void this.planTask.run([null, null, this.replaceExisting]);
     this.applyEpoch += 1;
+    this.backfillEpoch += 1;
     this.subscriptions.clear();
     super.disconnectedCallback();
   }
@@ -133,6 +154,12 @@ export class MemoryImportPage extends OpenClawLightDomElement {
         this.currentAgentId() !== this.pendingImport.agentId)
     ) {
       this.resetMutationState({ preserveAttemptedImport: true });
+    }
+    if (
+      snapshot.phase !== "connected" &&
+      (this.backfillBusy !== null || this.backfillRollbackPending)
+    ) {
+      this.resetBackfillState();
     }
   }
 
@@ -192,6 +219,7 @@ export class MemoryImportPage extends OpenClawLightDomElement {
   private selectAgent(agentId: string) {
     this.context.agentSelection.set(agentId);
     this.resetMutationState();
+    this.resetBackfillState();
   }
 
   private setReplaceExisting(enabled: boolean) {
@@ -221,6 +249,9 @@ export class MemoryImportPage extends OpenClawLightDomElement {
       this.loading ||
       this.error !== null ||
       this.applyingProviderId !== null ||
+      this.backfillBusy === "apply" ||
+      this.backfillBusy === "rollback" ||
+      this.backfillRollbackPending ||
       !agentId ||
       this.plan?.agentId !== agentId ||
       !planFingerprint ||
@@ -241,7 +272,12 @@ export class MemoryImportPage extends OpenClawLightDomElement {
   }
 
   private async confirmImport() {
-    if (this.applyingProviderId !== null) {
+    if (
+      this.applyingProviderId !== null ||
+      this.backfillBusy === "apply" ||
+      this.backfillBusy === "rollback" ||
+      this.backfillRollbackPending
+    ) {
       return;
     }
     const pending = this.pendingImport;
@@ -291,6 +327,172 @@ export class MemoryImportPage extends OpenClawLightDomElement {
     }
   }
 
+  private resetBackfillState() {
+    this.backfillEpoch += 1;
+    this.backfillFrom = "";
+    this.backfillTo = "";
+    this.backfillBusy = null;
+    this.backfillError = null;
+    this.backfillPreview = null;
+    this.backfillProgress = null;
+    this.backfillRollbackResult = null;
+    this.backfillRollbackPending = false;
+  }
+
+  private backfillRequest(agentId: string) {
+    return {
+      agentId,
+      ...(this.backfillFrom ? { from: this.backfillFrom } : {}),
+      ...(this.backfillTo ? { to: this.backfillTo } : {}),
+      limitDays: SESSION_BACKFILL_BATCH_DAYS,
+    };
+  }
+
+  private isCurrentBackfillRequest(
+    epoch: number,
+    client: NonNullable<ApplicationContext["gateway"]["snapshot"]["client"]>,
+    agentId: string,
+  ): boolean {
+    return (
+      epoch === this.backfillEpoch &&
+      this.context.gateway.snapshot.phase === "connected" &&
+      this.context.gateway.snapshot.client === client &&
+      this.currentAgentId() === agentId
+    );
+  }
+
+  private async previewBackfill() {
+    const snapshot = this.context.gateway.snapshot;
+    const client = snapshot.client;
+    const agentId = this.currentAgentId();
+    if (!client || !agentId || this.backfillBusy !== null || this.applyingProviderId !== null) {
+      return;
+    }
+    const epoch = ++this.backfillEpoch;
+    this.backfillBusy = "preview";
+    this.backfillError = null;
+    this.backfillPreview = null;
+    this.backfillProgress = null;
+    this.backfillRollbackResult = null;
+    try {
+      const result = await client.request<SessionBackfillGatewayResult>(
+        "memory.sessionBackfill.preview",
+        this.backfillRequest(agentId),
+      );
+      if (this.isCurrentBackfillRequest(epoch, client, agentId)) {
+        this.backfillPreview = result;
+      }
+    } catch (error) {
+      if (this.isCurrentBackfillRequest(epoch, client, agentId)) {
+        this.backfillError = toErrorMessage(error);
+      }
+    } finally {
+      if (this.isCurrentBackfillRequest(epoch, client, agentId)) {
+        this.backfillBusy = null;
+      }
+    }
+  }
+
+  private async applyBackfill() {
+    const snapshot = this.context.gateway.snapshot;
+    const client = snapshot.client;
+    const agentId = this.currentAgentId();
+    if (!client || !agentId || this.backfillBusy !== null || this.applyingProviderId !== null) {
+      return;
+    }
+    const epoch = ++this.backfillEpoch;
+    this.backfillBusy = "apply";
+    this.backfillError = null;
+    this.backfillPreview = null;
+    this.backfillRollbackResult = null;
+    this.backfillProgress = {
+      days: 0,
+      candidates: 0,
+      staged: 0,
+      complete: false,
+    };
+    let progress = this.backfillProgress;
+    const processedDays = new Set<string>();
+    try {
+      while (true) {
+        const chunk = await client.request<SessionBackfillGatewayResult>(
+          "memory.sessionBackfill.apply",
+          this.backfillRequest(agentId),
+        );
+        if (!this.isCurrentBackfillRequest(epoch, client, agentId)) {
+          return;
+        }
+        if (chunk.candidates > 0 && chunk.cursor?.advanced !== true) {
+          throw new Error("Session backfill stopped because the server cursor did not advance.");
+        }
+        if (chunk.candidates === 0 && chunk.cursor?.exhausted !== true) {
+          throw new Error("Session backfill stopped because the server cursor was not exhausted.");
+        }
+        for (const day of chunk.perDay) {
+          processedDays.add(day.day);
+        }
+        progress = {
+          days: processedDays.size,
+          candidates: progress.candidates + chunk.candidates,
+          staged: progress.staged + chunk.staged,
+          complete: chunk.candidates === 0,
+        };
+        this.backfillProgress = progress;
+        // A zero-candidate call is the idempotent completion sentinel; cursor metadata proves
+        // that the server's persisted scan agrees before the client stops driving chunks.
+        if (chunk.candidates === 0) {
+          break;
+        }
+      }
+    } catch (error) {
+      if (this.isCurrentBackfillRequest(epoch, client, agentId)) {
+        this.backfillError = toErrorMessage(error);
+      }
+    } finally {
+      if (this.isCurrentBackfillRequest(epoch, client, agentId)) {
+        this.backfillBusy = null;
+      }
+    }
+  }
+
+  private async confirmBackfillRollback() {
+    const snapshot = this.context.gateway.snapshot;
+    const client = snapshot.client;
+    const agentId = this.currentAgentId();
+    if (
+      !client ||
+      !agentId ||
+      this.backfillBusy !== null ||
+      this.applyingProviderId !== null ||
+      !this.backfillRollbackPending
+    ) {
+      return;
+    }
+    const epoch = ++this.backfillEpoch;
+    this.backfillBusy = "rollback";
+    this.backfillError = null;
+    try {
+      const result = await client.request<SessionBackfillRollbackResult>(
+        "memory.sessionBackfill.rollback",
+        { agentId },
+      );
+      if (this.isCurrentBackfillRequest(epoch, client, agentId)) {
+        this.backfillRollbackResult = result;
+        this.backfillPreview = null;
+        this.backfillProgress = null;
+        this.backfillRollbackPending = false;
+      }
+    } catch (error) {
+      if (this.isCurrentBackfillRequest(epoch, client, agentId)) {
+        this.backfillError = toErrorMessage(error);
+      }
+    } finally {
+      if (this.isCurrentBackfillRequest(epoch, client, agentId)) {
+        this.backfillBusy = null;
+      }
+    }
+  }
+
   override render() {
     const snapshot = this.context.gateway.snapshot;
     const agentsList = this.context.agents.state.agentsList;
@@ -309,6 +511,16 @@ export class MemoryImportPage extends OpenClawLightDomElement {
       pendingProviderId:
         this.pendingImport?.agentId === agentId ? this.pendingImport.providerId : null,
       lastResults: this.lastResults,
+      backfillAvailable:
+        isGatewayMethodAdvertised(snapshot, "memory.sessionBackfill.preview") !== false,
+      backfillFrom: this.backfillFrom,
+      backfillTo: this.backfillTo,
+      backfillBusy: this.backfillBusy,
+      backfillError: this.backfillError,
+      backfillPreview: this.backfillPreview,
+      backfillProgress: this.backfillProgress,
+      backfillRollbackResult: this.backfillRollbackResult,
+      backfillRollbackPending: this.backfillRollbackPending,
       onSelectAgent: (nextAgentId) => this.selectAgent(nextAgentId),
       onReplaceExisting: (enabled) => this.setReplaceExisting(enabled),
       onRefresh: () => void this.refresh(),
@@ -320,6 +532,34 @@ export class MemoryImportPage extends OpenClawLightDomElement {
         if (this.applyingProviderId === null) {
           this.pendingImport = null;
           this.applyError = null;
+        }
+      },
+      onBackfillFromChange: (value) => {
+        this.backfillFrom = value;
+        this.backfillPreview = null;
+        this.backfillProgress = null;
+        this.backfillRollbackResult = null;
+        this.backfillError = null;
+      },
+      onBackfillToChange: (value) => {
+        this.backfillTo = value;
+        this.backfillPreview = null;
+        this.backfillProgress = null;
+        this.backfillRollbackResult = null;
+        this.backfillError = null;
+      },
+      onBackfillPreview: () => void this.previewBackfill(),
+      onBackfillApply: () => void this.applyBackfill(),
+      onBackfillRollbackRequest: () => {
+        if (this.backfillBusy === null) {
+          this.backfillRollbackPending = true;
+          this.backfillError = null;
+        }
+      },
+      onBackfillRollbackConfirm: () => void this.confirmBackfillRollback(),
+      onBackfillRollbackCancel: () => {
+        if (this.backfillBusy === null) {
+          this.backfillRollbackPending = false;
         }
       },
     });

--- a/ui/src/pages/memory-import/view.test.ts
+++ b/ui/src/pages/memory-import/view.test.ts
@@ -74,6 +74,15 @@ function createProps(overrides: Partial<MemoryImportProps> = {}): MemoryImportPr
     applyingProviderId: null,
     pendingProviderId: null,
     lastResults: {},
+    backfillAvailable: true,
+    backfillFrom: "",
+    backfillTo: "",
+    backfillBusy: null,
+    backfillError: null,
+    backfillPreview: null,
+    backfillProgress: null,
+    backfillRollbackResult: null,
+    backfillRollbackPending: false,
     onSelectAgent: vi.fn(),
     onReplaceExisting: vi.fn(),
     onRefresh: vi.fn(),
@@ -81,6 +90,13 @@ function createProps(overrides: Partial<MemoryImportProps> = {}): MemoryImportPr
     onRequestImport: vi.fn(),
     onConfirmImport: vi.fn(),
     onCancelImport: vi.fn(),
+    onBackfillFromChange: vi.fn(),
+    onBackfillToChange: vi.fn(),
+    onBackfillPreview: vi.fn(),
+    onBackfillApply: vi.fn(),
+    onBackfillRollbackRequest: vi.fn(),
+    onBackfillRollbackConfirm: vi.fn(),
+    onBackfillRollbackCancel: vi.fn(),
     ...overrides,
   };
 }
@@ -141,6 +157,69 @@ describe("renderMemoryImport", () => {
     picker?.onSelect("writer");
     expect(onSelectAgent).toHaveBeenCalledWith("writer");
     container.remove();
+  });
+
+  it("renders per-day session backfill candidates and final staging progress", () => {
+    const container = document.createElement("div");
+    render(
+      renderMemoryImport(
+        createProps({
+          backfillPreview: {
+            days: 1,
+            candidates: 2,
+            staged: 0,
+            truncated: true,
+            perDay: [
+              {
+                day: "2026-07-01",
+                candidateCount: 2,
+                sample: ["Remember the release checklist", "Use the main agent"],
+              },
+            ],
+          },
+          backfillProgress: { days: 3, candidates: 7, staged: 4, complete: true },
+        }),
+      ),
+      container,
+    );
+
+    expect(container.textContent).toContain("2 candidates across 1 days");
+    expect(container.textContent).toContain("2026-07-01");
+    expect(container.textContent).toContain("Remember the release checklist");
+    expect(container.textContent).toContain("preview shows the first bounded batch");
+    expect(container.textContent).toContain("4 staged; promotion happens via dreaming");
+    expect(container.textContent).toContain("3 days processed");
+  });
+
+  it("requires destructive confirmation before session backfill rollback", () => {
+    const onBackfillRollbackConfirm = vi.fn();
+    const container = document.createElement("div");
+    render(
+      renderMemoryImport(createProps({ backfillRollbackPending: true, onBackfillRollbackConfirm })),
+      container,
+    );
+
+    expect(container.textContent).toContain("Tracked session cursors stay in place");
+    container
+      .querySelector<HTMLButtonElement>("[data-test-id='memory-backfill-rollback-confirm']")
+      ?.click();
+    expect(onBackfillRollbackConfirm).toHaveBeenCalledOnce();
+  });
+
+  it("serializes memory imports with backfill mutations", () => {
+    const importing = document.createElement("div");
+    render(renderMemoryImport(createProps({ applyingProviderId: "codex" })), importing);
+    expect(
+      importing.querySelector<HTMLButtonElement>("[data-test-id='memory-backfill-apply']")
+        ?.disabled,
+    ).toBe(true);
+
+    const backfilling = document.createElement("div");
+    render(renderMemoryImport(createProps({ backfillBusy: "apply" })), backfilling);
+    expect(
+      backfilling.querySelector<HTMLButtonElement>("[data-test-id='memory-import-provider-button']")
+        ?.disabled,
+    ).toBe(true);
   });
 
   it("passes the exact collection item ids when selection changes", () => {

--- a/ui/src/pages/memory-import/view.ts
+++ b/ui/src/pages/memory-import/view.ts
@@ -29,6 +29,27 @@ type MemoryCollection = {
   items: MemoryMigrationItem[];
 };
 
+export type SessionBackfillGatewayResult = {
+  days: number;
+  candidates: number;
+  perDay: Array<{ day: string; candidateCount: number; sample: string[] }>;
+  staged: number;
+  truncated?: boolean;
+  cursor?: { advanced: boolean; exhausted: boolean; hasMore: boolean };
+};
+
+export type SessionBackfillProgress = {
+  days: number;
+  candidates: number;
+  staged: number;
+  complete: boolean;
+};
+
+export type SessionBackfillRollbackResult = {
+  removedDiaryEntries: number;
+  removedStagedEntries: number;
+};
+
 type MemoryImportViewProps = {
   connected: boolean;
   agents: GatewayAgentRow[];
@@ -42,6 +63,15 @@ type MemoryImportViewProps = {
   applyingProviderId: string | null;
   pendingProviderId: string | null;
   lastResults: Record<string, MigrationsMemoryApplyResult>;
+  backfillAvailable: boolean;
+  backfillFrom: string;
+  backfillTo: string;
+  backfillBusy: "preview" | "apply" | "rollback" | null;
+  backfillError: string | null;
+  backfillPreview: SessionBackfillGatewayResult | null;
+  backfillProgress: SessionBackfillProgress | null;
+  backfillRollbackResult: SessionBackfillRollbackResult | null;
+  backfillRollbackPending: boolean;
   onSelectAgent: (agentId: string) => void;
   onReplaceExisting: (enabled: boolean) => void;
   onRefresh: () => void;
@@ -49,6 +79,13 @@ type MemoryImportViewProps = {
   onRequestImport: (providerId: string) => void;
   onConfirmImport: () => void;
   onCancelImport: () => void;
+  onBackfillFromChange: (value: string) => void;
+  onBackfillToChange: (value: string) => void;
+  onBackfillPreview: () => void;
+  onBackfillApply: () => void;
+  onBackfillRollbackRequest: () => void;
+  onBackfillRollbackConfirm: () => void;
+  onBackfillRollbackCancel: () => void;
 };
 
 function detailString(item: MemoryMigrationItem, key: string): string | undefined {
@@ -89,6 +126,15 @@ function fileCount(count: number): string {
   return t(count === 1 ? "memoryImport.fileCountOne" : "memoryImport.fileCount", {
     count: String(count),
   });
+}
+
+function processedDayCount(count: number): string {
+  return t(
+    count === 1
+      ? "memoryImport.backfill.processedDayCountOne"
+      : "memoryImport.backfill.processedDayCount",
+    { count: String(count) },
+  );
 }
 
 function artifactLabel(item: MemoryMigrationItem): string {
@@ -245,6 +291,10 @@ function renderProvider(props: MemoryImportViewProps, provider: MemoryMigrationP
   const selectedIds = new Set(props.selectedByProvider[provider.providerId] ?? []);
   const groups = groupMemoryItems(provider.items);
   const applying = props.applyingProviderId === provider.providerId;
+  const backfillMutating =
+    props.backfillBusy === "apply" ||
+    props.backfillBusy === "rollback" ||
+    props.backfillRollbackPending;
   const rows = provider.error
     ? html`<div class="callout danger" role="alert">${provider.error}</div>`
     : !provider.found
@@ -268,7 +318,10 @@ function renderProvider(props: MemoryImportViewProps, provider: MemoryMigrationP
               group,
               selectedIds,
               props.onToggleCollection,
-              props.loading || props.applyingProviderId !== null || props.error !== null,
+              props.loading ||
+                props.applyingProviderId !== null ||
+                props.error !== null ||
+                backfillMutating,
             ),
           )}
           ${renderSettingsRow({
@@ -282,6 +335,7 @@ function renderProvider(props: MemoryImportViewProps, provider: MemoryMigrationP
                 data-test-id="memory-import-provider-button"
                 ?disabled=${selectedIds.size === 0 ||
                 props.applyingProviderId !== null ||
+                backfillMutating ||
                 props.loading ||
                 props.error !== null}
                 @click=${() => props.onRequestImport(provider.providerId)}
@@ -370,7 +424,7 @@ function renderConfirmation(props: MemoryImportViewProps) {
 }
 
 function renderIntroSection(props: MemoryImportViewProps) {
-  const busy = props.loading || props.applyingProviderId !== null;
+  const busy = props.loading || props.applyingProviderId !== null || props.backfillBusy !== null;
   return renderSettingsSection(
     {
       title: t("memoryImport.title"),
@@ -411,6 +465,210 @@ function renderIntroSection(props: MemoryImportViewProps) {
   );
 }
 
+function renderBackfillConfirmation(props: MemoryImportViewProps) {
+  if (!props.backfillRollbackPending) {
+    return nothing;
+  }
+  return html`
+    <openclaw-modal-dialog
+      label=${t("memoryImport.backfill.rollbackConfirmTitle")}
+      description=${t("memoryImport.backfill.rollbackConfirmDescription")}
+      @modal-cancel=${props.onBackfillRollbackCancel}
+    >
+      <div class="exec-approval-card memory-import__confirm">
+        <div class="exec-approval-header">
+          <div>
+            <div class="exec-approval-title">
+              ${t("memoryImport.backfill.rollbackConfirmTitle")}
+            </div>
+            <div class="exec-approval-sub">
+              ${t("memoryImport.backfill.rollbackConfirmDescription")}
+            </div>
+          </div>
+        </div>
+        <div class="callout warn">${t("memoryImport.backfill.rollbackWarning")}</div>
+        <div class="exec-approval-actions">
+          <button
+            class="btn danger"
+            data-test-id="memory-backfill-rollback-confirm"
+            ?disabled=${props.backfillBusy !== null || props.applyingProviderId !== null}
+            @click=${props.onBackfillRollbackConfirm}
+          >
+            ${t("memoryImport.backfill.rollback")}
+          </button>
+          <button
+            class="btn"
+            ?disabled=${props.backfillBusy !== null || props.applyingProviderId !== null}
+            @click=${props.onBackfillRollbackCancel}
+          >
+            ${t("common.cancel")}
+          </button>
+        </div>
+      </div>
+    </openclaw-modal-dialog>
+  `;
+}
+
+function renderBackfillSection(props: MemoryImportViewProps) {
+  const busy = props.backfillBusy !== null || props.applyingProviderId !== null;
+  const result = props.backfillPreview;
+  return html`
+    <div data-test-id="memory-session-backfill">
+      ${renderSettingsSection(
+        {
+          title: t("memoryImport.backfill.title"),
+          description: t("memoryImport.backfill.subtitle"),
+        },
+        html`
+          ${props.backfillAvailable
+            ? html`
+                ${renderSettingsRow({
+                  title: t("memoryImport.backfill.dateRange"),
+                  description: t("memoryImport.backfill.dateRangeHint"),
+                  control: html`<div class="memory-import__backfill-dates">
+                    <label>
+                      <span>${t("memoryImport.backfill.from")}</span>
+                      <input
+                        class="input"
+                        type="date"
+                        .value=${props.backfillFrom}
+                        ?disabled=${busy}
+                        @input=${(event: Event) =>
+                          props.onBackfillFromChange(
+                            (event.currentTarget as HTMLInputElement).value,
+                          )}
+                      />
+                    </label>
+                    <label>
+                      <span>${t("memoryImport.backfill.to")}</span>
+                      <input
+                        class="input"
+                        type="date"
+                        .value=${props.backfillTo}
+                        ?disabled=${busy}
+                        @input=${(event: Event) =>
+                          props.onBackfillToChange((event.currentTarget as HTMLInputElement).value)}
+                      />
+                    </label>
+                  </div>`,
+                })}
+                ${renderSettingsRow({
+                  title: t("memoryImport.backfill.actions"),
+                  control: html`<div class="memory-import__backfill-actions">
+                    <button
+                      class="btn"
+                      data-test-id="memory-backfill-preview"
+                      ?disabled=${busy}
+                      @click=${props.onBackfillPreview}
+                    >
+                      ${props.backfillBusy === "preview"
+                        ? t("memoryImport.backfill.previewing")
+                        : t("memoryImport.backfill.preview")}
+                    </button>
+                    <button
+                      class="btn primary"
+                      data-test-id="memory-backfill-apply"
+                      ?disabled=${busy}
+                      @click=${props.onBackfillApply}
+                    >
+                      ${props.backfillBusy === "apply"
+                        ? t("memoryImport.backfill.applying")
+                        : t("memoryImport.backfill.apply")}
+                    </button>
+                    <button
+                      class="btn danger"
+                      data-test-id="memory-backfill-rollback"
+                      ?disabled=${busy}
+                      @click=${props.onBackfillRollbackRequest}
+                    >
+                      ${t("memoryImport.backfill.rollback")}
+                    </button>
+                  </div>`,
+                })}
+                ${props.backfillError
+                  ? html`<div class="callout danger" role="alert">${props.backfillError}</div>`
+                  : nothing}
+                ${result
+                  ? html`<div
+                      class="settings-row settings-row--stacked memory-import__backfill-preview"
+                    >
+                      <strong>
+                        ${t("memoryImport.backfill.previewSummary", {
+                          candidates: String(result.candidates),
+                          days: String(result.days),
+                        })}
+                      </strong>
+                      ${result.perDay.length > 0
+                        ? html`<ul>
+                            ${result.perDay.map(
+                              (day) => html`<li>
+                                <div>
+                                  <strong>${day.day}</strong>
+                                  <span>
+                                    ${t("memoryImport.backfill.candidateCount", {
+                                      count: String(day.candidateCount),
+                                    })}
+                                  </span>
+                                </div>
+                                ${day.sample.length > 0
+                                  ? html`<ul>
+                                      ${day.sample.map((sample) => html`<li>${sample}</li>`)}
+                                    </ul>`
+                                  : nothing}
+                              </li>`,
+                            )}
+                          </ul>`
+                        : html`<span>${t("memoryImport.backfill.noCandidates")}</span>`}
+                      ${result.truncated
+                        ? html`<div class="callout warn">
+                            ${t("memoryImport.backfill.previewTruncated")}
+                          </div>`
+                        : nothing}
+                    </div>`
+                  : nothing}
+                ${props.backfillProgress
+                  ? html`<div
+                      class="settings-row settings-row--stacked memory-import__backfill-progress"
+                      role="status"
+                    >
+                      <strong>
+                        ${props.backfillProgress.complete
+                          ? t("memoryImport.backfill.complete", {
+                              count: String(props.backfillProgress.staged),
+                            })
+                          : t("memoryImport.backfill.progress", {
+                              days: String(props.backfillProgress.days),
+                              staged: String(props.backfillProgress.staged),
+                            })}
+                      </strong>
+                      <span>
+                        ${t("memoryImport.backfill.processedCandidates", {
+                          count: String(props.backfillProgress.candidates),
+                        })}
+                        · ${processedDayCount(props.backfillProgress.days)}
+                      </span>
+                    </div>`
+                  : nothing}
+                ${props.backfillRollbackResult
+                  ? html`<div class="settings-row settings-row--stacked" role="status">
+                      <strong>${t("memoryImport.backfill.rollbackComplete")}</strong>
+                      <span>
+                        ${t("memoryImport.backfill.rollbackCounts", {
+                          diary: String(props.backfillRollbackResult.removedDiaryEntries),
+                          staged: String(props.backfillRollbackResult.removedStagedEntries),
+                        })}
+                      </span>
+                    </div>`
+                  : nothing}
+              `
+            : renderSettingsEmpty(t("memoryImport.backfill.unavailable"))}
+        `,
+      )}
+      ${renderBackfillConfirmation(props)}
+    </div>
+  `;
+}
+
 export function renderMemoryImport(props: MemoryImportViewProps) {
   if (!props.connected) {
     return renderSettingsPage(renderSettingsEmpty(t("memoryImport.disconnected")));
@@ -418,7 +676,7 @@ export function renderMemoryImport(props: MemoryImportViewProps) {
   return html`
     <div class="memory-import" data-test-id="memory-import-page">
       ${renderSettingsPage(html`
-        ${renderIntroSection(props)}
+        ${renderIntroSection(props)} ${renderBackfillSection(props)}
         ${props.error
           ? html`<div class="callout danger" role="alert">${props.error}</div>`
           : nothing}

--- a/ui/src/styles/memory-import.css
+++ b/ui/src/styles/memory-import.css
@@ -231,6 +231,66 @@
   margin-top: 12px;
 }
 
+.memory-import__backfill-dates,
+.memory-import__backfill-actions {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 8px;
+}
+
+.memory-import__backfill-dates label {
+  display: grid;
+  gap: 4px;
+  color: var(--muted);
+  font-size: 10px;
+  text-align: left;
+}
+
+.memory-import__backfill-dates input {
+  min-width: 150px;
+}
+
+.memory-import__backfill-preview.settings-row,
+.memory-import__backfill-progress.settings-row {
+  display: grid;
+  gap: 6px;
+}
+
+.memory-import__backfill-preview > ul,
+.memory-import__backfill-preview > ul > li > ul {
+  display: grid;
+  gap: 6px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.memory-import__backfill-preview > ul > li {
+  display: grid;
+  gap: 4px;
+  padding-top: 6px;
+  border-top: 1px solid var(--border);
+}
+
+.memory-import__backfill-preview > ul > li > div {
+  display: flex;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.memory-import__backfill-preview > ul > li > ul {
+  color: var(--muted);
+  font-size: 10px;
+}
+
+@media (max-width: 720px) {
+  .memory-import__backfill-dates,
+  .memory-import__backfill-actions {
+    justify-content: flex-start;
+  }
+}
+
 @keyframes memory-import-pulse {
   to {
     background-position: -200% 0;


### PR DESCRIPTION
## What Problem This Solves

Operators can backfill trusted memory candidates from retained agent sessions with the CLI, but the Control UI has no way to preview, apply, or roll back that history. This leaves a useful recovery and migration workflow inaccessible to browser-based administration.

## Why This Change Was Made

Memory Core now registers three additive plugin-owned Gateway methods and the existing Memory Import page exposes a “From past sessions” card. Preview and apply share the canonical session-backfill executor; apply uses bounded, client-driven 14-day calls with persisted idempotent cursors, so no job system or new core Gateway surface is required.

The three Gateway methods are approved additive plugin-registered surfaces, using the same policy recorded on #114819 and #115162. No protocol-version bump or core Gateway edit is needed.

This PR is AI-assisted. I reviewed the implementation, ran the repository’s autoreview workflow to a clean result, and understand the ownership and continuation contracts.

## User Impact

From Import Memory, an operator can select an agent and optional date range, preview per-day session candidates and samples, apply the history with visible cumulative progress, or confirm a rollback. Bounded previews clearly say when more candidates remain, Gateway errors are shown directly, and rollback removes only the diary/staged entries owned by session backfill while preserving tracked cursors.

## Evidence

### Live coordinator validation

The coordinator validated this end to end in a real browser against a development Gateway with real retained sessions. Full notes and artifacts: https://gist.github.com/steipete/d00e9b8ee024ab3430abc791e8668e2f (`live-ui-proof.md`).

- Preview returned 42 candidates.
- Apply added exactly 42 database-backed recall entries, moving the count from 70 to 112.
- Rollback removed exactly those 42 entries and left all 70 pre-existing recall entries untouched.

![before](https://gist.githubusercontent.com/steipete/d00e9b8ee024ab3430abc791e8668e2f/raw/before-session-backfill.png)

![after](https://gist.githubusercontent.com/steipete/d00e9b8ee024ab3430abc791e8668e2f/raw/after-session-backfill-preview.png)

### Gateway methods and authorization

| Method | Scope |
| --- | --- |
| `memory.sessionBackfill.preview` | `operator.read` |
| `memory.sessionBackfill.apply` | `operator.admin` |
| `memory.sessionBackfill.rollback` | `operator.admin` |

### Automated proof

- 135 focused assertions passed after rebasing onto `origin/main`: Memory Core gateway (6), shared executor (13), plugin registration (22), Memory Core CLI (75), Control UI page (10), and view (9).
- `node scripts/check-changed.mjs -- <11 changed files>` passed on the final corrected head in Blacksmith Testbox: all typecheck lanes, formatting, Control UI i18n, plugin boundaries, full core/UI/packages/extension lint, database-first guards, sidecar-loader checks, and runtime import-cycle checks (28m13s; the initial post-rebase pass was 36m40s).
- `deadcode:dependencies` and production/full-tree/script unused-export scans pass with zero entries after the CI follow-up.
- Source-blind mocked-browser validation passed preview, chunked apply, rollback confirmation, range-result reset, Gateway error display, and mutation serialization.
- Final Codex autoreview reported no accepted/actionable findings.

### Progress design

Apply intentionally has no server-side job. The UI drives small `limitDays=14` calls, requires authoritative cursor advancement for positive batches, accumulates unique processed days and staged counts, and finishes only after the idempotent zero-candidate exhausted sentinel. Per-message hashes and persisted ingestion cursors make retries converge safely.
