### PR TITLE
feat(protocol): publish node invoke cancellation payload

### DIFF
--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayNodeSession.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayNodeSession.swift
@@ -12,10 +12,6 @@ private struct NodeInvokeRequestPayload: Codable {
     var idempotencyKey: String?
 }
 
-private struct NodeInvokeCancelPayload: Codable {
-    var invokeId: String
-}
-
 /// Binds suspended work to one installed gateway channel generation.
 /// Callers use this lease so an actor hop cannot retarget a payload to a replacement gateway.
 public struct GatewayNodeSessionRoute: Sendable, Equatable {
@@ -1130,7 +1126,7 @@ extension GatewayNodeSession {
         if evt.event == "node.invoke.cancel" {
             guard let payload = evt.payload else { return }
             do {
-                let cancel: NodeInvokeCancelPayload = try self.decodeEventPayload(from: payload)
+                let cancel: NodeInvokeCancelEvent = try self.decodeEventPayload(from: payload)
                 self.cancelActiveInvoke(
                     requestID: cancel.invokeId,
                     admissionGeneration: admissionGeneration)

--- a/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
@@ -3825,6 +3825,24 @@ public struct NodeInvokeRequestEvent: Codable, Sendable {
     }
 }
 
+public struct NodeInvokeCancelEvent: Codable, Sendable {
+    public let invokeid: String
+    public let nodeid: String
+
+    public init(
+        invokeid: String,
+        nodeid: String)
+    {
+        self.invokeid = invokeid
+        self.nodeid = nodeid
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case invokeid = "invokeId"
+        case nodeid = "nodeId"
+    }
+}
+
 public struct NodeEventParams: Codable, Sendable {
     public let event: String
     public let payload: AnyCodable?

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/GatewayNodeSessionTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/GatewayNodeSessionTests.swift
@@ -1064,7 +1064,10 @@ struct GatewayNodeSessionTests {
             .event(EventFrame(
                 type: "event",
                 event: "node.invoke.cancel",
-                payload: AnyCodable(["invokeId": AnyCodable("terminal-1")]),
+                payload: AnyCodable([
+                    "invokeId": AnyCodable("terminal-1"),
+                    "nodeId": AnyCodable("test-node"),
+                ]),
                 seq: nil,
                 stateversion: nil)),
             socketGeneration: 1)
@@ -1570,7 +1573,10 @@ struct GatewayNodeSessionTests {
             .event(EventFrame(
                 type: "event",
                 event: "node.invoke.cancel",
-                payload: AnyCodable(["invokeId": AnyCodable("queued-ptz")]),
+                payload: AnyCodable([
+                    "invokeId": AnyCodable("queued-ptz"),
+                    "nodeId": AnyCodable("test-node"),
+                ]),
                 seq: nil,
                 stateversion: nil)),
             socketGeneration: 1)

--- a/docs/nodes/index.md
+++ b/docs/nodes/index.md
@@ -441,7 +441,8 @@ response. Streaming callers can set an inactivity deadline that starts with the
 first progress event and resets after later progress while retaining the
 invoke's separate hard timeout during approval and execution. Result, hard
 timeout, inactivity timeout, and node disconnect all discard pending stream
-state. Caller cancellation emits `node.invoke.cancel`; the node host then
+state. Caller cancellation emits `node.invoke.cancel` with the published
+`NodeInvokeCancelEvent` payload (`invokeId` and `nodeId`); the node host then
 terminates the matching process tree. Existing request/response commands are unchanged.
 
 ## Command policy

--- a/packages/gateway-protocol/src/index.ts
+++ b/packages/gateway-protocol/src/index.ts
@@ -187,6 +187,7 @@ export {
   NodePendingAckParamsSchema,
   NodeInvokeParamsSchema,
   NodeInvokeInputEventSchema,
+  NodeInvokeCancelEventSchema,
   NodeInvokeProgressParamsSchema,
   NodeEventResultSchema,
   NodePresenceAlivePayloadSchema,

--- a/packages/gateway-protocol/src/schema/nodes.test.ts
+++ b/packages/gateway-protocol/src/schema/nodes.test.ts
@@ -1,7 +1,26 @@
+import { Value } from "typebox/value";
 import { describe, expect, it } from "vitest";
-import { validateNodeInvokeProgressParams } from "../index.js";
+import {
+  NodeInvokeCancelEventSchema,
+  type NodeInvokeCancelEvent,
+  validateNodeInvokeProgressParams,
+} from "../index.js";
+import { ProtocolSchemas } from "./protocol-schemas.js";
 
 describe("node protocol schemas", () => {
+  it("publishes the closed node invoke cancellation payload", () => {
+    const payload: NodeInvokeCancelEvent = {
+      invokeId: "invoke-1",
+      nodeId: "node-1",
+    };
+
+    expect(ProtocolSchemas.NodeInvokeCancelEvent).toBe(NodeInvokeCancelEventSchema);
+    expect(Value.Check(NodeInvokeCancelEventSchema, payload)).toBe(true);
+    expect(Value.Check(NodeInvokeCancelEventSchema, { ...payload, invokeId: "" })).toBe(false);
+    expect(Value.Check(NodeInvokeCancelEventSchema, { invokeId: "invoke-1" })).toBe(false);
+    expect(Value.Check(NodeInvokeCancelEventSchema, { ...payload, extra: true })).toBe(false);
+  });
+
   it("accepts bounded progress chunks and rejects extra fields", () => {
     expect(
       validateNodeInvokeProgressParams({

--- a/packages/gateway-protocol/src/schema/nodes.ts
+++ b/packages/gateway-protocol/src/schema/nodes.ts
@@ -242,6 +242,12 @@ export const NodeInvokeInputEventSchema = closedObject({
   payloadJSON: Type.String({ maxLength: 16 * 1024 }),
 });
 
+/** Payload sent by the gateway to cancel one active node invoke. */
+export const NodeInvokeCancelEventSchema = closedObject({
+  invokeId: NonEmptyString,
+  nodeId: NonEmptyString,
+});
+
 // Wire types derive directly from local schema consts so public d.ts graphs never
 // pull in the ProtocolSchemas registry.
 export type NodePairListParams = Static<typeof NodePairListParamsSchema>;
@@ -256,6 +262,7 @@ export type NodeInvokeParams = Static<typeof NodeInvokeParamsSchema>;
 export type NodeInvokeResultParams = Static<typeof NodeInvokeResultParamsSchema>;
 export type NodeInvokeProgressParams = Static<typeof NodeInvokeProgressParamsSchema>;
 export type NodeInvokeInputEvent = Static<typeof NodeInvokeInputEventSchema>;
+export type NodeInvokeCancelEvent = Static<typeof NodeInvokeCancelEventSchema>;
 export type NodeEventParams = Static<typeof NodeEventParamsSchema>;
 export type NodeEventResult = Static<typeof NodeEventResultSchema>;
 export type NodePresenceAlivePayload = Static<typeof NodePresenceAlivePayloadSchema>;

--- a/packages/gateway-protocol/src/schema/protocol-schemas-node-invoke.ts
+++ b/packages/gateway-protocol/src/schema/protocol-schemas-node-invoke.ts
@@ -1,4 +1,5 @@
 import {
+  NodeInvokeCancelEventSchema,
   NodeInvokeInputEventSchema,
   NodeInvokeParamsSchema,
   NodeInvokeProgressParamsSchema,
@@ -6,12 +7,13 @@ import {
   NodeInvokeResultParamsSchema,
 } from "./nodes.js";
 
-// Node invoke request/input/progress/result wire schemas, grouped like the
-// sibling node-presence bundle so the main registry stays within its budget.
+// Node invoke request/cancel/input/progress/result wire schemas, grouped like
+// the sibling node-presence bundle so the main registry stays within its budget.
 export const NodeInvokeProtocolSchemas = {
   NodeInvokeParams: NodeInvokeParamsSchema,
   NodeInvokeInputEvent: NodeInvokeInputEventSchema,
   NodeInvokeProgressParams: NodeInvokeProgressParamsSchema,
   NodeInvokeResultParams: NodeInvokeResultParamsSchema,
   NodeInvokeRequestEvent: NodeInvokeRequestEventSchema,
+  NodeInvokeCancelEvent: NodeInvokeCancelEventSchema,
 };

--- a/src/gateway/node-registry.ts
+++ b/src/gateway/node-registry.ts
@@ -13,6 +13,7 @@ import { GATEWAY_CLIENT_IDS } from "../../packages/gateway-protocol/src/client-i
 // gateway-protocol index would retain the whole ProtocolSchemas registry in
 // the public plugin-sdk dts (check-plugin-sdk-exports guards this).
 import type {
+  NodeInvokeCancelEvent,
   NodePluginToolDescriptor,
   NodeSkillDescriptor,
 } from "../../packages/gateway-protocol/src/schema/nodes.js";
@@ -268,10 +269,11 @@ export class NodeRegistry {
       ) {
         return;
       }
-      this.sendEventToSession(node, "node.invoke.cancel", {
+      const payload: NodeInvokeCancelEvent = {
         invokeId: requestId,
         nodeId: pending.nodeId,
-      });
+      };
+      this.sendEventToSession(node, "node.invoke.cancel", payload);
     },
     isConnectionActive: (pending) => this.nodesById.get(pending.nodeId)?.connId === pending.connId,
     sendInput: (invokeId, pending, seq, payloadJSON) => {

--- a/src/node-host/invoke-payload.ts
+++ b/src/node-host/invoke-payload.ts
@@ -1,3 +1,4 @@
+import type { NodeInvokeCancelEvent } from "../../packages/gateway-protocol/src/schema/nodes.js";
 import type { NodeInvokeRequestPayload } from "./invoke-types.js";
 
 const MAX_INVOKE_INPUT_BYTES = 16 * 1024;
@@ -31,9 +32,7 @@ export function coerceNodeInvokePayload(payload: unknown): NodeInvokeRequestPayl
   };
 }
 
-export function coerceNodeInvokeCancelPayload(
-  payload: unknown,
-): { invokeId: string; nodeId: string } | null {
+export function coerceNodeInvokeCancelPayload(payload: unknown): NodeInvokeCancelEvent | null {
   const value =
     payload && typeof payload === "object" && !Array.isArray(payload)
       ? (payload as Record<string, unknown>)


### PR DESCRIPTION
Related: #115375

## Summary

Publishes the existing Gateway-to-node `node.invoke.cancel` payload as the
shared `NodeInvokeCancelEventSchema` / `NodeInvokeCancelEvent` contract. The
required wire fields remain `{ invokeId, nodeId }`; protocol versions and
runtime behavior are unchanged.

The Gateway producer, TypeScript node-host consumer, generated registry, and
live Swift `GatewayNodeSession` now consume that same contract. This is the
narrow cancellation-schema slice needed by cross-language node runtimes,
including the Rust series described in [RFC #54](https://github.com/openclaw/rfcs/pull/54).

## Scope

- exports and registers the closed cancellation-event schema;
- updates the Gateway producer and first-party TypeScript consumer;
- regenerates the Swift model and decodes it in the live Swift node session;
- adds fixtures requiring both non-empty identifiers; and
- documents the published payload.

This PR does not add a new cancellation mechanism, alter request/response
commands, or bundle the broader Rust runtime stack.

## Validation

At head `3cac3e4a3aa`:

- focused node-schema Vitest tests — 2/2 passed;
- `pnpm protocol-registry:check` — passed;
- `pnpm protocol:check:swift` — passed; and
- `git diff --check` — passed.

The branch was rebased onto current `main`; the obsolete schema registry from
the earlier base was adapted to the current fragment registry and explicit
root exports rather than restored.

AI-assisted: Codex was used for source audit, implementation, rebase conflict
resolution, tests, and review. I reviewed the resulting contract and diff.
