### PR TITLE
fix(mac): stop repeated exec approvals migration retries

### DIFF
--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -29907,7 +29907,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 766,
+      "line": 765,
       "path": "apps/macos/Sources/OpenClaw/AppState.swift",
       "source": "\\(user)@\\(host)",
       "surface": "apple",
@@ -29915,7 +29915,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 766,
+      "line": 765,
       "path": "apps/macos/Sources/OpenClaw/AppState.swift",
       "source": "\\(user)@\\(host):\\(port)",
       "surface": "apple",
@@ -32595,7 +32595,23 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 802,
+      "line": 184,
+      "path": "apps/macos/Sources/OpenClaw/ExecApprovals.swift",
+      "source": "Exec approvals need migration — run openclaw doctor --fix with OPENCLAW_STATE_DIR set to \\(error.stateDirectoryURL.path).",
+      "surface": "apple",
+      "id": "native.apple.b28538e2e444510f"
+    },
+    {
+      "kind": "conditional-branch",
+      "line": 187,
+      "path": "apps/macos/Sources/OpenClaw/ExecApprovals.swift",
+      "source": "Exec approvals unavailable. Retry to refresh.",
+      "surface": "apple",
+      "id": "native.apple.49e886ab7a093e63"
+    },
+    {
+      "kind": "conditional-branch",
+      "line": 913,
       "path": "apps/macos/Sources/OpenClaw/ExecApprovalsStore.swift",
       "source": "missing:\\(hash)",
       "surface": "apple",

--- a/apps/macos/Sources/OpenClaw/AppState.swift
+++ b/apps/macos/Sources/OpenClaw/AppState.swift
@@ -30,7 +30,6 @@ enum ExecApprovalsPolicyLoadState: Equatable {
 final class AppState {
     private static let logger = Logger(subsystem: "ai.openclaw", category: "app-state")
     private static let execApprovalsReadRetryAttempts = 5
-    private static let execApprovalsReadUnavailableMessage = "Exec approvals unavailable. Retry to refresh."
 
     private let isPreview: Bool
     @ObservationIgnored private let execApprovalsDefaultsAsyncResolver:
@@ -966,7 +965,7 @@ extension AppState {
     private func performExecApprovalModeReadAttempts(maxAttempts: Int, generation: Int) async {
         guard self.execApprovalsReadGeneration == generation else { return }
         guard maxAttempts > 0 else {
-            self.execApprovalPolicyLoadState = .unavailable(Self.execApprovalsReadUnavailableMessage)
+            self.execApprovalPolicyLoadState = .unavailable(ExecApprovalsReadError.unavailable.message)
             return
         }
         self.execApprovalPolicyLoadState = .loading
@@ -986,12 +985,16 @@ extension AppState {
                 self.syncExecApprovalMode(
                     ExecApprovalQuickMode.from(security: defaults.security, ask: defaults.ask))
                 return
-            case .failure:
+            case let .failure(.migrationRequired(error)):
+                self.execApprovalPolicyLoadState = .unavailable(
+                    ExecApprovalsReadError.migrationRequired(error).message)
+                return
+            case .failure(.unavailable):
                 continue
             }
         }
         guard self.execApprovalsReadGeneration == generation else { return }
-        self.execApprovalPolicyLoadState = .unavailable(Self.execApprovalsReadUnavailableMessage)
+        self.execApprovalPolicyLoadState = .unavailable(ExecApprovalsReadError.unavailable.message)
     }
 
     private func scheduleExecApprovalModeReadRetry() {

--- a/apps/macos/Sources/OpenClaw/ExecApprovals.swift
+++ b/apps/macos/Sources/OpenClaw/ExecApprovals.swift
@@ -175,7 +175,18 @@ enum ExecApprovalsMutationError: Error, Equatable, Sendable {
 }
 
 enum ExecApprovalsReadError: Error, Equatable, Sendable {
+    case migrationRequired(ExecApprovalsLegacyMigrationRequiredError)
     case unavailable
+
+    var message: String {
+        switch self {
+        case let .migrationRequired(error):
+            "Exec approvals need migration — run openclaw doctor --fix with " +
+                "OPENCLAW_STATE_DIR set to \(error.stateDirectoryURL.path)."
+        case .unavailable:
+            "Exec approvals unavailable. Retry to refresh."
+        }
+    }
 }
 
 struct ExecApprovalsResolved: Sendable {

--- a/apps/macos/Sources/OpenClaw/ExecApprovalsStore.swift
+++ b/apps/macos/Sources/OpenClaw/ExecApprovalsStore.swift
@@ -1,11 +1,114 @@
 import CryptoKit
+import Darwin
 import Foundation
 import OpenClawKit
 import OSLog
 import Security
 
+enum ExecApprovalsMigrationLogEvent: Equatable {
+    case required(ExecApprovalsLegacyMigrationRequiredError)
+    case recovered(stateDirectoryPath: String)
+}
+
+final class ExecApprovalsMigrationRequiredCache: @unchecked Sendable {
+    struct FileIdentity: Hashable, Sendable {
+        let device: UInt64
+        let inode: UInt64
+        let modificationSeconds: Int64
+        let modificationNanoseconds: Int64
+    }
+
+    private struct CachedFailure {
+        let error: ExecApprovalsLegacyMigrationRequiredError
+        let identity: FileIdentity
+    }
+
+    private struct Condition {
+        var cachedFailure: CachedFailure?
+        var loggedIdentities: Set<FileIdentity?> = []
+    }
+
+    private let lock = NSLock()
+    private var conditions: [String: Condition] = [:]
+    private let identityReader: (URL) -> FileIdentity?
+    private let onEvent: (ExecApprovalsMigrationLogEvent) -> Void
+
+    init(
+        identityReader: @escaping (URL) -> FileIdentity? = ExecApprovalsMigrationRequiredCache.fileIdentity,
+        onEvent: @escaping (ExecApprovalsMigrationLogEvent) -> Void)
+    {
+        self.identityReader = identityReader
+        self.onEvent = onEvent
+    }
+
+    func cachedError(stateDirectoryURL: URL) -> ExecApprovalsLegacyMigrationRequiredError? {
+        let key = Self.stateDirectoryKey(stateDirectoryURL)
+        self.lock.lock()
+        defer { self.lock.unlock() }
+        guard var condition = self.conditions[key],
+              let cachedFailure = condition.cachedFailure
+        else { return nil }
+        guard self.identityReader(cachedFailure.error.legacyFileURL) == cachedFailure.identity else {
+            // A changed path may be Doctor's source -> claim rename. Keep the condition
+            // open until a full SQLite resolve succeeds, so that rename cannot log recovery.
+            condition.cachedFailure = nil
+            self.conditions[key] = condition
+            return nil
+        }
+        return cachedFailure.error
+    }
+
+    func record(_ error: ExecApprovalsLegacyMigrationRequiredError) {
+        let identity = self.identityReader(error.legacyFileURL)
+        let key = Self.stateDirectoryKey(error.stateDirectoryURL)
+        self.lock.lock()
+        var condition = self.conditions[key] ?? Condition()
+        let shouldLog = condition.loggedIdentities.insert(identity).inserted
+        condition.cachedFailure = identity.map { CachedFailure(error: error, identity: $0) }
+        self.conditions[key] = condition
+        self.lock.unlock()
+        if shouldLog {
+            self.onEvent(.required(error))
+        }
+    }
+
+    func markResolved(stateDirectoryURL: URL) {
+        let key = Self.stateDirectoryKey(stateDirectoryURL)
+        self.lock.lock()
+        let recovered = self.conditions.removeValue(forKey: key) != nil
+        self.lock.unlock()
+        if recovered {
+            self.onEvent(.recovered(stateDirectoryPath: key))
+        }
+    }
+
+    private static func stateDirectoryKey(_ url: URL) -> String {
+        url.standardizedFileURL.path
+    }
+
+    private static func fileIdentity(_ url: URL) -> FileIdentity? {
+        var status = stat()
+        guard lstat(url.path, &status) == 0 else { return nil }
+        return FileIdentity(
+            device: UInt64(truncatingIfNeeded: status.st_dev),
+            inode: UInt64(truncatingIfNeeded: status.st_ino),
+            modificationSeconds: Int64(status.st_mtimespec.tv_sec),
+            modificationNanoseconds: Int64(status.st_mtimespec.tv_nsec))
+    }
+}
+
 enum ExecApprovalsStore {
     private static let logger = Logger(subsystem: "ai.openclaw", category: "exec-approvals")
+    private static let migrationRequiredCache = ExecApprovalsMigrationRequiredCache { event in
+        switch event {
+        case let .required(error):
+            Self.logger.error("exec approvals resolve blocked: \(error.localizedDescription, privacy: .public)")
+        case let .recovered(stateDirectoryPath):
+            Self.logger.info(
+                "exec approvals migration requirement cleared for \(stateDirectoryPath, privacy: .public)")
+        }
+    }
+
     private static let defaultAgentId = "main"
     // Keep omitted-file behavior aligned with the TypeScript gateway/CLI contract.
     private static let defaultSecurity: ExecSecurity = .full
@@ -257,16 +360,24 @@ enum ExecApprovalsStore {
     static func resolveResult(
         agentId: String?) -> Result<ExecApprovalsResolved, ExecApprovalsReadError>
     {
+        let stateDirectoryURL = self.stateDirURL()
+        if let error = self.migrationRequiredCache.cachedError(stateDirectoryURL: stateDirectoryURL) {
+            return .failure(.migrationRequired(error))
+        }
         do {
             let file = try ExecApprovalsSQLiteStore.withImmediateTransaction(
-                stateDirectoryURL: self.stateDirURL())
+                stateDirectoryURL: stateDirectoryURL)
             { record in
                 let ensured = self.ensureFile(record)
                 return ExecApprovalsSQLiteMutation(
                     value: ensured.file,
                     documentToWrite: ensured.needsWrite ? ensured.file : nil)
             }
+            self.migrationRequiredCache.markResolved(stateDirectoryURL: stateDirectoryURL)
             return .success(self.resolveFromFile(file, agentId: agentId))
+        } catch let error as ExecApprovalsLegacyMigrationRequiredError {
+            self.migrationRequiredCache.record(error)
+            return .failure(.migrationRequired(error))
         } catch {
             self.logger.warning("exec approvals resolve failed: \(error.localizedDescription, privacy: .public)")
             return .failure(.unavailable)

--- a/apps/macos/Sources/OpenClaw/SystemRunSettingsView.swift
+++ b/apps/macos/Sources/OpenClaw/SystemRunSettingsView.swift
@@ -473,6 +473,11 @@ extension ExecAsk {
 @MainActor
 @Observable
 final class ExecApprovalsSettingsModel {
+    private enum SettingsReadAttempt {
+        case loaded
+        case failed(ExecApprovalsReadError)
+    }
+
     private static let defaultsScopeId = "__defaults__"
     private static let readUnavailableMessage = "Exec approval settings are unavailable. Retry to refresh."
     @ObservationIgnored private let resolveApprovalsAsync:
@@ -674,11 +679,18 @@ final class ExecApprovalsSettingsModel {
                 }
             }
             guard self.readGeneration == generation, self.selectedAgentId == agentId else { return }
-            if await self.loadSettingsOnceAsync(
+            let attemptResult = await self.loadSettingsOnceAsync(
                 for: agentId,
                 generation: generation)
-            {
+            switch attemptResult {
+            case .loaded:
                 return
+            case let .failed(.migrationRequired(error)):
+                self.policyLoadState = .unavailable(
+                    ExecApprovalsReadError.migrationRequired(error).message)
+                return
+            case .failed(.unavailable):
+                continue
             }
         }
         guard self.readGeneration == generation else { return }
@@ -687,21 +699,33 @@ final class ExecApprovalsSettingsModel {
 
     private func loadSettingsOnceAsync(
         for agentId: String,
-        generation: Int) async -> Bool
+        generation: Int) async -> SettingsReadAttempt
     {
         if agentId == Self.defaultsScopeId {
             let result = await self.resolveDefaultsAsync()
-            guard self.readGeneration == generation, self.selectedAgentId == agentId else { return false }
-            guard case let .success(defaults) = result else { return false }
-            self.apply(defaults: defaults)
-            return true
+            guard self.readGeneration == generation, self.selectedAgentId == agentId else {
+                return .failed(.unavailable)
+            }
+            switch result {
+            case let .success(defaults):
+                self.apply(defaults: defaults)
+                return .loaded
+            case let .failure(error):
+                return .failed(error)
+            }
         }
 
         let result = await self.resolveApprovalsAsync(agentId)
-        guard self.readGeneration == generation, self.selectedAgentId == agentId else { return false }
-        guard case let .success(resolved) = result else { return false }
-        self.apply(resolved: resolved)
-        return true
+        guard self.readGeneration == generation, self.selectedAgentId == agentId else {
+            return .failed(.unavailable)
+        }
+        switch result {
+        case let .success(resolved):
+            self.apply(resolved: resolved)
+            return .loaded
+        case let .failure(error):
+            return .failed(error)
+        }
     }
 
     func setSecurity(_ security: ExecSecurity) {

--- a/apps/macos/Tests/OpenClawIPCTests/ExecApprovalsStoreRefactorTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/ExecApprovalsStoreRefactorTests.swift
@@ -112,6 +112,70 @@ struct ExecApprovalsStoreRefactorTests {
     }
 
     @Test
+    func `migration cache logs once and recovers after the legacy identity clears`() {
+        let stateDirectoryURL = URL(fileURLWithPath: "/tmp/openclaw-migration-cache-test")
+        let legacyFileURL = stateDirectoryURL.appendingPathComponent("exec-approvals.json")
+        let error = ExecApprovalsLegacyMigrationRequiredError(
+            stateDirectoryURL: stateDirectoryURL,
+            legacyFileURL: legacyFileURL)
+        var identity: ExecApprovalsMigrationRequiredCache.FileIdentity? = .init(
+            device: 1,
+            inode: 2,
+            modificationSeconds: 3,
+            modificationNanoseconds: 4)
+        var identityReadCount = 0
+        var events: [ExecApprovalsMigrationLogEvent] = []
+        let cache = ExecApprovalsMigrationRequiredCache(
+            identityReader: { _ in
+                identityReadCount += 1
+                return identity
+            },
+            onEvent: { events.append($0) })
+
+        cache.record(error)
+        #expect(cache.cachedError(stateDirectoryURL: stateDirectoryURL) == error)
+        #expect(cache.cachedError(stateDirectoryURL: stateDirectoryURL) == error)
+        #expect(identityReadCount == 3)
+        #expect(events == [.required(error)])
+
+        identity = nil
+        #expect(cache.cachedError(stateDirectoryURL: stateDirectoryURL) == nil)
+        cache.markResolved(stateDirectoryURL: stateDirectoryURL)
+        #expect(identityReadCount == 4)
+        #expect(events == [
+            .required(error),
+            .recovered(stateDirectoryPath: stateDirectoryURL.path),
+        ])
+    }
+
+    @Test
+    func `legacy migration failure is typed and removal recovers without restart`() async throws {
+        try await self.withTempHomeAndStateDir { _, stateDirectoryURL in
+            let legacyFileURL = stateDirectoryURL.appendingPathComponent("exec-approvals.json")
+            try FileManager.default.createDirectory(
+                at: stateDirectoryURL,
+                withIntermediateDirectories: true)
+            try Data(#"{"version":1,"agents":{}}"#.utf8).write(to: legacyFileURL)
+
+            let first = ExecApprovalsStore.resolveResult(agentId: "main")
+            guard case .failure(.migrationRequired) = first else {
+                Issue.record("expected typed migration-required failure")
+                return
+            }
+            let second = ExecApprovalsStore.resolveResult(agentId: "main")
+            guard case .failure(.migrationRequired) = second else {
+                Issue.record("expected cached migration-required failure")
+                return
+            }
+
+            try FileManager.default.removeItem(at: legacyFileURL)
+            let recovered = try ExecApprovalsStore.resolveResult(agentId: "main").get()
+            #expect(recovered.agent.security == .full)
+            #expect(recovered.agent.ask == .off)
+        }
+    }
+
+    @Test
     func `effective home owns the default approvals database and socket paths`() async throws {
         let root = self.realTemporaryDirectory
             .appendingPathComponent("openclaw-effective-home-\(UUID().uuidString)", isDirectory: true)

--- a/apps/macos/Tests/OpenClawIPCTests/ExecApprovalsUIRollbackTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/ExecApprovalsUIRollbackTests.swift
@@ -8,6 +8,42 @@ import Testing
 @MainActor
 struct ExecApprovalsUIRollbackTests {
     @Test
+    func `migration requirement surfaces without automatic retry`() async throws {
+        try await self.withTempStateDir { stateDirectoryURL in
+            let migrationError = ExecApprovalsLegacyMigrationRequiredError(
+                stateDirectoryURL: stateDirectoryURL,
+                legacyFileURL: stateDirectoryURL.appendingPathComponent("exec-approvals.json"))
+            var quickModeReadCount = 0
+            let state = AppState(
+                preview: true,
+                execApprovalsDefaultsAsyncResolver: {
+                    quickModeReadCount += 1
+                    return .failure(.migrationRequired(migrationError))
+                },
+                execApprovalsReadRetryDelay: .zero)
+
+            await state.recoverExecApprovalModeRead(maxAttempts: 5)
+
+            #expect(quickModeReadCount == 1)
+            #expect(state.execApprovalLoadError == ExecApprovalsReadError.migrationRequired(migrationError).message)
+
+            var settingsReadCount = 0
+            let model = ExecApprovalsSettingsModel(
+                resolveApprovalsAsync: { _ in
+                    settingsReadCount += 1
+                    return .failure(.migrationRequired(migrationError))
+                },
+                readRetryDelay: .zero,
+                automaticReadRetryAttempts: 5)
+
+            await model.loadSettings(for: "main")
+
+            #expect(settingsReadCount == 1)
+            #expect(model.readErrorMessage == ExecApprovalsReadError.migrationRequired(migrationError).message)
+        }
+    }
+
+    @Test
     func `quick mode recovers after initial approvals read is unavailable`() async throws {
         try await self.withTempStateDir { stateDir in
             _ = try ExecApprovalsStore.updateDefaults { defaults in

--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/ExecApprovalsLegacyMigrationGate.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/ExecApprovalsLegacyMigrationGate.swift
@@ -1,5 +1,25 @@
 import Foundation
 
+public struct ExecApprovalsLegacyMigrationRequiredError: LocalizedError, Equatable, Sendable {
+    public let stateDirectoryURL: URL
+    public let legacyFileURL: URL
+
+    public init(stateDirectoryURL: URL, legacyFileURL: URL) {
+        self.stateDirectoryURL = stateDirectoryURL
+        self.legacyFileURL = legacyFileURL
+    }
+
+    public var errorDescription: String? {
+        "Legacy exec approvals exist at \(self.legacyFileURL.path). " +
+            // Doctor repairs whichever state directory its own environment resolves to,
+            // and an app store never shares the CLI's default root, so always name the
+            // directory; a bare `doctor --fix` would repair a different one. Prose,
+            // not a `VAR=value cmd` one-liner, so the path needs no shell quoting.
+            "Run `openclaw doctor --fix` with OPENCLAW_STATE_DIR set to " +
+            "\(self.stateDirectoryURL.path) before using exec approvals."
+    }
+}
+
 enum ExecApprovalsLegacyMigrationGate {
     private static let doctorClaimSuffix = ".doctor-importing"
 
@@ -19,23 +39,14 @@ enum ExecApprovalsLegacyMigrationGate {
         let claimURL = URL(fileURLWithPath: sourceURL.path + self.doctorClaimSuffix)
         // Probe source on both sides of the claim so neither Doctor's source -> claim
         // rename nor its claim -> source recovery can pass through an absent window.
-        guard !pathMayExist(sourceURL),
-              !pathMayExist(claimURL),
-              !pathMayExist(sourceURL)
-        else {
-            throw NSError(
-                domain: "ai.openclaw.exec-approvals-store",
-                code: 1,
-                userInfo: [
-                    NSLocalizedDescriptionKey:
-                        "Legacy exec approvals exist at \(sourceURL.path). " +
-                        // Doctor repairs whichever state directory its own environment resolves to,
-                        // and an app store never shares the CLI's default root, so always name the
-                        // directory; a bare `doctor --fix` would repair a different one. Prose,
-                        // not a `VAR=value cmd` one-liner, so the path needs no shell quoting.
-                        "Run `openclaw doctor --fix` with OPENCLAW_STATE_DIR set to " +
-                        "\(stateDirectoryURL.path) before using exec approvals.",
-                ])
+        let sourceBeforeClaim = pathMayExist(sourceURL)
+        let claimExists = pathMayExist(claimURL)
+        let sourceAfterClaim = pathMayExist(sourceURL)
+        guard !sourceBeforeClaim, !claimExists, !sourceAfterClaim else {
+            let legacyFileURL = sourceBeforeClaim || sourceAfterClaim ? sourceURL : claimURL
+            throw ExecApprovalsLegacyMigrationRequiredError(
+                stateDirectoryURL: stateDirectoryURL,
+                legacyFileURL: legacyFileURL)
         }
     }
 

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ExecApprovalsSQLiteStoreTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ExecApprovalsSQLiteStoreTests.swift
@@ -212,13 +212,17 @@ struct ExecApprovalsSQLiteStoreTests {
             do {
                 _ = try ExecApprovalsSQLiteStore.read(stateDirectoryURL: stateDirectoryURL)
                 Issue.record("Expected pending legacy approvals to refuse SQLite access")
-            } catch {
+            } catch let error as ExecApprovalsLegacyMigrationRequiredError {
+                #expect(error.stateDirectoryURL == stateDirectoryURL)
+                #expect(error.legacyFileURL == legacyURL)
                 // The blocked state directory must be named; a bare command repairs the
                 // default root, and an app store never shares the CLI's default root.
                 #expect(
                     error.localizedDescription.contains(
                         "Run `openclaw doctor --fix` with OPENCLAW_STATE_DIR set to "
                             + stateDirectoryURL.path))
+            } catch {
+                Issue.record("Expected typed migration error, got \(error)")
             }
         }
     }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the macOS app retried a permanent exec-approvals migration gate once per second, repeatedly opening SQLite and crossing TCC/container boundaries while emitting about 86,400 warning lines per day. The affected menu-bar and settings surfaces only reported that approvals were unavailable, so operators were not told how to clear the condition.

## Why This Change Was Made

The shared migration gate now throws a typed error. The macOS store maps it to a distinct read failure, logs each state-directory/file identity once at error level, and short-circuits unchanged retries with one `lstat`; a successful normal resolve emits one recovery line. The existing menu-bar error row and Exec Approvals settings unavailable panel surface the exact state directory for `openclaw doctor --fix`. This does not run Doctor, weaken the gate, or change TypeScript behavior.

AI-assisted implementation; the final uncommitted bundle passed Codex autoreview after one accepted remediation-message finding was fixed.

## User Impact

Operators with legacy exec approvals no longer get a 1 Hz CPU/log storm. Exec policy remains fail-closed, the app explains which state directory needs migration, and normal resolution resumes without restarting the app after Doctor removes the legacy file.

## Evidence

Live incident excerpt from megaclaw on 2026-07-28:

```text
[ai.openclaw:exec-approvals] exec approvals resolve failed: Legacy exec approvals exist
at ~/.openclaw-clawmac-node/exec-approvals.json. Run `openclaw doctor --fix` ...
```

Shared package focused test:

```text
$ cd apps/shared/OpenClawKit && swift test --filter ExecApprovals 2>&1 | tail -20
Test "legacy source or Doctor claim refuses SQLite access" with 2 test cases passed after 0.006 seconds.
Suite ExecApprovalsSQLiteStoreTests passed after 0.026 seconds.
Test run with 9 tests in 1 suite passed after 0.026 seconds.
```

Additional proof:

```text
$ cd apps/macos && swift build --product OpenClaw
Build complete! (48.96 sec)

$ ./scripts/lint-swift.sh macos
Done linting! Found 0 violations, 0 serious.

$ swiftformat --lint <8 touched Swift files> --config config/swiftformat
0/8 files require formatting.

$ autoreview --mode uncommitted
autoreview clean: no accepted/actionable findings reported
```

The macOS app-target test command was attempted twice:

```text
$ cd apps/macos && swift test --filter ExecApprovals
Build complete! (382.78 sec)
error: Library not loaded: @rpath/Sparkle.framework/Versions/B/Sparkle
```

Retrying with `DYLD_FRAMEWORK_PATH` reached the same SwiftPM test-bundle loader error. The production app and test sources compiled before the loader failure; no third workaround was attempted.
