### PR TITLE
fix(gateway): redact CLI-imported history before dedupe

### DIFF
--- a/src/gateway/cli-session-history.claude.ts
+++ b/src/gateway/cli-session-history.claude.ts
@@ -483,7 +483,10 @@ export function readClaudeCliSessionMessages(params: {
   // Match local transcript persistence before dedupe so imported secrets cannot
   // bypass exact-text matching or reach chat history through the external copy.
   return visibleMessages.map(
-    (message) => redactTranscriptMessage(message as AgentMessage) as TranscriptLikeMessage,
+    (message) =>
+      redactTranscriptMessage(
+        message as unknown as AgentMessage,
+      ) as unknown as TranscriptLikeMessage,
   );
 }
 

--- a/src/gateway/cli-session-history.claude.ts
+++ b/src/gateway/cli-session-history.claude.ts
@@ -6,6 +6,8 @@ import path from "node:path";
 import { asFiniteNumber } from "@openclaw/normalization-core/number-coercion";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { hashCliReseedPrompt, parseCliReseedPrompt } from "../agents/cli-runner/reseed-envelope.js";
+import type { AgentMessage } from "../agents/runtime/index.js";
+import { redactTranscriptMessage } from "../agents/transcript-redact.js";
 import {
   isToolCallBlock,
   isToolResultBlock,
@@ -477,7 +479,12 @@ export function readClaudeCliSessionMessages(params: {
       // Ignore malformed external history entries.
     }
   }
-  return coalesceClaudeCliToolMessages(messages);
+  const visibleMessages = coalesceClaudeCliToolMessages(messages);
+  // Match local transcript persistence before dedupe so imported secrets cannot
+  // bypass exact-text matching or reach chat history through the external copy.
+  return visibleMessages.map(
+    (message) => redactTranscriptMessage(message as AgentMessage) as TranscriptLikeMessage,
+  );
 }
 
 type ClaudeCliCompactBoundaryEntry = {

--- a/src/gateway/cli-session-history.test.ts
+++ b/src/gateway/cli-session-history.test.ts
@@ -5,6 +5,8 @@ import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { hashCliReseedPrompt } from "../agents/cli-runner/reseed-envelope.js";
+import type { AgentMessage } from "../agents/runtime/index.js";
+import { redactTranscriptMessage } from "../agents/transcript-redact.js";
 import { withEnvAsync } from "../test-utils/env.js";
 import { readClaudeCliSessionMessages } from "./cli-session-history.claude.js";
 import {
@@ -153,6 +155,24 @@ function createClaudeHistoryLines(sessionId: string) {
       lastPrompt: "ignored",
     }),
   ].join("\n");
+}
+
+function createClaudeTextHistoryLines(
+  entries: Array<{ content: string; role: "assistant" | "user"; uuid: string }>,
+): string {
+  return entries
+    .map((entry, index) =>
+      JSON.stringify({
+        type: entry.role,
+        uuid: entry.uuid,
+        timestamp: new Date(Date.parse("2026-03-26T16:29:54.800Z") + index).toISOString(),
+        message: {
+          role: entry.role,
+          content: entry.content,
+        },
+      }),
+    )
+    .join("\n");
 }
 
 async function withClaudeProjectsDir<T>(
@@ -805,25 +825,130 @@ describe("cli session history", () => {
     });
   });
 
