### PR TITLE
fix(ui): clearly label beta releases in the update banner

### DIFF
--- a/ui/src/components/sidebar-update-card.test.ts
+++ b/ui/src/components/sidebar-update-card.test.ts
@@ -77,6 +77,21 @@ describe("SidebarUpdateCard", () => {
     expect(onUpdate).toHaveBeenCalledOnce();
   });
 
+  it.each(["2026.7.2", "2026.7.2-beta.5"])(
+    "identifies a beta update when its available version is %s",
+    async (latestVersion) => {
+      const element = await mount({
+        currentVersion: "2026.7.1-2",
+        latestVersion,
+        channel: "beta",
+      });
+
+      expect(element.querySelector(".sidebar-update-card__text")?.textContent).toBe(
+        `Update Gateway · v${latestVersion} (beta)`,
+      );
+    },
+  );
+
   it.each([null, { currentVersion: "2.0.0", latestVersion: "2.0.0", channel: "stable" }] as const)(
     "renders nothing when no newer update is available",
     async (update) => {

--- a/ui/src/components/sidebar-update-card.ts
+++ b/ui/src/components/sidebar-update-card.ts
@@ -107,6 +107,8 @@ class SidebarUpdateCard extends OpenClawLightDomContentsElement {
       : this.nativeUpdateAvailable
         ? t("chat.sidebar.updateMacAndGateway")
         : t("chat.sidebar.updateGateway");
+    const version =
+      update.channel === "beta" ? `v${update.latestVersion} (beta)` : `v${update.latestVersion}`;
     return html`
       <div class="sidebar-update-card" role="status" aria-live="polite">
         <button
@@ -120,7 +122,7 @@ class SidebarUpdateCard extends OpenClawLightDomContentsElement {
           }}
         >
           <span class="sidebar-update-card__icon" aria-hidden="true">${icons.download}</span>
-          <span class="sidebar-update-card__text">${title} · v${update.latestVersion}</span>
+          <span class="sidebar-update-card__text">${title} · ${version}</span>
         </button>
         <button
           class="sidebar-update-card__dismiss"

--- a/ui/src/components/sidebar-update-card.ts
+++ b/ui/src/components/sidebar-update-card.ts
@@ -107,8 +107,7 @@ class SidebarUpdateCard extends OpenClawLightDomContentsElement {
       : this.nativeUpdateAvailable
         ? t("chat.sidebar.updateMacAndGateway")
         : t("chat.sidebar.updateGateway");
-    const version =
-      update.channel === "beta" ? `v${update.latestVersion} (beta)` : `v${update.latestVersion}`;
+    const betaChannelSuffix = update.channel === "beta" ? " (beta)" : "";
     return html`
       <div class="sidebar-update-card" role="status" aria-live="polite">
         <button
@@ -122,7 +121,9 @@ class SidebarUpdateCard extends OpenClawLightDomContentsElement {
           }}
         >
           <span class="sidebar-update-card__icon" aria-hidden="true">${icons.download}</span>
-          <span class="sidebar-update-card__text">${title} · ${version}</span>
+          <span class="sidebar-update-card__text"
+            >${title} · v${update.latestVersion}${betaChannelSuffix}</span
+          >
         </button>
         <button
           class="sidebar-update-card__dismiss"

--- a/ui/src/e2e/update-coalesced.e2e.test.ts
+++ b/ui/src/e2e/update-coalesced.e2e.test.ts
@@ -33,6 +33,40 @@ describeControlUiE2e("Control UI coalesced update E2E", () => {
     await server?.close();
   });
 
+  it("identifies a beta release in the visible Gateway update card", async () => {
+    const artifactDir = path.resolve(".artifacts/control-ui-e2e/update-beta-channel");
+    const context = await browser.newContext({
+      locale: "en-US",
+      recordVideo: { dir: artifactDir, size: { height: 720, width: 1280 } },
+      serviceWorkers: "block",
+      viewport: { height: 720, width: 1280 },
+    });
+    const page = await context.newPage();
+    const gateway = await installMockGateway(page);
+
+    try {
+      expect((await page.goto(`${server.baseUrl}chat`))?.status()).toBe(200);
+      await gateway.waitForRequest("chat.startup");
+      await gateway.emitGatewayEvent("update.available", {
+        updateAvailable: {
+          channel: "beta",
+          currentVersion: "2026.7.1-2",
+          latestVersion: "2026.7.2-beta.5",
+        },
+      });
+
+      await page
+        .getByRole("button", {
+          name: /Update Gateway · v2026\.7\.2-beta\.5 \(beta\)/u,
+        })
+        .waitFor({ timeout: 10_000 });
+      await page.screenshot({ path: path.join(artifactDir, "beta-update-card.png") });
+      expect(await gateway.getRequests("update.run")).toHaveLength(0);
+    } finally {
+      await context.close();
+    }
+  });
+
   it("shows coalesced restart feedback after the Update click", async () => {
     const artifactDir = path.resolve(".artifacts/control-ui-e2e/update-coalesced");
     const context = await browser.newContext({


### PR DESCRIPTION
Closes #114969
Related: #115156, #114991

## What Problem This Solves

Fixes an issue where Control UI users seeing a Gateway update could mistake a beta-channel release for a stable release because the sidebar dropped the authoritative beta channel from its update label.

## Why This Change Was Made

The Gateway already publishes the exact update channel and release version. Keep ownership in the existing sidebar update card and append the beta indicator only for the authoritative beta channel; leave stable and latest-channel labels unchanged. Cover both full prerelease versions and shortened available versions without adding configuration, changing the update protocol, or changing release selection.

## User Impact

The actual sidebar action reads Update Gateway · v2026.7.2-beta.5 (beta) for a beta update, while stable updates continue to appear exactly as before. Users can see a prerelease before clicking the update action.

## Evidence

AI-assisted; independently reviewed with gpt-5.6-sol at xhigh reasoning: no accepted or actionable findings.

Fail-first proof on Blacksmith Testbox tbx_01kynxhzw5y8q4vr1byepqf5db: the new actual Chromium scenario failed on unmodified production because no beta-labeled visible button existed; both existing Gateway and Mac update scenarios passed.

After the fix, the same immutable worktree passed:

- pnpm test ui/src/components/sidebar-update-card.test.ts ui/src/pages/config/quick.test.ts ui/src/pages/channels/view.test.ts ui/src/pages/config/settings-targets.test.ts — four files, 56 tests passed.
- OPENCLAW_CAPTURE_UI_PROOF=1 pnpm test:ui:e2e ui/src/e2e/update-coalesced.e2e.test.ts ui/src/e2e/chat-flow.follow-ups.e2e.test.ts ui/src/e2e/profile-page.e2e.test.ts ui/src/e2e/sidebar-settings.e2e.test.ts ui/src/e2e/chat-flow.navigation-presentation.e2e.test.ts ui/src/e2e/channels-whatsapp-logout.e2e.test.ts — six real Chromium browser-flow files, 30 tests passed.
- The new visible Chromium scenario records a video and beta-update-card.png in the remote runner artifact directory; proof assets are not committed.
- .agents/skills/autoreview/scripts/autoreview --mode uncommitted --thinking xhigh: clean on the exact three-file diff.
- git diff --check: clean.

Thanks to @ripleyripedabot-max for the original report and @RerankerGuo and @synthalorian for the earlier beta-banner fix proposals in #115156 and #114991.