### PR TITLE
fix(doctor): restore default workspace suggestions

### DIFF
--- a/src/cli/program/register.maintenance.test.ts
+++ b/src/cli/program/register.maintenance.test.ts
@@ -82,6 +82,25 @@ describe("registerMaintenanceCommands doctor action", () => {
     expect(runtime.exit).toHaveBeenCalledWith(0);
   });
 
+  it("enables workspace suggestions by default and allows disabling them", async () => {
+    doctorCommand.mockResolvedValue(undefined);
+
+    await runMaintenanceCli(["doctor", "--non-interactive", "--yes"]);
+
+    expect(doctorCommand).toHaveBeenCalledTimes(1);
+    const [, defaultOptions] = commandCall(doctorCommand);
+    expect(defaultOptions.workspaceSuggestions).toBe(true);
+
+    vi.clearAllMocks();
+    doctorCommand.mockResolvedValue(undefined);
+
+    await runMaintenanceCli(["doctor", "--non-interactive", "--yes", "--no-workspace-suggestions"]);
+
+    expect(doctorCommand).toHaveBeenCalledTimes(1);
+    const [, disabledOptions] = commandCall(doctorCommand);
+    expect(disabledOptions.workspaceSuggestions).toBe(false);
+  });
+
   it("exits with code 1 when doctor fails", async () => {
     doctorCommand.mockRejectedValue(new Error("doctor failed"));
 

--- a/src/cli/program/register.maintenance.ts
+++ b/src/cli/program/register.maintenance.ts
@@ -41,7 +41,7 @@ export function registerMaintenanceCommands(program: Command) {
       () =>
         `\n${theme.muted("Docs:")} ${formatDocsLink("/cli/doctor", "docs.openclaw.ai/cli/doctor")}\n`,
     )
-    .option("--no-workspace-suggestions", "Disable workspace memory system suggestions", false)
+    .option("--no-workspace-suggestions", "Disable workspace memory system suggestions", true)
     .option("--yes", "Accept defaults without prompting", false)
     .option("--repair", "Apply recommended repairs without prompting", false)
     .option("--fix", "Apply recommended repairs (alias for --repair)", false)


### PR DESCRIPTION
Closes #109503.

Related: #109504. Thanks to @moguangyu5-design for reporting the defect, identifying the Commander default, and providing the original focused regression.

## What Problem This Solves

Fixes an issue where users running `openclaw doctor` would never receive the documented workspace backup and missing-memory-system suggestions unless they explicitly overrode an incorrectly registered negated option.

## Why This Change Was Made

Commander 15 treats a lone `--no-*` flag as enabled by default. The doctor command was overriding that dependency contract with an explicit `false`, so its production workspace health contribution always short-circuited. Set the existing option's default to `true` and regression-test both real Commander parsing paths; retain the existing explicit `--no-workspace-suggestions` opt-out. No config option, persisted state, migration, dependency, or SQLite schema changes.

## User Impact

`openclaw doctor` once again shows the documented workspace backup and memory-system guidance by default. Users and automation can continue to suppress it with `--no-workspace-suggestions`.

## Evidence

Independent maintainer-authored reproduction and validation on Blacksmith Testbox `tbx_01kynx8pfmpw6s987kdqfeptmb`, against the current `origin/main` patch and an isolated temporary state directory and workspace:

```text
$ pnpm test src/cli/program/register.maintenance.test.ts -- --reporter=verbose
Test Files  1 passed (1)
Tests       32 passed (32)

$ pnpm openclaw doctor --non-interactive --yes
Tip: back up the agent workspace in a private git repo
Memory system not found in workspace.

$ pnpm openclaw doctor --non-interactive --yes --no-workspace-suggestions
PASS: neither workspace suggestion is displayed

$ pnpm check:changed
PASS: formatting, core and core-test typechecking, lint, dependency guards,
      runtime boundaries, import cycles, and native SQLite schema v6

$ .agents/skills/autoreview/scripts/autoreview --mode uncommitted --thinking xhigh --stream-engine-output
autoreview clean: no accepted/actionable findings reported
overall: patch is correct (0.99)
```

Both doctor commands were actual production CLI invocations; the proof did not inject option values or call health contributions through test-only APIs. AI-assisted; the exact Commander dependency implementation, CLI registration, health contribution, public doctor docs, both actual CLI modes, and affected regression suite were personally verified.
