### PR TITLE
fix(agents): report embedded deadlines as timeouts

### DIFF
--- a/src/agents/agent-run-terminal-outcome.ts
+++ b/src/agents/agent-run-terminal-outcome.ts
@@ -426,6 +426,31 @@ export type AgentRunTerminalOutcome = {
   endedAt?: number;
 };
 
+/** Carries a canonical terminal outcome when an embedded attempt exits by throwing. */
+export class AgentRunTerminalOutcomeError extends Error {
+  readonly terminalOutcome: AgentRunTerminalOutcome;
+
+  constructor(error: unknown, terminalOutcome: AgentRunTerminalOutcome) {
+    super(error instanceof Error ? error.message : String(error), { cause: error });
+    this.name = "AgentRunTerminalOutcomeError";
+    this.terminalOutcome = terminalOutcome;
+  }
+}
+
+/** Finds a canonical terminal outcome through ordinary error wrapper boundaries. */
+export function findAgentRunTerminalOutcome(error: unknown): AgentRunTerminalOutcome | undefined {
+  let candidate = error;
+  const seen = new Set<object>();
+  while (candidate && typeof candidate === "object" && !seen.has(candidate)) {
+    seen.add(candidate);
+    if (candidate instanceof AgentRunTerminalOutcomeError) {
+      return candidate.terminalOutcome;
+    }
+    candidate = (candidate as { cause?: unknown }).cause;
+  }
+  return undefined;
+}
+
 /** Raw terminal input collected from run wait/liveness/timeout paths. */
 type AgentRunTerminalInput = {
   status: AgentRunWaitStatus;

--- a/src/agents/embedded-agent-runner/run/attempt.abort-race.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.abort-race.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { findAgentRunTerminalOutcome } from "../../agent-run-terminal-outcome.js";
 import {
   cleanupTempPaths,
   createContextEngineAttemptRunner,
@@ -61,5 +62,40 @@ describe("runEmbeddedAttempt abort races", () => {
     expect(hoisted.createAgentSessionMock).not.toHaveBeenCalled();
     expect(prompt).not.toHaveBeenCalled();
     expect(observedSignal).toBe(abortController.signal);
+  });
+
+  it("preserves a run-budget timeout when abort blocks prompt submission", async () => {
+    let releasePendingEvents!: () => void;
+    const pendingEvents = new Promise<void>((resolve) => {
+      releasePendingEvents = resolve;
+    });
+    const baseSubscription = hoisted.subscribeEmbeddedAgentSessionMock();
+    hoisted.subscribeEmbeddedAgentSessionMock.mockImplementation(() => ({
+      ...baseSubscription,
+      waitForPendingEvents: async () => await pendingEvents,
+    }));
+
+    const attempt = createContextEngineAttemptRunner({
+      contextEngine: createContextEngineBootstrapAndAssemble(),
+      sessionKey: "agent:main:telegram:direct:timeout",
+      tempPaths,
+      sessionPrompt: async () => {},
+      attemptOverrides: {
+        timeoutMs: 20,
+        onAttemptTimeout: () => releasePendingEvents(),
+      },
+    });
+
+    const error = await attempt.catch((caught: unknown) => caught);
+
+    expect(error).toMatchObject({
+      message: "attempt aborted before prompt submission",
+    });
+    expect(findAgentRunTerminalOutcome(error)).toMatchObject({
+      reason: "hard_timeout",
+      status: "timeout",
+      timeoutPhase: "provider",
+      providerStarted: true,
+    });
   });
 });

