### PR TITLE
chore(i18n): refresh native locales

### DIFF
--- a/apps/.i18n/native/ar.json
+++ b/apps/.i18n/native/ar.json
@@ -8399,6 +8399,11 @@
       "translated": "$count عامل إضافي"
     },
     {
+      "id": "native.android.c32ff602fa622e4b",
+      "source": "Done in $duration",
+      "translated": "اكتمل خلال $duration"
+    },
+    {
       "id": "native.android.c2dc3a65302976c0",
       "source": "1 token",
       "translated": "رمز مميز واحد"
@@ -8407,11 +8412,6 @@
       "id": "native.android.e7059e3a756908c4",
       "source": "$count tokens",
       "translated": "$count رموز مميزة"
-    },
-    {
-      "id": "native.android.c32ff602fa622e4b",
-      "source": "Done in $duration",
-      "translated": "اكتمل خلال $duration"
     },
     {
       "id": "native.android.d2797e7488fe5021",
@@ -8759,11 +8759,6 @@
       "translated": "جارٍ الاستماع"
     },
     {
-      "id": "native.android.1f198e7aceb8411f",
-      "source": "Speech recognizer unavailable",
-      "translated": "أداة التعرّف على الكلام غير متاحة"
-    },
-    {
       "id": "native.android.8532cc9537b69224",
       "source": "Start failed: $message",
       "translated": "فشل البدء: $message"
@@ -8772,6 +8767,11 @@
       "id": "native.android.a9216e087452b75b",
       "source": "Connecting…",
       "translated": "جارٍ الاتصال…"
+    },
+    {
+      "id": "native.android.1f198e7aceb8411f",
+      "source": "Speech recognizer unavailable",
+      "translated": "أداة التعرّف على الكلام غير متاحة"
     },
     {
       "id": "native.android.24bc808758b925ca",
@@ -20374,6 +20374,16 @@
       "translated": "تعذّر حفظ موافقات التنفيذ. تُعرض آخر الإعدادات المعروفة؛ أعد محاولة التغيير."
     },
     {
+      "id": "native.apple.b28538e2e444510f",
+      "source": "Exec approvals need migration — run openclaw doctor --fix with OPENCLAW_STATE_DIR set to \\(error.stateDirectoryURL.path).",
+      "translated": "تحتاج موافقات التنفيذ إلى الترحيل — شغّل openclaw doctor --fix مع تعيين OPENCLAW_STATE_DIR إلى \\(error.stateDirectoryURL.path)."
+    },
+    {
+      "id": "native.apple.49e886ab7a093e63",
+      "source": "Exec approvals unavailable. Retry to refresh.",
+      "translated": "موافقات التنفيذ غير متاحة. أعد المحاولة للتحديث."
+    },
+    {
       "id": "native.apple.1b8ba1cf6f9dfdc9",
       "source": "missing:\\(hash)",
       "translated": "missing:\\(hash)"
@@ -26422,6 +26432,11 @@
       "id": "native.apple.6fbcf8a03da3315a",
       "source": "Surfacing",
       "translated": "الصعود إلى السطح"
+    },
+    {
+      "id": "native.apple.286932b5ea17b3f8",
+      "source": "1 second",
+      "translated": "ثانية واحدة"
     },
     {
       "id": "native.apple.578503dfeef25502",

--- a/apps/.i18n/native/de.json
+++ b/apps/.i18n/native/de.json
@@ -8399,6 +8399,11 @@
       "translated": "$count weitere Worker"
     },
     {
+      "id": "native.android.c32ff602fa622e4b",
+      "source": "Done in $duration",
+      "translated": "Fertig in $duration"
+    },
+    {
       "id": "native.android.c2dc3a65302976c0",
       "source": "1 token",
       "translated": "1 Token"
@@ -8407,11 +8412,6 @@
       "id": "native.android.e7059e3a756908c4",
       "source": "$count tokens",
       "translated": "$count Token"
-    },
-    {
-      "id": "native.android.c32ff602fa622e4b",
-      "source": "Done in $duration",
-      "translated": "Fertig in $duration"
     },
     {
       "id": "native.android.d2797e7488fe5021",
@@ -8759,11 +8759,6 @@
       "translated": "Hört zu"
     },
     {
-      "id": "native.android.1f198e7aceb8411f",
-      "source": "Speech recognizer unavailable",
-      "translated": "Spracherkennung nicht verfügbar"
-    },
-    {
       "id": "native.android.8532cc9537b69224",
       "source": "Start failed: $message",
       "translated": "Start fehlgeschlagen: $message"
@@ -8772,6 +8767,11 @@
       "id": "native.android.a9216e087452b75b",
       "source": "Connecting…",
       "translated": "Verbindung wird hergestellt…"
+    },
+    {
+      "id": "native.android.1f198e7aceb8411f",
+      "source": "Speech recognizer unavailable",
+      "translated": "Spracherkennung nicht verfügbar"
     },
     {
       "id": "native.android.24bc808758b925ca",
@@ -20374,6 +20374,16 @@
       "translated": "Exec-Genehmigungen konnten nicht gespeichert werden. Die zuletzt bekannten Einstellungen werden angezeigt; wiederholen Sie die Änderung."
     },
     {
+      "id": "native.apple.b28538e2e444510f",
+      "source": "Exec approvals need migration — run openclaw doctor --fix with OPENCLAW_STATE_DIR set to \\(error.stateDirectoryURL.path).",
+      "translated": "Exec-Genehmigungen müssen migriert werden — führen Sie openclaw doctor --fix mit OPENCLAW_STATE_DIR gesetzt auf \\(error.stateDirectoryURL.path) aus."
+    },
+    {
+      "id": "native.apple.49e886ab7a093e63",
+      "source": "Exec approvals unavailable. Retry to refresh.",
+      "translated": "Exec-Genehmigungen sind nicht verfügbar. Versuchen Sie es erneut, um sie zu aktualisieren."
+    },
+    {
       "id": "native.apple.1b8ba1cf6f9dfdc9",
       "source": "missing:\\(hash)",
       "translated": "missing:\\(hash)"
@@ -26422,6 +26432,11 @@
       "id": "native.apple.6fbcf8a03da3315a",
       "source": "Surfacing",
       "translated": "Auftauchen"
+    },
+    {
+      "id": "native.apple.286932b5ea17b3f8",
+      "source": "1 second",
+      "translated": "1 Sekunde"
     },
     {
       "id": "native.apple.578503dfeef25502",

--- a/apps/.i18n/native/es.json
+++ b/apps/.i18n/native/es.json
@@ -8399,6 +8399,11 @@
       "translated": "$count trabajadores más"
     },
     {
+      "id": "native.android.c32ff602fa622e4b",
+      "source": "Done in $duration",
+      "translated": "Completado en $duration"
+    },
+    {
       "id": "native.android.c2dc3a65302976c0",
       "source": "1 token",
       "translated": "1 token"
@@ -8407,11 +8412,6 @@
       "id": "native.android.e7059e3a756908c4",
       "source": "$count tokens",
       "translated": "$count tokens"
-    },
-    {
-      "id": "native.android.c32ff602fa622e4b",
-      "source": "Done in $duration",
-      "translated": "Completado en $duration"
     },
     {
       "id": "native.android.d2797e7488fe5021",
@@ -8759,11 +8759,6 @@
       "translated": "Escuchando"
     },
     {
-      "id": "native.android.1f198e7aceb8411f",
-      "source": "Speech recognizer unavailable",
-      "translated": "El reconocimiento de voz no está disponible"
-    },
-    {
       "id": "native.android.8532cc9537b69224",
       "source": "Start failed: $message",
       "translated": "Error al iniciar: $message"
@@ -8772,6 +8767,11 @@
       "id": "native.android.a9216e087452b75b",
       "source": "Connecting…",
       "translated": "Conectando…"
+    },
+    {
+      "id": "native.android.1f198e7aceb8411f",
+      "source": "Speech recognizer unavailable",
+      "translated": "El reconocimiento de voz no está disponible"
     },
     {
       "id": "native.android.24bc808758b925ca",
@@ -20374,6 +20374,16 @@
       "translated": "No se pudieron guardar las aprobaciones de exec. Se muestran los últimos ajustes conocidos; reintenta el cambio."
     },
     {
+      "id": "native.apple.b28538e2e444510f",
+      "source": "Exec approvals need migration — run openclaw doctor --fix with OPENCLAW_STATE_DIR set to \\(error.stateDirectoryURL.path).",
+      "translated": "Las aprobaciones de ejecución deben migrarse — ejecuta openclaw doctor --fix con OPENCLAW_STATE_DIR establecido en \\(error.stateDirectoryURL.path)."
+    },
+    {
+      "id": "native.apple.49e886ab7a093e63",
+      "source": "Exec approvals unavailable. Retry to refresh.",
+      "translated": "Las aprobaciones de ejecución no están disponibles. Vuelve a intentarlo para actualizar."
+    },
+    {
       "id": "native.apple.1b8ba1cf6f9dfdc9",
       "source": "missing:\\(hash)",
       "translated": "missing:\\(hash)"
@@ -26422,6 +26432,11 @@
       "id": "native.apple.6fbcf8a03da3315a",
       "source": "Surfacing",
       "translated": "Saliendo a la superficie"
+    },
+    {
+      "id": "native.apple.286932b5ea17b3f8",
+      "source": "1 second",
+      "translated": "1 segundo"
     },
     {
       "id": "native.apple.578503dfeef25502",

--- a/apps/.i18n/native/fa.json
+++ b/apps/.i18n/native/fa.json
@@ -8399,6 +8399,11 @@
       "translated": "$count کارگر دیگر"
     },
     {
+      "id": "native.android.c32ff602fa622e4b",
+      "source": "Done in $duration",
+      "translated": "در مدت $duration انجام شد"
+    },
+    {
       "id": "native.android.c2dc3a65302976c0",
       "source": "1 token",
       "translated": "۱ توکن"
@@ -8407,11 +8412,6 @@
       "id": "native.android.e7059e3a756908c4",
       "source": "$count tokens",
       "translated": "$count توکن"
-    },
-    {
-      "id": "native.android.c32ff602fa622e4b",
-      "source": "Done in $duration",
-      "translated": "در مدت $duration انجام شد"
     },
     {
       "id": "native.android.d2797e7488fe5021",
@@ -8759,11 +8759,6 @@
       "translated": "در حال شنیدن"
     },
     {
-      "id": "native.android.1f198e7aceb8411f",
-      "source": "Speech recognizer unavailable",
-      "translated": "تشخیص‌دهنده گفتار در دسترس نیست"
-    },
-    {
       "id": "native.android.8532cc9537b69224",
       "source": "Start failed: $message",
       "translated": "شروع ناموفق بود: $message"
@@ -8772,6 +8767,11 @@
       "id": "native.android.a9216e087452b75b",
       "source": "Connecting…",
       "translated": "در حال اتصال…"
+    },
+    {
+      "id": "native.android.1f198e7aceb8411f",
+      "source": "Speech recognizer unavailable",
+      "translated": "تشخیص‌دهنده گفتار در دسترس نیست"
     },
     {
       "id": "native.android.24bc808758b925ca",
@@ -20374,6 +20374,16 @@
       "translated": "ذخیره تأییدهای exec ممکن نشد. آخرین تنظیمات شناخته‌شده نمایش داده شده‌اند؛ تغییر را دوباره امتحان کنید."
     },
     {
+      "id": "native.apple.b28538e2e444510f",
+      "source": "Exec approvals need migration — run openclaw doctor --fix with OPENCLAW_STATE_DIR set to \\(error.stateDirectoryURL.path).",
+      "translated": "تأییدهای اجرا نیاز به مهاجرت دارند — دستور openclaw doctor --fix را با تنظیم OPENCLAW_STATE_DIR روی \\(error.stateDirectoryURL.path) اجرا کنید."
+    },
+    {
+      "id": "native.apple.49e886ab7a093e63",
+      "source": "Exec approvals unavailable. Retry to refresh.",
+      "translated": "تأییدهای اجرا در دسترس نیستند. برای تازه‌سازی دوباره تلاش کنید."
+    },
+    {
       "id": "native.apple.1b8ba1cf6f9dfdc9",
       "source": "missing:\\(hash)",
       "translated": "missing:\\(hash)"
@@ -26422,6 +26432,11 @@
       "id": "native.apple.6fbcf8a03da3315a",
       "source": "Surfacing",
       "translated": "به‌سطح‌آمدن"
+    },
+    {
+      "id": "native.apple.286932b5ea17b3f8",
+      "source": "1 second",
+      "translated": "۱ ثانیه"
     },
     {
       "id": "native.apple.578503dfeef25502",

--- a/apps/.i18n/native/fr.json
+++ b/apps/.i18n/native/fr.json
@@ -8399,6 +8399,11 @@
       "translated": "$count workers de plus"
     },
     {
+      "id": "native.android.c32ff602fa622e4b",
+      "source": "Done in $duration",
+      "translated": "Terminé en $duration"
+    },
+    {
       "id": "native.android.c2dc3a65302976c0",
       "source": "1 token",
       "translated": "1 jeton"
@@ -8407,11 +8412,6 @@
       "id": "native.android.e7059e3a756908c4",
       "source": "$count tokens",
       "translated": "$count jetons"
-    },
-    {
-      "id": "native.android.c32ff602fa622e4b",
-      "source": "Done in $duration",
-      "translated": "Terminé en $duration"
     },
     {
       "id": "native.android.d2797e7488fe5021",
@@ -8759,11 +8759,6 @@
       "translated": "Écoute"
     },
     {
-      "id": "native.android.1f198e7aceb8411f",
-      "source": "Speech recognizer unavailable",
-      "translated": "Reconnaissance vocale indisponible"
-    },
-    {
       "id": "native.android.8532cc9537b69224",
       "source": "Start failed: $message",
       "translated": "Échec du démarrage : $message"
@@ -8772,6 +8767,11 @@
       "id": "native.android.a9216e087452b75b",
       "source": "Connecting…",
       "translated": "Connexion…"
+    },
+    {
+      "id": "native.android.1f198e7aceb8411f",
+      "source": "Speech recognizer unavailable",
+      "translated": "Reconnaissance vocale indisponible"
     },
     {
       "id": "native.android.24bc808758b925ca",
@@ -20374,6 +20374,16 @@
       "translated": "Impossible d'enregistrer les approbations exec. Les derniers paramètres connus sont affichés ; réessayez la modification."
     },
     {
+      "id": "native.apple.b28538e2e444510f",
+      "source": "Exec approvals need migration — run openclaw doctor --fix with OPENCLAW_STATE_DIR set to \\(error.stateDirectoryURL.path).",
+      "translated": "Les approbations d’exécution doivent être migrées — exécutez openclaw doctor --fix avec OPENCLAW_STATE_DIR défini sur \\(error.stateDirectoryURL.path)."
+    },
+    {
+      "id": "native.apple.49e886ab7a093e63",
+      "source": "Exec approvals unavailable. Retry to refresh.",
+      "translated": "Les approbations d’exécution sont indisponibles. Réessayez pour actualiser."
+    },
+    {
       "id": "native.apple.1b8ba1cf6f9dfdc9",
       "source": "missing:\\(hash)",
       "translated": "missing:\\(hash)"
@@ -26422,6 +26432,11 @@
       "id": "native.apple.6fbcf8a03da3315a",
       "source": "Surfacing",
       "translated": "Remontée à la surface"
+    },
+    {
+      "id": "native.apple.286932b5ea17b3f8",
+      "source": "1 second",
+      "translated": "1 seconde"
     },
     {
       "id": "native.apple.578503dfeef25502",

--- a/apps/.i18n/native/hi.json
+++ b/apps/.i18n/native/hi.json
@@ -8399,6 +8399,11 @@
       "translated": "$count और workers"
     },
     {
+      "id": "native.android.c32ff602fa622e4b",
+      "source": "Done in $duration",
+      "translated": "$duration में पूरा हुआ"
+    },
+    {
       "id": "native.android.c2dc3a65302976c0",
       "source": "1 token",
       "translated": "1 टोकन"
@@ -8407,11 +8412,6 @@
       "id": "native.android.e7059e3a756908c4",
       "source": "$count tokens",
       "translated": "$count टोकन"
-    },
-    {
-      "id": "native.android.c32ff602fa622e4b",
-      "source": "Done in $duration",
-      "translated": "$duration में पूरा हुआ"
     },
     {
       "id": "native.android.d2797e7488fe5021",
@@ -8759,11 +8759,6 @@
       "translated": "सुन रहा है"
     },
     {
-      "id": "native.android.1f198e7aceb8411f",
-      "source": "Speech recognizer unavailable",
-      "translated": "वाक् पहचानकर्ता उपलब्ध नहीं है"
-    },
-    {
       "id": "native.android.8532cc9537b69224",
       "source": "Start failed: $message",
       "translated": "शुरू करना विफल रहा: $message"
@@ -8772,6 +8767,11 @@
       "id": "native.android.a9216e087452b75b",
       "source": "Connecting…",
       "translated": "कनेक्ट हो रहा है…"
+    },
+    {
+      "id": "native.android.1f198e7aceb8411f",
+      "source": "Speech recognizer unavailable",
+      "translated": "वाक् पहचानकर्ता उपलब्ध नहीं है"
     },
     {
       "id": "native.android.24bc808758b925ca",
@@ -20374,6 +20374,16 @@
       "translated": "Exec अनुमोदन सहेजे नहीं जा सके। अंतिम ज्ञात सेटिंग्स दिखाई गई हैं; परिवर्तन पुनः प्रयास करें।"
     },
     {
+      "id": "native.apple.b28538e2e444510f",
+      "source": "Exec approvals need migration — run openclaw doctor --fix with OPENCLAW_STATE_DIR set to \\(error.stateDirectoryURL.path).",
+      "translated": "Exec अनुमोदनों को माइग्रेशन की आवश्यकता है — OPENCLAW_STATE_DIR को \\(error.stateDirectoryURL.path) पर सेट करके openclaw doctor --fix चलाएँ।"
+    },
+    {
+      "id": "native.apple.49e886ab7a093e63",
+      "source": "Exec approvals unavailable. Retry to refresh.",
+      "translated": "Exec अनुमोदन उपलब्ध नहीं हैं। रीफ़्रेश करने के लिए फिर से प्रयास करें।"
+    },
+    {
       "id": "native.apple.1b8ba1cf6f9dfdc9",
       "source": "missing:\\(hash)",
       "translated": "missing:\\(hash)"
@@ -26422,6 +26432,11 @@
       "id": "native.apple.6fbcf8a03da3315a",
       "source": "Surfacing",
       "translated": "सतह पर आ रहे हैं"
+    },
+    {
+      "id": "native.apple.286932b5ea17b3f8",
+      "source": "1 second",
+      "translated": "1 सेकंड"
     },
     {
       "id": "native.apple.578503dfeef25502",

--- a/apps/.i18n/native/id.json
+++ b/apps/.i18n/native/id.json
@@ -8399,6 +8399,11 @@
       "translated": "$count worker lagi"
     },
     {
+      "id": "native.android.c32ff602fa622e4b",
+      "source": "Done in $duration",
+      "translated": "Selesai dalam $duration"
+    },
+    {
       "id": "native.android.c2dc3a65302976c0",
       "source": "1 token",
       "translated": "1 token"
@@ -8407,11 +8412,6 @@
       "id": "native.android.e7059e3a756908c4",
       "source": "$count tokens",
       "translated": "$count token"
-    },
-    {
-      "id": "native.android.c32ff602fa622e4b",
-      "source": "Done in $duration",
-      "translated": "Selesai dalam $duration"
     },
     {
       "id": "native.android.d2797e7488fe5021",
@@ -8759,11 +8759,6 @@
       "translated": "Mendengarkan"
     },
     {
-      "id": "native.android.1f198e7aceb8411f",
-      "source": "Speech recognizer unavailable",
-      "translated": "Pengenal ucapan tidak tersedia"
-    },
-    {
       "id": "native.android.8532cc9537b69224",
       "source": "Start failed: $message",
       "translated": "Gagal memulai: $message"
@@ -8772,6 +8767,11 @@
       "id": "native.android.a9216e087452b75b",
       "source": "Connecting…",
       "translated": "Menghubungkan…"
+    },
+    {
+      "id": "native.android.1f198e7aceb8411f",
+      "source": "Speech recognizer unavailable",
+      "translated": "Pengenal ucapan tidak tersedia"
     },
     {
       "id": "native.android.24bc808758b925ca",
@@ -20374,6 +20374,16 @@
       "translated": "Tidak dapat menyimpan persetujuan exec. Pengaturan terakhir yang diketahui ditampilkan; coba lagi perubahannya."
     },
     {
+      "id": "native.apple.b28538e2e444510f",
+      "source": "Exec approvals need migration — run openclaw doctor --fix with OPENCLAW_STATE_DIR set to \\(error.stateDirectoryURL.path).",
+      "translated": "Persetujuan exec perlu dimigrasikan — jalankan openclaw doctor --fix dengan OPENCLAW_STATE_DIR diatur ke \\(error.stateDirectoryURL.path)."
+    },
+    {
+      "id": "native.apple.49e886ab7a093e63",
+      "source": "Exec approvals unavailable. Retry to refresh.",
+      "translated": "Persetujuan exec tidak tersedia. Coba lagi untuk memuat ulang."
+    },
+    {
       "id": "native.apple.1b8ba1cf6f9dfdc9",
       "source": "missing:\\(hash)",
       "translated": "missing:\\(hash)"
@@ -26422,6 +26432,11 @@
       "id": "native.apple.6fbcf8a03da3315a",
       "source": "Surfacing",
       "translated": "Muncul ke permukaan"
+    },
+    {
+      "id": "native.apple.286932b5ea17b3f8",
+      "source": "1 second",
+      "translated": "1 detik"
     },
     {
       "id": "native.apple.578503dfeef25502",

--- a/apps/.i18n/native/it.json
+++ b/apps/.i18n/native/it.json
@@ -8399,6 +8399,11 @@
       "translated": "$count altri worker"
     },
     {
+      "id": "native.android.c32ff602fa622e4b",
+      "source": "Done in $duration",
+      "translated": "Completato in $duration"
+    },
+    {
       "id": "native.android.c2dc3a65302976c0",
       "source": "1 token",
       "translated": "1 token"
@@ -8407,11 +8412,6 @@
       "id": "native.android.e7059e3a756908c4",
       "source": "$count tokens",
       "translated": "$count token"
-    },
-    {
-      "id": "native.android.c32ff602fa622e4b",
-      "source": "Done in $duration",
-      "translated": "Completato in $duration"
     },
     {
       "id": "native.android.d2797e7488fe5021",
@@ -8759,11 +8759,6 @@
       "translated": "In ascolto"
     },
     {
-      "id": "native.android.1f198e7aceb8411f",
-      "source": "Speech recognizer unavailable",
-      "translated": "Riconoscimento vocale non disponibile"
-    },
-    {
       "id": "native.android.8532cc9537b69224",
       "source": "Start failed: $message",
       "translated": "Avvio non riuscito: $message"
@@ -8772,6 +8767,11 @@
       "id": "native.android.a9216e087452b75b",
       "source": "Connecting…",
       "translated": "Connessione…"
+    },
+    {
+      "id": "native.android.1f198e7aceb8411f",
+      "source": "Speech recognizer unavailable",
+      "translated": "Riconoscimento vocale non disponibile"
     },
     {
       "id": "native.android.24bc808758b925ca",
@@ -20374,6 +20374,16 @@
       "translated": "Impossibile salvare le approvazioni exec. Sono mostrate le ultime impostazioni note; riprova la modifica."
     },
     {
+      "id": "native.apple.b28538e2e444510f",
+      "source": "Exec approvals need migration — run openclaw doctor --fix with OPENCLAW_STATE_DIR set to \\(error.stateDirectoryURL.path).",
+      "translated": "Le approvazioni di esecuzione richiedono una migrazione — esegui openclaw doctor --fix con OPENCLAW_STATE_DIR impostata su \\(error.stateDirectoryURL.path)."
+    },
+    {
+      "id": "native.apple.49e886ab7a093e63",
+      "source": "Exec approvals unavailable. Retry to refresh.",
+      "translated": "Approvazioni di esecuzione non disponibili. Riprova per aggiornare."
+    },
+    {
       "id": "native.apple.1b8ba1cf6f9dfdc9",
       "source": "missing:\\(hash)",
       "translated": "missing:\\(hash)"
@@ -26422,6 +26432,11 @@
       "id": "native.apple.6fbcf8a03da3315a",
       "source": "Surfacing",
       "translated": "Emersione"
+    },
+    {
+      "id": "native.apple.286932b5ea17b3f8",
+      "source": "1 second",
+      "translated": "1 secondo"
     },
     {
       "id": "native.apple.578503dfeef25502",

--- a/apps/.i18n/native/ja-JP.json
+++ b/apps/.i18n/native/ja-JP.json
@@ -8399,6 +8399,11 @@
       "translated": "他$count件のワーカー"
     },
     {
+      "id": "native.android.c32ff602fa622e4b",
+      "source": "Done in $duration",
+      "translated": "$duration で完了"
+    },
+    {
       "id": "native.android.c2dc3a65302976c0",
       "source": "1 token",
       "translated": "1トークン"
@@ -8407,11 +8412,6 @@
       "id": "native.android.e7059e3a756908c4",
       "source": "$count tokens",
       "translated": "$countトークン"
-    },
-    {
-      "id": "native.android.c32ff602fa622e4b",
-      "source": "Done in $duration",
-      "translated": "$duration で完了"
     },
     {
       "id": "native.android.d2797e7488fe5021",
@@ -8759,11 +8759,6 @@
       "translated": "聞き取り中"
     },
     {
-      "id": "native.android.1f198e7aceb8411f",
-      "source": "Speech recognizer unavailable",
-      "translated": "音声認識を利用できません"
-    },
-    {
       "id": "native.android.8532cc9537b69224",
       "source": "Start failed: $message",
       "translated": "開始に失敗しました: $message"
@@ -8772,6 +8767,11 @@
       "id": "native.android.a9216e087452b75b",
       "source": "Connecting…",
       "translated": "接続中…"
+    },
+    {
+      "id": "native.android.1f198e7aceb8411f",
+      "source": "Speech recognizer unavailable",
+      "translated": "音声認識を利用できません"
     },
     {
       "id": "native.android.24bc808758b925ca",
@@ -20374,6 +20374,16 @@
       "translated": "exec承認を保存できませんでした。最後に確認された設定を表示しています。変更をやり直してください。"
     },
     {
+      "id": "native.apple.b28538e2e444510f",
+      "source": "Exec approvals need migration — run openclaw doctor --fix with OPENCLAW_STATE_DIR set to \\(error.stateDirectoryURL.path).",
+      "translated": "実行の承認を移行する必要があります — OPENCLAW_STATE_DIR を \\(error.stateDirectoryURL.path) に設定して openclaw doctor --fix を実行してください。"
+    },
+    {
+      "id": "native.apple.49e886ab7a093e63",
+      "source": "Exec approvals unavailable. Retry to refresh.",
+      "translated": "実行の承認を利用できません。再試行して更新してください。"
+    },
+    {
       "id": "native.apple.1b8ba1cf6f9dfdc9",
       "source": "missing:\\(hash)",
       "translated": "missing:\\(hash)"
@@ -26422,6 +26432,11 @@
       "id": "native.apple.6fbcf8a03da3315a",
       "source": "Surfacing",
       "translated": "浮上中"
+    },
+    {
+      "id": "native.apple.286932b5ea17b3f8",
+      "source": "1 second",
+      "translated": "1秒"
     },
     {
       "id": "native.apple.578503dfeef25502",

--- a/apps/.i18n/native/ko.json
+++ b/apps/.i18n/native/ko.json
@@ -8399,6 +8399,11 @@
       "translated": "$count개 더 많은 워커"
     },
     {
+      "id": "native.android.c32ff602fa622e4b",
+      "source": "Done in $duration",
+      "translated": "$duration 만에 완료"
+    },
+    {
       "id": "native.android.c2dc3a65302976c0",
       "source": "1 token",
       "translated": "토큰 1개"
@@ -8407,11 +8412,6 @@
       "id": "native.android.e7059e3a756908c4",
       "source": "$count tokens",
       "translated": "토큰 $count개"
-    },
-    {
-      "id": "native.android.c32ff602fa622e4b",
-      "source": "Done in $duration",
-      "translated": "$duration 만에 완료"
     },
     {
       "id": "native.android.d2797e7488fe5021",
@@ -8759,11 +8759,6 @@
       "translated": "듣는 중"
     },
     {
-      "id": "native.android.1f198e7aceb8411f",
-      "source": "Speech recognizer unavailable",
-      "translated": "음성 인식기를 사용할 수 없습니다"
-    },
-    {
       "id": "native.android.8532cc9537b69224",
       "source": "Start failed: $message",
       "translated": "시작 실패: $message"
@@ -8772,6 +8767,11 @@
       "id": "native.android.a9216e087452b75b",
       "source": "Connecting…",
       "translated": "연결 중…"
+    },
+    {
+      "id": "native.android.1f198e7aceb8411f",
+      "source": "Speech recognizer unavailable",
+      "translated": "음성 인식기를 사용할 수 없습니다"
     },
     {
       "id": "native.android.24bc808758b925ca",
@@ -20374,6 +20374,16 @@
       "translated": "실행 승인을 저장할 수 없습니다. 마지막으로 알려진 설정이 표시되어 있으니 변경을 다시 시도하세요."
     },
     {
+      "id": "native.apple.b28538e2e444510f",
+      "source": "Exec approvals need migration — run openclaw doctor --fix with OPENCLAW_STATE_DIR set to \\(error.stateDirectoryURL.path).",
+      "translated": "실행 승인을 마이그레이션해야 합니다 — OPENCLAW_STATE_DIR을 \\(error.stateDirectoryURL.path)(으)로 설정하여 openclaw doctor --fix를 실행하세요."
+    },
+    {
+      "id": "native.apple.49e886ab7a093e63",
+      "source": "Exec approvals unavailable. Retry to refresh.",
+      "translated": "실행 승인을 사용할 수 없습니다. 새로 고치려면 다시 시도하세요."
+    },
+    {
       "id": "native.apple.1b8ba1cf6f9dfdc9",
       "source": "missing:\\(hash)",
       "translated": "missing:\\(hash)"
@@ -26422,6 +26432,11 @@
       "id": "native.apple.6fbcf8a03da3315a",
       "source": "Surfacing",
       "translated": "수면 위로 떠오르는 중"
+    },
+    {
+      "id": "native.apple.286932b5ea17b3f8",
+      "source": "1 second",
+      "translated": "1초"
     },
     {
       "id": "native.apple.578503dfeef25502",

--- a/apps/.i18n/native/nl.json
+++ b/apps/.i18n/native/nl.json
@@ -8399,6 +8399,11 @@
       "translated": "$count extra workers"
     },
     {
+      "id": "native.android.c32ff602fa622e4b",
+      "source": "Done in $duration",
+      "translated": "Klaar in $duration"
+    },
+    {
       "id": "native.android.c2dc3a65302976c0",
       "source": "1 token",
       "translated": "1 token"
@@ -8407,11 +8412,6 @@
       "id": "native.android.e7059e3a756908c4",
       "source": "$count tokens",
       "translated": "$count tokens"
-    },
-    {
-      "id": "native.android.c32ff602fa622e4b",
-      "source": "Done in $duration",
-      "translated": "Klaar in $duration"
     },
     {
       "id": "native.android.d2797e7488fe5021",
@@ -8759,11 +8759,6 @@
       "translated": "Luisteren"
     },
     {
-      "id": "native.android.1f198e7aceb8411f",
-      "source": "Speech recognizer unavailable",
-      "translated": "Spraakherkenning niet beschikbaar"
-    },
-    {
       "id": "native.android.8532cc9537b69224",
       "source": "Start failed: $message",
       "translated": "Starten mislukt: $message"
@@ -8772,6 +8767,11 @@
       "id": "native.android.a9216e087452b75b",
       "source": "Connecting…",
       "translated": "Verbinding maken…"
+    },
+    {
+      "id": "native.android.1f198e7aceb8411f",
+      "source": "Speech recognizer unavailable",
+      "translated": "Spraakherkenning niet beschikbaar"
     },
     {
       "id": "native.android.24bc808758b925ca",
@@ -20374,6 +20374,16 @@
       "translated": "Kan exec-goedkeuringen niet opslaan. De laatst bekende instellingen worden getoond; probeer de wijziging opnieuw."
     },
     {
+      "id": "native.apple.b28538e2e444510f",
+      "source": "Exec approvals need migration — run openclaw doctor --fix with OPENCLAW_STATE_DIR set to \\(error.stateDirectoryURL.path).",
+      "translated": "Uitvoeringsgoedkeuringen moeten worden gemigreerd — voer openclaw doctor --fix uit met OPENCLAW_STATE_DIR ingesteld op \\(error.stateDirectoryURL.path)."
+    },
+    {
+      "id": "native.apple.49e886ab7a093e63",
+      "source": "Exec approvals unavailable. Retry to refresh.",
+      "translated": "Uitvoeringsgoedkeuringen zijn niet beschikbaar. Probeer opnieuw om te vernieuwen."
+    },
+    {
       "id": "native.apple.1b8ba1cf6f9dfdc9",
       "source": "missing:\\(hash)",
       "translated": "missing:\\(hash)"
@@ -26422,6 +26432,11 @@
       "id": "native.apple.6fbcf8a03da3315a",
       "source": "Surfacing",
       "translated": "Bovenkomen"
+    },
+    {
+      "id": "native.apple.286932b5ea17b3f8",
+      "source": "1 second",
+      "translated": "1 seconde"
     },
     {
       "id": "native.apple.578503dfeef25502",

--- a/apps/.i18n/native/pl.json
+++ b/apps/.i18n/native/pl.json
@@ -8399,6 +8399,11 @@
       "translated": "$count więcej pracowników"
     },
     {
+      "id": "native.android.c32ff602fa622e4b",
+      "source": "Done in $duration",
+      "translated": "Ukończono w $duration"
+    },
+    {
       "id": "native.android.c2dc3a65302976c0",
       "source": "1 token",
       "translated": "1 token"
@@ -8407,11 +8412,6 @@
       "id": "native.android.e7059e3a756908c4",
       "source": "$count tokens",
       "translated": "$count tokenów"
-    },
-    {
-      "id": "native.android.c32ff602fa622e4b",
-      "source": "Done in $duration",
-      "translated": "Ukończono w $duration"
     },
     {
       "id": "native.android.d2797e7488fe5021",
@@ -8759,11 +8759,6 @@
       "translated": "Nasłuchiwanie"
     },
     {
-      "id": "native.android.1f198e7aceb8411f",
-      "source": "Speech recognizer unavailable",
-      "translated": "Rozpoznawanie mowy jest niedostępne"
-    },
-    {
       "id": "native.android.8532cc9537b69224",
       "source": "Start failed: $message",
       "translated": "Uruchomienie nie powiodło się: $message"
@@ -8772,6 +8767,11 @@
       "id": "native.android.a9216e087452b75b",
       "source": "Connecting…",
       "translated": "Łączenie…"
+    },
+    {
+      "id": "native.android.1f198e7aceb8411f",
+      "source": "Speech recognizer unavailable",
+      "translated": "Rozpoznawanie mowy jest niedostępne"
     },
     {
       "id": "native.android.24bc808758b925ca",
@@ -20374,6 +20374,16 @@
       "translated": "Nie udało się zapisać zatwierdzeń exec. Wyświetlono ostatnie znane ustawienia; ponów zmianę."
     },
     {
+      "id": "native.apple.b28538e2e444510f",
+      "source": "Exec approvals need migration — run openclaw doctor --fix with OPENCLAW_STATE_DIR set to \\(error.stateDirectoryURL.path).",
+      "translated": "Zatwierdzenia wykonywania wymagają migracji — uruchom openclaw doctor --fix ze zmienną OPENCLAW_STATE_DIR ustawioną na \\(error.stateDirectoryURL.path)."
+    },
+    {
+      "id": "native.apple.49e886ab7a093e63",
+      "source": "Exec approvals unavailable. Retry to refresh.",
+      "translated": "Zatwierdzenia wykonywania są niedostępne. Ponów próbę, aby odświeżyć."
+    },
+    {
       "id": "native.apple.1b8ba1cf6f9dfdc9",
       "source": "missing:\\(hash)",
       "translated": "missing:\\(hash)"
@@ -26422,6 +26432,11 @@
       "id": "native.apple.6fbcf8a03da3315a",
       "source": "Surfacing",
       "translated": "Wynurzanie"
+    },
+    {
+      "id": "native.apple.286932b5ea17b3f8",
+      "source": "1 second",
+      "translated": "1 sekunda"
     },
     {
       "id": "native.apple.578503dfeef25502",

--- a/apps/.i18n/native/pt-BR.json
+++ b/apps/.i18n/native/pt-BR.json
@@ -8399,6 +8399,11 @@
       "translated": "Mais $count workers"
     },
     {
+      "id": "native.android.c32ff602fa622e4b",
+      "source": "Done in $duration",
+      "translated": "Concluído em $duration"
+    },
+    {
       "id": "native.android.c2dc3a65302976c0",
       "source": "1 token",
       "translated": "1 token"
@@ -8407,11 +8412,6 @@
       "id": "native.android.e7059e3a756908c4",
       "source": "$count tokens",
       "translated": "$count tokens"
-    },
-    {
-      "id": "native.android.c32ff602fa622e4b",
-      "source": "Done in $duration",
-      "translated": "Concluído em $duration"
     },
     {
       "id": "native.android.d2797e7488fe5021",
@@ -8759,11 +8759,6 @@
       "translated": "Ouvindo"
     },
     {
-      "id": "native.android.1f198e7aceb8411f",
-      "source": "Speech recognizer unavailable",
-      "translated": "Reconhecimento de fala indisponível"
-    },
-    {
       "id": "native.android.8532cc9537b69224",
       "source": "Start failed: $message",
       "translated": "Falha ao iniciar: $message"
@@ -8772,6 +8767,11 @@
       "id": "native.android.a9216e087452b75b",
       "source": "Connecting…",
       "translated": "Conectando…"
+    },
+    {
+      "id": "native.android.1f198e7aceb8411f",
+      "source": "Speech recognizer unavailable",
+      "translated": "Reconhecimento de fala indisponível"
     },
     {
       "id": "native.android.24bc808758b925ca",
@@ -20374,6 +20374,16 @@
       "translated": "Não foi possível salvar as aprovações de execução. As últimas configurações conhecidas são exibidas; tente a alteração novamente."
     },
     {
+      "id": "native.apple.b28538e2e444510f",
+      "source": "Exec approvals need migration — run openclaw doctor --fix with OPENCLAW_STATE_DIR set to \\(error.stateDirectoryURL.path).",
+      "translated": "As aprovações de execução precisam de migração — execute openclaw doctor --fix com OPENCLAW_STATE_DIR definido como \\(error.stateDirectoryURL.path)."
+    },
+    {
+      "id": "native.apple.49e886ab7a093e63",
+      "source": "Exec approvals unavailable. Retry to refresh.",
+      "translated": "As aprovações de execução estão indisponíveis. Tente novamente para atualizar."
+    },
+    {
       "id": "native.apple.1b8ba1cf6f9dfdc9",
       "source": "missing:\\(hash)",
       "translated": "missing:\\(hash)"
@@ -26422,6 +26432,11 @@
       "id": "native.apple.6fbcf8a03da3315a",
       "source": "Surfacing",
       "translated": "Emergindo"
+    },
+    {
+      "id": "native.apple.286932b5ea17b3f8",
+      "source": "1 second",
+      "translated": "1 segundo"
     },
     {
       "id": "native.apple.578503dfeef25502",

--- a/apps/.i18n/native/ru.json
+++ b/apps/.i18n/native/ru.json
@@ -8399,6 +8399,11 @@
       "translated": "Ещё $count воркеров"
     },
     {
+      "id": "native.android.c32ff602fa622e4b",
+      "source": "Done in $duration",
+      "translated": "Готово за $duration"
+    },
+    {
       "id": "native.android.c2dc3a65302976c0",
       "source": "1 token",
       "translated": "1 токен"
@@ -8407,11 +8412,6 @@
       "id": "native.android.e7059e3a756908c4",
       "source": "$count tokens",
       "translated": "$count токенов"
-    },
-    {
-      "id": "native.android.c32ff602fa622e4b",
-      "source": "Done in $duration",
-      "translated": "Готово за $duration"
     },
     {
       "id": "native.android.d2797e7488fe5021",
@@ -8759,11 +8759,6 @@
       "translated": "Идёт прослушивание"
     },
     {
-      "id": "native.android.1f198e7aceb8411f",
-      "source": "Speech recognizer unavailable",
-      "translated": "Распознавание речи недоступно"
-    },
-    {
       "id": "native.android.8532cc9537b69224",
       "source": "Start failed: $message",
       "translated": "Не удалось запустить: $message"
@@ -8772,6 +8767,11 @@
       "id": "native.android.a9216e087452b75b",
       "source": "Connecting…",
       "translated": "Подключение…"
+    },
+    {
+      "id": "native.android.1f198e7aceb8411f",
+      "source": "Speech recognizer unavailable",
+      "translated": "Распознавание речи недоступно"
     },
     {
       "id": "native.android.24bc808758b925ca",
@@ -20374,6 +20374,16 @@
       "translated": "Не удалось сохранить одобрения выполнения. Показаны последние известные настройки; повторите изменение."
     },
     {
+      "id": "native.apple.b28538e2e444510f",
+      "source": "Exec approvals need migration — run openclaw doctor --fix with OPENCLAW_STATE_DIR set to \\(error.stateDirectoryURL.path).",
+      "translated": "Требуется миграция подтверждений выполнения — запустите openclaw doctor --fix, задав для OPENCLAW_STATE_DIR значение \\(error.stateDirectoryURL.path)."
+    },
+    {
+      "id": "native.apple.49e886ab7a093e63",
+      "source": "Exec approvals unavailable. Retry to refresh.",
+      "translated": "Подтверждения выполнения недоступны. Повторите попытку, чтобы обновить."
+    },
+    {
       "id": "native.apple.1b8ba1cf6f9dfdc9",
       "source": "missing:\\(hash)",
       "translated": "missing:\\(hash)"
@@ -26422,6 +26432,11 @@
       "id": "native.apple.6fbcf8a03da3315a",
       "source": "Surfacing",
       "translated": "Всплываем"
+    },
+    {
+      "id": "native.apple.286932b5ea17b3f8",
+      "source": "1 second",
+      "translated": "1 секунда"
     },
     {
       "id": "native.apple.578503dfeef25502",

--- a/apps/.i18n/native/sv.json
+++ b/apps/.i18n/native/sv.json
@@ -8399,6 +8399,11 @@
       "translated": "$count arbetare till"
     },
     {
+      "id": "native.android.c32ff602fa622e4b",
+      "source": "Done in $duration",
+      "translated": "Klart på $duration"
+    },
+    {
       "id": "native.android.c2dc3a65302976c0",
       "source": "1 token",
       "translated": "1 token"
@@ -8407,11 +8412,6 @@
       "id": "native.android.e7059e3a756908c4",
       "source": "$count tokens",
       "translated": "$count token"
-    },
-    {
-      "id": "native.android.c32ff602fa622e4b",
-      "source": "Done in $duration",
-      "translated": "Klart på $duration"
     },
     {
       "id": "native.android.d2797e7488fe5021",
@@ -8759,11 +8759,6 @@
       "translated": "Lyssnar"
     },
     {
-      "id": "native.android.1f198e7aceb8411f",
-      "source": "Speech recognizer unavailable",
-      "translated": "Taligenkänning är inte tillgänglig"
-    },
-    {
       "id": "native.android.8532cc9537b69224",
       "source": "Start failed: $message",
       "translated": "Det gick inte att starta: $message"
@@ -8772,6 +8767,11 @@
       "id": "native.android.a9216e087452b75b",
       "source": "Connecting…",
       "translated": "Ansluter…"
+    },
+    {
+      "id": "native.android.1f198e7aceb8411f",
+      "source": "Speech recognizer unavailable",
+      "translated": "Taligenkänning är inte tillgänglig"
     },
     {
       "id": "native.android.24bc808758b925ca",
@@ -20374,6 +20374,16 @@
       "translated": "Det gick inte att spara exec-godkännanden. De senast kända inställningarna visas; försök att ändra igen."
     },
     {
+      "id": "native.apple.b28538e2e444510f",
+      "source": "Exec approvals need migration — run openclaw doctor --fix with OPENCLAW_STATE_DIR set to \\(error.stateDirectoryURL.path).",
+      "translated": "Exec-godkännanden behöver migreras — kör openclaw doctor --fix med OPENCLAW_STATE_DIR inställd på \\(error.stateDirectoryURL.path)."
+    },
+    {
+      "id": "native.apple.49e886ab7a093e63",
+      "source": "Exec approvals unavailable. Retry to refresh.",
+      "translated": "Exec-godkännanden är inte tillgängliga. Försök igen för att uppdatera."
+    },
+    {
       "id": "native.apple.1b8ba1cf6f9dfdc9",
       "source": "missing:\\(hash)",
       "translated": "missing:\\(hash)"
@@ -26422,6 +26432,11 @@
       "id": "native.apple.6fbcf8a03da3315a",
       "source": "Surfacing",
       "translated": "Går upp till ytan"
+    },
+    {
+      "id": "native.apple.286932b5ea17b3f8",
+      "source": "1 second",
+      "translated": "1 sekund"
     },
     {
       "id": "native.apple.578503dfeef25502",

--- a/apps/.i18n/native/th.json
+++ b/apps/.i18n/native/th.json
@@ -8399,6 +8399,11 @@
       "translated": "worker อีก $count รายการ"
     },
     {
+      "id": "native.android.c32ff602fa622e4b",
+      "source": "Done in $duration",
+      "translated": "เสร็จใน $duration"
+    },
+    {
       "id": "native.android.c2dc3a65302976c0",
       "source": "1 token",
       "translated": "1 โทเค็น"
@@ -8407,11 +8412,6 @@
       "id": "native.android.e7059e3a756908c4",
       "source": "$count tokens",
       "translated": "$count โทเค็น"
-    },
-    {
-      "id": "native.android.c32ff602fa622e4b",
-      "source": "Done in $duration",
-      "translated": "เสร็จใน $duration"
     },
     {
       "id": "native.android.d2797e7488fe5021",
@@ -8759,11 +8759,6 @@
       "translated": "กำลังฟัง"
     },
     {
-      "id": "native.android.1f198e7aceb8411f",
-      "source": "Speech recognizer unavailable",
-      "translated": "ไม่สามารถใช้ตัวจดจำเสียงพูดได้"
-    },
-    {
       "id": "native.android.8532cc9537b69224",
       "source": "Start failed: $message",
       "translated": "เริ่มไม่สำเร็จ: $message"
@@ -8772,6 +8767,11 @@
       "id": "native.android.a9216e087452b75b",
       "source": "Connecting…",
       "translated": "กำลังเชื่อมต่อ…"
+    },
+    {
+      "id": "native.android.1f198e7aceb8411f",
+      "source": "Speech recognizer unavailable",
+      "translated": "ไม่สามารถใช้ตัวจดจำเสียงพูดได้"
     },
     {
       "id": "native.android.24bc808758b925ca",
@@ -20374,6 +20374,16 @@
       "translated": "ไม่สามารถบันทึกการอนุมัติ exec ได้ กำลังแสดงการตั้งค่าที่ทราบล่าสุด โปรดลองเปลี่ยนแปลงอีกครั้ง"
     },
     {
+      "id": "native.apple.b28538e2e444510f",
+      "source": "Exec approvals need migration — run openclaw doctor --fix with OPENCLAW_STATE_DIR set to \\(error.stateDirectoryURL.path).",
+      "translated": "การอนุมัติ Exec จำเป็นต้องย้ายข้อมูล — เรียกใช้ openclaw doctor --fix โดยตั้งค่า OPENCLAW_STATE_DIR เป็น \\(error.stateDirectoryURL.path)"
+    },
+    {
+      "id": "native.apple.49e886ab7a093e63",
+      "source": "Exec approvals unavailable. Retry to refresh.",
+      "translated": "การอนุมัติ Exec ไม่พร้อมใช้งาน โปรดลองอีกครั้งเพื่อรีเฟรช"
+    },
+    {
       "id": "native.apple.1b8ba1cf6f9dfdc9",
       "source": "missing:\\(hash)",
       "translated": "missing:\\(hash)"
@@ -26422,6 +26432,11 @@
       "id": "native.apple.6fbcf8a03da3315a",
       "source": "Surfacing",
       "translated": "กำลังโผล่ขึ้นสู่ผิวน้ำ"
+    },
+    {
+      "id": "native.apple.286932b5ea17b3f8",
+      "source": "1 second",
+      "translated": "1 วินาที"
     },
     {
       "id": "native.apple.578503dfeef25502",

--- a/apps/.i18n/native/tr.json
+++ b/apps/.i18n/native/tr.json
@@ -8399,6 +8399,11 @@
       "translated": "$count çalışan daha"
     },
     {
+      "id": "native.android.c32ff602fa622e4b",
+      "source": "Done in $duration",
+      "translated": "$duration içinde tamamlandı"
+    },
+    {
       "id": "native.android.c2dc3a65302976c0",
       "source": "1 token",
       "translated": "1 token"
@@ -8407,11 +8412,6 @@
       "id": "native.android.e7059e3a756908c4",
       "source": "$count tokens",
       "translated": "$count token"
-    },
-    {
-      "id": "native.android.c32ff602fa622e4b",
-      "source": "Done in $duration",
-      "translated": "$duration içinde tamamlandı"
     },
     {
       "id": "native.android.d2797e7488fe5021",
@@ -8759,11 +8759,6 @@
       "translated": "Dinleniyor"
     },
     {
-      "id": "native.android.1f198e7aceb8411f",
-      "source": "Speech recognizer unavailable",
-      "translated": "Konuşma tanıyıcı kullanılamıyor"
-    },
-    {
       "id": "native.android.8532cc9537b69224",
       "source": "Start failed: $message",
       "translated": "Başlatılamadı: $message"
@@ -8772,6 +8767,11 @@
       "id": "native.android.a9216e087452b75b",
       "source": "Connecting…",
       "translated": "Bağlanıyor…"
+    },
+    {
+      "id": "native.android.1f198e7aceb8411f",
+      "source": "Speech recognizer unavailable",
+      "translated": "Konuşma tanıyıcı kullanılamıyor"
     },
     {
       "id": "native.android.24bc808758b925ca",
@@ -20374,6 +20374,16 @@
       "translated": "Exec onayları kaydedilemedi. Bilinen son ayarlar gösteriliyor; değişikliği tekrar deneyin."
     },
     {
+      "id": "native.apple.b28538e2e444510f",
+      "source": "Exec approvals need migration — run openclaw doctor --fix with OPENCLAW_STATE_DIR set to \\(error.stateDirectoryURL.path).",
+      "translated": "Çalıştırma onaylarının taşınması gerekiyor — OPENCLAW_STATE_DIR değerini \\(error.stateDirectoryURL.path) olarak ayarlayıp openclaw doctor --fix komutunu çalıştırın."
+    },
+    {
+      "id": "native.apple.49e886ab7a093e63",
+      "source": "Exec approvals unavailable. Retry to refresh.",
+      "translated": "Çalıştırma onayları kullanılamıyor. Yenilemek için tekrar deneyin."
+    },
+    {
       "id": "native.apple.1b8ba1cf6f9dfdc9",
       "source": "missing:\\(hash)",
       "translated": "missing:\\(hash)"
@@ -26422,6 +26432,11 @@
       "id": "native.apple.6fbcf8a03da3315a",
       "source": "Surfacing",
       "translated": "Yüzeye çıkılıyor"
+    },
+    {
+      "id": "native.apple.286932b5ea17b3f8",
+      "source": "1 second",
+      "translated": "1 saniye"
     },
     {
       "id": "native.apple.578503dfeef25502",

--- a/apps/.i18n/native/uk.json
+++ b/apps/.i18n/native/uk.json
@@ -8399,6 +8399,11 @@
       "translated": "Ще $count воркерів"
     },
     {
+      "id": "native.android.c32ff602fa622e4b",
+      "source": "Done in $duration",
+      "translated": "Виконано за $duration"
+    },
+    {
       "id": "native.android.c2dc3a65302976c0",
       "source": "1 token",
       "translated": "1 токен"
@@ -8407,11 +8412,6 @@
       "id": "native.android.e7059e3a756908c4",
       "source": "$count tokens",
       "translated": "$count токенів"
-    },
-    {
-      "id": "native.android.c32ff602fa622e4b",
-      "source": "Done in $duration",
-      "translated": "Виконано за $duration"
     },
     {
       "id": "native.android.d2797e7488fe5021",
@@ -8759,11 +8759,6 @@
       "translated": "Прослуховування"
     },
     {
-      "id": "native.android.1f198e7aceb8411f",
-      "source": "Speech recognizer unavailable",
-      "translated": "Розпізнавання мовлення недоступне"
-    },
-    {
       "id": "native.android.8532cc9537b69224",
       "source": "Start failed: $message",
       "translated": "Не вдалося запустити: $message"
@@ -8772,6 +8767,11 @@
       "id": "native.android.a9216e087452b75b",
       "source": "Connecting…",
       "translated": "Підключення…"
+    },
+    {
+      "id": "native.android.1f198e7aceb8411f",
+      "source": "Speech recognizer unavailable",
+      "translated": "Розпізнавання мовлення недоступне"
     },
     {
       "id": "native.android.24bc808758b925ca",
@@ -20374,6 +20374,16 @@
       "translated": "Не вдалося зберегти дозволи на виконання. Показано останні відомі налаштування; повторіть зміну."
     },
     {
+      "id": "native.apple.b28538e2e444510f",
+      "source": "Exec approvals need migration — run openclaw doctor --fix with OPENCLAW_STATE_DIR set to \\(error.stateDirectoryURL.path).",
+      "translated": "Схвалення виконання потребують міграції — запустіть openclaw doctor --fix зі значенням OPENCLAW_STATE_DIR, установленим на \\(error.stateDirectoryURL.path)."
+    },
+    {
+      "id": "native.apple.49e886ab7a093e63",
+      "source": "Exec approvals unavailable. Retry to refresh.",
+      "translated": "Схвалення виконання недоступні. Повторіть спробу, щоб оновити."
+    },
+    {
       "id": "native.apple.1b8ba1cf6f9dfdc9",
       "source": "missing:\\(hash)",
       "translated": "missing:\\(hash)"
@@ -26422,6 +26432,11 @@
       "id": "native.apple.6fbcf8a03da3315a",
       "source": "Surfacing",
       "translated": "Виринання"
+    },
+    {
+      "id": "native.apple.286932b5ea17b3f8",
+      "source": "1 second",
+      "translated": "1 секунда"
     },
     {
       "id": "native.apple.578503dfeef25502",

--- a/apps/.i18n/native/vi.json
+++ b/apps/.i18n/native/vi.json
@@ -8399,6 +8399,11 @@
       "translated": "Thêm $count worker"
     },
     {
+      "id": "native.android.c32ff602fa622e4b",
+      "source": "Done in $duration",
+      "translated": "Hoàn tất sau $duration"
+    },
+    {
       "id": "native.android.c2dc3a65302976c0",
       "source": "1 token",
       "translated": "1 token"
@@ -8407,11 +8412,6 @@
       "id": "native.android.e7059e3a756908c4",
       "source": "$count tokens",
       "translated": "$count token"
-    },
-    {
-      "id": "native.android.c32ff602fa622e4b",
-      "source": "Done in $duration",
-      "translated": "Hoàn tất sau $duration"
     },
     {
       "id": "native.android.d2797e7488fe5021",
@@ -8759,11 +8759,6 @@
       "translated": "Đang nghe"
     },
     {
-      "id": "native.android.1f198e7aceb8411f",
-      "source": "Speech recognizer unavailable",
-      "translated": "Trình nhận dạng giọng nói không khả dụng"
-    },
-    {
       "id": "native.android.8532cc9537b69224",
       "source": "Start failed: $message",
       "translated": "Khởi động không thành công: $message"
@@ -8772,6 +8767,11 @@
       "id": "native.android.a9216e087452b75b",
       "source": "Connecting…",
       "translated": "Đang kết nối…"
+    },
+    {
+      "id": "native.android.1f198e7aceb8411f",
+      "source": "Speech recognizer unavailable",
+      "translated": "Trình nhận dạng giọng nói không khả dụng"
     },
     {
       "id": "native.android.24bc808758b925ca",
@@ -20374,6 +20374,16 @@
       "translated": "Không thể lưu phê duyệt thực thi. Hiển thị các cài đặt đã biết gần nhất; hãy thử lại thay đổi."
     },
     {
+      "id": "native.apple.b28538e2e444510f",
+      "source": "Exec approvals need migration — run openclaw doctor --fix with OPENCLAW_STATE_DIR set to \\(error.stateDirectoryURL.path).",
+      "translated": "Các phê duyệt thực thi cần được di chuyển — chạy openclaw doctor --fix với OPENCLAW_STATE_DIR được đặt thành \\(error.stateDirectoryURL.path)."
+    },
+    {
+      "id": "native.apple.49e886ab7a093e63",
+      "source": "Exec approvals unavailable. Retry to refresh.",
+      "translated": "Các phê duyệt thực thi không khả dụng. Thử lại để làm mới."
+    },
+    {
       "id": "native.apple.1b8ba1cf6f9dfdc9",
       "source": "missing:\\(hash)",
       "translated": "missing:\\(hash)"
@@ -26422,6 +26432,11 @@
       "id": "native.apple.6fbcf8a03da3315a",
       "source": "Surfacing",
       "translated": "Đang nổi lên"
+    },
+    {
+      "id": "native.apple.286932b5ea17b3f8",
+      "source": "1 second",
+      "translated": "1 giây"
     },
     {
       "id": "native.apple.578503dfeef25502",

--- a/apps/.i18n/native/zh-CN.json
+++ b/apps/.i18n/native/zh-CN.json
@@ -8399,6 +8399,11 @@
       "translated": "还有 $count 个 worker"
     },
     {
+      "id": "native.android.c32ff602fa622e4b",
+      "source": "Done in $duration",
+      "translated": "已完成，用时 $duration"
+    },
+    {
       "id": "native.android.c2dc3a65302976c0",
       "source": "1 token",
       "translated": "1 个 token"
@@ -8407,11 +8412,6 @@
       "id": "native.android.e7059e3a756908c4",
       "source": "$count tokens",
       "translated": "$count 个 token"
-    },
-    {
-      "id": "native.android.c32ff602fa622e4b",
-      "source": "Done in $duration",
-      "translated": "已完成，用时 $duration"
     },
     {
       "id": "native.android.d2797e7488fe5021",
@@ -8759,11 +8759,6 @@
       "translated": "正在聆听"
     },
     {
-      "id": "native.android.1f198e7aceb8411f",
-      "source": "Speech recognizer unavailable",
-      "translated": "语音识别器不可用"
-    },
-    {
       "id": "native.android.8532cc9537b69224",
       "source": "Start failed: $message",
       "translated": "启动失败：$message"
@@ -8772,6 +8767,11 @@
       "id": "native.android.a9216e087452b75b",
       "source": "Connecting…",
       "translated": "正在连接…"
+    },
+    {
+      "id": "native.android.1f198e7aceb8411f",
+      "source": "Speech recognizer unavailable",
+      "translated": "语音识别器不可用"
     },
     {
       "id": "native.android.24bc808758b925ca",
@@ -20374,6 +20374,16 @@
       "translated": "无法保存执行审批。已显示最后已知的设置；请重试更改。"
     },
     {
+      "id": "native.apple.b28538e2e444510f",
+      "source": "Exec approvals need migration — run openclaw doctor --fix with OPENCLAW_STATE_DIR set to \\(error.stateDirectoryURL.path).",
+      "translated": "执行审批需要迁移 — 请在将 OPENCLAW_STATE_DIR 设置为 \\(error.stateDirectoryURL.path) 后运行 openclaw doctor --fix。"
+    },
+    {
+      "id": "native.apple.49e886ab7a093e63",
+      "source": "Exec approvals unavailable. Retry to refresh.",
+      "translated": "执行审批不可用。请重试以刷新。"
+    },
+    {
       "id": "native.apple.1b8ba1cf6f9dfdc9",
       "source": "missing:\\(hash)",
       "translated": "missing:\\(hash)"
@@ -26422,6 +26432,11 @@
       "id": "native.apple.6fbcf8a03da3315a",
       "source": "Surfacing",
       "translated": "浮出水面中"
+    },
+    {
+      "id": "native.apple.286932b5ea17b3f8",
+      "source": "1 second",
+      "translated": "1 秒"
     },
     {
       "id": "native.apple.578503dfeef25502",

--- a/apps/.i18n/native/zh-TW.json
+++ b/apps/.i18n/native/zh-TW.json
@@ -8399,6 +8399,11 @@
       "translated": "另外 $count 個 worker"
     },
     {
+      "id": "native.android.c32ff602fa622e4b",
+      "source": "Done in $duration",
+      "translated": "在 $duration 內完成"
+    },
+    {
       "id": "native.android.c2dc3a65302976c0",
       "source": "1 token",
       "translated": "1 個權杖"
@@ -8407,11 +8412,6 @@
       "id": "native.android.e7059e3a756908c4",
       "source": "$count tokens",
       "translated": "$count 個權杖"
-    },
-    {
-      "id": "native.android.c32ff602fa622e4b",
-      "source": "Done in $duration",
-      "translated": "在 $duration 內完成"
     },
     {
       "id": "native.android.d2797e7488fe5021",
@@ -8759,11 +8759,6 @@
       "translated": "正在聆聽"
     },
     {
-      "id": "native.android.1f198e7aceb8411f",
-      "source": "Speech recognizer unavailable",
-      "translated": "語音辨識器無法使用"
-    },
-    {
       "id": "native.android.8532cc9537b69224",
       "source": "Start failed: $message",
       "translated": "啟動失敗：$message"
@@ -8772,6 +8767,11 @@
       "id": "native.android.a9216e087452b75b",
       "source": "Connecting…",
       "translated": "正在連線…"
+    },
+    {
+      "id": "native.android.1f198e7aceb8411f",
+      "source": "Speech recognizer unavailable",
+      "translated": "語音辨識器無法使用"
     },
     {
       "id": "native.android.24bc808758b925ca",
@@ -20374,6 +20374,16 @@
       "translated": "無法儲存 exec 核准。顯示的是最後已知的設定；請重試變更。"
     },
     {
+      "id": "native.apple.b28538e2e444510f",
+      "source": "Exec approvals need migration — run openclaw doctor --fix with OPENCLAW_STATE_DIR set to \\(error.stateDirectoryURL.path).",
+      "translated": "執行核准需要遷移 — 請執行 openclaw doctor --fix，並將 OPENCLAW_STATE_DIR 設為 \\(error.stateDirectoryURL.path)。"
+    },
+    {
+      "id": "native.apple.49e886ab7a093e63",
+      "source": "Exec approvals unavailable. Retry to refresh.",
+      "translated": "執行核准目前無法使用。請重試以重新整理。"
+    },
+    {
       "id": "native.apple.1b8ba1cf6f9dfdc9",
       "source": "missing:\\(hash)",
       "translated": "missing:\\(hash)"
@@ -26422,6 +26432,11 @@
       "id": "native.apple.6fbcf8a03da3315a",
       "source": "Surfacing",
       "translated": "浮出水面中"
+    },
+    {
+      "id": "native.apple.286932b5ea17b3f8",
+      "source": "1 second",
+      "translated": "1 秒"
     },
     {
       "id": "native.apple.578503dfeef25502",

--- a/apps/ios/Resources/Localizable.xcstrings
+++ b/apps/ios/Resources/Localizable.xcstrings
@@ -7209,6 +7209,142 @@
         }
       }
     },
