### PR TITLE
fix(gateway): preserve Unicode in streamed tool arguments

### DIFF
--- a/src/gateway/openai-http.test.ts
+++ b/src/gateway/openai-http.test.ts
@@ -2264,6 +2264,72 @@ describe("OpenAI-compatible HTTP API (e2e)", () => {
     }
   });
 
+  it.each([
+    { astral: "😀", boundary: 255 },
+    { astral: "𐐷", boundary: 511 },
+  ])(
+    "keeps streamed tool-call arguments well-formed ($astral at UTF-16 boundary $boundary)",
+    async ({ astral, boundary }) => {
+      const argumentPrefix = '{"value":"';
+      const value = `${"a".repeat(boundary - argumentPrefix.length)}${astral}tail`;
+      const expectedArguments = JSON.stringify({ value });
+      expect(expectedArguments.indexOf(astral)).toBe(boundary);
+
+      agentCommand.mockClear();
+      agentCommand.mockResolvedValueOnce({
+        payloads: [{ text: "Calling the tool." }],
+        meta: {
+          stopReason: "tool_calls",
+          pendingToolCalls: [
+            {
+              id: "call_1",
+              name: "read_value",
+              arguments: expectedArguments,
+            },
+          ],
+        },
+      } as never);
+
+      const res = await postChatCompletions(enabledPort, {
+        stream: true,
+        model: "openclaw",
+        messages: [{ role: "user", content: "read the value" }],
+      });
+      expect(res.status).toBe(200);
+      expect(res.headers.get("content-type")).toContain("text/event-stream");
+
+      const data = parseSseDataLines(await res.text());
+      expect(data.at(-1)).toBe("[DONE]");
+
+      const chunks = data
+        .filter((line) => line !== "[DONE]")
+        .map((line) => JSON.parse(line) as Record<string, unknown>);
+      const choices = chunks.flatMap(
+        (chunk) => (chunk.choices as Array<Record<string, unknown>> | undefined) ?? [],
+      );
+      const argumentDeltas = choices
+        .flatMap((choice) => {
+          const delta = choice.delta as Record<string, unknown> | undefined;
+          return (delta?.tool_calls as Array<Record<string, unknown>> | undefined) ?? [];
+        })
+        .map((toolCall) => {
+          const toolFunction = toolCall.function as Record<string, unknown> | undefined;
+          return toolFunction?.arguments;
+        })
+        .filter((argumentsDelta): argumentsDelta is string => typeof argumentsDelta === "string");
+
+      expect(argumentDeltas.length).toBeGreaterThan(1);
+      for (const argumentsDelta of argumentDeltas) {
+        expect(new TextDecoder().decode(new TextEncoder().encode(argumentsDelta))).toBe(
+          argumentsDelta,
+        );
+      }
+      expect(argumentDeltas.join("")).toBe(expectedArguments);
+      expect(JSON.parse(argumentDeltas.join(""))).toEqual({ value });
+      expect(choices.some((choice) => choice.finish_reason === "tool_calls")).toBe(true);
+    },
+  );
+
   it(
     "sends an initial SSE chunk before a streaming agent run settles",
     { timeout: 15_000 },

--- a/src/gateway/openai-http.ts
+++ b/src/gateway/openai-http.ts
@@ -7,6 +7,7 @@ import {
   normalizeLowercaseStringOrEmpty,
   normalizeOptionalString,
 } from "@openclaw/normalization-core/string-coerce";
+import { avoidTrailingHighSurrogateBreak } from "@openclaw/normalization-core/utf16-slice";
 import { isClientToolNameConflictError } from "../agents/agent-tool-definition-adapter.js";
 import type { AgentStreamParams, ClientToolDefinition } from "../agents/command/shared-types.js";
 import type { ImageContent } from "../agents/command/types.js";
@@ -324,8 +325,14 @@ function splitArgumentsForStreaming(argumentsValue: string): string[] {
   }
   const chunkSize = 256;
   const chunks: string[] = [];
-  for (let i = 0; i < argumentsValue.length; i += chunkSize) {
-    chunks.push(argumentsValue.slice(i, i + chunkSize));
+  for (let start = 0; start < argumentsValue.length;) {
+    const end = avoidTrailingHighSurrogateBreak(
+      argumentsValue,
+      start,
+      Math.min(start + chunkSize, argumentsValue.length),
+    );
+    chunks.push(argumentsValue.slice(start, end));
+    start = end;
   }
   return chunks.length > 0 ? chunks : [""];
 }


### PR DESCRIPTION
Related: #110642

## What Problem This Solves

Fixes an issue where clients consuming the Gateway's OpenAI-compatible streaming Chat Completions API would receive malformed function-tool argument deltas when an emoji or another astral Unicode character crossed a 256-UTF-16-code-unit SSE chunk boundary. Clients that encode or process each argument delta independently could lose the original character or fail before reconstructing the tool-call JSON.

## Why This Change Was Made

Keep the existing Gateway function-tool SSE shape and 256-code-unit chunking, but use the repository's canonical `avoidTrailingHighSurrogateBreak` helper to move a chunk boundary before a complete Unicode surrogate pair. The splitter remains private; no protocol, configuration, provider, or plugin API is added or changed.

The original independently reported problem and proposed surrogate-safe direction are credited to @coder-master-0915 in #110642. This replacement keeps the production change narrowly owned, omits unrelated local proof artifacts, and proves the observable Gateway HTTP/SSE behavior without exporting an internal helper.

## User Impact

OpenAI-compatible clients receive independently valid Unicode in every streamed tool-call argument delta. Tool-call arguments containing emoji and other astral characters survive streaming and still reconstruct to exactly the original JSON, with normal `tool_calls` completion and `[DONE]` behavior.

## Evidence

- Primary contract: OpenAI's official `openai-node` `ChatCompletionChunk.Choice.Delta.ToolCall.Function.arguments?: string` definition at https://github.com/openai/openai-node/blob/83e6b4a3820bc9c6eac4466cf99d828e90a2ef8a/src/resources/chat/completions/completions.ts.
- Fail first on current `main`, through the actual loopback Gateway and `POST /v1/chat/completions`: both `😀` at boundary 255 and `𐐷` at boundary 511 produced malformed SSE argument strings. Blacksmith Testbox reported **2 failed** regression cases before the production fix.
- The regression proves each received SSE argument delta survives an independent UTF-8 encode/decode, reconstructs the exact original JSON arguments, emits `finish_reason: "tool_calls"`, and ends with `[DONE]`.
- `pnpm test src/gateway/openai-http.test.ts packages/normalization-core/src/utf16-slice.test.ts`: **47 passing tests**, including **26 real Gateway HTTP/SSE tests** and **21 canonical UTF-16 helper tests** on Blacksmith Testbox.
- `pnpm check:changed`: passed on Blacksmith Testbox, including formatting, both core type-check lanes, all 245 lint rules, import-cycle checks, and repository safety guards.
- Fresh independent Codex review using `gpt-5.6-sol` with `xhigh` reasoning: **clean; no accepted or actionable findings**.
- AI-assisted; original report and idea credited to @coder-master-0915.
