### PR TITLE
fix(whatsapp): resolve WA Web version from web.whatsapp.com to avoid 405 handshake rejections

### DIFF
--- a/extensions/whatsapp/src/session-version.test.ts
+++ b/extensions/whatsapp/src/session-version.test.ts
@@ -1,0 +1,47 @@
+// Whatsapp tests cover WA Web socket version resolution.
+import { describe, expect, it, vi } from "vitest";
+import { resolveWaSocketVersion } from "./session-version.js";
+import { fetchLatestBaileysVersion, fetchLatestWaWebVersion } from "./session.runtime.js";
+
+vi.mock("./session.runtime.js", async () => {
+  const actual =
+    await vi.importActual<typeof import("./session.runtime.js")>("./session.runtime.js");
+  return {
+    ...actual,
+    fetchLatestBaileysVersion: vi.fn(),
+    fetchLatestWaWebVersion: vi.fn(),
+  };
+});
+
+const fetchLiveMock = vi.mocked(fetchLatestWaWebVersion);
+const fetchPinnedMock = vi.mocked(fetchLatestBaileysVersion);
+
+function stubLogger() {
+  return { warn: vi.fn() };
+}
+
+describe("resolveWaSocketVersion", () => {
+  it("prefers the live web.whatsapp.com version", async () => {
+    fetchLiveMock.mockResolvedValueOnce({ version: [2, 3000, 999], isLatest: true });
+    await expect(resolveWaSocketVersion(stubLogger())).resolves.toEqual([2, 3000, 999]);
+    expect(fetchPinnedMock).not.toHaveBeenCalled();
+  });
+
+  it("falls back to the pinned Baileys version when the live lookup is not latest", async () => {
+    fetchLiveMock.mockResolvedValueOnce({
+      version: [2, 3000, 1],
+      isLatest: false,
+      error: { message: "Could not find client revision" },
+    } as never);
+    fetchPinnedMock.mockResolvedValueOnce({ version: [2, 3000, 2], isLatest: true });
+    const logger = stubLogger();
+    await expect(resolveWaSocketVersion(logger)).resolves.toEqual([2, 3000, 2]);
+    expect(logger.warn).toHaveBeenCalled();
+  });
+
+  it("falls back to the pinned Baileys version when the live lookup throws", async () => {
+    fetchLiveMock.mockRejectedValueOnce(new Error("network down"));
+    fetchPinnedMock.mockResolvedValueOnce({ version: [2, 3000, 3], isLatest: true });
+    await expect(resolveWaSocketVersion(stubLogger())).resolves.toEqual([2, 3000, 3]);
+  });
+});

--- a/extensions/whatsapp/src/session-version.ts
+++ b/extensions/whatsapp/src/session-version.ts
@@ -1,0 +1,29 @@
+// Whatsapp plugin module resolves the WA Web version used for the socket handshake.
+import { fetchLatestBaileysVersion, fetchLatestWaWebVersion } from "./session.runtime.js";
+
+/**
+ * WhatsApp rejects handshakes from stale WA Web versions with a 405, so ask
+ * web.whatsapp.com for the live version and only fall back to the pinned
+ * Baileys version list when the live lookup fails.
+ */
+export async function resolveWaSocketVersion(logger: {
+  warn: (obj: unknown, msg?: string) => void;
+}): Promise<Awaited<ReturnType<typeof fetchLatestBaileysVersion>>["version"]> {
+  try {
+    const live = await fetchLatestWaWebVersion({});
+    if (live.isLatest) {
+      return live.version;
+    }
+    logger.warn(
+      { error: (live as { error?: { message?: string } }).error?.message },
+      "live WA Web version lookup failed; falling back to pinned Baileys version",
+    );
+  } catch (err) {
+    logger.warn(
+      { error: String(err) },
+      "live WA Web version lookup failed; falling back to pinned Baileys version",
+    );
+  }
+  const pinned = await fetchLatestBaileysVersion();
+  return pinned.version;
+}

