### PR TITLE
fix(gateway): prevent ambiguous config writes and auth disconnect drift

### DIFF
--- a/src/gateway/server-methods/config-write-flow.test.ts
+++ b/src/gateway/server-methods/config-write-flow.test.ts
@@ -5,6 +5,12 @@ const configMocks = vi.hoisted(() => ({
   replaceConfigFile: vi.fn(),
   resolveConfigSnapshotHash: vi.fn(),
 }));
+const secretsMocks = vi.hoisted(() => ({
+  activeSnapshot: null as {
+    sourceConfig: OpenClawConfig;
+    config: OpenClawConfig;
+  } | null,
+}));
 
 vi.mock("../../config/config.js", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../../config/config.js")>();
@@ -15,7 +21,15 @@ vi.mock("../../config/config.js", async (importOriginal) => {
   };
 });
 
-import { commitGatewayConfigWrite } from "./config-write-flow.js";
+vi.mock("../../secrets/runtime-state.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../secrets/runtime-state.js")>();
+  return {
+    ...actual,
+    getActiveSecretsRuntimeSnapshot: () => secretsMocks.activeSnapshot,
+  };
+});
+
+import { commitGatewayConfigWrite, didActiveSharedGatewayAuthChange } from "./config-write-flow.js";
 
 describe("commitGatewayConfigWrite", () => {
   beforeEach(() => {
@@ -25,6 +39,7 @@ describe("commitGatewayConfigWrite", () => {
       nextConfig: {},
       persistedHash: "persisted-hash",
     });
+    secretsMocks.activeSnapshot = null;
   });
 
   it("carries a missing file revision into the lock-time compare-and-swap", async () => {
@@ -47,5 +62,81 @@ describe("commitGatewayConfigWrite", () => {
         nextConfig: {},
       }),
     );
+  });
+});
+
+describe("didActiveSharedGatewayAuthChange", () => {
+  beforeEach(() => {
+    secretsMocks.activeSnapshot = null;
+  });
+
+  it("preserves runtime-only auth fields absent from the active secrets source", () => {
+    const runtimeConfig: OpenClawConfig = {
+      gateway: { auth: { mode: "token", token: "runtime-token" } },
+    };
+    secretsMocks.activeSnapshot = {
+      sourceConfig: {},
+      config: {},
+    };
+
+    expect(
+      didActiveSharedGatewayAuthChange({ fallbackPrev: runtimeConfig, next: runtimeConfig }),
+    ).toBe(false);
+  });
+
+  it("does not trust active secret values from a stale authored source", () => {
+    secretsMocks.activeSnapshot = {
+      sourceConfig: { gateway: { auth: { mode: "token", token: "token-a" } } },
+      config: { gateway: { auth: { mode: "token", token: "token-a" } } },
+    };
+    const current: OpenClawConfig = {
+      gateway: { auth: { mode: "token", token: "token-b" } },
+    };
+
+    expect(
+      didActiveSharedGatewayAuthChange({
+        fallbackPrev: current,
+        fallbackSource: current,
+        next: { gateway: { auth: { mode: "token", token: "token-a" } } },
+      }),
+    ).toBe(true);
+  });
+
+  it("preserves runtime-only siblings beside authored shared auth fields", () => {
+    secretsMocks.activeSnapshot = {
+      sourceConfig: { gateway: { auth: { mode: "token" } } },
+      config: { gateway: { auth: { mode: "token" } } },
+    };
+    const runtimeConfig: OpenClawConfig = {
+      gateway: { auth: { mode: "token", token: "runtime-token" } },
+    };
+
+    expect(
+      didActiveSharedGatewayAuthChange({
+        fallbackPrev: runtimeConfig,
+        fallbackSource: { gateway: { auth: { mode: "token" } } },
+        next: runtimeConfig,
+      }),
+    ).toBe(false);
+  });
+
+  it("uses active secret-expanded values when the authored source still matches", () => {
+    const tokenRef = {
+      source: "env" as const,
+      provider: "default",
+      id: "GATEWAY_TOKEN",
+    };
+    secretsMocks.activeSnapshot = {
+      sourceConfig: { gateway: { auth: { mode: "token", token: tokenRef } } },
+      config: { gateway: { auth: { mode: "token", token: "old-token" } } },
+    };
+
+    expect(
+      didActiveSharedGatewayAuthChange({
+        fallbackPrev: { gateway: { auth: { mode: "token", token: tokenRef } } },
+        fallbackSource: { gateway: { auth: { mode: "token", token: tokenRef } } },
+        next: { gateway: { auth: { mode: "token", token: "new-token" } } },
+      }),
+    ).toBe(true);
   });
 });

