### PR TITLE
fix(msteams): prevent hook-bypassing previews [AI-assisted]

### DIFF
--- a/extensions/msteams/src/reply-dispatcher.test.ts
+++ b/extensions/msteams/src/reply-dispatcher.test.ts
@@ -4,6 +4,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 const createChannelMessageReplyPipelineMock = vi.hoisted(() => vi.fn());
 const getMSTeamsRuntimeMock = vi.hoisted(() => vi.fn());
 const enqueueSystemEventMock = vi.hoisted(() => vi.fn());
+const getGlobalHookRunnerMock = vi.hoisted(() => vi.fn());
 const renderReplyPayloadsToMessagesMock = vi.hoisted(() => vi.fn(() => []));
 const sendMSTeamsMessagesMock = vi.hoisted(() => vi.fn(async () => []));
 
@@ -15,6 +16,11 @@ vi.mock("../runtime-api.js", () => ({
 
 vi.mock("./runtime.js", () => ({
   getMSTeamsRuntime: getMSTeamsRuntimeMock,
+}));
+
+vi.mock("openclaw/plugin-sdk/plugin-runtime", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("openclaw/plugin-sdk/plugin-runtime")>()),
+  getGlobalHookRunner: getGlobalHookRunnerMock,
 }));
 
 vi.mock("./messenger.js", () => ({
@@ -68,6 +74,7 @@ describe("createMSTeamsReplyDispatcher", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    getGlobalHookRunnerMock.mockReturnValue(undefined);
     lastStreamMock = undefined;
 
     typingCallbacks = {
@@ -212,6 +219,13 @@ describe("createMSTeamsReplyDispatcher", () => {
       throw new Error("createDispatcher must be called first");
     }
     lastCreatedDispatcher.replyOptions.onPartialReply?.({ text });
+  }
+
+  function registerHooks(...hooks: string[]): void {
+    const registered = new Set(hooks);
+    getGlobalHookRunnerMock.mockReturnValue({
+      hasHooks: vi.fn((hookName: string) => registered.has(hookName)),
+    });
   }
 
   it("sends an informative status update once work expands in personal chats", async () => {
@@ -388,6 +402,53 @@ describe("createMSTeamsReplyDispatcher", () => {
     // TeamsHttpStream.update). The SDK's HttpStream accumulates the text
     // and flushes the closing activity at stream.close().
     expect(getStreamMock().emit).toHaveBeenCalledWith("partial response");
+  });
+
+  it("preserves partial and progress streams for observer-only hooks", async () => {
+    registerHooks("message_sent");
+
+    const partialDispatcher = createDispatcher("personal");
+    partialDispatcher.replyOptions.onPartialReply?.({ text: "partial response" });
+    expect(getStreamMock().emit).toHaveBeenCalledWith("partial response");
+
+    vi.useFakeTimers();
+    const progressDispatcher = createDispatcher("personal", {
+      streaming: { mode: "progress" },
+    });
+    await progressDispatcher.replyOptions.onToolStart?.({ name: "exec" });
+    await vi.advanceTimersByTimeAsync(5_000);
+    expect(getStreamMock().update).toHaveBeenCalled();
+  });
+
+  it.each(
+    [
+      { label: "reply_payload_sending", hooks: ["reply_payload_sending"] },
+      { label: "message_sending", hooks: ["message_sending"] },
+      {
+        label: "both modifying hooks",
+        hooks: ["reply_payload_sending", "message_sending"],
+      },
+    ].flatMap(({ label, hooks }) =>
+      (["partial", "progress"] as const).map((mode) => ({ label, hooks, mode })),
+    ),
+  )("suppresses $mode provider streams when $label is registered", async ({ hooks, mode }) => {
+    registerHooks(...hooks);
+    renderReplyPayloadsToMessagesMock.mockReturnValue([{ content: "final" }] as never);
+    sendMSTeamsMessagesMock.mockResolvedValue(["final-id"] as never);
+
+    const dispatcher = createDispatcher("personal", { streaming: { mode } });
+    dispatcher.replyOptions.onPartialReply?.({ text: "original partial" });
+    await dispatcher.replyOptions.onToolStart?.({ name: "exec" });
+    await dispatcher.delivery.deliver({ text: "authoritative final" }, { kind: "final" });
+    await dispatcher.dispatcherOptions.onSettled?.();
+
+    const stream = getStreamMock();
+    expect(dispatcher.replyOptions.onPartialReply).toBeUndefined();
+    expect(dispatcher.replyOptions.onToolStart).toBeUndefined();
+    expect(dispatcher.replyOptions.suppressDefaultToolProgressMessages).toBeUndefined();
+    expect(stream.emit).not.toHaveBeenCalled();
+    expect(stream.update).not.toHaveBeenCalled();
+    expect(sendMSTeamsMessagesMock).toHaveBeenCalledTimes(1);
   });
 
   it("falls back to normal Teams delivery when native stream close returns no final activity", async () => {

--- a/extensions/msteams/src/reply-dispatcher.ts
+++ b/extensions/msteams/src/reply-dispatcher.ts
@@ -10,6 +10,7 @@ import {
   resolveChannelStreamingPreviewToolProgress,
   resolveChannelStreamingSuppressDefaultToolProgressMessages,
 } from "openclaw/plugin-sdk/channel-outbound";
+import { getGlobalHookRunner } from "openclaw/plugin-sdk/plugin-runtime";
 import { normalizeOptionalLowercaseString } from "openclaw/plugin-sdk/string-coerce-runtime";
 import {
   createChannelMessageReplyPipeline,
@@ -166,7 +167,15 @@ export function createMSTeamsReplyDispatcher(params: {
     resolveChannelLimitMb: ({ cfg }) => cfg.channels?.msteams?.mediaMaxMb,
   });
   const feedbackLoopEnabled = params.cfg.channels?.msteams?.feedbackEnabled !== false;
+  // Teams native streams are provider-visible before outbound modifiers run. Keep them off
+  // whenever a hook can rewrite or cancel so the original payload cannot escape the final gate.
+  const hookRunner = getGlobalHookRunner();
+  const allowProviderPreview = !(
+    (hookRunner?.hasHooks("reply_payload_sending") ?? false) ||
+    (hookRunner?.hasHooks("message_sending") ?? false)
+  );
   const streamController = createTeamsReplyStreamController({
+    allowProviderPreview,
     conversationType,
     context: params.context,
     feedbackLoopEnabled,
@@ -377,6 +386,7 @@ export function createMSTeamsReplyDispatcher(params: {
   const suppressDefaultToolProgressMessages =
     resolveChannelStreamingSuppressDefaultToolProgressMessages(msteamsCfg);
   const shouldSuppressDefaultToolProgressMessages =
+    streamController.hasStream() &&
     teamsStreamMode === "progress" &&
     suppressDefaultToolProgressMessages &&
     previewToolProgressEnabled;

--- a/extensions/msteams/src/reply-stream-controller.test.ts
+++ b/extensions/msteams/src/reply-stream-controller.test.ts
@@ -19,10 +19,15 @@ function makeContext(stream?: ReturnType<typeof makeStream>) {
 }
 
 function makeController(
-  opts: { conversationType?: string; stream?: ReturnType<typeof makeStream> } = {},
+  opts: {
+    allowProviderPreview?: boolean;
+    conversationType?: string;
+    stream?: ReturnType<typeof makeStream>;
+  } = {},
 ) {
   const stream = opts.stream;
   return createTeamsReplyStreamController({
+    allowProviderPreview: opts.allowProviderPreview ?? true,
     conversationType: opts.conversationType ?? "personal",
     context: makeContext(stream),
     feedbackLoopEnabled: false,
@@ -35,6 +40,19 @@ describe("createTeamsReplyStreamController", () => {
     const ctrl = makeController({ stream });
     ctrl.onPartialReply({ text: "hello" });
     expect(stream.emit).toHaveBeenCalledWith("hello");
+  });
+
+  it("falls back to normal delivery when provider previews are disabled", () => {
+    const stream = makeStream();
+    const ctrl = makeController({ allowProviderPreview: false, stream });
+
+    ctrl.onPartialReply({ text: "original partial" });
+
+    expect(ctrl.hasStream()).toBe(false);
+    expect(stream.emit).not.toHaveBeenCalled();
+    expect(ctrl.preparePayload({ text: "authoritative final" })).toEqual({
+      text: "authoritative final",
+    });
   });
 
   it("emits only the delta when openclaw sends cumulative text on each chunk", () => {
@@ -270,6 +288,7 @@ describe("createTeamsReplyStreamController", () => {
     const stream = makeStream();
     try {
       const ctrl = createTeamsReplyStreamController({
+        allowProviderPreview: true,
         conversationType: "personal",
         context: makeContext(stream),
         feedbackLoopEnabled: false,
@@ -300,6 +319,7 @@ describe("createTeamsReplyStreamController", () => {
   it("replaces Teams plan snapshots and keeps the explanation", async () => {
     const stream = makeStream();
     const ctrl = createTeamsReplyStreamController({
+      allowProviderPreview: true,
       conversationType: "personal",
       context: makeContext(stream),
       feedbackLoopEnabled: false,
@@ -327,6 +347,7 @@ describe("createTeamsReplyStreamController", () => {
     const stream = makeStream();
     try {
       const ctrl = createTeamsReplyStreamController({
+        allowProviderPreview: true,
         conversationType: "personal",
         context: makeContext(stream),
         feedbackLoopEnabled: false,
@@ -354,6 +375,7 @@ describe("createTeamsReplyStreamController", () => {
   it("suppresses block delivery when progress final text is emitted to the stream", () => {
     const stream = makeStream();
     const ctrl = createTeamsReplyStreamController({
+      allowProviderPreview: true,
       conversationType: "personal",
       context: makeContext(stream),
       feedbackLoopEnabled: false,
@@ -367,6 +389,7 @@ describe("createTeamsReplyStreamController", () => {
   it("ignores plan updates after final answer streaming starts", async () => {
     const stream = makeStream();
     const ctrl = createTeamsReplyStreamController({
+      allowProviderPreview: true,
       conversationType: "personal",
       context: makeContext(stream),
       feedbackLoopEnabled: false,
@@ -385,6 +408,7 @@ describe("createTeamsReplyStreamController", () => {
       throw new Error("progress final failed");
     });
     const ctrl = createTeamsReplyStreamController({
+      allowProviderPreview: true,
       conversationType: "personal",
       context: makeContext(stream),
       feedbackLoopEnabled: false,
@@ -432,6 +456,7 @@ describe("createTeamsReplyStreamController", () => {
         throw makeCancelError();
       });
       const ctrl = createTeamsReplyStreamController({
+        allowProviderPreview: true,
         conversationType: "personal",
         context: makeContext(stream),
         feedbackLoopEnabled: false,

--- a/extensions/msteams/src/reply-stream-controller.ts
+++ b/extensions/msteams/src/reply-stream-controller.ts
@@ -44,6 +44,7 @@ function isStreamCancelledError(err: unknown): boolean {
  *   block message. We bypass the controller in that case.
  */
 export function createTeamsReplyStreamController(params: {
+  allowProviderPreview: boolean;
   conversationType?: string;
   context: MSTeamsTurnContext;
   feedbackLoopEnabled: boolean;
@@ -59,7 +60,9 @@ export function createTeamsReplyStreamController(params: {
   const isPersonal = normalizeOptionalLowercaseString(params.conversationType) === "personal";
   const streamMode = resolveChannelPreviewStreamMode(params.msteamsConfig, "partial");
   const shouldUseNativeStream =
-    isPersonal && (streamMode === "partial" || streamMode === "progress");
+    params.allowProviderPreview &&
+    isPersonal &&
+    (streamMode === "partial" || streamMode === "progress");
   const shouldStreamPreviewToolProgress =
     streamMode === "progress" && resolveChannelStreamingPreviewToolProgress(params.msteamsConfig);
 


### PR DESCRIPTION
Related: #92374

## What Problem This Solves

Fixes an issue where Microsoft Teams users could see partial replies or progress cards
before outbound modifier hooks accepted the message. If `reply_payload_sending` or
`message_sending` later rewrote or cancelled that reply, the original content had
already escaped through Teams' provider-visible native stream and could remain visible.

## Why This Change Was Made

Microsoft Teams now creates its personal-chat native partial/progress stream only when
no modifier-capable outbound hook is registered. Hook-enabled turns use the existing
post-hook block-delivery path, so only the authoritative payload can reach Teams.

This is deliberately Teams-owned and matches the established sibling-channel safety
policy. It adds no core, Plugin SDK, config, protocol, storage, dependency, or migration
surface. Observer-only hooks retain native streaming, and normal block-style tool
progress remains available whenever the native stream is gated.

## User Impact

Deployments using outbound moderation, DLP, rewrite, or cancellation plugins no longer
leak pre-hook Microsoft Teams previews. Deployments with no modifying hooks, including
observer-only hooks such as `message_sent`, retain normal Teams streaming UX.

The conservative tradeoff is intentional: registering a modifier disables Teams native
previews even for an individual reply the hook ultimately leaves unchanged, because the
decision is not knowable until after the provider-visible operation would have begun.

## Evidence

- External Teams UI necessity proof: before the fix, delayed cancellation at either
  modifier left the original bot content visible in the dedicated QA personal chat.
- External Teams UI candidate proof on the frozen implementation base:
  - no-hook native streaming remained visible;
  - both rewrites produced exactly one authoritative final and no unmodified final;
  - `reply_payload_sending` cancellation produced no SUT preview or final;
  - `message_sending` cancellation produced no SUT preview or final.
- Rebased exact-head Blacksmith Testbox proof:
  - Microsoft Teams plugin: 79 files, 1,202/1,202 assertions passed;
  - `check:changed`: extension production/test typechecks, lint, formatting, boundary,
    API, dependency, dead-code, database-first, and import-cycle guards passed.
  - Run: https://github.com/openclaw/openclaw/actions/runs/30421319131
- Fresh branch autoreview against `origin/main`: no findings; patch correct at 0.96
  confidence.
- `git diff --check`: passed.

AI-assisted: yes. I understand the implementation and validated the provider-owned
preview boundary, fallback delivery behavior, sibling policy, tests, and live Teams UX.
