### PR TITLE
fix(onboard): keep blank workspace inputs from masking defaults

### DIFF
--- a/src/commands/onboard-non-interactive/local/workspace.test.ts
+++ b/src/commands/onboard-non-interactive/local/workspace.test.ts
@@ -68,4 +68,21 @@ describe("resolveNonInteractiveWorkspaceDir", () => {
 
     expect(resolved).toBe(path.join(stateDir, "workspace"));
   });
+
+  it("ignores blank CLI and configured workspace values", () => {
+    const home = path.join(root, "home");
+    const stateDir = path.join(root, "scratch-state");
+    const resolved = resolveNonInteractiveWorkspaceDir({
+      opts: { workspace: "   " },
+      baseConfig: { agents: { defaults: { workspace: "\t" } } },
+      defaultWorkspaceDir: path.join(home, ".openclaw", "workspace"),
+      env: {
+        HOME: home,
+        OPENCLAW_HOME: home,
+        OPENCLAW_STATE_DIR: stateDir,
+      },
+    });
+
+    expect(resolved).toBe(path.join(stateDir, "workspace"));
+  });
 });

--- a/src/commands/onboard-non-interactive/local/workspace.ts
+++ b/src/commands/onboard-non-interactive/local/workspace.ts
@@ -18,13 +18,15 @@ export function resolveNonInteractiveWorkspaceDir(params: {
   env?: NodeJS.ProcessEnv;
 }) {
   const env = params.env ?? process.env;
+  const requestedWorkspace = params.opts.workspace?.trim() || undefined;
+  const configuredWorkspace = params.baseConfig.agents?.defaults?.workspace?.trim() || undefined;
   const workspaceOverride = env.OPENCLAW_WORKSPACE_DIR?.trim() || undefined;
   const implicitWorkspaceDir = isDefaultStateDir(env)
     ? params.defaultWorkspaceDir
     : path.join(resolveStateDir(env), "workspace");
   const raw = (
-    params.opts.workspace ??
-    params.baseConfig.agents?.defaults?.workspace ??
+    requestedWorkspace ??
+    configuredWorkspace ??
     workspaceOverride ??
     implicitWorkspaceDir
   ).trim();


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where non-interactive onboarding accepted a blank `--workspace` value, persisted `agents.defaults.workspace: ""`, and then reported a different fallback workspace. This left the saved configuration and the workspace actually used by setup out of sync.

## Why This Change Was Made

Blank CLI and existing-config workspace values now behave as absent before the established precedence chain runs. Nonblank CLI, configured, environment, and state-directory workspace choices retain their existing order and path normalization.

This PR is AI-assisted. I reviewed the complete resolver, its caller, sibling guided/classic workspace handling, and the path-resolution contract.

## User Impact

Automated onboarding with an accidentally blank workspace now chooses one deterministic default and persists that exact path. Setup output, config, sessions, and later agent runs agree on the workspace.

## Evidence

- Before on the unchanged current-main resolver: an isolated `openclaw onboard --non-interactive --workspace '   ' ...` exited 0, persisted `agents.defaults.workspace: ""`, and reported `~/.openclaw/workspace`.
- After at `d00185f7f195f1b318998aca0e8fc5c46ff0d2aa`: the same black-box command persisted and reported the isolated `<state>/workspace`; a nonblank path containing an interior space stayed exact; `--skip-bootstrap` created no bootstrap files.
- Focused local regression: `node scripts/run-vitest.mjs src/commands/onboard-non-interactive/local/workspace.test.ts` — 4/4 passed.
- Blacksmith Testbox `tbx_01kynzp4yr9wryeq3evr941d78`: 21/21 focused onboarding tests passed, followed by a clean `check:changed` run. Workflow: https://github.com/openclaw/openclaw/actions/runs/30420466972
- Source-blind CLI behavior contract: satisfied for blank fallback, persisted/output agreement, explicit nonblank workspace preservation, and no-bootstrap behavior.
- Fresh rebased-head autoreview: clean, no accepted/actionable findings.
