### PR TITLE
fix(imessage): explain unsupported private status on older imsg

### DIFF
--- a/extensions/imessage/src/probe.ts
+++ b/extensions/imessage/src/probe.ts
@@ -243,6 +243,26 @@ export async function probeIMessagePrivateApi(
   try {
     const result = await runCommandWithTimeout([key, "status", "--json"], { timeoutMs });
     const combined = `${result.stdout}\n${result.stderr}`.trim();
+    const normalized = normalizeLowercaseStringOrEmpty(combined);
+    if (
+      result.code !== 0 &&
+      normalized.includes("unknown subcommand") &&
+      normalized.includes("status")
+    ) {
+      const status: NonNullable<IMessageProbe["privateApi"]> = {
+        available: false,
+        v2Ready: false,
+        selectors: {},
+        rpcMethods: [],
+        cliCapabilities: {
+          sendRichSupportsAttachment: false,
+          pollSendSupportsNoComment: false,
+        },
+        error: `imsg CLI does not support the "status" subcommand. Update imsg on the Messages Mac: ${IMESSAGE_UPDATE_COMMAND}`,
+      };
+      cacheIMessagePrivateApiStatus(key, status);
+      return status;
+    }
     const { payload, firstLineSnippet } = parseStatusPayload(result.stdout);
     const selectors = payload ? selectorsFromPayload(payload) : {};
     const rpcMethods = payload ? rpcMethodsFromPayload(payload) : [];

--- a/extensions/imessage/src/status.test.ts
+++ b/extensions/imessage/src/status.test.ts
@@ -545,6 +545,77 @@ describe("probeIMessage", () => {
     expect(createIMessageRpcClientMock).not.toHaveBeenCalled();
   });
 
+  it("explains how to update imsg when its private status subcommand is unsupported", async () => {
+    const runCommand = vi.spyOn(processRuntime, "runCommandWithTimeout").mockResolvedValueOnce({
+      stdout: "",
+      stderr: "Unknown subcommand 'status' for command 'imsg'",
+      code: 1,
+      signal: null,
+      killed: false,
+      termination: "exit",
+    });
+
+    await expect(
+      probeIMessagePrivateApi("imsg-legacy-private-status", 1000),
+    ).resolves.toMatchObject({
+      available: false,
+      v2Ready: false,
+      selectors: {},
+      rpcMethods: [],
+      cliCapabilities: {
+        sendRichSupportsAttachment: false,
+        pollSendSupportsNoComment: false,
+      },
+      error:
+        'imsg CLI does not support the "status" subcommand. Update imsg on the Messages Mac: brew update && brew upgrade imsg',
+    });
+    expect(runCommand).toHaveBeenCalledExactlyOnceWith(
+      ["imsg-legacy-private-status", "status", "--json"],
+      { timeoutMs: 1000 },
+    );
+  });
+
+  it("keeps foundational RPC healthy when an older imsg lacks private status", async () => {
+    const runCommand = vi
+      .spyOn(processRuntime, "runCommandWithTimeout")
+      .mockResolvedValueOnce({
+        stdout: "rpc help",
+        stderr: "",
+        code: 0,
+        signal: null,
+        killed: false,
+        termination: "exit",
+      })
+      .mockResolvedValueOnce({
+        stdout: "",
+        stderr: "Unknown subcommand 'status' for command 'imsg'",
+        code: 1,
+        signal: null,
+        killed: false,
+        termination: "exit",
+      });
+    const request = vi.fn().mockResolvedValue({ chats: [] });
+    const stop = vi.fn().mockResolvedValue(undefined);
+    vi.spyOn(clientModule, "createIMessageRpcClient").mockResolvedValue({
+      request,
+      stop,
+    } as unknown as Awaited<ReturnType<typeof clientModule.createIMessageRpcClient>>);
+
+    await expect(
+      probeIMessage(1000, { cliPath: "imsg-legacy-foundational-rpc", platform: "darwin" }),
+    ).resolves.toMatchObject({
+      ok: true,
+      privateApi: {
+        available: false,
+        error:
+          'imsg CLI does not support the "status" subcommand. Update imsg on the Messages Mac: brew update && brew upgrade imsg',
+      },
+    });
+    expect(runCommand).toHaveBeenCalledTimes(2);
+    expect(request).toHaveBeenCalledWith("chats.list", { limit: 1 }, { timeoutMs: 1000 });
+    expect(stop).toHaveBeenCalledOnce();
+  });
+
   it("explains how to install imsg when the default binary is missing", async () => {
     vi.spyOn(setupRuntime, "detectBinary").mockResolvedValue(false);
     const createIMessageRpcClientMock = vi


### PR DESCRIPTION
Closes #115074.

## What Problem This Solves

Fixes an issue where users with an older imsg release would see an opaque `Unknown subcommand 'status' for command 'imsg'` while checking iMessage channel health, even though the same imsg release supports the JSON-RPC transport used for ordinary Messages delivery.

## Why This Change Was Made

Recognize the exact unsupported-command response from the upstream CLI, mark only private API capabilities unavailable, stop probing other private-only commands, and show the existing `brew update && brew upgrade imsg` remediation. Preserve the separate foundational RPC health check, normal send/receive, the existing negative-cache lifetime, and all modern imsg behavior. No version-specific fallback, dependency, configuration, plugin SDK, or private API contract is added.

The upstream contract was personally verified against the [imsg v0.5.0 command router](https://github.com/openclaw/imsg/blob/v0.5.0/Sources/imsg/CommandRouter.swift), its [RPC command](https://github.com/openclaw/imsg/blob/v0.5.0/Sources/imsg/Commands/RpcCommand.swift), and the current [v0.13.4 release](https://github.com/openclaw/imsg/releases/tag/v0.13.4).

## User Impact

Users get an actionable upgrade instruction for unsupported private iMessage features. Existing iMessage RPC remains healthy instead of being incorrectly treated as unavailable, and modern installations retain their current capability probes.

## Evidence

Exact reviewed and submitted head: `871401db9ac06931139b677b0c937f9f040c4da5`.

Real official macOS release binaries, executed on Darwin arm64 without accessing Messages, chat.db, a live Gateway, or a user account:

- imsg v0.5.0 `--version`: `0.5.0`.
- imsg v0.5.0 `rpc --help`: exit 0 and documents JSON-RPC plus `--json`.
- imsg v0.5.0 `status --json`: exit 1 with the exact reported `Unknown subcommand 'status' for command 'imsg'`.
- imsg v0.13.4 `--version`: `0.13.4`.
- imsg v0.13.4 `rpc --help` and `status --help`: both exit 0.

Test-first remote proof:

- Before production fix, `pnpm test extensions/imessage/src/status.test.ts`: both new regressions fail and all 31 existing tests pass on Blacksmith Testbox `tbx_01kynxt52yv9ssswv95mrbnp4b`.
- After rebasing and on the exact submitted head, `pnpm test extensions/imessage/src/status.test.ts extensions/imessage/src/probe.test.ts`: 41/41 tests pass on Blacksmith Testbox `tbx_01kynyxy2jax4q98bvk4ec8szj`.
- Full path-scoped `pnpm check:changed -- extensions/imessage/src/probe.ts extensions/imessage/src/status.test.ts`: passes both extension typecheck lanes, formatting, lint, dependency, plugin boundary, database, media, and import-cycle guards on Blacksmith Testbox `tbx_01kyny2j19xb2xzvzg0ts3t9h8`.
- `git range-diff` confirms the final rebase is patch-identical to the fully validated changed-gate patch.
- Fresh exact-head `.agents/skills/autoreview/scripts/autoreview --mode commit --commit HEAD --engine codex --thinking xhigh`: clean; no accepted or actionable findings; TruffleHog clean.
- `git diff --check`: clean.

Reporter credit: @lamkan0210. AI-assisted with Codex.