### PR TITLE
fix(exec): safely cancel pending node approvals

### DIFF
--- a/src/agents/bash-tools.exec-host-node-followup.ts
+++ b/src/agents/bash-tools.exec-host-node-followup.ts
@@ -1,0 +1,81 @@
+import type { InterpreterInlineEvalHit } from "../infra/command-analysis/inline-eval.js";
+import type { ExecSecurity } from "../infra/exec-approvals.js";
+import type { ExecAutoReviewInput } from "../infra/exec-auto-review.js";
+import type { sendExecApprovalFollowupResult } from "./bash-tools.exec-host-shared.js";
+
+type SendExecApprovalFollowupResult = typeof sendExecApprovalFollowupResult;
+
+function execSecurityFloorRank(security: ExecSecurity): number {
+  switch (security) {
+    case "full":
+      return 0;
+    case "allowlist":
+      return 1;
+    case "deny":
+      return 2;
+  }
+  throw new Error("Unsupported exec security floor");
+}
+
+export function nodePolicyBlocksAutoReview(params: {
+  hostSecurity: ExecSecurity;
+  nodeApprovalPolicyKnown: boolean;
+  nodeSecurity?: ExecSecurity;
+  nodeAsk?: "off" | "on-miss" | "always";
+}): boolean {
+  // Remote policy may be stricter; local auto-review cannot bypass that floor.
+  return (
+    !params.nodeApprovalPolicyKnown ||
+    params.nodeAsk === "always" ||
+    (params.nodeSecurity !== undefined &&
+      execSecurityFloorRank(params.nodeSecurity) > execSecurityFloorRank(params.hostSecurity))
+  );
+}
+
+export function resolveNodeAutoReviewReason(params: {
+  inlineEvalHit: InterpreterInlineEvalHit | null;
+  hostSecurity: ExecSecurity;
+  analysisOk: boolean;
+  allowlistSatisfied: boolean;
+  durableApprovalSatisfied: boolean;
+}): ExecAutoReviewInput["reason"] {
+  if (params.inlineEvalHit !== null) {
+    return "strict-inline-eval";
+  }
+  if (
+    params.hostSecurity === "allowlist" &&
+    (!params.analysisOk || !params.allowlistSatisfied) &&
+    !params.durableApprovalSatisfied
+  ) {
+    return "allowlist-miss";
+  }
+  return "approval-required";
+}
+
+export function createNodeApprovalRequestFailureFollowup(params: {
+  send: SendExecApprovalFollowupResult;
+  target: Parameters<SendExecApprovalFollowupResult>[0];
+  nodeId: string;
+  approvalId: string;
+  command: string;
+  signal?: AbortSignal;
+}): () => Promise<void> {
+  const message = `Exec denied (node=${params.nodeId} id=${params.approvalId}, approval-request-failed): ${params.command}`;
+
+  return async () => {
+    if (params.signal?.aborted) {
+      return;
+    }
+    try {
+      await params.send(params.target, message);
+    } catch {
+      if (!params.signal?.aborted) {
+        try {
+          await params.send(params.target, message);
+        } catch {
+          // The delivery owner already records failures; detached work must settle.
+        }
+      }
+    }
+  };
+}

