### PR TITLE
fix(channels): stale runtime binding routes conversations to the wrong agent

### DIFF
--- a/src/channels/plugins/binding-routing.configured-fallback.test.ts
+++ b/src/channels/plugins/binding-routing.configured-fallback.test.ts
@@ -1,0 +1,184 @@
+// Route-level proof for the stale-binding guard: chains the two resolvers the way
+// channel plugins do (runtime binding first, configured binding when none applies)
+// and asserts a configured ACP binding is actually selected once a stale runtime
+// record is discarded.
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { loadSessionEntryReadOnly } from "../../config/sessions/session-accessor.js";
+import type { SessionEntry } from "../../config/sessions/types.js";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import {
+  registerSessionBindingAdapter,
+  testing,
+  type SessionBindingRecord,
+} from "../../infra/outbound/session-binding-service.js";
+import type { ResolvedAgentRoute } from "../../routing/resolve-route.js";
+import {
+  resolveConfiguredBindingRoute,
+  resolveRuntimeConversationBindingRoute,
+} from "./binding-routing.js";
+import { ensureConfiguredBindingBuiltinsRegistered } from "./configured-binding-builtins.js";
+
+const resolveAgentConfigMock = vi.hoisted(() => vi.fn());
+const resolveDefaultAgentIdMock = vi.hoisted(() => vi.fn());
+const resolveAgentWorkspaceDirMock = vi.hoisted(() => vi.fn());
+const getLoadedChannelPluginMock = vi.hoisted(() => vi.fn());
+
+vi.mock("../../agents/agent-scope.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../agents/agent-scope.js")>()),
+  resolveAgentConfig: resolveAgentConfigMock,
+  resolveDefaultAgentId: resolveDefaultAgentIdMock,
+  resolveAgentWorkspaceDir: resolveAgentWorkspaceDirMock,
+}));
+
+vi.mock("./index.js", () => ({
+  getLoadedChannelPlugin: getLoadedChannelPluginMock,
+}));
+
+vi.mock("../../config/sessions/session-accessor.js", { spy: true });
+
+const CONVERSATION_ID = "room-1";
+const STALE_SESSION_KEY = "agent:main:demo:default:direct:room-1";
+
+function createConfig(): OpenClawConfig {
+  return {
+    agents: { list: [{ id: "main" }, { id: "review" }] },
+    bindings: [
+      {
+        type: "acp",
+        agentId: "review",
+        match: {
+          channel: "demo",
+          accountId: "default",
+          peer: { kind: "channel", id: CONVERSATION_ID },
+        },
+        acp: { backend: "acpx" },
+      },
+    ],
+  } as unknown as OpenClawConfig;
+}
+
+function createDemoAcpPlugin() {
+  return {
+    id: "demo",
+    bindings: {
+      compileConfiguredBinding: vi.fn(({ conversationId }: { conversationId: string }) => ({
+        conversationId,
+      })),
+      matchInboundConversation: vi.fn(
+        ({
+          compiledBinding,
+          conversationId,
+        }: {
+          compiledBinding: { conversationId: string };
+          conversationId: string;
+        }) =>
+          compiledBinding.conversationId === conversationId
+            ? { conversationId, matchPriority: 2 }
+            : null,
+      ),
+    },
+  };
+}
+
+function createRoute(): ResolvedAgentRoute {
+  return {
+    agentId: "main",
+    channel: "demo",
+    accountId: "default",
+    sessionKey: "agent:main:main",
+    mainSessionKey: "agent:main:main",
+    lastRoutePolicy: "main",
+    matchedBy: "default",
+  };
+}
+
+/** The catch-all-created runtime binding described in #115354. */
+function registerRuntimeBinding(targetSessionKey: string): void {
+  const record: SessionBindingRecord = {
+    bindingId: "binding-1",
+    targetSessionKey,
+    targetKind: "session",
+    conversation: {
+      channel: "demo",
+      accountId: "default",
+      conversationId: CONVERSATION_ID,
+    },
+    status: "active",
+    boundAt: 1,
+  };
+  registerSessionBindingAdapter({
+    channel: "demo",
+    accountId: "default",
+    listBySession: () => [],
+    resolveByConversation: () => record,
+    touch: () => {},
+  });
+}
+
+/**
+ * Mirrors the channel-plugin ordering: apply the runtime binding, and fall through
+ * to the configured binding only when no runtime record is authoritative.
+ */
+function resolveChannelRoute(cfg: OpenClawConfig) {
+  const conversation = {
+    channel: "demo",
+    accountId: "default",
+    conversationId: CONVERSATION_ID,
+  };
+  const runtimeRoute = resolveRuntimeConversationBindingRoute({
+    route: createRoute(),
+    conversation,
+  });
+  if (runtimeRoute.bindingRecord) {
+    return { via: "runtime" as const, route: runtimeRoute.route, configuredBinding: null };
+  }
+  const configuredRoute = resolveConfiguredBindingRoute({
+    cfg,
+    route: runtimeRoute.route,
+    conversation,
+  });
+  return {
+    via: "configured" as const,
+    route: configuredRoute.route,
+    configuredBinding: configuredRoute.bindingResolution,
+  };
+}
+
+describe("configured binding fallback after a stale runtime binding", () => {
+  beforeEach(() => {
+    testing.resetSessionBindingAdaptersForTests();
+    resolveAgentConfigMock.mockReset().mockReturnValue(undefined);
+    resolveDefaultAgentIdMock.mockReset().mockReturnValue("main");
+    resolveAgentWorkspaceDirMock.mockReset().mockReturnValue("/tmp/workspace");
+    getLoadedChannelPluginMock.mockReset().mockReturnValue(createDemoAcpPlugin());
+    ensureConfiguredBindingBuiltinsRegistered();
+  });
+
+  it("selects the configured ACP binding when the runtime target session is gone", () => {
+    // Session store cannot resolve the catch-all's target: the stale state from #115354.
+    vi.mocked(loadSessionEntryReadOnly).mockReturnValue(undefined);
+    registerRuntimeBinding(STALE_SESSION_KEY);
+
+    const result = resolveChannelRoute(createConfig());
+
+    expect(result.via).toBe("configured");
+    expect(result.configuredBinding).not.toBeNull();
+    // The ACP binding owns the session key, so routing lands on the `review` agent
+    // instead of the catch-all's `main`.
+    expect(result.route.agentId).toBe("review");
+    expect(result.route.matchedBy).toBe("binding.channel");
+    expect(result.route.sessionKey).not.toBe(STALE_SESSION_KEY);
+  });
+
+  it("keeps honoring a live runtime binding over the configured binding", () => {
+    // Documented precedence is unchanged by the guard: a resolvable target still wins.
+    vi.mocked(loadSessionEntryReadOnly).mockReturnValue({} as SessionEntry);
+    registerRuntimeBinding(STALE_SESSION_KEY);
+
+    const result = resolveChannelRoute(createConfig());
+
+    expect(result.via).toBe("runtime");
+    expect(result.route.sessionKey).toBe(STALE_SESSION_KEY);
+    expect(result.route.agentId).toBe("main");
+  });
+});

