### PR TITLE
fix(gateway): speed up startup with stateless plugin paths

### DIFF
--- a/src/commands/doctor/shared/pristine-startup-state.test.ts
+++ b/src/commands/doctor/shared/pristine-startup-state.test.ts
@@ -50,6 +50,55 @@ function addBundledPlugin(
   };
 }
 
+function addConfiguredPlugin(
+  env: ReturnType<typeof createFixture>,
+  pluginId: string,
+  options: {
+    additionalLoadPaths?: readonly string[];
+    doctorContract?: boolean;
+    minHostVersion?: string;
+  } = {},
+) {
+  const pluginsDir = path.join(env.HOME, "configured-plugins");
+  const pluginDir = path.join(pluginsDir, pluginId);
+  fs.mkdirSync(pluginDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(pluginDir, "openclaw.plugin.json"),
+    `${JSON.stringify({ id: pluginId, configSchema: { type: "object" } })}\n`,
+  );
+  fs.writeFileSync(
+    path.join(pluginDir, "index.cjs"),
+    `module.exports = { id: ${JSON.stringify(pluginId)}, register() {} };\n`,
+  );
+  if (options.minHostVersion) {
+    fs.writeFileSync(
+      path.join(pluginDir, "package.json"),
+      `${JSON.stringify({
+        name: `fixture-${pluginId}`,
+        version: "1.0.0",
+        openclaw: {
+          extensions: ["./index.cjs"],
+          install: { minHostVersion: options.minHostVersion },
+        },
+      })}\n`,
+    );
+  }
+  if (options.doctorContract) {
+    fs.writeFileSync(path.join(pluginDir, "doctor-contract-api.js"), "export {};\n");
+  }
+
+  const config = JSON.parse(fs.readFileSync(env.OPENCLAW_CONFIG_PATH, "utf8")) as {
+    plugins?: Record<string, unknown>;
+  };
+  config.plugins = {
+    ...config.plugins,
+    allow: [pluginId],
+    load: { paths: [pluginsDir, ...(options.additionalLoadPaths ?? [])] },
+  };
+  fs.writeFileSync(env.OPENCLAW_CONFIG_PATH, `${JSON.stringify(config)}\n`);
+  return env;
+}
+
 afterEach(() => {
   for (const root of roots.splice(0)) {
     fs.rmSync(root, { force: true, recursive: true });
@@ -107,6 +156,57 @@ describe("pristine startup state", () => {
     );
 
     expect(canSkipPristineStartupStateMigrations(env)).toBe(false);
+  });
+
+  it("skips migration discovery for manifest-owned stateless configured plugin paths", () => {
+    const env = addConfiguredPlugin(
+      createFixture({ gateway: { mode: "local" }, plugins: { enabled: true } }),
+      "stateless-plugin",
+    );
+
+    expect(planPristineStartupStateMigrations(env)).toEqual({
+      skipAllStateMigrations: true,
+      skipCoreStateMigrations: true,
+    });
+  });
+
+  it("retains migration discovery for configured plugin doctor contracts", () => {
+    const env = addConfiguredPlugin(
+      createFixture({ gateway: { mode: "local" }, plugins: { enabled: true } }),
+      "stateful-plugin",
+      { doctorContract: true },
+    );
+
+    expect(planPristineStartupStateMigrations(env)).toEqual({
+      skipAllStateMigrations: false,
+      skipCoreStateMigrations: true,
+    });
+  });
+
+  it("retains bundled doctor migrations when a configured plugin is incompatible", () => {
+    const fixture = addConfiguredPlugin(
+      createFixture({ gateway: { mode: "local" }, plugins: { enabled: true } }),
+      "future-plugin",
+      { minHostVersion: ">=9999.0.0" },
+    );
+    const env = addBundledPlugin(fixture, "future-plugin", { doctorContract: true });
+
+    expect(planPristineStartupStateMigrations(env)).toEqual({
+      skipAllStateMigrations: false,
+      skipCoreStateMigrations: true,
+    });
+  });
+
+  it("retains migration discovery when another configured plugin path is missing", () => {
+    const fixture = createFixture({ gateway: { mode: "local" }, plugins: { enabled: true } });
+    const env = addConfiguredPlugin(fixture, "stateless-plugin", {
+      additionalLoadPaths: [path.join(fixture.HOME, "missing-plugin")],
+    });
+
+    expect(planPristineStartupStateMigrations(env)).toEqual({
+      skipAllStateMigrations: false,
+      skipCoreStateMigrations: true,
+    });
   });
 
   it("retains plugin migrations while skipping absent core state for load paths", () => {

--- a/src/commands/doctor/shared/pristine-startup-state.ts
+++ b/src/commands/doctor/shared/pristine-startup-state.ts
@@ -10,7 +10,12 @@ import {
 import type { OpenClawConfig } from "../../../config/types.openclaw.js";
 import { resolveEffectiveHomeDir } from "../../../infra/home-dir.js";
 import { tryReadJsonSync } from "../../../infra/json-files.js";
-import { inspectBundledPluginStartupMetadata } from "../../../plugins/bundled-plugin-startup-metadata.js";
+import {
+  inspectBundledPluginStartupMetadata,
+  inspectPluginStartupMetadata,
+} from "../../../plugins/bundled-plugin-startup-metadata.js";
+import { discoverConfiguredPluginLoadPaths } from "../../../plugins/discovery.js";
+import { loadPluginManifestRegistry } from "../../../plugins/manifest-registry.js";
 import { configMayRequireStartupPluginConvergence } from "./startup-plugin-convergence-plan.js";
 
 const STATEFUL_CONFIG_KEYS = new Set([
@@ -64,9 +69,57 @@ function hasOnlyMigrationSafePluginEntries(
   if (!isRecord(plugins)) {
     return plugins === undefined;
   }
-  if (Object.keys(plugins).some((key) => !["enabled", "entries", "allow", "deny"].includes(key))) {
+  if (
+    Object.keys(plugins).some(
+      (key) => !["enabled", "entries", "allow", "deny", "load"].includes(key),
+    )
+  ) {
     return false;
   }
+
+  if (plugins.load !== undefined) {
+    if (
+      !isRecord(plugins.load) ||
+      Object.keys(plugins.load).some((key) => key !== "paths") ||
+      !Array.isArray(plugins.load.paths) ||
+      !plugins.load.paths.every((entry) => typeof entry === "string" && entry.trim().length > 0)
+    ) {
+      return false;
+    }
+    if (plugins.load.paths.length > 0) {
+      const discovery = discoverConfiguredPluginLoadPaths({
+        loadPaths: plugins.load.paths,
+        env,
+      });
+      if (discovery.candidates.length === 0) {
+        return false;
+      }
+      // Discovery alone cannot prove host compatibility or rule out a fallback
+      // doctor owner; use the same candidate acceptance as normal plugin startup.
+      const registry = loadPluginManifestRegistry({
+        config: config as OpenClawConfig,
+        discovery,
+        env,
+        installRecords: {},
+      });
+      if (
+        registry.diagnostics.length > 0 ||
+        registry.plugins.length !== discovery.candidates.length
+      ) {
+        return false;
+      }
+      for (const plugin of registry.plugins) {
+        const metadata = inspectPluginStartupMetadata({
+          pluginId: plugin.id,
+          rootDir: plugin.rootDir,
+        });
+        if (!metadata || metadata.hasDoctorContract) {
+          return false;
+        }
+      }
+    }
+  }
+
   if (!isRecord(plugins.entries)) {
     return plugins.entries === undefined;
   }

--- a/src/plugins/bundled-plugin-startup-metadata.ts
+++ b/src/plugins/bundled-plugin-startup-metadata.ts
@@ -8,7 +8,7 @@ import { resolveBundledPluginsDir } from "./bundled-dir.js";
 const DOCTOR_CONTRACT_BASENAMES = ["doctor-contract-api", "contract-api"] as const;
 const MODULE_EXTENSIONS = ["js", "cjs", "mjs", "ts", "cts", "mts"] as const;
 
-type BundledPluginStartupMetadata = {
+type PluginStartupMetadata = {
   hasDoctorContract: boolean;
 };
 
@@ -22,19 +22,29 @@ function hasDoctorContractArtifact(pluginRoot: string): boolean {
   );
 }
 
+/** Inspects one manifest-owned plugin root without loading its runtime or doctor contract. */
+export function inspectPluginStartupMetadata(params: {
+  pluginId: string;
+  rootDir: string;
+}): PluginStartupMetadata | undefined {
+  const manifest = tryReadJsonSync(path.join(params.rootDir, "openclaw.plugin.json"));
+  if (!isRecord(manifest) || manifest.id !== params.pluginId) {
+    return undefined;
+  }
+  return { hasDoctorContract: hasDoctorContractArtifact(params.rootDir) };
+}
+
 /** Resolves one exact bundled id without scanning or materializing the full plugin catalog. */
 export function inspectBundledPluginStartupMetadata(params: {
   pluginId: string;
   env: NodeJS.ProcessEnv;
-}): BundledPluginStartupMetadata | undefined {
+}): PluginStartupMetadata | undefined {
   const bundledPluginsDir = resolveBundledPluginsDir(params.env);
   if (!bundledPluginsDir) {
     return undefined;
   }
-  const pluginRoot = path.join(bundledPluginsDir, params.pluginId);
-  const manifest = tryReadJsonSync(path.join(pluginRoot, "openclaw.plugin.json"));
-  if (!isRecord(manifest) || manifest.id !== params.pluginId) {
-    return undefined;
-  }
-  return { hasDoctorContract: hasDoctorContractArtifact(pluginRoot) };
+  return inspectPluginStartupMetadata({
+    pluginId: params.pluginId,
+    rootDir: path.join(bundledPluginsDir, params.pluginId),
+  });
 }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where fresh Gateway instances configured with explicit, stateless plugin load paths unnecessarily performed full plugin-state migration bootstrapping before opening the HTTP listener. The overhead grows with the number of installed plugins and increases startup time and peak memory.

## Why This Change Was Made

Verify configured plugin candidates with the canonical manifest registry before classifying a truly pristine state root, then reuse the existing manifest-owned doctor-contract inspection to skip only migrations that cannot contain work. Preserve the normal migration path for missing, blocked, malformed, duplicate, host-incompatible, or doctor-bearing plugins, including an incompatible configured plugin shadowing a bundled doctor owner. No config, schema, protocol, compatibility, or model-runtime contract changes are introduced.

## User Impact

Gateways with many stateless plugins can start listening sooner and consume less peak memory, while plugin-owned migration and compatibility checks remain intact. The independent model-runtime sidecar still dominates and varies in end-to-end readiness, so this change does not claim an overall /readyz improvement.

## Evidence

Frozen baseline: 545716528937dfd1394629fcdc042870208b8814. Same remote Blacksmith Testbox, actual built dist entrypoint, one warmup and three measured runs per case, reporting median values.

- 50 startup-lazy manifest plugins: migration/bootstrap 2492.1 ms to 104.9 ms, a 95.8 percent reduction; HTTP listen 4068.0 ms to 2780.8 ms, a 31.6 percent reduction; peak RSS 1151.2 MB to 1035.6 MB, a 115.6 MB reduction.
- 50 eager manifest plugins: HTTP listen 4341.1 ms to 3313.9 ms, a 23.7 percent reduction; peak RSS 1080.5 MB to 1017.4 MB, a 63.1 MB reduction.
- 425 regression tests passed across Gateway CLI, doctor preflight, pristine-state migration, configured load paths, doctor contracts, and all 106 manifest-registry tests.
- Explicit regression proves an incompatible configured plugin cannot bypass a same-ID bundled doctor contract; missing configured paths and configured doctor contracts retain full migration discovery.
- Full production `pnpm build` passed, including Control UI, plugin SDK exports, packaging, and CLI bootstrap guards.
- Full `pnpm check:changed` passed, including core and test type-checking, formatting, lint, dead-code, SDK boundary, dependency, import-cycle, database, and schema guards.
- Fresh independent autoreview: clean, no accepted or actionable findings.
- AI-assisted: yes.