### PR TITLE
fix(release): validate MiniMax tool-only turns

### DIFF
--- a/src/gateway/gateway-models.profiles.live.test.ts
+++ b/src/gateway/gateway-models.profiles.live.test.ts
@@ -1685,6 +1685,11 @@ function shouldSkipToolNonceProbeMissForLiveModel(modelKey?: string): boolean {
   return GATEWAY_LIVE_TOOL_NONCE_MISS_SKIP_MODEL_KEYS.has(normalizedKey);
 }
 
+function allowsToolOnlyReadTurnForLiveModel(modelKey?: string): boolean {
+  const provider = modelKey?.split("/", 1)[0];
+  return provider === "minimax" || provider === "minimax-portal";
+}
+
 describe("shouldSkipToolNonceProbeMissForLiveModel", () => {
   it.each([
     { modelKey: "anthropic/claude-opus-4-6", expected: true },
@@ -1701,6 +1706,16 @@ describe("shouldSkipToolNonceProbeMissForLiveModel", () => {
     { modelKey: "openai/gpt-5.4", expected: false },
   ])("returns $expected for $modelKey", ({ modelKey, expected }) => {
     expect(shouldSkipToolNonceProbeMissForLiveModel(modelKey)).toBe(expected);
+  });
+});
+
+describe("allowsToolOnlyReadTurnForLiveModel", () => {
+  it.each([
+    { modelKey: "minimax/MiniMax-M2.7", expected: true },
+    { modelKey: "minimax-portal/MiniMax-M2.7", expected: true },
+    { modelKey: "anthropic/claude-opus-4-6", expected: false },
+  ])("returns $expected for $modelKey", ({ modelKey, expected }) => {
+    expect(allowsToolOnlyReadTurnForLiveModel(modelKey)).toBe(expected);
   });
 });
 
@@ -2675,6 +2690,14 @@ function buildGatewayToolReadMessage(params: {
   );
 }
 
+function buildGatewayToolReadFollowUpMessage(params: { toolProbePath: string }): string {
+  const filename = path.basename(params.toolProbePath);
+  return (
+    `Continue the OpenClaw release-validation check for the synthetic local note "${filename}" ` +
+    "you just inspected. Reply with only its LEFT and RIGHT values, separated by one space."
+  );
+}
+
 describe("buildGatewayToolReadMessage", () => {
   it("keeps the request inside the workspace and out of tool-call syntax", () => {
     const message = buildGatewayToolReadMessage({
@@ -2689,6 +2712,16 @@ describe("buildGatewayToolReadMessage", () => {
     expect(message).not.toContain("/tmp/operator");
     expect(message).not.toContain('{"path"');
     expect(message).not.toContain("tool named");
+  });
+  it("keeps the tool-only follow-up scoped to the same synthetic note", () => {
+    const message = buildGatewayToolReadFollowUpMessage({
+      toolProbePath: "/tmp/operator/workspace/.openclaw-live-tool-probe-deadbeef.txt",
+    });
+
+    expect(message).toContain('".openclaw-live-tool-probe-deadbeef.txt"');
+    expect(message).toContain("synthetic local note");
+    expect(message).toContain("Reply with only");
+    expect(message).not.toContain("/tmp/operator");
   });
 });
 
@@ -3483,6 +3516,7 @@ async function runGatewayModelSuite(params: GatewayModelSuiteParams) {
               logProgress(`${progressLabel}: tool-read`);
               const runIdTool = randomUUID();
               const maxToolReadAttempts = 3;
+              const allowsToolOnlyReadTurn = allowsToolOnlyReadTurnForLiveModel(modelKey);
               let toolText = "";
               for (
                 let toolReadAttempt = 0;
@@ -3499,6 +3533,9 @@ async function runGatewayModelSuite(params: GatewayModelSuiteParams) {
                     message: buildGatewayToolReadMessage({ toolProbePath, strictReply }),
                     thinkingLevel,
                     context: `${progressLabel}: tool-read`,
+                    ...(allowsToolOnlyReadTurn && toolReadAttempt === 0
+                      ? { assistantText: "optional" as const }
+                      : {}),
                   });
                 } catch (error) {
                   const message = String(error instanceof Error ? error.message : error);
@@ -3522,6 +3559,7 @@ async function runGatewayModelSuite(params: GatewayModelSuiteParams) {
                 }
                 if (
                   isEmptyStreamText(toolText) &&
+                  !allowsToolOnlyReadTurn &&
                   shouldSkipEmptyResponseForLiveModel({
                     provider: model.provider,
                     allowNotFoundSkip: params.allowNotFoundSkip,
@@ -3538,6 +3576,30 @@ async function runGatewayModelSuite(params: GatewayModelSuiteParams) {
                 });
                 if (hasExpectedToolNonce(toolText, nonceA, nonceB)) {
                   break;
+                }
+                if (allowsToolOnlyReadTurn && toolReadAttempt === 0) {
+                  logProgress(`${progressLabel}: tool-read follow-up`);
+                  toolText = await requestGatewayAgentText({
+                    client,
+                    sessionKey,
+                    idempotencyKey: `idem-${runIdTool}-tool-follow-up`,
+                    modelKey,
+                    message: buildGatewayToolReadFollowUpMessage({ toolProbePath }),
+                    thinkingLevel,
+                    context: `${progressLabel}: tool-read follow-up`,
+                  });
+                  assertNoReasoningTags({
+                    text: toolText,
+                    model: modelKey,
+                    phase: "tool-read-follow-up",
+                    label: params.label,
+                  });
+                  if (hasExpectedToolNonce(toolText, nonceA, nonceB)) {
+                    break;
+                  }
+                  // MiniMax can finish the read turn without a final reply. A separate reply
+                  // must still carry the values; repeating the same read would hide that contract.
+                  throw new Error(`tool probe missing nonce: ${toolText}`);
                 }
                 if (
                   shouldRetryToolReadProbe({


### PR DESCRIPTION
## What Problem This Solves

Resolves a release-validation failure where both MiniMax M2.7 profile lanes successfully read the synthetic note but completed the tool turn without a terminal assistant reply. The test then reported a misleading "tool probe nonce miss" and skipped both models.

## Why This Change Was Made

The live harness already supports terminal tool-only turns where that is an explicit provider contract. For MiniMax only, this accepts the completed first read, then requires a separate strict follow-up to return both values. It does not accept the tool-only turn as proof by itself and it does not repeat the same read hoping for a different result.

## User Impact

The 2026.6.34 MiniMax release lane validates an actual tool read plus a value-bearing follow-up, while preserving failure/skip behavior if the model cannot produce that follow-up.

## Evidence

- Failing release check: https://github.com/openclaw/openclaw/actions/runs/30359628136/job/90276570817
- Both failures logged the exact values as `read` tool results, followed by terminal completion without an assistant reply.
- Existing tool-only contract inspected in `requestGatewayAgentText`; this patch uses its established follow-up-proof pattern rather than adding a retry exception.
- `git diff --check` passed.
- Fresh autoreview: no accepted/actionable findings.
- Focused local Vitest is unavailable because this linked worktree has no `node_modules`; exact-head hosted CI will run the gateway live-test file.