### PR TITLE
refactor(chat): consolidate media and outbox lifecycle ownership

### DIFF
--- a/ui/src/pages/chat/chat-outbox-drain.ts
+++ b/ui/src/pages/chat/chat-outbox-drain.ts
@@ -69,6 +69,11 @@ type StoredChatOutboxDrainLane = {
   rerun: boolean;
 };
 
+type StoredChatOutboxClientState = {
+  lanes: Map<string, StoredChatOutboxDrainLane>;
+  retryTimers: Map<string, ReturnType<typeof setTimeout>>;
+};
+
 const STORED_OUTBOX_RETRY_DEFAULT_MS = 500;
 const STORED_OUTBOX_RETRY_MIN_MS = 100;
 const STORED_OUTBOX_RETRY_MAX_MS = 30_000;
@@ -77,25 +82,15 @@ export const UNCONFIRMED_CHAT_SEND_ERROR =
 const UNCERTAIN_CLEAR_SUCCESSOR_ERROR =
   "A preceding /clear may have completed. Review the current conversation before retrying.";
 
-const storedChatOutboxDrainLanesByClient = new WeakMap<
-  GatewayBrowserClient,
-  Map<string, StoredChatOutboxDrainLane>
->();
-const storedChatOutboxRetryTimersByClient = new WeakMap<
-  GatewayBrowserClient,
-  Map<string, ReturnType<typeof setTimeout>>
->();
+const storedChatOutboxClients = new WeakMap<GatewayBrowserClient, StoredChatOutboxClientState>();
 
