### PR TITLE
fix(ui): keep explicit navigation ahead of chat canonicalization

### DIFF
--- a/ui/src/app/mobile-nav-layout.ts
+++ b/ui/src/app/mobile-nav-layout.ts
@@ -39,3 +39,7 @@ export function shouldMergeChatChrome(params: {
     !hasNativeShellClass()
   );
 }
+
+export function mergeChatPageChrome(mobileNavLayout: boolean, onboarding: boolean): boolean {
+  return shouldMergeChatChrome({ mobileNavLayout, routeId: "chat", onboarding });
+}

--- a/ui/src/pages/chat/chat-canonical-location.ts
+++ b/ui/src/pages/chat/chat-canonical-location.ts
@@ -1,0 +1,39 @@
+import type { RouteLocation } from "@openclaw/uirouter";
+import { locationWithoutDraft } from "./route-loader.ts";
+
+function currentRouteLocation(): RouteLocation {
+  return {
+    pathname: window.location.pathname,
+    search: window.location.search,
+    hash: window.location.hash,
+  };
+}
+
+function routeLocationsMatch(left: RouteLocation, right: RouteLocation): boolean {
+  return (
+    left.pathname === right.pathname && left.search === right.search && left.hash === right.hash
+  );
+}
+
+export function stillOwnsCanonicalLocation(
+  source: RouteLocation | undefined,
+  consumedSourceDraft: boolean,
+): boolean {
+  if (!source) {
+    return false;
+  }
+  const current = currentRouteLocation();
+  if (routeLocationsMatch(current, source)) {
+    return true;
+  }
+  const sourceHasDraft = new URLSearchParams(source.search).has("draft");
+  const currentHasDraft = new URLSearchParams(current.search).has("draft");
+  // Only the source route's own one-shot draft may disappear without
+  // transferring canonicalization ownership to a newer navigation.
+  return (
+    consumedSourceDraft &&
+    sourceHasDraft &&
+    !currentHasDraft &&
+    routeLocationsMatch(locationWithoutDraft(current), locationWithoutDraft(source))
+  );
+}

