### PR TITLE
fix(heartbeat): keep reasoning acknowledgements out of chat history

### DIFF
--- a/src/auto-reply/heartbeat-filter.test.ts
+++ b/src/auto-reply/heartbeat-filter.test.ts
@@ -93,6 +93,18 @@ describe("isHeartbeatOkResponse", () => {
     ).toBe(true);
   });
 
+  it.each([
+    ["thinking", { type: "thinking", thinking: "Checking the heartbeat." }],
+    ["redacted thinking", { type: "redacted_thinking", data: "opaque-reasoning" }],
+  ])("matches acknowledgements with hidden %s blocks", (_label, thinkingBlock) => {
+    expect(
+      isHeartbeatOkResponse({
+        role: "assistant",
+        content: [thinkingBlock, { type: "text", text: "HEARTBEAT_OK" }],
+      }),
+    ).toBe(true);
+  });
+
   it("preserves meaningful or non-text responses", () => {
     expect(
       isHeartbeatOkResponse({
@@ -155,6 +167,25 @@ describe("filterHeartbeatTranscriptArtifacts", () => {
       { role: "assistant", content: "Hi there!" },
       { role: "user", content: "What time is it?" },
       { role: "assistant", content: "It is 3pm." },
+    ]);
+  });
+
+  it.each([
+    ["thinking", { type: "thinking", thinking: "Checking the heartbeat." }],
+    ["redacted thinking", { type: "redacted_thinking", data: "opaque-reasoning" }],
+  ])("removes no-op heartbeat pairs with hidden %s blocks", (_label, thinkingBlock) => {
+    const nextUserMessage = { role: "user", content: "What time is it?" };
+    const messages = [
+      { role: "user", content: HEARTBEAT_TRANSCRIPT_PROMPT },
+      {
+        role: "assistant",
+        content: [thinkingBlock, { type: "text", text: "HEARTBEAT_OK" }],
+      },
+      nextUserMessage,
+    ];
+
+    expect(filterHeartbeatTranscriptArtifacts(messages, undefined, HEARTBEAT_PROMPT)).toEqual([
+      nextUserMessage,
     ]);
   });
 

--- a/src/auto-reply/heartbeat-filter.ts
+++ b/src/auto-reply/heartbeat-filter.ts
@@ -269,6 +269,11 @@ function resolveMessageText(content: unknown): { text: string; hasNonTextContent
       hasNonTextContent = true;
       continue;
     }
+    // Provider thinking is not user-visible output; it must not keep a
+    // no-op heartbeat acknowledgement in future model request history.
+    if (block.type === "thinking" || block.type === "redacted_thinking") {
+      continue;
+    }
     if (block.type !== "text" && block.type !== "input_text" && block.type !== "output_text") {
       hasNonTextContent = true;
       continue;


### PR DESCRIPTION
Closes #95796

## What Problem This Solves

Fixes an issue where users of reasoning-capable models accumulated internal heartbeat prompts and acknowledgements in every later model request when the heartbeat response included provider thinking or redacted thinking. This wasted context and could confuse later replies even though the heartbeat had no visible result. Thanks to @DinoMC for the detailed report.

## Why This Change Was Made

The canonical provider contract classifies `thinking` and `redacted_thinking` as hidden reasoning, not user-visible text. Ignore exactly those two existing block types while checking a heartbeat acknowledgement. Keep all other non-text content, tool calls, meaningful output, and visible heartbeat alerts protected by the existing logic.

## User Impact

Silent heartbeat acknowledgements from reasoning-capable providers no longer pollute future conversation context. Ordinary chat, visible heartbeat results, tool calls, media, and heartbeat browser imports retain their existing behavior.

## Evidence

- Fail-first production-path proof on Blacksmith Testbox `tbx_01kynxn11r99k76fzh62a3wjey`: all four newly added regressions failed against current `main`, while the other 34 heartbeat-filter tests passed.
- Fixed-head proof on fresh Blacksmith Testbox `tbx_01kynygx1wdys5qd4g71464hhq`: `OPENCLAW_TESTBOX=1 OPENCLAW_TESTBOX_REMOTE_RUN=1 pnpm test src/auto-reply/heartbeat-filter.test.ts src/auto-reply/heartbeat-filter.browser-import.test.ts src/auto-reply/heartbeat.test.ts src/agents/thinking-block.test.ts` — 4 files and 77 tests passed.
- The regressions exercise real heartbeat acknowledgement classification and the next user turn's model-history filtering for both hidden provider block types.
- Blacksmith Testbox changed gate: `CI=1 OPENCLAW_TESTBOX=1 OPENCLAW_TESTBOX_REMOTE_RUN=1 pnpm check:changed` — passed core formatting, core and core-test typechecking, changed-file lint, runtime import-cycle detection, and all applicable guards.
- Independent final-head review: `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main --thinking xhigh` — clean; no accepted or actionable findings.
- AI-assisted, reviewed against the canonical thinking contract in `packages/llm-core/src/types.ts` and `src/agents/thinking-block.ts`.
