### PR TITLE
refactor(agents): drop legacy subagent state recovery

### DIFF
--- a/src/agents/subagent-delivery-state.test.ts
+++ b/src/agents/subagent-delivery-state.test.ts
@@ -1,12 +1,9 @@
-// Subagent delivery-state tests cover migration of legacy run fields into the
-// nested completion/delivery shape used by current registry records.
+// Subagent delivery-state tests cover current registry record normalization.
 import { describe, expect, it } from "vitest";
 import { normalizeSubagentRunState } from "./subagent-delivery-state.js";
 import type { SubagentRunRecord } from "./subagent-registry.types.js";
 
-type LegacySubagentRunRecord = SubagentRunRecord & Record<string, unknown>;
-
-function baseRun(overrides: Partial<LegacySubagentRunRecord> = {}): LegacySubagentRunRecord {
+function baseRun(overrides: Partial<SubagentRunRecord> = {}): SubagentRunRecord {
   return {
     runId: "run-1",
     childSessionKey: "agent:main:subagent:child",
@@ -19,6 +16,9 @@ function baseRun(overrides: Partial<LegacySubagentRunRecord> = {}): LegacySubage
     createdAt: 100,
     startedAt: 100,
     expectsCompletionMessage: true,
+    execution: { status: "running", startedAt: 100 },
+    completion: { required: true },
+    delivery: { status: "pending" },
     ...overrides,
   };
 }
@@ -97,98 +97,6 @@ describe("normalizeSubagentRunState", () => {
 
     expect(valid.terminalOwner).toBe("interrupted-recovery");
     expect(malformed.every((entry) => entry.terminalOwner === undefined)).toBe(true);
-  });
-
-  it("migrates legacy pending delivery fields into nested completion and delivery state", () => {
-    // Restored runs may still carry flat pendingFinalDelivery fields from older
-    // builds; normalization must preserve retry payloads before stripping them.
-    const entry = normalizeSubagentRunState(
-      baseRun({
-        frozenResultText: "child output",
-        frozenResultCapturedAt: 200,
-        pendingFinalDelivery: true,
-        pendingFinalDeliveryCreatedAt: 210,
-        pendingFinalDeliveryLastAttemptAt: 220,
-        pendingFinalDeliveryAttemptCount: 3,
-        pendingFinalDeliveryLastError: "sink unavailable",
-        pendingFinalDeliveryPayload: {
-          requesterSessionKey: "agent:main:parent",
-          requesterDisplayKey: "agent:main:parent",
-          childSessionKey: "agent:main:subagent:child",
-          childRunId: "run-1",
-          task: "inspect",
-          startedAt: 100,
-          expectsCompletionMessage: true,
-          frozenResultText: "child output",
-        },
-      }),
-    ) as SubagentRunRecord & { pendingFinalDelivery?: boolean; frozenResultText?: string };
-
-    expect(entry.completion).toMatchObject({
-      required: true,
-      resultText: "child output",
-      capturedAt: 200,
-    });
-    expect(entry.delivery).toMatchObject({
-      status: "pending",
-      createdAt: 210,
-      lastAttemptAt: 220,
-      attemptCount: 3,
-      lastError: "sink unavailable",
-      payload: expect.objectContaining({ childRunId: "run-1" }),
-    });
-    expect(entry.pendingFinalDelivery).toBeUndefined();
-    expect(entry.frozenResultText).toBeUndefined();
-  });
-
-  it("merges partial nested state with legacy fields before stripping legacy fields", () => {
-    const entry = normalizeSubagentRunState(
-      baseRun({
-        completion: { required: true },
-        delivery: { status: "not_required" },
-        pendingFinalDelivery: true,
-        pendingFinalDeliveryAttemptCount: 2,
-        lastAnnounceRetryAt: 240,
-        frozenResultText: "legacy result",
-      }),
-    ) as SubagentRunRecord & { pendingFinalDelivery?: boolean; lastAnnounceRetryAt?: number };
-
-    expect(entry.completion?.resultText).toBe("legacy result");
-    expect(entry.delivery).toMatchObject({
-      status: "pending",
-      attemptCount: 2,
-      lastAttemptAt: 240,
-    });
-    expect(entry.pendingFinalDelivery).toBeUndefined();
-    expect(entry.lastAnnounceRetryAt).toBeUndefined();
-  });
-
-  it("migrates in-progress handoff leases to steering leases", () => {
-    const entry = normalizeSubagentRunState(
-      baseRun({
-        cleanupHandled: true,
-        delivery: {
-          status: "in_progress",
-          payload: {
-            requesterSessionKey: "agent:main:parent",
-            requesterDisplayKey: "agent:main:parent",
-            childSessionKey: "agent:main:subagent:child",
-            childRunId: "run-1",
-            task: "inspect",
-          },
-          handoffLeaseId: "lease-1",
-          handoffLeasedAt: 300,
-        },
-      } as Partial<LegacySubagentRunRecord>),
-    ) as SubagentRunRecord & { delivery?: { handoffLeaseId?: string } };
-
-    expect(entry.delivery).toMatchObject({
-      status: "in_progress",
-      steeringLeaseId: "lease-1",
-      steeringLeasedAt: 300,
-    });
-    expect(entry.delivery?.handoffLeaseId).toBeUndefined();
-    expect(entry.cleanupHandled).toBe(false);
   });
 
   it("clears stale cleanupHandled locks for unfinished restored cleanup", () => {

--- a/src/agents/subagent-delivery-state.ts
+++ b/src/agents/subagent-delivery-state.ts
@@ -4,7 +4,6 @@ import type {
   SubagentRunRecord,
 } from "./subagent-registry.types.js";
 
-/** Normalizes current-version ownership metadata before persistence or restore. */
 export function normalizeSubagentRunState(entry: SubagentRunRecord): SubagentRunRecord {
   const taskRunId = typeof entry.taskRunId === "string" ? entry.taskRunId.trim() : "";
   entry.taskRunId = taskRunId || undefined;

--- a/src/agents/subagent-delivery-state.ts
+++ b/src/agents/subagent-delivery-state.ts
@@ -1,53 +1,12 @@
-/**
- * Subagent delivery state migration.
- *
- * Normalizes legacy flat registry rows into nested execution, completion, and delivery state.
- */
+/** Subagent delivery state helpers. */
 import type {
-  PendingFinalDeliveryPayload,
   SubagentCompletionDeliveryState,
   SubagentCompletionState,
-  SubagentExecutionState,
   SubagentRunRecord,
 } from "./subagent-registry.types.js";
 
-/** Legacy flat fields accepted while restoring older subagent registry rows. */
-type LegacySubagentRunRecord = SubagentRunRecord & {
-  announceRetryCount?: number;
-  lastAnnounceRetryAt?: number;
-  lastAnnounceDeliveryError?: string;
-  frozenResultText?: string | null;
-  frozenResultCapturedAt?: number;
-  fallbackFrozenResultText?: string | null;
-  fallbackFrozenResultCapturedAt?: number;
-  pendingFinalDelivery?: boolean;
-  pendingFinalDeliveryCreatedAt?: number;
-  pendingFinalDeliveryLastAttemptAt?: number;
-  pendingFinalDeliveryAttemptCount?: number;
-  pendingFinalDeliveryLastError?: string | null;
-  pendingFinalDeliveryPayload?: PendingFinalDeliveryPayload;
-  deliverySuspendedAt?: number;
-  deliverySuspendedReason?: "retry-limit" | "expiry";
-  deliveryDiscardedAt?: number;
-  deliveryDiscardReason?: "expired" | "pressure-pruned";
-  deliveryDiscardedPayloadSummary?: SubagentCompletionDeliveryState["discardedPayloadSummary"];
-  completionEnqueuedAt?: number;
-  completionDeliveredAt?: number;
-  completionAnnouncedAt?: number;
-  lastAnnounceDropReason?: SubagentCompletionDeliveryState["lastDropReason"];
-};
-
-// Delivery state used to name the steering lease "handoff"; normalize those
-// fields into the current steering names on restore.
-type LegacyDeliveryState = SubagentCompletionDeliveryState & {
-  handoffLeaseId?: string;
-  handoffLeasedAt?: number;
-  handoffInjectedAt?: number;
-};
-
-/** Normalizes legacy subagent run fields into nested execution/completion/delivery state. */
+/** Normalizes current-version ownership metadata before persistence or restore. */
 export function normalizeSubagentRunState(entry: SubagentRunRecord): SubagentRunRecord {
-  const legacy = entry as LegacySubagentRunRecord;
   const taskRunId = typeof entry.taskRunId === "string" ? entry.taskRunId.trim() : "";
   entry.taskRunId = taskRunId || undefined;
   const requesterTurnRunId =
@@ -91,12 +50,6 @@ export function normalizeSubagentRunState(entry: SubagentRunRecord): SubagentRun
         : undefined,
     };
   }
-  entry.execution = mergeExecutionState(entry.execution, buildExecutionState(entry));
-  entry.completion = mergeCompletionState(entry.completion, buildCompletionState(entry, legacy));
-  entry.delivery = mergeDeliveryState(entry, entry.delivery, buildDeliveryState(entry, legacy));
-  delete (entry.delivery as LegacyDeliveryState | undefined)?.handoffLeaseId;
-  delete (entry.delivery as LegacyDeliveryState | undefined)?.handoffLeasedAt;
-  delete (entry.delivery as LegacyDeliveryState | undefined)?.handoffInjectedAt;
   // cleanupHandled is an in-process lock; after restart, unfinished cleanup must
   // retry unless durable cleanup completion was recorded.
   if (
@@ -106,197 +59,7 @@ export function normalizeSubagentRunState(entry: SubagentRunRecord): SubagentRun
   ) {
     entry.cleanupHandled = false;
   }
-  delete legacy.announceRetryCount;
-  delete legacy.lastAnnounceRetryAt;
-  delete legacy.lastAnnounceDeliveryError;
-  delete legacy.frozenResultText;
-  delete legacy.frozenResultCapturedAt;
-  delete legacy.fallbackFrozenResultText;
-  delete legacy.fallbackFrozenResultCapturedAt;
-  delete legacy.pendingFinalDelivery;
-  delete legacy.pendingFinalDeliveryCreatedAt;
-  delete legacy.pendingFinalDeliveryLastAttemptAt;
-  delete legacy.pendingFinalDeliveryAttemptCount;
-  delete legacy.pendingFinalDeliveryLastError;
-  delete legacy.pendingFinalDeliveryPayload;
-  delete legacy.deliverySuspendedAt;
-  delete legacy.deliverySuspendedReason;
-  delete legacy.deliveryDiscardedAt;
-  delete legacy.deliveryDiscardReason;
-  delete legacy.deliveryDiscardedPayloadSummary;
-  delete legacy.completionEnqueuedAt;
-  delete legacy.completionDeliveredAt;
-  delete legacy.completionAnnouncedAt;
-  delete legacy.lastAnnounceDropReason;
   return entry;
-}
-
-// Current nested state wins, but restored legacy fields backfill missing values
-// so older registry rows keep their completion/delivery history.
-function mergeExecutionState(
-  current: SubagentExecutionState | undefined,
-  restored: SubagentExecutionState,
-): SubagentExecutionState {
-  return current ? { ...restored, ...current } : restored;
-}
-
-function mergeCompletionState(
-  current: SubagentCompletionState | undefined,
-  restored: SubagentCompletionState,
-): SubagentCompletionState {
-  if (!current) {
-    return restored;
-  }
-  return {
-    ...restored,
-    ...current,
-    required: current.required ?? restored.required,
-  };
-}
-
-function mergeDeliveryState(
-  entry: SubagentRunRecord,
-  current: SubagentCompletionDeliveryState | undefined,
-  restored: SubagentCompletionDeliveryState,
-): SubagentCompletionDeliveryState {
-  if (!current) {
-    return restored;
-  }
-  const status =
-    current.status === "not_required" &&
-    entry.expectsCompletionMessage !== false &&
-    restored.status !== "not_required"
-      ? restored.status
-      : current.status;
-  return {
-    ...restored,
-    ...current,
-    status,
-    payload: current.payload ?? restored.payload,
-    createdAt: current.createdAt ?? restored.createdAt,
-    enqueuedAt: current.enqueuedAt ?? restored.enqueuedAt,
-    deliveredAt: current.deliveredAt ?? restored.deliveredAt,
-    announcedAt: current.announcedAt ?? restored.announcedAt,
-    lastAttemptAt: current.lastAttemptAt ?? restored.lastAttemptAt,
-    attemptCount: current.attemptCount ?? restored.attemptCount,
-    lastError: current.lastError ?? restored.lastError,
-    steeringLeaseId:
-      current.steeringLeaseId ??
-      (current as LegacyDeliveryState).handoffLeaseId ??
-      restored.steeringLeaseId,
-    steeringLeasedAt:
-      current.steeringLeasedAt ??
-      (current as LegacyDeliveryState).handoffLeasedAt ??
-      restored.steeringLeasedAt,
-    steeringInjectedAt:
-      current.steeringInjectedAt ??
-      (current as LegacyDeliveryState).handoffInjectedAt ??
-      restored.steeringInjectedAt,
-    suspendedAt: current.suspendedAt ?? restored.suspendedAt,
-    suspendedReason: current.suspendedReason ?? restored.suspendedReason,
-    discardedAt: current.discardedAt ?? restored.discardedAt,
-    discardReason: current.discardReason ?? restored.discardReason,
-    discardedPayloadSummary: current.discardedPayloadSummary ?? restored.discardedPayloadSummary,
-    lastDropReason: current.lastDropReason ?? restored.lastDropReason,
-  };
-}
-
-function buildExecutionState(entry: SubagentRunRecord): SubagentExecutionState {
-  if (typeof entry.endedAt === "number") {
-    return {
-      status: "terminal",
-      startedAt: entry.startedAt,
-      endedAt: entry.endedAt,
-      outcome: entry.outcome,
-    };
-  }
-  return {
-    status: "running",
-    startedAt: entry.startedAt,
-  };
-}
-
-// Completion was historically stored in flat frozen-result fields.
-function buildCompletionState(
-  entry: SubagentRunRecord,
-  legacy: LegacySubagentRunRecord,
-): SubagentCompletionState {
-  return {
-    required: entry.expectsCompletionMessage === true,
-    ...(legacy.frozenResultText !== undefined ? { resultText: legacy.frozenResultText } : {}),
-    ...(typeof legacy.frozenResultCapturedAt === "number"
-      ? { capturedAt: legacy.frozenResultCapturedAt }
-      : {}),
-    ...(legacy.fallbackFrozenResultText !== undefined
-      ? { fallbackResultText: legacy.fallbackFrozenResultText }
-      : {}),
-    ...(typeof legacy.fallbackFrozenResultCapturedAt === "number"
-      ? { fallbackCapturedAt: legacy.fallbackFrozenResultCapturedAt }
-      : {}),
-  };
-}
-
-// Delivery migration preserves terminal/suspended/pending semantics from the old
-// announce fields while defaulting live unended runs to not_required.
-function buildDeliveryState(
-  entry: SubagentRunRecord,
-  legacy: LegacySubagentRunRecord,
-): SubagentCompletionDeliveryState {
-  if (entry.expectsCompletionMessage === false) {
-    return { status: "not_required" };
-  }
-  if (typeof legacy.deliveryDiscardedAt === "number") {
-    return {
-      status: "discarded",
-      discardedAt: legacy.deliveryDiscardedAt,
-      discardReason: legacy.deliveryDiscardReason,
-      discardedPayloadSummary: legacy.deliveryDiscardedPayloadSummary,
-    };
-  }
-  if (typeof legacy.deliverySuspendedAt === "number") {
-    return {
-      status: "suspended",
-      payload: legacy.pendingFinalDeliveryPayload,
-      createdAt: legacy.pendingFinalDeliveryCreatedAt,
-      lastAttemptAt: legacy.pendingFinalDeliveryLastAttemptAt ?? legacy.lastAnnounceRetryAt,
-      attemptCount: legacy.pendingFinalDeliveryAttemptCount ?? legacy.announceRetryCount,
-      lastError: legacy.pendingFinalDeliveryLastError ?? legacy.lastAnnounceDeliveryError ?? null,
-      suspendedAt: legacy.deliverySuspendedAt,
-      suspendedReason: legacy.deliverySuspendedReason,
-      lastDropReason: legacy.lastAnnounceDropReason,
-    };
-  }
-  if (typeof legacy.completionAnnouncedAt === "number") {
-    return {
-      status: "delivered",
-      enqueuedAt: legacy.completionEnqueuedAt,
-      deliveredAt: legacy.completionDeliveredAt ?? legacy.completionAnnouncedAt,
-      announcedAt: legacy.completionAnnouncedAt,
-      lastDropReason: legacy.lastAnnounceDropReason,
-    };
-  }
-  if (legacy.pendingFinalDelivery === true || legacy.pendingFinalDeliveryPayload) {
-    return {
-      status: "pending",
-      payload: legacy.pendingFinalDeliveryPayload,
-      createdAt: legacy.pendingFinalDeliveryCreatedAt,
-      lastAttemptAt: legacy.pendingFinalDeliveryLastAttemptAt ?? legacy.lastAnnounceRetryAt,
-      attemptCount: legacy.pendingFinalDeliveryAttemptCount ?? legacy.announceRetryCount,
-      lastError: legacy.pendingFinalDeliveryLastError ?? legacy.lastAnnounceDeliveryError ?? null,
-      enqueuedAt: legacy.completionEnqueuedAt,
-      deliveredAt: legacy.completionDeliveredAt,
-      lastDropReason: legacy.lastAnnounceDropReason,
-    };
-  }
-  return {
-    status: typeof entry.endedAt === "number" ? "pending" : "not_required",
-    enqueuedAt: legacy.completionEnqueuedAt,
-    deliveredAt: legacy.completionDeliveredAt,
-    lastAttemptAt: legacy.lastAnnounceRetryAt,
-    attemptCount: legacy.announceRetryCount,
-    lastError: legacy.lastAnnounceDeliveryError ?? null,
-    lastDropReason: legacy.lastAnnounceDropReason,
-  };
 }
 
 /** Ensures a run has a nested completion state object. */

--- a/src/agents/subagent-delivery-state.ts
+++ b/src/agents/subagent-delivery-state.ts
@@ -1,4 +1,3 @@
-/** Subagent delivery state helpers. */
 import type {
   SubagentCompletionDeliveryState,
   SubagentCompletionState,

--- a/src/agents/subagent-orphan-recovery.restart-integration.test.ts
+++ b/src/agents/subagent-orphan-recovery.restart-integration.test.ts
@@ -22,6 +22,7 @@ import { captureEnv } from "../test-utils/env.js";
 import { cleanupSessionStateForTest } from "../test-utils/session-state-cleanup.js";
 import { recoverOrphanedSubagentSessions as recoverOrphanedSubagentSessionsWithRuntime } from "./subagent-orphan-recovery.js";
 import {
+  createCanonicalSubagentRunFixture,
   createSubagentRegistryTestDeps,
   readSubagentSessionStore,
   writeSubagentSessionEntry,
@@ -58,7 +59,7 @@ vi.mock("../gateway/session-utils.fs.js", () => ({
 const TWO_HOURS_MS = 2 * 60 * 60 * 1_000;
 
 function makeRunRecord(overrides: Partial<SubagentRunRecord>): SubagentRunRecord {
-  return {
+  return createCanonicalSubagentRunFixture({
     runId: "run",
     childSessionKey: "agent:main:subagent:child",
     requesterSessionKey: "agent:main:main",
@@ -68,7 +69,7 @@ function makeRunRecord(overrides: Partial<SubagentRunRecord>): SubagentRunRecord
     createdAt: Date.now(),
     startedAt: Date.now(),
     ...overrides,
-  } as SubagentRunRecord;
+  } as SubagentRunRecord);
 }
 
 describe("subagent orphan recovery — faithful restart path", () => {

--- a/src/agents/subagent-registry.persistence.resume.test.ts
+++ b/src/agents/subagent-registry.persistence.resume.test.ts
@@ -84,6 +84,9 @@ describe("subagent registry persistence resume", () => {
         task: "do the thing",
         cleanup: "keep",
         createdAt: Date.now(),
+        execution: { status: "running" },
+        completion: { required: false },
+        delivery: { status: "not_required" },
       };
       saveSubagentRegistryToSqlite(new Map([[run.runId, run]]));
       await writeSubagentSessionEntry({

--- a/src/agents/subagent-registry.persistence.test-support.ts
+++ b/src/agents/subagent-registry.persistence.test-support.ts
@@ -12,11 +12,40 @@ import {
   loadSessionEntry,
   replaceSessionEntry,
 } from "../config/sessions/session-accessor.js";
+import type { SubagentRunRecord } from "./subagent-registry.types.js";
 
 type SessionStore = Record<string, Record<string, unknown>>;
 
 function resolveSubagentSessionStorePath(stateDir: string, agentId: string): string {
   return path.join(stateDir, "agents", agentId, "sessions", "sessions.json");
+}
+
+/** Expands shorthand test records into the canonical nested persistence shape. */
+export function createCanonicalSubagentRunFixture(run: SubagentRunRecord): SubagentRunRecord {
+  const terminal = typeof run.endedAt === "number";
+  return {
+    execution: terminal
+      ? { status: "terminal", startedAt: run.startedAt, endedAt: run.endedAt, outcome: run.outcome }
+      : { status: "running", startedAt: run.startedAt },
+    completion: { required: run.expectsCompletionMessage === true },
+    delivery: {
+      status:
+        run.expectsCompletionMessage === false
+          ? "not_required"
+          : terminal
+            ? "pending"
+            : "not_required",
+    },
+    ...run,
+  };
+}
+
+export function canonicalSubagentRunFixtures(
+  runs: Map<string, SubagentRunRecord>,
+): Map<string, SubagentRunRecord> {
+  return new Map(
+    [...runs].map(([runId, run]) => [runId, createCanonicalSubagentRunFixture(run)]),
+  );
 }
 
 /** Reads test session entries through the active SQLite accessor. */

--- a/src/agents/subagent-registry.persistence.test-support.ts
+++ b/src/agents/subagent-registry.persistence.test-support.ts
@@ -43,9 +43,7 @@ export function createCanonicalSubagentRunFixture(run: SubagentRunRecord): Subag
 export function canonicalSubagentRunFixtures(
   runs: Map<string, SubagentRunRecord>,
 ): Map<string, SubagentRunRecord> {
-  return new Map(
-    [...runs].map(([runId, run]) => [runId, createCanonicalSubagentRunFixture(run)]),
-  );
+  return new Map([...runs].map(([runId, run]) => [runId, createCanonicalSubagentRunFixture(run)]));
 }
 
 /** Reads test session entries through the active SQLite accessor. */

--- a/src/agents/subagent-registry.persistence.test.ts
+++ b/src/agents/subagent-registry.persistence.test.ts
@@ -17,6 +17,7 @@ import { scheduleOrphanRecovery } from "./subagent-orphan-recovery.js";
 import { persistSubagentSessionTiming } from "./subagent-registry-helpers.js";
 import { getSubagentRunsSnapshotForRead } from "./subagent-registry-state.js";
 import {
+  canonicalSubagentRunFixtures,
   createSubagentRegistryTestDeps,
   readSubagentSessionStore,
   removeSubagentSessionEntry,
@@ -196,26 +197,7 @@ describe("subagent registry persistence", () => {
     saveSubagentRegistryToSqlite(runs);
 
   function saveCanonicalRunFixtures(runs: Map<string, SubagentRunRecord>) {
-    saveSubagentRegistryToSqlite(
-      new Map(
-        [...runs].map(([runId, run]) => [
-          runId,
-          {
-            execution: {
-              status: typeof run.endedAt === "number" ? "terminal" : "running",
-              startedAt: run.startedAt,
-              endedAt: run.endedAt,
-              outcome: run.outcome,
-            },
-            completion: { required: run.expectsCompletionMessage === true },
-            delivery: {
-              status: typeof run.endedAt === "number" ? "pending" : "not_required",
-            },
-            ...run,
-          },
-        ]),
-      ),
-    );
+    saveSubagentRegistryToSqlite(canonicalSubagentRunFixtures(runs));
   }
 
   beforeEach(() => {

--- a/src/agents/subagent-registry.persistence.test.ts
+++ b/src/agents/subagent-registry.persistence.test.ts
@@ -132,7 +132,7 @@ describe("subagent registry persistence", () => {
     tempStateDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-subagent-"));
     setTestEnvValue("OPENCLAW_STATE_DIR", tempStateDir);
     const runs = (persisted.runs ?? {}) as Record<string, SubagentRunRecord>;
-    saveSubagentRegistryToSqlite(new Map(Object.entries(runs)));
+    saveCanonicalRunFixtures(new Map(Object.entries(runs)));
     if (opts?.seedChildSessions !== false) {
       await seedChildSessionsForPersistedRuns(persisted);
     }
@@ -194,6 +194,29 @@ describe("subagent registry persistence", () => {
 
   const fastPersistSubagentRunsToDisk = (runs: Map<string, SubagentRunRecord>) =>
     saveSubagentRegistryToSqlite(runs);
+
+  function saveCanonicalRunFixtures(runs: Map<string, SubagentRunRecord>) {
+    saveSubagentRegistryToSqlite(
+      new Map(
+        [...runs].map(([runId, run]) => [
+          runId,
+          {
+            execution: {
+              status: typeof run.endedAt === "number" ? "terminal" : "running",
+              startedAt: run.startedAt,
+              endedAt: run.endedAt,
+              outcome: run.outcome,
+            },
+            completion: { required: run.expectsCompletionMessage === true },
+            delivery: {
+              status: typeof run.endedAt === "number" ? "pending" : "not_required",
+            },
+            ...run,
+          },
+        ]),
+      ),
+    );
+  }
 
   beforeEach(() => {
     announceSpy.mockReset();
@@ -397,7 +420,7 @@ describe("subagent registry persistence", () => {
         },
       },
     };
-    saveSubagentRegistryToSqlite(
+    saveCanonicalRunFixtures(
       new Map(Object.entries(persisted.runs) as Array<[string, SubagentRunRecord]>),
     );
     await writeChildSessionEntry({
@@ -513,7 +536,7 @@ describe("subagent registry persistence", () => {
         usage: { inputTokens: 10, outputTokens: 3 },
       },
     };
-    saveSubagentRegistryToSqlite(new Map([[run.runId, run]]));
+    saveCanonicalRunFixtures(new Map([[run.runId, run]]));
     await writeChildSessionEntry({
       sessionKey: run.childSessionKey,
       sessionId: "session-swarm-restart",
@@ -588,7 +611,7 @@ describe("subagent registry persistence", () => {
         maxConcurrent: 8,
       },
     };
-    saveSubagentRegistryToSqlite(new Map([[run.runId, run]]));
+    saveCanonicalRunFixtures(new Map([[run.runId, run]]));
 
     closeOpenClawStateDatabaseForTest();
     expect(loadSubagentRegistryFromSqlite().get(run.runId)).toMatchObject({
@@ -938,7 +961,7 @@ describe("subagent registry persistence", () => {
       attachmentsDir,
     });
 
-    saveSubagentRegistryToSqlite(
+    saveCanonicalRunFixtures(
       new Map(Object.entries(persisted.runs) as Array<[string, SubagentRunRecord]>),
     );
 
@@ -1071,6 +1094,9 @@ describe("subagent registry persistence", () => {
       createdAt: now - 50,
       startedAt: now - 25,
       endedAt: now,
+      execution: { status: "terminal", startedAt: now - 25, endedAt: now },
+      completion: { required: false },
+      delivery: { status: "pending" },
       suppressAnnounceReason: "steer-restart",
       cleanupHandled: false,
     });

--- a/src/agents/subagent-registry.store.sqlite.test.ts
+++ b/src/agents/subagent-registry.store.sqlite.test.ts
@@ -152,13 +152,20 @@ describe("subagent registry sqlite store", () => {
     });
   });
 
-  it("rejects writes without canonical nested state", async () => {
+  it("rejects writes outside the canonical nested state", async () => {
     await withTempStateEnv(async () => {
-      const run = createRun({ execution: undefined });
+      const missingState = createRun({ execution: undefined });
+      const retiredState = createRun();
+      Object.assign(retiredState.delivery!, { handoffLeaseId: "lease-1" });
+      const invalidStatus = createRun({
+        execution: { status: "running\n" } as unknown as SubagentRunRecord["execution"],
+      });
 
-      expect(() => saveSubagentRegistryToSqlite(new Map([[run.runId, run]]))).toThrow(
-        "subagent run is missing canonical nested state",
-      );
+      for (const run of [missingState, retiredState, invalidStatus]) {
+        expect(() => saveSubagentRegistryToSqlite(new Map([[run.runId, run]]))).toThrow(
+          "subagent run is missing canonical nested state",
+        );
+      }
     });
   });
 

--- a/src/agents/subagent-registry.store.sqlite.test.ts
+++ b/src/agents/subagent-registry.store.sqlite.test.ts
@@ -33,6 +33,12 @@ function createRun(overrides: Partial<SubagentRunRecord> = {}): SubagentRunRecor
     endedAt: 250,
     outcome: { status: "ok", startedAt: 110, endedAt: 250, elapsedMs: 140 },
     expectsCompletionMessage: true,
+    execution: {
+      status: "terminal",
+      startedAt: 110,
+      endedAt: 250,
+      outcome: { status: "ok", startedAt: 110, endedAt: 250, elapsedMs: 140 },
+    },
     completion: {
       required: true,
       resultText: "done",
@@ -146,6 +152,16 @@ describe("subagent registry sqlite store", () => {
     });
   });
 
+  it("rejects writes without canonical nested state", async () => {
+    await withTempStateEnv(async () => {
+      const run = createRun({ execution: undefined });
+
+      expect(() => saveSubagentRegistryToSqlite(new Map([[run.runId, run]]))).toThrow(
+        "subagent run is missing canonical nested state",
+      );
+    });
+  });
+
   it("preserves announcedAt for not_required delivery when completion was announced", async () => {
     await withTempStateEnv(async () => {
       const run = createRun({
@@ -219,6 +235,34 @@ describe("subagent registry sqlite store", () => {
       expect(
         openOpenClawStateDatabase().db.prepare("SELECT COUNT(*) AS count FROM subagent_runs").get(),
       ).toEqual({ count: 0 });
+    });
+  });
+
+  it("ignores rows with retired flat delivery state", async () => {
+    await withTempStateEnv(async () => {
+      const run = createRun();
+      saveSubagentRegistryToSqlite(new Map([[run.runId, run]]));
+
+      const { db } = openOpenClawStateDatabase();
+      db.prepare("UPDATE subagent_runs SET payload_json = ? WHERE run_id = ?").run(
+        JSON.stringify({
+          ...run,
+          execution: undefined,
+          completion: undefined,
+          delivery: undefined,
+          pendingFinalDelivery: true,
+        }),
+        run.runId,
+      );
+
+      expect(loadSubagentRegistryFromSqlite()).toEqual(new Map());
+
+      saveSubagentRegistryToSqlite(new Map([[run.runId, run]]));
+      db.prepare("UPDATE subagent_runs SET payload_json = ? WHERE run_id = ?").run(
+        JSON.stringify({ ...run, delivery: "pending" }),
+        run.runId,
+      );
+      expect(loadSubagentRegistryFromSqlite()).toEqual(new Map());
     });
   });
 

--- a/src/agents/subagent-registry.store.sqlite.ts
+++ b/src/agents/subagent-registry.store.sqlite.ts
@@ -58,7 +58,6 @@ function isCanonicalSubagentRunRecord(value: unknown): value is CanonicalSubagen
   );
 }
 
-/** Converts undefined to null so optional record fields round-trip through sqlite columns. */
 function jsonStringify(value: unknown): string | null {
   return value === undefined ? null : JSON.stringify(value);
 }
@@ -304,7 +303,6 @@ function rowToSubagentRunRecord(row: SubagentRunSqliteRow): SubagentRunRecord | 
   return record.runId && record.childSessionKey && record.requesterSessionKey ? record : null;
 }
 
-/** Flattens a normalized subagent run into typed sqlite columns plus payload_json. */
 function subagentRunRecordToSqliteInsert(entry: SubagentRunRecord): SubagentRunSqliteInsert {
   const normalized = normalizeSubagentRunState(structuredClone(entry));
   if (!isCanonicalSubagentRunRecord(normalized)) {

--- a/src/agents/subagent-registry.store.sqlite.ts
+++ b/src/agents/subagent-registry.store.sqlite.ts
@@ -90,8 +90,8 @@ function createDeliveryFromTypedColumns(
   row: SubagentRunSqliteRow,
   fallback: SubagentCompletionDeliveryState | undefined,
 ): SubagentCompletionDeliveryState | undefined {
-  // Typed delivery columns are authoritative for retry/delivered state while
-  // payload_json keeps compatibility with older fields during migration.
+  // Typed delivery columns own retry/delivered state; payload_json supplies
+  // canonical delivery fields without dedicated columns.
   const delivery = fallback ? { ...fallback } : undefined;
   const payload = parseJson(row.pending_final_delivery_payload_json) as
     | PendingFinalDeliveryPayload

--- a/src/agents/subagent-registry.store.sqlite.ts
+++ b/src/agents/subagent-registry.store.sqlite.ts
@@ -3,6 +3,7 @@
  * store preserves typed columns for hot delivery state while retaining the
  * normalized payload JSON for forward-compatible record hydration.
  */
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import type { Insertable, Selectable, Updateable } from "kysely";
 import { executeSqliteQuerySync, getNodeSqliteKysely } from "../infra/kysely-sync.js";
 import type { DB as OpenClawStateKyselyDatabase } from "../state/openclaw-state-db.generated.js";
@@ -26,6 +27,24 @@ type SubagentRegistryDatabase = Pick<OpenClawStateKyselyDatabase, "subagent_runs
 type SubagentRunSqliteRow = Selectable<SubagentRunsTable>;
 type SubagentRunSqliteInsert = Insertable<SubagentRunsTable>;
 type SubagentRunSqliteUpdate = Updateable<SubagentRunsTable>;
+type CanonicalSubagentRunRecord = SubagentRunRecord &
+  Required<Pick<SubagentRunRecord, "execution" | "completion" | "delivery">>;
+const EXECUTION_STATUS_RE = /^(?:queued|running|interrupted|terminal)$/;
+const DELIVERY_STATUS_RE = /^(?:not_required|pending|in_progress|delivered|failed|suspended|discarded)$/;
+
+function hasStateStatus(value: unknown, pattern: RegExp): value is Record<string, unknown> {
+  return isRecord(value) && typeof value.status === "string" && pattern.test(value.status);
+}
+
+function isCanonicalSubagentRunRecord(value: unknown): value is CanonicalSubagentRunRecord {
+  return (
+    isRecord(value) &&
+    hasStateStatus(value.execution, EXECUTION_STATUS_RE) &&
+    isRecord(value.completion) &&
+    typeof value.completion.required === "boolean" &&
+    hasStateStatus(value.delivery, DELIVERY_STATUS_RE)
+  );
+}
 
 /** Converts undefined to null so optional record fields round-trip through sqlite columns. */
 function jsonStringify(value: unknown): string | null {
@@ -152,7 +171,22 @@ function createRequesterSettleWakeFromTypedColumns(
 
 /** Rehydrates one sqlite row into the normalized subagent run record shape. */
 function rowToSubagentRunRecord(row: SubagentRunSqliteRow): SubagentRunRecord | null {
-  const payload = (parseJson(row.payload_json) as Partial<SubagentRunRecord> | undefined) ?? {};
+  const parsedPayload = parseJson(row.payload_json);
+  // SQLite shipped after these nested state groups became canonical. Rows
+  // without them cannot be owned safely and are discarded as transient state.
+  if (!isCanonicalSubagentRunRecord(parsedPayload)) {
+    return null;
+  }
+  const payload = parsedPayload;
+  const persistedDelivery = payload.delivery as SubagentCompletionDeliveryState &
+    Record<string, unknown>;
+  if (
+    "handoffLeaseId" in persistedDelivery ||
+    "handoffLeasedAt" in persistedDelivery ||
+    "handoffInjectedAt" in persistedDelivery
+  ) {
+    return null;
+  }
   const requesterOrigin =
     (parseJson(row.requester_origin_json) as SubagentRunRecord["requesterOrigin"] | undefined) ??
     payload.requesterOrigin;
@@ -271,6 +305,9 @@ function rowToSubagentRunRecord(row: SubagentRunSqliteRow): SubagentRunRecord | 
 /** Flattens a normalized subagent run into typed sqlite columns plus payload_json. */
 function subagentRunRecordToSqliteInsert(entry: SubagentRunRecord): SubagentRunSqliteInsert {
   const normalized = normalizeSubagentRunState(structuredClone(entry));
+  if (!isCanonicalSubagentRunRecord(normalized)) {
+    throw new Error("subagent run is missing canonical nested state");
+  }
   const delivery = normalized.delivery;
   const completion = normalized.completion;
   const requesterSettleWake = normalized.requesterSettleWake;

--- a/src/agents/subagent-registry.store.sqlite.ts
+++ b/src/agents/subagent-registry.store.sqlite.ts
@@ -172,8 +172,7 @@ function createRequesterSettleWakeFromTypedColumns(
 /** Rehydrates one sqlite row into the normalized subagent run record shape. */
 function rowToSubagentRunRecord(row: SubagentRunSqliteRow): SubagentRunRecord | null {
   const parsedPayload = parseJson(row.payload_json);
-  // SQLite shipped after these nested state groups became canonical. Rows
-  // without them cannot be owned safely and are discarded as transient state.
+  // SQLite shipped after nested state became canonical; unowned rows are transient.
   if (!isCanonicalSubagentRunRecord(parsedPayload)) {
     return null;
   }

--- a/src/agents/subagent-registry.store.sqlite.ts
+++ b/src/agents/subagent-registry.store.sqlite.ts
@@ -29,20 +29,32 @@ type SubagentRunSqliteInsert = Insertable<SubagentRunsTable>;
 type SubagentRunSqliteUpdate = Updateable<SubagentRunsTable>;
 type CanonicalSubagentRunRecord = SubagentRunRecord &
   Required<Pick<SubagentRunRecord, "execution" | "completion" | "delivery">>;
-const EXECUTION_STATUS_RE = /^(?:queued|running|interrupted|terminal)$/;
-const DELIVERY_STATUS_RE = /^(?:not_required|pending|in_progress|delivered|failed|suspended|discarded)$/;
+const EXECUTION_STATUSES = new Set("queued running interrupted terminal".split(" "));
+const DELIVERY_STATUSES = new Set(
+  "not_required pending in_progress delivered failed suspended discarded".split(" "),
+);
 
-function hasStateStatus(value: unknown, pattern: RegExp): value is Record<string, unknown> {
-  return isRecord(value) && typeof value.status === "string" && pattern.test(value.status);
+function hasStateStatus(
+  value: unknown,
+  statuses: ReadonlySet<string>,
+): value is Record<string, unknown> {
+  return isRecord(value) && typeof value.status === "string" && statuses.has(value.status);
+}
+
+function hasCanonicalDeliveryState(value: unknown): value is Record<string, unknown> {
+  return (
+    hasStateStatus(value, DELIVERY_STATUSES) &&
+    !("handoffLeaseId" in value || "handoffLeasedAt" in value || "handoffInjectedAt" in value)
+  );
 }
 
 function isCanonicalSubagentRunRecord(value: unknown): value is CanonicalSubagentRunRecord {
   return (
     isRecord(value) &&
-    hasStateStatus(value.execution, EXECUTION_STATUS_RE) &&
+    hasStateStatus(value.execution, EXECUTION_STATUSES) &&
     isRecord(value.completion) &&
     typeof value.completion.required === "boolean" &&
-    hasStateStatus(value.delivery, DELIVERY_STATUS_RE)
+    hasCanonicalDeliveryState(value.delivery)
   );
 }
 
@@ -177,15 +189,6 @@ function rowToSubagentRunRecord(row: SubagentRunSqliteRow): SubagentRunRecord | 
     return null;
   }
   const payload = parsedPayload;
-  const persistedDelivery = payload.delivery as SubagentCompletionDeliveryState &
-    Record<string, unknown>;
-  if (
-    "handoffLeaseId" in persistedDelivery ||
-    "handoffLeasedAt" in persistedDelivery ||
-    "handoffInjectedAt" in persistedDelivery
-  ) {
-    return null;
-  }
   const requesterOrigin =
     (parseJson(row.requester_origin_json) as SubagentRunRecord["requesterOrigin"] | undefined) ??
     payload.requesterOrigin;

--- a/src/gateway/session-utils.subagent.test.ts
+++ b/src/gateway/session-utils.subagent.test.ts
@@ -7,6 +7,7 @@ import path from "node:path";
 import { expectDefined } from "@openclaw/normalization-core";
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import { saveSubagentRegistryToSqlite } from "../agents/subagent-registry.store.sqlite.js";
+import { canonicalSubagentRunFixtures } from "../agents/subagent-registry.persistence.test-support.js";
 import {
   addSubagentRunForTests,
   resetSubagentRegistryForTests,
@@ -829,7 +830,7 @@ describe("listSessionsFromStore subagent metadata", () => {
           OPENCLAW_TEST_READ_SUBAGENT_RUNS_FROM_SQLITE: "1",
         },
         () => {
-          saveSubagentRegistryToSqlite(persistedRuns);
+          saveSubagentRegistryToSqlite(canonicalSubagentRunFixtures(persistedRuns));
           const result = listSessionsFromStore({
             cfg,
             storePath: "/tmp/sessions.json",
@@ -920,7 +921,7 @@ describe("listSessionsFromStore subagent metadata", () => {
           OPENCLAW_TEST_READ_SUBAGENT_RUNS_FROM_SQLITE: "1",
         },
         () => {
-          saveSubagentRegistryToSqlite(persistedRuns);
+          saveSubagentRegistryToSqlite(canonicalSubagentRunFixtures(persistedRuns));
           return listSessionsFromStore({
             cfg,
             storePath: "/tmp/sessions.json",

--- a/src/gateway/session-utils.subagent.test.ts
+++ b/src/gateway/session-utils.subagent.test.ts
@@ -6,8 +6,8 @@ import os from "node:os";
 import path from "node:path";
 import { expectDefined } from "@openclaw/normalization-core";
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
-import { saveSubagentRegistryToSqlite } from "../agents/subagent-registry.store.sqlite.js";
 import { canonicalSubagentRunFixtures } from "../agents/subagent-registry.persistence.test-support.js";
+import { saveSubagentRegistryToSqlite } from "../agents/subagent-registry.store.sqlite.js";
 import {
   addSubagentRunForTests,
   resetSubagentRegistryForTests,


### PR DESCRIPTION
## What Problem This Solves

The subagent registry still carried steady-state migration code for retired flat delivery fields and pre-steering handoff lease names. That fallback ran on every SQLite restore even though the canonical nested state shape predates the SQLite store itself and the compatibility path had no registered lifetime or removal contract.

## Why This Change Was Made

This removes the unregistered runtime migration and makes the SQLite boundary accept only current nested execution, completion, and delivery state. Current writes fail fast when that invariant is missing; unrecognized restored rows are ignored as transient in-flight state. The retired JSON registry remains doctor-owned discard rather than a runtime import path.

History confirms that the nested shape landed in d73f3ac85d5fd68cecf33dd474e69372fadf22f9 on 2026-05-23, first tagged in v2026.5.24-alpha.1. SQLite persistence landed later in 5374c7a8a20804835c1e3218496f441e4b0775fa on 2026-05-30, first tagged in v2026.5.30-beta.1, and its writer already serialized normalized nested state. No release wrote flat payloads into this store. The handoff lease names existed in two prerelease tags before f24a1387909529c476ff2509f6fe283441849f41 renamed them; those in-flight rows are intentionally dropped under the transient-state policy rather than migrated indefinitely.

## User Impact

There is no behavior change for current canonical subagent runs. Operators upgrading from the short-lived pre-steering prereleases may lose an in-flight handoff row instead of having it silently rewritten; completed and future runs continue through the canonical SQLite path.

AI-assisted: Codex implemented and reviewed this maintainer-authorized refactor.

## Evidence

- Production boundary: `src/agents/subagent-delivery-state.ts:7` now handles current ownership metadata only; `src/agents/subagent-registry.store.sqlite.ts:51` validates exact canonical state groups, `src/agents/subagent-registry.store.sqlite.ts:185` discards unowned restored rows, and `src/agents/subagent-registry.store.sqlite.ts:308` rejects incomplete writes.
- Regression coverage: `src/agents/subagent-registry.store.sqlite.test.ts:155` proves noncanonical current writes fail, and `src/agents/subagent-registry.store.sqlite.test.ts:248` proves retired or malformed restored rows are ignored.
- Numstat: production `+42/-244` (net `-202`); tests/test-support `+105/-106` (net `-1`). Total `+147/-350` (net `-203`).
- `node scripts/run-vitest.mjs subagent-delivery-state subagent-registry` — 17 files passed, 398 tests passed.
- `node scripts/run-vitest.mjs src/agents/subagent-orphan-recovery.restart-integration.test.ts` — 1 file passed, 3 tests passed.
- `node scripts/run-vitest.mjs src/gateway/session-utils.subagent.test.ts` — 1 file passed, 30 tests passed.
- `git diff --check` — passed.
- `node scripts/check-changed.mjs -- <six changed files>` delegated to Blacksmith Testbox `tbx_01kyp5nht13a1phmm4whqvsq47` / Actions run 30425296804. The scoped gate reached an unrelated existing max-lines baseline ratchet for `extensions/ollama/src/setup.ts`; this PR does not touch that file.
- Exact-head CI run 30426314840 exposed shorthand test fixtures in the orphan-recovery and gateway session suites plus a max-lines ratchet in the persistence test. The fixtures now expand through `src/agents/subagent-registry.persistence.test-support.ts`, and the exact failed files pass locally.
- Exact-head CI runs 30427435256 and 30429268310 exposed failures already on fresh main from #115305: an untyped script callback, a TypeScript test import that missed the allowed `.js` public API spelling, and formatting around those changes. #115674 and #115645 fixed those upstream before the final rebase, so no code-mode files remain in this PR. The latter run also had an unrelated MCP timing flake; the exact file passes 85/85 locally.
- Autoreview accepted and fixed malformed-state validation, writer/loader contract, exact-status, and symmetric retired-handoff findings. No accepted/actionable findings remain. Two compatibility-preservation findings were rejected under the explicit lane contract and shipment evidence; an unused-import report was rejected because both imports remain used; the final typed-column report was rejected because no `delivery_status` column exists and reconstructed statuses are validated payload values or hard-coded canonical constants.
