### PR TITLE
fix(ui): stabilize Workboard form-state E2E

### DIFF
--- a/ui/src/pages/workboard/workboard.e2e.test.ts
+++ b/ui/src/pages/workboard/workboard.e2e.test.ts
@@ -77,6 +77,35 @@ function workboardField(scope: Page | Locator, label: string) {
   });
 }
 
+type UpdatingElement = HTMLElement & {
+  requestUpdate?: () => void;
+  updateComplete: Promise<boolean>;
+};
+
+async function waitForWorkboardRender(page: Page, requestUpdate = false): Promise<void> {
+  await page.locator("openclaw-app").evaluate(async (element, shouldRequestUpdate) => {
+    const app = element as UpdatingElement;
+    if (shouldRequestUpdate) {
+      app.requestUpdate?.();
+    }
+    await app.updateComplete;
+  }, requestUpdate);
+}
+
+async function waitForWorkboardSelectValue(control: Locator, value: string): Promise<void> {
+  // Web Awesome updates `value` before its deferred `change` event. Wait for
+  // that event's update boundary and the parent render that consumes it.
+  await control.evaluate(async (element) => {
+    await (element as UpdatingElement).updateComplete;
+  });
+  await waitForWorkboardRender(control.page());
+  await expect
+    .poll(() =>
+      control.evaluate((select) => (select as HTMLElement & { value?: string }).value ?? ""),
+    )
+    .toBe(value);
+}
+
 async function chooseWorkboardSelectOption(
   scope: Page | Locator,
   label: string,
@@ -103,6 +132,7 @@ async function chooseWorkboardSelectFieldOption(
     (select as HTMLElement & { value: string }).value = String(value);
     select.dispatchEvent(new Event("change", { bubbles: true }));
   }, optionValue);
+  await waitForWorkboardSelectValue(control, optionValue ?? "");
 }
 
 async function setWorkboardDraftField(
@@ -112,6 +142,9 @@ async function setWorkboardDraftField(
 ): Promise<void> {
   const input = scope.getByLabel(label);
   await input.fill(value);
+  // Prove the delegated input handler reached canonical draft state. A DOM-only
+  // value check can pass even when the next parent render would restore stale data.
+  await waitForWorkboardRender(input.page(), true);
   await expect.poll(() => input.inputValue()).toBe(value);
 }
 
@@ -408,38 +441,21 @@ describeControlUiE2e("Control UI Workboard mocked Gateway E2E", () => {
 
       await writable.page.keyboard.press("End");
       await writable.page.keyboard.press("Enter");
-      await expect
-        .poll(() =>
-          prioritySelect.evaluate(
-            (select) => (select as HTMLElement & { value?: string }).value ?? "",
-          ),
-        )
-        .toBe("urgent");
+      await waitForWorkboardSelectValue(prioritySelect, "urgent");
       await expect.poll(() => priorityCombobox.getAttribute("aria-expanded")).toBe("false");
 
       await priorityCombobox.focus();
       await writable.page.keyboard.press("ArrowDown");
       await writable.page.keyboard.press("ArrowUp");
       await writable.page.keyboard.press("Enter");
-      await expect
-        .poll(() =>
-          prioritySelect.evaluate(
-            (select) => (select as HTMLElement & { value?: string }).value ?? "",
-          ),
-        )
-        .toBe("high");
+      await waitForWorkboardSelectValue(prioritySelect, "high");
+      await expect.poll(() => priorityCombobox.getAttribute("aria-expanded")).toBe("false");
 
       await priorityCombobox.focus();
       await writable.page.keyboard.press("ArrowDown");
       await writable.page.keyboard.press("Home");
       await writable.page.keyboard.press("Enter");
-      await expect
-        .poll(() =>
-          prioritySelect.evaluate(
-            (select) => (select as HTMLElement & { value?: string }).value ?? "",
-          ),
-        )
-        .toBe("all");
+      await waitForWorkboardSelectValue(prioritySelect, "all");
       await expect.poll(() => priorityCombobox.getAttribute("aria-expanded")).toBe("false");
 
       await writableGateway.deferNext("workboard.cards.create");


### PR DESCRIPTION
## What Problem This Solves

Resolves an intermittent `checks-ui-e2e` failure in the Workboard create/edit scenario where CI could inspect a select or form value before the component event and parent render had settled. The observed failures surfaced as a priority filter still reading `high` instead of `all`, or a create request missing the freshly filled labels.

## Why This Change Was Made

Web Awesome commits a select's `value` before it emits its deferred `change` event after `updateComplete`. The test now waits for both the select update and the parent Workboard render, including the previously omitted close boundary after selecting `high`. Draft-field helpers also force and await a parent render so they prove canonical form state, not only the input element's immediate DOM value.

This is a test-determinism change only; product behavior is unchanged.

## User Impact

Maintainers should no longer see unrelated UI pull requests fail because the Workboard E2E reads intermediate form or filter state. There is no user-visible runtime change.

## Evidence

- Blacksmith Testbox `tbx_01kynvc3x4d2ftrekkqx4bnkhq`: `node scripts/run-vitest.mjs ui/src/pages/workboard/workboard.e2e.test.ts` passed in a bounded 10-iteration shell loop (30/30 tests). [Hydration run](https://github.com/openclaw/openclaw/actions/runs/30417046132)
- `pnpm lint` passed on the same synced Testbox.
- `pnpm deadcode:dependencies`, `pnpm deadcode:unused-files`, and `pnpm deadcode:exports` passed; unused-file and all unused-export scans reported 0 entries.
- Targeted `oxfmt --check` and `git diff --check` passed.
- Codex autoreview reported no accepted/actionable findings (0.93 confidence).

AI-assisted with Codex; the dependency event ordering, changed test path, and proof results were reviewed directly.
