### PR TITLE
fix(ui): preview model picker interactions live

### DIFF
--- a/ui/src/e2e/chat-flow.models-reasoning.e2e.test.ts
+++ b/ui/src/e2e/chat-flow.models-reasoning.e2e.test.ts
@@ -275,6 +275,111 @@ suite.define(() => {
     }
   });
 
+  it("previews reasoning and provider choices before committing them", async () => {
+    const context = await suite.newBrowserContext({
+      locale: "en-US",
+      serviceWorkers: "block",
+      viewport: { height: 900, width: 1280 },
+    });
+    const page = await context.newPage();
+    const sessionKey = "agent:main:session-a";
+    const session = {
+      key: sessionKey,
+      kind: "direct",
+      label: "Session A",
+      model: "gpt-5.6-sol",
+      modelProvider: "openai",
+      thinkingDefault: "high",
+      thinkingLevel: "high",
+      thinkingLevels: [
+        { id: "off", label: "off" },
+        { id: "low", label: "low" },
+        { id: "medium", label: "medium" },
+        { id: "high", label: "high" },
+        { id: "ultra", label: "ultra" },
+      ],
+      updatedAt: 2,
+    };
+    const gateway = await installMockGateway(page, {
+      methodResponses: {
+        "sessions.list": chatSessionListResponse([session]),
+      },
+      models: [
+        { id: "gpt-5.6-sol", name: "GPT-5.6 Sol", provider: "openai" },
+        { id: "claude-fable-5", name: "Claude Fable 5", provider: "anthropic" },
+      ],
+      sessionKey,
+    });
+
+    try {
+      await page.goto(`${suite.server.baseUrl}chat`);
+
+      const main = page.getByRole("main");
+      const picker = main.locator('[data-chat-model-select="true"]').first();
+      await picker.click();
+      const thinkingSlider = main.locator('[data-chat-thinking-slider="true"]');
+      const visibleReasoning = main.locator(
+        "[data-chat-thinking-preview-committed]:not([hidden]), " +
+          "[data-chat-thinking-preview-index]:not([hidden])",
+      );
+
+      for (const value of ["low", "medium", "ultra"]) {
+        await thinkingSlider.evaluate((input, nextValue) => {
+          const slider = input as HTMLInputElement;
+          const values = (slider.dataset.chatThinkingValues ?? "").split(",");
+          slider.value = String(values.indexOf(nextValue));
+          slider.dispatchEvent(new Event("input", { bubbles: true }));
+        }, value);
+        await expect
+          .poll(() => visibleReasoning.evaluate((element) => element.textContent?.trim()))
+          .toBe(value.charAt(0).toUpperCase() + value.slice(1));
+      }
+      await expectRequestCountStable(gateway, "sessions.patch", 0);
+
+      await gateway.setMethodResponse(
+        "sessions.list",
+        chatSessionListResponse([{ ...session, thinkingLevel: "ultra" }]),
+      );
+      await thinkingSlider.evaluate((input) => {
+        input.dispatchEvent(new Event("change", { bubbles: true }));
+      });
+      const thinkingPatch = await gateway.waitForRequest("sessions.patch");
+      expect(requireRecord(thinkingPatch.params)).toMatchObject({
+        key: sessionKey,
+        thinkingLevel: "ultra",
+      });
+      await expect.poll(() => picker.getAttribute("data-chat-thinking-value")).toBe("ultra");
+      await picker.click();
+      await expect.poll(() => picker.textContent()).toContain("Ultra");
+      await picker.click();
+
+      const anthropicProvider = main.locator('[data-chat-model-provider="anthropic"]');
+      const openaiProvider = main.locator('[data-chat-model-provider="openai"]');
+      const anthropicModels = main.locator('[data-chat-model-provider-group="anthropic"]');
+      await anthropicProvider.hover();
+      await expect.poll(() => anthropicModels.isVisible()).toBe(true);
+      await expectRequestCountStable(gateway, "sessions.patch", 1);
+
+      await openaiProvider.focus();
+      await expect.poll(() => anthropicModels.isHidden()).toBe(true);
+      await anthropicProvider.focus();
+      await expect.poll(() => anthropicModels.isVisible()).toBe(true);
+      await page.keyboard.press("Tab");
+      await expect
+        .poll(() => page.locator(":focus").getAttribute("data-chat-model-option"))
+        .toBe("anthropic/claude-fable-5");
+
+      await main.locator('[data-chat-model-option="anthropic/claude-fable-5"]').click();
+      const patches = await waitForRequests(gateway, "sessions.patch", 2);
+      expect(requireRecord(patches[1]?.params)).toMatchObject({
+        key: sessionKey,
+        model: "anthropic/claude-fable-5",
+      });
+    } finally {
+      await suite.closeBrowserContext(context);
+    }
+  });
+
   it("applies provider-specific reasoning after the selected model is saved", async () => {
     const context = await suite.newBrowserContext({
       locale: "en-US",

--- a/ui/src/pages/chat/chat-view.test.ts
+++ b/ui/src/pages/chat/chat-view.test.ts
@@ -588,7 +588,15 @@ function getThinkingSliderValues(container: Element): string[] {
 }
 
 function getThinkingReasoningValueLabel(container: Element): string {
-  return container.querySelector(".chat-controls__reasoning-value")?.textContent?.trim() ?? "";
+  const preview = container.querySelector(
+    "[data-chat-thinking-preview-committed]:not([hidden]), " +
+      "[data-chat-thinking-preview-index]:not([hidden])",
+  );
+  return (
+    preview?.textContent?.trim() ??
+    container.querySelector(".chat-controls__reasoning-value")?.textContent?.trim() ??
+    ""
+  );
 }
 
 function getThinkingResetButton(container: Element): HTMLButtonElement | null {
@@ -4619,7 +4627,7 @@ describe("chat model controls", () => {
     expect(onModelSelect).not.toHaveBeenCalled();
   });
 
-  it("groups models by provider and switches the visible provider section", () => {
+  it("previews provider models on hover and keyboard focus", () => {
     const { state } = createChatHeaderState({
       model: "gpt-5.5",
       modelProvider: "openai",
@@ -4630,6 +4638,7 @@ describe("chat model controls", () => {
       ],
     });
     const container = renderModelControls(state);
+    document.body.append(container);
 
     const providerButtons = Array.from(
       container.querySelectorAll<HTMLButtonElement>("[data-chat-model-provider]"),
@@ -4647,7 +4656,7 @@ describe("chat model controls", () => {
       container.querySelector<HTMLElement>('[data-chat-model-provider-group="anthropic"]')?.hidden,
     ).toBe(true);
 
-    providerButtons[1]?.click();
+    providerButtons[1]?.dispatchEvent(new MouseEvent("mouseenter"));
 
     expect(providerButtons[0]?.getAttribute("aria-pressed")).toBe("false");
     expect(providerButtons[1]?.getAttribute("aria-pressed")).toBe("true");
@@ -4659,6 +4668,32 @@ describe("chat model controls", () => {
     );
     expect(anthropicModels?.hidden).toBe(false);
     expect(anthropicModels?.textContent).toContain("Claude Sonnet 4.6");
+
+    const browser = container.querySelector<HTMLElement>(".chat-controls__model-browser");
+    browser?.dispatchEvent(new MouseEvent("mouseleave"));
+    expect(providerButtons[0]?.getAttribute("aria-pressed")).toBe("true");
+    expect(anthropicModels?.hidden).toBe(true);
+
+    providerButtons[2]?.dispatchEvent(new FocusEvent("focus"));
+    expect(providerButtons[2]?.getAttribute("aria-pressed")).toBe("true");
+    expect(providerButtons.map((button) => button.tabIndex)).toEqual([-1, -1, 0]);
+    expect(
+      container.querySelector<HTMLElement>('[data-chat-model-provider-group="google"]')?.hidden,
+    ).toBe(false);
+
+    providerButtons[2]?.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowLeft" }));
+    expect(providerButtons[1]?.getAttribute("aria-pressed")).toBe("true");
+    expect(providerButtons.map((button) => button.tabIndex)).toEqual([-1, 0, -1]);
+    providerButtons[2]?.dispatchEvent(new MouseEvent("mouseenter"));
+    expect(providerButtons[1]?.getAttribute("aria-pressed")).toBe("true");
+    browser?.dispatchEvent(new MouseEvent("mouseleave"));
+    expect(providerButtons[1]?.getAttribute("aria-pressed")).toBe("true");
+
+    browser?.dispatchEvent(
+      new FocusEvent("focusout", { bubbles: true, relatedTarget: document.body }),
+    );
+    expect(providerButtons[0]?.getAttribute("aria-pressed")).toBe("true");
+    container.remove();
   });
 
   it("groups legacy Codex model references under OpenAI", () => {
@@ -5002,11 +5037,16 @@ describe("chat model controls", () => {
     if (slider) {
       slider.value = "0";
       slider.dispatchEvent(new Event("input", { bubbles: true }));
-      // Drag preview is attribute-only: mutating rendered text would eject
-      // Lit's ChildPart markers and freeze later menu renders.
       expect(slider.getAttribute("aria-valuetext")).toBe("Low");
-      expect(getThinkingReasoningValueLabel(container)).toBe("High");
+      expect(getThinkingReasoningValueLabel(container)).toBe("Low");
       slider.dispatchEvent(new Event("change", { bubbles: true }));
+      expect(getThinkingReasoningValueLabel(container)).toBe("High");
+
+      slider.value = "0";
+      slider.dispatchEvent(new Event("input", { bubbles: true }));
+      slider.dispatchEvent(new Event("pointercancel"));
+      expect(slider.value).toBe(String(getThinkingSliderValues(container).indexOf("high")));
+      expect(getThinkingReasoningValueLabel(container)).toBe("High");
     }
     expect(onThinkingSelect).toHaveBeenCalledWith("low", "main");
 

--- a/ui/src/pages/chat/components/chat-model-controls.ts
+++ b/ui/src/pages/chat/components/chat-model-controls.ts
@@ -675,11 +675,7 @@ function renderChatModelReasoningSelect(params: {
                   selectChatModelProvider(event, selectedProvider);
                 }}
               >
-                <div
-                  class="chat-controls__provider-list"
-                  role="tablist"
-                  aria-label=${t("sessionsView.provider")}
-                >
+                <div class="chat-controls__provider-list" aria-label=${t("sessionsView.provider")}>
                   <div class="chat-controls__inline-select-section-label">
                     ${t("sessionsView.provider")}
                   </div>
@@ -693,9 +689,7 @@ function renderChatModelReasoningSelect(params: {
                           class="chat-controls__provider-option"
                           data-chat-model-provider=${provider}
                           type="button"
-                          role="tab"
                           aria-pressed=${active ? "true" : "false"}
-                          aria-selected=${active ? "true" : "false"}
                           tabindex=${active ? "0" : "-1"}
                           @click=${(event: MouseEvent) => selectChatModelProvider(event, provider)}
                           @mouseenter=${(event: MouseEvent) => {
@@ -731,7 +725,6 @@ function renderChatModelReasoningSelect(params: {
                       <div
                         class="chat-controls__provider-model-group"
                         data-chat-model-provider-group=${provider}
-                        role="tabpanel"
                         aria-label=${`${providerDisplayLabel(provider)} models`}
                         ?hidden=${provider !== selectedProvider}
                       >

--- a/ui/src/pages/chat/components/chat-model-controls.ts
+++ b/ui/src/pages/chat/components/chat-model-controls.ts
@@ -28,7 +28,7 @@ import {
 } from "../../../lib/chat/thinking.ts";
 import { formatCompactTokenCount } from "../../../lib/format.ts";
 import { areUiSessionKeysEquivalent } from "../../../lib/sessions/session-key.ts";
-import { selectChatModelProvider } from "./chat-model-provider-menu.ts";
+import { moveChatModelProviderFocus, selectChatModelProvider } from "./chat-model-provider-menu.ts";
 
 export type ChatModelControlsProps = {
   activeRunId: string | null;
@@ -456,25 +456,51 @@ function renderChatModelReasoningSelect(params: {
   const speedTooltip = fastMode.supported
     ? "Fast responses finish sooner and can use more of your usage limits."
     : "Speed control is not supported for this model.";
+  const resetSliderPreview = (input: HTMLInputElement, restoreValue = false) => {
+    if (restoreValue) {
+      input.value = String(sliderIndex);
+    }
+    input.style.setProperty("--reasoning-fill", `${sliderFillPercent(sliderIndex)}%`);
+    input.setAttribute("aria-valuetext", reasoningValueLabel);
+    const panel = input.closest(".chat-controls__reasoning-panel");
+    panel?.querySelectorAll<HTMLElement>("[data-chat-thinking-preview-index]").forEach((label) => {
+      label.hidden = true;
+    });
+    const committedLabel = panel?.querySelector<HTMLElement>(
+      "[data-chat-thinking-preview-committed]",
+    );
+    if (committedLabel) {
+      committedLabel.hidden = false;
+    }
+  };
   const onSliderDrag = (event: Event) => {
     const input = event.currentTarget as HTMLInputElement;
     const stop = sliderStops[Number(input.value)];
     if (!stop) {
       return;
     }
-    // Style/attribute-only drag preview; change commits on release and the
-    // re-render refreshes the visible value label. Never write into rendered
-    // text here: setting textContent on a Lit-managed span ejects the
-    // ChildPart markers and permanently breaks every later menu render.
     input.style.setProperty("--reasoning-fill", `${sliderFillPercent(Number(input.value))}%`);
     input.setAttribute("aria-valuetext", formatCombinedPickerThinkingLabel(stop.label));
+    const panel = input.closest(".chat-controls__reasoning-panel");
+    panel?.querySelectorAll<HTMLElement>("[data-chat-thinking-preview-index]").forEach((label) => {
+      label.hidden = label.dataset.chatThinkingPreviewIndex !== input.value;
+    });
+    const committedLabel = panel?.querySelector<HTMLElement>(
+      "[data-chat-thinking-preview-committed]",
+    );
+    if (committedLabel) {
+      committedLabel.hidden = true;
+    }
   };
   const onSliderCommit = (event: Event) => {
+    const input = event.currentTarget as HTMLInputElement;
+    const stop = sliderStops[Number(input.value)];
+    // Preview visibility is DOM-owned during a drag, so restore Lit's
+    // committed baseline before either the optimistic update or a failed patch.
+    resetSliderPreview(input);
     if (thinkingDisabled) {
       return;
     }
-    const input = event.currentTarget as HTMLInputElement;
-    const stop = sliderStops[Number(input.value)];
     if (!stop || stop.value === selectedThinkingValue) {
       return;
     }
@@ -629,8 +655,31 @@ function renderChatModelReasoningSelect(params: {
                 hasModelOverride: selectedModelValue !== "",
                 onReset: () => commitModel(""),
               })}
-              <div class="chat-controls__model-browser">
-                <div class="chat-controls__provider-list" aria-label=${t("sessionsView.provider")}>
+              <div
+                class="chat-controls__model-browser"
+                @mouseleave=${(event: MouseEvent) => {
+                  const browser = event.currentTarget as HTMLElement;
+                  if (browser.contains(document.activeElement)) {
+                    return;
+                  }
+                  selectChatModelProvider(event, selectedProvider);
+                }}
+                @focusout=${(event: FocusEvent) => {
+                  const browser = event.currentTarget as HTMLElement;
+                  if (
+                    event.relatedTarget instanceof Node &&
+                    browser.contains(event.relatedTarget)
+                  ) {
+                    return;
+                  }
+                  selectChatModelProvider(event, selectedProvider);
+                }}
+              >
+                <div
+                  class="chat-controls__provider-list"
+                  role="tablist"
+                  aria-label=${t("sessionsView.provider")}
+                >
                   <div class="chat-controls__inline-select-section-label">
                     ${t("sessionsView.provider")}
                   </div>
@@ -644,8 +693,24 @@ function renderChatModelReasoningSelect(params: {
                           class="chat-controls__provider-option"
                           data-chat-model-provider=${provider}
                           type="button"
+                          role="tab"
                           aria-pressed=${active ? "true" : "false"}
+                          aria-selected=${active ? "true" : "false"}
+                          tabindex=${active ? "0" : "-1"}
                           @click=${(event: MouseEvent) => selectChatModelProvider(event, provider)}
+                          @mouseenter=${(event: MouseEvent) => {
+                            const browser = (event.currentTarget as HTMLElement).closest(
+                              ".chat-controls__model-browser",
+                            );
+                            // Keyboard focus owns the active tab until it leaves; hover must
+                            // not hide the panel containing the focused model option.
+                            if (browser?.contains(document.activeElement)) {
+                              return;
+                            }
+                            selectChatModelProvider(event, provider);
+                          }}
+                          @focus=${(event: FocusEvent) => selectChatModelProvider(event, provider)}
+                          @keydown=${moveChatModelProviderFocus}
                         >
                           ${renderChatModelProviderIcon(provider)}
                           <span>${providerDisplayLabel(provider)}</span>
@@ -666,6 +731,7 @@ function renderChatModelReasoningSelect(params: {
                       <div
                         class="chat-controls__provider-model-group"
                         data-chat-model-provider-group=${provider}
+                        role="tabpanel"
                         aria-label=${`${providerDisplayLabel(provider)} models`}
                         ?hidden=${provider !== selectedProvider}
                       >
@@ -695,7 +761,20 @@ function renderChatModelReasoningSelect(params: {
                               ? ""
                               : "chat-controls__reasoning-value--inherit"}"
                           >
-                            ${reasoningValueText}
+                            ${sliderStops.length > 1
+                              ? html`
+                                  <span data-chat-thinking-preview-committed>
+                                    ${reasoningValueText}
+                                  </span>
+                                  ${sliderStops.map(
+                                    (stop, index) => html`
+                                      <span data-chat-thinking-preview-index=${index} hidden>
+                                        ${formatCombinedPickerThinkingLabel(stop.label)}
+                                      </span>
+                                    `,
+                                  )}
+                                `
+                              : reasoningValueText}
                           </span>
                           ${hasThinkingOverride
                             ? html`
@@ -762,6 +841,10 @@ function renderChatModelReasoningSelect(params: {
                                 @change=${onSliderCommit}
                                 @click=${onUnanchoredSliderClick}
                                 @keydown=${onUnanchoredSliderKeyDown}
+                                @pointercancel=${(event: PointerEvent) =>
+                                  resetSliderPreview(event.currentTarget as HTMLInputElement, true)}
+                                @blur=${(event: FocusEvent) =>
+                                  resetSliderPreview(event.currentTarget as HTMLInputElement, true)}
                               />
                             </div>
                           `

--- a/ui/src/pages/chat/components/chat-model-provider-menu.ts
+++ b/ui/src/pages/chat/components/chat-model-provider-menu.ts
@@ -1,4 +1,4 @@
-export function selectChatModelProvider(event: MouseEvent, provider: string): void {
+export function selectChatModelProvider(event: Event, provider: string): void {
   event.preventDefault();
   event.stopPropagation();
   const menu = (event.currentTarget as HTMLElement).closest(
@@ -8,12 +8,39 @@ export function selectChatModelProvider(event: MouseEvent, provider: string): vo
     return;
   }
   menu.querySelectorAll<HTMLElement>("[data-chat-model-provider]").forEach((button) => {
-    button.setAttribute(
-      "aria-pressed",
-      button.dataset.chatModelProvider === provider ? "true" : "false",
-    );
+    const active = button.dataset.chatModelProvider === provider;
+    button.setAttribute("aria-pressed", active ? "true" : "false");
+    button.setAttribute("aria-selected", active ? "true" : "false");
+    button.tabIndex = active ? 0 : -1;
   });
   menu.querySelectorAll<HTMLElement>("[data-chat-model-provider-group]").forEach((group) => {
     group.hidden = group.dataset.chatModelProviderGroup !== provider;
   });
+}
+
+export function moveChatModelProviderFocus(event: KeyboardEvent): void {
+  const direction =
+    event.key === "ArrowRight" || event.key === "ArrowDown"
+      ? 1
+      : event.key === "ArrowLeft" || event.key === "ArrowUp"
+        ? -1
+        : 0;
+  const current = event.currentTarget as HTMLElement;
+  const list = current.closest(".chat-controls__provider-list");
+  const buttons = list
+    ? [...list.querySelectorAll<HTMLButtonElement>("[data-chat-model-provider]")]
+    : [];
+  const currentIndex = buttons.indexOf(current as HTMLButtonElement);
+  if (currentIndex < 0 || (direction === 0 && event.key !== "Home" && event.key !== "End")) {
+    return;
+  }
+  event.preventDefault();
+  event.stopPropagation();
+  const nextIndex =
+    event.key === "Home"
+      ? 0
+      : event.key === "End"
+        ? buttons.length - 1
+        : (currentIndex + direction + buttons.length) % buttons.length;
+  buttons[nextIndex]?.focus();
 }

--- a/ui/src/pages/chat/components/chat-model-provider-menu.ts
+++ b/ui/src/pages/chat/components/chat-model-provider-menu.ts
@@ -10,7 +10,6 @@ export function selectChatModelProvider(event: Event, provider: string): void {
   menu.querySelectorAll<HTMLElement>("[data-chat-model-provider]").forEach((button) => {
     const active = button.dataset.chatModelProvider === provider;
     button.setAttribute("aria-pressed", active ? "true" : "false");
-    button.setAttribute("aria-selected", active ? "true" : "false");
     button.tabIndex = active ? 0 : -1;
   });
   menu.querySelectorAll<HTMLElement>("[data-chat-model-provider-group]").forEach((group) => {


### PR DESCRIPTION
## What Problem This Solves

Fixes two Control UI model-picker interactions that lagged behind user input: the reasoning value only refreshed after a slider drag committed, and the model list only changed after clicking a provider instead of while exploring provider rows.

## Why This Change Was Made

The picker now uses one preview/committed-state flow: slider `input` events update the visible reasoning preview while `change` commits it, and the existing active-provider state previews provider rows on pointer hover or keyboard focus without changing the selected model. Cancellation restores the committed reasoning value, and model-click commit behavior remains unchanged. Provider keyboard navigation stays on native pressed-button semantics, consistent with the Control UI shared-control inventory.

AI-assisted implementation; the author reviewed the state flow, tests, and proof artifacts.

## User Impact

Users can see each supported reasoning level while dragging and can inspect providers' model lists immediately by hover or keyboard navigation, while deliberate model selection still requires a model click.

## Evidence

- `node scripts/run-vitest.mjs ui/src/components/web-awesome-migration.node.test.ts` — 3/3 passed.
- `node scripts/run-vitest.mjs ui/src/pages/chat/chat-view.test.ts` — 206/206 passed.
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/chat-flow.models-reasoning.e2e.test.ts` — 7/7 passed.
- `.agents/skills/autoreview/scripts/autoreview --mode uncommitted` — no accepted/actionable findings after the CI follow-up.
- Blacksmith Testbox `pnpm check:changed` — passed on lease `tbx_01kynqq9v7gjkgk8keq69zsjkf`; [run 30414112107](https://github.com/openclaw/openclaw/actions/runs/30414112107).
- Visible desktop proof on Hetzner Crabbox lease `cbx_0cde34c0d93f`, asserted run `run_d571246e591c`: one continuous recording shows a held slider drag changing Low → Medium → Ultra before release, then hover-only provider preview changing Anthropic → OpenAI. The lease was released and the redacted local recording was inspected. Public artifact upload was unavailable (`artifact_upload_unavailable`), so no public video URL is claimed.
