### PR TITLE
test(telegram): cover forward-burst debounce coalescing through durable ingress

### DIFF
--- a/extensions/telegram/src/bot.media.downloads-media-file-path-no-file-download.e2e.test.ts
+++ b/extensions/telegram/src/bot.media.downloads-media-file-path-no-file-download.e2e.test.ts
@@ -202,7 +202,7 @@ describe("telegram inbound media", () => {
             photo: [{ file_id: "fid" }],
             date: 1736380800, // 2025-01-09T00:00:00Z
           },
-          me: { username: "openclaw_bot" },
+          me: { id: 999, username: "openclaw_bot" },
           getFile: scenario.getFile,
         });
 
@@ -239,7 +239,7 @@ describe("telegram inbound media", () => {
             photo: [{ file_id: "fid" }],
             date: 1736380800,
           },
-          me: { username: "openclaw_bot" },
+          me: { id: 999, username: "openclaw_bot" },
           getFile: async () => ({ file_path: "photos/1.jpg" }),
         });
 
@@ -281,7 +281,7 @@ describe("telegram inbound media", () => {
         chat: { id: 1234, type: "private" },
         photo: [{ file_id: "fid" }],
       },
-      me: { username: "openclaw_bot" },
+      me: { id: 999, username: "openclaw_bot" },
       getFile: async () => ({ file_path: "photos/2.jpg" }),
     });
 
@@ -342,7 +342,7 @@ describe("telegram inbound media", () => {
       replySpy.mockClear();
       await handler({
         message: testCase.message,
-        me: { username: "openclaw_bot" },
+        me: { id: 999, username: "openclaw_bot" },
         getFile: async () => ({ file_path: "unused" }),
       });
 
@@ -392,7 +392,7 @@ describe("telegram media groups", () => {
               media_group_id: "album-custom-api-root",
               photo: [{ file_id: "photo1" }],
             },
-            me: { username: "openclaw_bot" },
+            me: { id: 999, username: "openclaw_bot" },
             getFile: async () => ({ file_path: "photos/photo1.jpg" }),
           }),
           handler({
@@ -404,7 +404,7 @@ describe("telegram media groups", () => {
               media_group_id: "album-custom-api-root",
               photo: [{ file_id: "photo2" }],
             },
-            me: { username: "openclaw_bot" },
+            me: { id: 999, username: "openclaw_bot" },
             getFile: async () => ({ file_path: "photos/photo2.jpg" }),
           }),
         ]);
@@ -514,7 +514,7 @@ describe("telegram media groups", () => {
             scenario.messages.map((message) =>
               handler({
                 message,
-                me: { username: "openclaw_bot" },
+                me: { id: 999, username: "openclaw_bot" },
                 getFile: async () => ({ file_path: message.filePath }),
               }),
             ),
@@ -605,7 +605,7 @@ describe("telegram media groups", () => {
         ]) {
           await handler({
             message: message.message,
-            me: { username: "openclaw_bot" },
+            me: { id: 999, username: "openclaw_bot" },
             getFile: message.getFile,
           });
         }
@@ -718,7 +718,7 @@ describe("telegram media groups", () => {
         ]) {
           await handler({
             message: message.message,
-            me: { username: "openclaw_bot" },
+            me: { id: 999, username: "openclaw_bot" },
             getFile: message.getFile,
           });
         }
@@ -800,7 +800,7 @@ describe("telegram media groups", () => {
               media_group_id: "album-shared-by-telegram",
               photo: [{ file_id: "topic1photo" }],
             },
-            me: { username: "openclaw_bot" },
+            me: { id: 999, username: "openclaw_bot" },
             getFile: async () => ({ file_path: "photos/topic1.jpg" }),
           }),
           handler({
@@ -815,7 +815,7 @@ describe("telegram media groups", () => {
               media_group_id: "album-shared-by-telegram",
               photo: [{ file_id: "topic2photo" }],
             },
-            me: { username: "openclaw_bot" },
+            me: { id: 999, username: "openclaw_bot" },
             getFile: async () => ({ file_path: "photos/topic2.jpg" }),
           }),
         ]);
@@ -885,7 +885,7 @@ describe("telegram forwarded bursts", () => {
             date: 1736380800,
             forward_origin: { type: "hidden_user", date: 1736380700, sender_user_name: "A" },
           },
-          me: { username: "openclaw_bot" },
+          me: { id: 999, username: "openclaw_bot" },
           getFile: async () => ({}),
         });
 
