### PR TITLE
fix(sessions): cull oldest thread entries when protected entries exceed maxEntries (#115338)

### DIFF
--- a/src/config/sessions/store-maintenance.ts
+++ b/src/config/sessions/store-maintenance.ts
@@ -570,6 +570,11 @@ export function capEntryCount(
       }),
   );
   if (keys.length <= maxRemovableEntries) {
+    // All unprotected entries fit within the removable budget. If protected entries still exceed
+    // the cap (e.g. thread sessions grow without bound), cull the oldest thread entries.
+    if (Object.keys(store).length > maxEntries) {
+      return cullProtectedThreadEntries(store, maxEntries, opts);
+    }
     return 0;
   }
 
@@ -590,6 +595,59 @@ export function capEntryCount(
   }
   if (opts.log !== false) {
     log.info("capped session entry count", { removed: toRemove.length, maxEntries });
+  }
+  return toRemove.length;
+}
+
+function cullProtectedThreadEntries(
+  store: Record<string, SessionEntry>,
+  maxEntries: number,
+  opts: {
+    log?: boolean;
+    onCapped?: (params: { key: string; entry: SessionEntry }) => void;
+  } = {},
+): number {
+  const threadKeys = Object.keys(store).filter((key) => {
+    const entry = store[key];
+    if (!entry) {
+      return false;
+    }
+    if (!shouldPreserveMaintenanceEntry({ key, entry })) {
+      return false;
+    }
+    if (parseSessionThreadInfoFast(key).threadId) {
+      return true;
+    }
+    const chatType = normalizeLowercaseStringOrEmpty(
+      entry.chatType ?? sessionDeliveryOrigin(entry)?.chatType,
+    );
+    return chatType === "thread";
+  });
+
+  if (threadKeys.length === 0) {
+    return 0;
+  }
+
+  const nonThreadCount = Object.keys(store).length - threadKeys.length;
+  const maxThreadSlots = Math.max(0, maxEntries - nonThreadCount);
+  if (threadKeys.length <= maxThreadSlots) {
+    return 0;
+  }
+
+  const toCull = threadKeys.length - maxThreadSlots;
+  const sorted = threadKeys.toSorted((a, b) => {
+    const aTime = getEntryUpdatedAt(store[a]);
+    const bTime = getEntryUpdatedAt(store[b]);
+    return bTime - aTime;
+  });
+
+  const toRemove = sorted.slice(-toCull);
+  for (const key of toRemove) {
+    opts.onCapped?.({ key, entry: store[key]! });
+    delete store[key];
+  }
+  if (opts.log !== false) {
+    log.info("culled protected thread entries", { removed: toRemove.length, maxEntries });
   }
   return toRemove.length;
 }

--- a/src/config/sessions/store.pruning.test.ts
+++ b/src/config/sessions/store.pruning.test.ts
@@ -671,11 +671,9 @@ describe("capEntryCount", () => {
     expect(store.old).toBeUndefined();
   });
 
