### PR TITLE
fix(onboard): reject noninteractive TUI mode

### DIFF
--- a/src/commands/onboard.test.ts
+++ b/src/commands/onboard.test.ts
@@ -885,4 +885,18 @@ describe("setupWizardCommand", () => {
     expect(mocks.runInteractiveSetup).not.toHaveBeenCalled();
     expect(mocks.runGuidedOnboarding).not.toHaveBeenCalled();
   });
+
+  it("rejects conflicting TUI and non-interactive modes", async () => {
+    const runtime = makeRuntime();
+
+    await setupWizardCommand({ tui: true, nonInteractive: true, acceptRisk: true }, runtime);
+
+    expect(runtime.error).toHaveBeenCalledWith(
+      "--tui cannot be combined with --non-interactive. Remove --tui for automation, or remove --non-interactive to open the terminal hatch.",
+    );
+    expect(runtime.exit).toHaveBeenCalledWith(1);
+    expect(mocks.runNonInteractiveSetup).not.toHaveBeenCalled();
+    expect(mocks.runInteractiveSetup).not.toHaveBeenCalled();
+    expect(mocks.runGuidedOnboarding).not.toHaveBeenCalled();
+  });
 });

--- a/src/commands/onboard.ts
+++ b/src/commands/onboard.ts
@@ -473,6 +473,13 @@ export async function setupWizardCommand(
     runtime.exit(1);
     return;
   }
+  if (normalizedOpts.tui && normalizedOpts.nonInteractive) {
+    runtime.error(
+      "--tui cannot be combined with --non-interactive. Remove --tui for automation, or remove --non-interactive to open the terminal hatch.",
+    );
+    runtime.exit(1);
+    return;
+  }
   if (
     normalizedOpts.secretInputMode &&
     normalizedOpts.secretInputMode !== "plaintext" && // pragma: allowlist secret


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where `openclaw onboard --non-interactive --tui` exited successfully, wrote setup state, and never opened the requested terminal hatch. The same false-success behavior was reachable through `openclaw setup`.

## Why This Change Was Made

The shared onboarding dispatcher now rejects the contradictory TUI and automation modes before any setup path runs. Interactive `--tui` and ordinary non-interactive onboarding remain unchanged.

This PR is AI-assisted. I reviewed the full dispatcher, both CLI registrations, guided/classic/non-interactive siblings, and the TUI handoff owner.

## User Impact

Operators and scripts receive an actionable nonzero error instead of silently completing a different workflow from the one requested.

## Evidence

- Before on the unchanged current-main dispatcher: `openclaw onboard --non-interactive ... --tui` exited 0, wrote config, and did not launch a TUI.
- After at `b68cc3e85104a69fdf44682c4f0ae6420cb44ab0`: both `onboard` and `setup` exit 1 before writes; `onboard --tui` alone still reaches the interactive TTY gate.
- Source-blind CLI behavior contract: satisfied for both conflict entry points, no-write behavior, and the valid interactive-TUI branch.
- Focused local regression: `node scripts/run-vitest.mjs src/commands/onboard.test.ts` — 49/49 passed on the rebased head.
- Blacksmith Testbox `tbx_01kyp2pqm9hmm0wbzsmyb6vb3m`: 104/104 focused CLI/onboarding assertions passed, followed by a clean `check:changed`. Workflow: https://github.com/openclaw/openclaw/actions/runs/30422854075
- Fresh rebased-head autoreview: clean, no accepted/actionable findings.

Provenance: `--tui` entered the guided onboarding surface in PR #110054, authored and merged by `@steipete` on 2026-07-17.
