### PR TITLE
test(signal): verify archive limits without malformed tar

### DIFF
--- a/extensions/signal/src/install-signal-cli.test.ts
+++ b/extensions/signal/src/install-signal-cli.test.ts
@@ -2,19 +2,27 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { gzipSync } from "node:zlib";
 import JSZip from "jszip";
 import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
 import * as tar from "tar";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { ReleaseAsset } from "./install-signal-cli.js";
 
+type CapturedArchiveLimits = {
+  maxArchiveBytes?: number;
+  maxEntries?: number;
+  maxEntryBytes?: number;
+  maxExtractedBytes?: number;
+};
+
 const {
+  extractArchiveLimits,
   fetchWithSsrFGuardMock,
   resolveBrewExecutableMock,
   runPluginCommandWithTimeoutMock,
   tempDownloadPaths,
 } = vi.hoisted(() => ({
+  extractArchiveLimits: [] as CapturedArchiveLimits[],
   fetchWithSsrFGuardMock: vi.fn(),
   resolveBrewExecutableMock: vi.fn(),
   runPluginCommandWithTimeoutMock: vi.fn(),
@@ -29,6 +37,10 @@ vi.mock("openclaw/plugin-sdk/setup-tools", async (importOriginal) => {
   const actual = await importOriginal<typeof import("openclaw/plugin-sdk/setup-tools")>();
   return {
     ...actual,
+    extractArchive: async (params: Parameters<typeof actual.extractArchive>[0]) => {
+      extractArchiveLimits.push(params.limits ?? {});
+      return await actual.extractArchive(params);
+    },
     resolveBrewExecutable: resolveBrewExecutableMock,
   };
 });
@@ -119,6 +131,7 @@ function setProcessPlatform(platform: NodeJS.Platform, arch: string) {
 }
 
 beforeEach(() => {
+  extractArchiveLimits.length = 0;
   fetchWithSsrFGuardMock.mockReset();
   resolveBrewExecutableMock.mockReset();
   runPluginCommandWithTimeoutMock.mockReset();
@@ -651,7 +664,7 @@ describe("extractSignalCliArchive", () => {
     });
   });
 
-  it("extracts tar.gz archives", async () => {
+  it("extracts tar.gz archives with Signal-specific limits", async () => {
     await withArchiveWorkspace(async (workDir) => {
       const archivePath = path.join(workDir, "ok.tgz");
       const extractDir = path.join(workDir, "extract");
@@ -662,28 +675,14 @@ describe("extractSignalCliArchive", () => {
 
       await fs.mkdir(extractDir, { recursive: true });
       await expectExtractedSignalCli(archivePath, extractDir);
-    });
-  });
-
-  it("rejects native entries beyond the Signal-specific extraction limit", async () => {
-    await withArchiveWorkspace(async (workDir) => {
-      const archivePath = path.join(workDir, "oversized.tgz");
-      const extractDir = path.join(workDir, "extract");
-      const headerBlock = Buffer.alloc(512);
-      const header = new tar.Header({
-        path: "signal-cli",
-        type: "File",
-        mode: 0o755,
-        size: MAX_SIGNAL_CLI_EXTRACTED_BYTES + 1,
-      });
-      header.encode(headerBlock);
-      await fs.writeFile(archivePath, gzipSync(Buffer.concat([headerBlock, Buffer.alloc(1024)])));
-      await fs.mkdir(extractDir, { recursive: true });
-
-      await expect(extractSignalCliArchive(archivePath, extractDir, 5_000)).rejects.toThrow(
-        "archive entry extracted size exceeds limit",
-      );
-      await expectPathMissing(path.join(extractDir, "signal-cli"));
+      expect(extractArchiveLimits).toEqual([
+        {
+          maxArchiveBytes: 256 * 1024 * 1024,
+          maxEntries: 32,
+          maxEntryBytes: MAX_SIGNAL_CLI_EXTRACTED_BYTES,
+          maxExtractedBytes: MAX_SIGNAL_CLI_EXTRACTED_BYTES,
+        },
+      ]);
     });
   });
 });


### PR DESCRIPTION
## Summary

- remove the truncated synthetic TAR fixture that depended on parser error ordering
- keep exercising a valid Signal CLI tar.gz extraction through the real shared extractor
- capture and assert the Signal-specific archive, entry-count, per-entry, and aggregate extraction limits

Fixes #115267

## Verification

- `node scripts/run-vitest.mjs extensions/signal/src/install-signal-cli.test.ts` (42 passed)
- remote extension-test typecheck: https://github.com/openclaw/openclaw/actions/runs/30374741761 (passed; 2m12s command, 2m44s total)
- `./node_modules/.bin/oxfmt --check extensions/signal/src/install-signal-cli.test.ts`
- `git diff --check`
- autoreview: clean, no actionable findings

## Risk

Test-only. Shared archive tests continue to prove enforcement with valid small TAR/ZIP archives; this test verifies the Signal installer passes its larger product-specific limits.