### PR TITLE
fix(browser): cancel in-flight status probes

### DIFF
--- a/extensions/browser/src/browser/routes/basic.existing-session.test.ts
+++ b/extensions/browser/src/browser/routes/basic.existing-session.test.ts
@@ -25,8 +25,8 @@ const { getProfileLifecycle, ProfileRestartRequiredError } =
 const { registerBrowserBasicRoutes } = await import("./basic.js");
 
 function createExistingSessionProfileState(params?: {
-  isHttpReachable?: (timeoutMs?: number) => Promise<boolean>;
-  isTransportAvailable?: (timeoutMs?: number) => Promise<boolean>;
+  isHttpReachable?: (timeoutMs?: number, signal?: AbortSignal) => Promise<boolean>;
+  isTransportAvailable?: (timeoutMs?: number, signal?: AbortSignal) => Promise<boolean>;
   isReachable?: (
     timeoutMs?: number,
     options?: { ephemeral?: boolean; signal?: AbortSignal },
@@ -75,8 +75,8 @@ function readFirstReachabilityCall(
 function createManagedProfileState(
   profileOverrides?: Record<string, unknown>,
   reachability?: {
-    isHttpReachable?: () => Promise<boolean>;
-    isTransportAvailable?: () => Promise<boolean>;
+    isHttpReachable?: (timeoutMs?: number, signal?: AbortSignal) => Promise<boolean>;
+    isTransportAvailable?: (timeoutMs?: number, signal?: AbortSignal) => Promise<boolean>;
   },
 ) {
   return {
@@ -114,6 +114,7 @@ function createManagedProfileState(
 async function callBasicRouteWithState(params: {
   query?: Record<string, string>;
   state: ReturnType<typeof createExistingSessionProfileState>;
+  signal?: AbortSignal;
 }) {
   const { app, getHandlers } = createBrowserRouteApp();
   registerBrowserBasicRoutes(app, {
@@ -125,7 +126,14 @@ async function callBasicRouteWithState(params: {
   expect(handler).toBeTypeOf("function");
 
   const response = createBrowserRouteResponse();
-  await handler?.({ params: {}, query: params.query ?? { profile: "chrome-live" } }, response.res);
+  await handler?.(
+    {
+      params: {},
+      query: params.query ?? { profile: "chrome-live" },
+      ...(params.signal ? { signal: params.signal } : {}),
+    },
+    response.res,
+  );
   return response;
 }
 
@@ -609,7 +617,7 @@ describe("basic browser routes", () => {
 
     expect(response.statusCode).toBe(200);
     expect(isTransportAvailable).toHaveBeenCalledTimes(1);
-    expect(isTransportAvailable).toHaveBeenCalledWith(5_000);
+    expect(isTransportAvailable).toHaveBeenCalledWith(5_000, expect.any(AbortSignal));
     const [timeoutMs, reachabilityOptions] = readFirstReachabilityCall(isReachable);
     expect(timeoutMs).toBeGreaterThan(0);
     expect(timeoutMs).toBeLessThanOrEqual(7_000);
@@ -621,6 +629,47 @@ describe("basic browser routes", () => {
     expect(body.cdpReady).toBe(true);
     expect(body.pageReady).toBe(true);
     expect(body.running).toBe(true);
+  });
+
+  it("passes cancellation to managed browser status probes", async () => {
+    const isHttpReachable = vi.fn(async () => true);
+    const isTransportAvailable = vi.fn(async () => false);
+
+    const response = await callBasicRouteWithState({
+      query: { profile: "openclaw" },
+      state: createManagedProfileState({}, { isHttpReachable, isTransportAvailable }),
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(isHttpReachable).toHaveBeenCalledWith(300, expect.any(AbortSignal));
+    expect(isTransportAvailable).toHaveBeenCalledWith(600, expect.any(AbortSignal));
+  });
+
+  it("cancels an in-flight Chrome MCP page-readiness probe", async () => {
+    const controller = new AbortController();
+    const cancellation = new Error("browser status cancelled");
+    const isReachable = vi.fn(
+      async (_timeoutMs?: number, options?: { ephemeral?: boolean; signal?: AbortSignal }) =>
+        await new Promise<boolean>((_resolve, reject) => {
+          options?.signal?.addEventListener("abort", () => reject(cancellation), {
+            once: true,
+          });
+        }),
+    );
+
+    const pending = callBasicRouteWithState({
+      state: createExistingSessionProfileState({ isReachable }),
+      signal: controller.signal,
+    });
+    await vi.waitFor(() => expect(isReachable).toHaveBeenCalledOnce());
+    controller.abort(cancellation);
+
+    const response = await pending;
+    expect(response.statusCode).toBe(500);
+    expect(responseBodyRecord(response).error).toBe("Error: browser status cancelled");
+    const [, options] = readFirstReachabilityCall(isReachable);
+    expect(options?.signal?.aborted).toBe(true);
+    expect(options?.signal?.reason).toBe(cancellation);
   });
 
   it("keeps Chrome MCP page-readiness inside the status budget", async () => {

--- a/extensions/browser/src/browser/routes/basic.ts
+++ b/extensions/browser/src/browser/routes/basic.ts
@@ -41,7 +41,11 @@ function remainingChromeMcpStatusTimeoutMs(startedAtMs: number): number {
   return Math.max(1, STATUS_CHROME_MCP_TOTAL_TIMEOUT_MS - (Date.now() - startedAtMs));
 }
 
-async function probeChromeMcpPageReady(profileCtx: ProfileContext, timeoutMs: number) {
+async function probeChromeMcpPageReady(
+  profileCtx: ProfileContext,
+  timeoutMs: number,
+  signal: AbortSignal,
+) {
   const abort = new AbortController();
   const timer = setTimeout(() => {
     abort.abort(new Error(`Chrome MCP page-readiness probe timed out after ${timeoutMs}ms.`));
@@ -49,9 +53,10 @@ async function probeChromeMcpPageReady(profileCtx: ProfileContext, timeoutMs: nu
   try {
     return await profileCtx.isReachable(timeoutMs, {
       ephemeral: true,
-      signal: abort.signal,
+      signal: AbortSignal.any([signal, abort.signal]),
     });
   } catch {
+    signal.throwIfAborted();
     return false;
   } finally {
     clearTimeout(timer);
@@ -150,6 +155,7 @@ async function buildBrowserStatus(
         const statusStartedAtMs = Date.now();
         const transportReady = await profileCtx.isTransportAvailable(
           STATUS_CHROME_MCP_TRANSPORT_TIMEOUT_MS,
+          signal,
         );
         if (!transportReady) {
           return [false, false, false] as const;
@@ -160,13 +166,14 @@ async function buildBrowserStatus(
         const pageReachable = await probeChromeMcpPageReady(
           profileCtx,
           remainingChromeMcpStatusTimeoutMs(statusStartedAtMs),
+          signal,
         );
         return [transportReady, transportReady, pageReachable] as const;
       })()
     : await (async () => {
         const [http, ready] = await Promise.all([
-          profileCtx.isHttpReachable(STATUS_CDP_HTTP_TIMEOUT_MS),
-          profileCtx.isTransportAvailable(STATUS_CDP_TRANSPORT_TIMEOUT_MS),
+          profileCtx.isHttpReachable(STATUS_CDP_HTTP_TIMEOUT_MS, signal),
+          profileCtx.isTransportAvailable(STATUS_CDP_TRANSPORT_TIMEOUT_MS, signal),
         ]);
         // For managed CDP profiles, the transport check already includes a WS
         // handshake against the page, so pageReady mirrors cdpReady.

--- a/extensions/browser/src/browser/server-context.ts
+++ b/extensions/browser/src/browser/server-context.ts
@@ -169,14 +169,14 @@ function createProfileContext(
           await rawSelection.ensureTabAvailable(targetId, { ...options, signal }, true),
       );
     },
-    isHttpReachable: async (timeoutMs) =>
+    isHttpReachable: async (timeoutMs, callerSignal) =>
       await withLease(
-        undefined,
+        callerSignal,
         async (signal) => await rawAvailability.isHttpReachable(timeoutMs, signal),
       ),
-    isTransportAvailable: async (timeoutMs) =>
+    isTransportAvailable: async (timeoutMs, callerSignal) =>
       await withLease(
-        undefined,
+        callerSignal,
         async (signal) => await rawAvailability.isTransportAvailable(timeoutMs, signal),
       ),
     isReachable: async (timeoutMs, options) =>

--- a/extensions/browser/src/browser/server-context.types.ts
+++ b/extensions/browser/src/browser/server-context.types.ts
@@ -63,8 +63,8 @@ type BrowserProfileActions = {
     targetId?: string,
     options?: EnsureTabAvailableOptions,
   ) => Promise<BrowserTab>;
-  isHttpReachable: (timeoutMs?: number) => Promise<boolean>;
-  isTransportAvailable: (timeoutMs?: number) => Promise<boolean>;
+  isHttpReachable: (timeoutMs?: number, signal?: AbortSignal) => Promise<boolean>;
+  isTransportAvailable: (timeoutMs?: number, signal?: AbortSignal) => Promise<boolean>;
   isReachable: (
     timeoutMs?: number,
     options?: { ephemeral?: boolean; signal?: AbortSignal },


### PR DESCRIPTION
Closes #114295
Supersedes #114298. Thanks to @kevin2966n for reporting the issue and identifying the route-level signal gap.

## What Problem This Solves

Fixes an issue where users cancelling a browser status or doctor request would leave Chrome MCP or managed-browser probes running until their individual timeouts.

## Why This Change Was Made

Propagates the existing request cancellation signal through the browser plugin's complete profile-operation lifecycle: managed HTTP and CDP checks, Chrome MCP transport checks, and the independently timed page-readiness probe. Unlike the earlier route-only proposal, the typed profile context and lifecycle wrapper now forward the signal rather than discarding it. A page-readiness timeout remains an ordinary unavailable-page result, while caller cancellation stops work immediately.

## User Impact

Browser status and doctor requests stop promptly when their caller disconnects or cancels. Existing-session, local managed, and remotely attached browser profiles retain their existing timeout and response behavior.

## Evidence

- Red-to-green Linux proof on Blacksmith Testbox: the current-main Chrome MCP and managed-CDP signal regressions both fail before the production fix and pass after it.
- The rebased commit passes all 59 focused browser route, Chrome MCP, managed-start, profile lifecycle, and tab-ownership tests.
- The rebased commit passes `pnpm check:changed`, including changed-file formatting, lint, browser-plugin and browser-test type checks, SDK and plugin boundaries, dead exports, dependency pins, runtime import cycles, and storage guards.
- Testbox: `tbx_01kynzb70bk73tf6gfx5f7h8dh` (`tidal-crayfish-b08d`).
- A fresh Codex autoreview at x-high reasoning on the rebased branch found no actionable findings.
- AI-assisted implementation, independently reviewed and verified against the exact rebased commit.
