### PR TITLE
chore: remove stale persisted session identity from fixtures

### DIFF
--- a/extensions/memory-core/src/dreaming-phases.test.ts
+++ b/extensions/memory-core/src/dreaming-phases.test.ts
@@ -12,7 +12,6 @@ import {
 import { clearRuntimeConfigSnapshot } from "openclaw/plugin-sdk/runtime-config-snapshot";
 import { upsertSessionEntry } from "openclaw/plugin-sdk/session-store-runtime";
 import { appendSessionTranscriptMessageByIdentity } from "openclaw/plugin-sdk/session-transcript-runtime";
-import { formatSqliteSessionFileMarker } from "openclaw/plugin-sdk/sqlite-runtime-testing";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   filterRecallEntriesWithinLookback,
@@ -168,17 +167,11 @@ async function seedDreamingSessionTranscript(params: {
   // retaining per-message timestamps as the dreaming corpus clock.
   const updatedAt = Math.max(Date.now(), ...timestamps);
   await fs.mkdir(sessionsDir, { recursive: true });
-  const sessionFile = formatSqliteSessionFileMarker({
-    agentId,
-    sessionId: params.sessionId,
-    storePath,
-  });
   await upsertSessionEntry({
     agentId,
     sessionKey,
     storePath,
     entry: {
-      sessionFile,
       sessionId: params.sessionId,
       updatedAt,
       ...(params.spawnedBy ? { spawnedBy: params.spawnedBy } : {}),
@@ -203,7 +196,6 @@ async function seedDreamingSessionTranscript(params: {
     sessionKey,
     storePath,
     entry: {
-      sessionFile,
       sessionId: params.sessionId,
       updatedAt,
       ...(params.spawnedBy ? { spawnedBy: params.spawnedBy } : {}),

--- a/extensions/memory-core/src/memory/index.test.ts
+++ b/extensions/memory-core/src/memory/index.test.ts
@@ -7,10 +7,7 @@ import type { DatabaseSync } from "node:sqlite";
 import { clearMemoryEmbeddingProviders as clearRegistry } from "openclaw/plugin-sdk/memory-core-host-engine-embeddings";
 import { hashText } from "openclaw/plugin-sdk/memory-core-host-engine-storage";
 import { resolveSessionTranscriptsDirForAgent } from "openclaw/plugin-sdk/memory-core-host-runtime-core";
-import {
-  formatSqliteSessionFileMarker,
-  upsertSessionEntry,
-} from "openclaw/plugin-sdk/session-store-runtime";
+import { upsertSessionEntry } from "openclaw/plugin-sdk/session-store-runtime";
 import { appendSessionTranscriptMessageByIdentity } from "openclaw/plugin-sdk/session-transcript-runtime";
 import { resolveOpenClawAgentSqlitePath } from "openclaw/plugin-sdk/sqlite-runtime";
 import {
@@ -463,11 +460,6 @@ describe("memory index", () => {
       storePath,
       entry: {
         sessionId: params.sessionId,
-        sessionFile: formatSqliteSessionFileMarker({
-          agentId: "main",
-          sessionId: params.sessionId,
-          storePath,
-        }),
         updatedAt,
       },
     });

--- a/extensions/memory-core/src/memory/manager-sync-ops.startup-catchup.test.ts
+++ b/extensions/memory-core/src/memory/manager-sync-ops.startup-catchup.test.ts
@@ -364,7 +364,6 @@ describe("session startup catch-up", () => {
       sessionKey,
       storePath,
       entry: {
-        sessionFile: marker,
         sessionId,
         updatedAt: params.updatedAt ?? 10,
       },
@@ -675,7 +674,6 @@ describe("session startup catch-up", () => {
       sessionKey,
       storePath,
       entry: {
-        sessionFile: marker,
         sessionId,
         updatedAt: 10,
       },

--- a/extensions/memory-core/src/memory/qmd-manager.test.ts
+++ b/extensions/memory-core/src/memory/qmd-manager.test.ts
@@ -230,10 +230,7 @@ import {
 } from "openclaw/plugin-sdk/memory-core-host-engine-storage";
 import { MAX_TIMER_TIMEOUT_MS } from "openclaw/plugin-sdk/number-runtime";
 import { PluginStateLeaseError } from "openclaw/plugin-sdk/plugin-state-runtime";
-import {
-  formatSqliteSessionFileMarker,
-  upsertSessionEntry,
-} from "openclaw/plugin-sdk/session-store-runtime";
+import { upsertSessionEntry } from "openclaw/plugin-sdk/session-store-runtime";
 import { formatSessionTranscriptMemoryHitKey } from "openclaw/plugin-sdk/session-transcript-hit";
 import { appendSessionTranscriptMessageByIdentity } from "openclaw/plugin-sdk/session-transcript-runtime";
 import { closeOpenClawAgentDatabasesForTest } from "openclaw/plugin-sdk/sqlite-runtime-testing";
@@ -289,11 +286,6 @@ async function seedQmdSessionTranscript(params: {
     storePath,
     entry: {
       sessionId: params.sessionId,
-      sessionFile: formatSqliteSessionFileMarker({
-        agentId: params.agentId,
-        sessionId: params.sessionId,
-        storePath,
-      }),
       updatedAt: timestamp,
     },
   });

--- a/extensions/memory-core/src/session-backfill.test.ts
+++ b/extensions/memory-core/src/session-backfill.test.ts
@@ -7,7 +7,6 @@ import {
 } from "openclaw/plugin-sdk/runtime-config-snapshot";
 import { upsertSessionEntry } from "openclaw/plugin-sdk/session-store-runtime";
 import { appendSessionTranscriptMessageByIdentity } from "openclaw/plugin-sdk/session-transcript-runtime";
-import { formatSqliteSessionFileMarker } from "openclaw/plugin-sdk/sqlite-runtime-testing";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { writeBackfillDiaryEntries } from "./dreaming-narrative.js";
 import {
@@ -56,8 +55,7 @@ async function seedCanonicalTranscript(
     ...messages.map((message) => Date.parse(message.timestamp)),
   );
   await fs.mkdir(sessionsDir, { recursive: true });
-  const sessionFile = formatSqliteSessionFileMarker({ agentId, sessionId, storePath });
-  const entry = { sessionFile, sessionId, updatedAt };
+  const entry = { sessionId, updatedAt };
   await upsertSessionEntry({ agentId, sessionKey, storePath, entry });
   for (const message of messages) {
     await appendSessionTranscriptMessageByIdentity({


### PR DESCRIPTION
Closes #115167

## What Problem This Solves

Resolves a problem where memory-core test fixtures still described `sessionFile` as persisted session identity even though the canonical session store discards that retired field.

## Why This Change Was Made

Removes the stale field from every matching memory-core fixture writer while preserving SQLite markers where they remain valid sync inputs. Production behavior and compatibility boundaries are unchanged.

## User Impact

No user-visible runtime change. The tests now document the session identity that OpenClaw actually persists and uses.

## Evidence

- Blacksmith Testbox `tbx_01kynh267y0ev06xrbmk1c3v3s`: all five focused suites passed, 5 files and 352 tests.
- The same Testbox lease passed `pnpm check:changed`.
- Fresh branch autoreview: clean, no actionable findings, 0.97 confidence.
- Independent Pi review: no code or scope blocker; confirmed canonical projection ownership and retained legitimate marker-input coverage.
- Content-neutral rebase onto current `origin/main`; `git range-diff` marked the commit unchanged.
- `git diff --check origin/main...HEAD` passed.
