### PR TITLE
fix(qa): run profile scenarios on every eligible channel

### DIFF
--- a/docs/concepts/qa-e2e-automation.md
+++ b/docs/concepts/qa-e2e-automation.md
@@ -71,6 +71,12 @@ ownership. An explicit profile coverage ID selects every eligible primary owner
 for that ID, deduplicated by scenario. Scenario file and taxonomy order do not
 affect membership or execution order.
 
+`scenario.execution.channels` is an OR eligibility list: a channel-specific
+runner may execute the scenario on any one listed channel. Profile-backed
+execution expands that same list across every channel supported by the selected
+driver, and the profile run passes only when every expanded channel execution
+passes. This applies uniformly to every taxonomy profile.
+
 Slim evidence omits per-entry `execution` and sets `evidenceMode: "slim"`;
 `smoke-ci` defaults to slim, and `--evidence-mode full` restores full entries:
 
@@ -405,7 +411,8 @@ when the maintainer secret is present.
 
 The root `taxonomy.yaml` defines semantic coverage IDs. Scenario YAML files
 under `qa/scenarios/` map each scenario to those IDs and own execution
-metadata; `channel` is the only channel requirement. Taxonomy profiles select
+metadata; `execution.channel` or `execution.channels` declares channel
+requirements. Taxonomy profiles select
 coverage IDs or whole categories, and the catalog resolves their primary
 scenario owners. Transport runners apply channel and provider eligibility to
 that result instead of keeping scenario-ID allowlists. The channel driver is

