### PR TITLE
refactor(gateway): remove duplicate cron shutdown paths

### DIFF
--- a/src/gateway/server-cron-lazy.ts
+++ b/src/gateway/server-cron-lazy.ts
@@ -136,7 +136,6 @@ export function createLazyGatewayCronState(params: LazyGatewayCronParams): Gatew
           resolved.phase = "stopped";
           resolved.underlyingStarted = false;
           resolved.state.cron.stop();
-          resolved.state.stopExitWatchers?.();
           await resolved.state.stopStreamWatchers?.();
           return;
         }
@@ -161,7 +160,6 @@ export function createLazyGatewayCronState(params: LazyGatewayCronParams): Gatew
           resolved.phase = "stopped";
           resolved.underlyingStarted = false;
           resolved.state.cron.stop();
-          resolved.state.stopExitWatchers?.();
           await resolved.state.stopStreamWatchers?.();
           return;
         }
@@ -185,8 +183,6 @@ export function createLazyGatewayCronState(params: LazyGatewayCronParams): Gatew
         loaded.phase = "stopped";
         loaded.underlyingStarted = false;
         loaded.state.cron.stop();
-        loaded.state.stopExitWatchers?.();
-        void loaded.state.stopStreamWatchers?.().catch(() => {});
         return;
       }
       const loading = cronStateLoader.peek();
@@ -201,8 +197,6 @@ export function createLazyGatewayCronState(params: LazyGatewayCronParams): Gatew
             resolved.phase = "stopped";
             resolved.underlyingStarted = false;
             resolved.state.cron.stop();
-            resolved.state.stopExitWatchers?.();
-            void resolved.state.stopStreamWatchers?.().catch(() => {});
           })
           .catch(() => {});
       }
@@ -221,7 +215,6 @@ export function createLazyGatewayCronState(params: LazyGatewayCronParams): Gatew
         await resolved.state.cron.stopAndDrain();
       } else {
         resolved.state.cron.stop();
-        resolved.state.stopExitWatchers?.();
         await resolved.state.stopStreamWatchers?.();
       }
     },

