### PR TITLE
fix(agents): preserve tool-use evidence for Codex CLI runs

### DIFF
--- a/src/agents/cli-output.test.ts
+++ b/src/agents/cli-output.test.ts
@@ -2653,4 +2653,94 @@ describe("createCliJsonlStreamingParser", () => {
     expect(commentaryTexts).toEqual(["Reading the file now.", "Now searching."]);
   });
 });
+
+describe("codex exec JSONL tool events", () => {
+  function parseCodexToolEvents(events: Array<Record<string, unknown>>) {
+    const starts: CliToolUseStartDelta[] = [];
+    const results: CliToolResultDelta[] = [];
+    const parser = createCliJsonlStreamingParser({
+      backend: { command: "codex", output: "jsonl" },
+      providerId: "codex-cli",
+      onAssistantDelta: () => undefined,
+      onToolUseStart: (event) => starts.push(event),
+      onToolResult: (event) => results.push(event),
+    });
+    parser.push(`${events.map((event) => JSON.stringify(event)).join("\n")}\n`);
+    parser.finish();
+    return { starts, results };
+  }
+
+  it("correlates started and completed items and synthesizes terminal-only starts", () => {
+    const parsed = parseCodexToolEvents([
+      {
+        type: "item.started",
+        item: {
+          id: "mcp-1",
+          type: "mcp_tool_call",
+          server: "finance-data",
+          tool: "lookup",
+          arguments: { symbol: "AAPL" },
+          status: "in_progress",
+        },
+      },
+      {
+        type: "item.completed",
+        item: {
+          id: "mcp-1",
+          type: "mcp_tool_call",
+          server: "finance-data",
+          tool: "lookup",
+          status: "completed",
+        },
+      },
+      {
+        type: "item.completed",
+        item: {
+          id: "mcp-2",
+          type: "mcp_tool_call",
+          server: "",
+          tool: "lookup",
+          status: "failed",
+          error: { message: "fixture failure" },
+        },
+      },
+    ]);
+
+    expect(parsed.starts.map(({ toolCallId, name }) => ({ toolCallId, name }))).toEqual([
+      { toolCallId: "mcp-1", name: "finance-data.lookup" },
+      { toolCallId: "mcp-2", name: "lookup" },
+    ]);
+    expect(
+      parsed.results.map(({ toolCallId, name, isError }) => ({ toolCallId, name, isError })),
+    ).toEqual([
+      { toolCallId: "mcp-1", name: "finance-data.lookup", isError: false },
+      { toolCallId: "mcp-2", name: "lookup", isError: true },
+    ]);
+  });
+
+  it("uses the native builtin names from the Codex item contract", () => {
+    const parsed = parseCodexToolEvents([
+      {
+        type: "item.completed",
+        item: {
+          id: "command",
+          type: "command_execution",
+          command: "pwd",
+          status: "failed",
+        },
+      },
+      {
+        type: "item.completed",
+        item: { id: "patch", type: "file_change", changes: [], status: "completed" },
+      },
+      {
+        type: "item.completed",
+        item: { id: "search", type: "web_search", query: "fixture" },
+      },
+    ]);
+
+    expect(parsed.starts.map((event) => event.name)).toEqual(["bash", "apply_patch", "web_search"]);
+    expect(parsed.results.map((event) => event.isError)).toEqual([true, false, false]);
+  });
+});
 /* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */

--- a/src/agents/cli-output.ts
+++ b/src/agents/cli-output.ts
@@ -14,6 +14,7 @@ import type {
   MessagingToolSend,
   MessagingToolSourceReplyPayload,
 } from "./embedded-agent-messaging.types.js";
