### PR TITLE
perf(plugins): serve plugins.list from the process-current metadata snapshot

### DIFF
--- a/src/plugins/management-service-featured.test.ts
+++ b/src/plugins/management-service-featured.test.ts
@@ -7,6 +7,7 @@ const mocks = vi.hoisted(() => ({
 
 vi.mock("./plugin-metadata-snapshot.js", () => ({
   loadPluginMetadataSnapshot: (...args: unknown[]) => mocks.metadata(...args),
+  resolvePluginMetadataSnapshot: (...args: unknown[]) => mocks.metadata(...args),
 }));
 
 vi.mock("./official-external-plugin-catalog.js", async (importOriginal) => ({

--- a/src/plugins/management-service.lifecycle-cache.test.ts
+++ b/src/plugins/management-service.lifecycle-cache.test.ts
@@ -1,7 +1,11 @@
 import { describe, expect, it, vi } from "vitest";
-import { clearPluginMetadataLifecycleCaches } from "./plugin-metadata-lifecycle.js";
+import {
+  clearPluginMetadataLifecycleCaches,
+  registerPluginMetadataProcessMemoLifecycleClear,
+} from "./plugin-metadata-lifecycle.js";
 
 const mocks = vi.hoisted(() => ({
+  currentMetadata: undefined as unknown,
   metadata: vi.fn(),
   officialCatalog: vi.fn(),
 }));
@@ -9,6 +13,14 @@ const mocks = vi.hoisted(() => ({
 vi.mock("./plugin-metadata-snapshot.js", async (importOriginal) => ({
   ...(await importOriginal<typeof import("./plugin-metadata-snapshot.js")>()),
   loadPluginMetadataSnapshot: (...args: unknown[]) => mocks.metadata(...args),
+  resolvePluginMetadataSnapshot: (...args: unknown[]) => {
+    if (mocks.currentMetadata !== undefined) {
+      return mocks.currentMetadata;
+    }
+    const metadata = mocks.metadata(...args);
+    mocks.currentMetadata = metadata;
+    return metadata;
+  },
 }));
 
 vi.mock("./official-external-plugin-catalog.js", async (importOriginal) => ({
@@ -19,16 +31,31 @@ vi.mock("./official-external-plugin-catalog.js", async (importOriginal) => ({
 
 const { listManagedPlugins } = await import("./management-service.js");
 
+registerPluginMetadataProcessMemoLifecycleClear(() => {
+  mocks.currentMetadata = undefined;
+});
+
+function metadataSnapshot(pluginId?: string) {
+  return {
+    index: {
+      plugins: pluginId
+        ? [{ pluginId, packageName: `community/${pluginId}`, origin: "global", enabled: true }]
+        : [],
+      installRecords: {},
+    },
+    byPluginId: new Map(),
+    plugins: [],
+    diagnostics: [],
+    normalizePluginId: (rawPluginId: string) => rawPluginId,
+  };
+}
+
 describe("plugin management catalog lifecycle", () => {
   it("reuses the hosted official catalog until plugin metadata is invalidated", async () => {
     clearPluginMetadataLifecycleCaches();
-    mocks.metadata.mockReturnValue({
-      index: { plugins: [], installRecords: {} },
-      byPluginId: new Map(),
-      plugins: [],
-      diagnostics: [],
-      normalizePluginId: (pluginId: string) => pluginId,
-    });
+    mocks.metadata
+      .mockReturnValueOnce(metadataSnapshot())
+      .mockReturnValueOnce(metadataSnapshot("fresh-plugin"));
     mocks.officialCatalog
       .mockResolvedValueOnce({
         source: "hosted",
@@ -59,13 +86,17 @@ describe("plugin management catalog lifecycle", () => {
 
     expect(initial.plugins).toEqual([expect.objectContaining({ id: "diffs" })]);
     expect(cached.plugins).toEqual(initial.plugins);
+    expect(mocks.metadata).toHaveBeenCalledTimes(1);
     expect(mocks.officialCatalog).toHaveBeenCalledTimes(1);
 
     clearPluginMetadataLifecycleCaches();
 
     const refreshed = await listManagedPlugins({ config: {}, env: {} });
 
+    expect(mocks.metadata).toHaveBeenCalledTimes(2);
     expect(mocks.officialCatalog).toHaveBeenCalledTimes(2);
-    expect(refreshed.plugins).toEqual([]);
+    expect(refreshed.plugins).toEqual([
+      expect.objectContaining({ id: "fresh-plugin", installed: true, enabled: true }),
+    ]);
   });
 });

--- a/src/plugins/management-service.test.ts
+++ b/src/plugins/management-service.test.ts
@@ -1,4 +1,3 @@
-// Plugin management service tests cover cold state, catalog identity, and guarded mutations.
 import { expectDefined } from "@openclaw/normalization-core";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -53,6 +52,7 @@ vi.mock("./registry-refresh.js", () => ({
 
 vi.mock("./plugin-metadata-snapshot.js", () => ({
   loadPluginMetadataSnapshot: (...args: unknown[]) => mocks.metadata(...args),
+  resolvePluginMetadataSnapshot: (...args: unknown[]) => mocks.metadata(...args),
 }));
 
 vi.mock("./clawhub.js", () => ({
@@ -1082,8 +1082,7 @@ describe("plugin management service", () => {
     await expect(uninstallManagedPlugin({ pluginId: "workboard", env: {} })).rejects.toThrow(
       "bundled plugin cannot be uninstalled",
     );
-    expect(mocks.commitRecords).not.toHaveBeenCalled();
-    expect(mocks.applyUninstall).not.toHaveBeenCalled();
+    expect([mocks.commitRecords.mock.calls, mocks.applyUninstall.mock.calls]).toEqual([[], []]);
   });
 
   it("surfaces uninstall plan failures as lifecycle errors", async () => {

--- a/src/plugins/management-service.ts
+++ b/src/plugins/management-service.ts
@@ -68,7 +68,11 @@ import {
 } from "./official-external-plugin-catalog.js";
 import { withPluginLifecycleLease } from "./plugin-lifecycle-lease.js";
 import { registerPluginMetadataProcessMemoLifecycleClear } from "./plugin-metadata-lifecycle.js";
-import { loadPluginMetadataSnapshot } from "./plugin-metadata-snapshot.js";
+import {
+  loadPluginMetadataSnapshot,
+  resolvePluginMetadataSnapshot,
+  type PluginMetadataSnapshot,
+} from "./plugin-metadata-snapshot.js";
 import { resolveManifestProviderAuthChoices } from "./provider-auth-choices.js";
 import { listRecommendedToolInstalls } from "./recommended-tool-installs.js";
 import { refreshPluginRegistryAfterConfigMutation } from "./registry-refresh.js";
@@ -526,7 +530,6 @@ function resolveOfficialCatalogIconUrl(
   return resolveCatalogEntryIcon(entry);
 }
 
-type PluginMetadataSnapshot = ReturnType<typeof loadPluginMetadataSnapshot>;
 type PluginIndexRecord = PluginMetadataSnapshot["index"]["plugins"][number];
 
 function resolveInstalledHostedOfficialEntry(params: {
@@ -643,7 +646,7 @@ export async function resolveManagedPluginIconUrl(params: {
   officialCatalog?: OfficialCatalogResult;
 }): Promise<string | undefined> {
   const env = params.env ?? process.env;
-  const metadata = loadPluginMetadataSnapshot({ config: params.config, env });
+  const metadata = resolvePluginMetadataSnapshot({ config: params.config, env });
   const officialCatalog = params.officialCatalog ?? (await loadOfficialCatalog());
   return resolvePluginIconUrlFromCatalogFacts({
     metadata,
@@ -700,7 +703,7 @@ export async function listManagedPlugins(params: {
   officialCatalog?: OfficialCatalogResult;
 }): Promise<ManagedPluginCatalog> {
   const env = params.env ?? process.env;
-  const metadata = loadPluginMetadataSnapshot({ config: params.config, env });
+  const metadata = resolvePluginMetadataSnapshot({ config: params.config, env });
   const officialCatalog = params.officialCatalog ?? (await loadOfficialCatalog());
   const bundledOfficialEntries = listOfficialExternalPluginCatalogEntries();
   const plugins = metadata.index.plugins.map((record): ManagedPluginCatalogEntry => {


### PR DESCRIPTION
## What Problem This Solves

`plugins.list` on team.openclaw.ai logs 554ms avg (max 1409ms). `listManagedPlugins` and `listManagedPluginCatalog` called `loadPluginMetadataSnapshot(...)` — the unconditional full-scan entrypoint (registry snapshot + manifest registry rebuild + owner map + freeze, ~100ms+ per scan) — on every RPC, while the rest of the codebase serves the process-current snapshot.

## Why This Change Was Made

Gateway plugin metadata is process-stable by repo policy: installs/manifests change only via restart or explicit owner flows. `resolvePluginMetadataSnapshot` already implements the compatibility validation (config/env/index/policyHash/workspaceDir) with cold-scan fallback, so both list paths now use it.

## User Impact

Plugins page listing drops from ~554ms to warm double-digits; first call after a hosted-catalog fetch remains the only slow one.

## Evidence

- Both call sites swapped (`management-service.ts:646,:703`); tight 7/4 prod diff.
- Regression tests: repeated lists perform one metadata scan (spy); `plugins.refresh` → list observes fresh metadata; install/setEnabled invalidate via persisted registry writes; official-catalog promise cache still bounds the first fetch.
- Focused suites 66/66 + repaired shard 20/20; both deadcode lanes, full lint, core prod+test tsgo, format, git diff --check clean; autoreview clean. Testbox run: https://github.com/openclaw/openclaw/actions/runs/30384114637
