### PR TITLE
fix(lmstudio): preserve valid local models in mixed catalogs

### DIFF
--- a/extensions/lmstudio/src/models.fetch.ts
+++ b/extensions/lmstudio/src/models.fetch.ts
@@ -93,13 +93,6 @@ async function fetchLmstudioEndpoint(params: {
   };
 }
 
-function asLmstudioModelWire(value: unknown): LmstudioModelWire {
-  if (typeof value !== "object" || value === null || Array.isArray(value)) {
-    throw new Error("LM Studio model list: malformed JSON response");
-  }
-  return value as LmstudioModelWire;
-}
-
 function withResolvedLmstudioModelKey(
   error: unknown,
   resolvedModelKey: string,
@@ -152,10 +145,17 @@ export async function fetchLmstudioModels(params: {
         "LM Studio model list",
         "models",
       );
+      const validModels = models.filter(
+        (model): model is LmstudioModelWire =>
+          typeof model === "object" && model !== null && !Array.isArray(model),
+      );
+      if (models.length > 0 && validModels.length === 0) {
+        throw new Error("LM Studio model list: malformed JSON response");
+      }
       return {
         reachable: true,
         status: response.status,
-        models: models.map(asLmstudioModelWire),
+        models: validModels,
       };
     } finally {
       await release();

--- a/extensions/lmstudio/src/models.test.ts
+++ b/extensions/lmstudio/src/models.test.ts
@@ -632,6 +632,42 @@ describe("lmstudio-models", () => {
     }
   });
 
+  it("keeps valid model records when a reachable catalog includes malformed entries", async () => {
+    const model = {
+      type: "llm",
+      key: "qwen3-8b-instruct",
+      max_context_length: 32_768,
+      loaded_instances: [],
+    };
+    const fetchMock = vi.fn(async () =>
+      jsonResponse({ models: [null, model, [], "invalid-model", 42] }),
+    );
+
+    const result = await fetchLmstudioModels({
+      baseUrl: "http://localhost:1234/v1",
+      fetchImpl: asFetch(fetchMock),
+    });
+
+    expect(result).toEqual({ reachable: true, status: 200, models: [model] });
+  });
+
+  it("discovers valid local models from partially malformed catalogs", async () => {
+    const fetchMock = vi.fn(async () =>
+      jsonResponse({
+        models: [null, { type: "llm", key: "qwen3-8b-instruct" }, []],
+      }),
+    );
+
+    const models = await discoverLmstudioModels({
+      baseUrl: "http://localhost:1234/v1",
+      apiKey: "lm-token",
+      quiet: true,
+      fetchImpl: asFetch(fetchMock),
+    });
+
+    expect(models).toEqual([expect.objectContaining({ id: "qwen3-8b-instruct" })]);
+  });
+
   it("caps oversized direct fetch timeouts before discovering models", async () => {
     const timeoutController = new AbortController();
     const timeoutSpy = vi.spyOn(AbortSignal, "timeout").mockReturnValue(timeoutController.signal);


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where LM Studio users could lose every available local inference model and incorrectly see a running provider as unreachable when its otherwise valid model catalog contained one malformed entry.

## Why This Change Was Made

Filter malformed per-model records at the LM Studio plugin boundary while preserving the existing strict error for completely malformed nonempty catalogs and the existing errors for invalid response envelopes. Keep provider-specific parsing, authentication, and setup inside the owning plugin.

## User Impact

Local model discovery and setup remain usable when a reachable LM Studio server advertises a mixture of valid and malformed records. Completely malformed responses still fail safely. No provider configuration, environment variable, dependency, public SDK contract, or database schema changes.

## Evidence

- Blacksmith Testbox tbx_01kymwdw28kx998w1v5he67czq; remote proof https://github.com/openclaw/openclaw/actions/runs/30383174353.
- All 89 LM Studio discovery and setup tests pass, including new adversarial mixed-catalog fetch and actual provider-discovery regressions.
- Complete Linux changed-file gate passes: plugin formatting and targeted lint, extension and extension-test type checks, SDK API baseline, plugin ownership boundaries, dependency guards, database-first guard, and runtime import cycle check.
- Independent structured autoreview is clean with no actionable findings.
- Physical inference proof was not claimed: the host has an Ollama CLI but no running server or loaded model.