### PR TITLE
refactor(ollama): unify local model onboarding

### DIFF
--- a/config/max-lines-baseline.txt
+++ b/config/max-lines-baseline.txt
@@ -188,7 +188,6 @@ extensions/oc-path/src/oc-path/find.ts
 extensions/oc-path/src/oc-path/universal.ts
 extensions/ollama/index.test.ts
 extensions/ollama/index.ts
-extensions/ollama/src/setup.ts
 extensions/ollama/src/stream-runtime.test.ts
 extensions/ollama/src/stream.ts
 extensions/openai/image-generation-provider.test.ts

--- a/extensions/ollama/src/setup-model-selection.test.ts
+++ b/extensions/ollama/src/setup-model-selection.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildOllamaModelsConfig,
+  findAvailableOllamaModelName,
+  mergeUniqueModelNames,
+  normalizeOllamaModelName,
+} from "./setup-model-selection.js";
+
+describe("Ollama onboarding model selection", () => {
+  it("preserves catalog order while preferring an explicit latest tag", () => {
+    expect(mergeUniqueModelNames(["gemma4", "qwen3:0.6b"], ["GEMMA4:latest"])).toEqual([
+      "GEMMA4:latest",
+      "qwen3:0.6b",
+    ]);
+  });
+
+  it("resolves normalized custom model names to the installed latest tag", () => {
+    expect(normalizeOllamaModelName("  OLLAMA/Gemma4  ")).toBe("Gemma4");
+    expect(findAvailableOllamaModelName("Gemma4", ["qwen3:0.6b", "gemma4:latest"])).toBe(
+      "gemma4:latest",
+    );
+  });
+
+  it("keeps failed model inspections distinct from uninspected models", () => {
+    const models = buildOllamaModelsConfig(
+      ["broken", "uninspected"],
+      new Map([["broken", { name: "broken", capabilities: [] }]]),
+    );
+
+    expect(models[0]?.compat?.supportsTools).toBe(false);
+    expect(models[1]?.compat?.supportsTools).toBe(true);
+  });
+
+  it("preserves discovered Gemma vision, reasoning, context, and tool capabilities", () => {
+    const [model] = buildOllamaModelsConfig(
+      ["gemma4:e2b"],
+      new Map([
+        [
+          "gemma4:e2b",
+          {
+            name: "gemma4:e2b",
+            contextWindow: 131_072,
+            capabilities: ["completion", "tools", "vision", "thinking"],
+          },
+        ],
+      ]),
+    );
+
+    expect(model).toMatchObject({
+      id: "gemma4:e2b",
+      input: ["text", "image"],
+      reasoning: true,
+      contextWindow: 131_072,
+      compat: { supportsTools: true },
+    });
+  });
+});

