### PR TITLE
fix(security): audit open Feishu and Teams DMs

### DIFF
--- a/docs/channels/msteams.md
+++ b/docs/channels/msteams.md
@@ -142,6 +142,13 @@ Microsoft Teams has one account per channel configuration. Set policies directly
 - Do not rely on UPN/display-name matching for allowlists; they can change. OpenClaw disables direct name matching by default; opt in with `channels.msteams.dangerouslyAllowNameMatching: true`.
 - The wizard can resolve names to IDs via Microsoft Graph when credentials allow.
 
+Legacy `conversation:<stable-user-id>` entries in `allowFrom` are still projected to the
+bare user ID at startup, including `teams:` and `msteams:` prefixes. The security audit
+classifies that effective user access, not a grant to the conversation. Replace these
+entries with explicit AAD object IDs; raw conversation-form sender identities and
+approval principals remain rejected. Actual chat IDs such as `19:...@thread.tacv2`
+do not grant DM access.
+
 **Group access**
 
 - Default: `channels.msteams.groupPolicy = "allowlist"` (blocked unless you add `groupAllowFrom`). Set `channels.msteams.groupPolicy` explicitly to choose another policy; the root schema default takes precedence over `channels.defaults.groupPolicy`.

--- a/extensions/feishu/src/channel.test.ts
+++ b/extensions/feishu/src/channel.test.ts
@@ -148,6 +148,77 @@ describe("feishuPlugin metadata", () => {
   });
 });
 
+describe("feishuPlugin security", () => {
+  it("exposes account-scoped DM policy to security audits", () => {
+    const cfg = {
+      channels: {
+        feishu: {
+          allowFrom: ["*", "feishu:user:ou_owner"],
+          accounts: {
+            ops: {
+              appId: "cli_ops",
+              appSecret: "secret_ops",
+              dmPolicy: "open",
+            },
+          },
+        },
+      },
+    } as OpenClawConfig;
+    const resolveDmPolicy = feishuPlugin.security?.resolveDmPolicy;
+    if (!resolveDmPolicy) {
+      throw new Error("feishu security.resolveDmPolicy unavailable");
+    }
+
+    const result = resolveDmPolicy({
+      cfg,
+      accountId: "ops",
+      account: feishuPlugin.config.resolveAccount(cfg, "ops"),
+    });
+
+    expect(result).toMatchObject({
+      policy: "open",
+      allowFrom: ["*", "feishu:user:ou_owner"],
+      policyPath: "channels.feishu.accounts.ops.dmPolicy",
+      allowFromPath: "channels.feishu.",
+    });
+    expect(result?.normalizeEntry?.("feishu:user:ou_owner")).toBe("user:ou_owner");
+  });
+
+  it("tracks a root DM policy separately from an account allowlist", () => {
+    const cfg = {
+      channels: {
+        feishu: {
+          dmPolicy: "open",
+          accounts: {
+            ops: {
+              appId: "cli_ops",
+              appSecret: "secret_ops",
+              allowFrom: ["*"],
+            },
+          },
+        },
+      },
+    } as OpenClawConfig;
+    const resolveDmPolicy = feishuPlugin.security?.resolveDmPolicy;
+    if (!resolveDmPolicy) {
+      throw new Error("feishu security.resolveDmPolicy unavailable");
+    }
+
+    const result = resolveDmPolicy({
+      cfg,
+      accountId: "ops",
+      account: feishuPlugin.config.resolveAccount(cfg, "ops"),
+    });
+
+    expect(result).toMatchObject({
+      policy: "open",
+      allowFrom: ["*"],
+      policyPath: "channels.feishu.dmPolicy",
+      allowFromPath: "channels.feishu.accounts.ops.",
+    });
+  });
+});
+
 describe("feishuPlugin config", () => {
   it.each([
     {

--- a/extensions/feishu/src/channel.test.ts
+++ b/extensions/feishu/src/channel.test.ts
@@ -217,6 +217,40 @@ describe("feishuPlugin security", () => {
       allowFromPath: "channels.feishu.accounts.ops.",
     });
   });
+
+  it("preserves the authored account key in audit paths after normalized lookup", () => {
+    const cfg = {
+      channels: {
+        feishu: {
+          accounts: {
+            " Ops ": {
+              appId: "cli_ops",
+              appSecret: "secret_ops",
+              dmPolicy: "open",
+              allowFrom: ["*"],
+            },
+          },
+        },
+      },
+    } as OpenClawConfig;
+    const resolveDmPolicy = feishuPlugin.security?.resolveDmPolicy;
+    if (!resolveDmPolicy) {
+      throw new Error("feishu security.resolveDmPolicy unavailable");
+    }
+
+    const result = resolveDmPolicy({
+      cfg,
+      accountId: "ops",
+      account: feishuPlugin.config.resolveAccount(cfg, "ops"),
+    });
+
+    expect(result).toMatchObject({
+      policy: "open",
+      allowFrom: ["*"],
+      policyPath: "channels.feishu.accounts. Ops .dmPolicy",
+      allowFromPath: "channels.feishu.accounts. Ops .",
+    });
+  });
 });
 
 describe("feishuPlugin config", () => {

--- a/extensions/feishu/src/channel.ts
+++ b/extensions/feishu/src/channel.ts
@@ -1079,15 +1079,16 @@ function resolveFeishuDmFieldBasePath(params: {
   field: "dmPolicy" | "allowFrom";
 }): string {
   const accountId = params.accountId?.trim() || DEFAULT_ACCOUNT_ID;
-  const channelConfig = params.cfg.channels?.feishu as FeishuConfig | undefined;
-  const accountConfig = channelConfig?.accounts?.[accountId];
-  if (accountConfig?.[params.field] !== undefined) {
+  const channelConfig: unknown = params.cfg.channels?.feishu;
+  const accounts = isRecord(channelConfig) ? channelConfig.accounts : undefined;
+  const accountConfig = isRecord(accounts) ? accounts[accountId] : undefined;
+  if (isRecord(accountConfig) && accountConfig[params.field] !== undefined) {
     return `channels.feishu.accounts.${accountId}.`;
   }
-  if (channelConfig?.[params.field] !== undefined) {
+  if (isRecord(channelConfig) && channelConfig[params.field] !== undefined) {
     return "channels.feishu.";
   }
-  return accountConfig ? `channels.feishu.accounts.${accountId}.` : "channels.feishu.";
+  return isRecord(accountConfig) ? `channels.feishu.accounts.${accountId}.` : "channels.feishu.";
 }
 
 const resolveFeishuDmPolicy = (params: Parameters<typeof resolveFeishuDmPolicyBase>[0]) => {

--- a/extensions/feishu/src/channel.ts
+++ b/extensions/feishu/src/channel.ts
@@ -7,6 +7,7 @@ import { createActionGate, ToolAuthorizationError } from "openclaw/plugin-sdk/ch
 import {
   adaptScopedAccountAccessor,
   createHybridChannelConfigAdapter,
+  createScopedDmSecurityResolver,
 } from "openclaw/plugin-sdk/channel-config-helpers";
 import type {
   ChannelMessageActionAdapter,
@@ -89,7 +90,7 @@ import {
   resolveFeishuReplyMode,
   type FeishuOutboundSendMedia,
 } from "./outbound.js";
-import { resolveFeishuGroupToolPolicy } from "./policy.js";
+import { normalizeFeishuAllowEntry, resolveFeishuGroupToolPolicy } from "./policy.js";
 import {
   assertFeishuCardWithinEnvelope,
   buildFeishuPresentationCard,
@@ -1064,6 +1065,48 @@ function resolveRequestedFeishuMemberIdType(
   return undefined;
 }
 
+const resolveFeishuDmPolicyBase = createScopedDmSecurityResolver<ResolvedFeishuAccount>({
+  channelKey: "feishu",
+  resolvePolicy: (account) => account.config.dmPolicy,
+  resolveAllowFrom: (account) => account.config.allowFrom,
+  policyPathSuffix: "dmPolicy",
+  normalizeEntry: normalizeFeishuAllowEntry,
+});
+
+function resolveFeishuDmFieldBasePath(params: {
+  cfg: ClawdbotConfig;
+  accountId?: string | null;
+  field: "dmPolicy" | "allowFrom";
+}): string {
+  const accountId = params.accountId?.trim() || DEFAULT_ACCOUNT_ID;
+  const channelConfig = params.cfg.channels?.feishu as FeishuConfig | undefined;
+  const accountConfig = channelConfig?.accounts?.[accountId];
+  if (accountConfig?.[params.field] !== undefined) {
+    return `channels.feishu.accounts.${accountId}.`;
+  }
+  if (channelConfig?.[params.field] !== undefined) {
+    return "channels.feishu.";
+  }
+  return accountConfig ? `channels.feishu.accounts.${accountId}.` : "channels.feishu.";
+}
+
+const resolveFeishuDmPolicy = (params: Parameters<typeof resolveFeishuDmPolicyBase>[0]) => {
+  const accountId = params.accountId ?? params.account.accountId;
+  return {
+    ...resolveFeishuDmPolicyBase(params),
+    policyPath: `${resolveFeishuDmFieldBasePath({
+      cfg: params.cfg,
+      accountId,
+      field: "dmPolicy",
+    })}dmPolicy`,
+    allowFromPath: resolveFeishuDmFieldBasePath({
+      cfg: params.cfg,
+      accountId,
+      field: "allowFrom",
+    }),
+  };
+};
+
 export const feishuPlugin: ChannelPlugin<ResolvedFeishuAccount, FeishuProbeResult> =
   createChatChannelPlugin({
     base: {
@@ -2000,6 +2043,7 @@ export const feishuPlugin: ChannelPlugin<ResolvedFeishuAccount, FeishuProbeResul
       message: feishuMessageAdapter,
     },
     security: {
+      resolveDmPolicy: resolveFeishuDmPolicy,
       collectWarnings: ({ cfg, accountId }) => collectFeishuOpenGroupFindings({ cfg, accountId }),
       collectAuditFindings: ({ cfg }) => collectFeishuSecurityAuditFindings({ cfg }),
     },

--- a/extensions/feishu/src/channel.ts
+++ b/extensions/feishu/src/channel.ts
@@ -1,6 +1,6 @@
 // Feishu plugin module implements channel behavior.
 import { describeAccountSnapshot } from "openclaw/plugin-sdk/account-helpers";
-import { DEFAULT_ACCOUNT_ID } from "openclaw/plugin-sdk/account-resolution";
+import { DEFAULT_ACCOUNT_ID, resolveAccountEntry } from "openclaw/plugin-sdk/account-resolution";
 import { resolveAgentConfig } from "openclaw/plugin-sdk/agent-scope-runtime";
 import { formatAllowFromLowercase } from "openclaw/plugin-sdk/allow-from";
 import { createActionGate, ToolAuthorizationError } from "openclaw/plugin-sdk/channel-actions";
@@ -1081,14 +1081,26 @@ function resolveFeishuDmFieldBasePath(params: {
   const accountId = params.accountId?.trim() || DEFAULT_ACCOUNT_ID;
   const channelConfig: unknown = params.cfg.channels?.feishu;
   const accounts = isRecord(channelConfig) ? channelConfig.accounts : undefined;
-  const accountConfig = isRecord(accounts) ? accounts[accountId] : undefined;
-  if (isRecord(accountConfig) && accountConfig[params.field] !== undefined) {
-    return `channels.feishu.accounts.${accountId}.`;
+  const accountConfig = isRecord(accounts) ? resolveAccountEntry(accounts, accountId) : undefined;
+  // Reuse canonical account selection, then recover its authored key so diagnostic paths point
+  // at the actual config entry rather than the normalized runtime id.
+  const configAccountId =
+    isRecord(accounts) && isRecord(accountConfig)
+      ? Object.keys(accounts).find((key) => accounts[key] === accountConfig)
+      : undefined;
+  if (
+    configAccountId !== undefined &&
+    isRecord(accountConfig) &&
+    accountConfig[params.field] !== undefined
+  ) {
+    return `channels.feishu.accounts.${configAccountId}.`;
   }
   if (isRecord(channelConfig) && channelConfig[params.field] !== undefined) {
     return "channels.feishu.";
   }
-  return isRecord(accountConfig) ? `channels.feishu.accounts.${accountId}.` : "channels.feishu.";
+  return configAccountId !== undefined
+    ? `channels.feishu.accounts.${configAccountId}.`
+    : "channels.feishu.";
 }
 
 const resolveFeishuDmPolicy = (params: Parameters<typeof resolveFeishuDmPolicyBase>[0]) => {

--- a/extensions/msteams/src/channel-config.ts
+++ b/extensions/msteams/src/channel-config.ts
@@ -1,6 +1,9 @@
 import { DEFAULT_ACCOUNT_ID } from "openclaw/plugin-sdk/account-id";
 import { formatAllowFromLowercase } from "openclaw/plugin-sdk/allow-from";
-import { createTopLevelChannelConfigAdapter } from "openclaw/plugin-sdk/channel-config-helpers";
+import {
+  createScopedDmSecurityResolver,
+  createTopLevelChannelConfigAdapter,
+} from "openclaw/plugin-sdk/channel-config-helpers";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { tryReadSecretFileSync } from "openclaw/plugin-sdk/secret-file-runtime";
 import { resolveMSTeamsCredentials } from "./token.js";
@@ -67,4 +70,22 @@ export const msteamsConfigAdapter = createTopLevelChannelConfigAdapter<
   resolveAllowFrom: (account) => account.allowFrom,
   formatAllowFrom: (allowFrom) => formatAllowFromLowercase({ allowFrom }),
   resolveDefaultTo: (account) => account.defaultTo,
+});
+
+
+export const resolveMSTeamsDmPolicy = createScopedDmSecurityResolver<ResolvedMSTeamsAccount>({
+  channelKey: "msteams",
+  resolvePolicy: () => undefined,
+  resolveAllowFrom: () => undefined,
+  resolveAccess: ({ cfg }) => ({
+    dmPolicy: cfg.channels?.msteams?.dmPolicy,
+    allowFrom: cfg.channels?.msteams?.allowFrom,
+  }),
+  policyPathSuffix: "dmPolicy",
+  normalizeEntry: (raw) =>
+    raw
+      .replace(/^(msteams|teams):/i, "")
+      .replace(/^(user|conversation):/i, "")
+      .trim()
+      .toLowerCase(),
 });

--- a/extensions/msteams/src/channel-config.ts
+++ b/extensions/msteams/src/channel-config.ts
@@ -6,8 +6,10 @@ import {
 } from "openclaw/plugin-sdk/channel-config-helpers";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { tryReadSecretFileSync } from "openclaw/plugin-sdk/secret-file-runtime";
-import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/string-coerce-runtime";
-import { classifyMSTeamsEntryAuthentication } from "./ingress-identity.js";
+import {
+  classifyMSTeamsEntryAuthentication,
+  normalizeMSTeamsDmPrincipal,
+} from "./ingress-identity.js";
 import { resolveMSTeamsCredentials } from "./token.js";
 
 export type ResolvedMSTeamsAccount = {
@@ -87,7 +89,6 @@ export const resolveMSTeamsDmPolicy = createScopedDmSecurityResolver<ResolvedMST
     allowFrom: cfg.channels?.msteams?.allowFrom,
   }),
   policyPathSuffix: "dmPolicy",
-  // Keep audit counting aligned with inbound sender-id matching; prefixes are not aliases.
-  normalizeEntry: normalizeLowercaseStringOrEmpty,
+  normalizeEntry: normalizeMSTeamsDmPrincipal,
   classifyEntryAuthentication: classifyMSTeamsEntryAuthentication,
 });

--- a/extensions/msteams/src/channel-config.ts
+++ b/extensions/msteams/src/channel-config.ts
@@ -1,7 +1,7 @@
 import { DEFAULT_ACCOUNT_ID } from "openclaw/plugin-sdk/account-id";
 import { formatAllowFromLowercase } from "openclaw/plugin-sdk/allow-from";
 import {
-  createScopedDmSecurityResolver,
+  buildAccountScopedDmSecurityPolicy,
   createTopLevelChannelConfigAdapter,
 } from "openclaw/plugin-sdk/channel-config-helpers";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
@@ -80,15 +80,25 @@ export const msteamsConfigAdapter = createTopLevelChannelConfigAdapter<
   formatAllowFrom: (allowFrom) => formatAllowFromLowercase({ allowFrom }),
   resolveDefaultTo: (account) => account.defaultTo,
 });
-export const resolveMSTeamsDmPolicy = createScopedDmSecurityResolver<ResolvedMSTeamsAccount>({
-  channelKey: "msteams",
-  resolvePolicy: () => undefined,
-  resolveAllowFrom: () => undefined,
-  resolveAccess: ({ cfg }) => ({
-    dmPolicy: cfg.channels?.msteams?.dmPolicy,
-    allowFrom: cfg.channels?.msteams?.allowFrom,
-  }),
-  policyPathSuffix: "dmPolicy",
-  normalizeEntry: normalizeMSTeamsDmPrincipal,
-  classifyEntryAuthentication: classifyMSTeamsEntryAuthentication,
-});
+export function resolveMSTeamsDmPolicy({
+  cfg,
+  accountId,
+  account,
+}: {
+  cfg: OpenClawConfig;
+  accountId?: string | null;
+  account: ResolvedMSTeamsAccount;
+}) {
+  const config = cfg.channels?.msteams;
+  return buildAccountScopedDmSecurityPolicy({
+    cfg,
+    channelKey: "msteams",
+    accountId: accountId ?? account.accountId,
+    policy: config?.dmPolicy,
+    allowFrom: config?.allowFrom,
+    policyPathSuffix: "dmPolicy",
+    normalizeEntry: (raw) =>
+      normalizeMSTeamsDmPrincipal(raw, config?.dangerouslyAllowNameMatching === true),
+    classifyEntryAuthentication: classifyMSTeamsEntryAuthentication,
+  });
+}

--- a/extensions/msteams/src/channel-config.ts
+++ b/extensions/msteams/src/channel-config.ts
@@ -6,6 +6,7 @@ import {
 } from "openclaw/plugin-sdk/channel-config-helpers";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { tryReadSecretFileSync } from "openclaw/plugin-sdk/secret-file-runtime";
+import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { resolveMSTeamsCredentials } from "./token.js";
 
 export type ResolvedMSTeamsAccount = {
@@ -71,8 +72,6 @@ export const msteamsConfigAdapter = createTopLevelChannelConfigAdapter<
   formatAllowFrom: (allowFrom) => formatAllowFromLowercase({ allowFrom }),
   resolveDefaultTo: (account) => account.defaultTo,
 });
-
-
 export const resolveMSTeamsDmPolicy = createScopedDmSecurityResolver<ResolvedMSTeamsAccount>({
   channelKey: "msteams",
   resolvePolicy: () => undefined,
@@ -82,10 +81,6 @@ export const resolveMSTeamsDmPolicy = createScopedDmSecurityResolver<ResolvedMST
     allowFrom: cfg.channels?.msteams?.allowFrom,
   }),
   policyPathSuffix: "dmPolicy",
-  normalizeEntry: (raw) =>
-    raw
-      .replace(/^(msteams|teams):/i, "")
-      .replace(/^(user|conversation):/i, "")
-      .trim()
-      .toLowerCase(),
+  // Keep audit counting aligned with inbound sender-id matching; prefixes are not aliases.
+  normalizeEntry: normalizeLowercaseStringOrEmpty,
 });

--- a/extensions/msteams/src/channel-config.ts
+++ b/extensions/msteams/src/channel-config.ts
@@ -7,12 +7,14 @@ import {
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { tryReadSecretFileSync } from "openclaw/plugin-sdk/secret-file-runtime";
 import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/string-coerce-runtime";
+import { classifyMSTeamsEntryAuthentication } from "./ingress-identity.js";
 import { resolveMSTeamsCredentials } from "./token.js";
 
 export type ResolvedMSTeamsAccount = {
   accountId: string;
   enabled: boolean;
   configured: boolean;
+  config: { dangerouslyAllowNameMatching?: boolean };
   tokenStatus: "available" | "configured_unavailable" | "missing";
   credentialDiagnostics?: Extract<
     ReturnType<typeof tryReadSecretFileSync>,
@@ -50,6 +52,10 @@ export function resolveMSTeamsAccount(cfg: OpenClawConfig): ResolvedMSTeamsAccou
     accountId: DEFAULT_ACCOUNT_ID,
     enabled: config?.enabled !== false,
     configured: Boolean(credentials),
+    config:
+      typeof config?.dangerouslyAllowNameMatching === "boolean"
+        ? { dangerouslyAllowNameMatching: config.dangerouslyAllowNameMatching }
+        : {},
     tokenStatus: !credentials ? "missing" : unavailable ? "configured_unavailable" : "available",
     ...(unavailable ? { credentialDiagnostics: [certificate.diagnostic] } : {}),
   };
@@ -83,4 +89,5 @@ export const resolveMSTeamsDmPolicy = createScopedDmSecurityResolver<ResolvedMST
   policyPathSuffix: "dmPolicy",
   // Keep audit counting aligned with inbound sender-id matching; prefixes are not aliases.
   normalizeEntry: normalizeLowercaseStringOrEmpty,
+  classifyEntryAuthentication: classifyMSTeamsEntryAuthentication,
 });

--- a/extensions/msteams/src/channel-security.ts
+++ b/extensions/msteams/src/channel-security.ts
@@ -1,0 +1,26 @@
+import {
+  createAllowlistProviderGroupPolicyWarningCollector,
+  createConditionalWarningCollector,
+} from "openclaw/plugin-sdk/channel-policy";
+// Msteams plugin module owns lightweight channel security warnings shared by setup and runtime.
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+
+const collectMSTeamsSecurityWarnings = createAllowlistProviderGroupPolicyWarningCollector<{
+  cfg: OpenClawConfig;
+}>({
+  providerConfigPresent: (cfg) => cfg.channels?.msteams !== undefined,
+  resolveGroupPolicy: ({ cfg }) => cfg.channels?.msteams?.groupPolicy,
+  collect: ({ groupPolicy }) =>
+    groupPolicy === "open"
+      ? [
+          '- MS Teams groups: groupPolicy="open" allows any member to trigger (mention-gated). Set channels.msteams.groupPolicy="allowlist" + channels.msteams.groupAllowFrom to restrict senders.',
+        ]
+      : [],
+});
+
+export const collectMSTeamsSecurityFindings = createConditionalWarningCollector.findings({
+  collectWarnings: collectMSTeamsSecurityWarnings,
+  checkId: "channels.msteams.groups.open",
+  severity: "critical",
+  title: "MS Teams security warning",
+});

--- a/extensions/msteams/src/channel.setup.ts
+++ b/extensions/msteams/src/channel.setup.ts
@@ -7,6 +7,7 @@ import {
   resolveMSTeamsDmPolicy,
   type ResolvedMSTeamsAccount,
 } from "./channel-config.js";
+import { collectMSTeamsSecurityFindings } from "./channel-security.js";
 import { MSTeamsChannelConfigSchema } from "./config-schema.js";
 import { msteamsSetupContract } from "./setup-core.js";
 import { msteamsSetupWizard } from "./setup-surface.js";
@@ -38,6 +39,7 @@ export const msteamsSetupPlugin: ChannelPlugin<ResolvedMSTeamsAccount> = {
   },
   security: {
     resolveDmPolicy: resolveMSTeamsDmPolicy,
+    collectWarnings: collectMSTeamsSecurityFindings,
   },
   setupWizard: msteamsSetupWizard,
   setupContract: msteamsSetupContract,

--- a/extensions/msteams/src/channel.setup.ts
+++ b/extensions/msteams/src/channel.setup.ts
@@ -4,6 +4,7 @@ import type { ChannelPlugin } from "openclaw/plugin-sdk/channel-core";
 import {
   msteamsConfigAdapter,
   msteamsMeta,
+  resolveMSTeamsDmPolicy,
   type ResolvedMSTeamsAccount,
 } from "./channel-config.js";
 import { MSTeamsChannelConfigSchema } from "./config-schema.js";
@@ -34,6 +35,9 @@ export const msteamsSetupPlugin: ChannelPlugin<ResolvedMSTeamsAccount> = {
         configured: account.configured,
         extra: { tokenStatus: account.tokenStatus },
       }),
+  },
+  security: {
+    resolveDmPolicy: resolveMSTeamsDmPolicy,
   },
   setupWizard: msteamsSetupWizard,
   setupContract: msteamsSetupContract,

