### PR TITLE
fix(codex): enable configured apps in service sessions

### DIFF
--- a/docs/plugins/codex-harness-reference.md
+++ b/docs/plugins/codex-harness-reference.md
@@ -265,11 +265,17 @@ shorthand before OpenClaw builds app-server start options, and unresolved
 structured SecretRefs fail before any token or header is sent. When native
 Codex plugins are configured, OpenClaw uses the connected app-server's plugin
 control plane to install or refresh those plugins and then refreshes app
-inventory so plugin-owned apps are visible to the Codex thread. `app/list` is
-still the authoritative inventory and metadata source, but OpenClaw policy
-decides whether `thread/start` sends `config.apps[appId].enabled = true` for a
-listed accessible app even if Codex currently marks it disabled. Unknown or
-missing app ids remain fail-closed; this path only activates marketplace
+inventory so plugin-owned apps are visible to the Codex thread. `app/installed`
+provides authoritative runtime state, and `app/read` provides app metadata.
+Callable apps with authorized metadata can be enabled directly. A modern
+base-disabled app owned by an explicitly configured plugin may be enabled
+provisionally in `thread/start`; OpenClaw immediately attests the effective
+thread-scoped inventory and discards the thread before its first turn unless
+the app is enabled and callable. Account-wide disabled apps and revoked,
+unauthenticated, policy-blocked, or missing apps remain excluded. Supported
+older app-server versions fall back to `app/list` only when `app/installed` is
+unavailable, and that fallback never provisionally enables a disabled app.
+This path only activates marketplace
 plugins via `plugin/install` and refreshes inventory. Only connect OpenClaw to
 remote app-servers that are trusted to accept OpenClaw-managed plugin installs
 and app inventory refreshes.

--- a/docs/plugins/codex-harness.md
+++ b/docs/plugins/codex-harness.md
@@ -721,11 +721,17 @@ model or Codex runtime.
 
 When native Codex plugins are configured, OpenClaw installs or refreshes
 those plugins through the connected app-server before exposing plugin-owned
-apps to the Codex thread. `app/list` remains the source of truth for app
-ids, accessibility, and metadata, but OpenClaw owns the per-thread
-enablement decision: if policy allows a listed accessible app, OpenClaw
-sends `thread/start.config.apps[appId].enabled = true` even when `app/list`
-currently reports that app disabled. This path does not invent app
+apps to the Codex thread. `app/installed` supplies app IDs and runtime
+accessibility; `app/read` supplies app metadata. Callable apps with authorized
+metadata can be enabled directly. When a modern `app/installed` response marks
+an explicitly configured plugin-owned app base-disabled, OpenClaw may enable
+it provisionally in `thread/start`, then immediately re-read thread-scoped
+inventory. The thread is discarded before its first turn unless that app is
+enabled and callable there. Account-wide disabled apps and revoked,
+unauthenticated, policy-blocked, or missing apps remain excluded. Supported
+older app-server versions use `app/list` when they do not implement
+`app/installed`; that fallback never enables a disabled app provisionally.
+This path does not invent app
 installation for unknown ids; OpenClaw only activates marketplace plugins
 with `plugin/install` and then refreshes inventory.
 

--- a/docs/plugins/codex-native-plugins.md
+++ b/docs/plugins/codex-native-plugins.md
@@ -29,7 +29,7 @@ working.
 - Manually configured `workspace-directory` plugins require a Codex app-server
   whose `plugin/list` accepts `marketplaceKinds` and whose pathless workspace
   summaries include `remotePluginId`. The plugin must already be installed and
-  enabled, and its owned apps must be accessible in `app/list`.
+  enabled, and its owned apps must be accessible in the app runtime snapshot.
 
 `codexPlugins` has no effect on OpenClaw-provider runs, ACP conversation
 bindings, or other harnesses, because those paths never create Codex
@@ -48,9 +48,9 @@ Preview migration from the source Codex home:
 openclaw migrate codex --dry-run
 ```
 
-Add `--verify-plugin-apps` to make migration call source `app/list` and
-require every owned app to be present, enabled, and accessible before
-planning native activation:
+Add `--verify-plugin-apps` to make migration read the source installed app
+snapshot and app metadata, requiring every owned app to be present, enabled,
+and accessible before planning native activation:
 
 ```bash
 openclaw migrate codex --dry-run --verify-plugin-apps
@@ -177,12 +177,13 @@ step:
   checks that the source Codex app-server account is a ChatGPT subscription
   account. A non-ChatGPT or missing account response skips app-backed
   plugins with `codex_subscription_required`.
-- By default, migration skips the source `app/list` call: app-backed source
+- By default, migration skips source app inventory calls: app-backed source
   plugins that pass the account gate are planned without source app
   accessibility verification, and account-lookup transport failures skip
   with `codex_account_unavailable`.
-- With `--verify-plugin-apps`, migration takes a fresh source `app/list`
-  snapshot and requires every owned app to be present, enabled, and
+- With `--verify-plugin-apps`, migration takes a fresh source `app/installed`
+  snapshot, fetches app metadata with `app/read`, and requires every owned app
+  to be present, enabled, and
   accessible before planning native activation. Account-lookup transport
   failures then fall through to the source app-inventory gate instead of
   skipping outright.
@@ -190,7 +191,7 @@ step:
 For `workspace-directory` plugins, setup happens outside OpenClaw. OpenClaw
 queries that marketplace only when at least one enabled workspace entry is
 configured, resolves each plugin by exact `summary.id`, and reuses the existing
-`plugin/read` ownership and `app/list` readiness checks. An uninstalled,
+`plugin/read` ownership and installed app readiness checks. An uninstalled,
 disabled, inaccessible, or unauthenticated plugin exposes no apps; OpenClaw
 does not attempt installation or authentication.
 
@@ -232,16 +233,19 @@ current conversation.
 
 ## App inventory and ownership
 
-OpenClaw reads Codex app inventory through app-server `app/list`, caches it
-in memory for one hour, and refreshes stale or missing entries
-asynchronously. The cache is process-local; restarting the CLI or gateway
-drops it, and OpenClaw rebuilds it from the next `app/list` read.
+OpenClaw reads installed runtime state through app-server `app/installed` and
+fetches canonical app metadata with `app/read` in batches of at most 100 app
+IDs. It caches the combined inventory in memory for one hour and refreshes
+stale or missing entries asynchronously. The cache is process-local;
+restarting the CLI or gateway drops it, and OpenClaw rebuilds it from the next
+inventory read. Supported older app-server versions that do not implement
+`app/installed` continue to use `app/list`.
 
 Migration and runtime use separate cache keys:
 
 - Source migration verification uses the source Codex home and start
   options. It runs only with `--verify-plugin-apps` and forces a fresh
-  source `app/list` traversal for that planning run.
+  source runtime snapshot and metadata read for that planning run.
 - Target runtime setup uses the target agent's Codex app-server identity when
   building the thread app config. Curated plugin activation invalidates that
   target cache key, then force-refreshes it after `plugin/install`.
