### PR TITLE
fix(agents): keep MCP image blocks when structuredContent is set

### DIFF
--- a/src/agents/agent-bundle-mcp-materialize.ts
+++ b/src/agents/agent-bundle-mcp-materialize.ts
@@ -102,10 +102,11 @@ function toAgentToolResult(params: {
           text: `structuredContent:\n${JSON.stringify(params.result.structuredContent, null, 2)}`,
         } as const)
       : null;
-  // Structured MCP results are the canonical model payload here; replacing
-  // mirrored content avoids duplicating large tool output in the prompt.
+  // structuredContent replaces only the spec's mirrored text copy; image blocks
+  // have no JSON representation and must survive, or the model silently goes
+  // blind on servers that pair screenshots with structured output.
   const normalizedContent: AgentToolResult<unknown>["content"] = structuredContentBlock
-    ? [structuredContentBlock]
+    ? [...content.filter((block) => block.type === "image"), structuredContentBlock]
     : content.length > 0
       ? content
       : ([

--- a/src/agents/agent-bundle-mcp-tools.materialize.test.ts
+++ b/src/agents/agent-bundle-mcp-tools.materialize.test.ts
@@ -310,6 +310,43 @@ describe("createBundleMcpToolRuntime", () => {
     });
   });
 
+  it("keeps image blocks when MCP tools return structuredContent", async () => {
+    // structuredContent can only replace the spec's mirrored text copy; images
+    // have no JSON representation and must reach the model (silent-blindness bug
+    // class if dropped).
+    const runtime = await materializeBundleMcpToolsForRun({
+      runtime: makeToolRuntime({
+        result: {
+          content: [
+            { type: "text", text: "screenshot of https://example.com" },
+            { type: "image", data: "aGVsbG8=", mimeType: "image/png" },
+          ],
+          structuredContent: { url: "https://example.com", title: "Example" },
+          isError: false,
+        },
+      }),
+    });
+
+    const result = await expectDefined(runtime.tools[0], "runtime.tools[0] test invariant").execute(
+      "call-bundle-image",
+      {},
+      undefined,
+      undefined,
+    );
+
+    expect(result.content).toEqual([
+      { type: "image", data: "aGVsbG8=", mimeType: "image/png" },
+      {
+        type: "text",
+        text: `structuredContent:\n${JSON.stringify(
+          { url: "https://example.com", title: "Example" },
+          null,
+          2,
+        )}`,
+      },
+    ]);
+  });
+
   it("coerces non-text/image MCP tool-result blocks to text (resource_link/resource/audio)", async () => {
     // resource_link/resource/audio blocks have no base64 image source; if they
     // leaked into the provider image branch Anthropic would 400 on an image with


### PR DESCRIPTION
## What Problem This Solves

When an MCP server returns `structuredContent`, `toAgentToolResult` in `src/agents/agent-bundle-mcp-materialize.ts` replaced the **entire** content array with a single JSON text block. Any image blocks in the same result were silently dropped: `details.structuredContent` still looked complete in logs, but the model never saw the image. Classic silent failure — the agent goes blind with no visible error.

The MCP spec's backward-compat rule is that `structuredContent` SHOULD be mirrored as a serialized-JSON `TextContent` block; that mirror is the only thing safe to dedupe away. Image blocks have no JSON representation, so replacing them loses data the structured payload cannot carry.

## Why This Change Was Made

The replace-all behavior shipped in 2df8021cdab (v2026.5.28) to avoid duplicating large tool output in the prompt. That goal only requires dropping the mirrored *text* copy. Any spec-legal MCP server that pairs image blocks (e.g. screenshots) with an `outputSchema`/`structuredContent` result hits the drop today. Playwright MCP happens not to set `structuredContent`, and the bundled browser plugin uses a separate adapter (`extensions/browser/src/browser/chrome-mcp-result.ts`), so no bundled surface currently triggers it — but operator-configured third-party servers can.

## User Impact

Agents using external MCP servers that return images alongside structured output now receive the image in the tool result instead of only the JSON metadata. Text-only structured results are unchanged: the mirrored text copy is still deduped to the single JSON block.

## Evidence

- Fix: `structuredContent` now replaces only text blocks; mapped image blocks are kept ahead of the JSON block (`src/agents/agent-bundle-mcp-materialize.ts`).
- New regression test: image + `structuredContent` → both blocks survive (`src/agents/agent-bundle-mcp-tools.materialize.test.ts`).
- Existing dedup test ("keeps structuredContent visible when MCP tools also return text content") still passes unchanged, pinning the text-mirror collapse.
- Local proof: `node scripts/run-vitest.mjs src/agents/agent-bundle-mcp-tools.materialize.test.ts` — 18/18 passed. Autoreview (Codex gpt-5.6-sol, high): clean, no findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
