### PR TITLE
perf(agents): amortize history-limit eviction with hysteresis

### DIFF
--- a/src/agents/embedded-agent-runner.limithistoryturns.test.ts
+++ b/src/agents/embedded-agent-runner.limithistoryturns.test.ts
@@ -71,6 +71,12 @@ describe("limitHistoryTurns", () => {
       role === "user" ? userMessage(`message ${i}`) : assistantTextMessage(`message ${i}`),
     );
 
+  const makeTurns = (count: number): AgentMessage[] =>
+    Array.from({ length: count }, (_, i) => [
+      userMessage(`user ${i}`),
+      assistantTextMessage(`assistant ${i}`),
+    ]).flat();
+
   it("returns all messages when limit is undefined", () => {
     const messages = makeMessages(["user", "assistant", "user", "assistant"]);
     expect(limitHistoryTurns(messages, undefined)).toBe(messages);
@@ -95,11 +101,42 @@ describe("limitHistoryTurns", () => {
     expect(limitHistoryTurns(messages, 10)).toBe(messages);
   });
 
-  it("limits to last N user turns", () => {
-    const messages = makeMessages(["user", "assistant", "user", "assistant", "user", "assistant"]);
+  it("cuts back to the limit after crossing the hysteresis cushion", () => {
+    const messages = makeTurns(4);
     const limited = limitHistoryTurns(messages, 2);
     expect(limited.length).toBe(4);
-    expect(firstText(expectDefined(limited[0], "limited[0] test invariant"))).toBe("message 2");
+    expect(firstText(expectDefined(limited[0], "limited[0] test invariant"))).toBe("user 2");
+  });
+
+  it("keeps the window start fixed while turns append within the cushion", () => {
+    const messages = makeTurns(9);
+
+    for (const turnCount of [7, 8, 9]) {
+      const limited = limitHistoryTurns(messages.slice(0, turnCount * 2), 4);
+      expect(limited[0]).toBe(messages[6]);
+    }
+  });
+
+  it("makes a single cut to exactly the limit when crossing 1.5x", () => {
+    const messages = makeTurns(7);
+    const atThreshold = messages.slice(0, 12);
+
+    expect(limitHistoryTurns(atThreshold, 4)).toBe(atThreshold);
+    const limited = limitHistoryTurns(messages, 4);
+    expect(limited).toHaveLength(8);
+    expect(limited[0]).toBe(messages[6]);
+  });
+
+  it("repeats batched cuts with stable starts between them", () => {
+    const messages = makeTurns(13);
+    const expectedStartTurns = [3, 3, 3, 6, 6, 6, 9];
+
+    for (const [offset, expectedStartTurn] of expectedStartTurns.entries()) {
+      const turnCount = offset + 7;
+      const limited = limitHistoryTurns(messages.slice(0, turnCount * 2), 4);
+      expect(limited[0]).toBe(messages[expectedStartTurn * 2]);
+      expect(limited).toHaveLength((turnCount - expectedStartTurn) * 2);
+    }
   });
 
   it("handles single user turn limit", () => {
@@ -113,7 +150,15 @@ describe("limitHistoryTurns", () => {
   it("handles messages with multiple assistant responses per user turn", () => {
     // The limit is counted by user turns, so only the assistant tail attached to
     // the kept user turn should remain.
-    const messages = makeMessages(["user", "assistant", "assistant", "user", "assistant"]);
+    const messages = makeMessages([
+      "user",
+      "assistant",
+      "assistant",
+      "user",
+      "assistant",
+      "user",
+      "assistant",
+    ]);
     const limited = limitHistoryTurns(messages, 1);
     expect(limited.length).toBe(2);
     expect(expectDefined(limited[0], "limited[0] test invariant").role).toBe("user");
@@ -130,13 +175,13 @@ describe("limitHistoryTurns", () => {
     } as AgentMessage;
     const messages = [
       compactionSummary,
-      ...makeMessages(["user", "assistant", "user", "assistant"]),
+      ...makeMessages(["user", "assistant", "user", "assistant", "user", "assistant"]),
     ];
     const limited = limitHistoryTurns(messages, 1);
     // compactionSummary is preserved, last 1 user turn + assistant kept
     expect(limited.length).toBe(3);
     expect(expectDefined(limited[0], "limited[0] test invariant").role).toBe("compactionSummary");
-    expect(firstText(expectDefined(limited[1], "limited[1] test invariant"))).toBe("message 2");
+    expect(firstText(expectDefined(limited[1], "limited[1] test invariant"))).toBe("message 4");
   });
 
   it("preserves leading branchSummary when limiting", () => {
@@ -146,7 +191,10 @@ describe("limitHistoryTurns", () => {
       fromId: "abc",
       timestamp: Date.now(),
     } as AgentMessage;
-    const messages = [branchSummary, ...makeMessages(["user", "assistant", "user", "assistant"])];
+    const messages = [
+      branchSummary,
+      ...makeMessages(["user", "assistant", "user", "assistant", "user", "assistant"]),
+    ];
     const limited = limitHistoryTurns(messages, 1);
     expect(limited.length).toBe(3);
     expect(expectDefined(limited[0], "limited[0] test invariant").role).toBe("branchSummary");
@@ -160,13 +208,16 @@ describe("limitHistoryTurns", () => {
         value: true,
       });
     }
-    const messages = [...prelude, ...makeMessages(["user", "assistant", "user", "assistant"])];
+    const messages = [
+      ...prelude,
+      ...makeMessages(["user", "assistant", "user", "assistant", "user", "assistant"]),
+    ];
 
     const limited = limitHistoryTurns(messages, 1);
 
     expect(limited).toHaveLength(4);
     expect(firstText(expectDefined(limited[0], "limited[0] test invariant"))).toBe("message 0");
-    expect(firstText(expectDefined(limited[2], "limited[2] test invariant"))).toBe("message 2");
+    expect(firstText(expectDefined(limited[2], "limited[2] test invariant"))).toBe("message 4");
   });
 
   it("returns all when only non-conversation messages exist", () => {
@@ -188,9 +239,13 @@ describe("limitHistoryTurns", () => {
       assistantToolCallMessage("1"),
       userMessage("second"),
       assistantTextMessage("response"),
+      userMessage("third"),
+      assistantTextMessage("final response"),
     ];
     const limited = limitHistoryTurns(messages, 1);
-    expect(firstText(expectDefined(limited[0], "limited[0] test invariant"))).toBe("second");
-    expect(firstText(expectDefined(limited[1], "limited[1] test invariant"))).toBe("response");
+    expect(firstText(expectDefined(limited[0], "limited[0] test invariant"))).toBe("third");
+    expect(firstText(expectDefined(limited[1], "limited[1] test invariant"))).toBe(
+      "final response",
+    );
   });
 });

--- a/src/agents/embedded-agent-runner/history.ts
+++ b/src/agents/embedded-agent-runner/history.ts
@@ -22,7 +22,7 @@ function stripThreadSuffix(value: string): string {
 }
 
 /**
- * Limits conversation history to the last N user turns (and their associated
+ * Limits conversation history to recent user turns (and their associated
  * assistant responses). This reduces token usage for long-running DM sessions.
  *
  * Leading non-conversation messages (e.g. compactionSummary, branchSummary)
@@ -58,12 +58,29 @@ export function limitHistoryTurns(
   }
 
   let userCount = 0;
+  for (const message of tail) {
+    if (message.role === "user") {
+      userCount++;
+    }
+  }
+
+  // Allow a 50% cushion, then evict a full batch so the prompt-cache prefix stays
+  // stable between cuts; up to 1.5x turns trades strictness for amortized cache reuse.
+  const targetUserTurns = Math.floor(limit);
+  const maxUserTurns = Math.ceil(targetUserTurns * 1.5);
+  if (userCount <= maxUserTurns) {
+    return messages;
+  }
+  const evictionBatchSize = maxUserTurns - targetUserTurns + 1;
+  const userTurnsToKeep = targetUserTurns + ((userCount - targetUserTurns) % evictionBatchSize);
+
+  userCount = 0;
   let lastUserIndex = tail.length;
 
   for (const [i, message] of Array.from(tail.entries()).toReversed()) {
     if (message.role === "user") {
       userCount++;
-      if (userCount > limit) {
+      if (userCount > userTurnsToKeep) {
         return [...messages.slice(0, conversationStart), ...tail.slice(lastUserIndex)];
       }
       lastUserIndex = i;


### PR DESCRIPTION
## What Problem This Solves

Channel `historyLimit`/`dmHistoryLimit` sessions get a per-turn sliding window: once past the limit, every new user turn shifts the outbound prompt's start by one message, so the provider prompt cache never hits again for the life of the session (~0% prefix-cache hits, paid every turn).

Closes #115273.

## Why This Change Was Made

`limitHistoryTurns` (`src/agents/embedded-agent-runner/history.ts`) now applies hysteresis instead of exact-limit trimming: the window may grow to `ceil(limit × 1.5)`, and the keep count is derived with mod arithmetic so the absolute window start stays byte-identical for a full eviction batch of consecutive turns, then cuts back toward the limit in one step — amortizing one cache break over many turns, the same way compaction amortizes its boundary break. The function stays a pure, deterministic function of the message list and limit; no state, no timestamps.

## User Impact

Long channel sessions with a history limit regain provider prompt-cache reuse (lower cost and latency). Named tradeoff: the model temporarily sees up to 50% more turns than the configured limit; it never sees fewer. The compaction-execution caller sees the same bounded growth (slightly larger summarization input), which is harmless.

## Evidence

- `node scripts/run-vitest.mjs src/agents/embedded-agent-runner.limithistoryturns.test.ts` — 16 tests passed, covering below-limit passthrough, stable window start between cuts, single-step cutback on crossing 1.5×, repeated growth in steps, prelude/summary preservation, and tool-call histories.
- Codex-backed autoreview on the commit: clean, no accepted findings (0.96).
- Both production callers inspected (`attempt-history-prepare.ts`, `compaction-session-execution.ts`); neither depends on exact-limit trimming.
