### PR TITLE
fix(agents): separate retry count from API key position (#102938)

### DIFF
--- a/src/agents/api-key-rotation.test.ts
+++ b/src/agents/api-key-rotation.test.ts
@@ -312,4 +312,41 @@ describe("executeWithApiKeyRotation", () => {
       }),
     );
   });
+
+  it("passes apiKeyIndex and attemptNumber to rotation callbacks", async () => {
+    const shouldRetry = vi.fn(() => true);
+    const onRetry = vi.fn();
+    const execute = vi
+      .fn<(apiKey: string) => Promise<string>>()
+      .mockRejectedValueOnce(new Error("Rate limit"))
+      .mockResolvedValueOnce("ok");
+
+    await expect(
+      executeWithApiKeyRotation({
+        provider: "openai",
+        apiKeys: ["key-1", "key-2"],
+        shouldRetry,
+        onRetry,
+        execute,
+      }),
+    ).resolves.toBe("ok");
+
+    // shouldRetry receives apiKeyIndex (0) and attemptNumber (1)
+    expect(shouldRetry).toHaveBeenCalledWith(
+      expect.objectContaining({
+        attempt: 0,
+        apiKeyIndex: 0,
+        attemptNumber: 1,
+      }),
+    );
+
+    // onRetry receives apiKeyIndex (0) and attemptNumber (1)
+    expect(onRetry).toHaveBeenCalledWith(
+      expect.objectContaining({
+        attempt: 0,
+        apiKeyIndex: 0,
+        attemptNumber: 1,
+      }),
+    );
+  });
 });

--- a/src/agents/api-key-rotation.test.ts
+++ b/src/agents/api-key-rotation.test.ts
@@ -350,4 +350,45 @@ describe("executeWithApiKeyRotation", () => {
       }),
     );
   });
+
+  it("reports retry count and key position across same-key retries and rotation", async () => {
+    const retryCallbacks: Array<{ attempt: number; apiKeyIndex: number }> = [];
+    const rotationCallbacks: Array<{ attempt: number; apiKeyIndex: number }> = [];
+    const executedKeys: string[] = [];
+    const sleep = vi.fn(async () => undefined);
+    const transientError = Object.assign(new Error("controlled transient"), {
+      code: "ECONNRESET",
+    });
+
+    await expect(
+      executeWithApiKeyRotation({
+        provider: "openai",
+        apiKeys: ["key-1", "key-2"],
+        transientRetry: { attempts: 2, baseDelayMs: 0, maxDelayMs: 0, sleep },
+        execute: async (apiKey) => {
+          executedKeys.push(apiKey);
+          if (executedKeys.length < 4) {
+            throw transientError;
+          }
+          return "ok";
+        },
+        shouldRetry: ({ attempt, apiKeyIndex }) => {
+          retryCallbacks.push({ attempt, apiKeyIndex });
+          return retryCallbacks.length === 2;
+        },
+        onRetry: ({ attempt, apiKeyIndex }) => {
+          rotationCallbacks.push({ attempt, apiKeyIndex });
+        },
+      }),
+    ).resolves.toBe("ok");
+
+    expect(executedKeys).toEqual(["key-1", "key-1", "key-2", "key-2"]);
+    expect(sleep).toHaveBeenCalledTimes(2);
+    expect(retryCallbacks).toEqual([
+      { attempt: 1, apiKeyIndex: 0 },
+      { attempt: 2, apiKeyIndex: 0 },
+      { attempt: 1, apiKeyIndex: 1 },
+    ]);
+    expect(rotationCallbacks).toEqual([{ attempt: 2, apiKeyIndex: 0 }]);
+  });
 });

--- a/src/agents/api-key-rotation.test.ts
+++ b/src/agents/api-key-rotation.test.ts
@@ -331,10 +331,11 @@ describe("executeWithApiKeyRotation", () => {
       }),
     ).resolves.toBe("ok");
 
