### PR TITLE
fix(codex): accept safe Node network options during setup

### DIFF
--- a/docs/plugins/codex-harness.md
+++ b/docs/plugins/codex-harness.md
@@ -767,6 +767,15 @@ local launch normalization: `CODEX_HOME` stays pointed at the selected
 agent or user scope, and `HOME` stays inherited so subprocesses can use
 normal user-home state.
 
+Verified local setup turns also attest the selected Codex launcher and package.
+Inherited `NODE_OPTIONS` may contain bounded resource, warning, DNS result order,
+network-family autoselection, environment-proxy, and CA-source options because
+those settings cannot preload code or change module resolution. For example,
+`--dns-result-order=ipv4first --no-network-family-autoselection` is allowed.
+Malformed or unknown options and code-loading options such as `--require` or
+`--import` fail closed. If an inherited option is not needed by Codex, remove
+`NODE_OPTIONS` with `appServer.clearEnv`.
+
 ### Dynamic tools and web search
 
 Codex dynamic tools default to `searchable` loading. OpenClaw normally does

--- a/extensions/codex/src/app-server/runtime-artifact.test.ts
+++ b/extensions/codex/src/app-server/runtime-artifact.test.ts
@@ -242,14 +242,36 @@ describe("Codex app-server runtime artifact", () => {
     ).rejects.toThrow("WebSocket attestation is unsupported");
   });
 
