### PR TITLE
fix(heartbeat): keep message-tool final replies private

### DIFF
--- a/src/infra/heartbeat-runner-delivery.ts
+++ b/src/infra/heartbeat-runner-delivery.ts
@@ -2,7 +2,7 @@ import {
   hasOutboundReplyContent,
   resolveSendableOutboundReplyParts,
 } from "openclaw/plugin-sdk/reply-payload";
-import { copyReplyPayloadMetadata } from "../auto-reply/reply-payload.js";
+import { copyReplyPayloadMetadata, getReplyPayloadMetadata } from "../auto-reply/reply-payload.js";
 import { replaceGenericExternalRunFailureText } from "../auto-reply/reply/agent-runner-failure-copy.js";
 import { buildRecoverablePendingFinalDeliveryText } from "../auto-reply/reply/pending-final-delivery.js";
 import { sendDurableMessageBatch } from "../channels/message/runtime.js";
@@ -56,6 +56,7 @@ function heartbeatRunOwnsPendingFinalDelivery(
 export function classifyHeartbeatAgentOutcome(params: {
   agentRun: CompletedHeartbeatAgentRun;
   hasRelayableExecCompletion: boolean;
+  suppressUnmarkedSourceReplies: boolean;
   responsePrefix: string | undefined;
   ackMaxChars: number;
 }) {
@@ -67,6 +68,19 @@ export function classifyHeartbeatAgentOutcome(params: {
       preview: truncateHeartbeatPreview(heartbeatToolResponse.summary),
       response: heartbeatToolResponse,
     } as const;
+  }
+  if (
+    params.suppressUnmarkedSourceReplies &&
+    !params.hasRelayableExecCompletion &&
+    !heartbeatToolResponse &&
+    !heartbeatTerminalToolFailure &&
+    replyPayload &&
+    replyPayload.isError !== true &&
+    getReplyPayloadMetadata(replyPayload)?.deliverDespiteSourceReplySuppression !== true
+  ) {
+    // Message-tool privacy never makes an ordinary assistant final outbound;
+    // marked operator notices and terminal failures keep their visible paths.
+    return { kind: "ack", eventStatus: "ok-token", silent: true } as const;
   }
   if (!heartbeatToolResponse && (!replyPayload || !hasOutboundReplyContent(replyPayload))) {
     return { kind: "ack", eventStatus: "ok-empty" } as const;

--- a/src/infra/heartbeat-runner-execution.ts
+++ b/src/infra/heartbeat-runner-execution.ts
@@ -13,6 +13,7 @@ import {
   resolveHeartbeatToolResponseFromReplyResult,
 } from "../auto-reply/heartbeat-tool-response.js";
 import { stripHeartbeatToken } from "../auto-reply/heartbeat.js";
+import { markReplyPayloadForSourceSuppressionDelivery } from "../auto-reply/reply-payload.js";
 import {
   REPLY_OPERATION_RUN_STATE,
   type ReplyOperationRunState,
@@ -630,7 +631,13 @@ export async function invokeHeartbeatAgentRun(
   const heartbeatToolResponse = resolveHeartbeatToolResponseFromReplyResult(replyResult);
   const heartbeatScratchProposal = resolveHeartbeatScratchProposalFromReplyResult(replyResult);
   const heartbeatTerminalToolFailure = resolveHeartbeatTerminalToolFailure(replyResult);
-  const replyPayload = resolveHeartbeatReplyPayload(replyResult);
+  const selectedReplyPayload = resolveHeartbeatReplyPayload(replyResult);
+  // Commitment turns are explicit user notifications, not assistant source
+  // replies; keep their owner-marked delivery visible under tool-only policy.
+  const replyPayload =
+    hasDueCommitments && selectedReplyPayload
+      ? markReplyPayloadForSourceSuppressionDelivery(selectedReplyPayload)
+      : selectedReplyPayload;
   if (
     heartbeatScratchProposal !== undefined &&
     heartbeatToolResponse &&

--- a/src/infra/heartbeat-runner-run.ts
+++ b/src/infra/heartbeat-runner-run.ts
@@ -1,4 +1,5 @@
 import { resolveResponsePrefixTemplate } from "../auto-reply/reply/response-prefix-template.js";
+import { resolveSourceReplyDeliveryMode } from "../auto-reply/reply/source-reply-delivery-mode.js";
 import { HEARTBEAT_TOKEN } from "../auto-reply/tokens.js";
 import { sendDurableMessageBatch } from "../channels/message/runtime.js";
 import { markCommitmentsAttempted } from "../commitments/store.js";
@@ -153,6 +154,11 @@ export async function runHeartbeatOnce(opts: HeartbeatRunOptions): Promise<Heart
     const outcome = classifyHeartbeatAgentOutcome({
       agentRun,
       hasRelayableExecCompletion,
+      suppressUnmarkedSourceReplies:
+        resolveSourceReplyDeliveryMode({
+          cfg,
+          ctx: { ChatType: delivery.chatType, Provider: delivery.channel },
+        }) === "message_tool_only",
       responsePrefix: resolveHeartbeatResponsePrefix(),
       ackMaxChars: resolveHeartbeatAckMaxChars(cfg, heartbeat),
     });

--- a/src/infra/heartbeat-runner.commitments.test.ts
+++ b/src/infra/heartbeat-runner.commitments.test.ts
@@ -534,6 +534,21 @@ describe("runHeartbeatOnce commitments", () => {
     });
   });
 
+  it("delivers user commitments when automatic heartbeat replies are message-tool-only", async () => {
+    const { result, sendTelegram, store } = await setupCommitmentCase({
+      visibleReplies: "message_tool",
+    });
+
+    expect(result.status).toBe("ran");
+    expect(sendTelegram).toHaveBeenCalledTimes(1);
+    expectCommitmentFields(store.commitments[0], {
+      id: "cm_interview",
+      status: "sent",
+      attempts: 1,
+      sentAtMs: nowMs,
+    });
+  });
+
   it("keeps commitment-only delivery on the configured isolated run session", async () => {
     const { result, sendTelegram, store } = await setupCommitmentCase({
       isolatedSession: true,

--- a/src/infra/heartbeat-runner.tool-response.test.ts
+++ b/src/infra/heartbeat-runner.tool-response.test.ts
@@ -735,6 +735,93 @@ describe("runHeartbeatOnce heartbeat response tool", () => {
     });
   });
 
+  it.each([
+    {
+      name: "global message-tool reply policy",
+      visibleReplies: "message_tool" as const,
+      target: "telegram" as const,
+      chatType: "direct" as const,
+    },
+    {
+      name: "group-specific message-tool reply policy",
+      groupVisibleReplies: "message_tool" as const,
+      target: "last" as const,
+      chatType: "group" as const,
+    },
+  ])("keeps a heartbeat's unmarked final private under $name", async (policy) => {
+    await withTempTelegramHeartbeatSandbox(async ({ tmpDir, storePath, replySpy }) => {
+      const cfg = createConfig({ tmpDir, storePath, ...policy });
+      await seedMainSessionStore(storePath, cfg, {
+        chatType: policy.chatType,
+        lastChannel: "telegram",
+        lastProvider: "telegram",
+        lastTo: TELEGRAM_GROUP,
+      });
+      replySpy.mockResolvedValue({
+        text: "Private heartbeat reasoning with HEARTBEAT_OK inside the sentence.",
+      });
+      const sendTelegram = vi.fn().mockResolvedValue({ messageId: "m1" });
+
+      const result = await runHeartbeatOnce({
+        cfg,
+        deps: createDeps({ sendTelegram, getReplyFromConfig: replySpy }),
+      });
+
+      expect(result.status).toBe("ran");
+      expect(replyOptions(replySpy).sourceReplyDeliveryMode).toBe("message_tool_only");
+      expect(sendTelegram).not.toHaveBeenCalled();
+      expect(getLastHeartbeatEvent()).toMatchObject({
+        status: "ok-token",
+        channel: "telegram",
+        silent: true,
+      });
+    });
+  });
+
+  it("keeps marked operator notices visible in message-tool heartbeat mode", async () => {
+    await withTempTelegramHeartbeatSandbox(async ({ tmpDir, storePath, replySpy }) => {
+      const cfg = createConfig({ tmpDir, storePath, visibleReplies: "message_tool" });
+      await seedMainSessionStore(storePath, cfg, {
+        lastChannel: "telegram",
+        lastProvider: "telegram",
+        lastTo: TELEGRAM_GROUP,
+      });
+      const notice = "The configured model backend needs operator attention.";
+      replySpy.mockResolvedValue(markReplyPayloadForSourceSuppressionDelivery({ text: notice }));
+      const sendTelegram = vi.fn().mockResolvedValue({ messageId: "m1" });
+
+      const result = await runHeartbeatOnce({
+        cfg,
+        deps: createDeps({ sendTelegram, getReplyFromConfig: replySpy }),
+      });
+
+      expect(result.status).toBe("ran");
+      expectTelegramSend(sendTelegram, { text: notice, cfg });
+    });
+  });
+
+  it("keeps ordinary heartbeat finals visible under automatic reply policy", async () => {
+    await withTempTelegramHeartbeatSandbox(async ({ tmpDir, storePath, replySpy }) => {
+      const cfg = createConfig({ tmpDir, storePath, visibleReplies: "automatic" });
+      await seedMainSessionStore(storePath, cfg, {
+        lastChannel: "telegram",
+        lastProvider: "telegram",
+        lastTo: TELEGRAM_GROUP,
+      });
+      const text = "The heartbeat found a deployment requiring your attention.";
+      replySpy.mockResolvedValue({ text });
+      const sendTelegram = vi.fn().mockResolvedValue({ messageId: "m1" });
+
+      const result = await runHeartbeatOnce({
+        cfg,
+        deps: createDeps({ sendTelegram, getReplyFromConfig: replySpy }),
+      });
+
+      expect(result.status).toBe("ran");
+      expectTelegramSend(sendTelegram, { text, cfg });
+    });
+  });
+
   it("uses the heartbeat response tool prompt in message-tool mode", async () => {
     const result = await runPromptScenario({
       config: { visibleReplies: "message_tool" },


### PR DESCRIPTION
Closes #94053.

## What Problem This Solves

Fixes an issue where users who explicitly configure message-tool-only replies receive private heartbeat assistant text in Telegram direct messages or groups whenever the model returns a substantive final without invoking the heartbeat response tool.

## Why This Change Was Made

Resolve the existing canonical source-reply visibility policy for the actual heartbeat delivery channel and chat type, then classify unmarked successful assistant finals as silent acknowledgements. Preserve terminal tool failures, relayable exec completions, explicitly marked host/operator notices, automatic reply policy, and heartbeat response notifications. Mark only actual due-commitment replies at their execution owner so explicit user follow-ups remain deliverable without disabling message-tool privacy for the entire turn.

## User Impact

Message-tool-only heartbeats stay genuinely private in both direct and group conversations. Real model/provider warnings, explicit heartbeat notifications, and promised commitment follow-ups still reach users, and ordinary automatic reply behavior is unchanged.

## Evidence

Real Linux Blacksmith Testbox tbx_01kyp441wvknmhy8tdjxgtegxt with the actual heartbeat execution pipeline, canonical SQLite session and commitment stores, model reply options, and Telegram delivery fixture.

- First-failing RED against current main: both global and group-specific message-tool privacy cases reproduced the exact private Telegram send reported in #94053; all 31 existing heartbeat-response tests passed.
- Final GREEN: 107 tests passed across heartbeat tool responses, actual Telegram privacy and marked notices, due commitments, ghost-reminder/exec-completion routing, pending-final recovery, and heartbeat scheduler behavior.
- The added commitment case verifies message-tool privacy does not suppress a real authorized follow-up; non-error marked host notices, provider error notices, terminal tool failures, and explicit automatic policy remain covered.
- Full Linux CI=1 pnpm check:changed passed with core and test tsgo, zero-warning lint, formatting, dead-export, dependency, plugin and database boundaries, schema guard, and zero import cycles.
- Independent structured gpt-5.6-sol xhigh autoreview: no accepted/actionable findings, confidence 0.86.
