### PR TITLE
fix(nodes): stop paired local inference when callers disconnect

### DIFF
--- a/docs/plugins/sdk-runtime.md
+++ b/docs/plugins/sdk-runtime.md
@@ -397,6 +397,7 @@ two-party event loops that do not go through the shared inbound reply runner.
     List connected nodes and invoke a node-host command from Gateway-loaded plugin code or from plugin CLI commands. Use this when a plugin owns local work on a paired device, for example a browser or audio bridge on another Mac.
 
     ```typescript
+    const controller = new AbortController();
     const { nodes } = await api.runtime.nodes.list({ connected: true });
 
     const result = await api.runtime.nodes.invoke({
@@ -404,8 +405,15 @@ two-party event loops that do not go through the shared inbound reply runner.
       command: "my-plugin.command",
       params: { action: "start" },
       timeoutMs: 30000,
+      signal: controller.signal,
     });
     ```
+
+    Pass the agent tool or request `AbortSignal` as `signal` when the caller can
+    be canceled. Gateway-loaded calls forward cancellation to the paired node;
+    node-host command handlers receive it as `context.signal` so they can stop
+    in-flight requests and release local resources. Existing calls that omit the
+    signal retain their previous behavior.
 
     `nodes.list(...)` includes each connected node's advertised
     `nodePluginTools` descriptors when that node exposes plugin or MCP-backed

