### PR TITLE
fix(telegram): media_group album splits into separate agent turns under durable ingress

### DIFF
--- a/extensions/telegram/src/telegram-ingress-drain.test.ts
+++ b/extensions/telegram/src/telegram-ingress-drain.test.ts
@@ -4,7 +4,8 @@ import os from "node:os";
 import path from "node:path";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { createChannelIngressQueueForTests } from "openclaw/plugin-sdk/plugin-state-test-runtime";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
+import { createTelegramSpooledReplayDeferredParticipant } from "./bot-processing-outcome.js";
 import { createTelegramIngressMonitor } from "./telegram-ingress-drain.js";
 import { telegramSpooledUpdateLaneKey } from "./telegram-ingress-spool.js";
 import type { TelegramSpooledUpdatePayload } from "./telegram-ingress-spool.payload.js";
@@ -140,6 +141,69 @@ describe("createTelegramIngressMonitor", () => {
       expect(
         logs.some((line) => line.includes("completed without a recorded processing outcome")),
       ).toBe(true);
+      await monitor.stop();
+    });
+  });
+
+  it("deferred buffered work does not block later same-lane updates (media_group album)", async () => {
+    await withTempState(async (stateDir) => {
+      const queue = createChannelIngressQueueForTests<TelegramSpooledUpdatePayload>({
+        channelId: "telegram",
+        accountId: "default",
+        stateDir,
+      });
+      // Two album members share one chat lane, like updates with one media_group_id.
+      const eventIdA = "10".padStart(16, "0");
+      const eventIdB = "11".padStart(16, "0");
+      const payloadA = updatePayload(10);
+      const payloadB = updatePayload(11);
+      const laneA = telegramSpooledUpdateLaneKey(payloadA.update);
+      const laneB = telegramSpooledUpdateLaneKey(payloadB.update);
+      expect(laneA).toBe(laneB);
+      await queue.enqueue(eventIdA, payloadA, { laneKey: laneA });
+      await queue.enqueue(eventIdB, payloadB, { laneKey: laneB });
+
+      const dispatched: number[] = [];
+      let deferredParticipant: ReturnType<typeof createTelegramSpooledReplayDeferredParticipant>;
+      const monitor = createTelegramIngressMonitor({
+        queue,
+        cfg,
+        accountId: "default",
+        pollIntervalMs: 10,
+        dispatch: async (update, lifecycle) => {
+          const updateId = (update as { update_id: number }).update_id;
+          dispatched.push(updateId);
+          if (updateId === 10) {
+            // First album member buffers and defers; the spool claim must stay
+            // held without serializing the lane behind the open buffer.
+            deferredParticipant = createTelegramSpooledReplayDeferredParticipant(
+              `test:${updateId}`,
+            );
+            expect(deferredParticipant).not.toBeNull();
+            return;
+          }
+          await lifecycle.onAdopted();
+          return { kind: "completed" as const };
+        },
+      });
+
+      monitor.start();
+      // The second album member drains while the first member's buffer is open.
+      await vi.waitFor(
+        () => {
+          expect(dispatched).toContain(11);
+        },
+        { timeout: 5_000, interval: 20 },
+      );
+      expect(dispatched[0]).toBe(10);
+
+      // Buffer flushes: the deferred work completes and both claims tombstone.
+      deferredParticipant?.settle({ kind: "completed" });
+      await monitor.waitForIdle();
+      const statusA = await queue.enqueue(eventIdA, payloadA, { laneKey: laneA });
+      expect(statusA.kind).toBe("completed");
+      const statusB = await queue.enqueue(eventIdB, payloadB, { laneKey: laneB });
+      expect(statusB.kind).toBe("completed");
       await monitor.stop();
     });
   });

