### PR TITLE
fix(telegram): drain newly admitted updates reliably

### DIFF
--- a/extensions/telegram/src/polling-session.test.ts
+++ b/extensions/telegram/src/polling-session.test.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import { setImmediate as nextMacrotask } from "node:timers/promises";
 import { expectDefined } from "@openclaw/normalization-core";
 import type { ChannelAccountSnapshot } from "openclaw/plugin-sdk/channel-contract";
 import { DEFAULT_INGRESS_RETRY_MAX_ATTEMPTS as TELEGRAM_SPOOLED_RETRY_MAX_ATTEMPTS } from "openclaw/plugin-sdk/channel-outbound";
@@ -116,7 +117,7 @@ let claimNextTelegramSpooledUpdate: typeof import("./telegram-ingress-spool.test
 let listTelegramSpooledUpdateClaims: typeof import("./telegram-ingress-spool.test-support.js").listTelegramSpooledUpdateClaims;
 let listTelegramSpooledUpdates: typeof import("./telegram-ingress-spool.test-support.js").listTelegramSpooledUpdates;
 let recoverStaleTelegramSpooledUpdateClaims: typeof import("./telegram-ingress-spool.test-support.js").recoverStaleTelegramSpooledUpdateClaims;
-let writeTelegramSpooledUpdate: typeof import("./telegram-ingress-spool.js").writeTelegramSpooledUpdate;
+let writeTelegramSpooledUpdate: typeof import("./telegram-ingress-spool.test-support.js").writeTelegramSpooledUpdate;
 let createTelegramSpooledReplayDeferredParticipant: typeof import("./bot-processing-outcome.js").createTelegramSpooledReplayDeferredParticipant;
 type TelegramMessageProcessingResult =
   import("./bot-processing-outcome.js").TelegramMessageProcessingResult;
@@ -833,7 +834,7 @@ function startIsolatedIngressSession(params: {
 describe("TelegramPollingSession", () => {
   beforeAll(async () => {
     ({ TelegramPollingSession } = await import("./polling-session.js"));
-    ({ writeTelegramSpooledUpdate } = await import("./telegram-ingress-spool.js"));
+    ({ writeTelegramSpooledUpdate } = await import("./telegram-ingress-spool.test-support.js"));
     ({
       claimNextTelegramSpooledUpdate,
       listTelegramSpooledUpdateClaims,
@@ -1230,7 +1231,7 @@ describe("TelegramPollingSession", () => {
         await waitForTelegramTestState(() =>
           expect(worker.ackSpooledUpdate).toHaveBeenCalledWith("spool-failure", {
             ok: false,
-            message: "Telegram update missing numeric update_id.",
+            message: "Telegram spooled update is missing numeric update_id.",
           }),
         );
         expect(persistUpdateId).not.toHaveBeenCalled();
@@ -1267,7 +1268,6 @@ describe("TelegramPollingSession", () => {
             updateId: 42,
           }),
         );
-        worker.emit({ type: "spooled", updateId: 42, queued: 1 });
         await waitForTelegramTestState(() =>
           expect(handleUpdate).toHaveBeenCalledWith({ update_id: 42, message: { text: "hello" } }),
         );
@@ -1281,7 +1281,7 @@ describe("TelegramPollingSession", () => {
     });
   });
 
-  it("drains worker-spooled updates that arrive during an active drain", async () => {
+  it("serializes worker admission behind an active drain, then drains the update", async () => {
     await withTempSpool(async (tempDir) => {
       const abort = new AbortController();
       let releaseFirstClaim: (() => void) | undefined;
@@ -1339,15 +1339,18 @@ describe("TelegramPollingSession", () => {
           update: { update_id: 2, message: { text: "during-drain" } },
           queued: 1,
         });
+        // Durable admission shares the monitor's claim lock. The transport must
+        // not ACK a row until the active claim scan releases that ownership.
+        await nextMacrotask();
+        expect(worker.ackSpooledUpdate).not.toHaveBeenCalledWith("write-2", expect.anything());
+        releaseFirstClaim?.();
+        releaseFirstClaim = undefined;
         await waitForTelegramTestState(() =>
           expect(worker.ackSpooledUpdate).toHaveBeenCalledWith("write-2", {
             ok: true,
             updateId: 2,
           }),
         );
-        worker.emit({ type: "spooled", updateId: 2, queued: 1 });
-        releaseFirstClaim?.();
-        releaseFirstClaim = undefined;
 
         await waitForTelegramTestState(() =>
           expect(handleUpdate).toHaveBeenCalledWith({

--- a/extensions/telegram/src/polling-session.ts
+++ b/extensions/telegram/src/polling-session.ts
@@ -24,8 +24,6 @@ import { resolveTelegramAdoptionStallTimeoutMs } from "./telegram-ingress-drain.
 import {
   resolveTelegramIngressSpoolDir,
   resolveTelegramUpdateId,
-  telegramSpooledUpdateLaneKey,
-  writeTelegramSpooledUpdate,
 } from "./telegram-ingress-spool.js";
 import {
   createTelegramIngressWorker,
@@ -521,11 +519,14 @@ export class TelegramPollingSession {
         void (async () => {
           let updateId: number;
           try {
-            updateId = await writeTelegramSpooledUpdate({
-              spoolDir,
-              update: message.update,
-              laneKey: telegramSpooledUpdateLaneKey(message.update, this.opts.botInfo),
-            });
+            const admitted = await ingressMonitor.admit(message.update);
+            if (admitted.kind !== "durable") {
+              throw new Error(`Telegram polling update ${updateIdHint} was not durably admitted.`);
+            }
+            if (typeof updateIdHint !== "number") {
+              throw new Error(`Telegram polling update ${updateIdHint} has an invalid durable id.`);
+            }
+            updateId = updateIdHint;
             this.opts.log(`[telegram][diag] isolated polling update spooled updateId=${updateId}`);
           } catch (err: unknown) {
             this.opts.log(
@@ -549,7 +550,6 @@ export class TelegramPollingSession {
             );
           }
           ackSpooledUpdate(message.requestId, { ok: true, updateId });
-          requestImmediateDrain();
         })();
         return;
       }

--- a/extensions/telegram/src/telegram-ingress-drain.test.ts
+++ b/extensions/telegram/src/telegram-ingress-drain.test.ts
@@ -6,8 +6,8 @@ import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { createChannelIngressQueueForTests } from "openclaw/plugin-sdk/plugin-state-test-runtime";
 import { describe, expect, it } from "vitest";
 import { createTelegramIngressMonitor } from "./telegram-ingress-drain.js";
-import { telegramSpooledUpdateLaneKey } from "./telegram-ingress-spool.test-support.js";
 import type { TelegramSpooledUpdatePayload } from "./telegram-ingress-spool.payload.js";
+import { telegramSpooledUpdateLaneKey } from "./telegram-ingress-spool.test-support.js";
 
 async function withTempState<T>(fn: (stateDir: string) => Promise<T>): Promise<T> {
   const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-telegram-ingress-drain-"));

--- a/extensions/telegram/src/telegram-ingress-drain.test.ts
+++ b/extensions/telegram/src/telegram-ingress-drain.test.ts
@@ -6,7 +6,7 @@ import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { createChannelIngressQueueForTests } from "openclaw/plugin-sdk/plugin-state-test-runtime";
 import { describe, expect, it } from "vitest";
 import { createTelegramIngressMonitor } from "./telegram-ingress-drain.js";
-import { telegramSpooledUpdateLaneKey } from "./telegram-ingress-spool.js";
+import { telegramSpooledUpdateLaneKey } from "./telegram-ingress-spool.test-support.js";
 import type { TelegramSpooledUpdatePayload } from "./telegram-ingress-spool.payload.js";
 
 async function withTempState<T>(fn: (stateDir: string) => Promise<T>): Promise<T> {

--- a/extensions/telegram/src/telegram-ingress-spool.test-support.ts
+++ b/extensions/telegram/src/telegram-ingress-spool.test-support.ts
@@ -10,8 +10,8 @@ import {
   type ChannelIngressQueueRecord,
 } from "openclaw/plugin-sdk/channel-outbound";
 import type { TelegramBotInfo } from "./bot-info.js";
-import { openTelegramIngressQueue, resolveTelegramUpdateId } from "./telegram-ingress-spool.js";
 import { getTelegramSequentialKey } from "./sequential-key.js";
+import { openTelegramIngressQueue, resolveTelegramUpdateId } from "./telegram-ingress-spool.js";
 import {
   TELEGRAM_SPOOLED_UPDATE_PAYLOAD_VERSION,
   type TelegramSpooledUpdatePayload,

--- a/extensions/telegram/src/telegram-ingress-spool.test-support.ts
+++ b/extensions/telegram/src/telegram-ingress-spool.test-support.ts
@@ -10,10 +10,8 @@ import {
   type ChannelIngressQueueRecord,
 } from "openclaw/plugin-sdk/channel-outbound";
 import type { TelegramBotInfo } from "./bot-info.js";
-import {
-  openTelegramIngressQueue,
-  telegramSpooledUpdateLaneKey,
-} from "./telegram-ingress-spool.js";
+import { openTelegramIngressQueue, resolveTelegramUpdateId } from "./telegram-ingress-spool.js";
+import { getTelegramSequentialKey } from "./sequential-key.js";
 import {
   TELEGRAM_SPOOLED_UPDATE_PAYLOAD_VERSION,
   type TelegramSpooledUpdatePayload,
@@ -43,6 +41,40 @@ export type ClaimedTelegramSpooledUpdate = TelegramSpooledUpdate & {
 
 export function telegramQueueEventId(updateId: number): string {
   return String(updateId).padStart(16, "0");
+}
+
+export function telegramSpooledUpdateLaneKey(update: unknown, botInfo?: TelegramBotInfo): string {
+  return getTelegramSequentialKey({
+    update: update as Parameters<typeof getTelegramSequentialKey>[0]["update"],
+    ...(botInfo ? { me: botInfo } : {}),
+  });
+}
+
+export async function writeTelegramSpooledUpdate(params: {
+  spoolDir: string;
+  update: unknown;
+  laneKey?: string;
+  now?: number;
+}): Promise<number> {
+  const updateId = resolveTelegramUpdateId(params.update);
+  if (updateId === null) {
+    throw new Error("Telegram update missing numeric update_id.");
+  }
+  const receivedAt = params.now ?? Date.now();
+  await openTelegramIngressQueue(params.spoolDir).enqueue(
+    telegramQueueEventId(updateId),
+    {
+      version: TELEGRAM_SPOOLED_UPDATE_PAYLOAD_VERSION,
+      updateId,
+      receivedAt,
+      update: params.update,
+    },
+    {
+      receivedAt,
+      laneKey: params.laneKey ?? telegramSpooledUpdateLaneKey(params.update),
+    },
+  );
+  return updateId;
 }
 
 function spoolFileName(updateId: number): string {

--- a/extensions/telegram/src/telegram-ingress-spool.test.ts
+++ b/extensions/telegram/src/telegram-ingress-spool.test.ts
@@ -12,12 +12,12 @@ import { clearTelegramRuntimeForTest } from "./runtime.test-support.js";
 import {
   openTelegramIngressQueue,
   resolveTelegramIngressSpoolDir,
-  telegramSpooledUpdateLaneKey,
-  writeTelegramSpooledUpdate,
 } from "./telegram-ingress-spool.js";
 import {
   listTelegramSpooledUpdates,
   telegramQueueEventId,
+  telegramSpooledUpdateLaneKey,
+  writeTelegramSpooledUpdate,
 } from "./telegram-ingress-spool.test-support.js";
 
 async function withTempState<T>(

--- a/extensions/telegram/src/telegram-ingress-spool.ts
+++ b/extensions/telegram/src/telegram-ingress-spool.ts
@@ -6,10 +6,7 @@ import { computeBackoff, type BackoffPolicy } from "openclaw/plugin-sdk/runtime-
 import { resolveStateDir } from "openclaw/plugin-sdk/state-paths";
 import { getTelegramRuntime } from "./runtime.js";
 import { normalizeTelegramStateAccountId } from "./state-account-id.js";
-import {
-  TELEGRAM_SPOOLED_UPDATE_PAYLOAD_VERSION,
-  type TelegramSpooledUpdatePayload,
-} from "./telegram-ingress-spool.payload.js";
+import type { TelegramSpooledUpdatePayload } from "./telegram-ingress-spool.payload.js";
 const TELEGRAM_INGRESS_SPOOL_PREFIX = "ingress-spool-";
 export const TELEGRAM_SPOOLED_UPDATE_FAILED_TTL_MS = 30 * 24 * 60 * 60 * 1000;
 export const TELEGRAM_SPOOLED_UPDATE_FAILED_MAX_ENTRIES = 1000;

--- a/extensions/telegram/src/telegram-ingress-spool.ts
+++ b/extensions/telegram/src/telegram-ingress-spool.ts
@@ -4,9 +4,7 @@ import path from "node:path";
 import type { ChannelIngressQueue } from "openclaw/plugin-sdk/channel-outbound";
 import { computeBackoff, type BackoffPolicy } from "openclaw/plugin-sdk/runtime-env";
 import { resolveStateDir } from "openclaw/plugin-sdk/state-paths";
-import type { TelegramBotInfo } from "./bot-info.js";
 import { getTelegramRuntime } from "./runtime.js";
-import { getTelegramSequentialKey } from "./sequential-key.js";
 import { normalizeTelegramStateAccountId } from "./state-account-id.js";
 import {
   TELEGRAM_SPOOLED_UPDATE_PAYLOAD_VERSION,
@@ -79,45 +77,6 @@ export function openTelegramIngressQueue(
     accountId: parts.accountId,
     stateDir: parts.stateDir,
   });
-}
-
-export function telegramSpooledUpdateLaneKey(update: unknown, botInfo?: TelegramBotInfo): string {
-  return getTelegramSequentialKey({
-    update: update as Parameters<typeof getTelegramSequentialKey>[0]["update"],
-    ...(botInfo ? { me: botInfo } : {}),
-  });
-}
-
-/**
- * Durable-before-ack accept path: commit the update to the ingress queue.
- * Polling advances offset only after this returns; webhook returns 200 only after.
- */
-export async function writeTelegramSpooledUpdate(params: {
-  spoolDir: string;
-  update: unknown;
-  laneKey?: string;
-  now?: number;
-}): Promise<number> {
-  const updateId = resolveTelegramUpdateId(params.update);
-  if (updateId === null) {
-    throw new Error("Telegram update missing numeric update_id.");
-  }
-  const receivedAt = params.now ?? Date.now();
-  const queue = openTelegramIngressQueue(params.spoolDir);
-  await queue.enqueue(
-    telegramQueueEventId(updateId),
-    {
-      version: TELEGRAM_SPOOLED_UPDATE_PAYLOAD_VERSION,
-      updateId,
-      receivedAt,
-      update: params.update,
-    },
-    {
-      receivedAt,
-      laneKey: params.laneKey ?? telegramSpooledUpdateLaneKey(params.update),
-    },
-  );
-  return updateId;
 }
 
 /** Backoff for irrevocable-adoption completion retries (bot-message only). */

--- a/extensions/telegram/src/webhook.test.ts
+++ b/extensions/telegram/src/webhook.test.ts
@@ -20,10 +20,10 @@ import {
 import { setTelegramRuntime } from "./runtime.js";
 import { clearTelegramRuntimeForTest as clearTelegramRuntime } from "./runtime.test-support.js";
 import type { TelegramRuntime } from "./runtime.types.js";
-import { writeTelegramSpooledUpdate } from "./telegram-ingress-spool.js";
 import {
   listTelegramSpooledUpdateClaims,
   listTelegramSpooledUpdates,
+  writeTelegramSpooledUpdate,
 } from "./telegram-ingress-spool.test-support.js";
 
 const telegramSpooledRetryDeadLetterMinAgeMs = 24 * 60 * 60 * 1000;

--- a/extensions/telegram/src/webhook.ts
+++ b/extensions/telegram/src/webhook.ts
@@ -36,12 +36,8 @@ import { withTelegramApiErrorLogging } from "./api-logging.js";
 import { createTelegramBot } from "./bot.js";
 import { resolveTelegramTransport } from "./fetch.js";
 import { isRetryableTelegramApiError } from "./network-errors.js";
-import { getTelegramSequentialKey } from "./sequential-key.js";
 import { createTelegramTransportIngressMonitor } from "./telegram-ingress-drain-factory.js";
-import {
-  resolveTelegramIngressSpoolDir,
-  writeTelegramSpooledUpdate,
-} from "./telegram-ingress-spool.js";
+import { resolveTelegramIngressSpoolDir } from "./telegram-ingress-spool.js";
 import { createTelegramWebhookStatusPublisher } from "./webhook-status.js";
 
 const TELEGRAM_WEBHOOK_MAX_BODY_BYTES = 1024 * 1024;
@@ -295,12 +291,6 @@ function resolveTelegramWebhookRateLimitKey(
   return `${path}:${resolveTelegramWebhookClientIp(req, config)}`;
 }
 
-function resolveWebhookSpooledUpdateLaneKey(update: unknown): string {
-  return getTelegramSequentialKey({
-    update: update as Parameters<typeof getTelegramSequentialKey>[0]["update"],
-  });
-}
-
 export async function startTelegramWebhook(opts: {
   token: string;
   accountId?: string;
@@ -387,7 +377,6 @@ export async function startTelegramWebhook(opts: {
 
   const log = (line: string) => runtime.log?.(line);
   let webhookIngressMonitor: ReturnType<typeof createTelegramTransportIngressMonitor> | undefined;
-  const requestWebhookSpoolDrain = () => webhookIngressMonitor?.requestDrain();
   const startWebhookSpoolDrain = () => {
     if (webhookIngressMonitor) {
       return;
@@ -480,17 +469,15 @@ export async function startTelegramWebhook(opts: {
 
       // Telegram sees 200 only after the update is durable. If SQLite rejects
       // the enqueue, this path returns non-200 so Telegram redelivers.
-      await writeTelegramSpooledUpdate({
-        spoolDir,
-        update: body.value,
-        laneKey: resolveWebhookSpooledUpdateLaneKey(body.value),
-      });
+      const admitted = await webhookIngressMonitor?.admit(body.value);
+      if (!admitted || admitted.kind !== "durable") {
+        throw new Error("Telegram webhook update was not durably admitted.");
+      }
       // Enqueue duplicate detection makes Telegram webhook retries idempotent:
       // re-posted update_ids map to the same spool row and still ack fast.
       res.setHeader(TELEGRAM_WEBHOOK_ACCEPTED_HEADER, TELEGRAM_WEBHOOK_ACCEPTED_VALUE);
       respondText(200);
       status.noteWebhookUpdateReceived();
-      requestWebhookSpoolDrain();
       if (diagnosticsEnabled) {
         logWebhookProcessed({
           channel: "telegram",


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Telegram polling could accept and durably spool an inbound update, advance its offset, and then never dispatch that update to the agent. The same split ownership also existed on webhook admission: transports wrote through a separate queue instance and manually poked the monitor pump instead of using the monitor's admission lifecycle.

The failure was captured during exact-head live proof for #107179: Telegram delivered two updates, both were spooled and their offsets persisted, but neither row was claimed before the scenario timed out.

## Why This Change Was Made

Polling and webhook now admit updates through the one shared Telegram ingress monitor. That monitor owns durable enqueue, admission/claim serialization, and pump scheduling, so transport acknowledgement cannot drift from the queue instance that drains the row. The old production-only enqueue helper and duplicate lane derivation path are deleted; queue seeding remains test-only.

The regression tests also stop injecting a synthetic second `spooled` event after the real worker update. They now prove the actual update path schedules its own drain and that an update arriving during an active claim scan is not acknowledged until durable admission safely obtains the shared ownership lock.

## User Impact

Telegram messages admitted by polling or webhook are reliably handed to the agent instead of remaining stranded in durable ingress storage until a restart or later recovery pass.

## Evidence

- Live before-fix reproduction: Mantis Telegram run [30385677387](https://github.com/openclaw/openclaw/actions/runs/30385677387) on #107179 received and spooled update IDs `268380661` and `268380662`, persisted both offsets, recorded no Telegram reply, and timed out after 45 seconds. The redacted evidence artifact is [8699501960](https://github.com/openclaw/openclaw/actions/runs/30385677387/artifacts/8699501960).
- Exact refreshed branch: Testbox run [30392828052](https://github.com/openclaw/openclaw/actions/runs/30392828052) passed 120 focused polling, webhook, ingress-drain, and spool tests.
- Exact path-scoped changed gate: Testbox run [30394024141](https://github.com/openclaw/openclaw/actions/runs/30394024141) passed formatting, dead-export scans, extension production/test typechecks, lint, plugin boundaries, database-first checks, import cycles, and repository guards.
- Fresh Codex autoreview on the exact branch against current `main`: clean, no accepted/actionable findings (0.90 confidence).
- `git diff --check` passed.

AI-assisted maintainer fix; I reviewed the polling and webhook durable-before-ack paths, shared monitor admission/claim ordering, queue ownership, tests, and live failure artifacts.
