### PR TITLE
fix(msteams): resolve approvals before agent queue

### DIFF
--- a/extensions/msteams/src/approval-auth.ts
+++ b/extensions/msteams/src/approval-auth.ts
@@ -8,10 +8,12 @@ const MSTEAMS_ID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]
 
 function normalizeMSTeamsApproverId(value: string | number): string | undefined {
   const normalized = normalizeMSTeamsMessagingTarget(String(value));
-  if (!normalized?.startsWith("user:")) {
+  if (!normalized) {
     return undefined;
   }
-  const id = normalizeOptionalLowercaseString(normalized.slice("user:".length));
+  const id = normalizeOptionalLowercaseString(
+    normalized.startsWith("user:") ? normalized.slice("user:".length) : normalized,
+  );
   if (!id) {
     return undefined;
   }

--- a/extensions/msteams/src/approval-control.mock-gateway.test.ts
+++ b/extensions/msteams/src/approval-control.mock-gateway.test.ts
@@ -7,7 +7,7 @@ import {
   getMSTeamsTestRuntimeState,
   installMSTeamsTestRuntime,
 } from "./monitor-handler.test-helpers.js";
-import type { MSTeamsApprovalGatewayRuntime } from "./monitor-handler.types.js";
+import type { MSTeamsMessageHandlerDeps } from "./monitor-handler.types.js";
 import type { MSTeamsTurnContext } from "./sdk-types.js";
 
 const APPROVER_ID = "5e4b4b6f-c242-45de-b0de-bf44eb233145";
@@ -24,26 +24,26 @@ describe("msteams approval control mock-gateway proof", () => {
       releaseWaitingTurn = resolve;
     });
     const pendingApprovals = new Map([[APPROVAL_ID, releaseWaitingTurn]]);
-    const gatewayRequest = vi.fn<MSTeamsApprovalGatewayRuntime["request"]>(
-      async (method, params) => {
-        expect(method).toBe("approval.resolve");
-        const pending = pendingApprovals.get(params.id);
-        if (!pending) {
-          throw new Error("unknown or expired approval id");
-        }
-        pendingApprovals.delete(params.id);
-        pending(params.decision);
-        return {
-          applied: true,
-          approval: {
-            id: params.id,
-            presentation: { kind: params.kind },
-            status: "allowed",
-            decision: params.decision,
-          },
-        } as ApprovalResolveResult;
-      },
-    );
+    const gatewayRequest = vi.fn<
+      NonNullable<MSTeamsMessageHandlerDeps["approvalGatewayRuntime"]>["request"]
+    >(async (method, params) => {
+      expect(method).toBe("approval.resolve");
+      const pending = pendingApprovals.get(params.id);
+      if (!pending) {
+        throw new Error("unknown or expired approval id");
+      }
+      pendingApprovals.delete(params.id);
+      pending(params.decision);
+      return {
+        applied: true,
+        approval: {
+          id: params.id,
+          presentation: { kind: params.kind },
+          status: "allowed",
+          decision: params.decision,
+        },
+      } as ApprovalResolveResult;
+    });
     const deps = createMSTeamsMessageHandlerDeps({
       cfg: {
         channels: { msteams: { allowFrom: [APPROVER_ID] } },

--- a/extensions/msteams/src/approval-control.mock-gateway.test.ts
+++ b/extensions/msteams/src/approval-control.mock-gateway.test.ts
@@ -1,0 +1,119 @@
+import type { ApprovalResolveResult } from "openclaw/plugin-sdk/approval-gateway-runtime";
+import { describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../runtime-api.js";
+import { type MSTeamsActivityHandler, registerMSTeamsHandlers } from "./monitor-handler.js";
+import {
+  createMSTeamsMessageHandlerDeps,
+  getMSTeamsTestRuntimeState,
+  installMSTeamsTestRuntime,
+} from "./monitor-handler.test-helpers.js";
+import type { MSTeamsApprovalGatewayRuntime } from "./monitor-handler.types.js";
+import type { MSTeamsTurnContext } from "./sdk-types.js";
+
+const APPROVER_ID = "5e4b4b6f-c242-45de-b0de-bf44eb233145";
+const APPROVAL_ID = "plugin:approval-123";
+
+describe("msteams approval control mock-gateway proof", () => {
+  it("releases the gateway waiter before the approval reaches agent dispatch", async () => {
+    installMSTeamsTestRuntime();
+    const runtimeState = getMSTeamsTestRuntimeState();
+    runtimeState.dispatchReplyWithBufferedBlockDispatcher.mockClear();
+
+    let releaseWaitingTurn: ((decision: string) => void) | undefined;
+    const waitingTurn = new Promise<string>((resolve) => {
+      releaseWaitingTurn = resolve;
+    });
+    const pendingApprovals = new Map([[APPROVAL_ID, releaseWaitingTurn]]);
+    const gatewayRequest = vi.fn<MSTeamsApprovalGatewayRuntime["request"]>(
+      async (method, params) => {
+        expect(method).toBe("approval.resolve");
+        const pending = pendingApprovals.get(params.id);
+        if (!pending) {
+          throw new Error("unknown or expired approval id");
+        }
+        pendingApprovals.delete(params.id);
+        pending(params.decision);
+        return {
+          applied: true,
+          approval: {
+            id: params.id,
+            presentation: { kind: params.kind },
+            status: "allowed",
+            decision: params.decision,
+          },
+        } as ApprovalResolveResult;
+      },
+    );
+    const deps = createMSTeamsMessageHandlerDeps({
+      cfg: {
+        channels: { msteams: { allowFrom: [APPROVER_ID] } },
+      } as OpenClawConfig,
+    });
+    deps.approvalGatewayRuntime = { request: gatewayRequest };
+
+    let messageHandler: Parameters<MSTeamsActivityHandler["onMessage"]>[0] | undefined;
+    const handler: MSTeamsActivityHandler = {
+      onMessage: (callback) => {
+        messageHandler = callback;
+        return handler;
+      },
+      onMembersAdded: () => handler,
+      onReactionsAdded: () => handler,
+      onReactionsRemoved: () => handler,
+    };
+    registerMSTeamsHandlers(handler, deps);
+
+    const context = {
+      activity: {
+        id: "message-approval-1",
+        type: "message",
+        text: `/approve ${APPROVAL_ID} allow-once`,
+        from: { id: "bf-user", aadObjectId: APPROVER_ID, name: "Approver" },
+        recipient: { id: "bot-id", name: "OpenClaw" },
+        conversation: { id: "19:personal-chat", conversationType: "personal" },
+        channelData: {},
+        attachments: [],
+      },
+      sendActivity: vi.fn(async () => ({ id: "status-activity" })),
+      sendActivities: vi.fn(async () => []),
+    } as unknown as MSTeamsTurnContext;
+
+    await messageHandler?.(
+      context,
+      vi.fn(async () => undefined),
+    );
+    const resumedWithDecision = await waitingTurn;
+
+    expect(gatewayRequest).toHaveBeenCalledWith(
+      "approval.resolve",
+      { id: APPROVAL_ID, kind: "plugin", decision: "allow-once" },
+      { clientDisplayName: `Microsoft Teams approval (${APPROVER_ID})` },
+    );
+    expect(resumedWithDecision).toBe("allow-once");
+    expect(pendingApprovals.size).toBe(0);
+    expect(runtimeState.dispatchReplyWithBufferedBlockDispatcher).not.toHaveBeenCalled();
+    expect(context.sendActivity).toHaveBeenCalledWith(
+      `✅ Approval allow-once submitted for ${APPROVAL_ID}.`,
+    );
+
+    if (process.env.PR115301_PROOF === "1") {
+      console.info(
+        JSON.stringify({
+          verdict: "PASS",
+          scenario: "msteams-approval-releases-waiting-turn",
+          channel: "msteams",
+          gateway: "request-level-mock-gateway",
+          method: "approval.resolve",
+          approvalKind: "plugin",
+          ingress: "message",
+          authorized: true,
+          resolved: true,
+          pendingLedgerEntries: pendingApprovals.size,
+          waitingTurnResumed: resumedWithDecision === "allow-once",
+          approvalReachedAgentQueue: false,
+          secretsRedacted: true,
+        }),
+      );
+    }
+  });
+});

--- a/extensions/msteams/src/approval-control.test.ts
+++ b/extensions/msteams/src/approval-control.test.ts
@@ -61,20 +61,53 @@ describe("msteams approval control", () => {
     resolveApprovalOverGateway.mockClear();
   });
 
-  it("resolves an authorized plugin approval before agent dispatch", async () => {
+  it.each([
+    ["canonical id-first", "/approve plugin:approval-123 allow-once", "allow-once"],
+    ["decision alias", "/approve plugin:approval-123 always", "allow-always"],
+    ["decision-first", "/approve always plugin:approval-123", "allow-always"],
+    ["allow alias", "/approve plugin:approval-123 allow", "allow-once"],
+    ["bot mention", "/approve@openclaw plugin:approval-123 allowonce", "allow-once"],
+    [
+      "native Teams mention",
+      "<at>OpenClaw QA</at> /approve allowonce plugin:approval-123",
+      "allow-once",
+    ],
+    ["deny alias", "/approve plugin:approval-123 reject", "deny"],
+  ] as const)(
+    "resolves an authorized plugin approval before agent dispatch: %s",
+    async (_name, text, decision) => {
+      const handled = await maybeHandleMSTeamsApprovalControl({
+        context: createContext(APPROVER_ID),
+        deps: createDeps(),
+        text,
+      });
+
+      expect(handled).toBe(true);
+      expect(resolveApprovalOverGateway).toHaveBeenCalledWith({
+        cfg: expect.any(Object),
+        approvalId: "plugin:approval-123",
+        decision,
+        senderId: APPROVER_ID,
+        approvalKind: "plugin",
+        clientDisplayName: `Microsoft Teams approval (${APPROVER_ID})`,
+      });
+    },
+  );
+
+  it("resolves exec approvals through the canonical exec owner", async () => {
     const handled = await maybeHandleMSTeamsApprovalControl({
       context: createContext(APPROVER_ID),
       deps: createDeps(),
-      text: "/approve plugin:approval-123 allow-once",
+      text: "/approve exec-approval-123 deny",
     });
 
     expect(handled).toBe(true);
     expect(resolveApprovalOverGateway).toHaveBeenCalledWith({
       cfg: expect.any(Object),
-      approvalId: "plugin:approval-123",
-      decision: "allow-once",
+      approvalId: "exec-approval-123",
+      decision: "deny",
       senderId: APPROVER_ID,
-      allowPluginFallback: false,
+      approvalKind: "exec",
       clientDisplayName: `Microsoft Teams approval (${APPROVER_ID})`,
     });
   });

--- a/extensions/msteams/src/approval-control.test.ts
+++ b/extensions/msteams/src/approval-control.test.ts
@@ -55,7 +55,7 @@ function createContext(senderId: string): MSTeamsTurnContext {
       },
     },
     sendActivity: vi.fn(async () => ({ id: "status-activity" })),
-  } as MSTeamsTurnContext;
+  } as unknown as MSTeamsTurnContext;
 }
 
 describe("msteams approval control", () => {

--- a/extensions/msteams/src/approval-control.test.ts
+++ b/extensions/msteams/src/approval-control.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig, RuntimeEnv } from "../runtime-api.js";
 import { maybeHandleMSTeamsApprovalControl } from "./approval-control.js";
+import { installMSTeamsTestRuntime } from "./monitor-handler.test-helpers.js";
 import type { MSTeamsMessageHandlerDeps } from "./monitor-handler.types.js";
 import type { MSTeamsTurnContext } from "./sdk-types.js";
 
@@ -53,11 +54,13 @@ function createContext(senderId: string): MSTeamsTurnContext {
         conversationType: "personal",
       },
     },
+    sendActivity: vi.fn(async () => ({ id: "status-activity" })),
   } as MSTeamsTurnContext;
 }
 
 describe("msteams approval control", () => {
   beforeEach(() => {
+    installMSTeamsTestRuntime();
     resolveApprovalOverGateway.mockClear();
   });
 
@@ -95,8 +98,9 @@ describe("msteams approval control", () => {
   );
 
   it("resolves exec approvals through the canonical exec owner", async () => {
+    const context = createContext(APPROVER_ID);
     const handled = await maybeHandleMSTeamsApprovalControl({
-      context: createContext(APPROVER_ID),
+      context,
       deps: createDeps(),
       text: "/approve exec-approval-123 deny",
     });
@@ -110,6 +114,23 @@ describe("msteams approval control", () => {
       approvalKind: "exec",
       clientDisplayName: `Microsoft Teams approval (${APPROVER_ID})`,
     });
+    expect(context.sendActivity).toHaveBeenCalledWith(
+      "✅ Approval deny submitted for exec-approval-123.",
+    );
+  });
+
+  it("consumes gateway failures and sends a generic failure status", async () => {
+    resolveApprovalOverGateway.mockRejectedValueOnce(new Error("gateway secret detail"));
+    const context = createContext(APPROVER_ID);
+
+    const handled = await maybeHandleMSTeamsApprovalControl({
+      context,
+      deps: createDeps(),
+      text: "/approve plugin:approval-123 allow-once",
+    });
+
+    expect(handled).toBe(true);
+    expect(context.sendActivity).toHaveBeenCalledWith("❌ Failed to submit approval.");
   });
 
   it("consumes but does not resolve an unauthorized approval command", async () => {
@@ -120,6 +141,33 @@ describe("msteams approval control", () => {
     });
 
     expect(handled).toBe(true);
+    expect(resolveApprovalOverGateway).not.toHaveBeenCalled();
+  });
+
+  it("does not treat the implicit same-chat fallback as explicit authorization", async () => {
+    const deps = createDeps();
+    deps.cfg = {} as OpenClawConfig;
+
+    const handled = await maybeHandleMSTeamsApprovalControl({
+      context: createContext(OTHER_ID),
+      deps,
+      text: "/approve plugin:approval-123 allow-once",
+    });
+
+    expect(handled).toBe(true);
+    expect(resolveApprovalOverGateway).not.toHaveBeenCalled();
+  });
+
+  it("does not intercept approvals when text commands are disabled", async () => {
+    installMSTeamsTestRuntime({ shouldHandleTextCommands: () => false });
+
+    const handled = await maybeHandleMSTeamsApprovalControl({
+      context: createContext(APPROVER_ID),
+      deps: createDeps(),
+      text: "/approve plugin:approval-123 allow-once",
+    });
+
+    expect(handled).toBe(false);
     expect(resolveApprovalOverGateway).not.toHaveBeenCalled();
   });
 

--- a/extensions/msteams/src/approval-control.test.ts
+++ b/extensions/msteams/src/approval-control.test.ts
@@ -1,0 +1,103 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig, RuntimeEnv } from "../runtime-api.js";
+import { maybeHandleMSTeamsApprovalControl } from "./approval-control.js";
+import type { MSTeamsMessageHandlerDeps } from "./monitor-handler.types.js";
+import type { MSTeamsTurnContext } from "./sdk-types.js";
+
+const resolveApprovalOverGateway = vi.hoisted(() => vi.fn(async () => undefined));
+
+vi.mock("openclaw/plugin-sdk/approval-gateway-runtime", () => ({
+  resolveApprovalOverGateway,
+}));
+
+const APPROVER_ID = "5e4b4b6f-c242-45de-b0de-bf44eb233145";
+const OTHER_ID = "6e4b4b6f-c242-45de-b0de-bf44eb233146";
+
+function createDeps(): MSTeamsMessageHandlerDeps {
+  return {
+    cfg: {
+      channels: {
+        msteams: {
+          allowFrom: [APPROVER_ID],
+        },
+      },
+    } as OpenClawConfig,
+    runtime: { error: vi.fn() } as unknown as RuntimeEnv,
+    appId: "test-app",
+    app: {} as MSTeamsMessageHandlerDeps["app"],
+    tokenProvider: {
+      getAccessToken: vi.fn(async () => "token"),
+    },
+    textLimit: 4000,
+    mediaMaxBytes: 1024,
+    conversationStore: {} as MSTeamsMessageHandlerDeps["conversationStore"],
+    pollStore: {} as MSTeamsMessageHandlerDeps["pollStore"],
+    log: {
+      info: vi.fn(),
+      debug: vi.fn(),
+      error: vi.fn(),
+    } as unknown as MSTeamsMessageHandlerDeps["log"],
+  };
+}
+
+function createContext(senderId: string): MSTeamsTurnContext {
+  return {
+    activity: {
+      type: "message",
+      from: {
+        id: "bot-framework-user",
+        aadObjectId: senderId,
+      },
+      conversation: {
+        id: "19:personal-chat",
+        conversationType: "personal",
+      },
+    },
+  } as MSTeamsTurnContext;
+}
+
+describe("msteams approval control", () => {
+  beforeEach(() => {
+    resolveApprovalOverGateway.mockClear();
+  });
+
+  it("resolves an authorized plugin approval before agent dispatch", async () => {
+    const handled = await maybeHandleMSTeamsApprovalControl({
+      context: createContext(APPROVER_ID),
+      deps: createDeps(),
+      text: "/approve plugin:approval-123 allow-once",
+    });
+
+    expect(handled).toBe(true);
+    expect(resolveApprovalOverGateway).toHaveBeenCalledWith({
+      cfg: expect.any(Object),
+      approvalId: "plugin:approval-123",
+      decision: "allow-once",
+      senderId: APPROVER_ID,
+      allowPluginFallback: false,
+      clientDisplayName: `Microsoft Teams approval (${APPROVER_ID})`,
+    });
+  });
+
+  it("consumes but does not resolve an unauthorized approval command", async () => {
+    const handled = await maybeHandleMSTeamsApprovalControl({
+      context: createContext(OTHER_ID),
+      deps: createDeps(),
+      text: "/approve plugin:approval-123 allow-once",
+    });
+
+    expect(handled).toBe(true);
+    expect(resolveApprovalOverGateway).not.toHaveBeenCalled();
+  });
+
+  it("leaves non-approval text on the normal message path", async () => {
+    const handled = await maybeHandleMSTeamsApprovalControl({
+      context: createContext(APPROVER_ID),
+      deps: createDeps(),
+      text: "ok",
+    });
+
+    expect(handled).toBe(false);
+    expect(resolveApprovalOverGateway).not.toHaveBeenCalled();
+  });
+});

--- a/extensions/msteams/src/approval-control.ts
+++ b/extensions/msteams/src/approval-control.ts
@@ -61,7 +61,7 @@ export async function maybeHandleMSTeamsApprovalControl(params: {
     approvalKind,
   });
   const explicitlyAuthorized =
-    authorization?.authorized === true && !isImplicitSameChatApprovalAuthorization(authorization);
+    Boolean(authorization?.authorized) && !isImplicitSameChatApprovalAuthorization(authorization);
   const commandAuthorized = access.commandAccess.authorized;
   if (!senderAdmitted || (!commandAuthorized && !explicitlyAuthorized)) {
     params.deps.log.debug?.("dropping approval control from unauthorized sender", {

--- a/extensions/msteams/src/approval-control.ts
+++ b/extensions/msteams/src/approval-control.ts
@@ -1,15 +1,40 @@
+import { isImplicitSameChatApprovalAuthorization } from "openclaw/plugin-sdk/approval-auth-runtime";
 import { resolveApprovalOverGateway } from "openclaw/plugin-sdk/approval-gateway-runtime";
 import { parseExecApprovalCommandText } from "openclaw/plugin-sdk/approval-reply-runtime";
 import { msTeamsApprovalAuth } from "./approval-auth.js";
+import { formatUnknownError } from "./errors.js";
 import { stripMSTeamsMentionTags } from "./inbound.js";
 import type { MSTeamsMessageHandlerDeps } from "./monitor-handler.types.js";
+import { resolveMSTeamsSenderAccess } from "./monitor-handler/access.js";
+import { getMSTeamsRuntime } from "./runtime.js";
 import type { MSTeamsTurnContext } from "./sdk-types.js";
+
+async function sendApprovalStatus(params: {
+  context: MSTeamsTurnContext;
+  deps: MSTeamsMessageHandlerDeps;
+  text: string;
+}): Promise<void> {
+  try {
+    await params.context.sendActivity(params.text);
+  } catch (error) {
+    params.deps.log.debug?.("failed to send approval control status", {
+      error: formatUnknownError(error),
+    });
+  }
+}
 
 export async function maybeHandleMSTeamsApprovalControl(params: {
   context: MSTeamsTurnContext;
   deps: MSTeamsMessageHandlerDeps;
   text: string;
 }): Promise<boolean> {
+  const allowTextCommands = getMSTeamsRuntime().channel.commands.shouldHandleTextCommands({
+    cfg: params.deps.cfg,
+    surface: "msteams",
+  });
+  if (!allowTextCommands) {
+    return false;
+  }
   const parsed = parseExecApprovalCommandText(stripMSTeamsMentionTags(params.text));
   if (!parsed) {
     return false;
@@ -17,6 +42,17 @@ export async function maybeHandleMSTeamsApprovalControl(params: {
 
   const senderId = params.context.activity.from?.aadObjectId;
   const approvalKind = parsed.approvalId.startsWith("plugin:") ? "plugin" : "exec";
+  const access = await resolveMSTeamsSenderAccess({
+    cfg: params.deps.cfg,
+    activity: params.context.activity,
+    hasControlCommand: true,
+  });
+  const senderAdmitted = access.isDirectMessage
+    ? !access.msteamsCfg || access.senderAccess.decision === "allow"
+    : (!access.msteamsCfg ||
+        !access.channelGate.allowlistConfigured ||
+        access.channelGate.allowed) &&
+      access.senderAccess.allowed;
   const authorization = msTeamsApprovalAuth.authorizeActorAction?.({
     cfg: params.deps.cfg,
     accountId: "default",
@@ -24,26 +60,55 @@ export async function maybeHandleMSTeamsApprovalControl(params: {
     action: "approve",
     approvalKind,
   });
-  if (!authorization?.authorized) {
+  const explicitlyAuthorized =
+    authorization?.authorized === true && !isImplicitSameChatApprovalAuthorization(authorization);
+  const commandAuthorized = access.commandAccess.authorized;
+  if (!senderAdmitted || (!commandAuthorized && !explicitlyAuthorized)) {
     params.deps.log.debug?.("dropping approval control from unauthorized sender", {
       sender: senderId ?? "unknown",
       approvalKind,
+      senderAdmitted,
+      commandAuthorized,
+      explicitlyAuthorized,
     });
     return true;
   }
 
-  await resolveApprovalOverGateway({
-    cfg: params.deps.cfg,
-    approvalId: parsed.approvalId,
-    decision: parsed.decision,
-    senderId,
-    approvalKind,
-    clientDisplayName: `Microsoft Teams approval (${senderId?.trim() || "unknown"})`,
-  });
+  try {
+    await resolveApprovalOverGateway({
+      cfg: params.deps.cfg,
+      approvalId: parsed.approvalId,
+      decision: parsed.decision,
+      senderId,
+      approvalKind,
+      ...(params.deps.approvalGatewayRuntime
+        ? { gatewayRuntime: params.deps.approvalGatewayRuntime }
+        : {}),
+      clientDisplayName: `Microsoft Teams approval (${senderId?.trim() || "unknown"})`,
+    });
+  } catch (error) {
+    params.deps.log.error("failed to resolve approval control", {
+      approvalId: parsed.approvalId,
+      approvalKind,
+      sender: senderId ?? "unknown",
+      error: formatUnknownError(error),
+    });
+    await sendApprovalStatus({
+      context: params.context,
+      deps: params.deps,
+      text: "❌ Failed to submit approval.",
+    });
+    return true;
+  }
   params.deps.log.info("resolved approval control", {
     approvalId: parsed.approvalId,
     decision: parsed.decision,
     sender: senderId ?? "unknown",
+  });
+  await sendApprovalStatus({
+    context: params.context,
+    deps: params.deps,
+    text: `✅ Approval ${parsed.decision} submitted for ${parsed.approvalId}.`,
   });
   return true;
 }

--- a/extensions/msteams/src/approval-control.ts
+++ b/extensions/msteams/src/approval-control.ts
@@ -15,9 +15,14 @@ function parseApprovalCommand(text: string): {
   if (!match) {
     return null;
   }
+  const approvalId = match[1];
+  const decision = match[2];
+  if (!approvalId || !decision) {
+    return null;
+  }
   return {
-    approvalId: match[1],
-    decision: match[2].toLowerCase() as ExecApprovalReplyDecision,
+    approvalId,
+    decision: decision.toLowerCase() as ExecApprovalReplyDecision,
   };
 }
 

--- a/extensions/msteams/src/approval-control.ts
+++ b/extensions/msteams/src/approval-control.ts
@@ -1,37 +1,16 @@
 import { resolveApprovalOverGateway } from "openclaw/plugin-sdk/approval-gateway-runtime";
-import type { ExecApprovalReplyDecision } from "openclaw/plugin-sdk/approval-reply-runtime";
+import { parseExecApprovalCommandText } from "openclaw/plugin-sdk/approval-reply-runtime";
 import { msTeamsApprovalAuth } from "./approval-auth.js";
+import { stripMSTeamsMentionTags } from "./inbound.js";
 import type { MSTeamsMessageHandlerDeps } from "./monitor-handler.types.js";
 import type { MSTeamsTurnContext } from "./sdk-types.js";
-
-const APPROVE_COMMAND_RE =
-  /^\/approve\s+([A-Za-z0-9][A-Za-z0-9._:-]*)\s+(allow-once|allow-always|deny)\s*$/i;
-
-function parseApprovalCommand(text: string): {
-  approvalId: string;
-  decision: ExecApprovalReplyDecision;
-} | null {
-  const match = text.trim().match(APPROVE_COMMAND_RE);
-  if (!match) {
-    return null;
-  }
-  const approvalId = match[1];
-  const decision = match[2];
-  if (!approvalId || !decision) {
-    return null;
-  }
-  return {
-    approvalId,
-    decision: decision.toLowerCase() as ExecApprovalReplyDecision,
-  };
-}
 
 export async function maybeHandleMSTeamsApprovalControl(params: {
   context: MSTeamsTurnContext;
   deps: MSTeamsMessageHandlerDeps;
   text: string;
 }): Promise<boolean> {
-  const parsed = parseApprovalCommand(params.text);
+  const parsed = parseExecApprovalCommandText(stripMSTeamsMentionTags(params.text));
   if (!parsed) {
     return false;
   }
@@ -58,7 +37,7 @@ export async function maybeHandleMSTeamsApprovalControl(params: {
     approvalId: parsed.approvalId,
     decision: parsed.decision,
     senderId,
-    allowPluginFallback: approvalKind === "exec",
+    approvalKind,
     clientDisplayName: `Microsoft Teams approval (${senderId?.trim() || "unknown"})`,
   });
   params.deps.log.info("resolved approval control", {

--- a/extensions/msteams/src/approval-control.ts
+++ b/extensions/msteams/src/approval-control.ts
@@ -1,0 +1,65 @@
+import { resolveApprovalOverGateway } from "openclaw/plugin-sdk/approval-gateway-runtime";
+import type { ExecApprovalReplyDecision } from "openclaw/plugin-sdk/approval-reply-runtime";
+import { msTeamsApprovalAuth } from "./approval-auth.js";
+import type { MSTeamsMessageHandlerDeps } from "./monitor-handler.types.js";
+import type { MSTeamsTurnContext } from "./sdk-types.js";
+
+const APPROVE_COMMAND_RE =
+  /^\/approve\s+([A-Za-z0-9][A-Za-z0-9._:-]*)\s+(allow-once|allow-always|deny)\s*$/i;
+
+function parseApprovalCommand(text: string): {
+  approvalId: string;
+  decision: ExecApprovalReplyDecision;
+} | null {
+  const match = text.trim().match(APPROVE_COMMAND_RE);
+  if (!match) {
+    return null;
+  }
+  return {
+    approvalId: match[1],
+    decision: match[2].toLowerCase() as ExecApprovalReplyDecision,
+  };
+}
+
+export async function maybeHandleMSTeamsApprovalControl(params: {
+  context: MSTeamsTurnContext;
+  deps: MSTeamsMessageHandlerDeps;
+  text: string;
+}): Promise<boolean> {
+  const parsed = parseApprovalCommand(params.text);
+  if (!parsed) {
+    return false;
+  }
+
+  const senderId = params.context.activity.from?.aadObjectId;
+  const approvalKind = parsed.approvalId.startsWith("plugin:") ? "plugin" : "exec";
+  const authorization = msTeamsApprovalAuth.authorizeActorAction?.({
+    cfg: params.deps.cfg,
+    accountId: "default",
+    senderId,
+    action: "approve",
+    approvalKind,
+  });
+  if (!authorization?.authorized) {
+    params.deps.log.debug?.("dropping approval control from unauthorized sender", {
+      sender: senderId ?? "unknown",
+      approvalKind,
+    });
+    return true;
+  }
+
+  await resolveApprovalOverGateway({
+    cfg: params.deps.cfg,
+    approvalId: parsed.approvalId,
+    decision: parsed.decision,
+    senderId,
+    allowPluginFallback: approvalKind === "exec",
+    clientDisplayName: `Microsoft Teams approval (${senderId?.trim() || "unknown"})`,
+  });
+  params.deps.log.info("resolved approval control", {
+    approvalId: parsed.approvalId,
+    decision: parsed.decision,
+    sender: senderId ?? "unknown",
+  });
+  return true;
+}

--- a/extensions/msteams/src/monitor-handler.adaptive-card.test.ts
+++ b/extensions/msteams/src/monitor-handler.adaptive-card.test.ts
@@ -12,6 +12,11 @@ import type { MSTeamsMessageHandlerDeps } from "./monitor-handler.types.js";
 import type { MSTeamsTurnContext } from "./sdk-types.js";
 
 const runtimeApiMockState = getMSTeamsTestRuntimeState();
+const resolveApprovalOverGateway = vi.hoisted(() => vi.fn(async () => undefined));
+
+vi.mock("openclaw/plugin-sdk/approval-gateway-runtime", () => ({
+  resolveApprovalOverGateway,
+}));
 
 vi.mock("./reply-dispatcher.js", () => ({
   createMSTeamsReplyDispatcher: () => ({
@@ -150,6 +155,7 @@ function lastDispatchedCtxPayload(): Record<string, unknown> {
 describe("msteams adaptive card action invoke", () => {
   beforeEach(() => {
     runtimeApiMockState.dispatchReplyWithBufferedBlockDispatcher.mockClear();
+    resolveApprovalOverGateway.mockClear();
   });
 
   it("forwards adaptive card submitted data to the agent as message text", async () => {
@@ -219,6 +225,40 @@ describe("msteams adaptive card action invoke", () => {
     const ctxPayload = lastDispatchedCtxPayload();
     expect(ctxPayload.BodyForAgent).toBe("/codex plugins menu");
     expect(ctxPayload.CommandBody).toBe("/codex plugins menu");
+  });
+
+  it("resolves approval submit actions before agent dispatch", async () => {
+    const deps = createDeps();
+    deps.cfg = {
+      channels: {
+        msteams: {
+          allowFrom: ["user-aad"],
+        },
+      },
+    } as OpenClawConfig;
+    const run = vi.fn(async () => undefined);
+    const handler = createActivityHandler(run);
+    const registered = registerMSTeamsHandlers(handler, deps) as MSTeamsActivityHandler & {
+      run: NonNullable<MSTeamsActivityHandler["run"]>;
+    };
+
+    await runAdaptiveCardInvoke(registered, {
+      action: {
+        type: "Action.Submit",
+        data: "/approve plugin:approval-123 allow-once",
+      },
+    });
+
+    expect(resolveApprovalOverGateway).toHaveBeenCalledWith({
+      cfg: deps.cfg,
+      approvalId: "plugin:approval-123",
+      decision: "allow-once",
+      senderId: "user-aad",
+      approvalKind: "plugin",
+      clientDisplayName: "Microsoft Teams approval (user-aad)",
+    });
+    expect(runtimeApiMockState.dispatchReplyWithBufferedBlockDispatcher).not.toHaveBeenCalled();
+    expect(run).not.toHaveBeenCalled();
   });
 
   it("preserves legacy presentation submit values as structured data", async () => {

--- a/extensions/msteams/src/monitor-handler.adaptive-card.test.ts
+++ b/extensions/msteams/src/monitor-handler.adaptive-card.test.ts
@@ -13,6 +13,7 @@ import type { MSTeamsTurnContext } from "./sdk-types.js";
 
 const runtimeApiMockState = getMSTeamsTestRuntimeState();
 const resolveApprovalOverGateway = vi.hoisted(() => vi.fn(async () => undefined));
+const APPROVER_ID = "5e4b4b6f-c242-45de-b0de-bf44eb233145";
 
 vi.mock("openclaw/plugin-sdk/approval-gateway-runtime", () => ({
   resolveApprovalOverGateway,
@@ -62,6 +63,7 @@ async function runAdaptiveCardInvoke(
     run: NonNullable<MSTeamsActivityHandler["run"]>;
   },
   value: unknown,
+  senderId = "user-aad",
 ) {
   await registered.run({
     activity: {
@@ -72,7 +74,7 @@ async function runAdaptiveCardInvoke(
       serviceUrl: "https://service.example.test",
       from: {
         id: "user-bf",
-        aadObjectId: "user-aad",
+        aadObjectId: senderId,
         name: "User",
       },
       recipient: {
@@ -232,7 +234,7 @@ describe("msteams adaptive card action invoke", () => {
     deps.cfg = {
       channels: {
         msteams: {
-          allowFrom: ["user-aad"],
+          allowFrom: [APPROVER_ID],
         },
       },
     } as OpenClawConfig;
@@ -242,20 +244,24 @@ describe("msteams adaptive card action invoke", () => {
       run: NonNullable<MSTeamsActivityHandler["run"]>;
     };
 
-    await runAdaptiveCardInvoke(registered, {
-      action: {
-        type: "Action.Submit",
-        data: "/approve plugin:approval-123 allow-once",
+    await runAdaptiveCardInvoke(
+      registered,
+      {
+        action: {
+          type: "Action.Submit",
+          data: "/approve plugin:approval-123 allow-once",
+        },
       },
-    });
+      APPROVER_ID,
+    );
 
     expect(resolveApprovalOverGateway).toHaveBeenCalledWith({
       cfg: deps.cfg,
       approvalId: "plugin:approval-123",
       decision: "allow-once",
-      senderId: "user-aad",
+      senderId: APPROVER_ID,
       approvalKind: "plugin",
-      clientDisplayName: "Microsoft Teams approval (user-aad)",
+      clientDisplayName: `Microsoft Teams approval (${APPROVER_ID})`,
     });
     expect(runtimeApiMockState.dispatchReplyWithBufferedBlockDispatcher).not.toHaveBeenCalled();
     expect(run).not.toHaveBeenCalled();

--- a/extensions/msteams/src/monitor-handler.ts
+++ b/extensions/msteams/src/monitor-handler.ts
@@ -1,6 +1,7 @@
 // Msteams plugin module implements monitor handler behavior.
 import { normalizeOptionalLowercaseString } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { serializeMSTeamsAdaptiveCardActionValue } from "./adaptive-card-submit.js";
+import { maybeHandleMSTeamsApprovalControl } from "./approval-control.js";
 import { formatUnknownError } from "./errors.js";
 import type { MSTeamsMessageHandlerDeps } from "./monitor-handler.types.js";
 import { resolveMSTeamsSenderAccess } from "./monitor-handler/access.js";
@@ -155,6 +156,9 @@ export function registerMSTeamsHandlers<T extends MSTeamsActivityHandler>(
       if (ctx.activity?.type === "invoke" && ctx.activity?.name === "adaptiveCard/action") {
         const text = serializeMSTeamsAdaptiveCardActionValue(ctx.activity?.value);
         if (text) {
+          if (await maybeHandleMSTeamsApprovalControl({ context: ctx, deps, text })) {
+            return;
+          }
           return await handleTeamsMessage(
             {
               ...ctx,
@@ -181,7 +185,12 @@ export function registerMSTeamsHandlers<T extends MSTeamsActivityHandler>(
       await next();
     };
     try {
-      const result = await handleTeamsMessage(context as MSTeamsTurnContext, turnAdoptionLifecycle);
+      const ctx = context as MSTeamsTurnContext;
+      const text = ctx.activity.text ?? "";
+      const handledApproval = await maybeHandleMSTeamsApprovalControl({ context: ctx, deps, text });
+      const result = handledApproval
+        ? undefined
+        : await handleTeamsMessage(ctx, turnAdoptionLifecycle);
       await runNext();
       return result;
     } catch (err) {

--- a/extensions/msteams/src/monitor-handler.types.ts
+++ b/extensions/msteams/src/monitor-handler.types.ts
@@ -1,9 +1,22 @@
 // Msteams type declarations define plugin contracts.
+import type { ApprovalResolveResult } from "openclaw/plugin-sdk/approval-gateway-runtime";
 import type { OpenClawConfig, RuntimeEnv } from "../runtime-api.js";
 import type { MSTeamsConversationStore } from "./conversation-store.js";
 import type { MSTeamsMonitorLogger } from "./monitor-types.js";
 import type { MSTeamsPollStore } from "./polls.js";
 import type { MSTeamsApp } from "./sdk.js";
+
+export type MSTeamsApprovalGatewayRuntime = {
+  request: (
+    method: "approval.resolve",
+    params: {
+      id: string;
+      kind: "exec" | "plugin";
+      decision: "allow-once" | "allow-always" | "deny";
+    },
+    options?: { clientDisplayName?: string },
+  ) => Promise<ApprovalResolveResult>;
+};
 
 export type MSTeamsMessageHandlerDeps = {
   cfg: OpenClawConfig;
@@ -18,4 +31,5 @@ export type MSTeamsMessageHandlerDeps = {
   conversationStore: MSTeamsConversationStore;
   pollStore: MSTeamsPollStore;
   log: MSTeamsMonitorLogger;
+  approvalGatewayRuntime?: MSTeamsApprovalGatewayRuntime;
 };

--- a/extensions/msteams/src/monitor-handler.types.ts
+++ b/extensions/msteams/src/monitor-handler.types.ts
@@ -6,12 +6,12 @@ import type { MSTeamsMonitorLogger } from "./monitor-types.js";
 import type { MSTeamsPollStore } from "./polls.js";
 import type { MSTeamsApp } from "./sdk.js";
 
-export type MSTeamsApprovalGatewayRuntime = {
+type MSTeamsApprovalGatewayRuntime = {
   request: (
     method: "approval.resolve",
     params: {
       id: string;
-      kind: "exec" | "plugin";
+      kind: "exec" | "plugin" | "system-agent";
       decision: "allow-once" | "allow-always" | "deny";
     },
     options?: { clientDisplayName?: string },

--- a/src/auto-reply/reply/commands-approve.test.ts
+++ b/src/auto-reply/reply/commands-approve.test.ts
@@ -581,6 +581,32 @@ describe("handleApproveCommand", () => {
     expectApprovalResolverCall({ method, id });
   });
 
+  it.each([
+    ["id-first alias", "/approve abc allow", "allow-once"],
+    ["decision-first alias", "/approve always abc", "allow-always"],
+    ["deny alias", "/approve abc reject", "deny"],
+  ] as const)(
+    "submits approval with the shared command grammar: %s",
+    async (_name, commandBody, decision) => {
+      resolveApprovalOverGatewayMock.mockResolvedValue(undefined);
+      const result = await handleApproveCommand(
+        buildApproveParams(
+          commandBody,
+          {
+            commands: { text: true },
+            channels: { whatsapp: { allowFrom: ["*"] } },
+          } as OpenClawConfig,
+          { SenderId: "123" },
+        ),
+        true,
+      );
+
+      expect(result?.shouldContinue).toBe(false);
+      expect(result?.reply?.text).toContain(`Approval ${decision} submitted`);
+      expectApprovalResolverCall({ method: "exec.approval.resolve", id: "abc", decision });
+    },
+  );
+
   it("honors the configured default account for omitted-account /approve auth", async () => {
     setActivePluginRegistry(
       createTestRegistry([

--- a/src/auto-reply/reply/commands-approve.ts
+++ b/src/auto-reply/reply/commands-approve.ts
@@ -1,6 +1,4 @@
-import { expectDefined } from "@openclaw/normalization-core";
 // Implements approval commands for pending tool and execution requests.
-import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
 import {
   getChannelPlugin,
   resolveChannelApprovalCapability,
@@ -10,25 +8,13 @@ import { isApprovalNotFoundError } from "../../infra/approval-errors.js";
 import { resolveApprovalOverGateway } from "../../infra/approval-gateway-resolver.js";
 import { resolveApprovalCommandAuthorization } from "../../infra/channel-approval-auth.js";
 import { formatErrorMessage } from "../../infra/errors.js";
+import { parseExecApprovalCommandText } from "../../infra/exec-approval-reply.js";
 import { resolveChannelAccountId } from "./channel-context.js";
 import { requireGatewayClientScope } from "./command-gates.js";
 import type { CommandHandler } from "./commands-types.js";
 
 const COMMAND_REGEX = /^\/?approve(?:\s|$)/i;
 const FOREIGN_COMMAND_MENTION_REGEX = /^\/approve@([^\s]+)(?:\s|$)/i;
-
-const DECISION_ALIASES: Record<string, "allow-once" | "allow-always" | "deny"> = {
-  allow: "allow-once",
-  once: "allow-once",
-  "allow-once": "allow-once",
-  allowonce: "allow-once",
-  always: "allow-always",
-  "allow-always": "allow-always",
-  allowalways: "allow-always",
-  deny: "deny",
-  reject: "deny",
-  block: "deny",
-};
 
 type ParsedApproveCommand =
   | { ok: true; id: string; decision: "allow-once" | "allow-always" | "deny" }
@@ -46,31 +32,9 @@ function parseApproveCommand(raw: string): ParsedApproveCommand | null {
   if (!commandMatch) {
     return null;
   }
-  const rest = trimmed.slice(commandMatch[0].length).trim();
-  if (!rest) {
-    return { ok: false, error: APPROVE_USAGE_TEXT };
-  }
-  const tokens = rest.split(/\s+/).filter(Boolean);
-  if (tokens.length < 2) {
-    return { ok: false, error: APPROVE_USAGE_TEXT };
-  }
-
-  const first = normalizeLowercaseStringOrEmpty(tokens[0]);
-  const second = normalizeLowercaseStringOrEmpty(tokens[1]);
-
-  if (DECISION_ALIASES[first]) {
-    return {
-      ok: true,
-      decision: DECISION_ALIASES[first],
-      id: tokens.slice(1).join(" ").trim(),
-    };
-  }
-  if (DECISION_ALIASES[second]) {
-    return {
-      ok: true,
-      decision: DECISION_ALIASES[second],
-      id: expectDefined(tokens[0], "tokens entry at 0"),
-    };
+  const parsed = parseExecApprovalCommandText(trimmed);
+  if (parsed) {
+    return { ok: true, id: parsed.approvalId, decision: parsed.decision };
   }
   return { ok: false, error: APPROVE_USAGE_TEXT };
 }

--- a/src/infra/exec-approval-reply.test.ts
+++ b/src/infra/exec-approval-reply.test.ts
@@ -676,6 +676,26 @@ describe("exec approval reply helpers", () => {
       approvalId: "req-1",
       decision: "allow-always",
     });
+    expect(parseExecApprovalCommandText("/approve always req-1")).toEqual({
+      approvalId: "req-1",
+      decision: "allow-always",
+    });
+    expect(parseExecApprovalCommandText("/approve req-1 allow")).toEqual({
+      approvalId: "req-1",
+      decision: "allow-once",
+    });
+    expect(parseExecApprovalCommandText("/approve once req-1")).toEqual({
+      approvalId: "req-1",
+      decision: "allow-once",
+    });
+    expect(parseExecApprovalCommandText("/approve req-1 reject")).toEqual({
+      approvalId: "req-1",
+      decision: "deny",
+    });
+    expect(parseExecApprovalCommandText("/approve block req-1")).toEqual({
+      approvalId: "req-1",
+      decision: "deny",
+    });
     expect(parseExecApprovalCommandText("/approve req-1 maybe")).toBeNull();
   });
 

--- a/src/infra/exec-approval-reply.ts
+++ b/src/infra/exec-approval-reply.ts
@@ -26,6 +26,19 @@ import {
 } from "./exec-approvals.js";
 
 export type ExecApprovalReplyDecision = ExecApprovalDecision;
+
+const EXEC_APPROVAL_DECISION_ALIASES: Record<string, ExecApprovalReplyDecision> = {
+  allow: "allow-once",
+  once: "allow-once",
+  "allow-once": "allow-once",
+  allowonce: "allow-once",
+  always: "allow-always",
+  "allow-always": "allow-always",
+  allowalways: "allow-always",
+  deny: "deny",
+  reject: "deny",
+  block: "deny",
+};
 export type ExecApprovalUnavailableReason =
   | "initiating-platform-disabled"
   | "initiating-platform-unsupported"
@@ -319,17 +332,31 @@ export function parseExecApprovalCommandText(
   raw: string,
 ): { approvalId: string; decision: ExecApprovalReplyDecision } | null {
   const trimmed = raw.trim();
-  const match = trimmed.match(
-    /^\/?approve(?:@[^\s]+)?\s+([A-Za-z0-9][A-Za-z0-9._:-]*)\s+(allow-once|allow-always|always|deny)\b/i,
-  );
-  if (!match) {
+  const commandMatch = trimmed.match(/^\/?approve(?:@[^\s]+)?(?:\s|$)/i);
+  if (!commandMatch) {
     return null;
   }
-  const rawDecision = normalizeOptionalLowercaseString(match[2]) ?? "";
+  const tokens = trimmed.slice(commandMatch[0].length).trim().split(/\s+/).filter(Boolean);
+  if (tokens.length < 2) {
+    return null;
+  }
+
+  const first = normalizeOptionalLowercaseString(tokens[0]) ?? "";
+  const second = normalizeOptionalLowercaseString(tokens[1]) ?? "";
+  const firstDecision = EXEC_APPROVAL_DECISION_ALIASES[first];
+  if (firstDecision) {
+    return {
+      approvalId: tokens.slice(1).join(" ").trim(),
+      decision: firstDecision,
+    };
+  }
+  const secondDecision = EXEC_APPROVAL_DECISION_ALIASES[second];
+  if (!secondDecision) {
+    return null;
+  }
   return {
-    approvalId: expectDefined(match[1], "exec approval reply regex capture 1"),
-    decision:
-      rawDecision === "always" ? "allow-always" : (rawDecision as ExecApprovalReplyDecision),
+    approvalId: expectDefined(tokens[0], "exec approval reply token 0"),
+    decision: secondDecision,
   };
 }
 

--- a/src/infra/exec-control-command-guard.test.ts
+++ b/src/infra/exec-control-command-guard.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import {
+  detectUnsafeExecControlShellCommand,
+  rejectUnsafeExecControlShellCommand,
+} from "./exec-control-command-guard.js";
+
+describe("Skill Workshop lifecycle exec guard", () => {
+  it.each(["apply", "reject", "quarantine"])(
+    "detects openclaw skills workshop %s",
+    async (action) => {
+      await expect(
+        detectUnsafeExecControlShellCommand(`openclaw skills workshop ${action} proposal-123`),
+      ).resolves.toBe("skill-workshop-lifecycle");
+    },
+  );
+
+  it("detects package-runner and nested shell variants", async () => {
+    await expect(
+      detectUnsafeExecControlShellCommand(
+        "bash -lc 'pnpm exec openclaw skills workshop apply proposal-123'",
+      ),
+    ).resolves.toBe("skill-workshop-lifecycle");
+  });
+
+  it("allows read-only workshop commands", async () => {
+    await expect(
+      detectUnsafeExecControlShellCommand("openclaw skills workshop list"),
+    ).resolves.toBeNull();
+  });
+
+  it("rejects lifecycle commands with a tool-specific message", async () => {
+    await expect(
+      rejectUnsafeExecControlShellCommand("openclaw skills workshop apply proposal-123"),
+    ).rejects.toThrow("Use the skill_workshop tool");
+  });
+});

--- a/src/infra/exec-control-command-guard.test.ts
+++ b/src/infra/exec-control-command-guard.test.ts
@@ -34,3 +34,14 @@ describe("Skill Workshop lifecycle exec guard", () => {
     ).rejects.toThrow("Use the skill_workshop tool");
   });
 });
+
+describe("approval command exec guard", () => {
+  it.each([
+    "/approve exec-123 allow-once",
+    "/approve exec-123 always",
+    "/approve always exec-123",
+    "/approve@openclaw plugin:approval-123 reject",
+  ])("uses the shared approval grammar for %s", async (command) => {
+    await expect(detectUnsafeExecControlShellCommand(command)).resolves.toBe("approve");
+  });
+});

--- a/src/infra/exec-control-command-guard.ts
+++ b/src/infra/exec-control-command-guard.ts
@@ -10,7 +10,7 @@ type ParsedExecApprovalCommand = {
   decision: "allow-once" | "allow-always" | "deny";
 };
 
-type UnsafeExecControlShellCommandKind = "approve" | "channel-login";
+type UnsafeExecControlShellCommandKind = "approve" | "channel-login" | "skill-workshop-lifecycle";
 
 function parseExecApprovalShellCommand(raw: string): ParsedExecApprovalCommand | null {
   const normalized = raw.trimStart();
@@ -91,6 +91,22 @@ function parseOpenClawChannelsLoginShellCommand(raw: string): boolean {
   );
 }
 
+function parseOpenClawSkillWorkshopLifecycleShellCommand(raw: string): boolean {
+  const argv = splitShellArgs(raw);
+  if (!argv) {
+    return false;
+  }
+  const openclawArgv = stripOpenClawPackageRunner(argv);
+  return (
+    normalizeCommandBaseName(openclawArgv[0]) === "openclaw" &&
+    openclawArgv[1] === "skills" &&
+    openclawArgv[2] === "workshop" &&
+    (openclawArgv[3] === "apply" ||
+      openclawArgv[3] === "reject" ||
+      openclawArgv[3] === "quarantine")
+  );
+}
+
 export async function detectUnsafeExecControlShellCommand(
   command: string,
 ): Promise<UnsafeExecControlShellCommandKind | null> {
@@ -117,6 +133,9 @@ export async function detectUnsafeExecControlShellCommand(
     if (parseOpenClawChannelsLoginShellCommand(candidate)) {
       return "channel-login";
     }
+    if (parseOpenClawSkillWorkshopLifecycleShellCommand(candidate)) {
+      return "skill-workshop-lifecycle";
+    }
   }
   return null;
 }
@@ -136,6 +155,14 @@ export async function rejectUnsafeExecControlShellCommand(command: string): Prom
       [
         "exec cannot run interactive OpenClaw channel login commands.",
         "Run `openclaw channels login` in a terminal on the gateway host, or use the channel-specific login agent tool when available (for WhatsApp: `whatsapp_login`).",
+      ].join(" "),
+    );
+  }
+  if (unsafeKind === "skill-workshop-lifecycle") {
+    throw new Error(
+      [
+        "exec cannot run Skill Workshop lifecycle commands.",
+        "Use the skill_workshop tool so apply, reject, and quarantine actions pass through the formal approval flow.",
       ].join(" "),
     );
   }

--- a/src/infra/exec-control-command-guard.ts
+++ b/src/infra/exec-control-command-guard.ts
@@ -4,29 +4,14 @@ import { normalizeStringEntries } from "@openclaw/normalization-core/string-norm
 import { splitShellArgs } from "../utils/shell-argv.js";
 import { buildCommandPayloadCandidates } from "./command-analysis/risks.js";
 import { explainShellCommand } from "./command-explainer/extract.js";
-
-type ParsedExecApprovalCommand = {
-  approvalId: string;
-  decision: "allow-once" | "allow-always" | "deny";
-};
+import { parseExecApprovalCommandText } from "./exec-approval-reply.js";
 
 type UnsafeExecControlShellCommandKind = "approve" | "channel-login" | "skill-workshop-lifecycle";
 
-function parseExecApprovalShellCommand(raw: string): ParsedExecApprovalCommand | null {
-  const normalized = raw.trimStart();
-  const match = normalized.match(
-    /^\/approve(?:@[^\s]+)?\s+([A-Za-z0-9][A-Za-z0-9._:-]*)\s+(allow-once|allow-always|always|deny)\b/i,
-  );
-  if (!match) {
-    return null;
-  }
-  return {
-    approvalId: expectDefined(match[1], "exec control command guard regex capture 1"),
-    decision:
-      normalizeLowercaseStringOrEmpty(match[2]) === "always"
-        ? "allow-always"
-        : (normalizeLowercaseStringOrEmpty(match[2]) as ParsedExecApprovalCommand["decision"]),
-  };
+function parseExecApprovalShellCommand(
+  raw: string,
+): ReturnType<typeof parseExecApprovalCommandText> {
+  return parseExecApprovalCommandText(raw);
 }
 
 function normalizeCommandBaseName(token: string | undefined): string {


### PR DESCRIPTION
## What Problem This Solves

Microsoft Teams approval buttons and typed `/approve` commands were dispatched through the ordinary agent message path. When the active agent turn was waiting for that same approval, the response queued behind the blocked turn and expired. Adaptive Card clicks could also surface a generic Teams error because the invoke waited on agent dispatch.

The same incident exposed that agent `exec` could invoke Skill Workshop lifecycle CLI commands after a formal approval expired.

## Why This Change Was Made

- Intercept exact approval commands in the Microsoft Teams transport before normal agent dispatch.
- Reuse `parseExecApprovalCommandText`, including command mentions, `always`, decision-first syntax, and existing aliases.
- Authorize the AAD actor through normal Teams sender admission plus the existing approval capability; implicit same-chat fallback never counts as explicit authorization.
- Respect `commands.text=false` for both typed messages and Adaptive Card submissions.
- Resolve through the canonical gateway API with an explicit `approvalKind`; no legacy cross-owner fallback is used.
- Return a confirmation on success and a generic user-safe failure status while keeping diagnostic detail in logs.
- Normalize configured bare AAD UUID approvers as well as `user:<uuid>` targets.
- Reject `openclaw skills workshop apply|reject|quarantine` through agent exec, requiring the `skill_workshop` tool.

No new user configuration surface or persistent compatibility shim is added.

## User Impact

Teams approval buttons and `/approve` replies no longer deadlock behind the turn awaiting approval. Unauthorized actors are consumed without resolving the request. Skill Workshop lifecycle actions cannot bypass the formal approval tool through exec.

## Evidence

Evidence was produced on head `378d2d76bf58241827532773f80f4f367b027ee3`.

- Teams/parser/mock-gateway: 23 tests passed.
- Auto-reply parser/auth plus infra approval/exec guard: 73 tests passed.
- Canonical gateway resolver: 25 tests passed.
- Total focused tests: 121 passed.
- `oxfmt --check`, targeted `oxlint`, and `git diff --check` passed.
- Production extension types passed on the rebased head.
- Both Knip dependency/export scans and the package-boundary compiler for all 125 extensions passed on the immediately preceding CI-fix candidate; hosted CI is rerunning them on the rebased head.

Request-level mock-gateway proof uses the real Teams handler and real canonical resolver. The injected transport accepts only `approval.resolve`; its pending ledger releases the waiting turn only when that request arrives. The proof also asserts that the approval never reaches agent dispatch.

```json
{
  "verdict": "PASS",
  "scenario": "msteams-approval-releases-waiting-turn",
  "headSha": "378d2d76bf58241827532773f80f4f367b027ee3",
  "channel": "msteams",
  "gateway": "request-level-mock-gateway",
  "method": "approval.resolve",
  "approvalKind": "plugin",
  "ingress": "message",
  "authorized": true,
  "resolved": true,
  "pendingLedgerEntries": 0,
  "waitingTurnResumed": true,
  "approvalReachedAgentQueue": false,
  "secretsRedacted": true
}
```

The full local extension-test TypeScript check was stopped before exhausting host memory. The production extension typecheck and focused tests pass on the rebased head; the exact previously failing package-boundary compile passed on the immediately preceding candidate. The complete hosted CI matrix is running on the published head.
