### PR TITLE
fix(mcp): recover expired stateful HTTP sessions after restarts

### DIFF
--- a/src/agents/agent-bundle-mcp-runtime.test.ts
+++ b/src/agents/agent-bundle-mcp-runtime.test.ts
@@ -4609,6 +4609,296 @@ process.stdin.on("end", () => {
   );
 
   it(
+    "does not recycle a stateless streamable-http server on HTTP 404",
+    { timeout: 15_000 },
+    async () => {
+      let initializeCount = 0;
+      const callSessionIds: Array<string | undefined> = [];
+      const server = http.createServer((req, res) => {
+        if (req.method === "GET") {
+          res.writeHead(405).end();
+          return;
+        }
+        if (req.method !== "POST") {
+          res.writeHead(405).end();
+          return;
+        }
+
+        let body = "";
+        req.on("data", (chunk: Buffer) => {
+          body += chunk.toString();
+        });
+        req.on("end", () => {
+          const message = JSON.parse(body) as {
+            id?: number | string;
+            method?: string;
+            params?: { protocolVersion?: string };
+          };
+          if (message.method === "notifications/initialized") {
+            res.writeHead(202).end();
+            return;
+          }
+          if (message.method === "tools/call") {
+            const sessionId = req.headers["mcp-session-id"];
+            callSessionIds.push(typeof sessionId === "string" ? sessionId : undefined);
+            res.writeHead(404).end("Session not found");
+            return;
+          }
+
+          res.setHeader("content-type", "application/json");
+          if (message.method === "initialize") {
+            initializeCount += 1;
+            res.writeHead(200).end(
+              JSON.stringify({
+                jsonrpc: "2.0",
+                id: message.id,
+                result: {
+                  protocolVersion: message.params?.protocolVersion ?? "2025-03-26",
+                  capabilities: { tools: {} },
+                  serverInfo: { name: "stateless-404-server", version: "1.0.0" },
+                },
+              }),
+            );
+            return;
+          }
+          if (message.method === "tools/list") {
+            res.writeHead(200).end(
+              JSON.stringify({
+                jsonrpc: "2.0",
+                id: message.id,
+                result: {
+                  tools: [{ name: "probe", description: "probe", inputSchema: { type: "object" } }],
+                },
+              }),
+            );
+            return;
+          }
+          res.writeHead(405).end();
+        });
+      });
+
+      await new Promise<void>((resolve) => {
+        server.listen(0, "127.0.0.1", resolve);
+      });
+      const address = server.address() as { port: number };
+      let runtime: SessionMcpRuntime | undefined;
+
+      try {
+        runtime = await getOrCreateSessionMcpRuntime({
+          sessionId: "session-stateless-streamable-http-404",
+          sessionKey: "agent:test:session-stateless-streamable-http-404",
+          workspaceDir: "/workspace",
+          cfg: {
+            mcp: {
+              servers: {
+                stateless: {
+                  url: `http://127.0.0.1:${address.port}/mcp`,
+                  transport: "streamable-http",
+                },
+              },
+            },
+          },
+        });
+
+        expect((await runtime.getCatalog()).tools).toHaveLength(1);
+        for (let attempt = 0; attempt < 3; attempt += 1) {
+          await expect(runtime.callTool("stateless", "probe", {})).rejects.toThrow(
+            "Session not found",
+          );
+        }
+        await expect(runtime.callTool("stateless", "probe", {})).rejects.toThrow(
+          'bundle-mcp server "stateless" is paused after repeated tool failures',
+        );
+        expect(initializeCount).toBe(1);
+        expect(callSessionIds).toEqual([undefined, undefined, undefined]);
+        expect(runtime.peekCatalog()?.diagnostics).toBeUndefined();
+      } finally {
+        await runtime?.dispose();
+        await new Promise<void>((resolve, reject) => {
+          server.close((error) => (error ? reject(error) : resolve()));
+        });
+      }
+    },
+  );
+
+  it(
+    "reconnects a stateful streamable-http server after its session expires",
+    { timeout: 15_000 },
+    async () => {
+      let activeServerSessionId: string | undefined;
+      let initializeCount = 0;
+      const callAttempts: Array<{ attempt: unknown; sessionId: string | undefined }> = [];
+      const staleTerminations: string[] = [];
+      const invalidAuthHeaders: Array<string | undefined> = [];
+
+      const server = http.createServer((req, res) => {
+        const authHeader = req.headers["x-mcp-recovery"];
+        if (authHeader !== "proof") {
+          invalidAuthHeaders.push(Array.isArray(authHeader) ? authHeader.join(",") : authHeader);
+          res.writeHead(401).end();
+          return;
+        }
+        if (req.method === "GET") {
+          res.writeHead(405).end();
+          return;
+        }
+        if (req.method === "DELETE") {
+          const sessionId = req.headers["mcp-session-id"];
+          if (typeof sessionId === "string" && sessionId !== activeServerSessionId) {
+            staleTerminations.push(sessionId);
+            res.writeHead(404).end("Session not found");
+            return;
+          }
+          res.writeHead(204).end();
+          return;
+        }
+        if (req.method !== "POST") {
+          res.writeHead(405).end();
+          return;
+        }
+
+        let body = "";
+        req.on("data", (chunk: Buffer) => {
+          body += chunk.toString();
+        });
+        req.on("end", () => {
+          const message = JSON.parse(body) as {
+            id?: number | string;
+            method?: string;
+            params?: { arguments?: { attempt?: unknown }; protocolVersion?: string };
+          };
+          if (message.method === "initialize") {
+            initializeCount += 1;
+            activeServerSessionId = `server-session-${initializeCount}`;
+            res.setHeader("mcp-session-id", activeServerSessionId);
+            res.setHeader("content-type", "application/json");
+            res.writeHead(200).end(
+              JSON.stringify({
+                jsonrpc: "2.0",
+                id: message.id,
+                result: {
+                  protocolVersion: message.params?.protocolVersion ?? "2025-03-26",
+                  capabilities: { tools: {} },
+                  serverInfo: { name: "stateful-recovery-server", version: "1.0.0" },
+                },
+              }),
+            );
+            return;
+          }
+
+          const requestSessionId = req.headers["mcp-session-id"];
+          const sessionId = typeof requestSessionId === "string" ? requestSessionId : undefined;
+          if (message.method === "tools/call") {
+            callAttempts.push({ attempt: message.params?.arguments?.attempt, sessionId });
+          }
+          if (!sessionId || sessionId !== activeServerSessionId) {
+            res.writeHead(404).end("Session not found");
+            return;
+          }
+          if (message.method === "notifications/initialized") {
+            res.writeHead(202).end();
+            return;
+          }
+          res.setHeader("mcp-session-id", sessionId);
+          res.setHeader("content-type", "application/json");
+          if (message.method === "tools/list") {
+            res.writeHead(200).end(
+              JSON.stringify({
+                jsonrpc: "2.0",
+                id: message.id,
+                result: {
+                  tools: [{ name: "probe", description: "probe", inputSchema: { type: "object" } }],
+                },
+              }),
+            );
+            return;
+          }
+          if (message.method === "tools/call") {
+            res.writeHead(200).end(
+              JSON.stringify({
+                jsonrpc: "2.0",
+                id: message.id,
+                result: {
+                  content: [{ type: "text", text: `recovered ${sessionId}` }],
+                },
+              }),
+            );
+            return;
+          }
+          res.writeHead(405).end();
+        });
+      });
+
+      await new Promise<void>((resolve) => {
+        server.listen(0, "127.0.0.1", resolve);
+      });
+      const address = server.address() as { port: number };
+      let runtime: SessionMcpRuntime | undefined;
+
+      try {
+        runtime = await getOrCreateSessionMcpRuntime({
+          sessionId: "session-stateful-streamable-http-recovery",
+          sessionKey: "agent:test:session-stateful-streamable-http-recovery",
+          workspaceDir: "/workspace",
+          cfg: {
+            mcp: {
+              servers: {
+                stateful: {
+                  url: `http://127.0.0.1:${address.port}/mcp`,
+                  transport: "streamable-http",
+                  headers: { "x-mcp-recovery": "proof" },
+                },
+              },
+            },
+          },
+        });
+
+        expect((await runtime.getCatalog()).tools).toHaveLength(1);
+        await expect(
+          runtime.callTool("stateful", "probe", { attempt: "before" }),
+        ).resolves.toMatchObject({
+          content: [{ type: "text", text: "recovered server-session-1" }],
+        });
+
+        // Restart invalidates the server-side session without closing the HTTP
+        // transport. A failed mutating request must never be silently replayed.
+        activeServerSessionId = undefined;
+        await expect(runtime.callTool("stateful", "probe", { attempt: "expired" })).rejects.toThrow(
+          "Session not found",
+        );
+        expect(runtime.peekCatalog()?.diagnostics).toEqual([
+          expect.objectContaining({ serverName: "stateful" }),
+        ]);
+
+        await runtime.getCatalog();
+        await waitForPredicate(
+          () => initializeCount === 2 && !runtime?.peekCatalog()?.diagnostics?.length,
+          "stateful MCP server to replace its expired HTTP session",
+          LIST_TOOLS_SERVER_LOG_TIMEOUT_MS,
+        );
+
+        await expect(
+          runtime.callTool("stateful", "probe", { attempt: "after" }),
+        ).resolves.toMatchObject({
+          content: [{ type: "text", text: "recovered server-session-2" }],
+        });
+        expect(callAttempts).toEqual([
+          { attempt: "before", sessionId: "server-session-1" },
+          { attempt: "expired", sessionId: "server-session-1" },
+          { attempt: "after", sessionId: "server-session-2" },
+        ]);
+        expect(staleTerminations).toEqual(["server-session-1"]);
+        expect(invalidAuthHeaders).toEqual([]);
+      } finally {
+        await runtime?.dispose();
+        await new Promise<void>((resolve, reject) => {
+          server.close((error) => (error ? reject(error) : resolve()));
+        });
+      }
+    },
+  );
+
+  it(
     "force-closes streamable-http transport when DELETE hangs past the timeout",
     { timeout: 15_000 },
     async () => {

--- a/src/agents/agent-bundle-mcp-runtime.ts
+++ b/src/agents/agent-bundle-mcp-runtime.ts
@@ -1,6 +1,9 @@
 /** Session-scoped MCP runtime catalog loader and transport lifecycle. */
 import { Client, type ClientOptions } from "@modelcontextprotocol/sdk/client/index.js";
-import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+import {
+  StreamableHTTPClientTransport,
+  StreamableHTTPError,
+} from "@modelcontextprotocol/sdk/client/streamableHttp.js";
 import type { Transport } from "@modelcontextprotocol/sdk/shared/transport.js";
 import {
   ErrorCode,
@@ -587,20 +590,37 @@ export function createSessionMcpRuntime(params: {
       }
       return result;
     } catch (error) {
-      if (tracksFailureBackoff) {
+      // A stateful server uses HTTP 404 to invalidate an expired MCP session.
+      // Reinitialize a fresh client, but never replay a possibly mutating call.
+      const sessionExpired =
+        session.transportType === "streamable-http" &&
+        session.transport instanceof StreamableHTTPClientTransport &&
+        session.transport.sessionId !== undefined &&
+        error instanceof StreamableHTTPError &&
+        error.code === 404;
+      let recycleReason: "expired HTTP session" | "repeated request timeouts" | undefined;
+      if (sessionExpired) {
+        recycleReason = "expired HTTP session";
+      } else if (tracksFailureBackoff) {
         const failures = recordServerToolFailure(serverName, session, nowMs);
         const requestTimedOut =
           error !== null && typeof error === "object" && localRequestTimeouts.has(error);
         if (requestTimedOut && failures && failures >= BUNDLE_MCP_FAILURE_THRESHOLD) {
-          serverBackoff.delete(serverName);
-          scheduleCatalogServerRetry(serverName, "repeated request timeouts");
-          logWarn(`bundle-mcp: recycling server "${serverName}" after repeated timeouts`);
-          void retireSessionIfCurrent(serverName, session).catch((retireError: unknown) => {
-            logWarn(
-              `bundle-mcp: failed to retire timed-out server "${serverName}": ${redactMcpDiagnosticError(retireError)}`,
-            );
-          });
+          recycleReason = "repeated request timeouts";
         }
+      }
+      if (recycleReason) {
+        serverBackoff.delete(serverName);
+        scheduleCatalogServerRetry(serverName, recycleReason);
+        const timedOut = recycleReason === "repeated request timeouts";
+        logWarn(
+          `bundle-mcp: recycling server "${serverName}" after ${timedOut ? "repeated timeouts" : "an expired HTTP session"}`,
+        );
+        void retireSessionIfCurrent(serverName, session).catch((retireError: unknown) => {
+          logWarn(
+            `bundle-mcp: failed to retire ${timedOut ? "timed-out" : "expired-session"} server "${serverName}": ${redactMcpDiagnosticError(retireError)}`,
+          );
+        });
       }
       throw error;
     }


### PR DESCRIPTION
Closes #112540

## What Problem This Solves

Fixes an issue where users with stateful streamable-HTTP MCP servers permanently lost access to their tools after the MCP server restarted. The first tool call returned HTTP 404 `Session not found`, and later calls continued using the expired server session until the OpenClaw gateway was restarted.

## Why This Change Was Made

The pinned MCP SDK distinguishes an expired server-issued session from an ordinary stateless HTTP 404 through `StreamableHTTPClientTransport.sessionId` and `StreamableHTTPError.code`. Reuse the existing session retirement, catalog refresh, and backoff owner only for a genuine expired stateful session. Return the failed tool call to its caller without replaying a possibly mutating operation. Preserve existing stateless-server failure backoff and timeout recovery.

## User Impact

Stateful MCP servers automatically reconnect after their server-side session expires or the server restarts. Configured request headers survive reconnection, healthy normal error handling is preserved, and failed tool calls are never silently repeated.

## Evidence

- Red-before-fix: a real authenticated stateful Node HTTP MCP server reproduces `Session not found` and proves current `main` leaves its stale session cached.
- Green-after-fix: the same real server verifies initialization, first successful tool call, session expiry, failed call exactly once, stale-session DELETE, fresh session initialization, preserved request headers, and successful subsequent tool call.
- A second real stateless HTTP MCP server verifies repeated 404s preserve the existing backoff and do not reconnect or churn sessions.
- Blacksmith Testbox `tbx_01kyp3jt4pvvcwvttb8es9j7zb`: **152/152 passing** across MCP runtime, tool materialization, request boundaries, filtering, HTTP fetch, HTTP transport, and stdio transport.
- Full final `pnpm check:changed`: passed, including core/test typechecks, formatting, lint, dependency and owner-boundary guards, dead-export checks, and runtime import cycles.
- Fresh `gpt-5.6-sol` extra-high-effort autoreview: clean, no accepted or actionable findings.
- Confirmed upstream contract directly against the exact installed `@modelcontextprotocol/sdk@1.30.0` JavaScript and TypeScript declarations.
- AI-assisted; reviewed against the actual SDK, source, sibling behavior, and real HTTP regressions.