### PR TITLE
fix(sessions): adopt pre-persisted user-turn event id to stop duplicate transcript enrollment

### DIFF
--- a/src/agents/sessions/session-manager-entries.ts
+++ b/src/agents/sessions/session-manager-entries.ts
@@ -66,7 +66,15 @@ export class SessionManagerEntries extends SessionManagerPersistence {
     if (persistedEventId && this.byId.has(persistedEventId)) {
       // The recorder pre-persisted this turn before this manager loaded it; the
       // entry is already canonical. Appending again would force-insert a duplicate
-      // idempotency-key row into SQLite (#115389).
+      // idempotency-key row into SQLite (#115389). Adopt it as the active leaf the
+      // same way appendEntry would — without the leaf move the turn is loaded but
+      // off the prompt path, and the model never sees it.
+      if (this.appendParentId !== persistedEventId) {
+        this.appendParentId = persistedEventId;
+        this.leafId = persistedEventId;
+        this.appendMode = undefined;
+        this.promptReleasedSideBranchParentId = undefined;
+      }
       return persistedEventId;
     }
     const entry: SessionMessageEntry = {

--- a/src/agents/sessions/session-manager-entries.ts
+++ b/src/agents/sessions/session-manager-entries.ts
@@ -66,14 +66,15 @@ export class SessionManagerEntries extends SessionManagerPersistence {
     if (persistedEventId && this.byId.has(persistedEventId)) {
       // The recorder pre-persisted this turn before this manager loaded it; the
       // entry is already canonical. Appending again would force-insert a duplicate
-      // idempotency-key row into SQLite (#115389). Adopt it as the active leaf the
-      // same way appendEntry would — without the leaf move the turn is loaded but
-      // off the prompt path, and the model never sees it.
+      // idempotency-key row into SQLite (#115389). Adopt it as the active leaf via a
+      // persisted leaf control: an in-memory-only repoint is erased by
+      // reloadPersistedTranscript() mid-run and invisible to store-side readers,
+      // leaving the turn off the active path and out of the model prompt.
       if (this.appendParentId !== persistedEventId) {
-        this.appendParentId = persistedEventId;
-        this.leafId = persistedEventId;
-        this.appendMode = undefined;
-        this.promptReleasedSideBranchParentId = undefined;
+        this.appendLeafControl({
+          targetId: persistedEventId,
+          appendParentId: persistedEventId,
+        });
       }
       return persistedEventId;
     }

--- a/src/agents/sessions/session-manager-entries.ts
+++ b/src/agents/sessions/session-manager-entries.ts
@@ -1,5 +1,6 @@
 import { isSessionTranscriptSideAppendEntry } from "../../config/sessions/transcript-tree.js";
 import type { ImageContent, Message, TextContent } from "../../llm/types.js";
+import { takePersistedUserTurnEventId } from "../../sessions/user-turn-transcript-runtime-context.js";
 import {
   buildSessionContext as buildCoreSessionContext,
   type SessionTreeEntry as CoreSessionTreeEntry,
@@ -60,12 +61,22 @@ export class SessionManagerEntries extends SessionManagerPersistence {
     message: Message | CustomMessage | BashExecutionMessage,
     options?: AppendPersistenceOptions,
   ): string {
+    const { eventId: persistedEventId, message: entryMessage } =
+      takePersistedUserTurnEventId(message);
+    if (persistedEventId && this.byId.has(persistedEventId)) {
+      // The recorder pre-persisted this turn before this manager loaded it; the
+      // entry is already canonical. Appending again would force-insert a duplicate
+      // idempotency-key row into SQLite (#115389).
+      return persistedEventId;
+    }
     const entry: SessionMessageEntry = {
       type: "message",
-      id: generateSessionEntryId(this.byId),
+      // Adopting the pre-persisted event id keeps one transcript identity: the
+      // SQLite append then dedupes to the same row instead of force-inserting.
+      id: persistedEventId ?? generateSessionEntryId(this.byId),
       parentId: this.appendParentId,
       timestamp: new Date().toISOString(),
-      message,
+      message: entryMessage,
     };
     this.appendEntry(entry, options);
     return entry.id;

--- a/src/agents/sessions/session-manager.user-turn-event-identity.test.ts
+++ b/src/agents/sessions/session-manager.user-turn-event-identity.test.ts
@@ -1,0 +1,201 @@
+// Regression coverage for #115389: recorder-pre-persisted user turns must keep
+// one SQLite event identity when the run-side SessionManager appends the same turn.
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  formatSqliteSessionFileMarker,
+  parseSqliteSessionFileMarker,
+} from "../../config/sessions/legacy-sqlite-marker.js";
+import {
+  loadTranscriptEvents,
+  upsertSessionEntry,
+} from "../../config/sessions/session-accessor.js";
+import { resolveSqliteTargetFromSessionStorePath } from "../../config/sessions/session-sqlite-target.js";
+import { requireNodeSqlite } from "../../infra/node-sqlite.js";
+import { createUserTurnTranscriptRecorder } from "../../sessions/user-turn-transcript.js";
+import { closeOpenClawAgentDatabasesForTest } from "../../state/openclaw-agent-db.js";
+import { closeOpenClawStateDatabaseForTest } from "../../state/openclaw-state-db.js";
+import { guardSessionManager } from "../session-tool-result-guard-wrapper.js";
+import { SessionManager } from "./session-manager.js";
+
+const tempPaths: string[] = [];
+
+async function makeTempDir(): Promise<string> {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-user-turn-identity-"));
+  tempPaths.push(dir);
+  return dir;
+}
+
+function buildAssistantMessage(text: string) {
+  return {
+    role: "assistant" as const,
+    content: [{ type: "text" as const, text }],
+    api: "messages" as const,
+    provider: "anthropic" as const,
+    model: "sonnet-4.6" as const,
+    usage: {
+      input: 0,
+      output: 0,
+      cacheRead: 0,
+      cacheWrite: 0,
+      totalTokens: 0,
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+    },
+    stopReason: "stop" as const,
+    timestamp: Date.now(),
+  };
+}
+
+type TranscriptMessageEvent = {
+  id: string;
+  parentId: string | null;
+  type: string;
+  message: { role?: string; idempotencyKey?: string };
+};
+
+function isTranscriptMessageEvent(event: unknown): event is TranscriptMessageEvent {
+  return (
+    typeof event === "object" &&
+    event !== null &&
+    (event as { type?: unknown }).type === "message" &&
+    typeof (event as { message?: unknown }).message === "object"
+  );
+}
+
+async function setUpPrePersistedUserTurn(params: {
+  dir: string;
+  idempotencyKey: string;
+  text: string;
+}) {
+  const sessionId = "user-turn-identity-session";
+  const sessionKey = "agent:main:whatsapp:user-turn-identity";
+  const storePath = path.join(params.dir, "sessions.json");
+  const marker = formatSqliteSessionFileMarker({ agentId: "main", sessionId, storePath });
+  const scope = { agentId: "main", sessionId, sessionKey, storePath };
+  await upsertSessionEntry(
+    { agentId: "main", sessionKey, storePath },
+    { sessionFile: marker, sessionId, updatedAt: 10 },
+  );
+
+  // Production enrollment emitter: admitUserTurn pre-persists the inbound turn
+  // through the recorder before the embedded run opens its SessionManager.
+  const recorder = createUserTurnTranscriptRecorder({
+    input: {
+      text: params.text,
+      timestamp: 123,
+      idempotencyKey: params.idempotencyKey,
+    },
+    target: {
+      agentId: "main",
+      cwd: params.dir,
+      sessionEntry: undefined,
+      sessionId,
+      sessionKey,
+      storePath,
+    },
+  });
+  const prePersisted = await recorder.persistApproved();
+  if (!prePersisted?.appended) {
+    throw new Error("expected the recorder to pre-persist the user turn");
+  }
+
+  // Production run-side writer: the guarded SessionManager merges the prepared
+  // turn into the runtime user message before persistence.
+  const target = parseSqliteSessionFileMarker(marker);
+  if (!target) {
+    throw new Error("expected SQLite transcript marker fixture");
+  }
+  const sessionManager = guardSessionManager(
+    SessionManager.open({ ...target, sessionKey }, params.dir),
+    {
+      agentId: "main",
+      sessionKey,
+      preparedUserTurnMessage: await recorder.resolveMessage(),
+    },
+  );
+  return { prePersisted, recorder, scope, sessionManager };
+}
+
+describe("SessionManager user-turn event identity", () => {
+  afterEach(async () => {
+    closeOpenClawAgentDatabasesForTest();
+    closeOpenClawStateDatabaseForTest();
+    await Promise.all(
+      tempPaths.splice(0).map((dir) => fs.rm(dir, { recursive: true, force: true })),
+    );
+  });
+
+  it("keeps one transcript row when the run re-appends a pre-persisted user turn", async () => {
+    const dir = await makeTempDir();
+    const idempotencyKey =
+      "channel-user:v1:a94030e1a94030e1a94030e1a94030e1a94030e1a94030e1a94030e1a94030e1";
+    const { prePersisted, scope, sessionManager } = await setUpPrePersistedUserTurn({
+      dir,
+      idempotencyKey,
+      text: "hello twice?",
+    });
+
+    const entryId = sessionManager.appendMessage({
+      role: "user",
+      content: "hello twice?",
+      timestamp: Date.now(),
+    });
+
+    // One canonical row: the run-side append must dedupe to the recorder's event id.
+    const events = await loadTranscriptEvents(scope);
+    const userRows = events
+      .filter(isTranscriptMessageEvent)
+      .filter(
+        (event) => event.message.role === "user" && event.message.idempotencyKey === idempotencyKey,
+      );
+    expect(userRows.map((event) => event.id)).toEqual([prePersisted.messageId]);
+    expect(entryId).toBe(prePersisted.messageId);
+
+    // The identity row keeps its indexed key: no force-insert NULLed it out.
+    const { path: dbPath } = resolveSqliteTargetFromSessionStorePath(scope.storePath, {
+      agentId: "main",
+    });
+    const { DatabaseSync } = requireNodeSqlite();
+    const db = new DatabaseSync(dbPath);
+    try {
+      const identityRows = db
+        .prepare(
+          `SELECT event_id FROM transcript_event_identities
+           WHERE session_id = ? AND message_idempotency_key = ?`,
+        )
+        .all(scope.sessionId, idempotencyKey) as Array<{ event_id: string }>;
+      expect(identityRows.map((row) => row.event_id)).toEqual([prePersisted.messageId]);
+    } finally {
+      db.close();
+    }
+  });
+
+  it("persists the user entry before the first assistant event parents off it", async () => {
+    const dir = await makeTempDir();
+    const idempotencyKey =
+      "channel-user:v1:b94030e1b94030e1b94030e1b94030e1b94030e1b94030e1b94030e1b94030e1";
+    const { prePersisted, scope, sessionManager } = await setUpPrePersistedUserTurn({
+      dir,
+      idempotencyKey,
+      text: "ordering pin",
+    });
+
+    sessionManager.appendMessage({
+      role: "user",
+      content: "ordering pin",
+      timestamp: Date.now(),
+    });
+    const assistantEntryId = sessionManager.appendMessage(buildAssistantMessage("reply"));
+
+    // Creation-time adoption leaves no descendants to repoint: the user row exists
+    // before the first assistant event, which parents off the canonical row.
+    const events = (await loadTranscriptEvents(scope)).filter(isTranscriptMessageEvent);
+    const userIndex = events.findIndex((event) => event.id === prePersisted.messageId);
+    const assistantIndex = events.findIndex((event) => event.id === assistantEntryId);
+    expect(userIndex).toBeGreaterThanOrEqual(0);
+    expect(assistantIndex).toBeGreaterThan(userIndex);
+    expect(events[assistantIndex]?.parentId).toBe(prePersisted.messageId);
+  });
+});

--- a/src/agents/sessions/session-manager.user-turn-event-identity.test.ts
+++ b/src/agents/sessions/session-manager.user-turn-event-identity.test.ts
@@ -229,16 +229,16 @@ describe("SessionManager user-turn event identity", () => {
     });
     expect(entryId).toBe(prePersisted.messageId);
 
+    // The adoption must survive a mid-run transcript reload: the embedded runner
+    // reloads from SQLite when another writer touches the session, so an
+    // in-memory-only leaf repoint would silently drop the turn from the prompt.
+    sessionManager.reloadPersistedTranscript();
+    expect(sessionManager.getLeafId()).toBe(prePersisted.messageId);
+
     // The short-circuit must adopt the loaded row as the leaf: the turn has to be
     // in the prompt path, and the next assistant event must parent off it.
-    const contextTexts = sessionManager
-      .buildSessionContext()
-      .messages.map((message) =>
-        typeof message.content === "string"
-          ? message.content
-          : message.content?.map((block: { text?: string }) => block.text ?? "").join(" "),
-      );
-    expect(contextTexts.some((text) => text?.includes("keep the active turn"))).toBe(true);
+    const contextJson = JSON.stringify(sessionManager.buildSessionContext().messages);
+    expect(contextJson).toContain("keep the active turn");
     const assistantEntryId = sessionManager.appendMessage(buildAssistantMessage("adopted reply"));
     const events = (
       await loadTranscriptEvents({ agentId: "main", sessionId, sessionKey, storePath })

--- a/src/agents/sessions/session-manager.user-turn-event-identity.test.ts
+++ b/src/agents/sessions/session-manager.user-turn-event-identity.test.ts
@@ -172,6 +172,82 @@ describe("SessionManager user-turn event identity", () => {
     }
   });
 
+  it("adopts a loaded pre-persisted turn onto the active path when the leaf moved elsewhere", async () => {
+    const dir = await makeTempDir();
+    const idempotencyKey =
+      "channel-user:v1:c94030e1c94030e1c94030e1c94030e1c94030e1c94030e1c94030e1c94030e1";
+    const sessionId = "user-turn-identity-session";
+    const sessionKey = "agent:main:whatsapp:user-turn-identity";
+    const storePath = path.join(dir, "sessions.json");
+    const marker = formatSqliteSessionFileMarker({ agentId: "main", sessionId, storePath });
+    await upsertSessionEntry(
+      { agentId: "main", sessionKey, storePath },
+      { sessionFile: marker, sessionId, updatedAt: 10 },
+    );
+    const target = parseSqliteSessionFileMarker(marker);
+    if (!target) {
+      throw new Error("expected SQLite transcript marker fixture");
+    }
+
+    // A manager opened before enrollment: its in-memory leaf will diverge from
+    // the recorder's row, putting the pre-persisted turn on a sibling branch.
+    const earlierManager = SessionManager.open({ ...target, sessionKey }, dir);
+    earlierManager.appendMessage({ role: "user", content: "earlier turn", timestamp: Date.now() });
+    earlierManager.appendMessage(buildAssistantMessage("earlier reply"));
+
+    const recorder = createUserTurnTranscriptRecorder({
+      input: { text: "keep the active turn", timestamp: 456, idempotencyKey },
+      target: {
+        agentId: "main",
+        cwd: dir,
+        sessionEntry: undefined,
+        sessionId,
+        sessionKey,
+        storePath,
+      },
+    });
+    const prePersisted = await recorder.persistApproved();
+    if (!prePersisted?.appended) {
+      throw new Error("expected the recorder to pre-persist the user turn");
+    }
+    // The stale manager appends after enrollment: the store's newest event is now
+    // a sibling of the recorder's row, so a fresh open lands its leaf there.
+    earlierManager.appendMessage(buildAssistantMessage("sibling branch tip"));
+
+    const sessionManager = guardSessionManager(
+      SessionManager.open({ ...target, sessionKey }, dir),
+      {
+        agentId: "main",
+        sessionKey,
+        preparedUserTurnMessage: await recorder.resolveMessage(),
+      },
+    );
+    const entryId = sessionManager.appendMessage({
+      role: "user",
+      content: "keep the active turn",
+      timestamp: Date.now(),
+    });
+    expect(entryId).toBe(prePersisted.messageId);
+
+    // The short-circuit must adopt the loaded row as the leaf: the turn has to be
+    // in the prompt path, and the next assistant event must parent off it.
+    const contextTexts = sessionManager
+      .buildSessionContext()
+      .messages.map((message) =>
+        typeof message.content === "string"
+          ? message.content
+          : message.content?.map((block: { text?: string }) => block.text ?? "").join(" "),
+      );
+    expect(contextTexts.some((text) => text?.includes("keep the active turn"))).toBe(true);
+    const assistantEntryId = sessionManager.appendMessage(buildAssistantMessage("adopted reply"));
+    const events = (
+      await loadTranscriptEvents({ agentId: "main", sessionId, sessionKey, storePath })
+    ).filter(isTranscriptMessageEvent);
+    expect(events.find((event) => event.id === assistantEntryId)?.parentId).toBe(
+      prePersisted.messageId,
+    );
+  });
+
   it("persists the user entry before the first assistant event parents off it", async () => {
     const dir = await makeTempDir();
     const idempotencyKey =

--- a/src/config/sessions/session-accessor.sqlite-transcript-store.ts
+++ b/src/config/sessions/session-accessor.sqlite-transcript-store.ts
@@ -4,6 +4,7 @@ import {
   executeSqliteQuerySync,
   executeSqliteQueryTakeFirstSync,
 } from "../../infra/kysely-sync.js";
+import { getChildLogger } from "../../logging/logger.js";
 import { redactSecrets } from "../../logging/redact.js";
 import { canonicalizePersistedUserMessageMedia } from "../../media/media-facts.js";
 import type { OpenClawAgentDatabase } from "../../state/openclaw-agent-db.js";
@@ -102,16 +103,30 @@ export function appendTranscriptEventInTransaction(
   }
   // Caller-checked appends may retain a duplicate key in the payload, but the
   // identity index can point at only one row.
-  const indexedMessageIdempotencyKey =
-    identity.messageIdempotencyKey &&
-    !options.dedupeByMessageIdempotency &&
-    readTranscriptIdentityByMessageIdempotencyKey(
-      database,
-      scope.sessionId,
-      identity.messageIdempotencyKey,
-    )
-      ? undefined
-      : identity.messageIdempotencyKey;
+  const duplicateKeyOwner =
+    identity.messageIdempotencyKey && !options.dedupeByMessageIdempotency
+      ? readTranscriptIdentityByMessageIdempotencyKey(
+          database,
+          scope.sessionId,
+          identity.messageIdempotencyKey,
+        )
+      : undefined;
+  if (duplicateKeyOwner) {
+    // The index keeps pointing at the first writer; surface the bypass so a
+    // duplicated enrollment is auditable instead of silently NULLed (#115389).
+    getChildLogger({ subsystem: "session-sqlite" }).warn(
+      "transcript append duplicated a message idempotency key past the identity index",
+      {
+        sessionId: scope.sessionId,
+        eventId: identity.eventId,
+        existingEventId: duplicateKeyOwner.eventId,
+        messageIdempotencyKey: identity.messageIdempotencyKey,
+      },
+    );
+  }
+  const indexedMessageIdempotencyKey = duplicateKeyOwner
+    ? undefined
+    : identity.messageIdempotencyKey;
   executeSqliteQuerySync(
     database.db,
     db

--- a/src/sessions/user-turn-transcript-runtime-context.ts
+++ b/src/sessions/user-turn-transcript-runtime-context.ts
@@ -17,6 +17,60 @@ type RuntimeUserTurnTranscriptContext = {
   recorder: UserTurnTranscriptRecorder;
 };
 
+// The recorder pre-persists a user turn under its own SQLite event id. The id rides
+// the prepared message's __openclaw meta so SessionManager adopts one event identity
+// instead of force-inserting a duplicate idempotency-key row (#115389).
+const PERSISTED_USER_TURN_EVENT_ID_META_KEY = "persistedEventId";
+
+function readOpenClawMeta(message: unknown): Record<string, unknown> | undefined {
+  const meta =
+    message && typeof message === "object"
+      ? (message as Record<string, unknown>)["__openclaw"]
+      : undefined;
+  return meta && typeof meta === "object" && !Array.isArray(meta)
+    ? (meta as Record<string, unknown>)
+    : undefined;
+}
+
+export function readPersistedUserTurnEventId(message: unknown): string | undefined {
+  const value = readOpenClawMeta(message)?.[PERSISTED_USER_TURN_EVENT_ID_META_KEY];
+  return typeof value === "string" && value ? value : undefined;
+}
+
+/** Marks a prepared user turn with the SQLite event id it was pre-persisted under. */
+export function stampPersistedUserTurnEventId(
+  message: PersistedUserTurnMessage,
+  eventId: string,
+): PersistedUserTurnMessage {
+  if (readPersistedUserTurnEventId(message) === eventId) {
+    return message;
+  }
+  return {
+    ...(message as unknown as Record<string, unknown>),
+    __openclaw: { ...readOpenClawMeta(message), [PERSISTED_USER_TURN_EVENT_ID_META_KEY]: eventId },
+  } as unknown as PersistedUserTurnMessage;
+}
+
+/** Takes the adoption marker off a message before it becomes a session entry payload. */
+export function takePersistedUserTurnEventId<TMessage>(message: TMessage): {
+  eventId?: string;
+  message: TMessage;
+} {
+  const meta = readOpenClawMeta(message);
+  const eventId = meta?.[PERSISTED_USER_TURN_EVENT_ID_META_KEY];
+  if (!meta || typeof eventId !== "string" || !eventId) {
+    return { message };
+  }
+  const { [PERSISTED_USER_TURN_EVENT_ID_META_KEY]: _removed, ...restMeta } = meta;
+  const record: Record<string, unknown> = { ...(message as Record<string, unknown>) };
+  if (Object.keys(restMeta).length > 0) {
+    record["__openclaw"] = restMeta;
+  } else {
+    delete record["__openclaw"];
+  }
+  return { eventId, message: record as TMessage };
+}
+
 /** Carries transcript-only fields with a queued runtime message without exposing them to the model. */
 export function attachRuntimeUserTurnTranscriptContext(
   runtimeMessage: PersistedUserTurnMessage,

--- a/src/sessions/user-turn-transcript.ts
+++ b/src/sessions/user-turn-transcript.ts
@@ -8,6 +8,10 @@ import {
 import { readPersistedMediaFacts, type MediaFact } from "../media/media-facts.js";
 import { applyInputProvenanceToUserMessage, normalizeInputProvenance } from "./input-provenance.js";
 import {
+  readPersistedUserTurnEventId,
+  stampPersistedUserTurnEventId,
+} from "./user-turn-transcript-runtime-context.js";
+import {
   normalizeStructuredMediaEntryForTranscript,
   resolveTranscriptMediaPath,
 } from "./user-turn-transcript.media-normalize.js";
@@ -273,7 +277,7 @@ export function mergePreparedUserTurnMessageForRuntime(params: {
   } as unknown as AgentMessage;
 }
 
-/** Restores only auth state that write hooks must not be able to forge or erase. */
+/** Restores only operational state that write hooks must not be able to forge or erase. */
 export function restorePreparedUserTurnOperationalMetaForRuntime(params: {
   runtimeMessage: AgentMessage;
   preparedMessage?: PersistedUserTurnMessage;
@@ -283,13 +287,20 @@ export function restorePreparedUserTurnOperationalMetaForRuntime(params: {
   }
   const preparedMeta = readOpenClawMessageMeta(params.preparedMessage);
   const senderIsOwner = preparedMeta?.senderIsOwner;
-  if (typeof senderIsOwner !== "boolean") {
-    return params.runtimeMessage;
+  let restoredMessage: PersistedUserTurnMessage = params.runtimeMessage;
+  if (typeof senderIsOwner === "boolean") {
+    restoredMessage = {
+      ...(restoredMessage as unknown as Record<string, unknown>),
+      __openclaw: { ...readOpenClawMessageMeta(restoredMessage), senderIsOwner },
+    } as unknown as PersistedUserTurnMessage;
   }
-  return {
-    ...(params.runtimeMessage as unknown as Record<string, unknown>),
-    __openclaw: { ...readOpenClawMessageMeta(params.runtimeMessage), senderIsOwner },
-  } as unknown as AgentMessage;
+  // A hook rewrite must not detach the turn from its pre-persisted event identity;
+  // losing it re-opens the duplicate-enrollment force insert (#115389).
+  const persistedEventId = readPersistedUserTurnEventId(params.preparedMessage);
+  if (persistedEventId) {
+    restoredMessage = stampPersistedUserTurnEventId(restoredMessage, persistedEventId);
+  }
+  return restoredMessage;
 }
 
 /** Applies before-message hooks while preserving user-turn transcript metadata. */
@@ -627,7 +638,16 @@ export function createUserTurnTranscriptRecorder(
   };
   return {
     message,
-    resolveMessage: resolveMessageForPersistence,
+    resolveMessage: async () => {
+      const resolvedMessage = await resolveMessageForPersistence();
+      // Ride the pre-persisted event id on the prepared message so SessionManager
+      // adopts one event identity instead of force-inserting a duplicate (#115389).
+      // Persistence itself keeps using resolveMessageForPersistence, so the marker
+      // never lands in stored payloads.
+      return resolvedMessage && persistedResult
+        ? stampPersistedUserTurnEventId(resolvedMessage, persistedResult.messageId)
+        : resolvedMessage;
+    },
     getPersistedMessage: () => runtimePersistedMessage ?? persistedResult?.message,
     markSentToProvider: () => {
       sentToProvider = true;


### PR DESCRIPTION
Closes #115389

## What Problem This Solves

Every channel inbound that goes through the pre-persisted user-turn recorder is enrolled **twice** in the SQLite transcript with the same `message.idempotencyKey` (100% rate on recorder-enrolled inbounds; see #115389 for the full evidence). The recorder pre-persists the turn under its own event id; SessionManager then mints a *different* entry id for the same turn, its append dedupes to the recorder's row, sees `messageId !== entry.id`, and force-inserts a duplicate via the `caller-checked` bypass — with the duplicate's `transcript_event_identities` row NULLed, so the unique index never fires and the duplication is invisible to SQL auditing. Downstream, the duplicate rows feed the duplicate-source admission machinery and the per-exchange orphan-removal repair; under rapid message pairs this contributed to real replies being dropped in favor of the "No reply was generated" fallback on a production gateway.

## Why This Change Was Made

Producer-side identity unification, per the same doctrine as #113063: fix the writer, add no consumer-side cleanup.

- The recorder's `resolveMessage()` now stamps the persisted SQLite event id onto the prepared message's `__openclaw` meta (`stampPersistedUserTurnEventId`); the guard's existing merge carries it to the run-side writer, and the post-hook restore re-stamps it so a `before_message_write` rewrite cannot detach the turn from its identity.
- `SessionManagerEntries.appendMessage` takes the marker off the message (it never lands in `event_json`) and either short-circuits to the already-loaded canonical entry (normal inbound path — `SessionManager.open` has already loaded the recorder's row) or adopts the id at entry creation (steer path), so the SQLite append dedupes to the **same** id and the force-insert branch never fires.
- Hardening: the store's caller-checked NULLing branch now emits one structured warning (session, both event ids, key) when a duplicate key is force-appended past the index — the bypass stays (the one-row index constraint is real) but is no longer silent.
- Deliberately unchanged: the force-insert branch itself (generic recovery for `scan-assistant` keys and hook-stripped meta) and the gateway worker's `caller-checked` commit path (separate documented contract).

## User Impact

Rapid message pairs (~8–15s apart) no longer produce duplicate transcript enrollment — one user event per idempotency key, descendants parent off the canonical row. Jointly with the fallback-gate work in #115016, this removes the mechanism behind dropped replies + false "No reply was generated" notices on rapid pairs. Operators gain an audit log line if any duplicate-key append still occurs. No config, schema, or doctor changes.

## Evidence

- **Reproduce-first regression test** (`src/agents/sessions/session-manager.user-turn-event-identity.test.ts`, production emitters: real recorder `persistApproved()` + guarded `SessionManager.open().appendMessage`): observed failing on the unfixed base with the exact production signature (recorder UUID row + force-inserted 8-hex duplicate, same key, identities-row key NULL), passing after the fix. A second test pins ordering: the user entry persists before the first assistant event and the assistant parents off the recorder's event id.
- Focused suites green post-fix: `src/config/sessions/session-accessor` (192 tests), `src/sessions/user-turn-transcript` (32), session guard suites (30), plus the new tests (2). `pnpm tsgo:core` and `tsgo:core:test` clean; oxlint/format clean.
- Not run locally (rides this PR's CI): `agent-runner.runreplyagent.e2e` and a live rapid-pair channel repro. The production incident evidence (two dropped-reply incidents in 24h, pairs 8–15s apart) is in #115389.

AI-assisted: yes (agent-implemented, human-directed; reproduce-first + independent review before opening).
