### PR TITLE
fix(ui): session lists stay on the previous agent until reload after switching agents

### DIFF
--- a/ui/src/lib/sessions/index.event-refresh.test.ts
+++ b/ui/src/lib/sessions/index.event-refresh.test.ts
@@ -217,6 +217,44 @@ describe("event-driven session list refresh", () => {
     }
   });
 
+  it("keeps a queued agent switch when the debounced refresh fires mid-flight", async () => {
+    vi.useFakeTimers();
+    const firstList = deferred<SessionsListResult>();
+    const listParams: Array<Record<string, unknown>> = [];
+    const request = vi.fn((method: string, params?: unknown) => {
+      if (method !== "sessions.list") {
+        throw new Error(`Unexpected request: ${method}`);
+      }
+      listParams.push({ ...(params as Record<string, unknown>) });
+      if (listParams.length === 1) {
+        return firstList.promise;
+      }
+      return Promise.resolve(sessionsResult(listParams.length));
+    });
+    const { sessions, emitEvent } = createHarness(
+      request as unknown as GatewayBrowserClient["request"],
+    );
+
+    try {
+      const initial = sessions.refresh({ agentId: "main", force: true });
+      // The sidebar agent switch queues behind the in-flight canonical refresh.
+      void sessions.refresh({ agentId: "ticket-plus", force: true });
+      emitEvent(sessionChangedEvent("agent:main:main"));
+      // The debounced canonical refresh fires while the first list is still in
+      // flight; its coalesced options must carry the switched agent instead of
+      // resurrecting the previous agent over the queued switch.
+      await vi.advanceTimersByTimeAsync(SESSION_EVENT_REFRESH_DEBOUNCE_MS);
+      firstList.resolve(sessionsResult(1));
+      await initial;
+
+      expect(sessions.state.agentId).toBe("ticket-plus");
+      expect(listParams.at(-1)?.agentId).toBe("ticket-plus");
+    } finally {
+      sessions.dispose();
+      vi.useRealTimers();
+    }
+  });
+
   it("flushes a pending event refresh synchronously on dispose", async () => {
     vi.useFakeTimers();
     const request = vi.fn(async (method: string) => {

--- a/ui/src/lib/sessions/index.ts
+++ b/ui/src/lib/sessions/index.ts
@@ -890,18 +890,20 @@ export function createSessionCapability(gateway: SessionGateway): SessionCapabil
     }
   };
 
-  const load = async (options: SessionRefreshOptions) => {
-    const scope = captureConnection();
-    if (!scope) {
-      return;
-    }
-    const { append = false, force: _force, backgroundHydrate = false, ...requestOptions } = options;
-    const durableListOptions: SessionListOptions = { ...requestOptions };
+  // Foreground options become authoritative at refresh-call time, before any
+  // queueing: a queued refresh can be coalesced away by a later canonical
+  // `{ ...lastListOptions }` refresh, and capture-at-load-time would resurrect
+  // stale filters (e.g. the previous agent's scope after an agent switch).
+  const rememberListOptions = (options: SessionRefreshOptions) => {
+    const {
+      append: _append,
+      force: _force,
+      backgroundHydrate = false,
+      ...durableListOptions
+    } = options;
     // Pagination is request-local. Replacement refreshes restart at page one
     // while retaining the filters and response enrichments that shape the list.
     delete durableListOptions.offset;
-    // Foreground options become authoritative before I/O so a concurrent
-    // mutation cannot queue a replacement refresh with stale filters.
     if (!backgroundHydrate) {
       lastListOptions = durableListOptions;
       hasForegroundListOptions = true;
@@ -909,6 +911,14 @@ export function createSessionCapability(gateway: SessionGateway): SessionCapabil
       lastListOptions = durableListOptions;
       hasSeededListOptions = true;
     }
+  };
+
+  const load = async (options: SessionRefreshOptions) => {
+    const scope = captureConnection();
+    if (!scope) {
+      return;
+    }
+    const { append = false, force: _force, backgroundHydrate = false, ...requestOptions } = options;
     if (!backgroundHydrate) {
       publish({ ...state, loading: true, error: null, deletedSessions: [] });
     }
@@ -1003,6 +1013,7 @@ export function createSessionCapability(gateway: SessionGateway): SessionCapabil
     if (inFlight) {
       // An explicit queued refresh subsumes any older event invalidation.
       clearEventRefreshTimer();
+      rememberListOptions(options);
       queuedRefresh = options;
       return inFlight;
     }
@@ -1014,6 +1025,7 @@ export function createSessionCapability(gateway: SessionGateway): SessionCapabil
     }
     // An explicit refresh that will issue a request must run now.
     clearEventRefreshTimer();
+    rememberListOptions(options);
     const request = drainRefreshQueue(options).finally(() => {
       if (inFlight === request) {
         inFlight = null;


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Control UI users on multi-agent gateways would keep seeing the previous agent's sessions in session lists (sidebar recents, chat session picker, new-session and workboard surfaces) after switching the active agent, until a full page reload. Reproduces on 2026.7.1-2; switching agents while the gateway has active runs streaming session events makes it near-deterministic.

## Why This Change Was Made

The shared sessions capability coalesces canonical list refreshes: only one `sessions.list` runs at a time, later requests overwrite a single queued slot, and event-driven canonical refreshes re-issue `{ ...lastListOptions, force: true }`. But `lastListOptions` only became authoritative when a load actually started. An agent switch queued behind an in-flight refresh could be overwritten by a session-event refresh still carrying the previous agent's options — the switch was silently dropped and never retried, and every later event-driven refresh perpetuated the stale agent scope.

Foreground list options now become authoritative at `refresh()` call time, before queueing, so coalesced canonical refreshes always spread the newest agent scope. Background hydration keeps its existing seed-only rule, and pagination offsets stay request-local as before.

## User Impact

Switching agents in the Control UI now reliably shows the selected agent's sessions everywhere without needing a page reload.

## Evidence

- New regression test in `ui/src/lib/sessions/index.event-refresh.test.ts` ("keeps a queued agent switch when the debounced refresh fires mid-flight") reproduces the reported sequence: in-flight canonical refresh → agent switch queued → session event's debounced canonical refresh fires mid-flight → in-flight list resolves. It fails on current `main` (verified after #115374 — the debounce narrows the race window but the coalesced options still capture the previous agent) and passes with this fix.
- Local (this branch): full UI vitest lane green (469 files / 6729 tests, includes all sessions-capability suites), focused regression file 7/7, `tsgo:ui` + `tsgo:test:ui`, scoped oxlint, and `ui:i18n:verify` all green.
- **Real-behavior proof (live Control UI, after fix):** built this branch (`pnpm build`) and confirmed the gateway served the freshly built bundle (served `/assets/index-BPRisJsV.js` matches `dist/control-ui`). Ephemeral loopback gateway (`node dist/index.js gateway --port 18899 --bind loopback --allow-unconfigured`, isolated `OPENCLAW_STATE_DIR`/`OPENCLAW_HOME`/`OPENCLAW_CONFIG_PATH`), two agents (`alpha`, `beta`) with separate workspaces, and a local mock OpenAI-Responses SSE provider (`request.allowPrivateNetwork`, configurable response hold) so runs are real but deterministic. Real browser over the real WS transport — no UI mocks.
  - Seeded two threads per agent through the UI (real `sessions.create` + completed runs).
  - Switched Alpha→Beta→Alpha repeatedly via the sidebar agent switcher, never reloading: the thread rail and Recent Chats always showed exactly the selected agent's sessions; the previous agent's sessions never leaked in.
  - Exercised the event-refresh path live: session creations and a mock-held run completion triggered debounced canonical `sessions.list` refreshes around the switches, and lists stayed scoped to the selected agent throughout. Gateway log excerpt:

    ```
    02:26:21 sessions.create ✓ → sessions.list ✓ ×2      (create + debounced canonical refresh)
    02:27:25 sessions.create ✓ → sessions.list ✓ ×2
    02:36:03 model-fetch start  (SSE turn on beta, held ~8s by mock)
    02:36:11 sessions.list ✓    (event-driven canonical refresh after run completion)
    02:37:40 chat.history ✓     (switch to alpha — UI showed only alpha's sessions, no reload)
    ```

  - Note: the deterministic interleaving of "in-flight list → queued agent switch → debounced event refresh" is what the fake-timer regression test pins down; the live run demonstrates the user-visible outcome (agent switches always land on the selected agent's lists without reload) on the real transport with event refreshes firing.
- CI on head `ba83e701c68`: green except `checks-node-compact-large-4` (`src/media/playback-transcode.test.ts` timing test — unrelated surface, passes locally 26/26, and compact-large shards show recurring one-off timing failures on recent `main` runs). The previous head's only failure was the same class (`tui-pty-local.e2e.test.ts`, which also failed on a `main` run the same day).
- Per repo changelog policy (release generation owns `CHANGELOG.md`), the changelog entry was removed from this PR; release-note context lives in this PR body.