-  it("never evicts the agent primary main session even when protected entries fill the cap (#112637)", () => {
+  it("culls the oldest thread entries when protected entries fill the cap (#115338)", () => {
     const now = Date.now();
     const mainKey = "agent:main:main";
-    // `main` is the oldest entry, so pre-fix it was the first unprotected eviction target once
-    // protected thread entries (>= maxEntries) left zero removable budget.
     const store = makeStore([
       [mainKey, makeEntry(now - 10 * DAY_MS)],
       ["agent:main:slack:channel:C1:thread:1", makeEntry(now - 3 * DAY_MS)],
@@ -685,10 +683,29 @@ describe("capEntryCount", () => {
 
     const evicted = capEntryCount(store, 2);
 
-    // Every entry is now protected (main + threads), so nothing is evicted and `main` survives.
+    // main survives, oldest 2 thread entries are culled, newest thread entry remains.
     expect(store).toHaveProperty(mainKey);
+    expect(store).toHaveProperty("agent:main:slack:channel:C3:thread:3");
+    expect(store["agent:main:slack:channel:C1:thread:1"]).toBeUndefined();
+    expect(store["agent:main:slack:channel:C2:thread:2"]).toBeUndefined();
+    expect(evicted).toBe(2);
+    expect(Object.keys(store)).toHaveLength(2);
+  });
+
+  it("preserves all thread entries when under the cap", () => {
+    const now = Date.now();
+    const mainKey = "agent:main:main";
+    const store = makeStore([
+      [mainKey, makeEntry(now - 10 * DAY_MS)],
+      ["agent:main:slack:channel:C1:thread:1", makeEntry(now - DAY_MS)],
+    ]);
+
+    const evicted = capEntryCount(store, 3);
+
+    expect(store).toHaveProperty(mainKey);
+    expect(store).toHaveProperty("agent:main:slack:channel:C1:thread:1");
     expect(evicted).toBe(0);
-    expect(Object.keys(store)).toHaveLength(4);
+    expect(Object.keys(store)).toHaveLength(2);
   });
 
   it("preserves model-locked harness sessions when capping", () => {


### PR DESCRIPTION
## What Problem This Solves

Closes #115338: `session.maintenance.maxEntries` is effectively non-functional for Slack thread sessions. All thread entries are unconditionally protected from capping by `isProtectedSessionMaintenanceEntry()`, which returns `true` for any key with a `threadId`. Since every Slack thread creates a session entry with `:thread:<ts>` suffix, thread entries accumulate without bound regardless of `maxEntries`.

**Impact**: Unbounded sessions.json growth → CronSessionLifecycleClaimError at ~700+ entries (~3.2MB).

## Why This Change Was Made

`capEntryCount` in `store-maintenance.ts` computes `maxRemovableEntries = max(0, maxEntries - preservedCount)`. When all entries are protected (e.g. 1 main + N threads), `preservedCount > maxEntries`, leaving zero removable budget. No entries are ever evicted.

The fix adds `cullProtectedThreadEntries()` — when the unprotected-key budget is exhausted but the store still exceeds `maxEntries`, it sorts protected thread entries by `updatedAt` and removes the oldest ones until the store fits within `maxEntries`. Other protected types (main, group, channel) remain untouched.

## User Impact

- Thread session entries are now subject to capping when they exceed `maxEntries`
- `maxEntries` configuration becomes effective for heavy thread users
- No migration or config change needed
- Backward compatible: stores under `maxEntries` are unaffected

## Evidence

### Changed files
- `src/config/sessions/store-maintenance.ts` — add `cullProtectedThreadEntries` helper, wire into `capEntryCount`
- `src/config/sessions/store.pruning.test.ts` — update #112637 test for new behavior, add under-cap test

### Behavior Matrix

| Scenario | Before | After | Changed? |
|---|---|---|---|
| maxEntries=500, 600 threads + 1 main | 601 entries (no capping) | 500 entries (100 oldest threads culled) | ✅ Fix |
| maxEntries=100, 50 threads + 1 main | 51 entries (under cap) | 51 entries (no capping) | ❌ No |
| maxEntries=2, 3 threads + 1 main | 4 entries (no capping) | 2 entries (main + newest thread) | ✅ Fix |
| No thread entries, all protected | No change | No change | ❌ No |

### Code

`capEntryCount` entry point (store-maintenance.ts:570):
```ts
if (keys.length <= maxRemovableEntries) {
    if (Object.keys(store).length > maxEntries) {
      return cullProtectedThreadEntries(store, maxEntries, opts);
    }
    return 0;
  }
```

`cullProtectedThreadEntries` sorts thread keys by `updatedAt` descending, removes oldest entries that exceed `maxThreadSlots` (non-thread slots subtracted from `maxEntries`).

### Test coverage
- **Existing test updated**: "culls the oldest thread entries when protected entries fill the cap (#115338)" — 4 entries (1 main + 3 threads), maxEntries=2 → 2 entries remain (main + newest thread), evicted=2
- **New test**: "preserves all thread entries when under the cap" — 2 entries (1 main + 1 thread), maxEntries=3 → all preserved, evicted=0

### AI Assistance 🤖
This PR was developed with assistance from Claude (iCodemate), following the open-source-pr skill workflow. Commit message prefixed with `[AI]`.
