### PR TITLE
fix(memory): fall back to keyword search when embeddings cannot start

### DIFF
--- a/docs/concepts/memory-search.md
+++ b/docs/concepts/memory-search.md
@@ -116,9 +116,11 @@ tools or Active Memory escalation, but are never injected automatically.
 
 **FTS-only mode.** Set `provider: "none"` to intentionally disable embeddings
 and search with keywords only. Leaving `provider` unset or set to `"auto"`
-also falls back to keyword-only ranking if no embedding auth is configured,
-without erroring, and so does `provider: "local"` (the GGUF/llama.cpp
-provider) when it fails.
+falls back to keyword-only ranking when embedding setup or a request fails, as
+does `provider: "local"` (the GGUF/llama.cpp provider). Creation-time fallback
+still indexes text for keyword search, and `memory_search` includes the
+redacted embedding-bootstrap reason in `debug.embeddingBootstrap` even when
+there are no matches.
 
 **Explicit provider unavailable.** If you name any other provider explicitly
 (for example `openai`, `ollama`, `gemini`) and it becomes unavailable at

--- a/extensions/memory-core/src/memory/manager-embedding-ops.ts
+++ b/extensions/memory-core/src/memory/manager-embedding-ops.ts
@@ -329,13 +329,13 @@ export abstract class MemoryManagerEmbeddingOps extends MemoryManagerSyncOps {
     });
   }
 
