### PR TITLE
fix(linux): package media codecs for deb and AppImage

### DIFF
--- a/.github/workflows/linux-app-release.yml
+++ b/.github/workflows/linux-app-release.yml
@@ -93,6 +93,9 @@ jobs:
             build-essential \
             curl \
             file \
+            gstreamer1.0-libav \
+            gstreamer1.0-plugins-bad \
+            gstreamer1.0-plugins-good \
             libayatana-appindicator3-dev \
             librsvg2-dev \
             libssl-dev \

--- a/.github/workflows/linux-app.yml
+++ b/.github/workflows/linux-app.yml
@@ -39,6 +39,9 @@ jobs:
             build-essential \
             curl \
             file \
+            gstreamer1.0-libav \
+            gstreamer1.0-plugins-bad \
+            gstreamer1.0-plugins-good \
             libayatana-appindicator3-dev \
             librsvg2-dev \
             libssl-dev \

--- a/apps/linux/README.md
+++ b/apps/linux/README.md
@@ -14,6 +14,21 @@ sudo apt install libwebkit2gtk-4.1-dev build-essential curl wget file \
 
 Install a current stable Rust toolchain with `rustup`.
 
+## Media codecs
+
+The companion uses the host's GStreamer plugins for audio and video playback.
+WebM/VP9, Opus, Vorbis, and WAV normally work through `plugins-good`.
+H.264/MP4, AAC, and MP3 require the `libav` and/or `plugins-bad` packages.
+The `.deb` declares all three plugin packages as dependencies. For a source
+build or an AppImage, install them explicitly:
+
+```bash
+sudo apt update && sudo apt install gstreamer1.0-libav gstreamer1.0-plugins-good gstreamer1.0-plugins-bad
+```
+
+The AppImage does not bundle GStreamer, so its playback capabilities follow
+the host distribution's installed plugins.
+
 ## Develop and build
 
 The frontend is static HTML, CSS, and JavaScript. It has no package install or build step.

--- a/apps/linux/README.md
+++ b/apps/linux/README.md
@@ -16,18 +16,20 @@ Install a current stable Rust toolchain with `rustup`.
 
 ## Media codecs
 
-The companion uses the host's GStreamer plugins for audio and video playback.
+The companion uses GStreamer plugins for audio and video playback.
 WebM/VP9, Opus, Vorbis, and WAV normally work through `plugins-good`.
 H.264/MP4, AAC, and MP3 require the `libav` and/or `plugins-bad` packages.
-The `.deb` declares all three plugin packages as dependencies. For a source
-build or an AppImage, install them explicitly:
+The `.deb` uses the host's plugins and declares all three packages as
+dependencies. The AppImage bundles the GStreamer media framework and the
+plugins available on its Ubuntu build host. For a source build or when
+rebuilding either Linux bundle, install the packages explicitly:
 
 ```bash
 sudo apt update && sudo apt install gstreamer1.0-libav gstreamer1.0-plugins-good gstreamer1.0-plugins-bad
 ```
 
-The AppImage does not bundle GStreamer, so its playback capabilities follow
-the host distribution's installed plugins.
+The released AppImage therefore carries the codecs installed by the release
+workflow instead of relying on GStreamer packages from the user's system.
 
 ## Develop and build
 

