### PR TITLE
fix(hooks): resolve inbound claim conversation once per pair

### DIFF
--- a/src/auto-reply/reply/dispatch-from-config.gather.ts
+++ b/src/auto-reply/reply/dispatch-from-config.gather.ts
@@ -10,8 +10,7 @@ import {
 import { normalizeExplicitSessionKey } from "../../config/sessions/explicit-session-key-normalization.js";
 import {
   deriveInboundMessageHookContext,
-  toPluginInboundClaimContext,
-  toPluginInboundClaimEvent,
+  toPluginInboundClaimPair,
 } from "../../hooks/message-hook-mappers.js";
 import { isDiagnosticsEnabled } from "../../infra/diagnostic-events.js";
 import { measureDiagnosticsTimelineSpan } from "../../infra/diagnostics-timeline.js";
@@ -373,14 +372,15 @@ export async function gatherDispatchRequest(
     const nextHookContext = deriveInboundMessageHookContext(sourceCtx, {
       messageId: messageIdForHook,
     });
+    const inboundClaim = toPluginInboundClaimPair(nextHookContext, {
+      commandAuthorized:
+        typeof ctx.CommandAuthorized === "boolean" ? ctx.CommandAuthorized : undefined,
+      wasMentioned: typeof ctx.WasMentioned === "boolean" ? ctx.WasMentioned : undefined,
+    });
     return {
       hookContext: nextHookContext,
-      inboundClaimContext: toPluginInboundClaimContext(nextHookContext),
-      inboundClaimEvent: toPluginInboundClaimEvent(nextHookContext, {
-        commandAuthorized:
-          typeof ctx.CommandAuthorized === "boolean" ? ctx.CommandAuthorized : undefined,
-        wasMentioned: typeof ctx.WasMentioned === "boolean" ? ctx.WasMentioned : undefined,
-      }),
+      inboundClaimContext: inboundClaim.context,
+      inboundClaimEvent: inboundClaim.event,
     };
   };
   let { hookContext, inboundClaimContext, inboundClaimEvent } = buildHookState(hookCtx);

--- a/src/auto-reply/reply/dispatch-from-config.lifecycle-and-bindings.test-utils.ts
+++ b/src/auto-reply/reply/dispatch-from-config.lifecycle-and-bindings.test-utils.ts
@@ -723,8 +723,29 @@ describe("dispatchReplyFromConfig", () => {
     });
   });
 
