### PR TITLE
fix(gateway): accept SDK Responses plain-text format

### DIFF
--- a/src/gateway/open-responses.schema.ts
+++ b/src/gateway/open-responses.schema.ts
@@ -201,6 +201,14 @@ export const CreateResponseBodySchema = z
     instructions: z.string().optional(),
     tools: z.array(ToolDefinitionSchema).optional(),
     tool_choice: ToolChoiceSchema.optional(),
+    // The SDK sends its plain-text default explicitly; structured formats must
+    // stay rejected until the runtime actually enforces their contracts.
+    text: z
+      .object({
+        format: z.object({ type: z.literal("text") }).strict(),
+      })
+      .strict()
+      .optional(),
     stream: z.boolean().optional(),
     max_output_tokens: z.number().int().positive().optional(),
     max_tool_calls: z.number().int().positive().optional(),

--- a/src/gateway/openresponses-http.test.ts
+++ b/src/gateway/openresponses-http.test.ts
@@ -3,6 +3,7 @@
 import fs from "node:fs/promises";
 import http from "node:http";
 import path from "node:path";
+import OpenAI from "openai";
 import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { createClientToolNameConflictError } from "../agents/agent-tool-definition-adapter.js";
 import { FailoverError } from "../agents/failover-error.js";
@@ -305,6 +306,77 @@ async function expectInvalidRequest(
 }
 
 describe("OpenResponses HTTP API (e2e)", () => {
+  it.each([false, true])(
+    "accepts the official OpenAI SDK plain-text response format (stream: %s)",
+    async (stream) => {
+      agentCommand.mockClear();
+      agentCommand.mockResolvedValueOnce({
+        payloads: [{ text: "SDK plain-text response" }],
+      } as never);
+
+      const client = new OpenAI({
+        apiKey: "test",
+        baseURL: `http://127.0.0.1:${enabledPort}/v1`,
+        defaultHeaders: { "x-openclaw-scopes": "operator.write" },
+        maxRetries: 0,
+      });
+      const request = {
+        model: "openclaw",
+        input: "Return the plain-text response.",
+        text: { format: { type: "text" as const } },
+      };
+
+      if (stream) {
+        const events = await client.responses.create({ ...request, stream: true });
+        const eventTypes: string[] = [];
+        const textDeltas: string[] = [];
+        for await (const event of events) {
+          eventTypes.push(event.type);
+          if (event.type === "response.output_text.delta") {
+            textDeltas.push(event.delta);
+          }
+        }
+        expect(textDeltas.join("")).toBe("SDK plain-text response");
+        expect(eventTypes).toContain("response.completed");
+      } else {
+        const response = await client.responses.create({ ...request, stream: false });
+        expect(response.status).toBe("completed");
+        expect(response.output_text).toBe("SDK plain-text response");
+      }
+
+      expect(agentCommand).toHaveBeenCalledTimes(1);
+    },
+  );
+
+  it.each([
+    { name: "JSON-object output", text: { format: { type: "json_object" } } },
+    {
+      name: "JSON-schema output",
+      text: {
+        format: {
+          type: "json_schema",
+          name: "value",
+          schema: { type: "object" },
+        },
+      },
+    },
+    {
+      name: "unenforced verbosity",
+      text: { format: { type: "text" }, verbosity: "high" },
+    },
+  ])("rejects unsupported SDK text options ($name)", async ({ text }) => {
+    agentCommand.mockClear();
+
+    const res = await postResponses(enabledPort, {
+      model: "openclaw",
+      input: "Return the plain-text response.",
+      text,
+    });
+
+    await expectInvalidRequest(res, /text/);
+    expect(agentCommand).toHaveBeenCalledTimes(0);
+  });
+
   it("handles OpenResponses request parsing and validation", async () => {
     const port = enabledPort;
     const mockAgentOnce = (payloads: Array<{ text: string }>, meta?: unknown) => {


### PR DESCRIPTION
Related: #80418

## What Problem This Solves

Fixes an issue where the official OpenAI SDK bundled with OpenClaw receives `400 Unrecognized key: "text"` when it calls the Gateway's Responses endpoint with its supported plain-text output format. Both ordinary and streaming calls fail before the agent runs.

## Why This Change Was Made

Accept only the official SDK's explicit `text: { format: { type: "text" } }` request. This is the same unconstrained plain-text response the Gateway already generates. Keep both enclosing objects strict, and continue rejecting JSON-object output, JSON-schema output, and verbosity controls because the current runtime does not enforce or implement those contracts.

The original compatibility report and proposed fix are credited to @logicbridgedev in #80418. This replacement avoids unsupported structured-output promises, changelog modifications, and unrelated schema-only artifacts.

## User Impact

The OpenAI SDK already shipped with OpenClaw can create and stream ordinary Gateway Responses using its documented plain-text format. Existing plain-text output, tool behavior, SSE, authentication, and session routing are unchanged. Unsupported structured formats remain rejected before agent dispatch.

## Evidence

- Primary upstream contract: the exact `openai` version already pinned by OpenClaw, `6.48.0`, defines `ResponseCreateParamsBase.text`, `ResponseTextConfig.format`, and the plain-text `{ type: "text" }` format in https://github.com/openai/openai-node/blob/v6.48.0/src/resources/responses/responses.ts and https://github.com/openai/openai-node/blob/v6.48.0/src/resources/shared.ts.
- Fail first: the actual bundled OpenAI SDK and actual loopback Gateway both reproduce `400 Unrecognized key: "text"` for non-streaming and streaming `client.responses.create(...)` requests on unchanged `main`.
- Fixed behavior: the same real SDK HTTP calls return the expected complete plain-text response and real `response.output_text.delta` / `response.completed` SSE events.
- Contract coverage: three real HTTP regressions prove `json_object`, `json_schema`, and `verbosity` remain rejected and never reach agent dispatch.
- `pnpm test src/gateway/openresponses-http.test.ts src/gateway/openresponses-parity.test.ts src/gateway/openresponses-phase.test.ts src/gateway/openai-http.test.ts`: **82 passing tests**, including Responses request/streaming, parity, assistant phase, SDK compatibility, and sibling Chat Completions.
- `pnpm check:changed`: passed on Blacksmith Testbox, including core type-checking, format, lint, and repository safety guards.
- Fresh independent Codex review using `gpt-5.6-sol` with `xhigh` reasoning: clean.
- AI-assisted; original report and contributor credited to @logicbridgedev.
