### PR TITLE
fix(doctor): fail closed on newer cron schema

### DIFF
--- a/src/commands/doctor/cron/index.ts
+++ b/src/commands/doctor/cron/index.ts
@@ -29,6 +29,7 @@ import {
   formatUnresolvedCommandPromptAdvisory,
   formatUnresolvedShellPromptAdvisory,
 } from "./repair-plan.js";
+import { rethrowSqliteSchemaVersionError } from "./schema-safety.js";
 import { normalizeStoredCronJobs } from "./store-migration.js";
 import { noteCronDeliveryTargetAdvisory, noteCronModelOverrides } from "./warnings.js";
 
@@ -158,6 +159,7 @@ export async function collectLegacyCronStoreHealthFindings(params: {
   try {
     state = await loadLegacyCronRepairState({ cfg: params.cfg, readOnly: true });
   } catch (err) {
+    rethrowSqliteSchemaVersionError(err);
     const storePath = resolveCronJobsStorePath(readLegacyCronStorePath(params.cfg));
     return [
       legacyCronStoreFinding({
@@ -202,6 +204,7 @@ export async function collectLegacyCronStoreHealthFindings(params: {
       );
     }
   } catch (err) {
+    rethrowSqliteSchemaVersionError(err);
     findings.push(
       legacyCronStoreFinding({
         message: `Unable to read quarantined cron rows in SQLite at ${shortenHomePath(sqliteStorePath)}.`,
@@ -356,6 +359,7 @@ export async function maybeRepairLegacyCronStore(params: {
   try {
     state = await loadLegacyCronRepairState({ cfg: params.cfg });
   } catch (err) {
+    rethrowSqliteSchemaVersionError(err);
     const reason = err instanceof Error ? err.message : String(err);
     const storePath = resolveCronJobsStorePath(readLegacyCronStorePath(params.cfg));
     note(
@@ -395,6 +399,7 @@ export async function maybeRepairLegacyCronStore(params: {
       );
     }
   } catch (err) {
+    rethrowSqliteSchemaVersionError(err);
     const reason = err instanceof Error ? err.message : String(err);
     note(
       [

--- a/src/commands/doctor/cron/legacy-repair.ts
+++ b/src/commands/doctor/cron/legacy-repair.ts
@@ -50,6 +50,10 @@ import {
 } from "./repair-plan.js";
 import { planCronCodexRefRewriteAgainstPersistedConfig } from "./runtime-policy-migration.js";
 import {
+  assertCronStateSchemaSupported,
+  rethrowSqliteSchemaVersionError,
+} from "./schema-safety.js";
+import {
   collectStoredCronCodexRuntimePolicyTargets,
   cronCodexRuntimePolicyTargetKey,
   normalizeStoredCronJobs,
@@ -123,6 +127,7 @@ export async function loadLegacyCronRepairState(params: {
   const legacyStoreDetected = await legacyCronStoreFilesExist(storePath);
   const legacyRunLogDetected = await legacyCronRunLogFilesExist(storePath);
   const legacyQuarantine = await loadLegacyCronQuarantineForMigration(storePath);
+  assertCronStateSchemaSupported(params.env);
   if (
     params.onlyIfLegacyDetected &&
     !legacyStoreDetected &&
@@ -220,6 +225,7 @@ export async function applyLegacyCronStoreRepair(params: {
   migrateCodexModelRefs?: boolean;
   blockedModelIdentities?: ReadonlySet<LegacyCodexModelIdentity>;
 }): Promise<LegacyCronRepairResult> {
+  assertCronStateSchemaSupported();
   const { state } = params;
   const changes: string[] = [];
   const warnings: string[] = [];
@@ -309,6 +315,7 @@ export async function applyLegacyCronStoreRepair(params: {
         saveCronQuarantinedJobs({ storePath: state.storePath, ...quarantine });
       }
     } catch (err) {
+      rethrowSqliteSchemaVersionError(err);
       return {
         changes,
         warnings: [
@@ -337,6 +344,7 @@ export async function applyLegacyCronStoreRepair(params: {
     try {
       importedRunLogs = (await migrateLegacyCronRunLogsToSqlite(state.storePath)).importedFiles;
     } catch (err) {
+      rethrowSqliteSchemaVersionError(err);
       warnings.push(
         `Failed importing legacy cron run logs at ${shortenHomePath(state.storePath)}: ${errorMessage(err)}`,
       );
@@ -353,6 +361,7 @@ export async function applyLegacyCronStoreRepair(params: {
         try {
           markLegacyCronMigrationSourceRemoved(state.legacyMigrationSource);
         } catch (err) {
+          rethrowSqliteSchemaVersionError(err);
           warnings.push(
             `Cron store was archived, but its migration receipt could not be finalized: ${errorMessage(err)}`,
           );
@@ -411,6 +420,7 @@ export async function repairLegacyCronStoreWithoutPrompt(params: {
       onlyIfLegacyDetected: true,
     });
   } catch (err) {
+    rethrowSqliteSchemaVersionError(err);
     return {
       changes: [],
       warnings: [
@@ -438,6 +448,7 @@ export async function collectCronCodexRuntimePolicyTargetsReadOnly(params: {
       warnings: [],
     };
   } catch (err) {
+    rethrowSqliteSchemaVersionError(err);
     return {
       targets: [],
       warnings: [
@@ -466,6 +477,7 @@ export async function repairCronCodexModelRefsAfterConfigWrite(params: {
         })
       : { changes: [], warnings: [] };
   } catch (err) {
+    rethrowSqliteSchemaVersionError(err);
     return {
       changes: [],
       warnings: [

--- a/src/commands/doctor/cron/schema-safety.test.ts
+++ b/src/commands/doctor/cron/schema-safety.test.ts
@@ -1,0 +1,197 @@
+import { createHash } from "node:crypto";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { DatabaseSync } from "node:sqlite";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../../../config/types.openclaw.js";
+import { isSqliteSchemaVersionError } from "../../../infra/sqlite-user-version.js";
+import {
+  closeOpenClawStateDatabaseForTest,
+  OPENCLAW_STATE_SCHEMA_VERSION,
+} from "../../../state/openclaw-state-db.js";
+import { resolveOpenClawStateSqlitePath } from "../../../state/openclaw-state-db.paths.js";
+import { collectLegacyCronStoreHealthFindings, maybeRepairLegacyCronStore } from "./index.js";
+import {
+  applyLegacyCronStoreRepair,
+  collectCronCodexRuntimePolicyTargetsReadOnly,
+  loadLegacyCronRepairState,
+  repairCronCodexModelRefsAfterConfigWrite,
+  repairLegacyCronStoreWithoutPrompt,
+} from "./legacy-repair.js";
+
+type FutureSchemaFixture = {
+  cfg: OpenClawConfig;
+  databasePath: string;
+  storePath: string;
+};
+
+let tempRoot: string | undefined;
+let fixtureDatabase: DatabaseSync | undefined;
+
+afterEach(async () => {
+  fixtureDatabase?.close();
+  fixtureDatabase = undefined;
+  closeOpenClawStateDatabaseForTest();
+  vi.unstubAllEnvs();
+  if (tempRoot) {
+    await fs.rm(tempRoot, { recursive: true, force: true });
+    tempRoot = undefined;
+  }
+});
+
+async function writeFutureSchema(databasePath: string): Promise<void> {
+  await fs.mkdir(path.dirname(databasePath), { recursive: true });
+  const database = new DatabaseSync(databasePath);
+  try {
+    database.exec(`
+      CREATE TABLE preserved_sentinel (value TEXT NOT NULL) STRICT;
+      INSERT INTO preserved_sentinel (value) VALUES ('keep-me');
+      PRAGMA user_version = ${OPENCLAW_STATE_SCHEMA_VERSION + 1};
+    `);
+  } finally {
+    database.close();
+  }
+}
+
+async function createFixture(options: { futureSchema: boolean }): Promise<FutureSchemaFixture> {
+  tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-doctor-cron-schema-"));
+  vi.stubEnv("OPENCLAW_STATE_DIR", tempRoot);
+  const storePath = path.join(tempRoot, "cron", "jobs.json");
+  await fs.mkdir(path.dirname(storePath), { recursive: true });
+  await fs.writeFile(storePath, JSON.stringify({ version: 1, jobs: [] }), "utf8");
+
+  const databasePath = resolveOpenClawStateSqlitePath();
+  if (options.futureSchema) {
+    await writeFutureSchema(databasePath);
+  }
+
+  return {
+    cfg: { cron: { store: storePath } } as OpenClawConfig,
+    databasePath,
+    storePath,
+  };
+}
+
+async function snapshotFixture(databasePath: string) {
+  const database = new DatabaseSync(databasePath, { readOnly: true });
+  try {
+    const versionRow = database.prepare("PRAGMA user_version").get() as {
+      user_version: number;
+    };
+    const sentinelRow = database.prepare("SELECT value FROM preserved_sentinel").get() as {
+      value: string;
+    };
+    const bytes = await fs.readFile(databasePath);
+    const artifactNames = (await fs.readdir(path.dirname(databasePath))).toSorted();
+    return {
+      sha256: createHash("sha256").update(bytes).digest("hex"),
+      schemaVersion: versionRow.user_version,
+      sentinel: sentinelRow.value,
+      artifacts: Object.fromEntries(
+        await Promise.all(
+          artifactNames.map(async (name) => [
+            name,
+            createHash("sha256")
+              .update(await fs.readFile(path.join(path.dirname(databasePath), name)))
+              .digest("hex"),
+          ]),
+        ),
+      ),
+    };
+  } finally {
+    database.close();
+  }
+}
+
+async function expectSchemaRefusalWithoutMutation(
+  fixture: FutureSchemaFixture,
+  operation: () => Promise<unknown>,
+): Promise<void> {
+  const before = await snapshotFixture(fixture.databasePath);
+  let error: unknown;
+  try {
+    await operation();
+  } catch (caught) {
+    error = caught;
+  }
+  expect(isSqliteSchemaVersionError(error)).toBe(true);
+  await expect(snapshotFixture(fixture.databasePath)).resolves.toEqual(before);
+}
+
+describe("future shared-state schema safety", () => {
+  const entrypoints: Array<[string, (fixture: FutureSchemaFixture) => Promise<unknown>]> = [
+    [
+      "legacy cron health collection",
+      async ({ cfg }) => await collectLegacyCronStoreHealthFindings({ cfg }),
+    ],
+    [
+      "interactive legacy cron repair",
+      async ({ cfg }) =>
+        await maybeRepairLegacyCronStore({
+          cfg,
+          options: {},
+          prompter: { confirm: vi.fn() },
+        }),
+    ],
+    [
+      "non-interactive legacy cron repair",
+      async ({ cfg }) => await repairLegacyCronStoreWithoutPrompt({ cfg }),
+    ],
+    [
+      "Codex cron migration planning",
+      async ({ cfg }) => await collectCronCodexRuntimePolicyTargetsReadOnly({ cfg }),
+    ],
+    [
+      "Codex cron migration commit",
+      async ({ cfg }) => await repairCronCodexModelRefsAfterConfigWrite({ cfg }),
+    ],
+  ];
+
+  it.each(entrypoints)("fails closed without mutation during %s", async (_name, operation) => {
+    const fixture = await createFixture({ futureSchema: true });
+    await expectSchemaRefusalWithoutMutation(fixture, () => operation(fixture));
+  });
+
+  it("fails closed in non-interactive repair when no legacy files remain", async () => {
+    const fixture = await createFixture({ futureSchema: true });
+    await fs.rm(fixture.storePath);
+
+    await expectSchemaRefusalWithoutMutation(fixture, async () => {
+      await repairLegacyCronStoreWithoutPrompt({ cfg: fixture.cfg });
+    });
+  });
+
+  it("preserves active WAL artifacts while rejecting the future schema", async () => {
+    const fixture = await createFixture({ futureSchema: false });
+    await fs.mkdir(path.dirname(fixture.databasePath), { recursive: true });
+    fixtureDatabase = new DatabaseSync(fixture.databasePath);
+    fixtureDatabase.exec(`
+      PRAGMA journal_mode = WAL;
+      PRAGMA wal_autocheckpoint = 0;
+      CREATE TABLE preserved_sentinel (value TEXT NOT NULL) STRICT;
+      INSERT INTO preserved_sentinel (value) VALUES ('keep-me');
+      PRAGMA user_version = ${OPENCLAW_STATE_SCHEMA_VERSION + 1};
+    `);
+
+    await expectSchemaRefusalWithoutMutation(fixture, async () => {
+      await maybeRepairLegacyCronStore({
+        cfg: fixture.cfg,
+        options: {},
+        prompter: { confirm: vi.fn() },
+      });
+    });
+  });
+
+  it("fails closed if the schema advances between inspection and repair", async () => {
+    const fixture = await createFixture({ futureSchema: false });
+    const state = await loadLegacyCronRepairState({ cfg: fixture.cfg });
+    expect(state).not.toBeNull();
+    closeOpenClawStateDatabaseForTest();
+    await writeFutureSchema(fixture.databasePath);
+
+    await expectSchemaRefusalWithoutMutation(fixture, async () => {
+      await applyLegacyCronStoreRepair({ cfg: fixture.cfg, state: state! });
+    });
+  });
+});

--- a/src/commands/doctor/cron/schema-safety.ts
+++ b/src/commands/doctor/cron/schema-safety.ts
@@ -1,0 +1,12 @@
+import { isSqliteSchemaVersionError } from "../../../infra/sqlite-user-version.js";
+import { withExistingOpenClawStateDatabaseArtifactPreservingReadOnly } from "../../../state/openclaw-state-db-readonly.js";
+
+export function assertCronStateSchemaSupported(env?: NodeJS.ProcessEnv): void {
+  withExistingOpenClawStateDatabaseArtifactPreservingReadOnly(() => undefined, { env });
+}
+
+export function rethrowSqliteSchemaVersionError(error: unknown): void {
+  if (isSqliteSchemaVersionError(error)) {
+    throw error;
+  }
+}


### PR DESCRIPTION
## Summary

- fail closed when Doctor cron inspection or repair encounters a shared-state SQLite schema newer than this build supports
- perform an artifact-preserving, read-only schema preflight before Doctor cron reads, early no-op returns, and writable repair paths
- recheck at the apply boundary so a schema that advances after inspection also refuses safely
- preserve Doctor's existing warning-and-continue behavior for ordinary unreadable cron-store errors

This is intentionally scoped to `src/commands/doctor/cron/**`. It does not change runtime schema versions, migration policy, recovery behavior, sidecars, or persistence format.

## What Problem This Solves

Runtime database open already throws `SqliteSchemaVersionError` before mutating a newer database. Doctor's cron paths, however, had broad error catches that converted the same refusal into a warning such as "later health checks will continue." Writable Doctor paths could also open the source database before reliably establishing that its schema was supported.

The fix uses the canonical schema-version predicate at the Doctor cron boundary and inspects a private read-only SQLite snapshot first, including active WAL/SHM state.

## Evidence

Against current `main`, with supported schema `9` and a temporary fixture at schema `10`:

- runtime open: threw `SqliteSchemaVersionError`
- Doctor cron health path: resolved with a warning and continued
- source SHA-256 before/after: `f2a31cbd4b80d927c6560677785f10be76c599e06c42651210cd64ebc7000de8`
- `user_version`: remained `10`
- sentinel row: remained `keep-me`
- source artifacts: remained only `openclaw.sqlite`

On this PR head:

- runtime open: throws `SqliteSchemaVersionError`
- all five public Doctor cron entrypoints: throw `SqliteSchemaVersionError`
- the main database, active WAL, and SHM hashes remain unchanged
- the no-legacy/noninteractive path refuses before its previous early return
- apply refuses if the schema advances between inspection and repair

## Validation

- `pnpm exec vitest run src/commands/doctor/cron/schema-safety.test.ts src/commands/doctor/cron/index.test.ts src/commands/doctor/cron/legacy-repair.test.ts` — 75 passed
- `pnpm check:changed` — passed (format, lint, core typecheck, core-test typecheck)
- branch autoreview — clean
- separate read-only Codex follow-up review — clean

Closes #115421
