### PR TITLE
fix(ios): allow the first Motion & Fitness permission prompt

### DIFF
--- a/apps/ios/Sources/Motion/MotionService.swift
+++ b/apps/ios/Sources/Motion/MotionService.swift
@@ -9,8 +9,7 @@ final class MotionService: MotionServicing {
                 NSLocalizedDescriptionKey: "MOTION_UNAVAILABLE: activity not supported on this device",
             ])
         }
-        let auth = CMMotionActivityManager.authorizationStatus()
-        guard auth == .authorized else {
+        guard Self.allowsMotionQuery(CMMotionActivityManager.authorizationStatus()) else {
             throw NSError(domain: "Motion", code: 3, userInfo: [
                 NSLocalizedDescriptionKey: "MOTION_PERMISSION_REQUIRED: grant Motion & Fitness permission",
             ])
@@ -53,8 +52,7 @@ final class MotionService: MotionServicing {
                 NSLocalizedDescriptionKey: "PEDOMETER_UNAVAILABLE: step counting not supported",
             ])
         }
-        let auth = CMPedometer.authorizationStatus()
-        guard auth == .authorized else {
+        guard Self.allowsMotionQuery(CMPedometer.authorizationStatus()) else {
             throw NSError(domain: "Motion", code: 4, userInfo: [
                 NSLocalizedDescriptionKey: "MOTION_PERMISSION_REQUIRED: grant Motion & Fitness permission",
             ])
@@ -78,6 +76,18 @@ final class MotionService: MotionServicing {
                     cont.resume(returning: payload)
                 }
             }
+        }
+    }
+
+    static func allowsMotionQuery(_ authorizationStatus: CMAuthorizationStatus) -> Bool {
+        switch authorizationStatus {
+        case .notDetermined, .authorized:
+            // Core Motion only presents its first-use permission prompt when a query runs.
+            return true
+        case .restricted, .denied:
+            return false
+        @unknown default:
+            return false
         }
     }
 

--- a/apps/ios/Tests/MotionServiceTests.swift
+++ b/apps/ios/Tests/MotionServiceTests.swift
@@ -1,0 +1,21 @@
+import CoreMotion
+import Testing
+@testable import OpenClaw
+
+struct MotionServiceTests {
+    @Test func `first motion query can request authorization`() {
+        #expect(MotionService.allowsMotionQuery(.notDetermined))
+    }
+
+    @Test func `authorized motion queries remain allowed`() {
+        #expect(MotionService.allowsMotionQuery(.authorized))
+    }
+
+    @Test func `denied motion queries remain blocked`() {
+        #expect(!MotionService.allowsMotionQuery(.denied))
+    }
+
+    @Test func `restricted motion queries remain blocked`() {
+        #expect(!MotionService.allowsMotionQuery(.restricted))
+    }
+}


### PR DESCRIPTION
Closes #115227

## What Problem This Solves

Fixes an issue where iPhone users invoking the existing motion activity or pedometer commands could never grant Motion & Fitness permission on first use. The app returned `MOTION_PERMISSION_REQUIRED` before Core Motion could present its first-use authorization prompt.

## Why This Change Was Made

Apple Core Motion requests Motion & Fitness permission when its first motion or pedometer query runs, rather than through a separate permission-request API. Route both existing queries through one exhaustive authorization decision: allow `.notDetermined` and `.authorized`, block `.denied`, `.restricted`, and unknown future states. This preserves the existing permission UI, capability reporting, privacy manifest, command contracts, and explicit user consent.

## User Impact

iPhone users can grant Motion & Fitness access when first invoking `motion.activity` or `motion.pedometer`. Users who deny permission, or whose devices restrict access, continue to receive `MOTION_PERMISSION_REQUIRED`; no settings, default, gateway, or security surface changes.

## Evidence

- Confirmed the shipped failure on current `main`, the full iOS motion-command entry point, existing capability and permission reporting, and the existing `NSMotionUsageDescription` in `apps/ios/project.yml` and `apps/ios/Sources/Info.plist`.
- Checked Apple's installed iOS 27 Core Motion SDK headers and official [CMPedometer documentation](https://developer.apple.com/documentation/coremotion/cmpedometer), [Core Motion authorization states](https://developer.apple.com/documentation/coremotion/cmauthorizationstatus/notdetermined), and [Motion Usage Description](https://developer.apple.com/documentation/bundleresources/information-property-list/nsmotionusagedescription).
- Native fail-first, dedicated iPhone 17 / iOS 27 simulator: the real `OpenClaw` app-target test returned exit 65 with exactly `MotionServiceTests.first motion query can request authorization` failing before the fix.
- Native passing proof, same simulator and real app target:

  ```text
  xcodebuild -quiet -project apps/ios/OpenClaw.xcodeproj -scheme OpenClaw \
    -destination id=8CFE7E27-2DFA-41BE-B95F-5EE1D3BF4A32 \
    -only-testing:OpenClawTests/MotionServiceTests \
    -only-testing:OpenClawTests/NodeServicePermissionTests \
    -only-testing:OpenClawTests/DevicePermissionsTests \
    -parallel-testing-enabled NO \
    CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO test
  # exit 0
  ```

- All four Core Motion authorization states are covered; existing tests also confirm node-invoked contacts, calendars, and reminders do not request access.
- `swiftformat --lint --config config/swiftformat apps/ios/Sources/Motion/MotionService.swift apps/ios/Tests/MotionServiceTests.swift` — pass.
- `git diff --check` — pass.
- `.agents/skills/autoreview/scripts/autoreview --mode uncommitted --thinking xhigh` — clean; patch correctness confidence 0.98.
- Simulator proof exercises the actual native app and authorization decision. iOS Simulator does not provide real motion hardware; display of Apple's physical-device system prompt is established by the Apple API contract, not claimed as a physical-device test.

AI-assisted; all source, Apple SDK/API behavior, fail-first native tests, privacy boundaries, and review results were independently checked.
