### PR TITLE
refactor(code-mode): isolate tool catalogs per run

### DIFF
--- a/src/agents/embedded-agent-runner/run/attempt.tool-search-catalog-abort.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.tool-search-catalog-abort.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
-import { testing as toolSearchTesting } from "../../tool-search.test-support.js";
+import type { ToolSearchCatalogRef } from "../../tool-search.js";
 import {
   cleanupTempPaths,
   createContextEngineAttemptRunner,
@@ -29,6 +29,16 @@ function catalogProbeTools() {
   ];
 }
 
+function requireAttemptCatalogRef(): ToolSearchCatalogRef {
+  const options = hoisted.createOpenClawCodingToolsMock.mock.calls.at(-1)?.[0] as
+    | { toolSearchCatalogRef?: ToolSearchCatalogRef }
+    | undefined;
+  if (!options?.toolSearchCatalogRef) {
+    throw new Error("Expected the embedded attempt to own its Tool Search catalog");
+  }
+  return options.toolSearchCatalogRef;
+}
+
 describe("runEmbeddedAttempt tool-search catalog cleanup", () => {
   beforeAll(async () => {
     await preloadRunEmbeddedAttemptForTests();
@@ -36,13 +46,11 @@ describe("runEmbeddedAttempt tool-search catalog cleanup", () => {
 
   beforeEach(() => {
     resetEmbeddedAttemptHarness();
-    toolSearchTesting.sessionCatalogs.clear();
   });
 
   afterEach(async () => {
     await cleanupTempPaths(tempPaths);
     tempPaths.length = 0;
-    toolSearchTesting.sessionCatalogs.clear();
   });
 
   it("clears the registered run catalog when the run aborts during prep", async () => {
@@ -79,14 +87,15 @@ describe("runEmbeddedAttempt tool-search catalog cleanup", () => {
       },
     });
     await lockRequested;
-    // Guards the test itself: without a registered catalog the assertion below
-    // would pass vacuously.
-    expect([...toolSearchTesting.sessionCatalogs.keys()]).toContain(`run:${runId}`);
+    const catalogRef = requireAttemptCatalogRef();
+    expect(catalogRef.current?.entries).toContainEqual(
+      expect.objectContaining({ name: "cataloged_probe_tool" }),
+    );
 
     abortController.abort(abortError);
     await expect(attempt).rejects.toBe(abortError);
 
-    expect(toolSearchTesting.sessionCatalogs.has(`run:${runId}`)).toBe(false);
+    expect(catalogRef.current).toBeUndefined();
   });
 
   it.each([
@@ -107,9 +116,12 @@ describe("runEmbeddedAttempt tool-search catalog cleanup", () => {
     async ({ mode, tools }) => {
       const runId = `run-catalog-diagnostics-${mode}`;
       const diagnosticsError = new Error(`failed ${mode} tool diagnostics`);
-      let catalogRegisteredBeforeFailure = false;
+      let catalogRef: ToolSearchCatalogRef | undefined;
       const logDiagnostics = vi.fn(() => {
-        catalogRegisteredBeforeFailure = toolSearchTesting.sessionCatalogs.has(`run:${runId}`);
+        catalogRef = requireAttemptCatalogRef();
+        expect(catalogRef.current?.entries).toContainEqual(
+          expect.objectContaining({ name: "cataloged_probe_tool" }),
+        );
         throw diagnosticsError;
       });
       hoisted.createOpenClawCodingToolsMock.mockImplementation(() => catalogProbeTools());
@@ -133,8 +145,8 @@ describe("runEmbeddedAttempt tool-search catalog cleanup", () => {
 
       await expect(attempt).rejects.toBe(diagnosticsError);
       expect(logDiagnostics).toHaveBeenCalledOnce();
-      expect(catalogRegisteredBeforeFailure).toBe(true);
-      expect(toolSearchTesting.sessionCatalogs.has(`run:${runId}`)).toBe(false);
+      expect(catalogRef).toBeDefined();
+      expect(catalogRef?.current).toBeUndefined();
     },
   );
 });

--- a/src/agents/embedded-agent-runner/tool-name-allowlist.test.ts
+++ b/src/agents/embedded-agent-runner/tool-name-allowlist.test.ts
@@ -6,6 +6,7 @@ import { createStubTool } from "../test-helpers/agent-tool-stubs.js";
 import {
   addClientToolsToToolSearchCatalog,
   applyToolSearchCatalog,
+  createToolSearchCatalogRef,
   TOOL_SEARCH_CODE_MODE_TOOL_NAME,
 } from "../tool-search.js";
 import type { ClientToolDefinition } from "./run/params.js";
@@ -68,6 +69,7 @@ describe("tool name allowlists", () => {
       tools: uncompactedTools,
       config: { tools: { toolSearch: true } } as never,
       sessionId: "session-conflict-admission",
+      catalogRef: createToolSearchCatalogRef(),
     });
     const names = collectCoreBuiltinToolNames(uncompactedTools);
 
@@ -125,10 +127,12 @@ describe("tool name allowlists", () => {
 
   it("excludes client tool names when Tool Search compacts them into the catalog", () => {
     const config = { tools: { toolSearch: true } } as never;
+    const catalogRef = createToolSearchCatalogRef();
     const compacted = applyToolSearchCatalog({
       tools: [createStubTool(TOOL_SEARCH_CODE_MODE_TOOL_NAME)],
       config,
       sessionId: "session-client-allowed-names",
+      catalogRef,
     });
     const clientTools: ClientToolDefinition[] = [
       {
@@ -143,6 +147,7 @@ describe("tool name allowlists", () => {
       tools: [createStubTool("client_pick_file")],
       config,
       sessionId: "session-client-allowed-names",
+      catalogRef,
     });
 
     const allowlist = toSessionToolAllowlist(
@@ -170,6 +175,7 @@ describe("tool name allowlists", () => {
       tools: uncompactedTools,
       config,
       sessionId: "session-replay-allowed-names",
+      catalogRef: createToolSearchCatalogRef(),
     });
     const clientTools: ClientToolDefinition[] = [
       {

--- a/src/agents/tool-search-catalog.ts
+++ b/src/agents/tool-search-catalog.ts
@@ -1,4 +1,3 @@
-import { uniqueStrings, uniqueValues } from "@openclaw/normalization-core/string-normalization";
 import { getPluginToolMeta, type PluginToolMcpMeta } from "../plugins/tools.js";
 import type { HookContext } from "./agent-tools.before-tool-call.js";
 import {
@@ -24,15 +23,7 @@ import {
 import { ToolInputError, type AnyAgentTool } from "./tools/common.js";
 
 const MAX_REUSABLE_CATALOG_SNAPSHOTS = 256;
-const SESSION_CATALOGS_KEY = Symbol.for("openclaw.toolSearch.sessionCatalogs");
-const globalToolSearchState = globalThis as typeof globalThis & {
-  [SESSION_CATALOGS_KEY]?: Map<string, ToolSearchCatalogSession>;
-};
-
-export const sessionCatalogs =
-  globalToolSearchState[SESSION_CATALOGS_KEY] ??
-  (globalToolSearchState[SESSION_CATALOGS_KEY] = new Map<string, ToolSearchCatalogSession>());
-export const reusableCatalogSnapshots = new Map<
+const reusableCatalogSnapshots = new Map<
   string,
   { entries: ToolSearchCatalogEntry[]; fingerprint: string }
 >();
@@ -42,48 +33,19 @@ const untrustedSchemaIdentities = new WeakMap<object, number>();
 let nextCatalogToolIdentity = 1;
 let nextUntrustedSchemaIdentity = 1;
 
-function sessionCatalogKeys(input: {
-  sessionId?: string;
-  sessionKey?: string;
-  agentId?: string;
-  runId?: string;
-}): string[] {
-  const runId = input.runId?.trim();
-  if (runId) {
-    return [`run:${runId}`];
-  }
-  const keys: string[] = [];
-  if (input.sessionId?.trim()) {
-    keys.push(`session:${input.sessionId.trim()}`);
-  }
-  if (input.sessionKey?.trim()) {
-    keys.push(`key:${input.sessionKey.trim()}`);
-  }
-  if (input.agentId?.trim()) {
-    keys.push(`agent:${input.agentId.trim()}`);
-  }
-  return uniqueStrings(keys);
-}
-
-function sessionCatalogKey(input: {
-  sessionId?: string;
-  sessionKey?: string;
-  agentId?: string;
-  runId?: string;
-}): string | undefined {
-  return sessionCatalogKeys(input)[0];
-}
-
 function reusableCatalogKey(input: {
   sessionId?: string;
   sessionKey?: string;
   agentId?: string;
 }): string | undefined {
-  return sessionCatalogKey({
-    sessionId: input.sessionId,
-    sessionKey: input.sessionKey,
-    agentId: input.agentId,
-  });
+  if (input.sessionId?.trim()) {
+    return `session:${input.sessionId.trim()}`;
+  }
+  if (input.sessionKey?.trim()) {
+    return `key:${input.sessionKey.trim()}`;
+  }
+  const agentId = input.agentId?.trim();
+  return agentId ? `agent:${agentId}` : undefined;
 }
 
 function stableJsonFingerprint(value: unknown, seen = new WeakSet<object>()): string {
@@ -159,48 +121,18 @@ function catalogEntriesFingerprint(entries: readonly ToolSearchCatalogEntry[]): 
 }
 
 function restoreToolSearchCatalog(params: {
-  sessionId?: string;
-  sessionKey?: string;
-  agentId?: string;
-  runId?: string;
-  catalogRef?: ToolSearchCatalogRef;
+  catalogRef: ToolSearchCatalogRef;
   entries: ToolSearchCatalogEntry[];
   fingerprint: string;
-}): ToolSearchCatalogSession | undefined {
-  const keys = sessionCatalogKeys(params);
-  if (keys.length === 0 && !params.catalogRef) {
-    return undefined;
-  }
+}): void {
   const next = {
     entries: params.entries,
     searchCount: 0,
     describeCount: 0,
     callCount: 0,
   };
-  if (params.catalogRef) {
-    params.catalogRef.current = next;
-  }
+  params.catalogRef.current = next;
   catalogFingerprints.set(next, params.fingerprint);
-  for (const key of keys) {
-    sessionCatalogs.set(key, next);
-  }
-  return next;
-}
-
-function bindToolSearchCatalog(params: {
-  sessionId?: string;
-  sessionKey?: string;
-  agentId?: string;
-  runId?: string;
-  catalogRef?: ToolSearchCatalogRef;
-  catalog: ToolSearchCatalogSession;
-}): void {
-  if (params.catalogRef) {
-    params.catalogRef.current = params.catalog;
-  }
-  for (const key of sessionCatalogKeys(params)) {
-    sessionCatalogs.set(key, params.catalog);
-  }
 }
 
 function rememberReusableCatalog(key: string | undefined, catalog: ToolSearchCatalogSession): void {
@@ -337,43 +269,23 @@ export function collectUniqueCatalogToolNames(tools: readonly AnyAgentTool[]): S
 }
 
 function registerToolSearchCatalog(params: {
-  sessionId?: string;
-  sessionKey?: string;
-  agentId?: string;
-  runId?: string;
-  catalogRef?: ToolSearchCatalogRef;
+  catalogRef: ToolSearchCatalogRef;
   entries: ToolSearchCatalogEntry[];
   append?: boolean;
-}): ToolSearchCatalogSession | undefined {
-  const keys = sessionCatalogKeys(params);
-  const primaryKey = keys[0];
-  if (!primaryKey && !params.catalogRef) {
-    return undefined;
-  }
-  const prior = params.append
-    ? (params.catalogRef?.current ?? (primaryKey ? sessionCatalogs.get(primaryKey) : undefined))
-    : undefined;
-  const byId = new Map<string, ToolSearchCatalogEntry>();
-  for (const entry of prior?.entries ?? []) {
-    byId.set(entry.id, entry);
-  }
+}): ToolSearchCatalogSession {
+  const prior = params.append ? params.catalogRef.current : undefined;
+  const byId = new Map((prior?.entries ?? []).map((entry) => [entry.id, entry]));
   for (const entry of params.entries) {
     byId.set(entry.id, entry);
-    byId.set(entry.name, entry);
   }
   const next = {
-    entries: uniqueValues(byId.values()).toSorted((a, b) => a.id.localeCompare(b.id)),
+    entries: Array.from(byId.values()).toSorted((a, b) => a.id.localeCompare(b.id)),
     searchCount: prior?.searchCount ?? 0,
     describeCount: prior?.describeCount ?? 0,
     callCount: prior?.callCount ?? 0,
   };
   catalogFingerprints.set(next, catalogEntriesFingerprint(next.entries));
-  if (params.catalogRef) {
-    params.catalogRef.current = next;
-  }
-  for (const key of keys) {
-    sessionCatalogs.set(key, next);
-  }
+  params.catalogRef.current = next;
   return next;
 }
 
@@ -387,9 +299,6 @@ export function clearToolSearchCatalog(params: {
   if (params.catalogRef) {
     params.catalogRef.current = undefined;
   }
-  for (const key of sessionCatalogKeys(params)) {
-    sessionCatalogs.delete(key);
-  }
   if (!params.runId?.trim()) {
     const snapshotKey = reusableCatalogKey(params);
     if (snapshotKey) {
@@ -399,24 +308,11 @@ export function clearToolSearchCatalog(params: {
 }
 
 export function resolveCatalog(ctx: ToolSearchToolContext): ToolSearchCatalogSession {
-  if (ctx.catalogRef?.current) {
-    return ctx.catalogRef.current;
-  }
-  const keys = sessionCatalogKeys(ctx);
-  for (const key of keys) {
-    const catalog = sessionCatalogs.get(key);
-    if (catalog) {
-      return catalog;
-    }
-  }
-  if (ctx.runId?.trim()) {
+  const catalog = ctx.catalogRef?.current;
+  if (!catalog) {
     throw new ToolInputError("Tool Search catalog is unavailable for this run.");
   }
-  const uniqueCatalogs = uniqueValues(sessionCatalogs.values());
-  if (uniqueCatalogs.length === 1 && uniqueCatalogs[0]) {
-    return uniqueCatalogs[0];
-  }
-  throw new ToolInputError("Tool Search catalog is unavailable for this run.");
+  return catalog;
 }
 
 export function visibleCatalogEntries(
@@ -471,8 +367,8 @@ export function applyToolCatalogCompaction(
     };
   }
   const hasControlTool = params.tools.some((tool) => params.isVisibleControlTool(tool));
-  const key = sessionCatalogKey(params);
-  if (!hasControlTool || (!key && !params.catalogRef)) {
+  const catalogRef = params.catalogRef;
+  if (!hasControlTool || !catalogRef) {
     return {
       tools: params.tools.filter((tool) => !TOOL_SEARCH_CONTROL_TOOL_NAMES.has(tool.name)),
       compacted: false,
@@ -503,10 +399,8 @@ export function applyToolCatalogCompaction(
     visible.push(tool);
   }
   const incomingFingerprint = catalogEntriesFingerprint(catalog);
-  const existingCatalog =
-    params.catalogRef?.current ?? (key ? sessionCatalogs.get(key) : undefined);
+  const existingCatalog = catalogRef.current;
   if (existingCatalog && catalogFingerprints.get(existingCatalog) === incomingFingerprint) {
-    bindToolSearchCatalog({ ...params, catalog: existingCatalog });
     return {
       tools: visible,
       compacted: catalog.length > 0,
@@ -520,7 +414,7 @@ export function applyToolCatalogCompaction(
   const reusableSnapshot = reusableKey ? reusableCatalogSnapshots.get(reusableKey) : undefined;
   if (reusableSnapshot?.fingerprint === incomingFingerprint) {
     restoreToolSearchCatalog({
-      ...params,
+      catalogRef,
       entries: reusableSnapshot.entries,
       fingerprint: reusableSnapshot.fingerprint,
     });
@@ -537,10 +431,8 @@ export function applyToolCatalogCompaction(
     };
   }
 
-  const registered = registerToolSearchCatalog({ ...params, entries: catalog, append: false });
-  if (registered) {
-    rememberReusableCatalog(reusableKey, registered);
-  }
+  const registered = registerToolSearchCatalog({ catalogRef, entries: catalog });
+  rememberReusableCatalog(reusableKey, registered);
   return {
     tools: visible,
     compacted: catalog.length > 0,
@@ -559,16 +451,12 @@ export function addClientToolsToToolCatalog(params: {
   runId?: string;
   catalogRef?: ToolSearchCatalogRef;
 }): { tools: ToolDefinition[]; compacted: boolean; catalogToolCount: number } {
-  const key = sessionCatalogKey(params);
-  if (!params.enabled || (!key && !params.catalogRef)) {
-    return { tools: params.tools, compacted: false, catalogToolCount: 0 };
-  }
-  const existing = params.catalogRef?.current ?? (key ? sessionCatalogs.get(key) : undefined);
-  if (!existing) {
+  const catalogRef = params.catalogRef;
+  if (!params.enabled || !catalogRef?.current) {
     return { tools: params.tools, compacted: false, catalogToolCount: 0 };
   }
   registerToolSearchCatalog({
-    ...params,
+    catalogRef,
     entries: params.tools.map((tool) => toCatalogEntry(tool, "client")),
     append: true,
   });

--- a/src/agents/tool-search.test-support.ts
+++ b/src/agents/tool-search.test-support.ts
@@ -1,15 +1,7 @@
-import type { ToolSearchCatalogEntry, ToolSearchConfig, ToolSearchRuntime } from "./tool-search.js";
+import type { ToolSearchConfig, ToolSearchRuntime } from "./tool-search.js";
 import "./tool-search.js";
 
-type ToolSearchCatalogSession = {
-  entries: ToolSearchCatalogEntry[];
-  searchCount: number;
-  describeCount: number;
-  callCount: number;
-};
-
 type ToolSearchTestApi = {
-  sessionCatalogs: Map<string, ToolSearchCatalogSession>;
   maxToolSchemaDirectoryPromptChars: number;
   setToolSearchCodeModeSupportedForTest(value: boolean | undefined): void;
   setToolSearchMinCodeTimeoutMsForTest(value: number | undefined): void;
@@ -31,9 +23,6 @@ function getTestApi(): ToolSearchTestApi {
 }
 
 export const testing: ToolSearchTestApi = {
-  get sessionCatalogs() {
-    return getTestApi().sessionCatalogs;
-  },
   get maxToolSchemaDirectoryPromptChars() {
     return getTestApi().maxToolSchemaDirectoryPromptChars;
   },

--- a/src/agents/tool-search.test.ts
+++ b/src/agents/tool-search.test.ts
@@ -20,26 +20,100 @@ import { resetAdjustedParamsByToolCallIdForTests } from "./agent-tools.before-to
 import { normalizeAgentRuntimeTools } from "./runtime-plan/tools.js";
 import { SESSION_TOOL_STDERR_TAIL_BYTES } from "./sessions/tools/limits.js";
 import {
-  addClientToolsToToolSearchCatalog,
-  applyToolSearchCatalog,
-  applyToolSchemaDirectoryCatalog,
-  buildToolSchemaDirectoryPrompt,
-  clearToolSearchCatalog,
+  addClientToolsToToolSearchCatalog as addRunClientToolsToToolSearchCatalog,
+  applyToolSearchCatalog as applyRunToolSearchCatalog,
+  applyToolSchemaDirectoryCatalog as applyRunToolSchemaDirectoryCatalog,
+  buildToolSchemaDirectoryPrompt as buildRunToolSchemaDirectoryPrompt,
+  clearToolSearchCatalog as clearRunToolSearchCatalog,
   compactToolSearchCatalogEntry,
   createToolSearchCatalogRef,
-  createToolSearchTools,
+  createToolSearchTools as createRunToolSearchTools,
   projectToolSearchTargetTranscriptMessages,
   registerHeadlessToolSearchCatalog,
   resolveToolSearchConfig,
-  resolveToolSearchCatalogTool,
+  resolveToolSearchCatalogTool as resolveRunToolSearchCatalogTool,
   TOOL_CALL_RAW_TOOL_NAME,
   TOOL_DESCRIBE_RAW_TOOL_NAME,
   TOOL_SEARCH_CODE_MODE_TOOL_NAME,
   TOOL_SEARCH_RAW_TOOL_NAME,
+  type ToolSearchCatalogRef,
   ToolSearchRuntime,
 } from "./tool-search.js";
 import { testing } from "./tool-search.test-support.js";
 import { jsonResult, type AnyAgentTool } from "./tools/common.js";
+
+type TestCatalogContext = {
+  sessionId?: string;
+  sessionKey?: string;
+  agentId?: string;
+  runId?: string;
+  catalogRef?: ToolSearchCatalogRef;
+};
+
+const testCatalogRefs = new Map<string, ToolSearchCatalogRef>();
+
+function withTestCatalogRef<T extends TestCatalogContext>(params: T): T {
+  if (params.catalogRef) {
+    return params;
+  }
+  const key = params.runId?.trim()
+    ? `run:${params.runId.trim()}`
+    : params.sessionId?.trim()
+      ? `session:${params.sessionId.trim()}`
+      : params.sessionKey?.trim()
+        ? `key:${params.sessionKey.trim()}`
+        : params.agentId?.trim()
+          ? `agent:${params.agentId.trim()}`
+          : undefined;
+  if (!key) {
+    return params;
+  }
+  let catalogRef = testCatalogRefs.get(key);
+  if (!catalogRef) {
+    catalogRef = createToolSearchCatalogRef();
+    testCatalogRefs.set(key, catalogRef);
+  }
+  return { ...params, catalogRef };
+}
+
+function applyToolSearchCatalog(params: Parameters<typeof applyRunToolSearchCatalog>[0]) {
+  return applyRunToolSearchCatalog(withTestCatalogRef(params));
+}
+
+function applyToolSchemaDirectoryCatalog(
+  params: Parameters<typeof applyRunToolSchemaDirectoryCatalog>[0],
+) {
+  return applyRunToolSchemaDirectoryCatalog(withTestCatalogRef(params));
+}
+
+function addClientToolsToToolSearchCatalog(
+  params: Parameters<typeof addRunClientToolsToToolSearchCatalog>[0],
+) {
+  return addRunClientToolsToToolSearchCatalog(withTestCatalogRef(params));
+}
+
+function createToolSearchTools(params: Parameters<typeof createRunToolSearchTools>[0]) {
+  return createRunToolSearchTools(withTestCatalogRef(params));
+}
+
+function clearToolSearchCatalog(params: Parameters<typeof clearRunToolSearchCatalog>[0]) {
+  clearRunToolSearchCatalog(withTestCatalogRef(params));
+}
+
+function buildToolSchemaDirectoryPrompt(
+  params: Parameters<typeof buildRunToolSchemaDirectoryPrompt>[0],
+  options?: Parameters<typeof buildRunToolSchemaDirectoryPrompt>[1],
+) {
+  return buildRunToolSchemaDirectoryPrompt(withTestCatalogRef(params), options);
+}
+
+function resolveToolSearchCatalogTool(
+  params: Parameters<typeof resolveRunToolSearchCatalogTool>[0],
+  name: Parameters<typeof resolveRunToolSearchCatalogTool>[1],
+  options?: Parameters<typeof resolveRunToolSearchCatalogTool>[2],
+) {
+  return resolveRunToolSearchCatalogTool(withTestCatalogRef(params), name, options);
+}
 
 function fakeTool(name: string, description: string): AnyAgentTool {
   return {
@@ -503,6 +577,7 @@ describe("Tool Search", () => {
     expect(directory).not.toContain("\uD83D");
   });
   afterEach(() => {
+    testCatalogRefs.clear();
     resetGlobalHookRunner();
     resetAdjustedParamsByToolCallIdForTests();
     testing.setToolSearchCodeModeSupportedForTest(undefined);
@@ -1021,17 +1096,17 @@ describe("Tool Search", () => {
       sessionKey: "agent:main:main",
       runId: "run-a",
     });
-    expect(testing.sessionCatalogs.has("run:run-a")).toBe(false);
-    expect(testing.sessionCatalogs.has("run:run-b")).toBe(true);
+    expect(testCatalogRefs.get("run:run-a")?.current).toBeUndefined();
+    expect(testCatalogRefs.get("run:run-b")?.current).toBeDefined();
     expect(runATool.execute).toHaveBeenCalledTimes(1);
     expect(runBTool.execute).not.toHaveBeenCalled();
     clearToolSearchCatalog({ runId: "run-b" });
   });
 
-  it("uses the runtime-local catalog ref before the shared catalog registry", async () => {
+  it("keeps overlapping run catalogs isolated through their owned refs", async () => {
     const localRef = createToolSearchCatalogRef();
     const localTool = pluginTool("fake_local_ref", "Tool visible through the local ref");
-    const globalTool = pluginTool("fake_global_ref", "Tool visible through the registry fallback");
+    const globalTool = pluginTool("fake_global_ref", "Tool visible through another run");
     const config = { tools: { toolSearch: true } } as never;
 
     applyToolSearchCatalog({
@@ -1069,6 +1144,33 @@ describe("Tool Search", () => {
     expect(globalTool.execute).not.toHaveBeenCalled();
     clearToolSearchCatalog({ runId: "run-local-ref", catalogRef: localRef });
     clearToolSearchCatalog({ sessionId: "session-catalog-ref" });
+  });
+
+  it("fails closed without a run-owned catalog even when another catalog is active", async () => {
+    const catalogRef = createToolSearchCatalogRef();
+    const target = pluginTool("fake_other_run", "Tool owned by another run");
+    const config = { tools: { toolSearch: true } } as never;
+
+    applyRunToolSearchCatalog({
+      tools: [fakeTool(TOOL_SEARCH_CODE_MODE_TOOL_NAME, "code mode"), target],
+      config,
+      sessionId: "session-owned-catalog",
+      catalogRef,
+    });
+
+    const controls = createRunToolSearchTools({
+      config,
+      sessionId: "session-owned-catalog",
+    });
+    const callTool = expectDefined(controls[3], "unowned call tool test invariant");
+
+    await expect(
+      callTool.execute("call-without-owned-catalog", {
+        id: "fake_other_run",
+        args: { value: "denied" },
+      }),
+    ).rejects.toThrow("Tool Search catalog is unavailable for this run.");
+    expect(target.execute).not.toHaveBeenCalled();
   });
 
   it("keeps raw fallback tools and hides the code tool in tools mode", () => {
@@ -1561,9 +1663,9 @@ describe("Tool Search", () => {
 
     expect(compacted.tools).toEqual([]);
     expect(compacted.catalogToolCount).toBe(1);
-    const clientEntry = testing.sessionCatalogs
+    const clientEntry = testCatalogRefs
       .get("session:session-client")
-      ?.entries.find((entry) => entry.id === "client:client:client_pick_file");
+      ?.current?.entries.find((entry) => entry.id === "client:client:client_pick_file");
     expect(clientEntry?.source).toBe("client");
 
     const executeTool = vi.fn(async () => jsonResult({ status: "ok" }));
@@ -1671,9 +1773,9 @@ describe("Tool Search", () => {
     expect(compacted.tools.map((tool) => tool.name)).toEqual(["client_pick_file"]);
     expect(compacted.compacted).toBe(false);
     expect(compacted.catalogToolCount).toBe(0);
-    const clientEntry = testing.sessionCatalogs
+    const clientEntry = testCatalogRefs
       .get("session:session-directory-client")
-      ?.entries.find((entry) => entry.id === "client:client:client_pick_file");
+      ?.current?.entries.find((entry) => entry.id === "client:client:client_pick_file");
     expect(clientEntry).toBeUndefined();
   });
 
@@ -1692,9 +1794,9 @@ describe("Tool Search", () => {
       },
     });
 
-    const entry = testing.sessionCatalogs
+    const entry = testCatalogRefs
       .get("session:session-hooks")
-      ?.entries.find((candidate) => candidate.name === "fake_hooked");
+      ?.current?.entries.find((candidate) => candidate.name === "fake_hooked");
     if (!entry) {
       throw new Error("Expected fake_hooked catalog entry");
     }
@@ -1736,9 +1838,9 @@ describe("Tool Search", () => {
       },
     });
 
-    const entry = testing.sessionCatalogs
+    const entry = testCatalogRefs
       .get("session:session-hooks-abort")
-      ?.entries.find((candidate) => candidate.name === "fake_already_hooked");
+      ?.current?.entries.find((candidate) => candidate.name === "fake_already_hooked");
     expect(entry?.tool).toBe(abortWrapped);
     expect(isToolWrappedWithBeforeToolCallHook(entry!.tool as AnyAgentTool)).toBe(true);
   });
@@ -1806,9 +1908,9 @@ describe("Tool Search", () => {
       sessionId: "session-mcp-node",
     });
 
-    const entry = testing.sessionCatalogs
+    const entry = testCatalogRefs
       .get("session:session-mcp-node")
-      ?.entries.find((candidate) => candidate.name === "remote_echo");
+      ?.current?.entries.find((candidate) => candidate.name === "remote_echo");
     expect(entry).toMatchObject({
       id: "mcp:remoteDemo:remote_echo",
       source: "mcp",
@@ -2438,7 +2540,7 @@ describe("Tool Search", () => {
     expect(first.catalogRegistered).toBe(true);
     expect(first.catalogReused).toBe(false);
 
-    const catalogAfterFirst = testing.sessionCatalogs.get(`session:${sessionId}`);
+    const catalogAfterFirst = testCatalogRefs.get(`session:${sessionId}`)?.current;
     expect(catalogAfterFirst).toBeDefined();
 
     const second = applyToolSearchCatalog({
@@ -2448,7 +2550,7 @@ describe("Tool Search", () => {
     });
     expect(second.catalogRegistered).toBe(true);
     expect(second.catalogReused).toBe(true);
-    expect(testing.sessionCatalogs.get(`session:${sessionId}`)).toBe(catalogAfterFirst);
+    expect(testCatalogRefs.get(`session:${sessionId}`)?.current).toBe(catalogAfterFirst);
 
     const laterRef = createToolSearchCatalogRef();
     const later = applyToolSearchCatalog({
@@ -2459,8 +2561,8 @@ describe("Tool Search", () => {
       catalogRef: laterRef,
     });
     expect(later.catalogReused).toBe(true);
-    expect(laterRef.current).toBe(catalogAfterFirst);
-    expect(testing.sessionCatalogs.get("key:agent:main:tool-search-reuse")).toBe(catalogAfterFirst);
+    expect(laterRef.current).not.toBe(catalogAfterFirst);
+    expect(laterRef.current?.entries).toBe(catalogAfterFirst?.entries);
   });
 
   it("restores an unchanged catalog after run cleanup", () => {
@@ -2488,7 +2590,6 @@ describe("Tool Search", () => {
       catalogRef: firstRef,
     });
     expect(firstRef.current).toBeUndefined();
-    expect(testing.sessionCatalogs.has("run:run-1")).toBe(false);
 
     const secondRef = createToolSearchCatalogRef();
     const second = applyToolSearchCatalog({
@@ -2500,7 +2601,7 @@ describe("Tool Search", () => {
     });
     expect(second.catalogRegistered).toBe(true);
     expect(second.catalogReused).toBe(true);
-    expect(testing.sessionCatalogs.has("run:run-2")).toBe(true);
+    expect(secondRef.current).toBeDefined();
     expect(secondRef.current?.entries.find((entry) => entry.name === alpha.name)).toBe(
       firstAlphaEntry,
     );

--- a/src/agents/tool-search.ts
+++ b/src/agents/tool-search.ts
@@ -9,9 +9,7 @@ import {
   addClientToolsToToolCatalog,
   applyToolCatalogCompaction,
   isDirectVisibleCatalogTool,
-  reusableCatalogSnapshots,
   resolveCatalog,
-  sessionCatalogs,
 } from "./tool-search-catalog.js";
 import {
   appendToolSearchCodeStderrTail,
@@ -226,8 +224,6 @@ export function createToolSearchTools(ctx: ToolSearchToolContext): AnyAgentTool[
 }
 
 const testing = {
-  sessionCatalogs,
-  reusableCatalogSnapshots,
   maxToolSchemaDirectoryPromptChars: MAX_TOOL_SCHEMA_DIRECTORY_PROMPT_CHARS,
   resolveToolSearchConfig,
   isToolSearchCodeModeSupported,


### PR DESCRIPTION
## What Problem This Solves

Code Mode tool search stored live catalogs in process-global state, allowing fallback resolution outside the owning run and requiring redundant registry cleanup.

## Why This Change Was Made

Make the existing run-owned catalog reference the single authority. Remove global run, session and agent registries while preserving bounded fingerprinted directory snapshots.

## User Impact

Concurrent Code Mode runs have stronger tool isolation and production code is 116 lines smaller.

## Evidence

- Clean fresh independent autoreview.
- Blacksmith Testbox: all six focused catalog, ranking, runtime, embedded allowlist, abort, and client suites pass.
- Explicit missing-reference and cross-run isolation regressions.
- Personally verified upstream Codex session and cancellation ownership.
