### PR TITLE
fix(mxc): agent tools fail in Windows workspace subdirectories

### DIFF
--- a/extensions/mxc/src/fs-bridge.ts
+++ b/extensions/mxc/src/fs-bridge.ts
@@ -35,18 +35,26 @@ export function createMxcFsBridge(params: { sandbox: MxcFsBridgeContext }): Sand
 }
 
 class MxcFsBridge implements SandboxFsBridge {
-  private readonly defaultContainerRoot = path.resolve(this.sandbox.containerWorkdir);
+  // These must be assigned in the constructor body, not as field initializers.
+  // Plugin sources load through jiti, which evaluates field initializers before
+  // it assigns constructor parameter properties, so `this.sandbox` would still
+  // be undefined here and provisioning would crash reading containerWorkdir.
+  private readonly defaultContainerRoot: string;
 
-  private readonly protectedSkillMounts = resolveMxcProtectedSkillMounts(this.sandbox);
+  private readonly protectedSkillMounts: readonly MxcFsMount[];
 
-  private readonly workspaceMounts = resolveWorkspaceMounts(this.sandbox);
+  private readonly workspaceMounts: readonly MxcFsMount[];
 
   private readonly resolveRenameTargets = createWritableRenameTargetResolver(
     (target) => this.resolveTarget(target),
     (target, action) => this.ensureWritable(target, action),
   );
 
-  constructor(private readonly sandbox: MxcFsBridgeContext) {}
+  constructor(private readonly sandbox: MxcFsBridgeContext) {
+    this.defaultContainerRoot = path.resolve(sandbox.containerWorkdir);
+    this.protectedSkillMounts = resolveMxcProtectedSkillMounts(sandbox);
+    this.workspaceMounts = resolveWorkspaceMounts(sandbox);
+  }
 
   resolvePath(params: { filePath: string; cwd?: string }): SandboxResolvedPath {
     const target = this.resolveTarget(params);

--- a/extensions/mxc/src/mxc-backend.ts
+++ b/extensions/mxc/src/mxc-backend.ts
@@ -194,6 +194,17 @@ export function createMxcSandboxBackendHandle(params: {
     runtimeId: params.runtimeId,
     runtimeLabel: params.runtimeId,
     workdir: params.workdir,
+    workdirValidation: "backend",
+    async validateWorkdir(workdir) {
+      try {
+        return resolveWorkdirInsideWorkspace(params.workdir, workdir);
+      } catch (err) {
+        if (err instanceof Error && err.message.startsWith("MXC sandbox workdir")) {
+          return null;
+        }
+        throw err;
+      }
+    },
     capabilities: {},
 
     async buildExecSpec({ command, workdir, env, usePty }): Promise<SandboxBackendExecSpec> {

--- a/extensions/mxc/src/mxc-backend.ts
+++ b/extensions/mxc/src/mxc-backend.ts
@@ -106,7 +106,7 @@ function resolveWorkdirInsideWorkspace(workspaceDir: string, workdir: string): s
       return candidate;
     }
   } catch (err) {
-    if (isNodeError(err) && err.code === "ENOENT") {
+    if (isMissingPathError(err)) {
       throw new Error(`MXC sandbox workdir ${workdir} does not exist.`, { cause: err });
     }
     throw err;
@@ -118,7 +118,7 @@ function realpathForExistingPath(value: string, label: string): string {
   try {
     return realpathSync(path.resolve(value));
   } catch (err) {
-    if (isNodeError(err) && err.code === "ENOENT") {
+    if (isMissingPathError(err)) {
       throw new Error(`MXC ${label} ${value} does not exist.`, { cause: err });
     }
     throw err;
@@ -130,7 +130,7 @@ function realpathForPotentialPath(value: string): string {
   try {
     return realpathSync(resolved);
   } catch (err) {
-    if (!isNodeError(err) || err.code !== "ENOENT") {
+    if (!isMissingPathError(err)) {
       throw err;
     }
     const parent = path.dirname(resolved);
@@ -143,6 +143,13 @@ function realpathForPotentialPath(value: string): string {
 
 function isNodeError(err: unknown): err is NodeJS.ErrnoException {
   return err instanceof Error && "code" in err;
+}
+
+// ENOTDIR means a parent component is a file, so the path can never resolve to a
+// directory. Classifying it alongside ENOENT keeps validateWorkdir's "return null
+// for unusable workdirs" contract intact instead of leaking a raw filesystem error.
+function isMissingPathError(err: unknown): boolean {
+  return isNodeError(err) && (err.code === "ENOENT" || err.code === "ENOTDIR");
 }
 
 function buildMxcLauncherOptions(config: MxcConfig, usePty: boolean): MxcLauncherOptions {

--- a/extensions/mxc/test/mxc-backend.test.ts
+++ b/extensions/mxc/test/mxc-backend.test.ts
@@ -311,6 +311,17 @@ describeOnWindows("createMxcSandboxBackendHandle (Windows-only MXC backend tests
     ).resolves.toBeNull();
   });
 
+  test("reports workdirs nested under a file as unavailable instead of throwing", async () => {
+    // A file parent surfaces ENOTDIR on Linux (CI truth) and ENOENT on Windows.
+    // Both must reach the contract's null result rather than a raw filesystem error.
+    const filePath = path.join(baseParams.workdir, "not-a-directory.txt");
+    writeFileSync(filePath, "content");
+    const handle = createMxcSandboxBackendHandle(baseParams);
+
+    await expect(handle.validateWorkdir?.(path.join(filePath, "child"))).resolves.toBeNull();
+    await expect(handle.validateWorkdir?.(filePath)).resolves.toBeNull();
+  });
+
   test("buildExecSpec keeps command and env payload out of process argv", async () => {
     await withProcessEnv({ OPENCLAW_MXC_HOST_SECRET_TEST: "host-secret" }, async () => {
       const handle = createMxcSandboxBackendHandle(baseParams);

--- a/extensions/mxc/test/mxc-backend.test.ts
+++ b/extensions/mxc/test/mxc-backend.test.ts
@@ -299,6 +299,18 @@ describeOnWindows("createMxcSandboxBackendHandle (Windows-only MXC backend tests
     });
   });
 
+  test("normalizes agent-tool workdirs before execution", async () => {
+    const childDir = path.join(baseParams.workdir, "child");
+    mkdirSync(childDir);
+    const handle = createMxcSandboxBackendHandle(baseParams);
+
+    expect(handle.workdirValidation).toBe("backend");
+    await expect(handle.validateWorkdir?.(`${baseParams.workdir}/child`)).resolves.toBe(childDir);
+    await expect(
+      handle.validateWorkdir?.(path.join(baseParams.workdir, "missing")),
+    ).resolves.toBeNull();
+  });
+
   test("buildExecSpec keeps command and env payload out of process argv", async () => {
     await withProcessEnv({ OPENCLAW_MXC_HOST_SECRET_TEST: "host-secret" }, async () => {
       const handle = createMxcSandboxBackendHandle(baseParams);


### PR DESCRIPTION
## What Problem This Solves

Two failures on the MXC sandbox backend.

**Agent tools could not run from Windows workspace subdirectories.** A valid
child of the agent workspace written with slash-normalized Windows path
semantics was rejected. Invalid workdirs also failed inconsistently:
`validateWorkdir` is contracted to return `null` when a workdir is unusable,
but only `ENOENT` counted as "missing", so a workdir nested under a file raised
`ENOTDIR` on Linux and escaped as a raw filesystem error.

**Every MXC sandbox provisioning attempt crashed.** Building the filesystem
bridge threw before any tool could run:

```
SandboxProvisioningError: Cannot read properties of undefined (reading 'containerWorkdir')
```

## Why This Change Was Made

MXC now owns validation of agent-selected workdirs by opting into the
backend-owned `workdirValidation` contract, reusing its existing workspace
resolver for canonicalization, containment, existence, and directory checks
before execution. Generic Docker and SSH path behavior is unchanged.

The `ENOENT`-only classification appeared at three sibling sites in the same
file, so a shared `isMissingPathError` guard fixes the class rather than the
one reported path.

The provisioning crash was a class-field initialization-order bug.
`MxcFsBridge` initialized three fields from `this.sandbox`, but `sandbox` is a
constructor **parameter property**. Plugin sources load through jiti, which
evaluates field initializers before assigning parameter properties, so
`this.sandbox` was `undefined`. Those fields are now assigned in the
constructor body from the parameter.

## User Impact

Agents configured with the MXC backend can provision a sandbox at all, and can
execute tools from valid Windows workspace subdirectories. Invalid, missing,
out-of-workspace, and nested-under-a-file directories are rejected before MXC
launches and surface as a normal unavailable-workdir result rather than a raw
filesystem error.

## Evidence

**Exact head and base**

- Head: `88ce07175543df5400d0122d2a55d12e41ec73c8`
- Base: `e69c3df2361b38285917c29b0c90867c75b8ebe9` (current `main` at rebase)
- Scope: `extensions/mxc/src/mxc-backend.ts`,
  `extensions/mxc/src/fs-bridge.ts`,
  `extensions/mxc/test/mxc-backend.test.ts` (+56 / -7)

**Local checks**

- `node scripts/run-vitest.mjs extensions/mxc/test/mxc-backend.test.ts` — 49/49
- `pnpm tsgo` — clean
- `oxfmt --check` on all three changed files — clean
- CRLF-aware whitespace check — clean

**Real Windows proof**

Fresh Hyper-V desktop guest hydrated from this exact head via
`.github/workflows/crabbox-hydrate.yml` (`hydrate-windows-daemon`):

- Hydration run: https://github.com/paulcam206/openclaw/actions/runs/31036865396
- Guest checkout SHA verified equal to `88ce07175543df5400d0122d2a55d12e41ec73c8`
- Guest toolchain: Node `v24.19.0`, pnpm `11.15.1`, Windows 11
- `pnpm build` on the guest — exit 0
- Focused MXC backend suite on the guest — **49/49 passing**

<img width="1024" height="768" alt="01-vitest-49" src="https://github.com/user-attachments/assets/d86ba903-dcab-42f9-ab46-ff8d5988d681" />

https://github.com/user-attachments/assets/251a3408-9977-4bec-ab32-9ac84653e2cb

<img width="1624" height="248" alt="01-vitest-49 contact" src="https://github.com/user-attachments/assets/c9b28d23-3664-4a3c-9557-36d2a00236a1" />

**Runtime proof of the provisioning fix**

The test suite cannot cover the provisioning crash. `tsconfig.json` sets
`useDefineForClassFields: false`, so `tsgo` and Vitest both apply legacy field
ordering and the buggy code passes them — it passed 49/49 while the Gateway was
crashing. The bug only appears under the jiti loader the Gateway uses for
plugin sources.

So this is proved separately, on the same guest, at the same head. The proof
loads the **real** plugin registry from the built `dist/plugins/loader.js` — the
same module the Gateway uses — with `mxc` enabled. The loader resolves the
plugin to TypeScript source and evaluates it through jiti, then the real
`MxcFsBridge` is constructed through the real `createMxcFsBridge` using the
production alias map and production jiti options taken verbatim from `dist`.
No synthetic class, no stand-in, no hand-rolled loader.

```
PASS mxc-plugin-present
PASS plugin-resolves-to-typescript-source -> ...\extensions\mxc\index.ts
PASS real-loader-evaluated-mxc-entry-via-jiti -> status=loaded
     note: activation status detail -> activated
PASS load-real-fs-bridge-via-jiti
PASS construct-real-MxcFsBridge -> MxcFsBridge
PASS resolve-child-workdir -> ...\child
PASS backend-owns-workdir-validation -> backend
PASS validate-accepts-child-workdir -> ...\child
PASS validate-rejects-missing -> null
PASS validate-rejects-under-a-file -> null
PASS validate-rejects-out-of-workspace -> null
REAL MXC PROVISIONING PROOF: PASS
```

<img width="1024" height="768" alt="02-provisioning-proof-PASS" src="https://github.com/user-attachments/assets/a453c26a-2161-43e2-99c7-eec821fd9d70" />

<img width="1624" height="248" alt="02-provisioning-proof-PASS contact" src="https://github.com/user-attachments/assets/7fd2d90c-864f-498e-aed0-e03db3a9a8e9" />

https://github.com/user-attachments/assets/7fc9b124-4996-4548-b84b-275c95a8634b

**The proof discriminates**

A proof that only ever passes proves nothing. On the same guest, only
`extensions/mxc/src/fs-bridge.ts` was reverted to its pre-fix parent
(`ae7d52b57aea419db2074abf8d552e1e1ee0d355`) and the identical proof re-run:

```
PASS load-real-fs-bridge-via-jiti
FAIL construct-real-MxcFsBridge -> Cannot read properties of undefined (reading 'containerWorkdir')
REAL MXC PROVISIONING PROOF: FAIL (1)
```

Character-for-character the error reported from the live Gateway. The file was
then restored to head and the guest tree verified clean.

<img width="1024" height="768" alt="03-provisioning-proof-PREFIX-FAIL" src="https://github.com/user-attachments/assets/78a22fd6-870f-464d-a186-5c6316f20a42" />


https://github.com/user-attachments/assets/f8473147-7673-43d8-a4e4-9015e78cabc1

<img width="1624" height="248" alt="03-provisioning-proof-PREFIX-FAIL contact" src="https://github.com/user-attachments/assets/274b12d9-535d-4e4f-923e-7ec6613555b7" />

Please read the 49/49 as covering the workdir-validation behavior, not the
provisioning crash. The discrimination pair above is what covers the crash.

Recordings capture the runs as they execute rather than a still of an
already-finished prompt, and the guest taskbar clock in each screenshot matches
the capture timestamp in its `metadata.json`, confirming live frames rather than
a stale framebuffer.

**Maintainer verification**

Verified locally by the author on the Windows setup that originally hit the
provisioning crash.

**Structured review**

Both re-run against this rebased head:

- Autoreview (Codex `gpt-5.6-sol`, branch mode against the base above):
  TruffleHog clean, zero accepted/actionable findings,
  verdict "patch is correct (0.99)".
- ClawSweeper local-range review: `decision=keep_open`, confidence **high**,
  overall "patch is correct (0.86)", **zero** review findings, no merge-risk
  labels, security review cleared.

An earlier ClawSweeper pass flagged the `ENOTDIR` gap as an availability risk.
That finding was verified against the source, fixed across all three sibling
sites, and covered by a new regression test; re-reviews since have returned no
merge-risk labels.

**Known unrelated failure**

`src/agents/bash-tools.exec-workdir.test.ts` has 3 Windows-only failures
(`containerCwd` slash direction). Re-confirmed after this rebase: they reproduce
identically on base `e69c3df2361` with this PR's changes absent, so they are
pre-existing and out of scope here.

**Follow-up**

The class-field ordering divergence between the repo tsconfig and the jiti
plugin loader is a latent hazard for any plugin, not just MXC — a scan found
exactly one instance, fixed here. Filed as #119014 with a proposed guard.
