### PR TITLE
fix(cli): keep forced gateway startup working when listeners exit

### DIFF
--- a/src/cli/ports.ts
+++ b/src/cli/ports.ts
@@ -295,10 +295,13 @@ function killPids(
   beforeSignal?: BeforePortSignal,
 ) {
   for (const proc of listeners) {
+    beforeSignal?.({ port, pid: proc.pid, signal });
     try {
-      beforeSignal?.({ port, pid: proc.pid, signal });
       process.kill(proc.pid, signal);
     } catch (err) {
+      if (getErrnoCode(err) === "ESRCH") {
+        continue;
+      }
       throw new Error(
         `failed to kill pid ${proc.pid}${proc.command ? ` (${proc.command})` : ""}: ${String(err)}`,
         { cause: err },

--- a/src/cli/program.force.test.ts
+++ b/src/cli/program.force.test.ts
@@ -208,6 +208,52 @@ describe("gateway --force helpers", () => {
     ]);
   });
 
+  it("continues when a discovered listener exits before it can be signaled", () => {
+    (execFileSync as unknown as Mock).mockReturnValue(
+      ["p42", "cnode", "p99", "cssh", ""].join("\n"),
+    );
+    const gone = Object.assign(new Error("no such process"), { code: "ESRCH" });
+    const killMock = vi.fn().mockImplementationOnce(() => {
+      throw gone;
+    });
+    process.kill = killMock;
+
+    expect(forceFreePort(18789)).toEqual<PortProcess[]>([
+      { pid: 42, command: "node" },
+      { pid: 99, command: "ssh" },
+    ]);
+    expect(killMock).toHaveBeenNthCalledWith(1, 42, "SIGTERM");
+    expect(killMock).toHaveBeenNthCalledWith(2, 99, "SIGTERM");
+  });
+
+  it("does not suppress listener ownership-guard errors", () => {
+    (execFileSync as unknown as Mock).mockReturnValue(["p42", "cnode", ""].join("\n"));
+    const guardError = Object.assign(new Error("ownership verification failed"), {
+      code: "ESRCH",
+    });
+    const killMock = vi.fn();
+    process.kill = killMock;
+
+    expect(() =>
+      forceFreePort(18789, {
+        beforeSignal: () => {
+          throw guardError;
+        },
+      }),
+    ).toThrow(guardError);
+    expect(killMock).not.toHaveBeenCalled();
+  });
+
+  it("preserves real signal permission failures", () => {
+    (execFileSync as unknown as Mock).mockReturnValue(["p42", "cnode", ""].join("\n"));
+    const denied = Object.assign(new Error("permission denied"), { code: "EPERM" });
+    process.kill = vi.fn(() => {
+      throw denied;
+    });
+
+    expect(() => forceFreePort(18789)).toThrow(/failed to kill pid 42/);
+  });
+
   it("retries until the port is free", async () => {
     vi.useFakeTimers();
     let call = 0;


### PR DESCRIPTION
Supersedes #109713; credit to @Monkey-wusky for identifying the listener-exit race.

## What Problem This Solves

Fixes an issue where users starting the gateway with --force could receive a fatal "failed to kill pid ... no such process" when a port listener exited between discovery and signaling.

## Why This Change Was Made

Treat only an actual process.kill ESRCH as successful cleanup and continue through remaining discovered listeners. Keep the last-moment ownership guard outside the signal-error handler so permission errors and ownership-verification failures cannot be silently ignored. This also fixes the shared SIGKILL-escalation and guarded fuser paths without introducing fallback behavior.

## User Impact

Forced gateway startup continues when its discovered listener has already exited, while preserving protections against killing an unexpected process and surfacing real permission failures.

## Evidence

- Fail-first on current main: the new canonical gateway-force regressions failed for both an exited listener and unchanged ownership-guard errors.
- Exact final trusted source: 36/36 passed across src/cli/program.force.test.ts and src/cli/ports.test.ts, including remaining listeners, EPERM, beforeSignal, Linux/fuser, Windows and SIGKILL escalation.
- Real Linux end-to-end: dynamically allocated an owned TCP listener; real lsof discovered its real child PID; independently killed and reaped only that child immediately before the actual owner forceFreePort signaling; observed actual OS ESRCH; verified cleanup success and rebound the same TCP port.
- Full remote pnpm check:changed passed, including formatting, both core and core-test typechecks, 0-warning changed-file lint, dependency/plugin/runtime/database guards and dead-export scans.
- Exact-final gpt-5.6-sol xhigh autoreview: clean, no accepted or actionable findings.
- Node process.kill missing-PID and signal-0 existence contract: https://nodejs.org/api/process.html#processkillpid-signal
