### PR TITLE
feat(openai): support GA realtime over ChatGPT OAuth

### DIFF
--- a/docs/nodes/talk.md
+++ b/docs/nodes/talk.md
@@ -124,10 +124,20 @@ The Gateway owns the authenticated sideband and routes delegated work through
 the configured OpenClaw agent; the browser receives neither the OAuth token nor
 a Platform API key.
 
-For GA `gpt-realtime-*` browser and iOS WebRTC sessions, Platform credentials
-remain required in this order: the configured realtime API key, an `openai`
-API-key profile, then `OPENAI_API_KEY`. ChatGPT OAuth does not configure those
-GA sessions, Voice Call, Gateway relay, or Discord realtime voice.
+For GA `gpt-realtime-2.1`, `gpt-realtime-2.1-mini`, and `gpt-realtime-2`
+browser sessions, Platform credentials remain preferred in this order: the
+configured realtime API key, an `openai` API-key profile, then
+`OPENAI_API_KEY`. With none configured, browser Talk falls back to an OpenClaw
+ChatGPT OAuth profile and exchanges SDP through the Gateway's single-use offer
+broker, so the OAuth token never reaches the browser. A configured Platform
+credential that cannot be resolved fails closed instead of silently falling
+through to OAuth.
+
+iOS client-owned WebRTC, Voice Call, Gateway relay, provider WebSocket
+transports, Discord realtime voice, and Android realtime remain
+Platform-key-only. GA browser Talk keeps the existing client-owned data channel
+and `talk.client.toolCall` loop; only the credential owner and SDP exchange path
+change under OAuth.
 
 | Key                                      | Default                                    | Notes                                                                                                                                                                                                                                                                                   |
 | ---------------------------------------- | ------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |

--- a/docs/providers/openai.md
+++ b/docs/providers/openai.md
@@ -819,9 +819,10 @@ compatibility fallback when the shared
     Set `OPENAI_TTS_BASE_URL` to override the TTS base URL without affecting
     the chat API endpoint. OpenAI TTS and GA Realtime voice are configured
     through an OpenAI Platform API key. OAuth-only installs can use
-    Codex-backed chat models and GPT-Live browser Talk (which works over the
-    ChatGPT subscription — see the Realtime accordion), but not TTS or GA
-    realtime talk-back.
+    Codex-backed chat models plus GPT-Live and GA Realtime browser Talk over a
+    ChatGPT subscription (see the Realtime accordion). They cannot use OpenAI
+    TTS, iOS Realtime WebRTC, Voice Call, Gateway relay, or Discord realtime
+    voice without a Platform API key.
     </Note>
 
   </Accordion>
@@ -899,7 +900,7 @@ compatibility fallback when the shared
     | Silence duration                       | `...openai.silenceDurationMs`                                           | `500`                |
     | Prefix padding                         | `...openai.prefixPaddingMs`                                             | `300`                |
     | Reasoning effort                       | `...openai.reasoningEffort`                                             | (unset)              |
-    | Auth                                   | `openai` API-key profile, `...openai.apiKey`, or `OPENAI_API_KEY` | OpenAI Platform API key required |
+    | Auth                                   | `openai` auth profile, `...openai.apiKey`, or `OPENAI_API_KEY` | Platform API key; ChatGPT OAuth fallback for browser Talk only |
 
     Available built-in Realtime voices for `gpt-realtime-2.1`: `alloy`, `ash`,
     `ballad`, `coral`, `echo`, `sage`, `shimmer`, `verse`, `marin`, `cedar`.
@@ -908,6 +909,30 @@ compatibility fallback when the shared
     such as `fable`, `nova`, or `onyx` is not valid for Realtime sessions.
     Set the model explicitly to `gpt-realtime-2.1-mini` when you prefer the
     smaller, lower-cost Realtime 2.1 variant.
+
+    #### GA Realtime browser Talk over ChatGPT OAuth
+
+    Browser Talk can use `gpt-realtime-2.1`, `gpt-realtime-2.1-mini`, or
+    `gpt-realtime-2` with either Platform API-key auth or an OpenClaw ChatGPT
+    OAuth subscription profile. Platform auth keeps precedence in this order:
+    the configured realtime key, an `openai` API-key profile, then
+    `OPENAI_API_KEY`. When none is configured, the Gateway falls back to the
+    ChatGPT OAuth profile created by
+    `openclaw models auth login --provider openai`.
+
+    The two browser paths expose the same Talk session contract but keep
+    credentials on different sides of the trust boundary. Platform auth mints
+    an ephemeral client secret and the browser exchanges SDP directly with
+    OpenAI. OAuth auth stays in the Gateway: the existing single-use offer
+    broker sends raw `application/sdp` to
+    `/v1/realtime/calls?model=<model>` and returns only the answer SDP. The
+    OAuth token never reaches the browser. A configured Platform credential
+    that cannot be resolved still fails closed; repair or remove that source
+    before OAuth fallback can apply.
+
+    This OAuth fallback is browser-only. iOS client-owned WebRTC, Voice Call,
+    Gateway relay, provider WebSocket transports, Discord realtime voice, and
+    other backend Realtime bridges remain Platform-key-only.
 
     #### GPT-Live browser Talk
 
