### PR TITLE
fix(onboard): reject reset scope without reset

### DIFF
--- a/src/commands/onboard.test.ts
+++ b/src/commands/onboard.test.ts
@@ -377,6 +377,26 @@ describe("setupWizardCommand", () => {
     expect(mocks.runNonInteractiveSetup).not.toHaveBeenCalled();
   });
 
+  it("rejects --reset-scope without --reset", async () => {
+    const runtime = makeRuntime();
+
+    await setupWizardCommand(
+      {
+        resetScope: "full",
+      },
+      runtime,
+    );
+
+    expect(runtime.error).toHaveBeenCalledWith(
+      "--reset-scope requires --reset. Re-run with openclaw onboard --reset --reset-scope full.",
+    );
+    expect(runtime.exit).toHaveBeenCalledWith(1);
+    expect(mocks.handleReset).not.toHaveBeenCalled();
+    expect(mocks.runInteractiveSetup).not.toHaveBeenCalled();
+    expect(mocks.runNonInteractiveSetup).not.toHaveBeenCalled();
+    expect(mocks.runGuidedOnboarding).not.toHaveBeenCalled();
+  });
+
   it("fails fast for invalid non-interactive --mode before reset", async () => {
     const runtime = makeRuntime();
 

--- a/src/commands/onboard.ts
+++ b/src/commands/onboard.ts
@@ -492,6 +492,13 @@ export async function setupWizardCommand(
     runtime.exit(1);
     return;
   }
+  if (normalizedOpts.resetScope && !normalizedOpts.reset) {
+    runtime.error(
+      `--reset-scope requires --reset. Re-run with ${formatCliCommand(`openclaw onboard --reset --reset-scope ${normalizedOpts.resetScope}`)}.`,
+    );
+    runtime.exit(1);
+    return;
+  }
 
   if (normalizedOpts.nonInteractive && normalizedOpts.acceptRisk !== true) {
     // Non-interactive setup can write credentials and daemon config without a


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where `openclaw onboard --reset-scope <scope>` succeeded without `--reset`, even though no reset ran. Automation could therefore report successful full/config reset setup while preserving all of the state the operator intended to reset.

## Why This Change Was Made

The existing reset-scope option now fails fast unless its owning `--reset` action is present. Invalid scope values still receive the existing value-specific error first, and valid `--reset --reset-scope ...` behavior is unchanged.

This PR is AI-assisted. I reviewed the complete validation/dispatch path and exercised both public `onboard` and `setup` entry points.

## User Impact

Operators and scripts now get an actionable nonzero error instead of a false-success onboarding run when `--reset` was accidentally omitted.

## Evidence

- Before on the unchanged current-main validation path: `openclaw onboard --non-interactive ... --reset-scope full` exited 0 and performed ordinary onboarding without calling reset.
- After at `6b445573fa79087acdfcf9b0bbf164355189df11`: both `onboard` and `setup` exit 1 with `--reset-scope requires --reset`, and neither writes config/state. An invalid scope still emits `Invalid --reset-scope`.
- Source-blind CLI behavior contract: satisfied for both entry points, validation ordering, nonzero exits, and no-write behavior.
- Focused local regression: `node scripts/run-vitest.mjs src/commands/onboard.test.ts` — 48/48 passed on the rebased head.
- Blacksmith Testbox `tbx_01kyp18jaf0y8rdyhr7zvedbpe`: 103/103 focused CLI/onboarding assertions passed, followed by a clean `check:changed`. Workflow: https://github.com/openclaw/openclaw/actions/runs/30421717767
- Fresh rebased-head autoreview: clean, no accepted/actionable findings.
