### PR TITLE
fix(ui): order model picker by provider strength

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ Docs: https://docs.openclaw.ai
 
 - **Dev-channel updates:** finish package-to-git switches in a fresh CLI process even when source SHA and version metadata are unchanged, preventing stale hashed chunks from loading after the global package root changes.
 - **Parallels release smoke:** preserve Windows installer reboot results across Parallels, wait for WSL MSI/default-version readiness, force explicit test-owned gateway stops, and reset Linux package, config, and cache state before install lanes, preventing false prerequisite, safety-gate, and stale-config failures.
+- **Control UI model picker:** preserve provider-owned strongest-first model ordering, unify Moonshot aliases under one provider, widen the model column, and show context size inline without redundant row tooltips.
 - **OpenAI Realtime Talk auth:** remove the non-public Codex OAuth realtime fallback and require an OpenAI Platform API key for Talk, Voice Call, and Discord realtime voice, preventing OAuth-only gateways from advertising a browser session that the live service rejects. Fixes #115021.
 - **Codex native controls:** stop misclassifying valid thinking/fast runtime controls as provider overrides so Codex routes keep their native controls, while provider-native objects and invalid values stay fail-closed. Thanks @VACInc. (#107588)
 - **State snapshot verification:** run SQLite snapshot verification in a separate process so worker-thread file closes no longer drop the Gateway's POSIX WAL locks, eliminating spurious WAL misses and I/O errors. Thanks @VACInc. (#114016)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,7 +53,6 @@ Docs: https://docs.openclaw.ai
 
 - **Dev-channel updates:** finish package-to-git switches in a fresh CLI process even when source SHA and version metadata are unchanged, preventing stale hashed chunks from loading after the global package root changes.
 - **Parallels release smoke:** preserve Windows installer reboot results across Parallels, wait for WSL MSI/default-version readiness, force explicit test-owned gateway stops, and reset Linux package, config, and cache state before install lanes, preventing false prerequisite, safety-gate, and stale-config failures.
-- **Control UI model picker:** preserve provider-owned strongest-first model ordering, unify Moonshot aliases under one provider, widen the model column, and show context size inline without redundant row tooltips.
 - **OpenAI Realtime Talk auth:** remove the non-public Codex OAuth realtime fallback and require an OpenAI Platform API key for Talk, Voice Call, and Discord realtime voice, preventing OAuth-only gateways from advertising a browser session that the live service rejects. Fixes #115021.
 - **Codex native controls:** stop misclassifying valid thinking/fast runtime controls as provider overrides so Codex routes keep their native controls, while provider-native objects and invalid values stay fail-closed. Thanks @VACInc. (#107588)
 - **State snapshot verification:** run SQLite snapshot verification in a separate process so worker-thread file closes no longer drop the Gateway's POSIX WAL locks, eliminating spurious WAL misses and I/O errors. Thanks @VACInc. (#114016)

--- a/src/agents/model-catalog-order.ts
+++ b/src/agents/model-catalog-order.ts
@@ -26,5 +26,5 @@ export function compareModelCatalogEntries(a: ModelCatalogEntry, b: ModelCatalog
   }
   const orderComparison =
     (a.providerOrder ?? Number.MAX_SAFE_INTEGER) - (b.providerOrder ?? Number.MAX_SAFE_INTEGER);
-  return orderComparison || a.name.localeCompare(b.name) || a.id.localeCompare(b.id);
+  return orderComparison || a.id.localeCompare(b.id) || a.name.localeCompare(b.name);
 }

--- a/src/agents/model-catalog-order.ts
+++ b/src/agents/model-catalog-order.ts
@@ -1,0 +1,30 @@
+import { normalizeProviderId } from "@openclaw/model-catalog-core/provider-id";
+import type { ModelCatalogEntry } from "./model-catalog.types.js";
+
+/**
+ * Provider catalogs declare models strongest-first. Preserve that owner order
+ * after registry/config merges instead of falling back to alphabetical names.
+ */
+export function assignProviderModelOrder(
+  entries: readonly ModelCatalogEntry[],
+): ModelCatalogEntry[] {
+  const nextOrderByProvider = new Map<string, number>();
+  return entries.map((entry) => {
+    const provider = normalizeProviderId(entry.provider);
+    const providerOrder = nextOrderByProvider.get(provider) ?? 0;
+    nextOrderByProvider.set(provider, providerOrder + 1);
+    return { ...entry, providerOrder };
+  });
+}
+
+export function compareModelCatalogEntries(a: ModelCatalogEntry, b: ModelCatalogEntry): number {
+  const providerComparison = normalizeProviderId(a.provider).localeCompare(
+    normalizeProviderId(b.provider),
+  );
+  if (providerComparison !== 0) {
+    return providerComparison;
+  }
+  const orderComparison =
+    (a.providerOrder ?? Number.MAX_SAFE_INTEGER) - (b.providerOrder ?? Number.MAX_SAFE_INTEGER);
+  return orderComparison || a.name.localeCompare(b.name) || a.id.localeCompare(b.id);
+}

--- a/src/agents/model-catalog-visibility.test.ts
+++ b/src/agents/model-catalog-visibility.test.ts
@@ -87,6 +87,31 @@ describe("resolveLogicalVisibleModelCatalog", () => {
     expect(result.map((entry) => entry.id)).toEqual(["off", "old"]);
   });
 
+  it("preserves provider-owned strongest-first order", async () => {
+    const catalog: ModelCatalogEntry[] = [
+      { provider: "openai", id: "gpt-5.4", name: "GPT-5.4", providerOrder: 3 },
+      { provider: "openai", id: "gpt-5.6-luna", name: "GPT-5.6 Luna", providerOrder: 2 },
+      { provider: "openai", id: "gpt-5.6-sol", name: "GPT-5.6 Sol", providerOrder: 0 },
+      { provider: "openai", id: "gpt-5.6-terra", name: "GPT-5.6 Terra", providerOrder: 1 },
+    ];
+
+    const result = await resolveLogicalVisibleModelCatalog({
+      cfg: {} as OpenClawConfig,
+      catalog,
+      defaultProvider: "openai",
+      view: "all",
+      routePolicy: openAIModelCatalogRoutePolicy,
+      evaluateEntry: evaluateAvailableEntry,
+    });
+
+    expect(result.map((entry) => entry.id)).toEqual([
+      "gpt-5.6-sol",
+      "gpt-5.6-terra",
+      "gpt-5.6-luna",
+      "gpt-5.4",
+    ]);
+  });
+
   it("keeps deprecated configured primary and alias-key rows visible", async () => {
     const catalog: ModelCatalogEntry[] = [
       { provider: "demo", id: "primary", name: "Primary", status: "deprecated" },

--- a/src/agents/model-catalog-visibility.ts
+++ b/src/agents/model-catalog-visibility.ts
@@ -8,6 +8,7 @@ import type {
   ModelAuthAvailabilityEvaluation,
   ModelAuthAvailabilityRef,
 } from "./model-auth-availability.js";
+import { compareModelCatalogEntries } from "./model-catalog-order.js";
 import {
   type ModelCatalogRoutePolicy,
   type ModelCatalogRouteProjection,
@@ -77,9 +78,7 @@ async function modelCatalogEntryHasProviderAuth(
 }
 
 function sortModelCatalogEntries(entries: ModelCatalogEntry[]): ModelCatalogEntry[] {
-  return entries.toSorted(
-    (a, b) => a.provider.localeCompare(b.provider) || a.id.localeCompare(b.id),
-  );
+  return entries.toSorted(compareModelCatalogEntries);
 }
 
 function resolveLogicalKey(

--- a/src/agents/model-catalog.test.ts
+++ b/src/agents/model-catalog.test.ts
@@ -27,18 +27,25 @@ vi.mock("../plugins/provider-runtime.runtime.js", () => ({
   ) => mocks.augmentModelCatalogWithProviderPlugins(...args),
 }));
 
-const metadataSnapshot = { plugins: [] } as unknown as PluginMetadataSnapshot;
+const metadataSnapshot = {
+  plugins: [],
+  manifestRegistry: { plugins: [] },
+} as unknown as PluginMetadataSnapshot;
 
 function providerManifestSnapshot(params: {
   provider: string;
   discovery: "static" | "refreshable" | "runtime";
   modelIds: string[];
+  aliases?: string[];
 }): PluginMetadataSnapshot {
   const plugin = {
     id: params.provider,
     origin: "bundled",
     providers: [params.provider],
     modelCatalog: {
+      aliases: Object.fromEntries(
+        (params.aliases ?? []).map((alias) => [alias, { provider: params.provider }]),
+      ),
       providers: {
         [params.provider]: {
           api: "openai-responses",
@@ -146,6 +153,26 @@ describe("prepared model catalog builder", () => {
     ]);
   });
 
+  it("canonicalizes manifest-owned provider aliases in registry rows", async () => {
+    const snapshot = await build({
+      entries: [
+        { id: "kimi-k3", name: "Kimi K3", provider: "moonshotai" },
+        { id: "kimi-k2.7-code", name: "Kimi K2.7 Code", provider: "moonshot-ai" },
+      ],
+      metadataSnapshot: providerManifestSnapshot({
+        provider: "moonshot",
+        aliases: ["moonshotai", "moonshot-ai"],
+        discovery: "static",
+        modelIds: ["kimi-k3", "kimi-k2.7-code"],
+      }),
+    });
+
+    expect(snapshot.entries.map((entry) => `${entry.provider}/${entry.id}`)).toEqual([
+      "moonshot/kimi-k3",
+      "moonshot/kimi-k2.7-code",
+    ]);
+  });
+
   it("does not augment an account with undiscovered runtime-provider models", async () => {
     mocks.augmentModelCatalogWithProviderPlugins.mockResolvedValueOnce([
       { id: "gpt-5.4", name: "GPT-5.4", provider: "openai" },
@@ -169,6 +196,37 @@ describe("prepared model catalog builder", () => {
     expect(snapshot.entries[0]?.contextWindow).toBe(128_000);
     expect(snapshot.routeVariants.map((entry) => `${entry.provider}/${entry.id}`)).toEqual([
       "openai/gpt-5.5",
+    ]);
+  });
+
+  it("keeps provider-owned strongest-first order after runtime augmentation", async () => {
+    mocks.augmentModelCatalogWithProviderPlugins.mockResolvedValueOnce([
+      { id: "gpt-5.6-sol", name: "GPT-5.6 Sol", provider: "openai" },
+      { id: "gpt-5.6-terra", name: "GPT-5.6 Terra", provider: "openai" },
+      { id: "gpt-5.6-luna", name: "GPT-5.6 Luna", provider: "openai" },
+      { id: "gpt-5.4", name: "GPT-5.4", provider: "openai" },
+    ]);
+
+    const snapshot = await build({
+      entries: [
+        { id: "gpt-5.4", name: "GPT-5.4", provider: "openai" },
+        { id: "gpt-5.6-luna", name: "GPT-5.6 Luna", provider: "openai" },
+        { id: "gpt-5.6-sol", name: "GPT-5.6 Sol", provider: "openai" },
+        { id: "gpt-5.6-terra", name: "GPT-5.6 Terra", provider: "openai" },
+      ],
+      metadataSnapshot: providerManifestSnapshot({
+        provider: "openai",
+        discovery: "runtime",
+        modelIds: ["gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna", "gpt-5.4"],
+      }),
+      readOnly: false,
+    });
+
+    expect(snapshot.entries.map((entry) => entry.id)).toEqual([
+      "gpt-5.6-sol",
+      "gpt-5.6-terra",
+      "gpt-5.6-luna",
+      "gpt-5.4",
     ]);
   });
 

--- a/src/agents/model-catalog.ts
+++ b/src/agents/model-catalog.ts
@@ -18,6 +18,7 @@ import type { PluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot
 import { augmentModelCatalogWithProviderPlugins } from "../plugins/provider-runtime.runtime.js";
 import { createLazyImportLoader } from "../shared/lazy-promise.js";
 import { modelSupportsInput as modelCatalogEntrySupportsInput } from "./model-catalog-lookup.js";
+import { assignProviderModelOrder, compareModelCatalogEntries } from "./model-catalog-order.js";
 import type {
   ModelCatalogEntry,
   ModelCatalogSnapshot,
@@ -215,6 +216,7 @@ function overlayCatalogMetadata(
     ...(overlay.input !== undefined ? { input: overlay.input } : {}),
     ...(params ? { params } : {}),
     ...(overlay.mediaInput !== undefined ? { mediaInput: overlay.mediaInput } : {}),
+    ...(overlay.providerOrder !== undefined ? { providerOrder: overlay.providerOrder } : {}),
     ...(overlay.status !== undefined ? { status: overlay.status } : {}),
     ...(overlay.statusReason !== undefined ? { statusReason: overlay.statusReason } : {}),
     ...(overlay.replaces !== undefined ? { replaces: overlay.replaces } : {}),
@@ -378,6 +380,19 @@ export function loadManifestModelCatalog(params: {
     },
     config: params.config,
   });
+  const providerOrderByKey = new Map<string, number>();
+  for (const plugin of resolveEligibleManifestCatalogPlugins(resolvedSnapshot, params.config)) {
+    for (const [provider, providerCatalog] of Object.entries(
+      plugin.modelCatalog?.providers ?? {},
+    )) {
+      providerCatalog.models.forEach((model, providerOrder) => {
+        const key = catalogEntryDedupeKey(provider, model.id);
+        if (!providerOrderByKey.has(key)) {
+          providerOrderByKey.set(key, providerOrder);
+        }
+      });
+    }
+  }
   const rows = plan.rows.map((row) => {
     const entry: ModelCatalogEntry = {
       id: row.id,
@@ -386,6 +401,10 @@ export function loadManifestModelCatalog(params: {
       api: row.api,
       status: row.status,
     };
+    const providerOrder = providerOrderByKey.get(catalogEntryDedupeKey(row.provider, row.id));
+    if (providerOrder !== undefined) {
+      entry.providerOrder = providerOrder;
+    }
     if (row.baseUrl) {
       entry.baseUrl = row.baseUrl;
     }
@@ -421,13 +440,7 @@ export function loadManifestModelCatalog(params: {
 }
 
 function sortModelCatalogEntries(entries: ModelCatalogEntry[]): ModelCatalogEntry[] {
-  return entries.map(normalizeCatalogEntryContract).toSorted((a, b) => {
-    const p = a.provider.localeCompare(b.provider);
-    if (p !== 0) {
-      return p;
-    }
-    return a.name.localeCompare(b.name);
-  });
+  return entries.map(normalizeCatalogEntryContract).toSorted(compareModelCatalogEntries);
 }
 
 /** Builds the catalog once for a lifecycle generation. No request-time discovery or cache IO. */
@@ -468,10 +481,14 @@ export async function buildPreparedModelCatalogSnapshot(
       if (!rawId) {
         continue;
       }
-      const provider = normalizeOptionalString(entry?.provider) ?? "";
-      if (!provider) {
+      const rawProvider = normalizeOptionalString(entry?.provider) ?? "";
+      if (!rawProvider) {
         continue;
       }
+      const provider = canonicalizePreparedModelCatalogProvider(
+        rawProvider,
+        manifestMetadataSnapshot,
+      );
       const id = normalizeConfiguredProviderCatalogModelId(provider, rawId, {
         manifestPlugins: getManifestPlugins(),
       });
@@ -594,25 +611,31 @@ export async function buildPreparedModelCatalogSnapshot(
         );
         const normalizedSupplemental: ModelCatalogEntry[] = [];
         for (const entry of supplemental) {
-          const id = normalizeConfiguredProviderCatalogModelId(entry.provider, entry.id, {
+          const provider = canonicalizePreparedModelCatalogProvider(
+            entry.provider,
+            manifestMetadataSnapshot,
+          );
+          const id = normalizeConfiguredProviderCatalogModelId(provider, entry.id, {
             manifestPlugins: getManifestPlugins(),
           });
           // Account-discovered providers own the visible model set. Synthetic
           // metadata can enrich an available or explicitly configured model,
           // but must never advertise a model the account did not discover.
           if (
-            runtimeDiscoveryProviders.has(normalizeProviderId(entry.provider)) &&
-            !accountVisibleModelKeys.has(catalogEntryDedupeKey(entry.provider, id))
+            runtimeDiscoveryProviders.has(normalizeProviderId(provider)) &&
+            !accountVisibleModelKeys.has(catalogEntryDedupeKey(provider, id))
           ) {
             continue;
           }
           normalizedSupplemental.push({
             ...entry,
+            provider,
             id,
           });
         }
-        mergeCatalogRouteVariants(routeVariants, normalizedSupplemental);
-        mergeCatalogEntries(models, normalizedSupplemental);
+        const orderedSupplemental = assignProviderModelOrder(normalizedSupplemental);
+        mergeCatalogRouteVariants(routeVariants, orderedSupplemental);
+        mergeCatalogEntries(models, orderedSupplemental);
       }
     }
     logStage("plugin-models-merged", `entries=${models.length}`);

--- a/src/agents/model-catalog.types.ts
+++ b/src/agents/model-catalog.types.ts
@@ -14,6 +14,8 @@ export type ModelCatalogEntry = {
   id: string;
   name: string;
   provider: string;
+  /** Provider-owned strongest-first picker order; internal and never projected to clients. */
+  providerOrder?: number;
   alias?: string;
   api?: ModelApi;
   /** Private transport provenance for route matching; never project directly to clients. */

--- a/ui/src/components/provider-icon.ts
+++ b/ui/src/components/provider-icon.ts
@@ -73,6 +73,7 @@ const PROVIDER_ICON_ALIASES: Readonly<Record<string, string>> = {
   "github-copilot": "copilot",
   // CodexBar names its bundled OpenAI knot asset "codex".
   openai: "codex",
+  moonshot: "kimi",
   "opencode-go": "opencodego",
   "opencode-zen": "opencode",
   xai: "grok",
@@ -86,6 +87,7 @@ const PROVIDER_DISPLAY_LABELS: Readonly<Record<string, string>> = {
   google: "Google",
   "github-copilot": "GitHub",
   openai: "OpenAI",
+  moonshot: "Moonshot AI",
   opencode: "OpenCode",
   openrouter: "OpenRouter",
 };

--- a/ui/src/pages/chat/chat-view.test.ts
+++ b/ui/src/pages/chat/chat-view.test.ts
@@ -4692,6 +4692,9 @@ describe("chat model controls", () => {
         { id: "sonnet", name: "OpenCode Sonnet", provider: "opencode" },
         { id: "kimi", name: "OpenCode Kimi", provider: "opencode-go" },
         { id: "glm", name: "OpenCode GLM", provider: "opencode-zen" },
+        { id: "kimi-k3", name: "Kimi K3", provider: "moonshot" },
+        { id: "kimi-k2.7", name: "Kimi K2.7", provider: "moonshot-ai" },
+        { id: "kimi-k2.6", name: "Kimi K2.6", provider: "moonshotai" },
       ],
     });
     const container = renderModelControls(state);
@@ -4700,7 +4703,7 @@ describe("chat model controls", () => {
       container.querySelectorAll<HTMLButtonElement>("[data-chat-model-provider]"),
     );
     const providerLabels = providerButtons.map((button) => button.textContent?.trim());
-    expect(providerLabels).toEqual(["OpenAI", "Google", "OpenCode"]);
+    expect(providerLabels).toEqual(["OpenAI", "Google", "OpenCode", "Moonshot AI"]);
     expect(new Set(providerLabels).size).toBe(providerLabels.length);
     expect(
       container.querySelector('[data-chat-model-provider-group="google"]')?.textContent,
@@ -4717,6 +4720,38 @@ describe("chat model controls", () => {
     ).toBeNull();
     expect(container.querySelector('[data-chat-model-provider-group="opencode-go"]')).toBeNull();
     expect(container.querySelector('[data-chat-model-provider-group="opencode-zen"]')).toBeNull();
+    const moonshotModels = container.querySelector(
+      '[data-chat-model-provider-group="moonshot"]',
+    )?.textContent;
+    expect(moonshotModels).toContain("Kimi K3");
+    expect(moonshotModels).toContain("Kimi K2.7");
+    expect(moonshotModels).toContain("Kimi K2.6");
+    expect(container.querySelector('[data-chat-model-provider-group="moonshot-ai"]')).toBeNull();
+    expect(container.querySelector('[data-chat-model-provider-group="moonshotai"]')).toBeNull();
+  });
+
+  it("shows model context size inline without a redundant tooltip", () => {
+    const { state } = createChatHeaderState({
+      model: "gpt-5.6-sol",
+      modelProvider: "openai",
+      models: [
+        {
+          id: "gpt-5.6-sol",
+          name: "GPT-5.6 Sol",
+          provider: "openai",
+          contextWindow: 1_050_000,
+        },
+      ],
+    });
+    const container = renderModelControls(state);
+    const modelOption = container.querySelector<HTMLButtonElement>(
+      '[data-chat-model-option="openai/gpt-5.6-sol"]',
+    );
+
+    expect(modelOption?.querySelector(".chat-controls__model-option-meta")?.textContent).toBe(
+      "1.1M context",
+    );
+    expect(modelOption?.closest("openclaw-tooltip")).toBeNull();
   });
 
   it("shows canonical OpenAI model names instead of command aliases", () => {

--- a/ui/src/pages/chat/components/chat-model-controls.ts
+++ b/ui/src/pages/chat/components/chat-model-controls.ts
@@ -26,6 +26,7 @@ import {
   formatThinkingOverrideLabel,
   resolveChatThinkingSelectState,
 } from "../../../lib/chat/thinking.ts";
+import { formatCompactTokenCount } from "../../../lib/format.ts";
 import { areUiSessionKeysEquivalent } from "../../../lib/sessions/session-key.ts";
 import { selectChatModelProvider } from "./chat-model-provider-menu.ts";
 
@@ -56,12 +57,15 @@ export type ChatModelControlsProps = {
 
 type ChatModelProviderOption = ChatModelSelectOption & {
   commitValue: string;
+  contextWindow?: number;
   isDefault: boolean;
   provider: string;
 };
 
 const CHAT_MODEL_PROVIDER_GROUP_ALIASES: Readonly<Record<string, string>> = {
   "google-gemini-cli": "google",
+  "moonshot-ai": "moonshot",
+  moonshotai: "moonshot",
   "opencode-go": "opencode",
   "opencode-zen": "opencode",
 };
@@ -111,11 +115,10 @@ function resolveChatModelProvider(
   return "other";
 }
 
-function resolveChatModelPickerLabel(
+function resolveChatModelCatalogEntry(
   value: string,
-  fallbackLabel: string,
   catalog: ModelCatalogEntry[],
-): string {
+): ModelCatalogEntry | undefined {
   const trimmedValue = value.trim().toLowerCase();
   const separator = trimmedValue.indexOf("/");
   const normalizedValue =
@@ -125,14 +128,23 @@ function resolveChatModelPickerLabel(
         )}`
       : trimmedValue;
   if (!normalizedValue) {
-    return fallbackLabel;
+    return undefined;
   }
   const matches = catalog.filter((candidate) => {
     const provider = normalizeChatModelProviderId(candidate.provider);
     return `${provider}/${candidate.id.trim().toLowerCase()}` === normalizedValue;
   });
-  const entry =
-    matches.find((candidate) => candidate.provider.trim().toLowerCase() === "openai") ?? matches[0];
+  return (
+    matches.find((candidate) => candidate.provider.trim().toLowerCase() === "openai") ?? matches[0]
+  );
+}
+
+function resolveChatModelPickerLabel(
+  value: string,
+  fallbackLabel: string,
+  catalog: ModelCatalogEntry[],
+): string {
+  const entry = resolveChatModelCatalogEntry(value, catalog);
   if (entry && normalizeChatModelProviderId(entry.provider) === "openai") {
     return entry.name.trim() || fallbackLabel;
   }
@@ -194,8 +206,10 @@ export function renderChatModelControls(props: ChatModelControlsProps) {
   const modelOptions: ChatModelProviderOption[] = selectOptions.map((option) => {
     const isDefault =
       defaultSelectable && option.value.trim().toLowerCase() === normalizedDefaultModel;
+    const catalogEntry = resolveChatModelCatalogEntry(option.value, props.modelCatalog);
     return {
       commitValue: isDefault ? "" : option.value,
+      ...(catalogEntry?.contextWindow ? { contextWindow: catalogEntry.contextWindow } : {}),
       isDefault,
       value: option.value,
       label: resolveChatModelPickerLabel(option.value, option.label, props.modelCatalog),
@@ -514,50 +528,51 @@ function renderChatModelReasoningSelect(params: {
     const selected =
       entry.value === selectedModelValue || (entry.isDefault && selectedModelValue === "");
     const modelLabel = formatCombinedPickerModelOptionLabel(entry);
+    const contextLabel = entry.contextWindow
+      ? `${formatCompactTokenCount(entry.contextWindow)} context`
+      : "";
     return html`
       <div class="chat-controls__combined-model">
-        <openclaw-tooltip .content=${entry.label}>
-          <button
-            class="chat-controls__inline-select-option chat-controls__combined-model-option ${selected
-              ? "chat-controls__inline-select-option--selected"
-              : ""}"
-            data-chat-model-option=${entry.value}
-            data-chat-model-default=${entry.isDefault ? "true" : nothing}
-            role="option"
-            aria-selected=${selected ? "true" : "false"}
-            type="button"
-            ?disabled=${disabled || modelSelectionLocked}
-            @click=${(event: MouseEvent) => {
-              event.stopPropagation();
-              if (disabled || modelSelectionLocked || entry.commitValue === selectedModelValue) {
-                event.preventDefault();
-                return;
-              }
-              commitModel(entry.commitValue);
-            }}
-          >
-            <span class="chat-controls__model-option-copy">
-              <span class="chat-controls__model-option-title">
-                <span class="chat-controls__model-option-name">${modelLabel}</span>
-                ${entry.isDefault
-                  ? html`<span class="chat-controls__model-default-label"
-                      >${t("chat.modelControls.default")}</span
-                    >`
-                  : ""}
-              </span>
-              <span class="chat-controls__model-option-provider">
-                ${providerDisplayLabel(entry.provider)}
-              </span>
+        <button
+          class="chat-controls__inline-select-option chat-controls__combined-model-option ${selected
+            ? "chat-controls__inline-select-option--selected"
+            : ""}"
+          data-chat-model-option=${entry.value}
+          data-chat-model-default=${entry.isDefault ? "true" : nothing}
+          role="option"
+          aria-selected=${selected ? "true" : "false"}
+          type="button"
+          ?disabled=${disabled || modelSelectionLocked}
+          @click=${(event: MouseEvent) => {
+            event.stopPropagation();
+            if (disabled || modelSelectionLocked || entry.commitValue === selectedModelValue) {
+              event.preventDefault();
+              return;
+            }
+            commitModel(entry.commitValue);
+          }}
+        >
+          <span class="chat-controls__model-option-copy">
+            <span class="chat-controls__model-option-title">
+              <span class="chat-controls__model-option-name">${modelLabel}</span>
+              ${entry.isDefault
+                ? html`<span class="chat-controls__model-default-label"
+                    >${t("chat.modelControls.default")}</span
+                  >`
+                : ""}
             </span>
-            ${selected
-              ? html`
-                  <span class="chat-controls__inline-select-check" aria-hidden="true">
-                    ${icons.check}
-                  </span>
-                `
+            ${contextLabel
+              ? html`<span class="chat-controls__model-option-meta">${contextLabel}</span>`
               : ""}
-          </button>
-        </openclaw-tooltip>
+          </span>
+          ${selected
+            ? html`
+                <span class="chat-controls__inline-select-check" aria-hidden="true">
+                  ${icons.check}
+                </span>
+              `
+            : ""}
+        </button>
       </div>
     `;
   };

--- a/ui/src/styles/chat/layout.css
+++ b/ui/src/styles/chat/layout.css
@@ -3928,7 +3928,7 @@ openclaw-chat-page {
   display: flex;
   flex-direction: column;
   gap: 0;
-  width: min(392px, calc(100vw - 24px));
+  width: min(448px, calc(100vw - 24px));
   max-height: min(440px, calc(100vh - 96px));
   padding: 0;
   overflow: hidden;
@@ -3936,7 +3936,7 @@ openclaw-chat-page {
 
 .chat-controls__model-browser {
   display: grid;
-  grid-template-columns: 120px minmax(0, 1fr);
+  grid-template-columns: 112px minmax(0, 1fr);
   min-height: 132px;
   max-height: 220px;
   flex: 1 1 220px;
@@ -4076,7 +4076,7 @@ openclaw-chat-page {
 }
 
 .chat-controls__model-option-title,
-.chat-controls__model-option-provider {
+.chat-controls__model-option-meta {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -4118,7 +4118,7 @@ openclaw-chat-page {
   content: "";
 }
 
-.chat-controls__model-option-provider {
+.chat-controls__model-option-meta {
   color: var(--muted);
   font-size: 11px;
   font-weight: 450;

--- a/ui/src/styles/chat/layout.css
+++ b/ui/src/styles/chat/layout.css
@@ -3928,7 +3928,7 @@ openclaw-chat-page {
   display: flex;
   flex-direction: column;
   gap: 0;
-  width: min(448px, calc(100vw - 24px));
+  width: min(464px, calc(100vw - 24px));
   max-height: min(440px, calc(100vh - 96px));
   padding: 0;
   overflow: hidden;
@@ -3936,7 +3936,7 @@ openclaw-chat-page {
 
 .chat-controls__model-browser {
   display: grid;
-  grid-template-columns: 112px minmax(0, 1fr);
+  grid-template-columns: 128px minmax(0, 1fr);
   min-height: 132px;
   max-height: 220px;
   flex: 1 1 220px;


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the Control UI model picker alphabetized models inside each provider, placing newer and stronger models below older entries. The same picker could also expose Moonshot aliases as separate providers, squeeze model names into a narrow column, and hide context size behind no useful inline metadata.

## Why This Change Was Made

Provider catalogs now carry their declared strongest-first order through registry, manifest, and runtime-discovery merges, while manifest-owned provider aliases are canonicalized before deduplication. The picker keeps a defensive grouping for supported aliases, uses one Moonshot AI identity, widens the model pane, removes redundant row tooltips, and shows context size inline.

## User Impact

Users see the strongest/current models first for each provider. OpenAI shows Sol, Terra, and Luna in provider-owned order; Moonshot aliases collapse into one Moonshot AI section; and each model row exposes its context size directly.

## Evidence

- Blacksmith Testbox `tbx_01kymzhdsh4t82btf2xc0tbbwx`: `pnpm check:changed` passed on the current patch (core/UI typecheck, lint, dead-code, i18n, and architecture guards).
- Focused Vitest: 17 catalog-builder tests, 11 visibility tests, and 206 Control UI picker tests passed.
- Exact ordering regression rerun: 25 `models.list` tests plus the 17 catalog-builder and 11 visibility tests passed on https://github.com/openclaw/openclaw/actions/runs/30392297274.
- Browser-layout E2E: all 6 `chat-composer-redesign.e2e.test.ts` scenarios passed, including mobile picker bounds.
- Testbox hydration/run: https://github.com/openclaw/openclaw/actions/runs/30387299289
- Codex autoreview on the rebased branch: clean, no accepted/actionable findings.

### Before

<img width="848" height="716" alt="Model picker before: duplicated Moonshot providers and alphabetical OpenAI models" src="https://github.com/user-attachments/assets/1fc88550-94fd-4bfb-b86f-804451e81aa0" />

### After

<img width="992" height="716" alt="Model picker after: unified Moonshot AI, strongest-first models, and inline context" src="https://github.com/user-attachments/assets/1aa91112-9299-403e-92de-e8d114db909e" />