--- a/src/channels/plugins/binding-routing.session-store.test.ts
+++ b/src/channels/plugins/binding-routing.session-store.test.ts
@@ -1,0 +1,117 @@
+// Exercises runtime binding route resolution against a real SQLite session store,
+// with no session-accessor mocking, so the stale-target fallback is proven end to end.
+import { afterEach, describe, expect, it } from "vitest";
+import { cleanupTempDirs, makeTempDir } from "../../../test/helpers/temp-dir.js";
+import { upsertSessionEntry } from "../../config/sessions/session-accessor.js";
+import {
+  registerSessionBindingAdapter,
+  testing,
+  type SessionBindingRecord,
+} from "../../infra/outbound/session-binding-service.js";
+import type { ResolvedAgentRoute } from "../../routing/resolve-route.js";
+import { closeOpenClawAgentDatabasesForTest } from "../../state/openclaw-agent-db.js";
+import { closeOpenClawStateDatabaseForTest } from "../../state/openclaw-state-db.js";
+import { withEnvAsync } from "../../test-utils/env.js";
+import { resolveRuntimeConversationBindingRoute } from "./binding-routing.js";
+
+const tempDirs: string[] = [];
+
+const LIVE_SESSION_KEY = "agent:review:acp:live-session";
+const DELETED_SESSION_KEY = "agent:review:acp:deleted-session";
+
+function createRoute(): ResolvedAgentRoute {
+  return {
+    agentId: "main",
+    channel: "demo",
+    accountId: "default",
+    sessionKey: "agent:main:main",
+    mainSessionKey: "agent:main:main",
+    lastRoutePolicy: "main",
+    matchedBy: "default",
+  };
+}
+
+function registerAdapter(targetSessionKey: string): void {
+  const record: SessionBindingRecord = {
+    bindingId: "binding-1",
+    targetSessionKey,
+    targetKind: "session",
+    conversation: {
+      channel: "demo",
+      accountId: "default",
+      conversationId: "room-1",
+    },
+    status: "active",
+    boundAt: 1,
+  };
+  registerSessionBindingAdapter({
+    channel: "demo",
+    accountId: "default",
+    listBySession: () => [],
+    resolveByConversation: () => record,
+    touch: () => {},
+  });
+}
+
+function resolveRoute(route: ResolvedAgentRoute) {
+  return resolveRuntimeConversationBindingRoute({
+    route,
+    conversation: {
+      channel: "demo",
+      accountId: "default",
+      conversationId: "room-1",
+    },
+  });
+}
+
+afterEach(() => {
+  testing.resetSessionBindingAdaptersForTests();
+  closeOpenClawAgentDatabasesForTest();
+  closeOpenClawStateDatabaseForTest();
+  cleanupTempDirs(tempDirs);
+});
+
+describe("runtime conversation binding route against the real session store", () => {
+  it("routes to a bound session that still exists in the store", async () => {
+    const stateDir = makeTempDir(tempDirs, "openclaw-binding-live-session-");
+
+    await withEnvAsync({ OPENCLAW_STATE_DIR: stateDir }, async () => {
+      await upsertSessionEntry(
+        { agentId: "review", sessionKey: LIVE_SESSION_KEY },
+        { sessionId: "session-1", updatedAt: 10 },
+      );
+      registerAdapter(LIVE_SESSION_KEY);
+
+      const result = resolveRoute(createRoute());
+
+      expect(result.bindingRecord).not.toBeNull();
+      expect(result.boundSessionKey).toBe(LIVE_SESSION_KEY);
+      expect(result.route.agentId).toBe("review");
+      expect(result.route.sessionKey).toBe(LIVE_SESSION_KEY);
+    });
+  });
+
+  it("falls back to the caller's route when the bound session is gone from the store", async () => {
+    const stateDir = makeTempDir(tempDirs, "openclaw-binding-stale-session-");
+
+    await withEnvAsync({ OPENCLAW_STATE_DIR: stateDir }, async () => {
+      // Only the live session is persisted; the binding points at a session key the
+      // store cannot resolve, which is the state left behind when a session is pruned.
+      await upsertSessionEntry(
+        { agentId: "review", sessionKey: LIVE_SESSION_KEY },
+        { sessionId: "session-1", updatedAt: 10 },
+      );
+      registerAdapter(DELETED_SESSION_KEY);
+
+      const route = createRoute();
+      const result = resolveRoute(route);
+
+      // A null record is what lets the caller keep its configured binding instead of
+      // being stranded on the dead target.
+      expect(result.bindingRecord).toBeNull();
+      expect(result.boundSessionKey).toBeUndefined();
+      expect(result.route).toBe(route);
+      expect(result.route.agentId).toBe("main");
+    });
+  });
+});