--- a/ui/src/pages/chat/chat-page.test.ts
+++ b/ui/src/pages/chat/chat-page.test.ts
@@ -380,6 +380,7 @@ describe("chat page split layout host", () => {
   });
 
   it("replaces a cold literal main route after canonical defaults resolve", async () => {
+    window.history.replaceState({}, "", "/chat/research/workspace?draft=ship");
     const page = new ChatPage();
     const navigation = setNavigationContext(page);
     const canonicalLocation = deferred<RouteLocation | null>();
@@ -388,6 +389,11 @@ describe("chat page split layout host", () => {
       face: "chat",
       draft: "ship",
       canonicalLocationReady: canonicalLocation.promise,
+      canonicalLocationSource: {
+        pathname: "/chat/research/workspace",
+        search: "?draft=ship",
+        hash: "",
+      },
     };
     document.body.append(page);
     await page.updateComplete;
@@ -408,7 +414,63 @@ describe("chat page split layout host", () => {
     );
   });
 
+  it("does not let a cold chat canonicalization replace a newer route", async () => {
+    window.history.replaceState({}, "", "/chat/research/workspace");
+    const page = new ChatPage();
+    const navigation = setNavigationContext(page);
+    const canonicalLocation = deferred<RouteLocation | null>();
+    page.data = {
+      sessionKey: "agent:research:workspace",
+      face: "chat",
+      canonicalLocationReady: canonicalLocation.promise,
+      canonicalLocationSource: {
+        pathname: "/chat/research/workspace",
+        search: "",
+        hash: "",
+      },
+    };
+    document.body.append(page);
+    await page.updateComplete;
+
+    window.history.replaceState({}, "", "/settings/general");
+    canonicalLocation.resolve({ pathname: "/chat/research", search: "", hash: "" });
+    await canonicalLocation.promise;
+    await Promise.resolve();
+
+    expect(navigation.replace).not.toHaveBeenCalled();
+  });
+
+  it("does not let a cold chat canonicalization replace a newer draft", async () => {
+    window.history.replaceState({}, "", "/chat/research/workspace?draft=old");
+    const page = new ChatPage();
+    const navigation = setNavigationContext(page);
+    const canonicalLocation = deferred<RouteLocation | null>();
+    page.data = {
+      sessionKey: "agent:research:workspace",
+      face: "chat",
+      draft: "old",
+      canonicalLocationReady: canonicalLocation.promise,
+      canonicalLocationSource: {
+        pathname: "/chat/research/workspace",
+        search: "?draft=old",
+        hash: "",
+      },
+    };
+    document.body.append(page);
+    await page.updateComplete;
+    await Promise.resolve();
+    navigation.replace.mockClear();
+
+    window.history.replaceState({}, "", "/chat/research/workspace?draft=new");
+    canonicalLocation.resolve({ pathname: "/chat/research", search: "?draft=old", hash: "" });
+    await canonicalLocation.promise;
+    await Promise.resolve();
+
+    expect(navigation.replace).not.toHaveBeenCalled();
+  });
+
   it("replaces into the canonical face namespace without adding history", async () => {
+    window.history.replaceState({}, "", "/chat");
     const page = new ChatPage();
     const navigation = setNavigationContext(page);
     // The loader resolved this session to its stored dashboard face while the route was
@@ -418,6 +480,11 @@ describe("chat page split layout host", () => {
       face: "dashboard",
       canonicalLocation: {
         pathname: "/dashboard/main/deploy-monitor-12345678",
+        search: "",
+        hash: "",
+      },
+      canonicalLocationSource: {
+        pathname: "/chat",
         search: "",
         hash: "",
       },

--- a/ui/src/pages/chat/chat-page.ts
+++ b/ui/src/pages/chat/chat-page.ts
@@ -1,4 +1,5 @@
 import { consume } from "@lit/context";
+import type { RouteLocation } from "@openclaw/uirouter";
 import { html, nothing } from "lit";
 import { property, state } from "lit/decorators.js";
 import { repeat } from "lit/directives/repeat.js";
@@ -46,6 +47,41 @@ import {
 } from "./split-layout.ts";
 
 const NARROW_SPLIT_QUERY = "(max-width: 1099px)";
+
+function currentRouteLocation(): RouteLocation {
+  return {
+    pathname: window.location.pathname,
+    search: window.location.search,
+    hash: window.location.hash,
+  };
+}
+
+function routeLocationsMatch(left: RouteLocation, right: RouteLocation): boolean {
+  return (
+    left.pathname === right.pathname && left.search === right.search && left.hash === right.hash
+  );
+}
+
+function stillOwnsCanonicalLocation(
+  source: RouteLocation | undefined,
+  consumedSourceDraft: boolean,
+): boolean {
+  if (!source) {
+    return false;
+  }
+  const current = currentRouteLocation();
+  if (routeLocationsMatch(current, source)) {
+    return true;
+  }
+  const sourceHasDraft = new URLSearchParams(source.search).has("draft");
+  const currentHasDraft = new URLSearchParams(current.search).has("draft");
+  return (
+    consumedSourceDraft &&
+    sourceHasDraft &&
+    !currentHasDraft &&
+    routeLocationsMatch(locationWithoutDraft(current), locationWithoutDraft(source))
+  );
+}
 
 type DropIndicator = { paneId: string; zone: SplitDropZone; rect: SplitDropRect };
 type ChatPaneElement = HTMLElement & { paneId?: string; sessionKey?: string };
@@ -123,14 +159,30 @@ export class ChatPage extends OpenClawLightDomElement {
       this.consumedDraftData !== data &&
       (!this.layout || activePane?.sessionKey === data.sessionKey);
     if (changedProperties.has("data")) {
-      if (data?.canonicalLocation) {
+      if (
+        data?.canonicalLocation &&
+        stillOwnsCanonicalLocation(
+          data.canonicalLocationSource,
+          this.consumedDraftData === data,
+        )
+      ) {
         // data.face is the loader's resolved face, which may differ from the namespace
         // this route was matched under; replacing under it moves the URL to that board.
         this.context.replace(data.face ?? "chat", data.canonicalLocation);
         return;
       }
       void data?.canonicalLocationReady?.then((location) => {
-        if (location && this.isConnected && this.data === data) {
+        if (
+          location &&
+          this.isConnected &&
+          this.data === data &&
+          stillOwnsCanonicalLocation(
+            data.canonicalLocationSource,
+            this.consumedDraftData === data,
+          )
+        ) {
+          // A lazy chat canonicalization can resolve while the old page remains
+          // mounted under a cold navigation. Never replace that newer route.
           this.context.replace(
             data.face ?? "chat",
             this.consumedDraftData === data ? locationWithoutDraft(location) : location,

--- a/ui/src/pages/chat/chat-page.ts
+++ b/ui/src/pages/chat/chat-page.ts
@@ -46,8 +46,6 @@ import {
   type ChatSplitPane,
 } from "./split-layout.ts";
 
-const NARROW_SPLIT_QUERY = "(max-width: 1099px)";
-
 type DropIndicator = { paneId: string; zone: SplitDropZone; rect: SplitDropRect };
 type ChatPaneElement = HTMLElement & { paneId?: string; sessionKey?: string };
 
@@ -84,7 +82,7 @@ export class ChatPage extends OpenClawLightDomElement {
   override connectedCallback() {
     super.connectedCallback();
     this.layout = loadSettings().chatSplitLayout;
-    this.mediaQuery = window.matchMedia(NARROW_SPLIT_QUERY);
+    this.mediaQuery = window.matchMedia("(max-width: 1099px)");
     this.narrow = this.mediaQuery.matches;
     this.mediaQuery.addEventListener("change", this.handleViewportChange);
     this.mobileNavMediaQuery = window.matchMedia(mobileNavLayoutMediaQuery());

--- a/ui/src/pages/chat/chat-page.ts
+++ b/ui/src/pages/chat/chat-page.ts
@@ -3,7 +3,7 @@ import { html, nothing } from "lit";
 import { property, state } from "lit/decorators.js";
 import { repeat } from "lit/directives/repeat.js";
 import { applicationContext, type ApplicationContext } from "../../app/context.ts";
-import { mobileNavLayoutMediaQuery, shouldMergeChatChrome } from "../../app/mobile-nav-layout.ts";
+import { mergeChatPageChrome, mobileNavLayoutMediaQuery } from "../../app/mobile-nav-layout.ts";
 import { nativeGatewaysCapability } from "../../app/native-gateways.runtime.ts";
 import { loadSettings, patchSettings } from "../../app/settings.ts";
 import "../../components/resizable-divider.ts";
@@ -40,6 +40,7 @@ import {
   resizePanes,
   setActivePane,
   setPaneSession,
+  singlePaneLayout,
   splitRatio,
   splitWeight,
   type ChatSplitLayout,
@@ -176,11 +177,7 @@ export class ChatPage extends OpenClawLightDomElement {
   };
 
   private resolveMergedChrome(mobileNavLayout: boolean): boolean {
-    return shouldMergeChatChrome({
-      mobileNavLayout,
-      routeId: "chat",
-      onboarding: this.closest(".shell--onboarding") !== null,
-    });
+    return mergeChatPageChrome(mobileNavLayout, this.closest(".shell--onboarding") !== null);
   }
 
   private readonly handleMobileNavViewportChange = (event: MediaQueryListEvent) => {
@@ -602,17 +599,7 @@ export class ChatPage extends OpenClawLightDomElement {
   }
 
   private classicLayout(sessionKey = this.data?.sessionKey?.trim() ?? ""): ChatSplitLayout {
-    return {
-      columns: [
-        {
-          id: this.classicColumnId,
-          panes: [{ id: this.classicPaneId, sessionKey }],
-          paneWeights: [1],
-        },
-      ],
-      columnWeights: [1],
-      activePaneId: this.classicPaneId,
-    };
+    return singlePaneLayout(this.classicColumnId, this.classicPaneId, sessionKey);
   }
 
   private renderSplitLayout(layout: ChatSplitLayout, splitMode: boolean) {

--- a/ui/src/pages/chat/chat-page.ts
+++ b/ui/src/pages/chat/chat-page.ts
@@ -1,5 +1,4 @@
 import { consume } from "@lit/context";
-import type { RouteLocation } from "@openclaw/uirouter";
 import { html, nothing } from "lit";
 import { property, state } from "lit/decorators.js";
 import { repeat } from "lit/directives/repeat.js";
@@ -20,6 +19,7 @@ import { areUiSessionKeysEquivalent } from "../../lib/sessions/session-key.ts";
 import { OpenClawLightDomElement } from "../../lit/openclaw-element.ts";
 import { SubscriptionsController } from "../../lit/subscriptions-controller.ts";
 import { persistSessionBoardFace } from "./chat-board-face-persistence.ts";
+import { stillOwnsCanonicalLocation } from "./chat-canonical-location.ts";
 import "../../styles/chat.css";
 import "./chat-pane.ts";
 import { locationWithoutDraft, type SessionChatRouteData } from "./route-loader.ts";
@@ -47,41 +47,6 @@ import {
 } from "./split-layout.ts";
 
 const NARROW_SPLIT_QUERY = "(max-width: 1099px)";
-
-function currentRouteLocation(): RouteLocation {
-  return {
-    pathname: window.location.pathname,
-    search: window.location.search,
-    hash: window.location.hash,
-  };
-}
-
-function routeLocationsMatch(left: RouteLocation, right: RouteLocation): boolean {
-  return (
-    left.pathname === right.pathname && left.search === right.search && left.hash === right.hash
-  );
-}
-
-function stillOwnsCanonicalLocation(
-  source: RouteLocation | undefined,
-  consumedSourceDraft: boolean,
-): boolean {
-  if (!source) {
-    return false;
-  }
-  const current = currentRouteLocation();
-  if (routeLocationsMatch(current, source)) {
-    return true;
-  }
-  const sourceHasDraft = new URLSearchParams(source.search).has("draft");
-  const currentHasDraft = new URLSearchParams(current.search).has("draft");
-  return (
-    consumedSourceDraft &&
-    sourceHasDraft &&
-    !currentHasDraft &&
-    routeLocationsMatch(locationWithoutDraft(current), locationWithoutDraft(source))
-  );
-}
 
 type DropIndicator = { paneId: string; zone: SplitDropZone; rect: SplitDropRect };
 type ChatPaneElement = HTMLElement & { paneId?: string; sessionKey?: string };

--- a/ui/src/pages/chat/chat-page.ts
+++ b/ui/src/pages/chat/chat-page.ts
@@ -125,10 +125,7 @@ export class ChatPage extends OpenClawLightDomElement {
     if (changedProperties.has("data")) {
       if (
         data?.canonicalLocation &&
-        stillOwnsCanonicalLocation(
-          data.canonicalLocationSource,
-          this.consumedDraftData === data,
-        )
+        stillOwnsCanonicalLocation(data.canonicalLocationSource, this.consumedDraftData === data)
       ) {
         // data.face is the loader's resolved face, which may differ from the namespace
         // this route was matched under; replacing under it moves the URL to that board.
@@ -140,10 +137,7 @@ export class ChatPage extends OpenClawLightDomElement {
           location &&
           this.isConnected &&
           this.data === data &&
-          stillOwnsCanonicalLocation(
-            data.canonicalLocationSource,
-            this.consumedDraftData === data,
-          )
+          stillOwnsCanonicalLocation(data.canonicalLocationSource, this.consumedDraftData === data)
         ) {
           // A lazy chat canonicalization can resolve while the old page remains
           // mounted under a cold navigation. Never replace that newer route.

--- a/ui/src/pages/chat/route-loader.ts
+++ b/ui/src/pages/chat/route-loader.ts
@@ -449,9 +449,7 @@ function resolvedSessionRouteData(params: {
     draft: draftFromLocation(params.location),
     face,
     ...(params.shortId && params.shortId.length > 8 ? { shortId: params.shortId } : {}),
-    ...(canonicalLocation
-      ? { canonicalLocation, canonicalLocationSource: params.location }
-      : {}),
+    ...(canonicalLocation ? { canonicalLocation, canonicalLocationSource: params.location } : {}),
   };
 }
 
@@ -488,9 +486,7 @@ function resolvedMainSessionRouteData(params: {
     agentId: params.target.agentId,
     draft: draftFromLocation(params.location),
     face,
-    ...(canonicalLocation
-      ? { canonicalLocation, canonicalLocationSource: params.location }
-      : {}),
+    ...(canonicalLocation ? { canonicalLocation, canonicalLocationSource: params.location } : {}),
   };
 }
 

--- a/ui/src/pages/chat/route-loader.ts
+++ b/ui/src/pages/chat/route-loader.ts
@@ -60,6 +60,7 @@ export type ChatRouteData =
       shortId?: string;
       canonicalLocation?: RouteLocation;
       canonicalLocationReady?: Promise<RouteLocation | null>;
+      canonicalLocationSource?: RouteLocation;
     }
   | {
       kind: "ambiguous";
@@ -448,7 +449,9 @@ function resolvedSessionRouteData(params: {
     draft: draftFromLocation(params.location),
     face,
     ...(params.shortId && params.shortId.length > 8 ? { shortId: params.shortId } : {}),
-    ...(canonicalLocation ? { canonicalLocation } : {}),
+    ...(canonicalLocation
+      ? { canonicalLocation, canonicalLocationSource: params.location }
+      : {}),
   };
 }
 
@@ -485,7 +488,9 @@ function resolvedMainSessionRouteData(params: {
     agentId: params.target.agentId,
     draft: draftFromLocation(params.location),
     face,
-    ...(canonicalLocation ? { canonicalLocation } : {}),
+    ...(canonicalLocation
+      ? { canonicalLocation, canonicalLocationSource: params.location }
+      : {}),
   };
 }
 
@@ -537,7 +542,7 @@ export async function loadChatRoute(
       face: resolvedFace,
       // Non-null only on a preference-derived open, where it always at least drops the
       // marker from the URL.
-      ...(canonicalLocation ? { canonicalLocation } : {}),
+      ...(canonicalLocation ? { canonicalLocation, canonicalLocationSource: routeLocation } : {}),
     };
   }
   if (target.kind === "main") {
@@ -570,7 +575,7 @@ export async function loadChatRoute(
       draft: draftFromLocation(routeLocation),
       face,
       ...(canonicalLocation && canonicalLocation.search !== routeLocation.search
-        ? { canonicalLocation }
+        ? { canonicalLocation, canonicalLocationSource: routeLocation }
         : {}),
     };
   }
@@ -668,11 +673,13 @@ export async function loadChatRoute(
       draft: draftFromLocation(routeLocation),
       face,
       ...(canonicalLocation
-        ? { canonicalLocation }
+        ? { canonicalLocation, canonicalLocationSource: routeLocation }
         : preferenceLocation && preferenceLocation.search !== routeLocation.search
-          ? { canonicalLocation: preferenceLocation }
+          ? { canonicalLocation: preferenceLocation, canonicalLocationSource: routeLocation }
           : {}),
-      ...(canonicalLocationReady ? { canonicalLocationReady } : {}),
+      ...(canonicalLocationReady
+        ? { canonicalLocationReady, canonicalLocationSource: routeLocation }
+        : {}),
     };
   }
   const cached = findCachedShortSession(context, routeLocation, target);
@@ -685,7 +692,9 @@ export async function loadChatRoute(
       draft: draftFromLocation(routeLocation),
       face,
       ...(target.shortId.length > 8 ? { shortId: target.shortId } : {}),
-      ...(canonicalLocationChanged ? { canonicalLocation } : {}),
+      ...(canonicalLocationChanged
+        ? { canonicalLocation, canonicalLocationSource: routeLocation }
+        : {}),
     };
   }
   const resolution = cached?.row

--- a/ui/src/pages/chat/route-resolution.test.ts
+++ b/ui/src/pages/chat/route-resolution.test.ts
@@ -112,6 +112,11 @@ describe("gateway-backed session route resolution", () => {
       draft: undefined,
       face: "dashboard",
       canonicalLocation: { pathname: "/dashboard/research", search: "", hash: "" },
+      canonicalLocationSource: {
+        pathname: "/chat/research",
+        search: `?${SESSION_FACE_PREFERENCE_PARAM}=1`,
+        hash: "",
+      },
     });
     expect(list).toHaveBeenCalledWith(
       expect.objectContaining({ agentId: "research", search: "global" }),
@@ -163,6 +168,7 @@ describe("gateway-backed session route resolution", () => {
       draft: undefined,
       face: "chat",
       canonicalLocation: { pathname: "/chat/roboclaw", search: "", hash: "" },
+      canonicalLocationSource: targetLocation(target),
     });
   });
 
@@ -223,6 +229,7 @@ describe("gateway-backed session route resolution", () => {
         search: "?catalog=claude&host=gateway%3Alocal&thread=thread-1",
         hash: "",
       },
+      canonicalLocationSource: targetLocation(target),
     });
   });
 

--- a/ui/src/pages/chat/route.test.ts
+++ b/ui/src/pages/chat/route.test.ts
@@ -83,6 +83,11 @@ describe("loadChatRoute", () => {
         search: "?draft=ship",
         hash: "",
       },
+      canonicalLocationSource: {
+        pathname: "/chat/wrong/not-the-name-12345678",
+        search: "?draft=ship",
+        hash: "",
+      },
     });
 
     await expect(
@@ -357,6 +362,7 @@ describe("loadChatRoute", () => {
       draft: undefined,
       face: "chat",
       canonicalLocation: { pathname: "/chat/main", search: "", hash: "" },
+      canonicalLocationSource: { pathname: "/chat/main/workspace", search: "", hash: "" },
     });
     expect(list).not.toHaveBeenCalled();
   });
@@ -377,6 +383,11 @@ describe("loadChatRoute", () => {
       face: "chat",
       canonicalLocation: {
         pathname: "/chat/research",
+        search: "?draft=ship",
+        hash: "#pane",
+      },
+      canonicalLocationSource: {
+        pathname: "/chat/research/workspace",
         search: "?draft=ship",
         hash: "#pane",
       },
@@ -435,6 +446,11 @@ describe("loadChatRoute", () => {
       draft: undefined,
       face: "chat",
       canonicalLocation: { pathname: "/chat/research", search: "", hash: "" },
+      canonicalLocationSource: {
+        pathname: "/chat/research/workspace",
+        search: "",
+        hash: "",
+      },
     });
   });
 

--- a/ui/src/pages/chat/split-layout.ts
+++ b/ui/src/pages/chat/split-layout.ts
@@ -10,6 +10,18 @@ export type ChatSplitLayout = {
   activePaneId: string;
 };
 
+export function singlePaneLayout(
+  columnId: string,
+  paneId: string,
+  sessionKey: string,
+): ChatSplitLayout {
+  return {
+    columns: [{ id: columnId, panes: [{ id: paneId, sessionKey }], paneWeights: [1] }],
+    columnWeights: [1],
+    activePaneId: paneId,
+  };
+}
+
 const MIN_PAIR_SHARE = 0.15;
 
 export function splitWeight(weights: number[], index: number, context: string): number {


### PR DESCRIPTION
Closes #115297

## What Problem This Solves

Fixes an issue where an explicit Control UI navigation could be overwritten by a late chat-route canonicalization when the Gateway and lazy route imports settled under load. In CI this appeared as rotating `checks-ui-e2e` timeouts: the requested URL briefly appeared, then the app returned to the old chat route and the awaited page never mounted.

## Why This Change Was Made

Chat route data now carries the exact source location that produced any immediate or deferred canonical rewrite. `ChatPage` applies the rewrite only while it still owns that source location, with one narrow exception for consuming the source route's own one-shot `draft` parameter. A newer route or a new/changed draft remains authoritative.

This complements #115320's browser-side route readiness helpers and 8-vCPU CI runner. Those changes make the lane less timing-sensitive; this change removes the production race that the loaded reproducer exposed.

## User Impact

Explicit navigation—such as opening Settings while the initial chat route is still resolving—no longer jumps back to chat. Pull requests also stop depending on whether that stale continuation happens to win on the CI runner.

## Evidence

- Before: [job 90326823954](https://github.com/openclaw/openclaw/actions/runs/30374457716/job/90326823954) observed `/settings/general`, then timed out after the app returned to `/chat/main`; the unchanged rerun passed.
- Root-cause stress: with one of four Testbox CPUs saturated, the old code reproduced within 2-4 runs. Diagnostic router state at timeout was committed `chat`, no pending match, URL `/chat/main`.
- Fixed stress: 10/10 repeated sidebar files passed under the same load (110/110 browser tests), followed by 5/5 on the #115320 base (55/55).
- Cited set: Codex sessions, sidebar customization, workspace memory, and Workboard routing passed together under load (28/28).
- Complete lane: 104 files and 367 browser tests passed in Testbox run [30384639661](https://github.com/openclaw/openclaw/actions/runs/30384639661).
- Final focused proof: 70/70 chat page and route tests passed in Testbox run [30386572718](https://github.com/openclaw/openclaw/actions/runs/30386572718).
- Fresh Codex autoreview: clean; no accepted/actionable findings.

AI-assisted: yes. The implementation and every reviewer finding were verified against the route owner, the current app code, and `@openclaw/uirouter` 0.1.0 source/types.
