### PR TITLE
fix(ui): prevent leaked dashboard subscriptions on pane lifecycle changes

### DIFF
--- a/ui/src/lib/board/provider.test.ts
+++ b/ui/src/lib/board/provider.test.ts
@@ -70,55 +70,6 @@ describe("board providers", () => {
     });
   });
 
-  it("keeps older gateways without board methods on the null provider", () => {
-    mockLocation.search = "";
-    const provider = boardProviderForSession("agent:main:legacy", {} as never, false);
-
-    expect(provider.canPinWidgets).toBe(false);
-    expect(boardExists(provider.snapshot$.value)).toBe(false);
-  });
-
-  it("keeps the cached gateway transport stable across consumer capability profiles", () => {
-    mockLocation.search = "";
-    const client = {
-      request: vi.fn(),
-      addEventListener: vi.fn(() => () => {}),
-    };
-    const provider = boardProviderForSession(
-      "agent:main:pin-capability",
-      client as never,
-      true,
-      false,
-      false,
-    );
-
-    expect(provider.canPinWidgets).toBe(false);
-    expect(provider.canPinMcpApps).toBe(false);
-    expect(
-      boardProviderForSession(
-        "agent:main:pin-capability",
-        client as never,
-        true,
-        false,
-        true,
-        false,
-      ),
-    ).toBe(provider);
-    expect(provider.canPinWidgets).toBe(false);
-    expect(provider.canPinMcpApps).toBe(false);
-    expect(
-      boardProviderForSession(
-        "agent:main:pin-capability",
-        client as never,
-        true,
-        false,
-        true,
-        true,
-      ),
-    ).toBe(provider);
-    expect(provider.canPinMcpApps).toBe(false);
-  });
-
   registerBoardProviderLeaseCases(() => {
     mockLocation.search = "";
   });

--- a/ui/src/lib/board/provider.ts
+++ b/ui/src/lib/board/provider.ts
@@ -384,16 +384,9 @@ export function boardProviderCacheKey(sessionKey: string): string {
   return normalized === "main" ? buildAgentMainSessionKey({ agentId: "main" }) : normalized;
 }
 
