### PR TITLE
fix(agents): restore CLI usage for OpenAI-compatible providers

### DIFF
--- a/src/agents/cli-output.test.ts
+++ b/src/agents/cli-output.test.ts
@@ -14,6 +14,41 @@ import { createClaudeApiErrorFixture } from "./test-helpers/claude-api-error-fix
 
 type ParseCliOutputParams = Parameters<typeof parseCliOutput>[0];
 
+const OPENAI_COMPATIBLE_CLI_USAGE_CASES = [
+  {
+    name: "standard OpenAI snake_case token fields",
+    raw: {
+      prompt_tokens: 17,
+      completion_tokens: 5,
+      total_tokens: 22,
+      prompt_tokens_details: { cached_tokens: 6 },
+    },
+    normalized: { input: 11, output: 5, cacheRead: 6, cacheWrite: undefined, total: 22 },
+  },
+  {
+    name: "camelCase OpenAI-compatible token fields",
+    raw: {
+      promptTokens: 17,
+      completionTokens: 5,
+      total_tokens: 22,
+      prompt_tokens_details: { cached_tokens: 6 },
+    },
+    normalized: { input: 11, output: 5, cacheRead: 6, cacheWrite: undefined, total: 22 },
+  },
+  {
+    name: "existing input/output field precedence",
+    raw: {
+      input_tokens: 19,
+      prompt_tokens: 99,
+      output_tokens: 7,
+      completion_tokens: 77,
+      total_tokens: 26,
+      prompt_tokens_details: { cached_tokens: 4 },
+    },
+    normalized: { input: 15, output: 7, cacheRead: 4, cacheWrite: undefined, total: 26 },
+  },
+] as const;
+
 function parseCliJson(raw: string, backend: ParseCliOutputParams["backend"], providerId = "") {
   return parseCliOutput({ raw, backend, providerId, outputMode: "json" });
 }
@@ -362,6 +397,31 @@ describe("parseCliJson", () => {
       },
     });
   });
+
+  it.each(OPENAI_COMPATIBLE_CLI_USAGE_CASES)(
+    "normalizes $name from CLI JSON output",
+    ({ raw, normalized }) => {
+      const result = parseCliJson(
+        JSON.stringify({
+          session_id: "openai-compatible-session",
+          response: "OpenAI-compatible response",
+          usage: raw,
+        }),
+        {
+          command: "openai-compatible",
+          output: "json",
+          sessionIdFields: ["session_id"],
+        },
+        "openai-compatible-cli",
+      );
+
+      expect(result).toEqual({
+        text: "OpenAI-compatible response",
+        sessionId: "openai-compatible-session",
+        usage: normalized,
+      });
+    },
+  );
 });
 
 describe("parseCliJsonl", () => {
@@ -433,6 +493,36 @@ describe("parseCliJsonl", () => {
       },
     });
   });