--- a/extensions/telegram/src/telegram-ingress-drain.test.ts
+++ b/extensions/telegram/src/telegram-ingress-drain.test.ts
@@ -164,7 +164,9 @@ describe("createTelegramIngressMonitor", () => {
       await queue.enqueue(eventIdB, payloadB, { laneKey: laneB });
 
       const dispatched: number[] = [];
-      let deferredParticipant: ReturnType<typeof createTelegramSpooledReplayDeferredParticipant>;
+      let deferredParticipant:
+        | ReturnType<typeof createTelegramSpooledReplayDeferredParticipant>
+        | undefined;
       const monitor = createTelegramIngressMonitor({
         queue,
         cfg,
@@ -180,7 +182,7 @@ describe("createTelegramIngressMonitor", () => {
               `test:${updateId}`,
             );
             expect(deferredParticipant).not.toBeNull();
-            return;
+            return undefined;
           }
           await lifecycle.onAdopted();
           return { kind: "completed" as const };

--- a/extensions/telegram/src/telegram-ingress-drain.ts
+++ b/extensions/telegram/src/telegram-ingress-drain.ts
@@ -148,6 +148,12 @@ export function createTelegramIngressMonitor(params: CreateTelegramIngressMonito
         // result so failed-retryable releases and stalls cannot disappear.
         const participant = result.deferredWork;
         if (participant) {
+          // The claim stays held until the deferred turn adopts or abandons,
+          // but it no longer serializes the lane: later same-lane updates
+          // (e.g. the rest of a media-group album) must drain now so they can
+          // join the open buffer instead of starting a second turn after the
+          // first member's buffer flushes.
+          lifecycle.onDeferred();
           const terminal = await new Promise<TelegramMessageProcessingResult>((resolve, reject) => {
             const abortError = () =>
               lifecycle.abortSignal.reason instanceof Error
@@ -218,6 +224,11 @@ export function createTelegramIngressMonitor(params: CreateTelegramIngressMonito
       orderBy: "id",
       scanLimit: TELEGRAM_SPOOLED_DRAIN_SCAN_LIMIT,
       startLimit: TELEGRAM_SPOOLED_DRAIN_START_LIMIT,
+      // Buffered work (media-group albums, debounce) holds its claim until the
+      // deferred turn settles, but later same-lane updates must still drain so
+      // they can join the open buffer before it flushes. Otherwise one album
+      // splits into multiple agent turns.
+      deferredClaimDoesNotBlockLane: true,
       resolveNonRetryableFailure: resolveTelegramIngressNonRetryableFailure,
       shouldSupersedePending: createShouldSupersedeTelegramSpooledPending({
         cfg: params.cfg,

--- a/src/channels/message/ingress-claim-write.ts
+++ b/src/channels/message/ingress-claim-write.ts
@@ -1,0 +1,97 @@
+/**
+ * Claim write helpers for the durable channel-ingress drain: bounded, retried,
+ * claim-token-fenced tombstone / dead-letter / release writes.
+ */
+import { formatErrorMessage } from "../../infra/errors.js";
+import {
+  DEFAULT_INGRESS_RETRY_BASE_MS,
+  DEFAULT_INGRESS_RETRY_MAX_MS,
+  sleepIngressRetryDelay,
+} from "./ingress-retry-policy.js";
+
+/** Bounded tombstone write retries — wedged ownership beats silent double-dispatch. */
+export const INGRESS_TOMBSTONE_RETRY_MAX_ATTEMPTS = 8;
+
+/**
+ * Closed error when adoption races a pre-adoption guillotine/supersede, or when
+ * a claim-token fence rejects complete/fail (lease reclaimed by another owner).
+ * Callers must stop the turn (abortSignal is also aborted when applicable).
+ */
+export class IngressAdoptionLostError extends Error {
+  readonly code: "guillotined" | "superseded" | "reclaimed";
+
+  constructor(code: "guillotined" | "superseded" | "reclaimed") {
+    super(`ingress adoption lost: ${code}`);
+    this.name = "IngressAdoptionLostError";
+    this.code = code;
+  }
+}
+
+export function isIngressAdoptionLostError(error: unknown): error is IngressAdoptionLostError {
+  return error instanceof IngressAdoptionLostError;
+}
+
+/**
+ * Claim-token fenced writes can throw OR return false when the lease was
+ * reclaimed. For complete, false is ownership loss (do not settle success).
+ * For release/fail, false means the row is already gone from this owner —
+ * treat as done so abandon races do not wedge.
+ */
+export async function commitIngressClaimWriteWithRetry(params: {
+  claimId: string;
+  label: "tombstone" | "dead-letter" | "release";
+  write: () => Promise<boolean>;
+  falseMeansReclaimed: boolean;
+  isStopped: () => boolean;
+  abortSignal?: AbortSignal;
+  log: (message: string) => void;
+  formatError?: (err: unknown) => string;
+}): Promise<void> {
+  const formatError = params.formatError ?? formatErrorMessage;
+  let attempt = 0;
+  for (;;) {
+    // First write still runs after session abort: terminal complete/release
+    // (failed-retryable requeue, post-dispatch tombstone) must not be blocked.
+    // Stop only cuts retry backoffs (webhook stop / dispose mid-retry).
+    if (attempt > 0 && params.isStopped()) {
+      throw new Error("ingress drain stopped during claim write");
+    }
+    try {
+      const committed = await params.write();
+      if (!committed) {
+        if (params.falseMeansReclaimed) {
+          throw new IngressAdoptionLostError("reclaimed");
+        }
+        return;
+      }
+      return;
+    } catch (err) {
+      if (isIngressAdoptionLostError(err)) {
+        throw err;
+      }
+      attempt += 1;
+      if (params.isStopped() || attempt >= INGRESS_TOMBSTONE_RETRY_MAX_ATTEMPTS) {
+        if (attempt >= INGRESS_TOMBSTONE_RETRY_MAX_ATTEMPTS && !params.isStopped()) {
+          params.log(
+            `ingress drain: ${params.label} write failed for event ${params.claimId} after ${attempt} attempt(s); holding claim: ${formatError(err)}`,
+          );
+        }
+        throw err;
+      }
+      const delayMs = Math.min(
+        DEFAULT_INGRESS_RETRY_MAX_MS,
+        DEFAULT_INGRESS_RETRY_BASE_MS * 2 ** (attempt - 1),
+      );
+      const displayId = params.claimId.replace(/^0+(?=\d)/, "") || params.claimId;
+      // Operator + test-visible: tombstone/complete retries after durable adoption.
+      params.log(
+        `ingress drain: ${params.label} retry ${attempt}/${INGRESS_TOMBSTONE_RETRY_MAX_ATTEMPTS} for event ${params.claimId} in ${delayMs}ms: ${formatError(err)}`,
+      );
+      if (params.label === "tombstone") {
+        params.log(`completion retry ${attempt} scheduled for event ${displayId}`);
+      }
+      // Abortable sleep: webhook stop aborts abortSignal mid-backoff.
+      await sleepIngressRetryDelay(delayMs, params.abortSignal);
+    }
+  }
+}

--- a/src/channels/message/ingress-drain-state.ts
+++ b/src/channels/message/ingress-drain-state.ts
@@ -1,0 +1,35 @@
+/**
+ * Shared state types and small helpers for the durable channel-ingress drain.
+ * Kept separate from ingress-drain.ts to keep the drain orchestration readable
+ * (and under the file-size lint budget).
+ */
+import type { ChannelIngressQueueClaim, ChannelIngressQueueRecord } from "./ingress-queue.js";
+
+export type ActiveHandlerState<TPayload, TMetadata> = {
+  eventId: string;
+  laneKey: string;
+  claim: ChannelIngressQueueClaim<TPayload, TMetadata>;
+  abortController: AbortController;
+  startedAt: number;
+  phase: "dispatching" | "deferred" | "adopted" | "settled";
+  task: Promise<void>;
+  stallTimer?: ReturnType<typeof setTimeout>;
+  claimRefreshTimer?: ReturnType<typeof setInterval>;
+  /** Closed code: pre-adoption stall watchdog has claimed settle ownership. */
+  guillotined: boolean;
+  /** Closed code: pre-adoption supersede has claimed settle ownership. */
+  superseded: boolean;
+  /** Single settle owner for complete / fail / release / supersede / guillotine. */
+  settleOnce: (fn: () => Promise<void>) => Promise<void>;
+};
+
+export function resolveIngressDrainLaneKey<TPayload, TMetadata>(
+  record: ChannelIngressQueueRecord<TPayload, TMetadata>,
+  deriveLaneKey?: (record: ChannelIngressQueueRecord<TPayload, TMetadata>) => string | undefined,
+): string {
+  return deriveLaneKey?.(record) ?? record.laneKey ?? record.id;
+}
+
+export function sortedIngressDrainKeys(keys: Iterable<string>): string[] {
+  return [...keys].toSorted((a, b) => a.localeCompare(b));
+}

--- a/src/channels/message/ingress-drain.deferred-displacement.test.ts
+++ b/src/channels/message/ingress-drain.deferred-displacement.test.ts
@@ -1,0 +1,156 @@
+// Regression tests: a deferred claim displaced from the per-lane map by a later
+// same-lane claim (deferredClaimDoesNotBlockLane) must remain supersedable,
+// abortable on dispose, and awaited by waitForIdle.
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { expectDefined } from "@openclaw/normalization-core";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { closeOpenClawStateDatabaseForTest } from "../../state/openclaw-state-db.js";
+import { createChannelIngressDrain, isIngressAdoptionLostError } from "./ingress-drain.js";
+
+// Module-private in ingress-drain.ts; derive from the factory signature.
+type ChannelIngressDispatchLifecycle = Parameters<
+  Parameters<typeof createChannelIngressDrain>[0]["dispatchClaimedEvent"]
+>[1];
+import { createChannelIngressQueue } from "./ingress-queue.js";
+
+type Payload = { text: string };
+
+function createTestIngressQueue(stateDir: string) {
+  return createChannelIngressQueue<Payload>({
+    channelId: "test",
+    accountId: "a",
+    stateDir,
+  });
+}
+
+async function withTempState<T>(fn: (stateDir: string) => Promise<T>): Promise<T> {
+  const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-ingress-drain-"));
+  try {
+    return await fn(stateDir);
+  } finally {
+    closeOpenClawStateDatabaseForTest();
+    await fs.rm(stateDir, { recursive: true, force: true });
+  }
+}
+
+afterEach(() => {
+  vi.useRealTimers();
+  closeOpenClawStateDatabaseForTest();
+});
+
+describe("channel ingress drain deferred displacement", () => {
+  it("displaced deferred claims stay supersedable after a later same-lane claim", async () => {
+    await withTempState(async (stateDir) => {
+      const queue = createTestIngressQueue(stateDir);
+      await queue.enqueue("evt-a", { text: "a" }, { laneKey: "l1" });
+      await queue.enqueue("evt-b", { text: "b" }, { laneKey: "l1" });
+
+      const dispatched: string[] = [];
+      const lifecycles = new Map<string, ChannelIngressDispatchLifecycle>();
+      const drain = createChannelIngressDrain<Payload>({
+        queue,
+        deferredClaimDoesNotBlockLane: true,
+        shouldSupersedePending: (candidate) => candidate.id === "evt-c",
+        dispatchClaimedEvent: async (event, lifecycle) => {
+          dispatched.push(event.id);
+          lifecycles.set(event.id, lifecycle);
+          return { kind: "deferred" };
+        },
+      });
+
+      expect(await drain.drainOnce()).toEqual({ started: 1 });
+      await vi.waitFor(() => {
+        expect(dispatched).toEqual(["evt-a"]);
+      });
+      // evt-b claims the lane while evt-a is deferred, displacing evt-a from the
+      // per-lane map. evt-a's claim must remain supersedable anyway.
+      expect(await drain.drainOnce()).toEqual({ started: 1 });
+      await vi.waitFor(() => {
+        expect(dispatched).toEqual(["evt-a", "evt-b"]);
+      });
+      expect(await queue.listClaims()).toHaveLength(2);
+
+      // evt-c supersedes BOTH pre-adoption claims: displaced evt-a and evt-b.
+      await queue.enqueue("evt-c", { text: "c" }, { laneKey: "l1" });
+      expect(await drain.drainOnce()).toEqual({ started: 1 });
+      await vi.waitFor(() => {
+        expect(dispatched).toEqual(["evt-a", "evt-b", "evt-c"]);
+      });
+      expect(lifecycles.get("evt-a")?.abortSignal.aborted).toBe(true);
+      expect(lifecycles.get("evt-b")?.abortSignal.aborted).toBe(true);
+      await drain.waitForIdle();
+      // Only evt-c's claim remains held; evt-a/evt-b were tombstoned, not released.
+      expect((await queue.listClaims()).map((claim) => claim.id)).toEqual(["evt-c"]);
+
+      // Late adoption of a superseded claim is a closed error, never a settle.
+      const lateAdopt = await Promise.resolve(
+        expectDefined(lifecycles.get("evt-a"), "evt-a lifecycle").onAdopted(),
+      ).then(
+        () => null,
+        (err: unknown) => err,
+      );
+      expect(isIngressAdoptionLostError(lateAdopt) && lateAdopt.code).toBe("superseded");
+
+      await expectDefined(lifecycles.get("evt-c"), "evt-c lifecycle").onAdopted();
+      await drain.waitForIdle();
+      expect(await queue.listClaims()).toHaveLength(0);
+      drain.dispose();
+    });
+  });
+
+  it("dispose aborts displaced deferred claims and waitForIdle awaits them", async () => {
+    await withTempState(async (stateDir) => {
+      const queue = createTestIngressQueue(stateDir);
+      await queue.enqueue("evt-a", { text: "a" }, { laneKey: "l1" });
+      await queue.enqueue("evt-b", { text: "b" }, { laneKey: "l1" });
+
+      const dispatched: string[] = [];
+      const lifecycles = new Map<string, ChannelIngressDispatchLifecycle>();
+      let evtATaskSettled = false;
+      const drain = createChannelIngressDrain<Payload>({
+        queue,
+        deferredClaimDoesNotBlockLane: true,
+        dispatchClaimedEvent: async (event, lifecycle) => {
+          dispatched.push(event.id);
+          lifecycles.set(event.id, lifecycle);
+          if (event.id === "evt-a") {
+            // Hold the dispatch open until aborted, like the Telegram adapter
+            // awaiting a buffered album participant's terminal result: defer
+            // first, then wait.
+            lifecycle.onDeferred();
+            await new Promise<void>((resolve) => {
+              if (lifecycle.abortSignal.aborted) {
+                resolve();
+                return;
+              }
+              lifecycle.abortSignal.addEventListener("abort", () => resolve(), { once: true });
+            }).then(() => {
+              evtATaskSettled = true;
+            });
+          }
+          return { kind: "deferred" };
+        },
+      });
+
+      expect(await drain.drainOnce()).toEqual({ started: 1 });
+      await vi.waitFor(() => {
+        expect(dispatched).toEqual(["evt-a"]);
+      });
+      expect(await drain.drainOnce()).toEqual({ started: 1 });
+      await vi.waitFor(() => {
+        expect(dispatched).toEqual(["evt-a", "evt-b"]);
+      });
+
+      // evt-a is displaced but still holding its claim: dispose must abort it,
+      // and waitForIdle must await its task.
+      const idle = drain.waitForIdle();
+      drain.dispose();
+      await idle;
+      expect(lifecycles.get("evt-a")?.abortSignal.aborted).toBe(true);
+      expect(lifecycles.get("evt-b")?.abortSignal.aborted).toBe(true);
+      expect(evtATaskSettled).toBe(true);
+    });
+  });
+});

--- a/src/channels/message/ingress-drain.test.ts
+++ b/src/channels/message/ingress-drain.test.ts
@@ -196,6 +196,82 @@ describe("channel ingress drain", () => {
     });
   });
 
+  it("deferred claim does not block same-lane events when deferredClaimDoesNotBlockLane is set", async () => {
+    await withTempState(async (stateDir) => {
+      const queue = createTestIngressQueue(stateDir);
+      await queue.enqueue("evt-a", { text: "a" }, { laneKey: "l1" });
+      await queue.enqueue("evt-b", { text: "b" }, { laneKey: "l1" });
+
+      const dispatched: string[] = [];
+      const lifecycles = new Map<string, ChannelIngressDispatchLifecycle>();
+      const drain = createChannelIngressDrain<Payload>({
+        queue,
+        deferredClaimDoesNotBlockLane: true,
+        dispatchClaimedEvent: async (event, lifecycle) => {
+          dispatched.push(event.id);
+          lifecycles.set(event.id, lifecycle);
+          return { kind: "deferred" };
+        },
+      });
+
+      expect(await drain.drainOnce()).toEqual({ started: 1 });
+      await vi.waitFor(() => {
+        expect(dispatched).toEqual(["evt-a"]);
+      });
+      // evt-a is deferred: its claim stays held, but the lane must not block evt-b.
+      expect(await drain.drainOnce()).toEqual({ started: 1 });
+      await vi.waitFor(() => {
+        expect(dispatched).toEqual(["evt-a", "evt-b"]);
+      });
+      expect(await queue.listClaims()).toHaveLength(2);
+
+      // Both deferred claims adopt independently and tombstone.
+      await expectDefined(lifecycles.get("evt-a"), "evt-a lifecycle").onAdopted();
+      await expectDefined(lifecycles.get("evt-b"), "evt-b lifecycle").onAdopted();
+      await drain.waitForIdle();
+      expect(await queue.listClaims()).toHaveLength(0);
+      expect(await queue.listPending()).toEqual([]);
+      drain.dispose();
+    });
+  });
+
+  it("deferred claim still blocks same-lane events by default", async () => {
+    await withTempState(async (stateDir) => {
+      const queue = createTestIngressQueue(stateDir);
+      await queue.enqueue("evt-a", { text: "a" }, { laneKey: "l1" });
+      await queue.enqueue("evt-b", { text: "b" }, { laneKey: "l1" });
+
+      const dispatched: string[] = [];
+      const lifecycles = new Map<string, ChannelIngressDispatchLifecycle>();
+      const drain = createChannelIngressDrain<Payload>({
+        queue,
+        dispatchClaimedEvent: async (event, lifecycle) => {
+          dispatched.push(event.id);
+          lifecycles.set(event.id, lifecycle);
+          return { kind: "deferred" };
+        },
+      });
+
+      expect(await drain.drainOnce()).toEqual({ started: 1 });
+      await vi.waitFor(() => {
+        expect(dispatched).toEqual(["evt-a"]);
+      });
+      expect(await drain.drainOnce()).toEqual({ started: 0 });
+      expect(dispatched).toEqual(["evt-a"]);
+
+      // Adoption tombstones the deferred claim; the lane unblocks for evt-b.
+      await expectDefined(lifecycles.get("evt-a"), "evt-a lifecycle").onAdopted();
+      await drain.waitForIdle();
+      expect(await drain.drainOnce()).toEqual({ started: 1 });
+      await vi.waitFor(() => {
+        expect(dispatched).toEqual(["evt-a", "evt-b"]);
+      });
+      await expectDefined(lifecycles.get("evt-b"), "evt-b lifecycle").onAdopted();
+      await drain.waitForIdle();
+      drain.dispose();
+    });
+  });
+
   it("lets callers await an abandoned claim release", async () => {
     await withTempState(async (stateDir) => {
       const queue = createTestIngressQueue(stateDir);

--- a/src/channels/message/ingress-drain.ts
+++ b/src/channels/message/ingress-drain.ts
@@ -103,6 +103,15 @@ export type CreateChannelIngressDrainOptions<
     lifecycle: ChannelIngressDispatchLifecycle,
   ) => Promise<ChannelIngressDrainDispatchResult | void> | ChannelIngressDrainDispatchResult | void;
   resolveNonRetryableFailure?: (err: unknown) => IngressNonRetryableFailure | null;
+  /**
+   * When true, a lane whose only in-flight work is deferred (turn ownership
+   * handed to buffered/followup work via lifecycle.onDeferred) does not block
+   * claiming later same-lane events. Channels that buffer same-lane updates
+   * into deferred work (e.g. Telegram media-group albums) rely on this so
+   * later album members can join the buffer before it flushes. The deferred
+   * claim itself remains held and heartbeat-refreshed until adopted/abandoned.
+   */
+  deferredClaimDoesNotBlockLane?: boolean;
   shouldSupersedePending?: (
     newEvent:
       | ChannelIngressQueueRecord<TPayload, TMetadata>
@@ -744,13 +753,23 @@ export function createChannelIngressDrain<
 
     const pending = await queue.listPending({ limit: "all", orderBy });
     const claims = await queue.listClaims();
+    const deferredLaneKeys = new Set(
+      [...activeByLane.values()]
+        .filter((state) => state.phase === "deferred")
+        .map((state) => state.laneKey),
+    );
+    const laneBlockedWhileDeferred = (laneKey: string): boolean =>
+      options.deferredClaimDoesNotBlockLane !== true || !deferredLaneKeys.has(laneKey);
     const activeLaneKeys = new Set(
       [...activeByLane.values()]
         .filter((state) => state.phase !== "settled")
-        .map((state) => state.laneKey),
+        .map((state) => state.laneKey)
+        .filter((laneKey) => laneBlockedWhileDeferred(laneKey)),
     );
     const claimedLaneKeys = new Set(
-      claims.map((claim) => resolveLaneKey(claim, options.deriveLaneKey)),
+      claims
+        .map((claim) => resolveLaneKey(claim, options.deriveLaneKey))
+        .filter((laneKey) => laneBlockedWhileDeferred(laneKey)),
     );
     const retryDelayedLaneKeys = new Set<string>();
     for (const event of pending) {
@@ -805,7 +824,12 @@ export function createChannelIngressDrain<
         if (await supersedeActiveIfNeeded(claimed, laneKey)) {
           blockedLaneKeys.delete(laneKey);
         }
-        if (activeByLane.has(laneKey)) {
+        const stillActive = activeByLane.get(laneKey);
+        if (
+          stillActive &&
+          stillActive.phase !== "settled" &&
+          !(options.deferredClaimDoesNotBlockLane === true && stillActive.phase === "deferred")
+        ) {
           await queue.release(claimed, { recordAttempt: false });
           blockedLaneKeys.add(laneKey);
           continue;

--- a/src/channels/message/ingress-drain.ts
+++ b/src/channels/message/ingress-drain.ts
@@ -14,17 +14,23 @@ import {
   isLiveLocalIngressDrainOwner,
   registerLiveIngressDrainInstance,
 } from "./ingress-claim-owner.js";
+import {
+  commitIngressClaimWriteWithRetry,
+  IngressAdoptionLostError,
+} from "./ingress-claim-write.js";
+import {
+  type ActiveHandlerState,
+  resolveIngressDrainLaneKey,
+  sortedIngressDrainKeys,
+} from "./ingress-drain-state.js";
 import type {
   ChannelIngressQueue,
   ChannelIngressQueueClaim,
   ChannelIngressQueueRecord,
 } from "./ingress-queue.js";
 import {
-  DEFAULT_INGRESS_RETRY_BASE_MS,
-  DEFAULT_INGRESS_RETRY_MAX_MS,
   resolveIngressFailureDisposition,
   resolveIngressRetryDelayMs,
-  sleepIngressRetryDelay,
   type IngressNonRetryableFailure,
   type IngressRetryPolicyConfig,
 } from "./ingress-retry-policy.js";
@@ -32,27 +38,8 @@ import {
 /** Default claim→adoption stall before dead-lettering with handler-timeout. */
 export const DEFAULT_INGRESS_ADOPTION_STALL_MS = 5 * 60 * 1000;
 
-/** Bounded tombstone write retries — wedged ownership beats silent double-dispatch. */
-const INGRESS_TOMBSTONE_RETRY_MAX_ATTEMPTS = 8;
-
-/**
- * Closed error when adoption races a pre-adoption guillotine/supersede, or when
- * a claim-token fence rejects complete/fail (lease reclaimed by another owner).
- * Callers must stop the turn (abortSignal is also aborted when applicable).
- */
-class IngressAdoptionLostError extends Error {
-  readonly code: "guillotined" | "superseded" | "reclaimed";
-
-  constructor(code: "guillotined" | "superseded" | "reclaimed") {
-    super(`ingress adoption lost: ${code}`);
-    this.name = "IngressAdoptionLostError";
-    this.code = code;
-  }
-}
-
-export function isIngressAdoptionLostError(error: unknown): error is IngressAdoptionLostError {
-  return error instanceof IngressAdoptionLostError;
-}
+// Moved to ./ingress-claim-write.js; re-exported for existing importers.
+export { isIngressAdoptionLostError } from "./ingress-claim-write.js";
 
 /** Full pre-adoption → adoption ownership lifecycle for one claimed event. */
 type ChannelIngressDispatchLifecycle = {
@@ -140,35 +127,6 @@ export type ChannelIngressDrain = {
   dispose: () => void;
 };
 
-type ActiveHandlerState<TPayload, TMetadata> = {
-  eventId: string;
-  laneKey: string;
-  claim: ChannelIngressQueueClaim<TPayload, TMetadata>;
-  abortController: AbortController;
-  startedAt: number;
-  phase: "dispatching" | "deferred" | "adopted" | "settled";
-  task: Promise<void>;
-  stallTimer?: ReturnType<typeof setTimeout>;
-  claimRefreshTimer?: ReturnType<typeof setInterval>;
-  /** Closed code: pre-adoption stall watchdog has claimed settle ownership. */
-  guillotined: boolean;
-  /** Closed code: pre-adoption supersede has claimed settle ownership. */
-  superseded: boolean;
-  /** Single settle owner for complete / fail / release / supersede / guillotine. */
-  settleOnce: (fn: () => Promise<void>) => Promise<void>;
-};
-
-function resolveLaneKey<TPayload, TMetadata>(
-  record: ChannelIngressQueueRecord<TPayload, TMetadata>,
-  deriveLaneKey?: (record: ChannelIngressQueueRecord<TPayload, TMetadata>) => string | undefined,
-): string {
-  return deriveLaneKey?.(record) ?? record.laneKey ?? record.id;
-}
-
-function sortedKeys(keys: Iterable<string>): string[] {
-  return [...keys].toSorted((a, b) => a.localeCompare(b));
-}
-
 /**
  * Maps a drain lifecycle onto reply options.
  * Single surface: turnAdoptionLifecycle only.
@@ -218,7 +176,18 @@ export function createChannelIngressDrain<
   const scanLimit = options.scanLimit ?? 100;
   const startLimit = options.startLimit ?? 32;
   const activeByLane = new Map<string, ActiveHandlerState<TPayload, TMetadata>>();
+  // States displaced from activeByLane when deferredClaimDoesNotBlockLane lets a
+  // later same-lane event claim while an earlier one is still deferred. They keep
+  // their own stall/refresh timers and abort controller; tracking them here keeps
+  // stall guillotine, supersede, abort/dispose, and waitForIdle applied to every
+  // held claim — a displaced deferred claim must never become invisible.
+  const displacedActiveStates = new Set<ActiveHandlerState<TPayload, TMetadata>>();
   let disposed = false;
+
+  const allActiveStates = (): ActiveHandlerState<TPayload, TMetadata>[] => [
+    ...activeByLane.values(),
+    ...displacedActiveStates,
+  ];
 
   const log = (message: string) => {
     options.onLog?.(message);
@@ -243,7 +212,7 @@ export function createChannelIngressDrain<
     // Claim-token fencing prevents this owner from settling a recovered claim.
     deregisterLiveIngressDrainInstance(ownerId);
     const reason = toErrorObject(options.abortSignal?.reason, "ingress-drain-aborted");
-    for (const state of activeByLane.values()) {
+    for (const state of allActiveStates()) {
       if (state.phase === "dispatching" || state.phase === "deferred") {
         state.abortController.abort(reason);
       }
@@ -258,6 +227,7 @@ export function createChannelIngressDrain<
   const removeActive = (state: ActiveHandlerState<TPayload, TMetadata>) => {
     clearStallTimer(state);
     clearClaimRefresh(state);
+    displacedActiveStates.delete(state);
     if (activeByLane.get(state.laneKey) === state) {
       activeByLane.delete(state.laneKey);
     }
@@ -312,59 +282,22 @@ export function createChannelIngressDrain<
    */
   const isStopped = () => disposed || options.abortSignal?.aborted === true;
 
-  const commitClaimWriteWithRetry = async (params: {
+  const commitClaimWriteWithRetry = (params: {
     claim: ChannelIngressQueueClaim<TPayload, TMetadata>;
     label: "tombstone" | "dead-letter" | "release";
     write: () => Promise<boolean>;
     falseMeansReclaimed: boolean;
-  }): Promise<void> => {
-    let attempt = 0;
-    for (;;) {
-      // First write still runs after session abort: terminal complete/release
-      // (failed-retryable requeue, post-dispatch tombstone) must not be blocked.
-      // Stop only cuts retry backoffs (webhook stop / dispose mid-retry).
-      if (attempt > 0 && isStopped()) {
-        throw new Error("ingress drain stopped during claim write");
-      }
-      try {
-        const committed = await params.write();
-        if (!committed) {
-          if (params.falseMeansReclaimed) {
-            throw new IngressAdoptionLostError("reclaimed");
-          }
-          return;
-        }
-        return;
-      } catch (err) {
-        if (isIngressAdoptionLostError(err)) {
-          throw err;
-        }
-        attempt += 1;
-        if (isStopped() || attempt >= INGRESS_TOMBSTONE_RETRY_MAX_ATTEMPTS) {
-          if (attempt >= INGRESS_TOMBSTONE_RETRY_MAX_ATTEMPTS && !isStopped()) {
-            log(
-              `ingress drain: ${params.label} write failed for event ${params.claim.id} after ${attempt} attempt(s); holding claim: ${formatError(err)}`,
-            );
-          }
-          throw err;
-        }
-        const delayMs = Math.min(
-          DEFAULT_INGRESS_RETRY_MAX_MS,
-          DEFAULT_INGRESS_RETRY_BASE_MS * 2 ** (attempt - 1),
-        );
-        const displayId = params.claim.id.replace(/^0+(?=\d)/, "") || params.claim.id;
-        // Operator + test-visible: tombstone/complete retries after durable adoption.
-        log(
-          `ingress drain: ${params.label} retry ${attempt}/${INGRESS_TOMBSTONE_RETRY_MAX_ATTEMPTS} for event ${params.claim.id} in ${delayMs}ms: ${formatError(err)}`,
-        );
-        if (params.label === "tombstone") {
-          log(`completion retry ${attempt} scheduled for event ${displayId}`);
-        }
-        // Abortable sleep: webhook stop aborts options.abortSignal mid-backoff.
-        await sleepIngressRetryDelay(delayMs, options.abortSignal);
-      }
-    }
-  };
+  }): Promise<void> =>
+    commitIngressClaimWriteWithRetry({
+      claimId: params.claim.id,
+      label: params.label,
+      write: params.write,
+      falseMeansReclaimed: params.falseMeansReclaimed,
+      isStopped,
+      abortSignal: options.abortSignal,
+      log,
+      formatError,
+    });
 
   const completeClaimWithRetry = async (
     claim: ChannelIngressQueueClaim<TPayload, TMetadata>,
@@ -560,48 +493,69 @@ export function createChannelIngressDrain<
     };
   };
 
-  const supersedeActiveIfNeeded = async (
+  const trySupersedeState = async (
     candidate: ChannelIngressQueueRecord<TPayload, TMetadata>,
-    laneKey: string,
+    pending: ActiveHandlerState<TPayload, TMetadata>,
   ): Promise<boolean> => {
-    const pending = activeByLane.get(laneKey);
-    if (!pending || pending.phase === "adopted" || pending.phase === "settled") {
+    if (pending.phase === "adopted" || pending.phase === "settled") {
       return false;
     }
     if (!(await options.shouldSupersedePending?.(candidate, pending.claim))) {
       return false;
     }
     // Revalidate after async predicate: a late true must not kill an adopted turn
-    // or a different map entry that replaced this pending handler.
-    const stillPending = activeByLane.get(laneKey);
+    // or a state that settled / was removed while the predicate ran.
+    // Widened read: TS narrows `pending.phase` above and keeps the narrowing
+    // across the await, so compare against the full union explicitly.
+    const phaseAfterPredicate = pending.phase as ActiveHandlerState<TPayload, TMetadata>["phase"];
     if (
-      stillPending !== pending ||
-      stillPending.phase === "adopted" ||
-      stillPending.phase === "settled" ||
-      stillPending.guillotined ||
-      stillPending.superseded
+      (activeByLane.get(pending.laneKey) !== pending && !displacedActiveStates.has(pending)) ||
+      phaseAfterPredicate === "adopted" ||
+      phaseAfterPredicate === "settled" ||
+      pending.guillotined ||
+      pending.superseded
     ) {
       return false;
     }
     // Pre-adoption supersede only — after adoption core owns interruption.
     // Tombstone (complete), never release: requeue would replay the aborted turn.
-    stillPending.superseded = true;
-    clearStallTimer(stillPending);
+    pending.superseded = true;
+    clearStallTimer(pending);
     try {
-      stillPending.abortController.abort(new Error("ingress-superseded"));
+      pending.abortController.abort(new Error("ingress-superseded"));
     } catch {
       // ignore
     }
     try {
-      await stillPending.settleOnce(async () => {
-        await completeClaimWithRetry(stillPending.claim);
+      await pending.settleOnce(async () => {
+        await completeClaimWithRetry(pending.claim);
       });
     } catch (err) {
       log(
-        `ingress drain: failed to tombstone superseded event ${stillPending.eventId}: ${formatError(err)}`,
+        `ingress drain: failed to tombstone superseded event ${pending.eventId}: ${formatError(err)}`,
       );
     }
     return true;
+  };
+
+  const supersedeActiveIfNeeded = async (
+    candidate: ChannelIngressQueueRecord<TPayload, TMetadata>,
+    laneKey: string,
+  ): Promise<boolean> => {
+    // Supersede every pre-adoption state on the lane: the current map entry AND
+    // any displaced deferred states (deferredClaimDoesNotBlockLane). A deferred
+    // album head must stay supersedable even after a later album member claimed.
+    let supersededAny = false;
+    const pending = activeByLane.get(laneKey);
+    if (pending && (await trySupersedeState(candidate, pending))) {
+      supersededAny = true;
+    }
+    for (const state of displacedActiveStates) {
+      if (state.laneKey === laneKey && (await trySupersedeState(candidate, state))) {
+        supersededAny = true;
+      }
+    }
+    return supersededAny;
   };
 
   const runClaimed = (
@@ -699,17 +653,27 @@ export function createChannelIngressDrain<
       }
     })();
 
+    // A later same-lane claim is only possible when the previous state is
+    // deferred (deferredClaimDoesNotBlockLane) or settled. Keep the displaced
+    // state tracked so its claim stays abortable, supersedable, and awaited.
+    const displaced = activeByLane.get(laneKey);
+    if (displaced && displaced.phase !== "settled") {
+      displacedActiveStates.add(displaced);
+    }
     activeByLane.set(laneKey, state);
     return state;
   };
 
   const recoverStaleClaims = async (): Promise<number> => {
     const activeLanes = new Set(activeByLane.keys());
+    for (const state of displacedActiveStates) {
+      activeLanes.add(state.laneKey);
+    }
     return await queue.recoverStaleClaims({
       staleMs: 0,
       now: now(),
       shouldRecover: (claim) => {
-        const laneKey = resolveLaneKey(claim, options.deriveLaneKey);
+        const laneKey = resolveIngressDrainLaneKey(claim, options.deriveLaneKey);
         if (activeLanes.has(laneKey)) {
           return false;
         }
@@ -753,13 +717,22 @@ export function createChannelIngressDrain<
 
     const pending = await queue.listPending({ limit: "all", orderBy });
     const claims = await queue.listClaims();
-    const deferredLaneKeys = new Set(
-      [...activeByLane.values()]
-        .filter((state) => state.phase === "deferred")
-        .map((state) => state.laneKey),
-    );
+    // A lane is exempt from blocking only when EVERY live state on it is
+    // deferred (map entry plus displaced deferred states). One dispatching
+    // state re-blocks the lane even if a deferred claim is still held.
+    const deferredLaneKeys = new Set<string>();
+    const nonDeferredLaneKeys = new Set<string>();
+    for (const state of allActiveStates()) {
+      if (state.phase === "deferred") {
+        deferredLaneKeys.add(state.laneKey);
+      } else if (state.phase !== "settled") {
+        nonDeferredLaneKeys.add(state.laneKey);
+      }
+    }
     const laneBlockedWhileDeferred = (laneKey: string): boolean =>
-      options.deferredClaimDoesNotBlockLane !== true || !deferredLaneKeys.has(laneKey);
+      options.deferredClaimDoesNotBlockLane !== true ||
+      !deferredLaneKeys.has(laneKey) ||
+      nonDeferredLaneKeys.has(laneKey);
     const activeLaneKeys = new Set(
       [...activeByLane.values()]
         .filter((state) => state.phase !== "settled")
@@ -768,21 +741,21 @@ export function createChannelIngressDrain<
     );
     const claimedLaneKeys = new Set(
       claims
-        .map((claim) => resolveLaneKey(claim, options.deriveLaneKey))
+        .map((claim) => resolveIngressDrainLaneKey(claim, options.deriveLaneKey))
         .filter((laneKey) => laneBlockedWhileDeferred(laneKey)),
     );
     const retryDelayedLaneKeys = new Set<string>();
     for (const event of pending) {
       if (resolveIngressRetryDelayMs(event, options.retryPolicy, now()) > 0) {
-        retryDelayedLaneKeys.add(resolveLaneKey(event, options.deriveLaneKey));
+        retryDelayedLaneKeys.add(resolveIngressDrainLaneKey(event, options.deriveLaneKey));
       }
     }
 
     // Deterministic blocked set for claimNext lane serialization.
     const blockedLaneKeys = new Set<string>([
-      ...sortedKeys(activeLaneKeys),
-      ...sortedKeys(claimedLaneKeys),
-      ...sortedKeys(retryDelayedLaneKeys),
+      ...sortedIngressDrainKeys(activeLaneKeys),
+      ...sortedIngressDrainKeys(claimedLaneKeys),
+      ...sortedIngressDrainKeys(retryDelayedLaneKeys),
     ]);
 
     // Optional supersede scan: pending events may abort unadopted same-lane work.
@@ -791,7 +764,7 @@ export function createChannelIngressDrain<
       if (shouldStop()) {
         break;
       }
-      const laneKey = resolveLaneKey(event, options.deriveLaneKey);
+      const laneKey = resolveIngressDrainLaneKey(event, options.deriveLaneKey);
       if (await supersedeActiveIfNeeded(event, laneKey)) {
         blockedLaneKeys.delete(laneKey);
       }
@@ -818,7 +791,7 @@ export function createChannelIngressDrain<
         await queue.release(claimed, { recordAttempt: false });
         break;
       }
-      const laneKey = resolveLaneKey(claimed, options.deriveLaneKey);
+      const laneKey = resolveIngressDrainLaneKey(claimed, options.deriveLaneKey);
       const existing = activeByLane.get(laneKey);
       if (existing && existing.phase !== "settled") {
         if (await supersedeActiveIfNeeded(claimed, laneKey)) {
@@ -845,9 +818,9 @@ export function createChannelIngressDrain<
   return {
     recoverStaleClaims,
     drainOnce,
-    activeLaneKeys: () => new Set(activeByLane.keys()),
+    activeLaneKeys: () => new Set(allActiveStates().map((state) => state.laneKey)),
     waitForIdle: async () => {
-      const tasks = [...activeByLane.values()].map((state) => state.task);
+      const tasks = allActiveStates().map((state) => state.task);
       await Promise.allSettled(tasks);
     },
     dispose: () => {
@@ -855,7 +828,7 @@ export function createChannelIngressDrain<
       options.abortSignal?.removeEventListener("abort", abortActiveClaims);
       deregisterLiveIngressDrainInstance(ownerId);
       // Snapshot: removeActive mutates activeByLane during this sweep.
-      const activeStates = Array.from(activeByLane.values());
+      const activeStates = allActiveStates();
       for (const state of activeStates) {
         clearStallTimer(state);
         if (state.phase === "dispatching" || state.phase === "deferred") {


### PR DESCRIPTION
Fixes openclaw/openclaw#115325

## What Problem This Solves

Fixes an issue where Telegram users sending a multi-photo album (updates sharing one `media_group_id`) through the durable polling/webhook ingress would have the album split into multiple agent turns: the first photo arrived as a captioned image turn, and the remaining photos were delivered seconds later as separate media-only turns with empty bodies. The agent received incomplete album context and could run twice for one user action.

Regression range: introduced by `f7786a16` ("refactor(telegram): drive ingress through the core drain"), present in `2026.7.2-beta.3` through current `main`.

## Why This Change Was Made

The pre-refactor Telegram drain explicitly excluded deferred spool claims from its blocked-lane set, so later same-lane album members could drain and join the open media-group buffer. The core drain has no such exclusion: the Telegram ingress adapter awaits the deferred media-group participant's terminal result with the claim held and the handler state pre-adoption, so the chat lane stays blocked until the buffer flushes — by which time the next album member can only start a new group.

This restores the old semantics as an opt-in on the shared drain: a new `deferredClaimDoesNotBlockLane` option keeps a deferred claim held (and heartbeat-refreshed, stall-watched, and supersedable) but excludes its lane from the blocked-lane sets, letting later same-lane events claim and dispatch. Telegram enables it and now marks spooled deliveries with deferred buffered work as deferred via `lifecycle.onDeferred()`, while still awaiting the participant's terminal result so failed-retryable releases and stall timeouts propagate exactly as before. Default drain behavior for all other channels is unchanged.

## User Impact

Telegram albums sent as one action are delivered to the agent as one turn containing all images and the caption again — no more fragmented prompts, duplicate replies, or doubled model runs for a single album. Behavior for non-buffered messages, retry/dead-letter policy, supersede, and other channels is unchanged.

## Evidence

- New core drain tests: `deferred claim does not block same-lane events when deferredClaimDoesNotBlockLane is set` (lane frees while the deferred claim stays held; both claims adopt and tombstone independently) and `deferred claim still blocks same-lane events by default` (opt-in confirmed).
- New Telegram adapter test: `deferred buffered work does not block later same-lane updates (media_group album)` — two same-lane updates, the first registering deferred buffered work; the second drains and dispatches while the buffer is open, then both tombstone after the deferred work settles.
- Red/green: both new tests fail on `origin/main` without this change and pass with it.
- Suites run (all green): `ingress-drain` (27), `telegram-ingress-drain` (4), `ingress-monitor` + `ingress-claim-owner` (26), `telegram-ingress-spool` + `telegram-ingress-supersede` + `telegram-ingress-worker.runtime` (24), `ingress-queue` + `ingress-queue.dead-letters` (34), `bot.create-telegram-bot.media-group-skip-warning` (3).
- `tsc --noEmit` (core + extensions projects): no new diagnostics; the two `TS2883` warnings in `src/media-understanding/audio.test-helpers.ts` are pre-existing on `origin/main` (verified against a clean checkout).

---

AI-assisted: this fix was implemented and validated by an AI agent (synthclaw) with human direction.
