### PR TITLE
fix(plugins): keep bulk updates on the beta channel

### DIFF
--- a/docs/cli/plugins.md
+++ b/docs/cli/plugins.md
@@ -454,7 +454,7 @@ Updates apply to tracked plugin installs in the managed plugin index and tracked
 
   </Accordion>
   <Accordion title="Beta channel updates">
-    Targeted `openclaw plugins update <id-or-npm-spec>` reuses the tracked plugin spec unless you pass a new spec. Bulk `openclaw plugins update --all` uses the configured `update.channel` when it syncs trusted official plugin records to the official catalog target, so beta-channel installs can stay on the beta release line instead of being silently normalized to stable/latest.
+    Targeted `openclaw plugins update <id-or-npm-spec>` reuses the tracked plugin spec unless you pass a new spec. Bulk `openclaw plugins update --all` uses the canonical registry-channel resolver when it syncs trusted official plugin records to the official catalog target. An installed beta core therefore keeps official plugins on the beta release line when `update.channel` is unset, matching the core updater instead of silently normalizing them to stable/latest. Explicit `beta`, `dev`, and `extended-stable` selections retain their existing precedence.
 
     `openclaw update` also knows the active OpenClaw update channel: on the beta channel, default-line npm and ClawHub plugin records try `@beta` first. They fall back to the recorded default/latest spec if no plugin beta release exists; npm plugins also fall back when the beta package exists but fails install validation. That fallback is reported as a warning and does not fail the core update. Exact versions and explicit tags stay pinned to that selector for targeted updates.
 

--- a/docs/plugins/manage-plugins.md
+++ b/docs/plugins/manage-plugins.md
@@ -176,9 +176,11 @@ runs.
 `openclaw plugins update --all` is the bulk maintenance path. It still
 respects ordinary tracked install specs, but trusted official OpenClaw
 plugin records sync to the current official catalog target instead of
-staying pinned to a stale exact official package; when `update.channel` is
-`beta`, that sync prefers the beta release line. Use a targeted
-`update <plugin-id>` to keep an exact or tagged official spec untouched.
+staying pinned to a stale exact official package. The canonical channel
+resolver uses both `update.channel` and the installed core version, so an
+installed beta core with no configured channel keeps official plugins on the
+beta release line. Use a targeted `update <plugin-id>` to keep an exact or
+tagged official spec untouched.
 
 For npm installs, pass an explicit package spec to switch the tracked
 record:

--- a/src/cli/plugins-cli.update.test.ts
+++ b/src/cli/plugins-cli.update.test.ts
@@ -3,7 +3,9 @@ import path from "node:path";
 import { Command } from "commander";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
+import { resolveRegistryUpdateChannel } from "../infra/update-channels.js";
 import { CLAWHUB_INSTALL_ERROR_CODE } from "../plugins/clawhub-error-codes.js";
+import { VERSION } from "../version.js";
 import {
   loadConfig,
   notifyGatewayPluginMetadataChanged,
@@ -1187,6 +1189,28 @@ describe("plugins cli update", () => {
     expect(updateParams.syncOfficialPluginInstalls).toBe(true);
     expect(updateParams.officialPluginUpdateChannel).toBe("beta");
     expect(updateParams.updateChannel).toBeUndefined();
+  });
+
+  it("infers the official catalog channel from the installed core for update --all", async () => {
+    const config = createTrackedPluginConfig({
+      pluginId: "codex",
+      spec: "@openclaw/codex",
+      resolvedName: "@openclaw/codex",
+    });
+    loadConfig.mockReturnValue(config);
+    setInstalledPluginIndexInstallRecords(config.plugins?.installs ?? {});
+    updateNpmInstalledPlugins.mockResolvedValue({
+      config,
+      changed: false,
+      outcomes: [],
+    });
+
+    await runPluginsCommand(["plugins", "update", "--all"]);
+
+    const updateParams = expectSingleCallParams(updateNpmInstalledPlugins);
+    expect(updateParams.officialPluginUpdateChannel).toBe(
+      resolveRegistryUpdateChannel({ currentVersion: VERSION }),
+    );
   });
 
   it("passes extended-stable channel and installed core version to update --all", async () => {

--- a/src/cli/plugins-update-command.ts
+++ b/src/cli/plugins-update-command.ts
@@ -19,7 +19,7 @@ import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { PluginInstallRecord } from "../config/types.plugins.js";
 import { readHookInstalls } from "../hooks/installs.js";
 import { updateNpmInstalledHookPacks } from "../hooks/update.js";
-import { normalizeUpdateChannel } from "../infra/update-channels.js";
+import { normalizeUpdateChannel, resolveRegistryUpdateChannel } from "../infra/update-channels.js";
 import {
   containsConfigIncludeDirective,
   resolveCombinedPluginAndHookConfigMutationPreflight,
@@ -343,7 +343,10 @@ async function runPluginUpdateCommandUnlocked(params: RunPluginUpdateCommandPara
           specOverrides: pluginSelection.specOverrides,
           dryRun: params.opts.dryRun,
           officialPluginUpdateChannel: params.opts.all
-            ? (normalizeUpdateChannel(cfg.update?.channel) ?? undefined)
+            ? resolveRegistryUpdateChannel({
+                configChannel: normalizeUpdateChannel(cfg.update?.channel),
+                currentVersion: VERSION,
+              })
             : undefined,
           syncOfficialPluginInstalls: params.opts.all ? true : undefined,
           coreVersion: VERSION,


### PR DESCRIPTION
Backport of https://github.com/openclaw/openclaw/pull/115083

## What Problem This Solves

Fixes an issue where users running the 2026.7.2 beta line could have `openclaw plugins update --all` select stable official-plugin packages when `update.channel` was unset.

## Why This Change Was Made

This is the exact `-x` backport of main squash `8ffc5670758c4d8c24859021f18b0ed4795aed98` onto frozen release head `34e5065fcc4d2e161e49236ca12d9820ee73720f`. It reuses the canonical registry-channel resolver and includes the matching regression test and documentation. No version, tag, changelog, appcast, publish, or release-prep surface changes.

## User Impact

Beta installations without an explicit update channel keep trusted official plugins on the beta release line during bulk updates. Existing targeted-update behavior and explicit `beta`, `dev`, and `extended-stable` selections remain unchanged.

## Evidence

- Backport patch-id matches main: `69d85fd67cff4c71380f5cb5967c791404bfe297`; all four resulting file blobs are byte-identical to the main squash.
- Exact release-head Testbox tree assertion passed: frozen base plus the cherry-pick produced tree `ce9ce530303c1b7f6dc1a57b46b922b180db0b27`.
- 98 focused tests passed: 37 plugin CLI update tests, 50 update-channel resolver tests, and 11 install-channel specification tests.
- `pnpm docs:list` and formatting checks for all 742 docs files passed.
- Release-base path-scoped `pnpm check:changed` passed for core, core tests, and docs, including typecheck, test types, lint, formatting, architecture/guard checks, and dead-export checks.
- `git diff --check` passed.
- Fresh autoreview against the frozen release base reported no accepted/actionable findings (0.97 confidence).
- Testbox run: https://github.com/openclaw/openclaw/actions/runs/30424923360