-  protected override beginSyncProviderGeneration(): void {
+  protected override beginSyncProviderGeneration(options?: { forceFtsOnly?: boolean }): void {
     if (this.syncProviderGeneration) {
       this.syncProviderGenerationOwners += 1;
       return;
     }
-    const provider = this.provider;
-    const runtime = this.providerRuntime;
+    const provider = options?.forceFtsOnly ? null : this.provider;
+    const runtime = provider ? this.providerRuntime : undefined;
     const identities = resolveMemoryIndexProviderIdentities({
       provider,
       cacheKeyData: runtime?.cacheKeyData,

--- a/extensions/memory-core/src/memory/manager-sync-ops.ts
+++ b/extensions/memory-core/src/memory/manager-sync-ops.ts
@@ -157,6 +157,10 @@ export abstract class MemoryManagerSyncOps extends MemoryManagerSourceSyncOps {
     // indexes can safely sync without an embedding provider.
     this.assertFtsOnlySyncAllowed();
 
+    const syncProvider = this.syncProviderGeneration
+      ? this.syncProviderGeneration.provider
+      : this.provider;
+
     const progress = params?.progress ? this.createSyncProgress(params.progress) : undefined;
     if (progress) {
       progress.report({
@@ -165,7 +169,9 @@ export abstract class MemoryManagerSyncOps extends MemoryManagerSourceSyncOps {
         label: "Loading vector extension…",
       });
     }
-    const vectorReady = await this.ensureVectorReady();
+    // Keyword-only generations never write vectors, so they must not wait for
+    // the vector extension before text and FTS indexing can proceed.
+    const vectorReady = syncProvider ? await this.ensureVectorReady() : false;
     const meta = this.readMeta();
     const targetArchiveFiles = await this.combineTargetArchiveFiles({
       sessions: params?.sessions,
@@ -178,9 +184,6 @@ export abstract class MemoryManagerSyncOps extends MemoryManagerSourceSyncOps {
     if (params?.reason === "cli" && !params.force && !hasTargetArchiveFiles) {
       await this.markSessionStartupCatchupDirtyFiles();
     }
-    const syncProvider = this.syncProviderGeneration
-      ? this.syncProviderGeneration.provider
-      : this.provider;
     const syncProviderKey = this.syncProviderGeneration
       ? this.syncProviderGeneration.providerKey
       : this.providerKey;

--- a/extensions/memory-core/src/memory/manager-sync-ops.ts
+++ b/extensions/memory-core/src/memory/manager-sync-ops.ts
@@ -74,7 +74,7 @@ export abstract class MemoryManagerSyncOps extends MemoryManagerSourceSyncOps {
   private fallbackProviderInitPromise: Promise<boolean> | null = null;
   protected syncProviderGeneration: MemorySyncProviderGeneration | null = null;
 
-  protected beginSyncProviderGeneration(): void {}
+  protected beginSyncProviderGeneration(_options?: { forceFtsOnly?: boolean }): void {}
   protected endSyncProviderGeneration(): void {}
 
   protected override shouldDeferSourceWideBatch(): boolean {

--- a/extensions/memory-core/src/memory/manager.fts-only-reindex.test.ts
+++ b/extensions/memory-core/src/memory/manager.fts-only-reindex.test.ts
@@ -503,6 +503,14 @@ describe("memory manager FTS-only reindex", () => {
       expect(JSON.stringify(debug)).not.toContain("No API key resolved");
       expect(memoryManager.status().custom?.indexIdentity).toEqual({ status: "valid" });
 
+      await fs.writeFile(
+        path.join(workspaceDir, "MEMORY.md"),
+        "Gamma fallback refresh\n\nIndexed while embeddings remain degraded.",
+      );
+      await expect(memoryManager.sync({ reason: "watch", force: true })).resolves.toBeUndefined();
+      await expect(memoryManager.search("Gamma fallback refresh")).resolves.toHaveLength(1);
+      expect(providerQueryCalls).toBe(0);
+
       providerEmbeddingError = null;
       nowSpy.mockReturnValue(now + 62_000);
       await expect(memoryManager.search("Alpha topic")).resolves.toHaveLength(1);

--- a/extensions/memory-core/src/memory/manager.fts-only-reindex.test.ts
+++ b/extensions/memory-core/src/memory/manager.fts-only-reindex.test.ts
@@ -8,15 +8,45 @@ import { resolveOpenClawAgentSqlitePath } from "openclaw/plugin-sdk/sqlite-runti
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { closeAllMemorySearchManagers, getMemorySearchManager } from "./index.js";
 import type { MemoryIndexMeta } from "./manager-reindex-state.js";
-import type { MemoryIndexManager } from "./manager.js";
+import { closeAllMemoryIndexManagers, type MemoryIndexManager } from "./manager.js";
 import "./test-runtime-mocks.js";
 
+let providerConstructionError: Error | null = null;
+let providerConstructionGate: Promise<void> | null = null;
+let providerAvailable = false;
+let providerEmbeddingError: Error | null = null;
+let providerQueryCalls = 0;
 const createEmbeddingProviderMock = vi.hoisted(() =>
-  vi.fn(async () => ({
-    requestedProvider: "auto",
-    provider: null,
-    providerUnavailableReason: "No embeddings provider available.",
-  })),
+  vi.fn(async () => {
+    await providerConstructionGate;
+    if (providerConstructionError) {
+      throw providerConstructionError;
+    }
+    if (providerAvailable) {
+      return {
+        requestedProvider: "auto",
+        provider: {
+          id: "openai",
+          model: "mock-embed",
+          embedBatch: async (texts: string[]) => {
+            if (providerEmbeddingError) {
+              throw providerEmbeddingError;
+            }
+            return texts.map(() => [1, 0]);
+          },
+          embedQuery: async () => {
+            providerQueryCalls += 1;
+            return [1, 0];
+          },
+        },
+      };
+    }
+    return {
+      requestedProvider: "auto",
+      provider: null,
+      providerUnavailableReason: "No embeddings provider available.",
+    };
+  }),
 );
 const originalFtsOnlyStateDir = process.env.OPENCLAW_STATE_DIR;
 
@@ -54,6 +84,11 @@ describe("memory manager FTS-only reindex", () => {
 
   beforeEach(async () => {
     createEmbeddingProviderMock.mockClear();
+    providerConstructionError = null;
+    providerConstructionGate = null;
+    providerAvailable = false;
+    providerEmbeddingError = null;
+    providerQueryCalls = 0;
     workspaceDir = path.join(fixtureRoot, `case-${caseId++}`);
     await fs.mkdir(path.join(workspaceDir, "memory"), { recursive: true });
     await fs.writeFile(path.join(workspaceDir, "MEMORY.md"), "Alpha topic\n\nKeep this note.");
@@ -148,6 +183,329 @@ describe("memory manager FTS-only reindex", () => {
     const secondStatus = memoryManager.status();
     expect(secondStatus.chunks).toBeGreaterThan(0);
     expect(countChunksContaining("Alpha topic")).toBeGreaterThan(0);
+  });
+
+  it("returns keyword matches when optional provider construction fails during search bootstrap", async () => {
+    providerConstructionError = Object.assign(
+      new Error(
+        'No API key resolved for provider "openai" (auth mode: api-key, checked: OPENAI_API_KEY).',
+      ),
+      {
+        name: "MissingProviderAuthError",
+        code: "missing-api-key",
+        provider: "openai",
+      },
+    );
+    const memoryManager = await createManager();
+    const debug: Array<{ embeddingBootstrap?: unknown }> = [];
+
+    const results = await memoryManager.search("Alpha topic", {
+      onDebug: (entry) => debug.push(entry),
+    });
+
+    expect(results).toEqual([
+      expect.objectContaining({
+        path: "MEMORY.md",
+        snippet: expect.stringContaining("Alpha topic"),
+        source: "memory",
+      }),
+    ]);
+    expect(debug).toContainEqual({
+      backend: "builtin",
+      embeddingBootstrap: {
+        ok: false,
+        provider: "openai",
+        reason:
+          'MissingProviderAuthError: No API key resolved for provider "openai" (auth mode: api-key, checked: OPENAI_API_KEY).',
+        degradedTo: "keyword-only",
+      },
+    });
+    expect(createEmbeddingProviderMock).toHaveBeenCalledOnce();
+
+    await expect(memoryManager.search("Alpha topic")).resolves.toHaveLength(1);
+    expect(createEmbeddingProviderMock).toHaveBeenCalledOnce();
+  });
+
+  it("keeps explicit required providers fail-closed when construction fails", async () => {
+    providerConstructionError = Object.assign(
+      new Error(
+        'No API key resolved for provider "openai" (auth mode: api-key, checked: OPENAI_API_KEY).',
+      ),
+      {
+        name: "MissingProviderAuthError",
+        code: "missing-api-key",
+        provider: "openai",
+      },
+    );
+    const memoryManager = await createManager({ provider: "openai" });
+
+    await expect(memoryManager.search("Alpha topic")).rejects.toThrow(
+      'No API key resolved for provider "openai"',
+    );
+    expect(countChunksContaining("Alpha topic")).toBe(0);
+  });
+
+  it("uses keyword search when provider construction fails against an existing semantic index", async () => {
+    providerAvailable = true;
+    const firstManager = await createManager();
+    await firstManager.sync({ force: true });
+    await firstManager.close();
+    manager = null;
+    await closeAllMemorySearchManagers();
+    await closeAllMemoryIndexManagers();
+    providerAvailable = false;
+    providerConstructionError = Object.assign(
+      new Error(
+        'No API key resolved for provider "openai" (auth mode: api-key, checked: OPENAI_API_KEY).',
+      ),
+      {
+        name: "MissingProviderAuthError",
+        code: "missing-api-key",
+        provider: "openai",
+      },
+    );
+    const memoryManager = await createManager();
+    const debug: unknown[] = [];
+
+    await expect(
+      memoryManager.search("Alpha topic", { onDebug: (entry) => debug.push(entry) }),
+    ).resolves.toEqual([expect.objectContaining({ path: "MEMORY.md", source: "memory" })]);
+    expect(debug).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          embeddingBootstrap: expect.objectContaining({ degradedTo: "keyword-only" }),
+        }),
+      ]),
+    );
+    expect(
+      memoryManager as unknown as {
+        embeddingBootstrapFailure?: unknown;
+        provider?: { id: string } | null;
+      },
+    ).toMatchObject({
+      embeddingBootstrapFailure: expect.objectContaining({ degradedTo: "keyword-only" }),
+      provider: null,
+    });
+    expect(memoryManager.status()).toMatchObject({
+      provider: "none",
+      custom: { indexIdentity: { status: "valid" }, searchMode: "fts-only" },
+    });
+  });
+
+  it("retries expired bootstrap failures through probes and rebuilds the fallback index", async () => {
+    const now = Date.now();
+    const nowSpy = vi.spyOn(Date, "now").mockReturnValue(now);
+    try {
+      providerConstructionError = Object.assign(
+        new Error(
+          'No API key resolved for provider "openai" (auth mode: api-key, checked: OPENAI_API_KEY).',
+        ),
+        {
+          name: "MissingProviderAuthError",
+          code: "missing-api-key",
+          provider: "openai",
+        },
+      );
+      const memoryManager = await createManager();
+      await expect(memoryManager.search("Alpha topic")).resolves.toHaveLength(1);
+      const callsBeforeProbe = createEmbeddingProviderMock.mock.calls.length;
+
+      providerConstructionError = null;
+      providerAvailable = true;
+      nowSpy.mockReturnValue(now + 31_000);
+      await expect(memoryManager.probeEmbeddingAvailability()).resolves.toEqual({ ok: true });
+      const callsAfterProbe = createEmbeddingProviderMock.mock.calls.length;
+      await expect(memoryManager.search("Alpha topic")).resolves.toHaveLength(1);
+
+      expect(callsAfterProbe).toBeGreaterThan(callsBeforeProbe);
+      expect(memoryManager.status()).toMatchObject({
+        provider: "openai",
+        custom: {
+          indexIdentity: { status: "valid" },
+          providerState: { mode: "active", providerId: "openai" },
+        },
+      });
+    } finally {
+      nowSpy.mockRestore();
+    }
+  });
+
+  it("caches a normal no-provider result after an expired bootstrap failure", async () => {
+    const now = Date.now();
+    const nowSpy = vi.spyOn(Date, "now").mockReturnValue(now);
+    try {
+      providerConstructionError = Object.assign(
+        new Error(
+          'No API key resolved for provider "openai" (auth mode: api-key, checked: OPENAI_API_KEY).',
+        ),
+        {
+          name: "MissingProviderAuthError",
+          code: "missing-api-key",
+          provider: "openai",
+        },
+      );
+      const memoryManager = await createManager();
+      await expect(memoryManager.search("Alpha topic")).resolves.toHaveLength(1);
+
+      providerConstructionError = null;
+      nowSpy.mockReturnValue(now + 31_000);
+      const debug: unknown[] = [];
+      await expect(
+        memoryManager.search("Alpha topic", { onDebug: (entry) => debug.push(entry) }),
+      ).resolves.toHaveLength(1);
+      const callsAfterRetry = createEmbeddingProviderMock.mock.calls.length;
+      await expect(memoryManager.search("Alpha topic")).resolves.toHaveLength(1);
+
+      expect(createEmbeddingProviderMock).toHaveBeenCalledTimes(callsAfterRetry);
+      expect(JSON.stringify(debug)).toContain("No embeddings provider available.");
+    } finally {
+      nowSpy.mockRestore();
+    }
+  });
+
+  it("degrades concurrent bootstrap waiters to the same keyword index", async () => {
+    let releaseProviderConstruction!: () => void;
+    providerConstructionGate = new Promise<void>((resolve) => {
+      releaseProviderConstruction = resolve;
+    });
+    providerConstructionError = Object.assign(
+      new Error(
+        'No API key resolved for provider "openai" (auth mode: api-key, checked: OPENAI_API_KEY).',
+      ),
+      {
+        name: "MissingProviderAuthError",
+        code: "missing-api-key",
+        provider: "openai",
+      },
+    );
+    const memoryManager = await createManager();
+
+    const backgroundSync = memoryManager.sync({ reason: "startup" }).catch((err: unknown) => err);
+    await vi.waitFor(() => expect(createEmbeddingProviderMock).toHaveBeenCalledOnce());
+    const firstSearch = memoryManager.search("Alpha topic");
+    const secondSearch = memoryManager.search("Alpha topic");
+    releaseProviderConstruction();
+
+    await expect(backgroundSync).resolves.toBe(providerConstructionError);
+    const results = await Promise.all([firstSearch, secondSearch]);
+    expect(results).toEqual([
+      [expect.objectContaining({ path: "MEMORY.md", source: "memory" })],
+      [expect.objectContaining({ path: "MEMORY.md", source: "memory" })],
+    ]);
+    expect(createEmbeddingProviderMock).toHaveBeenCalledOnce();
+  });
+
+  it("serializes provider construction when concurrent probes retry an expired failure", async () => {
+    const now = Date.now();
+    const nowSpy = vi.spyOn(Date, "now").mockReturnValue(now);
+    try {
+      providerConstructionError = Object.assign(
+        new Error(
+          'No API key resolved for provider "openai" (auth mode: api-key, checked: OPENAI_API_KEY).',
+        ),
+        {
+          name: "MissingProviderAuthError",
+          code: "missing-api-key",
+          provider: "openai",
+        },
+      );
+      const memoryManager = await createManager();
+      await expect(memoryManager.search("Alpha topic")).resolves.toHaveLength(1);
+      const callsBeforeRetry = createEmbeddingProviderMock.mock.calls.length;
+
+      providerConstructionError = null;
+      providerAvailable = true;
+      nowSpy.mockReturnValue(now + 31_000);
+      let releaseProviderConstruction!: () => void;
+      providerConstructionGate = new Promise<void>((resolve) => {
+        releaseProviderConstruction = resolve;
+      });
+      const firstProbe = memoryManager.probeEmbeddingAvailability();
+      const secondProbe = memoryManager.probeEmbeddingAvailability();
+      await vi.waitFor(() =>
+        expect(createEmbeddingProviderMock).toHaveBeenCalledTimes(callsBeforeRetry + 1),
+      );
+      releaseProviderConstruction();
+
+      await expect(Promise.all([firstProbe, secondProbe])).resolves.toEqual([
+        { ok: true },
+        { ok: true },
+      ]);
+      expect(createEmbeddingProviderMock).toHaveBeenCalledTimes(callsBeforeRetry + 1);
+    } finally {
+      nowSpy.mockRestore();
+    }
+  });
+
+  it("keeps keyword results when semantic recovery reindex fails", async () => {
+    const now = Date.now();
+    const nowSpy = vi.spyOn(Date, "now").mockReturnValue(now);
+    try {
+      providerConstructionError = Object.assign(
+        new Error(
+          'No API key resolved for provider "openai" (auth mode: api-key, checked: OPENAI_API_KEY).',
+        ),
+        {
+          name: "MissingProviderAuthError",
+          code: "missing-api-key",
+          provider: "openai",
+        },
+      );
+      const memoryManager = await createManager();
+      await expect(memoryManager.search("Alpha topic")).resolves.toHaveLength(1);
+
+      providerConstructionError = null;
+      providerAvailable = true;
+      nowSpy.mockReturnValue(now + 31_000);
+      await expect(memoryManager.probeEmbeddingAvailability()).resolves.toEqual({ ok: true });
+      providerEmbeddingError = new Error("embedding request failed during rebuild");
+      const debug: unknown[] = [];
+
+      await expect(
+        memoryManager.search("Alpha topic", { onDebug: (entry) => debug.push(entry) }),
+      ).resolves.toHaveLength(1);
+      expect(providerQueryCalls).toBe(0);
+      expect(debug).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            embeddingBootstrap: expect.objectContaining({
+              degradedTo: "keyword-only",
+              reason: expect.stringContaining("embedding request failed during rebuild"),
+            }),
+          }),
+        ]),
+      );
+      expect(JSON.stringify(debug)).not.toContain("No API key resolved");
+      expect(memoryManager.status().custom?.indexIdentity).toEqual({ status: "valid" });
+
+      providerEmbeddingError = null;
+      nowSpy.mockReturnValue(now + 62_000);
+      await expect(memoryManager.search("Alpha topic")).resolves.toHaveLength(1);
+      expect(providerQueryCalls).toBeGreaterThan(0);
+      const recoveredStatus = memoryManager.status();
+      expect(recoveredStatus.custom?.providerState).toEqual({
+        mode: "active",
+        providerId: "openai",
+      });
+      expect(recoveredStatus.custom?.providerUnavailableReason).toBeUndefined();
+    } finally {
+      nowSpy.mockRestore();
+    }
+  });
+
+  it("redacts credential material from bootstrap debug reasons", async () => {
+    const credential = "sk-test-abcdefghijklmnopqrstuvwxyz123456";
+    providerConstructionError = Object.assign(new Error(`apiKey=${credential}`), {
+      name: "MissingProviderAuthError",
+      code: "missing-api-key",
+      provider: "openai",
+    });
+    const memoryManager = await createManager();
+    const debug: unknown[] = [];
+
+    await memoryManager.search("Alpha topic", { onDebug: (entry) => debug.push(entry) });
+
+    expect(JSON.stringify(debug)).not.toContain(credential);
   });
 
   it("syncs explicit provider-none memory without resolving an embedding provider", async () => {

--- a/extensions/memory-core/src/memory/manager.fts-only-reindex.test.ts
+++ b/extensions/memory-core/src/memory/manager.fts-only-reindex.test.ts
@@ -226,6 +226,30 @@ describe("memory manager FTS-only reindex", () => {
     expect(createEmbeddingProviderMock).toHaveBeenCalledOnce();
   });
 
+  it("returns keyword matches when the first bootstrap embedding request fails", async () => {
+    providerAvailable = true;
+    providerEmbeddingError = new Error("embedding request failed during bootstrap");
+    const memoryManager = await createManager();
+    const debug: unknown[] = [];
+
+    const results = await memoryManager.search("Alpha topic", {
+      onDebug: (entry) => debug.push(entry),
+    });
+
+    expect(results).toEqual([expect.objectContaining({ path: "MEMORY.md", source: "memory" })]);
+    expect(providerQueryCalls).toBe(0);
+    expect(debug).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          embeddingBootstrap: expect.objectContaining({
+            degradedTo: "keyword-only",
+            reason: expect.stringContaining("embedding request failed during bootstrap"),
+          }),
+        }),
+      ]),
+    );
+  });
+
   it("keeps explicit required providers fail-closed when construction fails", async () => {
     providerConstructionError = Object.assign(
       new Error(

--- a/extensions/memory-core/src/memory/manager.fts-only-reindex.test.ts
+++ b/extensions/memory-core/src/memory/manager.fts-only-reindex.test.ts
@@ -243,6 +243,7 @@ describe("memory manager FTS-only reindex", () => {
         expect.objectContaining({
           embeddingBootstrap: expect.objectContaining({
             degradedTo: "keyword-only",
+            provider: "openai",
             reason: expect.stringContaining("embedding request failed during bootstrap"),
           }),
         }),

--- a/extensions/memory-core/src/memory/manager.fts-only-reindex.test.ts
+++ b/extensions/memory-core/src/memory/manager.fts-only-reindex.test.ts
@@ -271,50 +271,71 @@ describe("memory manager FTS-only reindex", () => {
   });
 
   it("uses keyword search when provider construction fails against an existing semantic index", async () => {
-    providerAvailable = true;
-    const firstManager = await createManager();
-    await firstManager.sync({ force: true });
-    await firstManager.close();
-    manager = null;
-    await closeAllMemorySearchManagers();
-    await closeAllMemoryIndexManagers();
-    providerAvailable = false;
-    providerConstructionError = Object.assign(
-      new Error(
-        'No API key resolved for provider "openai" (auth mode: api-key, checked: OPENAI_API_KEY).',
-      ),
-      {
-        name: "MissingProviderAuthError",
-        code: "missing-api-key",
-        provider: "openai",
-      },
-    );
-    const memoryManager = await createManager();
-    const debug: unknown[] = [];
+    const now = Date.now();
+    const nowSpy = vi.spyOn(Date, "now").mockReturnValue(now);
+    try {
+      providerAvailable = true;
+      const firstManager = await createManager();
+      await firstManager.sync({ force: true });
+      await expect(firstManager.probeVectorAvailability()).resolves.toBe(true);
+      await firstManager.close();
+      manager = null;
+      await closeAllMemorySearchManagers();
+      await closeAllMemoryIndexManagers();
+      providerAvailable = false;
+      providerConstructionError = Object.assign(
+        new Error(
+          'No API key resolved for provider "openai" (auth mode: api-key, checked: OPENAI_API_KEY).',
+        ),
+        {
+          name: "MissingProviderAuthError",
+          code: "missing-api-key",
+          provider: "openai",
+        },
+      );
+      const memoryManager = await createManager();
+      const debug: unknown[] = [];
 
-    await expect(
-      memoryManager.search("Alpha topic", { onDebug: (entry) => debug.push(entry) }),
-    ).resolves.toEqual([expect.objectContaining({ path: "MEMORY.md", source: "memory" })]);
-    expect(debug).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({
-          embeddingBootstrap: expect.objectContaining({ degradedTo: "keyword-only" }),
-        }),
-      ]),
-    );
-    expect(
-      memoryManager as unknown as {
-        embeddingBootstrapFailure?: unknown;
-        provider?: { id: string } | null;
-      },
-    ).toMatchObject({
-      embeddingBootstrapFailure: expect.objectContaining({ degradedTo: "keyword-only" }),
-      provider: null,
-    });
-    expect(memoryManager.status()).toMatchObject({
-      provider: "none",
-      custom: { indexIdentity: { status: "valid" }, searchMode: "fts-only" },
-    });
+      await expect(
+        memoryManager.search("Alpha topic", { onDebug: (entry) => debug.push(entry) }),
+      ).resolves.toEqual([expect.objectContaining({ path: "MEMORY.md", source: "memory" })]);
+      expect(debug).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            embeddingBootstrap: expect.objectContaining({ degradedTo: "keyword-only" }),
+          }),
+        ]),
+      );
+      expect(
+        memoryManager as unknown as {
+          embeddingBootstrapFailure?: unknown;
+          provider?: { id: string } | null;
+        },
+      ).toMatchObject({
+        embeddingBootstrapFailure: expect.objectContaining({ degradedTo: "keyword-only" }),
+        provider: null,
+      });
+      expect(memoryManager.status()).toMatchObject({
+        provider: "none",
+        vector: { semanticAvailable: false },
+        custom: { indexIdentity: { status: "valid" }, searchMode: "fts-only" },
+      });
+
+      providerConstructionError = null;
+      providerAvailable = true;
+      nowSpy.mockReturnValue(now + 31_000);
+      await expect(memoryManager.probeEmbeddingAvailability()).resolves.toEqual({ ok: true });
+      await expect(memoryManager.search("Alpha topic")).resolves.toHaveLength(1);
+
+      expect(providerQueryCalls).toBeGreaterThan(0);
+      expect(memoryManager.status()).toMatchObject({
+        provider: "openai",
+        vector: { semanticAvailable: true },
+        custom: { providerState: { mode: "active", providerId: "openai" } },
+      });
+    } finally {
+      nowSpy.mockRestore();
+    }
   });
 
   it("retries expired bootstrap failures through probes and rebuilds the fallback index", async () => {

--- a/extensions/memory-core/src/memory/manager.fts-only-reindex.test.ts
+++ b/extensions/memory-core/src/memory/manager.fts-only-reindex.test.ts
@@ -511,9 +511,19 @@ describe("memory manager FTS-only reindex", () => {
       await expect(memoryManager.search("Gamma fallback refresh")).resolves.toHaveLength(1);
       expect(providerQueryCalls).toBe(0);
 
-      providerEmbeddingError = null;
       nowSpy.mockReturnValue(now + 62_000);
-      await expect(memoryManager.search("Alpha topic")).resolves.toHaveLength(1);
+      await fs.writeFile(
+        path.join(workspaceDir, "MEMORY.md"),
+        "Delta fallback refresh\n\nRetry remains keyword-only while embeddings still fail.",
+      );
+      await expect(memoryManager.sync({ reason: "watch", force: true })).resolves.toBeUndefined();
+      await expect(memoryManager.search("Delta fallback refresh")).resolves.toHaveLength(1);
+      expect(providerQueryCalls).toBe(0);
+
+      providerEmbeddingError = null;
+      nowSpy.mockReturnValue(now + 93_000);
+      await expect(memoryManager.sync({ reason: "watch", force: true })).resolves.toBeUndefined();
+      await expect(memoryManager.search("Delta fallback refresh")).resolves.toHaveLength(1);
       expect(providerQueryCalls).toBeGreaterThan(0);
       const recoveredStatus = memoryManager.status();
       expect(recoveredStatus.custom?.providerState).toEqual({

--- a/extensions/memory-core/src/memory/manager.ts
+++ b/extensions/memory-core/src/memory/manager.ts
@@ -712,7 +712,7 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
 
   private markEmbeddingBootstrapFailure(
     err: unknown,
-    options?: { retainProvider?: boolean },
+    options?: { retainProvider?: boolean; provider?: string },
   ): MemoryEmbeddingBootstrapDebug {
     const rawErrorName = readErrorName(err).trim();
     const errorName = /^[A-Za-z][A-Za-z0-9_.-]{0,63}$/.test(rawErrorName) ? rawErrorName : "";
@@ -723,13 +723,7 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
       errorName && errorName !== "Error" ? `${errorName}: ${message}` : message,
       { mode: "tools" },
     );
-    const errorProvider =
-      err && typeof err === "object" && typeof Reflect.get(err, "provider") === "string"
-        ? String(Reflect.get(err, "provider")).trim()
-        : "";
-    const provider = /^[A-Za-z0-9][A-Za-z0-9._:/-]{0,127}$/.test(errorProvider)
-      ? errorProvider
-      : (this.provider?.id ?? this.settings.provider);
+    const provider = options?.provider ?? this.provider?.id ?? this.settings.provider;
     const debug: MemoryEmbeddingBootstrapDebug = {
       ok: false,
       provider,
@@ -1117,13 +1111,14 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
           );
         } catch (err) {
           if (this.providerRequirement.mode === "optional" && this.shouldFallbackOnError(err)) {
+            const failedProvider = this.provider?.id ?? this.settings.provider;
             await this.retireCurrentProvider().catch((retireErr: unknown) => {
               const message = redactSensitiveText(formatErrorMessage(retireErr), {
                 mode: "tools",
               });
               log.warn(`memory search-bootstrap: failed to retire embedding provider: ${message}`);
             });
-            this.markEmbeddingBootstrapFailure(err);
+            this.markEmbeddingBootstrapFailure(err, { provider: failedProvider });
             await this.syncAdmitted({ reason: "search", force: true }).catch(
               (fallbackErr: unknown) => {
                 const message = redactSensitiveText(formatErrorMessage(fallbackErr), {

--- a/extensions/memory-core/src/memory/manager.ts
+++ b/extensions/memory-core/src/memory/manager.ts
@@ -1116,7 +1116,25 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
             { allowEmbeddingBootstrapFallback: true },
           );
         } catch (err) {
-          log.warn(`memory sync failed (search-bootstrap): ${String(err)}`);
+          if (this.providerRequirement.mode === "optional" && this.shouldFallbackOnError(err)) {
+            await this.retireCurrentProvider().catch((retireErr: unknown) => {
+              const message = redactSensitiveText(formatErrorMessage(retireErr), {
+                mode: "tools",
+              });
+              log.warn(`memory search-bootstrap: failed to retire embedding provider: ${message}`);
+            });
+            this.markEmbeddingBootstrapFailure(err);
+            await this.syncAdmitted({ reason: "search", force: true }).catch(
+              (fallbackErr: unknown) => {
+                const message = redactSensitiveText(formatErrorMessage(fallbackErr), {
+                  mode: "tools",
+                });
+                log.warn(`memory sync failed (search-bootstrap-fallback): ${message}`);
+              },
+            );
+          } else {
+            log.warn(`memory sync failed (search-bootstrap): ${String(err)}`);
+          }
         }
         hasIndexedContent = this.hasIndexedContent();
       }

--- a/extensions/memory-core/src/memory/manager.ts
+++ b/extensions/memory-core/src/memory/manager.ts
@@ -1987,8 +1987,11 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
       sourceFilterParams: sourceFilter.params,
     });
 
+    // Status projects the effective keyword-only search mode while degraded.
+    // Sync generations still snapshot this.provider so recovery can rebuild vectors.
+    const statusProvider = this.embeddingBootstrapFailure ? null : this.provider;
     const providerInfo = resolveStatusProviderInfo({
-      provider: this.embeddingBootstrapFailure ? null : this.provider,
+      provider: statusProvider,
       providerInitialized: this.embeddingBootstrapFailure ? true : this.providerInitialized,
       requestedProvider: this.requestedProvider,
       configuredModel: this.settings.model || undefined,

--- a/extensions/memory-core/src/memory/manager.ts
+++ b/extensions/memory-core/src/memory/manager.ts
@@ -796,24 +796,53 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
         activeFailure = this.markEmbeddingBootstrapFailure(err, { retainProvider: true });
       }
     }
-    if (this.refreshIndexIdentityDirty({ providerKeyKnown: true }).status === "valid") {
-      this.embeddingBootstrapFailure = undefined;
-      this.providerUnavailableReason = undefined;
-      if (this.provider) {
-        this.providerLifecycle = this.fallbackFrom
-          ? {
-              mode: "fallback-active",
-              providerId: this.provider.id,
-              fallbackFrom: this.fallbackFrom,
-              reason: this.fallbackReason ?? "fallback activated",
-            }
-          : { mode: "active", providerId: this.provider.id };
-      }
-      EMBEDDING_PROBE_CACHE.delete(this.cacheKey);
+    if (
+      this.refreshIndexIdentityDirty({ providerKeyKnown: true }).status === "valid" &&
+      (await this.confirmEmbeddingBootstrapRecovery())
+    ) {
+      this.clearEmbeddingBootstrapFailureAfterRecovery();
       return false;
     }
+    activeFailure = this.embeddingBootstrapFailure ?? activeFailure;
     onDebug?.({ backend: "builtin", embeddingBootstrap: activeFailure });
     return true;
+  }
+
+  private clearEmbeddingBootstrapFailureAfterRecovery(): void {
+    this.embeddingBootstrapFailure = undefined;
+    this.providerUnavailableReason = undefined;
+    if (this.provider) {
+      this.providerLifecycle = this.fallbackFrom
+        ? {
+            mode: "fallback-active",
+            providerId: this.provider.id,
+            fallbackFrom: this.fallbackFrom,
+            reason: this.fallbackReason ?? "fallback activated",
+          }
+        : { mode: "active", providerId: this.provider.id };
+    }
+    EMBEDDING_PROBE_CACHE.delete(this.cacheKey);
+  }
+
+  private async confirmEmbeddingBootstrapRecovery(): Promise<boolean> {
+    const cached = this.getCachedEmbeddingAvailability();
+    if (cached) {
+      return cached.ok;
+    }
+    if (!this.provider) {
+      return false;
+    }
+    try {
+      await this.embedBatchWithRetry(["ping"]);
+      this.cacheProbeResult({ ok: true });
+      return true;
+    } catch (err) {
+      this.markEmbeddingBootstrapFailure(err, {
+        retainProvider: true,
+        provider: this.provider.id,
+      });
+      return false;
+    }
   }
 
   private async ensureProviderInitialized(): Promise<void> {
@@ -1848,27 +1877,70 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
       }
     }
     this.syncing = (async () => {
-      const useCachedBootstrapFallback =
+      const hadBootstrapFailure = this.embeddingBootstrapFailure !== undefined;
+      let forceFtsOnly =
         this.embeddingBootstrapFailure !== undefined &&
         this.getCachedEmbeddingAvailability()?.ok === false;
-      if (!useCachedBootstrapFallback) {
+      if (!forceFtsOnly) {
         try {
           await this.ensureProviderInitialized();
         } catch (err) {
           if (
-            !options?.allowEmbeddingBootstrapFallback ||
-            this.providerRequirement.mode !== "optional"
+            this.providerRequirement.mode !== "optional" ||
+            (!options?.allowEmbeddingBootstrapFallback && !hadBootstrapFailure)
           ) {
             throw err;
           }
           this.markEmbeddingBootstrapFailure(err);
+          forceFtsOnly = true;
+        }
+        if (hadBootstrapFailure && !this.provider) {
+          const failure = this.embeddingBootstrapFailure!;
+          const nextFailure: MemoryEmbeddingBootstrapDebug = {
+            ...failure,
+            reason: this.providerUnavailableReason ?? failure.reason,
+          };
+          this.embeddingBootstrapFailure = nextFailure;
+          this.cacheProbeResult({ ok: false, error: nextFailure.reason });
+          forceFtsOnly = true;
         }
       }
-      this.beginSyncProviderGeneration({ forceFtsOnly: useCachedBootstrapFallback });
+
+      const runGeneration = async (keywordOnly: boolean) => {
+        this.beginSyncProviderGeneration({ forceFtsOnly: keywordOnly });
+        try {
+          await this.runSyncWithReadonlyRecovery(params);
+        } finally {
+          this.endSyncProviderGeneration();
+        }
+      };
       try {
-        await this.runSyncWithReadonlyRecovery(params);
-      } finally {
-        this.endSyncProviderGeneration();
+        await runGeneration(forceFtsOnly);
+      } catch (err) {
+        const canDegrade =
+          this.providerRequirement.mode === "optional" &&
+          (options?.allowEmbeddingBootstrapFallback || hadBootstrapFailure) &&
+          this.shouldFallbackOnError(err);
+        if (!canDegrade) {
+          throw err;
+        }
+        const failedProvider = this.provider?.id ?? this.settings.provider;
+        this.markEmbeddingBootstrapFailure(err, {
+          retainProvider: this.provider !== null,
+          provider: failedProvider,
+        });
+        forceFtsOnly = true;
+        await runGeneration(true);
+      }
+
+      if (
+        hadBootstrapFailure &&
+        !forceFtsOnly &&
+        this.provider &&
+        this.refreshIndexIdentityDirty({ providerKeyKnown: true }).status === "valid" &&
+        (await this.confirmEmbeddingBootstrapRecovery())
+      ) {
+        this.clearEmbeddingBootstrapFailureAfterRecovery();
       }
     })().finally(() => {
       this.syncing = null;

--- a/extensions/memory-core/src/memory/manager.ts
+++ b/extensions/memory-core/src/memory/manager.ts
@@ -800,6 +800,9 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
       this.refreshIndexIdentityDirty({ providerKeyKnown: true }).status === "valid" &&
       (await this.confirmEmbeddingBootstrapRecovery())
     ) {
+      // A valid existing index skips recovery reindex, so explicitly restore the
+      // semantic readiness flag cleared when bootstrap degradation began.
+      this.vector.semanticAvailable = await this.probeVectorStoreAvailabilityAdmitted();
       this.clearEmbeddingBootstrapFailureAfterRecovery();
       return false;
     }

--- a/extensions/memory-core/src/memory/manager.ts
+++ b/extensions/memory-core/src/memory/manager.ts
@@ -723,6 +723,8 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
       errorName && errorName !== "Error" ? `${errorName}: ${message}` : message,
       { mode: "tools" },
     );
+    // settings.provider is already resolved from "auto"; never trust an unknown
+    // error object's provider-shaped field for public diagnostics.
     const provider = options?.provider ?? this.provider?.id ?? this.settings.provider;
     const debug: MemoryEmbeddingBootstrapDebug = {
       ok: false,
@@ -1847,7 +1849,6 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
     }
     this.syncing = (async () => {
       const useCachedBootstrapFallback =
-        params?.reason === "search" &&
         this.embeddingBootstrapFailure !== undefined &&
         this.getCachedEmbeddingAvailability()?.ok === false;
       if (!useCachedBootstrapFallback) {
@@ -1863,7 +1864,7 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
           this.markEmbeddingBootstrapFailure(err);
         }
       }
-      this.beginSyncProviderGeneration();
+      this.beginSyncProviderGeneration({ forceFtsOnly: useCachedBootstrapFallback });
       try {
         await this.runSyncWithReadonlyRecovery(params);
       } finally {

--- a/extensions/memory-core/src/memory/manager.ts
+++ b/extensions/memory-core/src/memory/manager.ts
@@ -2,7 +2,7 @@
 import type { DatabaseSync } from "node:sqlite";
 import type { FSWatcher } from "chokidar";
 import { resolveAgentConfig } from "openclaw/plugin-sdk/agent-runtime";
-import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
+import { formatErrorMessage, readErrorName } from "openclaw/plugin-sdk/error-runtime";
 import { listRegisteredMemoryEmbeddingProviderAdapters } from "openclaw/plugin-sdk/memory-core-host-embedding-registry";
 import { classifyMemoryMultimodalPath } from "openclaw/plugin-sdk/memory-core-host-engine-embeddings";
 import {
@@ -33,6 +33,7 @@ import {
   type MemorySyncParams,
 } from "openclaw/plugin-sdk/memory-core-host-engine-storage";
 import { normalizeAgentId } from "openclaw/plugin-sdk/routing";
+import { redactSensitiveText } from "openclaw/plugin-sdk/security-runtime";
 import { uniqueValues } from "openclaw/plugin-sdk/string-coerce-runtime";
 import {
   resolveMemoryCoreLocalServiceHostIdentity,
@@ -118,6 +119,7 @@ type MemoryEmbeddingProviderRequirement = {
   provider: string;
   configuredProvider?: string;
 };
+type MemoryEmbeddingBootstrapDebug = NonNullable<MemorySearchRuntimeDebug["embeddingBootstrap"]>;
 
 const { cache: INDEX_CACHE, pending: INDEX_CACHE_PENDING } =
   resolveSingletonManagedCache<MemoryIndexManager>(MEMORY_INDEX_MANAGER_CACHE_KEY);
@@ -422,6 +424,7 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
   private readonly requestedProvider: EmbeddingProviderRequest;
   private providerInitPromise: Promise<void> | null = null;
   private providerInitialized = false;
+  private embeddingBootstrapFailure?: MemoryEmbeddingBootstrapDebug;
   private providerRetirementPromise: Promise<void> = Promise.resolve();
   private providersPendingRetirement = new Set<EmbeddingProvider>();
   private closePromise: Promise<void> | null = null;
@@ -707,10 +710,127 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
     this.providerInitialized = true;
   }
 
+  private markEmbeddingBootstrapFailure(
+    err: unknown,
+    options?: { retainProvider?: boolean },
+  ): MemoryEmbeddingBootstrapDebug {
+    const rawErrorName = readErrorName(err).trim();
+    const errorName = /^[A-Za-z][A-Za-z0-9_.-]{0,63}$/.test(rawErrorName) ? rawErrorName : "";
+    const message =
+      redactSensitiveText(formatErrorMessage(err), { mode: "tools" }).trim() ||
+      "embedding provider initialization failed";
+    const reason = redactSensitiveText(
+      errorName && errorName !== "Error" ? `${errorName}: ${message}` : message,
+      { mode: "tools" },
+    );
+    const errorProvider =
+      err && typeof err === "object" && typeof Reflect.get(err, "provider") === "string"
+        ? String(Reflect.get(err, "provider")).trim()
+        : "";
+    const provider = /^[A-Za-z0-9][A-Za-z0-9._:/-]{0,127}$/.test(errorProvider)
+      ? errorProvider
+      : (this.provider?.id ?? this.settings.provider);
+    const debug: MemoryEmbeddingBootstrapDebug = {
+      ok: false,
+      provider,
+      reason,
+      degradedTo: "keyword-only",
+    };
+    if (!options?.retainProvider) {
+      this.provider = null;
+      this.providerRuntime = undefined;
+    }
+    this.providerInitialized = true;
+    this.providerUnavailableReason = reason;
+    this.providerLifecycle = createDegradedMemoryProviderLifecycle({
+      providerId: provider,
+      reason,
+    });
+    this.embeddingBootstrapFailure = debug;
+    this.providerKey = this.computeProviderKey();
+    this.batch = this.resolveBatchConfig();
+    this.vector.semanticAvailable = false;
+    this.cacheProbeResult({ ok: false, error: reason });
+    return debug;
+  }
+
+  private async ensureEmbeddingProviderForSearch(
+    onDebug?: (debug: MemorySearchRuntimeDebug) => void,
+  ): Promise<boolean> {
+    const failure = this.embeddingBootstrapFailure;
+    if (failure) {
+      const cached = this.getCachedEmbeddingAvailability();
+      if (cached?.ok === false) {
+        onDebug?.({ backend: "builtin", embeddingBootstrap: failure });
+        return true;
+      }
+    }
+    try {
+      await this.ensureProviderInitialized();
+    } catch (err) {
+      if (this.providerRequirement.mode !== "optional") {
+        throw err;
+      }
+      const nextFailure = this.markEmbeddingBootstrapFailure(err);
+      onDebug?.({ backend: "builtin", embeddingBootstrap: nextFailure });
+      return true;
+    }
+    if (!failure) {
+      return false;
+    }
+    if (!this.provider) {
+      const nextFailure: MemoryEmbeddingBootstrapDebug = {
+        ...failure,
+        reason: this.providerUnavailableReason ?? failure.reason,
+      };
+      this.embeddingBootstrapFailure = nextFailure;
+      this.cacheProbeResult({ ok: false, error: nextFailure.reason });
+      onDebug?.({ backend: "builtin", embeddingBootstrap: nextFailure });
+      return true;
+    }
+
+    const currentIdentity = this.refreshIndexIdentityDirty({ providerKeyKnown: true });
+    let activeFailure = failure;
+    if (currentIdentity.status !== "valid") {
+      try {
+        await this.syncAdmitted({ reason: "search", force: true });
+      } catch (err) {
+        const message = redactSensitiveText(formatErrorMessage(err), { mode: "tools" });
+        log.warn(`memory sync failed (embedding-bootstrap-recovery): ${message}`);
+        activeFailure = this.markEmbeddingBootstrapFailure(err, { retainProvider: true });
+      }
+    }
+    if (this.refreshIndexIdentityDirty({ providerKeyKnown: true }).status === "valid") {
+      this.embeddingBootstrapFailure = undefined;
+      this.providerUnavailableReason = undefined;
+      if (this.provider) {
+        this.providerLifecycle = this.fallbackFrom
+          ? {
+              mode: "fallback-active",
+              providerId: this.provider.id,
+              fallbackFrom: this.fallbackFrom,
+              reason: this.fallbackReason ?? "fallback activated",
+            }
+          : { mode: "active", providerId: this.provider.id };
+      }
+      EMBEDDING_PROBE_CACHE.delete(this.cacheKey);
+      return false;
+    }
+    onDebug?.({ backend: "builtin", embeddingBootstrap: activeFailure });
+    return true;
+  }
+
   private async ensureProviderInitialized(): Promise<void> {
     if (this.providerInitialized) {
-      await this.getPendingFallbackProviderInitialization()?.catch(() => undefined);
-      return;
+      const bootstrapRetryDue =
+        this.embeddingBootstrapFailure !== undefined &&
+        !this.provider &&
+        this.getCachedEmbeddingAvailability() === null;
+      if (!bootstrapRetryDue) {
+        await this.getPendingFallbackProviderInitialization()?.catch(() => undefined);
+        return;
+      }
+      this.resetProviderInitializationForRetry();
     }
     if (this.settings.provider === "none") {
       this.applyProviderResult({
@@ -916,6 +1036,21 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
     return state;
   }
 
+  private refreshKeywordFallbackIndexIdentity() {
+    const meta = this.readMeta();
+    const state = this.resolveCurrentIndexIdentityState({
+      meta,
+      provider: meta && meta.provider !== "none" ? { id: meta.provider, model: meta.model } : null,
+      providerKeyKnown: false,
+      vectorReady: false,
+    });
+    this.indexIdentityState = state;
+    this.indexIdentityDirty =
+      state.status === "mismatched" ||
+      (state.status === "missing" && (this.sources.has("memory") || this.hasIndexedChunks()));
+    return state;
+  }
+
   private async withManagerOperation<T>(run: () => Promise<T>): Promise<T> {
     if (this.closing || this.closed) {
       throw new Error("Memory index manager is closed");
@@ -976,7 +1111,10 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
           // A fresh process can receive its first search before background watch/session
           // syncs have built the index. Force one synchronous bootstrap so the first
           // lookup after restart does not fail closed with empty results.
-          await this.syncAdmitted({ reason: "search", force: true });
+          await this.syncAdmitted(
+            { reason: "search", force: true },
+            { allowEmbeddingBootstrapFallback: true },
+          );
         } catch (err) {
           log.warn(`memory sync failed (search-bootstrap): ${String(err)}`);
         }
@@ -987,9 +1125,18 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
         hasIndexedContent,
       });
       if (!preflight.shouldSearch) {
+        if (this.embeddingBootstrapFailure) {
+          opts?.onDebug?.({
+            backend: "builtin",
+            embeddingBootstrap: this.embeddingBootstrapFailure,
+          });
+        }
         return [];
       }
       const cleaned = preflight.normalizedQuery;
+      const embeddingBootstrapKeywordOnly = await this.ensureEmbeddingProviderForSearch(
+        opts?.onDebug,
+      );
       void this.warmSession(opts?.sessionKey);
       await startAsyncSearchSync({
         enabled: this.settings.sync.onSearch,
@@ -1001,6 +1148,7 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
         },
       });
       if (
+        !embeddingBootstrapKeywordOnly &&
         preflight.shouldInitializeProvider &&
         !this.provider &&
         this.providerLifecycle.mode === "degraded" &&
@@ -1010,11 +1158,12 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
         // Retrying the degraded fallback here can strand a valid existing index.
         this.resetProviderInitializationForRetry();
       }
-      if (preflight.shouldInitializeProvider) {
-        await this.ensureProviderInitialized();
-        this.assertRequiredProviderAvailable("search");
-      }
-      if (!this.provider && this.providerLifecycle.mode === "degraded") {
+      this.assertRequiredProviderAvailable("search");
+      if (
+        !embeddingBootstrapKeywordOnly &&
+        !this.provider &&
+        this.providerLifecycle.mode === "degraded"
+      ) {
         const activatedFallback = await this.activateFallbackProvider(
           this.providerLifecycle.reason,
         ).catch((fallbackErr: unknown) => {
@@ -1029,9 +1178,11 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
           });
         }
       }
-      const indexIdentity = this.refreshIndexIdentityDirty({
-        providerKeyKnown: this.providerInitialized,
-      });
+      const indexIdentity = embeddingBootstrapKeywordOnly
+        ? this.refreshKeywordFallbackIndexIdentity()
+        : this.refreshIndexIdentityDirty({
+            providerKeyKnown: this.providerInitialized,
+          });
       if (indexIdentity.status !== "valid") {
         return [];
       }
@@ -1059,7 +1210,7 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
       );
 
       // FTS-only mode: no embedding provider available
-      if (!this.provider) {
+      if (embeddingBootstrapKeywordOnly || !this.provider) {
         this.assertRequiredProviderAvailable("search");
         if (!this.fts.enabled || !this.fts.available) {
           log.warn("memory search: no provider and FTS unavailable");
@@ -1657,15 +1808,48 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
     return await this.syncAdmitted(params);
   }
 
-  private async syncAdmitted(params?: MemorySyncParams): Promise<void> {
+  private async syncAdmitted(
+    params?: MemorySyncParams,
+    options?: { allowEmbeddingBootstrapFallback?: boolean },
+  ): Promise<void> {
     if (this.syncing) {
       if (hasTargetedSessionSyncParams(params)) {
         return this.enqueueTargetedSessionSync(params);
       }
-      return this.syncing;
+      try {
+        return await this.syncing;
+      } catch (err) {
+        if (
+          options?.allowEmbeddingBootstrapFallback &&
+          this.providerRequirement.mode === "optional" &&
+          (!this.providerInitialized || this.embeddingBootstrapFailure !== undefined)
+        ) {
+          if (!this.embeddingBootstrapFailure) {
+            this.markEmbeddingBootstrapFailure(err);
+          }
+          return await this.syncAdmitted(params, options);
+        }
+        throw err;
+      }
     }
     this.syncing = (async () => {
-      await this.ensureProviderInitialized();
+      const useCachedBootstrapFallback =
+        params?.reason === "search" &&
+        this.embeddingBootstrapFailure !== undefined &&
+        this.getCachedEmbeddingAvailability()?.ok === false;
+      if (!useCachedBootstrapFallback) {
+        try {
+          await this.ensureProviderInitialized();
+        } catch (err) {
+          if (
+            !options?.allowEmbeddingBootstrapFallback ||
+            this.providerRequirement.mode !== "optional"
+          ) {
+            throw err;
+          }
+          this.markEmbeddingBootstrapFailure(err);
+        }
+      }
       this.beginSyncProviderGeneration();
       try {
         await this.runSyncWithReadonlyRecovery(params);
@@ -1779,9 +1963,13 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
   }
 
   status(): MemoryProviderStatus {
-    this.refreshIndexIdentityDirty({
-      providerKeyKnown: this.providerInitialized,
-    });
+    if (this.embeddingBootstrapFailure) {
+      this.refreshKeywordFallbackIndexIdentity();
+    } else {
+      this.refreshIndexIdentityDirty({
+        providerKeyKnown: this.providerInitialized,
+      });
+    }
     const sourceFilter = this.buildSourceFilter();
     const aggregateState = collectMemoryStatusAggregate({
       db: {
@@ -1800,8 +1988,8 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
     });
 
     const providerInfo = resolveStatusProviderInfo({
-      provider: this.provider,
-      providerInitialized: this.providerInitialized,
+      provider: this.embeddingBootstrapFailure ? null : this.provider,
+      providerInitialized: this.embeddingBootstrapFailure ? true : this.providerInitialized,
       requestedProvider: this.requestedProvider,
       configuredModel: this.settings.model || undefined,
     });

--- a/extensions/memory-core/src/tools.test.ts
+++ b/extensions/memory-core/src/tools.test.ts
@@ -1062,6 +1062,47 @@ describe("memory_search unavailable payloads", () => {
     });
   });
 
+  it("surfaces embedding bootstrap degradation when keyword search has no hits", async () => {
+    let searchCalls = 0;
+    setMemorySearchImpl(async (opts) => {
+      searchCalls += 1;
+      opts?.onDebug?.({
+        backend: "builtin",
+        embeddingBootstrap: {
+          ok: false,
+          provider: "openai",
+          reason:
+            'MissingProviderAuthError: No API key resolved for provider "openai" (auth mode: api-key, checked: OPENAI_API_KEY).',
+          degradedTo: "keyword-only",
+        },
+      });
+      return [];
+    });
+    const tool = createMemorySearchToolOrThrow({
+      config: {
+        agents: { list: [{ id: "main", default: true }] },
+        memory: { citations: "off" },
+      },
+    });
+
+    const result = await tool.execute("bootstrap-debug", { query: "unknown memory" });
+    const details = result.details as {
+      results?: unknown[];
+      debug?: { embeddingBootstrap?: MemorySearchRuntimeDebug["embeddingBootstrap"] };
+    };
+
+    expect(details.results).toEqual([]);
+    expect(details.debug?.embeddingBootstrap).toEqual({
+      ok: false,
+      provider: "openai",
+      reason:
+        'MissingProviderAuthError: No API key resolved for provider "openai" (auth mode: api-key, checked: OPENAI_API_KEY).',
+      degradedTo: "keyword-only",
+    });
+    expect(searchCalls).toBe(1);
+    expect(getMemorySyncMockCalls()).toBe(0);
+  });
+
   it("returns unavailable metadata when the index identity is paused", async () => {
     let searchCalls = 0;
     setMemorySearchImpl(async () => {

--- a/extensions/memory-core/src/tools.ts
+++ b/extensions/memory-core/src/tools.ts
@@ -111,6 +111,18 @@ function mergeQmdRuntimeDebug(
   return Object.keys(merged).length > 0 ? merged : undefined;
 }
 
+function mergeEmbeddingBootstrapRuntimeDebug(
+  entries: readonly MemorySearchRuntimeDebug[],
+): MemorySearchRuntimeDebug["embeddingBootstrap"] | undefined {
+  let merged: MemorySearchRuntimeDebug["embeddingBootstrap"];
+  for (const entry of entries) {
+    if (entry.embeddingBootstrap) {
+      merged = entry.embeddingBootstrap;
+    }
+  }
+  return merged;
+}
+
 function resolveMemorySearchToolCooldownKey(options: {
   agentId?: string;
   agentSessionKey?: string;
@@ -608,6 +620,7 @@ export function createMemorySearchTool(options: {
                   outsideSearchMs?: number;
                   searchMs: number;
                   managerCacheState?: string;
+                  embeddingBootstrap?: MemorySearchRuntimeDebug["embeddingBootstrap"];
                   qmd?: MemorySearchRuntimeDebug["qmd"];
                   hits: number;
                 }
@@ -701,6 +714,7 @@ export function createMemorySearchTool(options: {
                 // retry. Long-lived QMD managers must not run update work in the tool hot path.
                 if (
                   rawResults.length === 0 &&
+                  !runtimeDebug.some((entry) => entry.embeddingBootstrap) &&
                   activeMemory.manager.sync &&
                   (statusBeforeRetry.backend !== "qmd" || options.oneShotCliRun === true)
                 ) {
@@ -764,6 +778,7 @@ export function createMemorySearchTool(options: {
                 fallback = status.fallback;
                 const latestDebug = runtimeDebug.at(-1);
                 const qmdDebug = mergeQmdRuntimeDebug(runtimeDebug);
+                const embeddingBootstrap = mergeEmbeddingBootstrapRuntimeDebug(runtimeDebug);
                 searchMode = latestDebug?.effectiveMode;
                 const searchMs = Math.max(0, Date.now() - searchStartedAt);
                 searchDebug = {
@@ -777,6 +792,7 @@ export function createMemorySearchTool(options: {
                   managerMs,
                   searchMs,
                   managerCacheState,
+                  embeddingBootstrap,
                   qmd: qmdDebug,
                   hits: rawResults.length,
                 };

--- a/packages/memory-host-sdk/src/host/types.ts
+++ b/packages/memory-host-sdk/src/host/types.ts
@@ -100,6 +100,12 @@ export type MemorySearchRuntimeDebug = {
   configuredMode?: string;
   effectiveMode?: string;
   fallback?: string;
+  embeddingBootstrap?: {
+    ok: false;
+    provider: string;
+    reason: string;
+    degradedTo: "keyword-only";
+  };
   qmd?: MemorySearchRuntimeQmdDebug;
 };
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the first `memory_search` on an empty index returned an ordinary empty result when an optional embedding provider could not start, such as OpenAI auth being absent under `provider: "auto"`.

In production this silent path made provider misconfiguration indistinguishable from a genuine no-match result. Agents could then invent explanations instead of reporting that semantic recall had degraded. The existing request-time keyword fallback did not cover provider construction or the first document-embedding request during search bootstrap, even though the memory-search docs promised keyword-only recall for unset/auto providers without usable embedding auth.

Before, a zero-hit tool result exposed no reason:

```json
{
  "results": [],
  "debug": {
    "backend": "builtin",
    "hits": 0
  }
}
```

After, the same result retains a redacted, actionable degradation reason:

```json
{
  "results": [],
  "debug": {
    "backend": "builtin",
    "hits": 0,
    "embeddingBootstrap": {
      "ok": false,
      "provider": "openai",
      "reason": "MissingProviderAuthError: No API key resolved for provider \"openai\" (auth mode: api-key, checked: OPENAI_API_KEY).",
      "degradedTo": "keyword-only"
    }
  }
}
```

## Why This Change Was Made

Optional-provider bootstrap failures now reuse the existing FTS-only sync generation and `finalizeKeywordOnlyResults` path. Text and FTS rows are indexed without vectors; required explicit providers remain fail-closed. The existing 30-second embedding availability cache owns retry cadence, ordinary degraded syncs keep the keyword index fresh, and semantic mode resumes only after a successful embedding confirmation and semantic rebuild.

The additive public `MemorySearchRuntimeDebug.embeddingBootstrap` field is redacted before reaching tool output. No config, storage schema, protocol version, surface budget, or baseline changed.

## User Impact

Users with unset/auto/local optional embedding providers retain keyword memory recall when embedding setup or the first bootstrap embedding request fails. Empty keyword results now explain the degradation instead of looking like authoritative proof that memory contains no matches. Explicitly configured remote providers still fail closed.

AI-assisted: implementation and review used Codex; the final full-branch autoreview reported no accepted/actionable findings.

## Main-Side CI Follow-up

The temporary per-file timeout mitigation was dropped during current-main replay because #115428 landed the root-cause fix for startup-log shard hangs.

## Evidence

- `node scripts/run-vitest.mjs extensions/memory-core/src/memory/manager.fts-only-reindex.test.ts` — 17/17 passed. Covers constructor failure, first embedding-request failure, keyword hits, zero-provider caching, existing semantic indexes, concurrent waiters/retries, degraded watch syncs, semantic recovery, failed recovery, redaction, and required-provider fail-closed behavior.
- `node scripts/run-vitest.mjs extensions/memory-core/src/tools.test.ts` — 45/45 passed. Covers zero-hit tool JSON and proves no force-sync retry hides `debug.embeddingBootstrap`.
- `pnpm plugin-sdk:surface:check` — passed; 320 entrypoints, 7,508 exports, 0 forbidden package subpaths.
- `pnpm docs:check-mdx` — 758 files passed.
- `node scripts/check-changed.mjs -- <8 touched files>` — passed on Blacksmith Testbox in https://github.com/openclaw/openclaw/actions/runs/30395124769: all typechecks, changed-file lint, SDK/boundary, dead-export, database-first, schema, and import-cycle guards green.
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main` — clean; no accepted/actionable findings.
