### PR TITLE
feat(ui): give plugin Discover a path URL and make hub tabs user-driven

### DIFF
--- a/docs/web/control-ui.md
+++ b/docs/web/control-ui.md
@@ -182,7 +182,7 @@ official external plugins, and one-click MCP connectors for popular services.
 Typing in the search box queries
 [ClawHub](https://clawhub.ai/plugins) inline and appends a **From ClawHub**
 section with download counts and source-verification badges. Deep links can
-target the store directly with `/settings/plugins?tab=discover`.
+target the store directly with `/settings/plugins/discover`.
 
 The **Skills** tab keeps the skill status report, enable/disable toggles, API
 key entry, and inline ClawHub skill search, scoped to the selected agent. The

--- a/docs/web/urls.md
+++ b/docs/web/urls.md
@@ -160,7 +160,7 @@ no route-specific URL parameters.
 | Logs                | `/logs`                     | -                         | -                                                |
 | Skill Workshop      | `/skills/workshop`          | -                         | -                                                |
 | Skills              | `/skills`                   | -                         | -                                                |
-| Plugins             | `/settings/plugins`         | -                         | `?tab=discover\|installed`                       |
+| Plugins             | `/settings/plugins`         | -                         | `/settings/plugins/discover`                     |
 | Automations         | `/cron`                     | -                         | -                                                |
 | Tasks               | `/tasks`                    | -                         | -                                                |
 | Devices             | `/settings/devices`         | `/nodes`                  | Shared settings parameters below                 |
@@ -174,6 +174,10 @@ Memory tabs use the paths in the table instead of `?tab=`. Older Memory links
 with `?tab=memories|dreams|settings`, `?tab=dreaming`, `?tab=search`, or
 `?section=memory` are replaced once with the corresponding path while keeping
 any setting anchor.
+
+Plugin catalog tabs also use paths instead of `?tab=`. Older links with
+`?tab=discover|installed` are replaced once with the corresponding path while
+keeping other query parameters and the fragment.
 
 ## Special documents and startup modes
 

--- a/ui/src/app-route-paths.test.ts
+++ b/ui/src/app-route-paths.test.ts
@@ -5,8 +5,11 @@ import {
   inferBasePathFromPathname,
   memoryTabFromPath,
   pathForMemoryTab,
+  pathForPluginsHubTab,
+  pluginsHubTabFromPath,
   routeIdFromPath,
   type MemoryRouteTab,
+  type PluginsHubRouteTab,
 } from "./app-route-paths.ts";
 import { createApplicationRouter, startApplicationRouter } from "./app-routes.ts";
 import type { ApplicationContext } from "./app/context.ts";
@@ -77,6 +80,77 @@ describe("Memory tab route paths", () => {
     expect(router.getState().location).toEqual(location);
     expect(router.getState().matches[0]?.location).toEqual(location);
     expect(location.pathname).toBe("/settings/memory/settings");
+    expect(push).not.toHaveBeenCalled();
+    expect(replace).not.toHaveBeenCalled();
+    router.stop();
+  });
+});
+
+describe("Plugins hub tab route paths", () => {
+  it.each([
+    ["installed", "/settings/plugins"],
+    ["discover", "/settings/plugins/discover"],
+  ] as const)("round-trips %s through its canonical path", (tab, pathname) => {
+    expect(pathForPluginsHubTab(tab)).toBe(pathname);
+    expect(pluginsHubTabFromPath(pathname)).toBe(tab);
+    expect(routeIdFromPath(pathname)).toBe("plugins");
+  });
+
+  it.each(["installed", "discover"] as const)(
+    "round-trips %s under a configured base path",
+    (tab: PluginsHubRouteTab) => {
+      const pathname = pathForPluginsHubTab(tab, "/ui");
+      expect(pluginsHubTabFromPath(pathname, "/ui")).toBe(tab);
+      expect(routeIdFromPath(pathname, "/ui")).toBe("plugins");
+      expect(inferBasePathFromPathname(pathname)).toBe("/ui");
+    },
+  );
+
+  it("rejects unknown and nested Plugins hub tab segments", () => {
+    expect(pluginsHubTabFromPath("/settings/plugins/unknown")).toBeNull();
+    expect(pluginsHubTabFromPath("/settings/plugins/discover/extra")).toBeNull();
+    expect(routeIdFromPath("/settings/plugins/unknown")).toBeNull();
+    expect(routeIdFromPath("/settings/plugins/discover/extra")).toBeNull();
+  });
+
+  it("publishes the real dynamic pathname after the exact-match startup bridge", async () => {
+    let location: RouteLocation = {
+      pathname: "/settings/plugins/discover",
+      search: "?query=calendar",
+      hash: "#featured",
+    };
+    const push = vi.fn((next: RouteLocation) => {
+      location = next;
+    });
+    const replace = vi.fn((next: RouteLocation) => {
+      location = next;
+    });
+    const history: RouterHistory = {
+      location: () => location,
+      push,
+      replace,
+      listen: () => () => undefined,
+    };
+    const router = createApplicationRouter();
+    const pluginsRoute = router.getRoute("plugins");
+    if (!pluginsRoute) {
+      throw new Error("Plugins route missing");
+    }
+    pluginsRoute.component = async () => ({ render: () => null });
+    const context = {
+      basePath: "",
+      gateway: {
+        snapshot: { phase: "reconnecting", client: null },
+      },
+    } as unknown as ApplicationContext;
+
+    await startApplicationRouter(router, history, "", context);
+
+    expect(router.getState().location).toEqual(location);
+    expect(router.getState().matches[0]?.location).toEqual(location);
+    expect(location.pathname).toBe("/settings/plugins/discover");
+    expect(location.search).toBe("?query=calendar");
+    expect(location.hash).toBe("#featured");
     expect(push).not.toHaveBeenCalled();
     expect(replace).not.toHaveBeenCalled();
     router.stop();

--- a/ui/src/app-route-paths.ts
+++ b/ui/src/app-route-paths.ts
@@ -4,8 +4,10 @@ import { isValidWorkboardBoardId } from "@openclaw/workboard-contract";
 import type { BoardFace } from "./lib/board/settings.ts";
 export const INTERNAL_SESSION_PATH_PARAM = "__openclawSessionPath";
 export const INTERNAL_MEMORY_PATH_PARAM = "__openclawMemoryPath";
+export const INTERNAL_PLUGINS_PATH_PARAM = "__openclawPluginsPath";
 
 export type MemoryRouteTab = "overview" | "memories" | "dreams" | "settings";
+export type PluginsHubRouteTab = "installed" | "discover";
 
 const APP_ROUTE_DEFINITIONS = {
   chat: { path: "/chat" },
@@ -115,6 +117,20 @@ export function memoryTabFromPath(pathname: string, basePath = ""): MemoryRouteT
   return segment === "memories" || segment === "dreams" || segment === "settings" ? segment : null;
 }
 
+export function pathForPluginsHubTab(tab: PluginsHubRouteTab, basePath = ""): string {
+  const pluginsPath = pathForRoute("plugins", basePath);
+  return tab === "installed" ? pluginsPath : `${pluginsPath}/discover`;
+}
+
+export function pluginsHubTabFromPath(pathname: string, basePath = ""): PluginsHubRouteTab | null {
+  const normalizedPath = normalizePath(pathname);
+  const pluginsPath = pathForRoute("plugins", basePath);
+  if (normalizedPath === pluginsPath) {
+    return "installed";
+  }
+  return normalizedPath === `${pluginsPath}/discover` ? "discover" : null;
+}
+
 export function isSessionRouteId(routeId: string | null | undefined): routeId is BoardFace {
   return routeId === "chat" || routeId === "dashboard";
 }
@@ -174,6 +190,9 @@ export function routeIdFromPath(pathname: string, basePath = ""): RouteId | null
   }
   if (memoryTabFromPath(normalizedPath, normalizedBasePath)) {
     return "memory";
+  }
+  if (pluginsHubTabFromPath(normalizedPath, normalizedBasePath)) {
+    return "plugins";
   }
   const sessionNamespace = sessionRouteNamespaceFromPath(normalizedPath, normalizedBasePath);
   if (sessionNamespace) {
@@ -240,9 +259,16 @@ export function inferBasePathFromPathname(pathname: string): string {
     const routePath = routePaths.find((path) => normalizePath(path) === candidate);
     const dynamicWorkboardRoute = workboardBoardIdFromPath(candidate) !== null;
     const dynamicMemoryRoute = memoryTabFromPath(candidate) !== null;
+    const dynamicPluginsRoute = pluginsHubTabFromPath(candidate) !== null;
     const sessionNamespace = sessionRouteNamespaceFromPath(candidate);
     const dynamicSessionRoute = sessionNamespace !== null;
-    if (!routePath && !dynamicWorkboardRoute && !dynamicMemoryRoute && !dynamicSessionRoute) {
+    if (
+      !routePath &&
+      !dynamicWorkboardRoute &&
+      !dynamicMemoryRoute &&
+      !dynamicPluginsRoute &&
+      !dynamicSessionRoute
+    ) {
       continue;
     }
     const previousSegment = segments[index - 1];
@@ -250,14 +276,20 @@ export function inferBasePathFromPathname(pathname: string): string {
       ? APP_ROUTE_DEFINITIONS.workboard.path
       : dynamicMemoryRoute
         ? APP_ROUTE_DEFINITIONS.memory.path
-        : sessionNamespace
-          ? APP_ROUTE_DEFINITIONS[sessionNamespace].path
-          : null;
+        : dynamicPluginsRoute
+          ? APP_ROUTE_DEFINITIONS.plugins.path
+          : sessionNamespace
+            ? APP_ROUTE_DEFINITIONS[sessionNamespace].path
+            : null;
     const firstRouteSegment = (routePath ?? dynamicRoutePath ?? "").split("/").find(Boolean);
     if (
       index > 0 &&
       previousSegment === firstRouteSegment &&
-      (candidate === routePath || dynamicWorkboardRoute || dynamicSessionRoute)
+      (candidate === routePath ||
+        dynamicWorkboardRoute ||
+        dynamicMemoryRoute ||
+        dynamicPluginsRoute ||
+        dynamicSessionRoute)
     ) {
       return "";
     }

--- a/ui/src/app-routes.ts
+++ b/ui/src/app-routes.ts
@@ -3,8 +3,10 @@ import type { PageDefinition, Router, RouterHistory } from "@openclaw/uirouter";
 import {
   INTERNAL_SESSION_PATH_PARAM,
   INTERNAL_MEMORY_PATH_PARAM,
+  INTERNAL_PLUGINS_PATH_PARAM,
   memoryTabFromPath,
   pathForRoute,
+  pluginsHubTabFromPath,
   routeIdFromPath,
   sessionRouteNamespaceFromPath,
   workboardBoardIdFromPath,
@@ -95,8 +97,8 @@ export function createApplicationRouter(): ApplicationRouter {
   const router = createRouter<RouteId, ApplicationContext<RouteId>, AppRouteModule>({
     routes: appRoutes,
   });
-  // The shared router intentionally matches exact paths only. Workboard ids
-  // and session refs are runtime data, so the app owns those dynamic paths.
+  // The shared router intentionally matches exact paths only. Workboard ids,
+  // hub tabs, and session refs are runtime data, so the app owns those paths.
   return {
     ...router,
     routeIdFromPath,
@@ -113,6 +115,10 @@ function dynamicRouteFromPath(pathname: string, basePath: string): DynamicRoute 
   const memoryTab = memoryTabFromPath(pathname, basePath);
   if (memoryTab && memoryTab !== "overview") {
     return ["memory", INTERNAL_MEMORY_PATH_PARAM, pathname];
+  }
+  const pluginsTab = pluginsHubTabFromPath(pathname, basePath);
+  if (pluginsTab === "discover") {
+    return ["plugins", INTERNAL_PLUGINS_PATH_PARAM, pathname];
   }
   const sessionNamespace = sessionRouteNamespaceFromPath(pathname, basePath);
   return sessionNamespace ? [sessionNamespace, INTERNAL_SESSION_PATH_PARAM, pathname] : null;

--- a/ui/src/components/hub-tabs.ts
+++ b/ui/src/components/hub-tabs.ts
@@ -16,7 +16,6 @@ type HubTabsProps<T extends string> = {
   ariaLabel: string;
   panelId: string;
   className?: string;
-  userSelectionOnly?: boolean;
   onSelect: (tab: T) => void;
 };
 
@@ -25,21 +24,6 @@ type HubTabsProps<T extends string> = {
 // from stealing focus later.
 const PENDING_FOCUS_WINDOW_MS = 2000;
 let pendingFocus: { hubId: string; tab: string; at: number } | null = null;
-let pointerActivation: { hubId: string; tab: string } | null = null;
-
-function selectHubTab<T extends string>(tab: T, props: HubTabsProps<T>) {
-  if (props.userSelectionOnly) {
-    // Manual activation below makes click/Enter/Space the only route writers;
-    // setup-time tab-show events must not navigate or they can oscillate paths.
-    return;
-  }
-  const activatedByPointer = pointerActivation?.hubId === props.id && pointerActivation.tab === tab;
-  pointerActivation = null;
-  if (!activatedByPointer && tab !== props.active) {
-    pendingFocus = { hubId: props.id, tab, at: Date.now() };
-  }
-  props.onSelect(tab);
-}
 
 function reclaimFocus(hubId: string, tab: string, element: Element | undefined) {
   if (!element || pendingFocus?.hubId !== hubId || pendingFocus.tab !== tab) {
@@ -68,7 +52,6 @@ export function renderHubTabs<T extends string>(props: HubTabsProps<T>): Templat
       .active=${props.active}
       activation="manual"
       without-scroll-controls
-      @wa-tab-show=${(event: CustomEvent<{ name: T }>) => selectHubTab(event.detail.name, props)}
     >
       ${props.tabs.map((tab) => {
         const selected = props.active === tab.value;
@@ -80,19 +63,12 @@ export function renderHubTabs<T extends string>(props: HubTabsProps<T>): Templat
             class="hub-tab"
             ?active=${selected}
             @click=${(event: MouseEvent) => {
-              if (props.userSelectionOnly) {
-                pointerActivation = null;
-                if ((event.detail > 0 || event.isTrusted) && tab.value !== props.active) {
-                  props.onSelect(tab.value);
-                }
-                return;
+              if ((event.detail > 0 || event.isTrusted) && tab.value !== props.active) {
+                props.onSelect(tab.value);
               }
-              pointerActivation = event.detail > 0 ? { hubId: props.id, tab: tab.value } : null;
             }}
             @keydown=${(event: KeyboardEvent) => {
-              pointerActivation = null;
               if (
-                props.userSelectionOnly &&
                 !event.repeat &&
                 (event.key === "Enter" || event.key === " ") &&
                 tab.value !== props.active

--- a/ui/src/components/plugins-hub-tabs.test.ts
+++ b/ui/src/components/plugins-hub-tabs.test.ts
@@ -83,13 +83,6 @@ describe("renderPluginsHubTabs", () => {
     target?.dispatchEvent(
       new KeyboardEvent("keydown", { key: "Enter", bubbles: true, composed: true }),
     );
-    source.querySelector("wa-tab-group")?.dispatchEvent(
-      new CustomEvent("wa-tab-show", {
-        bubbles: true,
-        composed: true,
-        detail: { name: "workshop" },
-      }),
-    );
     expect(onSelect).toHaveBeenLastCalledWith("workshop");
 
     source.remove();
@@ -101,8 +94,9 @@ describe("renderPluginsHubTabs", () => {
     });
   });
 
-  it("hands focus to the destination strip after synthesized activation", async () => {
-    const source = await mount({ active: "installed", onSelect: () => undefined });
+  it("ignores setup-time tab-show events", async () => {
+    const onSelect = vi.fn();
+    const source = await mount({ active: "installed", onSelect });
     source.querySelector("wa-tab-group")?.dispatchEvent(
       new CustomEvent("wa-tab-show", {
         bubbles: true,
@@ -110,14 +104,14 @@ describe("renderPluginsHubTabs", () => {
         detail: { name: "discover" },
       }),
     );
+    expect(onSelect).not.toHaveBeenCalled();
     source.remove();
 
     const destination = await mount({ active: "discover", onSelect: () => undefined });
-    await vi.waitFor(() => {
-      expect(document.activeElement).toBe(
-        destination.querySelector<HTMLElement>("#plugins-tab-discover"),
-      );
-    });
+    await Promise.resolve();
+    expect(document.activeElement).not.toBe(
+      destination.querySelector<HTMLElement>("#plugins-tab-discover"),
+    );
   });
 
   it("does not queue focus recovery for same-tab keyboard activation", async () => {
@@ -126,14 +120,6 @@ describe("renderPluginsHubTabs", () => {
     installed?.dispatchEvent(
       new KeyboardEvent("keydown", { key: "Enter", bubbles: true, composed: true }),
     );
-    container.querySelector("wa-tab-group")?.dispatchEvent(
-      new CustomEvent("wa-tab-show", {
-        bubbles: true,
-        composed: true,
-        detail: { name: "installed" },
-      }),
-    );
-
     // A later re-render of the strip must not reclaim focus from whatever
     // control the user moved on to.
     container.remove();
@@ -149,13 +135,6 @@ describe("renderPluginsHubTabs", () => {
     source
       .querySelector<HTMLElement>("#plugins-tab-skills")
       ?.dispatchEvent(new MouseEvent("click", { detail: 1 }));
-    source.querySelector("wa-tab-group")?.dispatchEvent(
-      new CustomEvent("wa-tab-show", {
-        bubbles: true,
-        composed: true,
-        detail: { name: "skills" },
-      }),
-    );
     source.remove();
 
     const destination = await mount({ active: "skills", onSelect: () => undefined });
@@ -165,10 +144,10 @@ describe("renderPluginsHubTabs", () => {
     );
   });
 
-  it("clears a same-tab pointer source when keyboard navigation follows", async () => {
-    const source = await mount({ active: "installed", onSelect: () => undefined });
+  it("does not turn arrow navigation into route selection", async () => {
+    const onSelect = vi.fn();
+    const source = await mount({ active: "installed", onSelect });
     const active = source.querySelector<HTMLElement>("#plugins-tab-installed");
-    active?.dispatchEvent(new MouseEvent("click", { detail: 1 }));
     active?.dispatchEvent(
       new KeyboardEvent("keydown", { key: "ArrowRight", bubbles: true, composed: true }),
     );
@@ -179,13 +158,6 @@ describe("renderPluginsHubTabs", () => {
         detail: { name: "discover" },
       }),
     );
-    source.remove();
-
-    const destination = await mount({ active: "discover", onSelect: () => undefined });
-    await vi.waitFor(() => {
-      expect(document.activeElement).toBe(
-        destination.querySelector<HTMLElement>("#plugins-tab-discover"),
-      );
-    });
+    expect(onSelect).not.toHaveBeenCalled();
   });
 });

--- a/ui/src/components/sessions-hub-tabs.test.ts
+++ b/ui/src/components/sessions-hub-tabs.test.ts
@@ -45,6 +45,16 @@ describe("renderSessionsHubTabs", () => {
     const onSelect = vi.fn();
     const container = await mount({ active: "sessions", onSelect });
 
+    container
+      .querySelector("#sessions-tab-worktrees")
+      ?.dispatchEvent(new MouseEvent("click", { detail: 1, bubbles: true }));
+
+    expect(onSelect).toHaveBeenLastCalledWith("worktrees");
+  });
+
+  it("ignores setup-time tab-show events", async () => {
+    const onSelect = vi.fn();
+    const container = await mount({ active: "sessions", onSelect });
     container.querySelector("wa-tab-group")?.dispatchEvent(
       new CustomEvent("wa-tab-show", {
         bubbles: true,
@@ -52,8 +62,7 @@ describe("renderSessionsHubTabs", () => {
         detail: { name: "worktrees" },
       }),
     );
-
-    expect(onSelect).toHaveBeenLastCalledWith("worktrees");
+    expect(onSelect).not.toHaveBeenCalled();
   });
 
   it("hands focus to the destination strip after keyboard navigation", async () => {
@@ -63,13 +72,6 @@ describe("renderSessionsHubTabs", () => {
       ?.dispatchEvent(
         new KeyboardEvent("keydown", { key: "Enter", bubbles: true, composed: true }),
       );
-    source.querySelector("wa-tab-group")?.dispatchEvent(
-      new CustomEvent("wa-tab-show", {
-        bubbles: true,
-        composed: true,
-        detail: { name: "worktrees" },
-      }),
-    );
     source.remove();
 
     const destination = await mount({ active: "worktrees", onSelect: () => undefined });

--- a/ui/src/pages/config/memory.ts
+++ b/ui/src/pages/config/memory.ts
@@ -298,7 +298,6 @@ export function renderMemory(props: MemoryViewProps) {
         ],
         ariaLabel: t("memoryPage.tablistLabel"),
         panelId: MEMORY_PANEL_ID,
-        userSelectionOnly: true,
         onSelect: (tab) => props.onTabChange(tab),
       })}
       <div id=${MEMORY_PANEL_ID} class="memory-page__panel" role="tabpanel">

--- a/ui/src/pages/plugins/plugins-page.routing.test.ts
+++ b/ui/src/pages/plugins/plugins-page.routing.test.ts
@@ -1,0 +1,163 @@
+/* @vitest-environment jsdom */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { i18n } from "../../i18n/index.ts";
+import {
+  createClient,
+  createContext,
+  createGateway,
+  createPluginsRouteLocation,
+  createResult,
+  mountPage,
+  resetPluginsPageTestState,
+} from "./plugins-page.test-support.ts";
+import type { PluginsRouteData } from "./plugins-page.ts";
+
+function clickHubTab(page: HTMLElement, tab: "installed" | "discover" | "skills" | "workshop") {
+  page
+    .querySelector(`#plugins-tab-${tab}`)
+    ?.dispatchEvent(new MouseEvent("click", { detail: 1, bubbles: true }));
+}
+
+describe("PluginsPage routing", () => {
+  beforeEach(async () => {
+    await i18n.setLocale("en");
+  });
+
+  afterEach(resetPluginsPageTestState);
+
+  it("applies the Discover path from route data", async () => {
+    const { client } = createClient(async () => createResult());
+    const harness = createGateway(client);
+    const routeData: PluginsRouteData = {
+      gateway: harness.gateway,
+      gatewaySnapshot: harness.gateway.snapshot,
+      result: createResult(),
+      error: null,
+      location: createPluginsRouteLocation("/settings/plugins/discover"),
+    };
+    const { page } = await mountPage(
+      createContext(
+        harness.gateway,
+        vi.fn(async () => undefined),
+      ),
+      routeData,
+    );
+
+    expect(page.activeTab).toBe("discover");
+    const tabGroup = page.querySelector<HTMLElement & { updateComplete: Promise<boolean> }>(
+      "wa-tab-group",
+    );
+    await tabGroup?.updateComplete;
+    expect(
+      page.querySelector<HTMLElement & { active: boolean }>("#plugins-tab-discover")?.active,
+    ).toBe(true);
+  });
+
+  it.each([
+    ["/settings/plugins", "installed", null],
+    ["/settings/plugins/discover", "discover", null],
+    ["/settings/plugins?tab=discover", "discover", "/settings/plugins/discover"],
+    ["/settings/plugins?tab=installed", "installed", "/settings/plugins"],
+    ["/settings/plugins?tab=unknown", "installed", "/settings/plugins"],
+    [
+      "/settings/plugins?tab=discover&query=calendar#featured",
+      "discover",
+      "/settings/plugins/discover?query=calendar#featured",
+    ],
+  ] as const)(
+    "performs at most one replace for %s and never oscillates back to a query tab",
+    async (sourceUrl, expectedTab, expectedUrl) => {
+      const { client } = createClient(async () => createResult());
+      const harness = createGateway(client);
+      const context = createContext(
+        harness.gateway,
+        vi.fn(async () => undefined),
+      );
+      const routeData: PluginsRouteData = {
+        gateway: harness.gateway,
+        gatewaySnapshot: harness.gateway.snapshot,
+        result: createResult(),
+        error: null,
+        location: createPluginsRouteLocation(sourceUrl),
+      };
+      const { page } = await mountPage(context, routeData);
+
+      expect(page.activeTab).toBe(expectedTab);
+      for (let cycle = 0; cycle < 3; cycle += 1) {
+        page.routeData = { ...page.routeData } as PluginsRouteData;
+        await page.updateComplete;
+      }
+      page.querySelector("wa-tab-group")?.dispatchEvent(
+        new CustomEvent("wa-tab-show", {
+          bubbles: true,
+          composed: true,
+          detail: { name: expectedTab === "discover" ? "installed" : "discover" },
+        }),
+      );
+
+      expect(context.replace).toHaveBeenCalledTimes(expectedUrl ? 1 : 0);
+      expect(context.navigate).not.toHaveBeenCalled();
+      if (!expectedUrl) {
+        return;
+      }
+      const canonicalLocation = createPluginsRouteLocation(expectedUrl);
+      expect(context.replace).toHaveBeenCalledWith("plugins", canonicalLocation);
+
+      page.routeData = { ...routeData, location: canonicalLocation };
+      await page.updateComplete;
+      for (let cycle = 0; cycle < 3; cycle += 1) {
+        page.routeData = { ...page.routeData } as PluginsRouteData;
+        await page.updateComplete;
+      }
+      expect(context.replace).toHaveBeenCalledOnce();
+    },
+  );
+
+  it("pushes catalog tab paths and restores the tab from history", async () => {
+    const { client } = createClient(async () => createResult());
+    const harness = createGateway(client);
+    const context = createContext(
+      harness.gateway,
+      vi.fn(async () => undefined),
+    );
+    const routeData: PluginsRouteData = {
+      gateway: harness.gateway,
+      gatewaySnapshot: harness.gateway.snapshot,
+      location: createPluginsRouteLocation(),
+      result: createResult(),
+      error: null,
+    };
+    const { page } = await mountPage(context, routeData);
+
+    clickHubTab(page, "skills");
+    expect(context.navigate).toHaveBeenCalledWith("skills");
+    clickHubTab(page, "workshop");
+    expect(context.navigate).toHaveBeenCalledWith("skill-workshop");
+    expect(page.activeTab).toBe("installed");
+
+    clickHubTab(page, "discover");
+    expect(page.activeTab).toBe("discover");
+    expect(context.navigate).toHaveBeenCalledWith("plugins", {
+      pathname: "/settings/plugins/discover",
+    });
+    page.routeData = {
+      ...routeData,
+      location: createPluginsRouteLocation("/settings/plugins/discover"),
+    };
+    await page.updateComplete;
+
+    clickHubTab(page, "installed");
+    expect(page.activeTab).toBe("installed");
+    expect(context.navigate).toHaveBeenCalledWith("plugins", {
+      pathname: "/settings/plugins",
+    });
+
+    page.routeData = {
+      ...routeData,
+      location: createPluginsRouteLocation("/settings/plugins/discover"),
+    };
+    await page.updateComplete;
+    expect(page.activeTab).toBe("discover");
+  });
+});

--- a/ui/src/pages/plugins/plugins-page.test-support.ts
+++ b/ui/src/pages/plugins/plugins-page.test-support.ts
@@ -1,3 +1,4 @@
+import type { RouteLocation } from "@openclaw/uirouter";
 import { vi } from "vitest";
 import type { GatewayBrowserClient } from "../../api/gateway.ts";
 import type {
@@ -60,6 +61,15 @@ export function createPlugin(overrides: Partial<PluginCatalogItem> = {}): Plugin
 
 export function createResult(plugin = createPlugin()): PluginListResult {
   return { plugins: [plugin], diagnostics: [], mutationAllowed: true };
+}
+
+export function createPluginsRouteLocation(url = "/settings/plugins"): RouteLocation {
+  const parsed = new URL(url, "https://control.test");
+  return {
+    pathname: parsed.pathname,
+    search: parsed.search,
+    hash: parsed.hash,
+  };
 }
 
 export function createClient(handler: RequestHandler) {
@@ -188,6 +198,7 @@ export function createContext(
     basePath: "",
     runtimeConfig: harness.runtimeConfig,
     navigate: vi.fn(),
+    replace: vi.fn(),
   } as unknown as ApplicationContext;
 }
 

--- a/ui/src/pages/plugins/plugins-page.test.ts
+++ b/ui/src/pages/plugins/plugins-page.test.ts
@@ -11,6 +11,7 @@ import {
   createContext,
   createGateway,
   createPlugin,
+  createPluginsRouteLocation,
   createResult,
   createRuntimeConfigHarness,
   deferred,
@@ -19,6 +20,12 @@ import {
   type RuntimeConfigTestState,
 } from "./plugins-page.test-support.ts";
 import type { PluginsRouteData } from "./plugins-page.ts";
+
+function clickHubTab(page: HTMLElement, tab: "installed" | "discover" | "skills" | "workshop") {
+  page
+    .querySelector(`#plugins-tab-${tab}`)
+    ?.dispatchEvent(new MouseEvent("click", { detail: 1, bubbles: true }));
+}
 
 describe("PluginsPage", () => {
   beforeEach(async () => {
@@ -34,7 +41,7 @@ describe("PluginsPage", () => {
     const routeData: PluginsRouteData = {
       gateway: harness.gateway,
       gatewaySnapshot: harness.gateway.snapshot,
-      initialTab: null,
+      location: createPluginsRouteLocation(),
       result,
       error: null,
     };
@@ -117,7 +124,7 @@ describe("PluginsPage", () => {
     const routeData: PluginsRouteData = {
       gateway: harness.gateway,
       gatewaySnapshot: harness.gateway.snapshot,
-      initialTab: null,
+      location: createPluginsRouteLocation(),
       result,
       error: null,
     };
@@ -187,7 +194,7 @@ describe("PluginsPage", () => {
       {
         gateway: harness.gateway,
         gatewaySnapshot: harness.gateway.snapshot,
-        initialTab: null,
+        location: createPluginsRouteLocation(),
         result,
         error: null,
       },
@@ -198,67 +205,6 @@ describe("PluginsPage", () => {
     expect(
       page.querySelector('[data-plugin-id="unsafe-icon"] .plugins-tile--fallback')?.textContent,
     ).toContain("UI");
-  });
-
-  it("applies a ?tab=discover deep link from route data", async () => {
-    const { client } = createClient(async () => createResult());
-    const harness = createGateway(client);
-    const routeData: PluginsRouteData = {
-      gateway: harness.gateway,
-      gatewaySnapshot: harness.gateway.snapshot,
-      result: createResult(),
-      error: null,
-      initialTab: "discover",
-    };
-    const { page } = await mountPage(
-      createContext(
-        harness.gateway,
-        vi.fn(async () => undefined),
-      ),
-      routeData,
-    );
-
-    expect(page.activeTab).toBe("discover");
-    const tabGroup = page.querySelector<HTMLElement & { updateComplete: Promise<boolean> }>(
-      "wa-tab-group",
-    );
-    await tabGroup?.updateComplete;
-    expect(
-      page.querySelector<HTMLElement & { active: boolean }>("#plugins-tab-discover")?.active,
-    ).toBe(true);
-  });
-
-  it("routes the skills and workshop hub tabs through navigation", async () => {
-    const { client } = createClient(async () => createResult());
-    const harness = createGateway(client);
-    const context = createContext(
-      harness.gateway,
-      vi.fn(async () => undefined),
-    );
-    const routeData: PluginsRouteData = {
-      gateway: harness.gateway,
-      gatewaySnapshot: harness.gateway.snapshot,
-      initialTab: null,
-      result: createResult(),
-      error: null,
-    };
-    const { page } = await mountPage(context, routeData);
-
-    page.querySelector<HTMLButtonElement>("#plugins-tab-skills")?.click();
-    expect(context.navigate).toHaveBeenCalledWith("skills");
-    page.querySelector<HTMLButtonElement>("#plugins-tab-workshop")?.click();
-    expect(context.navigate).toHaveBeenCalledWith("skill-workshop");
-    expect(page.activeTab).toBe("installed");
-
-    // Catalog tabs switch locally for instant feedback and keep the URL in
-    // sync with the ?tab=discover deep link.
-    page.querySelector<HTMLButtonElement>("#plugins-tab-discover")?.click();
-    expect(page.activeTab).toBe("discover");
-    expect(context.navigate).toHaveBeenCalledWith("plugins", { search: "?tab=discover" });
-    await page.updateComplete;
-    page.querySelector<HTMLButtonElement>("#plugins-tab-installed")?.click();
-    expect(page.activeTab).toBe("installed");
-    expect(context.navigate).toHaveBeenCalledWith("plugins", undefined);
   });
 
   it("refreshes the authoritative catalog after a same-client reconnect", async () => {
@@ -273,7 +219,7 @@ describe("PluginsPage", () => {
     const routeData: PluginsRouteData = {
       gateway: harness.gateway,
       gatewaySnapshot: harness.gateway.snapshot,
-      initialTab: null,
+      location: createPluginsRouteLocation(),
       result: createResult(),
       error: null,
     };
@@ -313,13 +259,13 @@ describe("PluginsPage", () => {
       {
         gateway: harness.gateway,
         gatewaySnapshot: harness.gateway.snapshot,
-        initialTab: null,
+        location: createPluginsRouteLocation(),
         result: createResult(),
         error: null,
       },
     );
 
-    page.querySelector<HTMLButtonElement>("#plugins-tab-discover")?.click();
+    clickHubTab(page, "discover");
     const search = page.querySelector<HTMLInputElement>("#plugins-global-search")!;
     search.value = "w";
     search.dispatchEvent(new Event("input", { bubbles: true }));
@@ -359,7 +305,7 @@ describe("PluginsPage", () => {
       {
         gateway: harness.gateway,
         gatewaySnapshot: harness.gateway.snapshot,
-        initialTab: "discover",
+        location: createPluginsRouteLocation("/settings/plugins/discover"),
         result: createResult(),
         error: null,
       },
@@ -421,7 +367,7 @@ describe("PluginsPage", () => {
       {
         gateway: harness.gateway,
         gatewaySnapshot: harness.gateway.snapshot,
-        initialTab: null,
+        location: createPluginsRouteLocation(),
         result: createResult(),
         error: null,
       },
@@ -454,7 +400,7 @@ describe("PluginsPage", () => {
       {
         gateway: harness.gateway,
         gatewaySnapshot: harness.gateway.snapshot,
-        initialTab: null,
+        location: createPluginsRouteLocation(),
         result: createResult(),
         error: null,
       },
@@ -496,13 +442,13 @@ describe("PluginsPage", () => {
       {
         gateway: harness.gateway,
         gatewaySnapshot: harness.gateway.snapshot,
-        initialTab: null,
+        location: createPluginsRouteLocation(),
         result: createResult(),
         error: null,
       },
     );
 
-    page.querySelector<HTMLButtonElement>("#plugins-tab-discover")?.click();
+    clickHubTab(page, "discover");
     const search = page.querySelector<HTMLInputElement>("#plugins-global-search")!;
     search.value = "calendar";
     search.dispatchEvent(new Event("input", { bubbles: true }));
@@ -546,7 +492,7 @@ describe("PluginsPage", () => {
       {
         gateway: harness.gateway,
         gatewaySnapshot: harness.gateway.snapshot,
-        initialTab: null,
+        location: createPluginsRouteLocation(),
         result: createResult(),
         error: null,
       },
@@ -594,7 +540,7 @@ describe("PluginsPage", () => {
       {
         gateway: harness.gateway,
         gatewaySnapshot: harness.gateway.snapshot,
-        initialTab: null,
+        location: createPluginsRouteLocation(),
         result: createResult(),
         error: null,
       },
@@ -644,7 +590,7 @@ describe("PluginsPage", () => {
     const { page } = await mountPage(createContext(harness.gateway, refreshConfig), {
       gateway: harness.gateway,
       gatewaySnapshot: harness.gateway.snapshot,
-      initialTab: null,
+      location: createPluginsRouteLocation(),
       result: disabledResult,
       error: null,
     });
@@ -699,7 +645,7 @@ describe("PluginsPage", () => {
       {
         gateway: harness.gateway,
         gatewaySnapshot: harness.gateway.snapshot,
-        initialTab: null,
+        location: createPluginsRouteLocation(),
         result: { plugins: [createPlugin(), removable], diagnostics: [], mutationAllowed: true },
         error: null,
       },
@@ -750,7 +696,7 @@ describe("PluginsPage", () => {
       {
         gateway: gatewayHarness.gateway,
         gatewaySnapshot: gatewayHarness.gateway.snapshot,
-        initialTab: null,
+        location: createPluginsRouteLocation(),
         result: createResult(),
         error: null,
       },
@@ -822,7 +768,7 @@ describe("PluginsPage", () => {
       {
         gateway: gatewayHarness.gateway,
         gatewaySnapshot: gatewayHarness.gateway.snapshot,
-        initialTab: null,
+        location: createPluginsRouteLocation(),
         result: createResult(),
         error: null,
       },
@@ -863,13 +809,13 @@ describe("PluginsPage", () => {
       {
         gateway: gatewayHarness.gateway,
         gatewaySnapshot: gatewayHarness.gateway.snapshot,
-        initialTab: null,
+        location: createPluginsRouteLocation(),
         result: createResult(),
         error: null,
       },
     );
 
-    page.querySelector<HTMLButtonElement>("#plugins-tab-discover")?.click();
+    clickHubTab(page, "discover");
     await page.updateComplete;
     page
       .querySelector<HTMLButtonElement>(
@@ -903,7 +849,7 @@ describe("PluginsPage", () => {
       {
         gateway: gatewayHarness.gateway,
         gatewaySnapshot: gatewayHarness.gateway.snapshot,
-        initialTab: null,
+        location: createPluginsRouteLocation(),
         result: createResult(),
         error: null,
       },

--- a/ui/src/pages/plugins/plugins-page.ts
+++ b/ui/src/pages/plugins/plugins-page.ts
@@ -1,10 +1,11 @@
 import { consume } from "@lit/context";
 import { initialState, Task, TaskStatus } from "@lit/task";
+import type { RouteLocation } from "@openclaw/uirouter";
 import { html, type PropertyValues } from "lit";
 import { property, state } from "lit/decorators.js";
 import type { GatewayBrowserClient } from "../../api/gateway.ts";
 import { serializeSidebarEntry, titleForRoute } from "../../app-navigation.ts";
-import { pathForRoute } from "../../app-route-paths.ts";
+import { pathForPluginsHubTab, pathForRoute } from "../../app-route-paths.ts";
 import {
   applicationContext,
   type ApplicationContext,
@@ -45,6 +46,7 @@ import { SubscriptionsController } from "../../lit/subscriptions-controller.ts";
 import { fetchPluginIconBlobUrl } from "./icon-loader.ts";
 import type { ConnectorSuggestion } from "./presentation.ts";
 import { pluginArtPath } from "./presentation.ts";
+import { canonicalPluginsRouteLocation, pluginsHubTabForRoute } from "./route-data.ts";
 import {
   connectorRowKey,
   pluginRowKey,
@@ -59,8 +61,7 @@ export type PluginsRouteData = {
   gatewaySnapshot: ApplicationGatewaySnapshot;
   result: PluginListResult | null;
   error: string | null;
-  /** Tab requested via ?tab=; lets other hub pages deep-link Discover. */
-  initialTab: PluginsTab | null;
+  location: RouteLocation;
 };
 
 function errorMessage(error: unknown): string {
@@ -124,6 +125,7 @@ class PluginsPage extends OpenClawLightDomElement {
   private gatewaySource?: ApplicationContext["gateway"];
   private sourceGeneration = 0;
   private routeDataConsumed = false;
+  private normalizedLocation = "";
   private searchTimer: ReturnType<typeof setTimeout> | null = null;
   private mutationToken = 0;
   private readonly mutationTokens = new Map<string, number>();
@@ -209,12 +211,14 @@ class PluginsPage extends OpenClawLightDomElement {
   override willUpdate(changed: PropertyValues<this>) {
     if (changed.has("routeData")) {
       this.applyRouteData();
+      this.syncCanonicalLocation();
     }
   }
 
   override connectedCallback() {
     super.connectedCallback();
     document.addEventListener("keydown", this.handleDocumentKeydown, true);
+    this.syncCanonicalLocation();
   }
 
   override disconnectedCallback() {
@@ -296,10 +300,7 @@ class PluginsPage extends OpenClawLightDomElement {
       this.ensureInitialData();
       return;
     }
-    // Honor ?tab= even when the loader snapshot is stale; the tab choice is
-    // navigation intent, not catalog data. A bare URL means Installed so
-    // history back/forward always restores the tab the URL describes.
-    const urlTab = data.initialTab ?? "installed";
+    const urlTab = pluginsHubTabForRoute(data.location, this.context.basePath);
     if (urlTab !== this.activeTab) {
       this.changeTab(urlTab);
     }
@@ -313,6 +314,27 @@ class PluginsPage extends OpenClawLightDomElement {
     this.replaceResult(data.result);
     this.error = data.error;
     this.ensureInitialData();
+  }
+
+  private syncCanonicalLocation() {
+    const context = this.context;
+    const location = this.routeData?.location;
+    if (!context || !location) {
+      return;
+    }
+    const canonical = canonicalPluginsRouteLocation(location, context.basePath);
+    if (!canonical) {
+      this.normalizedLocation = "";
+      return;
+    }
+    const source = `${location.pathname}${location.search}${location.hash}`;
+    if (this.normalizedLocation === source) {
+      return;
+    }
+    // One source location gets one replace. Route-data updates clear the guard
+    // once the canonical path arrives, so returning to an old link still works.
+    this.normalizedLocation = source;
+    context.replace("plugins", canonical);
   }
 
   private invalidateRequests(invalidateCatalog = true) {
@@ -555,13 +577,10 @@ class PluginsPage extends OpenClawLightDomElement {
 
   private selectHubTab(tab: PluginsHubTab) {
     if (tab === "installed" || tab === "discover") {
-      // Switch locally for instant feedback, then navigate so the URL and
-      // history match the documented ?tab=discover deep link.
       this.changeTab(tab);
-      this.context.navigate(
-        "plugins",
-        tab === "discover" ? { search: "?tab=discover" } : undefined,
-      );
+      this.context.navigate("plugins", {
+        pathname: pathForPluginsHubTab(tab, this.context.basePath),
+      });
       return;
     }
     this.context.navigate(tab === "skills" ? "skills" : "skill-workshop");

--- a/ui/src/pages/plugins/route-data.test.ts
+++ b/ui/src/pages/plugins/route-data.test.ts
@@ -1,0 +1,55 @@
+// @vitest-environment node
+import type { RouteLocation } from "@openclaw/uirouter";
+import { describe, expect, it } from "vitest";
+import {
+  canonicalPluginsRouteLocation,
+  pluginsHubTabForRoute,
+  pluginsRouteLocation,
+} from "./route-data.ts";
+
+function location(url: string): RouteLocation {
+  const parsed = new URL(url, "https://control.test");
+  return {
+    pathname: parsed.pathname,
+    search: parsed.search,
+    hash: parsed.hash,
+  };
+}
+
+describe("Plugins route data", () => {
+  it.each([
+    ["/settings/plugins", "installed"],
+    ["/settings/plugins/discover", "discover"],
+    ["/settings/plugins?tab=discover", "discover"],
+    ["/settings/plugins?tab=installed", "installed"],
+    ["/settings/plugins?tab=unknown", "installed"],
+    ["/settings/plugins/discover?tab=installed", "discover"],
+  ] as const)("selects %s as %s", (url, tab) => {
+    expect(pluginsHubTabForRoute(location(url))).toBe(tab);
+  });
+
+  it.each([
+    ["/settings/plugins", null],
+    ["/settings/plugins/discover", null],
+    ["/settings/plugins?tab=discover", "/settings/plugins/discover"],
+    ["/settings/plugins?tab=installed", "/settings/plugins"],
+    ["/settings/plugins?tab=unknown", "/settings/plugins"],
+    [
+      "/settings/plugins?tab=discover&query=calendar#featured",
+      "/settings/plugins/discover?query=calendar#featured",
+    ],
+  ] as const)("normalizes %s to %s", (sourceUrl, expectedUrl) => {
+    const canonical = canonicalPluginsRouteLocation(location(sourceUrl));
+    expect(canonical).toEqual(expectedUrl ? location(expectedUrl) : null);
+  });
+
+  it("recovers the dynamic pathname without leaking the internal router parameter", () => {
+    expect(
+      pluginsRouteLocation(
+        location(
+          "/settings/plugins?__openclawPluginsPath=%2Fsettings%2Fplugins%2Fdiscover&query=calendar#featured",
+        ),
+      ),
+    ).toEqual(location("/settings/plugins/discover?query=calendar#featured"));
+  });
+});

--- a/ui/src/pages/plugins/route-data.ts
+++ b/ui/src/pages/plugins/route-data.ts
@@ -1,0 +1,43 @@
+import type { RouteLocation } from "@openclaw/uirouter";
+import {
+  INTERNAL_PLUGINS_PATH_PARAM,
+  pathForPluginsHubTab,
+  pluginsHubTabFromPath,
+  type PluginsHubRouteTab,
+} from "../../app-route-paths.ts";
+
+export function pluginsRouteLocation(location: RouteLocation): RouteLocation {
+  const searchParams = new URLSearchParams(location.search);
+  const pathname = searchParams.get(INTERNAL_PLUGINS_PATH_PARAM) ?? location.pathname;
+  searchParams.delete(INTERNAL_PLUGINS_PATH_PARAM);
+  const search = searchParams.toString();
+  return {
+    pathname,
+    search: search ? `?${search}` : "",
+    hash: location.hash,
+  };
+}
+
+export function pluginsHubTabForRoute(location: RouteLocation, basePath = ""): PluginsHubRouteTab {
+  const pathTab = pluginsHubTabFromPath(location.pathname, basePath);
+  if (pathTab === "discover") {
+    return pathTab;
+  }
+  return new URLSearchParams(location.search).get("tab") === "discover" ? "discover" : "installed";
+}
+
+export function canonicalPluginsRouteLocation(
+  location: RouteLocation,
+  basePath = "",
+): RouteLocation | null {
+  const searchParams = new URLSearchParams(location.search);
+  const hadLegacyTab = searchParams.has("tab");
+  searchParams.delete("tab");
+  const search = searchParams.toString();
+  const canonical: RouteLocation = {
+    pathname: pathForPluginsHubTab(pluginsHubTabForRoute(location, basePath), basePath),
+    search: search ? `?${search}` : "",
+    hash: location.hash,
+  };
+  return hadLegacyTab || canonical.pathname !== location.pathname ? canonical : null;
+}

--- a/ui/src/pages/plugins/route.ts
+++ b/ui/src/pages/plugins/route.ts
@@ -4,41 +4,37 @@ import { routePageSpec } from "../../app-route-paths.ts";
 import type { ApplicationContext } from "../../app/context.ts";
 import { loadPluginCatalog } from "../../lib/plugins/index.ts";
 import type { PluginsRouteData } from "./plugins-page.ts";
+import { pluginsRouteLocation } from "./route-data.ts";
 
 function errorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
-}
-
-function initialTabFromSearch(search: string): PluginsRouteData["initialTab"] {
-  const tab = new URLSearchParams(search).get("tab");
-  return tab === "discover" || tab === "installed" ? tab : null;
 }
 
 async function loadPluginsRouteData(
   context: ApplicationContext,
   options: RouteLoaderOptions,
 ): Promise<PluginsRouteData> {
-  const initialTab = initialTabFromSearch(options.location.search);
+  const location = pluginsRouteLocation(options.location);
   const gateway = context.gateway;
   const gatewaySnapshot = gateway.snapshot;
   const client = gatewaySnapshot.client;
   if (gatewaySnapshot.phase !== "connected" || !client) {
-    return { gateway, gatewaySnapshot, result: null, error: null, initialTab };
+    return { gateway, gatewaySnapshot, result: null, error: null, location };
   }
   try {
     const result = await loadPluginCatalog(client);
-    return { gateway, gatewaySnapshot, result, error: null, initialTab };
+    return { gateway, gatewaySnapshot, result, error: null, location };
   } catch (error) {
-    return { gateway, gatewaySnapshot, result: null, error: errorMessage(error), initialTab };
+    return { gateway, gatewaySnapshot, result: null, error: errorMessage(error), location };
   }
 }
 
 export const page = definePage({
   ...routePageSpec("plugins"),
-  // Query-only tab changes need distinct matches; without this the router
-  // reuses the cached loader result and the hub keeps the previous tab.
-  loaderDeps: (_context: ApplicationContext, location: RouteLocation) =>
-    initialTabFromSearch(location.search) ?? "",
+  loaderDeps: (_context: ApplicationContext, location: RouteLocation) => {
+    const routeLocation = pluginsRouteLocation(location);
+    return `${routeLocation.pathname}\u0000${routeLocation.search}\u0000${routeLocation.hash}`;
+  },
   loader: loadPluginsRouteData,
   component: () =>
     import("./plugins-page.ts").then(() => ({

--- a/ui/src/pages/skill-workshop/plugins-hub-navigation.ts
+++ b/ui/src/pages/skill-workshop/plugins-hub-navigation.ts
@@ -1,8 +1,9 @@
+import { pathForPluginsHubTab } from "../../app-route-paths.ts";
 import type { ApplicationContext } from "../../app/context.ts";
 import type { PluginsHubTab } from "../../components/plugins-hub-tabs.ts";
 
 export function selectPluginsHubTab(
-  context: Pick<ApplicationContext, "navigate">,
+  context: Pick<ApplicationContext, "basePath" | "navigate">,
   tab: PluginsHubTab,
 ) {
   if (tab === "workshop") {
@@ -12,5 +13,7 @@ export function selectPluginsHubTab(
     context.navigate("skills");
     return;
   }
-  context.navigate("plugins", tab === "discover" ? { search: "?tab=discover" } : undefined);
+  context.navigate("plugins", {
+    pathname: pathForPluginsHubTab(tab, context.basePath),
+  });
 }

--- a/ui/src/pages/skills/skills-page.ts
+++ b/ui/src/pages/skills/skills-page.ts
@@ -5,6 +5,7 @@ import { property, state } from "lit/decorators.js";
 import type { GatewayBrowserClient } from "../../api/gateway.ts";
 import type { AgentsListResult, SkillStatusReport } from "../../api/types.ts";
 import { titleForRoute } from "../../app-navigation.ts";
+import { pathForPluginsHubTab } from "../../app-route-paths.ts";
 import {
   applicationContext,
   type ApplicationContext,
@@ -378,7 +379,9 @@ class SkillsPage extends OpenClawLightDomElement {
       this.context.navigate("skill-workshop");
       return;
     }
-    this.context.navigate("plugins", tab === "discover" ? { search: "?tab=discover" } : undefined);
+    this.context.navigate("plugins", {
+      pathname: pathForPluginsHubTab(tab, this.context.basePath),
+    });
   }
 
   override render() {


### PR DESCRIPTION
## What Problem This Solves

The Plugins hub encoded its Installed and Discover tabs in `?tab=`, while setup-time tab-show events could also invoke navigation. That made the documented Discover deep link inconsistent with newer path-based Settings tabs and left every hub consumer exposed to route writes that were not initiated by the user.

## Why This Change Was Made

This makes `/settings/plugins` the canonical Installed URL and `/settings/plugins/discover` the canonical Discover URL, using the same one-way, single-replace migration shape as the Memory tabs. Legacy `?tab=discover|installed` links keep working, preserve unrelated query parameters and fragments, and never normalize back to a query tab.

`renderHubTabs` now treats click, Enter, and Space as the only selection writers for all consumers. Memory, Plugins, and Sessions keep keyboard focus reclamation, while setup-time `wa-tab-show` events are inert. The existing `/skills` and `/skills/workshop` routes are unchanged.

AI-assisted implementation; the resulting routing, ownership boundaries, tests, and browser behavior were reviewed directly.

## User Impact

Users can bookmark and share the Discover tab at `/settings/plugins/discover`. Existing query-based links migrate in place without losing other URL state, tab clicks create useful history entries, and Back restores the previous hub tab without route oscillation.

## Evidence

Focused UI proof:

```text
node scripts/run-vitest.mjs ui/src/app-route-paths.test.ts ui/src/components/plugins-hub-tabs.test.ts ui/src/components/sessions-hub-tabs.test.ts ui/src/pages/config/memory-page.test.ts ui/src/pages/plugins/route-data.test.ts ui/src/pages/plugins/plugins-page.routing.test.ts ui/src/pages/plugins/plugins-page.test.ts ui/src/pages/skill-workshop/skill-workshop-page.test.ts ui/src/pages/config/memory.test.ts

Test Files  9 passed (9)
Tests      129 passed (129)
```

Exact-head browser proof with `pnpm dev:ui:mock --port=5203` and a pre-load `history.pushState` / `history.replaceState` spy:

| Start URL | Selected tab | History writes | Final URL |
| --- | --- | --- | --- |
| `/settings/plugins` | Installed | 0 push, 0 replace | `/settings/plugins` |
| `/settings/plugins/discover` | Discover | 0 push, 0 replace | `/settings/plugins/discover` |
| `/settings/plugins?tab=discover&probe=1#plugins-hub-panel` | Discover | 0 push, 1 replace | `/settings/plugins/discover?probe=1#plugins-hub-panel` |
| `/settings/plugins?tab=installed&probe=1#plugins-hub-panel` | Installed | 0 push, 1 replace | `/settings/plugins?probe=1#plugins-hub-panel` |

From Installed, clicking Discover and then Installed recorded exactly two pushes (`/settings/plugins/discover`, `/settings/plugins`). Browser Back restored Discover with no extra write. Dispatching a synthetic setup-time `wa-tab-show` event left the selected tab, URL, and history counters unchanged.

There is no visual styling delta; the address-bar path and history behavior are the relevant before/after evidence.

Static and review gates:

```text
./node_modules/.bin/oxfmt <all 18 touched files>
./node_modules/.bin/oxlint <all touched TypeScript files>
git diff --check origin/main...HEAD

.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main --engine codex --model gpt-5.6-sol --thinking high
autoreview clean: no accepted/actionable findings reported
overall: patch is correct (0.9)
```
