### PR TITLE
fix(msteams): recognize provider-prefixed target ids

### DIFF
--- a/extensions/msteams/src/channel.test.ts
+++ b/extensions/msteams/src/channel.test.ts
@@ -108,6 +108,26 @@ describe("msteamsPlugin", () => {
     expect(looksLikeId?.("a:1bfPersonalChat")).toBe(true);
     expect(looksLikeId?.("user:Jane Doe")).toBe(false);
   });
+
+  it("recognizes provider-prefixed explicit targets without claiming display names", () => {
+    const messaging = msteamsPlugin.messaging;
+    const aadUserId = "40a1a0ed-4ff2-4164-a219-55518990c197";
+
+    expect(
+      ["teams", "msteams"].map((provider) => {
+        const target = `${provider}:user:${aadUserId}`;
+        return {
+          explicit: messaging?.targetResolver?.looksLikeId?.(target),
+          normalized: messaging?.normalizeTarget?.(target),
+        };
+      }),
+    ).toEqual([
+      { explicit: true, normalized: `user:${aadUserId}` },
+      { explicit: true, normalized: `user:${aadUserId}` },
+    ]);
+    expect(messaging?.targetResolver?.looksLikeId?.("teams:user:Jane Doe")).toBe(false);
+    expect(messaging?.targetResolver?.looksLikeId?.("msteams:user:Jane Doe")).toBe(false);
+  });
 });
 
 describe("msteams config schema", () => {

--- a/extensions/msteams/src/resolve-allowlist.test.ts
+++ b/extensions/msteams/src/resolve-allowlist.test.ts
@@ -520,12 +520,9 @@ describe("looksLikeMSTeamsTargetId", () => {
     "Product Team/Roadmap",
     "Engineering",
     "hello",
-  ])(
-    "rejects non-id inputs (%s)",
-    (raw) => {
-      expect(looksLikeMSTeamsTargetId(raw)).toBe(false);
-    },
-  );
+  ])("rejects non-id inputs (%s)", (raw) => {
+    expect(looksLikeMSTeamsTargetId(raw)).toBe(false);
+  });
 
   it("normalizes leading/trailing whitespace before classifying", () => {
     expect(looksLikeMSTeamsTargetId("  19:abc@thread.tacv2  ")).toBe(true);

--- a/extensions/msteams/src/resolve-allowlist.test.ts
+++ b/extensions/msteams/src/resolve-allowlist.test.ts
@@ -500,7 +500,27 @@ describe("looksLikeMSTeamsTargetId", () => {
     expect(looksLikeMSTeamsTargetId("user:40a1a0ed-4ff2-4164-a219-55518990c197")).toBe(true);
   });
 
-  it.each(["", "   ", "user:John Smith", "Product Team/Roadmap", "Engineering", "hello"])(
+  it.each([
+    "teams:user:40a1a0ed-4ff2-4164-a219-55518990c197",
+    "msteams:user:40a1a0ed-4ff2-4164-a219-55518990c197",
+    "TEAMS:conversation:19:abc@thread.tacv2",
+    "msteams:19:abc@thread.tacv2",
+    "teams:29:1a2b3c4d5e6f",
+    "  teams:user:40a1a0ed-4ff2-4164-a219-55518990c197  ",
+  ])("accepts provider-prefixed explicit ids (%s)", (raw) => {
+    expect(looksLikeMSTeamsTargetId(raw)).toBe(true);
+  });
+
+  it.each([
+    "",
+    "   ",
+    "user:John Smith",
+    "teams:user:John Smith",
+    "msteams:user:John Smith",
+    "Product Team/Roadmap",
+    "Engineering",
+    "hello",
+  ])(
     "rejects non-id inputs (%s)",
     (raw) => {
       expect(looksLikeMSTeamsTargetId(raw)).toBe(false);

--- a/extensions/msteams/src/resolve-allowlist.ts
+++ b/extensions/msteams/src/resolve-allowlist.ts
@@ -183,7 +183,7 @@ export function looksLikeMSTeamsConversationId(raw: string): boolean {
  * can forward verbatim to the channel adapter.
  */
 export function looksLikeMSTeamsTargetId(raw: string): boolean {
-  const trimmed = raw.trim();
+  const trimmed = stripProviderPrefix(raw.trim()).trim();
   if (looksLikeMSTeamsConversationId(trimmed)) {
     return true;
   }


### PR DESCRIPTION
Closes #104381.

## What Problem This Solves

Microsoft Teams outbound targets already accept the `teams:` and `msteams:` channel aliases, but the production target-ID gate tested the original, still-prefixed input instead of the normalized target. As a result, explicit stable destinations such as `teams:user:<aad-object-id>`, `msteams:user:<aad-object-id>`, and `teams:29:<bot-framework-id>` could fall through to directory lookup and fail even though the owner normalizer and outbound session route recognized the same destination.

## Why This Change Was Made

Reuse the existing Microsoft Teams owner-local `stripProviderPrefix` helper before classifying a target. This is a one-line production change; no core API, configuration, Graph request, authentication behavior, or permission changes. Mutable display names such as `teams:user:Jane Doe` continue to require directory resolution and are explicitly covered.

Microsoft documents the distinction between Microsoft Entra/AAD user IDs, bot-scoped Bot Framework user IDs, and stored conversation references in [Send proactive messages in Microsoft Teams](https://learn.microsoft.com/en-us/microsoftteams/platform/bots/how-to/conversations/send-proactive-messages).

## User Impact

Users can send to supported provider-prefixed Teams user and conversation IDs through the actual registered channel messaging resolver without accidental directory lookup. Existing unprefixed IDs, display-name security boundaries, conversation routes, case-insensitive aliases, and whitespace normalization remain intact.

## Evidence

AI-assisted. Tested remotely on Linux through the Blacksmith Testbox using current `main`; no local dependency installation and no real Teams tenant claimed.

Failing production-path proof before the one-line repair:

```text
node scripts/crabbox-wrapper.mjs run --provider blacksmith-testbox --timing-json -- \
  OPENCLAW_TESTBOX=1 OPENCLAW_TESTBOX_REMOTE_RUN=1 \
  pnpm test extensions/msteams/src/resolve-allowlist.test.ts \
            extensions/msteams/src/channel.test.ts

FAIL msteamsPlugin > recognizes provider-prefixed explicit targets without claiming display names
FAIL accepts provider-prefixed explicit ids (teams:user:<aad-guid>)
FAIL accepts provider-prefixed explicit ids (msteams:user:<aad-guid>)
FAIL accepts provider-prefixed explicit ids (teams:29:<bot-framework-id>)
FAIL accepts provider-prefixed explicit ids (  teams:user:<aad-guid>  )
```

Passing same production-path proof after the one-line repair:

```text
Test Files  2 passed (2)
     Tests  64 passed (64)
exitCode: 0
```

Remote execution: https://github.com/openclaw/openclaw/actions/runs/30424513893. This was a delegated Testbox lease; the wrapper's final `exitCode: 0` and `runStatus: succeeded` are the proof because Blacksmith can mark the backing session step cancelled during normal lease cleanup.

The channel regression invokes the exported `msteamsPlugin.messaging.targetResolver.looksLikeId` and `messaging.normalizeTarget` together for both provider aliases, and proves provider-prefixed display names remain ineligible for direct-ID delivery.