--- a/extensions/whatsapp/src/session.runtime.ts
+++ b/extensions/whatsapp/src/session.runtime.ts
@@ -10,6 +10,7 @@ export function createBaileysSignalRepository(
 export {
   BufferJSON,
   fetchLatestBaileysVersion,
+  fetchLatestWaWebVersion,
   makeCacheableSignalKeyStore,
   makeWASocket,
   useMultiFileAuthState,

--- a/extensions/whatsapp/src/session.ts
+++ b/extensions/whatsapp/src/session.ts
@@ -34,9 +34,9 @@ import {
 } from "./creds-persistence.js";
 import { renderQrTerminal } from "./qr-terminal.js";
 import { getStatusCode } from "./session-errors.js";
+import { resolveWaSocketVersion } from "./session-version.js";
 import {
   createBaileysSignalRepository,
-  fetchLatestBaileysVersion,
   makeCacheableSignalKeyStore,
   makeWASocket,
   useMultiFileAuthState,
@@ -257,7 +257,7 @@ async function createWaSocketInternal(
   const saveCreds = async () => {
     await writeCredsJsonAtomically(authDir, state.creds);
   };
-  const { version } = await fetchLatestBaileysVersion();
+  const version = await resolveWaSocketVersion(sessionLogger);
   const waWebSocketUrl = resolveWaWebSocketUrl(opts.waWebSocketUrl) ?? resolveEnvWaWebSocketUrl();
   const agent = await resolveEnvProxyAgent(sessionLogger);
   const fetchAgent = await resolveEnvFetchDispatcher(sessionLogger, agent);

--- a/test/mocks/baileys.ts
+++ b/test/mocks/baileys.ts
@@ -4,6 +4,7 @@ import { vi } from "vitest";
 
 type BaileysExports = typeof import("baileys");
 type FetchLatestBaileysVersionFn = BaileysExports["fetchLatestBaileysVersion"];
+type FetchLatestWaWebVersionFn = BaileysExports["fetchLatestWaWebVersion"];
 type MakeCacheableSignalKeyStoreFn = BaileysExports["makeCacheableSignalKeyStore"];
 type MakeWASocketFn = BaileysExports["makeWASocket"];
 type UseMultiFileAuthStateFn = BaileysExports["useMultiFileAuthState"];
@@ -34,6 +35,7 @@ type MockBaileysModule = {
   DisconnectReason: { loggedOut: number };
   extractMessageContent: ReturnType<typeof vi.fn<ExtractMessageContentFn>>;
   fetchLatestBaileysVersion: ReturnType<typeof vi.fn<FetchLatestBaileysVersionFn>>;
+  fetchLatestWaWebVersion: ReturnType<typeof vi.fn<FetchLatestWaWebVersionFn>>;
   getContentType: ReturnType<typeof vi.fn<GetContentTypeFn>>;
   isJidGroup: ReturnType<typeof vi.fn<IsJidGroupFn>>;
   makeCacheableSignalKeyStore: ReturnType<typeof vi.fn<MakeCacheableSignalKeyStoreFn>>;
@@ -163,6 +165,9 @@ export function createMockBaileys(): {
     ),
     fetchLatestBaileysVersion: vi
       .fn<FetchLatestBaileysVersionFn>()
+      .mockResolvedValue({ version: [1, 2, 3], isLatest: true }),
+    fetchLatestWaWebVersion: vi
+      .fn<FetchLatestWaWebVersionFn>()
       .mockResolvedValue({ version: [1, 2, 3], isLatest: true }),
     getContentType: vi.fn<GetContentTypeFn>((message) => mockGetContentType(message)),
     isJidGroup: vi.fn<IsJidGroupFn>((jid) => mockIsJidGroup(jid)),


### PR DESCRIPTION
## What

`createWaSocketInternal` resolves the WA Web version for the socket handshake from `web.whatsapp.com` (`fetchLatestWaWebVersion`) and only falls back to the pinned Baileys version list (`fetchLatestBaileysVersion`) when the live lookup fails or reports a non-latest result.

## What Problem This Solves

WhatsApp started rejecting handshakes from the version baked into `baileys@7.0.0-rc13` (`2.3000.1035194821`) with **status 405** during setup, while live `web.whatsapp.com` had moved on to `2.3000.1044015310`. Because `fetchLatestBaileysVersion()` returns that stale baked-in value when its remote fetch does not resolve, the WhatsApp channel wedges in a connect → 405 → reconnect loop and never pairs. This was a fleet-wide event, not a per-account problem — see WhiskeySockets/Baileys#2731.

Asking `web.whatsapp.com` for the current version first makes the handshake track WhatsApp's live rollout, so a version bump on their side no longer takes the channel down until the dependency is republished.

The fallback is deliberate: if the live lookup throws (network, proxy, WhatsApp changing the page shape) or comes back `isLatest: false`, we log a warning and use the pinned list exactly as before. No behavior is removed — the pinned path only stops being the *first* choice.

## Changes

- `extensions/whatsapp/src/session.runtime.ts` — re-export `fetchLatestWaWebVersion` alongside the existing Baileys runtime exports.
- `extensions/whatsapp/src/session-version.ts` — new module exporting `resolveWaSocketVersion(logger)`, which implements live-first / pinned-fallback.
- `extensions/whatsapp/src/session.ts` — `createWaSocketInternal` calls `resolveWaSocketVersion` instead of `fetchLatestBaileysVersion()` directly.
- `extensions/whatsapp/src/session-version.test.ts` — new unit tests for the three branches.
- `test/mocks/baileys.ts` — mock the new export so the existing WhatsApp suite keeps working.

`baileys@7.0.0-rc13` (the version this repo already pins) exports `fetchLatestWaWebVersion`, so no dependency change is needed.

## Evidence

- 3 new unit tests in `session-version.test.ts` cover: live version preferred (pinned fetch never called), fallback when the live lookup returns `isLatest: false`, fallback when the live lookup throws.
- Full WhatsApp extension suite on this branch at `upstream/main`: **98 files / 1169 tests, all passing** (`vitest.extension-whatsapp.config.ts`).
- `oxfmt --check` and `oxlint` clean on the touched files; `pnpm deadcode:full` (knip) passes.
- The fix has been running in a production deployment since the 405 event; the channel reconnected and has stayed paired.

## AI assistance

🤖 AI-assisted (Claude Code). I wrote the root-cause analysis and reviewed the patch; the diff is small and I understand what it does.
