### PR TITLE
fix(ui): anchor the thread branches menu to its trigger button

### DIFF
--- a/ui/src/pages/chat/components/chat-pane-header.test.ts
+++ b/ui/src/pages/chat/components/chat-pane-header.test.ts
@@ -378,6 +378,14 @@ describe("chat pane header", () => {
     });
     const items = multiple.container.querySelectorAll(".chat-pane__branch-item");
     expect(multiple.container.querySelector(".chat-pane__branches-trigger")).not.toBeNull();
+    // wa-popup anchors to the first slot="trigger" element; a display:contents
+    // wrapper (like openclaw-tooltip) has a zero rect and pins the menu to the
+    // window's top-left corner, so the slotted trigger must be the button itself.
+    expect(
+      multiple.container
+        .querySelector('.chat-pane__branches-menu > [slot="trigger"]')
+        ?.classList.contains("chat-pane__branches-trigger"),
+    ).toBe(true);
     expect(items).toHaveLength(2);
     expect(items[0]?.textContent).toContain("Current work");
     expect(items[0]?.getAttribute("data-active")).toBe("true");

--- a/ui/src/pages/chat/components/chat-pane-header.ts
+++ b/ui/src/pages/chat/components/chat-pane-header.ts
@@ -360,24 +360,29 @@ export function renderChatPaneHeader(props: ChatPaneHeaderProps) {
       ${props.sharingControl ?? nothing}
       ${!props.catalog && props.branches.length > 1
         ? html`
-            <wa-dropdown
-              class="chat-pane__branches-menu"
-              placement="bottom-end"
-              @wa-select=${(event: CustomEvent<{ item: { value?: string } }>) => {
-                const leafEntryId = event.detail.item.value;
-                const branch = props.branches.find(
-                  (candidate) => candidate.leafEntryId === leafEntryId,
-                );
-                if (leafEntryId && branch && !branch.active && !props.branchSwitchDisabledReason) {
-                  props.onBranchSelect(leafEntryId);
-                }
-              }}
+            <openclaw-tooltip
+              .content=${props.branchSwitchDisabledReason ?? t("chat.sessionHeader.branches")}
             >
-              <openclaw-tooltip
-                slot="trigger"
-                .content=${props.branchSwitchDisabledReason ?? t("chat.sessionHeader.branches")}
+              <wa-dropdown
+                class="chat-pane__branches-menu"
+                placement="bottom-end"
+                @wa-select=${(event: CustomEvent<{ item: { value?: string } }>) => {
+                  const leafEntryId = event.detail.item.value;
+                  const branch = props.branches.find(
+                    (candidate) => candidate.leafEntryId === leafEntryId,
+                  );
+                  if (
+                    leafEntryId &&
+                    branch &&
+                    !branch.active &&
+                    !props.branchSwitchDisabledReason
+                  ) {
+                    props.onBranchSelect(leafEntryId);
+                  }
+                }}
               >
                 <button
+                  slot="trigger"
                   class="btn btn--ghost btn--icon chat-icon-btn chat-pane__branches-trigger"
                   type="button"
                   ?disabled=${Boolean(props.branchSwitchDisabledReason)}
@@ -385,40 +390,40 @@ export function renderChatPaneHeader(props: ChatPaneHeaderProps) {
                 >
                   ${icons.gitBranch}
                 </button>
-              </openclaw-tooltip>
-              ${props.branches.map((branch) => {
-                const relativeTime = branchRelativeTime(branch.updatedAt);
-                return html`
-                  <wa-dropdown-item
-                    class="chat-pane__branch-item"
-                    value=${branch.leafEntryId}
-                    ?disabled=${branch.active || Boolean(props.branchSwitchDisabledReason)}
-                    data-active=${branch.active ? "true" : "false"}
-                  >
-                    <span class="chat-pane__branch-copy">
-                      <span class="chat-pane__branch-headline"
-                        >${branch.headline || t("chat.sessionHeader.untitledBranch")}</span
-                      >
-                      <span class="chat-pane__branch-meta"
-                        >${t(
-                          branch.messageCount === 1
-                            ? "chat.sessionHeader.oneMessage"
-                            : "chat.sessionHeader.messages",
-                          { count: String(branch.messageCount) },
-                        )}${relativeTime ? ` · ${relativeTime}` : ""}</span
-                      >
-                    </span>
-                    ${branch.active
-                      ? html`<span
-                          class="chat-pane__branch-active"
-                          aria-label=${t("chat.sessionHeader.activeBranch")}
-                          >${icons.check}</span
-                        >`
-                      : nothing}
-                  </wa-dropdown-item>
-                `;
-              })}
-            </wa-dropdown>
+                ${props.branches.map((branch) => {
+                  const relativeTime = branchRelativeTime(branch.updatedAt);
+                  return html`
+                    <wa-dropdown-item
+                      class="chat-pane__branch-item"
+                      value=${branch.leafEntryId}
+                      ?disabled=${branch.active || Boolean(props.branchSwitchDisabledReason)}
+                      data-active=${branch.active ? "true" : "false"}
+                    >
+                      <span class="chat-pane__branch-copy">
+                        <span class="chat-pane__branch-headline"
+                          >${branch.headline || t("chat.sessionHeader.untitledBranch")}</span
+                        >
+                        <span class="chat-pane__branch-meta"
+                          >${t(
+                            branch.messageCount === 1
+                              ? "chat.sessionHeader.oneMessage"
+                              : "chat.sessionHeader.messages",
+                            { count: String(branch.messageCount) },
+                          )}${relativeTime ? ` · ${relativeTime}` : ""}</span
+                        >
+                      </span>
+                      ${branch.active
+                        ? html`<span
+                            class="chat-pane__branch-active"
+                            aria-label=${t("chat.sessionHeader.activeBranch")}
+                            >${icons.check}</span
+                          >`
+                        : nothing}
+                    </wa-dropdown-item>
+                  `;
+                })}
+              </wa-dropdown>
+            </openclaw-tooltip>
           `
         : nothing}
       ${renderGatewayPicker(props)}


### PR DESCRIPTION
## What Problem This Solves

In the macOS app (and any Control UI host), opening the thread-branches menu in the chat pane header renders the menu pinned to the window's top-left corner — overlapping the Mac traffic lights — instead of dropping down from its trigger button.

Root cause: `wa-dropdown` resolves its popup anchor as the first element assigned to the `trigger` slot (`wa-popup` `handleAnchorChange` → `assignedElements()[0]`). The branches menu passed `<openclaw-tooltip slot="trigger">`, and the tooltip host is `display: contents`, which reports a zero-size rect at (0,0). Floating positioning then anchors the menu to the viewport origin.

## Why This Change Was Made

Restructure the branches menu to the shape every other tooltip-wrapped dropdown in the codebase already uses (e.g. `chat-sidebar-editor-menu.ts`): the `openclaw-tooltip` wraps the whole `wa-dropdown`, and the plain `<button>` carries `slot="trigger"`. The popup now anchors to a real box, and the disabled-reason tooltip still shows (listeners attach to the dropdown host, so it works even while the button is disabled).

## User Impact

The thread-branches dropdown opens attached to its git-branch button in the chat header instead of the top-left corner of the window. Tooltip behavior ("Thread branches" / branch-switch-disabled reason) is unchanged.

## Evidence

- `node scripts/run-vitest.mjs ui/src/pages/chat/components/chat-pane-header.test.ts` — 25/25 pass, including a new regression assertion that the slotted trigger is the button itself (a `display: contents` wrapper would zero the anchor rect again).
- `node scripts/check-changed.mjs` — delegated Testbox run green (0 warnings, 0 errors).
- Codex autoreview (`gpt-5.6-sol`, xhigh) clean: "patch is correct (0.99)".