--- a/extensions/ollama/src/setup-model-selection.ts
+++ b/extensions/ollama/src/setup-model-selection.ts
@@ -1,0 +1,209 @@
+import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
+import { readProviderJsonResponse } from "openclaw/plugin-sdk/provider-http";
+import { fetchWithSsrFGuard } from "openclaw/plugin-sdk/ssrf-runtime";
+import { OLLAMA_CLOUD_DEFAULT_MODELS } from "./defaults.js";
+import {
+  buildDefaultOllamaCloudModelDefinition,
+  buildOllamaBaseUrlSsrFPolicy,
+  buildOllamaModelDefinition,
+  enrichOllamaModelsWithContext,
+  fetchOllamaModels,
+  resolveOllamaApiBase,
+  type OllamaModelWithContext,
+} from "./provider-models.js";
+
+const OLLAMA_CONTEXT_ENRICH_LIMIT = 200;
+const OLLAMA_TOOLS_SCAN_CONCURRENCY = 8;
+
+type OllamaCloudDefaultModel = (typeof OLLAMA_CLOUD_DEFAULT_MODELS)[number];
+
+export function normalizeOllamaModelName(value: string | undefined): string | undefined {
+  const trimmed = value?.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+  return trimmed.toLowerCase().startsWith("ollama/")
+    ? trimmed.slice("ollama/".length).trim() || undefined
+    : trimmed;
+}
+
+function getOllamaLatestDedupeKey(name: string): string {
+  const normalized = name.trim().toLowerCase();
+  return normalized.endsWith(":latest") ? normalized.slice(0, -":latest".length) : normalized;
+}
+
+export function mergeUniqueModelNames(...groups: string[][]): string[] {
+  const mergedByKey = new Map<string, string>();
+  for (const group of groups) {
+    for (const name of group) {
+      const key = getOllamaLatestDedupeKey(name);
+      const existing = mergedByKey.get(key);
+      if (
+        existing === undefined ||
+        (!existing.trim().toLowerCase().endsWith(":latest") &&
+          name.trim().toLowerCase().endsWith(":latest"))
+      ) {
+        mergedByKey.set(key, name);
+      }
+    }
+  }
+  return [...mergedByKey.values()];
+}
+
+export function findAvailableOllamaModelName(
+  modelName: string,
+  availableModelNames: Iterable<string>,
+): string | undefined {
+  const wantedKey = getOllamaLatestDedupeKey(modelName);
+  for (const available of availableModelNames) {
+    if (getOllamaLatestDedupeKey(available) === wantedKey) {
+      return available;
+    }
+  }
+  return undefined;
+}
+
+export function buildOllamaModelsConfig(
+  modelNames: string[],
+  discoveredModelsByName?: Map<string, OllamaModelWithContext>,
+  defaultModels: readonly OllamaCloudDefaultModel[] = [],
+) {
+  return modelNames.map((name) => {
+    const discovered = discoveredModelsByName?.get(name);
+    const defaultModel = defaultModels.find((model) => model.id === name);
+    if (defaultModel && !discovered) {
+      return buildDefaultOllamaCloudModelDefinition(defaultModel);
+    }
+    const capabilities =
+      discovered?.capabilities ?? (defaultModel ? [...defaultModel.capabilities] : undefined);
+    return buildOllamaModelDefinition(
+      name,
+      discovered?.contextWindow ?? defaultModel?.contextWindow,
+      capabilities,
+    );
+  });
+}
+
+function parseOllamaSetupShowInfo(data: {
+  model_info?: Record<string, unknown>;
+  capabilities?: unknown;
+  parameters?: unknown;
+}): Pick<OllamaModelWithContext, "contextWindow" | "capabilities"> {
+  let contextWindow: number | undefined;
+  for (const [key, value] of Object.entries(data.model_info ?? {})) {
+    if (key.endsWith(".context_length") && typeof value === "number" && value > 0) {
+      contextWindow = Math.floor(value);
+      break;
+    }
+  }
+  if (typeof data.parameters === "string") {
+    for (const line of data.parameters.split(/\r?\n/)) {
+      const match = line.trim().match(/^num_ctx\s+(-?\d+)\b/);
+      const parsed = match?.[1] ? Number.parseInt(match[1], 10) : undefined;
+      if (parsed && parsed > 0 && (contextWindow === undefined || parsed > contextWindow)) {
+        contextWindow = parsed;
+      }
+    }
+  }
+  const capabilities = Array.isArray(data.capabilities)
+    ? data.capabilities.filter((value): value is string => typeof value === "string")
+    : undefined;
+  return { contextWindow, capabilities };
+}
+
+export async function inspectOllamaModelsForSetup(
+  baseUrl: string,
+  models: OllamaModelWithContext[],
+  signal?: AbortSignal,
+): Promise<{ inspected: OllamaModelWithContext[]; inspectionFailures: string[] }> {
+  const apiBase = resolveOllamaApiBase(baseUrl);
+  const inspected: OllamaModelWithContext[] = [];
+  const inspectionFailures: string[] = [];
+  for (let index = 0; index < models.length; index += OLLAMA_TOOLS_SCAN_CONCURRENCY) {
+    signal?.throwIfAborted();
+    const batch = models.slice(index, index + OLLAMA_TOOLS_SCAN_CONCURRENCY);
+    const results = await Promise.all(
+      batch.map(async (model) => {
+        try {
+          const requestSignal = signal
+            ? AbortSignal.any([AbortSignal.timeout(3000), signal])
+            : AbortSignal.timeout(3000);
+          const { response, release } = await fetchWithSsrFGuard({
+            url: `${apiBase}/api/show`,
+            init: {
+              method: "POST",
+              headers: { "Content-Type": "application/json" },
+              body: JSON.stringify({ name: model.name }),
+              signal: requestSignal,
+            },
+            signal: requestSignal,
+            policy: buildOllamaBaseUrlSsrFPolicy(apiBase),
+            auditContext: "ollama-setup.tools-scan",
+          });
+          try {
+            if (!response.ok) {
+              throw new Error(`Ollama model inspection failed with HTTP ${response.status}`);
+            }
+            const data = await readProviderJsonResponse<{
+              model_info?: Record<string, unknown>;
+              capabilities?: unknown;
+              parameters?: unknown;
+            }>(response, "ollama-setup.tools-scan");
+            return Object.assign({}, model, parseOllamaSetupShowInfo(data));
+          } finally {
+            await release();
+          }
+        } catch (error) {
+          signal?.throwIfAborted();
+          // A failed inspection must not inherit the optimistic tools default
+          // reserved for models that were never inspected.
+          inspectionFailures.push(`${model.name}: ${formatErrorMessage(error)}`);
+          return Object.assign({}, model, { capabilities: [] as string[] });
+        }
+      }),
+    );
+    inspected.push(...results);
+  }
+  return { inspected, inspectionFailures };
+}
+
+export async function discoverOllamaModelsForSetup(params: {
+  baseUrl: string;
+  inspectTools?: boolean;
+  signal?: AbortSignal;
+}) {
+  const { reachable, models } = await fetchOllamaModels(params.baseUrl);
+  const firstModels = models.slice(0, OLLAMA_CONTEXT_ENRICH_LIMIT);
+  const inspection: { inspected: OllamaModelWithContext[]; inspectionFailures: string[] } =
+    !reachable
+      ? { inspected: [], inspectionFailures: [] }
+      : params.inspectTools
+        ? await inspectOllamaModelsForSetup(params.baseUrl, firstModels, params.signal)
+        : {
+            inspected: await enrichOllamaModelsWithContext(params.baseUrl, firstModels),
+            inspectionFailures: [],
+          };
+  if (
+    params.inspectTools &&
+    !inspection.inspected.some((model) => model.capabilities?.includes("tools")) &&
+    models.length > OLLAMA_CONTEXT_ENRICH_LIMIT
+  ) {
+    const remainingScan = await inspectOllamaModelsForSetup(
+      params.baseUrl,
+      models.slice(OLLAMA_CONTEXT_ENRICH_LIMIT),
+      params.signal,
+    );
+    inspection.inspected.push(...remainingScan.inspected);
+    inspection.inspectionFailures.push(...remainingScan.inspectionFailures);
+  }
+  return {
+    reachable,
+    models,
+    inspectedModels: inspection.inspected,
+    discoveredModelsByName: new Map(inspection.inspected.map((model) => [model.name, model])),
+    inspectionFailures: inspection.inspectionFailures,
+    hasToolsCapableModel: inspection.inspected.some((model) =>
+      model.capabilities?.includes("tools"),
+    ),
+  };
+}

