### PR TITLE
fix(ci): validate frozen Matrix QA targets

### DIFF
--- a/.github/workflows/qa-live-transports-convex.yml
+++ b/.github/workflows/qa-live-transports-convex.yml
@@ -404,16 +404,25 @@ jobs:
           mkdir -p "${output_dir}"
 
           matrix_help="$(pnpm openclaw qa matrix --help 2>&1)"
-          if ! grep -Fq -- "--shard <index/total>" <<<"${matrix_help}"; then
-            echo "Selected target predates profile-free Matrix catalog sharding; update the target revision." >&2
-            exit 1
+          if grep -Fq -- "--shard <index/total>" <<<"${matrix_help}"; then
+            matrix_selection=(--shard "${{ matrix.shard }}/5")
+          else
+            legacy_profiles=(transport media e2ee-smoke e2ee-deep e2ee-cli)
+            shard_index="${{ matrix.shard }}"
+            if (( shard_index < 1 || shard_index > ${#legacy_profiles[@]} )); then
+              echo "Invalid Matrix shard index for legacy profile fallback: ${shard_index}" >&2
+              exit 1
+            fi
+            legacy_profile="${legacy_profiles[shard_index - 1]}"
+            echo "Selected target predates profile-free Matrix catalog sharding; using legacy profile '${legacy_profile}'."
+            matrix_selection=(--profile "${legacy_profile}")
           fi
 
           pnpm openclaw qa matrix \
             --repo-root . \
             --output-dir "${output_dir}" \
             --provider-mode mock-openai \
-            --shard "${{ matrix.shard }}/5" \
+            "${matrix_selection[@]}" \
             --fast
 
       - name: Upload Matrix QA artifacts

--- a/test/scripts/package-acceptance-workflow.test.ts
+++ b/test/scripts/package-acceptance-workflow.test.ts
@@ -2636,7 +2636,7 @@ describe("package artifact reuse", () => {
       '--shard "${{ matrix.shard }}/5"',
     );
     expect(workflowStep(matrixJob, "Run Matrix live lane").run).toContain(
-      "Selected target predates profile-free Matrix catalog sharding",
+      'matrix_selection=(--shard "${{ matrix.shard }}/5")',
     );
     expect(readWorkflow(QA_LIVE_TRANSPORTS_WORKFLOW).jobs?.run_live_matrix_sharded).toBeUndefined();
     expect(releaseTelegramWorkflow).toContain(
@@ -2645,8 +2645,26 @@ describe("package artifact reuse", () => {
     expect(workflowStep(matrixJob, "Run Matrix live lane").run).not.toContain("for attempt in");
     expect(qaWorkflow).not.toContain("Matrix live lane failed on attempt");
     expect(qaWorkflow).not.toContain("OPENCLAW_QA_MATRIX_CANARY_TIMEOUT_MS");
-    expect(qaWorkflow).not.toContain("--profile");
+    expect(qaWorkflow).toContain('matrix_selection=(--profile "${legacy_profile}")');
     expect(qaWorkflow).not.toContain("--fail-fast");
+  });
+
+  it("keeps modern Matrix shards and legacy profile partitions coverage-equivalent", () => {
+    const matrixJob = workflowJob(QA_LIVE_TRANSPORTS_WORKFLOW, "run_live_matrix");
+    const run = workflowStep(matrixJob, "Run Matrix live lane").run;
+
+    expect(run).toContain('grep -Fq -- "--shard <index/total>"');
+    expect(run).toContain('matrix_selection=(--shard "${{ matrix.shard }}/5")');
+    expect(run).toContain(
+      "legacy_profiles=(transport media e2ee-smoke e2ee-deep e2ee-cli)",
+    );
+    expect(run).toContain('legacy_profile="${legacy_profiles[shard_index - 1]}"');
+    expect(run).toContain('matrix_selection=(--profile "${legacy_profile}")');
+    expect(run).toContain('"${matrix_selection[@]}" \\');
+    expect(run).toContain(
+      "Selected target predates profile-free Matrix catalog sharding; using legacy profile",
+    );
+    expect(matrixJob.strategy?.matrix?.shard).toEqual([1, 2, 3, 4, 5]);
   });
 
   it("runs live transport lanes nightly while release checks stay gated", () => {

--- a/test/scripts/package-acceptance-workflow.test.ts
+++ b/test/scripts/package-acceptance-workflow.test.ts
@@ -2655,9 +2655,7 @@ describe("package artifact reuse", () => {
 
     expect(run).toContain('grep -Fq -- "--shard <index/total>"');
     expect(run).toContain('matrix_selection=(--shard "${{ matrix.shard }}/5")');
-    expect(run).toContain(
-      "legacy_profiles=(transport media e2ee-smoke e2ee-deep e2ee-cli)",
-    );
+    expect(run).toContain("legacy_profiles=(transport media e2ee-smoke e2ee-deep e2ee-cli)");
     expect(run).toContain('legacy_profile="${legacy_profiles[shard_index - 1]}"');
     expect(run).toContain('matrix_selection=(--profile "${legacy_profile}")');
     expect(run).toContain('"${matrix_selection[@]}" \\');


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where release validation for a frozen OpenClaw candidate failed before running any Matrix QA scenarios when the trusted current workflow expected the newer `qa matrix --shard` CLI.

## Why This Change Was Made

The trusted workflow now detects the selected target's CLI contract. Modern targets keep numeric `N/5` catalog sharding; older frozen targets use the historical five-profile partition (`transport`, `media`, `e2ee-smoke`, `e2ee-deep`, `e2ee-cli`) without changing artifact naming, job count, or enforcement.

## User Impact

Release operators can validate frozen candidates with the current trusted workflow without backporting an unrelated QA catalog refactor or omitting Matrix coverage. There is no product runtime or changelog impact.

## Evidence

- Failure reproduced in Release Checks run https://github.com/openclaw/openclaw/actions/runs/30377806473/job/90338910476: the selected target lacked `--shard`, so the workflow exited before any scenario ran and produced no artifact.
- `actionlint .github/workflows/qa-live-transports-convex.yml`
- `node scripts/run-vitest.mjs test/scripts/package-acceptance-workflow.test.ts` — 92 passed
- `node scripts/run-vitest.mjs test/scripts/ci-workflow-guards.test.ts` — 90 passed, 1 skipped
- Contract coverage proves both modern `--shard N/5` and legacy profile selection, including all five historical profiles.
- Autoreview: no accepted/actionable findings.