-    // shouldRetry receives apiKeyIndex (0) and attemptNumber (1)
+    // shouldRetry receives apiKeyIndex (0) and attemptNumber (1); attempt is now
+    // the canonical one-based retry count (= attemptNumber), not the key index.
     expect(shouldRetry).toHaveBeenCalledWith(
       expect.objectContaining({
-        attempt: 0,
+        attempt: 1,
         apiKeyIndex: 0,
         attemptNumber: 1,
       }),
@@ -343,10 +344,50 @@ describe("executeWithApiKeyRotation", () => {
     // onRetry receives apiKeyIndex (0) and attemptNumber (1)
     expect(onRetry).toHaveBeenCalledWith(
       expect.objectContaining({
-        attempt: 0,
+        attempt: 1,
         apiKeyIndex: 0,
         attemptNumber: 1,
       }),
     );
+  });
+
+  it("diverges attempt (retry count) from apiKeyIndex (key position) across keys and retries", async () => {
+    // Two keys, transient retry on key-1 (attemptNumber 1→2), then rotate to
+    // key-2 (attemptNumber 1). attempt must track attemptNumber, not apiKeyIndex.
+    const calls: Array<{ attempt: number; apiKeyIndex: number; attemptNumber: number }> = [];
+    const cause = Object.assign(new Error("socket closed"), { code: "ECONNRESET" });
+    const execute = vi.fn(async () => {
+      throw cause;
+    });
+
+    let shouldRetryCallCount = 0;
+    await expect(
+      executeWithApiKeyRotation({
+        provider: "openai",
+        apiKeys: ["key-1", "key-2"],
+        shouldRetry: (params) => {
+          calls.push({
+            attempt: params.attempt,
+            apiKeyIndex: params.apiKeyIndex,
+            attemptNumber: params.attemptNumber,
+          });
+          shouldRetryCallCount += 1;
+          // First call: don't rotate (let transient retry run).
+          // Second call: rotate to key-2.
+          return shouldRetryCallCount === 2;
+        },
+        transientRetry: { attempts: 2, baseDelayMs: 0, maxDelayMs: 0, sleep: async () => {} },
+        execute,
+      }),
+    ).rejects.toThrow("socket closed");
+
+    // key-1: attemptNumber 1 (no rotate), then 2 (rotate to key-2)
+    // key-2: attemptNumber 1 (no rotate), then 2 (last key, break)
+    expect(calls).toEqual([
+      { attempt: 1, apiKeyIndex: 0, attemptNumber: 1 },
+      { attempt: 2, apiKeyIndex: 0, attemptNumber: 2 },
+      { attempt: 1, apiKeyIndex: 1, attemptNumber: 1 },
+      { attempt: 2, apiKeyIndex: 1, attemptNumber: 2 },
+    ]);
   });
 });

--- a/src/agents/api-key-rotation.test.ts
+++ b/src/agents/api-key-rotation.test.ts
@@ -313,7 +313,7 @@ describe("executeWithApiKeyRotation", () => {
     );
   });
 
