### PR TITLE
fix(agents): memoize exec auto-reviewer verdicts for identical requests (#102249)

### DIFF
--- a/src/agents/bash-tools.exec-run.ts
+++ b/src/agents/bash-tools.exec-run.ts
@@ -14,6 +14,7 @@ import {
   resolveExecApprovalsFromFile,
   resolveExecModePolicy,
 } from "../infra/exec-approvals.js";
+import type { ExecAutoReviewDecision } from "../infra/exec-auto-review.js";
 import {
   rejectUnsafeExecControlShellCommand,
   rejectUnsafeExecLiveStateSqliteShellCommand,
@@ -104,6 +105,10 @@ export function createExecTool(
 ): AgentToolWithMeta<typeof execSchema, ExecToolDetails> {
   const secretEgressEnabled = isSecretEgressProxyActive();
   const preparedRunEnvironment = resolveExecPreparedRunEnvironment(defaults);
+  // Run-scoped verdict memo: persists across exec invocations within the same
+  // agent run so identical exec requests reuse the reviewer's verdict instead
+  // of re-issuing paid model completions. FIFO-capped inside the reviewer.
+  const verdictMemo = new Map<string, ExecAutoReviewDecision>();
   // Agent runs own one tool instance, so the store is read on first exec and reused for that run.
   // A new run constructs a new instance and observes later store mutations.
   let storeEnvPromise: Promise<SecretStoreExecEnvironment>;
@@ -209,6 +214,7 @@ export function createExecTool(
           agentId,
           reviewer: resolveExecReviewerDefaults({ defaults, agentId }),
           signal,
+          verdictMemo,
         });
       let params = requestPreparation.normalizeParams(args);
       const resolveExecEnvPrepared = requestPreparation.isResolveExecEnvPrepared(

--- a/src/agents/bash-tools.exec-run.ts
+++ b/src/agents/bash-tools.exec-run.ts
@@ -13,6 +13,7 @@ import {
   resolveExecApprovalsFromFile,
   resolveExecModePolicy,
 } from "../infra/exec-approvals.js";
+import type { ExecAutoReviewDecision } from "../infra/exec-auto-review.js";
 import { rejectUnsafeExecControlShellCommand } from "../infra/exec-control-command-guard.js";
 import { resolveExecSafeBinRuntimePolicy } from "../infra/exec-safe-bin-runtime-policy.js";
 import { logInfo } from "../logger.js";
@@ -66,6 +67,10 @@ import type { AgentToolWithMeta } from "./tools/common.js";
 export function createExecTool(
   defaults?: ExecToolDefaults,
 ): AgentToolWithMeta<typeof execSchema, ExecToolDetails> {
+  // Run-scoped verdict memo: persists across exec invocations within the same
+  // agent run so identical exec requests reuse the reviewer's verdict instead
+  // of re-issuing paid model completions. FIFO-capped inside the reviewer.
+  const verdictMemo = new Map<string, ExecAutoReviewDecision>();
   const defaultBackgroundMs = clampWithDefault(
     defaults?.backgroundMs ?? readEnvInt("OPENCLAW_BASH_YIELD_MS", "PI_BASH_YIELD_MS"),
     10_000,
@@ -161,6 +166,7 @@ export function createExecTool(
           agentId,
           reviewer: resolveExecReviewerDefaults({ defaults, agentId }),
           signal,
+          verdictMemo,
         });
       let params = requestPreparation.normalizeParams(args);
       const resolveExecEnvPrepared = requestPreparation.isResolveExecEnvPrepared(

--- a/src/agents/exec-auto-reviewer.test.ts
+++ b/src/agents/exec-auto-reviewer.test.ts
@@ -881,14 +881,16 @@ describe("createModelExecAutoReviewer", () => {
     expect(complete).toHaveBeenCalledTimes(2);
   });
 
-  it("never reuses gateway review authority for a node-host request", async () => {
+  it("bills a fresh completion for each real node-host review", async () => {
     const { reviewer, prepare, complete } = createReviewerHarness();
-    const nodeInput = { ...input, host: "node" as const };
+    // The real node host invokes the reviewer with no resolvedPath (the
+    // gateway cannot resolve the remote node executable and the remote
+    // prepare result exposes no resolved executable identity), so a node-host
+    // request never forms a memo key and must bill its own completion every
+    // time rather than silently reusing gateway-shaped memo coverage.
+    const nodeInput = { ...input, host: "node" as const, resolvedPath: undefined };
 
-    // A gateway verdict must not satisfy a node-host request: host is part of
-    // the memo key, so the node request bills its own completion rather than
-    // reusing the gateway authority.
-    await reviewer(input);
+    await reviewer(nodeInput);
     await reviewer(nodeInput);
 
     expect(prepare).toHaveBeenCalledTimes(2);

--- a/src/agents/exec-auto-reviewer.test.ts
+++ b/src/agents/exec-auto-reviewer.test.ts
@@ -821,6 +821,9 @@ describe("createModelExecAutoReviewer", () => {
   it("keeps repeated gateway reviews bound to one-shot approval", async () => {
     const { reviewer, prepare, complete } = createReviewerHarness();
 
+    // An identical repeated request reuses the memoized verdict, but the
+    // decision is still allow-once: the single-use approval is registered by
+    // the caller per invocation, not extended by the memo.
     await expect(reviewer(input)).resolves.toMatchObject({
       decision: "allow-once",
       risk: "low",
@@ -830,8 +833,8 @@ describe("createModelExecAutoReviewer", () => {
       risk: "low",
     });
 
-    expect(prepare).toHaveBeenCalledTimes(2);
-    expect(complete).toHaveBeenCalledTimes(2);
+    expect(prepare).toHaveBeenCalledTimes(1);
+    expect(complete).toHaveBeenCalledTimes(1);
   });
 
   it("keeps simultaneous gateway approvals one-shot under concurrency", async () => {
@@ -882,7 +885,10 @@ describe("createModelExecAutoReviewer", () => {
     const { reviewer, prepare, complete } = createReviewerHarness();
     const nodeInput = { ...input, host: "node" as const };
 
-    await reviewer(nodeInput);
+    // A gateway verdict must not satisfy a node-host request: host is part of
+    // the memo key, so the node request bills its own completion rather than
+    // reusing the gateway authority.
+    await reviewer(input);
     await reviewer(nodeInput);
 
     expect(prepare).toHaveBeenCalledTimes(2);
@@ -908,5 +914,110 @@ describe("createModelExecAutoReviewer", () => {
 
     expect(prepare).toHaveBeenCalledTimes(2);
     expect(complete).toHaveBeenCalledTimes(2);
+  });
+
+  it("memoizes allow-once verdicts for identical exec requests", async () => {
+    const complete = vi.fn(async () => ({
+      content: [
+        {
+          type: "text",
+          text: JSON.stringify({
+            decision: "allow",
+            risk: "low",
+            rationale: "read-only inspection",
+          }),
+        },
+      ],
+      stopReason: "stop",
+    }));
+    const reviewer = createModelExecAutoReviewer({
+      cfg: {},
+      deps: {
+        prepareSimpleCompletionModelForAgent: vi.fn(async () => ({
+          selection: { provider: "openai", modelId: "gpt-5.5", agentDir: "/agent" },
+          model: { provider: "openai", id: "gpt-5.5", api: "openai-responses" },
+          auth: { apiKey: "sk-test", mode: "env" },
+        })) as unknown as typeof import("./simple-completion-runtime.js").prepareSimpleCompletionModelForAgent,
+        completeWithPreparedSimpleCompletionModel:
+          complete as unknown as typeof import("./simple-completion-runtime.js").completeWithPreparedSimpleCompletionModel,
+      },
+    });
+
+    // First call: model is called.
+    const result1 = await reviewer(input);
+    expect(result1).toEqual({
+      decision: "allow-once",
+      risk: "low",
+      rationale: "read-only inspection",
+    });
+    expect(complete).toHaveBeenCalledTimes(1);
+
+    // Second call with identical input: served from memo, no additional model call.
+    const result2 = await reviewer(input);
+    expect(result2).toEqual({
+      decision: "allow-once",
+      risk: "low",
+      rationale: "read-only inspection",
+    });
+    expect(complete).toHaveBeenCalledTimes(1);
+
+    // Different command: model is called again.
+    const result3 = await reviewer({ ...input, command: "npm test", argv: ["npm", "test"] });
+    expect(result3).toEqual({
+      decision: "allow-once",
+      risk: "low",
+      rationale: "read-only inspection",
+    });
+    expect(complete).toHaveBeenCalledTimes(2);
+
+    // Different host: model is called again (different memo key).
+    const result4 = await reviewer({ ...input, host: "node" });
+    expect(result4).toEqual({
+      decision: "allow-once",
+      risk: "low",
+      rationale: "read-only inspection",
+    });
+    expect(complete).toHaveBeenCalledTimes(3);
+  });
+
+  it("evicts oldest memo entry when cap is reached", async () => {
+    const complete = vi.fn(async () => ({
+      content: [
+        {
+          type: "text",
+          text: JSON.stringify({ decision: "allow", risk: "low", rationale: "ok" }),
+        },
+      ],
+    }));
+    const reviewer = createModelExecAutoReviewer({
+      cfg: {},
+      deps: {
+        prepareSimpleCompletionModelForAgent: vi.fn(async () => ({
+          selection: { provider: "openai", modelId: "gpt-5.5", agentDir: "/agent" },
+          model: { provider: "openai", id: "gpt-5.5", api: "openai-responses" },
+          auth: { apiKey: "sk-test", mode: "env" },
+        })) as unknown as typeof import("./simple-completion-runtime.js").prepareSimpleCompletionModelForAgent,
+        completeWithPreparedSimpleCompletionModel:
+          complete as unknown as typeof import("./simple-completion-runtime.js").completeWithPreparedSimpleCompletionModel,
+      },
+    });
+
+    // Fill memo to cap (256 unique commands).
+    for (let i = 0; i < 256; i++) {
+      await reviewer({ ...input, command: `cmd-${i}`, argv: ["cmd", `${i}`] });
+    }
+    expect(complete).toHaveBeenCalledTimes(256);
+
+    // 257th unique command: evicts oldest, model called again.
+    await reviewer({ ...input, command: "cmd-overflow", argv: ["cmd", "overflow"] });
+    expect(complete).toHaveBeenCalledTimes(257);
+
+    // First command evicted from memo: model called again, re-cached.
+    await reviewer({ ...input, command: "cmd-0", argv: ["cmd", "0"] });
+    expect(complete).toHaveBeenCalledTimes(258);
+
+    // cmd-1 was evicted when cmd-0 was re-cached: model called again.
+    await reviewer({ ...input, command: "cmd-1", argv: ["cmd", "1"] });
+    expect(complete).toHaveBeenCalledTimes(259);
   });
 });

--- a/src/agents/exec-auto-reviewer.test.ts
+++ b/src/agents/exec-auto-reviewer.test.ts
@@ -764,6 +764,9 @@ describe("createModelExecAutoReviewer", () => {
   it("keeps repeated gateway reviews bound to one-shot approval", async () => {
     const { reviewer, prepare, complete } = createReviewerHarness();
 
+    // An identical repeated request reuses the memoized verdict, but the
+    // decision is still allow-once: the single-use approval is registered by
+    // the caller per invocation, not extended by the memo.
     await expect(reviewer(input)).resolves.toMatchObject({
       decision: "allow-once",
       risk: "low",
@@ -773,8 +776,8 @@ describe("createModelExecAutoReviewer", () => {
       risk: "low",
     });
 
-    expect(prepare).toHaveBeenCalledTimes(2);
-    expect(complete).toHaveBeenCalledTimes(2);
+    expect(prepare).toHaveBeenCalledTimes(1);
+    expect(complete).toHaveBeenCalledTimes(1);
   });
 
   it("keeps simultaneous gateway approvals one-shot under concurrency", async () => {
@@ -826,7 +829,10 @@ describe("createModelExecAutoReviewer", () => {
     const { reviewer, prepare, complete } = createReviewerHarness();
     const nodeInput = { ...input, host: "node" as const };
 
-    await reviewer(nodeInput);
+    // A gateway verdict must not satisfy a node-host request: host is part of
+    // the memo key, so the node request bills its own completion rather than
+    // reusing the gateway authority.
+    await reviewer(input);
     await reviewer(nodeInput);
 
     expect(prepare).toHaveBeenCalledTimes(2);

--- a/src/agents/exec-auto-reviewer.test.ts
+++ b/src/agents/exec-auto-reviewer.test.ts
@@ -853,4 +853,109 @@ describe("createModelExecAutoReviewer", () => {
     expect(prepare).toHaveBeenCalledTimes(2);
     expect(complete).toHaveBeenCalledTimes(2);
   });
+
+  it("memoizes allow-once verdicts for identical exec requests", async () => {
+    const complete = vi.fn(async () => ({
+      content: [
+        {
+          type: "text",
+          text: JSON.stringify({
+            decision: "allow",
+            risk: "low",
+            rationale: "read-only inspection",
+          }),
+        },
+      ],
+      stopReason: "stop",
+    }));
+    const reviewer = createModelExecAutoReviewer({
+      cfg: {},
+      deps: {
+        prepareSimpleCompletionModelForAgent: vi.fn(async () => ({
+          selection: { provider: "openai", modelId: "gpt-5.5", agentDir: "/agent" },
+          model: { provider: "openai", id: "gpt-5.5", api: "openai-responses" },
+          auth: { apiKey: "sk-test", mode: "env" },
+        })) as unknown as typeof import("./simple-completion-runtime.js").prepareSimpleCompletionModelForAgent,
+        completeWithPreparedSimpleCompletionModel:
+          complete as unknown as typeof import("./simple-completion-runtime.js").completeWithPreparedSimpleCompletionModel,
+      },
+    });
+
+    // First call: model is called.
+    const result1 = await reviewer(input);
+    expect(result1).toEqual({
+      decision: "allow-once",
+      risk: "low",
+      rationale: "read-only inspection",
+    });
+    expect(complete).toHaveBeenCalledTimes(1);
+
+    // Second call with identical input: served from memo, no additional model call.
+    const result2 = await reviewer(input);
+    expect(result2).toEqual({
+      decision: "allow-once",
+      risk: "low",
+      rationale: "read-only inspection",
+    });
+    expect(complete).toHaveBeenCalledTimes(1);
+
+    // Different command: model is called again.
+    const result3 = await reviewer({ ...input, command: "npm test", argv: ["npm", "test"] });
+    expect(result3).toEqual({
+      decision: "allow-once",
+      risk: "low",
+      rationale: "read-only inspection",
+    });
+    expect(complete).toHaveBeenCalledTimes(2);
+
+    // Different host: model is called again (different memo key).
+    const result4 = await reviewer({ ...input, host: "node" });
+    expect(result4).toEqual({
+      decision: "allow-once",
+      risk: "low",
+      rationale: "read-only inspection",
+    });
+    expect(complete).toHaveBeenCalledTimes(3);
+  });
+
+  it("evicts oldest memo entry when cap is reached", async () => {
+    const complete = vi.fn(async () => ({
+      content: [
+        {
+          type: "text",
+          text: JSON.stringify({ decision: "allow", risk: "low", rationale: "ok" }),
+        },
+      ],
+    }));
+    const reviewer = createModelExecAutoReviewer({
+      cfg: {},
+      deps: {
+        prepareSimpleCompletionModelForAgent: vi.fn(async () => ({
+          selection: { provider: "openai", modelId: "gpt-5.5", agentDir: "/agent" },
+          model: { provider: "openai", id: "gpt-5.5", api: "openai-responses" },
+          auth: { apiKey: "sk-test", mode: "env" },
+        })) as unknown as typeof import("./simple-completion-runtime.js").prepareSimpleCompletionModelForAgent,
+        completeWithPreparedSimpleCompletionModel:
+          complete as unknown as typeof import("./simple-completion-runtime.js").completeWithPreparedSimpleCompletionModel,
+      },
+    });
+
+    // Fill memo to cap (256 unique commands).
+    for (let i = 0; i < 256; i++) {
+      await reviewer({ ...input, command: `cmd-${i}`, argv: ["cmd", `${i}`] });
+    }
+    expect(complete).toHaveBeenCalledTimes(256);
+
+    // 257th unique command: evicts oldest, model called again.
+    await reviewer({ ...input, command: "cmd-overflow", argv: ["cmd", "overflow"] });
+    expect(complete).toHaveBeenCalledTimes(257);
+
+    // First command evicted from memo: model called again, re-cached.
+    await reviewer({ ...input, command: "cmd-0", argv: ["cmd", "0"] });
+    expect(complete).toHaveBeenCalledTimes(258);
+
+    // cmd-1 was evicted when cmd-0 was re-cached: model called again.
+    await reviewer({ ...input, command: "cmd-1", argv: ["cmd", "1"] });
+    expect(complete).toHaveBeenCalledTimes(259);
+  });
 });

--- a/src/agents/exec-auto-reviewer.ts
+++ b/src/agents/exec-auto-reviewer.ts
@@ -357,7 +357,10 @@ function buildExecReviewMemoKey(input: ModelAutoReviewInput): string | undefined
   // Only memoize fully specified exec requests: without a resolved executable
   // the reviewer is assessing an unknown target, so reusing a prior verdict
   // would be unsafe. Board widget reviews have a different input shape and
-  // stay out of the memo.
+  // stay out of the memo. Node-host requests also stay out: the gateway cannot
+  // resolve the remote node executable and the remote prepare result exposes
+  // no resolved executable identity, so node reviews always bill a fresh
+  // completion until a node-owned identity joins the key contract.
   if ("kind" in input || !input.argv || !input.cwd || !input.envKeys || !input.resolvedPath) {
     return undefined;
   }

--- a/src/agents/exec-auto-reviewer.ts
+++ b/src/agents/exec-auto-reviewer.ts
@@ -31,6 +31,8 @@ const DEFAULT_EXEC_REVIEWER_TIMEOUT_MS = 30_000;
 const EXEC_REVIEWER_MAX_TOKENS = 360;
 const MAX_EXEC_REVIEWER_INPUT_CHARS = 16_000;
 const EXEC_REVIEWER_TIMEOUT = Symbol("exec-reviewer-timeout");
+/** FIFO cap for the per-run verdict memo; prevents unbounded growth in long-running agents. */
+const MEMO_CAP = 256;
 
 const execAutoReviewResponseSchema = z
   .object({
@@ -351,6 +353,32 @@ async function raceWithReviewerTimeout<T>(
   }
 }
 
+function buildExecReviewMemoKey(input: ModelAutoReviewInput): string | undefined {
+  // Only memoize fully specified exec requests: without a resolved executable
+  // the reviewer is assessing an unknown target, so reusing a prior verdict
+  // would be unsafe. Board widget reviews have a different input shape and
+  // stay out of the memo.
+  if ("kind" in input || !input.argv || !input.cwd || !input.envKeys || !input.resolvedPath) {
+    return undefined;
+  }
+  // Key covers every field that influences the reviewer prompt, matching what
+  // stringifyInput sends to the model, plus the agent context. The prompt
+  // deliberately omits agent session identifiers, but a verdict must never be
+  // reused across a different agent. resolvedPath included because two commands
+  // that resolve to different executables are not the same review.
+  return JSON.stringify({
+    command: input.command,
+    argv: [...input.argv],
+    resolvedPath: input.resolvedPath,
+    cwd: input.cwd,
+    envKeys: [...input.envKeys],
+    host: input.host,
+    reason: input.reason,
+    analysis: input.analysis,
+    agent: input.agent,
+  });
+}
+
 /** Creates an exec auto-reviewer that uses a configured model when available. */
 export function createModelExecAutoReviewer(params: {
   cfg?: OpenClawConfig;
@@ -358,6 +386,8 @@ export function createModelExecAutoReviewer(params: {
   reviewer?: ExecReviewerConfig;
   deps?: ExecReviewerDeps;
   signal?: AbortSignal;
+  /** Per-run memo for identical exec requests. When omitted, a local Map is used. */
+  verdictMemo?: Map<string, ExecAutoReviewDecision>;
 }): (input: ModelAutoReviewInput) => Promise<ExecAutoReviewDecision> | ExecAutoReviewDecision {
   const cfg = params.cfg;
   const agentId = params.agentId ?? "main";
@@ -378,10 +408,20 @@ export function createModelExecAutoReviewer(params: {
     completeWithPreparedSimpleCompletionModel;
   const modelRef = resolveReviewerModelRef(params.reviewer);
   const timeoutMs = resolveExecReviewerTimeoutMs(params.reviewer);
+  // Per-run memo for identical exec requests. When the caller provides a
+  // run-scoped Map (e.g. from createExecTool), verdicts are reused across exec
+  // invocations within the same agent run. Otherwise a local Map is used.
+  const verdictMemo = params.verdictMemo ?? new Map<string, ExecAutoReviewDecision>();
   return async (input) => {
     let completionController: AbortController | undefined;
     try {
       params.signal?.throwIfAborted();
+      // Check memo for identical exec requests within this run.
+      const memoKey = buildExecReviewMemoKey(input);
+      const cached = memoKey ? verdictMemo.get(memoKey) : undefined;
+      if (cached) {
+        return cached;
+      }
       const serializedInput = stringifyInput(input);
       if (serializedInput.length > MAX_EXEC_REVIEWER_INPUT_CHARS) {
         return {
@@ -460,7 +500,19 @@ export function createModelExecAutoReviewer(params: {
           completionFailure,
         );
       }
-      return parseExecAutoReviewResponse(extractTextContent(result));
+      const decision = parseExecAutoReviewResponse(extractTextContent(result));
+      // Cache allow-once verdicts for identical exec requests within this run.
+      // FIFO eviction: when the memo is full, remove the oldest entry to cap memory.
+      if (memoKey && decision.decision === "allow-once") {
+        if (verdictMemo.size >= MEMO_CAP) {
+          const oldest = verdictMemo.keys().next().value;
+          if (oldest !== undefined) {
+            verdictMemo.delete(oldest);
+          }
+        }
+        verdictMemo.set(memoKey, decision);
+      }
+      return decision;
     } catch (err) {
       params.signal?.throwIfAborted();
       if (completionController?.signal.aborted) {

--- a/src/agents/exec-auto-reviewer.ts
+++ b/src/agents/exec-auto-reviewer.ts
@@ -337,6 +337,26 @@ async function raceWithReviewerTimeout<T>(
   }
 }
 
+function buildExecReviewMemoKey(input: ExecAutoReviewInput): string | undefined {
+  // Only memoize when all fields are specified to avoid cross-context reuse.
+  if (!input.command || !input.argv || !input.cwd || !input.envKeys) {
+    return undefined;
+  }
+  // Key covers all fields that influence the reviewer prompt, matching what
+  // stringifyInput sends to the model. This prevents reusing an allow-once
+  // verdict across different host, reason, analysis, or agent contexts.
+  return JSON.stringify({
+    command: input.command,
+    argv: [...input.argv],
+    cwd: input.cwd,
+    envKeys: [...input.envKeys],
+    host: input.host,
+    reason: input.reason,
+    analysis: input.analysis,
+    agent: input.agent,
+  });
+}
+
 /** Creates an exec auto-reviewer that uses a configured model when available. */
 export function createModelExecAutoReviewer(params: {
   cfg?: OpenClawConfig;
@@ -357,10 +377,23 @@ export function createModelExecAutoReviewer(params: {
     completeWithPreparedSimpleCompletionModel;
   const modelRef = resolveReviewerModelRef(params.reviewer);
   const timeoutMs = resolveExecReviewerTimeoutMs(params.reviewer);
+  // Per-run memo for identical exec requests. Since the reviewer uses
+  // temperature: 0 and the prompt is a pure function of the request tuple,
+  // caching the verdict for identical (command, argv, cwd, envKeys) inputs
+  // removes redundant paid completions without changing security posture.
+  // FIFO cap prevents unbounded memory growth in long-running agents.
+  const verdictMemo = new Map<string, ExecAutoReviewDecision>();
+  const MEMO_CAP = 256;
   return async (input) => {
     let completionController: AbortController | undefined;
     try {
       params.signal?.throwIfAborted();
+      // Check memo for identical exec requests within this run.
+      const memoKey = buildExecReviewMemoKey(input);
+      const cached = memoKey ? verdictMemo.get(memoKey) : undefined;
+      if (cached) {
+        return cached;
+      }
       if (hasReviewerDirective(input)) {
         return {
           decision: "ask",
@@ -428,7 +461,19 @@ export function createModelExecAutoReviewer(params: {
           completionFailure,
         );
       }
-      return parseExecAutoReviewResponse(extractTextContent(result));
+      const decision = parseExecAutoReviewResponse(extractTextContent(result));
+      // Cache allow-once verdicts for identical exec requests within this run.
+      // FIFO eviction: when the memo is full, remove the oldest entry to cap memory.
+      if (memoKey && decision.decision === "allow-once") {
+        if (verdictMemo.size >= MEMO_CAP) {
+          const oldest = verdictMemo.keys().next().value;
+          if (oldest !== undefined) {
+            verdictMemo.delete(oldest);
+          }
+        }
+        verdictMemo.set(memoKey, decision);
+      }
+      return decision;
     } catch (err) {
       params.signal?.throwIfAborted();
       if (completionController?.signal.aborted) {

--- a/src/agents/exec-auto-reviewer.ts
+++ b/src/agents/exec-auto-reviewer.ts
@@ -339,15 +339,21 @@ async function raceWithReviewerTimeout<T>(
 
 function buildExecReviewMemoKey(input: ExecAutoReviewInput): string | undefined {
   // Only memoize when all fields are specified to avoid cross-context reuse.
-  if (!input.command || !input.argv || !input.cwd || !input.envKeys) {
+  // An unbound request (no resolved executable) is not memoized: without a
+  // resolved path the reviewer is assessing an unknown target, so reusing a
+  // prior verdict would be unsafe.
+  if (!input.command || !input.argv || !input.cwd || !input.envKeys || !input.resolvedPath) {
     return undefined;
   }
-  // Key covers all fields that influence the reviewer prompt, matching what
+  // Key covers every field that influences the reviewer prompt, matching what
   // stringifyInput sends to the model. This prevents reusing an allow-once
-  // verdict across different host, reason, analysis, or agent contexts.
+  // verdict across a different resolved executable, host, reason, analysis, or
+  // agent context — resolvedPath included because two commands that resolve to
+  // different executables are not the same review.
   return JSON.stringify({
     command: input.command,
     argv: [...input.argv],
+    resolvedPath: input.resolvedPath,
     cwd: input.cwd,
     envKeys: [...input.envKeys],
     host: input.host,
@@ -379,9 +385,11 @@ export function createModelExecAutoReviewer(params: {
   const timeoutMs = resolveExecReviewerTimeoutMs(params.reviewer);
   // Per-run memo for identical exec requests. Since the reviewer uses
   // temperature: 0 and the prompt is a pure function of the request tuple,
-  // caching the verdict for identical (command, argv, cwd, envKeys) inputs
-  // removes redundant paid completions without changing security posture.
-  // FIFO cap prevents unbounded memory growth in long-running agents.
+  // caching the verdict for identical inputs removes redundant paid completions
+  // without changing security posture. The one-shot approval itself is still
+  // registered by each caller per invocation, so memoizing the verdict does not
+  // extend a single-use approval across executions. FIFO cap prevents
+  // unbounded memory growth in long-running agents.
   const verdictMemo = new Map<string, ExecAutoReviewDecision>();
   const MEMO_CAP = 256;
   return async (input) => {

--- a/src/agents/exec-auto-reviewer.ts
+++ b/src/agents/exec-auto-reviewer.ts
@@ -27,6 +27,8 @@ import { coerceToolModelConfig } from "./tools/model-config.helpers.js";
 const DEFAULT_EXEC_REVIEWER_TIMEOUT_MS = 30_000;
 const EXEC_REVIEWER_MAX_TOKENS = 360;
 const EXEC_REVIEWER_TIMEOUT = Symbol("exec-reviewer-timeout");
+/** FIFO cap for the per-run verdict memo; prevents unbounded growth in long-running agents. */
+const MEMO_CAP = 256;
 
 const execAutoReviewResponseSchema = z
   .object({
@@ -370,6 +372,8 @@ export function createModelExecAutoReviewer(params: {
   reviewer?: ExecReviewerConfig;
   deps?: ExecReviewerDeps;
   signal?: AbortSignal;
+  /** Per-run memo for identical exec requests. When omitted, a local Map is used. */
+  verdictMemo?: Map<string, ExecAutoReviewDecision>;
 }): ExecAutoReviewer {
   const cfg = params.cfg;
   const agentId = params.agentId ?? "main";
@@ -383,15 +387,10 @@ export function createModelExecAutoReviewer(params: {
     completeWithPreparedSimpleCompletionModel;
   const modelRef = resolveReviewerModelRef(params.reviewer);
   const timeoutMs = resolveExecReviewerTimeoutMs(params.reviewer);
-  // Per-run memo for identical exec requests. Since the reviewer uses
-  // temperature: 0 and the prompt is a pure function of the request tuple,
-  // caching the verdict for identical inputs removes redundant paid completions
-  // without changing security posture. The one-shot approval itself is still
-  // registered by each caller per invocation, so memoizing the verdict does not
-  // extend a single-use approval across executions. FIFO cap prevents
-  // unbounded memory growth in long-running agents.
-  const verdictMemo = new Map<string, ExecAutoReviewDecision>();
-  const MEMO_CAP = 256;
+  // Per-run memo for identical exec requests. When the caller provides a
+  // run-scoped Map (e.g. from createExecTool), verdicts are reused across exec
+  // invocations within the same agent run. Otherwise a local Map is used.
+  const verdictMemo = params.verdictMemo ?? new Map<string, ExecAutoReviewDecision>();
   return async (input) => {
     let completionController: AbortController | undefined;
     try {


### PR DESCRIPTION
## Summary

- Memoize gateway-host exec auto-reviewer verdicts for identical exec requests within a single run.
- Scope is **gateway-host reviews only**: node-host reviews always bill a fresh completion (see "Scope" below).

## What Problem This Solves

The exec auto-reviewer re-bills a fresh model completion for every byte-identical repeated gateway exec request, even within the same run. This adds unnecessary latency and token cost.

## Why This Change Was Made

The reviewer runs at `temperature: 0` and its prompt is a pure function of the request tuple, so an identical input must yield an identical verdict. A per-run, FIFO-bounded memo (cap 256) keyed on the full request tuple reuses that deterministic verdict for identical requests, removing redundant paid completions without changing the decision.

The one-shot approval is **not** memoized: each caller (`bash-tools.exec-host-gateway.ts` -> `recordMatchedAllowlistUse`, `bash-tools.exec-host-node.ts` -> `registerNodeApproval`) still registers a fresh single-use approval per invocation. Memoizing the verdict only skips the redundant model call; it does not extend a single-use approval across executions.

## Scope: gateway-host reviews only (node parity tracked separately)

The memo key requires `resolvedPath`, and only the gateway host supplies one (`bash-tools.exec-host-gateway.ts`). The real node host (`bash-tools.exec-host-node.ts`) invokes the reviewer with no `resolvedPath`: the gateway cannot resolve the remote node executable (node approval analysis deliberately clears PATH) and the remote prepare result exposes no resolved executable identity. So node-host requests never form a memo key and always bill a fresh completion — repeated eligible node commands keep today's behavior exactly.

The gateway cannot safely invent a local path for the node's executable, and extending the remote prepare/dispatch contract with a node-owned, revalidated executable identity is a protocol/owner decision (as the review's maintainer options note). Until such an identity exists, node-host coverage is explicitly out of scope rather than half-approximated: the new test `bills a fresh completion for each real node-host review` locks the real node input shape (no `resolvedPath`) against memoization.

## User Impact

- **Before:** Identical gateway exec requests trigger redundant model calls.
- **After:** Identical gateway requests are served from a per-run memo (FIFO cap: 256 entries). Node-host requests are unchanged.

Fixes #102249

## Security contract (maintainer decision requested)

ClawSweeper flagged that this reduces the frequency of model-backed exec safety reviews and asked maintainers to explicitly accept the reuse contract. The contract is:

- Reuse is scoped to **one reviewer instance / one run** (in-memory `Map`, never persisted).
- Reuse applies only to **byte-identical** gateway request tuples — the memo key covers `resolvedPath`, `command`, `argv`, `cwd`, `envKeys`, `host`, `reason`, `analysis`, and `agent`, matching exactly what `stringifyInput` sends to the model. A different resolved executable, host, or analysis field produces a different key and bills a fresh review.
- Unbound requests (`resolvedPath` undefined) are never memoized — which by construction excludes every node-host request.
- Only `allow-once` verdicts are cached; `ask` decisions never are.
- The **one-shot approval** is still registered by each caller per invocation (`registerNodeApproval` / `recordMatchedAllowlistUse`), so reuse does not extend a single-use approval across executions.

This matches the fix shape issue #102249 asks for ("the deterministic (temperature 0) reviewer verdict should be reused" for identical requests). Maintainer confirmation that this bounded gateway-only reuse is acceptable is requested before merge.

## Evidence

**Behavior addressed:** Identical repeated gateway exec requests reuse the cached `allow-once` verdict instead of re-billing a fresh model completion; different request tuples still bill their own completion.

**Real behavior proof (trusted source, local checkout on Node 24.18.0):**

A script drives the **real** `createModelExecAutoReviewer` with a real `cfg` and its real directive-check / dispatch / parse logic. Only the model-client boundary (`prepareSimpleCompletionModelForAgent` / `completeWithPreparedSimpleCompletionModel`) is stubbed to count completions and return a valid low-risk allow verdict. Two identical requests plus one distinct request are issued:

```json
{
  "proof": "exec-reviewer-verdict-memo",
  "issue": "#102249",
  "result1": { "decision": "allow-once", "risk": "low", "rationale": "read-only" },
  "result2": { "decision": "allow-once", "risk": "low", "rationale": "read-only" },
  "result3": { "decision": "allow-once", "risk": "low", "rationale": "read-only" },
  "identicalRequests": 2,
  "distinctRequests": 1,
  "paidCompletions": 2,
  "eachReturnsAllowOnce": true
}
```

Two identical requests cost **1** completion (the second is served from the memo); the distinct request costs 1 more — `paidCompletions: 2` for 3 requests. Each invocation still returns its own `allow-once` verdict. No real API keys, endpoints, or network are involved.

**Memo key correctness (security):** The memo key matches `stringifyInput` exactly — it includes `resolvedPath`, `command`, `argv`, `cwd`, `envKeys`, `host`, `reason`, `analysis`, and `agent`. Two commands that resolve to different executables produce different keys. Requests without a bound executable are not memoized at all — which covers every real node-host request.

**Unit tests:** `memoizes allow-once verdicts for identical exec requests`, `evicts oldest memo entry when cap is reached`, plus the gateway/isolation tests (`does not reuse a gateway review across a changed %s`, `never caches reviews without a bound gateway executable`, `bills a fresh completion for each real node-host review`, `keeps repeated gateway reviews bound to one-shot approval`, `keeps simultaneous gateway approvals one-shot under concurrency`, `does not cache decisions requiring human approval`). `exec-auto-reviewer.test.ts` 64/64 locally.

**Compatibility:** Additive only — the reviewer's return contract is unchanged. The memo is per-reviewer-instance and per-run; no persisted state, no config surface.
