### PR TITLE
fix: flatten qqbot_remind cron.add payload for Gateway closed schema (#115469)

### DIFF
--- a/extensions/qqbot/src/bridge/tools/remind.test.ts
+++ b/extensions/qqbot/src/bridge/tools/remind.test.ts
@@ -33,19 +33,21 @@ function createRegisteredRemindTool(context: OpenClawPluginToolContext = {}): An
 }
 
 type CronAddToolPayload = {
-  job?: {
-    sessionTarget?: string;
-    payload?: {
-      kind?: string;
-      message?: string;
-      toolsAllow?: string[];
-    };
-    delivery?: {
-      mode?: string;
-      channel?: string;
-      to?: string;
-      accountId?: string;
-    };
+  name?: string;
+  schedule?: unknown;
+  sessionTarget?: string;
+  wakeMode?: string;
+  deleteAfterRun?: boolean;
+  payload?: {
+    kind?: string;
+    message?: string;
+    toolsAllow?: string[];
+  };
+  delivery?: {
+    mode?: string;
+    channel?: string;
+    to?: string;
+    accountId?: string;
   };
 };
 
@@ -71,16 +73,19 @@ describe("bridge/tools/remind", () => {
     const addPayload = addCall?.[2] as CronAddToolPayload | undefined;
     expect(addCall?.[0]).toBe("cron.add");
     expect(addCall?.[1]).toEqual({ timeoutMs: 60_000 });
-    expect(addPayload?.job?.sessionTarget).toBe("isolated");
-    expect(addPayload?.job?.payload?.kind).toBe("agentTurn");
-    expect(addPayload?.job?.payload?.message).toContain("drink water");
-    expect(addPayload?.job?.payload?.toolsAllow).toEqual([]);
-    expect(addPayload?.job?.delivery).toEqual({
+    expect(addPayload?.name).toBe("Reminder: drink water");
+    expect(addPayload?.sessionTarget).toBe("isolated");
+    expect(addPayload?.payload?.kind).toBe("agentTurn");
+    expect(addPayload?.payload?.message).toContain("drink water");
+    expect(addPayload?.payload?.toolsAllow).toEqual([]);
+    expect(addPayload?.delivery).toEqual({
       mode: "announce",
       channel: "qqbot",
       to: "qqbot:c2c:user-openid",
       accountId: "bot2",
     });
+    expect(addPayload?.deleteAfterRun).toBe(true);
+    expect((addPayload?.schedule as { kind?: string })?.kind).toBe("at");
     expect(result.details).toEqual({
       ok: true,
       action: "add",

--- a/extensions/qqbot/src/bridge/tools/remind.ts
+++ b/extensions/qqbot/src/bridge/tools/remind.ts
@@ -36,7 +36,7 @@ const defaultDeps: RemindToolDeps = {
         return await callGatewayTool(
           "cron.add",
           { timeoutMs: DEFAULT_GATEWAY_TIMEOUT_MS },
-          { job: params.job },
+          params.job,
         );
     }
     return unexpectedCronParams(params);


### PR DESCRIPTION
## Summary

- **Root cause**: `qqbot_remind`'s `callCron` helper wrapped its add payload with an extra `{ job: params.job }` layer before calling `cron.add` over the Gateway.
- **Gateway contract mismatch**: `CronAddParamsSchema` is a `closedObject` that requires `name` at the root and rejects unknown root properties. When qqbot_remind passed the job fields inside a nested `job` object, the validator reported both `"must have required property 'name'"` (because the root was empty of real fields) and `"unexpected property 'job'"`.
- **Fix**: Pass `params.job` directly as the `cron.add` third argument so every job field (`name`, `schedule`, `sessionTarget`, `wakeMode`, `deleteAfterRun`, `payload`, `delivery`) lands at the Gateway-schema root without re-nesting.
- **Test correction**: The existing `remind.test.ts` was asserting fields through the now-removed `addPayload.job` wrapper. Migrate every assertion to read at the flat payload root, and additionally lock in `name`, `deleteAfterRun`, and the `at` schedule kind so the test is an accurate contract mirror of `CronAddParamsSchema`.

## Test plan

- `extensions/qqbot/src/bridge/tools/remind.test.ts`
  - `schedules reminders directly through Gateway cron with ambient QQ delivery context` now asserts flat root fields: `name="Reminder: drink water"`, `sessionTarget="isolated"`, `payload.kind/`message`/toolsAllow`, `delivery.mode/channel/to/accountId`, `deleteAfterRun=true`, and `schedule.kind="at"`.
  - `routes list and remove through Gateway cron without exposing generic cron to the model` is unchanged and continues to confirm `cron.list` → `{}` and `cron.remove` → `{ jobId }`.

Closes #115469