-export function boardProviderForSession(
-  sessionKey: string,
-  client?: BoardGatewayClient | null,
-  available = true,
-  connected = true,
-  canPinWidgets = available,
-  canPinMcpApps = false,
-  canMutate = available,
-  canGrant = available,
-): BoardProvider {
+// Session lookups are read-only: only a lifecycle-owned lease may create and
+// subscribe a gateway transport, so hidden panes cannot orphan subscriptions.
+export function boardProviderForSession(sessionKey: string, available = true): BoardProvider {
   const key = boardProviderCacheKey(sessionKey);
   const mockScope = resolveMockBoardScope();
   if (mockScope && isMockBoardSession(key)) {
@@ -408,34 +401,7 @@ export function boardProviderForSession(
     }
     return provider;
   }
-  if (!available) {
-    let provider = nullProviders.get(key);
-    if (!provider) {
-      provider = new NullProvider(key);
-      nullProviders.set(key, provider);
-    }
-    return provider;
-  }
-  if (client) {
-    let entry = gatewayProviders.get(key);
-    if (!entry) {
-      const provider = new GatewayBoardProvider(
-        key,
-        client,
-        connected,
-        canPinWidgets,
-        canPinMcpApps,
-        canMutate,
-        canGrant,
-      );
-      entry = { provider, consumers: 0 };
-      gatewayProviders.set(key, entry);
-    } else {
-      entry.provider.attachClient(client, connected);
-    }
-    return entry.provider;
-  }
-  const gatewayProvider = gatewayProviders.get(key)?.provider;
+  const gatewayProvider = available ? gatewayProviders.get(key)?.provider : undefined;
   if (gatewayProvider) {
     return gatewayProvider;
   }
@@ -467,19 +433,16 @@ export function acquireBoardProviderForSession(
   canGrant = true,
 ): BoardProviderLease {
   const key = boardProviderCacheKey(sessionKey);
-  const provider = boardProviderForSession(
-    key,
-    client,
-    true,
-    connected,
-    canPinWidgets,
-    canPinMcpApps,
-    canMutate,
-    canGrant,
-  );
-  const entry = gatewayProviders.get(key);
-  if (!entry || entry.provider !== provider) {
+  const provider = boardProviderForSession(key);
+  if (provider instanceof MockBoardProvider) {
     return { provider, update: () => undefined, release: () => undefined };
+  }
+  let entry = gatewayProviders.get(key);
+  if (!entry) {
+    entry = { provider: new GatewayBoardProvider(key, client, connected), consumers: 0 };
+    gatewayProviders.set(key, entry);
+  } else {
+    entry.provider.attachClient(client, connected);
   }
   const scopedProvider = new ScopedGatewayBoardProvider(entry.provider, {
     canPinWidgets,

--- a/ui/src/pages/chat/chat-pane-board.test.ts
+++ b/ui/src/pages/chat/chat-pane-board.test.ts
@@ -534,6 +534,113 @@ describe("chat pane board shell", () => {
     expect(pane.resolveBoardProvider().snapshot$.value.sessionKey).toBe("agent:work:primary");
   });
 
+  it("does not subscribe to a gateway board before the pane owns a lifecycle lease", async () => {
+    window.history.replaceState({}, "", "/");
+    const pane = createTestPane();
+    const sessionKey = "agent:main:board-lifecycle-ownership";
+    const snapshot = { sessionKey, revision: 1, tabs: [], widgets: [] };
+    const removeListener = vi.fn();
+    const request = vi.fn(async () => snapshot);
+    const addEventListener = vi.fn(() => removeListener);
+    const client = { request, addEventListener } as unknown as GatewayBrowserClient;
+    pane.state.sessionKey = sessionKey;
+    pane.context = {
+      ...pane.context,
+      gateway: {
+        snapshot: {
+          client,
+          phase: "connected",
+          hello: {
+            auth: { role: "operator", scopes: ["operator.read", "operator.write"] },
+            features: { methods: ["board.get"] },
+          },
+        },
+      },
+    } as unknown as ApplicationContext;
+
+    expect(pane.resolveBoardProvider().snapshot$.value.sessionKey).toBe(sessionKey);
+    expect(request).not.toHaveBeenCalled();
+    expect(addEventListener).not.toHaveBeenCalled();
+
+    Reflect.set(pane, "boardProviderLifecycleConnected", true);
+    const provider = pane.resolveBoardProvider();
+    try {
+      await vi.waitFor(() => expect(provider.snapshot$.value).toEqual(snapshot));
+      expect(request).toHaveBeenCalledOnce();
+      expect(addEventListener).toHaveBeenCalledOnce();
+    } finally {
+      const release = Reflect.get(pane, "releaseBoardProviderLease") as () => void;
+      release.call(pane);
+    }
+
+    expect(removeListener).toHaveBeenCalledOnce();
+  });
+
+  it("keeps gateways without board support on the null provider", () => {
+    window.history.replaceState({}, "", "/");
+    const pane = createTestPane();
+    const sessionKey = "agent:main:board-unsupported";
+    const request = vi.fn();
+    const addEventListener = vi.fn(() => () => {});
+    const client = { request, addEventListener } as unknown as GatewayBrowserClient;
+    pane.state.sessionKey = sessionKey;
+    Reflect.set(pane, "boardProviderLifecycleConnected", true);
+    pane.context = {
+      ...pane.context,
+      gateway: {
+        snapshot: {
+          client,
+          phase: "connected",
+          hello: { features: { methods: ["chat.history"] } },
+        },
+      },
+    } as unknown as ApplicationContext;
+
+    expect(pane.resolveBoardProvider()).toMatchObject({
+      canMutate: false,
+      canGrant: false,
+      canPinWidgets: false,
+      canPinMcpApps: false,
+    });
+    expect(request).not.toHaveBeenCalled();
+    expect(addEventListener).not.toHaveBeenCalled();
+  });
+
+  it("does not reuse another board lease after gateway board support disappears", () => {
+    window.history.replaceState({}, "", "/");
+    const pane = createTestPane();
+    const sessionKey = "agent:main:board-support-revoked";
+    const snapshot = { sessionKey, revision: 1, tabs: [], widgets: [] };
+    const request = vi.fn(async () => snapshot);
+    const addEventListener = vi.fn(() => () => {});
+    const client = { request, addEventListener } as unknown as GatewayBrowserClient;
+    pane.state.sessionKey = sessionKey;
+    Reflect.set(pane, "boardProviderLifecycleConnected", true);
+    pane.context = {
+      ...pane.context,
+      gateway: {
+        snapshot: {
+          client,
+          phase: "connected",
+          hello: { features: { methods: ["chat.history"] } },
+        },
+      },
+    } as unknown as ApplicationContext;
+
+    const otherConsumer = acquireBoardProviderForSession(sessionKey, client);
+    try {
+      expect(pane.resolveBoardProvider()).toMatchObject({
+        canMutate: false,
+        canGrant: false,
+        canPinWidgets: false,
+        canPinMcpApps: false,
+      });
+      expect(addEventListener).toHaveBeenCalledOnce();
+    } finally {
+      otherConsumer.release();
+    }
+  });
+
   it("enables MCP App pinning only when app-view and put methods are both advertised", () => {
     window.history.replaceState({}, "", "/");
     const cases = [
@@ -548,6 +655,7 @@ describe("chat pane board shell", () => {
 
     for (const testCase of cases) {
       const pane = createTestPane();
+      Reflect.set(pane, "boardProviderLifecycleConnected", true);
       const sessionKey = `agent:main:${testCase.suffix}`;
       const client = {
         request: vi.fn(async () => ({ sessionKey, revision: 0, tabs: [], widgets: [] })),
@@ -682,6 +790,7 @@ describe("chat pane board shell", () => {
   ])("derives board actions from the $profile connection scopes", (profile) => {
     window.history.replaceState({}, "", "/");
     const pane = createTestPane();
+    Reflect.set(pane, "boardProviderLifecycleConnected", true);
     const sessionKey = `agent:main:scope-${profile.profile.replaceAll(" ", "-")}`;
     const client = {
       request: vi.fn(async () => ({ sessionKey, revision: 0, tabs: [], widgets: [] })),

--- a/ui/src/pages/chat/chat-pane-board.ts
+++ b/ui/src/pages/chat/chat-pane-board.ts
@@ -199,16 +199,7 @@ export abstract class ChatPaneBoard extends ChatPaneHistory {
       return this.boardProviderLease.provider;
     }
     this.releaseBoardProviderLease();
-    return boardProviderForSession(
-      sessionKey,
-      client,
-      available,
-      gateway?.phase === "connected",
-      canPinWidgets,
-      canPinMcpApps,
-      canMutate,
-      canGrant,
-    );
+    return boardProviderForSession(sessionKey, available);
   }
 
   protected releaseBoardProviderLease(): void {


### PR DESCRIPTION
Related: #115364

AI-assisted; independently reviewed with the repository's structured autoreview workflow.

## What Problem This Solves

Fixes an issue where opening or replacing a chat pane could start a session dashboard request and Gateway event subscription before that pane had a mounted lifecycle owner. The obsolete provider-creation path left the subscription outside the dashboard lease, and a Gateway that lost dashboard support could incorrectly expose another consumer's cached transport.

## Why This Change Was Made

Complete the session-dashboard ownership refactor from #115364: ordinary board lookup is read-only, and the lifecycle-owned lease is the single production path that creates, connects, shares, and releases a Gateway dashboard transport. Preserve independent per-consumer permissions, cached sidebar availability, mock dashboards, unsupported older Gateways, and shared Workboard consumers. Delete the obsolete eight-argument factory path and the two tests that only protected that retired implementation.

## User Impact

Switching, reconnecting, or unmounting chat and Workboard dashboards no longer leaks hidden Gateway subscriptions or inherits stale dashboard capabilities. Unsupported Gateways continue to show the safe chat-only dashboard state.

## Evidence

- Reproduced on current `main`: the new lifecycle regression failed because resolving an unmounted pane immediately called `board.get` and subscribed to Gateway events.
- After the fix, the regression proves zero pre-mount requests/subscriptions, exactly one mounted request/subscription, and exactly one unsubscribe on release.
- Additional regression proves revoking board support never exposes another consumer's still-cached transport.
- `FS_SAFE_NATIVE_MODE=off NODE_NO_WARNINGS=1 OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs run --config test/vitest/vitest.ui.config.ts --configLoader runner --reporter=dot ui/src/lib/board/provider.test.ts ui/src/lib/board/gateway-provider.test.ts ui/src/lib/board/availability-controller.test.ts ui/src/pages/chat/chat-pane-board.test.ts ui/src/pages/workboard/workboard-card-dashboard.test.ts` (using the existing shared dependency install) — **5 files, 80 tests passed**.
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.ui.config.ts --configLoader runner --reporter=dot ui/src/lib/board/provider.mcp-app.test.ts ui/src/pages/chat/board-session-surface.test.ts` — **2 additional sibling suites, 11 tests passed**.
- Type-aware Oxlint and Oxfmt checks passed for all four changed files; `git diff --check` passed.
- Fresh structured autoreview: **clean; no accepted or actionable findings**.
- Net production change: **46 lines removed**. No config, public protocol, persistent state, migration, or plugin SDK changes.
