### PR TITLE
fix(agents): infer a bare fallback model id's provider from configured models instead of inheriting the primary's

### DIFF
--- a/src/agents/model-fallback-candidates.provider-inference.test.ts
+++ b/src/agents/model-fallback-candidates.provider-inference.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+// Tests that a bare fallback model id infers its provider from the configured models
+// (matching the auth/selection path) instead of inheriting the primary's provider.
+import type { OpenClawConfig } from "../config/config.js";
+import { resolveModelCandidateChain } from "./model-fallback-candidates.js";
+
+const cfg = {
+  models: {
+    providers: {
+      anthropic: { models: [{ id: "claude-opus-4-6" }] },
+      openai: { models: [{ id: "gpt-5.4" }] },
+    },
+  },
+} as unknown as OpenClawConfig;
+
+function fallbackProvider(fallbacks: string[], model: string): string | undefined {
+  const chain = resolveModelCandidateChain({
+    cfg,
+    provider: "anthropic",
+    model: "claude-opus-4-6",
+    fallbacksOverride: fallbacks,
+  });
+  return chain.find((c) => c.model === model)?.provider;
+}
+
+describe("resolveModelCandidateChain bare fallback provider inference", () => {
+  it("infers a bare fallback id's provider from configured models, not the primary's provider", () => {
+    // openai/gpt-5.4 is configured; a bare "gpt-5.4" fallback under an anthropic primary must
+    // route to openai, not the dead route anthropic/gpt-5.4.
+    expect(fallbackProvider(["gpt-5.4"], "gpt-5.4")).toBe("openai");
+  });
+
+  it("leaves a slash-qualified fallback unchanged", () => {
+    expect(fallbackProvider(["openai/gpt-5.4"], "gpt-5.4")).toBe("openai");
+  });
+
+  it("keeps the default (primary) provider for a bare fallback not uniquely configured", () => {
+    expect(fallbackProvider(["mystery-model"], "mystery-model")).toBe("anthropic");
+  });
+
+  it("keeps the default provider for a bare id configured under multiple providers (not unique)", () => {
+    const multiCfg = {
+      models: {
+        providers: {
+          openai: { models: [{ id: "gpt-5.4" }] },
+          azure: { models: [{ id: "gpt-5.4" }] },
+        },
+      },
+      agents: { defaults: { model: { primary: "anthropic/claude-opus-4-6" } } },
+    } as unknown as OpenClawConfig;
+    const chain = resolveModelCandidateChain({
+      cfg: multiCfg,
+      provider: "anthropic",
+      model: "claude-opus-4-6",
+      fallbacksOverride: ["gpt-5.4"],
+    });
+    // Configured under two providers => inference is not unique => default (primary) preserved.
+    expect(chain.find((c) => c.model === "gpt-5.4")?.provider).toBe("anthropic");
+  });
+});

--- a/src/agents/model-fallback-candidates.ts
+++ b/src/agents/model-fallback-candidates.ts
@@ -32,6 +32,7 @@ import {
   resolveModelAliasFromPair,
   resolveModelRefFromString,
 } from "./model-selection-resolve.js";
+import { inferUniqueProviderFromConfiguredModels } from "./model-selection-shared.js";
 
 const MAX_FALLBACK_CANDIDATE_CACHE_ENTRIES = 256;
 const fallbackCandidateCache = new Map<string, ModelFallbackCandidate[]>();
