### PR TITLE
refactor(process): remove obsolete process cancellation paths

### DIFF
--- a/src/agents/cli-runner/execute-process.ts
+++ b/src/agents/cli-runner/execute-process.ts
@@ -6,7 +6,7 @@ import {
   scopedHeartbeatWakeOptionsForPolicy,
 } from "../../infra/event-session-routing.js";
 import type { CliBackendConfig } from "../../plugins/cli-backend.types.js";
-import type { ManagedRun, RunExit } from "../../process/supervisor/types.js";
+import type { RunExit } from "../../process/supervisor/types.js";
 import {
   createCliJsonlStreamingParser,
   extractCliErrorMessage,
@@ -257,16 +257,9 @@ export async function executeCliProcess(params: {
     if (runParams.abortSignal?.aborted) {
       throw createCliAbortError();
     }
-    let activeManagedRun: ManagedRun | undefined;
     // Startup can wait behind another scoped run. Reserve cancellation under
     // the caller's run id before awaiting the child or replacement fence.
-    const abortManagedRun = () => {
-      if (activeManagedRun) {
-        activeManagedRun.cancel("manual-cancel");
-        return;
-      }
-      supervisor.cancel(runParams.runId, "manual-cancel");
-    };
+    const abortManagedRun = () => supervisor.cancel(runParams.runId, "manual-cancel");
     runParams.abortSignal?.addEventListener("abort", abortManagedRun, { once: true });
     try {
       const managedRun = await supervisor.spawn({
@@ -287,7 +280,6 @@ export async function executeCliProcess(params: {
         onStdout: consumeStdout,
         onStderr: consumeStderr,
       });
-      activeManagedRun = managedRun;
       managedRunPid = managedRun.pid;
       let replyBackendCompleted = false;
       const replyBackendHandle = runParams.replyOperation

--- a/src/agents/cli-runner/execute.test-support.ts
+++ b/src/agents/cli-runner/execute.test-support.ts
@@ -54,53 +54,59 @@ export const enqueueSystemEventMock: UnknownMock = vi.fn();
 export const requestHeartbeatMock: UnknownMock = vi.fn();
 
 setCliRunnerExecuteTestDeps({
-  getProcessSupervisor: () => ({
-    spawn: async (params: Parameters<SupervisorSpawnFn>[0]) => {
-      let stdoutDelivered = false;
-      let stderrDelivered = false;
-      // Supervisor tests sometimes return captured output even when streaming
-      // was requested; replay it through callbacks once to match production.
-      const wrappedParams = {
-        ...params,
-        onStdout: params.onStdout
-          ? (chunk: string) => {
-              stdoutDelivered = true;
-              params.onStdout?.(chunk);
+  getProcessSupervisor: () => {
+    const activeRuns = new Map<string, Awaited<ReturnType<SupervisorSpawnFn>>>();
+    return {
+      spawn: async (params: Parameters<SupervisorSpawnFn>[0]) => {
+        let stdoutDelivered = false;
+        let stderrDelivered = false;
+        // Supervisor tests sometimes return captured output even when streaming
+        // was requested; replay it through callbacks once to match production.
+        const wrappedParams = {
+          ...params,
+          onStdout: params.onStdout
+            ? (chunk: string) => {
+                stdoutDelivered = true;
+                params.onStdout?.(chunk);
+              }
+            : undefined,
+          onStderr: params.onStderr
+            ? (chunk: string) => {
+                stderrDelivered = true;
+                params.onStderr?.(chunk);
+              }
+            : undefined,
+        };
+        const managedRun = (await supervisorSpawnMock(wrappedParams)) as Awaited<
+          ReturnType<SupervisorSpawnFn>
+        >;
+        activeRuns.set(params.runId ?? managedRun.runId, managedRun);
+        const wait = managedRun.wait;
+        return {
+          ...managedRun,
+          wait: async () => {
+            const exit = await wait();
+            if (params.captureOutput === false) {
+              // Production streams stdout/stderr through callbacks; replay captured
+              // output once so tests cover streaming and captured-output paths.
+              if (!stdoutDelivered && exit.stdout) {
+                params.onStdout?.(exit.stdout);
+              }
+              if (!stderrDelivered && exit.stderr) {
+                params.onStderr?.(exit.stderr);
+              }
             }
-          : undefined,
-        onStderr: params.onStderr
-          ? (chunk: string) => {
-              stderrDelivered = true;
-              params.onStderr?.(chunk);
-            }
-          : undefined,
-      };
-      const managedRun = (await supervisorSpawnMock(wrappedParams)) as Awaited<
-        ReturnType<SupervisorSpawnFn>
-      >;
-      const wait = managedRun.wait;
-      return {
-        ...managedRun,
-        wait: async () => {
-          const exit = await wait();
-          if (params.captureOutput === false) {
-            // Production streams stdout/stderr through callbacks; replay captured
-            // output once so tests cover streaming and captured-output paths.
-            if (!stdoutDelivered && exit.stdout) {
-              params.onStdout?.(exit.stdout);
-            }
-            if (!stderrDelivered && exit.stderr) {
-              params.onStderr?.(exit.stderr);
-            }
-          }
-          return exit;
-        },
-      };
-    },
-    cancel: vi.fn(),
-    cancelScope: vi.fn(),
-    getRecord: vi.fn(),
-  }),
+            return exit;
+          },
+        };
+      },
+      cancel: vi.fn((runId: string, reason?: Parameters<ProcessSupervisor["cancel"]>[1]) => {
+        activeRuns.get(runId)?.cancel(reason);
+      }),
+      cancelScope: vi.fn(),
+      getRecord: vi.fn(),
+    };
+  },
   enqueueSystemEvent: (
     text: Parameters<EnqueueSystemEventFn>[0],
     options: Parameters<EnqueueSystemEventFn>[1],

--- a/src/process/supervisor/adapters/child.ts
+++ b/src/process/supervisor/adapters/child.ts
@@ -422,19 +422,6 @@ export async function createChildAdapter(params: {
         (resolve, reject) => {
           resolveWait = resolve;
           rejectWait = reject;
-          if (waitResult) {
-            const settled = waitResult;
-            resolveWait = null;
-            rejectWait = null;
-            resolve(settled);
-            return;
-          }
-          if (waitError !== undefined) {
-            const error = waitError;
-            resolveWait = null;
-            rejectWait = null;
-            reject(toErrorObject(error, "Non-Error rejection"));
-          }
         },
       );
     }

--- a/src/process/supervisor/registry.test.ts
+++ b/src/process/supervisor/registry.test.ts
@@ -32,32 +32,29 @@ describe("process supervisor run registry", () => {
     const registry = createRunRegistry();
     addRunningRecord(registry, { runId: "r1", sessionId: "s1", startedAtMs: 1 });
 
-    const first = registry.finalize("r1", {
+    registry.finalize("r1", {
       reason: "overall-timeout",
       exitCode: null,
       exitSignal: "SIGKILL",
     });
-    const second = registry.finalize("r1", {
+    expect(registry.get("r1")).toMatchObject({
+      state: "exited",
+      terminationReason: "overall-timeout",
+      exitCode: null,
+      exitSignal: "SIGKILL",
+    });
+
+    registry.finalize("r1", {
       reason: "manual-cancel",
       exitCode: 0,
       exitSignal: null,
     });
-
-    if (!first) {
-      throw new Error("missing first finalize result");
-    }
-    expect(first.firstFinalize).toBe(true);
-    expect(first.record.terminationReason).toBe("overall-timeout");
-    expect(first.record.exitCode).toBeNull();
-    expect(first.record.exitSignal).toBe("SIGKILL");
-
-    if (!second) {
-      throw new Error("missing second finalize result");
-    }
-    expect(second.firstFinalize).toBe(false);
-    expect(second.record.terminationReason).toBe("overall-timeout");
-    expect(second.record.exitCode).toBeNull();
-    expect(second.record.exitSignal).toBe("SIGKILL");
+    expect(registry.get("r1")).toMatchObject({
+      state: "exited",
+      terminationReason: "overall-timeout",
+      exitCode: null,
+      exitSignal: "SIGKILL",
+    });
   });
 
   it("prunes oldest exited records once retention cap is exceeded", () => {

--- a/src/process/supervisor/registry.ts
+++ b/src/process/supervisor/registry.ts
@@ -31,7 +31,7 @@ type RunRegistry = {
       exitCode: number | null;
       exitSignal: NodeJS.Signals | number | null;
     },
-  ) => { record: RunRecord; firstFinalize: boolean } | null;
+  ) => void;
 };
 
 /**
@@ -110,10 +110,9 @@ export function createRunRegistry(options?: { maxExitedRecords?: number }): RunR
 
   const finalize: RunRegistry["finalize"] = (runId, exit) => {
     const current = records.get(runId);
-    if (!current) {
-      return null;
+    if (!current || current.state === "exited") {
+      return;
     }
-    const firstFinalize = current.state !== "exited";
     const ts = nowMs();
     const next: RunRecord = {
       ...current,
@@ -121,13 +120,12 @@ export function createRunRegistry(options?: { maxExitedRecords?: number }): RunR
       // First terminal observation wins; late fallback timers must not rewrite
       // the exit reason or signal after a real process exit has been recorded.
       terminationReason: current.terminationReason ?? exit.reason,
-      exitCode: current.exitCode !== undefined ? current.exitCode : exit.exitCode,
-      exitSignal: current.exitSignal !== undefined ? current.exitSignal : exit.exitSignal,
+      exitCode: exit.exitCode,
+      exitSignal: exit.exitSignal,
       updatedAtMs: ts,
     };
     records.set(runId, next);
     pruneExitedRecords();
-    return { record: { ...next }, firstFinalize };
   };
 
   return {

--- a/src/process/supervisor/supervisor.ts
+++ b/src/process/supervisor/supervisor.ts
@@ -1,7 +1,6 @@
 // Process supervisor manages long-running child and PTY process lifecycles.
 import crypto from "node:crypto";
 import { performance } from "node:perf_hooks";
-import { expectDefined } from "@openclaw/normalization-core";
 import { resolveTimerTimeoutMs } from "@openclaw/normalization-core/number-coercion";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { sliceUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
@@ -80,27 +79,19 @@ function resolveElapsedTimeoutReason(params: {
   overallTimeoutDeadlineMs: number | null;
   noOutputTimeoutDeadlineMs: number | null;
 }): TerminationReason | null {
-  const elapsedDeadlines: Array<{ reason: TerminationReason; deadlineMs: number }> = [];
-  if (params.overallTimeoutDeadlineMs !== null && params.nowMs >= params.overallTimeoutDeadlineMs) {
-    elapsedDeadlines.push({
-      reason: "overall-timeout",
-      deadlineMs: params.overallTimeoutDeadlineMs,
-    });
-  }
   if (
-    params.noOutputTimeoutDeadlineMs !== null &&
-    params.nowMs >= params.noOutputTimeoutDeadlineMs
+    params.overallTimeoutDeadlineMs !== null &&
+    params.nowMs >= params.overallTimeoutDeadlineMs &&
+    (params.noOutputTimeoutDeadlineMs === null ||
+      params.nowMs < params.noOutputTimeoutDeadlineMs ||
+      params.overallTimeoutDeadlineMs <= params.noOutputTimeoutDeadlineMs)
   ) {
-    elapsedDeadlines.push({
-      reason: "no-output-timeout",
-      deadlineMs: params.noOutputTimeoutDeadlineMs,
-    });
+    return "overall-timeout";
   }
-  if (elapsedDeadlines.length === 0) {
-    return null;
-  }
-  elapsedDeadlines.sort((a, b) => a.deadlineMs - b.deadlineMs);
-  return expectDefined(elapsedDeadlines[0], "elapsed deadlines entry at 0").reason;
+  return params.noOutputTimeoutDeadlineMs !== null &&
+    params.nowMs >= params.noOutputTimeoutDeadlineMs
+    ? "no-output-timeout"
+    : null;
 }
 
 export function createProcessSupervisor(): ProcessSupervisor {
@@ -391,18 +382,6 @@ export function createProcessSupervisor(): ProcessSupervisor {
           noOutputTimeoutDeadlineMs,
         });
         const terminalReason = forcedReason ?? deadlineReason;
-        if (settled) {
-          return {
-            reason: terminalReason ?? "exit",
-            exitCode: result.code,
-            exitSignal: result.signal,
-            durationMs: Date.now() - startedAtMs,
-            stdout,
-            stderr,
-            timedOut: isTimeoutReason(terminalReason ?? "exit"),
-            noOutputTimedOut: terminalReason === "no-output-timeout",
-          };
-        }
         settled = true;
         clearTimers();
         adapter.dispose();
@@ -417,7 +396,7 @@ export function createProcessSupervisor(): ProcessSupervisor {
           durationMs: Date.now() - startedAtMs,
           stdout,
           stderr,
-          timedOut: isTimeoutReason(terminalReason ?? reason),
+          timedOut: isTimeoutReason(reason),
           noOutputTimedOut: terminalReason === "no-output-timeout",
         };
         registry.finalize(runId, {


### PR DESCRIPTION
Related: #115317
Related: #115324

## What Problem This Solves

Process execution retained separate pending and active cancellation routing, unreachable completion branches, allocated and sorted tiny timeout lists, and registry finalization metadata that no production caller consumed. The original CI run also exposed a shared CLI-test supervisor double whose no-op cancellation did not implement the real supervisor contract: the managed-run cancellation regression waited forever, so the watchdog terminated the process after 600 seconds.

## Why This Change Was Made

Route every CLI process cancellation through the authoritative process supervisor by caller run ID, use a single terminal finalization path, compare timeout deadlines directly, and make registry finalization idempotent. Keep the test supervisor faithful by registering active runs per independent supervisor instance and forwarding cancellation to the matching managed run; do not restore redundant production cancellation state or invent untested pending behavior.

## User Impact

Pending, queued, and running CLI commands preserve first-cancellation and first-terminal behavior with fewer lifecycle branches. The complete change is six files, +85/-126 lines, and adds no configuration, protocol, provider, or external supervisor contract.

## Evidence

- Exact previously stalled owner suite: 104 CLI-spawn tests passed.
- Real-supervisor pending cancellation, cancellation reasons, queued cancellation, and registry: four files and 36 tests passed.
- Shared-fake sibling capture and Claude background-task coverage: two files and 69 tests passed.
- Child-adapter suite: 28 tests passed, including child close during pending secret-input delivery before wait registration.
- Total focused proof: 237 passing tests; no failing tests.
- Exact touched-file formatting and type-aware lint with type checking passed; git diff check passed.
- Fresh independent full-branch structured autoreview against current origin/main: clean; no accepted or actionable findings.
- AI-assisted; no raw session transcript or credentials included.