### PR TITLE
fix(gateway): stop managed crash loops for pending agent DB migrations

### DIFF
--- a/src/cli/gateway-cli/run-loop.test.ts
+++ b/src/cli/gateway-cli/run-loop.test.ts
@@ -2,6 +2,10 @@
 import { describe, expect, it, vi } from "vitest";
 import type { GatewayServer } from "../../gateway/server.impl.js";
 import type { GatewayBonjourBeacon } from "../../infra/bonjour-discovery.js";
+import {
+  GATEWAY_AGENT_MEDIA_MIGRATION_REQUIRED_REASON,
+  OpenClawAgentDatabaseMediaMigrationRequiredError,
+} from "../../state/openclaw-agent-db-migration-required.js";
 import { pickBeaconHost, pickGatewayPort } from "./discover.js";
 
 const acquireGatewayLock = vi.fn(async (_opts?: { port?: number }) => ({
@@ -470,6 +474,34 @@ describe("runGatewayLoop", () => {
         (completeBoot.mock.calls[0]?.[0] as { reason?: string } | undefined)?.reason ?? "";
       expect(reason).toHaveLength(499);
       expect(Buffer.from(reason).toString()).toBe(reason);
+    });
+  });
+
+  it("records a typed reason for media-migration startup failures", async () => {
+    await withIsolatedSignals(async () => {
+      const failure = new OpenClawAgentDatabaseMediaMigrationRequiredError(
+        "/tmp/openclaw-agent.sqlite",
+        14,
+      );
+      const { runtime } = createRuntimeWithExitSignal();
+      const completeBoot = vi.fn();
+      const { runGatewayLoop } = await import("./run-loop.js");
+
+      await expect(
+        runGatewayLoop({
+          start: vi.fn(async () => {
+            throw failure;
+          }) as unknown as Parameters<typeof runGatewayLoop>[0]["start"],
+          runtime: runtime as unknown as Parameters<typeof runGatewayLoop>[0]["runtime"],
+          completeBoot,
+        }),
+      ).rejects.toBe(failure);
+
+      expect(completeBoot).toHaveBeenCalledWith({
+        outcome: "startup_failed",
+        reason: failure.message,
+        startupReason: GATEWAY_AGENT_MEDIA_MIGRATION_REQUIRED_REASON,
+      });
     });
   });
 

--- a/src/cli/gateway-cli/run-loop.ts
+++ b/src/cli/gateway-cli/run-loop.ts
@@ -12,13 +12,20 @@ import {
 } from "../../gateway/restart-trace.js";
 import type { startGatewayServer } from "../../gateway/server.js";
 import { formatErrorMessage } from "../../infra/errors.js";
-import type { GatewayBootLifecycleCompletion } from "../../infra/gateway-boot-lifecycle.js";
+import {
+  GATEWAY_BOOT_REASON_MAX_UTF16_CODE_UNITS,
+  type GatewayBootLifecycleCompletion,
+} from "../../infra/gateway-boot-lifecycle.js";
 import { acquireGatewayLock } from "../../infra/gateway-lock.js";
 import type { GatewayRestartEmitter } from "../../infra/restart.js";
 import { flushLogger } from "../../logging/logger.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
 import type { RuntimeEnv } from "../../runtime.js";
 import { createLazyImportLoader } from "../../shared/lazy-promise.js";
+import {
+  findOpenClawAgentDatabaseMediaMigrationRequiredError,
+  GATEWAY_AGENT_MEDIA_MIGRATION_REQUIRED_REASON,
+} from "../../state/openclaw-agent-db-migration-required.js";
 import { formatActiveTaskRestartBlocker } from "../../tasks/task-restart-blocker.js";
 const gatewayLog = createSubsystemLogger("gateway");
 const LAUNCHD_SUPERVISED_RESTART_EXIT_DELAY_MS = 1500;
@@ -1031,9 +1038,16 @@ export async function runGatewayLoop(params: {
         startupFailedWithoutServerHandle = false;
         isFirstStart = false;
       } catch (err) {
+        const mediaMigrationRequired = findOpenClawAgentDatabaseMediaMigrationRequiredError(err);
         params.completeBoot?.({
           outcome: "startup_failed",
-          reason: truncateUtf16Safe(formatErrorMessage(err), 500),
+          reason: truncateUtf16Safe(
+            formatErrorMessage(err),
+            GATEWAY_BOOT_REASON_MAX_UTF16_CODE_UNITS,
+          ),
+          ...(mediaMigrationRequired
+            ? { startupReason: GATEWAY_AGENT_MEDIA_MIGRATION_REQUIRED_REASON }
+            : {}),
         });
         // On initial startup, let the error propagate so the outer handler
         // can report "Gateway failed to start" and exit non-zero. Only

--- a/src/cli/gateway-cli/run.supervised-lock.test.ts
+++ b/src/cli/gateway-cli/run.supervised-lock.test.ts
@@ -2,6 +2,7 @@
 import { createServer } from "node:http";
 import { describe, expect, it, vi } from "vitest";
 import { GatewayLockError } from "../../infra/gateway-lock.js";
+import { OpenClawAgentDatabaseMediaMigrationRequiredError } from "../../state/openclaw-agent-db-migration-required.js";
 import { testing } from "./run.test-support.js";
 
 const loadGatewayTlsRuntimeMock = vi.hoisted(() =>
@@ -20,6 +21,14 @@ function createLogger() {
 }
 
 describe("supervised gateway lock recovery", () => {
+  it("uses exit 78 for offline agent database migration requirements", () => {
+    expect(
+      testing.resolveGatewayStartupFailureExitCode(
+        new OpenClawAgentDatabaseMediaMigrationRequiredError("/tmp/openclaw-agent.sqlite", 14),
+      ),
+    ).toBe(78);
+  });
+
   it("does not retry gateway lock errors outside a supervisor", async () => {
     const err = new GatewayLockError("gateway already running");
     const startLoop = vi.fn(async () => {

--- a/src/cli/gateway-cli/run.ts
+++ b/src/cli/gateway-cli/run.ts
@@ -58,6 +58,7 @@ import { setConsoleSubsystemFilter, setConsoleTimestampPrefix } from "../../logg
 import { withDiagnosticPhase } from "../../logging/diagnostic-phase.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
 import { defaultRuntime } from "../../runtime.js";
+import { findOpenClawAgentDatabaseMediaMigrationRequiredError } from "../../state/openclaw-agent-db-migration-required.js";
 import { printClawBanner, type ClawBannerResult } from "../claw-banner.js";
 import { formatCliCommand } from "../command-format.js";
 import { formatInvalidConfigPort, formatInvalidPortOption } from "../error-format.js";
@@ -474,7 +475,9 @@ function resolveGatewayLockErrorExitCode(err: unknown): number {
 }
 
 function resolveGatewayStartupFailureExitCode(err: unknown): number {
-  return isInvalidConfigError(err) ? EXIT_CONFIG_ERROR : 1;
+  return isInvalidConfigError(err) || findOpenClawAgentDatabaseMediaMigrationRequiredError(err)
+    ? EXIT_CONFIG_ERROR
+    : 1;
 }
 
 function normalizeGatewayHealthProbeHost(host: string): string {
@@ -1216,6 +1219,20 @@ async function runGatewayCommandOnce(opts: GatewayRunOpts, hooks: GatewayRunRunt
     }
     if (isInvalidConfigError(err)) {
       throw err;
+    }
+    if (findOpenClawAgentDatabaseMediaMigrationRequiredError(err)) {
+      try {
+        const { parkCurrentLaunchAgentForMaintenance } = await import("../../daemon/launchd.js");
+        if (await parkCurrentLaunchAgentForMaintenance()) {
+          gatewayLog.error(
+            `gateway requires offline media migration; parked the managed LaunchAgent. Run ${formatCliCommand("openclaw doctor --fix")} to repair and restart it.`,
+          );
+        }
+      } catch (parkError) {
+        gatewayLog.error(
+          `failed to park the managed LaunchAgent after migration-required startup: ${formatErrorMessage(parkError)}`,
+        );
+      }
     }
     await maybeWriteGatewayStartupFailureBundle(err);
     defaultRuntime.error(

--- a/src/commands/doctor-gateway-daemon-flow.test.ts
+++ b/src/commands/doctor-gateway-daemon-flow.test.ts
@@ -657,6 +657,24 @@ describe("maybeRepairGatewayDaemon", () => {
     expect(note).toHaveBeenCalledWith(EXTERNAL_SERVICE_REPAIR_NOTE, "Gateway LaunchAgent");
   });
 
+  it("re-enables and bootstraps a parked LaunchAgent during non-interactive repair", async () => {
+    setPlatform("darwin");
+    service.isLoaded.mockResolvedValueOnce(false).mockResolvedValue(true);
+    service.readRuntime
+      .mockResolvedValueOnce({ status: "unknown", missingSupervision: true })
+      .mockResolvedValue({ status: "running" });
+    vi.mocked(launchd.launchAgentPlistExists).mockResolvedValueOnce(true).mockResolvedValue(false);
+    vi.mocked(launchd.isLaunchAgentLoaded).mockResolvedValueOnce(false).mockResolvedValueOnce(true);
+
+    await runNonInteractiveRepair();
+
+    expect(launchd.repairLaunchAgentBootstrap).toHaveBeenCalledWith({
+      env: process.env,
+    });
+    expect(service.install).not.toHaveBeenCalled();
+    expect(note).toHaveBeenCalledWith("Gateway LaunchAgent repaired.", "Gateway LaunchAgent");
+  });
+
   it("reports macOS GUI-session runtime instead of install guidance for a not-loaded LaunchAgent", async () => {
     setPlatform("darwin");
     service.isLoaded.mockResolvedValue(false);

--- a/src/daemon/launchd-restart-handoff.test.ts
+++ b/src/daemon/launchd-restart-handoff.test.ts
@@ -17,7 +17,10 @@ vi.mock("node:child_process", async () => {
   };
 });
 
-import { scheduleDetachedLaunchdRestartHandoff } from "./launchd-restart-handoff.js";
+import {
+  scheduleDetachedLaunchdMaintenancePark,
+  scheduleDetachedLaunchdRestartHandoff,
+} from "./launchd-restart-handoff.js";
 
 type SpawnCall = [string, string[], { env: Record<string, string | undefined> }];
 
@@ -41,7 +44,7 @@ function requireSpawnCall(callIndex = 0): SpawnCall {
 }
 
 async function executeHandoff(
-  mode: "reload" | "start-after-exit",
+  mode: "park" | "reload" | "start-after-exit",
   launchctlStub: string,
 ): Promise<{
   calls: string[];
@@ -63,11 +66,18 @@ async function executeHandoff(
     fs.chmodSync(path.join(stubDir, "sleep"), 0o755);
 
     spawnMock.mockReturnValue({ pid: 4242, unref: unrefMock, once: vi.fn() });
-    scheduleDetachedLaunchdRestartHandoff({
-      env: { HOME: home, OPENCLAW_PROFILE: "default" },
-      mode,
-      waitForPid: noWaitPid,
-    });
+    if (mode === "park") {
+      scheduleDetachedLaunchdMaintenancePark({
+        env: { HOME: home, OPENCLAW_PROFILE: "default" },
+        waitForPid: noWaitPid,
+      });
+    } else {
+      scheduleDetachedLaunchdRestartHandoff({
+        env: { HOME: home, OPENCLAW_PROFILE: "default" },
+        mode,
+        waitForPid: noWaitPid,
+      });
+    }
     const [, args] = requireSpawnCall();
     const script = args[1];
     if (!script) {
@@ -189,6 +199,17 @@ describe("scheduleDetachedLaunchdRestartHandoff", () => {
     expect(result.calls.some((call) => call.includes("kickstart -k"))).toBe(false);
     expect(result.calls.some((call) => call.startsWith("bootstrap "))).toBe(false);
     expect(result.log).toContain("restart done");
+  });
+
+  it("parks the service with bootout after the caller exits", async () => {
+    const result = await executeHandoff(
+      "park",
+      'case "$1" in bootout) exit 0 ;; *) exit 1 ;; esac',
+    );
+
+    expect(result.exitCode).toBe(0);
+    expect(result.calls).toEqual(["bootout gui/501/test.label"]);
+    expect(result.log).toContain("service park done");
   });
 
   it("outwaits launchd's stop window after bootout and retries bootstrap for reload mode", () => {

--- a/src/daemon/launchd-restart-handoff.ts
+++ b/src/daemon/launchd-restart-handoff.ts
@@ -12,6 +12,7 @@ import { LAUNCH_AGENT_EXIT_TIMEOUT_SECONDS } from "./launchd-plist.js";
 import { renderPosixRestartLogSetup } from "./restart-logs.js";
 
 type LaunchdRestartHandoffMode = "kickstart" | "reload" | "start-after-exit";
+type LaunchdHandoffMode = LaunchdRestartHandoffMode | "park";
 
 type LaunchdRestartHandoffResult = Result<Promise<boolean>, string>;
 
@@ -95,7 +96,7 @@ function resolveLaunchdRestartTarget(
 }
 
 function buildLaunchdRestartScript(
-  mode: LaunchdRestartHandoffMode,
+  mode: LaunchdHandoffMode,
   restartLogEnv: LaunchdRestartLogEnv,
 ): string {
   // The detached shell waits for the caller before touching launchd so the
@@ -109,6 +110,26 @@ if [ -n "$wait_pid" ] && [ "$wait_pid" -gt 1 ] 2>/dev/null; then
   done
 fi
 `;
+
+  if (mode === "park") {
+    return `service_target="$1"
+domain="$2"
+plist_path="$3"
+${waitForCallerPid}
+status=0
+if launchctl bootout "$service_target"; then
+  status=0
+else
+  status=$?
+fi
+if [ "$status" -eq 0 ]; then
+  printf '[%s] openclaw service park done source=handoff interactive=0\\n' "$(date -u +%FT%TZ)" >&2
+else
+  printf '[%s] openclaw service park failed source=handoff status=%s interactive=0\\n' "$(date -u +%FT%TZ)" "$status" >&2
+fi
+exit "$status"
+`;
+  }
 
   if (mode === "kickstart") {
     // Restart is explicit operator intent; undo any previous `launchctl disable`.
@@ -231,9 +252,9 @@ exit "$status"
 `;
 }
 
-export function scheduleDetachedLaunchdRestartHandoff(params: {
+function scheduleDetachedLaunchdHandoff(params: {
   env?: Record<string, string | undefined>;
-  mode: LaunchdRestartHandoffMode;
+  mode: LaunchdHandoffMode;
   waitForPid?: number;
 }): LaunchdRestartHandoffResult {
   const target = resolveLaunchdRestartTarget(params.env);
@@ -275,4 +296,19 @@ export function scheduleDetachedLaunchdRestartHandoff(params: {
   } catch (error) {
     return err(formatErrorMessage(error));
   }
+}
+
+export function scheduleDetachedLaunchdRestartHandoff(params: {
+  env?: Record<string, string | undefined>;
+  mode: LaunchdRestartHandoffMode;
+  waitForPid?: number;
+}): LaunchdRestartHandoffResult {
+  return scheduleDetachedLaunchdHandoff(params);
+}
+
+export function scheduleDetachedLaunchdMaintenancePark(params: {
+  env?: Record<string, string | undefined>;
+  waitForPid?: number;
+}): LaunchdRestartHandoffResult {
+  return scheduleDetachedLaunchdHandoff({ ...params, mode: "park" });
 }

--- a/src/daemon/launchd.test.ts
+++ b/src/daemon/launchd.test.ts
@@ -14,6 +14,7 @@ import {
   disableCurrentOpenClawUpdateLaunchdJob,
   disableOpenClawUpdateLaunchdJob,
   findStaleOpenClawUpdateLaunchdJobs,
+  parkCurrentLaunchAgentForMaintenance,
   parseLaunchctlPrint,
   parseLaunchctlListOpenClawUpdateJobs,
   readLaunchAgentProgramArguments,
@@ -56,6 +57,9 @@ const state = vi.hoisted(() => ({
   cleanupProtectedPids: [] as Array<number | undefined>,
 }));
 const launchdRestartHandoffState = vi.hoisted(() => ({
+  scheduleDetachedLaunchdMaintenancePark: vi.fn<
+    (_params: unknown) => { ok: true; value: Promise<boolean> } | { ok: false; error: string }
+  >(() => ({ ok: true, value: Promise.resolve(true) })),
   scheduleDetachedLaunchdRestartHandoff: vi.fn<
     (_params: unknown) => { ok: true; value: Promise<boolean> } | { ok: false; error: string }
   >(() => ({ ok: true, value: Promise.resolve(true) })),
@@ -327,6 +331,8 @@ vi.mock("./exec-file.js", () => ({
 }));
 
 vi.mock("./launchd-restart-handoff.js", () => ({
+  scheduleDetachedLaunchdMaintenancePark: (params: unknown) =>
+    launchdRestartHandoffState.scheduleDetachedLaunchdMaintenancePark(params),
   scheduleDetachedLaunchdRestartHandoff: (params: unknown) =>
     launchdRestartHandoffState.scheduleDetachedLaunchdRestartHandoff(params),
 }));
@@ -454,6 +460,11 @@ beforeEach(() => {
   formatPortDiagnostics.mockReturnValue(["Port 18789 is already in use."]);
   launchdRestartHandoffState.scheduleDetachedLaunchdRestartHandoff.mockReset();
   launchdRestartHandoffState.scheduleDetachedLaunchdRestartHandoff.mockReturnValue({
+    ok: true,
+    value: Promise.resolve(true),
+  });
+  launchdRestartHandoffState.scheduleDetachedLaunchdMaintenancePark.mockReset();
+  launchdRestartHandoffState.scheduleDetachedLaunchdMaintenancePark.mockReturnValue({
     ok: true,
     value: Promise.resolve(true),
   });
@@ -1585,6 +1596,76 @@ describe("launchd install", () => {
     );
 
     expect(state.launchctlCalls).toEqual([]);
+  });
+
+  it("disables the current LaunchAgent before scheduling maintenance bootout", async () => {
+    const env = createDefaultLaunchdEnv();
+    state.disableCode = 0;
+
+    await withProcessEnv(
+      {
+        LAUNCH_JOB_LABEL: "ai.openclaw.gateway",
+      },
+      async () => {
+        await expect(parkCurrentLaunchAgentForMaintenance({ env })).resolves.toBe(true);
+      },
+    );
+
+    const domain = typeof process.getuid === "function" ? `gui/${process.getuid()}` : "gui/501";
+    expect(state.launchctlCalls).toEqual([["disable", `${domain}/ai.openclaw.gateway`]]);
+    expect(launchdRestartHandoffState.scheduleDetachedLaunchdMaintenancePark).toHaveBeenCalledWith({
+      env,
+      waitForPid: process.pid,
+    });
+  });
+
+  it("does not park an external LaunchAgent", async () => {
+    const env = createDefaultLaunchdEnv();
+
+    await withProcessEnv(
+      {
+        LAUNCH_JOB_LABEL: undefined,
+        LAUNCH_JOB_NAME: undefined,
+        XPC_SERVICE_NAME: undefined,
+        OPENCLAW_SERVICE_MARKER: undefined,
+        OPENCLAW_SERVICE_KIND: undefined,
+        OPENCLAW_LAUNCHD_LABEL: undefined,
+      },
+      async () => {
+        await expect(parkCurrentLaunchAgentForMaintenance({ env })).resolves.toBe(false);
+      },
+    );
+
+    expect(state.launchctlCalls).toEqual([]);
+    expect(
+      launchdRestartHandoffState.scheduleDetachedLaunchdMaintenancePark,
+    ).not.toHaveBeenCalled();
+  });
+
+  it("re-enables the LaunchAgent when the maintenance handoff cannot spawn", async () => {
+    const env = createDefaultLaunchdEnv();
+    state.disableCode = 0;
+    launchdRestartHandoffState.scheduleDetachedLaunchdMaintenancePark.mockReturnValueOnce({
+      ok: true,
+      value: Promise.resolve(false),
+    });
+
+    await withProcessEnv(
+      {
+        LAUNCH_JOB_LABEL: "ai.openclaw.gateway",
+      },
+      async () => {
+        await expect(parkCurrentLaunchAgentForMaintenance({ env })).rejects.toThrow(
+          "helper failed to spawn; restored launchd enable state",
+        );
+      },
+    );
+
+    const domain = typeof process.getuid === "function" ? `gui/${process.getuid()}` : "gui/501";
+    expect(state.launchctlCalls).toEqual([
+      ["disable", `${domain}/ai.openclaw.gateway`],
+      ["enable", `${domain}/ai.openclaw.gateway`],
+    ]);
   });
 
   it("refuses in-band LaunchAgent stop when XPC_SERVICE_NAME is inherited", async () => {

--- a/src/daemon/launchd.ts
+++ b/src/daemon/launchd.ts
@@ -29,7 +29,10 @@ import {
   LAUNCH_AGENT_EXIT_TIMEOUT_SECONDS,
   readLaunchAgentProgramArgumentsFromFile,
 } from "./launchd-plist.js";
-import { scheduleDetachedLaunchdRestartHandoff } from "./launchd-restart-handoff.js";
+import {
+  scheduleDetachedLaunchdMaintenancePark,
+  scheduleDetachedLaunchdRestartHandoff,
+} from "./launchd-restart-handoff.js";
 import { formatLine, toPosixPath, writeFormattedLines } from "./output.js";
 import { resolveGatewayStateDir, resolveHomeDir } from "./paths.js";
 import { resolveGatewaySupervisorLogPaths } from "./restart-logs.js";
@@ -1092,6 +1095,50 @@ export async function stopLaunchAgent({
 
   await assertGatewayPortReleasedAfterStop(serviceEnv);
   stdout.write(`${formatLine("Stopped LaunchAgent", serviceTarget)}\n`);
+}
+
+export async function parkCurrentLaunchAgentForMaintenance(
+  params: {
+    env?: GatewayServiceEnv;
+  } = {},
+): Promise<boolean> {
+  const serviceEnv = params.env ?? (process.env as GatewayServiceEnv);
+  const domain = resolveGuiDomain();
+  const label = resolveLaunchAgentLabel({ env: serviceEnv });
+  if (
+    !isCurrentProcessLaunchdServiceLabel(label, process.env, {
+      allowConfiguredLabelFallback: false,
+    })
+  ) {
+    return false;
+  }
+  const serviceTarget = `${domain}/${label}`;
+  // Disable before exit so KeepAlive cannot spawn a replacement before the
+  // detached handoff can boot the current job out of launchd.
+  const disable = await execLaunchctl(["disable", serviceTarget]);
+  if (disable.code !== 0) {
+    throw new Error(
+      `launchctl disable failed while parking ${serviceTarget}: ${formatLaunchctlResultDetail(disable)}`,
+    );
+  }
+  const handoff = scheduleDetachedLaunchdMaintenancePark({
+    env: serviceEnv,
+    waitForPid: process.pid,
+  });
+  const handoffError = !handoff.ok
+    ? handoff.error
+    : (await handoff.value)
+      ? undefined
+      : "helper failed to spawn";
+  if (handoffError) {
+    const rollback = await execLaunchctl(["enable", serviceTarget]);
+    const rollbackDetail =
+      rollback.code === 0
+        ? "restored launchd enable state"
+        : `launchctl enable rollback failed: ${formatLaunchctlResultDetail(rollback)}`;
+    throw new Error(`launchd maintenance park handoff failed: ${handoffError}; ${rollbackDetail}`);
+  }
+  return true;
 }
 
 async function writeLaunchAgentPlist({

--- a/src/infra/gateway-boot-lifecycle.test.ts
+++ b/src/infra/gateway-boot-lifecycle.test.ts
@@ -2,7 +2,12 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import { afterEach, describe, expect, it } from "vitest";
+import {
+  formatLegacyAgentMediaMigrationRequiredMessage,
+  GATEWAY_AGENT_MEDIA_MIGRATION_REQUIRED_REASON,
+} from "../state/openclaw-agent-db-migration-required.js";
 import type { DB as OpenClawStateKyselyDatabase } from "../state/openclaw-state-db.generated.js";
 import {
   closeOpenClawStateDatabaseForTest,
@@ -11,10 +16,12 @@ import {
 import {
   GATEWAY_CRASH_LOOP_BREAKER_REASON,
   GATEWAY_CRASH_LOOP_RECOVERED_REASON,
+  GATEWAY_BOOT_REASON_MAX_UTF16_CODE_UNITS,
   completeGatewayBootLifecycle,
   formatGatewayCrashLoopManualChannelStartHint,
   inspectGatewayCrashLoopBreaker,
   recordGatewayBootStart,
+  repairGatewayAgentMediaMigrationStartupFailures,
 } from "./gateway-boot-lifecycle.js";
 import { executeSqliteQuerySync, getNodeSqliteKysely } from "./kysely-sync.js";
 
@@ -192,6 +199,89 @@ describe("gateway crash-loop breaker", () => {
 
     expect(decision.tripped).toBe(false);
     expect(decision.uncleanBoots).toBe(0);
+  });
+
+  it("repairs only typed and shipped media-migration startup failures", () => {
+    const lifecycle = createLifecycleDb();
+    const databasePath = "/tmp/openclaw-agent.sqlite";
+    const longDatabasePath = `/tmp/${"agent-".repeat(100)}openclaw-agent.sqlite`;
+    const nowMs = 1_000_000;
+
+    insertBootRows(lifecycle, [
+      {
+        bootId: "typed-a",
+        startedAtMs: nowMs - 4,
+        completedAtMs: nowMs - 3,
+        outcome: "startup_failed",
+        startupReason: GATEWAY_AGENT_MEDIA_MIGRATION_REQUIRED_REASON,
+        reason: "typed migration failure",
+      },
+      {
+        bootId: "typed-b",
+        startedAtMs: nowMs - 3,
+        completedAtMs: nowMs - 2,
+        outcome: "startup_failed",
+        startupReason: GATEWAY_AGENT_MEDIA_MIGRATION_REQUIRED_REASON,
+        reason: "typed migration failure",
+      },
+      {
+        bootId: "beta-raw",
+        startedAtMs: nowMs - 2,
+        completedAtMs: nowMs - 1,
+        outcome: "startup_failed",
+        reason: formatLegacyAgentMediaMigrationRequiredMessage(databasePath, 14),
+      },
+      {
+        bootId: "beta-raw-truncated",
+        startedAtMs: nowMs - 2,
+        completedAtMs: nowMs - 1,
+        outcome: "startup_failed",
+        reason: truncateUtf16Safe(
+          formatLegacyAgentMediaMigrationRequiredMessage(longDatabasePath, 14),
+          GATEWAY_BOOT_REASON_MAX_UTF16_CODE_UNITS,
+        ),
+      },
+      {
+        bootId: "unrelated",
+        startedAtMs: nowMs - 1,
+        completedAtMs: nowMs,
+        outcome: "startup_failed",
+        reason: "EADDRINUSE",
+      },
+    ]);
+
+    expect(inspectGatewayCrashLoopBreaker(lifecycle.env, nowMs).tripped).toBe(true);
+    expect(
+      repairGatewayAgentMediaMigrationStartupFailures({
+        databasePaths: [databasePath, longDatabasePath],
+        env: lifecycle.env,
+      }),
+    ).toBe(4);
+    expect(inspectGatewayCrashLoopBreaker(lifecycle.env, nowMs + 1)).toMatchObject({
+      tripped: false,
+      uncleanBoots: 1,
+    });
+    expect(
+      repairGatewayAgentMediaMigrationStartupFailures({
+        databasePaths: [databasePath],
+        env: lifecycle.env,
+      }),
+    ).toBe(0);
+
+    const rows = executeSqliteQuerySync(
+      lifecycle.db,
+      lifecycle.kysely
+        .selectFrom("gateway_boot_lifecycle")
+        .select(["boot_id", "outcome"])
+        .orderBy("boot_id"),
+    ).rows;
+    expect(rows).toEqual([
+      { boot_id: "beta-raw", outcome: "startup_failure_repaired" },
+      { boot_id: "beta-raw-truncated", outcome: "startup_failure_repaired" },
+      { boot_id: "typed-a", outcome: "startup_failure_repaired" },
+      { boot_id: "typed-b", outcome: "startup_failure_repaired" },
+      { boot_id: "unrelated", outcome: "startup_failed" },
+    ]);
   });
 
   it("prunes boot rows older than retention when recording a new boot", () => {

--- a/src/infra/gateway-boot-lifecycle.ts
+++ b/src/infra/gateway-boot-lifecycle.ts
@@ -1,6 +1,12 @@
 // Persists gateway boot outcomes for supervisor crash-loop decisions.
 import { randomUUID } from "node:crypto";
+import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import { createSubsystemLogger } from "../logging/subsystem.js";
+import { OPENCLAW_AGENT_SCHEMA_VERSION } from "../state/openclaw-agent-db-contract.js";
+import {
+  formatLegacyAgentMediaMigrationRequiredMessage,
+  GATEWAY_AGENT_MEDIA_MIGRATION_REQUIRED_REASON,
+} from "../state/openclaw-agent-db-migration-required.js";
 import type { DB as OpenClawStateKyselyDatabase } from "../state/openclaw-state-db.generated.js";
 import {
   openOpenClawStateDatabase,
@@ -20,6 +26,7 @@ const GATEWAY_BOOT_LOOP_WINDOW_MS = 5 * 60_000;
 // Keep enough history for operator forensics while bounding one-row-per-boot
 // growth. Retention must comfortably exceed GATEWAY_BOOT_LOOP_WINDOW_MS.
 const GATEWAY_BOOT_LIFECYCLE_RETENTION_MS = 24 * 60 * 60_000;
+export const GATEWAY_BOOT_REASON_MAX_UTF16_CODE_UNITS = 500;
 export const GATEWAY_CRASH_LOOP_BREAKER_REASON = "gateway.crash_loop_breaker";
 export const GATEWAY_CRASH_LOOP_RECOVERED_REASON = "gateway.crash_loop_recovered";
 /**
@@ -49,11 +56,13 @@ type GatewayBootLifecycleOutcome =
   | "clean_stop"
   | "planned_restart"
   | "startup_failed"
+  | "startup_failure_repaired"
   | "forced_stop";
 
 export type GatewayBootLifecycleCompletion = {
   outcome: GatewayBootLifecycleOutcome;
   reason?: string;
+  startupReason?: string;
 };
 
 export type GatewayCrashLoopBreakerDecision = {
@@ -200,6 +209,7 @@ export function completeGatewayBootLifecycle(
             .set({
               completed_at_ms: nowMs,
               outcome: completion.outcome,
+              ...(completion.startupReason ? { startup_reason: completion.startupReason } : {}),
               reason: completion.reason ?? null,
             })
             .where("boot_id", "=", bootId),
@@ -209,5 +219,57 @@ export function completeGatewayBootLifecycle(
     );
   } catch (err) {
     gatewayLifecycleLog.warn(`failed to persist gateway boot outcome; fail-open: ${String(err)}`);
+  }
+}
+
+export function repairGatewayAgentMediaMigrationStartupFailures(params: {
+  databasePaths: readonly string[];
+  env?: NodeJS.ProcessEnv;
+}): number {
+  if (params.databasePaths.length === 0) {
+    return 0;
+  }
+  try {
+    return runOpenClawStateWriteTransaction(
+      ({ db }) => {
+        const kysely = getNodeSqliteKysely<GatewayBootLifecycleDatabase>(db);
+        const legacyMessages = [
+          ...new Set(
+            params.databasePaths.flatMap((pathname) =>
+              Array.from({ length: OPENCLAW_AGENT_SCHEMA_VERSION }, (_, schemaVersion) => {
+                const message = formatLegacyAgentMediaMigrationRequiredMessage(
+                  pathname,
+                  schemaVersion,
+                );
+                return [
+                  message,
+                  truncateUtf16Safe(message, GATEWAY_BOOT_REASON_MAX_UTF16_CODE_UNITS),
+                ];
+              }).flat(),
+            ),
+          ),
+        ];
+        const result = executeSqliteQuerySync(
+          db,
+          kysely
+            .updateTable("gateway_boot_lifecycle")
+            .set({ outcome: "startup_failure_repaired" })
+            .where("outcome", "=", "startup_failed")
+            .where((eb) =>
+              eb.or([
+                eb("startup_reason", "=", GATEWAY_AGENT_MEDIA_MIGRATION_REQUIRED_REASON),
+                eb("reason", "in", legacyMessages),
+              ]),
+            ),
+        );
+        return Number(result.numAffectedRows ?? 0);
+      },
+      { env: params.env ?? process.env },
+    );
+  } catch (err) {
+    gatewayLifecycleLog.warn(
+      `failed to repair media-migration startup history; fail-open: ${String(err)}`,
+    );
+    return 0;
   }
 }

--- a/src/infra/state-migrations.media-persistence.lifecycle-recovery.test.ts
+++ b/src/infra/state-migrations.media-persistence.lifecycle-recovery.test.ts
@@ -1,0 +1,67 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { cleanupTempDirs, makeTempDir } from "../../test/helpers/temp-dir.js";
+import { GATEWAY_AGENT_MEDIA_MIGRATION_REQUIRED_REASON } from "../state/openclaw-agent-db-migration-required.js";
+import {
+  closeOpenClawAgentDatabasesForTest,
+  openOpenClawAgentDatabase,
+} from "../state/openclaw-agent-db.js";
+import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
+import {
+  completeGatewayBootLifecycle,
+  inspectGatewayCrashLoopBreaker,
+  recordGatewayBootStart,
+} from "./gateway-boot-lifecycle.js";
+import { requireNodeSqlite } from "./node-sqlite.js";
+import { migrateLegacyMediaPersistence } from "./state-migrations.media-persistence.js";
+
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  closeOpenClawAgentDatabasesForTest();
+  closeOpenClawStateDatabaseForTest();
+  cleanupTempDirs(tempDirs);
+});
+
+describe("media persistence gateway lifecycle recovery", () => {
+  it("repairs repeated typed startup failures after a successful v14 migration", () => {
+    const stateDir = makeTempDir(tempDirs, "media-persistence-startup-recovery-");
+    const env = { OPENCLAW_STATE_DIR: stateDir };
+    const databasePath = openOpenClawAgentDatabase({ agentId: "main", env }).path;
+    closeOpenClawAgentDatabasesForTest();
+
+    const { DatabaseSync } = requireNodeSqlite();
+    const database = new DatabaseSync(databasePath);
+    database.exec(`
+      PRAGMA user_version = 14;
+      UPDATE schema_meta SET schema_version = 14 WHERE meta_key = 'primary';
+    `);
+    database.close();
+
+    const nowMs = 1_000_000;
+    for (let index = 0; index < 3; index += 1) {
+      const bootId = recordGatewayBootStart(env, nowMs + index);
+      completeGatewayBootLifecycle(
+        bootId,
+        {
+          outcome: "startup_failed",
+          reason: `migration required ${index}`,
+          startupReason: GATEWAY_AGENT_MEDIA_MIGRATION_REQUIRED_REASON,
+        },
+        env,
+        nowMs + index + 1,
+      );
+    }
+    expect(inspectGatewayCrashLoopBreaker(env, nowMs + 4).tripped).toBe(true);
+
+    const result = migrateLegacyMediaPersistence({ env });
+
+    expect(result.warnings).toEqual([]);
+    expect(result.changes.join("\n")).toContain(
+      "Repaired 3 gateway startup failure records after media migration.",
+    );
+    expect(inspectGatewayCrashLoopBreaker(env, nowMs + 5)).toMatchObject({
+      tripped: false,
+      uncleanBoots: 0,
+    });
+  });
+});

--- a/src/infra/state-migrations.media-persistence.lifecycle-recovery.test.ts
+++ b/src/infra/state-migrations.media-persistence.lifecycle-recovery.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it } from "vitest";
-import { cleanupTempDirs, makeTempDir } from "../../test/helpers/temp-dir.js";
+import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import { GATEWAY_AGENT_MEDIA_MIGRATION_REQUIRED_REASON } from "../state/openclaw-agent-db-migration-required.js";
 import {
   closeOpenClawAgentDatabasesForTest,
@@ -14,17 +14,16 @@ import {
 import { requireNodeSqlite } from "./node-sqlite.js";
 import { migrateLegacyMediaPersistence } from "./state-migrations.media-persistence.js";
 
-const tempDirs: string[] = [];
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
 afterEach(() => {
   closeOpenClawAgentDatabasesForTest();
   closeOpenClawStateDatabaseForTest();
-  cleanupTempDirs(tempDirs);
 });
 
 describe("media persistence gateway lifecycle recovery", () => {
   it("repairs repeated typed startup failures after a successful v14 migration", () => {
-    const stateDir = makeTempDir(tempDirs, "media-persistence-startup-recovery-");
+    const stateDir = tempDirs.make("media-persistence-startup-recovery-");
     const env = { OPENCLAW_STATE_DIR: stateDir };
     const databasePath = openOpenClawAgentDatabase({ agentId: "main", env }).path;
     closeOpenClawAgentDatabasesForTest();

--- a/src/infra/state-migrations.media-persistence.ts
+++ b/src/infra/state-migrations.media-persistence.ts
@@ -33,6 +33,7 @@ import {
 import { OPENCLAW_AGENT_SCHEMA_SQL } from "../state/openclaw-agent-schema.generated.js";
 import { OPENCLAW_SQLITE_BUSY_TIMEOUT_MS } from "../state/openclaw-state-db.js";
 import { VERSION } from "../version.js";
+import { repairGatewayAgentMediaMigrationStartupFailures } from "./gateway-boot-lifecycle.js";
 import {
   executeSqliteQuerySync,
   getNodeSqliteKysely,
@@ -598,6 +599,7 @@ export function migrateLegacyMediaPersistence(
   }
 
   const seenPaths = new Set<string>();
+  let databaseMigrationFailed = false;
   const archiveDirectories = new Set<string>();
   for (const entry of registered) {
     const pathname = path.resolve(entry.path);
@@ -652,7 +654,20 @@ export function migrateLegacyMediaPersistence(
         );
       }
     } catch (error) {
+      databaseMigrationFailed = true;
       warnings.push(`Skipped media persistence migration for ${pathname}: ${String(error)}`);
+    }
+  }
+
+  if (!databaseMigrationFailed && seenPaths.size > 0) {
+    const repairedFailures = repairGatewayAgentMediaMigrationStartupFailures({
+      databasePaths: [...seenPaths],
+      env,
+    });
+    if (repairedFailures > 0) {
+      changes.push(
+        `Repaired ${repairedFailures} gateway startup failure ${repairedFailures === 1 ? "record" : "records"} after media migration.`,
+      );
     }
   }
 

--- a/src/state/openclaw-agent-db-migration-required.test.ts
+++ b/src/state/openclaw-agent-db-migration-required.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import {
+  findOpenClawAgentDatabaseMediaMigrationRequiredError,
+  OpenClawAgentDatabaseMediaMigrationRequiredError,
+} from "./openclaw-agent-db-migration-required.js";
+
+describe("agent database media migration error classification", () => {
+  it("recognizes a rehydrated exact migration error through its cause chain", () => {
+    const original = new OpenClawAgentDatabaseMediaMigrationRequiredError(
+      "/tmp/openclaw-agent.sqlite",
+      14,
+    );
+    const rehydrated = new Error("startup failed", {
+      cause: new Error(original.message),
+    });
+
+    expect(findOpenClawAgentDatabaseMediaMigrationRequiredError(rehydrated)).toMatchObject({
+      pathname: "/tmp/openclaw-agent.sqlite",
+      schemaVersion: 14,
+    });
+  });
+
+  it("does not classify similar operator guidance as the migration error", () => {
+    expect(
+      findOpenClawAgentDatabaseMediaMigrationRequiredError(
+        new Error("OpenClaw agent database is outdated; run openclaw doctor --fix to migrate it."),
+      ),
+    ).toBeUndefined();
+  });
+});

--- a/src/state/openclaw-agent-db-migration-required.ts
+++ b/src/state/openclaw-agent-db-migration-required.ts
@@ -1,0 +1,65 @@
+export const GATEWAY_AGENT_MEDIA_MIGRATION_REQUIRED_REASON =
+  "gateway.agent_media_migration_required";
+
+export class OpenClawAgentDatabaseMediaMigrationRequiredError extends Error {
+  readonly code = GATEWAY_AGENT_MEDIA_MIGRATION_REQUIRED_REASON;
+
+  constructor(
+    readonly pathname: string,
+    readonly schemaVersion: number,
+  ) {
+    super(
+      `OpenClaw agent database ${pathname} uses schema version ${schemaVersion}; run openclaw doctor --fix to migrate persisted media before using it.`,
+    );
+    this.name = "OpenClawAgentDatabaseMediaMigrationRequiredError";
+  }
+}
+
+const AGENT_MEDIA_MIGRATION_REQUIRED_MESSAGE =
+  /^OpenClaw agent database (.+) uses schema version (\d+); run openclaw doctor --fix to migrate persisted media before using it\.$/u;
+
+function parseAgentMediaMigrationRequiredMessage(
+  message: unknown,
+): OpenClawAgentDatabaseMediaMigrationRequiredError | undefined {
+  if (typeof message !== "string") {
+    return undefined;
+  }
+  const match = AGENT_MEDIA_MIGRATION_REQUIRED_MESSAGE.exec(message);
+  const pathname = match?.[1];
+  const rawSchemaVersion = match?.[2];
+  if (!pathname || !rawSchemaVersion) {
+    return undefined;
+  }
+  const schemaVersion = Number(rawSchemaVersion);
+  if (!Number.isSafeInteger(schemaVersion)) {
+    return undefined;
+  }
+  return new OpenClawAgentDatabaseMediaMigrationRequiredError(pathname, schemaVersion);
+}
+
+export function findOpenClawAgentDatabaseMediaMigrationRequiredError(
+  error: unknown,
+): OpenClawAgentDatabaseMediaMigrationRequiredError | undefined {
+  let current = error;
+  const seen = new Set<unknown>();
+  while (current && typeof current === "object" && !seen.has(current)) {
+    if (current instanceof OpenClawAgentDatabaseMediaMigrationRequiredError) {
+      return current;
+    }
+    const errorLike = current as { cause?: unknown; message?: unknown };
+    const parsed = parseAgentMediaMigrationRequiredMessage(errorLike.message);
+    if (parsed) {
+      return parsed;
+    }
+    seen.add(current);
+    current = errorLike.cause;
+  }
+  return undefined;
+}
+
+export function formatLegacyAgentMediaMigrationRequiredMessage(
+  pathname: string,
+  schemaVersion: number,
+): string {
+  return new OpenClawAgentDatabaseMediaMigrationRequiredError(pathname, schemaVersion).message;
+}

--- a/src/state/openclaw-agent-db-schema-helpers.ts
+++ b/src/state/openclaw-agent-db-schema-helpers.ts
@@ -25,6 +25,7 @@ import {
   ensureOpenClawAgentBoardSchemaInTransaction,
 } from "./openclaw-agent-board-schema.js";
 import { OPENCLAW_AGENT_SCHEMA_VERSION } from "./openclaw-agent-db-contract.js";
+import { OpenClawAgentDatabaseMediaMigrationRequiredError } from "./openclaw-agent-db-migration-required.js";
 import { OPENCLAW_AGENT_SCHEMA_SQL } from "./openclaw-agent-schema.generated.js";
 import {
   AGENT_V14_ADDITIVE_SCHEMA_SQL,
@@ -196,9 +197,7 @@ export function assertCanonicalAgentMediaPersistenceVersion(
   const isNewUnownedDatabase =
     userVersion === 0 && readExistingAgentSchemaMeta(db) === null && !hasApplicationSchema;
   if (userVersion < OPENCLAW_AGENT_SCHEMA_VERSION && !isNewUnownedDatabase) {
-    throw new Error(
-      `OpenClaw agent database ${pathname} uses schema version ${userVersion}; run openclaw doctor --fix to migrate persisted media before using it.`,
-    );
+    throw new OpenClawAgentDatabaseMediaMigrationRequiredError(pathname, userVersion);
   }
 }
 


### PR DESCRIPTION
Fixes #115072

## What Problem This Solves

Fixes an issue where users upgrading a managed gateway with an older agent database would enter a supervisor crash loop while the database awaited `openclaw doctor --fix`. Repeated deterministic failures could trip the gateway restart-loop breaker, leaving channel/provider auto-start suppressed even after migration succeeded.

## Why This Change Was Made

Migration-required startup is now a typed, supervisor-aware failure. Systemd receives exit `78`, while the active managed LaunchAgent disables itself and schedules a detached bootout so KeepAlive cannot immediately relaunch it. After every registered agent database migrates successfully, Doctor selectively repairs only the matching migration startup records; its existing service repair path then re-enables and bootstraps the LaunchAgent.

This uses the existing lifecycle and Doctor ownership boundaries. It adds no config surface, protocol change, or SQLite schema-version bump.

## User Impact

Operators can run `openclaw doctor --fix` once to complete the migration and recover normal gateway/channel startup immediately. Unrelated startup failures remain recorded and continue to count toward crash-loop protection.

## Evidence

- Real Testbox scenario: created a registered schema-v14 agent database, ran three real gateway starts, and verified all three exited `78` with the typed migration reason.
- Verified the crash-loop breaker tripped before repair.
- Ran real `openclaw doctor --fix`; verified schema `14 -> 16`, exactly three migration failures changed to `startup_failure_repaired`, and an unrelated `EADDRINUSE` failure stayed active.
- Started the real gateway after Doctor and verified the HTTP server listened and remained alive until the bounded test timeout.
- Focused fresh-base suite: 301 passed, 30 skipped across state, lifecycle migration, CLI, launchd handoff/service, and Doctor tests.
- Fresh-base core typecheck, core-test typecheck, targeted oxlint, formatting, database guards, and plugin-boundary checks passed.
- Autoreview: clean after addressing its legacy 500-UTF16 truncation finding.
- Testbox runs: https://github.com/openclaw/openclaw/actions/runs/30424637073, https://github.com/openclaw/openclaw/actions/runs/30425507815, https://github.com/openclaw/openclaw/actions/runs/30425832192

An isolated macOS Crabbox backend was not available: Tart is not installed, Parallels has no configured host/template, and the SSH provider has no static host. LaunchAgent behavior is covered by executable handoff tests plus mocked service tests for disable-before-exit, detached bootout, rollback-on-handoff-failure, and Doctor enable/bootstrap recovery.