+    "1 second": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1 second"
+          }
+        },
+        "zh-CN": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1 秒"
+          }
+        },
+        "zh-TW": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1 秒"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1 segundo"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1 Sekunde"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1 segundo"
+          }
+        },
+        "ja-JP": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1秒"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1초"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1 seconde"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1 सेकंड"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ثانية واحدة"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1 secondo"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1 saniye"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1 секунда"
+          }
+        },
+        "id": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1 detik"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1 sekunda"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1 วินาที"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1 giây"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1 seconde"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "۱ ثانیه"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1 секунда"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1 sekund"
+          }
+        }
+      }
+    },
     "1 token": {
       "localizations": {
         "en": {

--- a/apps/macos/Sources/OpenClaw/Resources/Localizable.xcstrings
+++ b/apps/macos/Sources/OpenClaw/Resources/Localizable.xcstrings
@@ -2041,6 +2041,142 @@
         }
       }
     },
+    "1 second": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1 second"
+          }
+        },
+        "zh-CN": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1 秒"
+          }
+        },
+        "zh-TW": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1 秒"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1 segundo"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1 Sekunde"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1 segundo"
+          }
+        },
+        "ja-JP": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1秒"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1초"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1 seconde"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1 सेकंड"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ثانية واحدة"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1 secondo"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1 saniye"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1 секунда"
+          }
+        },
+        "id": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1 detik"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1 sekunda"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1 วินาที"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1 giây"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1 seconde"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "۱ ثانیه"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1 секунда"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1 sekund"
+          }
+        }
+      }
+    },
     "1 token": {
       "localizations": {
         "en": {
@@ -47461,6 +47597,142 @@
           "stringUnit": {
             "state": "translated",
             "value": "Exec-godkännanden är inte tillgängliga"
+          }
+        }
+      }
+    },
+    "Exec approvals unavailable. Retry to refresh.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Exec approvals unavailable. Retry to refresh."
+          }
+        },
+        "zh-CN": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "执行审批不可用。请重试以刷新。"
+          }
+        },
+        "zh-TW": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "執行核准目前無法使用。請重試以重新整理。"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "As aprovações de execução estão indisponíveis. Tente novamente para atualizar."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Exec-Genehmigungen sind nicht verfügbar. Versuchen Sie es erneut, um sie zu aktualisieren."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Las aprobaciones de ejecución no están disponibles. Vuelve a intentarlo para actualizar."
+          }
+        },
+        "ja-JP": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "実行の承認を利用できません。再試行して更新してください。"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "실행 승인을 사용할 수 없습니다. 새로 고치려면 다시 시도하세요."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Les approbations d’exécution sont indisponibles. Réessayez pour actualiser."
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Exec अनुमोदन उपलब्ध नहीं हैं। रीफ़्रेश करने के लिए फिर से प्रयास करें।"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "موافقات التنفيذ غير متاحة. أعد المحاولة للتحديث."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Approvazioni di esecuzione non disponibili. Riprova per aggiornare."
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Çalıştırma onayları kullanılamıyor. Yenilemek için tekrar deneyin."
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Схвалення виконання недоступні. Повторіть спробу, щоб оновити."
+          }
+        },
+        "id": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Persetujuan exec tidak tersedia. Coba lagi untuk memuat ulang."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zatwierdzenia wykonywania są niedostępne. Ponów próbę, aby odświeżyć."
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "การอนุมัติ Exec ไม่พร้อมใช้งาน โปรดลองอีกครั้งเพื่อรีเฟรช"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Các phê duyệt thực thi không khả dụng. Thử lại để làm mới."
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Uitvoeringsgoedkeuringen zijn niet beschikbaar. Probeer opnieuw om te vernieuwen."
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تأییدهای اجرا در دسترس نیستند. برای تازه‌سازی دوباره تلاش کنید."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Подтверждения выполнения недоступны. Повторите попытку, чтобы обновить."
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Exec-godkännanden är inte tillgängliga. Försök igen för att uppdatera."
           }
         }
       }


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where the native locale inventory was missing current iOS and macOS strings, causing the native i18n gate to fail on otherwise unrelated pull requests.

## Why This Change Was Made

Regenerates all 21 locale source files and the derived iOS and macOS string catalogs from the current source inventory. Structural interpolation tokens are preserved across every locale.

## User Impact

Native app translations stay aligned with the current source inventory, and unrelated pull requests can pass the native i18n gate again.

## Evidence

- `node --import tsx scripts/native-app-i18n.ts check`
- `node scripts/run-vitest.mjs test/scripts/android-app-i18n.test.ts` (28 passed)
- `git diff --check`
- Generated inventory: 5,345 entries across 21 locales
- Exact-head CI attempt 1 passed `native-i18n`; unrelated `macos-swift` timing test failed. Attempt 2 passed that test, then failed different timing-sensitive Swift tests across retries.
