### PR TITLE
perf(ui): debounce event-driven session list refreshes and right-size child paging

### DIFF
--- a/ui/src/lib/sessions/child-session-data.test.ts
+++ b/ui/src/lib/sessions/child-session-data.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it, vi } from "vitest";
+import type { GatewaySessionRow, SessionsListResult } from "../../api/types.ts";
+import { fetchChildSessionRows } from "./child-session-data.ts";
+import type { SessionCapability } from "./index.ts";
+
+const parentKey = "agent:main:parent";
+
+function childRow(index: number): GatewaySessionRow {
+  return {
+    key: `agent:worker:child-${index}`,
+    spawnedBy: parentKey,
+    kind: "direct",
+    updatedAt: index,
+  };
+}
+
+function listResult(
+  sessions: GatewaySessionRow[],
+  totalCount: number,
+  nextOffset: number | null,
+): SessionsListResult {
+  return {
+    ts: 1,
+    path: "",
+    count: sessions.length,
+    totalCount,
+    hasMore: nextOffset !== null,
+    nextOffset,
+    defaults: { modelProvider: null, model: null, contextTokens: null },
+    sessions,
+  };
+}
+
+describe("fetchChildSessionRows", () => {
+  it("loads a default 50-child Swarm roster in one request", async () => {
+    const children = Array.from({ length: 50 }, (_, index) => childRow(index));
+    const list = vi.fn().mockResolvedValue(listResult(children, children.length, null));
+
+    const rows = await fetchChildSessionRows({
+      sessions: { list } as unknown as SessionCapability,
+      parentKey,
+      isCurrent: () => true,
+    });
+
+    expect(rows).toHaveLength(50);
+    expect(list).toHaveBeenCalledOnce();
+    expect(list).toHaveBeenCalledWith({
+      spawnedBy: parentKey,
+      limit: 100,
+      includeGlobal: false,
+      includeUnknown: false,
+      configuredAgentsOnly: true,
+    });
+  });
+
+  it("continues paging when a child roster exceeds the default page", async () => {
+    const firstPage = Array.from({ length: 100 }, (_, index) => childRow(index));
+    const lastPage = [childRow(100)];
+    const list = vi
+      .fn()
+      .mockResolvedValueOnce(listResult(firstPage, 101, 100))
+      .mockResolvedValueOnce(listResult(lastPage, 101, null));
+
+    const rows = await fetchChildSessionRows({
+      sessions: { list } as unknown as SessionCapability,
+      parentKey,
+      isCurrent: () => true,
+    });
+
+    expect(rows).toHaveLength(101);
+    expect(list).toHaveBeenCalledTimes(2);
+    expect(list.mock.calls[1]?.[0]).toMatchObject({ offset: 100, limit: 100 });
+  });
+});

--- a/ui/src/lib/sessions/child-session-data.ts
+++ b/ui/src/lib/sessions/child-session-data.ts
@@ -2,6 +2,9 @@ import type { GatewaySessionRow } from "../../api/types.ts";
 import type { SessionCapability } from "./index.ts";
 
 const MAX_CHILD_SESSION_LIST_PASSES = 4;
