### PR TITLE
refactor(agents): centralize bundled CLI backend auth policy

### DIFF
--- a/src/agents/cli-runner/cli-backend-auth-policy.ts
+++ b/src/agents/cli-runner/cli-backend-auth-policy.ts
@@ -1,0 +1,27 @@
+/**
+ * Core-internal auth policy for bundled auth-owning CLI backends. Membership controls
+ * selected-profile resolution and raw credential forwarding during prepareExecution;
+ * third-party plugins cannot declare this trust decision through Plugin SDK metadata.
+ */
+export type BundledCliBackendAuthPolicy = {
+  /** Disable profile fallback and fail closed when the selected profile cannot materialize. */
+  strictSelectedProfile: boolean;
+  /** Provider whose imported OAuth profiles use identity-verified native passthrough. */
+  nativePassthroughProviderId?: string;
+};
+
+const BUNDLED_CLI_BACKEND_AUTH_POLICIES = {
+  "claude-cli": {
+    strictSelectedProfile: true,
+    nativePassthroughProviderId: "claude-cli",
+  },
+  "google-gemini-cli": { strictSelectedProfile: false },
+} satisfies Record<string, BundledCliBackendAuthPolicy>;
+
+export function resolveBundledCliBackendAuthPolicy(
+  backendId: string,
+): BundledCliBackendAuthPolicy | undefined {
+  return BUNDLED_CLI_BACKEND_AUTH_POLICIES[
+    backendId as keyof typeof BUNDLED_CLI_BACKEND_AUTH_POLICIES
+  ];
+}

