### PR TITLE
feat(gateway): add memory.search operator method

### DIFF
--- a/apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewayProtocol.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewayProtocol.kt
@@ -500,6 +500,7 @@ enum class GatewayMethod(
   SessionsCompanionAsk("sessions.companion.ask"),
   SessionsCompanionState("sessions.companion.state"),
   SessionsCompanionReset("sessions.companion.reset"),
+  MemorySearch("memory.search"),
 }
 
 enum class GatewayEvent(

--- a/src/gateway/methods/core-descriptors.since.test.ts
+++ b/src/gateway/methods/core-descriptors.since.test.ts
@@ -70,6 +70,7 @@ const CURRENT_TRAIN_METHODS = [
   "channels.pairing.dismiss",
   "cron.scratch.get",
   "cron.scratch.set",
+  "memory.search",
 ] as const;
 
 describe("core gateway method release trains", () => {

--- a/src/gateway/methods/core-descriptors.ts
+++ b/src/gateway/methods/core-descriptors.ts
@@ -473,6 +473,7 @@ const CORE_GATEWAY_METHOD_SPECS: readonly CoreGatewayMethodSpec[] = [
     since: "2026.7",
     controlPlaneWrite: true,
   },
+  { name: "memory.search", scope: "operator.read", since: "2026.7" },
 ] as const;
 
 const CORE_GATEWAY_METHOD_SPEC_BY_NAME: ReadonlyMap<string, CoreGatewayMethodSpec> = new Map(

--- a/src/gateway/server-methods-list.test.ts
+++ b/src/gateway/server-methods-list.test.ts
@@ -66,7 +66,7 @@ describe("listGatewayMethods", () => {
   });
 
   it("appends new methods after model probing without shifting older method indices", () => {
-    expect(listGatewayMethods().slice(-24)).toEqual([
+    expect(listGatewayMethods().slice(-25)).toEqual([
       "models.probe",
       "migrations.memory.plan",
       "migrations.memory.apply",
@@ -91,6 +91,7 @@ describe("listGatewayMethods", () => {
       "sessions.companion.ask",
       "sessions.companion.state",
       "sessions.companion.reset",
+      "memory.search",
     ]);
     const methods = listGatewayMethods();
     expect(methods.indexOf("node.pluginSurface.refresh")).toBe(
@@ -151,7 +152,7 @@ describe("listGatewayMethods", () => {
       "exec.approval.get",
     ]);
     expect(methods).toContain("tts.speak");
-    expect(coreMethods.slice(-31)).toEqual([
+    expect(coreMethods.slice(-32)).toEqual([
       "sessions.catalog.continue",
       "sessions.catalog.archive",
       "approval.get",
@@ -183,6 +184,7 @@ describe("listGatewayMethods", () => {
       "sessions.companion.ask",
       "sessions.companion.state",
       "sessions.companion.reset",
+      "memory.search",
     ]);
     expect(methods.indexOf("approval.get")).toBeGreaterThan(methods.indexOf("tts.speak"));
     expect(methods.indexOf("approval.resolve")).toBe(methods.indexOf("approval.get") + 1);

--- a/src/gateway/server-methods.ts
+++ b/src/gateway/server-methods.ts
@@ -161,6 +161,10 @@ const loadLogsHandlers = lazyHandlerModule(
   () => import("./server-methods/logs.js"),
   (module) => module.logsHandlers,
 );
+const loadMemorySearchHandlers = lazyHandlerModule(
+  () => import("./server-methods/memory-search.js"),
+  (module) => module.memorySearchHandlers,
+);
 const loadTerminalHandlers = lazyHandlerModule(
   () => import("./server-methods/terminal.js"),
   (module) => module.terminalHandlers,
@@ -878,6 +882,10 @@ export const coreGatewayHandlers: GatewayRequestHandlers = {
   ...createLazyCoreHandlers({
     methods: ["agents.workspace.list", "agents.workspace.get"],
     loadHandlers: loadAgentsWorkspaceHandlers,
+  }),
+  ...createLazyCoreHandlers({
+    methods: ["memory.search"],
+    loadHandlers: loadMemorySearchHandlers,
   }),
   ...createLazyCoreHandlers({
     methods: ["artifacts.list", "artifacts.get", "artifacts.download"],

--- a/src/gateway/server-methods/memory-search.test.ts
+++ b/src/gateway/server-methods/memory-search.test.ts
@@ -160,6 +160,85 @@ describe("memory.search gateway method", () => {
     expect(manager.close).toHaveBeenCalledOnce();
   });
 
+  it("rejects an unknown agentId without acquiring a manager", async () => {
+    const cfg = createConfig(testState.workspaceDir);
+
+    const respond = await invokeMemorySearch({ query: "lantern", agentId: "invented" }, cfg);
+
+    expect(respond).toHaveBeenCalledWith(
+      false,
+      undefined,
+      expect.objectContaining({
+        code: "INVALID_REQUEST",
+        message: "unknown agentId",
+      }),
+    );
+    expect(getActiveMemorySearchManager).not.toHaveBeenCalled();
+  });
+
+  it("rejects a non-string agentId without acquiring a manager", async () => {
+    const cfg = createConfig(testState.workspaceDir);
+
+    const respond = await invokeMemorySearch({ query: "lantern", agentId: 42 }, cfg);
+
+    expect(respond).toHaveBeenCalledWith(
+      false,
+      undefined,
+      expect.objectContaining({
+        code: "INVALID_REQUEST",
+        message: "agentId must be a string",
+      }),
+    );
+    expect(getActiveMemorySearchManager).not.toHaveBeenCalled();
+  });
+
+  it.each(["   ", "---", "ſ"])(
+    "rejects a normalization-empty agentId without acquiring a manager: %j",
+    async (agentId) => {
+      const cfg = createConfig(testState.workspaceDir);
+
+      const respond = await invokeMemorySearch({ query: "lantern", agentId }, cfg);
+
+      expect(respond).toHaveBeenCalledWith(
+        false,
+        undefined,
+        expect.objectContaining({
+          code: "INVALID_REQUEST",
+          message: "unknown agentId",
+        }),
+      );
+      expect(resolveDefaultAgentId).not.toHaveBeenCalled();
+      expect(getActiveMemorySearchManager).not.toHaveBeenCalled();
+    },
+  );
+
+  it.each([
+    { configured: "research", requested: "Research" },
+    { configured: "_", requested: "_" },
+  ])("searches configured non-default agent $configured", async ({ configured, requested }) => {
+    const cfg = createConfig(testState.workspaceDir);
+    cfg.agents = {
+      ...cfg.agents,
+      list: [{ id: "main", default: true }, { id: configured }],
+    };
+    const manager = createStubManager();
+    getActiveMemorySearchManager.mockResolvedValue({ manager });
+
+    const respond = await invokeMemorySearch({ query: "lantern", agentId: requested }, cfg);
+
+    expect(getActiveMemorySearchManager).toHaveBeenCalledWith({
+      cfg,
+      agentId: configured,
+      purpose: "cli",
+    });
+    expect(resolveDefaultAgentId).not.toHaveBeenCalled();
+    expect(respond).toHaveBeenCalledWith(
+      true,
+      expect.objectContaining({ agentId: configured }),
+      undefined,
+    );
+  });
+
   it("returns unavailable when no memory manager is configured", async () => {
     const cfg: OpenClawConfig = {};
     getActiveMemorySearchManager.mockResolvedValue({

--- a/src/gateway/server-methods/memory-search.test.ts
+++ b/src/gateway/server-methods/memory-search.test.ts
@@ -1,6 +1,7 @@
 import { expectDefined } from "@openclaw/normalization-core";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import type { MemorySearchResult } from "../../memory-host-sdk/host/types.js";
 import {
   createOpenClawTestState,
   type OpenClawTestState,
@@ -53,7 +54,7 @@ async function invokeMemorySearch(params: unknown, cfg: OpenClawConfig) {
 
 function createStubManager() {
   return {
-    search: vi.fn(async () => []),
+    search: vi.fn(async (): Promise<MemorySearchResult[]> => []),
     status: vi.fn(() => ({
       backend: "builtin" as const,
       provider: "none",

--- a/src/gateway/server-methods/memory-search.test.ts
+++ b/src/gateway/server-methods/memory-search.test.ts
@@ -1,8 +1,5 @@
-import fs from "node:fs/promises";
-import path from "node:path";
 import { expectDefined } from "@openclaw/normalization-core";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { getMemorySearchManager } from "../../../extensions/memory-core/runtime-api.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import {
   createOpenClawTestState,
@@ -78,52 +75,6 @@ describe("memory.search gateway method", () => {
 
   afterEach(async () => {
     await testState.cleanup();
-  });
-
-  it("searches a seeded workspace with the native FTS-only manager result shape", async () => {
-    const workspaceDir = await fs.realpath(testState.workspaceDir);
-    const memoryDir = path.join(workspaceDir, "memory");
-    await fs.mkdir(memoryDir, { recursive: true });
-    await fs.writeFile(
-      path.join(memoryDir, "project-lantern.md"),
-      "# Project Lantern\nThe launch window opens at sunrise.\n",
-    );
-    const cfg = createConfig(workspaceDir);
-    const acquired = await getMemorySearchManager({ cfg, agentId: "main", purpose: "cli" });
-    const manager = acquired.manager;
-    if (!manager) {
-      throw new Error(acquired.error ?? "expected seeded memory search manager");
-    }
-    const close = vi.spyOn(manager, "close");
-    getActiveMemorySearchManager.mockResolvedValue({ manager });
-
-    const respond = await invokeMemorySearch({ query: "  sunrise  " }, cfg);
-
-    expect(getActiveMemorySearchManager).toHaveBeenCalledWith({
-      cfg,
-      agentId: "main",
-      purpose: "cli",
-    });
-    expect(respond).toHaveBeenCalledWith(
-      true,
-      {
-        agentId: "main",
-        provider: "none",
-        searchMode: "fts-only",
-        results: [
-          expect.objectContaining({
-            path: "memory/project-lantern.md",
-            startLine: expect.any(Number),
-            endLine: expect.any(Number),
-            score: expect.any(Number),
-            snippet: expect.stringMatching(/sunrise/i),
-            source: "memory",
-          }),
-        ],
-      },
-      undefined,
-    );
-    expect(close).toHaveBeenCalledOnce();
   });
 
   it("rejects a missing or whitespace-only query before acquiring a manager", async () => {
@@ -221,7 +172,16 @@ describe("memory.search gateway method", () => {
       ...cfg.agents,
       list: [{ id: "main", default: true }, { id: configured }],
     };
+    const result = {
+      path: "memory/project-lantern.md",
+      startLine: 2,
+      endLine: 2,
+      score: 0.75,
+      snippet: "The launch window opens at sunrise.",
+      source: "memory" as const,
+    };
     const manager = createStubManager();
+    manager.search.mockResolvedValue([result]);
     getActiveMemorySearchManager.mockResolvedValue({ manager });
 
     const respond = await invokeMemorySearch({ query: "lantern", agentId: requested }, cfg);
@@ -234,7 +194,12 @@ describe("memory.search gateway method", () => {
     expect(resolveDefaultAgentId).not.toHaveBeenCalled();
     expect(respond).toHaveBeenCalledWith(
       true,
-      expect.objectContaining({ agentId: configured }),
+      {
+        agentId: configured,
+        provider: "none",
+        searchMode: "fts-only",
+        results: [result],
+      },
       undefined,
     );
   });

--- a/src/gateway/server-methods/memory-search.test.ts
+++ b/src/gateway/server-methods/memory-search.test.ts
@@ -1,0 +1,182 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { expectDefined } from "@openclaw/normalization-core";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { getMemorySearchManager } from "../../../extensions/memory-core/runtime-api.js";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import {
+  createOpenClawTestState,
+  type OpenClawTestState,
+} from "../../test-utils/openclaw-test-state.js";
+import type { GatewayRequestContext, RespondFn } from "./types.js";
+
+const getActiveMemorySearchManager = vi.hoisted(() => vi.fn());
+const resolveDefaultAgentId = vi.hoisted(() => vi.fn(() => "main"));
+
+vi.mock("../../plugins/memory-runtime.js", () => ({ getActiveMemorySearchManager }));
+vi.mock("../../agents/agent-scope.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../agents/agent-scope.js")>()),
+  resolveDefaultAgentId,
+}));
+
+import { memorySearchHandlers } from "./memory-search.js";
+
+let testState: OpenClawTestState;
+
+function createConfig(workspaceDir: string): OpenClawConfig {
+  return {
+    memory: {
+      search: {
+        provider: "none",
+        query: { minScore: 0 },
+      },
+    },
+    agents: {
+      defaults: { workspace: workspaceDir },
+      list: [{ id: "main", default: true }],
+    },
+  };
+}
+
+async function invokeMemorySearch(params: unknown, cfg: OpenClawConfig) {
+  const respond = vi.fn();
+  await expectDefined(
+    memorySearchHandlers["memory.search"],
+    'memorySearchHandlers["memory.search"] test invariant',
+  )({
+    req: { id: "memory-search-test" } as never,
+    params: params as never,
+    respond: respond as unknown as RespondFn,
+    context: { getRuntimeConfig: () => cfg } as unknown as GatewayRequestContext,
+    client: null,
+    isWebchatConnect: () => false,
+  });
+  return respond;
+}
+
+function createStubManager() {
+  return {
+    search: vi.fn(async () => []),
+    status: vi.fn(() => ({
+      backend: "builtin" as const,
+      provider: "none",
+      custom: { searchMode: "fts-only" },
+    })),
+    close: vi.fn(async () => undefined),
+  };
+}
+
+describe("memory.search gateway method", () => {
+  beforeEach(async () => {
+    testState = await createOpenClawTestState({
+      label: "gateway-memory-search",
+      layout: "state-only",
+    });
+    getActiveMemorySearchManager.mockReset();
+    resolveDefaultAgentId.mockClear();
+  });
+
+  afterEach(async () => {
+    await testState.cleanup();
+  });
+
+  it("searches a seeded workspace with the native FTS-only manager result shape", async () => {
+    const workspaceDir = await fs.realpath(testState.workspaceDir);
+    const memoryDir = path.join(workspaceDir, "memory");
+    await fs.mkdir(memoryDir, { recursive: true });
+    await fs.writeFile(
+      path.join(memoryDir, "project-lantern.md"),
+      "# Project Lantern\nThe launch window opens at sunrise.\n",
+    );
+    const cfg = createConfig(workspaceDir);
+    const acquired = await getMemorySearchManager({ cfg, agentId: "main", purpose: "cli" });
+    const manager = acquired.manager;
+    if (!manager) {
+      throw new Error(acquired.error ?? "expected seeded memory search manager");
+    }
+    const close = vi.spyOn(manager, "close");
+    getActiveMemorySearchManager.mockResolvedValue({ manager });
+
+    const respond = await invokeMemorySearch({ query: "  sunrise  " }, cfg);
+
+    expect(getActiveMemorySearchManager).toHaveBeenCalledWith({
+      cfg,
+      agentId: "main",
+      purpose: "cli",
+    });
+    expect(respond).toHaveBeenCalledWith(
+      true,
+      {
+        agentId: "main",
+        provider: "none",
+        searchMode: "fts-only",
+        results: [
+          expect.objectContaining({
+            path: "memory/project-lantern.md",
+            startLine: expect.any(Number),
+            endLine: expect.any(Number),
+            score: expect.any(Number),
+            snippet: expect.stringMatching(/sunrise/i),
+            source: "memory",
+          }),
+        ],
+      },
+      undefined,
+    );
+    expect(close).toHaveBeenCalledOnce();
+  });
+
+  it("rejects a missing or whitespace-only query before acquiring a manager", async () => {
+    const cfg = createConfig(testState.workspaceDir);
+
+    for (const params of [{}, { query: "   " }]) {
+      const respond = await invokeMemorySearch(params, cfg);
+      expect(respond).toHaveBeenCalledWith(
+        false,
+        undefined,
+        expect.objectContaining({
+          code: "INVALID_REQUEST",
+          message: "query must be a non-empty string",
+        }),
+      );
+    }
+    expect(getActiveMemorySearchManager).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    { requested: 100, expected: 50 },
+    { requested: 0, expected: 1 },
+  ])("clamps maxResults=$requested to $expected", async ({ requested, expected }) => {
+    const cfg = createConfig(testState.workspaceDir);
+    const manager = createStubManager();
+    getActiveMemorySearchManager.mockResolvedValue({ manager });
+
+    await invokeMemorySearch({ query: "lantern", maxResults: requested, minScore: 0.42 }, cfg);
+
+    expect(manager.search).toHaveBeenCalledWith("lantern", {
+      maxResults: expected,
+      minScore: 0.42,
+    });
+    expect(manager.close).toHaveBeenCalledOnce();
+  });
+
+  it("returns unavailable when no memory manager is configured", async () => {
+    const cfg: OpenClawConfig = {};
+    getActiveMemorySearchManager.mockResolvedValue({
+      manager: null,
+      error: "memory plugin unavailable",
+    });
+
+    const respond = await invokeMemorySearch({ query: "lantern" }, cfg);
+
+    expect(resolveDefaultAgentId).toHaveBeenCalledWith(cfg);
+    expect(respond).toHaveBeenCalledWith(
+      false,
+      undefined,
+      expect.objectContaining({
+        code: "UNAVAILABLE",
+        message: "memory plugin unavailable",
+      }),
+    );
+  });
+});

--- a/src/gateway/server-methods/memory-search.ts
+++ b/src/gateway/server-methods/memory-search.ts
@@ -1,0 +1,138 @@
+import { ErrorCodes, errorShape } from "../../../packages/gateway-protocol/src/index.js";
+import { resolveDefaultAgentId } from "../../agents/agent-scope.js";
+import { formatErrorMessage } from "../../infra/errors.js";
+import type {
+  MemoryProviderStatus,
+  MemorySearchManager,
+  MemorySearchResult,
+} from "../../memory-host-sdk/host/types.js";
+import { getActiveMemorySearchManager } from "../../plugins/memory-runtime.js";
+import { normalizeAgentId } from "../../routing/session-key.js";
+import type { GatewayRequestHandlers } from "./types.js";
+
+const DEFAULT_MAX_RESULTS = 20;
+const MAX_RESULTS = 50;
+
+export type MemorySearchResponse = {
+  agentId: string;
+  provider: string;
+  searchMode: "hybrid" | "fts-only";
+  results: MemorySearchResult[];
+};
+
+function resolveSearchMode(status: MemoryProviderStatus): MemorySearchResponse["searchMode"] {
+  const statusMode = status.custom?.searchMode;
+  if (statusMode === "hybrid" || statusMode === "fts-only") {
+    return statusMode;
+  }
+  return status.provider === "none" || status.vector?.enabled === false ? "fts-only" : "hybrid";
+}
+
+function resolveSearchOptions(
+  params: Record<string, unknown>,
+): Parameters<MemorySearchManager["search"]>[1] | null {
+  const rawMaxResults = params.maxResults;
+  if (
+    rawMaxResults !== undefined &&
+    (typeof rawMaxResults !== "number" || !Number.isFinite(rawMaxResults))
+  ) {
+    return null;
+  }
+  const maxResults = Math.min(
+    MAX_RESULTS,
+    Math.max(1, Math.floor(rawMaxResults ?? DEFAULT_MAX_RESULTS)),
+  );
+  const rawMinScore = params.minScore;
+  if (
+    rawMinScore !== undefined &&
+    (typeof rawMinScore !== "number" || !Number.isFinite(rawMinScore))
+  ) {
+    return null;
+  }
+  return {
+    maxResults,
+    ...(rawMinScore === undefined ? {} : { minScore: rawMinScore }),
+  };
+}
+
+/** Operator-scoped search over the active agent memory index. */
+export const memorySearchHandlers: GatewayRequestHandlers = {
+  "memory.search": async ({ params, respond, context }) => {
+    const record = params && typeof params === "object" ? (params as Record<string, unknown>) : {};
+    const query = typeof record.query === "string" ? record.query.trim() : "";
+    if (!query) {
+      respond(
+        false,
+        undefined,
+        errorShape(ErrorCodes.INVALID_REQUEST, "query must be a non-empty string"),
+      );
+      return;
+    }
+    const searchOptions = resolveSearchOptions(record);
+    if (!searchOptions) {
+      respond(
+        false,
+        undefined,
+        errorShape(
+          ErrorCodes.INVALID_REQUEST,
+          "maxResults and minScore must be finite numbers when provided",
+        ),
+      );
+      return;
+    }
+
+    const cfg = context.getRuntimeConfig();
+    const requestedAgentId =
+      typeof record.agentId === "string" ? normalizeAgentId(record.agentId) : null;
+    const agentId = requestedAgentId || resolveDefaultAgentId(cfg);
+    let acquired: Awaited<ReturnType<typeof getActiveMemorySearchManager>>;
+    try {
+      // Use the transient CLI lifecycle so request cleanup cannot close a shared manager.
+      // manager.search owns the same lazy/on-search sync behavior as the existing CLI path.
+      acquired = await getActiveMemorySearchManager({
+        cfg,
+        agentId,
+        purpose: "cli",
+      });
+    } catch (error) {
+      respond(
+        false,
+        undefined,
+        errorShape(
+          ErrorCodes.UNAVAILABLE,
+          `memory search unavailable: ${formatErrorMessage(error)}`,
+        ),
+      );
+      return;
+    }
+    const { manager, error: acquireError } = acquired;
+    if (!manager) {
+      respond(
+        false,
+        undefined,
+        errorShape(ErrorCodes.UNAVAILABLE, acquireError ?? "memory search unavailable"),
+      );
+      return;
+    }
+
+    try {
+      const results = await manager.search(query, searchOptions);
+      const status = manager.status();
+      const payload: MemorySearchResponse = {
+        agentId,
+        provider: status.provider,
+        searchMode: resolveSearchMode(status),
+        results,
+      };
+      respond(true, payload, undefined);
+    } catch (error) {
+      respond(
+        false,
+        undefined,
+        errorShape(ErrorCodes.UNAVAILABLE, `memory search failed: ${formatErrorMessage(error)}`),
+      );
+    } finally {
+      await manager.close?.().catch(() => {});
+    }
+  },
+};

--- a/src/gateway/server-methods/memory-search.ts
+++ b/src/gateway/server-methods/memory-search.ts
@@ -1,5 +1,5 @@
 import { ErrorCodes, errorShape } from "../../../packages/gateway-protocol/src/index.js";
-import { resolveDefaultAgentId } from "../../agents/agent-scope.js";
+import { listAgentIds, resolveDefaultAgentId } from "../../agents/agent-scope.js";
 import { formatErrorMessage } from "../../infra/errors.js";
 import type {
   MemoryProviderStatus,
@@ -55,6 +55,12 @@ function resolveSearchOptions(
   };
 }
 
+function hasUsableAgentIdInput(value: string): boolean {
+  // A valid suffix exposes whether the input contributes any canonical id characters
+  // without allowing normalizeAgentId's empty-input fallback to select `main`.
+  return normalizeAgentId(`${value}a`) !== "a";
+}
+
 /** Operator-scoped search over the active agent memory index. */
 export const memorySearchHandlers: GatewayRequestHandlers = {
   "memory.search": async ({ params, respond, context }) => {
@@ -82,9 +88,22 @@ export const memorySearchHandlers: GatewayRequestHandlers = {
     }
 
     const cfg = context.getRuntimeConfig();
-    const requestedAgentId =
-      typeof record.agentId === "string" ? normalizeAgentId(record.agentId) : null;
-    const agentId = requestedAgentId || resolveDefaultAgentId(cfg);
+    const hasAgentId = Object.hasOwn(record, "agentId");
+    if (hasAgentId && typeof record.agentId !== "string") {
+      respond(false, undefined, errorShape(ErrorCodes.INVALID_REQUEST, "agentId must be a string"));
+      return;
+    }
+    if (hasAgentId && !hasUsableAgentIdInput(record.agentId as string)) {
+      respond(false, undefined, errorShape(ErrorCodes.INVALID_REQUEST, "unknown agentId"));
+      return;
+    }
+    const requestedAgentId = hasAgentId ? normalizeAgentId(record.agentId as string) : null;
+    // Read-scoped input must not bootstrap state or index files for invented agent namespaces.
+    if (requestedAgentId !== null && !listAgentIds(cfg).includes(requestedAgentId)) {
+      respond(false, undefined, errorShape(ErrorCodes.INVALID_REQUEST, "unknown agentId"));
+      return;
+    }
+    const agentId = requestedAgentId ?? resolveDefaultAgentId(cfg);
     let acquired: Awaited<ReturnType<typeof getActiveMemorySearchManager>>;
     try {
       // Use the transient CLI lifecycle so request cleanup cannot close a shared manager.


### PR DESCRIPTION
## What Problem This Solves

The Control UI Memories tab needs an operator-scoped read RPC to search the memory index. Agents already have `memory_search`, and the CLI can search the index, but operators had no gateway method for this workflow.

## Why This Change Was Made

This is part of the Memory settings destination-page program. It follows the existing `wiki.search` and `sessions.search` precedent for domain-specific gateway search methods while keeping the operation read-only and validating any supplied agent ID against configured agents.

## User Impact

There is no user-visible change yet. This enables the upcoming Memories browse tab to search indexed memory through an operator-scoped gateway API.

## Evidence

Focused gateway proof after rebasing onto current `origin/main`:

```text
Test Files  3 passed (3)
Tests       33 passed (33)
[test] passed 1 Vitest shard in 15.86s
```

The method is registered as `operator.read`. It supports FTS-only search without requiring an embedding provider.
