### PR TITLE
fix(memory): preserve Unicode in short-term promotion

### DIFF
--- a/extensions/memory-core/src/short-term-promotion-rehydrate.ts
+++ b/extensions/memory-core/src/short-term-promotion-rehydrate.ts
@@ -1,4 +1,5 @@
 import fs from "node:fs/promises";
+import { sliceUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import { resolveShortTermSourcePathCandidates } from "./short-term-promotion-record.js";
 import type { PromotionCandidate } from "./short-term-promotion-types.js";
 import { normalizeSnippet, SHORT_TERM_BASENAME_RE } from "./short-term-promotion-utils.js";
@@ -101,7 +102,7 @@ function targetSnippetHasHeadingContext(targetSnippet: string, bodySnippet: stri
   if (bodyIndex <= 0) {
     return false;
   }
-  return targetSnippet.slice(0, bodyIndex).trimEnd().endsWith(":");
+  return sliceUtf16Safe(targetSnippet, 0, bodyIndex).trimEnd().endsWith(":");
 }
 
 function extractTargetHeadingBodySnippet(

--- a/extensions/memory-core/src/short-term-promotion-utils.ts
+++ b/extensions/memory-core/src/short-term-promotion-utils.ts
@@ -151,7 +151,7 @@ function hasDreamingNarrativeLead(snippet: string): boolean {
   // The composite detector below still requires the full signal combination, so widening
   // the lead check to anywhere in the first 200 chars closes the leak without creating
   // false positives for ordinary durable notes that merely mention the word in prose.
-  const head = withoutPrefix.slice(0, 200);
+  const head = truncateUtf16Safe(withoutPrefix, 200);
   return /\b(?:Candidate|Reflections?):/i.test(head);
 }
 

--- a/extensions/memory-core/src/short-term-promotion.test.ts
+++ b/extensions/memory-core/src/short-term-promotion.test.ts
@@ -2397,7 +2397,7 @@ describe("short-term promotion", () => {
       await writeDailyMemoryNote(workspaceDir, "2026-05-28", [
         "# 2026-05-28",
         "",
-        "## New model routing (16:23)",
+        "## 🚀 New model routing (16:23)",
         "- Keep Xiaomi Mimo as the low-cost default.",
       ]);
       await recordShortTermRecalls({
@@ -2436,10 +2436,11 @@ describe("short-term promotion", () => {
 
       expect(applied.applied).toBe(1);
       expect(applied.appliedCandidates[0]?.snippet).toBe(
-        "New model routing (16:23): Keep Xiaomi Mimo as the low-cost default.",
+        "🚀 New model routing (16:23): Keep Xiaomi Mimo as the low-cost default.",
       );
       const memoryText = await fs.readFile(path.join(workspaceDir, "MEMORY.md"), "utf-8");
-      expect(memoryText).toContain("New model routing (16:23)");
+      expect(memoryText).toContain("🚀 New model routing (16:23)");
+      expect(Buffer.from(memoryText, "utf8").toString("utf8")).toBe(memoryText);
       expect(memoryText).not.toContain("Old model routing");
     });
   });
@@ -4176,6 +4177,54 @@ describe("short-term promotion", () => {
   });
 
   describe("UTF-16 snippet bounds", () => {
+    it("keeps the dreaming narrative lead well-formed at a surrogate boundary", async () => {
+      await withTempWorkspace(async (workspaceDir) => {
+        const prefix = "x".repeat(199);
+        const snippet = `${prefix}🚀Candidate: durable memory`;
+        const originalRegExpTest = Object.getOwnPropertyDescriptor(RegExp.prototype, "test")
+          ?.value as typeof RegExp.prototype.test;
+        const inspectedLeads: string[] = [];
+
+        vi.spyOn(RegExp.prototype, "test").mockImplementation(function (
+          this: RegExp,
+          value: string,
+        ) {
+          if (this.source === "\\b(?:Candidate|Reflections?):") {
+            inspectedLeads.push(value);
+            expect(Buffer.from(value, "utf8").toString("utf8")).toBe(value);
+          }
+          return originalRegExpTest.call(this, value);
+        });
+
+        await writeDailyMemoryNote(workspaceDir, "2026-04-03", [snippet]);
+        await recordShortTermRecalls({
+          workspaceDir,
+          query: "utf16 dreaming lead",
+          results: [
+            {
+              path: "memory/2026-04-03.md",
+              source: "memory",
+              startLine: 1,
+              endLine: 1,
+              score: 0.9,
+              snippet,
+            },
+          ],
+        });
+
+        const ranked = await rankShortTermPromotionCandidates({
+          workspaceDir,
+          minScore: 0,
+          minRecallCount: 0,
+          minUniqueQueries: 0,
+        });
+
+        expect(inspectedLeads.length).toBeGreaterThan(0);
+        expect(ranked).toHaveLength(1);
+        expect(ranked[0]?.snippet).toBe(snippet);
+      });
+    });
+
     it("stores a complete-code-point short-term recall snippet", async () => {
       await withTempWorkspace(async (workspaceDir) => {
         const prefix = "y".repeat(testing.SHORT_TERM_RECALL_MAX_SNIPPET_CHARS - 1);


### PR DESCRIPTION
Closes #107876.

Related contributor fixes: #107882 and #107910.

## What Problem This Solves

Fixes an issue where the memory plugin's short-term promotion pipeline could cut an emoji or other non-BMP character in half at its 200-code-unit dreaming narrative boundary, passing a lone UTF-16 surrogate to the real contamination-detector regular expression. Heading-context rehydration also sliced UTF-16 directly.

## Why This Change Was Made

The existing surrogate-safe helpers already define the canonical product behavior. Use `truncateUtf16Safe` in the memory-owned dreaming lead and `sliceUtf16Safe` in the memory-owned heading-context extractor. Keep the current 200-code-unit limit, existing promotion and contamination semantics, and the existing text-utility plugin boundary.

The original contributor PRs target the pre-refactor monolithic promotion module. This change applies their shared intent to both current, split owner modules and retains one focused, genuinely fail-first regression.

## User Impact

Emoji, supplementary CJK characters, and other astral Unicode remain complete while memory is recorded, ranked, rehydrated, and promoted into `MEMORY.md`. No configuration, schema, migration, SDK API, compatibility path, or dependency changes.

## Root Cause

`withoutPrefix.slice(0, 200)` cuts between an emoji's UTF-16 high and low surrogates when the preceding text is 199 code units long. The production contamination detector immediately receives the malformed lead. The separately owned heading-context path also used raw UTF-16 slicing rather than the existing canonical helper.

## Evidence

- Fail-first proof against unmodified production on trusted Blacksmith Testbox: the real `recordShortTermRecalls` path produces a lone high surrogate; UTF-8 round-tripping the exact value reaching `hasDreamingNarrativeLead` changes it to U+FFFD, and the new regression fails. The actual daily-note heading rehydration control passes.
- Final immutable head: `7419634a02d1e3eea9b106fdfe96cee6e663863d`.
- Blacksmith Testbox `tbx_01kyp3krw65fshtwzmdd9qw2sj` verifies all three exact committed Git blob hashes before executing proof.
- Final focused and adjacent behavior: **176/176 passing** across short-term promotion, promotion metadata, dreaming phases, dreaming consolidation, dreaming repair, and dreaming shared state.
- Final full `CI=1 pnpm check:changed`: **passed**, including extension and test typechecks, type-aware changed-file lint, formatting, plugin boundaries, database-first guards, dependency and environment ratchets, dead exports, and zero runtime import cycles.
- Fresh independent Codex autoreview at extra-high effort on the immutable branch/base: clean; no actionable findings.
- Existing real daily-note regression additionally proves the emoji survives heading rehydration and the written `MEMORY.md` remains valid UTF-8.
- Thanks to @moguangyu5-design for the report and two-site diagnosis and to @arkyu2077 for the independent dreaming-lead fix.
- AI-assisted; checked against source, actual regression, and current split memory-owner boundaries.
