### PR TITLE
fix: Apply async-flow, resource-leak, and JSON.parse safety patches from source audit

### DIFF
--- a/src/commitments/runtime.ts
+++ b/src/commitments/runtime.ts
@@ -127,7 +127,7 @@ export function enqueueCommitmentExtraction(input: CommitmentExtractionEnqueueIn
   if (
     !resolved.enabled ||
     shouldDisableBackgroundExtractionForTests() ||
-    (agentId ? nowMs < (terminalFailureCooldownUntilByAgent.get(agentId) ?? 0) : false) ||
+    agentIdCooldownActive(agentId, nowMs) ||
     !isUsefulText(input.userText) ||
     !isUsefulText(input.assistantText) ||
     !agentId ||
@@ -185,6 +185,20 @@ function isTerminalExtractionError(error: unknown): boolean {
   );
 }
 
+function evictExpiredCooldowns(): void {
+  const nowMs = Date.now();
+  for (const [agentId, cooldownUntil] of terminalFailureCooldownUntilByAgent) {
+    if (nowMs >= cooldownUntil) {
+      terminalFailureCooldownUntilByAgent.delete(agentId);
+    }
+  }
+}
+
+function agentIdCooldownActive(agentId: string, nowMs: number): boolean {
+  evictExpiredCooldowns();
+  return agentId ? nowMs < (terminalFailureCooldownUntilByAgent.get(agentId) ?? 0) : false;
+}
+
 function openTerminalFailureCooldown(
   agentId: string,
   error: unknown,
@@ -196,6 +210,7 @@ function openTerminalFailureCooldown(
     resolveExpiresAtMsFromDurationMs(TERMINAL_EXTRACTION_FAILURE_COOLDOWN_MS, {
       nowMs: fallbackNowMs,
     });
+  evictExpiredCooldowns();
   if (cooldownUntil !== undefined) {
     terminalFailureCooldownUntilByAgent.set(agentId, cooldownUntil);
   }
@@ -285,7 +300,7 @@ function takeAgentBatch(
   maxItems: number,
 ): Array<Omit<CommitmentExtractionItem, "existingPending"> & { cfg?: OpenClawConfig }> {
   const batch = [];
-  for (let index = 0; index < queue.length && batch.length < maxItems;) {
+  for (let index = 0; index < queue.length && batch.length < maxItems; ) {
     if (queue[index]?.agentId !== agentId) {
       index += 1;
       continue;

--- a/src/infra/openclaw-root.ts
+++ b/src/infra/openclaw-root.ts
@@ -10,8 +10,12 @@ const packageRootsCache = new Map<string, string[]>();
 const argv1CandidateCache = new Map<string, string[]>();
 
 function parsePackageName(raw: string): string | null {
-  const parsed = JSON.parse(raw) as { name?: unknown };
-  return typeof parsed.name === "string" ? parsed.name : null;
+  try {
+    const parsed = JSON.parse(raw) as { name?: unknown };
+    return typeof parsed.name === "string" ? parsed.name : null;
+  } catch {
+    return null;
+  }
 }
 
 async function readPackageName(dir: string): Promise<string | null> {

--- a/src/infra/ports-inspect.ts
+++ b/src/infra/ports-inspect.ts
@@ -209,11 +209,18 @@ async function enrichUnixListenerProcessInfo(listeners: PortListener[]): Promise
       if (!listener.pid) {
         return;
       }
-      const [commandLine, user, parentPid] = await Promise.all([
-        resolveUnixCommandLine(listener.pid),
-        resolveUnixUser(listener.pid),
-        resolveUnixParentPid(listener.pid),
-      ]);
+      let commandLine: string | undefined;
+      let user: string | undefined;
+      let parentPid: number | undefined;
+      try {
+        [commandLine, user, parentPid] = await Promise.all([
+          resolveUnixCommandLine(listener.pid),
+          resolveUnixUser(listener.pid),
+          resolveUnixParentPid(listener.pid),
+        ]);
+      } catch {
+        // Skip enrichment for this listener if any resolution fails
+      }
       if (commandLine) {
         listener.commandLine = commandLine;
       }
@@ -533,10 +540,16 @@ async function readWindowsNetstatEntries<T extends PortListener>(
       if (!entry.pid) {
         return;
       }
-      const [imageName, commandLine] = await Promise.all([
-        resolveWindowsImageName(entry.pid),
-        resolveWindowsCommandLine(entry.pid),
-      ]);
+      let imageName: string | undefined;
+      let commandLine: string | undefined;
+      try {
+        [imageName, commandLine] = await Promise.all([
+          resolveWindowsImageName(entry.pid),
+          resolveWindowsCommandLine(entry.pid),
+        ]);
+      } catch {
+        // Skip enrichment for this entry if any resolution fails
+      }
       if (imageName) {
         entry.command = imageName;
       }

--- a/src/realtime-transcription/websocket-session.ts
+++ b/src/realtime-transcription/websocket-session.ts
@@ -426,6 +426,7 @@ class WebSocketRealtimeTranscriptionSession<Event> implements RealtimeTranscript
     this.ready = false;
     this.readySinceMs = undefined;
     if (this.ws) {
+      this.ws.removeAllListeners();
       this.ws.close(1000, "Transcription session closed");
       this.ws = null;
     }


### PR DESCRIPTION
## Summary

Four bug fixes identified during a comprehensive source-code audit of 5,291 files. The audit was conducted against an older snapshot; most P0/P1 bugs (sleep abort listener, transcript store JSON.parse, heartbeat runner Promise.all, bonjour allSettled migration) were already fixed by upstream refactoring. The remaining four bugs address:

### Changes

1. **ports-inspect.ts** (Bug 12, MAJOR): Inner `Promise.all` calls for process-info enrichment (Unix commandLine/user/parentPid and Windows imageName/commandLine) were unprotected. If one resolution threw, the outer `pMap` batch would abandon all other listeners. Wrapped in try/catch so a single failed resolution silently skips that entry.

2. **commitments/runtime.ts** (Bug 13, MAJOR): `terminalFailureCooldownUntilByAgent` Map entries were never evicted in production paths (only in test-only `resetCommitmentExtractionRuntimeForTests`). Added `evictExpiredCooldowns()` called both on new entry insertion and on cooldown check, preventing unbounded growth over long uptime.

3. **openclaw-root.ts** (Bug 15, MAJOR): `parsePackageName()` called `JSON.parse(raw)` without try/catch. While all callers already protect it, defense-in-depth prevents crashes if the function is called directly.

4. **websocket-session.ts** (Bug 17, MINOR): `forceClose()` closed the WebSocket without removing event listeners. Added `removeAllListeners()` before nulling the reference so old WebSocket instances don't retain stale closures during reconnection cycles.

### Not modified (already fixed or false positives)
- **Bug 7** (CRITICAL): sleep abort listener — refactored into retry-sleep.ts with `{ once: true }` and proper cleanup
- **Bug 8** (CRITICAL): Gemini auth JSON.parse — already had try/catch
- **Bug 9** (MAJOR): Transcript store JSON.parse — completely rewritten, all occurrences protected
- **Bug 10** (MAJOR): Heartbeat runner Promise.all — runOneAgent now has comprehensive try/catch
- **Bug 11** (MAJOR): Bonjour discovery — uses `Promise.allSettled`
- **Bug 14** (MAJOR): npm-managed-root JSON.parse — all in try/catch
- **Bug 16** (MAJOR): clawhub JSON.parse — all in try/catch
- **Bug 18** (MINOR): Abort check after sleep — non-issue with Node.js event loop model