### PR TITLE
fix(qa): validate maturity profiles against the scenario inventory

### DIFF
--- a/.github/workflows/qa-profile-evidence.yml
+++ b/.github/workflows/qa-profile-evidence.yml
@@ -232,6 +232,7 @@ jobs:
           set -euo pipefail
           node --import tsx --input-type=module <<'NODE'
           import fs from "node:fs";
+          import { readQaScenarioPack } from "./extensions/qa-lab/src/scenario-catalog.ts";
           import { readQaScorecardTaxonomyReport } from "./extensions/qa-lab/src/scorecard-taxonomy.ts";
 
           const requested = process.env.QA_PROFILE?.trim() ?? "";
@@ -239,7 +240,7 @@ jobs:
             throw new Error(`qa_profile must use a taxonomy profile id, got ${JSON.stringify(process.env.QA_PROFILE)}`);
           }
 
-          const taxonomy = readQaScorecardTaxonomyReport([]);
+          const taxonomy = readQaScorecardTaxonomyReport(readQaScenarioPack().scenarios);
           const profile = taxonomy.profiles.find((entry) => entry.id === requested);
           if (!profile) {
             const available = taxonomy.profiles.map((entry) => entry.id).join(", ");

--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -4767,6 +4767,9 @@ printf '%s\n' "\${CURL_SUCCESS_IP:-203.0.113.7}"
       (step: WorkflowStep) => step.name === "Validate QA profile input",
     );
     expect(validateProfileStep.run).toContain(
+      "readQaScorecardTaxonomyReport(readQaScenarioPack().scenarios)",
+    );
+    expect(validateProfileStep.run).toContain(
       "taxonomy.profiles.find((entry) => entry.id === requested)",
     );
     expect(validateProfileStep.run).toContain("profile=${profile.id}");


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where maturity scorecard runs failed during QA profile validation before any scenarios ran because coverage ownership was checked against an empty scenario inventory.

## Why This Change Was Made

The reusable QA evidence workflow now loads the canonical QA scenario pack when building the scorecard taxonomy report. A workflow guard test pins that contract so profile validation cannot silently regress to an empty inventory.

## User Impact

Maintainers can run full-taxonomy QA evidence generation without this false profile-ownership failure. There is no product-user behavior change.

## Evidence

- Failure reproduced in [maturity scorecard run 30369799338](https://github.com/openclaw/openclaw/actions/runs/30369799338): `smoke-ci profile coverage agent-runtime.runtime-override-switching has no primary owner`.
- Exact `QA_PROFILE=all` validation passes and resolves 342 scenario references.
- `node scripts/run-vitest.mjs test/scripts/ci-workflow-guards.test.ts`: 90 passed, 1 skipped.
- `actionlint .github/workflows/qa-profile-evidence.yml`: passed.
- Full remote `pnpm check:workflows`: [passed](https://github.com/openclaw/openclaw/actions/runs/30409460878).
- Autoreview: clean, no actionable findings.

AI-assisted change.