### PR TITLE
fix(qqbot): restore one-time and recurring reminders

### DIFF
--- a/extensions/qqbot/skills/qqbot-remind/SKILL.md
+++ b/extensions/qqbot/skills/qqbot-remind/SKILL.md
@@ -58,7 +58,7 @@ metadata: { "openclaw": { "emoji": "⏰", "requires": { "config": ["channels.qqb
 | `delivery.accountId` | 当前账户 ID   | 多账号场景下不可省略         |
 | `sessionTarget`      | `"isolated"`  | 隔离会话避免污染             |
 
-> `schedule.atMs` 必须是**绝对毫秒时间戳**（如 `1770733800000`），不支持 `"5m"` 等相对字符串。
+> `schedule.at` 必须是**绝对 ISO 8601 时间戳**（如 `"2026-07-29T09:00:00.000Z"`），不支持 `"5m"` 等相对字符串。
 > 计算方式：`当前时间戳ms + 延迟毫秒`。
 
 ### 一次性提醒（schedule.kind = "at"）
@@ -68,7 +68,7 @@ metadata: { "openclaw": { "emoji": "⏰", "requires": { "config": ["channels.qqb
   "action": "add",
   "job": {
     "name": "{任务名}",
-    "schedule": { "kind": "at", "atMs": "{当前时间戳ms + N*60000}" },
+    "schedule": { "kind": "at", "at": "{当前时间戳ms + N*60000 转换为 ISO 8601}" },
     "sessionTarget": "isolated",
     "wakeMode": "now",
     "deleteAfterRun": true,

--- a/extensions/qqbot/src/bridge/tools/remind.test.ts
+++ b/extensions/qqbot/src/bridge/tools/remind.test.ts
@@ -33,19 +33,23 @@ function createRegisteredRemindTool(context: OpenClawPluginToolContext = {}): An
 }
 
 type CronAddToolPayload = {
-  job?: {
-    sessionTarget?: string;
-    payload?: {
-      kind?: string;
-      message?: string;
-      toolsAllow?: string[];
-    };
-    delivery?: {
-      mode?: string;
-      channel?: string;
-      to?: string;
-      accountId?: string;
-    };
+  name?: string;
+  schedule?: {
+    kind?: string;
+    at?: string;
+    atMs?: number;
+  };
+  sessionTarget?: string;
+  payload?: {
+    kind?: string;
+    message?: string;
+    toolsAllow?: string[];
+  };
+  delivery?: {
+    mode?: string;
+    channel?: string;
+    to?: string;
+    accountId?: string;
   };
 };
 
@@ -71,11 +75,16 @@ describe("bridge/tools/remind", () => {
     const addPayload = addCall?.[2] as CronAddToolPayload | undefined;
     expect(addCall?.[0]).toBe("cron.add");
     expect(addCall?.[1]).toEqual({ timeoutMs: 60_000 });
-    expect(addPayload?.job?.sessionTarget).toBe("isolated");
-    expect(addPayload?.job?.payload?.kind).toBe("agentTurn");
-    expect(addPayload?.job?.payload?.message).toContain("drink water");
-    expect(addPayload?.job?.payload?.toolsAllow).toEqual([]);
-    expect(addPayload?.job?.delivery).toEqual({
+    expect(addPayload).not.toHaveProperty("job");
+    expect(addPayload?.name).toBe("Reminder: drink water");
+    expect(addPayload?.schedule?.kind).toBe("at");
+    expect(addPayload?.schedule?.at).toEqual(expect.any(String));
+    expect(addPayload?.schedule).not.toHaveProperty("atMs");
+    expect(addPayload?.sessionTarget).toBe("isolated");
+    expect(addPayload?.payload?.kind).toBe("agentTurn");
+    expect(addPayload?.payload?.message).toContain("drink water");
+    expect(addPayload?.payload?.toolsAllow).toEqual([]);
+    expect(addPayload?.delivery).toEqual({
       mode: "announce",
       channel: "qqbot",
       to: "qqbot:c2c:user-openid",

--- a/extensions/qqbot/src/bridge/tools/remind.ts
+++ b/extensions/qqbot/src/bridge/tools/remind.ts
@@ -36,7 +36,7 @@ const defaultDeps: RemindToolDeps = {
         return await callGatewayTool(
           "cron.add",
           { timeoutMs: DEFAULT_GATEWAY_TIMEOUT_MS },
-          { job: params.job },
+          params.job,
         );
     }
     return unexpectedCronParams(params);

--- a/extensions/qqbot/src/engine/tools/remind-logic.test.ts
+++ b/extensions/qqbot/src/engine/tools/remind-logic.test.ts
@@ -34,8 +34,9 @@ describe("engine/tools/remind-logic", () => {
       if (!("deleteAfterRun" in call.job)) {
         throw new Error("expected one-shot reminder job");
       }
-      expect(call.job.schedule.atMs).toBeGreaterThanOrEqual(before + 5 * 60_000);
-      expect(call.job.schedule.atMs).toBeLessThanOrEqual(Date.now() + 5 * 60_000 + 1_000);
+      const scheduledAtMs = Date.parse(call.job.schedule.at);
+      expect(scheduledAtMs).toBeGreaterThanOrEqual(before + 5 * 60_000);
+      expect(scheduledAtMs).toBeLessThanOrEqual(Date.now() + 5 * 60_000 + 1_000);
       expect(call.job.sessionTarget).toBe("isolated");
       expect(call.job.wakeMode).toBe("now");
       expect(call.job.deleteAfterRun).toBe(true);

--- a/extensions/qqbot/src/engine/tools/remind-logic.ts
+++ b/extensions/qqbot/src/engine/tools/remind-logic.ts
@@ -202,7 +202,7 @@ function buildOnceJob(params: RemindParams, atMs: number, to: string, accountId:
     action: "add" as const,
     job: {
       name,
-      schedule: { kind: "at" as const, atMs },
+      schedule: { kind: "at" as const, at: new Date(atMs).toISOString() },
       sessionTarget: "isolated" as const,
       wakeMode: "now" as const,
       deleteAfterRun: true,


### PR DESCRIPTION
Closes #115469

AI-assisted: Yes. I reviewed the complete QQBot reminder-to-Gateway call path,
the current `cron.add` protocol schema, and the adjacent reminder tests.

## What Problem This Solves

Fixes an issue where QQBot users requesting one-time or recurring reminders
would receive a Gateway parameter-validation error and no reminder would be
created.

The affected `qqbot_remind` workflow reported that the request was missing the
required root-level `name` field while also containing an unexpected root-level
`job` field.

## Why This Change Was Made

The QQBot reminder bridge now passes the generated job fields directly to
`cron.add`, matching the current Gateway RPC contract. One-time reminders also
use the canonical ISO `schedule.at` field instead of the obsolete numeric
`schedule.atMs` shape.

This does not change the Gateway cron protocol, scheduling permissions, QQBot
delivery targeting, configuration, or the list/remove flows.

## User Impact

QQBot users can create both relative reminders such as "remind me in 5
minutes" and recurring reminders such as "remind me every day at 9am" without
the Gateway rejecting the generated cron job.

## Evidence

Before the fix:

- Issue #115469 contains a live Gateway failure:
  `must have required property 'name'; at root: unexpected property 'job'`.
- The updated regression tests failed against the previous implementation:
  - the Gateway payload still contained a root-level `job` wrapper;
  - one-time schedules exposed `atMs` and had no canonical `at` value.

After the fix:

- `node scripts/run-vitest.mjs extensions/qqbot/src/bridge/tools/remind.test.ts extensions/qqbot/src/engine/tools/remind-logic.test.ts`
  - 2 test files passed
  - 7 tests passed
- `node_modules/.bin/oxfmt --check` on the four changed files — passed.
- `node scripts/run-oxlint.mjs` on the four changed files — passed.
- `git diff --check` — passed.
- The focused tests were rerun after rebasing onto the latest `origin/main` and
  passed again.

Not tested:

- No live QQBot account or Gateway instance was used locally. The linked issue
  provides the live failure evidence.
- Autoreview was attempted but could not start because its required TruffleHog
  binary is not installed in the local environment.