### PR TITLE
fix(ui): give Memory settings path-based tab URLs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,6 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
-- **Control UI Memory URLs:** give Overview, Memories, Dreams, and Settings stable path-based URLs, and normalize legacy query links with one history replacement so stale deployments cannot oscillate between tab forms.
 - **Control UI cloud workspace conflicts:** surface staged-ref guidance, bounded conflicted paths, structured transcript events, and sidebar attention for cloud worker results that kept local versions.
 - **Control UI update recovery:** the "A new version is available" Reload button now waits out the gateway restart that stranded the chunk and reloads as soon as it answers, instead of silently doing nothing and leaving a manual hard reload as the only way out.
 - **Control UI sender identity polish:** attributed user messages show the author's real avatar in an always-visible gutter on identity-resolving gateways, sender labels drop the opaque profile-UUID suffix (new and historical transcripts), and profile-id senders resolve avatars through the canonical gateway route.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
+- **Control UI Memory URLs:** give Overview, Memories, Dreams, and Settings stable path-based URLs, and normalize legacy query links with one history replacement so stale deployments cannot oscillate between tab forms.
 - **Control UI cloud workspace conflicts:** surface staged-ref guidance, bounded conflicted paths, structured transcript events, and sidebar attention for cloud worker results that kept local versions.
 - **Control UI update recovery:** the "A new version is available" Reload button now waits out the gateway restart that stranded the chunk and reloads as soon as it answers, instead of silently doing nothing and leaving a manual hard reload as the only way out.
 - **Control UI sender identity polish:** attributed user messages show the author's real avatar in an always-visible gutter on identity-resolving gateways, sender labels drop the opaque profile-UUID suffix (new and historical transcripts), and profile-id senders resolve avatars through the canonical gateway route.

--- a/docs/web/urls.md
+++ b/docs/web/urls.md
@@ -144,6 +144,7 @@ no route-specific URL parameters.
 | Approvals           | `/settings/approvals`       | -                         | Shared settings parameters below                 |
 | Automation settings | `/settings/automation`      | `/automation`             | Shared settings parameters below                 |
 | MCP                 | `/settings/mcp`             | `/mcp`                    | Shared settings parameters below                 |
+| Memory              | `/settings/memory`          | -                         | `/settings/memory/memories\|dreams\|settings`    |
 | Infrastructure      | `/settings/infrastructure`  | `/infrastructure`         | Shared settings parameters below                 |
 | Labs                | `/settings/labs`            | -                         | Shared settings parameters below                 |
 | About               | `/settings/about`           | -                         | Shared settings parameters below                 |
@@ -168,6 +169,11 @@ no route-specific URL parameters.
 Settings routes that use schema-backed deep links accept `?section=<section>`,
 `?advanced=1`, and `#<setting-id>`. These values select content within the page;
 they do not change the route identity.
+
+Memory tabs use the paths in the table instead of `?tab=`. Older Memory links
+with `?tab=memories|dreams|settings`, `?tab=dreaming`, `?tab=search`, or
+`?section=memory` are replaced once with the corresponding path while keeping
+any setting anchor.
 
 ## Special documents and startup modes
 

