### PR TITLE
fix(browser): avoid colliding extension relay ports

### DIFF
--- a/extensions/browser/src/browser/config.test.ts
+++ b/extensions/browser/src/browser/config.test.ts
@@ -142,6 +142,39 @@ describe("browser config", () => {
     expect(resolveProfile(resolved, "work")?.cdpPort).toBe(20123);
   });
 
+  it("does not assign an implicit extension relay an explicitly pinned extension port", () => {
+    const resolved = resolveBrowserConfig({
+      profiles: {
+        work: { driver: "extension", cdpPort: 18799, color: "#00AA00" },
+      },
+    });
+
+    expect(resolveProfile(resolved, "work")?.cdpPort).toBe(18799);
+    expect(resolveProfile(resolved, "chrome")?.cdpPort).toBe(18798);
+  });
+
+  it("does not assign an implicit extension relay an explicitly pinned managed port", () => {
+    const resolved = resolveBrowserConfig({
+      profiles: {
+        pinned: { cdpPort: 18799, color: "#00AA00" },
+      },
+    });
+
+    expect(resolveProfile(resolved, "pinned")?.cdpPort).toBe(18799);
+    expect(resolveProfile(resolved, "chrome")?.cdpPort).toBe(18798);
+  });
+
+  it("rejects implicit extension relays that exhaust the reserved port band", () => {
+    const profiles: NonNullable<BrowserConfig["profiles"]> = Object.fromEntries(
+      Array.from({ length: 8 }, (_, index) => [
+        `extension-${index}`,
+        { driver: "extension" as const, color: "#00AA00" },
+      ]),
+    );
+
+    expect(() => resolveBrowserConfig({ profiles })).toThrow(/extension.*relay.*port/i);
+  });
+
   it("embeds the host-local relay secret as Basic auth in the extension cdpUrl", () => {
     const token = "a".repeat(64);
     writeRelaySecret(token);

--- a/extensions/browser/src/browser/config.ts
+++ b/extensions/browser/src/browser/config.ts
@@ -317,10 +317,31 @@ function resolveExtensionRelayPorts(
     .filter(([, profile]) => profile.driver === "extension" && profile.cdpPort == null)
     .map(([name]) => name)
     .toSorted();
+  // Explicit ports can belong to any profile driver. Reserve them before
+  // allocation so an extension relay cannot bind another profile's listener.
+  const reservedPorts = new Set(
+    Object.values(profiles)
+      .map((profile) => profile.cdpPort)
+      .filter((port): port is number => typeof port === "number"),
+  );
   const ports: Record<string, number> = {};
-  names.forEach((name, index) => {
-    ports[name] = defaultPort - index;
-  });
+  const minimumPort = defaultPort - EXTENSION_RELAY_PORT_OFFSET;
+  let nextPort = defaultPort;
+  for (const name of names) {
+    while (nextPort > minimumPort && reservedPorts.has(nextPort)) {
+      nextPort -= 1;
+    }
+    // The control port sits below this band; crossing it would silently
+    // collide with browser control instead of creating an extension relay.
+    if (nextPort <= minimumPort) {
+      throw new Error(
+        "No available extension relay ports in the reserved browser relay port range",
+      );
+    }
+    ports[name] = nextPort;
+    reservedPorts.add(nextPort);
+    nextPort -= 1;
+  }
   return ports;
 }
 

--- a/extensions/browser/src/cli/browser-cli-extension.test.ts
+++ b/extensions/browser/src/cli/browser-cli-extension.test.ts
@@ -58,4 +58,29 @@ describe("browser extension pairing Gateway URL", () => {
     });
     expect(logSpy).not.toHaveBeenCalled();
   });
