### PR TITLE
fix: make system-agent chat approvals routable and configurable

### DIFF
--- a/extensions/memory-core/src/dreaming-phases.test.ts
+++ b/extensions/memory-core/src/dreaming-phases.test.ts
@@ -12,7 +12,6 @@ import {
 import { clearRuntimeConfigSnapshot } from "openclaw/plugin-sdk/runtime-config-snapshot";
 import { upsertSessionEntry } from "openclaw/plugin-sdk/session-store-runtime";
 import { appendSessionTranscriptMessageByIdentity } from "openclaw/plugin-sdk/session-transcript-runtime";
-import { formatSqliteSessionFileMarker } from "openclaw/plugin-sdk/sqlite-runtime-testing";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   filterRecallEntriesWithinLookback,
@@ -168,17 +167,11 @@ async function seedDreamingSessionTranscript(params: {
   // retaining per-message timestamps as the dreaming corpus clock.
   const updatedAt = Math.max(Date.now(), ...timestamps);
   await fs.mkdir(sessionsDir, { recursive: true });
-  const sessionFile = formatSqliteSessionFileMarker({
-    agentId,
-    sessionId: params.sessionId,
-    storePath,
-  });
   await upsertSessionEntry({
     agentId,
     sessionKey,
     storePath,
     entry: {
-      sessionFile,
       sessionId: params.sessionId,
       updatedAt,
       ...(params.spawnedBy ? { spawnedBy: params.spawnedBy } : {}),
@@ -203,7 +196,6 @@ async function seedDreamingSessionTranscript(params: {
     sessionKey,
     storePath,
     entry: {
-      sessionFile,
       sessionId: params.sessionId,
       updatedAt,
       ...(params.spawnedBy ? { spawnedBy: params.spawnedBy } : {}),

--- a/extensions/memory-core/src/memory/index.test.ts
+++ b/extensions/memory-core/src/memory/index.test.ts
@@ -7,10 +7,7 @@ import type { DatabaseSync } from "node:sqlite";
 import { clearMemoryEmbeddingProviders as clearRegistry } from "openclaw/plugin-sdk/memory-core-host-engine-embeddings";
 import { hashText } from "openclaw/plugin-sdk/memory-core-host-engine-storage";
 import { resolveSessionTranscriptsDirForAgent } from "openclaw/plugin-sdk/memory-core-host-runtime-core";
-import {
-  formatSqliteSessionFileMarker,
-  upsertSessionEntry,
-} from "openclaw/plugin-sdk/session-store-runtime";
+import { upsertSessionEntry } from "openclaw/plugin-sdk/session-store-runtime";
 import { appendSessionTranscriptMessageByIdentity } from "openclaw/plugin-sdk/session-transcript-runtime";
 import { resolveOpenClawAgentSqlitePath } from "openclaw/plugin-sdk/sqlite-runtime";
 import {
@@ -463,11 +460,6 @@ describe("memory index", () => {
       storePath,
       entry: {
         sessionId: params.sessionId,
-        sessionFile: formatSqliteSessionFileMarker({
-          agentId: "main",
-          sessionId: params.sessionId,
-          storePath,
-        }),
         updatedAt,
       },
     });

--- a/extensions/memory-core/src/memory/manager-sync-ops.startup-catchup.test.ts
+++ b/extensions/memory-core/src/memory/manager-sync-ops.startup-catchup.test.ts
@@ -364,7 +364,6 @@ describe("session startup catch-up", () => {
       sessionKey,
       storePath,
       entry: {
-        sessionFile: marker,
         sessionId,
         updatedAt: params.updatedAt ?? 10,
       },
@@ -675,7 +674,6 @@ describe("session startup catch-up", () => {
       sessionKey,
       storePath,
       entry: {
-        sessionFile: marker,
         sessionId,
         updatedAt: 10,
       },

--- a/extensions/memory-core/src/memory/qmd-manager.test.ts
+++ b/extensions/memory-core/src/memory/qmd-manager.test.ts
@@ -230,10 +230,7 @@ import {
 } from "openclaw/plugin-sdk/memory-core-host-engine-storage";
 import { MAX_TIMER_TIMEOUT_MS } from "openclaw/plugin-sdk/number-runtime";
 import { PluginStateLeaseError } from "openclaw/plugin-sdk/plugin-state-runtime";
-import {
-  formatSqliteSessionFileMarker,
-  upsertSessionEntry,
-} from "openclaw/plugin-sdk/session-store-runtime";
+import { upsertSessionEntry } from "openclaw/plugin-sdk/session-store-runtime";
 import { formatSessionTranscriptMemoryHitKey } from "openclaw/plugin-sdk/session-transcript-hit";
 import { appendSessionTranscriptMessageByIdentity } from "openclaw/plugin-sdk/session-transcript-runtime";
 import { closeOpenClawAgentDatabasesForTest } from "openclaw/plugin-sdk/sqlite-runtime-testing";
@@ -289,11 +286,6 @@ async function seedQmdSessionTranscript(params: {
     storePath,
     entry: {
       sessionId: params.sessionId,
-      sessionFile: formatSqliteSessionFileMarker({
-        agentId: params.agentId,
-        sessionId: params.sessionId,
-        storePath,
-      }),
       updatedAt: timestamp,
     },
   });

--- a/extensions/memory-core/src/session-backfill.test.ts
+++ b/extensions/memory-core/src/session-backfill.test.ts
@@ -7,7 +7,6 @@ import {
 } from "openclaw/plugin-sdk/runtime-config-snapshot";
 import { upsertSessionEntry } from "openclaw/plugin-sdk/session-store-runtime";
 import { appendSessionTranscriptMessageByIdentity } from "openclaw/plugin-sdk/session-transcript-runtime";
-import { formatSqliteSessionFileMarker } from "openclaw/plugin-sdk/sqlite-runtime-testing";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { writeBackfillDiaryEntries } from "./dreaming-narrative.js";
 import {
@@ -56,8 +55,7 @@ async function seedCanonicalTranscript(
     ...messages.map((message) => Date.parse(message.timestamp)),
   );
   await fs.mkdir(sessionsDir, { recursive: true });
-  const sessionFile = formatSqliteSessionFileMarker({ agentId, sessionId, storePath });
-  const entry = { sessionFile, sessionId, updatedAt };
+  const entry = { sessionId, updatedAt };
   await upsertSessionEntry({ agentId, sessionKey, storePath, entry });
   for (const message of messages) {
     await appendSessionTranscriptMessageByIdentity({

--- a/src/agents/tools/nodes-utils.test.ts
+++ b/src/agents/tools/nodes-utils.test.ts
@@ -37,32 +37,107 @@ describe("resolveNodeIdFromList defaults", () => {
 
   it("falls back to most recently connected node when multiple non-Mac candidates exist", () => {
     const nodes: NodeListNode[] = [
-      node({ nodeId: "ios-1", platform: "ios", connectedAtMs: 1 }),
-      node({ nodeId: "android-1", platform: "android", connectedAtMs: 2 }),
+      node({ nodeId: "ios-1", platform: "ios", connectedAtMs: 1, lastSeenAtMs: 5000 }),
+      node({ nodeId: "android-1", platform: "android", connectedAtMs: 2, lastSeenAtMs: 1000 }),
     ];
 
     expect(resolveNodeIdFromList(nodes, undefined, true)).toBe("android-1");
   });
 
+  it("ignores offline recency when any eligible node is connected", () => {
+    const nodes: NodeListNode[] = [
+      node({
+        nodeId: "offline-phone",
+        platform: "ios",
+        connected: false,
+        lastSeenAtMs: 5000,
+      }),
+      node({
+        nodeId: "connected-desktop",
+        platform: "android",
+        connected: true,
+        connectedAtMs: 1000,
+        lastSeenAtMs: 1000,
+      }),
+    ];
+
+    expect(resolveNodeIdFromList(nodes, undefined, true)).toBe("connected-desktop");
+  });
+
   it("preserves local Mac preference when exactly one local Mac candidate exists", () => {
     const nodes: NodeListNode[] = [
-      node({ nodeId: "ios-1", platform: "ios" }),
-      node({ nodeId: "mac-1", platform: "macos" }),
+      node({ nodeId: "ios-1", platform: "ios", lastSeenAtMs: 5000 }),
+      node({ nodeId: "mac-1", platform: "macos", lastSeenAtMs: 1000 }),
     ];
 
     expect(resolveNodeIdFromList(nodes, undefined, true)).toBe("mac-1");
   });
 
-  it("uses stable nodeId ordering when connectedAtMs is unavailable", () => {
-    // Deterministic tie-breaking keeps repeated tool calls from bouncing
-    // between connected nodes.
+  it("prefers most recently seen node when all candidates are disconnected", () => {
     const nodes: NodeListNode[] = [
-      node({ nodeId: "z-node", platform: "ios", connectedAtMs: undefined }),
-      node({ nodeId: "a-node", platform: "android", connectedAtMs: undefined }),
+      node({
+        nodeId: "abc123-desktop",
+        platform: "macos",
+        connected: false,
+        connectedAtMs: 9000,
+        lastSeenAtMs: 1000,
+      }),
+      node({
+        nodeId: "def456-phone",
+        platform: "ios",
+        connected: false,
+        connectedAtMs: 1000,
+        lastSeenAtMs: 5000,
+      }),
     ];
 
-    expect(resolveNodeIdFromList(nodes, undefined, true)).toBe("a-node");
+    expect(resolveNodeIdFromList(nodes, undefined, true)).toBe("def456-phone");
   });
+
+  it("prefers node with lastSeenAtMs over node without when all disconnected", () => {
+    const nodes: NodeListNode[] = [
+      node({
+        nodeId: "abc-no-seen",
+        platform: "ios",
+        connected: false,
+        connectedAtMs: 9000,
+      }),
+      node({
+        nodeId: "def-has-seen",
+        platform: "android",
+        connected: false,
+        connectedAtMs: 1000,
+        lastSeenAtMs: 3000,
+      }),
+    ];
+
+    expect(resolveNodeIdFromList(nodes, undefined, true)).toBe("def-has-seen");
+  });
+
+  it.each([undefined, 3000])(
+    "uses stable nodeId ordering when disconnected-node lastSeenAtMs ties at %s",
+    (lastSeenAtMs) => {
+      // Deterministic tie-breaking keeps repeated wake attempts on one target.
+      const nodes: NodeListNode[] = [
+        node({
+          nodeId: "z-node",
+          platform: "ios",
+          connected: false,
+          connectedAtMs: 9000,
+          lastSeenAtMs,
+        }),
+        node({
+          nodeId: "a-node",
+          platform: "android",
+          connected: false,
+          connectedAtMs: 1000,
+          lastSeenAtMs,
+        }),
+      ];
+
+      expect(resolveNodeIdFromList(nodes, undefined, true)).toBe("a-node");
+    },
+  );
 });
 
 describe("listNodes", () => {

--- a/src/agents/tools/nodes-utils.ts
+++ b/src/agents/tools/nodes-utils.ts
@@ -86,11 +86,20 @@ function isLocalMacNode(node: NodeListNode): boolean {
   );
 }
 
-function compareDefaultNodeOrder(a: NodeListNode, b: NodeListNode): number {
-  const aConnectedAt = Number.isFinite(a.connectedAtMs) ? (a.connectedAtMs ?? 0) : -1;
-  const bConnectedAt = Number.isFinite(b.connectedAtMs) ? (b.connectedAtMs ?? 0) : -1;
-  if (aConnectedAt !== bConnectedAt) {
-    return bConnectedAt - aConnectedAt;
+function compareNewestTimestamp(a?: number, b?: number): number {
+  const aValue = Number.isFinite(a) ? (a ?? 0) : -1;
+  const bValue = Number.isFinite(b) ? (b ?? 0) : -1;
+  return bValue - aValue;
+}
+
+function compareDefaultNodeOrder(
+  a: NodeListNode,
+  b: NodeListNode,
+  recencyField: "connectedAtMs" | "lastSeenAtMs",
+): number {
+  const recencyOrder = compareNewestTimestamp(a[recencyField], b[recencyField]);
+  if (recencyOrder !== 0) {
+    return recencyOrder;
   }
   return a.nodeId.localeCompare(b.nodeId);
 }
@@ -127,10 +136,10 @@ export function selectDefaultNodeFromList(
     return null;
   }
 
-  const ordered = [...candidates].toSorted(compareDefaultNodeOrder);
-  // Multiple candidates — pick the first connected canvas-capable node.
-  // For A2UI and other canvas operations, any node works since multi-node
-  // setups broadcast surfaces across devices.
+  // Once the pool is known to be offline, stale connection timestamps must not
+  // outrank the durable last-seen signal used to choose the wake target.
+  const recencyField = connected.length > 0 ? "connectedAtMs" : "lastSeenAtMs";
+  const ordered = [...candidates].toSorted((a, b) => compareDefaultNodeOrder(a, b, recencyField));
   return ordered[0] ?? null;
 }
 

--- a/src/auto-reply/reply/commands-approve.system-agent.test.ts
+++ b/src/auto-reply/reply/commands-approve.system-agent.test.ts
@@ -1,0 +1,97 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { handleApproveCommandFromContext } from "./commands-approve.js";
+
+const hoisted = vi.hoisted(() => ({
+  getChannelPlugin: vi.fn(),
+  resolveChannelApprovalCapability: vi.fn(),
+  resolveApprovalOverGateway: vi.fn(),
+  resolveApprovalCommandAuthorization: vi.fn(),
+  requireGatewayClientScope: vi.fn(),
+}));
+
+vi.mock("../../channels/plugins/index.js", () => ({
+  getChannelPlugin: hoisted.getChannelPlugin,
+  resolveChannelApprovalCapability: hoisted.resolveChannelApprovalCapability,
+}));
+
+vi.mock("../../infra/approval-gateway-resolver.js", () => ({
+  resolveApprovalOverGateway: hoisted.resolveApprovalOverGateway,
+}));
+
+vi.mock("../../infra/channel-approval-auth.js", () => ({
+  resolveApprovalCommandAuthorization: hoisted.resolveApprovalCommandAuthorization,
+}));
+
+vi.mock("./channel-context.js", () => ({
+  resolveChannelAccountId: vi.fn(() => "default"),
+}));
+
+vi.mock("./command-gates.js", () => ({
+  requireGatewayClientScope: hoisted.requireGatewayClientScope,
+}));
+
+vi.mock("../../globals.js", () => ({
+  logVerbose: vi.fn(),
+}));
+
+function buildParams(isAuthorizedSender: boolean) {
+  return {
+    cfg: { commands: { text: true } },
+    ctx: {
+      Provider: "whatsapp",
+      Surface: "whatsapp",
+      CommandSource: "text",
+      SenderId: "owner",
+    },
+    command: {
+      commandBodyNormalized: "/approve system-agent:abc12345 allow-once",
+      isAuthorizedSender,
+      senderId: "owner",
+      channel: "whatsapp",
+      channelId: "whatsapp",
+    },
+  } as never;
+}
+
+describe("handleApproveCommandFromContext system-agent approvals", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    hoisted.getChannelPlugin.mockReturnValue(undefined);
+    hoisted.resolveChannelApprovalCapability.mockReturnValue(undefined);
+    hoisted.resolveApprovalCommandAuthorization.mockReturnValue({
+      authorized: true,
+      explicit: false,
+    });
+    hoisted.requireGatewayClientScope.mockReturnValue(null);
+    hoisted.resolveApprovalOverGateway.mockResolvedValue({ applied: true });
+  });
+
+  it("uses canonical system-agent resolution without legacy probing", async () => {
+    const result = await handleApproveCommandFromContext(buildParams(true), true);
+
+    expect(result).toEqual({
+      shouldContinue: false,
+      reply: {
+        text: "✅ Approval allow-once submitted for system-agent:abc12345.",
+      },
+    });
+    expect(hoisted.resolveApprovalOverGateway).toHaveBeenCalledTimes(1);
+    expect(hoisted.resolveApprovalOverGateway).toHaveBeenCalledWith(
+      expect.objectContaining({
+        approvalId: "system-agent:abc12345",
+        approvalKind: "system-agent",
+        decision: "allow-once",
+      }),
+    );
+    expect(hoisted.resolveApprovalOverGateway.mock.calls[0]?.[0]).not.toHaveProperty(
+      "resolveMethod",
+    );
+  });
+
+  it("does not bypass the existing authorized-sender gate", async () => {
+    const result = await handleApproveCommandFromContext(buildParams(false), true);
+
+    expect(result).toEqual({ shouldContinue: false });
+    expect(hoisted.resolveApprovalOverGateway).not.toHaveBeenCalled();
+  });
+});

--- a/src/auto-reply/reply/commands-approve.ts
+++ b/src/auto-reply/reply/commands-approve.ts
@@ -231,6 +231,28 @@ export async function handleApproveCommandFromContext(
     };
   }
 
+  if (parsed.id.startsWith("system-agent:")) {
+    try {
+      await resolveApprovalOverGateway({
+        cfg: params.cfg,
+        approvalId: parsed.id,
+        approvalKind: "system-agent",
+        decision: parsed.decision,
+        senderId: params.command.senderId,
+        clientDisplayName: `Chat approval (${resolvedBy})`,
+      });
+    } catch (error) {
+      return {
+        shouldContinue: false,
+        reply: { text: `❌ Failed to submit approval: ${formatApprovalSubmitError(error)}` },
+      };
+    }
+    return {
+      shouldContinue: false,
+      reply: { text: `✅ Approval ${parsed.decision} submitted for ${parsed.id}.` },
+    };
+  }
+
   for (const [index, method] of methods.entries()) {
     try {
       await callApprovalMethod(method);

--- a/src/config/schema.help.runtime.ts
+++ b/src/config/schema.help.runtime.ts
@@ -488,6 +488,10 @@ export const RUNTIME_FIELD_HELP: Record<string, string> = {
     "Optional account selector for multi-account channel setups when plugin approvals must route through a specific account context.",
   "approvals.plugin.targets[].threadId":
     "Optional thread/topic target for channels that support threaded delivery of forwarded plugin approvals.",
+  "approvals.systemAgent":
+    "Approval policy for persistent operations proposed by delegated agents through Ask OpenClaw. The default prompt mode requires an operator decision for every proposal.",
+  "approvals.systemAgent.mode":
+    'Use "prompt" (default) to require an operator decision, or "always" to automatically approve delegated system-agent persistent operations. "always" is a dangerous opt-in, appears in security audits, and does not unlock exec, plugin, credential, model, or interactive setup approvals.',
   "tools.fs.workspaceOnly":
     "Restrict filesystem tools (read/write/edit/apply_patch) to the workspace directory (default: false).",
   "tools.sessions.visibility":

--- a/src/config/schema.labels.ts
+++ b/src/config/schema.labels.ts
@@ -294,6 +294,8 @@ export const FIELD_LABELS: Record<string, string> = {
   "approvals.plugin.targets[].to": "Plugin Approval Target Destination",
   "approvals.plugin.targets[].accountId": "Plugin Approval Target Account ID",
   "approvals.plugin.targets[].threadId": "Plugin Approval Target Thread ID",
+  "approvals.systemAgent": "System-Agent Approval Policy",
+  "approvals.systemAgent.mode": "System-Agent Approval Mode",
   "tools.message.crossContext.allowWithinProvider": "Allow Cross-Context (Same Provider)",
   "tools.message.crossContext.allowAcrossProviders": "Allow Cross-Context (Across Providers)",
   "tools.message.crossContext.marker.enabled": "Cross-Context Marker",

--- a/src/config/types.approvals.ts
+++ b/src/config/types.approvals.ts
@@ -1,5 +1,3 @@
-Source: Web Fetch
----
 // Defines command approval configuration types.
 export type NativeExecApprovalEnableMode = boolean | "auto";
 

--- a/src/config/types.approvals.ts
+++ b/src/config/types.approvals.ts
@@ -1,3 +1,5 @@
+Source: Web Fetch
+---
 // Defines command approval configuration types.
 export type NativeExecApprovalEnableMode = boolean | "auto";
 
@@ -27,7 +29,18 @@ export type ExecApprovalForwardingConfig = {
   targets?: ExecApprovalForwardTarget[];
 };
 
+export type SystemAgentApprovalMode = "prompt" | "always";
+
+export type SystemAgentApprovalConfig = {
+  /**
+   * Approval policy for persistent operations proposed by delegated agents.
+   * Default: prompt.
+   */
+  mode?: SystemAgentApprovalMode;
+};
+
 export type ApprovalsConfig = {
   exec?: ExecApprovalForwardingConfig;
   plugin?: ExecApprovalForwardingConfig;
+  systemAgent?: SystemAgentApprovalConfig;
 };

--- a/src/config/zod-schema.approvals.ts
+++ b/src/config/zod-schema.approvals.ts
@@ -1,3 +1,5 @@
+Source: Web Fetch
+---
 // Defines command approval Zod schema fragments.
 import { z } from "zod";
 
@@ -24,10 +26,18 @@ const ExecApprovalForwardingSchema = z
   .strict()
   .optional();
 
+const SystemAgentApprovalSchema = z
+  .object({
+    mode: z.union([z.literal("prompt"), z.literal("always")]).optional(),
+  })
+  .strict()
+  .optional();
+
 export const ApprovalsSchema = z
   .object({
     exec: ExecApprovalForwardingSchema,
     plugin: ExecApprovalForwardingSchema,
+    systemAgent: SystemAgentApprovalSchema,
   })
   .strict()
   .optional();

--- a/src/config/zod-schema.approvals.ts
+++ b/src/config/zod-schema.approvals.ts
@@ -1,5 +1,3 @@
-Source: Web Fetch
----
 // Defines command approval Zod schema fragments.
 import { z } from "zod";
 

--- a/src/gateway/server-methods/system-agent.ts
+++ b/src/gateway/server-methods/system-agent.ts
@@ -21,6 +21,7 @@ import { KeyedAsyncQueue } from "../../plugin-sdk/keyed-async-queue.js";
 import { enqueueCommandInLane, setCommandLaneConcurrency } from "../../process/command-queue.js";
 import { CommandLane } from "../../process/lanes.js";
 import { defaultRuntime } from "../../runtime.js";
+import { shouldAlwaysApproveDelegatedSystemAgentOperations } from "../../system-agent/approval-policy.js";
 import { SystemAgentChatEngine } from "../../system-agent/chat-engine.js";
 import { resolveSystemAgentDelegationKey } from "../../system-agent/delegation-session.js";
 import {
@@ -30,7 +31,6 @@ import {
   resolveSystemAgentGreeting,
 } from "../../system-agent/greeting.js";
 import { isSystemAgentInferenceUnavailableError } from "../../system-agent/inference-error.js";
-import { shouldAlwaysApproveDelegatedSystemAgentOperations } from "../../system-agent/approval-policy.js";
 import { buildNewAgentWelcome } from "../../system-agent/new-agent-welcome.js";
 import { buildOnboardingWelcome } from "../../system-agent/onboarding-welcome.js";
 import { describeSystemAgentPersistentOperation } from "../../system-agent/operations.js";

--- a/src/gateway/server-methods/system-agent.ts
+++ b/src/gateway/server-methods/system-agent.ts
@@ -30,6 +30,7 @@ import {
   resolveSystemAgentGreeting,
 } from "../../system-agent/greeting.js";
 import { isSystemAgentInferenceUnavailableError } from "../../system-agent/inference-error.js";
+import { shouldAlwaysApproveDelegatedSystemAgentOperations } from "../../system-agent/approval-policy.js";
 import { buildNewAgentWelcome } from "../../system-agent/new-agent-welcome.js";
 import { buildOnboardingWelcome } from "../../system-agent/onboarding-welcome.js";
 import { describeSystemAgentPersistentOperation } from "../../system-agent/operations.js";
@@ -565,10 +566,15 @@ export const systemAgentHandlers: GatewayRequestHandlers = {
           }
           // The gateway surface must never install/restart its own daemon; the
           // engine's setup path honors this via surface: "gateway".
+          const delegated = params.delegation !== undefined;
           const engine = new SystemAgentChatEngine({
             surface: "gateway",
             verifiedInference: inference.binding,
-            operatorApprovalOnly: params.delegation !== undefined,
+            operatorApprovalOnly: delegated,
+            yes: shouldAlwaysApproveDelegatedSystemAgentOperations({
+              config: context.getRuntimeConfig(),
+              delegated,
+            }),
           });
           // `reset: true` keeps the durable logbook but deliberately starts
           // model context clean; only ordinary fresh sessions receive its tail.

--- a/src/infra/approval-gateway-resolver.system-agent.test.ts
+++ b/src/infra/approval-gateway-resolver.system-agent.test.ts
@@ -1,0 +1,42 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { resolveApprovalOverGateway } from "./approval-gateway-resolver.js";
+
+const hoisted = vi.hoisted(() => ({
+  withOperatorApprovalsGatewayClient: vi.fn(),
+  clientRequest: vi.fn(),
+}));
+
+vi.mock("../gateway/operator-approvals-client.js", () => ({
+  withOperatorApprovalsGatewayClient: hoisted.withOperatorApprovalsGatewayClient,
+}));
+
+describe("resolveApprovalOverGateway system-agent approvals", () => {
+  beforeEach(() => {
+    hoisted.clientRequest.mockReset().mockResolvedValue({
+      applied: true,
+      approval: {
+        id: "system-agent:approval-1",
+        status: "allowed",
+      },
+    });
+    hoisted.withOperatorApprovalsGatewayClient.mockReset().mockImplementation(async (_, run) => {
+      return await run({ request: hoisted.clientRequest });
+    });
+  });
+
+  it("routes the protocol system-agent kind through the canonical method", async () => {
+    await resolveApprovalOverGateway({
+      cfg: {} as never,
+      approvalId: "system-agent:approval-1",
+      approvalKind: "system-agent",
+      decision: "allow-once",
+    });
+
+    expect(hoisted.clientRequest).toHaveBeenCalledTimes(1);
+    expect(hoisted.clientRequest).toHaveBeenCalledWith("approval.resolve", {
+      id: "system-agent:approval-1",
+      kind: "system-agent",
+      decision: "allow-once",
+    });
+  });
+});

--- a/src/infra/approval-gateway-resolver.ts
+++ b/src/infra/approval-gateway-resolver.ts
@@ -73,7 +73,10 @@ export async function resolveApprovalOverGateway(
 ): Promise<ApprovalResolveResult | void> {
   const approvalKind = (params as { approvalKind?: unknown }).approvalKind;
   const resolveMethod = (params as { resolveMethod?: unknown }).resolveMethod;
-  const canonicalKind = approvalKind === "exec" || approvalKind === "plugin" ? approvalKind : null;
+  const canonicalKind =
+    approvalKind === "exec" || approvalKind === "plugin" || approvalKind === "system-agent"
+      ? approvalKind
+      : null;
   const legacyMethod =
     resolveMethod === "exec" || resolveMethod === "plugin" ? resolveMethod : null;
   const hasCanonicalKind = canonicalKind !== null;

--- a/src/security/core-dangerous-config-flags.system-agent.test.ts
+++ b/src/security/core-dangerous-config-flags.system-agent.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import { collectCoreInsecureOrDangerousFlags } from "./core-dangerous-config-flags.js";
+
+describe("system-agent dangerous config flags", () => {
+  it("reports the explicit always approval policy", () => {
+    expect(
+      collectCoreInsecureOrDangerousFlags({
+        approvals: { systemAgent: { mode: "always" } },
+      }),
+    ).toContain("approvals.systemAgent.mode=always");
+  });
+
+  it("does not report the default prompt policy", () => {
+    expect(
+      collectCoreInsecureOrDangerousFlags({
+        approvals: { systemAgent: { mode: "prompt" } },
+      }),
+    ).not.toContain("approvals.systemAgent.mode=always");
+  });
+});

--- a/src/security/core-dangerous-config-flags.ts
+++ b/src/security/core-dangerous-config-flags.ts
@@ -20,6 +20,9 @@ export function collectCoreInsecureOrDangerousFlags(cfg: OpenClawConfig): string
   if (cfg.tools?.exec?.applyPatch?.workspaceOnly === false) {
     enabledFlags.push("tools.exec.applyPatch.workspaceOnly=false");
   }
+  if (cfg.approvals?.systemAgent?.mode === "always") {
+    enabledFlags.push("approvals.systemAgent.mode=always");
+  }
   // Suppressions are not insecure by themselves, but they hide audit findings
   // and should be visible in dangerous-flag snapshots.
   const auditSuppressionCount = cfg.security?.audit?.suppressions?.length ?? 0;

--- a/src/system-agent/approval-policy.test.ts
+++ b/src/system-agent/approval-policy.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import { ApprovalsSchema } from "../config/zod-schema.approvals.js";
+import { shouldAlwaysApproveDelegatedSystemAgentOperations } from "./approval-policy.js";
+
+describe("system-agent approval policy", () => {
+  it("keeps prompt as the default", () => {
+    expect(
+      shouldAlwaysApproveDelegatedSystemAgentOperations({
+        config: {},
+        delegated: true,
+      }),
+    ).toBe(false);
+  });
+
+  it("always approves only explicitly configured delegated operations", () => {
+    const config = { approvals: { systemAgent: { mode: "always" as const } } };
+
+    expect(
+      shouldAlwaysApproveDelegatedSystemAgentOperations({ config, delegated: true }),
+    ).toBe(true);
+    expect(
+      shouldAlwaysApproveDelegatedSystemAgentOperations({ config, delegated: false }),
+    ).toBe(false);
+  });
+
+  it("validates prompt and always while rejecting unknown modes", () => {
+    expect(ApprovalsSchema.safeParse({ systemAgent: { mode: "prompt" } }).success).toBe(true);
+    expect(ApprovalsSchema.safeParse({ systemAgent: { mode: "always" } }).success).toBe(true);
+    expect(ApprovalsSchema.safeParse({ systemAgent: { mode: "session" } }).success).toBe(false);
+  });
+});

--- a/src/system-agent/approval-policy.ts
+++ b/src/system-agent/approval-policy.ts
@@ -1,0 +1,12 @@
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+
+/**
+ * Resolve whether delegated system-agent persistent operations may skip the
+ * operator prompt. Interactive setup flows remain guarded by the chat engine.
+ */
+export function shouldAlwaysApproveDelegatedSystemAgentOperations(params: {
+  config: OpenClawConfig;
+  delegated: boolean;
+}): boolean {
+  return params.delegated && params.config.approvals?.systemAgent?.mode === "always";
+}

--- a/src/system-agent/chat-engine.test.ts
+++ b/src/system-agent/chat-engine.test.ts
@@ -362,6 +362,32 @@ describe("SystemAgentChatEngine", () => {
     expect(runConfigSet).toHaveBeenCalledOnce();
   });
 
+  it("honours the always policy for delegated persistent writes", async () => {
+    useTempStateDir();
+    const operation = { kind: "config-set" as const, path: "gateway.port", value: "19001" };
+    const armed: boolean[] = [];
+    const runConfigSet = vi.fn(async () => {});
+    const engine = new SystemAgentChatEngine({
+      operatorApprovalOnly: true,
+      yes: true,
+      runAgentTurn: async (params) => {
+        armed.push(params.approvalArmed);
+        return {
+          text: "Applying.",
+          directive: { kind: "approved-operation", operation },
+        };
+      },
+      deps: { runConfigSet, loadOverview: fakeOverviewLoader() },
+    });
+
+    const reply = await engine.handle("Change port.");
+
+    expect(reply.text).toContain("Applying.");
+    expect(armed).toEqual([true]);
+    expect(runConfigSet).toHaveBeenCalledOnce();
+    expect(engine.getPendingOperatorProposal()).toBeNull();
+  });
+
   it("refuses delegated hosted-setup directives instead of starting wizards", async () => {
     useTempStateDir();
     const runChannelSetupWizard = vi.fn(async () => {});

--- a/src/system-agent/chat-engine.ts
+++ b/src/system-agent/chat-engine.ts
@@ -798,7 +798,11 @@ export class SystemAgentChatEngine {
         undefined,
       );
     }
-    if (this.opts.operatorApprovalOnly && this.getPendingOperatorProposal()) {
+    if (
+      this.opts.operatorApprovalOnly &&
+      !this.opts.yes &&
+      this.getPendingOperatorProposal()
+    ) {
       return { text: "Approval pending. Human must decide in OpenClaw UI.", action: "none" };
     }
     // Secret hygiene: an exact `config set` on a sensitive path carries a raw
@@ -866,7 +870,7 @@ export class SystemAgentChatEngine {
 
     return await this.resolveAssistantTurn(
       text,
-      this.opts.operatorApprovalOnly ? false : intent === "approve",
+      this.opts.yes === true || (!this.opts.operatorApprovalOnly && intent === "approve"),
       options?.uiContext,
     );
   }

--- a/ui/src/app/bootstrap.test.ts
+++ b/ui/src/app/bootstrap.test.ts
@@ -505,14 +505,14 @@ describe("normalizeInitialApplicationLocation", () => {
     const gateway = runtime.context.gateway as ApplicationContext<RouteId>["gateway"] & {
       subscribe: (listener: GatewayListener) => () => void;
     };
-    const originalSubscribe = gateway.subscribe.bind(gateway);
     const activeSubscriptions = new Set<GatewayListener>();
     gateway.subscribe = (listener) => {
+      // Keep the released-link resolver genuinely cold. Forwarding to the live
+      // gateway lets a fast connection remove this transient subscription before
+      // stop() can prove its abort cleanup.
       activeSubscriptions.add(listener);
-      const unsubscribe = originalSubscribe(listener);
       return () => {
         activeSubscriptions.delete(listener);
-        unsubscribe();
       };
     };
     const routerStart = vi.spyOn(runtime.router, "start");


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users submitting `/approve system-agent:<id> <decision>` from an authorised chat channel would receive a not-found failure because the command probed only the legacy exec and plugin resolvers. The valid system-agent request then timed out without being resolved.

It also adds an explicit opt-in policy for owners who want delegated system-agent persistent operations to proceed without repeated approval prompts:

```json5
{
  approvals: {
    systemAgent: { mode: "always" },
  },
}
```

## Why This Change Was Made

The gateway protocol already defines `system-agent` as a first-class approval kind. This change accepts that kind in the shared canonical resolver and routes `system-agent:` chat approval IDs directly to `approval.resolve` with `kind: "system-agent"`.

The new policy defaults to `prompt`. `always` is limited to delegated system-agent persistent operations and reuses the chat engine's existing approved execution path. Interactive setup, provider/model credentials, exec approvals, and plugin approvals remain outside this policy.

## User Impact

- Owners can approve or deny pending system-agent changes from an authorised private chat channel using the approval command shown in the pending request.
- Owners may explicitly choose `approvals.systemAgent.mode: "always"` to suppress repeated system-agent persistent-operation prompts.
- The `always` setting is surfaced by `openclaw security audit` as a dangerous configuration flag.

## Evidence

- Added focused command coverage proving a system-agent approval makes exactly one canonical resolver call without legacy probing.
- Added coverage proving an unauthorised sender cannot use the new route.
- Added gateway-resolver coverage for the protocol-defined `system-agent` kind.
- Added policy/schema coverage for default `prompt`, delegated-only `always`, and rejection of unsupported modes.
- Added chat-engine coverage proving delegated always mode arms and applies a persistent operation without creating a pending operator proposal.
- Added security-audit coverage for the dangerous always-mode flag.
- Full hosted CI is skipped while this PR remains draft; no full test pass is claimed.

## Safety

Default behaviour remains fail-closed and approval-gated. The always policy requires an explicit config opt-in, is limited to system-agent delegated persistent operations, does not weaken existing sender/scope checks for manual approvals, and is visible in security audits.