-  it("routes plugin-owned bindings to the owning plugin before generic inbound claim broadcast", async () => {
+  it("resolves one matching inbound claim pair for a plugin-owned binding", async () => {
     setNoAbort();
+    let resolveCalls = 0;
+    setActivePluginRegistry(
+      createTestRegistry([
+        {
+          pluginId: "discord",
+          source: "test",
+          plugin: {
+            ...createChannelTestPluginBase({ id: "discord" }),
+            messaging: {
+              resolveInboundConversation: () => {
+                resolveCalls += 1;
+                return {
+                  conversationId: `conversation-${resolveCalls}`,
+                  parentConversationId: `parent-${resolveCalls}`,
+                };
+              },
+            },
+          },
+        },
+      ]),
+    );
     hookMocks.runner.hasHooks.mockImplementation(
       ((hookName?: string) =>
         hookName === "inbound_claim" || hookName === "message_received") as () => boolean,
@@ -793,20 +814,24 @@ describe("dispatchReplyFromConfig", () => {
             channel?: unknown;
             content?: unknown;
             conversationId?: unknown;
+            parentConversationId?: unknown;
             senderIsOwner?: unknown;
           },
           {
             accountId?: unknown;
             channelId?: unknown;
             conversationId?: unknown;
-            pluginBinding?: { data?: Record<string, unknown> };
+            parentConversationId?: unknown;
+            pluginBinding?: { bindingId?: string; data?: Record<string, unknown> };
           },
         ]
       | undefined;
+    expect(resolveCalls).toBe(1);
     expect(inboundClaimCall?.[0]).toBe("openclaw-codex-app-server");
     expect(inboundClaimCall?.[1]?.channel).toBe("discord");
     expect(inboundClaimCall?.[1]?.accountId).toBe("default");
-    expect(inboundClaimCall?.[1]?.conversationId).toBe("channel:1481858418548412579");
+    expect(inboundClaimCall?.[1]?.conversationId).toBe("conversation-1");
+    expect(inboundClaimCall?.[1]?.parentConversationId).toBe("parent-1");
     expect(inboundClaimCall?.[1]?.content).toBe("who are you");
     // Context OwnerAllowFrom authorizes commands but no longer grants owner status;
     // only commands.ownerAllowFrom or operator.admin does (operator.write here does not).
@@ -814,10 +839,97 @@ describe("dispatchReplyFromConfig", () => {
     expect(inboundClaimCall?.[1]).not.toHaveProperty("gatewayClientScopes");
     expect(inboundClaimCall?.[2]?.channelId).toBe("discord");
     expect(inboundClaimCall?.[2]?.accountId).toBe("default");
-    expect(inboundClaimCall?.[2]?.conversationId).toBe("channel:1481858418548412579");
+    expect(inboundClaimCall?.[2]?.conversationId).toBe(inboundClaimCall?.[1]?.conversationId);
+    expect(inboundClaimCall?.[2]?.parentConversationId).toBe(
+      inboundClaimCall?.[1]?.parentConversationId,
+    );
+    expect(inboundClaimCall?.[2]?.pluginBinding?.bindingId).toBe("binding-1");
     expect(inboundClaimCall?.[2]?.pluginBinding?.data?.kind).toBe("codex-app-server-session");
     expect(inboundClaimCall?.[2]?.pluginBinding?.data?.sessionFile).toBe("/tmp/session.jsonl");
     expect(hookMocks.runner.runInboundClaim).not.toHaveBeenCalled();
+    expect(replyResolver).not.toHaveBeenCalled();
+  });
+
+  it("preserves explicit inbound claim rejection for a plugin-owned binding", async () => {
+    setNoAbort();
+    const resolveInboundConversation = vi.fn(() => null);
+    setActivePluginRegistry(
+      createTestRegistry([
+        {
+          pluginId: "discord",
+          source: "test",
+          plugin: {
+            ...createChannelTestPluginBase({ id: "discord" }),
+            messaging: { resolveInboundConversation },
+          },
+        },
+      ]),
+    );
+    hookMocks.runner.hasHooks.mockImplementation(
+      ((hookName?: string) => hookName === "inbound_claim") as () => boolean,
+    );
+    hookMocks.registry.plugins = [{ id: "test-plugin", status: "loaded" }];
+    hookMocks.runner.runInboundClaimForPluginOutcome.mockResolvedValue({
+      status: "handled",
+      result: { handled: true },
+    });
+    sessionBindingMocks.resolveByConversation.mockReturnValue({
+      bindingId: "binding-null-rejection",
+      targetSessionKey: "plugin-binding:test:null-rejection",
+      targetKind: "session",
+      conversation: {
+        channel: "discord",
+        accountId: "default",
+        conversationId: "channel:null-rejection",
+      },
+      status: "active",
+      boundAt: 1710000000000,
+      metadata: {
+        pluginBindingOwner: "plugin",
+        pluginId: "test-plugin",
+        pluginRoot: "/plugins/test-plugin",
+      },
+    } satisfies SessionBindingRecord);
+    const dispatcher = createDispatcher();
+    const ctx = buildTestCtx({
+      Provider: "discord",
+      Surface: "discord",
+      OriginatingChannel: "discord",
+      OriginatingTo: "discord:channel:null-rejection",
+      To: "discord:channel:null-rejection",
+      AccountId: "default",
+      Body: "keep the rejection",
+      MessageSid: "msg-claim-null-rejection",
+      SessionKey: "agent:main:discord:channel:null-rejection",
+    });
+    const replyResolver = vi.fn(async () => ({ text: "should not run" }) satisfies ReplyPayload);
+
+    const result = await dispatchReplyFromConfig({
+      ctx,
+      cfg: emptyConfig,
+      dispatcher,
+      replyResolver,
+    });
+
+    expect(result).toEqual({ queuedFinal: false, counts: { tool: 0, block: 0, final: 0 } });
+    expect(resolveInboundConversation).toHaveBeenCalledTimes(1);
+    const [, event, context] = firstMockCall(
+      hookMocks.runner.runInboundClaimForPluginOutcome,
+      "targeted inbound claim",
+    ) as [
+      string,
+      { conversationId?: string; parentConversationId?: string },
+      {
+        conversationId?: string;
+        parentConversationId?: string;
+        pluginBinding?: { bindingId?: string };
+      },
+    ];
+    expect(event.conversationId).toBeUndefined();
+    expect(event.parentConversationId).toBeUndefined();
+    expect(context.conversationId).toBeUndefined();
+    expect(context.parentConversationId).toBeUndefined();
+    expect(context.pluginBinding?.bindingId).toBe("binding-null-rejection");
     expect(replyResolver).not.toHaveBeenCalled();
   });
 

--- a/src/hooks/message-hook-mappers.test.ts
+++ b/src/hooks/message-hook-mappers.test.ts
@@ -10,8 +10,7 @@ import { createChannelTestPluginBase, createTestRegistry } from "../test-utils/c
 import {
   buildCanonicalSentMessageHookContext,
   deriveInboundMessageHookContext,
-  toPluginInboundClaimEvent,
-  toPluginInboundClaimContext,
+  toPluginInboundClaimPair,
   toInternalMessagePreprocessedContext,
   toInternalMessageReceivedContext,
   toInternalMessageSentContext,
@@ -175,7 +174,7 @@ describe("message hook mappers", () => {
       replyToIsQuote: true,
     });
 
-    const claimContext = toPluginInboundClaimContext(canonical);
+    const { context: claimContext, event: claimEvent } = toPluginInboundClaimPair(canonical);
     expect(claimContext).toMatchObject({
       replyToId: "discord-message-42",
       replyToIdFull: "discord:channel-1:discord-message-42",
@@ -184,7 +183,6 @@ describe("message hook mappers", () => {
       replyToIsQuote: true,
     });
 
-    const claimEvent = toPluginInboundClaimEvent(canonical);
     expect(claimEvent).toMatchObject({
       replyToId: "discord-message-42",
       replyToIdFull: "discord:channel-1:discord-message-42",
@@ -305,7 +303,7 @@ describe("message hook mappers", () => {
       "https://example.test/ramp.jpg",
     ]);
     expect(canonical.mediaTypes).toEqual(["image/jpeg", "image/jpeg"]);
-    const claimEvent = toPluginInboundClaimEvent(canonical);
+    const { event: claimEvent } = toPluginInboundClaimPair(canonical);
     expect(claimEvent.metadata?.mediaPath).toBe("/tmp/tree.jpg");
     expect(claimEvent.metadata?.mediaUrl).toBe("https://example.test/tree.jpg");
     expect(claimEvent.metadata?.mediaType).toBe("image/jpeg");
@@ -376,7 +374,7 @@ describe("message hook mappers", () => {
     },
   ])("dual-emits $name hook media from canonical facts", (testCase) => {
     const ctx = finalizeInboundContextForSdk(makeInboundCtx(testCase.input));
-    const event = toPluginInboundClaimEvent(deriveInboundMessageHookContext(ctx));
+    const { event } = toPluginInboundClaimPair(deriveInboundMessageHookContext(ctx));
     const expectedIndex = "expectedIndex" in testCase ? (testCase.expectedIndex ?? 0) : 0;
 
     expect(event.media?.[expectedIndex]?.path).toBe(testCase.expectedPath);
@@ -408,7 +406,7 @@ describe("message hook mappers", () => {
     ];
 
     for (const event of [
-      toPluginInboundClaimEvent(canonical),
+      toPluginInboundClaimPair(canonical).event,
       toPluginMessageReceivedEvent(canonical),
       toInternalMessageReceivedContext(canonical),
       toInternalMessageTranscribedContext(canonical, {}),
@@ -418,7 +416,7 @@ describe("message hook mappers", () => {
       expect(event.originalMedia).toEqual(expectedOriginalMedia);
       expect(event.mediaStagingPending).toBe(true);
     }
-    expect(toPluginInboundClaimEvent(canonical).metadata?.mediaPath).toBeUndefined();
+    expect(toPluginInboundClaimPair(canonical).event.metadata?.mediaPath).toBeUndefined();
     expect(toPluginMessageReceivedEvent(canonical).metadata?.mediaPath).toBeUndefined();
     expect(toInternalMessageReceivedContext(canonical).metadata?.mediaPath).toBeUndefined();
   });
@@ -622,8 +620,7 @@ describe("message hook mappers", () => {
       ...deriveInboundMessageHookContext(makeInboundCtx()),
       trace,
     };
-    const inboundContext = toPluginInboundClaimContext(inbound);
-    const inboundEvent = toPluginInboundClaimEvent(inbound);
+    const { context: inboundContext, event: inboundEvent } = toPluginInboundClaimPair(inbound);
     expect(inboundContext.trace).not.toBe(trace);
     expect(inboundContext.trace).toEqual(trace);
     expect(Object.isFrozen(inboundContext.trace)).toBe(true);
@@ -657,7 +654,7 @@ describe("message hook mappers", () => {
       }),
     );
 
-    expect(toPluginInboundClaimContext(canonical)).toEqual({
+    expect(toPluginInboundClaimPair(canonical).context).toEqual({
       channelId: "claim-chat",
       accountId: "acc-1",
       conversationId: "channel:123456789012345678",
@@ -688,8 +685,9 @@ describe("message hook mappers", () => {
       }),
     );
 
-    expect(toPluginInboundClaimContext(canonical).conversationId).toBeUndefined();
-    expect(toPluginInboundClaimEvent(canonical).conversationId).toBeUndefined();
+    const { context, event } = toPluginInboundClaimPair(canonical);
+    expect(context.conversationId).toBeUndefined();
+    expect(event.conversationId).toBeUndefined();
   });
 
   it("passes thread parent ids to channel plugin claim resolvers", () => {
@@ -707,7 +705,7 @@ describe("message hook mappers", () => {
       }),
     );
 
-    expect(toPluginInboundClaimContext(canonical)).toMatchObject({
+    expect(toPluginInboundClaimPair(canonical).context).toMatchObject({
       channelId: "thread-claim-chat",
       conversationId: "1510164477642014740",
       parentConversationId: "channel:1510164477642014999",
@@ -728,7 +726,7 @@ describe("message hook mappers", () => {
       }),
     );
 
-    expect(toPluginInboundClaimContext(canonical)).toEqual({
+    expect(toPluginInboundClaimPair(canonical).context).toEqual({
       channelId: "claim-chat",
       accountId: "acc-1",
       conversationId: "user:1177378744822943744",

--- a/src/hooks/message-hook-mappers.ts
+++ b/src/hooks/message-hook-mappers.ts
@@ -368,10 +368,13 @@ function resolveInboundConversation(canonical: CanonicalInboundMessageHookContex
   return { conversationId: baseConversationId };
 }
 
-export function toPluginInboundClaimContext(
+function buildPluginInboundClaimContext(
   canonical: CanonicalInboundMessageHookContext,
+  conversation: {
+    conversationId?: string;
+    parentConversationId?: string;
+  },
 ): PluginHookInboundClaimContext {
-  const conversation = resolveInboundConversation(canonical);
   const context: PluginHookInboundClaimContext = {
     channelId: canonical.channelId,
     accountId: canonical.accountId,
@@ -403,14 +406,14 @@ export function toPluginInboundClaimContext(
   return context;
 }
 
-export function toPluginInboundClaimEvent(
+function buildPluginInboundClaimEvent(
   canonical: CanonicalInboundMessageHookContext,
+  context: PluginHookInboundClaimContext,
   extras?: {
     commandAuthorized?: boolean;
     wasMentioned?: boolean;
   },
 ): PluginHookInboundClaimEvent {
-  const context = toPluginInboundClaimContext(canonical);
   const event: PluginHookInboundClaimEvent = {
     content: canonical.content,
     body: canonical.body,
@@ -467,6 +470,24 @@ export function toPluginInboundClaimEvent(
   }
   assignTraceFields(event, canonical.trace);
   return event;
+}
+
+export function toPluginInboundClaimPair(
+  canonical: CanonicalInboundMessageHookContext,
+  extras?: {
+    commandAuthorized?: boolean;
+    wasMentioned?: boolean;
+  },
+): {
+  context: PluginHookInboundClaimContext;
+  event: PluginHookInboundClaimEvent;
+} {
+  const conversation = resolveInboundConversation(canonical);
+  const context = buildPluginInboundClaimContext(canonical, conversation);
+  return {
+    context,
+    event: buildPluginInboundClaimEvent(canonical, context, extras),
+  };
 }
 
 export function toPluginMessageReceivedEvent(


### PR DESCRIPTION
Fixes #114927

## What Problem This Solves

A channel plugin's `messaging.resolveInboundConversation()` could be called twice while constructing one `inbound_claim` hook delivery. A stateful resolver could therefore produce different `conversationId` or `parentConversationId` values in the event and context.

## Why This Change Was Made

The rewrite resolves the conversation once and constructs the event/context pair from that single result. The dispatch gatherer now consumes only the canonical pair builder; the obsolete separate claim event/context exports were removed instead of retaining duplicate internal paths.

The same invariant is covered both at the mapper boundary and through the real dispatch state rebuild path.

## User Impact

Plugin authors receive consistent conversation identity in each `inbound_claim` event/context pair, including after media metadata rebuilds the hook state.

## Evidence

Exact PR head: `f59eb37952302bfbb9619a34b30dcc8dbf6ad90b`

- `node scripts/run-vitest.mjs src/hooks/message-hook-mappers.test.ts`: 26 passed.
- `node scripts/run-vitest.mjs src/auto-reply/reply/inbound-context.test.ts`: 28 passed.
- Focused dispatch binding tests: 2 passed.
- Targeted format and oxlint checks passed.
- `git diff --check` passed.
- Fresh post-rebase autoreview found no actionable issues at 0.94 confidence.

Maintainer rewrite preserves the original contribution with a `Co-authored-by` trailer.



