### PR TITLE
fix(telegram): prevent retry checks from silently dropping messages

### DIFF
--- a/extensions/telegram/src/bot-update-tracker.test.ts
+++ b/extensions/telegram/src/bot-update-tracker.test.ts
@@ -437,6 +437,25 @@ describe("createTelegramUpdateTracker", () => {
     });
   });
 
+  it("does not record an update when checking handler dispatch before acceptance", () => {
+    const onSkip = vi.fn();
+    const tracker = createTelegramUpdateTracker({ initialUpdateId: 300, onSkip });
+    const ctx = updateCtx(301);
+
+    expect(tracker.shouldSkipHandlerDispatch(ctx)).toBe(false);
+    expect(tracker.shouldSkipHandlerDispatch(ctx)).toBe(false);
+    expect(onSkip).not.toHaveBeenCalled();
+
+    const accepted = tracker.beginUpdate(ctx);
+    if (!accepted.accepted) {
+      throw new Error("expected read-only skip checks to leave the update retryable");
+    }
+
+    expect(tracker.shouldSkipHandlerDispatch(ctx)).toBe(false);
+    tracker.finishUpdate(accepted.update, { completed: true });
+    expect(tracker.shouldSkipHandlerDispatch(ctx)).toBe(true);
+  });
+
   it("dedupes handler dispatch separately from the accepted watermark", () => {
     const onSkip = vi.fn();
     const tracker = createTelegramUpdateTracker({ initialUpdateId: 300, onSkip });

--- a/extensions/telegram/src/bot-update-tracker.ts
+++ b/extensions/telegram/src/bot-update-tracker.ts
@@ -306,7 +306,7 @@ export function createTelegramUpdateTracker(options: TelegramUpdateTrackerOption
       activeHandledUpdateKeys.set(key, true);
       return false;
     }
-    const skipped = recentUpdates.check(key);
+    const skipped = recentUpdates.peek(key);
     if (skipped) {
       skip(key);
     }


### PR DESCRIPTION
Closes #105192

## What Problem This Solves

Fixes an issue where a Telegram update can be silently dropped after a retry or an early handler check: checking whether a message should be skipped accidentally records that unprocessed update as already delivered.

## Why This Change Was Made

Use the existing documented read-only deduplication-cache operation for a skip query. Leave accepted, active, completed, persisted, and failed update ownership unchanged. This is intentionally limited to the Telegram update tracker and does not include unrelated agent steering or offset-persistence changes.

## User Impact

A real Telegram update remains retryable after any number of pre-delivery skip checks. Duplicate active and successfully completed updates continue to be suppressed.

## Evidence

- Remote Blacksmith Linux proof executes both real createTelegramBot ingress tests and all Telegram update-tracker regressions, including a new end-to-end tracker lifecycle: two read-only pre-acceptance checks, successful subsequent acceptance, actual handler dispatch, completed delivery, and final duplicate suppression.
- The same owned Blacksmith testbox completes the full changed gate: production and test TypeScript checks, targeted lint, formatting, SDK/plugin boundaries, all repository guards, and zero runtime import cycles; lease tbx_01kyp4jn73kpa960pvwdxqa4bz, exitCode=0.
- Fresh source-isolated xhigh autoreview: no actionable findings, correctness 0.97, TruffleHog clean.
- Existing failed-update retry and active-handler deduplication regressions remain passing; no config, provider, SDK, storage, or unrelated steering changes.