### PR TITLE
docs: document gateway and memory chat wizards

### DIFF
--- a/docs/cli/openclaw.md
+++ b/docs/cli/openclaw.md
@@ -71,6 +71,8 @@ setup workspace ~/Projects/work
 config set gateway.port 19001
 config set-ref gateway.auth.token env OPENCLAW_GATEWAY_TOKEN
 gateway status
+configure gateway
+open gateway wizard
 restart gateway
 agents
 create agent work workspace ~/Projects/work
@@ -84,6 +86,7 @@ open channel wizard for slack
 configure skills
 configure web search
 open search wizard
+import memory
 plugins list
 plugins search slack
 plugin install clawhub:openclaw-codex-app-server
@@ -99,7 +102,11 @@ OpenClaw uses typed operations instead of editing config ad hoc.
 
 Read-only operations run immediately: show overview, list agents, list installed plugins, search ClawHub plugins, show model/backend status, run status/health checks, check Gateway reachability, run doctor without interactive fixes, validate config, show the audit-log path.
 
-Starting a guided setup flow also runs immediately: channel setup (`connect telegram`), workspace skills setup (`configure skills`), and web-search provider setup (`configure web search`). Each hosted wizard collects explicit answers and owns the resulting writes; completions append audit entries and re-validate config. A web-search provider that needs a plugin install writes config only after the install succeeds — a failed or timed-out install stops setup and reports it instead of claiming the provider is configured.
+Starting a guided setup flow also runs immediately: channel setup (`connect telegram`), workspace skills setup (`configure skills`), web-search provider setup (`configure web search`), and local Gateway setup (`configure gateway`). Each config-backed hosted wizard collects explicit answers and owns the resulting writes; completions append audit entries and re-validate config. A web-search provider that needs a plugin install writes config only after the install succeeds — a failed or timed-out install stops setup and reports it instead of claiming the provider is configured.
+
+`configure gateway` guides you through the local Gateway's port, bind address, token or password auth, and Tailscale exposure. It saves config without applying it to the running Gateway, because changing the active address or credential could disconnect the setup chat. Say `restart gateway` after chat setup, or run `openclaw gateway restart` after a terminal-wizard handoff. Remote mode is guidance-only: use `openclaw onboard` for a fresh setup or `openclaw configure` to change the mode.
+
+`import memory` is copy-only rather than a config write. It detects supported local agent homes, lets you choose the available sources, and copies new memory files into the existing default agent workspace without importing config, credentials, or skills. It requires completed onboarding and reports confirmed imports, nothing-to-import results, provider failures, and failures where some files may already have been copied. No Gateway restart is needed. Use the Control UI's [Import Memory page](/web/control-ui#import-assistant-memory) when you need to target another agent or replace an existing import.
 
 Persistent operations require conversational approval (or `--yes` for a direct command): write config, `config set`, `config set-ref`, setup/onboarding bootstrap, change the default model, start/stop/restart the Gateway, create agents, and install plugins.
 
@@ -145,13 +152,14 @@ Discovery and read-only operations are not included. Secrets never appear in
 change history; config journal records contain changed paths rather than config
 values, and value comparison uses protected fingerprints.
 
-Channel and web-search setup can run as hosted conversations until they reach
-a secret. The local OpenClaw TUI does not accept sensitive wizard answers
+Channel, web-search, and local Gateway setup can run as hosted conversations
+until they reach a secret. The local OpenClaw TUI does not accept sensitive wizard answers
 because terminal chat input is visible. It offers `open channel wizard`
-(carrying the selected channel) or `open search wizard` immediately, handing
-off to the masked terminal wizard; you can also run
+(carrying the selected channel), `open search wizard`, or `open gateway wizard`
+immediately, handing off to the masked terminal wizard; you can also run
 `openclaw channels add --channel <channel>` or
-`openclaw configure --section web` later.
+`openclaw configure --section web` or `openclaw configure --section gateway`
+later.
 
 ### Switching to a masked terminal wizard
 
@@ -161,13 +169,15 @@ The local chat can hand control to a masked terminal wizard:
 open channel wizard for slack
 channel info slack
 open search wizard