@@ -898,7 +898,7 @@ describe("telegram forwarded bursts", () => {
             photo: [{ file_id: "fwd_photo_1" }],
             forward_origin: { type: "hidden_user", date: 1736380701, sender_user_name: "A" },
           },
-          me: { username: "openclaw_bot" },
+          me: { id: 999, username: "openclaw_bot" },
           getFile: async () => ({ file_path: "photos/fwd1.jpg" }),
         });
 

--- a/extensions/telegram/src/bot.media.downloads-media-file-path-no-file-download.e2e.test.ts
+++ b/extensions/telegram/src/bot.media.downloads-media-file-path-no-file-download.e2e.test.ts
@@ -202,7 +202,7 @@ describe("telegram inbound media", () => {
             photo: [{ file_id: "fid" }],
             date: 1736380800, // 2025-01-09T00:00:00Z
           },
-          me: { id: 999, username: "openclaw_bot" },
+          me: { username: "openclaw_bot" },
           getFile: scenario.getFile,
         });
 
@@ -239,7 +239,7 @@ describe("telegram inbound media", () => {
             photo: [{ file_id: "fid" }],
             date: 1736380800,
           },
-          me: { id: 999, username: "openclaw_bot" },
+          me: { username: "openclaw_bot" },
           getFile: async () => ({ file_path: "photos/1.jpg" }),
         });
 
@@ -281,7 +281,7 @@ describe("telegram inbound media", () => {
         chat: { id: 1234, type: "private" },
         photo: [{ file_id: "fid" }],
       },
-      me: { id: 999, username: "openclaw_bot" },
+      me: { username: "openclaw_bot" },
       getFile: async () => ({ file_path: "photos/2.jpg" }),
     });
 
@@ -342,7 +342,7 @@ describe("telegram inbound media", () => {
       replySpy.mockClear();
       await handler({
         message: testCase.message,
-        me: { id: 999, username: "openclaw_bot" },
+        me: { username: "openclaw_bot" },
         getFile: async () => ({ file_path: "unused" }),
       });
 
@@ -392,7 +392,7 @@ describe("telegram media groups", () => {
               media_group_id: "album-custom-api-root",
               photo: [{ file_id: "photo1" }],
             },
-            me: { id: 999, username: "openclaw_bot" },
+            me: { username: "openclaw_bot" },
             getFile: async () => ({ file_path: "photos/photo1.jpg" }),
           }),
           handler({
@@ -404,7 +404,7 @@ describe("telegram media groups", () => {
               media_group_id: "album-custom-api-root",
               photo: [{ file_id: "photo2" }],
             },
-            me: { id: 999, username: "openclaw_bot" },
+            me: { username: "openclaw_bot" },
             getFile: async () => ({ file_path: "photos/photo2.jpg" }),
           }),
         ]);
@@ -514,7 +514,7 @@ describe("telegram media groups", () => {
             scenario.messages.map((message) =>
               handler({
                 message,
-                me: { id: 999, username: "openclaw_bot" },
+                me: { username: "openclaw_bot" },
                 getFile: async () => ({ file_path: message.filePath }),
               }),
             ),
@@ -605,7 +605,7 @@ describe("telegram media groups", () => {
         ]) {
           await handler({
             message: message.message,
-            me: { id: 999, username: "openclaw_bot" },
+            me: { username: "openclaw_bot" },
             getFile: message.getFile,
           });
         }
@@ -718,7 +718,7 @@ describe("telegram media groups", () => {
         ]) {
           await handler({
             message: message.message,
-            me: { id: 999, username: "openclaw_bot" },
+            me: { username: "openclaw_bot" },
             getFile: message.getFile,
           });
         }
@@ -800,7 +800,7 @@ describe("telegram media groups", () => {
               media_group_id: "album-shared-by-telegram",
               photo: [{ file_id: "topic1photo" }],
             },
-            me: { id: 999, username: "openclaw_bot" },
+            me: { username: "openclaw_bot" },
             getFile: async () => ({ file_path: "photos/topic1.jpg" }),
           }),
           handler({
@@ -815,7 +815,7 @@ describe("telegram media groups", () => {
               media_group_id: "album-shared-by-telegram",
               photo: [{ file_id: "topic2photo" }],
             },
-            me: { id: 999, username: "openclaw_bot" },
+            me: { username: "openclaw_bot" },
             getFile: async () => ({ file_path: "photos/topic2.jpg" }),
           }),
         ]);