--- a/src/gateway/server-methods/config-write-flow.ts
+++ b/src/gateway/server-methods/config-write-flow.ts
@@ -16,6 +16,7 @@ import {
 } from "../../infra/restart-sentinel.js";
 import { scheduleGatewaySigusr1Restart } from "../../infra/restart.js";
 import { getActiveSecretsRuntimeSnapshot } from "../../secrets/runtime-state.js";
+import { isRecord } from "../../utils.js";
 import { resolveEffectiveSharedGatewayAuth, resolveGatewayAuth } from "../auth.js";
 import { buildGatewayReloadPlan, isNoopGatewayReloadPlan } from "../config-reload-plan.js";
 import { resolveGatewayReloadSettings } from "../config-reload-settings.js";
@@ -95,15 +96,76 @@ export function didSharedGatewayAuthChange(prev: OpenClawConfig, next: OpenClawC
   return prevAuth.mode !== nextAuth.mode || !isDeepStrictEqual(prevAuth.secret, nextAuth.secret);
 }
 
+// Active secrets snapshots own authored leaves, while runtime config can add fixed siblings.
+// Project only matching authored values so stale snapshots cannot drive disconnect decisions.
+function projectAuthoredValuesOntoRuntimeOverlay(params: {
+  source: unknown;
+  activeSource: unknown;
+  active: unknown;
+  fallback: unknown;
+}): unknown {
+  const { source, active } = params;
+  if (active === undefined) {
+    return structuredClone(params.fallback);
+  }
+  if (!isRecord(source) || !isRecord(active)) {
+    return structuredClone(
+      isDeepStrictEqual(source, params.activeSource) ? active : params.fallback,
+    );
+  }
+  const fallback = isRecord(params.fallback) ? params.fallback : {};
+  const activeSource = isRecord(params.activeSource) ? params.activeSource : {};
+  const sourceKeys = new Set(Object.keys(source));
+  return Object.fromEntries([
+    ...Object.entries(fallback).filter(([key]) => !sourceKeys.has(key)),
+    ...Object.keys(source).map((key) => [
+      key,
+      projectAuthoredValuesOntoRuntimeOverlay({
+        source: source[key],
+        activeSource: activeSource[key],
+        active: active[key],
+        fallback: fallback[key],
+      }),
+    ]),
+  ]);
+}
+
 /** Compares against the active secrets-expanded config when one is available. */
 export function didActiveSharedGatewayAuthChange(params: {
   fallbackPrev: OpenClawConfig;
+  fallbackSource?: OpenClawConfig;
   next: OpenClawConfig;
 }): boolean {
-  return didSharedGatewayAuthChange(
-    getActiveSecretsRuntimeSnapshot()?.config ?? params.fallbackPrev,
-    params.next,
-  );
+  const active = getActiveSecretsRuntimeSnapshot();
+  if (!active) {
+    return didSharedGatewayAuthChange(params.fallbackPrev, params.next);
+  }
+  const currentSourceGateway = (params.fallbackSource ?? active.sourceConfig).gateway;
+  const activeSourceGateway = active.sourceConfig.gateway;
+  const activeGateway = active.config.gateway;
+  const fallbackGateway = params.fallbackPrev.gateway;
+  const selectOwnedGatewayValue = <Key extends "auth" | "tailscale" | "trustedProxies">(
+    key: Key,
+  ): NonNullable<OpenClawConfig["gateway"]>[Key] =>
+    currentSourceGateway && Object.hasOwn(currentSourceGateway, key)
+      ? (projectAuthoredValuesOntoRuntimeOverlay({
+          source: currentSourceGateway[key],
+          activeSource: activeSourceGateway?.[key],
+          active: activeGateway?.[key],
+          fallback: fallbackGateway?.[key],
+        }) as NonNullable<OpenClawConfig["gateway"]>[Key])
+      : fallbackGateway?.[key];
+  const activeSharedAuthConfig: OpenClawConfig = {
+    ...params.fallbackPrev,
+    gateway: {
+      ...fallbackGateway,
+      // Secrets snapshots only own authored leaves; retain runtime-only auth siblings.
+      auth: selectOwnedGatewayValue("auth"),
+      tailscale: selectOwnedGatewayValue("tailscale"),
+      trustedProxies: selectOwnedGatewayValue("trustedProxies"),
+    },
+  };
+  return didSharedGatewayAuthChange(activeSharedAuthConfig, params.next);
 }
 
 function queueSharedGatewayAuthDisconnect(

--- a/src/gateway/server-methods/config.test.ts
+++ b/src/gateway/server-methods/config.test.ts
@@ -424,3 +424,98 @@ describe("config.patch hash-free ui.prefs LWW", () => {
     expect(storedConfig.ui?.prefs).toEqual({ locale: "de" });
   });
 });
