### PR TITLE
perf(gateway): cut CLI RPC startup config overhead

### DIFF
--- a/src/gateway/call.test.ts
+++ b/src/gateway/call.test.ts
@@ -5,6 +5,7 @@ import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
+import { resetConfigRuntimeState, setRuntimeConfigSnapshot } from "../config/runtime-snapshot.js";
 import type { DeviceIdentity } from "../infra/device-identity.js";
 import { createEmptyPluginRegistry } from "../plugins/registry-empty.js";
 import { setActivePluginRegistry } from "../plugins/runtime.js";
@@ -332,6 +333,7 @@ describe("callGateway url resolution", () => {
   ]);
 
   beforeEach(() => {
+    resetConfigRuntimeState();
     envSnapshot.restore();
     deleteTestEnvValue("OPENCLAW_ALLOW_INSECURE_PRIVATE_WS");
     deleteTestEnvValue("OPENCLAW_CONFIG_PATH");
@@ -343,6 +345,7 @@ describe("callGateway url resolution", () => {
   });
 
   afterEach(() => {
+    resetConfigRuntimeState();
     envSnapshot.restore();
     testing.resetDepsForTests();
   });
@@ -1376,6 +1379,79 @@ describe("buildGatewayConnectionDetails", () => {
       expect(details.url).toBe("ws://127.0.0.1:18789");
       expect(details.urlSource).toBe("local loopback");
     } finally {
+      fs.rmSync(tempStateDir, { recursive: true, force: true });
+    }
+  });
+
+  it("uses the reduced dispatch config for default RPC loading", async () => {
+    resetConfigRuntimeState();
+    const tempStateDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-gateway-call-"));
+    const configPath = path.join(tempStateDir, "openclaw.json");
+    fs.writeFileSync(
+      configPath,
+      JSON.stringify({
+        gateway: { mode: "local", bind: "loopback", port: 18800, auth: { mode: "none" } },
+        channels: { telegram: { dmPolicy: 42 } },
+      }),
+    );
+    setTestEnvValue("OPENCLAW_STATE_DIR", tempStateDir);
+    setTestEnvValue("OPENCLAW_CONFIG_PATH", configPath);
+    try {
+      testing.setDepsForTests({
+        createGatewayClient: (opts) =>
+          new StubGatewayClient(
+            opts as ConstructorParameters<typeof StubGatewayClient>[0],
+          ) as never,
+        loadOrCreateDeviceIdentity: () => {
+          throw new Error("auth mode none should not load a device identity");
+        },
+        loadDeviceAuthToken: () => null,
+        resolveGatewayPort: (config) => config?.gateway?.port ?? 18789,
+      });
+
+      await expect(callGateway({ method: "health" })).resolves.toEqual({ ok: true });
+
+      expect(lastClientOptions?.url).toBe("ws://127.0.0.1:18800");
+      expect(lastClientOptions?.deviceIdentity).toBeNull();
+    } finally {
+      resetConfigRuntimeState();
+      fs.rmSync(tempStateDir, { recursive: true, force: true });
+    }
+  });
+
+  it("keeps the active runtime snapshot authoritative for default RPC loading", async () => {
+    resetConfigRuntimeState();
+    const tempStateDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-gateway-call-"));
+    const configPath = path.join(tempStateDir, "openclaw.json");
+    fs.writeFileSync(
+      configPath,
+      JSON.stringify({
+        gateway: { mode: "local", bind: "loopback", port: 18800, auth: { mode: "none" } },
+      }),
+    );
+    setTestEnvValue("OPENCLAW_STATE_DIR", tempStateDir);
+    setTestEnvValue("OPENCLAW_CONFIG_PATH", configPath);
+    setRuntimeConfigSnapshot({
+      gateway: { mode: "local", bind: "loopback", port: 18801, auth: { mode: "none" } },
+    });
+    try {
+      testing.setDepsForTests({
+        createGatewayClient: (opts) =>
+          new StubGatewayClient(
+            opts as ConstructorParameters<typeof StubGatewayClient>[0],
+          ) as never,
+        loadOrCreateDeviceIdentity: () => {
+          throw new Error("auth mode none should not load a device identity");
+        },
+        loadDeviceAuthToken: () => null,
+        resolveGatewayPort: (config) => config?.gateway?.port ?? 18789,
+      });
+
+      await expect(callGateway({ method: "health" })).resolves.toEqual({ ok: true });
+
+      expect(lastClientOptions?.url).toBe("ws://127.0.0.1:18801");
+    } finally {
+      resetConfigRuntimeState();
       fs.rmSync(tempStateDir, { recursive: true, force: true });
     }
   });

--- a/src/gateway/call.ts
+++ b/src/gateway/call.ts
@@ -14,12 +14,16 @@ import {
   MIN_CLIENT_PROTOCOL_VERSION,
   PROTOCOL_VERSION,
 } from "../../packages/gateway-protocol/src/version.js";
-import { readGatewayDispatchConfig } from "../config/gateway-dispatch-config.js";
+import {
+  readGatewayDispatchConfig,
+  readGatewayDispatchConfigWithShellEnvFallback,
+} from "../config/gateway-dispatch-config.js";
 import {
   resolveConfigPath as resolveConfigPathFromPaths,
   resolveGatewayPort as resolveGatewayPortFromPaths,
   resolveStateDir as resolveStateDirFromPaths,
 } from "../config/paths.js";
+import { getRuntimeConfigSnapshot } from "../config/runtime-snapshot.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { createAbortError } from "../infra/abort-signal.js";
 import { loadDeviceAuthToken } from "../infra/device-auth-store.js";
@@ -331,8 +335,10 @@ export function isGatewayExplicitAuthRequiredError(
 
 const defaultCreateGatewayClient = (opts: GatewayClientOptions) => new GatewayClient(opts);
 type GatewayRuntimeConfigLoader = () => OpenClawConfig | Promise<OpenClawConfig>;
+// Gateway dispatch owns only connection, auth, TLS, and shell-env resolution.
+// Loading the full runtime config here makes every RPC pay unrelated plugin/state startup costs.
 const defaultGetRuntimeConfig = async (): Promise<OpenClawConfig> =>
-  (await import("../config/io.js")).getRuntimeConfig();
+  getRuntimeConfigSnapshot() ?? (await readGatewayDispatchConfigWithShellEnvFallback());
 const defaultGatewayCallDeps: {
   createGatewayClient: typeof defaultCreateGatewayClient;
   getRuntimeConfig: GatewayRuntimeConfigLoader;


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where read-only CLI Gateway commands paid the full runtime-config startup cost before opening their WebSocket, even though Gateway dispatch needs only connection, auth, TLS, shell-env, and a few routing fields. On the production ClawSweeper host, `openclaw cron status` remained near four seconds after the no-op SQLite repair was removed.

## Why This Change Was Made

Default Gateway calls now prefer the authoritative active runtime snapshot in long-lived processes and otherwise use the existing reduced Gateway-dispatch config reader. Explicit URL plus token calls retain their existing no-config fast path, and all credential, TLS, device identity, scope, and connection logic remains unchanged.

## User Impact

CLI commands that call the Gateway avoid loading and validating unrelated plugin/model/channel runtime config on every process start. Running Gateway processes still use their applied runtime snapshot, so pending or rejected file edits cannot redirect internal RPCs.

## Evidence

- Source-blind production contract after PR #115193: three `openclaw cron status --json` runs were 3867ms, 3832ms, and 3849ms (median 3849ms), versus a 3930ms baseline; no `state.schema.repair` or lock-wait diagnostic appeared. This isolated the remaining startup cost.
- Production timing split: `openclaw --version` 41ms, local `config get gateway.port` 2226ms, and Gateway RPC commands 10–11s under post-restart load. Gateway logs later showed the server-side `status` request itself at 622ms, leaving most time in client-side config/bootstrap work.
- Existing solution reused: `readGatewayDispatchConfigWithShellEnvFallback` already defines the bounded config surface for Gateway dispatch and is used by `agent-via-gateway`.
- Exact-head live proof on Hetzner from disposable checkout `f23b5c997028d96a1480dee0fe929588b30e0b27`, using the real `/root/.openclaw/openclaw.json` and live Gateway: `openclaw cron status --json` completed in 1880ms, 1858ms, and 1882ms (median 1880ms). All three returned `enabled=true`, `jobs=9`, and no `state.schema.repair`, lock-wait, or slow-transaction diagnostic. This is a 52.2% median improvement from the 3930ms baseline.
- Blacksmith Testbox `tbx_01kymqzcjp65g30as98r35qxa8`: `pnpm test src/gateway/call.test.ts` — 119 passed.
- Same Testbox: `pnpm check:changed` — core production/test typechecks, lint, formatting, database-first guard, import cycles, and repository guards passed.
- Autoreview accepted two findings: preserve active runtime snapshot precedence and reset process-global snapshot state in the new tests. Final Codex autoreview (`gpt-5.6-sol`, high) was clean.

Owner decision: accept the existing reduced Gateway-dispatch reader as the authoritative cold pre-connection contract. Unrelated invalid runtime surfaces should not block a safe Gateway RPC when connection/auth/TLS inputs are valid. Long-lived processes still use their applied runtime snapshot first, so pending or rejected config-file edits cannot redirect active internal RPCs.
