### PR TITLE
fix(whatsapp): preserve context when a quoted reply is unavailable

### DIFF
--- a/extensions/whatsapp/src/inbound/extract.test.ts
+++ b/extensions/whatsapp/src/inbound/extract.test.ts
@@ -1,7 +1,7 @@
 // Whatsapp tests cover extract plugin behavior.
 import type { proto } from "baileys";
 import { describe, expect, it } from "vitest";
-import { extractMentionedJids, hasInboundUserContent } from "./extract.js";
+import { describeReplyContext, extractMentionedJids, hasInboundUserContent } from "./extract.js";
 
 describe("extractMentionedJids", () => {
   const botJid = "5511999999999@s.whatsapp.net";
@@ -100,6 +100,56 @@ describe("extractMentionedJids", () => {
       },
     };
     expect(extractMentionedJids(message)).toEqual([botJid]);
+  });
+});
+
+describe("describeReplyContext", () => {
+  it("preserves a native reply reference when WhatsApp omits the quoted message", () => {
+    expect(
+      describeReplyContext({
+        extendedTextMessage: {
+          text: "yes",
+          contextInfo: {
+            stanzaId: "original-message",
+            participant: "15555550123@s.whatsapp.net",
+          },
+        },
+      }),
+    ).toMatchObject({
+      id: "original-message",
+      body: "[quoted message unavailable]",
+      sender: {
+        jid: "15555550123@s.whatsapp.net",
+        e164: "+15555550123",
+        label: "+15555550123",
+      },
+    });
+  });
+
+  it("preserves an unavailable reply reference without a quoted sender", () => {
+    expect(
+      describeReplyContext({
+        extendedTextMessage: {
+          text: "yes",
+          contextInfo: { stanzaId: "original-message" },
+        },
+      }),
+    ).toMatchObject({
+      id: "original-message",
+      body: "[quoted message unavailable]",
+      sender: { label: "unknown sender" },
+    });
+  });
+
+  it("does not invent a reply from unrelated context metadata", () => {
+    expect(
+      describeReplyContext({
+        extendedTextMessage: {
+          text: "hello",
+          contextInfo: { participant: "15555550123@s.whatsapp.net" },
+        },
+      }),
+    ).toBeNull();
   });
 });
 

--- a/extensions/whatsapp/src/inbound/extract.ts
+++ b/extensions/whatsapp/src/inbound/extract.ts
@@ -336,8 +336,21 @@ export function describeReplyContext(
   }
   const contextInfo = extractContextInfo(message);
   const quoted = normalizeMessageContent(contextInfo?.quotedMessage as proto.IMessage | undefined);
-  if (!quoted) {
+  if (!quoted && !contextInfo?.stanzaId) {
     return null;
+  }
+  const senderJid = contextInfo?.participant ?? undefined;
+  const sender = resolveComparableIdentity({
+    jid: senderJid,
+    label: senderJid ? (jidToE164(senderJid) ?? senderJid) : "unknown sender",
+  });
+  if (!quoted) {
+    // Baileys may preserve a real reply ID while omitting its private quoted payload.
+    return {
+      id: contextInfo?.stanzaId || undefined,
+      body: "[quoted message unavailable]",
+      sender,
+    };
   }
   const location = extractLocationData(quoted);
   const locationText = location ? formatLocationText(location) : undefined;
@@ -354,11 +367,6 @@ export function describeReplyContext(
     );
     return null;
   }
-  const senderJid = contextInfo?.participant ?? undefined;
-  const sender = resolveComparableIdentity({
-    jid: senderJid,
-    label: senderJid ? (jidToE164(senderJid) ?? senderJid) : "unknown sender",
-  });
   return {
     id: contextInfo?.stanzaId || undefined,
     body: body ?? "",

--- a/extensions/whatsapp/src/monitor-inbox.streams-inbound-messages.test-support.ts
+++ b/extensions/whatsapp/src/monitor-inbox.streams-inbound-messages.test-support.ts
@@ -2037,6 +2037,47 @@ describe("web monitor inbox", () => {
     await expectQuotedReplyContext({ conversation: "original" });
   });
 
+  it("preserves native reply context when WhatsApp omits the quoted message", async () => {
+    const onMessage = vi.fn(async () => {});
+    const { listener, sock } = await startInboxMonitor(onMessage as InboxOnMessage);
+
+    sock.ev.emit("messages.upsert", {
+      type: "notify",
+      messages: [
+        {
+          key: {
+            id: nextMessageId("quoted-unavailable"),
+            fromMe: false,
+            remoteJid: "999@s.whatsapp.net",
+          },
+          message: {
+            extendedTextMessage: {
+              text: "yes",
+              contextInfo: {
+                stanzaId: "original-message",
+                participant: "111@s.whatsapp.net",
+              },
+            },
+          },
+          messageTimestamp: 1_700_000_000,
+          pushName: "Tester",
+        },
+      ],
+    });
+
+    await waitForMessageCalls(onMessage, 1);
+
+    const inbound = inboundMessage(onMessage);
+    expect(inbound.payload.body).toBe("yes");
+    expect(inbound.quote).toMatchObject({
+      id: "original-message",
+      body: "[quoted message unavailable]",
+      sender: { displayName: "+111", jid: "111@s.whatsapp.net", e164: "+111" },
+    });
+
+    await listener.close();
+  });
+
   it("captures reply context from wrapped quoted messages", async () => {
     await expectQuotedReplyContext({
       viewOnceMessageV2Extension: {


### PR DESCRIPTION
Closes #114704

## What Problem This Solves

Fixes an issue where WhatsApp users replying to an earlier message would lose all quoted-reply context when WhatsApp supplies the native reply ID but omits the quoted message payload. The agent would see an unscoped short reply and could associate it with the wrong conversation topic.

## Why This Change Was Made

Baileys 7.0.0-rc13 explicitly declares stanzaId, participant, and quotedMessage as independently optional. Preserve the verified native reply ID and sender with an explicit [quoted message unavailable] notice, without recovering private message history, inventing a reply, changing configuration, or touching the plugin SDK.

## User Impact

WhatsApp native replies keep their visible reply block and original message reference even when the transport cannot provide the quoted body. Ordinary messages, complete quotes, existing privacy filtering, and quoted media remain unchanged.

## Evidence

- Fail-first: the unpatched current main fails all three new regressions, including a Baileys messages.upsert through the real WhatsApp inbox monitor.
- Exact rebased head 52f78110fee9808583bfb466655243e5127caec2: 128/128 focused WhatsApp extraction and inbound-monitor tests pass on Blacksmith Testbox tbx_01kyny671twa3r9b234j8ge570.
- node scripts/crabbox-wrapper.mjs run --provider blacksmith-testbox --id tbx_01kyny671twa3r9b234j8ge570 --timing-json -- env OPENCLAW_TESTBOX=1 OPENCLAW_TESTBOX_REMOTE_RUN=1 pnpm test extensions/whatsapp/src/inbound/extract.test.ts extensions/whatsapp/src/monitor-inbox.behavior.test.ts
- Full changed-code gate passed: extension production and test typechecks, oxfmt, extension lint, plugin boundaries, zero-unused-export guards, database-first and runtime guards.
- Exact rebased-head structured autoreview: clean; no accepted or actionable findings.
- Upstream contract verified against the exact Baileys rc13 gitHead 8053b086ecc97ec3f78299561de11959bab05d39, WAProto/WAProto.proto ContextInfo fields 1-3.
- Reported by @andersonjeccel. AI-assisted.