--- a/src/agents/bash-tools.exec-host-node.cancellation.test.ts
+++ b/src/agents/bash-tools.exec-host-node.cancellation.test.ts
@@ -44,6 +44,7 @@ vi.mock("../infra/exec-auto-review.js", () => ({
 vi.mock("./bash-tools.exec-approval-request.js", () => ({
   buildExecApprovalRequesterContext: vi.fn(() => ({})),
   buildExecApprovalTurnSourceContext: vi.fn(() => ({})),
+  isExecApprovalRunAbortedError: vi.fn(() => false),
   registerExecApprovalRequestForHostOrThrow: mocks.registerNodeApproval,
 }));
 

--- a/src/agents/bash-tools.exec-host-node.test.ts
+++ b/src/agents/bash-tools.exec-host-node.test.ts
@@ -4,6 +4,7 @@
  * auto-review, and follow-up execution paths.
  */
 import crypto from "node:crypto";
+import { setImmediate } from "node:timers/promises";
 import { expectDefined } from "@openclaw/normalization-core";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import type { ExecAllowlistEntry } from "../infra/exec-approvals.types.js";
@@ -470,13 +471,13 @@ function buildAllowlistEvalResult(params?: {
 
 function captureProcessUnhandledRejections() {
   const reasons: unknown[] = [];
-  const originalProcessEmit = process.emit;
+  const originalProcessEmit = process.emit.bind(process);
   const processEmit = vi.spyOn(process, "emit").mockImplementation((event, ...args) => {
     if (event === "unhandledRejection") {
       reasons.push(args[0]);
       return true;
     }
-    return Reflect.apply(originalProcessEmit, process, [event, ...args]) as boolean;
+    return originalProcessEmit(event, ...args);
   });
   return { reasons, restore: () => processEmit.mockRestore() };
 }
@@ -687,7 +688,7 @@ describe("executeNodeHostCommand", () => {
       if (scenario.delayed) {
         pendingDecision.reject(runAbortedApprovalError);
       }
-      await new Promise<void>((resolve) => setImmediate(resolve));
+      await setImmediate();
 
       expect(unhandledRejections.reasons).toEqual([]);
       expect(sendExecApprovalFollowupResultMock).not.toHaveBeenCalled();
@@ -737,7 +738,7 @@ describe("executeNodeHostCommand", () => {
           "Exec denied (node=node-1 id=approval-1, approval-request-failed): bun ./script.ts",
         );
       });
-      await new Promise<void>((resolve) => setImmediate(resolve));
+      await setImmediate();
       expect(unhandledRejections.reasons).toEqual([]);
       expect(
         callGatewayToolMock.mock.calls.some(
@@ -783,7 +784,7 @@ describe("executeNodeHostCommand", () => {
       });
 
       expect(result.details?.status).toBe("approval-pending");
-      await new Promise<void>((resolve) => setImmediate(resolve));
+      await setImmediate();
 
       expect(unhandledRejections.reasons).toEqual([]);
       expect(sendExecApprovalFollowupResultMock).toHaveBeenCalledTimes(2);
@@ -835,7 +836,7 @@ describe("executeNodeHostCommand", () => {
       });
 
       expect(result.details?.status).toBe("approval-pending");
-      await new Promise<void>((resolve) => setImmediate(resolve));
+      await setImmediate();
 
       expect(unhandledRejections.reasons).toEqual([]);
       expect(sendExecApprovalFollowupResultMock).toHaveBeenCalledTimes(2);
@@ -886,7 +887,7 @@ describe("executeNodeHostCommand", () => {
       await vi.waitFor(() => {
         expect(sendExecApprovalFollowupResultMock).toHaveBeenCalled();
       });
-      await new Promise<void>((resolve) => setImmediate(resolve));
+      await setImmediate();
 
       expect(unhandledRejections.reasons).toEqual([]);
       expect(sendExecApprovalFollowupResultMock).toHaveBeenCalledOnce();
@@ -929,7 +930,7 @@ describe("executeNodeHostCommand", () => {
     expect(resolveApprovalDecisionOrUndefinedMock).toHaveBeenCalledOnce();
     abortController.abort();
     pendingDecision.resolve("allow-once");
-    await new Promise<void>((resolve) => setImmediate(resolve));
+    await setImmediate();
 
     expect(createExecApprovalDecisionStateMock).not.toHaveBeenCalled();
     expect(sendExecApprovalFollowupResultMock).not.toHaveBeenCalled();
@@ -980,7 +981,7 @@ describe("executeNodeHostCommand", () => {
     });
     abortController.abort();
     policyCheckpoint.resolve(policy);
-    await new Promise<void>((resolve) => setImmediate(resolve));
+    await setImmediate();
 
     expect(sendExecApprovalFollowupResultMock).not.toHaveBeenCalled();
     expect(
@@ -1025,7 +1026,7 @@ describe("executeNodeHostCommand", () => {
       expect(results.every((result) => result.details?.status === "approval-pending")).toBe(true);
       expect(resolveApprovalDecisionOrUndefinedMock).toHaveBeenCalledTimes(32);
       pendingDecision.reject(runAbortedApprovalError);
-      await new Promise<void>((resolve) => setImmediate(resolve));
+      await setImmediate();
 
       expect(unhandledRejections.reasons).toEqual([]);
       expect(sendExecApprovalFollowupResultMock).not.toHaveBeenCalled();
@@ -1177,7 +1178,7 @@ describe("executeNodeHostCommand", () => {
       });
       abortController.abort(new Error("run aborted during node invocation"));
       pendingInvocation.reject(abortController.signal.reason);
-      await new Promise<void>((resolve) => setImmediate(resolve));
+      await setImmediate();
 
       expect(unhandledRejections.reasons).toEqual([]);
       expect(sendExecApprovalFollowupResultMock).not.toHaveBeenCalled();

--- a/src/agents/bash-tools.exec-host-node.test.ts
+++ b/src/agents/bash-tools.exec-host-node.test.ts
@@ -856,6 +856,47 @@ describe("executeNodeHostCommand", () => {
     }
   });
 
+  it("does not report a failed detached approval after its owning run is aborted", async () => {
+    const abortController = new AbortController();
+    resolveApprovalDecisionOrUndefinedMock.mockImplementationOnce(async (params) => {
+      abortController.abort(new Error("run aborted before approval failure delivery"));
+      params?.onFailure();
+      return undefined;
+    });
+    resolveExecHostApprovalContextMock.mockReturnValue({
+      approvals: { allowlist: [], file: { version: 1, agents: {} } },
+      hostSecurity: "full",
+      hostAsk: "always",
+      askFallback: "deny",
+    });
+
+    const result = await executeNodeHostCommand({
+      command: "bun ./script.ts",
+      workdir: "/tmp/work",
+      env: {},
+      security: "full",
+      ask: "off",
+      defaultTimeoutSec: 30,
+      approvalRunningNoticeMs: 0,
+      warnings: [],
+      agentId: "requested-agent",
+      sessionKey: "requested-session",
+      signal: abortController.signal,
+    });
+
+    expect(result.details?.status).toBe("approval-pending");
+    await setImmediate();
+    expect(resolveApprovalDecisionOrUndefinedMock).toHaveBeenCalledOnce();
+    expect(sendExecApprovalFollowupResultMock).not.toHaveBeenCalled();
+    expect(
+      callGatewayToolMock.mock.calls.some(
+        ([method, , params]) =>
+          method === "node.invoke" &&
+          (params as MockNodeInvokeParams | undefined)?.command === "system.run",
+      ),
+    ).toBe(false);
+  });
+
   it("never reports a completed detached node command as denied when delivery fails", async () => {
     const unhandledRejections = captureProcessUnhandledRejections();
 

--- a/src/agents/bash-tools.exec-host-node.test.ts
+++ b/src/agents/bash-tools.exec-host-node.test.ts
@@ -7,6 +7,7 @@ import crypto from "node:crypto";
 import { expectDefined } from "@openclaw/normalization-core";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import type { ExecAllowlistEntry } from "../infra/exec-approvals.types.js";
+import { createDeferred } from "../test-utils/deferred.js";
 import { MAX_SAFE_TIMEOUT_DELAY_MS } from "../utils/timer-delay.js";
 
 type StrictInlineEvalBoundary =
@@ -182,8 +183,15 @@ const resolveExecHostApprovalContextMock = vi.hoisted(() =>
   })),
 );
 const createAndRegisterDefaultExecApprovalRequestMock = vi.hoisted(() => vi.fn());
+const runAbortedApprovalError = vi.hoisted(() => new Error("approval owning run aborted"));
 const resolveApprovalDecisionOrUndefinedMock = vi.hoisted(() =>
-  vi.fn(async (): Promise<string | null | undefined> => "allow-once"),
+  vi.fn(
+    async (_params?: {
+      approvalId: string;
+      preResolvedDecision: string | null | undefined;
+      onFailure: () => void;
+    }): Promise<string | null | undefined> => "allow-once",
+  ),
 );
 const createExecApprovalDecisionStateMock = vi.hoisted(() =>
   vi.fn(
@@ -258,6 +266,7 @@ vi.mock("../infra/system-run-approval-context.js", () => ({
 vi.mock("./bash-tools.exec-approval-request.js", () => ({
   buildExecApprovalRequesterContext: vi.fn(() => ({})),
   buildExecApprovalTurnSourceContext: vi.fn(() => ({})),
+  isExecApprovalRunAbortedError: (error: unknown) => error === runAbortedApprovalError,
   registerExecApprovalRequestForHostOrThrow: registerExecApprovalRequestForHostOrThrowMock,
 }));
 
@@ -459,6 +468,19 @@ function buildAllowlistEvalResult(params?: {
   };
 }
 
+function captureProcessUnhandledRejections() {
+  const reasons: unknown[] = [];
+  const originalProcessEmit = process.emit;
+  const processEmit = vi.spyOn(process, "emit").mockImplementation((event, ...args) => {
+    if (event === "unhandledRejection") {
+      reasons.push(args[0]);
+      return true;
+    }
+    return Reflect.apply(originalProcessEmit, process, [event, ...args]) as boolean;
+  });
+  return { reasons, restore: () => processEmit.mockRestore() };
+}
+
 describe("executeNodeHostCommand", () => {
   beforeAll(async () => {
     ({ executeNodeHostCommand } = await import("./bash-tools.exec-host-node.js"));
@@ -627,6 +649,398 @@ describe("executeNodeHostCommand", () => {
     expect(registerExecApprovalRequestForHostOrThrowMock).not.toHaveBeenCalled();
   });
 
+  it.each([
+    { name: "an already-rejected approval", delayed: false },
+    { name: "an approval cancelled after the pending result", delayed: true },
+  ])("drops detached node execution without an unhandled rejection for $name", async (scenario) => {
+    const unhandledRejections = captureProcessUnhandledRejections();
+
+    try {
+      const pendingDecision = createDeferred<string | null | undefined>();
+      if (scenario.delayed) {
+        resolveApprovalDecisionOrUndefinedMock.mockReturnValueOnce(pendingDecision.promise);
+      } else {
+        resolveApprovalDecisionOrUndefinedMock.mockRejectedValueOnce(runAbortedApprovalError);
+      }
+      resolveExecHostApprovalContextMock.mockReturnValue({
+        approvals: { allowlist: [], file: { version: 1, agents: {} } },
+        hostSecurity: "full",
+        hostAsk: "always",
+        askFallback: "deny",
+      });
+
+      const result = await executeNodeHostCommand({
+        command: "bun ./script.ts",
+        workdir: "/tmp/work",
+        env: {},
+        security: "full",
+        ask: "off",
+        defaultTimeoutSec: 30,
+        approvalRunningNoticeMs: 0,
+        warnings: [],
+        agentId: "requested-agent",
+        sessionKey: "requested-session",
+      });
+
+      expect(result.details?.status).toBe("approval-pending");
+      expect(resolveApprovalDecisionOrUndefinedMock).toHaveBeenCalledOnce();
+      if (scenario.delayed) {
+        pendingDecision.reject(runAbortedApprovalError);
+      }
+      await new Promise<void>((resolve) => setImmediate(resolve));
+
+      expect(unhandledRejections.reasons).toEqual([]);
+      expect(sendExecApprovalFollowupResultMock).not.toHaveBeenCalled();
+      expect(
+        callGatewayToolMock.mock.calls.some(
+          ([method, , params]) =>
+            method === "node.invoke" &&
+            (params as MockNodeInvokeParams | undefined)?.command === "system.run",
+        ),
+      ).toBe(false);
+    } finally {
+      unhandledRejections.restore();
+    }
+  });
+
+  it("reports unexpected detached node approval failures without an unhandled rejection", async () => {
+    const unhandledRejections = captureProcessUnhandledRejections();
+
+    try {
+      resolveApprovalDecisionOrUndefinedMock.mockRejectedValueOnce(
+        new Error("approval wait unavailable"),
+      );
+      resolveExecHostApprovalContextMock.mockReturnValue({
+        approvals: { allowlist: [], file: { version: 1, agents: {} } },
+        hostSecurity: "full",
+        hostAsk: "always",
+        askFallback: "deny",
+      });
+
+      const result = await executeNodeHostCommand({
+        command: "bun ./script.ts",
+        workdir: "/tmp/work",
+        env: {},
+        security: "full",
+        ask: "off",
+        defaultTimeoutSec: 30,
+        approvalRunningNoticeMs: 0,
+        warnings: [],
+        agentId: "requested-agent",
+        sessionKey: "requested-session",
+      });
+
+      expect(result.details?.status).toBe("approval-pending");
+      await vi.waitFor(() => {
+        expect(sendExecApprovalFollowupResultMock).toHaveBeenCalledWith(
+          expect.objectContaining({ approvalId: "approval-1" }),
+          "Exec denied (node=node-1 id=approval-1, approval-request-failed): bun ./script.ts",
+        );
+      });
+      await new Promise<void>((resolve) => setImmediate(resolve));
+      expect(unhandledRejections.reasons).toEqual([]);
+      expect(
+        callGatewayToolMock.mock.calls.some(
+          ([method, , params]) =>
+            method === "node.invoke" &&
+            (params as MockNodeInvokeParams | undefined)?.command === "system.run",
+        ),
+      ).toBe(false);
+    } finally {
+      unhandledRejections.restore();
+    }
+  });
+
+  it("contains rejected detached node failure follow-ups without an unhandled rejection", async () => {
+    const unhandledRejections = captureProcessUnhandledRejections();
+
+    try {
+      resolveApprovalDecisionOrUndefinedMock.mockRejectedValueOnce(
+        new Error("approval wait unavailable"),
+      );
+      sendExecApprovalFollowupResultMock.mockRejectedValueOnce(
+        new Error("approval follow-up unavailable"),
+      );
+      sendExecApprovalFollowupResultMock.mockResolvedValueOnce(undefined);
+      resolveExecHostApprovalContextMock.mockReturnValue({
+        approvals: { allowlist: [], file: { version: 1, agents: {} } },
+        hostSecurity: "full",
+        hostAsk: "always",
+        askFallback: "deny",
+      });
+
+      const result = await executeNodeHostCommand({
+        command: "bun ./script.ts",
+        workdir: "/tmp/work",
+        env: {},
+        security: "full",
+        ask: "off",
+        defaultTimeoutSec: 30,
+        approvalRunningNoticeMs: 0,
+        warnings: [],
+        agentId: "requested-agent",
+        sessionKey: "requested-session",
+      });
+
+      expect(result.details?.status).toBe("approval-pending");
+      await new Promise<void>((resolve) => setImmediate(resolve));
+
+      expect(unhandledRejections.reasons).toEqual([]);
+      expect(sendExecApprovalFollowupResultMock).toHaveBeenCalledTimes(2);
+      expect(sendExecApprovalFollowupResultMock).toHaveBeenCalledWith(
+        expect.objectContaining({ approvalId: "approval-1" }),
+        "Exec denied (node=node-1 id=approval-1, approval-request-failed): bun ./script.ts",
+      );
+      expect(
+        callGatewayToolMock.mock.calls.some(
+          ([method, , params]) =>
+            method === "node.invoke" &&
+            (params as MockNodeInvokeParams | undefined)?.command === "system.run",
+        ),
+      ).toBe(false);
+    } finally {
+      unhandledRejections.restore();
+    }
+  });
+
+  it("contains rejected failure notices from the shared approval failure callback", async () => {
+    const unhandledRejections = captureProcessUnhandledRejections();
+
+    try {
+      resolveApprovalDecisionOrUndefinedMock.mockImplementationOnce(async (params) => {
+        params?.onFailure();
+        return undefined;
+      });
+      sendExecApprovalFollowupResultMock
+        .mockRejectedValueOnce(new Error("approval follow-up unavailable"))
+        .mockResolvedValueOnce(undefined);
+      resolveExecHostApprovalContextMock.mockReturnValue({
+        approvals: { allowlist: [], file: { version: 1, agents: {} } },
+        hostSecurity: "full",
+        hostAsk: "always",
+        askFallback: "deny",
+      });
+
+      const result = await executeNodeHostCommand({
+        command: "bun ./script.ts",
+        workdir: "/tmp/work",
+        env: {},
+        security: "full",
+        ask: "off",
+        defaultTimeoutSec: 30,
+        approvalRunningNoticeMs: 0,
+        warnings: [],
+        agentId: "requested-agent",
+        sessionKey: "requested-session",
+      });
+
+      expect(result.details?.status).toBe("approval-pending");
+      await new Promise<void>((resolve) => setImmediate(resolve));
+
+      expect(unhandledRejections.reasons).toEqual([]);
+      expect(sendExecApprovalFollowupResultMock).toHaveBeenCalledTimes(2);
+      expect(sendExecApprovalFollowupResultMock).toHaveBeenCalledWith(
+        expect.objectContaining({ approvalId: "approval-1" }),
+        "Exec denied (node=node-1 id=approval-1, approval-request-failed): bun ./script.ts",
+      );
+      expect(
+        callGatewayToolMock.mock.calls.some(
+          ([method, , params]) =>
+            method === "node.invoke" &&
+            (params as MockNodeInvokeParams | undefined)?.command === "system.run",
+        ),
+      ).toBe(false);
+    } finally {
+      unhandledRejections.restore();
+    }
+  });
+
+  it("never reports a completed detached node command as denied when delivery fails", async () => {
+    const unhandledRejections = captureProcessUnhandledRejections();
+
+    try {
+      sendExecApprovalFollowupResultMock.mockRejectedValueOnce(
+        new Error("completion follow-up unavailable"),
+      );
+      resolveExecHostApprovalContextMock.mockReturnValue({
+        approvals: { allowlist: [], file: { version: 1, agents: {} } },
+        hostSecurity: "full",
+        hostAsk: "always",
+        askFallback: "deny",
+      });
+
+      const result = await executeNodeHostCommand({
+        command: "bun ./script.ts",
+        workdir: "/tmp/work",
+        env: {},
+        security: "full",
+        ask: "off",
+        defaultTimeoutSec: 30,
+        approvalRunningNoticeMs: 0,
+        warnings: [],
+        agentId: "requested-agent",
+        sessionKey: "requested-session",
+      });
+
+      expect(result.details?.status).toBe("approval-pending");
+      await vi.waitFor(() => {
+        expect(sendExecApprovalFollowupResultMock).toHaveBeenCalled();
+      });
+      await new Promise<void>((resolve) => setImmediate(resolve));
+
+      expect(unhandledRejections.reasons).toEqual([]);
+      expect(sendExecApprovalFollowupResultMock).toHaveBeenCalledOnce();
+      expect(sendExecApprovalFollowupResultMock).toHaveBeenCalledWith(
+        expect.objectContaining({ approvalId: "approval-1" }),
+        "Exec finished (node=node-1 id=approval-1, code 0)\nok",
+      );
+      expect(requireGatewayCommand("system.run")).toBeDefined();
+    } finally {
+      unhandledRejections.restore();
+    }
+  });
+
+  it("drops a detached node approval when cancellation wins before consumption", async () => {
+    const pendingDecision = createDeferred<string | null | undefined>();
+    const abortController = new AbortController();
+    resolveApprovalDecisionOrUndefinedMock.mockReturnValueOnce(pendingDecision.promise);
+    resolveExecHostApprovalContextMock.mockReturnValue({
+      approvals: { allowlist: [], file: { version: 1, agents: {} } },
+      hostSecurity: "full",
+      hostAsk: "always",
+      askFallback: "deny",
+    });
+
+    const result = await executeNodeHostCommand({
+      command: "bun ./script.ts",
+      workdir: "/tmp/work",
+      env: {},
+      security: "full",
+      ask: "off",
+      defaultTimeoutSec: 30,
+      approvalRunningNoticeMs: 0,
+      warnings: [],
+      agentId: "requested-agent",
+      sessionKey: "requested-session",
+      signal: abortController.signal,
+    });
+
+    expect(result.details?.status).toBe("approval-pending");
+    expect(resolveApprovalDecisionOrUndefinedMock).toHaveBeenCalledOnce();
+    abortController.abort();
+    pendingDecision.resolve("allow-once");
+    await new Promise<void>((resolve) => setImmediate(resolve));
+
+    expect(createExecApprovalDecisionStateMock).not.toHaveBeenCalled();
+    expect(sendExecApprovalFollowupResultMock).not.toHaveBeenCalled();
+    expect(
+      callGatewayToolMock.mock.calls.some(
+        ([method, , params]) =>
+          method === "node.invoke" &&
+          (params as MockNodeInvokeParams | undefined)?.command === "system.run",
+      ),
+    ).toBe(false);
+  });
+
+  it("drops a detached node approval cancelled during final policy revalidation", async () => {
+    const abortController = new AbortController();
+    const policy = {
+      approvals: { allowlist: [], file: { version: 1, agents: {} } },
+      hostSecurity: "full" as const,
+      hostAsk: "always" as const,
+      askFallback: "deny" as const,
+    };
+    const policyCheckpoint = createDeferred<typeof policy>();
+    resolveExecHostApprovalContextMock
+      .mockReturnValueOnce(policy)
+      .mockImplementationOnce(
+        () =>
+          policyCheckpoint.promise as unknown as ReturnType<
+            typeof resolveExecHostApprovalContextMock
+          >,
+      );
+
+    const result = await executeNodeHostCommand({
+      command: "bun ./script.ts",
+      workdir: "/tmp/work",
+      env: {},
+      security: "full",
+      ask: "off",
+      defaultTimeoutSec: 30,
+      approvalRunningNoticeMs: 0,
+      warnings: [],
+      agentId: "requested-agent",
+      sessionKey: "requested-session",
+      signal: abortController.signal,
+    });
+
+    expect(result.details?.status).toBe("approval-pending");
+    await vi.waitFor(() => {
+      expect(resolveExecHostApprovalContextMock).toHaveBeenCalledTimes(2);
+    });
+    abortController.abort();
+    policyCheckpoint.resolve(policy);
+    await new Promise<void>((resolve) => setImmediate(resolve));
+
+    expect(sendExecApprovalFollowupResultMock).not.toHaveBeenCalled();
+    expect(
+      callGatewayToolMock.mock.calls.some(
+        ([method, , params]) =>
+          method === "node.invoke" &&
+          (params as MockNodeInvokeParams | undefined)?.command === "system.run",
+      ),
+    ).toBe(false);
+  });
+
+  it("disposes 32 concurrent detached node approval cancellations without rejections", async () => {
+    const unhandledRejections = captureProcessUnhandledRejections();
+
+    try {
+      const pendingDecision = createDeferred<string | null | undefined>();
+      resolveApprovalDecisionOrUndefinedMock.mockReturnValue(pendingDecision.promise);
+      resolveExecHostApprovalContextMock.mockReturnValue({
+        approvals: { allowlist: [], file: { version: 1, agents: {} } },
+        hostSecurity: "full",
+        hostAsk: "always",
+        askFallback: "deny",
+      });
+
+      const results = await Promise.all(
+        Array.from({ length: 32 }, () =>
+          executeNodeHostCommand({
+            command: "bun ./script.ts",
+            workdir: "/tmp/work",
+            env: {},
+            security: "full",
+            ask: "off",
+            defaultTimeoutSec: 30,
+            approvalRunningNoticeMs: 0,
+            warnings: [],
+            agentId: "requested-agent",
+            sessionKey: "requested-session",
+          }),
+        ),
+      );
+
+      expect(results.every((result) => result.details?.status === "approval-pending")).toBe(true);
+      expect(resolveApprovalDecisionOrUndefinedMock).toHaveBeenCalledTimes(32);
+      pendingDecision.reject(runAbortedApprovalError);
+      await new Promise<void>((resolve) => setImmediate(resolve));
+
+      expect(unhandledRejections.reasons).toEqual([]);
+      expect(sendExecApprovalFollowupResultMock).not.toHaveBeenCalled();
+      expect(
+        callGatewayToolMock.mock.calls.some(
+          ([method, , params]) =>
+            method === "node.invoke" &&
+            (params as MockNodeInvokeParams | undefined)?.command === "system.run",
+        ),
+      ).toBe(false);
+    } finally {
+      unhandledRejections.restore();
+    }
+  });
+
   it("forwards prepared systemRunPlan on async node invoke after approval", async () => {
     resolveExecHostApprovalContextMock.mockReturnValue({
       approvals: { allowlist: [], file: { version: 1, agents: {} } },
@@ -677,6 +1091,99 @@ describe("executeNodeHostCommand", () => {
     expect(runParams.turnSourceAccountId).toBe("work");
     expect(runParams.turnSourceThreadId).toBe("42");
     expect(resolveExecHostApprovalContextMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("forwards cancellation without removing detached node approval scopes", async () => {
+    const abortController = new AbortController();
+    resolveExecHostApprovalContextMock.mockReturnValue({
+      approvals: { allowlist: [], file: { version: 1, agents: {} } },
+      hostSecurity: "full",
+      hostAsk: "always",
+      askFallback: "deny",
+    });
+
+    const result = await executeNodeHostCommand({
+      command: "bun ./script.ts",
+      workdir: "/tmp/work",
+      env: {},
+      security: "full",
+      ask: "off",
+      defaultTimeoutSec: 30,
+      approvalRunningNoticeMs: 0,
+      warnings: [],
+      agentId: "requested-agent",
+      sessionKey: "requested-session",
+      signal: abortController.signal,
+    });
+
+    expect(result.details?.status).toBe("approval-pending");
+    await vi.waitFor(() => {
+      expect(requireGatewayCommand("system.run").callOptions).toEqual({
+        scopes: ["operator.write", "operator.approvals"],
+        signal: abortController.signal,
+      });
+    });
+  });
+
+  it("silently drops a detached node invocation cancelled during gateway dispatch", async () => {
+    const unhandledRejections = captureProcessUnhandledRejections();
+
+    try {
+      const abortController = new AbortController();
+      const pendingInvocation = createDeferred<{
+        payload: { success: boolean; stdout: string; exitCode: number };
+      }>();
+      resolveExecHostApprovalContextMock.mockReturnValue({
+        approvals: { allowlist: [], file: { version: 1, agents: {} } },
+        hostSecurity: "full",
+        hostAsk: "always",
+        askFallback: "deny",
+      });
+      callGatewayToolMock.mockImplementation(
+        async (method: string, _options: unknown, params: MockNodeInvokeParams | undefined) => {
+          if (method === "exec.approvals.node.get") {
+            return { file: { version: 1, agents: {} } };
+          }
+          if (method === "node.invoke" && params?.command === "system.run.prepare") {
+            return { payload: { plan: preparedPlan } };
+          }
+          if (method === "node.invoke" && params?.command === "system.run") {
+            return pendingInvocation.promise;
+          }
+          throw new Error(`unexpected gateway method: ${method}`);
+        },
+      );
+
+      const result = await executeNodeHostCommand({
+        command: "bun ./script.ts",
+        workdir: "/tmp/work",
+        env: {},
+        security: "full",
+        ask: "off",
+        defaultTimeoutSec: 30,
+        approvalRunningNoticeMs: 0,
+        warnings: [],
+        agentId: "requested-agent",
+        sessionKey: "requested-session",
+        signal: abortController.signal,
+      });
+
+      expect(result.details?.status).toBe("approval-pending");
+      await vi.waitFor(() => {
+        expect(requireGatewayCommand("system.run").callOptions).toEqual({
+          scopes: ["operator.write", "operator.approvals"],
+          signal: abortController.signal,
+        });
+      });
+      abortController.abort(new Error("run aborted during node invocation"));
+      pendingInvocation.reject(abortController.signal.reason);
+      await new Promise<void>((resolve) => setImmediate(resolve));
+
+      expect(unhandledRejections.reasons).toEqual([]);
+      expect(sendExecApprovalFollowupResultMock).not.toHaveBeenCalled();
+    } finally {
+      unhandledRejections.restore();
+    }
   });
 
   it("does not dispatch an async human approval after gateway policy revocation", async () => {

--- a/src/agents/bash-tools.exec-host-node.ts
+++ b/src/agents/bash-tools.exec-host-node.ts
@@ -5,7 +5,6 @@
  */
 import { randomUUID } from "node:crypto";
 import { APPROVALS_SCOPE, WRITE_SCOPE } from "../gateway/operator-scopes.js";
-import type { InterpreterInlineEvalHit } from "../infra/command-analysis/inline-eval.js";
 import {
   type ExecAsk,
   type ExecSecurity,
@@ -17,7 +16,6 @@ import {
 import {
   defaultExecAutoReviewer,
   resolveExecAutoReviewDecision,
-  type ExecAutoReviewInput,
 } from "../infra/exec-auto-review.js";
 import { tail } from "./bash-process-registry.js";
 import {
@@ -26,6 +24,11 @@ import {
   isExecApprovalRunAbortedError,
   registerExecApprovalRequestForHostOrThrow,
 } from "./bash-tools.exec-approval-request.js";
+import {
+  createNodeApprovalRequestFailureFollowup,
+  nodePolicyBlocksAutoReview,
+  resolveNodeAutoReviewReason,
+} from "./bash-tools.exec-host-node-followup.js";
 import {
   analyzeNodeApprovalRequirement,
   buildNodeSystemRunInvoke,
@@ -102,53 +105,6 @@ async function assertCurrentNodeGatewayPolicyAllowsDispatch(params: {
   if (!params.currentPolicyAllows?.(current)) {
     throw new Error("exec denied: host=node policy changed before dispatch");
   }
-}
-
-function resolveNodeAutoReviewReason(params: {
-  inlineEvalHit: InterpreterInlineEvalHit | null;
-  hostSecurity: ExecSecurity;
-  analysisOk: boolean;
-  allowlistSatisfied: boolean;
-  durableApprovalSatisfied: boolean;
-}): ExecAutoReviewInput["reason"] {
-  if (params.inlineEvalHit !== null) {
-    return "strict-inline-eval";
-  }
-  if (
-    params.hostSecurity === "allowlist" &&
-    (!params.analysisOk || !params.allowlistSatisfied) &&
-    !params.durableApprovalSatisfied
-  ) {
-    return "allowlist-miss";
-  }
-  return "approval-required";
-}
-
-function execSecurityFloorRank(security: ExecSecurity): number {
-  switch (security) {
-    case "full":
-      return 0;
-    case "allowlist":
-      return 1;
-    case "deny":
-      return 2;
-  }
-  throw new Error("Unsupported exec security floor");
-}
-
-function nodePolicyBlocksAutoReview(params: {
-  hostSecurity: ExecSecurity;
-  nodeApprovalPolicyKnown: boolean;
-  nodeSecurity?: ExecSecurity;
-  nodeAsk?: "off" | "on-miss" | "always";
-}): boolean {
-  // Remote node policy can be stricter than local host policy; do not auto-approve across that gap.
-  return (
-    !params.nodeApprovalPolicyKnown ||
-    params.nodeAsk === "always" ||
-    (params.nodeSecurity !== undefined &&
-      execSecurityFloorRank(params.nodeSecurity) > execSecurityFloorRank(params.hostSecurity))
-  );
 }
 
 /**
@@ -528,23 +484,14 @@ export async function executeNodeHostCommand(
           turnSourceAccountId: params.turnSourceAccountId,
           turnSourceThreadId: params.turnSourceThreadId,
         });
-        const sendApprovalRequestFailedFollowup = (): Promise<void> =>
-          Promise.resolve(
-            execHostShared.sendExecApprovalFollowupResult(
-              followupTarget,
-              `Exec denied (node=${target.nodeId} id=${approvalId}, approval-request-failed): ${params.command}`,
-            ),
-          ).catch(() => {
-            if (params.signal?.aborted) {
-              return;
-            }
-            return Promise.resolve(
-              execHostShared.sendExecApprovalFollowupResult(
-                followupTarget,
-                `Exec denied (node=${target.nodeId} id=${approvalId}, approval-request-failed): ${params.command}`,
-              ),
-            ).catch(() => undefined);
-          });
+        const sendApprovalRequestFailedFollowup = createNodeApprovalRequestFailureFollowup({
+          send: execHostShared.sendExecApprovalFollowupResult,
+          target: followupTarget,
+          nodeId: target.nodeId,
+          approvalId,
+          command: params.command,
+          signal: params.signal,
+        });
         let nodeInvocationStarted = false;
         let nodeInvocationCompleted = false;
 
@@ -689,7 +636,7 @@ export async function executeNodeHostCommand(
               `Exec denied (node=${target.nodeId} id=${approvalId}, invoke-failed): ${params.command}`,
             );
           }
-        })().catch((error: unknown) => {
+        })().catch(async (error: unknown): Promise<void> => {
           // Once dispatch starts, a delivery failure cannot mean execution was denied.
           if (
             nodeInvocationStarted ||
@@ -698,7 +645,7 @@ export async function executeNodeHostCommand(
           ) {
             return;
           }
-          return sendApprovalRequestFailedFollowup();
+          await sendApprovalRequestFailedFollowup();
         });
 
         return execHostShared.buildExecApprovalPendingToolResult({

--- a/src/agents/bash-tools.exec-host-node.ts
+++ b/src/agents/bash-tools.exec-host-node.ts
@@ -23,6 +23,7 @@ import { tail } from "./bash-process-registry.js";
 import {
   buildExecApprovalRequesterContext,
   buildExecApprovalTurnSourceContext,
+  isExecApprovalRunAbortedError,
   registerExecApprovalRequestForHostOrThrow,
 } from "./bash-tools.exec-approval-request.js";
 import {
@@ -527,18 +528,43 @@ export async function executeNodeHostCommand(
           turnSourceAccountId: params.turnSourceAccountId,
           turnSourceThreadId: params.turnSourceThreadId,
         });
-
-        void (async () => {
-          const decision = await execHostShared.resolveApprovalDecisionOrUndefined({
-            approvalId,
-            preResolvedDecision,
-            onFailure: () =>
-              void execHostShared.sendExecApprovalFollowupResult(
+        const sendApprovalRequestFailedFollowup = (): Promise<void> =>
+          Promise.resolve(
+            execHostShared.sendExecApprovalFollowupResult(
+              followupTarget,
+              `Exec denied (node=${target.nodeId} id=${approvalId}, approval-request-failed): ${params.command}`,
+            ),
+          ).catch(() => {
+            if (params.signal?.aborted) {
+              return;
+            }
+            return Promise.resolve(
+              execHostShared.sendExecApprovalFollowupResult(
                 followupTarget,
                 `Exec denied (node=${target.nodeId} id=${approvalId}, approval-request-failed): ${params.command}`,
               ),
+            ).catch(() => undefined);
           });
-          if (decision === undefined) {
+        let nodeInvocationStarted = false;
+        let nodeInvocationCompleted = false;
+
+        void (async () => {
+          let decision: string | null | undefined;
+          try {
+            decision = await execHostShared.resolveApprovalDecisionOrUndefined({
+              approvalId,
+              preResolvedDecision,
+              onFailure: () => void sendApprovalRequestFailedFollowup(),
+            });
+          } catch (error) {
+            // Detached run cancellation has no awaiting tool caller to catch it.
+            if (isExecApprovalRunAbortedError(error)) {
+              return;
+            }
+            await sendApprovalRequestFailedFollowup();
+            return;
+          }
+          if (decision === undefined || params.signal?.aborted) {
             return;
           }
 
@@ -598,7 +624,11 @@ export async function executeNodeHostCommand(
               authority: approvalSource ? "ask-fallback" : "human-approval",
               fallbackPolicy: currentFallback ?? undefined,
             });
+            if (params.signal?.aborted) {
+              return;
+            }
             // Approved follow-up invocations need approval scopes because they mutate remote node state.
+            nodeInvocationStarted = true;
             const raw = await callGatewayTool(
               "node.invoke",
               { timeoutMs: target.invokeTimeoutMs },
@@ -625,8 +655,12 @@ export async function executeNodeHostCommand(
                 notifyOnExit: params.notifyOnExit,
                 systemRunPlan: prepared.plan,
               }),
-              { scopes: APPROVED_NODE_INVOKE_SCOPES },
+              {
+                scopes: APPROVED_NODE_INVOKE_SCOPES,
+                ...(params.signal ? { signal: params.signal } : {}),
+              },
             );
+            nodeInvocationCompleted = true;
             const payload =
               raw?.payload && typeof raw.payload === "object"
                 ? (raw.payload as {
@@ -647,12 +681,25 @@ export async function executeNodeHostCommand(
               : `Exec finished (node=${target.nodeId} id=${approvalId}, ${exitLabel})`;
             await execHostShared.sendExecApprovalFollowupResult(followupTarget, summary);
           } catch {
+            if (params.signal?.aborted || nodeInvocationCompleted) {
+              return;
+            }
             await execHostShared.sendExecApprovalFollowupResult(
               followupTarget,
               `Exec denied (node=${target.nodeId} id=${approvalId}, invoke-failed): ${params.command}`,
             );
           }
-        })();
+        })().catch((error: unknown) => {
+          // Once dispatch starts, a delivery failure cannot mean execution was denied.
+          if (
+            nodeInvocationStarted ||
+            params.signal?.aborted ||
+            isExecApprovalRunAbortedError(error)
+          ) {
+            return;
+          }
+          return sendApprovalRequestFailedFollowup();
+        });
 
         return execHostShared.buildExecApprovalPendingToolResult({
           host: "node",


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users cancelling a node-hosted command while approval was pending could leave an unhandled background rejection, start the remote command after cancellation, emit a denial after the run was already cancelled, or report a completed command as denied when notification delivery failed.

## Why This Change Was Made

Refactor node-specific approval reasoning and bounded follow-up delivery into the existing node owner's small internal helper. Classify the canonical run-abort error; check cancellation before approval consumption, before failure notices, after final policy, and during gateway dispatch; pass the existing signal without changing operator approval scopes; observe both detached task and callback failures; retry a failed approval notice at most once; and never report a started or completed node command as approval-denied. The primary node owner remains below the enforced 700-line threshold. No approval policy, run identity, gateway protocol, configuration, workflow, or permissions are changed.

## User Impact

Cancelled node commands stop without starting remote side effects, emitting stale messages, or causing process-level unhandled rejections. Successful commands remain successful even if follow-up delivery fails; genuine approval-request failures keep their existing truthful notices.

## Evidence

- Fail-first proof on main `430de2299c484116d14693af70cff64643f01619`: immediate and delayed unhandled rejections; real remote execution during final-policy cancellation; independently detached failure-callback rejection; spurious notices after cancellation; and false denial after successful execution.
- `node scripts/run-vitest.mjs src/agents/bash-tools.exec-host-node.test.ts src/agents/bash-tools.exec-host-node.cancellation.test.ts src/agents/bash-tools.exec-host-node-phases.cancellation.test.ts src/agents/bash-tools.exec-host-shared.test.ts src/agents/bash-tools.exec-approval-request.test.ts`: **5 files, 127 tests passed**.
- Existing detached gateway cancellation sibling regressions: **2 tests passed**.
- Stress: **32 concurrent pending approval cancellations**, zero dispatches, zero unhandled rejections.
- `node scripts/run-oxlint.mjs --tsconfig tsconfig.json src/agents/bash-tools.exec-host-node.ts src/agents/bash-tools.exec-host-node-followup.ts src/agents/bash-tools.exec-host-node.test.ts src/agents/bash-tools.exec-host-node.cancellation.test.ts`: **all four files pass exact type-aware CI lint**.
- Effective module sizes: node owner **683/700**, node-specific helper **73/700**; no lint exemptions.
- Fresh final full-change independent autoreview: **clean; patch is correct**.
- Targeted `oxfmt --check` and `git diff --check`: passed.