@@ -372,10 +373,23 @@ function resolveFallbackCandidatesUncached(
       ? params.fallbacksOverride
       : resolveAgentModelFallbackValues(params.cfg?.agents?.defaults?.model);
   for (const raw of modelFallbacks) {
+    // A bare (slash-less) fallback id should infer its provider from the configured models --
+    // matching the auth/selection path (resolveBareModelDefaultProvider) -- instead of inheriting
+    // the primary's provider, which yields a dead route when the model is configured under a
+    // different provider.
+    const trimmedFallback = normalizeOptionalString(raw);
+    const fallbackDefaultProvider =
+      trimmedFallback && !trimmedFallback.includes("/")
+        ? (inferUniqueProviderFromConfiguredModels({
+            cfg: params.cfg ?? ({} as OpenClawConfig),
+            model: trimmedFallback,
+            manifestPlugins: params.manifestPlugins,
+          }) ?? defaultProvider)
+        : defaultProvider;
     const resolved = resolveModelRefFromString({
       cfg: params.cfg,
       raw,
-      defaultProvider,
+      defaultProvider: fallbackDefaultProvider,
       aliasIndex,
       allowPluginNormalization: allowPluginModelAliases,
       manifestPlugins: params.manifestPlugins,


### PR DESCRIPTION
## What Problem This Solves

A **bare (slash-less) fallback model id** in `agents.defaults.model.fallbacks` inherits the **primary model's provider**, so a fallback that is correctly configured under a *different* provider silently resolves to a **dead route** and can never actually be used.

Example config:
```jsonc
{
  "agents": { "defaults": { "model": { "primary": "anthropic/claude-opus-4-6", "fallbacks": ["gpt-5.4"] } } },
  "models":  { "providers": { "openai": { "models": [{ "id": "gpt-5.4" }] } } }
}
```
The `gpt-5.4` fallback is configured under `openai`, but it resolves to **`anthropic/gpt-5.4`** — a model `anthropic` doesn't serve — so when the primary fails, the fallback attempt is a dead route.

## Why This Change Was Made

`resolveFallbackCandidatesUncached` (`src/agents/model-fallback-candidates.ts`) resolves every fallback with `defaultProvider` set to the **primary's** provider, and `resolveModelRefFromString` applies that default to any bare id:

```ts
const defaultProvider = primary?.provider ?? DEFAULT_PROVIDER;
// …
for (const raw of modelFallbacks) {
  const resolved = resolveModelRefFromString({ cfg, raw, defaultProvider, … }); // bare "gpt-5.4" → anthropic/gpt-5.4
}
```

But the **authorization / selection path** already infers a bare id's provider from the configured models — `resolveBareModelDefaultProvider` (`src/agents/model-selection-shared.ts:308`) calls `inferUniqueProviderFromConfiguredModels` first. So the auth layer authorizes `openai/gpt-5.4` while the fallback-candidate layer executes `anthropic/gpt-5.4`: a sibling inconsistency and an auth/execution provider mismatch.

The fix makes the fallback path infer a bare id's provider the same way — only when the id is **uniquely** configured under one provider; a slash-qualified id, an unconfigured id, or one configured under multiple providers is unchanged (still the primary/default provider).

## User Impact

A bare fallback model id now routes to the provider it is actually configured under, so configured fallbacks work instead of dead-ending. Slash-qualified fallbacks and bare ids that aren't uniquely configured are unchanged.

## Evidence

Reproduce-first unit test added (`model-fallback-candidates.provider-inference.test.ts`), driving the real `resolveModelCandidateChain`:

Before (fix reverted):
```
× infers a bare fallback id's provider from configured models, not the primary's provider
  AssertionError: expected 'anthropic' to be 'openai'
```
After (fix applied):
```
 Test Files  2 passed (2)
      Tests  6 passed (6)
```
Regression: **526 passed** across `model-fallback.test.ts` + `model-selection.test.ts` + the new test (0 failures).

## Real-behavior proof (on current main)

Running the real production functions with the config above:

- `resolveModelCandidateChain` fallback candidate: **before** `anthropic/gpt-5.4` (dead) → **after** `openai/gpt-5.4`.
- The sibling auth/selection path — `inferUniqueProviderFromConfiguredModels({ cfg, model: "gpt-5.4" })` — already returns **`openai`**, confirming the two layers disagreed before this fix and now agree.

**Note for maintainers:** the fix mirrors `resolveBareModelDefaultProvider`'s existing inference, applied inside the fallback loop; it is conservative (only bare, uniquely-configured ids change) and provider-agnostic. No change to slash-qualified fallbacks, the primary route, or the image-fallback path.
