### PR TITLE
fix(heartbeat): deliver task-preempted same-session commitments

### DIFF
--- a/src/infra/heartbeat-runner-scheduler.ts
+++ b/src/infra/heartbeat-runner-scheduler.ts
@@ -19,7 +19,6 @@ import {
   type HeartbeatConfig,
 } from "./heartbeat-runner-config.js";
 import { runHeartbeatOnce } from "./heartbeat-runner-run.js";
-import { resolveHeartbeatSession } from "./heartbeat-runner-session.js";
 import {
   computeNextHeartbeatPhaseDueMs,
   resolveHeartbeatPhaseMs,
@@ -382,11 +381,8 @@ export function startHeartbeatRunner(opts: {
       advanceAgentSchedule(agent, now, reason);
       let agentRan = res.status === "ran";
 
-      const defaultSessionKey = resolveHeartbeatSession(
-        wakeConfig,
-        agent.agentId,
-        agent.heartbeat,
-      ).sessionKey;
+      // Re-read pending commitments after the global turn so a task-preempted
+      // default session gets an isolated follow-up without duplicating sends.
       const dueSessionKeys = canHeartbeatDeliverCommitments(agent.heartbeat)
         ? await listDueCommitmentSessionKeys({
             cfg: wakeConfig,
@@ -396,9 +392,6 @@ export function startHeartbeatRunner(opts: {
           })
         : [];
       for (const dueSessionKey of dueSessionKeys) {
-        if (dueSessionKey === defaultSessionKey) {
-          continue;
-        }
         let commitmentRes: HeartbeatRunResult;
         try {
           commitmentRes = await runOnce({

--- a/src/infra/heartbeat-runner.commitments.test.ts
+++ b/src/infra/heartbeat-runner.commitments.test.ts
@@ -469,6 +469,124 @@ describe("runHeartbeatOnce commitments", () => {
     });
   });
 
+  it.each([
+    { taskPreemptsCommitment: true, expectedRunCount: 2 },
+    { taskPreemptsCommitment: false, expectedRunCount: 1 },
+  ])(
+    "delivers a default-session commitment exactly once when task preemption is $taskPreemptsCommitment",
+    async ({ taskPreemptsCommitment, expectedRunCount }) => {
+      vi.useFakeTimers();
+      vi.setSystemTime(nowMs);
+
+      await withTempHeartbeatSandbox(async ({ tmpDir, storePath, replySpy }) => {
+        setTestEnvValue("OPENCLAW_STATE_DIR", tmpDir);
+        const sessionKey = "agent:main:telegram:user-155462274";
+        const cfg: OpenClawConfig = {
+          agents: {
+            defaults: {
+              workspace: tmpDir,
+              heartbeat: { every: "5m", target: "last", session: sessionKey },
+            },
+          },
+          channels: { telegram: { allowFrom: ["*"] } },
+          session: { store: storePath },
+        };
+        await seedSessionStore(storePath, sessionKey, {
+          lastChannel: "telegram",
+          lastProvider: "telegram",
+          lastTo: "stale-target",
+        });
+        await saveCommitmentStore(undefined, {
+          version: 1,
+          commitments: [buildCommitment({ id: "cm_interview", sessionKey, to: "155462274" })],
+        });
+
+        const sendTelegram = vi.fn().mockResolvedValue({
+          messageId: "m1",
+          chatId: "155462274",
+        });
+        replySpy.mockImplementation(async (ctx, opts) => {
+          if (taskPreemptsCommitment && replySpy.mock.calls.length === 1) {
+            expect(ctx.Body).toContain("Run the following periodic tasks");
+            expect(ctx.Body).toContain("Check deployment status with the normal tools");
+            expect(ctx.Body).not.toContain("Due inferred follow-up commitments");
+            expect(opts?.disableTools).toBeUndefined();
+            return { text: HEARTBEAT_TOKEN };
+          }
+
+          expect(ctx.Body).toContain("Due inferred follow-up commitments");
+          expect(ctx.Body).toContain("How did the interview go?");
+          expect(ctx.Body).not.toContain("Check deployment status with the normal tools");
+          expect(ctx.OriginatingTo).toBe("155462274");
+          expect(opts?.disableTools).toBe(true);
+          expect(opts?.skillFilter).toStrictEqual([]);
+          return { text: "How did the interview go?" };
+        });
+
+        const runOnce = vi.fn<typeof runHeartbeatOnce>(async (opts) =>
+          runHeartbeatOnce({
+            ...opts,
+            ...(taskPreemptsCommitment && opts.runScope === "global"
+              ? {
+                  tasks: [
+                    {
+                      jobId: "job-deployment-status",
+                      name: "deployment-status",
+                      prompt: "Check deployment status with the normal tools",
+                    },
+                  ],
+                }
+              : {}),
+            deps: {
+              ...opts.deps,
+              getReplyFromConfig: replySpy,
+              telegram: sendTelegram,
+              getQueueSize: () => 0,
+              nowMs: () => nowMs,
+            },
+          }),
+        );
+        const runner = startHeartbeatRunner({
+          cfg,
+          runOnce,
+          stableSchedulerSeed: "same-session-commitment-monitor-tick",
+        });
+
+        requestHeartbeat({
+          source: "interval",
+          intent: "scheduled",
+          reason: "interval",
+          agentId: "main",
+          scheduledEveryMs: 5 * 60_000,
+          coalesceMs: 0,
+        });
+        await vi.advanceTimersByTimeAsync(1);
+        await vi.waitFor(() => expect(runOnce).toHaveBeenCalledTimes(expectedRunCount));
+        runner.stop();
+
+        expect(replySpy).toHaveBeenCalledTimes(expectedRunCount);
+        if (taskPreemptsCommitment) {
+          expect(runOnce.mock.calls[1]?.[0]).toMatchObject({
+            agentId: "main",
+            runScope: "commitment-only",
+            sessionKey,
+          });
+        }
+        expect(sendTelegram).toHaveBeenCalledTimes(1);
+        expect(sendTelegram).toHaveBeenCalledWith(
+          "155462274",
+          "How did the interview go?",
+          expect.any(Object),
+        );
+        expectCommitmentFields((await loadCommitmentStore()).commitments[0], {
+          id: "cm_interview",
+          status: "sent",
+          attempts: 1,
+        });
+      });
+    },
+  );
+
   it("delivers due commitments on a targeted cron-monitor interval tick", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(nowMs);


### PR DESCRIPTION
Supersedes #75469.

## What Problem This Solves

Fixes an issue where heartbeat commitments for the configured user session were silently starved whenever a scheduled heartbeat task took priority. Users never received the promised follow-up even though the commitment remained due.

## Why This Change Was Made

After the normal task turn finishes, query the canonical SQLite commitment store and run the existing tools-disabled, commitment-only follow-up for every still-due session, including the heartbeat default session. The completed global turn removes any commitment it already delivered, so no duplicate follow-up is generated. This reuses the existing heartbeat owner, cron-monitor wake, delivery route, terminal outcome, and isolation contract without introducing any configuration, migration, timer, or provider change.

## User Impact

Users reliably receive same-session follow-up commitments after periodic tasks. Normal commitment deliveries continue to send exactly once, and commitment metadata never enters a tool-capable task prompt.

## Evidence

Real Linux Blacksmith Testbox tbx_01kyp2jk4m8ns55xbn7qef29ps, running the actual cron-monitor scheduler, SQLite commitment store, heartbeat model-prompt pipeline, and Telegram channel fixture.

- RED before production fix: the new task-preemption regression failed because only the global task turn ran; the no-duplicate case and all 13 existing commitment tests passed.
- GREEN after production fix: 65 tests passed across heartbeat commitments, heartbeat scheduler, heartbeat cadence, and the cron heartbeat monitor. Both actual task-preempted and already-delivered same-session cases verify user delivery, tool isolation, terminal behavior, and exactly one Telegram send.
- Full Linux pnpm check:changed passed, including core and test tsgo, zero-warning lint, formatting, plugin and database boundaries, dead exports, and import cycles.
- Independent structured gpt-5.6-sol xhigh autoreview: no accepted or actionable findings; confidence 0.96.
