### PR TITLE
fix: UI vitest shard flakes when agent-tool chip click leaks #agent-tool-read into shared jsdom history

### DIFF
--- a/ui/src/pages/agents/panels-tools-skills.browser.test.ts
+++ b/ui/src/pages/agents/panels-tools-skills.browser.test.ts
@@ -1,6 +1,6 @@
 // Control UI tests cover agents panels tools skills behavior.
 import { render } from "lit";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { SkillStatusEntry } from "../../api/types.ts";
 import { renderAgentSkills, renderAgentTools } from "./panels-tools-skills.ts";
 
@@ -431,7 +431,11 @@ describe("agents tools panel (browser)", () => {
     expect(group.open).toBe(false);
     expect(tool.open).toBe(false);
 
-    const previousUrl = `${window.location.pathname}${window.location.search}${window.location.hash}`;
+    // The chip handler navigates via history.replaceState on shared jsdom
+    // history. Stub it so the click can never leak #agent-tool-read into
+    // later files that share this worker (see #115221; the finally-restore
+    // there stayed racy across CI pools and file orderings).
+    const replaceStateSpy = vi.spyOn(window.history, "replaceState").mockImplementation(() => {});
     try {
       chip.click();
       await new Promise((resolve) => {
@@ -440,10 +444,11 @@ describe("agents tools panel (browser)", () => {
 
       expect(group.open).toBe(true);
       expect(tool.open).toBe(true);
+      expect(replaceStateSpy).toHaveBeenCalledTimes(1);
+      expect(String(replaceStateSpy.mock.calls[0]?.[2])).toContain("#agent-tool-read");
+      expect(window.location.hash).toBe("");
     } finally {
-      // Hash links mutate shared jsdom history; restore the actual prior URL
-      // so a later Settings route never inherits this tool-card deep link.
-      window.history.replaceState({}, "", previousUrl);
+      replaceStateSpy.mockRestore();
       container.remove();
     }
   });


### PR DESCRIPTION
Fixes openclaw/openclaw#115355
Completes #115221.

## What Problem This Solves

Fixes an issue where contributors' PRs would intermittently fail CI on unrelated UI tests when the shared UI vitest worker carried a stale `#agent-tool-read` location hash out of the agent tools browser test. The recurring flake has bitten #114628, #114662, #114750, #114991, and #115221's own first hosted full-suite run (three moved-Settings-route regressions). #115221 (58a3679c49) restored the previous URL in a `finally` block after the click, but that cleanup stays racy across CI pools and file orderings, so the pollution source remained.

## Why This Change Was Made

The agent tools browser test clicks a real anchor chip whose handler calls `history.replaceState` on shared jsdom history. Instead of mutating real history and racing to restore it, the test now stubs `window.history.replaceState` for the duration of the click, so it can never leak the hash regardless of pool, worker reuse, or environment-teardown timing. The stub also lets the test assert the handler still requested the `#agent-tool-read` deep link, strengthening coverage of the behavior the click exists to exercise.

## User Impact

No user-visible impact. Contributors and maintainers should no longer see unrelated `config-page.test.ts` "moved section routes" failures (expected `hash: ""`, got `#agent-tool-read`) blocking unrelated PRs.

## Evidence

- Polluter + victim together on the fixed branch: `panels-tools-skills.browser.test.ts` + `config-page.test.ts`, 24/24 tests pass with `--maxWorkers=1`.
- Broader scope: all `ui/src/pages/agents/` + `ui/src/pages/config/` suites — 23 files, 251/251 tests pass.
- Local investigation notes: jsdom registries are fresh per file in the default local pool, so the leak only manifests under hosted full-suite scheduling (matching the intermittent CI failures); the stub removes the mutation outright, so no run configuration can propagate it.

AI-assisted: this fix was investigated, implemented, and verified with AI assistance (triage of the pollution source, local repro attempts, and test verification as listed above).