### PR TITLE
fix(models): read self-hosted context metadata

### DIFF
--- a/src/plugins/provider-self-hosted-setup.test.ts
+++ b/src/plugins/provider-self-hosted-setup.test.ts
@@ -146,6 +146,29 @@ function cancelTrackedResponse(init?: ResponseInit): {
   };
 }
 
+async function discoverSingleCatalogModel(
+  row: Record<string, unknown>,
+  options?: { contextWindow?: number },
+) {
+  const release = vi.fn(async () => undefined);
+  fetchWithSsrFGuardMock.mockResolvedValueOnce({
+    response: new Response(JSON.stringify({ data: [row] }), { status: 200 }),
+    finalUrl: "https://provider.example/v1/models",
+    release,
+  });
+
+  const models = await discoverOpenAICompatibleLocalModels({
+    baseUrl: "https://provider.example/v1",
+    label: "custom provider",
+    contextWindow: options?.contextWindow,
+    discoverRuntimeContext: false,
+    env: {},
+  });
+
+  expect(release).toHaveBeenCalledOnce();
+  return models[0];
+}
+
 describe("discoverOpenAICompatibleLocalModels", () => {
   it("retains valid models when a provider catalog contains malformed entries", async () => {
     const release = vi.fn(async () => undefined);
@@ -379,6 +402,57 @@ describe("discoverOpenAICompatibleLocalModels", () => {
     expect(propsRelease).toHaveBeenCalledOnce();
     expect(propsResponse.wasCanceled()).toBe(true);
   });
+
+  it.each([
+    ["context_length", 200_000],
+    ["context_window", 400_000],
+    ["context_size", 1_048_576],
+  ] as const)("reads provider-advertised %s", async (field, contextWindow) => {
+    const model = await discoverSingleCatalogModel({ id: "custom-model", [field]: contextWindow });
+
+    expect(model).toMatchObject({ id: "custom-model", contextWindow });
+  });
+
+  it("keeps explicit and llama.cpp metadata ahead of top-level catalog fields", async () => {
+    const row = {
+      id: "custom-model",
+      meta: { n_ctx_train: 262_144 },
+      context_length: 200_000,
+      context_window: 100_000,
+      context_size: 50_000,
+    };
+
+    await expect(discoverSingleCatalogModel(row)).resolves.toMatchObject({
+      contextWindow: 262_144,
+    });
+
+    await expect(
+      discoverSingleCatalogModel(row, { contextWindow: 524_288 }),
+    ).resolves.toMatchObject({ contextWindow: 524_288 });
+  });
+
+  it("uses a deterministic top-level field priority", async () => {
+    const model = await discoverSingleCatalogModel({
+      id: "custom-model",
+      context_length: 300_000,
+      context_window: 200_000,
+      context_size: 100_000,
+    });
+
+    expect(model).toMatchObject({ contextWindow: 300_000 });
+  });
+
+  it.each([0, -1, "1048576", null])(
+    "ignores malformed top-level context metadata: %j",
+    async (contextSize) => {
+      const model = await discoverSingleCatalogModel({
+        id: "custom-model",
+        context_size: contextSize,
+      });
+
+      expect(model).toMatchObject({ contextWindow: 128_000 });
+    },
+  );
 
   it("cancels model discovery error bodies before falling back", async () => {
     const release = vi.fn(async () => undefined);

--- a/src/plugins/provider-self-hosted-setup.ts
+++ b/src/plugins/provider-self-hosted-setup.ts
@@ -90,6 +90,24 @@ function readPositiveInteger(value: unknown): number | undefined {
   return Math.trunc(value);
 }
 
+const OPENAI_COMPAT_CONTEXT_WINDOW_FIELDS = [
+  "context_length",
+  "context_window",
+  "context_size",
+] as const;
+
+function readOpenAICompatibleContextWindow(
+  model: Record<string, unknown> | undefined,
+): number | undefined {
+  for (const field of OPENAI_COMPAT_CONTEXT_WINDOW_FIELDS) {
+    const contextWindow = readPositiveInteger(model?.[field]);
+    if (contextWindow !== undefined) {
+      return contextWindow;
+    }
+  }
+  return undefined;
+}
+
 async function readSelfHostedDiscoveryJson<T>(response: Response, label: string): Promise<T> {
   return await readProviderJsonResponse<T>(response, `${label} discovery`, {
     maxBytes: SELF_HOSTED_DISCOVERY_JSON_MAX_BYTES,
@@ -209,7 +227,13 @@ export async function discoverOpenAICompatibleLocalModels(params: {
         if (!modelId) {
           return [];
         }
-        return [{ id: modelId, meta: asObject(model?.meta) }];
+        return [
+          {
+            id: modelId,
+            meta: asObject(model?.meta),
+            advertisedContextWindow: readOpenAICompatibleContextWindow(model),
+          },
+        ];
       });
       const runtimeContextTokensByModelId = new Map<string, number>();
       if (params.contextWindow === undefined && params.discoverRuntimeContext !== false) {
@@ -253,6 +277,7 @@ export async function discoverOpenAICompatibleLocalModels(params: {
           contextWindow:
             params.contextWindow ??
             readPositiveInteger(model.meta?.n_ctx_train) ??
+            model.advertisedContextWindow ??
             SELF_HOSTED_DEFAULT_CONTEXT_WINDOW,
           maxTokens: params.maxTokens ?? SELF_HOSTED_DEFAULT_MAX_TOKENS,
         };


### PR DESCRIPTION
Closes #109367
Replaces #109368 on current `main`.

## What Problem This Solves

Fixes an issue where self-hosted OpenAI-compatible model discovery ignored top-level context metadata. Providers such as Cortecs advertise `context_size: 1048576`, but OpenClaw discarded that value and assigned its 128k fallback, triggering unnecessary compaction on sessions the model could accept directly.

## Why This Change Was Made

The discovery owner now normalizes the three observed field conventions—`context_length`, `context_window`, and `context_size`—into one validated value before model construction. Explicit operator configuration remains authoritative, llama.cpp's established `meta.n_ctx_train` stays next, provider-advertised top-level metadata follows, and the generic default remains last.

This rebuilds the contributor's correct two-file fix on current `main`, while carrying only validated metadata through the runtime and adding malformed-input coverage.

## User Impact

Self-hosted providers that publish their real context capacity at the top level of `/v1/models` now get accurate catalog and compaction limits instead of silently falling back to 128k.

## Evidence

- @Mohl's live Cortecs proof on #109368 discovered `glm-5.2` with `contextWindow: 1048576` across 74 live models after the fix.
- `node scripts/run-vitest.mjs src/plugins/provider-self-hosted-setup.test.ts` — 29 tests passed on rebased head `cd8a80b54cda`.
- Coverage includes all three accepted field names, deterministic field priority, explicit/llama.cpp precedence, malformed values, and response-release behavior.
- Blacksmith Testbox `tbx_01kyp25rdd8yta45py6ddaj40e` / Actions run https://github.com/openclaw/openclaw/actions/runs/30422428024 — `node scripts/check-changed.mjs` passed.
- Codex autoreview on the exact branch diff: no accepted/actionable findings, confidence 0.95.
- No approved Cortecs credential was present in the Molty vault, so the current head did not repeat the authenticated call; the contributor's redacted live result remains the external behavior proof.
