### PR TITLE
fix: guard anthropic cost normalization for costless models (#115482)

### DIFF
--- a/extensions/anthropic/register.runtime.ts
+++ b/extensions/anthropic/register.runtime.ts
@@ -804,7 +804,11 @@ function applyAnthropicOpus5Cost(params: {
   if (!isAnthropicOpus5Model(params.modelId)) {
     return undefined;
   }
-  if (modelCostsEqual(params.model.cost, ANTHROPIC_OPUS_5_COST)) {
+  const existing = params.model.cost;
+  if (
+    existing &&
+    modelCostsEqual(existing, ANTHROPIC_OPUS_5_COST)
+  ) {
     return undefined;
   }
   return { ...params.model, cost: ANTHROPIC_OPUS_5_COST };
@@ -818,7 +822,8 @@ function applyAnthropicSonnet5Cost(params: {
     return undefined;
   }
   const cost = resolveAnthropicSonnet5Cost();
-  if (modelCostsEqual(params.model.cost, cost)) {
+  const existing = params.model.cost;
+  if (existing && modelCostsEqual(existing, cost)) {
     return undefined;
   }
   return { ...params.model, cost };

--- a/extensions/anthropic/stream-wrappers.test.ts
+++ b/extensions/anthropic/stream-wrappers.test.ts
@@ -301,6 +301,41 @@ describe("anthropic stream wrappers", () => {
     });
   });
 
+  it("applies fast-mode pricing without crashing when a model arrives without a cost object", () => {
+    const captured: {
+      headers?: Record<string, string>;
+      model?: { cost?: { input: number; output: number; cacheRead: number; cacheWrite: number } };
+      payload?: Record<string, unknown>;
+    } = {};
+    const base: StreamFn = (model, _context, options) => {
+      captured.headers = options?.headers;
+      captured.model = model as typeof captured.model;
+      const payload = {} as Record<string, unknown>;
+      options?.onPayload?.(payload as never, model as never);
+      captured.payload = payload;
+      return {} as never;
+    };
+    const wrapper = createAnthropicFastModeWrapper(base, true);
+    void wrapper(
+      {
+        provider: "anthropic",
+        api: "anthropic-messages",
+        id: "claude-opus-5",
+      } as never,
+      {} as never,
+      { apiKey: "sk-ant-api03-test-key" } as never,
+    );
+
+    expect(captured.headers?.["anthropic-beta"]).toContain("fast-mode-2026-02-01");
+    expect(captured.payload).toEqual({ speed: "fast" });
+    expect(captured.model?.cost).toEqual({
+      input: 0,
+      output: 0,
+      cacheRead: 0,
+      cacheWrite: 0,
+    });
+  });
+
   it.each([
     {
       label: "OAuth",

--- a/extensions/anthropic/stream-wrappers.ts
+++ b/extensions/anthropic/stream-wrappers.ts
@@ -98,13 +98,19 @@ function isDirectAnthropicApiModel(model: Parameters<StreamFn>[0]): boolean {
 }
 
 function applyAnthropicFastModePricing(model: Parameters<StreamFn>[0]): Parameters<StreamFn>[0] {
+  const baseCost = model.cost ?? {
+    input: 0,
+    output: 0,
+    cacheRead: 0,
+    cacheWrite: 0,
+  };
   return {
     ...model,
     cost: {
-      input: model.cost.input * ANTHROPIC_FAST_MODE_COST_MULTIPLIER,
-      output: model.cost.output * ANTHROPIC_FAST_MODE_COST_MULTIPLIER,
-      cacheRead: model.cost.cacheRead * ANTHROPIC_FAST_MODE_COST_MULTIPLIER,
-      cacheWrite: model.cost.cacheWrite * ANTHROPIC_FAST_MODE_COST_MULTIPLIER,
+      input: baseCost.input * ANTHROPIC_FAST_MODE_COST_MULTIPLIER,
+      output: baseCost.output * ANTHROPIC_FAST_MODE_COST_MULTIPLIER,
+      cacheRead: baseCost.cacheRead * ANTHROPIC_FAST_MODE_COST_MULTIPLIER,
+      cacheWrite: baseCost.cacheWrite * ANTHROPIC_FAST_MODE_COST_MULTIPLIER,
     },
   };
 }


### PR DESCRIPTION
## Summary

- Fix `applyAnthropicOpus5Cost` / `applyAnthropicSonnet5Cost` to short-circuit the equality comparison when `params.model.cost` is undefined instead of relying on `modelCostsEqual`'s optional chain. The override path (apply the well-known family pricing) is the whole point of these helpers, so a missing cost should fall through to it.
- Fix `applyAnthropicFastModePricing` to treat a missing `model.cost` as a zero baseline instead of dereferencing undefined on every `input/output/cacheRead/cacheWrite` access. Combined with the sibling guard above, this covers the defensive audit requested on the normalize/fast-mode helpers.
- Add a regression test that runs `createAnthropicFastModeWrapper` against a costless Opus 5 model and asserts the fast-mode beta header + payload are still injected while the emitted cost is correctly zeroed.

## Test plan

- Existing coverage in `extensions/anthropic/index.test.ts`:
  - `resolves Claude Opus 5` already normalizes a model with `cost: undefined` onto the standard Opus 5 pricing (the existing Sonnet 5 costless test is mirrored here).
  - `normalizes a Sonnet 5 model without cost metadata instead of crashing` is unchanged and continues to fill in the promotional/standard Sonnet 5 pricing.
- New regression in `extensions/anthropic/stream-wrappers.test.ts`:
  - `applies fast-mode pricing without crashing when a model arrives without a cost object` verifies the beta header, the `speed=fast` payload, and the zeroed fast-mode cost result for a costless Opus 5.

Closes #115482
