### PR TITLE
fix: keep strongest models first after live discovery

### DIFF
--- a/extensions/kimi-coding/openclaw.plugin.json
+++ b/extensions/kimi-coding/openclaw.plugin.json
@@ -28,34 +28,6 @@
         "defaultModel": "kimi-for-coding",
         "models": [
           {
-            "id": "kimi-for-coding",
-            "name": "Kimi Code",
-            "reasoning": true,
-            "input": ["text", "image"],
-            "contextWindow": 262144,
-            "maxTokens": 32768,
-            "cost": {
-              "input": 0,
-              "output": 0,
-              "cacheRead": 0,
-              "cacheWrite": 0
-            }
-          },
-          {
-            "id": "kimi-for-coding-highspeed",
-            "name": "Kimi K2.7 Code HighSpeed",
-            "reasoning": true,
-            "input": ["text", "image"],
-            "contextWindow": 262144,
-            "maxTokens": 32768,
-            "cost": {
-              "input": 0,
-              "output": 0,
-              "cacheRead": 0,
-              "cacheWrite": 0
-            }
-          },
-          {
             "id": "k3",
             "name": "Kimi K3",
             "reasoning": true,
@@ -107,6 +79,34 @@
             },
             "compat": {
               "codeMode": "preferred"
+            }
+          },
+          {
+            "id": "kimi-for-coding",
+            "name": "Kimi Code",
+            "reasoning": true,
+            "input": ["text", "image"],
+            "contextWindow": 262144,
+            "maxTokens": 32768,
+            "cost": {
+              "input": 0,
+              "output": 0,
+              "cacheRead": 0,
+              "cacheWrite": 0
+            }
+          },
+          {
+            "id": "kimi-for-coding-highspeed",
+            "name": "Kimi K2.7 Code HighSpeed",
+            "reasoning": true,
+            "input": ["text", "image"],
+            "contextWindow": 262144,
+            "maxTokens": 32768,
+            "cost": {
+              "input": 0,
+              "output": 0,
+              "cacheRead": 0,
+              "cacheWrite": 0
             }
           }
         ]

