### PR TITLE
perf(usage): stale-while-revalidate caches for usage.status and sessions.usage

### DIFF
--- a/src/gateway/server-methods/models-auth-status-usage-cache.ts
+++ b/src/gateway/server-methods/models-auth-status-usage-cache.ts
@@ -1,18 +1,29 @@
+import { resolveAgentDir, resolveDefaultAgentId } from "../../agents/agent-scope.js";
 // Stale-while-revalidate cache for models.authStatus provider usage enrichment.
-import type { AuthProfileStore } from "../../agents/auth-profiles.js";
+import {
+  ensureAuthProfileStore,
+  externalCliDiscoveryForConfigStatus,
+  type AuthProfileStore,
+} from "../../agents/auth-profiles.js";
 import {
   fingerprintAuthProfileCredential,
   fingerprintAuthProfileOwnerShape,
   fingerprintResolvedProviderAuth,
 } from "../../agents/execution-auth-binding.js";
+import { resolveEnvApiKey } from "../../agents/model-auth-env.js";
 import { resolveUsableCustomProviderApiKey } from "../../agents/model-auth.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { loadProviderUsageSummary } from "../../infra/provider-usage.load.js";
-import type { ProviderUsageSnapshot, UsageProviderId } from "../../infra/provider-usage.types.js";
+import type {
+  ProviderUsageSnapshot,
+  UsageProviderId,
+  UsageSummary,
+} from "../../infra/provider-usage.types.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
+import { listProviderUsagePluginDescriptors } from "../../plugins/provider-runtime.js";
 import { formatForLog } from "../ws-log.js";
 
-const log = createSubsystemLogger("models-auth-status");
+const log = createSubsystemLogger("provider-usage-cache");
 const USAGE_CACHE_TTL_MS = 60_000;
 
 export type ProviderUsageStatus = Pick<
@@ -26,6 +37,7 @@ type ProviderUsageCacheEntry = {
   credentialKey: string;
   providerKey: string;
   refreshedAt: number;
+  summary: UsageSummary;
   usageByProvider: Map<string, ProviderUsageStatus>;
 };
 
@@ -34,6 +46,7 @@ type ProviderUsageRefresh = {
   configRef: object;
   credentialKey: string;
   providerKey: string;
+  promise: Promise<UsageSummary>;
 };
 
 const usageCacheByAgentId = new Map<string, ProviderUsageCacheEntry>();
@@ -99,6 +112,32 @@ function providerUsageCacheKey(providerIds: readonly UsageProviderId[]): string 
   return providerIds.toSorted().join("\0");
 }
 
