### PR TITLE
fix(agents): prevent Code Mode resume loss and unbounded preparation

### DIFF
--- a/src/agents/code-mode-deadline.test.ts
+++ b/src/agents/code-mode-deadline.test.ts
@@ -1,0 +1,85 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { awaitCodeModeDeadline } from "./code-mode-deadline.js";
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("Code Mode execution deadlines", () => {
+  it("returns work completed within the shared deadline", async () => {
+    await expect(
+      awaitCodeModeDeadline({
+        operation: async () => "prepared",
+        deadlineMs: Date.now() + 1_000,
+        createTimeoutError: () => new Error("timed out"),
+        createAbortError: () => new Error("aborted"),
+      }),
+    ).resolves.toBe("prepared");
+  });
+
+  it("rejects pending preparation when its wall-clock budget expires", async () => {
+    vi.useFakeTimers();
+    const result = awaitCodeModeDeadline({
+      operation: () => new Promise<string>(() => {}),
+      deadlineMs: Date.now() + 100,
+      createTimeoutError: () => new Error("timed out"),
+      createAbortError: () => new Error("aborted"),
+    });
+    const assertion = expect(result).rejects.toThrow("timed out");
+
+    await vi.advanceTimersByTimeAsync(100);
+
+    await assertion;
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it("rejects pending preparation immediately when its caller aborts", async () => {
+    vi.useFakeTimers();
+    const controller = new AbortController();
+    const result = awaitCodeModeDeadline({
+      operation: () => new Promise<string>(() => {}),
+      deadlineMs: Date.now() + 30_000,
+      signal: controller.signal,
+      createTimeoutError: () => new Error("timed out"),
+      createAbortError: () => new Error("aborted"),
+    });
+
+    controller.abort();
+
+    await expect(result).rejects.toThrow("aborted");
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it("rejects elapsed deadlines before waiting on preparation", async () => {
+    const operation = vi.fn(() => new Promise<string>(() => {}));
+
+    await expect(
+      awaitCodeModeDeadline({
+        operation,
+        deadlineMs: Date.now() - 1,
+        createTimeoutError: () => new Error("timed out"),
+        createAbortError: () => new Error("aborted"),
+      }),
+    ).rejects.toThrow("timed out");
+
+    expect(operation).not.toHaveBeenCalled();
+  });
+
+  it("does not start preparation when its caller is already aborted", async () => {
+    const controller = new AbortController();
+    controller.abort();
+    const operation = vi.fn(() => new Promise<string>(() => {}));
+
+    await expect(
+      awaitCodeModeDeadline({
+        operation,
+        deadlineMs: Date.now() + 1_000,
+        signal: controller.signal,
+        createTimeoutError: () => new Error("timed out"),
+        createAbortError: () => new Error("aborted"),
+      }),
+    ).rejects.toThrow("aborted");
+
+    expect(operation).not.toHaveBeenCalled();
+  });
+});

--- a/src/agents/code-mode-deadline.ts
+++ b/src/agents/code-mode-deadline.ts
@@ -1,0 +1,40 @@
+/** Race preparation and bridge work against the same guest-owned deadline. */
+export async function awaitCodeModeDeadline<T>(params: {
+  operation: () => Promise<T>;
+  deadlineMs: number;
+  signal?: AbortSignal;
+  createTimeoutError: () => Error;
+  createAbortError: (signal: AbortSignal) => Error;
+}): Promise<T> {
+  const remainingMs = params.deadlineMs - Date.now();
+  if (remainingMs <= 0) {
+    throw params.createTimeoutError();
+  }
+  if (params.signal?.aborted) {
+    throw params.createAbortError(params.signal);
+  }
+
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  let onAbort: (() => void) | undefined;
+  try {
+    const deadline = new Promise<never>((_resolve, reject) => {
+      timer = setTimeout(() => reject(params.createTimeoutError()), remainingMs);
+      const signal = params.signal;
+      if (signal) {
+        onAbort = () => reject(params.createAbortError(signal));
+        signal.addEventListener("abort", onAbort, { once: true });
+        if (signal.aborted) {
+          onAbort();
+        }
+      }
+    });
+    return await Promise.race([params.operation(), deadline]);
+  } finally {
+    if (timer) {
+      clearTimeout(timer);
+    }
+    if (params.signal && onAbort) {
+      params.signal.removeEventListener("abort", onAbort);
+    }
+  }
+}

--- a/src/agents/code-mode-execution.ts
+++ b/src/agents/code-mode-execution.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from "node:crypto";
 import { codeModeReplayIdForToolCall } from "./code-mode-bridge.js";
+import { awaitCodeModeDeadline } from "./code-mode-deadline.js";
 import {
   createCodeModeNamespaceRuntime,
   type CodeModeNamespaceRuntime,
@@ -78,6 +79,7 @@ export async function runExec(params: {
       telemetry: telemetry(runtime),
     };
   }
+  const deadlineMs = Date.now() + config.timeoutMs;
   const catalog = runtime.all({ includeMcp: false });
   const namespaceCatalog = runtime.namespaceEntries();
   const swarmEnabled = resolveSwarmConfig(
@@ -92,33 +94,30 @@ export async function runExec(params: {
   );
   const namespaceRuntime = createCodeModeNamespaceRuntime(namespaceCatalog);
   const apiFiles = createCodeModeApiFilesForRun(namespaceCatalog, swarmEnabled);
-  let source: string;
   try {
-    source = await prepareSource({ code: params.code, language: params.language, config });
-  } catch (error) {
-    return {
-      status: "failed" as const,
-      error: codeModeFailureMessage(error),
-      code: codeModeFailureCode(error),
-      output: [],
-      replaySafe: params.restartSafe,
-      telemetry: telemetry(runtime),
-    };
-  }
-  const deadlineMs = Date.now() + config.timeoutMs;
-  try {
+    const source = await awaitCodeModeDeadline({
+      operation: () => prepareSource({ code: params.code, language: params.language, config }),
+      deadlineMs,
+      signal: params.signal,
+      createTimeoutError: () => new Error("interrupted"),
+      createAbortError: () => new Error("code mode execution aborted"),
+    });
+    const remainingMs = deadlineMs - Date.now();
+    if (remainingMs <= 0) {
+      throw new Error("interrupted");
+    }
     const result = normalizeCodeModeWorkerResult(
       await runCodeModeWorker(
         {
           kind: "exec",
           source,
-          config,
+          config: { ...config, timeoutMs: remainingMs },
           catalog,
           apiFiles,
           namespaces: namespaceRuntime.descriptors,
           swarmEnabled,
         },
-        config.timeoutMs + CODE_MODE_WORKER_WATCHDOG_GRACE_MS,
+        remainingMs + CODE_MODE_WORKER_WATCHDOG_GRACE_MS,
         undefined,
         params.signal,
       ),
@@ -140,8 +139,8 @@ export async function runExec(params: {
   } catch (error) {
     return {
       status: "failed" as const,
-      error: codeModeFailureMessage(error),
-      code: codeModeFailureCode(error),
+      error: params.signal?.aborted ? "code mode execution aborted" : codeModeFailureMessage(error),
+      code: params.signal?.aborted ? ("aborted" as const) : codeModeFailureCode(error),
       output: [],
       replaySafe: params.restartSafe,
       telemetry: telemetry(runtime),
@@ -219,6 +218,7 @@ async function settleCodeModeResult(params: {
   deliveredOutputCount?: number;
   pending?: PendingBridgeState[];
   activeRunId?: string;
+  reservedActiveRunSlot?: boolean;
   signal?: AbortSignal;
   onUpdate?: AgentToolUpdateCallback;
 }) {
@@ -284,7 +284,9 @@ async function settleCodeModeResult(params: {
         config: params.config,
         output,
       });
-      releaseReservation = reserveActiveRunSlot();
+      if (!params.reservedActiveRunSlot) {
+        releaseReservation = reserveActiveRunSlot();
+      }
       const pendingIds = new Set(pending.map((entry) => entry.id));
       pending.push(
         ...createPendingBridgeStates({
@@ -400,7 +402,9 @@ async function settleCodeModeResult(params: {
         });
         // Reserve before launching fresh work; transferred snapshots must
         // obey the same process-wide active-run cap as initial suspensions.
-        releaseReservation = reserveActiveRunSlot();
+        if (!params.reservedActiveRunSlot) {
+          releaseReservation = reserveActiveRunSlot();
+        }
         const pendingIds = new Set(pending.map((entry) => entry.id));
         pending.push(
           ...createPendingBridgeStates({
@@ -450,6 +454,7 @@ async function settleCodeModeResult(params: {
       namespaceRuntime: params.namespaceRuntime,
       output,
       deliveredOutputCount,
+      reservedActiveRunSlot: params.reservedActiveRunSlot,
       replaySafe: params.replaySafe,
       settlementMode: result.settlementMode,
       signal: params.signal,
@@ -501,6 +506,7 @@ export async function runWait(params: {
   // One wait call shares a single wall-clock deadline across draining the prior
   // pending calls, the resume worker, and the inline settle phase.
   const deadlineMs = Date.now() + state.config.timeoutMs;
+  let releaseActiveRunSlot: (() => void) | undefined;
   try {
     const ready = await waitForPending(
       state.pending,
@@ -542,9 +548,9 @@ export async function runWait(params: {
       state.pending,
     );
     const pending = state.pending.filter((entry) => !entry.settled);
-    // Transfer outstanding calls to the next snapshot; dispose would abort a
-    // still-live sibling before the guest observes the completed frontier.
-    activeRuns.delete(state.runId);
+    // Keep the run's existing slot reserved while its live sibling calls and
+    // snapshot move through the worker; a new exec must not claim this slot.
+    releaseActiveRunSlot = reserveActiveRunSlot(state.runId);
     // The resumed guest inherits only the remaining shared budget as its QuickJS
     // interrupt deadline; the extra host margin is watchdog grace only.
     const result = normalizeCodeModeWorkerResult(
@@ -580,6 +586,7 @@ export async function runWait(params: {
       deliveredOutputCount: state.deliveredOutputCount,
       pending,
       activeRunId: state.runId,
+      reservedActiveRunSlot: true,
       signal: params.signal,
       onUpdate: params.onUpdate,
     });
@@ -598,6 +605,7 @@ export async function runWait(params: {
       telemetry: telemetry(state.runtime),
     };
   } finally {
+    releaseActiveRunSlot?.();
     resumingRunIds.delete(state.runId);
   }
 }

--- a/src/agents/code-mode-headless.test.ts
+++ b/src/agents/code-mode-headless.test.ts
@@ -58,6 +58,7 @@ function expectFailed(result: CodeModeHeadlessResult) {
 describe("headless Code Mode", () => {
   afterEach(() => {
     vi.useRealTimers();
+    testing.setTypescriptRuntimeForTest(null);
     expect(testing.activeRuns.size).toBe(0);
     testing.activeRuns.clear();
     testing.resumingRunIds.clear();
@@ -804,6 +805,46 @@ describe("headless Code Mode", () => {
     expect(result).toMatchObject({
       code: "aborted",
       error: "code mode execution aborted",
+    });
+  });
+
+  it("times out an unfinished headless TypeScript runtime load", async () => {
+    testing.setTypescriptRuntimeForTest(new Promise<typeof import("typescript")>(() => {}));
+
+    const result = expectFailed(
+      await runCodeModeScriptHeadless({
+        ctx: createHeadlessHarness(),
+        language: "typescript",
+        code: "return 42;",
+        wallClockMs: 25,
+      }),
+    );
+
+    expect(result).toMatchObject({
+      code: "timeout",
+      error: "code mode headless wall-clock timeout exceeded",
+      output: [],
+      toolCallCount: 0,
+    });
+  });
+
+  it("aborts an unfinished headless TypeScript runtime load", async () => {
+    testing.setTypescriptRuntimeForTest(new Promise<typeof import("typescript")>(() => {}));
+    const controller = new AbortController();
+    const resultPromise = runCodeModeScriptHeadless({
+      ctx: createHeadlessHarness(),
+      language: "typescript",
+      code: "return 42;",
+      signal: controller.signal,
+    });
+
+    controller.abort();
+
+    expect(expectFailed(await resultPromise)).toMatchObject({
+      code: "aborted",
+      error: "code mode execution aborted",
+      output: [],
+      toolCallCount: 0,
     });
   });
 

--- a/src/agents/code-mode-headless.ts
+++ b/src/agents/code-mode-headless.ts
@@ -300,7 +300,10 @@ export async function runCodeModeScriptHeadless(params: {
           signal: abortScope.signal,
         }),
       );
-      const frontierPending = pendingBridgeStatesForSettlement(pending, result.settlementMode);
+      // Preserve the waiting frontier before the lazy deadline callback;
+      // later worker legs replace the discriminated result entirely.
+      const settlementMode = result.settlementMode;
+      const frontierPending = pendingBridgeStatesForSettlement(pending, settlementMode);
       if (frontierPending.length === 0) {
         return headlessFailure({
           code: "internal_error",
@@ -310,7 +313,7 @@ export async function runCodeModeScriptHeadless(params: {
         });
       }
       await awaitCodeModeDeadline({
-        operation: () => waitForPendingBridgeSettlement(pending, result.settlementMode),
+        operation: () => waitForPendingBridgeSettlement(pending, settlementMode),
         deadlineMs: deadline,
         signal: abortScope.signal,
         createTimeoutError: () => new CodeModeHeadlessTimeoutError(),

--- a/src/agents/code-mode-headless.ts
+++ b/src/agents/code-mode-headless.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from "node:crypto";
 import { clampNumber } from "../utils.js";
+import { awaitCodeModeDeadline } from "./code-mode-deadline.js";
 import { toCodeModeJsonSafe } from "./code-mode-json.js";
 import {
   createCodeModeNamespaceRuntime,
@@ -89,37 +90,6 @@ function remainingHeadlessMs(deadline: number): number {
     throw new CodeModeHeadlessTimeoutError();
   }
   return remaining;
-}
-
-async function awaitHeadlessDeadline<T>(params: {
-  promise: Promise<T>;
-  deadline: number;
-  signal?: AbortSignal;
-}): Promise<T> {
-  const remainingMs = remainingHeadlessMs(params.deadline);
-  if (params.signal?.aborted) {
-    throw headlessAbortError(params.signal);
-  }
-  let timer: ReturnType<typeof setTimeout> | undefined;
-  let onAbort: (() => void) | undefined;
-  try {
-    const timeout = new Promise<never>((_resolve, reject) => {
-      timer = setTimeout(() => reject(new CodeModeHeadlessTimeoutError()), remainingMs);
-      const signal = params.signal;
-      if (signal) {
-        onAbort = () => reject(headlessAbortError(signal));
-        signal.addEventListener("abort", onAbort, { once: true });
-      }
-    });
-    return await Promise.race([params.promise, timeout]);
-  } finally {
-    if (timer) {
-      clearTimeout(timer);
-    }
-    if (params.signal && onAbort) {
-      params.signal.removeEventListener("abort", onAbort);
-    }
-  }
 }
 
 async function runHeadlessWorkerLeg(params: {
@@ -252,10 +222,12 @@ export async function runCodeModeScriptHeadless(params: {
     const catalog = runtime.all({ includeMcp: false });
     const namespaceCatalog = runtime.namespaceEntries();
     const namespaceRuntime = createCodeModeNamespaceRuntime(namespaceCatalog);
-    const preparedSource = await awaitHeadlessDeadline({
-      promise: prepareSource({ code: params.code, language: params.language, config }),
-      deadline,
+    const preparedSource = await awaitCodeModeDeadline({
+      operation: () => prepareSource({ code: params.code, language: params.language, config }),
+      deadlineMs: deadline,
       signal: abortScope.signal,
+      createTimeoutError: () => new CodeModeHeadlessTimeoutError(),
+      createAbortError: headlessAbortError,
     });
     const namespaces = mergeHeadlessNamespaces(
       namespaceRuntime.descriptors,
@@ -337,10 +309,12 @@ export async function runCodeModeScriptHeadless(params: {
           toolCallCount,
         });
       }
-      await awaitHeadlessDeadline({
-        promise: waitForPendingBridgeSettlement(pending, result.settlementMode),
-        deadline,
+      await awaitCodeModeDeadline({
+        operation: () => waitForPendingBridgeSettlement(pending, result.settlementMode),
+        deadlineMs: deadline,
         signal: abortScope.signal,
+        createTimeoutError: () => new CodeModeHeadlessTimeoutError(),
+        createAbortError: headlessAbortError,
       });
       const settledRequests = settledBridgeRequestsInCompletionOrder(pending);
       pending = pending.filter((entry) => !entry.settled);

--- a/src/agents/code-mode-runtime.test.ts
+++ b/src/agents/code-mode-runtime.test.ts
@@ -1,11 +1,53 @@
 import { describe, expect, it } from "vitest";
 import {
+  enforceOutputLimit,
+  enforceResultLimit,
   isCodeModeEngagedForModel,
   prepareSource,
   resolveCodeModeConfig,
 } from "./code-mode-runtime.js";
 
 const config = resolveCodeModeConfig({ tools: { codeMode: true } } as never);
+
+describe("Code Mode output accounting", () => {
+  it("accepts Unicode output at its exact serialized byte limit", () => {
+    const output = [{ type: "text", text: "😀 café" }];
+    const maxOutputBytes = Buffer.byteLength(JSON.stringify(output), "utf8");
+
+    expect(() => enforceOutputLimit(output, { ...config, maxOutputBytes })).not.toThrow();
+    expect(() =>
+      enforceOutputLimit(output, { ...config, maxOutputBytes: maxOutputBytes - 1 }),
+    ).toThrow("code mode output limit exceeded");
+  });
+
+  it("counts serialized output only once against the returned value", () => {
+    const output = [{ type: "text", text: "😀" }];
+    const value = { result: "café" };
+    const maxOutputBytes =
+      Buffer.byteLength(JSON.stringify(output), "utf8") +
+      Buffer.byteLength(JSON.stringify(value), "utf8");
+
+    expect(() =>
+      enforceResultLimit({ output, value, config: { ...config, maxOutputBytes } }),
+    ).not.toThrow();
+    expect(() =>
+      enforceResultLimit({
+        output,
+        value,
+        config: { ...config, maxOutputBytes: maxOutputBytes - 1 },
+      }),
+    ).toThrow("code mode output limit exceeded");
+  });
+
+  it("does not charge an empty output array against the returned value", () => {
+    const value = "ok";
+    const maxOutputBytes = Buffer.byteLength(JSON.stringify(value), "utf8");
+
+    expect(() =>
+      enforceResultLimit({ output: [], value, config: { ...config, maxOutputBytes } }),
+    ).not.toThrow();
+  });
+});
 
 describe("Code Mode master switch resolution", () => {
   it.each([

--- a/src/agents/code-mode-runtime.ts
+++ b/src/agents/code-mode-runtime.ts
@@ -92,7 +92,10 @@ export type CodeModeWorkerResult =
 const typescriptRuntimeLoader = createLazyPromiseLoader(() => import("typescript"), {
   cacheRejections: true,
 });
-let typescriptRuntimeForTest: typeof import("typescript") | null = null;
+let typescriptRuntimeForTest:
+  | typeof import("typescript")
+  | Promise<typeof import("typescript")>
+  | null = null;
 
 function normalizeCodeModeRawConfig(value: unknown): Record<string, unknown> | undefined {
   const codeMode = value;
@@ -303,8 +306,11 @@ export function enforceResultLimit(params: {
   value?: unknown;
   config: CodeModeConfig;
 }): void {
-  enforceOutputLimit(params.output, params.config);
-  const outputBytes = params.output.length > 0 ? jsonByteLength(params.output) : 0;
+  const serializedOutputBytes = jsonByteLength(params.output);
+  if (serializedOutputBytes > params.config.maxOutputBytes) {
+    throw new CodeModeLimitError("output_limit_exceeded", "code mode output limit exceeded");
+  }
+  const outputBytes = params.output.length > 0 ? serializedOutputBytes : 0;
   if (
     params.value !== undefined &&
     outputBytes + jsonByteLength(params.value) > params.config.maxOutputBytes
@@ -560,7 +566,7 @@ function rejectsModuleAccess(
 
 async function loadTypeScriptRuntime(): Promise<typeof import("typescript")> {
   if (typescriptRuntimeForTest) {
-    return typescriptRuntimeForTest;
+    return await typescriptRuntimeForTest;
   }
   return await typescriptRuntimeLoader.load();
 }
@@ -644,7 +650,9 @@ export function enforceSnapshotPayloadLimits(params: {
 export const codeModeRuntimeTesting = {
   getTypescriptRuntimePromise: (): Promise<typeof import("typescript")> | null =>
     typescriptRuntimeLoader.peek() ?? null,
-  setTypescriptRuntimeForTest: (runtime: typeof import("typescript") | null) => {
+  setTypescriptRuntimeForTest: (
+    runtime: typeof import("typescript") | Promise<typeof import("typescript")> | null,
+  ) => {
     typescriptRuntimeForTest = runtime;
   },
 };

--- a/src/agents/code-mode-state.ts
+++ b/src/agents/code-mode-state.ts
@@ -181,8 +181,14 @@ function enforceActiveRunLimit(): void {
   }
 }
 
-export function reserveActiveRunSlot(): () => void {
-  enforceActiveRunLimit();
+export function reserveActiveRunSlot(ownedRunId?: string): () => void {
+  if (ownedRunId === undefined) {
+    enforceActiveRunLimit();
+  } else if (!activeRuns.delete(ownedRunId)) {
+    throw new ToolInputError("code mode run is unavailable or expired.");
+  }
+  // Resume transfers an existing slot without exposing a free capacity window
+  // to concurrent exec calls or rejecting its own run at the global limit.
   activeRunReservations += 1;
   let released = false;
   return () => {
@@ -205,6 +211,7 @@ export function snapshotState(params: {
   namespaceRuntime: CodeModeNamespaceRuntime;
   output: unknown[];
   deliveredOutputCount?: number;
+  reservedActiveRunSlot?: boolean;
   replaySafe: boolean;
   settlementMode: CodeModeSettlementMode;
   signal?: AbortSignal;
@@ -261,8 +268,11 @@ function enforceSnapshotStateLimits(params: {
   snapshotBytes: Uint8Array;
   config: CodeModeConfig;
   output: unknown[];
+  reservedActiveRunSlot?: boolean;
 }) {
-  enforceActiveRunLimit();
+  if (!params.reservedActiveRunSlot) {
+    enforceActiveRunLimit();
+  }
   enforceSnapshotPayloadLimits(params);
 }
 

--- a/src/agents/code-mode-worker-lifecycle.test.ts
+++ b/src/agents/code-mode-worker-lifecycle.test.ts
@@ -4,6 +4,7 @@ import { resolveCodeModeConfig, toToolSearchConfig } from "./code-mode-runtime.j
 import {
   activeRuns,
   disposeCodeModeRun,
+  reserveActiveRunSlot,
   storeSnapshotState,
   type PendingBridgeState,
 } from "./code-mode-state.js";
@@ -15,6 +16,7 @@ import {
 } from "./tool-search.js";
 
 const EXPIRING_RUN_ID = "cm_worker_lifecycle_expiry";
+const CAPACITY_RUN_PREFIX = "cm_worker_lifecycle_capacity_";
 
 function parkExpiringRun(method: "callValue" | "agentWait"): ReturnType<typeof vi.fn> {
   const rawConfig = {
@@ -53,10 +55,55 @@ function parkExpiringRun(method: "callValue" | "agentWait"): ReturnType<typeof v
 
 afterEach(() => {
   disposeCodeModeRun(EXPIRING_RUN_ID);
+  for (const runId of activeRuns.keys()) {
+    if (runId.startsWith(CAPACITY_RUN_PREFIX)) {
+      disposeCodeModeRun(runId);
+    }
+  }
   vi.useRealTimers();
 });
 
 describe("Code Mode worker lifecycle", () => {
+  it("transfers a resumed run's slot atomically at the suspended-run limit", () => {
+    parkExpiringRun("callValue");
+    const ownedState = activeRuns.get(EXPIRING_RUN_ID);
+    expect(ownedState).toBeDefined();
+    if (!ownedState) {
+      throw new Error("expected a parked Code Mode run");
+    }
+    for (let index = 0; index < 63; index += 1) {
+      const runId = `${CAPACITY_RUN_PREFIX}${index}`;
+      activeRuns.set(runId, { ...ownedState, runId, pending: [] });
+    }
+
+    const release = reserveActiveRunSlot(EXPIRING_RUN_ID);
+    try {
+      expect(activeRuns.has(EXPIRING_RUN_ID)).toBe(false);
+      expect(activeRuns.size).toBe(63);
+      expect(() => reserveActiveRunSlot()).toThrow("too many suspended code mode runs");
+
+      activeRuns.set(EXPIRING_RUN_ID, ownedState);
+    } finally {
+      release();
+    }
+
+    expect(activeRuns.size).toBe(64);
+    expect(() => reserveActiveRunSlot()).toThrow("too many suspended code mode runs");
+
+    disposeCodeModeRun(`${CAPACITY_RUN_PREFIX}0`);
+    const releaseFreedSlot = reserveActiveRunSlot();
+    releaseFreedSlot();
+  });
+
+  it("rejects an unavailable run without leaking a capacity reservation", () => {
+    expect(() => reserveActiveRunSlot("cm_missing_lifecycle_owner")).toThrow(
+      "code mode run is unavailable or expired",
+    );
+
+    const release = reserveActiveRunSlot();
+    release();
+  });
+
   it("honors an already-aborted execution before starting a worker", async () => {
     const config = resolveCodeModeConfig({ tools: { codeMode: true } } as never);
     const controller = new AbortController();

--- a/src/agents/code-mode.test-support.ts
+++ b/src/agents/code-mode.test-support.ts
@@ -39,6 +39,7 @@ type CodeModeTestApi = {
   activeRuns: Map<
     string,
     {
+      runId: string;
       config: CodeModeConfig;
       expiresAt: number;
       replayId?: string;
@@ -90,7 +91,9 @@ type CodeModeTestApi = {
   ): CodeModeConfig;
   resolveCodeModeWorkerUrl(currentModuleUrl: string): URL;
   getTypescriptRuntimePromise(): Promise<typeof import("typescript")> | null;
-  setTypescriptRuntimeForTest(runtime: typeof import("typescript") | null): void;
+  setTypescriptRuntimeForTest(
+    runtime: typeof import("typescript") | Promise<typeof import("typescript")> | null,
+  ): void;
   setSwarmDepsForTest(overrides?: {
     emitSessionLifecycleEvent?: (event: Record<string, unknown>) => void;
     getSwarmRunByLaunchReplayKey?: (key: string, requesterSessionKey?: string) => unknown;

--- a/src/agents/code-mode.test.ts
+++ b/src/agents/code-mode.test.ts
@@ -681,6 +681,30 @@ describe("Code Mode", () => {
     expect(index).not.toContain("fake_099");
   });
 
+  it("keeps a thousand-tool catalog index deterministic and within its character budget", () => {
+    const { config, catalogRef, tools } = createCodeModeHarness();
+    const catalogTools = Array.from({ length: 1_024 }, (_, index) =>
+      pluginTool(`tool_${index.toString().padStart(4, "0")}`, "Deferred", "catalog-owner"),
+    );
+    const compacted = applyCodeModeCatalog({
+      tools: [...tools, ...catalogTools],
+      config,
+      sessionId: "session-code-mode",
+      sessionKey: "agent:main:main",
+      runId: "run-code-mode",
+      catalogRef,
+    });
+
+    const description = compacted.tools[0]?.description ?? "";
+    const indexStart = description.indexOf("OpenClaw/plugin tool quick index");
+    const index = indexStart >= 0 ? description.slice(indexStart) : "";
+
+    expect(index.length).toBeLessThanOrEqual(8_000);
+    expect(index).toContain('"openclaw:catalog-owner:tool_0000"');
+    expect(index).toContain("additional OpenClaw/plugin tools omitted");
+    expect(index).not.toContain('"openclaw:catalog-owner:tool_1023"');
+  });
+
   it("omits MCP and namespace guidance from the exec schema when the run catalog has neither", () => {
     const { config, catalogRef, tools } = createCodeModeHarness();
     const compacted = applyCodeModeCatalog({
@@ -2743,6 +2767,69 @@ describe("Code Mode", () => {
     expect(stillWaiting.runId).toBe(first.runId);
   });
 
+  it("resumes and reparks a yielding run at the suspended-run capacity limit", async () => {
+    const { config, catalogRef, tools: codeModeTools } = createCodeModeHarness();
+    applyCodeModeCatalog({
+      tools: [...codeModeTools, pluginTool("fake_noop", "Noop")],
+      config,
+      sessionId: "session-code-mode",
+      sessionKey: "agent:main:main",
+      runId: "run-code-mode",
+      catalogRef,
+    });
+
+    const first = resultDetails(
+      await expectDefined(codeModeTools[0], "Code Mode exec test invariant").execute(
+        "code-call-at-capacity",
+        {
+          code: `
+            await yield_control("first");
+            await yield_control("second");
+            return "done";
+          `,
+        },
+      ),
+    );
+    expect(first.status).toBe("waiting");
+    const firstRunId = first.runId;
+    expect(typeof firstRunId).toBe("string");
+    if (typeof firstRunId !== "string") {
+      throw new Error("expected a parked Code Mode run");
+    }
+    const parked = testing.activeRuns.get(firstRunId);
+    expect(parked).toBeDefined();
+    if (!parked) {
+      throw new Error("expected a parked Code Mode snapshot");
+    }
+
+    // Inert snapshots occupy real capacity without starting 63 extra workers.
+    for (let index = 0; index < 63; index += 1) {
+      const runId = `cm_code_mode_capacity_${index}`;
+      testing.activeRuns.set(runId, { ...parked, runId, pending: [] });
+    }
+
+    const second = resultDetails(
+      await expectDefined(codeModeTools[1], "Code Mode wait test invariant").execute(
+        "code-wait-at-capacity",
+        { runId: firstRunId },
+      ),
+    );
+
+    expect(second.status).toBe("waiting");
+    expect(second.reason).toBe("yield");
+    expect(testing.activeRuns.size).toBe(64);
+
+    const completed = resultDetails(
+      await expectDefined(codeModeTools[1], "Code Mode wait test invariant").execute(
+        "code-wait-after-capacity",
+        { runId: second.runId },
+      ),
+    );
+
+    expect(completed).toMatchObject({ status: "completed", value: "done" });
+    expect(testing.activeRuns.size).toBe(63);
+  });
+
   it("reports only unsettled pending tool calls when wait times out", async () => {
     const catalogRef = createToolSearchCatalogRef();
     const config = {
@@ -3247,6 +3334,67 @@ describe("Code Mode", () => {
     expect(typedShell.status).toBe("failed");
     expect(typedShell.code).toBe("invalid_input");
     expect(typedShell.error).toMatch(/JavaScript or TypeScript, not shell commands/);
+    expect(testing.activeRuns.size).toBe(0);
+  });
+
+  it("times out an unfinished TypeScript runtime load without starting a worker", async () => {
+    const { config, catalogRef, tools: codeModeTools } = createCodeModeHarness();
+    (config as { tools: { codeMode: unknown } }).tools.codeMode = {
+      enabled: true,
+      timeoutMs: 100,
+    };
+    applyCodeModeCatalog({
+      tools: [...codeModeTools, pluginTool("fake_noop", "Noop")],
+      config,
+      sessionId: "session-code-mode",
+      sessionKey: "agent:main:main",
+      runId: "run-code-mode",
+      catalogRef,
+    });
+    testing.setTypescriptRuntimeForTest(new Promise<typeof import("typescript")>(() => {}));
+
+    const result = resultDetails(
+      await expectDefined(codeModeTools[0], "Code Mode exec test invariant").execute(
+        "code-call-typescript-load-timeout",
+        { code: "return 42;", language: "typescript" },
+      ),
+    );
+
+    expect(result).toMatchObject({
+      status: "failed",
+      code: "timeout",
+      error: "code mode timeout exceeded",
+      output: [],
+    });
+    expect(testing.activeRuns.size).toBe(0);
+  });
+
+  it("aborts an unfinished TypeScript runtime load without starting a worker", async () => {
+    const { config, catalogRef, tools: codeModeTools } = createCodeModeHarness();
+    applyCodeModeCatalog({
+      tools: [...codeModeTools, pluginTool("fake_noop", "Noop")],
+      config,
+      sessionId: "session-code-mode",
+      sessionKey: "agent:main:main",
+      runId: "run-code-mode",
+      catalogRef,
+    });
+    testing.setTypescriptRuntimeForTest(new Promise<typeof import("typescript")>(() => {}));
+    const controller = new AbortController();
+    const resultPromise = expectDefined(codeModeTools[0], "Code Mode exec test invariant").execute(
+      "code-call-typescript-load-abort",
+      { code: "return 42;", language: "typescript" },
+      controller.signal,
+    );
+
+    controller.abort();
+
+    expect(resultDetails(await resultPromise)).toMatchObject({
+      status: "failed",
+      code: "aborted",
+      error: "code mode execution aborted",
+      output: [],
+    });
     expect(testing.activeRuns.size).toBe(0);
   });
 

--- a/src/agents/code-mode.ts
+++ b/src/agents/code-mode.ts
@@ -70,20 +70,26 @@ type CodeModeToolContext = ToolSearchToolContext;
 
 const MAX_CODE_MODE_CATALOG_INDEX_CHARS = 8_000;
 
+const CODE_MODE_CATALOG_INDEX_HEADING = [
+  "OpenClaw/plugin tool quick index (exact ids; descriptions are intentionally deferred):",
+  "Each line is `id input -> output`; `-> ?` means unknown.",
+  "OUTPUT DECLARED RULE: use declared fields for dependent calls in the first exec.",
+  "OUTPUT UNKNOWN RULE: return the raw tool value unchanged; inspect or map it only in a later exec.",
+].join("\n");
+
+function codeModeCatalogIndexFooter(included: number, total: number): string {
+  const omitted = total - included;
+  return omitted > 0
+    ? `${omitted} additional OpenClaw/plugin tools omitted from this prompt index. Use ALL_TOOLS or tools.search inside exec to find them.`
+    : "Use these exact ids with tools.callValue; use ALL_TOOLS or tools.search inside exec when lookup is ambiguous.";
+}
+
 function renderCodeModeCatalogIndex(lines: readonly string[], total: number): string {
-  const omitted = total - lines.length;
-  const footer =
-    omitted > 0
-      ? `${omitted} additional OpenClaw/plugin tools omitted from this prompt index. Use ALL_TOOLS or tools.search inside exec to find them.`
-      : "Use these exact ids with tools.callValue; use ALL_TOOLS or tools.search inside exec when lookup is ambiguous.";
   return [
-    "OpenClaw/plugin tool quick index (exact ids; descriptions are intentionally deferred):",
-    "Each line is `id input -> output`; `-> ?` means unknown.",
-    "OUTPUT DECLARED RULE: use declared fields for dependent calls in the first exec.",
-    "OUTPUT UNKNOWN RULE: return the raw tool value unchanged; inspect or map it only in a later exec.",
+    CODE_MODE_CATALOG_INDEX_HEADING,
     ...lines,
     "",
-    footer,
+    codeModeCatalogIndexFooter(lines.length, total),
   ].join("\n");
 }
 
@@ -115,12 +121,17 @@ function formatCodeModeCatalogIndex(catalog: readonly ToolSearchCatalogEntry[]):
   // entries stay discoverable through ALL_TOOLS, and the stable input order
   // keeps prompt bytes deterministic for provider caches.
   const included: string[] = [];
+  let includedLineLength = 0;
   for (const line of lines) {
-    if (
-      renderCodeModeCatalogIndex([...included, line], lines.length).length <=
-      MAX_CODE_MODE_CATALOG_INDEX_CHARS
-    ) {
+    const candidateLineLength = includedLineLength + 1 + line.length;
+    const candidateLength =
+      CODE_MODE_CATALOG_INDEX_HEADING.length +
+      candidateLineLength +
+      2 +
+      codeModeCatalogIndexFooter(included.length + 1, lines.length).length;
+    if (candidateLength <= MAX_CODE_MODE_CATALOG_INDEX_CHARS) {
       included.push(line);
+      includedLineLength = candidateLineLength;
     }
   }
   return renderCodeModeCatalogIndex(included, lines.length);


### PR DESCRIPTION
Related: #115213

## What Problem This Solves

Fixes issues where Code Mode users resuming a suspended workflow at the 64-run concurrency limit could lose the run or its outstanding tool calls, and where a TypeScript execution could ignore its configured timeout or cancellation while the compiler was loading. Large plugin catalogs also spent quadratic time repeatedly reconstructing the same bounded model-visible quick index.

## Why This Change Was Made

Atomically transfer a suspended run's existing capacity reservation throughout resume, inline settlement, and re-parking. Share one abortable deadline implementation between normal and headless execution and charge TypeScript preparation against the original guest budget. Build the exact same deterministic 8,000-character catalog index in one linear pass and serialize terminal output only once when enforcing the combined result limit.

This retains per-run worker isolation, existing prompt bytes, the current public config, snapshot/output limits, and the upstream Codex single-observer and cancellation contracts. AI-assisted; independently autoreviewed before submission.

## User Impact

Concurrent Code Mode workflows reliably resume and complete even when all 64 suspension slots are occupied. Cancelled or expired TypeScript requests return promptly without launching or leaking a worker. Large plugin catalogs retain the identical visible index while constructing it substantially faster.

## Evidence

- Remote Linux/Node real-worker proof: all eight Code Mode test files passed, **589 tests**, covering QuickJS-WASI execution, lifecycle, full-capacity re-parking, concurrent workers, headless mode, swarm, MCP, nodes, exact-once output, byte/output/snapshot caps, and caller aborts.
- The Linux runtime stress tests include more than **130,000** adversarial JavaScript/TypeScript module-access, Unicode, regular-expression, and parser inputs.
- New deterministic regressions prove that unfinished normal/headless TypeScript preparation obeys timeout and cancellation without creating a suspended run.
- New integration regression parks all 64 slots, resumes a real guest through another explicit yield, and completes without losing run ownership.
- Byte-identical catalog benchmark, including an intentionally oversized skipped entry: **90× faster at 1,024 tools** and **82× faster at 2,048 tools**, while preserving exact prompt output and the 8,000-character bound.
- Remote Linux changed-code checks and production build are run against the full 12-file patch before landing.
- Upstream contract inspected directly: `codex-rs/code-mode/src/cell_actor/callbacks.rs` and `codex-rs/code-mode/src/service_contract_tests.rs`.
