### PR TITLE
docs(security): fix warning line wrap

### DIFF
--- a/docs/gateway/security/index.md
+++ b/docs/gateway/security/index.md
@@ -8,7 +8,7 @@ title: "Security"
 <Warning>
   **Personal assistant trust model.** This guidance assumes one trusted
   operator boundary per gateway (single-user, personal-assistant model).
-  OpenClaw is **not** a hostile multi-tenant security boundary for multiple
+  OpenClaw is not a hostile multi-tenant security boundary for multiple
   adversarial users sharing one agent or gateway. For mixed-trust or
   adversarial-user operation, split trust boundaries: separate gateway +
   credentials, ideally separate OS users or hosts.


### PR DESCRIPTION
## What Problem This Solves

The security warning renders the emphasized word “not” as a standalone block, creating an unintended line break that interrupts the sentence.

## Why This Change Was Made

Mintlify callouts style bold fragments as labels. Removing the second inline bold fragment keeps the warning title emphasized while allowing the sentence to flow normally.

## User Impact

The personal-assistant trust-model warning reads continuously without changing its meaning.

## Evidence

- `node scripts/docs-list.js`
- focused `check-docs-mdx.mjs` validation: passed
- focused `oxfmt --check`: passed
- `git diff --check`: passed
- autoreview: clean, no accepted/actionable findings