--- a/extensions/qa-lab/src/cli.runtime.test.ts
+++ b/extensions/qa-lab/src/cli.runtime.test.ts
@@ -572,6 +572,7 @@ describe("qa cli runtime", () => {
     const suiteArgs = mockFirstObjectArg(runQaSuite);
     expect(suiteArgs.scenarioIds).toContain("channel-chat-baseline");
     expect(suiteArgs.scenarioIds).toContain("thread-follow-up");
+    expect(suiteArgs.expandScenarioChannels).toBe(true);
     expect(suiteArgs.adapterFactories).toBe(
       listLiveTransportQaAdapterFactories.mock.results[0]?.value,
     );
@@ -627,7 +628,7 @@ describe("qa cli runtime", () => {
     expect(suiteArgs.scenarioIds).not.toContain("control-ui-qa-channel-image-roundtrip");
   });
 
-  it("rejects explicit profile selections with an incompatible scenario", async () => {
+  it("rejects explicit profile selections outside the profile taxonomy", async () => {
     await expect(
       runQaProfileCommand({
         repoRoot: "/tmp/openclaw-repo",
@@ -635,7 +636,7 @@ describe("qa cli runtime", () => {
         scenarioIds: ["control-ui-qa-channel-image-roundtrip"],
       }),
     ).rejects.toThrow(
-      "qa run --qa-profile smoke-ci cannot run explicitly selected scenario(s): control-ui-qa-channel-image-roundtrip (channelDriver=qa-channel).",
+      "qa run did not find taxonomy scenarios for --qa-profile smoke-ci --scenario control-ui-qa-channel-image-roundtrip.",
     );
 
     expect(runQaSuite).not.toHaveBeenCalled();

--- a/extensions/qa-lab/src/cli.runtime.ts
+++ b/extensions/qa-lab/src/cli.runtime.ts
@@ -146,6 +146,7 @@ export type QaProfileCommandOptions = QaScenarioRunCommandOptions & {
 };
 
 export type QaSuiteCommandOptions = QaScenarioRunCommandOptions & {
+  expandScenarioChannels?: boolean;
   channelDriver?: string;
   channel?: string;
   runner?: string;
@@ -709,6 +710,7 @@ export async function runQaProfileCommand(opts: QaProfileCommandOptions) {
       concurrency: opts.concurrency,
       allowFailures: opts.allowFailures,
       channelDriver: profileReport.channelDriver,
+      expandScenarioChannels: true,
     });
     evidencePath =
       suiteResult && "evidencePath" in suiteResult ? suiteResult.evidencePath : undefined;
@@ -1008,6 +1010,7 @@ export async function runQaSuiteCommand(opts: QaSuiteCommandOptions) {
     evidenceMode: opts.evidenceMode,
     transportId,
     channelDriver,
+    ...(opts.expandScenarioChannels ? { expandScenarioChannels: true } : {}),
     ...(liveAdapterFactories
       ? {
           adapterFactories: liveAdapterFactories,

--- a/extensions/qa-lab/src/profile-planning.ts
+++ b/extensions/qa-lab/src/profile-planning.ts
@@ -8,7 +8,7 @@ import {
   type QaProviderModeInput,
 } from "./model-selection.js";
 import { readQaScenarioPack, type QaSeedScenarioWithSource } from "./scenario-catalog.js";
-import { describeQaProviderLaneMismatches } from "./scenario-lane.js";
+import { describeQaProviderLaneMismatches, resolveQaScenarioLaneChannel } from "./scenario-lane.js";
 import {
   readQaScorecardTaxonomyReport,
   type QaScorecardCategoryCoverageReport,
@@ -131,23 +131,13 @@ export function resolveQaRunProfileExecutionSelection(params: {
     if (scenario.execution.channel === "qa-channel" && params.channelDriver !== "qa-channel") {
       reasons.push("channelDriver=qa-channel");
     }
-    // Unpinned live profiles must resolve a declared real transport before checking a
-    // portable scenario; qa-channel is the built-in harness, not a live adapter.
-    const declaredLiveChannel =
-      params.channelDriver === "live" && scenario.execution.kind === "flow"
-        ? (scenario.execution.channels?.find(
-            (channel) =>
-              channel !== "qa-channel" &&
-              (!params.supportsChannel || params.supportsChannel(channel)),
-          ) ?? scenario.execution.channels?.find((channel) => channel !== "qa-channel"))
-        : undefined;
-    const effectiveChannel =
-      params.channelDriver === "qa-channel"
-        ? "qa-channel"
-        : (params.channel ??
-          scenario.execution.channel ??
-          declaredLiveChannel ??
-          params.defaultChannel);
+    const effectiveChannel = resolveQaScenarioLaneChannel({
+      scenario,
+      channelDriver: params.channelDriver,
+      channel: params.channel,
+      defaultChannel: params.defaultChannel,
+      supportsChannel: params.supportsChannel,
+    });
     reasons.push(
       ...describeQaProviderLaneMismatches({
         scenario,

--- a/extensions/qa-lab/src/scenario-lane.test.ts
+++ b/extensions/qa-lab/src/scenario-lane.test.ts
@@ -4,6 +4,7 @@ import type { QaProviderMode } from "./model-selection.js";
 import { readQaScenarioById, readQaScenarioPack } from "./scenario-catalog.js";
 import {
   describeQaProviderLaneMismatches,
+  resolveQaScenarioLaneChannels,
   scenarioMatchesQaProviderLane,
 } from "./scenario-lane.js";
 import { makeQaSuiteTestScenario } from "./suite-test-helpers.js";
@@ -69,6 +70,18 @@ describe("QA scenario lane matching", () => {
       );
     },
   );
+
+  it("keeps multi-channel metadata as OR eligibility while exposing every supported lane", () => {
+    const scenario = readQaScenarioById("thread-isolation");
+
+    expect(
+      resolveQaScenarioLaneChannels({
+        scenario,
+        channelDriver: "live",
+        supportsChannel: (channel) => channel === "slack" || channel === "matrix",
+      }),
+    ).toEqual(["slack", "matrix"]);
+  });
 
   it("reports every declared mismatch in one decision", () => {
     const scenario = makeQaSuiteTestScenario("strict-live-lane", {

--- a/extensions/qa-lab/src/scenario-lane.ts
+++ b/extensions/qa-lab/src/scenario-lane.ts
@@ -9,6 +9,41 @@ function normalizeQaConfigString(value: unknown): string | undefined {
   return typeof value === "string" && value.trim() ? value.trim() : undefined;
 }
 
+export function resolveQaScenarioLaneChannel(params: {
+  scenario: QaSeedScenario;
+  channelDriver: QaScorecardChannelDriver;
+  channel?: string | null;
+  defaultChannel?: string;
+  supportsChannel?: (channel: string) => boolean;
+}): string | undefined {
+  if (params.channelDriver === "qa-channel") {
+    return "qa-channel";
+  }
+  const selectedChannel = params.channel?.trim().toLowerCase();
+  if (selectedChannel) {
+    return selectedChannel;
+  }
+  const scenarioChannel = params.scenario.execution.channel?.trim().toLowerCase();
+  if (scenarioChannel) {
+    return scenarioChannel;
+  }
+  if (params.channelDriver === "live" && params.scenario.execution.kind === "flow") {
+    const liveChannels = params.scenario.execution.channels?.filter(
+      (channel) => channel !== "qa-channel",
+    );
+    const supportedChannel = liveChannels?.find(
+      (channel) => !params.supportsChannel || params.supportsChannel(channel),
+    );
+    if (supportedChannel) {
+      return supportedChannel;
+    }
+    if (liveChannels?.[0]) {
+      return liveChannels[0];
+    }
+  }
+  return params.defaultChannel?.trim().toLowerCase() || undefined;
+}
+
 export function describeQaProviderLaneMismatches(params: {
   scenario: QaSeedScenario;
   primaryModel: string;

--- a/extensions/qa-lab/src/scenario-lane.ts
+++ b/extensions/qa-lab/src/scenario-lane.ts
@@ -9,39 +9,46 @@ function normalizeQaConfigString(value: unknown): string | undefined {
   return typeof value === "string" && value.trim() ? value.trim() : undefined;
 }
 
-export function resolveQaScenarioLaneChannel(params: {
+export function resolveQaScenarioLaneChannels(params: {
   scenario: QaSeedScenario;
   channelDriver: QaScorecardChannelDriver;
   channel?: string | null;
   defaultChannel?: string;
   supportsChannel?: (channel: string) => boolean;
-}): string | undefined {
+}): Array<string | undefined> {
   if (params.channelDriver === "qa-channel") {
-    return "qa-channel";
+    return ["qa-channel"];
   }
   const selectedChannel = params.channel?.trim().toLowerCase();
   if (selectedChannel) {
-    return selectedChannel;
+    return [selectedChannel];
   }
   const scenarioChannel = params.scenario.execution.channel?.trim().toLowerCase();
   if (scenarioChannel) {
-    return scenarioChannel;
+    return [scenarioChannel];
   }
-  if (params.channelDriver === "live" && params.scenario.execution.kind === "flow") {
-    const liveChannels = params.scenario.execution.channels?.filter(
+  if (params.scenario.execution.kind === "flow") {
+    const driverChannels = params.scenario.execution.channels?.filter(
       (channel) => channel !== "qa-channel",
     );
-    const supportedChannel = liveChannels?.find(
+    const supportedChannels = driverChannels?.filter(
       (channel) => !params.supportsChannel || params.supportsChannel(channel),
     );
-    if (supportedChannel) {
-      return supportedChannel;
+    if (supportedChannels?.length) {
+      return supportedChannels;
     }
-    if (liveChannels?.[0]) {
-      return liveChannels[0];
+    if (driverChannels?.length) {
+      return driverChannels;
     }
   }
-  return params.defaultChannel?.trim().toLowerCase() || undefined;
+  const defaultChannel = params.defaultChannel?.trim().toLowerCase();
+  return [defaultChannel];
+}
+
+export function resolveQaScenarioLaneChannel(
+  params: Parameters<typeof resolveQaScenarioLaneChannels>[0],
+): string | undefined {
+  return resolveQaScenarioLaneChannels(params)[0];
 }
 
 export function describeQaProviderLaneMismatches(params: {

--- a/extensions/qa-lab/src/suite-launch.runtime.test.ts
+++ b/extensions/qa-lab/src/suite-launch.runtime.test.ts
@@ -299,7 +299,7 @@ describe("qa suite runtime launcher", () => {
     const adapterFactories = [
       {
         id: "portable-driver",
-        matches: vi.fn(),
+        matches: vi.fn(({ channelId }) => ["matrix", "slack", "telegram"].includes(channelId)),
         create: vi.fn(),
       },
     ];
@@ -310,11 +310,16 @@ describe("qa suite runtime launcher", () => {
       providerMode: "mock-openai",
       channelDriver: "live",
       adapterFactories,
-      scenarioIds: ["channel-chat-baseline", "telegram-help-command", "matrix-restart-resume"],
+      scenarioIds: [
+        "channel-chat-baseline",
+        "telegram-help-command",
+        "matrix-restart-resume",
+        "thread-isolation",
+      ],
     });
 
     const outputDir = path.join(repoRoot, ".artifacts", "qa-e2e", "pluggable-channels");
-    expect(runQaFlowSuite).toHaveBeenCalledTimes(3);
+    expect(runQaFlowSuite).toHaveBeenCalledTimes(4);
     expect(runQaFlowSuite).toHaveBeenCalledWith(
       expect.objectContaining({
         adapterFactories,
@@ -337,6 +342,13 @@ describe("qa suite runtime launcher", () => {
         channelId: "matrix",
         outputDir: path.join(outputDir, "flow", "matrix"),
         scenarioIds: ["matrix-restart-resume"],
+      }),
+    );
+    expect(runQaFlowSuite).toHaveBeenCalledWith(
+      expect.objectContaining({
+        adapterFactories,
+        channelId: "slack",
+        scenarioIds: ["thread-isolation"],
       }),
     );
   });

--- a/extensions/qa-lab/src/suite-launch.runtime.test.ts
+++ b/extensions/qa-lab/src/suite-launch.runtime.test.ts
@@ -294,8 +294,22 @@ describe("qa suite runtime launcher", () => {
     );
   });
 
-  it("partitions portable scenarios by channel for a pluggable driver", async () => {
+  it("expands profile scenarios across every eligible pluggable channel", async () => {
     const repoRoot = await makeTempRepo("qa-suite-pluggable-channels-");
+    const defaultFlowImplementation = runQaFlowSuite.getMockImplementation();
+    if (!defaultFlowImplementation) {
+      throw new Error("expected default QA flow suite mock implementation");
+    }
+    runQaFlowSuite.mockImplementation(async (params) => {
+      const result = await defaultFlowImplementation(params);
+      if (params?.channelId === "matrix" && params.scenarioIds?.includes("thread-isolation")) {
+        result.scenarios[0] = {
+          ...result.scenarios[0],
+          status: "fail",
+        };
+      }
+      return result;
+    });
     const adapterFactories = [
       {
         id: "portable-driver",
@@ -304,12 +318,13 @@ describe("qa suite runtime launcher", () => {
       },
     ];
 
-    await runQaSuite({
+    const result = await runQaSuite({
       repoRoot,
       outputDir: ".artifacts/qa-e2e/pluggable-channels",
       providerMode: "mock-openai",
       channelDriver: "live",
       adapterFactories,
+      expandScenarioChannels: true,
       scenarioIds: [
         "channel-chat-baseline",
         "telegram-help-command",
@@ -319,7 +334,7 @@ describe("qa suite runtime launcher", () => {
     });
 
     const outputDir = path.join(repoRoot, ".artifacts", "qa-e2e", "pluggable-channels");
-    expect(runQaFlowSuite).toHaveBeenCalledTimes(4);
+    expect(runQaFlowSuite).toHaveBeenCalledTimes(5);
     expect(runQaFlowSuite).toHaveBeenCalledWith(
       expect.objectContaining({
         adapterFactories,
@@ -340,13 +355,63 @@ describe("qa suite runtime launcher", () => {
       expect.objectContaining({
         adapterFactories,
         channelId: "matrix",
-        outputDir: path.join(outputDir, "flow", "matrix"),
+        outputDir: path.join(outputDir, "flow", "matrix-isolated"),
         scenarioIds: ["matrix-restart-resume"],
       }),
     );
     expect(runQaFlowSuite).toHaveBeenCalledWith(
       expect.objectContaining({
         adapterFactories,
+        channelId: "slack",
+        scenarioIds: ["thread-isolation"],
+      }),
+    );
+    expect(runQaFlowSuite).toHaveBeenCalledWith(
+      expect.objectContaining({
+        adapterFactories,
+        channelId: "matrix",
+        outputDir: path.join(outputDir, "flow", "matrix-shared"),
+        scenarioIds: ["thread-isolation"],
+      }),
+    );
+    expect(result.executionKind).toBe("suite");
+    if (result.executionKind !== "suite") {
+      throw new Error("expected unified suite result");
+    }
+    expect(result.result.scenarios.map((scenario) => scenario.name)).toContain(
+      "thread-isolation [slack]",
+    );
+    expect(result.result.scenarios.map((scenario) => scenario.name)).toContain(
+      "thread-isolation [matrix]",
+    );
+    expect(
+      result.result.scenarios.find((scenario) => scenario.name === "thread-isolation [slack]"),
+    ).toMatchObject({ status: "pass" });
+    expect(
+      result.result.scenarios.find((scenario) => scenario.name === "thread-isolation [matrix]"),
+    ).toMatchObject({ status: "fail" });
+  });
+
+  it("uses one eligible channel outside profile execution", async () => {
+    const repoRoot = await makeTempRepo("qa-suite-portable-channel-");
+
+    await runQaSuite({
+      repoRoot,
+      providerMode: "mock-openai",
+      channelDriver: "live",
+      adapterFactories: [
+        {
+          id: "portable-driver",
+          matches: ({ channelId }) => channelId === "slack" || channelId === "matrix",
+          create: vi.fn(),
+        },
+      ],
+      scenarioIds: ["thread-isolation"],
+    });
+
+    expect(runQaFlowSuite).toHaveBeenCalledTimes(1);
+    expect(runQaFlowSuite).toHaveBeenCalledWith(
+      expect.objectContaining({
         channelId: "slack",
         scenarioIds: ["thread-isolation"],
       }),

--- a/extensions/qa-lab/src/suite-launch.runtime.ts
+++ b/extensions/qa-lab/src/suite-launch.runtime.ts
@@ -24,7 +24,7 @@ import {
   readQaBootstrapScenarioCatalog,
   type QaSeedScenarioWithSource,
 } from "./scenario-catalog.js";
-import { resolveQaScenarioLaneChannel } from "./scenario-lane.js";
+import { resolveQaScenarioLaneChannel, resolveQaScenarioLaneChannels } from "./scenario-lane.js";
 import {
   mapQaSuiteWithConcurrency,
   normalizeQaSuiteConcurrency,
@@ -221,17 +221,22 @@ async function resolveQaFlowChannelGroups(
     }
     const groups = new Map<string | undefined, QaSeedScenarioWithSource[]>();
     for (const scenario of scenarios) {
-      const channel = resolveQaScenarioLaneChannel({
+      const channelParams = {
         scenario,
         channelDriver: runParams.channelDriver ?? "qa-channel",
         supportsChannel: (channelId) =>
           runParams.adapterFactories?.some((factory) =>
             factory.matches({ channelId, driver: "live" }),
           ) === true,
-      });
-      const group = groups.get(channel) ?? [];
-      group.push(scenario);
-      groups.set(channel, group);
+      } satisfies Parameters<typeof resolveQaScenarioLaneChannel>[0];
+      const channels = runParams.expandScenarioChannels
+        ? resolveQaScenarioLaneChannels(channelParams)
+        : [resolveQaScenarioLaneChannel(channelParams)];
+      for (const channel of channels) {
+        const group = groups.get(channel) ?? [];
+        group.push(scenario);
+        groups.set(channel, group);
+      }
     }
     return [...groups].map(([channel, groupedScenarios]) => ({
       channel,
@@ -699,7 +704,7 @@ async function runUnifiedQaSuite(params: {
         defaultConcurrency,
       );
   const evidenceSummaries: QaEvidenceSummaryJson[] = [];
-  const scenarioResultsById = new Map<string, QaSuiteScenarioResult>();
+  const scenarioResultsById = new Map<string, QaSuiteScenarioResult[]>();
   const sharedFlowPartitionTasks: QaUnifiedPartitionTask[] = [];
   const isolatedFlowPartitionTasks: QaUnifiedPartitionTask[] = [];
   const testFilePartitionTasks: QaUnifiedPartitionTask[] = [];
@@ -793,7 +798,10 @@ async function runUnifiedQaSuite(params: {
           .join("-");
         const buildCredentialUnavailableResult = (details: string): QaUnifiedPartitionResult => {
           const blockedResults = partition.scenarios.map((scenario) => ({
-            name: scenario.title,
+            name:
+              params.runParams?.expandScenarioChannels && channelGroup.channel
+                ? `${scenario.title} [${channelGroup.channel}]`
+                : scenario.title,
             status: "blocked" as const,
             details,
           }));
@@ -818,7 +826,10 @@ async function runUnifiedQaSuite(params: {
             scenarioResults: partition.scenarios.map((scenario) => ({
               scenarioId: scenario.id,
               result: {
-                name: scenario.title,
+                name:
+                  params.runParams?.expandScenarioChannels && channelGroup.channel
+                    ? `${scenario.title} [${channelGroup.channel}]`
+                    : scenario.title,
                 status: "fail",
                 details,
                 steps: [{ name: "Acquire channel credential", status: "fail", details }],
@@ -895,7 +906,16 @@ async function runUnifiedQaSuite(params: {
             for (const [index, scenario] of partition.scenarios.entries()) {
               const scenarioResult = result.scenarios[index];
               if (scenarioResult) {
-                scenarioResults.push({ scenarioId: scenario.id, result: scenarioResult });
+                scenarioResults.push({
+                  scenarioId: scenario.id,
+                  result:
+                    params.runParams?.expandScenarioChannels && channelGroup.channel
+                      ? {
+                          ...scenarioResult,
+                          name: `${scenarioResult.name} [${channelGroup.channel}]`,
+                        }
+                      : scenarioResult,
+                });
               }
             }
             return {
@@ -1106,7 +1126,9 @@ async function runUnifiedQaSuite(params: {
   const partitionResults = [...concurrentPartitionResults, ...scriptPartitionResults];
   for (const partitionResult of partitionResults) {
     for (const scenarioResult of partitionResult.scenarioResults) {
-      scenarioResultsById.set(scenarioResult.scenarioId, scenarioResult.result);
+      const results = scenarioResultsById.get(scenarioResult.scenarioId) ?? [];
+      results.push(scenarioResult.result);
+      scenarioResultsById.set(scenarioResult.scenarioId, results);
     }
     evidenceSummaries.push(...partitionResult.evidenceSummaries);
   }
@@ -1116,9 +1138,9 @@ async function runUnifiedQaSuite(params: {
     generatedAt: finishedAt.toISOString(),
   });
   const scenarios = params.plan.scenarios.flatMap((scenario) => {
-    const result = scenarioResultsById.get(scenario.id);
-    if (result) {
-      return [result];
+    const results = scenarioResultsById.get(scenario.id);
+    if (results?.length) {
+      return results;
     }
     if (failFast && !startedScenarioIds.has(scenario.id)) {
       return [];
@@ -1154,9 +1176,25 @@ async function runUnifiedQaSuite(params: {
     startedAt,
   });
   const progressResults = params.plan.scenarios.flatMap((scenario) => {
-    const result = scenarioResultsById.get(scenario.id);
-    if (result) {
-      return [{ scenarioId: scenario.id, result }];
+    const results = scenarioResultsById.get(scenario.id);
+    if (results?.length) {
+      const status: QaSuiteScenarioResult["status"] = results.some(
+        (result) => result.status === "fail",
+      )
+        ? "fail"
+        : results.some((result) => result.status === "skip")
+          ? "skip"
+          : "pass";
+      return [
+        {
+          scenarioId: scenario.id,
+          result: {
+            name: scenario.title,
+            status,
+            steps: results.flatMap((result) => result.steps),
+          },
+        },
+      ];
     }
     if (failFast && !startedScenarioIds.has(scenario.id)) {
       return [];

--- a/extensions/qa-lab/src/suite-launch.runtime.ts
+++ b/extensions/qa-lab/src/suite-launch.runtime.ts
@@ -24,6 +24,7 @@ import {
   readQaBootstrapScenarioCatalog,
   type QaSeedScenarioWithSource,
 } from "./scenario-catalog.js";
+import { resolveQaScenarioLaneChannel } from "./scenario-lane.js";
 import {
   mapQaSuiteWithConcurrency,
   normalizeQaSuiteConcurrency,
@@ -220,7 +221,14 @@ async function resolveQaFlowChannelGroups(
     }
     const groups = new Map<string | undefined, QaSeedScenarioWithSource[]>();
     for (const scenario of scenarios) {
-      const channel = normalizeQaSuiteScenarioChannel(scenario);
+      const channel = resolveQaScenarioLaneChannel({
+        scenario,
+        channelDriver: runParams.channelDriver ?? "qa-channel",
+        supportsChannel: (channelId) =>
+          runParams.adapterFactories?.some((factory) =>
+            factory.matches({ channelId, driver: "live" }),
+          ) === true,
+      });
       const group = groups.get(channel) ?? [];
       group.push(scenario);
       groups.set(channel, group);

--- a/extensions/qa-lab/src/suite.ts
+++ b/extensions/qa-lab/src/suite.ts
@@ -156,6 +156,9 @@ export type QaSuiteRunParams = {
   runtimePair?: [RuntimeId, RuntimeId];
   captureRuntimeParityCell?: boolean;
   roundTripProbe?: QaSuiteRoundTripProbe;
+  // Profile runs prove every applicable declared channel. Direct channel lanes
+  // still treat execution.channels as an OR eligibility list.
+  expandScenarioChannels?: boolean;
   // Unified suite partitions consume child evidence in memory; only the
   // parent should write the aggregate qa-evidence.json artifact.
   writeEvidenceFile?: boolean;


### PR DESCRIPTION
makes `channels` have AND behavior for execution, executes on all eligible channels

## What Problem This Solves

Fixes an issue where taxonomy-backed QA profile runs either launched portable multi-channel scenarios without a concrete channel or selected only one eligible channel. That could abort maturity evidence generation or silently omit required per-channel proof.

## Why This Change Was Made

Keep `scenario.execution.channels` as OR eligibility for direct channel-specific runs, while every `qa run --qa-profile ...` expands a scenario across all channels supported by the selected driver. Unified suite aggregation now preserves each `(scenario, channel)` result, so one failing channel fails the profile even when another channel passes.

## User Impact

Release operators get complete per-channel maturity evidence from every profile without profile-ID-specific behavior. Direct channel lanes still run one selected eligible channel.

## Evidence

- Failure reproduced in [Maturity scorecard run 30420111086](https://github.com/openclaw/openclaw/actions/runs/30420111086): `thread-isolation` was accepted for the live profile, then rejected with `channel=qa-channel|slack|matrix`.
- Regression proof makes Matrix fail while Slack passes and verifies both results remain in the aggregate and the profile stays failed.
- `node scripts/run-vitest.mjs extensions/qa-lab/src/scenario-lane.test.ts extensions/qa-lab/src/cli.runtime.test.ts extensions/qa-lab/src/suite-launch.runtime.test.ts` — 162 tests passed after rebase.
- `node scripts/check-changed.mjs` — production/test typechecks, lint, formatting, guards, dead-export checks, and import-cycle checks passed on Blacksmith ([run 30422492307](https://github.com/openclaw/openclaw/actions/runs/30422492307)).
- Updated one stale assertion already present on current `main`: a scenario outside `smoke-ci` fails at taxonomy membership before channel compatibility.
- Autoreview: no accepted/actionable findings remain.

AI-assisted: yes. I reviewed the implementation and understand the change.
