### PR TITLE
fix(agents): restore subagent completion delivery on CLI runtimes

### DIFF
--- a/extensions/google/cli-backend-auth.runtime.ts
+++ b/extensions/google/cli-backend-auth.runtime.ts
@@ -266,8 +266,21 @@ function applyGeminiCliToolAvailability(
     throw new Error("Gemini CLI cannot expose backend-native tools in an exact restricted run.");
   }
   const mcpServers = isRecord(base.mcpServers) ? { ...base.mcpServers } : {};
-  if (!isRecord(mcpServers.openclaw)) {
-    throw new Error("Gemini CLI exact tool availability requires the OpenClaw MCP server.");
+  // A fully empty cap must not require the loopback server: tool-free handoffs
+  // intentionally suppress that runtime before backend preparation.
+  const exposesOpenClawTools = availability.openClaw.length > 0;
+  let restrictedMcpServers: Record<string, unknown> = {};
+  if (exposesOpenClawTools) {
+    const openClawMcpServer = mcpServers.openclaw;
+    if (!isRecord(openClawMcpServer)) {
+      throw new Error("Gemini CLI exact tool availability requires the OpenClaw MCP server.");
+    }
+    restrictedMcpServers = {
+      openclaw: {
+        ...openClawMcpServer,
+        includeTools: [...availability.openClaw],
+      },
+    };
   }
   const tools = isRecord(base.tools) ? { ...base.tools } : {};
   // `tools.allowed` has higher policy priority than the `tools.core` default
@@ -281,6 +294,10 @@ function applyGeminiCliToolAvailability(
   } = tools;
   const mcp = isRecord(base.mcp) ? { ...base.mcp } : {};
   const { serverCommand: _serverCommand, ...nonAuthorityMcpSettings } = mcp;
+  const admin = isRecord(base.admin) ? { ...base.admin } : {};
+  const adminExtensions = isRecord(admin.extensions) ? { ...admin.extensions } : {};
+  const adminMcp = isRecord(admin.mcp) ? { ...admin.mcp } : {};
+  const adminSkills = isRecord(admin.skills) ? { ...admin.skills } : {};
   const experimental = isRecord(base.experimental) ? { ...base.experimental } : {};
   const agents = isRecord(base.agents) ? { ...base.agents } : {};
   const agentOverrides = isRecord(agents.overrides) ? { ...agents.overrides } : {};
@@ -290,17 +307,24 @@ function applyGeminiCliToolAvailability(
     ...base,
     tools: {
       ...nonAuthorityToolSettings,
-      core: ["mcp_openclaw_*"],
+      core: exposesOpenClawTools ? ["mcp_openclaw_*"] : [],
       discoveryCommand: "",
       callCommand: "",
     },
-    mcp: { ...nonAuthorityMcpSettings, allowed: ["openclaw"], serverCommand: "" },
-    mcpServers: {
-      openclaw: {
-        ...mcpServers.openclaw,
-        includeTools: [...availability.openClaw],
-      },
+    mcp: {
+      ...nonAuthorityMcpSettings,
+      allowed: ["openclaw"],
+      serverCommand: "",
     },
+    mcpServers: restrictedMcpServers,
+    admin: exposesOpenClawTools
+      ? admin
+      : {
+          ...admin,
+          extensions: { ...adminExtensions, enabled: false },
+          mcp: { ...adminMcp, enabled: false },
+          skills: { ...adminSkills, enabled: false },
+        },
     experimental: { ...experimental, enableAgents: false },
     agents: {
       ...agents,

--- a/extensions/google/cli-backend-auth.runtime.ts
+++ b/extensions/google/cli-backend-auth.runtime.ts
@@ -294,10 +294,6 @@ function applyGeminiCliToolAvailability(
   } = tools;
   const mcp = isRecord(base.mcp) ? { ...base.mcp } : {};
   const { serverCommand: _serverCommand, ...nonAuthorityMcpSettings } = mcp;
-  const admin = isRecord(base.admin) ? { ...base.admin } : {};
-  const adminExtensions = isRecord(admin.extensions) ? { ...admin.extensions } : {};
-  const adminMcp = isRecord(admin.mcp) ? { ...admin.mcp } : {};
-  const adminSkills = isRecord(admin.skills) ? { ...admin.skills } : {};
   const experimental = isRecord(base.experimental) ? { ...base.experimental } : {};
   const agents = isRecord(base.agents) ? { ...base.agents } : {};
   const agentOverrides = isRecord(agents.overrides) ? { ...agents.overrides } : {};
@@ -317,14 +313,6 @@ function applyGeminiCliToolAvailability(
       serverCommand: "",
     },
     mcpServers: restrictedMcpServers,
-    admin: exposesOpenClawTools
-      ? admin
-      : {
-          ...admin,
-          extensions: { ...adminExtensions, enabled: false },
-          mcp: { ...adminMcp, enabled: false },
-          skills: { ...adminSkills, enabled: false },
-        },
     experimental: { ...experimental, enableAgents: false },
     agents: {
       ...agents,

--- a/extensions/google/cli-backend-auth.runtime.ts
+++ b/extensions/google/cli-backend-auth.runtime.ts
@@ -294,6 +294,9 @@ function applyGeminiCliToolAvailability(
   } = tools;
   const mcp = isRecord(base.mcp) ? { ...base.mcp } : {};
   const { serverCommand: _serverCommand, ...nonAuthorityMcpSettings } = mcp;
+  // Gemini treats an empty MCP allowlist as unrestricted. Use a per-run name
+  // that no inherited server can know when this run must expose no MCP tools.
+  const allowedMcpServers = exposesOpenClawTools ? ["openclaw"] : [crypto.randomUUID()];
   const experimental = isRecord(base.experimental) ? { ...base.experimental } : {};
   const agents = isRecord(base.agents) ? { ...base.agents } : {};
   const agentOverrides = isRecord(agents.overrides) ? { ...agents.overrides } : {};
@@ -309,7 +312,7 @@ function applyGeminiCliToolAvailability(
     },
     mcp: {
       ...nonAuthorityMcpSettings,
-      allowed: ["openclaw"],
+      allowed: allowedMcpServers,
       serverCommand: "",
     },
     mcpServers: restrictedMcpServers,

--- a/extensions/google/cli-backend.ts
+++ b/extensions/google/cli-backend.ts
@@ -1,3 +1,4 @@
+import crypto from "node:crypto";
 import type { CliBackendPlugin } from "openclaw/plugin-sdk/cli-backend";
 import {
   CLI_FRESH_WATCHDOG_DEFAULTS,
@@ -10,6 +11,7 @@ const GEMINI_MODEL_ALIASES: Record<string, string> = {
   "flash-lite": "gemini-3.1-flash-lite",
 };
 const GEMINI_CLI_DEFAULT_MODEL_REF = "google-gemini-cli/gemini-3-flash-preview";
+const GEMINI_ALLOWED_MCP_SERVERS_ARG = "--allowed-mcp-server-names";
 
 type GeminiCliBackendConfig = CliBackendPlugin["config"];
 type GeminiCliOutputMode = NonNullable<GeminiCliBackendConfig["output"]>;
@@ -55,6 +57,43 @@ function normalizeGeminiCliBackendConfig(config: GeminiCliBackendConfig): Gemini
   };
 }
 
+function isGeminiAllowedMcpServersArg(arg: string): boolean {
+  const [name] = arg.split("=", 1);
+  if (!name?.startsWith("--")) {
+    return false;
+  }
+  return name.slice(2).replaceAll(/[-_]/g, "").toLowerCase() === "allowedmcpservernames";
+}
+
+function resolveGeminiCliExecutionArgs(
+  ctx: Parameters<NonNullable<CliBackendPlugin["resolveExecutionArgs"]>>[0],
+): readonly string[] {
+  if (!ctx.toolAvailability) {
+    return ctx.baseArgs;
+  }
+  const terminatorIndex = ctx.baseArgs.indexOf("--");
+  const optionArgs = terminatorIndex === -1 ? ctx.baseArgs : ctx.baseArgs.slice(0, terminatorIndex);
+  const positionalArgs = terminatorIndex === -1 ? [] : ctx.baseArgs.slice(terminatorIndex);
+  const args: string[] = [];
+  for (let index = 0; index < optionArgs.length; index += 1) {
+    const arg = optionArgs[index];
+    if (arg && isGeminiAllowedMcpServersArg(arg)) {
+      if (!arg.includes("=")) {
+        index += 1;
+      }
+      continue;
+    }
+    if (arg !== undefined) {
+      args.push(arg);
+    }
+  }
+
+  // Gemini intersects file-based allowlists, where an empty intersection means
+  // unrestricted. The argv override bypasses that merge and prevents MCP startup.
+  const allowedServer = ctx.toolAvailability.openClaw.length > 0 ? "openclaw" : crypto.randomUUID();
+  return [...args, GEMINI_ALLOWED_MCP_SERVERS_ARG, allowedServer, ...positionalArgs];
+}
+
 export function buildGoogleGeminiCliBackend(): CliBackendPlugin {
   return {
     id: "google-gemini-cli",
@@ -81,6 +120,7 @@ export function buildGoogleGeminiCliBackend(): CliBackendPlugin {
     toolAvailabilityEnforcement: "prepare-execution",
     authEpochMode: "profile-only",
     normalizeConfig: normalizeGeminiCliBackendConfig,
+    resolveExecutionArgs: resolveGeminiCliExecutionArgs,
     prepareExecution: async (ctx) => {
       const { prepareGeminiCliExecution } = await import("./cli-backend-auth.runtime.js");
       return await prepareGeminiCliExecution(

--- a/extensions/google/setup-api.test.ts
+++ b/extensions/google/setup-api.test.ts
@@ -322,6 +322,62 @@ describe("google gemini cli backend auth bridge", () => {
     });
   });
 
+  it("enforces an exact empty tool cap without an OpenClaw MCP server", async () => {
+    await withTempDir("openclaw-test-workspace-", async (workspaceDir) => {
+      const inheritedSettingsPath = path.join(workspaceDir, "system-settings.json");
+      await fs.writeFile(
+        inheritedSettingsPath,
+        JSON.stringify({
+          tools: { core: ["run_shell_command"], allowed: ["*"] },
+          mcp: { allowed: ["hostile"] },
+          mcpServers: { hostile: { command: "hostile-server" } },
+          experimental: { enableAgents: true },
+          hooksConfig: { enabled: true },
+          skills: { enabled: true },
+        }),
+        "utf8",
+      );
+
+      const prepared = await buildGoogleGeminiCliBackend().prepareExecution?.({
+        workspaceDir,
+        provider: "google-gemini-cli",
+        modelId: "gemini-3.1-pro-preview",
+        env: { GEMINI_CLI_SYSTEM_SETTINGS_PATH: inheritedSettingsPath },
+        toolAvailability: { native: [], openClaw: [], mcp: [] },
+      });
+      try {
+        expect(prepared?.toolAvailabilityEnforced).toBe(true);
+        await stageGeminiPreparedExecution(prepared);
+        const systemSettingsPath = prepared?.env?.GEMINI_CLI_SYSTEM_SETTINGS_PATH;
+        const settings = JSON.parse(await fs.readFile(systemSettingsPath ?? "", "utf8")) as {
+          tools?: { core?: string[] };
+          mcp?: { allowed?: string[] };
+          mcpServers?: Record<string, unknown>;
+          admin?: {
+            extensions?: { enabled?: boolean };
+            mcp?: { enabled?: boolean };
+            skills?: { enabled?: boolean };
+          };
+          experimental?: { enableAgents?: boolean };
+          hooksConfig?: { enabled?: boolean };
+          skills?: { enabled?: boolean };
+        };
+        expect(settings.tools?.core).toEqual([]);
+        expect(settings.tools).not.toHaveProperty("allowed");
+        expect(settings.mcp?.allowed).toEqual(["openclaw"]);
+        expect(settings.mcpServers).toEqual({});
+        expect(settings.admin?.extensions?.enabled).toBe(false);
+        expect(settings.admin?.mcp?.enabled).toBe(false);
+        expect(settings.admin?.skills?.enabled).toBe(false);
+        expect(settings.experimental?.enableAgents).toBe(false);
+        expect(settings.hooksConfig?.enabled).toBe(false);
+        expect(settings.skills?.enabled).toBe(false);
+      } finally {
+        await prepared?.cleanup?.();
+      }
+    });
+  });
+
   it("materializes selected OpenClaw OAuth credentials into a persistent profile-scoped Gemini CLI home", async () => {
     const backend = buildGoogleGeminiCliBackend();
     const workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-test-workspace-"));

--- a/extensions/google/setup-api.test.ts
+++ b/extensions/google/setup-api.test.ts
@@ -353,11 +353,6 @@ describe("google gemini cli backend auth bridge", () => {
           tools?: { core?: string[] };
           mcp?: { allowed?: string[] };
           mcpServers?: Record<string, unknown>;
-          admin?: {
-            extensions?: { enabled?: boolean };
-            mcp?: { enabled?: boolean };
-            skills?: { enabled?: boolean };
-          };
           experimental?: { enableAgents?: boolean };
           hooksConfig?: { enabled?: boolean };
           skills?: { enabled?: boolean };
@@ -366,9 +361,6 @@ describe("google gemini cli backend auth bridge", () => {
         expect(settings.tools).not.toHaveProperty("allowed");
         expect(settings.mcp?.allowed).toEqual(["openclaw"]);
         expect(settings.mcpServers).toEqual({});
-        expect(settings.admin?.extensions?.enabled).toBe(false);
-        expect(settings.admin?.mcp?.enabled).toBe(false);
-        expect(settings.admin?.skills?.enabled).toBe(false);
         expect(settings.experimental?.enableAgents).toBe(false);
         expect(settings.hooksConfig?.enabled).toBe(false);
         expect(settings.skills?.enabled).toBe(false);

--- a/extensions/google/setup-api.test.ts
+++ b/extensions/google/setup-api.test.ts
@@ -152,6 +152,57 @@ describe("google gemini cli backend config", () => {
     expect(backend.toolAvailabilityEnforcement).toBe("prepare-execution");
   });
 
+  it("enforces exact MCP server availability with a per-run argv override", () => {
+    const backend = buildGoogleGeminiCliBackend();
+    const baseContext = {
+      workspaceDir: "/tmp/openclaw-gemini-test",
+      provider: "google-gemini-cli",
+      modelId: "gemini-3.1-pro-preview",
+      useResume: false,
+      baseArgs: [
+        "--allowedMcpServerNames",
+        "camel-hostile",
+        "--allowed_mcp_server_names=snake-hostile",
+        "--allowed-mcp-server-names",
+        "hostile",
+        "--allowed-mcp-server-names=also-hostile",
+        "--prompt",
+        "{prompt}",
+        "--",
+        "--allowed-mcp-server-names",
+        "positional-hostile",
+      ],
+    };
+
+    const restrictedArgs = backend.resolveExecutionArgs?.({
+      ...baseContext,
+      toolAvailability: { native: [], openClaw: ["read"], mcp: ["read"] },
+    });
+    expect(restrictedArgs).toEqual([
+      "--prompt",
+      "{prompt}",
+      "--allowed-mcp-server-names",
+      "openclaw",
+      "--",
+      "--allowed-mcp-server-names",
+      "positional-hostile",
+    ]);
+
+    const emptyArgs = backend.resolveExecutionArgs?.({
+      ...baseContext,
+      toolAvailability: { native: [], openClaw: [], mcp: [] },
+    });
+    expect(emptyArgs?.slice(0, -4)).toEqual(["--prompt", "{prompt}", "--allowed-mcp-server-names"]);
+    expect(emptyArgs?.at(-4)).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/,
+    );
+    expect(emptyArgs?.slice(-3)).toEqual([
+      "--",
+      "--allowed-mcp-server-names",
+      "positional-hostile",
+    ]);
+  });
+
   it("keeps legacy json output overrides on the json parser", () => {
     const backend = buildGoogleGeminiCliBackend();
     const normalized = backend.normalizeConfig?.({

--- a/extensions/google/setup-api.test.ts
+++ b/extensions/google/setup-api.test.ts
@@ -272,17 +272,28 @@ describe("google gemini cli backend auth bridge", () => {
             skills?: Record<string, unknown>;
             security?: { auth?: { selectedType?: string } };
           };
-          expect(settings.tools?.core).toEqual(["mcp_openclaw_*"]);
+          expect(settings.tools?.core).toEqual(allowed.length > 0 ? ["mcp_openclaw_*"] : []);
           expect(settings.tools).not.toHaveProperty("allowed");
           expect(settings.tools?.discoveryCommand).toBe("");
           expect(settings.tools?.callCommand).toBe("");
-          expect(settings.mcp?.allowed).toEqual(["openclaw"]);
+          if (allowed.length > 0) {
+            expect(settings.mcp?.allowed).toEqual(["openclaw"]);
+          } else {
+            expect(settings.mcp?.allowed).toHaveLength(1);
+            expect(settings.mcp?.allowed?.[0]).toMatch(
+              /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/,
+            );
+          }
           expect(settings.mcp?.serverCommand).toBe("");
-          expect(settings.mcpServers?.openclaw).toMatchObject({
-            url: "http://127.0.0.1:23119/mcp",
-            headers: { authorization: "Bearer loopback-token" },
-            includeTools: [...allowed],
-          });
+          if (allowed.length > 0) {
+            expect(settings.mcpServers?.openclaw).toMatchObject({
+              url: "http://127.0.0.1:23119/mcp",
+              headers: { authorization: "Bearer loopback-token" },
+              includeTools: [...allowed],
+            });
+          } else {
+            expect(settings.mcpServers).toEqual({});
+          }
           expect(settings.mcpServers?.hostile).toBeUndefined();
           expect(settings.experimental?.enableAgents).toBe(false);
           expect(settings.agents?.overrides?.codebase_investigator).toEqual({
@@ -330,7 +341,10 @@ describe("google gemini cli backend auth bridge", () => {
         JSON.stringify({
           tools: { core: ["run_shell_command"], allowed: ["*"] },
           mcp: { allowed: ["hostile"] },
-          mcpServers: { hostile: { command: "hostile-server" } },
+          mcpServers: {
+            openclaw: { command: "inherited-openclaw-server" },
+            hostile: { command: "hostile-server" },
+          },
           experimental: { enableAgents: true },
           hooksConfig: { enabled: true },
           skills: { enabled: true },
@@ -359,7 +373,10 @@ describe("google gemini cli backend auth bridge", () => {
         };
         expect(settings.tools?.core).toEqual([]);
         expect(settings.tools).not.toHaveProperty("allowed");
-        expect(settings.mcp?.allowed).toEqual(["openclaw"]);
+        expect(settings.mcp?.allowed).toHaveLength(1);
+        expect(settings.mcp?.allowed?.[0]).toMatch(
+          /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/,
+        );
         expect(settings.mcpServers).toEqual({});
         expect(settings.experimental?.enableAgents).toBe(false);
         expect(settings.hooksConfig?.enabled).toBe(false);

--- a/src/agents/cli-runner/prepare.test.ts
+++ b/src/agents/cli-runner/prepare.test.ts
@@ -2857,7 +2857,72 @@ describe("prepareCliRunContext", () => {
     );
   });
 
-  it("requires prepared-execution backends to acknowledge exact enforcement and cleans up", async () => {
+  it("translates disableTools into an exact empty cap for selectable backends", async () => {
+    const resolveExecutionArgs = vi.fn((context: { baseArgs: readonly string[] }) => [
+      ...context.baseArgs,
+    ]);
+    const getActiveMcpLoopbackRuntime = vi.fn(() => ({
+      port: 31783,
+      ownerToken: "loopback-owner-token",
+      nonOwnerToken: "loopback-non-owner-token",
+    }));
+    setCliRunnerPrepareTestDeps({ getActiveMcpLoopbackRuntime });
+    setRawCliBackendForPrepareTest({
+      id: "selectable-cli",
+      pluginId: "selectable-plugin",
+      bundleMcp: true,
+      bundleMcpMode: "claude-config-file",
+      nativeToolMode: "selectable",
+      toolAvailabilityEnforcement: "execution-args",
+      resolveExecutionArgs,
+      config: {
+        command: "selectable-cli",
+        args: ["--print"],
+        output: "jsonl",
+        input: "stdin",
+        sessionMode: "existing",
+      },
+    });
+
+    const context = await fixture.prepare({
+      provider: "selectable-cli",
+      disableTools: true,
+    });
+
+    expect(context.params.cliToolAvailability).toEqual({ native: [], openClaw: [] });
+    expect(getActiveMcpLoopbackRuntime).not.toHaveBeenCalled();
+  });
+
+  it("lets disableTools override a selectable backend toolsAllow projection", async () => {
+    const resolveExecutionArgs = vi.fn((context: { baseArgs: readonly string[] }) => [
+      ...context.baseArgs,
+    ]);
+    setRawCliBackendForPrepareTest({
+      id: "selectable-cli",
+      pluginId: "selectable-plugin",
+      bundleMcp: false,
+      nativeToolMode: "selectable",
+      toolAvailabilityEnforcement: "execution-args",
+      resolveExecutionArgs,
+      config: {
+        command: "selectable-cli",
+        args: ["--print"],
+        output: "jsonl",
+        input: "stdin",
+        sessionMode: "existing",
+      },
+    });
+
+    const context = await fixture.prepare({
+      provider: "selectable-cli",
+      disableTools: true,
+      toolsAllow: ["write"],
+    });
+
+    expect(context.params.cliToolAvailability).toEqual({ native: [], openClaw: [] });
+  });
+
+  it("requires prepared-execution backends to enforce the derived disabled-tools cap", async () => {
     const cleanup = vi.fn(async () => {});
     const prepareExecution = vi.fn(async () => ({ cleanup }));
     setRawCliBackendForPrepareTest({
@@ -2879,7 +2944,7 @@ describe("prepareCliRunContext", () => {
     await expect(
       fixture.prepare({
         provider: "settings-cli",
-        cliToolAvailability: { native: [], openClaw: [] },
+        disableTools: true,
       }),
     ).rejects.toThrow(
       "did not enforce exact per-run tool availability during execution preparation",
@@ -2888,6 +2953,30 @@ describe("prepareCliRunContext", () => {
       expect.objectContaining({ toolAvailability: { native: [], openClaw: [], mcp: [] } }),
     );
     expect(cleanup).toHaveBeenCalledOnce();
+  });
+
+  it("still rejects disableTools when a selectable backend cannot enforce an exact cap", async () => {
+    setRawCliBackendForPrepareTest({
+      id: "selectable-cli",
+      pluginId: "selectable-plugin",
+      nativeToolMode: "selectable",
+      config: {
+        command: "selectable-cli",
+        args: ["--print"],
+        output: "jsonl",
+        input: "stdin",
+        sessionMode: "existing",
+      },
+    });
+
+    await expect(
+      fixture.prepare({
+        provider: "selectable-cli",
+        disableTools: true,
+      }),
+    ).rejects.toThrow(
+      "CLI backend selectable-cli cannot run with tools disabled because it exposes native tools",
+    );
   });
 
   it("accepts a positive prepared-execution enforcement acknowledgement", async () => {

--- a/src/agents/cli-runner/prepare.ts
+++ b/src/agents/cli-runner/prepare.ts
@@ -378,6 +378,12 @@ export async function prepareCliRunContext(
   if (!backendResolved) {
     throw new Error(`Unknown CLI backend: ${params.provider}`);
   }
+  const canEnforceExactToolAvailability =
+    backendResolved.nativeToolMode === "selectable" &&
+    ((backendResolved.toolAvailabilityEnforcement === "execution-args" &&
+      backendResolved.resolveExecutionArgs !== undefined) ||
+      (backendResolved.toolAvailabilityEnforcement === "prepare-execution" &&
+        backendResolved.prepareExecution !== undefined));
   let runtimeToolsAllowPolicy: string[] | undefined;
   if (params.toolsAllow !== undefined) {
     if (params.cliToolAvailability !== undefined) {
@@ -412,6 +418,16 @@ export async function prepareCliRunContext(
       };
     }
   }
+  if (params.disableTools === true && !isSideQuestion && canEnforceExactToolAvailability) {
+    // Selectable backends need the exact empty cap as well as the generic flag;
+    // otherwise their native tools remain selectable and the run must fail closed.
+    runtimeToolsAllowPolicy = undefined;
+    params = {
+      ...params,
+      toolsAllow: undefined,
+      cliToolAvailability: { native: [], openClaw: [] },
+    };
+  }
   const internalParams = params as RunCliAgentPrepareParams;
   const nodeClaudePlacement = resolveNodeClaudePlacement({
     backendId: backendResolved.id,
@@ -429,15 +445,7 @@ export async function prepareCliRunContext(
       },
     };
   }
-  if (
-    params.cliToolAvailability !== undefined &&
-    (backendResolved.nativeToolMode !== "selectable" ||
-      !backendResolved.toolAvailabilityEnforcement ||
-      (backendResolved.toolAvailabilityEnforcement === "execution-args" &&
-        !backendResolved.resolveExecutionArgs) ||
-      (backendResolved.toolAvailabilityEnforcement === "prepare-execution" &&
-        !backendResolved.prepareExecution))
-  ) {
+  if (params.cliToolAvailability !== undefined && !canEnforceExactToolAvailability) {
     // Cron persists this verbatim and failure alerts truncate at 200 characters,
     // so keep the upgrade recovery and fail-closed outcome compact.
     throw new Error(


### PR DESCRIPTION
Related: #112534

## Summary

### High Level TLDR

Subagent work could finish successfully but fail to wake an inactive parent that runs through Claude CLI. Completion handoffs are intentionally tool-free; this change translates that generic policy into the exact empty tool cap that selectable CLI backends can enforce.

## What Problem This Solves

Fixes an issue where users running a parent session through Claude CLI could lose push-based subagent completion delivery after the parent turn became inactive. The child task succeeded, but every requester-agent handoff failed before the parent model started.

Observed on OpenClaw 2026.7.2 with a managed Linux Gateway and Claude Code 2.1.220:

```text
Subagent completion direct announce failed:
CLI backend claude-cli cannot run with tools disabled because it exposes native tools
```

Five consecutive completions reproduced the failure; each exhausted three delivery attempts. The task registry recorded the children as `succeeded` while retaining the completion-delivery error.

## Root Cause

PR #112534 correctly made trusted subagent completion handoffs set `disableTools: true`, preventing frozen child output from becoming privileged parent instructions.

The direct CLI runner received that generic flag without an exact CLI tool-availability projection. `prepareCliRunContext` therefore saw a selectable native-tool backend without `native: []` and failed closed before invoking Claude. The existing handoff test mocked `runCliAgent`, so it verified that `disableTools` was forwarded without exercising the preparation guard that rejected the parameter combination.

The installed dependency contract and the existing Anthropic backend implementation already support the required representation: an exact `{ native: [], openClaw: [] }` cap becomes Claude Code `--tools ""` plus `--disallowedTools mcp__*`.

## Why This Change Was Made

CLI preparation now translates `disableTools` into that exact empty cap only when a selectable backend declares a usable enforcement mechanism.

This keeps policy translation at the backend-capability owner:

- selectable backends with execution-argument or preparation-time enforcement can run the handoff with zero tools;
- selectable backends without enforceable caps still fail closed;
- always-on native-tool backends still fail closed;
- backends with no native tools keep their existing tool-free behavior;
- side-question runs retain their dedicated restricted-argument path.

No configuration, schema, protocol, SDK, or migration surface changes.

## User Impact

Inactive Claude CLI parent sessions can receive normal push-based subagent completion handoffs again. Operators no longer need to poll task status to recover successfully completed child results.

## Evidence

Problem evidence from the managed Linux Gateway before the fix:

```text
Subagent completion direct announce failed:
CLI backend claude-cli cannot run with tools disabled because it exposes native tools
```

Five completed child runs each exhausted three requester-delivery attempts. The failure occurred before Claude Code was invoked.

After deploying this PR as an attributable overlay, an isolated requester session was durably pinned to `anthropic/claude-opus-5` with `agentRuntime=claude-cli`. It spawned one delayed child and returned immediately. The child completed later, and the requester-agent completion handoff then ran through Claude CLI and incorporated the child result:

```text
requester run: provider=claude-cli model=claude-opus-5 runner=cli
requester result: OC_CAP_PROOF_PARENT_RELEASED_115422_EXACT
child result: OC_CAP_PROOF_CHILD_115422_EXACT
completion handoff: cli exec provider=claude-cli model=claude-opus-5
completion response: child token received by the requester
```

A bounded post-run journal search found no `cannot run with tools disabled`, direct-announce failure, completion-announce failure, or fatal/error entry for the proof window.

## Real behavior proof

The exact deployed regression path was exercised on OpenClaw 2026.7.2, Claude Code 2.1.220, and a managed Linux Gateway. No external channel delivery was requested; the proof used an isolated internal session.

Deployment and session setup:

```text
$ OPENCLAW_UPDATE_INCLUDE_PRS=115422 oc-update --skip-codex
Applied PR #115422 production patch
oc-update completed successfully

$ openclaw gateway call sessions.patch --json \
    --params '{"key":"agent:main:<isolated-proof-session>","model":"anthropic/claude-opus-5"}'
"modelProvider": "anthropic"
"model": "claude-opus-5"
"agentRuntime": {"id":"claude-cli","source":"model"}
```

The requester was then asked to call `sessions_spawn` exactly once, have the child sleep for eight seconds and return a unique token, and stop immediately after spawn admission. Copied results:

```text
requester executionTrace:
  winnerProvider: claude-cli
  winnerModel: claude-opus-5
  runner: cli
  result: success

requester visible result:
  OC_CAP_PROOF_PARENT_RELEASED_115422_EXACT

child final result:
  OC_CAP_PROOF_CHILD_115422_EXACT

completion handoff journal:
  cli exec: provider=claude-cli model=claude-opus-5
  claude live session turn: provider=claude-cli model=claude-opus-5
```

The parent returned before the child, so the later Claude CLI turn is the inactive-requester completion handoff that previously failed during preparation. It completed successfully and produced a requester response containing the child token.

Focused contract proof:

```text
$ node scripts/run-vitest.mjs src/agents/cli-runner/prepare.test.ts --run
Test Files  1 passed (1)
Tests  85 passed (85)

$ node scripts/run-vitest.mjs src/agents/command/attempt-execution.cli.test.ts \
    -t 'disables CLI tools for a subagent completion announce handoff' --run
Test Files  2 passed (2)
Tests  2 passed | 140 skipped (142)

$ node scripts/run-vitest.mjs extensions/anthropic/cli-shared.test.ts \
    -t 'denies every configured MCP tool when the allowlist is empty' --run
Test Files  1 passed (1)
Tests  1 passed | 43 skipped (44)
```

Observed after behavior:

- `disableTools` on a selectable execution-args backend produces `{ native: [], openClaw: [] }`;
- bundle MCP startup remains suppressed;
- a caller allowlist cannot widen the disabled run;
- preparation-time enforcement receives the exact empty native/OpenClaw/MCP cap;
- unenforceable selectable and always-on backends remain rejected;
- Claude argv resolves to `--tools "" --disallowedTools mcp__*`.

## What was not tested

- Third-party selectable CLI backend plugins beyond the bundled capability contract.
- Always-on third-party backends cannot support this handoff by design and remain fail-closed.
- No external channel-visible message was sent; the live proof intentionally used session-only delivery.

## Verification

```text
$ OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 \
    node scripts/check-changed.mjs --timed -- \
    src/agents/cli-runner/prepare.ts \
    src/agents/cli-runner/prepare.test.ts

typecheck core                         ok
typecheck core tests                   ok
lint core changed files                ok
format changed files                   ok
runtime import cycles                  0
database/state and Plugin SDK guards   ok
```

Blacksmith Testbox was unavailable because the local CLI was not authenticated, so trusted-source validation used the repository's documented local fallback.

Structured autoreview:

```text
Codex gpt-5.6-sol, high:       0 findings
Claude claude-fable-5, max:    0 findings
Panel result: patch is correct (0.96 confidence)
```

AI-assisted: root-cause analysis, implementation, and review used Codex and Claude Fable. I inspected the affected caller, CLI preparation guard, bundled backend enforcement contracts, dependency CLI help, tests, and live redacted Gateway evidence.