-  it("passes apiKeyIndex and attemptNumber to rotation callbacks", async () => {
+  it("passes apiKeyIndex and attempt to rotation callbacks", async () => {
     const shouldRetry = vi.fn(() => true);
     const onRetry = vi.fn();
     const execute = vi
@@ -331,30 +331,27 @@ describe("executeWithApiKeyRotation", () => {
       }),
     ).resolves.toBe("ok");
 
-    // shouldRetry receives apiKeyIndex (0) and attemptNumber (1); attempt is now
-    // the canonical one-based retry count (= attemptNumber), not the key index.
+    // shouldRetry receives apiKeyIndex (0) and attempt (1, canonical retry count).
     expect(shouldRetry).toHaveBeenCalledWith(
       expect.objectContaining({
         attempt: 1,
         apiKeyIndex: 0,
-        attemptNumber: 1,
       }),
     );
 
-    // onRetry receives apiKeyIndex (0) and attemptNumber (1)
+    // onRetry receives apiKeyIndex (0) and attempt (1).
     expect(onRetry).toHaveBeenCalledWith(
       expect.objectContaining({
         attempt: 1,
         apiKeyIndex: 0,
-        attemptNumber: 1,
       }),
     );
   });
 
   it("diverges attempt (retry count) from apiKeyIndex (key position) across keys and retries", async () => {
-    // Two keys, transient retry on key-1 (attemptNumber 1→2), then rotate to
-    // key-2 (attemptNumber 1). attempt must track attemptNumber, not apiKeyIndex.
-    const calls: Array<{ attempt: number; apiKeyIndex: number; attemptNumber: number }> = [];
+    // Two keys, transient retry on key-1 (attempt 1→2), then rotate to
+    // key-2 (attempt 1). attempt must track the retry count, not apiKeyIndex.
+    const calls: Array<{ attempt: number; apiKeyIndex: number }> = [];
     const cause = Object.assign(new Error("socket closed"), { code: "ECONNRESET" });
     const execute = vi.fn(async () => {
       throw cause;
@@ -369,7 +366,6 @@ describe("executeWithApiKeyRotation", () => {
           calls.push({
             attempt: params.attempt,
             apiKeyIndex: params.apiKeyIndex,
-            attemptNumber: params.attemptNumber,
           });
           shouldRetryCallCount += 1;
           // First call: don't rotate (let transient retry run).
@@ -381,13 +377,13 @@ describe("executeWithApiKeyRotation", () => {
       }),
     ).rejects.toThrow("socket closed");
 
-    // key-1: attemptNumber 1 (no rotate), then 2 (rotate to key-2)
-    // key-2: attemptNumber 1 (no rotate), then 2 (last key, break)
+    // key-1: attempt 1 (no rotate), then 2 (rotate to key-2)
+    // key-2: attempt 1 (no rotate), then 2 (last key, break)
     expect(calls).toEqual([
-      { attempt: 1, apiKeyIndex: 0, attemptNumber: 1 },
-      { attempt: 2, apiKeyIndex: 0, attemptNumber: 2 },
-      { attempt: 1, apiKeyIndex: 1, attemptNumber: 1 },
-      { attempt: 2, apiKeyIndex: 1, attemptNumber: 2 },
+      { attempt: 1, apiKeyIndex: 0 },
+      { attempt: 2, apiKeyIndex: 0 },
+      { attempt: 1, apiKeyIndex: 1 },
+      { attempt: 2, apiKeyIndex: 1 },
     ]);
   });
 });

--- a/src/agents/api-key-rotation.ts
+++ b/src/agents/api-key-rotation.ts
@@ -18,7 +18,12 @@ import { collectProviderApiKeys, isApiKeyRateLimitError } from "./live-auth-keys
 type ApiKeyRetryParams = {
   apiKey: string;
   error: unknown;
+  /** @deprecated Use apiKeyIndex for key-rotation position or attemptNumber for per-key retry count. */
   attempt: number;
+  /** Zero-based index of the current key in the rotation array. */
+  apiKeyIndex: number;
+  /** One-based attempt count for the current key (resets to 1 when rotating to a new key). */
+  attemptNumber: number;
 };
 
 type ExecuteWithApiKeyRotationOptions<T> = {
@@ -65,7 +70,14 @@ export async function executeWithApiKeyRotation<T>(
         lastError = error;
         const message = formatErrorMessage(error);
         const rotateKey = params.shouldRetry
-          ? params.shouldRetry({ apiKey, error, attempt: apiKeyIndex, message })
+          ? params.shouldRetry({
+              apiKey,
+              error,
+              attempt: apiKeyIndex,
+              apiKeyIndex,
+              attemptNumber,
+              message,
+            })
           : isApiKeyRateLimitError(message);
 
         if (rotateKey) {
@@ -74,7 +86,14 @@ export async function executeWithApiKeyRotation<T>(
           if (apiKeyIndex + 1 >= keys.length) {
             break;
           }
-          params.onRetry?.({ apiKey, error, attempt: apiKeyIndex, message });
+          params.onRetry?.({
+            apiKey,
+            error,
+            attempt: apiKeyIndex,
+            apiKeyIndex,
+            attemptNumber,
+            message,
+          });
           break;
         }
 

--- a/src/agents/api-key-rotation.ts
+++ b/src/agents/api-key-rotation.ts
@@ -19,7 +19,8 @@ import { collectProviderApiKeys, isApiKeyRateLimitError } from "./live-auth-keys
 type ApiKeyRetryParams = {
   apiKey: string;
   error: unknown;
-  attempt: number;
+  attempt: number; // One-based execution count for the current key.
+  apiKeyIndex: number; // Zero-based position of the current key.
 };
 
 type ExecuteWithApiKeyRotationOptions<T> = {
@@ -59,7 +60,7 @@ export async function executeWithApiKeyRotation<T>(
   const transientRetry = resolveTransientProviderRetryOptions(params.transientRetry);
   keyLoop: for (const [apiKeyIndex, apiKey] of keys.entries()) {
     const maxOperationAttempts = resolveTransientProviderAttempts(transientRetry);
-    for (let attemptNumber = 1; attemptNumber <= maxOperationAttempts; attemptNumber += 1) {
+    for (let attempt = 1; attempt <= maxOperationAttempts; attempt += 1) {
       transientRetry?.signal?.throwIfAborted();
       try {
         return await params.execute(apiKey);
@@ -67,9 +68,8 @@ export async function executeWithApiKeyRotation<T>(
         transientRetry?.signal?.throwIfAborted();
         lastError = error;
         const message = formatErrorMessage(error);
-        const rotateKey = params.shouldRetry
-          ? params.shouldRetry({ apiKey, error, attempt: apiKeyIndex, message })
-          : isApiKeyRateLimitError(message);
+        const retry = { apiKey, error, attempt, apiKeyIndex, message };
+        const rotateKey = params.shouldRetry?.(retry) ?? isApiKeyRateLimitError(message);
 
         if (rotateKey) {
           // A rotation signal consumes the current key and moves to the next key
@@ -77,7 +77,7 @@ export async function executeWithApiKeyRotation<T>(
           if (apiKeyIndex + 1 >= keys.length) {
             break;
           }
-          params.onRetry?.({ apiKey, error, attempt: apiKeyIndex, message });
+          params.onRetry?.(retry);
           break;
         }
 
@@ -89,14 +89,14 @@ export async function executeWithApiKeyRotation<T>(
             message,
             provider: params.provider,
             apiKeyIndex,
-            attemptNumber,
+            attemptNumber: attempt,
             maxAttempts: maxOperationAttempts,
           })
         ) {
           break keyLoop;
         }
 
-        const delayMs = resolveTransientProviderDelayMs(transientRetry, attemptNumber);
+        const delayMs = resolveTransientProviderDelayMs(transientRetry, attempt);
         // Same-key transient retries are bounded by provider policy and keep the
         // current key stable so auth rotation only handles key-specific failures.
         const sleep = transientRetry.sleep ?? sleepWithAbort;

--- a/src/agents/api-key-rotation.ts
+++ b/src/agents/api-key-rotation.ts
@@ -18,12 +18,10 @@ import { collectProviderApiKeys, isApiKeyRateLimitError } from "./live-auth-keys
 type ApiKeyRetryParams = {
   apiKey: string;
   error: unknown;
-  /** One-based retry count for the current key (same as attemptNumber; canonical name). */
+  /** One-based retry count for the current key (resets to 1 when rotating to a new key). */
   attempt: number;
   /** Zero-based index of the current key in the rotation array. */
   apiKeyIndex: number;
-  /** One-based attempt count for the current key (resets to 1 when rotating to a new key). */
-  attemptNumber: number;
 };
 
 type ExecuteWithApiKeyRotationOptions<T> = {
@@ -75,7 +73,6 @@ export async function executeWithApiKeyRotation<T>(
               error,
               attempt: attemptNumber,
               apiKeyIndex,
-              attemptNumber,
               message,
             })
           : isApiKeyRateLimitError(message);
@@ -91,7 +88,6 @@ export async function executeWithApiKeyRotation<T>(
             error,
             attempt: attemptNumber,
             apiKeyIndex,
-            attemptNumber,
             message,
           });
           break;

--- a/src/agents/api-key-rotation.ts
+++ b/src/agents/api-key-rotation.ts
@@ -18,7 +18,7 @@ import { collectProviderApiKeys, isApiKeyRateLimitError } from "./live-auth-keys
 type ApiKeyRetryParams = {
   apiKey: string;
   error: unknown;
-  /** @deprecated Use apiKeyIndex for key-rotation position or attemptNumber for per-key retry count. */
+  /** One-based retry count for the current key (same as attemptNumber; canonical name). */
   attempt: number;
   /** Zero-based index of the current key in the rotation array. */
   apiKeyIndex: number;
@@ -73,7 +73,7 @@ export async function executeWithApiKeyRotation<T>(
           ? params.shouldRetry({
               apiKey,
               error,
-              attempt: apiKeyIndex,
+              attempt: attemptNumber,
               apiKeyIndex,
               attemptNumber,
               message,
@@ -89,7 +89,7 @@ export async function executeWithApiKeyRotation<T>(
           params.onRetry?.({
             apiKey,
             error,
-            attempt: apiKeyIndex,
+            attempt: attemptNumber,
             apiKeyIndex,
             attemptNumber,
             message,


### PR DESCRIPTION
## Summary

- Make `attempt` the one-based execution count for the current API key.
- Add `apiKeyIndex` as the zero-based key position.
- Keep same-key retries and API-key rotation in their existing order.

## What Problem This Solves

API-key rotation tracked both a one-based retry count and a zero-based key position. The callback field named `attempt` received the key position, so callbacks could not tell a same-key retry from a move to another key.

Fixes #102938

## Why This Change Was Made

The rotation owner now builds one callback context from the current execution. `attempt` comes from the per-key execution loop, while `apiKeyIndex` comes from the key loop. Both `shouldRetry` and `onRetry` receive that same context.

The earlier `attemptNumber` callback field from #103577 was not retained. It never shipped, and it duplicated the corrected `attempt` field. The separate transient-retry classifier keeps its existing `attemptNumber` contract.

## Compatibility

**Maintainer decision:** Accept the semantic correction to `attempt`. A stable release exposed the old index-valued callback through `plugin-sdk/provider-auth-runtime`, but that subpath is now private-local and JavaScript-only. No in-repo caller supplies either rotation callback.

Private-local consumers must read key position from `apiKeyIndex` after this change. Keeping index position in `attempt` would preserve the reported naming defect, while adding `attemptNumber` would create a second name for the same retry count.

## User Impact

- **Before:** callbacks reported key positions as `attempt`, such as `0, 0, 1` across two keys.
- **After:** callbacks report per-key executions as `attempt` (`1, 2, 1`) and key positions as `apiKeyIndex` (`0, 0, 1`).

## Evidence

**Real behavior proof:** The production `executeWithApiKeyRotation` owner ran with two controlled keys. The first key failed twice, the second key failed once, and the fourth execution succeeded. The second callback requested rotation. Both revisions executed `key-1, key-1, key-2, key-2` and performed two same-key retry sleeps.

- Exact main `629a47e3cc20a9f8b6d19c105f840b8a693ec4aa`: `attempt` was `0, 0, 1`; `apiKeyIndex` was absent.
- Exact head `ee3e95ac04e85d2324881d25bac18a473b09f06a`: `attempt` was `1, 2, 1`; `apiKeyIndex` was `0, 0, 1`; `attemptNumber` was absent.
- `onRetry` received `attempt: 2` and `apiKeyIndex: 0` before rotation.

```json
{
  "contractPass": true,
  "result": "ok:key-2",
  "executions": ["key-1", "key-1", "key-2", "key-2"],
  "sameKeyRetrySleeps": 2,
  "shouldRetry": [
    { "attempt": 1, "apiKeyIndex": 0 },
    { "attempt": 2, "apiKeyIndex": 0 },
    { "attempt": 1, "apiKeyIndex": 1 }
  ],
  "onRetry": [{ "attempt": 2, "apiKeyIndex": 0 }],
  "attemptNumberPresent": false
}
```

**Regression test:** `node scripts/run-vitest.mjs src/agents/api-key-rotation.test.ts`

- Exact main with the regression test: 1 failed, 22 passed for the callback mismatch.
- Exact head: 23 passed.

**Changed-scope checks:** formatting, lint, production types, test types, dependency checks, dead-export checks, import-cycle checks, and selected repository guards passed.

Production LOC: +8/-8 (net 0) | Tests: +41/-0
