### PR TITLE
fix(cli): recover channel turns from expired sessions

### DIFF
--- a/src/agents/cli-session.test.ts
+++ b/src/agents/cli-session.test.ts
@@ -13,10 +13,13 @@ import {
   clearCliSession,
   getCliSessionBinding,
   hashCliSessionText,
+  resolveCliSessionClearReason,
   resolveCliSessionReuse,
   setCliSessionBinding,
   setCliSessionId,
+  shouldClearFailedCliSessionBinding,
 } from "./cli-session.js";
+import { FailoverError } from "./failover-error.js";
 
 describe("cli-session helpers", () => {
   it("persists binding metadata alongside legacy session ids", () => {
@@ -622,5 +625,37 @@ describe("cli-session helpers", () => {
   it("hashes trimmed extra system prompts consistently", () => {
     expect(hashCliSessionText("  keep this  ")).toBe(hashCliSessionText("keep this"));
     expect(hashCliSessionText("")).toBeUndefined();
+  });
+
+  it("shares failed reused-session cleanup policy across CLI entry points", () => {
+    const failover = new FailoverError("session expired", {
+      reason: "session_expired",
+      provider: "claude-cli",
+      model: "claude-opus-4-8",
+    });
+    const abort = Object.assign(new Error("aborted"), { name: "AbortError" });
+
+    const binding = { sessionId: "reused" };
+    const forkBinding = { sessionId: "fork-source", forkNextResume: true as const };
+
+    expect(shouldClearFailedCliSessionBinding({ error: failover, binding })).toBe(true);
+    expect(shouldClearFailedCliSessionBinding({ error: failover, binding: forkBinding })).toBe(
+      true,
+    );
+    expect(resolveCliSessionClearReason(failover)).toBe("session_expired");
+    expect(shouldClearFailedCliSessionBinding({ error: abort, binding })).toBe(true);
+    expect(shouldClearFailedCliSessionBinding({ error: abort, binding: forkBinding })).toBe(false);
+    expect(
+      shouldClearFailedCliSessionBinding({
+        error: failover,
+        binding,
+        hasNewGeneratedMediaTask: true,
+      }),
+    ).toBe(false);
+    expect(resolveCliSessionClearReason(abort)).toBe("AbortError");
+    expect(
+      shouldClearFailedCliSessionBinding({ error: new Error("provider failed"), binding }),
+    ).toBe(false);
+    expect(shouldClearFailedCliSessionBinding({ error: failover })).toBe(false);
   });
 });

--- a/src/agents/cli-session.ts
+++ b/src/agents/cli-session.ts
@@ -8,6 +8,8 @@ import { normalizeProviderId } from "@openclaw/model-catalog-core/provider-id";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import type { CliSessionBinding, SessionEntry } from "../config/sessions.js";
 import { normalizeCliSessionReseedReceipt } from "../config/sessions/cli-session-binding.js";
+import { readErrorName } from "../infra/errors.js";
+import { isFailoverError } from "./failover-error.js";
 export { getCliSessionBinding, getCliSessionId } from "../config/sessions/cli-session-binding.js";
 
 const CLAUDE_CLI_BACKEND_ID = "claude-cli";
@@ -116,6 +118,31 @@ export function clearAllCliSessions(entry: Partial<MutableCliSessionFields>): vo
   entry.cliSessionBindings = undefined;
   entry.cliSessionIds = undefined;
   entry.claudeCliSessionId = undefined;
+}
+
+/** Decide whether a failed CLI turn invalidates the binding it tried to resume. */
+export function shouldClearFailedCliSessionBinding(params: {
+  error: unknown;
+  binding?: CliSessionBinding;
+  hasNewGeneratedMediaTask?: boolean;
+}): boolean {
+  if (!normalizeOptionalString(params.binding?.sessionId)) {
+    return false;
+  }
+  // Detached media delivers back into this run later and still needs the binding.
+  if (params.hasNewGeneratedMediaTask === true) {
+    return false;
+  }
+  if (isFailoverError(params.error)) {
+    return true;
+  }
+  // A pre-successor fork abort keeps its one-shot marker for the next turn.
+  return params.binding?.forkNextResume !== true && readErrorName(params.error) === "AbortError";
+}
+
+/** Stable reason used when recording why a failed reused CLI session was cleared. */
+export function resolveCliSessionClearReason(error: unknown): string {
+  return isFailoverError(error) ? error.reason : (readErrorName(error) ?? "error");
 }
 
 type CliSessionInvalidatedReason = "auth-profile" | "auth-epoch" | "message-policy" | "cwd" | "mcp";

--- a/src/agents/command/attempt-execution.cli.test.ts
+++ b/src/agents/command/attempt-execution.cli.test.ts
@@ -553,6 +553,37 @@ describe("CLI attempt execution", () => {
     expect(persisted[sessionKey]?.claudeCliSessionId).toBeUndefined();
   });
 
+  it("clears a fork-marked Claude CLI session after terminal failover", async () => {
+    const sessionKey = "agent:main:direct:cli-fork-expired";
+    const cliSessionId = "expired-fork-source";
+    await writeClaudeCliAssistantTranscript(cliSessionId);
+    const sessionEntry = makeClaudeCliSessionEntry("session-cli-fork-expired", cliSessionId);
+    sessionEntry.cliSessionBindings!["claude-cli"]!.forkNextResume = true;
+    const sessionStore: Record<string, SessionEntry> = { [sessionKey]: sessionEntry };
+    await writeSessionStoreSeed(sessionStore);
+    runCliAgentMock.mockRejectedValueOnce(
+      new FailoverError("fork source expired", {
+        reason: "session_expired",
+        provider: "claude-cli",
+        model: "opus",
+      }),
+    );
+
+    await expect(
+      runClaudeCliAttempt({
+        sessionKey,
+        sessionEntry,
+        sessionStore,
+        body: "fork from an expired source",
+        runId: "run-cli-fork-expired",
+      }),
+    ).rejects.toMatchObject({ name: "FailoverError", reason: "session_expired" });
+
+    expect(firstRunCliAgentArg().forkCliSessionOnResume).toBe(true);
+    expect(sessionStore[sessionKey]?.cliSessionBindings?.["claude-cli"]).toBeUndefined();
+    expect(readSessionStore()[sessionKey]?.cliSessionBindings?.["claude-cli"]).toBeUndefined();
+  });
+
   it("preserves a reused Claude CLI session after detached media starts", async () => {
     const sessionKey = "agent:main:cron:job:run:run-id";
     const cliSessionId = "media-continuation-session";

--- a/src/agents/command/attempt-execution.ts
+++ b/src/agents/command/attempt-execution.ts
@@ -29,7 +29,6 @@ import {
 } from "../../gateway/server-methods/agent-timestamp.js";
 import { emitAgentAuditEvent, emitAgentEvent } from "../../infra/agent-events.js";
 import { emitTrustedDiagnosticEvent } from "../../infra/diagnostic-events.js";
-import { readErrorName } from "../../infra/errors.js";
 import { redactSensitiveText } from "../../logging/redact.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
 import type { PluginMetadataSnapshot } from "../../plugins/plugin-metadata-snapshot.types.js";
@@ -60,9 +59,12 @@ import {
 import { runCliAgent } from "../cli-runner.js";
 import { hasClaudeLiveSessionForOwner } from "../cli-runner/claude-live-session.js";
 import { resolveCliRuntimeToolsAllow } from "../cli-runner/tool-policy.js";
-import { getCliSessionBinding } from "../cli-session.js";
+import {
+  getCliSessionBinding,
+  resolveCliSessionClearReason,
+  shouldClearFailedCliSessionBinding,
+} from "../cli-session.js";
 import { runEmbeddedAgent, type EmbeddedAgentRunResult } from "../embedded-agent.js";
-import { FailoverError } from "../failover-error.js";
 import { runAgentHarnessBeforeMessageWriteHook } from "../harness/hook-helpers.js";
 import { resolveAvailableAgentHarnessPolicy } from "../harness/selection.js";
 import { resolveCliRuntimeExecutionProvider } from "../model-runtime-aliases.js";
@@ -95,20 +97,6 @@ export {
 } from "./attempt-execution.helpers.js";
 
 const log = createSubsystemLogger("agents/agent-command");
-
-function shouldClearReusedCliSessionAfterError(err: unknown): boolean {
-  if (readErrorName(err) === "AbortError") {
-    return true;
-  }
-  return err instanceof FailoverError;
-}
-
-function resolveClearedCliSessionReason(err: unknown): string {
-  if (err instanceof FailoverError) {
-    return err.reason;
-  }
-  return readErrorName(err) || "error";
-}
 
 function normalizeTranscriptMirrorText(value: string): string {
   return value.trim().replace(/\s+/gu, " ");
@@ -908,14 +896,19 @@ export function runAgentAttempt(params: {
         const failedCliSessionId = failedCliSessionBinding?.sessionId;
         if (
           isClaudeCliProvider(cliExecutionProvider) &&
-          failedCliSessionBinding?.forkNextResume !== true &&
-          shouldClearReusedCliSessionAfterError(err) &&
-          !hasNewGeneratedMediaTaskForSessionKey(params.sessionKey, mediaTaskIdsBefore) &&
+          shouldClearFailedCliSessionBinding({
+            error: err,
+            binding: failedCliSessionBinding,
+            hasNewGeneratedMediaTask: hasNewGeneratedMediaTaskForSessionKey(
+              params.sessionKey,
+              mediaTaskIdsBefore,
+            ),
+          }) &&
           failedCliSessionId &&
           mutableCliSessionStore
         ) {
           log.warn(
-            `CLI session cleared after failed reused turn: provider=${sanitizeForLog(cliExecutionProvider)} sessionKey=${mutableCliSessionStore.sessionKey} reason=${sanitizeForLog(resolveClearedCliSessionReason(err))}`,
+            `CLI session cleared after failed reused turn: provider=${sanitizeForLog(cliExecutionProvider)} sessionKey=${mutableCliSessionStore.sessionKey} reason=${sanitizeForLog(resolveCliSessionClearReason(err))}`,
           );
 
           params.sessionEntry =

--- a/src/auto-reply/reply/agent-runner-cli-candidate.ts
+++ b/src/auto-reply/reply/agent-runner-cli-candidate.ts
@@ -1,7 +1,10 @@
 import { resolveBootstrapWarningSignaturesSeen } from "../../agents/bootstrap-budget.js";
 import type { BootstrapContextRunKind } from "../../agents/bootstrap-mode.js";
 import type { RunCliAgentParams } from "../../agents/cli-runner/types.js";
-import { getCliSessionBinding } from "../../agents/cli-session.js";
+import {
+  getCliSessionBinding,
+  shouldClearFailedCliSessionBinding,
+} from "../../agents/cli-session.js";
 import type { RunEmbeddedAgentParams } from "../../agents/embedded-agent-runner/run/params.js";
 import type { FastModeAutoProgressState } from "../../agents/fast-mode.js";
 import {
@@ -10,6 +13,10 @@ import {
 } from "../../agents/run-termination.js";
 import { withLocalSessionPlacementTurnAdmission } from "../../agents/session-placement-admission.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import {
+  getGeneratedMediaTaskIdsForSessionKey,
+  hasNewGeneratedMediaTaskForSessionKey,
+} from "../../tasks/task-status-access.js";
 import type { ThinkLevel } from "../thinking.js";
 import type { ReplyPayload } from "../types.js";
 import {
@@ -18,7 +25,7 @@ import {
 } from "./agent-lifecycle-terminal.js";
 import { resolveRunAuthProfile } from "./agent-runner-auth-profile.js";
 import {
-  clearDroppedCliSessionBinding,
+  clearCliSessionBindingForRun,
   createCliReasoningStreamBridge,
   createCliToolSummaryTracker,
   keepCliSessionBindingOnlyWhenReused,
@@ -80,6 +87,7 @@ export async function runCliFallbackCandidate(params: {
     turn.getActiveSessionEntry(),
     params.cliExecutionProvider,
   );
+  const mediaTaskIdsBefore = getGeneratedMediaTaskIdsForSessionKey(turn.sessionKey);
   const cliLifecycleStartedAt = Date.now();
   const lifecycleBackstop = createAgentLifecycleTerminalBackstop({
     runId: params.runId,
@@ -144,6 +152,31 @@ export async function runCliFallbackCandidate(params: {
           onAgentRunStart: params.notifyAgentRunStart,
           suppressAssistantBridge: turn.followupRun.run.silentExpected,
           onActivity: () => turn.replyOperation?.recordActivity(),
+          onErrorBeforeLifecycle:
+            params.cliExecutionProvider === "claude-cli" && cliSessionBinding?.sessionId
+              ? async (error) => {
+                  if (
+                    !shouldClearFailedCliSessionBinding({
+                      error,
+                      binding: cliSessionBinding,
+                      hasNewGeneratedMediaTask: hasNewGeneratedMediaTaskForSessionKey(
+                        turn.sessionKey,
+                        mediaTaskIdsBefore,
+                      ),
+                    })
+                  ) {
+                    return;
+                  }
+                  await clearCliSessionBindingForRun({
+                    provider: params.cliExecutionProvider,
+                    expectedSessionId: cliSessionBinding.sessionId,
+                    sessionKey: turn.sessionKey,
+                    sessionStore: turn.activeSessionStore,
+                    storePath: turn.storePath,
+                    activeSessionEntry: turn.getActiveSessionEntry(),
+                  });
+                }
+              : undefined,
           preserveProgressCallbackStartOrder: params.preserveProgressCallbackStartOrder,
           onAssistantText: async (text) => {
             if (!params.preserveProgressCallbackStartOrder) {
@@ -343,8 +376,9 @@ export async function runCliFallbackCandidate(params: {
     ),
   );
   if (droppedCliSessionReplacement) {
-    await clearDroppedCliSessionBinding({
+    await clearCliSessionBindingForRun({
       provider: params.cliExecutionProvider,
+      expectedSessionId: cliSessionBinding?.sessionId,
       sessionKey: turn.sessionKey,
       sessionStore: turn.activeSessionStore,
       storePath: turn.storePath,

--- a/src/auto-reply/reply/agent-runner-cli-candidate.ts
+++ b/src/auto-reply/reply/agent-runner-cli-candidate.ts
@@ -87,7 +87,6 @@ export async function runCliFallbackCandidate(params: {
     turn.getActiveSessionEntry(),
     params.cliExecutionProvider,
   );
-  const mediaTaskIdsBefore = getGeneratedMediaTaskIdsForSessionKey(turn.sessionKey);
   const cliLifecycleStartedAt = Date.now();
   const lifecycleBackstop = createAgentLifecycleTerminalBackstop({
     runId: params.runId,
@@ -142,8 +141,11 @@ export async function runCliFallbackCandidate(params: {
         agentId: turn.followupRun.run.agentId,
         runId: params.runId,
       },
-      () =>
-        runCliAgentWithLifecycle({
+      () => {
+        // Admission may wait behind another turn that starts detached media.
+        // Snapshot only after this turn owns the session placement.
+        const mediaTaskIdsBefore = getGeneratedMediaTaskIdsForSessionKey(turn.sessionKey);
+        return runCliAgentWithLifecycle({
           runId: params.runId,
           lifecycleGeneration: params.lifecycleGeneration,
           provider: params.cliExecutionProvider,
@@ -372,7 +374,8 @@ export async function runCliFallbackCandidate(params: {
             onExecutionPhase: params.signalExecutionPhaseForTyping,
             replyOperation: turn.replyOperation,
           },
-        }),
+        });
+      },
     ),
   );
   if (droppedCliSessionReplacement) {

--- a/src/auto-reply/reply/agent-runner-cli-dispatch.test.ts
+++ b/src/auto-reply/reply/agent-runner-cli-dispatch.test.ts
@@ -1,8 +1,11 @@
 // Tests CLI dispatch arguments and runtime selection for agent runner turns.
+import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
 import type { EmbeddedAgentRunResult } from "../../agents/embedded-agent-runner/types.js";
 import { FailoverError } from "../../agents/failover-error.js";
 import { createAgentRunRestartAbortError } from "../../agents/run-termination.js";
+import { loadSessionEntry, replaceSessionEntry } from "../../config/sessions/session-accessor.js";
 import {
   emitAgentEvent,
   getAgentEventLifecycleGeneration,
@@ -10,6 +13,7 @@ import {
   resetAgentEventsForTest,
 } from "../../infra/agent-events.js";
 import {
+  clearCliSessionBindingForRun,
   createCliToolSummaryTracker,
   keepCliSessionBindingOnlyWhenReused,
   runCliAgentWithLifecycle,
@@ -26,6 +30,7 @@ type ReasoningProgressPayload = Parameters<
 const cliDispatchState = vi.hoisted(() => ({
   runCliAgentMock: vi.fn(),
 }));
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
 vi.mock("../../agents/cli-runner.js", () => ({
   runCliAgent: (...args: unknown[]) => cliDispatchState.runCliAgentMock(...args),
@@ -654,6 +659,62 @@ describe("keepCliSessionBindingOnlyWhenReused", () => {
     expect(onDroppedReplacement).toHaveBeenCalledOnce();
     expect(result.meta.agentMeta?.sessionId).toBe("");
     expect(result.meta.agentMeta?.cliSessionBinding).toBeUndefined();
+  });
+});
+
+describe("clearCliSessionBindingForRun", () => {
+  it("clears the expected binding from active and stored session entries", async () => {
+    const activeEntry = {
+      sessionId: "openclaw-active",
+      updatedAt: 1,
+      cliSessionBindings: { "claude-cli": { sessionId: "stale-session" } },
+      cliSessionIds: { "claude-cli": "stale-session" },
+      claudeCliSessionId: "stale-session",
+    };
+    const storedEntry = structuredClone(activeEntry);
+    const storePath = path.join(tempDirs.make("cli-session-cleanup-"), "sessions.json");
+    await replaceSessionEntry({ storePath, sessionKey: "main" }, structuredClone(activeEntry));
+
+    await clearCliSessionBindingForRun({
+      provider: "claude-cli",
+      expectedSessionId: "stale-session",
+      sessionKey: "main",
+      sessionStore: { main: storedEntry },
+      storePath,
+      activeSessionEntry: activeEntry,
+    });
+
+    for (const entry of [activeEntry, storedEntry]) {
+      expect(entry.cliSessionBindings?.["claude-cli"]).toBeUndefined();
+      expect(entry.cliSessionIds?.["claude-cli"]).toBeUndefined();
+      expect(entry.claudeCliSessionId).toBeUndefined();
+      expect(entry.updatedAt).toBeGreaterThan(1);
+    }
+    const persisted = loadSessionEntry({ storePath, sessionKey: "main" });
+    expect(persisted?.cliSessionBindings?.["claude-cli"]).toBeUndefined();
+    expect(persisted?.cliSessionIds?.["claude-cli"]).toBeUndefined();
+    expect(persisted?.claudeCliSessionId).toBeUndefined();
+  });
+
+  it("does not clear a replacement binding adopted by another turn", async () => {
+    const entry = {
+      sessionId: "openclaw-active",
+      updatedAt: 1,
+      cliSessionBindings: { "claude-cli": { sessionId: "replacement-session" } },
+      cliSessionIds: { "claude-cli": "replacement-session" },
+      claudeCliSessionId: "replacement-session",
+    };
+
+    await clearCliSessionBindingForRun({
+      provider: "claude-cli",
+      expectedSessionId: "stale-session",
+      activeSessionEntry: entry,
+    });
+
+    expect(entry.cliSessionBindings["claude-cli"].sessionId).toBe("replacement-session");
+    expect(entry.cliSessionIds["claude-cli"]).toBe("replacement-session");
+    expect(entry.claudeCliSessionId).toBe("replacement-session");
+    expect(entry.updatedAt).toBe(1);
   });
 });
 

--- a/src/auto-reply/reply/agent-runner-cli-dispatch.ts
+++ b/src/auto-reply/reply/agent-runner-cli-dispatch.ts
@@ -3,7 +3,7 @@ import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { runCliAgent } from "../../agents/cli-runner.js";
 import type { RunCliAgentParams } from "../../agents/cli-runner/types.js";
-import { clearCliSession } from "../../agents/cli-session.js";
+import { clearCliSession, getCliSessionBinding } from "../../agents/cli-session.js";
 import { extractToolResultText } from "../../agents/embedded-agent-subscribe.tools.js";
 import { inferToolMetaFromArgs } from "../../agents/embedded-agent-utils.js";
 import type { EmbeddedAgentRunResult } from "../../agents/embedded-agent.js";
@@ -218,8 +218,9 @@ export function keepCliSessionBindingOnlyWhenReused(params: {
   };
 }
 
-export async function clearDroppedCliSessionBinding(params: {
+export async function clearCliSessionBindingForRun(params: {
   provider: string;
+  expectedSessionId?: string;
   sessionKey?: string;
   sessionStore?: Record<string, SessionEntry>;
   storePath?: string;
@@ -228,6 +229,14 @@ export async function clearDroppedCliSessionBinding(params: {
   const updatedAt = Date.now();
   const clearEntry = (entry: SessionEntry | undefined) => {
     if (!entry) {
+      return;
+    }
+    // A later turn may already have adopted a replacement session; only the
+    // failed run that still owns this binding may clear it.
+    if (
+      params.expectedSessionId &&
+      getCliSessionBinding(entry, params.provider)?.sessionId !== params.expectedSessionId
+    ) {
       return;
     }
     clearCliSession(entry, params.provider);

--- a/src/auto-reply/reply/agent-runner-execution-cli-sessions.test.ts
+++ b/src/auto-reply/reply/agent-runner-execution-cli-sessions.test.ts
@@ -1,5 +1,10 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
+import { testing as cliBackendsTesting } from "../../agents/cli-backends.test-support.js";
+import type { RunCliAgentParams } from "../../agents/cli-runner/types.js";
+import { FailoverError } from "../../agents/failover-error.js";
 import type { SessionEntry } from "../../config/sessions.js";
+import { registerGeneratedMediaTaskActivity } from "../../tasks/generated-media-task-activity.js";
+import { resetGeneratedMediaTaskActivityForTests } from "../../tasks/task-runtime.test-helpers.js";
 import type { TemplateContext } from "../templating.js";
 import { SILENT_REPLY_TOKEN } from "../tokens.js";
 import {
@@ -16,6 +21,53 @@ import {
 import type { FallbackRunnerParams } from "./agent-runner-execution.test-support.js";
 
 const state = setupAgentRunnerExecutionTestState();
+afterEach(resetGeneratedMediaTaskActivityForTests);
+
+const expiredClaudeSessionProgram = String.raw`
+let input = "";
+process.stdin.setEncoding("utf8");
+process.stdin.on("data", (chunk) => { input += chunk; });
+process.stdin.on("end", () => {
+  if (!input.trim()) process.exit(2);
+  process.stdout.write(JSON.stringify({
+    type: "result",
+    subtype: "error_during_execution",
+    is_error: true,
+    session_id: "stale-cli-session",
+    result: "No conversation found with session ID stale-cli-session",
+  }) + "\n");
+});
+`;
+
+function useScriptedExpiredClaudeBackend() {
+  const backend = {
+    id: "claude-cli",
+    modelProvider: "anthropic",
+    pluginId: "anthropic",
+    bundleMcp: false,
+    config: {
+      command: process.execPath,
+      args: ["-e", expiredClaudeSessionProgram],
+      resumeArgs: ["-e", expiredClaudeSessionProgram, "--resume", "{sessionId}"],
+      input: "stdin" as const,
+      output: "jsonl" as const,
+      jsonlDialect: "claude-stream-json" as const,
+      sessionMode: "existing" as const,
+      systemPromptWhen: "never" as const,
+    },
+  };
+  cliBackendsTesting.setDepsForTest({
+    resolvePluginSetupCliBackend: ({ backend: id }) =>
+      id === backend.id ? { pluginId: backend.pluginId, backend } : undefined,
+    resolveRuntimeCliBackends: () => [backend],
+  });
+  state.runCliAgentMock.mockImplementationOnce((params: RunCliAgentParams) => {
+    if (!state.runCliAgentActual) {
+      throw new Error("real CLI runner was not initialized");
+    }
+    return state.runCliAgentActual(params);
+  });
+}
 
 describe("executeAgentTurn: CLI session routing", () => {
   it("forwards the static extra system prompt to CLI backends", async () => {
@@ -462,4 +514,127 @@ describe("executeAgentTurn: CLI session routing", () => {
     expect(result.runResult.meta?.agentMeta?.clearCliSessionBinding).toBeUndefined();
     expect(activeSessionStore.main.cliSessionBindings?.["codex-cli"]).toBeUndefined();
   });
+
+  it("clears a fork-marked Claude CLI binding when the channel turn fails", async () => {
+    state.isCliProviderMock.mockReturnValue(true);
+    state.runWithModelFallbackMock.mockImplementationOnce(async (params: FallbackRunnerParams) => ({
+      result: await params.run("claude-cli", "claude-opus-4-8"),
+      provider: "claude-cli",
+      model: "claude-opus-4-8",
+      attempts: [],
+    }));
+    state.runCliAgentMock.mockRejectedValueOnce(
+      new FailoverError("No conversation found", {
+        reason: "session_expired",
+        provider: "claude-cli",
+        model: "claude-opus-4-8",
+      }),
+    );
+
+    const followupRun = createFollowupRun();
+    followupRun.run.provider = "claude-cli";
+    followupRun.run.model = "claude-opus-4-8";
+    const sessionEntry = {
+      sessionId: "openclaw-session",
+      updatedAt: 1,
+      cliSessionBindings: {
+        "claude-cli": { sessionId: "stale-cli-session", forkNextResume: true },
+      },
+      cliSessionIds: { "claude-cli": "stale-cli-session" },
+      claudeCliSessionId: "stale-cli-session",
+    } as SessionEntry;
+    const activeSessionStore = { main: sessionEntry };
+    const executeAgentTurn = await getExecuteAgentTurnForTest();
+
+    const result = await executeAgentTurn({
+      ...createMinimalRunAgentTurnParams({ followupRun }),
+      activeSessionStore,
+      getActiveSessionEntry: () => sessionEntry,
+    });
+
+    expect(result.kind).toBe("final");
+    expect(sessionEntry.cliSessionBindings?.["claude-cli"]).toBeUndefined();
+    expect(sessionEntry.cliSessionIds?.["claude-cli"]).toBeUndefined();
+    expect(sessionEntry.claudeCliSessionId).toBeUndefined();
+  });
+
+  it("preserves a reused binding after a channel turn starts detached media", async () => {
+    const sessionKey = "agent:main:cron:media-job:run:run-1";
+    state.isCliProviderMock.mockReturnValue(true);
+    state.runWithModelFallbackMock.mockImplementationOnce(async (params: FallbackRunnerParams) => ({
+      result: await params.run("claude-cli", "claude-opus-4-8"),
+      provider: "claude-cli",
+      model: "claude-opus-4-8",
+      attempts: [],
+    }));
+    const abort = Object.assign(new Error("detached media continues"), { name: "AbortError" });
+    state.runCliAgentMock.mockImplementationOnce(async () => {
+      registerGeneratedMediaTaskActivity("tool:image_generate:run-1", sessionKey);
+      throw abort;
+    });
+
+    const followupRun = createFollowupRun();
+    followupRun.run.provider = "claude-cli";
+    followupRun.run.model = "claude-opus-4-8";
+    const sessionEntry = {
+      sessionId: "openclaw-session",
+      updatedAt: 1,
+      cliSessionBindings: { "claude-cli": { sessionId: "media-session" } },
+      cliSessionIds: { "claude-cli": "media-session" },
+      claudeCliSessionId: "media-session",
+    } as SessionEntry;
+    const activeSessionStore = { [sessionKey]: sessionEntry };
+    const executeAgentTurn = await getExecuteAgentTurnForTest();
+
+    await executeAgentTurn({
+      ...createMinimalRunAgentTurnParams({ followupRun }),
+      sessionKey,
+      activeSessionStore,
+      getActiveSessionEntry: () => sessionEntry,
+    });
+
+    expect(sessionEntry.cliSessionBindings?.["claude-cli"]?.sessionId).toBe("media-session");
+    expect(sessionEntry.cliSessionIds?.["claude-cli"]).toBe("media-session");
+    expect(sessionEntry.claudeCliSessionId).toBe("media-session");
+  });
+
+  it("clears a reused binding after a real CLI subprocess reports an expired session", async () => {
+    state.isCliProviderMock.mockReturnValue(true);
+    state.runWithModelFallbackMock.mockImplementationOnce(async (params: FallbackRunnerParams) => ({
+      result: await params.run("claude-cli", "claude-opus-4-8"),
+      provider: "claude-cli",
+      model: "claude-opus-4-8",
+      attempts: [],
+    }));
+    useScriptedExpiredClaudeBackend();
+
+    const followupRun = createFollowupRun();
+    followupRun.run.provider = "claude-cli";
+    followupRun.run.model = "claude-opus-4-8";
+    followupRun.run.skillsSnapshot = { prompt: "", skills: [], version: 0 };
+    followupRun.run.timeoutMs = 10_000;
+    const sessionEntry = {
+      sessionId: "openclaw-session",
+      updatedAt: 1,
+      cliSessionBindings: { "claude-cli": { sessionId: "stale-cli-session" } },
+      cliSessionIds: { "claude-cli": "stale-cli-session" },
+      claudeCliSessionId: "stale-cli-session",
+    } as SessionEntry;
+    const activeSessionStore = { main: sessionEntry };
+    const executeAgentTurn = await getExecuteAgentTurnForTest();
+
+    const result = await executeAgentTurn({
+      ...createMinimalRunAgentTurnParams({ followupRun }),
+      activeSessionStore,
+      getActiveSessionEntry: () => sessionEntry,
+    });
+
+    expect(result.kind).toBe("final");
+    expect(state.runCliAgentMock.mock.calls[0]?.[0]).toMatchObject({
+      cliSessionId: "stale-cli-session",
+    });
+    expect(sessionEntry.cliSessionBindings?.["claude-cli"]).toBeUndefined();
+    expect(sessionEntry.cliSessionIds?.["claude-cli"]).toBeUndefined();
+    expect(sessionEntry.claudeCliSessionId).toBeUndefined();
+  }, 15_000);
 });

--- a/src/auto-reply/reply/agent-runner-execution-cli-sessions.test.ts
+++ b/src/auto-reply/reply/agent-runner-execution-cli-sessions.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it } from "vitest";
 import { testing as cliBackendsTesting } from "../../agents/cli-backends.test-support.js";
 import type { RunCliAgentParams } from "../../agents/cli-runner/types.js";
 import { FailoverError } from "../../agents/failover-error.js";
+import { installSessionPlacementAdmissionProvider } from "../../agents/session-placement-admission.js";
 import type { SessionEntry } from "../../config/sessions.js";
 import { registerGeneratedMediaTaskActivity } from "../../tasks/generated-media-task-activity.js";
 import { resetGeneratedMediaTaskActivityForTests } from "../../tasks/task-runtime.test-helpers.js";
@@ -596,6 +597,75 @@ describe("executeAgentTurn: CLI session routing", () => {
     expect(sessionEntry.cliSessionBindings?.["claude-cli"]?.sessionId).toBe("media-session");
     expect(sessionEntry.cliSessionIds?.["claude-cli"]).toBe("media-session");
     expect(sessionEntry.claudeCliSessionId).toBe("media-session");
+  });
+
+  it("does not attribute media from an earlier admitted turn to a queued failure", async () => {
+    const sessionKey = "agent:main:cron:media-job:run:run-queued";
+    state.isCliProviderMock.mockReturnValue(true);
+    state.runWithModelFallbackMock.mockImplementationOnce(async (params: FallbackRunnerParams) => ({
+      result: await params.run("claude-cli", "claude-opus-4-8"),
+      provider: "claude-cli",
+      model: "claude-opus-4-8",
+      attempts: [],
+    }));
+    state.runCliAgentMock.mockRejectedValueOnce(
+      new FailoverError("queued session expired", {
+        reason: "session_expired",
+        provider: "claude-cli",
+        model: "claude-opus-4-8",
+      }),
+    );
+
+    let releaseAdmission!: () => void;
+    const admissionGate = new Promise<void>((resolve) => {
+      releaseAdmission = resolve;
+    });
+    let notifyAdmissionWait!: () => void;
+    const admissionWait = new Promise<void>((resolve) => {
+      notifyAdmissionWait = resolve;
+    });
+    const restoreAdmission = installSessionPlacementAdmissionProvider({
+      executeLocalTurn: async (_claim, runLocal) => {
+        notifyAdmissionWait();
+        await admissionGate;
+        return await runLocal();
+      },
+      executeTurn: async (_claim, _params, runLocal) => await runLocal(),
+    });
+
+    const followupRun = createFollowupRun();
+    followupRun.run.provider = "claude-cli";
+    followupRun.run.model = "claude-opus-4-8";
+    const sessionEntry = {
+      sessionId: "openclaw-session",
+      updatedAt: 1,
+      cliSessionBindings: { "claude-cli": { sessionId: "queued-stale-session" } },
+      cliSessionIds: { "claude-cli": "queued-stale-session" },
+      claudeCliSessionId: "queued-stale-session",
+    } as SessionEntry;
+    const activeSessionStore = { [sessionKey]: sessionEntry };
+    const executeAgentTurn = await getExecuteAgentTurnForTest();
+
+    try {
+      const runPromise = executeAgentTurn({
+        ...createMinimalRunAgentTurnParams({ followupRun }),
+        sessionKey,
+        activeSessionStore,
+        getActiveSessionEntry: () => sessionEntry,
+      });
+      await admissionWait;
+      registerGeneratedMediaTaskActivity("tool:image_generate:earlier-turn", sessionKey);
+      releaseAdmission();
+      const result = await runPromise;
+
+      expect(result.kind).toBe("final");
+      expect(sessionEntry.cliSessionBindings?.["claude-cli"]).toBeUndefined();
+      expect(sessionEntry.cliSessionIds?.["claude-cli"]).toBeUndefined();
+      expect(sessionEntry.claudeCliSessionId).toBeUndefined();
+    } finally {
+      releaseAdmission();
+      restoreAdmission();
+    }
   });
 
   it("clears a reused binding after a real CLI subprocess reports an expired session", async () => {


### PR DESCRIPTION
Closes #97887

## What Problem This Solves

Fixes an issue where channel users on the Claude CLI backend could get stuck in a permanent failure loop after the persisted Claude session disappeared. Every later message retried the same dead session until an operator manually edited `sessions.json`.

## Why This Change Was Made

Channel and command turns now share one failed-session cleanup policy. Terminal failovers clear the exact stale binding, while fork-abort recovery and detached-media continuations retain the binding they still need; compare-and-clear ownership prevents an older failed turn from deleting a newer replacement session.

## User Impact

After an expired Claude CLI session fails, the next channel turn starts fresh instead of repeatedly resuming a missing session. The fix applies to the shared channel runner rather than one transport.

## Evidence

- Live Claude Code 2.1.204 probe through the production `--resume` stream-JSON shape returned `error_during_execution`, `is_error: true`, and `No conversation found with session ID` for a missing session, with zero API turns and zero cost.
- `node scripts/run-vitest.mjs src/auto-reply/reply/agent-runner-cli-dispatch.test.ts src/auto-reply/reply/agent-runner-execution-cli-sessions.test.ts src/agents/cli-session.test.ts src/agents/command/attempt-execution.cli.test.ts` — 132 tests passed on rebased head `d38ec8856117`.
- The regression suite includes a real JSONL subprocess, persisted `sessions.json` assertions, forked-resume policy, detached-media preservation, replacement-binding ownership, and queued-turn admission ordering.
- Blacksmith Testbox `tbx_01kynxmkk073re69s1khddfkfx` / Actions run https://github.com/openclaw/openclaw/actions/runs/30418861837 — `node scripts/check-changed.mjs` passed.
- Codex autoreview on the exact branch diff: no accepted/actionable findings, confidence 0.91.