--- a/src/gateway/server-cron.ts
+++ b/src/gateway/server-cron.ts
@@ -1346,46 +1346,41 @@ export function buildGatewayCronService(params: {
   const automationEpoch = claimSessionAutomationEpoch();
   const stopCron = cron.stop.bind(cron);
   cron.stop = () => {
-    stopCron();
-    stopExitWatchers();
-    stopHeartbeatReconcileRetry();
-    void stopStreamWatchers().catch((err: unknown) => {
-      cronLogger.warn(
-        { err: formatErrorMessage(err) },
-        "cron-stream: asynchronous teardown failed",
-      );
-    });
-    // Session rows must stop reporting automation from a stopped scheduler,
-    // but a reload's replacement service may already own the registration.
-    unregisterSessionAutomationSource(automationSource);
-  };
-  cron.stopAndDrain = async () => {
     try {
       stopCron();
       stopExitWatchers();
       stopHeartbeatReconcileRetry();
-      const streamWatchersStop = stopStreamWatchers().then(
-        () => ({ ok: true as const }),
-        (error: unknown) => ({ ok: false as const, error }),
-      );
-      const abortedRuns = abortActiveCronTaskRuns("Gateway shutting down.");
-      const [activeRunDrain, streamWatchersResult] = await Promise.all([
-        waitForActiveCronTaskRuns(CRON_ACTIVE_RUN_SHUTDOWN_DRAIN_MS),
-        streamWatchersStop,
-      ]);
-      if (!activeRunDrain.drained) {
+      void stopStreamWatchers().catch((err: unknown) => {
         cronLogger.warn(
-          { abortedRuns, activeRuns: activeRunDrain.active },
-          "cron: active runs did not drain before shutdown timeout",
+          { err: formatErrorMessage(err) },
+          "cron-stream: asynchronous teardown failed",
         );
-      }
-      if (!streamWatchersResult.ok) {
-        throw streamWatchersResult.error;
-      }
+      });
     } finally {
-      // A failed drain still stops this source; owner comparison protects a
-      // replacement that registered while the old watchers were settling.
+      // Session rows must stop reporting automation from a stopped scheduler,
+      // but a reload's replacement service may already own the registration.
       unregisterSessionAutomationSource(automationSource);
+    }
+  };
+  cron.stopAndDrain = async () => {
+    cron.stop();
+    const streamWatchersStop = stopStreamWatchers().then(
+      () => ({ ok: true as const }),
+      (error: unknown) => ({ ok: false as const, error }),
+    );
+    const abortedRuns = abortActiveCronTaskRuns("Gateway shutting down.");
+    const [activeRunDrain, streamWatchersResult] = await Promise.all([
+      waitForActiveCronTaskRuns(CRON_ACTIVE_RUN_SHUTDOWN_DRAIN_MS),
+      streamWatchersStop,
+    ]);
+    if (!activeRunDrain.drained) {
+      cronLogger.warn(
+        { abortedRuns, activeRuns: activeRunDrain.active },
+        "cron: active runs did not drain before shutdown timeout",
+      );
+    }
+    if (!streamWatchersResult.ok) {
+      throw streamWatchersResult.error;
     }
   };
   // Reconciliations serialize on one tail and only the latest requested epoch

--- a/ui/src/pages/config/memory-overview.test.ts
+++ b/ui/src/pages/config/memory-overview.test.ts
@@ -110,7 +110,7 @@ describe("renderMemoryOverview", () => {
     expect(container.textContent).toContain("Memory is hibernating");
     expect(container.textContent).toContain("Open Settings");
     expect(container.querySelector(".memory-overview__hero--sleeping")).not.toBeNull();
-    expect(container.querySelector(".lob-eye-peek")).not.toBeNull();
+    expect(container.querySelector(".lobster-pet__svg")).not.toBeNull();
     expect(container.querySelector(".lob-reading-book")).toBeNull();
   });
 


### PR DESCRIPTION
Related: #115316

## What Problem This Solves

Gateway cron shutdown stopped the same exit and stream watchers repeatedly from both the scheduler owner and its lazy wrapper. Failed synchronous teardown could also skip automation-source cleanup. Hosted exact-head CI additionally exposed a pre-existing randomized memory-overview test that assumed every legitimate mascot palette includes a decorative peek eye.

## Why This Change Was Made

Make cron.stop the single synchronous shutdown owner, unregister its automation source in finally, reuse the existing memoized stream teardown in stopAndDrain, and remove seven redundant lazy-wrapper watcher stops. Stabilize the unrelated main-branch CI blocker at its actual test boundary: assert the real mascot SVG rather than a palette-specific eye. Sleeping state and the absence of an awake reading book remain explicit; deterministic eye behavior remains covered by the seeded mascot-owner test.

## User Impact

Scheduler shutdown, reload and cancellation preserve their existing drain, retry and replacement-owner guarantees with 12 fewer production lines and no public interface, persistent configuration or storage changes. Valid randomly selected sleeping mascot variants no longer fail unrelated hosted test runs. No production UI code changes.

## Evidence

- 19 tests passed across canonical failed-drain and lazy shutdown regressions.
- 57 memory-overview and deterministic seeded-mascot tests passed, including the original sleeping-eye owner regression.
- 12 additional independent randomly seeded page-load stress runs passed: 72 passing overview regressions.
- Existing overlap coverage confirms stop and stopAndDrain await the exact same memoized watcher promise.
- Existing failed-drain retry and replacement-owner regressions preserved.
- Reproduced the exact failing hosted assertion against unchanged main and verified the same shard succeeds on three independent cleanup branches and current main.
- Exact changed UI test passed type-aware, type-checking oxlint.
- Exact three-file formatting and git diff check passed.
- Fresh independent structured autoreview of the complete three-file branch: clean, 0.97 confidence.
- AI-assisted; no raw session transcript or credentials included.