### PR TITLE
fix(doctor): stop false Slack message-drop warnings

### DIFF
--- a/extensions/slack/package.json
+++ b/extensions/slack/package.json
@@ -61,6 +61,12 @@
       "blurb": "supported (Socket Mode).",
       "systemImage": "number",
       "markdownCapable": true,
+      "doctorCapabilities": {
+        "dmAllowFromMode": "topOnly",
+        "groupModel": "route",
+        "groupAllowFromFallbackToAllowFrom": false,
+        "warnOnEmptyGroupSenderAllowlist": false
+      },
       "commands": {
         "nativeCommandsAutoEnabled": false,
         "nativeSkillsAutoEnabled": false

--- a/src/commands/doctor/channel-capabilities.test.ts
+++ b/src/commands/doctor/channel-capabilities.test.ts
@@ -33,6 +33,15 @@ describe("doctor channel capabilities", () => {
     });
   });
 
+  it("returns Slack route semantics without loading its channel plugin", () => {
+    expect(getDoctorChannelCapabilities("slack")).toEqual({
+      dmAllowFromMode: "topOnly",
+      groupModel: "route",
+      groupAllowFromFallbackToAllowFrom: false,
+      warnOnEmptyGroupSenderAllowlist: false,
+    });
+  });
+
   it("returns capability overrides from matrix plugin metadata", () => {
     expect(getDoctorChannelCapabilities("matrix")).toEqual({
       dmAllowFromMode: "nestedOnly",


### PR DESCRIPTION
Closes #110489.

Thanks to @ari-hjunk for the original real-world report and exact reproduction.

## What Problem This Solves

Fixes an issue where users running `openclaw doctor` against a correctly configured Slack channel allowlist were incorrectly warned that every group message would be silently dropped and told to add `channels.slack.groupAllowFrom`, a setting that Slack's strict plugin schema rejects.

## Why This Change Was Made

Slack already declares route-based group authorization and disables sender-based empty-allowlist warnings in its runtime doctor adapter. Unlike the existing Google Chat, Matrix, and Microsoft Teams plugins, it did not expose those same existing capabilities in its package channel metadata. Doctor runs a cold plugin-metadata scan before the Slack runtime adapter loads, so it incorrectly applied generic sender-based channel defaults. Declare Slack's already implemented doctor capabilities in the existing package metadata and add a cold-plugin regression alongside the equivalent channel capability tests. No user-facing configuration, schema, dependency, state, SQLite version, or migration is added.

## User Impact

Operators with valid Slack channel-ID allowlists no longer receive a false message-loss warning or advice to add a rejected Slack setting. Slack DM, pairing, channel route, and schema behavior remain unchanged.

## Evidence

Independent before-and-after verification on Blacksmith Testbox `tbx_01kynzjm0awvw3mh750rdkrhk4`, using the same isolated state, canonical ID-keyed Slack configuration, and actual production CLI invocation on current `main` and the patched checkout:

```text
$ pnpm openclaw doctor --non-interactive --yes

BEFORE, current main:
channels.slack.groupPolicy is "allowlist" but groupAllowFrom (and
allowFrom) is empty — all group messages will be silently dropped.
Add sender IDs to channels.slack.groupAllowFrom or
channels.slack.allowFrom, or set groupPolicy to "open".

AFTER, same real CLI and configuration:
PASS: valid Slack routes preserved; no false message-drop warning;
no invalid groupAllowFrom recommendation; no retired cron JSON path
Slack DMs: locked (channels.slack.dmPolicy="pairing")

$ pnpm test src/commands/doctor/channel-capabilities.test.ts \
    src/commands/doctor/shared/empty-allowlist-scan.test.ts \
    extensions/slack/src/config-schema.test.ts -- --reporter=verbose
PASS: cold-plugin Slack capability regression, existing cross-channel
      empty-allowlist warnings, and all 37 Slack schema tests

$ pnpm check:changed
PASS before remote full-core lint timeout: published Slack metadata,
     npm package-lock and generated channel metadata guards,
     formatting, core-test and extension type checks, and plugin boundaries
Full-repository lint: require the exact-head hosted CI gate before landing

$ pnpm build
PASS: published plugin/package build

$ .agents/skills/autoreview/scripts/autoreview --mode uncommitted --thinking xhigh --stream-engine-output
autoreview clean: no accepted/actionable findings reported
overall: patch is correct (0.98)
```

The original issue's obsolete Slack documentation example and retired cron override diagnostic were independently checked: current documentation uses the canonical channel configuration, and the same actual current-main doctor invocation does not emit a retired cron JSON-path warning. AI-assisted; the package metadata, Slack schema, runtime doctor adapter, cold catalog lookup, cross-channel sibling contracts, and both actual CLI executions were personally verified.
