### PR TITLE
fix(whatsapp): prevent replies from suppressing other chats

### DIFF
--- a/extensions/whatsapp/src/auto-reply/monitor/echo.test.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor/echo.test.ts
@@ -15,4 +15,39 @@ describe("createEchoTracker", () => {
     );
     expect(tracker.has(text)).toBe(true);
   });
+
+  it("keeps identical text isolated to its originating conversation", () => {
+    const tracker = createEchoTracker({});
+
+    tracker.rememberText("Done.", { conversationId: "+1000" });
+
+    expect(tracker.has("Done.", "+1000")).toBe(true);
+    expect(tracker.has("Done.", "+3000")).toBe(false);
+
+    tracker.forget("Done.", "+1000");
+
+    expect(tracker.has("Done.", "+1000")).toBe(false);
+  });
+
+  it("keeps combined-message deduplication independent of conversation-scoped text", () => {
+    const tracker = createEchoTracker({});
+    const combinedKey = tracker.buildCombinedKey({
+      sessionKey: "agent:main:whatsapp:+1000",
+      combinedBody: "first\nsecond",
+    });
+
+    tracker.rememberText("Done.", {
+      conversationId: "+1000",
+      combinedBody: "first\nsecond",
+      combinedBodySessionKey: "agent:main:whatsapp:+1000",
+    });
+
+    expect(tracker.has(combinedKey)).toBe(true);
+    expect(tracker.has("Done.", "+1000")).toBe(true);
+
+    tracker.forget(combinedKey);
+
+    expect(tracker.has(combinedKey)).toBe(false);
+    expect(tracker.has("Done.", "+1000")).toBe(true);
+  });
 });

--- a/extensions/whatsapp/src/auto-reply/monitor/echo.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor/echo.ts
@@ -6,11 +6,12 @@ export type EchoTracker = {
     opts: {
       combinedBody?: string;
       combinedBodySessionKey?: string;
+      conversationId?: string;
       logVerboseMessage?: boolean;
     },
   ) => void;
-  has: (key: string) => boolean;
-  forget: (key: string) => void;
+  has: (key: string, conversationId?: string) => boolean;
+  forget: (key: string, conversationId?: string) => void;
   buildCombinedKey: (params: { sessionKey: string; combinedBody: string }) => string;
 };
 
