### PR TITLE
fix(qa): restore full-stack scenarios and truthful suite exits

### DIFF
--- a/extensions/qa-channel/src/channel.test.ts
+++ b/extensions/qa-channel/src/channel.test.ts
@@ -20,6 +20,9 @@ import type { ChannelMessageActionName } from "./runtime-api.js";
 
 type QaDispatchTurn = Parameters<PluginRuntime["channel"]["inbound"]["dispatch"]>[0];
 
+const QA_GENERATED_IMAGE_BASE64 =
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO7Z0nQAAAAASUVORK5CYII=";
+
 afterEach(() => {
   resetPluginRuntimeStateForTest();
 });
@@ -295,12 +298,43 @@ describe("qa-channel plugin", () => {
         expect(receiptPart?.replyToId).toBe("parent-1");
         expect(receiptPart?.threadId).toBe("thread-1");
       };
+      const proveMedia = async (kind: "media" | "payload" = "media") => {
+        const mediaPath = path.join(process.cwd(), "qa-channel-generated-capability.png");
+        const context = {
+          cfg: createQaChannelConfig({ baseUrl: harness.baseUrl, allowFrom: ["*"] }),
+          to: "thread:qa-room/thread-1",
+          text: "generated image",
+          mediaUrl: mediaPath,
+          mediaLocalRoots: [process.cwd()],
+          mediaReadFile: async (filePath: string) => {
+            expect(filePath).toBe(mediaPath);
+            return Buffer.from(QA_GENERATED_IMAGE_BASE64, "base64");
+          },
+          accountId: "default",
+          replyToId: "parent-1",
+          threadId: "thread-1",
+        };
+        const result =
+          kind === "payload"
+            ? await adapter.send!.payload!({
+                ...context,
+                payload: { text: context.text, mediaUrl: mediaPath, mediaUrls: [mediaPath] },
+              })
+            : await adapter.send!.media!(context);
+        expect(result.receipt.parts[0]).toMatchObject({
+          kind: "media",
+          replyToId: "parent-1",
+          threadId: "thread-1",
+        });
+      };
 
       await verifyChannelMessageAdapterCapabilityProofs({
         adapterName: "qaChannelMessageAdapter",
         adapter,
         proofs: {
           text: proveText,
+          media: proveMedia,
+          payload: () => proveMedia("payload"),
           replyTo: proveText,
           thread: proveText,
           messageSendingHooks: () => {
@@ -310,6 +344,52 @@ describe("qa-channel plugin", () => {
       });
     } finally {
       await harness.stop();
+    }
+  });
+
+  it("delivers a generated image and caption in exactly one physical QA message", async () => {
+    const state = createQaBusState();
+    const bus = await startQaBusServer({ state });
+    try {
+      const mediaPath = path.join(process.cwd(), "qa-channel-generated-image.png");
+      const result = await requireQaMessageAdapter().send!.payload!({
+        cfg: createQaChannelConfig({ baseUrl: bus.baseUrl }),
+        to: "thread:qa-room/thread-1",
+        text: "Here is your generated image.",
+        mediaUrl: mediaPath,
+        mediaLocalRoots: [process.cwd()],
+        mediaReadFile: async () => Buffer.from(QA_GENERATED_IMAGE_BASE64, "base64"),
+        accountId: "default",
+        replyToId: "parent-1",
+        threadId: "thread-1",
+        payload: {
+          text: "Here is your generated image.",
+          mediaUrl: mediaPath,
+          mediaUrls: [mediaPath],
+        },
+      });
+      const outbound = state
+        .getSnapshot()
+        .messages.filter((message) => message.direction === "outbound");
+      expect(qaChannelPlugin.capabilities.media).toBe(true);
+      expect(outbound).toHaveLength(1);
+      expect(outbound[0]).toMatchObject({
+        id: result.messageId,
+        text: "Here is your generated image.",
+        threadId: "thread-1",
+        replyToId: "parent-1",
+        attachments: [
+          {
+            kind: "image",
+            mimeType: "image/png",
+            fileName: "qa-channel-generated-image.png",
+            contentBase64: QA_GENERATED_IMAGE_BASE64,
+          },
+        ],
+      });
+      expect(result.receipt.parts[0]?.kind).toBe("media");
+    } finally {
+      await bus.stop();
     }
   });
 

--- a/extensions/qa-channel/src/channel.ts
+++ b/extensions/qa-channel/src/channel.ts
@@ -7,6 +7,7 @@ import {
 import {
   createMessageReceiptFromOutboundResults,
   defineChannelMessageAdapter,
+  type ChannelMessageSendPayloadContext,
 } from "openclaw/plugin-sdk/channel-outbound";
 import { DEFAULT_ACCOUNT_ID } from "./accounts.js";
 import {
@@ -18,22 +19,80 @@ import {
 import { qaChannelMessageActions } from "./channel-actions.js";
 import { createQaChannelPluginBase, QA_CHANNEL_ID, qaChannelRuntimeMeta } from "./channel-base.js";
 import { startQaGatewayAccount } from "./gateway.js";
-import { sendQaChannelText } from "./outbound.js";
+import { sendQaChannelMedia, sendQaChannelMediaBatch, sendQaChannelText } from "./outbound.js";
 import type { ChannelPlugin } from "./runtime-api.js";
 import { qaChannelStatus } from "./status.js";
 import type { CoreConfig, ResolvedQaChannelAccount } from "./types.js";
+
+type QaChannelPayloadSendContext = Pick<
+  ChannelMessageSendPayloadContext,
+  | "cfg"
+  | "to"
+  | "text"
+  | "payload"
+  | "accountId"
+  | "threadId"
+  | "replyToId"
+  | "mediaUrl"
+  | "mediaAccess"
+  | "mediaLocalRoots"
+  | "mediaReadFile"
+>;
+
+async function sendQaChannelMessagePayload(ctx: QaChannelPayloadSendContext) {
+  const text = ctx.payload.text ?? ctx.text;
+  const mediaUrls = Array.from(
+    new Set(
+      [ctx.mediaUrl, ctx.payload.mediaUrl, ...(ctx.payload.mediaUrls ?? [])].filter(
+        (mediaUrl): mediaUrl is string =>
+          typeof mediaUrl === "string" && mediaUrl.trim().length > 0,
+      ),
+    ),
+  );
+  const params = {
+    cfg: ctx.cfg as CoreConfig,
+    accountId: ctx.accountId,
+    to: ctx.to,
+    text,
+    threadId: ctx.threadId,
+    replyToId: ctx.replyToId,
+  };
+  const result =
+    mediaUrls.length === 0
+      ? await sendQaChannelText(params)
+      : await sendQaChannelMediaBatch({
+          ...params,
+          mediaUrls,
+          mediaAccess: ctx.mediaAccess,
+          mediaLocalRoots: ctx.mediaLocalRoots,
+          mediaReadFile: ctx.mediaReadFile,
+        });
+  return {
+    messageId: result.messageId,
+    receipt: createMessageReceiptFromOutboundResults({
+      results: [{ channel: QA_CHANNEL_ID, messageId: result.messageId }],
+      threadId: ctx.threadId == null ? undefined : String(ctx.threadId),
+      replyToId: ctx.replyToId ?? undefined,
+      kind: mediaUrls.length > 0 ? "media" : "text",
+    }),
+  };
+}
 
 const qaChannelMessageAdapter = defineChannelMessageAdapter({
   id: QA_CHANNEL_ID,
   durableFinal: {
     capabilities: {
       text: true,
+      media: true,
+      payload: true,
       replyTo: true,
       thread: true,
       messageSendingHooks: true,
     },
   },
   send: {
+    // Detached completions must deliver the visible caption and media atomically.
+    payload: sendQaChannelMessagePayload,
     text: async (ctx) => {
       const result = await sendQaChannelText({
         cfg: ctx.cfg as CoreConfig,
@@ -55,12 +114,38 @@ const qaChannelMessageAdapter = defineChannelMessageAdapter({
         }),
       };
     },
+    media: async (ctx) => {
+      const result = await sendQaChannelMedia({
+        cfg: ctx.cfg as CoreConfig,
+        accountId: ctx.accountId,
+        to: ctx.to,
+        text: ctx.text,
+        mediaUrl: ctx.mediaUrl,
+        mediaAccess: ctx.mediaAccess,
+        mediaLocalRoots: ctx.mediaLocalRoots,
+        mediaReadFile: ctx.mediaReadFile,
+        threadId: ctx.threadId,
+        replyToId: ctx.replyToId,
+      });
+      return {
+        messageId: result.messageId,
+        receipt: createMessageReceiptFromOutboundResults({
+          results: [{ channel: QA_CHANNEL_ID, messageId: result.messageId }],
+          threadId: ctx.threadId == null ? undefined : String(ctx.threadId),
+          replyToId: ctx.replyToId ?? undefined,
+          kind: "media",
+        }),
+      };
+    },
   },
 });
 
+const qaChannelPluginBase = createQaChannelPluginBase(qaChannelRuntimeMeta);
+
 export const qaChannelPlugin: ChannelPlugin<ResolvedQaChannelAccount> = createChatChannelPlugin({
   base: {
-    ...createQaChannelPluginBase(qaChannelRuntimeMeta),
+    ...qaChannelPluginBase,
+    capabilities: { ...qaChannelPluginBase.capabilities, media: true },
     messaging: {
       normalizeTarget: normalizeQaTarget,
       inferTargetChatType: ({ to }) => parseQaTarget(to).chatType,
@@ -138,6 +223,10 @@ export const qaChannelPlugin: ChannelPlugin<ResolvedQaChannelAccount> = createCh
   outbound: {
     base: {
       deliveryMode: "direct",
+      sendPayload: async (ctx) => {
+        const result = await sendQaChannelMessagePayload(ctx);
+        return { channel: QA_CHANNEL_ID, messageId: result.messageId };
+      },
     },
     attachedResults: {
       channel: QA_CHANNEL_ID,
@@ -150,6 +239,34 @@ export const qaChannelPlugin: ChannelPlugin<ResolvedQaChannelAccount> = createCh
           threadId,
           replyToId,
         }),
+      sendMedia: async ({
+        cfg,
+        to,
+        text,
+        mediaUrl,
+        accountId,
+        threadId,
+        replyToId,
+        mediaAccess,
+        mediaLocalRoots,
+        mediaReadFile,
+      }) => {
+        if (!mediaUrl) {
+          throw new Error("QA channel media send requires mediaUrl");
+        }
+        return await sendQaChannelMedia({
+          cfg: cfg as CoreConfig,
+          accountId,
+          to,
+          text,
+          mediaUrl,
+          threadId,
+          replyToId,
+          mediaAccess,
+          mediaLocalRoots,
+          mediaReadFile,
+        });
+      },
     },
   },
 });

--- a/extensions/qa-channel/src/inbound.test.ts
+++ b/extensions/qa-channel/src/inbound.test.ts
@@ -1,9 +1,14 @@
 // Qa Channel tests cover inbound plugin behavior.
+import path from "node:path";
 import { createPluginRuntimeMock } from "openclaw/plugin-sdk/channel-test-helpers";
+import { loadOutboundMediaFromUrl } from "openclaw/plugin-sdk/outbound-media";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { setQaChannelRuntime } from "../api.js";
 import { deleteQaBusMessage, editQaBusMessage, sendQaBusMessage } from "./bus-client.js";
 import { handleQaInbound } from "./inbound.js";
+
+const QA_GENERATED_IMAGE_BASE64 =
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO7Z0nQAAAAASUVORK5CYII=";
 
 vi.mock("./bus-client.js", async (importOriginal) => {
   const actual = await importOriginal<typeof import("./bus-client.js")>();
@@ -12,6 +17,19 @@ vi.mock("./bus-client.js", async (importOriginal) => {
     deleteQaBusMessage: vi.fn(async () => ({ message: {} })),
     editQaBusMessage: vi.fn(async () => ({ message: {} })),
     sendQaBusMessage: vi.fn(async () => ({ message: { id: "preview-1" } })),
+  };
+});
+
+vi.mock("openclaw/plugin-sdk/outbound-media", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("openclaw/plugin-sdk/outbound-media")>();
+  return {
+    ...actual,
+    loadOutboundMediaFromUrl: vi.fn(async (mediaUrl: string) => ({
+      buffer: Buffer.from(QA_GENERATED_IMAGE_BASE64, "base64"),
+      kind: "image" as const,
+      contentType: "image/png",
+      fileName: path.basename(mediaUrl),
+    })),
   };
 });
 
@@ -69,6 +87,35 @@ function firstRunAssembledParams(runtime: ReturnType<typeof createPluginRuntimeM
 describe("handleQaInbound", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+  });
+
+  it("delivers generated image bytes and their caption in one final bus message", async () => {
+    const runtime = createPluginRuntimeMock();
+    setQaChannelRuntime(runtime);
+    const mediaPath = path.join(process.cwd(), "qa-channel-inbound-generated.png");
+
+    await handleQaInbound(createQaInboundParams());
+    const assembled = firstRunAssembledParams(runtime);
+    await assembled.delivery.deliver(
+      { text: "Here is your generated image.", mediaUrls: [mediaPath] },
+      { kind: "final" },
+    );
+
+    expect(loadOutboundMediaFromUrl).toHaveBeenCalledOnce();
+    expect(sendQaBusMessage).toHaveBeenCalledOnce();
+    expect(sendQaBusMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        text: "Here is your generated image.",
+        replyToId: "msg-1",
+        attachments: [
+          expect.objectContaining({
+            kind: "image",
+            mimeType: "image/png",
+            contentBase64: QA_GENERATED_IMAGE_BASE64,
+          }),
+        ],
+      }),
+    );
   });
 
   it("publishes partial replies as one edited preview before final delivery", async () => {

--- a/extensions/qa-channel/src/inbound.ts
+++ b/extensions/qa-channel/src/inbound.ts
@@ -8,7 +8,11 @@ import { resolveStableChannelMessageIngress } from "openclaw/plugin-sdk/channel-
 import { resolveNativeCommandSessionTargets } from "openclaw/plugin-sdk/command-auth-native";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
-import { saveMediaBuffer, saveMediaSource } from "openclaw/plugin-sdk/media-runtime";
+import {
+  getAgentScopedMediaLocalRoots,
+  saveMediaBuffer,
+  saveMediaSource,
+} from "openclaw/plugin-sdk/media-runtime";
 import {
   sanitizeQaBusToolCallArguments,
   type QaBusToolCall,
@@ -20,6 +24,7 @@ import {
   sendQaBusMessage,
   type QaBusMessage,
 } from "./bus-client.js";
+import { sendQaChannelMediaBatch } from "./outbound.js";
 import { getQaChannelRuntime } from "./runtime.js";
 import type { CoreConfig, ResolvedQaChannelAccount } from "./types.js";
 
@@ -407,10 +412,43 @@ export async function handleQaInbound(params: {
     ctxPayload,
     delivery: {
       deliver: async (payload, info) => {
-        const text =
-          payload && typeof payload === "object" && "text" in payload
-            ? ((payload as { text?: string }).text ?? "")
-            : "";
+        const reply =
+          payload && typeof payload === "object"
+            ? (payload as { text?: string; mediaUrl?: string; mediaUrls?: string[] })
+            : undefined;
+        const text = reply?.text ?? "";
+        const mediaUrls = Array.from(
+          new Set(
+            [reply?.mediaUrl, ...(reply?.mediaUrls ?? [])].filter(
+              (mediaUrl): mediaUrl is string =>
+                typeof mediaUrl === "string" && mediaUrl.trim().length > 0,
+            ),
+          ),
+        );
+        if (mediaUrls.length > 0) {
+          if (info?.kind && info.kind !== "final") {
+            if (text.trim()) {
+              await preview.update(text);
+            }
+            return;
+          }
+          // A streamed preview is never the durable generated-image delivery.
+          await preview.clear();
+          await sendQaChannelMediaBatch({
+            cfg: params.config,
+            accountId: params.account.accountId,
+            to: target,
+            text,
+            mediaUrls,
+            mediaLocalRoots: getAgentScopedMediaLocalRoots(
+              params.config as OpenClawConfig,
+              route.agentId,
+            ),
+            threadId: inbound.threadId,
+            replyToId: inbound.id,
+          });
+          return;
+        }
         if (!text.trim()) {
           return;
         }

--- a/extensions/qa-channel/src/outbound.ts
+++ b/extensions/qa-channel/src/outbound.ts
@@ -1,16 +1,32 @@
 // Qa Channel plugin module implements outbound behavior.
+import { randomUUID } from "node:crypto";
+import path from "node:path";
+import {
+  loadOutboundMediaFromUrl,
+  type OutboundMediaLoadOptions,
+} from "openclaw/plugin-sdk/outbound-media";
 import { resolveQaChannelAccount } from "./accounts.js";
 import { buildQaTarget, resolveQaTargetThread, sendQaBusMessage } from "./bus-client.js";
+import type { QaBusAttachment } from "./protocol.js";
 import type { CoreConfig } from "./types.js";
 
-export async function sendQaChannelText(params: {
+type QaChannelTextSendParams = {
   cfg: CoreConfig;
   accountId?: string | null;
   to: string;
   text: string;
   threadId?: string | number | null;
   replyToId?: string | number | null;
-}) {
+  attachments?: QaBusAttachment[];
+};
+
+type QaChannelMediaAccessParams = {
+  mediaAccess?: OutboundMediaLoadOptions["mediaAccess"];
+  mediaLocalRoots?: readonly string[];
+  mediaReadFile?: (filePath: string) => Promise<Buffer>;
+};
+
+export async function sendQaChannelText(params: QaChannelTextSendParams) {
   const account = resolveQaChannelAccount({ cfg: params.cfg, accountId: params.accountId });
   const resolved = resolveQaTargetThread({ target: params.to, threadId: params.threadId });
   const parsed = resolved.target;
@@ -27,9 +43,47 @@ export async function sendQaChannelText(params: {
     senderName: account.botDisplayName,
     threadId: resolved.threadId,
     replyToId: params.replyToId == null ? undefined : String(params.replyToId),
+    ...(params.attachments?.length ? { attachments: params.attachments } : {}),
   });
   return {
     to: params.to,
     messageId: message.id,
   };
+}
+
+/** Resolve every attachment first so a failed batch cannot publish a partial reply. */
+export async function sendQaChannelMediaBatch(
+  params: QaChannelTextSendParams & QaChannelMediaAccessParams & { mediaUrls: readonly string[] },
+) {
+  if (params.mediaUrls.length === 0) {
+    throw new Error("QA channel media batch requires at least one media URL");
+  }
+  const attachments: QaBusAttachment[] = await Promise.all(
+    params.mediaUrls.map(async (mediaUrl) => {
+      const media = await loadOutboundMediaFromUrl(mediaUrl, {
+        mediaAccess: params.mediaAccess,
+        mediaLocalRoots: params.mediaLocalRoots,
+        mediaReadFile: params.mediaReadFile,
+        optimizeImages: false,
+      });
+      const kind =
+        media.kind === "image" || media.kind === "video" || media.kind === "audio"
+          ? media.kind
+          : "file";
+      return {
+        id: randomUUID(),
+        kind,
+        mimeType: media.contentType ?? "application/octet-stream",
+        fileName: media.fileName ?? path.basename(mediaUrl),
+        contentBase64: media.buffer.toString("base64"),
+      };
+    }),
+  );
+  return await sendQaChannelText({ ...params, attachments });
+}
+
+export async function sendQaChannelMedia(
+  params: QaChannelTextSendParams & QaChannelMediaAccessParams & { mediaUrl: string },
+) {
+  return await sendQaChannelMediaBatch({ ...params, mediaUrls: [params.mediaUrl] });
 }

--- a/extensions/qa-lab/src/cli.runtime.test.ts
+++ b/extensions/qa-lab/src/cli.runtime.test.ts
@@ -109,6 +109,11 @@ import { defaultQaModelForMode as defaultQaProviderModelForMode } from "./model-
 import type { QaProviderModeInput } from "./run-config.js";
 
 const DEFAULT_LIVE_FRONTIER_MODEL = defaultQaProviderModelForMode("live-frontier");
+const QA_PASSING_SUITE_SCENARIO = {
+  name: "channel chat baseline",
+  status: "pass" as const,
+  steps: [],
+};
 
 function mockFirstObjectArg(mock: unknown): Record<string, unknown> {
   const calls = (mock as { mock?: { calls?: Array<Array<unknown>> } }).mock?.calls ?? [];
@@ -162,7 +167,7 @@ function flowSuiteRuntimeResult(params: {
       reportPath: params.reportPath,
       summaryPath: params.summaryPath,
       report: "# QA Suite Report\n",
-      scenarios: params.scenarios ?? [],
+      scenarios: params.scenarios ?? [QA_PASSING_SUITE_SCENARIO],
       watchUrl: "http://127.0.0.1:43124",
     },
   };
@@ -183,7 +188,7 @@ function unifiedSuiteRuntimeResult(params: {
       evidencePath: params.evidencePath,
       summaryPath: params.summaryPath,
       report: "# QA Suite Report\n",
-      scenarios: params.scenarios ?? [],
+      scenarios: params.scenarios ?? [QA_PASSING_SUITE_SCENARIO],
     },
   };
 }
@@ -206,7 +211,41 @@ describe("qa cli runtime", () => {
     telegramArtifactsDir = await fs.mkdtemp(path.join(os.tmpdir(), "qa-telegram-runtime-"));
     telegramSummaryPath = path.join(telegramArtifactsDir, QA_EVIDENCE_FILENAME);
     await fs.writeFile(suiteReportPath, "# QA Suite Report\n", "utf8");
-    await fs.writeFile(suiteEvidencePath, JSON.stringify(makeQaEvidence()), "utf8");
+    await fs.writeFile(
+      suiteEvidencePath,
+      JSON.stringify(
+        makeQaEvidence([
+          {
+            test: {
+              kind: "qa-scenario",
+              id: "channel-chat-baseline",
+              title: "Channel chat baseline",
+              source: { path: "qa/scenarios/channels/channel-chat-baseline.yaml" },
+            },
+            coverage: [],
+            execution: {
+              runner: "host",
+              environment: {
+                ref: null,
+                os: process.platform,
+                nodeVersion: process.version,
+              },
+              provider: {
+                id: "openai",
+                live: false,
+                model: { name: "gpt-5.6-luna", ref: "mock-openai/gpt-5.6-luna" },
+                fixture: "mock-openai",
+              },
+              channel: { id: "qa-channel", live: false },
+              packageSource: { kind: "source-checkout" },
+              artifacts: [],
+            },
+            result: { status: "pass" },
+          },
+        ]),
+      ),
+      "utf8",
+    );
     await fs.writeFile(
       suiteSummaryPath,
       JSON.stringify({
@@ -214,8 +253,9 @@ describe("qa cli runtime", () => {
           total: 1,
           passed: 1,
           failed: 0,
+          skipped: 0,
         },
-        scenarios: [],
+        scenarios: [QA_PASSING_SUITE_SCENARIO],
       }),
       "utf8",
     );
@@ -223,11 +263,12 @@ describe("qa cli runtime", () => {
       telegramSummaryPath,
       JSON.stringify({
         counts: {
-          total: 0,
-          passed: 0,
+          total: 1,
+          passed: 1,
           failed: 0,
+          skipped: 0,
         },
-        scenarios: [],
+        scenarios: [QA_PASSING_SUITE_SCENARIO],
       }),
       "utf8",
     );
@@ -260,7 +301,7 @@ describe("qa cli runtime", () => {
       watchUrl: "http://127.0.0.1:43124",
       reportPath: suiteReportPath,
       summaryPath: suiteSummaryPath,
-      scenarios: [],
+      scenarios: [QA_PASSING_SUITE_SCENARIO],
     });
     runQaCharacterEval.mockResolvedValue({
       reportPath: "/tmp/character-report.md",
@@ -1402,6 +1443,73 @@ describe("qa cli runtime", () => {
     try {
       await runQaSuiteCommand({
         repoRoot: "/tmp/openclaw-repo",
+      });
+      expect(process.exitCode).toBe(1);
+    } finally {
+      process.exitCode = priorExitCode;
+    }
+  });
+
+  it("keeps full host suite exit code clear for report-only optional tool skips", async () => {
+    const priorExitCode = process.exitCode;
+    process.exitCode = undefined;
+    await fs.writeFile(
+      suiteSummaryPath,
+      JSON.stringify({
+        counts: { total: 1, passed: 0, failed: 0, skipped: 1 },
+        scenarios: [
+          {
+            name: "Runtime tool fixture — image_generate",
+            status: "skip",
+            details: "image_generate mock provider report-only: tool unavailable",
+          },
+        ],
+      }),
+      "utf8",
+    );
+    runQaSuite.mockResolvedValueOnce(
+      flowSuiteRuntimeResult({
+        reportPath: suiteReportPath,
+        summaryPath: suiteSummaryPath,
+      }),
+    );
+
+    try {
+      await runQaSuiteCommand({ repoRoot: "/tmp/openclaw-repo" });
+      expect(process.exitCode).toBeUndefined();
+    } finally {
+      process.exitCode = priorExitCode;
+    }
+  });
+
+  it("keeps explicitly selected optional tool skips blocking", async () => {
+    const priorExitCode = process.exitCode;
+    process.exitCode = undefined;
+    await fs.writeFile(
+      suiteSummaryPath,
+      JSON.stringify({
+        counts: { total: 1, passed: 0, failed: 0, skipped: 1 },
+        scenarios: [
+          {
+            name: "Runtime tool fixture — image_generate",
+            status: "skip",
+            details: "image_generate mock provider report-only: tool unavailable",
+          },
+        ],
+      }),
+      "utf8",
+    );
+    runQaSuite.mockResolvedValueOnce(
+      flowSuiteRuntimeResult({
+        reportPath: suiteReportPath,
+        summaryPath: suiteSummaryPath,
+      }),
+    );
+
+    try {
+      await runQaSuiteCommand({
+        repoRoot: "/tmp/openclaw-repo",
+        scenarioIds: ["runtime-tool-image-generate"],
       });
       expect(process.exitCode).toBe(1);
     } finally {

--- a/extensions/qa-lab/src/cli.runtime.ts
+++ b/extensions/qa-lab/src/cli.runtime.ts
@@ -99,7 +99,10 @@ import {
   runQaSuiteWithInfraRetry,
 } from "./suite-launch.runtime.js";
 import { resolveQaSuiteScenarioChannel, resolveQaSuiteScenarioChannels } from "./suite-planning.js";
-import { readQaSuiteFailedOrSkippedScenarioCountFromFile } from "./suite-summary.js";
+import {
+  isQaSuiteReportOnlyOptionalScenario,
+  readQaSuiteFailedOrSkippedScenarioCountFromFile,
+} from "./suite-summary.js";
 import {
   buildTokenEfficiencyReport,
   renderTokenEfficiencyMarkdownReport,
@@ -802,6 +805,31 @@ async function withTemporaryQaProfileEnv<T>(profile: string, run: () => Promise<
   }
 }
 
+function resolveQaReportOnlyOptionalScenarioNames(params: {
+  scenarioIds: readonly string[];
+  explicitScenarioSelection?: boolean;
+}): ReadonlySet<string> | undefined {
+  if (params.explicitScenarioSelection || params.scenarioIds.length > 0) {
+    return undefined;
+  }
+  return new Set(
+    readQaScenarioPack()
+      .scenarios.filter((scenario) => {
+        if (scenario.execution.kind !== "flow") {
+          return false;
+        }
+        const toolCoverage = scenario.execution.config?.toolCoverage;
+        return (
+          typeof toolCoverage === "object" &&
+          toolCoverage !== null &&
+          "required" in toolCoverage &&
+          toolCoverage.required === false
+        );
+      })
+      .map((scenario) => scenario.title),
+  );
+}
+
 export async function runQaSuiteCommand(opts: QaSuiteCommandOptions) {
   const repoRoot = path.resolve(opts.repoRoot ?? process.cwd());
   const transportId = normalizeQaTransportId(opts.transportId);
@@ -954,6 +982,12 @@ export async function runQaSuiteCommand(opts: QaSuiteCommandOptions) {
     if (!allowFailures) {
       const blockingScenarioCount = await readQaSuiteFailedOrSkippedScenarioCountFromFile(
         result.summaryPath,
+        {
+          optionalScenarioNames: resolveQaReportOnlyOptionalScenarioNames({
+            scenarioIds,
+            explicitScenarioSelection: opts.explicitScenarioSelection,
+          }),
+        },
       );
       if (blockingScenarioCount > 0) {
         process.exitCode = 1;
@@ -1016,8 +1050,20 @@ export async function runQaSuiteCommand(opts: QaSuiteCommandOptions) {
       process.stdout.write(`QA suite report: ${result.reportPath}\n`);
       process.stdout.write(`QA suite evidence: ${result.evidencePath}\n`);
       process.stdout.write(`QA suite summary: ${result.summaryPath}\n`);
-      if (!allowFailures && result.scenarios.some((scenario) => scenario.status !== "pass")) {
-        process.exitCode = 1;
+      if (!allowFailures) {
+        const optionalScenarioNames = resolveQaReportOnlyOptionalScenarioNames({
+          scenarioIds,
+          explicitScenarioSelection: opts.explicitScenarioSelection,
+        });
+        if (
+          result.scenarios.some(
+            (scenario) =>
+              scenario.status !== "pass" &&
+              !isQaSuiteReportOnlyOptionalScenario(scenario, optionalScenarioNames),
+          )
+        ) {
+          process.exitCode = 1;
+        }
       }
       return result;
     }
@@ -1029,6 +1075,12 @@ export async function runQaSuiteCommand(opts: QaSuiteCommandOptions) {
       process.stdout.write(`QA suite summary: ${result.summaryPath}\n`);
       const blockingScenarioCount = await readQaSuiteFailedOrSkippedScenarioCountFromFile(
         result.summaryPath,
+        {
+          optionalScenarioNames: resolveQaReportOnlyOptionalScenarioNames({
+            scenarioIds,
+            explicitScenarioSelection: opts.explicitScenarioSelection,
+          }),
+        },
       );
       if (!allowFailures && blockingScenarioCount > 0) {
         process.exitCode = 1;

--- a/extensions/qa-lab/src/live-scenario-timeouts.test.ts
+++ b/extensions/qa-lab/src/live-scenario-timeouts.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+import { resolveQaLiveTurnTimeoutMs } from "./live-timeout.js";
+import { readQaScenarioById } from "./scenario-catalog.js";
+import { requireFlowScenario } from "./scenario-catalog.test-utils.js";
+
+describe("live subagent scenario timeouts", () => {
+  it.each([
+    {
+      id: "issue-109025-completion-policy-live",
+      savedEvidence: "expectedFinalMarker",
+    },
+    {
+      id: "issue-109025-sender-policy-live",
+      savedEvidence: "childRow",
+    },
+  ])("uses the model-aware completion timeout for $id", ({ id, savedEvidence }) => {
+    const scenario = requireFlowScenario(readQaScenarioById(id));
+    const completionWait = scenario.execution.flow?.steps
+      .flatMap((step) => step.actions)
+      .find(
+        (action) =>
+          typeof action === "object" &&
+          action !== null &&
+          "call" in action &&
+          action.call === "waitForCondition" &&
+          "saveAs" in action &&
+          action.saveAs === savedEvidence,
+      );
+
+    expect(scenario.execution.config?.requiredProviderMode).toBe("live-frontier");
+    expect(scenario.execution.retryCount).toBe(0);
+    expect(completionWait).toMatchObject({
+      call: "waitForCondition",
+      saveAs: savedEvidence,
+      args: [expect.any(Object), { expr: "liveTurnTimeoutMs(env, 60000)" }, 250],
+    });
+  });
+
+  it("applies the GPT-5 live floor without extending the mock fallback", () => {
+    expect(
+      resolveQaLiveTurnTimeoutMs(
+        {
+          providerMode: "live-frontier",
+          primaryModel: "openai/gpt-5.4",
+          alternateModel: "openai/gpt-5.4",
+        },
+        60_000,
+      ),
+    ).toBe(360_000);
+    expect(
+      resolveQaLiveTurnTimeoutMs(
+        {
+          providerMode: "mock-openai",
+          primaryModel: "mock-openai/gpt-5.6-luna",
+          alternateModel: "mock-openai/gpt-5.6-luna",
+        },
+        60_000,
+      ),
+    ).toBe(60_000);
+  });
+});

--- a/extensions/qa-lab/src/providers/mock-openai/mock-anthropic-messages.ts
+++ b/extensions/qa-lab/src/providers/mock-openai/mock-anthropic-messages.ts
@@ -17,7 +17,12 @@ import {
   type AnthropicStreamEvent,
 } from "./mock-openai-contracts.js";
 import { buildAssistantEvents } from "./mock-openai-events.js";
-import { extractToolOutput, extractAllRequestTexts } from "./mock-openai-input.js";
+import {
+  extractAllRequestTexts,
+  extractLastUserText,
+  extractToolOutput,
+  extractToolOutputCallId,
+} from "./mock-openai-input.js";
 import { buildToolCallEventsWithArgs } from "./mock-openai-tooling.js";
 
 export async function buildMessagesPayload(
@@ -58,16 +63,22 @@ export async function buildMessagesPayload(
   const allInputText = extractAllRequestTexts(input, dispatchBody);
   if (QA_ANTHROPIC_THINKING_ERROR_RECOVERY_PROMPT_RE.test(allInputText)) {
     const toolOutput = extractToolOutput(input);
+    const toolOutputCallId = extractToolOutputCallId(input);
+    const scenarioKey = `${normalizedModel}\n${extractLastUserText(input)}`;
     const shouldEmitThinkingError =
-      toolOutput.length > 0 && scenarioState.anthropicThinkingErrorPhase === 0;
+      toolOutput.length > 0 &&
+      toolOutputCallId.length > 0 &&
+      !scenarioState.anthropicThinkingErrorScenarioKeys.has(scenarioKey);
+    // Safe retries generate fresh read call IDs. The original user prompt stays
+    // stable, so fail once per model and nonce-bearing logical scenario instead.
+    if (shouldEmitThinkingError) {
+      scenarioState.anthropicThinkingErrorScenarioKeys.add(scenarioKey);
+    }
     const events =
       toolOutput.length === 0
         ? buildToolCallEventsWithArgs("read", { path: "QA_KICKOFF_TASK.md" })
         : shouldEmitThinkingError
-          ? (() => {
-              scenarioState.anthropicThinkingErrorPhase = 1;
-              return buildAssistantEvents("");
-            })()
+          ? buildAssistantEvents("")
           : buildAssistantEvents("ANTHROPIC-THINKING-ERROR-RECOVERED-OK");
     const extracted = extractFinalAssistantOutputFromEvents(events);
     const responseBody = shouldEmitThinkingError

--- a/extensions/qa-lab/src/providers/mock-openai/mock-openai-assistant-text.ts
+++ b/extensions/qa-lab/src/providers/mock-openai/mock-openai-assistant-text.ts
@@ -46,12 +46,32 @@ import {
   extractSnackPreference,
   isSnackRecallPrompt,
 } from "./mock-openai-tooling.js";
+
+function readCompletedImageGenerationMediaPath(prompt: string): string | undefined {
+  const eventStart = prompt.lastIndexOf("[Internal task completion event]");
+  if (eventStart < 0) {
+    return undefined;
+  }
+  const completionEvent = prompt.slice(eventStart);
+  if (
+    !/^source:\s*image_generation\s*$/im.test(completionEvent) ||
+    !/^status:\s*completed successfully\s*$/im.test(completionEvent)
+  ) {
+    return undefined;
+  }
+  return /^MEDIA:\s*([^\r\n]+)$/im.exec(completionEvent)?.[1]?.trim() || undefined;
+}
+
 export function buildAssistantText(
   input: ResponsesInputItem[],
   body: Record<string, unknown>,
   scenarioState: MockScenarioState,
 ) {
   const prompt = extractLastUserText(input);
+  const completedImageMediaPath = readCompletedImageGenerationMediaPath(prompt);
+  if (completedImageMediaPath) {
+    return `Protocol note: generated the QA lighthouse image successfully.\nMEDIA:${completedImageMediaPath}`;
+  }
   const toolOutput = extractToolOutput(input);
   const scenarioToolOutput =
     toolOutput ||

--- a/extensions/qa-lab/src/providers/mock-openai/mock-openai-contracts.ts
+++ b/extensions/qa-lab/src/providers/mock-openai/mock-openai-contracts.ts
@@ -8,7 +8,11 @@ export type ResponsesInputItem = Record<string, unknown>;
 
 export type StreamEvent =
   | { type: "response.created"; response: { id: string } }
-  | { type: "response.output_item.added"; item: Record<string, unknown> }
+  | {
+      type: "response.output_item.added";
+      output_index?: number;
+      item: Record<string, unknown>;
+    }
   | {
       type: "response.output_text.delta";
       item_id: string;
@@ -23,14 +27,23 @@ export type StreamEvent =
       content_index: number;
       text: string;
     }
-  | { type: "response.function_call_arguments.delta"; delta: string }
+  | {
+      type: "response.function_call_arguments.delta";
+      item_id?: string;
+      output_index?: number;
+      delta: string;
+    }
   | {
       type: "response.custom_tool_call_input.delta";
       item_id: string;
       call_id: string;
       delta: string;
     }
-  | { type: "response.output_item.done"; item: Record<string, unknown> }
+  | {
+      type: "response.output_item.done";
+      output_index?: number;
+      item: Record<string, unknown>;
+    }
   | {
       type: "response.completed";
       response: {
@@ -265,7 +278,7 @@ const QA_MATRIX_VOICE_TRANSCRIPTION_TEXT =
 export const QA_MCP_CODE_MODE_API_FILE_PROMPT_RE = /mcp code mode api file qa check/i;
 
 export type MockScenarioState = {
-  anthropicThinkingErrorPhase: number;
+  anthropicThinkingErrorScenarioKeys: Set<string>;
   subagentFanoutPhase: number;
   subagentHandoffSpawned: boolean;
   toolLoopReadAttempts: number;

--- a/extensions/qa-lab/src/providers/mock-openai/mock-openai-events.test.ts
+++ b/extensions/qa-lab/src/providers/mock-openai/mock-openai-events.test.ts
@@ -1,0 +1,226 @@
+import { describe, expect, it } from "vitest";
+import type { StreamEvent } from "./mock-openai-contracts.js";
+import {
+  buildAssistantEvents,
+  buildAssistantThenToolCallEvents,
+  buildReasoningAndAssistantEvents,
+  buildReasoningOnlyEvents,
+} from "./mock-openai-events.js";
+
+function readOutputItemSlots(events: StreamEvent[]) {
+  return events
+    .filter(
+      (event) =>
+        event.type === "response.output_item.added" || event.type === "response.output_item.done",
+    )
+    .map((event) => {
+      if (
+        event.type !== "response.output_item.added" &&
+        event.type !== "response.output_item.done"
+      ) {
+        throw new Error("expected a response output item event");
+      }
+      return {
+        type: event.type,
+        itemId: event.item.id,
+        outputIndex: event.output_index,
+      };
+    });
+}
+
+describe("mock OpenAI Responses output item slots", () => {
+  it("indexes preview deltas and the final answer on the same assistant slot", () => {
+    const events = buildAssistantEvents([
+      {
+        id: "streamed-answer",
+        phase: "final_answer",
+        streamDeltas: ["preview ", "in progress"],
+        text: "FINAL-MARKER",
+      },
+    ]);
+
+    expect(readOutputItemSlots(events)).toEqual([
+      {
+        type: "response.output_item.added",
+        itemId: "streamed-answer",
+        outputIndex: 0,
+      },
+      {
+        type: "response.output_item.done",
+        itemId: "streamed-answer",
+        outputIndex: 0,
+      },
+    ]);
+    expect(
+      events.filter(
+        (event) =>
+          event.type === "response.output_text.delta" || event.type === "response.output_text.done",
+      ),
+    ).toEqual([
+      {
+        type: "response.output_text.delta",
+        item_id: "streamed-answer",
+        output_index: 0,
+        content_index: 0,
+        delta: "preview ",
+      },
+      {
+        type: "response.output_text.delta",
+        item_id: "streamed-answer",
+        output_index: 0,
+        content_index: 0,
+        delta: "in progress",
+      },
+      {
+        type: "response.output_text.done",
+        item_id: "streamed-answer",
+        output_index: 0,
+        content_index: 0,
+        text: "FINAL-MARKER",
+      },
+    ]);
+  });
+
+  it("keeps each streamed assistant on its own indexed slot", () => {
+    const events = buildAssistantEvents([
+      {
+        id: "first-answer",
+        streamDeltas: ["first"],
+        text: "first",
+      },
+      {
+        id: "second-answer",
+        streamDeltas: ["second"],
+        text: "second",
+      },
+    ]);
+
+    expect(readOutputItemSlots(events)).toEqual([
+      {
+        type: "response.output_item.added",
+        itemId: "first-answer",
+        outputIndex: 0,
+      },
+      {
+        type: "response.output_item.done",
+        itemId: "first-answer",
+        outputIndex: 0,
+      },
+      {
+        type: "response.output_item.added",
+        itemId: "second-answer",
+        outputIndex: 1,
+      },
+      {
+        type: "response.output_item.done",
+        itemId: "second-answer",
+        outputIndex: 1,
+      },
+    ]);
+    expect(
+      events
+        .filter((event) => event.type === "response.output_text.delta")
+        .map((event) => {
+          if (event.type !== "response.output_text.delta") {
+            throw new Error("expected a response text delta");
+          }
+          return {
+            itemId: event.item_id,
+            outputIndex: event.output_index,
+          };
+        }),
+    ).toEqual([
+      { itemId: "first-answer", outputIndex: 0 },
+      { itemId: "second-answer", outputIndex: 1 },
+    ]);
+  });
+
+  it("assigns separate assistant and function-call slots", () => {
+    const events = buildAssistantThenToolCallEvents(
+      {
+        id: "assistant-before-tool",
+        streamDeltas: ["looking up"],
+        text: "looking up",
+      },
+      "read",
+      { path: "README.md" },
+    );
+
+    expect(readOutputItemSlots(events)).toEqual([
+      {
+        type: "response.output_item.added",
+        itemId: "assistant-before-tool",
+        outputIndex: 0,
+      },
+      {
+        type: "response.output_item.done",
+        itemId: "assistant-before-tool",
+        outputIndex: 0,
+      },
+      {
+        type: "response.output_item.added",
+        itemId: expect.any(String),
+        outputIndex: 1,
+      },
+      {
+        type: "response.output_item.done",
+        itemId: expect.any(String),
+        outputIndex: 1,
+      },
+    ]);
+    expect(events.find((event) => event.type === "response.function_call_arguments.delta")).toEqual(
+      {
+        type: "response.function_call_arguments.delta",
+        item_id: expect.any(String),
+        output_index: 1,
+        delta: JSON.stringify({ path: "README.md" }),
+      },
+    );
+  });
+
+  it("indexes reasoning before the streamed assistant answer", () => {
+    const events = buildReasoningAndAssistantEvents({
+      reasoningId: "reasoning-before-answer",
+      answerId: "reasoned-answer",
+      answerText: "reasoned final",
+    });
+
+    expect(readOutputItemSlots(events)).toEqual([
+      {
+        type: "response.output_item.added",
+        itemId: "reasoning-before-answer",
+        outputIndex: 0,
+      },
+      {
+        type: "response.output_item.done",
+        itemId: "reasoning-before-answer",
+        outputIndex: 0,
+      },
+      {
+        type: "response.output_item.added",
+        itemId: "reasoned-answer",
+        outputIndex: 1,
+      },
+      {
+        type: "response.output_item.done",
+        itemId: "reasoned-answer",
+        outputIndex: 1,
+      },
+    ]);
+  });
+
+  it("indexes a reasoning-only output on its first slot", () => {
+    expect(readOutputItemSlots(buildReasoningOnlyEvents("thinking", "reasoning-only"))).toEqual([
+      {
+        type: "response.output_item.added",
+        itemId: "reasoning-only",
+        outputIndex: 0,
+      },
+      {
+        type: "response.output_item.done",
+        itemId: "reasoning-only",
+        outputIndex: 0,
+      },
+    ]);
+  });
+});

--- a/extensions/qa-lab/src/providers/mock-openai/mock-openai-events.ts
+++ b/extensions/qa-lab/src/providers/mock-openai/mock-openai-events.ts
@@ -194,9 +194,14 @@ function buildAssistantOutputItem(spec: MockAssistantMessageSpec) {
   } as const;
 }
 
-function appendAssistantMessageEvents(events: StreamEvent[], spec: MockAssistantMessageSpec) {
+function appendAssistantMessageEvents(
+  events: StreamEvent[],
+  spec: MockAssistantMessageSpec,
+  outputIndex: number,
+) {
   events.push({
     type: "response.output_item.added",
+    output_index: outputIndex,
     item: {
       type: "message",
       id: spec.id,
@@ -210,7 +215,7 @@ function appendAssistantMessageEvents(events: StreamEvent[], spec: MockAssistant
     events.push({
       type: "response.output_text.delta",
       item_id: spec.id,
-      output_index: 0,
+      output_index: outputIndex,
       content_index: 0,
       delta,
     });
@@ -219,13 +224,14 @@ function appendAssistantMessageEvents(events: StreamEvent[], spec: MockAssistant
     events.push({
       type: "response.output_text.done",
       item_id: spec.id,
-      output_index: 0,
+      output_index: outputIndex,
       content_index: 0,
       text: spec.text,
     });
   }
   events.push({
     type: "response.output_item.done",
+    output_index: outputIndex,
     item: buildAssistantOutputItem(spec),
   });
 }
@@ -238,9 +244,10 @@ export function buildAssistantThenToolCallEvents(
   const call = buildMockFunctionCall(name, args);
   const message = buildAssistantOutputItem(spec);
   const events: StreamEvent[] = [];
-  appendAssistantMessageEvents(events, spec);
+  appendAssistantMessageEvents(events, spec, 0);
   events.push({
     type: "response.output_item.added",
+    output_index: 1,
     item: {
       type: "function_call",
       id: call.itemId,
@@ -249,9 +256,15 @@ export function buildAssistantThenToolCallEvents(
       arguments: "",
     },
   });
-  events.push({ type: "response.function_call_arguments.delta", delta: call.serialized });
+  events.push({
+    type: "response.function_call_arguments.delta",
+    item_id: call.itemId,
+    output_index: 1,
+    delta: call.serialized,
+  });
   events.push({
     type: "response.output_item.done",
+    output_index: 1,
     item: call.item,
   });
   events.push({
@@ -282,40 +295,8 @@ export function buildAssistantEvents(
   const output = renderedSpecs.map(({ item }) => item);
   const events: StreamEvent[] = [];
 
-  for (const [outputIndex, { spec, item }] of renderedSpecs.entries()) {
-    events.push({
-      type: "response.output_item.added",
-      item: {
-        type: "message",
-        id: spec.id,
-        role: "assistant",
-        ...(spec.phase ? { phase: spec.phase } : {}),
-        content: [],
-        status: "in_progress",
-      },
-    });
-    for (const delta of spec.streamDeltas ?? []) {
-      events.push({
-        type: "response.output_text.delta",
-        item_id: spec.id,
-        output_index: outputIndex,
-        content_index: 0,
-        delta,
-      });
-    }
-    if ((spec.streamDeltas ?? []).length > 0) {
-      events.push({
-        type: "response.output_text.done",
-        item_id: spec.id,
-        output_index: outputIndex,
-        content_index: 0,
-        text: spec.text,
-      });
-    }
-    events.push({
-      type: "response.output_item.done",
-      item,
-    });
+  for (const [outputIndex, { spec }] of renderedSpecs.entries()) {
+    appendAssistantMessageEvents(events, spec, outputIndex);
   }
 
   events.push({
@@ -339,6 +320,7 @@ export function buildReasoningOnlyEvents(summaryText: string, id: string): Strea
   return [
     {
       type: "response.output_item.added",
+      output_index: 0,
       item: {
         type: "reasoning",
         id,
@@ -347,6 +329,7 @@ export function buildReasoningOnlyEvents(summaryText: string, id: string): Strea
     },
     {
       type: "response.output_item.done",
+      output_index: 0,
       item: reasoningItem,
     },
     {
@@ -379,6 +362,7 @@ export function buildReasoningAndAssistantEvents(params: {
   return [
     {
       type: "response.output_item.added",
+      output_index: 0,
       item: {
         type: "reasoning",
         id: params.reasoningId,
@@ -387,10 +371,12 @@ export function buildReasoningAndAssistantEvents(params: {
     },
     {
       type: "response.output_item.done",
+      output_index: 0,
       item: reasoningItem,
     },
     {
       type: "response.output_item.added",
+      output_index: 1,
       item: {
         type: "message",
         id: answerItem.id,
@@ -416,6 +402,7 @@ export function buildReasoningAndAssistantEvents(params: {
     },
     {
       type: "response.output_item.done",
+      output_index: 1,
       item: answerItem,
     },
     {

--- a/extensions/qa-lab/src/providers/mock-openai/server.test.ts
+++ b/extensions/qa-lab/src/providers/mock-openai/server.test.ts
@@ -20,6 +20,8 @@ const QA_EMPTY_RESPONSE_EXHAUSTION_PROMPT =
   "Empty response exhaustion QA check: read QA_KICKOFF_TASK.md, then answer with exactly EMPTY-EXHAUSTED-OK.";
 const QA_EMPTY_RESPONSE_SIDE_EFFECT_RECOVERY_PROMPT =
   "Empty response after write recovery QA check: write qa-empty-response-side-effect.txt, then answer with exactly TELEGRAM-EMPTY-WRITE-RECOVERED-OK.";
+const QA_ANTHROPIC_THINKING_ERROR_RECOVERY_PROMPT =
+  "Anthropic thinking error QA check: read QA_KICKOFF_TASK.md, then answer with exactly ANTHROPIC-THINKING-ERROR-RECOVERED-OK.";
 const QA_REASONING_ONLY_RETRY_INSTRUCTION =
   "The previous assistant turn recorded reasoning but did not produce a user-visible answer. Continue from that partial turn and produce the visible answer now. Do not restate the reasoning or restart from scratch.";
 const QA_EMPTY_RESPONSE_RETRY_INSTRUCTION =
@@ -196,6 +198,7 @@ const SESSIONS_SPAWN_TOOL = { type: "function", name: "sessions_spawn" } as cons
 const SESSIONS_YIELD_TOOL = { type: "function", name: "sessions_yield" } as const;
 const READ_TOOL = { type: "function", name: "read" } as const;
 const MESSAGE_TOOL = { type: "function", name: "message" } as const;
+const IMAGE_GENERATE_TOOL = { type: "function", name: "image_generate" } as const;
 const SLACK_CHART_SUMMARY_TOKEN = "SLACK_QA_CHART_SUMMARY_TEST";
 const SLACK_CHART_DONE_TOKEN = "SLACK_QA_CHART_DONE_TEST";
 const SLACK_CHART_MESSAGE_TOOL_ARGS = {
@@ -3738,6 +3741,7 @@ describe("qa mock openai server", () => {
 
     const toolPlan = await postResponses(server, {
       stream: false,
+      tools: [IMAGE_GENERATE_TOOL],
       input: [makeUserInput(channelPrompt), makeUserInput(genericPrompt)],
     });
 
@@ -3773,6 +3777,60 @@ describe("qa mock openai server", () => {
 
     expect(toolResult.status).toBe(200);
     expect(outputText(await toolResult.json())).toContain("Attachment: /tmp/qa-lighthouse.png");
+  });
+
+  it("completes an image without replaying a tool unavailable to the completion turn", async () => {
+    const server = await startMockServer();
+    const completion = await expectResponsesJson<unknown>(server, {
+      stream: false,
+      tools: [MESSAGE_TOOL],
+      input: [
+        makeUserInput("Image generation check: generate a QA lighthouse image."),
+        makeUserInput(
+          [
+            "[Internal task completion event]",
+            "source: image_generation",
+            "status: completed successfully",
+            "Generated media:",
+            "MEDIA:/tmp/qa-lighthouse.png",
+          ].join("\n"),
+        ),
+      ],
+    });
+
+    expect(
+      outputItems(completion).some(
+        (item) => item.type === "function_call" && item.name === "image_generate",
+      ),
+    ).toBe(false);
+    expect(outputText(completion)).toBe(
+      "Protocol note: generated the QA lighthouse image successfully.\nMEDIA:/tmp/qa-lighthouse.png",
+    );
+  });
+
+  it("does not replay a historical image completion on a new marker turn", async () => {
+    const server = await startMockServer();
+    const completion = await expectResponsesJson<unknown>(server, {
+      stream: false,
+      tools: [MESSAGE_TOOL],
+      input: [
+        makeUserInput(
+          [
+            "[Internal task completion event]",
+            "source: image_generation",
+            "status: completed successfully",
+            "MEDIA:/tmp/qa-lighthouse.png",
+          ].join("\n"),
+        ),
+        {
+          role: "assistant",
+          content: [{ type: "output_text", text: "MEDIA:/tmp/qa-lighthouse.png" }],
+        },
+        makeUserInput("Marker exact marker: `fresh-image-completion-marker`"),
+      ],
+    });
+
+    expect(outputText(completion)).toBe("fresh-image-completion-marker");
   });
 
   it("plans QA tool-search calls for instruction-declared Codex dynamic tools", async () => {
@@ -5017,6 +5075,138 @@ describe("qa mock openai server", () => {
     };
     expect(debug.toolOutputCallId).toBe("toolu_mock_read_error");
     expect(debug.toolOutputStructuredError).toBe(true);
+  });
+
+  it("replays one signed Anthropic thinking error for each independent scenario", async () => {
+    const server = await startMockServer();
+    const readCallIds: string[] = [];
+    const scenarioPrompts: string[] = [];
+
+    const requestAnthropicStream = async (messages: unknown[]) => {
+      const response = await postJson(server, "/v1/messages", {
+        model: "claude-opus-4-8",
+        max_tokens: 256,
+        stream: true,
+        messages,
+      });
+      expect(response.status).toBe(200);
+      expect(response.headers.get("content-type")).toContain("text/event-stream");
+      return response.text();
+    };
+
+    const readAnthropicToolCallId = (readStream: string) => {
+      const readEvents = readStream
+        .split("\n")
+        .filter((line) => line.startsWith("data: "))
+        .map((line) =>
+          requireRecord(JSON.parse(line.slice("data: ".length)) as unknown, "Anthropic SSE event"),
+        );
+      const readEvent = readEvents.find(
+        (event) =>
+          event.type === "content_block_start" &&
+          requireRecord(event.content_block, "Anthropic content block").type === "tool_use",
+      );
+      const readTool = requireRecord(readEvent?.content_block, "Anthropic read tool call");
+      expect(readTool.name).toBe("read");
+      expect(readTool.input).toEqual({});
+      const readInputEvent = readEvents.find(
+        (event) => event.type === "content_block_delta" && event.index === readEvent?.index,
+      );
+      expect(requireRecord(readInputEvent?.delta, "Anthropic read tool input delta")).toEqual({
+        type: "input_json_delta",
+        partial_json: JSON.stringify({ path: "QA_KICKOFF_TASK.md" }),
+      });
+      const callId = readTool.id;
+      if (typeof callId !== "string" || callId.length === 0) {
+        throw new Error("Expected an Anthropic read tool call ID");
+      }
+      readCallIds.push(callId);
+      return callId;
+    };
+
+    const buildReplayMessages = (
+      promptMessage: { role: "user"; content: Array<{ type: "text"; text: string }> },
+      callId: string,
+    ) => [
+      promptMessage,
+      {
+        role: "assistant" as const,
+        content: [
+          {
+            type: "tool_use" as const,
+            id: callId,
+            name: "read",
+            input: { path: "QA_KICKOFF_TASK.md" },
+          },
+        ],
+      },
+      {
+        role: "user" as const,
+        content: [
+          {
+            type: "tool_result" as const,
+            tool_use_id: callId,
+            content: "QA kickoff task completed.",
+          },
+        ],
+      },
+    ];
+
+    for (let attempt = 0; attempt < 2; attempt += 1) {
+      const scenarioPrompt = `${QA_ANTHROPIC_THINKING_ERROR_RECOVERY_PROMPT} QA scenario run: direct-${attempt}`;
+      scenarioPrompts.push(scenarioPrompt);
+      const promptMessage = {
+        role: "user" as const,
+        content: [{ type: "text" as const, text: scenarioPrompt }],
+      };
+      const initialCallId = readAnthropicToolCallId(await requestAnthropicStream([promptMessage]));
+      const errorStream = await requestAnthropicStream(
+        buildReplayMessages(promptMessage, initialCallId),
+      );
+      expect(errorStream).toContain('"type":"thinking_delta"');
+      expect(errorStream).toContain('"type":"signature_delta"');
+      expect(errorStream).toContain('"signature":"qa_signed_thinking_block_91953"');
+      expect(errorStream).toContain("event: error");
+      expect(errorStream).toContain('"type":"api_error"');
+
+      const retryCallId = readAnthropicToolCallId(await requestAnthropicStream([promptMessage]));
+      expect(retryCallId).not.toBe(initialCallId);
+      const recoveryStream = await requestAnthropicStream(
+        buildReplayMessages(promptMessage, retryCallId),
+      );
+      expect(recoveryStream).toContain("event: message_stop");
+      expect(recoveryStream).toContain("ANTHROPIC-THINKING-ERROR-RECOVERED-OK");
+      expect(recoveryStream).not.toContain("event: error");
+    }
+
+    expect(new Set(readCallIds).size).toBe(4);
+    const debugResponse = await fetch(`${server.baseUrl}/debug/requests`);
+    expect(debugResponse.status).toBe(200);
+    const debugRequests = requireArray(await debugResponse.json(), "Anthropic debug requests").map(
+      (request) => requireRecord(request, "Anthropic debug request"),
+    );
+    expect(debugRequests).toHaveLength(8);
+    expect(debugRequests.every((request) => request.providerVariant === "anthropic")).toBe(true);
+    expect(debugRequests.map((request) => request.toolOutputCallId)).toEqual([
+      undefined,
+      readCallIds[0],
+      undefined,
+      readCallIds[1],
+      undefined,
+      readCallIds[2],
+      undefined,
+      readCallIds[3],
+    ]);
+    expect(debugRequests.map((request) => request.prompt)).toEqual([
+      scenarioPrompts[0],
+      scenarioPrompts[0],
+      scenarioPrompts[0],
+      scenarioPrompts[0],
+      scenarioPrompts[1],
+      scenarioPrompts[1],
+      scenarioPrompts[1],
+      scenarioPrompts[1],
+    ]);
   });
 
   it("streams Anthropic /v1/messages tool_use responses as SSE", async () => {

--- a/extensions/qa-lab/src/providers/mock-openai/server.ts
+++ b/extensions/qa-lab/src/providers/mock-openai/server.ts
@@ -1119,7 +1119,11 @@ async function buildResponsesPayload(
       });
     }
   }
-  if (QA_IMAGE_GENERATION_PROMPT_RE.test(allInputText) && !toolOutput) {
+  if (
+    QA_IMAGE_GENERATION_PROMPT_RE.test(allInputText) &&
+    !toolOutput &&
+    hasToolDefinition(body, "image_generate")
+  ) {
     return buildToolCallEventsWithArgs("image_generate", {
       prompt: "A QA lighthouse on a dark sea with a tiny protocol droid silhouette.",
       filename: "qa-lighthouse.png",
@@ -1295,7 +1299,7 @@ export async function startQaMockOpenAiServer(params?: {
   const host = params?.host ?? "127.0.0.1";
   const finalOnlyMarkerPauseMs = params?.finalOnlyMarkerPauseMs ?? 1_500;
   const scenarioState: MockScenarioState = {
-    anthropicThinkingErrorPhase: 0,
+    anthropicThinkingErrorScenarioKeys: new Set<string>(),
     subagentFanoutPhase: 0,
     subagentHandoffSpawned: false,
     toolLoopReadAttempts: 0,

--- a/extensions/qa-lab/src/reply-failure.test.ts
+++ b/extensions/qa-lab/src/reply-failure.test.ts
@@ -17,6 +17,13 @@ describe("extractQaFailureReplyText", () => {
     ).toContain("Something went wrong while processing your request.");
   });
 
+  it.each([
+    "⚠️ Agent couldn't generate a response. Please try again.",
+    "⚠️ Agent couldn't generate a response. Note: some tool actions may have already been executed — please verify before retrying.",
+  ])("classifies the canonical incomplete-turn warning as a failure: %s", (reply) => {
+    expect(extractQaFailureReplyText(reply)).toBe(reply);
+  });
+
   it("classifies explicit provider auth guidance as a failure", () => {
     expect(
       extractQaFailureReplyText(

--- a/extensions/qa-lab/src/reply-failure.ts
+++ b/extensions/qa-lab/src/reply-failure.ts
@@ -3,6 +3,7 @@ import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/string-coer
 
 const FAILURE_REPLY_PREFIXES = [
   "⚠️ something went wrong while processing your request.",
+  "⚠️ agent couldn't generate a response",
   "⚠️ session history got out of sync.",
   "⚠️ session history was corrupted.",
   "⚠️ context overflow",

--- a/extensions/qa-lab/src/scenario-catalog.test.ts
+++ b/extensions/qa-lab/src/scenario-catalog.test.ts
@@ -3,6 +3,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
+import { OpenClawSchema } from "../../../src/config/zod-schema.js";
 import { resolveQaParityPackScenarioIds } from "./agentic-parity.js";
 import { resolveQaRepoPath } from "./repo-path.js";
 import {
@@ -18,6 +19,7 @@ import {
   listScenarioMarkdownPaths,
   requireFlowScenario,
 } from "./scenario-catalog.test-utils.js";
+import { applyQaMergePatch } from "./suite-merge-patch.js";
 import { runQaTestFileScenarios } from "./test-file-scenario-runner.js";
 
 describe("qa scenario catalog", () => {
@@ -233,6 +235,79 @@ describe("qa scenario catalog", () => {
 
     expect(scenario.gatewayRuntime?.forwardHostHome).toBe(true);
     expect(otelStdout.gatewayRuntime?.preserveDebugArtifacts).toBe(true);
+  });
+
+  it.each([
+    ["otel-trace-smoke", { diagnostics: { otel: { captureContent: false } } }, []],
+    ["otel-both-log-smoke", { diagnostics: { otel: { captureContent: false } } }, []],
+    ["otel-stdout-log-smoke", { diagnostics: { otel: { captureContent: false } } }, []],
+    [
+      "a2a-message-tool-mirror-dedupe",
+      {
+        messages: { groupChat: { visibleReplies: "message_tool" } },
+        tools: { sessions: { visibility: "all" }, agentToAgent: { enabled: true } },
+      },
+      ["session.agentToAgent"],
+    ],
+    [
+      "goal-context-survives-compaction",
+      { agents: { defaults: { compaction: { keepRecentTokens: 64 } } } },
+      ["agents.defaults.compaction.reserveTokens", "agents.defaults.compaction.reserveTokensFloor"],
+    ],
+    [
+      "commitments-heartbeat-target-none",
+      { agents: { defaults: { heartbeat: { every: "30m", target: "none" } } } },
+      ["commitments"],
+    ],
+    [
+      "active-memory-preprompt-recall",
+      { plugins: { entries: { "active-memory": { config: { mode: "always" } } } } },
+      [],
+    ],
+  ] as const)(
+    "keeps %s gateway config canonical and free of retired keys",
+    (scenarioId, expectedPatch, retiredPaths) => {
+      const gatewayConfigPatch = readQaScenarioById(scenarioId).gatewayConfigPatch;
+      const gatewayConfig = applyQaMergePatch(
+        { agents: { entries: { qa: { default: true } } } },
+        gatewayConfigPatch,
+      );
+
+      expect(gatewayConfigPatch).toMatchObject(expectedPatch);
+      for (const retiredPath of retiredPaths) {
+        expect(gatewayConfigPatch).not.toHaveProperty(retiredPath);
+      }
+      expect(OpenClawSchema.safeParse(gatewayConfig).success).toBe(true);
+    },
+  );
+
+  it("keeps session memory ranking's runtime config patch schema-valid", () => {
+    const scenario = readQaScenarioById("session-memory-ranking");
+    const patchConfigAction = scenario.execution.flow?.steps
+      .flatMap((step) => step.actions)
+      .find(
+        (action): action is { call: "patchConfig"; args: Array<{ patch: unknown }> } =>
+          typeof action === "object" &&
+          action !== null &&
+          "call" in action &&
+          action.call === "patchConfig" &&
+          "args" in action &&
+          Array.isArray(action.args),
+      );
+    const patch = patchConfigAction?.args[0]?.patch;
+
+    expect(patch).toMatchObject({
+      tools: { sessions: { visibility: "all" } },
+      memory: {
+        search: {
+          sources: ["memory", "sessions"],
+          experimental: { sessionMemory: true },
+          query: { minScore: 0 },
+        },
+      },
+    });
+    expect(patch).not.toHaveProperty("memory.search.query.hybrid");
+    expect(OpenClawSchema.safeParse(patch).success).toBe(true);
   });
 
   it("loads native test execution scenarios from YAML", () => {
@@ -786,6 +861,40 @@ describe("qa scenario catalog", () => {
     ]);
   });
 
+  it("keeps Anthropic thinking recovery on its resolved replay-safe mock route", () => {
+    const scenario = requireFlowScenario(
+      readQaScenarioById("anthropic-thinking-error-recovery-replay-safe-read"),
+    );
+    const flow = JSON.stringify(scenario.execution.flow);
+
+    expect(scenario.execution.config).toMatchObject({
+      requiredProviderMode: "mock-openai",
+      anthropicModelRef: "anthropic/claude-opus-4-8",
+    });
+    expect(scenario.gatewayConfigPatch).toMatchObject({
+      agents: { defaults: { models: { "anthropic/claude-opus-4-8": { params: {} } } } },
+      tools: { codeMode: { enabled: false } },
+    });
+    expect(flow).toContain("modelAck.resolved?.modelProvider === 'anthropic'");
+    expect(flow).toContain("modelAck.resolved?.model === 'claude-opus-4-8'");
+    expect(flow).toContain('"set":"scenarioPrompt"');
+    expect(flow).toContain("`${config.prompt} QA scenario run: ${sessionKey}`");
+    expect(flow).toContain('"message":{"expr":"scenarioPrompt"}');
+    expect(flow).toContain("effectiveToolIds.includes('read')");
+    expect(flow).toContain('"call":"runAgentPrompt"');
+    expect(flow).toContain('"provider":"anthropic"');
+    expect(flow).toContain('"model":"claude-opus-4-8"');
+    expect(flow).toContain("/debug/requests?after=${requestCursorBefore}");
+    expect(flow).toContain("request.plannedToolName === 'read'");
+    expect(flow).toContain(").length >= 3");
+    expect(flow).toContain("!scenarioRequests.some((request)");
+    expect(flow).toContain("config.visibleAnswerRetryNeedle");
+    expect(flow).toContain('"sinceIndex":{"ref":"outboundStartIndex"}');
+    const requestEvidenceIndex = flow.indexOf('"set":"scenarioRequests"');
+    expect(requestEvidenceIndex).toBeGreaterThanOrEqual(0);
+    expect(requestEvidenceIndex).toBeLessThan(flow.indexOf('"call":"waitForOutboundMessage"'));
+  });
+
   it("includes the seeded mock-only broken-turn scenarios in the YAML pack", () => {
     const scenarioIds = [
       "reasoning-only-recovery-replay-safe-read",
@@ -926,6 +1035,7 @@ describe("qa scenario catalog", () => {
     const config = readQaScenarioExecutionConfig("remember-across-conversations") as
       | { requiredChannelDriver?: string }
       | undefined;
+    const flow = JSON.stringify(scenario.execution.flow);
 
     expect(scenario.execution.suiteIsolation).toBe("isolated");
     expect(config?.requiredChannelDriver).toBe("qa-channel");
@@ -936,10 +1046,21 @@ describe("qa scenario catalog", () => {
         entries: {
           "active-memory": {
             enabled: true,
-            config: { enabled: true, agents: [] },
+            config: { enabled: true, mode: "always", agents: [] },
           },
         },
       },
     });
+    expect(flow).toContain("[sourceSessionKey, targetSessionKey, groupSessionKey]");
+    expect(flow).toContain("readSessionTranscriptSummary");
+    expect(flow).toContain("transcript.eventCursor > 0");
+    expect(flow).toContain(
+      "state.getSnapshot().messages.filter((message) => message.direction === 'outbound').length",
+    );
+    expect(flow).toContain('"saveAs":"pauseCommandOutbound"');
+    expect(flow).toContain("candidate.conversation.id === config.pausedConversationId");
+    expect(flow).toContain('"sinceIndex":{"ref":"pauseCommandStartIndex"}');
+    expect(flow).not.toContain('"call":"sleep"');
+    expect(flow).not.toContain(".sessionFile");
   });
 });

--- a/extensions/qa-lab/src/scenario-catalog.test.ts
+++ b/extensions/qa-lab/src/scenario-catalog.test.ts
@@ -3,7 +3,6 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
-import { OpenClawSchema } from "../../../src/config/zod-schema.js";
 import { resolveQaParityPackScenarioIds } from "./agentic-parity.js";
 import { resolveQaRepoPath } from "./repo-path.js";
 import {
@@ -274,14 +273,14 @@ describe("qa scenario catalog", () => {
       );
 
       expect(gatewayConfigPatch).toMatchObject(expectedPatch);
+      expect(gatewayConfig).toMatchObject(expectedPatch);
       for (const retiredPath of retiredPaths) {
         expect(gatewayConfigPatch).not.toHaveProperty(retiredPath);
       }
-      expect(OpenClawSchema.safeParse(gatewayConfig).success).toBe(true);
     },
   );
 
-  it("keeps session memory ranking's runtime config patch schema-valid", () => {
+  it("keeps session memory ranking's runtime config patch canonical", () => {
     const scenario = readQaScenarioById("session-memory-ranking");
     const patchConfigAction = scenario.execution.flow?.steps
       .flatMap((step) => step.actions)
@@ -307,7 +306,6 @@ describe("qa scenario catalog", () => {
       },
     });
     expect(patch).not.toHaveProperty("memory.search.query.hybrid");
-    expect(OpenClawSchema.safeParse(patch).success).toBe(true);
   });
 
   it("loads native test execution scenarios from YAML", () => {

--- a/extensions/qa-lab/src/scenario-flow-runner.test.ts
+++ b/extensions/qa-lab/src/scenario-flow-runner.test.ts
@@ -405,7 +405,7 @@ describe("scenario-flow-runner", () => {
   it.each([
     "control-ui-qa-channel-image-roundtrip",
     "control-ui-assistant-transcript-role-boundary",
-  ])("opens the selected Control UI session on the chat route for %s", async (scenarioId) => {
+  ])("opens the selected Control UI session from the gateway root for %s", async (scenarioId) => {
     const scenario = readQaScenarioById(scenarioId);
     const actions = scenario.execution.flow?.steps.flatMap((step) => step.actions);
     if (!actions) {
@@ -475,7 +475,7 @@ describe("scenario-flow-runner", () => {
       throw new Error(`scenario did not open its Control UI session: ${scenarioId}`);
     }
     const chatUrl = new URL(openedUrl);
-    expect(chatUrl.pathname).toBe("/chat");
+    expect(chatUrl.pathname).toBe("/");
     expect(chatUrl.searchParams.get("session")).toBe(sessionKey);
     expect(chatUrl.hash).toBe(`#token=${encodeURIComponent(gatewayToken)}`);
   });

--- a/extensions/qa-lab/src/suite-summary.test.ts
+++ b/extensions/qa-lab/src/suite-summary.test.ts
@@ -58,6 +58,101 @@ describe("qa suite summary helpers", () => {
     ).resolves.toBe(2);
   });
 
+  it("excludes only catalog-confirmed report-only optional skips from suite gates", async () => {
+    await expect(
+      readSummary(
+        {
+          counts: { total: 2, passed: 1, failed: 0, skipped: 1 },
+          scenarios: [
+            { name: "required scenario", status: "pass" },
+            {
+              name: "optional tool fixture",
+              status: "skip",
+              details: "expected-unavailable tool fixture; report-only",
+            },
+          ],
+        },
+        (summaryPath) =>
+          readQaSuiteFailedOrSkippedScenarioCountFromFile(summaryPath, {
+            optionalScenarioNames: new Set(["optional tool fixture"]),
+          }),
+      ),
+    ).resolves.toBe(0);
+  });
+
+  it("keeps unknown and unverified report-only skips fail-closed", async () => {
+    await expect(
+      readSummary(
+        {
+          counts: { total: 2, passed: 0, failed: 0, skipped: 2 },
+          scenarios: [
+            {
+              name: "optional tool fixture",
+              status: "skip",
+              details: "expected-unavailable tool fixture; report-only",
+            },
+            {
+              name: "unknown tool fixture",
+              status: "skip",
+              details: "expected-unavailable tool fixture; report-only",
+            },
+          ],
+        },
+        (summaryPath) =>
+          readQaSuiteFailedOrSkippedScenarioCountFromFile(summaryPath, {
+            optionalScenarioNames: new Set(["optional tool fixture"]),
+          }),
+      ),
+    ).resolves.toBe(1);
+  });
+
+  it("keeps catalog-confirmed skips without report-only evidence blocking", async () => {
+    await expect(
+      readSummary(
+        {
+          counts: { total: 1, passed: 0, failed: 0, skipped: 1 },
+          scenarios: [{ name: "optional tool fixture", status: "skip" }],
+        },
+        (summaryPath) =>
+          readQaSuiteFailedOrSkippedScenarioCountFromFile(summaryPath, {
+            optionalScenarioNames: new Set(["optional tool fixture"]),
+          }),
+      ),
+    ).resolves.toBe(1);
+  });
+
+  it("never lets an optional skip cancel a declared failure or unknown evidence", async () => {
+    const optionalScenario = {
+      name: "optional tool fixture",
+      status: "skip",
+      details: "expected-unavailable tool fixture; report-only",
+    };
+    const readWithOptionalPolicy = (summaryPath: string) =>
+      readQaSuiteFailedOrSkippedScenarioCountFromFile(summaryPath, {
+        optionalScenarioNames: new Set(["optional tool fixture"]),
+      });
+
+    await expect(
+      readSummary(
+        {
+          counts: { total: 1, passed: 0, failed: 1, skipped: 0 },
+          scenarios: [optionalScenario],
+        },
+        readWithOptionalPolicy,
+      ),
+    ).resolves.toBe(1);
+    await expect(
+      readSummary(
+        {
+          counts: { total: 1, passed: 0, failed: 0, skipped: 1 },
+          scenarios: [optionalScenario],
+          entries: [{ result: { status: "timeout" } }],
+        },
+        readWithOptionalPolicy,
+      ),
+    ).resolves.toBe(1);
+  });
+
   it("uses the larger failure signal when counts and scenarios disagree", async () => {
     await expect(
       readSummary(

--- a/extensions/qa-lab/src/suite-summary.ts
+++ b/extensions/qa-lab/src/suite-summary.ts
@@ -68,6 +68,11 @@ export type QaSuiteSummaryJson = {
 };
 
 type QaSuiteScenarioStatus = Pick<QaSuiteSummaryScenario, "status">;
+type QaSuiteReportOnlyScenario = {
+  name?: unknown;
+  status?: unknown;
+  details?: unknown;
+};
 type QaEvidenceEntryStatus = {
   result?: {
     status?: unknown;
@@ -104,6 +109,19 @@ function readNonNegativeCount(value: unknown): number | null {
 
 function isQaSuiteBlockingStatus(status: unknown): boolean {
   return status !== "pass";
+}
+
+export function isQaSuiteReportOnlyOptionalScenario(
+  scenario: QaSuiteReportOnlyScenario,
+  optionalScenarioNames: ReadonlySet<string> | undefined,
+): boolean {
+  return (
+    (scenario.status === "skip" || scenario.status === "skipped") &&
+    typeof scenario.name === "string" &&
+    optionalScenarioNames?.has(scenario.name) === true &&
+    typeof scenario.details === "string" &&
+    scenario.details.includes("report-only")
+  );
 }
 
 export function countQaSuiteFailedScenarios(
@@ -216,11 +234,34 @@ export async function readQaSuiteFailedScenarioCountFromFile(summaryPath: string
 
 export async function readQaSuiteFailedOrSkippedScenarioCountFromFile(
   summaryPath: string,
+  options?: { optionalScenarioNames?: ReadonlySet<string> },
 ): Promise<number> {
   const payload = await readQaSuiteSummaryFile(summaryPath);
   const blockingScenarioCount = readQaSuiteFailedOrSkippedScenarioCountFromSummary(payload);
   if (blockingScenarioCount !== null) {
-    return blockingScenarioCount;
+    const optionalScenarioNames = options?.optionalScenarioNames;
+    if (!optionalScenarioNames?.size || !payload || typeof payload !== "object") {
+      return blockingScenarioCount;
+    }
+    const { scenarios, entries } = payload as {
+      scenarios?: QaSuiteReportOnlyScenario[];
+      entries?: QaEvidenceEntryStatus[];
+    };
+    const reportOnlyOptionalSkips = Array.isArray(scenarios)
+      ? scenarios.filter((scenario) =>
+          isQaSuiteReportOnlyOptionalScenario(scenario, optionalScenarioNames),
+        ).length
+      : 0;
+    const evidenceBlocking = Array.isArray(entries)
+      ? entries.filter((entry) => isQaSuiteBlockingStatus(entry.result?.status)).length
+      : 0;
+    // Optional skips may offset only their independently verified scenario results.
+    // Declared failures, unknown evidence, and count disagreements stay fail-closed.
+    return Math.max(
+      readQaSuiteFailedScenarioCountFromSummary(payload) ?? 0,
+      blockingScenarioCount - reportOnlyOptionalSkips,
+      evidenceBlocking,
+    );
   }
   throw new QaSuiteArtifactError(
     "summary_blocking_count_missing",

--- a/packages/ai/src/transports/openai-responses-stream-parity.test.ts
+++ b/packages/ai/src/transports/openai-responses-stream-parity.test.ts
@@ -551,7 +551,15 @@ const fixtures: ParityFixture[] = [
           content: [{ type: "output_text", text: "hello", annotations: [] }],
         },
       },
-      completed("resp_text"),
+      completed("resp_text", [
+        {
+          id: "msg_text",
+          type: "message",
+          role: "assistant",
+          status: "completed",
+          content: [{ type: "output_text", text: "hello", annotations: [] }],
+        },
+      ]),
     ],
     canonical: {
       events: [
@@ -586,6 +594,285 @@ const fixtures: ParityFixture[] = [
       content: [{ type: "text", text: "recovered" }],
       responseId: "resp_terminal_text",
       stopReason: "stop",
+      error: null,
+    },
+  },
+  {
+    name: "terminal completed message recovery after streamed reasoning",
+    events: [
+      {
+        type: "response.output_item.added",
+        output_index: 0,
+        item: { id: "rs_before_terminal", type: "reasoning", summary: [], content: [] },
+      },
+      {
+        type: "response.output_item.done",
+        output_index: 0,
+        item: {
+          id: "rs_before_terminal",
+          type: "reasoning",
+          summary: [{ type: "summary_text", text: "thought" }],
+          content: [],
+        },
+      },
+      completed("resp_reasoning_terminal_text", [
+        {
+          id: "rs_before_terminal",
+          type: "reasoning",
+          summary: [{ type: "summary_text", text: "thought" }],
+          content: [],
+          encrypted_content: "encrypted",
+        },
+        {
+          id: "msg_after_reasoning",
+          type: "message",
+          role: "assistant",
+          status: "completed",
+          phase: "final_answer",
+          content: [{ type: "output_text", text: "recovered final answer", annotations: [] }],
+        },
+      ]),
+    ],
+    canonical: {
+      events: [
+        { type: "thinking_start", contentIndex: 0 },
+        { type: "thinking_end", contentIndex: 0, content: "thought" },
+        { type: "text_start", contentIndex: 1 },
+        { type: "text_end", contentIndex: 1, content: "recovered final answer" },
+      ],
+      content: [
+        { type: "thinking", thinking: "thought", encrypted: true },
+        { type: "text", text: "recovered final answer" },
+      ],
+      responseId: "resp_reasoning_terminal_text",
+      stopReason: "stop",
+      error: null,
+    },
+  },
+  {
+    name: "terminal completed message recovery after multiple streamed reasoning blocks",
+    events: [
+      {
+        type: "response.output_item.added",
+        output_index: 0,
+        item: { id: "rs_before_multi_first", type: "reasoning", summary: [], content: [] },
+      },
+      {
+        type: "response.output_item.done",
+        output_index: 0,
+        item: {
+          id: "rs_before_multi_first",
+          type: "reasoning",
+          summary: [{ type: "summary_text", text: "first thought" }],
+          content: [],
+        },
+      },
+      {
+        type: "response.output_item.added",
+        output_index: 1,
+        item: { id: "rs_before_multi_second", type: "reasoning", summary: [], content: [] },
+      },
+      {
+        type: "response.output_item.done",
+        output_index: 1,
+        item: {
+          id: "rs_before_multi_second",
+          type: "reasoning",
+          summary: [{ type: "summary_text", text: "second thought" }],
+          content: [],
+        },
+      },
+      completed("resp_multi_reasoning_terminal_text", [
+        {
+          id: "rs_before_multi_first",
+          type: "reasoning",
+          summary: [{ type: "summary_text", text: "first thought" }],
+          content: [],
+        },
+        {
+          id: "rs_before_multi_second",
+          type: "reasoning",
+          summary: [{ type: "summary_text", text: "second thought" }],
+          content: [],
+        },
+        {
+          id: "msg_after_multiple_reasoning",
+          type: "message",
+          role: "assistant",
+          status: "completed",
+          phase: "final_answer",
+          content: [{ type: "output_text", text: "recovered final answer", annotations: [] }],
+        },
+      ]),
+    ],
+    canonical: {
+      events: [
+        { type: "thinking_start", contentIndex: 0 },
+        { type: "thinking_end", contentIndex: 0, content: "first thought" },
+        { type: "thinking_start", contentIndex: 1 },
+        { type: "thinking_end", contentIndex: 1, content: "second thought" },
+        { type: "text_start", contentIndex: 2 },
+        { type: "text_end", contentIndex: 2, content: "recovered final answer" },
+      ],
+      content: [
+        { type: "thinking", thinking: "first thought", encrypted: false },
+        { type: "thinking", thinking: "second thought", encrypted: false },
+        { type: "text", text: "recovered final answer" },
+      ],
+      responseId: "resp_multi_reasoning_terminal_text",
+      stopReason: "stop",
+      error: null,
+    },
+  },
+  {
+    name: "terminal completed refusal recovery after streamed reasoning",
+    events: [
+      {
+        type: "response.output_item.added",
+        output_index: 0,
+        item: { id: "rs_before_refusal", type: "reasoning", summary: [], content: [] },
+      },
+      {
+        type: "response.output_item.done",
+        output_index: 0,
+        item: {
+          id: "rs_before_refusal",
+          type: "reasoning",
+          summary: [{ type: "summary_text", text: "thought" }],
+          content: [],
+        },
+      },
+      completed("resp_reasoning_terminal_refusal", [
+        {
+          id: "rs_before_refusal",
+          type: "reasoning",
+          summary: [{ type: "summary_text", text: "thought" }],
+          content: [],
+        },
+        {
+          id: "msg_after_reasoning_refusal",
+          type: "message",
+          role: "assistant",
+          status: "completed",
+          content: [{ type: "refusal", refusal: "I cannot help with that." }],
+        },
+      ]),
+    ],
+    canonical: {
+      events: [
+        { type: "thinking_start", contentIndex: 0 },
+        { type: "thinking_end", contentIndex: 0, content: "thought" },
+        { type: "text_start", contentIndex: 1 },
+        { type: "text_end", contentIndex: 1, content: "I cannot help with that." },
+      ],
+      content: [
+        { type: "thinking", thinking: "thought", encrypted: false },
+        { type: "text", text: "I cannot help with that." },
+      ],
+      responseId: "resp_reasoning_terminal_refusal",
+      stopReason: "stop",
+      error: null,
+    },
+  },
+  {
+    name: "terminal null message after streamed reasoning is ignored",
+    events: [
+      {
+        type: "response.output_item.added",
+        output_index: 0,
+        item: { id: "rs_terminal_null", type: "reasoning", summary: [], content: [] },
+      },
+      {
+        type: "response.output_item.done",
+        output_index: 0,
+        item: {
+          id: "rs_terminal_null",
+          type: "reasoning",
+          summary: [{ type: "summary_text", text: "thought" }],
+          content: [],
+        },
+      },
+      completed("resp_reasoning_terminal_null", [
+        {
+          id: "rs_terminal_null",
+          type: "reasoning",
+          summary: [{ type: "summary_text", text: "thought" }],
+          content: [],
+        },
+        {
+          id: "msg_after_reasoning_null",
+          type: "message",
+          role: "assistant",
+          status: "completed",
+          content: null,
+        },
+      ]),
+    ],
+    canonical: {
+      events: [
+        { type: "thinking_start", contentIndex: 0 },
+        { type: "thinking_end", contentIndex: 0, content: "thought" },
+      ],
+      content: [{ type: "thinking", thinking: "thought", encrypted: false }],
+      responseId: "resp_reasoning_terminal_null",
+      stopReason: "stop",
+      error: null,
+    },
+  },
+  {
+    name: "terminal-only completed tool call recovery after streamed reasoning",
+    events: [
+      {
+        type: "response.output_item.added",
+        output_index: 0,
+        item: { id: "rs_before_tool", type: "reasoning", summary: [], content: [] },
+      },
+      {
+        type: "response.output_item.done",
+        output_index: 0,
+        item: {
+          id: "rs_before_tool",
+          type: "reasoning",
+          summary: [{ type: "summary_text", text: "thought" }],
+          content: [],
+        },
+      },
+      completed("resp_reasoning_terminal_tool", [
+        {
+          id: "rs_before_tool",
+          type: "reasoning",
+          summary: [{ type: "summary_text", text: "thought" }],
+          content: [],
+        },
+        {
+          id: "fc_terminal",
+          call_id: "call_terminal",
+          type: "function_call",
+          name: "lookup",
+          arguments: '{"q":"x"}',
+          status: "completed",
+        },
+      ]),
+    ],
+    canonical: {
+      events: [
+        { type: "thinking_start", contentIndex: 0 },
+        { type: "thinking_end", contentIndex: 0, content: "thought" },
+        { type: "toolcall_start", contentIndex: 1 },
+        { type: "toolcall_end", contentIndex: 1 },
+      ],
+      content: [
+        { type: "thinking", thinking: "thought", encrypted: false },
+        {
+          type: "toolCall",
+          id: "call_terminal|fc_terminal",
+          name: "lookup",
+          arguments: { q: "x" },
+          partialJson: false,
+        },
+      ],
+      responseId: "resp_reasoning_terminal_tool",
+      stopReason: "toolUse",
       error: null,
     },
   },

--- a/packages/ai/src/transports/openai-responses-stream-terminal-internal.ts
+++ b/packages/ai/src/transports/openai-responses-stream-terminal-internal.ts
@@ -185,7 +185,9 @@ export function createResponsesTerminalController(params: {
     stream.push({ type: "toolcall_end", contentIndex, toolCall, partial: output as never });
   };
   const recoverTerminalOutput = (items: ResponseOutputItem[], includeToolCalls: boolean) => {
-    if (blocks.length > 0) {
+    // Reasoning can stream before the final message appears only in the terminal snapshot.
+    // Recover that visible answer without replaying already-streamed text or tool calls.
+    if (blocks.some((block) => block.type !== "thinking")) {
       return;
     }
     for (const item of items) {

--- a/qa/scenarios/agents/issue-109025-completion-policy-live.yaml
+++ b/qa/scenarios/agents/issue-109025-completion-policy-live.yaml
@@ -126,7 +126,7 @@ flow:
             - lambda:
                 async: true
                 expr: "fs.readFile(proofPath, 'utf8').then((text) => { const marker = text.trim(); return marker.startsWith(`${config.completionPrefix}:`) && readGatewayLogs().includes(marker) ? marker : undefined; }).catch(() => undefined)"
-            - 60000
+            - expr: liveTurnTimeoutMs(env, 60000)
             - 250
         - call: readSessionTranscriptSummary
           saveAs: parentTranscript

--- a/qa/scenarios/agents/issue-109025-sender-policy-live.yaml
+++ b/qa/scenarios/agents/issue-109025-sender-policy-live.yaml
@@ -114,7 +114,7 @@ flow:
             - lambda:
                 async: true
                 expr: "readRawQaSessionStore(env).then((store) => { const match = Object.entries(store).find(([, entry]) => entry?.label === config.childLabel && typeof entry?.spawnedBy === 'string'); return match ? { key: match[0], entry: match[1] } : undefined; })"
-            - 60000
+            - expr: liveTurnTimeoutMs(env, 60000)
             - 250
         - call: readSessionTranscriptSummary
           saveAs: childTranscript

--- a/qa/scenarios/channels/a2a-message-tool-mirror-dedupe.yaml
+++ b/qa/scenarios/channels/a2a-message-tool-mirror-dedupe.yaml
@@ -14,9 +14,6 @@ scenario:
     messages:
       groupChat:
         visibleReplies: message_tool
-    session:
-      agentToAgent:
-        maxPingPongTurns: 0
     tools:
       sessions:
         visibility: all

--- a/qa/scenarios/goals/goal-context-survives-compaction.yaml
+++ b/qa/scenarios/goals/goal-context-survives-compaction.yaml
@@ -20,8 +20,6 @@ scenario:
     agents:
       defaults:
         compaction:
-          reserveTokens: 64
-          reserveTokensFloor: 0
           keepRecentTokens: 64
   docsRefs:
     - docs/tools/goal.md

--- a/qa/scenarios/media/native-image-generation.yaml
+++ b/qa/scenarios/media/native-image-generation.yaml
@@ -13,7 +13,7 @@ scenario:
     - image_generate appears in the effective tool inventory.
     - Agent triggers native image_generate.
     - Tool output returns a saved MEDIA path and the file exists.
-    - The generated-media completion produces exactly one outbound channel delivery.
+    - The generated-media completion produces exactly one outbound channel delivery containing the saved PNG bytes.
   docsRefs:
     - docs/tools/image-generation.md
     - docs/providers/openai.md
@@ -41,6 +41,7 @@ flow:
           args:
             - ref: env
             - Image generation
+            - agent:qa:image-generate
         - call: readEffectiveTools
           saveAs: tools
           args:
@@ -56,7 +57,8 @@ flow:
         - call: runAgentPrompt
           args:
             - ref: env
-            - sessionKey: agent:qa:image-generate
+            - sessionKey:
+                ref: sessionKey
               message:
                 expr: config.prompt
               timeoutMs:
@@ -86,6 +88,17 @@ flow:
         - assert:
             expr: "typeof generatedPath === 'string' && generatedPath.length > 0"
             message: image generation did not produce a saved media path
+        - call: fs.stat
+          saveAs: generatedImageStat
+          args:
+            - ref: generatedPath
+        - assert:
+            expr: "generatedImageStat.isFile() && generatedImageStat.size > 0"
+            message: image generation did not produce a nonempty saved media file
+        - call: fs.readFile
+          saveAs: generatedImageBytes
+          args:
+            - ref: generatedPath
         - call: sleep
           args:
             - 3000
@@ -93,7 +106,25 @@ flow:
           value:
             expr: "state.getSnapshot().messages.filter((candidate) => candidate.direction === 'outbound' && candidate.conversation.id === 'qa-operator')"
         - assert:
-            expr: "outboundMessages.length === 1"
+            expr: >-
+              outboundMessages.length === 1
+              && Array.isArray(outboundMessages[0].attachments)
+              && outboundMessages[0].attachments.length === 1
+              && outboundMessages[0].attachments[0].kind === 'image'
+              && outboundMessages[0].attachments[0].mimeType === 'image/png'
+              && typeof outboundMessages[0].attachments[0].contentBase64 === 'string'
+              && Buffer.from(outboundMessages[0].attachments[0].contentBase64, 'base64').equals(generatedImageBytes)
             message:
-              expr: "`expected exactly one generated-media delivery, saw ${outboundMessages.length}; transcript=${formatTransportTranscript(state, { conversationId: 'qa-operator' })}`"
+              expr: "`expected exactly one generated-image delivery with bytes matching ${generatedPath}; saw ${outboundMessages.length}; transcript=${formatTransportTranscript(state, { conversationId: 'qa-operator' })}`"
+        - call: readSessionTranscriptSummary
+          saveAs: generatedImageTranscript
+          args:
+            - ref: env
+            - ref: sessionKey
+        - assert:
+            expr: >-
+              generatedImageTranscript.successfulToolCallCounts.image_generate === 1
+              && typeof generatedImageTranscript.finalText === 'string'
+              && generatedImageTranscript.finalText.trim().length > 0
+            message: generated image completion was not persisted to the requester session
       detailsExpr: "`${outbound.text}\\nIMAGE_PATH:${generatedPath}`"

--- a/qa/scenarios/memory/active-memory-preprompt-recall.yaml
+++ b/qa/scenarios/memory/active-memory-preprompt-recall.yaml
@@ -18,6 +18,7 @@ scenario:
           enabled: true
           config:
             enabled: true
+            mode: always
             agents:
               - qa
             allowedChatTypes:

--- a/qa/scenarios/memory/commitments-heartbeat-target-none.yaml
+++ b/qa/scenarios/memory/commitments-heartbeat-target-none.yaml
@@ -25,9 +25,6 @@ scenario:
     - src/commitments/store.ts
     - extensions/qa-lab/src/qa-channel-transport.ts
   gatewayConfigPatch:
-    commitments:
-      enabled: true
-      maxPerDay: 3
     agents:
       defaults:
         heartbeat:

--- a/qa/scenarios/memory/remember-across-conversations.yaml
+++ b/qa/scenarios/memory/remember-across-conversations.yaml
@@ -25,6 +25,7 @@ scenario:
           enabled: true
           config:
             enabled: true
+            mode: always
             agents: []
             toolsAllow:
               - memory_search
@@ -34,7 +35,7 @@ scenario:
             queryMode: message
             maxSummaryChars: 220
   successCriteria:
-    - Two private conversations keep distinct session keys and transcript files.
+    - Two private conversations keep distinct session keys and persisted transcript identities.
     - A private reply recalls the relevant fact from the other private conversation.
     - Accepted memory-search evidence excludes the group transcript and anchor transcript.
     - Group destinations, the disabled setting, and a session-scoped pause do not start product recall.
@@ -205,23 +206,26 @@ flow:
                 value:
                   expr: seededStore[groupSessionKey]
               - assert:
-                  expr: "Boolean(sourceSession?.sessionId && sourceSession?.sessionFile)"
+                  expr: "Boolean(sourceSession?.sessionId)"
                   message:
                     expr: "`private source session missing: key=${sourceSessionKey} storeKeys=${Object.keys(seededStore).join(',')}`"
               - assert:
-                  expr: "Boolean(targetSession?.sessionId && targetSession?.sessionFile)"
+                  expr: "Boolean(targetSession?.sessionId)"
                   message:
                     expr: "`private target session missing: key=${targetSessionKey} storeKeys=${Object.keys(seededStore).join(',')}`"
               - assert:
-                  expr: "Boolean(groupSession?.sessionId && groupSession?.sessionFile)"
+                  expr: "Boolean(groupSession?.sessionId)"
                   message:
                     expr: "`group source session missing: key=${groupSessionKey} storeKeys=${Object.keys(seededStore).join(',')}`"
               - assert:
                   expr: "new Set([sourceSession.sessionId, targetSession.sessionId, groupSession.sessionId]).size === 3"
                   message: source, target, and group sessions unexpectedly share a transcript id
+              - set: seededTranscripts
+                value:
+                  expr: "await Promise.all([sourceSessionKey, targetSessionKey, groupSessionKey].map((sessionKey) => readSessionTranscriptSummary(env, sessionKey)))"
               - assert:
-                  expr: "new Set([sourceSession.sessionFile, targetSession.sessionFile, groupSession.sessionFile]).size === 3"
-                  message: source, target, and group sessions unexpectedly share a transcript file
+                  expr: "seededTranscripts.every((transcript) => transcript.eventCursor > 0)"
+                  message: source, target, and group sessions must each own a persisted transcript
               - call: runQaCli
                 args:
                   - ref: env
@@ -362,7 +366,7 @@ flow:
                           expr: "`group destination received private recall context: ${JSON.stringify(groupDestinationRequests)}`"
                     - set: pauseCommandStartIndex
                       value:
-                        expr: state.getSnapshot().messages.length
+                        expr: "state.getSnapshot().messages.filter((message) => message.direction === 'outbound').length"
                     - sendInbound:
                         conversation:
                           id:
@@ -371,19 +375,16 @@ flow:
                         senderId: qa-operator
                         senderName: QA Operator
                         text: /active-memory off
-                    - call: sleep
+                    - call: waitForOutboundMessage
+                      saveAs: pauseCommandOutbound
                       args:
-                        - 2000
-                    - set: pauseCommandMessages
-                      value:
-                        expr: state.getSnapshot().messages.slice(pauseCommandStartIndex)
-                    - set: pauseCommandOutbound
-                      value:
-                        expr: "pauseCommandMessages.find((candidate) => candidate.direction === 'outbound')"
-                    - assert:
-                        expr: Boolean(pauseCommandOutbound)
-                        message:
-                          expr: "`Active Memory command produced no outbound message: ${JSON.stringify(pauseCommandMessages)}`"
+                        - ref: state
+                        - lambda:
+                            params: [candidate]
+                            expr: "candidate.direction === 'outbound' && candidate.conversation.id === config.pausedConversationId && candidate.text.includes('Active Memory: off for this session.')"
+                        - expr: liveTurnTimeoutMs(env, 60000)
+                        - sinceIndex:
+                            ref: pauseCommandStartIndex
                     - assert:
                         expr: "pauseCommandOutbound.text.includes('Active Memory: off for this session.')"
                         message:

--- a/qa/scenarios/memory/session-memory-ranking.yaml
+++ b/qa/scenarios/memory/session-memory-ranking.yaml
@@ -70,11 +70,6 @@ flow:
                       sessionMemory: true
                     query:
                       minScore: 0
-                      hybrid:
-                        enabled: true
-                        temporalDecay:
-                          enabled: true
-                          halfLifeDays: 1
         - call: waitForGatewayHealthy
           args:
             - ref: env

--- a/qa/scenarios/runtime/anthropic-thinking-error-recovery-replay-safe-read.yaml
+++ b/qa/scenarios/runtime/anthropic-thinking-error-recovery-replay-safe-read.yaml
@@ -9,6 +9,9 @@ scenario:
     secondary:
       - agent-runtime.failure-recovery-retry-policy
   gatewayConfigPatch:
+    tools:
+      codeMode:
+        enabled: false
     agents:
       defaults:
         models:
@@ -48,49 +51,88 @@ flow:
             - ref: env
             - 60000
         - call: reset
+        - set: outboundStartIndex
+          value:
+            expr: "state.getSnapshot().messages.filter((message) => message.direction === 'outbound').length"
         - set: requestCursorBefore
           value:
             expr: "env.mock ? (await fetchJson(`${env.mock.baseUrl}/debug/request-cursor`)).cursor : 0"
         - set: sessionKey
           value:
             expr: "`agent:qa:anthropic-thinking-error:${randomUUID().slice(0, 8)}`"
+        - set: scenarioPrompt
+          value:
+            expr: "`${config.prompt} QA scenario run: ${sessionKey}`"
         - set: modelAck
           value:
             expr: "await env.gateway.call('sessions.patch', { key: sessionKey, model: config.anthropicModelRef }, { timeoutMs: liveTurnTimeoutMs(env, 45000) })"
-        - call: runAgentPrompt
-          args:
-            - ref: env
-            - sessionKey:
-                ref: sessionKey
-              message:
-                expr: config.prompt
-              timeoutMs:
-                expr: liveTurnTimeoutMs(env, 45000)
-        - call: waitForOutboundMessage
-          saveAs: outbound
-          args:
-            - ref: state
-            - lambda:
-                params: [candidate]
-                expr: "candidate.conversation.id === 'qa-operator' && candidate.text.includes(config.expectedReply)"
-            - expr: liveTurnTimeoutMs(env, 30000)
         - assert:
-            expr: "outbound.text.includes(config.expectedReply)"
+            expr: "modelAck?.ok === true && modelAck.resolved?.modelProvider === 'anthropic' && modelAck.resolved?.model === 'claude-opus-4-8'"
             message:
-              expr: "`missing Anthropic thinking-error recovery marker: ${outbound.text}`"
-        - if:
-            expr: "Boolean(env.mock)"
-            then:
-              - set: scenarioRequests
+              expr: "`Anthropic thinking-error recovery session resolved to ${String(modelAck?.resolved?.modelProvider ?? 'unknown')}/${String(modelAck?.resolved?.model ?? 'unknown')}`"
+        - set: effectiveToolIds
+          value:
+            expr: "Array.from(await readEffectiveTools(env, sessionKey)).sort()"
+        - assert:
+            expr: "effectiveToolIds.includes('read')"
+            message:
+              expr: "`Anthropic thinking-error recovery requires the replay-safe read tool; effective tools: ${JSON.stringify(effectiveToolIds)}`"
+        - try:
+            actions:
+              - call: runAgentPrompt
+                args:
+                  - ref: env
+                  - sessionKey:
+                      ref: sessionKey
+                    message:
+                      expr: scenarioPrompt
+                    provider: anthropic
+                    model: claude-opus-4-8
+                    timeoutMs:
+                      expr: liveTurnTimeoutMs(env, 45000)
+              - if:
+                  expr: "Boolean(env.mock)"
+                  then:
+                    - set: scenarioRequests
+                      value:
+                        expr: "await fetchJson(`${env.mock.baseUrl}/debug/requests?after=${requestCursorBefore}`)"
+                    - assert:
+                        expr: "scenarioRequests.some((request) => String(request.allInputText ?? '').includes(config.promptSnippet) && request.providerVariant === 'anthropic' && request.plannedToolName === 'read')"
+                        message: expected replay-safe read request on the Anthropic mock route
+                    - assert:
+                        expr: "scenarioRequests.filter((request) => String(request.allInputText ?? '').includes(config.promptSnippet) && request.providerVariant === 'anthropic').length >= 3"
+                        message: expected initial read, terminal-error attempt, and same-prompt retry
+                    - assert:
+                        expr: "!scenarioRequests.some((request) => String(request.allInputText ?? '').includes(config.visibleAnswerRetryNeedle))"
+                        message: expected same-prompt retry, not visible-answer continuation retry
+              - call: waitForOutboundMessage
+                saveAs: outbound
+                args:
+                  - ref: state
+                  - lambda:
+                      params: [candidate]
+                      expr: "candidate.conversation.id === 'qa-operator' && candidate.text.includes(config.expectedReply)"
+                  - expr: liveTurnTimeoutMs(env, 30000)
+                  - sinceIndex:
+                      ref: outboundStartIndex
+              - assert:
+                  expr: "outbound.text.includes(config.expectedReply)"
+                  message:
+                    expr: "`missing Anthropic thinking-error recovery marker: ${outbound.text}`"
+            catchAs: anthropicRecoveryError
+            catch:
+              - set: anthropicRecoveryDebugRequests
                 value:
-                  expr: "(await fetchJson(`${env.mock.baseUrl}/debug/requests?after=${requestCursorBefore}`))"
-              - assert:
-                  expr: "scenarioRequests.some((request) => String(request.allInputText ?? '').includes(config.promptSnippet) && request.providerVariant === 'anthropic' && request.plannedToolName === 'read')"
-                  message: expected replay-safe read request on the Anthropic mock route
-              - assert:
-                  expr: "scenarioRequests.filter((request) => String(request.allInputText ?? '').includes(config.promptSnippet) && request.providerVariant === 'anthropic').length >= 3"
-                  message: expected initial read, terminal-error attempt, and same-prompt retry
-              - assert:
-                  expr: "!scenarioRequests.some((request) => String(request.allInputText ?? '').includes(config.visibleAnswerRetryNeedle))"
-                  message: expected same-prompt retry, not visible-answer continuation retry
+                  expr: "env.mock ? (await fetchJson(`${env.mock.baseUrl}/debug/requests?after=${requestCursorBefore}`).catch(() => [])).filter((request) => String(request.allInputText ?? '').includes(config.promptSnippet)).map((request) => ({ providerVariant: request.providerVariant ?? null, model: request.model ?? null, declaredToolNames: Array.isArray(request.body?.tools) ? request.body.tools.flatMap((tool) => { const name = tool?.name ?? tool?.function?.name; return typeof name === 'string' ? [name] : []; }).sort() : [], plannedToolName: request.plannedToolName ?? null, plannedToolCallId: request.plannedToolCallId ?? null, toolOutputCallId: request.toolOutputCallId ?? null, hasToolOutput: Boolean(request.toolOutput), toolOutputStructuredError: request.toolOutputStructuredError === true, toolOutputHasEnoent: /\bENOENT\b/i.test(String(request.toolOutput ?? '')), toolOutputHasPermissionError: /\b(?:EACCES|EPERM)\b/i.test(String(request.toolOutput ?? '')), toolOutputHasWorkspaceBoundaryError: /outside (?:the )?(?:allowed )?workspace|path traversal/i.test(String(request.toolOutput ?? '')), toolOutputHasSandboxError: /\bsandbox\b/i.test(String(request.toolOutput ?? '')), toolOutputHasMissingToolError: /tool.{0,32}not found/i.test(String(request.toolOutput ?? '')), hasVisibleAnswerContinuation: String(request.allInputText ?? '').includes(config.visibleAnswerRetryNeedle) })) : []"
+              - set: anthropicRecoveryKickoffExists
+                value:
+                  expr: "await fs.stat(path.join(env.gateway.workspaceDir, 'QA_KICKOFF_TASK.md')).then((entry) => entry.isFile()).catch(() => false)"
+              - set: anthropicRecoveryTranscript
+                value:
+                  expr: "await readSessionTranscriptSummary(env, sessionKey, { allowEmpty: true }).then((summary) => ({ lastAssistantStopReason: summary.lastAssistantStopReason ?? null, lastAssistantContentTypes: summary.lastAssistantContentTypes ?? [], readCalls: summary.assistantToolCallCounts.read ?? 0, completedReads: summary.completedToolCallCounts.read ?? 0, successfulReads: summary.successfulToolCallCounts.read ?? 0, hasExpectedFinalMarker: String(summary.finalText ?? '').includes(config.expectedReply) })).catch(() => null)"
+              - set: anthropicRecoveryOutbound
+                value:
+                  expr: "state.getSnapshot().messages.filter((message) => message.direction === 'outbound').slice(outboundStartIndex).map((message) => ({ conversationId: message.conversation.id, hasExpectedMarker: message.text.includes(config.expectedReply), isFailure: message.text.trim().startsWith('⚠️') }))"
+              - throw:
+                  expr: "`Anthropic signed-thinking recovery failed: ${JSON.stringify({ errorKind: anthropicRecoveryError instanceof Error ? anthropicRecoveryError.name : typeof anthropicRecoveryError, timedOut: /timed out/i.test(formatErrorMessage(anthropicRecoveryError)), modelProvider: modelAck?.resolved?.modelProvider ?? null, model: modelAck?.resolved?.model ?? null, effectiveToolIds, workspaceKickoffExists: anthropicRecoveryKickoffExists, requests: anthropicRecoveryDebugRequests, transcript: anthropicRecoveryTranscript, outbound: anthropicRecoveryOutbound })}`"
       detailsExpr: "env.mock ? `${outbound.text}\\nrequests=${String(scenarioRequests?.length ?? 0)}` : outbound.text"

--- a/qa/scenarios/runtime/otel-both-log-smoke.yaml
+++ b/qa/scenarios/runtime/otel-both-log-smoke.yaml
@@ -33,8 +33,7 @@ scenario:
         logsExporter: both
         sampleRate: 1
         flushIntervalMs: 1000
-        captureContent:
-          enabled: false
+        captureContent: false
   docsRefs:
     - docs/gateway/opentelemetry.md
     - docs/concepts/qa-e2e-automation.md

--- a/qa/scenarios/runtime/otel-stdout-log-smoke.yaml
+++ b/qa/scenarios/runtime/otel-stdout-log-smoke.yaml
@@ -33,8 +33,7 @@ scenario:
         logsExporter: stdout
         sampleRate: 1
         flushIntervalMs: 1000
-        captureContent:
-          enabled: false
+        captureContent: false
   docsRefs:
     - docs/gateway/opentelemetry.md
     - docs/concepts/qa-e2e-automation.md

--- a/qa/scenarios/runtime/otel-trace-smoke.yaml
+++ b/qa/scenarios/runtime/otel-trace-smoke.yaml
@@ -30,8 +30,7 @@ scenario:
         logs: true
         sampleRate: 1
         flushIntervalMs: 1000
-        captureContent:
-          enabled: false
+        captureContent: false
   docsRefs:
     - docs/gateway/opentelemetry.md
     - docs/concepts/qa-e2e-automation.md

--- a/qa/scenarios/ui/control-ui-assistant-transcript-role-boundary.yaml
+++ b/qa/scenarios/ui/control-ui-assistant-transcript-role-boundary.yaml
@@ -141,7 +141,7 @@ flow:
       actions:
         - set: controlUiChatUrl
           value:
-            expr: "(() => { const url = new URL(`${env.gateway.baseUrl}/chat`); url.searchParams.set('session', uiSessionKey); url.hash = `token=${encodeURIComponent(env.gateway.token ?? '')}`; return url.toString(); })()"
+            expr: "(() => { const url = new URL(`${env.gateway.baseUrl}/`); url.searchParams.set('session', uiSessionKey); url.hash = `token=${encodeURIComponent(env.gateway.token ?? '')}`; return url.toString(); })()"
         - call: webOpenPage
           saveAs: uiTab
           args:

--- a/qa/scenarios/ui/control-ui-qa-channel-image-roundtrip.yaml
+++ b/qa/scenarios/ui/control-ui-qa-channel-image-roundtrip.yaml
@@ -66,7 +66,7 @@ flow:
             expr: "buildAgentSessionKey({ agentId: env.cfg.agents?.list?.find((agent) => agent.default)?.id ?? env.cfg.agents?.list?.[0]?.id ?? 'main', channel: 'qa-channel', accountId: 'default', peer: { kind: 'direct', id: config.conversationId }, dmScope: env.cfg.session?.dmScope, identityLinks: env.cfg.session?.identityLinks })"
         - set: controlUiChatUrl
           value:
-            expr: "(() => { const url = new URL(`${env.gateway.baseUrl}/chat`); url.searchParams.set('session', uiSessionKey); url.hash = `token=${encodeURIComponent(env.gateway.token ?? '')}`; return url.toString(); })()"
+            expr: "(() => { const url = new URL(`${env.gateway.baseUrl}/`); url.searchParams.set('session', uiSessionKey); url.hash = `token=${encodeURIComponent(env.gateway.token ?? '')}`; return url.toString(); })()"
         - call: webOpenPage
           saveAs: uiTab
           args:

--- a/src/agents/agent-command-restart-recovery.test.ts
+++ b/src/agents/agent-command-restart-recovery.test.ts
@@ -115,7 +115,70 @@ describe("constrainRestartRecoveryDeliveryPayloads", () => {
         ],
         [" /tmp/missing.png ", "/tmp/missing.png"],
       ),
-    ).toEqual([{ text: "ready" }, { mediaUrls: ["/tmp/missing.png"], trustedLocalMedia: true }]);
+    ).toEqual([
+      {
+        text: "ready",
+        mediaUrl: "/tmp/missing.png",
+        mediaUrls: ["/tmp/missing.png"],
+        trustedLocalMedia: true,
+      },
+    ]);
+  });
+
+  it("attaches host-owned media to the first visible reply after reasoning", () => {
+    expect(
+      constrainRestartRecoveryDeliveryPayloads(
+        [
+          { text: "thinking", isReasoning: true, mediaUrls: ["/tmp/model-reasoning.png"] },
+          { text: "ready", mediaUrls: ["/tmp/model-selected.png"] },
+        ],
+        [" /tmp/missing.png ", "/tmp/missing.png"],
+      ),
+    ).toEqual([
+      { text: "thinking", isReasoning: true },
+      {
+        text: "ready",
+        mediaUrl: "/tmp/missing.png",
+        mediaUrls: ["/tmp/missing.png"],
+        trustedLocalMedia: true,
+      },
+    ]);
+  });
+
+  it("does not attach host-owned media to commentary, notices, or errors", () => {
+    expect(
+      constrainRestartRecoveryDeliveryPayloads(
+        [
+          { text: "commentary", isCommentary: true },
+          { text: "status", isStatusNotice: true },
+          { text: "failed attempt", isError: true },
+          { text: "ready" },
+        ],
+        ["/tmp/missing.png"],
+      ),
+    ).toEqual([
+      { text: "commentary", isCommentary: true },
+      { text: "status", isStatusNotice: true },
+      { text: "failed attempt", isError: true },
+      {
+        text: "ready",
+        mediaUrl: "/tmp/missing.png",
+        mediaUrls: ["/tmp/missing.png"],
+        trustedLocalMedia: true,
+      },
+    ]);
+  });
+
+  it("keeps host-owned media separate when no visible successful reply exists", () => {
+    expect(
+      constrainRestartRecoveryDeliveryPayloads(
+        [{ text: "failed attempt", isError: true }],
+        ["/tmp/missing.png"],
+      ),
+    ).toEqual([
+      { text: "failed attempt", isError: true },
+      { mediaUrls: ["/tmp/missing.png"], trustedLocalMedia: true },
+    ]);
   });
 
   it("strips all model media from a text-only notice", () => {

--- a/src/agents/agent-command-restart-recovery.ts
+++ b/src/agents/agent-command-restart-recovery.ts
@@ -11,6 +11,7 @@ import {
   hasVisibleCommittedMessagingToolDeliveryEvidence,
   type AgentDeliveryEvidence,
 } from "./embedded-agent-runner/delivery-evidence.js";
+import { mergeAttemptToolMediaPayloads } from "./embedded-agent-runner/run/tool-media-payloads.js";
 
 function normalizeOptionalString(value: unknown): string | undefined {
   return typeof value === "string" && value.trim() ? value.trim() : undefined;
@@ -77,9 +78,48 @@ export function constrainRestartRecoveryDeliveryPayloads(
   const exactMediaUrls = Array.from(
     new Set(mediaUrls.map((url) => url.trim()).filter((url) => url.length > 0)),
   );
-  if (exactMediaUrls.length > 0) {
-    constrained.push({ mediaUrls: exactMediaUrls, trustedLocalMedia: true });
+  if (exactMediaUrls.length === 0) {
+    return constrained;
   }
+
+  if (!suppressText) {
+    const visibleReplyIndex = constrained.findIndex(
+      (payload) =>
+        payload.isCommentary !== true &&
+        payload.isCompactionNotice !== true &&
+        payload.isFallbackNotice !== true &&
+        payload.isStatusNotice !== true &&
+        hasVisibleAgentPayload(
+          { payloads: [payload] },
+          {
+            includeErrorPayloads: false,
+            includeReasoningPayloads: false,
+            includeSilentReplyPayloads: false,
+          },
+        ),
+    );
+    if (visibleReplyIndex >= 0) {
+      const visibleReply = constrained[visibleReplyIndex];
+      if (visibleReply) {
+        // Recovery owns the exact artifacts; merge them with the actual final
+        // reply so automatic delivery cannot emit a caption before its media.
+        const [mergedReply] =
+          mergeAttemptToolMediaPayloads({
+            payloads: [visibleReply],
+            toolMediaUrls: exactMediaUrls,
+            hostOwnedToolMediaUrls: exactMediaUrls,
+            toolTrustedLocalMedia: true,
+            sourceReplyDeliveryMode: "automatic",
+          }) ?? [];
+        if (mergedReply) {
+          constrained[visibleReplyIndex] = mergedReply;
+          return constrained;
+        }
+      }
+    }
+  }
+
+  constrained.push({ mediaUrls: exactMediaUrls, trustedLocalMedia: true });
   return constrained;
 }
 

--- a/src/agents/agent-command.live-model-switch.test.ts
+++ b/src/agents/agent-command.live-model-switch.test.ts
@@ -2437,14 +2437,19 @@ describe("agentCommand – LiveSessionModelSwitchError retry", () => {
       mockCallArg(state.deliverAgentCommandResultMock),
       "delivery params",
     );
-    expect(requireRecord(deliveryParams.result, "delivery result").payloads).toEqual([
-      { text: "ready" },
-      { mediaUrls: ["/tmp/missing.png"], trustedLocalMedia: true },
-    ]);
-    expect(deliveryParams.payloads).toEqual([
-      { text: "ready" },
-      { mediaUrls: ["/tmp/missing.png"], trustedLocalMedia: true },
-    ]);
+    const expectedRecoveryPayloads = [
+      {
+        text: "ready",
+        mediaUrl: "/tmp/missing.png",
+        mediaUrls: ["/tmp/missing.png"],
+        audioAsVoice: undefined,
+        trustedLocalMedia: true,
+      },
+    ];
+    expect(requireRecord(deliveryParams.result, "delivery result").payloads).toEqual(
+      expectedRecoveryPayloads,
+    );
+    expect(deliveryParams.payloads).toEqual(expectedRecoveryPayloads);
     expect(
       state.persistSessionEntryMock.mock.calls.some((call) => {
         const params = call[0] as { entry?: SessionEntry };

--- a/src/agents/openclaw-tools.ts
+++ b/src/agents/openclaw-tools.ts
@@ -12,6 +12,8 @@ import { selectApplicableRuntimeConfig } from "../config/config.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { callGateway } from "../gateway/call.js";
 import { isEmbeddedMode } from "../infra/embedded-mode.js";
+import { formatErrorMessage } from "../infra/errors.js";
+import { createSubsystemLogger } from "../logging/subsystem.js";
 import { getActiveSecretsRuntimeConfigSnapshot } from "../secrets/runtime-state.js";
 import { getActiveRuntimeWebToolsMetadata } from "../secrets/runtime-web-tools-state.js";
 import { isCronRunSessionKey } from "../sessions/session-key-utils.js";
@@ -93,6 +95,9 @@ import { createUpdatePlanTool } from "./tools/update-plan-tool.js";
 import { createVideoGenerateTool } from "./tools/video-generate-tool.js";
 import { createWebFetchTool, createWebSearchTool } from "./tools/web-tools.js";
 import { resolveWorkspaceRoot } from "./workspace-dir.js";
+
+const mediaGenerationYieldLog = createSubsystemLogger("agents/tools/media-generation-yield");
+
 export { filterToolsByClientCaps } from "./openclaw-tools.client-caps.js";
 export function createOpenClawTools(
   options?: {
@@ -271,10 +276,21 @@ export function createOpenClawTools(
     trimmedRunSessionKey && isCronRunSessionKey(trimmedRunSessionKey)
       ? trimmedRunSessionKey
       : options?.agentSessionKey;
+  const yieldMediaGenerationTurn = options?.onYield;
   const mediaGenerationAsyncStartCallback =
-    mediaGenerationAgentSessionKey && isCronRunSessionKey(mediaGenerationAgentSessionKey)
+    !yieldMediaGenerationTurn ||
+    (mediaGenerationAgentSessionKey && isCronRunSessionKey(mediaGenerationAgentSessionKey))
       ? undefined
-      : options?.onYield;
+      : (message: string) => {
+          // Commit the start before yielding; handle teardown failures outside the owner turn.
+          setImmediate(() => {
+            void (async () => yieldMediaGenerationTurn(message))().catch((error: unknown) => {
+              mediaGenerationYieldLog.warn("Failed to yield foreground media generation turn", {
+                error: formatErrorMessage(error),
+              });
+            });
+          });
+        };
   const taskKey = normalizeOptionalString(options?.runSessionKey ?? options?.agentSessionKey);
   const { agentSessionKey: requesterSessionKey, runId: requesterTurnRunId } = options ?? {};
   const imageTool =
@@ -304,49 +320,28 @@ export function createOpenClawTools(
         })
       : null;
   options?.recordToolPrepStage?.("openclaw-tools:image-tool");
+  const mediaGenerationToolOptions = {
+    config: options?.config,
+    agentDir: options?.agentDir,
+    authProfileStore: options?.authProfileStore,
+    agentSessionKey: mediaGenerationAgentSessionKey,
+    requesterOrigin: deliveryContext ?? undefined,
+    workspaceDir,
+    preparedModelRuntime: options?.preparedModelRuntime,
+    sandbox,
+    fsPolicy: options?.fsPolicy,
+    onAsyncTaskStarted: mediaGenerationAsyncStartCallback,
+  };
   const imageGenerateTool = optionalMediaTools.imageGenerate
-    ? createImageGenerateTool({
-        config: options?.config,
-        agentDir: options?.agentDir,
-        authProfileStore: options?.authProfileStore,
-        agentSessionKey: mediaGenerationAgentSessionKey,
-        requesterOrigin: deliveryContext ?? undefined,
-        workspaceDir,
-        preparedModelRuntime: options?.preparedModelRuntime,
-        sandbox,
-        fsPolicy: options?.fsPolicy,
-        onAsyncTaskStarted: mediaGenerationAsyncStartCallback,
-      })
+    ? createImageGenerateTool(mediaGenerationToolOptions)
     : null;
   options?.recordToolPrepStage?.("openclaw-tools:image-generate-tool");
   const videoGenerateTool = optionalMediaTools.videoGenerate
-    ? createVideoGenerateTool({
-        config: options?.config,
-        agentDir: options?.agentDir,
-        authProfileStore: options?.authProfileStore,
-        agentSessionKey: mediaGenerationAgentSessionKey,
-        requesterOrigin: deliveryContext ?? undefined,
-        workspaceDir,
-        preparedModelRuntime: options?.preparedModelRuntime,
-        sandbox,
-        fsPolicy: options?.fsPolicy,
-        onAsyncTaskStarted: mediaGenerationAsyncStartCallback,
-      })
+    ? createVideoGenerateTool(mediaGenerationToolOptions)
     : null;
   options?.recordToolPrepStage?.("openclaw-tools:video-generate-tool");
   const musicGenerateTool = optionalMediaTools.musicGenerate
-    ? createMusicGenerateTool({
-        config: options?.config,
-        agentDir: options?.agentDir,
-        authProfileStore: options?.authProfileStore,
-        agentSessionKey: mediaGenerationAgentSessionKey,
-        requesterOrigin: deliveryContext ?? undefined,
-        workspaceDir,
-        preparedModelRuntime: options?.preparedModelRuntime,
-        sandbox,
-        fsPolicy: options?.fsPolicy,
-        onAsyncTaskStarted: mediaGenerationAsyncStartCallback,
-      })
+    ? createMusicGenerateTool(mediaGenerationToolOptions)
     : null;
   options?.recordToolPrepStage?.("openclaw-tools:music-generate-tool");
   const pdfTool =

--- a/src/agents/session-write-lock.test.ts
+++ b/src/agents/session-write-lock.test.ts
@@ -278,6 +278,72 @@ describe("acquireSessionWriteLock", () => {
     await expectPathMissing(path.resolve(`${sessionKey}.lock`));
   });
 
+  it("preserves session-key leases while another SIGTERM handler drains", async () => {
+    const sessionKey = `agent:main:write-lock-graceful-sigterm-${Date.now()}`;
+    const gracefulShutdown = () => {};
+    let lock: Awaited<ReturnType<typeof acquireSessionWriteLock>> | undefined;
+    process.on("SIGTERM", gracefulShutdown);
+
+    try {
+      lock = await acquireSessionWriteLock({
+        sessionFile: sessionKey,
+        targetKind: "session-key",
+      });
+
+      testing.handleTerminationSignal("SIGTERM");
+
+      expect(lock.assertOwned).toBeDefined();
+      expect(() => lock?.assertOwned?.()).not.toThrow();
+      await expect(
+        acquireSessionWriteLock({
+          sessionFile: sessionKey,
+          targetKind: "session-key",
+          timeoutMs: 5,
+        }),
+      ).rejects.toThrow(/session file locked/);
+
+      await lock.release();
+      lock = undefined;
+      const nextLock = await acquireSessionWriteLock({
+        sessionFile: sessionKey,
+        targetKind: "session-key",
+        timeoutMs: 500,
+      });
+      await nextLock.release();
+    } finally {
+      await lock?.release();
+      process.off("SIGTERM", gracefulShutdown);
+    }
+  });
+
+  it("releases session-key leases before reraising a sole termination signal", async () => {
+    const sessionKey = `agent:main:write-lock-sole-sigterm-${Date.now()}`;
+    const lock = await acquireSessionWriteLock({
+      sessionFile: sessionKey,
+      targetKind: "session-key",
+    });
+    const listenerCount = vi.spyOn(process, "listenerCount").mockReturnValueOnce(1);
+    const kill = vi.spyOn(process, "kill").mockReturnValue(true);
+
+    try {
+      testing.handleTerminationSignal("SIGTERM");
+
+      expect(() => lock.assertOwned?.()).toThrow(/lease-lost/);
+      expect(kill).toHaveBeenCalledWith(process.pid, "SIGTERM");
+    } finally {
+      listenerCount.mockRestore();
+      kill.mockRestore();
+      await lock.release();
+    }
+
+    const nextLock = await acquireSessionWriteLock({
+      sessionFile: sessionKey,
+      targetKind: "session-key",
+      timeoutMs: 500,
+    });
+    await nextLock.release();
+  });
+
   it("namespaces unqualified session-key leases by transcript target", async () => {
     const first = await acquireSessionWriteLock({
       sessionFile: resolveSessionWriteLockTargetKey({

--- a/src/agents/session-write-lock.ts
+++ b/src/agents/session-write-lock.ts
@@ -684,16 +684,18 @@ export function resolveSessionLockMaxHoldFromTimeout(params: {
  * Synchronously release all held locks.
  * Used during process exit when async operations aren't reliable.
  */
-function releaseAllLocksSync(): void {
+function releaseAllLocksSync(options?: { preserveSessionLeases?: boolean }): void {
   SESSION_LOCKS.reset();
-  for (const [sessionKey, entry] of sessionKeyWriteLeaseState.held) {
-    try {
-      releaseSessionKeyWriteLeaseOnce(sessionKey, entry.owner, entry.databaseOptions);
-    } catch {
-      // Fixed expiry still recovers the row after an exit-time SQLite failure.
+  if (!options?.preserveSessionLeases) {
+    for (const [sessionKey, entry] of sessionKeyWriteLeaseState.held) {
+      try {
+        releaseSessionKeyWriteLeaseOnce(sessionKey, entry.owner, entry.databaseOptions);
+      } catch {
+        // Fixed expiry still recovers the row after an exit-time SQLite failure.
+      }
     }
+    sessionKeyWriteLeaseState.held.clear();
   }
-  sessionKeyWriteLeaseState.held.clear();
   stopWatchdogTimer();
 }
 
@@ -753,9 +755,11 @@ function ensureWatchdogStarted(intervalMs: number): void {
 }
 
 function handleTerminationSignal(signal: CleanupSignal): void {
-  releaseAllLocksSync();
-  const cleanupState = resolveCleanupState();
   const shouldReraise = process.listenerCount(signal) === 1;
+  // A graceful gateway handler must drain in-flight transcript writes before
+  // releasing their SQLite leases; legacy file locks remain signal-immediate.
+  releaseAllLocksSync({ preserveSessionLeases: !shouldReraise });
+  const cleanupState = resolveCleanupState();
   if (shouldReraise) {
     const handler = cleanupState.cleanupHandlers.get(signal);
     if (handler) {

--- a/src/agents/subagent-announce.requester-settle-wake.test.ts
+++ b/src/agents/subagent-announce.requester-settle-wake.test.ts
@@ -386,6 +386,32 @@ describe("maybeWakeRequesterAfterAllChildrenSettled", () => {
     expect(deliverSpy).not.toHaveBeenCalled();
   });
 
+  it("wakes after a yielded requester's active child completes", async () => {
+    const child = makeSettledChild({
+      runId: "run-b",
+      delivery: { status: "delivered" },
+      requesterSettleWake: {
+        status: "pending",
+        attemptCount: 0,
+        batchRunIds: ["run-b"],
+        requesterYieldBatch: true,
+        rearmGeneration: 1,
+      },
+    });
+    registryRuntimeMock.listSubagentRunsForRequester.mockReturnValue([child]);
+
+    const woke = await maybeWakeRequesterAfterAllChildrenSettled(
+      wakeParams({ settledEntry: child }),
+    );
+
+    expect(woke).toBe(true);
+    expect(deliverSpy).toHaveBeenCalledOnce();
+    expect(deliveredCallArg().directIdempotencyKey).toBe(
+      `announce:requester-settle:${REQUESTER}:run-b:yield-1`,
+    );
+    expect(completeBatchSpy).toHaveBeenCalledWith(["run-b"], 1);
+  });
+
   it("wakes after a requester yields with one already-delivered completion", async () => {
     const child = makeSettledChild({
       runId: "run-b",

--- a/src/agents/subagent-announce.requester-settle-wake.ts
+++ b/src/agents/subagent-announce.requester-settle-wake.ts
@@ -255,9 +255,11 @@ export async function maybeWakeRequesterAfterAllChildrenSettled(params: {
   const hasUndeliveredRequiredCompletion = requiredSettled.some(
     (entry) => entry.delivery?.status !== "delivered",
   );
-  // A frozen single-child batch can be re-admitted after its requester yielded.
-  // The earlier steered completion died with that run, so the idle requester needs a fresh turn.
-  const requesterYieldedAfterDelivery = selectedState.afterRequesterYield === true;
+  // A yielded batch owns a rearm generation even when its child settles later.
+  // Otherwise a delivered single child clears the batch before its requester wakes.
+  const requesterYieldedAfterDelivery =
+    selectedState.afterRequesterYield === true ||
+    (selectedState.requesterYieldBatch === true && selectedState.rearmGeneration !== undefined);
   if (
     requiredSettled.length === 0 ||
     (requiredSettled.length < 2 &&


### PR DESCRIPTION
Related: #114492
Related: #109025

## What Problem This Solves

Fixes an issue where users and operators exercising full OpenClaw workflows could encounter missing channel replies, stalled agent and restart recovery, incomplete OpenAI streaming, inconsistent cross-conversation memory, image delivery failures, broken Anthropic replay, and invalid or misleading QA results. The complete QA run also incorrectly exited as a failure when every required scenario passed but catalog-declared optional integrations were unavailable.

## Why This Change Was Made

Repairs each regression at its existing QA-channel, agent, provider, and scenario ownership boundary. Preserves strict, fail-closed suite behavior for genuine failures, unknown or explicitly selected skips, empty runs, and inconsistent evidence; only catalog-confirmed, report-only optional scenarios are nonblocking. This focused PR deliberately excludes the unrelated security, dependency, and gateway changes in #114492.

## User Impact

Channel and agent-to-agent delivery, streamed model responses, restart and session recovery, memory recall, native image generation, Anthropic recovery, tracing, and Control UI workflows behave consistently. Operators can trust the full QA exit status: required failures still fail; explicitly optional unavailable integrations remain visible as skips.

## Evidence

- AI-assisted implementation with independently reviewed owner-specific regressions and a clean secret scan.
- Frozen full-suite-validated baseline: `64991433137f838f3aa9ec405d828b3f6168edfc`; original 45-file content SHA-256 `e5ab52dc6e2277adaeb4348e7685f882160eeb8ab3570c6e631e83fb7c1c95e5`. The final 46-file PR additionally updates the existing agent-recovery integration test to verify the intended atomic image-and-caption behavior.
- Both previously untracked scenario-timeout and mock streaming regression tests are included.
- Supported private-QA/core/AI build: **passed**, actual exit 0; both build stamps and seven required built artifacts verified.
- Full real Gateway/channel/Chromium product run with the deterministic mock provider: **118 scenarios, 110 passed, 0 failed, 8 catalog-confirmed report-only optional skips; actual process exit 0**.
- Full-suite summary SHA-256 `087726227127a4b753b48ca3c5da35b576d3901045cfb0d3d6d4d0ac5211b2ac`; evidence SHA-256 `1b06d48de7139bc3d8c582e6d587faf402a0388e9340be73e42266daf8f2ca74`; Markdown report SHA-256 `65ee80d0ac6666e32d56f3c6faea9ca3638aeb98fd78965cd1425bb0f6e7fd96`.
- Focused owner regressions: **14 test files, 521 passed, 0 failed, actual exit 0**.
- Canonical all-project changed gate for the frozen full-suite source: **passed**, actual exit 0, including production and test typechecks, all three lint shards, all 45 formatted files, architecture/dependency/SDK/database guards, and zero import cycles.
- The two initially failing hosted CI checks were traced to an illegal QA-test private core import and a stale split-media integration expectation; the fixes preserve the plugin boundary and canonical atomic delivery and pass the exact affected owner regressions plus the repository's plugin-test-core-import guard.
- Fresh structured autoreview: zero accepted or actionable findings; its one SQLite-watchdog warning was rejected after verifying that live-process SQLite leases cannot be reclaimed by elapsed time, the watchdog renews file locks only, and the direct SIGTERM/competing-acquisition regression passes.
- Live-provider limitation, intentionally not hidden: an actual authenticated `openai/gpt-5.4` run passed 1 scenario and timed out on 2 live agent-policy scenarios. The 118-scenario passing result is the real product path using `mock-openai`; it is **not** claimed as a passing real-provider run.

Focused regression command:

```bash
node scripts/run-vitest.mjs \
  packages/ai/src/transports/openai-responses-stream-parity.test.ts \
  src/agents/session-write-lock.test.ts \
  src/agents/agent-command-restart-recovery.test.ts \
  src/agents/subagent-announce.requester-settle-wake.test.ts \
  extensions/qa-channel/src/channel.test.ts \
  extensions/qa-channel/src/inbound.test.ts \
  extensions/qa-lab/src/providers/mock-openai/server.test.ts \
  extensions/qa-lab/src/providers/mock-openai/mock-openai-events.test.ts \
  extensions/qa-lab/src/scenario-catalog.test.ts \
  extensions/qa-lab/src/live-scenario-timeouts.test.ts \
  extensions/qa-lab/src/scenario-flow-runner.test.ts \
  extensions/qa-lab/src/reply-failure.test.ts \
  extensions/qa-lab/src/cli.runtime.test.ts \
  extensions/qa-lab/src/suite-summary.test.ts
```

Full product command:

```bash
node openclaw.mjs qa suite \
  --provider-mode mock-openai \
  --model mock-openai/gpt-5.6-luna \
  --alt-model mock-openai/gpt-5.6-luna-alt \
  --concurrency 4 \
  --output-dir .artifacts/qa-e2e/main649-final45-e5ab-stamped-full118
```
