### PR TITLE
fix(gateway): prevent stalled plugins from blocking shutdown

### DIFF
--- a/src/gateway/server-close.test.ts
+++ b/src/gateway/server-close.test.ts
@@ -1,6 +1,8 @@
 /**
  * Gateway server close lifecycle tests.
  */
+import { spawn } from "node:child_process";
+import { once } from "node:events";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { isAgentRunRestartAbortReason } from "../agents/run-termination.js";
 import type { InternalHookEvent } from "../hooks/internal-hooks.js";
@@ -566,6 +568,64 @@ describe("createGatewayCloseHandler", () => {
         String(message).includes("gateway:shutdown hook timed out after 5000ms"),
       ),
     ).toBe(true);
+  });
+
+  it("cleans up live runtime children when a plugin service never stops", async () => {
+    vi.useFakeTimers();
+    const children = [
+      spawn(process.execPath, ["-e", "setInterval(() => {}, 1000)"], { stdio: "ignore" }),
+      spawn(process.execPath, ["-e", "setInterval(() => {}, 1000)"], { stdio: "ignore" }),
+    ];
+    const exits = children.map((child) => once(child, "exit"));
+    const spawnEvents = children.map((child) => once(child, "spawn"));
+    const disposeSessionMcpRuntimes = vi.fn(async () => {
+      children[0]?.kill("SIGTERM");
+      await exits[0];
+    });
+    const disposeBundleLspRuntimes = vi.fn(async () => {
+      children[1]?.kill("SIGTERM");
+      await exits[1];
+    });
+    const pluginServices = {
+      stop: vi.fn(() => new Promise<void>(() => {})),
+    };
+    const stopChannel = vi.fn(async () => undefined);
+    const deps = createGatewayCloseTestDeps({
+      channelIds: ["discord"],
+      disposeBundleLspRuntimes,
+      disposeSessionMcpRuntimes,
+      pluginServices,
+      stopChannel,
+    });
+
+    try {
+      await Promise.all(spawnEvents);
+      const close = createGatewayCloseHandler(deps);
+      const closePromise = close({ reason: "SIGINT" });
+
+      await vi.advanceTimersByTimeAsync(GATEWAY_SHUTDOWN_HOOK_TIMEOUT_MS);
+
+      expect(pluginServices.stop).toHaveBeenCalledOnce();
+      expect(disposeSessionMcpRuntimes).toHaveBeenCalledOnce();
+
+      const result = await closePromise;
+      expect(disposeBundleLspRuntimes).toHaveBeenCalledOnce();
+      expect(stopChannel).toHaveBeenCalledWith("discord");
+      expect(result.warnings).toContain("plugin-services");
+      await expect(Promise.all(exits)).resolves.toHaveLength(2);
+      expect(deps.heartbeatRunner.stop).toHaveBeenCalledOnce();
+      expect(
+        mocks.logWarn.mock.calls.some(([message]) =>
+          String(message).includes("plugin-services runtime disposal exceeded 5000ms"),
+        ),
+      ).toBe(true);
+    } finally {
+      for (const child of children) {
+        if (child.exitCode === null && child.signalCode === null) {
+          child.kill("SIGTERM");
+        }
+      }
+    }
   });
 
   it("drains the active-session tracker with reason=shutdown on SIGTERM/SIGINT close", async () => {

--- a/src/gateway/server-close.ts
+++ b/src/gateway/server-close.ts
@@ -575,7 +575,7 @@ async function triggerGatewayLifecycleHookWithTimeout(params: {
 }
 
 async function disposeRuntimeWithShutdownGrace(params: {
-  label: "bundle-mcp" | "bundle-lsp" | "embedding-providers";
+  label: "plugin-services" | "bundle-mcp" | "bundle-lsp" | "embedding-providers";
   dispose: () => Promise<void>;
   graceMs: number;
   warnings: string[];
@@ -853,7 +853,13 @@ export function createGatewayCloseHandler(
       }
       if (params.pluginServices) {
         await measureCloseStep("plugin-services", () =>
-          shutdownStep("plugin-services", () => params.pluginServices!.stop(), warnings),
+          // A stalled plugin must not prevent later runtime and child-process cleanup.
+          disposeRuntimeWithShutdownGrace({
+            label: "plugin-services",
+            dispose: () => params.pluginServices!.stop(),
+            graceMs: MCP_RUNTIME_CLOSE_GRACE_MS,
+            warnings,
+          }),
         );
       }
       await measureCloseStep("channels", async () => {


### PR DESCRIPTION
Closes #106714

## What Problem This Solves

Fixes an issue where a gateway shutdown or restart could hang indefinitely when a plugin service never completed its stop operation, preventing channels, agent harnesses, and child-process runtimes from being cleaned up.

## Why This Change Was Made

Apply the gateway's existing runtime shutdown grace and existing timeout/disposal helper to plugin services at their current point in the shutdown sequence. This preserves plugin-before-channel ordering and introduces no new configuration, environment variable, API, or timeout value.

## User Impact

A stalled plugin can no longer strand real MCP/LSP child processes or prevent the rest of gateway shutdown after SIGINT. Operators receive the existing structured shutdown warning.

## Evidence

- Fail-first on current main `6c812539859a8b7947f2b58f6b192e7858835795`: the new regression starts two real Node child processes, hangs plugin shutdown, and fails because neither child-runtime disposal is reached; all other 48 shutdown tests pass.
- After the fix, `pnpm test src/gateway/server-close.test.ts`: **49/49 passed**, including actual termination and exit of both child processes, subsequent channel cleanup, and the timeout warning.
- Exact final commit `c39d9c6d640a4615c252ea32c2f40020e5db37da`: full remote Blacksmith Testbox `pnpm check:changed` passed, including both core and core-test typechecking, formatting, 0-error lint, plugin boundaries, and all affected guards.
- Independent `gpt-5.6-sol` extra-high-effort autoreview: clean; no actionable findings.