@@ -981,7 +1006,7 @@ compatibility fallback when the shared
     never prints token material:
 
     ```bash
-    OPENCLAW_LIVE_TEST=1 OPENCLAW_LIVE_GPT_LIVE=1 node scripts/run-vitest.mjs run --config test/vitest/vitest.live.config.ts extensions/openai/realtime-quicksilver.live.test.ts
+    OPENCLAW_LIVE_TEST=1 OPENCLAW_LIVE_GPT_LIVE=1 node scripts/test-live.mjs -- extensions/openai/realtime-quicksilver.live.test.ts
     ```
 
     <Note>
@@ -1004,11 +1029,11 @@ compatibility fallback when the shared
     `gpt-realtime-*` models use a Gateway-minted ephemeral client secret and a
     direct browser SDP exchange when Platform credentials are available.
     Configured realtime keys, API-key profiles, and `OPENAI_API_KEY` use that
-    path in that order. ChatGPT OAuth is not a Platform Realtime credential and
-    is not used for GA models. GPT-Live instead uses the native Gateway offer
-    broker described above, prefers ChatGPT OAuth when both auth modes are
-    configured, and falls back to Platform API-key access when the account has
-    waitlist-gated `/v1/live` access.
+    path in that order. With no Platform credential, GA browser Talk uses the
+    same Gateway offer broker as GPT-Live so ChatGPT OAuth remains server-side.
+    GPT-Live prefers ChatGPT OAuth when both auth modes are configured and
+    falls back to Platform API-key access when the account has waitlist-gated
+    `/v1/live` access.
     Gateway relay and Voice Call backend realtime WebSocket bridges continue to
     require Platform credentials and a GA model.
     Maintainer live verification is available with