-  it("preserves repeated Claude messages with distinct external UUIDs", () => {
-    const importedMessages = [
-      "11111111-1111-4111-8111-111111111111",
-      "22222222-2222-4222-8222-222222222222",
-    ].map((externalId) => ({
-      role: "assistant",
-      content: "repeated Claude reply",
-      timestamp: Date.parse("2026-03-26T16:29:55.500Z"),
-      __openclaw: {
-        id: externalId,
-        importedFrom: "claude-cli",
-        externalId,
-        cliSessionId: "session-1",
-      },
-    }));
+  it.each([
+    ["deduplicates a local redacted copy against an imported full copy", false],
+    ["deduplicates when both local and imported copies are already redacted", true],
+  ])("%s", async (_label, importRedacted) => {
+    await withClaudeProjectsDir(async ({ homeDir, sessionId, filePath }) => {
+      const secretText = "key is sk-abcdef1234567890xyz";
+      const localMessage = redactTranscriptMessage({
+        role: "user",
+        content: secretText,
+      } as AgentMessage);
+      const localMessages = [localMessage];
+      const redactedContent = readRecord(localMessage).content;
+      if (typeof redactedContent !== "string") {
+        throw new Error("expected redacted local text content");
+      }
+      await fs.writeFile(
+        filePath,
+        createClaudeTextHistoryLines([
+          {
+            role: "user",
+            uuid: "user-secret-copy",
+            content: importRedacted ? redactedContent : secretText,
+          },
+        ]),
+        "utf-8",
+      );
 
-    expect(mergeImportedChatHistoryMessages({ localMessages: [], importedMessages })).toEqual(
-      importedMessages,
-    );
+      const messages = augmentBoundClaudeHistory({
+        homeDir,
+        sessionId,
+        provider: "claude-cli",
+        localMessages,
+      });
+
+      expect(messages).toBe(localMessages);
+    });
+  });
+
+  it("preserves repeated redacted Claude messages with distinct external UUIDs", async () => {
+    await withClaudeProjectsDir(async ({ homeDir, sessionId, filePath }) => {
+      const content = "shared key sk-abcdef1234567890xyz";
+      const externalIds = [
+        "11111111-1111-4111-8111-111111111111",
+        "22222222-2222-4222-8222-222222222222",
+      ];
+      await fs.writeFile(
+        filePath,
+        createClaudeTextHistoryLines(
+          externalIds.map((uuid) => ({ role: "assistant", uuid, content })),
+        ),
+        "utf-8",
+      );
+
+      const messages = augmentBoundClaudeHistory({
+        homeDir,
+        sessionId,
+        provider: "claude-cli",
+      });
+
+      expect(messages).toHaveLength(2);
+      expect(
+        messages.map((message) => readRecord(readRecord(message)["__openclaw"]).externalId),
+      ).toEqual(externalIds);
+    });
+  });
+
+  it("deduplicates an edited local message by external identity", async () => {
+    await withClaudeProjectsDir(async ({ homeDir, sessionId, filePath }) => {
+      const externalId = "edited-user-message";
+      await fs.writeFile(
+        filePath,
+        createClaudeTextHistoryLines([
+          { role: "user", uuid: externalId, content: "original imported text" },
+        ]),
+        "utf-8",
+      );
+      const localMessages = [
+        {
+          role: "user",
+          content: "edited local text",
+          __openclaw: {
+            importedFrom: "claude-cli",
+            externalId,
+            cliSessionId: sessionId,
+          },
+        },
+      ];
+
+      const messages = augmentBoundClaudeHistory({
+        homeDir,
+        sessionId,
+        provider: "claude-cli",
+        localMessages,
+      });
+
+      expect(messages).toBe(localMessages);
+    });
+  });
+
+  it("does not surface a secret present only in imported history after merge", async () => {
+    await withClaudeProjectsDir(async ({ homeDir, sessionId, filePath }) => {
+      const importedSecret = "sk-abcdef1234567890xyz";
+      await fs.writeFile(
+        filePath,
+        createClaudeTextHistoryLines([
+          {
+            role: "assistant",
+            uuid: "assistant-import-only-secret",
+            content: `imported only ${importedSecret}`,
+          },
+        ]),
+        "utf-8",
+      );
+
+      const messages = augmentBoundClaudeHistory({
+        homeDir,
+        sessionId,
+        provider: "claude-cli",
+        localMessages: [{ role: "user", content: "local visible text" }],
+      });
+
+      expect(messages).toHaveLength(2);
+      expect(JSON.stringify(messages)).not.toContain(importedSecret);
+    });
   });
 
   it("does not dedupe external ids from different imported sessions", () => {


### PR DESCRIPTION
Fixes #112930

## What Problem This Solves

Fixes an issue where users viewing Claude CLI-imported chat history in Control UI could see duplicate redacted/full copies and, more importantly, secrets that existed only in the imported CLI transcript.

## Why This Change Was Made

Claude CLI messages now pass through the canonical transcript redaction path before history merge and deduplication. This keeps redaction ownership in the existing shared boundary and lets redacted and full copies resolve to the same canonical history entry.

## User Impact

Control UI history no longer exposes secrets found only in imported Claude CLI transcripts, and equivalent redacted/full messages appear once instead of as duplicates. This is a security improvement for users who import CLI history.

## Evidence

- `node scripts/run-vitest.mjs src/gateway/cli-session-history.test.ts`: 44/44 gateway history tests passed after the CI repair, including 5 new regressions covering redacted/full deduplication and imported-only secret filtering.
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main --parallel-tests "node scripts/run-vitest.mjs src/gateway/cli-session-history.test.ts"`: clean, with no accepted/actionable findings; the attached focused test also passed 44/44.
- The initial rebase onto `origin/main` was conflict-free and patch-identical to the previously reviewed commit. The only subsequent production-code change is the compiler-required `unknown` bridge for the existing type assertion exposed by exact-head CI run 30424544337.
