### PR TITLE
fix(macos): bound websocket ping so a dropped pong cannot orphan its continuation

### DIFF
--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayWebSocketTransport.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayWebSocketTransport.swift
@@ -28,7 +28,17 @@ private final class WebSocketPingContinuationGate: @unchecked Sendable {
     }
 }
 
+/// Failure modes owned by the ping wrapper rather than by URLSession.
+public enum WebSocketPingError: Error, Equatable {
+    /// URLSession never delivered a pong result for a ping it accepted.
+    case timedOut
+}
+
 public struct WebSocketTaskBox: @unchecked Sendable {
+    /// Bounds a ping whose pong handler URLSession may never invoke. Long enough that a
+    /// slow-but-live link still pongs, short enough that a wedged keepalive recovers.
+    public static let pingTimeout: Duration = .seconds(10)
+
     public let task: any WebSocketTasking
     public init(task: any WebSocketTasking) {
         self.task = task
@@ -60,10 +70,28 @@ public struct WebSocketTaskBox: @unchecked Sendable {
         self.task.receive(completionHandler: completionHandler)
     }
 
-    public func sendPing() async throws {
+    public func sendPing(timeout: Duration = WebSocketTaskBox.pingTimeout) async throws {
         try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
             let gate = WebSocketPingContinuationGate()
+            // URLSession drops the pong handler entirely when the task is cancelled or
+            // closed mid-flight, which orphans this continuation and wedges the keepalive
+            // loop forever on an await that can never return. The deadline guarantees the
+            // continuation always resumes; the gate keeps that resume exactly once.
+            let deadline = Task {
+                do {
+                    try await Task.sleep(for: timeout)
+                } catch {
+                    // Cancelled because a pong arrived first; that callback owns the resume.
+                    // Swallowing this error instead would race the gate and report a healthy
+                    // ping as timed out.
+                    return
+                }
+                gate.resumeOnce {
+                    ThrowingContinuationSupport.resumeVoid(continuation, error: WebSocketPingError.timedOut)
+                }
+            }
             self.task.sendPing { error in
+                deadline.cancel()
                 // URLSession can race ping callbacks with cancellation; only the first
                 // pong result owns this checked continuation or Swift traps the app.
                 gate.resumeOnce {

--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayWebSocketTransport.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayWebSocketTransport.swift
@@ -28,12 +28,6 @@ private final class WebSocketPingContinuationGate: @unchecked Sendable {
     }
 }
 
-/// Failure modes owned by the ping wrapper rather than by URLSession.
-public enum WebSocketPingError: Error, Equatable {
-    /// URLSession never delivered a pong result for a ping it accepted.
-    case timedOut
-}
-
 public struct WebSocketTaskBox: @unchecked Sendable {
     /// Bounds a ping whose pong handler URLSession may never invoke. Long enough that a
     /// slow-but-live link still pongs, short enough that a wedged keepalive recovers.
@@ -87,7 +81,9 @@ public struct WebSocketTaskBox: @unchecked Sendable {
                     return
                 }
                 gate.resumeOnce {
-                    ThrowingContinuationSupport.resumeVoid(continuation, error: WebSocketPingError.timedOut)
+                    // URLError keeps this indistinguishable from a transport timeout for
+                    // callers, which already handle URLSession errors from every other path.
+                    ThrowingContinuationSupport.resumeVoid(continuation, error: URLError(.timedOut))
                 }
             }
             self.task.sendPing { error in

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/GatewayNodeSessionTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/GatewayNodeSessionTests.swift
@@ -36,6 +36,80 @@ private actor StringCapture {
     }
 }
 
+/// Delivers a pong asynchronously, well before the deadline, so a cancelled deadline
+/// task racing the gate would surface as a spurious timeout.
+private final class DelayedPongWebSocketTask: WebSocketTasking, @unchecked Sendable {
+    private let delay: Duration
+
+    init(delay: Duration) {
+        self.delay = delay
+    }
+
+    var state: URLSessionTask.State {
+        .running
+    }
+
+    func resume() {}
+
+    func cancel(with closeCode: URLSessionWebSocketTask.CloseCode, reason: Data?) {
+        _ = (closeCode, reason)
+    }
+
+    func send(_ message: URLSessionWebSocketTask.Message) async throws {
+        _ = message
+    }
+
+    func sendPing(pongReceiveHandler: @escaping @Sendable (Error?) -> Void) {
+        let delay = self.delay
+        Task {
+            try? await Task.sleep(for: delay)
+            pongReceiveHandler(nil)
+        }
+    }
+
+    func receive() async throws -> URLSessionWebSocketTask.Message {
+        throw URLError(.badServerResponse)
+    }
+
+    func receive(
+        completionHandler: @escaping @Sendable (Result<URLSessionWebSocketTask.Message, Error>) -> Void)
+    {
+        completionHandler(.failure(URLError(.badServerResponse)))
+    }
+}
+
+/// Mirrors URLSession dropping a pong handler outright when the task is cancelled or
+/// closed mid-flight: the ping is accepted and no callback ever arrives.
+private final class SilentPingWebSocketTask: WebSocketTasking, @unchecked Sendable {
+    var state: URLSessionTask.State {
+        .running
+    }
+
+    func resume() {}
+
+    func cancel(with closeCode: URLSessionWebSocketTask.CloseCode, reason: Data?) {
+        _ = (closeCode, reason)
+    }
+
+    func send(_ message: URLSessionWebSocketTask.Message) async throws {
+        _ = message
+    }
+
+    func sendPing(pongReceiveHandler: @escaping @Sendable (Error?) -> Void) {
+        _ = pongReceiveHandler
+    }
+
+    func receive() async throws -> URLSessionWebSocketTask.Message {
+        throw URLError(.badServerResponse)
+    }
+
+    func receive(
+        completionHandler: @escaping @Sendable (Result<URLSessionWebSocketTask.Message, Error>) -> Void)
+    {
+        completionHandler(.failure(URLError(.badServerResponse)))
+    }
+}
+
 private final class DoubleCallbackPingWebSocketTask: WebSocketTasking, @unchecked Sendable {
     private let callbacks: [Error?]
 
@@ -1079,6 +1153,32 @@ struct GatewayNodeSessionTests {
         #expect(Array(decoded.heldApprovals[0].approvalId.utf8) == Array(approvalID.utf8))
         #expect(try Array(#require(decoded.heldApprovals[0].activeResolutionAttemptId).utf8) ==
             Array(activeAttemptID.utf8))
+    }
+
+    @Test
+    func `websocket ping times out when no pong callback ever arrives`() async throws {
+        // Without the deadline this await never returns: the checked continuation is
+        // orphaned, Swift logs CONTINUATION MISUSE, and the keepalive loop wedges forever.
+        let task = SilentPingWebSocketTask()
+
+        do {
+            try await WebSocketTaskBox(task: task).sendPing(timeout: .milliseconds(50))
+            Issue.record("sendPing unexpectedly succeeded without a pong")
+        } catch let error as WebSocketPingError {
+            #expect(error == .timedOut)
+        }
+    }
+
+    @Test
+    func `websocket ping succeeds when the pong beats the deadline`() async throws {
+        // Cancelling the deadline makes Task.sleep throw; if that cancellation were
+        // swallowed the deadline task would fall through and race the pong callback,
+        // reporting a healthy ping as timed out.
+        let task = DelayedPongWebSocketTask(delay: .milliseconds(20))
+
+        for _ in 0..<20 {
+            try await WebSocketTaskBox(task: task).sendPing(timeout: .seconds(5))
+        }
     }
 
     @Test

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/GatewayNodeSessionTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/GatewayNodeSessionTests.swift
@@ -1164,8 +1164,8 @@ struct GatewayNodeSessionTests {
         do {
             try await WebSocketTaskBox(task: task).sendPing(timeout: .milliseconds(50))
             Issue.record("sendPing unexpectedly succeeded without a pong")
-        } catch let error as WebSocketPingError {
-            #expect(error == .timedOut)
+        } catch let error as URLError {
+            #expect(error.code == .timedOut)
         }
     }
 


### PR DESCRIPTION
## What Problem This Solves

Every OpenClaw Mac node was logging this continuously:

```
SWIFT TASK CONTINUATION MISUSE: sendPing() leaked its continuation without resuming it.
This may cause tasks waiting on it to remain suspended forever.
```

`URLSessionWebSocketTask.sendPing(pongReceiveHandler:)` **drops its handler entirely** when the task is cancelled or closed mid-flight — the callback simply never fires. `WebSocketTaskBox.sendPing()` wrapped that callback in `withCheckedThrowingContinuation`, and while `WebSocketPingContinuationGate` guarded the handler firing *twice*, nothing guarded it firing *zero* times.

The consequence is worse than a log line. `GatewayChannel.keepaliveLoop` does:

```swift
try await task.sendPing()
```

An orphaned continuation means that `await` **never returns**, so the keepalive loop is wedged for the lifetime of the process. Observed live on a production node.

## Why This Change Was Made

Race the ping against a deadline and let the existing gate arbitrate, so the continuation always resumes exactly once.

The subtle part is cancellation. A first attempt used `try? await Task.sleep(...)`, which **swallows the `CancellationError`** — so when a delivered pong cancelled the deadline, the deadline task fell straight through into the timeout resume and raced the callback. A healthy ping could then be reported as `.timedOut`. Codex autoreview caught this (P1, 0.99); the deadline now returns without resuming when cancelled.

## User Impact

Mac nodes keep their gateway keepalive alive instead of silently wedging after the first dropped pong. No API change: `sendPing(timeout:)` defaults to `WebSocketTaskBox.pingTimeout` (10s), so existing call sites are unchanged.

## Evidence

Red/green on the new timeout test, run on macOS 27 / Xcode 27.0 (27A5228h), Swift 6.4:

- **Red** — with the deadline removed, `websocket ping times out when no pong callback ever arrives` **hangs**; killed at 150s (`exit 124`).
- **Green** — with the fix, the same test passes in **0.054s**.

Full filtered suite, `swift test --filter "websocket ping"` → **4/4 passed**:

```
✔ websocket ping times out when no pong callback ever arrives (0.054s)
✔ websocket ping succeeds when the pong beats the deadline (0.526s)
✔ websocket ping ignores duplicate success callbacks (0.001s)
✔ websocket ping ignores duplicate callbacks after first error (0.001s)
```

The race test drives 20 sequential pings whose pong lands 20ms before a 5s deadline — it fails if a cancelled deadline can win the gate.

- `scripts/format-swift.sh macos` → 0/26 files require formatting
- `scripts/lint-swift.sh macos --strict` → 0 violations, 0 serious in 22 files
- Codex autoreview (`gpt-5.6-sol`, xhigh) → **clean, "patch is correct" (0.9)**
