### PR TITLE
fix: preserve current account routing for delegated messages

### DIFF
--- a/src/agents/tools/message-tool.test.ts
+++ b/src/agents/tools/message-tool.test.ts
@@ -1736,6 +1736,63 @@ describe("message tool secret scoping", () => {
       rejected: true,
       broadcast: true,
     },
+    {
+      name: "delegated channel-less uniformly prefixed broadcast",
+      channel: "googlechat",
+      accountId: "alternate",
+      requesterAccountId: "current",
+      trusted: true,
+      origin: undefined,
+      rejected: true,
+      broadcast: true,
+      broadcastTargets: ["slack:channel:one", "slack:channel:two"],
+    },
+    {
+      name: "delegated all-channel uniformly prefixed broadcast",
+      channel: "googlechat",
+      accountId: "alternate",
+      requesterAccountId: "current",
+      trusted: true,
+      origin: undefined,
+      rejected: true,
+      broadcast: true,
+      broadcastChannel: "all",
+      broadcastTargets: ["slack:channel:one", "slack:channel:two"],
+    },
+    {
+      name: "delegated explicitly scoped cross-provider broadcast",
+      channel: "slack",
+      accountId: "alternate",
+      requesterAccountId: "current",
+      trusted: true,
+      origin: undefined,
+      rejected: false,
+      broadcast: true,
+      broadcastChannel: "slack",
+      broadcastTargets: ["slack:channel:one", "slack:channel:two"],
+    },
+    {
+      name: "delegated channel-less broadcast with matching current account",
+      channel: "googlechat",
+      accountId: "current",
+      requesterAccountId: "current",
+      trusted: true,
+      origin: undefined,
+      rejected: false,
+      broadcast: true,
+      broadcastTargets: ["slack:channel:one", "slack:channel:two"],
+    },
+    {
+      name: "direct channel-less uniformly prefixed broadcast",
+      channel: "googlechat",
+      accountId: "alternate",
+      requesterAccountId: undefined,
+      trusted: false,
+      origin: "direct-operator" as const,
+      rejected: false,
+      broadcast: true,
+      broadcastTargets: ["slack:channel:one", "slack:channel:two"],
+    },
   ])(
     "$name respects trusted current-turn account isolation before secret resolution",
     async (testCase) => {
@@ -1820,7 +1877,13 @@ describe("message tool secret scoping", () => {
       const invocation = testCase.broadcast
         ? tool.execute("1", {
             action: "broadcast",
-            targets: ["googlechat:spaces/current", "slack:channel:other"],
+            ...("broadcastChannel" in testCase && testCase.broadcastChannel
+              ? { channel: testCase.broadcastChannel }
+              : {}),
+            targets:
+              "broadcastTargets" in testCase
+                ? testCase.broadcastTargets
+                : ["googlechat:spaces/current", "slack:channel:other"],
             accountId: testCase.accountId,
             message: "hi",
           })

--- a/src/agents/tools/message-tool.test.ts
+++ b/src/agents/tools/message-tool.test.ts
@@ -1662,6 +1662,189 @@ describe("message tool secret scoping", () => {
     expect(mocks.runMessageAction).not.toHaveBeenCalled();
   });
 
+  it.each([
+    {
+      name: "delegated same-provider alternate",
+      channel: "googlechat",
+      accountId: "alternate",
+      requesterAccountId: "current",
+      trusted: true,
+      origin: undefined,
+      rejected: true,
+    },
+    {
+      name: "delegated same-provider account with equivalent casing",
+      channel: "googlechat",
+      accountId: "CURRENT",
+      requesterAccountId: "current",
+      trusted: true,
+      origin: undefined,
+      rejected: false,
+    },
+    {
+      name: "direct same-provider alternate without a turn capability",
+      channel: "googlechat",
+      accountId: "alternate",
+      requesterAccountId: undefined,
+      trusted: false,
+      origin: "direct-operator" as const,
+      rejected: false,
+    },
+    {
+      name: "delegated cross-provider alternate",
+      channel: "slack",
+      accountId: "alternate",
+      requesterAccountId: "current",
+      trusted: true,
+      origin: undefined,
+      rejected: false,
+    },
+    {
+      name: "source-less same-provider alternate",
+      channel: "googlechat",
+      accountId: "alternate",
+      requesterAccountId: undefined,
+      trusted: false,
+      origin: undefined,
+      rejected: false,
+    },
+    {
+      name: "delegated same-provider account without trusted account identity",
+      channel: "googlechat",
+      accountId: "alternate",
+      requesterAccountId: undefined,
+      trusted: true,
+      origin: undefined,
+      rejected: true,
+    },
+    {
+      name: "unknown-origin same-provider alternate",
+      channel: "googlechat",
+      accountId: "alternate",
+      requesterAccountId: "current",
+      trusted: true,
+      origin: "future-origin" as never,
+      rejected: true,
+    },
+    {
+      name: "delegated unscoped broadcast including the current provider",
+      channel: "googlechat",
+      accountId: "alternate",
+      requesterAccountId: "current",
+      trusted: true,
+      origin: undefined,
+      rejected: true,
+      broadcast: true,
+    },
+  ])(
+    "$name respects trusted current-turn account isolation before secret resolution",
+    async (testCase) => {
+      const googleChatPlugin = createChannelPlugin({
+        id: "googlechat",
+        label: "Google Chat",
+        docsPath: "/channels/googlechat",
+        blurb: "test",
+        actions: ["send"],
+        config: {
+          listAccountIds: () => ["current", "alternate"],
+          resolveAccount: () => ({ enabled: true }),
+        },
+      });
+      const slackPlugin = createChannelPlugin({
+        id: "slack",
+        label: "Slack",
+        docsPath: "/channels/slack",
+        blurb: "test",
+        actions: ["send"],
+        config: {
+          listAccountIds: () => ["alternate"],
+          resolveAccount: () => ({ enabled: true }),
+        },
+      });
+      setActivePluginRegistry(
+        createTestRegistry([
+          { pluginId: "googlechat", source: "test", plugin: googleChatPlugin },
+          { pluginId: "slack", source: "test", plugin: slackPlugin },
+        ]),
+      );
+      const token = testCase.trusted
+        ? mintMessageActionTurnCapability({
+            agentId: "main",
+            runId: "run-1",
+            sessionKey: "agent:main:googlechat:current:space:current",
+            sessionId: "session-1",
+            requesterAccountId: testCase.requesterAccountId,
+            toolContext: {
+              currentChannelProvider: "googlechat",
+              currentChannelId: "spaces/current",
+            },
+          })
+        : undefined;
+      if (token) {
+        mintedTurnCapabilities.push(token);
+      }
+      mockSendResult({
+        channel: testCase.channel,
+        to: testCase.channel === "googlechat" ? "spaces/current" : "channel:other",
+      });
+
+      const tool = createMessageTool({
+        agentId: "main",
+        runId: "run-1",
+        agentSessionKey: "agent:main:googlechat:current:space:current",
+        sessionId: "session-1",
+        messageActionTurnCapability: token,
+        conversationReadOrigin: testCase.origin,
+        config: {
+          channels: {
+            googlechat: {
+              accounts: {
+                current: { serviceAccount: "current-credentials" },
+                alternate: { serviceAccount: "alternate-credentials" },
+              },
+            },
+            slack: {
+              accounts: {
+                alternate: { botToken: "alternate-token" },
+              },
+            },
+          },
+        } as never,
+        currentChannelProvider: "googlechat",
+        currentChannelId: "spaces/current",
+        agentAccountId: "current",
+        resolveCommandSecretRefsViaGateway: mocks.resolveCommandSecretRefsViaGateway as never,
+        runMessageAction: mocks.runMessageAction as never,
+      });
+
+      const invocation = testCase.broadcast
+        ? tool.execute("1", {
+            action: "broadcast",
+            targets: ["googlechat:spaces/current", "slack:channel:other"],
+            accountId: testCase.accountId,
+            message: "hi",
+          })
+        : tool.execute("1", {
+            action: "send",
+            channel: testCase.channel,
+            target: testCase.channel === "googlechat" ? "spaces/current" : "channel:other",
+            accountId: testCase.accountId,
+            message: "hi",
+          });
+
+      if (testCase.rejected) {
+        await expect(invocation).rejects.toThrow("does not match the trusted current account");
+        expect(mocks.resolveCommandSecretRefsViaGateway).not.toHaveBeenCalled();
+        expect(mocks.runMessageAction).not.toHaveBeenCalled();
+        return;
+      }
+
+      await expect(invocation).resolves.toBeDefined();
+      expect(mocks.resolveCommandSecretRefsViaGateway).toHaveBeenCalledOnce();
+      expect(mocks.runMessageAction).toHaveBeenCalledOnce();
+    },
+  );
+
   it("does not resolve secrets for broadcast channels that reject the explicit account", async () => {
     const slackPlugin = createChannelPlugin({
       id: "slack",

--- a/src/agents/tools/message-tool.test.ts
+++ b/src/agents/tools/message-tool.test.ts
@@ -404,6 +404,7 @@ function createChannelPlugin(params: {
   config?: Partial<ChannelPlugin["config"]>;
   message?: ChannelMessageAdapterShape;
   messaging?: ChannelPlugin["messaging"];
+  outbound?: ChannelPlugin["outbound"];
 }): ChannelPlugin {
   return {
     id: params.id as ChannelPlugin["id"],
@@ -423,6 +424,7 @@ function createChannelPlugin(params: {
     },
     ...(params.message ? { message: params.message } : {}),
     ...(params.messaging ? { messaging: params.messaging } : {}),
+    ...(params.outbound ? { outbound: params.outbound } : {}),
     actions: {
       describeMessageTool:
         params.describeMessageTool ??
@@ -1772,6 +1774,44 @@ describe("message tool secret scoping", () => {
       broadcastTargets: ["slack:channel:one", "slack:channel:two"],
     },
     {
+      name: "delegated fallback-resolved current-provider broadcast",
+      channel: "googlechat",
+      accountId: "alternate",
+      requesterAccountId: "current",
+      trusted: true,
+      origin: undefined,
+      rejected: true,
+      broadcast: true,
+      broadcastChannel: "last",
+      broadcastTargets: ["googlechat:spaces/current"],
+    },
+    {
+      name: "delegated fallback-resolved broadcast with matching current account",
+      channel: "googlechat",
+      accountId: "current",
+      requesterAccountId: "current",
+      trusted: true,
+      origin: undefined,
+      rejected: false,
+      broadcast: true,
+      broadcastChannel: "last",
+      broadcastTargets: ["googlechat:spaces/current"],
+      expectedRunnerChannel: "googlechat",
+    },
+    {
+      name: "direct fallback-resolved broadcast with alternate account",
+      channel: "googlechat",
+      accountId: "alternate",
+      requesterAccountId: undefined,
+      trusted: false,
+      origin: "direct-operator" as const,
+      rejected: false,
+      broadcast: true,
+      broadcastChannel: "last",
+      broadcastTargets: ["googlechat:spaces/current"],
+      expectedRunnerChannel: "googlechat",
+    },
+    {
       name: "delegated channel-less broadcast with matching current account",
       channel: "googlechat",
       accountId: "current",
@@ -1806,6 +1846,7 @@ describe("message tool secret scoping", () => {
           listAccountIds: () => ["current", "alternate"],
           resolveAccount: () => ({ enabled: true }),
         },
+        outbound: { deliveryMode: "direct", sendText: vi.fn() as never },
       });
       const slackPlugin = createChannelPlugin({
         id: "slack",
@@ -1817,6 +1858,7 @@ describe("message tool secret scoping", () => {
           listAccountIds: () => ["alternate"],
           resolveAccount: () => ({ enabled: true }),
         },
+        outbound: { deliveryMode: "direct", sendText: vi.fn() as never },
       });
       setActivePluginRegistry(
         createTestRegistry([
@@ -1905,6 +1947,9 @@ describe("message tool secret scoping", () => {
       await expect(invocation).resolves.toBeDefined();
       expect(mocks.resolveCommandSecretRefsViaGateway).toHaveBeenCalledOnce();
       expect(mocks.runMessageAction).toHaveBeenCalledOnce();
+      if ("expectedRunnerChannel" in testCase) {
+        expect(firstRunMessageActionInput()?.params?.channel).toBe(testCase.expectedRunnerChannel);
+      }
     },
   );
 

--- a/src/agents/tools/message-tool.ts
+++ b/src/agents/tools/message-tool.ts
@@ -51,6 +51,7 @@ import {
 import { resolveMessageActionTurnCapability } from "../../gateway/message-action-turn-capability.js";
 import { createAbortError } from "../../infra/abort-signal.js";
 import { sha256Base64UrlPrefix } from "../../infra/crypto-digest.js";
+import { resolveMessageChannelSelection } from "../../infra/outbound/channel-selection.js";
 import {
   resolveMessageBroadcastAccountPlan,
   validateExplicitMessageAccountSelection,
@@ -1589,12 +1590,26 @@ export function createMessageTool(options?: MessageToolOptions): AnyAgentTool {
       const gatewayOpts = readGatewayCallOptions(params);
       const rawConfig = options?.config ?? loadConfigForTool();
       const requestedAccountId = readStringParam(params, "accountId");
-      const requestedScope = resolveMessageSecretScope({
-        channel: params.channel,
-        target: params.target,
-        targets: params.targets,
+      validateExplicitMessageAccountSelection({
+        cfg: rawConfig,
         accountId: requestedAccountId,
+        checkResolvedAccount: false,
       });
+      const requestedBroadcastChannel = normalizeOptionalLowercaseString(params.channel);
+      if (
+        action === "broadcast" &&
+        requestedBroadcastChannel &&
+        requestedBroadcastChannel !== "all"
+      ) {
+        // Authorize and execute the same canonical provider. Otherwise an unavailable
+        // hint can fall back to the current provider only after account authorization.
+        const selection = await resolveMessageChannelSelection({
+          cfg: rawConfig,
+          channel: requestedBroadcastChannel,
+          fallbackChannel: effectiveCurrentChannel.currentChannelProvider,
+        });
+        params.channel = selection.channel;
+      }
       const scope = resolveMessageSecretScope({
         channel: params.channel,
         target: params.target,
@@ -1603,7 +1618,6 @@ export function createMessageTool(options?: MessageToolOptions): AnyAgentTool {
         accountId: requestedAccountId,
         fallbackAccountId: agentAccountId,
       });
-      const requestedBroadcastChannel = normalizeOptionalLowercaseString(params.channel);
       // Broadcast execution only narrows on an explicit non-all channel. Target
       // prefixes cannot authorize fewer providers than the runner will execute.
       const unscopedExplicitBroadcast =
@@ -1627,12 +1641,7 @@ export function createMessageTool(options?: MessageToolOptions): AnyAgentTool {
         explicitAccountId,
         selectedChannels: broadcastAccountPlan
           ? broadcastAccountPlan.candidateChannels
-          : [
-              requestedScope.channel ??
-                (action === "broadcast"
-                  ? undefined
-                  : trustedTurnContext?.toolContext?.currentChannelProvider),
-            ],
+          : [scope.channel],
         trustedCurrentChannel: trustedTurnContext?.toolContext?.currentChannelProvider,
         trustedRequesterAccountId: trustedTurnContext?.requesterAccountId,
         hasTrustedTurnContext: trustedTurnContext !== undefined,

--- a/src/agents/tools/message-tool.ts
+++ b/src/agents/tools/message-tool.ts
@@ -74,6 +74,7 @@ import { hasReplyPayloadContent } from "../../interactive/payload.js";
 import { stringifyRouteThreadId } from "../../plugin-sdk/channel-route.js";
 import { getPreparedMessageToolCatalog } from "../../plugins/prepared-message-tool-catalog.js";
 import { POLL_CREATION_PARAM_DEFS, SHARED_POLL_CREATION_PARAM_NAMES } from "../../poll-params.js";
+import { normalizeOptionalAccountId } from "../../routing/account-id.js";
 import { normalizeAccountId, parseSessionDeliveryRoute } from "../../routing/session-key.js";
 import { stripFormattedReasoningMessage } from "../../shared/text/formatted-reasoning-message.js";
 import { INTERNAL_MESSAGE_CHANNEL, normalizeMessageChannel } from "../../utils/message-channel.js";
@@ -1071,6 +1072,33 @@ type MessageToolOptions = {
   conversationReadOrigin?: ConversationReadInvocationOrigin;
 };
 
+// A live channel turn grants delegated use of that provider account, not a
+// model-selected sibling account. Keep cross-provider and source-less routing intact.
+function enforceTrustedTurnExplicitAccount(params: {
+  explicitAccountId?: string;
+  selectedChannels: Array<string | undefined>;
+  trustedCurrentChannel?: string;
+  trustedRequesterAccountId?: string;
+  hasTrustedTurnContext: boolean;
+}): void {
+  if (!params.explicitAccountId || !params.hasTrustedTurnContext) {
+    return;
+  }
+  const trustedCurrentChannel = normalizeMessageChannel(params.trustedCurrentChannel);
+  if (!trustedCurrentChannel) {
+    throw new Error("Trusted current account is missing its channel identity.");
+  }
+  const includesTrustedCurrentChannel = params.selectedChannels.some(
+    (channel) => normalizeMessageChannel(channel) === trustedCurrentChannel,
+  );
+  if (!includesTrustedCurrentChannel) {
+    return;
+  }
+  if (normalizeOptionalAccountId(params.trustedRequesterAccountId) !== params.explicitAccountId) {
+    throw new Error("Explicit account does not match the trusted current account.");
+  }
+}
+
 type MessageToolDiscoveryParams = {
   cfg: OpenClawConfig;
   currentChannelProvider?: string;
@@ -1583,10 +1611,6 @@ export function createMessageTool(options?: MessageToolOptions): AnyAgentTool {
         accountId: requestedAccountId,
         checkResolvedAccount: false,
       });
-      if (explicitAccountId) {
-        scope.accountId = explicitAccountId;
-        params.accountId = explicitAccountId;
-      }
       const broadcastAccountPlan =
         unscopedExplicitBroadcast && explicitAccountId
           ? resolveMessageBroadcastAccountPlan({
@@ -1594,6 +1618,24 @@ export function createMessageTool(options?: MessageToolOptions): AnyAgentTool {
               accountId: explicitAccountId,
             })
           : undefined;
+      enforceTrustedTurnExplicitAccount({
+        explicitAccountId,
+        selectedChannels: broadcastAccountPlan
+          ? broadcastAccountPlan.candidateChannels
+          : [
+              requestedScope.channel ??
+                (action === "broadcast"
+                  ? undefined
+                  : trustedTurnContext?.toolContext?.currentChannelProvider),
+            ],
+        trustedCurrentChannel: trustedTurnContext?.toolContext?.currentChannelProvider,
+        trustedRequesterAccountId: trustedTurnContext?.requesterAccountId,
+        hasTrustedTurnContext: trustedTurnContext !== undefined,
+      });
+      if (explicitAccountId) {
+        scope.accountId = explicitAccountId;
+        params.accountId = explicitAccountId;
+      }
       const scopedTargets = getScopedSecretTargetsForTool({
         config: rawConfig,
         channel: broadcastAccountPlan ? undefined : scope.channel,

--- a/src/agents/tools/message-tool.ts
+++ b/src/agents/tools/message-tool.ts
@@ -1603,8 +1603,13 @@ export function createMessageTool(options?: MessageToolOptions): AnyAgentTool {
         accountId: requestedAccountId,
         fallbackAccountId: agentAccountId,
       });
+      const requestedBroadcastChannel = normalizeOptionalLowercaseString(params.channel);
+      // Broadcast execution only narrows on an explicit non-all channel. Target
+      // prefixes cannot authorize fewer providers than the runner will execute.
       const unscopedExplicitBroadcast =
-        action === "broadcast" && !requestedScope.channel && requestedAccountId !== undefined;
+        action === "broadcast" &&
+        (!requestedBroadcastChannel || requestedBroadcastChannel === "all") &&
+        requestedAccountId !== undefined;
       const explicitAccountId = validateExplicitMessageAccountSelection({
         cfg: rawConfig,
         channel: unscopedExplicitBroadcast ? undefined : scope.channel,


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where a delegated same-channel message action could select a configured account other than the account associated with the active inbound turn. This also covers channel-less, `channel: all`, and fallback-resolved broadcasts.

## Why This Change Was Made

The message tool now validates explicit same-provider account selection against host-issued current-turn context before resolving channel credentials. Broadcast authorization uses the same provider expansion and fallback selection as execution, with one canonical provider passed into the runner. Direct operator, source-less, matching-account, and permitted cross-provider routing remain unchanged.

This change is AI-assisted and was reviewed against the complete message-tool execution path, account normalization and validation, secret scoping, broadcast planning, channel fallback selection, outbound policy, and turn-capability ownership.

## User Impact

Model-triggered message actions on the active channel stay associated with the inbound channel account. Delegated same-provider sibling-account actions fail closed. Existing direct operator actions, valid matching-account calls, source-less routing, and permitted cross-provider workflows continue to work as before.

## Evidence

- Focused message-tool suite: `165/165` passed locally.
- Focused Linux owner/routing suite: `351/351` passed on [Blacksmith Testbox](https://github.com/openclaw/openclaw/actions/runs/30423029060).
- Scoped changed gate for core and core tests: passed.
- Production build: passed.
- Fresh autoreview: clean.
- Exact-HEAD local ClawSweeper review: no findings; security review cleared.
- Live Google Chat direct account-selection matrix: all six states passed with provider-side verification.
- Live Google Chat delegated account-selection matrix: all six real human UI-inbound, model-selected states passed with provider-side verification.
- Live Google Chat + Slack broadcast matrix: eight model-selected delegated cases and direct-before/direct-after controls passed.
- Omitted-channel, `channel: all`, explicit-current, and fallback-resolved sibling-account cases rejected with zero mutation on either provider.
- Explicit permitted cross-provider, matching-current, fallback-resolved matching-current, and matching unscoped controls produced exactly the intended provider mutations.
- Exact candidate for the final focused and live proof: `f2f46a1cf7459adadad6329c470034684a5db78d`.