+
+  it.each(OPENAI_COMPATIBLE_CLI_USAGE_CASES)(
+    "normalizes $name from CLI JSONL output",
+    ({ raw, normalized }) => {
+      const result = parseCliJsonl(
+        [
+          JSON.stringify({ type: "init", session_id: "openai-compatible-session" }),
+          JSON.stringify({
+            type: "result",
+            session_id: "openai-compatible-session",
+            result: "OpenAI-compatible response",
+            usage: raw,
+          }),
+        ].join("\n"),
+        {
+          command: "openai-compatible",
+          output: "jsonl",
+          jsonlDialect: "claude-stream-json",
+          sessionIdFields: ["session_id"],
+        },
+        "openai-compatible-cli",
+      );
+
+      expect(result).toEqual({
+        text: "OpenAI-compatible response",
+        sessionId: "openai-compatible-session",
+        usage: normalized,
+      });
+    },
+  );
 
   it("parses Gemini stream-json message and result events", () => {
     const result = parseCliJsonl(
@@ -1138,6 +1228,42 @@ describe("parseCliOutput", () => {
 });
 
 describe("createCliJsonlStreamingParser", () => {
+  it.each(OPENAI_COMPATIBLE_CLI_USAGE_CASES)(
+    "normalizes $name while incrementally streaming CLI JSONL",
+    ({ raw, normalized }) => {
+      const parser = createCliJsonlStreamingParser({
+        backend: {
+          command: "openai-compatible",
+          output: "jsonl",
+          jsonlDialect: "claude-stream-json",
+          sessionIdFields: ["session_id"],
+        },
+        providerId: "openai-compatible-cli",
+        onAssistantDelta: () => {},
+      });
+
+      parser.push(
+        [
+          JSON.stringify({ type: "init", session_id: "openai-compatible-session" }),
+          JSON.stringify({
+            type: "result",
+            session_id: "openai-compatible-session",
+            result: "OpenAI-compatible response",
+            usage: raw,
+          }),
+          "",
+        ].join("\n"),
+      );
+      parser.finish();
+
+      expect(parser.getOutput()).toEqual({
+        text: "OpenAI-compatible response",
+        sessionId: "openai-compatible-session",
+        usage: normalized,
+      });
+    },
+  );
+
   it("surfaces codex-exec todo snapshots as typed plan updates", () => {
     const plans: Array<{ steps: Array<{ step: string; status: string }> }> = [];
     const parser = createCliJsonlStreamingParser({

--- a/src/agents/cli-output.ts
+++ b/src/agents/cli-output.ts
@@ -281,8 +281,14 @@ function toCliUsage(raw: Record<string, unknown>): CliUsage | undefined {
   };
   const pick = (key: string) =>
     typeof raw[key] === "number" && raw[key] > 0 ? raw[key] : undefined;
-  const totalInput = pick("input_tokens") ?? pick("inputTokens");
-  const output = pick("output_tokens") ?? pick("outputTokens");
+  // Chat Completions calls these prompt/completion tokens; preserve existing CLI-field precedence.
+  const totalInput =
+    pick("input_tokens") ?? pick("inputTokens") ?? pick("prompt_tokens") ?? pick("promptTokens");
+  const output =
+    pick("output_tokens") ??
+    pick("outputTokens") ??
+    pick("completion_tokens") ??
+    pick("completionTokens");
   const nestedCached =
     readNestedCached("input_tokens_details") ?? readNestedCached("prompt_tokens_details");
   const cacheRead =


### PR DESCRIPTION
Related: #77992
Credits: @Beandon13 for identifying the independent CLI parser gap in #78085.

## What Problem This Solves

Fixes an issue where users running a CLI-backed OpenAI-compatible provider would see missing input/output token counts and unreliable context usage because standard `prompt_tokens` and `completion_tokens` were discarded. The previously landed #85383 repaired chat-history sanitization for #77992, but the independently exercised CLI JSON, complete JSONL, and incremental JSONL paths remained broken.

## Why This Change Was Made

Normalize the official OpenAI Chat Completions usage fields once in the existing shared CLI usage owner. Preserve the existing `input_tokens`/`output_tokens` priority, supported camelCase forms, and `prompt_tokens_details.cached_tokens` subtraction, so cached prompt tokens are never double-counted. No configuration, provider route, protocol, storage, dependency, or migration change.

## User Impact

CLI-backed OpenAI-compatible providers report accurate input, output, cached, and total token usage in both JSON and streaming JSONL output; existing Claude, Gemini, and other CLI usage behavior is preserved.

## Evidence

- Upstream contracts verified directly: `openai/openai-node/src/resources/completions.ts` defines `CompletionUsage.prompt_tokens`, `completion_tokens`, `total_tokens`, and `prompt_tokens_details.cached_tokens`; `ggml-org/llama.cpp/tools/server/README.md` documents the same real `/v1/chat/completions` usage response.
- Red-first trusted Linux Testbox: unchanged production code failed all six new snake_case/camelCase regressions across actual JSON, completed JSONL, and incremental streaming; all 70 pre-existing and all three field-precedence controls passed.
- Green trusted Linux Testbox: `pnpm test src/agents/cli-output.test.ts src/agents/cli-runner/execute-output-buffer.test.ts src/agents/cli-runner/execute.supervisor-capture.test.ts` — 127 tests across three runner/parser shards passed.
- Touched-source `oxfmt` and `oxlint`: clean.
- Exact committed-head full `pnpm check:changed` on Blacksmith `tbx_01kyp1hqw71epapf43k9rbw74d`: exit 0, including core and core-test typechecks, lint, formatting, SDK/boundary contracts, dead exports, and database/security guards. Proof runner: https://github.com/openclaw/openclaw/actions/runs/30421254867 (first red/green lease); final changed-gate lease is independently Blacksmith-backed.
- Fresh `gpt-5.6-sol` `xhigh` structured autoreview: clean, correctness 0.98.
- Not tested: a live llama.cpp server or paid external model; the regression drives the real configured JSON, complete JSONL, incremental-stream parser, and runner boundaries using the official provider response shape.

AI-assisted: yes.