--- a/extensions/ollama/src/node-inference.abort.test.ts
+++ b/extensions/ollama/src/node-inference.abort.test.ts
@@ -1,0 +1,250 @@
+/** Proves paired-node Ollama work stops at every node-local HTTP phase. */
+import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
+import { createTestPluginApi } from "openclaw/plugin-sdk/plugin-test-api";
+import { describe, expect, it, vi } from "vitest";
+import { createOllamaNodeHostCommands, createOllamaNodeInferenceTool } from "./node-inference.js";
+import {
+  enrichOllamaCompletionModels,
+  enrichOllamaModelsWithContext,
+  fetchOllamaModels,
+  queryOllamaModelShowInfo,
+} from "./provider-models.js";
+
+type AbortTestServer = {
+  baseUrl: string;
+  requests: string[];
+  canceled: string[];
+};
+
+async function withAbortTestServer<T>(
+  stallPath: string,
+  run: (server: AbortTestServer) => Promise<T>,
+  options?: { stallCount?: number },
+): Promise<T> {
+  const requests: string[] = [];
+  const canceled: string[] = [];
+  let stalls = 0;
+  const server = createServer((request: IncomingMessage, response: ServerResponse) => {
+    const requestPath = new URL(request.url ?? "/", "http://127.0.0.1").pathname;
+    requests.push(requestPath);
+    if (requestPath === stallPath && stalls < (options?.stallCount ?? Number.POSITIVE_INFINITY)) {
+      stalls += 1;
+      response.once("close", () => {
+        if (!response.writableFinished) {
+          canceled.push(requestPath);
+        }
+      });
+      return;
+    }
+
+    response.setHeader("Content-Type", "application/json");
+    if (requestPath === "/api/tags") {
+      response.end(
+        JSON.stringify({
+          models: [{ name: "node-local:small", digest: "sha256:node-local-small", size: 512 }],
+        }),
+      );
+      return;
+    }
+    if (requestPath === "/api/show") {
+      response.end(
+        JSON.stringify({
+          capabilities: ["completion", "tools"],
+          model_info: { "test.context_length": 8192 },
+        }),
+      );
+      return;
+    }
+    if (requestPath === "/api/chat") {
+      response.end(
+        JSON.stringify({
+          model: "node-local:small",
+          message: { content: "node-only inference" },
+          done_reason: "stop",
+        }),
+      );
+      return;
+    }
+    response.statusCode = 404;
+    response.end(JSON.stringify({ error: "not found" }));
+  });
+
+  await new Promise<void>((resolve) => {
+    server.listen(0, "127.0.0.1", resolve);
+  });
+  const address = server.address();
+  if (!address || typeof address === "string") {
+    throw new Error("node-local Ollama fixture did not expose a TCP address");
+  }
+  try {
+    return await run({
+      baseUrl: `http://127.0.0.1:${address.port}`,
+      requests,
+      canceled,
+    });
+  } finally {
+    server.closeAllConnections();
+    await new Promise<void>((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+function requireNodeChatCommand(baseUrl: string) {
+  const command = createOllamaNodeHostCommands({ baseUrl }).find(
+    (candidate) => candidate.command === "ollama.chat",
+  );
+  if (!command) {
+    throw new Error("Ollama node chat command was not registered");
+  }
+  return command;
+}
+
+describe("node-local Ollama inference cancellation", () => {
+  it.each([
+    {
+      phase: "model tags",
+      request: (signal: AbortSignal) => fetchOllamaModels("http://127.0.0.1:1", { signal }),
+    },
+    {
+      phase: "model metadata",
+      request: (signal: AbortSignal) =>
+        queryOllamaModelShowInfo("http://127.0.0.1:1", "node-local:small", { signal }),
+    },
+    {
+      phase: "model context enrichment",
+      request: (signal: AbortSignal) =>
+        enrichOllamaModelsWithContext("http://127.0.0.1:1", [{ name: "node-local:small" }], {
+          signal,
+        }),
+    },
+    {
+      phase: "completion enrichment",
+      request: (signal: AbortSignal) =>
+        enrichOllamaCompletionModels("http://127.0.0.1:1", [{ name: "node-local:small" }], {
+          signal,
+        }),
+    },
+  ])("normalizes a pre-aborted string reason during $phase", async ({ request }) => {
+    const result = request(AbortSignal.abort("node inference canceled"));
+
+    await expect(result).rejects.toBeInstanceOf(Error);
+    await expect(result).rejects.toMatchObject({ message: "node inference canceled" });
+  });
+
+  it.each([
+    { phase: "model discovery", path: "/api/tags" },
+    { phase: "model capability verification", path: "/api/show" },
+    { phase: "model generation", path: "/api/chat" },
+  ])("closes the node-local request when $phase is canceled", async ({ path }) => {
+    await withAbortTestServer(path, async ({ baseUrl, requests, canceled }) => {
+      const controller = new AbortController();
+      const inference = requireNodeChatCommand(baseUrl).handle(
+        JSON.stringify({ model: "node-local:small", prompt: "answer locally" }),
+        undefined,
+        { sendNodeEvent: async () => undefined, signal: controller.signal },
+      );
+      await vi.waitFor(() => expect(requests).toContain(path));
+
+      controller.abort(new Error("node inference canceled"));
+
+      await expect(inference).rejects.toThrow("node inference canceled");
+      await vi.waitFor(() => expect(canceled).toContain(path));
+    });
+  });
+
+  it("forwards an agent-tool cancellation through its paired node runtime", async () => {
+    await withAbortTestServer("/api/chat", async ({ baseUrl, requests, canceled }) => {
+      const controller = new AbortController();
+      const invoke = vi.fn(
+        async (params: { command: string; params?: unknown; signal?: AbortSignal }) => ({
+          payloadJSON: await requireNodeChatCommand(baseUrl).handle(
+            JSON.stringify(params.params),
+            undefined,
+            { sendNodeEvent: async () => undefined, signal: params.signal },
+          ),
+        }),
+      );
+      const api = createTestPluginApi({
+        runtime: {
+          nodes: {
+            list: async () => ({
+              nodes: [
+                {
+                  nodeId: "paired-node",
+                  connected: true,
+                  commands: ["ollama.models", "ollama.chat"],
+                },
+              ],
+            }),
+            invoke,
+          },
+        } as never,
+      });
+
+      const inference = createOllamaNodeInferenceTool(api).execute(
+        "paired-node-inference",
+        {
+          action: "run",
+          model: "node-local:small",
+          prompt: "answer only from the paired node",
+        },
+        controller.signal,
+      );
+      await vi.waitFor(() => expect(requests).toContain("/api/chat"));
+
+      controller.abort(new Error("agent inference canceled"));
+
+      await expect(inference).rejects.toThrow("agent inference canceled");
+      expect(invoke).toHaveBeenCalledWith(
+        expect.objectContaining({
+          nodeId: "paired-node",
+          command: "ollama.chat",
+          signal: controller.signal,
+        }),
+      );
+      await vi.waitFor(() => expect(canceled).toContain("/api/chat"));
+    });
+  });
+
+  it("normalizes a pre-aborted agent-tool string reason before listing nodes", async () => {
+    const list = vi.fn(async () => ({ nodes: [] }));
+    const api = createTestPluginApi({
+      runtime: { nodes: { list, invoke: vi.fn() } } as never,
+    });
+
+    const inference = createOllamaNodeInferenceTool(api).execute(
+      "paired-node-inference",
+      { action: "discover" },
+      AbortSignal.abort("agent inference canceled"),
+    );
+
+    await expect(inference).rejects.toBeInstanceOf(Error);
+    await expect(inference).rejects.toMatchObject({ message: "agent inference canceled" });
+    expect(list).not.toHaveBeenCalled();
+  });
+
+  it("does not poison shared model metadata after a canceled show request", async () => {
+    await withAbortTestServer(
+      "/api/show",
+      async ({ baseUrl, requests, canceled }) => {
+        const controller = new AbortController();
+        const command = requireNodeChatCommand(baseUrl);
+        const params = JSON.stringify({ model: "node-local:small", prompt: "answer locally" });
+        const canceledInference = command.handle(params, undefined, {
+          sendNodeEvent: async () => undefined,
+          signal: controller.signal,
+        });
+        await vi.waitFor(() => expect(requests).toContain("/api/show"));
+
+        controller.abort(new Error("first inference canceled"));
+        await expect(canceledInference).rejects.toThrow("first inference canceled");
+        await vi.waitFor(() => expect(canceled).toContain("/api/show"));
+
+        await expect(command.handle(params)).resolves.toContain("node-only inference");
+        expect(requests.filter((request) => request === "/api/show")).toHaveLength(2);
+      },
+      { stallCount: 1 },
+    );
+  });
+});

--- a/extensions/ollama/src/node-inference.ts
+++ b/extensions/ollama/src/node-inference.ts
@@ -27,6 +27,7 @@ import {
   fetchOllamaModels,
   isOllamaCloudModel,
   resolveOllamaApiBase,
+  throwIfOllamaRequestAborted,
 } from "./provider-models.js";
 
 const OLLAMA_NODE_INFERENCE_CAPABILITY = "local-inference";
@@ -111,6 +112,7 @@ async function requestOllamaJson<T>(params: {
   path: string;
   timeoutMs: number;
   init?: RequestInit;
+  signal?: AbortSignal;
 }): Promise<T> {
   const apiBase = resolveOllamaApiBase(params.baseUrl);
   let response: Response;
@@ -121,12 +123,14 @@ async function requestOllamaJson<T>(params: {
       init: params.init,
       // Guard-owned timeoutMs also bounds DNS/proxy preflight; init.signal does not.
       timeoutMs: params.timeoutMs,
+      ...(params.signal ? { signal: params.signal } : {}),
       policy: buildOllamaBaseUrlSsrFPolicy(apiBase),
       auditContext: `ollama-node-inference${params.path}`,
     });
     response = guarded.response;
     release = guarded.release;
   } catch (error) {
+    throwIfOllamaRequestAborted(params.signal);
     throw new Error(`Ollama is unavailable at ${apiBase}: ${errorMessage(error)}`, {
       cause: error,
     });
@@ -152,12 +156,13 @@ async function requestOllamaJson<T>(params: {
   }
 }
 
-async function fetchLoadedModelNames(baseUrl: string): Promise<Set<string>> {
+async function fetchLoadedModelNames(baseUrl: string, signal?: AbortSignal): Promise<Set<string>> {
   try {
     const data = await requestOllamaJson<{ models?: Array<{ name?: unknown; model?: unknown }> }>({
       baseUrl,
       path: "/api/ps",
       timeoutMs: 5000,
+      ...(signal ? { signal } : {}),
     });
     return new Set(
       (data.models ?? [])
@@ -171,6 +176,7 @@ async function fetchLoadedModelNames(baseUrl: string): Promise<Set<string>> {
         .filter(Boolean),
     );
   } catch {
+    throwIfOllamaRequestAborted(signal);
     // Model discovery still works against Ollama versions without /api/ps.
     return new Set();
   }
@@ -178,16 +184,17 @@ async function fetchLoadedModelNames(baseUrl: string): Promise<Set<string>> {
 
 async function discoverOllamaNodeModels(
   baseUrl = OLLAMA_DEFAULT_BASE_URL,
+  signal?: AbortSignal,
 ): Promise<OllamaModelsPayload> {
   const apiBase = resolveOllamaApiBase(baseUrl);
-  const discovered = await fetchOllamaModels(apiBase);
+  const discovered = await fetchOllamaModels(apiBase, signal ? { signal } : undefined);
   if (!discovered.reachable) {
     throw new Error(`Ollama is not running at ${apiBase}`);
   }
   const localModels = discovered.models.filter(
     (model) => !model.remote_host?.trim() && !isOllamaCloudModel(model.name),
   );
-  const loadedNames = await fetchLoadedModelNames(apiBase);
+  const loadedNames = await fetchLoadedModelNames(apiBase, signal);
   // Probe loaded models before the bounded catalog can hide already-runnable node models.
   const prioritizedModels = localModels.toSorted(
     (left, right) => Number(loadedNames.has(right.name)) - Number(loadedNames.has(left.name)),
@@ -196,6 +203,7 @@ async function discoverOllamaNodeModels(
   // failed or legacy show probes must never expose unrunnable remote commands.
   const models = await enrichOllamaCompletionModels(apiBase, prioritizedModels, {
     requireCompletionCapability: true,
+    ...(signal ? { signal } : {}),
   });
   const rows = models
     .map((model): NodeModel => {
@@ -246,6 +254,7 @@ async function runOllamaNodeChat(params: {
   temperature?: number;
   maxTokens: number;
   timeoutMs: number;
+  signal?: AbortSignal;
 }): Promise<OllamaChatPayload> {
   const apiBase = resolveOllamaApiBase(params.baseUrl);
   const deadlineMs = performance.now() + params.timeoutMs;
@@ -256,7 +265,10 @@ async function runOllamaNodeChat(params: {
     }
     return remainingMs;
   };
-  const discovered = await fetchOllamaModels(apiBase, { timeoutMs: remainingTimeoutMs() });
+  const discovered = await fetchOllamaModels(apiBase, {
+    timeoutMs: remainingTimeoutMs(),
+    ...(params.signal ? { signal: params.signal } : {}),
+  });
   const localModel = discovered.models.find(
     (model) =>
       model.name === params.model && !model.remote_host?.trim() && !isOllamaCloudModel(model.name),
@@ -264,6 +276,7 @@ async function runOllamaNodeChat(params: {
   const [model] = localModel
     ? await enrichOllamaModelsWithContext(apiBase, [localModel], {
         timeoutMs: remainingTimeoutMs(),
+        ...(params.signal ? { signal: params.signal } : {}),
       })
     : [];
   if (!discovered.reachable || model?.capabilities?.includes("completion") !== true) {
@@ -288,6 +301,7 @@ async function runOllamaNodeChat(params: {
     baseUrl: params.baseUrl,
     path: "/api/chat",
     timeoutMs: remainingTimeoutMs(),
+    ...(params.signal ? { signal: params.signal } : {}),
     init: {
       method: "POST",
       headers: { "Content-Type": "application/json" },
@@ -335,12 +349,13 @@ export function createOllamaNodeHostCommands(options?: {
     {
       command: OLLAMA_MODELS_COMMAND,
       cap: OLLAMA_NODE_INFERENCE_CAPABILITY,
-      handle: async () => JSON.stringify(await discoverOllamaNodeModels(baseUrl)),
+      handle: async (_paramsJSON, _io, context) =>
+        JSON.stringify(await discoverOllamaNodeModels(baseUrl, context?.signal)),
     },
     {
       command: OLLAMA_CHAT_COMMAND,
       cap: OLLAMA_NODE_INFERENCE_CAPABILITY,
-      handle: async (paramsJSON) => {
+      handle: async (paramsJSON, _io, context) => {
         const params = readNodeCommandParams(paramsJSON);
         const model = readStringParam(params, "model", { required: true });
         const prompt = readStringParam(params, "prompt", { required: true, trim: false });
@@ -375,6 +390,7 @@ export function createOllamaNodeHostCommands(options?: {
             temperature,
             maxTokens,
             timeoutMs,
+            ...(context?.signal ? { signal: context.signal } : {}),
           }),
         );
       },
@@ -423,13 +439,16 @@ async function invokeNode(
   command: string,
   params: Record<string, unknown>,
   timeoutMs: number,
+  signal?: AbortSignal,
 ): Promise<Record<string, unknown>> {
+  throwIfOllamaRequestAborted(signal);
   const raw = await api.runtime.nodes.invoke({
     nodeId,
     command,
     params,
     timeoutMs,
     scopes: ["operator.write"],
+    ...(signal ? { signal } : {}),
   });
   return parseInvokePayload(raw);
 }
@@ -461,7 +480,8 @@ const ollamaNodeInferenceToolDefinition = {
 export function createOllamaNodeInferenceTool(api: OpenClawPluginApi): AnyAgentTool {
   return {
     ...ollamaNodeInferenceToolDefinition,
-    execute: async (_toolCallId, args) => {
+    execute: async (_toolCallId, args, signal) => {
+      throwIfOllamaRequestAborted(signal);
       const params = asRecord(args) ?? {};
       const action = readStringParam(params, "action", { required: true });
       const nodeQuery = readStringParam(params, "node");
@@ -481,6 +501,7 @@ export function createOllamaNodeInferenceTool(api: OpenClawPluginApi): AnyAgentT
                 OLLAMA_MODELS_COMMAND,
                 {},
                 DISCOVERY_TRANSPORT_TIMEOUT_MS,
+                signal,
               );
               const result: Record<string, unknown> = { nodeId: node.nodeId, ok: true };
               if (node.displayName) {
@@ -488,6 +509,7 @@ export function createOllamaNodeInferenceTool(api: OpenClawPluginApi): AnyAgentT
               }
               return Object.assign(result, payload);
             } catch (error) {
+              throwIfOllamaRequestAborted(signal);
               const result: Record<string, unknown> = {
                 nodeId: node.nodeId,
                 ok: false,
@@ -553,6 +575,7 @@ export function createOllamaNodeInferenceTool(api: OpenClawPluginApi): AnyAgentT
         OLLAMA_CHAT_COMMAND,
         commandParams,
         timeoutMs,
+        signal,
       );
       return jsonResult({
         nodeId: node.nodeId,

--- a/extensions/ollama/src/provider-models.ts
+++ b/extensions/ollama/src/provider-models.ts
@@ -1,5 +1,6 @@
 // Ollama provider module implements model/runtime integration.
 import { createHash } from "node:crypto";
+import { toErrorObject } from "openclaw/plugin-sdk/error-runtime";
 import { readProviderJsonResponse } from "openclaw/plugin-sdk/provider-http";
 import {
   isCloudModelRef,
@@ -82,6 +83,18 @@ export type OllamaModelShowInfo = {
   capabilities?: string[];
 };
 
+type OllamaModelRequestOptions = {
+  apiKey?: string;
+  timeoutMs?: number;
+  signal?: AbortSignal;
+};
+
+export function throwIfOllamaRequestAborted(signal?: AbortSignal): void {
+  if (signal?.aborted) {
+    throw toErrorObject(signal.reason, "Ollama request aborted");
+  }
+}
+
 function buildOllamaModelShowCacheKey(
   apiBase: string,
   model: Pick<OllamaTagModel, "name" | "digest" | "modified_at">,
@@ -135,7 +148,7 @@ function parseOllamaNumCtxParameter(parameters: unknown): number | undefined {
 export async function queryOllamaModelShowInfo(
   apiBase: string,
   modelName: string,
-  opts?: { apiKey?: string; timeoutMs?: number },
+  opts?: OllamaModelRequestOptions,
 ): Promise<OllamaModelShowInfo> {
   const normalizedApiBase = resolveOllamaApiBase(apiBase);
   try {
@@ -152,6 +165,7 @@ export async function queryOllamaModelShowInfo(
       },
       // Guard-owned timeoutMs also bounds DNS/proxy preflight; init.signal does not.
       timeoutMs: Math.min(opts?.timeoutMs ?? OLLAMA_SHOW_TIMEOUT_MS, OLLAMA_SHOW_TIMEOUT_MS),
+      ...(opts?.signal ? { signal: opts.signal } : {}),
       policy: buildOllamaBaseUrlSsrFPolicy(normalizedApiBase),
       auditContext: "ollama-provider-models.show",
     });
@@ -197,6 +211,7 @@ export async function queryOllamaModelShowInfo(
       await release();
     }
   } catch {
+    throwIfOllamaRequestAborted(opts?.signal);
     return {};
   }
 }
@@ -204,12 +219,12 @@ export async function queryOllamaModelShowInfo(
 async function queryOllamaModelShowInfoCached(
   apiBase: string,
   model: Pick<OllamaTagModel, "name" | "digest" | "modified_at">,
-  opts?: { apiKey?: string; timeoutMs?: number },
+  opts?: OllamaModelRequestOptions,
 ): Promise<OllamaModelShowInfo> {
   const normalizedApiBase = resolveOllamaApiBase(apiBase);
   const cacheKey = buildOllamaModelShowCacheKey(normalizedApiBase, model, opts?.apiKey);
-  // Request-scoped deadlines must not shorten an unrelated shared catalog probe.
-  if (!cacheKey || opts?.timeoutMs !== undefined) {
+  // Caller-owned deadlines and cancellation must not affect a shared catalog probe.
+  if (!cacheKey || opts?.timeoutMs !== undefined || opts?.signal) {
     return await queryOllamaModelShowInfo(normalizedApiBase, model.name, opts);
   }
 
@@ -239,11 +254,12 @@ export async function queryOllamaContextWindow(
 export async function enrichOllamaModelsWithContext(
   apiBase: string,
   models: OllamaTagModel[],
-  opts?: { apiKey?: string; concurrency?: number; timeoutMs?: number },
+  opts?: OllamaModelRequestOptions & { concurrency?: number },
 ): Promise<OllamaModelWithContext[]> {
   const concurrency = Math.max(1, Math.floor(opts?.concurrency ?? OLLAMA_SHOW_CONCURRENCY));
   const enriched: OllamaModelWithContext[] = [];
   for (let index = 0; index < models.length; index += concurrency) {
+    throwIfOllamaRequestAborted(opts?.signal);
     const batch = models.slice(index, index + concurrency);
     const batchResults = await Promise.all(
       batch.map(async (model) => {
@@ -262,7 +278,7 @@ export async function enrichOllamaModelsWithContext(
 export async function enrichOllamaCompletionModels(
   apiBase: string,
   models: OllamaTagModel[],
-  opts?: { apiKey?: string; requireCompletionCapability?: boolean },
+  opts?: OllamaModelRequestOptions & { requireCompletionCapability?: boolean },
 ): Promise<OllamaModelWithContext[]> {
   const completionModels: OllamaModelWithContext[] = [];
   const probeLimit = Math.min(models.length, MAX_OLLAMA_DISCOVERY_PROBES);
@@ -271,10 +287,11 @@ export async function enrichOllamaCompletionModels(
     index < probeLimit && completionModels.length < OLLAMA_CONTEXT_ENRICH_LIMIT;
     index += OLLAMA_SHOW_CONCURRENCY
   ) {
+    throwIfOllamaRequestAborted(opts?.signal);
     const batch = await enrichOllamaModelsWithContext(
       apiBase,
       models.slice(index, Math.min(index + OLLAMA_SHOW_CONCURRENCY, probeLimit)),
-      opts?.apiKey ? { apiKey: opts.apiKey } : undefined,
+      opts,
     );
     for (const model of batch) {
       const canComplete = model.capabilities?.includes("completion");
@@ -389,7 +406,7 @@ type OllamaModelsFetchDeps = {
 
 export async function fetchOllamaModels(
   baseUrl: string,
-  opts?: { apiKey?: string; timeoutMs?: number },
+  opts?: OllamaModelRequestOptions,
   deps?: OllamaModelsFetchDeps,
 ): Promise<{ reachable: boolean; models: OllamaTagModel[] }> {
   try {
@@ -401,6 +418,7 @@ export async function fetchOllamaModels(
       },
       // Guard-owned timeoutMs also bounds DNS/proxy preflight; init.signal does not.
       timeoutMs: Math.min(opts?.timeoutMs ?? OLLAMA_TAGS_TIMEOUT_MS, OLLAMA_TAGS_TIMEOUT_MS),
+      ...(opts?.signal ? { signal: opts.signal } : {}),
       policy: buildOllamaBaseUrlSsrFPolicy(apiBase),
       auditContext: "ollama-provider-models.tags",
       ...(deps?.fetchImpl ? { fetchImpl: deps.fetchImpl } : {}),
@@ -421,6 +439,7 @@ export async function fetchOllamaModels(
       await release();
     }
   } catch {
+    throwIfOllamaRequestAborted(opts?.signal);
     return { reachable: false, models: [] };
   }
 }

--- a/src/gateway/server-in-process-dispatch.abort.test.ts
+++ b/src/gateway/server-in-process-dispatch.abort.test.ts
@@ -1,0 +1,160 @@
+/** Proves in-process Gateway cancellation reaches real paired-node invocation state. */
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { GATEWAY_CLIENT_IDS } from "../../packages/gateway-protocol/src/client-info.js";
+import { NodeRegistry } from "./node-registry.js";
+import { dispatchGatewayRequestInProcessRaw } from "./server-in-process-dispatch.js";
+import type { GatewayRequestContext, GatewayRequestOptions } from "./server-methods/types.js";
+import type { GatewayWsClient } from "./server/ws-types.js";
+
+const handleGatewayRequest = vi.hoisted(() => vi.fn());
+
+vi.mock("./server-methods.js", () => ({ handleGatewayRequest }));
+
+const activeRegistries = new Set<NodeRegistry>();
+
+afterEach(() => {
+  for (const registry of activeRegistries) {
+    registry.unregister("paired-node-connection");
+  }
+  activeRegistries.clear();
+  handleGatewayRequest.mockReset();
+});
+
+function registerPairedNode(): { registry: NodeRegistry; frames: string[] } {
+  const frames: string[] = [];
+  const registry = new NodeRegistry();
+  activeRegistries.add(registry);
+  registry.register(
+    {
+      connId: "paired-node-connection",
+      usesSharedGatewayAuth: false,
+      socket: {
+        send(frame: unknown) {
+          if (typeof frame === "string") {
+            frames.push(frame);
+          }
+        },
+      },
+      connect: {
+        minProtocol: 1,
+        maxProtocol: 1,
+        client: {
+          id: GATEWAY_CLIENT_IDS.NODE_HOST,
+          version: "1.0.0",
+          platform: "linux",
+          mode: "node",
+        },
+        device: {
+          id: "paired-node",
+          publicKey: "public-key",
+          signature: "signature",
+          signedAt: 1,
+          nonce: "nonce",
+        },
+        caps: ["local-inference"],
+        commands: ["ollama.chat"],
+      },
+    } as GatewayWsClient,
+    { pairingIdentity: "paired-node-identity" },
+  );
+  return { registry, frames };
+}
+
+describe("in-process paired-node invocation cancellation", () => {
+  it("cancels a real first-party paired-node invocation and removes its pending work", async () => {
+    const { registry, frames } = registerPairedNode();
+    const controller = new AbortController();
+    handleGatewayRequest.mockImplementation(async (options: GatewayRequestOptions) => {
+      const result = await registry.invoke({
+        nodeId: "paired-node",
+        command: "ollama.chat",
+        timeoutMs: 10_000,
+        signal: options.signal,
+      });
+      options.respond(
+        result.ok,
+        result.payload,
+        result.error
+          ? {
+              code: result.error.code ?? "UNAVAILABLE",
+              message: result.error.message ?? "node invocation failed",
+            }
+          : undefined,
+      );
+    });
+
+    const invocation = dispatchGatewayRequestInProcessRaw(
+      "node.invoke",
+      { nodeId: "paired-node", command: "ollama.chat" },
+      {
+        client: null,
+        context: {} as GatewayRequestContext,
+        signal: controller.signal,
+      },
+    );
+    await vi.waitFor(() => expect(frames).toHaveLength(1));
+
+    controller.abort(new Error("inference caller disconnected"));
+
+    await expect(invocation).rejects.toThrow("inference caller disconnected");
+    await vi.waitFor(() => expect(frames).toHaveLength(2));
+    const request = JSON.parse(frames[0] ?? "{}") as { payload?: { id?: string } };
+    expect(JSON.parse(frames[1] ?? "{}")).toMatchObject({
+      event: "node.invoke.cancel",
+      payload: { invokeId: request.payload?.id, nodeId: "paired-node" },
+    });
+    expect(handleGatewayRequest).toHaveBeenCalledWith(
+      expect.objectContaining({ signal: controller.signal }),
+    );
+  });
+
+  it("rejects an already-canceled invocation without dispatching a Gateway request", async () => {
+    const controller = new AbortController();
+    controller.abort(new Error("inference already canceled"));
+
+    await expect(
+      dispatchGatewayRequestInProcessRaw(
+        "node.invoke",
+        { nodeId: "paired-node", command: "ollama.chat" },
+        {
+          client: null,
+          context: {} as GatewayRequestContext,
+          signal: controller.signal,
+        },
+      ),
+    ).rejects.toThrow("inference already canceled");
+    expect(handleGatewayRequest).not.toHaveBeenCalled();
+  });
+
+  it("normalizes a pre-aborted non-Error reason without dispatching a Gateway request", async () => {
+    const signal = AbortSignal.abort("inference caller disconnected");
+
+    await expect(
+      dispatchGatewayRequestInProcessRaw(
+        "node.invoke",
+        { nodeId: "paired-node", command: "ollama.chat" },
+        { client: null, context: {} as GatewayRequestContext, signal },
+      ),
+    ).rejects.toMatchObject({
+      name: "AbortError",
+      message: "gateway request aborted for node.invoke",
+      cause: "inference caller disconnected",
+    });
+    expect(handleGatewayRequest).not.toHaveBeenCalled();
+  });
+
+  it("preserves the legacy in-process request shape when no signal is supplied", async () => {
+    handleGatewayRequest.mockImplementation(async (options: GatewayRequestOptions) => {
+      options.respond(true, { ok: true });
+    });
+
+    await expect(
+      dispatchGatewayRequestInProcessRaw(
+        "node.invoke",
+        { nodeId: "paired-node", command: "ollama.chat" },
+        { client: null, context: {} as GatewayRequestContext },
+      ),
+    ).resolves.toMatchObject({ ok: true, payload: { ok: true } });
+    expect(handleGatewayRequest.mock.calls[0]?.[0]).not.toHaveProperty("signal");
+  });
+});

--- a/src/gateway/server-in-process-dispatch.ts
+++ b/src/gateway/server-in-process-dispatch.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from "node:crypto";
 import { GatewayClientRequestError } from "../../packages/gateway-client/src/index.js";
 import type { ErrorShape } from "../../packages/gateway-protocol/src/schema/frames.js";
+import { createAbortError } from "../infra/abort-signal.js";
 import { resolveSafeTimeoutDelayMs } from "../utils/timer-delay.js";
 import type { GatewayMethodRegistry } from "./methods/registry.js";
 import type { GatewayRequestOptions } from "./server-methods/types.js";
@@ -21,6 +22,7 @@ type InProcessGatewayDispatchOptions = {
   onAccepted?: (payload: unknown) => void;
   requestIdPrefix?: string;
   timeoutMs?: number;
+  signal?: AbortSignal;
 };
 
 export function unwrapGatewayMethodDispatchResponse(
@@ -52,28 +54,49 @@ function resolveRemainingDispatchTimeoutMs(deadlineMs?: number): number | undefi
     : resolveSafeTimeoutDelayMs(deadlineMs - Date.now(), { minMs: 0 });
 }
 
+function resolveDispatchAbortError(method: string, signal: AbortSignal): Error {
+  return signal.reason instanceof Error
+    ? signal.reason
+    : createAbortError(`gateway request aborted for ${method}`, { cause: signal.reason });
+}
+
 async function waitForDispatch<T>(
   method: string,
   promise: Promise<T>,
   deadlineMs?: number,
+  signal?: AbortSignal,
 ): Promise<T> {
+  if (signal?.aborted) {
+    throw resolveDispatchAbortError(method, signal);
+  }
   const remainingTimeoutMs = resolveRemainingDispatchTimeoutMs(deadlineMs);
-  if (remainingTimeoutMs === undefined) {
+  if (remainingTimeoutMs === undefined && !signal) {
     return await promise;
   }
   let timeout: NodeJS.Timeout | undefined;
+  let onAbort: (() => void) | undefined;
   try {
-    return await Promise.race([
-      promise,
-      new Promise<never>((_resolve, reject) => {
+    const cancellation = new Promise<never>((_resolve, reject) => {
+      if (remainingTimeoutMs !== undefined) {
         timeout = setTimeout(() => {
           reject(new Error(`gateway request timeout for ${method}`));
         }, remainingTimeoutMs);
-      }),
-    ]);
+      }
+      if (signal) {
+        onAbort = () => reject(resolveDispatchAbortError(method, signal));
+        signal.addEventListener("abort", onAbort, { once: true });
+        if (signal.aborted) {
+          onAbort();
+        }
+      }
+    });
+    return await Promise.race([promise, cancellation]);
   } finally {
     if (timeout) {
       clearTimeout(timeout);
+    }
+    if (signal && onAbort) {
+      signal.removeEventListener("abort", onAbort);
     }
   }
 }
@@ -84,6 +107,9 @@ export async function dispatchGatewayRequestInProcessRaw(
   params: unknown,
   options: InProcessGatewayDispatchOptions,
 ): Promise<GatewayMethodDispatchResponse> {
+  if (options.signal?.aborted) {
+    throw resolveDispatchAbortError(method, options.signal);
+  }
   let firstResponse: GatewayMethodDispatchResponse | undefined;
   let finalResponse: GatewayMethodDispatchResponse | undefined;
   let resolveFirstResponse: ((response: GatewayMethodDispatchResponse) => void) | undefined;
@@ -120,6 +146,7 @@ export async function dispatchGatewayRequestInProcessRaw(
     },
     context: options.context,
     methodRegistry: options.methodRegistry,
+    ...(options.signal ? { signal: options.signal } : {}),
   })
     .then(() => {
       if (!firstResponse) {
@@ -138,7 +165,7 @@ export async function dispatchGatewayRequestInProcessRaw(
       rejectFinalResponse?.(error);
     });
 
-  firstResponse = await waitForDispatch(method, firstResponsePromise, deadlineMs);
+  firstResponse = await waitForDispatch(method, firstResponsePromise, deadlineMs, options.signal);
   const firstPayload = firstResponse.payload as { status?: unknown } | undefined;
   if (options.expectFinal !== true || firstPayload?.status !== "accepted") {
     return firstResponse;
@@ -149,36 +176,22 @@ export async function dispatchGatewayRequestInProcessRaw(
   }
   return (
     finalResponse ??
-    (await new Promise<GatewayMethodDispatchResponse>((resolve, reject) => {
-      resolveFinalResponse = resolve;
-      const timeoutMs = resolveRemainingDispatchTimeoutMs(deadlineMs);
-      const timeout =
-        timeoutMs === undefined
-          ? undefined
-          : setTimeout(() => reject(new Error(`gateway request timeout for ${method}`)), timeoutMs);
-      const clearFinalTimeout = () => {
-        if (timeout) {
-          clearTimeout(timeout);
+    (await waitForDispatch(
+      method,
+      new Promise<GatewayMethodDispatchResponse>((resolve, reject) => {
+        resolveFinalResponse = resolve;
+        rejectFinalResponse = reject;
+        if (postFirstResponseError) {
+          reject(postFirstResponseError);
+          return;
         }
-      };
-      rejectFinalResponse = (err) => {
-        clearFinalTimeout();
-        reject(err);
-      };
-      if (postFirstResponseError) {
-        rejectFinalResponse(postFirstResponseError);
-        return;
-      }
-      if (finalResponse) {
-        clearFinalTimeout();
-        resolve(finalResponse);
-        return;
-      }
-      resolveFinalResponse = (response) => {
-        clearFinalTimeout();
-        resolve(response);
-      };
-    }))
+        if (finalResponse) {
+          resolve(finalResponse);
+        }
+      }),
+      deadlineMs,
+      options.signal,
+    ))
   );
 }
 

--- a/src/gateway/server-methods.ts
+++ b/src/gateway/server-methods.ts
@@ -955,7 +955,7 @@ function createRequestGatewayMethodRegistry(
 export async function handleGatewayRequest(
   opts: GatewayRequestOptions & { extraHandlers?: GatewayRequestHandlers },
 ): Promise<void> {
-  const { req, respond, client, isWebchatConnect, context } = opts;
+  const { req, respond, client, isWebchatConnect, context, signal } = opts;
   // Prefer the caller-attached registry when it owns the requested method so plugin dispatch
   // metadata newer than global runtime state still authorizes and dispatches correctly. When the
   // attached snapshot does not own the method, rebuild from the gateway-pinned registry. Without
@@ -1103,6 +1103,7 @@ export async function handleGatewayRequest(
       isWebchatConnect,
       respond,
       context,
+      ...(signal ? { signal } : {}),
       ...(sessionMutation.authorization
         ? { sessionMutationAuthorization: sessionMutation.authorization }
         : {}),

--- a/src/gateway/server-methods/nodes.invoke-abort.test.ts
+++ b/src/gateway/server-methods/nodes.invoke-abort.test.ts
@@ -1,0 +1,151 @@
+/** Ensures caller cancellation composes with, but never replaces, node pairing ownership. */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { isNodeWakeLifecycleCurrent } from "../node-wake-state.js";
+import { resetNodeWakeStateForTest } from "../node-wake-state.test-support.js";
+import { nodeInvokeHandlers } from "./nodes.invoke.js";
+import type { GatewayRequestHandlerOptions } from "./shared-types.js";
+
+const mocks = vi.hoisted(() => ({
+  captureNodePairingGeneration: vi.fn(async (nodeId: string) => ({
+    nodeId,
+    key: `generation:${nodeId}:1`,
+  })),
+  isNodePairingGenerationCurrent: vi.fn(async () => true),
+  isNodeCommandAllowed: vi.fn(() => ({ ok: true as const })),
+  resolveNodeCommandAllowlist: vi.fn(() => new Set<string>()),
+  applyPluginNodeInvokePolicy: vi.fn(async () => undefined),
+  sanitizeNodeInvokeParamsForForwarding: vi.fn(({ rawParams }: { rawParams: unknown }) => ({
+    ok: true as const,
+    params: rawParams,
+  })),
+}));
+
+vi.mock("../../infra/node-pairing-state.js", () => ({
+  captureNodePairingGeneration: mocks.captureNodePairingGeneration,
+  isNodePairingGenerationCurrent: mocks.isNodePairingGenerationCurrent,
+}));
+
+vi.mock("../node-command-policy.js", () => ({
+  DEFAULT_DANGEROUS_NODE_COMMANDS: [],
+  isForegroundRestrictedPluginNodeCommand: () => false,
+  isNodeCommandAllowed: mocks.isNodeCommandAllowed,
+  resolveNodeCommandAllowlist: mocks.resolveNodeCommandAllowlist,
+}));
+
+vi.mock("../node-invoke-plugin-policy.js", () => ({
+  applyPluginNodeInvokePolicy: mocks.applyPluginNodeInvokePolicy,
+}));
+
+vi.mock("../node-invoke-sanitize.js", () => ({
+  sanitizeNodeInvokeParamsForForwarding: mocks.sanitizeNodeInvokeParamsForForwarding,
+}));
+
+const session = {
+  nodeId: "paired-node",
+  connId: "paired-node-connection",
+  pairingGeneration: "generation:paired-node:1",
+  commands: ["ollama.chat"],
+  client: { invalidated: false },
+};
+
+beforeEach(() => {
+  resetNodeWakeStateForTest();
+  vi.clearAllMocks();
+});
+
+afterEach(() => {
+  resetNodeWakeStateForTest();
+});
+
+function startNodeInvoke(options: { invoke: ReturnType<typeof vi.fn>; signal?: AbortSignal }) {
+  const respond = vi.fn();
+  const handler = nodeInvokeHandlers["node.invoke"];
+  if (!handler) {
+    throw new Error("node.invoke handler is not registered");
+  }
+  const invocation = handler({
+    req: { type: "req", id: "paired-inference-request", method: "node.invoke" },
+    params: {
+      nodeId: "paired-node",
+      command: "ollama.chat",
+      params: { model: "node-local:small", prompt: "answer locally" },
+      timeoutMs: 10_000,
+      idempotencyKey: "paired-inference-idempotency-key",
+    },
+    client: null,
+    isWebchatConnect: () => false,
+    respond,
+    context: {
+      nodeRegistry: {
+        get: () => session,
+        getForPairingGeneration: () => session,
+        invoke: options.invoke,
+      },
+      getRuntimeConfig: () => ({}),
+      logGateway: { info: vi.fn(), warn: vi.fn() },
+    } as unknown as GatewayRequestHandlerOptions["context"],
+    ...(options.signal ? { signal: options.signal } : {}),
+  });
+  return { invocation, respond };
+}
+
+describe("node.invoke caller cancellation", () => {
+  it("cancels paired-node work without breaking pairing lifecycle identity", async () => {
+    const controller = new AbortController();
+    const invoke = vi.fn(
+      (params: { signal?: AbortSignal }) =>
+        new Promise((resolve) => {
+          params.signal?.addEventListener(
+            "abort",
+            () => resolve({ ok: false, error: { code: "ABORTED", message: "canceled" } }),
+            { once: true },
+          );
+        }),
+    );
+    const { invocation, respond } = startNodeInvoke({ invoke, signal: controller.signal });
+    await vi.waitFor(() => expect(invoke).toHaveBeenCalledOnce());
+    const invocationSignal = invoke.mock.calls[0]?.[0].signal as AbortSignal;
+
+    expect(invocationSignal).toBeInstanceOf(AbortSignal);
+    expect(invocationSignal.aborted).toBe(false);
+    expect(invocationSignal).not.toBe(controller.signal);
+    controller.abort(new Error("paired inference canceled"));
+
+    await invocation;
+
+    expect(invocationSignal.aborted).toBe(true);
+    expect(respond).toHaveBeenCalledWith(
+      false,
+      undefined,
+      expect.objectContaining({
+        details: expect.objectContaining({
+          nodeError: expect.objectContaining({ code: "ABORTED" }),
+        }),
+      }),
+    );
+  });
+
+  it("keeps the canonical pairing-owner signal for legacy callers", async () => {
+    let ownerSignalWasCurrent = false;
+    const invoke = vi.fn(async (params: { signal?: AbortSignal }) => {
+      if (params.signal) {
+        ownerSignalWasCurrent = isNodeWakeLifecycleCurrent(
+          "paired-node",
+          params.signal,
+          "generation:paired-node:1",
+        );
+      }
+      return { ok: true, payload: { response: "node-only inference" } };
+    });
+    const { invocation, respond } = startNodeInvoke({ invoke });
+
+    await invocation;
+
+    expect(ownerSignalWasCurrent).toBe(true);
+    expect(respond).toHaveBeenCalledWith(
+      true,
+      expect.objectContaining({ nodeId: "paired-node", command: "ollama.chat" }),
+      undefined,
+    );
+  });
+});

--- a/src/gateway/server-methods/nodes.invoke.ts
+++ b/src/gateway/server-methods/nodes.invoke.ts
@@ -121,7 +121,7 @@ function emitTalkPttNodeEvent(params: {
 }
 
 export const nodeInvokeHandlers: GatewayRequestHandlers = {
-  "node.invoke": async ({ params, respond, context, client, req }) => {
+  "node.invoke": async ({ params, respond, context, client, req, signal }) => {
     if (!validateNodeInvokeParams(params)) {
       respondInvalidParams({
         respond,
@@ -233,6 +233,9 @@ export const nodeInvokeHandlers: GatewayRequestHandlers = {
         return;
       }
       const wakeLifecycle = captureNodeWakeLifecycle(nodeId, generation.key);
+      // Wake helpers identify their owner by the original signal. Compose the
+      // caller only for dispatched node work; never replace that owner signal.
+      const invocationLifecycle = signal ? AbortSignal.any([wakeLifecycle, signal]) : wakeLifecycle;
       try {
         const continuePairingWork = async (): Promise<boolean> => {
           const pairingCurrent = await awaitNodeInvokeWithinDeadline(
@@ -476,7 +479,7 @@ export const nodeInvokeHandlers: GatewayRequestHandlers = {
                 threadId: p.turnSourceThreadId,
               },
               timeoutMs: p.timeoutMs,
-              signal: wakeLifecycle,
+              signal: invocationLifecycle,
               resolveRemainingTimeoutMs: resolveRemainingInvokeTimeoutMs,
               onNodeCommandDispatched: () => {
                 // Deadline races must retain transport ownership so a command
@@ -590,7 +593,7 @@ export const nodeInvokeHandlers: GatewayRequestHandlers = {
           command,
           params: forwardedParams.params,
           timeoutMs: dispatchTimeoutMs,
-          signal: wakeLifecycle,
+          signal: invocationLifecycle,
           idempotencyKey: p.idempotencyKey,
           ...(sessionKey ? { sessionKey } : {}),
         });

--- a/src/gateway/server-methods/shared-types.ts
+++ b/src/gateway/server-methods/shared-types.ts
@@ -314,6 +314,8 @@ export type GatewayRequestOptions = {
   respond: RespondFn;
   context: GatewayRequestContext;
   methodRegistry?: GatewayMethodRegistryView;
+  /** In-process caller lifetime; never serialized into a Gateway request frame. */
+  signal?: AbortSignal;
 };
 
 /** Commit-time guard captured by the pre-dispatch session participation check. */
@@ -331,6 +333,8 @@ export type GatewayRequestHandlerOptions = {
   respond: RespondFn;
   context: GatewayRequestContext;
   sessionMutationAuthorization?: SessionMutationAuthorization;
+  /** In-process caller lifetime; absent for ordinary transport requests. */
+  signal?: AbortSignal;
 };
 
 /** Single gateway method implementation. */

--- a/src/gateway/server-plugins.ts
+++ b/src/gateway/server-plugins.ts
@@ -253,6 +253,7 @@ type DispatchGatewayMethodInProcessOptions = {
   requireScopedClient?: boolean;
   syntheticScopes?: string[];
   timeoutMs?: number;
+  signal?: AbortSignal;
 };
 
 export type { GatewayMethodDispatchResponse } from "./server-in-process-dispatch.js";
@@ -324,6 +325,7 @@ export async function dispatchGatewayMethodInProcessRaw(
     onAccepted: options?.onAccepted,
     requestIdPrefix: "plugin-subagent",
     timeoutMs: options?.timeoutMs,
+    ...(options?.signal ? { signal: options.signal } : {}),
   });
 }
 
@@ -507,6 +509,8 @@ export function createGatewaySubagentRuntime(): PluginRuntime["subagent"] {
   };
 }
 
+type GatewayRuntimeNodes = Awaited<ReturnType<PluginRuntime["nodes"]["list"]>>["nodes"];
+
 export function createGatewayNodesRuntime(): PluginRuntime["nodes"] {
   return {
     async list(params) {
@@ -516,14 +520,12 @@ export function createGatewayNodesRuntime(): PluginRuntime["nodes"] {
         params?.connected === true
           ? nodes.filter(
               (node) =>
-                node !== null &&
                 typeof node === "object" &&
-                (node as { connected?: unknown }).connected === true,
+                (node as { connected?: unknown } | null)?.connected === true,
             )
           : nodes;
-      const projectedNodes = projectGatewayRuntimeNodes(filteredNodes);
       return {
-        nodes: projectedNodes as Awaited<ReturnType<PluginRuntime["nodes"]["list"]>>["nodes"],
+        nodes: projectGatewayRuntimeNodes(filteredNodes) as GatewayRuntimeNodes,
       };
     },
     async invoke(params) {
@@ -538,7 +540,7 @@ export function createGatewayNodesRuntime(): PluginRuntime["nodes"] {
         pluginTrustedOfficialInstall: scope?.pluginTrustedOfficialInstall,
         requestedScopes: normalizeOperatorScopeList(params.scopes),
       });
-      const payload = await dispatchGatewayMethodInProcess<unknown>(
+      return await dispatchGatewayMethodInProcess<unknown>(
         "node.invoke",
         {
           nodeId: params.nodeId,
@@ -550,9 +552,9 @@ export function createGatewayNodesRuntime(): PluginRuntime["nodes"] {
         {
           ...(pluginId ? { pluginRuntimeOwnerId: pluginId } : {}),
           ...(syntheticScopes ? { forceSyntheticClient: true, syntheticScopes } : {}),
+          ...(params.signal ? { signal: params.signal } : {}),
         },
       );
-      return payload;
     },
   };
 }

--- a/src/gateway/server/ws-connection/authenticated-request-dispatch.abort.test.ts
+++ b/src/gateway/server/ws-connection/authenticated-request-dispatch.abort.test.ts
@@ -1,0 +1,235 @@
+/** Verifies transport disconnect cancels only its own paired-node invocation. */
+import { EventEmitter } from "node:events";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { WebSocket } from "ws";
+import {
+  GATEWAY_CLIENT_IDS,
+  GATEWAY_CLIENT_MODES,
+} from "../../../../packages/gateway-protocol/src/client-info.js";
+import { NodeRegistry } from "../../node-registry.js";
+import type { GatewayRequestOptions } from "../../server-methods/types.js";
+import type { GatewayWsClient } from "../ws-types.js";
+import { createGatewayAuthenticatedRequestDispatcher } from "./authenticated-request-dispatch.js";
+import type { GatewayWsMessageHandlerParams } from "./message-handler-types.js";
+
+const handleGatewayRequest = vi.hoisted(() => vi.fn());
+
+vi.mock("../../server-methods.js", () => ({ handleGatewayRequest }));
+
+const activeRegistries = new Set<NodeRegistry>();
+
+afterEach(() => {
+  for (const registry of activeRegistries) {
+    registry.unregister("paired-node-connection");
+  }
+  activeRegistries.clear();
+  handleGatewayRequest.mockReset();
+});
+
+function createPairedNode() {
+  const frames: string[] = [];
+  const registry = new NodeRegistry();
+  activeRegistries.add(registry);
+  registry.register(
+    {
+      connId: "paired-node-connection",
+      usesSharedGatewayAuth: false,
+      socket: {
+        send(frame: unknown) {
+          if (typeof frame === "string") {
+            frames.push(frame);
+          }
+        },
+      },
+      connect: {
+        minProtocol: 1,
+        maxProtocol: 1,
+        client: {
+          id: GATEWAY_CLIENT_IDS.NODE_HOST,
+          version: "1.0.0",
+          platform: "linux",
+          mode: "node",
+        },
+        device: {
+          id: "paired-node",
+          publicKey: "public-key",
+          signature: "signature",
+          signedAt: 1,
+          nonce: "nonce",
+        },
+        caps: ["local-inference"],
+        commands: ["ollama.chat"],
+      },
+    } as GatewayWsClient,
+    { pairingIdentity: "paired-node-identity" },
+  );
+  return { registry, frames };
+}
+
+function createDispatcher(
+  socket: EventEmitter,
+  clientIdentity: Pick<GatewayWsClient["connect"]["client"], "id" | "mode"> = {
+    id: GATEWAY_CLIENT_IDS.CLI,
+    mode: GATEWAY_CLIENT_MODES.CLI,
+  },
+) {
+  const client = {
+    socket: socket as unknown as WebSocket,
+    connId: "operator-connection",
+    usesSharedGatewayAuth: false,
+    connect: {
+      minProtocol: 1,
+      maxProtocol: 1,
+      client: { ...clientIdentity, version: "1.0.0", platform: "linux" },
+      role: "operator",
+      scopes: ["operator.write"],
+    },
+  } as GatewayWsClient;
+  const dispatcher = createGatewayAuthenticatedRequestDispatcher({
+    handler: {
+      connId: client.connId,
+      extraHandlers: {},
+      buildRequestContext: () => ({}) as never,
+      send: vi.fn(),
+      close: vi.fn(),
+      isClosed: () => false,
+      setCloseCause: vi.fn(),
+      logGateway: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+    } as unknown as GatewayWsMessageHandlerParams,
+    isWebchatConnect: () => false,
+  });
+  return { client, dispatcher };
+}
+
+describe("paired-node WebSocket request cancellation", () => {
+  it("forwards CLI socket closure to the actual first-party node cancel event", async () => {
+    const socket = new EventEmitter();
+    const { registry, frames } = createPairedNode();
+    const { client, dispatcher } = createDispatcher(socket);
+    handleGatewayRequest.mockImplementation(async (options: GatewayRequestOptions) => {
+      const result = await registry.invoke({
+        nodeId: "paired-node",
+        command: "ollama.chat",
+        timeoutMs: 10_000,
+        signal: options.signal,
+      });
+      options.respond(
+        result.ok,
+        result.payload,
+        result.error
+          ? {
+              code: result.error.code ?? "UNAVAILABLE",
+              message: result.error.message ?? "node invocation failed",
+            }
+          : undefined,
+      );
+    });
+
+    await dispatcher.dispatch(
+      {
+        type: "req",
+        id: "paired-node-cli-inference",
+        method: "node.invoke",
+        params: {
+          nodeId: "paired-node",
+          command: "ollama.chat",
+          idempotencyKey: "paired-node-cli-inference",
+        },
+      },
+      client,
+    );
+    await vi.waitFor(() => expect(frames).toHaveLength(1));
+    expect(socket.listenerCount("close")).toBe(1);
+
+    socket.emit("close", 1000, Buffer.alloc(0));
+
+    await vi.waitFor(() => expect(frames).toHaveLength(2));
+    const request = JSON.parse(frames[0] ?? "{}") as { payload?: { id?: string } };
+    expect(JSON.parse(frames[1] ?? "{}")).toMatchObject({
+      event: "node.invoke.cancel",
+      payload: { invokeId: request.payload?.id, nodeId: "paired-node" },
+    });
+    await vi.waitFor(() => expect(socket.listenerCount("close")).toBe(0));
+  });
+
+  it("does not attach a node cancellation lifetime to unrelated requests", async () => {
+    const socket = new EventEmitter();
+    const { client, dispatcher } = createDispatcher(socket);
+    handleGatewayRequest.mockImplementation(async (options: GatewayRequestOptions) => {
+      options.respond(true, { ok: true });
+    });
+
+    await dispatcher.dispatch(
+      { type: "req", id: "ordinary-request", method: "test.trace", params: {} },
+      client,
+    );
+    await vi.waitFor(() => expect(handleGatewayRequest).toHaveBeenCalledOnce());
+
+    expect(handleGatewayRequest.mock.calls[0]?.[0]).not.toHaveProperty("signal");
+    expect(socket.listenerCount("close")).toBe(0);
+  });
+
+  it.each([
+    {
+      label: "control UI",
+      id: GATEWAY_CLIENT_IDS.CONTROL_UI,
+      mode: GATEWAY_CLIENT_MODES.UI,
+    },
+    {
+      label: "gateway SDK",
+      id: GATEWAY_CLIENT_IDS.GATEWAY_CLIENT,
+      mode: GATEWAY_CLIENT_MODES.BACKEND,
+    },
+    {
+      label: "native macOS app",
+      id: GATEWAY_CLIENT_IDS.MACOS_APP,
+      mode: GATEWAY_CLIENT_MODES.UI,
+    },
+  ])(
+    "does not cancel an authenticated $label node invocation on socket close",
+    async (identity) => {
+      const socket = new EventEmitter();
+      const { registry, frames } = createPairedNode();
+      const { client, dispatcher } = createDispatcher(socket, identity);
+      handleGatewayRequest.mockImplementation(async (options: GatewayRequestOptions) => {
+        const result = await registry.invoke({
+          nodeId: "paired-node",
+          command: "ollama.chat",
+          timeoutMs: 10_000,
+          signal: options.signal,
+        });
+        options.respond(result.ok, result.payload);
+      });
+
+      await dispatcher.dispatch(
+        {
+          type: "req",
+          id: "paired-node-ordinary-inference",
+          method: "node.invoke",
+          params: {
+            nodeId: "paired-node",
+            command: "ollama.chat",
+            idempotencyKey: "paired-node-ordinary-inference",
+          },
+        },
+        client,
+      );
+      await vi.waitFor(() => expect(frames).toHaveLength(1));
+      expect(handleGatewayRequest.mock.calls[0]?.[0]).not.toHaveProperty("signal");
+      expect(socket.listenerCount("close")).toBe(0);
+
+      socket.emit("close", 1000, Buffer.alloc(0));
+
+      expect(frames).toHaveLength(1);
+      const request = JSON.parse(frames[0] ?? "{}") as { payload?: { id?: string } };
+      expect(
+        registry.handleInvokeResult({
+          id: request.payload?.id ?? "",
+          nodeId: "paired-node",
+          connId: "paired-node-connection",
+          ok: true,
+        }),
+      ).toBe(true);
+    },
+  );
+});

--- a/src/gateway/server/ws-connection/authenticated-request-dispatch.ts
+++ b/src/gateway/server/ws-connection/authenticated-request-dispatch.ts
@@ -1,3 +1,7 @@
+import {
+  GATEWAY_CLIENT_IDS,
+  GATEWAY_CLIENT_MODES,
+} from "../../../../packages/gateway-protocol/src/client-info.js";
 import type { ConnectParams, ErrorShape } from "../../../../packages/gateway-protocol/src/index.js";
 import {
   ErrorCodes,
@@ -143,6 +147,18 @@ export function createGatewayAuthenticatedRequestDispatcher(params: {
     };
 
     const executeRequest = async () => {
+      // One-shot CLI clients cancel by closing their authenticated socket;
+      // leave long-lived SDK/UI invocations independent of connection teardown.
+      const nodeInvocationController =
+        req.method === "node.invoke" &&
+        client.connect.client.id === GATEWAY_CLIENT_IDS.CLI &&
+        client.connect.client.mode === GATEWAY_CLIENT_MODES.CLI
+          ? new AbortController()
+          : undefined;
+      const cancelNodeInvocation = () => nodeInvocationController?.abort();
+      if (nodeInvocationController) {
+        client.socket.once("close", cancelNodeInvocation);
+      }
       try {
         const { handleGatewayRequest } = await import("../../server-methods.js");
         await handleGatewayRequest({
@@ -153,11 +169,16 @@ export function createGatewayAuthenticatedRequestDispatcher(params: {
           extraHandlers,
           methodRegistry: getMethodRegistry?.(),
           context: buildRequestContext(),
+          ...(nodeInvocationController ? { signal: nodeInvocationController.signal } : {}),
         });
       } catch (err) {
         // Failure diagnostics and responses belong to the same request trace as the handler.
         logGateway.error(`request handler failed: ${formatForLog(err)}`);
         respond(false, undefined, errorShape(ErrorCodes.UNAVAILABLE, formatForLog(err)));
+      } finally {
+        if (nodeInvocationController) {
+          client.socket.off("close", cancelNodeInvocation);
+        }
       }
     };
     const upstreamTrace = parseDiagnosticTraceparent(req.traceparent);

--- a/src/node-host/invoke.ts
+++ b/src/node-host/invoke.ts
@@ -747,7 +747,13 @@ async function dispatchInvoke(
   try {
     const { pluginCommandIo: io, pluginCommandContext: context } = runtime;
     const invokeContext =
-      context && frame.sessionKey ? { ...context, sessionKey: frame.sessionKey } : context;
+      context && (frame.sessionKey || runtime.signal)
+        ? {
+            ...context,
+            ...(frame.sessionKey ? { sessionKey: frame.sessionKey } : {}),
+            ...(runtime.signal ? { signal: runtime.signal } : {}),
+          }
+        : context;
     const pluginResult = await invokePlugin(command, frame.paramsJSON, io, invokeContext);
     if (pluginResult !== null) {
       await sendRawPayloadResult(client, frame, pluginResult);

--- a/src/node-host/plugin-node-host.abort.test.ts
+++ b/src/node-host/plugin-node-host.abort.test.ts
@@ -1,0 +1,110 @@
+/** Verifies non-duplex plugin commands inherit the node invocation lifetime. */
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { GatewayClient } from "../gateway/client.js";
+import { createEmptyPluginRegistry } from "../plugins/registry-empty.js";
+import { resetPluginRuntimeStateForTest, setActivePluginRegistry } from "../plugins/runtime.js";
+import type { OpenClawPluginNodeHostCommandContext } from "../plugins/types.node-host.js";
+import { handleInvoke } from "./invoke.js";
+
+afterEach(() => {
+  resetPluginRuntimeStateForTest();
+});
+
+describe("non-duplex node-host plugin cancellation", () => {
+  it("passes the actual invocation signal into the node-owned plugin context", async () => {
+    const controller = new AbortController();
+    const sendNodeEvent = vi.fn(async () => undefined);
+    const handle = vi.fn(
+      async (
+        _paramsJSON?: string | null,
+        _io?: unknown,
+        context?: OpenClawPluginNodeHostCommandContext,
+      ) => {
+        await new Promise<void>((_resolve, reject) => {
+          context?.signal?.addEventListener(
+            "abort",
+            () =>
+              reject(
+                context.signal?.reason instanceof Error
+                  ? context.signal.reason
+                  : new Error("node plugin invocation aborted", { cause: context.signal?.reason }),
+              ),
+            { once: true },
+          );
+        });
+        return '{"stale":true}';
+      },
+    );
+    const registry = createEmptyPluginRegistry();
+    registry.nodeHostCommands = [
+      {
+        pluginId: "ollama",
+        pluginName: "Ollama",
+        command: { command: "ollama.chat", cap: "local-inference", handle },
+        source: "test",
+      },
+    ];
+    setActivePluginRegistry(registry);
+    const request = vi.fn<GatewayClient["request"]>().mockResolvedValue(null);
+
+    const invocation = handleInvoke(
+      {
+        id: "cancelable-model-inference",
+        nodeId: "paired-node",
+        command: "ollama.chat",
+        paramsJSON: '{"model":"local-only:small"}',
+        sessionKey: "agent:main:local-model",
+      },
+      { request } as unknown as GatewayClient,
+      { current: async () => [] },
+      undefined,
+      { signal: controller.signal, pluginCommandContext: { sendNodeEvent } },
+    );
+    await vi.waitFor(() => expect(handle).toHaveBeenCalledOnce());
+
+    controller.abort(new Error("paired inference canceled"));
+    await invocation;
+
+    expect(handle).toHaveBeenCalledWith('{"model":"local-only:small"}', undefined, {
+      sendNodeEvent,
+      sessionKey: "agent:main:local-model",
+      signal: controller.signal,
+    });
+    expect(request).not.toHaveBeenCalled();
+  });
+
+  it("preserves legacy plugin context when the caller supplies no signal", async () => {
+    const sendNodeEvent = vi.fn(async () => undefined);
+    const handle = vi.fn(async () => '{"ok":true}');
+    const registry = createEmptyPluginRegistry();
+    registry.nodeHostCommands = [
+      {
+        pluginId: "ollama",
+        pluginName: "Ollama",
+        command: { command: "ollama.chat", cap: "local-inference", handle },
+        source: "test",
+      },
+    ];
+    setActivePluginRegistry(registry);
+    const request = vi.fn<GatewayClient["request"]>().mockResolvedValue(null);
+
+    await handleInvoke(
+      {
+        id: "legacy-model-inference",
+        nodeId: "paired-node",
+        command: "ollama.chat",
+        paramsJSON: "{}",
+      },
+      { request } as unknown as GatewayClient,
+      { current: async () => [] },
+      undefined,
+      { pluginCommandContext: { sendNodeEvent } },
+    );
+
+    expect(handle).toHaveBeenCalledWith("{}", undefined, { sendNodeEvent });
+    expect(request).toHaveBeenCalledWith(
+      "node.invoke.result",
+      expect.objectContaining({ ok: true, payloadJSON: '{"ok":true}' }),
+    );
+  });
+});

--- a/src/plugins/cli-gateway-nodes-runtime.test.ts
+++ b/src/plugins/cli-gateway-nodes-runtime.test.ts
@@ -72,4 +72,32 @@ describe("createPluginCliGatewayNodesRuntime", () => {
       }),
     );
   });
+
+  it("forwards node invocation cancellation to the Gateway request", async () => {
+    const controller = new AbortController();
+    const nodes = createPluginCliGatewayNodesRuntime();
+
+    await nodes.invoke({
+      nodeId: "node-1",
+      command: "ollama.chat",
+      signal: controller.signal,
+    });
+
+    expect(callGatewayMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        method: "node.invoke",
+        signal: controller.signal,
+      }),
+    );
+    expect(callGatewayMock.mock.calls[0]?.[0].params).not.toHaveProperty("signal");
+  });
+
+  it("preserves the existing Gateway request shape when no signal is supplied", async () => {
+    const nodes = createPluginCliGatewayNodesRuntime();
+
+    await nodes.invoke({ nodeId: "node-1", command: "ollama.chat" });
+
+    expect(callGatewayMock.mock.calls[0]?.[0]).not.toHaveProperty("signal");
+    expect(callGatewayMock.mock.calls[0]?.[0].params).not.toHaveProperty("signal");
+  });
 });

--- a/src/plugins/cli-gateway-nodes-runtime.ts
+++ b/src/plugins/cli-gateway-nodes-runtime.ts
@@ -77,6 +77,7 @@ export function createPluginCliGatewayNodesRuntime(): PluginRuntime["nodes"] {
         clientName: GATEWAY_CLIENT_NAMES.CLI,
         mode: GATEWAY_CLIENT_MODES.CLI,
         ...(scopes ? { scopes } : {}),
+        ...(params.signal ? { signal: params.signal } : {}),
       });
     },
   };

--- a/src/plugins/runtime/types.ts
+++ b/src/plugins/runtime/types.ts
@@ -90,6 +90,8 @@ type RuntimeNodeInvokeParams = {
   params?: unknown;
   timeoutMs?: number;
   idempotencyKey?: string;
+  /** Cancel the invocation and any work already dispatched to a first-party node. */
+  signal?: AbortSignal;
   /** Requested Gateway scopes. Honored only for bundled or trusted official plugins. */
   scopes?: OperatorScope[];
 };

--- a/src/plugins/types.node-host.ts
+++ b/src/plugins/types.node-host.ts
@@ -19,6 +19,8 @@ export type OpenClawPluginNodeHostCommandContext = {
   sendNodeEvent(event: string, payload: unknown): Promise<unknown>;
   /** Agent session that owns this invocation, when the caller supplied one. */
   sessionKey?: string;
+  /** Aborts when the Gateway cancels this specific node-host invocation. */
+  signal?: AbortSignal;
 };
 
 type OpenClawPluginNodeHostCommandBase = {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users running local inference on a paired node would leave Ollama discovery or generation running after an authenticated CLI or in-process Gateway caller disconnected.

## Why This Change Was Made

Propagate caller cancellation through the existing authorized paired-node invocation lifetime and first-party node.invoke.cancel event, while combining cancellation with the existing monotonic local inference deadline. Restrict WebSocket-close cancellation to the authenticated canonical CLI client; preserve the original pairing owner, long-lived control UI/SDK/native app invocations, node-local SSRF policy, existing scopes, and the unchanged public protocol.

## User Impact

Abandoned paired-node model discovery and inference stop promptly instead of wasting CPU, memory, GPU, or Ollama sockets. Existing control UI, native app, gateway SDK, and no-signal plugin invocations continue unchanged. Pre-aborted callers consistently receive typed Error rejections, and request-scoped deadlines or cancellation cannot poison shared model metadata.

## Evidence

- 12 focused regression files and 88 passing tests spanning Gateway, authenticated CLI transport, pairing, plugin/node host, Ollama deadline, provider metadata, SSRF, and node-local inference.
- Real NodeRegistry evidence proves the existing first-party node.invoke.cancel frame is emitted for authenticated CLI disconnect and in-process cancellation.
- Real node-local HTTP fixtures prove abandoned Ollama /api/tags, /api/show, and /api/chat requests close.
- Real paired-node regressions prove control UI, gateway SDK, and native macOS client invocations survive socket closure and complete.
- Six typed pre-aborted regressions cover in-process Gateway, provider tags/show/context/completion, and the node inference agent tool.
- The already-landed paired-node inference deadline remains present and is validated alongside cancellation.
- Blacksmith Testbox validates all changed core, core test, extension, extension test, and docs lanes; plugin SDK surface; production build; and docs checks.
- Independent exact-head autoreview: clean, confidence 0.95.
- AI-assisted.