+function scopeProviderUsageCredentialKey(
+  credentialKey: string,
+  providerIds: readonly UsageProviderId[],
+): string {
+  // models.authStatus fingerprints every direct provider. Scope that evidence to
+  // this fetch set so usage.status can share the same credential-bound snapshot.
+  try {
+    const parsed = JSON.parse(credentialKey) as {
+      direct?: Array<[string, string | null]>;
+      [key: string]: unknown;
+    };
+    if (!Array.isArray(parsed.direct)) {
+      return credentialKey;
+    }
+    const providers = new Set(providerIds);
+    return JSON.stringify({
+      ...parsed,
+      direct: parsed.direct.filter(
+        ([provider, fingerprint]) => providers.has(provider) && fingerprint !== null,
+      ),
+    });
+  } catch {
+    return credentialKey;
+  }
+}
+
 function mapProviderUsage(usage: Awaited<ReturnType<typeof loadProviderUsageSummary>>) {
   const usageByProvider = new Map<string, ProviderUsageStatus>();
   for (const snap of usage.providers) {
@@ -120,7 +159,7 @@ function scheduleProviderUsageRefresh(params: {
   credentialKey: string;
   providerIds: UsageProviderId[];
   providerKey: string;
-}): void {
+}): Promise<UsageSummary> {
   const active = usageRefreshByAgentId.get(params.agentId);
   if (
     active?.agentDir === params.agentDir &&
@@ -128,52 +167,56 @@ function scheduleProviderUsageRefresh(params: {
     active.credentialKey === params.credentialKey &&
     active.providerKey === params.providerKey
   ) {
-    return;
+    return active.promise;
   }
   const publishGeneration = cacheGeneration;
-  const refresh = {
-    agentDir: params.agentDir,
-    configRef: params.configRef,
-    credentialKey: params.credentialKey,
-    providerKey: params.providerKey,
-  };
-  usageRefreshByAgentId.set(params.agentId, refresh);
-  void loadProviderUsageSummary({
+  const promise = loadProviderUsageSummary({
     providers: params.providerIds,
     agentDir: params.agentDir,
     timeoutMs: 3500,
   })
     .then((usage) => {
       if (
-        publishGeneration !== cacheGeneration ||
-        usageRefreshByAgentId.get(params.agentId) !== refresh
+        publishGeneration === cacheGeneration &&
+        usageRefreshByAgentId.get(params.agentId) === refresh
       ) {
-        return;
+        usageCacheByAgentId.set(params.agentId, {
+          agentDir: params.agentDir,
+          configRef: params.configRef,
+          credentialKey: params.credentialKey,
+          providerKey: params.providerKey,
+          refreshedAt: Date.now(),
+          summary: usage,
+          usageByProvider: mapProviderUsage(usage),
+        });
       }
-      usageCacheByAgentId.set(params.agentId, {
-        agentDir: params.agentDir,
-        configRef: params.configRef,
-        credentialKey: params.credentialKey,
-        providerKey: params.providerKey,
-        refreshedAt: Date.now(),
-        usageByProvider: mapProviderUsage(usage),
-      });
+      return usage;
     })
     .catch((err: unknown) => {
-      // Usage is auxiliary and stale data remains valid. Keep failures visible at
-      // debug level without delaying or failing the fresh auth-health response.
+      // Usage is auxiliary and stale data remains valid. Keep failures visible
+      // without delaying fresh auth-health responses.
       log.debug(
-        `usage enrichment failed (auth status still returned): providers=${params.providerIds.join(",")} error=${formatForLog(err)}`,
+        `usage refresh failed: providers=${params.providerIds.join(",")} error=${formatForLog(err)}`,
       );
+      throw err;
     })
     .finally(() => {
       if (usageRefreshByAgentId.get(params.agentId) === refresh) {
         usageRefreshByAgentId.delete(params.agentId);
       }
     });
+  const refresh: ProviderUsageRefresh = {
+    agentDir: params.agentDir,
+    configRef: params.configRef,
+    credentialKey: params.credentialKey,
+    providerKey: params.providerKey,
+    promise,
+  };
+  usageRefreshByAgentId.set(params.agentId, refresh);
+  return promise;
 }
 
-export function readProviderUsageStaleWhileRevalidate(params: {
+type ProviderUsageCacheParams = {
   agentId: string;
   agentDir: string;
   configRef: object;
@@ -181,36 +224,120 @@ export function readProviderUsageStaleWhileRevalidate(params: {
   forceRefresh?: boolean;
   providerIds: UsageProviderId[];
   now: number;
-}): Map<string, ProviderUsageStatus> {
-  if (params.providerIds.length === 0) {
-    usageCacheByAgentId.delete(params.agentId);
-    return new Map();
-  }
+};
+
+function resolveProviderUsageCacheRead(params: ProviderUsageCacheParams) {
   const providerIds = params.providerIds.toSorted();
   const providerKey = providerUsageCacheKey(providerIds);
+  const credentialKey = scopeProviderUsageCredentialKey(params.credentialKey, providerIds);
   const cached = usageCacheByAgentId.get(params.agentId);
   const matching =
     cached?.agentDir === params.agentDir &&
     cached.configRef === params.configRef &&
-    cached.credentialKey === params.credentialKey &&
+    cached.credentialKey === credentialKey &&
     cached.providerKey === providerKey
       ? cached
       : undefined;
-  if (
+  const needsRefresh =
     params.forceRefresh === true ||
     !matching ||
-    params.now - matching.refreshedAt >= USAGE_CACHE_TTL_MS
-  ) {
+    params.now - matching.refreshedAt >= USAGE_CACHE_TTL_MS;
+  return { credentialKey, matching, needsRefresh, providerIds, providerKey };
+}
+
+export function readProviderUsageStaleWhileRevalidate(
+  params: ProviderUsageCacheParams,
+): Map<string, ProviderUsageStatus> {
+  if (params.providerIds.length === 0) {
+    usageCacheByAgentId.delete(params.agentId);
+    return new Map();
+  }
+  const { credentialKey, matching, needsRefresh, providerIds, providerKey } =
+    resolveProviderUsageCacheRead(params);
+  if (needsRefresh) {
     // Never couple the RPC deadline to provider HTTP. A cold call returns auth
     // without usage; stale calls return the last snapshot while one refresh runs.
-    scheduleProviderUsageRefresh({
+    void scheduleProviderUsageRefresh({
       agentId: params.agentId,
       agentDir: params.agentDir,
       configRef: params.configRef,
-      credentialKey: params.credentialKey,
+      credentialKey,
       providerIds,
       providerKey,
-    });
+    }).catch(() => {});
   }
   return matching?.usageByProvider ?? new Map();
+}
+
+/** Returns cached provider usage, awaiting only a cold miss and refreshing stale data in place. */
+async function loadProviderUsageSummaryStaleWhileRevalidate(
+  params: ProviderUsageCacheParams,
+): Promise<UsageSummary> {
+  if (params.providerIds.length === 0) {
+    usageCacheByAgentId.delete(params.agentId);
+    return { updatedAt: params.now, providers: [] };
+  }
+  const { credentialKey, matching, needsRefresh, providerIds, providerKey } =
+    resolveProviderUsageCacheRead(params);
+  if (matching && !needsRefresh) {
+    return matching.summary;
+  }
+  const refresh = scheduleProviderUsageRefresh({
+    agentId: params.agentId,
+    agentDir: params.agentDir,
+    configRef: params.configRef,
+    credentialKey,
+    providerIds,
+    providerKey,
+  });
+  if (matching) {
+    void refresh.catch(() => {});
+    return matching.summary;
+  }
+  return await refresh;
+}
+
+/** Shares the models.authStatus cache contract with the unscoped usage.status RPC. */
+export async function loadUsageStatusStaleWhileRevalidate(params: {
+  config: OpenClawConfig;
+  now?: number;
+}): Promise<UsageSummary> {
+  const agentId = resolveDefaultAgentId(params.config);
+  const agentDir = resolveAgentDir(params.config, agentId);
+  const store = ensureAuthProfileStore(agentDir, {
+    externalCli: externalCliDiscoveryForConfigStatus({ cfg: params.config }),
+  });
+  const providerIds = listProviderUsagePluginDescriptors({
+    config: params.config,
+    env: process.env,
+  }).map((descriptor) => descriptor.provider);
+  const directApiKeys = new Map<
+    string,
+    { source: "config" | "env"; envVar?: string } | undefined
+  >();
+  for (const provider of providerIds) {
+    const resolved =
+      resolveUsableCustomProviderApiKey({
+        cfg: params.config,
+        provider,
+        env: process.env,
+      }) ?? resolveEnvApiKey(provider, process.env, { config: params.config });
+    if (!resolved) {
+      continue;
+    }
+    const envVar = resolved.source.match(/^(?:shell env|env): ([A-Z][A-Z0-9_]*)$/u)?.[1];
+    directApiKeys.set(provider, envVar ? { source: "env", envVar } : { source: "config" });
+  }
+  return await loadProviderUsageSummaryStaleWhileRevalidate({
+    agentId,
+    agentDir,
+    configRef: params.config,
+    credentialKey: fingerprintProviderUsageCredentials({
+      cfg: params.config,
+      directApiKeys,
+      store,
+    }),
+    providerIds,
+    now: params.now ?? Date.now(),
+  });
 }

--- a/src/gateway/server-methods/usage.sessions-usage-cache.test.ts
+++ b/src/gateway/server-methods/usage.sessions-usage-cache.test.ts
@@ -1,0 +1,323 @@
+import { expectDefined } from "@openclaw/normalization-core";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
+
+const mocks = vi.hoisted(() => ({
+  discoverAllSessions: vi.fn(),
+  loadCombinedSessionStoreForGateway: vi.fn(),
+  loadSessionCostSummariesFromCache: vi.fn(),
+}));
+
+vi.mock("../session-utils.js", async () => {
+  const actual = await vi.importActual<typeof import("../session-utils.js")>("../session-utils.js");
+  return {
+    ...actual,
+    loadCombinedSessionStoreForGateway: mocks.loadCombinedSessionStoreForGateway,
+  };
+});
+
+vi.mock("../../infra/session-cost-usage.js", async () => {
+  const actual = await vi.importActual<typeof import("../../infra/session-cost-usage.js")>(
+    "../../infra/session-cost-usage.js",
+  );
+  return {
+    ...actual,
+    discoverAllSessions: mocks.discoverAllSessions,
+    loadSessionCostSummariesFromCache: mocks.loadSessionCostSummariesFromCache,
+  };
+});
+
+import { testApi, usageHandlers } from "./usage.js";
+
+const config = {
+  agents: { list: [{ id: "main", default: true }, { id: "opus" }] },
+  session: {},
+} as OpenClawConfig;
+
+const baseParams = {
+  startDate: "2026-02-01",
+  endDate: "2026-02-02",
+  limit: 10,
+} as const;
+
+function sessionSummary(totalTokens: number) {
+  return {
+    input: totalTokens,
+    output: 0,
+    cacheRead: 0,
+    cacheWrite: 0,
+    totalTokens,
+    totalCost: totalTokens / 1000,
+    inputCost: totalTokens / 1000,
+    outputCost: 0,
+    cacheReadCost: 0,
+    cacheWriteCost: 0,
+    missingCostEntries: 0,
+  };
+}
+
+async function runSessionsUsage(
+  params: Record<string, unknown>,
+  runtimeConfig: OpenClawConfig = config,
+) {
+  const respond = vi.fn();
+  await expectDefined(
+    usageHandlers["sessions.usage"],
+    'usageHandlers["sessions.usage"] test invariant',
+  )({
+    respond,
+    params,
+    context: { getRuntimeConfig: () => runtimeConfig },
+  } as unknown as Parameters<(typeof usageHandlers)["sessions.usage"]>[0]);
+  expect(respond).toHaveBeenCalledTimes(1);
+  expect(respond.mock.calls[0]?.[0]).toBe(true);
+  return expectDefined(respond.mock.calls[0]?.[1], "sessions.usage result");
+}
+
+describe("sessions.usage result cache", () => {
+  let now = 1_000;
+
+  beforeEach(() => {
+    now = 1_000;
+    vi.spyOn(Date, "now").mockImplementation(() => now);
+    vi.clearAllMocks();
+    testApi.sessionsUsageCache.clear();
+    mocks.loadCombinedSessionStoreForGateway.mockReturnValue({
+      storePath: "(multiple)",
+      store: {},
+    });
+    mocks.discoverAllSessions.mockImplementation(async (params: { agentId?: string }) => [
+      {
+        sessionId: `session-${params.agentId ?? "unknown"}`,
+        sessionFile: `/tmp/${params.agentId ?? "unknown"}.jsonl`,
+        mtime: 100,
+      },
+    ]);
+    mocks.loadSessionCostSummariesFromCache.mockImplementation(
+      async (params: { sessions: unknown[] }) => ({
+        summaries: params.sessions.map(() => sessionSummary(10)),
+        cacheStatus: {
+          status: "fresh",
+          cachedFiles: params.sessions.length,
+          pendingFiles: 0,
+          staleFiles: 0,
+        },
+      }),
+    );
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns a byte-identical cached response without repeating transcript aggregation", async () => {
+    const first = await runSessionsUsage(baseParams);
+    const repeated = await runSessionsUsage(baseParams);
+
+    expect(JSON.stringify(repeated)).toBe(JSON.stringify(first));
+    expect(mocks.discoverAllSessions).toHaveBeenCalledTimes(1);
+    expect(mocks.loadSessionCostSummariesFromCache).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not share entries across result-shaping query parameters", async () => {
+    const variants: Array<Record<string, unknown>> = [
+      baseParams,
+      { ...baseParams, agentId: "opus" },
+      { ...baseParams, agentScope: "all" },
+      { ...baseParams, startDate: "2026-02-02", endDate: "2026-02-03" },
+      { ...baseParams, mode: "specific", utcOffset: "UTC+2" },
+      { ...baseParams, limit: 1 },
+      { ...baseParams, groupBy: "family" },
+      { ...baseParams, includeContextWeight: true },
+    ];
+
+    for (const params of variants) {
+      await runSessionsUsage(params);
+    }
+
+    expect(testApi.sessionsUsageCache.size).toBe(variants.length);
+    // The all-agent variant discovers both configured agents and aggregates
+    // each agent cache once; every other variant has one effective agent.
+    expect(mocks.discoverAllSessions).toHaveBeenCalledTimes(variants.length + 1);
+    expect(mocks.loadSessionCostSummariesFromCache).toHaveBeenCalledTimes(variants.length + 1);
+
+    const storeLoads = mocks.loadCombinedSessionStoreForGateway.mock.calls.length;
+    await runSessionsUsage({ ...baseParams, key: "agent:main:missing" });
+    expect(testApi.sessionsUsageCache.size).toBe(variants.length + 1);
+    expect(mocks.loadCombinedSessionStoreForGateway).toHaveBeenCalledTimes(storeLoads + 1);
+  });
+
+  it("does not share entries across runtime config snapshots", async () => {
+    const reloadedConfig = { ...config };
+
+    await runSessionsUsage(baseParams, config);
+    await runSessionsUsage(baseParams, reloadedConfig);
+
+    expect(mocks.discoverAllSessions).toHaveBeenCalledTimes(2);
+    expect(mocks.loadSessionCostSummariesFromCache).toHaveBeenCalledTimes(2);
+  });
+
+  it("coalesces concurrent cold misses into one transcript aggregation", async () => {
+    let release!: () => void;
+    const blocked = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    let started!: () => void;
+    const aggregationStarted = new Promise<void>((resolve) => {
+      started = resolve;
+    });
+    mocks.loadSessionCostSummariesFromCache.mockImplementationOnce(
+      async (params: { sessions: unknown[] }) => {
+        started();
+        await blocked;
+        return {
+          summaries: params.sessions.map(() => sessionSummary(10)),
+          cacheStatus: {
+            status: "fresh",
+            cachedFiles: params.sessions.length,
+            pendingFiles: 0,
+            staleFiles: 0,
+          },
+        };
+      },
+    );
+
+    const first = runSessionsUsage(baseParams);
+    const second = runSessionsUsage(baseParams);
+    await aggregationStarted;
+
+    expect(mocks.discoverAllSessions).toHaveBeenCalledTimes(1);
+    expect(mocks.loadSessionCostSummariesFromCache).toHaveBeenCalledTimes(1);
+    release();
+
+    const [firstResult, secondResult] = await Promise.all([first, second]);
+    expect(JSON.stringify(secondResult)).toBe(JSON.stringify(firstResult));
+  });
+
+  it("does not give a partial lower-cache snapshot the 30s freshness TTL", async () => {
+    mocks.loadSessionCostSummariesFromCache
+      .mockResolvedValueOnce({
+        summaries: [null],
+        cacheStatus: {
+          status: "refreshing",
+          cachedFiles: 0,
+          pendingFiles: 1,
+          staleFiles: 1,
+        },
+      })
+      .mockResolvedValueOnce({
+        summaries: [sessionSummary(20)],
+        cacheStatus: {
+          status: "fresh",
+          cachedFiles: 1,
+          pendingFiles: 0,
+          staleFiles: 0,
+        },
+      });
+
+    const partial = (await runSessionsUsage(baseParams)) as {
+      totals: { totalTokens: number };
+    };
+    const refreshed = (await runSessionsUsage(baseParams)) as {
+      totals: { totalTokens: number };
+    };
+
+    expect(partial.totals.totalTokens).toBe(0);
+    expect(refreshed.totals.totalTokens).toBe(20);
+    expect(mocks.loadSessionCostSummariesFromCache).toHaveBeenCalledTimes(2);
+  });
+
+  it("preserves a complete stale result when a refresh is partial", async () => {
+    const first = (await runSessionsUsage(baseParams)) as {
+      totals: { totalTokens: number };
+    };
+    expect(first.totals.totalTokens).toBe(10);
+
+    mocks.loadSessionCostSummariesFromCache.mockResolvedValueOnce({
+      summaries: [null],
+      cacheStatus: {
+        status: "refreshing",
+        cachedFiles: 0,
+        pendingFiles: 1,
+        staleFiles: 1,
+      },
+    });
+    now = 31_000;
+    await runSessionsUsage(baseParams);
+    await vi.waitFor(() => {
+      expect(
+        Array.from(testApi.sessionsUsageCache.values()).every((entry) => !entry.inFlight),
+      ).toBe(true);
+    });
+
+    let release!: () => void;
+    const blocked = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    let started!: () => void;
+    const aggregationStarted = new Promise<void>((resolve) => {
+      started = resolve;
+    });
+    mocks.loadSessionCostSummariesFromCache.mockImplementationOnce(
+      async (params: { sessions: unknown[] }) => {
+        started();
+        await blocked;
+        return {
+          summaries: params.sessions.map(() => sessionSummary(20)),
+          cacheStatus: {
+            status: "fresh",
+            cachedFiles: params.sessions.length,
+            pendingFiles: 0,
+            staleFiles: 0,
+          },
+        };
+      },
+    );
+
+    let returned = false;
+    const next = runSessionsUsage(baseParams).then((result) => {
+      returned = true;
+      return result as { totals: { totalTokens: number } };
+    });
+    await aggregationStarted;
+    await Promise.resolve();
+    expect(returned).toBe(true);
+    expect((await next).totals.totalTokens).toBe(10);
+    release();
+    await vi.waitFor(() => {
+      expect(
+        Array.from(testApi.sessionsUsageCache.values()).every((entry) => !entry.inFlight),
+      ).toBe(true);
+    });
+  });
+
+  it("serves stale data while one 30s refresh replaces it", async () => {
+    const first = await runSessionsUsage(baseParams);
+    mocks.loadSessionCostSummariesFromCache.mockImplementationOnce(
+      async (params: { sessions: unknown[] }) => ({
+        summaries: params.sessions.map(() => sessionSummary(20)),
+        cacheStatus: {
+          status: "fresh",
+          cachedFiles: params.sessions.length,
+          pendingFiles: 0,
+          staleFiles: 0,
+        },
+      }),
+    );
+
+    now = 31_000;
+    const stale = await runSessionsUsage(baseParams);
+    expect(JSON.stringify(stale)).toBe(JSON.stringify(first));
+    await vi.waitFor(() => {
+      expect(mocks.loadSessionCostSummariesFromCache).toHaveBeenCalledTimes(2);
+    });
+
+    await vi.waitFor(async () => {
+      const refreshed = (await runSessionsUsage(baseParams)) as {
+        totals: { totalTokens: number };
+      };
+      expect(refreshed.totals.totalTokens).toBe(20);
+    });
+    expect(mocks.loadSessionCostSummariesFromCache).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/gateway/server-methods/usage.sessions-usage.test.ts
+++ b/src/gateway/server-methods/usage.sessions-usage.test.ts
@@ -102,7 +102,7 @@ import {
   loadSessionUsageTimeSeries,
 } from "../../infra/session-cost-usage.js";
 import { loadCombinedSessionStoreForGateway } from "../session-utils.js";
-import { usageHandlers } from "./usage.js";
+import { testApi, usageHandlers } from "./usage.js";
 
 const TEST_RUNTIME_CONFIG = {
   agents: {
@@ -205,6 +205,7 @@ async function withUsageState(
 
 describe("sessions.usage", () => {
   beforeEach(() => {
+    testApi.sessionsUsageCache.clear();
     vi.useRealTimers();
     vi.clearAllMocks();
   });

--- a/src/gateway/server-methods/usage.status-cache.test.ts
+++ b/src/gateway/server-methods/usage.status-cache.test.ts
@@ -1,0 +1,162 @@
+import { expectDefined } from "@openclaw/normalization-core";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { resolveAgentDir, resolveDefaultAgentId } from "../../agents/agent-scope.js";
+import type { AuthProfileStore } from "../../agents/auth-profiles.js";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
+
+const mocks = vi.hoisted(() => ({
+  ensureAuthProfileStore: vi.fn(),
+  listProviderUsagePluginDescriptors: vi.fn(),
+  loadProviderUsageSummary: vi.fn(),
+}));
+
+vi.mock("../../agents/auth-profiles.js", async () => {
+  const actual = await vi.importActual<typeof import("../../agents/auth-profiles.js")>(
+    "../../agents/auth-profiles.js",
+  );
+  return {
+    ...actual,
+    ensureAuthProfileStore: mocks.ensureAuthProfileStore,
+    externalCliDiscoveryForConfigStatus: vi.fn(() => undefined),
+  };
+});
+
+vi.mock("../../plugins/provider-runtime.js", async () => {
+  const actual = await vi.importActual<typeof import("../../plugins/provider-runtime.js")>(
+    "../../plugins/provider-runtime.js",
+  );
+  return {
+    ...actual,
+    listProviderUsagePluginDescriptors: mocks.listProviderUsagePluginDescriptors,
+  };
+});
+
+vi.mock("../../infra/provider-usage.load.js", () => ({
+  loadProviderUsageSummary: mocks.loadProviderUsageSummary,
+}));
+
+import {
+  clearModelAuthStatusUsageCache,
+  fingerprintProviderUsageCredentials,
+  readProviderUsageStaleWhileRevalidate,
+} from "./models-auth-status-usage-cache.js";
+import { usageHandlers } from "./usage.js";
+
+const config = {
+  agents: { list: [{ id: "main", default: true }] },
+} as OpenClawConfig;
+
+function createStore(access = "access-one") {
+  return {
+    version: 1,
+    profiles: {
+      "openai:default": {
+        type: "oauth" as const,
+        provider: "openai",
+        access,
+        refresh: "refresh-one",
+        expires: 1_000_000,
+      },
+    },
+  };
+}
+
+async function runUsageStatus() {
+  const respond = vi.fn();
+  await expectDefined(
+    usageHandlers["usage.status"],
+    'usageHandlers["usage.status"] test invariant',
+  )({
+    respond,
+    params: {},
+    context: { getRuntimeConfig: () => config },
+  } as unknown as Parameters<(typeof usageHandlers)["usage.status"]>[0]);
+  expect(respond).toHaveBeenCalledTimes(1);
+  expect(respond.mock.calls[0]?.[0]).toBe(true);
+  return expectDefined(respond.mock.calls[0]?.[1], "usage.status result");
+}
+
+describe("usage.status provider usage cache", () => {
+  let now = 1_000;
+  let store = createStore();
+
+  beforeEach(() => {
+    now = 1_000;
+    store = createStore();
+    vi.spyOn(Date, "now").mockImplementation(() => now);
+    vi.clearAllMocks();
+    clearModelAuthStatusUsageCache();
+    mocks.ensureAuthProfileStore.mockImplementation(() => store);
+    mocks.listProviderUsagePluginDescriptors.mockReturnValue([
+      { provider: "openai", displayName: "OpenAI" },
+    ]);
+    mocks.loadProviderUsageSummary.mockImplementation(async () => ({
+      updatedAt: now,
+      providers: [
+        {
+          provider: "openai",
+          displayName: "OpenAI",
+          windows: [
+            {
+              label: "5h",
+              usedPercent: mocks.loadProviderUsageSummary.mock.calls.length * 10,
+            },
+          ],
+          plan: "Plus",
+        },
+      ],
+    }));
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("reuses byte-identical results within 60s and refreshes stale data in the background", async () => {
+    const first = await runUsageStatus();
+    const repeated = await runUsageStatus();
+
+    expect(JSON.stringify(repeated)).toBe(JSON.stringify(first));
+    expect(mocks.loadProviderUsageSummary).toHaveBeenCalledTimes(1);
+
+    now = 61_000;
+    const stale = await runUsageStatus();
+    expect(JSON.stringify(stale)).toBe(JSON.stringify(first));
+    expect(mocks.loadProviderUsageSummary).toHaveBeenCalledTimes(2);
+
+    await vi.waitFor(async () => {
+      const refreshed = (await runUsageStatus()) as {
+        providers: Array<{ windows: Array<{ usedPercent: number }> }>;
+      };
+      expect(refreshed.providers[0]?.windows[0]?.usedPercent).toBe(20);
+    });
+    expect(mocks.loadProviderUsageSummary).toHaveBeenCalledTimes(2);
+  });
+
+  it("shares the raw snapshot with models.authStatus and invalidates on credential rotation", async () => {
+    await runUsageStatus();
+    const agentId = resolveDefaultAgentId(config);
+    const agentDir = resolveAgentDir(config, agentId);
+    const usage = readProviderUsageStaleWhileRevalidate({
+      agentId,
+      agentDir,
+      configRef: config,
+      credentialKey: fingerprintProviderUsageCredentials({
+        cfg: config,
+        directApiKeys: new Map(),
+        store: store as AuthProfileStore,
+      }),
+      providerIds: ["openai"],
+      now,
+    });
+    expect(usage.get("openai")?.windows[0]?.usedPercent).toBe(10);
+    expect(mocks.loadProviderUsageSummary).toHaveBeenCalledTimes(1);
+
+    store.profiles["openai:default"].access = "access-two";
+    const rotated = (await runUsageStatus()) as {
+      providers: Array<{ windows: Array<{ usedPercent: number }> }>;
+    };
+    expect(rotated.providers[0]?.windows[0]?.usedPercent).toBe(20);
+    expect(mocks.loadProviderUsageSummary).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/gateway/server-methods/usage.test.ts
+++ b/src/gateway/server-methods/usage.test.ts
@@ -122,6 +122,7 @@ describe("gateway usage helpers", () => {
 
   beforeEach(() => {
     testApi.costUsageCache.clear();
+    testApi.sessionsUsageCache.clear();
     vi.useRealTimers();
     vi.clearAllMocks();
   });

--- a/src/gateway/server-methods/usage.ts
+++ b/src/gateway/server-methods/usage.ts
@@ -20,7 +20,6 @@ import {
   resolveTimezone,
   resolveTimeZoneDayStartMs,
 } from "../../infra/format-time/format-datetime.js";
-import { loadProviderUsageSummary } from "../../infra/provider-usage.js";
 import {
   addCostUsageTotals,
   createEmptyCostUsageTotals,
@@ -67,11 +66,14 @@ import {
   resolveStoredSessionKeyForAgentStore,
 } from "../session-store-key.js";
 import { loadCombinedSessionStoreForGateway, loadSessionEntryReadOnly } from "../session-utils.js";
+import { loadUsageStatusStaleWhileRevalidate } from "./models-auth-status-usage-cache.js";
 import type { GatewayRequestHandlers, RespondFn } from "./types.js";
 import { assertValidParams } from "./validation.js";
 
 const COST_USAGE_CACHE_TTL_MS = 30_000;
 const COST_USAGE_CACHE_MAX = 256;
+const SESSIONS_USAGE_CACHE_TTL_MS = 30_000;
+const SESSIONS_USAGE_CACHE_MAX = 256;
 const USAGE_AGENT_LOAD_CONCURRENCY = 12;
 
 async function runUsageAgentTasks<T>(tasks: Array<() => Promise<T>>): Promise<T[]> {
@@ -115,6 +117,17 @@ type CostUsageCacheEntry = {
 
 const costUsageCache = new Map<string, CostUsageCacheEntry>();
 
+type SessionsUsageCacheEntry = {
+  configRef: object;
+  result?: SessionsUsageResult;
+  updatedAt?: number;
+  inFlight?: Promise<SessionsUsageResult>;
+};
+
+const sessionsUsageCache = new Map<string, SessionsUsageCacheEntry>();
+
+class SessionsUsageInvalidRequestError extends Error {}
+
 function findCostUsageCacheEvictionKey(): string | undefined {
   for (const [key, entry] of costUsageCache) {
     // Prefer evicting settled entries so duplicate callers can still join active loads.
@@ -135,6 +148,129 @@ function setCostUsageCache(cacheKey: string, entry: CostUsageCacheEntry): void {
     }
   }
   costUsageCache.set(cacheKey, entry);
+}
+
+function findSessionsUsageCacheEvictionKey(): string | undefined {
+  for (const [key, entry] of sessionsUsageCache) {
+    // Prefer evicting settled entries so duplicate callers can still join active loads.
+    if (!entry.inFlight) {
+      return key;
+    }
+  }
+  return sessionsUsageCache.keys().next().value;
+}
+
+// Session reports have high-cardinality date and grouping axes. Bound the
+// short-lived result cache without breaking in-flight request coalescing.
+function setSessionsUsageCache(cacheKey: string, entry: SessionsUsageCacheEntry): void {
+  if (!sessionsUsageCache.has(cacheKey) && sessionsUsageCache.size >= SESSIONS_USAGE_CACHE_MAX) {
+    const evictKey = findSessionsUsageCacheEvictionKey();
+    if (evictKey !== undefined) {
+      sessionsUsageCache.delete(evictKey);
+    }
+  }
+  sessionsUsageCache.set(cacheKey, entry);
+}
+
+function usageDayBucketCacheKey(dayBucket: UsageDailyBucket | undefined): string {
+  return dayBucket
+    ? dayBucket.mode === "time-zone"
+      ? `time-zone:${dayBucket.timeZone}`
+      : `utc-offset:${dayBucket.utcOffsetMinutes}`
+    : "gateway";
+}
+
+type SessionsUsageCacheKeyParams = {
+  configRef: object;
+  agentId?: string;
+  agentScope?: "all";
+  startMs: number;
+  endMs: number;
+  includeUntimestamped?: boolean;
+  dayBucket?: UsageDailyBucket;
+  limit: number;
+  groupingMode: UsageGroupingMode;
+  specificKey: string | null;
+  includeContextWeight: boolean;
+};
+
+// Every normalized query axis that can change response bytes belongs in this
+// key; the 30s TTL mirrors usage.cost and keeps dashboard refreshes coherent.
+function sessionsUsageCacheKey(params: SessionsUsageCacheKeyParams): string {
+  return JSON.stringify([
+    params.agentScope === "all" ? "all" : `agent:${params.agentId}`,
+    params.startMs,
+    params.endMs,
+    params.includeUntimestamped === true,
+    usageDayBucketCacheKey(params.dayBucket),
+    params.limit,
+    params.groupingMode,
+    params.specificKey,
+    params.includeContextWeight,
+  ]);
+}
+
+async function loadSessionsUsageResultCached(
+  params: SessionsUsageCacheKeyParams & {
+    load: () => Promise<SessionsUsageResult>;
+  },
+): Promise<SessionsUsageResult> {
+  const cacheKey = sessionsUsageCacheKey(params);
+  const now = Date.now();
+  const candidate = sessionsUsageCache.get(cacheKey);
+  const cached = candidate?.configRef === params.configRef ? candidate : undefined;
+  if (cached?.result && cached.updatedAt && now - cached.updatedAt < SESSIONS_USAGE_CACHE_TTL_MS) {
+    return cached.result;
+  }
+
+  if (cached?.inFlight) {
+    if (cached.result && cached.updatedAt) {
+      return cached.result;
+    }
+    return await cached.inFlight;
+  }
+
+  const entry: SessionsUsageCacheEntry = cached ?? { configRef: params.configRef };
+  const inFlight = params
+    .load()
+    .then((result) => {
+      if (sessionsUsageCache.get(cacheKey) !== entry) {
+        return result;
+      }
+      // The lower cache returns partial rows while its own refresh runs. Do not
+      // pin that intentionally incomplete snapshot behind the outer 30s TTL.
+      const isComplete = !result.cacheStatus || result.cacheStatus.status === "fresh";
+      if (isComplete) {
+        entry.result = result;
+        entry.updatedAt = Date.now();
+      } else if (!entry.result) {
+        // Cold callers still need the partial response, but a stale complete
+        // result remains the safer SWR value until a complete refresh lands.
+        entry.result = result;
+        delete entry.updatedAt;
+      }
+      return result;
+    })
+    .catch((err: unknown) => {
+      if (entry.result) {
+        return entry.result;
+      }
+      throw err;
+    })
+    .finally(() => {
+      const current = sessionsUsageCache.get(cacheKey);
+      if (current === entry && current.inFlight === inFlight) {
+        current.inFlight = undefined;
+      }
+    });
+
+  entry.inFlight = inFlight;
+  setSessionsUsageCache(cacheKey, entry);
+
+  if (entry.result && entry.updatedAt) {
+    return entry.result;
+  }
+  return await inFlight;
 }
 
 function resolveSessionUsageFileOrRespond(
@@ -910,11 +1046,7 @@ async function loadCostUsageSummaryCached(params: {
   const agentId = allAgents
     ? undefined
     : normalizeAgentId(params.agentId ?? resolveDefaultAgentId(params.config));
-  const dayBucketKey = params.dayBucket
-    ? params.dayBucket.mode === "time-zone"
-      ? `time-zone:${params.dayBucket.timeZone}`
-      : `utc-offset:${params.dayBucket.utcOffsetMinutes}`
-    : "gateway";
+  const dayBucketKey = usageDayBucketCacheKey(params.dayBucket);
   const cacheKey = `${allAgents ? "all" : `agent:${agentId}`}:${params.startMs}-${params.endMs}:${dayBucketKey}`;
   const now = Date.now();
   const cached = costUsageCache.get(cacheKey);
@@ -1065,14 +1197,19 @@ export const testApi = {
   discoverAllSessionsForUsage,
   loadCostUsageSummaryCached,
   costUsageCache,
+  loadSessionsUsageResultCached,
+  sessionsUsageCache,
+  sessionsUsageCacheKey,
 };
 export { testApi as __test };
 
 export type { SessionUsageEntry, SessionsUsageAggregates, SessionsUsageResult };
 
 export const usageHandlers: GatewayRequestHandlers = {
-  "usage.status": async ({ respond }) => {
-    const summary = await loadProviderUsageSummary();
+  "usage.status": async ({ respond, context }) => {
+    const summary = await loadUsageStatusStaleWhileRevalidate({
+      config: context.getRuntimeConfig(),
+    });
     respond(true, summary, undefined);
   },
   "usage.cost": async ({ respond, params, context }) => {
@@ -1193,477 +1330,503 @@ export const usageHandlers: GatewayRequestHandlers = {
     const groupingMode: UsageGroupingMode =
       p.groupBy === "family" || p.includeHistorical === true ? "family" : "instance";
 
-    // Load session store for named sessions
-    const sessionStoreOpts = effectiveAgentId ? { agentId: effectiveAgentId } : {};
-    const { storePath, store } = loadCombinedSessionStoreForGateway(config, sessionStoreOpts);
-    const scopedStore = effectiveAgentId
-      ? filterSessionStoreByAgent({
-          config,
-          store,
-          agentId: effectiveAgentId,
-        })
-      : store;
-    const now = Date.now();
-
-    const mergedEntries: MergedEntry[] = [];
-
-    // Optimization: If a specific key is requested, skip full directory scan
-    if (specificKey) {
-      const scopedSpecificKey = resolveStoredSessionKeyForAgentStore({
-        cfg: config,
-        agentId: effectiveAgentId ?? resolveDefaultAgentId(config),
-        sessionKey: specificKey,
-      });
-      const scopedParsed = parseAgentSessionKey(scopedSpecificKey);
-      const agentIdFromKey =
-        scopedParsed?.agentId ?? effectiveAgentId ?? resolveDefaultAgentId(config);
-      const keyRest = scopedParsed?.rest ?? specificKey;
-
-      // Prefer the store entry when available, even if the caller provides a discovered key
-      // (`agent:<id>:<sessionId>`) for a session that now has a canonical store key.
-      const storeBySessionId = buildStoreBySessionId(scopedStore);
-
-      const storeMatch = scopedStore[scopedSpecificKey]
-        ? { key: scopedSpecificKey, entry: scopedStore[scopedSpecificKey] }
-        : scopedStore[specificKey]
-          ? { key: specificKey, entry: scopedStore[specificKey] }
-          : null;
-      const storeByIdMatch =
-        storeBySessionId.get(keyRest) ??
-        (keyRest !== specificKey ? storeBySessionId.get(specificKey) : undefined) ??
-        null;
-      const resolvedStoreKey = storeMatch?.key ?? storeByIdMatch?.key ?? scopedSpecificKey;
-      const storeEntry = storeMatch?.entry ?? storeByIdMatch?.entry;
-      const sessionId = storeEntry?.sessionId ?? keyRest;
-
-      // Resolve the session file path
-      let sessionFile: string | undefined;
-      try {
-        const pathOpts = resolveSessionFilePathOptions({
-          storePath: storePath !== "(multiple)" ? storePath : undefined,
-          agentId: agentIdFromKey,
-        });
-        sessionFile = resolveExistingUsageSessionFile({
-          sessionId,
-          sessionEntry: storeEntry,
-          sessionFile: resolveSessionFilePath(sessionId, storeEntry, pathOpts),
-          agentId: agentIdFromKey,
-        });
-      } catch {
-        respond(
-          false,
-          undefined,
-          errorShape(ErrorCodes.INVALID_REQUEST, `Invalid session reference: ${specificKey}`),
-        );
-        return;
-      }
-
-      if (sessionFile) {
-        try {
-          const stats = fs.statSync(sessionFile);
-          if (stats.isFile()) {
-            maybeMergeFamilyEntry({
-              mergedEntries,
-              groupingMode,
-              base: {
-                key: resolvedStoreKey,
-                agentId: agentIdFromKey,
-                sessionId,
-                sessionFile,
-                label: storeEntry?.label,
-                updatedAt: storeEntry?.updatedAt ?? stats.mtimeMs,
-                storeEntry,
-              },
-            });
-          }
-        } catch {
-          // File doesn't exist - no results for this key
-        }
-      }
-    } else {
-      // Full discovery for list view
-      const discoveredSessions = await discoverAllSessionsForUsage({
-        config,
-        ...(effectiveAgentId ? { agentId: effectiveAgentId } : {}),
+    let result: SessionsUsageResult;
+    try {
+      result = await loadSessionsUsageResultCached({
+        configRef: config,
+        ...(effectiveAgentId ? { agentId: effectiveAgentId } : { agentScope: "all" }),
         startMs,
         endMs,
-      });
+        includeUntimestamped,
+        dayBucket,
+        limit,
+        groupingMode,
+        specificKey,
+        includeContextWeight,
+        load: async () => {
+          // Load session store for named sessions only on a result-cache miss.
+          const sessionStoreOpts = effectiveAgentId ? { agentId: effectiveAgentId } : {};
+          const { storePath, store } = loadCombinedSessionStoreForGateway(config, sessionStoreOpts);
+          const scopedStore = effectiveAgentId
+            ? filterSessionStoreByAgent({
+                config,
+                store,
+                agentId: effectiveAgentId,
+              })
+            : store;
+          const now = Date.now();
 
-      // Build a map of sessionId -> store entry for quick lookup
-      const storeBySessionId = buildStoreBySessionId(scopedStore);
-      const storeFamilySessionIds = new Set<string>();
-      if (groupingMode === "family") {
-        for (const entry of Object.values(scopedStore)) {
-          for (const sessionId of entry?.usageFamilySessionIds ?? []) {
-            storeFamilySessionIds.add(sessionId);
-          }
-        }
-      }
+          const mergedEntries: MergedEntry[] = [];
 
-      for (const discovered of discoveredSessions) {
-        const storeMatch = storeBySessionId.get(discovered.sessionId);
-        if (storeMatch) {
-          // Named session from store
-          maybeMergeFamilyEntry({
-            mergedEntries,
-            groupingMode,
-            base: {
-              key: storeMatch.key,
-              agentId: discovered.agentId,
-              sessionId: discovered.sessionId,
-              sessionFile: discovered.sessionFile,
-              label: storeMatch.entry.label,
-              updatedAt: storeMatch.entry.updatedAt ?? discovered.mtime,
-              storeEntry: storeMatch.entry,
-            },
-          });
-        } else {
-          if (groupingMode === "family" && storeFamilySessionIds.has(discovered.sessionId)) {
-            // The current store row will load this historical transcript through included ids.
-            continue;
-          }
-          // Unnamed session - use session ID as key, no label
-          mergedEntries.push({
-            // Keep agentId in the key so the dashboard can attribute sessions and later fetch logs.
-            key: `agent:${discovered.agentId}:${discovered.sessionId}`,
-            agentId: discovered.agentId,
-            sessionId: discovered.sessionId,
-            sessionFile: discovered.sessionFile,
-            label: undefined, // No label for unnamed sessions
-            updatedAt: discovered.mtime,
-            scope: "instance",
-          });
-        }
-      }
-    }
+          // Optimization: If a specific key is requested, skip full directory scan
+          if (specificKey) {
+            const scopedSpecificKey = resolveStoredSessionKeyForAgentStore({
+              cfg: config,
+              agentId: effectiveAgentId ?? resolveDefaultAgentId(config),
+              sessionKey: specificKey,
+            });
+            const scopedParsed = parseAgentSessionKey(scopedSpecificKey);
+            const agentIdFromKey =
+              scopedParsed?.agentId ?? effectiveAgentId ?? resolveDefaultAgentId(config);
+            const keyRest = scopedParsed?.rest ?? specificKey;
 
-    // Sort by most recent first
-    mergedEntries.sort((a, b) => b.updatedAt - a.updatedAt);
+            // Prefer the store entry when available, even if the caller provides a discovered key
+            // (`agent:<id>:<sessionId>`) for a session that now has a canonical store key.
+            const storeBySessionId = buildStoreBySessionId(scopedStore);
 
-    // Load usage for each session
-    const sessions: SessionUsageEntry[] = [];
-    const aggregateTotals = createEmptyCostUsageTotals();
-    const aggregateMessages: SessionMessageCounts = {
-      total: 0,
-      user: 0,
-      assistant: 0,
-      toolCalls: 0,
-      toolResults: 0,
-      errors: 0,
-    };
-    const toolAggregateMap = new Map<string, number>();
-    const byModelMap = new Map<string, SessionModelUsage>();
-    const byProviderMap = new Map<string, SessionModelUsage>();
-    const byAgentMap = new Map<string, CostUsageSummary["totals"]>();
-    const byChannelMap = new Map<string, CostUsageSummary["totals"]>();
-    const dailyAggregateMap = new Map<
-      string,
-      {
-        date: string;
-        tokens: number;
-        cost: number;
-        messages: number;
-        toolCalls: number;
-        errors: number;
-      }
-    >();
-    const latencyTotals = {
-      count: 0,
-      sum: 0,
-      min: Number.POSITIVE_INFINITY,
-      max: 0,
-      p95Max: 0,
-    };
-    const dailyLatencyMap = new Map<
-      string,
-      { date: string; count: number; sum: number; min: number; max: number; p95Max: number }
-    >();
-    const modelDailyMap = new Map<string, SessionDailyModelUsage>();
-    let cacheStatus: UsageCacheStatus | undefined;
+            const storeMatch = scopedStore[scopedSpecificKey]
+              ? { key: scopedSpecificKey, entry: scopedStore[scopedSpecificKey] }
+              : scopedStore[specificKey]
+                ? { key: specificKey, entry: scopedStore[specificKey] }
+                : null;
+            const storeByIdMatch =
+              storeBySessionId.get(keyRest) ??
+              (keyRest !== specificKey ? storeBySessionId.get(specificKey) : undefined) ??
+              null;
+            const resolvedStoreKey = storeMatch?.key ?? storeByIdMatch?.key ?? scopedSpecificKey;
+            const storeEntry = storeMatch?.entry ?? storeByIdMatch?.entry;
+            const sessionId = storeEntry?.sessionId ?? keyRest;
 
-    const usageByEntryIndex: Array<SessionCostSummary | null> = Array.from(
-      { length: mergedEntries.length },
-      () => null,
-    );
-
-    // Group every included session (visible + hidden) by agent so the usage-cost
-    // cache is read and parsed at most once per agent. Loading each session
-    // individually re-reads and re-parses the whole cache file, so RSS spikes
-    // in proportion to `limit` on every dashboard connect (issue #100041).
-    const sessionsByAgent = new Map<
-      string,
-      Array<{ entryIndex: number; sessionId: string; sessionFile: string }>
-    >();
-    for (const [entryIndex, merged] of mergedEntries.entries()) {
-      for (const includedSessionId of merged.includedSessionIds ?? [merged.sessionId]) {
-        const includedSessionFile =
-          includedSessionId === merged.sessionId
-            ? merged.sessionFile
-            : resolveExistingUsageSessionFile({
-                sessionId: includedSessionId,
-                agentId: merged.agentId,
+            // Resolve the session file path
+            let sessionFile: string | undefined;
+            try {
+              const pathOpts = resolveSessionFilePathOptions({
+                storePath: storePath !== "(multiple)" ? storePath : undefined,
+                agentId: agentIdFromKey,
               });
-        if (!includedSessionFile) {
-          continue;
-        }
-        const agentSessions = sessionsByAgent.get(merged.agentId) ?? [];
-        agentSessions.push({
-          entryIndex,
-          sessionId: includedSessionId,
-          sessionFile: includedSessionFile,
-        });
-        sessionsByAgent.set(merged.agentId, agentSessions);
+              sessionFile = resolveExistingUsageSessionFile({
+                sessionId,
+                sessionEntry: storeEntry,
+                sessionFile: resolveSessionFilePath(sessionId, storeEntry, pathOpts),
+                agentId: agentIdFromKey,
+              });
+            } catch {
+              throw new SessionsUsageInvalidRequestError(
+                `Invalid session reference: ${specificKey}`,
+              );
+            }
+
+            if (sessionFile) {
+              try {
+                const stats = fs.statSync(sessionFile);
+                if (stats.isFile()) {
+                  maybeMergeFamilyEntry({
+                    mergedEntries,
+                    groupingMode,
+                    base: {
+                      key: resolvedStoreKey,
+                      agentId: agentIdFromKey,
+                      sessionId,
+                      sessionFile,
+                      label: storeEntry?.label,
+                      updatedAt: storeEntry?.updatedAt ?? stats.mtimeMs,
+                      storeEntry,
+                    },
+                  });
+                }
+              } catch {
+                // File doesn't exist - no results for this key
+              }
+            }
+          } else {
+            // Full discovery for list view
+            const discoveredSessions = await discoverAllSessionsForUsage({
+              config,
+              ...(effectiveAgentId ? { agentId: effectiveAgentId } : {}),
+              startMs,
+              endMs,
+            });
+
+            // Build a map of sessionId -> store entry for quick lookup
+            const storeBySessionId = buildStoreBySessionId(scopedStore);
+            const storeFamilySessionIds = new Set<string>();
+            if (groupingMode === "family") {
+              for (const entry of Object.values(scopedStore)) {
+                for (const sessionId of entry?.usageFamilySessionIds ?? []) {
+                  storeFamilySessionIds.add(sessionId);
+                }
+              }
+            }
+
+            for (const discovered of discoveredSessions) {
+              const storeMatch = storeBySessionId.get(discovered.sessionId);
+              if (storeMatch) {
+                // Named session from store
+                maybeMergeFamilyEntry({
+                  mergedEntries,
+                  groupingMode,
+                  base: {
+                    key: storeMatch.key,
+                    agentId: discovered.agentId,
+                    sessionId: discovered.sessionId,
+                    sessionFile: discovered.sessionFile,
+                    label: storeMatch.entry.label,
+                    updatedAt: storeMatch.entry.updatedAt ?? discovered.mtime,
+                    storeEntry: storeMatch.entry,
+                  },
+                });
+              } else {
+                if (groupingMode === "family" && storeFamilySessionIds.has(discovered.sessionId)) {
+                  // The current store row will load this historical transcript through included ids.
+                  continue;
+                }
+                // Unnamed session - use session ID as key, no label
+                mergedEntries.push({
+                  // Keep agentId in the key so the dashboard can attribute sessions and later fetch logs.
+                  key: `agent:${discovered.agentId}:${discovered.sessionId}`,
+                  agentId: discovered.agentId,
+                  sessionId: discovered.sessionId,
+                  sessionFile: discovered.sessionFile,
+                  label: undefined, // No label for unnamed sessions
+                  updatedAt: discovered.mtime,
+                  scope: "instance",
+                });
+              }
+            }
+          }
+
+          // Sort by most recent first
+          mergedEntries.sort((a, b) => b.updatedAt - a.updatedAt);
+
+          // Load usage for each session
+          const sessions: SessionUsageEntry[] = [];
+          const aggregateTotals = createEmptyCostUsageTotals();
+          const aggregateMessages: SessionMessageCounts = {
+            total: 0,
+            user: 0,
+            assistant: 0,
+            toolCalls: 0,
+            toolResults: 0,
+            errors: 0,
+          };
+          const toolAggregateMap = new Map<string, number>();
+          const byModelMap = new Map<string, SessionModelUsage>();
+          const byProviderMap = new Map<string, SessionModelUsage>();
+          const byAgentMap = new Map<string, CostUsageSummary["totals"]>();
+          const byChannelMap = new Map<string, CostUsageSummary["totals"]>();
+          const dailyAggregateMap = new Map<
+            string,
+            {
+              date: string;
+              tokens: number;
+              cost: number;
+              messages: number;
+              toolCalls: number;
+              errors: number;
+            }
+          >();
+          const latencyTotals = {
+            count: 0,
+            sum: 0,
+            min: Number.POSITIVE_INFINITY,
+            max: 0,
+            p95Max: 0,
+          };
+          const dailyLatencyMap = new Map<
+            string,
+            { date: string; count: number; sum: number; min: number; max: number; p95Max: number }
+          >();
+          const modelDailyMap = new Map<string, SessionDailyModelUsage>();
+          let cacheStatus: UsageCacheStatus | undefined;
+
+          const usageByEntryIndex: Array<SessionCostSummary | null> = Array.from(
+            { length: mergedEntries.length },
+            () => null,
+          );
+
+          // Group every included session (visible + hidden) by agent so the usage-cost
+          // cache is read and parsed at most once per agent. Loading each session
+          // individually re-reads and re-parses the whole cache file, so RSS spikes
+          // in proportion to `limit` on every dashboard connect (issue #100041).
+          const sessionsByAgent = new Map<
+            string,
+            Array<{ entryIndex: number; sessionId: string; sessionFile: string }>
+          >();
+          for (const [entryIndex, merged] of mergedEntries.entries()) {
+            for (const includedSessionId of merged.includedSessionIds ?? [merged.sessionId]) {
+              const includedSessionFile =
+                includedSessionId === merged.sessionId
+                  ? merged.sessionFile
+                  : resolveExistingUsageSessionFile({
+                      sessionId: includedSessionId,
+                      agentId: merged.agentId,
+                    });
+              if (!includedSessionFile) {
+                continue;
+              }
+              const agentSessions = sessionsByAgent.get(merged.agentId) ?? [];
+              agentSessions.push({
+                entryIndex,
+                sessionId: includedSessionId,
+                sessionFile: includedSessionFile,
+              });
+              sessionsByAgent.set(merged.agentId, agentSessions);
+            }
+          }
+
+          const agentLoads = await runUsageAgentTasks(
+            Array.from(sessionsByAgent.entries()).map(([agentId, agentSessions]) => async () => ({
+              agentSessions,
+              loaded: await loadSessionCostSummariesFromCache({
+                sessions: agentSessions,
+                config,
+                agentId,
+                startMs,
+                endMs,
+                includeUntimestamped,
+                dayBucket,
+              }),
+            })),
+          );
+          for (const { agentSessions, loaded } of agentLoads) {
+            cacheStatus = mergeUsageCacheStatus(cacheStatus, loaded.cacheStatus);
+            for (const [index, summary] of loaded.summaries.entries()) {
+              if (!summary) {
+                continue;
+              }
+              const session = expectDefined(agentSessions[index], "agent sessions entry at index");
+              const merged = expectDefined(
+                mergedEntries[session.entryIndex],
+                "merged entries entry at session.entry index",
+              );
+              const usage =
+                usageByEntryIndex[session.entryIndex] ?? createEmptySessionCostSummary();
+              usage.sessionId = merged.sessionId;
+              usage.sessionFile = merged.sessionFile;
+              mergeSessionUsageInto(usage, summary);
+              usageByEntryIndex[session.entryIndex] = usage;
+            }
+          }
+
+          // Track session-level aggregates across every matched session, so profile
+          // stats stay correct when the row list is truncated by `limit`.
+          let longestSessionDurationMs = 0;
+          let activeSessionCount = 0;
+
+          for (const [entryIndex, merged] of mergedEntries.entries()) {
+            const agentId = merged.agentId;
+            // A cold or stale cache intentionally yields null until its background refresh completes.
+            const usage = usageByEntryIndex[entryIndex] ?? null;
+
+            if (usage) {
+              addCostUsageTotals(aggregateTotals, usage);
+              longestSessionDurationMs = Math.max(longestSessionDurationMs, usage.durationMs ?? 0);
+              // Discovery admits transcripts modified after endMs (they can still hold
+              // in-range activity), so count only sessions whose filtered usage does.
+              if (usage.firstActivity !== undefined || (usage.messageCounts?.total ?? 0) > 0) {
+                activeSessionCount += 1;
+              }
+            }
+
+            const channel = sessionDeliveryChannel(merged.storeEntry);
+            const chatType =
+              merged.storeEntry?.chatType ?? sessionDeliveryOrigin(merged.storeEntry)?.chatType;
+
+            if (usage) {
+              if (usage.messageCounts) {
+                aggregateMessages.total += usage.messageCounts.total;
+                aggregateMessages.user += usage.messageCounts.user;
+                aggregateMessages.assistant += usage.messageCounts.assistant;
+                aggregateMessages.toolCalls += usage.messageCounts.toolCalls;
+                aggregateMessages.toolResults += usage.messageCounts.toolResults;
+                aggregateMessages.errors += usage.messageCounts.errors;
+              }
+
+              if (usage.toolUsage) {
+                for (const tool of usage.toolUsage.tools) {
+                  toolAggregateMap.set(
+                    tool.name,
+                    (toolAggregateMap.get(tool.name) ?? 0) + tool.count,
+                  );
+                }
+              }
+
+              if (usage.modelUsage) {
+                for (const entry of usage.modelUsage) {
+                  const modelKey = `${entry.provider ?? "unknown"}::${entry.model ?? "unknown"}`;
+                  const modelExisting =
+                    byModelMap.get(modelKey) ??
+                    ({
+                      provider: entry.provider,
+                      model: entry.model,
+                      count: 0,
+                      totals: createEmptyCostUsageTotals(),
+                    } as SessionModelUsage);
+                  modelExisting.count += entry.count;
+                  addCostUsageTotals(modelExisting.totals, entry.totals);
+                  byModelMap.set(modelKey, modelExisting);
+
+                  const providerKey = entry.provider ?? "unknown";
+                  const providerExisting =
+                    byProviderMap.get(providerKey) ??
+                    ({
+                      provider: entry.provider,
+                      model: undefined,
+                      count: 0,
+                      totals: createEmptyCostUsageTotals(),
+                    } as SessionModelUsage);
+                  providerExisting.count += entry.count;
+                  addCostUsageTotals(providerExisting.totals, entry.totals);
+                  byProviderMap.set(providerKey, providerExisting);
+                }
+              }
+
+              mergeUsageLatency(latencyTotals, usage.latency);
+              mergeUsageDailyLatency(dailyLatencyMap, usage.dailyLatency);
+
+              if (usage.dailyModelUsage) {
+                for (const entry of usage.dailyModelUsage) {
+                  const key = `${entry.date}::${entry.provider ?? "unknown"}::${entry.model ?? "unknown"}`;
+                  const existing =
+                    modelDailyMap.get(key) ??
+                    ({
+                      date: entry.date,
+                      provider: entry.provider,
+                      model: entry.model,
+                      tokens: 0,
+                      cost: 0,
+                      count: 0,
+                    } as SessionDailyModelUsage);
+                  existing.tokens += entry.tokens;
+                  existing.cost += entry.cost;
+                  existing.count += entry.count;
+                  modelDailyMap.set(key, existing);
+                }
+              }
+
+              if (agentId) {
+                const agentTotals = byAgentMap.get(agentId) ?? createEmptyCostUsageTotals();
+                addCostUsageTotals(agentTotals, usage);
+                byAgentMap.set(agentId, agentTotals);
+              }
+
+              if (channel) {
+                const channelTotals = byChannelMap.get(channel) ?? createEmptyCostUsageTotals();
+                addCostUsageTotals(channelTotals, usage);
+                byChannelMap.set(channel, channelTotals);
+              }
+
+              if (usage.dailyBreakdown) {
+                for (const day of usage.dailyBreakdown) {
+                  const daily = dailyAggregateMap.get(day.date) ?? {
+                    date: day.date,
+                    tokens: 0,
+                    cost: 0,
+                    messages: 0,
+                    toolCalls: 0,
+                    errors: 0,
+                  };
+                  daily.tokens += day.tokens;
+                  daily.cost += day.cost;
+                  dailyAggregateMap.set(day.date, daily);
+                }
+              }
+
+              if (usage.dailyMessageCounts) {
+                for (const day of usage.dailyMessageCounts) {
+                  const daily = dailyAggregateMap.get(day.date) ?? {
+                    date: day.date,
+                    tokens: 0,
+                    cost: 0,
+                    messages: 0,
+                    toolCalls: 0,
+                    errors: 0,
+                  };
+                  daily.messages += day.total;
+                  daily.toolCalls += day.toolCalls;
+                  daily.errors += day.errors;
+                  dailyAggregateMap.set(day.date, daily);
+                }
+              }
+            }
+
+            if (entryIndex < limit) {
+              sessions.push({
+                key: merged.key,
+                label: merged.label,
+                sessionId: merged.sessionId,
+                scope: merged.scope ?? "instance",
+                sessionFamilyKey: merged.sessionFamilyKey,
+                currentSessionId: merged.currentSessionId,
+                includedSessionIds: merged.includedSessionIds,
+                historicalInstanceCount: merged.includedSessionIds?.length,
+                updatedAt: merged.updatedAt,
+                agentId,
+                channel,
+                chatType,
+                origin: sessionDeliveryOrigin(merged.storeEntry),
+                modelOverride: merged.storeEntry?.modelOverride,
+                providerOverride: merged.storeEntry?.providerOverride,
+                modelProvider: merged.storeEntry?.modelProvider,
+                model: merged.storeEntry?.model,
+                usage,
+                contextWeight: includeContextWeight
+                  ? (merged.storeEntry?.systemPromptReport ?? null)
+                  : undefined,
+              });
+            }
+          }
+
+          const tail = buildUsageAggregateTail({
+            byChannelMap,
+            latencyTotals,
+            dailyLatencyMap,
+            modelDailyMap,
+            dailyMap: dailyAggregateMap,
+          });
+
+          const aggregates: SessionsUsageAggregates = {
+            sessionCount: activeSessionCount,
+            ...(longestSessionDurationMs > 0 ? { longestSessionDurationMs } : {}),
+            messages: aggregateMessages,
+            tools: {
+              totalCalls: Array.from(toolAggregateMap.values()).reduce(
+                (sum, count) => sum + count,
+                0,
+              ),
+              uniqueTools: toolAggregateMap.size,
+              tools: Array.from(toolAggregateMap.entries())
+                .map(([name, count]) => ({ name, count }))
+                .toSorted((a, b) => b.count - a.count),
+            },
+            byModel: Array.from(byModelMap.values()).toSorted((a, b) => {
+              const costDiff = (b.totals?.totalCost ?? 0) - (a.totals?.totalCost ?? 0);
+              if (costDiff !== 0) {
+                return costDiff;
+              }
+              return (b.totals?.totalTokens ?? 0) - (a.totals?.totalTokens ?? 0);
+            }),
+            byProvider: Array.from(byProviderMap.values()).toSorted((a, b) => {
+              const costDiff = (b.totals?.totalCost ?? 0) - (a.totals?.totalCost ?? 0);
+              if (costDiff !== 0) {
+                return costDiff;
+              }
+              return (b.totals?.totalTokens ?? 0) - (a.totals?.totalTokens ?? 0);
+            }),
+            byAgent: Array.from(byAgentMap.entries())
+              .map(([id, totals]) => ({ agentId: id, totals }))
+              .toSorted((a, b) => (b.totals?.totalCost ?? 0) - (a.totals?.totalCost ?? 0)),
+            ...tail,
+          };
+
+          return {
+            updatedAt: now,
+            startDate: formatDateLabel(startMs, dateInterpretation),
+            endDate: formatDateLabel(endMs, dateInterpretation),
+            sessions,
+            totals: aggregateTotals,
+            aggregates,
+            cacheStatus,
+          };
+        },
+      });
+    } catch (err) {
+      if (err instanceof SessionsUsageInvalidRequestError) {
+        respond(false, undefined, errorShape(ErrorCodes.INVALID_REQUEST, err.message));
+        return;
       }
+      throw err;
     }
-
-    const agentLoads = await runUsageAgentTasks(
-      Array.from(sessionsByAgent.entries()).map(([agentId, agentSessions]) => async () => ({
-        agentSessions,
-        loaded: await loadSessionCostSummariesFromCache({
-          sessions: agentSessions,
-          config,
-          agentId,
-          startMs,
-          endMs,
-          includeUntimestamped,
-          dayBucket,
-        }),
-      })),
-    );
-    for (const { agentSessions, loaded } of agentLoads) {
-      cacheStatus = mergeUsageCacheStatus(cacheStatus, loaded.cacheStatus);
-      for (const [index, summary] of loaded.summaries.entries()) {
-        if (!summary) {
-          continue;
-        }
-        const session = expectDefined(agentSessions[index], "agent sessions entry at index");
-        const merged = expectDefined(
-          mergedEntries[session.entryIndex],
-          "merged entries entry at session.entry index",
-        );
-        const usage = usageByEntryIndex[session.entryIndex] ?? createEmptySessionCostSummary();
-        usage.sessionId = merged.sessionId;
-        usage.sessionFile = merged.sessionFile;
-        mergeSessionUsageInto(usage, summary);
-        usageByEntryIndex[session.entryIndex] = usage;
-      }
-    }
-
-    // Track session-level aggregates across every matched session, so profile
-    // stats stay correct when the row list is truncated by `limit`.
-    let longestSessionDurationMs = 0;
-    let activeSessionCount = 0;
-
-    for (const [entryIndex, merged] of mergedEntries.entries()) {
-      const agentId = merged.agentId;
-      // A cold or stale cache intentionally yields null until its background refresh completes.
-      const usage = usageByEntryIndex[entryIndex] ?? null;
-
-      if (usage) {
-        addCostUsageTotals(aggregateTotals, usage);
-        longestSessionDurationMs = Math.max(longestSessionDurationMs, usage.durationMs ?? 0);
-        // Discovery admits transcripts modified after endMs (they can still hold
-        // in-range activity), so count only sessions whose filtered usage does.
-        if (usage.firstActivity !== undefined || (usage.messageCounts?.total ?? 0) > 0) {
-          activeSessionCount += 1;
-        }
-      }
-
-      const channel = sessionDeliveryChannel(merged.storeEntry);
-      const chatType =
-        merged.storeEntry?.chatType ?? sessionDeliveryOrigin(merged.storeEntry)?.chatType;
-
-      if (usage) {
-        if (usage.messageCounts) {
-          aggregateMessages.total += usage.messageCounts.total;
-          aggregateMessages.user += usage.messageCounts.user;
-          aggregateMessages.assistant += usage.messageCounts.assistant;
-          aggregateMessages.toolCalls += usage.messageCounts.toolCalls;
-          aggregateMessages.toolResults += usage.messageCounts.toolResults;
-          aggregateMessages.errors += usage.messageCounts.errors;
-        }
-
-        if (usage.toolUsage) {
-          for (const tool of usage.toolUsage.tools) {
-            toolAggregateMap.set(tool.name, (toolAggregateMap.get(tool.name) ?? 0) + tool.count);
-          }
-        }
-
-        if (usage.modelUsage) {
-          for (const entry of usage.modelUsage) {
-            const modelKey = `${entry.provider ?? "unknown"}::${entry.model ?? "unknown"}`;
-            const modelExisting =
-              byModelMap.get(modelKey) ??
-              ({
-                provider: entry.provider,
-                model: entry.model,
-                count: 0,
-                totals: createEmptyCostUsageTotals(),
-              } as SessionModelUsage);
-            modelExisting.count += entry.count;
-            addCostUsageTotals(modelExisting.totals, entry.totals);
-            byModelMap.set(modelKey, modelExisting);
-
-            const providerKey = entry.provider ?? "unknown";
-            const providerExisting =
-              byProviderMap.get(providerKey) ??
-              ({
-                provider: entry.provider,
-                model: undefined,
-                count: 0,
-                totals: createEmptyCostUsageTotals(),
-              } as SessionModelUsage);
-            providerExisting.count += entry.count;
-            addCostUsageTotals(providerExisting.totals, entry.totals);
-            byProviderMap.set(providerKey, providerExisting);
-          }
-        }
-
-        mergeUsageLatency(latencyTotals, usage.latency);
-        mergeUsageDailyLatency(dailyLatencyMap, usage.dailyLatency);
-
-        if (usage.dailyModelUsage) {
-          for (const entry of usage.dailyModelUsage) {
-            const key = `${entry.date}::${entry.provider ?? "unknown"}::${entry.model ?? "unknown"}`;
-            const existing =
-              modelDailyMap.get(key) ??
-              ({
-                date: entry.date,
-                provider: entry.provider,
-                model: entry.model,
-                tokens: 0,
-                cost: 0,
-                count: 0,
-              } as SessionDailyModelUsage);
-            existing.tokens += entry.tokens;
-            existing.cost += entry.cost;
-            existing.count += entry.count;
-            modelDailyMap.set(key, existing);
-          }
-        }
-
-        if (agentId) {
-          const agentTotals = byAgentMap.get(agentId) ?? createEmptyCostUsageTotals();
-          addCostUsageTotals(agentTotals, usage);
-          byAgentMap.set(agentId, agentTotals);
-        }
-
-        if (channel) {
-          const channelTotals = byChannelMap.get(channel) ?? createEmptyCostUsageTotals();
-          addCostUsageTotals(channelTotals, usage);
-          byChannelMap.set(channel, channelTotals);
-        }
-
-        if (usage.dailyBreakdown) {
-          for (const day of usage.dailyBreakdown) {
-            const daily = dailyAggregateMap.get(day.date) ?? {
-              date: day.date,
-              tokens: 0,
-              cost: 0,
-              messages: 0,
-              toolCalls: 0,
-              errors: 0,
-            };
-            daily.tokens += day.tokens;
-            daily.cost += day.cost;
-            dailyAggregateMap.set(day.date, daily);
-          }
-        }
-
-        if (usage.dailyMessageCounts) {
-          for (const day of usage.dailyMessageCounts) {
-            const daily = dailyAggregateMap.get(day.date) ?? {
-              date: day.date,
-              tokens: 0,
-              cost: 0,
-              messages: 0,
-              toolCalls: 0,
-              errors: 0,
-            };
-            daily.messages += day.total;
-            daily.toolCalls += day.toolCalls;
-            daily.errors += day.errors;
-            dailyAggregateMap.set(day.date, daily);
-          }
-        }
-      }
-
-      if (entryIndex < limit) {
-        sessions.push({
-          key: merged.key,
-          label: merged.label,
-          sessionId: merged.sessionId,
-          scope: merged.scope ?? "instance",
-          sessionFamilyKey: merged.sessionFamilyKey,
-          currentSessionId: merged.currentSessionId,
-          includedSessionIds: merged.includedSessionIds,
-          historicalInstanceCount: merged.includedSessionIds?.length,
-          updatedAt: merged.updatedAt,
-          agentId,
-          channel,
-          chatType,
-          origin: sessionDeliveryOrigin(merged.storeEntry),
-          modelOverride: merged.storeEntry?.modelOverride,
-          providerOverride: merged.storeEntry?.providerOverride,
-          modelProvider: merged.storeEntry?.modelProvider,
-          model: merged.storeEntry?.model,
-          usage,
-          contextWeight: includeContextWeight
-            ? (merged.storeEntry?.systemPromptReport ?? null)
-            : undefined,
-        });
-      }
-    }
-
-    const tail = buildUsageAggregateTail({
-      byChannelMap,
-      latencyTotals,
-      dailyLatencyMap,
-      modelDailyMap,
-      dailyMap: dailyAggregateMap,
-    });
-
-    const aggregates: SessionsUsageAggregates = {
-      sessionCount: activeSessionCount,
-      ...(longestSessionDurationMs > 0 ? { longestSessionDurationMs } : {}),
-      messages: aggregateMessages,
-      tools: {
-        totalCalls: Array.from(toolAggregateMap.values()).reduce((sum, count) => sum + count, 0),
-        uniqueTools: toolAggregateMap.size,
-        tools: Array.from(toolAggregateMap.entries())
-          .map(([name, count]) => ({ name, count }))
-          .toSorted((a, b) => b.count - a.count),
-      },
-      byModel: Array.from(byModelMap.values()).toSorted((a, b) => {
-        const costDiff = (b.totals?.totalCost ?? 0) - (a.totals?.totalCost ?? 0);
-        if (costDiff !== 0) {
-          return costDiff;
-        }
-        return (b.totals?.totalTokens ?? 0) - (a.totals?.totalTokens ?? 0);
-      }),
-      byProvider: Array.from(byProviderMap.values()).toSorted((a, b) => {
-        const costDiff = (b.totals?.totalCost ?? 0) - (a.totals?.totalCost ?? 0);
-        if (costDiff !== 0) {
-          return costDiff;
-        }
-        return (b.totals?.totalTokens ?? 0) - (a.totals?.totalTokens ?? 0);
-      }),
-      byAgent: Array.from(byAgentMap.entries())
-        .map(([id, totals]) => ({ agentId: id, totals }))
-        .toSorted((a, b) => (b.totals?.totalCost ?? 0) - (a.totals?.totalCost ?? 0)),
-      ...tail,
-    };
-
-    const result: SessionsUsageResult = {
-      updatedAt: now,
-      startDate: formatDateLabel(startMs, dateInterpretation),
-      endDate: formatDateLabel(endMs, dateInterpretation),
-      sessions,
-      totals: aggregateTotals,
-      aggregates,
-      cacheStatus,
-    };
-
     respond(true, result, undefined);
   },
   "sessions.usage.timeseries": async ({ respond, params, context }) => {

--- a/src/infra/session-cost-usage-collection.ts
+++ b/src/infra/session-cost-usage-collection.ts
@@ -146,7 +146,9 @@ function listUsageCountedSqliteTranscriptStats(
     ...(params?.sessionsDir ? { sessionsDir: params.sessionsDir } : {}),
   });
   const files: UsageCostTranscriptFile[] = [];
-  for (const instance of listSessionTranscriptInstances({ agentId, storePath })) {
+  // This scan reads transcript identity/timestamps only; clone:false avoids
+  // cloning every current entry before the history projection and SQL rollups.
+  for (const instance of listSessionTranscriptInstances({ agentId, storePath, clone: false })) {
     const marker = { agentId, sessionId: instance.sessionId, storePath };
     const mtimeMs = instance.updatedAtMs;
     if (params?.minMtimeMs !== undefined && mtimeMs < params.minMtimeMs) {


### PR DESCRIPTION
## What Problem This Solves

Opening the Usage page on team.openclaw.ai pays `usage.status` ~1294ms and `sessions.usage` ~1209ms every time. `usage.status` issued one authenticated HTTP fetch per configured provider on every call with no cache — while `models.authStatus` already had a purpose-built 60s credential-fingerprinted stale-while-revalidate cache for exactly this data. `sessions.usage` re-ran synchronous per-session transcript aggregates (a SUM over every event row per session, no covering index) on every call, with no result cache — unlike `usage.cost`, which already had the 30s TTL + coalescing pattern.

## Why This Change Was Made

Both RPCs re-derived results that are stable for tens of seconds. Reusing the two existing cache disciplines (shared SWR module; the usage.cost wrapper shape) avoids new frameworks and keeps invalidation semantics consistent.

## User Impact

Repeat Usage-page opens drop from ~1.2s per RPC to sub-10ms; provider HTTP fan-out happens at most once per 60s per credential set; the synchronous transcript aggregation no longer runs per open.

## Evidence

- `usage.status` shares the 60s credential-aware SWR cache with `models.authStatus` (single module, no duplication); credential change invalidates (test).
- `sessions.usage`: bounded 256-entry 30s SWR cache keyed on config identity, scope/agent, dates, bucket, limit, grouping, key, and context-weight mode; in-flight coalescing; complete stale results preferred over partial refreshes (documented + tested).
- Clone audit: the usage scan reads sessionId/timestamps only → `listSessionTranscriptInstances(clone:false)`, removing a structuredClone of ~800 entries per call. No schema/index change; a `(session_id, byte-size)` rollup/index is noted as follow-up needing operator approval only if cold scans remain material.
- 223 focused tests; response-shape parity; core tsgo, full lint, both deadcode lanes on Testbox (run https://github.com/openclaw/openclaw/actions/runs/30384451488); format, git diff --check; autoreview clean (three cache findings fixed, one rejected with fan-out proof).
