### PR TITLE
fix(gateway): prevent long-lived session history streams from exhausting memory

### DIFF
--- a/src/gateway/session-history-state.test.ts
+++ b/src/gateway/session-history-state.test.ts
@@ -165,6 +165,40 @@ describe("SessionHistorySseState", () => {
     expect(snapshot.rawTranscriptSeq).toBe(2);
   });
 
+  test("retains the recent projection without changing carried inline sequence", () => {
+    const state = newState([
+      assistantTextMessage("first", 1),
+      assistantTextMessage("second", 2),
+      assistantTextMessage("third", 3),
+      assistantTextMessage("fourth", 4),
+    ]);
+
+    const retained = state.retainRecentMessages(2);
+
+    expect(retained.items).toBe(retained.messages);
+    expect(retained.messages).toEqual([
+      assistantTextMessage("third", 3),
+      assistantTextMessage("fourth", 4),
+    ]);
+    expect(retained.hasMore).toBe(true);
+    expect(retained.nextCursor).toBe("3");
+
+    const appended = appendAssistantText(state, "fifth", 5);
+    expect(appended?.messageSeq).toBe(5);
+    expect(appended?.message?.content).toEqual(textContent("fifth"));
+    expect(state.retainRecentMessages(2).messages).toEqual([
+      assistantTextMessage("fourth", 4),
+      assistantTextMessage("fifth", 5),
+    ]);
+  });
+
+  test("keeps the existing projection when it already fits the retention window", () => {
+    const state = newState([assistantTextMessage("first", 1)]);
+    const initialSnapshot = state.snapshot();
+
+    expect(state.retainRecentMessages(2)).toBe(initialSnapshot);
+  });
+
   test("uses carried sequence for inline SSE appends", () => {
     const state = newState([assistantTextMessage("initial", 2)]);
 

--- a/src/gateway/session-history-state.ts
+++ b/src/gateway/session-history-state.ts
@@ -255,6 +255,21 @@ export class SessionHistorySseState {
     return this.sentHistory;
   }
 
+  retainRecentMessages(maxMessages: number): PaginatedSessionHistory {
+    if (this.sentHistory.messages.length <= maxMessages) {
+      return this.snapshot();
+    }
+
+    const messages = this.sentHistory.messages.slice(-maxMessages);
+    const firstSeq = resolveMessageSeq(messages[0]);
+    this.sentHistory = buildPaginatedSessionHistory({
+      messages,
+      hasMore: true,
+      ...(firstSeq !== undefined ? { nextCursor: String(firstSeq) } : {}),
+    });
+    return this.snapshot();
+  }
+
   appendInlineMessage(update: {
     message: unknown;
     messageId?: string;

--- a/src/gateway/sessions-history-http.revocation.test.ts
+++ b/src/gateway/sessions-history-http.revocation.test.ts
@@ -117,6 +117,7 @@ vi.mock("./session-history-state.js", () => ({
   SessionHistorySseState: {
     fromRawSnapshot: (_params: unknown) => ({
       snapshot: () => ({ items: [], nextCursor: null, messages: [] }),
+      retainRecentMessages: () => ({ items: [], nextCursor: null, messages: [] }),
       appendInlineMessage: ({ message, messageId }: { message: unknown; messageId?: string }) => ({
         message,
         messageSeq: 1,

--- a/src/gateway/sessions-history-http.test.ts
+++ b/src/gateway/sessions-history-http.test.ts
@@ -4,7 +4,7 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import type { AssistantMessage } from "openclaw/plugin-sdk/llm";
-import { afterEach, describe, expect, test } from "vitest";
+import { afterEach, describe, expect, test, vi } from "vitest";
 import { replaceTranscriptEvents } from "../config/sessions/session-accessor.js";
 import { resolveSqliteTargetFromSessionStorePath } from "../config/sessions/session-sqlite-target.js";
 import {
@@ -16,6 +16,7 @@ import { emitSessionTranscriptUpdate } from "../sessions/transcript-events.js";
 import { OPENCLAW_TRANSCRIPT_ARTIFACT_API } from "../shared/transcript-only-openclaw-assistant.js";
 import type { DB as OpenClawAgentKyselyDatabase } from "../state/openclaw-agent-db.generated.js";
 import { runOpenClawAgentWriteTransaction } from "../state/openclaw-agent-db.js";
+import { SessionHistorySseState } from "./session-history-state.js";
 import { testState } from "./test-helpers.runtime-state.js";
 import {
   connectReq,
@@ -897,6 +898,116 @@ describe("session history HTTP endpoints", () => {
         id: appendedId,
       });
     });
+  });
+
+  test("bounds retained SSE history without truncating full history or live updates", async () => {
+    const retainedMessageLimit = 1_000;
+    const initialMessageCount = retainedMessageLimit + 2;
+    const sessionKey = "agent:main:main";
+    const { storePath } = await seedSession();
+    await replaceTranscriptEvents(
+      {
+        agentId: AGENT_ID,
+        sessionId: "sess-main",
+        sessionKey,
+        storePath,
+      },
+      [
+        { type: "session", version: 1, id: "sess-main" },
+        ...Array.from({ length: initialMessageCount }, (_, index) => ({
+          id: `history-message-${index + 1}`,
+          parentId: index === 0 ? null : `history-message-${index}`,
+          message: makeTranscriptAssistantMessage({ text: `history message ${index + 1}` }),
+        })),
+      ],
+    );
+
+    const snapshotSpy = vi.spyOn(SessionHistorySseState.prototype, "snapshot");
+    try {
+      await withGatewayHarness(async (harness) => {
+        const stream = await openSessionHistorySse(harness.port, sessionKey);
+        try {
+          const initialEvent = await readSseEvent(stream.reader, stream.streamState);
+          expect(initialEvent.event).toBe("history");
+          const initialMessages = (initialEvent.data as SessionHistoryBody).messages ?? [];
+          expect(initialMessages).toHaveLength(initialMessageCount);
+          expect(initialMessages[0]?.content?.[0]?.text).toBe("history message 1");
+
+          const retained = snapshotSpy.mock.results.at(-1)?.value as
+            | { messages?: SessionHistoryMessage[] }
+            | undefined;
+          expect(retained?.messages).toHaveLength(retainedMessageLimit);
+          expect(retained?.messages?.[0]?.content?.[0]?.text).toBe("history message 3");
+
+          const cursorStream = await openSessionHistorySse(harness.port, sessionKey, {
+            query: `?cursor=${initialMessageCount + 1}`,
+          });
+          try {
+            const cursorEvent = await readSseEvent(cursorStream.reader, cursorStream.streamState);
+            expect(cursorEvent.event).toBe("history");
+            expect((cursorEvent.data as SessionHistoryBody).messages).toHaveLength(
+              initialMessageCount,
+            );
+            const cursorSnapshot = snapshotSpy.mock.results.at(-1)?.value as
+              | { messages?: SessionHistoryMessage[] }
+              | undefined;
+            expect(cursorSnapshot?.messages).toHaveLength(retainedMessageLimit);
+            expect(cursorSnapshot?.messages?.[0]?.content?.[0]?.text).toBe("history message 3");
+
+            const messageId = await appendVisibleAssistantMessage({
+              sessionKey,
+              text: "live history message",
+              storePath,
+            });
+            const lastSequence = initialMessages.at(-1)?.["__openclaw"]?.seq;
+            expect(lastSequence).toEqual(expect.any(Number));
+            await expectMessageEventMatch(stream, {
+              text: "live history message",
+              seq: (lastSequence ?? 0) + 1,
+              id: messageId,
+            });
+
+            const liveRetained = snapshotSpy.mock.results.findLast((result) => {
+              const snapshot = result.value as { messages?: SessionHistoryMessage[] } | undefined;
+              return snapshot?.messages?.at(-1)?.content?.[0]?.text === "live history message";
+            })?.value as { messages?: SessionHistoryMessage[] } | undefined;
+            expect(liveRetained?.messages).toHaveLength(retainedMessageLimit);
+            expect(liveRetained?.messages?.at(-1)?.content?.[0]?.text).toBe("live history message");
+
+            const refreshedCursorEvent = await readSseEvent(
+              cursorStream.reader,
+              cursorStream.streamState,
+            );
+            expect(refreshedCursorEvent.event).toBe("history");
+            const refreshedCursorMessages =
+              (refreshedCursorEvent.data as SessionHistoryBody).messages ?? [];
+            expect(refreshedCursorMessages).toHaveLength(initialMessageCount);
+            expect(refreshedCursorMessages[0]?.content?.[0]?.text).toBe("history message 1");
+
+            const refreshedCursorSnapshot = snapshotSpy.mock.results.at(-1)?.value as
+              | { messages?: SessionHistoryMessage[] }
+              | undefined;
+            expect(refreshedCursorSnapshot?.messages).toHaveLength(retainedMessageLimit);
+
+            const completeHistory = await vi.waitFor(
+              async () => await readSessionHistoryBody(harness.port, sessionKey),
+              { interval: 25, timeout: 5_000 },
+            );
+            expect(completeHistory.messages).toHaveLength(initialMessageCount + 1);
+            expect(completeHistory.messages?.[0]?.content?.[0]?.text).toBe("history message 1");
+            expect(completeHistory.messages?.at(-1)?.content?.[0]?.text).toBe(
+              "live history message",
+            );
+          } finally {
+            await cursorStream.reader.cancel();
+          }
+        } finally {
+          await stream.reader.cancel();
+        }
+      });
+    } finally {
+      snapshotSpy.mockRestore();
+    }
   });
 
   test("streams identity-only transcript updates over SSE", async () => {

--- a/src/gateway/sessions-history-http.ts
+++ b/src/gateway/sessions-history-http.ts
@@ -266,6 +266,16 @@ export async function handleSessionHistoryHttpRequest(
     unsubscribe?: () => void;
   } = {};
 
+  function writeStreamHistory(snapshot: ReturnType<SessionHistorySseState["snapshot"]>) {
+    sseWrite(res, "history", {
+      sessionKey: target.canonicalKey,
+      ...snapshot,
+    });
+    // Send the entire requested page before bounding private live state.
+    // Cursor refreshes reread SQLite, so their next page remains complete.
+    sentHistory = sseState.retainRecentMessages(MAX_SESSION_HISTORY_LIMIT);
+  }
+
   function releaseStreamResources() {
     if (streamStopped) {
       return;
@@ -338,10 +348,7 @@ export async function handleSessionHistoryHttpRequest(
   if (isStreamClosed()) {
     return true;
   }
-  sseWrite(res, "history", {
-    sessionKey: target.canonicalKey,
-    ...sentHistory,
-  });
+  writeStreamHistory(sentHistory);
   if (isStreamClosed()) {
     return true;
   }
@@ -423,10 +430,7 @@ export async function handleSessionHistoryHttpRequest(
         if (limit === undefined && cursor === undefined) {
           if (sseState.shouldRefreshForTranscriptPath(updatePath)) {
             sentHistory = await sseState.refreshAsync();
-            sseWrite(res, "history", {
-              sessionKey: target.canonicalKey,
-              ...sentHistory,
-            });
+            writeStreamHistory(sentHistory);
             return;
           }
           const nextEvent = sseState.appendInlineMessage({
@@ -439,16 +443,13 @@ export async function handleSessionHistoryHttpRequest(
           }
           if (nextEvent.shouldRefresh) {
             sentHistory = await sseState.refreshAsync();
-            sseWrite(res, "history", {
-              sessionKey: target.canonicalKey,
-              ...sentHistory,
-            });
+            writeStreamHistory(sentHistory);
             return;
           }
           if (nextEvent.message === undefined) {
             return;
           }
-          sentHistory = sseState.snapshot();
+          sentHistory = sseState.retainRecentMessages(MAX_SESSION_HISTORY_LIMIT);
           sseWrite(res, "message", {
             sessionKey: target.canonicalKey,
             message: nextEvent.message,
@@ -459,10 +460,7 @@ export async function handleSessionHistoryHttpRequest(
         }
       }
       sentHistory = await sseState.refreshAsync();
-      sseWrite(res, "history", {
-        sessionKey: target.canonicalKey,
-        ...sentHistory,
-      });
+      writeStreamHistory(sentHistory);
     });
   });
   return true;


### PR DESCRIPTION
Closes #105231

## What Problem This Solves

Fixes an issue where users watching a long-running session over the Gateway history stream could exhaust Gateway memory as the complete projected transcript was retained independently by every open connection. Cursor-only streams could retain the same unbounded transcript.

## Why This Change Was Made

Emit each complete requested history page before retaining only the existing 1,000-message session-history window in connection-local memory. Preserve canonical full SQLite history, complete unbounded and cursor responses, live message sequence continuity, and subsequent cursor refreshes, which reload their complete requested page from SQLite. This adds no configuration, schema, storage, or protocol surface.

## User Impact

Long-running and concurrent session history streams no longer grow without bound. Existing clients still receive complete history pages, full cursor refreshes, all live messages, and unchanged direct REST history.

## Evidence

- Red proof: the actual Gateway SSE endpoint with a parent-linked 1,002-message SQLite transcript retains all 1,002 messages before this change: https://github.com/openclaw/openclaw/actions/runs/30421703244
- Final exact-change remote proof: 109 passing real Gateway SSE, cursor, SQLite, REST, session, WebSocket, auth-revocation, and pagination tests, plus the complete changed-file gate, both core and core-test typechecks, targeted lint, formatting, database/schema guards, plugin boundaries, and dead-export checks: https://github.com/openclaw/openclaw/actions/runs/30424196015
- New end-to-end regression keeps concurrent full-history and cursor-only streams open, verifies both complete 1,002-message public responses and cursor refreshes while both private snapshots stay at 1,000, verifies the next live message and its exact carried sequence, and confirms direct REST still returns every one of the 1,003 persisted messages.
- Independent Codex autoreview: clean, with no actionable findings.
- AI-assisted; implementation, SQLite ownership, public compatibility, concurrent-stream behavior, and every linked test were manually verified.
