### PR TITLE
fix(slack): keep outbound hooks ahead of previews

### DIFF
--- a/extensions/slack/src/monitor/message-handler/dispatch-setup.ts
+++ b/extensions/slack/src/monitor/message-handler/dispatch-setup.ts
@@ -13,6 +13,7 @@ import {
   resolveChannelStreamingNativeTransport,
 } from "openclaw/plugin-sdk/channel-outbound";
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
+import { getGlobalHookRunner } from "openclaw/plugin-sdk/plugin-runtime";
 import { resolveInboundLastRouteSessionKey } from "openclaw/plugin-sdk/routing";
 import { danger, logVerbose } from "openclaw/plugin-sdk/runtime-env";
 import { resolvePinnedMainDmOwnerFromAllowlist } from "openclaw/plugin-sdk/security-runtime";
@@ -269,7 +270,15 @@ export async function createSlackDispatchSetup(prepared: PreparedSlackMessage) {
       messageTs,
       isThreadReply,
     });
+  const hookRunner = getGlobalHookRunner();
+  const modifyingHooksRegistered =
+    (hookRunner?.hasHooks("reply_payload_sending") ?? false) ||
+    (hookRunner?.hasHooks("message_sending") ?? false);
+  // Portable previews and native progress cards exist before outbound modifiers accept the
+  // payload. Native answer streaming stays enabled because it begins after both hook gates.
+  const allowPreHookProviderStreaming = !modifyingHooksRegistered;
   const previewStreamingEnabled =