--- a/extensions/kimi-coding/provider-catalog.test.ts
+++ b/extensions/kimi-coding/provider-catalog.test.ts
@@ -11,10 +11,10 @@ describe("kimi provider catalog", () => {
     expect(provider.baseUrl).toBe("https://api.kimi.com/coding/");
     expect(provider.headers).toEqual({ "User-Agent": "claude-code/0.1.0" });
     expect(provider.models.map((model) => model.id)).toEqual([
-      "kimi-for-coding",
-      "kimi-for-coding-highspeed",
       "k3",
       "k3-256k",
+      "kimi-for-coding",
+      "kimi-for-coding-highspeed",
     ]);
     expect(provider.models.find((model) => model.id === "k3")).toMatchObject({
       name: "Kimi K3",

--- a/src/agents/model-catalog-order.ts
+++ b/src/agents/model-catalog-order.ts
@@ -7,12 +7,32 @@ import type { ModelCatalogEntry } from "./model-catalog.types.js";
  */
 export function assignProviderModelOrder(
   entries: readonly ModelCatalogEntry[],
+  existingEntries: readonly ModelCatalogEntry[] = [],
 ): ModelCatalogEntry[] {
+  const orderByModel = new Map<string, number>();
   const nextOrderByProvider = new Map<string, number>();
+  for (const entry of existingEntries) {
+    if (entry.providerOrder === undefined) {
+      continue;
+    }
+    const provider = normalizeProviderId(entry.provider);
+    const key = `${provider}/${entry.id.trim().toLowerCase()}`;
+    orderByModel.set(key, entry.providerOrder);
+    nextOrderByProvider.set(
+      provider,
+      Math.max(nextOrderByProvider.get(provider) ?? 0, entry.providerOrder + 1),
+    );
+  }
   return entries.map((entry) => {
     const provider = normalizeProviderId(entry.provider);
+    const key = `${provider}/${entry.id.trim().toLowerCase()}`;
+    const existingOrder = orderByModel.get(key);
+    if (existingOrder !== undefined) {
+      return { ...entry, providerOrder: existingOrder };
+    }
     const providerOrder = nextOrderByProvider.get(provider) ?? 0;
     nextOrderByProvider.set(provider, providerOrder + 1);
+    orderByModel.set(key, providerOrder);
     return { ...entry, providerOrder };
   });
 }

--- a/src/agents/model-catalog-route.ts
+++ b/src/agents/model-catalog-route.ts
@@ -97,6 +97,9 @@ function logicalIdentity(
     name: name ?? id,
     provider: entry.provider,
     ...(entry.alias ? { alias: entry.alias } : {}),
+    ...(lifecycleEntry.providerOrder !== undefined
+      ? { providerOrder: lifecycleEntry.providerOrder }
+      : {}),
     ...(lifecycleEntry.status ? { status: lifecycleEntry.status } : {}),
     ...(lifecycleEntry.statusReason ? { statusReason: lifecycleEntry.statusReason } : {}),
     ...(lifecycleEntry.replaces ? { replaces: lifecycleEntry.replaces } : {}),

--- a/src/agents/model-catalog-visibility.test.ts
+++ b/src/agents/model-catalog-visibility.test.ts
@@ -87,7 +87,7 @@ describe("resolveLogicalVisibleModelCatalog", () => {
     expect(result.map((entry) => entry.id)).toEqual(["off", "old"]);
   });
 
-  it("preserves provider-owned strongest-first order", async () => {
+  it("preserves provider-owned strongest-first order through route projection", async () => {
     const catalog: ModelCatalogEntry[] = [
       { provider: "openai", id: "gpt-5.4", name: "GPT-5.4", providerOrder: 3 },
       { provider: "openai", id: "gpt-5.6-luna", name: "GPT-5.6 Luna", providerOrder: 2 },
@@ -101,7 +101,16 @@ describe("resolveLogicalVisibleModelCatalog", () => {
       defaultProvider: "openai",
       view: "all",
       routePolicy: openAIModelCatalogRoutePolicy,
-      evaluateEntry: evaluateAvailableEntry,
+      evaluateEntry: async (entry) =>
+        resolveLogicalModelCatalogEntryState({
+          entry,
+          evaluation: {
+            availability: true,
+            routeResolution: { kind: "routes", routes: [selectedRoute] },
+            selectedRoute,
+          },
+          routePolicy: openAIModelCatalogRoutePolicy,
+        }),
     });
 
     expect(result.map((entry) => entry.id)).toEqual([

--- a/src/agents/model-catalog.test.ts
+++ b/src/agents/model-catalog.test.ts
@@ -201,10 +201,10 @@ describe("prepared model catalog builder", () => {
 
   it("keeps provider-owned strongest-first order after runtime augmentation", async () => {
     mocks.augmentModelCatalogWithProviderPlugins.mockResolvedValueOnce([
+      { id: "gpt-5.4", name: "GPT-5.4", provider: "openai" },
+      { id: "gpt-5.6-luna", name: "GPT-5.6 Luna", provider: "openai" },
       { id: "gpt-5.6-sol", name: "GPT-5.6 Sol", provider: "openai" },
       { id: "gpt-5.6-terra", name: "GPT-5.6 Terra", provider: "openai" },
-      { id: "gpt-5.6-luna", name: "GPT-5.6 Luna", provider: "openai" },
-      { id: "gpt-5.4", name: "GPT-5.4", provider: "openai" },
     ]);
 
     const snapshot = await build({

--- a/src/agents/model-catalog.ts
+++ b/src/agents/model-catalog.ts
@@ -544,11 +544,12 @@ export async function buildPreparedModelCatalogSnapshot(
     );
     // Runtime declarations describe possible models, not account entitlement.
     // Only live registry or refreshed rows may publish those provider models.
-    const manifestModels = loadManifestModelCatalog({
+    const declaredManifestModels = loadManifestModelCatalog({
       config: cfg,
       env,
       metadataSnapshot: manifestMetadataSnapshot,
-    }).filter((entry) =>
+    });
+    const manifestModels = declaredManifestModels.filter((entry) =>
       supplementalManifestKeys.has(catalogEntryDedupeKey(entry.provider, entry.id)),
     );
     mergeCatalogRouteVariants(routeVariants, manifestModels);
@@ -633,7 +634,12 @@ export async function buildPreparedModelCatalogSnapshot(
             id,
           });
         }
-        const orderedSupplemental = assignProviderModelOrder(normalizedSupplemental);
+        // Manifest ranks are provider-owned policy. Live discovery enriches
+        // those rows and appends unknown models without replacing the ranking.
+        const orderedSupplemental = assignProviderModelOrder(
+          normalizedSupplemental,
+          declaredManifestModels,
+        );
         mergeCatalogRouteVariants(routeVariants, orderedSupplemental);
         mergeCatalogEntries(models, orderedSupplemental);
       }

--- a/src/gateway/server-methods/models-list-result.openai-routes.test.ts
+++ b/src/gateway/server-methods/models-list-result.openai-routes.test.ts
@@ -550,6 +550,29 @@ describe("models.list OpenAI routes", () => {
     });
   });
 
+  it("preserves provider-owned order in the public route-aware model list", async () => {
+    const routeResolverFactory = vi.fn(() => () => ({
+      kind: "indeterminate" as const,
+      defaultRuntimeId: "codex",
+    }));
+    const catalog: ModelCatalogEntry[] = [
+      { ...catalogEntry("gpt-5.4", "openai-responses"), providerOrder: 3 },
+      { ...catalogEntry("gpt-5.6-luna", "openai-responses"), providerOrder: 2 },
+      { ...catalogEntry("gpt-5.6-sol", "openai-responses"), providerOrder: 0 },
+      { ...catalogEntry("gpt-5.6-terra", "openai-responses"), providerOrder: 1 },
+    ];
+
+    const result = await listModels({ catalog, routeResolverFactory });
+
+    expect(result.models.map((entry) => entry.id)).toEqual([
+      "gpt-5.6-sol",
+      "gpt-5.6-terra",
+      "gpt-5.6-luna",
+      "gpt-5.4",
+    ]);
+    expect(result.models.every((entry) => !("providerOrder" in entry))).toBe(true);
+  });
+
   it("keeps public metadata for a provider-canonical model-level Platform route", async () => {
     const cfg = {
       models: {


### PR DESCRIPTION
Related: #115380

## What Problem This Solves

Fixes an issue where users opening the Control UI model picker would still see alphabetic OpenAI ordering after #115380 when live account discovery and route projection were active. GPT-5.6 Sol, Terra, and Luna remained below older models even though the provider catalog declared them first.

## Why This Change Was Made

Manifest order remains the provider-owned ranking when live discovery enriches known rows, while newly discovered models append after the declared catalog. Route projection now carries that internal rank through the final sort without exposing it in the public `models.list` payload. Kimi Coding's own catalog also declares K3 variants before older coding models.

## User Impact

The real model picker now receives OpenAI models in strongest-first order after account discovery: Sol, Terra, and Luna lead, followed by older and unranked entries. Kimi Coding likewise presents K3 first. The Moonshot alias, width, and inline-context improvements from #115380 are unchanged.

## Evidence

- Source-blind validation of the deployed #115380 build reproduced the miss: `models.list` rendered `Chat Latest`, GPT-5.4/5.5 rows, then Luna, Sol, and Terra.
- Blacksmith Testbox `tbx_01kyn6vfk4kxyjrf6zkv65gf33`: 17 catalog-builder, 11 visibility/route-projection, 22 public `models.list`, and 3 Kimi provider-catalog tests passed.
- The exact eight-file `pnpm check:changed` plan passed all core/extension typecheck, lint, dead-code, metadata, architecture, and storage guards: https://github.com/openclaw/openclaw/actions/runs/30396774376
- Targeted formatting passed.
- Final Codex autoreview: clean, no accepted/actionable findings.

The sanitized captures from #115380 remain the visual before/after target; this follow-up repairs the live server ordering handoff so the real picker matches the approved after state.

### Before

<img width="848" height="716" alt="Model picker before: duplicated Moonshot providers and alphabetical OpenAI models" src="https://github.com/user-attachments/assets/1fc88550-94fd-4bfb-b86f-804451e81aa0" />

### After

<img width="992" height="716" alt="Model picker after: unified Moonshot AI, strongest-first models, and inline context" src="https://github.com/user-attachments/assets/1aa91112-9299-403e-92de-e8d114db909e" />

AI-assisted: yes. I understand the owner-boundary changes and validated them with focused tests, the complete changed gate, source-blind live reproduction, and Codex autoreview.
