### PR TITLE
fix(nostr): chunk oversized outbound DMs so relays accept them

### DIFF
--- a/extensions/nostr/src/channel.outbound.test.ts
+++ b/extensions/nostr/src/channel.outbound.test.ts
@@ -202,4 +202,24 @@ describe("nostr outbound cfg threading", () => {
 
     await cleanup.stop();
   });
+
+  it("declares a chunker so textChunkLimit splits oversized replies instead of dropping them", () => {
+    const { chunker, textChunkLimit } = nostrOutboundAdapter;
+    expect(chunker).toBeTypeOf("function");
+    expect(textChunkLimit).toBe(4000);
+
+    // Text longer than the limit must be split into bounded chunks so each
+    // encrypted DM stays under relay event-size limits. Without a chunker the
+    // deliver pipeline ignores textChunkLimit and sends the whole reply in one
+    // event, which relays reject as oversized and the reply is lost.
+    const longText = `${"word ".repeat(1200)}final`;
+    const chunks = chunker!(longText, textChunkLimit!);
+
+    expect(chunks.length).toBeGreaterThan(1);
+    for (const chunk of chunks) {
+      expect(chunk.length).toBeLessThanOrEqual(textChunkLimit!);
+    }
+    // No content is dropped across the split.
+    expect(chunks.join(" ").replace(/\s+/g, " ").trim()).toBe(longText.replace(/\s+/g, " ").trim());
+  });
 });

