### PR TITLE
fix(feishu): keep intentional NO_REPLY block replies silent

### DIFF
--- a/extensions/feishu/src/reply-dispatcher.test.ts
+++ b/extensions/feishu/src/reply-dispatcher.test.ts
@@ -2867,6 +2867,156 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
     });
   });
 
+  it("does not send no-visible-reply fallback after an intentional silent block", async () => {
+    const runtime = createRuntimeLogger();
+    const { result, options } = createDispatcherHarness({ runtime, sessionKey: "main" });
+
+    options.onSkip?.({ text: "NO_REPLY" }, { kind: "block", reason: "silent" });
+    await expect(result.ensureNoVisibleReplyFallback("empty-complete")).resolves.toBe(false);
+
+    expect(sendMessageFeishuMock).not.toHaveBeenCalled();
+    expect(result.getVisibleReplyState()).toEqual({
+      visibleReplySent: false,
+      skippedFinalReason: "silent",
+    });
+  });
+
+  it("preserves a newer silent block when an older queued block fails", async () => {
+    useNonStreamingBlockAccount();
+    const runtime = createRuntimeLogger();
+    const { result, options } = createDispatcherHarness({ runtime, sessionKey: "main" });
+
+    options.onSkip?.(
+      { text: "NO_REPLY" },
+      { kind: "block", reason: "silent", assistantMessageIndex: 2 },
+    );
+    sendMessageFeishuMock.mockRejectedValueOnce(new Error("send failed"));
+    const earlierBlock = { text: "Earlier visible block" };
+    await options.beforeDeliver?.(earlierBlock, {
+      kind: "block",
+      assistantMessageIndex: 1,
+    });
+
+    await expect(options.deliver(earlierBlock, { kind: "block" })).rejects.toThrow("send failed");
+    await expect(result.ensureNoVisibleReplyFallback("failed-block")).resolves.toBe(false);
+
+    expect(sendMessageFeishuMock).toHaveBeenCalledTimes(1);
+    expect(result.getVisibleReplyState()).toEqual({
+      visibleReplySent: false,
+      skippedFinalReason: "silent",
+    });
+  });
+
+  it("recovers when an unindexed queued block fails after intentional silence", async () => {
+    useNonStreamingBlockAccount();
+    const runtime = createRuntimeLogger();
+    const { result, options } = createDispatcherHarness({ runtime, sessionKey: "main" });
+
+    options.onSkip?.({ text: "NO_REPLY" }, { kind: "block", reason: "silent" });
+    sendMessageFeishuMock.mockRejectedValueOnce(new Error("send failed"));
+
+    await expect(
+      options.deliver({ text: "Earlier visible block" }, { kind: "block" }),
+    ).rejects.toThrow("send failed");
+    await expect(result.ensureNoVisibleReplyFallback("failed-block")).resolves.toBe(true);
+
+    expect(sendMessageFeishuMock).toHaveBeenCalledTimes(2);
+    expect(String(sendMessageFeishuMock.mock.calls[1]?.[0]?.text)).toContain(
+      "without visible content",
+    );
+    expect(result.getVisibleReplyState()).toEqual({
+      visibleReplySent: true,
+      skippedFinalReason: null,
+    });
+  });
+
+  it("recovers when an indexed block fails after an unindexed silent block", async () => {
+    useNonStreamingBlockAccount();
+    const runtime = createRuntimeLogger();
+    const { result, options } = createDispatcherHarness({ runtime, sessionKey: "main" });
+
+    options.onSkip?.({ text: "NO_REPLY" }, { kind: "block", reason: "silent" });
+    const laterBlock = { text: "Later visible block" };
+    await options.beforeDeliver?.(laterBlock, {
+      kind: "block",
+      assistantMessageIndex: 2,
+    });
+    sendMessageFeishuMock.mockRejectedValueOnce(new Error("send failed"));
+
+    await expect(options.deliver(laterBlock, { kind: "block" })).rejects.toThrow("send failed");
+    await expect(result.ensureNoVisibleReplyFallback("failed-block")).resolves.toBe(true);
+
+    expect(sendMessageFeishuMock).toHaveBeenCalledTimes(2);
+    expect(String(firstMockArg(sendMessageFeishuMock, "send message params").text)).toBe(
+      "Later visible block",
+    );
+    expect(String(sendMessageFeishuMock.mock.calls[1]?.[0]?.text)).toContain(
+      "without visible content",
+    );
+  });
+
+  it("sends no-visible-reply fallback when a newer block fails after intentional silence", async () => {
+    useNonStreamingBlockAccount();
+    const runtime = createRuntimeLogger();
+    const { result, options } = createDispatcherHarness({ runtime, sessionKey: "main" });
+
+    options.onSkip?.(
+      { text: "NO_REPLY" },
+      { kind: "block", reason: "silent", assistantMessageIndex: 1 },
+    );
+    sendMessageFeishuMock.mockRejectedValueOnce(new Error("send failed"));
+    const laterBlock = { text: "Later visible block" };
+    await options.beforeDeliver?.(laterBlock, {
+      kind: "block",
+      assistantMessageIndex: 2,
+    });
+
+    await expect(options.deliver(laterBlock, { kind: "block" })).rejects.toThrow("send failed");
+    await expect(result.ensureNoVisibleReplyFallback("failed-block")).resolves.toBe(true);
+
+    expect(sendMessageFeishuMock).toHaveBeenCalledTimes(2);
+    expect(String(firstMockArg(sendMessageFeishuMock, "send message params").text)).toBe(
+      "Later visible block",
+    );
+    expect(String(sendMessageFeishuMock.mock.calls[1]?.[0]?.text)).toContain(
+      "without visible content",
+    );
+    expect(result.getVisibleReplyState()).toEqual({
+      visibleReplySent: true,
+      skippedFinalReason: null,
+    });
+  });
+
+  it("preserves block ordering when a before-delivery hook replaces the payload", async () => {
+    useNonStreamingBlockAccount();
+    const runtime = createRuntimeLogger();
+    const { result, options } = createDispatcherHarness({ runtime, sessionKey: "main" });
+
+    options.onSkip?.(
+      { text: "NO_REPLY" },
+      { kind: "block", reason: "silent", assistantMessageIndex: 1 },
+    );
+    const originalBlock = { text: "Later visible block" };
+    await options.beforeDeliver?.(originalBlock, {
+      kind: "block",
+      assistantMessageIndex: 2,
+    });
+    sendMessageFeishuMock.mockRejectedValueOnce(new Error("send failed"));
+
+    await expect(
+      options.deliver({ ...originalBlock, text: "Rewritten visible block" }, { kind: "block" }),
+    ).rejects.toThrow("send failed");
+    await expect(result.ensureNoVisibleReplyFallback("failed-block")).resolves.toBe(true);
+
+    expect(sendMessageFeishuMock).toHaveBeenCalledTimes(2);
+    expect(String(firstMockArg(sendMessageFeishuMock, "send message params").text)).toBe(
+      "Rewritten visible block",
+    );
+    expect(String(sendMessageFeishuMock.mock.calls[1]?.[0]?.text)).toContain(
+      "without visible content",
+    );
+  });
+
   it("sends no-visible-reply fallback when a final fails after an earlier silent skip", async () => {
     useNonStreamingAutoAccount();
     const runtime = createRuntimeLogger();

--- a/extensions/feishu/src/reply-dispatcher.ts
+++ b/extensions/feishu/src/reply-dispatcher.ts
@@ -328,6 +328,8 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
     | undefined;
   let visibleReplySent = false;
   let skippedFinalReason: string | null = null;
+  let skippedFinalAssistantMessageIndex: number | undefined;
+  let preparedDeliveryAssistantMessageIndex: number | undefined;
   let idleSideEffectsPromise: Promise<void> = Promise.resolve();
   let activeIdleSideEffectsPromise: Promise<void> | null = null;
   let idleRequestedForReply = false;
@@ -1181,9 +1183,14 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
       conversationType: chatId.startsWith("oc_") ? "group" : "direct",
     },
     onSkip: (_payload, info) => {
-      if (info.kind === "final") {
+      if (info.kind === "final" || (info.kind === "block" && info.reason === "silent")) {
         skippedFinalReason = info.reason;
+        skippedFinalAssistantMessageIndex = info.assistantMessageIndex;
       }
+    },
+    beforeDeliver: (payload, info) => {
+      preparedDeliveryAssistantMessageIndex = info.assistantMessageIndex;
+      return payload;
     },
     onReplyStart: async () => {
       if (!replyLifecycleStateInitialized) {
@@ -1194,6 +1201,8 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
         idleRequestedForReply = false;
         visibleReplySent = false;
         skippedFinalReason = null;
+        skippedFinalAssistantMessageIndex = undefined;
+        preparedDeliveryAssistantMessageIndex = undefined;
       }
       if (previewStreamingEnabled && renderMode === "card") {
         startStreaming();
@@ -1218,8 +1227,21 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
   const delivery: ChannelInboundTurnPlan["delivery"] = {
     observeMessageSent: true,
     deliver: async (payload: ReplyPayload, info) => {
-      if (info?.kind === "final") {
+      // Core serializes before-delivery hooks and delivery, even when a later hook replaces
+      // the payload, so consume the prepared index before another reply can overwrite it.
+      const deliveryAssistantMessageIndex = preparedDeliveryAssistantMessageIndex;
+      preparedDeliveryAssistantMessageIndex = undefined;
+      // Skips happen at enqueue time. Preserve silence only when both message indices
+      // prove the failed delivery was older; unknown ordering must allow recovery.
+      if (
+        info?.kind === "final" ||
+        skippedFinalReason !== "silent" ||
+        skippedFinalAssistantMessageIndex === undefined ||
+        deliveryAssistantMessageIndex === undefined ||
+        deliveryAssistantMessageIndex >= skippedFinalAssistantMessageIndex
+      ) {
         skippedFinalReason = null;
+        skippedFinalAssistantMessageIndex = undefined;
       }
       const payloadText =
         payload.isReasoning && payload.text ? formatReasoningMessage(payload.text) : payload.text;


### PR DESCRIPTION
Closes #109912
Related: #109937

<details>
<summary>Additional instructions</summary>

Maintainers can update this repository-owned branch directly.

</details>

## What Problem This Solves

Fixes an issue where Feishu direct-message users would receive a misleading “reply completed without visible content” warning after an assistant intentionally completed its turn with a `NO_REPLY` block.

## Why This Change Was Made

Feishu now treats an explicitly silent block like an explicitly silent final. Its plugin-owned dispatcher retains the core assistant-message ordering captured by the existing before-delivery contract: a proven older queued failure cannot erase a newer silence decision, while an actual later failure or unknown ordering still produces the existing visible recovery warning. Rewritten delivery payloads preserve the same ordering. No SDK, dependency, configuration, migration, or provider contract changes.

## User Impact

Intentional Feishu `NO_REPLY` turns stay silent. Actual failed visible replies still receive the existing recovery notice, including when assistant-message ordering is unavailable.

## Evidence

- Fail-first, same Blacksmith Testbox and latest clean `main`: the production dispatcher reproduced three erroneous silent-block and queued-delivery outcomes; 117 existing regressions passed.
- After the owner-local fix and six targeted ordering regressions: `pnpm test extensions/feishu/src/reply-dispatcher.test.ts extensions/feishu/src/bot.test.ts extensions/feishu/src/monitor.message-handler.ingress.test.ts` — **221 passed**, covering the Feishu inbound bot, durable ingress, streaming dispatcher, final and block silence, indexed and unindexed failures, and before-delivery payload replacement.
- `CI=1 NODE_OPTIONS=--max-old-space-size=4096 OPENCLAW_TESTBOX=1 OPENCLAW_TESTBOX_REMOTE_RUN=1 pnpm check:changed` — passed format, both extension typechecks, changed-file lint, plugin ownership boundaries, generated SDK contracts, dependency and storage guards, zero dead exports, and zero runtime import cycles.
- Blacksmith Testbox: `tbx_01kynxm4176a1s39t4n556qny9`.
- Fresh independent `gpt-5.6-sol`, `xhigh` autoreview: clean; its unknown-order failure finding is independently reproduced and fixed by the sixth regression.
- No live Feishu tenant or provider credentials were used; the provider-side API is not claimed as live-tested.
- AI-assisted. Thanks to @openagent-ai for the report and @goutamadwant for the earlier investigation in #109937.