+import type { ToolSummaryTrace } from "./embedded-agent-runner/types.js";
 
 export type CliUsage = {
   input?: number;
@@ -63,6 +64,7 @@ export type CliOutput = {
   messagingToolSentMediaUrls?: string[];
   messagingToolSentTargets?: MessagingToolSend[];
   messagingToolSourceReplyPayloads?: MessagingToolSourceReplyPayload[];
+  toolSummary?: ToolSummaryTrace;
   yielded?: true;
 };
 
@@ -152,6 +154,10 @@ function isClaudeCliProvider(providerId: string): boolean {
 
 function isGeminiCliProvider(providerId: string): boolean {
   return normalizeLowercaseStringOrEmpty(providerId) === "google-gemini-cli";
+}
+
+function isCodexCliProvider(providerId: string): boolean {
+  return normalizeLowercaseStringOrEmpty(providerId) === "codex-cli";
 }
 
 function isGeminiStreamJsonDialect(params: {
@@ -1161,6 +1167,83 @@ function dispatchGeminiCliStreamingToolEvent(params: {
   }
 }
 
+function readCodexCliToolItem(item: Record<string, unknown>): {
+  toolCallId: string;
+  name: string;
+  kind: CliToolUseStartDelta["kind"];
+  args: Record<string, unknown>;
+  isError: boolean;
+  result?: unknown;
+} | null {
+  const toolCallId = typeof item.id === "string" ? item.id.trim() : "";
+  if (!toolCallId) {
+    return null;
+  }
+  const itemType = normalizeLowercaseStringOrEmpty(item.type);
+  let name: string;
+  if (itemType === "mcp_tool_call") {
+    const tool = typeof item.tool === "string" ? item.tool.trim() : "";
+    if (!tool) {
+      return null;
+    }
+    const server = typeof item.server === "string" ? item.server.trim() : "";
+    name = server ? `${server}.${tool}` : tool;
+  } else if (itemType === "command_execution") {
+    name = "bash";
+  } else if (itemType === "file_change") {
+    name = "apply_patch";
+  } else if (itemType === "web_search") {
+    name = "web_search";
+  } else {
+    return null;
+  }
+  return {
+    toolCallId,
+    name,
+    kind: itemType === "mcp_tool_call" ? "mcp_tool_use" : "tool_use",
+    args: itemType === "mcp_tool_call" && isRecord(item.arguments) ? item.arguments : {},
+    isError: item.status === "failed" || item.status === "error",
+    result: item.result ?? item.error ?? item.aggregated_output,
+  };
+}
+
+function dispatchCodexCliStreamingToolEvent(params: {
+  providerId: string;
+  parsed: Record<string, unknown>;
+  tracker: ToolUseTracker;
+  onToolUseStart?: (delta: CliToolUseStartDelta) => void;
+  onToolResult?: (delta: CliToolResultDelta) => void;
+}): void {
+  if (
+    !isCodexCliProvider(params.providerId) ||
+    (params.parsed.type !== "item.started" && params.parsed.type !== "item.completed") ||
+    !isRecord(params.parsed.item)
+  ) {
+    return;
+  }
+  const item = readCodexCliToolItem(params.parsed.item);
+  if (!item) {
+    return;
+  }
+  emitToolStartOnce(
+    params.tracker,
+    item.toolCallId,
+    item.name,
+    item.kind,
+    item.args,
+    params.onToolUseStart,
+  );
+  if (params.parsed.type === "item.completed") {
+    emitToolResultOnce(
+      params.tracker,
+      item.toolCallId,
+      item.isError,
+      item.result,
+      params.onToolResult,
+    );
+  }
+}
+
 const GEMINI_CLI_ERROR_EVENT_FALLBACK = "Gemini CLI emitted an error event.";
 const GEMINI_CLI_RESULT_ERROR_FALLBACK = "Gemini CLI result status was error.";
 
@@ -1392,6 +1475,13 @@ export function createCliJsonlStreamingParser(params: {
     }
 
     if (params.onToolUseStart || params.onToolResult) {
+      dispatchCodexCliStreamingToolEvent({
+        providerId: params.providerId,
+        parsed,
+        tracker: toolTracker,
+        onToolUseStart: params.onToolUseStart,
+        onToolResult: params.onToolResult,
+      });
       dispatchGeminiCliStreamingToolEvent({
         backend: params.backend,
         providerId: params.providerId,

--- a/src/agents/cli-runner.tool-summary.test.ts
+++ b/src/agents/cli-runner.tool-summary.test.ts
@@ -1,0 +1,137 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { runPreparedCliAgent } from "./cli-runner.js";
+import { buildPreparedCliRunContext } from "./cli-runner.test-helpers.js";
+import {
+  mockSuccessfulCliRun,
+  restoreCliRunnerPrepareTestDeps,
+  supervisorSpawnMock,
+} from "./cli-runner.test-support.js";
+
+vi.mock("./cli-runner/session-history.js", () => ({
+  loadSessionHistory: vi.fn(async () => []),
+}));
+
+vi.mock("../plugins/hook-runner-global.js", () => ({
+  getGlobalHookRunner: vi.fn(() => null),
+}));
+
+type JsonlEvent = Record<string, unknown>;
+
+function codexContext() {
+  return buildPreparedCliRunContext({
+    provider: "codex-cli",
+    backend: {
+      command: "codex",
+      args: ["exec", "--json"],
+      output: "jsonl",
+      input: "arg",
+      modelArg: "--model",
+      sessionArgs: ["exec", "resume", "{sessionId}", "--json"],
+    },
+  });
+}
+
+async function runCodexFixture(events: JsonlEvent[]) {
+  mockSuccessfulCliRun(`${events.map((event) => JSON.stringify(event)).join("\n")}\n`);
+  return await runPreparedCliAgent(codexContext());
+}
+
+describe("codex-cli terminal tool summary", () => {
+  beforeEach(() => {
+    restoreCliRunnerPrepareTestDeps();
+    supervisorSpawnMock.mockReset();
+  });
+
+  it("preserves an explicit empty summary on a zero-tool success", async () => {
+    const result = await runCodexFixture([
+      { type: "thread.started", thread_id: "thread-zero" },
+      {
+        type: "item.completed",
+        item: { id: "message", type: "agent_message", text: "done" },
+      },
+      {
+        type: "turn.completed",
+        usage: { input_tokens: 1, cached_input_tokens: 0, output_tokens: 1 },
+      },
+    ]);
+
+    expect(result.meta.toolSummary).toEqual({ calls: 0, tools: [], failures: 0 });
+  });
+
+  it("carries correlated, repeated, terminal-only, builtin, and failed calls to metadata", async () => {
+    const result = await runCodexFixture([
+      { type: "thread.started", thread_id: "thread-tools" },
+      {
+        type: "item.started",
+        item: {
+          id: "mcp-1",
+          type: "mcp_tool_call",
+          server: "finance-data",
+          tool: "lookup",
+          status: "in_progress",
+        },
+      },
+      {
+        type: "item.completed",
+        item: {
+          id: "mcp-1",
+          type: "mcp_tool_call",
+          server: "finance-data",
+          tool: "lookup",
+          status: "completed",
+        },
+      },
+      {
+        type: "item.completed",
+        item: {
+          id: "mcp-2",
+          type: "mcp_tool_call",
+          server: "finance-data",
+          tool: "lookup",
+          status: "failed",
+          error: { message: "fixture failure" },
+        },
+      },
+      {
+        type: "item.completed",
+        item: {
+          id: "command-1",
+          type: "command_execution",
+          command: "pwd",
+          status: "completed",
+        },
+      },
+      {
+        type: "item.completed",
+        item: {
+          id: "patch-1",
+          type: "file_change",
+          changes: [],
+          status: "completed",
+        },
+      },
+      {
+        type: "item.completed",
+        item: {
+          id: "search-1",
+          type: "web_search",
+          query: "provider-free fixture",
+        },
+      },
+      {
+        type: "item.completed",
+        item: { id: "message", type: "agent_message", text: "done" },
+      },
+      {
+        type: "turn.completed",
+        usage: { input_tokens: 1, cached_input_tokens: 0, output_tokens: 1 },
+      },
+    ]);
+
+    expect(result.meta.toolSummary).toEqual({
+      calls: 5,
+      tools: ["finance-data.lookup", "bash", "apply_patch", "web_search"],
+      failures: 1,
+    });
+  });
+});

--- a/src/agents/cli-runner.ts
+++ b/src/agents/cli-runner.ts
@@ -1187,6 +1187,9 @@ export async function runPreparedCliAgent(
           : {}),
         systemPromptReport: context.systemPromptReport,
         ...(yielded ? { yielded: true, livenessState: "paused" as const, stopReason } : {}),
+        ...(resultParams.output.toolSummary
+          ? { toolSummary: resultParams.output.toolSummary }
+          : {}),
         executionTrace: {
           winnerProvider: params.provider,
           winnerModel: context.modelId,

--- a/src/agents/cli-runner/execute-tool-tracking.test.ts
+++ b/src/agents/cli-runner/execute-tool-tracking.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+import { buildPreparedCliRunContext } from "../cli-runner.test-helpers.js";
+import { createCliToolTracking } from "./execute-tool-tracking.js";
+
+function createTracking() {
+  return createCliToolTracking(buildPreparedCliRunContext({ provider: "codex-cli" }));
+}
+
+describe("createCliToolTracking tool summaries", () => {
+  it("attaches an explicit typed empty summary", () => {
+    const tracking = createTracking();
+
+    expect(tracking.withExecutionEvidence({ text: "done" }).toolSummary).toEqual({
+      calls: 0,
+      tools: [],
+      failures: 0,
+    });
+  });
+
+  it("correlates ids, preserves repeated-name calls, and counts terminal failures once", () => {
+    const tracking = createTracking();
+    tracking.handleCliToolUseStart({
+      toolCallId: "call-1",
+      name: "finance-data.lookup",
+      kind: "mcp_tool_use",
+      args: {},
+    });
+    tracking.handleCliToolUseStart({
+      toolCallId: "call-1",
+      name: "finance-data.lookup",
+      kind: "mcp_tool_use",
+      args: {},
+    });
+    tracking.handleCliToolUseStart({
+      toolCallId: "call-2",
+      name: "finance-data.lookup",
+      kind: "mcp_tool_use",
+      args: {},
+    });
+    tracking.handleCliToolResult({
+      toolCallId: "call-1",
+      name: "finance-data.lookup",
+      isError: false,
+    });
+    tracking.handleCliToolResult({
+      toolCallId: "call-2",
+      name: "finance-data.lookup",
+      isError: true,
+    });
+    tracking.handleCliToolResult({
+      toolCallId: "call-2",
+      name: "finance-data.lookup",
+      isError: true,
+    });
+    tracking.handleCliToolResult({
+      toolCallId: "terminal-only",
+      name: "bash",
+      isError: true,
+    });
+
+    expect(tracking.withExecutionEvidence({ text: "done" }).toolSummary).toEqual({
+      calls: 3,
+      tools: ["finance-data.lookup", "bash"],
+      failures: 2,
+    });
+  });
+});

--- a/src/agents/cli-runner/execute-tool-tracking.ts
+++ b/src/agents/cli-runner/execute-tool-tracking.ts
@@ -21,6 +21,7 @@ import type {
   MessagingToolSend,
   MessagingToolSourceReplyPayload,
 } from "../embedded-agent-messaging.types.js";
+import type { ToolSummaryTrace } from "../embedded-agent-runner/types.js";
 import {
   extractMessagingToolSendResult,
   extractMessagingToolSourceReplyPayload,
@@ -76,6 +77,10 @@ export function createCliToolTracking(context: PreparedCliRunContext) {
   >();
   const cliLoopbackCalls: CliLoopbackCall[] = [];
   const activeCliTools = new Map<string, ActiveCliTool>();
+  const summaryCalls = new Map<string, { name: string; failed: boolean }>();
+  const summaryTools: string[] = [];
+  const summaryToolNames = new Set<string>();
+  let summaryFailures = 0;
   let cliLoopbackCorrelationOverflowed = false;
   const messagingToolSentTexts: string[] = [];
   const messagingToolSentTextKeys = new Set<string>();
@@ -84,6 +89,20 @@ export function createCliToolTracking(context: PreparedCliRunContext) {
   const messagingToolSentTargets: MessagingToolSend[] = [];
   const messagingToolSentTargetKeys = new Set<string>();
   const messagingToolSourceReplyPayloads: MessagingToolSourceReplyPayload[] = [];
+  const trackSummaryCall = (toolCallId: string, rawName: string) => {
+    const current = summaryCalls.get(toolCallId);
+    if (current) {
+      return current;
+    }
+    const name = rawName.trim();
+    const created = { name, failed: false };
+    summaryCalls.set(toolCallId, created);
+    if (name && !summaryToolNames.has(name)) {
+      summaryToolNames.add(name);
+      summaryTools.push(name);
+    }
+    return created;
+  };
   const matchesCliLoopbackCall = (
     toolName: string,
     toolArgs: Record<string, unknown>,
@@ -418,6 +437,7 @@ export function createCliToolTracking(context: PreparedCliRunContext) {
     });
   };
   const handleCliToolUseStart = (event: CliToolUseStartDelta) => {
+    trackSummaryCall(event.toolCallId, event.name);
     if (event.kind !== "server_tool_use") {
       const activeTool: ActiveCliTool = {
         toolName: event.name,
@@ -479,6 +499,11 @@ export function createCliToolTracking(context: PreparedCliRunContext) {
     isError: boolean;
     result?: unknown;
   }) => {
+    const summaryCall = trackSummaryCall(event.toolCallId, event.name);
+    if (event.isError && !summaryCall.failed) {
+      summaryCall.failed = true;
+      summaryFailures += 1;
+    }
     const activeTool = activeCliTools.get(event.toolCallId);
     activeCliTools.delete(event.toolCallId);
     retireCliLoopbackCorrelation(event.toolCallId, activeTool);
@@ -583,6 +608,11 @@ export function createCliToolTracking(context: PreparedCliRunContext) {
     messagingToolSentTargets,
     messagingToolSourceReplyPayloads,
   });
+  const toolSummary = (): ToolSummaryTrace => ({
+    calls: summaryCalls.size,
+    tools: summaryTools.slice(),
+    failures: summaryFailures,
+  });
   return {
     beginGatewayCapture,
     handleCliToolUseStart,
@@ -594,6 +624,9 @@ export function createCliToolTracking(context: PreparedCliRunContext) {
       const current = evidence();
       return {
         ...output,
+        ...(context.params.provider.trim().toLowerCase() === "codex-cli"
+          ? { toolSummary: toolSummary() }
+          : {}),
         ...(yielded ? { yielded: true as const } : {}),
         ...(current.didSendViaMessagingTool ? { didSendViaMessagingTool: true } : {}),
         ...(current.didDeliverSourceReplyViaMessageTool

--- a/src/agents/embedded-agent-runner/run/run-attempt-result.test.ts
+++ b/src/agents/embedded-agent-runner/run/run-attempt-result.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import { buildTraceToolSummary } from "./run-attempt-result.js";
+
+type ToolMeta = Parameters<typeof buildTraceToolSummary>[0]["toolMetas"];
+
+function buildSummary(entries: Array<{ toolName: string; isError?: boolean }>) {
+  return buildTraceToolSummary({
+    toolMetas: entries as ToolMeta,
+    fallbackHadFailure: false,
+  });
+}
+
+describe("buildTraceToolSummary", () => {
+  it("returns a typed empty summary when no tools ran", () => {
+    expect(buildSummary([])).toEqual({ calls: 0, tools: [], failures: 0 });
+  });
+
+  it("keeps invocation counts separate from unique names and failures", () => {
+    expect(
+      buildSummary([
+        { toolName: "finance_lookup" },
+        { toolName: "finance_lookup", isError: true },
+        { toolName: "calendar_read" },
+      ]),
+    ).toEqual({
+      calls: 3,
+      tools: ["finance_lookup", "calendar_read"],
+      failures: 1,
+    });
+  });
+});

--- a/src/agents/embedded-agent-runner/run/run-attempt-result.ts
+++ b/src/agents/embedded-agent-runner/run/run-attempt-result.ts
@@ -62,9 +62,9 @@ export function hasCompletedModelProgressForIdleBreaker(
 export function buildTraceToolSummary(params: {
   toolMetas?: EmbeddedRunAttemptForRunner["toolMetas"];
   fallbackHadFailure: boolean;
-}): ToolSummaryTrace | undefined {
+}): ToolSummaryTrace {
   if (!params.toolMetas?.length) {
-    return undefined;
+    return { calls: 0, tools: [], failures: 0 };
   }
   const tools: string[] = [];
   const seen = new Set<string>();


### PR DESCRIPTION
Related: #115497

AI-assisted: yes. I reviewed the source ownership, direct terminal objects, tests, and generated patch.

## What Problem This Solves

Fixes an issue where users of Codex CLI-backed agents receive successful terminal results without deterministic tool-use evidence. Zero-tool success is indistinguishable from missing provenance, while tool-using results omit names, invocation counts, and failure counts.

## Why This Change Was Made

Codex `item.started` and `item.completed` JSONL records now flow through the existing parser and an item-ID-correlated tracker into terminal `toolSummary` metadata. Embedded zero-tool success also emits an explicit typed empty summary. Tool facts come only from typed process events; assistant prose, transcripts, logs, and session files remain out of scope.

## User Impact

Callers can reliably tell whether a successful embedded or Codex CLI run used no tools, which tools it used, how many calls occurred, and how many terminal calls failed. Existing non-empty embedded accounting and CLI execution traces are preserved.

## Evidence

- Frozen provider-free oracle: 4 failed / 4 passed before; 8 / 8 passed after.
- Existing controls: 80 / 80 passed after the change, preserving all 78 anchor controls.
- Changed focused tests: 75 / 75 passed.
- Independent adversarial vectors: 2 / 2 passed, including jagged JSONL chunks, duplicate start/completion frames, terminal-only calls, repeated tool names, failed terminal statuses, MCP fallback naming, native naming, and misleading assistant prose.
- `pnpm tsgo:core:test`: passed.
- `pnpm tsgo:core`: passed.
- Targeted format and lint: passed.
- Full `pnpm lint:core`: passed.
- Package, lockfile, workspace, and `extensions/codex` dependency bytes are unchanged.
- No provider or live gateway call was used for verification.

Allow edits from maintainers: enabled.