+
+describe("config.patch ID-keyed arrays", () => {
+  it("rejects duplicate IDs before applying an ID-merged array patch", async () => {
+    storedConfig = {
+      models: {
+        providers: {
+          custom: {
+            baseUrl: "https://example.invalid",
+            models: [{ id: "one", name: "One" }],
+          },
+        },
+      },
+    } as unknown as OpenClawConfig;
+
+    const { respond } = await invokeConfigPatch({
+      raw: {
+        models: {
+          providers: {
+            custom: {
+              models: [
+                { id: "one", name: "First" },
+                { id: "one", name: "Second" },
+              ],
+            },
+          },
+        },
+      },
+      baseHash: "base-hash",
+    });
+
+    expect(respond).toHaveBeenCalledWith(
+      false,
+      undefined,
+      expect.objectContaining({ message: expect.stringContaining("duplicate ID one") }),
+    );
+    expect(configWriteMocks.commitGatewayConfigWrite).not.toHaveBeenCalled();
+  });
+
+  it("allows duplicate IDs for an explicit array replacement", async () => {
+    storedConfig = {
+      models: {
+        providers: {
+          custom: {
+            baseUrl: "https://example.invalid",
+            models: [{ id: "one", name: "One" }],
+          },
+        },
+      },
+    } as unknown as OpenClawConfig;
+
+    const { respond } = await invokeConfigPatch({
+      raw: {
+        models: {
+          providers: {
+            custom: {
+              models: [
+                { id: "one", name: "First" },
+                { id: "one", name: "Second" },
+              ],
+            },
+          },
+        },
+      },
+      baseHash: "base-hash",
+      replacePaths: ["models.providers.custom.models"],
+    });
+
+    expect(respond).toHaveBeenCalledWith(
+      true,
+      expect.objectContaining({ ok: true, hash: "next-hash-1" }),
+      undefined,
+    );
+    expect(configWriteMocks.commitGatewayConfigWrite).toHaveBeenCalledOnce();
+
+    const followUp = await invokeConfigPatch({
+      raw: {
+        models: {
+          providers: {
+            custom: { models: [{ id: "one", name: "Third" }] },
+          },
+        },
+      },
+      baseHash: "next-hash-1",
+    });
+
+    expect(followUp.respond).toHaveBeenCalledWith(
+      false,
+      undefined,
+      expect.objectContaining({
+        message: expect.stringContaining("current config contains duplicate ID one"),
+      }),
+    );
+    expect(configWriteMocks.commitGatewayConfigWrite).toHaveBeenCalledOnce();
+  });
+});

--- a/src/gateway/server-methods/config.ts
+++ b/src/gateway/server-methods/config.ts
@@ -240,6 +240,72 @@ function isConfigPatchObjectWithStringId(
   return isPlainObject(value) && typeof value.id === "string" && value.id.length > 0;
 }
 
