### PR TITLE
fix(onboard): reject conflicting custom input flags

### DIFF
--- a/src/cli/program/register.onboard.test.ts
+++ b/src/cli/program/register.onboard.test.ts
@@ -210,6 +210,16 @@ describe("registerOnboardCommand", () => {
     expect(setupWizardOptions().tui).toBe(true);
   });
 
+  it("rejects conflicting custom model input capabilities", async () => {
+    await runCli(["onboard", "--custom-image-input", "--custom-text-input"]);
+
+    expect(runtime.error).toHaveBeenCalledWith(
+      "Use either --custom-image-input or --custom-text-input, not both.",
+    );
+    expect(runtime.exit).toHaveBeenCalledWith(1);
+    expect(setupWizardCommandMock).not.toHaveBeenCalled();
+  });
+
   it("parses --mistral-api-key and forwards mistralApiKey", async () => {
     await runCli(["onboard", "--mistral-api-key", "sk-mistral-test"]);
     expect(setupWizardOptions().mistralApiKey).toBe("sk-mistral-test"); // pragma: allowlist secret

--- a/src/cli/program/register.onboard.ts
+++ b/src/cli/program/register.onboard.ts
@@ -16,6 +16,7 @@ import type {
   TailscaleMode,
 } from "../../commands/onboard-types.js";
 import { resolveProviderOnboardAuthFlags } from "../../plugins/provider-auth-choices.js";
+import type { RuntimeEnv } from "../../runtime.js";
 import { runCommandWithRuntime } from "../cli-utils.js";
 import { formatCliCommand } from "../command-format.js";
 import { parseGatewayPortOption } from "../gateway-port-option.js";
@@ -179,6 +180,18 @@ export function pickOnboardAuthOptionValues(
   };
 }
 
+export function validateOnboardAuthOptionValues(
+  opts: Record<string, unknown>,
+  runtime: RuntimeEnv,
+): boolean {
+  if (opts.customImageInput === true && opts.customTextInput === true) {
+    runtime.error("Use either --custom-image-input or --custom-text-input, not both.");
+    runtime.exit(1);
+    return false;
+  }
+  return true;
+}
+
 export function registerOnboardCommand(program: Command): void {
   const command = program
     .command("onboard")
@@ -329,6 +342,9 @@ export function registerOnboardCommand(program: Command): void {
             ...(opts.acceptRisk ? { acceptRisk: true } : {}),
           },
         );
+        return;
+      }
+      if (!validateOnboardAuthOptionValues(opts as Record<string, unknown>, defaultRuntime)) {
         return;
       }
       const installDaemon = resolveInstallDaemonFlag(commandRuntime);

--- a/src/cli/program/register.setup.test.ts
+++ b/src/cli/program/register.setup.test.ts
@@ -221,6 +221,17 @@ describe("registerSetupCommand", () => {
     expect(setupCommandMock).not.toHaveBeenCalled();
   });
 
+  it("rejects conflicting custom model input capabilities", async () => {
+    await runCli(["setup", "--custom-image-input", "--custom-text-input"]);
+
+    expect(runtime.error).toHaveBeenCalledWith(
+      "Use either --custom-image-input or --custom-text-input, not both.",
+    );
+    expect(runtime.exit).toHaveBeenCalledWith(1);
+    expect(setupWizardCommandMock).not.toHaveBeenCalled();
+    expect(setupCommandMock).not.toHaveBeenCalled();
+  });
+
   it.each(["not-a-port", "70000"])(
     "rejects invalid --gateway-port %s before onboarding dispatch",
     async (gatewayPort) => {

--- a/src/cli/program/register.setup.ts
+++ b/src/cli/program/register.setup.ts
@@ -20,6 +20,7 @@ import {
   registerOnboardAuthOptions,
   resolveInstallDaemonFlag,
   resolveTailscaleResetOnExitFlag,
+  validateOnboardAuthOptionValues,
 } from "./register.onboard.js";
 
 const SYSTEM_AGENT_OPTION_NAMES = new Set(["message", "yes", "json"]);
@@ -116,6 +117,9 @@ async function runOnboardingEntry(
     }
     const { setupCommand } = await import("../../commands/setup.js");
     await setupCommand({ workspace: optionalString(options.workspace) }, runtime);
+    return;
+  }
+  if (!validateOnboardAuthOptionValues(options, runtime)) {
     return;
   }
   const installDaemon = resolveInstallDaemonFlag(commandRuntime);


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where custom-provider onboarding accepted both `--custom-image-input` and `--custom-text-input`, exited successfully, and silently let text-only win. The caller received no indication that its image-capable request had been discarded.

## Why This Change Was Made

The shared CLI auth-option boundary now rejects the mutually exclusive capability flags before either `onboard` or `setup` dispatches. Each flag by itself keeps its existing metadata behavior.

This PR is AI-assisted. I reviewed both CLI entry points, custom-provider config parsing, and the downstream model metadata contract.

## User Impact

Custom-provider automation now gets an actionable nonzero error for contradictory capability input instead of silently persisting the wrong model capability.

## Evidence

- Before on unchanged current-main CLI registration: passing both flags exited 0 and persisted model input as `['text']`.
- After at `b3e54fef4a6648af588f2ec17a639502014ee901`: `onboard` and `setup` reject the pair before writes; text-only still persists `['text']`; image-capable still persists `['text', 'image']`.
- Source-blind CLI behavior contract: satisfied for both conflict entry points and both valid single-flag branches.
- Focused local registration tests: 57/57 passed on the rebased head.
- Blacksmith Testbox `tbx_01kyp4729e73swt4bnk0f96m5g`: 89/89 focused custom-provider/CLI assertions passed, followed by a clean `check:changed`. Workflow: https://github.com/openclaw/openclaw/actions/runs/30424067297
- Fresh rebased-head autoreview: clean, no accepted/actionable findings.

Provenance: both capability flags were introduced by direct commit `59162379627bc0a2c26af78df4823926dfa4f9fc` (Peter Steinberger, 2026-04-28).
