### PR TITLE
fix(gateway): cancel HTTP tool calls when clients disconnect

### DIFF
--- a/src/gateway/tools-invoke-http.abort.test.ts
+++ b/src/gateway/tools-invoke-http.abort.test.ts
@@ -1,0 +1,318 @@
+import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
+import type { AddressInfo } from "node:net";
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+const lifecycle = vi.hoisted(() => ({
+  authorize: vi.fn(
+    async (_params: {
+      req: IncomingMessage;
+      res: ServerResponse;
+    }): Promise<{ cfg: Record<string, never>; requestAuth: { ok: true } } | undefined> => ({
+      cfg: {},
+      requestAuth: { ok: true },
+    }),
+  ),
+  beforeHook: vi.fn(async (args: { params: unknown; signal?: AbortSignal }) => ({
+    blocked: false as const,
+    params: args.params,
+  })),
+  cleanup: vi.fn(),
+  handled: vi.fn(),
+  sendJson: vi.fn(),
+  watch: vi.fn(),
+  execute: vi.fn(async (_toolCallId: string, _args: unknown, _signal?: AbortSignal) => ({
+    ok: true,
+  })),
+}));
+
+vi.mock("./http-common.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./http-common.js")>();
+  return {
+    ...actual,
+    sendJson: (...args: Parameters<typeof actual.sendJson>) => {
+      lifecycle.sendJson();
+      return actual.sendJson(...args);
+    },
+    watchClientDisconnect: (
+      req: IncomingMessage,
+      res: ServerResponse,
+      controller: AbortController,
+      onDisconnect?: () => void,
+    ) => {
+      lifecycle.watch();
+      const stopWatching = actual.watchClientDisconnect(req, res, controller, onDisconnect);
+      return () => {
+        lifecycle.cleanup();
+        stopWatching();
+      };
+    },
+  };
+});
+
+vi.mock("./http-utils.js", () => ({
+  authorizeScopedGatewayHttpRequestOrReply: lifecycle.authorize,
+  getHeader: (req: IncomingMessage, name: string) => {
+    const header = req.headers[name];
+    return typeof header === "string" ? header : undefined;
+  },
+  resolveOpenAiCompatibleHttpOperatorScopes: () => ["operator.write"],
+  resolveOpenAiCompatibleHttpSenderIsOwner: () => true,
+}));
+
+vi.mock("./tool-resolution.js", () => ({
+  resolveGatewayScopedTools: () => ({
+    agentId: "main",
+    tools: [
+      {
+        name: "abort_probe",
+        parameters: { type: "object", properties: {} },
+        execute: lifecycle.execute,
+      },
+    ],
+  }),
+}));
+
+vi.mock("../agents/agent-tools.before-tool-call.js", () => ({
+  runBeforeToolCallHook: lifecycle.beforeHook,
+}));
+
+vi.mock("../agents/agent-tools.js", () => ({
+  resolveToolLoopDetectionConfig: () => undefined,
+}));
+
+vi.mock("../config/sessions.js", () => ({
+  resolveMainSessionKey: () => "agent:main:main",
+}));
+
+vi.mock("../agents/channel-tools.js", () => ({
+  getChannelAgentToolMeta: () => undefined,
+}));
+
+vi.mock("../plugins/tools.js", () => ({
+  getPluginToolMeta: () => undefined,
+}));
+
+vi.mock("../logger.js", () => ({
+  logWarn: vi.fn(),
+}));
+
+const { handleToolsInvokeHttpRequest } = await import("./tools-invoke-http.js");
+
+let server: ReturnType<typeof createServer> | undefined;
+let serverPort = 0;
+
+beforeAll(async () => {
+  server = createServer((req, res) => {
+    void handleToolsInvokeHttpRequest(req, res, {
+      auth: { mode: "none", allowTailscale: false },
+    })
+      .then(() => {
+        lifecycle.handled();
+      })
+      .catch((error: unknown) => {
+        if (!res.destroyed && !res.writableEnded) {
+          res.statusCode = 500;
+          res.end(String(error));
+        }
+      });
+  });
+
+  await new Promise<void>((resolve, reject) => {
+    server?.once("error", reject);
+    server?.listen(0, "127.0.0.1", () => {
+      const address = server?.address() as AddressInfo | null;
+      serverPort = address?.port ?? 0;
+      resolve();
+    });
+  });
+});
+
+afterAll(async () => {
+  const activeServer = server;
+  if (!activeServer) {
+    return;
+  }
+  activeServer.closeAllConnections();
+  await new Promise<void>((resolve) => {
+    activeServer.close(() => resolve());
+  });
+  server = undefined;
+});
+
+beforeEach(() => {
+  lifecycle.authorize.mockReset();
+  lifecycle.authorize.mockResolvedValue({ cfg: {}, requestAuth: { ok: true } });
+  lifecycle.beforeHook.mockClear();
+  lifecycle.cleanup.mockReset();
+  lifecycle.handled.mockReset();
+  lifecycle.sendJson.mockReset();
+  lifecycle.watch.mockReset();
+  lifecycle.execute.mockReset();
+  lifecycle.execute.mockResolvedValue({ ok: true });
+});
+
+function invokeAbortProbe(signal?: AbortSignal): Promise<Response> {
+  return fetch(`http://127.0.0.1:${serverPort}/tools/invoke`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ tool: "abort_probe", args: {} }),
+    signal,
+  });
+}
+
+describe("POST /tools/invoke request cancellation", () => {
+  it("never attaches a disconnect watcher to an unauthorized request", async () => {
+    lifecycle.authorize.mockImplementationOnce(async ({ res }) => {
+      res.statusCode = 401;
+      res.end("unauthorized");
+      return undefined;
+    });
+
+    const response = await invokeAbortProbe();
+
+    expect(response.status).toBe(401);
+    expect(lifecycle.watch).not.toHaveBeenCalled();
+    expect(lifecycle.execute).not.toHaveBeenCalled();
+    expect(lifecycle.cleanup).not.toHaveBeenCalled();
+  });
+
+  it("does not start a tool after the client disconnects during authorization", async () => {
+    let reportAuthorizationStarted: ((req: IncomingMessage) => void) | undefined;
+    let releaseAuthorization: (() => void) | undefined;
+    const authorizationStarted = new Promise<IncomingMessage>((resolve) => {
+      reportAuthorizationStarted = resolve;
+    });
+    const authorizationReleased = new Promise<void>((resolve) => {
+      releaseAuthorization = resolve;
+    });
+
+    lifecycle.authorize.mockImplementationOnce(async ({ req }) => {
+      reportAuthorizationStarted?.(req);
+      await authorizationReleased;
+      return { cfg: {}, requestAuth: { ok: true } };
+    });
+
+    const requestController = new AbortController();
+    const response = invokeAbortProbe(requestController.signal);
+
+    try {
+      const serverRequest = await authorizationStarted;
+      requestController.abort();
+      await expect(response).rejects.toThrow();
+      await expect.poll(() => serverRequest.socket.destroyed).toBe(true);
+
+      releaseAuthorization?.();
+      await expect.poll(() => lifecycle.handled.mock.calls.length).toBe(1);
+      expect(lifecycle.watch).not.toHaveBeenCalled();
+      expect(lifecycle.execute).not.toHaveBeenCalled();
+      expect(lifecycle.sendJson).not.toHaveBeenCalled();
+    } finally {
+      releaseAuthorization?.();
+      requestController.abort();
+      await response.catch(() => undefined);
+    }
+  });
+
+  it("passes a request-owned abort signal to the tool and releases its disconnect watcher", async () => {
+    const response = await invokeAbortProbe();
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({ ok: true, result: { ok: true } });
+    expect(lifecycle.execute).toHaveBeenCalledTimes(1);
+
+    const toolSignal = lifecycle.execute.mock.calls[0]?.[2];
+    expect(toolSignal).toBeInstanceOf(AbortSignal);
+    expect(toolSignal?.aborted).toBe(false);
+    expect(lifecycle.beforeHook).toHaveBeenCalledWith(
+      expect.objectContaining({ signal: toolSignal }),
+    );
+    expect(lifecycle.cleanup).toHaveBeenCalledTimes(1);
+  });
+
+  it("aborts the running tool when its HTTP client disconnects", async () => {
+    let reportStarted: ((signal: AbortSignal | undefined) => void) | undefined;
+    let releaseExecution: (() => void) | undefined;
+    const executionStarted = new Promise<AbortSignal | undefined>((resolve) => {
+      reportStarted = resolve;
+    });
+
+    lifecycle.execute.mockImplementation(async (_toolCallId, _args, signal) => {
+      reportStarted?.(signal);
+      await new Promise<void>((resolve) => {
+        releaseExecution = resolve;
+        signal?.addEventListener("abort", () => resolve(), { once: true });
+      });
+      return { ok: true };
+    });
+
+    const requestController = new AbortController();
+    const response = invokeAbortProbe(requestController.signal);
+
+    try {
+      const toolSignal = await executionStarted;
+      expect(toolSignal).toBeInstanceOf(AbortSignal);
+
+      requestController.abort();
+      await expect(response).rejects.toThrow();
+      await expect.poll(() => toolSignal?.aborted).toBe(true);
+      await expect.poll(() => lifecycle.cleanup.mock.calls.length).toBe(1);
+      expect(lifecycle.sendJson).not.toHaveBeenCalled();
+    } finally {
+      requestController.abort();
+      releaseExecution?.();
+      await response.catch(() => undefined);
+    }
+  });
+
+  it("does not start a tool after the client disconnects during its policy hook", async () => {
+    let reportHookStarted: ((signal: AbortSignal | undefined) => void) | undefined;
+    let releaseHook: (() => void) | undefined;
+    const hookStarted = new Promise<AbortSignal | undefined>((resolve) => {
+      reportHookStarted = resolve;
+    });
+    const hookReleased = new Promise<void>((resolve) => {
+      releaseHook = resolve;
+    });
+
+    lifecycle.beforeHook.mockImplementationOnce(async ({ params, signal }) => {
+      reportHookStarted?.(signal);
+      await hookReleased;
+      return { blocked: false as const, params };
+    });
+
+    const requestController = new AbortController();
+    const response = invokeAbortProbe(requestController.signal);
+
+    try {
+      const hookSignal = await hookStarted;
+      expect(hookSignal).toBeInstanceOf(AbortSignal);
+
+      requestController.abort();
+      await expect(response).rejects.toThrow();
+      await expect.poll(() => hookSignal?.aborted).toBe(true);
+
+      releaseHook?.();
+      await expect.poll(() => lifecycle.handled.mock.calls.length).toBe(1);
+      expect(lifecycle.execute).not.toHaveBeenCalled();
+      expect(lifecycle.sendJson).not.toHaveBeenCalled();
+      expect(lifecycle.cleanup).toHaveBeenCalledTimes(1);
+    } finally {
+      releaseHook?.();
+      requestController.abort();
+      await response.catch(() => undefined);
+    }
+  });
+
+  it("releases its disconnect watcher when tool execution fails", async () => {
+    lifecycle.execute.mockRejectedValueOnce(new Error("probe failed"));
+
+    const response = await invokeAbortProbe();
+
+    expect(response.status).toBe(500);
+    await expect(response.json()).resolves.toEqual({
+      ok: false,
+      error: { type: "tool_error", message: "tool execution failed" },
+    });
+    expect(lifecycle.cleanup).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/gateway/tools-invoke-http.ts
+++ b/src/gateway/tools-invoke-http.ts
@@ -4,7 +4,12 @@ import { normalizeOptionalString } from "@openclaw/normalization-core/string-coe
 import { normalizeMessageChannel } from "../utils/message-channel.js";
 import type { AuthRateLimiter } from "./auth-rate-limit.js";
 import type { ResolvedGatewayAuth } from "./auth.js";
-import { readJsonBodyOrError, sendJson, sendMethodNotAllowed } from "./http-common.js";
+import {
+  readJsonBodyOrError,
+  sendJson,
+  sendMethodNotAllowed,
+  watchClientDisconnect,
+} from "./http-common.js";
 import {
   authorizeScopedGatewayHttpRequestOrReply,
   getHeader,
@@ -61,36 +66,53 @@ export async function handleToolsInvokeHttpRequest(
     return true;
   }
   const { cfg, requestAuth } = authResult;
-
-  const bodyUnknown = await readJsonBodyOrError(req, res, opts.maxBodyBytes ?? DEFAULT_BODY_BYTES);
-  if (bodyUnknown === undefined) {
+  if (req.socket.destroyed || res.destroyed || res.socket?.destroyed) {
     return true;
   }
-  const body = (bodyUnknown ?? {}) as ToolsInvokeInput;
+  const abortController = new AbortController();
+  const stopWatchingDisconnect = watchClientDisconnect(req, res, abortController);
 
-  // Resolve message channel/account hints (optional headers) for policy inheritance.
-  const messageChannel = normalizeMessageChannel(
-    getHeader(req, "x-openclaw-message-channel") ?? "",
-  );
-  const accountId = normalizeOptionalString(getHeader(req, "x-openclaw-account-id"));
-  const agentTo = normalizeOptionalString(getHeader(req, "x-openclaw-message-to"));
-  const agentThreadId = normalizeOptionalString(getHeader(req, "x-openclaw-thread-id"));
-  const senderIsOwner = resolveOpenAiCompatibleHttpSenderIsOwner(req, requestAuth);
-  const outcome = await invokeGatewayTool({
-    cfg,
-    input: body,
-    messageChannel: messageChannel ?? undefined,
-    accountId,
-    agentTo,
-    agentThreadId,
-    senderIsOwner,
-    conversationReadOrigin: "direct-operator",
-    toolCallIdPrefix: "http",
-  });
-  if (outcome.ok) {
-    sendJson(res, outcome.status, { ok: true, result: outcome.result });
-  } else {
-    sendJson(res, outcome.status, { ok: false, error: outcome.error });
+  try {
+    const bodyUnknown = await readJsonBodyOrError(
+      req,
+      res,
+      opts.maxBodyBytes ?? DEFAULT_BODY_BYTES,
+    );
+    if (bodyUnknown === undefined || abortController.signal.aborted) {
+      return true;
+    }
+    const body = (bodyUnknown ?? {}) as ToolsInvokeInput;
+
+    // Resolve message channel/account hints (optional headers) for policy inheritance.
+    const messageChannel = normalizeMessageChannel(
+      getHeader(req, "x-openclaw-message-channel") ?? "",
+    );
+    const accountId = normalizeOptionalString(getHeader(req, "x-openclaw-account-id"));
+    const agentTo = normalizeOptionalString(getHeader(req, "x-openclaw-message-to"));
+    const agentThreadId = normalizeOptionalString(getHeader(req, "x-openclaw-thread-id"));
+    const senderIsOwner = resolveOpenAiCompatibleHttpSenderIsOwner(req, requestAuth);
+    const outcome = await invokeGatewayTool({
+      cfg,
+      input: body,
+      messageChannel: messageChannel ?? undefined,
+      accountId,
+      agentTo,
+      agentThreadId,
+      senderIsOwner,
+      conversationReadOrigin: "direct-operator",
+      toolCallIdPrefix: "http",
+      signal: abortController.signal,
+    });
+    if (abortController.signal.aborted) {
+      return true;
+    }
+    if (outcome.ok) {
+      sendJson(res, outcome.status, { ok: true, result: outcome.result });
+    } else {
+      sendJson(res, outcome.status, { ok: false, error: outcome.error });
+    }
+  } finally {
+    stopWatchingDisconnect();
   }
 
   return true;

--- a/src/gateway/tools-invoke-shared.ts
+++ b/src/gateway/tools-invoke-shared.ts
@@ -169,6 +169,7 @@ export async function invokeGatewayTool(params: {
   conversationReadOrigin?: ConversationReadInvocationOrigin;
   toolCallIdPrefix: string;
   approvalMode?: "request" | "report";
+  signal?: AbortSignal;
 }): Promise<ToolsInvokeOutcome> {
   const conversationReadOrigin = normalizeConversationReadInvocationOrigin(
     params.conversationReadOrigin,
@@ -294,6 +295,7 @@ export async function invokeGatewayTool(params: {
         workspaceDir,
         loopDetection: resolveToolLoopDetectionConfig({ cfg: params.cfg, agentId }),
       },
+      signal: params.signal,
       approvalMode: params.approvalMode,
     });
     if (hookResult.blocked) {
@@ -308,12 +310,13 @@ export async function invokeGatewayTool(params: {
         },
       };
     }
+    params.signal?.throwIfAborted();
     return {
       ok: true,
       status: 200,
       toolName,
       source: resolveToolSource(gatewayTool),
-      result: await gatewayTool.execute?.(toolCallId, hookResult.params),
+      result: await gatewayTool.execute?.(toolCallId, hookResult.params, params.signal),
     };
   } catch (err) {
     const inputStatus = resolveToolInputErrorStatus(err);
@@ -328,7 +331,9 @@ export async function invokeGatewayTool(params: {
         },
       };
     }
-    logWarn(`tools-invoke: tool execution failed: ${String(err)}`);
+    if (!params.signal?.aborted) {
+      logWarn(`tools-invoke: tool execution failed: ${String(err)}`);
+    }
     return {
       ok: false,
       status: 500,


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where clients invoking Gateway tools over HTTP could disconnect while authorization, request parsing, tool approval, or execution was still in progress, but the Gateway would continue the abandoned work or attempt to write its response to a closed connection.

## Why This Change Was Made

Connect the existing `watchClientDisconnect` lifecycle to the existing typed tool and approval `AbortSignal`. Begin watching immediately after successful authorization, reject sockets that already closed during authorization, guard execution after asynchronous policy approval, suppress expected cancellation logging, and release socket listeners on every successful, failed, or canceled path.

This is intentionally limited to HTTP tool invocation and signal-aware tool/policy execution. It does not change Gateway authentication, RPC behavior, the node protocol, plugin SDK, stored configuration, or credentials. Paired-node transport and Ollama cancellation are separate owner-boundary follow-ups.

## User Impact

Disconnected HTTP requests no longer start or continue signal-aware tool work, wait unnecessarily for canceled policy approvals, write to dead sockets, or leave disconnect listeners attached. Unauthorized requests still terminate before a watcher is installed, and ordinary Gateway RPC and HTTP tool behavior remain unchanged.

## Evidence

- Reproduced the original defect on baseline `545716528937dfd1394629fcdc042870208b8814`: the new real-socket HTTP cancellation tests failed before the production fix.
- Added six focused real-HTTP regressions covering unauthorized requests, disconnect during authorization, signal delivery into policy and execution, disconnect during pending approval, disconnect during execution, successful completion, error cleanup, and no response after disconnect.
- Existing Gateway HTTP, authentication, policy, cron, RPC, and disconnect-helper suites: **4 files, 83 tests passed**.
- `OPENCLAW_HEAVY_CHECK_LOCK_SCOPE=worktree OPENCLAW_VITEST_MAX_WORKERS=1 OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=/tmp/openclaw-node-hardening-54571652-http-abort-vitest node scripts/run-vitest.mjs src/gateway/tools-invoke-http.abort.test.ts src/gateway/tools-invoke-http.test.ts src/gateway/tools-invoke-http.cron-regression.test.ts src/gateway/http-common.test.ts`
- Remote Blacksmith Testbox `tbx_01kyp0nrcgx0150y6smv10yjtc`: `node scripts/check-changed.mjs -- src/gateway/tools-invoke-http.ts src/gateway/tools-invoke-shared.ts src/gateway/tools-invoke-http.abort.test.ts` — passed formatting, production and test typechecks, lint, plugin and API contracts, dependency guards, dead-export checks, import cycles, and database/pairing guards. Run: https://github.com/openclaw/openclaw/actions/runs/30421235059. The backing lease may show cancellation after successful delegated cleanup; the authoritative Testbox timing JSON reports `exitCode: 0` and `runStatus: succeeded`.
- `.agents/skills/autoreview/scripts/autoreview --mode uncommitted` — clean, with no accepted or actionable findings.
- AI-assisted: yes. No private prompts, credentials, or session transcripts are included.