### PR TITLE
fix(agents): apply the fallback delegation gate to CLI-backend runs

### DIFF
--- a/src/agents/cli-runner/mcp-grant-context.test.ts
+++ b/src/agents/cli-runner/mcp-grant-context.test.ts
@@ -1,9 +1,15 @@
 import { describe, expect, it } from "vitest";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
-import { buildCliMcpGrantContext } from "./mcp-grant-context.js";
+import {
+  buildCliMcpDelegationCapabilityBinding,
+  buildCliMcpGrantContext,
+} from "./mcp-grant-context.js";
 import type { RunCliAgentParams } from "./types.js";
 
-function buildGrant(overrides: Partial<RunCliAgentParams> = {}) {
+function buildGrant(
+  overrides: Partial<RunCliAgentParams> = {},
+  delegationCapability?: "full" | "report_only",
+) {
   const run = {
     sessionKey: "agent:main:telegram:group:chat123",
     workspaceDir: "/workspace",
@@ -16,6 +22,7 @@ function buildGrant(overrides: Partial<RunCliAgentParams> = {}) {
     currentChannelId: "telegram:chat123",
     cliToolAvailability: { native: [], openClaw: ["message"] },
     ...overrides,
+    ...(delegationCapability ? buildCliMcpDelegationCapabilityBinding(delegationCapability) : {}),
   } as RunCliAgentParams;
 
   return buildCliMcpGrantContext({
@@ -149,5 +156,20 @@ describe("buildCliMcpGrantContext source-reply authority", () => {
     },
   ])("does not stamp source-only authority for $label", ({ overrides }) => {
     expect(buildGrant(overrides as Partial<RunCliAgentParams>).sourceReplyOnly).toBeUndefined();
+  });
+});
+
+describe("buildCliMcpGrantContext delegationCapability", () => {
+  it("stamps a report-only capability into the minted grant", () => {
+    expect(buildGrant({}, "report_only")).toMatchObject({
+      delegationCapability: "report_only",
+    });
+  });
+
+  it("leaves the grant shape untouched for ordinary runs", () => {
+    // Primary attempts must produce byte-identical grant contexts, so the key
+    // is absent rather than explicitly "full".
+    expect(buildGrant()).not.toHaveProperty("delegationCapability");
+    expect(buildGrant({}, "full")).not.toHaveProperty("delegationCapability");
   });
 });

--- a/src/agents/cli-runner/mcp-grant-context.ts
+++ b/src/agents/cli-runner/mcp-grant-context.ts
@@ -3,8 +3,23 @@ import { canonicalizeMainSessionAlias } from "../../config/sessions/main-session
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import type { McpLoopbackRequestContext } from "../../gateway/mcp-grant-store.js";
 import { resolveGatewayMessageChannel } from "../../utils/message-channel.js";
+import type { DelegationCapability } from "../delegation-capability.js";
 import { SESSION_PERMISSION_BY_EXEC_MODE } from "../session-permission-exec-mode.js";
 import type { RunCliAgentParams } from "./types.js";
+
+const cliMcpDelegationCapability = Symbol("cliMcpDelegationCapability");
+
+export function buildCliMcpDelegationCapabilityBinding(capability: DelegationCapability): object {
+  return capability === "report_only" ? { [cliMcpDelegationCapability]: capability } : {};
+}
+
+function readCliMcpDelegationCapability(run: object): DelegationCapability | undefined {
+  if (!(cliMcpDelegationCapability in run)) {
+    return undefined;
+  }
+  const capability = run[cliMcpDelegationCapability];
+  return capability === "full" || capability === "report_only" ? capability : undefined;
+}
 
 export function normalizeOptionalMcpContextValue(value: string | undefined): string | undefined {
   return value?.trim() || undefined;
@@ -124,6 +139,7 @@ export function buildCliMcpGrantContext(params: {
   );
   const currentChannelId = normalizeOptionalMcpContextValue(params.run.currentChannelId);
   const grantedToolsAllow = params.run.cliToolAvailability?.openClaw ?? params.toolsAllow;
+  const delegationCapability = readCliMcpDelegationCapability(params.run);
   // Trusted message-only completions stay restricted even when source routing
   // is missing; the message tool must fail closed instead of widening authority.
   const sourceReplyOnly =
@@ -147,6 +163,9 @@ export function buildCliMcpGrantContext(params: {
     ...(params.run.skillWorkshopProposalRevision
       ? { skillWorkshop: { proposalRevision: params.run.skillWorkshopProposalRevision } }
       : {}),
+    // Same enforcement point for the fallback delegation gate, so an
+    // unrestricted run keeps its exact prior grant shape.
+    ...(delegationCapability ? { delegationCapability } : {}),
     ...(params.run.scheduledToolPolicy
       ? { scheduledToolPolicy: { ...params.run.scheduledToolPolicy } }
       : {}),

--- a/src/agents/command/attempt-execution.cli.test.ts
+++ b/src/agents/command/attempt-execution.cli.test.ts
@@ -34,6 +34,7 @@ import { createTestPreparedRunAdmission } from "../admitted-run-context.test-sup
 import { clearRuntimeAuthProfileStoreSnapshots } from "../auth-profiles/runtime-snapshots.js";
 import { saveAuthProfileStore } from "../auth-profiles/store.js";
 import { testing as cliBackendsTesting } from "../cli-backends.test-support.js";
+import { buildCliMcpGrantContext } from "../cli-runner/mcp-grant-context.js";
 import { createCronCreatorAuthorityCapability } from "../cron-creator-authority-context.js";
 import type { RunEmbeddedAgentInternalParams } from "../embedded-agent-runner/run/internal-params.js";
 import type { EmbeddedAgentRunResult } from "../embedded-agent.js";
@@ -2951,6 +2952,97 @@ describe("CLI attempt execution", () => {
       suppressNextUserMessagePersistence: false,
     });
   });
+
+  it.each([
+    {
+      label: "a fallback completion report",
+      isFallbackRetry: true,
+      inputProvenance: { kind: "inter_session", sourceTool: "subagent_announce" },
+      expected: "report_only",
+    },
+    {
+      label: "a fallback answering ordinary user input",
+      isFallbackRetry: true,
+      inputProvenance: { kind: "external_user" },
+      expected: undefined,
+    },
+    {
+      label: "a primary completion report",
+      isFallbackRetry: false,
+      inputProvenance: { kind: "inter_session", sourceTool: "subagent_announce" },
+      expected: undefined,
+    },
+  ])(
+    "stamps the command-fallback CLI grant delegation capability for $label",
+    async ({ isFallbackRetry, inputProvenance, expected }) => {
+      const runId = `run-command-fallback-delegation-${String(isFallbackRetry)}-${expected}`;
+      const sessionKey = `agent:main:direct:${runId}`;
+      const sessionEntry: SessionEntry = {
+        sessionId: `session-${runId}`,
+        updatedAt: Date.now(),
+      };
+      const cfg = {
+        session: { store: storePath },
+        agents: {
+          defaults: {
+            models: {
+              "anthropic/claude-opus-4-7": { agentRuntime: { id: "claude-cli" } },
+            },
+          },
+        },
+      } as OpenClawConfig;
+      await writeSessionStoreSeed({ [sessionKey]: sessionEntry });
+      runCliAgentMock.mockResolvedValueOnce(makeCliResult("delegation gate"));
+
+      await runAgentAttempt({
+        providerOverride: "anthropic",
+        originalProvider: "anthropic",
+        modelOverride: "claude-opus-4-7",
+        cfg,
+        sessionEntry,
+        sessionId: sessionEntry.sessionId,
+        sessionKey,
+        sessionAgentId: "main",
+        sessionFile: path.join(tmpDir, `${runId}.jsonl`),
+        workspaceDir: tmpDir,
+        body: "report the completion",
+        isFallbackRetry,
+        resolvedThinkLevel: "medium",
+        timeoutMs: 1_000,
+        runId,
+        opts: {
+          message: "report the completion",
+          inputProvenance,
+        } as RunAgentAttemptParams["opts"],
+        runContext: {} as RunAgentAttemptParams["runContext"],
+        spawnedBy: undefined,
+        messageChannel: "telegram",
+        skillsSnapshot: undefined,
+        resolvedVerboseLevel: undefined,
+        agentDir,
+        onAgentEvent: vi.fn(),
+        authProfileProvider: "anthropic",
+        sessionStore: { [sessionKey]: sessionEntry },
+        storePath,
+        sessionHasHistory: false,
+      });
+
+      // The command loop is a second fallback entry point; its CLI grant must
+      // carry the same gate as the auto-reply candidate or the loopback surface
+      // resolves to full.
+      const grantContext = buildCliMcpGrantContext({
+        run: firstRunCliAgentArg() as unknown as Parameters<
+          typeof buildCliMcpGrantContext
+        >[0]["run"],
+        config: cfg,
+        requireExplicitMessageTarget: false,
+        agentId: "main",
+        modelProvider: "anthropic",
+        modelId: "claude-opus-4-7",
+      });
+      expect(grantContext.delegationCapability).toBe(expected);
+    },
+  );
 
   it("routes canonical Anthropic models through the configured Claude CLI runtime", async () => {
     const sessionKey = "agent:main:direct:canonical-claude-cli";

--- a/src/agents/command/attempt-execution.ts
+++ b/src/agents/command/attempt-execution.ts
@@ -73,6 +73,7 @@ import {
 } from "../cli-execution-auth.js";
 import { runCliAgent } from "../cli-runner.js";
 import { hasCliLiveSession } from "../cli-runner/cli-live-session-registry.js";
+import { buildCliMcpDelegationCapabilityBinding } from "../cli-runner/mcp-grant-context.js";
 import { resolveCliRuntimeToolsAllow } from "../cli-runner/tool-policy.js";
 import {
   getCliSessionBinding,
@@ -81,6 +82,7 @@ import {
 } from "../cli-session.js";
 import { resolveConversationCapabilityProfile } from "../conversation-capability-profile.js";
 import { resolveConversationToolPolicies } from "../conversation-tool-policy-pipeline.js";
+import { resolveDelegationCapability } from "../delegation-capability.js";
 import type { DeferredEmbeddedRunLifecycleManager } from "../embedded-agent-runner/run/deferred-lifecycle-owner.js";
 import type { RunEmbeddedAgentInternalParams } from "../embedded-agent-runner/run/internal-params.js";
 import { runEmbeddedAgent, type EmbeddedAgentRunResult } from "../embedded-agent.js";
@@ -1094,6 +1096,17 @@ export function runAgentAttempt(params: {
             toolsAllow: resolveCliRuntimeToolsAllow(
               runtimeToolsAllow,
               params.opts.toolsAllowIsDefault,
+            ),
+            // This loop is the command-origin sibling of the auto-reply fallback
+            // candidate, so its CLI grant needs the same delegation gate; the
+            // inputs match the tool state this invocation actually runs with.
+            ...buildCliMcpDelegationCapabilityBinding(
+              resolveDelegationCapability({
+                fallbackActive: params.isFallbackRetry,
+                inputProvenance: params.opts.inputProvenance,
+                disableTools,
+                toolsAllow: runtimeToolsAllow,
+              }),
             ),
             scheduledToolPolicy: params.opts.scheduledToolPolicy,
             cleanupBundleMcpOnRunEnd: params.opts.cleanupBundleMcpOnRunEnd,

--- a/src/agents/delegation-capability.test.ts
+++ b/src/agents/delegation-capability.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
+import { getPluginToolMeta, setPluginToolMeta } from "../plugins/tool-metadata.js";
 import { applyDelegationCapability, resolveDelegationCapability } from "./delegation-capability.js";
 import { attachToolAllowlistIntersection } from "./tool-policy.js";
 import type { AnyAgentTool } from "./tools/common.js";
@@ -157,5 +158,17 @@ describe("delegation capability", () => {
     );
     expect(cronExecute).toHaveBeenCalledTimes(2);
     expect(imageExecute).toHaveBeenCalledTimes(1);
+  });
+
+  it("preserves plugin ownership metadata through the report-only wrapper", () => {
+    const cron = createTool("cron");
+    setPluginToolMeta(cron, { pluginId: "scheduler" } as never);
+
+    const [wrapped] = applyDelegationCapability([cron], "report_only");
+
+    // The effective cron-creator allowlist reads meta off the returned tool, so
+    // a wrapper that drops it would silently unown the plugin's tool.
+    expect(wrapped).not.toBe(cron);
+    expect(getPluginToolMeta(wrapped as AnyAgentTool)).toEqual({ pluginId: "scheduler" });
   });
 });

--- a/src/agents/delegation-capability.ts
+++ b/src/agents/delegation-capability.ts
@@ -1,9 +1,13 @@
+import { createSubsystemLogger } from "../logging/subsystem.js";
+import { copyPluginToolMeta } from "../plugins/tool-metadata.js";
 import { isCompletionReportInputProvenance } from "../sessions/input-provenance.js";
 import { createRuntimeToolMatcher } from "./tool-policy-match.js";
 import { normalizeToolPolicyName } from "./tool-policy.js";
 import { AUTOMATIONS_TOOL_NAME } from "./tools/automations-tool-name.js";
 import type { AnyAgentTool } from "./tools/common.js";
 import { ToolAuthorizationError } from "./tools/common.js";
+
+const log = createSubsystemLogger("agents/delegation-capability");
 
 export type DelegationCapability = "full" | "report_only";
 
@@ -58,7 +62,7 @@ function readToolAction(params: unknown): string {
 }
 
 function wrapReportOnlyTool(tool: AnyAgentTool, allowedActions: ReadonlySet<string>): AnyAgentTool {
-  return new Proxy(tool, {
+  const wrapped = new Proxy(tool, {
     get(target, property, receiver) {
       if (property !== "execute") {
         return Reflect.get(target, property, receiver);
@@ -76,6 +80,11 @@ function wrapReportOnlyTool(tool: AnyAgentTool, allowedActions: ReadonlySet<stri
       };
     },
   });
+  // Plugin ownership lives in a WeakMap keyed by tool identity, so the proxy
+  // needs its own entry; otherwise plugin-owned report-only tools drop out of
+  // the effective cron-creator allowlist for the rest of the run.
+  copyPluginToolMeta(tool, wrapped);
+  return wrapped;
 }
 
 /**
@@ -90,12 +99,29 @@ export function applyDelegationCapability(
   if (capability !== "report_only") {
     return tools;
   }
-  return tools.flatMap((tool) => {
+  const removed: string[] = [];
+  const narrowed: string[] = [];
+  const gated = tools.flatMap((tool) => {
     const name = normalizeToolPolicyName(tool.name);
     if (NEW_DELEGATION_TOOL_NAMES.has(name)) {
+      removed.push(name);
       return [];
     }
     const allowedActions = REPORT_ONLY_TOOL_ACTIONS.get(name);
-    return allowedActions ? [wrapReportOnlyTool(tool, allowedActions)] : [tool];
+    if (!allowedActions) {
+      return [tool];
+    }
+    narrowed.push(name);
+    return [wrapReportOnlyTool(tool, allowedActions)];
   });
+  if (removed.length > 0 || narrowed.length > 0) {
+    // Removal is otherwise invisible: the model simply never sees the tool and
+    // no error is raised. Record it so a fallback completion turn stays
+    // auditable after the fact.
+    log.debug("delegation capability restricted run tools", {
+      removed,
+      narrowed,
+    });
+  }
+  return gated;
 }

--- a/src/auto-reply/reply/agent-runner-cli-candidate.ts
+++ b/src/auto-reply/reply/agent-runner-cli-candidate.ts
@@ -1,8 +1,10 @@
 import { resolveBootstrapWarningSignaturesSeen } from "../../agents/bootstrap-budget.js";
+import { buildCliMcpDelegationCapabilityBinding } from "../../agents/cli-runner/mcp-grant-context.js";
 import {
   getCliSessionBinding,
   shouldClearFailedCliSessionBinding,
 } from "../../agents/cli-session.js";
+import { resolveDelegationCapability } from "../../agents/delegation-capability.js";
 import { findModelInCatalog } from "../../agents/model-catalog-lookup.js";
 import { withLocalSessionPlacementTurnAdmission } from "../../agents/session-placement-admission.js";
 import { normalizeChatType } from "../../channels/chat-type.js";
@@ -332,6 +334,17 @@ export async function runCliFallbackCandidate(
             currentInboundEventKind: turn.followupRun.currentInboundEventKind,
             currentInboundContext: turn.followupRun.currentInboundContext,
             inputProvenance: turn.followupRun.run.inputProvenance,
+            // Candidate zero is the primary attempt; later candidates are
+            // fallbacks. Carry the runner-owned fact instead of inferring from
+            // this shared dispatch path, or primary CLI runs lose delegation.
+            ...buildCliMcpDelegationCapabilityBinding(
+              resolveDelegationCapability({
+                fallbackActive: params.isFallbackRetry,
+                inputProvenance: turn.followupRun.run.inputProvenance,
+                disableTools: turn.opts?.disableTools,
+                toolsAllow: turn.opts?.toolsAllow,
+              }),
+            ),
             modelProvider: params.provider,
             modelHasVision,
             modelContextWindow: selectedModelEntry?.contextWindow,

--- a/src/auto-reply/reply/agent-runner-execution-cli-delegation.test.ts
+++ b/src/auto-reply/reply/agent-runner-execution-cli-delegation.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "vitest";
+import { buildCliMcpGrantContext } from "../../agents/cli-runner/mcp-grant-context.js";
+import type { RunCliAgentParams } from "../../agents/cli-runner/types.js";
+import {
+  createFollowupRun,
+  createMinimalRunAgentTurnParams,
+  fallbackAttemptOptions,
+  getExecuteAgentTurnForTest,
+  initialFallbackAttemptOptions,
+  requireMockCall,
+  setupAgentRunnerExecutionTestState,
+} from "./agent-runner-execution.test-support.js";
+import type { FallbackRunnerParams } from "./agent-runner-execution.test-support.js";
+
+const state = setupAgentRunnerExecutionTestState();
+
+function resolveMockedCliGrantCapability() {
+  const run = requireMockCall(state.runCliAgentMock, 0, "CLI run params")[0] as RunCliAgentParams;
+  return buildCliMcpGrantContext({
+    run,
+    config: run.config ?? {},
+    requireExplicitMessageTarget: false,
+    agentId: "main",
+    modelProvider: "openai",
+    modelId: "gpt-5.4",
+  }).delegationCapability;
+}
+
+describe("executeAgentTurn: CLI delegation grants", () => {
+  it("keeps primary CLI completion grants unrestricted", async () => {
+    state.isCliProviderMock.mockReturnValue(true);
+    state.runWithModelFallbackMock.mockImplementationOnce(async (params: FallbackRunnerParams) => ({
+      result: await params.run("codex-cli", "gpt-5.4", initialFallbackAttemptOptions(params)),
+      provider: "codex-cli",
+      model: "gpt-5.4",
+      attempts: [],
+    }));
+    state.runCliAgentMock.mockResolvedValue({ payloads: [{ text: "done" }], meta: {} });
+    const followupRun = createFollowupRun();
+    followupRun.run.provider = "codex-cli";
+    followupRun.run.model = "gpt-5.4";
+    followupRun.run.inputProvenance = {
+      kind: "inter_session",
+      sourceTool: "subagent_announce",
+    };
+
+    const executeAgentTurn = await getExecuteAgentTurnForTest();
+    const result = await executeAgentTurn(createMinimalRunAgentTurnParams({ followupRun }));
+
+    expect(result.kind).toBe("success");
+    expect(resolveMockedCliGrantCapability()).toBeUndefined();
+  });
+
+  it("restricts fallback CLI completion grants", async () => {
+    state.isCliProviderMock.mockImplementation((provider) => provider === "codex-cli");
+    state.runWithModelFallbackMock.mockImplementationOnce(async (params: FallbackRunnerParams) => {
+      await params.run("anthropic", "claude", initialFallbackAttemptOptions(params));
+      return {
+        result: await params.run("codex-cli", "gpt-5.4", fallbackAttemptOptions(params, "unknown")),
+        provider: "codex-cli",
+        model: "gpt-5.4",
+        attempts: [{ provider: "anthropic", model: "claude", error: "rate limit" }],
+      };
+    });
+    state.runEmbeddedAgentMock.mockResolvedValue({ payloads: [], meta: {} });
+    state.runCliAgentMock.mockResolvedValue({ payloads: [{ text: "done" }], meta: {} });
+    const followupRun = createFollowupRun();
+    followupRun.run.inputProvenance = {
+      kind: "inter_session",
+      sourceTool: "subagent_announce",
+    };
+
+    const executeAgentTurn = await getExecuteAgentTurnForTest();
+    const result = await executeAgentTurn(createMinimalRunAgentTurnParams({ followupRun }));
+
+    expect(result.kind).toBe("success");
+    expect(resolveMockedCliGrantCapability()).toBe("report_only");
+  });
+});

--- a/src/auto-reply/reply/agent-runner-fallback-candidate.ts
+++ b/src/auto-reply/reply/agent-runner-fallback-candidate.ts
@@ -259,6 +259,7 @@ export async function runAgentFallbackCandidates(params: AgentFallbackCycleParam
           runId: params.runId,
           runAbortSignal: params.runAbortSignal,
           runLane,
+          isFallbackRetry: runOptions.isFallbackRetry,
           isFinalFallbackAttempt: runOptions?.isFinalFallbackAttempt,
           suppressQueuedUserPersistenceForCandidate:
             (turn.followupRun.run.suppressNextUserMessagePersistence ?? false) ||

--- a/src/auto-reply/reply/agent-runner-fallback-cycle.types.ts
+++ b/src/auto-reply/reply/agent-runner-fallback-cycle.types.ts
@@ -32,6 +32,7 @@ export type AgentFallbackCandidateCommonParams = {
   runId: string;
   runAbortSignal?: AbortSignal;
   runLane: RunEmbeddedAgentParams["lane"];
+  isFallbackRetry: boolean;
   isFinalFallbackAttempt?: boolean;
   suppressQueuedUserPersistenceForCandidate: boolean;
   userTurnTranscriptRecorder: RunEmbeddedAgentParams["userTurnTranscriptRecorder"];

--- a/src/gateway/mcp-grant-store.ts
+++ b/src/gateway/mcp-grant-store.ts
@@ -5,6 +5,7 @@ import {
 } from "../agents/admitted-run-context.js";
 import type { AuthProfileStore } from "../agents/auth-profiles/types.js";
 import type { ExecElevatedDefaults } from "../agents/bash-tools.exec-types.js";
+import type { DelegationCapability } from "../agents/delegation-capability.js";
 import type { ExecPolicyOverrides, ExecSessionDefaults } from "../agents/exec-defaults.js";
 import type { ScheduledToolPolicyContext } from "../agents/scheduled-tool-policy.js";
 import type {
@@ -55,6 +56,14 @@ export type McpLoopbackRequestContext = {
    */
   toolsAllow?: string[];
   skillWorkshop?: SkillWorkshopRunOptions;
+  /**
+   * Attempt-local authority to start or redirect delegated work, stamped into
+   * the grant so a fallback completion-report turn running on a CLI backend
+   * gets the same gate as an embedded attempt. The loopback surface enforces
+   * it on both tools/list and tools/call, so CLI-side advisory flags cannot
+   * reopen it. Unset keeps the full delegation surface.
+   */
+  delegationCapability?: DelegationCapability;
   scheduledToolPolicy?: ScheduledToolPolicyContext;
   /** Host-owned creator origin; child MCP request fields cannot widen it. */
   cronCreatorCallerOrigin?: CronScheduledToolCallerOrigin;

--- a/src/gateway/mcp-http.runtime.test.ts
+++ b/src/gateway/mcp-http.runtime.test.ts
@@ -318,4 +318,22 @@ describe("McpLoopbackToolCache", () => {
     expect(resolveGatewayScopedTools.mock.calls[0]?.[0]).not.toHaveProperty("sourceReplyOnly");
     expect(resolveGatewayScopedTools.mock.calls[1]?.[0]).toMatchObject({ sourceReplyOnly: true });
   });
+
+  it("does not share cache rows across delegation capabilities", () => {
+    const cache = new McpLoopbackToolCache();
+    const cfg = {} as OpenClawConfig;
+
+    cache.resolve(scopeParams({ cfg }));
+    cache.resolve(scopeParams({ cfg, delegationCapability: "report_only" }));
+
+    // A restricted attempt must neither read nor seed the full-capability row
+    // for the same session context.
+    expect(resolveGatewayScopedTools).toHaveBeenCalledTimes(2);
+    expect(resolveGatewayScopedTools.mock.calls[1]?.[0]).toMatchObject({
+      delegationCapability: "report_only",
+    });
+
+    cache.resolve(scopeParams({ cfg, delegationCapability: "report_only" }));
+    expect(resolveGatewayScopedTools).toHaveBeenCalledTimes(2);
+  });
 });

--- a/src/gateway/mcp-http.runtime.ts
+++ b/src/gateway/mcp-http.runtime.ts
@@ -208,6 +208,9 @@ export class McpLoopbackToolCache {
       // allowlist (deny-all), so the marker distinguishes presence.
       params.toolsAllow ? `allow:${[...new Set(params.toolsAllow)].toSorted().join(",")}` : "",
       JSON.stringify(params.skillWorkshop?.proposalRevision ?? null),
+      // A delegation-restricted attempt must never read or seed the cached
+      // full-capability list for the same session/run context.
+      params.delegationCapability === "report_only" ? "delegation:report_only" : "",
       JSON.stringify(params.scheduledToolPolicy ?? null),
       params.nodeExecAllowed === true ? "node-exec" : "",
       params.execSession?.execHost ?? "",

--- a/src/gateway/mcp-http.test.ts
+++ b/src/gateway/mcp-http.test.ts
@@ -1250,6 +1250,9 @@ describe("mcp loopback server", () => {
       sourceReplyDeliveryMode: "message_tool_only",
       sourceReplyOnly: true,
       toolsAllow: ["message"],
+      // The delegation gate lives in resolveGatewayScopedTools, so dropping
+      // this field at the HTTP mapping silently disables it for CLI backends.
+      delegationCapability: "report_only",
       taskSuggestionDeliveryMode: "gateway",
       requireExplicitMessageTarget: true,
       senderIsOwner: false,

--- a/src/gateway/mcp-http.ts
+++ b/src/gateway/mcp-http.ts
@@ -344,6 +344,7 @@ async function startMcpLoopbackServer(port = 0): Promise<{
           taskSuggestionDeliveryMode: requestContext.taskSuggestionDeliveryMode,
           requireExplicitMessageTarget: requestContext.requireExplicitMessageTarget,
           toolsAllow: requestContext.toolsAllow,
+          delegationCapability: requestContext.delegationCapability,
           scheduledToolPolicy: requestContext.scheduledToolPolicy,
           senderIsOwner: requestContext.senderIsOwner,
           nodeExecAllowed: requestContext.nodeExecAllowed,

--- a/src/gateway/tool-resolution.delegation.test.ts
+++ b/src/gateway/tool-resolution.delegation.test.ts
@@ -1,0 +1,120 @@
+/**
+ * Gateway loopback delegation-capability tests.
+ *
+ * The loopback surface is the tool universe for CLI backends, so a fallback
+ * completion-report turn must lose its delegation launchers here exactly as it
+ * does on the embedded attempt path.
+ */
+import { describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+
+const hoisted = vi.hoisted(() => {
+  function makeTool(name: string, execute = vi.fn(async () => ({ content: [], details: {} }))) {
+    return {
+      name,
+      description: `${name} tool`,
+      parameters: { type: "object", properties: {} },
+      execute,
+    };
+  }
+  const cronExecute = vi.fn(async () => ({ content: [], details: {} }));
+  return {
+    makeTool,
+    cronExecute,
+    createOpenClawToolsMock: vi.fn(
+      (_options?: {
+        inheritedToolAllowlist?: string[];
+        cronCreatorToolAllowlist?: Array<{ name: string }>;
+      }) => [
+        makeTool("read"),
+        makeTool("sessions_spawn"),
+        makeTool("sessions_send"),
+        makeTool("cron", cronExecute),
+        makeTool("gateway"),
+        makeTool("nodes"),
+      ],
+    ),
+  };
+});
+
+vi.mock("../agents/openclaw-tools.js", () => ({
+  createOpenClawTools: (options: Parameters<typeof hoisted.createOpenClawToolsMock>[0]) =>
+    hoisted.createOpenClawToolsMock(options),
+}));
+
+vi.mock("../agents/agent-tools.js", () => ({
+  createOpenClawCodingTools: () => [],
+}));
+
+vi.mock("../agents/lazy-exec-tool.js", () => ({
+  createLazyExecTool: vi.fn(),
+  resolveExecToolConfig: vi.fn(() => ({})),
+}));
+
+import { resolveGatewayScopedTools } from "./tool-resolution.js";
+
+function resolveLoopbackTools(delegationCapability?: "full" | "report_only") {
+  return resolveGatewayScopedTools({
+    cfg: {} as OpenClawConfig,
+    sessionKey: "agent:main:direct:test",
+    surface: "loopback",
+    senderIsOwner: true,
+    ...(delegationCapability ? { delegationCapability } : {}),
+  });
+}
+
+describe("resolveGatewayScopedTools delegationCapability", () => {
+  it("keeps the full loopback surface when the capability is unset or full", () => {
+    const unset = resolveLoopbackTools().tools.map((tool) => tool.name);
+    const full = resolveLoopbackTools("full").tools.map((tool) => tool.name);
+
+    expect(unset).toEqual(["read", "sessions_spawn", "sessions_send", "cron", "gateway", "nodes"]);
+    expect(full).toEqual(unset);
+  });
+
+  it("removes delegation launchers from a report-only loopback grant", () => {
+    const tools = resolveLoopbackTools("report_only").tools.map((tool) => tool.name);
+
+    expect(tools).toEqual(["read", "cron", "gateway", "nodes"]);
+    expect(tools).not.toContain("sessions_spawn");
+    expect(tools).not.toContain("sessions_send");
+  });
+
+  it("captures report-only derived authority from the gated loopback surface", () => {
+    hoisted.createOpenClawToolsMock.mockClear();
+    resolveGatewayScopedTools({
+      cfg: {
+        tools: {
+          allow: ["read", "sessions_spawn", "sessions_send", "cron", "gateway", "nodes"],
+        },
+      } as OpenClawConfig,
+      sessionKey: "agent:main:direct:test",
+      surface: "loopback",
+      senderIsOwner: true,
+      delegationCapability: "report_only",
+    });
+
+    const options = hoisted.createOpenClawToolsMock.mock.calls.at(-1)?.[0];
+    expect(options?.inheritedToolAllowlist).toEqual(["read", "automations", "gateway", "nodes"]);
+    expect(options?.cronCreatorToolAllowlist).toEqual([
+      { name: "read" },
+      { name: "automations" },
+      { name: "gateway" },
+      { name: "nodes" },
+    ]);
+  });
+
+  it("narrows report-only loopback tools to their status actions", async () => {
+    hoisted.cronExecute.mockClear();
+    const cron = resolveLoopbackTools("report_only").tools.find((tool) => tool.name === "cron");
+
+    await expect(cron?.execute("cron-status", { action: "status" })).resolves.toEqual({
+      content: [],
+      details: {},
+    });
+    await expect(cron?.execute("cron-add", { action: "add" })).rejects.toThrow(
+      "New delegation is unavailable",
+    );
+    expect(hoisted.cronExecute).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/gateway/tool-resolution.ts
+++ b/src/gateway/tool-resolution.ts
@@ -8,6 +8,10 @@ import type { AuthProfileStore } from "../agents/auth-profiles/types.js";
 import type { ExecElevatedDefaults } from "../agents/bash-tools.exec-types.js";
 import { nodeExecSchema } from "../agents/bash-tools.schemas.js";
 import {
+  applyDelegationCapability,
+  type DelegationCapability,
+} from "../agents/delegation-capability.js";
+import {
   resolveExecDefaults,
   type ExecPolicyOverrides,
   type ExecSessionDefaults,
@@ -98,6 +102,12 @@ export function resolveGatewayScopedTools(params: {
   allowGatewaySubagentBinding?: boolean;
   allowMediaInvokeCommands?: boolean;
   surface?: GatewayScopedToolSurface;
+  /**
+   * Attempt-local authority to start or redirect delegated work. Loopback
+   * grants carry it so CLI backends get the same fallback gate as embedded
+   * attempts; unset keeps the full delegation surface.
+   */
+  delegationCapability?: DelegationCapability;
   excludeToolNames?: Iterable<string>;
   /** Server-minted coding tools that must be mediated through the loopback surface. */
   mediatedToolNames?: Iterable<string>;
@@ -543,7 +553,10 @@ export function resolveGatewayScopedTools(params: {
     ].map(normalizeToolPolicyName),
   );
   const tools = applyToolAvailabilityDescriptions(
-    policyFiltered.filter((tool) => !gatewayDenySet.has(normalizeToolPolicyName(tool.name))),
+    applyDelegationCapability(
+      policyFiltered.filter((tool) => !gatewayDenySet.has(normalizeToolPolicyName(tool.name))),
+      params.delegationCapability,
+    ),
   );
   // The loopback exec tool is node-only. Do not let a raw `exec` capability get
   // reinterpreted as generic Gateway/sandbox exec by spawned sessions or cron jobs.


### PR DESCRIPTION
Refs #92011
Related: #92271

## What Problem This Solves

#92011 added a `report_only` delegation gate for fallback completion-report turns, but only the embedded attempt path applied it. CLI backends get their OpenClaw tools from the Gateway loopback MCP grant, so the runtime shape reported in #92271 could still see and call `sessions_spawn` and the other delegation launchers.

## Change

- Carry the attempt-local delegation capability in the minted loopback grant and include it in the loopback tool-cache key.
- Forward the capability through the production HTTP request-context mapping before Gateway tool resolution.
- Construct the final Gateway tool surface by applying the existing `applyDelegationCapability` after normal authorization and deny filtering, but before inherited and cron-creator authority are captured.
- Derive `inheritedToolAllowlist`, `cronCreatorToolAllowlist`, availability descriptions, and returned tools from that same gated surface.
- Wire both CLI fallback producers: `runCliFallbackCandidate` and the command-origin `runAgentAttempt` path.
- Reuse the shared launcher set and report-only action narrowing instead of maintaining a second CLI-specific list.
- Preserve plugin ownership metadata when report-only tools are wrapped.
- Emit a debug record containing the removed and narrowed tools.

The capability is transported through an internal symbol-backed binding, not the public `RunCliAgentParams` contract. Only `report_only` creates the binding; unrestricted/primary runs omit it, preserving their prior grant shape.

## Review findings addressed

- The command-origin fallback path now stamps the same capability as the auto-reply fallback candidate.
- The capability is no longer dropped by the explicit HTTP context mapping.
- The CLI transport no longer expands the Plugin SDK declaration surface.
- Primary/full runs no longer add an explicit `full` field to the grant.
- Report-only gating now happens before inherited and cron-creator authority capture.
- A focused resolver regression asserts both captured allowlists exclude delegation launchers and match the final gated surface.
- Availability descriptions are computed after gating, so they cannot advertise launchers absent from the executable surface.

## Scope

This PR closes the fallback CLI loopback surface. It deliberately does not wire the separate primary auto-reply CLI dispatch path in `src/auto-reply/reply/agent-runner-cli-dispatch.ts`, nor the opt-in `cliBackendDispatch: "subscription-auth"` orchestrator path. Those need separate plumbing and can remain follow-ups.

`conversations_send` / `conversations_turn` are also left unchanged. Whether unsolicited peer-conversation turns count as new delegation under `report_only` is a compatibility-policy decision rather than something this PR should decide implicitly.

## Exact-head producer proof

Environment: macOS, Node `v24.19.0`, pnpm `12.1.0`, exact head `3d04d908f3dabf832c62acc33111de6851b71e93`.

The driver calls the real `runAgentAttempt` twice: a primary external-user control and a fallback completion report with `{ kind: "inter_session", sourceTool: "subagent_announce" }`. A minimal CLI backend and harmless delegation-class plugin tool (`llm-task`) are installed through the production plugin registry with bundled MCP enabled. The tool's final effect is one append to an isolated marker file.

The real producer selects the CLI runtime, mints the grant, writes the strict MCP config, starts a real process-supervisor child, and passes its bearer token and capture key. Each child performs the MCP handshake and sends authenticated production HTTP `tools/list` / `tools/call` requests to `/mcp`. The driver does not call the grant builder, minting function, Gateway resolver, or capability gate directly.

```text
head: 3d04d908f3dabf832c62acc33111de6851b71e93

=== primary external-user (real child PID 72154) ===
run completed              : true
child received token       : true
child received capture key : true
HTTP tools/list size       : 2
has llm-task               : true
has sessions_spawn         : true
llm-task call              : isError=false {"status":"recorded"}
delegation effects         : 1

=== fallback completion-report (real child PID 72175) ===
run completed              : true
child received token       : true
child received capture key : true
HTTP tools/list size       : 0
has llm-task               : false
has sessions_spawn         : false
llm-task call              : isError=true "Tool not available: llm-task"
sessions_spawn call        : isError=true "Tool not available: sessions_spawn"
delegation effects         : 1 (unchanged)

verdict                    : passed=true, exit 0
```

This proves both final effects on the reviewed head: the primary child retains delegation authority and completes one real tool effect; the report-only fallback cannot discover either delegation launcher, both nearest-forbidden calls fail at the authenticated Gateway boundary, and no second effect occurs.

No live model provider was used; the behavior under test is CLI grant production and Gateway tool authorization, which occur before a model call.

## Evidence

Exact-head validation for `3d04d908f3dabf832c62acc33111de6851b71e93`:

- Real `runAgentAttempt` → process-supervisor child → authenticated production loopback HTTP → final-effect proof above — passed, exit 0.
- Current-main reproduction before repair: real `resolveGatewayScopedTools` report-only scenario exposed `sessions_spawn` / `sessions_send`; assertion failed as expected.
- Producer regression before repair: primary candidate incorrectly received `report_only` because `fallbackActive` was hardcoded; assertion failed as expected. Exact head threads runner-owned `isFallbackRetry` and passes.
- Focused touched-surface validation — 325 passed across the producer, delegation capability, grant context, MCP HTTP, and Gateway resolver suites.
- `pnpm check` — passed.
- Exact CI test-type stripe `node scripts/run-tsgo-core-test-shards.mjs --stripe 5/5 --concurrency 2` — passed.
- GitHub Actions exact-head CI run `33464835898` — passed, including `openclaw/ci-gate`.
- Native `OPENCLAW_TESTBOX=1 scripts/pr prepare-run 115405` — passed with prep/head SHA parity.
- SHA-bound Autoreview — READY, no actionable findings.