+
+  it("pairs with the allocated extension relay when another profile pins the default port", async () => {
+    vi.spyOn(cliCoreApiModule, "getRuntimeConfig").mockReturnValue({
+      browser: {
+        profiles: {
+          pinned: { cdpPort: 18799, color: "#00AA00" },
+        },
+      },
+    });
+    const writeJsonSpy = vi
+      .spyOn(cliCoreApiModule.defaultRuntime, "writeJson")
+      .mockImplementation(runtime.writeJson);
+    const { registerBrowserExtensionCommands } = await import("./browser-cli-extension.js");
+    const program = new Command();
+    const browser = program.command("browser");
+    registerBrowserExtensionCommands(browser, () => ({}));
+
+    await program.parseAsync(["browser", "extension", "pair", "--json"], { from: "user" });
+
+    expect(writeJsonSpy).toHaveBeenCalledWith({
+      pairingString: expect.stringContaining("127.0.0.1:18798/extension"),
+      relayPort: 18798,
+      remote: false,
+    });
+  });
 });

--- a/extensions/browser/src/cli/browser-cli-extension.ts
+++ b/extensions/browser/src/cli/browser-cli-extension.ts
@@ -30,12 +30,18 @@ function resolveChromeExtensionDir(pluginRoot?: string): string {
   return path.resolve(here, "..", "..", "chrome-extension");
 }
 
-function firstExtensionProfile(): { name: string; relayPort: number } | null {
-  const cfg = getRuntimeConfig();
-  const resolved = resolveBrowserConfig(cfg.browser, cfg);
+function firstExtensionProfile(
+  resolved: ReturnType<typeof resolveBrowserConfig>,
+): { name: string; relayPort: number } | null {
   for (const [name, profile] of Object.entries(resolved.profiles)) {
     if (profile.driver === "extension") {
-      return { name, relayPort: profile.cdpPort ?? resolved.extensionRelayDefaultPort };
+      return {
+        name,
+        relayPort:
+          profile.cdpPort ??
+          resolved.extensionRelayPorts[name] ??
+          resolved.extensionRelayDefaultPort,
+      };
     }
   }
   return null;
@@ -76,7 +82,7 @@ async function buildPairingString(gatewayUrl?: string): Promise<{
   // driver yet, so pairing works on a fresh gateway or node host before the
   // relay has started. Pairing must run on the machine that hosts the browser.
   const token = await ensureExtensionRelayToken();
-  const profile = firstExtensionProfile();
+  const profile = firstExtensionProfile(resolved);
   const relayPort = profile?.relayPort ?? resolved.extensionRelayDefaultPort;
 
   const gateway = gatewayUrl?.trim();


### PR DESCRIPTION
Closes #114294

Supersedes #114297. Thanks to @kevin2966n for identifying the original relay-allocation bug and opening the earlier draft.

## What Problem This Solves

Fixes an issue where users who configure a browser profile on the default extension-relay port cannot use or pair the built-in Chrome extension because the implicitly allocated extension relay tries to bind that same occupied port. Also prevents extension profiles from spilling out of the reserved relay-port band into the browser-control port.

## Why This Change Was Made

Reserve explicit CDP ports for every browser-profile driver before deterministically allocating implicit extension relay ports. Keep allocation inside the existing reserved port band and have the extension pairing command use the same resolved relay allocation as the browser runtime. This remains entirely within the browser plugin and does not add or change public configuration, gateway protocol, dependencies, or Plugin SDK surfaces.

## User Impact

Chrome extension pairing connects to the available relay even when an extension or managed browser profile explicitly pins the original default port. If all reserved relay ports are occupied, users receive a clear error instead of an unrelated browser-control port collision.

## Evidence

- Reproduced all four regressions on unmodified latest main on Linux: explicitly pinned extension-port collision, explicitly pinned managed-profile collision, reserved-band exhaustion, and the real `browser extension pair --json` command advertising the occupied port.
- After the fix, six browser-plugin test files pass on Linux: **156 passed, 1 platform-specific test skipped**; this includes allocator regressions, real CLI command parsing and JSON output, profile services, profile hot reload, and relay lifecycle.
- Complete Linux `pnpm check:changed` passes, including formatting, lint, production and test typechecking, plugin SDK API and ownership-boundary guards, dead-code checks, and runtime import-cycle and database guards.
- Independent xhigh-effort autoreview: clean, with no accepted or actionable findings.
- AI-assisted; all claims are backed by direct source inspection, red-to-green regression proof, and Linux validation.