--- a/ui/src/app-navigation.ts
+++ b/ui/src/app-navigation.ts
@@ -133,6 +133,7 @@ type SettingsNavigationGroup = {
 export type SettingsSearchBlock = {
   routeId: RouteId;
   label: string;
+  pathname?: string;
   search?: string;
   hash: string;
 };

--- a/ui/src/app-route-paths.test.ts
+++ b/ui/src/app-route-paths.test.ts
@@ -1,0 +1,84 @@
+// @vitest-environment node
+import type { RouteLocation, RouterHistory } from "@openclaw/uirouter";
+import { describe, expect, it, vi } from "vitest";
+import {
+  inferBasePathFromPathname,
+  memoryTabFromPath,
+  pathForMemoryTab,
+  routeIdFromPath,
+  type MemoryRouteTab,
+} from "./app-route-paths.ts";
+import { createApplicationRouter, startApplicationRouter } from "./app-routes.ts";
+import type { ApplicationContext } from "./app/context.ts";
+
+describe("Memory tab route paths", () => {
+  it.each([
+    ["overview", "/settings/memory"],
+    ["memories", "/settings/memory/memories"],
+    ["dreams", "/settings/memory/dreams"],
+    ["settings", "/settings/memory/settings"],
+  ] as const)("round-trips %s through its canonical path", (tab, pathname) => {
+    expect(pathForMemoryTab(tab)).toBe(pathname);
+    expect(memoryTabFromPath(pathname)).toBe(tab);
+    expect(routeIdFromPath(pathname)).toBe("memory");
+  });
+
+  it.each(["overview", "memories", "dreams", "settings"] as const)(
+    "round-trips %s under a configured base path",
+    (tab: MemoryRouteTab) => {
+      const pathname = pathForMemoryTab(tab, "/ui");
+      expect(memoryTabFromPath(pathname, "/ui")).toBe(tab);
+      expect(routeIdFromPath(pathname, "/ui")).toBe("memory");
+      expect(inferBasePathFromPathname(pathname)).toBe("/ui");
+    },
+  );
+
+  it("rejects unknown and nested Memory tab segments", () => {
+    expect(memoryTabFromPath("/settings/memory/unknown")).toBeNull();
+    expect(memoryTabFromPath("/settings/memory/dreams/extra")).toBeNull();
+    expect(routeIdFromPath("/settings/memory/unknown")).toBeNull();
+    expect(routeIdFromPath("/settings/memory/dreams/extra")).toBeNull();
+  });
+
+  it("publishes the real dynamic pathname after the exact-match startup bridge", async () => {
+    let location: RouteLocation = {
+      pathname: "/settings/memory/settings",
+      search: "",
+      hash: "#memory-backend",
+    };
+    const push = vi.fn((next: RouteLocation) => {
+      location = next;
+    });
+    const replace = vi.fn((next: RouteLocation) => {
+      location = next;
+    });
+    const history: RouterHistory = {
+      location: () => location,
+      push,
+      replace,
+      listen: () => () => undefined,
+    };
+    const router = createApplicationRouter();
+    const memoryRoute = router.getRoute("memory");
+    if (!memoryRoute) {
+      throw new Error("Memory route missing");
+    }
+    memoryRoute.component = async () => ({ render: () => null });
+    const context = {
+      basePath: "",
+      runtimeConfig: {
+        ensureLoaded: () => Promise.resolve(),
+        ensureSchemaLoaded: () => Promise.resolve(),
+      },
+    } as unknown as ApplicationContext;
+
+    await startApplicationRouter(router, history, "", context);
+
+    expect(router.getState().location).toEqual(location);
+    expect(router.getState().matches[0]?.location).toEqual(location);
+    expect(location.pathname).toBe("/settings/memory/settings");
+    expect(push).not.toHaveBeenCalled();
+    expect(replace).not.toHaveBeenCalled();
+    router.stop();
+  });
+});

--- a/ui/src/app-route-paths.ts
+++ b/ui/src/app-route-paths.ts
@@ -3,6 +3,9 @@ import type { RouteLocation } from "@openclaw/uirouter";
 import { isValidWorkboardBoardId } from "@openclaw/workboard-contract";
 import type { BoardFace } from "./lib/board/settings.ts";
 export const INTERNAL_SESSION_PATH_PARAM = "__openclawSessionPath";
+export const INTERNAL_MEMORY_PATH_PARAM = "__openclawMemoryPath";
+
+export type MemoryRouteTab = "overview" | "memories" | "dreams" | "settings";
 
 const APP_ROUTE_DEFINITIONS = {
   chat: { path: "/chat" },
@@ -93,6 +96,25 @@ export function pathForWorkboardBoard(boardId: string, basePath = ""): string {
   return `${pathForRoute("workboard", basePath)}/${encodedBoardId}`;
 }
 
+export function pathForMemoryTab(tab: MemoryRouteTab, basePath = ""): string {
+  const memoryPath = pathForRoute("memory", basePath);
+  return tab === "overview" ? memoryPath : `${memoryPath}/${tab}`;
+}
+
+export function memoryTabFromPath(pathname: string, basePath = ""): MemoryRouteTab | null {
+  const normalizedPath = normalizePath(pathname);
+  const memoryPath = pathForRoute("memory", basePath);
+  if (normalizedPath === memoryPath) {
+    return "overview";
+  }
+  const prefix = `${memoryPath}/`;
+  if (!normalizedPath.startsWith(prefix)) {
+    return null;
+  }
+  const segment = normalizedPath.slice(prefix.length);
+  return segment === "memories" || segment === "dreams" || segment === "settings" ? segment : null;
+}
+
 export function isSessionRouteId(routeId: string | null | undefined): routeId is BoardFace {
   return routeId === "chat" || routeId === "dashboard";
 }
@@ -149,6 +171,9 @@ export function routeIdFromPath(pathname: string, basePath = ""): RouteId | null
     : normalizedPath;
   if (workboardBoardIdFromPath(normalizedPath, normalizedBasePath)) {
     return "workboard";
+  }
+  if (memoryTabFromPath(normalizedPath, normalizedBasePath)) {
+    return "memory";
   }
   const sessionNamespace = sessionRouteNamespaceFromPath(normalizedPath, normalizedBasePath);
   if (sessionNamespace) {
@@ -214,14 +239,21 @@ export function inferBasePathFromPathname(pathname: string): string {
     const candidate = `/${segments.slice(index).join("/")}`;
     const routePath = routePaths.find((path) => normalizePath(path) === candidate);
     const dynamicWorkboardRoute = workboardBoardIdFromPath(candidate) !== null;
-    const dynamicSessionRoute = sessionRouteNamespaceFromPath(candidate) !== null;
-    if (!routePath && !dynamicWorkboardRoute && !dynamicSessionRoute) {
+    const dynamicMemoryRoute = memoryTabFromPath(candidate) !== null;
+    const sessionNamespace = sessionRouteNamespaceFromPath(candidate);
+    const dynamicSessionRoute = sessionNamespace !== null;
+    if (!routePath && !dynamicWorkboardRoute && !dynamicMemoryRoute && !dynamicSessionRoute) {
       continue;
     }
     const previousSegment = segments[index - 1];
-    const firstRouteSegment = (routePath ?? APP_ROUTE_DEFINITIONS.workboard.path)
-      .split("/")
-      .find(Boolean);
+    const dynamicRoutePath = dynamicWorkboardRoute
+      ? APP_ROUTE_DEFINITIONS.workboard.path
+      : dynamicMemoryRoute
+        ? APP_ROUTE_DEFINITIONS.memory.path
+        : sessionNamespace
+          ? APP_ROUTE_DEFINITIONS[sessionNamespace].path
+          : null;
+    const firstRouteSegment = (routePath ?? dynamicRoutePath ?? "").split("/").find(Boolean);
     if (
       index > 0 &&
       previousSegment === firstRouteSegment &&

--- a/ui/src/app-routes.ts
+++ b/ui/src/app-routes.ts
@@ -2,6 +2,8 @@ import { createRouter } from "@openclaw/uirouter";
 import type { PageDefinition, Router, RouterHistory } from "@openclaw/uirouter";
 import {
   INTERNAL_SESSION_PATH_PARAM,
+  INTERNAL_MEMORY_PATH_PARAM,
+  memoryTabFromPath,
   pathForRoute,
   routeIdFromPath,
   sessionRouteNamespaceFromPath,
@@ -107,6 +109,10 @@ function dynamicRouteFromPath(pathname: string, basePath: string): DynamicRoute 
   const boardId = workboardBoardIdFromPath(pathname, basePath);
   if (boardId) {
     return ["workboard", "board", boardId];
+  }
+  const memoryTab = memoryTabFromPath(pathname, basePath);
+  if (memoryTab && memoryTab !== "overview") {
+    return ["memory", INTERNAL_MEMORY_PATH_PARAM, pathname];
   }
   const sessionNamespace = sessionRouteNamespaceFromPath(pathname, basePath);
   return sessionNamespace ? [sessionNamespace, INTERNAL_SESSION_PATH_PARAM, pathname] : null;

--- a/ui/src/app/app-host.ts
+++ b/ui/src/app/app-host.ts
@@ -1799,6 +1799,7 @@ class OpenClawShell extends OpenClawLightDomElement {
       value: runtimeConfig.configForm ?? runtimeConfig.configSnapshot?.config ?? null,
       uiHints: runtimeConfig.configUiHints,
       identityAvailable: Boolean(gatewaySnapshot.selfUser),
+      basePath: context.basePath,
     });
     const onboarding = this.onboardingMode;
     const navDrawerOpen = this.navDrawerOpen && !onboarding;
@@ -1886,6 +1887,7 @@ class OpenClawShell extends OpenClawLightDomElement {
       ? renderSettingsSidebar({
           basePath: context.basePath,
           activeRouteId: activeRoute,
+          activePathname: this.routeState.location?.pathname ?? "",
           activeSearch: this.routeState.location?.search ?? "",
           activeHash: this.routeState.location?.hash ?? "",
           offline: gatewaySnapshot.offlineStable,

--- a/ui/src/components/hub-tabs.ts
+++ b/ui/src/components/hub-tabs.ts
@@ -16,6 +16,7 @@ type HubTabsProps<T extends string> = {
   ariaLabel: string;
   panelId: string;
   className?: string;
+  userSelectionOnly?: boolean;
   onSelect: (tab: T) => void;
 };
 
@@ -27,6 +28,11 @@ let pendingFocus: { hubId: string; tab: string; at: number } | null = null;
 let pointerActivation: { hubId: string; tab: string } | null = null;
 
 function selectHubTab<T extends string>(tab: T, props: HubTabsProps<T>) {
+  if (props.userSelectionOnly) {
+    // Manual activation below makes click/Enter/Space the only route writers;
+    // setup-time tab-show events must not navigate or they can oscillate paths.
+    return;
+  }
   const activatedByPointer = pointerActivation?.hubId === props.id && pointerActivation.tab === tab;
   pointerActivation = null;
   if (!activatedByPointer && tab !== props.active) {
@@ -74,10 +80,27 @@ export function renderHubTabs<T extends string>(props: HubTabsProps<T>): Templat
             class="hub-tab"
             ?active=${selected}
             @click=${(event: MouseEvent) => {
+              if (props.userSelectionOnly) {
+                pointerActivation = null;
+                if ((event.detail > 0 || event.isTrusted) && tab.value !== props.active) {
+                  props.onSelect(tab.value);
+                }
+                return;
+              }
               pointerActivation = event.detail > 0 ? { hubId: props.id, tab: tab.value } : null;
             }}
-            @keydown=${() => {
+            @keydown=${(event: KeyboardEvent) => {
               pointerActivation = null;
+              if (
+                props.userSelectionOnly &&
+                !event.repeat &&
+                (event.key === "Enter" || event.key === " ") &&
+                tab.value !== props.active
+              ) {
+                event.preventDefault();
+                pendingFocus = { hubId: props.id, tab: tab.value, at: Date.now() };
+                props.onSelect(tab.value);
+              }
             }}
             ${selected ? ref((element) => reclaimFocus(props.id, tab.value, element)) : nothing}
           >

--- a/ui/src/components/settings-sidebar.test.ts
+++ b/ui/src/components/settings-sidebar.test.ts
@@ -188,6 +188,50 @@ describe("settings sidebar search", () => {
     });
   });
 
+  it("keeps Memory search results on the canonical Settings tab path", () => {
+    const onNavigate = vi.fn();
+    render(
+      renderSettingsSidebar({
+        basePath: "/ui",
+        activeRouteId: "memory",
+        activePathname: "/ui/settings/memory/settings",
+        activeHash: "#memory-backend",
+        offline: false,
+        lastError: null,
+        version: "",
+        updateAvailable: null,
+        updateRunning: false,
+        onUpdate: vi.fn(),
+        searchQuery: "backend",
+        searchBlockMatches: [
+          {
+            routeId: "memory",
+            label: "Memory",
+            pathname: "/ui/settings/memory/settings",
+            hash: "#memory-backend",
+          },
+        ],
+        onExit: vi.fn(),
+        onRetryConnect: vi.fn(),
+        onNavigate,
+        onSearchQueryChange: vi.fn(),
+        preloadTimers: new Map(),
+      }),
+      container,
+    );
+
+    const link = container.querySelector<HTMLAnchorElement>(
+      '.settings-sidebar__subitem[href="/ui/settings/memory/settings#memory-backend"]',
+    );
+    expect(link).not.toBeNull();
+    expect(link?.getAttribute("aria-current")).toBe("location");
+    link?.click();
+    expect(onNavigate).toHaveBeenCalledWith("memory", {
+      pathname: "/ui/settings/memory/settings",
+      hash: "#memory-backend",
+    });
+  });
+
   it("filters localized routes and groups while preserving navigation", () => {
     let searchQuery = "";
     const onNavigate = vi.fn();

--- a/ui/src/components/settings-sidebar.ts
+++ b/ui/src/components/settings-sidebar.ts
@@ -24,6 +24,7 @@ import "./sidebar-update-card.ts";
 type SettingsSidebarProps = {
   basePath: string;
   activeRouteId: RouteId;
+  activePathname?: string;
   activeSearch?: string;
   activeHash?: string;
   offline: boolean;
@@ -54,6 +55,9 @@ type SettingsNavigationItemView = {
 };
 
 function isRedundantRouteBlock(routeId: RouteId, block: SettingsSearchBlock): boolean {
+  if (block.pathname) {
+    return false;
+  }
   const blockLabel = normalizeLowercaseStringOrEmpty(block.label);
   return [settingsNavigationLabelForRoute(routeId), titleForRoute(routeId)].some(
     (label) => normalizeLowercaseStringOrEmpty(label) === blockLabel,
@@ -96,7 +100,7 @@ function filterSettingsNavigationGroups(
   const blocksByRoute = new Map<RouteId, SettingsSearchBlock[]>();
   const seenBlocks = new Set<string>();
   for (const block of blockMatches) {
-    const blockKey = `${block.routeId}\u0000${block.search ?? ""}\u0000${block.hash}`;
+    const blockKey = `${block.routeId}\u0000${block.pathname ?? ""}\u0000${block.search ?? ""}\u0000${block.hash}`;
     if (seenBlocks.has(blockKey)) {
       continue;
     }
@@ -170,9 +174,11 @@ function renderItem(props: SettingsSidebarProps, routeId: RouteId, label?: strin
 }
 
 function renderBlockItem(props: SettingsSidebarProps, block: SettingsSearchBlock) {
-  const href = pathForRoute(block.routeId, props.basePath) + (block.search ?? "") + block.hash;
+  const pathname = block.pathname ?? pathForRoute(block.routeId, props.basePath);
+  const href = pathname + (block.search ?? "") + block.hash;
   const active =
     props.activeRouteId === block.routeId &&
+    (block.pathname === undefined || props.activePathname === block.pathname) &&
     props.activeHash === block.hash &&
     (block.search === undefined || props.activeSearch === block.search);
   return html`
@@ -193,6 +199,7 @@ function renderBlockItem(props: SettingsSidebarProps, block: SettingsSearchBlock
         }
         event.preventDefault();
         props.onNavigate(block.routeId, {
+          ...(block.pathname ? { pathname: block.pathname } : {}),
           ...(block.search ? { search: block.search } : {}),
           hash: block.hash,
         });

--- a/ui/src/pages/config/config-page.test.ts
+++ b/ui/src/pages/config/config-page.test.ts
@@ -104,6 +104,9 @@ describe("ConfigPage moved section routes", () => {
       context: { navigate: typeof navigate };
       pageId: "communications";
       routeData: {
+        pathname: string;
+        search: string;
+        hash: string;
         section: string;
         advanced: boolean;
         tab: string | null;
@@ -113,7 +116,15 @@ describe("ConfigPage moved section routes", () => {
     };
     state.context = { navigate };
     state.pageId = "communications";
-    state.routeData = { section, advanced: false, tab: null, targetBlockId: null };
+    state.routeData = {
+      pathname: "/settings/communications",
+      search: `?section=${section}`,
+      hash: "",
+      section,
+      advanced: false,
+      tab: null,
+      targetBlockId: null,
+    };
 
     state.syncRouteData();
 
@@ -127,6 +138,9 @@ describe("ConfigPage moved section routes", () => {
       context: { navigate: typeof navigate };
       pageId: "ai-agents";
       routeData: {
+        pathname: string;
+        search: string;
+        hash: string;
         section: string;
         advanced: boolean;
         tab: string | null;
@@ -136,7 +150,15 @@ describe("ConfigPage moved section routes", () => {
     };
     state.context = { navigate };
     state.pageId = "ai-agents";
-    state.routeData = { section: "models", advanced: false, tab: null, targetBlockId: null };
+    state.routeData = {
+      pathname: "/settings/ai-agents",
+      search: "?section=models",
+      hash: "",
+      section: "models",
+      advanced: false,
+      tab: null,
+      targetBlockId: null,
+    };
 
     state.syncRouteData();
 
@@ -150,6 +172,9 @@ describe("ConfigPage moved section routes", () => {
       context: { navigate: typeof navigate };
       pageId: "config";
       routeData: {
+        pathname: string;
+        search: string;
+        hash: string;
         section: string | null;
         advanced: boolean;
         tab: string | null;
@@ -160,6 +185,9 @@ describe("ConfigPage moved section routes", () => {
     state.context = { navigate };
     state.pageId = "config";
     state.routeData = {
+      pathname: "/settings/general",
+      search: "",
+      hash: "#settings-general-model",
       section: null,
       advanced: false,
       tab: null,

--- a/ui/src/pages/config/config-page.ts
+++ b/ui/src/pages/config/config-page.ts
@@ -50,7 +50,7 @@ import {
 } from "./config-sections.ts";
 import { renderMcp } from "./mcp.ts";
 import { renderMemoryPage } from "./memory-page.ts";
-import { memoryTabForRoute, narrowMemorySchema } from "./memory-schema.ts";
+import { narrowMemorySchema } from "./memory-schema.ts";
 import { renderQuickSettings } from "./quick.ts";
 import { configTargetIdFromHash, type ConfigRouteData } from "./route-data.ts";
 import { renderSecurity, type SecurityOverview } from "./security.ts";
@@ -1042,7 +1042,7 @@ export class ConfigPage extends OpenClawLightDomElement {
         configObject,
         pluginsHref: pathForRoute("plugins", this.context.basePath),
         memoryImportHref: pathForRoute("memory-import", this.context.basePath),
-        tab: memoryTabForRoute(this.routeData ?? {}),
+        routeData: this.routeData,
         // Memory's engine and backend are product decisions, not power-user
         // knobs: this page forces the advanced tier open so they never hide
         // behind the global Advanced toggle.

--- a/ui/src/pages/config/memory-page.test.ts
+++ b/ui/src/pages/config/memory-page.test.ts
@@ -1,16 +1,36 @@
 /* @vitest-environment jsdom */
 
+import { ContextProvider } from "@lit/context";
 import { describe, expect, it, vi } from "vitest";
-import type { ApplicationContext } from "../../app/context.ts";
+import {
+  applicationContext,
+  type ApplicationContext,
+  type ApplicationNavigationOptions,
+} from "../../app/context.ts";
 import type { PluginCatalogItem } from "../../lib/plugins/index.ts";
 import { waitForFast } from "../../test-helpers/wait-for.ts";
+import { configRouteData, type ConfigRouteData } from "./route-data.ts";
 import "./memory-page.ts";
 
 type MemoryPageElement = HTMLElement & {
   configObject: Record<string, unknown>;
-  tab: string | null;
-  updateComplete: Promise<unknown>;
+  routeData: ConfigRouteData | null;
+  updateComplete: Promise<boolean>;
+  requestUpdate: () => void;
 };
+
+function memoryRoute(url: string): ConfigRouteData {
+  const parsed = new URL(url, "https://control.test");
+  return configRouteData({
+    pathname: parsed.pathname,
+    search: parsed.search,
+    hash: parsed.hash,
+  });
+}
+
+function memoryTabRoute(tab: "overview" | "memories" | "dreams" | "settings") {
+  return memoryRoute(`/settings/memory${tab === "overview" ? "" : `/${tab}`}`);
+}
 
 function engine(id: string, enabled: boolean): PluginCatalogItem {
   return {
@@ -33,7 +53,10 @@ function createPage(params: {
   catalog?: readonly PluginCatalogItem[];
   patchForm?: (path: Array<string | number>, value: unknown) => void;
   setEnabled?: () => Promise<unknown>;
-  navigate?: (routeId: string, options?: { search?: string }) => void;
+  navigate?: (routeId: string, options?: ApplicationNavigationOptions) => void;
+  replace?: (routeId: string, options?: ApplicationNavigationOptions) => void;
+  routeData?: ConfigRouteData;
+  basePath?: string;
   agents?: Array<{ id: string; name?: string }>;
   memoryStatus?: (agentId: string) => Promise<unknown>;
   lookupSchemaPath?: (call: number) => Promise<unknown>;
@@ -69,7 +92,7 @@ function createPage(params: {
   };
   const element = document.createElement("openclaw-memory-settings") as MemoryPageElement;
   element.configObject = params.configObject;
-  element.tab = "settings";
+  element.routeData = params.routeData ?? memoryTabRoute("settings");
   const runtimeConfig = {
     state: {
       client: {},
@@ -91,8 +114,10 @@ function createPage(params: {
     patchForm: params.patchForm ?? vi.fn(),
     removeFormValue: vi.fn(),
     refresh: () => Promise.resolve(),
+    ensureLoaded: () => Promise.resolve(),
   };
-  (element as unknown as { context: ApplicationContext }).context = {
+  const context = {
+    basePath: params.basePath ?? "",
     gateway,
     runtimeConfig,
     agents: {
@@ -107,7 +132,14 @@ function createPage(params: {
       ensureList: () => Promise.resolve(),
     },
     navigate: params.navigate ?? vi.fn(),
+    replace: params.replace ?? vi.fn(),
   } as unknown as ApplicationContext;
+  (element as unknown as { context: ApplicationContext }).context = context;
+  const contextProvider = new ContextProvider(element, {
+    context: applicationContext,
+    initialValue: context,
+  });
+  contextProvider.setValue(context);
   const setPhase = (phase: string) => {
     gateway.snapshot = { ...gateway.snapshot, phase };
     runtimeConfig.state = { ...runtimeConfig.state, connected: phase === "connected" };
@@ -152,9 +184,21 @@ function visibleTab(element: HTMLElement): "overview" | "memories" | "dreams" | 
 }
 
 function selectTab(element: HTMLElement, tab: string) {
-  element
-    .querySelector("wa-tab-group")
-    ?.dispatchEvent(new CustomEvent("wa-tab-show", { detail: { name: tab }, bubbles: true }));
+  const target = element.querySelector(`#memory-tab-${tab}`);
+  target?.dispatchEvent(
+    new KeyboardEvent("keydown", { key: "Enter", bubbles: true, cancelable: true }),
+  );
+  target?.dispatchEvent(new MouseEvent("click", { detail: 0, bubbles: true }));
+  dispatchTabShow(element, tab);
+}
+
+function dispatchTabShow(element: HTMLElement, tab: string) {
+  element.querySelector("wa-tab-group")?.dispatchEvent(
+    new CustomEvent("wa-tab-show", {
+      detail: { name: tab },
+      bubbles: true,
+    }),
+  );
 }
 
 function activeEngine(element: HTMLElement): string | null {
@@ -356,10 +400,10 @@ describe("MemorySettingsPage catalog state", () => {
 });
 
 describe("MemorySettingsPage tab routing", () => {
-  it("honors every ?tab= arrival, including a repeat after a manual tab change", async () => {
+  it("renders every canonical tab path and honors browser history restoration", async () => {
     const navigate = vi.fn();
     const { element } = createPage({ configObject: {}, catalog: [], navigate });
-    element.tab = "settings";
+    element.routeData = memoryTabRoute("settings");
     document.body.append(element);
     try {
       await element.updateComplete;
@@ -367,19 +411,23 @@ describe("MemorySettingsPage tab routing", () => {
 
       // A manual click rewrites the URL rather than shadowing it with local state.
       selectTab(element, "overview");
-      expect(navigate).toHaveBeenCalledWith("memory", undefined);
-      element.tab = null;
+      expect(navigate).toHaveBeenCalledWith("memory", { pathname: "/settings/memory" });
+      element.routeData = memoryTabRoute("overview");
       await element.updateComplete;
       expect(visibleTab(element)).toBe("overview");
 
-      // Same intent as the first arrival: an adopt-once page would ignore this.
-      element.tab = "settings";
+      // The router feeding an older history entry back must restore that tab.
+      element.routeData = memoryTabRoute("settings");
       await element.updateComplete;
       expect(visibleTab(element)).toBe("settings");
 
-      element.tab = "memories";
+      element.routeData = memoryTabRoute("memories");
       await element.updateComplete;
       expect(visibleTab(element)).toBe("memories");
+
+      element.routeData = memoryTabRoute("dreams");
+      await element.updateComplete;
+      expect(visibleTab(element)).toBe("dreams");
     } finally {
       element.remove();
     }
@@ -388,24 +436,115 @@ describe("MemorySettingsPage tab routing", () => {
   it("writes the chosen tab into the URL so history restores it", async () => {
     const navigate = vi.fn();
     const { element } = createPage({ configObject: {}, catalog: [], navigate });
-    element.tab = "overview";
+    element.routeData = memoryTabRoute("overview");
     document.body.append(element);
     try {
       await element.updateComplete;
       expect(visibleTab(element)).toBe("overview");
 
       selectTab(element, "dreams");
-      expect(navigate).toHaveBeenCalledWith("memory", { search: "?tab=dreams" });
+      expect(navigate).toHaveBeenCalledWith("memory", { pathname: "/settings/memory/dreams" });
       // Nothing moves until the router feeds the new tab back in.
       await element.updateComplete;
       expect(visibleTab(element)).toBe("overview");
 
       selectTab(element, "memories");
-      expect(navigate).toHaveBeenCalledWith("memory", { search: "?tab=memories" });
+      expect(navigate).toHaveBeenCalledWith("memory", {
+        pathname: "/settings/memory/memories",
+      });
     } finally {
       element.remove();
     }
   });
+
+  it("handles Space directly so the browser cannot synthesize a second navigation", async () => {
+    const navigate = vi.fn();
+    const { element } = createPage({ configObject: {}, catalog: [], navigate });
+    element.routeData = memoryTabRoute("overview");
+    document.body.append(element);
+    try {
+      await element.updateComplete;
+      const space = new KeyboardEvent("keydown", {
+        key: " ",
+        bubbles: true,
+        cancelable: true,
+      });
+      element.querySelector("#memory-tab-dreams")?.dispatchEvent(space);
+
+      expect(space.defaultPrevented).toBe(true);
+      expect(navigate).toHaveBeenCalledOnce();
+      expect(navigate).toHaveBeenCalledWith("memory", {
+        pathname: "/settings/memory/dreams",
+      });
+    } finally {
+      element.remove();
+    }
+  });
+
+  it.each([
+    ["/settings/memory", null],
+    ["/settings/memory/memories", null],
+    ["/settings/memory/dreams", null],
+    ["/settings/memory/settings", null],
+    ["/settings/memory?tab=memories", "/settings/memory/memories"],
+    ["/settings/memory?tab=dreams", "/settings/memory/dreams"],
+    ["/settings/memory?tab=settings", "/settings/memory/settings"],
+    ["/settings/memory?tab=dreaming", "/settings/memory/dreams"],
+    ["/settings/memory?tab=search", "/settings/memory/settings"],
+    ["/settings/memory?tab=overview", "/settings/memory"],
+    ["/settings/memory?section=memory", "/settings/memory/settings"],
+    ["/settings/memory#memory-backend", "/settings/memory/settings#memory-backend"],
+    ["/settings/memory#config-section-memory", "/settings/memory/settings#config-section-memory"],
+    [
+      "/settings/memory#config-section-memory-search",
+      "/settings/memory/settings#config-section-memory-search",
+    ],
+  ] as const)(
+    "performs at most one replace for %s and never oscillates back to a query tab",
+    async (sourceUrl, expectedUrl) => {
+      const replace = vi.fn();
+      const navigate = vi.fn();
+      const { element } = createPage({
+        configObject: {},
+        catalog: [],
+        replace,
+        navigate,
+        routeData: memoryRoute(sourceUrl),
+      });
+      document.body.append(element);
+      try {
+        await element.updateComplete;
+        for (let cycle = 0; cycle < 3; cycle += 1) {
+          element.routeData = { ...element.routeData } as ConfigRouteData;
+          await element.updateComplete;
+        }
+        dispatchTabShow(element, "overview");
+        dispatchTabShow(element, "dreams");
+
+        expect(replace).toHaveBeenCalledTimes(expectedUrl ? 1 : 0);
+        expect(navigate).not.toHaveBeenCalled();
+        if (!expectedUrl) {
+          return;
+        }
+        const canonical = memoryRoute(expectedUrl);
+        expect(replace).toHaveBeenCalledWith("memory", {
+          pathname: canonical.pathname,
+          search: canonical.search,
+          hash: canonical.hash,
+        });
+
+        element.routeData = canonical;
+        await element.updateComplete;
+        for (let cycle = 0; cycle < 3; cycle += 1) {
+          element.routeData = { ...element.routeData } as ConfigRouteData;
+          await element.updateComplete;
+        }
+        expect(replace).toHaveBeenCalledOnce();
+      } finally {
+        element.remove();
+      }
+    },
+  );
 
   it("loads Overview status once per activation, agent change, and reconnect", async () => {
     const memoryStatus = vi.fn((agentId: string) =>
@@ -416,7 +555,7 @@ describe("MemorySettingsPage tab routing", () => {
       agents: [{ id: "main" }, { id: "research" }],
       memoryStatus,
     });
-    element.tab = "overview";
+    element.routeData = memoryTabRoute("overview");
     document.body.append(element);
     try {
       await waitForFast(() => expect(memoryStatus).toHaveBeenCalledTimes(1));
@@ -448,7 +587,7 @@ describe("MemorySettingsPage tab routing", () => {
       catalog: [engine("engine-a", true), engine("engine-b", true)],
       memoryStatus,
     });
-    element.tab = "overview";
+    element.routeData = memoryTabRoute("overview");
     document.body.append(element);
     try {
       await waitForFast(() => expect(memoryStatus).toHaveBeenCalledTimes(1));
@@ -467,7 +606,7 @@ describe("MemorySettingsPage tab routing", () => {
     try {
       await element.updateComplete;
       setPhase("disconnected");
-      element.tab = "overview";
+      element.routeData = memoryTabRoute("overview");
       await waitForFast(() =>
         expect(element.textContent).toContain(
           "The gateway is offline, so memory status is unavailable.",

--- a/ui/src/pages/config/memory-page.ts
+++ b/ui/src/pages/config/memory-page.ts
@@ -6,6 +6,7 @@ import { asNullableRecord as asConfigRecord } from "@openclaw/normalization-core
 import { html, type PropertyValues, type TemplateResult } from "lit";
 import { property, state } from "lit/decorators.js";
 import type { DoctorMemoryStatusPayload } from "../../../../src/gateway/server-methods/doctor.ts";
+import { pathForMemoryTab } from "../../app-route-paths.ts";
 import { applicationContext, type ApplicationContext } from "../../app/context.ts";
 import type { AgentSelectOption } from "../../components/agent-select.ts";
 import { t } from "../../i18n/index.ts";
@@ -29,6 +30,8 @@ import "./memory-memories.ts";
 import { renderDreamingSettings, renderDreamingUnsupported } from "./memory-dreaming.ts";
 import { renderMemoryOverview, type MemoryOverviewStatus } from "./memory-overview.ts";
 import {
+  canonicalMemoryRouteLocation,
+  memoryTabForRoute,
   memorySchemaKeysForTab,
   resolveMemoryBackend,
   resolveMemoryEngineSelection,
@@ -42,6 +45,7 @@ import {
   type MemoryEngineOption,
   type MemoryPluginState,
 } from "./memory.ts";
+import type { ConfigRouteData } from "./route-data.ts";
 
 const MEMORY_ADDON_PLUGINS = [
   { id: "active-memory", labelKey: "memoryPage.addons.activeMemory.title" },
@@ -69,7 +73,7 @@ type MemoryPageProps = {
   configObject: Record<string, unknown>;
   pluginsHref: string;
   memoryImportHref: string;
-  tab: MemoryTab | null;
+  routeData: ConfigRouteData | null;
   buildEditor: (keys: readonly string[]) => TemplateResult;
 };
 
@@ -102,7 +106,7 @@ class MemorySettingsPage extends OpenClawLightDomElement {
   @property({ attribute: false }) configObject: Record<string, unknown> = {};
   @property() pluginsHref = "";
   @property() memoryImportHref = "";
-  @property({ attribute: false }) tab: MemoryTab | null = null;
+  @property({ attribute: false }) routeData: ConfigRouteData | null = null;
   @property({ attribute: false }) buildEditor: MemoryPageProps["buildEditor"] = () => html``;
 
   @state() private catalog: MemoryCatalog = { kind: "unavailable" };
@@ -116,6 +120,7 @@ class MemorySettingsPage extends OpenClawLightDomElement {
   private overviewRequest: { connection: CatalogConnection; agentId: string } | null = null;
   private supportPluginId: string | null = null;
   private supportProbe: { pluginId: string } | null = null;
+  private normalizedLocation = "";
 
   private readonly subscriptions = new SubscriptionsController(this)
     .watch(
@@ -150,14 +155,22 @@ class MemorySettingsPage extends OpenClawLightDomElement {
     super.disconnectedCallback();
   }
 
+  override connectedCallback() {
+    super.connectedCallback();
+    this.syncCanonicalLocation();
+  }
+
   protected override updated(changed: PropertyValues<this>) {
-    if (changed.has("tab")) {
-      const previous = (changed.get("tab") as MemoryTab | null | undefined) ?? "overview";
-      const current = this.tab ?? "overview";
+    if (changed.has("routeData")) {
+      const previous = this.activeTab(
+        (changed.get("routeData") as ConfigRouteData | null | undefined) ?? null,
+      );
+      const current = this.activeTab();
       if (previous !== current) {
         this.overviewRequest = null;
         void this.loadOverviewStatus();
       }
+      this.syncCanonicalLocation();
     }
     if (changed.has("configObject")) {
       const previous = changed.get("configObject") as Record<string, unknown> | undefined;
@@ -172,6 +185,31 @@ class MemorySettingsPage extends OpenClawLightDomElement {
     }
   }
 
+  private activeTab(routeData = this.routeData): MemoryTab {
+    return memoryTabForRoute(routeData ?? {}, this.context?.basePath ?? "") ?? "overview";
+  }
+
+  private syncCanonicalLocation() {
+    const context = this.context;
+    const routeData = this.routeData;
+    if (!context || !routeData) {
+      return;
+    }
+    const canonical = canonicalMemoryRouteLocation(routeData, context.basePath);
+    if (!canonical) {
+      this.normalizedLocation = "";
+      return;
+    }
+    const source = `${routeData.pathname}${routeData.search}${routeData.hash}`;
+    if (this.normalizedLocation === source) {
+      return;
+    }
+    // One source location gets one replace. Route-data updates clear the guard
+    // once the canonical path arrives, so returning to an old link still works.
+    this.normalizedLocation = source;
+    context.replace("memory", canonical);
+  }
+
   private syncGateway(client: GatewayClient | null, connected: boolean) {
     if (this.connection?.client === client && this.connection.connected === connected) {
       return;
@@ -181,7 +219,7 @@ class MemorySettingsPage extends OpenClawLightDomElement {
     this.overviewRequest = null;
     if (!client || !connected) {
       this.catalog = { kind: "unavailable" };
-      if ((this.tab ?? "overview") === "overview") {
+      if (this.activeTab() === "overview") {
         this.overviewStatus = {
           kind: "error",
           message: t("memoryPage.overview.hero.gatewayOffline"),
@@ -239,7 +277,7 @@ class MemorySettingsPage extends OpenClawLightDomElement {
   }
 
   private async loadOverviewStatus(force = false) {
-    if ((this.tab ?? "overview") !== "overview") {
+    if (this.activeTab() !== "overview") {
       return;
     }
     if (resolveMemoryEngineSelection(this.configObject).kind === "off") {
@@ -428,14 +466,16 @@ class MemorySettingsPage extends OpenClawLightDomElement {
   }
 
   private navigateTab(tab: MemoryTab) {
-    this.context.navigate("memory", tab === "overview" ? undefined : { search: `?tab=${tab}` });
+    this.context.navigate("memory", {
+      pathname: pathForMemoryTab(tab, this.context.basePath),
+    });
   }
 
   override render() {
     const runtimeConfig = this.context.runtimeConfig;
     const engineSelection = resolveMemoryEngineSelection(this.configObject);
     const backend = resolveMemoryBackend(this.configObject);
-    const activeTab = this.tab ?? "overview";
+    const activeTab = this.activeTab();
     const agentId = this.resolveAgentId();
     const agents = this.agentOptions();
     return renderMemory({
@@ -502,7 +542,7 @@ export function renderMemoryPage(props: MemoryPageProps) {
       .configObject=${props.configObject}
       .pluginsHref=${props.pluginsHref}
       .memoryImportHref=${props.memoryImportHref}
-      .tab=${props.tab}
+      .routeData=${props.routeData}
       .buildEditor=${props.buildEditor}
     ></openclaw-memory-settings>
   `;

--- a/ui/src/pages/config/memory-schema.ts
+++ b/ui/src/pages/config/memory-schema.ts
@@ -6,9 +6,11 @@
 // those answers live here rather than in the view module — importing the view
 // from search would pull lit, hub-tabs, and settings-ui into the startup chunk.
 import { asNullableRecord as asConfigRecord } from "@openclaw/normalization-core/record-coerce";
+import type { RouteLocation } from "@openclaw/uirouter";
 import { resolveSlotSelection } from "../../../../src/plugins/slots.ts";
+import { memoryTabFromPath, pathForMemoryTab, type MemoryRouteTab } from "../../app-route-paths.ts";
 
-export type MemoryTab = "overview" | "memories" | "dreams" | "settings";
+export type MemoryTab = MemoryRouteTab;
 
 export type MemoryBackend = "builtin" | "qmd";
 
@@ -40,20 +42,62 @@ function normalizeMemoryTab(value: string | null | undefined): MemoryTab | null 
 }
 
 /** Old settings-search URLs had a memory section/hash but no tab. */
-export function memoryTabForRoute(route: {
-  tab?: string | null;
-  section?: string | null;
-  targetBlockId?: string | null;
-}): MemoryTab | null {
+export function memoryTabForRoute(
+  route: {
+    pathname?: string;
+    tab?: string | null;
+    section?: string | null;
+    targetBlockId?: string | null;
+  },
+  basePath = "",
+): MemoryTab | null {
+  const pathTab = route.pathname ? memoryTabFromPath(route.pathname, basePath) : null;
+  if (pathTab && pathTab !== "overview") {
+    return pathTab;
+  }
   const tab = normalizeMemoryTab(route.tab);
   if (tab) {
     return tab;
   }
   const target = route.targetBlockId ?? "";
-  return route.section === "memory" ||
+  if (
+    route.section === "memory" ||
     target === MEMORY_BACKEND_ANCHOR_ID ||
     target.startsWith("config-section-memory")
-    ? "settings"
+  ) {
+    return "settings";
+  }
+  return pathTab;
+}
+
+export function canonicalMemoryRouteLocation(
+  route: {
+    pathname: string;
+    search: string;
+    hash: string;
+    tab?: string | null;
+    section?: string | null;
+    targetBlockId?: string | null;
+    advanced?: boolean;
+  },
+  basePath = "",
+): RouteLocation | null {
+  const params = new URLSearchParams(route.search);
+  const hadLegacyTab = params.has("tab");
+  const hadLegacySection = route.section === "memory" && params.has("section");
+  params.delete("tab");
+  if (hadLegacySection) {
+    params.delete("section");
+    params.delete("advanced");
+  }
+  const search = params.toString();
+  const canonical: RouteLocation = {
+    pathname: pathForMemoryTab(memoryTabForRoute(route, basePath) ?? "overview", basePath),
+    search: search ? `?${search}` : "",
+    hash: route.hash,
+  };
+  return hadLegacyTab || hadLegacySection || canonical.pathname !== route.pathname
+    ? canonical
     : null;
 }
 

--- a/ui/src/pages/config/memory.test.ts
+++ b/ui/src/pages/config/memory.test.ts
@@ -164,6 +164,18 @@ describe("memoryTabForRoute", () => {
     expect(memoryTabForRoute({ targetBlockId: "config-section-memory" })).toBe("settings");
     expect(memoryTabForRoute({})).toBeNull();
   });
+
+  it("prefers an explicit canonical path over stale legacy route state", () => {
+    expect(
+      memoryTabForRoute({
+        pathname: "/settings/memory/dreams",
+        tab: "settings",
+        section: "memory",
+        targetBlockId: "memory-backend",
+      }),
+    ).toBe("dreams");
+    expect(memoryTabForRoute({ pathname: "/settings/memory" })).toBe("overview");
+  });
 });
 
 describe("memorySchemaKeysForTab", () => {

--- a/ui/src/pages/config/memory.ts
+++ b/ui/src/pages/config/memory.ts
@@ -292,6 +292,7 @@ export function renderMemory(props: MemoryViewProps) {
         ],
         ariaLabel: t("memoryPage.tablistLabel"),
         panelId: MEMORY_PANEL_ID,
+        userSelectionOnly: true,
         onSelect: (tab) => props.onTabChange(tab),
       })}
       <div id=${MEMORY_PANEL_ID} class="memory-page__panel" role="tabpanel">

--- a/ui/src/pages/config/route-data.test.ts
+++ b/ui/src/pages/config/route-data.test.ts
@@ -5,10 +5,14 @@ describe("config route data", () => {
   it("normalizes the selected section and decodes the target block", () => {
     expect(
       configRouteData({
+        pathname: "/settings/general",
         search: "?section=%20browser%20",
         hash: "#config-section-browser%2Fprofiles",
       }),
     ).toEqual({
+      pathname: "/settings/general",
+      search: "?section=+browser+",
+      hash: "#config-section-browser%2Fprofiles",
       section: "browser",
       advanced: false,
       tab: null,
@@ -18,7 +22,10 @@ describe("config route data", () => {
 
   it("ignores malformed target hashes", () => {
     expect(configTargetIdFromHash("#%")).toBeNull();
-    expect(configRouteData({ search: "", hash: "#%" })).toEqual({
+    expect(configRouteData({ pathname: "/settings/general", search: "", hash: "#%" })).toEqual({
+      pathname: "/settings/general",
+      search: "",
+      hash: "#%",
       section: null,
       advanced: false,
       tab: null,
@@ -27,7 +34,16 @@ describe("config route data", () => {
   });
 
   it("preserves advanced search navigation intent", () => {
-    expect(configRouteData({ search: "?section=gateway&advanced=1", hash: "" })).toEqual({
+    expect(
+      configRouteData({
+        pathname: "/settings/advanced",
+        search: "?section=gateway&advanced=1",
+        hash: "",
+      }),
+    ).toEqual({
+      pathname: "/settings/advanced",
+      search: "?section=gateway&advanced=1",
+      hash: "",
       section: "gateway",
       advanced: true,
       tab: null,
@@ -36,11 +52,34 @@ describe("config route data", () => {
   });
 
   it("carries the hub tab a settings-search destination asks for", () => {
-    expect(configRouteData({ search: "?section=memory&tab=search", hash: "" })).toEqual({
+    expect(
+      configRouteData({
+        pathname: "/settings/memory",
+        search: "?section=memory&tab=search",
+        hash: "",
+      }),
+    ).toEqual({
+      pathname: "/settings/memory",
+      search: "?section=memory&tab=search",
+      hash: "",
       section: "memory",
       advanced: false,
       tab: "search",
       targetBlockId: null,
+    });
+  });
+
+  it("recovers a dynamic Memory pathname from the router's exact-match location", () => {
+    expect(
+      configRouteData({
+        pathname: "/settings/memory",
+        search: "?__openclawMemoryPath=%2Fsettings%2Fmemory%2Fdreams&agent=main",
+        hash: "",
+      }),
+    ).toMatchObject({
+      pathname: "/settings/memory/dreams",
+      search: "?agent=main",
+      tab: null,
     });
   });
 });

--- a/ui/src/pages/config/route-data.ts
+++ b/ui/src/pages/config/route-data.ts
@@ -1,6 +1,10 @@
 import type { RouteLocation } from "@openclaw/uirouter";
+import { INTERNAL_MEMORY_PATH_PARAM } from "../../app-route-paths.ts";
 
 export type ConfigRouteData = {
+  pathname: string;
+  search: string;
+  hash: string;
   section: string | null;
   advanced: boolean;
   /** Raw `?tab=`; curated hub pages normalize it against their own tab set. */
@@ -19,10 +23,16 @@ export function configTargetIdFromHash(hash: string): string | null {
   }
 }
 
-export function configRouteData(location: Pick<RouteLocation, "search" | "hash">): ConfigRouteData {
+export function configRouteData(location: RouteLocation): ConfigRouteData {
   const searchParams = new URLSearchParams(location.search);
+  const pathname = searchParams.get(INTERNAL_MEMORY_PATH_PARAM) ?? location.pathname;
+  searchParams.delete(INTERNAL_MEMORY_PATH_PARAM);
+  const search = searchParams.toString();
   const section = searchParams.get("section")?.trim() || null;
   return {
+    pathname,
+    search: search ? `?${search}` : "",
+    hash: location.hash,
     section,
     advanced: searchParams.get("advanced") === "1",
     tab: searchParams.get("tab")?.trim() || null,

--- a/ui/src/pages/config/route.ts
+++ b/ui/src/pages/config/route.ts
@@ -16,7 +16,7 @@ function configPage(id: ConfigPageId) {
   return definePage({
     ...routePageSpec(id),
     loaderDeps: (_context: ApplicationContext, location: RouteLocation) =>
-      `${location.search}\u0000${location.hash}`,
+      `${location.pathname}\u0000${location.search}\u0000${location.hash}`,
     loader: (context: ApplicationContext, { location }) => loadConfigRoute(context, location),
     component: () =>
       import("./config-page.ts").then(() => ({

--- a/ui/src/pages/config/settings-search.test.ts
+++ b/ui/src/pages/config/settings-search.test.ts
@@ -82,10 +82,28 @@ describe("findSettingsSearchBlocks", () => {
     expect(matches).toEqual([
       expect.objectContaining({
         routeId: "memory",
-        search: "?section=memory&tab=settings",
+        pathname: "/settings/memory/settings",
         hash: "#memory-backend",
       }),
     ]);
+
+    expect(
+      findSettingsSearchBlocks({
+        query: "backend",
+        schema: {
+          type: "object",
+          properties: {
+            memory: {
+              type: "object",
+              properties: { backend: { type: "string", title: "Backend" } },
+            },
+          },
+        },
+        value: { memory: { backend: "builtin" } },
+        uiHints: { "memory.backend": { advanced: false } },
+        basePath: "/ui",
+      }),
+    ).toEqual([expect.objectContaining({ pathname: "/ui/settings/memory/settings" })]);
   });
 
   it("opens every Memory schema match on the merged Settings tab", () => {
@@ -117,7 +135,10 @@ describe("findSettingsSearchBlocks", () => {
       uiHints,
     });
     expect(searchOnly).toEqual([
-      expect.objectContaining({ routeId: "memory", search: "?section=memory&tab=settings" }),
+      expect.objectContaining({
+        routeId: "memory",
+        pathname: "/settings/memory/settings",
+      }),
     ]);
 
     const sectionWide = findSettingsSearchBlocks({
@@ -129,7 +150,7 @@ describe("findSettingsSearchBlocks", () => {
     expect(sectionWide).toEqual([
       expect.objectContaining({
         routeId: "memory",
-        search: "?section=memory&tab=settings",
+        pathname: "/settings/memory/settings",
         hash: "#config-section-memory",
       }),
     ]);
@@ -144,7 +165,7 @@ describe("findSettingsSearchBlocks", () => {
     expect(backendOnly).toEqual([
       expect.objectContaining({
         routeId: "memory",
-        search: "?section=memory&tab=settings",
+        pathname: "/settings/memory/settings",
         hash: "#memory-backend",
       }),
     ]);
@@ -180,7 +201,10 @@ describe("findSettingsSearchBlocks", () => {
     // Another plugin owns the slot: memory.backend and its sub-config are unread.
     expect(find({ plugins: { slots: { memory: "memory-lancedb" } } })).toEqual([]);
     expect(find({ memory: { backend: "qmd" } })).toEqual([
-      expect.objectContaining({ routeId: "memory", search: "?section=memory&tab=settings" }),
+      expect.objectContaining({
+        routeId: "memory",
+        pathname: "/settings/memory/settings",
+      }),
     ]);
   });
 

--- a/ui/src/pages/config/settings-search.ts
+++ b/ui/src/pages/config/settings-search.ts
@@ -1,5 +1,6 @@
 import type { ConfigUiHints } from "../../api/types.ts";
 import { settingsSearchTextMatches, type SettingsSearchBlock } from "../../app-navigation.ts";
+import { pathForMemoryTab } from "../../app-route-paths.ts";
 import { SECTION_META } from "../../components/config-form.meta.ts";
 import {
   matchesConfigSectionSearch,
@@ -69,10 +70,10 @@ function memoryDestination(params: {
   hints: ConfigUiHints;
   query: string;
   editorHash: string;
-}): { search: string; hash: string } {
+}): { hash: string } {
   const properties = params.schema.properties;
   if (!properties) {
-    return { search: "", hash: params.editorHash };
+    return { hash: params.editorHash };
   }
   const sliceMatches = (keys: readonly string[]) => {
     const sliced = Object.fromEntries(
@@ -96,9 +97,9 @@ function memoryDestination(params: {
   // memoryVisibleSchemaKeys drops `backend` when no engine renders the curated
   // row, so a match here always has the anchor on the page to scroll to.
   if (onlySliceMatches(MEMORY_CURATED_SCHEMA_KEYS)) {
-    return { search: "&tab=settings", hash: `#${MEMORY_BACKEND_ANCHOR_ID}` };
+    return { hash: `#${MEMORY_BACKEND_ANCHOR_ID}` };
   }
-  return { search: "&tab=settings", hash: params.editorHash };
+  return { hash: params.editorHash };
 }
 
 export function findSettingsSearchBlocks(params: {
@@ -107,6 +108,7 @@ export function findSettingsSearchBlocks(params: {
   value: Record<string, unknown> | null;
   uiHints: ConfigUiHints;
   identityAvailable?: boolean;
+  basePath?: string;
 }): SettingsSearchBlock[] {
   if (!params.query.trim()) {
     return [];
@@ -170,12 +172,21 @@ export function findSettingsSearchBlocks(params: {
             editorHash,
           })
         : { search: "", hash: editorHash };
-    matches.push({
-      routeId,
-      label: meta?.label ?? sectionSchema.title ?? key,
-      search: `?section=${encodedKey}${matchesAdvanced ? "&advanced=1" : ""}${destination.search}`,
-      hash: destination.hash,
-    });
+    matches.push(
+      routeId === "memory"
+        ? {
+            routeId,
+            label: meta?.label ?? sectionSchema.title ?? key,
+            pathname: pathForMemoryTab("settings", params.basePath),
+            hash: destination.hash,
+          }
+        : {
+            routeId,
+            label: meta?.label ?? sectionSchema.title ?? key,
+            search: `?section=${encodedKey}${matchesAdvanced ? "&advanced=1" : ""}`,
+            hash: destination.hash,
+          },
+    );
   }
   return matches;
 }


### PR DESCRIPTION
## What Problem This Solves

Fixes a reported infinite redirect between `/settings/memory` and `/settings/memory?tab=dreams` on a deployed instance. Query-parameter tab URLs were also fragile and awkward to share.

## Why This Change Was Made

Memory tabs now use canonical paths: `/settings/memory`, `/settings/memory/memories`, `/settings/memory/dreams`, and `/settings/memory/settings`. Every known legacy query or settings-search form normalizes one way with at most one history replacement, hashes are preserved, and Memory ignores setup-time tab events so no `?tab=` writer or programmatic tab oscillation remains.

## User Impact

Memory tabs have clean, shareable URLs; tab clicks and browser Back/Forward preserve the selected tab; and the reported root-to-Dreams oscillation is structurally impossible.

## Evidence

- Focused routing/config tests: 191 passed across the changed route, Memory, settings-search, sidebar, and config-page files.
- Final tab/router regression set: 66 passed, including canonical paths, base paths, legacy normalization, multi-cycle loop guards, click/keyboard navigation, and dynamic-path startup handoff.
- Requested broad UI command: 6,521 passed; one unrelated `chat-thread.measure.test.ts` assertion flaked, and its immediate focused rerun passed all 9 tests.
- Codex autoreview: `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main --engine codex --model gpt-5.6-sol --thinking high` returned clean with no accepted/actionable findings.
- Mock harness history-spy matrix:
  - `/settings/memory` → unchanged, Overview, 0 operations
  - `/settings/memory/memories` → unchanged, Memories, 0 operations
  - `/settings/memory/dreams` → unchanged, Dreams, 0 operations
  - `/settings/memory/settings` → unchanged, Settings, 0 operations
  - `/settings/memory?tab=memories` → `/settings/memory/memories`, one replace
  - `/settings/memory?tab=dreams` → `/settings/memory/dreams`, one replace
  - `/settings/memory?tab=settings` → `/settings/memory/settings`, one replace
  - `/settings/memory?tab=dreaming` → `/settings/memory/dreams`, one replace
  - `/settings/memory?tab=search` → `/settings/memory/settings`, one replace
  - `/settings/memory?tab=overview` → `/settings/memory`, one replace
  - `/settings/memory?section=memory` → `/settings/memory/settings`, one replace
  - `/settings/memory#memory-backend` → `/settings/memory/settings#memory-backend`, one replace
  - `/settings/memory#config-section-memory` → `/settings/memory/settings#config-section-memory`, one replace
  - `/settings/memory#config-section-memory-search` → `/settings/memory/settings#config-section-memory-search`, one replace
  - A real Dreams tab click added one `pushState`; browser Back restored the prior Settings path and selected Settings tab. No console errors were observed.
