### PR TITLE
fix(telegram): coalesce durable album ingress into one turn

### DIFF
--- a/extensions/telegram/src/bot-processing-outcome.ts
+++ b/extensions/telegram/src/bot-processing-outcome.ts
@@ -28,6 +28,8 @@ export type TelegramSpooledReplayDeferredParticipant = {
   key: string;
   abortSignal: AbortSignal;
   task: Promise<TelegramMessageProcessingResult>;
+  isSettled: () => boolean;
+  wasOwnerAbortedWhilePending: () => boolean;
   /** Defers external timeout settlement while durable adoption decides ownership. */
   beginSettlementHold: () => TelegramSpooledReplaySettlementHold | undefined;
   settle: (result: TelegramMessageProcessingResult) => void;
@@ -79,18 +81,27 @@ export function createTelegramSpooledReplayParticipant(
   key: string,
 ): TelegramSpooledReplayDeferredParticipant {
   const abortController = new AbortController();
+  const ownerAbortSignal = telegramSpooledReplayFrames.getStore()?.lifecycle?.abortSignal;
   let settled = false;
+  let ownerAbortedWhilePending = ownerAbortSignal?.aborted === true;
   let settlementHeld = false;
   let pendingSettlement: TelegramMessageProcessingResult | undefined;
   let resolveTask: (result: TelegramMessageProcessingResult) => void = () => {};
   const task = new Promise<TelegramMessageProcessingResult>((resolve) => {
     resolveTask = resolve;
   });
+  const onOwnerAbort = () => {
+    if (!settled) {
+      ownerAbortedWhilePending = true;
+    }
+  };
+  ownerAbortSignal?.addEventListener("abort", onOwnerAbort, { once: true });
   const settleNow = (result: TelegramMessageProcessingResult) => {
     if (settled) {
       return;
     }
     settled = true;
+    ownerAbortSignal?.removeEventListener("abort", onOwnerAbort);
     if (result.kind !== "completed") {
       abortController.abort(result.kind === "failed-retryable" ? result.error : result.kind);
     }
@@ -100,6 +111,8 @@ export function createTelegramSpooledReplayParticipant(
     key,
     abortSignal: abortController.signal,
     task,
+    isSettled: () => settled,
+    wasOwnerAbortedWhilePending: () => ownerAbortedWhilePending,
     beginSettlementHold: () => {
       if (settled || settlementHeld) {
         return undefined;

--- a/extensions/telegram/src/polling-session.test.ts
+++ b/extensions/telegram/src/polling-session.test.ts
@@ -1823,21 +1823,28 @@ describe("TelegramPollingSession", () => {
         },
       });
 
-      // Core drain serializes same-lane claims: 43 stays pending until 42 settles.
-      await waitForTelegramTestState(() => expect(events).toEqual(["topic10:42"]));
+      // Telegram releases lane occupancy after each buffered update defers, while
+      // retaining both durable claims until their participants settle.
+      await waitForTelegramTestState(() => expect(events).toEqual(["topic10:42", "topic10:43"]));
+      await waitForTelegramTestState(() => expect(participants).toHaveLength(2));
       await waitForTelegramTestState(async () =>
         expect(
           (await listTelegramSpooledUpdateClaims({ spoolDir: tempDir })).map(
             (claim) => claim.updateId,
           ),
-        ).toEqual([42]),
+        ).toEqual([42, 43]),
       );
-      expect(await pendingUpdateIds(tempDir, "all")).toEqual([43]);
+      expect(await pendingUpdateIds(tempDir, "all")).toEqual([]);
 
       const completed: TelegramMessageProcessingResult = { kind: "completed" };
       participants[0]?.settle(completed);
-      await waitForTelegramTestState(() => expect(events).toEqual(["topic10:42", "topic10:43"]));
-      await waitForTelegramTestState(() => expect(participants).toHaveLength(2));
+      await waitForTelegramTestState(async () =>
+        expect(
+          (await listTelegramSpooledUpdateClaims({ spoolDir: tempDir })).map(
+            (claim) => claim.updateId,
+          ),
+        ).toEqual([43]),
+      );
       participants[1]?.settle(completed);
       await waitForTelegramTestState(async () =>
         expect(await listTelegramSpooledUpdateClaims({ spoolDir: tempDir })).toEqual([]),

--- a/extensions/telegram/src/telegram-ingress-drain.test.ts
+++ b/extensions/telegram/src/telegram-ingress-drain.test.ts
@@ -163,6 +163,102 @@ describe("createTelegramIngressMonitor", () => {
     });
   });
 
+  it.each(["completed", "skipped"] as const)(
+    "releases an aborted deferred claim after a late %s settlement",
+    async (terminalKind) => {
+      await withTempState(async (stateDir) => {
+        const queue = createChannelIngressQueueForTests<TelegramSpooledUpdatePayload>({
+          channelId: "telegram",
+          accountId: "default",
+          stateDir,
+        });
+        const updateId = terminalKind === "completed" ? 6 : 7;
+        const eventId = String(updateId).padStart(16, "0");
+        const payload = updatePayload(updateId);
+        const laneKey = telegramSpooledUpdateLaneKey(payload.update);
+        await queue.enqueue(eventId, payload, { laneKey });
+        const participant: { current?: TelegramSpooledReplayDeferredParticipant } = {};
+        const monitor = createTelegramIngressMonitor({
+          queue,
+          cfg,
+          accountId: "default",
+          dispatch: async () => {
+            participant.current =
+              createTelegramSpooledReplayDeferredParticipant(`test:late-${terminalKind}`) ??
+              undefined;
+          },
+        });
+
+        monitor.start();
+        await vi.waitFor(() => expect(participant.current).toBeDefined());
+        await monitor.stop();
+        expect((await queue.listClaims()).map((claim) => claim.id)).toEqual([eventId]);
+
+        participant.current?.settle({ kind: terminalKind });
+        await vi.waitFor(async () =>
+          expect(await queue.listPending({ limit: "all" })).toMatchObject([
+            {
+              id: eventId,
+              attempts: 1,
+              lastError: "Telegram ingress monitor is stopped.",
+            },
+          ]),
+        );
+        expect((await queue.enqueue(eventId, payload, { laneKey })).kind).not.toBe("completed");
+      });
+    },
+  );
+
+  it("releases when dispatch settles only after its owner was aborted", async () => {
+    await withTempState(async (stateDir) => {
+      const queue = createChannelIngressQueueForTests<TelegramSpooledUpdatePayload>({
+        channelId: "telegram",
+        accountId: "default",
+        stateDir,
+      });
+      const eventId = "8".padStart(16, "0");
+      const payload = updatePayload(8);
+      const laneKey = telegramSpooledUpdateLaneKey(payload.update);
+      await queue.enqueue(eventId, payload, { laneKey });
+      let finishDispatch!: () => void;
+      const dispatchGate = new Promise<void>((resolve) => {
+        finishDispatch = resolve;
+      });
+      let ownerSignal: AbortSignal | undefined;
+      const monitor = createTelegramIngressMonitor({
+        queue,
+        cfg,
+        accountId: "default",
+        dispatch: async (_update, lifecycle) => {
+          ownerSignal = lifecycle.abortSignal;
+          const participant = createTelegramSpooledReplayDeferredParticipant(
+            "test:abort-before-settlement",
+          );
+          await dispatchGate;
+          participant?.settle({ kind: "completed" });
+        },
+      });
+
+      monitor.start();
+      await vi.waitFor(() => expect(ownerSignal).toBeDefined());
+      const stopped = monitor.stop();
+      await vi.waitFor(() => expect(ownerSignal?.aborted).toBe(true));
+      finishDispatch();
+      await stopped;
+
+      await vi.waitFor(async () =>
+        expect(await queue.listPending({ limit: "all" })).toMatchObject([
+          {
+            id: eventId,
+            attempts: 1,
+            lastError: "Telegram ingress monitor is stopped.",
+          },
+        ]),
+      );
+      expect((await queue.enqueue(eventId, payload, { laneKey })).kind).not.toBe("completed");
+    });
+  });
+
   it("tombstones completed dispatch results", async () => {
     await withTempState(async (stateDir) => {
       const queue = createChannelIngressQueueForTests<TelegramSpooledUpdatePayload>({

--- a/extensions/telegram/src/telegram-ingress-drain.test.ts
+++ b/extensions/telegram/src/telegram-ingress-drain.test.ts
@@ -4,10 +4,17 @@ import os from "node:os";
 import path from "node:path";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { createChannelIngressQueueForTests } from "openclaw/plugin-sdk/plugin-state-test-runtime";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
+import {
+  createTelegramSpooledReplayDeferredParticipant,
+  type TelegramSpooledReplayDeferredParticipant,
+} from "./bot-processing-outcome.js";
 import { createTelegramIngressMonitor } from "./telegram-ingress-drain.js";
 import { telegramSpooledUpdateLaneKey } from "./telegram-ingress-spool.js";
-import type { TelegramSpooledUpdatePayload } from "./telegram-ingress-spool.payload.js";
+import {
+  TelegramIngressPayloadError,
+  type TelegramSpooledUpdatePayload,
+} from "./telegram-ingress-spool.payload.js";
 
 async function withTempState<T>(fn: (stateDir: string) => Promise<T>): Promise<T> {
   const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-telegram-ingress-drain-"));
@@ -75,6 +82,83 @@ describe("createTelegramIngressMonitor", () => {
       const pending = await queue.listPending({ limit: "all" });
       expect(pending.some((row) => row.id === eventId)).toBe(true);
 
+      await monitor.stop();
+    });
+  });
+
+  it("applies a late deferred retry failure with the real error", async () => {
+    await withTempState(async (stateDir) => {
+      const queue = createChannelIngressQueueForTests<TelegramSpooledUpdatePayload>({
+        channelId: "telegram",
+        accountId: "default",
+        stateDir,
+      });
+      const eventId = "4".padStart(16, "0");
+      const payload = updatePayload(4);
+      const laneKey = telegramSpooledUpdateLaneKey(payload.update);
+      await queue.enqueue(eventId, payload, { laneKey });
+      const participant: { current?: TelegramSpooledReplayDeferredParticipant } = {};
+      const monitor = createTelegramIngressMonitor({
+        queue,
+        cfg,
+        accountId: "default",
+        dispatch: async () => {
+          participant.current =
+            createTelegramSpooledReplayDeferredParticipant("test:late-retry") ?? undefined;
+        },
+      });
+
+      monitor.start();
+      await vi.waitFor(() => expect(participant.current).toBeDefined());
+      expect(await queue.listClaims()).toHaveLength(1);
+      participant.current?.settle({
+        kind: "failed-retryable",
+        error: new Error("late provider blip"),
+      });
+
+      await vi.waitFor(async () =>
+        expect(await queue.listPending({ limit: "all" })).toMatchObject([
+          { id: eventId, attempts: 1, lastError: "late provider blip" },
+        ]),
+      );
+      await monitor.stop();
+    });
+  });
+
+  it("dead-letters a late deferred non-retryable failure", async () => {
+    await withTempState(async (stateDir) => {
+      const queue = createChannelIngressQueueForTests<TelegramSpooledUpdatePayload>({
+        channelId: "telegram",
+        accountId: "default",
+        stateDir,
+      });
+      const eventId = "5".padStart(16, "0");
+      const payload = updatePayload(5);
+      const laneKey = telegramSpooledUpdateLaneKey(payload.update);
+      await queue.enqueue(eventId, payload, { laneKey });
+      const participant: { current?: TelegramSpooledReplayDeferredParticipant } = {};
+      const monitor = createTelegramIngressMonitor({
+        queue,
+        cfg,
+        accountId: "default",
+        dispatch: async () => {
+          participant.current =
+            createTelegramSpooledReplayDeferredParticipant("test:late-fatal") ?? undefined;
+        },
+      });
+
+      monitor.start();
+      await vi.waitFor(() => expect(participant.current).toBeDefined());
+      participant.current?.settle({
+        kind: "failed-retryable",
+        error: new TelegramIngressPayloadError("late invalid payload"),
+      });
+
+      await vi.waitFor(async () =>
+        expect(await queue.listFailed?.({ limit: "all" })).toMatchObject([
+          { id: eventId, reason: "invalid-event", message: "late invalid payload" },
+        ]),
+      );
       await monitor.stop();
     });
   });

--- a/extensions/telegram/src/telegram-ingress-drain.ts
+++ b/extensions/telegram/src/telegram-ingress-drain.ts
@@ -70,7 +70,12 @@ function inspectTelegramSpooledUpdate(update: unknown, botInfo?: TelegramBotInfo
   };
 }
 
-export type TelegramIngressDrainLifecycle = Omit<ChannelIngressMonitorLifecycle, "admission">;
+export type TelegramIngressDrainLifecycle = Omit<
+  ChannelIngressMonitorLifecycle,
+  "admission" | "onFailed"
+> & {
+  onFailed: (error: unknown) => void | Promise<void>;
+};
 
 type TelegramIngressDrainDispatch = (
   update: unknown,
@@ -128,11 +133,14 @@ export function createTelegramIngressMonitor(params: CreateTelegramIngressMonito
         ),
     },
     deliver: async (update, lifecycle) => {
+      // The monitor always supplies onFailed; the optional public field preserves
+      // structural compatibility for channel lifecycles that never use deferred failure.
+      const telegramLifecycle = lifecycle as TelegramIngressDrainLifecycle;
       try {
         const result = await runWithTelegramSpooledReplayUpdate(
           update as object,
-          async () => await params.dispatch(update, lifecycle),
-          lifecycle,
+          async () => await params.dispatch(update, telegramLifecycle),
+          telegramLifecycle,
         );
         const outcome = result.value;
         if (outcome && typeof outcome === "object" && "kind" in outcome) {
@@ -144,52 +152,31 @@ export function createTelegramIngressMonitor(params: CreateTelegramIngressMonito
             return { kind: "completed" };
           }
         }
-        // Every spooled participant gets deferredWork. Wait for its terminal
-        // result so failed-retryable releases and stalls cannot disappear.
+        // Every spooled participant gets deferredWork. Forward its terminal
+        // result without retaining Telegram's ingress serialization lane.
         const participant = result.deferredWork;
         if (participant) {
-          const terminal = await new Promise<TelegramMessageProcessingResult>((resolve, reject) => {
-            const abortError = () =>
-              lifecycle.abortSignal.reason instanceof Error
-                ? lifecycle.abortSignal.reason
-                : new Error("ingress-aborted");
-            if (lifecycle.abortSignal.aborted) {
-              reject(abortError());
-              return;
-            }
-            const onAbort = () => reject(abortError());
-            lifecycle.abortSignal.addEventListener("abort", onAbort, { once: true });
-            void participant.task.then(
-              (value) => {
-                lifecycle.abortSignal.removeEventListener("abort", onAbort);
-                resolve(value);
-              },
-              (error: unknown) => {
-                lifecycle.abortSignal.removeEventListener("abort", onAbort);
-                reject(error instanceof Error ? error : new Error(String(error)));
-              },
-            );
-          }).then(
-            (value) => value,
-            (error: unknown) => {
-              if (lifecycle.abortSignal.aborted) {
-                return { kind: "skipped" as const };
+          void participant.task
+            .then(async (terminal) => {
+              if (terminal.kind === "failed-retryable") {
+                await telegramLifecycle.onFailed(terminal.error);
+                return;
               }
-              throw error;
-            },
-          );
-          if (terminal.kind === "failed-retryable") {
-            return { kind: "failed-retryable", error: terminal.error };
-          }
-          if (lifecycle.abortSignal.aborted) {
-            return {
-              kind: "failed-retryable",
-              error:
-                lifecycle.abortSignal.reason instanceof Error
-                  ? lifecycle.abortSignal.reason
-                  : new Error("ingress-aborted"),
-            };
-          }
+              await lifecycle.onAdopted();
+            })
+            .catch(async (error: unknown) => {
+              await telegramLifecycle.onFailed(
+                error instanceof Error ? error : new Error(String(error)),
+              );
+            })
+            .catch((error: unknown) => {
+              params.onLog?.(
+                `telegram ingress: deferred settlement failed for update ${
+                  resolveTelegramUpdateId(update) ?? "unknown"
+                }: ${String(error)}`,
+              );
+            });
+          return { kind: "deferred" };
         }
         if (!participant) {
           // A dispatched update that records no outcome and defers no participant
@@ -214,6 +201,7 @@ export function createTelegramIngressMonitor(params: CreateTelegramIngressMonito
       failedMaxEntries: TELEGRAM_SPOOLED_UPDATE_FAILED_MAX_ENTRIES,
     },
     drain: {
+      deferredLaneOccupancy: "release",
       adoptionStallTimeoutMs: params.adoptionStallTimeoutMs ?? DEFAULT_INGRESS_ADOPTION_STALL_MS,
       orderBy: "id",
       scanLimit: TELEGRAM_SPOOLED_DRAIN_SCAN_LIMIT,

--- a/extensions/telegram/src/telegram-ingress-drain.ts
+++ b/extensions/telegram/src/telegram-ingress-drain.ts
@@ -166,29 +166,36 @@ export function createTelegramIngressMonitor(params: CreateTelegramIngressMonito
           const removeAbortListener = () => {
             telegramLifecycle.abortSignal.removeEventListener("abort", onAbort);
           };
+          // Two-arg then: the rejection arm must observe only a participant.task
+          // rejection. Chaining it as .catch would also swallow onFailed/onAdopted
+          // settlement errors and re-drive them through onFailed with an
+          // infrastructure error — applying the wrong disposition, or silently
+          // discarding a wedged tombstone once the phase moved past pre-adoption.
           void participant.task
-            .then(async (terminal) => {
-              removeAbortListener();
-              if (terminal.kind === "failed-retryable") {
-                await telegramLifecycle.onFailed(terminal.error);
-                return;
-              }
-              if (abortedWhilePending) {
+            .then(
+              async (terminal) => {
+                removeAbortListener();
+                if (terminal.kind === "failed-retryable") {
+                  await telegramLifecycle.onFailed(terminal.error);
+                  return;
+                }
+                if (abortedWhilePending) {
+                  await telegramLifecycle.onFailed(
+                    telegramLifecycle.abortSignal.reason instanceof Error
+                      ? telegramLifecycle.abortSignal.reason
+                      : new Error("ingress-aborted"),
+                  );
+                  return;
+                }
+                await lifecycle.onAdopted();
+              },
+              async (error: unknown) => {
+                removeAbortListener();
                 await telegramLifecycle.onFailed(
-                  telegramLifecycle.abortSignal.reason instanceof Error
-                    ? telegramLifecycle.abortSignal.reason
-                    : new Error("ingress-aborted"),
+                  error instanceof Error ? error : new Error(String(error)),
                 );
-                return;
-              }
-              await lifecycle.onAdopted();
-            })
-            .catch(async (error: unknown) => {
-              removeAbortListener();
-              await telegramLifecycle.onFailed(
-                error instanceof Error ? error : new Error(String(error)),
-              );
-            })
+              },
+            )
             .catch((error: unknown) => {
               params.onLog?.(
                 `telegram ingress: deferred settlement failed for update ${

--- a/extensions/telegram/src/telegram-ingress-drain.ts
+++ b/extensions/telegram/src/telegram-ingress-drain.ts
@@ -156,15 +156,35 @@ export function createTelegramIngressMonitor(params: CreateTelegramIngressMonito
         // result without retaining Telegram's ingress serialization lane.
         const participant = result.deferredWork;
         if (participant) {
+          let abortedWhilePending = participant.wasOwnerAbortedWhilePending();
+          const onAbort = () => {
+            if (!participant.isSettled()) {
+              abortedWhilePending = true;
+            }
+          };
+          telegramLifecycle.abortSignal.addEventListener("abort", onAbort, { once: true });
+          const removeAbortListener = () => {
+            telegramLifecycle.abortSignal.removeEventListener("abort", onAbort);
+          };
           void participant.task
             .then(async (terminal) => {
+              removeAbortListener();
               if (terminal.kind === "failed-retryable") {
                 await telegramLifecycle.onFailed(terminal.error);
+                return;
+              }
+              if (abortedWhilePending) {
+                await telegramLifecycle.onFailed(
+                  telegramLifecycle.abortSignal.reason instanceof Error
+                    ? telegramLifecycle.abortSignal.reason
+                    : new Error("ingress-aborted"),
+                );
                 return;
               }
               await lifecycle.onAdopted();
             })
             .catch(async (error: unknown) => {
+              removeAbortListener();
               await telegramLifecycle.onFailed(
                 error instanceof Error ? error : new Error(String(error)),
               );

--- a/extensions/telegram/src/telegram-ingress-media-group.e2e.test.ts
+++ b/extensions/telegram/src/telegram-ingress-media-group.e2e.test.ts
@@ -1,0 +1,301 @@
+// Telegram ingress media-group regression: durable queue → core drain → grammY → album buffer.
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import {
+  closeOpenClawStateDatabaseForTest,
+  createChannelIngressQueueForTests,
+  resetPluginStateStoreForTests,
+} from "openclaw/plugin-sdk/plugin-state-test-runtime";
+import type { MsgContext } from "openclaw/plugin-sdk/reply-runtime";
+import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { TelegramBotDeps } from "./bot-deps.js";
+import { telegramBotInfoForTest } from "./bot.create-telegram-bot.test-support.js";
+import { runTelegramChannelInboundEventWithHarness } from "./bot.test-helpers.js";
+import type { TelegramTransport } from "./fetch.js";
+import type { TelegramRuntime } from "./runtime.types.js";
+
+const downstreamTurns = vi.hoisted(() => vi.fn());
+
+vi.mock("./fetch.js", () => ({
+  resolveTelegramApiBase: (apiRoot?: string) => apiRoot ?? "https://api.telegram.org",
+  resolveTelegramFetch: (proxyFetch?: typeof fetch) => proxyFetch ?? globalThis.fetch,
+  resolveTelegramTransport: (proxyFetch?: typeof fetch) => {
+    const fetchImpl = proxyFetch ?? globalThis.fetch;
+    return { fetch: fetchImpl, sourceFetch: fetchImpl, close: async () => {} };
+  },
+  shouldRetryTelegramTransportFallback: () => false,
+}));
+
+vi.mock("openclaw/plugin-sdk/channel-inbound", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("openclaw/plugin-sdk/channel-inbound")>();
+  return {
+    ...actual,
+    runChannelInboundEvent: async (params: Parameters<typeof actual.runChannelInboundEvent>[0]) =>
+      await runTelegramChannelInboundEventWithHarness(actual, params, async (dispatchParams) => {
+        downstreamTurns(dispatchParams.ctx);
+        return { queuedFinal: false, counts: { block: 0, final: 0, tool: 0 } };
+      }),
+  };
+});
+
+vi.mock("./telegram-media.runtime.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./telegram-media.runtime.js")>();
+  return {
+    ...actual,
+    saveRemoteMedia: async (params: { filePathHint?: string }) => ({
+      id: params.filePathHint ?? "photo",
+      path: `/tmp/${path.basename(params.filePathHint ?? "photo.jpg")}`,
+      size: 4,
+      contentType: "image/jpeg",
+    }),
+  };
+});
+
+vi.mock("./bot.agent.runtime.js", () => ({
+  resolveDefaultAgentId: vi.fn(() => "default"),
+}));
+
+vi.mock("./bot-handlers.agent.runtime.js", () => ({
+  resolveAgentDir: vi.fn(() => "/tmp/agent"),
+  resolveAgentWorkspaceDir: vi.fn(() => "/tmp/workspace"),
+  resolveDefaultAgentId: vi.fn(() => "default"),
+  resolveDefaultModelForAgent: vi.fn(() => ({ provider: "openai", model: "gpt-test" })),
+}));
+
+vi.mock("./bot-message-dispatch.agent.runtime.js", () => ({
+  findModelInCatalog: vi.fn(() => undefined),
+  loadPreparedModelCatalog: vi.fn(async () => []),
+  modelSupportsVision: vi.fn(() => false),
+  resolveAgentDir: vi.fn(() => "/tmp/agent"),
+  resolveAgentWorkspaceDir: vi.fn(() => "/tmp/workspace"),
+  resolveDefaultModelForAgent: vi.fn(() => ({ provider: "openai", model: "gpt-test" })),
+}));
+
+const { createTelegramBot } = await import("./bot.js");
+const { resetInboundDedupe } = await import("openclaw/plugin-sdk/reply-runtime");
+const { createTelegramTransportIngressMonitor } =
+  await import("./telegram-ingress-drain-factory.js");
+const { setTelegramRuntime } = await import("./runtime.js");
+const { resetTelegramAccountThrottlersForTest } = await import("./runtime.test-support.js");
+const { openTelegramIngressQueue, telegramQueueEventId, writeTelegramSpooledUpdate } =
+  await import("./telegram-ingress-spool.js");
+
+const cfg = {
+  channels: { telegram: { dmPolicy: "open", allowFrom: ["*"] } },
+} as OpenClawConfig;
+
+function photoUpdate(params: { updateId: number; messageId: number; caption?: string }) {
+  return {
+    update_id: params.updateId,
+    message: {
+      message_id: params.messageId,
+      date: 1_736_380_800 + params.messageId,
+      chat: { id: 111, type: "private" as const, first_name: "Ada" },
+      from: { id: 111, is_bot: false, first_name: "Ada" },
+      media_group_id: "album-115325",
+      ...(params.caption ? { caption: params.caption } : {}),
+      photo: [
+        {
+          file_id: `photo-${params.messageId}`,
+          file_unique_id: `unique-${params.messageId}`,
+          width: 100,
+          height: 100,
+          file_size: 4,
+        },
+      ],
+    },
+  };
+}
+
+function createBotApiTransport(): TelegramTransport {
+  let getFileCall = 0;
+  const fetchImpl = vi.fn(async (input: RequestInfo | URL) => {
+    const url = input instanceof Request ? input.url : input instanceof URL ? input.href : input;
+    if (url.includes("/getFile")) {
+      getFileCall += 1;
+      return new Response(
+        JSON.stringify({
+          ok: true,
+          result: {
+            file_id: `photo-${getFileCall}`,
+            file_unique_id: `unique-${getFileCall}`,
+            file_size: 4,
+            file_path: `photos/photo-${getFileCall}.jpg`,
+          },
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      );
+    }
+    return new Response(JSON.stringify({ ok: true, result: true }), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    });
+  }) as unknown as typeof fetch;
+  return { fetch: fetchImpl, sourceFetch: fetchImpl, close: async () => {} };
+}
+
+function createTelegramDeps(stateDir: string): TelegramBotDeps {
+  return {
+    getRuntimeConfig: () => cfg,
+    resolveStorePath: (storePath?: string) => storePath ?? path.join(stateDir, "sessions.json"),
+    readChannelAllowFromStore: async () => [],
+    upsertChannelPairingRequest: async () => ({ code: "PAIRCODE", created: true }),
+    enqueueSystemEvent: () => false,
+    dispatchReplyWithBufferedBlockDispatcher: async () => ({
+      queuedFinal: false,
+      counts: { block: 0, final: 0, tool: 0 },
+    }),
+    buildModelsProviderData: async () => ({
+      byProvider: new Map<string, Set<string>>(),
+      providers: [],
+      resolvedDefault: { provider: "openai", model: "gpt-test" },
+      modelNames: new Map<string, string>(),
+    }),
+    listSkillCommandsForAgents: () => [],
+    wasSentByBot: () => false,
+  } as TelegramBotDeps;
+}
+
+async function assertAlbumTurnAndTombstones(params: {
+  spoolDir: string;
+  firstUpdateId: number;
+  secondUpdateId: number;
+}) {
+  await vi.waitFor(
+    () => {
+      expect(downstreamTurns).toHaveBeenCalledTimes(1);
+    },
+    { timeout: 5_000, interval: 5 },
+  );
+  const turn = downstreamTurns.mock.calls[0]?.[0] as MsgContext & Record<string, unknown>;
+  expect(turn.Body).toContain("Two photo album");
+  expect(turn.media).toMatchObject([
+    { path: "/tmp/photo-1.jpg", kind: "image" },
+    { path: "/tmp/photo-2.jpg", kind: "image" },
+  ]);
+
+  const queue = openTelegramIngressQueue(params.spoolDir);
+  await vi.waitFor(async () => {
+    expect(await queue.listClaims()).toEqual([]);
+    expect(await queue.listPending({ limit: "all" })).toEqual([]);
+  });
+  await expect(
+    queue.enqueue(telegramQueueEventId(params.firstUpdateId), {} as never),
+  ).resolves.toMatchObject({ kind: "completed" });
+  await expect(
+    queue.enqueue(telegramQueueEventId(params.secondUpdateId), {} as never),
+  ).resolves.toMatchObject({ kind: "completed" });
+}
+
+describe("Telegram durable ingress media groups", () => {
+  const originalStateDir = process.env.OPENCLAW_STATE_DIR;
+  let stateDir: string;
+  let spoolDir: string;
+  let activeResources: Array<{
+    monitor: ReturnType<typeof createTelegramTransportIngressMonitor>;
+    telegramTransport: TelegramTransport;
+  }>;
+
+  beforeEach(async () => {
+    stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-telegram-album-ingress-"));
+    process.env.OPENCLAW_STATE_DIR = stateDir;
+    spoolDir = path.join(stateDir, "telegram", "ingress-spool-default");
+    activeResources = [];
+    downstreamTurns.mockClear();
+    resetInboundDedupe();
+    resetPluginStateStoreForTests({ closeDatabase: false });
+    resetTelegramAccountThrottlersForTest();
+    setTelegramRuntime({
+      state: {
+        openChannelIngressQueue: (
+          options?: Omit<Parameters<typeof createChannelIngressQueueForTests>[0], "channelId">,
+        ) => createChannelIngressQueueForTests({ ...options, channelId: "telegram" }),
+      },
+      channel: {},
+    } as TelegramRuntime);
+  });
+
+  afterEach(async () => {
+    await Promise.all(
+      activeResources.map(async ({ monitor, telegramTransport }) => {
+        await monitor.stop();
+        await telegramTransport.close();
+      }),
+    );
+    closeOpenClawStateDatabaseForTest();
+    resetPluginStateStoreForTests({ closeDatabase: false });
+    if (originalStateDir === undefined) {
+      delete process.env.OPENCLAW_STATE_DIR;
+    } else {
+      process.env.OPENCLAW_STATE_DIR = originalStateDir;
+    }
+    await fs.rm(stateDir, { recursive: true, force: true });
+  });
+
+  async function createMonitor() {
+    const telegramTransport = createBotApiTransport();
+    const bot = createTelegramBot({
+      token: "tok",
+      botInfo: telegramBotInfoForTest,
+      config: cfg,
+      telegramDeps: createTelegramDeps(stateDir),
+      telegramTransport,
+      testTimings: { mediaGroupFlushMs: 40, textFragmentGapMs: 20 },
+      runtime: {
+        log: () => {},
+        error: (error) => {
+          throw error instanceof Error ? error : new Error(String(error));
+        },
+        getRuntimeConfig: () => cfg,
+        exit: () => {
+          throw new Error("unexpected runtime exit");
+        },
+      } as RuntimeEnv,
+    });
+    const monitor = createTelegramTransportIngressMonitor({
+      spoolDir,
+      bot,
+      cfg,
+      accountId: "default",
+      botInfo: telegramBotInfoForTest,
+      pollIntervalMs: 10,
+    });
+    const resources = { monitor, telegramTransport };
+    activeResources.push(resources);
+    return resources;
+  }
+
+  it("coalesces album members admitted a few milliseconds apart", async () => {
+    const { monitor, telegramTransport } = await createMonitor();
+    const first = photoUpdate({ updateId: 101, messageId: 1, caption: "Two photo album" });
+    const second = photoUpdate({ updateId: 102, messageId: 2 });
+    monitor.start();
+
+    await monitor.admit(first);
+    await new Promise((resolve) => {
+      setTimeout(resolve, 5);
+    });
+    await monitor.admit(second);
+    await assertAlbumTurnAndTombstones({ spoolDir, firstUpdateId: 101, secondUpdateId: 102 });
+
+    await monitor.stop();
+    await telegramTransport.close();
+  });
+
+  it("coalesces an album replayed from a durable restart backlog", async () => {
+    const first = photoUpdate({ updateId: 201, messageId: 1, caption: "Two photo album" });
+    const second = photoUpdate({ updateId: 202, messageId: 2 });
+    await writeTelegramSpooledUpdate({ spoolDir, update: first });
+    await writeTelegramSpooledUpdate({ spoolDir, update: second });
+    const { monitor, telegramTransport } = await createMonitor();
+
+    monitor.start();
+    await assertAlbumTurnAndTombstones({ spoolDir, firstUpdateId: 201, secondUpdateId: 202 });
+
+    await monitor.stop();
+    await telegramTransport.close();
+  });
+});

--- a/src/channels/message/ingress-drain-state.ts
+++ b/src/channels/message/ingress-drain-state.ts
@@ -1,0 +1,56 @@
+import type { ChannelIngressQueueClaim, ChannelIngressQueueRecord } from "./ingress-queue.js";
+
+export class IngressAdoptionLostError extends Error {
+  readonly code: "guillotined" | "superseded" | "reclaimed";
+
+  constructor(code: "guillotined" | "superseded" | "reclaimed") {
+    super(`ingress adoption lost: ${code}`);
+    this.name = "IngressAdoptionLostError";
+    this.code = code;
+  }
+}
+
+export function isIngressAdoptionLostError(error: unknown): error is IngressAdoptionLostError {
+  return error instanceof IngressAdoptionLostError;
+}
+
+export type ChannelIngressDrainDispatchResult =
+  | { kind: "completed" }
+  | { kind: "deferred" }
+  | { kind: "failed-retryable"; error: unknown };
+
+export type ActiveHandlerState<TPayload, TMetadata> = {
+  eventId: string;
+  laneKey: string;
+  claim: ChannelIngressQueueClaim<TPayload, TMetadata>;
+  abortController: AbortController;
+  startedAt: number;
+  phase: "dispatching" | "deferred" | "adopted" | "settled";
+  occupiesLane: boolean;
+  task: Promise<void>;
+  stallTimer?: ReturnType<typeof setTimeout>;
+  claimRefreshTimer?: ReturnType<typeof setInterval>;
+  /** Closed code: pre-adoption stall watchdog has claimed settle ownership. */
+  guillotined: boolean;
+  /** Closed code: pre-adoption supersede has claimed settle ownership. */
+  superseded: boolean;
+  /** Single settle owner for complete / fail / release / supersede / guillotine. */
+  settleOnce: (fn: () => Promise<void>) => Promise<void>;
+};
+
+export function activeClaimKey<TPayload, TMetadata>(
+  claim: ChannelIngressQueueClaim<TPayload, TMetadata>,
+): string {
+  return `${claim.id}\0${claim.claim.token}`;
+}
+
+export function resolveLaneKey<TPayload, TMetadata>(
+  record: ChannelIngressQueueRecord<TPayload, TMetadata>,
+  deriveLaneKey?: (record: ChannelIngressQueueRecord<TPayload, TMetadata>) => string | undefined,
+): string {
+  return deriveLaneKey?.(record) ?? record.laneKey ?? record.id;
+}
+
+export function sortedKeys(keys: Iterable<string>): string[] {
+  return [...keys].toSorted((a, b) => a.localeCompare(b));
+}

--- a/src/channels/message/ingress-drain-supersede.test.ts
+++ b/src/channels/message/ingress-drain-supersede.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it, vi } from "vitest";
+import { createChannelIngressDrain } from "./ingress-drain.js";
+import {
+  createTestIngressQueue,
+  type IngressDrainTestPayload as Payload,
+  withTempState,
+} from "./ingress-drain.test-helpers.js";
+
+describe("channel ingress drain supersede", () => {
+  it("supersedes every released pre-adoption state on one lane", async () => {
+    await withTempState(async (stateDir) => {
+      const queue = createTestIngressQueue(stateDir);
+      await queue.enqueue("album-1", { text: "first" }, { laneKey: "shared" });
+      await queue.enqueue("album-2", { text: "second" }, { laneKey: "shared" });
+      const signals = new Map<string, AbortSignal>();
+      const drain = createChannelIngressDrain<Payload>({
+        queue,
+        deferredLaneOccupancy: "release",
+        shouldSupersedePending: (candidate) => candidate.id === "abort",
+        dispatchClaimedEvent: async (event, lifecycle) => {
+          if (event.id === "abort") {
+            await lifecycle.onAdopted();
+            return { kind: "completed" };
+          }
+          signals.set(event.id, lifecycle.abortSignal);
+          return { kind: "deferred" };
+        },
+      });
+
+      expect(await drain.drainOnce()).toEqual({ started: 1 });
+      await vi.waitFor(() => expect(signals.size).toBe(1));
+      expect(await drain.drainOnce()).toEqual({ started: 1 });
+      await vi.waitFor(() => expect(signals.size).toBe(2));
+      expect(await queue.listClaims()).toHaveLength(2);
+
+      await queue.enqueue("abort", { text: "/abort" }, { laneKey: "shared" });
+      expect(await drain.drainOnce()).toEqual({ started: 1 });
+      await drain.waitForIdle();
+
+      expect([...signals.values()].every((signal) => signal.aborted)).toBe(true);
+      expect(await queue.listClaims()).toEqual([]);
+      for (const id of ["album-1", "album-2", "abort"]) {
+        expect((await queue.enqueue(id, { text: id })).kind).toBe("completed");
+      }
+      drain.dispose();
+    });
+  });
+
+  it("preserves single-owner supersede behavior with default lane holding", async () => {
+    await withTempState(async (stateDir) => {
+      const queue = createTestIngressQueue(stateDir);
+      await queue.enqueue("old", { text: "old" }, { laneKey: "shared" });
+      const predicatePendingIds: string[] = [];
+      let oldSignal: AbortSignal | undefined;
+      const drain = createChannelIngressDrain<Payload>({
+        queue,
+        shouldSupersedePending: (candidate, pending) => {
+          predicatePendingIds.push(pending.id);
+          return candidate.id === "new";
+        },
+        dispatchClaimedEvent: async (event, lifecycle) => {
+          if (event.id === "old") {
+            oldSignal = lifecycle.abortSignal;
+            return { kind: "deferred" };
+          }
+          await lifecycle.onAdopted();
+          return { kind: "completed" };
+        },
+      });
+
+      await drain.drainOnce();
+      await queue.enqueue("new", { text: "new" }, { laneKey: "shared" });
+      expect(await drain.drainOnce()).toEqual({ started: 1 });
+      await drain.waitForIdle();
+
+      expect(predicatePendingIds).toEqual(["old"]);
+      expect(oldSignal?.aborted).toBe(true);
+      expect((await queue.enqueue("old", { text: "old" })).kind).toBe("completed");
+      expect((await queue.enqueue("new", { text: "new" })).kind).toBe("completed");
+      drain.dispose();
+    });
+  });
+
+  it("keeps the candidate blocked when a current lane owner is not superseded", async () => {
+    await withTempState(async (stateDir) => {
+      const queue = createTestIngressQueue(stateDir);
+      await queue.enqueue("released", { text: "released" }, { laneKey: "shared" });
+      await queue.enqueue("owner", { text: "owner" }, { laneKey: "shared" });
+      let releaseOwner!: () => void;
+      const ownerGate = new Promise<void>((resolve) => {
+        releaseOwner = resolve;
+      });
+      const signals = new Map<string, AbortSignal>();
+      const drain = createChannelIngressDrain<Payload>({
+        queue,
+        deferredLaneOccupancy: "release",
+        shouldSupersedePending: (candidate, pending) =>
+          candidate.id === "abort" && pending.id === "released",
+        dispatchClaimedEvent: async (event, lifecycle) => {
+          signals.set(event.id, lifecycle.abortSignal);
+          if (event.id === "released") {
+            return { kind: "deferred" };
+          }
+          await ownerGate;
+          await lifecycle.onAdopted();
+          return { kind: "completed" };
+        },
+      });
+
+      await drain.drainOnce();
+      await vi.waitFor(() => expect(signals.has("released")).toBe(true));
+      await drain.drainOnce();
+      await vi.waitFor(() => expect(signals.has("owner")).toBe(true));
+      await queue.enqueue("abort", { text: "/abort" }, { laneKey: "shared" });
+
+      expect(await drain.drainOnce()).toEqual({ started: 0 });
+      expect(signals.get("released")?.aborted).toBe(true);
+      expect(signals.get("owner")?.aborted).toBe(false);
+      expect((await queue.listPending({ limit: "all" })).map((event) => event.id)).toEqual([
+        "abort",
+      ]);
+      releaseOwner();
+      await drain.waitForIdle();
+      drain.dispose();
+    });
+  });
+});

--- a/src/channels/message/ingress-drain-supersede.ts
+++ b/src/channels/message/ingress-drain-supersede.ts
@@ -1,0 +1,77 @@
+import { activeClaimKey, type ActiveHandlerState } from "./ingress-drain-state.js";
+import type { ChannelIngressQueueClaim, ChannelIngressQueueRecord } from "./ingress-queue.js";
+
+type SupersedeActiveStatesParams<TPayload, TMetadata> = {
+  candidate: ChannelIngressQueueRecord<TPayload, TMetadata>;
+  laneKey: string;
+  activeByClaim: Map<string, ActiveHandlerState<TPayload, TMetadata>>;
+  laneOwnerByKey: Map<string, ActiveHandlerState<TPayload, TMetadata>>;
+  shouldSupersedePending?: (
+    candidate:
+      | ChannelIngressQueueRecord<TPayload, TMetadata>
+      | ChannelIngressQueueClaim<TPayload, TMetadata>,
+    pending: ChannelIngressQueueClaim<TPayload, TMetadata>,
+  ) => boolean | Promise<boolean>;
+  clearStallTimer: (state: ActiveHandlerState<TPayload, TMetadata>) => void;
+  completeClaim: (claim: ChannelIngressQueueClaim<TPayload, TMetadata>) => Promise<void>;
+  formatError: (error: unknown) => string;
+  log: (message: string) => void;
+};
+
+function isPreAdoptionState<TPayload, TMetadata>(
+  state: ActiveHandlerState<TPayload, TMetadata>,
+): boolean {
+  return (
+    (state.phase === "dispatching" || state.phase === "deferred") &&
+    !state.guillotined &&
+    !state.superseded
+  );
+}
+
+/** Supersede every accepted pre-adoption claim on one lane, including released deferrals. */
+export async function supersedeActiveStatesIfNeeded<TPayload, TMetadata>(
+  params: SupersedeActiveStatesParams<TPayload, TMetadata>,
+): Promise<boolean> {
+  const states = new Set(
+    [...params.activeByClaim.values()].filter(
+      (state) => state.laneKey === params.laneKey && isPreAdoptionState(state),
+    ),
+  );
+  const laneOwner = params.laneOwnerByKey.get(params.laneKey);
+  if (laneOwner && isPreAdoptionState(laneOwner)) {
+    states.add(laneOwner);
+  }
+
+  let supersededAny = false;
+  for (const pending of states) {
+    if (!(await params.shouldSupersedePending?.(params.candidate, pending.claim))) {
+      continue;
+    }
+    // Revalidate after the async predicate so a late true cannot kill adopted or replaced work.
+    if (
+      params.activeByClaim.get(activeClaimKey(pending.claim)) !== pending ||
+      !isPreAdoptionState(pending) ||
+      (pending.occupiesLane && params.laneOwnerByKey.get(params.laneKey) !== pending)
+    ) {
+      continue;
+    }
+    pending.superseded = true;
+    params.clearStallTimer(pending);
+    try {
+      pending.abortController.abort(new Error("ingress-superseded"));
+    } catch {
+      // ignore
+    }
+    try {
+      await pending.settleOnce(async () => {
+        await params.completeClaim(pending.claim);
+      });
+    } catch (error) {
+      params.log(
+        `ingress drain: failed to tombstone superseded event ${pending.eventId}: ${params.formatError(error)}`,
+      );
+    }
+    supersededAny = true;
+  }
+  return supersededAny && !params.laneOwnerByKey.has(params.laneKey);
+}

--- a/src/channels/message/ingress-drain.test-helpers.ts
+++ b/src/channels/message/ingress-drain.test-helpers.ts
@@ -1,0 +1,32 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { closeOpenClawStateDatabaseForTest } from "../../state/openclaw-state-db.js";
+import { createChannelIngressQueue } from "./ingress-queue.js";
+
+export type IngressDrainTestPayload = { text: string };
+
+export function createTestIngressQueue(
+  stateDir: string,
+  options: Omit<
+    Parameters<typeof createChannelIngressQueue>[0],
+    "channelId" | "accountId" | "stateDir"
+  > = {},
+) {
+  return createChannelIngressQueue<IngressDrainTestPayload>({
+    channelId: "test",
+    accountId: "a",
+    stateDir,
+    ...options,
+  });
+}
+
+export async function withTempState<T>(fn: (stateDir: string) => Promise<T>): Promise<T> {
+  const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-ingress-drain-"));
+  try {
+    return await fn(stateDir);
+  } finally {
+    closeOpenClawStateDatabaseForTest();
+    await fs.rm(stateDir, { recursive: true, force: true });
+  }
+}

--- a/src/channels/message/ingress-drain.test-helpers.ts
+++ b/src/channels/message/ingress-drain.test-helpers.ts
@@ -1,6 +1,6 @@
 import fs from "node:fs/promises";
-import os from "node:os";
 import path from "node:path";
+import { resolvePreferredOpenClawTmpDir } from "../../infra/tmp-openclaw-dir.js";
 import { closeOpenClawStateDatabaseForTest } from "../../state/openclaw-state-db.js";
 import { createChannelIngressQueue } from "./ingress-queue.js";
 
@@ -22,7 +22,9 @@ export function createTestIngressQueue(
 }
 
 export async function withTempState<T>(fn: (stateDir: string) => Promise<T>): Promise<T> {
-  const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-ingress-drain-"));
+  const stateDir = await fs.mkdtemp(
+    path.join(resolvePreferredOpenClawTmpDir(), "openclaw-ingress-drain-"),
+  );
   try {
     return await fn(stateDir);
   } finally {

--- a/src/channels/message/ingress-drain.test.ts
+++ b/src/channels/message/ingress-drain.test.ts
@@ -1,7 +1,4 @@
 // Durable ingress drain contract tests for lifecycle reliability invariants.
-import fs from "node:fs/promises";
-import os from "node:os";
-import path from "node:path";
 import { expectDefined } from "@openclaw/normalization-core";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { closeOpenClawStateDatabaseForTest } from "../../state/openclaw-state-db.js";
@@ -11,43 +8,20 @@ import {
   DEFAULT_INGRESS_ADOPTION_STALL_MS,
   isIngressAdoptionLostError,
 } from "./ingress-drain.js";
+import {
+  createTestIngressQueue,
+  type IngressDrainTestPayload as Payload,
+  withTempState,
+} from "./ingress-drain.test-helpers.js";
 
 // Module-private in ingress-drain.ts; derive from the factory signature.
 type ChannelIngressDispatchLifecycle = Parameters<
   Parameters<typeof createChannelIngressDrain>[0]["dispatchClaimedEvent"]
 >[1];
-import { createChannelIngressQueue } from "./ingress-queue.js";
 import {
   DEFAULT_INGRESS_RETRY_DEAD_LETTER_MIN_AGE_MS,
   DEFAULT_INGRESS_RETRY_MAX_ATTEMPTS,
 } from "./ingress-retry-policy.js";
-
-type Payload = { text: string };
-
-function createTestIngressQueue(
-  stateDir: string,
-  options: Omit<
-    Parameters<typeof createChannelIngressQueue>[0],
-    "channelId" | "accountId" | "stateDir"
-  > = {},
-) {
-  return createChannelIngressQueue<Payload>({
-    channelId: "test",
-    accountId: "a",
-    stateDir,
-    ...options,
-  });
-}
-
-async function withTempState<T>(fn: (stateDir: string) => Promise<T>): Promise<T> {
-  const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-ingress-drain-"));
-  try {
-    return await fn(stateDir);
-  } finally {
-    closeOpenClawStateDatabaseForTest();
-    await fs.rm(stateDir, { recursive: true, force: true });
-  }
-}
 
 describe("channel ingress drain", () => {
   beforeEach(() => {
@@ -193,6 +167,170 @@ describe("channel ingress drain", () => {
         expect(pending[0]?.attempts).toBeGreaterThanOrEqual(1);
       });
       drain.dispose();
+    });
+  });
+
+  it("holds lanes by default and releases only opted-in deferred lanes", async () => {
+    for (const occupancy of ["hold", "release"] as const) {
+      await withTempState(async (stateDir) => {
+        const queue = createTestIngressQueue(stateDir);
+        await queue.enqueue("first", { text: "first" }, { laneKey: "shared" });
+        const lifecycles: ChannelIngressDispatchLifecycle[] = [];
+        const drain = createChannelIngressDrain<Payload>({
+          queue,
+          ...(occupancy === "release" ? { deferredLaneOccupancy: occupancy } : {}),
+          dispatchClaimedEvent: async (_event, lifecycle) => {
+            lifecycles.push(lifecycle);
+            return { kind: "deferred" };
+          },
+        });
+        expect(await drain.drainOnce()).toEqual({ started: 1 });
+        await vi.waitFor(() => expect(lifecycles).toHaveLength(1));
+        expect(drain.activeLaneKeys().has("shared")).toBe(occupancy === "hold");
+
+        await queue.enqueue("second", { text: "second" }, { laneKey: "shared" });
+        expect(await drain.drainOnce()).toEqual({ started: occupancy === "hold" ? 0 : 1 });
+        await vi.waitFor(() => expect(lifecycles).toHaveLength(occupancy === "hold" ? 1 : 2));
+        expect((await queue.listClaims()).map((claim) => claim.id).toSorted()).toEqual(
+          occupancy === "hold" ? ["first"] : ["first", "second"],
+        );
+        drain.dispose();
+      });
+    }
+  });
+
+  it("keeps heartbeat and watchdog ownership after releasing a deferred lane", async () => {
+    await withTempState(async (stateDir) => {
+      let clock = 1_000;
+      const queue = createTestIngressQueue(stateDir, { now: () => clock });
+      await queue.enqueue("released-stall", { text: "x" }, { laneKey: "shared" });
+      const refreshClaim = vi.fn(async () => true);
+      queue.refreshClaim = refreshClaim;
+      const drain = createChannelIngressDrain<Payload>({
+        queue,
+        now: () => clock,
+        claimLeaseMs: 3_000,
+        adoptionStallTimeoutMs: 2_000,
+        deferredLaneOccupancy: "release",
+        dispatchClaimedEvent: async () => ({ kind: "deferred" }),
+      });
+
+      await drain.drainOnce();
+      await vi.waitFor(() => expect(drain.activeLaneKeys()).toEqual(new Set()));
+      clock += 1_000;
+      await vi.advanceTimersByTimeAsync(1_000);
+      expect(refreshClaim).toHaveBeenCalledTimes(1);
+
+      clock += 1_000;
+      await vi.advanceTimersByTimeAsync(1_000);
+      await vi.waitFor(async () => expect(await queue.listFailed?.()).toHaveLength(1));
+      const failed = await queue.listFailed?.();
+      expect(failed?.[0]).toMatchObject({ id: "released-stall", reason: "handler-timeout" });
+      drain.dispose();
+    });
+  });
+
+  it("applies retry, non-retryable, and retry-limit policy to deferred failures", async () => {
+    await withTempState(async (stateDir) => {
+      let clock = 10_000;
+      const queue = createTestIngressQueue(stateDir, { now: () => clock });
+      await queue.enqueue("late-failure", { text: "x" }, { laneKey: "shared", receivedAt: clock });
+      const lifecycles: ChannelIngressDispatchLifecycle[] = [];
+      const drain = createChannelIngressDrain<Payload>({
+        queue,
+        now: () => clock,
+        deferredLaneOccupancy: "release",
+        retryPolicy: { baseMs: 1_000, maxMs: 1_000 },
+        dispatchClaimedEvent: async (_event, lifecycle) => {
+          lifecycles.push(lifecycle);
+          return { kind: "deferred" };
+        },
+      });
+
+      await drain.drainOnce();
+      await vi.waitFor(() => expect(lifecycles).toHaveLength(1));
+      const onFailed = expectDefined(
+        expectDefined(lifecycles[0], "deferred lifecycle").onFailed,
+        "deferred failure lifecycle",
+      );
+      await onFailed(new Error("late provider failure"));
+
+      expect(await queue.listPending({ limit: "all" })).toMatchObject([
+        { id: "late-failure", attempts: 1, lastError: "late provider failure" },
+      ]);
+      expect(await drain.drainOnce()).toEqual({ started: 0 });
+      clock += 1_000;
+      expect(await drain.drainOnce()).toEqual({ started: 1 });
+      drain.dispose();
+    });
+    await withTempState(async (stateDir) => {
+      const queue = createTestIngressQueue(stateDir, { now: () => 10_000 });
+      await queue.enqueue("non-retryable", { text: "x" }, { laneKey: "one", receivedAt: 1 });
+      await queue.enqueue("retry-limit", { text: "x" }, { laneKey: "two", receivedAt: 1 });
+      const lifecycles = new Map<string, ChannelIngressDispatchLifecycle>();
+      const drain = createChannelIngressDrain<Payload>({
+        queue,
+        now: () => 10_000,
+        deferredLaneOccupancy: "release",
+        retryPolicy: { maxAttempts: 1, deadLetterMinAgeMs: 0 },
+        resolveNonRetryableFailure: (error) =>
+          error instanceof Error && error.message === "fatal input"
+            ? { reason: "invalid-input", message: error.message }
+            : null,
+        dispatchClaimedEvent: async (event, lifecycle) => {
+          lifecycles.set(event.id, lifecycle);
+          return { kind: "deferred" };
+        },
+      });
+
+      expect(await drain.drainOnce()).toEqual({ started: 2 });
+      await vi.waitFor(() => expect(lifecycles.size).toBe(2));
+      await expectDefined(
+        expectDefined(lifecycles.get("non-retryable"), "non-retryable lifecycle").onFailed,
+        "non-retryable failure lifecycle",
+      )(new Error("fatal input"));
+      await expectDefined(
+        expectDefined(lifecycles.get("retry-limit"), "retry-limit lifecycle").onFailed,
+        "retry-limit failure lifecycle",
+      )(new Error("still broken"));
+
+      expect(await queue.listFailed?.({ limit: "all" })).toMatchObject([
+        { id: "non-retryable", reason: "invalid-input", message: "fatal input" },
+        { id: "retry-limit", reason: "retry-limit-exceeded", message: "still broken" },
+      ]);
+      drain.dispose();
+    });
+  });
+
+  it("protects and aborts released deferred claims until disposal", async () => {
+    await withTempState(async (stateDir) => {
+      const queue = createTestIngressQueue(stateDir);
+      await queue.enqueue("released", { text: "x" }, { laneKey: "shared" });
+      let aborted = false;
+      const first = createChannelIngressDrain<Payload>({
+        queue,
+        deferredLaneOccupancy: "release",
+        dispatchClaimedEvent: async (_event, lifecycle) => {
+          lifecycle.abortSignal.addEventListener("abort", () => {
+            aborted = true;
+          });
+          return { kind: "deferred" };
+        },
+      });
+      const second = createChannelIngressDrain<Payload>({
+        queue,
+        dispatchClaimedEvent: async () => ({ kind: "deferred" }),
+      });
+
+      await first.drainOnce();
+      await vi.waitFor(() => expect(first.activeLaneKeys()).toEqual(new Set()));
+      expect(await second.recoverStaleClaims()).toBe(0);
+
+      first.dispose();
+      expect(aborted).toBe(true);
+      expect((await queue.listClaims()).map((claim) => claim.id)).toEqual(["released"]);
+      expect(await second.recoverStaleClaims()).toBe(1);
+      second.dispose();
     });
   });
 
@@ -567,6 +705,9 @@ describe("channel ingress drain", () => {
       onAdoptionFinalizing: () => {
         calls.push("finalizing");
       },
+      onFailed: () => {
+        calls.push("failed");
+      },
       onAdopted: () => {
         calls.push("adopted");
       },
@@ -579,6 +720,7 @@ describe("channel ingress drain", () => {
     });
     expect(bound.turnAdoptionLifecycle.abortSignal).toBe(abort.signal);
     expect(bound.turnAdoptionLifecycle.admission).toBe("exclusive");
+    expect("onFailed" in bound.turnAdoptionLifecycle).toBe(false);
     expect("onAdopted" in bound).toBe(false);
     expect(Object.keys(bound)).toEqual(["turnAdoptionLifecycle"]);
     bound.turnAdoptionLifecycle.onDeferred();
@@ -1007,6 +1149,7 @@ describe("channel ingress drain", () => {
       onAdopted: async () => {},
       onDeferred: () => {},
       onAdoptionFinalizing: () => {},
+      onFailed: () => {},
       onAbandoned: () => {},
     });
     expect(bound.turnAdoptionLifecycle.admission).toBe("exclusive");

--- a/src/channels/message/ingress-drain.ts
+++ b/src/channels/message/ingress-drain.ts
@@ -76,7 +76,7 @@ type ChannelIngressDispatchLifecycle = {
   onAbandoned: () => void | Promise<void>;
 };
 
-export type DeferredLaneOccupancy = "hold" | "release";
+type DeferredLaneOccupancy = "hold" | "release";
 
 export type CreateChannelIngressDrainOptions<
   TPayload,

--- a/src/channels/message/ingress-drain.ts
+++ b/src/channels/message/ingress-drain.ts
@@ -23,6 +23,7 @@ import {
   type ActiveHandlerState,
   type ChannelIngressDrainDispatchResult,
 } from "./ingress-drain-state.js";
+import { supersedeActiveStatesIfNeeded } from "./ingress-drain-supersede.js";
 export { isIngressAdoptionLostError } from "./ingress-drain-state.js";
 import type {
   ChannelIngressQueue,
@@ -542,46 +543,18 @@ export function createChannelIngressDrain<
   const supersedeActiveIfNeeded = async (
     candidate: ChannelIngressQueueRecord<TPayload, TMetadata>,
     laneKey: string,
-  ): Promise<boolean> => {
-    const pending = laneOwnerByKey.get(laneKey);
-    if (!pending || pending.phase === "adopted" || pending.phase === "settled") {
-      return false;
-    }
-    if (!(await options.shouldSupersedePending?.(candidate, pending.claim))) {
-      return false;
-    }
-    // Revalidate after async predicate: a late true must not kill an adopted turn
-    // or a different map entry that replaced this pending handler.
-    const stillPending = laneOwnerByKey.get(laneKey);
-    if (
-      stillPending !== pending ||
-      stillPending.phase === "adopted" ||
-      stillPending.phase === "settled" ||
-      stillPending.guillotined ||
-      stillPending.superseded
-    ) {
-      return false;
-    }
-    // Pre-adoption supersede only — after adoption core owns interruption.
-    // Tombstone (complete), never release: requeue would replay the aborted turn.
-    stillPending.superseded = true;
-    clearStallTimer(stillPending);
-    try {
-      stillPending.abortController.abort(new Error("ingress-superseded"));
-    } catch {
-      // ignore
-    }
-    try {
-      await stillPending.settleOnce(async () => {
-        await completeClaimWithRetry(stillPending.claim);
-      });
-    } catch (err) {
-      log(
-        `ingress drain: failed to tombstone superseded event ${stillPending.eventId}: ${formatError(err)}`,
-      );
-    }
-    return true;
-  };
+  ): Promise<boolean> =>
+    await supersedeActiveStatesIfNeeded({
+      candidate,
+      laneKey,
+      activeByClaim,
+      laneOwnerByKey,
+      shouldSupersedePending: options.shouldSupersedePending,
+      clearStallTimer,
+      completeClaim: completeClaimWithRetry,
+      formatError,
+      log,
+    });
 
   const runClaimed = (
     claim: ChannelIngressQueueClaim<TPayload, TMetadata>,

--- a/src/channels/message/ingress-drain.ts
+++ b/src/channels/message/ingress-drain.ts
@@ -14,6 +14,16 @@ import {
   isLiveLocalIngressDrainOwner,
   registerLiveIngressDrainInstance,
 } from "./ingress-claim-owner.js";
+import {
+  activeClaimKey,
+  IngressAdoptionLostError,
+  isIngressAdoptionLostError,
+  resolveLaneKey,
+  sortedKeys,
+  type ActiveHandlerState,
+  type ChannelIngressDrainDispatchResult,
+} from "./ingress-drain-state.js";
+export { isIngressAdoptionLostError } from "./ingress-drain-state.js";
 import type {
   ChannelIngressQueue,
   ChannelIngressQueueClaim,
@@ -34,25 +44,6 @@ export const DEFAULT_INGRESS_ADOPTION_STALL_MS = 5 * 60 * 1000;
 
 /** Bounded tombstone write retries — wedged ownership beats silent double-dispatch. */
 const INGRESS_TOMBSTONE_RETRY_MAX_ATTEMPTS = 8;
-
-/**
- * Closed error when adoption races a pre-adoption guillotine/supersede, or when
- * a claim-token fence rejects complete/fail (lease reclaimed by another owner).
- * Callers must stop the turn (abortSignal is also aborted when applicable).
- */
-class IngressAdoptionLostError extends Error {
-  readonly code: "guillotined" | "superseded" | "reclaimed";
-
-  constructor(code: "guillotined" | "superseded" | "reclaimed") {
-    super(`ingress adoption lost: ${code}`);
-    this.name = "IngressAdoptionLostError";
-    this.code = code;
-  }
-}
-
-export function isIngressAdoptionLostError(error: unknown): error is IngressAdoptionLostError {
-  return error instanceof IngressAdoptionLostError;
-}
 
 /** Full pre-adoption → adoption ownership lifecycle for one claimed event. */
 type ChannelIngressDispatchLifecycle = {
@@ -75,6 +66,8 @@ type ChannelIngressDispatchLifecycle = {
    * Claim stays held until onAdopted / onAbandoned / fail.
    */
   onAdoptionFinalizing: () => void;
+  /** Deferred work terminally failed after dispatch returned. */
+  onFailed?: (error: unknown) => void | Promise<void>;
   /**
    * Deferred turn finished without ever owning the reply lane.
    * Drain releases the claim for retry.
@@ -82,10 +75,7 @@ type ChannelIngressDispatchLifecycle = {
   onAbandoned: () => void | Promise<void>;
 };
 
-type ChannelIngressDrainDispatchResult =
-  | { kind: "completed" }
-  | { kind: "deferred" }
-  | { kind: "failed-retryable"; error: unknown };
+export type DeferredLaneOccupancy = "hold" | "release";
 
 export type CreateChannelIngressDrainOptions<
   TPayload,
@@ -113,6 +103,11 @@ export type CreateChannelIngressDrainOptions<
   ownerId?: string;
   adoptionStallTimeoutMs?: number;
   claimLeaseMs?: number;
+  /**
+   * Whether a claimed event keeps occupying its ingress serialization lane after
+   * dispatch hands ownership to deferred work. Default "hold" (current behavior).
+   */
+  deferredLaneOccupancy?: DeferredLaneOccupancy;
   retryPolicy?: IngressRetryPolicyConfig;
   now?: () => number;
   formatError?: (err: unknown) => string;
@@ -130,35 +125,6 @@ export type ChannelIngressDrain = {
   waitForIdle: () => Promise<void>;
   dispose: () => void;
 };
-
-type ActiveHandlerState<TPayload, TMetadata> = {
-  eventId: string;
-  laneKey: string;
-  claim: ChannelIngressQueueClaim<TPayload, TMetadata>;
-  abortController: AbortController;
-  startedAt: number;
-  phase: "dispatching" | "deferred" | "adopted" | "settled";
-  task: Promise<void>;
-  stallTimer?: ReturnType<typeof setTimeout>;
-  claimRefreshTimer?: ReturnType<typeof setInterval>;
-  /** Closed code: pre-adoption stall watchdog has claimed settle ownership. */
-  guillotined: boolean;
-  /** Closed code: pre-adoption supersede has claimed settle ownership. */
-  superseded: boolean;
-  /** Single settle owner for complete / fail / release / supersede / guillotine. */
-  settleOnce: (fn: () => Promise<void>) => Promise<void>;
-};
-
-function resolveLaneKey<TPayload, TMetadata>(
-  record: ChannelIngressQueueRecord<TPayload, TMetadata>,
-  deriveLaneKey?: (record: ChannelIngressQueueRecord<TPayload, TMetadata>) => string | undefined,
-): string {
-  return deriveLaneKey?.(record) ?? record.laneKey ?? record.id;
-}
-
-function sortedKeys(keys: Iterable<string>): string[] {
-  return [...keys].toSorted((a, b) => a.localeCompare(b));
-}
 
 /**
  * Maps a drain lifecycle onto reply options.
@@ -208,7 +174,9 @@ export function createChannelIngressDrain<
   const orderBy = options.orderBy ?? "received";
   const scanLimit = options.scanLimit ?? 100;
   const startLimit = options.startLimit ?? 32;
-  const activeByLane = new Map<string, ActiveHandlerState<TPayload, TMetadata>>();
+  const deferredLaneOccupancy = options.deferredLaneOccupancy ?? "hold";
+  const activeByClaim = new Map<string, ActiveHandlerState<TPayload, TMetadata>>();
+  const laneOwnerByKey = new Map<string, ActiveHandlerState<TPayload, TMetadata>>();
   let disposed = false;
 
   const log = (message: string) => {
@@ -234,7 +202,7 @@ export function createChannelIngressDrain<
     // Claim-token fencing prevents this owner from settling a recovered claim.
     deregisterLiveIngressDrainInstance(ownerId);
     const reason = toErrorObject(options.abortSignal?.reason, "ingress-drain-aborted");
-    for (const state of activeByLane.values()) {
+    for (const state of activeByClaim.values()) {
       if (state.phase === "dispatching" || state.phase === "deferred") {
         state.abortController.abort(reason);
       }
@@ -249,9 +217,11 @@ export function createChannelIngressDrain<
   const removeActive = (state: ActiveHandlerState<TPayload, TMetadata>) => {
     clearStallTimer(state);
     clearClaimRefresh(state);
-    if (activeByLane.get(state.laneKey) === state) {
-      activeByLane.delete(state.laneKey);
+    activeByClaim.delete(activeClaimKey(state.claim));
+    if (laneOwnerByKey.get(state.laneKey) === state) {
+      laneOwnerByKey.delete(state.laneKey);
     }
+    state.occupiesLane = false;
   };
 
   const markLeaseReclaimed = (state: ActiveHandlerState<TPayload, TMetadata>) => {
@@ -522,6 +492,12 @@ export function createChannelIngressDrain<
         }
         // Deferred holds the claim; watchdog remains armed until adoption or abandon.
         state.phase = "deferred";
+        if (deferredLaneOccupancy === "release") {
+          if (laneOwnerByKey.get(state.laneKey) === state) {
+            laneOwnerByKey.delete(state.laneKey);
+          }
+          state.occupiesLane = false;
+        }
       },
       onAdoptionFinalizing: () => {
         if (state.phase !== "dispatching" && state.phase !== "deferred") {
@@ -533,6 +509,18 @@ export function createChannelIngressDrain<
         // Adoption finalization (settlement hold) owns the claim; do not let a
         // stall watchdog race and dead-letter an about-to-complete event.
         clearStallTimer(state);
+      },
+      onFailed: async (error) => {
+        if (state.phase !== "dispatching" && state.phase !== "deferred") {
+          return;
+        }
+        if (state.guillotined || state.superseded) {
+          return;
+        }
+        clearStallTimer(state);
+        await state.settleOnce(async () => {
+          await applyFailureDisposition(state.claim, error);
+        });
       },
       onAbandoned: async () => {
         if (state.phase !== "deferred" && state.phase !== "dispatching") {
@@ -555,7 +543,7 @@ export function createChannelIngressDrain<
     candidate: ChannelIngressQueueRecord<TPayload, TMetadata>,
     laneKey: string,
   ): Promise<boolean> => {
-    const pending = activeByLane.get(laneKey);
+    const pending = laneOwnerByKey.get(laneKey);
     if (!pending || pending.phase === "adopted" || pending.phase === "settled") {
       return false;
     }
@@ -564,7 +552,7 @@ export function createChannelIngressDrain<
     }
     // Revalidate after async predicate: a late true must not kill an adopted turn
     // or a different map entry that replaced this pending handler.
-    const stillPending = activeByLane.get(laneKey);
+    const stillPending = laneOwnerByKey.get(laneKey);
     if (
       stillPending !== pending ||
       stillPending.phase === "adopted" ||
@@ -607,6 +595,7 @@ export function createChannelIngressDrain<
       abortController,
       startedAt: now(),
       phase: "dispatching" as const,
+      occupiesLane: true,
       guillotined: false,
       superseded: false,
       task: Promise.resolve(),
@@ -690,21 +679,18 @@ export function createChannelIngressDrain<
       }
     })();
 
-    activeByLane.set(laneKey, state);
+    activeByClaim.set(activeClaimKey(claim), state);
+    laneOwnerByKey.set(laneKey, state);
     return state;
   };
 
   const recoverStaleClaims = async (): Promise<number> => {
-    const activeLanes = new Set(activeByLane.keys());
+    const activeLanes = new Set(laneOwnerByKey.keys());
     return await queue.recoverStaleClaims({
       staleMs: 0,
       now: now(),
       shouldRecover: (claim) => {
-        const laneKey = resolveLaneKey(claim, options.deriveLaneKey);
-        if (activeLanes.has(laneKey)) {
-          return false;
-        }
-        if (activeByLane.has(laneKey)) {
+        if (activeByClaim.has(activeClaimKey(claim))) {
           return false;
         }
         // Same-PID multi-drain: only recover when the owner instance is not live.
@@ -744,13 +730,19 @@ export function createChannelIngressDrain<
 
     const pending = await queue.listPending({ limit: "all", orderBy });
     const claims = await queue.listClaims();
-    const activeLaneKeys = new Set(
-      [...activeByLane.values()]
-        .filter((state) => state.phase !== "settled")
-        .map((state) => state.laneKey),
-    );
+    const activeLaneKeys = new Set(laneOwnerByKey.keys());
     const claimedLaneKeys = new Set(
-      claims.map((claim) => resolveLaneKey(claim, options.deriveLaneKey)),
+      claims
+        .filter((claim) => {
+          const state = activeByClaim.get(activeClaimKey(claim));
+          return !(
+            state?.phase === "deferred" &&
+            !state.occupiesLane &&
+            !state.guillotined &&
+            !state.superseded
+          );
+        })
+        .map((claim) => resolveLaneKey(claim, options.deriveLaneKey)),
     );
     const retryDelayedLaneKeys = new Set<string>();
     for (const event of pending) {
@@ -800,12 +792,12 @@ export function createChannelIngressDrain<
         break;
       }
       const laneKey = resolveLaneKey(claimed, options.deriveLaneKey);
-      const existing = activeByLane.get(laneKey);
+      const existing = laneOwnerByKey.get(laneKey);
       if (existing && existing.phase !== "settled") {
         if (await supersedeActiveIfNeeded(claimed, laneKey)) {
           blockedLaneKeys.delete(laneKey);
         }
-        if (activeByLane.has(laneKey)) {
+        if (laneOwnerByKey.has(laneKey)) {
           await queue.release(claimed, { recordAttempt: false });
           blockedLaneKeys.add(laneKey);
           continue;
@@ -821,17 +813,17 @@ export function createChannelIngressDrain<
   return {
     recoverStaleClaims,
     drainOnce,
-    activeLaneKeys: () => new Set(activeByLane.keys()),
+    activeLaneKeys: () => new Set(laneOwnerByKey.keys()),
     waitForIdle: async () => {
-      const tasks = [...activeByLane.values()].map((state) => state.task);
+      const tasks = [...activeByClaim.values()].map((state) => state.task);
       await Promise.allSettled(tasks);
     },
     dispose: () => {
       disposed = true;
       options.abortSignal?.removeEventListener("abort", abortActiveClaims);
       deregisterLiveIngressDrainInstance(ownerId);
-      // Snapshot: removeActive mutates activeByLane during this sweep.
-      const activeStates = Array.from(activeByLane.values());
+      // Snapshot: removeActive mutates activeByClaim during this sweep.
+      const activeStates = Array.from(activeByClaim.values());
       for (const state of activeStates) {
         clearStallTimer(state);
         if (state.phase === "dispatching" || state.phase === "deferred") {

--- a/src/channels/message/ingress-monitor.ts
+++ b/src/channels/message/ingress-monitor.ts
@@ -28,6 +28,7 @@ export type ChannelIngressMonitorLifecycle = {
   onAdopted: () => void | Promise<void>;
   onDeferred: () => void;
   onAdoptionFinalizing: () => void;
+  onFailed?: (error: unknown) => void | Promise<void>;
   onAbandoned: () => void | Promise<void>;
 };
 
@@ -305,6 +306,12 @@ export function createChannelIngressMonitor<TRaw, TBody, TStoredPayload, TMetada
             handedOff = true;
             deferredHandoff = true;
             lifecycle.onAdoptionFinalizing();
+          },
+          onFailed: async (error) => {
+            handedOff = true;
+            deferredHandoff = true;
+            await lifecycle.onFailed?.(error);
+            requestDrain();
           },
           onAbandoned: async () => {
             handedOff = true;

--- a/src/plugin-sdk/channel-ingress-runtime.test.ts
+++ b/src/plugin-sdk/channel-ingress-runtime.test.ts
@@ -32,6 +32,7 @@ describe("plugin-sdk/channel-ingress-runtime", () => {
       onAdopted: vi.fn(async () => {}),
       onDeferred: vi.fn(),
       onAdoptionFinalizing: vi.fn(),
+      onFailed: vi.fn(async () => {}),
       onAbandoned: vi.fn(async () => {}),
     });
     const first = createLifecycle();
@@ -58,6 +59,7 @@ describe("plugin-sdk/channel-ingress-runtime", () => {
       onAdopted: adopted,
       onDeferred: vi.fn(),
       onAdoptionFinalizing: vi.fn(),
+      onFailed: vi.fn(async () => {}),
       onAbandoned: abandoned,
     };
 
@@ -79,6 +81,7 @@ describe("plugin-sdk/channel-ingress-runtime", () => {
         },
         onDeferred: vi.fn(),
         onAdoptionFinalizing: vi.fn(),
+        onFailed: vi.fn(async () => {}),
         onAbandoned: abandoned,
       },
     ]);

--- a/src/plugin-sdk/channel-ingress-runtime.ts
+++ b/src/plugin-sdk/channel-ingress-runtime.ts
@@ -72,6 +72,9 @@ export function fanInChannelIngressLifecycles(
   const abandonAll = async () => {
     await Promise.all(lifecycles.map(async (lifecycle) => await lifecycle.onAbandoned()));
   };
+  const failAll = async (error: unknown) => {
+    await Promise.all(lifecycles.map(async (lifecycle) => await lifecycle.onFailed?.(error)));
+  };
 
   return {
     lifecycle: {
@@ -93,6 +96,10 @@ export function fanInChannelIngressLifecycles(
         for (const lifecycle of lifecycles) {
           lifecycle.onAdoptionFinalizing();
         }
+      },
+      onFailed: async (error) => {
+        handedOff = true;
+        await failAll(error);
       },
       onAbandoned: async () => {
         handedOff = true;


### PR DESCRIPTION
## Problem

A Telegram multi-photo album arrives as several Bot API updates sharing one `media_group_id`. Since `refactor(telegram): drive ingress through the core drain` (f7786a16cfe81d2d619ff760df20387d6579c307) those updates are split into two agent turns: a captioned image turn, then a second image turn with an empty body. In the reported capture the two updates entered the durable queue 15 ms apart but were delivered 4.75 s apart.

## Root cause

The core drain conflates **claim lifetime** with **lane occupancy**. `activeByLane` was a single `Map` keyed by lane serving three roles at once — claim registry, lane owner, and supersede target — and `drainOnce` blocks any pending event whose lane is active or claimed.

Telegram's adapter awaited the deferred spooled-replay participant inline, so the first album member held the chat/topic lane for its whole dispatch plus the 500 ms media-group buffer plus the entire downstream turn. Later members of the same album could not be claimed in time to join the buffer; by the time they were, the buffer key had been deleted and they opened a new group and a second turn.

Telegram's private drain did not have this problem before the refactor: it excluded deferred claims from the blocked-lane set and its per-update handler returned as soon as work was deferred. The shared drain had no way to express "hold the claim, release the lane".

## Fix

Separate the two concerns in core, behind an opt-in that leaves every other channel untouched.

- New `deferredLaneOccupancy: "hold" | "release"` drain option, defaulting to `"hold"`. Roughly a dozen channels return `deferred` today and all keep current behavior.
- `activeByLane` splits into `activeByClaim` (claim-token fenced; owns watchdog, heartbeat, recovery protection, settlement) and `laneOwnerByKey` (only states that block new same-lane claims), with `occupiesLane` orthogonal to `phase`.
- New drain-owned `onFailed(error)` lifecycle method. Deferred work can now fail *after* dispatch returned, and this routes through the existing `applyFailureDisposition` so attempts, retry delay, non-retryable classification, real error text, and dead-lettering all match an immediate `failed-retryable`. Reusing `onAbandoned` would have recorded a synthetic `turn-abandoned` and bypassed that policy.
- Telegram opts into `"release"` and forwards its participant's terminal result instead of awaiting it.

This also repairs Telegram's text and forwarded-message debounce, which creates deferred participants the same way and was defeated by the same lane coupling.

## Accepted behavior change

With `"release"`, an unrelated later same-lane message can reach reply admission before an album still inside its 500 ms flush window. That is the restored pre-f7786a16 contract, not a new defect: grammY `sequentialize` still preserves handler-entry order, and the reply lane serializes once a turn is admitted. Related to but distinct from https://github.com/openclaw/openclaw/issues/113327.

## Review findings folded in

Three defects were caught by review during development and fixed in later commits here:

1. A late `completed`/`skipped` settlement could tombstone a claim whose turn never durably ran when the monitor was stopped mid-flight, losing the update instead of replaying it. Late settlement now tracks whether the owner aborted *while the participant was pending* and releases for retry.
2. Released deferred claims became invisible to supersede, so an authorized `/abort` or bot command during a buffer window no longer cancelled the pending work. Supersede now evaluates every pre-adoption state on a lane and cancels all accepted ones, so `/abort` during a buffered album cancels the whole album.
3. The detached continuation chained its rejection handler with `.catch` after `.then`, so failures thrown by `onAdopted()`/`onFailed()` were re-driven through `onFailed()` as participant failures — applying the wrong disposition, or silently discarding a wedged tombstone once the phase moved past pre-adoption. Now uses the two-argument `then` form.

## Proof

Regression test fails on `origin/main` and passes here. With the adapter reverted, both cases fail with one media entry instead of two, and the restart case loses the caption entirely — matching the reported symptom.

Focused suites, all green:

- `extensions/telegram/src/telegram-ingress-media-group.e2e.test.ts` — 2 (new; real bot, durable queue, core drain, grammY, media-group buffer; live-admission and restart-backlog variants)
- `src/channels/message/ingress-drain.test.ts` — 29
- `src/channels/message/ingress-drain-supersede.test.ts` — 3 (new)
- `src/channels/message/ingress-monitor.test.ts` — 18
- `extensions/telegram/src/telegram-ingress-drain.test.ts` — 8
- `extensions/telegram/src/polling-session.test.ts` — 78
- `extensions/telegram/src/bot.create-telegram-bot.channel-post-media.test.ts` — 18

`pnpm check:changed` passed on Testbox: typecheck, lint (0 warnings / 0 errors across core, extensions, scripts), and runtime import cycles. Autoreview is clean on the branch diff.

`extensions/telegram/src/polling-session.test.ts` contained a test titled "holds buffered spooled claims until deferred processing settles **without blocking same-lane buffering**" whose body asserted the opposite — that update 43 stayed pending until 42 settled. Its body now matches its own title and asserts both claims are held while both members buffer.

## Known gaps

`extensions/telegram/src/bot.media.downloads-media-file-path-no-file-download.e2e.test.ts` fails 10/10 on `origin/main`, independent of this branch: its harness supplies neither `ctx.me.id` nor `opts.botInfo.id`, so `resolveBotUserId` throws. Neither that file nor the runtime it calls has changed between an older `main` and current `origin/main`. Not touched here; it needs its own harness fix, and it is the suite that would otherwise cover the forwarded-burst debounce path this PR also repairs.

Fixes https://github.com/openclaw/openclaw/issues/115325