@@ -885,7 +885,7 @@ describe("telegram forwarded bursts", () => {
             date: 1736380800,
             forward_origin: { type: "hidden_user", date: 1736380700, sender_user_name: "A" },
           },
-          me: { id: 999, username: "openclaw_bot" },
+          me: { username: "openclaw_bot" },
           getFile: async () => ({}),
         });
 
@@ -898,7 +898,7 @@ describe("telegram forwarded bursts", () => {
             photo: [{ file_id: "fwd_photo_1" }],
             forward_origin: { type: "hidden_user", date: 1736380701, sender_user_name: "A" },
           },
-          me: { id: 999, username: "openclaw_bot" },
+          me: { username: "openclaw_bot" },
           getFile: async () => ({ file_path: "photos/fwd1.jpg" }),
         });
 

--- a/extensions/telegram/src/bot.media.test-utils.ts
+++ b/extensions/telegram/src/bot.media.test-utils.ts
@@ -1,6 +1,7 @@
 // Telegram helper module supports bot.media utils behavior.
 import * as ssrf from "openclaw/plugin-sdk/ssrf-runtime";
 import { afterEach, beforeAll, beforeEach, expect, vi, type Mock } from "vitest";
+import { telegramBotInfoForTest } from "./bot.create-telegram-bot.test-support.js";
 import * as harness from "./bot.media.e2e-harness.js";
 
 type StickerSpy = Mock<(...args: unknown[]) => unknown>;
