### PR TITLE
refactor(chat): consolidate browser and terminal history ownership

### DIFF
--- a/src/tui/tui-session-run-coordinator.ts
+++ b/src/tui/tui-session-run-coordinator.ts
@@ -6,11 +6,20 @@ import type { ChatEvent, TuiHistoryLoadResult, TuiStateAccess } from "./tui-type
 const MAX_TRACKED_RUNS = 200;
 const RETAINED_TRACKED_RUNS = 150;
 const TRACKED_RUN_RETENTION_MS = 10 * 60 * 1000;
+const HISTORY_RELOAD_QUEUED = 1;
+const HISTORY_RELOAD_OWNED = 1 << 1;
+const HISTORY_RELOAD_DISPLAYED = 1 << 2;
+const HISTORY_RELOAD_GAP_RECOVERY = 1 << 3;
 
 type HistoryOwnedRun = {
   runId: string;
   result: TuiHistoryLoadResult;
   previouslyDisplayed: boolean;
+};
+
+type TuiHistoryReloadRun = {
+  flags: number;
+  deferredEvent?: ChatEvent;
 };
 
 type TuiSessionRunCoordinatorContext = {
@@ -37,12 +46,7 @@ export class TuiSessionRunCoordinator {
 
   pendingHistoryRefresh = false;
 
-  private readonly historyReloadRunIds = new Set<string>();
-  private readonly historyOwnedReloadRunIds = new Set<string>();
-  private readonly historyDisplayedReloadRunIds = new Set<string>();
-  private readonly gapRecoveryReloadRunIds = new Set<string>();
-  private readonly queuedHistoryReloadRunIds = new Set<string>();
-  private readonly deferredHistoryRunEvents = new Map<string, ChatEvent>();
+  private readonly historyReloadRuns = new Map<string, TuiHistoryReloadRun>();
   private readonly sessionMessagePersistenceRunIds = new Set<string>();
   private readonly confirmedStreamRunIds = new Set<string>();
   private readonly retiredOrphanRunIds = new Map<string, number>();
@@ -258,14 +262,18 @@ export class TuiSessionRunCoordinator {
   }
 
   isHistoryReloadingRun(runId: string): boolean {
-    return this.historyReloadRunIds.has(runId);
+    return this.historyReloadRuns.has(runId);
   }
 
   deferHistoryRunEvent(event: ChatEvent): void {
-    const previous = this.deferredHistoryRunEvents.get(event.runId);
+    const reload = this.historyReloadRuns.get(event.runId);
+    if (!reload) {
+      return;
+    }
+    const previous = reload.deferredEvent;
     // A terminal event remains authoritative over a delayed streaming delta.
     if (!previous || previous.state === "delta" || event.state !== "delta") {
-      this.deferredHistoryRunEvents.set(event.runId, event);
+      reload.deferredEvent = event;
     }
   }
 
@@ -298,19 +306,15 @@ export class TuiSessionRunCoordinator {
     }
 
     const generation = this.historyReloadGeneration;
-    const runIds = Array.from(this.queuedHistoryReloadRunIds);
-    // A second gap may arrive before this reload finishes; keep each drain's
-    // ownership separate so the next reload cannot lose its finalization.
-    const historyOwnedRunIds = new Set(
-      runIds.filter((runId) => this.historyOwnedReloadRunIds.delete(runId)),
-    );
-    const historyDisplayedRunIds = new Set(
-      runIds.filter((runId) => this.historyDisplayedReloadRunIds.delete(runId)),
-    );
-    const gapRecoveryRunIds = new Set(
-      runIds.filter((runId) => this.gapRecoveryReloadRunIds.delete(runId)),
-    );
-    this.queuedHistoryReloadRunIds.clear();
+    // Snapshot each run's flags before awaiting; an overlapping gap owns the
+    // next drain and must not inherit or erase this drain's finalization.
+    const reloads: Array<{ runId: string; flags: number }> = [];
+    for (const [runId, reload] of this.historyReloadRuns) {
+      if (reload.flags & HISTORY_RELOAD_QUEUED) {
+        reloads.push({ runId, flags: reload.flags });
+        reload.flags = 0;
+      }
+    }
     this.historyReloadQueued = false;
     this.historyReloadInFlight = true;
 
@@ -318,18 +322,19 @@ export class TuiSessionRunCoordinator {
       if (generation !== this.historyReloadGeneration) {
         return;
       }
-      for (const runId of runIds) {
-        if (this.queuedHistoryReloadRunIds.has(runId)) {
+      for (const { runId, flags } of reloads) {
+        const current = this.historyReloadRuns.get(runId);
+        if (!current || current.flags & HISTORY_RELOAD_QUEUED) {
           continue;
         }
-        this.historyReloadRunIds.delete(runId);
-        const deferred = this.deferredHistoryRunEvents.get(runId);
-        this.deferredHistoryRunEvents.delete(runId);
-        const historyOwned = historyOwnedRunIds.has(runId);
-        const previouslyDisplayed = historyDisplayedRunIds.has(runId);
+        this.historyReloadRuns.delete(runId);
+        const deferred = current.deferredEvent;
+        const historyOwned = Boolean(flags & HISTORY_RELOAD_OWNED);
+        const previouslyDisplayed = Boolean(flags & HISTORY_RELOAD_DISPLAYED);
+        const gapRecovery = Boolean(flags & HISTORY_RELOAD_GAP_RECOVERY);
         const restoredInFlight = result.loaded && result.inFlightRunId === runId;
 
-        if (historyOwned && !restoredInFlight && (result.loaded || !gapRecoveryRunIds.has(runId))) {
+        if (historyOwned && !restoredInFlight && (result.loaded || !gapRecovery)) {
           this.context.finalizeHistoryOwnedRun({ runId, result, previouslyDisplayed });
         }
         if (deferred && (!result.loaded || historyOwned || restoredInFlight)) {
@@ -370,14 +375,15 @@ export class TuiSessionRunCoordinator {
     }
     for (const runId of queuedRunIds) {
       this.historyReloadQueued = true;
-      this.historyReloadRunIds.add(runId);
-      this.queuedHistoryReloadRunIds.add(runId);
+      const reload = this.historyReloadRuns.get(runId) ?? { flags: 0 };
+      reload.flags |= HISTORY_RELOAD_QUEUED;
       if (historyOwned.has(runId)) {
-        this.historyOwnedReloadRunIds.add(runId);
+        reload.flags |= HISTORY_RELOAD_OWNED;
       }
       if (displayed.has(runId)) {
-        this.historyDisplayedReloadRunIds.add(runId);
+        reload.flags |= HISTORY_RELOAD_DISPLAYED;
       }
+      this.historyReloadRuns.set(runId, reload);
     }
     this.drainHistoryReloadQueue();
   }
@@ -393,7 +399,9 @@ export class TuiSessionRunCoordinator {
       return;
     }
     for (const runId of trackedRunIds) {
-      this.gapRecoveryReloadRunIds.add(runId);
+      const reload = this.historyReloadRuns.get(runId) ?? { flags: 0 };
+      reload.flags |= HISTORY_RELOAD_GAP_RECOVERY;
+      this.historyReloadRuns.set(runId, reload);
     }
     this.queueHistoryReload(trackedRunIds, trackedRunIds, displayedRunIds);
   }
@@ -408,12 +416,7 @@ export class TuiSessionRunCoordinator {
     this.liveTerminalErrorMessages.clear();
     this.completedRuns.clear();
     this.postFinalizingRuns.clear();
-    this.historyReloadRunIds.clear();
-    this.historyOwnedReloadRunIds.clear();
-    this.historyDisplayedReloadRunIds.clear();
-    this.gapRecoveryReloadRunIds.clear();
-    this.queuedHistoryReloadRunIds.clear();
-    this.deferredHistoryRunEvents.clear();
+    this.historyReloadRuns.clear();
     this.confirmedStreamRunIds.clear();
     this.retiredOrphanRunIds.clear();
     this.rejectUnconfirmedRuns = false;

--- a/ui/src/pages/chat/chat-history.ts
+++ b/ui/src/pages/chat/chat-history.ts
@@ -85,13 +85,30 @@ const SYNTHETIC_TRANSCRIPT_REPAIR_RESULT =
   "[openclaw] missing tool result in session history; inserted synthetic error result for transcript repair.";
 const CHAT_HISTORY_REQUEST_LIMIT = 100;
 const STARTUP_CHAT_HISTORY_RETRY_TIMEOUT_MS = 60_000;
-const chatHistoryRequestVersions = new WeakMap<object, number>();
-const chatBranchRequestVersions = new WeakMap<object, number>();
-const selectedSessionMessageSubscriptionGenerations = new WeakMap<object, number>();
-const pendingSessionMessageSubscriptionReleases = new WeakMap<
-  object,
-  Set<SessionMessageSubscription>
->();
+
+type ChatHistoryPaneRequests = {
+  historyVersion: number;
+  branchVersion: number;
+  subscriptionGeneration: number;
+  pendingSubscriptionReleases: Set<SessionMessageSubscription>;
+  inFlightHistory?: InFlightChatHistoryRequest;
+};
+
+const chatHistoryPaneRequests = new WeakMap<object, ChatHistoryPaneRequests>();
+
+function getChatHistoryPaneRequests(owner: object): ChatHistoryPaneRequests {
+  let requests = chatHistoryPaneRequests.get(owner);
+  if (!requests) {
+    requests = {
+      historyVersion: 0,
+      branchVersion: 0,
+      subscriptionGeneration: 0,
+      pendingSubscriptionReleases: new Set(),
+    };
+    chatHistoryPaneRequests.set(owner, requests);
+  }
+  return requests;
+}
 
 type ChatHistoryRequestOwnership = {
   version: number;
@@ -108,11 +125,8 @@ function beginChatHistoryRequest(
   sessionKey: string,
   agentId?: string,
 ): ChatHistoryRequestOwnership {
-  const key = state as object;
-  const nextVersion = (chatHistoryRequestVersions.get(key) ?? 0) + 1;
-  chatHistoryRequestVersions.set(key, nextVersion);
   return {
-    version: nextVersion,
+    version: ++getChatHistoryPaneRequests(state).historyVersion,
     client,
     connectionEpoch,
     sessionKey,
@@ -122,7 +136,7 @@ function beginChatHistoryRequest(
 
 function ownsChatHistoryRequest(state: ChatState, ownership: ChatHistoryRequestOwnership): boolean {
   return (
-    chatHistoryRequestVersions.get(state as object) === ownership.version &&
+    getChatHistoryPaneRequests(state).historyVersion === ownership.version &&
     state.client === ownership.client &&
     state.connected &&
     state.connectionEpoch === ownership.connectionEpoch
@@ -142,11 +156,11 @@ function shouldApplyChatHistoryResult(
 }
 
 function resetChatHistoryProjection(state: ChatState, agentId?: string): void {
-  const owner = state as object;
+  const requests = getChatHistoryPaneRequests(state);
   // A destructive reset keeps the session key, so invalidate both the old
   // snapshot owner and its coalesced request before creating the next epoch.
-  chatHistoryRequestVersions.set(owner, (chatHistoryRequestVersions.get(owner) ?? 0) + 1);
-  inFlightChatHistoryRequests.delete(state);
+  requests.historyVersion += 1;
+  requests.inFlightHistory = undefined;
   state.chatLoading = false;
   const scope = readChatSessionProjectionScope(state, { agentId });
   // Destructive operations keep the public session key, so only an explicit
@@ -534,15 +548,6 @@ function resolveSelectedSessionMessageSubscriptionAgentId(
   return resolveSelectedGlobalAliasAgentId(state, key);
 }
 
-function beginSelectedSessionMessageSubscriptionSync(
-  state: ChatSessionMessageSubscriptionState,
-): number {
-  const key = state as object;
-  const next = (selectedSessionMessageSubscriptionGenerations.get(key) ?? 0) + 1;
-  selectedSessionMessageSubscriptionGenerations.set(key, next);
-  return next;
-}
-
 function isCurrentSelectedSessionMessageSubscriptionSync(
   state: ChatSessionMessageSubscriptionState,
   params: {
@@ -553,7 +558,7 @@ function isCurrentSelectedSessionMessageSubscriptionSync(
   },
 ): boolean {
   return (
-    selectedSessionMessageSubscriptionGenerations.get(state as object) === params.generation &&
+    getChatHistoryPaneRequests(state).subscriptionGeneration === params.generation &&
     state.client === params.client &&
     state.connected &&
     state.sessionKey.trim() === params.requestedKey &&
@@ -562,22 +567,11 @@ function isCurrentSelectedSessionMessageSubscriptionSync(
   );
 }
 
-function rememberPendingSessionMessageSubscriptionRelease(
-  state: ChatSessionMessageSubscriptionState,
-  subscription: SessionMessageSubscription,
-): void {
-  const key = state as object;
-  const pending = pendingSessionMessageSubscriptionReleases.get(key) ?? new Set();
-  pending.add(subscription);
-  pendingSessionMessageSubscriptionReleases.set(key, pending);
-}
-
 async function retryPendingSessionMessageSubscriptionReleases(
   state: ChatSessionMessageSubscriptionState,
 ): Promise<void> {
-  const key = state as object;
-  const pending = pendingSessionMessageSubscriptionReleases.get(key);
-  if (!pending) {
+  const pending = getChatHistoryPaneRequests(state).pendingSubscriptionReleases;
+  if (pending.size === 0) {
     return;
   }
   await Promise.all(
@@ -590,9 +584,6 @@ async function retryPendingSessionMessageSubscriptionReleases(
       }
     }),
   );
-  if (pending.size === 0) {
-    pendingSessionMessageSubscriptionReleases.delete(key);
-  }
 }
 
 export async function syncSelectedSessionMessageSubscription(
@@ -608,7 +599,8 @@ export async function syncSelectedSessionMessageSubscription(
     return;
   }
   await retryPendingSessionMessageSubscriptionReleases(state);
-  const generation = beginSelectedSessionMessageSubscriptionSync(state);
+  const paneRequests = getChatHistoryPaneRequests(state);
+  const generation = ++paneRequests.subscriptionGeneration;
   const previousRequestedKey = normalizeSubscriptionKey(
     state.chatSessionMessageSubscriptionRequestedKey,
   );
@@ -666,13 +658,13 @@ export async function syncSelectedSessionMessageSubscription(
             if (previousSubscription) {
               // Both live handles stay owned: the replacement becomes active while the
               // failed previous release remains queued until a later sync releases it.
-              rememberPendingSessionMessageSubscriptionRelease(state, previousSubscription);
+              paneRequests.pendingSubscriptionReleases.add(previousSubscription);
             }
             state.chatSessionMessageSubscriptionRequestedKey = nextKey;
             state.chatSessionMessageSubscription = subscribeResult.value;
             state.sessionsError = `${String(unsubscribeResult.reason)}; replacement release failed: ${String(replacementReleaseError)}`;
           } else {
-            rememberPendingSessionMessageSubscriptionRelease(state, subscribeResult.value);
+            paneRequests.pendingSubscriptionReleases.add(subscribeResult.value);
           }
           return;
         }
@@ -704,7 +696,7 @@ export async function syncSelectedSessionMessageSubscription(
       } catch {
         // A rejected release still owns its live Gateway observer; retain the
         // exact handle so the next sync can complete the original unsubscribe.
-        rememberPendingSessionMessageSubscriptionRelease(state, subscribed);
+        paneRequests.pendingSubscriptionReleases.add(subscribed);
       }
       return;
     }
@@ -728,8 +720,6 @@ type LoadChatHistoryOptions = {
   deferBranches?: boolean;
   startup?: boolean;
 };
-
-const inFlightChatHistoryRequests = new WeakMap<ChatState, InFlightChatHistoryRequest>();
 
 type SharedChatHistoryRequest = {
   consumers: Set<SharedChatHistoryConsumer>;
@@ -1112,15 +1102,15 @@ export async function loadChatBranches(state: ChatState): Promise<void> {
     state.chatBranchesConnectionEpoch = state.connectionEpoch;
     return;
   }
-  const version = (chatBranchRequestVersions.get(state as object) ?? 0) + 1;
-  chatBranchRequestVersions.set(state as object, version);
+  const requests = getChatHistoryPaneRequests(state);
+  const version = ++requests.branchVersion;
   const connectionEpoch = state.connectionEpoch;
   const agentParams = scopedAgentParamsForSession(state, sessionKey);
   state.chatBranchesLoading = true;
   try {
     const branches = await sessions.listBranches(sessionKey, agentParams);
     if (
-      chatBranchRequestVersions.get(state as object) !== version ||
+      requests.branchVersion !== version ||
       state.client !== client ||
       !state.connected ||
       state.connectionEpoch !== connectionEpoch ||
@@ -1133,7 +1123,7 @@ export async function loadChatBranches(state: ChatState): Promise<void> {
     state.chatBranchesConnectionEpoch = connectionEpoch;
   } catch {
     if (
-      chatBranchRequestVersions.get(state as object) === version &&
+      requests.branchVersion === version &&
       state.client === client &&
       state.connectionEpoch === connectionEpoch &&
       visibleSessionMatches(state, sessionKey, agentParams.agentId)
@@ -1143,7 +1133,7 @@ export async function loadChatBranches(state: ChatState): Promise<void> {
       state.chatBranchesConnectionEpoch = connectionEpoch;
     }
   } finally {
-    if (chatBranchRequestVersions.get(state as object) === version) {
+    if (requests.branchVersion === version) {
       state.chatBranchesLoading = false;
       state.requestUpdate?.();
     }
@@ -1167,7 +1157,8 @@ export async function loadChatHistory(
   const client = state.client;
   const connectionEpoch = state.connectionEpoch;
   const requestKey = `${connectionEpoch}\0${method}\0${sessionKey}\0${requestAgentId ?? ""}\0${CHAT_HISTORY_REQUEST_LIMIT}`;
-  const inFlight = inFlightChatHistoryRequests.get(state);
+  const requests = getChatHistoryPaneRequests(state);
+  const inFlight = requests.inFlightHistory;
   // Live events replace the rendered array while their snapshot is pending;
   // only stable session and connection ownership may start another request.
   if (
@@ -1192,16 +1183,16 @@ export async function loadChatHistory(
     requestAgentId,
     method,
   ).finally(() => {
-    if (inFlightChatHistoryRequests.get(state)?.promise === promise) {
-      inFlightChatHistoryRequests.delete(state);
+    if (requests.inFlightHistory?.promise === promise) {
+      requests.inFlightHistory = undefined;
     }
   });
-  inFlightChatHistoryRequests.set(state, {
+  requests.inFlightHistory = {
     client,
     connectionEpoch,
     key: requestKey,
     promise,
-  });
+  };
   return promise;
 }
 

--- a/ui/vitest.config.ts
+++ b/ui/vitest.config.ts
@@ -10,6 +10,7 @@ import {
   jsdomOptimizedDeps,
   resolveDefaultVitestPool,
 } from "../test/vitest/vitest.shared.config.ts";
+import { uiIsolatedTestFiles } from "../test/vitest/vitest.ui-isolated-paths.mjs";
 
 const here = path.dirname(fileURLToPath(import.meta.url));
 const repoRoot = path.resolve(here, "..");
@@ -94,6 +95,7 @@ const nodeDrivenBrowserLayoutTests = [
   "src/pages/sessions/view.browser.test.ts",
 ] as const;
 const mockRegistryUnitTests = [
+  ...uiIsolatedTestFiles.map((testFile) => testFile.slice("ui/".length)),
   "src/components/mcp-app-view.test.ts",
   "src/pages/chat/chat-page.test.ts",
 ] as const;
@@ -162,8 +164,8 @@ export default defineConfig({
         },
         test: {
           ...sharedUiTestConfig,
-          // These two tests intentionally replace module exports. Isolate only this tiny
-          // project so the main 339-file suite keeps its isolate:false speed contract.
+          // Reuse the canonical singleton-sensitive list so the package and
+          // root runners isolate the same tests without slowing the main suite.
           isolate: true,
           deps: jsdomOptimizedDeps,
           name: "unit-mock-registry",


### PR DESCRIPTION
Related: #115429
Related: #115461

## What Problem This Solves

When the same conversation is open in the browser and terminal, reconnects, delayed history, split panes, or rapid session switches must not show stale messages or apply updates to the wrong session. The same change also fixes a real Control UI CI failure caused by the package-level runner not honoring the repository's existing isolated-test policy.

## Why This Change Was Made

Keep each browser pane's history, request, and subscription lifecycle in one pane-owned record, and each terminal run's history and recovery lifecycle in one run-owned record. Reuse the existing canonical UI isolated-test list in both test runners. This replaces eleven independently maintained registries with two canonical owners without introducing a second projection, fallback, migration, or protocol.

## User Impact

Web and terminal clients consistently display the same authoritative conversation through reconnects, streaming, out-of-order history, peer messages, and session switches. The UI test suite deterministically isolates singleton-sensitive tests. There are no new settings, storage formats, schema changes, or operator actions.

## Evidence

- Net-negative merged diff: **96 additions, 100 deletions, 3 files**.
- **1,268** focused Gateway, shared-client, browser, and terminal regression tests passed.
- **46/46** real Chromium chat end-to-end scenarios passed.
- **48/48** interactive terminal PTY scenarios passed.
- **465 UI test files and 6,766/6,766 UI tests** passed using the exact CI command: `pnpm --dir ui test --maxWorkers 3`.
- Production `pnpm build` and the exact three-file `pnpm check:changed` passed.
- Formatting, core/UI/test typechecks, import-cycle checks, dead-export scans, plugin boundaries, database guards, and zero-warning lint passed.
- Two independent structured reviews reported no actionable findings.
- All **88 GitHub CI checks** passed before the protected maintainer merge.
- Merged into `main` as b7ab8aa3da3c04527cf8d6ea10dda4535dc5c1d8.
- AI-assisted implementation and review.
