### PR TITLE
feat(ui): add contextual Settings documentation links

### DIFF
--- a/docs/cli/mcp.md
+++ b/docs/cli/mcp.md
@@ -809,6 +809,8 @@ Registry commands do not start the channel bridge. Only `probe` and `doctor --pr
 
 The browser Control UI includes a dedicated MCP settings page at `/settings/mcp`; the previous `/mcp` path remains an alias. The page shows configured server counts, enabled/OAuth/filter summaries, per-server transport rows, enable/disable controls, common CLI commands, and a scoped editor for the `mcp` config section.
 
+For a shorter setup walkthrough covering Settings, CLI, and direct config, see [Connect MCP servers](/tools/mcp).
+
 Use the page for operator edits and quick inventory. Use `openclaw mcp doctor --probe` or `openclaw mcp probe` when you need live server proof.
 
 Operator workflow:
@@ -900,5 +902,6 @@ Current limits:
 
 ## Related
 
+- [Connect MCP servers](/tools/mcp)
 - [CLI reference](/cli)
 - [Plugins](/cli/plugins)

--- a/docs/concepts/agent-bindings.md
+++ b/docs/concepts/agent-bindings.md
@@ -1,0 +1,120 @@
+---
+summary: "Route channel accounts and conversations to the right OpenClaw agent"
+title: "Agent bindings"
+read_when:
+  - Routing channel accounts to different agents
+  - Sending one conversation to a specialized agent
+  - Deciding whether the default agent is sufficient
+---
+
+An agent binding routes an inbound channel conversation to a configured agent. Each binding names an `agentId` and matches channel facts such as the account, peer, guild, team, or Discord roles. Bindings choose the agent that owns the resulting session; they do not create channel accounts or change channel access policy.
+
+## When to use a binding
+
+Use the default agent when every unmatched conversation should share one workspace, model policy, and session boundary. With no matching binding, OpenClaw routes inbound traffic to the agent marked `default: true`.
+
+Add bindings when you need a stable split such as:
+
+- one channel account per agent
+- a support inbox routed to a support workspace
+- one direct message or group routed to a specialist
+- a guild, team, or Discord role routed differently from the rest of an account
+
+Configure the channel account first. A binding only selects an agent after that channel has accepted the inbound message through its normal pairing, allowlist, and account rules.
+
+## Route an account to an agent
+
+This example keeps `main` as the fallback and routes the Discord account named `support` to a separate agent:
+
+```json5
+{
+  agents: {
+    entries: {
+      main: {
+        default: true,
+        workspace: "~/.openclaw/workspace",
+      },
+      support: {
+        workspace: "~/.openclaw/workspace-support",
+      },
+    },
+  },
+  bindings: [
+    {
+      agentId: "support",
+      comment: "Route the support bot account to the support agent",
+      match: {
+        channel: "discord",
+        accountId: "support",
+      },
+    },
+  ],
+}
+```
+
+Messages on the `support` account now resolve to `agentId: "support"`. Other Discord accounts and other channels continue to use `main` unless another binding matches.
+
+Restart the Gateway after changing routing config, then verify the roster and channel accounts:
+
+```bash
+openclaw agents list --bindings
+openclaw channels status --probe
+```
+
+## Match a specific conversation
+
+Add `match.peer` when only one direct message, group, or channel should use the specialized agent:
+
+```json5
+{
+  bindings: [
+    {
+      agentId: "support",
+      match: {
+        channel: "discord",
+        accountId: "default",
+        peer: {
+          kind: "channel",
+          id: "123456789012345678",
+        },
+      },
+    },
+  ],
+}
+```
+
+`peer.kind` accepts `direct`, `group`, or `channel`. Use the channel's canonical peer ID rather than a display name.
+
+## Match fields and precedence
+
+Every binding requires `agentId` and `match.channel`. Optional route-match fields are:
+
+- `accountId`: one configured account; omitted matches only the channel's default account, while `"*"` is a channel-wide fallback
+- `peer`: a concrete or wildcard direct, group, or channel peer
+- `guildId` and `teamId`: channel-specific group-space constraints
+- `roles`: Discord role IDs, evaluated with the guild constraint
+- `session.dmScope`: an optional session-scoping override for matched direct messages
+
+More specific conversation and group-space matches win before account and channel fallbacks. Within the same match tier, the first binding in config order wins. Put narrow rules before broader rules when they share a tier.
+
+Top-level `bindings` also accepts explicit `type: "acp"` entries for persistent ACP conversations. Those require a concrete `match.peer.id` and follow the ACP conversation identity contract rather than ordinary route precedence. See [ACP agents](/tools/acp-agents) when that is the behavior you need.
+
+## Common mistakes
+
+### Omitting accountId to mean every account
+
+An omitted `accountId` matches only the channel's default account. Use `accountId: "*"` for an intentional channel-wide fallback.
+
+### Binding to an unknown agent
+
+The `agentId` must exist under `agents.entries`. Keep exactly one configured entry marked `default: true`.
+
+### Treating bindings as access control
+
+Bindings choose an agent after a message is admitted. Keep channel pairing, `dmPolicy`, group policy, and allowlists configured independently.
+
+## Related
+
+- [Multi-agent routing](/concepts/multi-agent)
+- [Agent configuration](/gateway/config-agents)
+- [Channel routing](/channels/channel-routing)

--- a/docs/concepts/agent-bindings.md
+++ b/docs/concepts/agent-bindings.md
@@ -7,24 +7,24 @@ read_when:
   - Deciding whether the default agent is sufficient
 ---
 
-An agent binding routes an inbound channel conversation to a configured agent. Each binding names an `agentId` and matches channel facts such as the account, peer, guild, team, or Discord roles. Bindings choose the agent that owns the resulting session; they do not create channel accounts or change channel access policy.
+When a message arrives on a channel, OpenClaw has to decide which agent answers it. By default that is easy: the agent marked `default: true` gets everything. An agent binding overrides that decision for a slice of your traffic — each binding names an `agentId` and matches channel facts such as the account, peer, guild, team, or Discord roles, and the matched agent owns the resulting session.
+
+Bindings only pick the agent. They do not create channel accounts and they do not grant access — a binding is consulted only after the channel has already accepted the message through its normal pairing, allowlist, and account rules.
 
 ## When to use a binding
 
-Use the default agent when every unmatched conversation should share one workspace, model policy, and session boundary. With no matching binding, OpenClaw routes inbound traffic to the agent marked `default: true`.
-
-Add bindings when you need a stable split such as:
+If every conversation can share one workspace, one model policy, and one session boundary, you do not need bindings — the default agent is the right answer. Reach for bindings when you want a stable split, for example:
 
 - one channel account per agent
 - a support inbox routed to a support workspace
 - one direct message or group routed to a specialist
 - a guild, team, or Discord role routed differently from the rest of an account
 
-Configure the channel account first. A binding only selects an agent after that channel has accepted the inbound message through its normal pairing, allowlist, and account rules.
+Configure the channel account first, then bind it. A binding pointing at an account the channel never accepts does nothing.
 
 ## Route an account to an agent
 
-This example keeps `main` as the fallback and routes the Discord account named `support` to a separate agent:
+This example keeps `main` as the fallback and routes the Discord account named `support` to its own agent and workspace:
 
 ```json5
 {
@@ -52,9 +52,9 @@ This example keeps `main` as the fallback and routes the Discord account named `
 }
 ```
 
-Messages on the `support` account now resolve to `agentId: "support"`. Other Discord accounts and other channels continue to use `main` unless another binding matches.
+Messages on the `support` account now resolve to `agentId: "support"`; every other Discord account and every other channel keeps using `main` unless another binding matches.
 
-Restart the Gateway after changing routing config, then verify the roster and channel accounts:
+Routing config is read at startup, so restart the Gateway, then verify the roster and channel accounts:
 
 ```bash
 openclaw agents list --bindings
@@ -63,7 +63,7 @@ openclaw channels status --probe
 
 ## Match a specific conversation
 
-Add `match.peer` when only one direct message, group, or channel should use the specialized agent:
+Add `match.peer` when only one direct message, group, or channel should reach the specialized agent:
 
 ```json5
 {
@@ -83,35 +83,35 @@ Add `match.peer` when only one direct message, group, or channel should use the 
 }
 ```
 
-`peer.kind` accepts `direct`, `group`, or `channel`. Use the channel's canonical peer ID rather than a display name.
+`peer.kind` accepts `direct`, `group`, or `channel`. Use the channel's canonical peer ID, not a display name.
 
 ## Match fields and precedence
 
-Every binding requires `agentId` and `match.channel`. Optional route-match fields are:
+Every binding requires `agentId` and `match.channel`. The optional route-match fields:
 
-- `accountId`: one configured account; omitted matches only the channel's default account, while `"*"` is a channel-wide fallback
+- `accountId`: one configured account. Omitting it matches only the channel's default account; `"*"` is an explicit channel-wide fallback.
 - `peer`: a concrete or wildcard direct, group, or channel peer
 - `guildId` and `teamId`: channel-specific group-space constraints
-- `roles`: Discord role IDs, evaluated with the guild constraint
+- `roles`: Discord role IDs, evaluated together with the guild constraint
 - `session.dmScope`: an optional session-scoping override for matched direct messages
 
-More specific conversation and group-space matches win before account and channel fallbacks. Within the same match tier, the first binding in config order wins. Put narrow rules before broader rules when they share a tier.
+Precedence is by specificity: concrete conversation and group-space matches win over account and channel fallbacks. Within the same tier, the first binding in config order wins — put narrow rules before broad ones when they share a tier.
 
-Top-level `bindings` also accepts explicit `type: "acp"` entries for persistent ACP conversations. Those require a concrete `match.peer.id` and follow the ACP conversation identity contract rather than ordinary route precedence. See [ACP agents](/tools/acp-agents) when that is the behavior you need.
+Top-level `bindings` also accepts `type: "acp"` entries for persistent ACP conversations. Those require a concrete `match.peer.id` and follow the ACP conversation identity contract instead of ordinary route precedence; see [ACP agents](/tools/acp-agents) when that is what you need.
 
 ## Common mistakes
 
 ### Omitting accountId to mean every account
 
-An omitted `accountId` matches only the channel's default account. Use `accountId: "*"` for an intentional channel-wide fallback.
+An omitted `accountId` matches only the channel's default account. If you want a channel-wide fallback, say so explicitly with `accountId: "*"`.
 
 ### Binding to an unknown agent
 
-The `agentId` must exist under `agents.entries`. Keep exactly one configured entry marked `default: true`.
+The `agentId` must exist under `agents.entries`, and exactly one entry should be marked `default: true`. A binding that references a missing agent misroutes silently.
 
 ### Treating bindings as access control
 
-Bindings choose an agent after a message is admitted. Keep channel pairing, `dmPolicy`, group policy, and allowlists configured independently.
+Bindings choose an agent for messages that were already admitted. Pairing, `dmPolicy`, group policy, and allowlists are separate controls — configure them independently.
 
 ## Related
 

--- a/docs/concepts/multi-agent.md
+++ b/docs/concepts/multi-agent.md
@@ -10,6 +10,8 @@ Run multiple _isolated_ agents in one Gateway process, each with its own workspa
 
 An **agent** is the full per-persona scope: workspace files, auth profiles, model registry, and session store. A **binding** maps a channel account (a Slack workspace, a WhatsApp number, etc.) to one of those agents.
 
+For a focused setup guide with account and conversation examples, see [Agent bindings](/concepts/agent-bindings).
+
 ## What is one agent
 
 Each agent has its own:

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1267,6 +1267,7 @@
                 "group": "Multi-agent",
                 "pages": [
                   "concepts/multi-agent",
+                  "concepts/agent-bindings",
                   "concepts/parallel-specialist-lanes",
                   "concepts/presence",
                   "concepts/delegate-architecture"
@@ -1386,6 +1387,7 @@
                   "tools/llm-task",
                   "tools/lobster",
                   "tools/media-overview",
+                  "tools/mcp",
                   "tools/music-generation",
                   "tools/pdf",
                   "tools/reactions",
@@ -1766,6 +1768,7 @@
                 "pages": [
                   "web/index",
                   "web/control-ui",
+                  "web/notifications",
                   "web/urls",
                   "web/dashboard",
                   "web/dashboards",

--- a/docs/docs_map.md
+++ b/docs/docs_map.md
@@ -10952,7 +10952,7 @@ Do not edit it by hand; run `pnpm docs:map:gen`.
 
 - Route: /web/notifications
 - Headings:
-  - H2: Choose your notification surface
+  - H2: Which surface you get
   - H2: Enable browser notifications
   - H2: Enable notifications in the macOS app
   - H2: Troubleshooting

--- a/docs/docs_map.md
+++ b/docs/docs_map.md
@@ -2305,6 +2305,20 @@ Do not edit it by hand; run `pnpm docs:map:gen`.
   - H2: Common issues
   - H2: Related pages
 
+## concepts/agent-bindings.md
+
+- Route: /concepts/agent-bindings
+- Headings:
+  - H2: When to use a binding
+  - H2: Route an account to an agent
+  - H2: Match a specific conversation
+  - H2: Match fields and precedence
+  - H2: Common mistakes
+  - H3: Omitting accountId to mean every account
+  - H3: Binding to an unknown agent
+  - H3: Treating bindings as access control
+  - H2: Related
+
 ## concepts/agent-loop.md
 
 - Route: /concepts/agent-loop
@@ -10289,6 +10303,20 @@ Do not edit it by hand; run `pnpm docs:map:gen`.
   - H2: Logs and expected behavior
   - H2: Related
 
+## tools/mcp.md
+
+- Route: /tools/mcp
+- Headings:
+  - H2: Add a server from Settings
+  - H2: Add a server from the CLI
+  - H2: Configure a server directly
+  - H2: Troubleshooting
+  - H3: The server appears in Settings but exposes no tools
+  - H3: A stdio server does not start
+  - H3: An HTTP server needs authorization
+  - H3: Changes do not reach an active agent
+  - H2: Related
+
 ## tools/media-overview.md
 
 - Route: /tools/media-overview
@@ -10919,6 +10947,20 @@ Do not edit it by hand; run `pnpm docs:map:gen`.
   - H2: The Lobsterdex
   - H2: Field notes
   - H2: Privacy
+
+## web/notifications.md
+
+- Route: /web/notifications
+- Headings:
+  - H2: Choose your notification surface
+  - H2: Enable browser notifications
+  - H2: Enable notifications in the macOS app
+  - H2: Troubleshooting
+  - H3: Enable is unavailable
+  - H3: Browser permission is blocked
+  - H3: Service worker is not ready
+  - H3: Web Push asks for a Doctor migration
+  - H2: Related
 
 ## web/tui.md
 

--- a/docs/tools/mcp.md
+++ b/docs/tools/mcp.md
@@ -7,33 +7,33 @@ read_when:
   - Troubleshooting MCP transport, OAuth, or tool discovery
 ---
 
-The Model Context Protocol (MCP) lets an agent use tools, resources, and prompts exposed by another process or service. OpenClaw keeps outbound server definitions under `mcp.servers`, connects eligible runtimes to enabled servers, and applies normal tool-profile and tool-policy controls to the tools they expose.
+The Model Context Protocol (MCP) is how an agent borrows tools from another program: an MCP server exposes tools, resources, and prompts, and OpenClaw connects to it and makes those tools available to your agents. Server definitions live under `mcp.servers` in config, and the tools they expose go through the same tool-profile and tool-policy controls as everything else — connecting a server does not bypass your policy.
 
 <Note>
-This guide connects third-party MCP servers **to OpenClaw**. To expose OpenClaw channel conversations to another MCP client, use [`openclaw mcp serve`](/cli/mcp#openclaw-as-an-mcp-server).
+This guide is about connecting third-party MCP servers **to OpenClaw**. For the reverse — exposing OpenClaw channel conversations to another MCP client — use [`openclaw mcp serve`](/cli/mcp#openclaw-as-an-mcp-server).
 </Note>
 
 ## Add a server from Settings
 
-1. Open the Control UI and choose **Settings → MCP**.
-2. In **Configured servers**, select **Add server**.
-3. Enter a unique name and choose **Streamable HTTP**, **SSE**, or **Stdio**.
-4. For HTTP transports, enter an `http://` or `https://` URL. For stdio, enter the command followed by its arguments.
+1. Open the Control UI and go to **Settings → MCP**.
+2. Under **Configured servers**, select **Add server**.
+3. Give it a unique name and pick a transport: **Streamable HTTP**, **SSE**, or **Stdio**.
+4. For the HTTP transports, enter the server's `http://` or `https://` URL. For stdio, enter the command followed by its arguments.
 5. Select **Add server**.
 
-The page saves the new `mcp.servers` entry through the Gateway config path. Use the scoped editor farther down the page for headers, environment values, OAuth metadata, TLS settings, timeouts, parallel-tool-call hints, or tool filters. Server rows can also enable, disable, or remove definitions.
+That writes the new `mcp.servers` entry through the Gateway. For anything beyond the basics — headers, environment values, OAuth metadata, TLS settings, timeouts, parallel-tool-call hints, tool filters — use the scoped config editor further down the page. The server rows also let you enable, disable, or remove a definition.
 
-Run a live probe after setup:
+Once the server is saved, verify it actually answers:
 
 ```bash
 openclaw mcp doctor <name> --probe
 ```
 
-Settings changes do not prove the remote service is reachable. Active Gateway or agent processes may also need a restart or runtime rebuild before they use the new definition.
+Saving a definition proves nothing about reachability — the probe does. Note that already-running Gateway or agent processes may need a restart or runtime reload before they pick up the new definition.
 
 ## Add a server from the CLI
 
-For a local stdio server:
+A local stdio server:
 
 ```bash
 openclaw mcp add local-tools \
@@ -43,7 +43,7 @@ openclaw mcp add local-tools \
 openclaw mcp doctor local-tools --probe
 ```
 
-For a remote Streamable HTTP server:
+A remote Streamable HTTP server, exposing only some of its tools:
 
 ```bash
 openclaw mcp add docs \
@@ -53,11 +53,11 @@ openclaw mcp add docs \
 openclaw mcp doctor docs --probe
 ```
 
-Use `openclaw mcp status --verbose` for a config-only summary, `openclaw mcp probe <name>` for live capabilities, and `openclaw mcp login <name>` when an HTTP server uses OAuth. The [MCP CLI reference](/cli/mcp) documents every command, flag, output shape, and the separate `mcp serve` bridge.
+Useful companions: `openclaw mcp status --verbose` for a config-only summary, `openclaw mcp probe <name>` for live capabilities, and `openclaw mcp login <name>` when an HTTP server uses OAuth. The [MCP CLI reference](/cli/mcp) documents every command, flag, and output shape, plus the separate `mcp serve` bridge.
 
 ## Configure a server directly
 
-This example registers a remote server and exposes only its read tools:
+The same `docs` server, written straight into config:
 
 ```json5
 {
@@ -78,31 +78,31 @@ This example registers a remote server and exposes only its read tools:
 }
 ```
 
-An enabled server needs either a command for stdio or a URL for SSE or Streamable HTTP. `enabled: false` keeps the definition but excludes it from embedded runtime discovery. Store sensitive headers and environment values through the supported secret mechanisms instead of committing literal credentials.
+An enabled server needs either a command (stdio) or a URL (SSE or Streamable HTTP). Setting `enabled: false` keeps the definition around without connecting it. Keep credentials out of config literals — store sensitive headers and environment values through the supported secret mechanisms.
 
 ## Troubleshooting
 
 ### The server appears in Settings but exposes no tools
 
-Run `openclaw mcp doctor <name> --probe`. Doctor checks the saved definition before opening a live connection; the probe then reports tools and other advertised capabilities. Check `toolFilter.include` and `toolFilter.exclude` if the server connects but expected tools remain hidden.
+Run `openclaw mcp doctor <name> --probe`. Doctor validates the saved definition first, then opens a live connection and reports the tools and other capabilities the server advertises. If it connects but expected tools are missing, check `toolFilter.include` and `toolFilter.exclude`.
 
 ### A stdio server does not start
 
-Confirm that `command` resolves in the Gateway process environment and that `cwd` exists. Arguments belong in `args`; an explicit `transport: "stdio"` requires a non-empty command.
+Confirm the `command` resolves in the Gateway process environment and that `cwd` exists. Arguments belong in `args`, and an explicit `transport: "stdio"` requires a non-empty command.
 
 ### An HTTP server needs authorization
 
-Set `auth: "oauth"` and any required `oauth` metadata, then run:
+Set `auth: "oauth"` plus any required `oauth` metadata, then:
 
 ```bash
 openclaw mcp login <name>
 ```
 
-Follow the printed authorization URL and rerun with `--code` when requested.
+Follow the printed authorization URL and rerun with `--code` when prompted.
 
 ### Changes do not reach an active agent
 
-Run `openclaw mcp reload` for runtimes owned by the current CLI process. Gateway and agent processes in another process need their own reload, config publish, or restart path.
+`openclaw mcp reload` refreshes runtimes owned by the current CLI process. A Gateway or agent running elsewhere needs its own reload, config publish, or restart.
 
 ## Related
 

--- a/docs/tools/mcp.md
+++ b/docs/tools/mcp.md
@@ -1,0 +1,111 @@
+---
+summary: "Connect MCP servers to OpenClaw from Settings, the CLI, or config"
+title: "Connect MCP servers"
+read_when:
+  - Adding an MCP server for OpenClaw agents
+  - Choosing between Settings and `openclaw mcp`
+  - Troubleshooting MCP transport, OAuth, or tool discovery
+---
+
+The Model Context Protocol (MCP) lets an agent use tools, resources, and prompts exposed by another process or service. OpenClaw keeps outbound server definitions under `mcp.servers`, connects eligible runtimes to enabled servers, and applies normal tool-profile and tool-policy controls to the tools they expose.
+
+<Note>
+This guide connects third-party MCP servers **to OpenClaw**. To expose OpenClaw channel conversations to another MCP client, use [`openclaw mcp serve`](/cli/mcp#openclaw-as-an-mcp-server).
+</Note>
+
+## Add a server from Settings
+
+1. Open the Control UI and choose **Settings → MCP**.
+2. In **Configured servers**, select **Add server**.
+3. Enter a unique name and choose **Streamable HTTP**, **SSE**, or **Stdio**.
+4. For HTTP transports, enter an `http://` or `https://` URL. For stdio, enter the command followed by its arguments.
+5. Select **Add server**.
+
+The page saves the new `mcp.servers` entry through the Gateway config path. Use the scoped editor farther down the page for headers, environment values, OAuth metadata, TLS settings, timeouts, parallel-tool-call hints, or tool filters. Server rows can also enable, disable, or remove definitions.
+
+Run a live probe after setup:
+
+```bash
+openclaw mcp doctor <name> --probe
+```
+
+Settings changes do not prove the remote service is reachable. Active Gateway or agent processes may also need a restart or runtime rebuild before they use the new definition.
+
+## Add a server from the CLI
+
+For a local stdio server:
+
+```bash
+openclaw mcp add local-tools \
+  --command node \
+  --arg ./dist/mcp-server.js \
+  --cwd /srv/openclaw-tools
+openclaw mcp doctor local-tools --probe
+```
+
+For a remote Streamable HTTP server:
+
+```bash
+openclaw mcp add docs \
+  --url https://mcp.example.com/mcp \
+  --transport streamable-http \
+  --include 'search,read_*'
+openclaw mcp doctor docs --probe
+```
+
+Use `openclaw mcp status --verbose` for a config-only summary, `openclaw mcp probe <name>` for live capabilities, and `openclaw mcp login <name>` when an HTTP server uses OAuth. The [MCP CLI reference](/cli/mcp) documents every command, flag, output shape, and the separate `mcp serve` bridge.
+
+## Configure a server directly
+
+This example registers a remote server and exposes only its read tools:
+
+```json5
+{
+  mcp: {
+    servers: {
+      docs: {
+        url: "https://mcp.example.com/mcp",
+        transport: "streamable-http",
+        enabled: true,
+        connectionTimeoutMs: 5000,
+        requestTimeoutMs: 20000,
+        toolFilter: {
+          include: ["search", "read_*"],
+        },
+      },
+    },
+  },
+}
+```
+
+An enabled server needs either a command for stdio or a URL for SSE or Streamable HTTP. `enabled: false` keeps the definition but excludes it from embedded runtime discovery. Store sensitive headers and environment values through the supported secret mechanisms instead of committing literal credentials.
+
+## Troubleshooting
+
+### The server appears in Settings but exposes no tools
+
+Run `openclaw mcp doctor <name> --probe`. Doctor checks the saved definition before opening a live connection; the probe then reports tools and other advertised capabilities. Check `toolFilter.include` and `toolFilter.exclude` if the server connects but expected tools remain hidden.
+
+### A stdio server does not start
+
+Confirm that `command` resolves in the Gateway process environment and that `cwd` exists. Arguments belong in `args`; an explicit `transport: "stdio"` requires a non-empty command.
+
+### An HTTP server needs authorization
+
+Set `auth: "oauth"` and any required `oauth` metadata, then run:
+
+```bash
+openclaw mcp login <name>
+```
+
+Follow the printed authorization URL and rerun with `--code` when requested.
+
+### Changes do not reach an active agent
+
+Run `openclaw mcp reload` for runtimes owned by the current CLI process. Gateway and agent processes in another process need their own reload, config publish, or restart path.
+
+## Related
+
+- [MCP CLI reference](/cli/mcp)
+- [Manage plugins](/plugins/manage-plugins)
+- [Tool policies](/tools)

--- a/docs/web/control-ui.md
+++ b/docs/web/control-ui.md
@@ -518,6 +518,8 @@ The Control UI ships a `manifest.webmanifest` and a service worker, so modern br
 
 Inside the macOS app, the Notifications settings page shows the app's native notification permission instead of browser push because the app delivers notifications natively.
 
+See [Notifications](/web/notifications) for the browser and macOS setup steps.
+
 If the page shows **Protocol mismatch** right after an OpenClaw update, first reopen the dashboard with `openclaw dashboard` and hard-refresh. If it still fails, clear site data for the dashboard origin or test in a private browser window; an old tab or browser service-worker cache can keep running a pre-update Control UI bundle against the newer Gateway.
 
 | Surface                                            | What it does                                                                 |
@@ -540,7 +542,7 @@ The Control UI uses these scope-gated Gateway methods to register and test brows
 - `push.web.vapidPublicKey` fetches the active VAPID public key.
 - `push.web.subscribe` registers an `endpoint` plus `keys.p256dh`/`keys.auth`.
 - `push.web.unsubscribe` removes a registered endpoint.
-- `push.web.test` sends a test notification to the caller's subscription.
+- `push.web.test` sends a test notification to registered browser subscriptions.
 
 <Note>
 Web Push is independent of the iOS APNS relay path (see [Configuration](/gateway/configuration) for relay-backed push) and the `push.test` method, which targets native mobile pairing.

--- a/docs/web/notifications.md
+++ b/docs/web/notifications.md
@@ -7,52 +7,56 @@ read_when:
   - Comparing Control UI notifications with mobile push
 ---
 
-OpenClaw can notify the browser that runs the Control UI or the native macOS app that embeds it. Open **Settings → Notifications** to configure the current device and send a test. This page does not control channel reaction notifications, Android notification forwarding, or iOS background push.
+OpenClaw can ping you when something needs your attention — in the browser that runs the Control UI, or through native macOS notifications when you use the OpenClaw macOS app. Everything lives under **Settings → Notifications**: enable the current device, check its status, and send yourself a test.
 
-## Choose your notification surface
+This page covers those two surfaces. It does not control channel reaction notifications, Android notification forwarding, or iOS background push — the mobile apps register for push through their own node paths; see [iOS](/platforms/ios) and [Nodes](/nodes).
 
-| Where Settings is open                            | What OpenClaw uses                                 | What the page controls                                                                    |
-| ------------------------------------------------- | -------------------------------------------------- | ----------------------------------------------------------------------------------------- |
-| Supported web browser or installed Control UI PWA | Browser Push API and the Control UI service worker | Browser permission, the current browser subscription, unsubscribe, and test delivery      |
-| OpenClaw macOS app                                | macOS native notifications                         | App permission, a shortcut to System Settings when blocked, and a local test notification |
-| Browser without Push API support                  | No notification transport                          | Status only; enable and test actions stay unavailable                                     |
+## Which surface you get
 
-The macOS app intentionally shows the native permission flow instead of browser push. Mobile apps use their own node and push-registration paths; see [iOS](/platforms/ios) and [Nodes](/nodes).
+What the Notifications page controls depends on where you opened it:
+
+| Where Settings is open                            | Transport                                          | What you can do                                                               |
+| ------------------------------------------------- | -------------------------------------------------- | ----------------------------------------------------------------------------- |
+| Supported web browser or installed Control UI PWA | Browser Push API via the Control UI service worker | Grant permission, subscribe or unsubscribe this browser, send a test          |
+| OpenClaw macOS app                                | Native macOS notifications                         | Grant app permission, jump to System Settings when blocked, send a local test |
+| Browser without Push API support                  | None                                               | Status only; enable and test stay unavailable                                 |
+
+The macOS app deliberately uses the native permission flow instead of browser push — that is the notification system your Mac already respects.
 
 ## Enable browser notifications
 
 1. Open the Control UI in a browser that supports service workers, `PushManager`, and notifications.
-2. Connect the Control UI to the Gateway.
+2. Make sure the Control UI is connected to the Gateway.
 3. Open **Settings → Notifications** and select **Enable notifications**.
-4. Allow notifications in the browser prompt.
-5. Select **Send test**.
+4. Allow notifications when the browser asks.
+5. Select **Send test** — a test notification should arrive within a few seconds.
 
-Enabling creates a browser push subscription and registers its endpoint and keys with the Gateway. The Gateway stores browser subscriptions and its VAPID signing key in `state/openclaw.sqlite`; Settings does not add an `openclaw.json` key. Existing browser subscriptions are reconciled with the Gateway after reconnect.
+Behind the scenes, enabling creates a push subscription in this browser and registers its endpoint and keys with the Gateway. The Gateway keeps browser subscriptions and its VAPID signing key in `state/openclaw.sqlite` — there is no `openclaw.json` key to edit. When the Control UI reconnects, existing subscriptions are reconciled with the Gateway automatically.
 
-**Send test** asks the Gateway to send a Web Push test to its registered browser subscriptions. **Unsubscribe** removes the current browser endpoint from the Gateway and then unsubscribes it locally.
+**Send test** asks the Gateway to push a test message to every registered browser subscription. **Unsubscribe** removes the current browser's endpoint from the Gateway, then unsubscribes locally.
 
 ## Enable notifications in the macOS app
 
 1. Open **Settings → Notifications** in the OpenClaw macOS app.
-2. Select **Enable notifications** when the permission is **Not requested**.
+2. Select **Enable notifications** while the permission shows **Not requested**.
 3. Approve the macOS permission prompt.
 4. Select **Send test** to post a local OpenClaw notification.
 
-If permission is **Denied**, select **Open System Settings**, allow notifications for OpenClaw, and return to the app. The page refreshes permission state when the app regains focus. This permission belongs to macOS and is not stored in Gateway config.
+If the permission shows **Denied**, macOS will not re-prompt: select **Open System Settings**, allow notifications for OpenClaw there, and switch back — the page rechecks permission when the app regains focus. This permission belongs to macOS, not to Gateway config.
 
 ## Troubleshooting
 
 ### Enable is unavailable
 
-The browser either lacks the required Web Push APIs or the Control UI is disconnected from the Gateway. Try a current browser, confirm the Gateway connection, and reload the page.
+Either the browser lacks the required Web Push APIs or the Control UI is not connected to the Gateway. Try a current browser, confirm the Gateway connection, and reload the page.
 
 ### Browser permission is blocked
 
-Allow notifications for the Control UI origin in the browser's site settings, then reload Settings. A denied browser permission cannot be reopened programmatically.
+A denied browser permission cannot be reopened from the page. Allow notifications for the Control UI origin in the browser's site settings, then reload Settings.
 
 ### Service worker is not ready
 
-The Control UI waits up to 10 seconds for its service worker. If that times out after an update, hard-refresh the dashboard. If the old worker remains, clear site data for the dashboard origin and reconnect.
+The Control UI waits up to 10 seconds for its service worker. If that times out right after an update, hard-refresh the page. If an old worker sticks around, clear site data for the dashboard origin and reconnect.
 
 ### Web Push asks for a Doctor migration
 

--- a/docs/web/notifications.md
+++ b/docs/web/notifications.md
@@ -1,0 +1,65 @@
+---
+summary: "Enable and test browser or macOS notifications from the Control UI"
+title: "Notifications"
+read_when:
+  - Enabling notifications from Settings
+  - Troubleshooting browser or macOS notification permission
+  - Comparing Control UI notifications with mobile push
+---
+
+OpenClaw can notify the browser that runs the Control UI or the native macOS app that embeds it. Open **Settings → Notifications** to configure the current device and send a test. This page does not control channel reaction notifications, Android notification forwarding, or iOS background push.
+
+## Choose your notification surface
+
+| Where Settings is open                            | What OpenClaw uses                                 | What the page controls                                                                    |
+| ------------------------------------------------- | -------------------------------------------------- | ----------------------------------------------------------------------------------------- |
+| Supported web browser or installed Control UI PWA | Browser Push API and the Control UI service worker | Browser permission, the current browser subscription, unsubscribe, and test delivery      |
+| OpenClaw macOS app                                | macOS native notifications                         | App permission, a shortcut to System Settings when blocked, and a local test notification |
+| Browser without Push API support                  | No notification transport                          | Status only; enable and test actions stay unavailable                                     |
+
+The macOS app intentionally shows the native permission flow instead of browser push. Mobile apps use their own node and push-registration paths; see [iOS](/platforms/ios) and [Nodes](/nodes).
+
+## Enable browser notifications
+
+1. Open the Control UI in a browser that supports service workers, `PushManager`, and notifications.
+2. Connect the Control UI to the Gateway.
+3. Open **Settings → Notifications** and select **Enable notifications**.
+4. Allow notifications in the browser prompt.
+5. Select **Send test**.
+
+Enabling creates a browser push subscription and registers its endpoint and keys with the Gateway. The Gateway stores browser subscriptions and its VAPID signing key in `state/openclaw.sqlite`; Settings does not add an `openclaw.json` key. Existing browser subscriptions are reconciled with the Gateway after reconnect.
+
+**Send test** asks the Gateway to send a Web Push test to its registered browser subscriptions. **Unsubscribe** removes the current browser endpoint from the Gateway and then unsubscribes it locally.
+
+## Enable notifications in the macOS app
+
+1. Open **Settings → Notifications** in the OpenClaw macOS app.
+2. Select **Enable notifications** when the permission is **Not requested**.
+3. Approve the macOS permission prompt.
+4. Select **Send test** to post a local OpenClaw notification.
+
+If permission is **Denied**, select **Open System Settings**, allow notifications for OpenClaw, and return to the app. The page refreshes permission state when the app regains focus. This permission belongs to macOS and is not stored in Gateway config.
+
+## Troubleshooting
+
+### Enable is unavailable
+
+The browser either lacks the required Web Push APIs or the Control UI is disconnected from the Gateway. Try a current browser, confirm the Gateway connection, and reload the page.
+
+### Browser permission is blocked
+
+Allow notifications for the Control UI origin in the browser's site settings, then reload Settings. A denied browser permission cannot be reopened programmatically.
+
+### Service worker is not ready
+
+The Control UI waits up to 10 seconds for its service worker. If that times out after an update, hard-refresh the dashboard. If the old worker remains, clear site data for the dashboard origin and reconnect.
+
+### Web Push asks for a Doctor migration
+
+Run `openclaw doctor --fix` with the Gateway stopped. Web Push refuses to use the retired JSON stores until Doctor imports them into SQLite.
+
+## Related
+
+- [Control UI PWA and Web Push](/web/control-ui#pwa-install-and-web-push)
+- [iOS push delivery](/platforms/ios)
+- [Node notification commands](/nodes)

--- a/src/config/schema.hints.test.ts
+++ b/src/config/schema.hints.test.ts
@@ -1,3 +1,5 @@
+import { existsSync } from "node:fs";
+import { resolve } from "node:path";
 // Verifies schema hint metadata and sensitive path handling.
 import { isSensitiveUrlConfigPath } from "@openclaw/net-policy/redact-sensitive-url";
 import { describe, expect, it } from "vitest";
@@ -8,7 +10,7 @@ import { isSensitiveConfigPath } from "./sensitive-paths.js";
 import { OpenClawSchema } from "./zod-schema.js";
 import { sensitive } from "./zod-schema.sensitive.js";
 
-const { collectMatchingSchemaPaths, mapSensitivePaths } = testApi;
+const { collectMatchingSchemaPaths, mapSensitivePaths, SECTION_DOCS_URLS } = testApi;
 const BUNDLED_CHANNEL_HINT_PREFIXES = [
   "channels.discord",
   "channels.imessage",
@@ -19,6 +21,30 @@ const BUNDLED_CHANNEL_HINT_PREFIXES = [
   "channels.telegram",
   "channels.whatsapp",
 ] as const;
+
+describe("section docs URLs", () => {
+  it("maps every URL to an existing task-oriented docs page", () => {
+    const hints = buildBaseHints();
+    const docsOrigin = "https://docs.openclaw.ai";
+
+    for (const [path, docsUrl] of Object.entries(SECTION_DOCS_URLS)) {
+      const docsPath = docsUrl.slice(docsOrigin.length).replace(/^\//u, "");
+      const candidates = [
+        resolve(process.cwd(), "docs", `${docsPath}.md`),
+        resolve(process.cwd(), "docs", docsPath, "index.md"),
+      ];
+
+      expect(docsUrl.startsWith(`${docsOrigin}/`), docsUrl).toBe(true);
+      expect(
+        candidates.some((candidate) => existsSync(candidate)),
+        docsUrl,
+      ).toBe(true);
+      expect(hints[path]?.docsUrl, path).toBe(docsUrl);
+    }
+
+    expect(hints.meta?.docsUrl).toBeUndefined();
+  });
+});
 
 describe("isSensitiveConfigPath", () => {
   it("matches whitelist suffixes case-insensitively", () => {

--- a/src/config/schema.hints.ts
+++ b/src/config/schema.hints.ts
@@ -45,6 +45,48 @@ const GROUP_HINTS = [
   ["voicewake", "Voice Wake", 230],
 ] as const;
 
+// docsUrl targets task-oriented or beginner pages; configuration-reference anchors are banned.
+const SECTION_DOCS_URLS = {
+  messages: "https://docs.openclaw.ai/concepts/messages",
+  tts: "https://docs.openclaw.ai/tts",
+  commands: "https://docs.openclaw.ai/tools/slash-commands",
+  hooks: "https://docs.openclaw.ai/automation/hooks",
+  cron: "https://docs.openclaw.ai/automation/cron-jobs",
+  bindings: "https://docs.openclaw.ai/concepts/agent-bindings",
+  plugins: "https://docs.openclaw.ai/plugins/manage-plugins",
+  mcp: "https://docs.openclaw.ai/tools/mcp",
+  memory: "https://docs.openclaw.ai/concepts/memory",
+  talk: "https://docs.openclaw.ai/nodes/talk",
+  gateway: "https://docs.openclaw.ai/gateway/configuration",
+  browser: "https://docs.openclaw.ai/tools/browser",
+  nodeHost: "https://docs.openclaw.ai/nodes",
+  discovery: "https://docs.openclaw.ai/gateway/discovery",
+  acp: "https://docs.openclaw.ai/tools/acp-agents",
+  agents: "https://docs.openclaw.ai/concepts/agent",
+  models: "https://docs.openclaw.ai/concepts/models",
+  skills: "https://docs.openclaw.ai/tools/skills",
+  tools: "https://docs.openclaw.ai/tools",
+  session: "https://docs.openclaw.ai/concepts/session",
+  security: "https://docs.openclaw.ai/gateway/security",
+  approvals: "https://docs.openclaw.ai/tools/exec-approvals",
+  env: "https://docs.openclaw.ai/help/environment",
+  auth: "https://docs.openclaw.ai/concepts/oauth",
+  update: "https://docs.openclaw.ai/install/updating",
+  logging: "https://docs.openclaw.ai/logging",
+  diagnostics: "https://docs.openclaw.ai/gateway/diagnostics",
+  cli: "https://docs.openclaw.ai/cli",
+  secrets: "https://docs.openclaw.ai/gateway/secrets",
+  ui: "https://docs.openclaw.ai/web/control-ui",
+  wizard: "https://docs.openclaw.ai/start/wizard",
+  channels: "https://docs.openclaw.ai/channels",
+  broadcast: "https://docs.openclaw.ai/channels/broadcast-groups",
+  audio: "https://docs.openclaw.ai/nodes/audio",
+  voicewake: "https://docs.openclaw.ai/nodes/voicewake",
+  presence: "https://docs.openclaw.ai/concepts/presence",
+  cloudWorkers: "https://docs.openclaw.ai/gateway/cloud-workers",
+  worktrees: "https://docs.openclaw.ai/concepts/managed-worktrees",
+} as const satisfies Record<string, string>;
+
 const FIELD_PLACEHOLDERS: Record<string, string> = {
   "gateway.remote.url": "ws://host:18789",
   "gateway.remote.tlsFingerprint": "sha256:ab12cd34…",
@@ -87,6 +129,9 @@ export function buildBaseHints(): ConfigUiHints {
       group: label,
       order,
     };
+  }
+  for (const [path, docsUrl] of Object.entries(SECTION_DOCS_URLS)) {
+    hints[path] = { ...hints[path], docsUrl };
   }
   for (const [metadata, field] of [
     [FIELD_LABELS, "label"],
@@ -279,4 +324,5 @@ function mapSensitivePathsMut(schema: z.ZodType, path: string, hints: ConfigUiHi
 export const testApi = {
   collectMatchingSchemaPaths,
   mapSensitivePaths,
+  SECTION_DOCS_URLS,
 };

--- a/src/shared/config-ui-hints-types.ts
+++ b/src/shared/config-ui-hints-types.ts
@@ -4,6 +4,7 @@ export type ConfigUiPresentation = "phone-number";
 export type ConfigUiHint = {
   label?: string;
   help?: string;
+  docsUrl?: string;
   tags?: string[];
   group?: string;
   order?: number;

--- a/ui/src/components/config-form.browser.test.ts
+++ b/ui/src/components/config-form.browser.test.ts
@@ -740,4 +740,49 @@ describe("config form renderer", () => {
     );
     expect(help).toHaveLength(1);
   });
+
+  it("renders section help when the top-level hint has a docs URL", () => {
+    const container = document.createElement("div");
+    render(
+      renderConfigForm({
+        schema: rootAnalysis.schema,
+        uiHints: { gateway: { docsUrl: "https://docs.openclaw.ai/gateway/configuration" } },
+        unsupportedPaths: rootAnalysis.unsupportedPaths,
+        value: {},
+        activeSection: "gateway",
+        onPatch: vi.fn(),
+      }),
+      container,
+    );
+
+    const button = expectElement(
+      container.querySelector<HTMLButtonElement>(".settings-section__help-button"),
+      "section help button",
+    );
+    expect(button.getAttribute("aria-label")).toBe("Help for Gateway");
+    const link = expectElement(
+      container.querySelector<HTMLAnchorElement>(".settings-section__help-popover a"),
+      "section guide link",
+    );
+    expect(link.getAttribute("href")).toBe("https://docs.openclaw.ai/gateway/configuration");
+    expect(link.getAttribute("target")).toBe("_blank");
+    expect(link.getAttribute("rel")).toBe("noopener noreferrer");
+  });
+
+  it("omits section help when the top-level hint has no docs URL", () => {
+    const container = document.createElement("div");
+    render(
+      renderConfigForm({
+        schema: rootAnalysis.schema,
+        uiHints: {},
+        unsupportedPaths: rootAnalysis.unsupportedPaths,
+        value: {},
+        activeSection: "gateway",
+        onPatch: vi.fn(),
+      }),
+      container,
+    );
+
+    expect(container.querySelector(".settings-section__help-button")).toBeNull();
+  });
 });

--- a/ui/src/components/config-form.render.ts
+++ b/ui/src/components/config-form.render.ts
@@ -2,6 +2,8 @@
 import { html, nothing, type TemplateResult } from "lit";
 import type { ConfigUiHints } from "../api/types.ts";
 import { t } from "../i18n/index.ts";
+import { buildExternalLinkRel, EXTERNAL_LINK_TARGET } from "../lib/external-link.ts";
+import "./web-awesome-popover.ts";
 import { SECTION_META } from "./config-form.meta.ts";
 import { renderNode } from "./config-form.node.ts";
 import { matchesConfigSectionSearch, parseConfigSearchQuery } from "./config-form.search.ts";
@@ -210,6 +212,9 @@ export function renderConfigForm(props: ConfigFormProps) {
     nodeValue: unknown;
     path: Array<string | number>;
   }) => {
+    const sectionHint = hintForPath(params.path.slice(0, 1), props.uiHints);
+    const docsUrl = sectionHint?.docsUrl;
+    const docsTriggerId = `settings-section-help-${params.id}`;
     const revealAdvanced =
       props.showAdvanced === true ||
       props.forceAdvancedSection === params.path[0] ||
@@ -234,8 +239,40 @@ export function renderConfigForm(props: ConfigFormProps) {
       <section class="settings-section" id=${params.id}>
         <div class="settings-section__header">
           <h2 class="settings-section__heading">${params.label}</h2>
-          ${props.sectionActions
-            ? html`<div class="settings-section__actions">${props.sectionActions}</div>`
+          ${props.sectionActions || docsUrl
+            ? html`<div class="settings-section__actions">
+                ${props.sectionActions ?? nothing}
+                ${docsUrl
+                  ? html`
+                      <span class="settings-section__docs">
+                        <button
+                          id=${docsTriggerId}
+                          type="button"
+                          class="settings-section__help-button"
+                          aria-label=${t("configForm.sectionHelp", { section: params.label })}
+                          aria-haspopup="dialog"
+                        >
+                          <span aria-hidden="true">?</span>
+                        </button>
+                        <wa-popover
+                          class="settings-section__help-popover"
+                          for=${docsTriggerId}
+                          placement="bottom-end"
+                        >
+                          <div class="settings-section__help-panel">
+                            ${params.description ? html`<p>${params.description}</p>` : nothing}
+                            <a
+                              href=${docsUrl}
+                              target=${EXTERNAL_LINK_TARGET}
+                              rel=${buildExternalLinkRel()}
+                              >${t("configForm.readGuide")} <span aria-hidden="true">→</span></a
+                            >
+                          </div>
+                        </wa-popover>
+                      </span>
+                    `
+                  : nothing}
+              </div>`
             : nothing}
         </div>
         ${params.description

--- a/ui/src/components/mcp-servers-card.test.ts
+++ b/ui/src/components/mcp-servers-card.test.ts
@@ -227,6 +227,11 @@ describe("openclaw-mcp-servers-card", () => {
     expect(card.querySelector(".settings-empty")?.textContent).toContain(
       "No MCP servers configured.",
     );
+    const setupLink = card.querySelector<HTMLAnchorElement>(".settings-empty a");
+    expect(setupLink?.textContent?.trim()).toBe("Set up your first MCP server");
+    expect(setupLink?.href).toBe("https://docs.openclaw.ai/tools/mcp");
+    expect(setupLink?.target).toBe("_blank");
+    expect(setupLink?.rel).toBe("noopener noreferrer");
   });
 
   it.each([

--- a/ui/src/components/mcp-servers-card.ts
+++ b/ui/src/components/mcp-servers-card.ts
@@ -20,7 +20,12 @@ import { OpenClawLightDomElement } from "../lit/openclaw-element.ts";
 import { SubscriptionsController } from "../lit/subscriptions-controller.ts";
 import { icons } from "./icons.ts";
 import { renderMcpServerForm, type McpServerForm } from "./mcp-server-form.ts";
-import { renderSettingsEmpty, renderSettingsSection, renderSettingsStatus } from "./settings-ui.ts";
+import {
+  renderDocsLink,
+  renderSettingsEmpty,
+  renderSettingsSection,
+  renderSettingsStatus,
+} from "./settings-ui.ts";
 
 type McpServerMessage = { kind: "error" | "success"; text: string };
 
@@ -44,6 +49,8 @@ class McpServersCard extends OpenClawLightDomElement {
   private context?: ApplicationContext;
 
   @property() pluginsHref = "";
+
+  @property() docsUrl = "https://docs.openclaw.ai/tools/mcp";
 
   @state() private rows: McpServerSummary[] | null = null;
   @state() private busy = false;
@@ -219,7 +226,9 @@ class McpServersCard extends OpenClawLightDomElement {
     const body = !rows
       ? html`<div class="mcp-server-loading" role="status">${t("common.loading")}</div>`
       : rows.length === 0
-        ? renderSettingsEmpty(t("mcpPage.noServers"))
+        ? renderSettingsEmpty(html`
+            ${t("mcpPage.noServers")} ${renderDocsLink(this.docsUrl, t("mcpPage.setUpFirstServer"))}
+          `)
         : rows.map((server) => this.renderRow(server));
     return html`
       <div class="mcp-server-list">

--- a/ui/src/components/settings-ui.ts
+++ b/ui/src/components/settings-ui.ts
@@ -6,6 +6,7 @@ import "@awesome.me/webawesome/dist/components/radio/radio.js";
 import "@awesome.me/webawesome/dist/components/radio-group/radio-group.js";
 import "@awesome.me/webawesome/dist/components/switch/switch.js";
 import { html, nothing, type TemplateResult } from "lit";
+import { buildExternalLinkRel, EXTERNAL_LINK_TARGET } from "../lib/external-link.ts";
 import { icons } from "./icons.ts";
 import "./tooltip.ts";
 
@@ -43,6 +44,12 @@ export function renderSettingsPage(
       ${children}
     </div>
   `;
+}
+
+export function renderDocsLink(url: string, label: unknown): TemplateResult {
+  return html`<a href=${url} target=${EXTERNAL_LINK_TARGET} rel=${buildExternalLinkRel()}
+    >${label}</a
+  >`;
 }
 
 /** Section = plain text heading + one group surface containing rows. */

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -70,6 +70,7 @@ export const en: TranslationMap = {
     settingsSections: "Settings sections",
     version: "Version",
     docs: "Docs",
+    learnMore: "Learn more",
     theme: "Theme",
     colorMode: "Color mode",
     colorModeOption: "Color mode: {mode}",
@@ -982,6 +983,8 @@ export const en: TranslationMap = {
     noEvents: "No events yet.",
   },
   configForm: {
+    sectionHelp: "Help for {section}",
+    readGuide: "Read the guide",
     showAdvanced: "Show advanced",
     advancedHidden: "{count} advanced setting hidden",
     advancedHiddenPlural: "{count} advanced settings hidden",
@@ -1177,6 +1180,7 @@ export const en: TranslationMap = {
       lobsterdexOpen: "Open Lobsterdex",
     },
     security: {
+      intro: "Review gateway access, tool policy, device authentication, and approvals.",
       title: "Security",
       gatewayAuth: "Gateway auth",
       execPolicy: "Exec policy",
@@ -2135,12 +2139,14 @@ export const en: TranslationMap = {
     working: "Working…",
   },
   mcpPage: {
+    intro: "Connect and manage MCP servers that provide tools to OpenClaw.",
     connectorsLink: "Discover one-click connectors on the Plugins page.",
     servers: "Servers",
     oauth: "OAuth",
     filtered: "Filtered",
     configuredServers: "Configured servers",
     noServers: "No MCP servers configured.",
+    setUpFirstServer: "Set up your first MCP server",
     operatorCommands: "MCP operator commands",
     operatorCommandsHint: "Status, diagnostics, auth, probing, and runtime reload.",
     runtimeHint:
@@ -2151,6 +2157,7 @@ export const en: TranslationMap = {
     mtls: "mTLS",
   },
   talkPage: {
+    intro: "Configure realtime voice providers, models, and speaker voices.",
     voiceSection: {
       title: "Realtime voice",
       description:
@@ -2188,6 +2195,7 @@ export const en: TranslationMap = {
     },
   },
   memoryPage: {
+    intro: "Choose how OpenClaw stores, searches, and maintains agent memory.",
     tablistLabel: "Memory sections",
     tabs: {
       overview: "Overview",

--- a/ui/src/pages/config/mcp.ts
+++ b/ui/src/pages/config/mcp.ts
@@ -1,8 +1,14 @@
 import { html, type TemplateResult } from "lit";
 import "../../components/mcp-servers-card.ts";
-import { renderSettingsRow, renderSettingsValue } from "../../components/settings-ui.ts";
+import {
+  renderDocsLink,
+  renderSettingsRow,
+  renderSettingsValue,
+} from "../../components/settings-ui.ts";
 import { t } from "../../i18n/index.ts";
 import { summarizeMcpServers } from "../../lib/config/mcp-servers.ts";
+
+const MCP_DOCS_URL = "https://docs.openclaw.ai/tools/mcp";
 
 type McpViewProps = {
   configObject: Record<string, unknown>;
@@ -19,6 +25,9 @@ export function renderMcp(props: McpViewProps) {
   return html`
     <section class="mcp-page">
       <div class="settings-page">
+        <p class="settings-page__intro">
+          ${t("mcpPage.intro")} ${renderDocsLink(MCP_DOCS_URL, t("common.learnMore"))}
+        </p>
         <section class="settings-section mcp-page__summary">
           <div class="settings-section__header">
             <h2 class="settings-section__heading">${t("mcpPage.servers")}</h2>
@@ -60,7 +69,10 @@ export function renderMcp(props: McpViewProps) {
           </div>
         </section>
 
-        <openclaw-mcp-servers-card .pluginsHref=${props.pluginsHref}></openclaw-mcp-servers-card>
+        <openclaw-mcp-servers-card
+          .pluginsHref=${props.pluginsHref}
+          .docsUrl=${MCP_DOCS_URL}
+        ></openclaw-mcp-servers-card>
       </div>
 
       ${props.editor}

--- a/ui/src/pages/config/memory.ts
+++ b/ui/src/pages/config/memory.ts
@@ -4,6 +4,7 @@ import "../../components/agent-select-registration.ts";
 import type { AgentSelectOption } from "../../components/agent-select.ts";
 import { renderHubTabs } from "../../components/hub-tabs.ts";
 import {
+  renderDocsLink,
   renderSettingsRow,
   renderSettingsSection,
   renderSettingsSegmented,
@@ -75,6 +76,8 @@ type MemoryViewProps = {
 };
 
 const MEMORY_PANEL_ID = "memory-settings-panel";
+
+const MEMORY_DOCS_URL = "https://docs.openclaw.ai/concepts/memory";
 
 const MEMORY_ENGINE_OFF = "";
 
@@ -281,6 +284,9 @@ function renderSettingsTab(props: MemoryViewProps) {
 export function renderMemory(props: MemoryViewProps) {
   return html`
     <section class="memory-page">
+      <p class="settings-page__intro">
+        ${t("memoryPage.intro")} ${renderDocsLink(MEMORY_DOCS_URL, t("common.learnMore"))}
+      </p>
       ${renderHubTabs<MemoryTab>({
         id: "memory",
         active: props.activeTab,

--- a/ui/src/pages/config/notifications-section.ts
+++ b/ui/src/pages/config/notifications-section.ts
@@ -2,12 +2,19 @@ import { html, nothing } from "lit";
 import type { NativeNotificationsPermission } from "../../app/native-notifications.ts";
 import { icons } from "../../components/icons.ts";
 import {
+  renderDocsLink,
   renderSettingsRow,
   renderSettingsStatus,
   renderSettingsValue,
 } from "../../components/settings-ui.ts";
 import { t } from "../../i18n/index.ts";
 import { COMMUNICATION_SETTINGS_TARGET_IDS } from "./settings-targets.ts";
+
+const NOTIFICATIONS_DOCS_URL = "https://docs.openclaw.ai/web/notifications";
+
+function renderNotificationsHint(copy: string) {
+  return html`${copy} ${renderDocsLink(NOTIFICATIONS_DOCS_URL, t("common.learnMore"))}`;
+}
 
 export type WebPushUiState = {
   supported: boolean;
@@ -82,7 +89,9 @@ export function renderNotificationsSection(props: NotificationsSectionProps) {
             <h2 class="settings-section__heading">${t("configView.notifications.nativeTitle")}</h2>
             <div class="settings-section__actions">${renderSettingsStatus(status)}</div>
           </div>
-          <p class="settings-section__desc">${t("configView.notifications.nativeHint")}</p>
+          <p class="settings-section__desc">
+            ${renderNotificationsHint(t("configView.notifications.nativeHint"))}
+          </p>
           <div class="settings-group">
             ${renderSettingsRow({
               title: t("configView.notifications.permission"),
@@ -125,6 +134,9 @@ export function renderNotificationsSection(props: NotificationsSectionProps) {
               })}
             </div>
           </div>
+          <p class="settings-section__desc">
+            ${renderNotificationsHint(t("configView.notifications.unavailableHint"))}
+          </p>
           <div class="settings-group">
             <div class="settings-row">
               <div class="settings-row__text">
@@ -207,7 +219,9 @@ export function renderNotificationsSection(props: NotificationsSectionProps) {
             ${renderSettingsStatus({ kind: statusKind, label: statusLabel })}
           </div>
         </div>
-        <p class="settings-section__desc">${t("configView.notifications.hint")}</p>
+        <p class="settings-section__desc">
+          ${renderNotificationsHint(t("configView.notifications.hint"))}
+        </p>
         <div class="settings-group">
           ${renderSettingsRow({
             title: t("configView.notifications.browserSupport"),

--- a/ui/src/pages/config/security.ts
+++ b/ui/src/pages/config/security.ts
@@ -4,6 +4,7 @@
 import { html, type TemplateResult } from "lit";
 import { icons } from "../../components/icons.ts";
 import {
+  renderDocsLink,
   renderSettingsRow,
   renderSettingsSection,
   renderSettingsSegmented,
@@ -13,6 +14,8 @@ import {
 } from "../../components/settings-ui.ts";
 import { t } from "../../i18n/index.ts";
 import { PROFILE_OPTIONS } from "../../lib/agents/display.ts";
+
+const SECURITY_DOCS_URL = "https://docs.openclaw.ai/gateway/security";
 
 export type SecurityOverview = {
   gatewayAuth: string;
@@ -98,7 +101,13 @@ function renderSecurityOverview(props: SecurityViewProps) {
 export function renderSecurity(props: SecurityViewProps) {
   return html`
     <section class="security-page">
-      <div class="settings-page">${renderSecurityOverview(props)}</div>
+      <div class="settings-page">
+        <p class="settings-page__intro">
+          ${t("quickSettings.security.intro")}
+          ${renderDocsLink(SECURITY_DOCS_URL, t("common.learnMore"))}
+        </p>
+        ${renderSecurityOverview(props)}
+      </div>
       ${props.editor}
     </section>
   `;

--- a/ui/src/pages/config/talk.ts
+++ b/ui/src/pages/config/talk.ts
@@ -4,6 +4,7 @@
 // same config draft, so both stay in sync without narrowing the schema.
 import { html, nothing, type TemplateResult } from "lit";
 import {
+  renderDocsLink,
   renderSettingsRow,
   renderSettingsSection,
   renderSettingsSegmented,
@@ -52,6 +53,8 @@ type TalkViewProps = {
 };
 
 const TALK_PICKER_UNSET = "";
+
+const TALK_DOCS_URL = "https://docs.openclaw.ai/nodes/talk";
 
 /** Config may name a provider by alias; pickers always speak canonical ids. */
 function findProviderOption(
@@ -301,6 +304,9 @@ export function renderTalk(props: TalkViewProps) {
   return html`
     <section class="talk-page">
       <div class="settings-page">
+        <p class="settings-page__intro">
+          ${t("talkPage.intro")} ${renderDocsLink(TALK_DOCS_URL, t("common.learnMore"))}
+        </p>
         ${renderSettingsSection(
           {
             title: t("talkPage.voiceSection.title"),

--- a/ui/src/styles/settings.css
+++ b/ui/src/styles/settings.css
@@ -141,6 +141,53 @@
   flex: 0 0 auto;
 }
 
+.settings-section__docs {
+  display: inline-flex;
+  align-items: center;
+}
+
+.settings-section__help-button {
+  display: inline-grid;
+  width: 22px;
+  height: 22px;
+  padding: 0;
+  place-items: center;
+  border: 1px solid color-mix(in srgb, var(--muted) 35%, transparent);
+  border-radius: 50%;
+  background: transparent;
+  color: var(--muted);
+  font: 600 var(--control-ui-text-xs) / 1 var(--font-sans);
+  cursor: pointer;
+}
+
+.settings-section__help-button:hover,
+.settings-section__help-button:focus-visible {
+  border-color: color-mix(in srgb, var(--accent) 55%, var(--border));
+  color: var(--accent);
+}
+
+.settings-section__help-popover::part(body) {
+  max-width: 280px;
+  padding: var(--space-3) var(--space-4);
+}
+
+.settings-section__help-panel {
+  display: grid;
+  gap: var(--space-2);
+  font-size: var(--control-ui-text-sm);
+  line-height: 1.45;
+}
+
+.settings-section__help-panel p {
+  margin: 0;
+  color: var(--muted-strong);
+}
+
+.settings-section__help-panel a {
+  width: fit-content;
+  font-weight: 600;
+}
+
 /* ── Group (the only surface) ── */
 
 .settings-group {


### PR DESCRIPTION
## What Problem This Solves

Control UI settings had almost no links to docs.openclaw.ai. For many sections, the only correlatable target was the giant configuration-reference page, which is not useful to beginners, while Notifications, MCP, and agent bindings had no dedicated docs page at all.

## Why This Change Was Made

This adds server-owned `docsUrl` metadata to `ConfigUiHints` through `SECTION_DOCS_URLS` in `src/config/schema.hints.ts`. The mapping is prohibited from pointing at configuration-reference anchors and a test verifies that every URL resolves to a real docs page. The config form renderer now gives each section a `?` help popover with a “Read the guide” link.

The curated Memory, Talk, Security, MCP, and Notifications pages now include short introductory guidance with Learn-more links. The MCP empty state links to “Set up your first MCP server.” New task-oriented guides at `/web/notifications`, `/tools/mcp`, and `/concepts/agent-bindings` are registered in the docs navigation and cross-linked from the relevant surfaces.

## User Impact

Beginners get a contextual path from every settings section to a task-oriented guide. This changes no runtime behavior or configuration contract.

## Evidence

- `node scripts/run-vitest.mjs src/config/schema.hints.test.ts` — 12 passed
- `node scripts/run-vitest.mjs ui/src/components/config-form` — 25 passed
- Focused `mcp-servers-card` tests — 20 passed
- `pnpm ui:i18n:baseline` — no drift
- Delegated `check-changed` lanes — green
- Autoreview with Codex `gpt-5.6-sol` — clean, 0 findings