--- a/extensions/openai/realtime-quicksilver-session.test.ts
+++ b/extensions/openai/realtime-quicksilver-session.test.ts
@@ -103,6 +103,61 @@ describe("GPT-Live session shaping", () => {
 });
 
 describe("GPT-Live offer broker", () => {
+  it("brokers GA OAuth with raw SDP and no sideband while preserving single-use tokens", async () => {
+    const requests: Array<{ url: string; init?: RequestInit }> = [];
+    const fetchImpl = vi.fn(async (url: string | URL | Request, init?: RequestInit) => {
+      requests.push({
+        url: typeof url === "string" ? url : url instanceof URL ? url.href : url.url,
+        init,
+      });
+      return new Response("v=ga-answer\r\n", { status: 201 });
+    }) as unknown as typeof fetch;
+    const { realtime, sockets } = createBroker({ fetchImpl });
+    try {
+      const reservation = await realtime.broker.createBrowserSession(
+        { providerConfig: {}, model: "gpt-realtime-2.1", voice: "cedar" },
+        { type: "oauth", token: "oauth-token", accountId: "account-123" },
+      );
+      expect(reservation).toMatchObject({
+        offerUrl: OPENAI_QUICKSILVER_OFFER_PATH,
+        model: "gpt-realtime-2.1",
+        voice: "cedar",
+      });
+      if (reservation.transport !== "webrtc") {
+        throw new Error("Expected WebRTC reservation");
+      }
+
+      const response = createResponseHarness();
+      await realtime.handler(
+        createRequest({ token: reservation.clientSecret, body: "v=ga-offer\r\n" }),
+        response.res,
+      );
+
+      expect(response.res.statusCode).toBe(201);
+      expect(response.readBody()).toBe("v=ga-answer\r\n");
+      expect(sockets).toEqual([]);
+      expect(requests[0]).toMatchObject({
+        url: "https://api.openai.com/v1/realtime/calls?model=gpt-realtime-2.1",
+        init: {
+          method: "POST",
+          body: "v=ga-offer\r\n",
+          headers: expect.objectContaining({
+            Authorization: "Bearer oauth-token",
+            "chatgpt-account-id": "account-123",
+            "Content-Type": "application/sdp",
+          }),
+        },
+      });
+      expect(requests[0]?.init?.headers).not.toHaveProperty("OpenAI-Alpha");
+
+      const replay = createResponseHarness();
+      await realtime.handler(createRequest({ token: reservation.clientSecret }), replay.res);
+      expect(replay.res.statusCode).toBe(401);
+    } finally {
+      await realtime.cleanup();
+    }
+  });
+
   it.each([
     {
       name: "OAuth",

--- a/extensions/openai/realtime-quicksilver-session.ts
+++ b/extensions/openai/realtime-quicksilver-session.ts
@@ -36,6 +36,7 @@ import {
   type OpenAIQuicksilverInitialItem,
   type OpenAIQuicksilverRequestIds,
 } from "./realtime-quicksilver-wire.js";
+import { isOpenAIGptLiveModel } from "./realtime-quicksilver.js";
 export const OPENAI_QUICKSILVER_OFFER_PATH = "/plugins/openai/realtime/calls";
 export const OPENAI_QUICKSILVER_CAPABILITIES = {
   transports: ["webrtc" as const],
@@ -429,16 +430,16 @@ export function createOpenAIQuicksilverBrowserSessionBroker(params: {
       if (cleanedUp || shutdownController.signal.aborted) {
         throw new Error("OpenAI GPT-Live sessions are stopping; restart Gateway and try again");
       }
-      if (!request.runAgentConsult) {
+      const model = request.model?.trim();
+      if (!model) {
+        throw new Error("OpenAI realtime browser sessions require a model");
+      }
+      if (isOpenAIGptLiveModel(model) && !request.runAgentConsult) {
         throw new Error("OpenAI GPT-Live requires the Gateway agent-consult runtime");
       }
       prunePendingOffers();
       if (reservations.size >= OPENAI_QUICKSILVER_MAX_SESSIONS) {
         throw new Error("Too many concurrent OpenAI GPT-Live sessions; try again in a minute");
-      }
-      const model = request.model?.trim();
-      if (!model) {
-        throw new Error("OpenAI GPT-Live requires a model");
       }
       const voice = resolveOpenAIQuicksilverVoice(request.voice);
       const token = randomBytes(32).toString("base64url");
@@ -548,10 +549,6 @@ export function createOpenAIQuicksilverBrowserSessionBroker(params: {
         respondText(res, 400, "SDP offer is required");
         return true;
       }
-      const runAgentConsult = offer.request.runAgentConsult;
-      if (!runAgentConsult) {
-        throw new Error("OpenAI GPT-Live requires the Gateway agent-consult runtime");
-      }
       const upstreamSignal = AbortSignal.any([
         lifecycleSignal,
         AbortSignal.timeout(OPENAI_QUICKSILVER_UPSTREAM_TIMEOUT_MS),
@@ -569,6 +566,18 @@ export function createOpenAIQuicksilverBrowserSessionBroker(params: {
         signal: upstreamSignal,
         fetchImpl: params.fetchImpl,
       });
+      if (call.kind === "ga-realtime") {
+        res.statusCode = call.status;
+        res.setHeader("cache-control", "no-store");
+        res.setHeader("content-type", "application/sdp");
+        res.setHeader("x-content-type-options", "nosniff");
+        res.end(call.answerSdp);
+        return true;
+      }
+      const runAgentConsult = offer.request.runAgentConsult;
+      if (!runAgentConsult) {
+        throw new Error("OpenAI GPT-Live requires the Gateway agent-consult runtime");
+      }
       const connected = await connectOpenAIQuicksilverSideband({
         auth: offer.auth,
         createSocket,

--- a/extensions/openai/realtime-quicksilver-wire.test.ts
+++ b/extensions/openai/realtime-quicksilver-wire.test.ts
@@ -47,6 +47,7 @@ describe("GPT-Live call creation", () => {
         fetchImpl,
       }),
     ).resolves.toEqual({
+      kind: "gpt-live",
       status: 201,
       answerSdp: "v=answer\r\n",
       callId: "rtc_1",
@@ -97,6 +98,51 @@ describe("GPT-Live call creation", () => {
       expect(body).toContain(JSON.stringify(session));
     }
   });
+
+  it.each(["gpt-realtime-2.1", "gpt-realtime-2.1-mini", "gpt-realtime-2"])(
+    "uses raw SDP with the model query and no quicksilver alpha header for %s OAuth",
+    async (model) => {
+      vi.stubEnv("OPENCLAW_VERSION", "2026.7.2-test");
+      let capturedHeaders: HeadersInit | undefined;
+      const fetchImpl = vi.fn(async (_url: string | URL | Request, init?: RequestInit) => {
+        capturedHeaders = init?.headers;
+        return new Response("v=ga-answer\r\n", { status: 201 });
+      });
+
+      await expect(
+        createOpenAIQuicksilverCall({
+          auth: { type: "oauth", token: "oauth-token", accountId: "acct-1" },
+          requestIds: createRequestIds("ga-oauth"),
+          sdp: "v=ga-offer\r\n",
+          session: buildOpenAIQuicksilverSession({ model }),
+          fetchImpl: fetchImpl as unknown as typeof fetch,
+        }),
+      ).resolves.toEqual({
+        kind: "ga-realtime",
+        status: 201,
+        answerSdp: "v=ga-answer\r\n",
+      });
+      expect(fetchImpl).toHaveBeenCalledWith(
+        `https://api.openai.com/v1/realtime/calls?model=${model}`,
+        expect.objectContaining({
+          method: "POST",
+          body: "v=ga-offer\r\n",
+          headers: {
+            Authorization: "Bearer oauth-token",
+            "User-Agent": "openclaw/2026.7.2-test",
+            "chatgpt-account-id": "acct-1",
+            originator: "openclaw",
+            "session-id": "ga-oauth-session",
+            "thread-id": "ga-oauth-thread",
+            version: "2026.7.2-test",
+            "x-session-id": "ga-oauth-realtime",
+            "Content-Type": "application/sdp",
+          },
+        }),
+      );
+      expect(capturedHeaders).not.toHaveProperty("OpenAI-Alpha");
+    },
+  );
 
   it.each([
     {

--- a/extensions/openai/realtime-quicksilver-wire.ts
+++ b/extensions/openai/realtime-quicksilver-wire.ts
@@ -2,12 +2,14 @@
 import { randomBytes } from "node:crypto";
 import { resolveProviderRequestHeaders } from "openclaw/plugin-sdk/provider-http";
 import { z } from "zod";
+import { isOpenAIGptLiveModel } from "./realtime-quicksilver.js";
 
 const OPENAI_QUICKSILVER_APPEND_MAX_BYTES = 500;
 const OPENAI_QUICKSILVER_CONTEXT_MAX_ENTRIES = 16;
 const OPENAI_QUICKSILVER_CONTEXT_MAX_ITEM_CHARS = 800;
 const OPENAI_QUICKSILVER_CONTEXT_MAX_UTF8_BYTES = 8_000;
 const OPENAI_QUICKSILVER_CALL_URL = "https://api.openai.com/v1/live";
+const OPENAI_REALTIME_CALL_URL = "https://api.openai.com/v1/realtime/calls";
 const OPENAI_GPT_LIVE_WAITLIST_URL = "https://openai.com/form/gpt-live-1-in-the-api/";
 
 const OPENAI_QUICKSILVER_VOICES = [
@@ -200,10 +202,24 @@ export function openAIQuicksilverAuthHeaders(
   auth: OpenAIQuicksilverAuth,
   requestIds: OpenAIQuicksilverRequestIds,
 ): Record<string, string> {
+  return openAIRealtimeAuthHeaders({
+    auth,
+    requestIds,
+    baseUrl: OPENAI_QUICKSILVER_CALL_URL,
+    includeQuicksilverAlpha: true,
+  });
+}
+
+function openAIRealtimeAuthHeaders(params: {
+  auth: OpenAIQuicksilverAuth;
+  requestIds: OpenAIQuicksilverRequestIds;
+  baseUrl: string;
+  includeQuicksilverAlpha: boolean;
+}): Record<string, string> {
   const attributionHeaders =
     resolveProviderRequestHeaders({
       provider: "openai",
-      baseUrl: "https://api.openai.com/v1/live",
+      baseUrl: params.baseUrl,
       capability: "audio",
       transport: "http",
       defaultHeaders: {},
@@ -211,14 +227,14 @@ export function openAIQuicksilverAuthHeaders(
   // x-oai-attestation is optional and intentionally omitted on unsupported clients.
   return {
     ...attributionHeaders,
-    Authorization: `Bearer ${auth.token}`,
-    "OpenAI-Alpha": "quicksilver=v2",
-    "session-id": requestIds.sessionId,
-    "thread-id": requestIds.threadId,
-    "x-session-id": requestIds.realtimeSessionId,
-    ...(auth.type === "oauth"
+    Authorization: `Bearer ${params.auth.token}`,
+    ...(params.includeQuicksilverAlpha ? { "OpenAI-Alpha": "quicksilver=v2" } : {}),
+    "session-id": params.requestIds.sessionId,
+    "thread-id": params.requestIds.threadId,
+    "x-session-id": params.requestIds.realtimeSessionId,
+    ...(params.auth.type === "oauth"
       ? {
-          "chatgpt-account-id": auth.accountId,
+          "chatgpt-account-id": params.auth.accountId,
         }
       : {}),
   };
@@ -322,32 +338,62 @@ export async function createOpenAIQuicksilverCall(params: {
   requestIds: OpenAIQuicksilverRequestIds;
   signal?: AbortSignal;
   fetchImpl?: typeof fetch;
-}): Promise<{ status: number; answerSdp: string; callId: string; sidebandUrl: string }> {
-  const authHeaders = openAIQuicksilverAuthHeaders(params.auth, params.requestIds);
-  const multipart = buildOpenAIQuicksilverMultipartBody({
-    sdp: params.sdp,
-    session: params.session,
-  });
+}): Promise<
+  | {
+      kind: "gpt-live";
+      status: number;
+      answerSdp: string;
+      callId: string;
+      sidebandUrl: string;
+    }
+  | { kind: "ga-realtime"; status: number; answerSdp: string }
+> {
+  const isGptLive = isOpenAIGptLiveModel(params.session.model);
+  const authHeaders = isGptLive
+    ? openAIQuicksilverAuthHeaders(params.auth, params.requestIds)
+    : openAIRealtimeAuthHeaders({
+        auth: params.auth,
+        requestIds: params.requestIds,
+        baseUrl: OPENAI_REALTIME_CALL_URL,
+        includeQuicksilverAlpha: false,
+      });
+  const multipart = isGptLive
+    ? buildOpenAIQuicksilverMultipartBody({
+        sdp: params.sdp,
+        session: params.session,
+      })
+    : undefined;
+  const callUrl = isGptLive
+    ? OPENAI_QUICKSILVER_CALL_URL
+    : `${OPENAI_REALTIME_CALL_URL}?model=${encodeURIComponent(params.session.model)}`;
 
-  const response = await (params.fetchImpl ?? fetch)(OPENAI_QUICKSILVER_CALL_URL, {
+  const response = await (params.fetchImpl ?? fetch)(callUrl, {
     method: "POST",
-    headers: { ...authHeaders, "Content-Type": multipart.contentType },
-    body: multipart.body,
+    headers: {
+      ...authHeaders,
+      "Content-Type": multipart?.contentType ?? "application/sdp",
+    },
+    body: multipart?.body ?? params.sdp,
     signal: params.signal,
   });
   if (!response.ok) {
     const detail = (await response.text().catch(() => "")).trim().slice(0, 500);
     throw new OpenAIQuicksilverCallError(
-      describeOpenAIQuicksilverCallError(response.status, detail),
+      isGptLive
+        ? describeOpenAIQuicksilverCallError(response.status, detail)
+        : `OpenAI Realtime call creation failed (${response.status})${detail ? `: ${detail}` : ""}`,
       response.status,
     );
   }
   const answerSdp = await response.text();
   if (!answerSdp.trim()) {
     throw new OpenAIQuicksilverCallError(
-      "GPT-Live call creation returned an empty SDP answer",
+      `${isGptLive ? "GPT-Live" : "OpenAI Realtime"} call creation returned an empty SDP answer`,
       response.status,
     );
+  }
+  if (!isGptLive) {
+    return { kind: "ga-realtime", status: response.status, answerSdp };
   }
   const callId = decodeOpenAIQuicksilverCallId({
     location: response.headers.get("Location"),
@@ -355,6 +401,7 @@ export async function createOpenAIQuicksilverCall(params: {
     callUrl: OPENAI_QUICKSILVER_CALL_URL,
   });
   return {
+    kind: "gpt-live",
     status: response.status,
     answerSdp,
     callId,

--- a/extensions/openai/realtime-quicksilver.live.test.ts
+++ b/extensions/openai/realtime-quicksilver.live.test.ts
@@ -1,9 +1,15 @@
 import { randomUUID } from "node:crypto";
+import { createServer, type Server } from "node:http";
 import { readCodexCliCredentialsCached } from "openclaw/plugin-sdk/provider-auth";
 import type { Page } from "playwright";
 import { describe, expect, it } from "vitest";
 import WebSocket, { type RawData } from "ws";
 import { resolveCodexAuthIdentity } from "./openai-chatgpt-auth-identity.js";
+import {
+  createOpenAIQuicksilverBrowserSessionBroker,
+  OPENAI_QUICKSILVER_OFFER_PATH,
+  resolveOpenAIChatGptSubscriptionAuth,
+} from "./realtime-quicksilver-session.js";
 import {
   buildOpenAIQuicksilverSession,
   createOpenAIQuicksilverCall,
@@ -128,10 +134,19 @@ async function sendSessionClose(socket: WebSocket): Promise<void> {
 async function resolveLiveOAuthProfile(): Promise<
   Extract<OpenAIQuicksilverAuth, { type: "oauth" }> | undefined
 > {
-  const credential = readCodexCliCredentialsCached({
-    allowKeychainPrompt: false,
-    ttlMs: 0,
-  });
+  try {
+    const profile = await resolveOpenAIChatGptSubscriptionAuth({});
+    if (profile) {
+      return profile;
+    }
+  } catch (error) {
+    if (!(error instanceof Error) || error.name !== "AuthProfileMigrationRequiredError") {
+      throw error;
+    }
+  }
+  // The live probe may run while an older local OpenClaw profile awaits Doctor.
+  // Codex CLI OAuth proves the same bearer/account wire without changing runtime fallback rules.
+  const credential = readCodexCliCredentialsCached({ allowKeychainPrompt: false, ttlMs: 0 });
   if (!credential) {
     return undefined;
   }
@@ -140,7 +155,28 @@ async function resolveLiveOAuthProfile(): Promise<
   return accountId ? { type: "oauth", token: credential.access, accountId } : undefined;
 }
 
-describeLive("GPT-Live OAuth WebRTC", () => {
+async function listen(server: Server): Promise<string> {
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      server.removeListener("error", reject);
+      resolve();
+    });
+  });
+  const address = server.address();
+  if (!address || typeof address === "string") {
+    throw new Error("Live realtime broker did not bind a TCP port");
+  }
+  return `http://127.0.0.1:${address.port}`;
+}
+
+async function closeServer(server: Server): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+}
+
+describeLive("OpenAI OAuth WebRTC", () => {
   it(
     "creates a call and joins the authenticated sideband",
     async ({ skip }) => {
@@ -175,6 +211,9 @@ describeLive("GPT-Live OAuth WebRTC", () => {
           }),
         });
 
+        if (call.kind !== "gpt-live") {
+          throw new Error("GPT-Live call unexpectedly used the GA realtime wire shape");
+        }
         expect(call.status).toBe(201);
         expect(call.callId).toMatch(/^rtc_[\w-]+$/);
         expect(call.answerSdp).toMatch(/^v=0/m);
@@ -192,6 +231,100 @@ describeLive("GPT-Live OAuth WebRTC", () => {
         sideband?.close(1000, "test cleanup");
         await closeBrowserPeer(page).catch(() => undefined);
         await browser.close();
+      }
+    },
+    LIVE_TIMEOUT_MS,
+  );
+
+  it(
+    "creates all GA realtime models through the single-use OAuth broker",
+    async ({ skip }) => {
+      const auth = await resolveLiveOAuthProfile();
+      if (!auth) {
+        skip("No OpenClaw ChatGPT OAuth profile is available");
+        return;
+      }
+
+      const realtime = createOpenAIQuicksilverBrowserSessionBroker({
+        getConfig: () => ({}),
+        logger: { debug: () => undefined, warn: () => undefined },
+      });
+      const server = createServer((req, res) => {
+        if (req.url === "/") {
+          res.statusCode = 200;
+          res.setHeader("content-type", "text/html; charset=utf-8");
+          res.end("<!doctype html><title>OpenClaw realtime live proof</title>");
+          return;
+        }
+        if (req.url === OPENAI_QUICKSILVER_OFFER_PATH) {
+          void realtime.handler(req, res);
+          return;
+        }
+        res.statusCode = 404;
+        res.end("Not found");
+      });
+      const baseUrl = await listen(server);
+      const { chromium } = await import("playwright");
+      const browser = await chromium.launch({
+        headless: true,
+        args: ["--no-sandbox", "--use-fake-device-for-media-stream"],
+      });
+      const page = await browser.newPage();
+      try {
+        await page.goto(baseUrl);
+        for (const model of ["gpt-realtime-2.1", "gpt-realtime-2.1-mini", "gpt-realtime-2"]) {
+          try {
+            const reservation = await realtime.broker.createBrowserSession(
+              { providerConfig: {}, model, voice: "marin" },
+              auth,
+            );
+            if (reservation.transport !== "webrtc") {
+              throw new Error("GA realtime broker did not return a WebRTC reservation");
+            }
+            if (!reservation.offerUrl) {
+              throw new Error("GA realtime broker did not return an offer URL");
+            }
+            const offerSdp = await createBrowserOffer(page);
+            const brokerResponse = await page.evaluate(
+              async ({ offerUrl, token, sdp }) => {
+                const response = await fetch(offerUrl, {
+                  method: "POST",
+                  headers: {
+                    Authorization: `Bearer ${token}`,
+                    "Content-Type": "application/sdp",
+                  },
+                  body: sdp,
+                });
+                return { status: response.status, answerSdp: await response.text() };
+              },
+              {
+                offerUrl: `${baseUrl}${reservation.offerUrl}`,
+                token: reservation.clientSecret,
+                sdp: offerSdp,
+              },
+            );
+
+            expect(brokerResponse, model).toEqual({
+              status: 201,
+              answerSdp: expect.stringMatching(/^v=0/m),
+            });
+            await applyBrowserAnswer(page, brokerResponse.answerSdp);
+            await expect(
+              page.evaluate(
+                () =>
+                  (globalThis as BrowserWithGptLivePeer).openclawGptLivePeer?.remoteDescription
+                    ?.type,
+              ),
+              model,
+            ).resolves.toBe("answer");
+          } finally {
+            await closeBrowserPeer(page).catch(() => undefined);
+          }
+        }
+      } finally {
+        await browser.close();
+        await realtime.cleanup();
+        await closeServer(server);
       }
     },
     LIVE_TIMEOUT_MS,

--- a/extensions/openai/realtime-voice-provider.test.ts
+++ b/extensions/openai/realtime-voice-provider.test.ts
@@ -955,6 +955,98 @@ describe("buildOpenAIRealtimeVoiceProvider", () => {
     });
   });
 
+  it("uses ChatGPT OAuth as the browser-only fallback for GA realtime", async () => {
+    const oauthToken = createTestJwt({
+      "https://api.openai.com/auth": { chatgpt_account_id: "account-123" },
+    });
+    resolveProviderAuthProfileApiKeyMock.mockImplementation(
+      async ({ profileTypes }: { profileTypes?: readonly string[] }) =>
+        profileTypes?.includes("oauth") ? oauthToken : undefined,
+    );
+    isProviderAuthProfileConfiguredMock.mockImplementation(
+      ({ profileTypes }: { profileTypes?: readonly string[] }) =>
+        profileTypes?.includes("oauth") === true,
+    );
+    const createBrowserSession = vi.fn(async () => ({
+      provider: "openai",
+      transport: "webrtc" as const,
+      clientSecret: "broker-token",
+      offerUrl: "/plugins/openai/realtime/calls",
+    }));
+    const provider = buildOpenAIRealtimeVoiceProvider({
+      quicksilverBrowserSessionBroker: {
+        capabilities: { handlesAgentConsult: true as const },
+        createBrowserSession,
+        cancelBrowserSession: vi.fn(),
+      },
+    });
+    const cfg = { agents: { defaults: {} } } as never;
+    const request = {
+      cfg,
+      providerConfig: {},
+      model: "gpt-realtime-2.1",
+      voice: "cedar",
+      agentId: "main",
+      workspaceDir: "/tmp/openclaw-agent-workspace",
+      initialItems: [],
+    };
+
+    expect(provider.isConfigured({ cfg, providerConfig: {} })).toBe(false);
+    expect(
+      readInternalRealtimeVoiceProviderApi(provider).isBrowserSessionConfigured({
+        cfg,
+        providerConfig: { model: "gpt-realtime-2.1" },
+        agentId: "main",
+      }),
+    ).toBe(true);
+    await expect(provider.createBrowserSession?.(request)).resolves.toMatchObject({
+      clientSecret: "broker-token",
+      offerUrl: "/plugins/openai/realtime/calls",
+    });
+    expect(createBrowserSession).toHaveBeenCalledWith(
+      expect.objectContaining({ model: "gpt-realtime-2.1", voice: "cedar" }),
+      { type: "oauth", token: oauthToken, accountId: "account-123" },
+    );
+    expect(fetchWithSsrFGuardMock).not.toHaveBeenCalled();
+  });
+
+  it("does not use GA OAuth fallback when a Platform credential source is unresolved", async () => {
+    const oauthToken = createTestJwt({
+      "https://api.openai.com/auth": { chatgpt_account_id: "account-123" },
+    });
+    resolveProviderAuthProfileApiKeyMock.mockImplementation(
+      async ({ profileTypes }: { profileTypes?: readonly string[] }) =>
+        profileTypes?.includes("oauth") ? oauthToken : undefined,
+    );
+    isProviderAuthProfileConfiguredMock.mockImplementation(
+      ({ profileTypes }: { profileTypes?: readonly string[] }) =>
+        profileTypes?.includes("api_key") === true,
+    );
+    const createBrowserSession = vi.fn();
+    const provider = buildOpenAIRealtimeVoiceProvider({
+      quicksilverBrowserSessionBroker: {
+        capabilities: { handlesAgentConsult: true as const },
+        createBrowserSession,
+        cancelBrowserSession: vi.fn(),
+      },
+    });
+
+    await expect(
+      provider.createBrowserSession?.({
+        cfg: {} as never,
+        providerConfig: {},
+        model: "gpt-realtime-2.1",
+        agentId: "main",
+        workspaceDir: "/tmp/openclaw-agent-workspace",
+        initialItems: [],
+      } as never),
+    ).rejects.toThrow("OpenAI Realtime voice requires an OpenAI Platform API key");
+    expect(createBrowserSession).not.toHaveBeenCalled();
+    expect(resolveProviderAuthProfileApiKeyMock).not.toHaveBeenCalledWith(
+      expect.objectContaining({ profileTypes: ["oauth"] }),
+    );
+  });
+
   it("passes configured gpt-live model and voice to the native broker", async () => {
     const createBrowserSession = vi.fn(async (_request: unknown, _auth: unknown) => ({
       provider: "openai",

--- a/extensions/openai/realtime-voice-provider.ts
+++ b/extensions/openai/realtime-voice-provider.ts
@@ -1685,7 +1685,34 @@ async function createOpenAIRealtimeBrowserSession(
     cfg: req.cfg,
   });
   if (auth.status === "missing") {
-    throw new Error(OPENAI_REALTIME_PLATFORM_AUTH_REQUIRED);
+    if (
+      hasOpenAIRealtimePlatformAuthInput({
+        configuredApiKey: config.apiKey,
+        cfg: req.cfg,
+      })
+    ) {
+      throw new Error(OPENAI_REALTIME_PLATFORM_AUTH_REQUIRED);
+    }
+    const subscriptionAuth = await resolveOpenAIChatGptSubscriptionAuth({
+      cfg: req.cfg,
+      agentDir: req.cfg ? resolveAgentDir(req.cfg, req.agentId) : undefined,
+    });
+    if (!subscriptionAuth) {
+      throw new Error(OPENAI_REALTIME_PLATFORM_AUTH_REQUIRED);
+    }
+    if (!quicksilverBroker) {
+      throw new Error("OpenAI realtime browser session broker is unavailable");
+    }
+    const session = await quicksilverBroker.createBrowserSession(
+      {
+        ...req,
+        model,
+        voice: normalizeOpenAIRealtimeVoice(req.voice) ?? config.voice ?? "alloy",
+      },
+      subscriptionAuth,
+    );
+    quicksilverBrokerBySession.set(session, quicksilverBroker);
+    return session;
   }
 
   const voice = normalizeOpenAIRealtimeVoice(req.voice) ?? config.voice ?? "alloy";
@@ -1828,7 +1855,10 @@ export function buildOpenAIRealtimeVoiceProvider(options?: {
             hasOpenAIChatGptSubscriptionAuthInput({ cfg, agentId }))
         );
       }
-      return false;
+      return (
+        options?.quicksilverBrowserSessionBroker !== undefined &&
+        hasOpenAIChatGptSubscriptionAuthInput({ cfg, agentId })
+      );
     },
     resolveBrowserSessionCapabilities: ({ providerConfig, model }) => {
       const config = normalizeProviderConfig(providerConfig);


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where browser Talk could use ChatGPT OAuth for GPT-Live but GA OpenAI Realtime models still required a Platform API key, even though the ChatGPT subscription credential can create those WebRTC calls without exposing OAuth to the browser.

## Why This Change Was Made

This extends the existing OpenAI single-use offer broker instead of introducing another route. GPT-Live keeps its multipart `/v1/live` call plus Gateway sideband; GA models use raw `application/sdp` at `/v1/realtime/calls?model=<model>` and keep the existing browser-owned data channel/tool loop. Platform auth remains preferred for GA, while ChatGPT OAuth is a browser-only fallback when no Platform source is configured. iOS, Voice Call, Gateway relay, provider WebSocket, Discord, and Android realtime remain Platform-key-only.

AI-assisted implementation; the author reviewed the complete auth, broker, browser, provider-readiness, and documentation paths and ran Codex autoreview to a clean result.

## User Impact

ChatGPT OAuth-only installations can now use `gpt-realtime-2.1`, `gpt-realtime-2.1-mini`, and `gpt-realtime-2` in browser Talk. The OAuth token remains on the Gateway; the browser receives only the existing short-lived single-use broker token and answer SDP.

## Evidence

- `node scripts/run-vitest.mjs extensions/openai/realtime-voice-provider.test.ts extensions/openai/realtime-gpt-live-wire.test.ts extensions/openai/realtime-gpt-live-session.test.ts extensions/openai/realtime-gpt-live-delegation.test.ts src/gateway/server-methods/talk.test.ts` — 5 files, 199 tests passed at head `cb8676d83047cdf808df835f1a440b11461b515e`.
- `OPENCLAW_LIVE_TEST=1 OPENCLAW_LIVE_GPT_LIVE=1 node scripts/test-live.mjs -- extensions/openai/realtime-gpt-live.live.test.ts -t "creates all GA realtime models"` — passed at the same head. Real Chromium offers for all three GA models received `201` answer SDP through the broker and applied it as the remote description; no token material was logged.
- The complete live file also passed once before the conflict-free latest-main rebase. On two later complete-file runs, the new GA case passed while the pre-existing GPT-Live sideband assertion intermittently timed out waiting 15 seconds for `session.started`; the focused exact-head GA proof above remained green.
- `node scripts/check-changed.mjs` — passed on Blacksmith Testbox `tbx_01kyp53rsam1v45rktb8ek1cc5` (types, lint, format, dead exports, boundaries, import cycles, and guards): https://github.com/openclaw/openclaw/actions/runs/30424824002
- `node scripts/check-docs-mdx.mjs docs README.md` — passed. Full anchor audit reached an unrelated existing parse error at `docs/concepts/qa-e2e-automation.md:1320`; the touched pages add no internal links.
- Codex autoreview: clean, no accepted/actionable findings.

Release-note context: GA OpenAI Realtime browser Talk now supports ChatGPT OAuth as a Gateway-brokered fallback while preserving Platform-key precedence and keeping non-browser surfaces Platform-key-only.

