### PR TITLE
fix(agents): forward caller-owned sessionManager into run attempts

### DIFF
--- a/src/agents/embedded-agent-runner/run/run-attempt-dispatch.session-manager.test.ts
+++ b/src/agents/embedded-agent-runner/run/run-attempt-dispatch.session-manager.test.ts
@@ -86,6 +86,12 @@ function buildDispatchInput(overrides: {
   } as unknown as Parameters<typeof dispatchEmbeddedRunAttempt>[0]["control"];
   return {
     params,
+    transcriptOwnership: overrides.sessionManager
+      ? { kind: "caller-owned", sessionManager: overrides.sessionManager }
+      : {
+          kind: "runtime-target",
+          sessionTarget: (runtime as { sessionTarget?: unknown }).sessionTarget as never,
+        },
     runtime,
     control,
     bootstrapPromptWarningSignaturesSeen: [],
@@ -108,7 +114,7 @@ describe("dispatchEmbeddedRunAttempt caller-owned session manager", () => {
     expect(backendCalls.at(-1)?.sessionManager).toBe(sessionManager);
   });
 
-  it("leaves sessionManager undefined for persisted runs", async () => {
+  it("leaves sessionManager undefined for runtime-target runs", async () => {
     const dispatched = await dispatchEmbeddedRunAttempt(buildDispatchInput({}));
     expect(dispatched.preparedAttempt.sessionManager).toBeUndefined();
     expect(backendCalls.at(-1)?.sessionManager).toBeUndefined();

--- a/src/agents/embedded-agent-runner/run/run-attempt-dispatch.session-manager.test.ts
+++ b/src/agents/embedded-agent-runner/run/run-attempt-dispatch.session-manager.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it, vi } from "vitest";
+import { SessionManager } from "../../sessions/index.js";
+import { createEmbeddedRunReplayState } from "../replay-state.js";
+import { dispatchEmbeddedRunAttempt } from "./run-attempt-dispatch.js";
+import type { EmbeddedRunAttemptParams } from "./types.js";
+
+const backendCalls: EmbeddedRunAttemptParams[] = [];
+
+vi.mock("./backend.js", () => ({
+  runEmbeddedAttemptWithBackend: vi.fn(async (attempt: EmbeddedRunAttemptParams) => {
+    backendCalls.push(attempt);
+    return { messages: [], usage: undefined };
+  }),
+}));
+
+function buildDispatchInput(overrides: {
+  sessionManager?: SessionManager;
+}): Parameters<typeof dispatchEmbeddedRunAttempt>[0] {
+  const params = {
+    sessionId: "probe-setup-inference-test",
+    sessionKey: "agent:main:setup-inference:incognito-probe-setup-inference-test",
+    ...(overrides.sessionManager ? { sessionManager: overrides.sessionManager } : {}),
+    agentId: "main",
+    trigger: "manual",
+    sessionFile: "in-memory:probe-setup-inference-test",
+    workspaceDir: "/tmp/openclaw-dispatch-test",
+    prompt: "Reply with OK",
+    runId: "probe-setup-inference-test",
+    config: undefined,
+  } as unknown as Parameters<typeof dispatchEmbeddedRunAttempt>[0]["params"];
+  const runtime = {
+    sessionId: "probe-setup-inference-test",
+    sessionFile: "in-memory:probe-setup-inference-test",
+    sessionTarget: {
+      agentId: "main",
+      sessionId: "probe-setup-inference-test",
+      sessionKey: "agent:main:setup-inference:incognito-probe-setup-inference-test",
+      storePath: "/tmp/openclaw-dispatch-test/sessions.json",
+    },
+    sessionKey: "agent:main:setup-inference:incognito-probe-setup-inference-test",
+    trajectorySessionFile: "in-memory:probe-setup-inference-test",
+    trajectoryRecorder: undefined,
+    workspaceDir: "/tmp/openclaw-dispatch-test",
+    isCanonicalWorkspace: false,
+    agentDir: "/tmp/openclaw-dispatch-test/agent",
+    prompt: "Reply with OK",
+    provider: "test-provider",
+    modelId: "test-model",
+    requestedModelId: "test-model",
+    fallbackActive: false,
+    fallbackReason: null,
+    agentHarnessId: "openclaw",
+    runtimePlan: { extraParams: {} },
+    model: { api: "openai-completions", provider: "test-provider", id: "test-model" },
+    authProfileIdSource: "auto",
+    initialReplayState: createEmbeddedRunReplayState(),
+    authStorage: undefined,
+    authProfileStore: { profiles: {} },
+    modelRegistry: undefined,
+    agentId: "main",
+    thinkLevel: "off",
+    fastMode: false,
+    toolResultFormat: "markdown",
+    skipPreparedUserTurnMessage: false,
+    apiKeyInfo: undefined,
+    runtimeAuthActive: false,
+    captureRuntimeArtifact: false,
+  } as unknown as Parameters<typeof dispatchEmbeddedRunAttempt>[0]["runtime"];
+  const control = {
+    lifecycleGeneration: "test-generation",
+    pluginHarnessOwnsTransport: false,
+    laneTaskAbortController: new AbortController(),
+    laneTaskReleaseController: new AbortController(),
+    noteLaneTaskProgress: () => {},
+    onToolOutcome: () => {},
+    allocateToolOutcomeOrdinal: () => 0,
+    onToolStreamBoundary: () => {},
+    onRunProgress: () => {},
+    onToolResult: () => {},
+    onAgentEvent: () => {},
+    onUserMessagePersisted: () => {},
+    onUserMessagePersistenceInvalidated: () => {},
+    getPostCompactionAbortError: () => undefined,
+    setPostCompactionAbortController: () => {},
+    clearPostCompactionAbortController: () => {},
+  } as unknown as Parameters<typeof dispatchEmbeddedRunAttempt>[0]["control"];
+  return {
+    params,
+    runtime,
+    control,
+    bootstrapPromptWarningSignaturesSeen: [],
+    suppressNextUserMessagePersistence: false,
+    beforeAgentFinalizeRevisionAttempts: 0,
+    maxBeforeAgentFinalizeRevisions: 1,
+  };
+}
+
+describe("dispatchEmbeddedRunAttempt caller-owned session manager", () => {
+  it("forwards params.sessionManager into the attempt params", async () => {
+    // Regression: ephemeral helper runs (setup-inference probe, slug generator,
+    // companion ask) pass a caller-owned in-memory manager. Dropping it forces
+    // prepare onto the canonical SQLite target, whose missing incognito row
+    // fails the first header persist ("Session transcript header was not
+    // persisted") and false-negatives the custodian inference gate.
+    const sessionManager = SessionManager.inMemory("/tmp/openclaw-dispatch-test");
+    const dispatched = await dispatchEmbeddedRunAttempt(buildDispatchInput({ sessionManager }));
+    expect(dispatched.preparedAttempt.sessionManager).toBe(sessionManager);
+    expect(backendCalls.at(-1)?.sessionManager).toBe(sessionManager);
+  });
+
+  it("leaves sessionManager undefined for persisted runs", async () => {
+    const dispatched = await dispatchEmbeddedRunAttempt(buildDispatchInput({}));
+    expect(dispatched.preparedAttempt.sessionManager).toBeUndefined();
+    expect(backendCalls.at(-1)?.sessionManager).toBeUndefined();
+  });
+});

--- a/src/agents/session-tool-result-guard-wrapper.rebind.test.ts
+++ b/src/agents/session-tool-result-guard-wrapper.rebind.test.ts
@@ -1,0 +1,104 @@
+// Covers per-attempt guard state rebinding when a caller-owned SessionManager
+// is reused across run attempts (auth/model fallback retries). Re-guarding must
+// honor the new attempt's suppression flag and callbacks instead of keeping the
+// first attempt's captured state, which would duplicate the user turn and
+// notify stale prompt state.
+import type { AgentMessage } from "openclaw/plugin-sdk/agent-core";
+import { SessionManager } from "openclaw/plugin-sdk/agent-sessions";
+import { describe, expect, it, vi } from "vitest";
+import { guardSessionManager } from "./session-tool-result-guard-wrapper.js";
+
+function userMessage(text: string): AgentMessage {
+  return { role: "user", content: [{ type: "text", text }] } as AgentMessage;
+}
+
+function persistedRoles(sm: SessionManager): string[] {
+  return sm
+    .getEntries()
+    .filter((entry) => entry.type === "message")
+    .map((entry) => ((entry as { message: AgentMessage }).message as { role: string }).role);
+}
+
+async function flushAsyncCallbacks(): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+describe("guardSessionManager attempt rebinding", () => {
+  it("returns the same guarded instance when re-guarding", () => {
+    const first = guardSessionManager(SessionManager.inMemory());
+    const second = guardSessionManager(first);
+    expect(second).toBe(first);
+  });
+
+  it("honors the retry attempt's persistence suppression instead of duplicating the user turn", async () => {
+    const firstAttemptPersisted = vi.fn();
+    const firstAttemptSuppressed = vi.fn();
+    const sm = guardSessionManager(SessionManager.inMemory(), {
+      onUserMessagePersisted: firstAttemptPersisted,
+      onUserMessagePersistenceSuppressed: firstAttemptSuppressed,
+    });
+    const appendMessage = sm.appendMessage.bind(sm) as unknown as (message: AgentMessage) => void;
+
+    appendMessage(userMessage("prompt"));
+    await flushAsyncCallbacks();
+    expect(persistedRoles(sm)).toEqual(["user"]);
+    expect(firstAttemptPersisted).toHaveBeenCalledTimes(1);
+
+    // Second attempt reuses the caller-owned manager: the user turn is already
+    // persisted, so normalization requests suppression for the retry.
+    const retryAttemptPersisted = vi.fn();
+    const retryAttemptSuppressed = vi.fn();
+    const reguarded = guardSessionManager(sm, {
+      suppressNextUserMessagePersistence: true,
+      onUserMessagePersisted: retryAttemptPersisted,
+      onUserMessagePersistenceSuppressed: retryAttemptSuppressed,
+    });
+    expect(reguarded).toBe(sm);
+
+    appendMessage(userMessage("prompt"));
+    await flushAsyncCallbacks();
+
+    expect(persistedRoles(sm)).toEqual(["user"]);
+    expect(retryAttemptSuppressed).toHaveBeenCalledTimes(1);
+    expect(retryAttemptPersisted).not.toHaveBeenCalled();
+    // The first attempt's callbacks must not observe the retry.
+    expect(firstAttemptPersisted).toHaveBeenCalledTimes(1);
+    expect(firstAttemptSuppressed).not.toHaveBeenCalled();
+  });
+
+  it("clears stale suppression when the retry attempt does not request it", async () => {
+    const sm = guardSessionManager(SessionManager.inMemory(), {
+      suppressNextUserMessagePersistence: true,
+    });
+    const appendMessage = sm.appendMessage.bind(sm) as unknown as (message: AgentMessage) => void;
+
+    const retryAttemptPersisted = vi.fn();
+    guardSessionManager(sm, {
+      onUserMessagePersisted: retryAttemptPersisted,
+    });
+
+    appendMessage(userMessage("prompt"));
+    await flushAsyncCallbacks();
+
+    expect(persistedRoles(sm)).toEqual(["user"]);
+    expect(retryAttemptPersisted).toHaveBeenCalledTimes(1);
+  });
+
+  it("notifies the retry attempt's preparing callback instead of the first attempt's", () => {
+    const firstAttemptPreparing = vi.fn();
+    const sm = guardSessionManager(SessionManager.inMemory(), {
+      onUserMessagePreparingForPersistence: firstAttemptPreparing,
+    });
+    const appendMessage = sm.appendMessage.bind(sm) as unknown as (message: AgentMessage) => void;
+
+    const retryAttemptPreparing = vi.fn();
+    guardSessionManager(sm, {
+      onUserMessagePreparingForPersistence: retryAttemptPreparing,
+    });
+
+    appendMessage(userMessage("prompt"));
+
+    expect(retryAttemptPreparing).toHaveBeenCalledTimes(1);
+    expect(firstAttemptPreparing).not.toHaveBeenCalled();
+  });
+});

--- a/src/agents/session-tool-result-guard-wrapper.rebind.test.ts
+++ b/src/agents/session-tool-result-guard-wrapper.rebind.test.ts
@@ -6,10 +6,28 @@
 import type { AgentMessage } from "openclaw/plugin-sdk/agent-core";
 import { SessionManager } from "openclaw/plugin-sdk/agent-sessions";
 import { describe, expect, it, vi } from "vitest";
+import { resolveLiveToolResultMaxChars } from "./embedded-agent-runner/tool-result-truncation.js";
 import { guardSessionManager } from "./session-tool-result-guard-wrapper.js";
 
 function userMessage(text: string): AgentMessage {
   return { role: "user", content: [{ type: "text", text }] } as AgentMessage;
+}
+
+function assistantToolCall(id: string): AgentMessage {
+  return {
+    role: "assistant",
+    content: [{ type: "toolCall", id, name: "n", arguments: {} }],
+  } as AgentMessage;
+}
+
+function toolResult(id: string, text: string): AgentMessage {
+  return {
+    role: "toolResult",
+    toolCallId: id,
+    toolName: "n",
+    content: [{ type: "text", text }],
+    isError: false,
+  } as AgentMessage;
 }
 
 function persistedRoles(sm: SessionManager): string[] {
@@ -19,8 +37,23 @@ function persistedRoles(sm: SessionManager): string[] {
     .map((entry) => ((entry as { message: AgentMessage }).message as { role: string }).role);
 }
 
+function persistedToolResultTexts(sm: SessionManager): string[] {
+  return sm
+    .getEntries()
+    .filter((entry) => entry.type === "message")
+    .map((entry) => (entry as { message: AgentMessage }).message)
+    .filter((message) => (message as { role?: string }).role === "toolResult")
+    .map((message) =>
+      ((message as { content?: Array<{ text?: string }> }).content ?? [])
+        .map((block) => block.text ?? "")
+        .join(""),
+    );
+}
+
 async function flushAsyncCallbacks(): Promise<void> {
-  await new Promise((resolve) => setTimeout(resolve, 0));
+  await new Promise((resolve) => {
+    setTimeout(resolve, 0);
+  });
 }
 
 describe("guardSessionManager attempt rebinding", () => {
@@ -100,5 +133,32 @@ describe("guardSessionManager attempt rebinding", () => {
 
     expect(retryAttemptPreparing).toHaveBeenCalledTimes(1);
     expect(firstAttemptPreparing).not.toHaveBeenCalled();
+  });
+
+  it("applies the retry attempt's smaller tool-result cap after rebinding", () => {
+    const oversized = "x".repeat(20_000);
+    const sm = guardSessionManager(SessionManager.inMemory(), {
+      contextWindowTokens: 200_000,
+    });
+    const appendMessage = sm.appendMessage.bind(sm) as unknown as (message: AgentMessage) => void;
+
+    appendMessage(assistantToolCall("call_1"));
+    appendMessage(toolResult("call_1", oversized));
+
+    // Retry attempt falls back to a model with a much smaller context window.
+    guardSessionManager(sm, { contextWindowTokens: 4_000 });
+    appendMessage(assistantToolCall("call_2"));
+    appendMessage(toolResult("call_2", oversized));
+
+    const texts = persistedToolResultTexts(sm);
+    expect(texts).toHaveLength(2);
+    // The first attempt's large-window cap keeps the payload intact.
+    expect(texts[0]).toBe(oversized);
+    // The rebound guard must enforce the retry attempt's smaller cap instead
+    // of the limit captured when the guard was first installed.
+    const retryCap = resolveLiveToolResultMaxChars({ contextWindowTokens: 4_000 });
+    expect(retryCap).toBeLessThan(oversized.length);
+    expect(texts[1]).not.toBe(oversized);
+    expect(texts[1]?.length ?? 0).toBeLessThanOrEqual(retryCap + 500);
   });
 });

--- a/src/agents/session-tool-result-guard.ts
+++ b/src/agents/session-tool-result-guard.ts
@@ -673,12 +673,16 @@ export function installSessionToolResultGuard(
     return transformer ? transformer(message, meta) : message;
   };
 
-  const allowSyntheticToolResults = opts?.allowSyntheticToolResults ?? true;
-  const missingToolResultText = opts?.missingToolResultText;
+  // Rebinding may swap `opts` contents in place when a caller-owned manager is
+  // reused across attempts (e.g. model fallback with a smaller context window),
+  // so read attempt-scoped policy and size fields at call time instead of
+  // capturing them once at install time.
+  const allowSyntheticToolResults = () => opts?.allowSyntheticToolResults ?? true;
+  const missingToolResultText = () => opts?.missingToolResultText;
   const beforeWrite = opts?.beforeMessageWriteHook;
   const toolResultTransformerMayMutate = opts?.transformToolResultForPersistence !== undefined;
-  const redactionConfig = opts?.redactLoggingConfig;
-  const maxToolResultChars = resolveMaxToolResultChars(opts);
+  const redactionConfig = () => opts?.redactLoggingConfig;
+  const maxToolResultChars = () => resolveMaxToolResultChars(opts);
   const transcriptSeqByEntryId: TranscriptSeqByEntryId = new Map();
   let suppressNextUserMessagePersistence = opts?.suppressNextUserMessagePersistence === true;
 
@@ -745,12 +749,12 @@ export function installSessionToolResultGuard(
     if (pendingState.size() === 0) {
       return;
     }
-    if (allowSyntheticToolResults) {
+    if (allowSyntheticToolResults()) {
       for (const [id, name] of pendingState.entries()) {
         const synthetic = makeMissingToolResult({
           toolCallId: id,
           toolName: name,
-          text: missingToolResultText,
+          text: missingToolResultText(),
         });
         const persistedSynthetic = persistMessage(synthetic);
         const transformed = persistToolResult(persistedSynthetic, {
@@ -761,7 +765,7 @@ export function installSessionToolResultGuard(
         const flushed = applyBeforeWriteHook(transformed);
         if (flushed) {
           appendMessageAndCacheTranscriptSeq(
-            capToolResultForPersistence(flushed.message, maxToolResultChars, redactionConfig),
+            capToolResultForPersistence(flushed.message, maxToolResultChars(), redactionConfig()),
             {
               invalidateSerializedPrefixCache:
                 persistedSynthetic !== synthetic ||
@@ -814,8 +818,8 @@ export function installSessionToolResultGuard(
       const persistedToolResult = persistMessage(normalizedToolResult);
       const capped = capToolResultForPersistence(
         persistedToolResult,
-        maxToolResultChars,
-        redactionConfig,
+        maxToolResultChars(),
+        redactionConfig(),
       );
       const transformed = persistToolResult(capped, {
         toolCallId: id ?? undefined,
@@ -831,7 +835,7 @@ export function installSessionToolResultGuard(
         pendingState.delete(id);
       }
       return appendMessageAndCacheTranscriptSeq(
-        capToolResultForPersistence(persisted.message, maxToolResultChars, redactionConfig),
+        capToolResultForPersistence(persisted.message, maxToolResultChars(), redactionConfig()),
         {
           invalidateSerializedPrefixCache:
             callerInvalidatesCache ||
@@ -876,7 +880,7 @@ export function installSessionToolResultGuard(
     // this assistant append, and transcript repair can move late real results
     // back into strict provider order before the next replay.
     if (
-      !allowSyntheticToolResults &&
+      !allowSyntheticToolResults() &&
       pendingState.shouldFlushBeforeNewToolCalls(toolCalls.length)
     ) {
       flushPendingToolResults();

--- a/src/agents/session-tool-result-guard.ts
+++ b/src/agents/session-tool-result-guard.ts
@@ -654,6 +654,7 @@ export function installSessionToolResultGuard(
   flushPendingToolResults: () => void;
   clearPendingToolResults: () => void;
   clearNextUserMessagePersistenceSuppression: () => void;
+  setNextUserMessagePersistenceSuppression: (value: boolean) => void;
   getPendingIds: () => string[];
 } {
   const originalAppend = getRawSessionAppendMessage(sessionManager);
@@ -956,6 +957,9 @@ export function installSessionToolResultGuard(
     clearPendingToolResults,
     clearNextUserMessagePersistenceSuppression: () => {
       suppressNextUserMessagePersistence = false;
+    },
+    setNextUserMessagePersistenceSuppression: (value: boolean) => {
+      suppressNextUserMessagePersistence = value;
     },
     getPendingIds: pendingState.getPendingIds,
   };


### PR DESCRIPTION
Fixes #115392

### What Problem This Solves

`RunEmbeddedAgentParams.sessionManager` ("Caller-owned in-memory transcript for ephemeral helper runs", `run/params.ts`) is honored by `prepareEmbeddedAttemptSessionManager`:

```ts
attempt.sessionManager ?? (attempt.sessionTarget ? SessionManager.open(...) : SessionManager.inMemory(...))
```

...but `dispatchEmbeddedRunAttempt` (`run/run-attempt-dispatch.ts`) builds `attemptParams` field-by-field and never copied `params.sessionManager`. Every caller-owned manager was silently dropped, and the runner fell back to opening the canonical SQLite target.

Impact (all callers that pass a caller-owned manager):

- **setup-inference probe** (`system-agent/setup-inference-persist.ts`): the incognito probe key has no `session_nodes` row, so the first header persist fails with `Session transcript header was not persisted` -> the Control UI custodian page blocks with "OpenClaw requires working inference" although normal inference works (see #115392 for the full trace + live-install proof).
- **session-companion-ask** (`gateway/session-companion-ask.ts`): pre-seeded history (`appendMessage` before the run) was lost.
- **LLM slug generator** (`hooks/llm-slug-generator.ts`): lost its in-memory isolation.

Regression window: #113233 moved the probe from a real temp `session.jsonl` to `in-memory:<id>` + caller-owned manager; the dispatch layer never forwarded the new field. First broken release: 2026.7.2-beta.5.

### Fix

Forward the field in the attempt literal (one line + comment):

```ts
sessionTarget: runtime.sessionTarget,
sessionManager: params.sessionManager,
```

### Evidence

- New `run/run-attempt-dispatch.session-manager.test.ts`: pins the caller-owned instance through `preparedAttempt` and the backend invocation, plus the undefined case for persisted runs. Verified the first assertion fails without the fix.
- New `session-tool-result-guard-wrapper.rebind.test.ts`: covers re-guarding a caller-owned manager across retry attempts (suppression, callbacks, and attempt-scoped tool-result caps rebind instead of keeping first-attempt state).
- `run-attempt-dispatch.media.test.ts` + `system-agent/setup-inference.test.ts` + guard suites green; tsgo core green (core:test has pre-existing `ui/` errors on main, none in `src/`).
- Live verification on a 2026.7.2-beta.5 install (patched dist): `openclaw gateway call openclaw.setup.verify` returns `{ "ok": true, "latencyMs": 5846, "modelRef": "azure-foundry/gpt-5.6-terra" }` and `/custodian` unblocks; before the fix it returned `{ "ok": false, "error": "Session transcript header was not persisted" }` on every attempt.

---

### Re-verification after merge-conflict resolution (2026-07-30)

ClawSweeper requested a rerun of the focused session proof on the merged result. `main` (`f1ee2a3098`) was merged into this branch; `run-attempt-dispatch.ts` now matches main verbatim (the dispatcher forward was upstreamed via #115452's `transcriptOwnership` union), and this PR retains the guard-rebind work + regression tests, adapted to the new required `input.transcriptOwnership` shape.

Isolated gateway built from the merged head (`dist/build-info.json`):

```json
{ "version": "2026.7.2", "commit": "0d88dfd7b8f9307654976b46e7922dedc0dd90da" }
```

Setup verification against a real Azure Foundry deployment (state dir isolated to `/tmp`, secrets via env refs, endpoint redacted):

```
$ openclaw gateway call openclaw.setup.verify --params "{}" --timeout 120000
Gateway call: openclaw.setup.verify
{
  "ok": true,
  "latencyMs": 5795,
  "modelRef": "azure-foundry/gpt-5.6-terra"
}
```

Validation on the merged head: `run-attempt-dispatch.session-manager.test.ts`, `session-tool-result-guard-wrapper.rebind.test.ts`, `session-tool-result-guard.test.ts` green; tsgo core + core:test green.