### PR TITLE
fix(agents): warn in read results when the run model cannot see images

### DIFF
--- a/src/agents/agent-tools.read.ts
+++ b/src/agents/agent-tools.read.ts
@@ -881,6 +881,7 @@ type SandboxToolParams = {
   root: string;
   bridge: SandboxFsBridge;
   modelContextWindowTokens?: number;
+  modelSupportsImages?: boolean;
   imageSanitization?: ImageSanitizationLimits;
 };
 
@@ -888,6 +889,7 @@ type SandboxToolParams = {
 export function createSandboxedReadTool(params: SandboxToolParams) {
   const base = createReadTool(params.root, {
     operations: createSandboxReadOperations(params),
+    modelSupportsImages: params.modelSupportsImages,
   }) as unknown as AnyAgentTool;
   return createOpenClawReadTool(base, {
     modelContextWindowTokens: params.modelContextWindowTokens,

--- a/src/agents/agent-tools.ts
+++ b/src/agents/agent-tools.ts
@@ -647,6 +647,7 @@ function createOpenClawCodingToolsInternal(options?: OpenClawCodingToolsOptions)
             root: sandboxRoot,
             bridge: sandboxFsBridge!,
             modelContextWindowTokens: options?.modelContextWindowTokens,
+            modelSupportsImages: options?.modelHasVision,
             imageSanitization,
           });
           const guarded = workspaceOnly
@@ -663,7 +664,9 @@ function createOpenClawCodingToolsInternal(options?: OpenClawCodingToolsOptions)
           );
           continue;
         }
