### PR TITLE
refactor(chat): remove duplicate session projection paths

### DIFF
--- a/ui/src/pages/chat/chat-gateway.test.ts
+++ b/ui/src/pages/chat/chat-gateway.test.ts
@@ -2251,28 +2251,23 @@ describe("authoritative terminal history identity", () => {
       runIdBeforeApply: "run-1",
     });
 
-    const currentMessages = [liveTerminal];
     const previousMessages = [liveTerminal];
     const collided = reconcileAuthoritativeTerminalHistory({
-      currentMessages,
       host,
       previousMessages,
       sessionKey: "main",
       visibleMessages: [collision],
     });
-    expect(collided.currentMessages).toEqual(currentMessages);
-    expect(collided.previousMessages).toEqual(previousMessages);
+    expect(collided).toEqual(previousMessages);
     expect(authoritativeHistoryAppliedForRun(host, "run-1")).toBe(false);
 
     const persisted = reconcileAuthoritativeTerminalHistory({
-      currentMessages,
       host,
       previousMessages,
       sessionKey: "main",
       visibleMessages: [collision, nativeTerminal],
     });
-    expect(persisted.currentMessages).toEqual([]);
-    expect(persisted.previousMessages).toEqual([]);
+    expect(persisted).toEqual([]);
     expect(authoritativeHistoryAppliedForRun(host, "run-1")).toBe(true);
   });
 });

--- a/ui/src/pages/chat/chat-gateway.ts
+++ b/ui/src/pages/chat/chat-gateway.ts
@@ -1,6 +1,5 @@
 import {
   hasSessionProjectionAcceptedFinal,
-  reduceSessionProjection,
   reduceSessionProjectionRunEvent,
 } from "@openclaw/gateway-client/browser";
 import { isAssistantHeartbeatAckForDisplay } from "../../lib/chat/heartbeat-display.ts";
@@ -17,7 +16,12 @@ import {
   type ChatEventPayload,
   type ChatState,
 } from "./chat-history.ts";
-import { getChatSessionProjection, setChatSessionProjection } from "./history-merge.ts";
+import {
+  getChatSessionProjection,
+  readChatSessionProjectionScope,
+  reduceChatSessionProjection,
+  setChatSessionProjection,
+} from "./history-merge.ts";
 import { reconcileChatRunLifecycle } from "./run-lifecycle.ts";
 import { appendChatMessageToCache } from "./session-message-cache.ts";
 import { retireSteeredChipsForTerminalRun } from "./steer-lifecycle.ts";
@@ -230,21 +234,15 @@ function handleChatEvent(
     }
     return null;
   }
