### PR TITLE
fix(cli): keep help, update previews, and plugin pinning correct

### DIFF
--- a/src/cli/plugins-install-preflight.test.ts
+++ b/src/cli/plugins-install-preflight.test.ts
@@ -9,6 +9,7 @@ import {
   installPluginFromNpmPackArchive,
   installPluginFromNpmSpec,
   installPluginFromPath,
+  parseClawHubPluginSpec,
   promptYesNo,
   readConfigFileSnapshotForWrite,
   resetPluginsCliTestState,
@@ -137,6 +138,21 @@ describe("plugin install mutation-free preflight", () => {
       error: "--pin is not supported with git: installs.",
     },
     {
+      label: "ClawHub pin",
+      args: ["clawhub:demo", "--pin"],
+      error: "--pin is only supported with npm registry installs.",
+    },
+    {
+      label: "npm-pack pin",
+      args: ["npm-pack:/tmp/openclaw-plugin-preflight-test.tgz", "--pin"],
+      error: "--pin is only supported with npm registry installs.",
+    },
+    {
+      label: "local path pin",
+      args: [".", "--pin"],
+      error: "--pin is only supported with npm registry installs.",
+    },
+    {
       label: "registry link",
       args: ["npm:demo", "--link"],
       error: "--link requires a local path.",
@@ -162,6 +178,10 @@ describe("plugin install mutation-free preflight", () => {
       error: "Plugin path not found:",
     },
   ])("rejects $label before the lifecycle lease", async ({ args, error }) => {
+    if (args[0] === "clawhub:demo") {
+      parseClawHubPluginSpec.mockReturnValue({ name: "demo" });
+    }
+
     await expect(runPluginsCommand(["plugins", "install", ...args, "--force"])).rejects.toThrow(
       "__exit__:1",
     );

--- a/src/cli/plugins-install-preflight.ts
+++ b/src/cli/plugins-install-preflight.ts
@@ -72,6 +72,14 @@ function resolveSourceOptionError(
   if (sourcePlan.request.source === "git" && opts.pin) {
     return `--pin is not supported with git: installs. Pin the ref in the spec instead, for example ${formatCliCommand(`openclaw plugins install git:<repo>@<ref> ${NON_CLAWHUB_INSTALL_FORCE_FLAG}`)}.`;
   }
+  if (
+    opts.pin &&
+    sourcePlan.request.source !== "npm" &&
+    sourcePlan.request.source !== "official" &&
+    sourcePlan.request.source !== "bundled"
+  ) {
+    return "--pin is only supported with npm registry installs.";
+  }
   if (opts.link && sourcePlan.request.source !== "local") {
     return `--link requires a local path. Run ${formatCliCommand(`openclaw plugins install --link <path> ${NON_CLAWHUB_INSTALL_FORCE_FLAG}`)}.`;
   }

--- a/src/cli/update-cli.test.ts
+++ b/src/cli/update-cli.test.ts
@@ -2850,6 +2850,19 @@ describe("update-cli", () => {
     },
   ] as const)("updateCommand dry-run behavior: $name", runUpdateCliScenario);
 
+  it.each([
+    { name: "text", options: { dryRun: true, channel: "beta" } },
+    { name: "JSON", options: { dryRun: true, json: true, channel: "beta" } },
+  ])("reads config without recording observations during a $name dry run", async ({ options }) => {
+    await updateCommand(options);
+
+    expect(readConfigFileSnapshot).toHaveBeenCalledWith({
+      skipPluginValidation: true,
+      observe: false,
+    });
+    expect(cleanupStaleManagedServiceUpdateHandoffs).not.toHaveBeenCalled();
+  });
+
   it("does not clean managed-service handoffs during a JSON dry run", async () => {
     await updateCommand({ dryRun: true, json: true, channel: "beta" });
 

--- a/src/cli/update-cli/update-command.ts
+++ b/src/cli/update-cli/update-command.ts
@@ -181,7 +181,10 @@ async function updateCommandInternal(
     return;
   }
 
-  let configSnapshot = await readConfigFileSnapshot({ skipPluginValidation: true });
+  let configSnapshot = await readConfigFileSnapshot({
+    skipPluginValidation: true,
+    ...(opts.dryRun === true ? { observe: false } : {}),
+  });
   if (opts.channel && !opts.dryRun && !configSnapshot.valid) {
     configSnapshot = await maybeRepairLegacyConfigForUpdateChannel({
       configSnapshot,

--- a/src/entry.test.ts
+++ b/src/entry.test.ts
@@ -3,6 +3,64 @@ import { describe, expect, it, vi } from "vitest";
 import { tryHandlePrecomputedCommandHelpFastPath, tryHandleRootHelpFastPath } from "./entry.js";
 
 describe("entry root help fast path", () => {
+  it.each([
+    { name: "long root help", argv: ["node", "openclaw", "--help"] },
+    { name: "short root help", argv: ["node", "openclaw", "-h"] },
+    {
+      name: "profile-prefixed root help",
+      argv: ["node", "openclaw", "--profile", "work", "--help"],
+    },
+    {
+      name: "no-color-prefixed root help",
+      argv: ["node", "openclaw", "--no-color", "--help"],
+    },
+  ])("respects the startup help fast path kill switch for $name", async ({ argv }) => {
+    const outputPrecomputedRootHelpText = vi.fn(() => true);
+    const outputRootHelp = vi.fn();
+    const loadRootHelpRenderOptionsForConfigSensitivePlugins = vi.fn(async () => null);
+
+    await expect(
+      tryHandleRootHelpFastPath(argv, {
+        env: { OPENCLAW_DISABLE_CLI_STARTUP_HELP_FAST_PATH: "1" },
+        outputPrecomputedRootHelpText,
+        outputRootHelp,
+        loadRootHelpRenderOptionsForConfigSensitivePlugins,
+      }),
+    ).resolves.toBe(false);
+
+    expect(loadRootHelpRenderOptionsForConfigSensitivePlugins).not.toHaveBeenCalled();
+    expect(outputPrecomputedRootHelpText).not.toHaveBeenCalled();
+    expect(outputRootHelp).not.toHaveBeenCalled();
+  });
+
+  it("respects the process env startup help fast path kill switch", async () => {
+    const original = process.env.OPENCLAW_DISABLE_CLI_STARTUP_HELP_FAST_PATH;
+    const outputPrecomputedRootHelpText = vi.fn(() => true);
+    const outputRootHelp = vi.fn();
+    const loadRootHelpRenderOptionsForConfigSensitivePlugins = vi.fn(async () => null);
+    process.env.OPENCLAW_DISABLE_CLI_STARTUP_HELP_FAST_PATH = "1";
+
+    try {
+      await expect(
+        tryHandleRootHelpFastPath(["node", "openclaw", "--help"], {
+          outputPrecomputedRootHelpText,
+          outputRootHelp,
+          loadRootHelpRenderOptionsForConfigSensitivePlugins,
+        }),
+      ).resolves.toBe(false);
+
+      expect(loadRootHelpRenderOptionsForConfigSensitivePlugins).not.toHaveBeenCalled();
+      expect(outputPrecomputedRootHelpText).not.toHaveBeenCalled();
+      expect(outputRootHelp).not.toHaveBeenCalled();
+    } finally {
+      if (original === undefined) {
+        delete process.env.OPENCLAW_DISABLE_CLI_STARTUP_HELP_FAST_PATH;
+      } else {
+        process.env.OPENCLAW_DISABLE_CLI_STARTUP_HELP_FAST_PATH = original;
+      }
+    }
+  });
+
   it("prefers precomputed root help text when available", async () => {
     let outputPrecomputedRootHelpTextCalls = 0;
 

--- a/src/entry.ts
+++ b/src/entry.ts
@@ -213,7 +213,11 @@ export async function tryHandleRootHelpFastPath(
     env?: NodeJS.ProcessEnv;
   } = {},
 ): Promise<boolean> {
-  if (resolveCliContainerTarget(argv, deps.env)) {
+  const env = deps.env ?? process.env;
+  if (
+    env.OPENCLAW_DISABLE_CLI_STARTUP_HELP_FAST_PATH === "1" ||
+    resolveCliContainerTarget(argv, env)
+  ) {
     return false;
   }
   if (!isRootHelpInvocation(argv)) {
@@ -230,7 +234,7 @@ export async function tryHandleRootHelpFastPath(
     const loadRootHelpRenderOptionsForConfigSensitivePlugins =
       deps.loadRootHelpRenderOptionsForConfigSensitivePlugins ??
       (await loadRootHelpLiveConfigModule()).loadRootHelpRenderOptionsForConfigSensitivePlugins;
-    const liveRootHelpOptions = await loadRootHelpRenderOptionsForConfigSensitivePlugins(deps.env);
+    const liveRootHelpOptions = await loadRootHelpRenderOptionsForConfigSensitivePlugins(env);
     if (!liveRootHelpOptions) {
       const outputPrecomputedRootHelpText =
         deps.outputPrecomputedRootHelpText ??


### PR DESCRIPTION
## What Problem This Solves

Fixes three user-visible CLI failures reproduced against current main:

- Root help ignored the existing startup-help kill switch, including short help and profile/no-color-prefixed invocations.
- Text and JSON update dry runs observed configuration snapshots, allowing a supposedly read-only preview to record configuration recovery state.
- ClawHub, local directory, and local npm-pack installs silently accepted the npm-only pin flag without pinning anything.

## Why This Change Was Made

Honor the existing kill switch at the root-help entry owner, make only update preview snapshot reads non-observing, and reject unsupported pin/source combinations during the canonical mutation-free plugin-install preflight. Preserve actual npm, trusted official, documented bundled, Git-specific, marketplace-specific, hook-pack, and ordinary mutable-update behavior.

## User Impact

Help and diagnostics respect operator-selected startup behavior. Update previews stay genuinely read-only in both text and JSON mode. Plugin installs explain unsupported pinning immediately without acquiring lifecycle locks, prompting, loading install state, or starting an install.

## Evidence

- Fresh main baseline: 5578d01777ef354bd459bc6ee0c04716ab6b0eaa.
- Failure-first Linux proof: five root-help regressions, two update-preview regressions, and three unsupported-source pin regressions fail before their respective fixes.
- Blacksmith Testbox: 793 passing tests across 17 CLI startup, version, argv, update, collision, install planning, install preflight, config, policy, bundled fallback, plugin management, and auto-reply command test files.
- The three invalid plugin sources each assert no lifecycle lease, configuration read/write, confirmation, plugin install, or hook fallback.
- Independent Codex autoreview: clean, no accepted or actionable findings.
- Full Blacksmith Testbox proof: targeted production lint, complete check:changed gate (types, formatting, boundaries, dependency and dead-export guards), and complete pnpm build all passed at the validated branch content.
- AI-assisted; changes, reproductions, tests, and review verified.