### PR TITLE
refactor(code-mode): unify safe OpenAI tool filtering

### DIFF
--- a/packages/ai/src/transports/openai-transport-params.code-mode.test.ts
+++ b/packages/ai/src/transports/openai-transport-params.code-mode.test.ts
@@ -41,7 +41,7 @@ describe("OpenAI Code Mode payload tool names", () => {
           { name: "computer" },
           withThrowingGetter("name"),
         ],
-      } as Parameters<typeof resolveCodeModeResponsesVisibleToolNames>[0]),
+      } as unknown as Parameters<typeof resolveCodeModeResponsesVisibleToolNames>[0]),
     ).toEqual(new Set(["exec", "wait", "computer"]));
   });
 });

--- a/packages/ai/src/transports/openai-transport-params.code-mode.test.ts
+++ b/packages/ai/src/transports/openai-transport-params.code-mode.test.ts
@@ -1,0 +1,147 @@
+import { describe, expect, it } from "vitest";
+import {
+  assertCodeModeResponsesToolSurface,
+  enforceCodeModeResponsesToolSurface,
+  filterCodeModePayloadTools,
+  readCodeModePayloadToolName,
+  resolveCodeModeResponsesVisibleToolNames,
+} from "./openai-transport-params.js";
+
+function withThrowingGetter(field: string): Record<string, unknown> {
+  return Object.defineProperty({}, field, {
+    enumerable: true,
+    get() {
+      throw new Error(`unexpected ${field} getter`);
+    },
+  }) as Record<string, unknown>;
+}
+
+describe("OpenAI Code Mode payload tool names", () => {
+  it.each([
+    ["direct declaration", { name: "exec" }, "exec"],
+    ["nested declaration", { function: { name: "wait" } }, "wait"],
+    ["nested fallback", { name: 7, function: { name: "computer" } }, "computer"],
+    ["inherited declaration", Object.create({ name: "exec" }), undefined],
+    ["missing declaration", {}, undefined],
+    ["non-record declaration", null, undefined],
+  ])("reads a %s", (_description, tool, expected) => {
+    expect(readCodeModePayloadToolName(tool)).toBe(expected);
+  });
+
+  it.each(["name", "function"])("rejects a throwing %s getter", (field) => {
+    expect(readCodeModePayloadToolName(withThrowingGetter(field))).toBeUndefined();
+  });
+
+  it("uses only tool names declared in the current request", () => {
+    expect(
+      resolveCodeModeResponsesVisibleToolNames({
+        tools: [
+          { name: "exec" },
+          { function: { name: "wait" } },
+          { name: "computer" },
+          withThrowingGetter("name"),
+        ],
+      } as Parameters<typeof resolveCodeModeResponsesVisibleToolNames>[0]),
+    ).toEqual(new Set(["exec", "wait", "computer"]));
+  });
+});
+
+describe("OpenAI Code Mode payload tool filtering", () => {
+  const visibleToolNames = new Set(["exec", "wait", "computer"]);
+
+  it.each(["functionDeclarations", "function_declarations"] as const)(
+    "filters grouped %s without admitting provider-native tools",
+    (field) => {
+      const payload: { tools: unknown[] } = {
+        tools: [
+          { type: "function", name: "exec" },
+          { type: "function", function: { name: "wait" } },
+          {
+            [field]: [
+              { name: "computer", parameters: { type: "object" } },
+              { name: "web_search", parameters: { type: "object" } },
+              withThrowingGetter("name"),
+            ],
+          },
+          { type: "web_search" },
+          withThrowingGetter("name"),
+        ],
+      };
+
+      filterCodeModePayloadTools(payload, visibleToolNames);
+
+      expect(payload.tools).toEqual([
+        { type: "function", name: "exec" },
+        { type: "function", function: { name: "wait" } },
+        { [field]: [{ name: "computer", parameters: { type: "object" } }] },
+      ]);
+    },
+  );
+
+  it.each(["functionDeclarations", "function_declarations"] as const)(
+    "rejects a throwing %s getter without exposing the group",
+    (field) => {
+      const payload: { tools: unknown[] } = {
+        tools: [{ name: "exec" }, { name: "wait" }, withThrowingGetter(field)],
+      };
+
+      expect(() => filterCodeModePayloadTools(payload, visibleToolNames)).not.toThrow();
+      expect(payload.tools).toEqual([{ name: "exec" }, { name: "wait" }]);
+    },
+  );
+
+  it("ignores a throwing payload tools getter", () => {
+    expect(() =>
+      filterCodeModePayloadTools(withThrowingGetter("tools"), visibleToolNames),
+    ).not.toThrow();
+  });
+
+  it("keeps the existing Responses and Completions enforcement contract", () => {
+    const payload = {
+      tools: [{ name: "exec" }, { name: "web_search" }, { name: "wait" }],
+    };
+
+    enforceCodeModeResponsesToolSurface(payload, visibleToolNames);
+
+    expect(payload.tools).toEqual([{ name: "exec" }, { name: "wait" }]);
+    expect(() => assertCodeModeResponsesToolSurface(payload, visibleToolNames)).not.toThrow();
+  });
+
+  it.each(["functionDeclarations", "function_declarations"] as const)(
+    "rejects and removes grouped %s from final OpenAI payloads",
+    (field) => {
+      const payload = {
+        tools: [
+          { name: "exec" },
+          { name: "wait" },
+          { [field]: [{ name: "exec" }, { name: "computer" }] },
+        ],
+      };
+
+      expect(() => assertCodeModeResponsesToolSurface(payload, visibleToolNames)).toThrow(
+        /tool surface violation/,
+      );
+
+      enforceCodeModeResponsesToolSurface(payload, visibleToolNames);
+
+      expect(payload.tools).toEqual([{ name: "exec" }, { name: "wait" }]);
+      expect(() => assertCodeModeResponsesToolSurface(payload, visibleToolNames)).not.toThrow();
+    },
+  );
+
+  it.each([
+    [{ name: "exec" }, { name: "exec" }, { name: "wait" }],
+    [{ name: "exec" }, { name: "computer" }],
+    [{ name: "exec" }, { name: "wait" }, { name: "web_search" }],
+  ])("rejects duplicate, missing, or undeclared controls", (...tools) => {
+    expect(() => assertCodeModeResponsesToolSurface({ tools }, visibleToolNames)).toThrow(
+      /tool surface violation/,
+    );
+  });
+
+  it("fails closed when the asserted payload tools getter throws", () => {
+    expect(() =>
+      assertCodeModeResponsesToolSurface(withThrowingGetter("tools"), visibleToolNames),
+    ).toThrow(/tool surface violation/);
+  });
+});