--- a/extensions/msteams/src/channel.test.ts
+++ b/extensions/msteams/src/channel.test.ts
@@ -272,23 +272,28 @@ describe("msteamsPlugin", () => {
         },
       },
     } as OpenClawConfig;
-    const resolveDmPolicy = msteamsPlugin.security?.resolveDmPolicy;
-    if (!resolveDmPolicy) {
-      throw new Error("msteams security.resolveDmPolicy unavailable");
+    for (const plugin of [msteamsPlugin, msteamsSetupPlugin]) {
+      const resolveDmPolicy = plugin.security?.resolveDmPolicy;
+      if (!resolveDmPolicy) {
+        throw new Error("msteams security.resolveDmPolicy unavailable");
+      }
+
+      const result = resolveDmPolicy({
+        cfg,
+        account: plugin.config.resolveAccount(cfg, "default"),
+      });
+
+      expect(result).toMatchObject({
+        policy: "open",
+        allowFrom: ["*"],
+        policyPath: "channels.msteams.dmPolicy",
+        allowFromPath: "channels.msteams.",
+      });
+      expect(result?.normalizeEntry?.("msteams:user:OWNER")).toBe("owner");
     }
-
-    const result = resolveDmPolicy({
-      cfg,
-      account: msteamsPlugin.config.resolveAccount(cfg, "default"),
-    });
-
-    expect(result).toMatchObject({
-      policy: "open",
-      allowFrom: ["*"],
-      policyPath: "channels.msteams.dmPolicy",
-      allowFromPath: "channels.msteams.",
-    });
-    expect(result?.normalizeEntry?.("msteams:user:OWNER")).toBe("owner");
+    expect(msteamsSetupPlugin.security?.resolveDmPolicy).toBe(
+      msteamsPlugin.security?.resolveDmPolicy,
+    );
   });
 
   it("advertises legacy and group-management message-tool actions together", () => {

--- a/extensions/msteams/src/channel.test.ts
+++ b/extensions/msteams/src/channel.test.ts
@@ -292,7 +292,8 @@ describe("msteamsPlugin", () => {
         allowFromPath: "channels.msteams.",
       });
       expect(result?.normalizeEntry?.(" OWNER ")).toBe("owner");
-      expect(result?.normalizeEntry?.(" msteams:user:OWNER ")).toBe("msteams:user:owner");
+      expect(result?.normalizeEntry?.(" msteams:user:OWNER ")).toBe("owner");
+      expect(result?.normalizeEntry?.(" teams:OWNER ")).toBe("owner");
     }
     expect(msteamsSetupPlugin.security?.resolveDmPolicy).toBe(
       msteamsPlugin.security?.resolveDmPolicy,
@@ -631,6 +632,7 @@ describe("msTeamsApprovalAuth", () => {
   it.each([
     ["conversation", `conversation:${otherUserId}`],
     ["provider-prefixed conversation", `msteams:conversation:${otherUserId}`],
+    ["whitespace-padded provider conversation", ` msteams:conversation:${otherUserId} `],
     ["chat", `chat:${otherUserId}`],
     ["email", "owner@example.com"],
     ["display name", "Owner Display"],

--- a/extensions/msteams/src/channel.test.ts
+++ b/extensions/msteams/src/channel.test.ts
@@ -335,12 +335,13 @@ describe("msteamsPlugin", () => {
 
   it("classifies authored Teams identities for security audits", () => {
     const stableId = "40a1a0ed-4ff2-4164-a219-55518990c197";
+    const stableNonUuidId = "0123456789abcdef";
     const cfg = {
       channels: {
         msteams: {
           ...createConfiguredMSTeamsCfg().channels?.msteams,
           dmPolicy: "allowlist",
-          allowFrom: [stableId, "Alice Example", "alice@example.com"],
+          allowFrom: [stableId, stableNonUuidId, "Alice Example", "alice@example.com"],
           dangerouslyAllowNameMatching: true,
         },
       },
@@ -357,6 +358,8 @@ describe("msteamsPlugin", () => {
       expect(account.config).toEqual({ dangerouslyAllowNameMatching: true });
       expect(classify(stableId)).toBe("asserted");
       expect(classify(`teams:user:${stableId}`)).toBe("asserted");
+      expect(classify(stableNonUuidId)).toBe("asserted");
+      expect(classify(`msteams:user:${stableNonUuidId}`)).toBe("asserted");
       expect(classify("Alice Example")).toBe("mutable");
       expect(classify("alice@example.com")).toBe("mutable");
       expect(classify("19:group@thread.tacv2")).toBeUndefined();

--- a/extensions/msteams/src/channel.test.ts
+++ b/extensions/msteams/src/channel.test.ts
@@ -262,6 +262,35 @@ describe("msteamsPlugin", () => {
     ]);
   });
 
+  it("exposes the configured DM policy to security audits", () => {
+    const cfg = {
+      channels: {
+        msteams: {
+          ...createConfiguredMSTeamsCfg().channels?.msteams,
+          dmPolicy: "open",
+          allowFrom: ["*"],
+        },
+      },
+    } as OpenClawConfig;
+    const resolveDmPolicy = msteamsPlugin.security?.resolveDmPolicy;
+    if (!resolveDmPolicy) {
+      throw new Error("msteams security.resolveDmPolicy unavailable");
+    }
+
+    const result = resolveDmPolicy({
+      cfg,
+      account: msteamsPlugin.config.resolveAccount(cfg, "default"),
+    });
+
+    expect(result).toMatchObject({
+      policy: "open",
+      allowFrom: ["*"],
+      policyPath: "channels.msteams.dmPolicy",
+      allowFromPath: "channels.msteams.",
+    });
+    expect(result?.normalizeEntry?.("msteams:user:OWNER")).toBe("owner");
+  });
+
   it("advertises legacy and group-management message-tool actions together", () => {
     const actions = msteamsPlugin.actions?.describeMessageTool?.({
       cfg: createConfiguredMSTeamsCfg(),

--- a/extensions/msteams/src/channel.test.ts
+++ b/extensions/msteams/src/channel.test.ts
@@ -363,8 +363,12 @@ describe("msteamsPlugin", () => {
       expect(classify("Alice Example")).toBe("mutable");
       expect(classify("alice@example.com")).toBe("mutable");
       expect(classify("19:group@thread.tacv2")).toBeUndefined();
-      expect(classify(`conversation:${stableNonUuidId}`)).toBeUndefined();
-      expect(classify(`msteams:conversation:${stableNonUuidId}`)).toBeUndefined();
+      expect(classify(`conversation:${stableNonUuidId}`)).toBe("asserted");
+      expect(classify(`msteams:conversation:${stableNonUuidId}`)).toBe("asserted");
+      expect(classify(` teams:conversation:${stableId.toUpperCase()} `)).toBe("asserted");
+      expect(classify("conversation:Alice Example")).toBeUndefined();
+      expect(classify("msteams:conversation:alice@example.com")).toBeUndefined();
+      expect(classify("teams:conversation:19:group@thread.tacv2")).toBeUndefined();
     }
   });
 

--- a/extensions/msteams/src/channel.test.ts
+++ b/extensions/msteams/src/channel.test.ts
@@ -363,6 +363,8 @@ describe("msteamsPlugin", () => {
       expect(classify("Alice Example")).toBe("mutable");
       expect(classify("alice@example.com")).toBe("mutable");
       expect(classify("19:group@thread.tacv2")).toBeUndefined();
+      expect(classify(`conversation:${stableNonUuidId}`)).toBeUndefined();
+      expect(classify(`msteams:conversation:${stableNonUuidId}`)).toBeUndefined();
     }
   });
 

--- a/extensions/msteams/src/channel.test.ts
+++ b/extensions/msteams/src/channel.test.ts
@@ -289,7 +289,8 @@ describe("msteamsPlugin", () => {
         policyPath: "channels.msteams.dmPolicy",
         allowFromPath: "channels.msteams.",
       });
-      expect(result?.normalizeEntry?.("msteams:user:OWNER")).toBe("owner");
+      expect(result?.normalizeEntry?.(" OWNER ")).toBe("owner");
+      expect(result?.normalizeEntry?.(" msteams:user:OWNER ")).toBe("msteams:user:owner");
     }
     expect(msteamsSetupPlugin.security?.resolveDmPolicy).toBe(
       msteamsPlugin.security?.resolveDmPolicy,

--- a/extensions/msteams/src/channel.test.ts
+++ b/extensions/msteams/src/channel.test.ts
@@ -315,13 +315,12 @@ describe("msteamsPlugin", () => {
         throw new Error("msteams security.collectWarnings unavailable");
       }
 
-      await expect(
-        collectWarnings({
-          cfg,
-          accountId: "default",
-          account: plugin.config.resolveAccount(cfg, "default"),
-        }),
-      ).resolves.toEqual([
+      const warnings = await collectWarnings({
+        cfg,
+        accountId: "default",
+        account: plugin.config.resolveAccount(cfg, "default"),
+      });
+      expect(warnings).toEqual([
         expect.objectContaining({
           checkId: "channels.msteams.groups.open",
           severity: "critical",

--- a/extensions/msteams/src/channel.test.ts
+++ b/extensions/msteams/src/channel.test.ts
@@ -92,6 +92,7 @@ describe("msteamsPlugin", () => {
         accountId: "default",
         enabled: true,
         configured: true,
+        config: {},
         tokenStatus: "available",
       });
       expect(plugin.config.resolveAllowFrom?.({ cfg, accountId: "default" })).toEqual([
@@ -212,6 +213,7 @@ describe("msteamsPlugin", () => {
       accountId: "default",
       enabled: true,
       configured: true,
+      config: {},
       tokenStatus: "available",
     });
   });
@@ -295,6 +297,70 @@ describe("msteamsPlugin", () => {
     expect(msteamsSetupPlugin.security?.resolveDmPolicy).toBe(
       msteamsPlugin.security?.resolveDmPolicy,
     );
+  });
+
+  it("keeps critical open-group findings on the setup security surface", async () => {
+    const cfg = {
+      channels: {
+        msteams: {
+          ...createConfiguredMSTeamsCfg().channels?.msteams,
+          groupPolicy: "open",
+        },
+      },
+    } as OpenClawConfig;
+
+    for (const plugin of [msteamsPlugin, msteamsSetupPlugin]) {
+      const collectWarnings = plugin.security?.collectWarnings;
+      if (!collectWarnings) {
+        throw new Error("msteams security.collectWarnings unavailable");
+      }
+
+      await expect(
+        collectWarnings({
+          cfg,
+          accountId: "default",
+          account: plugin.config.resolveAccount(cfg, "default"),
+        }),
+      ).resolves.toEqual([
+        expect.objectContaining({
+          checkId: "channels.msteams.groups.open",
+          severity: "critical",
+        }),
+      ]);
+    }
+    expect(msteamsSetupPlugin.security?.collectWarnings).toBe(
+      msteamsPlugin.security?.collectWarnings,
+    );
+  });
+
+  it("classifies authored Teams identities for security audits", () => {
+    const stableId = "40a1a0ed-4ff2-4164-a219-55518990c197";
+    const cfg = {
+      channels: {
+        msteams: {
+          ...createConfiguredMSTeamsCfg().channels?.msteams,
+          dmPolicy: "allowlist",
+          allowFrom: [stableId, "Alice Example", "alice@example.com"],
+          dangerouslyAllowNameMatching: true,
+        },
+      },
+    } as OpenClawConfig;
+
+    for (const plugin of [msteamsPlugin, msteamsSetupPlugin]) {
+      const account = plugin.config.resolveAccount(cfg, "default");
+      const policy = plugin.security?.resolveDmPolicy?.({ cfg, account });
+      const classify = policy?.classifyEntryAuthentication;
+      if (!classify) {
+        throw new Error("msteams DM entry classifier unavailable");
+      }
+
+      expect(account.config).toEqual({ dangerouslyAllowNameMatching: true });
+      expect(classify(stableId)).toBe("asserted");
+      expect(classify(`teams:user:${stableId}`)).toBe("asserted");
+      expect(classify("Alice Example")).toBe("mutable");
+      expect(classify("alice@example.com")).toBe("mutable");
+      expect(classify("19:group@thread.tacv2")).toBeUndefined();
+    }
   });
 
   it("advertises legacy and group-management message-tool actions together", () => {

--- a/extensions/msteams/src/channel.test.ts
+++ b/extensions/msteams/src/channel.test.ts
@@ -291,9 +291,9 @@ describe("msteamsPlugin", () => {
         policyPath: "channels.msteams.dmPolicy",
         allowFromPath: "channels.msteams.",
       });
-      expect(result?.normalizeEntry?.(" OWNER ")).toBe("owner");
-      expect(result?.normalizeEntry?.(" msteams:user:OWNER ")).toBe("owner");
-      expect(result?.normalizeEntry?.(" teams:OWNER ")).toBe("owner");
+      expect(result?.normalizeEntry?.(" 0123456789ABCDEF ")).toBe("0123456789abcdef");
+      expect(result?.normalizeEntry?.(" msteams:user:0123456789ABCDEF ")).toBe("0123456789abcdef");
+      expect(result?.normalizeEntry?.(" teams:0123456789ABCDEF ")).toBe("0123456789abcdef");
     }
     expect(msteamsSetupPlugin.security?.resolveDmPolicy).toBe(
       msteamsPlugin.security?.resolveDmPolicy,

--- a/extensions/msteams/src/channel.ts
+++ b/extensions/msteams/src/channel.ts
@@ -11,10 +11,6 @@ import {
   createRuntimeOutboundDelegates,
 } from "openclaw/plugin-sdk/channel-outbound";
 import { createPairingPrefixStripper } from "openclaw/plugin-sdk/channel-pairing";
-import {
-  createAllowlistProviderGroupPolicyWarningCollector,
-  createConditionalWarningCollector,
-} from "openclaw/plugin-sdk/channel-policy";
 import { registerChannelRuntimeContext } from "openclaw/plugin-sdk/channel-runtime-context";
 import {
   createChannelDirectoryAdapter,
@@ -53,6 +49,7 @@ import {
   shouldSuppressLocalMSTeamsExecApprovalPrompt,
 } from "./approval-native.js";
 import { resolveMSTeamsAccount, type ResolvedMSTeamsAccount } from "./channel-config.js";
+import { collectMSTeamsSecurityFindings } from "./channel-security.js";
 import { msteamsSetupPlugin } from "./channel.setup.js";
 import { collectMSTeamsMutableAllowlistWarnings } from "./doctor.js";
 import { resolveMSTeamsGroupToolPolicy } from "./policy.js";
@@ -89,25 +86,6 @@ const MSTEAMS_GROUP_MANAGEMENT_ACTIONS = new Set<ChannelMessageActionName>([
   "removeParticipant",
   "renameGroup",
 ]);
-
-const collectMSTeamsSecurityWarnings = createAllowlistProviderGroupPolicyWarningCollector<{
-  cfg: OpenClawConfig;
-}>({
-  providerConfigPresent: (cfg) => cfg.channels?.msteams !== undefined,
-  resolveGroupPolicy: ({ cfg }) => cfg.channels?.msteams?.groupPolicy,
-  collect: ({ groupPolicy }) =>
-    groupPolicy === "open"
-      ? [
-          '- MS Teams groups: groupPolicy="open" allows any member to trigger (mention-gated). Set channels.msteams.groupPolicy="allowlist" + channels.msteams.groupAllowFrom to restrict senders.',
-        ]
-      : [],
-});
-const collectMSTeamsSecurityFindings = createConditionalWarningCollector.findings({
-  collectWarnings: collectMSTeamsSecurityWarnings,
-  checkId: "channels.msteams.groups.open",
-  severity: "critical",
-  title: "MS Teams security warning",
-});
 
 const loadMSTeamsChannelRuntime = createLazyRuntimeNamedExport(
   () => import("./channel.runtime.js"),
@@ -1097,7 +1075,7 @@ export const msteamsPlugin: ChannelPlugin<ResolvedMSTeamsAccount, ProbeMSTeamsRe
     },
     security: {
       ...msteamsSetupPlugin.security,
-      collectWarnings: ({ cfg }) => collectMSTeamsSecurityFindings({ cfg }),
+      collectWarnings: collectMSTeamsSecurityFindings,
     },
     pairing: {
       text: {

--- a/extensions/msteams/src/channel.ts
+++ b/extensions/msteams/src/channel.ts
@@ -29,7 +29,6 @@ import type {
   ChannelMessageActionName,
   ChannelOutboundAdapter,
   ChannelPlugin,
-  OpenClawConfig,
 } from "../runtime-api.js";
 import {
   buildProbeChannelStatusSummary,

--- a/extensions/msteams/src/channel.ts
+++ b/extensions/msteams/src/channel.ts
@@ -1,5 +1,7 @@
 // Msteams plugin module implements channel behavior.
 import { CHANNEL_APPROVAL_NATIVE_RUNTIME_CONTEXT_CAPABILITY } from "openclaw/plugin-sdk/approval-handler-adapter-runtime";
+import { describeAccountSnapshot } from "openclaw/plugin-sdk/account-helpers";
+import { createScopedDmSecurityResolver } from "openclaw/plugin-sdk/channel-config-helpers";
 import type {
   ChannelMessageActionAdapter,
   ChannelMessageToolDiscovery,
@@ -107,6 +109,18 @@ const collectMSTeamsSecurityFindings = createConditionalWarningCollector.finding
   checkId: "channels.msteams.groups.open",
   severity: "critical",
   title: "MS Teams security warning",
+});
+
+const resolveMSTeamsDmPolicy = createScopedDmSecurityResolver<ResolvedMSTeamsAccount>({
+  channelKey: "msteams",
+  resolvePolicy: () => undefined,
+  resolveAllowFrom: () => undefined,
+  resolveAccess: ({ cfg }) => ({
+    dmPolicy: cfg.channels?.msteams?.dmPolicy,
+    allowFrom: cfg.channels?.msteams?.allowFrom,
+  }),
+  policyPathSuffix: "dmPolicy",
+  normalizeEntry: (raw) => normalizeMSTeamsUserInput(raw).toLowerCase(),
 });
 
 const loadMSTeamsChannelRuntime = createLazyRuntimeNamedExport(
@@ -1096,6 +1110,7 @@ export const msteamsPlugin: ChannelPlugin<ResolvedMSTeamsAccount, ProbeMSTeamsRe
       },
     },
     security: {
+      resolveDmPolicy: resolveMSTeamsDmPolicy,
       collectWarnings: ({ cfg }) => collectMSTeamsSecurityFindings({ cfg }),
     },
     pairing: {

--- a/extensions/msteams/src/channel.ts
+++ b/extensions/msteams/src/channel.ts
@@ -63,6 +63,7 @@ import {
 import {
   normalizeMSTeamsMessagingTarget,
   normalizeMSTeamsUserInput,
+  isStableMSTeamsUserId,
   looksLikeMSTeamsTargetId,
   parseMSTeamsConversationId,
   parseMSTeamsTeamChannelInput,
@@ -493,7 +494,7 @@ export const msteamsPlugin: ChannelPlugin<ResolvedMSTeamsAccount, ProbeMSTeamsRe
                 return;
               }
               const cleaned = stripPrefix(trimmed);
-              if (/^[0-9a-fA-F-]{16,}$/.test(cleaned) || cleaned.includes("@")) {
+              if (isStableMSTeamsUserId(cleaned) || cleaned.includes("@")) {
                 entry.resolved = true;
                 entry.id = cleaned;
                 return;

--- a/extensions/msteams/src/channel.ts
+++ b/extensions/msteams/src/channel.ts
@@ -1,7 +1,5 @@
 // Msteams plugin module implements channel behavior.
 import { CHANNEL_APPROVAL_NATIVE_RUNTIME_CONTEXT_CAPABILITY } from "openclaw/plugin-sdk/approval-handler-adapter-runtime";
-import { describeAccountSnapshot } from "openclaw/plugin-sdk/account-helpers";
-import { createScopedDmSecurityResolver } from "openclaw/plugin-sdk/channel-config-helpers";
 import type {
   ChannelMessageActionAdapter,
   ChannelMessageToolDiscovery,
@@ -109,18 +107,6 @@ const collectMSTeamsSecurityFindings = createConditionalWarningCollector.finding
   checkId: "channels.msteams.groups.open",
   severity: "critical",
   title: "MS Teams security warning",
-});
-
-const resolveMSTeamsDmPolicy = createScopedDmSecurityResolver<ResolvedMSTeamsAccount>({
-  channelKey: "msteams",
-  resolvePolicy: () => undefined,
-  resolveAllowFrom: () => undefined,
-  resolveAccess: ({ cfg }) => ({
-    dmPolicy: cfg.channels?.msteams?.dmPolicy,
-    allowFrom: cfg.channels?.msteams?.allowFrom,
-  }),
-  policyPathSuffix: "dmPolicy",
-  normalizeEntry: (raw) => normalizeMSTeamsUserInput(raw).toLowerCase(),
 });
 
 const loadMSTeamsChannelRuntime = createLazyRuntimeNamedExport(
@@ -1110,7 +1096,7 @@ export const msteamsPlugin: ChannelPlugin<ResolvedMSTeamsAccount, ProbeMSTeamsRe
       },
     },
     security: {
-      resolveDmPolicy: resolveMSTeamsDmPolicy,
+      ...msteamsSetupPlugin.security,
       collectWarnings: ({ cfg }) => collectMSTeamsSecurityFindings({ cfg }),
     },
     pairing: {

--- a/extensions/msteams/src/inbound.ts
+++ b/extensions/msteams/src/inbound.ts
@@ -1,6 +1,8 @@
 // Msteams plugin module implements inbound behavior.
 import { decodeHtmlEntities } from "openclaw/plugin-sdk/html-entity-runtime";
 
+export { normalizeMSTeamsConversationId } from "./ingress-identity.js";
+
 type MSTeamsQuoteInfo = {
   sender: string;
   body: string;
@@ -84,10 +86,6 @@ type MentionableActivity = {
     mentioned?: { id?: string };
   }> | null;
 };
-
-export function normalizeMSTeamsConversationId(raw: string): string {
-  return raw.split(";")[0] ?? raw;
-}
 
 export function extractMSTeamsConversationMessageId(raw: string): string | undefined {
   if (!raw) {

--- a/extensions/msteams/src/ingress-identity.ts
+++ b/extensions/msteams/src/ingress-identity.ts
@@ -1,0 +1,121 @@
+// Msteams plugin module owns lightweight sender identity normalization and audit classification.
+import type {
+  IdentifierAuthentication,
+  StableChannelIngressIdentityParams,
+} from "openclaw/plugin-sdk/channel-ingress-runtime";
+import { normalizeOptionalLowercaseString } from "openclaw/plugin-sdk/string-coerce-runtime";
+
+const MSTEAMS_SENDER_NAME_KIND = "plugin:msteams-sender-name" as const;
+const MSTEAMS_CONVERSATION_ID_KIND = "plugin:msteams-conversation-id" as const;
+const MSTEAMS_AAD_OBJECT_ID = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+const MSTEAMS_GROUP_CONVERSATION_ID = /^19:.+@thread\.(?:tacv2|skype|v2)$/i;
+
+function stripProviderPrefix(raw: string): string {
+  return raw.replace(/^(msteams|teams):/i, "");
+}
+
+export function normalizeMSTeamsUserInput(raw: string): string {
+  return stripProviderPrefix(raw)
+    .replace(/^(user|conversation):/i, "")
+    .trim();
+}
+
+export function normalizeMSTeamsConversationId(raw: string): string {
+  return raw.split(";")[0] ?? raw;
+}
+
+/** Detect supported prefixed and bare Bot Framework or Graph conversation IDs. */
+export function looksLikeMSTeamsConversationId(raw: string): boolean {
+  const trimmed = raw.trim();
+  if (!trimmed) {
+    return false;
+  }
+  if (/^conversation:/i.test(trimmed)) {
+    return true;
+  }
+  if (MSTEAMS_GROUP_CONVERSATION_ID.test(trimmed)) {
+    return true;
+  }
+  if (/^19:.+@unq\.gbl\.spaces$/i.test(trimmed)) {
+    return true;
+  }
+  if (/^a:1[A-Za-z0-9_-]+$/i.test(trimmed)) {
+    return true;
+  }
+  if (/^8:orgid:[A-Za-z0-9-]+$/i.test(trimmed)) {
+    return true;
+  }
+  return /@thread\b/i.test(trimmed);
+}
+
+function normalizeIngressValue(value?: string | null): string | null {
+  return normalizeOptionalLowercaseString(value) ?? null;
+}
+
+function normalizeSenderNameIngressValue(value?: string | null): string | null {
+  const normalized = normalizeIngressValue(value);
+  if (!normalized) {
+    return null;
+  }
+  // Conversation allowlist entries must never become spoofable display-name principals.
+  return looksLikeMSTeamsConversationId(normalizeMSTeamsConversationId(normalized))
+    ? null
+    : normalized;
+}
+
+function normalizeAllowlistConversationId(value?: string | null): string | null {
+  const trimmed = value?.trim();
+  // Microsoft Graph conversation IDs are opaque; case-folding would authorize a different chat.
+  return trimmed ? normalizeMSTeamsConversationId(trimmed) : null;
+}
+
+export const msteamsIngressIdentity = {
+  key: "sender-id",
+  // Bot Framework authenticates the connector and vouches for the activity, without this
+  // plugin independently proving exact ownership of every from.id representation.
+  authentication: "asserted",
+  normalize: normalizeIngressValue,
+  aliases: [
+    {
+      key: "sender-name",
+      kind: MSTEAMS_SENDER_NAME_KIND,
+      normalizeEntry: normalizeSenderNameIngressValue,
+      normalizeSubject: normalizeSenderNameIngressValue,
+      authentication: "mutable",
+    },
+    {
+      key: "conversation-id",
+      kind: MSTEAMS_CONVERSATION_ID_KIND,
+      authentication: "asserted",
+      normalizeEntry: normalizeAllowlistConversationId,
+      normalizeSubject: normalizeAllowlistConversationId,
+    },
+  ],
+  isWildcardEntry: (entry) => normalizeIngressValue(entry) === "*",
+  resolveEntryId: ({ entryIndex, fieldKey }) =>
+    `msteams-entry-${entryIndex + 1}:${
+      fieldKey === "sender-name"
+        ? "name"
+        : fieldKey === "conversation-id"
+          ? "conversation-id"
+          : "id"
+    }`,
+} satisfies StableChannelIngressIdentityParams;
+
+/** Classify authored DM allowlist entries without loading the Teams runtime. */
+export function classifyMSTeamsEntryAuthentication(
+  raw: string,
+): IdentifierAuthentication | undefined {
+  const unscoped = stripProviderPrefix(raw).trim();
+  const normalized = normalizeMSTeamsUserInput(raw);
+  if (
+    !normalized ||
+    normalized === "*" ||
+    /^conversation:/i.test(unscoped) ||
+    /^accessGroup:/i.test(normalized) ||
+    looksLikeMSTeamsConversationId(normalizeMSTeamsConversationId(normalized))
+  ) {
+    return undefined;
+  }
+  return MSTEAMS_AAD_OBJECT_ID.test(normalized) ? "asserted" : "mutable";
+}

--- a/extensions/msteams/src/ingress-identity.ts
+++ b/extensions/msteams/src/ingress-identity.ts
@@ -15,18 +15,23 @@ function stripProviderPrefix(raw: string): string {
 }
 
 export function normalizeMSTeamsUserInput(raw: string): string {
-  return stripProviderPrefix(raw)
+  return stripProviderPrefix(raw.trim())
     .replace(/^(user|conversation):/i, "")
     .trim();
 }
 
+/** Canonical user principal shared by startup projection, security audit, and ingress. */
+export function normalizeMSTeamsDmPrincipal(raw: string): string {
+  return normalizeMSTeamsUserInput(raw).toLowerCase();
+}
+
 /** Match the stable user-id shape accepted by runtime allowlist projection and targeting. */
 export function isStableMSTeamsUserId(raw: string): boolean {
-  const unscoped = stripProviderPrefix(raw).trim();
+  const unscoped = stripProviderPrefix(raw.trim()).trim();
   if (/^conversation:/i.test(unscoped)) {
     return false;
   }
-  return MSTEAMS_STABLE_USER_ID.test(normalizeMSTeamsUserInput(unscoped));
+  return MSTEAMS_STABLE_USER_ID.test(normalizeMSTeamsDmPrincipal(unscoped));
 }
 
 export function normalizeMSTeamsConversationId(raw: string): string {
@@ -70,7 +75,7 @@ function normalizeMSTeamsIngressUserId(value?: string | null): string | null {
   if (/^conversation:/i.test(unscoped)) {
     return null;
   }
-  return unscoped.replace(/^user:/i, "").trim() || null;
+  return normalizeMSTeamsDmPrincipal(unscoped) || null;
 }
 
 function normalizeSenderNameIngressValue(value?: string | null): string | null {

--- a/extensions/msteams/src/ingress-identity.ts
+++ b/extensions/msteams/src/ingress-identity.ts
@@ -22,7 +22,11 @@ export function normalizeMSTeamsUserInput(raw: string): string {
 
 /** Match the stable user-id shape accepted by runtime allowlist projection and targeting. */
 export function isStableMSTeamsUserId(raw: string): boolean {
-  return MSTEAMS_STABLE_USER_ID.test(normalizeMSTeamsUserInput(raw));
+  const unscoped = stripProviderPrefix(raw).trim();
+  if (/^conversation:/i.test(unscoped)) {
+    return false;
+  }
+  return MSTEAMS_STABLE_USER_ID.test(normalizeMSTeamsUserInput(unscoped));
 }
 
 export function normalizeMSTeamsConversationId(raw: string): string {

--- a/extensions/msteams/src/ingress-identity.ts
+++ b/extensions/msteams/src/ingress-identity.ts
@@ -20,9 +20,18 @@ export function normalizeMSTeamsUserInput(raw: string): string {
     .trim();
 }
 
-/** Canonical user principal shared by startup projection, security audit, and ingress. */
-export function normalizeMSTeamsDmPrincipal(raw: string): string {
-  return normalizeMSTeamsUserInput(raw).toLowerCase();
+/** Project static DM principals; only opted-in audits may include resolvable names. */
+export function normalizeMSTeamsDmPrincipal(raw: string, allowNameMatching = false): string {
+  const trimmed = raw.trim();
+  if (trimmed === "*" || /^accessGroup:/i.test(trimmed)) {
+    return trimmed;
+  }
+  // Startup has historically projected conversation-prefixed hexadecimal user IDs.
+  const id = normalizeMSTeamsUserInput(trimmed).toLowerCase();
+  return isStableMSTeamsUserId(id) ||
+    (allowNameMatching && classifyMSTeamsEntryAuthentication(trimmed) === "mutable")
+    ? id
+    : "";
 }
 
 /** Match the stable user-id shape accepted by runtime allowlist projection and targeting. */
@@ -31,7 +40,7 @@ export function isStableMSTeamsUserId(raw: string): boolean {
   if (/^conversation:/i.test(unscoped)) {
     return false;
   }
-  return MSTEAMS_STABLE_USER_ID.test(normalizeMSTeamsDmPrincipal(unscoped));
+  return MSTEAMS_STABLE_USER_ID.test(normalizeMSTeamsUserInput(unscoped));
 }
 
 export function normalizeMSTeamsConversationId(raw: string): string {
@@ -75,7 +84,7 @@ function normalizeMSTeamsIngressUserId(value?: string | null): string | null {
   if (/^conversation:/i.test(unscoped)) {
     return null;
   }
-  return normalizeMSTeamsDmPrincipal(unscoped) || null;
+  return normalizeMSTeamsUserInput(unscoped) || null;
 }
 
 function normalizeSenderNameIngressValue(value?: string | null): string | null {
@@ -137,7 +146,7 @@ export function classifyMSTeamsEntryAuthentication(
   // Audit the startup projection, not a raw inbound identity: legacy typed
   // hexadecimal entries already authorize the projected user. Ingress and
   // approval checks must still reject raw conversation-form identities.
-  if (isStableMSTeamsUserId(normalizeMSTeamsDmPrincipal(raw))) {
+  if (isStableMSTeamsUserId(normalizeMSTeamsUserInput(raw))) {
     return "asserted";
   }
   const normalized = normalizeMSTeamsIngressUserId(raw);

--- a/extensions/msteams/src/ingress-identity.ts
+++ b/extensions/msteams/src/ingress-identity.ts
@@ -7,7 +7,7 @@ import { normalizeOptionalLowercaseString } from "openclaw/plugin-sdk/string-coe
 
 const MSTEAMS_SENDER_NAME_KIND = "plugin:msteams-sender-name" as const;
 const MSTEAMS_CONVERSATION_ID_KIND = "plugin:msteams-conversation-id" as const;
-const MSTEAMS_AAD_OBJECT_ID = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+const MSTEAMS_STABLE_USER_ID = /^[0-9a-f-]{16,}$/i;
 const MSTEAMS_GROUP_CONVERSATION_ID = /^19:.+@thread\.(?:tacv2|skype|v2)$/i;
 
 function stripProviderPrefix(raw: string): string {
@@ -18,6 +18,11 @@ export function normalizeMSTeamsUserInput(raw: string): string {
   return stripProviderPrefix(raw)
     .replace(/^(user|conversation):/i, "")
     .trim();
+}
+
+/** Match the stable user-id shape accepted by runtime allowlist projection and targeting. */
+export function isStableMSTeamsUserId(raw: string): boolean {
+  return MSTEAMS_STABLE_USER_ID.test(normalizeMSTeamsUserInput(raw));
 }
 
 export function normalizeMSTeamsConversationId(raw: string): string {
@@ -117,5 +122,5 @@ export function classifyMSTeamsEntryAuthentication(
   ) {
     return undefined;
   }
-  return MSTEAMS_AAD_OBJECT_ID.test(normalized) ? "asserted" : "mutable";
+  return isStableMSTeamsUserId(normalized) ? "asserted" : "mutable";
 }

--- a/extensions/msteams/src/ingress-identity.ts
+++ b/extensions/msteams/src/ingress-identity.ts
@@ -134,6 +134,12 @@ export const msteamsIngressIdentity = {
 export function classifyMSTeamsEntryAuthentication(
   raw: string,
 ): IdentifierAuthentication | undefined {
+  // Audit the startup projection, not a raw inbound identity: legacy typed
+  // hexadecimal entries already authorize the projected user. Ingress and
+  // approval checks must still reject raw conversation-form identities.
+  if (isStableMSTeamsUserId(normalizeMSTeamsDmPrincipal(raw))) {
+    return "asserted";
+  }
   const normalized = normalizeMSTeamsIngressUserId(raw);
   if (
     !normalized ||
@@ -143,5 +149,5 @@ export function classifyMSTeamsEntryAuthentication(
   ) {
     return undefined;
   }
-  return MSTEAMS_STABLE_USER_ID.test(normalized) ? "asserted" : "mutable";
+  return "mutable";
 }

--- a/extensions/msteams/src/ingress-identity.ts
+++ b/extensions/msteams/src/ingress-identity.ts
@@ -61,13 +61,27 @@ function normalizeIngressValue(value?: string | null): string | null {
   return normalizeOptionalLowercaseString(value) ?? null;
 }
 
+function normalizeMSTeamsIngressUserId(value?: string | null): string | null {
+  const normalized = normalizeIngressValue(value);
+  if (!normalized) {
+    return null;
+  }
+  const unscoped = stripProviderPrefix(normalized).trim();
+  if (/^conversation:/i.test(unscoped)) {
+    return null;
+  }
+  return unscoped.replace(/^user:/i, "").trim() || null;
+}
+
 function normalizeSenderNameIngressValue(value?: string | null): string | null {
   const normalized = normalizeIngressValue(value);
   if (!normalized) {
     return null;
   }
   // Conversation allowlist entries must never become spoofable display-name principals.
-  return looksLikeMSTeamsConversationId(normalizeMSTeamsConversationId(normalized))
+  return looksLikeMSTeamsConversationId(
+    normalizeMSTeamsConversationId(stripProviderPrefix(normalized)),
+  )
     ? null
     : normalized;
 }
@@ -83,7 +97,7 @@ export const msteamsIngressIdentity = {
   // Bot Framework authenticates the connector and vouches for the activity, without this
   // plugin independently proving exact ownership of every from.id representation.
   authentication: "asserted",
-  normalize: normalizeIngressValue,
+  normalize: normalizeMSTeamsIngressUserId,
   aliases: [
     {
       key: "sender-name",
@@ -115,16 +129,14 @@ export const msteamsIngressIdentity = {
 export function classifyMSTeamsEntryAuthentication(
   raw: string,
 ): IdentifierAuthentication | undefined {
-  const unscoped = stripProviderPrefix(raw).trim();
-  const normalized = normalizeMSTeamsUserInput(raw);
+  const normalized = normalizeMSTeamsIngressUserId(raw);
   if (
     !normalized ||
     normalized === "*" ||
-    /^conversation:/i.test(unscoped) ||
     /^accessGroup:/i.test(normalized) ||
     looksLikeMSTeamsConversationId(normalizeMSTeamsConversationId(normalized))
   ) {
     return undefined;
   }
-  return isStableMSTeamsUserId(normalized) ? "asserted" : "mutable";
+  return MSTEAMS_STABLE_USER_ID.test(normalized) ? "asserted" : "mutable";
 }

--- a/extensions/msteams/src/monitor-handler/access.participant.test.ts
+++ b/extensions/msteams/src/monitor-handler/access.participant.test.ts
@@ -1,6 +1,8 @@
 import type { ResolveStableChannelMessageIngressParams } from "openclaw/plugin-sdk/channel-ingress-runtime";
 import { describe, expect, it, vi } from "vitest";
+import { resolveMSTeamsAccount, resolveMSTeamsDmPolicy } from "../channel-config.js";
 import { installMSTeamsTestRuntime } from "../monitor-handler.test-helpers.js";
+import { projectStableMSTeamsUserAllowlist } from "../resolve-allowlist.js";
 import { resolveMSTeamsSenderAccess } from "./access.js";
 
 const observed = vi.hoisted(() =>
@@ -19,6 +21,62 @@ vi.mock("openclaw/plugin-sdk/channel-ingress-runtime", async (importOriginal) =>
 });
 
 describe("Teams participant domain", () => {
+  it("keeps startup projection, audit identity, and inbound admission on one principal", async () => {
+    installMSTeamsTestRuntime({ readAllowFromStore: vi.fn(async () => []) });
+    const stableId = "40a1a0ed-4ff2-4164-a219-55518990c197";
+    const authoredAllowFrom = [
+      stableId.toUpperCase(),
+      `user:${stableId}`,
+      `teams:${stableId}`,
+      `msteams:user:${stableId}`,
+    ];
+    const cfg = {
+      channels: {
+        msteams: {
+          appId: "app-id",
+          appPassword: "secret",
+          dmPolicy: "allowlist" as const,
+          allowFrom: authoredAllowFrom,
+        },
+      },
+    };
+    const projectedAllowFrom = projectStableMSTeamsUserAllowlist(authoredAllowFrom);
+    const auditPolicy = resolveMSTeamsDmPolicy({
+      cfg,
+      account: resolveMSTeamsAccount(cfg),
+    });
+    const auditedPrincipals = new Set(
+      authoredAllowFrom.map((entry) => auditPolicy.normalizeEntry?.(entry)),
+    );
+
+    expect(projectedAllowFrom).toEqual([stableId]);
+    expect([...auditedPrincipals]).toEqual([stableId]);
+
+    const result = await resolveMSTeamsSenderAccess({
+      cfg: {
+        channels: {
+          msteams: {
+            dmPolicy: "allowlist",
+            allowFrom: projectedAllowFrom,
+          },
+        },
+      },
+      activity: {
+        type: "message",
+        id: "message",
+        text: "hello",
+        serviceUrl: "https://fixture.invalid",
+        channelId: "msteams",
+        from: { id: "opaque-account", aadObjectId: stableId.toUpperCase(), name: "Alice" },
+        recipient: { id: "bot", name: "Bot" },
+        conversation: { id: "conversation", conversationType: "personal" },
+      },
+    });
+
+    expect(result.senderAccess.decision).toBe("allow");
+    expect(result.senderAccess.effectiveAllowFrom).toEqual([stableId]);
+  });
+
   it.each([
     ["bare", "40a1a0ed-4ff2-4164-a219-55518990c197", "allow"],
     ["user-prefixed", "user:40a1a0ed-4ff2-4164-a219-55518990c197", "allow"],

--- a/extensions/msteams/src/monitor-handler/access.participant.test.ts
+++ b/extensions/msteams/src/monitor-handler/access.participant.test.ts
@@ -19,6 +19,47 @@ vi.mock("openclaw/plugin-sdk/channel-ingress-runtime", async (importOriginal) =>
 });
 
 describe("Teams participant domain", () => {
+  it.each([
+    ["bare", "40a1a0ed-4ff2-4164-a219-55518990c197", "allow"],
+    ["user-prefixed", "user:40a1a0ed-4ff2-4164-a219-55518990c197", "allow"],
+    ["provider-prefixed", "teams:40a1a0ed-4ff2-4164-a219-55518990c197", "allow"],
+    ["provider-and-user-prefixed", "msteams:user:40a1a0ed-4ff2-4164-a219-55518990c197", "allow"],
+    ["conversation-prefixed", "conversation:40a1a0ed-4ff2-4164-a219-55518990c197", "block"],
+    [
+      "provider-and-conversation-prefixed",
+      "msteams:conversation:40a1a0ed-4ff2-4164-a219-55518990c197",
+      "block",
+    ],
+  ] as const)(
+    "applies a typed %s entry before message handling",
+    async (_label, allowEntry, expected) => {
+      installMSTeamsTestRuntime({ readAllowFromStore: vi.fn(async () => []) });
+      const stableId = "40a1a0ed-4ff2-4164-a219-55518990c197";
+      const result = await resolveMSTeamsSenderAccess({
+        cfg: {
+          channels: {
+            msteams: {
+              dmPolicy: "allowlist",
+              allowFrom: [allowEntry],
+            },
+          },
+        },
+        activity: {
+          type: "message",
+          id: "message",
+          text: "hello",
+          serviceUrl: "https://fixture.invalid",
+          channelId: "msteams",
+          from: { id: "opaque-account", aadObjectId: stableId, name: "Alice" },
+          recipient: { id: "bot", name: "Bot" },
+          conversation: { id: "conversation", conversationType: "personal" },
+        },
+      });
+
+      expect(result.senderAccess.decision).toBe(expected);
+    },
+  );
+
   it.each(["entra", "application", "unknown"] as const)(
     "retains %s identity evidence",
     async (kind) => {

--- a/extensions/msteams/src/monitor-handler/access.participant.test.ts
+++ b/extensions/msteams/src/monitor-handler/access.participant.test.ts
@@ -29,6 +29,9 @@ describe("Teams participant domain", () => {
       `user:${stableId}`,
       `teams:${stableId}`,
       `msteams:user:${stableId}`,
+      `conversation:${stableId}`,
+      ` teams:conversation:${stableId.toUpperCase()} `,
+      `msteams:conversation:${stableId}`,
     ];
     const cfg = {
       channels: {
@@ -51,6 +54,9 @@ describe("Teams participant domain", () => {
 
     expect(projectedAllowFrom).toEqual([stableId]);
     expect([...auditedPrincipals]).toEqual([stableId]);
+    expect(
+      authoredAllowFrom.map((entry) => auditPolicy.classifyEntryAuthentication?.(entry)),
+    ).toEqual(authoredAllowFrom.map(() => "asserted"));
 
     const result = await resolveMSTeamsSenderAccess({
       cfg: {

--- a/extensions/msteams/src/monitor-handler/access.ts
+++ b/extensions/msteams/src/monitor-handler/access.ts
@@ -5,7 +5,6 @@ import {
   channelIngressRoutes,
   resolveStableChannelMessageIngress,
   type ChannelIngressContextBinding,
-  type StableChannelIngressIdentityParams,
 } from "openclaw/plugin-sdk/channel-ingress-runtime";
 import { normalizeOptionalLowercaseString } from "openclaw/plugin-sdk/string-coerce-runtime";
 import {
@@ -21,67 +20,11 @@ import type {
 } from "../conversation-store.js";
 import { formatUnknownError } from "../errors.js";
 import { normalizeMSTeamsConversationId } from "../inbound.js";
+import { msteamsIngressIdentity } from "../ingress-identity.js";
 import type { MSTeamsMonitorLogger } from "../monitor-types.js";
 import { resolveMSTeamsAllowlistMatch, resolveMSTeamsRouteConfig } from "../policy.js";
-import { looksLikeMSTeamsConversationId } from "../resolve-allowlist.js";
 import { getMSTeamsRuntime } from "../runtime.js";
 import type { MSTeamsTurnContext } from "../sdk-types.js";
-
-const MSTEAMS_SENDER_NAME_KIND = "plugin:msteams-sender-name" as const;
-const MSTEAMS_CONVERSATION_ID_KIND = "plugin:msteams-conversation-id" as const;
-const msteamsIngressIdentity = {
-  key: "sender-id",
-  // Bot Framework authenticates the connector and vouches for the activity, without this
-  // plugin independently proving exact ownership of every from.id representation.
-  authentication: "asserted",
-  normalize: normalizeIngressValue,
-  aliases: [
-    {
-      key: "sender-name",
-      kind: MSTEAMS_SENDER_NAME_KIND,
-      normalizeEntry: normalizeSenderNameIngressValue,
-      normalizeSubject: normalizeSenderNameIngressValue,
-      authentication: "mutable",
-    },
-    {
-      key: "conversation-id",
-      kind: MSTEAMS_CONVERSATION_ID_KIND,
-      authentication: "asserted",
-      normalizeEntry: normalizeAllowlistConversationId,
-      normalizeSubject: normalizeAllowlistConversationId,
-    },
-  ],
-  isWildcardEntry: (entry) => normalizeIngressValue(entry) === "*",
-  resolveEntryId: ({ entryIndex, fieldKey }) =>
-    `msteams-entry-${entryIndex + 1}:${
-      fieldKey === "sender-name"
-        ? "name"
-        : fieldKey === "conversation-id"
-          ? "conversation-id"
-          : "id"
-    }`,
-} satisfies StableChannelIngressIdentityParams;
-
-function normalizeIngressValue(value?: string | null): string | null {
-  return normalizeOptionalLowercaseString(value) ?? null;
-}
-
-function normalizeSenderNameIngressValue(value?: string | null): string | null {
-  const normalized = normalizeIngressValue(value);
-  if (!normalized) {
-    return null;
-  }
-  // Conversation allowlist entries must never become spoofable display-name principals.
-  return looksLikeMSTeamsConversationId(normalizeMSTeamsConversationId(normalized))
-    ? null
-    : normalized;
-}
-
-function normalizeAllowlistConversationId(value?: string | null): string | null {
-  const trimmed = value?.trim();
-  // Microsoft Graph conversation IDs are opaque; case-folding would authorize a different chat.
-  return trimmed ? normalizeMSTeamsConversationId(trimmed) : null;
-}
 
 function formatMSTeamsSenderReason(params: {
   reasonCode: string;

--- a/extensions/msteams/src/monitor.ts
+++ b/extensions/msteams/src/monitor.ts
@@ -41,6 +41,7 @@ import {
 import { resolveMSTeamsPrivateQaRuntime } from "./qa/private-runtime.js";
 import { createMSTeamsReplayContext } from "./replay-context.js";
 import {
+  isStableMSTeamsUserId,
   looksLikeMSTeamsConversationId,
   projectStableMSTeamsGroupAllowlist,
   projectStableMSTeamsUserAllowlist,
@@ -118,11 +119,10 @@ export async function monitorMSTeamsProvider(
       .replace(/^(msteams|teams):/i, "")
       .replace(/^user:/i, "")
       .trim();
-  const isStableUserId = (entry: string) => /^[0-9a-fA-F-]{16,}$/.test(entry);
   const cleanAllowEntries = (entries?: string[]) =>
     entries?.map((entry) => cleanAllowEntry(entry)).filter((entry) => entry && entry !== "*") ?? [];
   const isMutableUserEntry = (entry: string) =>
-    !isStableUserId(entry) &&
+    !isStableMSTeamsUserId(entry) &&
     !/^accessGroup:/i.test(entry) &&
     !looksLikeMSTeamsConversationId(normalizeMSTeamsConversationId(entry));
 

--- a/extensions/msteams/src/resolve-allowlist.test.ts
+++ b/extensions/msteams/src/resolve-allowlist.test.ts
@@ -120,9 +120,15 @@ describe("projectStableMSTeamsUserAllowlist", () => {
         "*",
         "accessGroup:operators",
         "msteams:user:40a1a0ed-4ff2-4164-a219-55518990c197",
+        "teams:user:0123456789abcdef",
         "Alice Example",
       ]),
-    ).toEqual(["*", "accessGroup:operators", "40a1a0ed-4ff2-4164-a219-55518990c197"]);
+    ).toEqual([
+      "*",
+      "accessGroup:operators",
+      "40a1a0ed-4ff2-4164-a219-55518990c197",
+      "0123456789abcdef",
+    ]);
   });
 
   it("does not authorize group conversation IDs in the direct-message allowlist", () => {

--- a/extensions/msteams/src/resolve-allowlist.test.ts
+++ b/extensions/msteams/src/resolve-allowlist.test.ts
@@ -131,7 +131,7 @@ describe("projectStableMSTeamsUserAllowlist", () => {
     ]);
   });
 
-  it("does not authorize group conversation IDs in the direct-message allowlist", () => {
+  it("preserves legacy typed stable IDs while dropping opaque conversation IDs", () => {
     expect(
       projectStableMSTeamsUserAllowlist([
         "19:group@thread.tacv2",
@@ -140,7 +140,7 @@ describe("projectStableMSTeamsUserAllowlist", () => {
         "msteams:conversation:fedcba9876543210",
         "user:40a1a0ed-4ff2-4164-a219-55518990c197",
       ]),
-    ).toEqual(["40a1a0ed-4ff2-4164-a219-55518990c197"]);
+    ).toEqual(["0123456789abcdef", "fedcba9876543210", "40a1a0ed-4ff2-4164-a219-55518990c197"]);
   });
 });
 

--- a/extensions/msteams/src/resolve-allowlist.test.ts
+++ b/extensions/msteams/src/resolve-allowlist.test.ts
@@ -136,6 +136,8 @@ describe("projectStableMSTeamsUserAllowlist", () => {
       projectStableMSTeamsUserAllowlist([
         "19:group@thread.tacv2",
         "19:legacy@thread.skype",
+        "conversation:0123456789abcdef",
+        "msteams:conversation:fedcba9876543210",
         "user:40a1a0ed-4ff2-4164-a219-55518990c197",
       ]),
     ).toEqual(["40a1a0ed-4ff2-4164-a219-55518990c197"]);

--- a/extensions/msteams/src/resolve-allowlist.ts
+++ b/extensions/msteams/src/resolve-allowlist.ts
@@ -96,7 +96,9 @@ function normalizeStaticMSTeamsAllowEntry(raw: string): string | undefined {
   if (trimmed === "*" || /^accessGroup:/i.test(trimmed)) {
     return trimmed;
   }
-  return isStableMSTeamsUserId(trimmed) ? normalizeMSTeamsUserInput(trimmed) : undefined;
+  // Preserve the previous startup projection for typed hexadecimal entries.
+  const id = normalizeMSTeamsUserInput(trimmed);
+  return isStableMSTeamsUserId(id) ? id : undefined;
 }
 
 export function projectStableMSTeamsUserAllowlist(entries?: string[]): string[] | undefined {

--- a/extensions/msteams/src/resolve-allowlist.ts
+++ b/extensions/msteams/src/resolve-allowlist.ts
@@ -96,8 +96,7 @@ function normalizeStaticMSTeamsAllowEntry(raw: string): string | undefined {
   if (trimmed === "*" || /^accessGroup:/i.test(trimmed)) {
     return trimmed;
   }
-  const id = normalizeMSTeamsUserInput(trimmed);
-  return isStableMSTeamsUserId(id) ? id : undefined;
+  return isStableMSTeamsUserId(trimmed) ? normalizeMSTeamsUserInput(trimmed) : undefined;
 }
 
 export function projectStableMSTeamsUserAllowlist(entries?: string[]): string[] | undefined {

--- a/extensions/msteams/src/resolve-allowlist.ts
+++ b/extensions/msteams/src/resolve-allowlist.ts
@@ -12,7 +12,13 @@ import {
   type GraphGroup,
   type GraphUser,
 } from "./graph.js";
-import { normalizeMSTeamsConversationId } from "./inbound.js";
+import {
+  looksLikeMSTeamsConversationId,
+  normalizeMSTeamsConversationId,
+  normalizeMSTeamsUserInput,
+} from "./ingress-identity.js";
+
+export { looksLikeMSTeamsConversationId, normalizeMSTeamsUserInput } from "./ingress-identity.js";
 
 type MSTeamsChannelResolution = {
   input: string;
@@ -150,12 +156,6 @@ export function normalizeMSTeamsMessagingTarget(raw: string): string | undefined
   return trimmed || undefined;
 }
 
-export function normalizeMSTeamsUserInput(raw: string): string {
-  return stripProviderPrefix(raw)
-    .replace(/^(user|conversation):/i, "")
-    .trim();
-}
-
 export function parseMSTeamsConversationId(raw: string): string | null {
   const trimmed = stripProviderPrefix(raw).trim();
   if (!/^conversation:/i.test(trimmed)) {
@@ -163,48 +163,6 @@ export function parseMSTeamsConversationId(raw: string): string | null {
   }
   const id = trimmed.slice("conversation:".length).trim();
   return id;
-}
-
-/**
- * Detect whether a raw target string is a supported Microsoft Teams
- * conversation id.
- *
- * Accepts both prefixed and bare formats:
- * - `conversation:<id>` — explicit conversation prefix
- * - `19:abc@thread.tacv2` / `19:abc@thread.skype` / `19:abc@thread.v2` — group or channel
- * - `19:{userId}_{appId}@unq.gbl.spaces` — Graph 1:1 chat thread format
- * - `a:1xxx` — Bot Framework personal (1:1) chat id
- * - `8:orgid:xxx` — Bot Framework org-scoped personal chat id
- */
-export function looksLikeMSTeamsConversationId(raw: string): boolean {
-  const trimmed = raw.trim();
-  if (!trimmed) {
-    return false;
-  }
-  if (/^conversation:/i.test(trimmed)) {
-    return true;
-  }
-  // Bare Bot Framework / Graph conversation id formats.
-  // Channel / group ids always start with `19:` and include an `@thread.*`
-  // suffix (`@thread.tacv2`, `@thread.v2`, or the legacy `@thread.skype`). Personal chat
-  // ids come in three shapes: `a:1...` (Bot Framework), `8:orgid:...`
-  // (org-scoped Bot Framework), and `19:{userId}_{appId}@unq.gbl.spaces`
-  // (Graph API 1:1 chat thread). Bot Framework user ids use `29:...`.
-  if (MSTEAMS_GROUP_CONVERSATION_ID.test(trimmed)) {
-    return true;
-  }
-  if (/^19:.+@unq\.gbl\.spaces$/i.test(trimmed)) {
-    return true;
-  }
-  if (/^a:1[A-Za-z0-9_-]+$/i.test(trimmed)) {
-    return true;
-  }
-  if (/^8:orgid:[A-Za-z0-9-]+$/i.test(trimmed)) {
-    return true;
-  }
-  // Fallback: anything containing @thread is still treated as a conversation
-  // id so the current matches for tenant-specific suffixes remain accepted.
-  return /@thread\b/i.test(trimmed);
 }
 
 /**

--- a/extensions/msteams/src/resolve-allowlist.ts
+++ b/extensions/msteams/src/resolve-allowlist.ts
@@ -13,12 +13,17 @@ import {
   type GraphUser,
 } from "./graph.js";
 import {
+  isStableMSTeamsUserId,
   looksLikeMSTeamsConversationId,
   normalizeMSTeamsConversationId,
   normalizeMSTeamsUserInput,
 } from "./ingress-identity.js";
 
-export { looksLikeMSTeamsConversationId, normalizeMSTeamsUserInput } from "./ingress-identity.js";
+export {
+  isStableMSTeamsUserId,
+  looksLikeMSTeamsConversationId,
+  normalizeMSTeamsUserInput,
+} from "./ingress-identity.js";
 
 type MSTeamsChannelResolution = {
   input: string;
@@ -81,10 +86,6 @@ function findExactUsers(items: GraphUser[], query: string): GraphUser[] {
       ),
     ),
   );
-}
-
-function isStableMSTeamsUserId(raw: string): boolean {
-  return /^[0-9a-fA-F-]{16,}$/.test(normalizeMSTeamsUserInput(raw));
 }
 
 function normalizeStaticMSTeamsAllowEntry(raw: string): string | undefined {
@@ -175,10 +176,10 @@ export function looksLikeMSTeamsTargetId(raw: string): boolean {
     return true;
   }
   if (/^user:/i.test(trimmed)) {
-    // Only treat as an id when the value after `user:` looks like a UUID;
+    // Only treat as an id when the value after `user:` matches the runtime stable-id shape;
     // display names must fall through to directory lookup.
     const id = trimmed.slice("user:".length).trim();
-    return /^[0-9a-fA-F-]{16,}$/.test(id);
+    return isStableMSTeamsUserId(id);
   }
   return /^29:[A-Za-z0-9_-]+$/i.test(trimmed);
 }

--- a/extensions/msteams/src/resolve-allowlist.ts
+++ b/extensions/msteams/src/resolve-allowlist.ts
@@ -16,6 +16,7 @@ import {
   isStableMSTeamsUserId,
   looksLikeMSTeamsConversationId,
   normalizeMSTeamsConversationId,
+  normalizeMSTeamsDmPrincipal,
   normalizeMSTeamsUserInput,
 } from "./ingress-identity.js";
 
@@ -97,7 +98,7 @@ function normalizeStaticMSTeamsAllowEntry(raw: string): string | undefined {
     return trimmed;
   }
   // Preserve the previous startup projection for typed hexadecimal entries.
-  const id = normalizeMSTeamsUserInput(trimmed);
+  const id = normalizeMSTeamsDmPrincipal(trimmed);
   return isStableMSTeamsUserId(id) ? id : undefined;
 }
 

--- a/extensions/msteams/src/resolve-allowlist.ts
+++ b/extensions/msteams/src/resolve-allowlist.ts
@@ -89,25 +89,12 @@ function findExactUsers(items: GraphUser[], query: string): GraphUser[] {
   );
 }
 
-function normalizeStaticMSTeamsAllowEntry(raw: string): string | undefined {
-  const trimmed = raw.trim();
-  if (!trimmed) {
-    return undefined;
-  }
-  if (trimmed === "*" || /^accessGroup:/i.test(trimmed)) {
-    return trimmed;
-  }
-  // Preserve the previous startup projection for typed hexadecimal entries.
-  const id = normalizeMSTeamsDmPrincipal(trimmed);
-  return isStableMSTeamsUserId(id) ? id : undefined;
-}
-
 export function projectStableMSTeamsUserAllowlist(entries?: string[]): string[] | undefined {
   if (!entries) {
     return undefined;
   }
   const projected = entries
-    .map((entry) => normalizeStaticMSTeamsAllowEntry(entry))
+    .map((entry) => normalizeMSTeamsDmPrincipal(entry))
     .filter((entry): entry is string => Boolean(entry));
   return [...new Map(projected.map((entry) => [normalizeExactMatch(entry), entry])).values()];
 }
@@ -118,7 +105,7 @@ export function projectStableMSTeamsGroupAllowlist(entries?: string[]): string[]
   }
   const projected = entries
     .map((entry) => {
-      const stableUserEntry = normalizeStaticMSTeamsAllowEntry(entry);
+      const stableUserEntry = normalizeMSTeamsDmPrincipal(entry);
       if (stableUserEntry) {
         return stableUserEntry;
       }

--- a/extensions/msteams/src/setup-surface.test.ts
+++ b/extensions/msteams/src/setup-surface.test.ts
@@ -115,6 +115,27 @@ describe("msteams setup surface", () => {
     ).resolves.toEqual(["MS Teams: needs app credentials"]);
   });
 
+  it("rejects conversation IDs as user IDs when Graph lookup is unavailable", async () => {
+    const stableUserId = "0123456789abcdef";
+    resolveMSTeamsUserAllowlist.mockRejectedValue(new Error("Graph unavailable"));
+    const note = vi.fn(async () => {});
+    const text = vi
+      .fn()
+      .mockResolvedValueOnce(`conversation:${stableUserId}`)
+      .mockResolvedValueOnce(stableUserId);
+
+    const next = await delegatedMsteamsSetupWizard.dmPolicy?.promptAllowFrom?.({
+      cfg: { channels: { msteams: {} } },
+      prompter: { note, text } as never,
+    });
+
+    expect(note).toHaveBeenCalledWith(
+      "Graph lookup unavailable. Use user IDs only.",
+      "MS Teams allowlist",
+    );
+    expect(next?.channels?.msteams?.allowFrom).toEqual([stableUserId]);
+  });
+
   it("finalize keeps env credentials when available and accepted", async () => {
     vi.stubEnv("MSTEAMS_APP_ID", "env-app");
     vi.stubEnv("MSTEAMS_APP_PASSWORD", "env-secret");

--- a/extensions/msteams/src/setup-surface.ts
+++ b/extensions/msteams/src/setup-surface.ts
@@ -15,6 +15,7 @@ import {
 } from "openclaw/plugin-sdk/setup";
 import { formatUnknownError } from "./errors.js";
 import {
+  isStableMSTeamsUserId,
   parseMSTeamsTeamEntry,
   resolveMSTeamsChannelAllowlist,
   resolveMSTeamsUserAllowlist,
@@ -37,10 +38,6 @@ export function openDelegatedOAuthUrl(url: string): Promise<void> {
   return Promise.reject(
     new Error(`Automatic browser launch is not available. Open this URL manually: ${url}`),
   );
-}
-
-function looksLikeGuid(value: string): boolean {
-  return /^[0-9a-fA-F-]{16,}$/.test(value);
 }
 
 async function promptMSTeamsAllowFrom(params: {
@@ -82,7 +79,7 @@ async function promptMSTeamsAllowFrom(params: {
     }).catch(() => null);
 
     if (!resolved) {
-      const ids = parts.filter((part) => looksLikeGuid(part));
+      const ids = parts.filter((part) => isStableMSTeamsUserId(part));
       if (ids.length !== parts.length) {
         await params.prompter.note(
           t("wizard.msteams.graphLookupUnavailable"),

--- a/extensions/msteams/src/setup-surface.ts
+++ b/extensions/msteams/src/setup-surface.ts
@@ -14,8 +14,8 @@ import {
   type WizardPrompter,
 } from "openclaw/plugin-sdk/setup";
 import { formatUnknownError } from "./errors.js";
+import { isStableMSTeamsUserId } from "./ingress-identity.js";
 import {
-  isStableMSTeamsUserId,
   parseMSTeamsTeamEntry,
   resolveMSTeamsChannelAllowlist,
   resolveMSTeamsUserAllowlist,

--- a/src/security/audit-channel-msteams.test.ts
+++ b/src/security/audit-channel-msteams.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it, vi } from "vitest";
+import { msteamsPlugin } from "../../extensions/msteams/api.js";
+import type { OpenClawConfig } from "../config/config.js";
+import { collectChannelSecurityFindingsCore } from "./audit-channel.js";
+
+vi.mock("../channels/message-access/store-allow-from.js", () => ({
+  readChannelIngressStoreAllowFromForDmPolicy: async () => [],
+}));
+
+const stableId = "40a1a0ed-4ff2-4164-a219-55518990c197";
+const conversationEntries = [
+  "conversation:a:1personal-chat",
+  "teams:conversation:a:1personal-chat",
+  "a:1personal-chat",
+  "19:group@thread.tacv2",
+  "msteams:conversation:19:legacy@thread.skype",
+  "19:personal@unq.gbl.spaces",
+  "8:orgid:opaque-account",
+  "conversation:Alice Example",
+];
+
+describe.each([false, true])("Teams audit (name matching: %s)", (allowNameMatching) => {
+  it.each([
+    {
+      name: "opaque conversations cannot unlock DMs or create routes",
+      allowFrom: conversationEntries,
+      locked: true,
+      collision: false,
+    },
+    {
+      name: "opaque conversations cannot add routes beside a stable sender",
+      allowFrom: [stableId, ...conversationEntries],
+      locked: false,
+      collision: false,
+    },
+    {
+      name: "legacy typed stable IDs still identify one admitted sender",
+      allowFrom: [
+        stableId,
+        `conversation:${stableId}`,
+        ` teams:conversation:${stableId.toUpperCase()} `,
+        `msteams:user:${stableId}`,
+      ],
+      locked: false,
+      collision: false,
+    },
+    {
+      name: "distinct stable senders still expose shared-session collisions",
+      allowFrom: [stableId, "0123456789abcdef"],
+      locked: false,
+      collision: true,
+    },
+    {
+      name: "mutable names are only potential senders with explicit opt-in",
+      allowFrom: ["Alice Example"],
+      locked: !allowNameMatching,
+      collision: false,
+    },
+  ])("$name", async ({ allowFrom, locked, collision }) => {
+    const cfg: OpenClawConfig = {
+      agents: { entries: { main: {} } },
+      session: { dmScope: "main" },
+      channels: {
+        msteams: {
+          authType: "secret",
+          appId: "fixture-app",
+          appPassword: "fixture-password",
+          tenantId: "fixture-tenant",
+          dmPolicy: "allowlist",
+          allowFrom,
+          dangerouslyAllowNameMatching: allowNameMatching,
+        },
+      },
+    };
+    const findings = await collectChannelSecurityFindingsCore({ cfg, plugins: [msteamsPlugin] });
+    expect(findings.some((finding) => finding.checkId === "channels.msteams.dm.locked")).toBe(
+      locked,
+    );
+    expect(findings.some((finding) => finding.checkId.includes(".dm.session_collision."))).toBe(
+      collision,
+    );
+    expect(
+      findings.some(
+        (finding) => finding.checkId === "channels.msteams.allowFrom.mutable_entries_inert",
+      ),
+    ).toBe(!allowNameMatching && allowFrom.includes("Alice Example"));
+  });
+});

--- a/test/security-audit-msteams.test.ts
+++ b/test/security-audit-msteams.test.ts
@@ -1,11 +1,20 @@
 import { describe, expect, it, vi } from "vitest";
-import { msteamsPlugin } from "../../extensions/msteams/api.js";
-import type { OpenClawConfig } from "../config/config.js";
-import { collectChannelSecurityFindingsCore } from "./audit-channel.js";
+import { msteamsPlugin } from "../extensions/msteams/api.js";
+import type { ChannelPlugin } from "../src/channels/plugins/types.plugin.js";
+import type { OpenClawConfig } from "../src/config/config.js";
+import { collectChannelSecurityFindingsCore } from "../src/security/audit-channel.js";
 
-vi.mock("../channels/message-access/store-allow-from.js", () => ({
+vi.mock("../src/channels/message-access/store-allow-from.js", () => ({
   readChannelIngressStoreAllowFromForDmPolicy: async () => [],
 }));
+
+const msteamsAuditPlugin: ChannelPlugin = {
+  id: msteamsPlugin.id,
+  meta: msteamsPlugin.meta,
+  capabilities: msteamsPlugin.capabilities,
+  config: msteamsPlugin.config,
+  security: msteamsPlugin.security,
+};
 
 const stableId = "40a1a0ed-4ff2-4164-a219-55518990c197";
 const conversationEntries = [
@@ -72,7 +81,10 @@ describe.each([false, true])("Teams audit (name matching: %s)", (allowNameMatchi
         },
       },
     };
-    const findings = await collectChannelSecurityFindingsCore({ cfg, plugins: [msteamsPlugin] });
+    const findings = await collectChannelSecurityFindingsCore({
+      cfg,
+      plugins: [msteamsAuditPlugin],
+    });
     expect(findings.some((finding) => finding.checkId === "channels.msteams.dm.locked")).toBe(
       locked,
     );


### PR DESCRIPTION
Closes #115410

## What Problem This Solves

`openclaw security audit` silently skipped DM policy checks for Feishu and Microsoft Teams. Both channels support `dmPolicy`, but neither exposed that configuration through the channel security adapter, so an open-DM configuration could receive no critical finding.

## Why This Change Was Made

The shared audit reads DM access through `security.resolveDmPolicy`. This change wires both existing channel configurations into that contract:

- Feishu reports account-aware policy and allowlist values, preserving the actual authored account key and source path for each independently inherited field.
- Microsoft Teams reports its single-account policy and allowlist using the same trim-and-lowercase primary identity normalization as current inbound access. The resolver is shared by the full runtime plugin and the lightweight setup plugin used by read-only audit discovery, so both paths stay aligned.

This changes audit visibility only. It does not alter inbound authorization behavior or configuration shapes.

## User Impact

Operators running `openclaw security audit` now receive a critical `channels.feishu.dm.open` or `channels.msteams.dm.open` finding when either channel allows public DMs. Findings point to the correct root or account-scoped configuration paths, including account keys that normalize by case or whitespace, and case-only variants of a Teams sender ID are not miscounted as separate users.

## Evidence

Rebased exact head: `77eb6197884bc4e82b2651af576dc3480b83d50e` on main `4eaba567efb42ba55ef851b935c587fbdc4c6bed`.

- Current-main inspection still shows no `resolveDmPolicy` on either channel, so the audit omission remains reproducible and this PR is not superseded.
- Regression proof on the pre-fix implementation: focused assertions failed because each channel's `security.resolveDmPolicy` was unavailable.
- Feishu channel suite passed: `node scripts/run-vitest.mjs extensions/feishu/src/channel.test.ts`.
- Microsoft Teams channel suite passed: `node scripts/run-vitest.mjs extensions/msteams/src/channel.test.ts`.
- Shared DM-policy audit and read-only setup-fallback suites passed: `node scripts/run-vitest.mjs src/security/audit-channel-dm-policy.test.ts src/security/audit-channel-readonly-setup-fallback.test.ts`.
- Full exact-head build passed: `OPENCLAW_TSDOWN_MAX_OLD_SPACE_MB=4352 pnpm build`.
- Exact-head repository CI completed successfully, including the extension, type, lint, security, and merge gates.

The local changed-file check passed formatting and repository guards before reaching an unrelated `doctor-contract-declarations` mismatch affecting eight other plugins; the same test fails on clean `origin/main` at `4eaba567efb42ba55ef851b935c587fbdc4c6bed`.

### Exact-head real CLI behavior proof

This proof was captured from exact head `77eb6197884bc4e82b2651af576dc3480b83d50e` through the repository CLI entrypoint with isolated state and a schema-valid config containing only dummy credentials. Feishu used the authored account key `" Ops "`, while the runtime lookup used normalized account ID `ops`; both channels used `dmPolicy: "open"` and `allowFrom: ["*"]`. The non-deep audit does not contact either service. The temporary absolute path is redacted below as `$PROOF_DIR`.

```console
$ OPENCLAW_HOME="$PROOF_DIR/home" \
  OPENCLAW_STATE_DIR="$PROOF_DIR/state" \
  OPENCLAW_CONFIG_PATH="$PROOF_DIR/openclaw.json" \
  pnpm openclaw config validate
Config valid: $PROOF_DIR/openclaw.json

$ OPENCLAW_HOME="$PROOF_DIR/home" \
  OPENCLAW_STATE_DIR="$PROOF_DIR/state" \
  OPENCLAW_CONFIG_PATH="$PROOF_DIR/openclaw.json" \
  pnpm openclaw security audit --json |
  jq '[.findings[]
    | select(
        .checkId == "channels.feishu.dm.open"
        or .checkId == "channels.msteams.dm.open"
      )
    | {checkId, severity, title, detail, remediation}]'
[
  {
    "checkId": "channels.feishu.dm.open",
    "severity": "critical",
    "title": "Feishu (account:  Ops ) DMs are open",
    "detail": "channels.feishu.accounts. Ops .dmPolicy=\"open\" allows anyone to DM the bot.",
    "remediation": "Use pairing/allowlist; if you really need open DMs, ensure channels.feishu.accounts. Ops .allowFrom includes \"*\"."
  },
  {
    "checkId": "channels.msteams.dm.open",
    "severity": "critical",
    "title": "Microsoft Teams DMs are open",
    "detail": "channels.msteams.dmPolicy=\"open\" allows anyone to DM the bot.",
    "remediation": "Use pairing/allowlist; if you really need open DMs, ensure channels.msteams.allowFrom includes \"*\"."
  }
]
```

This PR was AI-assisted; the implementation, tests, and validation were reviewed by the submitting author.


<!-- final-repair-2026-09-01 -->
## Final repair follow-up (2026-09-01)

Current exact head: `6843ff421d5dbd152813085d77dc63ddb325fb9a`.

- Restored the pre-PR startup projection for typed hexadecimal entries, so existing `conversation:<16-hex>` and provider-prefixed variants continue reaching ingress as the same bare stable ID instead of silently losing DM access on upgrade.
- Startup projection, security-audit principal accounting, and final ingress now share `normalizeMSTeamsDmPrincipal`. Bare IDs plus the existing `user:`, `teams:`, and `msteams:user:` forms (including case and surrounding-whitespace variants) converge to one lowercase principal.
- Provider-prefixed conversation values are also excluded from the mutable sender-name alias, so they cannot become display-name principals.
- The compatibility policy for legacy `conversation:<16-hex>` startup entries is unchanged: startup still projects them to the historical bare ID, while raw conversation-form identities remain blocked at ingress and approval boundaries. Maintainers still own the later reject/migrate policy decision.
- Fresh isolated autoreview reported no finding (`patch is correct`, confidence `0.99`).

### Exact-head validation

- `node scripts/run-vitest.mjs extensions/msteams/src/channel.test.ts extensions/msteams/src/resolve-allowlist.test.ts extensions/msteams/src/monitor-handler/access.participant.test.ts extensions/msteams/src/monitor-handler/message-handler.authz.test.ts src/security/audit-channel-dm-policy.test.ts src/security/audit-channel-readonly-setup-fallback.test.ts` — 147 tests passed.
- The new authority-chain regression failed before the production change because audit retained four distinct prefixed principals; it now proves startup projection, audit identity, and final admission converge on one principal. Exact-head focused post-commit rerun — 11 tests passed.
- `pnpm openclaw config validate` — isolated authority proof config valid; the command completed the exact-head TypeScript build, bundled plugin assets, plugin control-plane loading, and runtime post-build first.
- Changed-file guards, formatting, dead-export scans, plugin boundaries, and production extension typecheck passed. The all-extension test typecheck was stopped locally after 33 minutes of active CPU work without output; hosted CI remains the exact-head test-type gate.

### Exact-head security-audit proof

The non-deep audit used isolated state and a schema-valid config containing only synthetic credentials. The temporary absolute path is redacted as `$PROOF_DIR`.

```console
$ OPENCLAW_HOME="$PROOF_DIR/home" \
  OPENCLAW_STATE_DIR="$PROOF_DIR/state" \
  OPENCLAW_CONFIG_PATH="$PROOF_DIR/openclaw.json" \
  pnpm openclaw config validate
Config valid: $PROOF_DIR/openclaw.json

$ OPENCLAW_HOME="$PROOF_DIR/home" \
  OPENCLAW_STATE_DIR="$PROOF_DIR/state" \
  OPENCLAW_CONFIG_PATH="$PROOF_DIR/openclaw.json" \
  pnpm openclaw security audit --json | jq \
  '[.findings[] | select(.checkId == "channels.feishu.dm.open" or .checkId == "channels.msteams.dm.open") | {checkId,severity,title,detail,remediation}]'
[
  {
    "checkId": "channels.feishu.dm.open",
    "severity": "critical",
    "title": "Feishu (account:  Ops ) DMs are open",
    "detail": "channels.feishu.accounts. Ops .dmPolicy=\"open\" allows anyone to DM the bot.",
    "remediation": "Use pairing/allowlist; if you really need open DMs, ensure channels.feishu.accounts. Ops .allowFrom includes \"*\"."
  },
  {
    "checkId": "channels.msteams.dm.open",
    "severity": "critical",
    "title": "Microsoft Teams DMs are open",
    "detail": "channels.msteams.dmPolicy=\"open\" allows anyone to DM the bot.",
    "remediation": "Use pairing/allowlist; if you really need open DMs, ensure channels.msteams.allowFrom includes \"*\"."
  }
]
```

### Exact-head ingress proof

The focused boundary test invokes production `resolveMSTeamsSenderAccess` before message handling:

```text
PASS bare stable ID                              -> allow
PASS user:<stable-id>                            -> allow
PASS teams:<stable-id>                           -> allow
PASS msteams:user:<stable-id>                    -> allow
PASS conversation:<stable-id>                    -> block
PASS msteams:conversation:<stable-id>            -> block
```

### Exact-head authority-chain proof

The same synthetic AAD object ID was authored four ways (uppercase bare, `user:`, `teams:`, and `msteams:user:`) under `session.dmScope="main"`. Before the repair, audit normalization retained four principals and therefore modeled a false shared-session topology; startup projection already reduced them to one. The exact-head production CLI now reports:

```json
{
  "teamsSessionCollisions": 0,
  "teamsLockedFindings": 0,
  "teamsMutableEntryFindings": 0
}
```

<!-- protocol-declaration-repair-2026-09-03 -->
## CI declaration repair (2026-09-03)

Current head: `0106433785a05b2ad2e022fdf29436752b6d9a67`. Earlier exact-head evidence above is retained with its original SHA and has not been relabeled as a new live run.

- Fixed the shared CI blocker from [run 33530935019](https://github.com/openclaw/openclaw/actions/runs/33530935019): TS7056 while emitting `ProtocolSchemas` declarations.
- Backported the already-merged [upstream fix #135360](https://github.com/openclaw/openclaw/pull/135360), preserving its author. Both changed files are byte-identical to upstream commit `6abc3adf10bf17121c10cb347654e895cce261c3`. Runtime schema inventory and Teams/Feishu authorization behavior are unchanged.
- Local final-tree verification passed: `node scripts/run-tsgo.mjs -p tsconfig.plugin-sdk.dts.json --declaration true` (GOMAXPROCS=2, GOMEMLIMIT=3GiB, 180-second watchdog); protocol registry guard; all 3 composer regression tests through the gateway-client test runner with one worker; focused lint; formatting; and diff whitespace checks. No full runtime build or new live audit was run for this type-only repair.
- Fresh isolated autoreview reported no accepted/actionable findings. Hosted CI must validate the new head; the failed old run is not being retried.
- The legacy Teams conversation-ID reject/migrate policy remains a maintainer decision; this follow-up does not change it.


<!-- legacy-audit-classification-2026-09-03 -->
## Legacy audit classification follow-up (2026-09-03)

Current exact head: `a0fbf1586ea731e7c3c5904db2d61aee97907c8d`. Earlier proof remains attached to its original SHA.

- Audit classification now recognizes legacy `conversation:<stable-user-id>` entries, including provider prefixes, through the same stable-ID projection that startup already uses. This is an audit-metadata correction: startup projection, inbound authorization, and approval checks are unchanged. Raw conversation-form sender identities and approval principals remain rejected.
- The shared audit already computes admitted principals through `normalizeEntry`, independently of this classifier. This follow-up therefore does **not** claim to fix a newly reproduced false-locked or false-collision finding. The actual inconsistency was the classification of effective, already-authorized user access.
- The channel guide now explains that compatibility and recommends explicit AAD object IDs. Removing/migrating legacy entries remains a separate maintainer decision.

### Validation of the committed tree

- Both extended classification/authority-chain regressions failed before the production change (2 failed, 52 passed in the two focused files). After the fix, all six focused files passed: Teams channel, allowlist resolution, participant authority chain, inbound authorization, shared DM-policy audit, and read-only setup fallback.
- A separate isolated-state source harness invoked the production setup plugin and audit collector: one legacy user and three aliases produced one admitted principal with no locked/collision finding; two distinct legacy users produced the expected shared-session collision. All legacy entries were classified `asserted`. This is source-path proof, not a new full CLI or live Teams run.
- Focused syntax lint (zero warnings/errors), formatting, whitespace/conflict-marker checks, the coercion-helper guard, and the existing Teams package-boundary production typecheck passed: `node scripts/run-tsgo.mjs -p extensions/msteams/tsconfig.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/msteams-package.tsbuildinfo`.
- The all-extension production typecheck reached the local 180-second resource limit without a source diagnostic and was stopped. It is **not** reported as passed; full type/test/lint/build coverage remains with hosted CI. No full build was started.
- Fresh isolated repository autoreview accepted no actionable P0-P2 findings. The committed patch is byte-identical to the reviewed/validated working diff.
- Test/check processes were bounded to 3 GiB RAM, no swap, and two CPU equivalents. No operator-owned service was stopped or restarted.

