### PR TITLE
Message: adopt a channel id passed as `channel` as the target

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
-- **Message tool channel/target confusion:** document that `channel` selects the provider and adopt a channel id passed there as the destination when no target is given and there is no current conversation, instead of failing with "Action read requires a target."
+- **Message tool channel/target confusion:** document that `channel` selects the provider and adopt a channel id passed there as the destination when no target is given and there is no current conversation, instead of failing with "Action read requires a target." (#115381)
 - **Control UI cloud workspace conflicts:** surface staged-ref guidance, bounded conflicted paths, structured transcript events, and sidebar attention for cloud worker results that kept local versions.
 - **Control UI update recovery:** the "A new version is available" Reload button now waits out the gateway restart that stranded the chunk and reloads as soon as it answers, instead of silently doing nothing and leaving a manual hard reload as the only way out.
 - **Control UI sender identity polish:** attributed user messages show the author's real avatar in an always-visible gutter on identity-resolving gateways, sender labels drop the opaque profile-UUID suffix (new and historical transcripts), and profile-id senders resolve avatars through the canonical gateway route.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
+- **Message tool channel/target confusion:** document that `channel` selects the provider and adopt a channel id passed there as the destination when no target is given and there is no current conversation, instead of failing with "Action read requires a target."
 - **Control UI cloud workspace conflicts:** surface staged-ref guidance, bounded conflicted paths, structured transcript events, and sidebar attention for cloud worker results that kept local versions.
 - **Control UI update recovery:** the "A new version is available" Reload button now waits out the gateway restart that stranded the chunk and reloads as soon as it answers, instead of silently doing nothing and leaving a manual hard reload as the only way out.
 - **Control UI sender identity polish:** attributed user messages show the author's real avatar in an always-visible gutter on identity-resolving gateways, sender labels drop the opaque profile-UUID suffix (new and historical transcripts), and profile-id senders resolve avatars through the canonical gateway route.

--- a/src/agents/tools/message-tool.ts
+++ b/src/agents/tools/message-tool.ts
@@ -558,7 +558,12 @@ function hasSanitizedSendPayloadContent(params: Record<string, unknown>): boolea
 
 function buildRoutingSchema() {
   return {
-    channel: Type.Optional(Type.String()),
+    channel: Type.Optional(
+      Type.String({
+        description:
+          "Messaging provider to route through (slack, discord, telegram, signal, imessage, ...). Defaults to the current conversation's provider. This is not a destination: put channel/user ids in `target`.",
+      }),
+    ),
     target: Type.Optional(channelTargetSchema()),
     targets: Type.Optional(channelTargetsSchema()),
     accountId: Type.Optional(Type.String()),

--- a/src/infra/outbound/message-action-runner.send-validation.test.ts
+++ b/src/infra/outbound/message-action-runner.send-validation.test.ts
@@ -307,6 +307,60 @@ describe("runMessageAction send validation", () => {
     ).rejects.toThrow(/requires a target/i);
   });
 
+  it("adopts a channel id passed as channel when no target is given", async () => {
+    const result = await runMessageAction({
+      cfg: workspaceConfig,
+      action: "send",
+      params: {
+        channel: "C12345678",
+        message: "hello from codex",
+      },
+      sessionKey: "agent:main",
+      sourceReplyDeliveryMode: "message_tool_only",
+      dryRun: true,
+    });
+
+    expect(result).toMatchObject({
+      kind: "send",
+      channel: "workspace",
+      to: "C12345678",
+      handledBy: "core",
+      dryRun: true,
+    });
+  });
+
+  it("keeps a provider name in channel instead of adopting it as a target", async () => {
+    await expect(
+      runMessageAction({
+        cfg: workspaceConfig,
+        action: "send",
+        params: {
+          channel: "workspace",
+          message: "hello from codex",
+        },
+        sessionKey: "agent:main",
+        sourceReplyDeliveryMode: "message_tool_only",
+      }),
+    ).rejects.toThrow(/requires a target/i);
+  });
+
+  it("does not adopt channel as target when an explicit target is present", async () => {
+    await expect(
+      runMessageAction({
+        cfg: workspaceConfig,
+        action: "send",
+        params: {
+          channel: "C99999999",
+          target: "#C12345678",
+          message: "hello from codex",
+        },
+        sessionKey: "agent:main",
+        sourceReplyDeliveryMode: "message_tool_only",
+        dryRun: true,
+      }),
+    ).rejects.toThrow(/unknown channel/i);
+  });
+
   it("keeps explicit message routes on the normal outbound path", async () => {
     const result = await runMessageAction({
       cfg: workspaceConfig,

--- a/src/infra/outbound/message-action-runner.ts
+++ b/src/infra/outbound/message-action-runner.ts
@@ -61,6 +61,7 @@ import { stripFormattedReasoningMessage } from "../../shared/text/formatted-reas
 import { parseInlineDirectives } from "../../utils/directive-tags.js";
 import {
   INTERNAL_MESSAGE_CHANNEL,
+  resolveGatewayMessageChannel,
   type GatewayClientMode,
   type GatewayClientName,
 } from "../../utils/message-channel.js";
@@ -792,6 +793,41 @@ function hasExplicitTargetParam(params: Record<string, unknown>): boolean {
     (Array.isArray(params.targets) &&
       params.targets.some((value) => normalizeOptionalString(value)))
   );
+}
+
+// `channel` selects the provider ("slack"), never the destination, but callers
+// routinely pass a channel id there and omit `target`, which fails as "requires
+// a target". Provider ids are lowercase words, so a value carrying digits or
+// separators is unambiguously a destination and can be adopted as the target.
+// Provider-shaped values are left alone so an unregistered plugin channel still
+// reports "Unknown channel" rather than being read as a destination.
+const PROVIDER_SHAPED_VALUE = /^[a-z][a-z-]*$/;
+
+function adoptChannelParamAsTarget(
+  input: RunMessageActionParams,
+  params: Record<string, unknown>,
+): void {
+  const action = input.action;
+  if (!actionRequiresTarget(action)) {
+    return;
+  }
+  // Only when the runner has no conversation of its own to fall back on, so
+  // context-bearing calls keep their existing errors and stay context-isolated.
+  if (
+    normalizeOptionalString(input.toolContext?.currentChannelId) ||
+    normalizeOptionalString(input.toolContext?.currentMessagingTarget)
+  ) {
+    return;
+  }
+  const raw = normalizeOptionalString(params.channel);
+  if (!raw || hasExplicitTargetParam(params)) {
+    return;
+  }
+  if (resolveGatewayMessageChannel(raw) || PROVIDER_SHAPED_VALUE.test(raw.toLowerCase())) {
+    return;
+  }
+  params.target = raw;
+  delete params.channel;
 }
 
 function hasPotentialActionTargetInput(
@@ -1927,6 +1963,7 @@ export async function runMessageAction(
     return handleInternalSourceReplySendAction({ ...input, agentId: resolvedAgentId }, params);
   }
   applyImplicitSourceReplySendPolicy(input, params);
+  adoptChannelParamAsTarget(input, params);
   // Missing targets must fail before channel discovery, which can bootstrap or
   // probe configured plugins. Non-standard params may still be owner aliases.
   if (actionRequiresTarget(action) && !hasPotentialActionTargetInput(input, params)) {


### PR DESCRIPTION
## Summary

The `message` tool's `channel` param selects the **provider** (`slack`, `discord`, ...), but it was declared as a bare `Type.String()` with no description. Callers routinely read it as the destination, pass a channel id, and omit `target` — which fails with `Action read requires a target.` even though the destination was right there.

This does two things:

- Describes `channel` in the tool schema so the distinction from `target` is visible to models and humans.
- Adopts a clearly destination-shaped `channel` value as the target when the runner has no conversation of its own to fall back on.

The coercion is deliberately narrow. It is skipped when:

- the call already carries a `target`/`to`/`channelId` or a `targets` array,
- a current conversation exists (`currentChannelId` / `currentMessagingTarget`), so context-bearing calls keep their existing errors,
- the value resolves to a real provider, or is provider-shaped (`^[a-z][a-z-]*$`), so an unregistered plugin channel still reports `Unknown channel` instead of being silently read as a destination.

That last two points keep the context-isolation guarantees intact: the existing `message-action-runner.context.test.ts` case that rejects a delegated read carrying `channel: "C_TARGET"` still rejects with the same error, and still never reaches plugin dispatch.

## Test plan

- [x] `vitest run src/infra/outbound/message-action-runner.*.test.ts` — 221 passed, including the untouched context-isolation suite
- [x] Three new cases in `message-action-runner.send-validation.test.ts`: coercion routes to the id (`to: "C12345678"`), a provider name is not adopted, an explicit target wins
- [x] `pnpm tsgo` clean
- [x] `oxlint` clean on changed files

Made with [Cursor](https://cursor.com)