### PR TITLE
perf(sessions): incremental snapshot revalidation and shallow list projections

### DIFF
--- a/src/config/sessions/session-accessor.sqlite-data-version.test.ts
+++ b/src/config/sessions/session-accessor.sqlite-data-version.test.ts
@@ -19,6 +19,7 @@ import {
 import { ensureTranscriptSessionRoot } from "./session-accessor.sqlite-transcript-state.js";
 
 const parseSessionEntryCalls = vi.hoisted(() => vi.fn());
+const listProjectionCalls = vi.hoisted(() => vi.fn());
 
 vi.mock("./session-accessor.sqlite-status.js", async (importOriginal) => {
   const actual = await importOriginal<typeof import("./session-accessor.sqlite-status.js")>();
@@ -28,7 +29,18 @@ vi.mock("./session-accessor.sqlite-status.js", async (importOriginal) => {
       row: Parameters<typeof actual.parseSqliteSessionEntryJson>[0],
     ) => {
       parseSessionEntryCalls();
-      return actual.parseSqliteSessionEntryJson(row);
+      const entry = actual.parseSqliteSessionEntryJson(row);
+      if (entry?.label?.startsWith("projection-probe")) {
+        Object.defineProperty(entry, "__projectionProbe", {
+          configurable: true,
+          enumerable: true,
+          get: () => {
+            listProjectionCalls();
+            return entry.sessionId;
+          },
+        });
+      }
+      return entry;
     },
   };
 });
@@ -37,6 +49,7 @@ const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
 beforeEach(() => {
   parseSessionEntryCalls.mockClear();
+  listProjectionCalls.mockClear();
 });
 
 afterEach(() => {
@@ -111,12 +124,13 @@ function createSessionScope(label: string) {
 }
 
 describe("SQLite session entry cache", () => {
-  it("keeps sqlite-entry-cache list projections lazy and memoized per key", async () => {
+  it("keeps sqlite-entry-cache list projections shallow, lazy, and memoized per key", async () => {
     const scope = createSessionScope("lazy-list-projection");
     await upsertSessionEntry(scope, {
       label: "projected",
       sessionId: "lazy-list-projection",
       updatedAt: 1,
+      worktree: { id: "worktree-1", branch: "main", repoRoot: "/repo" },
       skillsSnapshot: { prompt: "large skill prompt", skills: [] },
       systemPromptReport: {
         source: "run",
@@ -128,19 +142,13 @@ describe("SQLite session entry cache", () => {
       },
     });
 
-    const cloneEntry = globalThis.structuredClone;
+    const fullEntry = listSessionEntries({ ...scope, clone: false })[0]?.entry;
+    expect(fullEntry).toBeDefined();
+    if (!fullEntry) {
+      throw new Error("missing seeded lazy-list-projection entry");
+    }
     const cloneSpy = vi.spyOn(globalThis, "structuredClone");
     try {
-      const fullEntry = listSessionEntries({ ...scope, clone: false })[0]?.entry;
-      expect(fullEntry).toBeDefined();
-      expect(cloneSpy).not.toHaveBeenCalled();
-      if (!fullEntry) {
-        throw new Error("missing seeded lazy-list-projection entry");
-      }
-      const expected = cloneEntry(fullEntry);
-      delete expected.skillsSnapshot;
-      delete expected.systemPromptReport;
-
       const first = listSessionEntries({
         ...scope,
         clone: false,
@@ -152,9 +160,12 @@ describe("SQLite session entry cache", () => {
         projection: "list",
       })[0]?.entry;
 
-      expect(first).toEqual(expected);
+      expect(first).not.toBe(fullEntry);
+      expect(first?.worktree).toBe(fullEntry.worktree);
+      expect(first?.skillsSnapshot).toBeUndefined();
+      expect(first?.systemPromptReport).toBeUndefined();
       expect(second).toBe(first);
-      expect(cloneSpy).toHaveBeenCalledOnce();
+      expect(cloneSpy).not.toHaveBeenCalled();
     } finally {
       cloneSpy.mockRestore();
     }
@@ -178,10 +189,58 @@ describe("SQLite session entry cache", () => {
     expect(second).toEqual(first);
   });
 
-  it("reloads after another connection commits", async () => {
+  it("reuses parsed entries and list projections after a same-connection non-entry write", async () => {
+    const scope = createSessionScope("same-connection-non-entry");
+    const siblingScope = { ...scope, sessionKey: "agent:main:same-connection-non-entry-2" };
+    await upsertSessionEntry(scope, {
+      label: "projection-probe-first",
+      sessionId: "same-connection-non-entry",
+      updatedAt: 1,
+    });
+    await upsertSessionEntry(siblingScope, {
+      label: "projection-probe-second",
+      sessionId: "same-connection-non-entry-2",
+      updatedAt: 1,
+    });
+    const first = listSessionEntries({ ...scope, clone: false, projection: "list" });
+
+    const database = openOpenClawAgentDatabase(scope);
+    ensureTranscriptSessionRoot(
+      database,
+      {
+        agentId: scope.agentId,
+        env: scope.env,
+        sessionId: "same-connection-non-entry",
+        sessionKey: scope.sessionKey,
+      },
+      2,
+    );
+    parseSessionEntryCalls.mockClear();
+    listProjectionCalls.mockClear();
+
+    const second = listSessionEntries({ ...scope, clone: false, projection: "list" });
+
+    expect(second.map((row) => row.entry)).toEqual(first.map((row) => row.entry));
+    expect(second[0]?.entry).toBe(first[0]?.entry);
+    expect(second[1]?.entry).toBe(first[1]?.entry);
+    expect(parseSessionEntryCalls).not.toHaveBeenCalled();
+    expect(listProjectionCalls).not.toHaveBeenCalled();
+  });
+
+  it("fully reloads after another connection commits", async () => {
     const scope = createSessionScope("external-write");
-    await upsertSessionEntry(scope, { label: "before", sessionId: "external", updatedAt: 1 });
-    const before = listSessionEntries(scope)[0]?.entry;
+    const siblingScope = { ...scope, sessionKey: "agent:main:external-write-sibling" };
+    await upsertSessionEntry(scope, {
+      label: "projection-probe-before",
+      sessionId: "external",
+      updatedAt: 1,
+    });
+    await upsertSessionEntry(siblingScope, {
+      label: "projection-probe-sibling",
+      sessionId: "external-sibling",
+      updatedAt: 1,
+    });
+    const before = listSessionEntries({ ...scope, clone: false, projection: "list" })[0]?.entry;
     expect(before).toBeDefined();
     if (!before) {
       throw new Error("missing seeded external-write entry");
@@ -196,7 +255,7 @@ describe("SQLite session entry cache", () => {
       synchronous: "NORMAL",
     });
     try {
-      const updated = { ...before, label: "after", updatedAt: 2 };
+      const updated = { ...before, label: "projection-probe-after", updatedAt: 2 };
       external
         .prepare(
           "UPDATE session_nodes SET entry_json = ?, label = ?, updated_at = ? WHERE session_key = ?",
@@ -204,27 +263,84 @@ describe("SQLite session entry cache", () => {
         .run(JSON.stringify(updated), updated.label, updated.updatedAt, scope.sessionKey);
 
       parseSessionEntryCalls.mockClear();
-      expect(listSessionEntries(scope)[0]?.entry.label).toBe("after");
-      expect(parseSessionEntryCalls).toHaveBeenCalledTimes(1);
+      listProjectionCalls.mockClear();
+      expect(
+        listSessionEntries({ ...scope, clone: false, projection: "list" })[0]?.entry.label,
+      ).toBe("projection-probe-after");
+      expect(parseSessionEntryCalls).toHaveBeenCalledTimes(2);
+      expect(listProjectionCalls).toHaveBeenCalledTimes(2);
     } finally {
       maintenance.close();
       external.close();
     }
   });
 
-  it("reloads after a raw insert on the cached connection", async () => {
-    const scope = createSessionScope("same-connection-insert");
+  it("fully reloads a cross-connection same-millisecond entry rewrite", async () => {
+    const scope = createSessionScope("external-same-ms");
+    const siblingScope = { ...scope, sessionKey: "agent:main:external-same-ms-sibling" };
     await upsertSessionEntry(scope, {
-      label: "existing",
-      sessionId: "same-connection-existing",
+      label: "projection-probe-before",
+      sessionId: "external-same-ms",
+      updatedAt: 1_000,
+    });
+    await upsertSessionEntry(siblingScope, {
+      label: "projection-probe-sibling",
+      sessionId: "external-same-ms-sibling",
+      updatedAt: 1_000,
+    });
+    const before = listSessionEntries({ ...scope, clone: false, projection: "list" })[0]?.entry;
+    if (!before) {
+      throw new Error("missing seeded external-same-ms entry");
+    }
+
+    const database = openOpenClawAgentDatabase(scope);
+    const external = new DatabaseSync(database.path);
+    const maintenance = configureSqliteConnectionPragmas(external, {
+      checkpointIntervalMs: 0,
+      databaseLabel: "session-entry-external-same-ms-writer",
+      databasePath: database.path,
+      foreignKeys: true,
+      synchronous: "NORMAL",
+    });
+    try {
+      const updated = { ...before, label: "projection-probe-after" };
+      external
+        .prepare("UPDATE session_nodes SET entry_json = ?, label = ? WHERE session_key = ?")
+        .run(JSON.stringify(updated), updated.label, scope.sessionKey);
+
+      parseSessionEntryCalls.mockClear();
+      listProjectionCalls.mockClear();
+      const after = listSessionEntries({ ...scope, clone: false, projection: "list" });
+
+      expect(after[0]?.entry.label).toBe("projection-probe-after");
+      expect(parseSessionEntryCalls).toHaveBeenCalledTimes(2);
+      expect(listProjectionCalls).toHaveBeenCalledTimes(2);
+    } finally {
+      maintenance.close();
+      external.close();
+    }
+  });
+
+  it("incrementally handles added and removed keys on the cached connection", async () => {
+    const scope = createSessionScope("same-connection-keys");
+    const removedScope = { ...scope, sessionKey: "agent:main:same-connection-removed" };
+    await upsertSessionEntry(scope, {
+      label: "projection-probe-kept",
+      sessionId: "same-connection-kept",
       updatedAt: 1,
     });
-    listSessionEntries(scope);
+    await upsertSessionEntry(removedScope, {
+      label: "projection-probe-removed",
+      sessionId: "same-connection-removed",
+      updatedAt: 1,
+    });
+    const before = listSessionEntries({ ...scope, clone: false, projection: "list" });
+    const keptProjection = before.find((row) => row.sessionKey === scope.sessionKey)?.entry;
 
     const database = openOpenClawAgentDatabase(scope);
     const insertedKey = "agent:main:same-connection-inserted";
     const insertedEntry = {
-      label: "inserted",
+      label: "projection-probe-inserted",
       sessionId: "same-connection-inserted",
       updatedAt: 2,
     };
@@ -238,25 +354,88 @@ describe("SQLite session entry cache", () => {
         JSON.stringify(insertedEntry),
         insertedEntry.updatedAt,
       );
+    database.db
+      .prepare("DELETE FROM session_nodes WHERE session_key = ?")
+      .run(removedScope.sessionKey);
 
     parseSessionEntryCalls.mockClear();
-    const entries = listSessionEntries(scope);
+    listProjectionCalls.mockClear();
+    const entries = listSessionEntries({ ...scope, clone: false, projection: "list" });
 
-    expect(entries.map((row) => row.sessionKey)).toEqual([scope.sessionKey, insertedKey]);
-    expect(entries[1]?.entry).toMatchObject(insertedEntry);
-    expect(parseSessionEntryCalls).toHaveBeenCalledTimes(2);
+    expect(entries.map((row) => row.sessionKey)).toEqual(
+      [scope.sessionKey, insertedKey].toSorted(),
+    );
+    expect(entries.find((row) => row.sessionKey === scope.sessionKey)?.entry).toBe(keptProjection);
+    expect(entries.find((row) => row.sessionKey === insertedKey)?.entry).toMatchObject(
+      insertedEntry,
+    );
+    expect(parseSessionEntryCalls).toHaveBeenCalledOnce();
+    expect(listProjectionCalls).toHaveBeenCalledOnce();
   });
 
-  it("reloads after a tracked same-process upsert", async () => {
-    const scope = createSessionScope("write-through");
-    await upsertSessionEntry(scope, { label: "before", sessionId: "write-through", updatedAt: 1 });
-    listSessionEntries(scope);
+  it("scales parse and projection work with changed keys instead of store size", async () => {
+    const scope = createSessionScope("changed-key-scaling");
+    const rowCount = 24;
+    for (let index = 0; index < rowCount; index++) {
+      await upsertSessionEntry(
+        { ...scope, sessionKey: `agent:main:changed-key-scaling-${index}` },
+        {
+          label: `projection-probe-${index}`,
+          sessionId: `changed-key-scaling-${index}`,
+          updatedAt: index + 1,
+        },
+      );
+    }
+    listSessionEntries({ ...scope, clone: false, projection: "list" });
 
-    await upsertSessionEntry(scope, { label: "after", updatedAt: 2 });
+    const database = openOpenClawAgentDatabase(scope);
+    for (const index of [3, 19]) {
+      const sessionKey = `agent:main:changed-key-scaling-${index}`;
+      const entry = {
+        label: `projection-probe-changed-${index}`,
+        sessionId: `changed-key-scaling-${index}`,
+        updatedAt: 1_000 + index,
+      };
+      database.db
+        .prepare(
+          "UPDATE session_nodes SET entry_json = ?, label = ?, updated_at = ? WHERE session_key = ?",
+        )
+        .run(JSON.stringify(entry), entry.label, entry.updatedAt, sessionKey);
+    }
     parseSessionEntryCalls.mockClear();
+    listProjectionCalls.mockClear();
 
-    expect(listSessionEntries(scope)[0]?.entry.label).toBe("after");
-    expect(parseSessionEntryCalls).toHaveBeenCalledTimes(1);
+    const entries = listSessionEntries({ ...scope, clone: false, projection: "list" });
+
+    expect(entries).toHaveLength(rowCount);
+    expect(parseSessionEntryCalls).toHaveBeenCalledTimes(2);
+    expect(listProjectionCalls).toHaveBeenCalledTimes(2);
+  });
+
+  it("fully reloads after a tracked same-process upsert", async () => {
+    const scope = createSessionScope("write-through");
+    const siblingScope = { ...scope, sessionKey: "agent:main:write-through-sibling" };
+    await upsertSessionEntry(scope, {
+      label: "projection-probe-before",
+      sessionId: "write-through",
+      updatedAt: 1,
+    });
+    await upsertSessionEntry(siblingScope, {
+      label: "projection-probe-sibling",
+      sessionId: "write-through-sibling",
+      updatedAt: 1,
+    });
+    listSessionEntries({ ...scope, clone: false, projection: "list" });
+
+    await upsertSessionEntry(scope, { label: "projection-probe-after", updatedAt: 2 });
+    parseSessionEntryCalls.mockClear();
+    listProjectionCalls.mockClear();
+
+    expect(listSessionEntries({ ...scope, clone: false, projection: "list" })[0]?.entry.label).toBe(
+      "projection-probe-after",
+    );
+    expect(parseSessionEntryCalls).toHaveBeenCalledTimes(2);
+    expect(listProjectionCalls).toHaveBeenCalledTimes(2);
   });
 
   it("does not let a tracked write mask an earlier raw connection write", async () => {
@@ -316,7 +495,7 @@ describe("SQLite session entry cache", () => {
     ]);
   });
 
-  it("bypasses the cache in a transaction and reloads persisted state after rollback", async () => {
+  it("bypasses the cache in a transaction and reuses the persisted snapshot after rollback", async () => {
     const scope = createSessionScope("transaction-rollback");
     await upsertSessionEntry(scope, { label: "before", sessionId: "rollback", updatedAt: 1 });
     const borrowedBefore = openSessionEntryReadView(scope).get(scope.sessionKey);
@@ -338,9 +517,9 @@ describe("SQLite session entry cache", () => {
 
     parseSessionEntryCalls.mockClear();
     const borrowedAfter = openSessionEntryReadView(scope).get(scope.sessionKey);
-    expect(borrowedAfter).not.toBe(borrowedBefore);
+    expect(borrowedAfter).toBe(borrowedBefore);
     expect(borrowedAfter?.label).toBe("before");
-    expect(parseSessionEntryCalls).toHaveBeenCalledTimes(1);
+    expect(parseSessionEntryCalls).not.toHaveBeenCalled();
   });
 
   it("isolates cloned results while borrowed views retain stable references", async () => {

--- a/src/config/sessions/session-accessor.sqlite-entry-cache.ts
+++ b/src/config/sessions/session-accessor.sqlite-entry-cache.ts
@@ -18,13 +18,22 @@ export type SqliteSessionEntryCacheSnapshot = {
 
 type SqliteSessionEntryCache = SqliteSessionEntryCacheSnapshot & {
   connection: DatabaseSync;
+  listProjections: Map<string, SessionEntry>;
+  updatedAtByKey: Map<string, number>;
   validityToken: SqliteSessionEntryCacheValidityToken;
+};
+
+type LoadedSessionEntrySnapshot = SqliteSessionEntryCacheSnapshot & {
+  listProjections: Map<string, SessionEntry>;
+  updatedAtByKey: Map<string, number>;
 };
 
 type SqliteSessionEntryCacheValidityToken = {
   dataVersion: number;
   totalChanges: number;
 };
+
+const MAX_INCREMENTAL_ENTRY_READ_KEYS = 500;
 
 // One parsed snapshot per opened agent database bounds memory to the process's database set.
 // The connection-local validity token plus tracked-write invalidation keeps it current;
@@ -62,7 +71,9 @@ function cacheValidityTokensEqual(
 }
 
 function createListProjection(entry: SessionEntry): SessionEntry {
-  const projected = structuredClone(entry);
+  // clone:false list consumers treat entries and their nested values as immutable.
+  // Share those nested values instead of deep-cloning large snapshots only to discard them.
+  const projected = { ...entry };
   delete projected.skillsSnapshot;
   delete projected.systemPromptReport;
   return projected;
@@ -70,8 +81,8 @@ function createListProjection(entry: SessionEntry): SessionEntry {
 
 function createLazyListProjections(
   entries: ReadonlyMap<string, SessionEntry>,
+  projectedByKey: Map<string, SessionEntry>,
 ): Pick<ReadonlyMap<string, SessionEntry>, "get"> {
-  const projectedByKey = new Map<string, SessionEntry>();
   return {
     get: (sessionKey) => {
       const cached = projectedByKey.get(sessionKey);
@@ -91,13 +102,14 @@ function createLazyListProjections(
   };
 }
 
-function loadSessionEntrySnapshot(
-  database: SessionEntryCacheDatabase,
-): SqliteSessionEntryCacheSnapshot {
+function loadSessionEntrySnapshot(database: SessionEntryCacheDatabase): LoadedSessionEntrySnapshot {
   const db = getSessionKysely(database.db);
   const rows = executeSqliteQuerySync(
     database.db,
-    db.selectFrom("session_nodes").select(["session_key", "entry_json"]).orderBy("session_key"),
+    db
+      .selectFrom("session_nodes")
+      .select(["session_key", "entry_json", "updated_at"])
+      .orderBy("session_key"),
   ).rows;
   const entries = new Map<string, SessionEntry>();
   for (const row of rows) {
@@ -107,10 +119,73 @@ function loadSessionEntrySnapshot(
     }
     entries.set(row.session_key, entry);
   }
+  const listProjections = new Map<string, SessionEntry>();
   return {
     entries,
     keys: rows.map((row) => row.session_key),
-    listEntries: createLazyListProjections(entries),
+    listEntries: createLazyListProjections(entries, listProjections),
+    listProjections,
+    updatedAtByKey: new Map(rows.map((row) => [row.session_key, row.updated_at])),
+  };
+}
+
+function incrementallyRevalidateSessionEntrySnapshot(
+  database: SessionEntryCacheDatabase,
+  cached: SqliteSessionEntryCache,
+  validityToken: SqliteSessionEntryCacheValidityToken,
+): SqliteSessionEntryCache {
+  const db = getSessionKysely(database.db);
+  const versions = executeSqliteQuerySync(
+    database.db,
+    db.selectFrom("session_nodes").select(["session_key", "updated_at"]),
+  ).rows;
+  const updatedAtByKey = new Map(versions.map((row) => [row.session_key, row.updated_at]));
+  const changedKeys = versions
+    .filter((row) => cached.updatedAtByKey.get(row.session_key) !== row.updated_at)
+    .map((row) => row.session_key);
+  const removedKeys = cached.keys.filter((sessionKey) => !updatedAtByKey.has(sessionKey));
+
+  if (changedKeys.length === 0 && removedKeys.length === 0) {
+    cached.validityToken = validityToken;
+    return cached;
+  }
+
+  // Keep the parameterized IN probe below SQLite variable limits. A bulk change is
+  // already cheaper to reload than to preserve individual parsed identities.
+  if (changedKeys.length > MAX_INCREMENTAL_ENTRY_READ_KEYS) {
+    const loaded = loadSessionEntrySnapshot(database);
+    return { ...loaded, connection: database.db, validityToken };
+  }
+
+  const entries = new Map(cached.entries);
+  const listProjections = new Map(cached.listProjections);
+  for (const sessionKey of [...changedKeys, ...removedKeys]) {
+    entries.delete(sessionKey);
+    listProjections.delete(sessionKey);
+  }
+  if (changedKeys.length > 0) {
+    const changedRows = executeSqliteQuerySync(
+      database.db,
+      db
+        .selectFrom("session_nodes")
+        .select(["session_key", "entry_json"])
+        .where("session_key", "in", changedKeys),
+    ).rows;
+    for (const row of changedRows) {
+      const entry = parseSqliteSessionEntryJson(row);
+      if (entry) {
+        entries.set(row.session_key, entry);
+      }
+    }
+  }
+  return {
+    entries,
+    keys: versions.map((row) => row.session_key).toSorted(),
+    listEntries: createLazyListProjections(entries, listProjections),
+    listProjections,
+    updatedAtByKey,
+    connection: database.db,
+    validityToken,
   };
 }
 
@@ -128,6 +203,30 @@ export function readSqliteSessionEntryCache(
     cacheValidityTokensEqual(cached.validityToken, validityToken)
   ) {
     return cached;
+  }
+  if (
+    cached?.connection === database.db &&
+    cached.validityToken.dataVersion === validityToken.dataVersion
+  ) {
+    // updated_at is entry-controlled, not a rowversion. Other connections can rewrite entry_json
+    // without advancing it, so data_version changes must fully reload or same-ms rewrites go stale.
+    // Accessor-owned writes on this connection hard-invalidate; unrelated local writes can safely diff.
+    const revalidated = incrementallyRevalidateSessionEntrySnapshot(
+      database,
+      cached,
+      validityToken,
+    );
+    if (readDataVersion(database.db) !== validityToken.dataVersion) {
+      // An external commit raced the two incremental reads. Reload from one row snapshot;
+      // publishing their mixed result could temporarily omit or retain the wrong keys.
+      const reloadToken = readCacheValidityToken(database.db);
+      const loaded = loadSessionEntrySnapshot(database);
+      const next = { ...loaded, connection: database.db, validityToken: reloadToken };
+      sessionEntryCaches.set(database.path, next);
+      return next;
+    }
+    sessionEntryCaches.set(database.path, revalidated);
+    return revalidated;
   }
   const loaded = loadSessionEntrySnapshot(database);
   const next = { ...loaded, connection: database.db, validityToken };


### PR DESCRIPTION
## What Problem This Solves

`sessions.list` on team.openclaw.ai runs 271ms avg × 98/2h under active use (118ms idle-warm), and pure in-memory RPCs (`question.list` 178ms, `plugin.surface.refresh` 134ms) show the same synchronous occupancy floor. Root cause: the session-entry snapshot cache validates with `PRAGMA data_version` + `total_changes()`. `total_changes()` is connection-scoped and all-tables — and the read path deliberately reuses the process writer handle — so every transcript-event append, unconditional `session_windows` touch, lease heartbeat, or trajectory row from any running agent invalidates the cache. With 3 concurrent agents the hit rate is ~zero, and every miss synchronously re-reads all ~800 `entry_json` blobs, JSON.parses each, rest-spread copies each, and `structuredClone`s each — only to delete the two heaviest fields (`skillsSnapshot`, `systemPromptReport`) from the clone.

## Why This Change Was Made

`session_nodes` already carries `updated_at` with a covering index (`idx_agent_session_nodes_updated_at`), so changed keys can be found with an index-only probe that never touches `entry_json`. Parse cost then scales with what changed, not store size.

## User Impact

Active-use `sessions.list` returns toward (and below) the idle-warm floor, and the event-loop occupancy tax on every other RPC drops with it.

## Evidence

- Incremental revalidation: on a token mismatch with `data_version` unchanged (same-connection writes — the frequent trigger), an index-covered `SELECT session_key, updated_at` diff re-parses only changed/new keys, drops removed ones, and reuses parsed entries + memoized projections for the rest. Verified via SQLite query plan that the probe is index-only.
- Safety gate (documented in code): other-connection commits (`data_version` moved) always take the full reload because `updated_at` is entry-controlled and a cross-process same-ms rewrite could be missed; tracked in-process entry writes still hard-delete the cache; external commits racing the incremental reads are detected; oversized changed-key batches fall back to full reload.
- Shallow list projection replaces `structuredClone` (+delete) with `{...entry}` (+delete); a downstream consumer audit across gateway listing, TUI, embedded gateway, catalog, sharing, and row projections found no nested mutation — the immutability contract is stated at the site.
- 240 tests across cache + gateway consumer suites, including: same-connection non-entry write reuses the snapshot (parse-count spy), tracked write invalidates, cross-connection commit full-reloads, add/remove keys, same-ms rewrite gate proof. Both deadcode lanes, full lint, core prod+test tsgo, format, git diff --check clean; autoreview clean. Testbox run: https://github.com/openclaw/openclaw/actions/runs/30385296092
