### PR TITLE
fix(agents): keep long sandbox prefixes scope-unique

### DIFF
--- a/src/agents/sandbox/browser.ts
+++ b/src/agents/sandbox/browser.ts
@@ -53,7 +53,7 @@ import {
   issueNoVncObserverToken,
 } from "./novnc-auth.js";
 import { readBrowserRegistry, updateBrowserRegistry } from "./registry.js";
-import { resolveSandboxAgentId, slugifySessionKey } from "./shared.js";
+import { buildSandboxContainerName, resolveSandboxAgentId, slugifySessionKey } from "./shared.js";
 import { isToolAllowed } from "./tool-policy.js";
 import type { SandboxBrowserContext, SandboxConfig } from "./types.js";
 import { validateNetworkMode } from "./validate-sandbox-security.js";
@@ -242,8 +242,7 @@ export async function ensureSandboxBrowser(params: {
   }
 
   const slug = params.cfg.scope === "shared" ? "shared" : slugifySessionKey(params.scopeKey);
-  const name = `${params.cfg.browser.containerPrefix}${slug}`;
-  const containerName = name.slice(0, 63);
+  const containerName = buildSandboxContainerName(params.cfg.browser.containerPrefix, slug);
   let existing = BROWSER_BRIDGES.get(params.scopeKey);
   const stopExistingForContainer = async () => {
     await stopCachedBrowserBridgesForContainer(containerName);

--- a/src/agents/sandbox/docker.ts
+++ b/src/agents/sandbox/docker.ts
@@ -95,7 +95,7 @@ import {
 } from "./constants.js";
 import { handleHotSandboxConfigMismatch } from "./current-config.js";
 import { readRegistryEntry, updateRegistry } from "./registry.js";
-import { resolveSandboxScopeKey, slugifySessionKey } from "./shared.js";
+import { buildSandboxContainerName, resolveSandboxScopeKey, slugifySessionKey } from "./shared.js";
 import type { SandboxConfig, SandboxDockerConfig, SandboxWorkspaceAccess } from "./types.js";
 import { validateSandboxSecurity } from "./validate-sandbox-security.js";
 import {
@@ -503,8 +503,7 @@ export async function ensureSandboxContainer(params: {
 }) {
   const scopeKey = resolveSandboxScopeKey(params.cfg.scope, params.sessionKey);
   const slug = params.cfg.scope === "shared" ? "shared" : slugifySessionKey(scopeKey);
-  const name = `${params.cfg.docker.containerPrefix}${slug}`;
-  const containerName = name.slice(0, 63);
+  const containerName = buildSandboxContainerName(params.cfg.docker.containerPrefix, slug);
   const readOnlyWorkspaceSkillMounts = resolveReadOnlyWorkspaceSkillMounts({
     workspaceDir: params.workspaceDir,
     agentWorkspaceDir: params.agentWorkspaceDir,

--- a/src/agents/sandbox/shared.test.ts
+++ b/src/agents/sandbox/shared.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+import { buildSandboxContainerName, slugifySessionKey } from "./shared.js";
+
+describe("buildSandboxContainerName", () => {
+  it("preserves scope identity when a custom prefix exceeds the Docker name limit", () => {
+    const commonPrefix = "custom-prefix-".repeat(6);
+    const first = buildSandboxContainerName(
+      `${commonPrefix}first`,
+      slugifySessionKey("session:first"),
+    );
+    const second = buildSandboxContainerName(
+      `${commonPrefix}second`,
+      slugifySessionKey("session:second"),
+    );
+    const sameScopeDifferentPrefix = buildSandboxContainerName(
+      `${commonPrefix}second`,
+      slugifySessionKey("session:first"),
+    );
+    const oversizedSlug = buildSandboxContainerName(
+      commonPrefix,
+      slugifySessionKey("session:".concat("x".repeat(200))),
+    );
+
+    expect(first).not.toBe(second);
+    expect(first).not.toBe(sameScopeDifferentPrefix);
+    expect(first).toHaveLength(63);
+    expect(second).toHaveLength(63);
+    expect(oversizedSlug).toHaveLength(63);
+    expect(first).toMatch(/-[0-9a-f]{12}$/);
+    expect(second).toMatch(/-[0-9a-f]{12}$/);
+    expect(oversizedSlug).toMatch(/-[0-9a-f]{12}$/);
+  });
+});

--- a/src/agents/sandbox/shared.ts
+++ b/src/agents/sandbox/shared.ts
@@ -25,6 +25,17 @@ export function slugifySessionKey(value: string) {
   return `${base}-${hash}`;
 }
 
+/** Builds a bounded Docker name without truncating the scope-identity slug. */
+export function buildSandboxContainerName(prefix: string, slug: string): string {
+  const maxLength = 63;
+  const fullName = `${prefix}${slug}`;
+  if (fullName.length <= maxLength) {
+    return fullName;
+  }
+  const identitySuffix = `-${hashTextSha256(fullName).slice(0, 12)}`;
+  return `${fullName.slice(0, maxLength - identitySuffix.length)}${identitySuffix}`;
+}
+
 /** Resolves the per-session sandbox workspace directory under the configured sandbox root. */
 function resolveSandboxWorkspaceDir(root: string, sessionKey: string) {
   const resolvedRoot = resolveUserPath(root);


### PR DESCRIPTION
Related: #51363
Related: #115252

## What Problem This Solves

Fixes an issue where users with long custom sandbox container prefixes could have different agent or session scopes collapse to the same 63-character Docker container name.

## Why This Change Was Made

When a composed name exceeds Docker's existing limit, preserve a readable prefix and append a deterministic hash of the complete prefix-and-scope identity. Both the runtime sandbox and browser sidecar now use the same helper.

Provenance: the truncation behavior was carried forward by `bcbfb357bec7` on January 14, 2026.

## User Impact

Distinct sandbox scopes remain isolated even when operators configure unusually long container prefixes.

## Evidence

- Added a focused regression test covering distinct scopes, distinct prefixes, oversized scope input, and the 63-character bound.
- Blacksmith Testbox: `src/agents/sandbox/shared.test.ts` passed.
- Blacksmith Testbox: changed-file typecheck, lint, boundary, dead-code, and guard lanes passed.
- Fresh autoreview completed with no accepted or actionable findings.
- `git diff --check` passed after rebasing onto current `origin/main`.