+open gateway wizard
 ```
 
 `open channel wizard for <channel>` opens masked channel setup after the chat
 TUI closes. Use `channel info <channel>` first for the channel label, setup
 state, prerequisites summary, and docs link. `open search wizard` works the
 same way for web-search provider setup, opening the masked search wizard after
-the chat TUI closes.
+the chat TUI closes. `open gateway wizard` opens masked local Gateway setup;
+when it finishes, run `openclaw gateway restart` to apply the saved settings.
 
 OpenClaw never changes provider/auth access from inside its own session: the
 session already depends on that inference route. For model-provider setup or

--- a/docs/cli/setup.md
+++ b/docs/cli/setup.md
@@ -116,7 +116,8 @@ openclaw setup --non-interactive --accept-risk --mode remote --remote-url wss://
 
 ## Notes
 
-- Inside the OpenClaw chat, `configure skills` and `configure web search` run the hosted skills and web-search setup flows; `open search wizard` hands off to the masked terminal wizard when a credential is needed. See [`openclaw setup` operations](/cli/openclaw#operations-and-approval).
+- Inside the interactive OpenClaw chat, `configure skills`, `configure web search`, and `configure gateway` run hosted setup flows. `open search wizard` and `open gateway wizard` hand credential entry to masked terminal wizards. Gateway setup is local-only and config-only; restart afterward with `restart gateway` in chat or `openclaw gateway restart` in the terminal. See [`openclaw setup` operations](/cli/openclaw#operations-and-approval).
+- `import memory` copies detected local memory into the existing default agent workspace without importing config, credentials, or skills. Finish onboarding first; the chat reports partial and failed copies instead of assuming success.
 - After baseline setup, run `openclaw onboard` for the full guided journey, `openclaw configure` for targeted changes, or `openclaw channels add` to add channel accounts.
 - If Hermes state is detected, interactive onboarding can offer migration automatically. Import onboarding requires a fresh setup; use [Migrate](/cli/migrate) for dry-run plans, backups, and overwrite mode outside onboarding.
 

--- a/docs/concepts/memory.md
+++ b/docs/concepts/memory.md
@@ -63,9 +63,14 @@ see raw vs. injected sizes and truncation status.
 
 ## Import from coding assistants
 
-The Control UI can import existing local memory from Codex and Claude Code.
+The Control UI can import existing local memory from Codex, Claude Code, and
+Hermes.
 Open **Settings** → **Import Memory**, choose the destination agent, review the
-detected files, and confirm the import. OpenClaw copies only Markdown memory:
+detected files, and confirm the import. For the existing default agent, you can
+instead open **Settings → Ask OpenClaw** and say `import memory`; this narrower
+chat wizard requires completed onboarding, copies only new detected memory, and
+reports per-source failures or possible partial copies. OpenClaw copies only
+Markdown memory:
 
 - Codex: the consolidated `MEMORY.md` and `memory_summary.md` files under
   `~/.codex/memories` (or `CODEX_HOME/memories`). Raw rollout and transcript
@@ -74,11 +79,14 @@ detected files, and confirm the import. OpenClaw copies only Markdown memory:
   `~/.claude/projects/*/memory`, plus a user-configured
   `autoMemoryDirectory` when present. Project instructions, sessions, settings,
   and credentials are not part of this memory-only action.
+- Hermes: `MEMORY.md` and `USER.md` from the detected Hermes home. Config,
+  credentials, and skills are not part of this memory-only action.
 
 Imported files stay separate under `memory/imports/codex/` and
-`memory/imports/claude-code/` in the selected agent workspace. They are indexed
-for `memory_search` and available through `memory_get`; they are not merged into
-the agent's bootstrap `MEMORY.md`. The source files are left unchanged.
+`memory/imports/claude-code/`, or `memory/imports/hermes/` in the selected agent
+workspace. They are indexed for `memory_search` and available through
+`memory_get`; they are not merged into the agent's bootstrap `MEMORY.md`. The
+source files are left unchanged.
 
 The preview marks destination conflicts. Enable **Replace existing imports** to
 replace those files; apply creates a verified pre-import backup and preserves

--- a/docs/start/wizard.md
+++ b/docs/start/wizard.md
@@ -32,6 +32,16 @@ Workspace skills and web search are configured the same conversational way:
 `configure skills` and `configure web search` host those setup flows in the
 chat, and `open search wizard` hands credential entry to the masked terminal
 wizard.
+For a local Gateway, `configure gateway` guides port, bind, auth, and Tailscale
+settings but saves config without restarting; say `restart gateway` afterward,
+or use `open gateway wizard` for masked terminal credential entry and then run
+`openclaw gateway restart`. Remote Gateway mode remains an onboarding or
+`openclaw configure` choice rather than a hosted chat wizard.
+
+After onboarding has created the default agent workspace, `import memory` can
+copy detected local memory into it. This conversational import does not change
+config or import credentials or skills, needs no Gateway restart, and reports
+per-source partial or failed copies honestly.
 To change the model provider or its authentication, exit OpenClaw and run
 `openclaw onboard`; OpenClaw does not open guided or classic provider flows.
 

--- a/docs/web/control-ui.md
+++ b/docs/web/control-ui.md
@@ -150,7 +150,11 @@ Open **Settings → Ask OpenClaw** to talk to the system setup and repair agent.
 
 Each chat message carries the Control UI page you are currently viewing as an untrusted ambient hint, so requests like "configure this channel" or "why is this page empty?" resolve against the page you are looking at.
 
-Guided channel setup, workspace skills setup, and web-search provider setup run as hosted wizards inside the chat: wizard steps render as structured question cards, secret steps mask input in the browser, and every applied write is approved, audited, and re-validated. If a chosen web-search provider needs a plugin install and that install fails, setup stops and reports the failure instead of pretending the provider is configured. See [`openclaw setup`](/cli/openclaw) for the operation and approval contract.
+Guided channel setup, workspace skills setup, web-search provider setup, and local Gateway setup run as hosted wizards inside the chat. Wizard questions stay in the conversation, secret steps mask input in the browser, and successful config-backed flows are audited and re-validated. If a chosen web-search provider needs a plugin install and that install fails, setup stops and reports the failure instead of pretending the provider is configured.
+
+For Gateway setup, say `configure gateway` to choose the port, bind address, token or password auth, and Tailscale exposure. Before the first question, the web surface warns that applying the saved settings requires a restart that may disconnect the chat or require a new Control UI sign-in. The wizard changes config only; say `restart gateway` when you are ready to apply it. It manages only a local Gateway, so remote mode changes stay in `openclaw onboard` or `openclaw configure`.
+
+Say `import memory` to copy detected local memory into the existing default agent workspace. This flow does not change config or import credentials or skills, needs no Gateway restart, and distinguishes confirmed imports, nothing to import, provider failures, and failures where some files may already have been copied. Finish onboarding first if the default workspace does not exist. See [Import assistant memory](#import-assistant-memory) for the broader page that can target another agent or replace existing imports, and [`openclaw setup`](/cli/openclaw) for the operation and approval contract.
 
 Outside onboarding, this page can show at most one dismissible event chip per visit. It stays silent for routine Gateway traffic and reacts only to health snapshots that report a disabled configuration reloader, a configured channel disconnect/degradation, a failed channel probe, or unavailable channel credentials. A newer event replaces the pending chip only when it is more severe; dismissing or using the chip silences event prompts for that visit. Clicking the chip sends its diagnosis question as a real `openclaw.chat` message, so the transcript records the request and OpenClaw performs the diagnosis. Onboarding never shows these event chips.
 
@@ -329,7 +333,7 @@ select it to open the owning Approvals page.
 
 ## Import assistant memory
 
-Open **Settings** → **Import Memory** to bring local Codex or Claude Code memory
+Open **Settings** → **Import Memory** to bring local Codex, Claude Code, or Hermes memory
 into an OpenClaw agent. The Gateway discovers supported local memory on its own
 host, so a remote Control UI imports from the Gateway computer rather than the
 browser computer.
@@ -348,6 +352,13 @@ Code imports Markdown from project auto-memory directories and a configured
 credentials through this page. Files are copied below `memory/imports/` in the
 selected workspace, where the active memory plugin can index them. Sources are
 never changed.
+
+For a narrower conversational path, open **Settings → Ask OpenClaw** and say
+`import memory`. The chat wizard copies only new detected memory into the
+existing default agent workspace; it does not choose another destination agent
+or replace conflicts. It reports each source's confirmed copy count and warns
+when a failure may have happened after a partial copy. Use the dedicated Import
+Memory page when you need destination selection, a file preview, or replacement.
 
 Planning and applying require `operator.admin`. Every apply creates a verified
 OpenClaw backup when state exists, writes a redacted migration report, and keeps


### PR DESCRIPTION
Related: #115363
Related: #115376

## What Problem This Solves

The recently landed Ask OpenClaw gateway-configuration and memory-import wizards were missing from the user documentation. Readers could not discover their chat commands, safety boundaries, terminal handoffs, or the distinction between the narrow conversational memory import and the broader Control UI import page.

## Why This Change Was Made

Extends the canonical wave-1 Ask OpenClaw docs from #115182 instead of creating a competing capability list. The update documents local, config-only Gateway setup and explicit restart guidance; remote-mode and terminal-secret handoff behavior; and default-agent, copy-only memory import with honest partial/failure reporting. It also corrects the canonical memory docs to include the already-supported Hermes source.

## User Impact

Users can now find and safely use `configure gateway`, `open gateway wizard`, and `import memory` from the CLI, onboarding, memory, and Control UI documentation. The docs make clear when a Gateway restart is required, when hosted setup is unavailable, and when to use the dedicated Import Memory page instead.

## Evidence

- `pnpm check:docs` passed: formatting, Markdown lint, MDX, i18n glossary, 6,281 internal links with zero broken links, and docs-map freshness.
- `git diff --check` passed.
- Codex autoreview (`gpt-5.6-sol`, xhigh) reported no accepted or actionable findings.
- Behavior was checked against the merged #115363 and #115376 implementations and tests on current `main`.

AI-assisted: yes. I reviewed the source-backed behavior and the final documentation diff.
