### PR TITLE
fix(web-fetch): speed up large styled pages

### DIFF
--- a/src/agents/tools/web-fetch-visibility.test.ts
+++ b/src/agents/tools/web-fetch-visibility.test.ts
@@ -1,9 +1,37 @@
 // web_fetch visibility tests cover hidden HTML and invisible Unicode stripping
 // before extracted content reaches the model.
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { sanitizeHtml, stripInvisibleUnicode } from "./web-fetch-visibility.js";
 
 describe("sanitizeHtml", () => {
+  it("reuses compiled CSS property matchers across styled elements", async () => {
+    const styledElements = 256;
+    const html = Array.from(
+      { length: styledElements },
+      (_, index) => `<p style="color:rgb(12,34,56)">Visible ${index}</p>`,
+    ).join("");
+    const NativeRegExp = globalThis.RegExp;
+    const regexpConstructor = vi.spyOn(globalThis, "RegExp").mockImplementation(function (
+      pattern?: string | RegExp,
+      flags?: string,
+    ) {
+      return Reflect.construct(NativeRegExp, [pattern, flags]);
+    });
+
+    try {
+      const result = await sanitizeHtml(html);
+      const perElementStyleMatchers = regexpConstructor.mock.calls.filter(
+        ([pattern]) => typeof pattern === "string" && pattern.startsWith("(?:^|;)\\s*"),
+      );
+
+      expect(result).toContain("Visible 0");
+      expect(result).toContain(`Visible ${styledElements - 1}`);
+      expect(perElementStyleMatchers).toHaveLength(0);
+    } finally {
+      regexpConstructor.mockRestore();
+    }
+  });
+
   it("strips display:none elements", async () => {
     const html = '<p>Visible</p><p style="display:none">Hidden</p>';
     const result = await sanitizeHtml(html);

--- a/src/agents/tools/web-fetch-visibility.ts
+++ b/src/agents/tools/web-fetch-visibility.ts
@@ -8,17 +8,22 @@ import {
   normalizeOptionalLowercaseString,
 } from "@openclaw/normalization-core/string-coerce";
 
-// CSS property values that indicate an element is hidden
-const HIDDEN_STYLE_PATTERNS: Array<[string, RegExp]> = [
-  ["display", /^\s*none\s*$/i],
-  ["visibility", /^\s*hidden\s*$/i],
-  ["opacity", /^\s*0\s*$/],
-  ["font-size", /^\s*0(px|em|rem|pt|%)?\s*$/i],
-  ["text-indent", /^\s*-\d{4,}px\s*$/],
-  ["color", /^\s*transparent\s*$/i],
-  ["color", /^\s*rgba\s*\(\s*\d+\s*,\s*\d+\s*,\s*\d+\s*,\s*0(?:\.0+)?\s*\)\s*$/i],
-  ["color", /^\s*hsla\s*\(\s*[\d.]+\s*,\s*[\d.]+%?\s*,\s*[\d.]+%?\s*,\s*0(?:\.0+)?\s*\)\s*$/i],
-];
+// Compile property matchers once: this list is checked for every styled element.
+const HIDDEN_STYLE_PATTERNS = (
+  [
+    ["display", /^\s*none\s*$/i],
+    ["visibility", /^\s*hidden\s*$/i],
+    ["opacity", /^\s*0\s*$/],
+    ["font-size", /^\s*0(px|em|rem|pt|%)?\s*$/i],
+    ["text-indent", /^\s*-\d{4,}px\s*$/],
+    ["color", /^\s*transparent\s*$/i],
+    ["color", /^\s*rgba\s*\(\s*\d+\s*,\s*\d+\s*,\s*\d+\s*,\s*0(?:\.0+)?\s*\)\s*$/i],
+    ["color", /^\s*hsla\s*\(\s*[\d.]+\s*,\s*[\d.]+%?\s*,\s*[\d.]+%?\s*,\s*0(?:\.0+)?\s*\)\s*$/i],
+  ] satisfies Array<[string, RegExp]>
+).map(([prop, valuePattern]) => {
+  const escapedProp = prop.replace(/-/g, "\\-");
+  return [new RegExp(`(?:^|;)\\s*${escapedProp}\\s*:\\s*([^;]+)`, "i"), valuePattern] as const;
+});
 
 // Class names associated with visually hidden content
 const HIDDEN_CLASS_NAMES = new Set([
@@ -53,11 +58,10 @@ function hasHiddenClass(className: string): boolean {
 }
 
 function isStyleHidden(style: string): boolean {
-  for (const [prop, pattern] of HIDDEN_STYLE_PATTERNS) {
-    const escapedProp = prop.replace(/-/g, "\\-");
-    const match = style.match(new RegExp(`(?:^|;)\\s*${escapedProp}\\s*:\\s*([^;]+)`, "i"));
+  for (const [propertyPattern, valuePattern] of HIDDEN_STYLE_PATTERNS) {
+    const match = style.match(propertyPattern);
     const value = match?.at(1);
-    if (value && pattern.test(value)) {
+    if (value && valuePattern.test(value)) {
       return true;
     }
   }


### PR DESCRIPTION
Closes #105437.

## What Problem This Solves

Fixes an issue where users fetching or extracting large style-heavy webpages would pay for eight newly constructed CSS-property regular expressions per visible element. The same sanitizer is used by `web_fetch`, browser extraction, and the Readability plugin, so large pages generated avoidable CPU and garbage collection overhead across all three user paths.

## Why This Change Was Made

Compile the existing eight property matchers exactly once when the existing visibility-pattern table initializes. Preserve every original expression, case-insensitive flag, property escape, value matcher, hidden-content rule, browser/Readability contract, and SDK surface. Do not add a cache, `Map`, dependency, configuration option, or fallback path.

## User Impact

Large HTML pages are extracted faster while hidden and visible content remain exactly as before. On the same hosted Linux worker, a representative 4,096-article page containing 8,193 inline-styled elements improved from a five-sample median of **30.01 ms to 21.95 ms (26.9% faster)**. Both the real sanitizer and complete basic HTML extraction retained visible article text and removed hidden content.

## Evidence

Hosted Blacksmith Testbox `tbx_01kyp1nyass41eh725x11pz5nh`:

```text
Before:
  256 visible styled elements construct 2,048 property RegExp instances.
  Regression fails: expected 0 per-element matchers, received 2048.
  4,096 real articles / 8,193 styled elements: 30.01 ms median, 5 samples.

After:
  256 visible styled elements construct 0 property RegExp instances.
  Existing visibility suite and new regression: 44 tests passed.
  4,096 real articles / 8,193 styled elements: 21.95 ms median, 5 samples.
  Actual sanitizeHtml and extractBasicHtmlContent retain visible content and
  remove the hidden-content marker.
```

Sibling runtime coverage:

```text
pnpm test \
  src/agents/tools/web-fetch-visibility.test.ts \
  src/agents/tools/web-fetch-utils.test.ts \
  extensions/web-readability/web-content-extractor.test.ts \
  extensions/browser/src/browser-extract.test.ts \
  --reporter=dot

4 files passed; 100 tests passed.
```

Also validated `pnpm check:changed` on the hosted Testbox and a fresh isolated Codex review with `gpt-5.6-sol` at `xhigh` reasoning. Thanks to @aniruddhaadak80 for the original report and @wendy-chsy for the earlier independently proposed fix.

- [x] AI-assisted (Codex).
- [x] I understand and independently verified the change.
- [x] No new configuration, dependency, cache, network capability, or hidden-content behavior.
