### PR TITLE
fix(agents): prevent cancelled CLI runs from starting

### DIFF
--- a/src/agents/cli-runner/execute-process.ts
+++ b/src/agents/cli-runner/execute-process.ts
@@ -6,7 +6,7 @@ import {
   scopedHeartbeatWakeOptionsForPolicy,
 } from "../../infra/event-session-routing.js";
 import type { CliBackendConfig } from "../../plugins/cli-backend.types.js";
-import type { RunExit } from "../../process/supervisor/types.js";
+import type { ManagedRun, RunExit } from "../../process/supervisor/types.js";
 import {
   createCliJsonlStreamingParser,
   extractCliErrorMessage,
@@ -254,47 +254,61 @@ export async function executeCliProcess(params: {
       backendId: context.backendResolved.id,
       cliSessionId: params.useResume ? params.resolvedSessionId : undefined,
     });
-    const managedRun = await supervisor.spawn({
-      sessionId: runParams.sessionId,
-      backendId: context.backendResolved.id,
-      scopeKey,
-      replaceExistingScope: Boolean(params.useResume && scopeKey),
-      mode: "child",
-      argv: [params.executionCommand, ...params.executionLeadingArgv, ...params.executionArgs],
-      timeoutMs: runParams.timeoutMs,
-      noOutputTimeoutMs: params.noOutputTimeoutMs,
-      cwd: context.cwd ?? context.workspaceDir,
-      env: params.env,
-      input: params.stdin ?? "",
-      secretInput: context.preparedBackend.secretInput,
-      captureOutput: false,
-      onStdout: consumeStdout,
-      onStderr: consumeStderr,
-    });
-    managedRunPid = managedRun.pid;
-    let replyBackendCompleted = false;
-    const replyBackendHandle = runParams.replyOperation
-      ? {
-          kind: "cli" as const,
-          cancel: () => managedRun.cancel("manual-cancel"),
-          isStreaming: () => !replyBackendCompleted,
-        }
-      : undefined;
-    if (replyBackendHandle) {
-      runParams.replyOperation?.attachBackend(replyBackendHandle);
-    }
-    const abortManagedRun = () => managedRun.cancel("manual-cancel");
-    runParams.abortSignal?.addEventListener("abort", abortManagedRun, { once: true });
     if (runParams.abortSignal?.aborted) {
-      abortManagedRun();
+      throw createCliAbortError();
     }
-    try {
-      result = await managedRun.wait();
-    } finally {
-      replyBackendCompleted = true;
-      if (replyBackendHandle) {
-        runParams.replyOperation?.detachBackend(replyBackendHandle);
+    let activeManagedRun: ManagedRun | undefined;
+    // Startup can wait behind another scoped run. Reserve cancellation under
+    // the caller's run id before awaiting the child or replacement fence.
+    const abortManagedRun = () => {
+      if (activeManagedRun) {
+        activeManagedRun.cancel("manual-cancel");
+        return;
       }
+      supervisor.cancel(runParams.runId, "manual-cancel");
+    };
+    runParams.abortSignal?.addEventListener("abort", abortManagedRun, { once: true });
+    try {
+      const managedRun = await supervisor.spawn({
+        runId: runParams.runId,
+        sessionId: runParams.sessionId,
+        backendId: context.backendResolved.id,
+        scopeKey,
+        replaceExistingScope: Boolean(params.useResume && scopeKey),
+        mode: "child",
+        argv: [params.executionCommand, ...params.executionLeadingArgv, ...params.executionArgs],
+        timeoutMs: runParams.timeoutMs,
+        noOutputTimeoutMs: params.noOutputTimeoutMs,
+        cwd: context.cwd ?? context.workspaceDir,
+        env: params.env,
+        input: params.stdin ?? "",
+        secretInput: context.preparedBackend.secretInput,
+        captureOutput: false,
+        onStdout: consumeStdout,
+        onStderr: consumeStderr,
+      });
+      activeManagedRun = managedRun;
+      managedRunPid = managedRun.pid;
+      let replyBackendCompleted = false;
+      const replyBackendHandle = runParams.replyOperation
+        ? {
+            kind: "cli" as const,
+            cancel: () => managedRun.cancel("manual-cancel"),
+            isStreaming: () => !replyBackendCompleted,
+          }
+        : undefined;
+      if (replyBackendHandle) {
+        runParams.replyOperation?.attachBackend(replyBackendHandle);
+      }
+      try {
+        result = await managedRun.wait();
+      } finally {
+        replyBackendCompleted = true;
+        if (replyBackendHandle) {
+          runParams.replyOperation?.detachBackend(replyBackendHandle);
+        }
+      }
+    } finally {
       runParams.abortSignal?.removeEventListener("abort", abortManagedRun);
     }
   }

--- a/src/agents/cli-runner/execute.pending-cancellation.test.ts
+++ b/src/agents/cli-runner/execute.pending-cancellation.test.ts
@@ -1,0 +1,297 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createProcessSupervisor } from "../../process/supervisor/supervisor.js";
+import type { ManagedRun, SpawnProcessAdapter } from "../../process/supervisor/types.js";
+import { createDeferred } from "../../test-utils/deferred.js";
+import { executeDeps } from "./execute-deps.js";
+import { executePreparedCliRun } from "./execute.js";
+import { setCliRunnerExecuteTestDeps } from "./execute.test-support.js";
+import { buildCliSupervisorScopeKey } from "./helpers.js";
+import type { PreparedCliRunContext } from "./types.js";
+
+const { createChildAdapterMock } = vi.hoisted(() => ({
+  createChildAdapterMock:
+    vi.fn<typeof import("../../process/supervisor/adapters/child.js").createChildAdapter>(),
+}));
+
+vi.mock("../../process/supervisor/adapters/child.js", () => ({
+  createChildAdapter: createChildAdapterMock,
+}));
+
+type TestAdapter = SpawnProcessAdapter & {
+  emitStdout: (chunk: string) => void;
+  settle: (code: number | null, signal?: NodeJS.Signals | null) => void;
+};
+
+function createTestAdapter(): TestAdapter {
+  const exit = createDeferred<{ code: number | null; signal: NodeJS.Signals | null }>();
+  let stdoutListener: ((chunk: string) => void) | undefined;
+  const adapter: TestAdapter = {
+    pid: 1234,
+    onStdout: (listener) => {
+      stdoutListener = listener;
+    },
+    onStderr: () => {},
+    wait: async () => await exit.promise,
+    kill: vi.fn((signal?: NodeJS.Signals) => {
+      exit.resolve({ code: null, signal: signal ?? "SIGTERM" });
+    }),
+    dispose: vi.fn(),
+    emitStdout: (chunk) => stdoutListener?.(chunk),
+    settle: (code, signal = null) => exit.resolve({ code, signal }),
+  };
+  return adapter;
+}
+
+function createRunContext(params: {
+  runId: string;
+  signal?: AbortSignal;
+  beforeExecution?: () => Promise<void>;
+}): PreparedCliRunContext {
+  const backend = {
+    command: "agent-cli",
+    args: [],
+    resumeArgs: ["--resume", "{sessionId}"],
+    output: "text" as const,
+    input: "stdin" as const,
+    serialize: true,
+  };
+
+  return {
+    params: {
+      agentId: "main",
+      sessionId: "session-1",
+      sessionKey: "agent:main:main",
+      sessionFile: "/tmp/openclaw-cli-cancellation-test.jsonl",
+      workspaceDir: "/tmp",
+      prompt: "hello",
+      provider: "test-cli",
+      model: "test-model",
+      timeoutMs: 1_000,
+      runId: params.runId,
+      ...(params.signal ? { abortSignal: params.signal } : {}),
+    },
+    started: Date.now(),
+    workspaceDir: "/tmp",
+    backendResolved: {
+      id: "test-cli",
+      config: backend,
+      bundleMcp: false,
+    },
+    preparedBackend: {
+      backend,
+      env: {},
+      ...(params.beforeExecution ? { beforeExecution: params.beforeExecution } : {}),
+    },
+    reusableCliSession: { mode: "none" },
+    hadSessionFile: false,
+    contextEngineConfig: {},
+    modelId: "test-model",
+    normalizedModel: "test-model",
+    systemPrompt: "system",
+    systemPromptReport: {} as PreparedCliRunContext["systemPromptReport"],
+    bootstrapPromptWarningLines: [],
+    authEpochVersion: 2,
+  };
+}
+
+describe("local CLI pending process cancellation", () => {
+  const restoreProcessSupervisor = executeDeps.getProcessSupervisor;
+  let supervisor: ReturnType<typeof createProcessSupervisor>;
+
+  beforeEach(() => {
+    createChildAdapterMock.mockReset();
+    supervisor = createProcessSupervisor();
+    setCliRunnerExecuteTestDeps({ getProcessSupervisor: () => supervisor });
+  });
+
+  afterEach(() => {
+    setCliRunnerExecuteTestDeps({ getProcessSupervisor: restoreProcessSupervisor });
+    vi.restoreAllMocks();
+  });
+
+  it("preserves the caller run id and cleans up cancellation after normal completion", async () => {
+    const controller = new AbortController();
+    const adapter = createTestAdapter();
+    const addListener = vi.spyOn(controller.signal, "addEventListener");
+    const removeListener = vi.spyOn(controller.signal, "removeEventListener");
+    createChildAdapterMock.mockResolvedValueOnce(adapter);
+
+    const run = executePreparedCliRun(
+      createRunContext({ runId: "cli-normal", signal: controller.signal }),
+    );
+    await vi.waitFor(() => {
+      expect(supervisor.getRecord("cli-normal")).toMatchObject({ state: "running" });
+    });
+    adapter.emitStdout("completed");
+    adapter.settle(0);
+
+    await expect(run).resolves.toMatchObject({ text: "completed" });
+    expect(supervisor.getRecord("cli-normal")).toMatchObject({ state: "exited" });
+    const abortListener = addListener.mock.calls.find(([event]) => event === "abort")?.[1];
+    expect(abortListener).toBeTypeOf("function");
+    expect(removeListener).toHaveBeenCalledWith("abort", abortListener);
+  });
+
+  it("cancels a child adapter that is still starting by the caller run id", async () => {
+    const controller = new AbortController();
+    const startup = createDeferred<SpawnProcessAdapter>();
+    const adapter = createTestAdapter();
+    const cancel = vi.spyOn(supervisor, "cancel");
+    createChildAdapterMock.mockReturnValueOnce(startup.promise);
+
+    const run = executePreparedCliRun(
+      createRunContext({ runId: "cli-pending", signal: controller.signal }),
+    );
+    await vi.waitFor(() => {
+      expect(supervisor.getRecord("cli-pending")).toMatchObject({ state: "starting" });
+    });
+
+    controller.abort();
+    expect(cancel).toHaveBeenCalledWith("cli-pending", "manual-cancel");
+    expect(supervisor.getRecord("cli-pending")).toMatchObject({
+      state: "exiting",
+      terminationReason: "manual-cancel",
+    });
+
+    startup.resolve(adapter);
+    await expect(run).rejects.toMatchObject({ name: "AbortError" });
+    expect(adapter.kill).toHaveBeenCalledWith("SIGTERM");
+    expect(supervisor.getRecord("cli-pending")).toMatchObject({
+      state: "exited",
+      terminationReason: "manual-cancel",
+    });
+  });
+
+  it("never starts a resumed replacement cancelled behind a real supervisor scope fence", async () => {
+    const controller = new AbortController();
+    const context = createRunContext({ runId: "cli-resume", signal: controller.signal });
+    const scopeKey = buildCliSupervisorScopeKey({
+      backend: context.preparedBackend.backend,
+      backendId: context.backendResolved.id,
+      cliSessionId: "resume-1",
+    });
+    if (!scopeKey) {
+      throw new Error("Expected the resumed CLI supervisor scope");
+    }
+
+    const firstStartup = createDeferred<SpawnProcessAdapter>();
+    const firstAdapter = createTestAdapter();
+    const cancel = vi.spyOn(supervisor, "cancel");
+    const spawn = vi.spyOn(supervisor, "spawn");
+    createChildAdapterMock.mockReturnValueOnce(firstStartup.promise);
+
+    const first = supervisor.spawn({
+      runId: "cli-existing",
+      sessionId: context.params.sessionId,
+      backendId: context.backendResolved.id,
+      scopeKey,
+      mode: "child",
+      argv: ["agent-cli"],
+    });
+    const replacement = executePreparedCliRun(context, "resume-1");
+
+    await vi.waitFor(() => {
+      expect(spawn).toHaveBeenCalledTimes(2);
+      expect(supervisor.getRecord("cli-existing")).toMatchObject({ state: "starting" });
+      expect(createChildAdapterMock).toHaveBeenCalledOnce();
+    });
+    expect(cancel).not.toHaveBeenCalled();
+    expect(supervisor.getRecord("cli-resume")).toBeUndefined();
+
+    controller.abort();
+    expect(cancel).toHaveBeenCalledWith("cli-resume", "manual-cancel");
+    firstStartup.resolve(firstAdapter);
+
+    const firstRun = await first;
+    await expect(replacement).rejects.toMatchObject({ name: "AbortError" });
+    expect(createChildAdapterMock).toHaveBeenCalledOnce();
+    expect(firstAdapter.kill).not.toHaveBeenCalled();
+    expect(supervisor.getRecord("cli-resume")).toMatchObject({
+      state: "exited",
+      terminationReason: "manual-cancel",
+    });
+
+    firstRun.cancel();
+    await expect(firstRun.wait()).resolves.toMatchObject({ reason: "manual-cancel" });
+  });
+
+  it("does not spawn when the caller is already aborted", async () => {
+    const controller = new AbortController();
+    const spawn = vi.spyOn(supervisor, "spawn");
+    controller.abort();
+
+    await expect(
+      executePreparedCliRun(
+        createRunContext({ runId: "cli-preaborted", signal: controller.signal }),
+      ),
+    ).rejects.toMatchObject({ name: "AbortError" });
+    expect(spawn).not.toHaveBeenCalled();
+    expect(createChildAdapterMock).not.toHaveBeenCalled();
+  });
+
+  it("does not spawn after cancellation during asynchronous backend preparation", async () => {
+    const controller = new AbortController();
+    const preparation = createDeferred();
+    const beforeExecution = vi.fn(async () => await preparation.promise);
+    const spawn = vi.spyOn(supervisor, "spawn");
+    const run = executePreparedCliRun(
+      createRunContext({
+        runId: "cli-preparation",
+        signal: controller.signal,
+        beforeExecution,
+      }),
+    );
+
+    await vi.waitFor(() => expect(beforeExecution).toHaveBeenCalledOnce());
+    controller.abort();
+    preparation.resolve();
+
+    await expect(run).rejects.toMatchObject({ name: "AbortError" });
+    expect(spawn).not.toHaveBeenCalled();
+    expect(createChildAdapterMock).not.toHaveBeenCalled();
+  });
+
+  it("drops an aborted turn waiting behind the serialized CLI run queue", async () => {
+    const firstPreparation = createDeferred();
+    const beforeExecution = vi.fn(async () => await firstPreparation.promise);
+    const firstAdapter = createTestAdapter();
+    createChildAdapterMock.mockResolvedValueOnce(firstAdapter);
+
+    const first = executePreparedCliRun(
+      createRunContext({ runId: "cli-queue-first", beforeExecution }),
+    );
+    await vi.waitFor(() => expect(beforeExecution).toHaveBeenCalledOnce());
+
+    const controller = new AbortController();
+    const second = executePreparedCliRun(
+      createRunContext({ runId: "cli-queue-aborted", signal: controller.signal }),
+    );
+    controller.abort();
+    firstPreparation.resolve();
+
+    await vi.waitFor(() => expect(createChildAdapterMock).toHaveBeenCalledOnce());
+    firstAdapter.emitStdout("first");
+    firstAdapter.settle(0);
+    await expect(first).resolves.toMatchObject({ text: "first" });
+    await expect(second).rejects.toMatchObject({ name: "AbortError" });
+    expect(createChildAdapterMock).toHaveBeenCalledOnce();
+    expect(supervisor.getRecord("cli-queue-aborted")).toBeUndefined();
+  });
+
+  it("removes the startup abort listener when process spawning rejects", async () => {
+    const controller = new AbortController();
+    const addListener = vi.spyOn(controller.signal, "addEventListener");
+    const removeListener = vi.spyOn(controller.signal, "removeEventListener");
+    const spawn = vi.spyOn(supervisor, "spawn").mockRejectedValueOnce(new Error("spawn failed"));
+
+    await expect(
+      executePreparedCliRun(
+        createRunContext({ runId: "cli-spawn-rejection", signal: controller.signal }),
+      ),
+    ).rejects.toThrow("spawn failed");
+    expect(spawn).toHaveBeenCalledWith(expect.objectContaining({ runId: "cli-spawn-rejection" }));
+    const abortListener = addListener.mock.calls.find(([event]) => event === "abort")?.[1];
+    expect(abortListener).toBeTypeOf("function");
+    expect(removeListener).toHaveBeenCalledWith("abort", abortListener);
+  });
+});

--- a/src/agents/cli-runner/execute.pending-cancellation.test.ts
+++ b/src/agents/cli-runner/execute.pending-cancellation.test.ts
@@ -1,6 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createProcessSupervisor } from "../../process/supervisor/supervisor.js";
-import type { ManagedRun, SpawnProcessAdapter } from "../../process/supervisor/types.js";
 import { createDeferred } from "../../test-utils/deferred.js";
 import { executeDeps } from "./execute-deps.js";
 import { executePreparedCliRun } from "./execute.js";
