### PR TITLE
fix(feishu): preserve valid empty inbound message events

### DIFF
--- a/extensions/feishu/src/bot.helpers.test.ts
+++ b/extensions/feishu/src/bot.helpers.test.ts
@@ -64,6 +64,13 @@ describe("buildFeishuAgentBody", () => {
 });
 
 describe("parseMessageContent media captions", () => {
+  it.each(["text", "image", "audio", "file", "video"])(
+    "keeps an empty %s message body empty",
+    (messageType) => {
+      expect(parseMessageContent("", messageType)).toBe("");
+    },
+  );
+
   it("keeps an audio-only body empty instead of leaking raw file_key JSON", () => {
     expect(
       parseMessageContent(JSON.stringify({ file_key: "file_audio", duration: 1200 }), "audio"),

--- a/extensions/feishu/src/bot.stripBotMention.test.ts
+++ b/extensions/feishu/src/bot.stripBotMention.test.ts
@@ -36,6 +36,22 @@ describe("normalizeMentions (via parseFeishuMessageEvent)", () => {
     expect(ctx.content).toBe("hello world");
   });
 
+  it("parses an empty group message body with bot-mention metadata", () => {
+    const event = makeEvent(
+      "",
+      [{ key: "@_bot_1", name: "Bot", id: { open_id: BOT_OPEN_ID } }],
+      "group",
+    );
+    event.message.content = "";
+
+    expect(parseFeishuMessageEvent(event, BOT_OPEN_ID)).toMatchObject({
+      content: "",
+      chatType: "group",
+      mentionedBot: true,
+      hasAnyMention: true,
+    });
+  });
+
   it("strips bot mention in p2p (addressing prefix, not semantic content)", () => {
     const ctx = parseFeishuMessageEvent(
       makeEvent("@_bot_1 hello", [{ key: "@_bot_1", name: "Bot", id: { open_id: "ou_bot" } }]),

--- a/extensions/feishu/src/monitor.message-handler.ingress.test.ts
+++ b/extensions/feishu/src/monitor.message-handler.ingress.test.ts
@@ -149,6 +149,73 @@ afterEach(() => {
 });
 
 describe("Feishu durable ingress debounce lifecycle", () => {
+  it("accepts an empty group message body without losing bot mentions or ingress adoption", async () => {
+    const transport = createLifecycle();
+    const logicalClaim = createClaim("empty-group-mention");
+    const harness = createHarness({
+      lifecycles: new Map([["evt-empty-group-mention", transport.lifecycle]]),
+      claims: [logicalClaim],
+      adoptTurn: true,
+    });
+    const event = createTextEvent("evt-empty-group-mention", "om-empty-group-mention", "");
+    event.message.chat_type = "group";
+    event.message.content = "";
+    event.message.mentions = [
+      {
+        key: "@_bot_1",
+        id: { open_id: "ou-bot" },
+        name: "OpenClaw",
+      },
+    ];
+
+    await expect(harness.handler(event)).resolves.toEqual({ kind: "deferred" });
+    await harness.flush();
+
+    expect(harness.handleMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event: expect.objectContaining({
+          message: expect.objectContaining({
+            chat_type: "group",
+            content: "",
+            mentions: event.message.mentions,
+          }),
+        }),
+      }),
+    );
+    expect(logicalClaim.commit).toHaveBeenCalledTimes(1);
+    expect(transport.calls.adopted).toHaveBeenCalledTimes(1);
+    expect(transport.calls.abandoned).not.toHaveBeenCalled();
+    expect(harness.runtimeError).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    {
+      name: "missing",
+      setContent: (event: FeishuMessageEvent) => Reflect.deleteProperty(event.message, "content"),
+    },
+    {
+      name: "non-string",
+      setContent: (event: FeishuMessageEvent) => Reflect.set(event.message, "content", 42),
+    },
+  ])("rejects a $name message body before durable dispatch", async ({ setContent }) => {
+    const transport = createLifecycle();
+    const harness = createHarness({
+      lifecycles: new Map([["evt-invalid-body", transport.lifecycle]]),
+      claims: [],
+      adoptTurn: true,
+    });
+    const event = createTextEvent("evt-invalid-body", "om-invalid-body", "");
+    setContent(event);
+
+    await expect(harness.handler(event)).rejects.toThrow(
+      "Feishu durable message event payload is malformed.",
+    );
+
+    expect(harness.claim).not.toHaveBeenCalled();
+    expect(harness.handleMessage).not.toHaveBeenCalled();
+    expect(transport.calls.adopted).not.toHaveBeenCalled();
+  });
+
   it("returns deferred and fans merged adoption to every constituent claim", async () => {
     const first = createLifecycle();
     const second = createLifecycle();

--- a/extensions/feishu/src/monitor.message-handler.ts
+++ b/extensions/feishu/src/monitor.message-handler.ts
@@ -83,8 +83,9 @@ function parseFeishuMessageEventPayload(value: unknown): FeishuMessageEvent | nu
   const chatId = readString(message.chat_id);
   const chatType = normalizeFeishuChatType(message.chat_type);
   const messageType = readString(message.message_type);
-  const content = readString(message.content);
-  if (!messageId || !chatId || !chatType || !messageType || !content) {
+  // Feishu can deliver a legitimately empty message body; keep absent or
+  // non-string bodies malformed instead of inventing fallback content.
+  if (!messageId || !chatId || !chatType || !messageType || typeof message.content !== "string") {
     return null;
   }
   return value as FeishuMessageEvent;

--- a/extensions/feishu/src/sequential-key.test.ts
+++ b/extensions/feishu/src/sequential-key.test.ts
@@ -70,4 +70,25 @@ describe("getFeishuSequentialKey", () => {
       }),
     ).toBe("feishu:default:oc_dm_chat:btw");
   });
+
+  it("keeps an empty group message with bot mentions on its normal chat lane", () => {
+    const event = createTextEvent({ text: "" });
+    event.message.chat_type = "group";
+    event.message.content = "";
+    event.message.mentions = [
+      {
+        key: "@_bot_1",
+        id: { open_id: "ou_bot_1" },
+        name: "OpenClaw",
+      },
+    ];
+
+    expect(
+      getFeishuSequentialKey({
+        accountId: "default",
+        event,
+        botOpenId: "ou_bot_1",
+      }),
+    ).toBe("feishu:default:oc_dm_chat");
+  });
 });


### PR DESCRIPTION
Closes #66657

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where a Feishu group receive event with an officially valid empty-string message body and separate bot-mention metadata was incorrectly classified as a permanently malformed durable inbound message. The message never reached mention normalization, sequential routing, or its normal no-content handling, and its ingress adoption was not settled.

## Why This Change Was Made

The installed official `@larksuiteoapi/node-sdk` declares `im.message.receive_v1.message.content` as a required `string`; Feishu’s own message FAQ additionally documents legitimately empty received message content. The existing plugin-local receive boundary must therefore check that content **is a string**, not that it **is a nonempty string**. This change accepts provider-contract-valid empty strings while retaining strict rejection of missing, numeric, and otherwise non-string message content. It does not invent body content, broaden malformed-payload acceptance, change provider configuration, or modify media, cards, or channel-core behavior.

Provider-contract references: https://open.feishu.cn/document/server-docs/im-v1/faq and https://open.feishu.cn/document/server-docs/im-v1/message-content-description/message_content.

## User Impact

A valid empty Feishu inbound event no longer crashes or permanently loses its durable turn. Its original bot mentions, chat route, and ingress claim are preserved, while malformed and missing message bodies remain rejected. This also preserves empty audio, image, video, and file content without fabricating visible text.

## Evidence

- Fail-first on reusable isolated Blacksmith Testbox `tbx_01kyp2vkkdqp91cgaeaxp5pta9`: the exact group-event durable-ingress regression rejected with `FeishuIngressPermanentError`; the other **47** focused tests passed, including explicit rejection of absent and non-string bodies.
- After the one plugin-owned production-boundary fix: **289/289 tests pass across seven Feishu suites**, covering actual durable ingress and claim adoption, bot-mention metadata, sequential chat routes, text/audio/image/file/video parsing, inbound bot behavior, outbound reply dispatch, and streaming cards.
- The complete remote `pnpm check:changed` passes both extension production/test typecheck lanes, targeted formatting and lint, SDK/owner-boundary validation, dead-export scans, dependency/storage guards, and runtime import-cycle checks; Testbox timing result `exitCode: 0`.
- Fresh independent `gpt-5.6-sol` **xhigh** autoreview: clean, `overall: patch is correct (0.98)`.
- Honest limitation: provider-transport behavior was verified through the real plugin inbound lifecycle with mocked Feishu delivery; no authenticated live Feishu tenant is claimed.

Thanks @rZeR0y for the original report and @Thiagocsoaresbh for the earlier investigation in #77109. This PR deliberately follows the current official SDK contract instead of accepting malformed absent content.