### PR TITLE
refactor(code-mode): make suspended-run teardown linear

### DIFF
--- a/src/agents/code-mode-state.ts
+++ b/src/agents/code-mode-state.ts
@@ -38,7 +38,6 @@ type CodeModeRunState = {
   output: unknown[];
   // Retain all output for cumulative limits, but never replay blocks already returned to the model.
   deliveredOutputCount: number;
-  createdAt: number;
   expiresAt: number;
   agentWaitRetainUntil?: number;
   runtime: ToolSearchRuntime;
@@ -109,9 +108,10 @@ export function disposeCodeModeRun(runId: string): void {
 
 /** Cancel suspended bridge work before its Gateway-owned runtimes disappear. */
 export function disposeAllCodeModeRuns(): void {
-  for (const runId of activeRuns.keys()) {
-    disposeCodeModeRun(runId);
-  }
+  activeRuns.forEach((state) => cancelPendingBridgeStates(state.pending));
+  activeRuns.clear();
+  resumingRunIds.clear();
+  scheduleActiveRunExpiry();
 }
 
 /** Advance the snapshot frontier before exposing output to a wait observer. */
@@ -158,16 +158,13 @@ export function waitForPendingBridgeSettlement(
   settlementMode: CodeModeSettlementMode,
 ): Promise<void> {
   const required = pendingBridgeStatesForSettlement(pending, settlementMode);
+  const outstanding = required.filter((entry) => !entry.settled);
   // Workers reject hostless pending guests; headless execution also validates
   // the frontier before reaching this shared settlement helper.
   if (
-    required.length === 0 ||
-    (settlementMode.kind === "awaiting" && required.some((entry) => entry.settled))
+    outstanding.length === 0 ||
+    (settlementMode.kind === "awaiting" && outstanding.length !== required.length)
   ) {
-    return Promise.resolve();
-  }
-  const outstanding = required.filter((entry) => !entry.settled);
-  if (outstanding.length === 0) {
     return Promise.resolve();
   }
   const settlement =
@@ -377,7 +374,6 @@ export function storeSnapshotState(params: {
     replaySafe: params.replaySafe,
     output: params.output,
     deliveredOutputCount: params.output.length,
-    createdAt: now,
     expiresAt,
     agentWaitRetainUntil,
     runtime: params.runtime,

--- a/src/agents/code-mode-worker-lifecycle.test.ts
+++ b/src/agents/code-mode-worker-lifecycle.test.ts
@@ -90,15 +90,18 @@ describe("Code Mode worker lifecycle", () => {
     expect(() => reserveActiveRunSlot()).toThrow("too many suspended code mode runs");
     expect(vi.getTimerCount()).toBe(1);
 
+    const clearExpiryTimer = vi.spyOn(globalThis, "clearTimeout");
     disposeAllCodeModeRuns();
     disposeAllCodeModeRuns();
 
     expect(firstCancel).toHaveBeenCalledOnce();
     expect(secondCancel).toHaveBeenCalledOnce();
+    expect(clearExpiryTimer).toHaveBeenCalledOnce();
     expect(activeRuns.size).toBe(0);
     expect(resumingRunIds.has(firstRunId)).toBe(false);
     expect(resumingRunIds.has(secondRunId)).toBe(false);
     expect(vi.getTimerCount()).toBe(0);
+    clearExpiryTimer.mockRestore();
 
     const releaseFreedSlot = reserveActiveRunSlot();
     releaseFreedSlot();


### PR DESCRIPTION
## What Problem This Solves

Suspended Code Mode runs repeatedly rescheduled expiration while a gateway was shutting down, turning teardown of a full run registry into unnecessary quadratic work.

## Why This Change Was Made

Cancel and clear suspended runs in one canonical synchronous teardown, then reschedule expiration once. Remove the unused run creation timestamp and preserve run capacity, cancellation ownership, and idempotent cleanup.

## User Impact

Gateway shutdown is more predictable under Code Mode load. The production implementation is four lines smaller.

## Evidence

- Independent fresh autoreview: no actionable findings.
- Blacksmith Testbox: 26 passing Code Mode lifecycle and swarm tests.
- Regression covers 64-run teardown, exactly-once timer cleanup, and repeated shutdown.
- Directly verified upstream Codex session lifecycle and cell callback cancellation contracts.
