### PR TITLE
fix: Gateway heap OOM from per-session usage rollups duplicating the catalog pricing fingerprint

### DIFF
--- a/src/infra/session-cost-usage-aggregation.ts
+++ b/src/infra/session-cost-usage-aggregation.ts
@@ -19,7 +19,9 @@ import { resolveModelCostConfigFingerprint } from "../utils/usage-format.js";
 import {
   acquireSessionCostUsageRefreshLock,
   deleteSessionCostUsageRollupsExcept,
+  readSessionCostUsageRollupPricingFingerprint,
   readSessionCostUsageRollupRows,
+  resetSessionCostUsageRollupScope,
   writeSessionCostUsageRollup,
 } from "./session-cost-usage-cache.sqlite.js";
 import {
@@ -46,7 +48,8 @@ import type { CostUsageTotals, ParsedTranscriptEntry } from "./session-cost-usag
 
 // Cache data is rebuildable. Semantic changes get a new version; old rows are
 // ignored and rebuilt instead of normalized through a runtime compatibility path.
-const USAGE_COST_ROLLUP_VERSION = 2;
+// v3 drops the per-row pricingFingerprint (now stored once per rollup scope).
+const USAGE_COST_ROLLUP_VERSION = 3;
 const USAGE_COST_FILE_ANCHOR_BYTES = 4096;
 
 type UsageCostJsonlCheckpoint = {
@@ -71,7 +74,6 @@ type UsageCostSqliteCheckpoint = {
 
 type UsageCostRollupEntry = {
   version: number;
-  pricingFingerprint: string;
   checkpoint: UsageCostJsonlCheckpoint | UsageCostSqliteCheckpoint;
   scannedAt: number;
   parsedRecords: number;
@@ -104,17 +106,13 @@ export function resolveUsageCostPricingFingerprint(
   return resolveModelCostConfigFingerprint(config, agentDir);
 }
 
-function normalizeUsageCostRollup(
-  raw: unknown,
-  pricingFingerprint: string,
-): UsageCostRollupEntry | undefined {
+function normalizeUsageCostRollup(raw: unknown): UsageCostRollupEntry | undefined {
   if (!raw || typeof raw !== "object") {
     return undefined;
   }
   const record = raw as Partial<UsageCostRollupEntry>;
   if (
     record.version !== USAGE_COST_ROLLUP_VERSION ||
-    record.pricingFingerprint !== pricingFingerprint ||
     !record.checkpoint ||
     !record.rollup ||
     typeof record.scannedAt !== "number" ||
@@ -130,12 +128,17 @@ export function readUsageCostRollups(
   agentId: string,
   pricingFingerprint: string,
   databasePath?: string,
-  rows = readSessionCostUsageRollupRows(agentId, databasePath),
+  rows?: ReturnType<typeof readSessionCostUsageRollupRows>,
 ): Map<string, UsageCostStoredRollup> {
   const result = new Map<string, UsageCostStoredRollup>();
-  for (const row of rows) {
+  // The pricing fingerprint is stored once per scope. A mismatch invalidates
+  // every rollup row without materializing their JSON payloads.
+  if (readSessionCostUsageRollupPricingFingerprint(agentId, databasePath) !== pricingFingerprint) {
+    return result;
+  }
+  for (const row of rows ?? readSessionCostUsageRollupRows(agentId, databasePath)) {
     try {
-      const entry = normalizeUsageCostRollup(JSON.parse(row.valueJson), pricingFingerprint);
+      const entry = normalizeUsageCostRollup(JSON.parse(row.valueJson));
       if (entry) {
         result.set(row.key, { entry, valueJson: row.valueJson });
       }
@@ -355,7 +358,6 @@ function scanRecordsIntoRollup(params: {
 async function scanJsonlUsageRollup(params: {
   file: UsageCostTranscriptFile;
   previous?: UsageCostStoredRollup;
-  pricingFingerprint: string;
   resolveCost: UsageCostResolver;
 }): Promise<UsageCostRollupEntry> {
   const previousCheckpoint =
@@ -409,7 +411,6 @@ async function scanJsonlUsageRollup(params: {
   }
   return {
     version: USAGE_COST_ROLLUP_VERSION,
-    pricingFingerprint: params.pricingFingerprint,
     checkpoint: {
       kind: "jsonl",
       parsedOffset: processedOffset,
@@ -463,7 +464,6 @@ function sqliteCheckpointAnchorHash(event: unknown): string {
 async function scanSqliteUsageRollup(params: {
   file: UsageCostTranscriptFile;
   previous?: UsageCostStoredRollup;
-  pricingFingerprint: string;
   resolveCost: UsageCostResolver;
 }): Promise<UsageCostRollupEntry> {
   const marker = parseSqliteSessionFileMarker(params.file.filePath);
@@ -546,7 +546,6 @@ async function scanSqliteUsageRollup(params: {
     : (scanSessionTranscriptTree(allRows.map((row) => row.event)).leafId ?? undefined);
   return {
     version: USAGE_COST_ROLLUP_VERSION,
-    pricingFingerprint: params.pricingFingerprint,
     checkpoint: {
       kind: "sqlite",
       maxSeq,
@@ -568,7 +567,6 @@ async function scanSqliteUsageRollup(params: {
 async function scanUsageFileForRollup(params: {
   file: UsageCostTranscriptFile;
   previous?: UsageCostStoredRollup;
-  pricingFingerprint: string;
   resolveCost: UsageCostResolver;
 }): Promise<UsageCostRollupEntry> {
   return params.file.kind === "sqlite"
@@ -594,6 +592,20 @@ export async function refreshCostUsageCacheForAgent(params: {
   try {
     const agentDir = params.agentDir ?? resolveUsageCostAgentDir(params.config, params.agentId);
     const pricingFingerprint = resolveUsageCostPricingFingerprint(params.config, agentDir);
+    // Pricing metadata lives once per scope. When it changes, drop the
+    // rebuildable rollup rows (including pre-v2 rows that embedded the full
+    // fingerprint per session) instead of reading them back.
+    if (
+      readSessionCostUsageRollupPricingFingerprint(params.agentId, databasePath) !==
+      pricingFingerprint
+    ) {
+      resetSessionCostUsageRollupScope({
+        agentId: params.agentId,
+        databasePath,
+        pricingFingerprint,
+        updatedAt: Date.now(),
+      });
+    }
     const rows = readSessionCostUsageRollupRows(params.agentId, databasePath);
     const rawValues = new Map(rows.map((row) => [row.key, row.valueJson]));
     const rollups = readUsageCostRollups(params.agentId, pricingFingerprint, databasePath, rows);
@@ -644,7 +656,6 @@ export async function refreshCostUsageCacheForAgent(params: {
       const entry = await scanUsageFileForRollup({
         file,
         previous,
-        pricingFingerprint,
         resolveCost,
       });
       const valueJson = JSON.stringify(entry);

--- a/src/infra/session-cost-usage-cache.sqlite.test.ts
+++ b/src/infra/session-cost-usage-cache.sqlite.test.ts
@@ -12,10 +12,13 @@ import {
   openOpenClawStateDatabase,
 } from "../state/openclaw-state-db.js";
 import { withEnv } from "../test-utils/env.js";
+import { readUsageCostRollups } from "./session-cost-usage-aggregation.js";
 import {
   deleteSessionCostUsageRollupsExcept,
   isSessionCostUsageRefreshRunning,
+  readSessionCostUsageRollupPricingFingerprint,
   readSessionCostUsageRollupRows,
+  resetSessionCostUsageRollupScope,
   writeSessionCostUsageRollup,
 } from "./session-cost-usage-cache.sqlite.js";
 
@@ -167,6 +170,141 @@ describe("session cost usage SQLite cache", () => {
         { key: "refresh-lock", scope: "session-cost-usage" },
         { key: "current.jsonl", scope: "session-cost-usage-rollup-v2" },
       ]);
+    });
+  });
+
+  it("stores the pricing fingerprint once per scope, not per rollup row", () => {
+    const stateDir = makeTempDir(tempDirs, "openclaw-usage-cache-fingerprint-");
+
+    withEnv({ OPENCLAW_STATE_DIR: stateDir }, () => {
+      const agentId = "worker-1";
+      // Stand-in for the hosted catalog pricing payload (openclaw/openclaw#115282).
+      const pricingFingerprint = "x".repeat(256 * 1024);
+
+      resetSessionCostUsageRollupScope({ agentId, pricingFingerprint, updatedAt: 1 });
+      expect(readSessionCostUsageRollupPricingFingerprint(agentId)).toBe(pricingFingerprint);
+
+      for (let index = 0; index < 5; index += 1) {
+        expect(
+          writeSessionCostUsageRollup({
+            agentId,
+            rollupId: `/sessions/${index}.jsonl`,
+            previousValueJson: null,
+            valueJson: `{"version":3,"totalTokens":${index}}`,
+            updatedAt: index + 1,
+          }),
+        ).toBe(true);
+      }
+
+      const rows = readSessionCostUsageRollupRows(agentId);
+      expect(rows).toHaveLength(5);
+      // The scope metadata row is never mixed into per-session rollup rows, and
+      // no row payload carries the multi-megabyte fingerprint.
+      for (const row of rows) {
+        expect(row.key).not.toBe("__usage_cost_rollup_meta__");
+        expect(row.valueJson.length).toBeLessThan(1024);
+      }
+
+      // Pruning keeps the scope metadata row intact.
+      deleteSessionCostUsageRollupsExcept({
+        agentId,
+        liveKeys: new Set(rows.map((r) => r.key)),
+        rows,
+      });
+      expect(readSessionCostUsageRollupPricingFingerprint(agentId)).toBe(pricingFingerprint);
+    });
+  });
+
+  it("rotates the scope on fingerprint change and purges legacy v1 rollup rows", () => {
+    const stateDir = makeTempDir(tempDirs, "openclaw-usage-cache-rotate-");
+
+    withEnv({ OPENCLAW_STATE_DIR: stateDir }, () => {
+      const agentId = "worker-1";
+      resetSessionCostUsageRollupScope({
+        agentId,
+        pricingFingerprint: "fingerprint-a",
+        updatedAt: 1,
+      });
+      expect(
+        writeSessionCostUsageRollup({
+          agentId,
+          rollupId: "/sessions/current.jsonl",
+          previousValueJson: null,
+          valueJson: '{"version":3,"totalTokens":1}',
+          updatedAt: 1,
+        }),
+      ).toBe(true);
+
+      // Seed an abandoned pre-v2 row with the duplicated per-row fingerprint.
+      const database = openOpenClawAgentDatabase({ agentId });
+      database.db
+        .prepare(
+          "INSERT INTO cache_entries (scope, key, value_json, blob, expires_at, updated_at) VALUES (?, ?, ?, NULL, NULL, ?)",
+        )
+        .run(
+          "session-cost-usage-rollup-v1",
+          "/sessions/legacy.jsonl",
+          JSON.stringify({ version: 2, pricingFingerprint: "x".repeat(1024) }),
+          1,
+        );
+      closeOpenClawAgentDatabasesForTest();
+
+      resetSessionCostUsageRollupScope({
+        agentId,
+        pricingFingerprint: "fingerprint-b",
+        updatedAt: 2,
+      });
+
+      expect(readSessionCostUsageRollupPricingFingerprint(agentId)).toBe("fingerprint-b");
+      expect(readSessionCostUsageRollupRows(agentId)).toEqual([]);
+      const verify = openOpenClawAgentDatabase({ agentId });
+      const legacyRows = verify.db
+        .prepare("SELECT count(*) AS count FROM cache_entries WHERE scope = ?")
+        .get("session-cost-usage-rollup-v1") as { count: number };
+      expect(legacyRows.count).toBe(0);
+    });
+  });
+
+  it("treats every rollup as stale when the scope pricing fingerprint differs", () => {
+    const stateDir = makeTempDir(tempDirs, "openclaw-usage-cache-mismatch-");
+
+    withEnv({ OPENCLAW_STATE_DIR: stateDir }, () => {
+      const agentId = "worker-1";
+      resetSessionCostUsageRollupScope({
+        agentId,
+        pricingFingerprint: "fingerprint-a",
+        updatedAt: 1,
+      });
+      const entry = {
+        version: 3,
+        checkpoint: {
+          kind: "jsonl",
+          parsedOffset: 0,
+          observedSize: 0,
+          observedMtimeMs: 0,
+          device: 0,
+          inode: 0,
+          anchorHash: "anchor",
+        },
+        scannedAt: 1,
+        parsedRecords: 0,
+        countedRecords: 0,
+        rollup: {},
+      };
+      expect(
+        writeSessionCostUsageRollup({
+          agentId,
+          rollupId: "/sessions/a.jsonl",
+          previousValueJson: null,
+          valueJson: JSON.stringify(entry),
+          updatedAt: 1,
+        }),
+      ).toBe(true);
+
+      expect(readUsageCostRollups(agentId, "fingerprint-a").size).toBe(1);
+      // Mismatch short-circuits before any rollup JSON is materialized.
+      expect(readUsageCostRollups(agentId, "fingerprint-b").size).toBe(0);
+      expect(readSessionCostUsageRollupRows(agentId)).toHaveLength(1);
     });
   });
 });

--- a/src/infra/session-cost-usage-cache.sqlite.ts
+++ b/src/infra/session-cost-usage-cache.sqlite.ts
@@ -10,8 +10,15 @@ import { isTransientSqliteError } from "./unhandled-rejections.js";
 const LEGACY_CACHE_SCOPE = "session-cost-usage";
 const LEGACY_CACHE_KEY = "cache";
 const REFRESH_LOCK_KEY = "refresh-lock";
-const RETIRED_ROLLUP_SCOPE = "session-cost-usage-rollup-v1";
+// v2 stores the pricing fingerprint once per scope instead of inside every
+// per-session rollup row. The hosted catalog fingerprint can be megabytes, so
+// duplicating it per row made the aggregate read large enough to OOM the
+// Gateway (openclaw/openclaw#115282).
 const ROLLUP_SCOPE = "session-cost-usage-rollup-v2";
+const LEGACY_ROLLUP_SCOPES = ["session-cost-usage-rollup-v1"];
+// Reserved key holding the scope-level pricing fingerprint. Rollup row keys
+// are absolute transcript paths, so this can never collide with a real row.
+const ROLLUP_META_KEY = "__usage_cost_rollup_meta__";
 
 type AgentCacheDatabase = Pick<OpenClawAgentKyselyDatabase, "cache_entries">;
 
@@ -109,13 +116,76 @@ export function readSessionCostUsageRollupRows(
         kysely
           .selectFrom("cache_entries")
           .select(["key", "value_json", "updated_at"])
-          .where("scope", "=", ROLLUP_SCOPE),
+          .where("scope", "=", ROLLUP_SCOPE)
+          .where("key", "!=", ROLLUP_META_KEY),
       ).rows.flatMap((row) =>
         row.value_json === null
           ? []
           : [{ key: row.key, valueJson: row.value_json, updatedAt: row.updated_at }],
       );
     }) ?? []
+  );
+}
+
+/** Reads the scope-level pricing fingerprint stored once for all rollup rows. */
+export function readSessionCostUsageRollupPricingFingerprint(
+  agentId?: string,
+  databasePath?: string,
+): string | null {
+  return readCacheValue(agentId, ROLLUP_SCOPE, ROLLUP_META_KEY, databasePath);
+}
+
+/**
+ * Rotates the rebuildable rollup scope to a new pricing fingerprint: drops
+ * every persisted rollup row (current and legacy scopes) and records the new
+ * fingerprint once. Callers must hold the refresh lock.
+ */
+export function resetSessionCostUsageRollupScope(params: {
+  agentId?: string;
+  databasePath?: string;
+  pricingFingerprint: string;
+  updatedAt: number;
+}): void {
+  runOpenClawAgentWriteTransaction(
+    (database) => {
+      const kysely = getNodeSqliteKysely<AgentCacheDatabase>(database.db);
+      executeSqliteQuerySync(
+        database.db,
+        kysely.deleteFrom("cache_entries").where("scope", "=", ROLLUP_SCOPE),
+      );
+      for (const legacyScope of LEGACY_ROLLUP_SCOPES) {
+        executeSqliteQuerySync(
+          database.db,
+          kysely.deleteFrom("cache_entries").where("scope", "=", legacyScope),
+        );
+      }
+      executeSqliteQuerySync(
+        database.db,
+        kysely
+          .insertInto("cache_entries")
+          .values({
+            scope: ROLLUP_SCOPE,
+            key: ROLLUP_META_KEY,
+            value_json: params.pricingFingerprint,
+            blob: null,
+            expires_at: null,
+            updated_at: params.updatedAt,
+          })
+          .onConflict((conflict) =>
+            conflict.columns(["scope", "key"]).doUpdateSet({
+              value_json: params.pricingFingerprint,
+              blob: null,
+              expires_at: null,
+              updated_at: params.updatedAt,
+            }),
+          ),
+      );
+    },
+    {
+      agentId: normalizeAgentId(params.agentId),
+      ...(params.databasePath ? { path: params.databasePath } : {}),
+    },
+    { operationLabel: "session-cost-usage.rollup.reset-scope" },
   );
 }
 
@@ -203,11 +273,14 @@ export function deleteSessionCostUsageRollupsExcept(params: {
           .where("key", "=", LEGACY_CACHE_KEY),
       );
       // v1 duplicated a multi-megabyte pricing catalog per row (#115282).
-      // Delete by scope so those values are never materialized during cleanup.
-      executeSqliteQuerySync(
-        database.db,
-        kysely.deleteFrom("cache_entries").where("scope", "=", RETIRED_ROLLUP_SCOPE),
-      );
+      // Delete by scope so those values are never materialized during cleanup
+      // and upgraded Gateways reclaim the disk.
+      for (const legacyScope of LEGACY_ROLLUP_SCOPES) {
+        executeSqliteQuerySync(
+          database.db,
+          kysely.deleteFrom("cache_entries").where("scope", "=", legacyScope),
+        );
+      }
     },
     {
       agentId: normalizeAgentId(params.agentId),

--- a/src/infra/session-cost-usage.test.ts
+++ b/src/infra/session-cost-usage.test.ts
@@ -23,6 +23,7 @@ import * as formatDatetime from "./format-time/format-datetime.js";
 import { refreshCostUsageCacheForAgent } from "./session-cost-usage-aggregation.js";
 import {
   acquireSessionCostUsageRefreshLock,
+  readSessionCostUsageRollupPricingFingerprint,
   readSessionCostUsageRollupRows,
   writeSessionCostUsageRollup,
 } from "./session-cost-usage-cache.sqlite.js";
@@ -727,9 +728,9 @@ describe("session cost usage", () => {
         );
         expect(row).toBeDefined();
         expect(Buffer.byteLength(row?.valueJson ?? "")).toBeLessThan(32 * 1024);
-        expect(JSON.parse(row?.valueJson ?? "null")).toMatchObject({
-          pricingFingerprint,
-        });
+        // The fingerprint is stored once in the scope meta row, never per row.
+        expect(row?.valueJson ?? "").not.toContain(pricingFingerprint);
+        expect(readSessionCostUsageRollupPricingFingerprint("main")).toBe(pricingFingerprint);
       });
     } finally {
       setRemoteModelCatalogOverlaySourcesForTest();
@@ -1195,7 +1196,7 @@ describe("session cost usage", () => {
         version: number;
         rollup: { untimestamped: { totals: { totalTokens: number } } };
       };
-      expect(appendedRollup.version).toBe(2);
+      expect(appendedRollup.version).toBe(3);
       expect(appendedRollup.rollup.untimestamped.totals.totalTokens).toBe(1_000);
 
       const allTime = await loadSessionCostSummariesFromCache({


### PR DESCRIPTION
Fixes openclaw/openclaw#115282

## What Problem This Solves

Fixes an issue where users opening the Control UI Usage/Profile surface on `2026.7.2-beta.5` would crash the entire Gateway with a Node/V8 heap OOM when their agent had hundreds of historical sessions. Each per-session usage rollup row in the agent's SQLite `cache_entries` (`scope = session-cost-usage-rollup-v1`) embedded the complete `pricingFingerprint`, which beta.5 expanded to ~2.6 MB of hosted catalog pricing data. In the reporter's environment, 645 rows totaled ~2.1 GB (≈1.67 GB of it the identical fingerprint repeated), and the read path materialized every row's JSON in one `.all()` call until the process hit its heap limit and aborted, taking unrelated agents and channels down with it.

## Why This Change Was Made

The rollup cache is rebuildable, so the fix restores the invariant established by #99714 for the retired JSON cache: shared pricing metadata is stored once, not per session entry. The pricing fingerprint now lives in a single reserved metadata row for a bumped rollup scope (`session-cost-usage-rollup-v2`, entry version 3), rollup rows carry only session-specific data, and the reader compares the scope fingerprint first — short-circuiting on mismatch without materializing any row payloads. On fingerprint change the refresh path (under its existing lock) rotates the scope and drops the rebuildable rows, and pruning also deletes abandoned v1 rows so upgraded Gateways reclaim the duplicated-fingerprint disk usage. No steady-state compatibility reader for the oversized row shape is added, per the cache's rebuildable design.

## User Impact

Usage/Profile stays responsive and the Gateway survives as session count grows: rollup storage and peak read memory no longer scale with `session count × full catalog fingerprint size`. Gateways upgrading from beta.5 automatically abandon and delete the oversized v1 rows on the next usage refresh; no data migration or user action is needed, and stale rollups are transparently rebuilt from transcripts.

## Evidence

- Verified against current `main` (`f84ee793da`): `UsageCostRollupEntry` embedded `pricingFingerprint` per row (`src/infra/session-cost-usage-aggregation.ts`), written via `JSON.stringify(entry)` per session, while `resolveModelCostConfigFingerprint()` (`src/utils/usage-format.ts`) includes the hosted `catalogPricing` payload, and `readSessionCostUsageRollupRows()` selected all `value_json` rows for the scope at once — matching the issue's measured 2.6 MB × 645 rows and the `StatementSync::All` OOM stack.
- New regression tests in `src/infra/session-cost-usage-cache.sqlite.test.ts` cover: fingerprint stored once per scope (never in row payloads, even with a 256 KB stand-in fingerprint), scope rotation on fingerprint change with legacy v1 row purge, and stale-on-mismatch reads that short-circuit before materializing row JSON.
- Targeted tests only: `npx vitest run src/infra/session-cost-usage-cache.sqlite.test.ts src/infra/session-cost-usage.test.ts src/infra/session-cost-usage.stream-errors.test.ts --maxWorkers=1` → 66/66 passed.

AI-assisted: this fix was investigated, implemented, and tested with AI assistance (OpenClaw agent), and reviewed against the issue's reproduction data and prior-art compaction in #99714.
