### PR TITLE
fix(ui): contain model picker scrolling

### DIFF
--- a/ui/src/e2e/chat-flow.models-reasoning.e2e.test.ts
+++ b/ui/src/e2e/chat-flow.models-reasoning.e2e.test.ts
@@ -40,6 +40,49 @@ suite.define(() => {
     }
   });
 
+  it("keeps high-velocity model scrolling inside the picker", async () => {
+    const context = await suite.newBrowserContext({
+      locale: "en-US",
+      serviceWorkers: "block",
+      viewport: { height: 900, width: 1280 },
+    });
+    const page = await context.newPage();
+    const models = [
+      { id: "gpt-5.5", name: "GPT-5.5", provider: "openai" },
+      ...Array.from({ length: 32 }, (_value, index) => ({
+        id: `scroll-model-${index + 1}`,
+        name: `Scroll Model ${index + 1}`,
+        provider: "openai",
+      })),
+    ];
+    await installMockGateway(page, {
+      models,
+      sessionKey: "agent:main:main",
+    });
+
+    try {
+      await page.goto(`${suite.server.baseUrl}chat`);
+      const main = page.getByRole("main");
+      await main.locator('[data-chat-model-select="true"]').click();
+      const modelScroller = main.locator(".chat-controls__provider-models");
+      await page.evaluate(() => {
+        document.documentElement.style.overflowY = "auto";
+        document.body.style.height = "1800px";
+        window.scrollTo(0, 300);
+      });
+      expect(await page.evaluate(() => window.scrollY)).toBe(300);
+      await modelScroller.hover();
+      const outerScrollBeforeFling = await page.evaluate(() => window.scrollY);
+      expect(outerScrollBeforeFling).toBeGreaterThan(0);
+      await page.mouse.wheel(0, -5_000);
+      await page.waitForTimeout(100);
+
+      expect(await page.evaluate(() => window.scrollY)).toBe(outerScrollBeforeFling);
+    } finally {
+      await suite.closeBrowserContext(context);
+    }
+  });
+
   it("keeps a session model override selected after switching away and back", async () => {
     const context = await suite.newBrowserContext({
       locale: "en-US",

--- a/ui/src/styles/chat/layout.css
+++ b/ui/src/styles/chat/layout.css
@@ -4036,6 +4036,7 @@ openclaw-chat-page {
   min-width: 0;
   padding: 8px;
   overflow-y: auto;
+  overscroll-behavior: none;
 }
 
 .chat-controls__provider-model-group {


### PR DESCRIPTION
## What Problem This Solves

Fast wheel or trackpad scrolling at the model picker boundary could chain into the outer page, making model options appear to fly above the picker border.

## Why This Change Was Made

The model list is the scroll owner for this interaction. Setting `overscroll-behavior: none` on that list keeps high-velocity boundary scrolling contained there instead of moving the surrounding document.

The regression test gives the picker enough models to scroll, flings upward at the boundary, and verifies the outer document scroll position does not change.

## User Impact

Rapidly scrolling through a long model list now stays inside the picker and no longer moves options beyond its top border.

## Evidence

- Crabbox Hetzner lease `cbx_d76c5d8b6f3b`
- Before-fix repro `run_36024c5ae051`: outer scroll escaped from `183` to `0`
- After-fix visual proof `run_544e714bdd59`: outer scroll stayed `300` to `300`, with no option hit-tested above the header
- Fresh current-main browser E2E `run_6a7eee9eb495`: `ui/src/e2e/chat-flow.models-reasoning.e2e.test.ts`, 7/7 passed
- Fresh format and lint `run_ced48998f46f`: `oxfmt --check` clean; targeted `oxlint` clean
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main --stream-engine-output`: no accepted/actionable findings, correctness 0.97
- `git diff --check origin/main...HEAD`: clean
