### PR TITLE
fix(plugins): honor update channel for targeted probes

### DIFF
--- a/src/cli/plugins-cli.update.test.ts
+++ b/src/cli/plugins-cli.update.test.ts
@@ -1144,28 +1144,43 @@ describe("plugins cli update", () => {
     ).toBe(true);
   });
 
-  it("does not sync official catalog specs for manual plugin updates", async () => {
-    const config = createTrackedPluginConfig({
-      pluginId: "codex",
+  it.each([
+    {
+      updateChannel: "beta" as const,
+      registryLine: "beta",
+      spec: "@openclaw/codex@2026.6.8-beta.1",
+    },
+    {
+      updateChannel: "stable" as const,
+      registryLine: "latest",
       spec: "@openclaw/codex@2026.5.28",
-      resolvedName: "@openclaw/codex",
-    });
-    loadConfig.mockReturnValue(config);
-    setInstalledPluginIndexInstallRecords(config.plugins?.installs ?? {});
-    updateNpmInstalledPlugins.mockResolvedValue({
-      config,
-      changed: false,
-      outcomes: [],
-    });
+    },
+  ])(
+    "passes the $updateChannel channel to probe $registryLine for targeted exact pins",
+    async ({ updateChannel, spec }) => {
+      const config = createTrackedPluginConfig({
+        pluginId: "codex",
+        spec,
+        resolvedName: "@openclaw/codex",
+      });
+      config.update = { channel: updateChannel };
+      loadConfig.mockReturnValue(config);
+      setInstalledPluginIndexInstallRecords(config.plugins?.installs ?? {});
+      updateNpmInstalledPlugins.mockResolvedValue({
+        config,
+        changed: false,
+        outcomes: [],
+      });
 
-    await runPluginsCommand(["plugins", "update", "codex"]);
+      await runPluginsCommand(["plugins", "update", "codex"]);
 
-    const updateParams = expectSingleCallParams(updateNpmInstalledPlugins);
-    expect(updateParams.pluginIds).toEqual(["codex"]);
-    expect(updateParams.syncOfficialPluginInstalls).toBeUndefined();
-    expect(updateParams.updateChannel).toBeUndefined();
-    expect(updateParams.officialPluginUpdateChannel).toBeUndefined();
-  });
+      const updateParams = expectSingleCallParams(updateNpmInstalledPlugins);
+      expect(updateParams.pluginIds).toEqual(["codex"]);
+      expect(updateParams.syncOfficialPluginInstalls).toBeUndefined();
+      expect(updateParams.updateChannel).toBe(updateChannel);
+      expect(updateParams.officialPluginUpdateChannel).toBeUndefined();
+    },
+  );
 
   it("syncs official catalog specs with beta channel context for update --all", async () => {
     const config = createTrackedPluginConfig({

--- a/src/cli/plugins-update-command.ts
+++ b/src/cli/plugins-update-command.ts
@@ -223,6 +223,7 @@ async function runPluginUpdateCommandUnlocked(params: RunPluginUpdateCommandPara
     sourceCfg,
     pluginInstallRecords,
   );
+  const configuredUpdateChannel = normalizeUpdateChannel(cfg.update?.channel) ?? undefined;
   const logger = {
     info: (msg: string) => defaultRuntime.log(msg),
     warn: (msg: string) => defaultRuntime.log(msg.includes("╭─") ? msg : theme.warn(msg)),
@@ -342,6 +343,7 @@ async function runPluginUpdateCommandUnlocked(params: RunPluginUpdateCommandPara
           pluginIds: pluginSelection.pluginIds,
           specOverrides: pluginSelection.specOverrides,
           dryRun: params.opts.dryRun,
+          updateChannel: params.opts.all ? undefined : configuredUpdateChannel,
           officialPluginUpdateChannel: params.opts.all
             ? resolveRegistryUpdateChannel({
                 configChannel: normalizeUpdateChannel(cfg.update?.channel),


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users running `openclaw plugins update <id>` on the beta channel could be told the plugin was up to date because the targeted npm probe checked the latest dist-tag instead of the configured update channel, including for exact beta pins.

Reported through Discord beta feedback. Complements #111169.

## Why This Change Was Made

Targeted plugin updates now pass the normalized configured update channel into the npm probe. Bulk `--all` updates retain their existing official-catalog synchronization and resolved registry-channel behavior.

## User Impact

Users on beta or another configured update channel now get update availability results for that channel when updating one plugin by id, instead of results derived from npm latest.

## Evidence

- Pre-rebase focused plugin CLI suite: 37/37 tests passed.
- Post-rebase focused proof: `node scripts/run-vitest.mjs src/cli/plugins-cli.update.test.ts` — 38/38 tests passed.
- Post-conflict review: `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main` — clean, with no accepted/actionable findings.
- `git diff --check origin/main...HEAD` passed before push.
