### PR TITLE
fix: hide credential profiles from model labels

### DIFF
--- a/src/gateway/session-utils-store.ts
+++ b/src/gateway/session-utils-store.ts
@@ -17,6 +17,7 @@ import {
 } from "../agents/agent-scope.js";
 import { resolveAgentAvatarUrlFromSource } from "../agents/identity-avatar-file.js";
 import type { ModelCatalogEntry } from "../agents/model-catalog.js";
+import { splitTrailingAuthProfile } from "../agents/model-ref-profile.js";
 import { resolveDefaultModelForAgent } from "../agents/model-selection.js";
 import { resolveEffectiveAgentRuntime } from "../agents/thinking-runtime.js";
 import { insideGitCheckout } from "../agents/worktrees/git.js";
@@ -312,10 +313,16 @@ function resolveGatewayAgentModel(
   cfg: OpenClawConfig,
   agentId: string,
 ): GatewayAgentRow["model"] | undefined {
-  const primary = resolveAgentEffectiveModelPrimary(cfg, agentId)?.trim();
+  // Agent rows expose model identity to clients; credential-profile binding stays in
+  // canonical config and is consumed only by execution-time model selection.
+  const primary = splitTrailingAuthProfile(
+    resolveAgentEffectiveModelPrimary(cfg, agentId) ?? "",
+  ).model;
   const fallbackOverride = resolveAgentModelFallbacksOverride(cfg, agentId);
   const defaultFallbacks = resolveAgentModelFallbackValues(cfg.agents?.defaults?.model);
-  const fallbacks = normalizeFallbackList(fallbackOverride ?? defaultFallbacks);
+  const fallbacks = normalizeFallbackList(
+    (fallbackOverride ?? defaultFallbacks).map((value) => splitTrailingAuthProfile(value).model),
+  );
   if (!primary && fallbacks.length === 0) {
     return undefined;
   }

--- a/src/gateway/session-utils.test.ts
+++ b/src/gateway/session-utils.test.ts
@@ -2425,6 +2425,57 @@ describe("gateway session utils", () => {
     });
   });
 
