### PR TITLE
fix: bump render version on unavailable attachment retry expiry

### DIFF
--- a/ui/src/pages/chat/components/chat-message-attachments.ts
+++ b/ui/src/pages/chat/components/chat-message-attachments.ts
@@ -102,6 +102,14 @@ function scheduleAssistantAttachmentRefresh(
     // budget; ticket refreshes must still invalidate their current generation.
     if (availability.status !== "unavailable") {
       deleteAssistantAttachmentAvailability(cacheKey);
+    } else {
+      // Bump the render version so the chat-thread memo key changes and the
+      // affected attachment row re-renders on the cooldown expiry. Preserving
+      // the cached unavailable entry lets the next resolve() call inherit the
+      // single-attempt budget via the !retryAttempted gate. Without this
+      // version bump, an unrelated rerender would be required before the
+      // retry-check branch in resolve() can run.
+      bumpAssistantAttachmentAvailabilityRenderVersion();
     }
     onRequestUpdate();
   }, refreshInMs);


### PR DESCRIPTION
## Summary

This PR fixes #114986 by ensuring transiently unavailable assistant media attachments correctly schedule a rerender when their 5-second retry cooldown expires.

## Problem

Unavailable attachment tickets were correctly cached with a 5-second retry cooldown, and the refresh timer fired at the right moment, but the timer callback only called `onRequestUpdate()` without bumping the global availability render version. Because the chat-thread memo key includes `getAssistantAttachmentAvailabilityRenderVersion()`, a stale memo match could skip the affected message row entirely. The retry-check branch in `resolveAssistantAttachmentAvailability()` therefore never ran until some unrelated UI activity happened to force a rerender.

## Changes

- Modified the unavailable-status timer branch in `scheduleAssistantAttachmentRefresh()` to bump the render version (via `bumpAssistantAttachmentAvailabilityRenderVersion()`) *before* calling `onRequestUpdate()`. The cached unavailable entry is still preserved on purpose so the next `resolve()` call can inherit the one-attempt retry budget through the existing `!retryAttempted` gate.

## Testing

- [x] Minimal change: 1 file, 8 lines added in existing timer callback
- [x] Preserves existing !retryAttempted budget semantics by keeping the cache entry
- [x] Follows established pattern: non-unavailable refresh already uses `deleteAssistantAttachmentAvailability` which bumps the same counter

Closes #114986