### PR TITLE
test(ui): emulate reduced motion in shared e2e gateway setup

### DIFF
--- a/ui/src/e2e/chat-flow.navigation-presentation.e2e.test.ts
+++ b/ui/src/e2e/chat-flow.navigation-presentation.e2e.test.ts
@@ -120,6 +120,11 @@ suite.define(() => {
       },
       sessionKey: sessionA,
     });
+    // This spec asserts scroll-restoration geometry that depends on the
+    // chat scroller's smooth anchoring; the reduced-motion emulation in
+    // installMockGateway switches it to instant jumps (#115297), so
+    // restore full motion for this test.
+    await page.emulateMedia({ reducedMotion: "no-preference" });
 
     try {
       await page.goto(`${suite.server.baseUrl}chat`);

--- a/ui/src/e2e/chat-flow.streaming.e2e.test.ts
+++ b/ui/src/e2e/chat-flow.streaming.e2e.test.ts
@@ -392,6 +392,11 @@ suite.define(() => {
       timestamp: baseTs + index,
     }));
     const gateway = await installMockGateway(page, { historyMessages });
+    // This spec asserts pixel-level scroll anchoring of a delayed pending
+    // send, which relies on smooth scrolling; the reduced-motion emulation
+    // in installMockGateway switches it to instant jumps (#115297), so
+    // restore full motion for this test.
+    await page.emulateMedia({ reducedMotion: "no-preference" });
 
     try {
       await page.goto(`${suite.server.baseUrl}chat`);

--- a/ui/src/e2e/chat-tool-turn-outcome.e2e.test.ts
+++ b/ui/src/e2e/chat-tool-turn-outcome.e2e.test.ts
@@ -254,6 +254,10 @@ describeControlUiE2e("Control UI autonomous tool-turn outcomes", () => {
         },
       ],
     });
+    // This spec asserts the chatToolRowTextWave CSS animation by name; the
+    // reduced-motion emulation in installMockGateway suppresses it
+    // (#115297), so restore full motion for this test.
+    await page.emulateMedia({ reducedMotion: "no-preference" });
 
     await page.goto(`${server.baseUrl}chat`);
     await page.getByText("Ready for the running tool wave proof.").waitFor();

--- a/ui/src/e2e/claude-sessions.e2e.test.ts
+++ b/ui/src/e2e/claude-sessions.e2e.test.ts
@@ -617,6 +617,11 @@ suite("Claude native session catalog", () => {
         },
       },
     });
+    // This spec asserts the older-history spinner and the scroll geometry
+    // around prepended virtual rows; the reduced-motion emulation in
+    // installMockGateway suppresses the spinner and switches scroll
+    // anchoring to instant jumps (#115297), so restore full motion here.
+    await page.emulateMedia({ reducedMotion: "no-preference" });
 
     await page.goto(`${server.baseUrl}chat`);
     await page.getByText(/^recent native message 140\n/).waitFor();

