### PR TITLE
fix(microsoft-foundry): preserve native GPT token limits

### DIFF
--- a/extensions/microsoft-foundry/index.test.ts
+++ b/extensions/microsoft-foundry/index.test.ts
@@ -803,6 +803,8 @@ describe("microsoft-foundry plugin", () => {
     const model = config.models?.providers?.["microsoft-foundry"]?.models[0];
     expect(model?.id).toBe("gpt-5.4");
     expect(model?.reasoning).toBe(true);
+    expect(model?.contextWindow).toBe(1_050_000);
+    expect(model?.maxTokens).toBe(128_000);
     expect(model?.compat?.supportsReasoningEffort).toBe(true);
   });
 
@@ -1419,6 +1421,41 @@ describe("microsoft-foundry plugin", () => {
     expect(provider?.apiKey).toBeUndefined();
     expect(provider?.headers).toBeUndefined();
   });
+
+  it.each([
+    ["gpt-5.6", 1_050_000, 128_000],
+    ["gpt-5.6-sol", 1_050_000, 128_000],
+    ["gpt-5.6-terra", 1_050_000, 128_000],
+    ["gpt-5.6-luna", 1_050_000, 128_000],
+    ["gpt-5.5", 1_050_000, 128_000],
+    ["gpt-5.4", 1_050_000, 128_000],
+    ["gpt-5.4-pro", 1_050_000, 128_000],
+    ["gpt-5.4-mini", 400_000, 128_000],
+    ["gpt-5.4-nano", 400_000, 128_000],
+    ["gpt-5-chat", 128_000, 16_384],
+    ["gpt-4o-mini", 128_000, 16_384],
+  ] as const)(
+    "uses Foundry-native token limits for %s",
+    (modelNameHint, contextWindow, maxTokens) => {
+      const result = buildFoundryAuthResult({
+        profileId: "microsoft-foundry:default",
+        apiKey: "test-api-key",
+        endpoint: "https://example.services.ai.azure.com",
+        modelId: `prod-${modelNameHint}`,
+        modelNameHint,
+        api: modelNameHint.startsWith("gpt-5") ? "openai-responses" : "openai-completions",
+        authMethod: "api-key",
+      });
+
+      expect(result.configPatch?.models?.providers?.["microsoft-foundry"]?.models[0]).toMatchObject(
+        {
+          name: modelNameHint,
+          contextWindow,
+          maxTokens,
+        },
+      );
+    },
+  );
 
   it.each([
     ["claude-mythos-preview", 128_000],

--- a/extensions/microsoft-foundry/shared.ts
+++ b/extensions/microsoft-foundry/shared.ts
@@ -225,12 +225,33 @@ function supportsFoundryManualClaudeThinking(value?: string | null): boolean {
     : false;
 }
 
+function resolveFoundryOpenAIModelTokenLimits(
+  normalized: string | undefined,
+): { contextWindow: number; maxTokens: number } | undefined {
+  if (!normalized) {
+    return undefined;
+  }
+  // Foundry publishes provider-native capacities. Keep exact families here so
+  // older GPT and continuously updated chat models retain their separate caps.
+  if (/^gpt-5\.(?:4(?:-pro)?|5|6(?:-(?:sol|terra|luna))?)$/u.test(normalized)) {
+    return { contextWindow: 1_050_000, maxTokens: 128_000 };
+  }
+  if (/^gpt-5\.4-(?:mini|nano)$/u.test(normalized)) {
+    return { contextWindow: 400_000, maxTokens: 128_000 };
+  }
+  return undefined;
+}
+
 function resolveFoundryModelTokenLimits(value?: string | null): {
   contextWindow: number;
   maxTokens: number;
 } {
   const normalized = normalizeFoundryModelName(value);
   const normalizedVersion = normalized?.replace(/\./g, "-");
+  const foundryOpenAILimits = resolveFoundryOpenAIModelTokenLimits(normalized);
+  if (foundryOpenAILimits) {
+    return foundryOpenAILimits;
+  }
   if (
     normalized &&
     (supportsClaudeAdaptiveThinking({ id: normalized }) ||


### PR DESCRIPTION
Closes #114165

## What Problem This Solves

Fixes an issue where Microsoft Foundry discovery declared current GPT deployments as 128k-context, 16k-output models even when Foundry exposes substantially larger native limits. The incorrect metadata caused premature compaction and unnecessarily capped long responses.

## Why This Change Was Made

The Foundry plugin now owns an exact provider-native capability mapping for the documented GPT-5.4, GPT-5.5, and GPT-5.6 families. Large models receive 1.05M context and 128k output; GPT-5.4 mini/nano receive 400k context and 128k output; chat and older model families continue through the existing fallback.

The issue's separate Claude Opus 5 adaptive-thinking report is already fixed on current `main`; this PR completes the remaining Foundry GPT metadata gap without importing policy from another provider plugin.

## User Impact

Agents using these Foundry GPT deployments can use the capacity Foundry actually provides, avoiding early transcript compaction and 16k output truncation.

## Evidence

- Current Microsoft Foundry model documentation: https://learn.microsoft.com/en-us/azure/ai-foundry/openai/concepts/models documents 1,050,000 context / 128,000 output for GPT-5.4, GPT-5.5, and GPT-5.6 large models, and 400,000 / 128,000 for GPT-5.4 mini/nano.
- Before the fix, the new real config-builder matrix failed 9 cases because every covered deployment resolved to 128,000 / 16,384.
- `node scripts/run-vitest.mjs extensions/microsoft-foundry` — 126 tests passed on rebased head `671327a58ff9`.
- Blacksmith Testbox `tbx_01kyp0dce8fejappxd2jjehq4n` / Actions run https://github.com/openclaw/openclaw/actions/runs/30421018862 — `node scripts/check-changed.mjs` passed.
- Codex autoreview on the exact branch diff: no accepted/actionable findings, confidence 0.94.
- No approved Azure/Foundry credential was present in the Molty vault, so authenticated deployment discovery was not run; the live external contract was verified against Microsoft's current documentation.
