### PR TITLE
chore: notify Synthia when an issue is opened so it can attempt a reproduction

### DIFF
--- a/.github/workflows/synthia-issue-ping.yml
+++ b/.github/workflows/synthia-issue-ping.yml
@@ -1,0 +1,51 @@
+# Tell Synthia an issue was filed, so it can attempt a reproduction against
+# current main. Nothing is written back to this repository.
+#
+# What leaves the runner: the repository slug and the issue number. Nothing
+# else — not the title, not the body, not the labels, not the reporter. Those
+# are read afterwards from the public issues API, the same way they are read
+# today by a scheduled poll. This workflow replaces that poll with a push.
+#
+# What this needs from you: nothing. No secret, no App, no token, no
+# collaborator access, no third-party action to review or pin. `permissions: {}`
+# means the job's GITHUB_TOKEN has no scopes at all, and the workflow never
+# uses it.
+#
+# What happens if Synthia is down: nothing. The step cannot fail the job, and a
+# ping that never arrives only means the reproduction attempt starts from the
+# next scheduled read instead.
+
+name: Synthia issue ping
+
+on:
+  issues:
+    types: [opened]
+
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.issue.number }}
+  cancel-in-progress: false
+
+jobs:
+  ping:
+    name: Notify Synthia
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    steps:
+      # Best-effort by construction: `continue-on-error` covers the job, and
+      # `|| true` covers the step. A third-party outage must never put a red
+      # mark on this repository's tracker.
+      - name: Notify
+        continue-on-error: true
+        env:
+          REPO: ${{ github.repository }}
+          ISSUE: ${{ github.event.issue.number }}
+        # Values arrive through env and the body is built by jq, so nothing is
+        # concatenated into a shell word or a JSON string.
+        run: |
+          curl -sS --max-time 20 -X POST \
+            https://mcp.synthiaresearch.com/v1/hooks/github/issue-opened \
+            -H 'content-type: application/json' \
+            --data "$(jq -nc --arg r "$REPO" --argjson i "$ISSUE" \
+                      '{repo: $r, issue: $i}')" || true


### PR DESCRIPTION

## What Problem This Solves

This is a problem on my side, not yours, and the ask is correspondingly small.

**Disclosure up front:** I work on Synthia, which is a commercial product, and this
workflow feeds its reproduction pipeline. So the benefit here is mine, not this project's.
I have kept the ask to something I would be comfortable being asked for by a stranger, and
everything below is meant to be checkable rather than taken on trust — but you should know
whose interest it serves before you read the rest.

I read this tracker through the public issues API on a schedule and attempt to reproduce
newly-filed issues against current `main` on my own machines. Polling works, but it is a
blunt instrument: it re-reads the same window every half hour whether or not anything
changed, and a report can sit for up to that long before anything looks at it.

This replaces the poll with a push. One workflow, fired when an issue is opened, that says
"issue N exists" and nothing else.

## Why This Change Was Made

The design goal was to make this the smallest possible thing to ask of a repository that
owes me nothing, so every part of it is subtractive:

- **No secret, no App, no token, no collaborator access.** `permissions: {}` means the
  job's `GITHUB_TOKEN` has no scopes at all, and the workflow never uses it.
- **No third-party action.** There is no `uses:` line, so there is nothing to review, pin,
  or trust — just `curl` and `jq`, both already used by 35 workflows in this repo.
- **No write access, ever.** Nothing is posted back to this tracker: no comments, no
  labels, no issues, no PRs. A wrong reproduction result costs you nothing because you
  never see it.
- **Coordinates only.** The request body is `{"repo": "...", "issue": 123}`. Not the
  title, not the body, not the labels, not the reporter. Those are read afterwards from
  the public API, exactly as they are read today.
- **Best-effort.** The step cannot fail the job. If my endpoint is down, slow, or gone,
  the workflow no-ops and reproduction starts from the next scheduled read instead.

Non-goals: this does not run anything in your CI, does not check out your code, and does
not gate any PR.

## User Impact

None. Nothing is posted to the tracker, no check is added to any PR, and no existing
workflow changes. Maintainers should not notice this exists.

If it ever becomes noise, deleting the file is a complete uninstall — there is no state on
your side to clean up.

## Evidence

**Static analysis** — clean under both linters, with `zizmor` at its strictest persona and
with *no* rule exemptions (i.e. not relying on the suppressions in `.github/zizmor.yml`):

```
$ actionlint .github/workflows/synthia-issue-ping.yml
$ zizmor --persona=pedantic .github/workflows/synthia-issue-ping.yml
No findings to report. Good job!
```

**It cannot fail your CI.** GitHub runs `run:` blocks as `bash -e {0}`, so the failure
modes matter. Running the shipped step verbatim under `bash -e`:

| condition | step exit |
| --- | --- |
| endpoint reachable, returns 204 | 0 |
| connection refused | 0 |
| endpoint returns an HTTP error | 0 |
| DNS resolution fails entirely | 0 |

`continue-on-error: true` covers the job on top of that.

**The payload is exactly what is claimed.** The step's own command, run with this repo's
values:

```
$ jq -nc --arg r "$REPO" --argjson i "$ISSUE" '{repo: $r, issue: $i}'
{"repo":"openclaw/openclaw","issue":999001}
```

Values reach the shell through `env:` and the body is built by `jq`, so nothing is
concatenated into a shell word or a JSON string.

---

**If `issues: [opened]` is too broad**, gating on `types: [labeled]` plus
`clawsweeper:needs-live-repro` is a one-line change and matches a need already in your
taxonomy — in one recent 100-issue window, 14 issues carried that label and 30 carried
`status: 📣 needs proof`.

And if you would simply rather not have a third party's workflow in the repo, closing this
is the right call and costs me nothing — the scheduled read already works.
