### PR TITLE
perf(gateway): reuse session discovery during agent requests

### DIFF
--- a/src/gateway/agent-turn/agent-handler-helpers.ts
+++ b/src/gateway/agent-turn/agent-handler-helpers.ts
@@ -79,16 +79,12 @@ export function respondDeletedAgentSession(params: {
 }
 
 export function respondUnavailableAgentSessionForKey(params: {
-  sessionKey: string;
+  loadedSession: ReturnType<typeof loadSessionEntry>;
   requestedSessionId?: string;
   isRawModelRun: boolean;
-  agentId?: string;
   respond: GatewayRequestHandlerOptions["respond"];
 }): boolean {
-  const { cfg, entry, canonicalKey, legacyKey } = loadSessionEntry(params.sessionKey, {
-    ...(params.agentId ? { agentId: params.agentId } : {}),
-    clone: false,
-  });
+  const { cfg, entry, canonicalKey, legacyKey } = params.loadedSession;
   if (
     respondDeletedAgentSession({
       cfg,

--- a/src/gateway/agent-turn/agent-request-routing.test.ts
+++ b/src/gateway/agent-turn/agent-request-routing.test.ts
@@ -1,0 +1,66 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../session-utils.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../session-utils.js")>();
+  return {
+    ...actual,
+    loadSessionEntry: vi.fn(),
+  };
+});
+
+import { loadSessionEntry } from "../session-utils.js";
+import { prepareAgentRequestRouting } from "./agent-request-routing.js";
+
+describe("prepareAgentRequestRouting", () => {
+  beforeEach(() => {
+    vi.mocked(loadSessionEntry)
+      .mockReset()
+      .mockReturnValue({
+        cfg: { agents: { list: [{ id: "main" }] } },
+        storePath: "/tmp/sessions.json",
+        store: {},
+        entry: {
+          sessionId: "session-1",
+          updatedAt: 1,
+        },
+        canonicalKey: "agent:main:main",
+        storeKeys: ["agent:main:main"],
+        legacyKey: undefined,
+      });
+  });
+
+  it("reuses one session load and carries target discovery through the request", async () => {
+    const respond = vi.fn();
+    const result = await prepareAgentRequestRouting({
+      request: {
+        message: "hello",
+        agentId: "main",
+        sessionKey: "agent:main:main",
+      },
+      cfg: { agents: { list: [{ id: "main" }] } },
+      isRawModelRun: false,
+      runId: "run-1",
+      agentDedupeKeys: [],
+      context: {
+        dedupe: new Map(),
+        logGateway: { info: vi.fn() },
+      },
+      respond,
+      reserveDedupe: vi.fn(),
+      clearDedupe: vi.fn(),
+    } as never);
+
+    expect(result?.preAttachmentSession).toEqual({
+      canonicalKey: "agent:main:main",
+      sessionId: "session-1",
+    });
+    expect(result?.sessionStoreDiscoveryCache).toBeInstanceOf(Map);
+    expect(loadSessionEntry).toHaveBeenCalledTimes(1);
+    expect(loadSessionEntry).toHaveBeenCalledWith("agent:main:main", {
+      agentId: "main",
+      clone: false,
+      targetDiscoveryCache: result?.sessionStoreDiscoveryCache,
+    });
+    expect(respond).not.toHaveBeenCalled();
+  });
+});

--- a/src/gateway/agent-turn/agent-request-routing.ts
+++ b/src/gateway/agent-turn/agent-request-routing.ts
@@ -18,6 +18,7 @@ import {
   isDeliverableMessageChannel,
   normalizeMessageChannel,
 } from "../../utils/message-channel.js";
+import type { GatewaySessionStoreDiscoveryCache } from "../session-utils-store-lookup.js";
 import {
   validateExpectedExistingSessionTarget,
   type ExpectedExistingSessionConstraint,
@@ -46,6 +47,7 @@ type AgentRequestRouting = {
   explicitRecipientSession?: ExplicitRecipientSession;
   preAcceptedReservedSessionKey?: string;
   preAttachmentSession?: { canonicalKey: string; sessionId: string };
+  sessionStoreDiscoveryCache: GatewaySessionStoreDiscoveryCache;
 };
 
 export async function prepareAgentRequestRouting(params: {
@@ -206,13 +208,20 @@ export async function prepareAgentRequestRouting(params: {
       return undefined;
     }
   }
+  const sessionStoreDiscoveryCache: GatewaySessionStoreDiscoveryCache = new Map();
+  const loaded = requestedSessionKey
+    ? loadSessionEntry(requestedSessionKey, {
+        ...(agentId ? { agentId } : {}),
+        clone: false,
+        targetDiscoveryCache: sessionStoreDiscoveryCache,
+      })
+    : undefined;
   if (
-    requestedSessionKey &&
+    loaded &&
     respondUnavailableAgentSessionForKey({
-      sessionKey: requestedSessionKey,
+      loadedSession: loaded,
       requestedSessionId,
       isRawModelRun: params.isRawModelRun,
-      agentId,
       respond: params.respond,
     })
   ) {
@@ -235,12 +244,6 @@ export async function prepareAgentRequestRouting(params: {
   // Keyless runs still need the run-id reservation before asynchronous preparation,
   // otherwise concurrent callers can dispatch the same id without a session owner.
   params.reserveDedupe(preAcceptedReservedSessionKey, agentId);
-  const loaded = requestedSessionKey
-    ? loadSessionEntry(requestedSessionKey, {
-        ...(agentId ? { agentId } : {}),
-        clone: false,
-      })
-    : undefined;
   return {
     normalizedAttachments,
     requestedBestEffortDeliver,
@@ -256,6 +259,7 @@ export async function prepareAgentRequestRouting(params: {
     preAttachmentSession: loaded?.entry
       ? { canonicalKey: loaded.canonicalKey, sessionId: loaded.entry.sessionId }
       : undefined,
+    sessionStoreDiscoveryCache,
   };
 }
 

--- a/src/gateway/agent-turn/agent-request-routing.ts
+++ b/src/gateway/agent-turn/agent-request-routing.ts
@@ -18,7 +18,6 @@ import {
   isDeliverableMessageChannel,
   normalizeMessageChannel,
 } from "../../utils/message-channel.js";
-import type { GatewaySessionStoreDiscoveryCache } from "../session-utils-store-lookup.js";
 import {
   validateExpectedExistingSessionTarget,
   type ExpectedExistingSessionConstraint,
@@ -26,6 +25,7 @@ import {
 import type { AgentRunRequest } from "../server-methods/agent-request-types.js";
 import { normalizeRpcAttachmentsToChatAttachments } from "../server-methods/attachment-normalize.js";
 import type { GatewayRequestHandlerOptions } from "../server-methods/types.js";
+import type { GatewaySessionStoreDiscoveryCache } from "../session-utils-store-lookup.js";
 import { loadSessionEntry, resolveSessionStoreKey } from "../session-utils.js";
 import { formatForLog } from "../ws-log.js";
 import { setGatewayDedupeEntries } from "./agent-dedupe.js";

--- a/src/gateway/agent-turn/agent-turn-service.ts
+++ b/src/gateway/agent-turn/agent-turn-service.ts
@@ -184,6 +184,7 @@ export function createAgentTurnService({
       explicitRecipientSession,
       preAcceptedReservedSessionKey,
       preAttachmentSession,
+      sessionStoreDiscoveryCache,
     } = routing;
     let agentId = routing.agentId;
     let requestedSessionKey = routing.requestedSessionKey;
@@ -322,6 +323,7 @@ export function createAgentTurnService({
           lifecycleGeneration,
           effectiveBootstrapContextRunKind,
           preAttachmentSession,
+          sessionStoreDiscoveryCache,
           respond,
         });
         if (!preparedSession) {

--- a/src/gateway/server-methods/agent-session-prepare.ts
+++ b/src/gateway/server-methods/agent-session-prepare.ts
@@ -24,6 +24,7 @@ import { isRecoverableTerminalSessionStatus } from "../../config/sessions/termin
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { parseCronRunScopeSuffix } from "../../sessions/session-key-utils.js";
 import { sessionDeliveryChannel } from "../../utils/delivery-context.shared.js";
+import type { GatewaySessionStoreDiscoveryCache } from "../session-utils-store-lookup.js";
 import {
   respondDeletedAgentSession,
   type RestoredCronContinuation,
@@ -71,11 +72,18 @@ export function prepareAgentSession(params: {
   lifecycleGeneration: string;
   effectiveBootstrapContextRunKind?: "default" | "heartbeat" | "cron";
   preAttachmentSession?: { canonicalKey: string; sessionId?: string };
+  sessionStoreDiscoveryCache?: GatewaySessionStoreDiscoveryCache;
   respond: GatewayRequestHandlerOptions["respond"];
 }): PreparedAgentSession | undefined {
   const { cfg, storePath, entry, canonicalKey, legacyKey, storeKeys } = loadSessionEntry(
     params.requestedSessionKey,
-    { ...(params.agentId ? { agentId: params.agentId } : {}), clone: false },
+    {
+      ...(params.agentId ? { agentId: params.agentId } : {}),
+      clone: false,
+      ...(params.sessionStoreDiscoveryCache
+        ? { targetDiscoveryCache: params.sessionStoreDiscoveryCache }
+        : {}),
+    },
   );
   if (params.expectedExistingSessionId && entry?.sessionId !== params.expectedExistingSessionId) {
     params.respond(

--- a/src/gateway/server-methods/agent-session-prepare.ts
+++ b/src/gateway/server-methods/agent-session-prepare.ts
@@ -24,11 +24,11 @@ import { isRecoverableTerminalSessionStatus } from "../../config/sessions/termin
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { parseCronRunScopeSuffix } from "../../sessions/session-key-utils.js";
 import { sessionDeliveryChannel } from "../../utils/delivery-context.shared.js";
-import type { GatewaySessionStoreDiscoveryCache } from "../session-utils-store-lookup.js";
 import {
   respondDeletedAgentSession,
   type RestoredCronContinuation,
 } from "../agent-turn/agent-handler-helpers.js";
+import type { GatewaySessionStoreDiscoveryCache } from "../session-utils-store-lookup.js";
 import { loadSessionEntry } from "../session-utils.js";
 import type { AgentRunRequest } from "./agent-request-types.js";
 import type { GatewayRequestHandlerOptions } from "./types.js";

--- a/src/gateway/server-methods/agent.abort-integration.test-utils.ts
+++ b/src/gateway/server-methods/agent.abort-integration.test-utils.ts
@@ -962,6 +962,7 @@ describe("gateway agent handler chat.abort integration", () => {
     expect(mocks.loadSessionEntry).toHaveBeenCalledWith("global", {
       agentId: "work",
       clone: false,
+      targetDiscoveryCache: expect.any(Map),
     });
     expect(context.chatAbortControllers.has(runId)).toBe(false);
 

--- a/src/gateway/server-methods/agent.sessions-and-models.test-utils.ts
+++ b/src/gateway/server-methods/agent.sessions-and-models.test-utils.ts
@@ -2133,6 +2133,7 @@ describe("gateway agent handler", () => {
     expect(mocks.loadSessionEntry).toHaveBeenCalledWith("agent:ops:main", {
       agentId: "ops",
       clone: false,
+      targetDiscoveryCache: expect.any(Map),
     });
   });
 
@@ -2183,6 +2184,7 @@ describe("gateway agent handler", () => {
     expect(mocks.loadSessionEntry).toHaveBeenCalledWith("global", {
       agentId: "work",
       clone: false,
+      targetDiscoveryCache: expect.any(Map),
     });
   });
 
@@ -2229,6 +2231,7 @@ describe("gateway agent handler", () => {
     expect(call.sessionKey).toBe("global");
     expect(mocks.loadSessionEntry).toHaveBeenCalledWith("global", {
       clone: false,
+      targetDiscoveryCache: expect.any(Map),
     });
   });
 
@@ -2276,6 +2279,7 @@ describe("gateway agent handler", () => {
     expect(mocks.loadSessionEntry).toHaveBeenCalledWith("agent:work:main", {
       agentId: "work",
       clone: false,
+      targetDiscoveryCache: expect.any(Map),
     });
   });
 
@@ -2412,6 +2416,7 @@ describe("gateway agent handler", () => {
     expect(mocks.loadSessionEntry).toHaveBeenCalledWith("main", {
       agentId: "work",
       clone: false,
+      targetDiscoveryCache: expect.any(Map),
     });
   });
 

--- a/src/gateway/session-utils-store-lookup.ts
+++ b/src/gateway/session-utils-store-lookup.ts
@@ -1,5 +1,6 @@
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { listAgentIds } from "../agents/agent-scope.js";
+import { resolveRuntimeConfigCacheKey } from "../config/runtime-snapshot.js";
 import {
   isConfiguredSessionStoreAgentId,
   resolveAgentMainSessionKey,
@@ -104,7 +105,8 @@ function resolveGatewaySessionStoreCandidates(
   agentId: string,
   cache?: GatewaySessionStoreDiscoveryCache,
 ): { existing: SessionStoreTarget[]; fallback: SessionStoreTarget } {
-  const cached = cache?.get(agentId);
+  const cacheKey = `${resolveRuntimeConfigCacheKey(cfg)}\u0000${agentId}`;
+  const cached = cache?.get(cacheKey);
   if (cached) {
     return cached;
   }
@@ -117,7 +119,7 @@ function resolveGatewaySessionStoreCandidates(
     existing: resolveExistingAgentSessionStoreTargetsSync(cfg, agentId),
     fallback,
   };
-  cache?.set(agentId, discovery);
+  cache?.set(cacheKey, discovery);
   return discovery;
 }
 
@@ -134,8 +136,8 @@ function resolveGatewaySessionStoreCandidates(
 export type GatewaySessionStoreCache = Map<string, Record<string, SessionEntry>>;
 
 /**
- * Sharing resolves every returned row, but store targets are stable within one request.
- * Keep discovery agent-scoped here or each row repeats registry probes and agent-root scans.
+ * Sharing resolves every returned row, but store targets are stable only within one config revision.
+ * Keep discovery config- and agent-scoped or reloads reuse obsolete store targets.
  */
 export type GatewaySessionStoreDiscoveryCache = Map<
   string,

--- a/src/gateway/session-utils-store.ts
+++ b/src/gateway/session-utils-store.ts
@@ -36,6 +36,7 @@ import { resolveGatewayModelThinkingProfile } from "./session-utils-model.js";
 import {
   resolveGatewaySessionStoreTarget,
   resolveGatewaySessionStoreTargetWithStore,
+  type GatewaySessionStoreDiscoveryCache,
 } from "./session-utils-store-lookup.js";
 import type { GatewayAgentRow } from "./session-utils.types.js";
 
@@ -121,7 +122,14 @@ function readAcpMetaForDeletedAgentCheck(params: {
 
 function loadSessionEntryWithMode(
   sessionKey: string,
-  opts: { agentId?: string; clone?: boolean; includeStoreChildEntries?: boolean } | undefined,
+  opts:
+    | {
+        agentId?: string;
+        clone?: boolean;
+        includeStoreChildEntries?: boolean;
+        targetDiscoveryCache?: GatewaySessionStoreDiscoveryCache;
+      }
+    | undefined,
   readOnly: boolean,
 ) {
   const cfg = getRuntimeConfig();
@@ -131,6 +139,7 @@ function loadSessionEntryWithMode(
     key,
     ...(opts?.clone === false ? { clone: false } : {}),
     ...(opts?.agentId ? { agentId: opts.agentId } : {}),
+    ...(opts?.targetDiscoveryCache ? { targetDiscoveryCache: opts.targetDiscoveryCache } : {}),
     ...(readOnly
       ? {
           exactRead: true,
@@ -160,14 +169,23 @@ function loadSessionEntryWithMode(
 
 export function loadGatewaySessionEntry(
   sessionKey: string,
-  opts?: { agentId?: string; clone?: boolean },
+  opts?: {
+    agentId?: string;
+    clone?: boolean;
+    targetDiscoveryCache?: GatewaySessionStoreDiscoveryCache;
+  },
 ) {
   return loadSessionEntryWithMode(sessionKey, opts, false);
 }
 
 export function loadGatewaySessionEntryReadOnly(
   sessionKey: string,
-  opts?: { agentId?: string; clone?: boolean; includeStoreChildEntries?: boolean },
+  opts?: {
+    agentId?: string;
+    clone?: boolean;
+    includeStoreChildEntries?: boolean;
+    targetDiscoveryCache?: GatewaySessionStoreDiscoveryCache;
+  },
 ) {
   return loadSessionEntryWithMode(sessionKey, opts, true);
 }

--- a/src/gateway/session-utils.test.ts
+++ b/src/gateway/session-utils.test.ts
@@ -2178,6 +2178,43 @@ describe("gateway session utils", () => {
     }
   });
 
+  test("loadSessionEntry invalidates request discovery after a runtime config reload", async () => {
+    resetConfigRuntimeState();
+    try {
+      await withStateDirEnv("session-utils-config-reload-", async ({ tempRoot }) => {
+        const firstStorePath = path.join(tempRoot, "first", "sessions.json");
+        const secondStorePath = path.join(tempRoot, "second", "sessions.json");
+        const firstConfig = {
+          session: { mainKey: "main", store: firstStorePath },
+          agents: { list: [{ id: "main", default: true }] },
+        } as OpenClawConfig;
+        const secondConfig = {
+          ...firstConfig,
+          session: { mainKey: "main", store: secondStorePath },
+        } as OpenClawConfig;
+        const targetDiscoveryCache = new Map();
+
+        setRuntimeConfigSnapshot(firstConfig, firstConfig);
+        const routingLoad = loadSessionEntry("agent:main:main", {
+          agentId: "main",
+          clone: false,
+          targetDiscoveryCache,
+        });
+        setRuntimeConfigSnapshot(secondConfig, secondConfig);
+        const preparationLoad = loadSessionEntry("agent:main:main", {
+          agentId: "main",
+          clone: false,
+          targetDiscoveryCache,
+        });
+
+        expect(routingLoad.storePath).toBe(path.resolve(firstStorePath));
+        expect(preparationLoad.storePath).toBe(path.resolve(secondStorePath));
+      });
+    } finally {
+      resetConfigRuntimeState();
+    }
+  });
+
   test("loadSessionEntry can borrow the cached store for read-only hot paths", async () => {
     resetConfigRuntimeState();
     try {


### PR DESCRIPTION
## What Problem This Solves

Agent requests with an existing session repeat session-store work before execution. Routing loads the same entry once for availability checks and again for the pre-attachment snapshot, then session preparation repeats store-target discovery before its required fresh store read.

On gateways with multiple agent stores, those duplicate calls repeat filesystem and registry discovery on every affected request.

## Why This Change Was Made

Routing now reuses its first loaded entry for both the availability check and the pre-attachment snapshot. It also carries the existing request-scoped target-discovery cache into session preparation.

Store contents are deliberately not cached: session preparation still performs a fresh store read so concurrent deletion, reset, and expected-session guards continue to observe current state.

## User Impact

Agent requests do less synchronous session-store work before execution, especially on gateways with several agent stores. There is no response-shape, authorization, or session-freshness behavior change.

## Evidence

### Current-main review

- Rebased cleanly onto current `openclaw/openclaw` main.
- Reviewed head: `bc8f19cc6ba40b0f532d51ae5e27bf4c5e946168`.
- Reviewed base: `51241c4e00ff3056dfae87aa45b69744c2ce3e8a`.
- The equivalent request-scoped reuse was not present on that base.

### Real configured gateway proof

Tested the reviewed head on Windows with a separate local-mode OpenClaw profile and a real loopback Gateway WebSocket on `127.0.0.1:19519`. The proof profile had one configured `main` agent. Channels, bundled plugins, cron, and providers were disabled so the run exercised the Gateway request/session path without touching production credentials or delivery channels.

Request:

```text
openclaw --profile proof115519 gateway call agent --timeout 10000 --json \
  --params '{"agentId":"main","sessionKey":"agent:main:proof-final-head","idempotencyKey":"proof-115519-final-head-1","message":"proof request","deliver":false}'
```

Gateway response:

```json
{
  "runId": "proof-115519-final-head-1",
  "sessionKey": "agent:main:proof-final-head",
  "status": "accepted",
  "acceptedAt": 1785362968920
}
```

Redacted request-path diagnostics:

```text
[proof115519] session-load #1 key=agent:main:proof-final-head discoveryCache=shared cacheSize=0
[proof115519] discovery #2 agent=main result=miss cacheSize=0
[proof115519] session-load #2 key=agent:main:proof-final-head discoveryCache=shared cacheSize=1
[proof115519] discovery #3 agent=main result=hit cacheSize=1
[ws] res OK agent 210ms runId=proof-115519-final-head-1
```

This shows both required properties in a live configured Gateway:

- Routing resolves the target on the first load (`cacheSize=0`, miss).
- Session preparation still calls `loadSessionEntry` again, so the authoritative store entry remains fresh, while target discovery reuses the request-scoped cache (`cacheSize=1`, hit).

The diagnostic counters were temporary, gated by a proof-only environment variable, and removed before the branch was pushed. No proof logging or test profile configuration is included in the PR.

### Quantified boundary

- Routing session loads: `2 -> 1`.
- Across the optimized routing + preparation boundary, store reads: `3 -> 2`.
- Across that same boundary, store-target resolutions: `3 -> 1`.
- Later independent agent-execution store operations are intentionally outside this optimization and are not included in these counts.

### Regression tests

- `agent-request-routing.test.ts`: 1 passed.
- Selected global/session-routing and attachment-abort cases in `agent.test.ts`: 7 passed / 256 skipped.
- Focused total: 8 passed, 0 failed.
- `git diff --check`: clean.
- Full `pnpm build`: passed on the reviewed head.

The focused routing regression verifies one routing `loadSessionEntry` call, preserves the pre-attachment session snapshot, and carries the same request-scoped discovery cache into fresh session preparation.
