### PR TITLE
refactor(code-mode): prepare MCP namespaces once per run

### DIFF
--- a/config/max-lines-baseline.txt
+++ b/config/max-lines-baseline.txt
@@ -382,7 +382,6 @@ src/agents/cli-runner/claude-live-session.ts
 src/agents/cli-runner/execute.supervisor-capture.test.ts
 src/agents/cli-runner/prepare.test.ts
 src/agents/cli-runner/prepare.ts
-src/agents/code-mode-namespaces.ts
 src/agents/code-mode.test.ts
 src/agents/command/attempt-execution.cli.test.ts
 src/agents/command/attempt-execution.test.ts

--- a/src/agents/code-mode-execution.ts
+++ b/src/agents/code-mode-execution.ts
@@ -93,7 +93,7 @@ export async function runExec(params: {
     params.assistantTurnId,
   );
   const namespaceRuntime = createCodeModeNamespaceRuntime(namespaceCatalog);
-  const apiFiles = createCodeModeApiFilesForRun(namespaceCatalog, swarmEnabled);
+  const apiFiles = createCodeModeApiFilesForRun(namespaceRuntime, swarmEnabled);
   try {
     const source = await awaitCodeModeDeadline({
       operation: () => prepareSource({ code: params.code, language: params.language, config }),

--- a/src/agents/code-mode-headless.ts
+++ b/src/agents/code-mode-headless.ts
@@ -241,7 +241,7 @@ export async function runCodeModeScriptHeadless(params: {
           kind: "exec",
           source,
           catalog,
-          apiFiles: createCodeModeApiFilesForRun(namespaceCatalog, swarmEnabled),
+          apiFiles: createCodeModeApiFilesForRun(namespaceRuntime, swarmEnabled),
           namespaces,
           swarmEnabled,
         },

--- a/src/agents/code-mode-mcp-api.ts
+++ b/src/agents/code-mode-mcp-api.ts
@@ -1,0 +1,339 @@
+import { isRecord } from "../../packages/normalization-core/src/record-coerce.js";
+import type { PluginToolMcpMeta } from "../plugins/tools.js";
+
+type McpApiParamDoc = {
+  name: string;
+  required: boolean;
+  type: string;
+  description?: string;
+  defaultValue?: unknown;
+};
+
+type McpApiToolDoc = {
+  method: string;
+  path: string[];
+  mcpTool: string;
+  operation: PluginToolMcpMeta["operation"];
+  description?: string;
+  parameters: unknown;
+  params: McpApiParamDoc[];
+};
+
+export type McpApiServerDoc = {
+  identifier: string;
+  serverName: string;
+  nodeLabel?: string;
+  tools: McpApiToolDoc[];
+};
+
+/** Virtual TypeScript-style API file exposed to code mode. */
+export type CodeModeApiVirtualFile = {
+  path: string;
+  description?: string;
+  content: string;
+  bytes: number;
+};
+
+export function readMcpSchemaProperties(schema: unknown): Record<string, unknown> {
+  const properties = isRecord(schema) ? schema.properties : undefined;
+  return isRecord(properties) ? properties : {};
+}
+
+export function readMcpRequiredKeys(schema: unknown): string[] {
+  const required = isRecord(schema) ? schema.required : undefined;
+  return Array.isArray(required)
+    ? required.filter((entry): entry is string => typeof entry === "string")
+    : [];
+}
+
+function escapeDocComment(value: string): string {
+  return value.replace(/\*\//gu, "* /").trim();
+}
+
+function normalizeDocLines(value: string | undefined): string[] {
+  return value
+    ? value
+        .split(/\r?\n/u)
+        .map((line) => line.trim())
+        .filter(Boolean)
+        .slice(0, 12)
+    : [];
+}
+
+function collapseDocText(value: string | undefined): string {
+  return normalizeDocLines(value).join(" ");
+}
+
+function renderDocComment(
+  summary: string | undefined,
+  params: readonly McpApiParamDoc[],
+): string[] {
+  const docLines = normalizeDocLines(summary);
+  if (docLines.length === 0 && params.length === 0) {
+    return [];
+  }
+  const lines = ["/**", ...docLines.map((line) => ` * ${escapeDocComment(line)}`)];
+  if (docLines.length > 0 && params.length > 0) {
+    lines.push(" *");
+  }
+  for (const param of params) {
+    const description = collapseDocText(param.description);
+    if (description) {
+      lines.push(
+        ` * @param ${param.name}${param.required ? "" : "?"} ${escapeDocComment(description)}`,
+      );
+    }
+  }
+  lines.push(" */");
+  return lines;
+}
+
+function tsPropertyName(name: string): string {
+  return /^[A-Za-z_$][A-Za-z0-9_$]*$/u.test(name) ? name : JSON.stringify(name);
+}
+
+function renderInlineObjectType(schema: unknown): string {
+  const properties = readMcpSchemaProperties(schema);
+  const keys = Object.keys(properties);
+  if (keys.length === 0) {
+    return "Record<string, unknown>";
+  }
+  const required = new Set(readMcpRequiredKeys(schema));
+  return `{ ${keys
+    .map(
+      (key) =>
+        `${tsPropertyName(key)}${required.has(key) ? "" : "?"}: ${schemaType(properties[key])}`,
+    )
+    .join("; ")} }`;
+}
+
+function schemaType(schema: unknown): string {
+  if (!isRecord(schema)) {
+    return "unknown";
+  }
+  const enumValues = Array.isArray(schema.enum)
+    ? schema.enum.filter(
+        (entry): entry is string | number | boolean =>
+          typeof entry === "string" || typeof entry === "number" || typeof entry === "boolean",
+      )
+    : [];
+  if (enumValues.length > 0 && enumValues.length <= 16) {
+    return enumValues.map((entry) => JSON.stringify(entry)).join(" | ");
+  }
+  const union = Array.isArray(schema.oneOf)
+    ? schema.oneOf
+    : Array.isArray(schema.anyOf)
+      ? schema.anyOf
+      : undefined;
+  if (union && union.length > 0 && union.length <= 8) {
+    return union.map(schemaType).join(" | ");
+  }
+  if (Array.isArray(schema.type)) {
+    return schema.type.map((type) => schemaType({ ...schema, type })).join(" | ");
+  }
+  switch (schema.type) {
+    case "string":
+      return "string";
+    case "integer":
+    case "number":
+      return "number";
+    case "boolean":
+      return "boolean";
+    case "array":
+      return `${schemaType(schema.items)}[]`;
+    case "object":
+      return renderInlineObjectType(schema);
+    case "null":
+      return "null";
+    default:
+      return Object.keys(readMcpSchemaProperties(schema)).length > 0
+        ? renderInlineObjectType(schema)
+        : "unknown";
+  }
+}
+
+export function buildMcpParamDocs(schema: unknown): McpApiParamDoc[] {
+  const properties = readMcpSchemaProperties(schema);
+  const requiredKeys = readMcpRequiredKeys(schema);
+  const required = new Set(requiredKeys);
+  return [...new Set([...requiredKeys, ...Object.keys(properties)])].map((key) => {
+    const descriptor = properties[key];
+    const doc: McpApiParamDoc = {
+      name: key,
+      required: required.has(key),
+      type: schemaType(descriptor),
+    };
+    if (isRecord(descriptor)) {
+      const description =
+        typeof descriptor.description === "string" ? descriptor.description.trim() : "";
+      if (description) {
+        doc.description = description;
+      }
+      if ("default" in descriptor) {
+        doc.defaultValue = descriptor.default;
+      }
+    }
+    return doc;
+  });
+}
+
+function renderMcpInputType(params: readonly McpApiParamDoc[]): string[] {
+  if (params.length === 0) {
+    return ["input?: Record<string, never>"];
+  }
+  const lines = ["input: {"];
+  for (const param of params) {
+    if (param.description || param.defaultValue !== undefined) {
+      const description = collapseDocText(param.description);
+      const suffix =
+        param.defaultValue === undefined ? "" : ` Default: ${JSON.stringify(param.defaultValue)}.`;
+      lines.push(`  /** ${escapeDocComment(`${description}${suffix}`.trim())} */`);
+    }
+    lines.push(`  ${tsPropertyName(param.name)}${param.required ? "" : "?"}: ${param.type};`);
+  }
+  lines.push("}");
+  return lines;
+}
+
+function renderMcpToolSignature(
+  tool: McpApiToolDoc,
+  functionName = tool.path.at(-1) ?? tool.method,
+): string[] {
+  return [
+    ...renderDocComment(tool.description, tool.params),
+    `function ${functionName}(`,
+    ...renderMcpInputType(tool.params).map((line) => `  ${line}`),
+    "): Promise<McpToolResult>;",
+  ];
+}
+
+function renderMcpServerHeader(server: McpApiServerDoc, tools: readonly McpApiToolDoc[]): string {
+  const lines = [
+    "type McpApiHeader = { header: string; tools?: unknown[]; schemas?: Record<string, unknown> };",
+    "",
+    "type McpToolResult = {",
+    "  content?: unknown[];",
+    "  structuredContent?: unknown;",
+    "  isError?: boolean;",
+    "  [key: string]: unknown;",
+    "};",
+    "",
+    `declare namespace MCP.${server.identifier} {`,
+    "  /** Return this TypeScript-style API header. */",
+    "  function $api(toolName?: string, options?: { schema?: boolean }): Promise<McpApiHeader>;",
+  ];
+  const nestedGroups = new Map<string, McpApiToolDoc[]>();
+  for (const tool of tools) {
+    if (tool.path.length === 1) {
+      lines.push("", ...renderMcpToolSignature(tool).map((line) => `  ${line}`));
+      continue;
+    }
+    const groupName = tool.path[0] ?? "tools";
+    const group = nestedGroups.get(groupName);
+    if (group) {
+      group.push(tool);
+    } else {
+      nestedGroups.set(groupName, [tool]);
+    }
+  }
+  for (const [groupName, groupTools] of [...nestedGroups].toSorted((a, b) =>
+    a[0].localeCompare(b[0]),
+  )) {
+    lines.push("", `  namespace ${groupName} {`);
+    for (const tool of groupTools) {
+      lines.push("", ...renderMcpToolSignature(tool).map((line) => `    ${line}`));
+    }
+    lines.push("  }");
+  }
+  lines.push("}");
+  return lines.join("\n");
+}
+
+function renderMcpRootHeader(servers: readonly McpApiServerDoc[]): string {
+  return [
+    "type McpApiHeader = { header: string; servers?: unknown[] };",
+    "",
+    "declare const MCP: {",
+    "  /** List visible MCP servers and request server-specific headers. */",
+    "  $api(): Promise<McpApiHeader>;",
+    ...servers.map((server) => `  readonly ${server.identifier}: typeof MCP.${server.identifier};`),
+    "};",
+  ].join("\n");
+}
+
+export function buildMcpApiResponse(params: {
+  servers: readonly McpApiServerDoc[];
+  server?: McpApiServerDoc;
+  args: unknown[];
+}) {
+  const [selector, options] = params.args;
+  if (!params.server) {
+    return {
+      kind: "mcp_api",
+      scope: "root",
+      header: renderMcpRootHeader(params.servers),
+      servers: params.servers.map((server) => ({
+        identifier: server.identifier,
+        serverName: server.serverName,
+        toolCount: server.tools.length,
+      })),
+      note: "Call MCP.<server>.$api() for a TypeScript-style header, then call tools with one object argument matching the shown input type.",
+    };
+  }
+  const selectedName = typeof selector === "string" ? selector.trim() : "";
+  const selected = selectedName
+    ? params.server.tools.filter(
+        (tool) =>
+          tool.method === selectedName ||
+          tool.path.join(".") === selectedName ||
+          tool.mcpTool === selectedName,
+      )
+    : params.server.tools;
+  return {
+    kind: "mcp_api",
+    scope: selected.length === 1 ? "tool" : "server",
+    server: { identifier: params.server.identifier, serverName: params.server.serverName },
+    header: renderMcpServerHeader(params.server, selected),
+    tools: selected.map((tool) => ({
+      method: tool.method,
+      path: tool.path,
+      mcpTool: tool.mcpTool,
+      operation: tool.operation,
+      description: tool.description,
+    })),
+    ...(isRecord(options) && options.schema === true
+      ? { schemas: Object.fromEntries(selected.map((tool) => [tool.method, tool.parameters])) }
+      : {}),
+    note: "Call MCP tools with one object argument, for example MCP.server.tool({ requiredField: value }).",
+  };
+}
+
+export function createMcpApiVirtualFiles(
+  servers: readonly McpApiServerDoc[],
+): CodeModeApiVirtualFile[] {
+  if (servers.length === 0) {
+    return [];
+  }
+  const rootContent = [
+    ...servers.map((server) => `/// <reference path="./${server.identifier}.d.ts" />`),
+    "",
+    renderMcpRootHeader(servers),
+  ].join("\n");
+  return [
+    {
+      path: "mcp/index.d.ts",
+      description: "Root MCP namespace declaration and server list.",
+      content: rootContent,
+      bytes: Buffer.byteLength(rootContent, "utf8"),
+    },
+    ...servers.map((server) => {
+      const content = renderMcpServerHeader(server, server.tools);
+      return {
+        path: `mcp/${server.identifier}.d.ts`,
+        description: `MCP server declaration for ${server.serverName}.`,
+        content,
+        bytes: Buffer.byteLength(content, "utf8"),
+      };
+    }),
+  ];
+}

--- a/src/agents/code-mode-namespaces.test.ts
+++ b/src/agents/code-mode-namespaces.test.ts
@@ -1,8 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
-import {
-  createCodeModeApiVirtualFiles,
-  createCodeModeNamespaceRuntime,
-} from "./code-mode-namespaces.js";
+import { createCodeModeNamespaceRuntime } from "./code-mode-namespaces.js";
 
 type McpCatalogEntry = NonNullable<Parameters<typeof createCodeModeNamespaceRuntime>[0]>[number];
 
@@ -49,7 +46,7 @@ describe("Code Mode MCP namespace model", () => {
     ];
     const runtime = createCodeModeNamespaceRuntime(catalog);
 
-    expect(runtime.apiFiles).toEqual(createCodeModeApiVirtualFiles(catalog));
+    expect(runtime.descriptors.map((descriptor) => descriptor.globalName)).toEqual(["MCP"]);
     expect(runtime.apiFiles.map((file) => file.path)).toEqual([
       "agents.d.ts",
       "mcp/index.d.ts",

--- a/src/agents/code-mode-namespaces.test.ts
+++ b/src/agents/code-mode-namespaces.test.ts
@@ -1,0 +1,167 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  createCodeModeApiVirtualFiles,
+  createCodeModeNamespaceRuntime,
+} from "./code-mode-namespaces.js";
+
+type McpCatalogEntry = NonNullable<Parameters<typeof createCodeModeNamespaceRuntime>[0]>[number];
+
+function mcpCatalogEntry(params: {
+  id: string;
+  serverName?: string;
+  safeServerName?: string;
+  toolName?: string;
+  description?: string;
+  parameters?: unknown;
+  operation?: NonNullable<McpCatalogEntry["mcp"]>["operation"];
+  node?: NonNullable<McpCatalogEntry["mcp"]>["node"];
+}): McpCatalogEntry {
+  const serverName = params.serverName ?? "github";
+  const toolName = params.toolName ?? "read_file";
+  return {
+    id: params.id,
+    name: params.id,
+    source: "mcp",
+    description: params.description,
+    parameters: params.parameters ?? { type: "object", properties: {} },
+    mcp: {
+      serverName,
+      safeServerName: params.safeServerName ?? serverName,
+      toolName,
+      operation: params.operation ?? "tool",
+      ...(params.node ? { node: params.node } : {}),
+    },
+  };
+}
+
+describe("Code Mode MCP namespace model", () => {
+  it("keeps run-owned namespace descriptors and virtual API files in sync", async () => {
+    const catalog = [
+      mcpCatalogEntry({
+        id: "github__read_file",
+        description: "Read repository 名称.",
+        parameters: {
+          type: "object",
+          properties: { path: { type: "string", description: "Repository 名称" } },
+          required: ["path"],
+        },
+      }),
+    ];
+    const runtime = createCodeModeNamespaceRuntime(catalog);
+
+    expect(runtime.apiFiles).toEqual(createCodeModeApiVirtualFiles(catalog));
+    expect(runtime.apiFiles.map((file) => file.path)).toEqual([
+      "agents.d.ts",
+      "mcp/index.d.ts",
+      "mcp/github.d.ts",
+    ]);
+    for (const file of runtime.apiFiles) {
+      expect(file.bytes).toBe(Buffer.byteLength(file.content, "utf8"));
+    }
+
+    catalog[0] = mcpCatalogEntry({ id: "replacement__tool", serverName: "replacement" });
+    const executeTool = vi.fn(async ({ input }: { input: unknown }) => input);
+    await expect(
+      runtime.invoke("mcp", ["github", "readFile"], [{ path: "README.md" }], executeTool),
+    ).resolves.toEqual({ path: "README.md" });
+    expect(runtime.apiFiles.map((file) => file.path)).toEqual([
+      "agents.d.ts",
+      "mcp/index.d.ts",
+      "mcp/github.d.ts",
+    ]);
+    expect(executeTool).toHaveBeenCalledWith(
+      expect.objectContaining({ catalogId: "github__read_file", toolName: "github__read_file" }),
+    );
+  });
+
+  it.each(["constructor", "toString", "__proto__"])(
+    "does not satisfy required MCP argument %s from Object.prototype",
+    async (key) => {
+      const runtime = createCodeModeNamespaceRuntime([
+        mcpCatalogEntry({
+          id: "github__read_file",
+          parameters: {
+            type: "object",
+            properties: { [key]: { type: "string" } },
+            required: [key],
+          },
+        }),
+      ]);
+      const executeTool = vi.fn(async ({ input }: { input: unknown }) => input);
+
+      await expect(
+        runtime.invoke("mcp", ["github", "readFile"], [{}], executeTool),
+      ).rejects.toThrow(`Missing required MCP namespace argument: ${key}`);
+      expect(executeTool).not.toHaveBeenCalled();
+
+      await expect(
+        runtime.invoke("mcp", ["github", "readFile"], [{ [key]: "provided" }], executeTool),
+      ).resolves.toEqual({ [key]: "provided" });
+    },
+  );
+
+  it.each(["constructor", "toString", "__proto__"])(
+    "applies MCP argument default %s as a safe own property",
+    async (key) => {
+      const runtime = createCodeModeNamespaceRuntime([
+        mcpCatalogEntry({
+          id: "github__read_file",
+          parameters: {
+            type: "object",
+            properties: { [key]: { type: "string", default: "safe" } },
+            required: [key],
+          },
+        }),
+      ]);
+      const executeTool = vi.fn(async ({ input }: { input: unknown }) => input);
+
+      await expect(
+        runtime.invoke("mcp", ["github", "readFile"], [{}], executeTool),
+      ).resolves.toEqual({ [key]: "safe" });
+      const input = executeTool.mock.calls[0]?.[0]?.input as Record<string, unknown>;
+      expect(Object.hasOwn(input, key)).toBe(true);
+      expect(Object.getPrototypeOf(input)).toBe(Object.prototype);
+    },
+  );
+
+  it("keeps forbidden and JavaScript-keyword namespace identifiers callable and escaped", async () => {
+    const catalog = [
+      mcpCatalogEntry({
+        id: "constructor__prototype",
+        serverName: "constructor",
+        toolName: "prototype",
+      }),
+      mcpCatalogEntry({ id: "github__delete", toolName: "delete" }),
+      mcpCatalogEntry({ id: "github__enum", toolName: "enum" }),
+    ];
+    const runtime = createCodeModeNamespaceRuntime(catalog);
+    const executeTool = vi.fn(async ({ toolName }: { toolName: string }) => toolName);
+
+    await expect(
+      runtime.invoke("mcp", ["constructor2", "prototype2"], [{}], executeTool),
+    ).resolves.toBe("constructor__prototype");
+    await expect(runtime.invoke("mcp", ["github", "delete2"], [{}], executeTool)).resolves.toBe(
+      "github__delete",
+    );
+    await expect(runtime.invoke("mcp", ["github", "enum2"], [{}], executeTool)).resolves.toBe(
+      "github__enum",
+    );
+  });
+
+  it("rejects prototype and NUL-delimited paths before calling tools", async () => {
+    const runtime = createCodeModeNamespaceRuntime([mcpCatalogEntry({ id: "github__read_file" })]);
+    const executeTool = vi.fn(async () => "unexpected");
+
+    for (const path of [
+      ["__proto__", "readFile"],
+      ["constructor", "readFile"],
+      ["github", "prototype"],
+      ["github", "read\u0000File"],
+    ]) {
+      await expect(runtime.invoke("mcp", path, [{}], executeTool)).rejects.toThrow(
+        "Invalid code mode namespace path segment",
+      );
+    }
+    expect(executeTool).not.toHaveBeenCalled();
+  });
+});

--- a/src/agents/code-mode-namespaces.ts
+++ b/src/agents/code-mode-namespaces.ts
@@ -7,6 +7,17 @@ import { tokTypes } from "acorn";
 import { isRecord } from "../../packages/normalization-core/src/record-coerce.js";
 import type { PluginToolMcpMeta } from "../plugins/tools.js";
 import { toCodeModeJsonSafe } from "./code-mode-json.js";
+import {
+  buildMcpApiResponse,
+  buildMcpParamDocs,
+  createMcpApiVirtualFiles,
+  readMcpRequiredKeys,
+  readMcpSchemaProperties,
+  type CodeModeApiVirtualFile,
+  type McpApiServerDoc,
+} from "./code-mode-mcp-api.js";
+
+export type { CodeModeApiVirtualFile } from "./code-mode-mcp-api.js";
 
 const FORBIDDEN_NAMESPACE_PATH_SEGMENTS = new Set(["__proto__", "constructor", "prototype"]);
 const NAMESPACE_PATH_KEY_SEPARATOR = "\u0000";
@@ -94,6 +105,7 @@ type CodeModeNamespaceCatalogEntry = {
 /** Runtime dispatcher for invoking callable namespace paths. */
 export type CodeModeNamespaceRuntime = {
   descriptors: CodeModeNamespaceDescriptor[];
+  apiFiles: CodeModeApiVirtualFile[];
   invoke(
     namespaceId: string,
     path: string[],
@@ -191,376 +203,41 @@ function uniqueIdentifier(base: string, used: Set<string>): string {
   return candidate;
 }
 
-function readSchemaRecord(schema: unknown): Record<string, unknown> | undefined {
-  return isRecord(schema) ? schema : undefined;
-}
-
-function readSchemaProperties(schema: unknown): Record<string, unknown> {
-  const record = readSchemaRecord(schema);
-  return isRecord(record?.properties) ? record.properties : {};
-}
-
-function readSchemaString(schema: unknown, key: string): string | undefined {
-  const record = readSchemaRecord(schema);
-  const value = record?.[key];
-  return typeof value === "string" && value.trim() ? value.trim() : undefined;
-}
-
-function readRequiredKeys(schema: unknown): string[] {
-  const record = readSchemaRecord(schema);
-  return Array.isArray(record?.required)
-    ? record.required.filter((entry): entry is string => typeof entry === "string")
-    : [];
-}
-
-function orderedSchemaKeys(schema: unknown): string[] {
-  const required = readRequiredKeys(schema);
-  const properties = Object.keys(readSchemaProperties(schema));
-  return [...new Set([...required, ...properties])];
-}
-
-function applySchemaDefaults(
-  schema: unknown,
-  input: Record<string, unknown>,
-): Record<string, unknown> {
-  const result = { ...input };
-  for (const [key, descriptor] of Object.entries(readSchemaProperties(schema))) {
-    if (!isRecord(descriptor) || !("default" in descriptor) || result[key] !== undefined) {
-      continue;
-    }
-    result[key] = descriptor.default;
-  }
-  return result;
-}
-
 function mapMcpNamespaceInput(schema: unknown, args: unknown[]): unknown {
   if (args.length > 1) {
     throw new Error("MCP namespace tools accept one object argument.");
   }
   const firstArg = args[0];
-  const result: Record<string, unknown> =
+  const input: Record<string, unknown> =
     firstArg === undefined ? {} : isRecord(firstArg) ? { ...firstArg } : {};
   if (firstArg !== undefined && !isRecord(firstArg)) {
     throw new Error("MCP namespace tools accept one object argument.");
   }
-  const withDefaults = applySchemaDefaults(schema, result);
-  const missing = readRequiredKeys(schema).filter((key) => withDefaults[key] === undefined);
+  for (const [key, descriptor] of Object.entries(readMcpSchemaProperties(schema))) {
+    if (
+      !isRecord(descriptor) ||
+      !Object.hasOwn(descriptor, "default") ||
+      (Object.hasOwn(input, key) && input[key] !== undefined)
+    ) {
+      continue;
+    }
+    // MCP schemas are untrusted; defining an own key keeps __proto__ a value, not a setter.
+    Object.defineProperty(input, key, {
+      value: descriptor.default,
+      enumerable: true,
+      configurable: true,
+      writable: true,
+    });
+  }
+  const missing = readMcpRequiredKeys(schema).filter(
+    (key) => !Object.hasOwn(input, key) || input[key] === undefined,
+  );
   if (missing.length > 0) {
     throw new Error(
       `Missing required MCP namespace argument${missing.length === 1 ? "" : "s"}: ${missing.join(", ")}`,
     );
   }
-  return withDefaults;
-}
-
-function escapeDocComment(value: string): string {
-  return value.replace(/\*\//gu, "* /").trim();
-}
-
-function indent(lines: string[], prefix: string): string[] {
-  return lines.map((line) => `${prefix}${line}`);
-}
-
-function renderDocComment(
-  summary: string | undefined,
-  params: readonly McpApiParamDoc[],
-): string[] {
-  const lines: string[] = [];
-  const docLines = normalizeDocLines(summary);
-  if (docLines.length === 0 && params.length === 0) {
-    return lines;
-  }
-  lines.push("/**");
-  for (const line of docLines) {
-    lines.push(` * ${escapeDocComment(line)}`);
-  }
-  if (docLines.length > 0 && params.length > 0) {
-    lines.push(" *");
-  }
-  for (const param of params) {
-    const description = collapseDocText(param.description);
-    if (description) {
-      lines.push(
-        ` * @param ${param.name}${param.required ? "" : "?"} ${escapeDocComment(description)}`,
-      );
-    }
-  }
-  lines.push(" */");
-  return lines;
-}
-
-function normalizeDocLines(value: string | undefined): string[] {
-  if (!value) {
-    return [];
-  }
-  return value
-    .split(/\r?\n/u)
-    .map((line) => line.trim())
-    .filter(Boolean)
-    .slice(0, 12);
-}
-
-function collapseDocText(value: string | undefined): string {
-  return normalizeDocLines(value).join(" ");
-}
-
-function schemaType(schema: unknown): string {
-  const record = readSchemaRecord(schema);
-  if (!record) {
-    return "unknown";
-  }
-  const enumValues = Array.isArray(record.enum)
-    ? record.enum.filter(
-        (entry): entry is string | number | boolean =>
-          typeof entry === "string" || typeof entry === "number" || typeof entry === "boolean",
-      )
-    : [];
-  if (enumValues.length > 0 && enumValues.length <= 16) {
-    return enumValues.map((entry) => JSON.stringify(entry)).join(" | ");
-  }
-  const oneOf = Array.isArray(record.oneOf) ? record.oneOf : undefined;
-  const anyOf = Array.isArray(record.anyOf) ? record.anyOf : undefined;
-  const union = oneOf ?? anyOf;
-  if (union && union.length > 0 && union.length <= 8) {
-    return union.map((entry) => schemaType(entry)).join(" | ");
-  }
-  const type = record.type;
-  if (Array.isArray(type)) {
-    return type.map((entry) => schemaType({ ...record, type: entry })).join(" | ");
-  }
-  switch (type) {
-    case "string":
-      return "string";
-    case "integer":
-    case "number":
-      return "number";
-    case "boolean":
-      return "boolean";
-    case "array":
-      return `${schemaType(record.items)}[]`;
-    case "object":
-      return renderInlineObjectType(record);
-    case "null":
-      return "null";
-    default:
-      return Object.keys(readSchemaProperties(schema)).length > 0
-        ? renderInlineObjectType(record)
-        : "unknown";
-  }
-}
-
-function tsPropertyName(name: string): string {
-  return /^[A-Za-z_$][A-Za-z0-9_$]*$/u.test(name) ? name : JSON.stringify(name);
-}
-
-function renderInlineObjectType(schema: unknown): string {
-  const properties = readSchemaProperties(schema);
-  const keys = Object.keys(properties);
-  if (keys.length === 0) {
-    return "Record<string, unknown>";
-  }
-  const required = new Set(readRequiredKeys(schema));
-  return `{ ${keys
-    .map(
-      (key) =>
-        `${tsPropertyName(key)}${required.has(key) ? "" : "?"}: ${schemaType(properties[key])}`,
-    )
-    .join("; ")} }`;
-}
-
-type McpApiParamDoc = {
-  name: string;
-  required: boolean;
-  type: string;
-  description?: string;
-  defaultValue?: unknown;
-};
-
-type McpApiToolDoc = {
-  method: string;
-  path: string[];
-  mcpTool: string;
-  operation: NonNullable<CodeModeNamespaceCatalogEntry["mcp"]>["operation"];
-  description?: string;
-  parameters: unknown;
-  params: McpApiParamDoc[];
-};
-
-type McpApiServerDoc = {
-  identifier: string;
-  serverName: string;
-  nodeLabel?: string;
-  tools: McpApiToolDoc[];
-};
-
-/** Virtual TypeScript-style API file exposed to code mode. */
-export type CodeModeApiVirtualFile = {
-  path: string;
-  description?: string;
-  content: string;
-  bytes: number;
-};
-
-function buildMcpParamDocs(schema: unknown): McpApiParamDoc[] {
-  const required = new Set(readRequiredKeys(schema));
-  return orderedSchemaKeys(schema).map((key) => {
-    const descriptor = readSchemaProperties(schema)[key];
-    const doc: McpApiParamDoc = {
-      name: key,
-      required: required.has(key),
-      type: schemaType(descriptor),
-    };
-    const description = readSchemaString(descriptor, "description");
-    if (description) {
-      doc.description = description;
-    }
-    if (isRecord(descriptor) && "default" in descriptor) {
-      doc.defaultValue = descriptor.default;
-    }
-    return doc;
-  });
-}
-
-function renderMcpInputType(params: readonly McpApiParamDoc[]): string[] {
-  if (params.length === 0) {
-    return ["input?: Record<string, never>"];
-  }
-  const lines = ["input: {"];
-  for (const param of params) {
-    if (param.description || param.defaultValue !== undefined) {
-      const description = collapseDocText(param.description);
-      const suffix =
-        param.defaultValue === undefined ? "" : ` Default: ${JSON.stringify(param.defaultValue)}.`;
-      lines.push(`  /** ${escapeDocComment(`${description}${suffix}`.trim())} */`);
-    }
-    lines.push(`  ${tsPropertyName(param.name)}${param.required ? "" : "?"}: ${param.type};`);
-  }
-  lines.push("}");
-  return lines;
-}
-
-function renderMcpToolSignature(
-  tool: McpApiToolDoc,
-  functionName = tool.path.at(-1) ?? tool.method,
-): string[] {
-  const lines = renderDocComment(tool.description, tool.params);
-  lines.push(`function ${functionName}(`);
-  lines.push(...indent(renderMcpInputType(tool.params), "  "));
-  lines.push("): Promise<McpToolResult>;");
-  return lines;
-}
-
-function renderMcpServerHeader(server: McpApiServerDoc, tools: readonly McpApiToolDoc[]): string {
-  const lines = [
-    "type McpApiHeader = { header: string; tools?: unknown[]; schemas?: Record<string, unknown> };",
-    "",
-    "type McpToolResult = {",
-    "  content?: unknown[];",
-    "  structuredContent?: unknown;",
-    "  isError?: boolean;",
-    "  [key: string]: unknown;",
-    "};",
-    "",
-    `declare namespace MCP.${server.identifier} {`,
-    "  /** Return this TypeScript-style API header. */",
-    "  function $api(toolName?: string, options?: { schema?: boolean }): Promise<McpApiHeader>;",
-  ];
-  const topLevelTools = tools.filter((tool) => tool.path.length === 1);
-  const nestedTools = tools.filter((tool) => tool.path.length > 1);
-  for (const tool of topLevelTools) {
-    lines.push("");
-    lines.push(...indent(renderMcpToolSignature(tool), "  "));
-  }
-  const nestedGroups = new Map<string, McpApiToolDoc[]>();
-  for (const tool of nestedTools) {
-    const groupName = tool.path[0] ?? "tools";
-    nestedGroups.set(groupName, [...(nestedGroups.get(groupName) ?? []), tool]);
-  }
-  for (const [groupName, groupTools] of [...nestedGroups.entries()].toSorted((a, b) =>
-    a[0].localeCompare(b[0]),
-  )) {
-    lines.push("");
-    lines.push(`  namespace ${groupName} {`);
-    for (const tool of groupTools) {
-      lines.push("");
-      lines.push(...indent(renderMcpToolSignature(tool, tool.path.at(-1) ?? tool.method), "    "));
-    }
-    lines.push("  }");
-  }
-  lines.push("}");
-  return lines.join("\n");
-}
-
-function renderMcpRootHeader(servers: readonly McpApiServerDoc[]): string {
-  return [
-    "type McpApiHeader = { header: string; servers?: unknown[] };",
-    "",
-    "declare const MCP: {",
-    "  /** List visible MCP servers and request server-specific headers. */",
-    "  $api(): Promise<McpApiHeader>;",
-    ...servers.map((server) => `  readonly ${server.identifier}: typeof MCP.${server.identifier};`),
-    "};",
-  ].join("\n");
-}
-
-function renderMcpRootFile(servers: readonly McpApiServerDoc[]): string {
-  const references = servers.map(
-    (server) => `/// <reference path="./${server.identifier}.d.ts" />`,
-  );
-  return [...references, "", renderMcpRootHeader(servers)].join("\n");
-}
-
-function buildMcpApiResponse(params: {
-  servers: readonly McpApiServerDoc[];
-  server?: McpApiServerDoc;
-  args: unknown[];
-}) {
-  const [selector, options] = params.args;
-  const includeSchema = isRecord(options) && options.schema === true;
-  if (!params.server) {
-    return {
-      kind: "mcp_api",
-      scope: "root",
-      header: renderMcpRootHeader(params.servers),
-      servers: params.servers.map((server) => ({
-        identifier: server.identifier,
-        serverName: server.serverName,
-        toolCount: server.tools.length,
-      })),
-      note: "Call MCP.<server>.$api() for a TypeScript-style header, then call tools with one object argument matching the shown input type.",
-    };
-  }
-  const selected =
-    typeof selector === "string" && selector.trim()
-      ? params.server.tools.filter(
-          (tool) =>
-            tool.method === selector.trim() ||
-            tool.path.join(".") === selector.trim() ||
-            tool.mcpTool === selector.trim(),
-        )
-      : params.server.tools;
-  return {
-    kind: "mcp_api",
-    scope: selected.length === 1 ? "tool" : "server",
-    server: {
-      identifier: params.server.identifier,
-      serverName: params.server.serverName,
-    },
-    header: renderMcpServerHeader(params.server, selected),
-    tools: selected.map((tool) => ({
-      method: tool.method,
-      path: tool.path,
-      mcpTool: tool.mcpTool,
-      operation: tool.operation,
-      description: tool.description,
-    })),
-    ...(includeSchema
-      ? {
-          schemas: Object.fromEntries(selected.map((tool) => [tool.method, tool.parameters])),
-        }
-      : {}),
-    note: "Call MCP tools with one object argument, for example MCP.server.tool({ requiredField: value }).",
-  };
+  return input;
 }
 
 function scopeAtPath(
@@ -670,12 +347,14 @@ function mcpNodeLabel(node: NonNullable<McpNamespaceServer["node"]>): string {
 function createMcpNamespaceModel(
   catalog: readonly CodeModeNamespaceCatalogEntry[],
 ): McpNamespaceModel | undefined {
-  const mcpEntries = catalog.filter((entry) => entry.source === "mcp" && entry.id && entry.mcp);
+  const mcpEntries = catalog
+    .filter((entry) => entry.source === "mcp" && entry.id && entry.mcp)
+    .toSorted((a, b) => (a.id ?? "").localeCompare(b.id ?? ""));
   if (mcpEntries.length === 0) {
     return undefined;
   }
   const serversByKey = new Map<string, McpNamespaceServer>();
-  for (const entry of mcpEntries.toSorted((a, b) => (a.id ?? "").localeCompare(b.id ?? ""))) {
+  for (const entry of mcpEntries) {
     const mcp = entry.mcp;
     if (!mcp) {
       continue;
@@ -704,7 +383,7 @@ function createMcpNamespaceModel(
   const usedToolIdentifiers = new Map<string, Set<string>>();
   const root = Object.create(null) as CodeModeNamespaceScope;
   const serverDocs = new Map<string, McpApiServerDoc>();
-  for (const entry of mcpEntries.toSorted((a, b) => (a.id ?? "").localeCompare(b.id ?? ""))) {
+  for (const entry of mcpEntries) {
     const mcp = entry.mcp;
     if (!mcp || !entry.id) {
       continue;
@@ -774,12 +453,6 @@ function createMcpNamespaceModel(
   return { root, docs };
 }
 
-function createMcpNamespaceScope(
-  catalog: readonly CodeModeNamespaceCatalogEntry[],
-): CodeModeNamespaceScope | undefined {
-  return createMcpNamespaceModel(catalog)?.root;
-}
-
 const SWARM_AGENTS_API_CONTENT = `type AgentJsonSchema = Record<string, unknown>;
 
 interface AgentRunOptions {
@@ -814,44 +487,25 @@ declare function log(message: string): void;
 export function createCodeModeApiVirtualFiles(
   catalog: readonly CodeModeNamespaceCatalogEntry[] = [],
 ): CodeModeApiVirtualFile[] {
-  const files: CodeModeApiVirtualFile[] = [
+  return createCodeModeApiVirtualFilesFromModel(createMcpNamespaceModel(catalog));
+}
+
+function createCodeModeApiVirtualFilesFromModel(
+  model: McpNamespaceModel | undefined,
+): CodeModeApiVirtualFile[] {
+  return [
     {
       path: "agents.d.ts",
       description: "Swarm collector globals and orchestration idioms.",
       content: SWARM_AGENTS_API_CONTENT,
       bytes: Buffer.byteLength(SWARM_AGENTS_API_CONTENT, "utf8"),
     },
+    ...createMcpApiVirtualFiles(model?.docs ?? []),
   ];
-  const model = createMcpNamespaceModel(catalog);
-  if (!model) {
-    return files;
-  }
-  const rootContent = renderMcpRootFile(model.docs);
-  files.push({
-    path: "mcp/index.d.ts",
-    description: "Root MCP namespace declaration and server list.",
-    content: rootContent,
-    bytes: Buffer.byteLength(rootContent, "utf8"),
-  });
-  for (const server of model.docs) {
-    const content = renderMcpServerHeader(server, server.tools);
-    files.push({
-      path: `mcp/${server.identifier}.d.ts`,
-      description: `MCP server declaration for ${server.serverName}.`,
-      content,
-      bytes: Buffer.byteLength(content, "utf8"),
-    });
-  }
-  return files;
 }
 
-function createMcpNamespaceEntry(
-  catalog: readonly CodeModeNamespaceCatalogEntry[],
-): CodeModeNamespaceRuntimeEntry | undefined {
-  const scope = createMcpNamespaceScope(catalog);
-  if (!scope) {
-    return undefined;
-  }
+function createMcpNamespaceEntry(model: McpNamespaceModel): CodeModeNamespaceRuntimeEntry {
+  const { root: scope } = model;
   const callablePaths = new Set<string>();
   return {
     pluginId: "bundle-mcp",
@@ -987,14 +641,12 @@ function resolveNamespacePath(
 export function createCodeModeNamespaceRuntime(
   catalog: readonly CodeModeNamespaceCatalogEntry[] = [],
 ): CodeModeNamespaceRuntime {
-  const entries: CodeModeNamespaceRuntimeEntry[] = [];
-  const mcpEntry = createMcpNamespaceEntry(catalog);
-  if (mcpEntry) {
-    entries.push(mcpEntry);
-  }
+  const model = createMcpNamespaceModel(catalog);
+  const entries = model ? [createMcpNamespaceEntry(model)] : [];
   const byId = new Map(entries.map((entry) => [entry.descriptor.id, entry]));
   return {
     descriptors: entries.map((entry) => entry.descriptor),
+    apiFiles: createCodeModeApiVirtualFilesFromModel(model),
     async invoke(namespaceId, path, args, executeTool) {
       const entry = byId.get(namespaceId);
       if (!entry) {
@@ -1030,4 +682,3 @@ export function createCodeModeNamespaceRuntime(
     },
   };
 }
-/* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */

--- a/src/agents/code-mode-namespaces.ts
+++ b/src/agents/code-mode-namespaces.ts
@@ -483,27 +483,6 @@ declare function log(message: string): void;
 // Schema: const fact = await agents.run<{ answer: string }>("Research", { schema: { type: "object", properties: { answer: { type: "string" } }, required: ["answer"] } });
 `;
 
-/** Builds virtual API declaration files for visible guest and MCP namespace tools. */
-export function createCodeModeApiVirtualFiles(
-  catalog: readonly CodeModeNamespaceCatalogEntry[] = [],
-): CodeModeApiVirtualFile[] {
-  return createCodeModeApiVirtualFilesFromModel(createMcpNamespaceModel(catalog));
-}
-
-function createCodeModeApiVirtualFilesFromModel(
-  model: McpNamespaceModel | undefined,
-): CodeModeApiVirtualFile[] {
-  return [
-    {
-      path: "agents.d.ts",
-      description: "Swarm collector globals and orchestration idioms.",
-      content: SWARM_AGENTS_API_CONTENT,
-      bytes: Buffer.byteLength(SWARM_AGENTS_API_CONTENT, "utf8"),
-    },
-    ...createMcpApiVirtualFiles(model?.docs ?? []),
-  ];
-}
-
 function createMcpNamespaceEntry(model: McpNamespaceModel): CodeModeNamespaceRuntimeEntry {
   const { root: scope } = model;
   const callablePaths = new Set<string>();
@@ -646,7 +625,15 @@ export function createCodeModeNamespaceRuntime(
   const byId = new Map(entries.map((entry) => [entry.descriptor.id, entry]));
   return {
     descriptors: entries.map((entry) => entry.descriptor),
-    apiFiles: createCodeModeApiVirtualFilesFromModel(model),
+    apiFiles: [
+      {
+        path: "agents.d.ts",
+        description: "Swarm collector globals and orchestration idioms.",
+        content: SWARM_AGENTS_API_CONTENT,
+        bytes: Buffer.byteLength(SWARM_AGENTS_API_CONTENT, "utf8"),
+      },
+      ...createMcpApiVirtualFiles(model?.docs ?? []),
+    ],
     async invoke(namespaceId, path, args, executeTool) {
       const entry = byId.get(namespaceId);
       if (!entry) {

--- a/src/agents/code-mode-runtime.ts
+++ b/src/agents/code-mode-runtime.ts
@@ -6,7 +6,7 @@ import { createLazyPromiseLoader } from "../shared/lazy-runtime.js";
 import { clampNumber } from "../utils.js";
 import { resolveAgentConfig } from "./agent-scope-config.js";
 import { toCodeModeJsonSafe } from "./code-mode-json.js";
-import { createCodeModeApiVirtualFiles } from "./code-mode-namespaces.js";
+import type { CodeModeNamespaceRuntime } from "./code-mode-namespaces.js";
 import {
   CODE_MODE_SHELL_SOURCE_ERROR,
   isShellLikeCodeModeSource,
@@ -629,10 +629,10 @@ export function errorMessage(error: unknown): string {
 }
 
 export function createCodeModeApiFilesForRun(
-  catalog: Parameters<typeof createCodeModeApiVirtualFiles>[0],
+  namespaceRuntime: CodeModeNamespaceRuntime,
   swarmEnabled: boolean,
 ) {
-  const files = createCodeModeApiVirtualFiles(catalog);
+  const { apiFiles: files } = namespaceRuntime;
   return swarmEnabled ? files : files.filter((file) => file.path !== "agents.d.ts");
 }
 

--- a/src/agents/code-mode-swarm.test.ts
+++ b/src/agents/code-mode-swarm.test.ts
@@ -1,6 +1,6 @@
 import { createHash } from "node:crypto";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { createCodeModeApiVirtualFiles } from "./code-mode-namespaces.js";
+import { createCodeModeNamespaceRuntime } from "./code-mode-namespaces.js";
 import { resolveCodeModeConfig } from "./code-mode.js";
 import { testing } from "./code-mode.test-support.js";
 import { stableStringify } from "./stable-stringify.js";
@@ -201,7 +201,7 @@ describe("Code Mode swarm guest", () => {
   });
 
   it("documents the typed swarm API and orchestration idioms", () => {
-    const files = createCodeModeApiVirtualFiles([]);
+    const { apiFiles: files } = createCodeModeNamespaceRuntime();
 
     expect(files.map((file) => file.path)).toEqual(["agents.d.ts"]);
     expect(files[0]?.content).toContain("Promise.all");


### PR DESCRIPTION
## What Problem This Solves

Code Mode rebuilt equivalent MCP namespace descriptions and virtual TypeScript declarations repeatedly for one run, kept an oversized grandfathered namespace module, and allowed inherited object properties to satisfy untrusted MCP schema inputs.

## Why This Change Was Made

Prepare one run-owned MCP namespace model and its virtual API files, split declaration rendering into its owner module, remove the stale max-lines exception, and require own input properties for MCP schema validation.

## User Impact

Code Mode uses less repeated namespace work, better rejects hostile MCP schemas, and reduces production code by 11 lines.

## Evidence

- Fresh independent autoreview and independent MCP security audit report no actionable findings.
- Blacksmith Testbox passes namespace, existing Code Mode, headless, node-plugin, swarm, and worker-lifecycle suites.
- New regressions cover constructor/toString/prototype schema properties, exact declaration bytes and per-run snapshot ownership.
- Checked the upstream Codex session, callback and namespace contracts directly.
