### PR TITLE
test(migrations): make checkpoint rehash fixture deterministic

### DIFF
--- a/src/infra/state-migrations.audit-logs.test.ts
+++ b/src/infra/state-migrations.audit-logs.test.ts
@@ -11,6 +11,7 @@ import { listSystemAgentAuditEntriesForTests } from "../system-agent/audit.test-
 import { withTempDir } from "../test-helpers/temp-dir.js";
 import { acquireGatewayLock } from "./gateway-lock.js";
 import { createSqliteAuditRecordStore } from "./sqlite-audit-record-store.js";
+import { openLegacyAuditRawCheckpointStore } from "./state-migrations.audit-checkpoints.js";
 import { detectLegacyAuditLogs, migrateLegacyAuditLogs } from "./state-migrations.audit-logs.js";
 
 const TEST_AUDIT_SCRUB_PATTERN = Buffer.from(
@@ -202,10 +203,26 @@ describe("legacy core audit log migration", () => {
       const modifiedRaw = `${JSON.stringify(modified)}\n`;
       expect(Buffer.byteLength(modifiedRaw)).toBe(checkpointedStat.size);
       await fs.writeFile(rawPath, modifiedRaw);
-      await fs.utimes(rawPath, checkpointedStat.atimeMs / 1_000, checkpointedStat.mtimeMs / 1_000);
       const rewrittenStat = await fs.stat(rawPath);
-      expect(rewrittenStat.mtimeMs).toBe(checkpointedStat.mtimeMs);
       expect(rewrittenStat.size).toBe(checkpointedStat.size);
+      const checkpointStore = openLegacyAuditRawCheckpointStore(stateDir);
+      const checkpoint = checkpointStore.entries()[0];
+      if (!checkpoint) {
+        throw new Error("expected a raw archive checkpoint");
+      }
+      // Match the rewritten file's cheap identity while retaining the original content hash.
+      // Detection must still hash the archive before treating the checkpoint as current.
+      checkpointStore.upsert(
+        checkpoint.key,
+        {
+          ...checkpoint.value,
+          dev: rewrittenStat.dev,
+          ino: rewrittenStat.ino,
+          mtimeMs: rewrittenStat.mtimeMs,
+          size: rewrittenStat.size,
+        },
+        checkpoint.createdAt,
+      );
 
       const detected = detectLegacyAuditLogs({ stateDir, doctorOnlyStateMigrations: true });
       expect(detected.sources).toMatchObject([{ sourcePath: rawPath, storage: "raw-archive" }]);


### PR DESCRIPTION
## Summary

- stop relying on bit-exact sub-millisecond `mtime` restoration in the audit checkpoint rehash test
- align the stored checkpoint metadata with the rewritten file while retaining the stale content hash
- keep the test focused on the production invariant: matching cheap metadata must still trigger content hashing

Fixes #115268

## Verification

- `node scripts/run-vitest.mjs src/infra/state-migrations.audit-logs.test.ts -t "rehashes a checkpointed raw archive before treating it as clean"` (1 passed, 18 skipped)
- `node scripts/run-vitest.mjs src/infra/state-migrations.audit-logs.test.ts` (19 passed)
- remote changed gate: https://github.com/openclaw/openclaw/actions/runs/30375016852 (passed; 5m42s command, 6m11s total)
- `./node_modules/.bin/oxfmt --check src/infra/state-migrations.audit-logs.test.ts`
- `git diff --check`
- autoreview: clean, no actionable findings

## Risk

Test-only. The fixture now constructs the metadata/hash mismatch directly instead of depending on filesystem timestamp precision.