### PR TITLE
fix(gateway): tool approval prompts never appear when the paired device baseline is narrower

### DIFF
--- a/src/agents/tools/gateway.test.ts
+++ b/src/agents/tools/gateway.test.ts
@@ -344,6 +344,10 @@ describe("gateway tool defaults", () => {
       name: "allow-always decision",
       params: { approvalDecision: "allow-always", runId: "approval-always" },
     },
+    {
+      name: "ask-fallback source",
+      params: { approvalSource: "ask-fallback", runId: "approval-fallback" },
+    },
   ])("binds persisted device identity to node system.run with $name", async ({ params }) => {
     mocks.callGateway.mockResolvedValueOnce({ ok: true });
 
@@ -351,6 +355,35 @@ describe("gateway tool defaults", () => {
       "node.invoke",
       {},
       { nodeId: "node-1", command: "system.run", params, idempotencyKey: "invoke-1" },
+      { scopes: ["operator.write", "operator.approvals"] },
+    );
+
+    const call = capturedGatewayCall();
+    expect(call.deviceIdentity).toEqual(mocks.deviceIdentity);
+    expect(call.approvalRuntimeToken).toEqual(expect.any(String));
+  });
+
+  it("keeps approved node system.run replays token-less for remote gateways", async () => {
+    mocks.configState.value = {
+      gateway: {
+        mode: "remote",
+        remote: {
+          url: "wss://gateway.example",
+          token: "remote-token",
+        },
+      },
+    };
+    mocks.callGateway.mockResolvedValueOnce({ ok: true });
+
+    await callGatewayTool(
+      "node.invoke",
+      {},
+      {
+        nodeId: "node-1",
+        command: "system.run",
+        params: { approved: true, runId: "approval-remote" },
+        idempotencyKey: "invoke-1",
+      },
       { scopes: ["operator.write", "operator.approvals"] },
     );
 
@@ -392,6 +425,27 @@ describe("gateway tool defaults", () => {
     const call = capturedGatewayCall();
     expect(call).not.toHaveProperty("deviceIdentity");
     expect(call).not.toHaveProperty("approvalRuntimeToken");
+  });
+
+  it("degrades ask-fallback node system.run device-less without a persisted identity", async () => {
+    mocks.persistedDeviceIdentity = null;
+    mocks.callGateway.mockResolvedValueOnce({ ok: true });
+
+    await callGatewayTool(
+      "node.invoke",
+      {},
+      {
+        nodeId: "node-1",
+        command: "system.run",
+        params: { approvalSource: "ask-fallback", runId: "approval-fallback" },
+        idempotencyKey: "invoke-1",
+      },
+      { scopes: ["operator.write", "operator.approvals"] },
+    );
+
+    const call = capturedGatewayCall();
+    expect(call).not.toHaveProperty("deviceIdentity");
+    expect(call.approvalRuntimeToken).toEqual(expect.any(String));
   });
 
   it("fails approved node system.run closed without a persisted identity", async () => {

--- a/src/agents/tools/gateway.ts
+++ b/src/agents/tools/gateway.ts
@@ -228,10 +228,19 @@ const OPTIONAL_LOCAL_AGENT_RUNTIME_IDENTITY_METHODS = new Set<string>(["node.inv
 
 function resolveApprovalRuntimeTokenForGatewayTool(params: {
   method: string;
+  callParams: unknown;
   opts: GatewayCallOptions;
   target: GatewayOverrideTarget;
 }): string | undefined {
-  if (!APPROVAL_RUNTIME_METHODS.has(params.method)) {
+  // Approved and ask-fallback node command replays carry the token too: they
+  // attach the shared device identity for approval matching, and the token
+  // keeps a stale narrower paired baseline from rejecting the replay connect
+  // at the local gateway.
+  const isApprovalRuntimeCall =
+    APPROVAL_RUNTIME_METHODS.has(params.method) ||
+    isApprovalReplayNodeSystemRun(params.method, params.callParams) ||
+    isAskFallbackNodeSystemRun(params.method, params.callParams);
+  if (!isApprovalRuntimeCall) {
     return undefined;
   }
   if (trimToUndefined(params.opts.gatewayUrl) !== undefined) {
@@ -245,11 +254,20 @@ function resolveApprovalRuntimeTokenForGatewayTool(params: {
   return getOperatorApprovalRuntimeToken();
 }
 
-function isApprovalReplayNodeSystemRun(method: string, callParams: unknown): boolean {
+function resolveNodeSystemRunParams(method: string, callParams: unknown) {
   const invoke = method === "node.invoke" ? asNullableRecord(callParams) : null;
-  const run = invoke?.command === "system.run" ? asNullableRecord(invoke.params) : null;
+  return invoke?.command === "system.run" ? asNullableRecord(invoke.params) : null;
+}
+
+function isApprovalReplayNodeSystemRun(method: string, callParams: unknown): boolean {
+  const run = resolveNodeSystemRunParams(method, callParams);
   const decision = normalizeOptionalString(run?.approvalDecision);
   return run?.approved === true || decision === "allow-once" || decision === "allow-always";
+}
+
+function isAskFallbackNodeSystemRun(method: string, callParams: unknown): boolean {
+  const run = resolveNodeSystemRunParams(method, callParams);
+  return normalizeOptionalString(run?.approvalSource) === "ask-fallback";
 }
 
 function attachNodeInvokeTurnSource(method: string, params: unknown): unknown {
@@ -295,6 +313,16 @@ function resolveApprovalRequesterDeviceIdentityForGatewayTool(params: {
   const isApprovalRuntimeMethod = APPROVAL_RUNTIME_METHODS.has(params.method);
   const isNodeApprovalReplay = isApprovalReplayNodeSystemRun(params.method, params.callParams);
   if (!isApprovalRuntimeMethod && !isNodeApprovalReplay) {
+    if (isAskFallbackNodeSystemRun(params.method, params.callParams)) {
+      // Ask-fallback replays a timed-out record. When registration ran without
+      // a persisted identity the record is unbound and the no-device backend
+      // bridge authorizes the replay, so degrade instead of failing closed.
+      try {
+        return loadDeviceIdentityIfPresent() ?? undefined;
+      } catch {
+        return undefined;
+      }
+    }
     return undefined;
   }
   if (isApprovalRuntimeMethod && trimToUndefined(params.opts.gatewayUrl) !== undefined) {
@@ -518,6 +546,7 @@ export async function callGatewayTool<T = Record<string, unknown>>(
     : resolveLeastPrivilegeOperatorScopesForMethod(method, callParams);
   const approvalRuntimeToken = resolveApprovalRuntimeTokenForGatewayTool({
     method,
+    callParams,
     opts,
     target: gateway.target,
   });

--- a/src/gateway/server.silent-scope-upgrade-reconnect.poc.test.ts
+++ b/src/gateway/server.silent-scope-upgrade-reconnect.poc.test.ts
@@ -19,6 +19,7 @@ import {
   loadDeviceIdentity,
   openTrackedWs,
 } from "./device-authz.test-helpers.js";
+import { getOperatorApprovalRuntimeToken } from "./operator-approval-runtime-token.js";
 import { withOperatorApprovalsGatewayClient } from "./operator-approvals-client.js";
 import {
   connectOk,
@@ -331,6 +332,90 @@ describe("gateway silent scope-upgrade reconnect", () => {
 
       const pending = await devicePairingModule.listDevicePairing();
       expect(pending.pending).toHaveLength(0);
+      await expectReadScopedPairing(identity.deviceId);
+    } finally {
+      await closeStartedGateway(started);
+    }
+  });
+
+  test("keeps local approval-runtime requester calls off stale paired baseline", async () => {
+    const started = await startServerWithClient("secret");
+    const paired = await issueReadScopedOperatorToken({
+      name: "approval-runtime-requester-baseline",
+      clientId: GATEWAY_CLIENT_NAMES.GATEWAY_CLIENT,
+      clientMode: GATEWAY_CLIENT_MODES.BACKEND,
+    });
+    const loaded = loadDeviceIdentity("approval-runtime-requester-baseline");
+
+    try {
+      // Mirror callGatewayTool("plugin.approval.request", ...): local backend
+      // client with shared auth, the process-local approval runtime token, and
+      // the persisted requester device identity attached for record binding.
+      const result = await callGateway<{ id?: string; decision?: unknown }>({
+        url: `ws://127.0.0.1:${started.port}`,
+        token: "secret",
+        method: "plugin.approval.request",
+        params: {
+          title: "tool approval",
+          description: "approve tool run",
+          timeoutMs: 1_500,
+          twoPhase: true,
+        },
+        expectFinal: false,
+        approvalRuntimeToken: getOperatorApprovalRuntimeToken(),
+        deviceIdentity: loaded.identity,
+        scopes: ["operator.approvals"],
+        timeoutMs: 3_000,
+      });
+      // No approval route is connected, so the request resolves immediately;
+      // reaching the handler at all proves the handshake was admitted.
+      expect(result.id).toBeTypeOf("string");
+      expect(result.decision).toBeNull();
+
+      const pending = await devicePairingModule.listDevicePairing();
+      expect(pending.pending).toHaveLength(0);
+      // The exemption never widens persisted authority: the paired baseline
+      // and the stored operator device token keep their read-only scopes.
+      const pairedAfter = await expectReadScopedPairing(paired.deviceId);
+      expect(pairedAfter?.tokens?.operator?.scopes).toEqual(["operator.read"]);
+      expect(pairedAfter?.tokens?.operator?.token).toBe(paired.token);
+    } finally {
+      await closeStartedGateway(started);
+    }
+  });
+
+  test("keeps local approved node command replays off stale paired baseline", async () => {
+    const started = await startServerWithClient("secret");
+    const identity = await approveReadScopedDevice({
+      clientId: GATEWAY_CLIENT_NAMES.GATEWAY_CLIENT,
+      clientMode: GATEWAY_CLIENT_MODES.BACKEND,
+    });
+
+    try {
+      // Mirror callGatewayTool("node.invoke", ...) replaying an approved
+      // system.run decision: device identity attached for approval matching.
+      const replay = callGateway({
+        url: `ws://127.0.0.1:${started.port}`,
+        token: "secret",
+        method: "node.invoke",
+        params: {
+          nodeId: "missing-node",
+          command: "system.run",
+          idempotencyKey: "replay-stale-baseline",
+          params: { command: ["echo", "ok"], approved: true, runId: "exec:none" },
+        },
+        approvalRuntimeToken: getOperatorApprovalRuntimeToken(),
+        deviceIdentity: loadOrCreateDeviceIdentity(),
+        scopes: ["operator.write"],
+        timeoutMs: 3_000,
+      });
+      // The replay must reach the node.invoke handler (the unknown node fails
+      // at method level), not die at the handshake with a NOT_PAIRED close.
+      await expect(replay).rejects.toMatchObject({
+        name: "GatewayClientRequestError",
+        gatewayCode: "UNAVAILABLE",
+        message: expect.stringContaining("node pairing changed"),
+      });
       await expectReadScopedPairing(identity.deviceId);
     } finally {
       await closeStartedGateway(started);

--- a/src/gateway/server/ws-connection/connect-device-pairing.ts
+++ b/src/gateway/server/ws-connection/connect-device-pairing.ts
@@ -45,7 +45,10 @@ import {
 import { issueGatewayConnectDeviceTokens } from "./connect-device-tokens.js";
 import { authorizeExistingGatewayDevice } from "./connect-existing-device.js";
 import { startGatewayNodePairingSshApproval } from "./connect-node-pairing-ssh.js";
-import { shouldAllowSilentLocalPairing } from "./handshake-auth-helpers.js";
+import {
+  isTrustedApprovalRuntimeConnect,
+  shouldAllowSilentLocalPairing,
+} from "./handshake-auth-helpers.js";
 import type {
   AuthenticatedGatewayConnect,
   DeviceAuthorizedGatewayConnect,
@@ -640,20 +643,37 @@ export async function authorizeGatewayConnectDevice(
       pairedClientId = paired.clientId;
       pairedBrowserOrigin = paired.browserOrigin;
       hasServerApprovedDeviceTokenBaseline = true;
-      const existingDevice = await authorizeExistingGatewayDevice({
-        context,
-        state: { ...state, scopes, handoffBootstrapProfile },
-        paired,
-        devicePublicKey,
-        clientAccessMetadata,
-        handoffBootstrapProfile,
-        requirePairing,
-        logUpgradeAudit,
+      // The approval runtime token is process-local proof; these connects only
+      // attach the shared device identity to bind approval records to their
+      // requester. A stale narrower paired baseline must not reject them, or
+      // local approval registration/replay dies before any approver UI sees
+      // the prompt. The paired record itself is never widened: session scopes
+      // come from gateway auth and ensureDeviceToken still caps issued tokens
+      // at the approved baseline.
+      const skipPairedBaselineForApprovalRuntime = isTrustedApprovalRuntimeConnect({
+        connectParams,
+        locality: pairingLocality,
       });
-      if (!existingDevice.ok) {
-        return undefined;
+      if (skipPairedBaselineForApprovalRuntime) {
+        logGateway.debug(
+          `approval-runtime connect exempted from paired baseline device=${device.id} conn=${connId}`,
+        );
+      } else {
+        const existingDevice = await authorizeExistingGatewayDevice({
+          context,
+          state: { ...state, scopes, handoffBootstrapProfile },
+          paired,
+          devicePublicKey,
+          clientAccessMetadata,
+          handoffBootstrapProfile,
+          requirePairing,
+          logUpgradeAudit,
+        });
+        if (!existingDevice.ok) {
+          return undefined;
+        }
+        handoffBootstrapProfile = existingDevice.handoffBootstrapProfile;
       }
-      handoffBootstrapProfile = existingDevice.handoffBootstrapProfile;
     }
   }
 

--- a/src/gateway/server/ws-connection/connect-session.ts
+++ b/src/gateway/server/ws-connection/connect-session.ts
@@ -28,7 +28,6 @@ import { resolveRuntimeServiceVersion } from "../../../version.js";
 import { verifyAgentRuntimeIdentityToken } from "../../agent-runtime-identity-token.js";
 import { APPROVALS_SCOPE } from "../../method-scopes.js";
 import { serializeEventPayload } from "../../node-registry.js";
-import { isOperatorApprovalRuntimeToken } from "../../operator-approval-runtime-token.js";
 import {
   buildPluginNodeCapabilityScopedHostUrl,
   indexPluginNodeCapabilitySurfaces,
@@ -45,6 +44,7 @@ import { incrementPresenceVersion } from "../health-state.js";
 import type { GatewayWsClient } from "../ws-types.js";
 import { sendGatewayHello } from "./connect-hello.js";
 import { prepareGatewayNodeConnect } from "./connect-node-session.js";
+import { isTrustedApprovalRuntimeConnect } from "./handshake-auth-helpers.js";
 import type {
   DeviceAuthorizedGatewayConnect,
   GatewayConnectPhaseContext,
@@ -239,11 +239,8 @@ export async function attachAuthenticatedGatewayConnect(
     }
   }
   const isTrustedApprovalRuntime =
-    pairingLocality !== "remote" &&
     scopes.includes(APPROVALS_SCOPE) &&
-    connectParams.client.id === GATEWAY_CLIENT_IDS.GATEWAY_CLIENT &&
-    connectParams.client.mode === GATEWAY_CLIENT_MODES.BACKEND &&
-    isOperatorApprovalRuntimeToken(connectParams.auth?.approvalRuntimeToken);
+    isTrustedApprovalRuntimeConnect({ connectParams, locality: pairingLocality });
   const agentRuntimeIdentityProof = connectParams.auth?.agentRuntimeIdentityToken;
   const canAcceptAgentRuntimeIdentity =
     pairingLocality !== "remote" &&

--- a/src/gateway/server/ws-connection/handshake-auth-helpers.test.ts
+++ b/src/gateway/server/ws-connection/handshake-auth-helpers.test.ts
@@ -6,7 +6,9 @@ import {
 } from "../../../../packages/gateway-protocol/src/client-info.js";
 import type { ConnectParams } from "../../../../packages/gateway-protocol/src/schema.js";
 import type { AuthRateLimiter } from "../../auth-rate-limit.js";
+import { getOperatorApprovalRuntimeToken } from "../../operator-approval-runtime-token.js";
 import {
+  isTrustedApprovalRuntimeConnect,
   resolveHandshakeBrowserSecurityContext,
   resolvePairingLocality,
   resolveUnauthorizedHandshakeContext,
@@ -503,6 +505,63 @@ describe("handshake auth helpers", () => {
         hasBrowserOriginHeader: true,
         sharedAuthOk: false,
         authMethod: "none",
+      }),
+    ).toBe(false);
+  });
+
+  it("trusts local backend approval-runtime connects only with the runtime token", () => {
+    const withApprovalRuntimeAuth = (
+      token: string | undefined,
+      client: { id?: string; mode?: string } = {},
+    ) =>
+      ({
+        client: {
+          id: client.id ?? GATEWAY_CLIENT_IDS.GATEWAY_CLIENT,
+          mode: client.mode ?? GATEWAY_CLIENT_MODES.BACKEND,
+        },
+        auth: token === undefined ? {} : { approvalRuntimeToken: token },
+      }) as ConnectParams;
+    const runtimeToken = getOperatorApprovalRuntimeToken();
+    expect(
+      isTrustedApprovalRuntimeConnect({
+        connectParams: withApprovalRuntimeAuth(runtimeToken),
+        locality: "direct_local",
+      }),
+    ).toBe(true);
+    expect(
+      isTrustedApprovalRuntimeConnect({
+        connectParams: withApprovalRuntimeAuth(runtimeToken),
+        locality: "shared_secret_loopback_local",
+      }),
+    ).toBe(true);
+    expect(
+      isTrustedApprovalRuntimeConnect({
+        connectParams: withApprovalRuntimeAuth(runtimeToken),
+        locality: "remote",
+      }),
+    ).toBe(false);
+    expect(
+      isTrustedApprovalRuntimeConnect({
+        connectParams: withApprovalRuntimeAuth("wrong-token"),
+        locality: "direct_local",
+      }),
+    ).toBe(false);
+    expect(
+      isTrustedApprovalRuntimeConnect({
+        connectParams: withApprovalRuntimeAuth(undefined),
+        locality: "direct_local",
+      }),
+    ).toBe(false);
+    expect(
+      isTrustedApprovalRuntimeConnect({
+        connectParams: withApprovalRuntimeAuth(runtimeToken, { id: GATEWAY_CLIENT_IDS.CLI }),
+        locality: "direct_local",
+      }),
+    ).toBe(false);
+    expect(
+      isTrustedApprovalRuntimeConnect({
+        connectParams: withApprovalRuntimeAuth(runtimeToken, { mode: GATEWAY_CLIENT_MODES.CLI }),
+        locality: "direct_local",
       }),
     ).toBe(false);
   });

--- a/src/gateway/server/ws-connection/handshake-auth-helpers.ts
+++ b/src/gateway/server/ws-connection/handshake-auth-helpers.ts
@@ -16,6 +16,7 @@ import {
   isPrivateOrLoopbackHost,
   resolveHostName,
 } from "../../net.js";
+import { isOperatorApprovalRuntimeToken } from "../../operator-approval-runtime-token.js";
 import type { AuthProvidedKind } from "./auth-messages.js";
 
 const BROWSER_ORIGIN_LOOPBACK_RATE_LIMIT_IP = "198.18.0.1";
@@ -263,6 +264,23 @@ export function resolvePairingLocality(params: {
     return "shared_secret_loopback_local";
   }
   return "remote";
+}
+
+/**
+ * Identifies the gateway's own local approval runtime: a backend gateway
+ * client on a non-remote connection proving possession of the process-local
+ * operator approval runtime token.
+ */
+export function isTrustedApprovalRuntimeConnect(params: {
+  connectParams: ConnectParams;
+  locality: PairingLocalityKind;
+}): boolean {
+  return (
+    params.locality !== "remote" &&
+    params.connectParams.client.id === GATEWAY_CLIENT_IDS.GATEWAY_CLIENT &&
+    params.connectParams.client.mode === GATEWAY_CLIENT_MODES.BACKEND &&
+    isOperatorApprovalRuntimeToken(params.connectParams.auth?.approvalRuntimeToken)
+  );
 }
 
 export function shouldSkipLocalBackendSelfPairing(params: {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where local tool-approval prompts would never appear when the host's shared device identity had previously been paired with scopes narrower than the request needed (for example only `operator.read`). Client never received ACP `session/request_permission` because `plugin.approval.request` was rejected at the Gateway websocket handshake with `pairing required: device is asking for more scopes than currently approved` — the approval was never registered, so no approver surface ever saw a pending prompt. Approved node command replays (`node.invoke` `system.run`) died at the same gate, and ask-fallback timeout replays additionally failed the approval device-binding guard because they attached no requester identity at all.

The failure was state-dependent: a fresh or unpaired device identity worked (the not-paired branch already skips pairing for local backend self-connects), while a reused identity paired with narrower scopes failed. Rebuilding the app/container does not reset the OpenClaw state volume holding the identity and pairing state, which explained the apparent flakiness.

## Why This Change Was Made

Local approval-runtime calls attach the shared device identity only to bind approval records to their requester (cross-process approval visibility, 890055d4217) — the connection's authority comes from normal gateway auth plus the process-local operator approval runtime token, not from the pairing record. The fix introduces `isTrustedApprovalRuntimeConnect` (backend gateway-client + non-remote pairing locality + valid `approvalRuntimeToken`) and exempts exactly those connects from the paired-device baseline gates, mirroring the existing not-paired `shouldSkipLocalBackendSelfPairing` seam. The deliberate no-silent-scope-widening decision (#55286, 20b08f1a856) is preserved for every other client: ordinary backend/CLI/browser reconnects without the runtime token still require explicit pairing approval, the paired record is never widened, and `ensureDeviceToken`/`verifyDeviceToken` independently keep issued device tokens capped at the approved baseline. Client-side, `callGatewayTool` now sends the runtime token on local approved and ask-fallback `node.invoke` replays too, and ask-fallback replays gain the previously missing requester-identity attachment (degrading gracefully when no identity is persisted, since such records are unbound and bridge via the trusted-backend path).

Non-goal: remote gateways are unchanged — the runtime token is never sent to env/URL-override or configured-remote targets, and remote locality never qualifies for the exemption.

## User Impact

Local tool approvals (plugin approvals, exec approvals, and approved/ask-fallback node command replays) now work regardless of what scopes the host's device identity was previously paired with. Operators no longer need to delete pairing state or re-pair to recover approval prompts in UIs such as RovoClaw. Security posture for everything else is unchanged: paired devices still cannot silently widen their approved scopes.

## Evidence

- Two new regression tests in `src/gateway/server.silent-scope-upgrade-reconnect.poc.test.ts` mirror the exact production connect options (`token` auth + `approvalRuntimeToken` + persisted device identity + least-privilege scopes) against a device paired read-only. Both fail on unfixed code with `gateway closed (1008): pairing required: device is asking for more scopes than currently approved` (verified by reverting the server change) and pass with the fix; the requester test also asserts the paired baseline and the stored operator device token keep their read-only scopes afterward.
- Pre-existing security-pinning tests in the same file still pass unchanged: non-backend clients and backend reconnects without the runtime token are still rejected on scope upgrade.
- Unit coverage: `isTrustedApprovalRuntimeConnect` (locality/token/client-class matrix) in `handshake-auth-helpers.test.ts`; client-side attachment matrix incl. ask-fallback binding, identity-less ask-fallback degradation, and remote-target token suppression in `src/agents/tools/gateway.test.ts`.
- Focused suites green: silent-scope-upgrade POC (10), handshake-auth-helpers (33), agents/tools gateway (54), operator-approvals-client, call/client (182), post-connect-health, trusted-proxy device auto-approve, compat-baseline, device-pairing-churn, auth-context, connect-policy, exec-approval request/followup. `tsgo` core + core-test lanes, `oxlint`, `oxfmt`, `git diff --check`, and import-cycle check all pass.
- Old-gateway compatibility: `auth.approvalRuntimeToken` has been in the closed connect schema since #81380, and the gateway client already retries token-less when a server rejects the field (covered by `client.test.ts`).
