### PR TITLE
fix: prevent changed checks from expanding into full lint

### DIFF
--- a/scripts/check-changed.mjs
+++ b/scripts/check-changed.mjs
@@ -436,6 +436,32 @@ export function createChangedCheckPlan(result, options = {}) {
   };
   const addTypecheck = (name, args) => add(name, args, createSparseTsgoSkipEnv(baseEnv));
   const addLint = (name, args) => add(name, args, baseEnv);
+  const addTargetedLint = (createCommand, lintablePathRe, fallbackName, fallbackArgs) => {
+    const targets = result.paths.filter((changedPath) => lintablePathRe.test(changedPath));
+    const otherPaths = result.paths.filter((changedPath) => !lintablePathRe.test(changedPath));
+    const targetedCommands = [];
+
+    for (let offset = 0; offset < targets.length; offset += TARGETED_LINT_PATH_LIMIT) {
+      const command = createCommand(
+        [...otherPaths, ...targets.slice(offset, offset + TARGETED_LINT_PATH_LIMIT)],
+        baseEnv,
+      );
+      if (!command) {
+        addLint(fallbackName, fallbackArgs);
+        return false;
+      }
+      targetedCommands.push(command);
+    }
+
+    if (targetedCommands.length === 0) {
+      addLint(fallbackName, fallbackArgs);
+      return false;
+    }
+    for (const command of targetedCommands) {
+      addCommand(command.name, command.bin, command.args, command.env);
+    }
+    return true;
+  };
   const addTestTempCreationReport = () => {
     if (!shouldRunTestTempCreationReport(result.paths)) {
       return;
@@ -635,17 +661,9 @@ export function createChangedCheckPlan(result, options = {}) {
   }
 
   if (lanes.core || lanes.coreTests || lanes.ui) {
-    const coreLintCommand = createTargetedCoreLintCommand(result.paths, baseEnv);
-    if (coreLintCommand) {
-      addCommand(
-        coreLintCommand.name,
-        coreLintCommand.bin,
-        coreLintCommand.args,
-        coreLintCommand.env,
-      );
-    } else {
-      addLint("lint core", ["lint:core"]);
-    }
+    addTargetedLint(createTargetedCoreLintCommand, LINTABLE_CORE_PATH_RE, "lint core", [
+      "lint:core",
+    ]);
   }
   if (
     lanes.liveDockerTooling &&
@@ -655,31 +673,21 @@ export function createChangedCheckPlan(result, options = {}) {
     addLint("lint core", ["lint:core"]);
   }
   if (lanes.extensions || lanes.extensionTests) {
-    const extensionLintCommand = createTargetedExtensionLintCommand(result.paths, baseEnv);
-    if (extensionLintCommand) {
-      addCommand(
-        extensionLintCommand.name,
-        extensionLintCommand.bin,
-        extensionLintCommand.args,
-        extensionLintCommand.env,
-      );
-    } else {
-      addLint("lint extensions", ["lint:extensions"]);
-    }
+    addTargetedLint(
+      createTargetedExtensionLintCommand,
+      LINTABLE_EXTENSION_PATH_RE,
+      "lint extensions",
+      ["lint:extensions"],
+    );
   }
   if (lanes.tooling || lanes.liveDockerTooling) {
-    const scriptLintCommand = createTargetedScriptLintCommand(result.paths, baseEnv);
-    if (scriptLintCommand) {
+    if (
+      addTargetedLint(createTargetedScriptLintCommand, LINTABLE_SCRIPT_PATH_RE, "lint scripts", [
+        "lint:scripts",
+      ])
+    ) {
       addLint("lint docker-e2e", ["lint:docker-e2e"]);
       addLint("raw HTTP/2 import guard", ["lint:tmp:no-raw-http2-imports"]);
-      addCommand(
-        scriptLintCommand.name,
-        scriptLintCommand.bin,
-        scriptLintCommand.args,
-        scriptLintCommand.env,
-      );
-    } else {
-      addLint("lint scripts", ["lint:scripts"]);
     }
   }
   if (lanes.apps && shouldSkipAppLintForMissingSwiftlint({ ...options, env: baseEnv })) {
@@ -786,6 +794,9 @@ function createTargetedOxlintCommand({
     paths.some(
       (changedPath) =>
         !lintablePathRe.test(changedPath) &&
+        !LINTABLE_CORE_PATH_RE.test(changedPath) &&
+        !LINTABLE_EXTENSION_PATH_RE.test(changedPath) &&
+        !LINTABLE_SCRIPT_PATH_RE.test(changedPath) &&
         !neutralPathRe.test(changedPath) &&
         !MARKDOWN_LINT_OPTIMIZATION_NEUTRAL_PATH_RE.test(changedPath),
     )

--- a/test/scripts/changed-lanes.test.ts
+++ b/test/scripts/changed-lanes.test.ts
@@ -737,6 +737,101 @@ describe("scripts/changed-lanes", () => {
     });
   });
 
+  it("targets mixed core, extension, and script lint without full-owner fan-out", () => {
+    const result = detectChangedLanes([
+      "src/gateway/node-registry.ts",
+      "extensions/lmstudio/src/models.fetch.ts",
+      "scripts/check-changed.mjs",
+    ]);
+    const plan = createChangedCheckPlan(result, { env: { PATH: "/usr/bin" } });
+
+    expect(plan.commands).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          name: "lint core changed file",
+          args: [
+            "scripts/run-oxlint.mjs",
+            "--tsconfig",
+            "config/tsconfig/oxlint.core.json",
+            "src/gateway/node-registry.ts",
+          ],
+        }),
+        expect.objectContaining({
+          name: "lint extension changed file",
+          args: [
+            "scripts/run-oxlint.mjs",
+            "--tsconfig",
+            "config/tsconfig/oxlint.extensions.json",
+            "extensions/lmstudio/src/models.fetch.ts",
+          ],
+        }),
+        expect.objectContaining({
+          name: "lint script changed file",
+          args: [
+            "scripts/run-oxlint.mjs",
+            "--tsconfig",
+            "config/tsconfig/oxlint.scripts.json",
+            "scripts/check-changed.mjs",
+          ],
+        }),
+      ]),
+    );
+    const commandNames = plan.commands.map((command) => command.args[0]);
+    for (const fullLane of ["lint:core", "lint:extensions", "lint:scripts"]) {
+      expect(commandNames).not.toContain(fullLane);
+    }
+  });
+
+  it.each([
+    {
+      owner: "core",
+      paths: [
+        "src/gateway/node-registry.ts",
+        "src/gateway/node-registry.invoke-stream.ts",
+        "src/gateway/server-methods/nodes.invoke.ts",
+        "src/gateway/server-methods/nodes.invoke-deadline.ts",
+        "src/node-host/runtime.ts",
+        "src/node-host/runner.ts",
+        "src/plugins/provider-self-hosted-setup.ts",
+        "packages/gateway-client/src/timeouts.ts",
+        "packages/normalization-core/src/number-coercion.ts",
+      ],
+      pluralName: "lint core changed files",
+      singularName: "lint core changed file",
+      fullLane: "lint:core",
+    },
+    {
+      owner: "extension",
+      paths: [
+        "extensions/lmstudio/src/embedding-provider.ts",
+        "extensions/lmstudio/src/stream.ts",
+        "extensions/lmstudio/src/api.ts",
+        "extensions/lmstudio/src/models.fetch.ts",
+        "extensions/lmstudio/src/setup.ts",
+        "extensions/lmstudio/src/defaults.ts",
+        "extensions/lmstudio/src/provider-auth.ts",
+        "extensions/lmstudio/src/runtime.ts",
+        "extensions/lmstudio/src/models.ts",
+      ],
+      pluralName: "lint extension changed files",
+      singularName: "lint extension changed file",
+      fullLane: "lint:extensions",
+    },
+  ])("batches broad $owner changes without falling back to full lint", (testCase) => {
+    const result = detectChangedLanes(testCase.paths);
+    const plan = createChangedCheckPlan(result, { env: { PATH: "/usr/bin" } });
+    const commands = plan.commands.filter(
+      (command) => command.name === testCase.pluralName || command.name === testCase.singularName,
+    );
+
+    expect(commands).toHaveLength(2);
+    expect(commands.map((command) => command.args.slice(3).length)).toEqual([8, 1]);
+    expect(commands.flatMap((command) => command.args.slice(3)).toSorted()).toEqual(
+      testCase.paths.toSorted(),
+    );
+    expect(plan.commands.map((command) => command.args[0])).not.toContain(testCase.fullLane);
+  });
+
   it.each([
     {
       name: "routes UI production changes to UI prod and core test lanes",


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where a focused change touching gateway core, local-inference plugins, or scripts triggered full core and plugin lint across thousands of unrelated files. Changing more than eight files in one owner also unnecessarily escalated to a full lint run.

## Why This Change Was Made

Partition changed source paths by their owning lint surface and run each owner in safe batches of at most eight files. Preserve full-owner fallback for deleted files, changed lint configuration, unsupported paths, and other conditions that invalidate targeted proof. Reuse the existing changed-check planner and public lint helper contracts.

## User Impact

Faster and more predictable pull-request checks, lower Testbox resource use, and less risk of remote validation expiring on otherwise narrowly scoped node, gateway, browser, and local-inference fixes. No product configuration or public API changes.

## Evidence

- Blacksmith Testbox tbx_01kymve0arcrtg96gx8xfzc2v9; hosted run https://github.com/openclaw/openclaw/actions/runs/30381867512.
- All 128 changed-lane regression tests passed, including mixed core/plugin/script changes and nine-file owner batching.
- Full Linux changed-file gate passed: formatting, conflict and dependency guards, script declaration contracts, test-root type checking, targeted script lint, Docker boundaries, and raw HTTP/2 checks.
- Independent structured autoreview returned clean with no actionable findings.
- Existing config-change, deleted-file, and broad-helper fallback regressions remain green.