### PR TITLE
fix(ollama): honor paired-node local inference deadlines

### DIFF
--- a/extensions/ollama/src/node-inference.deadline.test.ts
+++ b/extensions/ollama/src/node-inference.deadline.test.ts
@@ -1,0 +1,156 @@
+import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
+import type { Socket } from "node:net";
+import type { LookupFn } from "openclaw/plugin-sdk/ssrf-runtime";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createOllamaNodeHostCommands } from "./node-inference.js";
+import { fetchOllamaModels } from "./provider-models.js";
+
+const CHAT_MODEL = "deadline-model:latest";
+const CHAT_COMMAND = "ollama.chat";
+
+async function withDelayedOllamaServer<T>(
+  delays: Partial<Record<"/api/tags" | "/api/show" | "/api/chat", number>>,
+  run: (baseUrl: string, requestedPaths: string[]) => Promise<T>,
+): Promise<T> {
+  const requestedPaths: string[] = [];
+  const sockets = new Set<Socket>();
+  const handleRequest = async (request: IncomingMessage, response: ServerResponse) => {
+    const requestPath = request.url;
+    if (requestPath !== "/api/tags" && requestPath !== "/api/show" && requestPath !== "/api/chat") {
+      response.writeHead(404).end();
+      return;
+    }
+    requestedPaths.push(requestPath);
+    const bodyChunks: Buffer[] = [];
+    for await (const chunk of request) {
+      bodyChunks.push(Buffer.from(chunk));
+    }
+    if (requestPath !== "/api/tags" && Buffer.concat(bodyChunks).length === 0) {
+      throw new Error("Ollama deadline test received an empty POST body");
+    }
+    const delayMs = delays[requestPath];
+    if (delayMs !== undefined) {
+      await new Promise<void>((resolve) => {
+        setTimeout(resolve, delayMs);
+      });
+    }
+    if (response.destroyed) {
+      return;
+    }
+    response.setHeader("Content-Type", "application/json");
+    if (requestPath === "/api/tags") {
+      response.end(JSON.stringify({ models: [{ name: CHAT_MODEL }] }));
+      return;
+    }
+    if (requestPath === "/api/show") {
+      response.end(
+        JSON.stringify({
+          capabilities: ["completion", "tools"],
+          model_info: { "test.context_length": 32_768 },
+        }),
+      );
+      return;
+    }
+    response.end(
+      JSON.stringify({
+        model: CHAT_MODEL,
+        message: { content: "within the requested deadline" },
+        done_reason: "stop",
+      }),
+    );
+  };
+  const server = createServer((request, response) => {
+    void handleRequest(request, response);
+  });
+  server.on("connection", (socket) => {
+    sockets.add(socket);
+    socket.once("close", () => sockets.delete(socket));
+  });
+  await new Promise<void>((resolve) => {
+    server.listen(0, "127.0.0.1", resolve);
+  });
+  const address = server.address();
+  if (!address || typeof address === "string") {
+    throw new Error("Ollama deadline test server did not expose a TCP address");
+  }
+  try {
+    return await run(`http://127.0.0.1:${address.port}`, requestedPaths);
+  } finally {
+    const closed = new Promise<void>((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+    for (const socket of sockets) {
+      socket.destroy();
+    }
+    await closed;
+  }
+}
+
+function runNodeChat(baseUrl: string, timeoutMs: number): Promise<string> {
+  const chatCommand = createOllamaNodeHostCommands({ baseUrl }).find(
+    (entry) => entry.command === CHAT_COMMAND,
+  );
+  if (!chatCommand) {
+    throw new Error("Ollama node host did not expose its chat command");
+  }
+  return chatCommand.handle(
+    JSON.stringify({ model: CHAT_MODEL, prompt: "answer within the deadline", timeoutMs }),
+  );
+}
+
+describe("Ollama node inference deadline", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it.each([
+    ["/api/tags", ["/api/tags"]],
+    ["/api/show", ["/api/tags", "/api/show"]],
+    ["/api/chat", ["/api/tags", "/api/show", "/api/chat"]],
+  ] as const)("bounds a stalled %s request by the inference deadline", async (slowPath, paths) => {
+    await withDelayedOllamaServer({ [slowPath]: 900 }, async (baseUrl, requestedPaths) => {
+      const startedAtMs = performance.now();
+
+      await expect(runNodeChat(baseUrl, 250)).rejects.toThrow(/timed out|unavailable/);
+
+      expect(performance.now() - startedAtMs).toBeLessThan(2_000);
+      expect(requestedPaths).toEqual(paths);
+    });
+  });
+
+  it("shares one deadline across successful catalog and model preflight", async () => {
+    await withDelayedOllamaServer(
+      { "/api/tags": 160, "/api/show": 160, "/api/chat": 160 },
+      async (baseUrl, requestedPaths) => {
+        const startedAtMs = performance.now();
+
+        await expect(runNodeChat(baseUrl, 400)).rejects.toThrow(/timed out|unavailable/);
+
+        expect(performance.now() - startedAtMs).toBeLessThan(2_000);
+        expect(requestedPaths.slice(0, 2)).toEqual(["/api/tags", "/api/show"]);
+      },
+    );
+  });
+
+  it("applies the requested catalog timeout to guarded DNS preflight", async () => {
+    vi.stubEnv("OPENCLAW_PROXY_ACTIVE", "0");
+    const stalledLookup = vi.fn(() => new Promise<never>(() => {})) as unknown as LookupFn;
+    const fetchSpy = vi.fn(async () => new Response("DNS should not complete"));
+    const startedAtMs = performance.now();
+
+    await expect(
+      fetchOllamaModels(
+        "https://ollama.example.com",
+        { timeoutMs: 150 },
+        {
+          lookupFn: stalledLookup,
+          fetchImpl: fetchSpy,
+        },
+      ),
+    ).resolves.toEqual({ reachable: false, models: [] });
+
+    expect(performance.now() - startedAtMs).toBeLessThan(2_000);
+    expect(stalledLookup).toHaveBeenCalled();
+    expect(fetchSpy).not.toHaveBeenCalled();
+  }, 10_000);
+});

--- a/extensions/ollama/src/node-inference.test.ts
+++ b/extensions/ollama/src/node-inference.test.ts
@@ -476,7 +476,7 @@ describe("node_inference agent tool", () => {
         maxTokens: 32,
         timeoutMs: 120_000,
       },
-      timeoutMs: 130_000,
+      timeoutMs: 120_000,
       scopes: ["operator.write"],
     });
     expect(result.details).toMatchObject({

--- a/extensions/ollama/src/node-inference.ts
+++ b/extensions/ollama/src/node-inference.ts
@@ -37,7 +37,6 @@ const OLLAMA_NODE_INFERENCE_COMMANDS = [OLLAMA_MODELS_COMMAND, OLLAMA_CHAT_COMMA
 const DEFAULT_INFERENCE_TIMEOUT_MS = 120_000;
 const DEFAULT_MAX_TOKENS = 512;
 const DISCOVERY_TRANSPORT_TIMEOUT_MS = 90_000;
-const INFERENCE_TRANSPORT_GRACE_MS = 10_000;
 const MAX_INFERENCE_TIMEOUT_MS = 10 * 60_000;
 const MAX_TOKENS = 8192;
 const MAX_PROMPT_CHARS = 128_000;
@@ -249,13 +248,26 @@ async function runOllamaNodeChat(params: {
   timeoutMs: number;
 }): Promise<OllamaChatPayload> {
   const apiBase = resolveOllamaApiBase(params.baseUrl);
-  const discovered = await fetchOllamaModels(apiBase);
+  const deadlineMs = performance.now() + params.timeoutMs;
+  const remainingTimeoutMs = (): number => {
+    const remainingMs = Math.ceil(deadlineMs - performance.now());
+    if (remainingMs <= 0) {
+      throw new Error(`Ollama node inference timed out after ${params.timeoutMs}ms`);
+    }
+    return remainingMs;
+  };
+  const discovered = await fetchOllamaModels(apiBase, { timeoutMs: remainingTimeoutMs() });
   const localModel = discovered.models.find(
     (model) =>
       model.name === params.model && !model.remote_host?.trim() && !isOllamaCloudModel(model.name),
   );
-  const [model] = localModel ? await enrichOllamaModelsWithContext(apiBase, [localModel]) : [];
+  const [model] = localModel
+    ? await enrichOllamaModelsWithContext(apiBase, [localModel], {
+        timeoutMs: remainingTimeoutMs(),
+      })
+    : [];
   if (!discovered.reachable || model?.capabilities?.includes("completion") !== true) {
+    remainingTimeoutMs();
     throw new Error(
       `Ollama model ${JSON.stringify(params.model)} is not a local chat model; discover models first`,
     );
@@ -275,7 +287,7 @@ async function runOllamaNodeChat(params: {
   }>({
     baseUrl: params.baseUrl,
     path: "/api/chat",
-    timeoutMs: params.timeoutMs,
+    timeoutMs: remainingTimeoutMs(),
     init: {
       method: "POST",
       headers: { "Content-Type": "application/json" },
@@ -540,9 +552,7 @@ export function createOllamaNodeInferenceTool(api: OpenClawPluginApi): AnyAgentT
         node.nodeId,
         OLLAMA_CHAT_COMMAND,
         commandParams,
-        // The command validates the selected model before starting its chat timeout.
-        // Keep that bounded preflight outside the inference budget seen by users.
-        timeoutMs + INFERENCE_TRANSPORT_GRACE_MS,
+        timeoutMs,
       );
       return jsonResult({
         nodeId: node.nodeId,

--- a/extensions/ollama/src/provider-models.ts
+++ b/extensions/ollama/src/provider-models.ts
@@ -40,6 +40,8 @@ export type OllamaModelWithContext = OllamaTagModel & {
 
 const OLLAMA_SHOW_CONCURRENCY = 8;
 const OLLAMA_CONTEXT_ENRICH_LIMIT = 200;
+const OLLAMA_SHOW_TIMEOUT_MS = 3000;
+const OLLAMA_TAGS_TIMEOUT_MS = 5000;
 const MAX_OLLAMA_DISCOVERY_PROBES = OLLAMA_CONTEXT_ENRICH_LIMIT * 4;
 const MAX_OLLAMA_SHOW_CACHE_ENTRIES = 256;
 const ollamaModelShowInfoCache = new Map<string, Promise<OllamaModelShowInfo>>();
@@ -133,7 +135,7 @@ function parseOllamaNumCtxParameter(parameters: unknown): number | undefined {
 export async function queryOllamaModelShowInfo(
   apiBase: string,
   modelName: string,
-  opts?: { apiKey?: string },
+  opts?: { apiKey?: string; timeoutMs?: number },
 ): Promise<OllamaModelShowInfo> {
   const normalizedApiBase = resolveOllamaApiBase(apiBase);
   try {
@@ -149,7 +151,7 @@ export async function queryOllamaModelShowInfo(
         body: JSON.stringify({ name: modelName }),
       },
       // Guard-owned timeoutMs also bounds DNS/proxy preflight; init.signal does not.
-      timeoutMs: 3000,
+      timeoutMs: Math.min(opts?.timeoutMs ?? OLLAMA_SHOW_TIMEOUT_MS, OLLAMA_SHOW_TIMEOUT_MS),
       policy: buildOllamaBaseUrlSsrFPolicy(normalizedApiBase),
       auditContext: "ollama-provider-models.show",
     });
@@ -202,11 +204,12 @@ export async function queryOllamaModelShowInfo(
 async function queryOllamaModelShowInfoCached(
   apiBase: string,
   model: Pick<OllamaTagModel, "name" | "digest" | "modified_at">,
-  opts?: { apiKey?: string },
+  opts?: { apiKey?: string; timeoutMs?: number },
 ): Promise<OllamaModelShowInfo> {
   const normalizedApiBase = resolveOllamaApiBase(apiBase);
   const cacheKey = buildOllamaModelShowCacheKey(normalizedApiBase, model, opts?.apiKey);
-  if (!cacheKey) {
+  // Request-scoped deadlines must not shorten an unrelated shared catalog probe.
+  if (!cacheKey || opts?.timeoutMs !== undefined) {
     return await queryOllamaModelShowInfo(normalizedApiBase, model.name, opts);
   }
 
@@ -236,7 +239,7 @@ export async function queryOllamaContextWindow(
 export async function enrichOllamaModelsWithContext(
   apiBase: string,
   models: OllamaTagModel[],
-  opts?: { apiKey?: string; concurrency?: number },
+  opts?: { apiKey?: string; concurrency?: number; timeoutMs?: number },
 ): Promise<OllamaModelWithContext[]> {
   const concurrency = Math.max(1, Math.floor(opts?.concurrency ?? OLLAMA_SHOW_CONCURRENCY));
   const enriched: OllamaModelWithContext[] = [];
@@ -244,11 +247,7 @@ export async function enrichOllamaModelsWithContext(
     const batch = models.slice(index, index + concurrency);
     const batchResults = await Promise.all(
       batch.map(async (model) => {
-        const showInfo = await queryOllamaModelShowInfoCached(
-          apiBase,
-          model,
-          opts?.apiKey ? { apiKey: opts.apiKey } : undefined,
-        );
+        const showInfo = await queryOllamaModelShowInfoCached(apiBase, model, opts);
         return Object.assign({}, model, {
           contextWindow: showInfo.contextWindow,
           capabilities: showInfo.capabilities,
@@ -390,7 +389,7 @@ type OllamaModelsFetchDeps = {
 
 export async function fetchOllamaModels(
   baseUrl: string,
-  opts?: { apiKey?: string },
+  opts?: { apiKey?: string; timeoutMs?: number },
   deps?: OllamaModelsFetchDeps,
 ): Promise<{ reachable: boolean; models: OllamaTagModel[] }> {
   try {
@@ -401,7 +400,7 @@ export async function fetchOllamaModels(
         headers: opts?.apiKey ? { Authorization: `Bearer ${opts.apiKey}` } : undefined,
       },
       // Guard-owned timeoutMs also bounds DNS/proxy preflight; init.signal does not.
-      timeoutMs: 5000,
+      timeoutMs: Math.min(opts?.timeoutMs ?? OLLAMA_TAGS_TIMEOUT_MS, OLLAMA_TAGS_TIMEOUT_MS),
       policy: buildOllamaBaseUrlSsrFPolicy(apiBase),
       auditContext: "ollama-provider-models.tags",
       ...(deps?.fetchImpl ? { fetchImpl: deps.fetchImpl } : {}),


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users running a local Ollama model on a paired node could wait beyond the requested inference timeout because catalog discovery and model inspection each started an additional independent timeout before chat generation began. A stalled DNS or proxy preflight could also consume its original five-second catalog timeout even when the caller requested a much shorter inference deadline.

## Why This Change Was Made

Give the Ollama node host one monotonic deadline spanning catalog discovery, guarded DNS/proxy preflight, model capability inspection, and chat. Retain the existing five-second catalog and three-second model-inspection ceilings, keep SSRF policy and positive completion-capability verification unchanged, and bypass the shared metadata cache for request-scoped probes so one caller's short deadline cannot degrade unrelated catalog discovery. Remove the obsolete extra ten-second node-transport grace rather than adding another fallback or configuration option.

## User Impact

Paired-node local inference now respects its requested timeout throughout the actual Ollama operation, fails quickly when discovery stalls, and continues to reject remote and non-chat models. Existing provider discovery and onboarding retain their established timeout behavior.

## Evidence

- Reproduced the regression on frozen baseline `545716528937dfd1394629fcdc042870208b8814`: four deadline regressions failed, including guarded DNS preflight taking 5,004 ms for a requested 35 ms.
- `OPENCLAW_HEAVY_CHECK_LOCK_SCOPE=worktree OPENCLAW_VITEST_MAX_WORKERS=1 OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=/tmp/openclaw-node-hardening-54571652-ollama-deadline-vitest node scripts/run-vitest.mjs extensions/ollama/src/node-inference.deadline.test.ts extensions/ollama/src/node-inference.test.ts extensions/ollama/src/provider-models.test.ts extensions/ollama/src/provider-models.ssrf.test.ts extensions/ollama/src/provider-models.preflight-timeout.test.ts`: **5 files, 53 tests passed**.
- `.agents/skills/autoreview/scripts/autoreview --mode uncommitted`: **clean; no accepted or actionable findings** after preserving existing probe ceilings and making timing regressions CI-stable.
- `OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_HEAVY_CHECK_LOCK_SCOPE=worktree OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/check-changed.mjs -- extensions/ollama/src/node-inference.ts extensions/ollama/src/node-inference.test.ts extensions/ollama/src/node-inference.deadline.test.ts extensions/ollama/src/provider-models.ts`: **all exact-path checks passed**, including extension and extension-test typechecks, lint, formatting, SDK API, plugin boundaries, dead exports, database-first guards, and runtime import cycles.
- The delegated Blacksmith run independently passed the extension production and test typechecks, SDK and plugin boundaries, dead-export checks, and zero-error changed-file lint before its backend API timed out. The complete gate was then rerun locally using the repository-approved trusted-source fallback. Its package-manager subprocess warned that its Node was 24.14.0; supported-Node hosted PR CI is still required before landing.
- The independently managed real Ollama host exposed `gemma4:e2b`, `qwen3:0.6b`, and `qwen3:1.7b`; the campaign independently verified an actual `qwen3:0.6b` response with a bounded 512-token context. This provider proof is not represented as a Gateway-to-paired-node integration run.

## AI Assistance

Developed with Codex, independently reviewed with the repository's isolated autoreview workflow, and manually validated against the actual Ollama owner, SSRF guard, cache, callers, and sibling tests. No conversation transcripts or credentials are included.