### PR TITLE
fix(imessage): reconcile send timeouts by exact attempt ID

### DIFF
--- a/docs/channels/imessage.md
+++ b/docs/channels/imessage.md
@@ -533,6 +533,20 @@ See [ACP Agents](/tools/acp-agents) for shared ACP binding behavior.
 
   </Accordion>
 
+  <Accordion title="Exact recovery for durable text delivery">
+    Single-part durable iMessage text sends automatically use a caller-owned attempt UUID when the installed `imsg` advertises both `send.tracked` and `message.send_status`. If the send result is lost, OpenClaw queries that exact UUID instead of matching message history by recipient, text, or timestamp.
+
+    This path is intentionally narrow:
+
+    - it supports exactly one platform text message per durable intent
+    - it forces bridge transport and never falls back to AppleScript
+    - attachments, multi-part sends, and `sendTransport: "applescript"` are ineligible for automatic exact recovery and keep their existing behavior; they are rejected before persistence or provider I/O only when a caller explicitly requires exact reconciliation
+    - callers that explicitly set `bestEffort: true` or disable reconciliation keep their existing transport and fallback behavior; the ordinary durable final-reply route may still use a best-effort queue policy while opting into exact reconciliation
+
+    Refresh `openclaw channels status --probe` after updating `imsg`; a required send stays fail-closed until both RPC methods appear in the cached capability probe. During restart recovery, a not-yet-populated probe cache leaves a pre-dispatch intent pending for a later retry instead of marking it failed.
+
+  </Accordion>
+
   <Accordion title="Addressing formats">
     Preferred explicit targets:
 

--- a/docs/plugins/sdk-channel-outbound.md
+++ b/docs/plugins/sdk-channel-outbound.md
@@ -248,14 +248,24 @@ cannot safely accept core-managed outbound or deferred delivery. Core calls
 this hook synchronously before live outbound work, including paths that skip
 queue persistence, and again before replaying a recovered intent. The context
 includes `cfg`, `channel`, `to`, `accountId`, and a `phase` of `live` or
-`recovery`.
+`recovery`. When the caller requires exact unknown-send reconciliation, the
+context also includes `requireUnknownSendReconciliation: true`.
 
-Return `{ status: "allowed" }` to continue. Return
+Return `{ status: "allowed" }` to continue. For an automatically reconciling
+adapter, an allowed result may set `automaticUnknownSendReconciliation` to
+confirm or suppress the static opt-in for this specific delivery. This
+per-delivery result cannot weaken an explicit
+`requireUnknownSendReconciliation: true` requirement. Return
+`{ status: "deferred", reason }` when provider readiness is not yet
+authoritative. Live work fails before persistence or provider I/O; recovered
+work remains pending for a later retry without consuming an attempt. Return
 `{ status: "permanent_rejection", reason }` when the delivery must not be
 persisted, sent directly, or replayed. A live rejection fails before queue
 creation, message hooks, or platform work. A recovery rejection marks the
-queued record failed and skips reconciliation and replay. Omitting the hook
-means allowed.
+queued record failed and skips replay. For an ambiguous recovered send, core
+performs authoritative unknown-send reconciliation before this replay-only
+admission check, so a cold process-local capability cache cannot hide an
+already-sent provider result. Omitting the hook means allowed.
 
 The hook is a synchronous admission decision, not a send path. Read only
 already-loaded config or runtime state; do not perform network, filesystem, or

--- a/extensions/imessage/src/channel.runtime.ts
+++ b/extensions/imessage/src/channel.runtime.ts
@@ -16,6 +16,7 @@ import { probeIMessage } from "./probe.js";
 import { resolveIMessageRemoteHost } from "./remote-host.js";
 import { sendMessageIMessage } from "./send.js";
 import { imessageSetupWizard } from "./setup-surface.js";
+export { reconcileIMessageUnknownSend } from "./unknown-send-reconciliation.js";
 
 type IMessageSendFn = typeof sendMessageIMessage;
 
