### PR TITLE
fix(agents): materialize MCP for server-name toolsAllow globs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -370,6 +370,7 @@ Docs: https://docs.openclaw.ai
 - **iOS QR gateway handoff:** stop VisionKit before delivering scanned setup codes, and keep deferred auth, approval, Watch, and foreground-node work bound to its originating gateway across reconnects. (#99572) Thanks @PollyBot13.
 - **Agent terminal failures:** surface a safe interactive reply when an agent run ends without visible output, while preserving completed message-tool delivery and heartbeat-specific guidance. (#99304) Thanks @moeedahmed.
 - **MCP loopback tool results:** preserve schema-valid text, image, and embedded-resource content through HTTP tool calls while rendering malformed or protocol-incompatible blocks as safe text. (#100336) Thanks @tzy-17.
+- **MCP server globs:** discover configured MCP tools for narrow runtime allowlists such as `server*`, using canonical enabled-server names while preserving final tool policy. (#115277) Thanks @ericcaiwx-star.
 - **Control UI tool-result images:** render direct image content blocks from Gateway history and make the delayed-send scroll E2E setup deterministic. (#100295) Thanks @lzyyzznl.
 - **Control UI live tool ordering:** keep assistant stream text before its matching tool card when browser and Gateway timestamps disagree. (#93184) Thanks @Pick-cat.
 - **Plugin approval diagnostics:** distinguish request validation rejections, expired wait decisions, and unavailable Gateways while keeping approval failures fail-closed. (#100337) Thanks @tzy-17.

--- a/docs/gateway/config-tools.md
+++ b/docs/gateway/config-tools.md
@@ -62,6 +62,8 @@ Configured MCP servers are exposed as plugin-owned tools under the `bundle-mcp` 
 
 Server globs use the provider-safe MCP server prefix, not necessarily the raw `mcp.servers` key. Non-`[A-Za-z0-9_-]` characters become `-`, names that do not start with a letter get an `mcp-` prefix, and long or duplicate prefixes may be truncated or suffixed; for example, `mcp.servers["Outlook Graph"]` uses a glob like `outlook-graph__*`.
 
+Per-run `toolsAllow` caps also accept globs such as `outlook*` or `out*graph*` for configured MCP servers. These globs can trigger catalog discovery across all enabled static MCP servers, just like `outlook__*`; they do not limit which servers connect. Discovery is conservative and can run even when no tool ultimately matches. Final tool allow/deny and sandbox policies still apply, disabled servers remain excluded unless explicitly enabled by a session override, and requester-scoped servers still require their verified requester context.
+
 ```json5
 {
   agents: { defaults: { sandbox: { mode: "all" } } },

--- a/src/agents/embedded-agent-runner/run/attempt-bundle-tools.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-bundle-tools.test.ts
@@ -1,4 +1,8 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  createPluginMetadataSnapshot,
+  makeRegistry,
+} from "../../../config/plugin-auto-enable.test-helpers.js";
 import { setPluginToolMeta } from "../../../plugins/tools.js";
 import { attachToolAllowlistIntersection } from "../../tool-policy.js";
 
@@ -79,6 +83,127 @@ describe("prepareEmbeddedAttemptBundleTools", () => {
       sessionAgentId: "main",
     } as unknown as Parameters<typeof prepareEmbeddedAttemptBundleTools>[0];
   }
+
+  it.each([
+    { allow: ["chrome*"], expected: ["chrome__click"] },
+    { allow: ["ch*me*"], expected: ["chrome__click"] },
+    { allow: [" CHROME* "], expected: ["chrome__click"] },
+    { allow: ["*click"], expected: ["chrome__click", "other__click"] },
+    { allow: ["chrome__*"], expected: ["chrome__click"] },
+    { allow: ["chrome*."], expected: [] },
+    { allow: ["exec*"], expected: [], discover: false },
+    { allow: ["chrome"], expected: [], discover: false },
+    { allow: [], expected: [], discover: false },
+  ])("discovers configured MCP for $allow without widening final tools", async (testCase) => {
+    const input = createInput([], []);
+    input.attempt.config = {
+      plugins: { enabled: false },
+      mcp: { servers: { chrome: { command: "unused" }, other: { command: "unused" } } },
+    };
+    input.attempt.toolsAllow = testCase.allow;
+    input.preparedToolBase.effectiveToolsAllow = testCase.allow;
+    mocks.getOrCreateSessionMcpRuntime.mockResolvedValue({});
+    mocks.materializeBundleMcpToolsForRun.mockResolvedValue({
+      tools: [{ name: "chrome__click" }, { name: "other__click" }],
+    });
+
+    const result = await prepareEmbeddedAttemptBundleTools(input);
+
+    expect(mocks.getOrCreateSessionMcpRuntime).toHaveBeenCalledTimes(
+      testCase.discover === false ? 0 : 1,
+    );
+    expect(result.uncompactedEffectiveTools.map((tool) => tool.name)).toEqual(testCase.expected);
+    expect(mocks.createBundleLspToolRuntime).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    { enabled: false, override: undefined, expected: false },
+    { enabled: true, override: false, expected: false },
+    { enabled: false, override: true, expected: true },
+  ])("uses effective MCP enablement $enabled/$override", async (testCase) => {
+    const input = createInput([], []);
+    input.attempt.config = {
+      plugins: { enabled: false },
+      mcp: { servers: { chrome: { command: "unused", enabled: testCase.enabled } } },
+    };
+    input.attempt.toolsAllow = ["chrome*"];
+    if (testCase.override !== undefined) {
+      input.attempt.toolOverrides = { mcpServers: { chrome: testCase.override } };
+    }
+
+    await prepareEmbeddedAttemptBundleTools(input);
+
+    expect(mocks.getOrCreateSessionMcpRuntime).toHaveBeenCalledTimes(testCase.expected ? 1 : 0);
+  });
+
+  it.each([
+    { servers: ["chrome dev"], allow: "chrome-dev*" },
+    { servers: ["9chrome"], allow: "mcp-9chrome*" },
+    { servers: ["chrome dev", "chrome-dev"], allow: "chrome-dev-2*" },
+    { servers: ["a".repeat(31), "a".repeat(32)], allow: `${"a".repeat(28)}-2*` },
+    { servers: ["bash"], allow: "bash*" },
+  ])("uses canonical namespace allocation for $servers", async ({ servers, allow }) => {
+    const input = createInput([], []);
+    input.attempt.config = {
+      plugins: { enabled: false },
+      mcp: { servers: Object.fromEntries(servers.map((name) => [name, { command: "unused" }])) },
+    };
+    input.attempt.toolsAllow = [allow];
+
+    await prepareEmbeddedAttemptBundleTools(input);
+
+    expect(mocks.getOrCreateSessionMcpRuntime).toHaveBeenCalledOnce();
+  });
+
+  it.each(["disableTools", "raw", "restart", "reconciliation", "model"])(
+    "does not discover matching MCP when tools are disabled by %s",
+    async (mode) => {
+      const input = createInput([], []);
+      input.attempt.config = { mcp: { servers: { chrome: { command: "unused" } } } };
+      input.attempt.toolsAllow = ["chrome*"];
+      input.attempt.disableTools = mode === "disableTools";
+      input.isRawModelRun = mode === "raw";
+      input.attempt.forceRestartSafeTools = mode === "restart";
+      input.attempt.forceCodeModeReconciliationTools = mode === "reconciliation";
+      input.preparedToolBase.toolsEnabled = mode !== "model";
+
+      await prepareEmbeddedAttemptBundleTools(input);
+
+      expect(mocks.getOrCreateSessionMcpRuntime).not.toHaveBeenCalled();
+    },
+  );
+
+  it("allocates configured namespaces after colliding enabled plugin servers", async () => {
+    const input = createInput([], []);
+    input.attempt.config = {
+      plugins: { entries: { "native-mcp": { enabled: true } } },
+      mcp: { servers: { "chrome-dev": { command: "unused" } } },
+    };
+    input.attempt.toolsAllow = ["chrome-dev-2*"];
+    input.preparedToolBase.effectiveToolsAllow = input.attempt.toolsAllow;
+    const registry = makeRegistry([{ id: "native-mcp", channels: [] }]);
+    const record = registry.plugins[0];
+    if (!record) {
+      throw new Error("missing native plugin fixture");
+    }
+    record.format = "openclaw";
+    record.mcpServers = { "chrome dev": { command: "unused" } };
+    const snapshot = createPluginMetadataSnapshot({
+      config: input.attempt.config,
+      manifestRegistry: registry,
+    });
+    input.getCurrentAttemptPluginMetadataSnapshot = () => snapshot;
+    mocks.getOrCreateSessionMcpRuntime.mockResolvedValue({});
+    mocks.materializeBundleMcpToolsForRun.mockResolvedValue({
+      tools: [{ name: "chrome-dev__click" }, { name: "chrome-dev-2__click" }],
+    });
+
+    const result = await prepareEmbeddedAttemptBundleTools(input);
+
+    expect(result.uncompactedEffectiveTools.map((tool) => tool.name)).toEqual([
+      "chrome-dev-2__click",
+    ]);
+  });
 
   it.each([
     {

--- a/src/agents/embedded-agent-runner/run/attempt-bundle-tools.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-bundle-tools.ts
@@ -1,5 +1,7 @@
 import { getPluginToolMeta } from "../../../plugins/tools.js";
 import { createBundleLspToolRuntime } from "../../agent-bundle-lsp-runtime.js";
+import { assignSafeServerNames, TOOL_NAME_SEPARATOR } from "../../agent-bundle-mcp-names.js";
+import { loadSessionMcpConfig } from "../../agent-bundle-mcp-runtime-config.js";
 import {
   getOrCreateSessionMcpRuntime,
   materializeBundleMcpToolsForRun,
@@ -82,6 +84,18 @@ export async function prepareEmbeddedAttemptBundleTools(params: {
           isRuntimeToolAllowed(definition.function.name, effectiveToolsAllow),
         )
       : providedClientTools;
+  const bundleMetadataSnapshot = params.getCurrentAttemptPluginMetadataSnapshot();
+  // Scoped registries are partial views; only complete snapshots can bypass bundle discovery.
+  const bundleManifestRegistry =
+    bundleMetadataSnapshot?.pluginIds === undefined
+      ? bundleMetadataSnapshot?.manifestRegistry
+      : undefined;
+  const mcpConfig = {
+    workspaceDir: params.effectiveWorkspace,
+    cfg: params.attempt.config,
+    manifestRegistry: bundleManifestRegistry,
+    toolOverrides: params.attempt.toolOverrides,
+  };
   const bundleMcpEnabled =
     !params.attempt.forceRestartSafeTools &&
     !params.attempt.forceCodeModeReconciliationTools &&
@@ -89,28 +103,33 @@ export async function prepareEmbeddedAttemptBundleTools(params: {
       toolsEnabled,
       disableTools: params.attempt.disableTools || params.isRawModelRun,
       toolsAllow: params.attempt.toolsAllow,
+      resolveConfiguredMcpNamespaces: () => {
+        const configuredNames = Object.keys(params.attempt.config?.mcp?.servers ?? {});
+        if (configuredNames.length === 0) {
+          return [];
+        }
+        const { loaded } = loadSessionMcpConfig({ ...mcpConfig, logDiagnostics: false });
+        // Use the complete merged declaration order: bundled peers can own a
+        // collision suffix before a configured server. This does not connect MCP.
+        const safeNames = assignSafeServerNames(Object.keys(loaded.mcpServers));
+        return configuredNames.flatMap((name) => {
+          const safeName = safeNames.get(name);
+          return safeName ? [`${safeName}${TOOL_NAME_SEPARATOR}`] : [];
+        });
+      },
     });
-  const bundleMetadataSnapshot = params.getCurrentAttemptPluginMetadataSnapshot();
-  // Scoped registries are partial views; only complete snapshots can bypass bundle discovery.
-  const bundleManifestRegistry =
-    bundleMetadataSnapshot?.pluginIds === undefined
-      ? bundleMetadataSnapshot?.manifestRegistry
-      : undefined;
   const bundleMcpSessionRuntime = bundleMcpEnabled
     ? await getOrCreateSessionMcpRuntime({
+        ...mcpConfig,
         sessionId: params.attempt.sessionId,
         sessionKey: params.attempt.sessionKey,
-        workspaceDir: params.effectiveWorkspace,
         agentDir: params.agentDir,
-        cfg: params.attempt.config,
-        manifestRegistry: bundleManifestRegistry,
         // senderId is only set from the verified inbound sender (sessionCtx.SenderId
         // or the triggering run's sender on follow-ups). Cron/subagent/heartbeat runs
         // leave it unset, so requester-scoped MCP stays fail-closed for those paths.
         requesterSenderId: params.attempt.senderId,
         agentAccountId: params.attempt.agentAccountId,
         messageChannel: params.attempt.messageChannel ?? params.attempt.messageProvider,
-        toolOverrides: params.attempt.toolOverrides,
       })
     : undefined;
   const bundleMcpRuntime = bundleMcpSessionRuntime

--- a/src/agents/embedded-agent-runner/run/attempt-tool-construction-plan.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-tool-construction-plan.test.ts
@@ -1,5 +1,5 @@
 // Coverage for embedded attempt tool construction and runtime allowlists.
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { attachToolAllowlistIntersection } from "../../tool-policy.js";
 import {
   applyEmbeddedAttemptToolsAllow,
@@ -510,6 +510,36 @@ describe("resolveEmbeddedAttemptToolConstructionPlan", () => {
 });
 
 describe("shouldCreateBundleMcpRuntimeForAttempt", () => {
+  it.each([
+    { toolsAllow: undefined, expected: true },
+    { toolsAllow: ["*"], expected: true },
+    { toolsAllow: ["chrome*", "bundle-mcp"], expected: true },
+    { toolsAllow: ["chrome*", "group:plugins"], expected: true },
+    { toolsAllow: ["chrome*", "other__tool"], expected: true },
+    { toolsAllow: [], expected: false },
+    { toolsAllow: ["bash"], expected: false },
+  ])("keeps decisive allowlists metadata-free: $toolsAllow", ({ toolsAllow, expected }) => {
+    const resolveConfiguredMcpNamespaces = vi.fn(() => ["chrome__"]);
+    expect(
+      shouldCreateBundleMcpRuntimeForAttempt({
+        toolsEnabled: true,
+        toolsAllow,
+        resolveConfiguredMcpNamespaces,
+      }),
+    ).toBe(expected);
+    expect(resolveConfiguredMcpNamespaces).not.toHaveBeenCalled();
+  });
+
+  it("does not treat a generated bash namespace as the core exec alias", () => {
+    expect(
+      shouldCreateBundleMcpRuntimeForAttempt({
+        toolsEnabled: true,
+        toolsAllow: ["exec*"],
+        resolveConfiguredMcpNamespaces: () => ["bash__"],
+      }),
+    ).toBe(false);
+  });
+
   it("skips bundle MCP runtime when tools are disabled", () => {
     expect(shouldCreateBundleMcpRuntimeForAttempt({ toolsEnabled: false })).toBe(false);
     expect(shouldCreateBundleMcpRuntimeForAttempt({ toolsEnabled: true, disableTools: true })).toBe(

--- a/src/agents/embedded-agent-runner/run/attempt-tool-construction-plan.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-tool-construction-plan.ts
@@ -7,6 +7,7 @@ import {
   type OpenClawCodingToolConstructionPlan,
   resolveCoreToolFactoryFamily,
 } from "../../core-tool-factory-descriptors.js";
+import { mayMatchGlobWithPrefix } from "../../glob-pattern.js";
 import { isToolAllowedByPolicyName } from "../../tool-policy-match.js";
 import {
   attachToolAllowlistIntersection,
@@ -44,10 +45,6 @@ function cloneCodingToolConstructionPlan(
 function isBundleMcpAllowlistName(normalized: string): boolean {
   // Bundle MCP tools use the synthetic bundle name or `bundle__tool` separator form.
   return normalized === "bundle-mcp" || normalized.includes(TOOL_NAME_SEPARATOR);
-}
-
-function isPluginGroupAllowlistName(normalized: string): boolean {
-  return normalized === "group:plugins";
 }
 
 function hasWildcardToolAllowlist(toolsAllow: string[]): boolean {
@@ -219,7 +216,7 @@ function shouldCreateBundleRuntimeForAttempt(
     disableTools?: boolean;
     toolsAllow?: string[];
   },
-  matchesAllowlist: (normalizedToolName: string) => boolean,
+  matchesAllowlist: (normalizedToolNames: string[]) => boolean,
 ): boolean {
   if (!params.toolsEnabled || params.disableTools === true) {
     return false;
@@ -233,21 +230,33 @@ function shouldCreateBundleRuntimeForAttempt(
   if (hasWildcardToolAllowlist(params.toolsAllow)) {
     return true;
   }
-  return params.toolsAllow.some((toolName) => matchesAllowlist(normalizeToolPolicyName(toolName)));
+  return matchesAllowlist(params.toolsAllow.map(normalizeToolPolicyName));
 }
 
 /**
  * Decides whether the bundled MCP runtime is needed for this attempt. Bundle
- * runtime creation follows explicit bundle/plugin allowlist names rather than
- * generic local tool names.
+ * runtime creation follows explicit bundle/plugin names or globs that can reach
+ * a configured server namespace. Final tool policy remains authoritative.
  */
 export function shouldCreateBundleMcpRuntimeForAttempt(params: {
   toolsEnabled: boolean;
   disableTools?: boolean;
   toolsAllow?: string[];
+  resolveConfiguredMcpNamespaces?: () => string[];
 }): boolean {
-  return shouldCreateBundleRuntimeForAttempt(params, (normalized) => {
-    return isBundleMcpAllowlistName(normalized) || isPluginGroupAllowlistName(normalized);
+  return shouldCreateBundleRuntimeForAttempt(params, (names) => {
+    if (names.some((name) => isBundleMcpAllowlistName(name) || name === "group:plugins")) {
+      return true;
+    }
+    // Discovery can start all enabled static servers, even if a later glob
+    // constraint matches no tool. Only final full-name policy grants tools.
+    const globs = names.filter((name) => name.includes("*"));
+    return (
+      globs.length > 0 &&
+      (params.resolveConfiguredMcpNamespaces?.() ?? []).some((namespace) =>
+        globs.some((glob) => mayMatchGlobWithPrefix(glob, namespace.toLowerCase())),
+      )
+    );
   });
 }
 
@@ -261,7 +270,7 @@ export function shouldCreateBundleLspRuntimeForAttempt(params: {
   disableTools?: boolean;
   toolsAllow?: string[];
 }): boolean {
-  return shouldCreateBundleRuntimeForAttempt(params, (normalized) => {
-    return normalized.startsWith("lsp_");
-  });
+  return shouldCreateBundleRuntimeForAttempt(params, (names) =>
+    names.some((name) => name.startsWith("lsp_")),
+  );
 }

--- a/src/agents/glob-pattern.ts
+++ b/src/agents/glob-pattern.ts
@@ -57,3 +57,13 @@ export function matchesAnyGlobPattern(value: string, patterns: CompiledGlobPatte
   }
   return false;
 }
+
+/** Conservative discovery hint; concrete values still need the full glob matcher. */
+export function mayMatchGlobWithPrefix(pattern: string, prefix: string): boolean {
+  const wildcard = pattern.indexOf("*");
+  if (wildcard < 0) {
+    return false;
+  }
+  const literalHead = pattern.slice(0, wildcard);
+  return prefix.startsWith(literalHead) || literalHead.startsWith(prefix);
+}


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where isolated cron and other narrow-allowlist agent turns could not call configured MCP tools when `toolsAllow` used a server glob such as `chrome*`. The tool was filtered out before its server catalog was discovered, even though the final tool-name matcher would allow `chrome__click`.

## Why This Change Was Made

Construction planning now uses the canonical merged enabled-server configuration and collision-safe namespace assignment for otherwise-unrecognized globs. It reuses the existing metadata cache and final tool-policy flow instead of maintaining separate enablement and collision heuristics. The rewrite also covers interior globs, sanitized names, plugin/configured collisions, and explicit session enablement.

Discovery is intentionally conservative: like an existing `chrome__*` allowlist, a matching `chrome*` can initialize and list **all enabled static servers**, not only the named server. A glob can trigger discovery yet match no final tool. This is a construction hint, not new connection authorization or a full glob-language solver. Disabled servers, requester-scoped connections, final allow/deny policy, sandbox restrictions, raw MCP identities, and Codex raw-name filtering retain their existing owners.

## User Impact

Configured MCP server globs now reach their tools during restricted agent turns. Bare server names remain unsupported as tool names, unrelated core-only allowlists do not start MCP, and no-tools/raw/restart-safe paths remain disabled. No new setting, dependency, or migration is required.

AI-assisted maintainer rewrite of @ericcaiwx-star's reported bug and original PR. Production: +61/-23 (net +38); tests: +156/-1. The additional production code supplies the missing metadata-informed construction boundary; common config parameters and the single-use plugin-group predicate were consolidated.

## Evidence

### Before-fix, independently reproduced

On trusted main `53c0ca97540410486d5f213a5fd3a8e41f3280e3`, actual embedded tool preparation with `chrome*` and `ch*me*` produced no MCP tool and left an isolated Chromium page at zero clicks. The otherwise-identical `chrome__*` control completed both static servers' real stdio `initialize` and `tools/list`, exposed only `chrome__click`, called raw tool `click`, and changed the page from 0 to 1. [Isolated proof run](https://github.com/openclaw/openclaw/actions/runs/33057582781).

Exactly two expected regressions and eight controls completed. Final-denied tools were unavailable, requester-only connections received no request, disabled servers did not start, and app-only tools stayed out of the model surface. Full tracked-source hashes and the actually loaded module closure were verified. All owned processes and the test machine were stopped.

This is live MCP-to-browser owner-boundary proof with a provider-normalization fixture, not a full model, cron, authenticated external-service, Gateway WebSocket, or Codex runtime round trip.

### After-fix, independently verified

The exact reviewed patch passed all 10 scenarios in the [candidate proof run](https://github.com/openclaw/openclaw/actions/runs/33060577640). Both `chrome*` and `ch*me*` now complete real MCP initialization/listing/call and change the browser page from 0 to 1, matching the unchanged separator control.

| Scenario | Static servers discovered | Callable MCP tools | Browser count |
| --- | --- | --- | --- |
| `chrome*`, `ch*me*`, `chrome__*` | Both configured fixtures | Only `chrome__click` | 0 → 1 |
| Final-denied tool | Both fixtures | None | 0 |
| Conservative `chrome*.` | Both fixtures | None | 0 |
| Core-only glob, bare server, empty allowlist, disabled tools, raw run | None | None | 0 |

Every expected-start case required successful initialization and listing from both servers and no materialization diagnostics. Requester-only connections stayed untouched; disabled/app-only tools stayed unavailable; rejecting intersections were checked against a nonempty authorized input. Both screenshots were personally viewed. All 28 copied artifacts, 34,266 pre-import source entries, 1,739 actually consumed tracked source files, and both consumed harness files were verified. No generated workspace module or unresolved file URL appeared in the consumed closure.

The proof exited 0 with no fatal error or regression failure. Both process groups and all 10 MCP child processes were absent before isolated state cleanup; the test machine's exact status was confirmed completed. Candidate archive SHA-256: `0d3e3979014cc94b7dee1d38375f041272cf0c01bca506c354453c66877e6057`; artifact-manifest SHA-256: `ddd65f46c4226abdef16b1b07f1931da434558cb024937489ceedb368ffd9234`.

Environment: Node 24.19.0, Playwright 1.62.1, Chromium 144.0.7559.0. This retains the owner-boundary proof limits above; it does not claim zero browser-internal background network attempts.

### Focused regressions

```text
node scripts/run-vitest.mjs \
  src/agents/embedded-agent-runner/run/attempt-bundle-tools.test.ts \
  src/agents/embedded-agent-runner/run/attempt-tool-construction-plan.test.ts
```

New regressions on the original runtime: 11 expected failures, 50 passes. After repair and additional controls: 70 passed. Coverage includes actual final-name filtering, mixed/interior/leading globs, effective session enablement, canonical native-plugin/configured name collisions, long collision suffixes, core alias isolation, and disabled tool paths.

### Historical contributor proof

The author previously reported a production isolated-cron run with `toolsAllow: ["hzr-oa*"]`, a registered `hzr-oa__getUnreadReportCount` tool, successful MCP response, and terminal `ok` status in about 29 seconds. [Original redacted proof](https://github.com/openclaw/openclaw/pull/115277#issuecomment-5107192365). That supports the original report; it is not exact-head proof of this maintainer rewrite.

### Review follow-through

The reviewed compatibility decision is explicit above: server enablement owns connection inclusion, while final tool policy owns callability. The historical rebase suggestion is addressed by a trusted-main rewrite and direct inspection of subsequent owner drift; no rebase is performed merely because main advances. The original cron evidence is retained with its provenance and scope.

Both independent source reviews, isolated mandatory P0–P2 review, and separate full-source P0–P3 review are clean on the tested patch. Fresh committed-head P0–P2 and separately invoked full-source P0–P3 reviews also finished clean on `a9ba38f8af074df0630b010d9c049da6eab3c2f7`.

The August 27 exact-head ClawSweeper review accepted the runtime repair and live proof; its remaining P2 and first rank-up move request removal of the changelog line. Maintainer disposition: retained the single credited Unreleased bullet under the explicit user-requested changelog requirement for this landing. This is a scoped exception, not a contributor requirement or a release/version change. The second rank-up move, exact-head green checks, remains a mandatory landing gate.

Published head `a9ba38f8af074df0630b010d9c049da6eab3c2f7` passed [CI, including the required gate](https://github.com/openclaw/openclaw/actions/runs/33061445154) and [Workflow Sanity](https://github.com/openclaw/openclaw/actions/runs/33061445066). The exact-head check rank-up is satisfied; native maintainer preparation/merge remains the final step.
