### PR TITLE
fix(outbound): keep internal runtime context out of channel replies

### DIFF
--- a/src/infra/outbound/deliver.test.ts
+++ b/src/infra/outbound/deliver.test.ts
@@ -2592,6 +2592,28 @@ describe("deliverOutboundPayloads", () => {
     expect(requireMockCallArg(sendText, "sendText").text).toBe("visible");
   });
 
+  it("strips complete inline runtime context blocks before channel delivery", async () => {
+    const sendText = vi.fn().mockResolvedValue({
+      channel: "matrix" as const,
+      messageId: "clean-inline-runtime-context",
+      roomId: "!room",
+    });
+    setTestOutbound({ sendText });
+
+    await deliverOutboundPayloads({
+      cfg: {},
+      channel: "matrix",
+      to: "!room",
+      payloads: [
+        {
+          text: "before <<<BEGIN_OPENCLAW_INTERNAL_CONTEXT>>>private runtime metadata<<<END_OPENCLAW_INTERNAL_CONTEXT>>> after",
+        },
+      ],
+    });
+
+    expect(requireMockCallArg(sendText, "sendText").text).toBe("before  after");
+  });
+
   it("runs reply payload hooks before the final message_sending policy pass", async () => {
     hookMocks.runner.hasHooks.mockImplementation(
       (hookName?: string) => hookName === "reply_payload_sending" || hookName === "message_sending",

--- a/src/infra/outbound/protocol-scaffolding.ts
+++ b/src/infra/outbound/protocol-scaffolding.ts
@@ -1,5 +1,9 @@
 import { stripPlainTextToolCallBlocks } from "../../../packages/tool-call-repair/src/index.js";
-import { stripInternalRuntimeContext } from "../../agents/internal-runtime-context.js";
+import {
+  INTERNAL_RUNTIME_CONTEXT_BEGIN,
+  INTERNAL_RUNTIME_CONTEXT_END,
+  stripInternalRuntimeContext,
+} from "../../agents/internal-runtime-context.js";
 import { escapeRegExp } from "../../shared/regexp.js";
 
 const INTERNAL_RUNTIME_SCAFFOLDING_TAGS = ["system-reminder", "previous_response"] as const;
@@ -20,7 +24,33 @@ const INTERNAL_RUNTIME_MARKER_LINES = [
   "<<<BEGIN_UNTRUSTED_CHILD_RESULT>>>",
   "<<<END_UNTRUSTED_CHILD_RESULT>>>",
 ] as const;
+const ESCAPED_INTERNAL_RUNTIME_CONTEXT_BEGIN = escapeRegExp(INTERNAL_RUNTIME_CONTEXT_BEGIN);
+// Runtime producers escape nested opening delimiters. Consume every closing
+// marker before the next opener so marker-shaped payload text cannot escape.
+const INLINE_INTERNAL_RUNTIME_CONTEXT_BLOCK_RE = new RegExp(
+  `${ESCAPED_INTERNAL_RUNTIME_CONTEXT_BEGIN}(?:(?!${ESCAPED_INTERNAL_RUNTIME_CONTEXT_BEGIN})[\\s\\S])*${escapeRegExp(INTERNAL_RUNTIME_CONTEXT_END)}`,
+  "g",
+);
 const PROMPT_DATA_TAG_NAMES = ["prompt-data", "untrusted-text"] as const;
+
+function isStandaloneMarkerAt(text: string, marker: string, offset: number): boolean {
+  const lineStart = text.lastIndexOf("\n", offset - 1) + 1;
+  const lineEnd = text.indexOf("\n", offset + marker.length);
+  return (
+    text.slice(lineStart, offset).trim().length === 0 &&
+    text.slice(offset + marker.length, lineEnd === -1 ? undefined : lineEnd).trim().length === 0
+  );
+}
+
+function stripInlineInternalRuntimeContextBlocks(text: string): string {
+  // Keep standalone blocks with their canonical stripping owner and preserve
+  // ordinary prose that only mentions a single internal marker.
+  return text.replace(
+    INLINE_INTERNAL_RUNTIME_CONTEXT_BLOCK_RE,
+    (block, offset: number, value: string) =>
+      isStandaloneMarkerAt(value, INTERNAL_RUNTIME_CONTEXT_BEGIN, offset) ? block : "",
+  );
+}
 
 function standaloneLinePattern(token: string): string {
   return `(?:^|\\r?\\n)[ \\t]*${escapeRegExp(token)}[ \\t]*(?=\\r?\\n|$)`;
@@ -63,7 +93,7 @@ function unwrapPromptDataWrapperLines(text: string): string {
 
 export function stripInternalRuntimeScaffolding(text: string): string {
   let stripped = stripInternalRuntimeContext(
-    unwrapPromptDataWrapperLines(text)
+    unwrapPromptDataWrapperLines(stripInlineInternalRuntimeContextBlocks(text))
       .replace(INTERNAL_RUNTIME_SCAFFOLDING_BLOCK_RE, "")
       .replace(INTERNAL_RUNTIME_SCAFFOLDING_SELF_CLOSING_RE, "")
       .replace(INTERNAL_RUNTIME_SCAFFOLDING_TAG_RE, ""),

--- a/src/infra/outbound/sanitize-text.test.ts
+++ b/src/infra/outbound/sanitize-text.test.ts
@@ -1,6 +1,7 @@
 // Verifies plain-text sanitization strips runtime scaffolding, tool-call blocks,
 // prompt-data wrappers, and conservative HTML markup.
 import { describe, expect, it } from "vitest";
+import { escapeInternalRuntimeContextDelimiters } from "../../agents/internal-runtime-context.js";
 import { stripInternalRuntimeScaffolding } from "./protocol-scaffolding.js";
 import { sanitizeForPlainText } from "./sanitize-text.js";
 
@@ -171,6 +172,46 @@ describe("stripInternalRuntimeScaffolding", () => {
     ).toBe("before\nafter");
   });
 
+  it("removes complete internal runtime context blocks glued to visible text", () => {
+    expect(
+      stripInternalRuntimeScaffolding(
+        "before <<<BEGIN_OPENCLAW_INTERNAL_CONTEXT>>>private runtime metadata<<<END_OPENCLAW_INTERNAL_CONTEXT>>> after",
+      ),
+    ).toBe("before  after");
+  });
+
+  it("preserves inline marker mentions before a later complete runtime context block", () => {
+    expect(
+      stripInternalRuntimeScaffolding(
+        [
+          "what is <<<BEGIN_OPENCLAW_INTERNAL_CONTEXT>>>?",
+          "visible",
+          "<<<BEGIN_OPENCLAW_INTERNAL_CONTEXT>>>",
+          "private runtime metadata",
+          "<<<END_OPENCLAW_INTERNAL_CONTEXT>>>",
+          "after",
+        ].join("\n"),
+      ),
+    ).toBe("what is <<<BEGIN_OPENCLAW_INTERNAL_CONTEXT>>>?\nvisible\nafter");
+  });
+
+  it("removes marker-shaped private text from complete inline runtime context blocks", () => {
+    const escapedPrivateContext = escapeInternalRuntimeContextDelimiters(
+      "private <<<BEGIN_OPENCLAW_INTERNAL_CONTEXT>>>nested<<<END_OPENCLAW_INTERNAL_CONTEXT>>> metadata",
+    );
+    expect(
+      stripInternalRuntimeScaffolding(
+        `before <<<BEGIN_OPENCLAW_INTERNAL_CONTEXT>>>${escapedPrivateContext}<<<END_OPENCLAW_INTERNAL_CONTEXT>>> after`,
+      ),
+    ).toBe("before  after");
+
+    expect(
+      stripInternalRuntimeScaffolding(
+        "before <<<BEGIN_OPENCLAW_INTERNAL_CONTEXT>>>private <<<END_OPENCLAW_INTERNAL_CONTEXT>>> metadata<<<END_OPENCLAW_INTERNAL_CONTEXT>>> after",
+      ),
+    ).toBe("before  after");
+  });
+
   it("removes indented runtime context delimiters without leaving marker fragments", () => {
     expect(
       stripInternalRuntimeScaffolding(
@@ -252,6 +293,9 @@ describe("stripInternalRuntimeScaffolding", () => {
   });
 
   it("preserves inline delimiter mentions", () => {
+    expect(stripInternalRuntimeScaffolding("what is <<<BEGIN_OPENCLAW_INTERNAL_CONTEXT>>>?")).toBe(
+      "what is <<<BEGIN_OPENCLAW_INTERNAL_CONTEXT>>>?",
+    );
     expect(
       stripInternalRuntimeScaffolding("visible <<<END_OPENCLAW_INTERNAL_CONTEXT>>> inline mention"),
     ).toBe("visible <<<END_OPENCLAW_INTERNAL_CONTEXT>>> inline mention");


### PR DESCRIPTION
Closes #113754

## What Problem This Solves

Fixes an issue where users receiving assistant replies on a channel would see private internal OpenClaw runtime-context blocks when a model glued the complete context delimiters to otherwise visible reply text.

## Why This Change Was Made

Strip only complete, paired inline runtime-context blocks at the existing shared outbound-sanitization boundary. Keep standalone blocks under their canonical context owner, preserve ordinary text mentioning an unpaired delimiter, respect the producer's escaped nested-marker contract, and fail safely when a private payload contains extra closing delimiters.

This does not alter agent prompts, provider or channel plugin policy, configuration, storage, or public plugin APIs.

## User Impact

Internal context is no longer posted to users as part of a channel reply. Normal message text and legitimate discussions of individual context markers remain unchanged.

## Evidence

- Reproduced the bug before the fix with the real outbound sanitizer; the two targeted regressions failed on the baseline while all existing tests passed: https://github.com/openclaw/openclaw/actions/runs/30420240724.
- Verified the final rebased commit with 238 passing tests across the real Matrix outbound-adapter send, durable queue integration, channel payload contracts, agent-owned context behavior, glued runtime markers, marker-shaped private text, and preserved prose: https://github.com/openclaw/openclaw/actions/runs/30422340930.
- Full changed-code gate passed, including formatting, core and test typechecks, lint, dependency, plugin-boundary, database, and runtime import-cycle guards: https://github.com/openclaw/openclaw/actions/runs/30421706284.
- Structured Codex autoreview using gpt-5.6-sol at xhigh reasoning finished with no accepted or actionable findings on the exact rebased commit; git range-diff confirms the changed-gate patch is identical.
- AI-assisted; every changed source path, delivery caller, producer framing contract, and sibling behavior was independently inspected.
