### PR TITLE
test(telegram): restore media e2e coverage with harness bot identity

### DIFF
--- a/extensions/telegram/src/bot.media.test-utils.ts
+++ b/extensions/telegram/src/bot.media.test-utils.ts
@@ -1,6 +1,7 @@
 // Telegram helper module supports bot.media utils behavior.
 import * as ssrf from "openclaw/plugin-sdk/ssrf-runtime";
 import { afterEach, beforeAll, beforeEach, expect, vi, type Mock } from "vitest";
+import { telegramBotInfoForTest } from "./bot.create-telegram-bot.test-support.js";
 import * as harness from "./bot.media.e2e-harness.js";
 
 type StickerSpy = Mock<(...args: unknown[]) => unknown>;
@@ -62,6 +63,9 @@ export async function createBotHandlerWithOptions(options: {
   const effectiveProxyFetch = options.proxyFetch ?? (undiciFetchSpyRef as unknown as typeof fetch);
   createTelegramBotRef({
     token: "tok",
+    // Handlers resolve the bot identity from ctx.me?.id ?? opts.botInfo?.id; the
+    // harness contexts only carry a username, so botInfo supplies the id.
+    botInfo: telegramBotInfoForTest,
     config: harness.telegramBotDepsForTest.getRuntimeConfig(),
     testTimings: TELEGRAM_TEST_TIMINGS,
     ...(effectiveProxyFetch ? { proxyFetch: effectiveProxyFetch } : {}),


### PR DESCRIPTION
## What Problem This Solves

The Telegram media E2E harness failed all 10 cases before exercising their intended behavior. The failure was pre-existing on `origin/main`: `resolveBotUserId` threw `Telegram bot identity is unavailable`, so the suite provided no real coverage of forwarded-burst debounce and coalescing behavior.

## Why This Change Was Made

`resolveBotUserId` resolves `ctx.me?.id ?? opts.botInfo?.id`, but the media harness supplied neither value. The harness now reuses `telegramBotInfoForTest`, matching the already-passing channel-post-media suite and supplying the bot identity through the supported test seam.

This is an AI-assisted, test-only change. No changelog entry is needed because runtime behavior is unchanged.

## User Impact

There is no user-visible runtime change. Maintainers regain meaningful E2E coverage for Telegram media handling, including forwarded-burst debounce and coalescing.

## Evidence

- Before the fix on `origin/main`: `extensions/telegram/src/bot.media.downloads-media-file-path-no-file-download.e2e.test.ts` failed 10/10 cases before reaching behavior assertions.
- `node scripts/run-vitest.mjs extensions/telegram/src/bot.media.downloads-media-file-path-no-file-download.e2e.test.ts` — 10/10 pass.
- `node scripts/run-vitest.mjs extensions/telegram/src/bot.media.stickers-and-fragments.e2e.test.ts` — 6/6 pass for the other importer of the same harness.
- `pnpm check:test-types` — exit 0.
- `pnpm exec oxfmt --check extensions/telegram/src/bot.media.test-utils.ts` — clean.
- `pnpm exec oxlint extensions/telegram/src/bot.media.test-utils.ts` — clean.
- `$autoreview` with Codex (`gpt-5.6-sol`) — clean, with no accepted or actionable findings.
