### PR TITLE
fix(skills): show clean verdicts for owner-qualified skills

### DIFF
--- a/src/gateway/server-methods/skills.clawhub.test.ts
+++ b/src/gateway/server-methods/skills.clawhub.test.ts
@@ -275,7 +275,7 @@ describe("skills gateway handlers (clawhub)", () => {
       baseUrl: "https://clawhub.ai",
       token: undefined,
       skipAuth: true,
-      timeoutMs: undefined,
+      timeoutMs: expect.any(Number),
     });
     expect(response).toEqual({
       schema: "openclaw.skills.security-verdicts.v1",
@@ -434,6 +434,80 @@ describe("skills gateway handlers (clawhub)", () => {
         ),
       ),
     });
+  });
+
+  it("returns bulk misses when the owner-qualified fallback budget expires", async () => {
+    vi.useFakeTimers();
+    try {
+      const skillCount = 5;
+      buildWorkspaceSkillStatusMock.mockReturnValue({
+        workspaceDir: "/tmp/workspace",
+        managedSkillsDir: "/tmp/openclaw/skills",
+        skills: Array.from({ length: skillCount }, (_, index) => ({
+          name: `skill-${index}`,
+          skillKey: `skill-${index}`,
+          clawhub: {
+            status: "linked",
+            valid: true,
+            registry: "https://clawhub.ai",
+            slug: `skill-${index}`,
+            ownerHandle: `owner-${index}`,
+            installedVersion: "1.0.0",
+            installedAt: 123,
+          },
+        })),
+      });
+      fetchClawHubSkillSecurityVerdictsMock.mockResolvedValue({
+        schema: "clawhub.skill.security-verdicts.v1",
+        items: Array.from({ length: skillCount }, (_, index) => ({
+          ok: false,
+          decision: "fail",
+          reasons: ["skill.not_found"],
+          requestedSlug: `skill-${index}`,
+          requestedVersion: "1.0.0",
+          error: { code: "skill_not_found", message: "Skill not found" },
+        })),
+      });
+      fetchClawHubSkillVerificationMock.mockImplementation(
+        () =>
+          new Promise(() => {
+            // Intentionally never settles; the request-wide budget must win.
+          }),
+      );
+
+      let settled = false;
+      const responsePromise = callSkillsHandler("skills.securityVerdicts", {}).then((result) => {
+        settled = true;
+        return result;
+      });
+      await vi.advanceTimersByTimeAsync(0);
+      expect(fetchClawHubSkillVerificationMock).toHaveBeenCalledTimes(4);
+
+      await vi.advanceTimersByTimeAsync(4_999);
+      expect(settled).toBe(false);
+      await vi.advanceTimersByTimeAsync(1);
+      expect(settled).toBe(true);
+
+      const { ok, response, error } = await responsePromise;
+      expect(error).toBeUndefined();
+      expect(ok).toBe(true);
+      expect(fetchClawHubSkillVerificationMock).toHaveBeenCalledTimes(4);
+      expect(fetchClawHubSkillVerificationMock).toHaveBeenCalledWith(
+        expect.objectContaining({ timeoutMs: 5_000 }),
+      );
+      expect(response).toEqual({
+        schema: "openclaw.skills.security-verdicts.v1",
+        items: Array.from({ length: skillCount }, (_, index) =>
+          expect.objectContaining({
+            ok: false,
+            requestedSlug: `skill-${index}`,
+            error: { code: "skill_not_found", message: "Skill not found" },
+          }),
+        ),
+      });
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("does not passively fetch verdicts from a non-default registry", async () => {

--- a/src/gateway/server-methods/skills.clawhub.test.ts
+++ b/src/gateway/server-methods/skills.clawhub.test.ts
@@ -345,6 +345,97 @@ describe("skills gateway handlers (clawhub)", () => {
     });
   });
 
+  it("bounds concurrent owner-qualified verification fallbacks", async () => {
+    const skillCount = 5;
+    buildWorkspaceSkillStatusMock.mockReturnValue({
+      workspaceDir: "/tmp/workspace",
+      managedSkillsDir: "/tmp/openclaw/skills",
+      skills: Array.from({ length: skillCount }, (_, index) => ({
+        name: `skill-${index}`,
+        skillKey: `skill-${index}`,
+        clawhub: {
+          status: "linked",
+          valid: true,
+          registry: "https://clawhub.ai",
+          slug: `skill-${index}`,
+          ownerHandle: `owner-${index}`,
+          installedVersion: "1.0.0",
+          installedAt: 123,
+        },
+      })),
+    });
+    fetchClawHubSkillSecurityVerdictsMock.mockResolvedValue({
+      schema: "clawhub.skill.security-verdicts.v1",
+      items: Array.from({ length: skillCount }, (_, index) => ({
+        ok: false,
+        decision: "fail",
+        reasons: ["skill.not_found"],
+        requestedSlug: `skill-${index}`,
+        requestedVersion: "1.0.0",
+        error: { code: "skill_not_found", message: "Skill not found" },
+      })),
+    });
+
+    let activeFallbacks = 0;
+    let maxActiveFallbacks = 0;
+    const releaseFallbacks: Array<() => void> = [];
+    fetchClawHubSkillVerificationMock.mockImplementation(
+      async (params: { slug: string; ownerHandle: string }) => {
+        activeFallbacks += 1;
+        maxActiveFallbacks = Math.max(maxActiveFallbacks, activeFallbacks);
+        await new Promise<void>((resolve) => {
+          releaseFallbacks.push(resolve);
+        });
+        activeFallbacks -= 1;
+        return {
+          schema: "clawhub.skill.verify.v1",
+          ok: true,
+          decision: "pass",
+          reasons: [],
+          slug: params.slug,
+          publisherHandle: params.ownerHandle,
+          version: { version: "1.0.0", createdAt: 123 },
+          skill: { slug: params.slug, displayName: params.slug },
+          publisher: { handle: params.ownerHandle },
+          card: {},
+          artifact: {},
+          provenance: {},
+          security: { status: "clean", passed: true },
+          signature: {},
+        };
+      },
+    );
+
+    const responsePromise = callSkillsHandler("skills.securityVerdicts", {});
+    await vi.waitFor(() => expect(releaseFallbacks).toHaveLength(4));
+    expect(fetchClawHubSkillVerificationMock).toHaveBeenCalledTimes(4);
+
+    for (const release of releaseFallbacks.slice(0, 4)) {
+      release();
+    }
+    await vi.waitFor(() => expect(releaseFallbacks).toHaveLength(skillCount));
+    releaseFallbacks[4]?.();
+
+    const { ok, response, error } = await responsePromise;
+    expect(error).toBeUndefined();
+    expect(ok).toBe(true);
+    expect(maxActiveFallbacks).toBe(4);
+    expect(fetchClawHubSkillVerificationMock).toHaveBeenCalledTimes(skillCount);
+    expect(response).toEqual({
+      schema: "openclaw.skills.security-verdicts.v1",
+      items: expect.arrayContaining(
+        Array.from({ length: skillCount }, (_, index) =>
+          expect.objectContaining({
+            ok: true,
+            requestedSlug: `skill-${index}`,
+            publisherHandle: `owner-${index}`,
+            securityStatus: "clean",
+          }),
+        ),
+      ),
+    });
+  });
+
   it("does not passively fetch verdicts from a non-default registry", async () => {
     buildWorkspaceSkillStatusMock.mockReturnValue({
       workspaceDir: "/tmp/workspace",

--- a/src/gateway/server-methods/skills.clawhub.test.ts
+++ b/src/gateway/server-methods/skills.clawhub.test.ts
@@ -11,6 +11,7 @@ const resolveAgentWorkspaceDirMock = vi.fn<(_cfg: unknown, _agentId: string) => 
 );
 const buildWorkspaceSkillStatusMock = vi.fn();
 const readLocalSkillCardContentSyncMock = vi.fn();
+const fetchClawHubSkillVerificationMock = vi.fn();
 const fetchClawHubSkillSecurityVerdictsMock = vi.fn();
 const installSkillFromClawHubMock = vi.fn();
 const installSkillMock = vi.fn();
@@ -46,6 +47,7 @@ vi.mock("../../skills/lifecycle/install.js", () => ({
 
 vi.mock("../../infra/clawhub.js", () => ({
   fetchClawHubSkillDetail: vi.fn(),
+  fetchClawHubSkillVerification: (...args: unknown[]) => fetchClawHubSkillVerificationMock(...args),
   fetchClawHubSkillSecurityVerdicts: (...args: unknown[]) =>
     fetchClawHubSkillSecurityVerdictsMock(...args),
   resolveClawHubBaseUrl: () => "https://clawhub.ai",
@@ -91,6 +93,7 @@ describe("skills gateway handlers (clawhub)", () => {
     resolveAgentWorkspaceDirMock.mockReset();
     buildWorkspaceSkillStatusMock.mockReset();
     readLocalSkillCardContentSyncMock.mockReset();
+    fetchClawHubSkillVerificationMock.mockReset();
     fetchClawHubSkillSecurityVerdictsMock.mockReset();
     installSkillFromClawHubMock.mockReset();
     installSkillMock.mockReset();
@@ -197,6 +200,149 @@ describe("skills gateway handlers (clawhub)", () => {
     });
     expect(JSON.stringify(response)).not.toContain("scannerPayload");
     expect(JSON.stringify(response)).not.toContain('"security":');
+  });
+
+  it("falls back to owner-qualified verification when the bulk verdict misses a linked skill", async () => {
+    buildWorkspaceSkillStatusMock.mockReturnValue({
+      workspaceDir: "/tmp/workspace",
+      managedSkillsDir: "/tmp/openclaw/skills",
+      skills: [
+        {
+          name: "self-improvement",
+          skillKey: "self-improvement",
+          clawhub: {
+            status: "linked",
+            valid: true,
+            registry: "https://clawhub.ai",
+            slug: "self-improving-agent",
+            ownerHandle: "pskoett",
+            installedVersion: "3.0.24",
+            installedAt: 123,
+          },
+        },
+      ],
+    });
+    fetchClawHubSkillSecurityVerdictsMock.mockResolvedValue({
+      schema: "clawhub.skill.security-verdicts.v1",
+      items: [
+        {
+          ok: false,
+          decision: "fail",
+          reasons: ["skill.not_found"],
+          requestedSlug: "self-improving-agent",
+          requestedVersion: "3.0.24",
+          error: { code: "skill_not_found", message: "Skill not found" },
+        },
+      ],
+    });
+    fetchClawHubSkillVerificationMock.mockResolvedValue({
+      schema: "clawhub.skill.verify.v1",
+      ok: true,
+      decision: "pass",
+      reasons: [],
+      slug: "self-improving-agent",
+      publisherHandle: "pskoett",
+      version: { version: "3.0.24", createdAt: 123 },
+      skill: { slug: "self-improving-agent", displayName: "Self Improving Agent" },
+      publisher: { handle: "pskoett" },
+      card: {},
+      artifact: {},
+      provenance: {},
+      security: { status: "clean", passed: true },
+      signature: {},
+      pageUrl: "https://clawhub.ai/pskoett/self-improving-agent",
+    });
+
+    const { ok, response, error } = await callSkillsHandler("skills.securityVerdicts", {});
+
+    expect(error).toBeUndefined();
+    expect(ok).toBe(true);
+    expect(fetchClawHubSkillSecurityVerdictsMock).toHaveBeenCalledWith({
+      baseUrl: "https://clawhub.ai",
+      items: [
+        {
+          slug: "self-improving-agent",
+          ownerHandle: "pskoett",
+          version: "3.0.24",
+        },
+      ],
+      skipAuth: true,
+    });
+    expect(fetchClawHubSkillVerificationMock).toHaveBeenCalledWith({
+      slug: "self-improving-agent",
+      ownerHandle: "pskoett",
+      version: "3.0.24",
+      baseUrl: "https://clawhub.ai",
+      token: undefined,
+      skipAuth: true,
+      timeoutMs: undefined,
+    });
+    expect(response).toEqual({
+      schema: "openclaw.skills.security-verdicts.v1",
+      items: [
+        expect.objectContaining({
+          registry: "https://clawhub.ai",
+          ok: true,
+          decision: "pass",
+          requestedSlug: "self-improving-agent",
+          requestedVersion: "3.0.24",
+          publisherHandle: "pskoett",
+          securityStatus: "clean",
+          securityPassed: true,
+        }),
+      ],
+    });
+  });
+
+  it("keeps the bulk miss when owner-qualified verification is unavailable", async () => {
+    buildWorkspaceSkillStatusMock.mockReturnValue({
+      workspaceDir: "/tmp/workspace",
+      managedSkillsDir: "/tmp/openclaw/skills",
+      skills: [
+        {
+          name: "self-improvement",
+          skillKey: "self-improvement",
+          clawhub: {
+            status: "linked",
+            valid: true,
+            registry: "https://clawhub.ai",
+            slug: "self-improving-agent",
+            ownerHandle: "pskoett",
+            installedVersion: "3.0.24",
+            installedAt: 123,
+          },
+        },
+      ],
+    });
+    fetchClawHubSkillSecurityVerdictsMock.mockResolvedValue({
+      schema: "clawhub.skill.security-verdicts.v1",
+      items: [
+        {
+          ok: false,
+          decision: "fail",
+          reasons: ["skill.not_found"],
+          requestedSlug: "self-improving-agent",
+          requestedVersion: "3.0.24",
+          error: { code: "skill_not_found", message: "Skill not found" },
+        },
+      ],
+    });
+    fetchClawHubSkillVerificationMock.mockRejectedValue(new Error("registry unavailable"));
+
+    const { ok, response, error } = await callSkillsHandler("skills.securityVerdicts", {});
+
+    expect(error).toBeUndefined();
+    expect(ok).toBe(true);
+    expect(response).toEqual({
+      schema: "openclaw.skills.security-verdicts.v1",
+      items: [
+        expect.objectContaining({
+          ok: false,
+          decision: "fail",
+          error: { code: "skill_not_found", message: "Skill not found" },
+        }),
+      ],
+    });
   });
 
   it("does not passively fetch verdicts from a non-default registry", async () => {

--- a/src/infra/clawhub-install-trust.ts
+++ b/src/infra/clawhub-install-trust.ts
@@ -5,14 +5,16 @@ import { sanitizeTerminalText } from "../../packages/terminal-core/src/safe-text
 import { formatTerminalLink } from "../../packages/terminal-core/src/terminal-link.js";
 import { theme } from "../../packages/terminal-core/src/theme.js";
 import {
+  fetchOwnerQualifiedSkillSecurityVerdict,
+  isOwnerQualifiedSkillNotFoundVerdict,
+} from "./clawhub-skill-verdict.js";
+import {
   fetchClawHubPackageSecurity,
-  fetchClawHubSkillVerification,
   fetchClawHubSkillSecurityVerdicts,
   resolveClawHubBaseUrl,
   type ClawHubPackageSecurityResponse,
   type ClawHubPackageSecurityTrust,
   type ClawHubSkillSecurityVerdictItem,
-  type ClawHubSkillVerificationResponse,
 } from "./clawhub.js";
 import { formatErrorMessage } from "./errors.js";
 
@@ -101,7 +103,6 @@ const CLAWHUB_NON_RISK_REASONS = new Set([
   "scan:stale",
   "stale_scan",
 ]);
-const CLAWHUB_NON_SECURITY_SKILL_VERIFY_REASONS = new Set(["card.missing", "card_missing"]);
 const CLAWHUB_EVIDENCE_LABEL_WIDTH = 15;
 const CLAWHUB_RAW_LINK_LABEL_WIDTH = 16;
 
@@ -760,114 +761,6 @@ function resolveSkillSecurityLinks(
   };
 }
 
-function readObject(value: unknown): Record<string, unknown> | undefined {
-  return value && typeof value === "object" && !Array.isArray(value)
-    ? (value as Record<string, unknown>)
-    : undefined;
-}
-
-function readOptionalStringField(value: unknown, field: string): string | undefined {
-  const record = readObject(value);
-  return normalizeOptionalString(record?.[field]);
-}
-
-function readOptionalNumberField(value: unknown, field: string): number | undefined {
-  const record = readObject(value);
-  const raw = record?.[field];
-  return typeof raw === "number" && Number.isFinite(raw) ? raw : undefined;
-}
-
-function mapSkillVerificationSecurityForVerdict(
-  verification: ClawHubSkillVerificationResponse,
-  opts?: { allowCleanCardOnlyPass?: boolean },
-): unknown {
-  const security = readObject(verification.security);
-  if (!security || Object.hasOwn(security, "passed")) {
-    return verification.security;
-  }
-  const status =
-    normalizeOptionalString(security.status) ?? normalizeOptionalString(security.rawStatus);
-  const decisionPass =
-    verification.ok && normalizeClawHubTrustToken(verification.decision) === "pass";
-  if (!status || (!decisionPass && opts?.allowCleanCardOnlyPass !== true)) {
-    return verification.security;
-  }
-  // The owner-qualified fallback uses the older verify endpoint, whose pass
-  // decision plus concrete status predates the batched verdict `passed` flag.
-  return { ...security, passed: true };
-}
-
-function hasOnlyNonSecuritySkillVerifyReasons(reasons: readonly string[]): boolean {
-  return (
-    reasons.length > 0 &&
-    reasons.every((reason) =>
-      CLAWHUB_NON_SECURITY_SKILL_VERIFY_REASONS.has(normalizeClawHubTrustToken(reason)),
-    )
-  );
-}
-
-function isOwnerQualifiedSkillNotFoundVerdict(item: ClawHubSkillSecurityVerdictItem): boolean {
-  return item.error?.code === "skill_not_found";
-}
-
-function mapSkillVerificationToSecurityVerdictItem(params: {
-  verification: ClawHubSkillVerificationResponse;
-  slug: string;
-  ownerHandle: string;
-  version: string;
-}): ClawHubSkillSecurityVerdictItem {
-  const skill = readObject(params.verification.skill);
-  const publisher = readObject(params.verification.publisher);
-  const versionRecord = readObject(params.verification.version);
-  const pageUrl = normalizeOptionalString(params.verification.pageUrl);
-  const reasons = params.verification.reasons
-    .map((reason) => normalizeOptionalString(reason))
-    .filter((reason): reason is string => Boolean(reason));
-  const securityStatus = normalizeClawHubTrustToken(
-    readOptionalStringField(params.verification.security, "status") ??
-      readOptionalStringField(params.verification.security, "rawStatus"),
-  );
-  const cardOnlyCleanFailure =
-    !params.verification.ok &&
-    securityStatus === "clean" &&
-    hasOnlyNonSecuritySkillVerifyReasons(reasons);
-  const verifiedVersion =
-    normalizeOptionalString(params.verification.version) ??
-    readOptionalStringField(versionRecord, "version");
-  return {
-    ok: cardOnlyCleanFailure ? true : params.verification.ok,
-    decision: cardOnlyCleanFailure ? "pass" : params.verification.decision,
-    reasons: cardOnlyCleanFailure ? [] : reasons,
-    requestedSlug: params.slug,
-    requestedVersion: params.version,
-    slug:
-      normalizeOptionalString(params.verification.slug) ?? readOptionalStringField(skill, "slug"),
-    version: verifiedVersion ?? (cardOnlyCleanFailure ? params.version : null),
-    displayName:
-      normalizeOptionalString(params.verification.displayName) ??
-      readOptionalStringField(skill, "displayName"),
-    publisherHandle:
-      normalizeOptionalString(params.verification.publisherHandle) ??
-      readOptionalStringField(publisher, "handle") ??
-      params.ownerHandle,
-    publisherDisplayName:
-      normalizeOptionalString(params.verification.publisherDisplayName) ??
-      readOptionalStringField(publisher, "displayName"),
-    createdAt:
-      params.verification.createdAt ?? readOptionalNumberField(versionRecord, "createdAt") ?? null,
-    checkedAt: readOptionalNumberField(params.verification.security, "checkedAt") ?? null,
-    ...(pageUrl ? { skillUrl: pageUrl } : {}),
-    ...(pageUrl
-      ? {
-          securityAuditUrl: `${pageUrl}/security-audit?version=${encodeURIComponent(params.version)}`,
-        }
-      : {}),
-    security: mapSkillVerificationSecurityForVerdict(params.verification, {
-      allowCleanCardOnlyPass: cardOnlyCleanFailure,
-    }),
-  };
-}
-
 async function fetchOwnerQualifiedSkillSecurityFallback(params: {
   subject: {
     kind: "skill";
@@ -883,19 +776,13 @@ async function fetchOwnerQualifiedSkillSecurityFallback(params: {
   if (!ownerHandle) {
     throw new Error("owner-qualified skill fallback requires ownerHandle");
   }
-  const verification = await fetchClawHubSkillVerification({
+  const item = await fetchOwnerQualifiedSkillSecurityVerdict({
     slug: params.subject.packageName,
     ownerHandle,
     version: params.version,
     baseUrl: params.baseUrl,
     token: params.token,
     timeoutMs: params.timeoutMs,
-  });
-  const item = mapSkillVerificationToSecurityVerdictItem({
-    verification,
-    slug: params.subject.packageName,
-    ownerHandle,
-    version: params.version,
   });
   return {
     security: mapSkillSecurityVerdictToPackageSecurity({

--- a/src/infra/clawhub-skill-verdict.ts
+++ b/src/infra/clawhub-skill-verdict.ts
@@ -1,0 +1,149 @@
+// Shared owner-qualified ClawHub skill verdict fallback.
+import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
+import {
+  fetchClawHubSkillVerification,
+  type ClawHubSkillSecurityVerdictItem,
+  type ClawHubSkillVerificationResponse,
+} from "./clawhub.js";
+
+const CLAWHUB_NON_SECURITY_SKILL_VERIFY_REASONS = new Set(["card.missing", "card_missing"]);
+
+function normalizeClawHubTrustToken(value: string | null | undefined): string {
+  return normalizeOptionalString(value)?.toLowerCase() ?? "";
+}
+
+function readObject(value: unknown): Record<string, unknown> | undefined {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : undefined;
+}
+
+function readOptionalStringField(value: unknown, field: string): string | undefined {
+  const record = readObject(value);
+  return normalizeOptionalString(record?.[field]);
+}
+
+function readOptionalNumberField(value: unknown, field: string): number | undefined {
+  const record = readObject(value);
+  const raw = record?.[field];
+  return typeof raw === "number" && Number.isFinite(raw) ? raw : undefined;
+}
+
+function mapSkillVerificationSecurityForVerdict(
+  verification: ClawHubSkillVerificationResponse,
+  opts?: { allowCleanCardOnlyPass?: boolean },
+): unknown {
+  const security = readObject(verification.security);
+  if (!security || Object.hasOwn(security, "passed")) {
+    return verification.security;
+  }
+  const status =
+    normalizeOptionalString(security.status) ?? normalizeOptionalString(security.rawStatus);
+  const decisionPass =
+    verification.ok && normalizeClawHubTrustToken(verification.decision) === "pass";
+  if (!status || (!decisionPass && opts?.allowCleanCardOnlyPass !== true)) {
+    return verification.security;
+  }
+  // The owner-qualified fallback uses the older verify endpoint, whose pass
+  // decision plus concrete status predates the batched verdict `passed` flag.
+  return { ...security, passed: true };
+}
+
+function hasOnlyNonSecuritySkillVerifyReasons(reasons: readonly string[]): boolean {
+  return (
+    reasons.length > 0 &&
+    reasons.every((reason) =>
+      CLAWHUB_NON_SECURITY_SKILL_VERIFY_REASONS.has(normalizeClawHubTrustToken(reason)),
+    )
+  );
+}
+
+function mapSkillVerificationToSecurityVerdictItem(params: {
+  verification: ClawHubSkillVerificationResponse;
+  slug: string;
+  ownerHandle: string;
+  version: string;
+}): ClawHubSkillSecurityVerdictItem {
+  const skill = readObject(params.verification.skill);
+  const publisher = readObject(params.verification.publisher);
+  const versionRecord = readObject(params.verification.version);
+  const pageUrl = normalizeOptionalString(params.verification.pageUrl);
+  const reasons = params.verification.reasons
+    .map((reason) => normalizeOptionalString(reason))
+    .filter((reason): reason is string => Boolean(reason));
+  const securityStatus = normalizeClawHubTrustToken(
+    readOptionalStringField(params.verification.security, "status") ??
+      readOptionalStringField(params.verification.security, "rawStatus"),
+  );
+  const cardOnlyCleanFailure =
+    !params.verification.ok &&
+    securityStatus === "clean" &&
+    hasOnlyNonSecuritySkillVerifyReasons(reasons);
+  const verifiedVersion =
+    normalizeOptionalString(params.verification.version) ??
+    readOptionalStringField(versionRecord, "version");
+  return {
+    ok: cardOnlyCleanFailure ? true : params.verification.ok,
+    decision: cardOnlyCleanFailure ? "pass" : params.verification.decision,
+    reasons: cardOnlyCleanFailure ? [] : reasons,
+    requestedSlug: params.slug,
+    requestedVersion: params.version,
+    slug:
+      normalizeOptionalString(params.verification.slug) ?? readOptionalStringField(skill, "slug"),
+    version: verifiedVersion ?? (cardOnlyCleanFailure ? params.version : null),
+    displayName:
+      normalizeOptionalString(params.verification.displayName) ??
+      readOptionalStringField(skill, "displayName"),
+    publisherHandle:
+      normalizeOptionalString(params.verification.publisherHandle) ??
+      readOptionalStringField(publisher, "handle") ??
+      params.ownerHandle,
+    publisherDisplayName:
+      normalizeOptionalString(params.verification.publisherDisplayName) ??
+      readOptionalStringField(publisher, "displayName"),
+    createdAt:
+      params.verification.createdAt ?? readOptionalNumberField(versionRecord, "createdAt") ?? null,
+    checkedAt: readOptionalNumberField(params.verification.security, "checkedAt") ?? null,
+    ...(pageUrl ? { skillUrl: pageUrl } : {}),
+    ...(pageUrl
+      ? {
+          securityAuditUrl: `${pageUrl}/security-audit?version=${encodeURIComponent(params.version)}`,
+        }
+      : {}),
+    security: mapSkillVerificationSecurityForVerdict(params.verification, {
+      allowCleanCardOnlyPass: cardOnlyCleanFailure,
+    }),
+  };
+}
+
+export function isOwnerQualifiedSkillNotFoundVerdict(
+  item: ClawHubSkillSecurityVerdictItem,
+): boolean {
+  return item.error?.code === "skill_not_found";
+}
+
+export async function fetchOwnerQualifiedSkillSecurityVerdict(params: {
+  slug: string;
+  ownerHandle: string;
+  version: string;
+  baseUrl?: string;
+  token?: string;
+  skipAuth?: boolean;
+  timeoutMs?: number;
+}): Promise<ClawHubSkillSecurityVerdictItem> {
+  const verification = await fetchClawHubSkillVerification({
+    slug: params.slug,
+    ownerHandle: params.ownerHandle,
+    version: params.version,
+    baseUrl: params.baseUrl,
+    token: params.token,
+    skipAuth: params.skipAuth,
+    timeoutMs: params.timeoutMs,
+  });
+  return mapSkillVerificationToSecurityVerdictItem({
+    verification,
+    slug: params.slug,
+    ownerHandle: params.ownerHandle,
+    version: params.version,
+  });
+}

--- a/src/infra/clawhub.test.ts
+++ b/src/infra/clawhub.test.ts
@@ -780,6 +780,40 @@ describe("clawhub helpers", () => {
     expect(url.searchParams.get("version")).toBe("1.0.0");
   });
 
+  it("can fetch skill verification without resolved auth", async () => {
+    process.env.CLAWHUB_TOKEN = "env-token-123";
+    let requestedInit: RequestInit | undefined;
+
+    await fetchClawHubSkillVerification({
+      slug: "weather",
+      ownerHandle: "demo-owner",
+      version: "1.0.0",
+      skipAuth: true,
+      fetchImpl: async (_input, init) => {
+        requestedInit = init;
+        return new Response(
+          JSON.stringify({
+            schema: "clawhub.skill.verify.v1",
+            ok: true,
+            decision: "pass",
+            reasons: [],
+            skill: {},
+            publisher: {},
+            version: {},
+            card: {},
+            artifact: {},
+            provenance: {},
+            security: {},
+            signature: {},
+          }),
+          { headers: { "content-type": "application/json" } },
+        );
+      },
+    });
+
+    expect(new Headers(requestedInit?.headers).get("Authorization")).toBeNull();
+  });
+
   it("posts bulk skill security verdict requests", async () => {
     let requestedUrl = "";
     let requestedInit: RequestInit | undefined;

--- a/src/infra/clawhub.ts
+++ b/src/infra/clawhub.ts
@@ -1320,6 +1320,7 @@ export async function fetchClawHubSkillVerification(params: {
   tag?: string;
   baseUrl?: string;
   token?: string;
+  skipAuth?: boolean;
   timeoutMs?: number;
   fetchImpl?: FetchLike;
 }): Promise<ClawHubSkillVerificationResponse> {
@@ -1327,6 +1328,7 @@ export async function fetchClawHubSkillVerification(params: {
     baseUrl: params.baseUrl,
     path: `/api/v1/skills/${encodeURIComponent(params.slug)}/verify`,
     token: params.token,
+    skipAuth: params.skipAuth,
     timeoutMs: params.timeoutMs,
     fetchImpl: params.fetchImpl,
     search: {

--- a/src/skills/security/clawhub-verdicts.ts
+++ b/src/skills/security/clawhub-verdicts.ts
@@ -12,6 +12,7 @@ import { runTasksWithConcurrency } from "../../utils/run-with-concurrency.js";
 import type { buildWorkspaceSkillStatus } from "../discovery/status.js";
 
 const OWNER_QUALIFIED_VERDICT_CONCURRENCY = 4;
+const OWNER_QUALIFIED_VERDICT_BUDGET_MS = 5_000;
 
 type ClawHubVerdictTarget = {
   registry: string;
@@ -129,18 +130,30 @@ function canAutoFetchVerdictRegistry(registry: string): boolean {
   return configured !== null && target === configured;
 }
 
+function needsOwnerQualifiedVerdict(
+  item: ClawHubSkillSecurityVerdictItem,
+  target: { slug: string; ownerHandle?: string; version: string } | undefined,
+): target is { slug: string; ownerHandle: string; version: string } {
+  return Boolean(
+    target?.ownerHandle &&
+    target.slug === item.requestedSlug &&
+    target.version === item.requestedVersion &&
+    isOwnerQualifiedSkillNotFoundVerdict(item),
+  );
+}
+
 async function resolveOwnerQualifiedVerdict(params: {
   item: ClawHubSkillSecurityVerdictItem;
   target: { slug: string; ownerHandle?: string; version: string } | undefined;
   registry: string;
+  deadlineAtMs: number;
 }): Promise<ClawHubSkillSecurityVerdictItem> {
-  const { item, target, registry } = params;
-  if (
-    !target?.ownerHandle ||
-    target.slug !== item.requestedSlug ||
-    target.version !== item.requestedVersion ||
-    !isOwnerQualifiedSkillNotFoundVerdict(item)
-  ) {
+  const { item, target, registry, deadlineAtMs } = params;
+  if (!needsOwnerQualifiedVerdict(item, target)) {
+    return item;
+  }
+  const timeoutMs = deadlineAtMs - Date.now();
+  if (timeoutMs <= 0) {
     return item;
   }
   try {
@@ -150,10 +163,55 @@ async function resolveOwnerQualifiedVerdict(params: {
       version: target.version,
       baseUrl: registry,
       skipAuth: true,
+      timeoutMs,
     });
   } catch {
     // Keep the explicit bulk verdict if the compatibility fallback is unavailable.
     return item;
+  }
+}
+
+async function resolveOwnerQualifiedVerdicts(params: {
+  items: ClawHubSkillSecurityVerdictItem[];
+  targets: Array<{ slug: string; ownerHandle?: string; version: string }>;
+  registry: string;
+  deadlineAtMs: number;
+}): Promise<ClawHubSkillSecurityVerdictItem[]> {
+  const remainingMs = params.deadlineAtMs - Date.now();
+  if (remainingMs <= 0) {
+    return params.items;
+  }
+
+  const timedOut = Symbol("owner-qualified-verdict-timeout");
+  let timer: NodeJS.Timeout | undefined;
+  const timeoutPromise = new Promise<typeof timedOut>((resolve) => {
+    timer = setTimeout(() => resolve(timedOut), remainingMs);
+    timer.unref?.();
+  });
+  const resolvedItems = [...params.items];
+  const resolvedPromise = runTasksWithConcurrency({
+    limit: OWNER_QUALIFIED_VERDICT_CONCURRENCY,
+    tasks: params.items.map((item, index) => async () => {
+      resolvedItems[index] = await resolveOwnerQualifiedVerdict({
+        item,
+        target: params.targets[index],
+        registry: params.registry,
+        deadlineAtMs: params.deadlineAtMs,
+      });
+    }),
+  });
+  try {
+    const resolved = await Promise.race([resolvedPromise, timeoutPromise]);
+    if (resolved === timedOut) {
+      // Passive badge lookup must not wait across multiple fallback waves.
+      // Preserve every bulk verdict whose owner-qualified lookup is late.
+      return resolvedItems.slice();
+    }
+    return resolvedItems;
+  } finally {
+    if (timer) {
+      clearTimeout(timer);
+    }
   }
 }
 
@@ -198,25 +256,27 @@ export async function fetchOpenClawSkillSecurityVerdicts(
   }
 
   const items: OpenClawSkillSecurityVerdictItem[] = [];
+  let ownerFallbackDeadlineAtMs: number | undefined;
   for (const [registry, registryTargets] of byRegistry) {
     const response = await fetchClawHubSkillSecurityVerdicts({
       baseUrl: registry,
       items: registryTargets,
       skipAuth: true,
     });
-    const { results: resolvedItems } = await runTasksWithConcurrency({
-      limit: OWNER_QUALIFIED_VERDICT_CONCURRENCY,
-      tasks: response.items.map(
-        (item, index) => () =>
-          // The batch response mirrors request order but omits the requested owner,
-          // so also re-check slug and version before applying the owner fallback.
-          resolveOwnerQualifiedVerdict({
-            item,
-            target: registryTargets[index],
-            registry,
-          }),
-      ),
-    });
+    const needsOwnerFallback = response.items.some((item, index) =>
+      needsOwnerQualifiedVerdict(item, registryTargets[index]),
+    );
+    if (needsOwnerFallback && ownerFallbackDeadlineAtMs === undefined) {
+      ownerFallbackDeadlineAtMs = Date.now() + OWNER_QUALIFIED_VERDICT_BUDGET_MS;
+    }
+    const resolvedItems = needsOwnerFallback
+      ? await resolveOwnerQualifiedVerdicts({
+          items: response.items,
+          targets: registryTargets,
+          registry,
+          deadlineAtMs: ownerFallbackDeadlineAtMs!,
+        })
+      : response.items;
     for (const resolvedItem of resolvedItems) {
       items.push(projectClawHubVerdictItem(resolvedItem, registry));
     }

--- a/src/skills/security/clawhub-verdicts.ts
+++ b/src/skills/security/clawhub-verdicts.ts
@@ -1,3 +1,7 @@
+import {
+  fetchOwnerQualifiedSkillSecurityVerdict,
+  isOwnerQualifiedSkillNotFoundVerdict,
+} from "../../infra/clawhub-skill-verdict.js";
 // ClawHub verdict helpers normalize skill security verdicts from registry metadata.
 import {
   fetchClawHubSkillSecurityVerdicts,
@@ -5,6 +9,13 @@ import {
   type ClawHubSkillSecurityVerdictItem,
 } from "../../infra/clawhub.js";
 import type { buildWorkspaceSkillStatus } from "../discovery/status.js";
+
+type ClawHubVerdictTarget = {
+  registry: string;
+  slug: string;
+  ownerHandle?: string;
+  version: string;
+};
 
 /** ClawHub verdict item shape projected into local security scan verdicts. */
 type OpenClawSkillSecurityVerdictItem = Omit<
@@ -115,10 +126,38 @@ function canAutoFetchVerdictRegistry(registry: string): boolean {
   return configured !== null && target === configured;
 }
 
+async function resolveOwnerQualifiedVerdict(params: {
+  item: ClawHubSkillSecurityVerdictItem;
+  target: { slug: string; ownerHandle?: string; version: string } | undefined;
+  registry: string;
+}): Promise<ClawHubSkillSecurityVerdictItem> {
+  const { item, target, registry } = params;
+  if (
+    !target?.ownerHandle ||
+    target.slug !== item.requestedSlug ||
+    target.version !== item.requestedVersion ||
+    !isOwnerQualifiedSkillNotFoundVerdict(item)
+  ) {
+    return item;
+  }
+  try {
+    return await fetchOwnerQualifiedSkillSecurityVerdict({
+      slug: target.slug,
+      ownerHandle: target.ownerHandle,
+      version: target.version,
+      baseUrl: registry,
+      skipAuth: true,
+    });
+  } catch {
+    // Keep the explicit bulk verdict if the compatibility fallback is unavailable.
+    return item;
+  }
+}
+
 export function collectClawHubVerdictTargets(
   report: ReturnType<typeof buildWorkspaceSkillStatus>,
-): Array<{ registry: string; slug: string; version: string }> {
-  const targets = new Map<string, { registry: string; slug: string; version: string }>();
+): ClawHubVerdictTarget[] {
+  const targets = new Map<string, ClawHubVerdictTarget>();
   for (const skill of report.skills) {
     const link = skill.clawhub;
     if (!link || link.status !== "linked" || !link.valid) {
@@ -127,10 +166,11 @@ export function collectClawHubVerdictTargets(
     if (!canAutoFetchVerdictRegistry(link.registry)) {
       continue;
     }
-    const key = `${link.registry}\0${link.slug}\0${link.installedVersion}`;
+    const key = `${link.registry}\0${link.ownerHandle ?? ""}\0${link.slug}\0${link.installedVersion}`;
     targets.set(key, {
       registry: link.registry,
       slug: link.slug,
+      ...(link.ownerHandle ? { ownerHandle: link.ownerHandle } : {}),
       version: link.installedVersion,
     });
   }
@@ -138,12 +178,19 @@ export function collectClawHubVerdictTargets(
 }
 
 export async function fetchOpenClawSkillSecurityVerdicts(
-  targets: Array<{ registry: string; slug: string; version: string }>,
+  targets: ClawHubVerdictTarget[],
 ): Promise<OpenClawSkillSecurityVerdictItem[]> {
-  const byRegistry = new Map<string, Array<{ slug: string; version: string }>>();
+  const byRegistry = new Map<
+    string,
+    Array<{ slug: string; ownerHandle?: string; version: string }>
+  >();
   for (const target of targets) {
     const registryTargets = byRegistry.get(target.registry) ?? [];
-    registryTargets.push({ slug: target.slug, version: target.version });
+    registryTargets.push({
+      slug: target.slug,
+      ...(target.ownerHandle ? { ownerHandle: target.ownerHandle } : {}),
+      version: target.version,
+    });
     byRegistry.set(target.registry, registryTargets);
   }
 
@@ -154,8 +201,15 @@ export async function fetchOpenClawSkillSecurityVerdicts(
       items: registryTargets,
       skipAuth: true,
     });
-    for (const item of response.items) {
-      items.push(projectClawHubVerdictItem(item, registry));
+    for (const [index, item] of response.items.entries()) {
+      // The batch response mirrors request order but omits the requested owner,
+      // so also re-check slug and version before applying the owner fallback.
+      const resolvedItem = await resolveOwnerQualifiedVerdict({
+        item,
+        target: registryTargets[index],
+        registry,
+      });
+      items.push(projectClawHubVerdictItem(resolvedItem, registry));
     }
   }
   return items;

--- a/src/skills/security/clawhub-verdicts.ts
+++ b/src/skills/security/clawhub-verdicts.ts
@@ -8,7 +8,10 @@ import {
   resolveClawHubBaseUrl,
   type ClawHubSkillSecurityVerdictItem,
 } from "../../infra/clawhub.js";
+import { runTasksWithConcurrency } from "../../utils/run-with-concurrency.js";
 import type { buildWorkspaceSkillStatus } from "../discovery/status.js";
+
+const OWNER_QUALIFIED_VERDICT_CONCURRENCY = 4;
 
 type ClawHubVerdictTarget = {
   registry: string;
@@ -201,14 +204,20 @@ export async function fetchOpenClawSkillSecurityVerdicts(
       items: registryTargets,
       skipAuth: true,
     });
-    for (const [index, item] of response.items.entries()) {
-      // The batch response mirrors request order but omits the requested owner,
-      // so also re-check slug and version before applying the owner fallback.
-      const resolvedItem = await resolveOwnerQualifiedVerdict({
-        item,
-        target: registryTargets[index],
-        registry,
-      });
+    const { results: resolvedItems } = await runTasksWithConcurrency({
+      limit: OWNER_QUALIFIED_VERDICT_CONCURRENCY,
+      tasks: response.items.map(
+        (item, index) => () =>
+          // The batch response mirrors request order but omits the requested owner,
+          // so also re-check slug and version before applying the owner fallback.
+          resolveOwnerQualifiedVerdict({
+            item,
+            target: registryTargets[index],
+            registry,
+          }),
+      ),
+    });
+    for (const resolvedItem of resolvedItems) {
       items.push(projectClawHubVerdictItem(resolvedItem, registry));
     }
   }


### PR DESCRIPTION
Closes #106797

## What Problem This Solves

Fixes an issue where users with a valid owner-qualified ClawHub skill would see its Control UI security badge as **Unavailable** when the bulk verdict endpoint returned `skill_not_found`, even though owner-qualified verification for the same installed version passed with a clean security status.

## Why This Change Was Made

The gateway now preserves the installed skill's `ownerHandle` in verdict targets and bulk requests. When ClawHub's bulk endpoint still cannot resolve that owner-qualified item, OpenClaw falls back to the existing owner-qualified single-skill verification contract and projects that result through the same verdict mapping used by install-time trust checks.

Owner-qualified fallbacks have both a concurrency cap of four and one shared five-second budget for the passive Skills-page request. Each lookup receives only the remaining budget as its own timeout; queued lookups do not start after the deadline. Completed fallback results are retained, while late, failed, or unstarted lookups preserve their original per-item bulk verdict. The passive lookup remains unauthenticated.

## User Impact

Operators can trust the Skills page badge for linked owner-qualified skills: a clean owner-qualified verification is shown as clean instead of unavailable. Slow or unavailable owner-qualified verification cannot hold the passive verdict response across repeated 30-second fallback waves. Skills without an owner handle and non-default registries are unchanged.

## Evidence

- Live ClawHub reproduction on 2026-07-27:
  - owner-qualified `GET /api/v1/skills/self-improving-agent/verify?ownerHandle=pskoett&version=3.0.24` returned `ok=true`, `decision=pass`, and `security.status=clean`
  - bulk `POST /api/v1/skills/-/security-verdicts` returned `skill_not_found` for the same item, including when `ownerHandle` was supplied
- Current head: `17a511d7d59808fdbdd674af304b5aecc21e6a9e`.
- Isolated live gateway proof from the patched owner-qualified implementation:
  - discovered the linked skill `pskoett/self-improving-agent@3.0.24`
  - `skills.securityVerdicts` returned `ok=true`, `decision=pass`, `securityStatus=clean`, and `securityPassed=true`
  - returned owner-qualified links included `https://clawhub.ai/pskoett/skills/self-improving-agent`
- Focused tests: 206 passed across:
  - `src/gateway/server-methods/skills.clawhub.test.ts`
  - `src/skills/lifecycle/clawhub.test.ts`
  - `src/infra/clawhub.test.ts`
- Deterministic gateway regressions cover both controls:
  - five held lookups prove a maximum concurrency of four and preserve result order
  - five non-settling lookups prove the RPC returns at the shared five-second deadline, preserves all bulk misses, passes the remaining budget to active lookups, and never starts the queued fifth request
- Current-head targeted formatting, Oxlint, production TypeScript, test TypeScript, and `git diff --check` passed.
- The preceding bounded-concurrency head also passed full `check:changed` local-child `core` and `coreTests` lanes plus the full build; the follow-up is limited to the same gateway verdict implementation and test.
- `autoreview --mode uncommitted` on the deadline follow-up: clean, no accepted/actionable findings; patch judged correct with 0.94 confidence.

AI-assisted: yes, with Codex. I reviewed the implementation, live API evidence, tests, static checks, and final diff and understand the behavior and failure boundaries.