+  test("listAgentsForGateway projects a profile-qualified default as canonical model identity", () => {
+    const cfg = {
+      agents: {
+        defaults: {
+          model: {
+            primary: "openai/gpt-5.6-sol@openai:setup-fake",
+            fallbacks: ["anthropic/claude-sonnet-4-6@anthropic:backup"],
+          },
+        },
+        list: [{ id: "main", default: true }],
+      },
+    } as OpenClawConfig;
+    const catalog = [
+      {
+        provider: "openai",
+        id: "gpt-5.6-sol",
+        name: "GPT-5.6 Sol",
+        reasoning: true,
+      },
+    ];
+
+    const result = listAgentsForGateway(cfg, catalog);
+    const defaults = getSessionDefaults(cfg, catalog);
+
+    expect(result.agents[0]?.model).toEqual({
+      primary: "openai/gpt-5.6-sol",
+      fallbacks: ["anthropic/claude-sonnet-4-6"],
+    });
+    expect(result.agents[0]?.thinkingLevels).toEqual(defaults.thinkingLevels);
+    expect(result.agents[0]?.thinkingDefault).toBe(defaults.thinkingDefault);
+  });
+
+  test.each([
+    ["custom/vertex-ai_claude-haiku-4-5@20251001", "custom/vertex-ai_claude-haiku-4-5@20251001"],
+    [
+      "custom/vertex-ai_claude-haiku-4-5@20251001@custom:setup-fake",
+      "custom/vertex-ai_claude-haiku-4-5@20251001",
+    ],
+    ["lmstudio/gemma-4-31b-it@q8_0", "lmstudio/gemma-4-31b-it@q8_0"],
+    ["lmstudio/gemma-4-31b-it@q8_0@lmstudio:setup-fake", "lmstudio/gemma-4-31b-it@q8_0"],
+  ])("listAgentsForGateway preserves model-owned @ suffixes in %s", (primary, expected) => {
+    const cfg = {
+      agents: {
+        defaults: { model: { primary } },
+        list: [{ id: "main", default: true }],
+      },
+    } as OpenClawConfig;
+
+    expect(listAgentsForGateway(cfg).agents[0]?.model?.primary).toBe(expected);
+  });
+
   test("listAgentsForGateway reports whether each workspace is a git checkout", () => {
     const root = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-agent-workspace-git-"));
     const gitWorkspace = path.join(root, "git");

--- a/ui/src/e2e/chat-flow.models-reasoning.e2e.test.ts
+++ b/ui/src/e2e/chat-flow.models-reasoning.e2e.test.ts
@@ -226,6 +226,137 @@ suite.define(() => {
     }
   });
 
+  it("shows one canonical default model with matching inherited reasoning", async () => {
+    const artifactDir = process.env.OPENCLAW_UI_E2E_ARTIFACT_DIR?.trim();
+    const context = await suite.newBrowserContext({
+      locale: "en-US",
+      serviceWorkers: "block",
+      viewport: { height: 900, width: 1280 },
+      ...(artifactDir
+        ? { recordVideo: { dir: artifactDir, size: { height: 900, width: 1280 } } }
+        : {}),
+    });
+    const page = await context.newPage();
+    const thinkingLevels = ["off", "minimal", "low", "medium", "high", "xhigh", "max", "ultra"].map(
+      (id) => ({ id, label: id }),
+    );
+    const agentsList = {
+      agents: [
+        {
+          id: "main",
+          model: { primary: "openai/gpt-5.6-sol" },
+          name: "Main",
+          thinkingDefault: "medium",
+          thinkingLevels,
+          thinkingOptions: thinkingLevels.map((level) => level.label),
+        },
+      ],
+      defaultId: "main",
+      mainKey: "main",
+      scope: "agent",
+    };
+    const sessionsList = {
+      count: 2,
+      defaults: {
+        contextTokens: null,
+        model: "gpt-5.6-sol",
+        modelProvider: "openai",
+        thinkingDefault: "medium",
+        thinkingLevels,
+        thinkingOptions: thinkingLevels.map((level) => level.label),
+      },
+      path: "",
+      sessions: [
+        {
+          key: "agent:main:session-default",
+          kind: "direct",
+          label: "Default Sol",
+          updatedAt: 2,
+        },
+        {
+          key: "agent:main:session-explicit",
+          kind: "direct",
+          label: "Explicit Sol",
+          model: "gpt-5.6-sol",
+          modelProvider: "openai",
+          updatedAt: 1,
+        },
+      ],
+      ts: Date.now(),
+    };
+    const models = [
+      { id: "gpt-5.6-sol", name: "GPT-5.6 Sol", provider: "openai", reasoning: true },
+    ];
+    const gateway = await installMockGateway(page, {
+      methodResponses: {
+        "agents.list": agentsList,
+        "chat.startup": {
+          agentsList,
+          messages: [],
+          metadata: { models },
+          sessionId: "control-ui-profile-default-proof",
+          thinkingLevel: null,
+        },
+        "sessions.list": sessionsList,
+      },
+      models,
+      sessionKey: "agent:main:session-default",
+    });
+
+    try {
+      await page.goto(`${suite.server.baseUrl}chat`);
+      const main = page.getByRole("main");
+      const modelSelect = main.locator('[data-chat-model-select="true"]').first();
+      const thinkingSlider = main.locator('[data-chat-thinking-slider="true"]');
+      const expectedThinkingValues = thinkingLevels.map((level) => level.id).join(",");
+
+      await modelSelect.waitFor({ state: "visible", timeout: 10_000 });
+      expect(await modelSelect.textContent()).toContain("GPT-5.6 Sol");
+      expect(await modelSelect.textContent()).not.toContain("@openai:");
+      await modelSelect.click();
+      await main.locator('[data-chat-model-provider="openai"]').click();
+      await expect
+        .poll(() => main.locator('[data-chat-model-option="openai/gpt-5.6-sol"]').count())
+        .toBe(1);
+      expect(
+        (await main.locator("[data-chat-model-option]").allTextContents()).join(" "),
+      ).not.toContain("@openai:");
+      await expect
+        .poll(() => thinkingSlider.getAttribute("data-chat-thinking-values"))
+        .toBe(expectedThinkingValues);
+      const defaultThinkingValue = await modelSelect.getAttribute("data-chat-thinking-value");
+      if (artifactDir) {
+        await page.screenshot({ path: `${artifactDir}/default-sol.png`, fullPage: true });
+      }
+
+      await page.keyboard.press("Escape");
+      await page
+        .locator(
+          '.sidebar-recent-session[data-session-key="agent:main:session-explicit"] a.sidebar-recent-session__link',
+        )
+        .click();
+      await page.locator(".sidebar-recent-session--active").getByText("Explicit Sol").waitFor({
+        timeout: 10_000,
+      });
+      await modelSelect.click();
+      await main.locator('[data-chat-model-provider="openai"]').click();
+      await expect
+        .poll(() => main.locator('[data-chat-model-option="openai/gpt-5.6-sol"]').count())
+        .toBe(1);
+      await expect
+        .poll(() => thinkingSlider.getAttribute("data-chat-thinking-values"))
+        .toBe(expectedThinkingValues);
+      expect(await modelSelect.getAttribute("data-chat-thinking-value")).toBe(defaultThinkingValue);
+      if (artifactDir) {
+        await page.screenshot({ path: `${artifactDir}/explicit-sol.png`, fullPage: true });
+      }
+
+      expect(await gateway.getRequests("sessions.patch")).toHaveLength(0);
+    } finally {
+      await suite.closeBrowserContext(context);
+    }
+  });
+
   it("shows a pending send while a model override update is still pending", async () => {
     const context = await suite.newBrowserContext({
       locale: "en-US",

--- a/ui/src/lib/chat/model-select-state.test.ts
+++ b/ui/src/lib/chat/model-select-state.test.ts
@@ -586,6 +586,22 @@ describe("chat-model-select-state", () => {
     expect(resolved.defaultLabel).toBe("Default (Claude Opus 4.5)");
   });
 
+  it("keeps a canonical agent default as one named picker option", () => {
+    const state = createChatModelState({
+      agentDefaultModel: "openai/gpt-5.6-sol",
+      chatModelCatalog: createModelCatalog({
+        id: "gpt-5.6-sol",
+        name: "GPT-5.6 Sol",
+        provider: "openai",
+      }),
+    });
+
+    const resolved = resolveChatModelSelectState(state);
+
+    expect(resolved.defaultLabel).toBe("Default (GPT-5.6 Sol)");
+    expect(resolved.options).toEqual([{ value: "openai/gpt-5.6-sol", label: "GPT-5.6 Sol" }]);
+  });
+
   it("disambiguates duplicate friendly names in picker options and default labels", () => {
     const state = createChatModelState({
       chatModelCatalog: createModelCatalog(

--- a/ui/src/lib/chat/thinking.test.ts
+++ b/ui/src/lib/chat/thinking.test.ts
@@ -88,4 +88,40 @@ describe("chat thinking helpers", () => {
 
     expect(state.options.map((option) => option.value)).not.toContain("ultra");
   });
+
+  it("uses identical reasoning options for a canonical default and explicit selection", () => {
+    const thinkingLevels = ["off", "minimal", "low", "medium", "high", "xhigh", "max", "ultra"].map(
+      (id) => ({ id, label: id }),
+    );
+    const defaults = {
+      modelProvider: "openai",
+      model: "gpt-5.6-sol",
+      contextTokens: null,
+      thinkingLevels,
+      thinkingOptions: thinkingLevels.map((level) => level.label),
+      thinkingDefault: "medium",
+    };
+    const inherited = resolveChatThinkingSelectState({
+      catalog: [{ provider: "openai", id: "gpt-5.6-sol", reasoning: true }],
+      defaults,
+      sessionKey: "new-session:main",
+      session: { key: "new-session:main", kind: "direct", updatedAt: null },
+      sessionsResult: null,
+    });
+    const explicit = resolveChatThinkingSelectState({
+      catalog: [{ provider: "openai", id: "gpt-5.6-sol", reasoning: true }],
+      defaults,
+      sessionKey: "new-session:main",
+      session: {
+        key: "new-session:main",
+        kind: "direct",
+        updatedAt: null,
+        modelProvider: "openai",
+        model: "gpt-5.6-sol",
+      },
+      sessionsResult: null,
+    });
+
+    expect(explicit).toEqual(inherited);
+  });
 });


### PR DESCRIPTION
<!-- AI-assisted with Codex. No linked issue; #111827 is a separate legacy openai-codex runtime/catalog problem. -->

## What Problem This Solves

Fixes an issue where users completing guided onboarding would see an internal credential-profile suffix in the Control UI model label, a duplicate canonical/raw model option, and different reasoning controls for the same effective model.

## Why This Change Was Made

The gateway now projects the canonical model identity through the existing auth-profile-aware parser while leaving the full profile-qualified route in runtime configuration. This keeps credential selection intact and avoids naive `@` splitting, so legitimate model version and quantization suffixes remain unchanged.

## User Impact

The model picker shows one clean, human-readable model entry. The default and explicitly selected canonical model expose the same reasoning options and default, while runtime requests continue using the intended credential profile.

## Evidence

- Exact-main Blacksmith Testbox proof: [run 30414623054](https://github.com/openclaw/openclaw/actions/runs/30414623054), successful wrapper result (`exitCode: 0`).
- Focused gateway and UI regression tests: 171 assertions passed.
- Deterministic mocked Chromium Control UI flow: 7 tests passed, covering the clean default label, one canonical picker entry, and matching reasoning controls.
- Changed-surface formatting, lint, typechecks, runtime import-cycle guard, and database/state guards passed.
- Fresh autoreview completed with no accepted or actionable findings.
- Before/after screenshots and a recording were captured locally and intentionally not committed as PR-only media.

AI-assisted: yes. I reviewed the implementation and validation results.
