### PR TITLE
fix(health): show gateway probe duration in text output

### DIFF
--- a/src/commands/health.test.ts
+++ b/src/commands/health.test.ts
@@ -180,9 +180,39 @@ describe("healthCommand", () => {
 
     expect(runtime.exit).not.toHaveBeenCalled();
     const parsed = JSON.parse(requireFirstRuntimeLog()) as HealthSummary;
+    expect(parsed.durationMs).toBe(5);
     expect(parsed.channels.whatsapp?.linked).toBe(true);
     expect(parsed.channels.telegram?.configured).toBe(true);
     expect(parsed.sessions.count).toBe(1);
+  });
+
+  it("prints the gateway probe duration in text output", async () => {
+    const snapshot = createHealthSummary({
+      channels: {},
+      channelOrder: [],
+      channelLabels: {},
+    });
+    callGatewayMock.mockResolvedValueOnce(snapshot);
+
+    await healthCommand({ json: false, timeoutMs: 1000, config: {} }, runtime as never);
+
+    const output = stripAnsi(runtime.log.mock.calls.map((call) => String(call[0])).join("\n"));
+    expect(output).toContain("Gateway probe duration: 5ms");
+  });
+
+  it("omits the probe duration for legacy gateway snapshots", async () => {
+    const { durationMs, ...legacySnapshot } = createHealthSummary({
+      channels: {},
+      channelOrder: [],
+      channelLabels: {},
+    });
+    expect(durationMs).toBe(5);
+    callGatewayMock.mockResolvedValueOnce(legacySnapshot);
+
+    await healthCommand({ json: false, timeoutMs: 1000, config: {} }, runtime as never);
+
+    const output = stripAnsi(runtime.log.mock.calls.map((call) => String(call[0])).join("\n"));
+    expect(output).not.toContain("Gateway probe duration:");
   });
 
   it("prints the delivery queue warning line when the gateway reports dead-letters", async () => {

--- a/src/commands/health.ts
+++ b/src/commands/health.ts
@@ -1058,6 +1058,10 @@ export async function healthCommand(
       }
     }
 
+    if (Number.isFinite(summary.durationMs)) {
+      runtime.log(info(`Gateway probe duration: ${summary.durationMs}ms`));
+    }
+
     if (resolvedAgents.length > 0) {
       const agentLabels = resolvedAgents.map((agent) =>
         agent.isDefault ? `${agent.agentId} (default)` : agent.agentId,


### PR DESCRIPTION
Closes #50245.\n\n## What Problem This Solves\n\nFixes an issue where operators running openclaw health could not see the measured gateway probe duration even though the existing gateway health documentation explicitly says the command reports it, health JSON already contains it, and status already displays it.\n\n## Why This Change Was Made\n\nRender the existing finite durationMs only in the owner of the human-readable health output. Keep the gateway protocol, JSON output, configuration, and older gateway snapshots unchanged. This revives the focused idea from closed PR #50250 while adding the real CLI proof and legacy-snapshot regression it lacked.\n\n## User Impact\n\nThe real openclaw health command now displays Gateway probe duration: 5ms; operators diagnosing slow gateways no longer need JSON just to read existing timing. Older snapshots without durationMs print no misleading undefined or NaN value.\n\n## Evidence\n\n- Existing public behavior contract: docs/gateway/health.md explicitly says health reports probe duration; src/commands/status.command-sections.ts already renders the same duration.\n- Red regression on current main: the new real health-command regression failed because the text output contained Agents, Heartbeat interval and Session store but omitted Gateway probe duration.\n- Green regression: all 25 src/commands/health.test.ts tests pass, including unchanged JSON and older gateway snapshots without durationMs.\n- Real end-to-end proof on Blacksmith Testbox tbx_01kynxjrbgxrmsd5hzby7tqtzx: started a fresh authenticated gateway on a dynamically allocated loopback port with isolated state and ran the actual package CLI against it.\n- ACTUAL openclaw health --json: ok=true durationMs=1\n- ACTUAL openclaw health: Gateway probe duration: 5ms\n- PASS: real package CLI, isolated authenticated live Gateway, unchanged valid JSON, documented human timing.\n- Remote pnpm check:changed: PASS, including core and core-test typecheck, formatting, lint and all changed-file guards.\n- Fresh structured autoreview: gpt-5.6-sol, xhigh reasoning, no accepted or actionable findings.\n\nCredit to @JonathanJing for the original report and focused fix in #50250. AI-assisted; independently reproduced, implemented, and verified against current main.