### PR TITLE
feat(node-host): migrate retired state before connecting

### DIFF
--- a/src/node-host/runner.test.ts
+++ b/src/node-host/runner.test.ts
@@ -27,6 +27,7 @@ const mocks = vi.hoisted(() => ({
   normalizedPath: null as string | null,
   resolvedExecutables: new Map<string, string>(),
   closeMcpManager: vi.fn(async () => undefined),
+  runStartupMigrations: vi.fn(async () => undefined),
   configureNodeHost: vi.fn(async (params: Parameters<typeof configureNodeHost>[0]) => {
     mocks.capturedConfiguredGatewayConfigs.push(params.gateway);
     return {
@@ -145,6 +146,10 @@ vi.mock("./skills.js", () => ({
   scanNodeHostedSkills: vi.fn(() => mocks.nodeSkillDescriptors),
 }));
 
+vi.mock("./startup-state-migrations.js", () => ({
+  runStartupMigrations: mocks.runStartupMigrations,
+}));
+
 vi.mock("./runtime.js", async (importOriginal) => {
   const actual = await importOriginal<typeof import("./runtime.js")>();
   return {
@@ -198,6 +203,17 @@ describe("runNodeHost", () => {
     mocks.getRuntimeConfig.mockReturnValue({
       gateway: { handshakeTimeoutMs: 1_000 },
     });
+  });
+
+  it("runs startup state migrations before constructing node-host state", async () => {
+    await expect(runNodeHost({ gatewayHost: "127.0.0.1", gatewayPort: 18789 })).rejects.toThrow(
+      "event loop readiness timeout",
+    );
+
+    expect(mocks.runStartupMigrations).toHaveBeenCalledTimes(1);
+    expect(mocks.runStartupMigrations.mock.invocationCallOrder[0]).toBeLessThan(
+      mocks.configureNodeHost.mock.invocationCallOrder[0] ?? Number.POSITIVE_INFINITY,
+    );
   });
 
   it.each([

--- a/src/node-host/runner.ts
+++ b/src/node-host/runner.ts
@@ -22,6 +22,7 @@ import {
   coerceNodeInvokePayload,
 } from "./invoke-payload.js";
 import { prepareNodeHostRuntime, type NodeHostInventory } from "./runtime.js";
+import { runStartupMigrations } from "./startup-state-migrations.js";
 
 type NodeHostRunOptions = {
   gatewayHost: string;
@@ -176,6 +177,9 @@ function buildNodeHostLocalAuthConfig(config: OpenClawConfig): OpenClawConfig {
 }
 
 export async function runNodeHost(opts: NodeHostRunOptions): Promise<void> {
+  // Operator-approved startup is a second authorized entry point for Doctor-owned
+  // state migrators. Runtime invokes those owners here and never migrates inline.
+  await runStartupMigrations({ log: { info: writeStderrLine, warn: writeStderrLine } });
   const plannedGateway: NodeHostGatewayConfig = {
     host: opts.gatewayHost,
     port: opts.gatewayPort,

--- a/src/node-host/startup-state-migrations.test.ts
+++ b/src/node-host/startup-state-migrations.test.ts
@@ -1,0 +1,183 @@
+import fs from "node:fs";
+import fsp from "node:fs/promises";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
+import { loadDeviceAuthToken } from "../infra/device-auth-store.js";
+import { generateStoredDeviceIdentity } from "../infra/device-identity-store.js";
+import { loadDeviceIdentityIfPresent } from "../infra/device-identity.js";
+import { resolveExecApprovalsPath } from "../infra/exec-approvals-config.js";
+import { loadExecApprovals } from "../infra/exec-approvals-store.js";
+import { testing as execApprovalsStoreTesting } from "../infra/exec-approvals-store.test-support.js";
+import { acquireGatewayLock } from "../infra/gateway-lock.js";
+import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
+import { captureEnv, setTestEnvValue } from "../test-utils/env.js";
+import { runStartupMigrations } from "./startup-state-migrations.js";
+
+describe("node-host startup state migrations", () => {
+  const envSnapshot = captureEnv(["OPENCLAW_STATE_DIR"]);
+  const log = {
+    info: vi.fn<(message: string) => void>(),
+    warn: vi.fn<(message: string) => void>(),
+  };
+  const tempDirs = useAutoCleanupTempDirTracker((cleanup) => {
+    afterEach(() => {
+      closeOpenClawStateDatabaseForTest();
+      execApprovalsStoreTesting.reset();
+      envSnapshot.restore();
+      cleanup();
+    });
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  function useStateDir(): { env: NodeJS.ProcessEnv; stateDir: string } {
+    const stateDir = fs.realpathSync(tempDirs.make("openclaw-node-host-migrations-"));
+    return {
+      env: { ...process.env, HOME: stateDir, OPENCLAW_STATE_DIR: stateDir },
+      stateDir,
+    };
+  }
+
+  async function writeDeviceAuth(stateDir: string): Promise<string> {
+    const sourcePath = path.join(stateDir, "identity", "device-auth.json");
+    await fsp.mkdir(path.dirname(sourcePath), { recursive: true });
+    await fsp.writeFile(
+      sourcePath,
+      JSON.stringify({
+        version: 1,
+        deviceId: "device-1",
+        tokens: {
+          operator: {
+            token: "legacy-token",
+            scopes: ["operator.write"],
+            updatedAtMs: 10,
+          },
+        },
+      }),
+    );
+    return sourcePath;
+  }
+
+  async function writeDeviceIdentity(stateDir: string): Promise<{
+    deviceId: string;
+    sourcePath: string;
+  }> {
+    const identity = generateStoredDeviceIdentity(1_700_000_000_000);
+    const sourcePath = path.join(stateDir, "identity", "device.json");
+    await fsp.mkdir(path.dirname(sourcePath), { recursive: true });
+    await fsp.writeFile(sourcePath, JSON.stringify({ version: 1, ...identity }));
+    return { deviceId: identity.deviceId, sourcePath };
+  }
+
+  async function writeExecApprovals(env: NodeJS.ProcessEnv): Promise<string> {
+    const sourcePath = resolveExecApprovalsPath(env);
+    await fsp.writeFile(
+      sourcePath,
+      `${JSON.stringify({
+        version: 1,
+        defaults: { security: "deny" },
+        agents: {},
+      })}\n`,
+    );
+    return sourcePath;
+  }
+
+  it("migrates device auth before the runtime gate reads it", async () => {
+    const { env, stateDir } = useStateDir();
+    const sourcePath = await writeDeviceAuth(stateDir);
+
+    await runStartupMigrations({ env, log });
+
+    expect(fs.existsSync(sourcePath)).toBe(false);
+    expect(loadDeviceAuthToken({ deviceId: "device-1", role: "operator", env })).toMatchObject({
+      token: "legacy-token",
+      scopes: ["operator.read", "operator.write"],
+    });
+    expect(log.info).toHaveBeenCalledWith("Migrated 1 device-auth token to SQLite.");
+    expect(log.warn).not.toHaveBeenCalled();
+  });
+
+  it("migrates legacy exec approvals into the canonical store", async () => {
+    const { env, stateDir } = useStateDir();
+    const sourcePath = await writeExecApprovals(env);
+    setTestEnvValue("OPENCLAW_STATE_DIR", stateDir);
+    execApprovalsStoreTesting.reset();
+
+    await runStartupMigrations({ env, log });
+
+    expect(fs.existsSync(sourcePath)).toBe(false);
+    expect(loadExecApprovals().defaults?.security).toBe("deny");
+    expect(log.info).toHaveBeenCalledWith(
+      "Imported legacy exec approvals into shared SQLite state.",
+    );
+    expect(log.warn).not.toHaveBeenCalled();
+  });
+
+  it("migrates a legacy device identity", async () => {
+    const { env, stateDir } = useStateDir();
+    const { deviceId, sourcePath } = await writeDeviceIdentity(stateDir);
+
+    await runStartupMigrations({ env, log });
+
+    expect(fs.existsSync(sourcePath)).toBe(false);
+    expect(loadDeviceIdentityIfPresent({ env })?.deviceId).toBe(deviceId);
+    expect(log.info).toHaveBeenCalledWith("Migrated primary device identity to SQLite.");
+    expect(log.warn).not.toHaveBeenCalled();
+  });
+
+  it("preserves a pending native device identity claim and continues", async () => {
+    const { env, stateDir } = useStateDir();
+    const { sourcePath } = await writeDeviceIdentity(stateDir);
+    const nativeClaimPath = `${sourcePath}.native-importing`;
+    await fsp.rename(sourcePath, nativeClaimPath);
+
+    await expect(runStartupMigrations({ env, log })).resolves.toBeUndefined();
+
+    expect(fs.existsSync(nativeClaimPath)).toBe(true);
+    expect(log.info).not.toHaveBeenCalled();
+    expect(log.warn).toHaveBeenCalledWith(
+      "Native device identity import is pending; restart the native app before running Doctor.",
+    );
+  });
+
+  it("warns and leaves every legacy file untouched when the state lock is held", async () => {
+    const { env, stateDir } = useStateDir();
+    const deviceAuthPath = await writeDeviceAuth(stateDir);
+    const { sourcePath: deviceIdentityPath } = await writeDeviceIdentity(stateDir);
+    const execApprovalsPath = await writeExecApprovals(env);
+    const gatewayLock = await acquireGatewayLock({
+      allowInTests: true,
+      env,
+      pollIntervalMs: 10,
+      port: 18_792,
+      timeoutMs: 100,
+    });
+    if (!gatewayLock) {
+      throw new Error("expected test Gateway lock");
+    }
+
+    try {
+      await expect(runStartupMigrations({ env, log })).resolves.toBeUndefined();
+    } finally {
+      await gatewayLock.release();
+    }
+
+    expect(fs.existsSync(deviceAuthPath)).toBe(true);
+    expect(fs.existsSync(deviceIdentityPath)).toBe(true);
+    expect(fs.existsSync(execApprovalsPath)).toBe(true);
+    expect(log.info).not.toHaveBeenCalled();
+    expect(log.warn).toHaveBeenCalledTimes(3);
+  });
+
+  it("is silent when no retired state is present", async () => {
+    const { env } = useStateDir();
+
+    await runStartupMigrations({ env, log });
+
+    expect(log.info).not.toHaveBeenCalled();
+    expect(log.warn).not.toHaveBeenCalled();
+  });
+});

--- a/src/node-host/startup-state-migrations.ts
+++ b/src/node-host/startup-state-migrations.ts
@@ -53,7 +53,7 @@ export async function runStartupMigrations(params?: {
         doctorOnlyStateMigrations: true,
       });
       if (!detected.hasLegacy) {
-        return;
+        return undefined;
       }
       return await migrateLegacyDeviceAuth({ detected, env, stateDir });
     },
@@ -68,7 +68,7 @@ export async function runStartupMigrations(params?: {
         doctorOnlyStateMigrations: true,
       });
       if (!detected.hasLegacy) {
-        return;
+        return undefined;
       }
       return await migrateLegacyDeviceIdentity({
         detected,
@@ -87,7 +87,7 @@ export async function runStartupMigrations(params?: {
         doctorOnlyStateMigrations: true,
       });
       if (!detected.hasLegacy) {
-        return;
+        return undefined;
       }
       return await migrateLegacyExecApprovals({ detected, env, stateDir });
     },

--- a/src/node-host/startup-state-migrations.ts
+++ b/src/node-host/startup-state-migrations.ts
@@ -1,0 +1,96 @@
+/** Runs the Doctor-owned retired state-store migrations required by node-host startup. */
+import { resolveStateDir } from "../config/paths.js";
+import { formatErrorMessage } from "../infra/errors.js";
+import {
+  detectLegacyDeviceAuth,
+  migrateLegacyDeviceAuth,
+} from "../infra/state-migrations.device-auth.js";
+import {
+  detectLegacyDeviceIdentity,
+  migrateLegacyDeviceIdentity,
+} from "../infra/state-migrations.device-identity.js";
+import {
+  detectLegacyExecApprovals,
+  migrateLegacyExecApprovals,
+} from "../infra/state-migrations.exec-approvals.js";
+import type { MigrationLogger, MigrationMessages } from "../infra/state-migrations.types.js";
+import { createSubsystemLogger } from "../logging/subsystem.js";
+
+async function reportMigration(
+  label: string,
+  run: () => Promise<MigrationMessages | undefined>,
+  log: MigrationLogger,
+): Promise<void> {
+  try {
+    const result = await run();
+    for (const change of result?.changes ?? []) {
+      log.info(change);
+    }
+    for (const warning of result?.warnings ?? []) {
+      log.warn(warning);
+    }
+  } catch (error) {
+    // Startup auto-migration is best-effort by operator decision. Existing store
+    // gates remain the fail-closed authority when a Doctor-owned migrator throws.
+    log.warn(`Failed running ${label} startup migration: ${formatErrorMessage(error)}`);
+  }
+}
+
+/** Invoke the Doctor-owned state migrators authorized for node-host startup. */
+export async function runStartupMigrations(params?: {
+  env?: NodeJS.ProcessEnv;
+  log?: MigrationLogger;
+}): Promise<void> {
+  const stateDir = resolveStateDir(params?.env);
+  const env = { ...(params?.env ?? process.env), OPENCLAW_STATE_DIR: stateDir };
+  const log = params?.log ?? createSubsystemLogger("node-host/startup-migrations");
+
+  await reportMigration(
+    "device auth",
+    async () => {
+      const detected = detectLegacyDeviceAuth({
+        stateDir,
+        doctorOnlyStateMigrations: true,
+      });
+      if (!detected.hasLegacy) {
+        return;
+      }
+      return await migrateLegacyDeviceAuth({ detected, env, stateDir });
+    },
+    log,
+  );
+  await reportMigration(
+    "device identity",
+    async () => {
+      const detected = detectLegacyDeviceIdentity({
+        stateDir,
+        env,
+        doctorOnlyStateMigrations: true,
+      });
+      if (!detected.hasLegacy) {
+        return;
+      }
+      return await migrateLegacyDeviceIdentity({
+        detected,
+        env,
+        stateDir,
+        doctorOnlyStateMigrations: true,
+      });
+    },
+    log,
+  );
+  await reportMigration(
+    "exec approvals",
+    async () => {
+      const detected = detectLegacyExecApprovals({
+        stateDir,
+        doctorOnlyStateMigrations: true,
+      });
+      if (!detected.hasLegacy) {
+        return;
+      }
+      return await migrateLegacyExecApprovals({ detected, env, stateDir });
+    },
+    log,
+  );
+}

--- a/src/node-host/worker.ts
+++ b/src/node-host/worker.ts
@@ -3,6 +3,7 @@ import { createInterface } from "node:readline";
 import { VERSION } from "../version.js";
 import { loadNodeHostConfig } from "./config.js";
 import { prepareNodeHostRuntime, type NodeHostInventory } from "./runtime.js";
+import { runStartupMigrations } from "./startup-state-migrations.js";
 import {
   NodeHostWorkerBridgeClient,
   parseNodeHostWorkerInput,
@@ -13,11 +14,18 @@ function writeMessage(message: unknown): void {
   process.stdout.write(`${JSON.stringify(message)}\n`);
 }
 
+function writeStderrLine(message: string): void {
+  process.stderr.write(`${message}\n`);
+}
+
 function emitInventory(inventory: NodeHostInventory): void {
   writeMessage({ type: "inventory", inventory });
 }
 
 export async function runNodeHostWorker(): Promise<void> {
+  // Operator-approved startup is a second authorized entry point for Doctor-owned
+  // state migrators. Runtime invokes those owners here and never migrates inline.
+  await runStartupMigrations({ log: { info: writeStderrLine, warn: writeStderrLine } });
   const nodeConfig = await loadNodeHostConfig();
   const prepared = await prepareNodeHostRuntime({
     enableDuplexPluginCommands: true,


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where node hosts detect retired state stores, instruct the operator to run `openclaw doctor --fix`, and then fail or log forever because no startup path invokes the migration owner.

Live fleet evidence from 2026-07-28 showed all three forms: legacy device auth killed node-host connection on two Macs, legacy device identity killed `openclaw node run` on miniclaw, and the Mac app logged the exec-approvals migration instruction once per second for days.

## Why This Change Was Made

Node-host startup now invokes the existing Doctor-owned detection and migration functions for device auth, device identity, and exec approvals before constructing the runtime or first Gateway connection. Each existing migrator retains its own short SQLite-maintenance lock and fail-soft behavior; no config repair, Gateway startup behavior, migration gate, or SQLite schema version changes are included.

### Design decision

The operator approved automatic migration when a tool detects its own retired state. Doctor remains the sole migration owner: node-host startup is an explicit second authorized entry point that invokes those migrators, while runtime code still contains no inline migration logic. Lock contention or migration failure logs once and startup continues so the existing store gates preserve the current fail-closed behavior without a retry loop.

## User Impact

Installed node-host services and the Mac app node-host worker can recover the three retired JSON stores automatically on startup. Successful migrations emit one concise line; clean startup stays silent. A pending native identity claim is preserved with a warning, and failed or contended migrations remain available for Doctor recovery.

## Evidence

- `node scripts/run-vitest.mjs src/node-host/startup-state-migrations.test.ts` — 1 file passed, 6 tests passed.
- `node scripts/run-vitest.mjs src/node-host/runner.test.ts` — 1 file passed, 33 tests passed.
- `git diff --check` — clean.
- Codex autoreview (`--mode uncommitted`) — clean, no accepted/actionable findings after applying the explicit warn-and-continue operator contract.

AI-assisted implementation; the migration ownership, lock behavior, native-claim preservation, runtime gates, startup wiring, and focused tests were inspected directly.
