### PR TITLE
fix: doctor memory calls reject unknown agent targets

### DIFF
--- a/src/gateway/server-methods/doctor.test.ts
+++ b/src/gateway/server-methods/doctor.test.ts
@@ -6,9 +6,11 @@ import os from "node:os";
 import path from "node:path";
 import { expectDefined } from "@openclaw/normalization-core";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ErrorCodes, errorShape } from "../../../packages/gateway-protocol/src/index.js";
 import type { OpenClawConfig } from "../../config/config.js";
 
 const getRuntimeConfig = vi.hoisted(() => vi.fn(() => ({}) as OpenClawConfig));
+const listAgentIds = vi.hoisted(() => vi.fn(() => ["main", "research-analyst", "alpha"]));
 const resolveDefaultAgentId = vi.hoisted(() => vi.fn(() => "main"));
 const resolveAgentWorkspaceDir = vi.hoisted(() =>
   vi.fn((_cfg: OpenClawConfig, _agentId: string) => "/tmp/openclaw"),
@@ -33,6 +35,7 @@ vi.mock("../../config/config.js", () => ({
 }));
 
 vi.mock("../../agents/agent-scope.js", () => ({
+  listAgentIds,
   listAgentEntries: (cfg: OpenClawConfig) =>
     cfg.agents?.entries
       ? Object.entries(cfg.agents.entries).map(([id, entry]) => {
@@ -201,6 +204,37 @@ const invokeDoctorMemoryRemHarness = async (
   });
 };
 
+const DOCTOR_MEMORY_TARGET_METHODS = [
+  "doctor.memory.status",
+  "doctor.memory.dreamDiary",
+  "doctor.memory.backfillDreamDiary",
+  "doctor.memory.resetDreamDiary",
+  "doctor.memory.resetGroundedShortTerm",
+  "doctor.memory.repairDreamingArtifacts",
+  "doctor.memory.dedupeDreamDiary",
+] as const;
+
+const invokeDoctorMemoryTargetMethod = async (
+  method: (typeof DOCTOR_MEMORY_TARGET_METHODS)[number],
+  respond: ReturnType<typeof vi.fn>,
+  params: Record<string, unknown>,
+) => {
+  await expectDefined(
+    doctorHandlers[method],
+    `doctorHandlers[${method}] test invariant`,
+  )({
+    req: {} as never,
+    params: params as never,
+    respond: respond as never,
+    context: {
+      ...makeRuntimeContext(),
+      cron: { list: vi.fn(async () => []) },
+    } as never,
+    client: null,
+    isWebchatConnect: () => false,
+  });
+};
+
 function expectRecordFields(record: unknown, expected: Record<string, unknown>) {
   if (!record || typeof record !== "object") {
     throw new Error("Expected record");
@@ -266,6 +300,61 @@ const expectEmbeddingErrorResponse = (respond: ReturnType<typeof vi.fn>, error: 
     },
   });
 };
+
+describe("doctor.memory agent targeting", () => {
+  beforeEach(() => {
+    listAgentIds.mockClear();
+    resolveAgentWorkspaceDir.mockReset().mockReturnValue("/tmp/openclaw");
+    getMemorySearchManager.mockReset().mockResolvedValue({
+      manager: null,
+      error: "memory search unavailable",
+    });
+    removeBackfillDiaryEntries.mockReset().mockResolvedValue({ removed: 0 });
+    removeGroundedShortTermCandidates.mockReset().mockResolvedValue({ removed: 0 });
+    repairDreamingArtifacts.mockReset().mockResolvedValue({
+      changed: false,
+      archivedDreamsDiary: false,
+      archivedSessionCorpus: false,
+      archivedSessionIngestion: false,
+      warnings: [],
+    });
+    dedupeDreamDiaryEntries.mockReset().mockResolvedValue({ removed: 0, kept: 0 });
+  });
+
+  it.each(DOCTOR_MEMORY_TARGET_METHODS)(
+    "%s rejects an unknown agent before resolving agent state",
+    async (method) => {
+      const respond = vi.fn();
+
+      await invokeDoctorMemoryTargetMethod(method, respond, { agentId: "invented" });
+
+      expect(respond).toHaveBeenCalledWith(
+        false,
+        undefined,
+        errorShape(ErrorCodes.INVALID_REQUEST, 'unknown agent id "invented"'),
+      );
+      expect(getMemorySearchManager).not.toHaveBeenCalled();
+      expect(resolveAgentWorkspaceDir).not.toHaveBeenCalled();
+    },
+  );
+
+  it.each(DOCTOR_MEMORY_TARGET_METHODS)(
+    "%s rejects a non-string agentId before resolving the default agent",
+    async (method) => {
+      const respond = vi.fn();
+
+      await invokeDoctorMemoryTargetMethod(method, respond, { agentId: 42 });
+
+      expect(respond).toHaveBeenCalledWith(
+        false,
+        undefined,
+        errorShape(ErrorCodes.INVALID_REQUEST, "agentId must be a string"),
+      );
+      expect(getMemorySearchManager).not.toHaveBeenCalled();
+      expect(resolveAgentWorkspaceDir).not.toHaveBeenCalled();
+    },
+  );
+});
 
 describe("doctor.memory.status", () => {
   beforeEach(() => {

--- a/src/gateway/server-methods/doctor.ts
+++ b/src/gateway/server-methods/doctor.ts
@@ -4,7 +4,12 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { expectDefined } from "@openclaw/normalization-core";
 import { asOptionalRecord } from "@openclaw/normalization-core/record-coerce";
-import { resolveAgentWorkspaceDir, resolveDefaultAgentId } from "../../agents/agent-scope.js";
+import { ErrorCodes, errorShape } from "../../../packages/gateway-protocol/src/index.js";
+import {
+  listAgentIds,
+  resolveAgentWorkspaceDir,
+  resolveDefaultAgentId,
+} from "../../agents/agent-scope.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import {
   resolveMemoryDeepDreamingConfig,
@@ -28,7 +33,7 @@ import {
   writeBackfillDiaryEntries,
 } from "./doctor.memory-core-runtime.js";
 import { normalizeTrimmedString } from "./record-shared.js";
-import type { GatewayRequestContext, GatewayRequestHandlers } from "./types.js";
+import type { GatewayRequestContext, GatewayRequestHandlers, RespondFn } from "./types.js";
 
 const MANAGED_DEEP_SLEEP_CRON_NAME = "Memory Dreaming Promotion";
 const MANAGED_DEEP_SLEEP_CRON_TAG = "[managed-by=memory-core.short-term-promotion]";
@@ -707,23 +712,54 @@ function shouldProbeMemoryEmbeddings(params: unknown): boolean {
   return record.probe === true || record.deep === true;
 }
 
+function resolveDoctorMemoryAgent(
+  context: GatewayRequestContext,
+  params: unknown,
+  respond: RespondFn,
+): {
+  cfg: OpenClawConfig;
+  agentId: string;
+  requestedAgentId?: string;
+} | null {
+  const cfg = context.getRuntimeConfig();
+  const record = asOptionalRecord(params);
+  const rawAgentId = record?.agentId;
+  // Validate before resolving workspace or manager state; both paths can create agent storage.
+  if (rawAgentId !== undefined && typeof rawAgentId !== "string") {
+    respond(false, undefined, errorShape(ErrorCodes.INVALID_REQUEST, "agentId must be a string"));
+    return null;
+  }
+  const requestedAgentId =
+    typeof rawAgentId === "string" ? normalizeAgentId(rawAgentId) : undefined;
+  const agentId = requestedAgentId ?? resolveDefaultAgentId(cfg);
+  if (requestedAgentId && !listAgentIds(cfg).includes(agentId)) {
+    respond(
+      false,
+      undefined,
+      errorShape(ErrorCodes.INVALID_REQUEST, `unknown agent id "${requestedAgentId}"`),
+    );
+    return null;
+  }
+  return { cfg, agentId, ...(requestedAgentId ? { requestedAgentId } : {}) };
+}
+
 function resolveDoctorMemoryTarget(
   context: GatewayRequestContext,
   params: unknown,
+  respond: RespondFn,
 ): {
   cfg: OpenClawConfig;
   agentId: string;
   workspaceDir: string;
-} {
-  const cfg = context.getRuntimeConfig();
-  const record = asOptionalRecord(params);
-  const requestedAgentId =
-    typeof record?.agentId === "string" ? normalizeAgentId(record.agentId) : null;
-  const agentId = requestedAgentId || resolveDefaultAgentId(cfg);
+} | null {
+  const resolved = resolveDoctorMemoryAgent(context, params, respond);
+  if (!resolved) {
+    return null;
+  }
   return {
-    cfg,
-    agentId,
-    workspaceDir: resolveAgentWorkspaceDir(cfg, agentId),
+    cfg: resolved.cfg,
+    agentId: resolved.agentId,
+    workspaceDir: resolveAgentWorkspaceDir(resolved.cfg, resolved.agentId),
   };
 }
 
@@ -735,10 +771,11 @@ const SKIPPED_MEMORY_EMBEDDING_PROBE = {
 
 export const doctorHandlers: GatewayRequestHandlers = {
   "doctor.memory.status": async ({ respond, context, params }) => {
-    const cfg = context.getRuntimeConfig();
-    const requestedAgentId =
-      typeof params?.agentId === "string" ? normalizeAgentId(params.agentId) : null;
-    const agentId = requestedAgentId || resolveDefaultAgentId(cfg);
+    const resolved = resolveDoctorMemoryAgent(context, params, respond);
+    if (!resolved) {
+      return;
+    }
+    const { cfg, agentId, requestedAgentId } = resolved;
     const { manager, error } = await getActiveMemorySearchManager({
       cfg,
       agentId,
@@ -847,7 +884,11 @@ export const doctorHandlers: GatewayRequestHandlers = {
     }
   },
   "doctor.memory.dreamDiary": async ({ respond, context, params }) => {
-    const { agentId, workspaceDir } = resolveDoctorMemoryTarget(context, params);
+    const target = resolveDoctorMemoryTarget(context, params, respond);
+    if (!target) {
+      return;
+    }
+    const { agentId, workspaceDir } = target;
     const dreamDiary = await readDreamDiary(workspaceDir);
     const payload: DoctorMemoryDreamDiaryPayload = {
       agentId,
@@ -856,7 +897,11 @@ export const doctorHandlers: GatewayRequestHandlers = {
     respond(true, payload, undefined);
   },
   "doctor.memory.backfillDreamDiary": async ({ respond, context, params }) => {
-    const { cfg, agentId, workspaceDir } = resolveDoctorMemoryTarget(context, params);
+    const target = resolveDoctorMemoryTarget(context, params, respond);
+    if (!target) {
+      return;
+    }
+    const { cfg, agentId, workspaceDir } = target;
     const memoryDir = path.join(workspaceDir, "memory");
     const sourceFiles = await listWorkspaceDailyFiles(memoryDir);
     if (sourceFiles.length === 0) {
@@ -912,7 +957,11 @@ export const doctorHandlers: GatewayRequestHandlers = {
     respond(true, payload, undefined);
   },
   "doctor.memory.resetDreamDiary": async ({ respond, context, params }) => {
-    const { agentId, workspaceDir } = resolveDoctorMemoryTarget(context, params);
+    const target = resolveDoctorMemoryTarget(context, params, respond);
+    if (!target) {
+      return;
+    }
+    const { agentId, workspaceDir } = target;
     const removed = await removeBackfillDiaryEntries({ workspaceDir });
     const dreamDiary = await readDreamDiary(workspaceDir);
     const payload: DoctorMemoryDreamActionPayload = {
@@ -925,7 +974,11 @@ export const doctorHandlers: GatewayRequestHandlers = {
     respond(true, payload, undefined);
   },
   "doctor.memory.resetGroundedShortTerm": async ({ respond, context, params }) => {
-    const { agentId, workspaceDir } = resolveDoctorMemoryTarget(context, params);
+    const target = resolveDoctorMemoryTarget(context, params, respond);
+    if (!target) {
+      return;
+    }
+    const { agentId, workspaceDir } = target;
     const removed = await removeGroundedShortTermCandidates({ workspaceDir });
     const payload: DoctorMemoryDreamActionPayload = {
       agentId,
@@ -935,7 +988,11 @@ export const doctorHandlers: GatewayRequestHandlers = {
     respond(true, payload, undefined);
   },
   "doctor.memory.repairDreamingArtifacts": async ({ respond, context, params }) => {
-    const { agentId, workspaceDir } = resolveDoctorMemoryTarget(context, params);
+    const target = resolveDoctorMemoryTarget(context, params, respond);
+    if (!target) {
+      return;
+    }
+    const { agentId, workspaceDir } = target;
     const repair = await repairDreamingArtifacts({ workspaceDir });
     const payload: DoctorMemoryDreamActionPayload = {
       agentId,
@@ -950,7 +1007,11 @@ export const doctorHandlers: GatewayRequestHandlers = {
     respond(true, payload, undefined);
   },
   "doctor.memory.dedupeDreamDiary": async ({ respond, context, params }) => {
-    const { agentId, workspaceDir } = resolveDoctorMemoryTarget(context, params);
+    const target = resolveDoctorMemoryTarget(context, params, respond);
+    if (!target) {
+      return;
+    }
+    const { agentId, workspaceDir } = target;
     const dedupe = await dedupeDreamDiaryEntries({ workspaceDir });
     const dreamDiary = await readDreamDiary(workspaceDir);
     const payload: DoctorMemoryDreamActionPayload = {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where operator clients could send an unknown or non-string `agentId` to `doctor.memory.*` gateway methods and make them enter an unintended agent namespace or silently target the default agent. For `doctor.memory.status`, that could acquire a memory manager and bootstrap agent-scoped SQLite state before the target was known to be configured.

## Why This Change Was Made

The doctor memory handlers now share one validation boundary that rejects non-string IDs and checks normalized explicit IDs against the configured agent roster before resolving a workspace or acquiring a memory manager. Omitting `agentId` still preserves the existing default-agent contract.

The agent-targeting surface was added in #78748; the later shared doctor target resolver retained its normalization-only behavior. Other similar gateway handlers were audited: their lookalike paths are already protected by protocol validators and/or configured-agent checks, while the doctor memory methods had no request-schema gate.

## User Impact

Invalid explicit agent targets now return `INVALID_REQUEST` without creating or touching agent-scoped memory state. Configured agents and callers that omit `agentId` behave as before.

## Evidence

- Regression-first Testbox proof: all 14 unknown/non-string cases failed against the old handlers, while the existing 31 cases passed.
- Fixed Testbox proof: `pnpm test src/gateway/server-methods/doctor.test.ts` — 45/45 passed.
- Full changed gate on Blacksmith Testbox: `pnpm check:changed` — format, production/test typechecks, lint, architecture, boundary, and storage guards passed.
- `git diff --check` passed.
- Codex autoreview (`--mode uncommitted`) reported no accepted/actionable findings.