--- a/packages/ai/src/transports/openai-transport-params.ts
+++ b/packages/ai/src/transports/openai-transport-params.ts
@@ -20,13 +20,13 @@ const loggedOpenAIStrictToolDowngradeDiagnosticKeys = new Set<string>();
 
 function readToolPayloadField(record: Record<string, unknown>, field: string): unknown {
   try {
-    return record[field];
+    return Object.hasOwn(record, field) ? record[field] : undefined;
   } catch {
     return undefined;
   }
 }
 
-function transportPayloadToolName(tool: unknown): string | undefined {
+export function readCodeModePayloadToolName(tool: unknown): string | undefined {
   if (!isRecord(tool)) {
     return undefined;
   }
@@ -42,12 +42,52 @@ function transportPayloadToolName(tool: unknown): string | undefined {
   return typeof fnName === "string" ? fnName : undefined;
 }
 
+export function filterCodeModePayloadTools(
+  payload: unknown,
+  visibleToolNames: ReadonlySet<string>,
+): void {
+  if (!isRecord(payload)) {
+    return;
+  }
+  const tools = readToolPayloadField(payload, "tools");
+  if (!Array.isArray(tools)) {
+    return;
+  }
+  payload.tools = tools.flatMap((tool) => {
+    const name = readCodeModePayloadToolName(tool);
+    if (typeof name === "string" && isCodeModeModelVisibleToolName(name, visibleToolNames)) {
+      return [tool];
+    }
+    if (!isRecord(tool)) {
+      return [];
+    }
+    const filteredGroups: Record<string, unknown> = {};
+    for (const key of ["functionDeclarations", "function_declarations"] as const) {
+      const declarations = readToolPayloadField(tool, key);
+      if (!Array.isArray(declarations)) {
+        continue;
+      }
+      const filtered = declarations.filter((declaration) => {
+        const declarationName = readCodeModePayloadToolName(declaration);
+        return (
+          typeof declarationName === "string" &&
+          isCodeModeModelVisibleToolName(declarationName, visibleToolNames)
+        );
+      });
+      if (filtered.length > 0) {
+        filteredGroups[key] = filtered;
+      }
+    }
+    return Object.keys(filteredGroups).length > 0 ? [filteredGroups] : [];
+  });
+}
+
 export function resolveCodeModeResponsesVisibleToolNames(
   context: Pick<Context, "tools">,
 ): ReadonlySet<string> {
   return new Set(
     (context.tools ?? [])
-      .map(transportPayloadToolName)
+      .map(readCodeModePayloadToolName)
       .filter((name): name is string => typeof name === "string"),
   );
 }
@@ -56,11 +96,15 @@ export function enforceCodeModeResponsesToolSurface(
   payload: unknown,
   visibleToolNames: ReadonlySet<string>,
 ): void {
-  if (!isRecord(payload) || !Array.isArray(payload.tools)) {
+  if (!isRecord(payload)) {
     return;
   }
-  payload.tools = payload.tools.filter((tool) => {
-    const name = transportPayloadToolName(tool);
+  const tools = readToolPayloadField(payload, "tools");
+  if (!Array.isArray(tools)) {
+    return;
+  }
+  payload.tools = tools.filter((tool) => {
+    const name = readCodeModePayloadToolName(tool);
     return typeof name === "string" && isCodeModeModelVisibleToolName(name, visibleToolNames);
   });
 }
@@ -69,18 +113,20 @@ export function assertCodeModeResponsesToolSurface(
   payload: unknown,
   visibleToolNames: ReadonlySet<string>,
 ): void {
-  if (!isRecord(payload) || !Array.isArray(payload.tools)) {
+  const tools = isRecord(payload) ? readToolPayloadField(payload, "tools") : undefined;
+  if (!Array.isArray(tools)) {
     throw new Error("Code mode payload tool surface violation: expected exec,wait; got no tools");
   }
-  const names = payload.tools
-    .map(transportPayloadToolName)
+  const names = tools
+    .map(readCodeModePayloadToolName)
     .filter((name): name is string => typeof name === "string" && name.length > 0)
     .toSorted((left, right) => left.localeCompare(right));
   if (
     names.length >= 2 &&
+    names.length === tools.length &&
     new Set(names).size === names.length &&
-    names.filter((name) => name === "exec").length === 1 &&
-    names.filter((name) => name === "wait").length === 1 &&
+    names.includes("exec") &&
+    names.includes("wait") &&
     names.every((name) => isCodeModeModelVisibleToolName(name, visibleToolNames))
   ) {
     return;

--- a/src/llm/providers/stream-wrappers/openai.test.ts
+++ b/src/llm/providers/stream-wrappers/openai.test.ts
@@ -325,64 +325,67 @@ describe("createCodexNativeWebSearchWrapper", () => {
     ]);
   });
 
-  it("keeps grouped provider tool declarations when code mode filters the payload", () => {
-    const payloads: Array<Record<string, unknown>> = [];
-    const baseStreamFn: StreamFn = (model, context, options) => {
-      const payload: Record<string, unknown> = {
-        model: model.id,
-        tools: [
-          {
-            functionDeclarations: [
-              { name: "exec", description: "Run code" },
-              { name: "sessions_yield", description: "Yield the current session" },
-              { name: "structured_output", description: "Return a structured response" },
-              { name: "computer", description: "Control a desktop" },
-              { name: "image", description: "Read an image" },
-              { name: "message", description: "Deliver the response" },
-              { name: "read", description: "Read a file" },
-              { name: "wait", description: "Resume code" },
-            ],
-          },
-          { google_search: {} },
-        ],
+  it.each(["functionDeclarations", "function_declarations"] as const)(
+    "keeps grouped %s when code mode filters the payload",
+    (declarationField) => {
+      const payloads: Array<Record<string, unknown>> = [];
+      const baseStreamFn: StreamFn = (model, context, options) => {
+        const payload: Record<string, unknown> = {
+          model: model.id,
+          tools: [
+            {
+              [declarationField]: [
+                { name: "exec", description: "Run code" },
+                { name: "sessions_yield", description: "Yield the current session" },
+                { name: "structured_output", description: "Return a structured response" },
+                { name: "computer", description: "Control a desktop" },
+                { name: "image", description: "Read an image" },
+                { name: "message", description: "Deliver the response" },
+                { name: "read", description: "Read a file" },
+                { name: "wait", description: "Resume code" },
+              ],
+            },
+            { google_search: {} },
+          ],
+        };
+        options?.onPayload?.(payload, model);
+        payloads.push(structuredClone(payload));
+        return createAssistantMessageEventStream();
       };
-      options?.onPayload?.(payload, model);
-      payloads.push(structuredClone(payload));
-      return createAssistantMessageEventStream();
-    };
-    const wrapped = createCodexNativeWebSearchWrapper(baseStreamFn, {
-      codeModeToolSurfaceEnabled: true,
-    });
+      const wrapped = createCodexNativeWebSearchWrapper(baseStreamFn, {
+        codeModeToolSurfaceEnabled: true,
+      });
 
-    void wrapped(
-      {
-        api: "google-generative-ai",
-        provider: "google",
-        id: "gemini-3.1-pro",
-      } as never,
-      {
-        messages: [],
-        tools: [
-          { name: "exec", description: "", parameters: {} },
-          { name: "wait", description: "", parameters: {} },
-          { name: "sessions_yield", description: "", parameters: {} },
-          { name: "structured_output", description: "", parameters: {} },
-        ],
-      },
-      {},
-    );
+      void wrapped(
+        {
+          api: "google-generative-ai",
+          provider: "google",
+          id: "gemini-3.1-pro",
+        } as never,
+        {
+          messages: [],
+          tools: [
+            { name: "exec", description: "", parameters: {} },
+            { name: "wait", description: "", parameters: {} },
+            { name: "sessions_yield", description: "", parameters: {} },
+            { name: "structured_output", description: "", parameters: {} },
+          ],
+        },
+        {},
+      );
 
-    expect(payloads[0]?.tools).toEqual([
-      {
-        functionDeclarations: [
-          { name: "exec", description: "Run code" },
-          { name: "sessions_yield", description: "Yield the current session" },
-          { name: "structured_output", description: "Return a structured response" },
-          { name: "wait", description: "Resume code" },
-        ],
-      },
-    ]);
-  });
+      expect(payloads[0]?.tools).toEqual([
+        {
+          [declarationField]: [
+            { name: "exec", description: "Run code" },
+            { name: "sessions_yield", description: "Yield the current session" },
+            { name: "structured_output", description: "Return a structured response" },
+            { name: "wait", description: "Resume code" },
+          ],
+        },
+      ]);
+    },
+  );
 
   it("does not inject native web_search when agent policy denies web search", () => {
     const payloads: Array<Record<string, unknown>> = [];

--- a/src/llm/providers/stream-wrappers/openai.ts
+++ b/src/llm/providers/stream-wrappers/openai.ts
@@ -2,7 +2,11 @@ import {
   resolveOpenAIReasoningEffortForModel,
   supportsOpenAIReasoningEffort,
 } from "@openclaw/ai/internal/openai";
-import { emitModelTransportDebug, isCodeModeModelVisibleToolName } from "@openclaw/ai/transports";
+import {
+  emitModelTransportDebug,
+  filterCodeModePayloadTools,
+  readCodeModePayloadToolName,
+} from "@openclaw/ai/transports";
 import {
   flattenCompletionMessagesToStringContent,
   stripCompletionMessagesToRoleContent,
@@ -129,98 +133,12 @@ function isCodeModeEnabled(config?: OpenClawConfig): boolean {
   );
 }
 
-function readPayloadToolField(record: Record<string, unknown>, field: string): unknown {
-  try {
-    return record[field];
-  } catch {
-    return undefined;
-  }
-}
-
 function isPromiseLike(value: unknown): value is PromiseLike<unknown> {
   return (
     value !== null &&
     (typeof value === "object" || typeof value === "function") &&
     typeof (value as { then?: unknown }).then === "function"
   );
-}
-
-function readPayloadToolName(tool: unknown): string | undefined {
-  if (!tool || typeof tool !== "object") {
-    return undefined;
-  }
-  const record = tool as Record<string, unknown>;
-  const name = readPayloadToolField(record, "name");
-  if (typeof name === "string") {
-    return name;
-  }
-  const fn = readPayloadToolField(record, "function");
-  if (!fn || typeof fn !== "object") {
-    return undefined;
-  }
-  const fnName = readPayloadToolField(fn as Record<string, unknown>, "name");
-  return typeof fnName === "string" ? fnName : undefined;
-}
-
-function isCodeModePayloadToolName(
-  name: string | undefined,
-  visibleToolNames: ReadonlySet<string>,
-): boolean {
-  return typeof name === "string" && isCodeModeModelVisibleToolName(name, visibleToolNames);
-}
-
-function filterCodeModeToolDeclarations(
-  declarations: unknown,
-  visibleToolNames: ReadonlySet<string>,
-): unknown[] | undefined {
-  if (!Array.isArray(declarations)) {
-    return undefined;
-  }
-  return declarations.filter((declaration) =>
-    isCodeModePayloadToolName(readPayloadToolName(declaration), visibleToolNames),
-  );
-}
-
-function filterCodeModeGroupedToolDeclarations(
-  tool: unknown,
-  visibleToolNames: ReadonlySet<string>,
-): Record<string, unknown> | undefined {
-  if (!tool || typeof tool !== "object" || Array.isArray(tool)) {
-    return undefined;
-  }
-  const record = tool as Record<string, unknown>;
-  const filteredGroups: Record<string, unknown> = {};
-  for (const key of ["functionDeclarations", "function_declarations"] as const) {
-    const filtered = filterCodeModeToolDeclarations(
-      readPayloadToolField(record, key),
-      visibleToolNames,
-    );
-    if (filtered === undefined) {
-      continue;
-    }
-    if (filtered.length > 0) {
-      filteredGroups[key] = filtered;
-    }
-  }
-  return Object.keys(filteredGroups).length > 0 ? filteredGroups : undefined;
-}
-
-function filterCodeModePayloadTools(payload: unknown, visibleToolNames: ReadonlySet<string>): void {
-  if (!payload || typeof payload !== "object") {
-    return;
-  }
-  const record = payload as { tools?: unknown };
-  if (!Array.isArray(record.tools)) {
-    return;
-  }
-  record.tools = record.tools.flatMap((tool) => {
-    const name = readPayloadToolName(tool);
-    if (isCodeModePayloadToolName(name, visibleToolNames)) {
-      return [tool];
-    }
-    const grouped = filterCodeModeGroupedToolDeclarations(tool, visibleToolNames);
-    return grouped ? [grouped] : [];
-  });
 }
 
 function filterCodeModePayloadHookResult(
@@ -241,7 +159,7 @@ function resolveCodeModeVisibleToolNames(context: {
   }
   const names = new Set(
     context.tools
-      .map(readPayloadToolName)
+      .map(readCodeModePayloadToolName)
       .filter((name): name is string => typeof name === "string"),
   );
   return names.has("exec") && names.has("wait") ? names : undefined;

--- a/src/llm/providers/stream-wrappers/openai.ts
+++ b/src/llm/providers/stream-wrappers/openai.ts
@@ -5,6 +5,7 @@ import {
 import {
   emitModelTransportDebug,
   filterCodeModePayloadTools,
+  isCodeModeModelVisibleToolName,
   readCodeModePayloadToolName,
 } from "@openclaw/ai/transports";
 import {
@@ -162,7 +163,10 @@ function resolveCodeModeVisibleToolNames(context: {
       .map(readCodeModePayloadToolName)
       .filter((name): name is string => typeof name === "string"),
   );
-  return names.has("exec") && names.has("wait") ? names : undefined;
+  return isCodeModeModelVisibleToolName("exec", names) &&
+    isCodeModeModelVisibleToolName("wait", names)
+    ? names
+    : undefined;
 }
 
 function shouldApplyOpenAIReasoningCompatibility(model: {


### PR DESCRIPTION
## What Problem This Solves

OpenAI Responses, Completions and streaming wrappers independently parsed and filtered Code Mode tools, permitting inconsistent handling of grouped and hostile provider declarations.

## Why This Change Was Made

Use one safe package-owned declaration reader, keep grouped declarations in generic stream wrappers, and enforce a strictly flat exact tool surface at both terminal OpenAI request paths.

## User Impact

Code Mode prevents malformed or duplicate grouped tools from reaching OpenAI requests and reduces production code by 36 lines.

## Evidence

- Fresh independent autoreview and adversarial provider-contract audit, with the discovered grouped-injection defect fixed before publication.
- Blacksmith Testbox: all four Responses, Completions, package, streaming, and compatibility regression suites pass.
- Regression covers camel-case and snake-case grouped injection, inherited and throwing getters, direct-only request context, async replacement, and public API stability.
- Personally inspected upstream Codex tool specifications and execution contracts.
