### PR TITLE
fix(codex): scope ephemeral runs to physical session bindings

### DIFF
--- a/extensions/codex/src/app-server/run-attempt-connection.ts
+++ b/extensions/codex/src/app-server/run-attempt-connection.ts
@@ -40,7 +40,10 @@ import type { CodexRunAttemptInput } from "./run-attempt-types.js";
 import {
   createCodexSessionGenerationSupersededError,
   reclaimCurrentCodexSessionGeneration,
+  resolveCodexRunSessionBindingAuthority,
+  scopeCodexRunBindingStore,
   sessionBindingIdentity,
+  type CodexAppServerBindingIdentity,
   type CodexAppServerThreadBinding,
 } from "./session-binding.js";
 import { getLeasedSharedCodexAppServerClient } from "./shared-client.js";
@@ -117,25 +120,58 @@ export async function prepareCodexAttemptConnection({ params, options }: CodexRu
     agentId: sessionAgentId,
   });
   const agentDir = params.agentDir ?? resolveAgentDir(params.config ?? {}, sessionAgentId);
-  const bindingIdentity = sessionBindingIdentity({
+  let bindingIdentity: CodexAppServerBindingIdentity = sessionBindingIdentity({
     sessionId: params.sessionId,
     sessionKey: params.sessionKey,
     agentId: params.agentId,
     config: params.config,
   });
-  const bindingStore = options.bindingStore;
+  let bindingStore = options.bindingStore;
   preDynamicStartupStages.mark("session-agent");
   let activeContextEngine = isActiveHarnessContextEngine(params.contextEngine)
     ? params.contextEngine
     : undefined;
   const isInactiveThreadBootstrapBinding = (binding: CodexAppServerThreadBinding | undefined) =>
     !activeContextEngine && binding?.contextEngine?.projection?.mode === "thread_bootstrap";
+  // The public runner carries a resolved store target. Its durable row must
+  // authorize a stable-key fence before an old generation can read its binding.
+  if (
+    bindingIdentity.kind === "session" &&
+    bindingIdentity.sessionKey &&
+    (params.sessionTarget?.storePath || params.config?.session?.store)
+  ) {
+    const authority = resolveCodexRunSessionBindingAuthority({
+      identity: bindingIdentity,
+      config: params.config,
+      storePath: params.sessionTarget?.storePath,
+    });
+    if (authority === "superseded") {
+      throw createCodexSessionGenerationSupersededError(bindingIdentity.sessionId);
+    }
+    if (authority === "ephemeral") {
+      // Stable-key fences protect only durable session rows. Ephemeral callers rotate
+      // physical ids, so sharing that owner would strand every run after the first.
+      const logicalIdentity = bindingIdentity;
+      const physicalIdentity = {
+        kind: "session",
+        agentId: bindingIdentity.agentId,
+        sessionId: bindingIdentity.sessionId,
+      } as const;
+      bindingStore = scopeCodexRunBindingStore({
+        bindingStore,
+        logicalIdentity,
+        physicalIdentity,
+      });
+      bindingIdentity = physicalIdentity;
+    }
+  }
   let startupBinding = await bindingStore.read(bindingIdentity);
   if (!startupBinding && bindingIdentity.kind === "session" && bindingIdentity.sessionKey) {
     const reclaimed = await reclaimCurrentCodexSessionGeneration({
       bindingStore,
       identity: bindingIdentity,
       config: params.config,
+      storePath: params.sessionTarget?.storePath,
     });
     if (!reclaimed) {
       throw createCodexSessionGenerationSupersededError(bindingIdentity.sessionId);

--- a/extensions/codex/src/app-server/run-attempt.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.test.ts
@@ -5277,7 +5277,9 @@ describe("runCodexAppServerAttempt", () => {
       const expectedGeneration = index + 1;
       await vi.waitFor(() => {
         if (startupError) {
-          throw startupError;
+          throw startupError instanceof Error
+            ? startupError
+            : new Error("Codex attempt failed.", { cause: startupError });
         }
         expect(harness.requests.filter((request) => request.method === "turn/start")).toHaveLength(
           expectedGeneration,

--- a/extensions/codex/src/app-server/run-attempt.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.test.ts
@@ -5246,6 +5246,88 @@ describe("runCodexAppServerAttempt", () => {
     });
   });
 
+  it("starts sequential ephemeral generations that share a stable session key", async () => {
+    const { sessionFile, workspaceDir } = createRunPaths();
+    const sessionKey = "agent:main:ephemeral-helper";
+    const storePath = path.join(tempDir, "ephemeral-sessions.json");
+    let generation = 0;
+    const harness = createStartedThreadHarness(async (method) => {
+      if (method === "thread/start") {
+        generation += 1;
+        return threadStartResult(`thread-ephemeral-${generation}`);
+      }
+      if (method === "turn/start") {
+        return turnStartResult(`turn-ephemeral-${generation}`);
+      }
+      return undefined;
+    });
+
+    for (const [index, sessionId] of ["session-ephemeral-1", "session-ephemeral-2"].entries()) {
+      const params = createParams(sessionFile, workspaceDir);
+      params.sessionId = sessionId;
+      params.sessionKey = sessionKey;
+      params.sessionTarget = { agentId: "main", sessionId, sessionKey, storePath };
+      params.config = { ...params.config, session: { store: storePath } };
+
+      const run = runCodexAppServerAttempt(params);
+      let startupError: unknown;
+      void run.catch((error: unknown) => {
+        startupError = error;
+      });
+      const expectedGeneration = index + 1;
+      await vi.waitFor(() => {
+        if (startupError) {
+          throw startupError;
+        }
+        expect(harness.requests.filter((request) => request.method === "turn/start")).toHaveLength(
+          expectedGeneration,
+        );
+      }, fastWait);
+      const threadId = `thread-ephemeral-${expectedGeneration}`;
+      const turnId = `turn-ephemeral-${expectedGeneration}`;
+      await harness.completeTurn({ threadId, turnId });
+      await expect(run).resolves.toBeDefined();
+    }
+    expect(harness.requests.filter((request) => request.method === "thread/start")).toHaveLength(2);
+  });
+
+  it("rejects a run whose physical generation mismatches its durable session row", async () => {
+    const { sessionFile, workspaceDir } = createRunPaths();
+    const sessionKey = "agent:main:durable-generation";
+    const durableSessionId = "session-durable-current";
+    const storePath = path.join(tempDir, "durable-sessions.json");
+    registerCodexTestSessionIdentity(sessionFile, durableSessionId, sessionKey);
+    await writeCodexAppServerBinding(sessionFile, {
+      threadId: "thread-durable-current",
+      cwd: workspaceDir,
+    });
+    await upsertSessionEntry({
+      agentId: "main",
+      storePath,
+      sessionKey,
+      entry: { sessionId: durableSessionId, updatedAt: Date.now() },
+    });
+    const params = createParams(sessionFile, workspaceDir);
+    params.sessionId = "session-durable-stale";
+    params.sessionKey = sessionKey;
+    params.sessionTarget = {
+      agentId: "main",
+      sessionId: params.sessionId,
+      sessionKey,
+      storePath,
+    };
+    params.config = { ...params.config, session: { store: storePath } };
+    const clientFactory = vi.fn(async () => {
+      throw new Error("client must not start");
+    });
+
+    await expect(runCodexAppServerAttempt(params, { clientFactory })).rejects.toMatchObject({
+      name: "AgentHarnessSessionSupersededError",
+      message: "Codex session generation is no longer current: session-durable-stale",
+    });
+    expect(clientFactory).not.toHaveBeenCalled();
+  });
+
   it("does not inherit a bound local provider for explicit native OpenAI resumed runs", async () => {
     const { sessionFile, workspaceDir } = createRunPaths();
     await writeExistingBinding(sessionFile, workspaceDir, {

--- a/extensions/codex/src/app-server/session-binding.ts
+++ b/extensions/codex/src/app-server/session-binding.ts
@@ -74,6 +74,38 @@ export function sessionBindingIdentity(params: {
   };
 }
 
+export type CodexRunSessionBindingAuthority = "current" | "ephemeral" | "superseded";
+
+/** Decides whether a run may share the durable stable-key binding owner. */
+export function resolveCodexRunSessionBindingAuthority(params: {
+  identity: Extract<CodexAppServerBindingIdentity, { kind: "session" }>;
+  config?: OpenClawConfig;
+  storePath?: string;
+}): CodexRunSessionBindingAuthority {
+  const sessionKey = params.identity.sessionKey?.trim();
+  if (!sessionKey) {
+    return "ephemeral";
+  }
+  try {
+    const storePath =
+      params.storePath?.trim() ||
+      resolveStorePath(params.config?.session?.store, { agentId: params.identity.agentId });
+    const entry = getSessionEntry({
+      agentId: params.identity.agentId,
+      hydrateSkillPromptRefs: false,
+      readConsistency: "latest",
+      sessionKey,
+      storePath,
+    });
+    if (!entry) {
+      return "ephemeral";
+    }
+    return entry.sessionId === params.identity.sessionId ? "current" : "superseded";
+  } catch {
+    return "superseded";
+  }
+}
+
 /** Builds the terminal coordination error used when a newer OpenClaw session owns the binding. */
 export function createCodexSessionGenerationSupersededError(
   sessionId: string,
@@ -535,11 +567,52 @@ export type CodexAppServerBindingStore = {
   withLease<T>(identity: CodexAppServerBindingIdentity, run: () => Promise<T>): Promise<T>;
 };
 
+/** Carries one prepared run identity through callers that rederive it from public params. */
+export function scopeCodexRunBindingStore(params: {
+  bindingStore: CodexAppServerBindingStore;
+  logicalIdentity: Extract<CodexAppServerBindingIdentity, { kind: "session" }>;
+  physicalIdentity: Extract<CodexAppServerBindingIdentity, { kind: "session" }>;
+}): CodexAppServerBindingStore {
+  const mapSessionIdentity = (
+    identity: Extract<CodexAppServerBindingIdentity, { kind: "session" }>,
+  ) =>
+    identity.agentId === params.logicalIdentity.agentId &&
+    identity.sessionId === params.logicalIdentity.sessionId &&
+    identity.sessionKey?.trim() === params.logicalIdentity.sessionKey?.trim()
+      ? params.physicalIdentity
+      : identity;
+  const mapIdentity = (identity: CodexAppServerBindingIdentity) =>
+    identity.kind === "session" ? mapSessionIdentity(identity) : identity;
+  return {
+    read: (identity) => params.bindingStore.read(mapIdentity(identity)),
+    hasOtherThreadOwner: (threadId, identity) =>
+      params.bindingStore.hasOtherThreadOwner(
+        threadId,
+        identity ? mapIdentity(identity) : undefined,
+      ),
+    mutate: (identity, mutation) => params.bindingStore.mutate(mapIdentity(identity), mutation),
+    prepareSessionGenerationReclaim: (identity) =>
+      params.bindingStore.prepareSessionGenerationReclaim(mapSessionIdentity(identity)),
+    adoptSessionGeneration: (identity, expectedPreviousSessionId) =>
+      params.bindingStore.adoptSessionGeneration(
+        mapSessionIdentity(identity),
+        expectedPreviousSessionId,
+      ),
+    resetSessionGeneration: (identity) =>
+      params.bindingStore.resetSessionGeneration(mapSessionIdentity(identity)),
+    retireSessionGeneration: (identity) =>
+      params.bindingStore.retireSessionGeneration(mapSessionIdentity(identity)),
+    withThreadArchiveFence: (run) => params.bindingStore.withThreadArchiveFence(run),
+    withLease: (identity, run) => params.bindingStore.withLease(mapIdentity(identity), run),
+  };
+}
+
 /** Lets the authoritative OpenClaw session generation claim a stale stable binding row. */
 export async function reclaimCurrentCodexSessionGeneration(params: {
   bindingStore: CodexAppServerBindingStore;
   identity: Extract<CodexAppServerBindingIdentity, { kind: "session" }>;
   config?: OpenClawConfig;
+  storePath?: string;
 }): Promise<boolean> {
   const sessionKey = params.identity.sessionKey?.trim();
   if (!sessionKey) {
@@ -553,9 +626,9 @@ export async function reclaimCurrentCodexSessionGeneration(params: {
   // Only a stale stable-key owner needs session-store authority. Resolve it before
   // the second mutation so the session read never runs inside the binding write transaction.
   try {
-    const storePath = resolveStorePath(params.config?.session?.store, {
-      agentId: params.identity.agentId,
-    });
+    const storePath =
+      params.storePath?.trim() ||
+      resolveStorePath(params.config?.session?.store, { agentId: params.identity.agentId });
     const entry = getSessionEntry({
       agentId: params.identity.agentId,
       hydrateSkillPromptRefs: false,


### PR DESCRIPTION
Fixes #108769

## What Problem This Solves

Fixes an issue where plugin SDK callers running sequential isolated Codex embedded-agent tasks with one stable logical `sessionKey` and fresh physical `sessionId` values could have the second run rejected by the durable generation fence before model execution.

## Why This Change Was Made

Ephemeral callers now bind Codex attempts by their physical `sessionId`, while durable sessions retain the stable-key generation fence. Authority resolution explicitly distinguishes current, ephemeral, and superseded bindings; store read errors classify as superseded and fail closed, consistent with the existing reclaim path. The reset/reclaim behavior from #114056 is unchanged.

Upstream `codex-rs` was verified to key thread/resume behavior by `thread_id` only, so the physical session binding matches the underlying runtime identity without weakening durable ownership.

## User Impact

Plugins can safely reuse a logical session key across sequential isolated Codex runs that rotate physical session IDs. Durable sessions remain protected against stale generation reuse, and in-place reset/reclaim behavior is preserved.

## Evidence

- `node scripts/run-vitest.mjs extensions/codex` — 192/192 Codex extension tests passed on the reviewed production patch.
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main` — clean; no accepted/actionable findings on the reviewed production patch.
- Rebase onto `origin/main` was conflict-free and preserved the production patch's stable patch id (`0ae032dbfbe59456f2776c1cd10a7ce3d92dfb57`), so no post-rebase production-code review rerun was needed.
- `node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.extensions.json extensions/codex/src/app-server/run-attempt.test.ts` — passed after the CI-requested test-only error normalization.
- `node scripts/run-vitest.mjs extensions/codex/src/app-server/run-attempt.test.ts -t 'starts sequential ephemeral generations that share a stable session key'` — 1/1 passed.
- `git diff --check` — passed after the final commit.
