### PR TITLE
fix(ui): keep disabled microphone picker background neutral

### DIFF
--- a/ui/src/e2e/chat-composer-redesign.e2e.test.ts
+++ b/ui/src/e2e/chat-composer-redesign.e2e.test.ts
@@ -130,6 +130,7 @@ describeControlUiE2e("Control UI chat composer redesign", () => {
       const settings = composer.getByRole("button", { name: "View", exact: true });
       const splitView = page.getByRole("button", { name: "Open split view" });
       const voice = page.getByRole("button", { name: "Start voice input" });
+      const microphonePicker = page.getByRole("button", { name: "Microphone input" });
 
       await expect.poll(() => model.isVisible()).toBe(true);
       expect(await gateway.getRequests("chat.metadata")).toHaveLength(0);
@@ -538,6 +539,26 @@ describeControlUiE2e("Control UI chat composer redesign", () => {
       await expect.poll(() => viewMenu.isVisible()).toBe(true);
       await settings.click();
       await expect.poll(() => viewMenu.isVisible()).toBe(false);
+
+      await page.setViewportSize({ width: 1280, height: 900 });
+      await gateway.setOnline(false);
+      await expect.poll(() => voice.isDisabled()).toBe(true);
+      await expect
+        .poll(async () => {
+          const [voiceBackground, pickerBackground] = await Promise.all([
+            voice.evaluate((node) => getComputedStyle(node).backgroundColor),
+            microphonePicker.evaluate((node) => getComputedStyle(node).backgroundColor),
+          ]);
+          return voiceBackground === pickerBackground;
+        })
+        .toBe(true);
+      const artifactDir = process.env.OPENCLAW_UI_E2E_ARTIFACT_DIR?.trim();
+      if (artifactDir) {
+        await composerShell.screenshot({
+          animations: "disabled",
+          path: `${artifactDir}/voice-picker-disabled-background.png`,
+        });
+      }
     } finally {
       await context.close();
     }

--- a/ui/src/styles/chat/layout.css
+++ b/ui/src/styles/chat/layout.css
@@ -2813,6 +2813,11 @@ openclaw-chat-page {
   background: color-mix(in srgb, var(--accent) 20%, transparent);
 }
 
+/* Keep both halves of the voice pill visually joined when Talk is unavailable. */
+.chat-talk-control:has(.chat-send-btn:disabled) .chat-talk-input-picker__trigger {
+  background: color-mix(in srgb, var(--muted) 16%, transparent);
+}
+
 .chat-talk-input-picker__trigger:focus-visible {
   outline: 2px solid var(--ring);
   outline-offset: 2px;


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users saw the microphone picker half of the chat voice control remain red while the microphone half switched to its neutral disabled background when Talk was unavailable.

## Why This Change Was Made

The picker now follows the existing disabled voice-button fill, keeping the two halves of the pill visually joined without changing the picker interaction or the active Talk treatment. The composer browser test verifies the computed backgrounds match in the real disconnected state.

## User Impact

The disabled voice control now has one consistent neutral background instead of a red chevron segment beside a muted microphone.

## Evidence

- Exact head: `2a23abc414c81fbffd70243323355648af4553e0`
- Testbox-through-Crabbox: `tbx_01kynqca9ny94syzrrtwsger87`
- [Testbox Actions run](https://github.com/openclaw/openclaw/actions/runs/30413825609)
- Passed: focused oxfmt check, stylelint, `pnpm tsgo:ui`, and all 6 tests in `chat-composer-redesign.e2e.test.ts`
- The browser test captures the disconnected composer and asserts the microphone and picker have identical computed backgrounds.
