### PR TITLE
fix(sidebar): filter out empty categories when scoped to selected agent

### DIFF
--- a/ui/src/lib/sessions/grouping.test.ts
+++ b/ui/src/lib/sessions/grouping.test.ts
@@ -89,7 +89,7 @@ describe("groupSidebarSessionRows", () => {
     ]);
   });
 
-  it("keeps stored-but-empty known groups visible as sections", () => {
+  it("filters out stored-but-empty known groups when scoped to a selected agent", () => {
     const sections = groupSidebarSessionRows(
       [row({ key: "a" }), row({ key: "b", category: "Zulu" })],
       {
@@ -97,13 +97,11 @@ describe("groupSidebarSessionRows", () => {
       },
     );
     expect(sections.map((section) => section.id)).toEqual([
-      "category:Apps",
       "category:Zulu",
       "ungrouped",
       "work",
     ]);
-    expect(sections[0]?.rows).toEqual([]);
-    expect(sections[1]?.rows.map((item) => item.key)).toEqual(["b"]);
+    expect(sections[0]?.rows.map((item) => item.key)).toEqual(["b"]);
   });
 
   it("keeps custom groups in their persisted order", () => {

--- a/ui/src/lib/sessions/grouping.ts
+++ b/ui/src/lib/sessions/grouping.ts
@@ -273,7 +273,10 @@ export function groupSidebarSessionRows<Row extends SidebarGroupableRow>(
     ...[...categories.keys()]
       .filter((name) => !knownGroups.includes(name))
       .toSorted((a, b) => a.localeCompare(b)),
-  ];
+  ]
+    // Filter out categories that have no rows for the current scoped selection
+    .filter((category) => (categories.get(category) ?? []).length > 0);
+
   const orderedSections: SidebarSessionSection<Row>[] = orderedCategories.map((category) => ({
     id: `category:${category}`,
     category,


### PR DESCRIPTION
# fix(sidebar): filter out empty categories when scoped to selected agent

## Summary
Fixes an issue where stored categories with no matching sessions were still being rendered as empty sidebar sections when filtered by a specific agent ([#115348](https://github.com/issue-link-here)).

## Changes Made
- Updated `groupSidebarSessionRows` in `grouping.ts` to filter out empty `knownGroups` categories that contain `0` session rows for the currently selected agent context.
- Updated test assertions in `grouping.test.ts` to verify that empty stored categories are correctly hidden instead of persisting as empty sections.

## Testing & Verification
- Ran test suite to confirm all unit tests pass (`vitest run grouping.test.ts`).
- Verified sidebar layout behavior when switching between different agents with varying assigned session categories.

Fixes #115348