### PR TITLE
fix(gateway): stop health debug spam and refresh churn

### DIFF
--- a/src/commands/health.ts
+++ b/src/commands/health.ts
@@ -43,6 +43,7 @@ import { isDiagnosticFlagEnabled } from "../infra/diagnostic-flags.js";
 import { formatErrorMessage } from "../infra/errors.js";
 import { formatDurationHuman } from "../infra/format-time/format-duration.js";
 import { resolveHeartbeatSummaryForAgent } from "../infra/heartbeat-summary.js";
+import { createSubsystemLogger } from "../logging/subsystem.js";
 import {
   degradedPluginMatchesRoot,
   listActiveDegradedPlugins,
@@ -73,10 +74,15 @@ export { formatHealthChannelLines } from "./health-format.js";
 export type { HealthSummary } from "./health.types.js";
 
 const DEFAULT_TIMEOUT_MS = 10_000;
+const healthLog = createSubsystemLogger("health");
 
-const debugHealth = (cfg: OpenClawConfig | undefined, ...args: unknown[]) => {
+const debugHealth = (
+  cfg: OpenClawConfig | undefined,
+  message: string,
+  meta?: Record<string, unknown>,
+) => {
   if (isDiagnosticFlagEnabled("health", cfg)) {
-    console.warn("[health:debug]", ...args);
+    healthLog.info(message, meta);
   }
 };
 
@@ -256,7 +262,9 @@ export function buildDeliveryQueueHealthSummary(): DeliveryQueueHealthSummary | 
       return entry;
     });
   } catch (error) {
-    debugHealth(undefined, "outbound delivery queue health read failed", error);
+    debugHealth(undefined, "outbound delivery queue health read failed", {
+      error: formatErrorMessage(error),
+    });
   }
   let ingressFailed: NonNullable<DeliveryQueueHealthSummary["ingressFailed"]> = [];
   try {
@@ -272,7 +280,9 @@ export function buildDeliveryQueueHealthSummary(): DeliveryQueueHealthSummary | 
       return entry;
     });
   } catch (error) {
-    debugHealth(undefined, "channel ingress queue health read failed", error);
+    debugHealth(undefined, "channel ingress queue health read failed", {
+      error: formatErrorMessage(error),
+    });
   }
   if (failed.length === 0 && ingressFailed.length === 0) {
     return undefined;

--- a/src/gateway/server-methods/health.ts
+++ b/src/gateway/server-methods/health.ts
@@ -11,9 +11,27 @@ import type { ChannelRuntimeSnapshot } from "../server-channel-runtime.types.js"
 import { HEALTH_REFRESH_INTERVAL_MS } from "../server-constants.js";
 import { formatError } from "../server-utils.js";
 import { formatForLog } from "../ws-log.js";
-import type { GatewayRequestHandlers } from "./types.js";
+import type { GatewayRequestContext, GatewayRequestHandlers } from "./types.js";
 
 const ADMIN_SCOPE = "operator.admin";
+const requestRefreshStartedAt = new WeakMap<
+  GatewayRequestContext["refreshHealthSnapshot"],
+  number
+>();
+
+function shouldScheduleRequestRefresh(
+  refresh: GatewayRequestContext["refreshHealthSnapshot"],
+  now: number,
+): boolean {
+  const startedAt = requestRefreshStartedAt.get(refresh);
+  if (startedAt !== undefined && now - startedAt < HEALTH_REFRESH_INTERVAL_MS) {
+    return false;
+  }
+  // Scope the throttle to the Gateway refresh owner so independent servers do
+  // not suppress each other while request bursts share one cadence.
+  requestRefreshStartedAt.set(refresh, now);
+  return true;
+}
 
 function cachedAccountForRuntimeSnapshot(params: {
   cachedChannel: ChannelHealthSummary | undefined;
@@ -165,11 +183,11 @@ export const healthHandlers: GatewayRequestHandlers = {
         undefined,
         { cached: true },
       );
-      // Serve the fresh-enough cache immediately but still refresh in the
-      // background so the next caller sees updated expensive probe data.
-      void refreshHealthSnapshot({ probe: false, includeSensitive }).catch((err: unknown) =>
-        logHealth.error(`background health refresh failed: ${formatError(err)}`),
-      );
+      if (shouldScheduleRequestRefresh(refreshHealthSnapshot, now)) {
+        void refreshHealthSnapshot({ probe: false, includeSensitive }).catch((err: unknown) =>
+          logHealth.error(`background health refresh failed: ${formatError(err)}`),
+        );
+      }
       return;
     }
     try {

--- a/src/gateway/server-methods/server-methods.test.ts
+++ b/src/gateway/server-methods/server-methods.test.ts
@@ -38,6 +38,7 @@ import {
 } from "../chat-display-projection.js";
 import { ExecApprovalManager } from "../exec-approval-manager.js";
 import { createChatRunState } from "../server-chat-state.js";
+import { HEALTH_REFRESH_INTERVAL_MS } from "../server-constants.js";
 import { waitForAgentJob } from "./agent-job.js";
 import { injectTimestamp, timestampOptsFromConfig } from "./agent-timestamp.js";
 import { normalizeRpcAttachmentsToChatAttachments } from "./attachment-normalize.js";
@@ -4856,9 +4857,11 @@ describe("gateway healthHandlers.health cache freshness", () => {
     fresh?: Record<string, unknown>;
     runtimeSnapshot?: Record<string, unknown>;
     context?: Record<string, unknown>;
+    refreshHealthSnapshot?: ReturnType<typeof vi.fn>;
   }) {
     const respond = vi.fn();
-    const refreshHealthSnapshot = vi.fn().mockResolvedValue(params.fresh ?? params.cached);
+    const refreshHealthSnapshot =
+      params.refreshHealthSnapshot ?? vi.fn().mockResolvedValue(params.fresh ?? params.cached);
     await expectDefined(healthHandlers.health, "healthHandlers.health test invariant").call(
       healthHandlers,
       {
@@ -4890,8 +4893,39 @@ describe("gateway healthHandlers.health cache freshness", () => {
   });
 
   afterEach(() => {
+    vi.useRealTimers();
     clearContextEnginesForOwner(contextEngineTestOwner);
     resetContextEngineRuntimeQuarantineForTests();
+  });
+
+  it("rate-limits request-driven refreshes for fresh cached health", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-07-28T12:00:00Z"));
+    const cached = createHealthSnapshot({});
+    const refreshHealthSnapshot = vi.fn().mockResolvedValue(cached);
+
+    for (let index = 0; index < 3; index += 1) {
+      await requestHealthSnapshot({ cached, refreshHealthSnapshot });
+    }
+    expect(refreshHealthSnapshot).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(HEALTH_REFRESH_INTERVAL_MS - 1);
+    await requestHealthSnapshot({ cached: { ...cached, ts: Date.now() }, refreshHealthSnapshot });
+    expect(refreshHealthSnapshot).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(1);
+    await requestHealthSnapshot({ cached: { ...cached, ts: Date.now() }, refreshHealthSnapshot });
+    expect(refreshHealthSnapshot).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not throttle stale cached health refreshes", async () => {
+    const cached = createHealthSnapshot({ ts: Date.now() - HEALTH_REFRESH_INTERVAL_MS });
+    const refreshHealthSnapshot = vi.fn().mockResolvedValue(cached);
+
+    await requestHealthSnapshot({ cached, refreshHealthSnapshot });
+    await requestHealthSnapshot({ cached, refreshHealthSnapshot });
+
+    expect(refreshHealthSnapshot).toHaveBeenCalledTimes(2);
   });
 
   it("refreshes cached health when runtime channel lifecycle has changed", async () => {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where operators using health diagnostics could see repeated warning-level `health:debug` output, while repeated fresh-cache health RPCs could start an unbounded number of background refreshes.

Reported through Discord beta.2 feedback; there is no linked GitHub issue.

## Why This Change Was Made

Flag-gated health diagnostics now use the `health` subsystem logger at info level, preserving opt-in visibility without bypassing normal log routing. Fresh-cache request refreshes are limited to the existing 60-second health cadence per Gateway refresh owner, while stale-cache requests retain their synchronous refresh behavior.

## User Impact

Operators keep useful health diagnostics when explicitly enabled, but no longer get warning-level console spam. Bursts of health polling also stop creating redundant background refresh work.

## Evidence

- `node scripts/run-vitest.mjs src/gateway/server-methods/server-methods.test.ts`: 190/190 tests passed, including fresh-cache burst throttling and unchanged stale-cache behavior.
- `node scripts/run-vitest.mjs src/commands/health.test.ts`: 23/23 tests passed.
- `node scripts/run-vitest.mjs src/gateway/server/health-state.test.ts`: 6/6 tests passed.
- `git diff --check`: passed.
- Codex autoreview initially found that debug-level logging would hide flag-enabled diagnostics; the branch was corrected to info level. The final autoreview completed clean with no accepted/actionable findings.
- The branch rebased conflict-free onto current `origin/main`; the stable patch ID remained unchanged, so no post-review production code changed.
