### PR TITLE
feat(ui): add host control policy

### DIFF
--- a/ui/src/api/gateway.node.test.ts
+++ b/ui/src/api/gateway.node.test.ts
@@ -401,6 +401,24 @@ describe("GatewayBrowserClient", () => {
     vi.unstubAllGlobals();
   });
 
+  it("rejects Gateway requests when a host request preflight blocks the method", async () => {
+    const client = new GatewayBrowserClient({
+      url: DEFAULT_GATEWAY_URL,
+      requestPreflight: (method) => ({
+        ok: false,
+        code: "HOST_POLICY_BLOCKED",
+        message: `${method} blocked`,
+        details: { method },
+      }),
+    });
+
+    await expect(client.request("sessions.delete")).rejects.toMatchObject({
+      gatewayCode: "HOST_POLICY_BLOCKED",
+      details: { method: "sessions.delete" },
+    });
+    expect(wsInstances).toHaveLength(0);
+  });
+
   it("requests full control ui operator scopes with explicit shared auth", async () => {
     const client = new GatewayBrowserClient({
       url: "ws://127.0.0.1:18789",
@@ -413,6 +431,18 @@ describe("GatewayBrowserClient", () => {
     expect(connectFrame.params?.minProtocol).toBe(MIN_CLIENT_PROTOCOL_VERSION);
     expect(connectFrame.params?.maxProtocol).toBe(PROTOCOL_VERSION);
     expect(connectFrame.params?.scopes).toEqual([...CONTROL_UI_OPERATOR_SCOPES]);
+  });
+
+  it("uses host-provided operator scopes when connecting", async () => {
+    const client = new GatewayBrowserClient({
+      url: "ws://127.0.0.1:18789",
+      token: "shared-auth-token",
+      operatorScopes: ["operator.read", "operator.write"],
+    });
+
+    const { connectFrame } = await startConnect(client);
+
+    expect(connectFrame.params?.scopes).toEqual(["operator.read", "operator.write"]);
   });
 
   it("adds the current Control UI protocol to bare protocol mismatch errors", () => {

--- a/ui/src/api/gateway.ts
+++ b/ui/src/api/gateway.ts
@@ -306,6 +306,15 @@ export type GatewayBrowserClientOptions = {
   onGap?: (info: { expected: number; received: number }) => void;
   onRequestTiming?: (timing: GatewayRequestTiming) => void;
   onConnectTiming?: (timing: GatewayConnectTiming) => void;
+  operatorScopes?: readonly string[];
+  requestPreflight?: (method: string) =>
+    | { ok: true }
+    | {
+        ok: false;
+        code: string;
+        message: string;
+        details?: unknown;
+      };
 };
 
 export type GatewayEventListener = (evt: GatewayEventFrame) => void;
@@ -430,7 +439,13 @@ function formatBrowserWebSocketConstructorError(err: unknown, url: string): Gate
   };
 }
 
-function resolveControlUiConnectScopes(selectedAuth: SelectedConnectAuth): string[] {
+function resolveControlUiConnectScopes(
+  selectedAuth: SelectedConnectAuth,
+  operatorScopes?: readonly string[],
+): string[] {
+  if (operatorScopes && operatorScopes.length > 0) {
+    return [...operatorScopes];
+  }
   const isUsingStoredDeviceToken =
     Boolean(selectedAuth.storedToken) &&
     (selectedAuth.resolvedDeviceToken === selectedAuth.storedToken ||
@@ -821,7 +836,7 @@ export class GatewayBrowserClient {
         deviceId: deviceIdentity.deviceId,
       });
     }
-    const scopes = resolveControlUiConnectScopes(selectedAuth);
+    const scopes = resolveControlUiConnectScopes(selectedAuth, this.opts.operatorScopes);
     const device = await buildGatewayConnectDevice({
       deviceIdentity,
       client,
@@ -1121,6 +1136,16 @@ export class GatewayBrowserClient {
   }
 
   request<T = unknown>(method: string, params?: unknown): Promise<T> {
+    const preflight = this.opts.requestPreflight?.(method);
+    if (preflight && !preflight.ok) {
+      return Promise.reject(
+        new GatewayRequestError({
+          code: preflight.code,
+          message: preflight.message,
+          details: preflight.details,
+        }),
+      );
+    }
     if (!this.ws || this.ws.readyState !== WebSocket.OPEN) {
       return Promise.reject(new Error("gateway not connected"));
     }

--- a/ui/src/api/gateway.ts
+++ b/ui/src/api/gateway.ts
@@ -307,6 +307,8 @@ export type GatewayBrowserClientOptions = {
   onRequestTiming?: (timing: GatewayRequestTiming) => void;
   onConnectTiming?: (timing: GatewayConnectTiming) => void;
   operatorScopes?: readonly string[];
+  // Browser-side presentation preflight only; server and hosted gateways must
+  // still enforce authorization.
   requestPreflight?: (method: string) =>
     | { ok: true }
     | {

--- a/ui/src/app-routes.ts
+++ b/ui/src/app-routes.ts
@@ -73,10 +73,16 @@ export async function startApplicationRouter(
   context: ApplicationContext<RouteId>,
 ): Promise<void> {
   const location = history.location();
-  if (routeIdFromPath(location.pathname, basePath) === null) {
+  const routeId = routeIdFromPath(location.pathname, basePath);
+  if (routeId === null || !context.hostPolicy.isRouteEnabled(routeId)) {
+    const fallbackRoute = APP_ROUTE_IDS.find((candidate) =>
+      context.hostPolicy.isRouteEnabled(candidate),
+    );
     history.replace({
       ...location,
-      pathname: router.pathForRoute("chat", basePath),
+      pathname: router.pathForRoute(fallbackRoute ?? "chat", basePath),
+      search: "",
+      hash: "",
     });
   }
   await router.start(history, basePath, context);

--- a/ui/src/app/app-host.ts
+++ b/ui/src/app/app-host.ts
@@ -407,6 +407,7 @@ class OpenClawShell extends LitElement {
   private stopRouteSubscription: (() => void) | undefined;
   private stopOverlaySubscription: (() => void) | undefined;
   private stopRuntimeConfigSubscription: (() => void) | undefined;
+  private stopHostPolicySubscription: (() => void) | undefined;
   private stopThemeSubscription: (() => void) | undefined;
 
   override createRenderRoot() {
@@ -437,6 +438,7 @@ class OpenClawShell extends LitElement {
       this.stopRouteSubscription ||
       this.stopOverlaySubscription ||
       this.stopRuntimeConfigSubscription ||
+      this.stopHostPolicySubscription ||
       this.stopThemeSubscription
     ) {
       return;
@@ -478,7 +480,10 @@ class OpenClawShell extends LitElement {
       this.overlaySnapshot = snapshot;
     });
     this.stopRuntimeConfigSubscription = context.runtimeConfig.subscribe(() => {
-      // Route enablement (e.g. Workboard) derives from the config snapshot.
+      // Route enablement derives from runtime config and host policy.
+      this.requestUpdate();
+    });
+    this.stopHostPolicySubscription = context.hostPolicy.subscribe(() => {
       this.requestUpdate();
     });
   }
@@ -500,6 +505,8 @@ class OpenClawShell extends LitElement {
     this.stopOverlaySubscription = undefined;
     this.stopRuntimeConfigSubscription?.();
     this.stopRuntimeConfigSubscription = undefined;
+    this.stopHostPolicySubscription?.();
+    this.stopHostPolicySubscription = undefined;
     this.stopThemeSubscription?.();
     this.stopThemeSubscription = undefined;
     this.agentsListClient = null;
@@ -660,9 +667,15 @@ class OpenClawShell extends LitElement {
   }
 
   private enabledRouteIds(): readonly RouteId[] {
-    return isWorkboardEnabledInConfigSnapshot(this.context?.runtimeConfig.state.configSnapshot)
+    const baseRoutes = isWorkboardEnabledInConfigSnapshot(
+      this.context?.runtimeConfig.state.configSnapshot,
+    )
       ? APP_ROUTE_IDS
       : ROUTE_IDS_WITHOUT_WORKBOARD;
+    const hostPolicy = this.context?.hostPolicy;
+    return hostPolicy
+      ? baseRoutes.filter((routeId) => hostPolicy.isRouteEnabled(routeId))
+      : baseRoutes;
   }
 
   private ensureAgentsList(snapshot: { client: GatewayBrowserClient | null; connected: boolean }) {
@@ -710,6 +723,12 @@ class OpenClawShell extends LitElement {
   private updateRouteState(routeState: ShellRouteState) {
     this.routeState = routeState;
     const context = this.context;
+    if (context && routeState.routeId && !context.hostPolicy.isRouteEnabled(routeState.routeId)) {
+      context.replace(
+        APP_ROUTE_IDS.find((routeId) => context.hostPolicy.isRouteEnabled(routeId)) ?? "chat",
+      );
+      return;
+    }
     if (context) {
       this.ensureAgentsList(context.gateway.snapshot);
     }

--- a/ui/src/app/bootstrap.ts
+++ b/ui/src/app/bootstrap.ts
@@ -28,6 +28,7 @@ import type {
 } from "./context.ts";
 import { syncCustomThemeStyleTag } from "./custom-theme.ts";
 import { createApplicationGateway } from "./gateway-store.ts";
+import { createHostPolicyCapability } from "./host-policy.ts";
 import { createNativeChatDrafts } from "./native-bridge.ts";
 import { createApplicationOverlays } from "./overlays.ts";
 import {
@@ -213,6 +214,28 @@ function createSkillWorkshopRevisionHandoff(): ApplicationSkillWorkshopRevisionH
   };
 }
 
+function resolveHostedGatewayUrl(path: string, basePath: string): string | undefined {
+  const trimmed = path.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+  try {
+    const pageHref = globalThis.location?.href ?? "http://127.0.0.1/";
+    const normalizedPath = trimmed.startsWith("/") ? trimmed : `${basePath}/${trimmed}`;
+    const url = new URL(normalizedPath, pageHref);
+    if (url.protocol === "ws:" || url.protocol === "wss:") {
+      return url.href;
+    }
+    if (url.protocol === "http:" || url.protocol === "https:") {
+      url.protocol = url.protocol === "https:" ? "wss:" : "ws:";
+      return url.href;
+    }
+  } catch {
+    return undefined;
+  }
+  return undefined;
+}
+
 export type ApplicationRuntime = {
   readonly context: ApplicationContext<RouteId>;
   readonly router: ApplicationRouter;
@@ -251,7 +274,17 @@ export function bootstrapApplication(): ApplicationRuntime {
   }
 
   const settings = startup.settings;
-  const gateway = createApplicationGateway(settings, startup.password ?? "");
+  const hostPolicy = createHostPolicyCapability();
+  const gateway = createApplicationGateway(
+    settings,
+    startup.password ?? "",
+    undefined,
+    hostPolicy.preflightAction,
+    () => ({
+      gatewayUrl: resolveHostedGatewayUrl(hostPolicy.snapshot.gateway.path, basePath),
+      operatorScopes: hostPolicy.snapshot.gateway.scopes,
+    }),
+  );
   const agents = createAgentCapability(gateway);
   const agentIdentity = createAgentIdentityCapability(gateway);
   const agentSelection = createAgentSelectionCapability(gateway);
@@ -265,7 +298,7 @@ export function bootstrapApplication(): ApplicationRuntime {
   });
   const sessions = createSessionCapability(gateway);
   const workboard = createWorkboardCapability();
-  const runtimeConfig = createRuntimeConfigCapability(gateway);
+  const runtimeConfig = createRuntimeConfigCapability(gateway, hostPolicy);
   const overlays = createApplicationOverlays(gateway);
   const navigation = createApplicationNavigationPreferences(settings);
   const theme = createApplicationTheme(settings);
@@ -327,6 +360,7 @@ export function bootstrapApplication(): ApplicationRuntime {
   const context: ApplicationContext<RouteId> = {
     basePath,
     gateway,
+    hostPolicy,
     agents,
     agentIdentity,
     agentSelection,
@@ -342,6 +376,9 @@ export function bootstrapApplication(): ApplicationRuntime {
     webPush,
     skillWorkshopRevision,
     navigate: (routeId, options) => {
+      if (!context.hostPolicy.isRouteEnabled(routeId)) {
+        return;
+      }
       void router
         .navigate(routeId, context, { history: "push" }, routeLocation(routeId, options))
         .catch((error: unknown) => {
@@ -349,6 +386,9 @@ export function bootstrapApplication(): ApplicationRuntime {
         });
     },
     replace: (routeId, options) => {
+      if (!context.hostPolicy.isRouteEnabled(routeId)) {
+        return;
+      }
       void router
         .navigate(routeId, context, { history: "replace" }, routeLocation(routeId, options))
         .catch((error: unknown) => {
@@ -366,6 +406,7 @@ export function bootstrapApplication(): ApplicationRuntime {
     confirmPendingGatewayConnection,
     cancelPendingGatewayConnection,
     start: async () => {
+      await hostPolicy.refresh(basePath);
       void config.refresh({ skipWithoutAuthCandidate: true });
       const routerStart = startApplicationRouter(router, history, basePath, context);
       gateway.start();

--- a/ui/src/app/context.ts
+++ b/ui/src/app/context.ts
@@ -11,6 +11,7 @@ import type { WorkboardCapability } from "../lib/workboard/capability.ts";
 import type { AgentSelectionCapability } from "./agent-selection.ts";
 import type { ApplicationConfigCapability } from "./config.ts";
 import type { ApplicationGateway } from "./gateway.ts";
+import type { HostPolicyCapability } from "./host-policy.ts";
 import type { NativeChatDrafts } from "./native-bridge.ts";
 import type { ApplicationOverlays } from "./overlays.ts";
 import type { ThemeMode } from "./theme.ts";
@@ -60,6 +61,7 @@ export type ApplicationSkillWorkshopRevisionHandoff = {
 export type ApplicationContext<TRouteId extends string = string> = {
   readonly basePath: string;
   readonly gateway: ApplicationGateway;
+  readonly hostPolicy: HostPolicyCapability;
   readonly agents: AgentCapability;
   readonly agentIdentity: AgentIdentityCapability;
   readonly agentSelection: AgentSelectionCapability;

--- a/ui/src/app/gateway-store.test.ts
+++ b/ui/src/app/gateway-store.test.ts
@@ -153,4 +153,51 @@ describe("createApplicationGateway reconnecting snapshot", () => {
     // The superseded client cannot demote the fresh attempt's snapshot.
     expect(gateway.snapshot.reconnecting).toBe(true);
   });
+
+  it("passes the host request preflight to GatewayBrowserClient", () => {
+    const requestPreflight = vi.fn(() => ({ ok: true as const }));
+    const clients: FakeGatewayClient[] = [];
+    const gateway = createApplicationGateway(
+      loadSettings(),
+      "",
+      (opts) => {
+        const client = new FakeGatewayClient(opts);
+        clients.push(client);
+        return client as unknown as GatewayBrowserClient;
+      },
+      requestPreflight,
+    );
+
+    gateway.start();
+
+    expect(clients.at(-1)?.opts.requestPreflight).toBe(requestPreflight);
+  });
+
+  it("uses host Gateway URL and scopes when creating the browser client", () => {
+    const clients: FakeGatewayClient[] = [];
+    const gateway = createApplicationGateway(
+      loadSettings(),
+      "",
+      (opts) => {
+        const client = new FakeGatewayClient(opts);
+        clients.push(client);
+        return client as unknown as GatewayBrowserClient;
+      },
+      undefined,
+      () => ({
+        gatewayUrl: "wss://lobster.example/v1/openclaw-gateway?client_family=hosted-control-ui",
+        operatorScopes: ["operator.read", "operator.write"],
+      }),
+    );
+
+    gateway.start();
+
+    expect(gateway.connection.gatewayUrl).toBe(
+      "wss://lobster.example/v1/openclaw-gateway?client_family=hosted-control-ui",
+    );
+    expect(clients.at(-1)?.opts).toMatchObject({
+      url: "wss://lobster.example/v1/openclaw-gateway?client_family=hosted-control-ui",
+      operatorScopes: ["operator.read", "operator.write"],
+    });
+  });
 });

--- a/ui/src/app/gateway-store.ts
+++ b/ui/src/app/gateway-store.ts
@@ -18,6 +18,10 @@ import type {
 import { loadSettings, patchSettings } from "./settings.ts";
 
 type GatewayClientFactory = (opts: GatewayBrowserClientOptions) => GatewayBrowserClient;
+type HostedGatewayConfigProvider = () => {
+  gatewayUrl?: string;
+  operatorScopes?: readonly string[];
+};
 
 const defaultClientFactory: GatewayClientFactory = (opts) => new GatewayBrowserClient(opts);
 
@@ -25,6 +29,8 @@ export function createApplicationGateway(
   initialSettings: ReturnType<typeof loadSettings>,
   initialPassword = "",
   createClient: GatewayClientFactory = defaultClientFactory,
+  requestPreflight?: GatewayBrowserClientOptions["requestPreflight"],
+  hostedGatewayConfig?: HostedGatewayConfigProvider,
 ): ApplicationGateway {
   let settings = initialSettings;
   let connection: ApplicationGatewayConnection = {
@@ -89,7 +95,11 @@ export function createApplicationGateway(
 
   const connect = (overrides: ApplicationGatewayConnectOptions = {}) => {
     const { sessionKey: requestedSessionKey, ...connectionOverrides } = overrides;
-    const nextConnection = { ...connection, ...connectionOverrides };
+    const hostedConfig = hostedGatewayConfig?.();
+    const hostedConnection = hostedConfig?.gatewayUrl
+      ? { gatewayUrl: hostedConfig.gatewayUrl }
+      : {};
+    const nextConnection = { ...connection, ...connectionOverrides, ...hostedConnection };
     const hasRequestedSessionKey = requestedSessionKey !== undefined;
     const nextSessionKey = hasRequestedSessionKey
       ? requestedSessionKey.trim()
@@ -117,6 +127,8 @@ export function createApplicationGateway(
       clientVersion: "dev",
       mode: "webchat",
       instanceId: generateUUID(),
+      operatorScopes: hostedConfig?.operatorScopes,
+      requestPreflight,
       onHello: (hello: GatewayHelloOk) => {
         if (client !== nextClient) {
           return;

--- a/ui/src/app/host-policy.test.ts
+++ b/ui/src/app/host-policy.test.ts
@@ -16,7 +16,7 @@ describe("createHostPolicyCapability", () => {
     expect(policy.preflightAction("sessions.delete")).toEqual({ ok: true });
   });
 
-  it("normalizes routes, settings, and actions from a host policy wrapper", () => {
+  it("normalizes routes, coarse settings, and actions from a host policy wrapper", () => {
     const policy = createHostPolicyCapability({
       hostControlPolicy: {
         version: 1,
@@ -31,7 +31,7 @@ describe("createHostPolicyCapability", () => {
           logs: "readOnly",
         },
         settings: {
-          "agents.*": { state: "readOnly", reason: "deployment owned" },
+          "*": { state: "readOnly", reason: "deployment owned" },
           "agents.list.0.model": "editable",
         },
         actions: {
@@ -44,7 +44,7 @@ describe("createHostPolicyCapability", () => {
     expect(policy.snapshot.host).toMatchObject({ id: "lobster", mode: "hosted" });
     expect(policy.isRouteEnabled("debug")).toBe(false);
     expect(policy.routeState("logs")).toBe("readOnly");
-    expect(policy.settingState(["agents", "list", "0", "model"])).toBe("editable");
+    expect(policy.settingState(["agents", "list", "0", "model"])).toBe("readOnly");
     expect(policy.settingState(["agents", "defaults", "model"])).toBe("readOnly");
     expect(policy.canInvokeAction("sessions.delete")).toBe(false);
     expect(policy.preflightAction("config.save")).toMatchObject({
@@ -65,7 +65,7 @@ describe("createHostPolicyCapability", () => {
           gateway: { path: "/v1/openclaw-gateway", scopes: ["operator.read"] },
           defaults: { route: "enabled", setting: "editable", action: "enabled" },
           routes: { channels: "disabled" },
-          settings: {},
+          settings: { "*": "locked" },
           actions: {},
         },
       }),
@@ -79,5 +79,6 @@ describe("createHostPolicyCapability", () => {
       credentials: "same-origin",
     });
     expect(policy.isRouteEnabled("channels")).toBe(false);
+    expect(policy.isSettingEditable("*")).toBe(false);
   });
 });

--- a/ui/src/app/host-policy.test.ts
+++ b/ui/src/app/host-policy.test.ts
@@ -1,0 +1,83 @@
+// @vitest-environment node
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createHostPolicyCapability } from "./host-policy.ts";
+
+describe("createHostPolicyCapability", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("defaults to unrestricted local Control UI behavior", () => {
+    const policy = createHostPolicyCapability();
+
+    expect(policy.snapshot.host).toMatchObject({ id: "openclaw", mode: "local" });
+    expect(policy.isRouteEnabled("config")).toBe(true);
+    expect(policy.isSettingEditable(["agents", "defaults", "model"])).toBe(true);
+    expect(policy.preflightAction("sessions.delete")).toEqual({ ok: true });
+  });
+
+  it("normalizes routes, settings, and actions from a host policy wrapper", () => {
+    const policy = createHostPolicyCapability({
+      hostControlPolicy: {
+        version: 1,
+        host: { id: "lobster", mode: "hosted", displayName: "Lobster" },
+        gateway: {
+          path: "/v1/openclaw-gateway?client_family=hosted-control-ui",
+          scopes: ["operator.read", "operator.write"],
+        },
+        defaults: { route: "enabled", setting: "editable", action: "enabled" },
+        routes: {
+          debug: { state: "disabled", reason: "host diagnostics only" },
+          logs: "readOnly",
+        },
+        settings: {
+          "agents.*": { state: "readOnly", reason: "deployment owned" },
+          "agents.list.0.model": "editable",
+        },
+        actions: {
+          "sessions.delete": { state: "disabled", reason: "retention policy" },
+          "config.save": "brokered",
+        },
+      },
+    });
+
+    expect(policy.snapshot.host).toMatchObject({ id: "lobster", mode: "hosted" });
+    expect(policy.isRouteEnabled("debug")).toBe(false);
+    expect(policy.routeState("logs")).toBe("readOnly");
+    expect(policy.settingState(["agents", "list", "0", "model"])).toBe("editable");
+    expect(policy.settingState(["agents", "defaults", "model"])).toBe("readOnly");
+    expect(policy.canInvokeAction("sessions.delete")).toBe(false);
+    expect(policy.preflightAction("config.save")).toMatchObject({
+      ok: false,
+      code: "HOST_POLICY_BLOCKED",
+      details: { action: "config.save", state: "brokered" },
+    });
+  });
+
+  it("refreshes from the mounted control-ui config endpoint", async () => {
+    const policy = createHostPolicyCapability();
+    const fetchMock = vi.fn(async () => ({
+      ok: true,
+      json: async () => ({
+        hostControlPolicy: {
+          version: 1,
+          host: { id: "lobster", mode: "hosted" },
+          gateway: { path: "/v1/openclaw-gateway", scopes: ["operator.read"] },
+          defaults: { route: "enabled", setting: "editable", action: "enabled" },
+          routes: { channels: "disabled" },
+          settings: {},
+          actions: {},
+        },
+      }),
+    }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await policy.refresh("/openclaw");
+
+    expect(fetchMock).toHaveBeenCalledWith("/openclaw/control-ui-config.json", {
+      cache: "no-store",
+      credentials: "same-origin",
+    });
+    expect(policy.isRouteEnabled("channels")).toBe(false);
+  });
+});

--- a/ui/src/app/host-policy.ts
+++ b/ui/src/app/host-policy.ts
@@ -36,6 +36,11 @@ export type HostControlPolicyV1 = {
     action: HostControlActionState;
   };
   routes: Readonly<Record<string, HostControlRoutePolicy>>;
+  /**
+   * V1 supports a coarse settings lock through the "*" entry or the
+   * defaults.setting value. Field-level ownership is intentionally left to a
+   * later, server-enforced settings contract.
+   */
   settings: Readonly<Record<string, HostControlSettingPolicy>>;
   actions: Readonly<Record<string, HostControlActionPolicy>>;
 };
@@ -160,6 +165,13 @@ function normalizePolicyMap<T>(
   return Object.fromEntries(entries);
 }
 
+function normalizeSettingsPolicyMap(
+  value: unknown,
+): Readonly<Record<string, HostControlSettingPolicy>> {
+  const wildcard = isObject(value) ? normalizeSettingPolicy(value["*"]) : null;
+  return wildcard ? { "*": wildcard } : {};
+}
+
 function normalizeHostControlPolicy(value: unknown): HostControlPolicyV1 {
   const root = isObject(value) ? value : {};
   const policyRoot =
@@ -196,7 +208,7 @@ function normalizeHostControlPolicy(value: unknown): HostControlPolicyV1 {
       action: actionDefault,
     },
     routes: normalizePolicyMap(policyRoot.routes, normalizeRoutePolicy),
-    settings: normalizePolicyMap(policyRoot.settings, normalizeSettingPolicy),
+    settings: normalizeSettingsPolicyMap(policyRoot.settings),
     actions: normalizePolicyMap(policyRoot.actions, normalizeActionPolicy),
   };
 }
@@ -262,10 +274,8 @@ export function createHostPolicyCapability(initialPolicy?: unknown): HostPolicyC
 
   const routePolicy = (routeId: RouteId | string): HostControlRoutePolicy =>
     snapshot.routes[routeId] ?? { state: snapshot.defaults.route };
-  const settingPolicy = (path: string | readonly string[]): HostControlSettingPolicy =>
-    lookupHierarchicalPolicy(snapshot.settings, policyPath(path)) ?? {
-      state: snapshot.defaults.setting,
-    };
+  const settingPolicy = (_path: string | readonly string[]): HostControlSettingPolicy =>
+    snapshot.settings["*"] ?? { state: snapshot.defaults.setting };
   const actionPolicy = (action: string): HostControlActionPolicy =>
     lookupHierarchicalPolicy(snapshot.actions, action) ?? { state: snapshot.defaults.action };
 

--- a/ui/src/app/host-policy.ts
+++ b/ui/src/app/host-policy.ts
@@ -1,0 +1,320 @@
+import type { RouteId } from "../app-route-paths.ts";
+
+export type HostControlRouteState = "enabled" | "readOnly" | "disabled";
+export type HostControlSettingState = "editable" | "readOnly" | "locked";
+export type HostControlActionState = "enabled" | "disabled" | "brokered";
+
+export type HostControlRoutePolicy = {
+  state: HostControlRouteState;
+  reason?: string;
+};
+
+export type HostControlSettingPolicy = {
+  state: HostControlSettingState;
+  reason?: string;
+};
+
+export type HostControlActionPolicy = {
+  state: HostControlActionState;
+  reason?: string;
+};
+
+export type HostControlPolicyV1 = {
+  version: 1;
+  host: {
+    id: string;
+    mode: string;
+    displayName?: string;
+  };
+  gateway: {
+    path: string;
+    scopes: readonly string[];
+  };
+  defaults: {
+    route: HostControlRouteState;
+    setting: HostControlSettingState;
+    action: HostControlActionState;
+  };
+  routes: Readonly<Record<string, HostControlRoutePolicy>>;
+  settings: Readonly<Record<string, HostControlSettingPolicy>>;
+  actions: Readonly<Record<string, HostControlActionPolicy>>;
+};
+
+export type HostPolicyActionPreflightResult =
+  | { ok: true }
+  | {
+      ok: false;
+      code: "HOST_POLICY_BLOCKED";
+      message: string;
+      details: {
+        action: string;
+        state: HostControlActionState;
+        reason?: string;
+      };
+    };
+
+export type HostPolicyCapability = {
+  readonly snapshot: HostControlPolicyV1;
+  replace: (policy: unknown) => void;
+  refresh: (basePath: string) => Promise<void>;
+  subscribe: (listener: (policy: HostControlPolicyV1) => void) => () => void;
+  routePolicy: (routeId: RouteId | string) => HostControlRoutePolicy;
+  routeState: (routeId: RouteId | string) => HostControlRouteState;
+  isRouteEnabled: (routeId: RouteId | string) => boolean;
+  settingPolicy: (path: string | readonly string[]) => HostControlSettingPolicy;
+  settingState: (path: string | readonly string[]) => HostControlSettingState;
+  isSettingEditable: (path: string | readonly string[]) => boolean;
+  actionPolicy: (action: string) => HostControlActionPolicy;
+  actionState: (action: string) => HostControlActionState;
+  canInvokeAction: (action: string) => boolean;
+  preflightAction: (action: string) => HostPolicyActionPreflightResult;
+};
+
+const LOCAL_POLICY: HostControlPolicyV1 = {
+  version: 1,
+  host: {
+    id: "openclaw",
+    mode: "local",
+    displayName: "OpenClaw",
+  },
+  gateway: {
+    path: "",
+    scopes: [],
+  },
+  defaults: {
+    route: "enabled",
+    setting: "editable",
+    action: "enabled",
+  },
+  routes: {},
+  settings: {},
+  actions: {},
+};
+
+const ROUTE_STATES = new Set<HostControlRouteState>(["enabled", "readOnly", "disabled"]);
+const SETTING_STATES = new Set<HostControlSettingState>(["editable", "readOnly", "locked"]);
+const ACTION_STATES = new Set<HostControlActionState>(["enabled", "disabled", "brokered"]);
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function readString(value: unknown, fallback: string): string {
+  return typeof value === "string" && value.trim() ? value.trim() : fallback;
+}
+
+function readStringArray(value: unknown): string[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  return value.filter((entry): entry is string => typeof entry === "string" && entry.trim());
+}
+
+function normalizeReason(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+function normalizeRoutePolicy(value: unknown): HostControlRoutePolicy | null {
+  const candidate = isObject(value) ? value.state : value;
+  if (!ROUTE_STATES.has(candidate as HostControlRouteState)) {
+    return null;
+  }
+  return {
+    state: candidate as HostControlRouteState,
+    reason: isObject(value) ? normalizeReason(value.reason) : undefined,
+  };
+}
+
+function normalizeSettingPolicy(value: unknown): HostControlSettingPolicy | null {
+  const candidate = isObject(value) ? value.state : value;
+  if (!SETTING_STATES.has(candidate as HostControlSettingState)) {
+    return null;
+  }
+  return {
+    state: candidate as HostControlSettingState,
+    reason: isObject(value) ? normalizeReason(value.reason) : undefined,
+  };
+}
+
+function normalizeActionPolicy(value: unknown): HostControlActionPolicy | null {
+  const candidate = isObject(value) ? value.state : value;
+  if (!ACTION_STATES.has(candidate as HostControlActionState)) {
+    return null;
+  }
+  return {
+    state: candidate as HostControlActionState,
+    reason: isObject(value) ? normalizeReason(value.reason) : undefined,
+  };
+}
+
+function normalizePolicyMap<T>(
+  value: unknown,
+  normalize: (value: unknown) => T | null,
+): Readonly<Record<string, T>> {
+  if (!isObject(value)) {
+    return {};
+  }
+  const entries = Object.entries(value)
+    .map(([key, policy]) => [key.trim(), normalize(policy)] as const)
+    .filter((entry): entry is readonly [string, T] => Boolean(entry[0] && entry[1]));
+  return Object.fromEntries(entries);
+}
+
+function normalizeHostControlPolicy(value: unknown): HostControlPolicyV1 {
+  const root = isObject(value) ? value : {};
+  const policyRoot =
+    isObject(root.hostControlPolicy) || isObject(root.controlPolicy) || isObject(root.policy)
+      ? ((root.hostControlPolicy ?? root.controlPolicy ?? root.policy) as Record<string, unknown>)
+      : root;
+  const host = isObject(policyRoot.host) ? policyRoot.host : {};
+  const gateway = isObject(policyRoot.gateway) ? policyRoot.gateway : {};
+  const defaults = isObject(policyRoot.defaults) ? policyRoot.defaults : {};
+  const routeDefault = ROUTE_STATES.has(defaults.route as HostControlRouteState)
+    ? (defaults.route as HostControlRouteState)
+    : LOCAL_POLICY.defaults.route;
+  const settingDefault = SETTING_STATES.has(defaults.setting as HostControlSettingState)
+    ? (defaults.setting as HostControlSettingState)
+    : LOCAL_POLICY.defaults.setting;
+  const actionDefault = ACTION_STATES.has(defaults.action as HostControlActionState)
+    ? (defaults.action as HostControlActionState)
+    : LOCAL_POLICY.defaults.action;
+
+  return {
+    version: 1,
+    host: {
+      id: readString(host.id, LOCAL_POLICY.host.id),
+      mode: readString(host.mode, LOCAL_POLICY.host.mode),
+      displayName: readString(host.displayName, LOCAL_POLICY.host.displayName ?? ""),
+    },
+    gateway: {
+      path: readString(gateway.path, LOCAL_POLICY.gateway.path),
+      scopes: readStringArray(gateway.scopes),
+    },
+    defaults: {
+      route: routeDefault,
+      setting: settingDefault,
+      action: actionDefault,
+    },
+    routes: normalizePolicyMap(policyRoot.routes, normalizeRoutePolicy),
+    settings: normalizePolicyMap(policyRoot.settings, normalizeSettingPolicy),
+    actions: normalizePolicyMap(policyRoot.actions, normalizeActionPolicy),
+  };
+}
+
+function policyPath(path: string | readonly string[]): string {
+  const raw = Array.isArray(path) ? path.join(".") : path;
+  return raw
+    .split(".")
+    .map((part) => part.trim())
+    .filter(Boolean)
+    .join(".");
+}
+
+function lookupHierarchicalPolicy<T>(map: Readonly<Record<string, T>>, key: string): T | undefined {
+  const normalized = policyPath(key);
+  if (!normalized) {
+    return undefined;
+  }
+  const exact = map[normalized];
+  if (exact) {
+    return exact;
+  }
+  const parts = normalized.split(".");
+  for (let index = parts.length; index > 0; index -= 1) {
+    const wildcard = `${parts.slice(0, index).join(".")}.*`;
+    const match = map[wildcard];
+    if (match) {
+      return match;
+    }
+  }
+  return map["*"];
+}
+
+async function loadPolicyFromConfig(basePath: string): Promise<unknown | null> {
+  if (typeof fetch !== "function") {
+    return null;
+  }
+  const path = `${basePath.replace(/\/$/, "")}/control-ui-config.json`;
+  try {
+    const response = await fetch(path, {
+      cache: "no-store",
+      credentials: "same-origin",
+    });
+    if (!response.ok) {
+      return null;
+    }
+    return await response.json();
+  } catch {
+    return null;
+  }
+}
+
+export function createHostPolicyCapability(initialPolicy?: unknown): HostPolicyCapability {
+  let snapshot =
+    initialPolicy === undefined ? LOCAL_POLICY : normalizeHostControlPolicy(initialPolicy);
+  const listeners = new Set<(policy: HostControlPolicyV1) => void>();
+
+  const publish = () => {
+    for (const listener of listeners) {
+      listener(snapshot);
+    }
+  };
+
+  const routePolicy = (routeId: RouteId | string): HostControlRoutePolicy =>
+    snapshot.routes[routeId] ?? { state: snapshot.defaults.route };
+  const settingPolicy = (path: string | readonly string[]): HostControlSettingPolicy =>
+    lookupHierarchicalPolicy(snapshot.settings, policyPath(path)) ?? {
+      state: snapshot.defaults.setting,
+    };
+  const actionPolicy = (action: string): HostControlActionPolicy =>
+    lookupHierarchicalPolicy(snapshot.actions, action) ?? { state: snapshot.defaults.action };
+
+  return {
+    get snapshot() {
+      return snapshot;
+    },
+    replace(policy) {
+      snapshot = normalizeHostControlPolicy(policy);
+      publish();
+    },
+    async refresh(basePath) {
+      const next = await loadPolicyFromConfig(basePath);
+      if (next !== null) {
+        snapshot = normalizeHostControlPolicy(next);
+        publish();
+      }
+    },
+    subscribe(listener) {
+      listeners.add(listener);
+      return () => listeners.delete(listener);
+    },
+    routePolicy,
+    routeState: (routeId) => routePolicy(routeId).state,
+    isRouteEnabled: (routeId) => routePolicy(routeId).state !== "disabled",
+    settingPolicy,
+    settingState: (path) => settingPolicy(path).state,
+    isSettingEditable: (path) => settingPolicy(path).state === "editable",
+    actionPolicy,
+    actionState: (action) => actionPolicy(action).state,
+    canInvokeAction: (action) => actionPolicy(action).state === "enabled",
+    preflightAction(action) {
+      const policy = actionPolicy(action);
+      if (policy.state === "enabled") {
+        return { ok: true };
+      }
+      return {
+        ok: false,
+        code: "HOST_POLICY_BLOCKED",
+        message:
+          policy.state === "brokered"
+            ? `Gateway action '${action}' must be brokered by the host.`
+            : `Gateway action '${action}' is disabled by the host.`,
+        details: {
+          action,
+          state: policy.state,
+          reason: policy.reason,
+        },
+      };
+    },
+  };
+}

--- a/ui/src/components/app-sidebar.ts
+++ b/ui/src/components/app-sidebar.ts
@@ -731,11 +731,11 @@ class AppSidebar extends LitElement {
   }
 
   private async deleteSession(session: SidebarRecentSession) {
-    if (!window.confirm(t("sessionsView.deleteSessionConfirm", { session: session.label }))) {
+    const context = this.context;
+    if (!context || !context.hostPolicy.canInvokeAction("sessions.delete")) {
       return;
     }
-    const context = this.context;
-    if (!context) {
+    if (!window.confirm(t("sessionsView.deleteSessionConfirm", { session: session.label }))) {
       return;
     }
     const { selectedAgentId } = this.getSessionNavigationState();
@@ -861,6 +861,7 @@ class AppSidebar extends LitElement {
         hello: context?.gateway.snapshot.hello,
       }),
     );
+    const deleteAllowed = context?.hostPolicy.canInvokeAction("sessions.delete") ?? true;
     const groups = this.knownSessionGroups();
     return html`
       <div
@@ -1035,7 +1036,7 @@ class AppSidebar extends LitElement {
           type="button"
           class="sidebar-session-menu__item sidebar-session-menu__item--destructive"
           role="menuitem"
-          ?disabled=${!this.connected || !archiveAllowed}
+          ?disabled=${!this.connected || !archiveAllowed || !deleteAllowed}
           @click=${() => {
             this.closeSessionMenu();
             void this.deleteSession(session);
@@ -1648,6 +1649,7 @@ class AppSidebar extends LitElement {
     });
     const settingsActive =
       this.activeRouteId !== undefined && isSettingsNavigationRoute(this.activeRouteId);
+    const settingsEnabled = this.isRouteEnabled("config");
     return html`
       <aside class="sidebar ${this.collapsed ? "sidebar--collapsed" : ""}">
         <!-- macOS app only (CSS-gated on html.openclaw-native-macos): use the
@@ -1682,28 +1684,35 @@ class AppSidebar extends LitElement {
                 ></span>
               </openclaw-tooltip>
               <span class="sidebar-footer-bar__spacer"></span>
-              <openclaw-tooltip .content=${titleForRoute("config")}>
-                <a
-                  href=${pathForRoute("config", this.basePath)}
-                  class="sidebar-footer-icon ${settingsActive ? "sidebar-footer-icon--active" : ""}"
-                  aria-label=${titleForRoute("config")}
-                  aria-current=${settingsActive ? "page" : nothing}
-                  @focus=${(event: Event) => this.preloadRoute("config", event)}
-                  @blur=${this.cancelPreload}
-                  @pointerenter=${(event: Event) => this.preloadRoute("config", event)}
-                  @pointerleave=${this.cancelPreload}
-                  @touchstart=${(event: TouchEvent) => this.preloadRoute("config", event, true)}
-                  @click=${(event: MouseEvent) => {
-                    if (!shouldHandleNavigationClick(event)) {
-                      return;
-                    }
-                    event.preventDefault();
-                    this.onNavigate?.("config");
-                  }}
-                >
-                  ${icons.settings}
-                </a>
-              </openclaw-tooltip>
+              ${settingsEnabled
+                ? html`
+                    <openclaw-tooltip .content=${titleForRoute("config")}>
+                      <a
+                        href=${pathForRoute("config", this.basePath)}
+                        class="sidebar-footer-icon ${settingsActive
+                          ? "sidebar-footer-icon--active"
+                          : ""}"
+                        aria-label=${titleForRoute("config")}
+                        aria-current=${settingsActive ? "page" : nothing}
+                        @focus=${(event: Event) => this.preloadRoute("config", event)}
+                        @blur=${this.cancelPreload}
+                        @pointerenter=${(event: Event) => this.preloadRoute("config", event)}
+                        @pointerleave=${this.cancelPreload}
+                        @touchstart=${(event: TouchEvent) =>
+                          this.preloadRoute("config", event, true)}
+                        @click=${(event: MouseEvent) => {
+                          if (!shouldHandleNavigationClick(event)) {
+                            return;
+                          }
+                          event.preventDefault();
+                          this.onNavigate?.("config");
+                        }}
+                      >
+                        ${icons.settings}
+                      </a>
+                    </openclaw-tooltip>
+                  `
+                : nothing}
               <openclaw-tooltip
                 .content=${t("chat.docsOpensInNewTab", { label: t("common.docs") })}
               >

--- a/ui/src/components/settings-workspace.ts
+++ b/ui/src/components/settings-workspace.ts
@@ -8,6 +8,7 @@ import {
   titleForRoute,
 } from "../app-navigation.ts";
 import { isRouteId, pathForRoute, type RouteId } from "../app-route-paths.ts";
+import type { HostPolicyCapability } from "../app/host-policy.ts";
 import { icons } from "../components/icons.ts";
 import { t } from "../i18n/index.ts";
 
@@ -18,11 +19,14 @@ function renderSettingsSectionNav(
   currentRouteId: RouteId,
   navigate: (routeId: RouteId) => void,
   preload?: (routeId: RouteId) => Promise<void> | void,
+  hostPolicy?: HostPolicyCapability,
 ) {
   if (!isSettingsNavigationRoute(currentRouteId)) {
     return nothing;
   }
-  const routes = SETTINGS_NAVIGATION_ROUTES.filter(isRouteId);
+  const routes = SETTINGS_NAVIGATION_ROUTES.filter(
+    (routeId) => isRouteId(routeId) && (hostPolicy?.isRouteEnabled(routeId) ?? true),
+  );
   return html`
     <nav class="settings-section-nav" aria-label=${t("common.settingsSections")}>
       ${routes.map((routeId) => {
@@ -72,14 +76,14 @@ export function renderSettingsWorkspace(
   routeId: RouteId,
   navigate: (routeId: RouteId) => void,
   preload?: (routeId: RouteId) => Promise<void> | void,
-  options: { fillHeight?: boolean } = {},
+  options: { fillHeight?: boolean; hostPolicy?: HostPolicyCapability } = {},
 ) {
   const className = options.fillHeight
     ? "settings-workspace settings-workspace--fill-height"
     : "settings-workspace";
   return html`
     <section class=${className}>
-      ${renderSettingsSectionNav(basePath, routeId, navigate, preload)}
+      ${renderSettingsSectionNav(basePath, routeId, navigate, preload, options.hostPolicy)}
       <div class="settings-workspace__body">${body}</div>
     </section>
   `;

--- a/ui/src/lib/config/host-policy.test.ts
+++ b/ui/src/lib/config/host-policy.test.ts
@@ -1,0 +1,64 @@
+// @vitest-environment node
+import { describe, expect, it } from "vitest";
+import { createHostPolicyCapability } from "../../app/host-policy.ts";
+import { createRuntimeConfigCapability } from "./index.ts";
+
+function createGateway() {
+  return {
+    snapshot: {
+      client: null,
+      connected: false,
+      sessionKey: "main",
+    },
+    subscribe: () => () => {},
+  };
+}
+
+describe("runtime config host policy", () => {
+  it("blocks edits to read-only setting paths", () => {
+    const hostPolicy = createHostPolicyCapability({
+      version: 1,
+      host: { id: "lobster", mode: "hosted" },
+      gateway: { path: "/v1/openclaw-gateway", scopes: ["operator.read"] },
+      defaults: { route: "enabled", setting: "editable", action: "enabled" },
+      routes: {},
+      settings: {
+        "agents.*": { state: "readOnly", reason: "deployment owned" },
+      },
+      actions: {},
+    });
+    const runtimeConfig = createRuntimeConfigCapability(createGateway(), hostPolicy);
+    runtimeConfig.state.configForm = { agents: { defaults: { model: "gpt-5" } } };
+
+    runtimeConfig.patchForm(["agents", "defaults", "model"], "gpt-6");
+
+    expect(runtimeConfig.state.configForm).toEqual({
+      agents: { defaults: { model: "gpt-5" } },
+    });
+    expect(runtimeConfig.state.lastError).toBe("deployment owned");
+  });
+
+  it("allows exact editable overrides under a wildcard read-only setting", () => {
+    const hostPolicy = createHostPolicyCapability({
+      version: 1,
+      host: { id: "lobster", mode: "hosted" },
+      gateway: { path: "/v1/openclaw-gateway", scopes: ["operator.read"] },
+      defaults: { route: "enabled", setting: "editable", action: "enabled" },
+      routes: {},
+      settings: {
+        "agents.*": "readOnly",
+        "agents.defaults.model": "editable",
+      },
+      actions: {},
+    });
+    const runtimeConfig = createRuntimeConfigCapability(createGateway(), hostPolicy);
+    runtimeConfig.state.configForm = { agents: { defaults: { model: "gpt-5" } } };
+
+    runtimeConfig.patchForm(["agents", "defaults", "model"], "gpt-6");
+
+    expect(runtimeConfig.state.configForm).toEqual({
+      agents: { defaults: { model: "gpt-6" } },
+    });
+    expect(runtimeConfig.state.lastError).toBeNull();
+  });
+});

--- a/ui/src/lib/config/host-policy.test.ts
+++ b/ui/src/lib/config/host-policy.test.ts
@@ -23,7 +23,7 @@ describe("runtime config host policy", () => {
       defaults: { route: "enabled", setting: "editable", action: "enabled" },
       routes: {},
       settings: {
-        "agents.*": { state: "readOnly", reason: "deployment owned" },
+        "*": { state: "readOnly", reason: "deployment owned" },
       },
       actions: {},
     });
@@ -38,7 +38,7 @@ describe("runtime config host policy", () => {
     expect(runtimeConfig.state.lastError).toBe("deployment owned");
   });
 
-  it("allows exact editable overrides under a wildcard read-only setting", () => {
+  it("ignores child editable overrides in the coarse V1 settings policy", () => {
     const hostPolicy = createHostPolicyCapability({
       version: 1,
       host: { id: "lobster", mode: "hosted" },
@@ -46,7 +46,7 @@ describe("runtime config host policy", () => {
       defaults: { route: "enabled", setting: "editable", action: "enabled" },
       routes: {},
       settings: {
-        "agents.*": "readOnly",
+        "*": "readOnly",
         "agents.defaults.model": "editable",
       },
       actions: {},
@@ -57,8 +57,10 @@ describe("runtime config host policy", () => {
     runtimeConfig.patchForm(["agents", "defaults", "model"], "gpt-6");
 
     expect(runtimeConfig.state.configForm).toEqual({
-      agents: { defaults: { model: "gpt-6" } },
+      agents: { defaults: { model: "gpt-5" } },
     });
-    expect(runtimeConfig.state.lastError).toBeNull();
+    expect(runtimeConfig.state.lastError).toBe(
+      "Setting 'agents.defaults.model' is locked/read-only by the host.",
+    );
   });
 });

--- a/ui/src/lib/config/index.ts
+++ b/ui/src/lib/config/index.ts
@@ -2,6 +2,7 @@
 import { applyMergePatch } from "../../../../src/config/merge-patch.ts";
 import type { GatewayBrowserClient } from "../../api/gateway.ts";
 import type { ConfigSchemaResponse, ConfigSnapshot, ConfigUiHints } from "../../api/types.ts";
+import type { HostPolicyCapability } from "../../app/host-policy.ts";
 import { schemaType, type JsonSchema } from "../../components/config-form.shared.ts";
 import {
   cloneConfigObject,
@@ -52,6 +53,8 @@ type RuntimeConfigGateway = {
   readonly snapshot: RuntimeConfigGatewaySnapshot;
   subscribe: (listener: (snapshot: RuntimeConfigGatewaySnapshot) => void) => () => void;
 };
+
+type RuntimeConfigHostPolicy = Pick<HostPolicyCapability, "settingPolicy" | "isSettingEditable">;
 
 export type RuntimeConfigCapability = {
   readonly state: ConfigState;
@@ -786,8 +789,16 @@ export async function openConfigFile(state: ConfigState): Promise<void> {
   }
 }
 
+function formatPolicyPath(path: Array<string | number>): string {
+  return path
+    .map((part) => String(part).trim())
+    .filter(Boolean)
+    .join(".");
+}
+
 export function createRuntimeConfigCapability(
   gateway: RuntimeConfigGateway,
+  hostPolicy?: RuntimeConfigHostPolicy,
 ): RuntimeConfigCapability {
   const state = createInitialConfigState(gateway.snapshot);
   const listeners = new Set<(state: ConfigState) => void>();
@@ -813,6 +824,20 @@ export function createRuntimeConfigCapability(
   const mutate = (task: () => void) => {
     task();
     publish();
+  };
+  const denySettingMutation = (path: Array<string | number>): boolean => {
+    if (!hostPolicy) {
+      return false;
+    }
+    const normalizedPath = formatPolicyPath(path);
+    const policy = hostPolicy.settingPolicy(normalizedPath);
+    if (policy.state === "editable") {
+      return false;
+    }
+    state.lastError =
+      policy.reason ??
+      `Setting '${normalizedPath || "*"}' is ${policy.state === "locked" ? "locked" : "read-only"} by the host.`;
+    return true;
   };
   const trackLoad = (key: "config" | "schema", promise: Promise<void>): Promise<void> => {
     const next = promise.finally(() => {
@@ -868,11 +893,31 @@ export function createRuntimeConfigCapability(
         "schema",
         run(() => loadConfigSchema(state)),
       ),
-    patchForm: (path, value) => mutate(() => updateConfigFormValue(state, path, value)),
-    removeFormValue: (path) => mutate(() => removeConfigFormValue(state, path)),
-    setRaw: (value) => mutate(() => updateConfigRawValue(state, value)),
+    patchForm: (path, value) =>
+      mutate(() => {
+        if (!denySettingMutation(path)) {
+          updateConfigFormValue(state, path, value);
+        }
+      }),
+    removeFormValue: (path) =>
+      mutate(() => {
+        if (!denySettingMutation(path)) {
+          removeConfigFormValue(state, path);
+        }
+      }),
+    setRaw: (value) =>
+      mutate(() => {
+        if (!denySettingMutation(["*"])) {
+          updateConfigRawValue(state, value);
+        }
+      }),
     resetDraft: () => mutate(() => resetConfigPendingChanges(state)),
-    stagePreset: (patch) => mutate(() => stageConfigPreset(state, patch)),
+    stagePreset: (patch) =>
+      mutate(() => {
+        if (!denySettingMutation(["*"])) {
+          stageConfigPreset(state, patch);
+        }
+      }),
     save: () => run(() => saveConfig(state)),
     apply: () => run(() => applyConfig(state)),
     openFile: () => run(() => openConfigFile(state)),

--- a/ui/src/pages/agents/agents-page.ts
+++ b/ui/src/pages/agents/agents-page.ts
@@ -744,6 +744,7 @@ class AgentsPage extends LitElement implements AgentsState {
         "agents",
         (routeId) => this.context.navigate(routeId),
         (routeId) => this.context.preload(routeId),
+        { hostPolicy: this.context.hostPolicy },
       )}
     `;
   }

--- a/ui/src/pages/channels/channels-page.ts
+++ b/ui/src/pages/channels/channels-page.ts
@@ -375,6 +375,7 @@ class ChannelsPage extends LitElement {
         "channels",
         (routeId) => context.navigate(routeId),
         (routeId) => context.preload(routeId),
+        { hostPolicy: context.hostPolicy },
       )}
     `;
   }

--- a/ui/src/pages/config/config-page.ts
+++ b/ui/src/pages/config/config-page.ts
@@ -677,6 +677,7 @@ export class ConfigPage extends LitElement {
       schemaLoading: configState.configSchemaLoading,
       uiHints: configState.configUiHints,
       formMode: this.formModes[this.pageId],
+      readOnly: !this.context.hostPolicy.isSettingEditable("*"),
       viewState: this.configViewState,
       rawAvailable: Boolean(
         configState.configSnapshot?.config || configState.configForm || configState.configRaw,
@@ -829,6 +830,7 @@ export class ConfigPage extends LitElement {
       configSaving: runtimeConfig.state.configSaving,
       configApplying: runtimeConfig.state.configApplying,
       configReady: Boolean(runtimeConfig.state.configSnapshot?.hash),
+      readOnly: !this.context.hostPolicy.isSettingEditable("*"),
       onSelectPreset: (id) => {
         const preset = getPresetById(id);
         if (preset) {
@@ -922,6 +924,7 @@ export class ConfigPage extends LitElement {
         this.pageId,
         (routeId) => this.navigate(routeId),
         (routeId) => this.context.preload(routeId),
+        { hostPolicy: this.context.hostPolicy },
       )}
     `;
   }

--- a/ui/src/pages/config/quick.test.ts
+++ b/ui/src/pages/config/quick.test.ts
@@ -271,6 +271,47 @@ describe("renderQuickSettings", () => {
     ]);
   });
 
+  it("greys out quick deployment config controls when host settings are read-only", () => {
+    const onThinkingChange = vi.fn();
+    const onFastModeChange = vi.fn();
+    const onBrowserEnabledToggle = vi.fn();
+    const onToolProfileChange = vi.fn();
+    const onSelectPreset = vi.fn();
+    const container = document.createElement("div");
+
+    render(
+      renderQuickSettings(
+        createProps({
+          readOnly: true,
+          configDirty: true,
+          configReady: true,
+          onThinkingChange,
+          onFastModeChange,
+          onBrowserEnabledToggle,
+          onToolProfileChange,
+          onSelectPreset,
+        }),
+      ),
+      container,
+    );
+
+    expect(container.querySelector(".qs-container--host-readonly")).toBeInstanceOf(HTMLElement);
+    expect(expectButtonByText(expectRowByLabel(container, "Thinking"), "Low").disabled).toBe(true);
+    expect(expectButtonByText(expectRowByLabel(container, "Fast mode"), "Fast").disabled).toBe(
+      true,
+    );
+    expect(expectRowByLabel(container, "Browser enabled").querySelector("input")).toHaveProperty(
+      "disabled",
+      true,
+    );
+    expect(expectButtonByText(container, "full").disabled).toBe(true);
+    const presetButton = container.querySelector(".qs-preset");
+    expect(presetButton).toBeInstanceOf(HTMLButtonElement);
+    expect((presetButton as HTMLButtonElement).disabled).toBe(true);
+    expect(expectButtonByText(container, "Save Changes").disabled).toBe(true);
+    expect(expectButtonByText(container, "Apply Now").disabled).toBe(true);
+  });
+
   it("opens mobile pairing from Security quick settings", () => {
     const onPairMobile = vi.fn();
     const container = document.createElement("div");

--- a/ui/src/pages/config/quick.ts
+++ b/ui/src/pages/config/quick.ts
@@ -107,6 +107,7 @@ export type QuickSettingsProps = {
   configSaving?: boolean;
   configApplying?: boolean;
   configReady?: boolean;
+  readOnly?: boolean;
   onSelectPreset?: (presetId: ConfigPresetId) => void;
   onResetConfig?: () => void;
   onSaveConfig?: () => void;
@@ -410,6 +411,7 @@ function renderModelCard(props: QuickSettingsProps) {
                   class="qs-segmented__btn ${level === props.thinkingLevel
                     ? "qs-segmented__btn--active"
                     : ""}"
+                  ?disabled=${props.readOnly === true}
                   @click=${() => props.onThinkingChange?.(level)}
                 >
                   ${level.charAt(0).toUpperCase() + level.slice(1)}
@@ -431,6 +433,7 @@ function renderModelCard(props: QuickSettingsProps) {
               ([value, label]) => html`
                 <button
                   class="qs-segmented__btn ${fastMode === value ? "qs-segmented__btn--active" : ""}"
+                  ?disabled=${props.readOnly === true}
                   @click=${() =>
                     fastMode === value
                       ? undefined
@@ -548,6 +551,7 @@ function renderSecurityCard(props: QuickSettingsProps) {
             <input
               type="checkbox"
               .checked=${browserEnabled}
+              ?disabled=${props.readOnly === true}
               @change=${(event: Event) =>
                 props.onBrowserEnabledToggle?.((event.currentTarget as HTMLInputElement).checked)}
             />
@@ -565,6 +569,7 @@ function renderSecurityCard(props: QuickSettingsProps) {
                   normalizedToolProfile
                     ? "qs-segmented__btn--active"
                     : ""}"
+                  ?disabled=${props.readOnly === true}
                   @click=${() => props.onToolProfileChange?.(profile)}
                 >
                   ${profile}
@@ -918,6 +923,7 @@ function renderPresetsCard(props: QuickSettingsProps) {
   const hasPendingProfileChange = !profileSettingsEqual(draftSettings, savedSettings);
   const hasPendingConfigChange = props.configDirty === true;
   const canCommit =
+    props.readOnly !== true &&
     props.connected &&
     props.configReady === true &&
     props.configSaving !== true &&
@@ -955,6 +961,7 @@ function renderPresetsCard(props: QuickSettingsProps) {
                 type="button"
                 class="qs-preset ${preset.id === selectedPresetId ? "qs-preset--active" : ""}"
                 aria-pressed=${preset.id === selectedPresetId}
+                ?disabled=${props.readOnly === true}
                 @click=${() => props.onSelectPreset?.(preset.id)}
               >
                 <div class="qs-preset__head">
@@ -1051,7 +1058,7 @@ function renderConnectionFooter(props: QuickSettingsProps) {
 
 export function renderQuickSettings(props: QuickSettingsProps) {
   return html`
-    <div class="qs-container">
+    <div class="qs-container ${props.readOnly === true ? "qs-container--host-readonly" : ""}">
       <div class="qs-grid">
         ${renderModelCard(props)} ${renderChannelsCard(props)} ${renderSecurityCard(props)}
         ${renderSystemCard(props)} ${renderAppearanceCard(props)} ${renderPersonalCard(props)}

--- a/ui/src/pages/config/view.host-policy.test.ts
+++ b/ui/src/pages/config/view.host-policy.test.ts
@@ -1,0 +1,120 @@
+// @vitest-environment jsdom
+import { render } from "lit";
+import { describe, expect, it, vi } from "vitest";
+import type { ThemeMode, ThemeName } from "../../app/theme.ts";
+import { createConfigViewState, renderConfig, type ConfigProps } from "./view.ts";
+
+function baseProps(): ConfigProps {
+  return {
+    raw: "{\n}\n",
+    originalRaw: "{\n}\n",
+    valid: true,
+    issues: [],
+    loading: false,
+    saving: false,
+    applying: false,
+    updating: false,
+    connected: true,
+    schema: {
+      type: "object",
+      properties: {
+        gateway: {
+          type: "object",
+          properties: {
+            mode: { type: "string" },
+          },
+        },
+      },
+    },
+    schemaLoading: false,
+    uiHints: {},
+    formMode: "form",
+    viewState: createConfigViewState(),
+    showModeToggle: true,
+    formValue: { gateway: { mode: "remote" } },
+    originalValue: { gateway: { mode: "local" } },
+    searchQuery: "",
+    activeSection: null,
+    activeSubsection: null,
+    onRawChange: vi.fn(),
+    onFormModeChange: vi.fn(),
+    onViewStateChange: vi.fn(),
+    onFormPatch: vi.fn(),
+    onSearchChange: vi.fn(),
+    onSectionChange: vi.fn(),
+    onSubsectionChange: vi.fn(),
+    onReload: vi.fn(),
+    onReset: vi.fn(),
+    onSave: vi.fn(),
+    onApply: vi.fn(),
+    onUpdate: vi.fn(),
+    onOpenFile: vi.fn(),
+    version: "2026.3.11",
+    theme: "claw" as ThemeName,
+    themeMode: "system" as ThemeMode,
+    setTheme: vi.fn(),
+    setThemeMode: vi.fn(),
+    hasCustomTheme: false,
+    customThemeLabel: null,
+    customThemeSourceUrl: null,
+    customThemeImportUrl: "",
+    customThemeImportBusy: false,
+    customThemeImportMessage: null,
+    onCustomThemeImportUrlChange: vi.fn(),
+    onImportCustomTheme: vi.fn(),
+    onClearCustomTheme: vi.fn(),
+    borderRadius: 50,
+    setBorderRadius: vi.fn(),
+    textScale: 100,
+    setTextScale: vi.fn(),
+    gatewayUrl: "",
+    assistantName: "OpenClaw",
+  };
+}
+
+function buttonByText(container: HTMLElement, text: string): HTMLButtonElement {
+  const button = Array.from(container.querySelectorAll("button")).find(
+    (entry) => entry.textContent?.trim() === text,
+  );
+  expect(button).toBeInstanceOf(HTMLButtonElement);
+  return button as HTMLButtonElement;
+}
+
+function requireElement<T extends Element>(
+  container: HTMLElement,
+  selector: string,
+  constructor: new () => T,
+): T {
+  const element = container.querySelector(selector);
+  expect(element).toBeInstanceOf(constructor);
+  return element as T;
+}
+
+describe("config view host policy", () => {
+  it("greys out editable config controls when the host marks settings read-only", () => {
+    const container = document.createElement("div");
+    const renderCase = (overrides: Partial<ConfigProps>) =>
+      render(renderConfig({ ...baseProps(), ...overrides }), container);
+
+    renderCase({ readOnly: true });
+
+    expect(buttonByText(container, "Save").disabled).toBe(true);
+    expect(buttonByText(container, "Apply").disabled).toBe(true);
+    expect(buttonByText(container, "Open").disabled).toBe(true);
+    expect(requireElement(container, ".cfg-input", HTMLInputElement).disabled).toBe(true);
+    expect(container.querySelector(".config-layout--host-readonly")).toBeInstanceOf(HTMLElement);
+
+    renderCase({
+      readOnly: true,
+      formMode: "raw",
+      raw: '{\n  "gateway": { "mode": "remote" }\n}\n',
+      originalRaw: "{\n}\n",
+    });
+
+    expect(buttonByText(container, "Save").disabled).toBe(true);
+    expect(buttonByText(container, "Apply").disabled).toBe(true);
+    expect(
+      requireElement(container, ".config-raw-field textarea", HTMLTextAreaElement).disabled,
+    ).toBe(true);
+  });
+});

--- a/ui/src/pages/config/view.ts
+++ b/ui/src/pages/config/view.ts
@@ -110,6 +110,7 @@ export type ConfigProps = {
   schemaLoading: boolean;
   uiHints: ConfigUiHints;
   formMode: ConfigFormMode;
+  readOnly?: boolean;
   viewState: ConfigViewState;
   rawAvailable?: boolean;
   showModeToggle?: boolean;
@@ -1474,9 +1475,15 @@ export function renderConfig(props: ConfigProps) {
   // Save/apply buttons require actual changes to be enabled.
   // Note: formUnsafe warns about unsupported schema paths but shouldn't block saving.
   const canSaveForm = Boolean(props.formValue) && !props.loading && Boolean(analysis.schema);
+  const readOnly = props.readOnly === true;
   const canSave =
-    props.connected && !props.saving && hasChanges && (formMode === "raw" ? true : canSaveForm);
+    !readOnly &&
+    props.connected &&
+    !props.saving &&
+    hasChanges &&
+    (formMode === "raw" ? true : canSaveForm);
   const canApply =
+    !readOnly &&
     props.connected &&
     !props.applying &&
     !props.updating &&
@@ -1496,7 +1503,7 @@ export function renderConfig(props: ConfigProps) {
     Boolean(include?.has("__appearance__"));
 
   return html`
-    <div class="config-layout">
+    <div class="config-layout ${readOnly ? "config-layout--host-readonly" : ""}">
       <main class="config-main">
         <div class="config-actions">
           <div class="config-actions__left">
@@ -1545,7 +1552,7 @@ export function renderConfig(props: ConfigProps) {
             <div class="config-actions__buttons">
               ${props.onOpenFile
                 ? html`
-                    <button class="btn btn--sm" @click=${props.onOpenFile}>
+                    <button class="btn btn--sm" ?disabled=${readOnly} @click=${props.onOpenFile}>
                       ${icons.fileText} Open
                     </button>
                   `
@@ -1865,7 +1872,7 @@ export function renderConfig(props: ConfigProps) {
                           uiHints: props.uiHints,
                           value: props.formValue,
                           rawAvailable,
-                          disabled: props.loading || !props.formValue,
+                          disabled: readOnly || props.loading || !props.formValue,
                           unsupportedPaths: analysis.unsupportedPaths,
                           onPatch: props.onFormPatch,
                           searchQuery: props.searchQuery,
@@ -1939,7 +1946,11 @@ export function renderConfig(props: ConfigProps) {
                               <textarea
                                 placeholder="Raw config (JSON/JSON5)"
                                 .value=${props.raw}
+                                ?disabled=${readOnly}
                                 @input=${(e: Event) => {
+                                  if (readOnly) {
+                                    return;
+                                  }
                                   props.onRawChange((e.target as HTMLTextAreaElement).value);
                                 }}
                               ></textarea>

--- a/ui/src/pages/cron/cron-page.ts
+++ b/ui/src/pages/cron/cron-page.ts
@@ -436,6 +436,7 @@ class CronPage extends LitElement {
         "cron",
         (routeId) => this.context.navigate(routeId),
         (routeId) => this.context.preload(routeId),
+        { hostPolicy: this.context.hostPolicy },
       )}
     `;
   }

--- a/ui/src/pages/debug/debug-page.ts
+++ b/ui/src/pages/debug/debug-page.ts
@@ -189,6 +189,7 @@ class DebugPage extends LitElement {
         "debug",
         (routeId) => this.context.navigate(routeId),
         (routeId) => this.context.preload(routeId),
+        { hostPolicy: this.context.hostPolicy },
       )}
     `;
   }

--- a/ui/src/pages/logs/logs-page.ts
+++ b/ui/src/pages/logs/logs-page.ts
@@ -280,7 +280,7 @@ class LogsPage extends LitElement {
         "logs",
         (routeId) => this.context.navigate(routeId),
         (routeId) => this.context.preload(routeId),
-        { fillHeight: true },
+        { fillHeight: true, hostPolicy: this.context.hostPolicy },
       )}
     `;
   }

--- a/ui/src/pages/nodes/nodes-page.ts
+++ b/ui/src/pages/nodes/nodes-page.ts
@@ -297,6 +297,7 @@ class NodesPage extends LitElement implements NodesPageDataState {
         "nodes",
         (routeId) => this.context.navigate(routeId),
         (routeId) => this.context.preload(routeId),
+        { hostPolicy: this.context.hostPolicy },
       )}
     `;
   }

--- a/ui/src/pages/sessions/sessions-page.ts
+++ b/ui/src/pages/sessions/sessions-page.ts
@@ -463,7 +463,12 @@ class SessionsPage extends LitElement {
   private async deleteSelected() {
     const context = this.context;
     const keys = [...this.selectedKeys];
-    if (!context || keys.length === 0 || this.loading) {
+    if (
+      !context ||
+      keys.length === 0 ||
+      this.loading ||
+      !context.hostPolicy.canInvokeAction("sessions.delete")
+    ) {
       return;
     }
     if (
@@ -773,6 +778,7 @@ class SessionsPage extends LitElement {
         page: this.page,
         pageSize: this.pageSize,
         selectedKeys: this.selectedKeys,
+        canDeleteSessions: context.hostPolicy.canInvokeAction("sessions.delete"),
         workboardSessionKeys: new Set(
           workboardState.cards
             .flatMap((card) => [card.sessionKey, card.execution?.sessionKey])

--- a/ui/src/pages/sessions/view.test.ts
+++ b/ui/src/pages/sessions/view.test.ts
@@ -307,6 +307,37 @@ describe("sessions view", () => {
     expect(onPatch).toHaveBeenLastCalledWith("agent:main:dashboard:1", { archived: false });
   });
 
+  it("disables session selection and bulk deletion when delete is host-locked", async () => {
+    const container = document.createElement("div");
+    const onDeleteSelected = vi.fn();
+    render(
+      renderSessions({
+        ...buildProps(
+          buildResult({
+            key: "agent:main:dashboard:1",
+            kind: "direct",
+            updatedAt: Date.now(),
+          }),
+        ),
+        canDeleteSessions: false,
+        selectedKeys: new Set(["agent:main:dashboard:1"]),
+        onDeleteSelected,
+      }),
+      container,
+    );
+    await Promise.resolve();
+
+    const deleteButton = container.querySelector<HTMLButtonElement>(".data-table-bulk-bar .danger");
+    const checkboxes = Array.from(
+      container.querySelectorAll<HTMLInputElement>('table input[type="checkbox"]'),
+    );
+    expect(deleteButton?.disabled).toBe(true);
+    expect(checkboxes.every((checkbox) => checkbox.disabled)).toBe(true);
+
+    deleteButton?.click();
+    expect(onDeleteSelected).not.toHaveBeenCalled();
+  });
+
   it("keeps pinned sessions above newer unpinned sessions", async () => {
     const container = document.createElement("div");
     render(

--- a/ui/src/pages/sessions/view.ts
+++ b/ui/src/pages/sessions/view.ts
@@ -59,6 +59,7 @@ export type SessionsProps = {
   page: number;
   pageSize: number;
   selectedKeys: Set<string>;
+  canDeleteSessions?: boolean;
   expandedSessionKey: string | null;
   checkpointItemsByKey: Record<string, SessionCompactionCheckpoint[]>;
   checkpointLoadingKey: string | null;
@@ -702,6 +703,7 @@ function renderOverrideSelect(params: {
 }
 
 export function renderSessions(props: SessionsProps) {
+  const canDeleteSessions = props.canDeleteSessions ?? true;
   const rawRows = props.result?.sessions ?? [];
   const filtered = filterRows(rawRows, props.searchQuery, props.agentIdentityById);
   const sorted = sortRows(filtered, props.sortColumn, props.sortDir);
@@ -922,7 +924,7 @@ export function renderSessions(props: SessionsProps) {
                 </button>
                 <button
                   class="btn btn--sm danger"
-                  ?disabled=${props.loading}
+                  ?disabled=${props.loading || !canDeleteSessions}
                   @click=${props.onDeleteSelected}
                 >
                   ${icons.trash} ${t("sessionsView.deleteSelected")}
@@ -943,6 +945,7 @@ export function renderSessions(props: SessionsProps) {
                         paginated.every((r) => props.selectedKeys.has(r.key))}
                         .indeterminate=${paginated.some((r) => props.selectedKeys.has(r.key)) &&
                         !paginated.every((r) => props.selectedKeys.has(r.key))}
+                        ?disabled=${!canDeleteSessions}
                         @change=${() => {
                           const allSelected = paginated.every((r) => props.selectedKeys.has(r.key));
                           if (allSelected) {
@@ -1031,6 +1034,7 @@ export function renderSessions(props: SessionsProps) {
 }
 
 function renderRows(row: GatewaySessionRow, props: SessionsProps) {
+  const canDeleteSessions = props.canDeleteSessions ?? true;
   const updated = row.updatedAt ? formatRelativeTimestamp(row.updatedAt) : t("common.na");
   const latestCheckpoint = row.latestCompactionCheckpoint;
   const checkpointCount = row.compactionCheckpointCount ?? 0;
@@ -1127,6 +1131,7 @@ function renderRows(row: GatewaySessionRow, props: SessionsProps) {
         <input
           type="checkbox"
           .checked=${props.selectedKeys.has(row.key)}
+          ?disabled=${!canDeleteSessions}
           @change=${() => props.onToggleSelect(row.key)}
           aria-label=${t("sessionsView.selectSession")}
         />

--- a/ui/src/pages/skills/skills-page.ts
+++ b/ui/src/pages/skills/skills-page.ts
@@ -335,6 +335,7 @@ class SkillsPage extends LitElement {
         "skills",
         (routeId) => this.context.navigate(routeId),
         (routeId) => this.context.preload(routeId),
+        { hostPolicy: this.context.hostPolicy },
       )}
     `;
   }

--- a/ui/src/pages/worktrees/worktrees-page.ts
+++ b/ui/src/pages/worktrees/worktrees-page.ts
@@ -213,6 +213,7 @@ class WorktreesPage extends LitElement {
         "worktrees",
         (routeId) => this.context.navigate(routeId),
         (routeId) => this.context.preload(routeId),
+        { hostPolicy: this.context.hostPolicy },
       )}
     `;
   }


### PR DESCRIPTION
## Summary- add an opt-in `HostControlPolicyV1` bootstrap contract for hosted Control UI navigation, Gateway path/scopes, and selected UI action preflight- keep local OpenClaw default-open: without host config, routes/settings/actions behave as they do today- make settings policy intentionally coarse for V1: hosts can set settings read-only through `settings["*"]` or `defaults.setting`, but field-level ownership/child editable exceptions are deferred to a later server-enforced config contract- hide disabled routes through shared route/sidebar/settings wiring instead of touching every page- disable session-deletion affordances and read-only config editor controls as presentation UX only## Contract stance for hosted deploymentsThis PR is the small, generic OpenClaw UI contract. It is not a hosted authorization boundary by itself.- OpenClaw consumes the host policy to shape the browser experience: default route, hidden routes, read-only settings presentation, hosted Gateway URL/scopes, and blocked/destructive action affordances.- Browser `requestPreflight` mirrors the policy before sending a Gateway request, but the host/server must still enforce authorization.- Lobster's stacked PRs provide that host side for proof: hosted static mount, ECS gates, hosted Gateway route/scopes, and surgical `/chat`, `/sessions`, `/settings` route replacement.## Why this is intentionally smallThe earlier shape could imply granular setting locks like `agents.*` with `agents.defaults.model` editable. Current Control UI settings render/save paths do not provide a coherent field-level contract across every settings page, so V1 no longer promises that. The useful hosted slice is simple: deployment-owned settings are read-only in the hosted UI, and richer per-field ownership can come later with an authoritative mutation contract.## Validation- `git diff --check`- Local Vitest is blocked in this fresh release worktree because UI dependencies are not installed; the available global runner cannot load the repo config dependencies (`@vitest/browser-playwright`, `playwright`, `vitest/config`).- Main-port PR #115408 validates the same V1 simplification with the available runner: 4 files, 88 tests passed.## Real behavior proofPending promoted/quarantined OpenClaw package plus Lobster hosted integration. Planned proof path uses the Lobster PR stack to instantiate this exact OpenClaw Control UI under `/openclaw`, then enables the default-off Lobster flags to show route replacement and host-enforced lockdown.
## Expected follow-up PRs
This V1 is intentionally small. Likely follow-up PRs, after this has maintainer agreement and hosted proof, are:

1. Host-authoritative config mutation contract: server/Gateway enforcement for deployment-owned settings, with field provenance and transactional save/apply semantics.
2. Granular settings ownership: only after the authoritative mutation contract exists, add field-level read-only/editable policy and wire affected settings pages coherently.
3. Hosted action enforcement expansion: move any remaining browser-only destructive-action checks behind server-side capability checks where OpenClaw owns the method.
4. Packaged hosted proof fixtures: add a repeatable hosted Control UI proof harness once the promoted package and Lobster integration path are available.
5. Optional component-level embedding contract: smaller OpenClaw UI components only if we decide route-level replacement is not enough.