### PR TITLE
fix: keep provider ranking in startup catalogs

### DIFF
--- a/src/agents/model-catalog-order.ts
+++ b/src/agents/model-catalog-order.ts
@@ -8,6 +8,7 @@ import type { ModelCatalogEntry } from "./model-catalog.types.js";
 export function assignProviderModelOrder(
   entries: readonly ModelCatalogEntry[],
   existingEntries: readonly ModelCatalogEntry[] = [],
+  options: { appendUnknown?: boolean } = {},
 ): ModelCatalogEntry[] {
   const orderByModel = new Map<string, number>();
   const nextOrderByProvider = new Map<string, number>();
@@ -29,6 +30,9 @@ export function assignProviderModelOrder(
     const existingOrder = orderByModel.get(key);
     if (existingOrder !== undefined) {
       return { ...entry, providerOrder: existingOrder };
+    }
+    if (options.appendUnknown === false) {
+      return entry;
     }
     const providerOrder = nextOrderByProvider.get(provider) ?? 0;
     nextOrderByProvider.set(provider, providerOrder + 1);

--- a/src/agents/model-catalog.test.ts
+++ b/src/agents/model-catalog.test.ts
@@ -112,6 +112,18 @@ describe("prepared model catalog builder", () => {
     expect(snapshot.routeVariants).toEqual(snapshot.entries);
   });
 
+  it("keeps unranked registry rows in deterministic model-id order", async () => {
+    const snapshot = await build({
+      entries: [
+        { id: "model-b", name: "Model B", provider: "demo" },
+        { id: "model-a", name: "Model A", provider: "demo" },
+      ],
+    });
+
+    expect(snapshot.entries.map((entry) => entry.id)).toEqual(["model-a", "model-b"]);
+    expect(snapshot.entries.every((entry) => entry.providerOrder === undefined)).toBe(true);
+  });
+
   it("keeps account-denied runtime models out of the prepared catalog", async () => {
     const config: OpenClawConfig = { plugins: { enabled: false } };
     const runtimeManifest = providerManifestSnapshot({

--- a/src/agents/model-catalog.test.ts
+++ b/src/agents/model-catalog.test.ts
@@ -153,6 +153,30 @@ describe("prepared model catalog builder", () => {
     ]);
   });
 
+  it("ranks runtime registry rows from the manifest without augmentation", async () => {
+    const snapshot = await build({
+      entries: [
+        { id: "gpt-5.4", name: "GPT-5.4", provider: "openai" },
+        { id: "gpt-5.6-luna", name: "GPT-5.6 Luna", provider: "openai" },
+        { id: "gpt-5.6-sol", name: "GPT-5.6 Sol", provider: "openai" },
+        { id: "gpt-5.6-terra", name: "GPT-5.6 Terra", provider: "openai" },
+      ],
+      metadataSnapshot: providerManifestSnapshot({
+        provider: "openai",
+        discovery: "runtime",
+        modelIds: ["gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna", "gpt-5.4"],
+      }),
+      includeProviderPluginAugmentation: false,
+    });
+
+    expect(snapshot.entries.map((entry) => entry.id)).toEqual([
+      "gpt-5.6-sol",
+      "gpt-5.6-terra",
+      "gpt-5.6-luna",
+      "gpt-5.4",
+    ]);
+  });
+
   it("canonicalizes manifest-owned provider aliases in registry rows", async () => {
     const snapshot = await build({
       entries: [
@@ -230,6 +254,47 @@ describe("prepared model catalog builder", () => {
     ]);
   });
 
+  it("keeps manifest rank for configured runtime models absent from the registry", async () => {
+    mocks.augmentModelCatalogWithProviderPlugins.mockResolvedValueOnce([
+      { id: "gpt-5.4", name: "GPT-5.4", provider: "openai" },
+      { id: "gpt-5.6-sol", name: "GPT-5.6 Sol", provider: "openai" },
+    ]);
+
+    const snapshot = await build({
+      config: {
+        plugins: { enabled: false },
+        models: {
+          providers: {
+            openai: {
+              api: "openai-responses",
+              baseUrl: "https://api.openai.com/v1",
+              models: [
+                {
+                  id: "gpt-5.6-sol",
+                  name: "Configured GPT-5.6 Sol",
+                  contextWindow: 1_050_000,
+                  maxTokens: 128_000,
+                  reasoning: true,
+                  input: ["text", "image"],
+                  cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+                },
+              ],
+            },
+          },
+        },
+      },
+      entries: [{ id: "gpt-5.4", name: "GPT-5.4", provider: "openai" }],
+      metadataSnapshot: providerManifestSnapshot({
+        provider: "openai",
+        discovery: "runtime",
+        modelIds: ["gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna", "gpt-5.4"],
+      }),
+      readOnly: false,
+    });
+
+    expect(snapshot.entries.map((entry) => entry.id)).toEqual(["gpt-5.6-sol", "gpt-5.4"]);
+  });
+
   it("preserves explicitly configured runtime-provider models", async () => {
     mocks.augmentModelCatalogWithProviderPlugins.mockResolvedValueOnce([
       {
@@ -276,8 +341,8 @@ describe("prepared model catalog builder", () => {
     });
 
     expect(snapshot.entries.map((entry) => `${entry.provider}/${entry.id}`)).toEqual([
-      "openai/gpt-5.4",
       "openai/gpt-5.5",
+      "openai/gpt-5.4",
     ]);
     expect(snapshot.routeVariants).toEqual(
       expect.arrayContaining([

--- a/src/agents/model-catalog.ts
+++ b/src/agents/model-catalog.ts
@@ -534,7 +534,9 @@ export async function buildPreparedModelCatalogSnapshot(
     // Gateway startup may publish registry rows without runtime augmentation.
     // Rank them here so both static startup and later live enrichment preserve
     // provider-owned order instead of falling back to model-id sorting.
-    const orderedRegistryModels = assignProviderModelOrder(models, declaredManifestModels);
+    const orderedRegistryModels = assignProviderModelOrder(models, declaredManifestModels, {
+      appendUnknown: false,
+    });
     models.splice(0, models.length, ...orderedRegistryModels);
     mergeCatalogRouteVariants(routeVariants, orderedRegistryModels);
     const supplementalManifestPlan = planEffectiveModelCatalogRows({

--- a/src/agents/model-catalog.ts
+++ b/src/agents/model-catalog.ts
@@ -471,6 +471,11 @@ export async function buildPreparedModelCatalogSnapshot(
     const { buildShouldSuppressBuiltInModel } = await loadModelSuppression();
     logStage("catalog-deps-ready");
     const entries = params.modelRegistry.getAll() as DiscoveredModel[];
+    const declaredManifestModels = loadManifestModelCatalog({
+      config: cfg,
+      env,
+      metadataSnapshot: manifestMetadataSnapshot,
+    });
     logStage("registry-read", `entries=${entries.length}`);
 
     const shouldSuppressBuiltInModel = buildShouldSuppressBuiltInModel({ config: cfg });
@@ -525,8 +530,13 @@ export async function buildPreparedModelCatalogSnapshot(
         compat,
       } satisfies ModelCatalogEntry;
       models.push(model);
-      mergeCatalogRouteVariants(routeVariants, [model]);
     }
+    // Gateway startup may publish registry rows without runtime augmentation.
+    // Rank them here so both static startup and later live enrichment preserve
+    // provider-owned order instead of falling back to model-id sorting.
+    const orderedRegistryModels = assignProviderModelOrder(models, declaredManifestModels);
+    models.splice(0, models.length, ...orderedRegistryModels);
+    mergeCatalogRouteVariants(routeVariants, orderedRegistryModels);
     const supplementalManifestPlan = planEffectiveModelCatalogRows({
       registry: {
         plugins: resolveEligibleManifestCatalogPlugins(manifestMetadataSnapshot, cfg),
@@ -544,11 +554,6 @@ export async function buildPreparedModelCatalogSnapshot(
     );
     // Runtime declarations describe possible models, not account entitlement.
     // Only live registry or refreshed rows may publish those provider models.
-    const declaredManifestModels = loadManifestModelCatalog({
-      config: cfg,
-      env,
-      metadataSnapshot: manifestMetadataSnapshot,
-    });
     const manifestModels = declaredManifestModels.filter((entry) =>
       supplementalManifestKeys.has(catalogEntryDedupeKey(entry.provider, entry.id)),
     );
@@ -636,10 +641,10 @@ export async function buildPreparedModelCatalogSnapshot(
         }
         // Manifest ranks are provider-owned policy. Live discovery enriches
         // those rows and appends unknown models without replacing the ranking.
-        const orderedSupplemental = assignProviderModelOrder(
-          normalizedSupplemental,
-          declaredManifestModels,
-        );
+        const orderedSupplemental = assignProviderModelOrder(normalizedSupplemental, [
+          ...declaredManifestModels,
+          ...models,
+        ]);
         mergeCatalogRouteVariants(routeVariants, orderedSupplemental);
         mergeCatalogEntries(models, orderedSupplemental);
       }


### PR DESCRIPTION
Related: #115380
Related: #115406

## What Problem This Solves

Fixes an issue where the authenticated Control UI still showed alphabetic OpenAI ordering after #115406. Gateway startup intentionally publishes a static registry catalog before live provider augmentation, and those registry rows had no provider rank, so Sol, Terra, and Luna were sorted by model ID below older models.

## Why This Change Was Made

Registry rows now receive manifest-owned ranks before the static startup snapshot is published. Later live enrichment retains both the full manifest rank map and any ranked registry-only rows, so configured models that appear after startup keep their declared placement too.

## User Impact

The startup catalog used by `chat.metadata` and `models.list` presents provider models strongest-first immediately after Gateway launch. OpenAI can place Sol, Terra, and Luna ahead of older/unranked rows without waiting for or depending on live augmentation order.

## Evidence

- Source-blind production validation on exact #115406 build `6beb6961c9a` showed Kimi fixed but both `chat.metadata` and `models.list` still returned OpenAI as Chat Latest, GPT-5.4/5.5, Luna, Sol, Terra.
- Blacksmith Testbox `tbx_01kyncrhr5te9pvrw2msa8ehbe`: 20 catalog tests and the 17-test gateway model-list file pass, including static startup without augmentation, configured runtime models absent from the initial registry, and deterministic legacy ordering for unranked rows.
- Testbox run: https://github.com/openclaw/openclaw/actions/runs/30403897593
- Targeted formatting passed.
- The first hosted CI attempt exposed two related fake-catalog expectations; the fix now ranks only manifest-known rows and leaves unknown rows on legacy model-ID order.
- Final Codex autoreview: clean after accepted lifecycle and unranked-order findings were fixed and regression-covered.

The sanitized before/after picker captures remain on #115380; this server-only follow-up makes the real startup response match that approved visual target.

AI-assisted: yes. I understand the lifecycle/ownership change and validated the static startup, live enrichment, configured-model, formatting, and review paths.
