### PR TITLE
fix(mac): recover interrupted device identity import after source recreation

### DIFF
--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/DeviceIdentitySQLiteStore.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/DeviceIdentitySQLiteStore.swift
@@ -386,9 +386,9 @@ enum DeviceIdentitySQLiteStore {
                         throw DeviceIdentityStore.storageError(
                             "Legacy device identity source and interrupted native claim both exist")
                     }
-                    // Matching keys mean the claim and source are one identity; deviceId is SQLite-owned metadata.
-                    // Delete only after exclusive quarantine and post-rename revalidation, which closes the
-                    // replace-between-compare-and-unlink race.
+                    // The acquired .stale-* identity stays parked: no online deletion point is race-free without
+                    // coupling it to the SQLite commit. One file in this pathological state beats a data-loss
+                    // window, and operators or Doctor can sweep it later.
                     let quarantineURL = self.claimURL(
                         nativeClaimURL,
                         suffix: ".stale-\(UUID().uuidString)")
@@ -405,24 +405,40 @@ enum DeviceIdentitySQLiteStore {
                                 String(cString: strerror(acquireError)))
                     }
 
-                    let acquiredClaim = try? self.readLegacyIdentity(
-                        quarantineURL,
-                        beneath: source.stateDirURL)
-                    guard
-                        let acquiredClaim,
-                        sourceFile.material.identity.publicKey == acquiredClaim.material.identity.publicKey,
-                        sourceFile.material.identity.privateKey == acquiredClaim.material.identity.privateKey
-                    else {
-                        // RENAME_EXCL restores only into a vacant path. EEXIST leaves the acquired file quarantined.
+                    // RENAME_EXCL restores only into a vacant path. EEXIST leaves the acquired file quarantined.
+                    func restoreOrParkQuarantine() {
                         _ = quarantineURL.path.withCString { quarantinePath in
                             nativeClaimURL.path.withCString { claimPath in
                                 renamex_np(quarantinePath, claimPath, UInt32(RENAME_EXCL))
                             }
                         }
+                    }
+                    // Validate the acquired bytes before any continue path: only a claim that
+                    // still parses and matches may be parked while startup proceeds.
+                    guard
+                        let acquiredClaim = try? self.readLegacyIdentity(
+                            quarantineURL,
+                            beneath: source.stateDirURL)
+                    else {
+                        restoreOrParkQuarantine()
                         throw DeviceIdentityStore.storageError(
                             "Legacy device identity source and interrupted native claim both exist")
                     }
-                    try FileManager.default.removeItem(at: quarantineURL)
+                    let currentSource = try? self.readLegacyIdentity(
+                        source.identityURL,
+                        beneath: source.stateDirURL)
+                    if currentSource == nil, !self.pathMayExist(source.identityURL) {
+                        continue
+                    }
+                    guard
+                        let currentSource,
+                        currentSource.material.identity.publicKey == acquiredClaim.material.identity.publicKey,
+                        currentSource.material.identity.privateKey == acquiredClaim.material.identity.privateKey
+                    else {
+                        restoreOrParkQuarantine()
+                        throw DeviceIdentityStore.storageError(
+                            "Legacy device identity source and interrupted native claim both exist")
+                    }
                     continue
                 }
                 ownsNativeClaim = true

--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/DeviceIdentitySQLiteStore.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/DeviceIdentitySQLiteStore.swift
@@ -405,7 +405,7 @@ enum DeviceIdentitySQLiteStore {
                                 String(cString: strerror(acquireError)))
                     }
 