@@ -62,6 +63,9 @@ export async function createBotHandlerWithOptions(options: {
   const effectiveProxyFetch = options.proxyFetch ?? (undiciFetchSpyRef as unknown as typeof fetch);
   createTelegramBotRef({
     token: "tok",
+    // Production always constructs the bot from getMe(), so inbound handlers may
+    // resolve the bot user id from botInfo when a test ctx carries only a username.
+    botInfo: telegramBotInfoForTest,
     config: harness.telegramBotDepsForTest.getRuntimeConfig(),
     testTimings: TELEGRAM_TEST_TIMINGS,
     ...(effectiveProxyFetch ? { proxyFetch: effectiveProxyFetch } : {}),

--- a/extensions/telegram/src/telegram-ingress-coalescing.e2e.test.ts
+++ b/extensions/telegram/src/telegram-ingress-coalescing.e2e.test.ts
@@ -1,4 +1,7 @@
-// Telegram ingress media-group regression: durable queue → core drain → grammY → album buffer.
+// Telegram ingress coalescing regression: durable queue → core drain → grammY → inbound buffer.
+// Both Telegram inbound buffers (album, forward-burst debounce) defer their spooled
+// participant the same way, so both depend on deferredLaneOccupancy="release" to admit
+// later same-lane members. Cover them together — a lane regression breaks both at once.
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
@@ -110,6 +113,25 @@ function photoUpdate(params: { updateId: number; messageId: number; caption?: st
   };
 }
 
+function forwardedTextUpdate(params: { updateId: number; messageId: number; text: string }) {
+  return {
+    update_id: params.updateId,
+    message: {
+      message_id: params.messageId,
+      date: 1_736_380_800 + params.messageId,
+      chat: { id: 111, type: "private" as const, first_name: "Ada" },
+      from: { id: 111, is_bot: false, first_name: "Ada" },
+      // forward_origin puts the entry on the forward debounce lane (80ms window).
+      forward_origin: {
+        type: "user" as const,
+        date: 1_736_300_000,
+        sender_user: { id: 555, is_bot: false, first_name: "Origin" },
+      },
+      text: params.text,
+    },
+  };
+}
+
 function createBotApiTransport(): TelegramTransport {
   let getFileCall = 0;
   const fetchImpl = vi.fn(async (input: RequestInfo | URL) => {
@@ -159,38 +181,42 @@ function createTelegramDeps(stateDir: string): TelegramBotDeps {
   } as TelegramBotDeps;
 }
 
-async function assertAlbumTurnAndTombstones(params: {
-  spoolDir: string;
-  firstUpdateId: number;
-  secondUpdateId: number;
-}) {
+/** Both members must land in one turn; a second turn is the split this file guards. */
+async function awaitSingleDownstreamTurn(): Promise<MsgContext & Record<string, unknown>> {
   await vi.waitFor(
     () => {
       expect(downstreamTurns).toHaveBeenCalledTimes(1);
     },
     { timeout: 5_000, interval: 5 },
   );
-  const turn = downstreamTurns.mock.calls[0]?.[0] as MsgContext & Record<string, unknown>;
-  expect(turn.Body).toContain("Two photo album");
-  expect(turn.media).toMatchObject([
-    { path: "/tmp/photo-1.jpg", kind: "image" },
-    { path: "/tmp/photo-2.jpg", kind: "image" },
-  ]);
+  return downstreamTurns.mock.calls[0]?.[0] as MsgContext & Record<string, unknown>;
+}
 
+async function assertSpoolTombstoned(params: { spoolDir: string; updateIds: number[] }) {
   const queue = openTelegramIngressQueue(params.spoolDir);
   await vi.waitFor(async () => {
     expect(await queue.listClaims()).toEqual([]);
     expect(await queue.listPending({ limit: "all" })).toEqual([]);
   });
-  await expect(
-    queue.enqueue(telegramQueueEventId(params.firstUpdateId), {} as never),
-  ).resolves.toMatchObject({ kind: "completed" });
-  await expect(
-    queue.enqueue(telegramQueueEventId(params.secondUpdateId), {} as never),
-  ).resolves.toMatchObject({ kind: "completed" });
+  // Every member tombstones independently, so a replayed update cannot re-enter.
+  for (const updateId of params.updateIds) {
+    await expect(queue.enqueue(telegramQueueEventId(updateId), {} as never)).resolves.toMatchObject(
+      { kind: "completed" },
+    );
+  }
 }
 
-describe("Telegram durable ingress media groups", () => {
+async function assertAlbumTurnAndTombstones(params: { spoolDir: string; updateIds: number[] }) {
+  const turn = await awaitSingleDownstreamTurn();
+  expect(turn.Body).toContain("Two photo album");
+  expect(turn.media).toMatchObject([
+    { path: "/tmp/photo-1.jpg", kind: "image" },
+    { path: "/tmp/photo-2.jpg", kind: "image" },
+  ]);
+  await assertSpoolTombstoned(params);
+}
+
+describe("Telegram durable ingress coalescing", () => {
   const originalStateDir = process.env.OPENCLAW_STATE_DIR;
   let stateDir: string;
   let spoolDir: string;
@@ -279,7 +305,7 @@ describe("Telegram durable ingress media groups", () => {
       setTimeout(resolve, 5);
     });
     await monitor.admit(second);
-    await assertAlbumTurnAndTombstones({ spoolDir, firstUpdateId: 101, secondUpdateId: 102 });
+    await assertAlbumTurnAndTombstones({ spoolDir, updateIds: [101, 102] });
 
     await monitor.stop();
     await telegramTransport.close();
@@ -293,7 +319,47 @@ describe("Telegram durable ingress media groups", () => {
     const { monitor, telegramTransport } = await createMonitor();
 
     monitor.start();
-    await assertAlbumTurnAndTombstones({ spoolDir, firstUpdateId: 201, secondUpdateId: 202 });
+    await assertAlbumTurnAndTombstones({ spoolDir, updateIds: [201, 202] });
+
+    await monitor.stop();
+    await telegramTransport.close();
+  });
+
+  it("coalesces a forwarded burst admitted a few milliseconds apart", async () => {
+    const { monitor, telegramTransport } = await createMonitor();
+    monitor.start();
+
+    await monitor.admit(forwardedTextUpdate({ updateId: 301, messageId: 1, text: "First note" }));
+    await new Promise((resolve) => {
+      setTimeout(resolve, 5);
+    });
+    await monitor.admit(forwardedTextUpdate({ updateId: 302, messageId: 2, text: "Second note" }));
+
+    const turn = await awaitSingleDownstreamTurn();
+    expect(turn.Body).toContain("First note");
+    expect(turn.Body).toContain("Second note");
+    await assertSpoolTombstoned({ spoolDir, updateIds: [301, 302] });
+
+    await monitor.stop();
+    await telegramTransport.close();
+  });
+
+  it("coalesces a forwarded burst replayed from a durable restart backlog", async () => {
+    await writeTelegramSpooledUpdate({
+      spoolDir,
+      update: forwardedTextUpdate({ updateId: 401, messageId: 1, text: "First note" }),
+    });
+    await writeTelegramSpooledUpdate({
+      spoolDir,
+      update: forwardedTextUpdate({ updateId: 402, messageId: 2, text: "Second note" }),
+    });
+    const { monitor, telegramTransport } = await createMonitor();
+
+    monitor.start();
+    const turn = await awaitSingleDownstreamTurn();
+    expect(turn.Body).toContain("First note");
+    expect(turn.Body).toContain("Second note");
+    await assertSpoolTombstoned({ spoolDir, updateIds: [401, 402] });
 
     await monitor.stop();
     await telegramTransport.close();


### PR DESCRIPTION
Related: #115325

## What Problem This Solves

Resolves a problem where two Telegram inbound coalescing behaviors — multi-photo albums and forwarded message bursts — could each be split into several agent turns, but only one of them is protected against regressing again.

#115401 fixed the album split and stated the same change also repairs the text and forwarded-message debounce, since that buffer defers its spooled participant the same way. The album path got a durable-ingress regression test. The debounce path got none, so nothing stops a future lane change from silently re-splitting a forwarded burst into one turn per message.

The suite that would have covered it, `bot.media.downloads-media-file-path-no-file-download.e2e.test.ts`, fails 10/10 on `main` and was called out as a known gap in that PR. Two of its tests target forwarded-burst coalescing directly.

## Why This Change Was Made

Two steps, tests only. No runtime change.

The broken suite is harness drift, not a runtime gap. `bot.media.test-utils.ts` builds its bot without `botInfo`, and `resolveBotUserId` (`extensions/telegram/src/bot-handlers.message-events.runtime.ts:44`) needs `ctx.me?.id ?? opts.botInfo?.id`, which has been required since #114532. Its test contexts carry only `me.username`, so neither source resolves. Production always constructs the bot from `getMe()`, so `botInfo` is present on every real path and nothing reachable in prod hits that throw.

Fixing the harness rather than the call sites also revives `bot.media.stickers-and-fragments.e2e.test.ts`, which shares the harness and failed 3/6 for the same reason. 13 dead tests come back from a four-line change.

The other ~84 bare `me: { username }` literals across 8 Telegram suites are not drift worth touching: those tests supply `botInfo` through their own harnesses. Verified by running them — 371 pass. No sweep.

The revived tests call the grammY handler directly, so they prove the debouncer coalesces but never touch the spool, claims, or lane blocking. They cannot catch the reported defect, which lives in lane admission. So the durable-ingress regression file is extended to cover both buffers and renamed off `media-group`, since album and forward-burst are two instances of one contract: both defer a spooled participant, and both depend on `deferredLaneOccupancy: "release"` to admit later same-lane members. Keeping them in one file means a lane regression fails both together instead of half the behavior going quiet.

Non-goal: no change to the buffers or the drain. This pins shipped behavior.

## User Impact

No user-visible change. Forwarding several messages to a Telegram bot, and sending a multi-photo album, both continue to arrive as one agent turn — that behavior is now covered by tests that fail if it breaks. 13 previously dead Telegram media tests run again.

## Evidence

Regression value verified by reverting the fix. With `deferredLaneOccupancy` flipped back to `"hold"` in `extensions/telegram/src/telegram-ingress-drain.ts:231`, all four coalescing tests fail, including both new ones:

```
 × coalesces album members admitted a few milliseconds apart
 × coalesces an album replayed from a durable restart backlog
 × coalesces a forwarded burst admitted a few milliseconds apart
 × coalesces a forwarded burst replayed from a durable restart backlog

AssertionError: expected '[Telegram Ada id:111 Thu 2025-01-09 0…' to contain 'Second note'
```

The forwarded-burst failure is exactly the reported symptom: the first turn carries `First note`, and `Second note` arrives as a separate turn. Restored to `"release"`, all four pass. This confirms the debounce repair #115401 claimed but could not demonstrate.

Suites, all green on this branch:

- `extensions/telegram/src/telegram-ingress-coalescing.e2e.test.ts` — 4 (2 pre-existing album, 2 new forward-burst; real bot, durable queue, core drain, grammY)
- `extensions/telegram/src/bot.media.downloads-media-file-path-no-file-download.e2e.test.ts` — 10 (0/10 on `main`)
- `extensions/telegram/src/bot.media.stickers-and-fragments.e2e.test.ts` — 6 (3/6 on `main`)
- 8 further Telegram suites carrying the same bare `me` literal — 371, confirming no wider drift
- `extensions/telegram/src/telegram-ingress-drain.test.ts` + `extensions/telegram/src/polling-session.test.ts` — 86

`pnpm check:test-types` clean (core, extensions, root). `scripts/run-oxlint.mjs` clean on both changed files. `oxfmt` applied. `git diff --check` clean. Non-test LOC unchanged.

Proof gap: run locally, not on Testbox/Crabbox — no remote backend was reachable from this environment. `$autoreview` was likewise unavailable here, so this diff has had my review but not that gate; it is test-only and the runtime is untouched.