+    allowPreHookProviderStreaming &&
     !sourceRepliesAreToolOnly &&
     shouldEnableSlackPreviewStreaming({
       mode: slackStreaming.mode,
@@ -279,6 +288,7 @@ export async function createSlackDispatchSetup(prepared: PreparedSlackMessage) {
   );
   const streamingEnabled =
     !sourceRepliesAreToolOnly &&
+    (allowPreHookProviderStreaming || slackStreaming.mode !== "progress") &&
     isSlackStreamingEnabled({
       mode: slackStreaming.mode,
       nativeStreaming: slackStreaming.nativeStreaming,

--- a/extensions/slack/src/monitor/message-handler/dispatch.preview-fallback.test.ts
+++ b/extensions/slack/src/monitor/message-handler/dispatch.preview-fallback.test.ts
@@ -6,6 +6,7 @@ const FINAL_REPLY_TEXT = "final answer";
 const THREAD_TS = "thread-1";
 const SAME_TEXT = "same reply";
 
+const getGlobalHookRunnerMock = vi.hoisted(() => vi.fn());
 const createSlackDraftStreamMock = vi.fn();
 const deliverRepliesMock = vi.fn(
   async () => undefined as { messageId?: string; channelId?: string } | undefined,
@@ -843,6 +844,11 @@ vi.mock("openclaw/plugin-sdk/runtime-env", () => ({
   shouldLogVerbose: () => false,
 }));
 
+vi.mock("openclaw/plugin-sdk/plugin-runtime", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("openclaw/plugin-sdk/plugin-runtime")>();
+  return { ...actual, getGlobalHookRunner: getGlobalHookRunnerMock };
+});
+
 vi.mock("openclaw/plugin-sdk/security-runtime", () => ({
   resolvePinnedMainDmOwnerFromAllowlist: () => mockedPinnedMainDmOwner,
 }));
@@ -1101,6 +1107,7 @@ describe("dispatchPreparedSlackMessage preview fallback", () => {
     reactSlackMessageMock.mockReset();
     removeSlackReactionMock.mockReset();
     logVerboseMock.mockReset();
+    getGlobalHookRunnerMock.mockReset().mockReturnValue(undefined);
     for (const value of Object.values(statusReactionControllerMock)) {
       value.mockClear();
     }
@@ -1149,6 +1156,69 @@ describe("dispatchPreparedSlackMessage preview fallback", () => {
     await dispatchPreparedSlackMessage(createPreparedSlackMessage({ turnAdoptionLifecycle }));
 
     expect(capturedReplyOptions?.turnAdoptionLifecycle).toBe(turnAdoptionLifecycle);
+  });
+
+  it("preserves provider previews for observer-only hooks", async () => {
+    getGlobalHookRunnerMock.mockReturnValue({
+      hasHooks: vi.fn((hookName: string) => hookName === "message_sent"),
+    });
+
+    await dispatchPreparedSlackMessage(createPreparedSlackMessage());
+
+    expect(createSlackDraftStreamMock).toHaveBeenCalledTimes(1);
+    expect(finalizeSlackPreviewEditMock).toHaveBeenCalledTimes(1);
+  });
+
+  it.each([
+    { label: "reply_payload_sending", hooks: ["reply_payload_sending"] },
+    { label: "message_sending", hooks: ["message_sending"] },
+    {
+      label: "both modifying hooks",
+      hooks: ["reply_payload_sending", "message_sending"],
+    },
+  ])("suppresses portable provider previews when $label is registered", async ({ hooks }) => {
+    const registered = new Set(hooks);
+    getGlobalHookRunnerMock.mockReturnValue({
+      hasHooks: vi.fn((hookName: string) => registered.has(hookName)),
+    });
+
+    await dispatchPreparedSlackMessage(createPreparedSlackMessage());
+
+    expect(createSlackDraftStreamMock).not.toHaveBeenCalled();
+    expect(finalizeSlackPreviewEditMock).not.toHaveBeenCalled();
+    expect(deliverRepliesMock).toHaveBeenCalledTimes(1);
+    expectDeliverReplyCall(0, FINAL_REPLY_TEXT);
+  });
+
+  it("suppresses native progress cards when a modifying hook is registered", async () => {
+    getGlobalHookRunnerMock.mockReturnValue({
+      hasHooks: vi.fn((hookName: string) => hookName === "message_sending"),
+    });
+
+    await dispatchNativeProgressScenario({
+      finalPayload: { text: FINAL_REPLY_TEXT },
+      events: [{ kind: "item", progressText: "private progress" }],
+    });
+
+    expect(createSlackDraftStreamMock).not.toHaveBeenCalled();
+    expect(startSlackStreamMock).not.toHaveBeenCalled();
+    expect(appendSlackStreamMock).not.toHaveBeenCalled();
+    expect(deliverRepliesMock).toHaveBeenCalledTimes(1);
+    expectDeliverReplyCall(0, FINAL_REPLY_TEXT);
+  });
+
+  it("preserves post-hook native answer streaming when a modifying hook is registered", async () => {
+    getGlobalHookRunnerMock.mockReturnValue({
+      hasHooks: vi.fn((hookName: string) => hookName === "reply_payload_sending"),
+    });
+    mockedNativeStreaming = true;
+
+    await dispatchPreparedSlackMessage(createPreparedSlackMessage());
+
+    expect(createSlackDraftStreamMock).not.toHaveBeenCalled();
+    expect(startSlackStreamMock).toHaveBeenCalledTimes(1);
+    expect(stopSlackStreamMock).toHaveBeenCalledTimes(1);
+    expect(deliverRepliesMock).not.toHaveBeenCalled();
   });
 
   it("falls back to normal delivery when preview finalize fails", async () => {


### PR DESCRIPTION
Related: #92374

## What Problem This Solves

Fixes an issue where Slack users could see provider-owned progress content before an installed outbound hook rewrote or cancelled the corresponding outbound payload. Portable progress drafts and native progress cards were visible before `reply_payload_sending` and `message_sending` completed.

## Why This Change Was Made

Slack now keeps previews enabled for normal and observer-only turns, but disables pre-hook portable previews and native progress cards whenever either modifier-capable outbound hook is registered. Native answer streaming remains enabled because Slack starts that path only after both modifying hook gates.

This is intentionally Slack-owned and adds no core policy, public Plugin SDK surface, configuration, protocol, storage, migration, or dependency.

## User Impact

Slack deployments that use outbound rewrite or cancellation hooks no longer expose unmodified content through pre-hook previews or progress cards. Deployments with no modifying hooks—or only observer hooks such as `message_sent`—retain normal previews. Hook-transformed durable progress and native post-hook answer streaming continue to work.

## Evidence

AI-assisted: yes. I understand and reviewed the implementation and its provider-visible behavior.

Frozen investigation base: `5c6bccff4a1016a7f64cb768df917fc900d443c8`. Current PR head: `59ef2d0db5acbc6f5f1828f904ce6e2997ce18b1`.

### Live external Slack

Production Slack plugin + Gateway, real Socket Mode ingress, real Slack Web API readback, and a live OpenAI model. The QA topology came from the rotated 1Password Slack record; all stored evidence contains hashes and provider IDs only, not credentials or private message content.

| Scenario | Frozen `main` | Candidate |
|---|---|---|
| No hooks | Portable progress remained visible and finalized normally | Preserved |
| Observer-only | Portable progress remained visible; `message_sent` once | Preserved |
| Portable rewrite progress | Unmodified progress visible before RPS/MS completed | Only hook-transformed durable progress visible; RPS once → MS once → rewritten final; no unmodified progress |
| Native progress rewrite | Native progress stream started and unmodified progress was visible before modifiers completed | Native progress stream did not start; only hook-transformed durable progress and rewritten final were visible |
| Native answer rewrite | RPS once → MS once → post-hook native stream → rewritten final | Preserved with the same ordering |
| RPS cancellation | RPS once; no cancelled final or false `message_sent` | RPS once; no cancelled final, unmodified final content, or false `message_sent` |
| MS cancellation | RPS once → MS once; no cancelled final or false `message_sent` | Preserved with no cancelled final or false `message_sent` |

Live run records: [frozen baseline](https://crabbox.openclaw.ai/portal/runs/run_b2bb886e87f7), [candidate progress and cancellation](https://crabbox.openclaw.ai/portal/runs/run_8da005858e20), and [candidate RPS cancellation reconciliation](https://crabbox.openclaw.ai/portal/runs/run_c67412cecbc7).

### Deterministic proof

- Full Slack extension suite: 2,014/2,014 passed on Blacksmith Testbox ([run](https://github.com/openclaw/openclaw/actions/runs/30385413737)).
- Focused dispatch suite: 126/126 passed.
- `pnpm check:changed`: passed extension production/test types, format, lint, boundary/API, import-cycle, and database-first guards.
- `git diff --check`: passed.
- Fresh uncommitted autoreview: clean; no accepted/actionable findings, 0.91 “patch is correct.”
