### PR TITLE
fix(mcp): preserve non-text content in structured tool results

### DIFF
--- a/src/agents/agent-bundle-mcp-materialize.ts
+++ b/src/agents/agent-bundle-mcp-materialize.ts
@@ -92,9 +92,10 @@ function toAgentToolResult(params: {
   toolName: string;
   result: CallToolResult;
 }): AgentToolResult<unknown> {
-  const content: AgentToolResult<unknown>["content"] = Array.isArray(params.result.content)
-    ? params.result.content.map(mcpContentBlockToAgentContent)
-    : [];
+  const sourceContent = Array.isArray(params.result.content) ? params.result.content : [];
+  const content: AgentToolResult<unknown>["content"] = sourceContent.map(
+    mcpContentBlockToAgentContent,
+  );
   const structuredContentBlock =
     params.result.structuredContent !== undefined
       ? ({
@@ -102,10 +103,15 @@ function toAgentToolResult(params: {
           text: `structuredContent:\n${JSON.stringify(params.result.structuredContent, null, 2)}`,
         } as const)
       : null;
-  // Structured MCP results are the canonical model payload here; replacing
-  // mirrored content avoids duplicating large tool output in the prompt.
+  // Structured results replace mirrored text, but original non-text blocks
+  // still carry images, linked resources, and audio that the JSON cannot mirror.
   const normalizedContent: AgentToolResult<unknown>["content"] = structuredContentBlock
-    ? [structuredContentBlock]
+    ? [
+        structuredContentBlock,
+        ...sourceContent
+          .filter((block) => block.type !== "text")
+          .map(mcpContentBlockToAgentContent),
+      ]
     : content.length > 0
       ? content
       : ([

--- a/src/agents/agent-bundle-mcp-runtime.test.ts
+++ b/src/agents/agent-bundle-mcp-runtime.test.ts
@@ -4,6 +4,7 @@ import http from "node:http";
 import os from "node:os";
 import path from "node:path";
 import type { DatabaseSync } from "node:sqlite";
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { expectDefined } from "@openclaw/normalization-core";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { withTestTimeout } from "../../test/helpers/promise.js";
@@ -71,6 +72,7 @@ async function writeListToolsMcpServer(params: {
   callToolIsError?: boolean;
   callToolJsonRpcError?: boolean;
   callToolJsonRpcErrorCode?: number;
+  callToolResult?: CallToolResult;
   resourcePageDelayMs?: number;
   resourcePageCount?: number;
   resourceListJsonRpcError?: boolean;
@@ -108,6 +110,7 @@ const tools = ${JSON.stringify(
 const callToolIsError = ${params.callToolIsError === true};
 const callToolJsonRpcError = ${params.callToolJsonRpcError === true};
 const callToolJsonRpcErrorCode = ${params.callToolJsonRpcErrorCode ?? -32000};
+const callToolResult = ${JSON.stringify(params.callToolResult)};
 const resourcePageDelayMs = ${params.resourcePageDelayMs ?? 0};
 const resourcePageCount = ${params.resourcePageCount ?? 1};
 const resourceListJsonRpcError = ${params.resourceListJsonRpcError === true};
@@ -236,7 +239,9 @@ function handle(message) {
       id: message.id,
       result: {
         isError: callToolIsError,
-        content: [{ type: "text", text: callToolIsError ? "tool failed" : "tool ok" }],
+        ...(callToolResult ?? {
+          content: [{ type: "text", text: callToolIsError ? "tool failed" : "tool ok" }],
+        }),
       },
     });
   }
@@ -1182,6 +1187,67 @@ describe("session MCP runtime", () => {
       expect((await fs.readFile(retryLogPath, "utf8")).match(/recv tools\/list/g)).toHaveLength(2);
     } finally {
       nowSpy.mockRestore();
+      await runtime.dispose();
+    }
+  });
+
+  it("preserves non-text structured MCP results through a real stdio server", async () => {
+    const tempDir = tempDirTracker.make("bundle-mcp-structured-content-");
+    const serverPath = path.join(tempDir, "structured-content.mjs");
+    const logPath = path.join(tempDir, "server.log");
+    const structuredContent = { description: "captured screenshot" };
+    await writeListToolsMcpServer({
+      filePath: serverPath,
+      logPath,
+      callToolResult: {
+        content: [
+          { type: "text", text: "captured screenshot" },
+          { type: "image", data: "aW1hZ2U=", mimeType: "image/png" },
+          {
+            type: "resource_link",
+            uri: "https://example.com/report",
+            name: "report",
+            title: "Report",
+          },
+          { type: "resource", resource: { uri: "memo://one", text: "memo body" } },
+          { type: "audio", data: "AAAA", mimeType: "audio/mpeg" },
+        ],
+        structuredContent,
+      },
+    });
+
+    const runtime = await getOrCreateSessionMcpRuntime({
+      sessionId: "session-structured-content",
+      sessionKey: "agent:test:session-structured-content",
+      workspaceDir: tempDir,
+      cfg: {
+        mcp: {
+          servers: {
+            capture: { command: process.execPath, args: [serverPath] },
+          },
+        },
+      },
+    });
+
+    try {
+      const materialized = await materializeBundleMcpToolsForRun({ runtime });
+      const result = await expectDefined(
+        materialized.tools[0],
+        "materialized MCP tool test invariant",
+      ).execute("call-structured-content", {}, undefined, undefined);
+
+      expect(result.content).toEqual([
+        {
+          type: "text",
+          text: `structuredContent:\n${JSON.stringify(structuredContent, null, 2)}`,
+        },
+        { type: "image", data: "aW1hZ2U=", mimeType: "image/png" },
+        { type: "text", text: "[Report] https://example.com/report" },
+        { type: "text", text: "memo body" },
+        { type: "text", text: "[audio audio/mpeg]" },
+      ]);
+      await waitForFileText(logPath, "recv tools/call", LIST_TOOLS_SERVER_LOG_TIMEOUT_MS);
+    } finally {
       await runtime.dispose();
     }
   });

--- a/src/agents/agent-bundle-mcp-tools.materialize.test.ts
+++ b/src/agents/agent-bundle-mcp-tools.materialize.test.ts
@@ -310,6 +310,47 @@ describe("createBundleMcpToolRuntime", () => {
     });
   });
 
+  it("preserves non-text MCP content alongside structuredContent without duplicating mirrored text", async () => {
+    const structuredContent = { description: "captured screenshot" };
+    const runtime = await materializeBundleMcpToolsForRun({
+      runtime: makeToolRuntime({
+        result: {
+          content: [
+            { type: "text", text: "captured screenshot" },
+            { type: "image", data: "aW1hZ2U=", mimeType: "image/png" },
+            {
+              type: "resource_link",
+              uri: "https://example.com/report",
+              name: "report",
+              title: "Report",
+            },
+            { type: "resource", resource: { uri: "memo://one", text: "memo body" } },
+            { type: "audio", data: "AAAA", mimeType: "audio/mpeg" },
+          ],
+          structuredContent,
+        },
+      }),
+    });
+
+    const result = await expectDefined(runtime.tools[0], "runtime.tools[0] test invariant").execute(
+      "call-bundle-probe",
+      {},
+      undefined,
+      undefined,
+    );
+
+    expect(result.content).toEqual([
+      {
+        type: "text",
+        text: `structuredContent:\n${JSON.stringify(structuredContent, null, 2)}`,
+      },
+      { type: "image", data: "aW1hZ2U=", mimeType: "image/png" },
+      { type: "text", text: "[Report] https://example.com/report" },
+      { type: "text", text: "memo body" },
+      { type: "text", text: "[audio audio/mpeg]" },
+    ]);
+  });
+
   it("coerces non-text/image MCP tool-result blocks to text (resource_link/resource/audio)", async () => {
     // resource_link/resource/audio blocks have no base64 image source; if they
     // leaked into the provider image branch Anthropic would 400 on an image with


### PR DESCRIPTION
Related: #114846

## What Problem This Solves

Fixes an issue where users calling an MCP screenshot, rendering, resource, or audio tool would lose every non-text result whenever the server also returned structuredContent. Only the JSON summary reached the agent, even though the MCP SDK contract allows the content blocks and structured result together.

## Why This Change Was Made

Keep structuredContent as the single canonical text payload, but retain every originally non-text MCP block through the existing content converter. This preserves screenshots as images and safely renders resource links, embedded resources, and audio into the established agent text/image contract. Unlike an image-only workaround, the fix covers the complete MCP SDK 1.30.0 ContentBlock union without adding protocol, public API, configuration, dependencies, or duplicated mirrored text.

## User Impact

Agents can see MCP screenshots and access the human-readable information from returned resource links, embedded resources, and audio summaries alongside structured tool output. Existing structured text results remain deduplicated.

## Evidence

- Red-before-fix: the added materialization regression failed because current main returned only structuredContent and discarded all four non-text result blocks.
- Real MCP stdio round trip: a child MCP server performs initialize, tools/list, and tools/call and returns structured content plus image, resource link, embedded resource, and audio. The actual materialized agent tool preserves all four and proves the real server received tools/call.
- Blacksmith Testbox tbx_01kynxr9vpq6xcvbg7wck7cf8a: pnpm test src/agents/agent-bundle-mcp-tools.materialize.test.ts src/agents/agent-bundle-mcp-runtime.test.ts src/agents/agent-bundle-mcp-filter.test.ts src/agents/mcp-transport.test.ts — 119 tests passed.
- Same Testbox: pnpm check:changed — passed, including changed-file formatting, core and test type checks, lint, dependency guards, and import-cycle checks.
- .agents/skills/autoreview/scripts/autoreview --mode uncommitted — clean; no accepted or actionable findings.
- Dependency contract personally checked against @modelcontextprotocol/sdk 1.30.0 src/types.ts ContentBlockSchema and CallToolResultSchema.

AI-assisted; inspired by and credits @MatthewSynthia for reporting the screenshot-specific case in #114846.