-  it("fails closed when spawn environment can inject runtime code", async () => {
-    const options = startOptions("codex", { env: { NODE_OPTIONS: "--require=/tmp/inject.js" } });
+  it.each([
+    ["preload", "--require=/tmp/super-secret-inject.js", "--require"],
+    ["mixed safe and unsafe", "--no-warnings --import=/tmp/inject.mjs", "--import"],
+    ["module resolution", "--preserve-symlinks", "--preserve-symlinks"],
+    ["debugger", "--inspect=127.0.0.1:9229", "--inspect"],
+    ["unknown", "--future-node-option", "--future-node-option"],
+    ["invalid boolean value", "--no-warnings=true", "--no-warnings"],
+  ])("fails closed for %s NODE_OPTIONS", async (_label, nodeOptions, option) => {
+    const options = startOptions("codex", { env: { NODE_OPTIONS: nodeOptions } });
+    const capture = captureCodexAppServerRuntimeArtifactBeforeStart({
+      startOptions: options,
+      spawnIdentity: spawnIdentity(options),
+    });
+
+    await expect(capture).rejects.toThrow(`cannot attest NODE_OPTIONS option ${option}`);
+    await expect(capture).rejects.not.toThrow("super-secret-inject.js");
+  });
+
+  it.each([
+    ["unterminated quote", '--no-warnings "'],
+    ["trailing quoted escape", '--no-warnings "\\'],
+    ["tab delimiter", "--no-warnings\t--trace-warnings"],
+  ])("fails closed for malformed Node tokenization: %s", async (_label, nodeOptions) => {
+    const options = startOptions("codex", { env: { NODE_OPTIONS: nodeOptions } });
     await expect(
       captureCodexAppServerRuntimeArtifactBeforeStart({
         startOptions: options,
         spawnIdentity: spawnIdentity(options),
       }),
-    ).rejects.toThrow("injected runtime environment: NODE_OPTIONS");
+    ).rejects.toThrow("cannot safely parse NODE_OPTIONS");
   });
 
   it("allows bounded Node resource and warning options", async () => {
@@ -262,6 +284,32 @@ describe("Codex app-server runtime artifact", () => {
             "--max-old-space-size=4096 --no-warnings --disable-warning=ExperimentalWarning",
         },
       });
+
+      await expect(captureBinding({ options })).resolves.toMatchObject({
+        binding: { id: expect.stringMatching(/^codex-app-server:v1:/u) },
+      });
+    });
+  });
+
+  it.each([
+    [
+      "Discord network workaround",
+      "--dns-result-order=ipv4first --no-network-family-autoselection",
+    ],
+    [
+      "separate values and underscore aliases",
+      "--dns_result_order ipv6first --network_family_autoselection",
+    ],
+    ["quoted Node syntax", '"--dns-result-order=verbatim" "" --no-warnings'],
+    ["network attempt timeout", "--network-family-autoselection-attempt-timeout=250"],
+    ["proxy and platform trust", "--use-env-proxy --use-system-ca"],
+    ["bundled trust", "--use-bundled-ca"],
+    ["OpenSSL trust", "--use-openssl-ca"],
+  ])("allows bounded %s NODE_OPTIONS", async (_label, nodeOptions) => {
+    await withTempDir("openclaw-codex-runtime-node-options-", async (root) => {
+      const command = path.join(root, "codex");
+      await fs.writeFile(command, "native-v1");
+      const options = startOptions(command, { env: { NODE_OPTIONS: nodeOptions } });
 
       await expect(captureBinding({ options })).resolves.toMatchObject({
         binding: { id: expect.stringMatching(/^codex-app-server:v1:/u) },

--- a/extensions/codex/src/app-server/runtime-artifact.ts
+++ b/extensions/codex/src/app-server/runtime-artifact.ts
@@ -34,6 +34,28 @@ const RUNTIME_INJECTION_ENV_KEYS = new Set([
   "DYLD_INSERT_LIBRARIES",
   "DYLD_LIBRARY_PATH",
 ]);
+const SAFE_NODE_OPTIONS_BOOLEAN_FLAGS = new Set([
+  "--enable-network-family-autoselection",
+  "--network-family-autoselection",
+  "--no-deprecation",
+  "--no-network-family-autoselection",
+  "--no-warnings",
+  "--pending-deprecation",
+  "--throw-deprecation",
+  "--trace-deprecation",
+  "--trace-warnings",
+  "--use-bundled-ca",
+  "--use-env-proxy",
+  "--use-openssl-ca",
+  "--use-system-ca",
+]);
+const SAFE_NODE_OPTIONS_NUMERIC_FLAGS = new Set([
+  "--max-old-space-size",
+  "--max-semi-space-size",
+  "--network-family-autoselection-attempt-timeout",
+  "--stack-trace-limit",
+]);
+const SAFE_NODE_OPTIONS_DNS_RESULT_ORDERS = new Set(["ipv4first", "ipv6first", "verbatim"]);
 const ARTIFACT_BINDINGS_SYMBOL = Symbol.for("openclaw.codexAppServerRuntimeArtifactBindings");
 
 type CodexRuntimeArtifactSpawnIdentity = Readonly<{
@@ -226,11 +248,17 @@ function assertNoRuntimeInjectionEnvironment(env: NodeJS.ProcessEnv): void {
     if (!value?.trim()) {
       continue;
     }
-    if (key === "NODE_OPTIONS" && isSafeNodeOptions(value)) {
-      continue;
-    }
     if (key === "NODE_OPTIONS") {
-      throw new Error(`Codex runtime artifact cannot attest injected runtime environment: ${key}`);
+      const result = attestNodeOptions(value);
+      if (result.ok) {
+        continue;
+      }
+      if (result.option) {
+        throw new Error(
+          `Codex runtime artifact cannot attest NODE_OPTIONS option ${result.option}`,
+        );
+      }
+      throw new Error("Codex runtime artifact cannot safely parse NODE_OPTIONS");
     }
     if (RUNTIME_INJECTION_ENV_KEYS.has(key) || key.startsWith("DYLD_")) {
       // These variables can load code outside the selected launcher/package.
@@ -240,31 +268,67 @@ function assertNoRuntimeInjectionEnvironment(env: NodeJS.ProcessEnv): void {
   }
 }
 
-function isSafeNodeOptions(value: string): boolean {
-  const tokens = value.trim().split(/\s+/u);
-  const valueFlags = new Set([
-    "--max-old-space-size",
-    "--max_old_space_size",
-    "--max-semi-space-size",
-    "--max_semi_space_size",
-    "--stack-trace-limit",
-  ]);
-  const booleanFlags = new Set([
-    "--no-deprecation",
-    "--no-warnings",
-    "--pending-deprecation",
-    "--throw-deprecation",
-    "--trace-deprecation",
-    "--trace-warnings",
-  ]);
-  for (let index = 0; index < tokens.length; index += 1) {
-    const token = tokens[index]!;
-    if (booleanFlags.has(token)) {
+type NodeOptionsAttestationResult =
+  | Readonly<{ ok: true }>
+  | Readonly<{ ok: false; option?: string }>;
+
+function parseNodeOptions(value: string): string[] | undefined {
+  const tokens: string[] = [];
+  let inQuotes = false;
+  let startsNewToken = true;
+  for (let index = 0; index < value.length; index += 1) {
+    let character = value[index]!;
+    if (character === "\\" && inQuotes) {
+      index += 1;
+      if (index >= value.length) {
+        return undefined;
+      }
+      character = value[index]!;
+    } else if (character === " " && !inQuotes) {
+      startsNewToken = true;
+      continue;
+    } else if (character === '"') {
+      inQuotes = !inQuotes;
       continue;
     }
+    if (startsNewToken) {
+      tokens.push(character);
+      startsNewToken = false;
+    } else {
+      tokens[tokens.length - 1] += character;
+    }
+  }
+  return inQuotes ? undefined : tokens;
+}
+
+function normalizedNodeOptionName(token: string): string | undefined {
+  const equalsIndex = token.indexOf("=");
+  const rawName = equalsIndex === -1 ? token : token.slice(0, equalsIndex);
+  const name = rawName.replaceAll("_", "-");
+  return /^--[a-z][a-z0-9-]{0,63}$/u.test(name) ? name : undefined;
+}
+
+function attestNodeOptions(value: string): NodeOptionsAttestationResult {
+  // Match Node's NODE_OPTIONS lexer: only literal spaces delimit arguments,
+  // while double quotes group and backslashes escape only inside quotes.
+  const tokens = parseNodeOptions(value);
+  if (!tokens || tokens.length === 0) {
+    return { ok: false };
+  }
+  for (let index = 0; index < tokens.length; index += 1) {
+    const token = tokens[index]!;
     const equalsIndex = token.indexOf("=");
-    const flag = equalsIndex === -1 ? token : token.slice(0, equalsIndex);
+    const flag = normalizedNodeOptionName(token);
+    if (!flag) {
+      return { ok: false };
+    }
     const inlineValue = equalsIndex === -1 ? undefined : token.slice(equalsIndex + 1);
+    if (SAFE_NODE_OPTIONS_BOOLEAN_FLAGS.has(flag)) {
+      if (inlineValue === undefined) {
+        continue;
+      }
+      return { ok: false, option: flag };
+    }
     if (
       flag === "--disable-warning" &&
       inlineValue &&
@@ -272,15 +336,22 @@ function isSafeNodeOptions(value: string): boolean {
     ) {
       continue;
     }
-    if (!valueFlags.has(flag)) {
-      return false;
+    if (flag === "--dns-result-order") {
+      const order = inlineValue ?? tokens[++index];
+      if (order && SAFE_NODE_OPTIONS_DNS_RESULT_ORDERS.has(order)) {
+        continue;
+      }
+      return { ok: false, option: flag };
+    }
+    if (!SAFE_NODE_OPTIONS_NUMERIC_FLAGS.has(flag)) {
+      return { ok: false, option: flag };
     }
     const numericValue = inlineValue ?? tokens[++index];
     if (!numericValue || !/^\d+$/u.test(numericValue)) {
-      return false;
+      return { ok: false, option: flag };
     }
   }
-  return tokens.length > 0;
+  return { ok: true };
 }
 
 async function hashSelectedArtifactFiles(


### PR DESCRIPTION
Related: https://gist.github.com/vincentkoc/6f9746d328866ef7b740849bfb3cd019

## What Problem This Solves

Fixes an issue where Codex setup verification failed when operators inherited safe Node networking or resource options through `NODE_OPTIONS`. The runtime artifact previously rejected every non-empty `NODE_OPTIONS` value, including supported deployment settings such as `--dns-result-order=ipv4first --no-network-family-autoselection`.

## Why This Change Was Made

The Codex plugin now tokenizes `NODE_OPTIONS` with Node-compatible quoting rules and attests an explicit, bounded allowlist of non-code-loading runtime options. Unknown, malformed, debugger, module-resolution, import, and preload options still fail closed, and errors report only the rejected option name rather than its value. The operator documentation now records the supported policy and `appServer.clearEnv` escape hatch.

This PR is AI-assisted; I reviewed and understand the resulting code and behavior.

## User Impact

Operators can complete Codex setup and reuse verified runtime artifacts while using safe Node DNS, network-family, warning, CA-source, proxy, or bounded numeric runtime settings. Potential code-loading and otherwise unattested options remain blocked.

## Evidence

- Focused regression: `node scripts/run-vitest.mjs extensions/codex/src/app-server/runtime-artifact.test.ts` — 31/31 passed after rebasing onto current `main`.
- Full Codex plugin suite under `NODE_OPTIONS='--dns-result-order=ipv4first --no-network-family-autoselection'` — 140 files and 2,913 tests passed.
- Real Docker Codex app-server turn under the same options — passed with API-key auth.
- Verified setup activation captured and bound a Codex runtime artifact; a subsequent system-agent run reused it successfully.
- Unsafe `--require=/tmp/...` setup probe failed closed and did not expose the option value.
- Node 22.22.3, 24.15.0, 25.9.0, and 26.0.0 all accepted the exact options and reported `ipv4first` with network-family autoselection disabled.
- `pnpm docs:list` completed with Node 24.15.0.
- `git diff --check origin/main...HEAD` passed.
- Fresh structured autoreview: clean, no accepted/actionable findings (0.94 confidence).