--- a/src/channels/plugins/binding-routing.test.ts
+++ b/src/channels/plugins/binding-routing.test.ts
@@ -1,5 +1,7 @@
 // Binding routing tests cover channel binding selection and message routing behavior.
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { loadSessionEntryReadOnly } from "../../config/sessions/session-accessor.js";
+import type { SessionEntry } from "../../config/sessions/types.js";
 import {
   testing,
   registerSessionBindingAdapter,
@@ -12,6 +14,8 @@ import {
   resolveRuntimeConversationBindingRoute,
 } from "./binding-routing.js";
 import { registerStatefulBindingTargetDriver } from "./stateful-target-drivers.js";
+
+vi.mock("../../config/sessions/session-accessor.js", { spy: true });
 
 function createRoute(): ResolvedAgentRoute {
   return {
@@ -60,6 +64,8 @@ function registerAdapter(record: SessionBindingRecord | null): {
 describe("runtime conversation binding route", () => {
   beforeEach(() => {
     testing.resetSessionBindingAdaptersForTests();
+    // Binding targets resolve by default; the stale-target case opts out explicitly.
+    vi.mocked(loadSessionEntryReadOnly).mockReturnValue({} as SessionEntry);
   });
 
   it("rewrites the route to a runtime-bound ACP session and touches the binding", () => {
@@ -140,6 +146,48 @@ describe("runtime conversation binding route", () => {
     expect(result.bindingRecord).toBeNull();
     expect(result.boundSessionKey).toBeUndefined();
     expect(result.route).toBe(route);
+  });
+
+  it("ignores runtime bindings whose target session no longer exists", () => {
+    const route = createRoute();
+    const binding = createBinding();
+    registerAdapter(binding);
+    vi.mocked(loadSessionEntryReadOnly).mockReturnValue(undefined);
+
+    const result = resolveRuntimeConversationBindingRoute({
+      route,
+      conversation: {
+        channel: "demo",
+        accountId: "default",
+        conversationId: "room-1",
+      },
+    });
+
+    // A null record is what lets callers fall back to their configured binding instead of
+    // treating the dead runtime target as authoritative.
+    expect(result.bindingRecord).toBeNull();
+    expect(result.boundSessionKey).toBeUndefined();
+    expect(result.route).toBe(route);
+  });
+
+  it("keeps the runtime binding when the session store read throws", () => {
+    const binding = createBinding();
+    registerAdapter(binding);
+    vi.mocked(loadSessionEntryReadOnly).mockImplementation(() => {
+      throw new Error("session store unavailable");
+    });
+
+    const result = resolveRuntimeConversationBindingRoute({
+      route: createRoute(),
+      conversation: {
+        channel: "demo",
+        accountId: "default",
+        conversationId: "room-1",
+      },
+    });
+
+    expect(result.bindingRecord).toBe(binding);
+    expect(result.boundSessionKey).toBe("agent:review:acp:session-1");
   });
 });
 

--- a/src/channels/plugins/binding-routing.ts
+++ b/src/channels/plugins/binding-routing.ts
@@ -3,6 +3,7 @@
  *
  * Applies configured and runtime conversation bindings to agent route resolution.
  */
+import { loadSessionEntryReadOnly } from "../../config/sessions/session-accessor.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { logVerbose } from "../../globals.js";
 import {
@@ -126,6 +127,16 @@ export function resolveConfiguredBindingRoute(
   };
 }
 
+/** True when a runtime binding still points at a session the store can resolve. */
+function runtimeBindingTargetSessionExists(sessionKey: string): boolean {
+  try {
+    return Boolean(loadSessionEntryReadOnly({ sessionKey, clone: false }));
+  } catch {
+    // A store read failure must not silently drop an otherwise valid binding.
+    return true;
+  }
+}
+
 /**
  * Rewrites an agent route using a persisted runtime conversation binding, when applicable.
  */
@@ -162,6 +173,19 @@ export function resolveRuntimeConversationBindingRoute(
     // plugin is responsible for its runtime target handoff.
     return {
       bindingRecord,
+      route: params.route,
+    };
+  }
+
+  if (!runtimeBindingTargetSessionExists(boundSessionKey)) {
+    // Callers treat any returned record as authoritative and drop lower-priority configured
+    // bindings, so a record pointing at a deleted session would strand the conversation on a
+    // dead target forever instead of falling back. Same shape as the cron-run guard above.
+    logVerbose(
+      `ignored runtime conversation binding ${bindingRecord.bindingId} to missing session ${boundSessionKey}`,
+    );
+    return {
+      bindingRecord: null,
       route: params.route,
     };
   }


### PR DESCRIPTION
Related: #115354

**Scope note (per ClawSweeper):** this is a partial fix, so the link above is deliberately `Related:` rather than a closing keyword. Issue #115354 reports two distinct problems: a *stale* runtime binding overriding a configured ACP binding (handled here) and a *live* runtime binding outranking one (a precedence design question, intentionally untouched — see the reviewer note at the bottom). That issue should stay open after this merges.

## What Problem This Solves

Fixes an issue where users with a configured ACP binding would have their messages routed to the wrong agent when a stale runtime conversation binding existed for the same conversation. Once a catch-all binding wrote a runtime binding into `sessions.json`, that record kept winning even after its target session was deleted, so the conversation was permanently stranded on a dead session and the configured ACP binding never initialized.

Reported on Feishu with a catch-all `accountId: "*"` binding alongside per-user ACP bindings, but the resolver is core, so the same stale-record trap applies to every channel that consults runtime bindings.

## Why This Change Was Made

`resolveRuntimeConversationBindingRoute` treated any binding record with a non-empty `targetSessionKey` as valid. Callers use a returned record as authoritative and discard their lower-priority configured binding, so a record pointing at a deleted session removed the fallback path entirely.

The fix guards the core-owned branch the same way the existing cron-run guard does: if the target session no longer resolves, return a null record so callers fall back normally.

Deliberate boundaries:

- **Plugin-owned records are untouched.** Core already documents that the owning plugin controls its runtime target handoff, so the guard sits after that branch rather than second-guessing plugin lifecycles.
- **A store read failure keeps the binding.** Failing the other way would let a transient store error silently reroute live traffic, which is worse than honoring a possibly-stale record.
- **Routing precedence is unchanged.** Whether a *live* runtime binding should outrank a configured ACP binding is a separate design question — see the note below.

## User Impact

A deleted or pruned session no longer traps a conversation. Messages fall back to the configured binding and the ACP session initializes as intended, instead of silently routing to the catch-all agent. No configuration change and no migration; users currently hand-editing `sessions.json` to recover (the workaround in the issue) no longer need to.

## Evidence

Added two focused tests in `src/channels/plugins/binding-routing.test.ts` and confirmed the first one genuinely gates the fix. With the guard reverted and everything else unchanged:

```
❯ src/channels/plugins/binding-routing.test.ts:168:34
    168|     expect(result.bindingRecord).toBeNull();
       |                                  ^
 Test Files  1 failed (1)
      Tests  1 failed | 5 passed (6)
```

With the guard in place, 6/6 pass. The second test pins the fail-open-on-read-error behavior so it cannot be silently inverted later.

Also run locally, all clean:

- `node --import tsx scripts/check-import-cycles.ts` → `0 runtime value cycle(s)`
- `node --import tsx scripts/check-madge-import-cycles.ts` → `0 cycle(s)`
- `node scripts/run-oxlint.mjs` on both changed files → no findings
- `run-tsgo.mjs -p tsconfig.core.json` and `-p test/tsconfig/tsconfig.core.test.json` → clean
- `./node_modules/.bin/oxfmt` applied

Full-directory `src/channels/plugins/` run: **8 failed files / 23 failed tests on this branch vs 9 failed files / 29 failed tests on clean `origin/main`**. Those failures are pre-existing suite pollution in the full-directory run — they reproduce on `main` without this change, and every one of them passes in isolation. `binding-routing.test.ts` passes 6/6 in isolation on this branch.

`pnpm check:changed` delegated to Blacksmith Testbox, which was unavailable in this environment (`selected binary failed basic --version/--help sanity checks`), so the gates above were run locally per the documented fallback for trusted source.

## Real behavior proof (added after ClawSweeper review)

Added `src/channels/plugins/binding-routing.session-store.test.ts`, an **unmocked** integration test that runs against a real SQLite session store in a temp `OPENCLAW_STATE_DIR`. No `vi.mock` of the session accessor — it persists a real session with `upsertSessionEntry`, registers a real binding adapter, and resolves the route through the production path.

It covers both directions:

1. **Live target** — session persisted in the store, binding points at it → route is rewritten to that session (`agentId: review`, `sessionKey: agent:review:acp:live-session`). Confirms the guard does not break healthy bindings.
2. **Stale target** — binding points at a session key the store cannot resolve, which is the state left behind when a session is pruned → the record is dropped and the caller keeps its own route (`agentId: main`), which is what preserves the configured-binding fallback.

Both pass on this branch. Reverting only `binding-routing.ts` to `origin/main` and rerunning against the same real store fails exactly the stale case:

```
 ❯ src/channels/plugins/binding-routing.session-store.test.ts:111:36
    111|       expect(result.bindingRecord).toBeNull();
       |                                    ^
   {
     "bindingId": "binding-1",
     "targetSessionKey": "agent:review:acp:deleted-session",
     "status": "active",
     ...
   }

 Test Files  1 failed (1)
      Tests  1 failed | 1 passed (2)
```

With the guard restored, both files are green together — 8/8 across the mocked unit tests and the real-store integration tests.

## Explaining the earlier CI failure

The previous red run was `checks-node-compact-small-6`, failing on:

```
src/process/child-process.test.ts > releaseChildProcessOutputAfterExit >
  drains active descendant output after the parent exits
AssertionError: expected 'HEAD\n' to contain 'TAIL'
```

That is an async output-drain race in `src/process/`, which this PR does not touch — the diff is confined to `src/channels/plugins/`. It passes 5/5 locally on this branch. I could not use `gh run rerun` (fork contributors lack the permission), so the proof commit above re-triggers CI.

## Route-level proof (added after the second ClawSweeper review)

The previous round asked for proof that a configured ACP binding is *selected* after the stale record is discarded, not just that the record is dropped. Added `src/channels/plugins/binding-routing.configured-fallback.test.ts`, which chains the two resolvers in the same order channel plugins do — runtime binding first, configured binding only when no runtime record is authoritative — and asserts the resulting route.

Two cases:

1. **Stale runtime target** → resolution goes `via: "configured"`, `bindingResolution` is non-null, and the route lands on `agentId: "review"` (the ACP binding) instead of the catch-all's `main`, with `matchedBy: "binding.channel"`.
2. **Live runtime target** → resolution stays `via: "runtime"` and keeps the bound session. This pins that the guard does **not** alter the documented precedence.

Reverting only `binding-routing.ts` to `origin/main` reproduces the reported bug at route level:

```
FAIL  src/channels/plugins/binding-routing.configured-fallback.test.ts >
  configured binding fallback after a stale runtime binding >
  selects the configured ACP binding when the runtime target session is gone

AssertionError: expected 'runtime' to be 'configured' // Object.is equality
Expected: "configured"
Received: "runtime"

 ❯ src/channels/plugins/binding-routing.configured-fallback.test.ts:164:24
    164|     expect(result.via).toBe("configured");
       |                        ^

 Test Files  1 failed (1)
      Tests  1 failed | 1 passed (2)
```

`Received: "runtime"` is exactly the defect: the dead binding wins and the configured ACP binding is never reached.

With the guard restored, all three files are green together — **10/10** across the mocked unit tests, the real-SQLite-store integration tests, and these route-level tests. `oxfmt`, `run-oxlint.mjs`, and the `core.test` tsgo lane are all clean on the new file.

## Note for reviewers

While confirming this, I found the surrounding precedence handling is inconsistent across channels — `feishu` and `line` set `configuredBinding = null`, `slack` short-circuits, while `telegram` and `imessage` keep the configured binding. Details in [this comment](https://github.com/openclaw/openclaw/issues/115354#issuecomment-5108786549). I deliberately kept that out of this PR since unifying five channels' routing precedence is a product decision, not a bug fix. Happy to open a separate issue for it if useful.



