### PR TITLE
fix(usage): prevent Gateway OOM from bloated usage rollups

### DIFF
--- a/src/commands/doctor-usage-cost-cache.test.ts
+++ b/src/commands/doctor-usage-cost-cache.test.ts
@@ -3,11 +3,18 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
+import {
+  closeOpenClawAgentDatabasesForTest,
+  openOpenClawAgentDatabase,
+} from "../state/openclaw-agent-db.js";
+import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
 import { maybeRepairLegacyRuntimeFiles } from "./doctor-usage-cost-cache.js";
 
 let root: string | undefined;
 
 afterEach(async () => {
+  closeOpenClawAgentDatabasesForTest();
+  closeOpenClawStateDatabaseForTest();
   if (root) {
     await fs.rm(root, { recursive: true, force: true });
     root = undefined;
@@ -87,6 +94,36 @@ describe("legacy usage-cost cache cleanup", () => {
 
     await expect(fs.lstat(uploadRoot)).rejects.toMatchObject({ code: "ENOENT" });
     await expect(fs.readFile(path.join(external, "keep.txt"), "utf8")).resolves.toBe("keep");
+  });
+
+  it("removes retired usage rows from every registered agent database", async () => {
+    root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-usage-cost-sqlite-doctor-"));
+    const env = { OPENCLAW_STATE_DIR: root } as NodeJS.ProcessEnv;
+    const databases = ["main", "worker"].map((agentId) =>
+      openOpenClawAgentDatabase({ agentId, env }),
+    );
+    for (const database of databases) {
+      const insert = database.db.prepare(
+        "INSERT INTO cache_entries (scope, key, value_json, blob, expires_at, updated_at) VALUES (?, ?, ?, NULL, NULL, 1)",
+      );
+      insert.run("session-cost-usage-rollup-v1", "retired", '{"pricingFingerprint":"large"}');
+      insert.run("session-cost-usage-rollup-v2", "current", "{}");
+      insert.run("session-cost-usage", "cache", "{}");
+      insert.run("session-cost-usage", "refresh-lock", "{}");
+      insert.run("other", "keep", "{}");
+    }
+
+    await maybeRepairLegacyRuntimeFiles(true, env);
+
+    for (const database of databases) {
+      expect(
+        database.db.prepare("SELECT scope, key FROM cache_entries ORDER BY scope, key").all(),
+      ).toEqual([
+        { key: "keep", scope: "other" },
+        { key: "refresh-lock", scope: "session-cost-usage" },
+        { key: "current", scope: "session-cost-usage-rollup-v2" },
+      ]);
+    }
   });
 });
 

--- a/src/commands/doctor-usage-cost-cache.ts
+++ b/src/commands/doctor-usage-cost-cache.ts
@@ -4,6 +4,8 @@ import os from "node:os";
 import path from "node:path";
 import { note } from "../../packages/terminal-core/src/note.js";
 import { resolveStateDir } from "../config/paths.js";
+import { deleteSessionCostUsageRollupsExcept } from "../infra/session-cost-usage-cache.sqlite.js";
+import { listOpenClawRegisteredAgentDatabases } from "../state/openclaw-agent-db.js";
 import { maybeScrubConfigAuditLog } from "./doctor-config-audit-scrub.js";
 
 const LEGACY_USAGE_COST_TEMP_GRACE_MS = 10_000;
@@ -130,5 +132,18 @@ export async function maybeRepairLegacyRuntimeFiles(
 ): Promise<void> {
   await maybeScrubConfigAuditLog({ shouldRepair, env });
   await maybeRemoveLegacyUsageCostCacheFiles({ shouldRepair, env });
+  if (shouldRepair) {
+    for (const entry of listOpenClawRegisteredAgentDatabases({ env })) {
+      if ((await fs.stat(entry.path).catch(() => null))?.isFile()) {
+        deleteSessionCostUsageRollupsExcept({
+          agentId: entry.agentId,
+          databasePath: entry.path,
+          liveKeys: new Set(),
+          // Doctor retires old scopes only; current v2 rows are not prune candidates.
+          rows: [],
+        });
+      }
+    }
+  }
   await maybeRemoveLegacySkillUploadTree({ shouldRepair, env });
 }

--- a/src/infra/session-cost-usage-aggregation.ts
+++ b/src/infra/session-cost-usage-aggregation.ts
@@ -130,9 +130,10 @@ export function readUsageCostRollups(
   agentId: string,
   pricingFingerprint: string,
   databasePath?: string,
+  rows = readSessionCostUsageRollupRows(agentId, databasePath),
 ): Map<string, UsageCostStoredRollup> {
   const result = new Map<string, UsageCostStoredRollup>();
-  for (const row of readSessionCostUsageRollupRows(agentId, databasePath)) {
+  for (const row of rows) {
     try {
       const entry = normalizeUsageCostRollup(JSON.parse(row.valueJson), pricingFingerprint);
       if (entry) {
@@ -595,7 +596,7 @@ export async function refreshCostUsageCacheForAgent(params: {
     const pricingFingerprint = resolveUsageCostPricingFingerprint(params.config, agentDir);
     const rows = readSessionCostUsageRollupRows(params.agentId, databasePath);
     const rawValues = new Map(rows.map((row) => [row.key, row.valueJson]));
-    const rollups = readUsageCostRollups(params.agentId, pricingFingerprint, databasePath);
+    const rollups = readUsageCostRollups(params.agentId, pricingFingerprint, databasePath, rows);
     const discoveredFiles = await listUsageCountedTranscriptFiles(
       params.agentId,
       params.sessionsDir ? { sessionsDir: params.sessionsDir } : undefined,
@@ -616,6 +617,7 @@ export async function refreshCostUsageCacheForAgent(params: {
       agentId: params.agentId,
       databasePath,
       liveKeys: new Set(files.map((file) => file.filePath)),
+      rows,
     });
 
     const requestedPaths = new Set<string>();

--- a/src/infra/session-cost-usage-cache.sqlite.test.ts
+++ b/src/infra/session-cost-usage-cache.sqlite.test.ts
@@ -101,6 +101,7 @@ describe("session cost usage SQLite cache", () => {
           updatedAt: 1,
         }),
       ).toBe(true);
+      const rows = readSessionCostUsageRollupRows(agentId);
 
       const liveKeys = new (class extends Set<string> {
         override has(key: string): boolean {
@@ -119,10 +120,52 @@ describe("session cost usage SQLite cache", () => {
         }
       })();
 
-      deleteSessionCostUsageRollupsExcept({ agentId, liveKeys });
+      deleteSessionCostUsageRollupsExcept({ agentId, liveKeys, rows });
 
       expect(readSessionCostUsageRollupRows(agentId)).toEqual([
         { key: rollupId, updatedAt: 2, valueJson: refreshedValue },
+      ]);
+    });
+  });
+
+  it("reads only v2 rollups and prunes retired usage cache rows by scope", () => {
+    const stateDir = makeTempDir(tempDirs, "openclaw-usage-cache-retired-");
+
+    withEnv({ OPENCLAW_STATE_DIR: stateDir }, () => {
+      const agentId = "worker-1";
+      expect(
+        writeSessionCostUsageRollup({
+          agentId,
+          rollupId: "current.jsonl",
+          previousValueJson: null,
+          valueJson: '{"version":2}',
+          updatedAt: 2,
+        }),
+      ).toBe(true);
+      const database = openOpenClawAgentDatabase({ agentId });
+      const insert = database.db.prepare(
+        "INSERT INTO cache_entries (scope, key, value_json, blob, expires_at, updated_at) VALUES (?, ?, ?, NULL, NULL, ?)",
+      );
+      insert.run("session-cost-usage-rollup-v1", "retired.jsonl", '{"version":1}', 1);
+      insert.run("session-cost-usage", "cache", "{}", 1);
+      insert.run("session-cost-usage", "refresh-lock", "{}", 1);
+      insert.run("other", "keep", "{}", 1);
+
+      const rows = readSessionCostUsageRollupRows(agentId);
+      expect(rows).toEqual([{ key: "current.jsonl", updatedAt: 2, valueJson: '{"version":2}' }]);
+
+      deleteSessionCostUsageRollupsExcept({
+        agentId,
+        liveKeys: new Set(["current.jsonl"]),
+        rows,
+      });
+
+      expect(
+        database.db.prepare("SELECT scope, key FROM cache_entries ORDER BY scope, key").all(),
+      ).toEqual([
+        { key: "keep", scope: "other" },
+        { key: "refresh-lock", scope: "session-cost-usage" },
+        { key: "current.jsonl", scope: "session-cost-usage-rollup-v2" },
       ]);
     });
   });

--- a/src/infra/session-cost-usage-cache.sqlite.ts
+++ b/src/infra/session-cost-usage-cache.sqlite.ts
@@ -10,7 +10,8 @@ import { isTransientSqliteError } from "./unhandled-rejections.js";
 const LEGACY_CACHE_SCOPE = "session-cost-usage";
 const LEGACY_CACHE_KEY = "cache";
 const REFRESH_LOCK_KEY = "refresh-lock";
-const ROLLUP_SCOPE = "session-cost-usage-rollup-v1";
+const RETIRED_ROLLUP_SCOPE = "session-cost-usage-rollup-v1";
+const ROLLUP_SCOPE = "session-cost-usage-rollup-v2";
 
 type AgentCacheDatabase = Pick<OpenClawAgentKyselyDatabase, "cache_entries">;
 
@@ -177,10 +178,9 @@ export function deleteSessionCostUsageRollupsExcept(params: {
   agentId?: string;
   databasePath?: string;
   liveKeys: ReadonlySet<string>;
+  rows: readonly SessionCostUsageRollupRow[];
 }): void {
-  const existing = readSessionCostUsageRollupRows(params.agentId, params.databasePath).filter(
-    (row) => !params.liveKeys.has(row.key),
-  );
+  const existing = params.rows.filter((row) => !params.liveKeys.has(row.key));
   runOpenClawAgentWriteTransaction(
     (database) => {
       const kysely = getNodeSqliteKysely<AgentCacheDatabase>(database.db);
@@ -201,6 +201,12 @@ export function deleteSessionCostUsageRollupsExcept(params: {
           .deleteFrom("cache_entries")
           .where("scope", "=", LEGACY_CACHE_SCOPE)
           .where("key", "=", LEGACY_CACHE_KEY),
+      );
+      // v1 duplicated a multi-megabyte pricing catalog per row (#115282).
+      // Delete by scope so those values are never materialized during cleanup.
+      executeSqliteQuerySync(
+        database.db,
+        kysely.deleteFrom("cache_entries").where("scope", "=", RETIRED_ROLLUP_SCOPE),
       );
     },
     {

--- a/src/infra/session-cost-usage.test.ts
+++ b/src/infra/session-cost-usage.test.ts
@@ -12,10 +12,15 @@ import {
   upsertSessionEntry,
 } from "../config/sessions/session-accessor.js";
 import type { SessionEntry } from "../config/sessions/types.js";
+import {
+  resetRemoteModelCatalogOverlayForTest,
+  setRemoteModelCatalogOverlaySourcesForTest,
+} from "../model-catalog/remote-overlay.test-support.js";
 import { createSuiteTempRootTracker } from "../test-helpers/temp-dir.js";
 import { withEnvAsync } from "../test-utils/env.js";
 import * as usageFormat from "../utils/usage-format.js";
 import * as formatDatetime from "./format-time/format-datetime.js";
+import { refreshCostUsageCacheForAgent } from "./session-cost-usage-aggregation.js";
 import {
   acquireSessionCostUsageRefreshLock,
   readSessionCostUsageRollupRows,
@@ -642,6 +647,93 @@ describe("session cost usage", () => {
       expect(costSpy.mock.calls.length).toBeLessThanOrEqual(2);
     } finally {
       costSpy.mockRestore();
+    }
+  });
+
+  it("keeps rollup rows bounded with a multi-megabyte hosted pricing catalog", async () => {
+    const root = await makeSessionCostRoot("large-pricing-fingerprint");
+    const sessionsDir = path.join(root, "agents", "main", "sessions");
+    const sessionFile = path.join(sessionsDir, "large-pricing.jsonl");
+    await fs.mkdir(sessionsDir, { recursive: true });
+    await fs.writeFile(
+      sessionFile,
+      JSON.stringify({
+        type: "message",
+        timestamp: "2026-07-28T12:00:00.000Z",
+        message: {
+          role: "assistant",
+          provider: "openai",
+          model: "catalog-model-0",
+          usage: { input: 10, output: 20, totalTokens: 30 },
+        },
+      }),
+      "utf8",
+    );
+    const pricing = Object.fromEntries(
+      Array.from({ length: 40_000 }, (_, index) => [
+        `openai/catalog-model-${index}`,
+        { input: index + 1, output: index + 2, cacheRead: index + 3 },
+      ]),
+    );
+    const bundleJson = JSON.stringify({
+      schemaVersion: 1,
+      generatedAt: 200,
+      minVersion: "2026.7.0",
+      sourceCommit: "large-rollup-pricing-test",
+      providers: {
+        openai: { models: [{ id: "catalog-model-0", cost: { input: 1, output: 2 } }] },
+      },
+      pricing,
+    });
+    expect(Buffer.byteLength(bundleJson)).toBeGreaterThan(2 * 1024 * 1024);
+    setRemoteModelCatalogOverlaySourcesForTest({
+      bundledGeneratedAt: () => 100,
+      readStoredCatalog: () => ({
+        id: 1,
+        source_url: "https://catalog.openclaw.ai/models/v1/catalog.json",
+        bundle_json: bundleJson,
+        generated_at: 200,
+        min_version: "2026.7.0",
+        etag: null,
+        last_modified: null,
+        checked_at: 200,
+      }),
+    });
+    resetRemoteModelCatalogOverlayForTest();
+    const config = {
+      models: {
+        providers: {
+          openai: {
+            baseUrl: "https://api.openai.com/v1",
+            models: [{ id: "catalog-model-0", name: "Catalog model" }],
+          },
+        },
+      },
+    } as unknown as OpenClawConfig;
+
+    try {
+      await withStateDir(root, async () => {
+        const pricingFingerprint = usageFormat.resolveModelCostConfigFingerprint(config);
+        expect(pricingFingerprint).toMatch(/^[0-9a-f]{64}$/u);
+
+        await refreshCostUsageCacheForAgent({
+          agentId: "main",
+          config,
+          sessionFiles: [sessionFile],
+        });
+
+        const row = readSessionCostUsageRollupRows("main").find(
+          (candidate) => candidate.key === sessionFile,
+        );
+        expect(row).toBeDefined();
+        expect(Buffer.byteLength(row?.valueJson ?? "")).toBeLessThan(32 * 1024);
+        expect(JSON.parse(row?.valueJson ?? "null")).toMatchObject({
+          pricingFingerprint,
+        });
+      });
+    } finally {
+      setRemoteModelCatalogOverlaySourcesForTest();
+      resetRemoteModelCatalogOverlayForTest();
     }
   });
 

--- a/src/model-catalog/pricing.test.ts
+++ b/src/model-catalog/pricing.test.ts
@@ -231,4 +231,40 @@ describe("hosted model pricing", () => {
     } as unknown as OpenClawConfig;
     expect(() => resolveModelCostConfigFingerprint(config)).not.toThrow();
   });
+
+  it("bounds fingerprints for multi-megabyte hosted pricing catalogs", () => {
+    const pricing = Object.fromEntries(
+      Array.from({ length: 40_000 }, (_, index) => [
+        `openai/catalog-model-${index}`,
+        { input: index + 1, output: index + 2, cacheRead: index + 3 },
+      ]),
+    );
+    const bundle = {
+      schemaVersion: 1,
+      generatedAt: 200,
+      minVersion: "2026.7.0",
+      sourceCommit: "large-pricing-test",
+      providers: {
+        openai: { models: [{ id: "catalog-model-0", cost: { input: 1, output: 2 } }] },
+      },
+      pricing,
+    };
+    const bundleJson = JSON.stringify(bundle);
+    expect(Buffer.byteLength(bundleJson)).toBeGreaterThan(2 * 1024 * 1024);
+    readStoredCatalog.mockReturnValue({
+      source_url: "https://catalog.openclaw.ai/models/v1/catalog.json",
+      bundle_json: bundleJson,
+    });
+    resetRemoteModelCatalogOverlayForTest();
+
+    const fingerprint = resolveModelCostConfigFingerprint(configFor("https://api.openai.com/v1"));
+    const withoutHostedPricing = configFor("https://api.openai.com/v1");
+    withoutHostedPricing.models = {
+      ...withoutHostedPricing.models,
+      catalogRefresh: { enabled: false },
+    };
+
+    expect(fingerprint).toMatch(/^[0-9a-f]{64}$/u);
+    expect(fingerprint).not.toBe(resolveModelCostConfigFingerprint(withoutHostedPricing));
+  });
 });

--- a/src/utils/usage-format.test.ts
+++ b/src/utils/usage-format.test.ts
@@ -641,6 +641,8 @@ describe("usage-format", () => {
     metadataOnlyModel.cost = { input: 9, output: 8, cacheRead: 7, cacheWrite: 6 };
     const after = resolveModelCostConfigFingerprint(config);
 
+    expect(before).toMatch(/^[0-9a-f]{64}$/u);
+    expect(after).toMatch(/^[0-9a-f]{64}$/u);
     expect(after).not.toBe(before);
     expect(
       resolveModelCostConfig({

--- a/src/utils/usage-format.ts
+++ b/src/utils/usage-format.ts
@@ -2,6 +2,7 @@
  * Shared token/cost formatting and pricing lookup helpers for CLI, TUI, gateway, and status output.
  * Keep this module synchronous; request paths call it while rendering usage summaries.
  */
+import { createHash } from "node:crypto";
 import path from "node:path";
 import { expectDefined } from "@openclaw/normalization-core";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
@@ -529,7 +530,7 @@ export function resolveModelCostConfigFingerprint(
   agentDir?: string,
 ): string {
   const resolvedAgentDir = resolveCostAgentDir(config, agentDir);
-  return stableCostFingerprintValue({
+  const serialized = stableCostFingerprintValue({
     configuredRaw: serializeCostIndex(
       getProviderCostIndex(config?.models?.providers, { allowPluginNormalization: false }),
     ),
@@ -545,6 +546,7 @@ export function resolveModelCostConfigFingerprint(
     ),
     catalogPricing: modelCatalogPricingFingerprint(config),
   });
+  return createHash("sha256").update(serialized).digest("hex");
 }
 
 /**


### PR DESCRIPTION
## What Problem This Solves

Fixes #115282.

OpenClaw 2026.7.2-beta.5 Gateway crashes with V8 heap OOM when opening Control UI Usage/Profile with hundreds of sessions. Each `cache_entries` rollup row in scope `session-cost-usage-rollup-v1` embeds the full ~2.6 MB pricing fingerprint; 645 sessions produce ~2.1 GB, and the reader materializes all rows in one `node:sqlite` `.all()` call.

Lineage: #99511 -> #99714 -> #108834 -> #114060.

## Why This Change Was Made

`resolveModelCostConfigFingerprint` now returns a SHA-256 hex digest because the fingerprint is a compare-only value. The rollup scope is bumped to `session-cost-usage-rollup-v2`, with v1 rows deleted by scope (never selected) in the prune transaction. `openclaw doctor --fix` purges retired v1 and legacy usage-cost rows from every registered agent DB to reclaim disk, and `refreshCostUsageCacheForAgent` now reads the rollup scope once instead of three times.

## User Impact

Usage/Profile no longer crashes the Gateway. Existing bloated databases self-heal on the next usage refresh and can be cleaned immediately with `openclaw doctor --fix`.

## Evidence

- Focused Vitest: `session-cost-usage-cache.sqlite.test.ts` (5 passed).
- Focused Vitest: `session-cost-usage.test.ts` (58 passed), including the new bounded-rollup regression test with a >2 MB synthetic hosted catalog.
- Focused Vitest: `doctor-usage-cost-cache.test.ts` (4 passed).
- Focused Vitest: `usage-format.test.ts` (35 passed).
- Focused Vitest: `pricing.test.ts` (7 passed).
- Path-scoped changed gate green on Testbox `tbx_01kymwcev1xnhant1ghbxev8e0` / Actions run 30383113909.
- Codex autoreview clean.