-  const scope = {
-    sessionKey: state.sessionKey,
-    ...(state.currentSessionId ? { sessionId: state.currentSessionId } : {}),
-    ...(state.chatDisplayedLeafEntryId !== undefined
-      ? { activeLeafEntryId: state.chatDisplayedLeafEntryId }
-      : {}),
-  };
+  const scope = readChatSessionProjectionScope(state);
   const publishVisibleFinal = (
     message: Record<string, unknown>,
     visibleMessages: unknown[],
     runId: string | null | undefined,
   ): void => {
     const event = payload as ChatEventPayload & { messageId?: unknown; messageSeq?: unknown };
-    const projection = reduceSessionProjection(
-      getChatSessionProjection(state, visibleMessages.slice(0, -1), scope),
+    reduceChatSessionProjection(
+      state,
       {
         type: "messagePersisted",
         message,
@@ -253,11 +251,9 @@ function handleChatEvent(
           ...(event.messageId === undefined ? {} : { messageId: event.messageId }),
           ...(event.messageSeq === undefined ? {} : { messageSeq: event.messageSeq }),
         },
-        scope,
       },
+      { scope, messages: visibleMessages.slice(0, -1) },
     );
-    setChatSessionProjection(state, projection);
-    state.chatMessages = [...projection.messages];
   };
   const projectedRun =
     payload.runId && payload.state !== "status"

--- a/ui/src/pages/chat/chat-history.ts
+++ b/ui/src/pages/chat/chat-history.ts
@@ -1,9 +1,5 @@
 // Control UI page module owns Chat transcript loading and selected-session message subscription.
-import {
-  readSessionMessageSequence,
-  reduceSessionProjection,
-  type SessionProjectionScope,
-} from "@openclaw/gateway-client/browser";
+import { readSessionMessageSequence } from "@openclaw/gateway-client/browser";
 import type { CommandsListResult } from "../../../../packages/gateway-protocol/src/index.js";
 import type { GatewayBrowserClient, GatewayHelloOk } from "../../api/gateway.ts";
 import type {
@@ -55,7 +51,7 @@ import {
 } from "./chat-history-retry.ts";
 import type { ChatRunStartupPhase, ChatRunStartupState } from "./chat-run-startup.ts";
 import { persistChatComposerState } from "./composer-persistence.ts";
-import { getChatSessionProjection, setChatSessionProjection } from "./history-merge.ts";
+import { readChatSessionProjectionScope, reduceChatSessionProjection } from "./history-merge.ts";
 import { reconcileInitialUserMessageHandoff } from "./initial-turn-handoff.ts";
 import {
   controlUiNowMs,
@@ -152,21 +148,10 @@ function resetChatHistoryProjection(state: ChatState, agentId?: string): void {
   chatHistoryRequestVersions.set(owner, (chatHistoryRequestVersions.get(owner) ?? 0) + 1);
   inFlightChatHistoryRequests.delete(state);
   state.chatLoading = false;
-  const scope: SessionProjectionScope = {
-    sessionKey: state.sessionKey,
-    ...(agentId ? { agentId } : {}),
-    ...(state.currentSessionId ? { sessionId: state.currentSessionId } : {}),
-    ...(Object.hasOwn(state, "chatDisplayedLeafEntryId")
-      ? { activeLeafEntryId: state.chatDisplayedLeafEntryId ?? null }
-      : {}),
-  };
-  const projection = getChatSessionProjection(state, state.chatMessages, scope);
+  const scope = readChatSessionProjectionScope(state, { agentId });
   // Destructive operations keep the public session key, so only an explicit
   // reducer reset can prevent old live or pending rows from crossing epochs.
-  setChatSessionProjection(
-    state,
-    reduceSessionProjection(projection, { type: "sessionReset", scope }),
-  );
+  reduceChatSessionProjection(state, { type: "sessionReset" }, { scope });
 }
 
 export function isSilentReplyStream(text: string): boolean {
@@ -1000,7 +985,6 @@ export async function clearChatHistory(
         // ambiguous reset may already have destroyed. Clearing first also
         // prevents history loading from preserving a pre-reset optimistic tail.
         resetChatHistoryProjection(state, agentParams.agentId);
-        state.chatMessages = [];
         historyRefreshed = Boolean(await loadChatHistory(state));
       }
       setChatError(
@@ -1023,7 +1007,6 @@ export async function clearChatHistory(
     return "completed";
   }
   resetChatHistoryProjection(state, agentParams.agentId);
-  state.chatMessages = [];
   state.chatRunError = null;
   state.chatReplyTarget = null;
   reconcileChatRunLifecycle(state, {
@@ -1067,7 +1050,6 @@ export async function rewindChatHistory(
       return null;
     }
     resetChatHistoryProjection(state, agentParams.agentId);
-    state.chatMessages = [];
     await Promise.all([loadChatHistory(state), loadChatBranches(state)]);
     if (!visibleSessionMatches(state, sessionKey, agentParams.agentId)) {
       return null;
@@ -1108,7 +1090,6 @@ export async function switchChatHistoryBranch(
       return false;
     }
     resetChatHistoryProjection(state, agentParams.agentId);
-    state.chatMessages = [];
     await Promise.all([loadChatHistory(state), loadChatBranches(state)]);
     return visibleSessionMatches(state, sessionKey, agentParams.agentId);
   } catch (error) {
@@ -1340,8 +1321,7 @@ async function loadChatHistoryUncached(
     const nextSessionId = resolveChatHistorySessionId(res);
     applyChatAgentsList(state, res.agentsList, client);
     const visibleMessages = messages.filter((message) => !shouldHideHistoryMessage(message));
-    const reconciledTerminal = reconcileAuthoritativeTerminalHistory({
-      currentMessages: state.chatMessages,
+    const previousTerminalMessages = reconcileAuthoritativeTerminalHistory({
       host: state,
       previousMessages,
       sessionKey,
@@ -1358,36 +1338,31 @@ async function loadChatHistoryUncached(
       nextMessages: visibleMessages,
       nextPagination,
       nextSessionId,
-      previousMessages: retainsTranscriptIdentity ? reconciledTerminal.previousMessages : [],
+      previousMessages: retainsTranscriptIdentity ? previousTerminalMessages : [],
       previousPagination,
       previousSessionId,
     });
     const authoritativeMessages = reconciledHistory?.messages ?? visibleMessages;
-    const scope: SessionProjectionScope = {
+    const scope = readChatSessionProjectionScope(state, {
       sessionKey,
-      ...(requestAgentId ? { agentId: requestAgentId } : {}),
-      ...(nextSessionId ? { sessionId: nextSessionId } : {}),
-      ...(Object.hasOwn(res.sessionInfo ?? {}, "activeLeafEntryId") ||
-      Object.hasOwn(state, "chatDisplayedLeafEntryId")
+      agentId: requestAgentId,
+      sessionId: nextSessionId,
+      ...(Object.hasOwn(res.sessionInfo ?? {}, "activeLeafEntryId")
         ? { activeLeafEntryId: nextDisplayedLeafEntryId }
         : {}),
-    };
+    });
     // Only the pane-owned reducer proves which live and pending rows survive;
     // terminal-renderer cleanup must not reclassify them as history. A new
     // session or leaf starts empty.
-    const currentProjection = getChatSessionProjection(
+    reduceChatSessionProjection(
       state,
-      retainsTranscriptIdentity ? state.chatMessages : [],
-      scope,
+      {
+        type: "snapshotLoaded",
+        messages: authoritativeMessages,
+        options: { shouldIncludeMessage: (message) => !shouldHideHistoryMessage(message) },
+      },
+      { scope, messages: retainsTranscriptIdentity ? state.chatMessages : [] },
     );
-    const projection = reduceSessionProjection(currentProjection, {
-      type: "snapshotLoaded",
-      messages: authoritativeMessages,
-      scope,
-      options: { shouldIncludeMessage: (message) => !shouldHideHistoryMessage(message) },
-    });
-    setChatSessionProjection(state, projection);
-    state.chatMessages = [...projection.messages];
     if (Object.hasOwn(res.sessionInfo ?? {}, "activeLeafEntryId")) {
       state.chatDisplayedLeafEntryId = res.sessionInfo?.activeLeafEntryId?.trim() || null;
     }
@@ -1524,7 +1499,6 @@ async function loadChatHistoryUncached(
     });
     if (isMissingOperatorReadScopeError(err)) {
       resetChatHistoryProjection(state, requestAgentId);
-      state.chatMessages = [];
       state.chatThinkingLevel = null;
       state.chatVerboseLevel = null;
       setChatError(state, formatMissingOperatorReadScopeMessage("existing chat history"));

--- a/ui/src/pages/chat/chat-send-queued.ts
+++ b/ui/src/pages/chat/chat-send-queued.ts
@@ -1,8 +1,4 @@
 // Control UI queued-send implementation.
-import {
-  reduceSessionProjection,
-  type SessionProjectionScope,
-} from "@openclaw/gateway-client/browser";
 import { isNonTerminalAgentRunStatus } from "../../../../src/shared/agent-run-status.js";
 import { GatewayRequestError } from "../../api/gateway.ts";
 import { setLastActiveSessionKey } from "../../app/settings.ts";
@@ -65,7 +61,7 @@ import {
   type StoredChatOutboxScope,
 } from "./composer-persistence.ts";
 import { formatConnectError } from "./connect-error.ts";
-import { getChatSessionProjection, setChatSessionProjection } from "./history-merge.ts";
+import { readChatSessionProjectionScope, reduceChatSessionProjection } from "./history-merge.ts";
 import { resetChatInputHistoryNavigation } from "./input-history.ts";
 import { controlUiNowMs, roundedControlUiDurationMs } from "./performance.ts";
 import { reconcileChatRunLifecycle } from "./run-lifecycle.ts";
@@ -300,26 +296,13 @@ export async function sendQueuedChatMessage(
         sendState: "failed",
       }));
       if (isVisibleSession()) {
-        const scope: SessionProjectionScope = {
+        const scope = readChatSessionProjectionScope(host, {
           sessionKey,
-          ...(prepared.agentId ? { agentId: prepared.agentId } : {}),
-          ...(host.currentSessionId ? { sessionId: host.currentSessionId } : {}),
-          ...(Object.hasOwn(host, "chatDisplayedLeafEntryId")
-            ? { activeLeafEntryId: host.chatDisplayedLeafEntryId ?? null }
-            : {}),
-        };
-        const currentProjection = getChatSessionProjection(host, host.chatMessages, scope);
-        const projection = reduceSessionProjection(currentProjection, {
-          type: "sendFailed",
-          runId,
-          scope,
+          agentId: prepared.agentId,
         });
         // A definite rejection removes only this pane's existing optimistic
         // entry; unrelated transcript rows and unconfirmed sends stay intact.
-        if (projection !== currentProjection) {
-          setChatSessionProjection(host, projection);
-          host.chatMessages = [...projection.messages];
-        }
+        reduceChatSessionProjection(host, { type: "sendFailed", runId }, { scope });
         reconcileChatRunLifecycle(
           host as unknown as Parameters<typeof reconcileChatRunLifecycle>[0],
           {
@@ -349,18 +332,14 @@ export async function sendQueuedChatMessage(
     }
     if (isVisibleSession()) {
       if (retireOnAck) {
-        const scope: SessionProjectionScope = {
+        const scope = readChatSessionProjectionScope(host, {
           sessionKey,
-          ...(prepared.agentId ? { agentId: prepared.agentId } : {}),
-          ...(host.currentSessionId ? { sessionId: host.currentSessionId } : {}),
-          ...(Object.hasOwn(host, "chatDisplayedLeafEntryId")
-            ? { activeLeafEntryId: host.chatDisplayedLeafEntryId ?? null }
-            : {}),
-        };
+          agentId: prepared.agentId,
+        });
         // Route the existing optimistic bubble through the pane reducer so a
         // concurrent history snapshot cannot erase its send identity.
-        let projection = reduceSessionProjection(
-          getChatSessionProjection(host, host.chatMessages, scope),
+        reduceChatSessionProjection(
+          host,
           {
             type: "sendPending",
             runId,
@@ -373,19 +352,16 @@ export async function sendQueuedChatMessage(
               timestamp: startedAt,
               __openclaw: { idempotencyKey: `${runId}:user` },
             },
-            scope,
           },
+          { scope },
         );
         if (ack.runId !== runId) {
-          projection = reduceSessionProjection(projection, {
-            type: "sendAcknowledged",
-            previousRunId: runId,
-            runId: ack.runId,
-            scope,
-          });
+          reduceChatSessionProjection(
+            host,
+            { type: "sendAcknowledged", previousRunId: runId, runId: ack.runId },
+            { scope },
+          );
         }
-        setChatSessionProjection(host, projection);
-        host.chatMessages = [...projection.messages];
       }
       if (ack.status === "ok") {
         reconcileChatRunLifecycle(

--- a/ui/src/pages/chat/chat-state-events.ts
+++ b/ui/src/pages/chat/chat-state-events.ts
@@ -1,8 +1,6 @@
 import {
   readSessionMessageIdentity,
   readSessionMessageSequence,
-  reduceSessionProjection,
-  type SessionProjectionScope,
 } from "@openclaw/gateway-client/browser";
 import type { SessionObserverDigest } from "../../../../packages/gateway-protocol/src/schema/sessions.js";
 import type { GatewayEventFrame } from "../../api/gateway.ts";
@@ -43,7 +41,7 @@ import type { ChatPageHost } from "./chat-state-host.ts";
 import { requestChatPageUpdate } from "./chat-state-render.ts";
 import { resolveChatAgentId, selectedChatSessionRow } from "./chat-state-route.ts";
 import { handleBackgroundTasksEvent } from "./components/chat-background-tasks.ts";
-import { getChatSessionProjection, setChatSessionProjection } from "./history-merge.ts";
+import { readChatSessionProjectionScope, reduceChatSessionProjection } from "./history-merge.ts";
 import {
   reconcileChatRunFromCurrentSessionRow,
   reconcileChatRunFromSessionRow,
@@ -59,17 +57,6 @@ function sessionMessageMatchesChat(
   event: NonNullable<ReturnType<typeof readSessionChangedEvent>>,
 ): boolean {
   return chatScopedEventSessionMatches(state, event.key, event.agentId ?? undefined);
-}
-
-function readChatSessionProjectionScope(state: ChatPageHost): SessionProjectionScope {
-  return {
-    sessionKey: state.sessionKey,
-    agentId: resolveChatAgentId(state),
-    ...(state.currentSessionId ? { sessionId: state.currentSessionId } : {}),
-    ...(Object.hasOwn(state, "chatDisplayedLeafEntryId")
-      ? { activeLeafEntryId: state.chatDisplayedLeafEntryId ?? null }
-      : {}),
-  };
 }
 
 function applyLiveUserMessage(state: ChatPageHost, payload: unknown): void {
@@ -114,13 +101,12 @@ function applyLiveUserMessage(state: ChatPageHost, payload: unknown): void {
       ...(incoming.sequence !== null ? { seq: incoming.sequence } : {}),
     },
   };
-  const scope = readChatSessionProjectionScope(state);
-  const projection = reduceSessionProjection(
-    getChatSessionProjection(state, state.chatMessages, scope),
-    { type: "messagePersisted", message, envelope: event, scope },
+  const scope = readChatSessionProjectionScope(state, { agentId: resolveChatAgentId(state) });
+  reduceChatSessionProjection(
+    state,
+    { type: "messagePersisted", message, envelope: event },
+    { scope },
   );
-  setChatSessionProjection(state, projection);
-  state.chatMessages = [...projection.messages];
 }
 
 function selectedGlobalEventAgentId(state: ChatPageHost, agentId: string | null): string {
@@ -264,15 +250,10 @@ function handleSessionsChangedEvent(state: ChatPageHost, payload: unknown) {
   const resetsSelectedSession =
     matchesChat && (source?.reason === "reset" || source?.phase === "reset");
   if (resetsSelectedSession) {
-    const scope = readChatSessionProjectionScope(state);
-    const projection = reduceSessionProjection(
-      getChatSessionProjection(state, state.chatMessages, scope),
-      { type: "sessionReset", scope },
-    );
+    const scope = readChatSessionProjectionScope(state, { agentId: resolveChatAgentId(state) });
     // Reset keeps the public session ID; the explicit reducer event is the
     // only proof that its old live and pending transcript no longer exists.
-    setChatSessionProjection(state, projection);
-    state.chatMessages = [...projection.messages];
+    reduceChatSessionProjection(state, { type: "sessionReset" }, { scope });
   }
   if (matchesChat) {
     void loadChatBranches(state);

--- a/ui/src/pages/chat/history-merge.test.ts
+++ b/ui/src/pages/chat/history-merge.test.ts
@@ -1,12 +1,15 @@
 // @vitest-environment node
 import {
-  isLocallyOptimisticSessionMessage,
-  readSessionMessageSequence,
   reduceSessionProjection,
   type SessionProjectionScope,
 } from "@openclaw/gateway-client/browser";
 import { describe, expect, it } from "vitest";
-import { getChatSessionProjection, setChatSessionProjection } from "./history-merge.ts";
+import {
+  getChatSessionProjection,
+  readChatSessionProjectionScope,
+  reduceChatSessionProjection,
+  setChatSessionProjection,
+} from "./history-merge.ts";
 
 function createHistoryMessage(
   role: "assistant" | "user",
@@ -31,6 +34,48 @@ function projectLiveMessage(owner: object, message: unknown, scope: SessionProje
 }
 
 describe("pane-owned canonical session projection", () => {
+  it("uses one canonical identity for an explicitly unbranched pane", () => {
+    const owner = {
+      sessionKey: "agent:main:shared",
+      currentSessionId: "shared-session",
+      chatDisplayedLeafEntryId: undefined,
+      chatMessages: [],
+    };
+
+    expect(readChatSessionProjectionScope(owner)).toEqual({
+      sessionKey: "agent:main:shared",
+      sessionId: "shared-session",
+      activeLeafEntryId: null,
+    });
+    expect(
+      readChatSessionProjectionScope(owner, {
+        agentId: "main",
+        sessionId: null,
+        activeLeafEntryId: "selected-leaf",
+      }),
+    ).toEqual({
+      sessionKey: "agent:main:shared",
+      agentId: "main",
+      activeLeafEntryId: "selected-leaf",
+    });
+  });
+
+  it("publishes each pane reducer transition and displayed transcript together", () => {
+    const owner = { sessionKey: "agent:main:shared", chatMessages: [] as unknown[] };
+    const liveUser = createHistoryMessage("user", "shared prompt", {
+      id: "shared-user",
+      seq: 1,
+    });
+
+    const projection = reduceChatSessionProjection(owner, {
+      type: "messagePersisted",
+      message: liveUser,
+    });
+
+    expect(owner.chatMessages).toEqual([liveUser]);
+    expect(getChatSessionProjection(owner, owner.chatMessages, projection.scope)).toBe(projection);
+  });
+
   it("keeps each split pane's live projection independent", () => {
     const scope = { sessionKey: "agent:main:shared", sessionId: "shared-session" };
     const firstPane = {};
@@ -389,30 +434,4 @@ describe("pane-owned canonical session projection", () => {
       }).messages,
     ).toEqual([persisted]);
   });
-
-  it("delegates optimistic classification and persisted sequence to the reducer", () => {
-    const pending = createHistoryMessage("user", "pending", {
-      idempotencyKey: "pending-run:user",
-    });
-    const canonical = createHistoryMessage("user", "canonical", {
-      id: "canonical-user",
-      idempotencyKey: "pending-run:user",
-      seq: 7,
-    });
-    const marker = { content: [{ type: "status" }], __openclaw: { seq: 8 } };
-
-    expect(isLocallyOptimisticSessionMessage(pending)).toBe(true);
-    expect(isLocallyOptimisticSessionMessage(canonical)).toBe(false);
-    expect(readSessionMessageSequence(canonical)).toBe(7);
-    expect(readSessionMessageSequence(marker)).toBe(8);
-  });
-
-  it.each([0, -1, 1.5, Number.NaN, Number.POSITIVE_INFINITY, Number.MAX_SAFE_INTEGER + 1])(
-    "rejects unsafe persisted transcript sequence %s",
-    (sequence) => {
-      expect(
-        readSessionMessageSequence(createHistoryMessage("user", "prompt", { seq: sequence })),
-      ).toBe(null);
-    },
-  );
 });

--- a/ui/src/pages/chat/history-merge.ts
+++ b/ui/src/pages/chat/history-merge.ts
@@ -1,11 +1,50 @@
 import {
   createSessionProjection,
   reconcileSessionProjectionSnapshot,
+  reduceSessionProjection,
+  type SessionProjectionEvent,
   type SessionProjectionScope,
   type SessionProjectionState,
 } from "@openclaw/gateway-client/browser";
 
 const chatSessionProjections = new WeakMap<object, SessionProjectionState>();
+
+type ChatSessionProjectionOwner = {
+  sessionKey: string;
+  chatMessages: unknown[];
+  currentSessionId?: string | null;
+  chatDisplayedLeafEntryId?: string | null;
+};
+
+type ChatSessionProjectionScopeOptions = Omit<SessionProjectionScope, "sessionId"> & {
+  sessionId?: string | null;
+};
+
+/** Every live, pending, terminal, and history path must identify the same pane and branch. */
+export function readChatSessionProjectionScope(
+  owner: ChatSessionProjectionOwner,
+  options: ChatSessionProjectionScopeOptions = {},
+): SessionProjectionScope {
+  const sessionId = Object.hasOwn(options, "sessionId")
+    ? options.sessionId
+    : owner.currentSessionId;
+  return {
+    sessionKey: options.sessionKey ?? owner.sessionKey,
+    ...(options.agentId ? { agentId: options.agentId } : {}),
+    ...(sessionId ? { sessionId } : {}),
+    ...(options.lifecycleRevision !== undefined
+      ? { lifecycleRevision: options.lifecycleRevision }
+      : {}),
+    ...(Object.hasOwn(options, "activeLeafEntryId") ||
+    Object.hasOwn(owner, "chatDisplayedLeafEntryId")
+      ? {
+          activeLeafEntryId: Object.hasOwn(options, "activeLeafEntryId")
+            ? (options.activeLeafEntryId ?? null)
+            : (owner.chatDisplayedLeafEntryId ?? null),
+        }
+      : {}),
+  };
+}
 
 /** One pane owns its shared-reducer projection; split panes never share live state. */
 export function getChatSessionProjection(
@@ -56,4 +95,23 @@ export function getChatSessionProjection(
 
 export function setChatSessionProjection(owner: object, projection: SessionProjectionState): void {
   chatSessionProjections.set(owner, projection);
+}
+
+/** Publish the reducer and rendered transcript together; no caller maintains a second copy. */
+export function reduceChatSessionProjection(
+  owner: ChatSessionProjectionOwner,
+  event: SessionProjectionEvent,
+  options: {
+    scope?: SessionProjectionScope;
+    messages?: readonly unknown[];
+  } = {},
+): SessionProjectionState {
+  const scope = options.scope ?? readChatSessionProjectionScope(owner);
+  const current = getChatSessionProjection(owner, options.messages ?? owner.chatMessages, scope);
+  const projection = reduceSessionProjection(current, { ...event, scope });
+  if (projection !== current) {
+    setChatSessionProjection(owner, projection);
+    owner.chatMessages = [...projection.messages];
+  }
+  return projection;
 }

--- a/ui/src/pages/chat/steer-lifecycle.ts
+++ b/ui/src/pages/chat/steer-lifecycle.ts
@@ -1,7 +1,3 @@
-import {
-  reduceSessionProjection,
-  type SessionProjectionScope,
-} from "@openclaw/gateway-client/browser";
 import type { QueueMode } from "../../../../src/auto-reply/reply/queue/types.js";
 import type { SessionsListResult } from "../../api/types.ts";
 import { setLastActiveSessionKey } from "../../app/settings.ts";
@@ -27,7 +23,7 @@ import {
   type ChatSendAck,
   type TerminalFailureChatSendAck,
 } from "./chat-send-ack.ts";
-import { getChatSessionProjection, setChatSessionProjection } from "./history-merge.ts";
+import { readChatSessionProjectionScope, reduceChatSessionProjection } from "./history-merge.ts";
 import { hasAbortableSessionRun } from "./run-lifecycle.ts";
 import { scheduleChatScroll } from "./scroll.ts";
 import {
@@ -157,22 +153,17 @@ export function preserveQueuedUserTurn(state: SteerLifecycleHost, item: ChatQueu
   };
   if (visibleSessionMatches(state, sessionKey, item.agentId)) {
     if (!chatMessagesContainQueuedSend(state.chatMessages, item, true)) {
-      const scope: SessionProjectionScope = {
+      const scope = readChatSessionProjectionScope(state, {
         sessionKey,
-        ...(item.agentId ? { agentId: item.agentId } : {}),
-        ...(state.currentSessionId ? { sessionId: state.currentSessionId } : {}),
-        ...(Object.hasOwn(state, "chatDisplayedLeafEntryId")
-          ? { activeLeafEntryId: state.chatDisplayedLeafEntryId ?? null }
-          : {}),
-      };
+        agentId: item.agentId,
+      });
       // Steer retirement and history recovery must retain the same pending
       // entry; rendering a separate row loses it during a concurrent snapshot.
-      const projection = reduceSessionProjection(
-        getChatSessionProjection(state, state.chatMessages, scope),
-        { type: "sendPending", runId, message: userMessage, scope },
+      reduceChatSessionProjection(
+        state,
+        { type: "sendPending", runId, message: userMessage },
+        { scope },
       );
-      setChatSessionProjection(state, projection);
-      state.chatMessages = [...projection.messages];
     }
     return;
   }

--- a/ui/src/pages/chat/terminal-message-identity.ts
+++ b/ui/src/pages/chat/terminal-message-identity.ts
@@ -69,12 +69,11 @@ export function rememberAuthoritativeTerminal(options: {
 }
 
 export function reconcileAuthoritativeTerminalHistory<T>(options: {
-  currentMessages: T[];
   host: object;
   previousMessages: T[];
   sessionKey: string;
   visibleMessages: T[];
-}): { currentMessages: T[]; previousMessages: T[] } {
+}): T[] {
   const terminal = authoritativeTerminals.get(options.host);
   const historyContainsTerminal = Boolean(
     terminal &&
@@ -87,17 +86,12 @@ export function reconcileAuthoritativeTerminalHistory<T>(options: {
     }),
   );
   if (!terminal || !historyContainsTerminal) {
-    return options;
+    return options.previousMessages;
   }
   authoritativeTerminals.set(options.host, { ...terminal, historyApplied: true });
-  return {
-    currentMessages: options.currentMessages.filter(
-      (message) => !isLiveTerminalForRun(message, terminal.runId),
-    ),
-    previousMessages: options.previousMessages.filter(
-      (message) => !isLiveTerminalForRun(message, terminal.runId),
-    ),
-  };
+  return options.previousMessages.filter(
+    (message) => !isLiveTerminalForRun(message, terminal.runId),
+  );
 }
 
 export function authoritativeHistoryAppliedForRun(host: object, runId: string): boolean {


### PR DESCRIPTION
Related: #115429\n\n## What Problem This Solves\n\nUsers viewing the same conversation in the browser and terminal could still hit subtle inconsistencies because browser history, Gateway events, pending sends, steering, and resets each reconstructed conversation and branch identity separately after the shared-session redesign. One live-final path also treated an explicitly unbranched session differently from authoritative history.\n\n## Why This Change Was Made\n\nMake the existing pane projection the single owner of browser conversation scope and atomic reducer/transcript publication. Route live messages, authoritative history, pending and acknowledged sends, steer turns, and reset through that owner; canonicalize an explicitly unbranched leaf as null everywhere. Remove repeated transcript clearing, dead current-message terminal filtering, and browser-side tests that duplicate the more comprehensive canonical Gateway-client reducer tests. The result removes 188 lines while adding 172; production code alone is 30 lines smaller. No protocol, config, storage, dependency, or public SDK changes.\n\n## User Impact\n\nThe same conversation stays ordered and synchronized across browser panes, Gateway subscribers, and the terminal through delayed peer messages, stale history, pending-send acknowledgements, session resets, reconnects, attachments, and branch changes. The architecture has one conversation scope and publication path instead of independently maintained copies.\n\n## Evidence\n\n- 1,396 passing focused Gateway, shared-client, browser, and terminal tests across 25 files, including real Gateway tests with web and TUI subscribers attached to the same session.\n- 46 passing real Chromium end-to-end scenarios covering split panes, delayed peer messages, stale history, reconnect, streaming, lost acknowledgements, reset, session navigation, and attachments.\n- 48 passing real terminal PTY scenarios covering subscription recovery, event gaps, streaming, reset, and session switching.\n- Complete production build, browser bundle, plugin-export checks, precompressed assets, and Control UI performance budget.\n- Passing production UI TypeScript and UI-test TypeScript gates.\n- Passing exact changed-file formatting and git whitespace checks.\n- Fresh independent autoreview: no accepted or actionable findings; final deletion of mirrored reducer tests independently reviewed clean.\n- AI-assisted; maintainer-requested deletion-led follow-up to #115429.\n