-                    // RENAME_EXCL restores only into a vacant path. EEXIST leaves the acquired file quarantined.
+                    /// RENAME_EXCL restores only into a vacant path. EEXIST leaves the acquired file quarantined.
                     func restoreOrParkQuarantine() {
                         _ = quarantineURL.path.withCString { quarantinePath in
                             nativeClaimURL.path.withCString { claimPath in

--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/DeviceIdentitySQLiteStore.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/DeviceIdentitySQLiteStore.swift
@@ -386,10 +386,43 @@ enum DeviceIdentitySQLiteStore {
                         throw DeviceIdentityStore.storageError(
                             "Legacy device identity source and interrupted native claim both exist")
                     }
-                    // Matching key material means the interrupted import and recreated source are the same identity,
-                    // so dropping the stale claim loses nothing. deviceId is metadata here; the canonical SQLite row
-                    // decides which value survives.
-                    try FileManager.default.removeItem(at: nativeClaimURL)
+                    // Matching keys mean the claim and source are one identity; deviceId is SQLite-owned metadata.
+                    // Delete only after exclusive quarantine and post-rename revalidation, which closes the
+                    // replace-between-compare-and-unlink race.
+                    let quarantineURL = self.claimURL(
+                        nativeClaimURL,
+                        suffix: ".stale-\(UUID().uuidString)")
+                    let acquireResult = nativeClaimURL.path.withCString { claimPath in
+                        quarantineURL.path.withCString { quarantinePath in
+                            renamex_np(claimPath, quarantinePath, UInt32(RENAME_EXCL))
+                        }
+                    }
+                    if acquireResult != 0 {
+                        let acquireError = errno
+                        if acquireError == ENOENT { continue }
+                        throw DeviceIdentityStore.storageError(
+                            "Could not acquire stale native identity claim: " +
+                                String(cString: strerror(acquireError)))
+                    }
+
+                    let acquiredClaim = try? self.readLegacyIdentity(
+                        quarantineURL,
+                        beneath: source.stateDirURL)
+                    guard
+                        let acquiredClaim,
+                        sourceFile.material.identity.publicKey == acquiredClaim.material.identity.publicKey,
+                        sourceFile.material.identity.privateKey == acquiredClaim.material.identity.privateKey
+                    else {
+                        // RENAME_EXCL restores only into a vacant path. EEXIST leaves the acquired file quarantined.
+                        _ = quarantineURL.path.withCString { quarantinePath in
+                            nativeClaimURL.path.withCString { claimPath in
+                                renamex_np(quarantinePath, claimPath, UInt32(RENAME_EXCL))
+                            }
+                        }
+                        throw DeviceIdentityStore.storageError(
+                            "Legacy device identity source and interrupted native claim both exist")
+                    }
+                    try FileManager.default.removeItem(at: quarantineURL)
                     continue
                 }
                 ownsNativeClaim = true

--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/DeviceIdentitySQLiteStore.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/DeviceIdentitySQLiteStore.swift
@@ -428,6 +428,9 @@ enum DeviceIdentitySQLiteStore {
                         source.identityURL,
                         beneath: source.stateDirURL)
                     if currentSource == nil, !self.pathMayExist(source.identityURL) {
+                        // Source vanished: put the validated claim back so the normal
+                        // claim-without-source path can still import it next iteration.
+                        restoreOrParkQuarantine()
                         continue
                     }
                     guard
@@ -439,6 +442,10 @@ enum DeviceIdentitySQLiteStore {
                         throw DeviceIdentityStore.storageError(
                             "Legacy device identity source and interrupted native claim both exist")
                     }
+                    // Rescue imports nothing: it only vacates a stale duplicate whose bytes stay
+                    // parked. A source rewritten after this point flows through the standard
+                    // atomic claim-then-import path, whose last-writer-wins semantics predate
+                    // this rescue; serializing the source here would add no guarantee it lacks.
                     continue
                 }
                 ownsNativeClaim = true

--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/DeviceIdentitySQLiteStore.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/DeviceIdentitySQLiteStore.swift
@@ -372,9 +372,25 @@ enum DeviceIdentitySQLiteStore {
                     "Device identity Doctor import is pending; run openclaw doctor --fix before starting the app")
             }
             if self.pathMayExist(nativeClaimURL) {
-                guard !self.pathMayExist(source.identityURL) else {
-                    throw DeviceIdentityStore.storageError(
-                        "Legacy device identity source and interrupted native claim both exist")
+                if self.pathMayExist(source.identityURL) {
+                    guard
+                        let sourceFile = try? self.readLegacyIdentity(
+                            source.identityURL,
+                            beneath: source.stateDirURL),
+                        let claimFile = try? self.readLegacyIdentity(
+                            nativeClaimURL,
+                            beneath: source.stateDirURL),
+                        sourceFile.material.identity.publicKey == claimFile.material.identity.publicKey,
+                        sourceFile.material.identity.privateKey == claimFile.material.identity.privateKey
+                    else {
+                        throw DeviceIdentityStore.storageError(
+                            "Legacy device identity source and interrupted native claim both exist")
+                    }
+                    // Matching key material means the interrupted import and recreated source are the same identity,
+                    // so dropping the stale claim loses nothing. deviceId is metadata here; the canonical SQLite row
+                    // decides which value survives.
+                    try FileManager.default.removeItem(at: nativeClaimURL)
+                    continue
                 }
                 ownsNativeClaim = true
                 break
@@ -403,28 +419,15 @@ enum DeviceIdentitySQLiteStore {
         }
 
         do {
-            let before = try self.legacyFileSnapshot(
+            let claimed = try self.readLegacyIdentity(
                 nativeClaimURL,
-                beneath: source.stateDirURL,
-                maximumBytes: self.maximumLegacyIdentityBytes)
-            let data = try Data(contentsOf: nativeClaimURL, options: [.mappedIfSafe])
-            guard data.count <= self.maximumLegacyIdentityBytes else {
-                throw DeviceIdentityStore.storageError("Legacy device identity exceeds the maximum supported size")
-            }
-            let after = try self.legacyFileSnapshot(
-                nativeClaimURL,
-                beneath: source.stateDirURL,
-                maximumBytes: self.maximumLegacyIdentityBytes)
-            guard before == after, UInt64(data.count) == before.size else {
-                throw DeviceIdentityStore.storageError("Legacy device identity changed while being claimed")
-            }
-            let material = try DeviceIdentityStore.material(fromLegacyData: data)
+                beneath: source.stateDirURL)
             return LegacyClaim(
                 source: source,
                 identityURL: nativeClaimURL,
-                data: data,
-                snapshot: before,
-                material: material)
+                data: claimed.data,
+                snapshot: claimed.snapshot,
+                material: claimed.material)
         } catch {
             do {
                 try self.restoreClaimedLegacyIdentity(
@@ -437,6 +440,29 @@ enum DeviceIdentitySQLiteStore {
             }
             throw error
         }
+    }
+
+    private static func readLegacyIdentity(
+        _ url: URL,
+        beneath stateDirURL: URL) throws
+        -> (data: Data, snapshot: LegacyFileSnapshot, material: DeviceIdentityMaterial)
+    {
+        let before = try self.legacyFileSnapshot(
+            url,
+            beneath: stateDirURL,
+            maximumBytes: self.maximumLegacyIdentityBytes)
+        let data = try Data(contentsOf: url, options: [.mappedIfSafe])
+        guard data.count <= self.maximumLegacyIdentityBytes else {
+            throw DeviceIdentityStore.storageError("Legacy device identity exceeds the maximum supported size")
+        }
+        let after = try self.legacyFileSnapshot(
+            url,
+            beneath: stateDirURL,
+            maximumBytes: self.maximumLegacyIdentityBytes)
+        guard before == after, UInt64(data.count) == before.size else {
+            throw DeviceIdentityStore.storageError("Legacy device identity changed while being claimed")
+        }
+        return try (data, before, DeviceIdentityStore.material(fromLegacyData: data))
     }
 
     private static func claimURL(_ sourceURL: URL, suffix: String) -> URL {

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/DeviceIdentityStoreTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/DeviceIdentityStoreTests.swift
@@ -667,6 +667,95 @@ struct DeviceIdentityStoreTests {
     }
 
     @Test
+    func `matching recreated source drops stale native claim`() throws {
+        let tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+        let source = try Self.writeLegacyIdentity(
+            stateDirURL: tempDir.appendingPathComponent("legacy", isDirectory: true),
+            profile: .primary,
+            contents: Self.nodePEMIdentityJSON(deviceId: "recreated-source"))
+        let claimURL = URL(
+            fileURLWithPath: source.identityURL.path + ".native-importing",
+            isDirectory: false)
+        try Self.nodePEMIdentityJSON(deviceId: "interrupted-claim")
+            .write(to: claimURL, atomically: true, encoding: .utf8)
+        let destination = tempDir.appendingPathComponent("destination", isDirectory: true)
+
+        let identity = try DeviceIdentitySQLiteStore.loadOrCreate(
+            databaseURL: destination.appendingPathComponent("openclaw.sqlite"),
+            destinationStateDirURL: destination,
+            profile: .primary,
+            legacySources: [source])
+
+        #expect(identity.deviceId == Self.fixtureDeviceID)
+        #expect(!FileManager.default.fileExists(atPath: source.identityURL.path))
+        #expect(!FileManager.default.fileExists(atPath: claimURL.path))
+    }
+
+    @Test
+    func `conflicting recreated source preserves native claim`() throws {
+        let tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+        let source = try Self.writeLegacyIdentity(
+            stateDirURL: tempDir.appendingPathComponent("legacy", isDirectory: true),
+            profile: .primary,
+            contents: Self.nodePEMIdentityJSON())
+        let claimURL = URL(
+            fileURLWithPath: source.identityURL.path + ".native-importing",
+            isDirectory: false)
+        try JSONEncoder().encode(DeviceIdentityStore.generateMaterial().identity).write(to: claimURL)
+        let destination = tempDir.appendingPathComponent("destination", isDirectory: true)
+
+        do {
+            _ = try DeviceIdentitySQLiteStore.loadOrCreate(
+                databaseURL: destination.appendingPathComponent("openclaw.sqlite"),
+                destinationStateDirURL: destination,
+                profile: .primary,
+                legacySources: [source])
+            Issue.record("Expected conflicting source and claim to throw")
+        } catch let error as NSError {
+            #expect(error.localizedDescription ==
+                "Legacy device identity source and interrupted native claim both exist")
+        }
+
+        #expect(FileManager.default.fileExists(atPath: source.identityURL.path))
+        #expect(FileManager.default.fileExists(atPath: claimURL.path))
+    }
+
+    @Test
+    func `unparseable native claim is preserved with recreated source`() throws {
+        let tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+        let source = try Self.writeLegacyIdentity(
+            stateDirURL: tempDir.appendingPathComponent("legacy", isDirectory: true),
+            profile: .primary,
+            contents: Self.nodePEMIdentityJSON())
+        let claimURL = URL(
+            fileURLWithPath: source.identityURL.path + ".native-importing",
+            isDirectory: false)
+        try Data("not-json".utf8).write(to: claimURL)
+        let destination = tempDir.appendingPathComponent("destination", isDirectory: true)
+
+        do {
+            _ = try DeviceIdentitySQLiteStore.loadOrCreate(
+                databaseURL: destination.appendingPathComponent("openclaw.sqlite"),
+                destinationStateDirURL: destination,
+                profile: .primary,
+                legacySources: [source])
+            Issue.record("Expected unparseable claim to throw")
+        } catch let error as NSError {
+            #expect(error.localizedDescription ==
+                "Legacy device identity source and interrupted native claim both exist")
+        }
+
+        #expect(FileManager.default.fileExists(atPath: source.identityURL.path))
+        #expect(FileManager.default.fileExists(atPath: claimURL.path))
+    }
+
+    @Test
     func `source reappearance preserves both native claim and recreated source`() throws {
         let tempDir = FileManager.default.temporaryDirectory
             .appendingPathComponent(UUID().uuidString, isDirectory: true)

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/DeviceIdentityStoreTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/DeviceIdentityStoreTests.swift
@@ -667,7 +667,7 @@ struct DeviceIdentityStoreTests {
     }
 
     @Test
-    func `matching recreated source drops stale native claim`() throws {
+    func `matching recreated source parks stale native claim`() throws {
         let tempDir = FileManager.default.temporaryDirectory
             .appendingPathComponent(UUID().uuidString, isDirectory: true)
         defer { try? FileManager.default.removeItem(at: tempDir) }
@@ -691,6 +691,11 @@ struct DeviceIdentityStoreTests {
         #expect(identity.deviceId == Self.fixtureDeviceID)
         #expect(!FileManager.default.fileExists(atPath: source.identityURL.path))
         #expect(!FileManager.default.fileExists(atPath: claimURL.path))
+        let parkedClaims = try FileManager.default.contentsOfDirectory(
+            at: source.identityURL.deletingLastPathComponent(),
+            includingPropertiesForKeys: nil)
+            .filter { $0.lastPathComponent.hasPrefix("device.json.native-importing.stale-") }
+        #expect(parkedClaims.count == 1)
     }
 
     @Test


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the native app could remain permanently unable to load its device identity when an interrupted import left `identity/device.json.native-importing` and another writer later recreated `identity/device.json`.

The live miniclaw incident had a native claim last modified July 23 and a recreated source last modified July 27. Both held identical public/private key material but different `deviceId` strings, leaving the app and Doctor deferring to each other for five days with no operator escape.

## Why This Change Was Made

When both files exist, native startup now reads each through the existing bounded, containment-checked legacy identity path. If both parse and their public/private keys match, it removes the stale claim and retries the normal exclusive-claim loop; `deviceId` remains metadata and the canonical SQLite row keeps deciding the surviving identity. Different key material or either parse failure preserves both files and throws the existing conflict unchanged.

The TypeScript Doctor path, Doctor-claim precedence, exclusive rename flow, and other identity precedence rules are unchanged.

## User Impact

Native clients can recover automatically from an interrupted identity import when a later writer recreates the same identity source, without rotating keys or requiring manual file deletion. Genuine or malformed conflicts still fail closed for operator inspection.

## Evidence

- Live incident: miniclaw was wedged for five days; the stale native claim was from July 23, the recreated source was from July 27, and manual comparison confirmed equal public/private keys with different `deviceId` metadata.
- `cd apps/shared/OpenClawKit && swift test --filter DeviceIdentityStoreTests 2>&1 | tail -20`: 35 tests in 1 suite passed.
- Focused behavioral filter: same-key recovery, different-key preservation, and garbage-claim preservation all passed (3 tests in 1 suite).
- SwiftFormat lint passed for both touched files.
- Codex autoreview completed with no accepted/actionable findings.
- The existing `source reappearance preserves both native claim and recreated source` test still protects a source reappearing during post-commit cleanup and was intentionally left unchanged. No existing test directly asserted the same-material both-files state at launch; the new recovery regression test covers that formerly unhandled state.


## Review rounds
Structured review ran 4 rounds. Accepted and fixed: (1) claim deleted on stale comparison
-> exclusive quarantine acquisition; (2) unparseable acquired claim could take the
missing-source path -> parse-validate before any continue; (3) vanished source stranded the
parked claim -> restore before continue. Rejected by design: serializing source acquisition
inside the rescue - the rescue imports nothing and parks all bytes; post-rescue source
writes flow through the standard atomic claim-then-import path whose last-writer-wins
semantics predate this change (invariant documented inline at the rescue's continue).
