### PR TITLE
fix(google): reject malformed video operation JSON

### DIFF
--- a/extensions/google/video-generation-provider.test.ts
+++ b/extensions/google/video-generation-provider.test.ts
@@ -712,6 +712,51 @@ describe("google video generation provider", () => {
     expect(streamed.wasCanceled()).toBe(true);
   });
 
+  it("reports malformed Google REST operation JSON with a stable provider error", async () => {
+    vi.spyOn(providerAuthRuntime, "resolveApiKeyForProvider").mockResolvedValue({
+      apiKey: "google-key",
+      source: "env",
+      mode: "api-key",
+    });
+    generateVideosMock.mockRejectedValue(Object.assign(new Error("sdk 404"), { status: 404 }));
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(new Response("{ nope", { status: 200 })));
+
+    await expect(
+      buildGoogleVideoGenerationProvider().generateVideo({
+        provider: "google",
+        model: "veo-3.1-fast-generate-preview",
+        prompt: "A tiny robot watering a windowsill garden",
+        cfg: {},
+        durationSeconds: 3,
+      }),
+    ).rejects.toThrow("Google video operation response returned malformed JSON");
+  });
+
+  it("rejects invalid UTF-8 in Google REST operation JSON before parsing", async () => {
+    vi.spyOn(providerAuthRuntime, "resolveApiKeyForProvider").mockResolvedValue({
+      apiKey: "google-key",
+      source: "env",
+      mode: "api-key",
+    });
+    generateVideosMock.mockRejectedValue(Object.assign(new Error("sdk 404"), { status: 404 }));
+    const invalidUtf8Json = new Uint8Array([
+      ...Buffer.from('{"done":true,"name":"operations/'),
+      0xff,
+      ...Buffer.from('"}'),
+    ]);
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(new Response(invalidUtf8Json)));
+
+    await expect(
+      buildGoogleVideoGenerationProvider().generateVideo({
+        provider: "google",
+        model: "veo-3.1-fast-generate-preview",
+        prompt: "A tiny robot watering a windowsill garden",
+        cfg: {},
+        durationSeconds: 3,
+      }),
+    ).rejects.toThrow("Google video operation response returned malformed JSON");
+  });
+
   it("retries transient Google REST poll failures with empty bodies", async () => {
     vi.useFakeTimers();
     vi.spyOn(providerAuthRuntime, "resolveApiKeyForProvider").mockResolvedValue({

--- a/extensions/google/video-generation-provider.test.ts
+++ b/extensions/google/video-generation-provider.test.ts
@@ -705,7 +705,7 @@ describe("google video generation provider", () => {
         cfg: {},
         durationSeconds: 3,
       }),
-    ).rejects.toThrow("Google video operation response exceeds 16777216 bytes");
+    ).rejects.toThrow("Google video operation response: JSON response exceeds 16777216 bytes");
 
     expect(fetchMock).toHaveBeenCalledTimes(1);
     expect(streamed.getReadCount()).toBeLessThan(64);
@@ -729,7 +729,7 @@ describe("google video generation provider", () => {
         cfg: {},
         durationSeconds: 3,
       }),
-    ).rejects.toThrow("Google video operation response returned malformed JSON");
+    ).rejects.toThrow("Google video operation response: malformed JSON response");
   });
 
   it("rejects invalid UTF-8 in Google REST operation JSON before parsing", async () => {
@@ -754,7 +754,7 @@ describe("google video generation provider", () => {
         cfg: {},
         durationSeconds: 3,
       }),
-    ).rejects.toThrow("Google video operation response returned malformed JSON");
+    ).rejects.toThrow("Google video operation response: malformed JSON response");
   });
 
   it("retries transient Google REST poll failures with empty bodies", async () => {

--- a/extensions/google/video-generation-provider.ts
+++ b/extensions/google/video-generation-provider.ts
@@ -33,6 +33,7 @@ const MAX_POLL_ATTEMPTS = 120;
 const GOOGLE_VIDEO_OPERATION_RESPONSE_MAX_BYTES = 16 * 1024 * 1024;
 const GOOGLE_VIDEO_EMPTY_RESULT_MESSAGE =
   "Google video generation response missing generated videos";
+const googleVideoOperationJsonDecoder = new TextDecoder("utf-8", { fatal: true });
 
 function resolveConfiguredGoogleVideoBaseUrl(req: VideoGenerationRequest): string | undefined {
   const configured = normalizeOptionalString(req.cfg?.models?.providers?.google?.baseUrl);
@@ -61,6 +62,17 @@ function resolveGoogleVideoRestModelPath(model: string): string {
     return `models/${trimmed.slice("google/".length)}`;
   }
   return `models/${trimmed}`;
+}
+
+function parseGoogleVideoOperationPayload(buffer: Uint8Array): unknown {
+  if (buffer.byteLength === 0) {
+    return {};
+  }
+  try {
+    return JSON.parse(googleVideoOperationJsonDecoder.decode(buffer)) as unknown;
+  } catch (cause) {
+    throw new Error("Google video operation response returned malformed JSON", { cause });
+  }
 }
 
 function parseVideoSize(size: string | undefined): { width: number; height: number } | undefined {
@@ -367,8 +379,7 @@ async function requestGoogleVideoJson(params: {
             }
             throw createHttpError(response, detail);
           }
-          const payload = text ? (JSON.parse(text) as unknown) : {};
-          return payload;
+          return parseGoogleVideoOperationPayload(buffer);
         } finally {
           await release();
         }

--- a/extensions/google/video-generation-provider.ts
+++ b/extensions/google/video-generation-provider.ts
@@ -4,6 +4,7 @@ import { resolveApiKeyForProvider } from "openclaw/plugin-sdk/provider-auth-runt
 import {
   createProviderOperationDeadline,
   executeProviderOperationWithRetry,
+  readProviderJsonResponse,
   resolveProviderOperationTimeoutMs,
   waitProviderOperationPollInterval,
 } from "openclaw/plugin-sdk/provider-http";
@@ -33,7 +34,6 @@ const MAX_POLL_ATTEMPTS = 120;
 const GOOGLE_VIDEO_OPERATION_RESPONSE_MAX_BYTES = 16 * 1024 * 1024;
 const GOOGLE_VIDEO_EMPTY_RESULT_MESSAGE =
   "Google video generation response missing generated videos";
-const googleVideoOperationJsonDecoder = new TextDecoder("utf-8", { fatal: true });
 
 function resolveConfiguredGoogleVideoBaseUrl(req: VideoGenerationRequest): string | undefined {
   const configured = normalizeOptionalString(req.cfg?.models?.providers?.google?.baseUrl);
@@ -62,17 +62,6 @@ function resolveGoogleVideoRestModelPath(model: string): string {
     return `models/${trimmed.slice("google/".length)}`;
   }
   return `models/${trimmed}`;
-}
-
-function parseGoogleVideoOperationPayload(buffer: Uint8Array): unknown {
-  if (buffer.byteLength === 0) {
-    return {};
-  }
-  try {
-    return JSON.parse(googleVideoOperationJsonDecoder.decode(buffer)) as unknown;
-  } catch (cause) {
-    throw new Error("Google video operation response returned malformed JSON", { cause });
-  }
 }
 
 function parseVideoSize(size: string | undefined): { width: number; height: number } | undefined {
@@ -359,16 +348,13 @@ async function requestGoogleVideoJson(params: {
           signal: controller.signal,
         });
         try {
-          const buffer = await readResponseWithLimit(
-            response,
-            GOOGLE_VIDEO_OPERATION_RESPONSE_MAX_BYTES,
-            {
-              onOverflow: ({ maxBytes }) =>
-                new Error(`Google video operation response exceeds ${maxBytes} bytes`),
-            },
-          );
-          const text = new TextDecoder().decode(buffer);
           if (!response.ok) {
+            const text = new TextDecoder().decode(
+              await readResponseWithLimit(response, GOOGLE_VIDEO_OPERATION_RESPONSE_MAX_BYTES, {
+                onOverflow: ({ maxBytes }) =>
+                  new Error(`Google video operation response exceeds ${maxBytes} bytes`),
+              }),
+            );
             let detail: unknown = text;
             if (text) {
               try {
@@ -379,7 +365,9 @@ async function requestGoogleVideoJson(params: {
             }
             throw createHttpError(response, detail);
           }
-          return parseGoogleVideoOperationPayload(buffer);
+          return await readProviderJsonResponse(response, "Google video operation response", {
+            maxBytes: GOOGLE_VIDEO_OPERATION_RESPONSE_MAX_BYTES,
+          });
         } finally {
           await release();
         }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Google video generation REST operation responses could leak raw JSON parser errors or accept replacement-character corrupted fields when a successful poll response contained malformed JSON or invalid UTF-8.

## Why This Change Was Made

Successful Google video operation responses are now routed through the shared `readProviderJsonResponse` reader, which owns the bounded read, fatal UTF-8 decoding, and malformed-JSON wrapping used by every other provider. The Google-local decoder/parser was removed so the provider cannot drift into a second JSON error contract. Non-OK response bodies keep the existing lenient text/JSON error-detail behavior.

## User Impact

Users get one consistent stable provider error — `Google video operation response: malformed JSON response` — for malformed or invalid UTF-8 successful Google operation payloads, and the non-OK error-detail path is unchanged.

## Evidence

- Real call-chain proof, base vs head: the same `proof-live.ts` command ran the production `buildGoogleVideoGenerationProvider().generateVideo` entrypoint through the real guarded fetch against a loopback HTTP fixture standing in for the Google REST endpoint. Only the SSRF private-network policy is relaxed for the loopback fixture; fetch, DNS pinning, redirect handling, and response streams are the real runtime code.
- Head `ac184d6a` (with the shared reader): valid operation JSON returned one video; malformed JSON and invalid UTF-8 were rejected with the stable provider error; a 16 MiB overflow was rejected before buffering; a 503 detail response kept its error payload.
- Base `1acc64b2` (before this PR): malformed JSON leaked the raw V8 parse error, invalid UTF-8 was accepted with replacement characters and failed later with a confusing empty-result error, and the overflow message differed.
- Focused regression suite: `node scripts/run-vitest.mjs extensions/google/video-generation-provider.test.ts` — 22 passed (the shared-reader path is additionally covered by `src/agents/provider-http-errors.test.ts` on main).

```text
$ PROOF_COMMAND="node --no-deprecation --import tsx --import 'data:text/javascript,import { register } from \"node:module\"; import { pathToFileURL } from \"node:url\"; register(\"./proof-loader.mjs\", pathToFileURL(\"./\"));' --import tsx proof-live.ts"

$ git checkout 1acc64b28a1 && $PROOF_COMMAND
head=1acc64b28a1
entrypoint=buildGoogleVideoGenerationProvider().generateVideo transport=real guarded fetch via loopback fixture
valid=ok videos=1 bytes=9
malformed=rejected Expected property name or '}' in JSON at position 2 (line 1 column 3)
invalid-utf8=rejected Google video generation response missing generated videos
oversize=rejected Google video operation response exceeds 16777216 bytes
non-ok=rejected HTTP 503: Service Unavailable: {"error":{"code":503,"message":"fixture overloaded"}}

$ git checkout ac184d6a43c && $PROOF_COMMAND
head=ac184d6a43c
entrypoint=buildGoogleVideoGenerationProvider().generateVideo transport=real guarded fetch via loopback fixture
valid=ok videos=1 bytes=9
malformed=rejected Google video operation response: malformed JSON response
invalid-utf8=rejected Google video operation response: malformed JSON response
oversize=rejected Google video operation response: JSON response exceeds 16777216 bytes
non-ok=rejected HTTP 503: Service Unavailable: {"error":{"code":503,"message":"fixture overloaded"}}
```

<details>
<summary>proof-live.ts</summary>

```ts
// Real call-chain proof for the Google video-operation JSON boundary.
// Runs the production provider entrypoint through the real guarded fetch
// against a loopback fixture; only the SSRF private-network policy is relaxed.
import { execSync } from "node:child_process";
import { buildGoogleVideoGenerationProvider } from "./extensions/google/video-generation-provider.js";
import { startFixture } from "./proof-fixture.js";

const HEAD = execSync("git rev-parse --short HEAD", { encoding: "utf8" }).trim();

function request(cfgModels: Record<string, unknown>) {
  return {
    provider: "google",
    model: "veo-3.1-fast-generate-preview",
    prompt: "A tiny robot watering a windowsill garden",
    cfg: {
      models: { providers: { google: { ...cfgModels } } },
    },
    durationSeconds: 3,
  };
}

async function runScenario(
  label: string,
  scenario: "valid" | "malformed" | "invalid-utf8" | "oversize" | "non-ok",
): Promise<string> {
  const fixture = await startFixture(scenario);
  try {
    const provider = buildGoogleVideoGenerationProvider();
    try {
      const result = await provider.generateVideo(
        request({ apiKey: "proof-key", baseUrl: fixture.baseUrl, models: [] }),
      );
      return `${label}=ok videos=${result.videos.length} bytes=${result.videos[0]?.buffer.byteLength}`;
    } catch (error) {
      const message = error instanceof Error ? error.message : String(error);
      return `${label}=rejected ${message}`;
    }
  } finally {
    await fixture.close();
  }
}

console.log(`head=${HEAD}`);
console.log(
  `entrypoint=buildGoogleVideoGenerationProvider().generateVideo transport=real guarded fetch via loopback fixture`,
);
console.log(await runScenario("valid", "valid"));
console.log(await runScenario("malformed", "malformed"));
console.log(await runScenario("invalid-utf8", "invalid-utf8"));
console.log(await runScenario("oversize", "oversize"));
console.log(await runScenario("non-ok", "non-ok"));
```

</details>

<details>
<summary>proof-fixture.ts</summary>

```ts
// Proof fixture: emulates Google REST video-operation endpoints over real HTTP.
import http from "node:http";
import type { AddressInfo } from "node:net";

export type FixtureScenario =
  | "valid"
  | "malformed"
  | "invalid-utf8"
  | "oversize"
  | "non-ok";

const INVALID_UTF8_OPERATION = new Uint8Array([
  ...Buffer.from('{"done":true,"name":"operations/'),
  0xff,
  ...Buffer.from('"}'),
]);

function validOperationBody(): string {
  return JSON.stringify({
    done: true,
    name: "operations/proof-valid",
    response: {
      generatedVideos: [
        {
          video: {
            videoBytes: Buffer.from("proof-mp4").toString("base64"),
            mimeType: "video/mp4",
          },
        },
      ],
    },
  });
}

function readRequestBody(req: http.IncomingMessage): Promise<Buffer> {
  return new Promise((resolve, reject) => {
    const chunks: Buffer[] = [];
    req.on("data", (chunk) => {
      chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
    });
    req.on("end", () => resolve(Buffer.concat(chunks)));
    req.on("error", reject);
  });
}

export function startFixture(scenario: FixtureScenario): Promise<{
  baseUrl: string;
  requests: Array<{ method: string; path: string; bodyBytes: number }>;
  close: () => Promise<void>;
}> {
  const requests: Array<{ method: string; path: string; bodyBytes: number }> = [];
  let predictLongRunningCalls = 0;
  const server = http.createServer(async (req, res) => {
    const body = await readRequestBody(req);
    const path = req.url ?? "/";
    requests.push({ method: req.method ?? "GET", path, bodyBytes: body.byteLength });

    // The Google SDK and the provider REST fallback both call
    // `:predictLongRunning`. The SDK call returns 404 to force the provider's
    // REST fallback (the production path this PR changes); the fallback call
    // then receives the scenario response.
    if (!path.includes(":predictLongRunning")) {
      res.writeHead(404, { "content-type": "application/json" });
      res.end(JSON.stringify({ error: { code: 404, message: "force REST fallback" } }));
      return;
    }
    predictLongRunningCalls += 1;
    if (predictLongRunningCalls === 1) {
      res.writeHead(404, { "content-type": "application/json" });
      res.end(JSON.stringify({ error: { code: 404, message: "force REST fallback" } }));
      return;
    }

    if (scenario === "non-ok" && path.includes(":predictLongRunning")) {
      res.writeHead(503, { "content-type": "application/json" });
      res.end(JSON.stringify({ error: { code: 503, message: "fixture overloaded" } }));
      return;
    }

    res.writeHead(200, { "content-type": "application/json" });
    if (scenario === "valid") {
      res.end(validOperationBody());
      return;
    }
    if (scenario === "malformed") {
      res.end("{ nope");
      return;
    }
    if (scenario === "invalid-utf8") {
      res.end(INVALID_UTF8_OPERATION);
      return;
    }
    if (scenario === "oversize") {
      const chunk = Buffer.alloc(1024 * 1024, "x");
      let sent = 0;
      const total = 17 * 1024 * 1024;
      const send = (): void => {
        if (sent >= total || res.destroyed) {
          res.end();
          return;
        }
        const next = Math.min(chunk.byteLength, total - sent);
        sent += next;
        res.write(chunk.subarray(0, next), send);
      };
      send();
      return;
    }
    res.end(validOperationBody());
  });

  return new Promise((resolve, reject) => {
    server.once("error", reject);
    server.listen(0, "127.0.0.1", () => {
      const address = server.address() as AddressInfo;
      resolve({
        baseUrl: `http://127.0.0.1:${address.port}`,
        requests,
        close: () =>
          new Promise((resolveClose) => {
            server.close(() => resolveClose());
          }),
      });
    });
  });
}
```

</details>

<details>
<summary>proof-loader.mjs</summary>

```js
// Serves the proof shim in place of src/plugin-sdk/ssrf-runtime.ts so the real
// guarded fetch runs against the loopback fixture with only the private-network
// policy relaxed. Other modules resolve and load normally.
import { readFileSync } from "node:fs";