@@ -23,6 +24,11 @@ export function createEchoTracker(params: {
 
   const buildCombinedKey = (p: { sessionKey: string; combinedBody: string }) =>
     `combined:${p.sessionKey}:${p.combinedBody}`;
+
+  // Native message echoes belong to one conversation; combined keys already
+  // contain their session scope and must remain directly addressable.
+  const buildTextKey = (text: string, conversationId?: string) =>
+    conversationId ? `${conversationId}\0${text}` : text;
 
   const trim = () => {
     while (recentlySent.size > maxItems) {
@@ -38,7 +44,7 @@ export function createEchoTracker(params: {
     if (!text) {
       return;
     }
-    recentlySent.add(text);
+    recentlySent.add(buildTextKey(text, opts.conversationId));
     if (opts.combinedBody && opts.combinedBodySessionKey) {
       recentlySent.add(
         buildCombinedKey({
@@ -57,9 +63,9 @@ export function createEchoTracker(params: {
 
   return {
     rememberText,
-    has: (key) => recentlySent.has(key),
-    forget: (key) => {
-      recentlySent.delete(key);
+    has: (key, conversationId) => recentlySent.has(buildTextKey(key, conversationId)),
+    forget: (key, conversationId) => {
+      recentlySent.delete(buildTextKey(key, conversationId));
     },
     buildCombinedKey,
   };

--- a/extensions/whatsapp/src/auto-reply/monitor/inbound-dispatch.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor/inbound-dispatch.ts
@@ -25,6 +25,7 @@ import {
 } from "../../outbound-media-contract.js";
 import type { WhatsAppReplyDeliveryResult } from "../deliver-reply.js";
 import { markWhatsAppVisibleDeliveryError } from "../util.js";
+import type { EchoTracker } from "./echo.js";
 import { formatGroupMembers } from "./group-members.js";
 import type { GroupHistoryEntry } from "./inbound-context.js";
 import {
@@ -580,14 +581,7 @@ export function createWhatsAppReplyPlan(params: {
   maxMediaTextChunkLimit?: number;
   msg: AdmittedWebInboundMessage;
   onModelSelected?: ChannelReplyOnModelSelected;
-  rememberSentText: (
-    text: string | undefined,
-    opts: {
-      combinedBody?: string;
-      combinedBodySessionKey?: string;
-      logVerboseMessage?: boolean;
-    },
-  ) => void;
+  rememberSentText: EchoTracker["rememberText"];
   replyLogger: ReturnType<typeof getChildLogger>;
   replyPipeline: WhatsAppDispatchPipeline;
   replyResolver: typeof getReplyFromConfig;
@@ -630,6 +624,7 @@ export function createWhatsAppReplyPlan(params: {
     params.rememberSentText(payload.text, {
       combinedBody: params.context.Body as string | undefined,
       combinedBodySessionKey: params.route.sessionKey,
+      conversationId,
       logVerboseMessage: shouldLog,
     });
     if (shouldLogVerbose()) {

--- a/extensions/whatsapp/src/auto-reply/monitor/on-message.acp-bindings.test.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor/on-message.acp-bindings.test.ts
@@ -76,6 +76,7 @@ vi.mock("./status-reaction.js", () => ({
 }));
 
 import { createTestWebInboundMessage } from "../../inbound/test-message.test-helper.js";
+import { createEchoTracker } from "./echo.js";
 import { createWebOnMessageHandler } from "./on-message.js";
 
 const baseRoute = {
@@ -250,7 +251,11 @@ function createGroupCfg(): Record<string, unknown> {
   };
 }
 
-function createHandler(warn = vi.fn(), cfg: Record<string, unknown> = createCfg()) {
+function createHandler(
+  warn = vi.fn(),
+  cfg: Record<string, unknown> = createCfg(),
+  echoTracker?: ReturnType<typeof createEchoTracker>,
+) {
   const groupHistories = new Map();
   return {
     warn,
@@ -263,7 +268,7 @@ function createHandler(warn = vi.fn(), cfg: Record<string, unknown> = createCfg(
       groupHistoryLimit: 20,
       groupHistories,
       groupMemberNames: new Map(),
-      echoTracker: {
+      echoTracker: echoTracker ?? {
         has: () => false,
         forget: () => {},
         rememberText: () => {},
@@ -377,6 +382,42 @@ describe("createWebOnMessageHandler configured ACP bindings", () => {
     ensureConfiguredBindingRouteReadyMock.mockResolvedValue({ ok: true });
     resolveConfiguredBindingRouteMock.mockReset();
     resolveConfiguredBindingRouteMock.mockImplementation(resolvedConfiguredRoute());
+  });
+
+  it("dispatches another conversation's identical text while suppressing the actual echo", async () => {
+    const sentConversation = "15550001111@s.whatsapp.net";
+    const otherConversation = "15550002222@s.whatsapp.net";
+    const echoTracker = createEchoTracker({ maxItems: 10 });
+    echoTracker.rememberText("Done.", { conversationId: sentConversation });
+    resolveConfiguredBindingRouteMock.mockImplementation(({ route }) => ({
+      bindingResolution: null,
+      route,
+    }));
+    const { handler } = createHandler(vi.fn(), createCfg(), echoTracker);
+
+    const messageForConversation = (conversationId: string) =>
+      createTestWebInboundMessage({
+        admission: {
+          accountId: "work",
+          conversation: { kind: "direct", id: conversationId },
+          sender: { id: conversationId },
+        },
+        payload: { body: "Done." },
+        platform: {
+          chatJid: conversationId,
+          recipientJid: "15559876543@s.whatsapp.net",
+        },
+      });
+
+    await handler(messageForConversation(otherConversation));
+
+    expect(processMessageMock).toHaveBeenCalledTimes(1);
+    expect(echoTracker.has("Done.", sentConversation)).toBe(true);
+
+    await handler(messageForConversation(sentConversation));
+
+    expect(processMessageMock).toHaveBeenCalledTimes(1);
+    expect(echoTracker.has("Done.", sentConversation)).toBe(false);
   });
 
   it("rewrites matching WhatsApp inbound turns to the configured ACP session key", async () => {

--- a/extensions/whatsapp/src/auto-reply/monitor/on-message.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor/on-message.ts
@@ -176,9 +176,9 @@ export function createWebOnMessageHandler(params: {
     }
 
     // Skip if this is a message we just sent (echo detection)
-    if (params.echoTracker.has(msg.payload.body)) {
+    if (params.echoTracker.has(msg.payload.body, conversationId)) {
       logVerbose("Skipping auto-reply: detected echo (message matches recently sent text)");
-      params.echoTracker.forget(msg.payload.body);
+      params.echoTracker.forget(msg.payload.body, conversationId);
       return;
     }
 

--- a/extensions/whatsapp/src/auto-reply/monitor/process-message.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor/process-message.ts
@@ -36,6 +36,7 @@ import { deliverWebReply } from "../deliver-reply.js";
 import { whatsappInboundLog } from "../loggers.js";
 import { elide } from "../util.js";
 import { maybeSendAckReaction } from "./ack-reaction.js";
+import type { EchoTracker } from "./echo.js";
 import {
   resolveVisibleWhatsAppGroupHistory,
   resolveVisibleWhatsAppReplyContext,
@@ -195,16 +196,9 @@ export async function processMessage(params: {
   replyResolver: typeof getReplyFromConfig;
   replyLogger: ReturnType<typeof getChildLogger>;
   backgroundTasks: Set<Promise<unknown>>;
-  rememberSentText: (
-    text: string | undefined,
-    opts: {
-      combinedBody?: string;
-      combinedBodySessionKey?: string;
-      logVerboseMessage?: boolean;
-    },
-  ) => void;
-  echoHas: (key: string) => boolean;
-  echoForget: (key: string) => void;
+  rememberSentText: EchoTracker["rememberText"];
+  echoHas: EchoTracker["has"];
+  echoForget: EchoTracker["forget"];
   buildCombinedEchoKey: (p: { sessionKey: string; combinedBody: string }) => string;
   maxMediaTextChunkLimit?: number;
   groupHistory?: GroupHistoryEntry[];


### PR DESCRIPTION
Related: #111425

## What Problem This Solves

Fixes an issue where WhatsApp users in one conversation would have an ordinary inbound message silently discarded when it happened to contain the same text that OpenClaw had recently sent to a different conversation. Common replies such as “Done.”, “OK”, and “yes” could consequently fail to reach the agent.

## Why This Change Was Made

Scope native sent-text echo keys to the existing admitted WhatsApp conversation ID. Carry that same authoritative ID from successful outbound delivery into inbound echo lookup and removal. Preserve the independently session-scoped combined-message deduplication path, genuine same-conversation echo suppression, account routing, and quoted-context privacy.

This is an independently rebuilt, current-main replacement for the solution identified by @YangManBOBO in #111425. Thank you to @YangManBOBO for finding the cross-chat collision and identifying conversation-local echo keys.

## User Impact

An inbound WhatsApp message is delivered normally even when another chat recently received identical text. Actual echoes in the originating chat continue to be suppressed. No configuration, plugin SDK, provider contract, security behavior, persisted state, or fallback changes.

## Evidence

- Fail-first: the real WhatsApp inbound handler on unmodified current main silently suppresses the other conversation; the regression reproduces the precise user-visible delivery loss.
- After the fix, the real admitted inbound handler dispatches the other conversation, retains the originating chat’s echo entry, then suppresses and consumes the actual same-chat echo.
- Combined session keys remain independently addressable and forgettable.
- Remote Blacksmith Testbox: 88/88 tests passed across the echo tracker, real inbound handler, inbound dispatch, message processing, ACP routing, and quoted-context privacy.
- Remote full `pnpm check:changed`: passed, including production and test typechecks, formatting, lint, plugin-boundary, dependency, dead-code, and import-cycle gates.
- Fresh isolated `gpt-5.6-sol` extra-high-effort structured review: clean, zero accepted or actionable findings.
