### PR TITLE
fix(compaction): plan cut points in trigger units

### DIFF
--- a/packages/agent-core/src/harness/compaction/compaction.test.ts
+++ b/packages/agent-core/src/harness/compaction/compaction.test.ts
@@ -333,6 +333,30 @@ describe("session-entry compaction budgeting", () => {
     ).toEqual({ ok: true, value: undefined });
   });
 
+  it("plans provider-triggered cuts in provider token units", () => {
+    const entries = [
+      createMessageEntry({ role: "user", content: "first", timestamp: 1 }, 0),
+      createMessageEntry(createAssistant("ok", createUsage(2), 2), 1),
+      createMessageEntry({ role: "user", content: "second", timestamp: 3 }, 2),
+      createMessageEntry(createAssistant("ok", createUsage(2), 4), 3),
+      createMessageEntry({ role: "user", content: "latest", timestamp: 5 }, 4),
+      createMessageEntry(createAssistant("done", createUsage(170_000), 6), 5),
+    ];
+
+    const result = prepareCompaction(entries, {
+      enabled: true,
+      reserveTokens: 16_384,
+      keepRecentTokens: 20_000,
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok || !result.value) {
+      throw new Error("expected provider usage to produce a compactable prefix");
+    }
+    expect(result.value.firstKeptEntryId).toBe("entry-4");
+    expect(result.value.messagesToSummarize.length).toBeGreaterThan(0);
+  });
+
   it("keeps reset-filtered tool rows out of later compaction input", () => {
     const entries: SessionTreeEntry[] = [
       createMessageEntry({ role: "user", content: "discarded", timestamp: 1 }, 0),

--- a/packages/agent-core/src/harness/compaction/compaction.ts
+++ b/packages/agent-core/src/harness/compaction/compaction.ts
@@ -769,7 +769,25 @@ export function prepareCompaction(
   }
   const boundaryEnd = effectiveEntries.length;
 
-  const tokensBefore = estimateContextTokens(buildSessionContext(pathEntries).messages).tokens;
+  const contextMessages = buildSessionContext(pathEntries).messages;
+  const contextUsage = estimateContextTokens(contextMessages);
+  const tokensBefore = contextUsage.tokens;
+  const totalEstimatedTokens = contextMessages.reduce(
+    (total, message) => total + estimateTokens(message),
+    0,
+  );
+  // Provider usage includes prompt/schema tokens omitted by estimateTokens. Normalize its trigger
+  // units to the cut walk, capped at a one-token retained tail; otherwise a small transcript
+  // can leave the cut at the first entry and free nothing.
+  const triggerUnitScale =
+    totalEstimatedTokens > 0 &&
+    Number.isFinite(totalEstimatedTokens) &&
+    Number.isFinite(contextUsage.usageTokens)
+      ? Math.min(
+          Math.max(1, settings.keepRecentTokens),
+          Math.max(1, contextUsage.usageTokens / totalEstimatedTokens),
+        )
+      : 1;
   const resetPreludeTokens = resetPreludeMessages.reduce(
     (total, message) => total + estimateTokens(message),
     0,
@@ -778,7 +796,7 @@ export function prepareCompaction(
   // other model-visible boundary context so a large kept tail moves the cut earlier.
   const keepRecentTokens = Math.min(
     Number.MAX_SAFE_INTEGER,
-    settings.keepRecentTokens + resetPreludeTokens,
+    settings.keepRecentTokens / triggerUnitScale + resetPreludeTokens,
   );
 
   const cutPoint = findCutPoint(effectiveEntries, boundaryStart, boundaryEnd, keepRecentTokens);


### PR DESCRIPTION
## What Problem This Solves

Auto-compaction's trigger measures provider context tokens (usage-based, including system prompt and tool schemas), but the cut-point planner accumulates a chars/4 estimate that excludes them. When provider usage is high while the transcript's estimated size is small (cached system prompt + tool definitions dominating), the cut walk never reaches the `keepRecentTokens` budget, `cutIndex` stays at the first entry, and compaction selects zero or near-zero messages — freeing nothing while the trigger keeps firing. Downstream this exhausts the overflow-recovery ladder (residual reports in #78562's thread) and was the root of the "safeguard thrash" residual from #100982.

Closes #111886.

## Why This Change Was Made

`prepareCompaction` (`packages/agent-core/src/harness/compaction/compaction.ts`) now normalizes the retained-tail budget into trigger units: it computes the ratio of provider usage tokens to the summed per-message estimates and divides `keepRecentTokens` by it (clamped to ≥1 so estimates above usage never inflate the tail, and bounded so the budget never drops below one token). The kept tail then costs ~`keepRecentTokens` in the same units the trigger measures, so the cut point advances past compactable prefix whenever the trigger fires. When no finite usage/estimate ratio exists, the scale is 1 and behavior is byte-identical to before. Auto-skip on genuinely empty cuts and the manual `keepRecentTokens: 0` full-branch retry are preserved unchanged.

## User Impact

Sessions with high provider usage but compact transcripts (the common cached-system-prompt shape) now free real tokens on auto-compaction instead of entering repeated no-progress compaction cycles.

## Evidence

- `node scripts/run-vitest.mjs packages/agent-core/src/harness/compaction/compaction.test.ts` — 22 tests passed, including the new regression translated from the issue: ~170k provider usage over a short transcript must select a non-empty old prefix.
- Codex-backed autoreview on the commit: clean, no accepted findings (0.82).
- Related triage: #100982 closed as fixed-on-main with its residual folded here; #94046 closed as superseded (manual path); this PR completes the cluster.