-        const freshReadTool = createReadTool(codingRoot);
+        const freshReadTool = createReadTool(codingRoot, {
+          modelSupportsImages: options?.modelHasVision,
+        });
         const wrapped = createOpenClawReadTool(freshReadTool, {
           modelContextWindowTokens: options?.modelContextWindowTokens,
           imageSanitization,

--- a/src/agents/sessions/tools/read.test.ts
+++ b/src/agents/sessions/tools/read.test.ts
@@ -119,6 +119,49 @@ describe("read tool", () => {
     );
   });
 
+  it("notes the omission when the run model cannot see images", async () => {
+    // Embedded-runner runs never wire an ExtensionContext, so the capability
+    // has to arrive via options; without the note the model only sees a
+    // wire-level placeholder and hallucinates around it.
+    const tempDir = tempDirs.make("openclaw-read-nonvision-");
+    const filePath = path.join(tempDir, "pixel.png");
+    await fs.writeFile(filePath, Buffer.from(ONE_PIXEL_PNG_BASE64, "base64"));
+    const tool = createReadToolDefinition(tempDir, {
+      autoResizeImages: false,
+      modelSupportsImages: false,
+    });
+    const result = await tool.execute(
+      "call-nonvision",
+      { path: filePath },
+      undefined,
+      undefined,
+      {} as never,
+    );
+
+    expect(textContent(result)).toContain("does not support images");
+    expect(result.content.some((part) => part.type === "image")).toBe(true);
+  });
+
+  it("stays quiet when the run model supports images", async () => {
+    const tempDir = tempDirs.make("openclaw-read-vision-");
+    const filePath = path.join(tempDir, "pixel.png");
+    await fs.writeFile(filePath, Buffer.from(ONE_PIXEL_PNG_BASE64, "base64"));
+    const tool = createReadToolDefinition(tempDir, {
+      autoResizeImages: false,
+      modelSupportsImages: true,
+    });
+    const result = await tool.execute(
+      "call-vision",
+      { path: filePath },
+      undefined,
+      undefined,
+      {} as never,
+    );
+
+    expect(textContent(result)).not.toContain("does not support images");
+    expect(result.content.some((part) => part.type === "image")).toBe(true);
+  });
+
   it("shell-quotes the long-first-line fallback path", async () => {
     // The fallback command is shown to the model; quote the path so suggested
     // follow-up commands cannot execute path text as shell syntax.

--- a/src/agents/sessions/tools/read.ts
+++ b/src/agents/sessions/tools/read.ts
@@ -156,6 +156,12 @@ export interface ReadToolOptions {
   autoResizeImages?: boolean;
   /** Custom operations for file reading. Default: local filesystem */
   operations?: ReadOperations;
+  /**
+   * Image-input capability of the run's resolved model. The embedded-runner
+   * path never wires an ExtensionContext, so without this the non-vision note
+   * below can never fire there and the model only gets a wire-level placeholder.
+   */
+  modelSupportsImages?: boolean;
 }
 
 type ReadRenderArgs = { path?: string; file_path?: string; offset?: number; limit?: number };
@@ -188,8 +194,12 @@ function trimTrailingEmptyLines(lines: string[]): string[] {
   return lines.slice(0, end);
 }
 
-function getNonVisionImageNote(model: Model | undefined): string | undefined {
-  if (!model || model.input.includes("image")) {
+function getNonVisionImageNote(
+  model: Model | undefined,
+  modelSupportsImages?: boolean,
+): string | undefined {
+  const supportsImages = modelSupportsImages ?? (model ? model.input.includes("image") : undefined);
+  if (supportsImages !== false) {
     return undefined;
   }
   return "[Current model does not support images. The image will be omitted from this request.]";
@@ -380,7 +390,10 @@ export function createReadToolDefinition(
               : undefined;
             let content: (TextContent | ImageContent)[];
             let truncationDetails: TruncationResult | undefined;
-            const nonVisionImageNote = getNonVisionImageNote(ctx?.model);
+            const nonVisionImageNote = getNonVisionImageNote(
+              ctx?.model,
+              options?.modelSupportsImages,
+            );
             if (mimeType) {
               // Read image as binary.
               const buffer = await ops.readFile(absolutePath);


### PR DESCRIPTION
Addresses #115288.

## What Problem This Solves

When a sub-agent (or any embedded run) resolves to a model without declared image input, the provider boundary swaps image blocks for a generic placeholder on the wire. The read tool already had a guard for exactly this, a note in the tool result telling the model the image will be omitted, but it could never fire in the embedded-runner path: the tool is built by `createOpenClawCodingTools` via `createReadTool`, which wraps the definition without an `ExtensionContext`, so `ctx.model` was always undefined. Weak local models then hallucinate a description around the bare placeholder, which is what the reporter saw.

The attempt already resolves the capability (`modelHasVision` from `attempt.model.input`) and passes it into `createOpenClawCodingTools` for the media factory. This threads the same flag into the read tool, both the plain and the sandboxed construction, so the note fires when the run model lacks image input. The image block still attaches and the existing wire downgrade is unchanged; the note just makes the omission explicit at the exact spot the model reads, instead of silent.

Sessions that wrap tools with a real `ExtensionContext` keep using `ctx.model`; the explicit option only wins when set, so every other construction path behaves as before.

## Evidence

New cases in `read.test.ts` cover both directions: `modelSupportsImages: false` adds the note and keeps the image block, `true` stays quiet. `read.test.ts` 16/16 green across both vitest projects, `agent-tools-agent-config.test.ts` 48/48, oxfmt clean.

Also ran the built tool from the branch through tsx against a real PNG on disk:

```text
modelSupportsImages=false
  text: "Read image file [image/png]\n[Current model does not support images. The image will be omitted from this request.]"
  image block attached: true
modelSupportsImages=true
  text: "Read image file [image/png]"
  image block attached: true
modelSupportsImages=undefined
  text: "Read image file [image/png]"
  image block attached: true
```

Two adjacent findings from the trace, left alone here on purpose: the reporter's ollama model resolved to text-only input because the registry row did not declare modalities (the `input` field on model config exists for that), and whether spawn should inherit the caller's model is a product call for maintainers.