--- a/extensions/ollama/src/setup-pull.test.ts
+++ b/extensions/ollama/src/setup-pull.test.ts
@@ -1,0 +1,44 @@
+import type { WizardPrompter } from "openclaw/plugin-sdk/setup";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { pullOllamaModel } from "./setup-pull.js";
+
+const fetchWithSsrFGuardMock = vi.hoisted(() => vi.fn());
+
+vi.mock("openclaw/plugin-sdk/ssrf-runtime", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("openclaw/plugin-sdk/ssrf-runtime")>();
+  return {
+    ...actual,
+    fetchWithSsrFGuard: fetchWithSsrFGuardMock,
+  };
+});
+
+describe("Ollama onboarding model pulls", () => {
+  afterEach(() => {
+    fetchWithSsrFGuardMock.mockReset();
+  });
+
+  it("coerces non-Error stream failures through the shared error contract", async () => {
+    const release = vi.fn(async () => {});
+    const response = new Response(
+      new ReadableStream<Uint8Array>({
+        pull(controller) {
+          controller.error({ code: "OLLAMA_PULL_INTERRUPTED" });
+        },
+      }),
+    );
+    fetchWithSsrFGuardMock.mockResolvedValue({ response, release });
+    const progress = { update: vi.fn(), stop: vi.fn() };
+    const prompter = {
+      progress: vi.fn(() => progress),
+    } as unknown as WizardPrompter;
+
+    await expect(pullOllamaModel("http://127.0.0.1:11434", "gemma4:e2b", prompter)).resolves.toBe(
+      false,
+    );
+
+    expect(progress.stop).toHaveBeenCalledWith(
+      expect.stringContaining("Failed to download gemma4:e2b: Non-Error rejection"),
+    );
+    expect(release).toHaveBeenCalledOnce();
+  });
+});

--- a/extensions/ollama/src/setup-pull.ts
+++ b/extensions/ollama/src/setup-pull.ts
@@ -1,0 +1,187 @@
+import { formatErrorMessage, toErrorObject } from "openclaw/plugin-sdk/error-runtime";
+import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime";
+import type { WizardPrompter } from "openclaw/plugin-sdk/setup";
+import { fetchWithSsrFGuard } from "openclaw/plugin-sdk/ssrf-runtime";
+import { buildOllamaBaseUrlSsrFPolicy, resolveOllamaApiBase } from "./provider-models.js";
+import { normalizeOllamaModelName } from "./setup-model-selection.js";
+
+const OLLAMA_PULL_RESPONSE_TIMEOUT_MS = 30_000;
+const OLLAMA_PULL_STREAM_IDLE_TIMEOUT_MS = 300_000;
+
+type OllamaPullChunk = {
+  status?: string;
+  total?: number;
+  completed?: number;
+  error?: string;
+};
+
+type OllamaPullResult = { ok: true } | { ok: false; message: string };
+
+function formatOllamaPullStatus(status: string): { text: string; hidePercent: boolean } {
+  const trimmed = status.trim();
+  const partStatusMatch = trimmed.match(/^([a-z-]+)\s+(?:sha256:)?[a-f0-9]{8,}$/i);
+  if (partStatusMatch) {
+    return { text: `${partStatusMatch[1]} part`, hidePercent: false };
+  }
+  const hidePercent = /^verifying\b.*\bdigest\b/i.test(trimmed);
+  return { text: hidePercent ? "verifying digest" : trimmed, hidePercent };
+}
+
+async function readOllamaPullChunkWithIdleTimeout(
+  reader: ReadableStreamDefaultReader<Uint8Array>,
+): Promise<ReadableStreamReadResult<Uint8Array>> {
+  return await new Promise((resolve, reject) => {
+    const timeoutId = setTimeout(() => {
+      void reader.cancel().catch(() => undefined);
+      reject(
+        new Error(
+          `Ollama pull stalled: no data received for ${Math.round(OLLAMA_PULL_STREAM_IDLE_TIMEOUT_MS / 1000)}s`,
+        ),
+      );
+    }, OLLAMA_PULL_STREAM_IDLE_TIMEOUT_MS);
+
+    void reader
+      .read()
+      .then(resolve, (error: unknown) => reject(toErrorObject(error, "Non-Error rejection")))
+      .finally(() => clearTimeout(timeoutId));
+  });
+}
+
+async function pullOllamaModelCore(params: {
+  baseUrl: string;
+  modelName: string;
+  onStatus?: (status: string, percent: number | null) => void;
+  signal?: AbortSignal;
+}): Promise<OllamaPullResult> {
+  const baseUrl = resolveOllamaApiBase(params.baseUrl);
+  const modelName = normalizeOllamaModelName(params.modelName) ?? params.modelName.trim();
+  const responseController = new AbortController();
+  const responseTimeout = setTimeout(
+    responseController.abort.bind(responseController),
+    OLLAMA_PULL_RESPONSE_TIMEOUT_MS,
+  );
+  try {
+    params.signal?.throwIfAborted();
+    const { response, release } = await fetchWithSsrFGuard({
+      url: `${baseUrl}/api/pull`,
+      init: {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ name: modelName }),
+      },
+      signal: params.signal
+        ? AbortSignal.any([responseController.signal, params.signal])
+        : responseController.signal,
+      policy: buildOllamaBaseUrlSsrFPolicy(baseUrl),
+      auditContext: "ollama-setup.pull",
+    });
+    clearTimeout(responseTimeout);
+    try {
+      if (!response.ok) {
+        return { ok: false, message: `Failed to download ${modelName} (HTTP ${response.status})` };
+      }
+      if (!response.body) {
+        return { ok: false, message: `Failed to download ${modelName} (no response body)` };
+      }
+
+      const reader = response.body.getReader();
+      const decoder = new TextDecoder();
+      let buffer = "";
+      const layers = new Map<string, { total: number; completed: number }>();
+
+      const parseLine = (line: string): OllamaPullResult => {
+        const trimmed = line.trim();
+        if (!trimmed) {
+          return { ok: true };
+        }
+        try {
+          const chunk = JSON.parse(trimmed) as OllamaPullChunk;
+          if (chunk.error) {
+            return { ok: false, message: `Download failed: ${chunk.error}` };
+          }
+          if (!chunk.status) {
+            return { ok: true };
+          }
+          if (chunk.total && chunk.completed !== undefined) {
+            layers.set(chunk.status, { total: chunk.total, completed: chunk.completed });
+            const totals = [...layers.values()].reduce(
+              (sum, layer) => ({
+                total: sum.total + layer.total,
+                completed: sum.completed + layer.completed,
+              }),
+              { total: 0, completed: 0 },
+            );
+            params.onStatus?.(
+              chunk.status,
+              totals.total > 0 ? Math.round((totals.completed / totals.total) * 100) : null,
+            );
+          } else {
+            params.onStatus?.(chunk.status, null);
+          }
+        } catch {
+          // Ignore malformed streaming lines from Ollama.
+        }
+        return { ok: true };
+      };
+
+      for (;;) {
+        const { done, value } = await readOllamaPullChunkWithIdleTimeout(reader);
+        if (done) {
+          return parseLine(buffer);
+        }
+        buffer += decoder.decode(value, { stream: true });
+        const lines = buffer.split("\n");
+        buffer = lines.pop() ?? "";
+        for (const line of lines) {
+          const parsed = parseLine(line);
+          if (!parsed.ok) {
+            return parsed;
+          }
+        }
+      }
+    } finally {
+      await release();
+    }
+  } catch (err) {
+    const reason = formatErrorMessage(err);
+    return { ok: false, message: `Failed to download ${modelName}: ${reason}` };
+  } finally {
+    clearTimeout(responseTimeout);
+  }
+}
+
+export async function pullOllamaModel(
+  baseUrl: string,
+  modelName: string,
+  prompter: WizardPrompter,
+  signal?: AbortSignal,
+): Promise<boolean> {
+  const spinner = prompter.progress(`Downloading ${modelName}...`);
+  const result = await pullOllamaModelCore({
+    baseUrl,
+    modelName,
+    ...(signal ? { signal } : {}),
+    onStatus: (status, percent) => {
+      const displayStatus = formatOllamaPullStatus(status);
+      const progress = displayStatus.hidePercent ? "" : ` - ${percent ?? 0}%`;
+      spinner.update(`Downloading ${modelName} - ${displayStatus.text}${progress}`);
+    },
+  });
+  spinner.stop(result.ok ? `Downloaded ${modelName}` : result.message);
+  return result.ok;
+}
+
+export async function pullOllamaModelNonInteractive(
+  baseUrl: string,
+  modelName: string,
+  runtime: RuntimeEnv,
+): Promise<boolean> {
+  runtime.log(`Downloading ${modelName}...`);
+  const result = await pullOllamaModelCore({ baseUrl, modelName });
+  if (result.ok) {
+    runtime.log(`Downloaded ${modelName}`);
+  } else {
+    runtime.error(result.message);
+  }
+  return result.ok;
+}

