### PR TITLE
fix(telegram): prevent false empty replies after message-tool delivery

### DIFF
--- a/extensions/telegram/src/bot-message-dispatch.fallback-topic-media.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.fallback-topic-media.test.ts
@@ -124,6 +124,40 @@ describeTelegramDispatch("dispatchTelegramMessage fallback-topic-media", () => {
     expect(deliverReplies).not.toHaveBeenCalled();
   });
 
+  it("does not emit an empty-response fallback for message-tool-only delivery skips", async () => {
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(async ({ dispatcherOptions }) => {
+      dispatcherOptions.onSkip?.({}, { kind: "final", reason: "empty" });
+      return {
+        queuedFinal: false,
+        counts: { block: 0, final: 0, tool: 0 },
+        sourceReplyDeliveryMode: "message_tool_only",
+      };
+    });
+
+    await dispatchWithContext({
+      context: createContext({
+        chatId: -1001234,
+        isGroup: true,
+        ctxPayload: {
+          SessionKey: "agent:test:telegram:group:-1001234",
+          ChatType: "group",
+        } as TelegramMessageContext["ctxPayload"],
+        primaryCtx: {
+          message: { chat: { id: -1001234, type: "supergroup" } },
+        } as TelegramMessageContext["primaryCtx"],
+        msg: {
+          chat: { id: -1001234, type: "supergroup" },
+          message_id: 456,
+        } as TelegramMessageContext["msg"],
+        threadSpec: { id: undefined, scope: "none" },
+        replyThreadId: undefined,
+      }),
+      streamMode: "off",
+    });
+
+    expect(deliverReplies).not.toHaveBeenCalled();
+  });
+
   it("does not emit a silent-reply fallback for no-response group turns", async () => {
     dispatchReplyWithBufferedBlockDispatcher.mockResolvedValue({
       queuedFinal: false,

--- a/extensions/telegram/src/bot-message-dispatch.fallback-topic-media.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.fallback-topic-media.test.ts
@@ -158,6 +158,34 @@ describeTelegramDispatch("dispatchTelegramMessage fallback-topic-media", () => {
     expect(deliverReplies).not.toHaveBeenCalled();
   });
 
+  it("retains the failure fallback when message-tool-only delivery also fails", async () => {
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(async ({ dispatcherOptions }) => {
+      dispatcherOptions.onSkip?.({}, { kind: "final", reason: "empty" });
+      await dispatcherOptions.onError?.(new Error("Telegram final delivery failed"), {
+        kind: "final",
+      });
+      return {
+        queuedFinal: false,
+        counts: { block: 0, final: 0, tool: 0 },
+        sourceReplyDeliveryMode: "message_tool_only",
+      };
+    });
+
+    await dispatchWithContext({
+      context: createContext({
+        ctxPayload: createDirectSessionPayload(),
+      }),
+      streamMode: "off",
+    });
+
+    expect(deliverReplies).toHaveBeenCalledOnce();
+    expect(deliverReplies).toHaveBeenCalledWith(
+      expect.objectContaining({
+        replies: [{ text: "No response generated. Please try again." }],
+      }),
+    );
+  });
+
   it("does not emit a silent-reply fallback for no-response group turns", async () => {
     dispatchReplyWithBufferedBlockDispatcher.mockResolvedValue({
       queuedFinal: false,

--- a/extensions/telegram/src/bot-message-dispatch.ts
+++ b/extensions/telegram/src/bot-message-dispatch.ts
@@ -487,6 +487,7 @@ export const dispatchTelegramMessage = async ({
   const shouldSendFailureFallback =
     !isRoomEvent &&
     !suppressFailureFallback &&
+    !state.suppressSilentReplyFallback &&
     !progress.finalAnswerDelivered() &&
     (state.dispatchError ||
       deliverySummary.skippedNonSilent > 0 ||

--- a/extensions/telegram/src/bot-message-dispatch.ts
+++ b/extensions/telegram/src/bot-message-dispatch.ts
@@ -487,11 +487,10 @@ export const dispatchTelegramMessage = async ({
   const shouldSendFailureFallback =
     !isRoomEvent &&
     !suppressFailureFallback &&
-    !state.suppressSilentReplyFallback &&
     !progress.finalAnswerDelivered() &&
     (state.dispatchError ||
-      deliverySummary.skippedNonSilent > 0 ||
-      deliverySummary.failedNonSilent > 0);
+      deliverySummary.failedNonSilent > 0 ||
+      (deliverySummary.skippedNonSilent > 0 && !state.suppressSilentReplyFallback));
   if (shouldSendFailureFallback) {
     const fallbackText = state.dispatchError
       ? "Something went wrong while processing your request. Please try again."

--- a/extensions/telegram/src/bot-native-commands.session-meta.test.ts
+++ b/extensions/telegram/src/bot-native-commands.session-meta.test.ts
@@ -1379,7 +1379,7 @@ describe("registerTelegramNativeCommands — session metadata", () => {
   it("retains the native fallback when message-tool-only delivery also fails", async () => {
     dispatchChannelInboundTurnMock.mockImplementationOnce(async (plan) => {
       plan.dispatcherOptions?.onSkip?.({}, { kind: "final", reason: "empty" });
-      await plan.delivery.onError?.(new Error("Telegram final delivery failed"), {
+      plan.delivery.onError?.(new Error("Telegram final delivery failed"), {
         kind: "final",
       });
       return {

--- a/extensions/telegram/src/bot-native-commands.session-meta.test.ts
+++ b/extensions/telegram/src/bot-native-commands.session-meta.test.ts
@@ -1376,6 +1376,36 @@ describe("registerTelegramNativeCommands — session metadata", () => {
     expect(deliveryMocks.deliverReplies).not.toHaveBeenCalled();
   });
 
+  it("retains the native fallback when message-tool-only delivery also fails", async () => {
+    dispatchChannelInboundTurnMock.mockImplementationOnce(async (plan) => {
+      plan.dispatcherOptions?.onSkip?.({}, { kind: "final", reason: "empty" });
+      await plan.delivery.onError?.(new Error("Telegram final delivery failed"), {
+        kind: "final",
+      });
+      return {
+        admission: { kind: "dispatch" },
+        dispatched: true,
+        ctxPayload: plan.ctxPayload,
+        routeSessionKey: plan.route.sessionKey,
+        dispatchResult: {
+          queuedFinal: false,
+          counts: { block: 0, final: 0, tool: 0 },
+          sourceReplyDeliveryMode: "message_tool_only",
+        },
+      };
+    });
+    const { handler } = registerAndResolveStatusHandler({ cfg: {} });
+
+    await handler(createTelegramPrivateCommandContext());
+
+    expect(deliveryMocks.deliverReplies).toHaveBeenCalledOnce();
+    expect(deliveryMocks.deliverReplies).toHaveBeenCalledWith(
+      expect.objectContaining({
+        replies: [{ text: "No response generated. Please try again." }],
+      }),
+    );
+  });
+
   it("retains the empty fallback for a true non-silent metadata-only native reply", async () => {
     dispatchChannelInboundTurnMock.mockImplementationOnce(async (plan) => {
       plan.dispatcherOptions?.onSkip?.({}, { kind: "final", reason: "empty" });

--- a/extensions/telegram/src/bot-native-commands.session-meta.test.ts
+++ b/extensions/telegram/src/bot-native-commands.session-meta.test.ts
@@ -1354,6 +1354,28 @@ describe("registerTelegramNativeCommands — session metadata", () => {
     expect(deliveryMocks.deliverReplies).not.toHaveBeenCalled();
   });
 
+  it("does not emit the empty fallback for a message-tool-only native reply", async () => {
+    dispatchChannelInboundTurnMock.mockImplementationOnce(async (plan) => {
+      plan.dispatcherOptions?.onSkip?.({}, { kind: "final", reason: "empty" });
+      return {
+        admission: { kind: "dispatch" },
+        dispatched: true,
+        ctxPayload: plan.ctxPayload,
+        routeSessionKey: plan.route.sessionKey,
+        dispatchResult: {
+          queuedFinal: false,
+          counts: { block: 0, final: 0, tool: 0 },
+          sourceReplyDeliveryMode: "message_tool_only",
+        },
+      };
+    });
+    const { handler } = registerAndResolveStatusHandler({ cfg: {} });
+
+    await handler(createTelegramPrivateCommandContext());
+
+    expect(deliveryMocks.deliverReplies).not.toHaveBeenCalled();
+  });
+
   it("retains the empty fallback for a true non-silent metadata-only native reply", async () => {
     dispatchChannelInboundTurnMock.mockImplementationOnce(async (plan) => {
       plan.dispatcherOptions?.onSkip?.({}, { kind: "final", reason: "empty" });

--- a/extensions/telegram/src/bot-native-commands.ts
+++ b/extensions/telegram/src/bot-native-commands.ts
@@ -1650,6 +1650,7 @@ export const registerTelegramNativeCommands = ({
           delivered: false,
           intentionallySuppressed: false,
           skippedNonSilent: 0,
+          failedNonSilent: 0,
         };
 
         const { deliverReplies } = await loadTelegramNativeCommandDeliveryRuntime();
@@ -1735,6 +1736,7 @@ export const registerTelegramNativeCommands = ({
               }
             },
             onError: (err, info) => {
+              deliveryState.failedNonSilent += 1;
               runtime.error?.(danger(`telegram slash ${info.kind} reply failed: ${String(err)}`));
             },
           },
@@ -1752,7 +1754,8 @@ export const registerTelegramNativeCommands = ({
           !deliveryState.intentionallySuppressed &&
           deliveryState.skippedNonSilent > 0 &&
           (!turnResult.dispatched ||
-            turnResult.dispatchResult.sourceReplyDeliveryMode !== "message_tool_only")
+            turnResult.dispatchResult.sourceReplyDeliveryMode !== "message_tool_only" ||
+            deliveryState.failedNonSilent > 0)
         ) {
           await deliverReplies({
             replies: [{ text: EMPTY_RESPONSE_FALLBACK }],

--- a/extensions/telegram/src/bot-native-commands.ts
+++ b/extensions/telegram/src/bot-native-commands.ts
@@ -1743,14 +1743,16 @@ export const registerTelegramNativeCommands = ({
             disableBlockStreaming,
           },
         };
-        await (
+        const turnResult = await (
           telegramDeps.dispatchChannelInboundTurn ??
           defaultTelegramNativeCommandDeps.dispatchChannelInboundTurn
         )(turnPlan);
         if (
           !deliveryState.delivered &&
           !deliveryState.intentionallySuppressed &&
-          deliveryState.skippedNonSilent > 0
+          deliveryState.skippedNonSilent > 0 &&
+          (!turnResult.dispatched ||
+            turnResult.dispatchResult.sourceReplyDeliveryMode !== "message_tool_only")
         ) {
           await deliverReplies({
             replies: [{ text: EMPTY_RESPONSE_FALLBACK }],


### PR DESCRIPTION
Closes #90091

## What Problem This Solves

Fixes an issue where Telegram users who already receive a visible agent reply through the message tool also receive a misleading "No response generated. Please try again." fallback when automatic final delivery is skipped. The same defect affected both normal group messages and native slash commands.

## Why This Change Was Made

Treat message-tool-only dispatch as the owner of the visible response in both Telegram delivery surfaces. Retain the existing fallback for genuinely empty non-message-tool replies, cancelled hooks, and real delivery modes. No configuration, provider, SDK, or storage surface changes.

## User Impact

A successful Telegram message-tool reply remains the only visible response. Native commands still display the established fallback when a real non-silent reply is absent.

## Evidence

- Remote Blacksmith Linux exact source proof: both affected Telegram test files, 54/54 passing; includes new actual group-message and native slash regression cases and the existing true-empty native-fallback control. Testbox tbx_01kyp3bnj6j0p5412nn9tn9b12, exitCode=0.
- Independent remote Blacksmith changed gate: formatting, package/plugin boundary guards, production and test extension typechecks, targeted lint, database/runtime guards, and import-cycle checks all pass. Testbox tbx_01kyp3gzgyx9wg83tkb51gmd6g, exitCode=0.
- Fresh source-isolated xhigh Codex autoreview: no actionable findings; TruffleHog clean.
- Rebases cleanly on current main; git diff --check clean.