### PR TITLE
refactor(ui): remove duplicate dashboard widget paths

### DIFF
--- a/ui/src/lib/board/gateway-provider.ts
+++ b/ui/src/lib/board/gateway-provider.ts
@@ -139,32 +139,25 @@ export class GatewayBoardProvider implements BoardProvider {
     });
   }
 
-  async pinWidget(input: BoardPinWidgetInput): Promise<void> {
-    const name = input.name ?? canvasWidgetNameForDocument(input.docId);
-    const title = normalizeBoardWidgetTitle(input.title);
-    await this.mutate(
-      "board.widget.put",
-      {
-        sessionKey: this.sessionKey,
-        name,
-        ...(title ? { title } : {}),
-        content: { kind: "canvas-doc", docId: input.docId },
-        ...(input.tabId || input.size || input.after
-          ? {
-              placement: {
-                ...(input.tabId ? { tabId: input.tabId } : {}),
-                ...(input.size ? { size: input.size } : {}),
-                ...(input.after ? { after: input.after } : {}),
-              },
-            }
-          : {}),
-      },
-      name,
-    );
+  pinWidget(input: BoardPinWidgetInput): Promise<void> {
+    return this.pinBoardWidget(input, input.name ?? canvasWidgetNameForDocument(input.docId), {
+      kind: "canvas-doc",
+      docId: input.docId,
+    });
   }
 
-  async pinMcpApp(input: BoardPinMcpAppInput): Promise<void> {
-    const name = input.name ?? mcpAppWidgetNameForViewId(input.viewId);
+  pinMcpApp(input: BoardPinMcpAppInput): Promise<void> {
+    return this.pinBoardWidget(input, input.name ?? mcpAppWidgetNameForViewId(input.viewId), {
+      kind: "mcp-app",
+      viewId: input.viewId,
+    });
+  }
+
+  private async pinBoardWidget(
+    input: BoardPinWidgetInput | BoardPinMcpAppInput,
+    name: string,
+    content: { kind: "canvas-doc"; docId: string } | { kind: "mcp-app"; viewId: string },
+  ): Promise<void> {
     const title = normalizeBoardWidgetTitle(input.title);
     await this.mutate(
       "board.widget.put",
@@ -172,7 +165,7 @@ export class GatewayBoardProvider implements BoardProvider {
         sessionKey: this.sessionKey,
         name,
         ...(title ? { title } : {}),
-        content: { kind: "mcp-app", viewId: input.viewId },
+        content,
         ...(input.tabId || input.size || input.after
           ? {
               placement: {

--- a/ui/src/lib/board/provider.ts
+++ b/ui/src/lib/board/provider.ts
@@ -164,42 +164,21 @@ class MockBoardProvider implements BoardProvider {
   }
 
   async pinWidget(input: BoardPinWidgetInput): Promise<void> {
-    const snapshot = this.snapshotSignal.value;
     const name = input.name ?? canvasWidgetNameForDocument(input.docId);
-    const title = normalizeBoardWidgetTitle(input.title);
-    const tabId = input.tabId ?? snapshot.tabs[0]?.tabId ?? "main";
-    const tabs = snapshot.tabs.length
-      ? snapshot.tabs
-      : [
-          {
-            tabId: "main",
-            title: t("chat.board.defaultTab"),
-            position: 0,
-            chatDock: "right" as const,
-          },
-        ];
-    const existing = snapshot.widgets.find((widget) => widget.name === name);
-    const widgets = snapshot.widgets.filter((widget) => widget.name !== name);
-    widgets.push({
-      name,
-      tabId,
-      ...(title ? { title } : {}),
-      contentKind: "html",
-      sizeW: existing?.sizeW ?? 6,
-      sizeH: existing?.sizeH ?? 4,
-      position: existing?.position ?? widgets.filter((widget) => widget.tabId === tabId).length,
-      grantState: "none",
-      revision: (existing?.revision ?? 0) + 1,
-      frameUrl: `about:blank#board-widget=${encodeURIComponent(name)}`,
-    });
-    this.snapshotSignal.set(
-      normalizeMockBoardSnapshot({ ...snapshot, revision: snapshot.revision + 1, tabs, widgets }),
-    );
+    this.pinMockBoardWidget(input, name, "html");
   }
 
   async pinMcpApp(input: BoardPinMcpAppInput): Promise<void> {
-    const snapshot = this.snapshotSignal.value;
     const name = input.name ?? mcpAppWidgetNameForViewId(input.viewId);
+    this.pinMockBoardWidget(input, name, "mcp-app");
+  }
+
+  private pinMockBoardWidget(
+    input: BoardPinWidgetInput | BoardPinMcpAppInput,
+    name: string,
+    contentKind: "html" | "mcp-app",
+  ): void {
+    const snapshot = this.snapshotSignal.value;
     const title = normalizeBoardWidgetTitle(input.title);
     const tabId = input.tabId ?? snapshot.tabs[0]?.tabId ?? "main";
     const tabs = snapshot.tabs.length
@@ -218,20 +197,18 @@ class MockBoardProvider implements BoardProvider {
       name,
       tabId,
       ...(title ? { title } : {}),
-      contentKind: "mcp-app",
+      contentKind,
       sizeW: existing?.sizeW ?? 6,
       sizeH: existing?.sizeH ?? 4,
       position: existing?.position ?? widgets.filter((widget) => widget.tabId === tabId).length,
       grantState: "none",
       revision: (existing?.revision ?? 0) + 1,
+      ...(contentKind === "html"
+        ? { frameUrl: `about:blank#board-widget=${encodeURIComponent(name)}` }
+        : {}),
     });
     this.snapshotSignal.set(
-      normalizeMockBoardSnapshot({
-        ...snapshot,
-        revision: snapshot.revision + 1,
-        tabs,
-        widgets,
-      }),
+      normalizeMockBoardSnapshot({ ...snapshot, revision: snapshot.revision + 1, tabs, widgets }),
     );
   }
 

--- a/ui/src/pages/chat/chat-pane-board.test.ts
+++ b/ui/src/pages/chat/chat-pane-board.test.ts
@@ -111,6 +111,42 @@ function createTestPane(sessions: SessionCapability = {} as SessionCapability) {
   return pane;
 }
 
+function createGatewayBoardPane(params: {
+  sessionKey: string;
+  methods?: readonly string[];
+  scopes?: readonly string[];
+  capabilities?: readonly string[];
+  lifecycleConnected?: boolean;
+}) {
+  window.history.replaceState({}, "", "/");
+  const pane = createTestPane();
+  const snapshot = { sessionKey: params.sessionKey, revision: 1, tabs: [], widgets: [] };
+  const removeListener = vi.fn();
+  const request = vi.fn(async () => snapshot);
+  const addEventListener = vi.fn(() => removeListener);
+  const client = { request, addEventListener } as unknown as GatewayBrowserClient;
+  pane.state.sessionKey = params.sessionKey;
+  pane.state.client = client;
+  Reflect.set(pane, "boardProviderLifecycleConnected", params.lifecycleConnected ?? true);
+  pane.context = {
+    ...pane.context,
+    gateway: {
+      snapshot: {
+        client,
+        phase: "connected",
+        hello: {
+          ...(params.scopes ? { auth: { role: "operator", scopes: params.scopes } } : {}),
+          features: {
+            methods: params.methods ?? ["board.get"],
+            ...(params.capabilities ? { capabilities: params.capabilities } : {}),
+          },
+        },
+      },
+    },
+  } as unknown as ApplicationContext;
+  return { pane, snapshot, client, request, addEventListener, removeListener };
+}
+
 beforeEach(() => {
   vi.stubGlobal("localStorage", createStorageMock());
   vi.stubGlobal("sessionStorage", createStorageMock());
@@ -535,28 +571,12 @@ describe("chat pane board shell", () => {
   });
 
   it("does not subscribe to a gateway board before the pane owns a lifecycle lease", async () => {
-    window.history.replaceState({}, "", "/");
-    const pane = createTestPane();
     const sessionKey = "agent:main:board-lifecycle-ownership";
-    const snapshot = { sessionKey, revision: 1, tabs: [], widgets: [] };
-    const removeListener = vi.fn();
-    const request = vi.fn(async () => snapshot);
-    const addEventListener = vi.fn(() => removeListener);
-    const client = { request, addEventListener } as unknown as GatewayBrowserClient;
-    pane.state.sessionKey = sessionKey;
-    pane.context = {
-      ...pane.context,
-      gateway: {
-        snapshot: {
-          client,
-          phase: "connected",
-          hello: {
-            auth: { role: "operator", scopes: ["operator.read", "operator.write"] },
-            features: { methods: ["board.get"] },
-          },
-        },
-      },
-    } as unknown as ApplicationContext;
+    const { pane, snapshot, request, addEventListener, removeListener } = createGatewayBoardPane({
+      sessionKey,
+      scopes: ["operator.read", "operator.write"],
+      lifecycleConnected: false,
+    });
 
     expect(pane.resolveBoardProvider().snapshot$.value.sessionKey).toBe(sessionKey);
     expect(request).not.toHaveBeenCalled();
@@ -577,24 +597,10 @@ describe("chat pane board shell", () => {
   });
 
   it("keeps gateways without board support on the null provider", () => {
-    window.history.replaceState({}, "", "/");
-    const pane = createTestPane();
-    const sessionKey = "agent:main:board-unsupported";
-    const request = vi.fn();
-    const addEventListener = vi.fn(() => () => {});
-    const client = { request, addEventListener } as unknown as GatewayBrowserClient;
-    pane.state.sessionKey = sessionKey;
-    Reflect.set(pane, "boardProviderLifecycleConnected", true);
-    pane.context = {
-      ...pane.context,
-      gateway: {
-        snapshot: {
-          client,
-          phase: "connected",
-          hello: { features: { methods: ["chat.history"] } },
-        },
-      },
-    } as unknown as ApplicationContext;
+    const { pane, request, addEventListener } = createGatewayBoardPane({
+      sessionKey: "agent:main:board-unsupported",
+      methods: ["chat.history"],
+    });
 
     expect(pane.resolveBoardProvider()).toMatchObject({
       canMutate: false,
@@ -607,25 +613,11 @@ describe("chat pane board shell", () => {
   });
 
   it("does not reuse another board lease after gateway board support disappears", () => {
-    window.history.replaceState({}, "", "/");
-    const pane = createTestPane();
     const sessionKey = "agent:main:board-support-revoked";
-    const snapshot = { sessionKey, revision: 1, tabs: [], widgets: [] };
-    const request = vi.fn(async () => snapshot);
-    const addEventListener = vi.fn(() => () => {});
-    const client = { request, addEventListener } as unknown as GatewayBrowserClient;
-    pane.state.sessionKey = sessionKey;
-    Reflect.set(pane, "boardProviderLifecycleConnected", true);
-    pane.context = {
-      ...pane.context,
-      gateway: {
-        snapshot: {
-          client,
-          phase: "connected",
-          hello: { features: { methods: ["chat.history"] } },
-        },
-      },
-    } as unknown as ApplicationContext;
+    const { pane, client, addEventListener } = createGatewayBoardPane({
+      sessionKey,
+      methods: ["chat.history"],
+    });
 
     const otherConsumer = acquireBoardProviderForSession(sessionKey, client);
     try {
@@ -642,7 +634,6 @@ describe("chat pane board shell", () => {
   });
 
   it("enables MCP App pinning only when app-view and put methods are both advertised", () => {
-    window.history.replaceState({}, "", "/");
     const cases = [
       { suffix: "put-only", methods: ["board.get", "board.widget.put"], expected: false },
       { suffix: "view-only", methods: ["board.get", "board.widget.appView"], expected: false },
@@ -654,62 +645,27 @@ describe("chat pane board shell", () => {
     ];
 
     for (const testCase of cases) {
-      const pane = createTestPane();
-      Reflect.set(pane, "boardProviderLifecycleConnected", true);
-      const sessionKey = `agent:main:${testCase.suffix}`;
-      const client = {
-        request: vi.fn(async () => ({ sessionKey, revision: 0, tabs: [], widgets: [] })),
-        addEventListener: vi.fn(() => () => {}),
-      } as unknown as GatewayBrowserClient;
-      pane.state.sessionKey = sessionKey;
-      pane.context = {
-        ...pane.context,
-        gateway: {
-          ...pane.context.gateway,
-          snapshot: {
-            client,
-            phase: "connected",
-            hello: { features: { methods: testCase.methods } },
-          } as never,
-        },
-      };
-
+      const { pane } = createGatewayBoardPane({
+        sessionKey: `agent:main:${testCase.suffix}`,
+        methods: testCase.methods,
+      });
       expect(pane.resolveBoardProvider().canPinMcpApps).toBe(testCase.expected);
     }
   });
 
   it("updates chat authorization without changing another consumer of the same board", async () => {
-    window.history.replaceState({}, "", "/");
-    const pane = createTestPane();
     const sessionKey = "agent:main:chat-lease-scope-change";
-    const snapshot = { sessionKey, revision: 1, tabs: [], widgets: [] };
-    const removeListener = vi.fn();
-    const request = vi.fn(async () => snapshot);
-    const addEventListener = vi.fn(() => removeListener);
-    const client = {
-      request,
-      addEventListener,
-    } as unknown as GatewayBrowserClient;
     const features = {
       methods: ["board.get", "board.widget.appView", "board.widget.put"],
       capabilities: ["board-widget-put-canvas-doc"],
     };
-    pane.state.sessionKey = sessionKey;
-    pane.state.client = client;
-    Reflect.set(pane, "boardProviderLifecycleConnected", true);
-    pane.context = {
-      ...pane.context,
-      gateway: {
-        snapshot: {
-          client,
-          phase: "connected",
-          hello: {
-            auth: { role: "operator", scopes: ["operator.read", "operator.write"] },
-            features,
-          },
-        },
-      },
-    } as unknown as ApplicationContext;
+    const { pane, snapshot, client, request, addEventListener, removeListener } =
+      createGatewayBoardPane({
+        sessionKey,
+        scopes: ["operator.read", "operator.write"],
+        methods: features.methods,
+        capabilities: features.capabilities,
+      });
     const chat = pane.resolveBoardProvider();
     const approvals = acquireBoardProviderForSession(
       sessionKey,
@@ -788,33 +744,12 @@ describe("chat pane board shell", () => {
       canGrant: true,
     },
   ])("derives board actions from the $profile connection scopes", (profile) => {
-    window.history.replaceState({}, "", "/");
-    const pane = createTestPane();
-    Reflect.set(pane, "boardProviderLifecycleConnected", true);
-    const sessionKey = `agent:main:scope-${profile.profile.replaceAll(" ", "-")}`;
-    const client = {
-      request: vi.fn(async () => ({ sessionKey, revision: 0, tabs: [], widgets: [] })),
-      addEventListener: vi.fn(() => () => {}),
-    } as unknown as GatewayBrowserClient;
-    pane.state.sessionKey = sessionKey;
-    pane.context = {
-      ...pane.context,
-      gateway: {
-        ...pane.context.gateway,
-        snapshot: {
-          client,
-          phase: "connected",
-          hello: {
-            auth: { role: "operator", scopes: profile.scopes },
-            features: {
-              methods: ["board.get", "board.widget.appView", "board.widget.put"],
-              capabilities: ["board-widget-put-canvas-doc"],
-            },
-          },
-        } as never,
-      },
-    };
-
+    const { pane } = createGatewayBoardPane({
+      sessionKey: `agent:main:scope-${profile.profile.replaceAll(" ", "-")}`,
+      scopes: profile.scopes,
+      methods: ["board.get", "board.widget.appView", "board.widget.put"],
+      capabilities: ["board-widget-put-canvas-doc"],
+    });
     const provider = pane.resolveBoardProvider();
     expect(provider.canMutate).toBe(profile.canMutate);
     expect(provider.canGrant).toBe(profile.canGrant);


### PR DESCRIPTION
Related: #115364, #115457

AI-assisted; independently reviewed using the repository's structured autoreview workflow.

## What Problem This Solves

Fixes an issue where session dashboards maintained separate, nearly identical canvas-widget and MCP-app pinning paths in both live Gateway and mock providers. Their request construction, title normalization, widget placement, revision updates, and mock frame handling could silently drift. The dashboard ownership regressions also rebuilt the same Gateway fixture in six places.

## Why This Change Was Made

Complete the dashboard ownership refactor with one canonical live widget-put path, one canonical mock widget-pinning path, and one reusable mounted Gateway fixture for lifecycle and authorization regressions. Preserve the exact wire payload, widget names, capability gates, mock snapshots, release behavior, and every existing regression scenario.

## User Impact

Canvas widgets and MCP apps behave consistently when pinned, replaced, or rendered in a dashboard. Gateway requests remain unchanged, mock dashboards stay in sync with live dashboard behavior, and chat/Workboard permission and subscription lifecycle protections remain covered.

## Evidence

- Exact complete diff: **+99/-194, 95 fewer lines overall** across three files.
- Production code: **30 fewer lines**. Test code: **65 fewer lines**, with no deleted test scenarios.
- Focused proof: `node scripts/run-vitest.mjs run --config test/vitest/vitest.ui.config.ts --configLoader runner --reporter=dot ui/src/lib/board/provider.test.ts ui/src/lib/board/gateway-provider.test.ts ui/src/lib/board/availability-controller.test.ts ui/src/lib/board/provider.mcp-app.test.ts ui/src/pages/chat/chat-pane-board.test.ts ui/src/pages/chat/board-session-surface.test.ts ui/src/pages/workboard/workboard-card-dashboard.test.ts` — **7 suites, 91 tests passed**.
- Oxfmt, type-aware Oxlint, `git diff --check`, and fresh structured autoreview all passed.
- Review confirmed the canvas/MCP wire contract, generated widget names, normalized titles, placement, tickets, mock frame URLs, snapshot revisions, independent dashboard permissions, unsupported Gateways, and one-time subscription cleanup.
- No configuration, gateway protocol, migration, database, public SDK, dependency, or generated-file changes.