@@ -31,6 +32,8 @@ export async function sendIMessageOutbound(params: {
   accountId?: string;
   deps?: { [channelId: string]: unknown };
   replyToId?: string;
+  deliveryQueueId?: string;
+  onPlatformSendDispatch?: NonNullable<Parameters<IMessageSendFn>[2]["onPlatformSendDispatch"]>;
   conversationReadOrigin?: "delegated" | "direct-operator";
   onDeliveryResult?: NonNullable<Parameters<IMessageSendFn>[2]["onDeliveryResult"]>;
 }) {
@@ -55,6 +58,8 @@ export async function sendIMessageOutbound(params: {
     maxBytes,
     accountId: params.accountId ?? undefined,
     replyToId: params.replyToId ?? undefined,
+    deliveryQueueId: params.deliveryQueueId,
+    onPlatformSendDispatch: params.onPlatformSendDispatch,
     conversationReadOrigin: params.conversationReadOrigin,
     ...(params.onDeliveryResult ? { onDeliveryResult: params.onDeliveryResult } : {}),
   });

--- a/extensions/imessage/src/channel.ts
+++ b/extensions/imessage/src/channel.ts
@@ -60,6 +60,7 @@ import {
   normalizeIMessageHandle,
   parseIMessageTarget,
 } from "./targets.js";
+import { resolveIMessageExactDeliveryAdmission } from "./unknown-send-reconciliation-core.js";
 
 const loadIMessageChannelRuntime = createLazyRuntimeModule(() => import("./channel.runtime.js"));
 
@@ -138,15 +139,26 @@ async function registerDeliveredIMessageApprovalPayload(
 const imessageMessageAdapter = defineChannelMessageAdapter({
   id: "imessage",
   durableFinal: {
+    automaticUnknownSendReconciliation: true,
     capabilities: {
       text: true,
       media: true,
       replyTo: true,
       messageSendingHooks: true,
+      reconcileUnknownSend: true,
     },
+    admitDeferredDelivery: resolveIMessageExactDeliveryAdmission,
+    reconcileUnknownSendKinds: { text: true },
+    reconcileUnknownSend: async (ctx) =>
+      await (await loadIMessageChannelRuntime()).reconcileIMessageUnknownSend(ctx),
   },
   send: {
     text: async (ctx) => {
+      if (ctx.deliveryQueueId && (ctx.deliveryPartIndex !== 0 || ctx.deliveryPartCount !== 1)) {
+        throw new Error(
+          "Exact iMessage send reconciliation requires exactly one platform text send",
+        );
+      }
       const result = await (
         await loadIMessageChannelRuntime()
       ).sendIMessageOutbound({
@@ -156,6 +168,8 @@ const imessageMessageAdapter = defineChannelMessageAdapter({
         accountId: ctx.accountId ?? undefined,
         deps: (ctx as typeof ctx & IMessageMessageContextExtras).deps,
         replyToId: ctx.replyToId ?? undefined,
+        deliveryQueueId: ctx.deliveryQueueId,
+        onPlatformSendDispatch: ctx.onPlatformSendDispatch,
         conversationReadOrigin: (ctx as typeof ctx & IMessageMessageContextExtras)
           .conversationReadOrigin,
       });

--- a/extensions/imessage/src/send.test.ts
+++ b/extensions/imessage/src/send.test.ts
@@ -13,6 +13,7 @@ import {
 } from "./monitor/sanitize-outbound.js";
 import { resolveIMessageRemoteHost } from "./remote-host.js";
 import { loadFreshIMessageReplyCacheForTest } from "./test-support/runtime.js";
+import { deriveIMessageAttemptId } from "./unknown-send-reconciliation-core.js";
 
 type ApprovalReactionsModule = typeof import("./approval-reactions.js");
 type ClientModule = typeof import("./client.js");
@@ -3575,6 +3576,138 @@ describe("sendMessageIMessage receipts", () => {
     ).rejects.toThrow("imsg rpc error (send)");
 
     expect(runCliJson).not.toHaveBeenCalled();
+  });
+});
+
+describe("sendMessageIMessage tracked durable attempts", () => {
+  beforeEach(async () => {
+    await loadFreshSendModule();
+  });
+
+  afterEach(() => {
+    clearIMessageApprovalReactionTargetsForTest();
+    vi.restoreAllMocks();
+    vi.unstubAllEnvs();
+    vi.useRealTimers();
+  });
+
+  it("uses send.tracked with the deterministic caller-owned GUID", async () => {
+    const deliveryQueueId = "cron:daily:report";
+    const attemptId = deriveIMessageAttemptId(deliveryQueueId);
+    const order: string[] = [];
+    const request = vi.fn(async (_method: string, params: Record<string, unknown>) => {
+      order.push("request");
+      return {
+        attempt_id: params.attempt_id,
+        guid: params.attempt_id,
+        message_id: params.attempt_id,
+        service: "iMessage",
+      };
+    });
+    const client = {
+      request,
+      stop: vi.fn(async () => {}),
+    } as unknown as IMessageRpcClient;
+
+    const result = await sendMessageIMessage("chat_guid:iMessage;+;group-guid", "once", {
+      config: IMESSAGE_TEST_CFG,
+      client,
+      deliveryQueueId,
+      onPlatformSendDispatch: async () => {
+        order.push("dispatch");
+      },
+    });
+
+    expect(request).toHaveBeenCalledWith(
+      "send.tracked",
+      expect.objectContaining({
+        attempt_id: attemptId,
+        text: "once",
+        transport: "bridge",
+      }),
+      { timeoutMs: 180_000 },
+    );
+    expect(result).toMatchObject({ messageId: attemptId, guid: attemptId });
+    expect(order).toEqual(["dispatch", "request"]);
+  });
+
+  it("does not retry or use sent-row recovery after a tracked-send timeout", async () => {
+    const client = createRejectingClient(new Error("imsg rpc timeout (send.tracked)"));
+    const resolveSentMessageGuidImpl = vi.fn(async () => "foreign-guid");
+
+    await expect(
+      sendMessageIMessage("chat_guid:iMessage;+;group-guid", "once", {
+        config: IMESSAGE_TEST_CFG,
+        client,
+        deliveryQueueId: "queue-timeout",
+        resolveSentMessageGuidImpl,
+      }),
+    ).rejects.toThrow("imsg rpc timeout (send.tracked)");
+
+    expect(getClientMocks(client).request).toHaveBeenCalledOnce();
+    expect(resolveSentMessageGuidImpl).not.toHaveBeenCalled();
+  });
+
+  it("does not call imsg when durable dispatch ownership cannot be persisted", async () => {
+    const client = createClient({});
+
+    await expect(
+      sendMessageIMessage("chat_guid:iMessage;+;group-guid", "once", {
+        config: IMESSAGE_TEST_CFG,
+        client,
+        deliveryQueueId: "queue-dispatch-fence",
+        onPlatformSendDispatch: async () => {
+          throw new Error("dispatch fence unavailable");
+        },
+      }),
+    ).rejects.toThrow("dispatch fence unavailable");
+
+    expect(getClientMocks(client).request).not.toHaveBeenCalled();
+  });
+
+  it("fails closed when send.tracked does not echo the exact attempt identity", async () => {
+    const client = createClient({
+      attempt_id: "11111111-1111-5111-8111-111111111111",
+      guid: "11111111-1111-5111-8111-111111111111",
+      message_id: "11111111-1111-5111-8111-111111111111",
+    });
+
+    await expect(
+      sendMessageIMessage("chat_guid:iMessage;+;group-guid", "once", {
+        config: IMESSAGE_TEST_CFG,
+        client,
+        deliveryQueueId: "queue-mismatch",
+      }),
+    ).rejects.toThrow("mismatched attempt identity");
+  });
+
+  it("rejects tracked media and AppleScript before provider I/O", async () => {
+    const resolveAttachmentImpl = vi.fn(async () => ({
+      path: "/tmp/image.png",
+      contentType: "image/png",
+    }));
+    const client = createClient({});
+
+    await expect(
+      sendMessageIMessage("chat_guid:iMessage;+;group-guid", "caption", {
+        config: IMESSAGE_TEST_CFG,
+        client,
+        deliveryQueueId: "queue-media",
+        mediaUrl: "/tmp/image.png",
+        resolveAttachmentImpl,
+      }),
+    ).rejects.toThrow("supports text messages only");
+    expect(resolveAttachmentImpl).not.toHaveBeenCalled();
+    expect(getClientMocks(client).request).not.toHaveBeenCalled();
+
+    await expect(
+      sendMessageIMessage("chat_guid:iMessage;+;group-guid", "once", {
+        config: { channels: { imessage: { sendTransport: "applescript" } } },
+        client,
+        deliveryQueueId: "queue-applescript",
+      }),
+    ).rejects.toThrow("requires bridge transport");
+    expect(getClientMocks(client).request).not.toHaveBeenCalled();
   });
 });
 

--- a/extensions/imessage/src/send.ts
+++ b/extensions/imessage/src/send.ts
@@ -70,6 +70,10 @@ import {
   normalizeIMessageHandle,
   parseIMessageTarget,
 } from "./targets.js";
+import {
+  deriveIMessageAttemptId,
+  IMESSAGE_TRACKED_SEND_METHOD,
+} from "./unknown-send-reconciliation-core.js";
 
 type ParsedIMessageTarget = ReturnType<typeof parseIMessageTarget>;
 const MIN_PENDING_PERSISTED_ECHO_TTL_MS = 60_000;
@@ -90,6 +94,7 @@ type IMessageSendOpts = {
   accountId?: string;
   conversationReadOrigin?: "delegated" | "direct-operator";
   replyToId?: string;
+  deliveryQueueId?: string;
   mediaUrl?: string;
   mediaAccess?: OutboundMediaAccess;
   mediaLocalRoots?: readonly string[];
@@ -114,6 +119,7 @@ type IMessageSendOpts = {
   }) => Promise<IMessageRpcClient>;
   withRemoteFile?: typeof withIMessageRemoteFile;
   runCliJson?: (args: readonly string[]) => Promise<Record<string, unknown>>;
+  onPlatformSendDispatch?: () => Promise<void>;
   onDeliveryResult?: (result: IMessageDeliveryProgress) => Promise<void> | void;
   resolveMessageGuidImpl?: (params: {
     dbPath?: string;
@@ -850,6 +856,17 @@ export async function sendMessageIMessage(
     resolveTargetService(target) ??
     (account.config.service as IMessageService | undefined);
   const sendTransport = (account.config.sendTransport ?? "auto") as IMessageSendTransport;
+  const trackedAttemptId = opts.deliveryQueueId
+    ? deriveIMessageAttemptId(opts.deliveryQueueId)
+    : undefined;
+  if (trackedAttemptId && sendTransport === "applescript") {
+    throw new Error(
+      "Exact iMessage send reconciliation requires bridge transport; sendTransport=applescript is unsupported",
+    );
+  }
+  if (trackedAttemptId && opts.mediaUrl?.trim()) {
+    throw new Error("Exact iMessage send reconciliation supports text messages only");
+  }
   const resolvedReplyToId = resolveAuthorizedIMessageReplyReference({
     account,
     target,
@@ -1029,7 +1046,8 @@ export async function sendMessageIMessage(
     text: message,
     service: service || "auto",
     region,
-    transport: sendTransport,
+    transport: trackedAttemptId ? "bridge" : sendTransport,
+    ...(trackedAttemptId ? { attempt_id: trackedAttemptId } : {}),
   };
   if (resolvedReplyToId) {
     params.reply_to = resolvedReplyToId;
@@ -1068,8 +1086,15 @@ export async function sendMessageIMessage(
     await client.stop();
   };
   const requestSuccessfulSend = async (sendParams: Record<string, unknown>) => {
-    const request = async (nativeParams: Record<string, unknown>) =>
-      await requestIMessageRpcSend(client, "send", nativeParams, timeoutMs);
+    const request = async (nativeParams: Record<string, unknown>) => {
+      await opts.onPlatformSendDispatch?.();
+      return await requestIMessageRpcSend(
+        client,
+        trackedAttemptId ? IMESSAGE_TRACKED_SEND_METHOD : "send",
+        nativeParams,
+        timeoutMs,
+      );
+    };
     const response = filePath
       ? await withOriginalIMessageAttachmentPath(filePath, async (attachmentPath) => {
           if (remoteHost) {
@@ -1105,7 +1130,11 @@ export async function sendMessageIMessage(
       }
       result = await requestSuccessfulSend(params);
     } catch (error) {
-      if (resolvedReplyToId && isThreadedReplyUnsupportedError(error)) {
+      if (trackedAttemptId) {
+        // The caller-owned GUID is the only retry/reconciliation key. Never
+        // retry or fall back after an uncertain tracked-send result.
+        throw error;
+      } else if (resolvedReplyToId && isThreadedReplyUnsupportedError(error)) {
         // #99638: the transport cannot deliver a threaded reply, so resend the
         // message unthreaded rather than dropping it. Covers text and media
         // replies alike (both carry reply_to through this send). One retry with
@@ -1141,6 +1170,16 @@ export async function sendMessageIMessage(
         } else {
           throw error;
         }
+      }
+    }
+    if (trackedAttemptId) {
+      const returnedIds = [result.attempt_id, result.guid, result.message_id];
+      if (
+        returnedIds.some(
+          (value) => typeof value !== "string" || value.trim().toLowerCase() !== trackedAttemptId,
+        )
+      ) {
+        throw new Error("imsg send.tracked returned mismatched attempt identity");
       }
     }
     const resolvedId = resolveMessageId(result);

--- a/extensions/imessage/src/test-plugin.test.ts
+++ b/extensions/imessage/src/test-plugin.test.ts
@@ -344,8 +344,65 @@ describe("imessagePlugin contracts", () => {
         messageSendingHooks: () => {
           expect(sendText).toBeTypeOf("function");
         },
+        reconcileUnknownSend: () => {
+          expect(adapter.durableFinal?.reconcileUnknownSend).toBeTypeOf("function");
+        },
       },
     });
+  });
+
+  it("automatically opts normal durable text sends into exact reconciliation", () => {
+    const durableFinal = requireMessageAdapter().durableFinal;
+
+    expect(durableFinal?.automaticUnknownSendReconciliation).toBe(true);
+    expect(durableFinal?.reconcileUnknownSendKinds).toEqual({ text: true });
+    expect(durableFinal?.reconcileUnknownSend).toBeTypeOf("function");
+  });
+
+  it("forwards one exact queue id and rejects multi-part tracked sends before provider I/O", async () => {
+    const sendText = requireMessageSendText(requireMessageAdapter());
+    const sendIMessage = vi.fn(async () => ({
+      messageId: "tracked-guid",
+      sentText: "once",
+      receipt: createMessageReceiptFromOutboundResults({
+        results: [{ channel: "imessage", messageId: "tracked-guid" }],
+        kind: "text",
+      }),
+    }));
+
+    await sendText({
+      cfg: {} as never,
+      to: "+15551234567",
+      text: "once",
+      deliveryQueueId: "queue-1",
+      deliveryPartIndex: 0,
+      deliveryPartCount: 1,
+      deps: { imessage: sendIMessage },
+    } as Parameters<typeof sendText>[0] & {
+      deps: { imessage: typeof sendIMessage };
+    });
+
+    expect(sendIMessage).toHaveBeenCalledWith(
+      "+15551234567",
+      "once",
+      expect.objectContaining({ deliveryQueueId: "queue-1" }),
+    );
+
+    sendIMessage.mockClear();
+    await expect(
+      sendText({
+        cfg: {} as never,
+        to: "+15551234567",
+        text: "split",
+        deliveryQueueId: "queue-2",
+        deliveryPartIndex: 0,
+        deliveryPartCount: 2,
+        deps: { imessage: sendIMessage },
+      } as Parameters<typeof sendText>[0] & {
+        deps: { imessage: typeof sendIMessage };
+      }),
+    ).rejects.toThrow("requires exactly one platform text send");
+    expect(sendIMessage).not.toHaveBeenCalled();
   });
 
   it.each(["message", "outbound"] as const)(

--- a/extensions/imessage/src/unknown-send-reconciliation-core.ts
+++ b/extensions/imessage/src/unknown-send-reconciliation-core.ts
@@ -1,0 +1,77 @@
+import { createHash } from "node:crypto";
+import type { ChannelMessageDurableFinalAdapter } from "openclaw/plugin-sdk/channel-outbound";
+import { resolveIMessageAccount } from "./accounts.js";
+import {
+  getCachedIMessagePrivateApiStatus,
+  imessageRpcSupportsMethod,
+} from "./private-api-status.js";
+
+export const IMESSAGE_TRACKED_SEND_METHOD = "send.tracked";
+const IMESSAGE_SEND_STATUS_METHOD = "message.send_status";
+
+const UUID_URL_NAMESPACE = Buffer.from("6ba7b8119dad11d180b400c04fd430c8", "hex");
+const IMESSAGE_ATTEMPT_NAME_PREFIX = "https://openclaw.ai/imessage/delivery-attempt/";
+
+type DeferredDeliveryAdmission = NonNullable<
+  ChannelMessageDurableFinalAdapter["admitDeferredDelivery"]
+>;
+
+function formatUuid(bytes: Buffer): string {
+  const hex = bytes.toString("hex");
+  return [hex.slice(0, 8), hex.slice(8, 12), hex.slice(12, 16), hex.slice(16, 20), hex.slice(20)]
+    .join("-")
+    .toLowerCase();
+}
+
+/** Stable UUIDv5 used as the caller-owned iMessage GUID for one durable queue intent. */
+export function deriveIMessageAttemptId(queueId: string): string {
+  const digest = createHash("sha1")
+    .update(UUID_URL_NAMESPACE)
+    .update(`${IMESSAGE_ATTEMPT_NAME_PREFIX}${queueId}`)
+    .digest()
+    .subarray(0, 16);
+  digest[6] = ((digest[6] ?? 0) & 0x0f) | 0x50;
+  digest[8] = ((digest[8] ?? 0) & 0x3f) | 0x80;
+  return formatUuid(digest);
+}
+
+export const resolveIMessageExactDeliveryAdmission: DeferredDeliveryAdmission = (ctx) => {
+  const account = resolveIMessageAccount({ cfg: ctx.cfg, accountId: ctx.accountId });
+  if (account.config.sendTransport === "applescript") {
+    if (ctx.requireUnknownSendReconciliation !== true) {
+      return { status: "allowed", automaticUnknownSendReconciliation: false };
+    }
+    return {
+      status: "permanent_rejection",
+      reason:
+        "Required durable iMessage delivery needs bridge transport; sendTransport=applescript cannot provide exact send reconciliation.",
+    };
+  }
+  const cliPath = account.config.cliPath?.trim() || "imsg";
+  const status = getCachedIMessagePrivateApiStatus(cliPath);
+  if (!status) {
+    if (ctx.requireUnknownSendReconciliation !== true) {
+      return { status: "allowed", automaticUnknownSendReconciliation: false };
+    }
+    return {
+      status: "deferred",
+      reason:
+        "Required durable iMessage delivery is waiting for the imsg RPC capability probe; refresh channel status before retrying.",
+    };
+  }
+  const missingMethods = [IMESSAGE_TRACKED_SEND_METHOD, IMESSAGE_SEND_STATUS_METHOD].filter(
+    (method) => !imessageRpcSupportsMethod(status, method),
+  );
+  if (missingMethods.length > 0) {
+    if (ctx.requireUnknownSendReconciliation !== true) {
+      return { status: "allowed", automaticUnknownSendReconciliation: false };
+    }
+    return {
+      status: "permanent_rejection",
+      reason: `Required durable iMessage delivery needs imsg RPC methods ${missingMethods.join(
+        " and ",
+      )}; upgrade imsg and refresh its status probe before retrying.`,
+    };
+  }
+  return { status: "allowed", automaticUnknownSendReconciliation: true };
+};

--- a/extensions/imessage/src/unknown-send-reconciliation.test.ts
+++ b/extensions/imessage/src/unknown-send-reconciliation.test.ts
@@ -1,0 +1,230 @@
+import type {
+  ChannelMessageDurableFinalAdapter,
+  ChannelMessageUnknownSendContext,
+} from "openclaw/plugin-sdk/channel-outbound";
+import { describe, expect, it, vi } from "vitest";
+import type { IMessageRpcClient } from "./client.js";
+import { setCachedIMessagePrivateApiStatus } from "./private-api-status.js";
+import {
+  deriveIMessageAttemptId,
+  resolveIMessageExactDeliveryAdmission,
+} from "./unknown-send-reconciliation-core.js";
+import { reconcileIMessageUnknownSend } from "./unknown-send-reconciliation.js";
+
+type AdmissionContext = Parameters<
+  NonNullable<ChannelMessageDurableFinalAdapter["admitDeferredDelivery"]>
+>[0];
+
+function admissionContext(params?: {
+  cliPath?: string;
+  sendTransport?: "auto" | "bridge" | "applescript";
+  requireUnknownSendReconciliation?: boolean;
+}): AdmissionContext {
+  return {
+    cfg: {
+      channels: {
+        imessage: {
+          cliPath: params?.cliPath,
+          sendTransport: params?.sendTransport,
+        },
+      },
+    },
+    channel: "imessage",
+    to: "+15555550123",
+    phase: "live",
+    ...(params?.requireUnknownSendReconciliation ? { requireUnknownSendReconciliation: true } : {}),
+  };
+}
+
+function unknownSendContext(queueId = "cron:daily:report"): ChannelMessageUnknownSendContext {
+  return {
+    cfg: { channels: { imessage: { cliPath: "imsg-reconcile-test" } } },
+    queueId,
+    channel: "imessage",
+    to: "+15555550123",
+    enqueuedAt: 1,
+    retryCount: 1,
+    effectiveReplyToId: "reply-guid",
+    payloads: [{ text: "once" }],
+  };
+}
+
+function createClient(result: Record<string, unknown>) {
+  const request = vi.fn(async () => result);
+  const stop = vi.fn(async () => {});
+  return {
+    client: { request, stop } as unknown as IMessageRpcClient,
+    request,
+    stop,
+  };
+}
+
+describe("iMessage exact unknown-send reconciliation", () => {
+  it("derives a stable UUIDv5 from any durable queue id", () => {
+    const first = deriveIMessageAttemptId("cron:daily:report");
+
+    expect(first).toBe(deriveIMessageAttemptId("cron:daily:report"));
+    expect(first).not.toBe(deriveIMessageAttemptId("cron:daily:report:other"));
+    expect(first).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-5[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/);
+  });
+
+  it("leaves ordinary iMessage sends admitted without tracked-send support", () => {
+    expect(resolveIMessageExactDeliveryAdmission(admissionContext())).toEqual({
+      status: "allowed",
+      automaticUnknownSendReconciliation: false,
+    });
+  });
+
+  it("enables automatic exact delivery only after both marker methods are cached", () => {
+    const cliPath = "imsg-admission-automatic-ready";
+    setCachedIMessagePrivateApiStatus(cliPath, {
+      available: true,
+      v2Ready: true,
+      selectors: {},
+      rpcMethods: ["send.tracked", "message.send_status"],
+    });
+
+    expect(resolveIMessageExactDeliveryAdmission(admissionContext({ cliPath }))).toEqual({
+      status: "allowed",
+      automaticUnknownSendReconciliation: true,
+    });
+  });
+
+  it("defers required exact delivery until the imsg capability probe is authoritative", () => {
+    expect(
+      resolveIMessageExactDeliveryAdmission(
+        admissionContext({
+          cliPath: "imsg-admission-unprobed",
+          requireUnknownSendReconciliation: true,
+        }),
+      ),
+    ).toMatchObject({ status: "deferred" });
+  });
+
+  it("rejects required exact delivery when transport or probed imsg capabilities are insufficient", () => {
+    expect(
+      resolveIMessageExactDeliveryAdmission(
+        admissionContext({
+          cliPath: "imsg-admission-applescript",
+          sendTransport: "applescript",
+          requireUnknownSendReconciliation: true,
+        }),
+      ),
+    ).toMatchObject({ status: "permanent_rejection" });
+
+    const cliPath = "imsg-admission-confirmed-missing";
+    setCachedIMessagePrivateApiStatus(cliPath, {
+      available: true,
+      v2Ready: true,
+      selectors: {},
+      rpcMethods: ["message.send_status"],
+    });
+    expect(
+      resolveIMessageExactDeliveryAdmission(
+        admissionContext({
+          cliPath,
+          requireUnknownSendReconciliation: true,
+        }),
+      ),
+    ).toMatchObject({ status: "permanent_rejection" });
+  });
+
+  it("admits required exact delivery only when imsg advertises both marker methods", () => {
+    const cliPath = "imsg-admission-ready";
+    setCachedIMessagePrivateApiStatus(cliPath, {
+      available: true,
+      v2Ready: true,
+      selectors: {},
+      rpcMethods: ["send.tracked", "message.send_status"],
+    });
+
+    expect(
+      resolveIMessageExactDeliveryAdmission(
+        admissionContext({ cliPath, requireUnknownSendReconciliation: true }),
+      ),
+    ).toEqual({ status: "allowed", automaticUnknownSendReconciliation: true });
+  });
+
+  it.each(["sent", "delivered"])("accepts an exact %s status as sent", async (sendState) => {
+    const ctx = unknownSendContext();
+    const attemptId = deriveIMessageAttemptId(ctx.queueId);
+    const rpc = createClient({ guid: attemptId.toUpperCase(), send_state: sendState });
+
+    const result = await reconcileIMessageUnknownSend(ctx, {
+      createClient: async () => rpc.client,
+      resolveRemoteHost: async () => undefined,
+    });
+
+    expect(result).toMatchObject({
+      status: "sent",
+      messageId: attemptId,
+      receipt: {
+        primaryPlatformMessageId: attemptId,
+        replyToId: "reply-guid",
+      },
+    });
+    expect(rpc.request).toHaveBeenCalledWith(
+      "message.send_status",
+      { guid: attemptId },
+      { timeoutMs: 10_000 },
+    );
+    expect(rpc.stop).toHaveBeenCalledOnce();
+  });
+
+  it("preserves a confirmed send when RPC cleanup rejects", async () => {
+    const ctx = unknownSendContext();
+    const attemptId = deriveIMessageAttemptId(ctx.queueId);
+    const request = vi.fn(async () => ({ guid: attemptId, send_state: "sent" }));
+    const stop = vi.fn(async () => {
+      throw new Error("cleanup failed");
+    });
+
+    const result = await reconcileIMessageUnknownSend(ctx, {
+      createClient: async () => ({ request, stop }) as unknown as IMessageRpcClient,
+      resolveRemoteHost: async () => undefined,
+    });
+
+    expect(result).toMatchObject({ status: "sent", messageId: attemptId });
+    expect(stop).toHaveBeenCalledOnce();
+  });
+
+  it.each([
+    { response: { send_state: "pending" }, retryable: false },
+    { response: { guid: "different-guid", send_state: "sent" }, retryable: false },
+    { response: { send_state: "failed" }, retryable: false },
+  ])("keeps unproven status unresolved", async ({ response, retryable }) => {
+    const ctx = unknownSendContext();
+    const attemptId = deriveIMessageAttemptId(ctx.queueId);
+    const rpc = createClient({ guid: attemptId, ...response });
+
+    const result = await reconcileIMessageUnknownSend(ctx, {
+      createClient: async () => rpc.client,
+      resolveRemoteHost: async () => undefined,
+    });
+
+    expect(result.status).toBe("unresolved");
+    if (result.status === "unresolved") {
+      expect(result.retryable).toBe(response.send_state === "pending" ? true : retryable);
+    }
+    expect(rpc.stop).toHaveBeenCalledOnce();
+  });
+
+  it("treats status lookup failures as retryable and still stops the client", async () => {
+    const request = vi.fn(async () => {
+      throw new Error("status unavailable");
+    });
+    const stop = vi.fn(async () => {});
+
+    const result = await reconcileIMessageUnknownSend(unknownSendContext(), {
+      createClient: async () => ({ request, stop }) as unknown as IMessageRpcClient,
+      resolveRemoteHost: async () => undefined,
+    });
+
+    expect(result).toEqual({
+      status: "unresolved",
+      error: "status unavailable",
+      retryable: true,
+    });
+    expect(stop).toHaveBeenCalledOnce();
+  });
+});

--- a/extensions/imessage/src/unknown-send-reconciliation.ts
+++ b/extensions/imessage/src/unknown-send-reconciliation.ts
@@ -1,0 +1,102 @@
+import {
+  createMessageReceiptFromOutboundResults,
+  type ChannelMessageUnknownSendContext,
+  type ChannelMessageUnknownSendReconciliationResult,
+} from "openclaw/plugin-sdk/channel-outbound";
+import { resolveIMessageAccount } from "./accounts.js";
+import { createIMessageRpcClient, type IMessageRpcClient } from "./client.js";
+import { DEFAULT_IMESSAGE_PROBE_TIMEOUT_MS } from "./constants.js";
+import { resolveIMessageRemoteHost } from "./remote-host.js";
+import { deriveIMessageAttemptId } from "./unknown-send-reconciliation-core.js";
+
+const IMESSAGE_SEND_STATUS_METHOD = "message.send_status";
+
+type IMessageSendStatusResult = {
+  guid?: unknown;
+  send_state?: unknown;
+};
+
+type ReconciliationDeps = {
+  createClient?: (params: {
+    cliPath: string;
+    dbPath?: string;
+    remoteHost?: string;
+  }) => Promise<IMessageRpcClient>;
+  resolveRemoteHost?: typeof resolveIMessageRemoteHost;
+};
+
+export async function reconcileIMessageUnknownSend(
+  ctx: ChannelMessageUnknownSendContext,
+  deps: ReconciliationDeps = {},
+): Promise<ChannelMessageUnknownSendReconciliationResult> {
+  const attemptId = deriveIMessageAttemptId(ctx.queueId);
+  const account = resolveIMessageAccount({ cfg: ctx.cfg, accountId: ctx.accountId });
+  const cliPath = account.config.cliPath?.trim() || "imsg";
+  const dbPath = account.config.dbPath?.trim();
+  const timeoutMs = account.config.probeTimeoutMs ?? DEFAULT_IMESSAGE_PROBE_TIMEOUT_MS;
+  let client: IMessageRpcClient | undefined;
+  try {
+    const resolveRemoteHost = deps.resolveRemoteHost ?? resolveIMessageRemoteHost;
+    const remoteHost = await resolveRemoteHost({
+      cliPath,
+      remoteHost: account.config.remoteHost,
+    });
+    client = await (deps.createClient ?? createIMessageRpcClient)({
+      cliPath,
+      ...(dbPath ? { dbPath } : {}),
+      ...(remoteHost ? { remoteHost } : {}),
+    });
+    const result = await client.request<IMessageSendStatusResult>(
+      IMESSAGE_SEND_STATUS_METHOD,
+      { guid: attemptId },
+      { timeoutMs },
+    );
+    const guid = typeof result.guid === "string" ? result.guid.trim().toLowerCase() : "";
+    if (guid !== attemptId) {
+      return {
+        status: "unresolved",
+        error: "imsg returned a mismatched GUID for the tracked send attempt",
+        retryable: false,
+      };
+    }
+    const sendState = typeof result.send_state === "string" ? result.send_state.trim() : "";
+    if (sendState === "sent" || sendState === "delivered") {
+      const replyToId =
+        ctx.effectiveReplyToId !== undefined ? ctx.effectiveReplyToId : ctx.replyToId;
+      return {
+        status: "sent",
+        messageId: attemptId,
+        receipt: createMessageReceiptFromOutboundResults({
+          results: [{ channel: "imessage", messageId: attemptId }],
+          kind: "text",
+          ...(replyToId ? { replyToId } : {}),
+        }),
+      };
+    }
+    if (sendState === "failed") {
+      return {
+        status: "unresolved",
+        error: "imsg reports that the tracked send attempt failed",
+        retryable: false,
+      };
+    }
+    return {
+      status: "unresolved",
+      error: "imsg has not confirmed the tracked send attempt",
+      retryable: true,
+    };
+  } catch (error) {
+    return {
+      status: "unresolved",
+      error: error instanceof Error ? error.message : String(error),
+      retryable: true,
+    };
+  } finally {
+    try {
+      await client?.stop();
+    } catch {
+      // The status lookup is authoritative. Cleanup failure must not overwrite
+      // either a confirmed send or the original reconciliation error.
+    }
+  }
+}

--- a/src/channels/message/types.ts
+++ b/src/channels/message/types.ts
@@ -315,7 +315,16 @@ export type ChannelMessageUnknownSendReconciliationResult =
 
 /** Provider decision made before core persists or replays a deferred delivery. */
 export type ChannelMessageDeferredDeliveryAdmissionResult =
-  | { status: "allowed" }
+  | {
+      status: "allowed";
+      /** Per-delivery narrowing of the adapter's static automatic reconciliation opt-in. */
+      automaticUnknownSendReconciliation?: boolean;
+    }
+  | {
+      /** Provider readiness is not yet authoritative; live callers fail and recovery keeps custody. */
+      status: "deferred";
+      reason: string;
+    }
   | { status: "permanent_rejection"; reason: string };
 
 /** Minimal context available at deferred-delivery admission boundaries. */
@@ -325,6 +334,8 @@ export type ChannelMessageDeferredDeliveryAdmissionContext<TConfig = OpenClawCon
   to: string;
   accountId?: string | null;
   phase: "live" | "recovery";
+  /** Whether this delivery must be provably reconciled after an unknown send result. */
+  requireUnknownSendReconciliation?: boolean;
 };
 
 /** Optional hooks around adapter send attempts, platform success/failure, and commit. */

--- a/src/infra/outbound/deliver-queue.exact-reconciliation.integration.test.ts
+++ b/src/infra/outbound/deliver-queue.exact-reconciliation.integration.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { createMessageReceiptFromOutboundResults } from "../../channels/message/receipt.js";
+import { sendDurableMessageBatchCore } from "../../channels/message/send.js";
 import type { ChannelMessageSendTextContext } from "../../channels/message/types.js";
 import type { OpenClawConfig } from "../../config/config.js";
 import { createEmptyPluginRegistry } from "../../plugins/registry.js";
@@ -98,4 +99,65 @@ describe("exact Matrix delivery queue reconciliation", () => {
       expect(sendText).toHaveBeenCalledOnce();
     },
   );
+
+  it("carries an ordinary durable best-effort final through automatic exact reconciliation", async () => {
+    process.env.OPENCLAW_STATE_DIR = tmpDir;
+    const deliveryIntentId = "cron-direct-delivery:v1:ordinary-best-effort-final";
+    const messageId = "ordinary-best-effort-message";
+    const reconcileUnknownSend = vi.fn();
+    const sendText = vi.fn(async (ctx: ChannelMessageSendTextContext) => {
+      expect(ctx.deliveryQueueId).toBe(deliveryIntentId);
+      await ctx.onPlatformSendDispatch?.();
+      return {
+        messageId,
+        receipt: createMessageReceiptFromOutboundResults({
+          results: [{ channel: "matrix", messageId }],
+          kind: "text",
+        }),
+      };
+    });
+    setActivePluginRegistry(
+      createTestRegistry([
+        {
+          pluginId: "matrix",
+          source: "test",
+          plugin: {
+            ...createOutboundTestPlugin({ id: "matrix", outbound: matrixOutboundForQueueTest }),
+            message: {
+              id: "matrix",
+              durableFinal: {
+                automaticUnknownSendReconciliation: true,
+                capabilities: { text: true, reconcileUnknownSend: true },
+                admitDeferredDelivery: () => ({
+                  status: "allowed",
+                  automaticUnknownSendReconciliation: true,
+                }),
+                reconcileUnknownSendKinds: { text: true },
+                reconcileUnknownSend,
+              },
+              send: { text: sendText },
+            },
+          },
+        },
+      ]),
+    );
+
+    const result = await sendDurableMessageBatchCore({
+      cfg: {} as OpenClawConfig,
+      channel: "matrix",
+      to: "!room:example",
+      payloads: [{ text: "ordinary durable inbound final" }],
+      durability: "best_effort",
+      deliveryIntentId,
+      completionRetention: boundedCronCompletionRetention,
+      reusePendingDeliveryIntent: true,
+    });
+
+    expect(result).toMatchObject({ status: "sent" });
+    expect(sendText).toHaveBeenCalledOnce();
+    expect(reconcileUnknownSend).not.toHaveBeenCalled();
+    expect(
+      getDeliveryQueueEntryStatus(OUTBOUND_DELIVERY_QUEUE_NAME, deliveryIntentId, tmpDir),
+    ).toBe("completed");
+  });
 });

--- a/src/infra/outbound/deliver-queue.ts
+++ b/src/infra/outbound/deliver-queue.ts
@@ -139,6 +139,8 @@ async function runOutboundDeliveryWithQueue(
       `Required durable message send is unsupported for ${channel}: unknown-send reconciliation requires exactly one payload`,
     );
   }
+  const queuePolicy = params.queuePolicy ?? "best_effort";
+  let automaticUnknownSendReconciliationAllowed = false;
   if (params.deferredDeliveryAdmissionPassed !== true) {
     const admission = resolveDeferredDeliveryAdmission(
       {
@@ -147,15 +149,19 @@ async function runOutboundDeliveryWithQueue(
         to,
         accountId: params.accountId,
         phase: "live",
+        ...(params.requireUnknownSendReconciliation === true
+          ? { requireUnknownSendReconciliation: true }
+          : {}),
       },
       { agentId: params.session?.agentId },
     );
-    if (admission.status === "permanent_rejection") {
+    if (admission.status !== "allowed") {
       emitPreQueueFailure();
       throw new Error(admission.reason);
     }
+    automaticUnknownSendReconciliationAllowed =
+      admission.automaticUnknownSendReconciliation !== false;
   }
-  const queuePolicy = params.queuePolicy ?? "best_effort";
   const existingStableDelivery = params.deliveryIntentId
     ? await loadPendingDelivery(params.deliveryIntentId)
     : null;
@@ -244,10 +250,14 @@ async function runOutboundDeliveryWithQueue(
         `Required durable message send is unsupported for ${channel}: prepared payload capability mismatch${support.capability ? ` (${support.capability})` : ""}`,
       );
     }
+    // Ordinary inbound finals use a best-effort queue policy. Only the explicit
+    // bestEffort flag opts out of exact reconciliation after provider admission.
     unknownSendReconciliationEnabled =
       support.ok &&
       (params.requireUnknownSendReconciliation === true ||
-        support.automaticUnknownSendReconciliation);
+        (params.bestEffort !== true &&
+          automaticUnknownSendReconciliationAllowed &&
+          support.automaticUnknownSendReconciliation));
   }
   const deliveryParams: DeliverOutboundPayloadsParams = {
     ...params,

--- a/src/infra/outbound/deliver.test.ts
+++ b/src/infra/outbound/deliver.test.ts
@@ -9,6 +9,7 @@ import { onTrustedMessageAuditEventForTest as onTrustedMessageAuditEvent } from 
 import { chunkText } from "../../auto-reply/chunk.js";
 import { createMessageReceiptFromOutboundResults } from "../../channels/message/receipt.js";
 import type {
+  ChannelMessageDurableFinalAdapter,
   ChannelMessageSendMediaContext,
   ChannelMessageSendTextContext,
 } from "../../channels/message/types.js";
@@ -1131,16 +1132,24 @@ describe("deliverOutboundPayloads", () => {
   });
 
   it("rejects provider-blocked deferred delivery before queue creation or platform work", async () => {
-    const admitDeferredDelivery = vi.fn(() => ({
+    const admitDeferredDelivery = vi.fn<
+      NonNullable<ChannelMessageDurableFinalAdapter["admitDeferredDelivery"]>
+    >(() => ({
       status: "permanent_rejection" as const,
       reason: "unsupported_enterprise_slack_delivery",
     }));
     const messageSendText = vi.fn();
     setMatrixMessageAdapter({
       id: "matrix",
-      durableFinal: { admitDeferredDelivery },
+      durableFinal: {
+        capabilities: { text: true, reconcileUnknownSend: true },
+        admitDeferredDelivery,
+        reconcileUnknownSendKinds: { text: true },
+        reconcileUnknownSend: async () => ({ status: "not_sent" }),
+      },
       send: { text: messageSendText },
     });
+    hookMocks.runner.hasHooks.mockReturnValue(true);
 
     const request = {
       cfg: {},
@@ -1155,6 +1164,9 @@ describe("deliverOutboundPayloads", () => {
     await expect(deliverOutboundPayloads({ ...request, skipQueue: true })).rejects.toThrow(
       "unsupported_enterprise_slack_delivery",
     );
+    await expect(
+      deliverOutboundPayloads({ ...request, requireUnknownSendReconciliation: true }),
+    ).rejects.toThrow("unsupported_enterprise_slack_delivery");
 
     expect(admitDeferredDelivery).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -1164,9 +1176,16 @@ describe("deliverOutboundPayloads", () => {
         to: "!room:example",
       }),
     );
+    expect(admitDeferredDelivery.mock.calls[0]?.[0]).not.toHaveProperty(
+      "requireUnknownSendReconciliation",
+    );
+    expect(admitDeferredDelivery).toHaveBeenLastCalledWith(
+      expect.objectContaining({ requireUnknownSendReconciliation: true }),
+    );
     expect(queueMocks.enqueueDelivery).not.toHaveBeenCalled();
-    expect(admitDeferredDelivery).toHaveBeenCalledTimes(2);
+    expect(admitDeferredDelivery).toHaveBeenCalledTimes(3);
     expect(messageSendText).not.toHaveBeenCalled();
+    expect(hookMocks.runner.runReplyPayloadSending).not.toHaveBeenCalled();
     expect(hookMocks.runner.runMessageSending).not.toHaveBeenCalled();
   });
 
@@ -1227,6 +1246,12 @@ describe("deliverOutboundPayloads", () => {
   });
 
   it("automatically enables provider reconciliation for one supported prepared payload", async () => {
+    const admitDeferredDelivery = vi.fn<
+      NonNullable<ChannelMessageDurableFinalAdapter["admitDeferredDelivery"]>
+    >(() => ({
+      status: "allowed" as const,
+      automaticUnknownSendReconciliation: true,
+    }));
     const messageSendText = vi.fn(async (ctx: ChannelMessageSendTextContext) => {
       await ctx.onPlatformSendDispatch?.();
       return {
@@ -1242,6 +1267,7 @@ describe("deliverOutboundPayloads", () => {
       durableFinal: {
         automaticUnknownSendReconciliation: true,
         capabilities: { text: true, reconcileUnknownSend: true },
+        admitDeferredDelivery,
         reconcileUnknownSendKinds: { text: true },
         reconcileUnknownSend: async () => ({ status: "not_sent" }),
       },
@@ -1251,6 +1277,134 @@ describe("deliverOutboundPayloads", () => {
     await deliverMatrix({ queuePolicy: "required" });
 
     expect(requireMockCallArg(queueMocks.enqueueDelivery, "enqueueDelivery")).toMatchObject({
+      requireUnknownSendReconciliation: true,
+    });
+    expect(admitDeferredDelivery).toHaveBeenCalledWith(
+      expect.objectContaining({
+        phase: "live",
+      }),
+    );
+    expect(admitDeferredDelivery.mock.calls[0]?.[0]).not.toHaveProperty(
+      "requireUnknownSendReconciliation",
+    );
+    expect(admitDeferredDelivery.mock.invocationCallOrder[0]).toBeLessThan(
+      queueMocks.enqueueDelivery.mock.invocationCallOrder[0]!,
+    );
+    expect(messageSendText).toHaveBeenCalledWith(
+      expect.objectContaining({
+        deliveryQueueId: "mock-queue-id",
+        deliveryPartIndex: 0,
+        deliveryPartCount: 1,
+      }),
+    );
+  });
+
+  it("keeps ordinary delivery on the legacy path when admission declines automatic reconciliation", async () => {
+    const admitDeferredDelivery = vi.fn<
+      NonNullable<ChannelMessageDurableFinalAdapter["admitDeferredDelivery"]>
+    >(() => ({
+      status: "allowed" as const,
+      automaticUnknownSendReconciliation: false,
+    }));
+    const messageSendText = vi.fn(async (_ctx: ChannelMessageSendTextContext) => ({
+      messageId: "message-adapter-1",
+      receipt: createMessageReceiptFromOutboundResults({
+        results: [{ channel: "matrix", messageId: "message-adapter-1" }],
+        kind: "text",
+      }),
+    }));
+    setMatrixMessageAdapter({
+      id: "matrix",
+      durableFinal: {
+        automaticUnknownSendReconciliation: true,
+        capabilities: { text: true, reconcileUnknownSend: true },
+        admitDeferredDelivery,
+        reconcileUnknownSendKinds: { text: true },
+        reconcileUnknownSend: async () => ({ status: "not_sent" }),
+      },
+      send: { text: messageSendText },
+    });
+
+    await deliverMatrix({ queuePolicy: "required" });
+
+    expect(
+      requireMockCallArg(queueMocks.enqueueDelivery, "enqueueDelivery")
+        .requireUnknownSendReconciliation,
+    ).toBeUndefined();
+    expect(admitDeferredDelivery.mock.calls[0]?.[0]).not.toHaveProperty(
+      "requireUnknownSendReconciliation",
+    );
+    expect(messageSendText.mock.calls[0]?.[0].deliveryQueueId).toBeUndefined();
+  });
+
+  it("keeps explicit bestEffort delivery on the legacy path when automatic reconciliation is available", async () => {
+    const admitDeferredDelivery = vi.fn<
+      NonNullable<ChannelMessageDurableFinalAdapter["admitDeferredDelivery"]>
+    >(() => ({
+      status: "allowed" as const,
+      automaticUnknownSendReconciliation: true,
+    }));
+    const messageSendText = vi.fn(async (_ctx: ChannelMessageSendTextContext) => ({
+      messageId: "message-adapter-1",
+      receipt: createMessageReceiptFromOutboundResults({
+        results: [{ channel: "matrix", messageId: "message-adapter-1" }],
+        kind: "text",
+      }),
+    }));
+    setMatrixMessageAdapter({
+      id: "matrix",
+      durableFinal: {
+        automaticUnknownSendReconciliation: true,
+        capabilities: { text: true, reconcileUnknownSend: true },
+        admitDeferredDelivery,
+        reconcileUnknownSendKinds: { text: true },
+        reconcileUnknownSend: async () => ({ status: "not_sent" }),
+      },
+      send: { text: messageSendText },
+    });
+
+    await deliverMatrix({ bestEffort: true });
+
+    expect(
+      requireMockCallArg(queueMocks.enqueueDelivery, "enqueueDelivery")
+        .requireUnknownSendReconciliation,
+    ).toBeUndefined();
+    expect(messageSendText.mock.calls[0]?.[0].deliveryQueueId).toBeUndefined();
+  });
+
+  it("automatically reconciles an ordinary durable best-effort queue policy", async () => {
+    const admitDeferredDelivery = vi.fn<
+      NonNullable<ChannelMessageDurableFinalAdapter["admitDeferredDelivery"]>
+    >(() => ({
+      status: "allowed" as const,
+      automaticUnknownSendReconciliation: true,
+    }));
+    const messageSendText = vi.fn(async (ctx: ChannelMessageSendTextContext) => {
+      await ctx.onPlatformSendDispatch?.();
+      return {
+        messageId: "message-adapter-1",
+        receipt: createMessageReceiptFromOutboundResults({
+          results: [{ channel: "matrix", messageId: "message-adapter-1" }],
+          kind: "text",
+        }),
+      };
+    });
+    setMatrixMessageAdapter({
+      id: "matrix",
+      durableFinal: {
+        automaticUnknownSendReconciliation: true,
+        capabilities: { text: true, reconcileUnknownSend: true },
+        admitDeferredDelivery,
+        reconcileUnknownSendKinds: { text: true },
+        reconcileUnknownSend: async () => ({ status: "not_sent" }),
+      },
+      send: { text: messageSendText },
+    });
+
+    await deliverMatrix({ queuePolicy: "best_effort" });
+
+    expect(requireMockCallArg(queueMocks.enqueueDelivery, "enqueueDelivery")).toMatchObject({
+      queuePolicy: "best_effort",
       requireUnknownSendReconciliation: true,
     });
     expect(messageSendText).toHaveBeenCalledWith(

--- a/src/infra/outbound/delivery-queue-recovery.ts
+++ b/src/infra/outbound/delivery-queue-recovery.ts
@@ -238,6 +238,10 @@ function needsUnknownSendReconciliation(entry: QueuedDelivery): boolean {
   );
 }
 
+function requiresPreAdmissionReconciliation(entry: QueuedDelivery): boolean {
+  return entry.requireUnknownSendReconciliation === true && needsUnknownSendReconciliation(entry);
+}
+
 function hasActiveDeliveryOwner(entry: QueuedDelivery, now: number): boolean {
   return (
     (typeof entry.completionRetention === "object" ||
@@ -374,7 +378,8 @@ async function applyRecoveryDeliveryAdmission(params: {
   log: RecoveryLogger;
   stateDir?: string;
   logLabel: string;
-}): Promise<"allowed" | "failed" | "not_pending"> {
+  onFailed?: (entry: QueuedDelivery, errMsg: string) => void;
+}): Promise<"allowed" | "deferred" | "failed" | "not_pending"> {
   const admission = resolveDeferredDeliveryAdmission(
     {
       cfg: params.cfg,
@@ -382,11 +387,20 @@ async function applyRecoveryDeliveryAdmission(params: {
       to: params.entry.to,
       accountId: params.entry.accountId,
       phase: "recovery",
+      ...(params.entry.requireUnknownSendReconciliation === true
+        ? { requireUnknownSendReconciliation: true }
+        : {}),
     },
     { agentId: params.entry.session?.agentId },
   );
   if (admission.status === "allowed") {
     return "allowed";
+  }
+  if (admission.status === "deferred") {
+    params.log.info(
+      `${params.logLabel}: entry ${params.entry.id} deferred before recovery: ${admission.reason}`,
+    );
+    return "deferred";
   }
   await markDurableDeliveryFailedBestEffort(params.entry, params.log, params.stateDir);
   const failed = await terminalizeWithMediaRetention(params, async (spoolPaths) => {
@@ -404,6 +418,7 @@ async function applyRecoveryDeliveryAdmission(params: {
   }
   emitRecoveredTerminalFailure(params.entry, admission.reason);
   emitQueuedAuditTerminals(params.entry, () => queuedDeadLetterAuditTerminals(params.entry));
+  params.onFailed?.(params.entry, admission.reason);
   params.log.warn(
     `${params.logLabel}: entry ${params.entry.id} permanently rejected before recovery: ${admission.reason}`,
   );
@@ -740,9 +755,11 @@ async function drainQueuedEntry(opts: {
   deliver: DeliverFn;
   log: RecoveryLogger;
   stateDir?: string;
+  logLabel?: string;
+  recoveryDeliveryAdmissionPassed?: true;
   onRecovered?: (entry: QueuedDelivery) => void;
   onFailed?: (entry: QueuedDelivery, errMsg: string) => void;
-}): Promise<"recovered" | "failed" | "moved-to-failed" | "already-gone"> {
+}): Promise<"recovered" | "failed" | "moved-to-failed" | "already-gone" | "deferred"> {
   const { entry } = opts;
   const maxRetries = resolveMaxRetries(entry);
   const attemptBudgetExhausted = resolveAttemptCount(entry) >= maxRetries;
@@ -862,6 +879,25 @@ async function drainQueuedEntry(opts: {
         }
       }
       return "failed";
+    }
+  }
+  // Admission governs replay, not reconciliation. Ambiguous sends must query
+  // authoritative provider state before a cold process-local capability cache
+  // is allowed to defer or reject the row.
+  if (opts.recoveryDeliveryAdmissionPassed !== true) {
+    const admission = await applyRecoveryDeliveryAdmission({
+      entry,
+      cfg: opts.cfg,
+      log: opts.log,
+      stateDir: opts.stateDir,
+      logLabel: opts.logLabel ?? "Recovery",
+      onFailed: opts.onFailed,
+    });
+    if (admission !== "allowed") {
+      if (admission === "failed" || admission === "deferred") {
+        return admission;
+      }
+      return "already-gone";
     }
   }
   const payloadOutcomes: OutboundPayloadDeliveryOutcome[] = [];
@@ -1247,15 +1283,19 @@ export async function drainPendingDeliveriesCore(opts: {
         if (hasActiveDeliveryOwner(currentEntry, Date.now())) {
           return;
         }
-        const admission = await applyRecoveryDeliveryAdmission({
-          entry: currentEntry,
-          cfg: opts.cfg,
-          log: opts.log,
-          stateDir: opts.stateDir,
-          logLabel: opts.logLabel,
-        });
-        if (admission !== "allowed") {
-          return;
+        let recoveryDeliveryAdmissionPassed: true | undefined;
+        if (!requiresPreAdmissionReconciliation(currentEntry)) {
+          const admission = await applyRecoveryDeliveryAdmission({
+            entry: currentEntry,
+            cfg: opts.cfg,
+            log: opts.log,
+            stateDir: opts.stateDir,
+            logLabel: opts.logLabel,
+          });
+          if (admission !== "allowed") {
+            return;
+          }
+          recoveryDeliveryAdmissionPassed = true;
         }
 
         const currentDecision = opts.selectEntry(currentEntry, Date.now());
@@ -1314,6 +1354,8 @@ export async function drainPendingDeliveriesCore(opts: {
           deliver: opts.deliver,
           log: opts.log,
           stateDir: opts.stateDir,
+          logLabel: opts.logLabel,
+          recoveryDeliveryAdmissionPassed,
           onFailed: (failedEntry, errMsg) => {
             if (isPermanentDeliveryError(errMsg)) {
               opts.log.warn(
@@ -1384,18 +1426,22 @@ export async function recoverPendingDeliveries(opts: {
         opts.log.info(`Recovery skipped for delivery ${currentEntry.id}: active platform owner`);
         return "continue";
       }
-      const admission = await applyRecoveryDeliveryAdmission({
-        entry: currentEntry,
-        cfg: opts.cfg,
-        log: opts.log,
-        stateDir: opts.stateDir,
-        logLabel: "Recovery",
-      });
-      if (admission !== "allowed") {
-        if (admission === "failed") {
-          summary.failed += 1;
+      let recoveryDeliveryAdmissionPassed: true | undefined;
+      if (!requiresPreAdmissionReconciliation(currentEntry)) {
+        const admission = await applyRecoveryDeliveryAdmission({
+          entry: currentEntry,
+          cfg: opts.cfg,
+          log: opts.log,
+          stateDir: opts.stateDir,
+          logLabel: "Recovery",
+        });
+        if (admission !== "allowed") {
+          if (admission === "failed") {
+            summary.failed += 1;
+          }
+          return "continue";
         }
-        return "continue";
+        recoveryDeliveryAdmissionPassed = true;
       }
 
       const maxRetries = resolveMaxRetries(currentEntry);
@@ -1440,6 +1486,8 @@ export async function recoverPendingDeliveries(opts: {
         deliver: opts.deliver,
         log: opts.log,
         stateDir: opts.stateDir,
+        logLabel: "Recovery",
+        recoveryDeliveryAdmissionPassed,
         onRecovered: (recoveredEntry) => {
           summary.recovered += 1;
           opts.log.info(`Recovered delivery ${recoveredEntry.id} on ${recoveredEntry.channel}`);

--- a/src/infra/outbound/delivery-queue.recovery.test.ts
+++ b/src/infra/outbound/delivery-queue.recovery.test.ts
@@ -507,15 +507,16 @@ describe("delivery-queue recovery", () => {
           accountId: "enterprise",
           payloads: [{ text: "blocked" }],
         });
-    if (stableAttempt) {
-      await enqueueClaimedRecoveryDelivery(id, {
-        channel: "slack",
-        to: "C123",
-        accountId: "enterprise",
-        payloads: [{ text: "disabled account must never be replayed" }],
-        completionRetention: BOUNDED_COMPLETION_RETENTION,
-      });
-    }
+    const producerClaimId = stableAttempt
+      ? await enqueueClaimedRecoveryDelivery(id, {
+          channel: "slack",
+          to: "C123",
+          accountId: "enterprise",
+          payloads: [{ text: "disabled account must never be replayed" }],
+          completionRetention: BOUNDED_COMPLETION_RETENTION,
+          requireUnknownSendReconciliation: true,
+        })
+      : undefined;
     if (!stableAttempt) {
       setQueuedEntryState(tmpDir(), id, {
         retryCount: MAX_RETRIES,
@@ -524,12 +525,19 @@ describe("delivery-queue recovery", () => {
         platformSendStartedAt: Date.now(),
       });
     }
-    const admitDeferredDelivery = vi.fn(() => ({
-      status: "permanent_rejection" as const,
-      reason: "unsupported_enterprise_slack_delivery",
-    }));
+    const order: string[] = [];
+    const admitDeferredDelivery = vi.fn(() => {
+      order.push("admit");
+      return {
+        status: "permanent_rejection" as const,
+        reason: "unsupported_enterprise_slack_delivery",
+      };
+    });
     const reconcileUnknownSend = stableAttempt
-      ? vi.fn().mockResolvedValue({ status: "not_sent" })
+      ? vi.fn().mockImplementation(async () => {
+          order.push("reconcile");
+          return { status: "not_sent" } as const;
+        })
       : vi.fn();
     resolveOutboundChannelMessageAdapterMock.mockReturnValue({
       durableFinal: {
@@ -546,15 +554,18 @@ describe("delivery-queue recovery", () => {
         accountId: "enterprise",
         channel: "slack",
         phase: "recovery",
+        ...(stableAttempt ? { requireUnknownSendReconciliation: true } : {}),
         ...(stableAttempt ? {} : { to: "C123" }),
       }),
     );
-    expect(reconcileUnknownSend).not.toHaveBeenCalled();
+    expect(reconcileUnknownSend).toHaveBeenCalledTimes(stableAttempt ? 1 : 0);
+    expect(order).toEqual(stableAttempt ? ["reconcile", "admit"] : ["admit"]);
     expect(deliver).not.toHaveBeenCalled();
     expect(result).toEqual(RECOVERY_SUMMARY.failed);
     if (stableAttempt) {
       expect(await loadPendingDeliveries(tmpDir())).toEqual([]);
       expect(readOutboundQueueStatus(tmpDir(), id)).toBe("failed");
+      expect(producerClaimId).toEqual(expect.any(String));
     } else {
       expect(readOutboundQueueStatus(tmpDir(), id)).toBeUndefined();
       expectPayloadAudits(capture?.auditEvents ?? [], id, [
@@ -565,6 +576,80 @@ describe("delivery-queue recovery", () => {
       });
       await runRecovery({ deliver });
       expect(deliver).not.toHaveBeenCalled();
+    }
+  });
+  it("keeps an expired exact row pending while provider admission is not authoritative", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-08-13T00:00:00.000Z"));
+    try {
+      const id = "cron-direct-delivery:v1:deferred-cold-admission";
+      await enqueueDeliveryOnce(
+        {
+          channel: "imessage",
+          to: "+15555550123",
+          payloads: [{ text: "send exactly once after the capability probe" }],
+          queuePolicy: "required",
+          completionRetention: BOUNDED_COMPLETION_RETENTION,
+          requireUnknownSendReconciliation: true,
+        },
+        id,
+        tmpDir(),
+      );
+      const initialClaim = await claimDeliveryPlatformSendAttempt(id, tmpDir());
+      expect(initialClaim).toEqual(expect.any(String));
+      vi.advanceTimersByTime(31_000);
+
+      let providerReady = false;
+      const admitDeferredDelivery = vi.fn(() =>
+        providerReady
+          ? ({ status: "allowed" } as const)
+          : ({ status: "deferred", reason: "capability probe pending" } as const),
+      );
+      resolveOutboundChannelMessageAdapterMock.mockReturnValue({
+        durableFinal: { admitDeferredDelivery },
+      });
+      const deliver = vi.fn(async (params: Parameters<DeliverFn>[0]) => {
+        if (!params.deliveryProducerClaimId) {
+          throw new Error("recovered exact send must own its platform attempt");
+        }
+        await markDeliveryPlatformSendAttemptStarted(
+          id,
+          tmpDir(),
+          { replyToId: null },
+          params.deliveryProducerClaimId,
+        );
+        return [{ channel: "imessage", messageId: "tracked-message" }];
+      });
+
+      const deferred = await runRecovery({ deliver });
+
+      expect(deferred.result).toEqual(RECOVERY_SUMMARY.empty);
+      expect(deliver).not.toHaveBeenCalled();
+      expectMockMessageContaining(deferred.log.info, "deferred before recovery");
+      expect(await loadPendingDeliveries(tmpDir())).toEqual([
+        expect.objectContaining({
+          id,
+          recoveryState: "producer_claimed",
+          producerClaimId: initialClaim,
+          retryCount: 0,
+        }),
+      ]);
+
+      providerReady = true;
+      const recovered = await runRecovery({ deliver });
+
+      expect(recovered.result).toEqual(RECOVERY_SUMMARY.recovered);
+      expect(deliver).toHaveBeenCalledOnce();
+      expect(admitDeferredDelivery).toHaveBeenCalledTimes(2);
+      expect(admitDeferredDelivery).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          phase: "recovery",
+          requireUnknownSendReconciliation: true,
+        }),
+      );
+      expect(readOutboundQueueStatus(tmpDir(), id)).toBe("completed");
+    } finally {
+      vi.useRealTimers();
     }
   });
   it.each([
@@ -1041,6 +1126,7 @@ describe("delivery-queue recovery", () => {
       payloads: [{ text: "the platform already delivered this permanent intent" }],
       completionRetention: "permanent",
       requiresProducerClaim: true,
+      requireUnknownSendReconciliation: true,
     });
     await markDeliveryPlatformOutcomeUnknown(id, tmpDir(), platformSendAttemptId);
     setQueuedEntryState(tmpDir(), id, {
@@ -1050,11 +1136,16 @@ describe("delivery-queue recovery", () => {
     const reconcileUnknownSend = vi
       .fn()
       .mockResolvedValue(reconciledSent("reconciled-permanent-message"));
-    installUnknownSendAdapter(reconcileUnknownSend);
+    const admitDeferredDelivery = vi.fn(() => ({
+      status: "permanent_rejection" as const,
+      reason: "cold capability cache",
+    }));
+    installUnknownSendAdapter(reconcileUnknownSend, { admitDeferredDelivery });
     const deliver = vi.fn();
     const { result } = await runRecovery({ deliver });
     expect(result).toMatchObject({ recovered: 1, failed: 0 });
     expect(reconcileUnknownSend).toHaveBeenCalledOnce();
+    expect(admitDeferredDelivery).not.toHaveBeenCalled();
     expect(deliver).not.toHaveBeenCalled();
     expect(readOutboundQueueStatus(tmpDir(), id)).toBe("completed");
     expect(await loadPendingDeliveries(tmpDir())).toHaveLength(0);


### PR DESCRIPTION
Closes #115328
Depends on openclaw/imsg#235 shipping in an `imsg` release (design issue: openclaw/imsg#234)

## What Problem This Solves

An iMessage send can commit on the Mac and then time out before OpenClaw receives the terminal RPC result. Retrying that durable queue item can duplicate a user-visible reply.

The earlier history-based approach could not prove that a recipient/text/time match belonged to the durable queue attempt. This revision removes that heuristic and binds recovery to one caller-owned UUID.

## Design

- OpenClaw derives a deterministic RFC 4122 UUIDv5 attempt ID from the durable queue ID.
- Eligible single-part durable iMessage text sends call `imsg` RPC `send.tracked` with that exact ID.
- `imsg` must echo the same UUID as `attempt_id`, `guid`, and `message_id`; a mismatch remains unresolved.
- After a lost response or timeout, OpenClaw queries only `message.send_status` for that UUID.
- Only exact `sent` or `delivered` status recovers the platform receipt. Pending, failed, missing, mismatched, or errored status stays unresolved and is never declared safe to replay.
- The tracked path is bridge-only, text-only, and one-message-only. It never falls back to AppleScript or another transport after an uncertain dispatch.
- Admission requires cached `imsg` capabilities for both RPC methods before persistence or provider I/O.
- Recovery checks authoritative provider status before replay-only admission, including after a cold process-local capability cache.
- Media, multipart, AppleScript, best-effort, and explicitly unreconciled sends keep their existing behavior.

This deliberately keeps the exact path unavailable until the upstream marker contract is released and proven on a real Mac.

## User Impact

Once supported by a released `imsg`, a lost terminal response can be reconciled to one queue-owned send attempt instead of guessed from message history. Without attributable evidence, OpenClaw keeps the send unresolved rather than risking a duplicate or false acknowledgement.

## Evidence

- Exact head: `ec2e4dc54908822b72d5ba3cae643cb5ee8e68f6`, rebased onto `main` `462fe4d0e07cf003907ef866b4dd54a46945b20a`.
- GitHub reports the PR mergeable/behind after the guarded update.
- `370/370` focused tests pass: `242` shared outbound/recovery tests and `128` iMessage extension tests.
- Positive coverage includes exact UUID derivation, one-send enforcement, durable ownership before provider I/O, cold-cache recovery, exact sent/delivered recovery, and capability-approved automatic admission.
- Negative coverage includes missing capabilities, response-ID mismatch, pending/failed/missing status, callback failure, unsupported message shapes, and no fallback after an uncertain bridge dispatch.
- Core production types, extension production types, extension test types, and core `src` test types pass.
- Targeted `oxfmt --check`, direct source `oxlint`, and `git diff --check` pass across all 16 changed files.
- Range-diff against the prior repaired commit is exact; this rebase changes only the base.
- Direct dependency inspection confirms openclaw/imsg#235 merged as `268912be7189295e393364f95b7e11d517de975b` and adds caller-owned `send.tracked`, capability advertisement, collision rejection, and fail-closed uncertain-dispatch behavior.
- No released `imsg` tag contains that merge yet. Latest release `v0.14.1` predates it, so real-Mac tracked-send/status recovery proof remains externally blocked until the next release.
- Hosted CI on this exact head is the broad validation gate.

## Remaining Merge Gates

- A released `imsg` build containing openclaw/imsg#235.
- Redacted real-Mac proof showing an intentionally lost tracked-send response recovered by exact `message.send_status` without replay.
- Maintainer acceptance of the additive channel-SDK admission/reconciliation contract.

## AI Assistance

AI-assisted implementation and test authoring. The exact-attempt contract was selected after review proved the earlier history heuristic could not establish queue ownership.