+// Matches the Gateway default and covers the default 50-child Swarm roster.
+// Custom larger groups keep paging through the bounded retry loop below.
+const CHILD_SESSION_LIST_PAGE_SIZE = 100;
 
 export async function fetchChildSessionRows(params: {
   sessions: SessionCapability;
@@ -10,7 +13,7 @@ export async function fetchChildSessionRows(params: {
   pageSize?: number;
 }): Promise<GatewaySessionRow[] | null> {
   const rowsByKey = new Map<string, GatewaySessionRow>();
-  const pageSize = params.pageSize ?? 20;
+  const pageSize = params.pageSize ?? CHILD_SESSION_LIST_PAGE_SIZE;
   for (let pass = 0; pass < MAX_CHILD_SESSION_LIST_PASSES; pass += 1) {
     const seenOffsets = new Set<number>();
     const rowsBeforePass = rowsByKey.size;

--- a/ui/src/lib/sessions/index.event-refresh.test.ts
+++ b/ui/src/lib/sessions/index.event-refresh.test.ts
@@ -1,0 +1,211 @@
+// @vitest-environment node
+import { describe, expect, it, vi } from "vitest";
+import type { GatewayBrowserClient, GatewayEventFrame } from "../../api/gateway.ts";
+import type { SessionsListResult } from "../../api/types.ts";
+import { createSessionCapability } from "./index.ts";
+
+const SESSION_EVENT_REFRESH_DEBOUNCE_MS = 200;
+const SESSION_EVENT_REFRESH_MAX_WAIT_MS = 1_000;
+
+function sessionsResult(ts: number): SessionsListResult {
+  return {
+    ts,
+    path: "",
+    count: 0,
+    defaults: { modelProvider: null, model: null, contextTokens: null },
+    sessions: [],
+  };
+}
+
+function deferred<T>() {
+  let resolve: (value: T) => void = () => undefined;
+  const promise = new Promise<T>((next) => {
+    resolve = next;
+  });
+  return { promise, resolve };
+}
+
+function sessionChangedEvent(key: string): GatewayEventFrame {
+  return {
+    type: "event",
+    event: "sessions.changed",
+    payload: { sessionKey: key, reason: "create", key, kind: "direct", updatedAt: 1 },
+  };
+}
+
+function createHarness(request: GatewayBrowserClient["request"]) {
+  const client = { request } as GatewayBrowserClient;
+  let eventListener: ((event: GatewayEventFrame) => void) | undefined;
+  const sessions = createSessionCapability({
+    snapshot: {
+      client,
+      phase: "connected",
+      sessionKey: "agent:main:main",
+      assistantAgentId: "main",
+      hello: null,
+    },
+    subscribe: () => () => undefined,
+    subscribeEvents(listener) {
+      eventListener = listener;
+      return () => {
+        eventListener = undefined;
+      };
+    },
+  });
+  return { sessions, emitEvent: (event: GatewayEventFrame) => eventListener?.(event) };
+}
+
+describe("event-driven session list refresh", () => {
+  it("debounces rapid session events into one trailing list refresh", async () => {
+    vi.useFakeTimers();
+    const request = vi.fn(async (method: string) => {
+      if (method !== "sessions.list") {
+        throw new Error(`Unexpected request: ${method}`);
+      }
+      return sessionsResult(1);
+    });
+    const { sessions, emitEvent } = createHarness(
+      request as unknown as GatewayBrowserClient["request"],
+    );
+
+    try {
+      await sessions.refresh({ force: true });
+      emitEvent(sessionChangedEvent("agent:main:first"));
+      emitEvent(sessionChangedEvent("agent:main:second"));
+      emitEvent(sessionChangedEvent("agent:main:third"));
+
+      expect(request).toHaveBeenCalledTimes(1);
+      await vi.advanceTimersByTimeAsync(SESSION_EVENT_REFRESH_DEBOUNCE_MS - 1);
+      expect(request).toHaveBeenCalledTimes(1);
+      await vi.advanceTimersByTimeAsync(1);
+      expect(request).toHaveBeenCalledTimes(2);
+    } finally {
+      sessions.dispose();
+      vi.useRealTimers();
+    }
+  });
+
+  it("bounds canonical refresh latency during sustained event traffic", async () => {
+    vi.useFakeTimers();
+    const request = vi.fn(async (method: string) => {
+      if (method !== "sessions.list") {
+        throw new Error(`Unexpected request: ${method}`);
+      }
+      return sessionsResult(1);
+    });
+    const { sessions, emitEvent } = createHarness(
+      request as unknown as GatewayBrowserClient["request"],
+    );
+
+    try {
+      await sessions.refresh({ force: true });
+      emitEvent(sessionChangedEvent("agent:main:first"));
+      for (let index = 0; index < 5; index += 1) {
+        await vi.advanceTimersByTimeAsync(SESSION_EVENT_REFRESH_DEBOUNCE_MS - 1);
+        emitEvent(sessionChangedEvent(`agent:main:sustained-${index}`));
+      }
+
+      expect(request).toHaveBeenCalledTimes(1);
+      await vi.advanceTimersByTimeAsync(
+        SESSION_EVENT_REFRESH_MAX_WAIT_MS - 5 * (SESSION_EVENT_REFRESH_DEBOUNCE_MS - 1),
+      );
+      expect(request).toHaveBeenCalledTimes(2);
+    } finally {
+      sessions.dispose();
+      vi.useRealTimers();
+    }
+  });
+
+  it("lets an explicit refresh bypass and subsume the event debounce", async () => {
+    vi.useFakeTimers();
+    const request = vi.fn(async (method: string) => {
+      if (method !== "sessions.list") {
+        throw new Error(`Unexpected request: ${method}`);
+      }
+      return sessionsResult(1);
+    });
+    const { sessions, emitEvent } = createHarness(
+      request as unknown as GatewayBrowserClient["request"],
+    );
+
+    try {
+      await sessions.refresh({ force: true });
+      emitEvent(sessionChangedEvent("agent:main:event"));
+      await sessions.refresh({ force: true });
+
+      expect(request).toHaveBeenCalledTimes(2);
+      await vi.advanceTimersByTimeAsync(SESSION_EVENT_REFRESH_DEBOUNCE_MS);
+      expect(request).toHaveBeenCalledTimes(2);
+    } finally {
+      sessions.dispose();
+      vi.useRealTimers();
+    }
+  });
+
+  it("queues one trailing refresh for an event during an in-flight refresh", async () => {
+    vi.useFakeTimers();
+    const secondList = deferred<SessionsListResult>();
+    const thirdListStarted = deferred<void>();
+    let listCalls = 0;
+    const request = vi.fn(async (method: string) => {
+      if (method !== "sessions.list") {
+        throw new Error(`Unexpected request: ${method}`);
+      }
+      listCalls += 1;
+      if (listCalls === 2) {
+        return await secondList.promise;
+      }
+      if (listCalls === 3) {
+        thirdListStarted.resolve();
+      }
+      return sessionsResult(listCalls);
+    });
+    const { sessions, emitEvent } = createHarness(
+      request as unknown as GatewayBrowserClient["request"],
+    );
+
+    try {
+      await sessions.refresh({ force: true });
+      emitEvent(sessionChangedEvent("agent:main:first"));
+      await vi.advanceTimersByTimeAsync(SESSION_EVENT_REFRESH_DEBOUNCE_MS);
+      expect(request).toHaveBeenCalledTimes(2);
+
+      emitEvent(sessionChangedEvent("agent:main:during-flight"));
+      await vi.advanceTimersByTimeAsync(SESSION_EVENT_REFRESH_DEBOUNCE_MS);
+      expect(request).toHaveBeenCalledTimes(2);
+
+      secondList.resolve(sessionsResult(2));
+      await thirdListStarted.promise;
+      expect(request).toHaveBeenCalledTimes(3);
+    } finally {
+      sessions.dispose();
+      vi.useRealTimers();
+    }
+  });
+
+  it("flushes a pending event refresh synchronously on dispose", async () => {
+    vi.useFakeTimers();
+    const request = vi.fn(async (method: string) => {
+      if (method !== "sessions.list") {
+        throw new Error(`Unexpected request: ${method}`);
+      }
+      return sessionsResult(1);
+    });
+    const { sessions, emitEvent } = createHarness(
+      request as unknown as GatewayBrowserClient["request"],
+    );
+
+    try {
+      await sessions.refresh({ force: true });
+      emitEvent(sessionChangedEvent("agent:main:pending"));
+      sessions.dispose();
+
+      expect(request).toHaveBeenCalledTimes(2);
+      await vi.advanceTimersByTimeAsync(SESSION_EVENT_REFRESH_DEBOUNCE_MS * 2);
+      expect(request).toHaveBeenCalledTimes(2);
+    } finally {
+      sessions.dispose();
+      vi.useRealTimers();
+    }
+  });
+});

--- a/ui/src/lib/sessions/index.ts
+++ b/ui/src/lib/sessions/index.ts
@@ -99,6 +99,9 @@ export const DEFAULT_SESSION_LIST_QUERY = {
   limit: 50,
 } as const satisfies SessionListOptions;
 
+const SESSION_EVENT_REFRESH_DEBOUNCE_MS = 200;
+const SESSION_EVENT_REFRESH_MAX_WAIT_MS = 1_000;
+
 type SessionRefreshOptions = SessionListOptions & {
   force?: boolean;
   // Sidebar startup hydration must not block session creation or drop the open session.
@@ -839,6 +842,8 @@ export function createSessionCapability(gateway: SessionGateway): SessionCapabil
   };
   let inFlight: Promise<void> | null = null;
   let queuedRefresh: SessionRefreshOptions | null = null;
+  let eventRefreshTimer: ReturnType<typeof globalThis.setTimeout> | null = null;
+  let eventRefreshDeadline: number | null = null;
   let canonicalListRevision = 0;
   let disposed = false;
   let connectionEpoch = 0;
@@ -1097,11 +1102,21 @@ export function createSessionCapability(gateway: SessionGateway): SessionCapabil
     }
   };
 
+  const clearEventRefreshTimer = () => {
+    if (eventRefreshTimer !== null) {
+      globalThis.clearTimeout(eventRefreshTimer);
+      eventRefreshTimer = null;
+    }
+    eventRefreshDeadline = null;
+  };
+
   const refresh = (options: SessionRefreshOptions = {}) => {
     if (gateway.snapshot.phase !== "connected" || !gateway.snapshot.client || disposed) {
       return Promise.resolve();
     }
     if (inFlight) {
+      // An explicit queued refresh subsumes any older event invalidation.
+      clearEventRefreshTimer();
       queuedRefresh = options;
       return inFlight;
     }
@@ -1111,6 +1126,8 @@ export function createSessionCapability(gateway: SessionGateway): SessionCapabil
     if (state.result && !options.force && !hasListOverrides) {
       return Promise.resolve();
     }
+    // An explicit refresh that will issue a request must run now.
+    clearEventRefreshTimer();
     const request = drainRefreshQueue(options).finally(() => {
       if (inFlight === request) {
         inFlight = null;
@@ -1119,6 +1136,43 @@ export function createSessionCapability(gateway: SessionGateway): SessionCapabil
     inFlight = request;
     return request;
   };
+
+  const flushEventRefresh = () => {
+    if (eventRefreshTimer === null) {
+      return;
+    }
+    clearEventRefreshTimer();
+    void refresh({ ...lastListOptions, force: true });
+  };
+
+  const scheduleEventRefresh = () => {
+    const now = Date.now();
+    eventRefreshDeadline ??= now + SESSION_EVENT_REFRESH_MAX_WAIT_MS;
+    if (eventRefreshTimer !== null) {
+      globalThis.clearTimeout(eventRefreshTimer);
+    }
+    const delay = Math.min(
+      SESSION_EVENT_REFRESH_DEBOUNCE_MS,
+      Math.max(0, eventRefreshDeadline - now),
+    );
+    eventRefreshTimer = globalThis.setTimeout(() => {
+      eventRefreshTimer = null;
+      eventRefreshDeadline = null;
+      void refresh({ ...lastListOptions, force: true });
+    }, delay);
+  };
+
+  const handleVisibilityChange = () => {
+    if (document.visibilityState === "hidden") {
+      flushEventRefresh();
+    }
+  };
+  const observesPageLifecycle =
+    typeof document !== "undefined" && typeof globalThis.addEventListener === "function";
+  if (observesPageLifecycle) {
+    document.addEventListener("visibilitychange", handleVisibilityChange);
+    globalThis.addEventListener("pagehide", flushEventRefresh);
+  }
 
   const refreshReplacement = (agentId?: string | null) => {
     // Mutation refreshes replace the visible sidebar rows. A foreground probe
@@ -1861,6 +1915,7 @@ export function createSessionCapability(gateway: SessionGateway): SessionCapabil
     connectionConnected = connected;
     if (connectionChanged) {
       const hadPullRequestSummaries = pullRequestSummaries.size > 0;
+      clearEventRefreshTimer();
       connectionEpoch += 1;
       if (previousClient) {
         resetSessionMessageSubscriptionRegistry(previousClient);
@@ -1967,8 +2022,9 @@ export function createSessionCapability(gateway: SessionGateway): SessionCapabil
         });
       }
       // Gateway lists are filtered and windowed. Events cannot preserve server
-      // membership or ordering, so the coalesced refresh remains canonical.
-      void refresh({ ...lastListOptions, force: true });
+      // membership or ordering, so the coalesced refresh remains canonical. Only
+      // events debounce, with a max wait; explicit refreshes and page exit flush it.
+      scheduleEventRefresh();
     }
   });
 
@@ -2027,6 +2083,13 @@ export function createSessionCapability(gateway: SessionGateway): SessionCapabil
       return () => listeners.delete(listener);
     },
     dispose() {
+      // Page teardown must start the trailing refresh synchronously before the
+      // disposed guard makes the capability inert.
+      flushEventRefresh();
+      if (observesPageLifecycle) {
+        document.removeEventListener("visibilitychange", handleVisibilityChange);
+        globalThis.removeEventListener("pagehide", flushEventRefresh);
+      }
       for (const subscription of ownedMessageSubscriptions) {
         void releaseSessionMessageSubscription(subscription).catch(() => undefined);
       }

--- a/ui/src/test-helpers/app-sidebar-cases/child-sessions.ts
+++ b/ui/src/test-helpers/app-sidebar-cases/child-sessions.ts
@@ -77,7 +77,7 @@ describe("AppSidebar agent chip", () => {
 
     expect(harness.list).toHaveBeenCalledWith({
       spawnedBy: "agent:main:parent",
-      limit: 20,
+      limit: 100,
       includeGlobal: false,
       includeUnknown: false,
       configuredAgentsOnly: true,
@@ -236,7 +236,7 @@ describe("AppSidebar agent chip", () => {
       count: 1,
       totalCount: 2,
       hasMore,
-      nextOffset: hasMore ? 20 : null,
+      nextOffset: hasMore ? 100 : null,
       defaults: { modelProvider: null, model: null, contextTokens: null },
       sessions: [
         {
@@ -273,7 +273,7 @@ describe("AppSidebar agent chip", () => {
     await waitForFast(() => expect(harness.list).toHaveBeenCalledTimes(2));
     expect(harness.list.mock.calls[1]?.[0]).toMatchObject({
       spawnedBy: "agent:main:parent",
-      offset: 20,
+      offset: 100,
     });
     await waitForFast(() =>
       expect(sidebar.querySelectorAll(".sidebar-recent-session--child")).toHaveLength(2),
@@ -289,7 +289,7 @@ describe("AppSidebar agent chip", () => {
       count: sessions.length,
       totalCount: 2,
       hasMore,
-      nextOffset: hasMore ? 20 : null,
+      nextOffset: hasMore ? 100 : null,
       defaults: { modelProvider: null, model: null, contextTokens: null },
       sessions,
     });


### PR DESCRIPTION
## What Problem This Solves

`sessions.list` fires 98 times per 2 hours of active use on team.openclaw.ai. The client's canonical-refresh design (every `sessions.changed` and run-terminal message triggers a full forced list, because events can't preserve server membership/ordering) is correct — but coalescing was in-flight-only with no trailing debounce, so a burst of N change events serialized N back-to-back full lists. Separately, expanding a parent session's children paged at size 20 with up to 4 sequential passes — the worst per-user-action request amplifier.

## Why This Change Was Made

Bursts should collapse to one canonical refresh; the common child expand should be one request.

## User Impact

Fewer redundant full lists during active agent turns (bursts collapse to one within 200ms, bounded by a 1s maximum wait under sustained traffic); child expansion resolves in a single request for typical rosters.

## Evidence

- 200ms trailing debounce with 1s max-wait on event-triggered refreshes only: explicit user refreshes bypass/subsume it, an event during an in-flight refresh still queues exactly one more (trailing edge guaranteed), and page-hide/teardown flush pending work. The canonical-refresh design comment is extended with the debounce contract.
- Child page size 20 → 100: matches the Gateway default limit, covers normal sub-agent counts and the default 50-child Swarm roster, keeps the multi-pass fallback beyond 100. `spawnedBy` already pays the full-row-context path server-side, so the larger limit doesn't change the cost class (verified in session-utils-list).
- Follow-up found during the audit (not fixed here, separate territory): archived/all sidebar views use a direct `sessions.list` path (session-data-controller-pagination.ts:131, triggered from capability publishes at session-data-controller.ts:418) that bypasses this debounce and can repeat identical requests.
- 244 focused tests (fake timers via bounded advance, per repo shard rules) + full UI e2e 96 files/345 tests + cross-page Workboard e2e; UI prod+test tsgo, all deadcode lanes, full lint, format, git diff --check; autoreview clean (max-wait added from an accepted finding).