const SHIM_SOURCE = readFileSync(new URL("./ssrf-runtime-shim.mjs", import.meta.url), "utf8");

export async function load(url, context, nextLoad) {
  if (url.includes("/src/plugin-sdk/ssrf-runtime.")) {
    return {
      format: "module",
      source: SHIM_SOURCE,
      shortCircuit: true,
    };
  }
  return nextLoad(url, context);
}
```

</details>

<details>
<summary>ssrf-runtime-shim.mjs</summary>

```js
// Proof-only SSRF seam, served in place of src/plugin-sdk/ssrf-runtime.ts.
// Runs the real guarded fetch with the private-network policy relaxed so the
// loopback fixture can stand in for the Google endpoint. All other exports are
// re-exported from the real modules unchanged.
import { fetchWithSsrFGuard as realGuardedFetch } from "../infra/net/fetch-guard.js";

export {
  closeDispatcher,
  createPinnedDispatcher,
  SsrFBlockedError,
  isBlockedHostnameOrIp,
  isPrivateIpAddress,
  resolvePinnedHostname,
  resolvePinnedHostnameWithPolicy,
  resolveSsrFPolicyForUrl,
  ssrfPolicyFromHttpBaseUrlAllowedHostname,
  ssrfPolicyFromHttpBaseUrlAllowedOrigin,
} from "../infra/net/ssrf.js";
export { formatErrorMessage } from "../infra/errors.js";
export {
  assertHttpUrlTargetsPrivateNetwork,
  buildHostnameAllowlistPolicyFromSuffixAllowlist,
  createLegacyPrivateNetworkDoctorContract,
  hasLegacyFlatAllowPrivateNetworkAlias,
  isPrivateNetworkOptInEnabled,
  mergeSsrFPolicies,
  migrateLegacyFlatAllowPrivateNetworkAlias,
  ssrfPolicyFromDangerouslyAllowPrivateNetwork,
  ssrfPolicyFromPrivateNetworkOptIn,
  ssrfPolicyFromAllowPrivateNetwork,
} from "./ssrf-policy.js";
export { isLoopbackHost, isPrivateOrLoopbackHost } from "../gateway/net.js";

export function fetchWithSsrFGuard(params) {
  return realGuardedFetch({ ...params, policy: { allowPrivateNetwork: true } });
}
```

</details>

AI-assisted: built with Codex