--- a/extensions/nostr/src/gateway.ts
+++ b/extensions/nostr/src/gateway.ts
@@ -10,7 +10,7 @@ import {
 import { createChannelPairingController } from "openclaw/plugin-sdk/channel-pairing";
 import { attachChannelToResult } from "openclaw/plugin-sdk/channel-send-result";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
-import { stripMarkdown } from "openclaw/plugin-sdk/text-chunking";
+import { chunkTextForOutbound, stripMarkdown } from "openclaw/plugin-sdk/text-chunking";
 import type { ChannelOutboundAdapter, ChannelPlugin } from "./channel-api.js";
 import type { MetricEvent, MetricsSnapshot } from "./metrics.js";
 import { startNostrBus, type NostrBusHandle } from "./nostr-bus.js";
@@ -23,7 +23,7 @@ type NostrGatewayStart = NonNullable<
 >;
 type NostrOutboundAdapter = Pick<
   ChannelOutboundAdapter,
-  "deliveryCapabilities" | "deliveryMode" | "textChunkLimit" | "sendText"
+  "deliveryCapabilities" | "deliveryMode" | "textChunkLimit" | "chunker" | "sendText"
 > & {
   sendText: NonNullable<ChannelOutboundAdapter["sendText"]>;
 };
@@ -312,6 +312,10 @@ export const nostrPairingTextAdapter = {
 export const nostrOutboundAdapter: NostrOutboundAdapter = {
   deliveryMode: "direct",
   textChunkLimit: 4000,
+  // Without a chunker the declared textChunkLimit is ignored and oversized
+  // encrypted DMs are rejected by every relay, dropping the whole reply.
+  // Mirrors msteams/zalouser/irc, which use the shared chunkTextForOutbound.
+  chunker: chunkTextForOutbound,
   deliveryCapabilities: {
     durableFinal: {
       text: true,


### PR DESCRIPTION
## What Problem This Solves

Nostr is the only shipped channel that declares `textChunkLimit` (4000) on its outbound adapter but provides **no `chunker`**. The deliver pipeline treats a missing chunker as "no limit": `src/infra/outbound/deliver-core.ts:116` computes `configuredTextLimit = handler.chunker ? resolveTextChunkLimit(...) : undefined`, and `src/infra/outbound/message-plan.ts:134` returns the whole text as a single send unit when the chunker is null. So when an agent reply (after markdown stripping) is longer than a relay accepts, nostr encrypts and publishes it as one event. Every relay rejects it as `oversized-event`, and `sendEncryptedDm` (`extensions/nostr/src/nostr-bus.ts:743`) throws `Failed to publish to any relay` — **the entire reply is dropped and the user receives nothing.**

This contradicts the adapter's own declared contract (`textChunkLimit: 4000`) and the channel's metrics, which already track `event.rejected.oversized_ciphertext` / `event.rejected.oversized_plaintext` (`extensions/nostr/src/metrics.ts:20-21`). The sibling channels that declare a text limit all provide a chunker.

## Why This Change Was Made

Add the shared SDK chunker `chunkTextForOutbound` to `nostrOutboundAdapter`, the exact same function already used by msteams (`extensions/msteams/src/channel.ts:446`), zalouser (`extensions/zalouser/src/channel.adapters.ts:458`), irc (`extensions/irc/src/outbound-base.ts:8`), and others. This is the canonical, minimal owner-boundary fix: it makes the already-declared `textChunkLimit: 4000` actually take effect, splitting a long reply into bounded encrypted DMs that relays accept, instead of inventing nostr-specific truncation or size logic.

Why `chunkTextForOutbound`: it splits on newline/space boundaries with a hard-split fallback for unsplittable tokens, guarantees every chunk ≤ limit, and is already the shared helper for this exact adapter field across the channel set.

## User Impact

- Nostr DM replies longer than the relay limit (long explanations, code, tables) now **arrive** instead of being silently dropped. Today the user sees nothing and the agent errors out, which reads as "the agent didn't respond."
- Each chunk stays under the relay event-size limit, so encrypted (NIP-04) content that inflates ciphertext still fits.
- Behavior is unchanged for replies within the limit (single send).

## Evidence

**Root cause verified on `main` (`1eb038bd43e`):**
- `extensions/nostr/src/gateway.ts:312` — `nostrOutboundAdapter` has `textChunkLimit: 4000`, no `chunker`.
- `src/infra/outbound/deliver-core.ts:116` — `configuredTextLimit = handler.chunker ? ... : undefined`.
- `src/infra/outbound/message-plan.ts:134` — `if (!params.chunker || params.textLimit === undefined) return [planTextUnit(params.text, 0)]` (whole text, one unit).
- `extensions/nostr/src/nostr-bus.ts:743-784` — `sendEncryptedDm` has no size pre-check; loops relays, throws on all-rejected.

**Runtime probe (`node --import tsx`, before vs. after):**

Before fix (gateway.ts reverted to `main`):
```
=== Nostr outbound adapter contract ===
textChunkLimit: 4000
chunker present: false
effective configuredTextLimit: undefined
without a chunker, textChunkLimit is ignored → reply sent whole → relay rejects oversized

RESULT: FAIL (no chunker — textChunkLimit ineffective, oversized reply dropped by relay)
```

After fix:
```
=== Nostr outbound adapter contract ===
textChunkLimit: 4000
chunker present: true
effective configuredTextLimit: 4000

=== Chunker behavior on 6005-byte reply ===
chunk count: 2
max chunk length: 3999
every chunk <= textChunkLimit: true
content fully preserved: true

RESULT: PASS
```

**Tests:**
- `node scripts/run-vitest.mjs extensions/nostr/src/channel.outbound.test.ts` — 6 passed (5 existing + 1 new). New test asserts the chunker is present and splits a 6000+ byte reply into bounded chunks with no content loss.
- `tsgo` extensions prod + extensions test (`tsconfig.extensions.json`, `tsconfig.extensions.test.json`) — clean.
- `oxlint` on both files — 0 warnings, 0 errors. `oxfmt` — formatted.

**Known unrelated pre-existing failure:** 2 tests in `extensions/nostr/src/channel.test.ts` (setup-wizard prompt flow: "configures a private key and relay URLs", "preserves the selected named account label during setup") fail identically on clean `main` (`1eb038bd43e`) — unrelated to this change (nostr outbound chunker). Verified by `git stash` + re-run.

**Autoreview note:** Ran `$autoreview` per CONTRIBUTING; both review engines were blocked in this sandbox (Codex CLI gets `403 Forbidden` from the OpenAI Responses API; Claude CLI not installed). This is an environment/network limitation, not a code review result. The change was instead verified by full read of the changed function, the deliver pipeline, five sibling channels using the identical SDK chunker, the nostr bus encryption path, and the dependency contract (`createDirectDmPreCryptoGuardPolicy`).

**Not tested live:** Real relay round-trip / live Gateway boot. The fix operates at the adapter-contract layer that the deliver pipeline consumes; live relay behavior for the now-bounded chunks is unchanged from how it already handles within-limit DMs.
