### PR TITLE
fix(cli): keep JSON stdout valid through finalization

### DIFF
--- a/src/cli/json-output-mode.ts
+++ b/src/cli/json-output-mode.ts
@@ -18,7 +18,11 @@ export function hasJsonOutputFlag(argv: readonly string[]): boolean {
 export async function withConsoleLogsRoutedToStderrForJson<T>(
   argv: readonly string[],
   run: () => Promise<T>,
-  options: { machineOutput?: boolean; restoreChanges?: boolean } = {},
+  options: {
+    machineOutput?: boolean;
+    restoreChanges?: boolean;
+    retainRoutingUntilProcessExit?: boolean;
+  } = {},
 ): Promise<T> {
   const forceStderr = hasJsonOutputFlag(argv) || options.machineOutput;
   if (!forceStderr && !options.restoreChanges) {
@@ -33,9 +37,11 @@ export async function withConsoleLogsRoutedToStderrForJson<T>(
   try {
     return await run();
   } finally {
-    // Restore the process-wide logging switch so nested/serial CLI calls keep their own output mode.
-    loggingState.forceConsoleToStderr = previousForceStderr;
-    loggingState.earlyConsoleRoutingRestore = previousEarlyRestore;
+    if (!options.retainRoutingUntilProcessExit) {
+      // Restore the process-wide logging switch so nested/serial CLI calls keep their own output mode.
+      loggingState.forceConsoleToStderr = previousForceStderr;
+      loggingState.earlyConsoleRoutingRestore = previousEarlyRestore;
+    }
   }
 }
 

--- a/src/cli/run-main.exit.test.ts
+++ b/src/cli/run-main.exit.test.ts
@@ -8,6 +8,7 @@ import { CommanderError } from "commander";
 import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { GATEWAY_SERVICE_RUNTIME_PID_ENV } from "../daemon/constants.js";
 import { loggingState } from "../logging/state.js";
+import { createSubsystemLogger } from "../logging/subsystem.js";
 import { withSecureTestNodeExecPath } from "../secrets/test-node-command.test-support.js";
 import { captureEnv, withEnvAsync } from "../test-utils/env.js";
 import { getGatewayRunRuntimeHooks } from "./gateway-cli/runtime-hooks.js";
@@ -2667,6 +2668,54 @@ describe("runCli exit behavior", () => {
     expect(stderrDuringPluginRegistration).toBe(true);
     expect(stderrDuringParse).toBe(true);
     expect(loggingState.forceConsoleToStderr).toBe(false);
+  });
+
+  it("retains stderr routing for late subsystem logs in one-shot JSON commands", async () => {
+    tryRouteCliMock.mockResolvedValueOnce(false);
+    const stdout: string[] = [];
+    const stderr: string[] = [];
+    const previousRawConsole = loggingState.rawConsole;
+    const previousOverrideSettings = loggingState.overrideSettings;
+    const stdoutWrite = vi.spyOn(process.stdout, "write").mockImplementation(((
+      value: string | Uint8Array,
+    ) => {
+      stdout.push(String(value));
+      return true;
+    }) as typeof process.stdout.write);
+    loggingState.overrideSettings = {
+      level: "silent",
+      consoleLevel: "info",
+      consoleStyle: "compact",
+    };
+    loggingState.rawConsole = {
+      log: (value) => stdout.push(String(value)),
+      info: (value) => stdout.push(String(value)),
+      warn: (value) => stderr.push(String(value)),
+      error: (value) => stderr.push(String(value)),
+    };
+    buildProgramMock.mockReturnValueOnce({
+      commands: [],
+      parseAsync: vi.fn(async () => {
+        process.stdout.write('{"ok":true,"status":"ok"}\n');
+      }),
+    });
+
+    try {
+      await runCli(["node", "openclaw", "agent", "exec", "inspect", "--json"], {
+        retainConsoleRoutingUntilProcessExit: true,
+      });
+      createSubsystemLogger("state/db").info("late migration diagnostic");
+
+      expect(JSON.parse(stdout.join(""))).toEqual({ ok: true, status: "ok" });
+      expect(stderr).toEqual([expect.stringContaining("late migration diagnostic")]);
+      expect(loggingState.forceConsoleToStderr).toBe(true);
+    } finally {
+      stdoutWrite.mockRestore();
+      loggingState.rawConsole = previousRawConsole;
+      loggingState.overrideSettings = previousOverrideSettings;
+      loggingState.forceConsoleToStderr = false;
+      loggingState.earlyConsoleRoutingRestore = null;
+    }
   });
 
   it("routes plugin registration logs for descriptor-declared machine output", async () => {

--- a/src/cli/run-main.ts
+++ b/src/cli/run-main.ts
@@ -1026,6 +1026,7 @@ export async function runCli(
   argv: string[] = process.argv,
   options: {
     additionalStartupTrace?: ReturnType<typeof createGatewayStartupTrace>;
+    retainConsoleRoutingUntilProcessExit?: boolean;
   } = {},
 ) {
   const originalArgv = normalizeWindowsArgv(argv);
@@ -1033,7 +1034,11 @@ export async function runCli(
   return await withConsoleLogsRoutedToStderrForJson(
     originalArgv,
     () => runCliWithPreparedOutputMode(originalArgv, { ...options, builtInMachineOutput }),
-    { machineOutput: builtInMachineOutput, restoreChanges: true },
+    {
+      machineOutput: builtInMachineOutput,
+      restoreChanges: true,
+      retainRoutingUntilProcessExit: options.retainConsoleRoutingUntilProcessExit,
+    },
   );
 }
 

--- a/src/entry.run-main.test.ts
+++ b/src/entry.run-main.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it, vi } from "vitest";
+import { runMainOrRootHelp } from "./entry.js";
+
+describe("entry run-main boundary", () => {
+  it("retains JSON console routing through process finalization", async () => {
+    const runCli = vi.fn(async () => undefined);
+
+    await runMainOrRootHelp(["node", "openclaw", "status"], {
+      loadRunCli: async () => ({ runCli }),
+    });
+
+    expect(runCli).toHaveBeenCalledWith(["node", "openclaw", "status"], {
+      additionalStartupTrace: expect.any(Object),
+      retainConsoleRoutingUntilProcessExit: true,
+    });
+  });
+});

--- a/src/entry.ts
+++ b/src/entry.ts
@@ -291,7 +291,11 @@ async function runMainOrRootHelp(argv: string[]): Promise<void> {
         "run-main-import",
         () => import("./cli/run-main.js"),
       );
-      await runCli(argv, { additionalStartupTrace: gatewayEntryStartupTrace });
+      await runCli(argv, {
+        additionalStartupTrace: gatewayEntryStartupTrace,
+        // Finalizers and process-exit hooks can still emit diagnostics after runCli settles.
+        retainConsoleRoutingUntilProcessExit: true,
+      });
     },
     onError: async (error) => {
       const { loadCliDotEnvForEarlyDiagnostic } = await import("./cli/dotenv.js");

--- a/src/entry.ts
+++ b/src/entry.ts
@@ -269,10 +269,6 @@ export async function tryHandlePrecomputedCommandHelpFastPath(
   }
 }
 
-type RunMainOrRootHelpDeps = {
-  loadRunCli?: () => Promise<Pick<typeof import("./cli/run-main.js"), "runCli">>;
-};
-
 export async function runMainOrRootHelp(
   argv: string[],
   deps: RunMainOrRootHelpDeps = {},
@@ -322,3 +318,7 @@ export async function runMainOrRootHelp(
     },
   });
 }
+
+type RunMainOrRootHelpDeps = {
+  loadRunCli?: () => Promise<Pick<typeof import("./cli/run-main.js"), "runCli">>;
+};

--- a/src/entry.ts
+++ b/src/entry.ts
@@ -269,7 +269,14 @@ export async function tryHandlePrecomputedCommandHelpFastPath(
   }
 }
 
-async function runMainOrRootHelp(argv: string[]): Promise<void> {
+type RunMainOrRootHelpDeps = {
+  loadRunCli?: () => Promise<Pick<typeof import("./cli/run-main.js"), "runCli">>;
+};
+
+export async function runMainOrRootHelp(
+  argv: string[],
+  deps: RunMainOrRootHelpDeps = {},
+): Promise<void> {
   await runCliWithExitFinalization({
     run: async () => {
       if (isNativeHookRelayArgv(argv) && !argv.includes("--help") && !argv.includes("-h")) {
@@ -289,7 +296,7 @@ async function runMainOrRootHelp(argv: string[]): Promise<void> {
       }
       const { runCli } = await gatewayEntryStartupTrace.measure(
         "run-main-import",
-        () => import("./cli/run-main.js"),
+        deps.loadRunCli ?? (() => import("./cli/run-main.js")),
       );
       await runCli(argv, {
         additionalStartupTrace: gatewayEntryStartupTrace,

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -24,6 +24,22 @@ describe("legacy root entry", () => {
     );
 
     await runLegacyCliEntry(["openclaw", "status"], { runCli });
-    expect(runCli).toHaveBeenCalledWith(["openclaw", "status"]);
+    expect(runCli).toHaveBeenCalledWith(["openclaw", "status"], undefined);
+  });
+
+  it("forwards process-lifetime console routing for executable callers", async () => {
+    const runCli = vi.fn(async () => undefined);
+
+    await runLegacyCliEntry(
+      ["openclaw", "agent", "exec", "inspect", "--json"],
+      { runCli },
+      {
+        retainConsoleRoutingUntilProcessExit: true,
+      },
+    );
+
+    expect(runCli).toHaveBeenCalledWith(["openclaw", "agent", "exec", "inspect", "--json"], {
+      retainConsoleRoutingUntilProcessExit: true,
+    });
   });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,7 +15,12 @@ import {
 } from "./infra/unhandled-rejections.js";
 
 type LegacyCliDeps = {
-  runCli: (argv: string[]) => Promise<void>;
+  runCli: (
+    argv: string[],
+    options?: {
+      retainConsoleRoutingUntilProcessExit?: boolean;
+    },
+  ) => Promise<void>;
 };
 
 type LibraryExports = typeof import("./library.js");
@@ -54,9 +59,12 @@ async function loadLegacyCliDeps(): Promise<LegacyCliDeps> {
 export async function runLegacyCliEntry(
   argv: string[] = process.argv,
   deps?: LegacyCliDeps,
+  options?: {
+    retainConsoleRoutingUntilProcessExit?: boolean;
+  },
 ): Promise<void> {
   const { runCli } = deps ?? (await loadLegacyCliDeps());
-  await runCli(argv);
+  await runCli(argv, options);
 }
 
 const isMain = isMainModule({
@@ -121,7 +129,11 @@ if (isMain) {
   });
 
   void runCliWithExitFinalization({
-    run: async () => await runLegacyCliEntry(process.argv),
+    run: async () =>
+      await runLegacyCliEntry(process.argv, undefined, {
+        // Finalizers and process-exit hooks can still emit diagnostics after runCli settles.
+        retainConsoleRoutingUntilProcessExit: true,
+      }),
     onError: (err) => {
       for (const line of formatCliFailureLines({
         title: "The CLI command failed.",


### PR DESCRIPTION
Closes #115306

## What Problem This Solves

Fixes an issue where users consuming `openclaw ... --json` from a one-shot executable could receive a valid JSON document followed by a late subsystem diagnostic on stdout when finalizers or exit hooks logged after CLI dispatch completed.

## Why This Change Was Made

Executable entry points now retain the resolved JSON console-routing state through process finalization. Programmatic and serial `runCli` callers keep the existing restoration behavior, so the process-lifetime rule is limited to real executable entry paths.

## User Impact

Scripts can parse the complete stdout stream from JSON CLI commands as one document even when late state/database or other subsystem diagnostics occur. Diagnostics remain available on stderr.

## Evidence

- Reproduced on `OpenClaw 2026.7.2 (e05fe2d)` with a successful `agent exec --json` result followed by `[state/db] state database schema migration pending; verifying integrity first`.
- Regression test emits a late subsystem diagnostic after `runCli` resolves and proves stdout remains one parseable JSON document while the diagnostic reaches stderr.
- Focused tests: 201 passed across `src/cli/json-output-mode.test.ts`, `src/cli/run-main.exit.test.ts`, and `src/index.test.ts`.
- Targeted type-aware oxlint: passed.
- Targeted oxfmt and `git diff --check`: passed.
- Fresh autoreview: clean, no actionable findings.
- `check:changed` remote delegation was unavailable because Blacksmith authentication is not configured; trusted-source focused local proof was used per repository policy.
