### PR TITLE
fix(skills): isolate coding-agent Codex auth

### DIFF
--- a/skills/coding-agent/SKILL.md
+++ b/skills/coding-agent/SKILL.md
@@ -40,6 +40,8 @@ Use for background feature builds, PR reviews, large refactors, and issue-to-PR 
 
 - Always launch with `background:true`.
 - Codex and OpenCode: use `pty:true`.
+- Codex: never inherit ambient `CODEX_HOME` or the default `~/.codex`. Use a
+  separately authenticated coding-agent home and scope it to each Codex command.
 - Claude Code: no PTY; use `claude --permission-mode bypassPermissions --print`.
 - Capture a real notification route before spawning.
 - Worker must send completion/failure via `openclaw message send`.
@@ -120,10 +122,32 @@ printf 'prompt file: %s\n' "$PROMPT"
 
 Use `$PROMPT` when launching from the same shell/session. If using a separate tool call, substitute the printed path. The launch forms below are for trusted checkouts only; untrusted contributor refs require the repository's approved sandbox/review workflow.
 
+Before the first Codex worker on a host, prepare a dedicated auth home in the
+foreground. Do not copy `auth.json` or other credentials from ambient
+`~/.codex`; authorize this home separately. Codex scopes both file and keyring
+credentials by `CODEX_HOME`.
+
+```bash
+CODEX_WORKER_HOME="$HOME/.codex-coding-agent"
+mkdir -p "$CODEX_WORKER_HOME"
+if ! env -u CODEX_API_KEY -u CODEX_ACCESS_TOKEN -u OPENAI_API_KEY \
+  CODEX_HOME="$CODEX_WORKER_HOME" codex login status >/dev/null 2>&1; then
+  printf 'Codex coding-agent login required for %s\n' "$CODEX_WORKER_HOME"
+  env -u CODEX_API_KEY -u CODEX_ACCESS_TOKEN -u OPENAI_API_KEY \
+    CODEX_HOME="$CODEX_WORKER_HOME" codex login --device-auth
+fi
+printf 'Codex worker home: %s\n' "$CODEX_WORKER_HOME"
+```
+
+The login is an interactive foreground setup step, not a background worker.
+The launch command repeats the fixed, quoted home and removes ambient Codex and
+OpenAI auth overrides. Never export the worker home into the OpenClaw Gateway
+environment.
+
 Codex:
 
 ```bash
-bash pty:true background:true workdir:/path/isolated-worktree command:"codex exec - < \"$PROMPT\""
+bash pty:true background:true workdir:/path/isolated-worktree command:"env -u CODEX_API_KEY -u CODEX_ACCESS_TOKEN -u OPENAI_API_KEY CODEX_HOME=\"$HOME/.codex-coding-agent\" codex exec - < \"$PROMPT\""
 ```
 
 Claude Code:
@@ -159,7 +183,7 @@ Build X.
 <notification block>
 EOF
 printf 'prompt file: %s\n' "$PROMPT"
-bash pty:true background:true workdir:$SCRATCH command:"codex exec - < \"$PROMPT\""
+bash pty:true background:true workdir:$SCRATCH command:"env -u CODEX_API_KEY -u CODEX_ACCESS_TOKEN -u OPENAI_API_KEY CODEX_HOME=\"$HOME/.codex-coding-agent\" codex exec - < \"$PROMPT\""
 ```
 
 ## Process actions

--- a/src/skills/loading/env-path-guidance.test.ts
+++ b/src/skills/loading/env-path-guidance.test.ts
@@ -50,8 +50,18 @@ const CASES: GuidanceCase[] = [
   },
   {
     file: "skills/coding-agent/SKILL.md",
-    required: ["OPENCLAW_STATE_DIR"],
-    forbidden: ["NEVER start Codex in ~/.openclaw/"],
+    required: [
+      "OPENCLAW_STATE_DIR",
+      "CODEX_WORKER_HOME",
+      'CODEX_HOME="$CODEX_WORKER_HOME" codex login status',
+      "env -u CODEX_API_KEY -u CODEX_ACCESS_TOKEN -u OPENAI_API_KEY",
+    ],
+    forbidden: [
+      "NEVER start Codex in ~/.openclaw/",
+      'command:"codex exec - < \\"$PROMPT\\""',
+      "CODEX_HOME=~/.codex",
+      "CODEX_HOME=/absolute/codex-worker-home",
+    ],
   },
 ];
 
@@ -68,4 +78,14 @@ describe("bundled skill env-path guidance", () => {
       }
     },
   );
+  it("isolates every bundled Codex worker launch from ambient auth", () => {
+    const content = fs.readFileSync(path.join(REPO_ROOT, "skills/coding-agent/SKILL.md"), "utf8");
+    const launches = content.split("\n").filter((line) => line.includes("codex exec -"));
+
+    expect(launches).toHaveLength(2);
+    for (const launch of launches) {
+      expect(launch).toContain("env -u CODEX_API_KEY -u CODEX_ACCESS_TOKEN -u OPENAI_API_KEY");
+      expect(launch).toContain('CODEX_HOME=\\"$HOME/.codex-coding-agent\\"');
+    }
+  });
 });


### PR DESCRIPTION
Closes #109704

## What Problem This Solves

Fixes an issue where the bundled coding-agent launched Codex CLI with the host's ambient auth environment. Users who also authenticated OpenClaw with ChatGPT OAuth could rotate or invalidate the refresh token backing OpenClaw, leaving primary model requests stuck in authentication fallback.

## Why This Change Was Made

Every bundled Codex setup and launch path now uses one separately authenticated coding-agent home, scopes `CODEX_HOME` to the command, and removes ambient `CODEX_API_KEY`, `CODEX_ACCESS_TOKEN`, and `OPENAI_API_KEY` overrides. Worker paths are fixed and quoted, while Claude Code and OpenCode behavior is unchanged.

This keeps OpenClaw's OAuth database and the external Codex worker as separate credential owners without copying refresh tokens or changing provider APIs.

## User Impact

Running a Codex coding worker no longer reuses the default `~/.codex` credential or an inherited gateway API key. First-time users get a foreground `codex login status` preflight and a one-time device login for the isolated worker home.

## Evidence

- Upstream Codex source confirms `CODEX_HOME` owns config/auth resolution and defaults to `~/.codex`: https://github.com/openai/codex/blob/main/codex-rs/utils/home-dir/src/lib.rs#L5-L17
- Upstream file and keyring auth are both scoped by the Codex home path: https://github.com/openai/codex/blob/main/codex-rs/login/src/auth/storage.rs#L150-L151 and https://github.com/openai/codex/blob/main/codex-rs/login/src/auth/storage.rs#L233-L245
- Upstream `codex login status` loads the scoped store: https://github.com/openai/codex/blob/main/codex-rs/cli/src/login.rs#L424-L475
- A live preflight with synthetic ambient auth variables plus the documented `env -u` launch shape returned exit 1 / `Not logged in` for a fresh isolated home, proving no ambient credential satisfied it.
- `node scripts/run-vitest.mjs src/skills/loading/env-path-guidance.test.ts` — 7 tests passed on rebased head `5102b67cdd8d`.
- Blacksmith Testbox `tbx_01kyp4vsarbv3a99bz37yxc4h0` / Actions run https://github.com/openclaw/openclaw/actions/runs/30424617632 — `node scripts/check-changed.mjs` passed.
- Codex autoreview on the exact branch diff: no accepted/actionable findings, confidence 0.96.