+function assertNoDuplicateConfigPatchIds(params: {
+  patch: unknown;
+  current: unknown;
+  replacePaths: ReadonlySet<string>;
+  path?: string;
+}): void {
+  const path = params.path ?? "";
+  if (Array.isArray(params.patch)) {
+    if (
+      !Array.isArray(params.current) ||
+      params.replacePaths.has(path) ||
+      !isConfigPatchIdKeyedArray(params.current)
+    ) {
+      return;
+    }
+    // ID-keyed merge is sequential and would silently let the last duplicate win.
+    // Reject only arrays using that merge contract; explicit replacements may contain duplicates.
+    const currentIds = new Set<string>();
+    for (const entry of params.current) {
+      if (currentIds.has(entry.id)) {
+        throw new Error(
+          `Cannot ID-merge array at ${path || "<root>"}: current config contains duplicate ID ${entry.id}; use replacePaths for an explicit replacement.`,
+        );
+      }
+      currentIds.add(entry.id);
+    }
+    const ids = new Set<string>();
+    for (const entry of params.patch) {
+      if (!isConfigPatchObjectWithStringId(entry)) {
+        continue;
+      }
+      if (ids.has(entry.id)) {
+        throw new Error(`Ambiguous duplicate ID ${entry.id} in array at ${path || "<root>"}.`);
+      }
+      ids.add(entry.id);
+    }
+    const currentById = new Map(params.current.map((entry) => [entry.id, entry] as const));
+    for (const entry of params.patch) {
+      if (!isConfigPatchObjectWithStringId(entry)) {
+        continue;
+      }
+      const currentEntry = currentById.get(entry.id);
+      if (currentEntry) {
+        assertNoDuplicateConfigPatchIds({
+          patch: entry,
+          current: currentEntry,
+          replacePaths: params.replacePaths,
+          path: `${path}[]`,
+        });
+      }
+    }
+    return;
+  }
+  if (!isRecord(params.patch) || !isRecord(params.current)) {
+    return;
+  }
+  for (const [key, child] of Object.entries(params.patch)) {
+    assertNoDuplicateConfigPatchIds({
+      patch: child,
+      current: params.current[key],
+      replacePaths: params.replacePaths,
+      path: formatConfigPatchPath(path, key),
+    });
+  }
+}
+
 function isConfigPatchIdKeyedArray(
   value: unknown[],
 ): value is Array<Record<string, unknown> & { id: string }> {
@@ -645,6 +711,7 @@ async function respondWithConfigRestartWrite(params: {
 
 function shouldDisconnectSharedAuthClientsForConfigWrite(params: {
   prevConfig: OpenClawConfig;
+  prevSourceConfig: OpenClawConfig;
   nextConfig: OpenClawConfig;
   preparedSecretsSnapshot: PreparedSecretsRuntimeSnapshot;
 }): boolean {
@@ -652,6 +719,7 @@ function shouldDisconnectSharedAuthClientsForConfigWrite(params: {
     didSharedGatewayAuthChange(params.prevConfig, params.nextConfig) ||
     didActiveSharedGatewayAuthChange({
       fallbackPrev: params.prevConfig,
+      fallbackSource: params.prevSourceConfig,
       next: params.preparedSecretsSnapshot.config,
     })
   );
@@ -937,6 +1005,16 @@ export const configHandlers: GatewayRequestHandlers = {
       return;
     }
     const replacePaths = readConfigPatchReplacePaths(params);
+    try {
+      assertNoDuplicateConfigPatchIds({
+        patch: parsedRes.parsed,
+        current: snapshot.config,
+        replacePaths,
+      });
+    } catch (error) {
+      respond(false, undefined, errorShape(ErrorCodes.INVALID_REQUEST, formatErrorMessage(error)));
+      return;
+    }
     const merged = applyMergePatch(snapshot.config, parsedRes.parsed, {
       // Arrays with stable ids behave like maps for partial control-plane edits.
       mergeObjectArraysById: true,
@@ -1053,6 +1131,7 @@ export const configHandlers: GatewayRequestHandlers = {
     // previous shared secret immediately after the config update succeeds.
     const disconnectSharedAuthClients = shouldDisconnectSharedAuthClientsForConfigWrite({
       prevConfig: snapshot.config,
+      prevSourceConfig: snapshot.sourceConfig,
       nextConfig: validated.config,
       preparedSecretsSnapshot,
     });
@@ -1109,6 +1188,7 @@ export const configHandlers: GatewayRequestHandlers = {
     // previous shared secret immediately after the config update succeeds.
     const disconnectSharedAuthClients = shouldDisconnectSharedAuthClientsForConfigWrite({
       prevConfig: snapshot.config,
+      prevSourceConfig: snapshot.sourceConfig,
       nextConfig: parsed.config,
       preparedSecretsSnapshot,
     });


### PR DESCRIPTION
<!-- AI-assisted maintainer change. -->

Related: #115289

## What Problem This Solves

Fixes two gateway configuration-write bugs on current main:

1. `config.patch` silently accepted duplicate IDs in arrays using ID-keyed merge semantics, so later entries overwrote earlier entries in the same request.
2. `config.patch` and `config.apply` could compare shared authentication against a partial or stale active secrets snapshot, causing unnecessary client disconnects or missing a required disconnect after an auth change.

## Why This Change Was Made

The patch rejects duplicate IDs only when the target array is actually using ID-merge semantics; explicit array replacements keep their existing contract. Shared-auth comparison now projects active secret-expanded values only onto leaves still owned by the current authored source, preserving runtime-only siblings and falling back when active secret state is stale.

This deliberately does not port the closed branch's planner, redaction copies, sentinel stripping, or merge-patch pruning. Main's existing `redact-snapshot.ts` and `io.write-prepare.ts` owners already cover those paths.

## User Impact

Gateway config edits now fail clearly instead of resolving duplicate-ID patches by request order. Auth-affecting edits disconnect shared-auth clients exactly when the current effective credentials changed, including when active secret state is partial or stale.

Release-note context: Gateway config patch hardening rejects ambiguous duplicate IDs in ID-merged patches and corrects shared-auth disconnect decisions for partial or stale active secret snapshots.

## Evidence

Baseline reproduction on current main:

- Duplicate-ID regression test failed because the RPC succeeded and persisted the second duplicate entry.
- Runtime-only auth regression test failed with `expected true to be false`.

Verify-first candidate results:

| Dead-branch candidate | Current-main result | Decision |
| --- | --- | --- |
| `assertNoDuplicateConfigPatchIds` | Reproduced: duplicate ID entries were accepted with last-write-wins behavior. | Ported, narrowed to actual ID-merge paths and hardened for ambiguous duplicate IDs already present in the current array. |
| `findInvalidRedactionSentinelPath` / `replaceRedactionSentinelsWithProbe` | Did not reproduce: main's `restoreRedactedValues` rejects sentinels at non-sensitive paths for both patch and apply. | Skipped. |
| `stripRedactedPatchSentinels` | Did not reproduce: gateway restore plus canonical write preparation preserved an authored env reference when its redaction sentinel accompanied a sibling patch. | Skipped. |
| `isEmptyMergePatchAgainst` / `pruneEmptyMergePatchBranches` | Did not reproduce: unchanged patches already return `noop`, while `io.write-prepare.ts` preserves untouched include-owned branches without planner ownership rejection. | Skipped. |
| `collectRuntimeOnlyAgentUnsets` | Not a supported `config.patch` deletion path: main fails closed and requires the `agents.delete` RPC, whose writer carries explicit removal authority. | Skipped. |
| `resolveSharedAuthAuthoredSource` | Reproduced as partial/stale active-secret comparison errors. Main already exposes canonical `snapshot.sourceConfig`, so the fix passes that source into the auth owner instead of copying the dead branch's gateway-private resolver. | Adapted and ported at the existing auth-comparison boundary. |

Focused exact-head proof after rebasing onto current `origin/main`:

- `node scripts/run-vitest.mjs src/gateway/server-methods/config.test.ts src/gateway/server-methods/config-write-flow.test.ts src/config/redact-snapshot.restore.test.ts src/config/io.write-prepare.test.ts`
- 27 gateway tests passed.
- 116 runtime-config tests passed.
- `git diff --check` passed.

Autoreview found two real duplicate-ID contract gaps; both were fixed and the focused tests rerun. Its final remaining suggestion was rejected after direct source inspection: `mergeObjectArraysById` intentionally continues ID merging for mixed patches and appends non-ID entries, covered by `src/config/merge-patch.test.ts`.
