### PR TITLE
fix(ui): fall back when profile hero avatar fails

### DIFF
--- a/ui/src/pages/profile/profile-page.test.ts
+++ b/ui/src/pages/profile/profile-page.test.ts
@@ -230,6 +230,44 @@ it("rerenders on connection transitions for unidentified connections", async () 
   expect(page.querySelector(".profile-hero")).not.toBeNull();
 });
 
+it("falls back to the text avatar when the hero image fails to load", async () => {
+  const request = vi.fn();
+  const harness = createConnectedContext(request as GatewayBrowserClient["request"]);
+  const agentsState = harness.context.agents.state as unknown as {
+    agentsList: {
+      defaultId: string;
+      agents: Array<{
+        id: string;
+        identity: { name: string; emoji: string; avatarUrl: string };
+      }>;
+    };
+  };
+  agentsState.agentsList = {
+    defaultId: "main",
+    agents: [
+      {
+        id: "main",
+        identity: { name: "Molty", emoji: "🦞", avatarUrl: "/unloadable-avatar.png" },
+      },
+    ],
+  };
+  const provider = createApplicationContextProvider(harness.context);
+  const page = document.createElement(PROFILE_PAGE_TEST_TAG) as ProfilePageElement;
+  provider.append(page);
+  document.body.append(provider);
+
+  await page.updateComplete;
+  const image = page.querySelector<HTMLImageElement>(".profile-hero__avatar-image");
+  expect(image?.getAttribute("src")).toBe("/unloadable-avatar.png");
+  expect(page.querySelector(".profile-hero__avatar-text")).toBeNull();
+
+  image?.dispatchEvent(new Event("error"));
+  await page.updateComplete;
+
+  expect(page.querySelector(".profile-hero__avatar-image")).toBeNull();
+  expect(page.querySelector(".profile-hero__avatar-text")?.textContent).toBe("🦞");
+});
+
 it("retries the identity bootstrap when users.self returns no profile", async () => {
   const profile: UserProfile = {
     id: "profile-1",

--- a/ui/src/pages/profile/profile-page.ts
+++ b/ui/src/pages/profile/profile-page.ts
@@ -52,6 +52,7 @@ export class ProfilePage extends OpenClawLightDomElement {
   @state() private identityLoading = false;
   @state() private identityBusy: "display-name" | "avatar" | null = null;
   @state() private identityError: string | null = null;
+  @state() private failedHeroAvatarUrl: string | null = null;
 
   private client: GatewayBrowserClient | null = null;
   private connected = false;
@@ -317,8 +318,15 @@ export class ProfilePage extends OpenClawLightDomElement {
   }
 
   private renderAvatar(avatarUrl: string | null, textAvatar: string | null, name: string) {
-    if (avatarUrl) {
-      return html`<img class="profile-hero__avatar-image" src=${avatarUrl} alt=${name} />`;
+    if (avatarUrl && avatarUrl !== this.failedHeroAvatarUrl) {
+      return html`<img
+        class="profile-hero__avatar-image"
+        src=${avatarUrl}
+        alt=${name}
+        @error=${() => {
+          this.failedHeroAvatarUrl = avatarUrl;
+        }}
+      />`;
     }
     if (textAvatar) {
       return html`<span class="profile-hero__avatar-text">${textAvatar}</span>`;


### PR DESCRIPTION
Fixes #107853

## What Problem This Solves

Fixes an issue where users viewing the profile page would see a broken profile hero image when the configured assistant avatar could not be loaded.

## Why This Change Was Made

The profile hero now remembers the failed avatar URL and falls back to the existing text avatar. A different avatar URL is still eligible to render normally.

## User Impact

Users see the assistant emoji or text avatar instead of a broken image when the profile hero avatar fails to load.

## Evidence

- Focused profile-page UI tests: 7/7 passed, including the new failed-image fallback regression test.
- Codex autoreview: clean on the original committed branch diff.
- Rebase onto current main was conflict-free, and the rebased commit has the identical stable patch ID, so no post-rebase autoreview rerun was needed.