-function storedChatOutboxClientMap<T>(
-  store: WeakMap<GatewayBrowserClient, Map<string, T>>,
-  client: GatewayBrowserClient,
-): Map<string, T> {
-  const existing = store.get(client);
+function getStoredChatOutboxClientState(client: GatewayBrowserClient): StoredChatOutboxClientState {
+  const existing = storedChatOutboxClients.get(client);
   if (existing) {
     return existing;
   }
-  const created = new Map<string, T>();
-  store.set(client, created);
+  const created = { lanes: new Map(), retryTimers: new Map() };
+  storedChatOutboxClients.set(client, created);
   return created;
 }
 
@@ -118,7 +113,7 @@ export function scheduleStoredChatOutboxRetry(
     return;
   }
   const connectionEpoch = host.connectionEpoch;
-  const timers = storedChatOutboxClientMap(storedChatOutboxRetryTimersByClient, client);
+  const timers = getStoredChatOutboxClientState(client).retryTimers;
   const key = storedChatOutboxScopeKey(scope);
   if (timers.has(key)) {
     return;
@@ -542,15 +537,14 @@ export async function scheduleStoredChatOutboxDrain(
     return;
   }
   const key = storedChatOutboxScopeKey(scope);
-  const retryTimers = storedChatOutboxRetryTimersByClient.get(client);
-  const retryTimer = retryTimers?.get(key);
+  const { lanes, retryTimers } = getStoredChatOutboxClientState(client);
+  const retryTimer = retryTimers.get(key);
   if (retryTimer !== undefined) {
     clearTimeout(retryTimer);
-    retryTimers?.delete(key);
+    retryTimers.delete(key);
   }
   // Drain ownership follows the live gateway client. A disconnected client can
   // leave an RPC pending, but its lane must never capture a replacement client.
-  const lanes = storedChatOutboxClientMap(storedChatOutboxDrainLanesByClient, client);
   const existing = lanes.get(key);
   if (existing) {
     const existingHostOwnsScope =

--- a/ui/src/pages/chat/components/chat-message-media.ts
+++ b/ui/src/pages/chat/components/chat-message-media.ts
@@ -59,16 +59,39 @@ export type ChatMediaResource<Value> = {
   refresh: { at: number; timer: ReturnType<typeof setTimeout> } | undefined;
 };
 
+type ChatMediaSubscriber = {
+  resources: Map<string, ChatMediaResource<unknown>>;
+  children: Set<() => void>;
+  owner?: () => void;
+};
+
+type ManagedImageBlobUrl = {
+  url: string;
+  retainCount: number;
+};
+
 const chatMediaResources = new Map<string, ChatMediaResource<unknown>>();
-const chatMediaSubscriberResources = new Map<() => void, Map<string, ChatMediaResource<unknown>>>();
-const chatMediaSubscriberChildren = new Map<() => void, Set<() => void>>();
-const chatMediaSubscriberOwners = new Map<() => void, () => void>();
-const managedImageBlobUrlResolvedCache = new Map<string, string>();
-const managedImageBlobUrlRetainCounts = new Map<string, number>();
+const chatMediaSubscribers = new Map<() => void, ChatMediaSubscriber>();
+const managedImageBlobUrls = new Map<string, ManagedImageBlobUrl>();
 const MANAGED_IMAGE_BLOB_URL_CACHE_MAX_ENTRIES = 64;
 
 function chatMediaResourceKey(kind: ChatMediaResourceKind, cacheKey: string): string {
   return `${kind}\0${cacheKey}`;
+}
+
+function getChatMediaSubscriber(subscriber: () => void): ChatMediaSubscriber {
+  let state = chatMediaSubscribers.get(subscriber);
+  if (!state) {
+    state = { resources: new Map(), children: new Set() };
+    chatMediaSubscribers.set(subscriber, state);
+  }
+  return state;
+}
+
+function pruneChatMediaSubscriber(subscriber: () => void, state: ChatMediaSubscriber): void {
+  if (!state.owner && state.children.size === 0 && state.resources.size === 0) {
+    chatMediaSubscribers.delete(subscriber);
+  }
 }
 
 function detachChatMediaResourceSubscriber(
@@ -114,11 +137,7 @@ export function observeChatMediaResource<Value>(
     chatMediaResources.set(resourceKey, resource as ChatMediaResource<unknown>);
   }
   if (subscriber) {
-    let subscriptions = chatMediaSubscriberResources.get(subscriber);
-    if (!subscriptions) {
-      subscriptions = new Map();
-      chatMediaSubscriberResources.set(subscriber, subscriptions);
-    }
+    const subscriptions = getChatMediaSubscriber(subscriber).resources;
     const subscriptionKey = chatMediaResourceKey(kind, subscriberScope);
     const previous = subscriptions.get(subscriptionKey);
     if (previous && previous !== resource) {
@@ -181,52 +200,39 @@ export function scheduleChatMediaResourceRefresh<Value>(
 }
 
 export function observeChatMediaResourceSubscriber(owner: () => void, subscriber: () => void) {
-  const previousOwner = chatMediaSubscriberOwners.get(subscriber);
-  if (previousOwner === owner) {
+  const state = getChatMediaSubscriber(subscriber);
+  if (state.owner === owner) {
     return;
   }
-  if (previousOwner) {
-    const previousChildren = chatMediaSubscriberChildren.get(previousOwner);
-    previousChildren?.delete(subscriber);
-    if (previousChildren?.size === 0) {
-      chatMediaSubscriberChildren.delete(previousOwner);
+  if (state.owner) {
+    const previousOwner = state.owner;
+    const previous = chatMediaSubscribers.get(previousOwner);
+    if (previous) {
+      previous.children.delete(subscriber);
+      pruneChatMediaSubscriber(previousOwner, previous);
     }
   }
-  let children = chatMediaSubscriberChildren.get(owner);
-  if (!children) {
-    children = new Set();
-    chatMediaSubscriberChildren.set(owner, children);
-  }
-  children.add(subscriber);
-  chatMediaSubscriberOwners.set(subscriber, owner);
+  getChatMediaSubscriber(owner).children.add(subscriber);
+  state.owner = owner;
 }
 
 export function releaseChatMediaResourceSubscriber(subscriber: (() => void) | undefined) {
-  if (!subscriber) {
+  const state = subscriber && chatMediaSubscribers.get(subscriber);
+  if (!subscriber || !state) {
     return;
   }
-  const children = chatMediaSubscriberChildren.get(subscriber);
-  if (children) {
-    chatMediaSubscriberChildren.delete(subscriber);
-    for (const child of children) {
-      releaseChatMediaResourceSubscriber(child);
+  chatMediaSubscribers.delete(subscriber);
+  for (const child of state.children) {
+    releaseChatMediaResourceSubscriber(child);
+  }
+  if (state.owner) {
+    const owner = chatMediaSubscribers.get(state.owner);
+    if (owner) {
+      owner.children.delete(subscriber);
+      pruneChatMediaSubscriber(state.owner, owner);
     }
   }
-  const owner = chatMediaSubscriberOwners.get(subscriber);
-  if (owner) {
-    chatMediaSubscriberOwners.delete(subscriber);
-    const ownerChildren = chatMediaSubscriberChildren.get(owner);
-    ownerChildren?.delete(subscriber);
-    if (ownerChildren?.size === 0) {
-      chatMediaSubscriberChildren.delete(owner);
-    }
-  }
-  const subscriptions = chatMediaSubscriberResources.get(subscriber);
-  if (!subscriptions) {
-    return;
-  }
-  chatMediaSubscriberResources.delete(subscriber);
-  for (const resource of new Set(subscriptions.values())) {
+  for (const resource of new Set(state.resources.values())) {
     detachChatMediaResourceSubscriber(resource, subscriber);
   }
 }
@@ -245,68 +251,60 @@ export function trimManagedImageMissResources() {
 }
 
 export function readManagedImageBlobUrl(cacheKey: string): string | undefined {
-  const cached = managedImageBlobUrlResolvedCache.get(cacheKey);
+  const cached = managedImageBlobUrls.get(cacheKey);
   if (!cached) {
     return undefined;
   }
-  managedImageBlobUrlResolvedCache.delete(cacheKey);
-  managedImageBlobUrlResolvedCache.set(cacheKey, cached);
-  return cached;
+  managedImageBlobUrls.delete(cacheKey);
+  managedImageBlobUrls.set(cacheKey, cached);
+  return cached.url;
 }
 
 function trimManagedImageBlobUrlCache() {
-  while (managedImageBlobUrlResolvedCache.size > MANAGED_IMAGE_BLOB_URL_CACHE_MAX_ENTRIES) {
-    const evictable = [...managedImageBlobUrlResolvedCache.keys()].find(
-      (cacheKey) => (managedImageBlobUrlRetainCounts.get(cacheKey) ?? 0) === 0,
-    );
+  while (managedImageBlobUrls.size > MANAGED_IMAGE_BLOB_URL_CACHE_MAX_ENTRIES) {
+    const evictable = [...managedImageBlobUrls].find(([, cached]) => cached.retainCount === 0);
     if (!evictable) {
       return;
     }
-    const evicted = managedImageBlobUrlResolvedCache.get(evictable);
-    managedImageBlobUrlResolvedCache.delete(evictable);
-    if (evicted) {
-      const resourceKey = chatMediaResourceKey("managed-image", evictable);
-      const resource = chatMediaResources.get(resourceKey);
-      // Subscriber-free successful resources share their blob's LRU lifetime.
-      // The promise finalizer may still be queued, but a matching value is settled.
-      if (resource?.value === evicted && resource.subscribers.size === 0) {
-        chatMediaResources.delete(resourceKey);
-      }
-      URL.revokeObjectURL(evicted);
+    const [cacheKey, cached] = evictable;
+    managedImageBlobUrls.delete(cacheKey);
+    const resourceKey = chatMediaResourceKey("managed-image", cacheKey);
+    const resource = chatMediaResources.get(resourceKey);
+    // Subscriber-free successful resources share their blob's LRU lifetime.
+    // The promise finalizer may still be queued, but a matching value is settled.
+    if (resource?.value === cached.url && resource.subscribers.size === 0) {
+      chatMediaResources.delete(resourceKey);
     }
+    URL.revokeObjectURL(cached.url);
   }
 }
 
 export function retainManagedImageBlobUrl(cacheKey: string): (() => void) | undefined {
-  if (!managedImageBlobUrlResolvedCache.has(cacheKey)) {
+  const cached = managedImageBlobUrls.get(cacheKey);
+  if (!cached) {
     return undefined;
   }
-  managedImageBlobUrlRetainCounts.set(
-    cacheKey,
-    (managedImageBlobUrlRetainCounts.get(cacheKey) ?? 0) + 1,
-  );
+  cached.retainCount += 1;
   let released = false;
   return () => {
     if (released) {
       return;
     }
     released = true;
-    const remaining = (managedImageBlobUrlRetainCounts.get(cacheKey) ?? 1) - 1;
-    if (remaining <= 0) {
-      managedImageBlobUrlRetainCounts.delete(cacheKey);
-    } else {
-      managedImageBlobUrlRetainCounts.set(cacheKey, remaining);
+    const current = managedImageBlobUrls.get(cacheKey);
+    if (current && current.retainCount > 0) {
+      current.retainCount -= 1;
     }
     trimManagedImageBlobUrlCache();
   };
 }
 
 export function cacheManagedImageBlobUrl(cacheKey: string, blobUrl: string) {
-  const previous = managedImageBlobUrlResolvedCache.get(cacheKey);
-  managedImageBlobUrlResolvedCache.delete(cacheKey);
-  managedImageBlobUrlResolvedCache.set(cacheKey, blobUrl);
-  if (previous && previous !== blobUrl) {
-    URL.revokeObjectURL(previous);
+  const previous = managedImageBlobUrls.get(cacheKey);
+  managedImageBlobUrls.delete(cacheKey);
+  managedImageBlobUrls.set(cacheKey, { url: blobUrl, retainCount: previous?.retainCount ?? 0 });
+  if (previous && previous.url !== blobUrl) {
+    URL.revokeObjectURL(previous.url);
   }
 
   // Blob URLs retain browser-managed image data. Keep recent previews reusable,


### PR DESCRIPTION
Related: #115511

## What Problem This Solves

When a chat is open in multiple panes or reconnects while sending, queued messages, retry timers, managed images, attachment subscriptions, and retained lightbox previews must stay attached to the correct Gateway client and visible pane. Keeping those related lifecycles in separate registries makes split-pane cleanup, retries, media eviction, and disconnect behavior harder to reason about and easier to desynchronize.

## Why This Change Was Made

Replace seven independently maintained chat-lifecycle registries with three canonical owners: one per media subscriber, one per managed-image cache entry, and one per Gateway client's queued-send/retry state. Preserve recursive subscriber cleanup, split-pane image sharing, blob URL LRU/retention, client-epoch checks, durable FIFO ordering, retry cancellation, and the shared web/TUI session projection.

The resulting production diff is deletion-led: **90 additions, 98 deletions, two files, seven registries reduced to three**. There are no schema, storage, configuration, protocol, dependency, or plugin changes.

## User Impact

Messages and images remain consistent across split panes, reconnects, streaming, history recovery, cached image eviction, lightbox previews, offline delivery, and session switching. No setup changes, new settings, migration, or operator action.

## Evidence

- **1,194** focused Gateway, gateway-client, TUI, session, browser, attachment, outbox, and media lifecycle regression tests passed, including real Gateway verification that web and terminal clients receive the same authoritative ordered transcript.
- **55/55** real Chromium scenarios passed across chat messaging, history recovery, streaming, split-pane navigation, pending-send handoff, attachment lifecycle, media tickets, and actual managed-image LRU eviction/refetch.
- **467 Control UI test files and 6,800/6,800 tests passed** using the exact Linux CI command: `pnpm --dir ui test --maxWorkers 3`.
- The exact two-file `pnpm check:changed` passed: UI/core-test typechecks, formatting, lint (**zero warnings or errors**), production/full-tree/script dead-code scans (**zero unused exports**), dependency and package guards, and UI i18n verification.
- Full production `pnpm build` passed, including CLI, finalized Control UI assets and performance budgets, and all 146 public plugin SDK subpaths.
- Fresh independent adversarial review reported **no actionable findings**.
- Rebased onto current `main`; stable patch ID matches the exact remotely tested and reviewed patch.
- AI-assisted implementation and review.
