### PR TITLE
fix(ui): explain empty agent session groups

### DIFF
--- a/ui/src/components/app-sidebar-session-list-render.ts
+++ b/ui/src/components/app-sidebar-session-list-render.ts
@@ -211,6 +211,11 @@ function renderSessionSection(params: {
       ${collapsed
         ? nothing
         : html`
+            ${group && totalRowCount === 0
+              ? html`<span class="sidebar-session-empty-hint sidebar-session-empty-placeholder"
+                  >${t("chat.sidebar.noSessionsForAgent")}</span
+                >`
+              : nothing}
             ${section.rows.length > 0 || showDraft
               ? html`<div class="sidebar-recent-sessions__list" role="list" aria-label=${label}>
                   ${showDraft ? renderDraftSessionRow() : nothing}

--- a/ui/src/e2e/session-management.groups.e2e.test.ts
+++ b/ui/src/e2e/session-management.groups.e2e.test.ts
@@ -840,6 +840,18 @@ suite.define(() => {
       await expect
         .poll(() => emptyGroups.locator(".sidebar-session-empty-placeholder").allTextContents())
         .toEqual(["No sessions found for this agent", "No sessions found for this agent"]);
+      const firstEmptyGroup = emptyGroups.first();
+      const textLeft = (selector: string) =>
+        firstEmptyGroup.locator(selector).evaluate((element) => {
+          const range = document.createRange();
+          range.selectNodeContents(element);
+          return range.getBoundingClientRect().x;
+        });
+      const [titleLeft, placeholderLeft] = await Promise.all([
+        textLeft(".sidebar-recent-sessions__label-text"),
+        textLeft(".sidebar-session-empty-placeholder"),
+      ]);
+      expect(placeholderLeft).toBeCloseTo(titleLeft, 0);
     } finally {
       await context.close();
     }

--- a/ui/src/e2e/session-management.groups.e2e.test.ts
+++ b/ui/src/e2e/session-management.groups.e2e.test.ts
@@ -787,4 +787,61 @@ suite.define(() => {
       await context.close();
     }
   });
+
+  it("explains empty gateway groups for the selected agent", async () => {
+    const context = await suite.browser.newContext({
+      locale: "en-US",
+      serviceWorkers: "block",
+      viewport: { height: 900, width: 1280 },
+    });
+    const page = await context.newPage();
+    const gateway = await installMockGateway(page, {
+      assistantName: "Ivan",
+      defaultAgentId: "ivan",
+      featureMethods: ["chat.metadata", "chat.startup", "sessions.groups.list"],
+      methodResponses: {
+        "sessions.list": {
+          cases: [
+            {
+              match: { agentId: "ivan" },
+              response: sessionsListResponse([
+                sessionRow("agent:ivan:main", "Ivan", Date.parse("2026-07-28T18:00:00.000Z")),
+              ]),
+            },
+            {
+              match: { agentId: "main" },
+              response: sessionsListResponse([
+                sessionRow("agent:main:email", "Email intake", 1, { category: "Email intake" }),
+                sessionRow("agent:main:replies", "Customer replies", 1, {
+                  category: "Customer replies",
+                }),
+              ]),
+            },
+          ],
+        },
+      },
+      sessionGroups: ["Email intake", "Customer replies"],
+      sessionKey: "agent:ivan:main",
+    });
+
+    try {
+      await page.goto(`${suite.server.baseUrl}chat`);
+      await expect
+        .poll(async () =>
+          (await gateway.getRequests("sessions.list")).some(
+            (request) => requireRecord(request.params).agentId === "ivan",
+          ),
+        )
+        .toBe(true);
+
+      const emptyGroups = page.locator('[data-session-section^="category:"]');
+      await expect.poll(() => emptyGroups.count()).toBe(2);
+      await captureUiProof(page, "sidebar-empty-cross-agent-groups.png");
+      await expect
+        .poll(() => emptyGroups.locator(".sidebar-session-empty-placeholder").allTextContents())
+        .toEqual(["No sessions found for this agent", "No sessions found for this agent"]);
+    } finally {
+      await context.close();
+    }
+  });
 });

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -4282,6 +4282,7 @@ export const en: TranslationMap = {
       threads: "Threads",
       groups: "Groups",
       coding: "Coding",
+      noSessionsForAgent: "No sessions found for this agent",
       catalogViewOptions: "View options",
       catalogGroupByProject: "Project",
       catalogGroupByPerson: "Person",

--- a/ui/src/styles/layout.css
+++ b/ui/src/styles/layout.css
@@ -1731,6 +1731,11 @@ html.openclaw-native-macos
   font-size: 11px;
 }
 
+.sidebar-session-empty-placeholder {
+  /* Match the section title: 9px header inset + 8px drag handle + 8px gap. */
+  padding-left: 25px;
+}
+
 .sidebar-session--archived {
   opacity: 0.62;
 }


### PR DESCRIPTION
## What Problem This Solves

On multi-agent gateways, the Control UI keeps the gateway-wide custom session-group catalog visible while requesting session rows for only the selected agent. Groups populated only by another agent therefore looked like empty headings and could be mistaken for a loading or data-loss problem.

Closes #115348.

## Why This Change Was Made

Empty custom groups intentionally remain visible as drop targets. Instead of changing group scope or hiding them, this adds the requested explanatory placeholder inside each expanded empty custom group:

> No sessions found for this agent

The placeholder is horizontally aligned with the session-group title. The change stays in the Control UI renderer and does not alter Gateway, grouping, persistence, or drag/drop behavior. The original stored-empty-group behavior was introduced in #101117; this change clarifies its multi-agent presentation.

## User Impact

Users who select an agent with no sessions in a gateway-wide custom group now see why the group is empty. Populated groups, collapsed groups, Threads, Coding, and catalog sections are unchanged.

## Evidence

- Pre-fix reproduction, Blacksmith Testbox through Crabbox: `tbx_01kyn6cbmjfwwkvzmghjq8h9dz`, Actions run https://github.com/openclaw/openclaw/actions/runs/30396172072. The selected-agent browser flow rendered two custom groups and failed with `expected ["No sessions found for this agent", "No sessions found for this agent"], received []`.
- Final browser and alignment proof at head `1732dcc09b7`, Blacksmith Testbox through Crabbox: `tbx_01kyncv1dbrpk4dq38pdm1tmr6`, Actions run https://github.com/openclaw/openclaw/actions/runs/30403979993. `ui/src/e2e/session-management.groups.e2e.test.ts`: 9/9 passed; the regression test verifies the placeholder text and group title have the same rendered X coordinate, and the updated screenshot was inspected.
- Final changed gate on the same Testbox: `OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 corepack pnpm check:changed` passed in 21m46s, including format, dead-code, Control UI i18n verification, core-test/UI typechecks, and lint with 0 warnings/errors.
- Autoreview: `.agents/skills/autoreview/scripts/autoreview --mode local --stream-engine-output` returned clean with no accepted/actionable findings (confidence 0.94).

Visual proof: https://pagedrop.ai/g/Patrick-Erichsen/8e0f632e6b74864012ac4b696b01cc8a
