### PR TITLE
fix(process): keep process exit and cancellation reasons consistent

### DIFF
--- a/src/process/supervisor/supervisor.cancellation-reason.test.ts
+++ b/src/process/supervisor/supervisor.cancellation-reason.test.ts
@@ -1,0 +1,175 @@
+// Active process cancellation must keep one canonical terminal reason.
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../test-utils/deferred.js";
+import { createProcessSupervisor } from "./supervisor.js";
+import type {
+  ProcessSupervisor,
+  SpawnInput,
+  SpawnProcessAdapter,
+  TerminationReason,
+} from "./types.js";
+
+const { createChildAdapterMock, createPtyAdapterMock } = vi.hoisted(() => ({
+  createChildAdapterMock: vi.fn(),
+  createPtyAdapterMock: vi.fn(),
+}));
+
+vi.mock("./adapters/child.js", () => ({
+  createChildAdapter: createChildAdapterMock,
+}));
+
+vi.mock("./adapters/pty.js", () => ({
+  createPtyAdapter: createPtyAdapterMock,
+}));
+
+type CancellationTestAdapter = SpawnProcessAdapter<NodeJS.Signals | null> & {
+  killMock: ReturnType<typeof vi.fn>;
+  disposeMock: ReturnType<typeof vi.fn>;
+  settle: (signal: NodeJS.Signals) => void;
+};
+
+function createCancellationTestAdapter(): CancellationTestAdapter {
+  const completion = createDeferred<{ code: number | null; signal: NodeJS.Signals | null }>();
+  const killMock = vi.fn();
+  const disposeMock = vi.fn();
+
+  return {
+    pid: 4321,
+    onStdout: () => undefined,
+    onStderr: () => undefined,
+    wait: async () => completion.promise,
+    kill: (signal) => killMock(signal),
+    dispose: disposeMock,
+    killMock,
+    disposeMock,
+    settle: (signal) => completion.resolve({ code: null, signal }),
+  };
+}
+
+type CancellationPath = "run-id" | "scope";
+
+function cancelThrough(
+  supervisor: ProcessSupervisor,
+  path: CancellationPath,
+  runId: string,
+  scopeKey: string,
+  reason: TerminationReason,
+): void {
+  if (path === "scope") {
+    supervisor.cancelScope(scopeKey, reason);
+    return;
+  }
+  supervisor.cancel(runId, reason);
+}
+
+const cancellationPaths = [
+  { label: "run ID", first: "run-id", later: "run-id" },
+  { label: "scope", first: "scope", later: "scope" },
+  { label: "run ID followed by scope", first: "run-id", later: "scope" },
+  { label: "scope followed by run ID", first: "scope", later: "run-id" },
+] as const satisfies ReadonlyArray<{
+  label: string;
+  first: CancellationPath;
+  later: CancellationPath;
+}>;
+
+const cancellationReasons = [
+  {
+    firstReason: "manual-cancel",
+    laterReasons: ["overall-timeout", "no-output-timeout", "manual-cancel"],
+  },
+  {
+    firstReason: "overall-timeout",
+    laterReasons: ["manual-cancel", "no-output-timeout", "overall-timeout"],
+  },
+  {
+    firstReason: "no-output-timeout",
+    laterReasons: ["manual-cancel", "overall-timeout", "no-output-timeout"],
+  },
+] as const satisfies ReadonlyArray<{
+  firstReason: TerminationReason;
+  laterReasons: ReadonlyArray<TerminationReason>;
+}>;
+
+describe("process supervisor first cancellation reason", () => {
+  beforeEach(() => {
+    createChildAdapterMock.mockReset();
+    createPtyAdapterMock.mockReset();
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.clearAllTimers();
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  for (const mode of ["child", "pty"] as const) {
+    describe(`${mode} processes`, () => {
+      for (const path of cancellationPaths) {
+        describe(path.label, () => {
+          it.each(cancellationReasons)(
+            "keeps $firstReason after repeated overlapping cancellation",
+            async ({ firstReason, laterReasons }) => {
+              const adapter = createCancellationTestAdapter();
+              const adapterMock = mode === "child" ? createChildAdapterMock : createPtyAdapterMock;
+              adapterMock.mockResolvedValueOnce(adapter);
+
+              const supervisor = createProcessSupervisor();
+              const runId = `first-cancellation-${mode}`;
+              const scopeKey = `scope:first-cancellation-${mode}`;
+              const commonInput = {
+                runId,
+                scopeKey,
+                sessionId: "first-cancellation-reason",
+                backendId: "test",
+              };
+              const input: SpawnInput =
+                mode === "child"
+                  ? { ...commonInput, mode: "child", argv: [process.execPath, "-e", ""] }
+                  : { ...commonInput, mode: "pty", ptyCommand: "printf running" };
+              const run = await supervisor.spawn(input);
+              const exitPromise = run.wait();
+
+              cancelThrough(supervisor, path.first, runId, scopeKey, firstReason);
+              for (const laterReason of laterReasons) {
+                cancelThrough(supervisor, path.later, runId, scopeKey, laterReason);
+                expect(supervisor.getRecord(runId), `after ${laterReason}`).toMatchObject({
+                  state: "exiting",
+                  terminationReason: firstReason,
+                });
+              }
+
+              expect(supervisor.getRecord(runId)).toMatchObject({
+                state: "exiting",
+                terminationReason: firstReason,
+              });
+              expect(adapter.killMock).toHaveBeenCalledTimes(1);
+
+              const signal =
+                process.platform === "win32" && firstReason !== "manual-cancel"
+                  ? "SIGKILL"
+                  : "SIGTERM";
+              expect(adapter.killMock).toHaveBeenCalledWith(signal);
+              adapter.settle(signal);
+
+              await expect(exitPromise).resolves.toMatchObject({
+                reason: firstReason,
+                exitSignal: signal,
+                timedOut: firstReason !== "manual-cancel",
+                noOutputTimedOut: firstReason === "no-output-timeout",
+              });
+              expect(supervisor.getRecord(runId)).toMatchObject({
+                state: "exited",
+                terminationReason: firstReason,
+                exitSignal: signal,
+              });
+              expect(adapter.disposeMock).toHaveBeenCalledTimes(1);
+              expect(vi.getTimerCount()).toBe(0);
+            },
+          );
+        });
+      }
+    });
+  }
+});

--- a/src/process/supervisor/supervisor.ts
+++ b/src/process/supervisor/supervisor.ts
@@ -112,9 +112,6 @@ export function createProcessSupervisor(): ProcessSupervisor {
   const cancel = (runId: string, reason: TerminationReason = "manual-cancel") => {
     const current = active.get(runId);
     if (current) {
-      registry.updateState(runId, "exiting", {
-        terminationReason: reason,
-      });
       current.run.cancel(reason);
       return;
     }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where repeated or competing cancellation of a running process could overwrite its recorded termination reason even though the actual process exit correctly preserved the first cancellation. Baseline: `d44d0d96ad6964acae62afc35e0332ac3633cc2e`.

## Why This Change Was Made

Remove the redundant registry write and let the existing canonical first-cancellation-wins process handler update both the live process and registry. Pending runs, PTY fallback, timeout deadlines, scope replacement, and the public supervisor contract are unchanged.

## User Impact

Process status, timeout diagnosis, cancellation reporting, and process exit results consistently describe the same first terminal event.

## Evidence

- AI-assisted; before the change, **24/24** deterministic regressions failed across child and PTY processes, direct and scope cancellation, and competing reason orderings.
- `node scripts/run-vitest.mjs src/process/supervisor/supervisor.cancellation-reason.test.ts src/process/supervisor/supervisor.queued-cancellation.test.ts src/process/supervisor/supervisor.timeout-overflow.test.ts src/process/supervisor/supervisor.test.ts`: **4 files, 69 tests passed**.
- Regression checks the registry after every competing cancellation, actual `wait()` exit, one process kill, final record, disposal, and no timer leaks.
- Fresh independent autoreview: **clean; no actionable findings**.
- Existing formatter and `git diff --check`: passed.
- Reviewed head: `4267bc6ef3bebe84db073c4fcb66321e86e7728a`.
