### PR TITLE
refactor(codex): reuse shared toErrorObject coercion

### DIFF
--- a/extensions/codex/src/app-server/approval-bridge.test.ts
+++ b/extensions/codex/src/app-server/approval-bridge.test.ts
@@ -2468,6 +2468,23 @@ describe("Codex app-server approval bridge", () => {
     await expect(pending).rejects.toThrow("approval expired or not found");
   });
 
+  it("coerces a non-Error abort reason through the shared toErrorObject", async () => {
+    // Keep the gateway wait pending so the pre-aborted signal wins the race.
+    mockCallGatewayTool.mockImplementationOnce(() => new Promise(() => {}));
+    const controller = new AbortController();
+    controller.abort({ code: 500, status: "server_error" });
+
+    const thrown = await waitForPluginApprovalDecision({
+      approvalId: "plugin:approval-non-error-abort",
+      signal: controller.signal,
+    }).catch((error: unknown) => error);
+
+    expect(thrown).toBeInstanceOf(Error);
+    expect((thrown as Error).message).toBe("Non-Error rejection");
+    expect((thrown as Error & { code?: unknown; status?: unknown }).code).toBe(500);
+    expect((thrown as Error & { code?: unknown; status?: unknown }).status).toBe("server_error");
+  });
+
   it("preserves an accepted approval expiry as timed out", async () => {
     const params = createParams();
     const onNativeToolFailureDisposition = vi.fn();

--- a/extensions/codex/src/app-server/plugin-approval-roundtrip.ts
+++ b/extensions/codex/src/app-server/plugin-approval-roundtrip.ts
@@ -6,7 +6,7 @@ import {
   callGatewayTool,
   type EmbeddedRunAttemptParams,
 } from "openclaw/plugin-sdk/agent-harness-runtime";
-import { isApprovalNotFoundError } from "openclaw/plugin-sdk/error-runtime";
+import { isApprovalNotFoundError, toErrorObject } from "openclaw/plugin-sdk/error-runtime";
 import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import { resolveCodexGatewayTimeoutWithGraceMs } from "./attempt-timeouts.js";
 
@@ -111,10 +111,10 @@ export async function waitForPluginApprovalDecision(params: {
   let onAbort: (() => void) | undefined;
   const abortPromise = new Promise<never>((_, reject) => {
     if (params.signal!.aborted) {
-      reject(toLintErrorObject(params.signal!.reason, "Non-Error rejection"));
+      reject(toErrorObject(params.signal!.reason, "Non-Error rejection"));
       return;
     }
-    onAbort = () => reject(toLintErrorObject(params.signal!.reason, "Non-Error rejection"));
+    onAbort = () => reject(toErrorObject(params.signal!.reason, "Non-Error rejection"));
     params.signal!.addEventListener("abort", onAbort, { once: true });
   });
   try {
@@ -144,18 +144,4 @@ export function mapExecDecisionToOutcome(
 
 function truncateForGateway(value: string, maxLength: number): string {
   return value.length <= maxLength ? value : `${truncateUtf16Safe(value, maxLength - 3)}...`;
-}
-
-function toLintErrorObject(value: unknown, fallbackMessage: string): Error {
-  if (value instanceof Error) {
-    return value;
-  }
-  if (typeof value === "string") {
-    return new Error(value);
-  }
-  const error = new Error(fallbackMessage, { cause: value });
-  if ((typeof value === "object" && value !== null) || typeof value === "function") {
-    Object.assign(error, value);
-  }
-  return error;
 }


### PR DESCRIPTION
## What Problem This Solves

`extensions/codex/src/app-server/plugin-approval-roundtrip.ts` carried a private `toLintErrorObject(value, fallbackMessage)` helper, byte-identical to the shared `toErrorObject` already re-exported through `openclaw/plugin-sdk/error-runtime`. The same helper is copy-pasted across 12+ production modules. Keeping these copies separate is drift risk: whenever the error-coercion logic needs to change, every copy must be updated in lockstep.

## Why This Change Was Made

- Delete the local `toLintErrorObject` and import the shared `toErrorObject` from `openclaw/plugin-sdk/error-runtime`.
- Update the two `waitForPluginApprovalDecision` signal-abort reject sites to call the shared helper (fallback message `"Non-Error rejection"` unchanged).
- Add a regression test that aborts the wait signal with a non-Error reason and asserts the shared coercion runs (fallback message + enumerable fields copied).
- Byte-identical bodies → behavior-preserving, `deletions ≥ additions` (+3/−17 source, +17 test).

Follows the `refactor(*): reuse shared error coercion` pattern: #113229 (browser), #113589 (telegram), #113586 (matrix), #113581 (slack), #113544 (signal), #113529 (packages), #115116 (ollama), #115194 (qa-channel).

## User Impact

None at runtime. The Codex app-server approval wait's abort-rejection coercion is unchanged: an aborted turn still surfaces the abort reason through the same `Error` shape (fallback message for non-Error reasons, enumerable fields copied via `Object.assign`).

## Note on the `toErrorObject` facade export

`openclaw/plugin-sdk/error-runtime` **does** export `toErrorObject` — added by #113229 (2026-07-24) at `src/plugin-sdk/error-runtime.ts:25`, re-exported via `src/infra/errors.ts:74` → `@openclaw/normalization-core/error-coercion`. The merged #113589 uses the identical import. If a stale local `dist` snapshot (pre-#113229) is consulted it appears missing, but CI builds fresh. (Flagged proactively since prior copies in this vein hit a stale-snapshot false positive.)

## Evidence

- `node scripts/run-vitest.mjs extensions/codex/src/app-server/approval-bridge.test.ts` — 88/88 passed on current head `2db85ca3` (includes the new regression test)
- `oxlint` / `oxfmt --check` — clean
- CI on current head `2db85ca3`: `check-prod-types`, `check-test-types`, `check-lint`, `check-additional-extension-package-boundary`, `build-artifacts`, `check-sqlite-session-flip-proof`, `openclaw/ci-gate` all pass (run 30509268745)

Related implementation pattern: #113589, #115116, #115194

Real behavior proof at exact PR head `2db85ca3eb14887c318fdabad909775cb56363bb` (tsx loads the REAL exported module from source — no vi.mock, no stubbed module — and drives the same abort path a killed Codex run takes):

```text
=== real-runtime codex approval-wait abort coercion (tsx, not vitest mock) ===
$ ./node_modules/.bin/tsx scripts/proof/codex-real-setup-proof.mjs
real module path: .../extensions/codex/src/app-server/plugin-approval-roundtrip.ts
waitForPluginApprovalDecision is function: true

--- REAL call-site output (reject(toErrorObject(signal.reason, ...)) at :114/:117) ---
isError: true
message: Non-Error rejection
code: 500
status: server_error
cause: {"code":500,"status":"server_error"}
constructor: Error

# Pre-abort the turn signal with a non-Error reason (a real Codex run-kill shape),
# call the REAL exported waitForPluginApprovalDecision (no vi.mock). The
# signal-aborted reject site reject(toErrorObject(signal.reason, "Non-Error rejection"))
# settles via Promise.race before the in-flight callGatewayTool wait -> the shared
# toErrorObject coerces the non-Error reason: fallback message + Object.assign'd
# code/status fields + cause preserved.

--- behavior-preservation: shared toErrorObject == deleted local helper (runtime) ---
  [MATCH] Error instance
  [MATCH] string
  [MATCH] object{code,status}
  [MATCH] null
  [MATCH] number
verdict: shared toErrorObject is behavior-equivalent to the deleted local helper
         across all input shapes; real call-site coercion confirmed via the exported function.

=== non-Error coercion branch (committed regression test, runs in CI) ===
$ node scripts/run-vitest.mjs extensions/codex/src/app-server/approval-bridge.test.ts
 Test Files  1 passed (1)      Tests 88 passed (88)
 ✓ coerces a non-Error abort reason through the shared toErrorObject
   aborts with { code: 500, status: "server_error" }; asserts thrown is an Error,
   message "Non-Error rejection", code=500, status="server_error"

=== duplication before this PR: byte-identical toLintErrorObject production copies ===
extensions/acpx/src/runtime-turn.ts
extensions/codex/src/app-server/plugin-approval-roundtrip.ts   <- removed by this PR
extensions/copilot/src/event-bridge.ts
extensions/discord/src/monitor.gateway.ts
extensions/line/src/bot-handlers.ts
extensions/lobster/src/lobster-runner.ts
extensions/memory-core/src/memory/manager.ts
extensions/ollama/src/setup.ts
extensions/openai/openai-chatgpt-oauth-flow.runtime.ts
extensions/qa-channel/src/bus-client.ts
extensions/whatsapp/src/session.ts
src/agents/agent-tools.before-tool-call.approval.ts
src/agents/api-key-rotation.ts
```

AI-assisted: Codex


