### PR TITLE
fix(android): preserve generated lint suppressions

### DIFF
--- a/scripts/android-app-i18n.ts
+++ b/scripts/android-app-i18n.ts
@@ -93,8 +93,11 @@ type ResourceString = {
   value: string;
 };
 
-const GENERATED_TRANSLATION_LINT_IGNORE =
-  'tools:ignore="Typos,TypographyDashes,TypographyEllipsis"';
+const GENERATED_TRANSLATION_LINT_IGNORES = [
+  "Typos",
+  "TypographyDashes",
+  "TypographyEllipsis",
+] as const;
 
 type TranslationContradiction = {
   locale: string;
@@ -274,6 +277,19 @@ function parseStrings(source: string): ResourceString[] {
     rawValue: match[3] ?? "",
     value: decodeXml(match[3] ?? ""),
   }));
+}
+
+function withGeneratedTranslationLintIgnores(attrs: string): string {
+  const existing = attrs.match(/\btools:ignore\s*=\s*"([^"]*)"/u);
+  const ignores = [
+    ...(existing?.[1]
+      ?.split(",")
+      .map((value) => value.trim())
+      .filter(Boolean) ?? []),
+    ...GENERATED_TRANSLATION_LINT_IGNORES,
+  ];
+  const rendered = `tools:ignore="${[...new Set(ignores)].join(",")}"`;
+  return existing ? attrs.replace(existing[0], rendered) : `${attrs} ${rendered}`;
 }
 
 function parseArrays(source: string): Map<string, string[]> {
@@ -1136,7 +1152,7 @@ function localizeManualStrings(
         ? selectExactArtifactTranslation(source, inventoryEntry.id, artifactEntries)
         : source;
     return {
-      attrs: translatable ? `${entry.attrs} ${GENERATED_TRANSLATION_LINT_IGNORE}` : entry.attrs,
+      attrs: translatable ? withGeneratedTranslationLintIgnores(entry.attrs) : entry.attrs,
       key: entry.key,
       rawValue: `"${escapeAndroidResourceValue(value)}"`,
       value,
@@ -1168,7 +1184,7 @@ function renderStringsXml(
       // Translation-memory text intentionally preserves technical tokens and source punctuation,
       // so Android's English dictionary and typography suggestions do not apply to managed keys.
       lines.push(
-        `    <string name="${key}"${formatted} ${GENERATED_TRANSLATION_LINT_IGNORE}>"${renderAndroidResourceValue(entry.source, entry.value)}"</string>`,
+        `    <string name="${key}"${withGeneratedTranslationLintIgnores(formatted)}>"${renderAndroidResourceValue(entry.source, entry.value)}"</string>`,
       );
     }
   }

--- a/test/scripts/android-app-i18n.test.ts
+++ b/test/scripts/android-app-i18n.test.ts
@@ -77,9 +77,18 @@ describe("Android app i18n resources", () => {
       expect(content).toContain('<resources xmlns:tools="http://schemas.android.com/tools">');
       for (const tag of stringTags) {
         if (!tag.includes('translatable="false"')) {
-          expect(tag).toContain('tools:ignore="Typos,TypographyDashes,TypographyEllipsis"');
+          expect(tag.match(/\btools:ignore=/gu)).toHaveLength(1);
+          expect(tag).toMatch(/\btools:ignore="[^"]*\bTypos\b[^"]*"/u);
+          expect(tag).toMatch(/\btools:ignore="[^"]*\bTypographyDashes\b[^"]*"/u);
+          expect(tag).toMatch(/\btools:ignore="[^"]*\bTypographyEllipsis\b[^"]*"/u);
         }
       }
+      expect(content).toContain(
+        'name="open_thread" tools:ignore="MissingTranslation,Typos,TypographyDashes,TypographyEllipsis"',
+      );
+      expect(content).toContain(
+        'name="show_new_messages" tools:ignore="MissingTranslation,Typos,TypographyDashes,TypographyEllipsis"',
+      );
     }
   });
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where native locale refreshes could generate invalid Wear XML when a source string already carried a `tools:ignore` attribute. Android builds then failed because the generated string contained the same XML attribute twice.

## Why This Change Was Made

The Android i18n generator now merges its lint suppressions into an existing `tools:ignore` value and deduplicates entries. Non-translatable strings retain their original attributes.

## User Impact

Native locale refresh PRs can generate buildable Wear resources while preserving source-owned lint suppressions such as `MissingTranslation`.

## Evidence

- `node scripts/run-vitest.mjs test/scripts/android-app-i18n.test.ts` (28 passed)
- `oxfmt --check scripts/android-app-i18n.ts test/scripts/android-app-i18n.test.ts`
- `git diff --check`
- `autoreview --mode uncommitted` (clean, 0.96)