--- a/ui/src/e2e/lobster-pet.e2e.test.ts
+++ b/ui/src/e2e/lobster-pet.e2e.test.ts
@@ -61,6 +61,10 @@ describeControlUiE2e("Control UI lobster pet", () => {
     page = await context.newPage();
     await page.clock.install({ time: new Date("2026-07-09T12:00:00") });
     await installMockGateway(page);
+    // These specs assert motion-driven pet acts (startle/droop), which the
+    // reduced-motion emulation in installMockGateway suppresses (#115297);
+    // restore full motion for this file.
+    await page.emulateMedia({ reducedMotion: "no-preference" });
     await page.goto(server.baseUrl);
     await page.waitForFunction(() => Boolean(customElements.get("openclaw-lobster-pet")));
     const loadedAt = await page.evaluate(() => Date.now());

--- a/ui/src/e2e/sidebar-customization.e2e.test.ts
+++ b/ui/src/e2e/sidebar-customization.e2e.test.ts
@@ -681,6 +681,10 @@ describeControlUiE2e("Control UI sidebar customization mocked Gateway E2E", () =
 
   it("keeps the lobster on the footer ledge across desktop and drawer layouts", async () => {
     const { context, page } = await openSidebarTestPage();
+    // This spec asserts the startle act, which prefers-reduced-motion
+    // suppresses; the shared mock-Gateway install emulates reduced motion
+    // (#115297), so restore full motion before poking the pet.
+    await page.emulateMedia({ reducedMotion: "no-preference" });
 
     try {
       const sidebar = page.locator("openclaw-app-sidebar");

--- a/ui/src/test-helpers/control-ui-e2e.ts
+++ b/ui/src/test-helpers/control-ui-e2e.ts
@@ -1554,6 +1554,12 @@ export async function installMockGateway(
   scenario: ControlUiMockGatewayScenario = {},
 ): Promise<MockGatewayControls> {
   const normalizedScenario = normalizeScenario(scenario);
+  // Emulate reduced motion at this shared boundary so cosmetic CSS
+  // animations/transitions settle deterministically on loaded Linux CI
+  // runners instead of stalling visibility and poll waits (#115297). The
+  // Control UI already honors prefers-reduced-motion broadly; a spec that
+  // needs full motion can re-emulate afterwards via page.emulateMedia.
+  await page.emulateMedia({ reducedMotion: "reduce" });
   await page.route(`**${CONTROL_UI_BOOTSTRAP_CONFIG_PATH}`, (route) =>
     route.fulfill({
       body: JSON.stringify(createControlUiMockBootstrapConfig(normalizedScenario)),


### PR DESCRIPTION
## What

Adds `await page.emulateMedia({ reducedMotion: "reduce" })` to `installMockGateway()` in `ui/src/test-helpers/control-ui-e2e.ts` — the shared mocked-Gateway page setup used by 93 of the Control UI E2E spec files.

## What Problem This Solves

The `checks-ui-e2e` lane intermittently stalls on the Ubuntu 24.04 CI runner: different `expect.poll(...)`/Playwright visibility waits time out in different specs on different runs, then pass unchanged on rerun (e.g. job 90326823954 timed out 30s waiting for the Settings search field after the route had already changed; the unchanged rerun passed all 370 tests). The shared page setup leaves CSS motion at the browser default, so cosmetic animations/transitions can keep elements from settling under load. The Control UI already honors `prefers-reduced-motion` broadly (`confetti.ts`, `openclaw-mascot.ts`, `panel-tab-strip.ts`, terminal panel styles, `lobster-pet-plans.ts`, `pages/agents/panels-tools-skills.ts`, `pages/chat/scroll.ts`), but nothing emulated it in the test environment.

Fixes openclaw/openclaw#115297

## Impact

- Every spec that installs the mock Gateway now runs with deterministic reduced motion, matching the issue's proposed owner-boundary fix; cosmetic motion can no longer stall visibility/poll waits under Linux CI load.
- Specs that genuinely need full motion can re-emulate afterwards via `page.emulateMedia({ reducedMotion: "no-preference" })`.
- Existing precedent: `browser-talk-start-stop.e2e.test.ts` already emulates `reducedMotion: "reduce"` manually and its assertions (e.g. `animationName === "none"`) depend on it; `approval-page.e2e.test.ts` passes `reducedMotion: "reduce"` at context creation. This change generalizes that pattern to the shared boundary.
- No production code touched; test infrastructure only.

## Evidence

- `ui/src/test-helpers/control-ui-e2e.test.ts` + `control-ui-e2e.mock-gateway.test.ts`: 13/13 pass.
- Headless system-Chromium e2e runs with the fix applied: `about.e2e.test.ts` (1/1 pass) and `new-session-page.workspace-memory.e2e.test.ts` (7/7 pass — one of the specs named as flaky in the issue).
- `oxfmt --check` and `oxlint` clean on the changed files.
- First full-lane CI run on the global emulation surfaced exactly four specs that assert motion-dependent behavior (`chat-flow.navigation-presentation` scroll-restore geometry, `chat-flow.streaming` pending-send scroll anchoring, `chat-tool-turn-outcome` `chatToolRowTextWave` animation name, `claude-sessions` older-history spinner/prepend geometry). Each now re-emulates `no-preference` at the test level (same escape hatch as `lobster-pet`/`sidebar-customization`), and all four pass headless locally against system Chromium after the fix.
- The global boundary stays because the issue's stalls land in different specs on every run; per-spec opt-in cannot cover a lane-wide flake, while the motion-asserting specs fail deterministically and are enumerable (CI listed all four in one run).

## Notes

AI-assisted (OpenClaw agent): verification, fix, and testing performed by an AI coding agent; diff reviewed before push.

