### PR TITLE
fix: make Code Mode reliable across gateway and provider lifecycles

### DIFF
--- a/packages/ai/src/transports/openai-completions-transport.ts
+++ b/packages/ai/src/transports/openai-completions-transport.ts
@@ -63,6 +63,7 @@ import {
   buildOpenAISdkRequestOptions,
   enforceCodeModeResponsesToolSurface,
   getCompat,
+  resolveCodeModeResponsesVisibleToolNames,
   resolveOpenAIStrictToolFlagWithDiagnostics,
 } from "./openai-transport-params.js";
 import {
@@ -321,8 +322,9 @@ export function createOpenAICompletionsTransportStreamFn(): StreamFn {
           (options as { openclawCodeModeToolSurface?: unknown } | undefined)
             ?.openclawCodeModeToolSurface === true
         ) {
-          enforceCodeModeResponsesToolSurface(params);
-          assertCodeModeResponsesToolSurface(params);
+          const visibleToolNames = resolveCodeModeResponsesVisibleToolNames(context);
+          enforceCodeModeResponsesToolSurface(params, visibleToolNames);
+          assertCodeModeResponsesToolSurface(params, visibleToolNames);
         }
         const compat = getCompat(model as OpenAIModeModel);
         if (compat.requiresNonEmptyUserOrAssistantMessage) {

--- a/packages/ai/src/transports/openai-responses-client.ts
+++ b/packages/ai/src/transports/openai-responses-client.ts
@@ -46,6 +46,7 @@ import {
   buildOpenAISdkRequestOptions,
   enforceCodeModeResponsesToolSurface,
   isOpenAICodexResponsesModel,
+  resolveCodeModeResponsesVisibleToolNames,
 } from "./openai-transport-params.js";
 import { log } from "./openai-transport-shared.js";
 import { sanitizeResponsesImagePayload } from "./responses-image-payload-sanitizer.js";
@@ -185,8 +186,9 @@ function createResponsesTransportExecutor(config: ResponsesTransportExecutorOpti
           (options as { openclawCodeModeToolSurface?: unknown } | undefined)
             ?.openclawCodeModeToolSurface === true
         ) {
-          enforceCodeModeResponsesToolSurface(params);
-          assertCodeModeResponsesToolSurface(params);
+          const visibleToolNames = resolveCodeModeResponsesVisibleToolNames(context);
+          enforceCodeModeResponsesToolSurface(params, visibleToolNames);
+          assertCodeModeResponsesToolSurface(params, visibleToolNames);
         }
         const requestStartedAt = Date.now();
         firstEventAbort = createFirstStreamEventAbortController(options?.signal);

--- a/packages/ai/src/transports/openai-transport-params.ts
+++ b/packages/ai/src/transports/openai-transport-params.ts
@@ -42,17 +42,33 @@ function transportPayloadToolName(tool: unknown): string | undefined {
   return typeof fnName === "string" ? fnName : undefined;
 }
 
-export function enforceCodeModeResponsesToolSurface(payload: unknown): void {
+export function resolveCodeModeResponsesVisibleToolNames(
+  context: Pick<Context, "tools">,
+): ReadonlySet<string> {
+  return new Set(
+    (context.tools ?? [])
+      .map(transportPayloadToolName)
+      .filter((name): name is string => typeof name === "string"),
+  );
+}
+
+export function enforceCodeModeResponsesToolSurface(
+  payload: unknown,
+  visibleToolNames: ReadonlySet<string>,
+): void {
   if (!isRecord(payload) || !Array.isArray(payload.tools)) {
     return;
   }
   payload.tools = payload.tools.filter((tool) => {
     const name = transportPayloadToolName(tool);
-    return typeof name === "string" && isCodeModeModelVisibleToolName(name);
+    return typeof name === "string" && isCodeModeModelVisibleToolName(name, visibleToolNames);
   });
 }
 
-export function assertCodeModeResponsesToolSurface(payload: unknown): void {
+export function assertCodeModeResponsesToolSurface(
+  payload: unknown,
+  visibleToolNames: ReadonlySet<string>,
+): void {
   if (!isRecord(payload) || !Array.isArray(payload.tools)) {
     throw new Error("Code mode payload tool surface violation: expected exec,wait; got no tools");
   }
@@ -65,7 +81,7 @@ export function assertCodeModeResponsesToolSurface(payload: unknown): void {
     new Set(names).size === names.length &&
     names.filter((name) => name === "exec").length === 1 &&
     names.filter((name) => name === "wait").length === 1 &&
-    names.every(isCodeModeModelVisibleToolName)
+    names.every((name) => isCodeModeModelVisibleToolName(name, visibleToolNames))
   ) {
     return;
   }

--- a/packages/ai/src/transports/transport-utils.ts
+++ b/packages/ai/src/transports/transport-utils.ts
@@ -83,14 +83,11 @@ export function supportsModelTools(model: { compat?: unknown }): boolean {
   return compat?.supportsTools !== false;
 }
 
-export function isCodeModeModelVisibleToolName(name: string): boolean {
-  return (
-    name === "exec" ||
-    name === "wait" ||
-    name === "computer" ||
-    name === "image" ||
-    name === "message"
-  );
+export function isCodeModeModelVisibleToolName(
+  name: string,
+  visibleToolNames: ReadonlySet<string>,
+): boolean {
+  return visibleToolNames.has(name);
 }
 
 function isGoogleGemini3Model(modelId: string, family: "flash" | "pro"): boolean {

--- a/scripts/e2e/lib/mcp-code-mode-validation.ts
+++ b/scripts/e2e/lib/mcp-code-mode-validation.ts
@@ -3,6 +3,33 @@ export type McpCodeModeMentions = Record<
   number
 >;
 
+/** Extracts actual assistant tool calls, never prompt or assistant prose. */
+export function extractMcpCodeModePlannedTools(transcriptEvents: readonly unknown[]): string[] {
+  return transcriptEvents.flatMap((event) => {
+    if (!event || typeof event !== "object") {
+      return [];
+    }
+    const message = (event as { message?: unknown }).message;
+    if (!message || typeof message !== "object") {
+      return [];
+    }
+    const { role, content } = message as { role?: unknown; content?: unknown };
+    if (role !== "assistant" || !Array.isArray(content)) {
+      return [];
+    }
+    return content.flatMap((block) => {
+      if (!block || typeof block !== "object") {
+        return [];
+      }
+      const { type, name } = block as { type?: unknown; name?: unknown };
+      return (type === "toolCall" || type === "tool_use" || type === "tool_call") &&
+        typeof name === "string"
+        ? [name]
+        : [];
+    });
+  });
+}
+
 function assert(condition: unknown, message: string): asserts condition {
   if (!condition) {
     throw new Error(message);

--- a/scripts/e2e/mcp-code-mode-gateway-client.ts
+++ b/scripts/e2e/mcp-code-mode-gateway-client.ts
@@ -2,9 +2,12 @@
 import path from "node:path";
 import { setTimeout as setNodeTimeout, clearTimeout as clearNodeTimeout } from "node:timers";
 import { pathToFileURL } from "node:url";
+import { getSessionEntry } from "openclaw/plugin-sdk/session-store-runtime";
+import { readSessionTranscriptEvents } from "openclaw/plugin-sdk/session-transcript-runtime";
 import { readBoundedResponseText } from "../lib/bounded-response.ts";
 import { readPositiveIntEnv } from "./lib/env-limits.mjs";
 import {
+  extractMcpCodeModePlannedTools,
   type McpCodeModeMentions,
   validateMcpCodeModeResult,
 } from "./lib/mcp-code-mode-validation.ts";
@@ -35,6 +38,7 @@ export function readMcpCodeModeClientFetchLimits(
 }
 
 const DEFAULT_FETCH_LIMITS = readMcpCodeModeClientFetchLimits();
+const MCP_CODE_MODE_SESSION_KEY = "agent:main:openresponses:mcp-code-mode-gateway-e2e";
 
 function assert(condition: unknown, message: string): asserts condition {
   if (!condition) {
@@ -127,6 +131,7 @@ async function main() {
       authorization: `Bearer ${gatewayToken}`,
       "content-type": "application/json",
       "x-openclaw-agent": "main",
+      "x-openclaw-session-key": MCP_CODE_MODE_SESSION_KEY,
       "x-openclaw-scopes": "operator.write",
     },
     body: JSON.stringify({
@@ -160,7 +165,21 @@ async function main() {
     }),
   });
   const mentions = await readSessionLogMentions(stateDir);
-  const finalText = validateMcpCodeModeResult(response, mentions as McpCodeModeMentions);
+  const session = getSessionEntry({
+    agentId: "main",
+    sessionKey: MCP_CODE_MODE_SESSION_KEY,
+  });
+  assert(session?.sessionId, "gateway did not persist the MCP code-mode session");
+  const transcriptEvents = await readSessionTranscriptEvents({
+    agentId: "main",
+    sessionId: session.sessionId,
+    sessionKey: MCP_CODE_MODE_SESSION_KEY,
+  });
+  const plannedTools = extractMcpCodeModePlannedTools(transcriptEvents);
+  const finalText = validateMcpCodeModeResult(response, mentions as McpCodeModeMentions, {
+    plannedTools,
+    requireExec: true,
+  });
 
   process.stdout.write(
     `${JSON.stringify(
@@ -168,6 +187,7 @@ async function main() {
         ok: true,
         gatewayUrl,
         finalText,
+        plannedTools,
         sessionLogMentions: mentions,
       },
       null,

--- a/scripts/lib/docker-e2e-scenarios.mjs
+++ b/scripts/lib/docker-e2e-scenarios.mjs
@@ -252,6 +252,18 @@ function liveCodexNpmPluginLane() {
   );
 }
 
+function mcpCodeModeGatewayLane() {
+  return serviceLane(
+    "mcp-code-mode-gateway",
+    "OPENCLAW_SKIP_DOCKER_BUILD=1 pnpm test:docker:mcp-code-mode-gateway",
+    {
+      resources: ["npm"],
+      stateScenario: "empty",
+      weight: 3,
+    },
+  );
+}
+
 function liveMcpCodeModeGatewayLane() {
   return liveLane(
     "live-mcp-code-mode-gateway",
@@ -470,15 +482,7 @@ export const mainLanes = [
     stateScenario: "empty",
     weight: 3,
   }),
-  serviceLane(
-    "mcp-code-mode-gateway",
-    "OPENCLAW_SKIP_DOCKER_BUILD=1 pnpm test:docker:mcp-code-mode-gateway",
-    {
-      resources: ["npm"],
-      stateScenario: "empty",
-      weight: 3,
-    },
-  ),
+  mcpCodeModeGatewayLane(),
   lane(
     "agent-bundle-mcp-tools",
     "OPENCLAW_SKIP_DOCKER_BUILD=1 pnpm test:docker:agent-bundle-mcp-tools",
@@ -870,6 +874,7 @@ const primaryReleasePathChunks = {
       stateScenario: "empty",
       weight: 3,
     }),
+    mcpCodeModeGatewayLane(),
   ],
   "package-update-openai": releasePathPackageInstallOpenAiLanes,
   "package-update-anthropic": releasePathPackageInstallAnthropicLanes,

--- a/src/agents/code-mode-state.ts
+++ b/src/agents/code-mode-state.ts
@@ -107,6 +107,13 @@ export function disposeCodeModeRun(runId: string): void {
   scheduleActiveRunExpiry();
 }
 
+/** Cancel suspended bridge work before its Gateway-owned runtimes disappear. */
+export function disposeAllCodeModeRuns(): void {
+  for (const runId of activeRuns.keys()) {
+    disposeCodeModeRun(runId);
+  }
+}
+
 /** Advance the snapshot frontier before exposing output to a wait observer. */
 export function takeUndeliveredCodeModeRunOutput(state: CodeModeRunState): unknown[] {
   const output = state.output.slice(state.deliveredOutputCount);

--- a/src/agents/code-mode-worker-lifecycle.test.ts
+++ b/src/agents/code-mode-worker-lifecycle.test.ts
@@ -3,8 +3,10 @@ import { createCodeModeNamespaceRuntime } from "./code-mode-namespaces.js";
 import { resolveCodeModeConfig, toToolSearchConfig } from "./code-mode-runtime.js";
 import {
   activeRuns,
+  disposeAllCodeModeRuns,
   disposeCodeModeRun,
   reserveActiveRunSlot,
+  resumingRunIds,
   storeSnapshotState,
   type PendingBridgeState,
 } from "./code-mode-state.js";
@@ -18,7 +20,10 @@ import {
 const EXPIRING_RUN_ID = "cm_worker_lifecycle_expiry";
 const CAPACITY_RUN_PREFIX = "cm_worker_lifecycle_capacity_";
 
-function parkExpiringRun(method: "callValue" | "agentWait"): ReturnType<typeof vi.fn> {
+function parkExpiringRun(
+  method: "callValue" | "agentWait",
+  runId = EXPIRING_RUN_ID,
+): ReturnType<typeof vi.fn> {
   const rawConfig = {
     tools: { codeMode: { enabled: true, snapshotTtlSeconds: 1 } },
   } as never;
@@ -37,7 +42,7 @@ function parkExpiringRun(method: "callValue" | "agentWait"): ReturnType<typeof v
   };
 
   storeSnapshotState({
-    runId: EXPIRING_RUN_ID,
+    runId,
     replayId: "cm_replay_lifecycle",
     pending: [pending],
     replaySafe: false,
@@ -64,6 +69,41 @@ afterEach(() => {
 });
 
 describe("Code Mode worker lifecycle", () => {
+  it("cancels every suspended run, releases capacity, and clears its expiry timer", () => {
+    vi.useFakeTimers({ toFake: ["Date", "setTimeout", "clearTimeout"] });
+    const firstRunId = `${CAPACITY_RUN_PREFIX}shutdown_first`;
+    const secondRunId = `${CAPACITY_RUN_PREFIX}shutdown_second`;
+    const firstCancel = parkExpiringRun("callValue", firstRunId);
+    const secondCancel = parkExpiringRun("agentWait", secondRunId);
+    const firstRun = activeRuns.get(firstRunId);
+    if (!firstRun) {
+      throw new Error("expected a parked Code Mode shutdown run");
+    }
+    resumingRunIds.add(firstRunId);
+    resumingRunIds.add(secondRunId);
+    for (let index = 0; index < 62; index += 1) {
+      const runId = `${CAPACITY_RUN_PREFIX}shutdown_${index}`;
+      activeRuns.set(runId, { ...firstRun, runId, pending: [] });
+    }
+
+    expect(activeRuns.size).toBe(64);
+    expect(() => reserveActiveRunSlot()).toThrow("too many suspended code mode runs");
+    expect(vi.getTimerCount()).toBe(1);
+
+    disposeAllCodeModeRuns();
+    disposeAllCodeModeRuns();
+
+    expect(firstCancel).toHaveBeenCalledOnce();
+    expect(secondCancel).toHaveBeenCalledOnce();
+    expect(activeRuns.size).toBe(0);
+    expect(resumingRunIds.has(firstRunId)).toBe(false);
+    expect(resumingRunIds.has(secondRunId)).toBe(false);
+    expect(vi.getTimerCount()).toBe(0);
+
+    const releaseFreedSlot = reserveActiveRunSlot();
+    releaseFreedSlot();
+  });
+
   it("transfers a resumed run's slot atomically at the suspended-run limit", () => {
     parkExpiringRun("callValue");
     const ownedState = activeRuns.get(EXPIRING_RUN_ID);

--- a/src/agents/embedded-agent-runner/run/attempt.tool-search-catalog-abort.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.tool-search-catalog-abort.test.ts
@@ -88,4 +88,53 @@ describe("runEmbeddedAttempt tool-search catalog cleanup", () => {
 
     expect(toolSearchTesting.sessionCatalogs.has(`run:${runId}`)).toBe(false);
   });
+
+  it.each([
+    {
+      mode: "code-mode",
+      tools: { codeMode: { enabled: true } },
+    },
+    {
+      mode: "tool-search-tools",
+      tools: { toolSearch: { enabled: true, mode: "tools" } },
+    },
+    {
+      mode: "tool-search-directory",
+      tools: { toolSearch: { enabled: true, mode: "directory" } },
+    },
+  ] as const)(
+    "clears the $mode run catalog when diagnostics throw during preparation",
+    async ({ mode, tools }) => {
+      const runId = `run-catalog-diagnostics-${mode}`;
+      const diagnosticsError = new Error(`failed ${mode} tool diagnostics`);
+      let catalogRegisteredBeforeFailure = false;
+      const logDiagnostics = vi.fn(() => {
+        catalogRegisteredBeforeFailure = toolSearchTesting.sessionCatalogs.has(`run:${runId}`);
+        throw diagnosticsError;
+      });
+      hoisted.createOpenClawCodingToolsMock.mockImplementation(() => catalogProbeTools());
+
+      const attempt = createContextEngineAttemptRunner({
+        contextEngine: createContextEngineBootstrapAndAssemble(),
+        sessionKey: "agent:main:telegram:direct:123",
+        tempPaths,
+        attemptOverrides: {
+          runId,
+          disableTools: false,
+          config: { tools },
+          runtimePlan: {
+            tools: {
+              normalize: (normalizedTools: unknown[]) => normalizedTools,
+              logDiagnostics,
+            },
+          } as never,
+        },
+      });
+
+      await expect(attempt).rejects.toBe(diagnosticsError);
+      expect(logDiagnostics).toHaveBeenCalledOnce();
+      expect(catalogRegisteredBeforeFailure).toBe(true);
+      expect(toolSearchTesting.sessionCatalogs.has(`run:${runId}`)).toBe(false);
+    },
+  );
 });

--- a/src/agents/embedded-agent-runner/run/attempt.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.ts
@@ -252,6 +252,9 @@ export async function runEmbeddedAttempt(
     bundleMcpRuntime = preparedBundleTools.bundleMcpRuntime;
     bundleLspRuntime = preparedBundleTools.bundleLspRuntime;
     const { clientTools, uncompactedEffectiveTools } = preparedBundleTools;
+    // Catalog preparation registers global run state before tool projection and
+    // diagnostics, so arm cleanup before either can fail and leak the catalog.
+    toolSearchCatalogApplied = toolSearchCatalogRef !== undefined;
     const preparedToolCatalog = prepareEmbeddedAttemptToolCatalog({
       attempt: params,
       preparedToolBase,
@@ -278,9 +281,6 @@ export async function runEmbeddedAttempt(
       toolSearch,
       toolSearchRunPlan,
     } = preparedToolCatalog;
-    // Arms the early-exit catalog clear: the run-scoped catalog is registered in
-    // a process-global map that only clearToolSearchCatalog deletes from, so a
-    // prep-phase abort after registration leaks the entry without this.
     toolSearchCatalogApplied = toolSearch.catalogRegistered;
     const preparedSystemPrompt = await prepareEmbeddedAttemptSystemPrompt({
       activeContextEngine,

--- a/src/agents/node-plugin-tools.test.ts
+++ b/src/agents/node-plugin-tools.test.ts
@@ -166,6 +166,80 @@ describe("createNodePluginTools", () => {
     expect(result.content).toEqual([{ type: "text", text: "pong" }]);
   });
 
+  it("forwards the caller abort signal to node gateway invocations", async () => {
+    replaceNodePluginTools({
+      nodeId: "node-1",
+      tools: [
+        {
+          pluginId: "remote-demo",
+          name: "remote_echo",
+          description: "Echo through a remote node",
+          command: "remote.echo",
+        },
+      ],
+    });
+    vi.mocked(callGatewayTool).mockResolvedValueOnce({ payload: { ok: true } });
+    const controller = new AbortController();
+    const tool = expectDefined(
+      createNodePluginTools({})[0],
+      "createNodePluginTools({})[0] test invariant",
+    );
+
+    await tool.execute("call-cancellable", { text: "ping" }, controller.signal);
+
+    expect(callGatewayTool).toHaveBeenCalledWith(
+      "node.invoke",
+      {},
+      {
+        nodeId: "node-1",
+        command: "remote.echo",
+        params: { text: "ping" },
+        idempotencyKey: "call-cancellable",
+      },
+      { scopes: ["operator.write"], signal: controller.signal },
+    );
+  });
+
+  it("propagates caller cancellation through node gateway invocations", async () => {
+    replaceNodePluginTools({
+      nodeId: "node-1",
+      tools: [
+        {
+          pluginId: "remote-demo",
+          name: "remote_echo",
+          description: "Echo through a remote node",
+          command: "remote.echo",
+        },
+      ],
+    });
+    vi.mocked(callGatewayTool).mockImplementationOnce(async (_method, _opts, _params, extra) => {
+      extra?.signal?.throwIfAborted();
+      return { payload: { ok: true } };
+    });
+    const controller = new AbortController();
+    const abortError = new DOMException("node call cancelled", "AbortError");
+    controller.abort(abortError);
+    const tool = expectDefined(
+      createNodePluginTools({})[0],
+      "createNodePluginTools({})[0] test invariant",
+    );
+
+    await expect(tool.execute("call-aborted", { text: "ping" }, controller.signal)).rejects.toBe(
+      abortError,
+    );
+    expect(callGatewayTool).toHaveBeenCalledWith(
+      "node.invoke",
+      {},
+      {
+        nodeId: "node-1",
+        command: "remote.echo",
+        params: { text: "ping" },
+        idempotencyKey: "call-aborted",
+      },
+      { scopes: ["operator.write"], signal: controller.signal },
+    );
+  });
+
   it("wraps node-host MCP arguments and maps MCP content", async () => {
     replaceNodePluginTools({
       nodeId: "node-1",
@@ -299,7 +373,7 @@ describe("createNodePluginTools", () => {
         idempotencyKey: expect.stringContaining("docs_search"),
         sessionKey: "agent:main:node-mcp-code-mode",
       },
-      { scopes: ["operator.write"] },
+      { scopes: ["operator.write"], signal: expect.any(AbortSignal) },
     );
   });
 
@@ -363,7 +437,7 @@ describe("createNodePluginTools", () => {
         nodeId: "node-c",
         params: { server: "docs", tool: "search_c", arguments: {} },
       }),
-      { scopes: ["operator.write"] },
+      { scopes: ["operator.write"], signal: expect.any(AbortSignal) },
     );
   });
 

--- a/src/agents/node-plugin-tools.ts
+++ b/src/agents/node-plugin-tools.ts
@@ -228,7 +228,7 @@ export function createNodePluginTools(params: {
       }),
       parameters: descriptor.parameters as never,
       ...(mcpTool ? { executionMode: "sequential" as const } : {}),
-      execute: async (toolCallId, toolParams) => {
+      execute: async (toolCallId, toolParams, signal) => {
         const raw = await callGatewayTool(
           "node.invoke",
           mcpTool ? { timeoutMs: NODE_MCP_TOOL_CALL_GATEWAY_TIMEOUT_MS } : {},
@@ -246,7 +246,7 @@ export function createNodePluginTools(params: {
             idempotencyKey: toolCallId,
             ...(params.agentSessionKey ? { sessionKey: params.agentSessionKey } : {}),
           },
-          { scopes: ["operator.write"] },
+          { scopes: ["operator.write"], ...(signal ? { signal } : {}) },
         );
         const payload = readNodeInvokePayload(raw);
         if (mcpTool) {

--- a/src/agents/openai-transport-params.code-mode.test.ts
+++ b/src/agents/openai-transport-params.code-mode.test.ts
@@ -6,6 +6,7 @@ import { describe, expect, it } from "vitest";
 
 describe("OpenAI Code Mode direct tools", () => {
   it("keeps policy-required direct tools model-visible", () => {
+    const visibleToolNames = new Set(["exec", "wait", "computer", "image", "message"]);
     const payload = {
       tools: ["exec", "wait", "computer", "image", "message", "web_fetch"].map((name) => ({
         type: "function",
@@ -13,7 +14,7 @@ describe("OpenAI Code Mode direct tools", () => {
       })),
     };
 
-    enforceCodeModeResponsesToolSurface(payload);
+    enforceCodeModeResponsesToolSurface(payload, visibleToolNames);
 
     expect(payload.tools.map((tool) => tool.name)).toEqual([
       "exec",
@@ -22,6 +23,27 @@ describe("OpenAI Code Mode direct tools", () => {
       "image",
       "message",
     ]);
-    expect(() => assertCodeModeResponsesToolSurface(payload)).not.toThrow();
+    expect(() => assertCodeModeResponsesToolSurface(payload, visibleToolNames)).not.toThrow();
   });
+
+  it.each(["sessions_yield", "structured_output", "heartbeat_respond", "openclaw"])(
+    "preserves the request-visible direct-only %s tool and rejects undeclared tools",
+    (directToolName) => {
+      const visibleToolNames = new Set(["exec", "wait", directToolName]);
+      const payload = {
+        tools: ["exec", directToolName, "computer", "image", "message", "web_fetch", "wait"].map(
+          (name) => ({ type: "function", name }),
+        ),
+      };
+
+      expect(() => assertCodeModeResponsesToolSurface(payload, visibleToolNames)).toThrow(
+        /tool surface violation/,
+      );
+
+      enforceCodeModeResponsesToolSurface(payload, visibleToolNames);
+
+      expect(payload.tools.map((tool) => tool.name)).toEqual(["exec", directToolName, "wait"]);
+      expect(() => assertCodeModeResponsesToolSurface(payload, visibleToolNames)).not.toThrow();
+    },
+  );
 });

--- a/src/agents/openai-transport-stream.base.test.ts
+++ b/src/agents/openai-transport-stream.base.test.ts
@@ -959,6 +959,7 @@ describe("openai transport stream", () => {
   });
 
   it("enforces the code mode responses tool surface before requests leave OpenClaw", () => {
+    const visibleToolNames = new Set(["exec", "wait", "computer"]);
     const payload = {
       tools: [
         { type: "function", name: "exec" },
@@ -968,8 +969,8 @@ describe("openai transport stream", () => {
       ],
     };
 
-    testing.enforceCodeModeResponsesToolSurface(payload);
-    testing.assertCodeModeResponsesToolSurface(payload);
+    testing.enforceCodeModeResponsesToolSurface(payload, visibleToolNames);
+    testing.assertCodeModeResponsesToolSurface(payload, visibleToolNames);
     expect(payload.tools).toEqual([
       { type: "function", name: "exec" },
       { type: "function", name: "computer" },
@@ -978,6 +979,7 @@ describe("openai transport stream", () => {
   });
 
   it("skips unreadable code mode response payload tool names", () => {
+    const visibleToolNames = new Set(["exec", "wait"]);
     const payload = {
       tools: [
         { type: "function", name: "exec" },
@@ -999,8 +1001,8 @@ describe("openai transport stream", () => {
       ],
     };
 
-    testing.enforceCodeModeResponsesToolSurface(payload);
-    testing.assertCodeModeResponsesToolSurface(payload);
+    testing.enforceCodeModeResponsesToolSurface(payload, visibleToolNames);
+    testing.assertCodeModeResponsesToolSurface(payload, visibleToolNames);
     expect(payload.tools).toEqual([
       { type: "function", name: "exec" },
       { type: "function", function: { name: "wait" } },
@@ -1008,6 +1010,7 @@ describe("openai transport stream", () => {
   });
 
   it("rejects duplicate direct-only tools in a code mode payload", () => {
+    const visibleToolNames = new Set(["exec", "wait", "computer"]);
     const payload = {
       tools: [
         { type: "function", name: "exec" },
@@ -1017,16 +1020,20 @@ describe("openai transport stream", () => {
       ],
     };
 
-    expect(() => testing.assertCodeModeResponsesToolSurface(payload)).toThrow(
+    expect(() => testing.assertCodeModeResponsesToolSurface(payload, visibleToolNames)).toThrow(
       /tool surface violation/,
     );
   });
 
   it("fails closed when the code mode final payload tool surface is not exec/wait", () => {
+    const visibleToolNames = new Set(["exec", "wait"]);
     expect(() =>
-      testing.assertCodeModeResponsesToolSurface({
-        tools: [{ type: "function", name: "exec" }, { type: "web_search_preview" }],
-      }),
+      testing.assertCodeModeResponsesToolSurface(
+        {
+          tools: [{ type: "function", name: "exec" }, { type: "web_search_preview" }],
+        },
+        visibleToolNames,
+      ),
     ).toThrow(/Code mode payload tool surface violation/);
   });
 

--- a/src/gateway/server-close.test.ts
+++ b/src/gateway/server-close.test.ts
@@ -11,6 +11,7 @@ const mocks = vi.hoisted(() => ({
   logInfo: vi.fn(),
   logWarn: vi.fn(),
   listChannelPlugins: vi.fn((): Array<{ id: "telegram" | "discord" }> => []),
+  disposeAllCodeModeRuns: vi.fn(),
   disposeAgentHarnesses: vi.fn(async () => undefined),
   disposeAllSessionMcpRuntimes: vi.fn(async () => undefined),
   triggerInternalHook: vi.fn<TriggerInternalHookMock>(async (_eventValue) => undefined),
@@ -48,6 +49,10 @@ vi.mock("../hooks/internal-hooks.js", async () => {
 
 vi.mock("../agents/harness/registry.js", () => ({
   disposeRegisteredAgentHarnesses: mocks.disposeAgentHarnesses,
+}));
+
+vi.mock("../agents/code-mode-state.js", () => ({
+  disposeAllCodeModeRuns: mocks.disposeAllCodeModeRuns,
 }));
 
 vi.mock("../agents/agent-bundle-mcp-tools.js", async () => ({
@@ -159,6 +164,7 @@ describe("createGatewayCloseHandler", () => {
     mocks.logWarn.mockClear();
     mocks.listChannelPlugins.mockReset();
     mocks.listChannelPlugins.mockReturnValue([]);
+    mocks.disposeAllCodeModeRuns.mockReset();
     mocks.disposeAgentHarnesses.mockClear();
     mocks.disposeAgentHarnesses.mockResolvedValue(undefined);
     mocks.disposeAllSessionMcpRuntimes.mockClear();
@@ -1467,8 +1473,20 @@ describe("createGatewayCloseHandler", () => {
     expect(stopChannel.mock.calls.map(([id]) => id)).toEqual(["telegram", "discord"]);
   });
 
-  it("unsubscribes lifecycle listeners and disposes bundle runtimes during shutdown", async () => {
+  it("disposes Code Mode runs before agent and bundle runtimes during shutdown", async () => {
     const closeOrder: string[] = [];
+    mocks.disposeAllCodeModeRuns.mockImplementation(() => {
+      closeOrder.push("code-mode-runs");
+    });
+    mocks.disposeAgentHarnesses.mockImplementation(async () => {
+      closeOrder.push("agent-harnesses");
+    });
+    mocks.disposeAllSessionMcpRuntimes.mockImplementation(async () => {
+      closeOrder.push("bundle-mcp");
+    });
+    mocks.disposeAllBundleLspRuntimes.mockImplementation(async () => {
+      closeOrder.push("bundle-lsp");
+    });
     mocks.drainRetainedEmbeddingProviders.mockImplementation(async () => {
       closeOrder.push("embedding-providers");
     });
@@ -1498,11 +1516,19 @@ describe("createGatewayCloseHandler", () => {
     expect(taskUnsub).toHaveBeenCalledTimes(1);
     expect(transcriptUnsub).toHaveBeenCalledTimes(1);
     expect(stopTaskRegistryMaintenance).toHaveBeenCalledTimes(1);
+    expect(mocks.disposeAllCodeModeRuns).toHaveBeenCalledTimes(1);
     expect(mocks.disposeAgentHarnesses).toHaveBeenCalledTimes(1);
     expect(mocks.disposeAllSessionMcpRuntimes).toHaveBeenCalledTimes(1);
     expect(mocks.disposeAllBundleLspRuntimes).toHaveBeenCalledTimes(1);
     expect(mocks.drainRetainedEmbeddingProviders).toHaveBeenCalledTimes(1);
-    expect(closeOrder).toEqual(["http-server", "embedding-providers"]);
+    expect(closeOrder).toEqual([
+      "code-mode-runs",
+      "agent-harnesses",
+      "bundle-mcp",
+      "bundle-lsp",
+      "http-server",
+      "embedding-providers",
+    ]);
   });
 
   it("starts bundle MCP and LSP runtime disposal concurrently", async () => {

--- a/src/gateway/server-close.ts
+++ b/src/gateway/server-close.ts
@@ -4,7 +4,6 @@ import type { Server as HttpServer } from "node:http";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import type { WebSocketServer } from "ws";
 import { disposeAllSessionMcpRuntimes } from "../agents/agent-bundle-mcp-tools.js";
-import { disposeAllCodeModeRuns } from "../agents/code-mode-state.js";
 import { disposeRegisteredAgentHarnesses } from "../agents/harness/registry.js";
 import { createAgentRunRestartAbortError } from "../agents/run-termination.js";
 import { clearSessionSuspensionTimers } from "../agents/session-suspension.js";
@@ -863,8 +862,16 @@ export function createGatewayCloseHandler(
           await shutdownStep(`channel/${channelId}`, () => params.stopChannel(channelId), warnings);
         }
       });
-      // Cancel parked bridge calls while their agent harnesses and MCP transports still exist.
-      await shutdownStep("code-mode-runs", () => disposeAllCodeModeRuns(), warnings);
+      // Load the bridge only at shutdown; eager imports boot the subagent registry at startup.
+      // Cancel parked calls before their agent harnesses and MCP transports disappear.
+      await shutdownStep(
+        "code-mode-runs",
+        async () => {
+          const { disposeAllCodeModeRuns } = await import("../agents/code-mode-state.js");
+          return disposeAllCodeModeRuns();
+        },
+        warnings,
+      );
       await shutdownStep("agent-harnesses", () => disposeRegisteredAgentHarnesses(), warnings);
       await measureCloseStep("bundle-runtimes", async () => {
         await Promise.all([

--- a/src/gateway/server-close.ts
+++ b/src/gateway/server-close.ts
@@ -4,6 +4,7 @@ import type { Server as HttpServer } from "node:http";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import type { WebSocketServer } from "ws";
 import { disposeAllSessionMcpRuntimes } from "../agents/agent-bundle-mcp-tools.js";
+import { disposeAllCodeModeRuns } from "../agents/code-mode-state.js";
 import { disposeRegisteredAgentHarnesses } from "../agents/harness/registry.js";
 import { createAgentRunRestartAbortError } from "../agents/run-termination.js";
 import { clearSessionSuspensionTimers } from "../agents/session-suspension.js";
@@ -862,6 +863,8 @@ export function createGatewayCloseHandler(
           await shutdownStep(`channel/${channelId}`, () => params.stopChannel(channelId), warnings);
         }
       });
+      // Cancel parked bridge calls while their agent harnesses and MCP transports still exist.
+      await shutdownStep("code-mode-runs", () => disposeAllCodeModeRuns(), warnings);
       await shutdownStep("agent-harnesses", () => disposeRegisteredAgentHarnesses(), warnings);
       await measureCloseStep("bundle-runtimes", async () => {
         await Promise.all([

--- a/src/llm/providers/stream-wrappers/openai.test.ts
+++ b/src/llm/providers/stream-wrappers/openai.test.ts
@@ -203,6 +203,8 @@ describe("createCodexNativeWebSearchWrapper", () => {
         tools: [
           { name: "exec", description: "", parameters: {} },
           { name: "wait", description: "", parameters: {} },
+          { name: "sessions_yield", description: "", parameters: {} },
+          { name: "structured_output", description: "", parameters: {} },
         ],
       },
       {
@@ -212,6 +214,8 @@ describe("createCodexNativeWebSearchWrapper", () => {
             { type: "function", name: "computer" },
             { type: "function", name: "image" },
             { type: "function", name: "message" },
+            { type: "function", name: "sessions_yield" },
+            { type: "function", name: "structured_output" },
             {
               type: "function",
               get function(): { name: string } {
@@ -229,9 +233,8 @@ describe("createCodexNativeWebSearchWrapper", () => {
     expect(nextPayload).toEqual({
       tools: [
         { type: "function", name: "exec" },
-        { type: "function", name: "computer" },
-        { type: "function", name: "image" },
-        { type: "function", name: "message" },
+        { type: "function", name: "sessions_yield" },
+        { type: "function", name: "structured_output" },
         { type: "function", name: "wait" },
       ],
     });
@@ -279,6 +282,8 @@ describe("createCodexNativeWebSearchWrapper", () => {
         tools: [
           { type: "function", name: "exec" },
           { type: "function", name: "wait" },
+          { type: "function", name: "sessions_yield" },
+          { type: "function", name: "structured_output" },
           { type: "function", name: "computer" },
           { type: "function", name: "image" },
           { type: "function", name: "message" },
@@ -304,6 +309,8 @@ describe("createCodexNativeWebSearchWrapper", () => {
         tools: [
           { name: "exec", description: "", parameters: {} },
           { name: "wait", description: "", parameters: {} },
+          { name: "sessions_yield", description: "", parameters: {} },
+          { name: "structured_output", description: "", parameters: {} },
         ],
       },
       {},
@@ -313,9 +320,8 @@ describe("createCodexNativeWebSearchWrapper", () => {
     expect(payloads[0]?.tools).toEqual([
       { type: "function", name: "exec" },
       { type: "function", name: "wait" },
-      { type: "function", name: "computer" },
-      { type: "function", name: "image" },
-      { type: "function", name: "message" },
+      { type: "function", name: "sessions_yield" },
+      { type: "function", name: "structured_output" },
     ]);
   });
 
@@ -328,6 +334,8 @@ describe("createCodexNativeWebSearchWrapper", () => {
           {
             functionDeclarations: [
               { name: "exec", description: "Run code" },
+              { name: "sessions_yield", description: "Yield the current session" },
+              { name: "structured_output", description: "Return a structured response" },
               { name: "computer", description: "Control a desktop" },
               { name: "image", description: "Read an image" },
               { name: "message", description: "Deliver the response" },
@@ -357,6 +365,8 @@ describe("createCodexNativeWebSearchWrapper", () => {
         tools: [
           { name: "exec", description: "", parameters: {} },
           { name: "wait", description: "", parameters: {} },
+          { name: "sessions_yield", description: "", parameters: {} },
+          { name: "structured_output", description: "", parameters: {} },
         ],
       },
       {},
@@ -366,9 +376,8 @@ describe("createCodexNativeWebSearchWrapper", () => {
       {
         functionDeclarations: [
           { name: "exec", description: "Run code" },
-          { name: "computer", description: "Control a desktop" },
-          { name: "image", description: "Read an image" },
-          { name: "message", description: "Deliver the response" },
+          { name: "sessions_yield", description: "Yield the current session" },
+          { name: "structured_output", description: "Return a structured response" },
           { name: "wait", description: "Resume code" },
         ],
       },

--- a/src/llm/providers/stream-wrappers/openai.ts
+++ b/src/llm/providers/stream-wrappers/openai.ts
@@ -162,27 +162,39 @@ function readPayloadToolName(tool: unknown): string | undefined {
   return typeof fnName === "string" ? fnName : undefined;
 }
 
-function isCodeModePayloadToolName(name: string | undefined): boolean {
-  return typeof name === "string" && isCodeModeModelVisibleToolName(name);
+function isCodeModePayloadToolName(
+  name: string | undefined,
+  visibleToolNames: ReadonlySet<string>,
+): boolean {
+  return typeof name === "string" && isCodeModeModelVisibleToolName(name, visibleToolNames);
 }
 
-function filterCodeModeToolDeclarations(declarations: unknown): unknown[] | undefined {
+function filterCodeModeToolDeclarations(
+  declarations: unknown,
+  visibleToolNames: ReadonlySet<string>,
+): unknown[] | undefined {
   if (!Array.isArray(declarations)) {
     return undefined;
   }
   return declarations.filter((declaration) =>
-    isCodeModePayloadToolName(readPayloadToolName(declaration)),
+    isCodeModePayloadToolName(readPayloadToolName(declaration), visibleToolNames),
   );
 }
 
-function filterCodeModeGroupedToolDeclarations(tool: unknown): Record<string, unknown> | undefined {
+function filterCodeModeGroupedToolDeclarations(
+  tool: unknown,
+  visibleToolNames: ReadonlySet<string>,
+): Record<string, unknown> | undefined {
   if (!tool || typeof tool !== "object" || Array.isArray(tool)) {
     return undefined;
   }
   const record = tool as Record<string, unknown>;
   const filteredGroups: Record<string, unknown> = {};
   for (const key of ["functionDeclarations", "function_declarations"] as const) {
-    const filtered = filterCodeModeToolDeclarations(readPayloadToolField(record, key));
+    const filtered = filterCodeModeToolDeclarations(
+      readPayloadToolField(record, key),
+      visibleToolNames,
+    );
     if (filtered === undefined) {
       continue;
     }
@@ -193,7 +205,7 @@ function filterCodeModeGroupedToolDeclarations(tool: unknown): Record<string, un
   return Object.keys(filteredGroups).length > 0 ? filteredGroups : undefined;
 }
 
-function filterCodeModePayloadTools(payload: unknown): void {
+function filterCodeModePayloadTools(payload: unknown, visibleToolNames: ReadonlySet<string>): void {
   if (!payload || typeof payload !== "object") {
     return;
   }
@@ -203,26 +215,36 @@ function filterCodeModePayloadTools(payload: unknown): void {
   }
   record.tools = record.tools.flatMap((tool) => {
     const name = readPayloadToolName(tool);
-    if (isCodeModePayloadToolName(name)) {
+    if (isCodeModePayloadToolName(name, visibleToolNames)) {
       return [tool];
     }
-    const grouped = filterCodeModeGroupedToolDeclarations(tool);
+    const grouped = filterCodeModeGroupedToolDeclarations(tool, visibleToolNames);
     return grouped ? [grouped] : [];
   });
 }
 
-function filterCodeModePayloadHookResult(payload: unknown, nextPayload: unknown): unknown {
+function filterCodeModePayloadHookResult(
+  payload: unknown,
+  nextPayload: unknown,
+  visibleToolNames: ReadonlySet<string>,
+): unknown {
   const finalPayload = nextPayload === undefined ? payload : nextPayload;
-  filterCodeModePayloadTools(finalPayload);
+  filterCodeModePayloadTools(finalPayload, visibleToolNames);
   return nextPayload === undefined ? undefined : finalPayload;
 }
 
-function hasCodeModeVisibleTools(context: { tools?: unknown }): boolean {
+function resolveCodeModeVisibleToolNames(context: {
+  tools?: unknown;
+}): ReadonlySet<string> | undefined {
   if (!Array.isArray(context.tools)) {
-    return false;
+    return undefined;
   }
-  const names = new Set(context.tools.map(readPayloadToolName).filter(Boolean));
-  return names.has("exec") && names.has("wait");
+  const names = new Set(
+    context.tools
+      .map(readPayloadToolName)
+      .filter((name): name is string => typeof name === "string"),
+  );
+  return names.has("exec") && names.has("wait") ? names : undefined;
 }
 
 function shouldApplyOpenAIReasoningCompatibility(model: {
@@ -703,11 +725,12 @@ export function createCodexNativeWebSearchWrapper(
     // provider-family wrapper stays aligned for the same request.
     const codeModeSurfaceFromOptions =
       (options as OpenClawSimpleStreamOptions | undefined)?.openclawCodeModeToolSurface === true;
+    const codeModeVisibleToolNames = resolveCodeModeVisibleToolNames(context);
     if (
       (params.codeModeToolSurfaceEnabled === true ||
         codeModeSurfaceFromOptions ||
         isCodeModeEnabled(params.config)) &&
-      hasCodeModeVisibleTools(context)
+      codeModeVisibleToolNames
     ) {
       emitModelTransportDebug(
         log,
@@ -720,14 +743,14 @@ export function createCodexNativeWebSearchWrapper(
         ...options,
         openclawCodeModeToolSurface: true,
         onPayload: (payload) => {
-          filterCodeModePayloadTools(payload);
+          filterCodeModePayloadTools(payload, codeModeVisibleToolNames);
           const nextPayload = originalOnPayload?.(payload, model);
           if (isPromiseLike(nextPayload)) {
             return Promise.resolve(nextPayload).then((resolvedPayload) =>
-              filterCodeModePayloadHookResult(payload, resolvedPayload),
+              filterCodeModePayloadHookResult(payload, resolvedPayload, codeModeVisibleToolNames),
             );
           }
-          return filterCodeModePayloadHookResult(payload, nextPayload);
+          return filterCodeModePayloadHookResult(payload, nextPayload, codeModeVisibleToolNames);
         },
       };
       return underlying(model, context, codeModeOptions);

--- a/test/scripts/docker-e2e-plan.test.ts
+++ b/test/scripts/docker-e2e-plan.test.ts
@@ -248,6 +248,28 @@ describe("scripts/lib/docker-e2e-plan", () => {
     expect(plan.lanes.map((lane) => lane.name)).not.toContain("openwebui");
   });
 
+  it("includes deterministic packaged MCP code-mode proof in the unfiltered release core", () => {
+    const plan = planFor({
+      profile: RELEASE_PATH_PROFILE,
+      releaseChunk: "core",
+    });
+    const codeModeLanes = plan.lanes.filter((lane) => lane.name === "mcp-code-mode-gateway");
+
+    expect(plan.selectedLanes).toEqual([]);
+    expect(codeModeLanes.map(summarizeLane)).toEqual([
+      {
+        command: "OPENCLAW_SKIP_DOCKER_BUILD=1 pnpm test:docker:mcp-code-mode-gateway",
+        imageKind: "functional",
+        live: false,
+        name: "mcp-code-mode-gateway",
+        resources: ["docker", "service", "npm"],
+        stateScenario: "empty",
+        weight: 3,
+      },
+    ]);
+    expect(plan.lanes.map((lane) => lane.name)).not.toContain("live-mcp-code-mode-gateway");
+  });
+
   it("plans Open WebUI only when release-path coverage requests it", () => {
     const withoutOpenWebUI = planFor({
       includeOpenWebUI: false,

--- a/test/scripts/mcp-code-mode-gateway-client.test.ts
+++ b/test/scripts/mcp-code-mode-gateway-client.test.ts
@@ -1,6 +1,9 @@
 // Mcp Code Mode Gateway Client tests cover mcp code mode gateway client script behavior.
 import { describe, expect, it } from "vitest";
-import { validateMcpCodeModeResult } from "../../scripts/e2e/lib/mcp-code-mode-validation.ts";
+import {
+  extractMcpCodeModePlannedTools,
+  validateMcpCodeModeResult,
+} from "../../scripts/e2e/lib/mcp-code-mode-validation.ts";
 import {
   fetchJson,
   readMcpCodeModeClientFetchLimits,
@@ -179,5 +182,66 @@ describe("MCP code-mode gateway Docker client result validation", () => {
         requireExec: true,
       }),
     ).not.toThrow();
+  });
+
+  it("rejects success and exec mentions without a real assistant tool call", () => {
+    const plannedTools = extractMcpCodeModePlannedTools([
+      {
+        type: "message",
+        message: {
+          role: "user",
+          content: [{ type: "toolCall", name: "exec" }],
+        },
+      },
+      {
+        type: "message",
+        message: {
+          role: "assistant",
+          content: [
+            {
+              type: "text",
+              text: "I called exec, API.list, API.read, and MCP.fixture.lookupNote.",
+            },
+          ],
+        },
+      },
+    ]);
+
+    expect(plannedTools).toEqual([]);
+    expect(() =>
+      validateMcpCodeModeResult(okResponse, okMentions, {
+        plannedTools,
+        requireExec: true,
+      }),
+    ).toThrow("agent did not call code-mode exec");
+  });
+
+  it("accepts success backed by a structured assistant exec tool call", () => {
+    const plannedTools = extractMcpCodeModePlannedTools([
+      {
+        type: "message",
+        message: {
+          role: "assistant",
+          content: [
+            {
+              type: "toolCall",
+              id: "mcp-code-mode-exec",
+              name: "exec",
+              arguments: {
+                language: "javascript",
+                code: 'return await MCP.fixture.lookupNote({ id: "alpha" });',
+              },
+            },
+          ],
+        },
+      },
+    ]);
+
+    expect(plannedTools).toEqual(["exec"]);
+    const result = validateMcpCodeModeResult(okResponse, okMentions, {
+      plannedTools,
+      requireExec: true,
+    });
+    expect(result).toBe("MCP_CODE_MODE_FILE_OK note=fixture-note-alpha unclear=none");
   });
 });


### PR DESCRIPTION
## What Problem This Solves

Fixes Code Mode runs that could retain all suspended execution slots after Gateway shutdown, leak process-global tool catalogs when preparation fails, lose cancellation for node-backed MCP calls, or silently strip legitimate direct-only tools from OpenAI and Copilot requests. Also fixes release validation that omitted the real packaged Code Mode gateway and accepted assistant text without proving execution.

Related: #115213, #115314.

## Why This Change Was Made

Keeps run disposal and catalog cleanup at their canonical owners, forwards the existing caller signal to node invocations, derives the transport allowlist solely from each request-visible tool context, and reuses the existing deterministic packaged MCP gateway smoke in the release core. Product proof reads structured assistant tool calls through the existing session-store and session-transcript SDKs; no new config, protocol, storage, schema, or compatibility surface.

## User Impact

Gateway restarts free all suspended Code Mode slots and outstanding work. Direct-only tools such as sessions_yield and structured_output remain available without exposing undeclared tools. Node calls respect cancellation. Release checks prove real packaged gateway execution and reject fabricated transcript evidence.

## Evidence

- Twelve independent frozen-main subsystem audits and direct upstream Codex contract inspection.
- 967 passing Linux tests across six shards, including real worker isolation, 64-slot shutdown, deadline/cancellation, restart cleanup, both provider transports, node-backed MCP, and three failing-preparation catalog modes.
- 130,000 adversarial parser, division, regular-expression, loader, and Unicode cases.
- Full remote pnpm check:changed passed all production/test/script type checks, lint, SDK/export boundaries, package guards, and database-first checks.
- Full pnpm build passed, including all 146 public Plugin SDK subpaths.
- Fresh package passed tarball integrity and dist import-graph verification.
- Real release-path mcp-code-mode-gateway Docker lane passed against the freshly built package, gateway, local mock provider, actual MCP fixture, and persisted structured exec evidence.
- Fresh Codex autoreview: clean, no accepted or actionable findings.

AI-assisted and independently reviewed.