### PR TITLE
perf(sessions): single-pass list pipeline without redundant store materializations

### DIFF
--- a/src/config/sessions/combined-store-gateway.ts
+++ b/src/config/sessions/combined-store-gateway.ts
@@ -45,32 +45,17 @@ function resolveCombinedStorePath(paths: string[], storeConfig?: string): string
 
 function loadGatewayStoreEntries(params: {
   agentId: string;
+  includeOpenDatabases?: boolean;
   projection: GatewaySessionEntryProjection;
   storePath: string;
-}): Record<string, SessionEntry> {
-  return Object.fromEntries(
-    listSessionEntriesReadOnly({
-      agentId: params.agentId,
-      clone: false,
-      projection: params.projection,
-      storePath: params.storePath,
-    }).map(({ sessionKey, entry }) => [sessionKey, entry]),
-  );
-}
-
-function loadIncognitoGatewayStoreEntries(params: {
-  agentId: string;
-  projection: GatewaySessionEntryProjection;
-  storePath: string;
-}): Record<string, SessionEntry> {
-  return Object.fromEntries(
-    listSessionEntries({
-      agentId: params.agentId,
-      clone: false,
-      projection: params.projection,
-      storePath: params.storePath,
-    }).map(({ sessionKey, entry }) => [sessionKey, entry]),
-  );
+}) {
+  const listEntries = params.includeOpenDatabases ? listSessionEntries : listSessionEntriesReadOnly;
+  return listEntries({
+    agentId: params.agentId,
+    clone: false,
+    projection: params.projection,
+    storePath: params.storePath,
+  });
 }
 
 function mergeSessionEntryIntoCombined(params: {
@@ -129,13 +114,14 @@ function mergeOpenIncognitoStores(params: {
     if (params.agentId && target.agentId !== params.agentId) {
       continue;
     }
-    const store = loadIncognitoGatewayStoreEntries({
+    const store = loadGatewayStoreEntries({
       agentId: target.agentId,
+      includeOpenDatabases: true,
       projection: params.projection,
       storePath: target.storePath,
     });
     let merged = false;
-    for (const [sessionKey, entry] of Object.entries(store)) {
+    for (const { sessionKey, entry } of store) {
       if (!isIncognitoSessionKey(sessionKey) || entry.incognito !== true) {
         continue;
       }
@@ -213,7 +199,7 @@ export function loadCombinedSessionStoreForGateway(
     );
     for (const { agentId, storePath } of ownerTargets) {
       const store = loadGatewayStoreEntries({ agentId, projection, storePath });
-      for (const [key, entry] of Object.entries(store)) {
+      for (const { sessionKey: key, entry } of store) {
         const canonicalKey = resolveStoredSessionKeyForAgentStore({
           cfg,
           agentId,
@@ -264,7 +250,7 @@ export function loadCombinedSessionStoreForGateway(
     const agentId = target.agentId;
     const storePath = target.storePath;
     const store = loadGatewayStoreEntries({ agentId, projection, storePath });
-    for (const [key, entry] of Object.entries(store)) {
+    for (const { sessionKey: key, entry } of store) {
       const canonicalKey = resolveStoredSessionKeyForAgentStore({
         cfg,
         agentId,

--- a/src/gateway/server-methods/sessions-read.ts
+++ b/src/gateway/server-methods/sessions-read.ts
@@ -37,7 +37,7 @@ import {
 import { resolveRequestedSessionAgentId as resolveRequestedGlobalAgentId } from "../session-create-service.js";
 import {
   canAccessIncognitoSession,
-  filterDraftSessionsForClient,
+  createSessionListEntryFilter,
   isGatewayAdmin,
   resolveSessionSharingRole,
   resolveSessionSharingTarget,
@@ -251,15 +251,10 @@ export const sessionReadHandlers: GatewayRequestHandlers = {
             },
           },
         );
-        const visibleStore = filterDraftSessionsForClient({ client, store });
+        const entryFilter = createSessionListEntryFilter({ client });
         const listStore = configuredAgentsOnly
-          ? filterSessionStoreToConfiguredAgents(cfg, visibleStore)
-          : visibleStore;
-        const visibleStorePath = Object.entries(listStore).some(
-          ([sessionKey, entry]) => entry.incognito === true || isIncognitoSessionKey(sessionKey),
-        )
-          ? storePath
-          : (durableStorePath ?? storePath);
+          ? filterSessionStoreToConfiguredAgents(cfg, store)
+          : store;
         const modelCatalog = await measureDiagnosticsTimelineSpan(
           "gateway.sessions.list.model_catalog",
           () =>
@@ -278,7 +273,9 @@ export const sessionReadHandlers: GatewayRequestHandlers = {
           () =>
             listSessionsFromStoreAsync({
               cfg,
-              storePath: visibleStorePath,
+              durableStorePath,
+              ...(entryFilter ? { entryFilter } : {}),
+              storePath,
               store: listStore,
               modelCatalog,
               opts: p,
@@ -286,9 +283,6 @@ export const sessionReadHandlers: GatewayRequestHandlers = {
           {
             config: cfg,
             phase: "sessions.list",
-            attributes: {
-              storeEntries: Object.keys(listStore).length,
-            },
           },
         );
         const identityId = gatewayClientSessionCreator(client)?.id;
@@ -421,11 +415,11 @@ export const sessionReadHandlers: GatewayRequestHandlers = {
             },
           },
         );
-        // The pre-await draft filter used a stale store snapshot; re-drop rows
+        // The pre-await visibility predicate used a stale store snapshot; re-drop rows
         // whose freshly resolved sharing state is a draft this caller cannot see
         // (a session flipped to draft mid-list, or an older shared alias hiding
         // a now-draft canonical entry). Drafts are owner+admin only — members
-        // lose access, matching filterDraftSessionsForClient — so keep a draft
+        // lose access, matching createSessionListEntryFilter — so keep a draft
         // row only for the owner role. Admins and identity-less solo callers
         // keep everything.
         const canSeeDrafts = !identityId || isGatewayAdmin(client);

--- a/src/gateway/server-methods/sessions-sharing.test.ts
+++ b/src/gateway/server-methods/sessions-sharing.test.ts
@@ -24,7 +24,7 @@ import {
   authorizeResolvedSessionMutation,
   resolveSessionMutationAuthorization,
   canReceiveSessionEvent,
-  filterDraftSessionsForClient,
+  createSessionListEntryFilter,
   invalidateSessionSharingSnapshot,
 } from "../session-sharing.js";
 import { sessionReadHandlers } from "./sessions-read.js";
@@ -569,11 +569,8 @@ describe("session sharing handlers", () => {
         if (!entry) {
           throw new Error("expected member transition session entry");
         }
-        const listed = filterDraftSessionsForClient({
-          client: memberClient,
-          store: { [sessionKey]: entry },
-        });
-        expect(Object.hasOwn(listed, sessionKey)).toBe(allowed);
+        const listed = createSessionListEntryFilter({ client: memberClient })?.(sessionKey, entry);
+        expect(listed ?? true).toBe(allowed);
         expect(
           canReceiveSessionEvent({
             cfg: {},

--- a/src/gateway/server-startup-log.test.ts
+++ b/src/gateway/server-startup-log.test.ts
@@ -8,6 +8,9 @@ import { formatAgentModelStartupDetails, logGatewayStartup } from "./server-star
 const pluginRegistryMocks = vi.hoisted(() => ({
   loadPluginManifestRegistryForPluginRegistry: vi.fn(),
 }));
+const modelSelectionMocks = vi.hoisted(() => ({
+  resolveConfiguredModelRef: vi.fn(),
+}));
 const modelMocks = vi.hoisted(() => ({
   resolveThinkingDefault: vi.fn(() => "medium" as const),
 }));
@@ -25,6 +28,11 @@ vi.mock("../plugins/plugin-registry.js", async (importOriginal) => ({
     pluginRegistryMocks.loadPluginManifestRegistryForPluginRegistry,
 }));
 
+vi.mock("../agents/model-selection-shared.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../agents/model-selection-shared.js")>()),
+  resolveConfiguredModelRef: modelSelectionMocks.resolveConfiguredModelRef,
+}));
+
 // Provider thinking owns a dedicated suite. Startup logging only needs its
 // fixture-level default while proving precedence and banner composition.
 vi.mock("../agents/model-thinking-default.js", () => ({
@@ -38,6 +46,11 @@ describe("gateway startup log", () => {
     }
     modelMocks.resolveThinkingDefault.mockClear();
     modelMocks.resolveThinkingDefault.mockReturnValue("medium");
+    modelSelectionMocks.resolveConfiguredModelRef.mockReset();
+    modelSelectionMocks.resolveConfiguredModelRef.mockReturnValue({
+      provider: "openai",
+      model: "gpt-5.5",
+    });
     pluginRegistryMocks.loadPluginManifestRegistryForPluginRegistry.mockReset();
     pluginRegistryMocks.loadPluginManifestRegistryForPluginRegistry.mockReturnValue({
       plugins: [],

--- a/src/gateway/session-sharing.test.ts
+++ b/src/gateway/session-sharing.test.ts
@@ -9,7 +9,7 @@ import {
   authorizeIncognitoSessionTarget,
   resolveSessionMutationAuthorization,
   canReceiveSessionEvent,
-  filterDraftSessionsForClient,
+  createSessionListEntryFilter,
   resolveSessionSharingRole,
   resolveSessionVisibility,
 } from "./session-sharing.js";
@@ -17,6 +17,14 @@ import {
 afterEach(() => closeOpenClawAgentDatabasesForTest());
 
 type SharingTarget = Parameters<typeof resolveSessionSharingRole>[0]["target"];
+
+function isListed(
+  requestClient: GatewayClient,
+  sessionKey: string,
+  entry: SharingTarget["entry"],
+): boolean {
+  return createSessionListEntryFilter({ client: requestClient })?.(sessionKey, entry) ?? true;
+}
 
 function client(params: {
   user?: string;
@@ -138,10 +146,8 @@ describe("session sharing policy", () => {
       visibility: "draft" as const,
       createdActor: { type: "human" as const, id: "owner@example.com", label: "Owner" },
     };
-    expect(filterDraftSessionsForClient({ client: owner, store: { main: entry } })).toHaveProperty(
-      "main",
-    );
-    expect(filterDraftSessionsForClient({ client: viewer, store: { main: entry } })).toEqual({});
+    expect(isListed(owner, "main", entry)).toBe(true);
+    expect(isListed(viewer, "main", entry)).toBe(false);
   });
 
   it("keeps incognito admin-only while treating identityless connections as owner-equivalent", async () => {
@@ -163,9 +169,7 @@ describe("session sharing policy", () => {
       const context = { chatAbortControllers: new Map(), getRuntimeConfig: () => cfg } as never;
 
       for (const visibleClient of [admin, solo]) {
-        expect(
-          filterDraftSessionsForClient({ client: visibleClient, store: { [sessionKey]: entry } }),
-        ).toHaveProperty(sessionKey);
+        expect(isListed(visibleClient, sessionKey, entry)).toBe(true);
         expect(
           canReceiveSessionEvent({
             cfg,
@@ -184,9 +188,7 @@ describe("session sharing policy", () => {
       }
 
       for (const hiddenClient of [owner, viewer]) {
-        expect(
-          filterDraftSessionsForClient({ client: hiddenClient, store: { [sessionKey]: entry } }),
-        ).toEqual({});
+        expect(isListed(hiddenClient, sessionKey, entry)).toBe(false);
         expect(
           canReceiveSessionEvent({
             cfg,

--- a/src/gateway/session-sharing.ts
+++ b/src/gateway/session-sharing.ts
@@ -702,19 +702,16 @@ export function canReceiveSessionEvent(params: {
   });
 }
 
-export function filterDraftSessionsForClient(params: {
+export function createSessionListEntryFilter(params: {
   client: GatewayClient | null;
-  store: Record<string, SessionEntry>;
-}): Record<string, SessionEntry> {
+}): ((sessionKey: string, entry: SessionEntry) => boolean) | undefined {
   const identity = gatewayClientSessionCreator(params.client);
   if (isGatewayAdmin(params.client) || !identity) {
-    return params.store;
+    return undefined;
   }
-  return Object.fromEntries(
-    Object.entries(params.store).filter(([sessionKey, entry]) => {
-      const owner = entry.createdActor?.id === identity.id;
-      const incognito = entry.incognito === true || isIncognitoSessionKey(sessionKey);
-      return !incognito && (owner || resolveSessionVisibility(entry) !== "draft");
-    }),
-  );
+  return (sessionKey, entry) => {
+    const owner = entry.createdActor?.id === identity.id;
+    const incognito = entry.incognito === true || isIncognitoSessionKey(sessionKey);
+    return !incognito && (owner || resolveSessionVisibility(entry) !== "draft");
+  };
 }

--- a/src/gateway/session-utils-creators.test.ts
+++ b/src/gateway/session-utils-creators.test.ts
@@ -3,7 +3,7 @@ import type { SessionEntry } from "../config/sessions.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { filterSessionStoreToConfiguredAgents } from "./server-methods/sessions-shared.js";
 import type { GatewayClient } from "./server-methods/types.js";
-import { filterDraftSessionsForClient } from "./session-sharing.js";
+import { createSessionListEntryFilter } from "./session-sharing.js";
 
 const getUserProfileListItem = vi.hoisted(() =>
   vi.fn((profileId: string) => ({
@@ -14,7 +14,7 @@ const getUserProfileListItem = vi.hoisted(() =>
 
 vi.mock("../state/user-profiles.js", () => ({ getUserProfileListItem }));
 
-import { listSessionsFromStore } from "./session-utils.js";
+import { listSessionsFromStore, listSessionsFromStoreAsync } from "./session-utils.js";
 
 afterEach(() => vi.restoreAllMocks());
 
@@ -69,7 +69,7 @@ it("returns the complete deterministic creator facet independently of pagination
   expect(filtered.creators).toEqual(result.creators);
 });
 
-it("preserves legacy list output across visibility, scope, creator, and search filters", () => {
+it("preserves legacy list output across visibility, scope, creator, and search filters", async () => {
   const now = 1_000_000;
   vi.spyOn(Date, "now").mockReturnValue(now);
   getUserProfileListItem.mockImplementation((profileId: string) => ({
@@ -157,12 +157,13 @@ it("preserves legacy list output across visibility, scope, creator, and search f
       scopes: ["operator.read"],
     },
   } as GatewayClient;
-  const visibleStore = filterDraftSessionsForClient({ client: viewer, store });
-  const configuredStore = filterSessionStoreToConfiguredAgents(cfg, visibleStore);
+  const entryFilter = createSessionListEntryFilter({ client: viewer });
+  const configuredStore = filterSessionStoreToConfiguredAgents(cfg, store);
 
-  const project = (opts: Parameters<typeof listSessionsFromStore>[0]["opts"]) => {
-    const result = listSessionsFromStore({
+  const project = async (opts: Parameters<typeof listSessionsFromStore>[0]["opts"]) => {
+    const result = await listSessionsFromStoreAsync({
       cfg,
+      ...(entryFilter ? { entryFilter } : {}),
       opts,
       store: configuredStore,
       storePath: "/tmp/openclaw-session-filter-parity",
@@ -180,7 +181,12 @@ it("preserves legacy list output across visibility, scope, creator, and search f
   // These exact projections were captured from the pre-refactor chained-filter implementation.
   expect(
     JSON.stringify(
-      project({ archived: "all", includeGlobal: true, includeUnknown: true, search: "needle" }),
+      await project({
+        archived: "all",
+        includeGlobal: true,
+        includeUnknown: true,
+        search: "needle",
+      }),
     ),
   ).toBe(
     JSON.stringify({
@@ -198,7 +204,7 @@ it("preserves legacy list output across visibility, scope, creator, and search f
   );
   expect(
     JSON.stringify(
-      project({
+      await project({
         agentId: "main",
         archived: "all",
         creatorId: "profile-bob",

--- a/src/gateway/session-utils-list.ts
+++ b/src/gateway/session-utils-list.ts
@@ -15,7 +15,11 @@ import { shouldKeepSubagentRunChildLink } from "../agents/subagent-run-liveness.
 import type { SessionEntry } from "../config/sessions.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { withPinnedActivePluginRegistryWorkspaceDir } from "../plugins/runtime-workspace-state.js";
-import { normalizeAgentId, parseAgentSessionKey } from "../routing/session-key.js";
+import {
+  isIncognitoSessionKey,
+  normalizeAgentId,
+  parseAgentSessionKey,
+} from "../routing/session-key.js";
 import { isCronRunSessionKey } from "../sessions/session-key-utils.js";
 import { type SessionEntryPair, sortAndLimitSessionEntries } from "./session-list-order.js";
 import { resolveStoredSessionKeyForAgentStore } from "./session-store-key.js";
@@ -54,6 +58,18 @@ import type { GatewaySessionRow, SessionsListResult } from "./session-utils.type
 const SESSIONS_LIST_YIELD_BATCH_SIZE = 10;
 
 const SESSIONS_LIST_DEFAULT_LIMIT = 100;
+const SESSIONS_LIST_TRANSCRIPT_FIELD_ROWS = 100;
+const SESSIONS_LIST_TRANSCRIPT_USAGE_MAX_BYTES = 64 * 1024;
+
+type ListSessionsFromStoreParams = {
+  cfg: OpenClawConfig;
+  durableStorePath?: string;
+  entryFilter?: (key: string, entry: SessionEntry) => boolean;
+  storePath: string;
+  store: Record<string, SessionEntry>;
+  modelCatalog?: ModelCatalogEntry[];
+  opts: SessionsListParams;
+};
 
 type SessionEntrySelection = {
   entries: SessionEntryPair[];
@@ -151,6 +167,7 @@ function filterSessionEntries(params: {
   now: number;
   userProfileLabelById?: Map<string, string | undefined>;
   getRowContext?: SessionListRowContextProvider;
+  entryFilter?: (key: string, entry: SessionEntry) => boolean;
 }): Pick<SessionEntrySelection, "creators" | "entries"> {
   const { cfg, store, opts, now } = params;
   const includeGlobal = opts.includeGlobal === true;
@@ -170,6 +187,9 @@ function filterSessionEntries(params: {
   const creators = new Map<string, { id: string; label?: string }>();
 
   for (const [key, entry] of Object.entries(store)) {
+    if (params.entryFilter && !params.entryFilter(key, entry)) {
+      continue;
+    }
     if (
       isCronRunSessionKey(key) ||
       (!includeGlobal && key === "global") ||
@@ -291,6 +311,7 @@ function selectSessionEntries(params: {
   getRowContext?: SessionListRowContextProvider;
   defaultLimit?: number;
   userProfileLabelById?: Map<string, string | undefined>;
+  entryFilter?: (key: string, entry: SessionEntry) => boolean;
 }): SessionEntrySelection {
   const { creators, entries: filtered } = filterSessionEntries(params);
   const limit = resolveSessionsListLimit(params.opts, params.defaultLimit);
@@ -312,6 +333,101 @@ function selectSessionEntries(params: {
   };
 }
 
+function prepareSessionList(params: ListSessionsFromStoreParams) {
+  const { cfg, store, opts } = params;
+  const now = Date.now();
+  const userProfileLabelById = new Map<string, string | undefined>();
+  let rowContext: SessionListRowContext | undefined;
+  const getRowContext = () => {
+    rowContext ??= buildSessionListRowContext({ store, now, userProfileLabelById });
+    return rowContext;
+  };
+  const hasSpawnedByFilter = typeof opts.spawnedBy === "string" && opts.spawnedBy.length > 0;
+  const filteredSessionKeys = new Set<string>();
+  let hasIncognito = false;
+  const entryFilter = (key: string, entry: SessionEntry) => {
+    if (params.entryFilter && !params.entryFilter(key, entry)) {
+      filteredSessionKeys.add(key);
+      return false;
+    }
+    hasIncognito ||= entry.incognito === true || isIncognitoSessionKey(key);
+    return true;
+  };
+  const selection = selectSessionEntries({
+    cfg,
+    store,
+    opts,
+    now,
+    entryFilter,
+    getRowContext:
+      hasSpawnedByFilter || Boolean(normalizeOptionalString(opts.search))
+        ? getRowContext
+        : undefined,
+    defaultLimit: SESSIONS_LIST_DEFAULT_LIMIT,
+    userProfileLabelById,
+  });
+  const fullRowContext =
+    rowContext ||
+    hasSpawnedByFilter ||
+    filteredSessionKeys.size > 0 ||
+    selection.entries.length > SESSIONS_LIST_YIELD_BATCH_SIZE
+      ? getRowContext()
+      : undefined;
+  if (fullRowContext && filteredSessionKeys.size > 0) {
+    // The predicate replaces a filtered-store object; keep its hidden child links out too.
+    for (const [parentKey, childKeys] of fullRowContext.storeChildSessionsByKey) {
+      fullRowContext.storeChildSessionsByKey.set(
+        parentKey,
+        childKeys.filter((key) => !filteredSessionKeys.has(key)),
+      );
+    }
+  }
+  const sharedRowContext =
+    fullRowContext ??
+    (selection.entries.length > 0
+      ? buildSessionListRowMetadataContext({ now, userProfileLabelById })
+      : undefined);
+  populateSessionListAcpMetadata({
+    cfg,
+    entries: selection.entries,
+    opts,
+    rowContext: sharedRowContext,
+  });
+  return {
+    ...selection,
+    includeDerivedTitles: opts.includeDerivedTitles === true,
+    includeLastMessage: opts.includeLastMessage === true,
+    now,
+    rowContext: sharedRowContext,
+    storeChildSessionsByKey: fullRowContext?.storeChildSessionsByKey,
+    storePath: hasIncognito ? params.storePath : (params.durableStorePath ?? params.storePath),
+  };
+}
+
+function buildSessionsListResult(params: {
+  cfg: OpenClawConfig;
+  list: ReturnType<typeof prepareSessionList>;
+  modelCatalog?: ModelCatalogEntry[];
+  sessions: GatewaySessionRow[];
+}): SessionsListResult {
+  const { list, sessions } = params;
+  return {
+    ts: list.now,
+    path: list.storePath,
+    count: sessions.length,
+    totalCount: list.totalCount,
+    limitApplied: list.limitApplied,
+    offset: list.offset > 0 ? list.offset : undefined,
+    nextOffset: list.nextOffset,
+    hasMore: list.hasMore,
+    creators: list.creators,
+    defaults: getSessionDefaults(params.cfg, params.modelCatalog, {
+      allowPluginNormalization: false,
+    }),
+    sessions,
+  };
+}
+
 export function filterAndSortSessionEntries(params: {
   cfg: OpenClawConfig;
   store: Record<string, SessionEntry>;
@@ -321,92 +437,40 @@ export function filterAndSortSessionEntries(params: {
   return selectSessionEntries(params).entries;
 }
 
-export function listSessionsFromStore(params: {
-  cfg: OpenClawConfig;
-  storePath: string;
-  store: Record<string, SessionEntry>;
-  modelCatalog?: ModelCatalogEntry[];
-  opts: SessionsListParams;
-}): SessionsListResult {
-  const { cfg, storePath, store, opts } = params;
-  const now = Date.now();
-  const sessionListTranscriptUsageMaxBytes = 64 * 1024;
-  const sessionListTranscriptFieldRows = 100;
-  // Creator facets and rows must share one profile-label snapshot. Every row context in this
-  // public list call is built with this map below, so a profile rename cannot split the response.
-  const userProfileLabelById = new Map<string, string | undefined>();
-  let rowContext: SessionListRowContext | undefined;
-  const getRowContext = () => {
-    rowContext ??= buildSessionListRowContext({ store, now, userProfileLabelById });
-    return rowContext;
-  };
-  const includeDerivedTitles = opts.includeDerivedTitles === true;
-  const includeLastMessage = opts.includeLastMessage === true;
-  const hasSpawnedByFilter = typeof opts.spawnedBy === "string" && opts.spawnedBy.length > 0;
-
-  const selection = selectSessionEntries({
-    cfg,
-    store,
-    opts,
-    now,
-    getRowContext:
-      hasSpawnedByFilter || Boolean(normalizeOptionalString(opts.search))
-        ? getRowContext
-        : undefined,
-    defaultLimit: SESSIONS_LIST_DEFAULT_LIMIT,
-    userProfileLabelById,
-  });
-  const { entries, creators, totalCount, limitApplied, offset, nextOffset, hasMore } = selection;
-  const fullRowContext =
-    rowContext || hasSpawnedByFilter || entries.length > SESSIONS_LIST_YIELD_BATCH_SIZE
-      ? getRowContext()
-      : undefined;
-  const sharedRowContext =
-    fullRowContext ??
-    (entries.length > 0
-      ? buildSessionListRowMetadataContext({ now, userProfileLabelById })
-      : undefined);
-  populateSessionListAcpMetadata({ cfg, entries, opts, rowContext: sharedRowContext });
-
-  const sessions = entries.map(([key, entry], index) => {
-    const includeTranscriptFields = index < sessionListTranscriptFieldRows;
+export function listSessionsFromStore(params: ListSessionsFromStoreParams): SessionsListResult {
+  const { cfg, store, opts } = params;
+  const list = prepareSessionList(params);
+  const sessions = list.entries.map(([key, entry], index) => {
+    const includeTranscriptFields = index < SESSIONS_LIST_TRANSCRIPT_FIELD_ROWS;
     const rowAgentId =
       key === "global" && typeof opts.agentId === "string"
         ? normalizeAgentId(opts.agentId)
         : undefined;
     const storeChildSessionsByKey =
-      fullRowContext?.storeChildSessionsByKey ??
-      buildSingleRowStoreChildSessionsByKey({ store, storePath, key, now });
+      list.storeChildSessionsByKey ??
+      buildSingleRowStoreChildSessionsByKey({
+        store,
+        storePath: list.storePath,
+        key,
+        now: list.now,
+      });
     return buildGatewaySessionRow({
       cfg,
-      storePath,
+      storePath: list.storePath,
       store,
       key,
       entry,
       agentId: rowAgentId,
       modelCatalog: params.modelCatalog,
-      now,
-      includeDerivedTitles: includeTranscriptFields && includeDerivedTitles,
-      includeLastMessage: includeTranscriptFields && includeLastMessage,
-      transcriptUsageMaxBytes: sessionListTranscriptUsageMaxBytes,
+      now: list.now,
+      includeDerivedTitles: includeTranscriptFields && list.includeDerivedTitles,
+      includeLastMessage: includeTranscriptFields && list.includeLastMessage,
+      transcriptUsageMaxBytes: SESSIONS_LIST_TRANSCRIPT_USAGE_MAX_BYTES,
       storeChildSessionsByKey,
-      rowContext: sharedRowContext,
+      rowContext: list.rowContext,
     });
   });
-
-  return {
-    ts: now,
-    path: storePath,
-    count: sessions.length,
-    totalCount,
-    limitApplied,
-    offset: offset > 0 ? offset : undefined,
-    nextOffset,
-    hasMore,
-    creators,
-    defaults: getSessionDefaults(cfg, params.modelCatalog, { allowPluginNormalization: false }),
-    sessions,
-  };
+  return buildSessionsListResult({ cfg, list, modelCatalog: params.modelCatalog, sessions });
 }
 
 /**
@@ -419,91 +483,54 @@ export function listSessionsFromStore(params: {
  * By yielding every SESSIONS_LIST_YIELD_BATCH_SIZE rows, we keep the event
  * loop responsive for WebSocket heartbeats, channel I/O, and concurrent RPC.
  */
-export async function listSessionsFromStoreAsync(params: {
-  cfg: OpenClawConfig;
-  storePath: string;
-  store: Record<string, SessionEntry>;
-  modelCatalog?: ModelCatalogEntry[];
-  opts: SessionsListParams;
-}): Promise<SessionsListResult> {
+export async function listSessionsFromStoreAsync(
+  params: ListSessionsFromStoreParams,
+): Promise<SessionsListResult> {
   // Pin the active plugin-registry workspace dir for the duration of this
   // call so per-row metadata lookups use a stable memo key. Without this pin,
   // concurrent agent turns / crons mutate the process-global workspace dir
   // between rows, the memo never hits, and each row triggers a full
   // loadPluginMetadataSnapshot scan (~100 ms).
   return withPinnedActivePluginRegistryWorkspaceDir(async () => {
-    const { cfg, storePath, store, opts } = params;
-    const now = Date.now();
-    const sessionListTranscriptUsageMaxBytes = 64 * 1024;
-    const sessionListTranscriptFieldRows = 100;
-    // Creator facets and rows must share one profile-label snapshot. Every row context in this
-    // public list call is built with this map below, so a profile rename cannot split the response.
-    const userProfileLabelById = new Map<string, string | undefined>();
-    let rowContext: SessionListRowContext | undefined;
-    const getRowContext = () => {
-      rowContext ??= buildSessionListRowContext({ store, now, userProfileLabelById });
-      return rowContext;
-    };
-    const includeDerivedTitles = opts.includeDerivedTitles === true;
-    const includeLastMessage = opts.includeLastMessage === true;
-    const hasSpawnedByFilter = typeof opts.spawnedBy === "string" && opts.spawnedBy.length > 0;
-
-    const selection = selectSessionEntries({
-      cfg,
-      store,
-      opts,
-      now,
-      getRowContext:
-        hasSpawnedByFilter || Boolean(normalizeOptionalString(opts.search))
-          ? getRowContext
-          : undefined,
-      defaultLimit: SESSIONS_LIST_DEFAULT_LIMIT,
-      userProfileLabelById,
-    });
-    const { entries, creators, totalCount, limitApplied, offset, nextOffset, hasMore } = selection;
-    const fullRowContext =
-      rowContext || hasSpawnedByFilter || entries.length > SESSIONS_LIST_YIELD_BATCH_SIZE
-        ? getRowContext()
-        : undefined;
-    const sharedRowContext =
-      fullRowContext ??
-      (entries.length > 0
-        ? buildSessionListRowMetadataContext({ now, userProfileLabelById })
-        : undefined);
-    populateSessionListAcpMetadata({ cfg, entries, opts, rowContext: sharedRowContext });
-
+    const { cfg, store, opts } = params;
+    const list = prepareSessionList(params);
     const sessions: GatewaySessionRow[] = [];
-    for (let i = 0; i < entries.length; i++) {
-      const [key, entry] = expectDefined(entries[i], "entries entry at i");
-      const includeTranscriptFields = i < sessionListTranscriptFieldRows;
+    for (let i = 0; i < list.entries.length; i++) {
+      const [key, entry] = expectDefined(list.entries[i], "entries entry at i");
+      const includeTranscriptFields = i < SESSIONS_LIST_TRANSCRIPT_FIELD_ROWS;
       const rowAgentId =
         key === "global" && typeof opts.agentId === "string"
           ? normalizeAgentId(opts.agentId)
           : undefined;
       const storeChildSessionsByKey =
-        fullRowContext?.storeChildSessionsByKey ??
-        buildSingleRowStoreChildSessionsByKey({ store, storePath, key, now });
+        list.storeChildSessionsByKey ??
+        buildSingleRowStoreChildSessionsByKey({
+          store,
+          storePath: list.storePath,
+          key,
+          now: list.now,
+        });
       const row = buildGatewaySessionRow({
         cfg,
-        storePath,
+        storePath: list.storePath,
         store,
         key,
         entry,
         agentId: rowAgentId,
         modelCatalog: params.modelCatalog,
-        now,
+        now: list.now,
         includeDerivedTitles: false,
         includeLastMessage: false,
-        transcriptUsageMaxBytes: sessionListTranscriptUsageMaxBytes,
+        transcriptUsageMaxBytes: SESSIONS_LIST_TRANSCRIPT_USAGE_MAX_BYTES,
         storeChildSessionsByKey,
-        rowContext: sharedRowContext,
+        rowContext: list.rowContext,
         skipTranscriptUsageFallback: true,
         lightweightListRow: true,
       });
       if (
         entry?.sessionId &&
         includeTranscriptFields &&
-        (includeDerivedTitles || includeLastMessage)
+        (list.includeDerivedTitles || list.includeLastMessage)
       ) {
         const parsed = parseAgentSessionKey(key);
         const sessionAgentId =
@@ -514,37 +541,25 @@ export async function listSessionsFromStoreAsync(params: {
           sessionEntry: entry,
           sessionId: entry.sessionId,
           sessionKey: key,
-          storePath,
+          storePath: list.storePath,
         });
-        if (includeDerivedTitles) {
+        if (list.includeDerivedTitles) {
           row.derivedTitle = deriveSessionTitle(entry, fields.firstUserMessage, row.displayName);
         }
-        if (includeLastMessage && fields.lastMessagePreview) {
+        if (list.includeLastMessage && fields.lastMessagePreview) {
           row.lastMessagePreview = fields.lastMessagePreview;
         }
       }
       sessions.push(row);
       // Yield to the event loop between batches so WebSocket heartbeats,
       // channel I/O, and concurrent RPC calls are not starved.
-      if ((i + 1) % SESSIONS_LIST_YIELD_BATCH_SIZE === 0 && i + 1 < entries.length) {
+      if ((i + 1) % SESSIONS_LIST_YIELD_BATCH_SIZE === 0 && i + 1 < list.entries.length) {
         await new Promise<void>((resolve) => {
           setImmediate(resolve);
         });
       }
     }
 
-    return {
-      ts: now,
-      path: storePath,
-      count: sessions.length,
-      totalCount,
-      limitApplied,
-      offset: offset > 0 ? offset : undefined,
-      nextOffset,
-      hasMore,
-      creators,
-      defaults: getSessionDefaults(cfg, params.modelCatalog, { allowPluginNormalization: false }),
-      sessions,
-    };
+    return buildSessionsListResult({ cfg, list, modelCatalog: params.modelCatalog, sessions });
   });
 }


### PR DESCRIPTION
## What Problem This Solves

With the reload storm fixed (#115359), `sessions.list`'s remaining warm cost is per-request O(store) passes: each request materialized every entry via `Object.fromEntries` per store, rebuilt an 800-key object in `filterDraftSessionsForClient`, and ran an `Object.entries(...).some(...)` scan just to answer one boolean — on top of the passes that genuinely must exist (canonical-key merge, single-pass filter, child index).

## Why This Change Was Made

Repo shape: iterate entries once and derive all needed facts in that pass. Redundant materializations set the ~118ms warm floor.

## User Impact

Lower warm `sessions.list` latency and less event-loop occupancy per request; response bytes identical.

## Evidence

- Removed: per-store `Object.fromEntries` (accessor rows merge directly), the draft/incognito store reconstruction, the incognito `.some()` scan, and a diagnostic `Object.keys()` scan.
- Kept with reasons (commented): canonical-key merge (cross-agent rows + collision freshness), the single filter pass (now also carrying sharing visibility/path facts), the child index (parent projections; hidden links pruned), and a bounded post-await ACL filter (sharing changes mid-request).
- Out of scope by design: skipping owner targets by requestedAgentId (flagged medium-risk in the audit; needs its own correctness analysis).
- Parity: the existing captured legacy fixture replayed through the new pipeline, plus serialized-response and incognito-path regressions.
- 12 files / 190 focused tests + 11/11 affected rerun; all deadcode lanes; full lint; tsgo core+test; format; git diff --check; autoreview clean. Net −8 production LOC.
