### PR TITLE
fix(cli): preserve mid-turn text in durable replies

### DIFF
--- a/src/auto-reply/reply/agent-runner-cli-candidate.ts
+++ b/src/auto-reply/reply/agent-runner-cli-candidate.ts
@@ -35,7 +35,10 @@ import { isReplyOperationRestartAbort } from "./reply-operation-abort.js";
 
 type CliPresentation = Pick<
   ReturnType<typeof createAgentTurnPresentation>,
-  "handlePartialForTyping" | "preparePartialForTyping" | "startPresentationWhileTyping"
+  | "blockReplyHandler"
+  | "handlePartialForTyping"
+  | "preparePartialForTyping"
+  | "startPresentationWhileTyping"
 >;
 
 export async function runCliFallbackCandidate(params: {
@@ -118,6 +121,11 @@ export async function runCliFallbackCandidate(params: {
       await turn.opts?.onToolResult?.(payload);
     },
   });
+  const bridgeCliPreambleProgress =
+    Boolean(turn.opts?.onItemEvent) && shouldBridgeCliPreambleEvents(turn.opts);
+  const bridgeCliDurableCommentary =
+    Boolean(params.presentation.blockReplyHandler) &&
+    (turn.blockStreamingEnabled || turn.opts?.commentaryPayloadsEnabled === true);
   const result = await params.timing.measure("cli_run", () =>
     withLocalSessionPlacementTurnAdmission(
       {
@@ -205,13 +213,29 @@ export async function runCliFallbackCandidate(params: {
             ]);
           },
           onCommentaryText:
-            turn.opts?.onItemEvent && shouldBridgeCliPreambleEvents(turn.opts)
+            bridgeCliPreambleProgress || bridgeCliDurableCommentary
               ? async (payload) => {
-                  await turn.opts?.onItemEvent?.({
-                    itemId: payload.itemId,
-                    kind: "preamble",
-                    progressText: payload.text,
-                  });
+                  const deliveries: unknown[] = [];
+                  if (bridgeCliPreambleProgress) {
+                    deliveries.push(
+                      turn.opts?.onItemEvent?.({
+                        itemId: payload.itemId,
+                        kind: "preamble",
+                        progressText: payload.text,
+                      }),
+                    );
+                  }
+                  if (bridgeCliDurableCommentary) {
+                    // Block mode treats completed CLI text as an ordinary answer block so
+                    // the existing pipeline owns coalescing and final-payload dedupe.
+                    deliveries.push(
+                      params.presentation.blockReplyHandler?.({
+                        text: payload.text,
+                        ...(turn.blockStreamingEnabled ? {} : { isCommentary: true }),
+                      }),
+                    );
+                  }
+                  await Promise.all(deliveries);
                 }
               : undefined,
           onFastModeAutoProgress: async (payload) => {

--- a/src/auto-reply/reply/agent-runner-execution-cli-commentary.test.ts
+++ b/src/auto-reply/reply/agent-runner-execution-cli-commentary.test.ts
@@ -1,0 +1,148 @@
+import { describe, expect, it, vi } from "vitest";
+import type { TemplateContext } from "../templating.js";
+import type { GetReplyOptions } from "../types.js";
+import {
+  createFollowupRun,
+  createMockTypingSignaler,
+  getExecuteAgentTurnForTest,
+  setupAgentRunnerExecutionTestState,
+} from "./agent-runner-execution.test-support.js";
+import type { FallbackRunnerParams } from "./agent-runner-execution.test-support.js";
+
+const state = setupAgentRunnerExecutionTestState();
+
+function useClaudeCliFallback() {
+  state.isCliProviderMock.mockReturnValue(true);
+  state.runWithModelFallbackMock.mockImplementationOnce(async (params: FallbackRunnerParams) => ({
+    result: await params.run("claude-cli", "claude-opus-4-6"),
+    provider: "claude-cli",
+    model: "claude-opus-4-6",
+    attempts: [],
+  }));
+}
+
+function createClaudeCliFollowupRun() {
+  const followupRun = createFollowupRun();
+  followupRun.run.provider = "claude-cli";
+  followupRun.run.model = "claude-opus-4-6";
+  return followupRun;
+}
+
+function createTurnParams(opts: GetReplyOptions, blockStreamingEnabled: boolean) {
+  return {
+    commandBody: "hi",
+    followupRun: createClaudeCliFollowupRun(),
+    sessionCtx: { Provider: "telegram", MessageSid: "msg" } as unknown as TemplateContext,
+    opts,
+    typingSignals: createMockTypingSignaler(),
+    blockReplyPipeline: null,
+    blockStreamingEnabled,
+    resolvedBlockStreamingBreak: "message_end" as const,
+    applyReplyToMode: <T>(payload: T) => payload,
+    shouldEmitToolResult: () => true,
+    shouldEmitToolOutput: () => false,
+    pendingToolTasks: new Set<Promise<void>>(),
+    resetSessionAfterRoleOrderingConflict: async () => false,
+    isHeartbeat: false,
+    sessionKey: "main",
+    getActiveSessionEntry: () => undefined,
+    resolvedVerboseLevel: "off" as const,
+  };
+}
+
+describe("executeAgentTurn: CLI durable commentary", () => {
+  it("delivers completed CLI commentary through block streaming", async () => {
+    useClaudeCliFallback();
+    state.createBlockReplyDeliveryHandlerMock.mockImplementationOnce(
+      (params: { onBlockReply: NonNullable<GetReplyOptions["onBlockReply"]> }) =>
+        params.onBlockReply,
+    );
+    state.runCliAgentMock.mockImplementationOnce(
+      async (params: { runId: string; emitCommentaryText?: boolean }) => {
+        expect(params.emitCommentaryText).toBe(true);
+        const agentEvents = await import("../../infra/agent-events.js");
+        agentEvents.emitAgentEvent({
+          runId: params.runId,
+          stream: "item",
+          data: {
+            kind: "preamble",
+            itemId: "commentary-durable-1",
+            progressText: "The durable findings live here.",
+          },
+        });
+        return { payloads: [{ text: "Short final wrap-up." }], meta: {} };
+      },
+    );
+
+    const onBlockReply = vi.fn<NonNullable<GetReplyOptions["onBlockReply"]>>(async () => undefined);
+    const onItemEvent = vi.fn<NonNullable<GetReplyOptions["onItemEvent"]>>(async () => undefined);
+    const executeAgentTurn = await getExecuteAgentTurnForTest();
+    const result = await executeAgentTurn(
+      createTurnParams(
+        {
+          onBlockReply,
+          onItemEvent,
+          commentaryProgressEnabled: false,
+          progressPreambleEnabled: true,
+        },
+        true,
+      ),
+    );
+
+    await vi.waitFor(() => {
+      expect(onBlockReply).toHaveBeenCalledExactlyOnceWith({
+        text: "The durable findings live here.",
+      });
+      expect(onItemEvent).toHaveBeenCalledExactlyOnceWith({
+        itemId: "commentary-durable-1",
+        kind: "preamble",
+        progressText: "The durable findings live here.",
+      });
+    });
+    expect(result.kind).toBe("success");
+    if (result.kind === "success") {
+      expect(result.runResult.payloads).toEqual([{ text: "Short final wrap-up." }]);
+    }
+  });
+
+  it("delivers commentary payloads without block streaming", async () => {
+    useClaudeCliFallback();
+    state.createBlockReplyDeliveryHandlerMock.mockImplementationOnce(
+      (params: { onBlockReply: NonNullable<GetReplyOptions["onBlockReply"]> }) =>
+        params.onBlockReply,
+    );
+    state.runCliAgentMock.mockImplementationOnce(
+      async (params: { runId: string; emitCommentaryText?: boolean }) => {
+        expect(params.emitCommentaryText).toBe(true);
+        const agentEvents = await import("../../infra/agent-events.js");
+        agentEvents.emitAgentEvent({
+          runId: params.runId,
+          stream: "item",
+          data: {
+            kind: "preamble",
+            itemId: "commentary-payload-1",
+            progressText: "A durable commentary update.",
+          },
+        });
+        return { payloads: [{ text: "Final answer." }], meta: {} };
+      },
+    );
+
+    const onBlockReply = vi.fn<NonNullable<GetReplyOptions["onBlockReply"]>>(async () => undefined);
+    const executeAgentTurn = await getExecuteAgentTurnForTest();
+    const result = await executeAgentTurn(
+      createTurnParams({ onBlockReply, commentaryPayloadsEnabled: true }, false),
+    );
+
+    await vi.waitFor(() => {
+      expect(onBlockReply).toHaveBeenCalledExactlyOnceWith({
+        text: "A durable commentary update.",
+        isCommentary: true,
+      });
+    });
+    expect(result.kind).toBe("success");
+    if (result.kind === "success") {
+      expect(result.runResult.payloads).toEqual([{ text: "Final answer." }]);
+    }
+  });
+});

--- a/src/auto-reply/reply/agent-runner-execution-cli-commentary.test.ts
+++ b/src/auto-reply/reply/agent-runner-execution-cli-commentary.test.ts
@@ -1,4 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
+import { testing as cliBackendsTesting } from "../../agents/cli-backends.test-support.js";
+import type { RunCliAgentParams } from "../../agents/cli-runner/types.js";
 import type { TemplateContext } from "../templating.js";
 import type { GetReplyOptions } from "../types.js";
 import {
@@ -11,6 +13,43 @@ import type { FallbackRunnerParams } from "./agent-runner-execution.test-support
 
 const state = setupAgentRunnerExecutionTestState();
 
+const scriptedCliProgram = String.raw`
+let input = "";
+process.stdin.setEncoding("utf8");
+process.stdin.on("data", (chunk) => { input += chunk; });
+process.stdin.on("end", () => {
+  if (!input.trim()) process.exit(2);
+  const events = [
+    { type: "init", session_id: "scripted-commentary" },
+    {
+      type: "stream_event",
+      event: {
+        type: "content_block_delta",
+        delta: { type: "text_delta", text: "The subprocess findings are durable." },
+      },
+    },
+    {
+      type: "stream_event",
+      event: {
+        type: "content_block_start",
+        index: 1,
+        content_block: { type: "tool_use", id: "tool-scripted", name: "Read", input: {} },
+      },
+    },
+    {
+      type: "stream_event",
+      event: {
+        type: "content_block_delta",
+        delta: { type: "text_delta", text: "Subprocess final answer." },
+      },
+    },
+    { type: "stream_event", event: { type: "message_stop" } },
+    { type: "result", session_id: "scripted-commentary", result: "Subprocess final answer." },
+  ];
+  process.stdout.write(events.map((event) => JSON.stringify(event)).join("\n") + "\n");
+});
+`;
+
 function useClaudeCliFallback() {
   state.isCliProviderMock.mockReturnValue(true);
   state.runWithModelFallbackMock.mockImplementationOnce(async (params: FallbackRunnerParams) => ({
@@ -21,10 +60,41 @@ function useClaudeCliFallback() {
   }));
 }
 
+function useScriptedClaudeCliBackend() {
+  const backend = {
+    id: "claude-cli",
+    modelProvider: "anthropic",
+    pluginId: "anthropic",
+    bundleMcp: false,
+    config: {
+      command: process.execPath,
+      args: ["-e", scriptedCliProgram],
+      input: "stdin" as const,
+      output: "jsonl" as const,
+      jsonlDialect: "claude-stream-json" as const,
+      sessionMode: "none" as const,
+      systemPromptWhen: "never" as const,
+    },
+  };
+  cliBackendsTesting.setDepsForTest({
+    resolvePluginSetupCliBackend: ({ backend: id }) =>
+      id === backend.id ? { pluginId: backend.pluginId, backend } : undefined,
+    resolveRuntimeCliBackends: () => [backend],
+  });
+  state.runCliAgentMock.mockImplementationOnce(async (params: RunCliAgentParams) => {
+    if (!state.runCliAgentActual) {
+      throw new Error("real CLI runner was not initialized");
+    }
+    return await state.runCliAgentActual(params);
+  });
+}
+
 function createClaudeCliFollowupRun() {
   const followupRun = createFollowupRun();
   followupRun.run.provider = "claude-cli";
   followupRun.run.model = "claude-opus-4-6";
+  followupRun.run.skillsSnapshot = { prompt: "", skills: [], version: 0 };
+  followupRun.run.timeoutMs = 10_000;
   return followupRun;
 }
 
@@ -51,6 +121,27 @@ function createTurnParams(opts: GetReplyOptions, blockStreamingEnabled: boolean)
 }
 
 describe("executeAgentTurn: CLI durable commentary", () => {
+  it("delivers commentary from a real JSONL CLI subprocess", async () => {
+    useClaudeCliFallback();
+    useScriptedClaudeCliBackend();
+    state.createBlockReplyDeliveryHandlerMock.mockImplementationOnce(
+      (params: { onBlockReply: NonNullable<GetReplyOptions["onBlockReply"]> }) =>
+        params.onBlockReply,
+    );
+    const onBlockReply = vi.fn<NonNullable<GetReplyOptions["onBlockReply"]>>(async () => undefined);
+    const executeAgentTurn = await getExecuteAgentTurnForTest();
+    const result = await executeAgentTurn(createTurnParams({ onBlockReply }, true));
+
+    expect(state.runCliAgentMock.mock.calls[0]?.[0]).toMatchObject({ emitCommentaryText: true });
+    expect(result.kind).toBe("success");
+    if (result.kind === "success") {
+      expect(result.runResult.payloads).toEqual([{ text: "Subprocess final answer." }]);
+    }
+    expect(onBlockReply).toHaveBeenCalledExactlyOnceWith({
+      text: "The subprocess findings are durable.",
+    });
+  });
+
   it("delivers completed CLI commentary through block streaming", async () => {
     useClaudeCliFallback();
     state.createBlockReplyDeliveryHandlerMock.mockImplementationOnce(

--- a/src/auto-reply/reply/agent-runner-execution.test-support.ts
+++ b/src/auto-reply/reply/agent-runner-execution.test-support.ts
@@ -20,6 +20,7 @@ import type { TypingSignaler } from "./typing-mode.js";
 type RunEntryParams = Parameters<typeof runEmbeddedAgentEntry<EmbeddedAgentRunResult>>[0];
 type RunEntryResult = Awaited<ReturnType<typeof runEmbeddedAgentEntry<EmbeddedAgentRunResult>>>;
 type RunEntryDelegate = (params: RunEntryParams) => Promise<RunEntryResult>;
+type RunCliAgent = typeof import("../../agents/cli-runner.js").runCliAgent;
 
 export const PROVIDER_AUTHENTICATION_ERROR_USER_MESSAGE = `⚠️ ${AUTH_INVALID_TOKEN_USER_TEXT}`;
 export const PROVIDER_RATE_LIMIT_OR_QUOTA_ERROR_USER_MESSAGE =
@@ -31,6 +32,7 @@ const state = vi.hoisted(() => ({
   runEmbeddedAgentMock: vi.fn(),
   runEmbeddedAgentEntryMock: vi.fn(),
   runCliAgentMock: vi.fn(),
+  runCliAgentActual: undefined as RunCliAgent | undefined,
   runWithModelFallbackMock: vi.fn(),
   isCliProviderMock: vi.fn((_: unknown) => false),
   isInternalMessageChannelMock: vi.fn((_: unknown) => false),
@@ -77,9 +79,16 @@ vi.mock("../../agents/agent-bundle-mcp-manager-api.js", () => ({
   peekSessionMcpRuntime: (params: unknown) => state.peekSessionMcpRuntimeMock(params),
 }));
 
-vi.mock("../../agents/cli-runner.js", () => ({
-  runCliAgent: (params: unknown) => state.runCliAgentMock(params),
-}));
+vi.mock("../../agents/cli-runner.js", async () => {
+  const actual = await vi.importActual<typeof import("../../agents/cli-runner.js")>(
+    "../../agents/cli-runner.js",
+  );
+  state.runCliAgentActual = actual.runCliAgent;
+  return {
+    ...actual,
+    runCliAgent: (params: unknown) => state.runCliAgentMock(params),
+  };
+});
 
 vi.mock("../../agents/model-fallback-runner.js", () => ({
   runWithModelFallback: (params: unknown) => state.runWithModelFallbackMock(params),
@@ -102,7 +111,10 @@ vi.mock("../../agents/model-selection.js", async () => {
   };
 });
 
-vi.mock("../../agents/bootstrap-budget.js", () => ({
+vi.mock("../../agents/bootstrap-budget.js", async () => ({
+  ...(await vi.importActual<typeof import("../../agents/bootstrap-budget.js")>(
+    "../../agents/bootstrap-budget.js",
+  )),
   resolveBootstrapWarningSignaturesSeen: () => [],
 }));
 
@@ -111,6 +123,7 @@ vi.mock("../../agents/embedded-agent-helpers.js", async () => {
     "../../agents/embedded-agent-helpers.js",
   );
   return {
+    ...actual,
     BILLING_ERROR_USER_MESSAGE: "billing",
     formatBillingErrorMessage: actual.formatBillingErrorMessage,
     formatRateLimitOrOverloadedErrorCopy: (message: string) => {
@@ -144,7 +157,8 @@ vi.mock("../../config/sessions.js", () => ({
   updateSessionStore: state.updateSessionStoreMock,
 }));
 
-vi.mock("../../globals.js", () => ({
+vi.mock("../../globals.js", async () => ({
+  ...(await vi.importActual<typeof import("../../globals.js")>("../../globals.js")),
   logVerbose: vi.fn(),
 }));
 
@@ -169,7 +183,10 @@ vi.mock("../../runtime.js", () => ({
   },
 }));
 
-vi.mock("../../utils/message-channel.js", () => ({
+vi.mock("../../utils/message-channel.js", async () => ({
+  ...(await vi.importActual<typeof import("../../utils/message-channel.js")>(
+    "../../utils/message-channel.js",
+  )),
   isMarkdownCapableMessageChannel: () => true,
   resolveMessageChannel: () => "whatsapp",
   isInternalMessageChannel: (value: unknown) => state.isInternalMessageChannelMock(value),


### PR DESCRIPTION
Closes #110067
Related: #106760

## What Problem This Solves

Fixes an issue where users of CLI-backed agents could lose substantive assistant text from durable channel replies when the model wrote that text before a tool call and ended the turn with a short final wrap-up.

## Why This Change Was Made

Completed CLI commentary now enters the existing shared block-reply delivery owner. Block-streaming turns treat it as an ordinary answer block so the established coalescing and final-payload dedupe rules apply; channels that explicitly enable commentary payloads can receive the same text as durable commentary without enabling block streaming. The transient preamble-progress projection remains independent and can run alongside durable delivery.

This keeps the fix provider- and channel-neutral, adds no config surface, and avoids reconstructing full accumulated CLI output at the end of the turn.

## User Impact

Long CLI-backed tool runs can preserve their substantive mid-turn narration instead of leaving operators with only a terse final sentence. Existing progress drafts continue to work as before.

## Evidence

- `node scripts/run-vitest.mjs src/agents/cli-output.test.ts src/agents/cli-runner.spawn.test.ts src/auto-reply/reply/agent-runner-execution-cli-progress.test.ts src/auto-reply/reply/agent-runner-execution-cli-commentary.test.ts` — 188 tests passed on the final head.
- The new regression launches a real scripted `stream-json` CLI subprocess, exercises the production parser/lifecycle bridge, and verifies both the durable commentary block and distinct final answer.
- `OPENCLAW_HEAVY_CHECK_LOCK_SCOPE=worktree node scripts/check-changed.mjs` — passed on Blacksmith Testbox `tbx_01kynm9xp2ewcm0f6egaxt3r7v`; typecheck, lint, formatting, dead-code, boundary, and repository guards all clean.
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main` — clean; no accepted/actionable findings, confidence 0.91.

AI-assisted implementation; I reviewed the full delivery path and validation output.