--- a/src/agents/cli-runner/prepare.ts
+++ b/src/agents/cli-runner/prepare.ts
@@ -116,6 +116,10 @@ import {
 import { prepareCliBundleMcpConfig } from "./bundle-mcp.js";
 import { getClaudeLiveSessionGenerationForOwner } from "./claude-live-session.js";
 import { prepareClaudeCliSkillsPlugin } from "./claude-skills-plugin.js";
+import {
+  resolveBundledCliBackendAuthPolicy,
+  type BundledCliBackendAuthPolicy,
+} from "./cli-backend-auth-policy.js";
 import { buildCliAgentSystemPrompt, isClaudeCliProvider, normalizeCliModel } from "./helpers.js";
 import { cliBackendLog } from "./log.js";
 import { buildCliMcpGrantContext, normalizeOptionalMcpContextValue } from "./mcp-grant-context.js";
@@ -321,12 +325,12 @@ if (process.env.VITEST || process.env.NODE_ENV === "test") {
 }
 
 function shouldRefreshAuthProfileForExecution(params: {
-  backendId: string;
+  policy?: BundledCliBackendAuthPolicy;
   authProfileId?: string;
   authCredential?: AuthProfileCredential;
 }): boolean {
   return Boolean(
-    (params.backendId === "google-gemini-cli" || params.backendId === "claude-cli") &&
+    params.policy &&
     params.authProfileId &&
     (params.authCredential?.type === "oauth" ||
       params.authCredential?.type === "api_key" ||
@@ -423,6 +427,7 @@ export async function prepareCliRunContext(
   if (!backendResolved) {
     throw new Error(`Unknown CLI backend: ${params.provider}`);
   }
+  const backendAuthPolicy = resolveBundledCliBackendAuthPolicy(backendResolved.id);
   const canEnforceExactToolAvailability =
     backendResolved.nativeToolMode === "selectable" &&
     ((backendResolved.toolAvailabilityEnforcement === "execution-args" &&
@@ -556,9 +561,9 @@ export async function prepareCliRunContext(
   // from refreshing itself, so verify the live login matches the selected
   // identity and let Claude authenticate natively (it refreshes in place).
   const nativeClaudeCliCredential =
-    backendResolved.id === "claude-cli" &&
+    backendAuthPolicy?.nativePassthroughProviderId !== undefined &&
     authCredential?.type === "oauth" &&
-    authCredential.provider === "claude-cli"
+    authCredential.provider === backendAuthPolicy.nativePassthroughProviderId
       ? authCredential
       : undefined;
   if (effectiveAuthProfileId && authStore && nativeClaudeCliCredential) {
@@ -591,7 +596,7 @@ export async function prepareCliRunContext(
   } else if (
     effectiveAuthProfileId &&
     shouldRefreshAuthProfileForExecution({
-      backendId: backendResolved.id,
+      policy: backendAuthPolicy,
       authProfileId: effectiveAuthProfileId,
       authCredential,
     })
@@ -605,9 +610,9 @@ export async function prepareCliRunContext(
       agentDir,
       // Claude's selected profile is an account boundary. Never refresh or
       // substitute a sibling account while preparing this run.
-      ...(backendResolved.id === "claude-cli" ? { allowProfileFallback: false } : {}),
+      ...(backendAuthPolicy?.strictSelectedProfile ? { allowProfileFallback: false } : {}),
     });
-    if (!resolvedAuth && backendResolved.id === "claude-cli") {
+    if (!resolvedAuth && backendAuthPolicy?.strictSelectedProfile) {
       throw buildCliAuthProfileResolutionError({
         backendId: backendResolved.id,
         profileId: authProfileId,
@@ -617,7 +622,7 @@ export async function prepareCliRunContext(
     }
     if (
       resolvedAuth &&
-      backendResolved.id === "claude-cli" &&
+      backendAuthPolicy?.strictSelectedProfile &&
       resolvedAuth.profileId !== authProfileId
     ) {
       throw buildCliAuthProfileResolutionError({
@@ -631,7 +636,7 @@ export async function prepareCliRunContext(
     authStore = loadScopedAuthStore({ profileId: resolvedAuthProfileId });
     authCredential = resolvedAuth?.credential ?? authStore.profiles[resolvedAuthProfileId];
     if (
-      backendResolved.id === "claude-cli" &&
+      backendAuthPolicy?.strictSelectedProfile &&
       (!authCredential ||
         (authCredential.type === "oauth" && !hasUsableOAuthCredential(authCredential)))
     ) {
@@ -1021,12 +1026,11 @@ export async function prepareCliRunContext(
     } satisfies Parameters<NonNullable<typeof backendResolved.prepareExecution>>[0];
     preparedExecution =
       (await backendResolved.prepareExecution?.(
-        (backendResolved.id === "google-gemini-cli" || backendResolved.id === "claude-cli"
+        (backendAuthPolicy
           ? {
               ...prepareExecutionContext,
-              // Private bridge for bundled auth-owning CLI backends. This is intentionally not
-              // part of the public Plugin SDK until a credential-forwarding
-              // contract exists.
+              // Private bridge for bundled auth-owning CLI backends. The core-internal auth
+              // policy table owns membership until a public forwarding contract exists.
               authCredential,
             }
           : prepareExecutionContext) as typeof prepareExecutionContext & {


### PR DESCRIPTION
## What Problem This Solves

Follow-up from #115134. Core CLI auth preparation repeated bundled-backend id checks across profile refresh, native passthrough, strict selected-profile handling, and the private credential bridge, making one trust policy easy to update inconsistently.

## Why This Change Was Made

This replaces the scattered checks with one core-internal bundled CLI backend auth policy table. Table membership owns both pre-spawn selected-profile resolution and access to the private raw-credential bridge; it deliberately remains outside Plugin SDK metadata because third-party backend plugins must not be able to declare that credential-forwarding trust.

## User Impact

None. This is a behavior-neutral refactor: Claude CLI keeps strict selected-profile and identity-verified native passthrough semantics, while Claude CLI and Google Gemini CLI keep the same profile resolution and private credential forwarding behavior.

## Evidence

- `node scripts/run-vitest.mjs src/agents/cli-runner/prepare.test.ts` — 91 passed; repeated after rebasing onto current `origin/main`, 91 passed.
- `node scripts/run-vitest.mjs src/agents/command/attempt-execution.cli.test.ts src/agents/embedded-agent-runner/cli-backend-dispatch.test.ts src/system-agent/setup-inference.test.ts extensions/anthropic/cli-shared.test.ts` — 276 passed across four shards (119 + 40 + 72 + 45).
- Root checkout `node_modules/.bin/oxfmt --check` on both touched files — passed.
- `node scripts/run-oxlint.mjs` on both touched files — passed.
- `git diff --check` — passed.
- `./.agents/skills/autoreview/scripts/autoreview --mode uncommitted` — clean; no accepted/actionable findings.
