### PR TITLE
fix(auto-reply): single durable owner for CLI commentary

### DIFF
--- a/src/auto-reply/get-reply-options.types.ts
+++ b/src/auto-reply/get-reply-options.types.ts
@@ -209,6 +209,7 @@ export type GetReplyOptions = {
     meta?: string;
     approvalId?: string;
     approvalSlug?: string;
+    suppressDurableProgress?: true;
   }) => Promise<ProgressCallbackResult> | ProgressCallbackResult;
   /**
    * Called when the utility-model narration of the in-progress turn changes.

--- a/src/auto-reply/reply/agent-runner-cli-candidate.ts
+++ b/src/auto-reply/reply/agent-runner-cli-candidate.ts
@@ -257,6 +257,8 @@ export async function runCliFallbackCandidate(params: {
                         itemId: payload.itemId,
                         kind: "preamble",
                         progressText: payload.text,
+                        // The block bridge owns durability; this event remains a progress preview.
+                        ...(bridgeCliDurableCommentary ? { suppressDurableProgress: true } : {}),
                       }),
                     );
                   }

--- a/src/auto-reply/reply/agent-runner-execution-cli-commentary.test.ts
+++ b/src/auto-reply/reply/agent-runner-execution-cli-commentary.test.ts
@@ -188,6 +188,7 @@ describe("executeAgentTurn: CLI durable commentary", () => {
         itemId: "commentary-durable-1",
         kind: "preamble",
         progressText: "The durable findings live here.",
+        suppressDurableProgress: true,
       });
     });
     expect(result.kind).toBe("success");

--- a/src/auto-reply/reply/dispatch-from-config.prepare-execution.ts
+++ b/src/auto-reply/reply/dispatch-from-config.prepare-execution.ts
@@ -422,14 +422,18 @@ export async function prepareDispatchExecution(state: ChooseDispatchRouteReadySt
     suppressAutomaticSourceDelivery &&
     allowSuppressedSourceProgressCallbacks &&
     canForwardItemEvents;
+  const shouldDeliverDurableCommentaryProgress = (
+    payload: Parameters<NonNullable<GetReplyOptions["onItemEvent"]>>[0],
+  ) =>
+    deliverStandaloneCommentaryProgress &&
+    payload.kind === "preamble" &&
+    payload.suppressDurableProgress !== true;
   const forwardItemEvent = canForwardItemEvents
     ? wrapProgressCallback(params.replyOptions?.onItemEvent, {
         ...itemEventForwardingOptions,
         waitForDirectBlockReplyDelivery: true,
         onForward: (payload) =>
-          preserveProgressCallbackStartOrder &&
-          deliverStandaloneCommentaryProgress &&
-          payload.kind === "preamble"
+          preserveProgressCallbackStartOrder && shouldDeliverDurableCommentaryProgress(payload)
             ? noteCommentaryProgress(payload)
             : undefined,
         onVisible: (payload) => {
@@ -453,8 +457,7 @@ export async function prepareDispatchExecution(state: ChooseDispatchRouteReadySt
         }
         if (
           (!forwardItemEvent || !preserveProgressCallbackStartOrder) &&
-          deliverStandaloneCommentaryProgress &&
-          payload.kind === "preamble"
+          shouldDeliverDurableCommentaryProgress(payload)
         ) {
           await noteCommentaryProgress(payload);
         }

--- a/src/auto-reply/reply/dispatch-from-config.progress.test-utils.ts
+++ b/src/auto-reply/reply/dispatch-from-config.progress.test-utils.ts
@@ -92,6 +92,61 @@ describe("dispatchReplyFromConfig", () => {
     expect(activeDuringOffRun).toBe(false);
   });
 
+  it("keeps block-owned commentary out of the standalone durable progress lane", async () => {
+    setNoAbort();
+    sessionStoreMocks.currentEntry = {
+      verboseLevel: "on",
+    };
+    const dispatcher = createDispatcher();
+    const ctx = buildTestCtx({
+      Provider: "discord",
+      Surface: "discord",
+      ChatType: "direct",
+    });
+    const onItemEvent = vi.fn();
+
+    const replyResolver = async (
+      _ctx: MsgContext,
+      opts?: GetReplyOptions,
+      _cfg?: OpenClawConfig,
+    ) => {
+      await opts?.onItemEvent?.({
+        itemId: "commentary-1",
+        kind: "preamble",
+        progressText: "Inspecting the dispatch path.",
+        suppressDurableProgress: true,
+      });
+      await opts?.onBlockReply?.({ text: "Inspecting the dispatch path." });
+      return { text: "Done." } satisfies ReplyPayload;
+    };
+
+    await dispatchReplyFromConfig({
+      ctx,
+      cfg: emptyConfig,
+      dispatcher,
+      replyResolver,
+      replyOptions: {
+        suppressDefaultToolProgressMessages: true,
+        commentaryProgressEnabled: true,
+        progressPreambleEnabled: true,
+        commentaryPayloadsEnabled: true,
+        onItemEvent,
+      },
+    });
+
+    expect(onItemEvent).toHaveBeenCalledExactlyOnceWith({
+      itemId: "commentary-1",
+      kind: "preamble",
+      progressText: "Inspecting the dispatch path.",
+      suppressDurableProgress: true,
+    });
+    expect(dispatcher.sendToolResult).not.toHaveBeenCalled();
+    expect(dispatcher.sendBlockReply).toHaveBeenCalledExactlyOnceWith({
+      text: "Inspecting the dispatch path.",
+    });
+    expect(dispatcher.sendFinalReply).toHaveBeenCalledExactlyOnceWith({ text: "Done." });
+  });
+
   it("forwards channel-owned group progress callbacks while source delivery is suppressed", async () => {
     setNoAbort();
     sessionStoreMocks.currentEntry = {


### PR DESCRIPTION
## What Problem This Solves

Fixes a regression from #115455 where CLI auto-reply commentary was delivered twice to channels: once as durable commentary with the 💬 prefix and again as the raw commentary block.

## Why This Change Was Made

The block bridge is now the single durable owner for CLI commentary. A typed `suppressDurableProgress` marker prevents the parallel durable-progress path from emitting the same commentary while preserving the existing ownership boundary.

## User Impact

Users running CLI-backed auto-replies receive each commentary update once instead of seeing duplicate prefixed and raw messages.

## Evidence

- Focused auto-reply shard 3/3: green.
- Dispatch-focused suite: 302 tests passed.
- Pre-commit autoreview: clean, with no accepted or actionable findings.
- Post-rebase stable patch ID matches the reviewed commit, so no production-code conflict resolution or material diff change occurred.