--- a/src/agents/embedded-agent-runner/run/attempt.abort-race.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.abort-race.test.ts
@@ -69,9 +69,12 @@ describe("runEmbeddedAttempt abort races", () => {
     const pendingEvents = new Promise<void>((resolve) => {
       releasePendingEvents = resolve;
     });
-    const baseSubscription = hoisted.subscribeEmbeddedAgentSessionMock();
-    hoisted.subscribeEmbeddedAgentSessionMock.mockImplementation(() => ({
-      ...baseSubscription,
+    const baseSubscribe = hoisted.subscribeEmbeddedAgentSessionMock.getMockImplementation();
+    if (!baseSubscribe) {
+      throw new Error("missing embedded subscription mock");
+    }
+    hoisted.subscribeEmbeddedAgentSessionMock.mockImplementation((params) => ({
+      ...baseSubscribe(params),
       waitForPendingEvents: async () => await pendingEvents,
     }));
 

--- a/src/agents/embedded-agent-runner/run/attempt.spawn-workspace.test-support.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.spawn-workspace.test-support.ts
@@ -605,6 +605,7 @@ vi.mock("../wait-for-idle-before-flush.js", () => ({
 vi.mock("../runs.js", () => ({
   setActiveEmbeddedRun: () => {},
   clearActiveEmbeddedRun: () => {},
+  markActiveEmbeddedRunAbandoned: () => {},
   updateActiveEmbeddedRunSnapshot: () => {},
 }));
 

--- a/src/agents/embedded-agent-runner/run/attempt.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.ts
@@ -7,6 +7,8 @@ import { resolveContextEngineOwnerPluginId } from "../../../context-engine/regis
 import { createBundleLspToolRuntime } from "../../agent-bundle-lsp-runtime.js";
 import { materializeBundleMcpToolsForRun } from "../../agent-bundle-mcp-tools.js";
 import {
+  AgentRunTerminalOutcomeError,
+  buildAgentRunTerminalOutcomeFromAttempt,
   mergeAgentRunAttemptTerminal,
   projectAgentRunAttemptTerminal,
   type AgentRunAttemptTerminal,
@@ -490,6 +492,15 @@ export async function runEmbeddedAttempt(
         }),
       });
     }
+  } catch (error) {
+    const terminalOutcome = buildAgentRunTerminalOutcomeFromAttempt({
+      terminal: executionState.terminal,
+      abortSignal: params.abortSignal,
+    });
+    if (terminalOutcome.status === "timeout") {
+      throw new AgentRunTerminalOutcomeError(error, terminalOutcome);
+    }
+    throw error;
   } finally {
     externalAbortController.dispose();
     clearToolActivityRun(params.runId);

--- a/src/agents/model-fallback-attempt.ts
+++ b/src/agents/model-fallback-attempt.ts
@@ -5,6 +5,7 @@ import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { isCronTerminalAbortReasonText } from "../cron/service/execution-errors.js";
 import { formatErrorMessage, toErrorObject } from "../infra/errors.js";
 import { isCommandLaneTaskTimeoutError } from "../process/command-queue.js";
+import { findAgentRunTerminalOutcome } from "./agent-run-terminal-outcome.js";
 import { isDefaultAgentRuntimeId, normalizeOptionalAgentRuntimeId } from "./agent-runtime-id.js";
 import { externalCliDiscoveryForProviders } from "./auth-profiles/external-cli-discovery.js";
 import type { AuthProfileStore } from "./auth-profiles/types.js";
@@ -213,6 +214,10 @@ function isCallerAbortSignal(signal: AbortSignal | undefined): boolean {
   return signal?.aborted === true;
 }
 
+function isAgentRunTerminalTimeout(err: unknown): boolean {
+  return findAgentRunTerminalOutcome(err)?.status === "timeout";
+}
+
 function buildFallbackSuccess<T>(params: {
   result: T;
   provider: string;
@@ -243,6 +248,7 @@ async function runFallbackCandidate<T>(params: {
     return { ok: true, result };
   } catch (err) {
     if (
+      isAgentRunTerminalTimeout(err) ||
       isCommandLaneTaskTimeoutError(err) ||
       isAgentHarnessPreflightError(err) ||
       isSandboxProvisioningError(err)
@@ -645,6 +651,7 @@ export function shouldDiscardDeferredSessionSuspension(params: {
   return (
     isTerminalAbort(params.abortSignal) ||
     isCallerAbortSignal(params.abortSignal) ||
+    isAgentRunTerminalTimeout(params.error) ||
     isAgentRunDirectAbortReason(params.error) ||
     isAgentRunRestartAbortReason(params.error) ||
     isTerminalAbortFromError(params.error) ||

--- a/src/agents/model-fallback.test.ts
+++ b/src/agents/model-fallback.test.ts
@@ -15,6 +15,7 @@ import { createWarnLogCapture } from "../logging/test-helpers/warn-log-capture.j
 import { setCurrentPluginMetadataSnapshot } from "../plugins/current-plugin-metadata-snapshot.js";
 import { clearCurrentPluginMetadataSnapshot } from "../plugins/current-plugin-metadata-state.js";
 import { loadPluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot.js";
+import { AgentRunTerminalOutcomeError } from "./agent-run-terminal-outcome.js";
 import { AUTH_STORE_VERSION } from "./auth-profiles/constants.js";
 import type { AuthProfileStore } from "./auth-profiles/types.js";
 import { testing as cliBackendsTesting } from "./cli-backends.test-support.js";
@@ -1707,6 +1708,39 @@ describe("runWithModelFallback", () => {
         cfg,
         provider: "openai",
         model: "gpt-4.1-mini",
+        run,
+      }),
+    ).rejects.toBe(timeoutError);
+    expect(run).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not run a second candidate after a canonical hard run timeout", async () => {
+    const cfg = makeCfg({
+      agents: {
+        defaults: {
+          model: {
+            primary: "openai/gpt-5.4",
+            fallbacks: ["anthropic/claude-sonnet-4-6"],
+          },
+        },
+      },
+    });
+    const timeoutError = new AgentRunTerminalOutcomeError(
+      new Error("attempt aborted before prompt submission"),
+      {
+        reason: "hard_timeout",
+        status: "timeout",
+        timeoutPhase: "provider",
+        providerStarted: true,
+      },
+    );
+    const run = vi.fn().mockRejectedValueOnce(timeoutError).mockResolvedValueOnce("too late");
+
+    await expect(
+      runWithModelFallback({
+        cfg,
+        provider: "openai",
+        model: "gpt-5.4",
         run,
       }),
     ).rejects.toBe(timeoutError);

--- a/src/commands/agent-exec.test.ts
+++ b/src/commands/agent-exec.test.ts
@@ -5,6 +5,7 @@ import path from "node:path";
 import { Readable } from "node:stream";
 import { promisify } from "node:util";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { AgentRunTerminalOutcomeError } from "../agents/agent-run-terminal-outcome.js";
 import {
   ensureAuthProfileStore,
   findPersistedAuthProfileCredential,
@@ -234,6 +235,36 @@ describe("agent exec command composition", () => {
     expect(result).toMatchObject({
       exitCode: 2,
       envelope: { status: "timeout", error: { kind: "timeout" } },
+    });
+  });
+
+  it("maps embedded terminal-outcome timeouts to exit code 2", async () => {
+    const { runtime } = createRuntime();
+    const timeout = new AgentRunTerminalOutcomeError(
+      new Error("attempt aborted before prompt submission"),
+      {
+        reason: "hard_timeout",
+        status: "timeout",
+        timeoutPhase: "provider",
+        providerStarted: true,
+      },
+    );
+
+    const result = await agentExecCommand("inspect", { json: true }, runtime, {
+      runAgent: vi.fn(async () => {
+        throw timeout;
+      }),
+    });
+
+    expect(result).toMatchObject({
+      exitCode: 2,
+      envelope: {
+        status: "timeout",
+        error: {
+          kind: "timeout",
+          message: "attempt aborted before prompt submission",
+        },
+      },
     });
   });
 

--- a/src/commands/agent-exec.ts
+++ b/src/commands/agent-exec.ts
@@ -5,6 +5,7 @@ import os from "node:os";
 import path from "node:path";
 import { TextDecoder } from "node:util";
 import { readByteStreamWithLimit } from "@openclaw/media-core/read-byte-stream-with-limit";
+import { findAgentRunTerminalOutcome } from "../agents/agent-run-terminal-outcome.js";
 import type { EmbeddedAgentRunMeta } from "../agents/embedded-agent.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { formatErrorMessage } from "../infra/errors.js";
@@ -329,6 +330,9 @@ function setAgentExecEnvironment(params: {
 }
 
 function isStructuredTimeoutError(error: unknown): boolean {
+  if (findAgentRunTerminalOutcome(error)?.status === "timeout") {
+    return true;
+  }
   let candidate = error;
   for (let depth = 0; depth < 4; depth += 1) {
     if (!candidate || typeof candidate !== "object") {


### PR DESCRIPTION
Closes #115307

## What Problem This Solves

Fixes an issue where users running `agent exec --json` could hit the embedded agent's configured deadline but receive `status: "error"`, `error.kind: "exception"`, and exit code 1 instead of the documented timeout result.

## Why This Change Was Made

The embedded attempt now preserves its canonical terminal outcome when a later abort/session-lock race throws. `agent exec` reads that structured outcome through ordinary error wrappers and maps real embedded deadlines to the existing timeout envelope and exit code 2; non-timeout exceptions keep their prior behavior.

## User Impact

Automation can reliably distinguish embedded timeouts from model, provider, and OpenClaw exceptions. Retry, alerting, and acceptance-matrix logic receive the correct terminal state.

## Evidence

- Live reproduction on `OpenClaw 2026.7.2 (e05fe2d)` logged `embedded run timeout ... timeoutMs=180000`, then returned after 199817 ms as `status: "error"` with `attempt aborted before prompt submission`.
- Abort-race regression proves the thrown error carries `status: "timeout"`, `reason: "hard_timeout"`, and the provider timeout phase.
- Agent-exec regression proves the structured outcome becomes `status: "timeout"`, `error.kind: "timeout"`, and exit code 2.
- Focused tests: 53 passed across terminal-outcome, abort-race, and agent-exec tests.
- Targeted type-aware oxlint: passed.
- Targeted oxfmt and `git diff --check`: passed.
- Fresh autoreview: clean, no actionable findings.
- Broad changed-check delegation is unavailable because Blacksmith authentication is not configured; trusted-source focused local proof was used per repository policy.
