### PR TITLE
fix(plugins): prevent provider metadata from stalling agent turns

### DIFF
--- a/src/agents/provider-attribution.test.ts
+++ b/src/agents/provider-attribution.test.ts
@@ -117,17 +117,27 @@ const providerEndpointPlugins = vi.hoisted(() => [
 ]);
 
 const providerMetadataState = vi.hoisted(() => ({
-  compatible: true,
+  defaultDiscoveryCompatible: true,
+  pluginIdScoped: false,
   snapshot: undefined as unknown,
 }));
+const loadPluginMetadataSnapshot = vi.hoisted(() =>
+  vi.fn(() => ({
+    owners: {
+      providerEndpoints: [],
+      providerRequests: new Map(),
+    },
+  })),
+);
 
 vi.mock("../plugins/current-plugin-metadata-snapshot.js", () => ({
   getCurrentPluginMetadataSnapshot: (params?: {
-    config?: unknown;
+    allowScopedSnapshot?: boolean;
     requireDefaultDiscoveryContext?: boolean;
   }) =>
-    params?.config !== undefined ||
-    (params?.requireDefaultDiscoveryContext && !providerMetadataState.compatible)
+    (providerMetadataState.pluginIdScoped && params?.allowScopedSnapshot !== true) ||
+    (params?.requireDefaultDiscoveryContext === true &&
+      !providerMetadataState.defaultDiscoveryCompatible)
       ? undefined
       : (providerMetadataState.snapshot ?? {
           owners: {
@@ -149,6 +159,10 @@ vi.mock("../plugins/current-plugin-metadata-snapshot.js", () => ({
             ),
           },
         }),
+}));
+
+vi.mock("../plugins/plugin-metadata-snapshot.js", () => ({
+  loadPluginMetadataSnapshot,
 }));
 
 import {
@@ -188,8 +202,10 @@ function listProviderAttributionPolicies(env: ProviderAttributionTestEnv) {
 
 describe("provider attribution", () => {
   afterEach(() => {
-    providerMetadataState.compatible = true;
+    providerMetadataState.defaultDiscoveryCompatible = true;
+    providerMetadataState.pluginIdScoped = false;
     providerMetadataState.snapshot = undefined;
+    loadPluginMetadataSnapshot.mockClear();
   });
 
   it("uses provider facts from the replacement plugin snapshot after reload", () => {
@@ -235,8 +251,8 @@ describe("provider attribution", () => {
     );
   });
 
-  it("rejects provider facts from a scoped current snapshot", () => {
-    providerMetadataState.compatible = false;
+  it("rejects provider facts from a plugin-id-scoped current snapshot", () => {
+    providerMetadataState.pluginIdScoped = true;
     providerMetadataState.snapshot = {
       owners: {
         providerEndpoints: [
@@ -252,6 +268,23 @@ describe("provider attribution", () => {
     };
 
     expect(resolveProviderEndpoint("https://scoped-only.example").endpointClass).toBe("custom");
+  });
+
+  it("reuses lifecycle provider facts without a default-discovery fallback", () => {
+    providerMetadataState.defaultDiscoveryCompatible = false;
+    providerMetadataState.snapshot = {
+      owners: {
+        providerEndpoints: [],
+        providerRequests: new Map([["custom-provider", { family: "custom" }]]),
+      },
+    };
+
+    for (let index = 0; index < 10; index += 1) {
+      expect(
+        resolveProviderRequestPolicy({ provider: "custom-provider" }).knownProviderFamily,
+      ).toBe("custom");
+    }
+    expect(loadPluginMetadataSnapshot).not.toHaveBeenCalled();
   });
 
   it("resolves the canonical OpenClaw product and runtime version", () => {

--- a/src/agents/provider-attribution.ts
+++ b/src/agents/provider-attribution.ts
@@ -180,7 +180,6 @@ type ProviderMetadataOwners = {
 function resolveProviderMetadataOwners(): ProviderMetadataOwners {
   const current = getCurrentPluginMetadataSnapshot({
     allowWorkspaceScopedSnapshot: true,
-    requireDefaultDiscoveryContext: true,
   });
   if (current) {
     return {


### PR DESCRIPTION
Related: #112699

## What Problem This Solves

Fixes an issue where users of Gateways with configured plugin load paths could experience multi-second event-loop stalls while an agent turn resolved model provider metadata.

## Why This Change Was Made

Provider attribution now reuses the Gateway lifecycle's current unscoped metadata snapshot even when that snapshot does not match default plugin discovery. Plugin-ID-scoped snapshots remain rejected, and the existing synchronous discovery remains only as a fallback when no reusable lifecycle snapshot exists.

## User Impact

Agent turns no longer rescan and freeze the full plugin metadata graph for every inline model. This removes the observed 5–9 second Gateway scheduling stalls without changing provider routing or plugin reload semantics.

## Evidence

- Added a regression test that resolves provider policy ten times under a non-default discovery context and proves the synchronous metadata loader is never called.
- The regression test failed before the production change and passed afterward.
- Final rebased head: 76 focused tests passed across provider attribution, current metadata snapshot, and inline provider model coverage.
- `pnpm check:changed` passed all core and core-test gates.
- Fresh branch autoreview found no accepted or actionable findings.
- Live before/after on a maintainer-operated Gateway with 154 plugin metadata records and configured plugin load paths:
  - Before: lane dequeue to harness selection took 7.09s; model processing began after 9.15s; event-loop max was 9101.6ms.
  - Fixed run 1: 1.44s to harness selection and 3.09s to model processing.
  - Fixed run 2: 1.55s to harness selection and 2.76s to model processing; the following heartbeat reported a 29.9ms event-loop max.
- The exact fix commit was deployed in an immutable runtime for the measurement, then the Gateway was restored to its previous `main` runtime.
