### PR TITLE
fix(slack): resolve conversation type for app_mention in C-prefixed group DMs

### DIFF
--- a/extensions/slack/src/monitor/events/messages.test.ts
+++ b/extensions/slack/src/monitor/events/messages.test.ts
@@ -718,6 +718,18 @@ describe("registerSlackMessageEvents", () => {
     expect(inboundLogLines()).toEqual([]);
   });
 
+  it("skips app_mention events for modern C-prefixed group DMs without channel_type", async () => {
+    const { handleSlackMessage } = await invokeRegisteredHandler({
+      eventName: "app_mention",
+      overrides: { dmPolicy: "open", channelType: "mpim" },
+      event: { ...makeAppMentionEvent({ channel: "C0MPDM42" }), channel_type: undefined },
+    });
+
+    expect(handleSlackMessage).not.toHaveBeenCalled();
+    // Handled via message.mpim; must not log a duplicate receipt.
+    expect(inboundLogLines()).toEqual([]);
+  });
+
   it("routes app_mention events from channels to the message handler", async () => {
     const { handleSlackMessage } = await invokeRegisteredHandler({
       eventName: "app_mention",

--- a/extensions/slack/src/monitor/events/messages.ts
+++ b/extensions/slack/src/monitor/events/messages.ts
@@ -319,6 +319,22 @@ export function registerSlackMessageEvents(params: {
         if (channelType === "im" || channelType === "mpim") {
           return;
         }
+        // Modern Slack group DMs (mpims) use C-prefixed channel ids and
+        // app_mention events carry no channel_type, so the prefix inference
+        // above reports "channel" for them. Confirm against the event-carried
+        // type cache (fed by message.mpim) and, on a miss, conversations.info
+        // before treating this as a channel mention — otherwise group-DM
+        // mentions run down the channel path and are double-handled alongside
+        // the paired message.mpim event.
+        if (channelType === "channel" && !mention.channel_type) {
+          const scope = eventScope ?? undefined;
+          const knownType =
+            ctx.recallSlackChannelType(mention.channel, scope) ??
+            (await ctx.resolveChannelName(mention.channel, scope)).type;
+          if (knownType === "mpim") {
+            return;
+          }
+        }
 
         // Emit a per-inbound receipt before dispatch so a silently-dropped mention
         // (e.g. router consumes it without a tool call) still leaves journal evidence,

--- a/extensions/slack/src/monitor/events/system-event-test-harness.ts
+++ b/extensions/slack/src/monitor/events/system-event-test-harness.ts
@@ -9,7 +9,7 @@ export type SlackSystemEventHandler = (args: {
 export type SlackSystemEventTestOverrides = {
   dmPolicy?: "open" | "pairing" | "allowlist" | "disabled";
   allowFrom?: string[];
-  channelType?: "im" | "channel";
+  channelType?: "im" | "channel" | "mpim";
   channelUsers?: string[];
   reactionMode?: "off" | "own" | "all" | "allowlist";
   reactionAllowlist?: Array<string | number>;
@@ -50,6 +50,7 @@ export function createSlackSystemEventTestHarness(overrides?: SlackSystemEventTe
     shouldDropMismatchedSlackEvent: () => false,
     isChannelAllowed: () => true,
     rememberSlackChannelType: () => {},
+    recallSlackChannelType: () => undefined,
     resolveChannelName: async () => ({
       name: channelType === "im" ? "direct" : "general",
       type: channelType,


### PR DESCRIPTION
Fixes #115463

## What Problem This Solves

Fixes an issue where Slack users mentioning an OpenClaw bot in a modern, C-prefixed multi-person direct message could trigger two agent runs, incorrect channel classification, or a reply delivered to the wrong conversation. Slack’s app-mention event does not provide `channel_type`, so prefix-based inference alone cannot distinguish a modern group DM from an ordinary channel.

## Why This Change Was Made

Keep conversation classification and duplicate prevention inside the existing Slack transport owner. For a type-less C-prefixed `app_mention`, consult the workspace-scoped Slack conversation-type cache first and reuse the existing cached `conversations.info` resolver only on a cache miss. Suppress the mention only when Slack identifies the conversation as an MPIM; its canonical `message.mpim` event remains the sole inbound delivery. Explicit event types, actual channels, ordinary DMs, authorization, configuration, and public plugin contracts retain their existing behavior.

## User Impact

A bot mentioned in a C-prefixed Slack group DM processes the rich group-DM message once and replies to that same group conversation. Regular Slack channels, direct messages, and installations without group-DM events continue to use their established handling.

## Evidence

- Slack documents that [`app_mention` event payloads](https://docs.slack.dev/reference/events/app_mention/) contain a conversation ID but do not include `channel_type`.
- Slack’s [conversation object](https://docs.slack.dev/reference/objects/conversation-object/) identifies multi-person direct messages through `is_mpim`; [`conversations.info`](https://docs.slack.dev/reference/methods/conversations.info/) returns that authoritative conversation object.
- Contributor head `2a046e238a5b95434aea5367ec7ea4570a02d477` adds an event-router regression proving that a C-prefixed MPIM mention without `channel_type` is not dispatched or logged a second time.
- The same head preserves the existing real-channel and DM app-mention regressions and uses the existing Slack monitor’s workspace-scoped cached conversation resolver.
- Contributor-reported focused monitor validation: 48 files and 925 passing tests. The contributor also reports successful operation of the equivalent patch in their production Slack gateway; this is reporter-provided live evidence, not an independently executed maintainer live test.