@@ -17,7 +16,11 @@ vi.mock("../../process/supervisor/adapters/child.js", () => ({
   createChildAdapter: createChildAdapterMock,
 }));
 
-type TestAdapter = SpawnProcessAdapter & {
+type ChildAdapter = Awaited<
+  ReturnType<typeof import("../../process/supervisor/adapters/child.js").createChildAdapter>
+>;
+
+type TestAdapter = ChildAdapter & {
   emitStdout: (chunk: string) => void;
   settle: (code: number | null, signal?: NodeJS.Signals | null) => void;
 };
@@ -134,7 +137,7 @@ describe("local CLI pending process cancellation", () => {
 
   it("cancels a child adapter that is still starting by the caller run id", async () => {
     const controller = new AbortController();
-    const startup = createDeferred<SpawnProcessAdapter>();
+    const startup = createDeferred<ChildAdapter>();
     const adapter = createTestAdapter();
     const cancel = vi.spyOn(supervisor, "cancel");
     createChildAdapterMock.mockReturnValueOnce(startup.promise);
@@ -174,7 +177,7 @@ describe("local CLI pending process cancellation", () => {
       throw new Error("Expected the resumed CLI supervisor scope");
     }
 
-    const firstStartup = createDeferred<SpawnProcessAdapter>();
+    const firstStartup = createDeferred<ChildAdapter>();
     const firstAdapter = createTestAdapter();
     const cancel = vi.spyOn(supervisor, "cancel");
     const spawn = vi.spyOn(supervisor, "spawn");

--- a/src/agents/cli-runner/execute.ts
+++ b/src/agents/cli-runner/execute.ts
@@ -292,6 +292,9 @@ export async function executePreparedCliRun(
   };
   const executeAttempt = async (): Promise<CliOutput> => {
     await context.preparedBackend.beforeExecution?.();
+    if (params.abortSignal?.aborted) {
+      throw createCliAbortError();
+    }
     const cliTurnStartedAt = Date.now();
     const restoreSkillEnv = params.skillsSnapshot
       ? applySkillEnvOverridesFromSnapshot({
@@ -516,6 +519,9 @@ export async function executePreparedCliRun(
   };
   try {
     completedOutput = await enqueueCliRun(queueKey, async () => {
+      if (params.abortSignal?.aborted) {
+        throw createCliAbortError();
+      }
       if (params.lifecycleGeneration) {
         assertAgentRunLifecycleGenerationCurrent(params.lifecycleGeneration);
       }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where an already-cancelled CLI agent run could still start or replace a real backend process when cancellation arrived while waiting in the serialized run queue, asynchronous backend preparation, or a pending supervisor spawn. Baseline: `d44d0d96ad6964acae62afc35e0332ac3633cc2e`.

## Why This Change Was Made

Carry the existing caller-owned run identity into supervisor startup, register cancellation before awaiting process admission, and recheck cancellation at the canonical queued-run and backend preparation boundaries. Preserve persistent multi-turn session identity, active-run cleanup, pending scope replacement, reply attachment, and failed-spawn listener cleanup.

## User Impact

Cancelled agent turns cannot unexpectedly start a backend process, replace an existing running process, or emit stale run-start diagnostics after the caller has aborted.

## Evidence

- AI-assisted; new real-supervisor regression on unchanged production: **6 failures, 1 pass**.
- `node scripts/run-vitest.mjs src/agents/cli-runner/execute.pending-cancellation.test.ts src/agents/cli-runner/execute.supervisor-capture.test.ts src/agents/cli-runner.spawn.test.ts src/process/supervisor/supervisor.test.ts`: **4 files, 184 tests passed**.
- Covers deferred adapter startup, cancelled fenced replacement, queued second turn, async `beforeExecution`, already-aborted input, abort listener cleanup when spawn rejects, and successful normal execution.
- Fresh independent structured autoreview for the full change and the exact CI-driven child-adapter type correction: **clean; no actionable findings**.
- Test mocks use the actual `Awaited<ReturnType<typeof createChildAdapter>>` contract; no broad assertions or `any` workarounds.
- Existing formatter and `git diff --check`: passed.
- Reviewed head: `d66b23340231d04531c2b8a7ab652c0df60c1eec`.
