### PR TITLE
fix(doctor): skip unusable registered agent databases

### DIFF
--- a/src/commands/doctor-agent-database-operation.ts
+++ b/src/commands/doctor-agent-database-operation.ts
@@ -1,0 +1,22 @@
+import { note } from "../../packages/terminal-core/src/note.js";
+import { formatErrorMessage } from "../infra/errors.js";
+import { shortenHomePath } from "../utils.js";
+
+type DoctorAgentDatabaseOperationResult<T> = { ok: true; value: T } | { ok: false };
+
+/** Keep one unusable agent database from aborting sibling Doctor work. */
+export function runDoctorAgentDatabaseOperation<T>(params: {
+  agentId: string;
+  path: string;
+  run: () => T;
+}): DoctorAgentDatabaseOperationResult<T> {
+  try {
+    return { ok: true, value: params.run() };
+  } catch (error) {
+    note(
+      `- Agent ${params.agentId} database ${shortenHomePath(params.path)}: ${formatErrorMessage(error)}`,
+      "Doctor warnings",
+    );
+    return { ok: false };
+  }
+}

--- a/src/commands/doctor-agent-memory-schema.ts
+++ b/src/commands/doctor-agent-memory-schema.ts
@@ -67,7 +67,10 @@ function repairDoctorAgentMemorySchemas(
   const warnings: string[] = [];
   let registered: ReturnType<typeof listOpenClawRegisteredAgentDatabases>;
   try {
-    registered = listOpenClawRegisteredAgentDatabases({ env });
+    registered = listOpenClawRegisteredAgentDatabases({
+      env,
+      includeIncompatibleSchemaVersions: true,
+    });
   } catch (error) {
     return {
       repaired,

--- a/src/commands/doctor-session-delivery-state.test.ts
+++ b/src/commands/doctor-session-delivery-state.test.ts
@@ -59,6 +59,20 @@ function readEntryJson(env: NodeJS.ProcessEnv, sessionKey: string): string {
 }
 
 describe("doctor canonical session delivery state", () => {
+  it("warns and skips an unmigrated agent database", () => {
+    const stateDir = fs.realpathSync(tempDirs.make("openclaw-delivery-legacy-schema-"));
+    const env = { ...process.env, OPENCLAW_STATE_DIR: stateDir };
+    const database = openOpenClawAgentDatabase({ agentId: "main", env });
+    database.db.exec("PRAGMA user_version = 8;");
+    closeOpenClawAgentDatabasesForTest();
+
+    expect(repairCanonicalSessionDeliveryStates({ apply: true, cfg: {}, env })).toEqual({
+      found: 0,
+      repaired: 0,
+      scannedStores: 1,
+    });
+  });
+
   it("keeps bare channel and origin metadata below explicit delivery context", () => {
     const stateDir = fs.realpathSync(tempDirs.make("openclaw-delivery-fallback-order-"));
     const env = { ...process.env, OPENCLAW_STATE_DIR: stateDir };

--- a/src/commands/doctor-session-delivery-state.ts
+++ b/src/commands/doctor-session-delivery-state.ts
@@ -16,6 +16,7 @@ import {
   deliveryContextFromSession,
   sessionDeliveryChannel,
 } from "../utils/delivery-context.shared.js";
+import { runDoctorAgentDatabaseOperation } from "./doctor-agent-database-operation.js";
 import { resolveTargetSqlitePath } from "./doctor-session-sqlite-readers.js";
 
 export type SessionDeliveryStateRepairReport = {
@@ -42,15 +43,21 @@ export function repairCanonicalSessionDeliveryStates(params: {
   let found = 0;
   let repaired = 0;
   for (const target of targets) {
-    const inspected = withOpenClawAgentDatabaseReadOnly(
-      (database) => collectDeliveryRewrites(database.db),
-      { agentId: target.agentId, env: params.env, path: target.sqlitePath },
-    );
-    if (!inspected.found) {
+    const operation = runDoctorAgentDatabaseOperation({
+      agentId: target.agentId,
+      path: target.sqlitePath,
+      run: () =>
+        withOpenClawAgentDatabaseReadOnly((database) => collectDeliveryRewrites(database.db), {
+          agentId: target.agentId,
+          env: params.env,
+          path: target.sqlitePath,
+        }),
+    });
+    if (!operation.ok || !operation.value.found) {
       continue;
     }
-    found += inspected.value.length;
-    if (!params.apply || inspected.value.length === 0) {
+    found += operation.value.value.length;
+    if (!params.apply || operation.value.value.length === 0) {
       continue;
     }
     const wasOpen = isOpenClawAgentDatabaseOpen(target.sqlitePath);

--- a/src/commands/doctor-session-incognito-key-repair.ts
+++ b/src/commands/doctor-session-incognito-key-repair.ts
@@ -15,6 +15,7 @@ import {
   openOpenClawStateDatabase,
   runOpenClawStateWriteTransaction,
 } from "../state/openclaw-state-db.js";
+import { runDoctorAgentDatabaseOperation } from "./doctor-agent-database-operation.js";
 import {
   collectSharedStateSessionKeys,
   deleteRepairJournal,
@@ -46,20 +47,25 @@ export function repairReservedIncognitoSessionKeys(params: {
     ? collectSharedStateSessionKeys(sharedDatabase.db)
     : new Set<string>();
   for (const target of targets) {
-    const inspected = withOpenClawAgentDatabaseReadOnly(
-      (database) => ({
-        occupied: params.apply ? collectOccupiedSessionKeys(database.db) : new Set<string>(),
-        reserved: listReservedIncognitoKeys(database.db),
-      }),
-      { agentId: target.agentId, env: params.env, path: target.sqlitePath },
-    );
-    if (!inspected.found) {
+    const operation = runDoctorAgentDatabaseOperation({
+      agentId: target.agentId,
+      path: target.sqlitePath,
+      run: () =>
+        withOpenClawAgentDatabaseReadOnly(
+          (database) => ({
+            occupied: params.apply ? collectOccupiedSessionKeys(database.db) : new Set<string>(),
+            reserved: listReservedIncognitoKeys(database.db),
+          }),
+          { agentId: target.agentId, env: params.env, path: target.sqlitePath },
+        ),
+    });
+    if (!operation.ok || !operation.value.found) {
       continue;
     }
-    for (const key of inspected.value.reserved) {
+    for (const key of operation.value.value.reserved) {
       reservedKeys.add(key);
     }
-    for (const key of inspected.value.occupied) {
+    for (const key of operation.value.value.occupied) {
       occupiedKeys.add(key);
     }
   }

--- a/src/commands/doctor-telegram-general-topic-conversations.ts
+++ b/src/commands/doctor-telegram-general-topic-conversations.ts
@@ -19,6 +19,7 @@ import {
   runOpenClawAgentWriteTransaction,
   type OpenClawAgentDatabase,
 } from "../state/openclaw-agent-db.js";
+import { runDoctorAgentDatabaseOperation } from "./doctor-agent-database-operation.js";
 
 const GENERAL_TOPIC_ID = "1";
 const LEGACY_GENERAL_TARGET = /^telegram:(-?\d+):topic:1$/u;
@@ -105,24 +106,30 @@ export function detectTelegramGeneralTopicConversationRepairs(params: {
 }): TelegramGeneralTopicConversationRepair[] {
   const env = params.env ?? process.env;
   return resolveRepairScopes(params.cfg, env).flatMap(({ scope, storePath }) => {
-    const result = withOpenClawAgentDatabaseReadOnly(
-      (database) =>
-        listLegacyRows(database.db).flatMap((row) => {
-          const canonical = canonicalIdentity(row);
-          return canonical && canonical.conversationId !== row.conversation_id
-            ? [
-                {
-                  agentId: scope.agentId,
-                  canonicalConversationId: canonical.conversationId,
-                  legacyConversationId: row.conversation_id,
-                  storePath,
-                },
-              ]
-            : [];
-        }),
-      toDatabaseOptions(scope),
-    );
-    return result.found ? result.value : [];
+    const databaseOptions = toDatabaseOptions(scope);
+    const inspected = runDoctorAgentDatabaseOperation({
+      agentId: scope.agentId,
+      path: databaseOptions.path ?? storePath,
+      run: () =>
+        withOpenClawAgentDatabaseReadOnly(
+          (database) =>
+            listLegacyRows(database.db).flatMap((row) => {
+              const canonical = canonicalIdentity(row);
+              return canonical && canonical.conversationId !== row.conversation_id
+                ? [
+                    {
+                      agentId: scope.agentId,
+                      canonicalConversationId: canonical.conversationId,
+                      legacyConversationId: row.conversation_id,
+                      storePath,
+                    },
+                  ]
+                : [];
+            }),
+          databaseOptions,
+        ),
+    });
+    return inspected.ok && inspected.value.found ? inspected.value.value : [];
   });
 }
 

--- a/src/commands/doctor-usage-cost-cache.ts
+++ b/src/commands/doctor-usage-cost-cache.ts
@@ -6,6 +6,7 @@ import { note } from "../../packages/terminal-core/src/note.js";
 import { resolveStateDir } from "../config/paths.js";
 import { deleteSessionCostUsageRollupsExcept } from "../infra/session-cost-usage-cache.sqlite.js";
 import { listOpenClawRegisteredAgentDatabases } from "../state/openclaw-agent-db.js";
+import { runDoctorAgentDatabaseOperation } from "./doctor-agent-database-operation.js";
 import { maybeScrubConfigAuditLog } from "./doctor-config-audit-scrub.js";
 
 const LEGACY_USAGE_COST_TEMP_GRACE_MS = 10_000;
@@ -135,12 +136,17 @@ export async function maybeRepairLegacyRuntimeFiles(
   if (shouldRepair) {
     for (const entry of listOpenClawRegisteredAgentDatabases({ env })) {
       if ((await fs.stat(entry.path).catch(() => null))?.isFile()) {
-        deleteSessionCostUsageRollupsExcept({
+        runDoctorAgentDatabaseOperation({
           agentId: entry.agentId,
-          databasePath: entry.path,
-          liveKeys: new Set(),
-          // Doctor retires old scopes only; current v2 rows are not prune candidates.
-          rows: [],
+          path: entry.path,
+          run: () =>
+            deleteSessionCostUsageRollupsExcept({
+              agentId: entry.agentId,
+              databasePath: entry.path,
+              liveKeys: new Set(),
+              // Doctor retires old scopes only; current v2 rows are not prune candidates.
+              rows: [],
+            }),
         });
       }
     }

--- a/src/infra/state-migrations.media-persistence.test.ts
+++ b/src/infra/state-migrations.media-persistence.test.ts
@@ -12,11 +12,15 @@ import { reconcileSessionTranscriptIndexInTransaction } from "../config/sessions
 import { registerOpenClawAgentDatabase } from "../state/openclaw-agent-db-registry.js";
 import {
   closeOpenClawAgentDatabasesForTest,
+  listOpenClawRegisteredAgentDatabases,
   OPENCLAW_AGENT_SCHEMA_VERSION,
   openOpenClawAgentDatabase,
   runOpenClawAgentWriteTransaction,
 } from "../state/openclaw-agent-db.js";
-import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
+import {
+  closeOpenClawStateDatabaseForTest,
+  openOpenClawStateDatabase,
+} from "../state/openclaw-state-db.js";
 import { requireNodeSqlite } from "./node-sqlite.js";
 import { migrateLegacyMediaPersistence } from "./state-migrations.media-persistence.js";
 
@@ -103,7 +107,12 @@ function createLegacyDatabaseFixture(params: {
   } finally {
     database.close();
   }
-  registerOpenClawAgentDatabase({ agentId, env: params.env, path: databasePath });
+  registerOpenClawAgentDatabase({
+    agentId,
+    env: params.env,
+    path: databasePath,
+    schemaVersion: PREVIOUS_VERSION,
+  });
   return databasePath;
 }
 
@@ -801,6 +810,44 @@ describe("legacy media persistence doctor migration", () => {
     const result = migrateLegacyMediaPersistence({ env });
     expect(result.warnings).toHaveLength(1);
     expect(readDatabaseSnapshot(databasePath).version.user_version).toBe(PREVIOUS_VERSION);
+    expect(listOpenClawRegisteredAgentDatabases({ env })).toEqual([]);
+    expect(
+      listOpenClawRegisteredAgentDatabases({
+        env,
+        includeIncompatibleSchemaVersions: true,
+      }),
+    ).toEqual([expect.objectContaining({ path: databasePath, schemaVersion: PREVIOUS_VERSION })]);
+  });
+
+  it("prunes missing and archived registry entries before migration", () => {
+    const stateDir = makeTempDir(tempDirs, "media-persistence-registry-hygiene-");
+    const env = { OPENCLAW_STATE_DIR: stateDir };
+    const missingPath = path.join(stateDir, "agents", "missing", "agent", "openclaw-agent.sqlite");
+    const archivedPath = path.join(stateDir, "imports", "archived", "openclaw-agent.sqlite");
+    fs.mkdirSync(path.dirname(archivedPath), { recursive: true });
+    fs.writeFileSync(archivedPath, "archived fixture");
+    const state = openOpenClawStateDatabase({ env });
+    const insert = state.db.prepare(
+      "INSERT INTO agent_databases(agent_id,path,schema_version,last_seen_at,size_bytes) VALUES(?,?,?,?,?)",
+    );
+    insert.run("missing", missingPath, OPENCLAW_AGENT_SCHEMA_VERSION, 1, null);
+    insert.run("archived", archivedPath, 8, 1, null);
+
+    const result = migrateLegacyMediaPersistence({ env });
+
+    expect(result.changes).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining("Removed missing agent database registry entry"),
+        expect.stringContaining("Removed archived or transient agent database registry entry"),
+      ]),
+    );
+    expect(result.warnings).toContain(`Skipped missing registered agent database ${missingPath}.`);
+    expect(
+      listOpenClawRegisteredAgentDatabases({
+        env,
+        includeIncompatibleSchemaVersions: true,
+      }),
+    ).toEqual([]);
   });
 
   it("aborts one database on invalid trajectory JSON without advancing its version", () => {

--- a/src/infra/state-migrations.media-persistence.ts
+++ b/src/infra/state-migrations.media-persistence.ts
@@ -17,8 +17,12 @@ import {
   hasMeaningfulRetiredMediaCarrier,
 } from "../media/media-facts.js";
 import { assertOpenClawAgentDatabaseOwner } from "../state/openclaw-agent-db-maintenance.js";
-import { listOpenClawRegisteredAgentDatabases } from "../state/openclaw-agent-db-registry.js";
-import { registerOpenClawAgentDatabase } from "../state/openclaw-agent-db-registry.js";
+import {
+  isPersistentOpenClawAgentDatabasePath,
+  listOpenClawRegisteredAgentDatabases,
+  registerOpenClawAgentDatabase,
+  unregisterOpenClawAgentDatabase,
+} from "../state/openclaw-agent-db-registry.js";
 import { assertOpenClawAgentSchemaContains } from "../state/openclaw-agent-db-schema-helpers.js";
 import { migrateOpenClawAgentDatabaseToMediaPrerequisiteSchema } from "../state/openclaw-agent-db-schema.js";
 import type { DB as OpenClawAgentKyselyDatabase } from "../state/openclaw-agent-db.generated.js";
@@ -580,7 +584,10 @@ export function migrateLegacyMediaPersistence(
   const warnings: string[] = [];
   let registered: ReturnType<typeof listOpenClawRegisteredAgentDatabases>;
   try {
-    registered = listOpenClawRegisteredAgentDatabases({ env });
+    registered = listOpenClawRegisteredAgentDatabases({
+      env,
+      includeIncompatibleSchemaVersions: true,
+    });
   } catch (error) {
     return {
       changes,
@@ -594,6 +601,26 @@ export function migrateLegacyMediaPersistence(
   const archiveDirectories = new Set<string>();
   for (const entry of registered) {
     const pathname = path.resolve(entry.path);
+    if (!isPersistentOpenClawAgentDatabasePath(pathname, env)) {
+      unregisterOpenClawAgentDatabase({ agentId: entry.agentId, env, path: entry.path });
+      changes.push(`Removed archived or transient agent database registry entry ${pathname}.`);
+      continue;
+    }
+    let stat: fs.Stats | undefined;
+    try {
+      stat = fs.statSync(pathname);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+        warnings.push(`Could not inspect registered agent database ${pathname}: ${String(error)}`);
+        continue;
+      }
+    }
+    if (!stat?.isFile()) {
+      unregisterOpenClawAgentDatabase({ agentId: entry.agentId, env, path: entry.path });
+      changes.push(`Removed missing agent database registry entry ${pathname}.`);
+      warnings.push(`Skipped missing registered agent database ${pathname}.`);
+      continue;
+    }
     archiveDirectories.add(
       resolveSqliteTranscriptArchiveDirectory({
         agentId: entry.agentId,

--- a/src/state/openclaw-agent-db-registry-listing.ts
+++ b/src/state/openclaw-agent-db-registry-listing.ts
@@ -3,7 +3,10 @@ import path from "node:path";
 import { executeSqliteQuerySync, getNodeSqliteKysely } from "../infra/kysely-sync.js";
 import { resolveSqliteDatabaseFilePaths } from "../infra/sqlite-files.js";
 import { normalizeAgentId } from "../routing/session-key.js";
-import type { OpenClawRegisteredAgentDatabase } from "./openclaw-agent-db-contract.js";
+import {
+  OPENCLAW_AGENT_SCHEMA_VERSION,
+  type OpenClawRegisteredAgentDatabase,
+} from "./openclaw-agent-db-contract.js";
 import { withOpenClawStateDatabaseReadOnly } from "./openclaw-state-db-readonly.js";
 import { detectOpenClawStateDatabaseSchemaMigrationsFromDatabase } from "./openclaw-state-db-schema-repair.js";
 import type { DB as OpenClawStateKyselyDatabase } from "./openclaw-state-db.generated.js";
@@ -79,11 +82,16 @@ function hasUnavailableMissingSqlitePath(pathname: string): boolean {
 
 /** List agent databases recorded in the shared OpenClaw state registry. */
 export function listOpenClawRegisteredAgentDatabases(
-  options: OpenClawStateDatabaseOptions = {},
+  options: OpenClawStateDatabaseOptions & {
+    includeIncompatibleSchemaVersions?: boolean;
+  } = {},
 ): OpenClawRegisteredAgentDatabase[] {
   const pathname = resolveAgentDatabaseRegistryPath(options);
   if (registeredAgentDatabasesMemo?.pathname === pathname) {
-    return cloneRegisteredAgentDatabases(registeredAgentDatabasesMemo.entries);
+    const entries = cloneRegisteredAgentDatabases(registeredAgentDatabasesMemo.entries);
+    return options.includeIncompatibleSchemaVersions
+      ? entries
+      : entries.filter((entry) => entry.schemaVersion === OPENCLAW_AGENT_SCHEMA_VERSION);
   }
   if (!existsSync(pathname)) {
     if (hasUnavailableMissingSqlitePath(pathname)) {
@@ -128,5 +136,8 @@ export function listOpenClawRegisteredAgentDatabases(
     }));
   }, options);
   registeredAgentDatabasesMemo = { pathname, entries };
-  return cloneRegisteredAgentDatabases(entries);
+  const cloned = cloneRegisteredAgentDatabases(entries);
+  return options.includeIncompatibleSchemaVersions
+    ? cloned
+    : cloned.filter((entry) => entry.schemaVersion === OPENCLAW_AGENT_SCHEMA_VERSION);
 }

--- a/src/state/openclaw-agent-db-registry.ts
+++ b/src/state/openclaw-agent-db-registry.ts
@@ -1,7 +1,9 @@
 import { randomBytes } from "node:crypto";
 import { lstatSync, mkdirSync, readlinkSync, realpathSync, rmdirSync, statSync } from "node:fs";
 import path from "node:path";
+import { resolveStateDir } from "../config/paths.js";
 import { executeSqliteQuerySync, getNodeSqliteKysely } from "../infra/kysely-sync.js";
+import { isPathInside } from "../infra/path-guards.js";
 import {
   assertAgentDeletionPathFence,
   prepareAgentDeletionPathFence,
@@ -569,7 +571,11 @@ export function registerOpenClawAgentDatabase(params: {
   agentId: string;
   path: string;
   env?: NodeJS.ProcessEnv;
+  schemaVersion?: number;
 }): void {
+  if (!isPersistentOpenClawAgentDatabasePath(params.path, params.env)) {
+    return;
+  }
   const deletionFence = prepareAgentDeletionPathFence(
     { agentId: params.agentId, path: params.path },
     { env: params.env },
@@ -592,13 +598,13 @@ export function registerOpenClawAgentDatabase(params: {
           .values({
             agent_id: params.agentId,
             path: params.path,
-            schema_version: OPENCLAW_AGENT_SCHEMA_VERSION,
+            schema_version: params.schemaVersion ?? OPENCLAW_AGENT_SCHEMA_VERSION,
             last_seen_at: lastSeenAt,
             size_bytes: sizeBytes,
           })
           .onConflict((conflict) =>
             conflict.columns(["agent_id", "path"]).doUpdateSet({
-              schema_version: OPENCLAW_AGENT_SCHEMA_VERSION,
+              schema_version: params.schemaVersion ?? OPENCLAW_AGENT_SCHEMA_VERSION,
               last_seen_at: lastSeenAt,
               size_bytes: sizeBytes,
             }),
@@ -608,6 +614,39 @@ export function registerOpenClawAgentDatabase(params: {
     { env: params.env },
   );
   invalidateRegisteredAgentDatabasesMemo({ env: params.env });
+}
+
+function canonicalPathForRegistryBoundary(pathname: string): string {
+  const identity = resolveAgentDatabasePathIdentity(pathname);
+  if (identity.realPath) {
+    return identity.realPath;
+  }
+  if (!identity.parentRealPath || !identity.unresolvedSuffix) {
+    return identity.parentRealPath ?? path.resolve(pathname);
+  }
+  const unresolvedSegments = identity.unresolvedSuffix.split(path.sep);
+  return unresolvedSegments.includes("..")
+    ? identity.parentRealPath
+    : path.join(identity.parentRealPath, ...unresolvedSegments);
+}
+
+/** Named import artifacts are offline archives, not durable runtime discovery state. */
+export function isPersistentOpenClawAgentDatabasePath(
+  pathname: string,
+  env: NodeJS.ProcessEnv = process.env,
+): boolean {
+  const lexicalCandidate = path.resolve(pathname);
+  const lexicalImportsDir = path.join(path.resolve(resolveStateDir(env)), "imports");
+  if (lexicalCandidate === lexicalImportsDir || isPathInside(lexicalImportsDir, lexicalCandidate)) {
+    return false;
+  }
+  const candidate = canonicalPathForRegistryBoundary(pathname);
+  const stateDir = canonicalPathForRegistryBoundary(resolveStateDir(env));
+  const importsDir = canonicalPathForRegistryBoundary(path.join(stateDir, "imports"));
+  if (candidate === importsDir || isPathInside(importsDir, candidate)) {
+    return false;
+  }
+  return true;
 }
 
 export function unregisterOpenClawAgentDatabase(params: {

--- a/src/state/openclaw-agent-db.test.ts
+++ b/src/state/openclaw-agent-db.test.ts
@@ -921,6 +921,92 @@ describe("openclaw agent database", () => {
     ]);
   });
 
+  it("keeps incompatible schema versions maintenance-only", () => {
+    const stateDir = createTempStateDir();
+    const env = { OPENCLAW_STATE_DIR: stateDir };
+    const databasePath = path.join(stateDir, "agents", "legacy", "agent", "openclaw-agent.sqlite");
+    registerOpenClawAgentDatabase({
+      agentId: "legacy",
+      path: databasePath,
+      env,
+      schemaVersion: OPENCLAW_AGENT_SCHEMA_VERSION - 1,
+    });
+
+    expect(listOpenClawRegisteredAgentDatabases({ env })).toEqual([]);
+    expect(
+      listOpenClawRegisteredAgentDatabases({
+        env,
+        includeIncompatibleSchemaVersions: true,
+      }),
+    ).toEqual([
+      expect.objectContaining({
+        agentId: "legacy",
+        path: databasePath,
+        schemaVersion: OPENCLAW_AGENT_SCHEMA_VERSION - 1,
+      }),
+    ]);
+  });
+
+  it("does not persist archived import databases in the registry", () => {
+    const stateDir = createTempStateDir();
+    const env = { OPENCLAW_STATE_DIR: stateDir };
+    const archivedPath = path.join(stateDir, "imports", "archive", "openclaw-agent.sqlite");
+
+    registerOpenClawAgentDatabase({ agentId: "archive", path: archivedPath, env });
+
+    expect(
+      listOpenClawRegisteredAgentDatabases({
+        env,
+        includeIncompatibleSchemaVersions: true,
+      }),
+    ).toEqual([]);
+  });
+
+  it.runIf(process.platform !== "win32")(
+    "keeps symlinked import artifacts outside the runtime registry",
+    () => {
+      const stateDir = fs.realpathSync(createTempStateDir());
+      const env = { OPENCLAW_STATE_DIR: stateDir };
+      const activePath = path.join(stateDir, "active", "openclaw-agent.sqlite");
+      const archivedPath = path.join(stateDir, "imports", "archive", "openclaw-agent.sqlite");
+      fs.mkdirSync(path.dirname(activePath), { recursive: true });
+      fs.mkdirSync(path.dirname(archivedPath), { recursive: true });
+      fs.writeFileSync(activePath, "fixture");
+      fs.symlinkSync(activePath, archivedPath);
+
+      registerOpenClawAgentDatabase({ agentId: "archive", path: archivedPath, env });
+
+      expect(
+        listOpenClawRegisteredAgentDatabases({
+          env,
+          includeIncompatibleSchemaVersions: true,
+        }),
+      ).toEqual([]);
+    },
+  );
+
+  it.runIf(process.platform !== "win32")(
+    "keeps missing databases beneath symlinked import parents outside the registry",
+    () => {
+      const stateDir = fs.realpathSync(createTempStateDir());
+      const env = { OPENCLAW_STATE_DIR: stateDir };
+      const importsDir = path.join(stateDir, "imports", "archive");
+      const aliasDir = path.join(stateDir, "archive-alias");
+      fs.mkdirSync(importsDir, { recursive: true });
+      fs.symlinkSync(importsDir, aliasDir, "dir");
+      const missingPath = path.join(aliasDir, "openclaw-agent.sqlite");
+
+      registerOpenClawAgentDatabase({ agentId: "archive", path: missingPath, env });
+
+      expect(
+        listOpenClawRegisteredAgentDatabases({
+          env,
+          includeIncompatibleSchemaVersions: true,
+        }),
+      ).toEqual([]);
+    },
+  );
+
   it.skipIf(process.platform === "win32")(
     "fails closed when the missing registry has a dangling parent symlink",
     () => {
@@ -2345,6 +2431,51 @@ describe("openclaw agent database", () => {
       expect.objectContaining({ agentId: "worker-2", path: second.path }),
     ]);
   });
+
+  it.runIf(process.platform !== "win32")(
+    "disposes a cached transient database through a symlinked path spelling",
+    () => {
+      const stateDir = fs.realpathSync(createTempStateDir());
+      const env = { OPENCLAW_STATE_DIR: stateDir };
+      const realDir = path.join(stateDir, "probe-real");
+      const aliasDir = path.join(stateDir, "probe-alias");
+      fs.mkdirSync(realDir, { recursive: true });
+      fs.symlinkSync(realDir, aliasDir, "dir");
+      const realPath = path.join(realDir, "openclaw-agent.sqlite");
+      const aliasPath = path.join(aliasDir, "openclaw-agent.sqlite");
+      const database = openOpenClawAgentDatabase({ agentId: "probe", env, path: realPath });
+
+      expect(disposeOpenClawAgentDatabaseByPath(aliasPath, { env })).toBe(true);
+      expect(database.db.isOpen).toBe(false);
+      expect(listOpenClawRegisteredAgentDatabases({ env })).toEqual([]);
+    },
+  );
+
+  it.runIf(process.platform !== "win32")(
+    "refuses disposal when two cached path spellings reference the same database",
+    () => {
+      const stateDir = fs.realpathSync(createTempStateDir());
+      const env = { OPENCLAW_STATE_DIR: stateDir };
+      const realDir = path.join(stateDir, "probe-real");
+      const aliasDir = path.join(stateDir, "probe-alias");
+      fs.mkdirSync(realDir, { recursive: true });
+      fs.symlinkSync(realDir, aliasDir, "dir");
+      const real = openOpenClawAgentDatabase({
+        agentId: "probe",
+        env,
+        path: path.join(realDir, "openclaw-agent.sqlite"),
+      });
+      const alias = openOpenClawAgentDatabase({
+        agentId: "probe",
+        env,
+        path: path.join(aliasDir, "openclaw-agent.sqlite"),
+      });
+
+      expect(disposeOpenClawAgentDatabaseByPath(real.path, { env })).toBe(false);
+      expect(real.db.isOpen).toBe(true);
+      expect(alias.db.isOpen).toBe(true);
+    },
+  );
 
   it("reopens a recreated agent id on a fresh database after archival", () => {
     const stateDir = createTempStateDir();

--- a/src/state/openclaw-agent-db.ts
+++ b/src/state/openclaw-agent-db.ts
@@ -34,6 +34,7 @@ import {
 } from "./openclaw-agent-db-lease.js";
 import { ensureOpenClawAgentDatabasePermissions } from "./openclaw-agent-db-permissions.js";
 import {
+  isSameOpenClawAgentDatabasePath,
   registerOpenClawAgentDatabase,
   unregisterOpenClawAgentDatabase,
 } from "./openclaw-agent-db-registry.js";
@@ -608,33 +609,37 @@ export function closeOpenClawAgentDatabaseByPath(pathname: string): boolean {
   return true;
 }
 
-/** Close and unregister one transient agent database by exact cached pathname. */
+/** Close and unregister one unambiguous transient agent database by filesystem identity. */
 export function disposeOpenClawAgentDatabaseByPath(
   pathname: string,
   options: { env?: NodeJS.ProcessEnv } = {},
 ): boolean {
-  // Require the cache's exact lexical owner. Following a symlink or accepting
-  // an uncached path could unregister a database another process now owns.
   const resolvedPath = path.resolve(pathname);
   // Disposal can be followed by file deletion or recreation, so revalidate next open.
   validatedAgentDatabasePaths.delete(resolvedPath);
-  const database = cachedDatabases.get(resolvedPath);
-  if (!database || database.path !== resolvedPath) {
+  const matchingDatabases = [...cachedDatabases.values()].filter((candidate) =>
+    isSameOpenClawAgentDatabasePath(candidate.path, resolvedPath),
+  );
+  if (matchingDatabases.length > 1) {
     return false;
   }
-  if (incognitoDatabases.has(database)) {
-    return closeOpenClawAgentDatabaseByPath(resolvedPath);
+  const database = matchingDatabases[0];
+  if (database && incognitoDatabases.has(database)) {
+    return closeOpenClawAgentDatabaseByPath(database.path);
+  }
+  if (!database) {
+    return false;
   }
   try {
     unregisterOpenClawAgentDatabase({
       agentId: database.agentId,
-      path: resolvedPath,
+      path: database.path,
       ...(options.env ? { env: options.env } : {}),
     });
   } finally {
     // Secret-bearing transient DBs must close even when registry maintenance
     // fails; Windows otherwise cannot remove the file during caller cleanup.
-    closeOpenClawAgentDatabaseByPath(resolvedPath);
+    closeOpenClawAgentDatabaseByPath(database.path);
   }
   return true;
 }


### PR DESCRIPTION
Closes #115538

## What Problem This Solves

Fixes an issue where `openclaw doctor --fix` could exit nonzero when one row in the shared `agent_databases` registry pointed to a missing database or a database that could not migrate to the current schema. On the affected production host, one archived schema-v8 import database blocked eight consecutive hourly dev-channel updates even though active agent databases were healthy.

## Why This Change Was Made

Normal runtime discovery now exposes only registry rows already at the current agent schema, while Doctor's migration owners explicitly enumerate incompatible rows. Every Doctor-owned per-database inspection has a shared warning-and-skip boundary, so an unusable store cannot abort sibling work. Doctor also prunes missing and archived-import registry rows, import artifacts no longer register as runtime state, and transient disposal resolves an unambiguous process-owned handle by filesystem identity without weakening cross-process ownership safety.

This keeps the v16 persisted-media guard introduced by #113695 intact: incompatible databases still require repair and remain visible to maintenance, but they are not fed back into later steady-state read paths during the same Doctor run. No SQLite schema version changes are introduced.

## User Impact

Operators can run Doctor and automated update health checks successfully even when an archived, missing, or otherwise unmigratable auxiliary agent database is registered. The unusable database is preserved for manual recovery, warnings identify it, healthy databases continue through Doctor, and stale missing/import rows stop poisoning future runs.

Release-note context: Doctor no longer aborts the entire repair run when one registered agent database is missing or cannot migrate.

## Evidence

- Production evidence and eight failed updater cycles are recorded in #115538.
- Blacksmith Testbox focused proof:
  - latest `src/state/openclaw-agent-db.test.ts`: 93 passed, 6 platform-specific skips
  - related media/Doctor/Telegram shards: 35 passed
  - schema-v8 regression visibly emitted `Doctor warnings` and returned a zero-result repair report instead of throwing
- Blacksmith Testbox changed gate (`tbx_01kyp0yfde3hk0tx7e4sxq9357`): `pnpm check:changed` green in 5m02s, including formatting, core and core-test tsgo, changed lint, dead-code, import-cycle, database-first, and repository guard lanes.
- Source-blind CLI behavior proof on Testbox: an isolated state directory was seeded with a schema-v8 agent DB whose `acp_parent_stream_events` lacked `session_id` plus a missing probe row. Two consecutive `pnpm openclaw doctor --fix --non-interactive` runs exited 0; the first warned and skipped the legacy DB, removed the missing row, preserved the legacy file at `PRAGMA user_version = 8`, and reached `Doctor complete`.
- Latest focused Testbox run: [Actions run 30422760753](https://github.com/openclaw/openclaw/actions/runs/30422760753), provider `blacksmith-testbox`, lease `tbx_01kyp2jv2kvyyn1yycfpjds1b0`.
- `git diff --check` clean.
- Codex autoreview (`gpt-5.6-sol`, xhigh) accepted and fixed two ownership/symlink findings, then completed clean with no actionable findings.

AI-assisted: implemented and reviewed with Codex; the maintainer inspected the code path, regression provenance, and live CLI behavior.