--- a/extensions/ollama/src/setup.ts
+++ b/extensions/ollama/src/setup.ts
@@ -1,4 +1,3 @@
-import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 // Ollama setup module handles plugin onboarding behavior.
 import { expectDefined } from "openclaw/plugin-sdk/expect-runtime";
 import type {
@@ -19,7 +18,6 @@ import { applyAgentDefaultModelPrimary } from "openclaw/plugin-sdk/provider-onbo
 import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime";
 import { WizardCancelledError, type WizardPrompter } from "openclaw/plugin-sdk/setup";
 import { fetchWithSsrFGuard } from "openclaw/plugin-sdk/ssrf-runtime";
-import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/string-coerce-runtime";
 import {
   OLLAMA_CLOUD_BASE_URL,
   OLLAMA_CLOUD_DEFAULT_MODELS,
@@ -30,15 +28,22 @@ import {
 import { readProviderBaseUrl } from "./provider-base-url.js";
 import {
   buildOllamaBaseUrlSsrFPolicy,
-  buildDefaultOllamaCloudModelDefinition,
   buildOllamaProvider,
-  buildOllamaModelDefinition,
   enrichOllamaModelsWithContext,
   fetchOllamaModels,
   isOllamaCloudModel,
   resolveOllamaApiBase,
   type OllamaModelWithContext,
 } from "./provider-models.js";
+import {
+  buildOllamaModelsConfig,
+  discoverOllamaModelsForSetup,
+  findAvailableOllamaModelName,
+  inspectOllamaModelsForSetup,
+  mergeUniqueModelNames,
+  normalizeOllamaModelName,
+} from "./setup-model-selection.js";
+import { pullOllamaModel, pullOllamaModelNonInteractive } from "./setup-pull.js";
 
 export { buildOllamaProvider };
 
@@ -47,13 +52,9 @@ const OLLAMA_SUGGESTED_MODELS_CLOUD = OLLAMA_CLOUD_DEFAULT_MODELS.map((model) =>
 const OLLAMA_SUGGESTED_MODELS_LOCAL_CLOUD = OLLAMA_CLOUD_DEFAULT_MODELS.map(
   (model) => `${model.id}:cloud`,
 );
-const OLLAMA_CONTEXT_ENRICH_LIMIT = 200;
 const OLLAMA_CLOUD_MAX_DISCOVERED_MODELS = 500;
-const OLLAMA_PULL_RESPONSE_TIMEOUT_MS = 30_000;
-const OLLAMA_PULL_STREAM_IDLE_TIMEOUT_MS = 300_000;
 const OLLAMA_RECOMMENDED_TOOLS_MODEL = "gemma4:e4b";
 const OLLAMA_RECOMMENDED_TOOLS_MODEL_SIZE = "about 9.6 GB";
-const OLLAMA_TOOLS_SCAN_CONCURRENCY = 8;
 
 type OllamaCloudDefaultModel = (typeof OLLAMA_CLOUD_DEFAULT_MODELS)[number];
 
@@ -113,30 +114,6 @@ function buildOllamaCloudSigninLines(signinUrl?: string): string[] {
   ];
 }
 
-function normalizeOllamaModelName(value: string | undefined): string | undefined {
-  const trimmed = value?.trim();
-  if (!trimmed) {
-    return undefined;
-  }
-  if (normalizeLowercaseStringOrEmpty(trimmed).startsWith("ollama/")) {
-    const normalized = trimmed.slice("ollama/".length).trim();
-    return normalized || undefined;
-  }
-  return trimmed;
-}
-
-function formatOllamaPullStatus(status: string): { text: string; hidePercent: boolean } {
-  const trimmed = status.trim();
-  const partStatusMatch = trimmed.match(/^([a-z-]+)\s+(?:sha256:)?[a-f0-9]{8,}$/i);
-  if (partStatusMatch) {
-    return { text: `${partStatusMatch[1]} part`, hidePercent: false };
-  }
-  if (/^verifying\b.*\bdigest\b/i.test(trimmed)) {
-    return { text: "verifying digest", hidePercent: true };
-  }
-  return { text: trimmed, hidePercent: false };
-}
-
 export async function checkOllamaCloudAuth(
   baseUrl: string,
 ): Promise<{ signedIn: boolean; signinUrl?: string }> {
@@ -170,212 +147,6 @@ export async function checkOllamaCloudAuth(
   } catch {
     return { signedIn: false };
   }
-}
-
-type OllamaPullChunk = {
-  status?: string;
-  total?: number;
-  completed?: number;
-  error?: string;
-};
-
-type OllamaPullResult = { ok: true } | { ok: false; message: string };
-
-async function readOllamaPullChunkWithIdleTimeout(
-  reader: ReadableStreamDefaultReader<Uint8Array>,
-): Promise<ReadableStreamReadResult<Uint8Array>> {
-  let timeoutId: ReturnType<typeof setTimeout> | undefined;
-  let timedOut = false;
-
-  return await new Promise((resolve, reject) => {
-    const clear = () => {
-      if (timeoutId !== undefined) {
-        clearTimeout(timeoutId);
-        timeoutId = undefined;
-      }
-    };
-
-    timeoutId = setTimeout(() => {
-      timedOut = true;
-      clear();
-      void reader.cancel().catch(() => undefined);
-      reject(
-        new Error(
-          `Ollama pull stalled: no data received for ${Math.round(OLLAMA_PULL_STREAM_IDLE_TIMEOUT_MS / 1000)}s`,
-        ),
-      );
-    }, OLLAMA_PULL_STREAM_IDLE_TIMEOUT_MS);
-
-    void reader.read().then(
-      (result) => {
-        clear();
-        if (!timedOut) {
-          resolve(result);
-        }
-      },
-      (err: unknown) => {
-        clear();
-        if (!timedOut) {
-          reject(toLintErrorObject(err, "Non-Error rejection"));
-        }
-      },
-    );
-  });
-}
-
-async function pullOllamaModelCore(params: {
-  baseUrl: string;
-  modelName: string;
-  onStatus?: (status: string, percent: number | null) => void;
-  signal?: AbortSignal;
-}): Promise<OllamaPullResult> {
-  const baseUrl = resolveOllamaApiBase(params.baseUrl);
-  const modelName = normalizeOllamaModelName(params.modelName) ?? params.modelName.trim();
-  const responseController = new AbortController();
-  const responseTimeout = setTimeout(
-    responseController.abort.bind(responseController),
-    OLLAMA_PULL_RESPONSE_TIMEOUT_MS,
-  );
-  try {
-    params.signal?.throwIfAborted();
-    const { response, release } = await fetchWithSsrFGuard({
-      url: `${baseUrl}/api/pull`,
-      init: {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ name: modelName }),
-      },
-      signal: params.signal
-        ? AbortSignal.any([responseController.signal, params.signal])
-        : responseController.signal,
-      policy: buildOllamaBaseUrlSsrFPolicy(baseUrl),
-      auditContext: "ollama-setup.pull",
-    });
-    clearTimeout(responseTimeout);
-    try {
-      if (!response.ok) {
-        return { ok: false, message: `Failed to download ${modelName} (HTTP ${response.status})` };
-      }
-      if (!response.body) {
-        return { ok: false, message: `Failed to download ${modelName} (no response body)` };
-      }
-
-      const reader = response.body.getReader();
-      const decoder = new TextDecoder();
-      let buffer = "";
-      const layers = new Map<string, { total: number; completed: number }>();
-
-      const parseLine = (line: string): OllamaPullResult => {
-        const trimmed = line.trim();
-        if (!trimmed) {
-          return { ok: true };
-        }
-        try {
-          const chunk = JSON.parse(trimmed) as OllamaPullChunk;
-          if (chunk.error) {
-            return { ok: false, message: `Download failed: ${chunk.error}` };
-          }
-          if (!chunk.status) {
-            return { ok: true };
-          }
-          if (chunk.total && chunk.completed !== undefined) {
-            layers.set(chunk.status, { total: chunk.total, completed: chunk.completed });
-            let totalSum = 0;
-            let completedSum = 0;
-            for (const layer of layers.values()) {
-              totalSum += layer.total;
-              completedSum += layer.completed;
-            }
-            params.onStatus?.(
-              chunk.status,
-              totalSum > 0 ? Math.round((completedSum / totalSum) * 100) : null,
-            );
-          } else {
-            params.onStatus?.(chunk.status, null);
-          }
-        } catch {
-          // Ignore malformed streaming lines from Ollama.
-        }
-        return { ok: true };
-      };
-
-      for (;;) {
-        const { done, value } = await readOllamaPullChunkWithIdleTimeout(reader);
-        if (done) {
-          break;
-        }
-        buffer += decoder.decode(value, { stream: true });
-        const lines = buffer.split("\n");
-        buffer = lines.pop() ?? "";
-        for (const line of lines) {
-          const parsed = parseLine(line);
-          if (!parsed.ok) {
-            return parsed;
-          }
-        }
-      }
-
-      const trailing = buffer.trim();
-      if (trailing) {
-        const parsed = parseLine(trailing);
-        if (!parsed.ok) {
-          return parsed;
-        }
-      }
-
-      return { ok: true };
-    } finally {
-      await release();
-    }
-  } catch (err) {
-    const reason = formatErrorMessage(err);
-    return { ok: false, message: `Failed to download ${modelName}: ${reason}` };
-  } finally {
-    clearTimeout(responseTimeout);
-  }
-}
-
-async function pullOllamaModel(
-  baseUrl: string,
-  modelName: string,
-  prompter: WizardPrompter,
-  signal?: AbortSignal,
-): Promise<boolean> {
-  const spinner = prompter.progress(`Downloading ${modelName}...`);
-  const result = await pullOllamaModelCore({
-    baseUrl,
-    modelName,
-    ...(signal ? { signal } : {}),
-    onStatus: (status, percent) => {
-      const displayStatus = formatOllamaPullStatus(status);
-      if (displayStatus.hidePercent) {
-        spinner.update(`Downloading ${modelName} - ${displayStatus.text}`);
-      } else {
-        spinner.update(`Downloading ${modelName} - ${displayStatus.text} - ${percent ?? 0}%`);
-      }
-    },
-  });
-  if (!result.ok) {
-    spinner.stop(result.message);
-    return false;
-  }
-  spinner.stop(`Downloaded ${modelName}`);
-  return true;
-}
-
-async function pullOllamaModelNonInteractive(
-  baseUrl: string,
-  modelName: string,
-  runtime: RuntimeEnv,
-): Promise<boolean> {
-  runtime.log(`Downloading ${modelName}...`);
-  const result = await pullOllamaModelCore({ baseUrl, modelName });
-  if (!result.ok) {
-    runtime.error(result.message);
-    return false;
-  }
-  runtime.log(`Downloaded ${modelName}`);
-  return true;
 }
 
 async function promptForOllamaCloudCredential(params: {
@@ -429,71 +200,6 @@ async function promptForOllamaCloudCredential(params: {
     credentialMode: captured.credentialMode,
     discoveryApiKey,
   };
-}
-
-function buildOllamaModelsConfig(
-  modelNames: string[],
-  discoveredModelsByName?: Map<string, OllamaModelWithContext>,
-  defaultModels: readonly OllamaCloudDefaultModel[] = [],
-) {
-  return modelNames.map((name) => {
-    const discovered = discoveredModelsByName?.get(name);
-    const defaultModel = defaultModels.find((model) => model.id === name);
-    if (defaultModel && !discovered) {
-      return buildDefaultOllamaCloudModelDefinition(defaultModel);
-    }
-    const capabilities =
-      discovered?.capabilities ?? (defaultModel ? [...defaultModel.capabilities] : undefined);
-    return buildOllamaModelDefinition(
-      name,
-      discovered?.contextWindow ?? defaultModel?.contextWindow,
-      capabilities,
-    );
-  });
-}
-
-function getOllamaLatestDedupeKey(name: string): string {
-  const normalized = normalizeLowercaseStringOrEmpty(name);
-  return normalized.endsWith(":latest") ? normalized.slice(0, -":latest".length) : normalized;
-}
-
-function isExplicitLatestOllamaModel(name: string): boolean {
-  return normalizeLowercaseStringOrEmpty(name).endsWith(":latest");
-}
-
-function shouldReplaceOllamaModelName(existing: string, candidate: string): boolean {
-  return !isExplicitLatestOllamaModel(existing) && isExplicitLatestOllamaModel(candidate);
-}
-
-function mergeUniqueModelNames(...groups: string[][]): string[] {
-  const indexByKey = new Map<string, number>();
-  const merged: string[] = [];
-  for (const group of groups) {
-    for (const name of group) {
-      const key = getOllamaLatestDedupeKey(name);
-      const existingIndex = indexByKey.get(key);
-      if (existingIndex !== undefined) {
-        const existing = expectDefined(merged[existingIndex], "indexed Ollama model name");
-        if (shouldReplaceOllamaModelName(existing, name)) {
-          merged[existingIndex] = name;
-        }
-        continue;
-      }
-      indexByKey.set(key, merged.length);
-      merged.push(name);
-    }
-  }
-  return merged;
-}
-
-function findAvailableOllamaModelName(modelName: string, availableModelNames: Iterable<string>) {
-  const wantedKey = getOllamaLatestDedupeKey(modelName);
-  for (const available of availableModelNames) {
-    if (getOllamaLatestDedupeKey(available) === wantedKey) {
-      return available;
-    }
-  }
-  return undefined;
 }
 
 function applyOllamaProviderConfig(
@@ -569,93 +275,6 @@ async function resolveHostBackedSuggestedModelNames(params: {
   return OLLAMA_SUGGESTED_MODELS_LOCAL;
 }
 
-function parseOllamaSetupShowInfo(data: {
-  model_info?: Record<string, unknown>;
-  capabilities?: unknown;
-  parameters?: unknown;
-}): Pick<OllamaModelWithContext, "contextWindow" | "capabilities"> {
-  let contextWindow: number | undefined;
-  for (const [key, value] of Object.entries(data.model_info ?? {})) {
-    if (key.endsWith(".context_length") && typeof value === "number" && value > 0) {
-      contextWindow = Math.floor(value);
-      break;
-    }
-  }
-  if (typeof data.parameters === "string") {
-    for (const line of data.parameters.split(/\r?\n/)) {
-      const match = line.trim().match(/^num_ctx\s+(-?\d+)\b/);
-      const parsed = match?.[1] ? Number.parseInt(match[1], 10) : undefined;
-      if (parsed && parsed > 0 && (contextWindow === undefined || parsed > contextWindow)) {
-        contextWindow = parsed;
-      }
-    }
-  }
-  const capabilities = Array.isArray(data.capabilities)
-    ? data.capabilities.filter((value): value is string => typeof value === "string")
-    : undefined;
-  return { contextWindow, capabilities };
-}
-
-async function inspectOllamaModelsForSetup(
-  baseUrl: string,
-  models: OllamaModelWithContext[],
-  signal?: AbortSignal,
-): Promise<{ inspected: OllamaModelWithContext[]; inspectionFailures: string[] }> {
-  const apiBase = resolveOllamaApiBase(baseUrl);
-  const inspected: OllamaModelWithContext[] = [];
-  const inspectionFailures: string[] = [];
-  for (let index = 0; index < models.length; index += OLLAMA_TOOLS_SCAN_CONCURRENCY) {
-    signal?.throwIfAborted();
-    const batch = models.slice(index, index + OLLAMA_TOOLS_SCAN_CONCURRENCY);
-    const results = await Promise.all(
-      batch.map(async (model) => {
-        try {
-          const requestSignal = signal
-            ? AbortSignal.any([AbortSignal.timeout(3000), signal])
-            : AbortSignal.timeout(3000);
-          const { response, release } = await fetchWithSsrFGuard({
-            url: `${apiBase}/api/show`,
-            init: {
-              method: "POST",
-              headers: { "Content-Type": "application/json" },
-              body: JSON.stringify({ name: model.name }),
-              signal: requestSignal,
-            },
-            signal: requestSignal,
-            policy: buildOllamaBaseUrlSsrFPolicy(apiBase),
-            auditContext: "ollama-setup.tools-scan",
-          });
-          try {
-            if (!response.ok) {
-              throw new Error(`Ollama model inspection failed with HTTP ${response.status}`);
-            }
-            const data = await readProviderJsonResponse<{
-              model_info?: Record<string, unknown>;
-              capabilities?: unknown;
-              parameters?: unknown;
-            }>(response, "ollama-setup.tools-scan");
-            return Object.assign({}, model, parseOllamaSetupShowInfo(data));
-          } finally {
-            await release();
-          }
-        } catch (error) {
-          signal?.throwIfAborted();
-          // Fail open per model: one stale/corrupt local model (observed: a
-          // months-old pull whose /api/show returns HTTP 500) must not brick
-          // the whole setup. Mark the failure with EMPTY capabilities: undefined
-          // means "never inspected" and downstream config building optimistically
-          // defaults that to supportsTools, which would advertise a broken model
-          // as tools-capable (ClawSweeper P2 on #109797).
-          inspectionFailures.push(`${model.name}: ${formatErrorMessage(error)}`);
-          return Object.assign({}, model, { capabilities: [] as string[] });
-        }
-      }),
-    );
-    inspected.push(...results);
-  }
-  return { inspected, inspectionFailures };
-}
-
 async function promptAndConfigureHostBackedOllama(params: {
   cfg: OpenClawConfig;
   mode: HostBackedOllamaInteractiveMode;
@@ -664,33 +283,24 @@ async function promptAndConfigureHostBackedOllama(params: {
   signal?: AbortSignal;
 }): Promise<OllamaSetupResult> {
   const baseUrl = await promptForOllamaBaseUrl(params.prompter, params.env);
-  const { reachable, models } = await fetchOllamaModels(baseUrl);
+  const {
+    reachable,
+    models,
+    inspectedModels,
+    discoveredModelsByName,
+    inspectionFailures,
+    hasToolsCapableModel,
+  } = await discoverOllamaModelsForSetup({
+    baseUrl,
+    inspectTools: true,
+    ...(params.signal ? { signal: params.signal } : {}),
+  });
 
   if (!reachable) {
     await params.prompter.note(buildOllamaUnreachableLines(baseUrl).join("\n"), "Ollama");
     throw new WizardCancelledError("Ollama not reachable");
   }
 
-  const firstScan = await inspectOllamaModelsForSetup(
-    baseUrl,
-    models.slice(0, OLLAMA_CONTEXT_ENRICH_LIMIT),
-    params.signal,
-  );
-  let inspectedModels = firstScan.inspected;
-  const inspectionFailures = [...firstScan.inspectionFailures];
-  const supportsTools = (model: OllamaModelWithContext) =>
-    model.capabilities?.includes("tools") === true;
-  let hasToolsCapableModel = inspectedModels.some(supportsTools);
-  if (!hasToolsCapableModel && models.length > OLLAMA_CONTEXT_ENRICH_LIMIT) {
-    const remainingScan = await inspectOllamaModelsForSetup(
-      baseUrl,
-      models.slice(OLLAMA_CONTEXT_ENRICH_LIMIT),
-      params.signal,
-    );
-    inspectedModels = [...inspectedModels, ...remainingScan.inspected];
-    inspectionFailures.push(...remainingScan.inspectionFailures);
-    hasToolsCapableModel = remainingScan.inspected.some(supportsTools);
-  }
   if (inspectionFailures.length > 0) {
     await params.prompter.note(
       [
@@ -701,7 +311,6 @@ async function promptAndConfigureHostBackedOllama(params: {
       "Ollama",
     );
   }
-  const discoveredModelsByName = new Map(inspectedModels.map((model) => [model.name, model]));
   let discoveredModelNames = models.map((model) => model.name);
   // A pull offer is only meaningful when inspection actually worked: if every
   // scan failed we cannot know what is installed, so recommending a multi-GB
@@ -834,7 +443,9 @@ export async function configureOllamaNonInteractive(params: {
   const baseUrl = resolveOllamaApiBase(
     (params.opts.customBaseUrl?.trim() || resolveOllamaSetupDefaultBaseUrl()).replace(/\/+$/, ""),
   );
-  const { reachable, models } = await fetchOllamaModels(baseUrl);
+  const { reachable, models, discoveredModelsByName } = await discoverOllamaModelsForSetup({
+    baseUrl,
+  });
   const explicitModel = normalizeOllamaModelName(params.opts.customModelId);
 
   if (!reachable) {
@@ -843,11 +454,6 @@ export async function configureOllamaNonInteractive(params: {
     return params.nextConfig;
   }
 
-  const enrichedModels = await enrichOllamaModelsWithContext(
-    baseUrl,
-    models.slice(0, OLLAMA_CONTEXT_ENRICH_LIMIT),
-  );
-  const discoveredModelsByName = new Map(enrichedModels.map((model) => [model.name, model]));
   const modelNames = models.map((model) => model.name);
   // Configured local models are advertised as available, so suggested models
   // belong in the inventory only when Ollama actually reports them as installed.
@@ -964,18 +570,3 @@ export async function ensureOllamaModelPulled(params: {
     throw new WizardCancelledError("Failed to download selected Ollama model");
   }
 }
-
-function toLintErrorObject(value: unknown, fallbackMessage: string): Error {
-  if (value instanceof Error) {
-    return value;
-  }
-  if (typeof value === "string") {
-    return new Error(value);
-  }
-  const error = new Error(fallbackMessage, { cause: value });
-  if ((typeof value === "object" && value !== null) || typeof value === "function") {
-    Object.assign(error, value);
-  }
-  return error;
-}
-/* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */


### PR DESCRIPTION
## What Problem This Solves

Ollama local onboarding duplicated catalog discovery, model selection, inspection, and pull handling between interactive and non-interactive setup. The 981-line setup owner carried a grandfathered max-lines suppression, making it harder to preserve selected-model capabilities, correctly handle broken models, and safely maintain streamed downloads.

## Why This Change Was Made

Consolidates bounded model preparation into one private Ollama onboarding owner and extracts streamed model downloads into a separate private owner. Keeps all existing public setup exports, provider configuration, cloud and local setup behavior, latest-tag aliases, cancellation, and auth isolation unchanged. Reuses the canonical Plugin SDK error coercion contract instead of copying an error helper. Failed inspections remain distinguishable from uninspected models so a broken model cannot acquire optimistic tool capabilities.

Production code decreases from 981 to 968 lines across three focused modules; the original setup owner drops from 981 to 572 lines and its max-lines suppression is removed. No core changes, configuration additions, cache additions, migrations, or provider SDK contract changes.

## User Impact

Interactive and non-interactive Ollama onboarding use the same prepared local model catalog. Selected Gemma and Qwen models retain the context window, image support, reasoning, and tool capabilities reported by the real Ollama server. Existing installed latest tags are reused instead of pulled again. Interrupted downloads retain bounded cleanup and the existing user-visible progress/error behavior.

## Evidence

- Real source onboarding against an existing local Ollama server, using temporary isolated agent directories removed after proof: `gemma4:e2b` selected with 131072 context, image plus text, reasoning and tools; `qwen3:0.6b` selected with 40960 context, reasoning and tools. Both retained the complete three-model installed catalog. No existing model, normal configuration, or running service was changed.
- 48 passing existing and new onboarding regressions, including the 201st catalog model, freshly pulled Gemma metadata, failed inspections, latest aliases, setup cancellation, bounded stream timeout, and non-Error stream failures: `node scripts/run-vitest.mjs extensions/ollama/src/setup.test.ts extensions/ollama/src/setup.non-interactive-auth.test.ts extensions/ollama/src/setup-model-selection.test.ts extensions/ollama/src/setup-pull.test.ts`.
- 135 passing Ollama plugin, provider-catalog, and web-search sibling regressions: `node scripts/run-vitest.mjs extensions/ollama/index.test.ts extensions/ollama/src/provider-models.test.ts extensions/ollama/src/web-search-provider.test.ts`.
- Targeted `oxfmt --check`, targeted `oxlint`, and `git diff --check`: clean.
- Fresh independent structured autoreview: clean; no actionable findings.
- Absorbs the canonical error-coercion cleanup proposed in #115116 without altering the unrelated provider inspection contract proposed in #109971.

AI-assisted: Codex