@@ -276,8 +280,9 @@ account without requiring a matching plugin package:
 }
 ```
 
-`allow_all_plugins: true` takes a complete `app/list` snapshot when a new native
-Codex thread is established and admits only apps marked accessible for that
+`allow_all_plugins: true` reads a complete installed app snapshot and app
+metadata when a new native Codex thread is established and admits only apps
+marked accessible for that
 account. It does not install, authenticate, or enable apps globally. Existing
 threads keep their persisted app set; use `/new`, `/reset`, or restart the
 gateway to pick up newly connected or revoked apps.
@@ -349,9 +354,13 @@ plugins, while unsafe schemas and ambiguous ownership fail closed:
 
 **Workspace plugin is installed but not visible:** confirm the workspace
 `plugin/list` result reports the exact configured ID as installed and enabled,
-then confirm `app/list` reports every owned app accessible for the same Codex
-account. OpenClaw can enable an accessible app for the thread even when the
-account inventory currently reports that app disabled. If you changed that state after the gateway cached app
+then confirm `app/installed` returns every owned app for the same Codex
+account and `app/read` returns its metadata. A modern base-disabled app owned
+by an explicitly configured plugin is enabled provisionally for a new thread
+and must immediately attest as enabled and callable there. Account-wide
+disabled apps, legacy-inventory disabled apps, and apps that fail that
+thread-scoped attestation stay excluded; enable or reauthorize the app in Codex
+before starting another thread. If you changed that state after the gateway cached app
 inventory, wait for the one-hour cache refresh or restart the gateway, then use
 `/new` or `/reset`. OpenClaw does not repair or authenticate workspace plugins.
 If the explicit workspace list request is rejected, each enabled workspace

--- a/extensions/codex/src/app-server/app-inventory-cache.test.ts
+++ b/extensions/codex/src/app-server/app-inventory-cache.test.ts
@@ -6,17 +6,17 @@ import {
   buildCodexAppInventoryCacheKey,
   serializeCodexAppInventoryError,
 } from "./app-inventory-cache.js";
+import { codexAppInventoryResponse } from "./app-inventory.test-helpers.js";
+import { CodexAppServerRpcError } from "./client.js";
 import type { v2 } from "./protocol.js";
 
 describe("Codex app inventory cache", () => {
-  it("returns missing while scheduling one coalesced app/list refresh", async () => {
+  it("coalesces installed app and metadata requests into one inventory refresh", async () => {
     const cache = new CodexAppInventoryCache({ ttlMs: 100 });
-    const request = vi.fn(async (_method: "app/list", params: v2.AppsListParams) => {
-      return {
-        data: [app(params.cursor ? "app-2" : "app-1")],
-        nextCursor: params.cursor ? null : "next",
-      } satisfies v2.AppsListResponse;
-    });
+    const apps = [app("app-1"), app("app-2")];
+    const request = vi.fn(async (method, params) =>
+      codexAppInventoryResponse(method, apps, params),
+    );
 
     const key = buildCodexAppInventoryCacheKey(
       { codexHome: "/codex", authProfileId: "work" },
@@ -28,13 +28,17 @@ describe("Codex app inventory cache", () => {
     expect(read.refreshScheduled).toBe(true);
 
     const snapshot = await cache.refreshNow({ key, request, nowMs: 0 });
-    expect(snapshot.apps.map((item) => item.id)).toEqual(["app-1", "app-2"]);
-    expect(request).toHaveBeenCalledTimes(2);
+    expect(snapshot.apps).toEqual(apps);
+    expect(snapshot.source).toBe("installed");
+    expect(request).toHaveBeenNthCalledWith(1, "app/installed", { forceRefresh: true });
+    expect(request).toHaveBeenNthCalledWith(2, "app/read", {
+      appIds: ["app-1", "app-2"],
+    });
 
     const fresh = cache.read({ key, request, nowMs: 50 });
     expect(fresh.state).toBe("fresh");
     expect(fresh.refreshScheduled).toBe(false);
-    expect(fresh.snapshot?.apps.map((item) => item.id)).toEqual(["app-1", "app-2"]);
+    expect(fresh.snapshot?.apps).toEqual(apps);
   });
 
   it("changes the cache key when either build version changes", () => {
@@ -45,34 +49,25 @@ describe("Codex app inventory cache", () => {
     expect(buildCodexAppInventoryCacheKey(input, "2026.6.27", "2026.6.28")).not.toBe(baseline);
   });
 
-  it("can read missing inventory without scheduling app/list", async () => {
+  it("reads missing inventory without scheduling app discovery when suppressed", () => {
     const cache = new CodexAppInventoryCache({ ttlMs: 100 });
-    const request = vi.fn(async () => {
-      return {
-        data: [app("app-1")],
-        nextCursor: null,
-      } satisfies v2.AppsListResponse;
-    });
+    const request = vi.fn(async (method, params) =>
+      codexAppInventoryResponse(method, [app("app-1")], params),
+    );
 
-    const read = cache.read({
-      key: "runtime",
-      request,
-      suppressRefresh: true,
-    });
+    const read = cache.read({ key: "runtime", request, suppressRefresh: true });
 
     expect(read.state).toBe("missing");
     expect(read.refreshScheduled).toBe(false);
     expect(request).not.toHaveBeenCalled();
   });
 
-  it("finds a targeted app on a later large page", async () => {
+  it("reads metadata only for targeted installed apps", async () => {
     const cache = new CodexAppInventoryCache({ ttlMs: 100 });
-    const request = vi.fn(async (_method: "app/list", params: v2.AppsListParams) => {
-      return {
-        data: [app(params.cursor ? "google-calendar-app" : "app-1")],
-        nextCursor: params.cursor ? "page-3" : "page-2",
-      } satisfies v2.AppsListResponse;
-    });
+    const apps = [app("app-1"), app("google-calendar-app")];
+    const request = vi.fn(async (method, params) =>
+      codexAppInventoryResponse(method, apps, params),
+    );
 
     const snapshot = await cache.refreshNow({
       key: "runtime",
@@ -80,28 +75,18 @@ describe("Codex app inventory cache", () => {
       targetAppIds: ["google-calendar-app"],
     });
 
-    expect(snapshot.apps.map((item) => item.id)).toEqual(["app-1", "google-calendar-app"]);
-    expect(request).toHaveBeenCalledTimes(2);
-    expect(request).toHaveBeenNthCalledWith(1, "app/list", {
-      cursor: undefined,
-      limit: 1_000,
-      forceRefetch: false,
-    });
-    expect(request).toHaveBeenNthCalledWith(2, "app/list", {
-      cursor: "page-2",
-      limit: 1_000,
-      forceRefetch: false,
+    expect(snapshot.apps).toEqual([app("google-calendar-app")]);
+    expect(request).toHaveBeenNthCalledWith(1, "app/installed", { forceRefresh: true });
+    expect(request).toHaveBeenNthCalledWith(2, "app/read", {
+      appIds: ["google-calendar-app"],
     });
   });
 
-  it("exhausts targeted refresh pages when a target app is absent", async () => {
+  it("does not request metadata when a targeted app is not installed", async () => {
     const cache = new CodexAppInventoryCache({ ttlMs: 100 });
-    const request = vi.fn(async (_method: "app/list", params: v2.AppsListParams) => {
-      return {
-        data: [app(params.cursor ? "app-2" : "app-1")],
-        nextCursor: params.cursor ? null : "page-2",
-      } satisfies v2.AppsListResponse;
-    });
+    const request = vi.fn(async (method, params) =>
+      codexAppInventoryResponse(method, [app("app-1")], params),
+    );
 
     const snapshot = await cache.refreshNow({
       key: "runtime",
@@ -109,64 +94,134 @@ describe("Codex app inventory cache", () => {
       targetAppIds: ["missing-app"],
     });
 
-    expect(snapshot.apps.map((item) => item.id)).toEqual(["app-1", "app-2"]);
-    expect(request).toHaveBeenCalledTimes(2);
+    expect(snapshot.apps).toEqual([]);
+    expect(request).toHaveBeenCalledExactlyOnceWith("app/installed", { forceRefresh: true });
   });
 
-  it("rejects a repeated app/list cursor instead of caching a partial snapshot", async () => {
+  it("limits each metadata request to the app/read 100-app contract", async () => {
     const cache = new CodexAppInventoryCache({ ttlMs: 100 });
-    const request = vi.fn(async () => ({
-      data: [app(`app-${request.mock.calls.length}`)],
-      nextCursor: "page-2",
-    }));
+    const apps = Array.from({ length: 205 }, (_, index) => app(`app-${index}`));
+    const request = vi.fn(async (method, params) =>
+      codexAppInventoryResponse(method, apps, params),
+    );
 
-    await expect(
-      cache.refreshNow({
-        key: "runtime",
-        request,
-        targetAppIds: ["missing-app"],
-      }),
-    ).rejects.toThrow("app/list returned repeated cursor page-2");
+    const snapshot = await cache.refreshNow({ key: "runtime", request });
 
-    const read = cache.read({ key: "runtime", request, suppressRefresh: true });
-    expect(read.state).toBe("missing");
-    expect(read.snapshot).toBeUndefined();
+    expect(snapshot.apps).toEqual(apps);
+    expect(request).toHaveBeenCalledTimes(4);
+    expect(request).toHaveBeenNthCalledWith(2, "app/read", {
+      appIds: apps.slice(0, 100).map((entry) => entry.id),
+    });
+    expect(request).toHaveBeenNthCalledWith(3, "app/read", {
+      appIds: apps.slice(100, 200).map((entry) => entry.id),
+    });
+    expect(request).toHaveBeenNthCalledWith(4, "app/read", {
+      appIds: apps.slice(200).map((entry) => entry.id),
+    });
   });
 
-  it("uses stale inventory for the current read while still refreshing asynchronously", async () => {
+  it("excludes installed apps whose metadata is missing", async () => {
+    const cache = new CodexAppInventoryCache({ ttlMs: 100 });
+    const installedApps = [app("available-app"), app("missing-app")];
+    const request = vi.fn(async (method, params) =>
+      codexAppInventoryResponse(
+        method,
+        method === "app/read" ? [installedApps[0]!] : installedApps,
+        params,
+      ),
+    );
+
+    const snapshot = await cache.refreshNow({ key: "runtime", request });
+
+    expect(snapshot.apps).toEqual([app("available-app")]);
+  });
+
+  it("excludes retained runtime rows when global or workspace policy denies app metadata", async () => {
+    const cache = new CodexAppInventoryCache({ ttlMs: 100 });
+    const disabledApp = { ...app("policy-disabled-app"), isEnabled: false };
+    const request = vi.fn(async (method, params) =>
+      codexAppInventoryResponse(method, method === "app/read" ? [] : [disabledApp], params),
+    );
+
+    const snapshot = await cache.refreshNow({ key: "runtime", request });
+
+    expect(snapshot.apps).toEqual([]);
+    expect(request).toHaveBeenNthCalledWith(2, "app/read", {
+      appIds: ["policy-disabled-app"],
+    });
+  });
+
+  it("retains disabled app metadata without marking its runtime callable", async () => {
+    const cache = new CodexAppInventoryCache({ ttlMs: 100 });
+    const disabledApp = { ...app("disabled-app"), isEnabled: false };
+    const request = vi.fn(async (method, params) =>
+      codexAppInventoryResponse(method, [disabledApp], params),
+    );
+
+    const snapshot = await cache.refreshNow({ key: "runtime", request });
+
+    expect(snapshot.apps).toEqual([{ ...disabledApp, isAccessible: false }]);
+  });
+
+  it("does not expose enabled installed apps that are not callable", async () => {
+    const cache = new CodexAppInventoryCache({ ttlMs: 100 });
+    const inaccessibleApp = { ...app("inaccessible-app"), isAccessible: false };
+    const request = vi.fn(async (method, params) =>
+      codexAppInventoryResponse(method, [inaccessibleApp], params),
+    );
+
+    const snapshot = await cache.refreshNow({ key: "runtime", request });
+
+    expect(snapshot.apps).toEqual([inaccessibleApp]);
+  });
+
+  it("force-refreshes the upstream runtime snapshot on every cache refresh", async () => {
+    const cache = new CodexAppInventoryCache({ ttlMs: 100 });
+    let installedCalls = 0;
+    const request = vi.fn(async (method, params) => {
+      if (method === "app/installed") {
+        installedCalls += 1;
+      }
+      return codexAppInventoryResponse(method, [app(`refreshed-app-${installedCalls}`)], params);
+    });
+
+    const first = await cache.refreshNow({ key: "runtime", request, nowMs: 0 });
+    const second = await cache.refreshNow({ key: "runtime", request, nowMs: 101 });
+
+    expect(first.apps).toEqual([app("refreshed-app-1")]);
+    expect(second.apps).toEqual([app("refreshed-app-2")]);
+    expect(request).toHaveBeenNthCalledWith(1, "app/installed", { forceRefresh: true });
+    expect(request).toHaveBeenNthCalledWith(3, "app/installed", { forceRefresh: true });
+  });
+
+  it("uses stale inventory for the current read while refreshing asynchronously", async () => {
     const cache = new CodexAppInventoryCache({ ttlMs: 10 });
-    const request = vi.fn(async () => {
-      return {
-        data: [app(`app-${request.mock.calls.length}`)],
-        nextCursor: null,
-      } satisfies v2.AppsListResponse;
+    let installedCalls = 0;
+    const request = vi.fn(async (method, params) => {
+      if (method === "app/installed") {
+        installedCalls += 1;
+      }
+      return codexAppInventoryResponse(method, [app(`app-${installedCalls}`)], params);
     });
     const key = "runtime";
     await cache.refreshNow({ key, request, nowMs: 0 });
 
     const stale = cache.read({ key, request, nowMs: 11, suppressRefresh: true });
     expect(stale.state).toBe("stale");
-    expect(stale.snapshot?.apps.map((item) => item.id)).toEqual(["app-1"]);
+    expect(stale.snapshot?.apps).toEqual([app("app-1")]);
     expect(stale.refreshScheduled).toBe(true);
 
     const refreshed = await cache.refreshNow({ key, request, nowMs: 11 });
-    expect(refreshed.apps.map((item) => item.id)).toEqual(["app-2"]);
+    expect(refreshed.apps).toEqual([app("app-2")]);
   });
 
   it("marks inventory stale when the expiry would exceed the Date range", async () => {
     const cache = new CodexAppInventoryCache({ ttlMs: 100 });
-    const request = vi.fn(async () => {
-      return {
-        data: [app("app-overflow")],
-        nextCursor: null,
-      } satisfies v2.AppsListResponse;
-    });
+    const request = vi.fn(async (method, params) =>
+      codexAppInventoryResponse(method, [app("app-overflow")], params),
+    );
     const key = "runtime";
-    const snapshot = await cache.refreshNow({
-      key,
-      request,
-      nowMs: MAX_DATE_TIMESTAMP_MS,
-    });
+    const snapshot = await cache.refreshNow({ key, request, nowMs: MAX_DATE_TIMESTAMP_MS });
 
     expect(snapshot.expiresAtMs).toBe(0);
     const read = cache.read({
@@ -175,7 +230,7 @@ describe("Codex app inventory cache", () => {
       nowMs: Date.parse("2026-05-29T12:00:00.000Z"),
     });
     expect(read.state).toBe("stale");
-    expect(read.snapshot?.apps.map((item) => item.id)).toEqual(["app-overflow"]);
+    expect(read.snapshot?.apps).toEqual([app("app-overflow")]);
   });
 
   it("records refresh errors without discarding the last successful snapshot", async () => {
@@ -184,7 +239,7 @@ describe("Codex app inventory cache", () => {
     await cache.refreshNow({
       key,
       nowMs: 0,
-      request: async () => ({ data: [app("app-1")], nextCursor: null }),
+      request: async (method, params) => codexAppInventoryResponse(method, [app("app-1")], params),
     });
 
     await expect(
@@ -192,39 +247,90 @@ describe("Codex app inventory cache", () => {
         key,
         nowMs: 2,
         request: async () => {
-          throw new Error("app list failed");
+          throw new Error("app inventory failed");
         },
       }),
-    ).rejects.toThrow("app list failed");
+    ).rejects.toThrow("app inventory failed");
 
     const read = cache.read({
       key,
       nowMs: 2,
-      request: async () => ({ data: [app("app-2")], nextCursor: null }),
+      request: async (method, params) => codexAppInventoryResponse(method, [app("app-2")], params),
     });
-    expect(read.snapshot?.apps.map((item) => item.id)).toEqual(["app-1"]);
-    expect(read.diagnostic?.message).toBe("app list failed");
+    expect(read.snapshot?.apps).toEqual([app("app-1")]);
+    expect(read.diagnostic?.message).toBe("app inventory failed");
   });
 
-  it("omits challenge HTML when serializing app/list errors", () => {
+  it("preserves supported older app servers when app/installed is unavailable", async () => {
+    const cache = new CodexAppInventoryCache({ ttlMs: 100 });
+    const request = vi.fn(async (method, params) => {
+      if (method === "app/installed") {
+        throw new CodexAppServerRpcError({ code: -32601, message: "Method not found" }, method);
+      }
+      return codexAppInventoryResponse(method, [app("legacy-app")], params);
+    });
+
+    const snapshot = await cache.refreshNow({ key: "runtime", request });
+
+    expect(snapshot.apps).toEqual([app("legacy-app")]);
+    expect(snapshot.source).toBe("legacy");
+    expect(request).toHaveBeenNthCalledWith(1, "app/installed", { forceRefresh: true });
+    expect(request).toHaveBeenNthCalledWith(2, "app/list", {
+      cursor: undefined,
+      limit: 100,
+      forceRefetch: false,
+    });
+  });
+
+  it("does not expose disabled apps from supported older app servers", async () => {
+    const cache = new CodexAppInventoryCache({ ttlMs: 100 });
+    const disabledApp = { ...app("legacy-disabled-app"), isEnabled: false };
+    const request = vi.fn(async (method, params) => {
+      if (method === "app/installed") {
+        throw new CodexAppServerRpcError({ code: -32601, message: "Method not found" }, method);
+      }
+      return codexAppInventoryResponse(method, [disabledApp], params);
+    });
+
+    const snapshot = await cache.refreshNow({ key: "runtime", request });
+
+    expect(snapshot.apps).toEqual([{ ...disabledApp, isAccessible: false }]);
+    expect(request).toHaveBeenNthCalledWith(1, "app/installed", { forceRefresh: true });
+    expect(request).toHaveBeenNthCalledWith(2, "app/list", {
+      cursor: undefined,
+      limit: 100,
+      forceRefetch: false,
+    });
+  });
+
+  it("does not fall back to the legacy directory for authorization failures", async () => {
+    const cache = new CodexAppInventoryCache({ ttlMs: 100 });
+    const request = vi.fn(async (method) => {
+      throw new CodexAppServerRpcError({ code: 403, message: "Forbidden" }, method);
+    });
+
+    await expect(cache.refreshNow({ key: "runtime", request })).rejects.toThrow("Forbidden");
+    expect(request).toHaveBeenCalledExactlyOnceWith("app/installed", { forceRefresh: true });
+  });
+
+  it("omits challenge HTML when serializing app inventory errors", () => {
     const error = new Error(
-      'failed to list apps: Request failed with status 403 Forbidden: <html><script src="/backend-api/connectors/directory/list?__cf_chl_tk=secret-token"></script></html>',
+      'failed to read apps: Request failed with status 403 Forbidden: <html><script src="/backend-api/connectors/directory/list?__cf_chl_tk=secret-token"></script></html>',
     );
-    const serialized = serializeCodexAppInventoryError(error);
 
-    expect(serialized.message).toBe(
-      "failed to list apps: Request failed with status 403 Forbidden: [HTML response body omitted]",
+    expect(serializeCodexAppInventoryError(error).message).toBe(
+      "failed to read apps: Request failed with status 403 Forbidden: [HTML response body omitted]",
     );
   });
 
-  it("keeps serialized app/list error messages on a UTF-16 boundary", () => {
+  it("keeps serialized app inventory error messages on a UTF-16 boundary", () => {
     const error = new Error(`${"x".repeat(499)}🚀tail`);
 
     expect(serializeCodexAppInventoryError(error).message).toBe(`${"x".repeat(499)}...`);
   });
 
-  it("keeps serialized app/list error data on a UTF-16 boundary", () => {
-    const error = Object.assign(new Error("app list failed"), {
+  it("keeps serialized app inventory error data on a UTF-16 boundary", () => {
+    const error = Object.assign(new Error("app inventory failed"), {
       data: { label: `${"x".repeat(499)}🚀tail` },
     });
 
@@ -233,23 +339,26 @@ describe("Codex app inventory cache", () => {
     });
   });
 
-  it("forces a post-install refresh past an older in-flight app/list", async () => {
+  it("forces a post-install refresh past an older in-flight runtime snapshot", async () => {
     const cache = new CodexAppInventoryCache({ ttlMs: 1_000 });
     const key = "runtime";
-    let resolveStale: ((response: v2.AppsListResponse) => void) | undefined;
-    let resolveFresh: ((response: v2.AppsListResponse) => void) | undefined;
-    const request = vi.fn(
-      async (_method: "app/list", params: v2.AppsListParams): Promise<v2.AppsListResponse> => {
-        expect(params.forceRefetch).toBe(request.mock.calls.length === 2);
-        return await new Promise((resolve) => {
-          if (request.mock.calls.length === 1) {
+    let resolveStale: ((response: v2.AppsInstalledResponse) => void) | undefined;
+    let resolveFresh: ((response: v2.AppsInstalledResponse) => void) | undefined;
+    let installedCalls = 0;
+    const request = vi.fn(async (method, params) => {
+      if (method === "app/installed") {
+        installedCalls += 1;
+        expect(params.forceRefresh).toBe(true);
+        return await new Promise<v2.AppsInstalledResponse>((resolve) => {
+          if (installedCalls === 1) {
             resolveStale = resolve;
           } else {
             resolveFresh = resolve;
           }
         });
-      },
-    );
+      }
+      return codexAppInventoryResponse(method, [app("fresh-app"), app("stale-app")], params);
+    });
 
     const staleRead = cache.read({ key, request, nowMs: 0 });
     expect(staleRead.state).toBe("missing");
@@ -259,24 +368,25 @@ describe("Codex app inventory cache", () => {
     const forcedRead = cache.read({ key, request, nowMs: 1, forceRefetch: true });
     expect(forcedRead.state).toBe("missing");
     expect(forcedRead.refreshScheduled).toBe(true);
-    expect(request).toHaveBeenCalledTimes(2);
+    expect(installedCalls).toBe(2);
 
     const forced = cache.refreshNow({ key, request, nowMs: 1 });
-    resolveFresh?.({ data: [app("fresh-app")], nextCursor: null });
+    resolveFresh?.(codexAppInventoryResponse("app/installed", [app("fresh-app")]));
     await expect(forced).resolves.toStrictEqual({
       key,
       apps: [app("fresh-app")],
+      source: "installed",
       fetchedAtMs: 1,
       expiresAtMs: 1_001,
       revision: 2,
     });
 
-    resolveStale?.({ data: [app("stale-app")], nextCursor: null });
-    await Promise.resolve();
+    resolveStale?.(codexAppInventoryResponse("app/installed", [app("stale-app")]));
+    await vi.waitFor(() => expect(request).toHaveBeenCalledTimes(4));
 
     const freshRead = cache.read({ key, request, nowMs: 2 });
     expect(freshRead.state).toBe("fresh");
-    expect(freshRead.snapshot?.apps.map((item) => item.id)).toEqual(["fresh-app"]);
+    expect(freshRead.snapshot?.apps).toEqual([app("fresh-app")]);
   });
 });
 

--- a/extensions/codex/src/app-server/app-inventory-cache.ts
+++ b/extensions/codex/src/app-server/app-inventory-cache.ts
@@ -10,18 +10,26 @@ import {
 } from "openclaw/plugin-sdk/number-runtime";
 import { isRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
-import type { JsonValue, v2 } from "./protocol.js";
+import { CodexAppServerRpcError } from "./client.js";
+import type {
+  CodexAppServerRequestParams,
+  CodexAppServerRequestResult,
+  JsonValue,
+  v2,
+} from "./protocol.js";
 
 /** Default app inventory cache freshness window. */
 const CODEX_APP_INVENTORY_CACHE_TTL_MS = 60 * 60 * 1_000;
-const CODEX_TARGETED_APP_INVENTORY_LIMIT = 1_000;
+// Codex 0.145.0 AppsReadParams rejects requests with more than 100 app IDs.
+const CODEX_APP_READ_BATCH_LIMIT = 100;
+const CODEX_TARGETED_LEGACY_APP_INVENTORY_LIMIT = 1_000;
 const MAX_SERIALIZED_ERROR_MESSAGE_LENGTH = 500;
 
-/** App-server request function used to list installed/available apps. */
-export type CodexAppInventoryRequest = (
-  method: "app/list",
-  params: v2.AppsListParams,
-) => Promise<v2.AppsListResponse>;
+/** App-server request function used to read installed apps and their metadata. */
+export type CodexAppInventoryRequest = <Method extends "app/installed" | "app/list" | "app/read">(
+  method: Method,
+  params: CodexAppServerRequestParams<Method>,
+) => Promise<CodexAppServerRequestResult<Method>>;
 
 /** Runtime identity fields that affect visible Codex app inventory. */
 export type CodexAppInventoryCacheKeyInput = {
@@ -44,6 +52,7 @@ type CodexAppInventoryCacheDiagnostic = {
 export type CodexAppInventorySnapshot = {
   key: string;
   apps: v2.AppInfo[];
+  source: "installed" | "legacy";
   fetchedAtMs: number;
   expiresAtMs: number;
   revision: number;
@@ -193,7 +202,7 @@ export class CodexAppInventoryCache {
   ): Promise<CodexAppInventorySnapshot> {
     const nowMs = resolveDateTimestampMs(params.nowMs);
     try {
-      const apps = await listAllApps(
+      const inventory = await readInstalledApps(
         params.request,
         params.forceRefetch ?? false,
         params.targetAppIds,
@@ -202,7 +211,8 @@ export class CodexAppInventoryCache {
       const expiresAtMs = resolveExpiresAtMsFromDurationMs(this.ttlMs, { nowMs }) ?? 0;
       const snapshot: CodexAppInventorySnapshot = {
         key: params.key,
-        apps,
+        apps: inventory.apps,
+        source: inventory.source,
         fetchedAtMs: nowMs,
         expiresAtMs,
         revision: this.revision,
@@ -288,30 +298,105 @@ function normalizeRuntimeIdentityForCacheKey(
   return entries.length > 0 ? Object.fromEntries(entries) : null;
 }
 
-async function listAllApps(
+async function readInstalledApps(
   request: CodexAppInventoryRequest,
   forceRefetch: boolean,
   targetAppIds: readonly string[] = [],
+): Promise<{ apps: v2.AppInfo[]; source: CodexAppInventorySnapshot["source"] }> {
+  let installed: v2.AppsInstalledResponse;
+  try {
+    // A non-forced installed read returns the prior committed runtime snapshot;
+    // refreshing OpenClaw's cache must refresh the upstream snapshot as well.
+    installed = await request("app/installed", { forceRefresh: true });
+  } catch (error) {
+    // OpenClaw still supports Codex 0.143.0 and 0.144.x, which do not
+    // implement the 0.145.0 installed-app lifecycle methods.
+    if (
+      !(error instanceof CodexAppServerRpcError) ||
+      error.code !== -32601 ||
+      error.method !== "app/installed"
+    ) {
+      throw error;
+    }
+    return {
+      apps: await readLegacyInstalledApps(request, forceRefetch, targetAppIds),
+      source: "legacy",
+    };
+  }
+  const targetIds = new Set(targetAppIds.filter(Boolean));
+  const apps =
+    targetIds.size === 0 ? installed.apps : installed.apps.filter((app) => targetIds.has(app.id));
+  if (apps.length === 0) {
+    return { apps: [], source: "installed" };
+  }
+
+  const metadataResponses = await Promise.all(
+    Array.from({ length: Math.ceil(apps.length / CODEX_APP_READ_BATCH_LIMIT) }, (_, index) =>
+      request("app/read", {
+        appIds: apps
+          .slice(index * CODEX_APP_READ_BATCH_LIMIT, (index + 1) * CODEX_APP_READ_BATCH_LIMIT)
+          .map((app) => app.id),
+      }),
+    ),
+  );
+  const metadataById = new Map(
+    metadataResponses
+      .flatMap((response) => response.apps)
+      .map((metadata) => [metadata.id, metadata]),
+  );
+
+  return {
+    apps: apps.flatMap((installedApp): v2.AppInfo[] => {
+      const metadata = metadataById.get(installedApp.id);
+      if (!metadata) {
+        return [];
+      }
+
+      return [
+        {
+          id: installedApp.id,
+          name: metadata.name,
+          description: metadata.description ?? null,
+          logoUrl: metadata.iconUrl ?? null,
+          logoUrlDark: metadata.iconUrlDark ?? null,
+          distributionChannel: metadata.distributionChannel ?? null,
+          branding: null,
+          appMetadata: null,
+          labels: null,
+          installUrl: metadata.installUrl ?? null,
+          isAccessible: installedApp.callable,
+          isEnabled: installedApp.enabled,
+          pluginDisplayNames: metadata.pluginDisplayNames,
+        },
+      ];
+    }),
+    source: "installed",
+  };
+}
+
+async function readLegacyInstalledApps(
+  request: CodexAppInventoryRequest,
+  forceRefetch: boolean,
+  targetAppIds: readonly string[],
 ): Promise<v2.AppInfo[]> {
   const apps: v2.AppInfo[] = [];
-  const targetIds = new Set(targetAppIds.filter(Boolean));
-  const remainingTargetIds = new Set(targetIds);
+  const remainingTargetIds = new Set(targetAppIds.filter(Boolean));
   const seenCursors = new Set<string>();
   let cursor: string | null | undefined;
+
   do {
     const response = await request("app/list", {
       cursor,
-      // Thread startup only needs to recover the configured plugin-owned apps.
-      // Large pages minimize startup latency while pagination still proves an
-      // absent target instead of publishing a known-incomplete lookup.
-      limit: targetIds.size > 0 ? CODEX_TARGETED_APP_INVENTORY_LIMIT : 100,
+      limit: remainingTargetIds.size > 0 ? CODEX_TARGETED_LEGACY_APP_INVENTORY_LIMIT : 100,
       forceRefetch,
     });
-    apps.push(...response.data);
     for (const app of response.data) {
+      // Legacy accessibility predates installed callability; disabled apps
+      // must obey the same fail-closed runtime contract as modern snapshots.
+      apps.push(app.isEnabled ? app : { ...app, isAccessible: false });
       remainingTargetIds.delete(app.id);
     }
-    if (targetIds.size > 0 && remainingTargetIds.size === 0) {
+    if (targetAppIds.length > 0 && remainingTargetIds.size === 0) {
       break;
     }
     cursor = response.nextCursor;
@@ -322,6 +407,7 @@ async function listAllApps(
       seenCursors.add(cursor);
     }
   } while (cursor);
+
   return apps;
 }
 

--- a/extensions/codex/src/app-server/app-inventory-protocol.ts
+++ b/extensions/codex/src/app-server/app-inventory-protocol.ts
@@ -1,0 +1,69 @@
+import type { JsonValue } from "./protocol-json.js";
+
+/** App inventory shape consumed by OpenClaw's existing plugin policy. */
+export type CodexAppInfo = {
+  id: string;
+  name: string;
+  description?: string | null;
+  logoUrl?: string | null;
+  logoUrlDark?: string | null;
+  distributionChannel?: string | null;
+  branding?: JsonValue;
+  appMetadata?: JsonValue;
+  labels?: JsonValue;
+  installUrl?: string | null;
+  isAccessible: boolean;
+  isEnabled: boolean;
+  pluginDisplayNames: string[];
+};
+
+/** Legacy inventory contract retained for supported pre-0.145 app servers. */
+export type CodexAppsListParams = {
+  cursor?: string | null;
+  limit?: number;
+  forceRefetch?: boolean;
+};
+
+export type CodexAppsListResponse = {
+  data: CodexAppInfo[];
+  nextCursor?: string | null;
+};
+
+/** Runtime app state returned by Codex app-server `app/installed`. */
+type CodexInstalledApp = {
+  id: string;
+  runtimeName?: string | null;
+  enabled: boolean;
+  callable: boolean;
+};
+
+export type CodexAppsInstalledParams = {
+  threadId?: string | null;
+  forceRefresh?: boolean;
+};
+
+export type CodexAppsInstalledResponse = {
+  apps: CodexInstalledApp[];
+};
+
+/** Canonical connector metadata returned by Codex app-server `app/read`. */
+type CodexConnectorMetadata = {
+  id: string;
+  name: string;
+  description?: string | null;
+  iconUrl?: string | null;
+  iconUrlDark?: string | null;
+  distributionChannel?: string | null;
+  installUrl?: string | null;
+  pluginDisplayNames: string[];
+};
+
+export type CodexAppsReadParams = {
+  appIds: string[];
+  includeTools?: boolean;
+};
+
+export type CodexAppsReadResponse = {
+  apps: CodexConnectorMetadata[];
+  missingAppIds: string[];
+};

--- a/extensions/codex/src/app-server/app-inventory.test-helpers.ts
+++ b/extensions/codex/src/app-server/app-inventory.test-helpers.ts
@@ -1,0 +1,48 @@
+import type { CodexAppsReadParams } from "./app-inventory-protocol.js";
+import type { CodexAppServerRequestParams, CodexAppServerRequestResult, v2 } from "./protocol.js";
+
+type CodexAppInventoryMethod = "app/installed" | "app/list" | "app/read";
+
+/** Builds app-server inventory fixtures from the existing app policy test shape. */
+export function codexAppInventoryResponse<Method extends CodexAppInventoryMethod>(
+  method: Method,
+  apps: readonly v2.AppInfo[],
+  params?: CodexAppServerRequestParams<Method>,
+): CodexAppServerRequestResult<Method> {
+  if (method === "app/installed") {
+    return {
+      apps: apps.map((app) => ({
+        id: app.id,
+        runtimeName: app.name,
+        enabled: app.isEnabled,
+        callable: app.isAccessible && app.isEnabled,
+      })),
+    } as CodexAppServerRequestResult<Method>;
+  }
+
+  if (method === "app/read") {
+    const requestedIds = (params as CodexAppsReadParams | undefined)?.appIds;
+    const requestedIdSet = requestedIds ? new Set(requestedIds) : undefined;
+    const matchingApps = requestedIdSet ? apps.filter((app) => requestedIdSet.has(app.id)) : apps;
+    const returnedIds = new Set(matchingApps.map((app) => app.id));
+
+    return {
+      apps: matchingApps.map((app) => ({
+        id: app.id,
+        name: app.name,
+        description: app.description,
+        iconUrl: app.logoUrl,
+        iconUrlDark: app.logoUrlDark,
+        distributionChannel: app.distributionChannel,
+        installUrl: app.installUrl,
+        pluginDisplayNames: app.pluginDisplayNames,
+      })),
+      missingAppIds: requestedIds?.filter((id) => !returnedIds.has(id)) ?? [],
+    } as CodexAppServerRequestResult<Method>;
+  }
+
+  return {
+    data: [...apps],
+    nextCursor: null,
+  } as CodexAppServerRequestResult<Method>;
+}

--- a/extensions/codex/src/app-server/plugin-activation.test.ts
+++ b/extensions/codex/src/app-server/plugin-activation.test.ts
@@ -129,9 +129,9 @@ describe("Codex plugin activation", () => {
         if (method === "config/mcpServer/reload") {
           return {};
         }
-        if (method === "app/list") {
-          expectBooleanParam(params, "forceRefetch", true);
-          return { data: [], nextCursor: null } satisfies v2.AppsListResponse;
+        if (method === "app/installed") {
+          expectBooleanParam(params, "forceRefresh", true);
+          return { apps: [] } satisfies v2.AppsInstalledResponse;
         }
         throw new Error(`unexpected request ${method}`);
       },
@@ -149,7 +149,7 @@ describe("Codex plugin activation", () => {
       "skills/list",
       "hooks/list",
       "config/mcpServer/reload",
-      "app/list",
+      "app/installed",
     ]);
     expect(pluginListCalls).toBe(2);
     expect(
@@ -182,8 +182,8 @@ describe("Codex plugin activation", () => {
         if (method === "config/mcpServer/reload") {
           return {};
         }
-        if (method === "app/list") {
-          throw new Error("app/list unavailable");
+        if (method === "app/installed") {
+          throw new Error("app/installed unavailable");
         }
         throw new Error(`unexpected request ${method}`);
       },
@@ -196,7 +196,7 @@ describe("Codex plugin activation", () => {
     });
     expect(result.diagnostics).toEqual([
       {
-        message: "Codex app inventory refresh skipped: app/list unavailable",
+        message: "Codex app inventory refresh skipped: app/installed unavailable",
       },
     ]);
     expect(appCache.getRevision()).toBeGreaterThan(0);

--- a/extensions/codex/src/app-server/plugin-activation.ts
+++ b/extensions/codex/src/app-server/plugin-activation.ts
@@ -16,7 +16,7 @@ import {
   type CodexPluginRuntimeRequest,
 } from "./plugin-inventory.js";
 import type { CodexPluginMetadataCache } from "./plugin-metadata-cache.js";
-import type { v2 } from "./protocol.js";
+import type { CodexAppServerRequestResult, v2 } from "./protocol.js";
 
 /** Terminal reason reported after trying to activate one Codex plugin policy. */
 type CodexPluginActivationReason =
@@ -178,7 +178,7 @@ async function refreshCodexPluginRuntimeState(params: {
   if (params.appCache && params.appCacheKey) {
     params.appCache.invalidate(params.appCacheKey, "Codex plugin activation changed app inventory");
     const request: CodexAppInventoryRequest = async (method, requestParams) =>
-      (await params.request(method, requestParams)) as v2.AppsListResponse;
+      (await params.request(method, requestParams)) as CodexAppServerRequestResult<typeof method>;
     try {
       await params.appCache.refreshNow({
         key: params.appCacheKey,

--- a/extensions/codex/src/app-server/plugin-inventory.test.ts
+++ b/extensions/codex/src/app-server/plugin-inventory.test.ts
@@ -1,6 +1,7 @@
 // Codex tests cover plugin inventory plugin behavior.
 import { describe, expect, it } from "vitest";
 import { CodexAppInventoryCache } from "./app-inventory-cache.js";
+import { codexAppInventoryResponse } from "./app-inventory.test-helpers.js";
 import { CodexAppServerRpcError } from "./client.js";
 import {
   CODEX_PLUGINS_MARKETPLACE_NAME,
@@ -15,10 +16,8 @@ describe("Codex plugin inventory", () => {
     await appCache.refreshNow({
       key: "runtime",
       nowMs: 0,
-      request: async () => ({
-        data: [appInfo("google-calendar-app", true)],
-        nextCursor: null,
-      }),
+      request: async (method, params) =>
+        codexAppInventoryResponse(method, [appInfo("google-calendar-app", true)], params),
     });
     const calls: string[] = [];
     const inventory = await readCodexPluginInventory({
@@ -84,10 +83,8 @@ describe("Codex plugin inventory", () => {
     await appCache.refreshNow({
       key: "runtime",
       nowMs: 0,
-      request: async () => ({
-        data: [appInfo("github-app", true)],
-        nextCursor: null,
-      }),
+      request: async (method, params) =>
+        codexAppInventoryResponse(method, [appInfo("github-app", true)], params),
     });
 
     const listed = pluginList([
@@ -149,10 +146,8 @@ describe("Codex plugin inventory", () => {
     await appCache.refreshNow({
       key: "runtime",
       nowMs: 0,
-      request: async () => ({
-        data: [appInfo("google-calendar-app", true)],
-        nextCursor: null,
-      }),
+      request: async (method, params) =>
+        codexAppInventoryResponse(method, [appInfo("google-calendar-app", true)], params),
     });
     const remoteSummary = pluginSummary("google-calendar@openai-curated-remote", {
       name: "google-calendar",
@@ -214,7 +209,8 @@ describe("Codex plugin inventory", () => {
     await appCache.refreshNow({
       key: "runtime",
       nowMs: 0,
-      request: async () => ({ data: [appInfo("workspace-data-app", true)], nextCursor: null }),
+      request: async (method, params) =>
+        codexAppInventoryResponse(method, [appInfo("workspace-data-app", true)], params),
     });
     const calls: Array<{ method: string; params: unknown }> = [];
     const exactSummary = pluginSummary("workspace-data@workspace-directory", {
@@ -490,10 +486,7 @@ describe("Codex plugin inventory", () => {
     await appCache.refreshNow({
       key: "runtime",
       nowMs: 0,
-      request: async () => ({
-        data: [],
-        nextCursor: null,
-      }),
+      request: async (method, params) => codexAppInventoryResponse(method, [], params),
     });
     const inventory = await readCodexPluginInventory({
       pluginConfig: {
@@ -541,15 +534,12 @@ describe("Codex plugin inventory", () => {
     await appCache.refreshNow({
       key: "runtime",
       nowMs: 0,
-      request: async () => ({
-        data: [
-          {
-            ...appInfo("calendar-app", true),
-            pluginDisplayNames: ["Google Calendar"],
-          },
-        ],
-        nextCursor: null,
-      }),
+      request: async (method, params) =>
+        codexAppInventoryResponse(
+          method,
+          [{ ...appInfo("calendar-app", true), pluginDisplayNames: ["Google Calendar"] }],
+          params,
+        ),
     });
 
     const inventory = await readCodexPluginInventory({
@@ -606,8 +596,8 @@ describe("Codex plugin inventory", () => {
       appCache,
       appCacheKey: "runtime",
       request: async (method) => {
-        if (method === "app/list") {
-          return { data: [], nextCursor: null };
+        if (method === "app/installed" || method === "app/read") {
+          return codexAppInventoryResponse(method, []);
         }
         if (method === "plugin/list") {
           return pluginList([pluginSummary("google-calendar", { installed: true, enabled: true })]);

--- a/extensions/codex/src/app-server/plugin-inventory.ts
+++ b/extensions/codex/src/app-server/plugin-inventory.ts
@@ -21,7 +21,7 @@ import type {
   CodexPluginMetadataCache,
   CodexPluginMetadataQueryKind,
 } from "./plugin-metadata-cache.js";
-import type { v2 } from "./protocol.js";
+import type { CodexAppServerRequestResult, v2 } from "./protocol.js";
 
 const CODEX_PLUGINS_REMOTE_MARKETPLACE_NAME = `${CODEX_PLUGINS_MARKETPLACE_NAME}-remote`;
 
@@ -356,7 +356,7 @@ function readCachedAppInventory(
     return undefined;
   }
   const request: CodexAppInventoryRequest = async (method, requestParams) =>
-    (await params.request(method, requestParams)) as v2.AppsListResponse;
+    (await params.request(method, requestParams)) as CodexAppServerRequestResult<typeof method>;
   return params.appCache.read({
     key: params.appCacheKey,
     request,

--- a/extensions/codex/src/app-server/plugin-thread-app-admission.ts
+++ b/extensions/codex/src/app-server/plugin-thread-app-admission.ts
@@ -1,0 +1,217 @@
+import { embeddedAgentLog } from "openclaw/plugin-sdk/agent-harness-runtime";
+import {
+  serializeCodexAppInventoryError,
+  type CodexAppInventoryCache,
+  type CodexAppInventoryRequest,
+  type CodexAppInventorySnapshot,
+} from "./app-inventory-cache.js";
+import type { ResolvedCodexPluginsPolicy } from "./config.js";
+import type {
+  CodexPluginInventory,
+  CodexPluginInventoryRecord,
+  CodexPluginOwnedApp,
+  CodexPluginRuntimeRequest,
+} from "./plugin-inventory.js";
+import type { CodexAppServerRequestResult } from "./protocol.js";
+import { isJsonObject, type JsonObject, type v2 } from "./protocol.js";
+
+export type CodexPluginThreadAppAdmissionDiagnostic = {
+  code: "account_app_inventory_unavailable";
+  message: string;
+};
+
+type CodexPluginThreadAppAdmissionParams = {
+  request: CodexPluginRuntimeRequest;
+  configCwd?: string;
+  appCacheKey: string;
+  nowMs?: number;
+};
+
+export async function refreshAppInventoryNow(
+  params: CodexPluginThreadAppAdmissionParams,
+  appCache: CodexAppInventoryCache,
+  options: { forceRefetch?: boolean; reason?: string; targetAppIds?: readonly string[] } = {},
+): Promise<CodexAppInventorySnapshot | undefined> {
+  const appCacheKey = params.appCacheKey;
+  if (!appCacheKey) {
+    return undefined;
+  }
+  const request: CodexAppInventoryRequest = async (method, requestParams) =>
+    (await params.request(method, requestParams)) as CodexAppServerRequestResult<typeof method>;
+  try {
+    return await appCache.refreshNow({
+      key: appCacheKey,
+      request,
+      nowMs: params.nowMs,
+      forceRefetch: options.forceRefetch,
+      targetAppIds: options.targetAppIds,
+    });
+  } catch (error) {
+    embeddedAgentLog.warn("codex plugin thread config app inventory refresh failed", {
+      reason: options.reason,
+      forceRefetch: options.forceRefetch === true,
+      error: serializeCodexAppInventoryError(error),
+    });
+    // Keep building from the diagnostic inventory state; app exposure remains scoped below.
+    return undefined;
+  }
+}
+
+export function collectInventoryOwnedAppIds(inventory: CodexPluginInventory): string[] {
+  return Array.from(
+    new Set(inventory.records.flatMap((record) => record.ownedAppIds).filter(Boolean)),
+  ).toSorted();
+}
+
+export async function readThreadAdmissibleAccountApps(
+  params: CodexPluginThreadAppAdmissionParams,
+  appCache: CodexAppInventoryCache,
+): Promise<{
+  apps: v2.AppInfo[];
+  source?: CodexAppInventorySnapshot["source"];
+  diagnostic?: CodexPluginThreadAppAdmissionDiagnostic;
+}> {
+  // Account-wide mode needs metadata for every installed app, not only the
+  // configured plugin-owned app ids used by targeted startup refreshes.
+  const snapshot = await refreshAppInventoryNow(params, appCache, {
+    forceRefetch: false,
+    reason: "account_apps_all",
+    targetAppIds: [],
+  });
+  if (!snapshot) {
+    return {
+      apps: [],
+      diagnostic: {
+        code: "account_app_inventory_unavailable",
+        message: "Codex account app inventory was unavailable; account apps were not exposed.",
+      },
+    };
+  }
+  return {
+    apps: snapshot.apps
+      // Account-wide discovery must preserve Codex's effective enablement policy.
+      // Only an explicitly configured plugin may provisionally enable its owned app.
+      .filter((app) => resolveAppInfoThreadAdmission(app, snapshot.source) === "ready")
+      .toSorted((left, right) => left.id.localeCompare(right.id)),
+    source: snapshot.source,
+  };
+}
+
+export function toOwnedAccountApp(app: v2.AppInfo): CodexPluginOwnedApp {
+  return {
+    id: app.id,
+    name: app.name,
+    accessible: app.isAccessible,
+    enabled: app.isEnabled,
+    needsAuth: !app.isAccessible,
+  };
+}
+
+export function resolveThreadConfigAppsForRecord(params: {
+  record: CodexPluginInventoryRecord;
+  inventory: CodexPluginInventory;
+}): CodexPluginOwnedApp[] {
+  if (params.inventory.appInventory?.state === "missing") {
+    return [];
+  }
+  return params.record.apps;
+}
+
+type CodexPluginAppThreadAdmission = "ready" | "provisional" | "blocked";
+
+export function resolvePluginAppThreadAdmission(
+  app: CodexPluginOwnedApp,
+  inventory: CodexPluginInventory,
+): CodexPluginAppThreadAdmission {
+  if (app.accessible) {
+    return "ready";
+  }
+  const snapshot = inventory.appInventory?.snapshot;
+  if (!snapshot) {
+    return "blocked";
+  }
+  const appInfo = snapshot.apps.find((candidate) => candidate.id === app.id);
+  return appInfo ? resolveAppInfoThreadAdmission(appInfo, snapshot.source) : "blocked";
+}
+
+function resolveAppInfoThreadAdmission(
+  app: v2.AppInfo,
+  source: CodexAppInventorySnapshot["source"] | undefined,
+): CodexPluginAppThreadAdmission {
+  if (app.isAccessible) {
+    return "ready";
+  }
+  // The explicit OpenClaw plugin entry is the unmanaged enablement decision.
+  // Codex still applies feature/workspace gates and managed app requirements
+  // after this thread override; thread-scoped attestation fails closed if they win.
+  return source === "installed" && !app.isEnabled ? "provisional" : "blocked";
+}
+
+export async function readConfigLayersForAppAdmission(
+  params: CodexPluginThreadAppAdmissionParams,
+): Promise<readonly JsonObject[] | undefined> {
+  try {
+    const response = await params.request("config/read", {
+      includeLayers: true,
+      ...(params.configCwd ? { cwd: params.configCwd } : {}),
+    });
+    if (!isJsonObject(response) || !Array.isArray(response.layers)) {
+      throw new Error("Codex config/read omitted config layers");
+    }
+    return response.layers.flatMap((layer) => {
+      if (!isJsonObject(layer)) {
+        throw new Error("Codex config/read returned an invalid config layer");
+      }
+      if (layer.disabledReason !== undefined && layer.disabledReason !== null) {
+        if (typeof layer.disabledReason !== "string") {
+          throw new Error("Codex config/read returned an invalid disabled layer");
+        }
+        return [];
+      }
+      if (!isJsonObject(layer.config)) {
+        throw new Error("Codex config/read returned an invalid layer config");
+      }
+      return [layer.config];
+    });
+  } catch (error) {
+    embeddedAgentLog.warn("codex plugin app admission config read failed", { error });
+    return undefined;
+  }
+}
+
+export function resolveExplicitAppEnablement(
+  layersHighestPrecedenceFirst: readonly JsonObject[],
+  appId: string,
+): boolean | undefined {
+  // Codex includes disabled layers and orders active config from highest to lowest.
+  // The first app-specific value wins; ignoring `_default` preserves the deny-all
+  // service-account baseline while preventing SessionFlags from undoing an explicit opt-out.
+  for (const layer of layersHighestPrecedenceFirst) {
+    const apps = layer.apps;
+    const app = isJsonObject(apps) ? apps[appId] : undefined;
+    if (!isJsonObject(app) || !Object.hasOwn(app, "enabled")) {
+      continue;
+    }
+    return app.enabled === true;
+  }
+  return undefined;
+}
+
+export function shouldForceRefreshForNotReadyPluginApps(
+  params: CodexPluginThreadAppAdmissionParams,
+  policy: ResolvedCodexPluginsPolicy,
+  inventory: CodexPluginInventory,
+): boolean {
+  if (!params.appCacheKey || !policy.pluginPolicies.some((plugin) => plugin.enabled)) {
+    return false;
+  }
+  if (inventory.appInventory?.state === "missing") {
+    return false;
+  }
+  return inventory.records.some(
+    (record) =>
+      record.appOwnership === "proven" &&
+      record.ownedAppIds.length > 0 &&
+      (record.apps.length === 0 || record.apps.some((app) => !app.accessible)),
+  );
+}

--- a/extensions/codex/src/app-server/plugin-thread-app-admission.ts
+++ b/extensions/codex/src/app-server/plugin-thread-app-admission.ts
@@ -91,7 +91,7 @@ export async function readThreadAdmissibleAccountApps(
     apps: snapshot.apps
       // Account-wide discovery must preserve Codex's effective enablement policy.
       // Only an explicitly configured plugin may provisionally enable its owned app.
-      .filter((app) => resolveAppInfoThreadAdmission(app, snapshot.source) === "ready")
+      .filter((app) => resolveAccountAppThreadAdmission(app, snapshot.source) === "ready")
       .toSorted((left, right) => left.id.localeCompare(right.id)),
     source: snapshot.source,
   };
@@ -118,6 +118,13 @@ export function resolveThreadConfigAppsForRecord(params: {
 }
 
 type CodexPluginAppThreadAdmission = "ready" | "provisional" | "blocked";
+
+export function resolveAccountAppThreadAdmission(
+  app: v2.AppInfo,
+  source: CodexAppInventorySnapshot["source"] | undefined,
+): CodexPluginAppThreadAdmission {
+  return resolveAppInfoThreadAdmission(app, source);
+}
 
 export function resolvePluginAppThreadAdmission(
   app: CodexPluginOwnedApp,

--- a/extensions/codex/src/app-server/plugin-thread-attestation.test.ts
+++ b/extensions/codex/src/app-server/plugin-thread-attestation.test.ts
@@ -1,0 +1,68 @@
+// Codex tests cover provisional plugin app attestation behavior.
+import { describe, expect, it, vi } from "vitest";
+import { attestCodexPluginThreadApps } from "./plugin-thread-attestation.js";
+import type { v2 } from "./protocol.js";
+
+describe("Codex provisional plugin app attestation", () => {
+  it("reads effective app state directly from the newly started thread", async () => {
+    const request = vi.fn(async () => installedApps(["linear-app"]));
+
+    await attestCodexPluginThreadApps({
+      client: { request } as never,
+      threadId: "thread-linear",
+      appIds: ["linear-app", "linear-app"],
+    });
+
+    expect(request).toHaveBeenCalledExactlyOnceWith(
+      "app/installed",
+      {
+        threadId: "thread-linear",
+        forceRefresh: true,
+      },
+      { signal: undefined },
+    );
+  });
+
+  it.each([
+    {
+      state: "missing",
+      response: installedApps([]),
+      failure: "linear-app:missing",
+    },
+    {
+      state: "disabled",
+      response: installedApps(["linear-app"], { enabled: false, callable: false }),
+      failure: "linear-app:disabled",
+    },
+    {
+      state: "not callable",
+      response: installedApps(["linear-app"], { callable: false }),
+      failure: "linear-app:not-callable",
+    },
+  ])("fails closed when a provisional app is $state", async ({ response, failure }) => {
+    await expect(
+      attestCodexPluginThreadApps({
+        client: { request: vi.fn(async () => response) } as never,
+        threadId: "thread-linear",
+        appIds: ["linear-app"],
+      }),
+    ).rejects.toMatchObject({
+      name: "CodexPluginThreadAppAttestationError",
+      message: expect.stringContaining(failure),
+    });
+  });
+});
+
+function installedApps(
+  appIds: string[],
+  state: { enabled?: boolean; callable?: boolean } = {},
+): v2.AppsInstalledResponse {
+  return {
+    apps: appIds.map((id) => ({
+      id,
+      runtimeName: id,
+      enabled: state.enabled ?? true,
+      callable: state.callable ?? true,
+    })),
+  };
+}

--- a/extensions/codex/src/app-server/plugin-thread-attestation.ts
+++ b/extensions/codex/src/app-server/plugin-thread-attestation.ts
@@ -6,7 +6,7 @@ import type { CodexAppServerClient } from "./client.js";
 import type { v2 } from "./protocol.js";
 
 /** Raised when a fresh thread does not expose every provisionally admitted app. */
-export class CodexPluginThreadAppAttestationError extends Error {
+class CodexPluginThreadAppAttestationError extends Error {
   constructor(message: string, options?: ErrorOptions) {
     super(message, options);
     this.name = "CodexPluginThreadAppAttestationError";

--- a/extensions/codex/src/app-server/plugin-thread-attestation.ts
+++ b/extensions/codex/src/app-server/plugin-thread-attestation.ts
@@ -1,0 +1,61 @@
+/**
+ * Confirms provisionally admitted Codex apps against the effective config of a
+ * newly started thread before OpenClaw persists or turns on that thread.
+ */
+import type { CodexAppServerClient } from "./client.js";
+import type { v2 } from "./protocol.js";
+
+/** Raised when a fresh thread does not expose every provisionally admitted app. */
+export class CodexPluginThreadAppAttestationError extends Error {
+  constructor(message: string, options?: ErrorOptions) {
+    super(message, options);
+    this.name = "CodexPluginThreadAppAttestationError";
+  }
+}
+
+/** Reads thread-scoped runtime state directly so it never enters the account cache. */
+export async function attestCodexPluginThreadApps(params: {
+  client: CodexAppServerClient;
+  threadId: string;
+  appIds: readonly string[];
+  signal?: AbortSignal;
+}): Promise<void> {
+  const appIds = Array.from(new Set(params.appIds.filter(Boolean))).toSorted();
+  if (appIds.length === 0) {
+    return;
+  }
+
+  let response: v2.AppsInstalledResponse;
+  try {
+    response = await params.client.request(
+      "app/installed",
+      {
+        threadId: params.threadId,
+        forceRefresh: true,
+      },
+      { signal: params.signal },
+    );
+  } catch (error) {
+    throw new CodexPluginThreadAppAttestationError(
+      `Codex could not confirm provisional apps for thread ${params.threadId}`,
+      { cause: error },
+    );
+  }
+
+  const installedById = new Map(response.apps.map((app) => [app.id, app] as const));
+  const failures = appIds.flatMap((appId): string[] => {
+    const app = installedById.get(appId);
+    if (!app) {
+      return [`${appId}:missing`];
+    }
+    if (!app.enabled) {
+      return [`${appId}:disabled`];
+    }
+    return app.callable ? [] : [`${appId}:not-callable`];
+  });
+  if (failures.length > 0) {
+    throw new CodexPluginThreadAppAttestationError(
+      `Codex thread ${params.threadId} did not expose provisional apps: ${failures.join(", ")}`,
+    );
+  }
+}

--- a/extensions/codex/src/app-server/plugin-thread-config.test.ts
+++ b/extensions/codex/src/app-server/plugin-thread-config.test.ts
@@ -1,6 +1,9 @@
 // Codex tests cover plugin thread config plugin behavior.
 import { describe, expect, it, vi } from "vitest";
 import { CodexAppInventoryCache } from "./app-inventory-cache.js";
+import type { CodexAppsInstalledParams } from "./app-inventory-protocol.js";
+import { codexAppInventoryResponse } from "./app-inventory.test-helpers.js";
+import { CodexAppServerRpcError } from "./client.js";
 import {
   CODEX_PLUGINS_MARKETPLACE_NAME,
   CODEX_PLUGINS_WORKSPACE_MARKETPLACE_NAME,
@@ -25,10 +28,8 @@ describe("Codex plugin thread config", () => {
     await appCache.refreshNow({
       key: "runtime",
       nowMs: 0,
-      request: async () => ({
-        data: [appInfo("google-calendar-app", true)],
-        nextCursor: null,
-      }),
+      request: async (method, params) =>
+        codexAppInventoryResponse(method, [appInfo("google-calendar-app", true)], params),
     });
 
     const config = await buildCodexPluginThreadConfig({
@@ -95,10 +96,8 @@ describe("Codex plugin thread config", () => {
     await appCache.refreshNow({
       key: "runtime",
       nowMs: 0,
-      request: async () => ({
-        data: [appInfo("workspace-data-app", true)],
-        nextCursor: null,
-      }),
+      request: async (method, params) =>
+        codexAppInventoryResponse(method, [appInfo("workspace-data-app", true)], params),
     });
     const methods: string[] = [];
 
@@ -270,10 +269,8 @@ describe("Codex plugin thread config", () => {
     await appCache.refreshNow({
       key: "runtime",
       nowMs: 0,
-      request: async () => ({
-        data: [appInfo("google-calendar-app", true)],
-        nextCursor: null,
-      }),
+      request: async (method, params) =>
+        codexAppInventoryResponse(method, [appInfo("google-calendar-app", true)], params),
     });
     let configReadCount = 0;
     const request = vi.fn(async (method: string) => {
@@ -470,10 +467,8 @@ describe("Codex plugin thread config", () => {
     await appCache.refreshNow({
       key: "runtime",
       nowMs: 0,
-      request: async () => ({
-        data: [appInfo("google-calendar-app", true)],
-        nextCursor: null,
-      }),
+      request: async (method, params) =>
+        codexAppInventoryResponse(method, [appInfo("google-calendar-app", true)], params),
     });
     let configReadCount = 0;
     const request = vi.fn(async (method: string) => {
@@ -567,12 +562,13 @@ describe("Codex plugin thread config", () => {
     await appCache.refreshNow({
       key: "runtime",
       nowMs: 0,
-      request: async () => ({
-        data: [appInfo("google-calendar-app", true)],
-        nextCursor: null,
-      }),
+      request: async (method, params) =>
+        codexAppInventoryResponse(method, [appInfo("google-calendar-app", true, false)], params),
     });
     const request = vi.fn(async (method: string) => {
+      if (method === "app/installed" || method === "app/read") {
+        return codexAppInventoryResponse(method, [appInfo("google-calendar-app", true, false)]);
+      }
       if (method === "plugin/list") {
         return pluginList([pluginSummary("google-calendar", { installed: true, enabled: true })]);
       }
@@ -634,6 +630,7 @@ describe("Codex plugin thread config", () => {
       },
     });
     expect(config.policyContext.apps).toStrictEqual({});
+    expect(config.provisionalAppIds).toBeUndefined();
     expect(config.diagnostics).toStrictEqual([
       {
         code: "approval_overrides_clear_failed",
@@ -656,10 +653,8 @@ describe("Codex plugin thread config", () => {
     await appCache.refreshNow({
       key: "runtime",
       nowMs: 0,
-      request: async () => ({
-        data: [appInfo("google-calendar-app", true)],
-        nextCursor: null,
-      }),
+      request: async (method, params) =>
+        codexAppInventoryResponse(method, [appInfo("google-calendar-app", true)], params),
     });
 
     const config = await buildCodexPluginThreadConfig({
@@ -752,7 +747,7 @@ describe("Codex plugin thread config", () => {
     expect(config.policyContext.apps).toStrictEqual({});
   });
 
-  it("exposes every accessible account app from a complete app inventory", async () => {
+  it("exposes only ready account apps while preserving callable-tool denies", async () => {
     const pluginConfig = {
       codexPlugins: {
         enabled: true,
@@ -761,36 +756,28 @@ describe("Codex plugin thread config", () => {
       },
     };
     expect(shouldBuildCodexPluginThreadConfig(pluginConfig)).toBe(true);
-    const appListParams: v2.AppsListParams[] = [];
+    const installedParams: CodexAppsInstalledParams[] = [];
+    const accountApps = [
+      { ...appInfo("chatgpt-meetings", true), name: "ChatGPT Meetings" },
+      appInfo("disabled-account-app", true, false),
+      appInfo("inaccessible-app", false),
+      { ...appInfo("slack", true), name: "Slack" },
+    ];
     const config = await buildCodexPluginThreadConfig({
       pluginConfig,
       appCacheKey: "runtime",
       request: async (method, rawParams) => {
-        if (method !== "app/list") {
+        if (method !== "app/installed" && method !== "app/read") {
           throw new Error(`unexpected request ${method}`);
         }
-        const params = rawParams as v2.AppsListParams;
-        appListParams.push(params);
-        if (!params.cursor) {
-          return {
-            data: [
-              { ...appInfo("chatgpt-meetings", true, false), name: "ChatGPT Meetings" },
-              appInfo("inaccessible-app", false),
-            ],
-            nextCursor: "page-2",
-          };
+        if (method === "app/installed") {
+          installedParams.push(rawParams as CodexAppsInstalledParams);
         }
-        return {
-          data: [{ ...appInfo("slack", true), name: "Slack" }],
-          nextCursor: null,
-        };
+        return codexAppInventoryResponse(method, accountApps);
       },
     });
 
-    expect(appListParams).toEqual([
-      { cursor: undefined, limit: 100, forceRefetch: false },
-      { cursor: "page-2", limit: 100, forceRefetch: false },
-    ]);
+    expect(installedParams).toEqual([{ forceRefresh: true }]);
     expect(config.configPatch).toEqual({
       apps: {
         _default: {
@@ -828,6 +815,7 @@ describe("Codex plugin thread config", () => {
         mcpServerNames: [],
       },
     });
+    expect(config.provisionalAppIds).toBeUndefined();
     expect(config.diagnostics).toStrictEqual([]);
   });
 
@@ -842,7 +830,7 @@ describe("Codex plugin thread config", () => {
       },
       appCacheKey: "runtime",
       request: async (method) => {
-        if (method === "app/list") {
+        if (method === "app/installed") {
           throw new Error("inventory unavailable");
         }
         throw new Error(`unexpected request ${method}`);
@@ -868,11 +856,10 @@ describe("Codex plugin thread config", () => {
   it("clears durable approval overrides for account apps in ask mode", async () => {
     let configReadCount = 0;
     const request = vi.fn(async (method: string) => {
-      if (method === "app/list") {
-        return {
-          data: [{ ...appInfo("chatgpt-meetings", true), name: "ChatGPT Meetings" }],
-          nextCursor: null,
-        };
+      if (method === "app/installed" || method === "app/read") {
+        return codexAppInventoryResponse(method, [
+          { ...appInfo("chatgpt-meetings", true), name: "ChatGPT Meetings" },
+        ]);
       }
       if (method === "config/read") {
         configReadCount += 1;
@@ -943,11 +930,10 @@ describe("Codex plugin thread config", () => {
         if (method === "plugin/read") {
           return pluginDetail("meetings", [appSummary("chatgpt-meetings")]);
         }
-        if (method === "app/list") {
-          return {
-            data: [{ ...appInfo("chatgpt-meetings", true), name: "ChatGPT Meetings" }],
-            nextCursor: null,
-          };
+        if (method === "app/installed" || method === "app/read") {
+          return codexAppInventoryResponse(method, [
+            { ...appInfo("chatgpt-meetings", true), name: "ChatGPT Meetings" },
+          ]);
         }
         if (method === "config/read") {
           throw new Error("approval policy unavailable");
@@ -1026,11 +1012,13 @@ describe("Codex plugin thread config", () => {
 
   it("waits for the initial app inventory before exposing plugin apps", async () => {
     const appCache = new CodexAppInventoryCache();
-    const appListParams: v2.AppsListParams[] = [];
+    const installedParams: CodexAppsInstalledParams[] = [];
     const request = vi.fn(async (method: string, params?: unknown) => {
-      if (method === "app/list") {
-        appListParams.push(params as v2.AppsListParams);
-        return { data: [appInfo("google-calendar-app", true, false)], nextCursor: null };
+      if (method === "app/installed" || method === "app/read") {
+        if (method === "app/installed") {
+          installedParams.push(params as CodexAppsInstalledParams);
+        }
+        return codexAppInventoryResponse(method, [appInfo("google-calendar-app", true)]);
       }
       if (method === "plugin/list") {
         return pluginList([pluginSummary("google-calendar", { installed: true, enabled: true })]);
@@ -1082,26 +1070,98 @@ describe("Codex plugin thread config", () => {
     });
     expect(config.diagnostics).toStrictEqual([]);
     expect(
-      request.mock.calls.reduce((count, [method]) => count + (method === "app/list" ? 1 : 0), 0),
+      request.mock.calls.reduce(
+        (count, [method]) => count + (method === "app/installed" ? 1 : 0),
+        0,
+      ),
     ).toBe(1);
-    expect(appListParams).toEqual([
-      {
-        cursor: undefined,
-        limit: 1_000,
-        forceRefetch: false,
-      },
-    ]);
+    expect(installedParams).toEqual([{ forceRefresh: true }]);
   });
 
-  it("re-enables an OpenClaw-allowed app even when app/list reports it disabled", async () => {
+  it("provisionally exposes a base-disabled installed plugin app", async () => {
     const appCache = new CodexAppInventoryCache();
     await appCache.refreshNow({
       key: "runtime",
       nowMs: 0,
-      request: async () => ({
-        data: [appInfo("google-calendar-app", true, false)],
-        nextCursor: null,
-      }),
+      request: async (method, params) =>
+        codexAppInventoryResponse(method, [appInfo("google-calendar-app", true, false)], params),
+    });
+
+    const config = await buildCodexPluginThreadConfig({
+      pluginConfig: {
+        codexPlugins: {
+          enabled: true,
+          plugins: {
+            "google-calendar": {
+              marketplaceName: CODEX_PLUGINS_MARKETPLACE_NAME,
+              pluginName: "google-calendar",
+            },
+          },
+        },
+      },
+      appCache,
+      appCacheKey: "runtime",
+      nowMs: 1,
+      request: async (method, params) => {
+        if (method === "app/installed" || method === "app/read") {
+          return codexAppInventoryResponse(method, [appInfo("google-calendar-app", true, false)]);
+        }
+        if (method === "config/read") {
+          expect(params).toEqual({ includeLayers: true });
+          return {
+            config: {},
+            layers: [
+              {
+                name: "user",
+                config: {
+                  apps: {
+                    _default: {
+                      enabled: false,
+                    },
+                  },
+                },
+                disabledReason: null,
+              },
+            ],
+          };
+        }
+        if (method === "plugin/list") {
+          return pluginList([pluginSummary("google-calendar", { installed: true, enabled: true })]);
+        }
+        if (method === "plugin/read") {
+          return pluginDetail("google-calendar", [appSummary("google-calendar-app")]);
+        }
+        throw new Error(`unexpected request ${method}`);
+      },
+    });
+
+    expect(config.inventory?.records[0]?.apps).toStrictEqual([
+      {
+        id: "google-calendar-app",
+        name: "google-calendar-app",
+        accessible: false,
+        enabled: false,
+        needsAuth: true,
+      },
+    ]);
+    expect(config.configPatch?.apps).toMatchObject({
+      "google-calendar-app": {
+        enabled: true,
+      },
+    });
+    expect(config.provisionalAppIds).toEqual(["google-calendar-app"]);
+    expect(config.diagnostics).not.toContainEqual(
+      expect.objectContaining({ code: "app_not_ready" }),
+    );
+  });
+
+  it("does not override an explicit app-specific disable from Codex config", async () => {
+    const appCache = new CodexAppInventoryCache();
+    await appCache.refreshNow({
+      key: "runtime",
+      nowMs: 0,
+      request: async (method, params) =>
+        codexAppInventoryResponse(method, [appInfo("google-calendar-app", true, false)], params),
     });
 
     const config = await buildCodexPluginThreadConfig({
@@ -1120,6 +1180,27 @@ describe("Codex plugin thread config", () => {
       appCacheKey: "runtime",
       nowMs: 1,
       request: async (method) => {
+        if (method === "app/installed" || method === "app/read") {
+          return codexAppInventoryResponse(method, [appInfo("google-calendar-app", true, false)]);
+        }
+        if (method === "config/read") {
+          return {
+            config: {},
+            layers: [
+              {
+                name: "project",
+                config: {
+                  apps: {
+                    "google-calendar-app": {
+                      enabled: false,
+                    },
+                  },
+                },
+                disabledReason: null,
+              },
+            ],
+          };
+        }
         if (method === "plugin/list") {
           return pluginList([pluginSummary("google-calendar", { installed: true, enabled: true })]);
         }
@@ -1130,26 +1211,220 @@ describe("Codex plugin thread config", () => {
       },
     });
 
-    expect(config.inventory?.records[0]?.apps).toStrictEqual([
-      {
-        id: "google-calendar-app",
-        name: "google-calendar-app",
-        accessible: true,
-        enabled: false,
-        needsAuth: false,
+    expect(config.configPatch?.apps).not.toHaveProperty("google-calendar-app");
+    expect(config.provisionalAppIds).toBeUndefined();
+    expect(config.diagnostics).toContainEqual(expect.objectContaining({ code: "app_not_ready" }));
+  });
+
+  it("uses the highest-precedence app-specific Codex config value", async () => {
+    const appCache = new CodexAppInventoryCache();
+    await appCache.refreshNow({
+      key: "runtime",
+      nowMs: 0,
+      request: async (method, params) =>
+        codexAppInventoryResponse(method, [appInfo("google-calendar-app", true, false)], params),
+    });
+
+    const config = await buildCodexPluginThreadConfig({
+      pluginConfig: {
+        codexPlugins: {
+          enabled: true,
+          plugins: {
+            "google-calendar": {
+              marketplaceName: CODEX_PLUGINS_MARKETPLACE_NAME,
+              pluginName: "google-calendar",
+            },
+          },
+        },
       },
-    ]);
+      appCache,
+      appCacheKey: "runtime",
+      nowMs: 1,
+      request: async (method) => {
+        if (method === "app/installed" || method === "app/read") {
+          return codexAppInventoryResponse(method, [appInfo("google-calendar-app", true, false)]);
+        }
+        if (method === "config/read") {
+          return {
+            config: {},
+            layers: [
+              {
+                name: "project",
+                config: {
+                  apps: {
+                    "google-calendar-app": {
+                      enabled: true,
+                    },
+                  },
+                },
+                disabledReason: null,
+              },
+              {
+                name: "user",
+                config: {
+                  apps: {
+                    "google-calendar-app": {
+                      enabled: false,
+                    },
+                  },
+                },
+                disabledReason: null,
+              },
+            ],
+          };
+        }
+        if (method === "plugin/list") {
+          return pluginList([pluginSummary("google-calendar", { installed: true, enabled: true })]);
+        }
+        if (method === "plugin/read") {
+          return pluginDetail("google-calendar", [appSummary("google-calendar-app")]);
+        }
+        throw new Error(`unexpected request ${method}`);
+      },
+    });
+
     expect(config.configPatch?.apps).toMatchObject({
       "google-calendar-app": {
         enabled: true,
       },
     });
-    expect(config.diagnostics).toStrictEqual([]);
+    expect(config.provisionalAppIds).toEqual(["google-calendar-app"]);
+  });
+
+  it("fails closed when Codex config layers cannot be inspected", async () => {
+    const appCache = new CodexAppInventoryCache();
+    await appCache.refreshNow({
+      key: "runtime",
+      nowMs: 0,
+      request: async (method, params) =>
+        codexAppInventoryResponse(method, [appInfo("google-calendar-app", true, false)], params),
+    });
+
+    const config = await buildCodexPluginThreadConfig({
+      pluginConfig: {
+        codexPlugins: {
+          enabled: true,
+          plugins: {
+            "google-calendar": {
+              marketplaceName: CODEX_PLUGINS_MARKETPLACE_NAME,
+              pluginName: "google-calendar",
+            },
+          },
+        },
+      },
+      appCache,
+      appCacheKey: "runtime",
+      nowMs: 1,
+      request: async (method) => {
+        if (method === "app/installed" || method === "app/read") {
+          return codexAppInventoryResponse(method, [appInfo("google-calendar-app", true, false)]);
+        }
+        if (method === "config/read") {
+          throw new Error("config unavailable");
+        }
+        if (method === "plugin/list") {
+          return pluginList([pluginSummary("google-calendar", { installed: true, enabled: true })]);
+        }
+        if (method === "plugin/read") {
+          return pluginDetail("google-calendar", [appSummary("google-calendar-app")]);
+        }
+        throw new Error(`unexpected request ${method}`);
+      },
+    });
+
+    expect(config.configPatch?.apps).not.toHaveProperty("google-calendar-app");
+    expect(config.provisionalAppIds).toBeUndefined();
+    expect(config.diagnostics).toContainEqual(expect.objectContaining({ code: "app_not_ready" }));
+  });
+
+  it("does not expose an enabled installed plugin app without callable tools", async () => {
+    const appCache = new CodexAppInventoryCache();
+    await appCache.refreshNow({
+      key: "runtime",
+      nowMs: 0,
+      request: async (method, params) =>
+        codexAppInventoryResponse(method, [appInfo("google-calendar-app", false)], params),
+    });
+
+    const config = await buildCodexPluginThreadConfig({
+      pluginConfig: {
+        codexPlugins: {
+          enabled: true,
+          plugins: {
+            "google-calendar": {
+              marketplaceName: CODEX_PLUGINS_MARKETPLACE_NAME,
+              pluginName: "google-calendar",
+            },
+          },
+        },
+      },
+      appCache,
+      appCacheKey: "runtime",
+      nowMs: 1,
+      request: async (method) => {
+        if (method === "app/installed" || method === "app/read") {
+          return codexAppInventoryResponse(method, [appInfo("google-calendar-app", false)]);
+        }
+        if (method === "plugin/list") {
+          return pluginList([pluginSummary("google-calendar", { installed: true, enabled: true })]);
+        }
+        if (method === "plugin/read") {
+          return pluginDetail("google-calendar", [appSummary("google-calendar-app")]);
+        }
+        throw new Error(`unexpected request ${method}`);
+      },
+    });
+
+    expect(config.configPatch?.apps).not.toHaveProperty("google-calendar-app");
+    expect(config.provisionalAppIds).toBeUndefined();
+    expect(config.diagnostics).toContainEqual(expect.objectContaining({ code: "app_not_ready" }));
+  });
+
+  it("does not provisionally expose a disabled app from the legacy inventory fallback", async () => {
+    const appCache = new CodexAppInventoryCache();
+    const disabledApp = appInfo("google-calendar-app", true, false);
+    const request = vi.fn(async (method: string) => {
+      if (method === "app/installed") {
+        throw new CodexAppServerRpcError({ code: -32601, message: "Method not found" }, method);
+      }
+      if (method === "app/list") {
+        return codexAppInventoryResponse("app/list", [disabledApp]);
+      }
+      if (method === "plugin/list") {
+        return pluginList([pluginSummary("google-calendar", { installed: true, enabled: true })]);
+      }
+      if (method === "plugin/read") {
+        return pluginDetail("google-calendar", [appSummary("google-calendar-app")]);
+      }
+      throw new Error(`unexpected request ${method}`);
+    });
+
+    const config = await buildCodexPluginThreadConfig({
+      pluginConfig: {
+        codexPlugins: {
+          enabled: true,
+          plugins: {
+            "google-calendar": {
+              marketplaceName: CODEX_PLUGINS_MARKETPLACE_NAME,
+              pluginName: "google-calendar",
+            },
+          },
+        },
+      },
+      appCache,
+      appCacheKey: "runtime",
+      nowMs: 0,
+      request,
+    });
+
+    expect(config.configPatch?.apps).not.toHaveProperty("google-calendar-app");
+    expect(config.provisionalAppIds).toBeUndefined();
+    expect(config.diagnostics).toContainEqual(expect.objectContaining({ code: "app_not_ready" }));
   });
 
   it("refreshes missing app inventory when plugin activation becomes unnecessary", async () => {
     const appCache = new CodexAppInventoryCache();
-    const appListParams: v2.AppsListParams[] = [];
+    const installedParams: CodexAppsInstalledParams[] = [];
     let pluginListCalls = 0;
     const request = vi.fn(async (method: string, params?: unknown) => {
       if (method === "plugin/list") {
@@ -1162,12 +1437,11 @@ describe("Codex plugin thread config", () => {
       if (method === "plugin/read") {
         return pluginDetail("google-calendar", [appSummary("google-calendar-app")]);
       }
-      if (method === "app/list") {
-        appListParams.push(params as v2.AppsListParams);
-        return {
-          data: [appInfo("google-calendar-app", true)],
-          nextCursor: null,
-        } satisfies v2.AppsListResponse;
+      if (method === "app/installed" || method === "app/read") {
+        if (method === "app/installed") {
+          installedParams.push(params as CodexAppsInstalledParams);
+        }
+        return codexAppInventoryResponse(method, [appInfo("google-calendar-app", true)]);
       }
       throw new Error(`unexpected request ${method}`);
     });
@@ -1195,13 +1469,7 @@ describe("Codex plugin thread config", () => {
       },
     });
     expect(request.mock.calls.map(([method]) => method)).not.toContain("plugin/install");
-    expect(appListParams).toEqual([
-      {
-        cursor: undefined,
-        limit: 1_000,
-        forceRefetch: true,
-      },
-    ]);
+    expect(installedParams).toEqual([{ forceRefresh: true }]);
   });
 
   it("does not expose plugin apps missing from the app inventory snapshot", async () => {
@@ -1209,10 +1477,7 @@ describe("Codex plugin thread config", () => {
     await appCache.refreshNow({
       key: "runtime",
       nowMs: 0,
-      request: async () => ({
-        data: [],
-        nextCursor: null,
-      }),
+      request: async (method, params) => codexAppInventoryResponse(method, [], params),
     });
 
     const config = await buildCodexPluginThreadConfig({
@@ -1272,10 +1537,8 @@ describe("Codex plugin thread config", () => {
     await appCache.refreshNow({
       key: "runtime",
       nowMs: 0,
-      request: async () => ({
-        data: [appInfo("google-calendar-app", true)],
-        nextCursor: null,
-      }),
+      request: async (method, params) =>
+        codexAppInventoryResponse(method, [appInfo("google-calendar-app", true)], params),
     });
 
     const config = await buildCodexPluginThreadConfig({
@@ -1320,12 +1583,9 @@ describe("Codex plugin thread config", () => {
     await appCache.refreshNow({
       key: "runtime",
       nowMs: 0,
-      request: async () => ({
-        data: [],
-        nextCursor: null,
-      }),
+      request: async (method, params) => codexAppInventoryResponse(method, [], params),
     });
-    const appListParams: v2.AppsListParams[] = [];
+    const installedParams: CodexAppsInstalledParams[] = [];
     const request = vi.fn(async (method: string, params?: unknown) => {
       if (method === "plugin/list") {
         return pluginList([pluginSummary("google-calendar", { installed: true, enabled: true })]);
@@ -1333,12 +1593,11 @@ describe("Codex plugin thread config", () => {
       if (method === "plugin/read") {
         return pluginDetail("google-calendar", [appSummary("google-calendar-app")]);
       }
-      if (method === "app/list") {
-        appListParams.push(params as v2.AppsListParams);
-        return {
-          data: [appInfo("google-calendar-app", true)],
-          nextCursor: null,
-        } satisfies v2.AppsListResponse;
+      if (method === "app/installed" || method === "app/read") {
+        if (method === "app/installed") {
+          installedParams.push(params as CodexAppsInstalledParams);
+        }
+        return codexAppInventoryResponse(method, [appInfo("google-calendar-app", true)]);
       }
       throw new Error(`unexpected request ${method}`);
     });
@@ -1384,13 +1643,7 @@ describe("Codex plugin thread config", () => {
       mcpServerNames: [],
     });
     expect(config.diagnostics).toStrictEqual([]);
-    expect(appListParams).toEqual([
-      {
-        cursor: undefined,
-        limit: 1_000,
-        forceRefetch: true,
-      },
-    ]);
+    expect(installedParams).toEqual([{ forceRefresh: true }]);
   });
 
   it("re-reads app readiness after re-enabling an installed plugin", async () => {
@@ -1399,13 +1652,11 @@ describe("Codex plugin thread config", () => {
     await appCache.refreshNow({
       key: "runtime",
       nowMs: 0,
-      request: async () => ({
-        data: [appInfo("google-calendar-app", true, false)],
-        nextCursor: null,
-      }),
+      request: async (method, params) =>
+        codexAppInventoryResponse(method, [appInfo("google-calendar-app", true, false)], params),
     });
     let enabled = false;
-    const appListParams: v2.AppsListParams[] = [];
+    const installedParams: CodexAppsInstalledParams[] = [];
     const request = vi.fn(async (method: string, params?: unknown) => {
       if (method === "plugin/list") {
         return pluginList([pluginSummary("google-calendar", { installed: true, enabled })]);
@@ -1426,12 +1677,11 @@ describe("Codex plugin thread config", () => {
       if (method === "config/mcpServer/reload") {
         return {};
       }
-      if (method === "app/list") {
-        appListParams.push(params as v2.AppsListParams);
-        return {
-          data: [appInfo("google-calendar-app", true, enabled)],
-          nextCursor: null,
-        } satisfies v2.AppsListResponse;
+      if (method === "app/installed" || method === "app/read") {
+        if (method === "app/installed") {
+          installedParams.push(params as CodexAppsInstalledParams);
+        }
+        return codexAppInventoryResponse(method, [appInfo("google-calendar-app", true, enabled)]);
       }
       throw new Error(`unexpected request ${method}`);
     });
@@ -1486,22 +1736,13 @@ describe("Codex plugin thread config", () => {
       "skills/list",
       "hooks/list",
       "config/mcpServer/reload",
-      "app/list",
-      "app/list",
+      "app/installed",
+      "app/read",
+      "app/installed",
+      "app/read",
       "plugin/read",
     ]);
-    expect(appListParams).toEqual([
-      {
-        cursor: undefined,
-        limit: 1_000,
-        forceRefetch: true,
-      },
-      {
-        cursor: undefined,
-        limit: 1_000,
-        forceRefetch: true,
-      },
-    ]);
+    expect(installedParams).toEqual([{ forceRefresh: true }, { forceRefresh: true }]);
   });
 
   it("installs an unconfigured remote plugin before waiting for app inventory", async () => {
@@ -1527,11 +1768,8 @@ describe("Codex plugin thread config", () => {
       if (method === "config/mcpServer/reload") {
         return {};
       }
-      if (method === "app/list") {
-        return {
-          data: [appInfo("google-calendar-app", true, installed)],
-          nextCursor: null,
-        } satisfies v2.AppsListResponse;
+      if (method === "app/installed" || method === "app/read") {
+        return codexAppInventoryResponse(method, [appInfo("google-calendar-app", true, installed)]);
       }
       throw new Error(`unexpected request ${method}: ${JSON.stringify(params)}`);
     });
@@ -1560,7 +1798,7 @@ describe("Codex plugin thread config", () => {
     });
     const methods = request.mock.calls.map(([method]) => method);
     expect(methods.indexOf("plugin/install")).toBeGreaterThan(-1);
-    expect(methods.indexOf("app/list")).toBeGreaterThan(methods.indexOf("plugin/install"));
+    expect(methods.indexOf("app/installed")).toBeGreaterThan(methods.indexOf("plugin/install"));
   });
 
   it("surfaces critical post-install refresh failures and keeps plugin apps disabled", async () => {
@@ -1568,10 +1806,8 @@ describe("Codex plugin thread config", () => {
     await appCache.refreshNow({
       key: "runtime",
       nowMs: 0,
-      request: async () => ({
-        data: [appInfo("google-calendar-app", true)],
-        nextCursor: null,
-      }),
+      request: async (method, params) =>
+        codexAppInventoryResponse(method, [appInfo("google-calendar-app", true)], params),
     });
 
     const config = await buildCodexPluginThreadConfig({
@@ -1642,8 +1878,8 @@ describe("Codex plugin thread config", () => {
       appCache,
       appCacheKey: "runtime",
       request: async (method) => {
-        if (method === "app/list") {
-          throw new Error("app/list unavailable");
+        if (method === "app/installed") {
+          throw new Error("app/installed unavailable");
         }
         if (method === "plugin/list") {
           return pluginList([pluginSummary("google-calendar", { installed: true, enabled: true })]);
@@ -1678,11 +1914,12 @@ describe("Codex plugin thread config", () => {
     await appCache.refreshNow({
       key: "runtime",
       nowMs: 0,
-      request: async () =>
-        ({
-          data: [{ ...appInfo("google-calendar-app", true), id: "" }] as unknown as v2.AppInfo[],
-          nextCursor: null,
-        }) satisfies v2.AppsListResponse,
+      request: async (method, params) =>
+        codexAppInventoryResponse(
+          method,
+          [{ ...appInfo("google-calendar-app", true), id: "" }],
+          params,
+        ),
     });
 
     const config = await buildCodexPluginThreadConfig({
@@ -1745,7 +1982,7 @@ describe("Codex plugin thread config", () => {
     });
     await appCache.refreshNow({
       key: "runtime-a",
-      request: async () => ({ data: [], nextCursor: null }),
+      request: async (method, params) => codexAppInventoryResponse(method, [], params),
     });
     const second = buildCodexPluginThreadConfigInputFingerprint({
       pluginConfig: { codexPlugins: { enabled: true } },
@@ -1764,10 +2001,8 @@ describe("Codex plugin thread config", () => {
     await appCache.refreshNow({
       key: "runtime",
       nowMs: 0,
-      request: async () => ({
-        data: [appInfo("github-app", true)],
-        nextCursor: null,
-      }),
+      request: async (method, params) =>
+        codexAppInventoryResponse(method, [appInfo("github-app", true)], params),
     });
 
     const config = await buildCodexPluginThreadConfig({
@@ -1991,7 +2226,7 @@ describe("Codex plugin thread config", () => {
     await appCache.refreshNow({
       key: "runtime",
       nowMs: 0,
-      request: async () => ({ data: [], nextCursor: null }),
+      request: async (method, params) => codexAppInventoryResponse(method, [], params),
     });
     const pluginConfig = {
       codexPlugins: {
@@ -2169,10 +2404,8 @@ async function buildReadyGoogleCalendarThreadConfig(
   await appCache.refreshNow({
     key: "runtime",
     nowMs: 0,
-    request: async () => ({
-      data: [appInfo("google-calendar-app", true)],
-      nextCursor: null,
-    }),
+    request: async (method, params) =>
+      codexAppInventoryResponse(method, [appInfo("google-calendar-app", true)], params),
   });
 
   return buildCodexPluginThreadConfig({

--- a/extensions/codex/src/app-server/plugin-thread-config.ts
+++ b/extensions/codex/src/app-server/plugin-thread-config.ts
@@ -3,13 +3,9 @@
  * for native Codex turns.
  */
 import crypto from "node:crypto";
-import { embeddedAgentLog } from "openclaw/plugin-sdk/agent-harness-runtime";
 import {
   defaultCodexAppInventoryCache,
-  serializeCodexAppInventoryError,
-  type CodexAppInventorySnapshot,
   type CodexAppInventoryCache,
-  type CodexAppInventoryRequest,
 } from "./app-inventory-cache.js";
 import {
   resolveCodexPluginsPolicy,
@@ -25,13 +21,23 @@ import {
   readCodexPluginInventory,
   type CodexPluginInventory,
   type CodexPluginInventoryDiagnostic,
-  type CodexPluginInventoryRecord,
   type CodexPluginOwnedApp,
   type CodexPluginRuntimeRequest,
 } from "./plugin-inventory.js";
 import type { CodexPluginMetadataCache } from "./plugin-metadata-cache.js";
-import type { CodexAppServerRequestResult } from "./protocol.js";
-import { isJsonObject, type JsonObject, type JsonValue, type v2 } from "./protocol.js";
+import {
+  collectInventoryOwnedAppIds,
+  readConfigLayersForAppAdmission,
+  readThreadAdmissibleAccountApps,
+  refreshAppInventoryNow,
+  resolveExplicitAppEnablement,
+  resolvePluginAppThreadAdmission,
+  resolveThreadConfigAppsForRecord,
+  shouldForceRefreshForNotReadyPluginApps,
+  toOwnedAccountApp,
+  type CodexPluginThreadAppAdmissionDiagnostic,
+} from "./plugin-thread-app-admission.js";
+import { isJsonObject, type JsonObject, type JsonValue } from "./protocol.js";
 
 /** Policy context for one app id exposed by a configured Codex plugin. */
 export type PluginAppPolicyContextEntry = {
@@ -66,12 +72,12 @@ export type PluginAppPolicyContext = {
 /** Diagnostic emitted while building app config for a native Codex thread. */
 type CodexPluginThreadConfigDiagnostic =
   | CodexPluginInventoryDiagnostic
+  | CodexPluginThreadAppAdmissionDiagnostic
   | {
       code:
         | "plugin_activation_failed"
         | "plugin_config_timeout"
         | "app_not_ready"
-        | "account_app_inventory_unavailable"
         | "approval_overrides_clear_failed";
       plugin?: ResolvedCodexPluginPolicy;
       message: string;
@@ -625,199 +631,12 @@ function shouldRefreshMissingAppInventory(
   );
 }
 
-async function refreshAppInventoryNow(
-  params: BuildCodexPluginThreadConfigParams,
-  appCache: CodexAppInventoryCache,
-  options: { forceRefetch?: boolean; reason?: string; targetAppIds?: readonly string[] } = {},
-): Promise<CodexAppInventorySnapshot | undefined> {
-  const appCacheKey = params.appCacheKey;
-  if (!appCacheKey) {
-    return undefined;
-  }
-  const request: CodexAppInventoryRequest = async (method, requestParams) =>
-    (await params.request(method, requestParams)) as CodexAppServerRequestResult<typeof method>;
-  try {
-    const snapshot = await appCache.refreshNow({
-      key: appCacheKey,
-      request,
-      nowMs: params.nowMs,
-      forceRefetch: options.forceRefetch,
-      targetAppIds: options.targetAppIds,
-    });
-    return snapshot;
-  } catch (error) {
-    embeddedAgentLog.warn("codex plugin thread config app inventory refresh failed", {
-      reason: options.reason,
-      forceRefetch: options.forceRefetch === true,
-      error: serializeCodexAppInventoryError(error),
-    });
-    // Keep building from the diagnostic inventory state; app exposure remains scoped below.
-    return undefined;
-  }
-}
-
-function collectInventoryOwnedAppIds(inventory: CodexPluginInventory): string[] {
-  return Array.from(
-    new Set(inventory.records.flatMap((record) => record.ownedAppIds).filter(Boolean)),
-  ).toSorted();
-}
-
 function emptyCodexPluginInventory(policy: ResolvedCodexPluginsPolicy): CodexPluginInventory {
   return {
     policy,
     records: [],
     diagnostics: [],
   };
-}
-
-async function readThreadAdmissibleAccountApps(
-  params: BuildCodexPluginThreadConfigParams,
-  appCache: CodexAppInventoryCache,
-): Promise<{
-  apps: v2.AppInfo[];
-  source?: CodexAppInventorySnapshot["source"];
-  diagnostic?: CodexPluginThreadConfigDiagnostic;
-}> {
-  // Account-wide mode needs metadata for every installed app, not only the
-  // configured plugin-owned app ids used by targeted startup refreshes.
-  const snapshot = await refreshAppInventoryNow(params, appCache, {
-    forceRefetch: false,
-    reason: "account_apps_all",
-    targetAppIds: [],
-  });
-  if (!snapshot) {
-    return {
-      apps: [],
-      diagnostic: {
-        code: "account_app_inventory_unavailable",
-        message: "Codex account app inventory was unavailable; account apps were not exposed.",
-      },
-    };
-  }
-  return {
-    apps: snapshot.apps
-      // Account-wide discovery must preserve Codex's effective enablement policy.
-      // Only an explicitly configured plugin may provisionally enable its owned app.
-      .filter((app) => resolveAppInfoThreadAdmission(app, snapshot.source) === "ready")
-      .toSorted((left, right) => left.id.localeCompare(right.id)),
-    source: snapshot.source,
-  };
-}
-
-function toOwnedAccountApp(app: v2.AppInfo): CodexPluginOwnedApp {
-  return {
-    id: app.id,
-    name: app.name,
-    accessible: app.isAccessible,
-    enabled: app.isEnabled,
-    needsAuth: !app.isAccessible,
-  };
-}
-
-function resolveThreadConfigAppsForRecord(params: {
-  record: CodexPluginInventoryRecord;
-  inventory: CodexPluginInventory;
-}): CodexPluginOwnedApp[] {
-  if (params.inventory.appInventory?.state === "missing") {
-    return [];
-  }
-  return params.record.apps;
-}
-
-type CodexPluginAppThreadAdmission = "ready" | "provisional" | "blocked";
-
-function resolvePluginAppThreadAdmission(
-  app: CodexPluginOwnedApp,
-  inventory: CodexPluginInventory,
-): CodexPluginAppThreadAdmission {
-  if (app.accessible) {
-    return "ready";
-  }
-  const snapshot = inventory.appInventory?.snapshot;
-  const appInfo = snapshot?.apps.find((candidate) => candidate.id === app.id);
-  return appInfo ? resolveAppInfoThreadAdmission(appInfo, snapshot.source) : "blocked";
-}
-
-function resolveAppInfoThreadAdmission(
-  app: v2.AppInfo,
-  source: CodexAppInventorySnapshot["source"] | undefined,
-): CodexPluginAppThreadAdmission {
-  if (app.isAccessible) {
-    return "ready";
-  }
-  // The explicit OpenClaw plugin entry is the unmanaged enablement decision.
-  // Codex still applies feature/workspace gates and managed app requirements
-  // after this thread override; thread-scoped attestation fails closed if they win.
-  return source === "installed" && !app.isEnabled ? "provisional" : "blocked";
-}
-
-async function readConfigLayersForAppAdmission(
-  params: BuildCodexPluginThreadConfigParams,
-): Promise<readonly JsonObject[] | undefined> {
-  try {
-    const response = await params.request("config/read", {
-      includeLayers: true,
-      ...(params.configCwd ? { cwd: params.configCwd } : {}),
-    });
-    if (!isJsonObject(response) || !Array.isArray(response.layers)) {
-      throw new Error("Codex config/read omitted config layers");
-    }
-    return response.layers.flatMap((layer) => {
-      if (!isJsonObject(layer)) {
-        throw new Error("Codex config/read returned an invalid config layer");
-      }
-      if (layer.disabledReason !== undefined && layer.disabledReason !== null) {
-        if (typeof layer.disabledReason !== "string") {
-          throw new Error("Codex config/read returned an invalid disabled layer");
-        }
-        return [];
-      }
-      if (!isJsonObject(layer.config)) {
-        throw new Error("Codex config/read returned an invalid layer config");
-      }
-      return [layer.config];
-    });
-  } catch (error) {
-    embeddedAgentLog.warn("codex plugin app admission config read failed", { error });
-    return undefined;
-  }
-}
-
-function resolveExplicitAppEnablement(
-  layersHighestPrecedenceFirst: readonly JsonObject[],
-  appId: string,
-): boolean | undefined {
-  // Codex includes disabled layers and orders active config from highest to lowest.
-  // The first app-specific value wins; ignoring `_default` preserves the deny-all
-  // service-account baseline while preventing SessionFlags from undoing an explicit opt-out.
-  for (const layer of layersHighestPrecedenceFirst) {
-    const apps = layer.apps;
-    const app = isJsonObject(apps) ? apps[appId] : undefined;
-    if (!isJsonObject(app) || !Object.hasOwn(app, "enabled")) {
-      continue;
-    }
-    return app.enabled === true;
-  }
-  return undefined;
-}
-
-function shouldForceRefreshForNotReadyPluginApps(
-  params: BuildCodexPluginThreadConfigParams,
-  policy: ResolvedCodexPluginsPolicy,
-  inventory: CodexPluginInventory,
-): boolean {
-  if (!params.appCacheKey || !policy.pluginPolicies.some((plugin) => plugin.enabled)) {
-    return false;
-  }
-  if (inventory.appInventory?.state === "missing") {
-    return false;
-  }
-  return inventory.records.some(
-    (record) =>
-      record.appOwnership === "proven" &&
-      record.ownedAppIds.length > 0 &&
-      (record.apps.length === 0 || record.apps.some((app) => !app.accessible)),
-  );
 }
 
 function policyFingerprint(policy: ResolvedCodexPluginsPolicy): JsonValue {

--- a/extensions/codex/src/app-server/plugin-thread-config.ts
+++ b/extensions/codex/src/app-server/plugin-thread-config.ts
@@ -30,6 +30,7 @@ import {
   readConfigLayersForAppAdmission,
   readThreadAdmissibleAccountApps,
   refreshAppInventoryNow,
+  resolveAccountAppThreadAdmission,
   resolveExplicitAppEnablement,
   resolvePluginAppThreadAdmission,
   resolveThreadConfigAppsForRecord,
@@ -361,7 +362,7 @@ export async function buildCodexPluginThreadConfig(
     if (pluginOwnedAppIds.has(app.id)) {
       continue;
     }
-    const admission = resolveAppInfoThreadAdmission(app, accountAppsResult.source);
+    const admission = resolveAccountAppThreadAdmission(app, accountAppsResult.source);
     const accountApp = toOwnedAccountApp(app);
     if (
       policy.destructiveApprovalMode === "ask" &&

--- a/extensions/codex/src/app-server/plugin-thread-config.ts
+++ b/extensions/codex/src/app-server/plugin-thread-config.ts
@@ -30,6 +30,7 @@ import {
   type CodexPluginRuntimeRequest,
 } from "./plugin-inventory.js";
 import type { CodexPluginMetadataCache } from "./plugin-metadata-cache.js";
+import type { CodexAppServerRequestResult } from "./protocol.js";
 import { isJsonObject, type JsonObject, type JsonValue, type v2 } from "./protocol.js";
 
 /** Policy context for one app id exposed by a configured Codex plugin. */
@@ -80,6 +81,7 @@ type CodexPluginThreadConfigDiagnostic =
 export type CodexPluginThreadConfig = {
   enabled: boolean;
   configPatch?: JsonObject;
+  provisionalAppIds?: readonly string[];
   fingerprint: string;
   inputFingerprint: string;
   policyContext: PluginAppPolicyContext;
@@ -267,14 +269,15 @@ export async function buildCodexPluginThreadConfig(
     });
   }
 
-  const accountAppsResult: Awaited<ReturnType<typeof readAccessibleAccountApps>> =
-    policy.allowAllPlugins ? await readAccessibleAccountApps(params, appCache) : { apps: [] };
+  const accountAppsResult: Awaited<ReturnType<typeof readThreadAdmissibleAccountApps>> =
+    policy.allowAllPlugins ? await readThreadAdmissibleAccountApps(params, appCache) : { apps: [] };
 
   const diagnostics: CodexPluginThreadConfigDiagnostic[] = [
     ...inventory.diagnostics,
     ...activationDiagnostics,
     ...(accountAppsResult.diagnostic ? [accountAppsResult.diagnostic] : []),
   ];
+  const provisionalAppIds = new Set<string>();
   const apps: JsonObject = {
     _default: {
       enabled: false,
@@ -284,6 +287,7 @@ export async function buildCodexPluginThreadConfig(
   };
   const policyApps: Record<string, CodexAppPolicyContextEntry> = {};
   const pluginAppIds: Record<string, string[]> = {};
+  let configLayersForAppAdmission: Promise<readonly JsonObject[] | undefined> | undefined;
   const pluginOwnedAppIds = new Set(
     inventory.records.flatMap((record) =>
       record.appOwnership === "proven" ? record.ownedAppIds : [],
@@ -301,7 +305,15 @@ export async function buildCodexPluginThreadConfig(
     }
     pluginAppIds[record.policy.configKey] = [...record.ownedAppIds].toSorted();
     for (const app of resolveThreadConfigAppsForRecord({ record, inventory })) {
-      if (!isPluginAppReadyForThreadStart(app)) {
+      let admission = resolvePluginAppThreadAdmission(app, inventory);
+      if (admission === "provisional") {
+        configLayersForAppAdmission ??= readConfigLayersForAppAdmission(params);
+        const layers = await configLayersForAppAdmission;
+        if (layers === undefined || resolveExplicitAppEnablement(layers, app.id) === false) {
+          admission = "blocked";
+        }
+      }
+      if (admission === "blocked") {
         diagnostics.push({
           code: "app_not_ready",
           plugin: record.policy,
@@ -320,6 +332,9 @@ export async function buildCodexPluginThreadConfig(
         }))
       ) {
         continue;
+      }
+      if (admission === "provisional") {
+        provisionalAppIds.add(app.id);
       }
       apps[app.id] = buildEnabledAppConfig(record.policy);
       policyApps[app.id] = {
@@ -340,6 +355,7 @@ export async function buildCodexPluginThreadConfig(
     if (pluginOwnedAppIds.has(app.id)) {
       continue;
     }
+    const admission = resolveAppInfoThreadAdmission(app, accountAppsResult.source);
     const accountApp = toOwnedAccountApp(app);
     if (
       policy.destructiveApprovalMode === "ask" &&
@@ -351,6 +367,9 @@ export async function buildCodexPluginThreadConfig(
       }))
     ) {
       continue;
+    }
+    if (admission === "provisional") {
+      provisionalAppIds.add(app.id);
     }
     apps[app.id] = buildEnabledAppConfig(policy);
     policyApps[app.id] = {
@@ -367,6 +386,9 @@ export async function buildCodexPluginThreadConfig(
   return {
     enabled: true,
     configPatch,
+    ...(provisionalAppIds.size > 0
+      ? { provisionalAppIds: Array.from(provisionalAppIds).toSorted() }
+      : {}),
     fingerprint: fingerprintJson({
       version: CODEX_PLUGIN_THREAD_CONFIG_FINGERPRINT_VERSION,
       inputFingerprint,
@@ -584,7 +606,7 @@ function shouldWaitForInitialAppInventory(
   policy: ResolvedCodexPluginsPolicy,
   inventory: CodexPluginInventory,
 ): boolean {
-  // Install/enable first so the initial app/list can observe newly activated plugin apps.
+  // Install/enable first so the initial app snapshot observes newly activated plugin apps.
   if (inventory.records.some((record) => record.activationRequired)) {
     return false;
   }
@@ -613,7 +635,7 @@ async function refreshAppInventoryNow(
     return undefined;
   }
   const request: CodexAppInventoryRequest = async (method, requestParams) =>
-    (await params.request(method, requestParams)) as Awaited<ReturnType<CodexAppInventoryRequest>>;
+    (await params.request(method, requestParams)) as CodexAppServerRequestResult<typeof method>;
   try {
     const snapshot = await appCache.refreshNow({
       key: appCacheKey,
@@ -648,15 +670,16 @@ function emptyCodexPluginInventory(policy: ResolvedCodexPluginsPolicy): CodexPlu
   };
 }
 
-async function readAccessibleAccountApps(
+async function readThreadAdmissibleAccountApps(
   params: BuildCodexPluginThreadConfigParams,
   appCache: CodexAppInventoryCache,
 ): Promise<{
   apps: v2.AppInfo[];
+  source?: CodexAppInventorySnapshot["source"];
   diagnostic?: CodexPluginThreadConfigDiagnostic;
 }> {
-  // Account-wide mode needs a complete inventory. A plugin-targeted cache fill can
-  // stop once its known app ids are found, so always traverse all app/list pages here.
+  // Account-wide mode needs metadata for every installed app, not only the
+  // configured plugin-owned app ids used by targeted startup refreshes.
   const snapshot = await refreshAppInventoryNow(params, appCache, {
     forceRefetch: false,
     reason: "account_apps_all",
@@ -673,8 +696,11 @@ async function readAccessibleAccountApps(
   }
   return {
     apps: snapshot.apps
-      .filter((app) => app.isAccessible)
+      // Account-wide discovery must preserve Codex's effective enablement policy.
+      // Only an explicitly configured plugin may provisionally enable its owned app.
+      .filter((app) => resolveAppInfoThreadAdmission(app, snapshot.source) === "ready")
       .toSorted((left, right) => left.id.localeCompare(right.id)),
+    source: snapshot.source,
   };
 }
 
@@ -698,11 +724,81 @@ function resolveThreadConfigAppsForRecord(params: {
   return params.record.apps;
 }
 
-function isPluginAppReadyForThreadStart(app: CodexPluginOwnedApp): boolean {
-  // `app/list` is the source of truth for inventory and access posture, but
-  // OpenClaw owns the per-thread enablement decision. A listed app that is
-  // accessible can be re-enabled for this thread via `config.apps[app.id]`.
-  return app.accessible;
+type CodexPluginAppThreadAdmission = "ready" | "provisional" | "blocked";
+
+function resolvePluginAppThreadAdmission(
+  app: CodexPluginOwnedApp,
+  inventory: CodexPluginInventory,
+): CodexPluginAppThreadAdmission {
+  if (app.accessible) {
+    return "ready";
+  }
+  const snapshot = inventory.appInventory?.snapshot;
+  const appInfo = snapshot?.apps.find((candidate) => candidate.id === app.id);
+  return appInfo ? resolveAppInfoThreadAdmission(appInfo, snapshot.source) : "blocked";
+}
+
+function resolveAppInfoThreadAdmission(
+  app: v2.AppInfo,
+  source: CodexAppInventorySnapshot["source"] | undefined,
+): CodexPluginAppThreadAdmission {
+  if (app.isAccessible) {
+    return "ready";
+  }
+  // The explicit OpenClaw plugin entry is the unmanaged enablement decision.
+  // Codex still applies feature/workspace gates and managed app requirements
+  // after this thread override; thread-scoped attestation fails closed if they win.
+  return source === "installed" && !app.isEnabled ? "provisional" : "blocked";
+}
+
+async function readConfigLayersForAppAdmission(
+  params: BuildCodexPluginThreadConfigParams,
+): Promise<readonly JsonObject[] | undefined> {
+  try {
+    const response = await params.request("config/read", {
+      includeLayers: true,
+      ...(params.configCwd ? { cwd: params.configCwd } : {}),
+    });
+    if (!isJsonObject(response) || !Array.isArray(response.layers)) {
+      throw new Error("Codex config/read omitted config layers");
+    }
+    return response.layers.flatMap((layer) => {
+      if (!isJsonObject(layer)) {
+        throw new Error("Codex config/read returned an invalid config layer");
+      }
+      if (layer.disabledReason !== undefined && layer.disabledReason !== null) {
+        if (typeof layer.disabledReason !== "string") {
+          throw new Error("Codex config/read returned an invalid disabled layer");
+        }
+        return [];
+      }
+      if (!isJsonObject(layer.config)) {
+        throw new Error("Codex config/read returned an invalid layer config");
+      }
+      return [layer.config];
+    });
+  } catch (error) {
+    embeddedAgentLog.warn("codex plugin app admission config read failed", { error });
+    return undefined;
+  }
+}
+
+function resolveExplicitAppEnablement(
+  layersHighestPrecedenceFirst: readonly JsonObject[],
+  appId: string,
+): boolean | undefined {
+  // Codex includes disabled layers and orders active config from highest to lowest.
+  // The first app-specific value wins; ignoring `_default` preserves the deny-all
+  // service-account baseline while preventing SessionFlags from undoing an explicit opt-out.
+  for (const layer of layersHighestPrecedenceFirst) {
+    const apps = layer.apps;
+    const app = isJsonObject(apps) ? apps[appId] : undefined;
+    if (!isJsonObject(app) || !Object.hasOwn(app, "enabled")) {
+      continue;
+    }
+    return app.enabled === true;
+  }
+  return undefined;
 }
 
 function shouldForceRefreshForNotReadyPluginApps(

--- a/extensions/codex/src/app-server/protocol.ts
+++ b/extensions/codex/src/app-server/protocol.ts
@@ -1,3 +1,12 @@
+import type {
+  CodexAppInfo,
+  CodexAppsInstalledParams,
+  CodexAppsInstalledResponse,
+  CodexAppsListParams,
+  CodexAppsListResponse,
+  CodexAppsReadParams,
+  CodexAppsReadResponse,
+} from "./app-inventory-protocol.js";
 import type { JsonObject, JsonValue } from "./protocol-json.js";
 import type * as CodexMcpProtocol from "./protocol-mcp.js";
 
@@ -256,6 +265,10 @@ type CodexThreadSetNameParams = JsonObject & {
 };
 
 type CodexThreadArchiveParams = JsonObject & {
+  threadId: string;
+};
+
+type CodexThreadDeleteParams = JsonObject & {
   threadId: string;
 };
 
@@ -627,33 +640,6 @@ type CodexPluginInstallResponse = {
   appsNeedingAuth: CodexAppSummary[];
 };
 
-type CodexAppInfo = {
-  id: string;
-  name: string;
-  description?: string | null;
-  logoUrl?: string | null;
-  logoUrlDark?: string | null;
-  distributionChannel?: string | null;
-  branding?: JsonValue;
-  appMetadata?: JsonValue;
-  labels?: JsonValue;
-  installUrl?: string | null;
-  isAccessible: boolean;
-  isEnabled: boolean;
-  pluginDisplayNames: string[];
-};
-
-type CodexAppsListParams = {
-  cursor?: string | null;
-  limit?: number;
-  forceRefetch?: boolean;
-};
-
-type CodexAppsListResponse = {
-  data: CodexAppInfo[];
-  nextCursor?: string | null;
-};
-
 type CodexSkillsListParams = {
   cwds: string[];
   forceReload?: boolean;
@@ -710,8 +696,7 @@ export type CodexRequestObject = Record<string, unknown>;
 export declare namespace v2 {
   export type AppInfo = CodexAppInfo;
   export type AppSummary = CodexAppSummary;
-  export type AppsListParams = CodexAppsListParams;
-  export type AppsListResponse = CodexAppsListResponse;
+  export type AppsInstalledResponse = CodexAppsInstalledResponse;
   export type HooksListParams = CodexHooksListParams;
   export type HooksListResponse = CodexHooksListResponse;
   export type PluginDetail = CodexPluginDetail;
@@ -728,9 +713,13 @@ export declare namespace v2 {
 }
 
 type CodexAppServerRequestParamsOverride = {
+  "app/installed": CodexAppsInstalledParams;
+  "app/list": CodexAppsListParams;
+  "app/read": CodexAppsReadParams;
   "environment/add": { environmentId: string; execServerUrl: string };
   "thread/fork": CodexThreadForkParams;
   "thread/archive": CodexThreadArchiveParams;
+  "thread/delete": CodexThreadDeleteParams;
   "thread/inject_items": CodexThreadInjectItemsParams;
   "thread/list": CodexThreadListParams;
   "thread/turns/list": CodexThreadTurnsListParams;
@@ -751,7 +740,9 @@ type CodexAppServerRequestResultMap = {
   initialize: CodexInitializeResponse;
   "account/rateLimits/read": JsonValue;
   "account/read": CodexGetAccountResponse;
+  "app/installed": CodexAppsInstalledResponse;
   "app/list": CodexAppsListResponse;
+  "app/read": CodexAppsReadResponse;
   "config/mcpServer/reload": JsonValue;
   "config/read": CodexConfigReadResponse;
   "configRequirements/read": CodexConfigRequirementsReadResponse;
@@ -773,6 +764,7 @@ type CodexAppServerRequestResultMap = {
   "skills/list": CodexSkillsListResponse;
   "thread/compact/start": JsonValue;
   "thread/archive": JsonValue;
+  "thread/delete": JsonValue;
   "thread/fork": CodexThreadForkResponse;
   "thread/inject_items": JsonValue;
   "thread/list": CodexThreadListResponse;

--- a/extensions/codex/src/app-server/run-attempt.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.test.ts
@@ -23,6 +23,7 @@ import { readSessionTranscriptEvents } from "openclaw/plugin-sdk/session-transcr
 import { describe, expect, it, vi } from "vitest";
 import WebSocket from "ws";
 import { defaultCodexAppInventoryCache } from "./app-inventory-cache.js";
+import { codexAppInventoryResponse } from "./app-inventory.test-helpers.js";
 import {
   buildCodexOpenClawPromptContext,
   buildCodexSystemPromptReport,
@@ -59,6 +60,7 @@ import {
   type CodexDynamicToolFunctionSpec,
   type CodexDynamicToolSpec,
   type CodexServerNotification,
+  type v2,
 } from "./protocol.js";
 import { itemNotification, rawItemCompleted, turnCompleted } from "./protocol.test-helpers.js";
 
@@ -466,8 +468,8 @@ async function startThreadWithDisabledNativeSurfaceForTest(
     if (method === "thread/start") {
       return threadStartResult();
     }
-    if (method === "app/list") {
-      throw new Error("app/list should not run when runtime toolsAllow is empty.");
+    if (method === "app/installed" || method === "app/read") {
+      throw new Error("App inventory should not run when runtime toolsAllow is empty.");
     }
     throw new Error(`unexpected method: ${method}`);
   });
@@ -609,26 +611,21 @@ type GoogleCalendarCacheKeyInput = {
   agentDir: string;
 };
 
-function googleCalendarAppListResult(isEnabled: boolean) {
+function googleCalendarAppInfo(isEnabled: boolean): v2.AppInfo {
   return {
-    data: [
-      {
-        id: "google-calendar-app",
-        name: "Google Calendar",
-        description: null,
-        logoUrl: null,
-        logoUrlDark: null,
-        distributionChannel: null,
-        branding: null,
-        appMetadata: null,
-        labels: null,
-        installUrl: null,
-        isAccessible: true,
-        isEnabled,
-        pluginDisplayNames: [],
-      },
-    ],
-    nextCursor: null,
+    id: "google-calendar-app",
+    name: "Google Calendar",
+    description: null,
+    logoUrl: null,
+    logoUrlDark: null,
+    distributionChannel: null,
+    branding: null,
+    appMetadata: null,
+    labels: null,
+    installUrl: null,
+    isAccessible: true,
+    isEnabled,
+    pluginDisplayNames: [],
   };
 }
 
@@ -687,10 +684,12 @@ const GOOGLE_CALENDAR_PLUGIN_READ_RESULT = {
   },
 } as const;
 
-function createGoogleCalendarRequest(appList?: () => unknown) {
+function createGoogleCalendarRequest(
+  appInventory?: (method: "app/installed" | "app/read") => unknown,
+) {
   return vi.fn(async (method: string) => {
-    if (method === "app/list" && appList) {
-      return appList();
+    if ((method === "app/installed" || method === "app/read") && appInventory) {
+      return appInventory(method);
     }
     if (method === "plugin/list") {
       return GOOGLE_CALENDAR_PLUGIN_LIST_RESULT;
@@ -712,7 +711,8 @@ async function primeGoogleCalendarAppInventory(key: string, isEnabled: boolean):
   defaultCodexAppInventoryCache.clear();
   await defaultCodexAppInventoryCache.refreshNow({
     key,
-    request: async () => googleCalendarAppListResult(isEnabled),
+    request: async (method, params) =>
+      codexAppInventoryResponse(method, [googleCalendarAppInfo(isEnabled)], params),
   });
 }
 
@@ -2200,7 +2200,8 @@ describe("runCodexAppServerAttempt", () => {
       open_world_enabled: false,
     });
     expect(startParams?.config?.apps?.["google-calendar-app"]?.enabled).toBeUndefined();
-    expect(request.mock.calls.map(([method]) => method)).not.toContain("app/list");
+    expect(request.mock.calls.map(([method]) => method)).not.toContain("app/installed");
+    expect(request.mock.calls.map(([method]) => method)).not.toContain("app/read");
   });
 
   it("fails closed for Codex app defaults when restricted native tools have no plugin config", async () => {
@@ -2228,7 +2229,8 @@ describe("runCodexAppServerAttempt", () => {
       destructive_enabled: false,
       open_world_enabled: false,
     });
-    expect(request.mock.calls.map(([method]) => method)).not.toContain("app/list");
+    expect(request.mock.calls.map(([method]) => method)).not.toContain("app/installed");
+    expect(request.mock.calls.map(([method]) => method)).not.toContain("app/read");
   });
   it("retires the shared Codex app-server client after one-shot cleanup turns", async () => {
     const { closeAndWait, events, retireSpy, state } = installCleanupTrackingClient();
@@ -4404,8 +4406,8 @@ describe("runCodexAppServerAttempt", () => {
           accountId: "account-work",
           runtimeIdentity: getMockRuntimeIdentity(),
         }),
-      appList: () => {
-        throw new Error("app/list should use the account-keyed cache entry");
+      appInventory: () => {
+        throw new Error("App discovery should use the account-keyed cache entry");
       },
       configure: (params: EmbeddedRunAttemptParams) => {
         params.authProfileId = "openai:work";
@@ -4424,10 +4426,11 @@ describe("runCodexAppServerAttempt", () => {
           },
         };
       },
-      expectsAppList: false,
+      expectsAppInventory: false,
+      expectedAppEnabled: true,
     },
     {
-      name: "sends a thread/start app enable override when app/list cached the app as disabled",
+      name: "does not expose a cached disabled app when runtime callability is unknown",
       cachedEnabled: false,
       cacheKey: ({ appServer, agentDir }: GoogleCalendarCacheKeyInput) =>
         buildCodexPluginAppCacheKey({
@@ -4435,10 +4438,10 @@ describe("runCodexAppServerAttempt", () => {
           agentDir,
           runtimeIdentity: getMockRuntimeIdentity(),
         }),
-      appList: () => {
-        throw new Error("app/list should use the cached inventory entry");
-      },
-      expectsAppList: false,
+      appInventory: (method: "app/installed" | "app/read") =>
+        codexAppInventoryResponse(method, [googleCalendarAppInfo(false)]),
+      expectsAppInventory: true,
+      expectedAppEnabled: undefined,
     },
     {
       name: "keys plugin app inventory by inherited API key fallback credentials",
@@ -4453,39 +4456,55 @@ describe("runCodexAppServerAttempt", () => {
           }),
           runtimeIdentity: getMockRuntimeIdentity(),
         }),
-      appList: () => googleCalendarAppListResult(true),
+      appInventory: (method: "app/installed" | "app/read") =>
+        codexAppInventoryResponse(method, [googleCalendarAppInfo(true)]),
       configure: () => {
         vi.stubEnv("CODEX_API_KEY", "new-codex-env-key");
         vi.stubEnv("OPENAI_API_KEY", "");
       },
-      expectsAppList: true,
+      expectsAppInventory: true,
+      expectedAppEnabled: true,
     },
-  ])("$name", async ({ cachedEnabled, cacheKey, appList, configure, expectsAppList }) => {
-    const { sessionFile, workspaceDir, agentDir } = createRunPaths();
-    const pluginConfig = GOOGLE_CALENDAR_PLUGIN_CONFIG;
-    const appServer = resolveCodexAppServerRuntimeOptions({
-      pluginConfig: readCodexPluginConfig(pluginConfig),
-    });
-    await primeGoogleCalendarAppInventory(cacheKey({ appServer, agentDir }), cachedEnabled);
-    const { requests, waitForMethod, completeTurn } = createStartedThreadHarness(
-      createGoogleCalendarRequest(appList),
-    );
-    const params = createParams(sessionFile, workspaceDir);
-    params.agentDir = agentDir;
-    configure?.(params);
-    const run = runCodexAppServerAttempt(params, { pluginConfig });
-    await completeStartedRun(run, waitForMethod, completeTurn);
-    const threadStart = requests.find((entry) => entry.method === "thread/start");
-    const threadStartParams = threadStart?.params as
-      | { config?: { apps?: Record<string, { enabled?: boolean }> } }
-      | undefined;
-    expect(threadStartParams?.config?.apps?.["google-calendar-app"]?.enabled).toBe(true);
-    if (expectsAppList) {
-      expect(requests.map((entry) => entry.method)).toContain("app/list");
-    } else {
-      expect(requests.map((entry) => entry.method)).not.toContain("app/list");
-    }
-  });
+  ])(
+    "$name",
+    async ({
+      cachedEnabled,
+      cacheKey,
+      appInventory,
+      configure,
+      expectsAppInventory,
+      expectedAppEnabled,
+    }) => {
+      const { sessionFile, workspaceDir, agentDir } = createRunPaths();
+      const pluginConfig = GOOGLE_CALENDAR_PLUGIN_CONFIG;
+      const appServer = resolveCodexAppServerRuntimeOptions({
+        pluginConfig: readCodexPluginConfig(pluginConfig),
+      });
+      await primeGoogleCalendarAppInventory(cacheKey({ appServer, agentDir }), cachedEnabled);
+      const { requests, waitForMethod, completeTurn } = createStartedThreadHarness(
+        createGoogleCalendarRequest(appInventory),
+      );
+      const params = createParams(sessionFile, workspaceDir);
+      params.agentDir = agentDir;
+      configure?.(params);
+      const run = runCodexAppServerAttempt(params, { pluginConfig });
+      await completeStartedRun(run, waitForMethod, completeTurn);
+      const threadStart = requests.find((entry) => entry.method === "thread/start");
+      const threadStartParams = threadStart?.params as
+        | { config?: { apps?: Record<string, { enabled?: boolean }> } }
+        | undefined;
+      expect(threadStartParams?.config?.apps?.["google-calendar-app"]?.enabled).toBe(
+        expectedAppEnabled,
+      );
+      if (expectsAppInventory) {
+        expect(requests.map((entry) => entry.method)).toContain("app/installed");
+        expect(requests.map((entry) => entry.method)).toContain("app/read");
+      } else {
+        expect(requests.map((entry) => entry.method)).not.toContain("app/installed");
+        expect(requests.map((entry) => entry.method)).not.toContain("app/read");
+      }
+    },
+  );
 
   it("times out app-server startup before thread setup can hang forever", async () => {
     setCodexAppServerClientFactoryForTest(() => new Promise<never>(() => {}));

--- a/extensions/codex/src/app-server/sandbox-guard.ts
+++ b/extensions/codex/src/app-server/sandbox-guard.ts
@@ -17,7 +17,9 @@ type DirectMethodPolicy =
 const DIRECT_METHOD_POLICIES = new Map<string, DirectMethodPolicy>([
   ["account/rateLimits/read", "allowed-control-plane"],
   ["account/read", "allowed-control-plane"],
+  ["app/installed", "allowed-control-plane"],
   ["app/list", "allowed-control-plane"],
+  ["app/read", "allowed-control-plane"],
   ["config/mcpServer/reload", "allowed-control-plane"],
   ["config/read", "allowed-control-plane"],
   ["config/value/write", "allowed-control-plane"],

--- a/extensions/codex/src/app-server/thread-lifecycle-io.ts
+++ b/extensions/codex/src/app-server/thread-lifecycle-io.ts
@@ -17,6 +17,7 @@ import {
   type CodexNativeSkillIsolation,
 } from "./native-skill-isolation.js";
 import { buildCodexAppServerConnectionFingerprint } from "./plugin-app-cache-key.js";
+import { attestCodexPluginThreadApps } from "./plugin-thread-attestation.js";
 import {
   buildCodexPluginAppsConfigPatchFromPolicyContext,
   mergeCodexThreadConfigs,
@@ -468,6 +469,58 @@ export async function startFreshCodexThread(
     }
   });
   const response = assertCodexThreadStartResponse(threadStartResponse);
+  // The thread config may be what makes a base-disabled app callable. Attest
+  // after start but before persistence so a failed app can never reach a turn.
+  if (pluginThreadConfig?.provisionalAppIds?.length) {
+    try {
+      await lifecycleTiming.measure("plugin-app-attestation", () =>
+        attestCodexPluginThreadApps({
+          client: params.client,
+          threadId: response.thread.id,
+          appIds: pluginThreadConfig.provisionalAppIds ?? [],
+          signal: params.signal,
+        }),
+      );
+    } catch (error) {
+      // Persistent pre-turn threads have no rollout for thread/archive, so delete
+      // them explicitly. Ephemeral threads cannot be deleted and unload after
+      // releasing their only subscription.
+      let cleanupConfirmed: boolean;
+      if (startParams.ephemeral === true) {
+        cleanupConfirmed = await unsubscribeCodexThreadBestEffort(params.client, {
+          threadId: response.thread.id,
+          timeoutMs: CODEX_APP_SERVER_UNSUBSCRIBE_TIMEOUT_MS,
+        });
+      } else {
+        try {
+          await params.client.request(
+            "thread/delete",
+            { threadId: response.thread.id },
+            { timeoutMs: CODEX_APP_SERVER_UNSUBSCRIBE_TIMEOUT_MS },
+          );
+          cleanupConfirmed = true;
+        } catch (cleanupError) {
+          embeddedAgentLog.debug("codex plugin app attestation thread deletion failed", {
+            threadId: response.thread.id,
+            cleanupError,
+          });
+          await unsubscribeCodexThreadBestEffort(params.client, {
+            threadId: response.thread.id,
+            timeoutMs: CODEX_APP_SERVER_UNSUBSCRIBE_TIMEOUT_MS,
+          });
+          cleanupConfirmed = false;
+        }
+      }
+      if (!cleanupConfirmed) {
+        await (params.abandonClient ?? (() => closeCodexStartupClientBestEffort(params.client)))();
+        throw new CodexAppServerUnsafeSubscriptionError(
+          "Codex plugin app attestation cleanup failed",
+          { cause: error },
+        );
+      }
+      throw error;
+    }
+  }
   const rolloutPath = resolveCodexThreadRolloutPath(response.thread);
   if (ringZeroActive) {
     try {

--- a/extensions/codex/src/app-server/thread-lifecycle-run.ts
+++ b/extensions/codex/src/app-server/thread-lifecycle-run.ts
@@ -159,6 +159,7 @@ export async function startOrResumeThread(
         nativeCodeModeOnlyEnabled: params.nativeCodeModeOnlyEnabled,
         webSearchAllowed: params.webSearchAllowed,
         environmentSelection: params.environmentSelection,
+        provisionalAppIds: pluginThreadConfig?.provisionalAppIds,
         signal: params.signal,
         throwIfAborted,
         lifecycleTiming,

--- a/extensions/codex/src/app-server/thread-lifecycle.test.ts
+++ b/extensions/codex/src/app-server/thread-lifecycle.test.ts
@@ -7,6 +7,7 @@ import { GPT5_BEHAVIOR_CONTRACT as CODEX_GPT5_BEHAVIOR_CONTRACT } from "openclaw
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { CodexAppServerRpcError } from "./client.js";
 import { buildCodexAppServerConnectionFingerprint } from "./plugin-app-cache-key.js";
+import type { CodexPluginThreadConfig } from "./plugin-thread-config.js";
 import { CODEX_OPENCLAW_DIRECT_DYNAMIC_TOOL_NAMESPACE } from "./protocol.js";
 import {
   sessionBindingIdentity,
@@ -283,6 +284,52 @@ function createThreadLifecycleAppServerOptions(): Parameters<
     sandbox: "workspace-write",
     connectionClass: "local-loopback",
     remoteAppsSubstrate: "preconfigured",
+  };
+}
+
+function createProvisionalPluginThreadConfigProvider(appId: string) {
+  const config: CodexPluginThreadConfig = {
+    enabled: true,
+    configPatch: {
+      apps: {
+        _default: {
+          enabled: false,
+          destructive_enabled: false,
+          open_world_enabled: false,
+        },
+        [appId]: {
+          enabled: true,
+          destructive_enabled: false,
+          open_world_enabled: true,
+          default_tools_approval_mode: "auto",
+        },
+      },
+    },
+    provisionalAppIds: [appId],
+    fingerprint: `plugin-config-${appId}`,
+    inputFingerprint: `plugin-input-${appId}`,
+    policyContext: {
+      fingerprint: `plugin-policy-${appId}`,
+      apps: {
+        [appId]: {
+          configKey: "linear",
+          marketplaceName: "openai-curated",
+          pluginName: "linear",
+          allowDestructiveActions: false,
+          destructiveApprovalMode: "deny",
+          mcpServerNames: [],
+        },
+      },
+      pluginAppIds: { linear: [appId] },
+    },
+    diagnostics: [],
+  };
+  return {
+    enabled: true,
+    inputFingerprint: config.inputFingerprint,
+    enabledPluginConfigKeys: ["linear"],
+    recoverablePluginConfigKeys: ["linear"],
+    build: vi.fn(async () => config),
   };
 }
 
@@ -1717,6 +1764,209 @@ describe("Codex plugin binding recovery", () => {
   });
 });
 
+describe("Codex provisional plugin app attestation", () => {
+  beforeEach(async () => {
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-codex-plugin-attestation-"));
+    resetCodexTestBindingStore();
+  });
+
+  afterEach(async () => {
+    await fs.rm(tempDir, { recursive: true, force: true });
+    vi.restoreAllMocks();
+  });
+
+  it("attests the effective thread app before committing the binding", async () => {
+    const workspaceDir = path.join(tempDir, "workspace");
+    const params = createThreadLifecycleParams(path.join(tempDir, "session.jsonl"), workspaceDir);
+    const request = vi.fn(async (method: string, requestParams?: unknown) => {
+      if (method === "thread/start") {
+        return threadStartResult("thread-linear");
+      }
+      if (method === "app/installed") {
+        expect(requestParams).toEqual({
+          threadId: "thread-linear",
+          forceRefresh: true,
+        });
+        return {
+          apps: [
+            {
+              id: "linear-app",
+              runtimeName: "Linear",
+              enabled: true,
+              callable: true,
+            },
+          ],
+        };
+      }
+      throw new Error(`unexpected method: ${method}`);
+    });
+    const mutate = vi.fn(testCodexAppServerBindingStore.mutate);
+    const bindingStore: CodexAppServerBindingStore = {
+      ...testCodexAppServerBindingStore,
+      mutate,
+    };
+
+    await startOrResumeThreadImpl({
+      client: { request } as never,
+      bindingStore,
+      params,
+      cwd: workspaceDir,
+      dynamicTools: [],
+      appServer: createThreadLifecycleAppServerOptions(),
+      pluginThreadConfig: createProvisionalPluginThreadConfigProvider("linear-app"),
+    });
+
+    expect(request.mock.calls.map(([method]) => method)).toEqual(["thread/start", "app/installed"]);
+    expect(request.mock.invocationCallOrder[1]).toBeLessThan(
+      mutate.mock.invocationCallOrder[0] ?? Number.POSITIVE_INFINITY,
+    );
+    await expect(
+      testCodexAppServerBindingStore.read(
+        sessionBindingIdentity({
+          sessionId: params.sessionId,
+          sessionKey: params.sessionKey,
+          agentId: params.agentId,
+          config: params.config,
+        }),
+      ),
+    ).resolves.toMatchObject({
+      threadId: "thread-linear",
+      pluginAppsFingerprint: "plugin-config-linear-app",
+    });
+  });
+
+  it("deletes the persistent nonmaterialized thread when attestation fails", async () => {
+    const workspaceDir = path.join(tempDir, "workspace");
+    const params = createThreadLifecycleParams(path.join(tempDir, "session.jsonl"), workspaceDir);
+    const abandonClient = vi.fn(async () => undefined);
+    const request = vi.fn(
+      async (method: string, _requestParams?: unknown, _requestOptions?: unknown) => {
+        if (method === "thread/start") {
+          return threadStartResult("thread-linear-missing");
+        }
+        if (method === "app/installed") {
+          return { apps: [] };
+        }
+        if (method === "thread/delete") {
+          return {};
+        }
+        throw new Error(`unexpected method: ${method}`);
+      },
+    );
+
+    await expect(
+      startOrResumeThread({
+        client: { request } as never,
+        abandonClient,
+        params,
+        cwd: workspaceDir,
+        dynamicTools: [],
+        appServer: createThreadLifecycleAppServerOptions(),
+        pluginThreadConfig: createProvisionalPluginThreadConfigProvider("linear-app"),
+      }),
+    ).rejects.toThrow("linear-app:missing");
+
+    expect(request.mock.calls.map(([method]) => method)).toEqual([
+      "thread/start",
+      "app/installed",
+      "thread/delete",
+    ]);
+    expect(request.mock.calls[2]?.[1]).toEqual({ threadId: "thread-linear-missing" });
+    expect(request.mock.calls[2]?.[2]).toEqual({ timeoutMs: 5_000 });
+    expect(abandonClient).not.toHaveBeenCalled();
+    await expect(
+      testCodexAppServerBindingStore.read(
+        sessionBindingIdentity({
+          sessionId: params.sessionId,
+          sessionKey: params.sessionKey,
+          agentId: params.agentId,
+          config: params.config,
+        }),
+      ),
+    ).resolves.toBeUndefined();
+  });
+
+  it("abandons the client when a persistent attestation failure cannot delete the thread", async () => {
+    const workspaceDir = path.join(tempDir, "workspace");
+    const params = createThreadLifecycleParams(path.join(tempDir, "session.jsonl"), workspaceDir);
+    const abandonClient = vi.fn(async () => undefined);
+    const request = vi.fn(async (method: string) => {
+      if (method === "thread/start") {
+        return threadStartResult("thread-linear-unsafe");
+      }
+      if (method === "app/installed") {
+        return { apps: [] };
+      }
+      if (method === "thread/delete") {
+        throw new Error("delete unavailable");
+      }
+      if (method === "thread/unsubscribe") {
+        return {};
+      }
+      throw new Error(`unexpected method: ${method}`);
+    });
+
+    await expect(
+      startOrResumeThread({
+        client: { request } as never,
+        abandonClient,
+        params,
+        cwd: workspaceDir,
+        dynamicTools: [],
+        appServer: createThreadLifecycleAppServerOptions(),
+        pluginThreadConfig: createProvisionalPluginThreadConfigProvider("linear-app"),
+      }),
+    ).rejects.toThrow("Codex plugin app attestation cleanup failed");
+
+    expect(request.mock.calls.map(([method]) => method)).toEqual([
+      "thread/start",
+      "app/installed",
+      "thread/delete",
+      "thread/unsubscribe",
+    ]);
+    expect(abandonClient).toHaveBeenCalledOnce();
+  });
+
+  it("unsubscribes an ephemeral thread when attestation fails", async () => {
+    const workspaceDir = path.join(tempDir, "workspace");
+    const params = createThreadLifecycleParams(path.join(tempDir, "session.jsonl"), workspaceDir);
+    params.sessionKey = "agent:main:internal-session-effects:incognito-plugin-attestation";
+    const abandonClient = vi.fn(async () => undefined);
+    const request = vi.fn(async (method: string, requestParams?: unknown) => {
+      if (method === "thread/start") {
+        expect(requestParams).toEqual(expect.objectContaining({ ephemeral: true }));
+        return threadStartResult("thread-linear-ephemeral");
+      }
+      if (method === "app/installed") {
+        return { apps: [] };
+      }
+      if (method === "thread/unsubscribe") {
+        return {};
+      }
+      throw new Error(`unexpected method: ${method}`);
+    });
+
+    await expect(
+      startOrResumeThread({
+        client: { request } as never,
+        abandonClient,
+        params,
+        cwd: workspaceDir,
+        dynamicTools: [],
+        appServer: createThreadLifecycleAppServerOptions(),
+        pluginThreadConfig: createProvisionalPluginThreadConfigProvider("linear-app"),
+      }),
+    ).rejects.toThrow("linear-app:missing");
+
+    expect(request.mock.calls.map(([method]) => method)).toEqual([
+      "thread/start",
+      "app/installed",
+      "thread/unsubscribe",
+    ]);
+    expect(abandonClient).not.toHaveBeenCalled();
+  });
+});
+
 describe("Codex app-server adopted thread lifecycle", () => {
   beforeEach(async () => {
     tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-codex-thread-adoption-"));
@@ -1998,6 +2248,141 @@ describe("Codex app-server supervised branch lifecycle", () => {
     });
     await expect(testCodexAppServerBindingStore.read(identity)).resolves.toMatchObject({
       appServerRuntimeFingerprint: buildCodexAppServerConnectionFingerprint(commonParams.appServer),
+    });
+  });
+
+  it("cleans tracked supervision branches when provisional app attestation fails", async () => {
+    const sourceThreadId = "thread-source";
+    const probeThreadId = "thread-probe";
+    const finalThreadId = "thread-final";
+    const workspaceDir = path.join(tempDir, "workspace");
+    const attempt = createThreadLifecycleParams(path.join(tempDir, "session.jsonl"), workspaceDir);
+    const identity = await seedPendingSupervisionBinding({
+      attempt,
+      cwd: workspaceDir,
+      pending: { sourceThreadId },
+    });
+    const abandonClient = vi.fn(async () => undefined);
+    const request = vi.fn(async (method: string, requestParams: unknown) => {
+      if (method === "thread/read") {
+        return { thread: sourceThread({ threadId: sourceThreadId }) };
+      }
+      if (method === "thread/fork") {
+        return nativeThreadResult(probeThreadId, "native-effective", "native-provider");
+      }
+      if (method === "thread/start") {
+        return nativeThreadResult(finalThreadId, "native-effective", "native-provider");
+      }
+      if (method === "app/installed") {
+        expect(requestParams).toEqual({
+          threadId: finalThreadId,
+          forceRefresh: true,
+        });
+        return { apps: [] };
+      }
+      if (method === "thread/delete") {
+        return {};
+      }
+      if (method === "thread/archive") {
+        return {};
+      }
+      throw new Error(`unexpected method: ${method}`);
+    });
+
+    await expect(
+      startOrResumeThread({
+        client: { request } as never,
+        abandonClient,
+        params: attempt,
+        cwd: workspaceDir,
+        dynamicTools: [],
+        appServer: createThreadLifecycleAppServerOptions(),
+        pluginThreadConfig: createProvisionalPluginThreadConfigProvider("linear-app"),
+      }),
+    ).rejects.toThrow("linear-app:missing");
+
+    expect(request.mock.calls.map(([method]) => method)).toEqual([
+      "thread/read",
+      "thread/fork",
+      "thread/start",
+      "app/installed",
+      "thread/delete",
+      "thread/archive",
+    ]);
+    expect(request.mock.calls[4]?.[1]).toEqual({ threadId: finalThreadId });
+    expect(request.mock.calls[5]?.[1]).toEqual({ threadId: probeThreadId });
+    expect(abandonClient).not.toHaveBeenCalled();
+    await expect(testCodexAppServerBindingStore.read(identity)).resolves.toMatchObject({
+      pendingSupervisionBranch: {
+        sourceThreadId,
+      },
+    });
+    expect(
+      (await testCodexAppServerBindingStore.read(identity))?.pendingSupervisionBranch
+        ?.cleanupThreadIds ?? [],
+    ).toEqual([]);
+  });
+
+  it("abandons a supervised client when attestation cannot delete the canonical branch", async () => {
+    const sourceThreadId = "thread-source";
+    const probeThreadId = "thread-probe";
+    const finalThreadId = "thread-final";
+    const workspaceDir = path.join(tempDir, "workspace");
+    const attempt = createThreadLifecycleParams(path.join(tempDir, "session.jsonl"), workspaceDir);
+    const identity = await seedPendingSupervisionBinding({
+      attempt,
+      cwd: workspaceDir,
+      pending: { sourceThreadId },
+    });
+    const abandonClient = vi.fn(async () => undefined);
+    const request = vi.fn(async (method: string) => {
+      if (method === "thread/read") {
+        return { thread: sourceThread({ threadId: sourceThreadId }) };
+      }
+      if (method === "thread/fork") {
+        return nativeThreadResult(probeThreadId, "native-effective", "native-provider");
+      }
+      if (method === "thread/start") {
+        return nativeThreadResult(finalThreadId, "native-effective", "native-provider");
+      }
+      if (method === "app/installed") {
+        return { apps: [] };
+      }
+      if (method === "thread/delete") {
+        throw new Error("delete unavailable");
+      }
+      if (method === "thread/unsubscribe") {
+        return {};
+      }
+      throw new Error(`unexpected method: ${method}`);
+    });
+
+    await expect(
+      startOrResumeThread({
+        client: { request } as never,
+        abandonClient,
+        params: attempt,
+        cwd: workspaceDir,
+        dynamicTools: [],
+        appServer: createThreadLifecycleAppServerOptions(),
+        pluginThreadConfig: createProvisionalPluginThreadConfigProvider("linear-app"),
+      }),
+    ).rejects.toThrow("Codex supervised plugin app attestation cleanup failed");
+
+    expect(request.mock.calls.map(([method]) => method)).toEqual([
+      "thread/read",
+      "thread/fork",
+      "thread/start",
+      "app/installed",
+      "thread/delete",
+      "thread/unsubscribe",
+    ]);
+    expect(abandonClient).toHaveBeenCalledOnce();
+    await expect(testCodexAppServerBindingStore.read(identity)).resolves.toMatchObject({
+      pendingSupervisionBranch: {
+        sourceThreadId,
+        cleanupThreadIds: [probeThreadId, finalThreadId],
+      },
     });
   });
 

--- a/extensions/codex/src/app-server/thread-lifecycle.test.ts
+++ b/extensions/codex/src/app-server/thread-lifecycle.test.ts
@@ -1800,7 +1800,10 @@ describe("Codex provisional plugin app attestation", () => {
       }
       throw new Error(`unexpected method: ${method}`);
     });
-    const mutate = vi.fn(testCodexAppServerBindingStore.mutate);
+    const mutate = vi.fn(
+      async (...args: Parameters<typeof testCodexAppServerBindingStore.mutate>) =>
+        await testCodexAppServerBindingStore.mutate(...args),
+    );
     const bindingStore: CodexAppServerBindingStore = {
       ...testCodexAppServerBindingStore,
       mutate,

--- a/extensions/codex/src/app-server/thread-supervision.ts
+++ b/extensions/codex/src/app-server/thread-supervision.ts
@@ -13,6 +13,7 @@ import {
 import { CodexAppServerRpcError, type CodexAppServerClient } from "./client.js";
 import type { CodexAppServerRuntimeOptions } from "./config.js";
 import { buildCodexAppServerConnectionFingerprint } from "./plugin-app-cache-key.js";
+import { attestCodexPluginThreadApps } from "./plugin-thread-attestation.js";
 import {
   assertCodexThreadForkResponse,
   assertCodexThreadStartResponse,
@@ -67,6 +68,7 @@ type PendingSupervisionMaterializationParams = {
   webSearchAllowed?: boolean;
   environmentSelection?: CodexTurnEnvironmentParams[];
   signal?: AbortSignal;
+  provisionalAppIds?: readonly string[];
   throwIfAborted: () => void;
   lifecycleTiming: Pick<CodexThreadLifecycleTimingTracker, "measure" | "mark" | "logSummary">;
   normalizeBindingModelProvider: (
@@ -203,6 +205,38 @@ export async function materializePendingSupervisionBranch(
       modelProvider: nativeModelProvider,
       operation: "thread/start response",
     });
+    if (params.provisionalAppIds?.length) {
+      try {
+        await params.lifecycleTiming.measure("plugin-app-attestation", () =>
+          attestCodexPluginThreadApps({
+            client: params.client,
+            threadId: finalThreadId,
+            appIds: params.provisionalAppIds ?? [],
+            signal: params.signal,
+          }),
+        );
+      } catch (error) {
+        // The canonical branch has not reached a turn, so persistent threads
+        // require delete rather than archive; the forked probe has a rollout.
+        const finalCleanupConfirmed = await cleanUnmaterializedSupervisionThread(
+          params.client,
+          finalThreadId,
+          startParams.ephemeral === true,
+        );
+        if (
+          !finalCleanupConfirmed ||
+          !(await archiveSupervisionArtifact(params.client, probeThreadId))
+        ) {
+          provisionalCleanupSafe = false;
+          throw new CodexAppServerUnsafeSubscriptionError(
+            "Codex supervised plugin app attestation cleanup failed",
+            { cause: error },
+          );
+        }
+        pending = await trackPendingSupervisionArtifacts(params, pending, []);
+        throw error;
+      }
+    }
     if (history.responseItems.length > 0) {
       await params.lifecycleTiming.measure("supervision-history-inject", () =>
         params.client.request(
@@ -637,6 +671,37 @@ async function archiveSupervisionArtifact(
       timeoutMs: CODEX_APP_SERVER_UNSUBSCRIBE_TIMEOUT_MS,
     });
     embeddedAgentLog.warn("failed to archive temporary Codex supervision thread", {
+      threadId,
+      error,
+    });
+    return false;
+  }
+}
+
+async function cleanUnmaterializedSupervisionThread(
+  client: CodexAppServerClient,
+  threadId: string,
+  ephemeral: boolean,
+): Promise<boolean> {
+  if (ephemeral) {
+    return unsubscribeCodexThreadBestEffort(client, {
+      threadId,
+      timeoutMs: CODEX_APP_SERVER_UNSUBSCRIBE_TIMEOUT_MS,
+    });
+  }
+  try {
+    await client.request(
+      "thread/delete",
+      { threadId },
+      { timeoutMs: CODEX_APP_SERVER_UNSUBSCRIBE_TIMEOUT_MS },
+    );
+    return true;
+  } catch (error) {
+    await unsubscribeCodexThreadBestEffort(client, {
+      threadId,
+      timeoutMs: CODEX_APP_SERVER_UNSUBSCRIBE_TIMEOUT_MS,
+    });
+    embeddedAgentLog.warn("failed to delete unmaterialized Codex supervision thread", {
       threadId,
       error,
     });

--- a/extensions/codex/src/migration/provider.test.ts
+++ b/extensions/codex/src/migration/provider.test.ts
@@ -10,6 +10,7 @@ import type { MigrationProviderContext } from "openclaw/plugin-sdk/plugin-entry"
 import { upsertAuthProfile } from "openclaw/plugin-sdk/provider-auth";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { defaultCodexAppInventoryCache } from "../app-server/app-inventory-cache.js";
+import { codexAppInventoryResponse } from "../app-server/app-inventory.test-helpers.js";
 import { CODEX_PLUGINS_MARKETPLACE_NAME } from "../app-server/config.js";
 import { buildCodexPluginAppCacheKey } from "../app-server/plugin-app-cache-key.js";
 import type { CodexGetAccountResponse, v2 } from "../app-server/protocol.js";
@@ -995,7 +996,16 @@ describe("buildCodexMigrationProvider", () => {
     expect(configState.agents?.defaults?.model).toBeUndefined();
   });
 
-  it("skips source-installed plugins whose owned apps are inaccessible", async () => {
+  it.each([
+    {
+      name: "skips source-installed plugins whose owned apps are inaccessible",
+      isEnabled: true,
+    },
+    {
+      name: "skips source-installed plugins whose disabled owned apps are non-callable",
+      isEnabled: false,
+    },
+  ])("$name", async ({ isEnabled }) => {
     const fixture = await createCodexFixture();
     appServerRequest.mockImplementation(
       async ({ method, requestParams }: { method: string; requestParams?: unknown }) => {
@@ -1010,13 +1020,15 @@ describe("buildCodexMigrationProvider", () => {
         if (method === "account/read") {
           return chatGptAccount();
         }
-        if (method === "app/list") {
-          expectRecordFields(requestParams, { forceRefetch: true });
-          return appsList([
+        if (method === "app/installed" || method === "app/read") {
+          if (method === "app/installed") {
+            expectRecordFields(requestParams, { forceRefresh: true });
+          }
+          return codexAppInventoryResponse(method, [
             appInfo("asdk_app_readwise", {
               name: "Readwise",
               isAccessible: false,
-              isEnabled: true,
+              isEnabled,
             }),
           ]);
         }
@@ -1053,16 +1065,16 @@ describe("buildCodexMigrationProvider", () => {
         id: "asdk_app_readwise",
         name: "Readwise",
         isAccessible: false,
-        isEnabled: true,
+        isEnabled,
         needsAuth: false,
       },
     ]);
-    expect(appServerRequest.mock.calls.filter(([arg]) => arg.method === "app/list")).toHaveLength(
-      1,
-    );
+    expect(
+      appServerRequest.mock.calls.filter(([arg]) => arg.method === "app/installed"),
+    ).toHaveLength(1);
   });
 
-  it("plans app-backed plugins without source app/list by default", async () => {
+  it("plans app-backed plugins without source app inventory by default", async () => {
     const fixture = await createCodexFixture();
     appServerRequest.mockImplementation(async ({ method }: { method: string }) => {
       if (method === "plugin/list") {
@@ -1097,9 +1109,9 @@ describe("buildCodexMigrationProvider", () => {
       status: "planned",
     });
     expect(plan.warnings).toEqual([]);
-    expect(appServerRequest.mock.calls.filter(([arg]) => arg.method === "app/list")).toHaveLength(
-      0,
-    );
+    expect(
+      appServerRequest.mock.calls.filter(([arg]) => arg.method === "app/installed"),
+    ).toHaveLength(0);
   });
 
   it("warns and skips app-backed plugins when source Codex account is not ChatGPT subscription auth", async () => {
@@ -1153,9 +1165,9 @@ describe("buildCodexMigrationProvider", () => {
     expect(plan.warnings).toEqual([
       "Codex app-backed plugin migration requires the Codex app-server source account to be logged in with a ChatGPT subscription account. Log in to the Codex app with subscription auth; OpenClaw auth or API-key auth does not satisfy Codex app connector access.",
     ]);
-    expect(appServerRequest.mock.calls.filter(([arg]) => arg.method === "app/list")).toHaveLength(
-      0,
-    );
+    expect(
+      appServerRequest.mock.calls.filter(([arg]) => arg.method === "app/installed"),
+    ).toHaveLength(0);
   });
 
   it("warns and skips app-backed plugins when source Codex account is missing", async () => {
@@ -1191,9 +1203,9 @@ describe("buildCodexMigrationProvider", () => {
       reason: "codex_subscription_required",
       status: "skipped",
     });
-    expect(appServerRequest.mock.calls.filter(([arg]) => arg.method === "app/list")).toHaveLength(
-      0,
-    );
+    expect(
+      appServerRequest.mock.calls.filter(([arg]) => arg.method === "app/installed"),
+    ).toHaveLength(0);
   });
 
   it("falls through to app inventory when source account read fails and app verification is requested", async () => {
@@ -1208,8 +1220,8 @@ describe("buildCodexMigrationProvider", () => {
       if (method === "account/read") {
         throw new Error("account unavailable");
       }
-      if (method === "app/list") {
-        return appsList([appInfo("app-gmail")]);
+      if (method === "app/installed" || method === "app/read") {
+        return codexAppInventoryResponse(method, [appInfo("app-gmail")]);
       }
       throw new Error(`unexpected request ${method}`);
     });
@@ -1229,9 +1241,9 @@ describe("buildCodexMigrationProvider", () => {
       action: "install",
       status: "planned",
     });
-    expect(appServerRequest.mock.calls.filter(([arg]) => arg.method === "app/list")).toHaveLength(
-      1,
-    );
+    expect(
+      appServerRequest.mock.calls.filter(([arg]) => arg.method === "app/installed"),
+    ).toHaveLength(1);
   });
 
   it("skips app-backed plugins by default when source account read fails", async () => {
@@ -1268,9 +1280,9 @@ describe("buildCodexMigrationProvider", () => {
       status: "skipped",
     });
     expectRecordFields(manualItem.details, { error: "account unavailable" });
-    expect(appServerRequest.mock.calls.filter(([arg]) => arg.method === "app/list")).toHaveLength(
-      0,
-    );
+    expect(
+      appServerRequest.mock.calls.filter(([arg]) => arg.method === "app/installed"),
+    ).toHaveLength(0);
   });
 
   it("reads source plugin readiness with native source auth instead of target agent auth", async () => {
@@ -1287,8 +1299,8 @@ describe("buildCodexMigrationProvider", () => {
       if (method === "account/read") {
         return chatGptAccount();
       }
-      if (method === "app/list") {
-        return appsList([appInfo("app-google-calendar")]);
+      if (method === "app/installed" || method === "app/read") {
+        return codexAppInventoryResponse(method, [appInfo("app-google-calendar")]);
       }
       throw new Error(`unexpected request ${method}`);
     });
@@ -1315,7 +1327,7 @@ describe("buildCodexMigrationProvider", () => {
       }),
     );
 
-    expect(appServerRequest).toHaveBeenCalledTimes(4);
+    expect(appServerRequest).toHaveBeenCalledTimes(5);
     for (const [arg] of appServerRequest.mock.calls) {
       expect(arg.authProfileId).toBeNull();
       expect(arg.isolated).toBe(true);
@@ -1343,8 +1355,8 @@ describe("buildCodexMigrationProvider", () => {
       if (method === "account/read") {
         return chatGptAccount();
       }
-      if (method === "app/list") {
-        return appsList([
+      if (method === "app/installed" || method === "app/read") {
+        return codexAppInventoryResponse(method, [
           appInfo("asdk_app_readwise", {
             name: "Readwise",
             isAccessible: false,
@@ -1395,7 +1407,12 @@ describe("buildCodexMigrationProvider", () => {
     const fixture = await createCodexFixture();
     await defaultCodexAppInventoryCache.refreshNow({
       key: sourceAppCacheKey(fixture),
-      request: async () => appsList([appInfo("app-google-calendar", { isAccessible: false })]),
+      request: async (method, params) =>
+        codexAppInventoryResponse(
+          method,
+          [appInfo("app-google-calendar", { isAccessible: false })],
+          params,
+        ),
     });
     appServerRequest.mockImplementation(
       async ({ method, requestParams }: { method: string; requestParams?: unknown }) => {
@@ -1412,9 +1429,14 @@ describe("buildCodexMigrationProvider", () => {
         if (method === "account/read") {
           return chatGptAccount();
         }
-        if (method === "app/list") {
-          expectRecordFields(requestParams, { forceRefetch: true });
-          return appsList([appInfo("app-google-calendar"), appInfo("app-gmail")]);
+        if (method === "app/installed" || method === "app/read") {
+          if (method === "app/installed") {
+            expectRecordFields(requestParams, { forceRefresh: true });
+          }
+          return codexAppInventoryResponse(method, [
+            appInfo("app-google-calendar"),
+            appInfo("app-gmail"),
+          ]);
         }
         throw new Error(`unexpected request ${method}`);
       },
@@ -1432,9 +1454,9 @@ describe("buildCodexMigrationProvider", () => {
 
     expectRecordFields(findItem(plan.items, "plugin:google-calendar"), { status: "planned" });
     expectRecordFields(findItem(plan.items, "plugin:gmail"), { status: "planned" });
-    expect(appServerRequest.mock.calls.filter(([arg]) => arg.method === "app/list")).toHaveLength(
-      1,
-    );
+    expect(
+      appServerRequest.mock.calls.filter(([arg]) => arg.method === "app/installed"),
+    ).toHaveLength(1);
   });
 
   it("fails closed for disabled plugins and plugin/read failures", async () => {
@@ -1474,9 +1496,9 @@ describe("buildCodexMigrationProvider", () => {
       status: "skipped",
     });
     expect(plan.items.some((item) => item.id === "config:codex-plugins")).toBe(false);
-    expect(appServerRequest.mock.calls.filter(([arg]) => arg.method === "app/list")).toHaveLength(
-      0,
-    );
+    expect(
+      appServerRequest.mock.calls.filter(([arg]) => arg.method === "app/installed"),
+    ).toHaveLength(0);
   });
 
   it("fails closed when app inventory refresh fails for app-backed plugins", async () => {
@@ -1491,7 +1513,7 @@ describe("buildCodexMigrationProvider", () => {
       if (method === "account/read") {
         return chatGptAccount();
       }
-      if (method === "app/list") {
+      if (method === "app/installed") {
         throw new Error("app inventory unavailable");
       }
       throw new Error(`unexpected request ${method}`);
@@ -1529,8 +1551,8 @@ describe("buildCodexMigrationProvider", () => {
       if (method === "account/read") {
         return chatGptAccount();
       }
-      if (method === "app/list") {
-        return appsList([appInfo("ready-app"), appInfo("auth-app")]);
+      if (method === "app/installed" || method === "app/read") {
+        return codexAppInventoryResponse(method, [appInfo("ready-app"), appInfo("auth-app")]);
       }
       throw new Error(`unexpected request ${method}`);
     });
@@ -1634,8 +1656,8 @@ describe("buildCodexMigrationProvider", () => {
         if (method === "config/mcpServer/reload") {
           return {};
         }
-        if (method === "app/list") {
-          return appsList([]);
+        if (method === "app/installed" || method === "app/read") {
+          return codexAppInventoryResponse(method, []);
         }
         throw new Error(`unexpected request ${method}`);
       },
@@ -1726,8 +1748,8 @@ describe("buildCodexMigrationProvider", () => {
         if (method === "config/mcpServer/reload") {
           return {};
         }
-        if (method === "app/list") {
-          return appsList([]);
+        if (method === "app/installed" || method === "app/read") {
+          return codexAppInventoryResponse(method, []);
         }
         throw new Error(`unexpected request ${method}`);
       },
@@ -1791,8 +1813,8 @@ describe("buildCodexMigrationProvider", () => {
         if (method === "config/mcpServer/reload") {
           return {};
         }
-        if (method === "app/list") {
-          return appsList([]);
+        if (method === "app/installed" || method === "app/read") {
+          return codexAppInventoryResponse(method, []);
         }
         throw new Error(`unexpected request ${method}`);
       },
@@ -1917,8 +1939,8 @@ describe("buildCodexMigrationProvider", () => {
       if (method === "config/mcpServer/reload") {
         return {};
       }
-      if (method === "app/list") {
-        return appsList([]);
+      if (method === "app/installed" || method === "app/read") {
+        return codexAppInventoryResponse(method, []);
       }
       throw new Error(`unexpected request ${method}`);
     });
@@ -1974,8 +1996,8 @@ describe("buildCodexMigrationProvider", () => {
       if (method === "config/mcpServer/reload") {
         return {};
       }
-      if (method === "app/list") {
-        return appsList([]);
+      if (method === "app/installed" || method === "app/read") {
+        return codexAppInventoryResponse(method, []);
       }
       throw new Error(`unexpected request ${method}`);
     });
@@ -2032,7 +2054,8 @@ describe("buildCodexMigrationProvider", () => {
     const sourceKey = sourceAppCacheKey(fixture);
     await defaultCodexAppInventoryCache.refreshNow({
       key: sourceKey,
-      request: async () => appsList([appInfo("source-only-app")]),
+      request: async (method, params) =>
+        codexAppInventoryResponse(method, [appInfo("source-only-app")], params),
     });
     const configState: MigrationProviderContext["config"] = {
       plugins: {
@@ -2077,8 +2100,8 @@ describe("buildCodexMigrationProvider", () => {
       if (method === "config/mcpServer/reload") {
         return {};
       }
-      if (method === "app/list") {
-        return appsList([]);
+      if (method === "app/installed" || method === "app/read") {
+        return codexAppInventoryResponse(method, []);
       }
       throw new Error(`unexpected request ${method}`);
     });
@@ -2161,8 +2184,8 @@ describe("buildCodexMigrationProvider", () => {
       if (method === "config/mcpServer/reload") {
         return {};
       }
-      if (method === "app/list") {
-        return appsList([]);
+      if (method === "app/installed" || method === "app/read") {
+        return codexAppInventoryResponse(method, []);
       }
       throw new Error(`unexpected request ${method}`);
     });
@@ -2238,8 +2261,8 @@ describe("buildCodexMigrationProvider", () => {
       if (method === "config/mcpServer/reload") {
         return {};
       }
-      if (method === "app/list") {
-        return appsList([]);
+      if (method === "app/installed" || method === "app/read") {
+        return codexAppInventoryResponse(method, []);
       }
       throw new Error(`unexpected request ${method}`);
     });
@@ -2309,8 +2332,8 @@ describe("buildCodexMigrationProvider", () => {
       if (method === "config/mcpServer/reload") {
         return {};
       }
-      if (method === "app/list") {
-        return appsList([]);
+      if (method === "app/installed" || method === "app/read") {
+        return codexAppInventoryResponse(method, []);
       }
       throw new Error(`unexpected request ${method}`);
     });
@@ -2376,8 +2399,8 @@ describe("buildCodexMigrationProvider", () => {
       if (method === "config/mcpServer/reload") {
         return {};
       }
-      if (method === "app/list") {
-        return appsList([]);
+      if (method === "app/installed" || method === "app/read") {
+        return codexAppInventoryResponse(method, []);
       }
       throw new Error(`unexpected request ${method}`);
     });
@@ -2598,10 +2621,6 @@ function appInfo(id: string, overrides: Partial<v2.AppInfo> = {}): v2.AppInfo {
     pluginDisplayNames: [],
     ...overrides,
   };
-}
-
-function appsList(apps: v2.AppInfo[]): v2.AppsListResponse {
-  return { data: apps, nextCursor: null };
 }
 
 function chatGptAccount(): CodexGetAccountResponse {

--- a/extensions/codex/src/migration/source.ts
+++ b/extensions/codex/src/migration/source.ts
@@ -11,7 +11,11 @@ import {
   pluginReadParams,
   type CodexPluginMarketplaceRef,
 } from "../app-server/plugin-inventory.js";
-import type { CodexGetAccountResponse, v2 } from "../app-server/protocol.js";
+import type {
+  CodexAppServerRequestResult,
+  CodexGetAccountResponse,
+  v2,
+} from "../app-server/protocol.js";
 import { requestCodexAppServerJson } from "../app-server/request.js";
 import { exists, isDirectory, resolveHomePath, resolveUserHomeDir } from "./helpers.js";
 import {
@@ -359,7 +363,7 @@ async function refreshSourceAppInventory(
     appServer: { start: options.startOptions },
   });
   const request: CodexAppInventoryRequest = async (method, requestParams) =>
-    await requestSourceCodexAppServerJson<v2.AppsListResponse>(options, {
+    await requestSourceCodexAppServerJson<CodexAppServerRequestResult<typeof method>>(options, {
       method,
       requestParams,
     });


### PR DESCRIPTION
Related: #115075

## What Problem This Solves

Fixes an issue where service-account-backed Codex sessions could discover an installed plugin app but could not call it when the app was disabled in the base runtime and enabled only by the gateway's configured plugin policy.

## Why This Change Was Made

The Codex plugin now reads committed runtime inventory through `app/installed`, enriches it with `app/read`, provisionally enables policy-selected base-disabled apps in thread-scoped config, and attests that those apps are callable before any turn or durable thread ownership. Explicit app-specific Codex config denials remain authoritative.

## User Impact

Operators can use configured Codex plugin apps such as Linear from service-account gateways without globally enabling every installed app. Missing or non-callable apps fail closed before a model turn.

## Evidence

- Compared against Codex `rust-v0.145.0` app-server protocol and runtime implementation.
- `git diff --check`: passed.
- `node --check` on the changed thread-config and lifecycle TypeScript files: passed.
- Mandatory autoreview: clean after repairing supervised pre-turn cleanup.
- Live pre-fix proof on the `dxclaw` service-account runtime:
  - `app/installed` returned the Linear app in the base inventory.
  - `app/read` returned Linear metadata and tools including `list_issues`.
  - The gateway turn reported `LINEAR_READ_UNAVAILABLE` because the app was not callable in the thread.
- Focused Vitest was not run locally because this linked worktree has no compatible dependency tree; exact-head remote build/CI is the dependency-hydrated proof path.

## Real behavior proof

- Behavior or issue addressed: policy-selected plugin apps were not enabled in service-account-backed Codex threads when the base app inventory reported them disabled.
- Real environment tested: tenant `dxclaw` on a0s, connected to DevBox `clawdx` on `devbox-2`, remote Codex 0.145.0 app-server, and the real Linear connector.
- Exact steps or command run after this patch: built and deployed OpenClaw commit `6e9771eb286b55c1aacefa5f64ac36d88c5a2bb2` with `applied deploy -s claw-gateway -e staging --wait --local-deploy --filter metadata.name=openclaw-gateway-dxclaw`, then sent a read-only Slack request to `dxclaw` to call Linear `list_issues`.
- Evidence after fix: deployed gateway image digest `sha256:afe2c5bf419b9d04370546042574015d99ad839925a4a1c560f83f78cdcc3282`; Slack parent `1785280801.503179`; `dxclaw` reply `1785282122.192349`; gateway logs recorded the matching inbound app mention and successful Slack reply delivery.
- Observed result after fix: `{"status":"LINEAR_READ_OK","connector":"linear","tool":"list_issues","firstIdentifier":"IDP-4021"}`.
- What was not tested: destructive Linear writes and approval UI were omitted because the unchanged deployed policy uses `auto`, not `ask`; Google Calendar was omitted because it is not enabled; focused local Vitest was not run because the linked worktree has no dependency tree and local dependency reconciliation is prohibited for this workflow.