--- a/apps/linux/src-tauri/tauri.conf.json
+++ b/apps/linux/src-tauri/tauri.conf.json
@@ -36,7 +36,7 @@
       }
     ],
     "security": {
-      "csp": "default-src 'self'; script-src 'self'; style-src 'self'; img-src 'self' data: http: https:; connect-src ipc: http://ipc.localhost",
+      "csp": "default-src 'self'; script-src 'self'; style-src 'self'; img-src 'self' data: http: https:; media-src 'self' data: blob: http: https:; connect-src ipc: http://ipc.localhost",
       "capabilities": [
         {
           "identifier": "local-companion",
@@ -95,6 +95,15 @@
     ],
     "resources": {
       "../../../scripts/install-cli.sh": "install-cli.sh"
+    },
+    "linux": {
+      "deb": {
+        "depends": [
+          "gstreamer1.0-libav",
+          "gstreamer1.0-plugins-good",
+          "gstreamer1.0-plugins-bad"
+        ]
+      }
     },
     "macOS": {
       "minimumSystemVersion": "13.0"

--- a/apps/linux/src-tauri/tauri.conf.json
+++ b/apps/linux/src-tauri/tauri.conf.json
@@ -97,6 +97,9 @@
       "../../../scripts/install-cli.sh": "install-cli.sh"
     },
     "linux": {
+      "appimage": {
+        "bundleMediaFramework": true
+      },
       "deb": {
         "depends": [
           "gstreamer1.0-libav",

--- a/docs/docs_map.md
+++ b/docs/docs_map.md
@@ -5416,6 +5416,7 @@ Do not edit it by hand; run `pnpm docs:map:gen`.
 - Route: /platforms/linux
 - Headings:
   - H2: Desktop companion
+  - H3: Media codecs
   - H3: Quick Chat
   - H3: Canvas
   - H2: CLI and SSH alternative

--- a/docs/platforms/linux.md
+++ b/docs/platforms/linux.md
@@ -43,6 +43,21 @@ or mark the AppImage executable and run it directly. The AppImage runtime
 needs FUSE 2 (`sudo apt install libfuse2`, or `libfuse2t64` on Ubuntu 24.04+);
 without it, run the AppImage with `APPIMAGE_EXTRACT_AND_RUN=1`.
 
+### Media codecs
+
+The companion uses the host's GStreamer plugins for audio and video playback.
+WebM/VP9, Opus, Vorbis, and WAV normally work through `plugins-good`.
+H.264/MP4, AAC, and MP3 require the `libav` and/or `plugins-bad` packages.
+The `.deb` declares all three plugin packages as dependencies. For a source
+build or an AppImage, install them explicitly:
+
+```bash
+sudo apt update && sudo apt install gstreamer1.0-libav gstreamer1.0-plugins-good gstreamer1.0-plugins-bad
+```
+
+The AppImage does not bundle GStreamer, so its playback capabilities follow
+the host distribution's installed plugins.
+
 You can also build the same bundles from a source checkout:
 
 ```bash

--- a/docs/platforms/linux.md
+++ b/docs/platforms/linux.md
@@ -45,18 +45,20 @@ without it, run the AppImage with `APPIMAGE_EXTRACT_AND_RUN=1`.
 
 ### Media codecs
 
-The companion uses the host's GStreamer plugins for audio and video playback.
+The companion uses GStreamer plugins for audio and video playback.
 WebM/VP9, Opus, Vorbis, and WAV normally work through `plugins-good`.
 H.264/MP4, AAC, and MP3 require the `libav` and/or `plugins-bad` packages.
-The `.deb` declares all three plugin packages as dependencies. For a source
-build or an AppImage, install them explicitly:
+The `.deb` uses the host's plugins and declares all three packages as
+dependencies. The AppImage bundles the GStreamer media framework and the
+plugins available on its Ubuntu build host. For a source build or when
+rebuilding either Linux bundle, install the packages explicitly:
 
 ```bash
 sudo apt update && sudo apt install gstreamer1.0-libav gstreamer1.0-plugins-good gstreamer1.0-plugins-bad
 ```
 
-The AppImage does not bundle GStreamer, so its playback capabilities follow
-the host distribution's installed plugins.
+The released AppImage therefore carries the codecs installed by the release
+workflow instead of relying on GStreamer packages from the user's system.
 
 You can also build the same bundles from a source checkout:
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Linux companion users could not reliably play common audio and video formats because the packaged app omitted GStreamer codec dependencies, the AppImage did not bundle the media framework, and the shell CSP did not permit media sources.

Part of #115590

## Why This Change Was Made

The Linux packaging now declares the GStreamer plugin sets needed by the Debian package, installs the same codecs in both Linux build workflows, bundles the media framework into the AppImage, and permits local, data, blob, HTTP, and HTTPS media sources. The Linux docs describe the resulting package behavior and source-build requirements.

## User Impact

Linux users installing the Debian package or AppImage can play common WebM, VP9, Opus, Vorbis, WAV, H.264, MP4, AAC, and MP3 media without manually discovering the missing codec packages. Source builders get the exact GStreamer package prerequisites.

## Evidence

- Rebased onto `origin/main` at `be24db5f72a6992273f90f707305f8650643523a`.
- Head: `305042153d85c5679408c64714b45b92a3d1f164`.
- `apps/linux/src-tauri/tauri.conf.json` validates against the official Tauri config schema `https://schema.tauri.app/config/2.11.5`.
- `actionlint .github/workflows/linux-app-release.yml .github/workflows/linux-app.yml` passes.
- `pnpm docs:list` passes.
- `pnpm docs:map:check` passes.
- `git diff --check origin/main...HEAD` passes.
