### PR TITLE
fix: reject remote flags during local onboarding

### DIFF
--- a/src/commands/onboard.test.ts
+++ b/src/commands/onboard.test.ts
@@ -473,6 +473,16 @@ describe("setupWizardCommand", () => {
       expectedError: "URL must start with ws:// or wss://",
     },
     {
+      label: "remote URL in local mode",
+      options: { mode: "local" as const, remoteUrl: "wss://gateway.example.invalid" },
+      expectedError: "--remote-url requires --mode remote in non-interactive setup.",
+    },
+    {
+      label: "remote token in default local mode",
+      options: { remoteToken: "fixture-token" },
+      expectedError: "--remote-token requires --mode remote in non-interactive setup.",
+    },
+    {
       label: "unsupported daemon runtime while daemon install is skipped",
       options: { daemonRuntime: "bogus" as never, installDaemon: false },
       expectedError: "Invalid --daemon-runtime",

--- a/src/commands/onboard.ts
+++ b/src/commands/onboard.ts
@@ -67,6 +67,16 @@ function validatePreflightOptions(opts: OnboardOptions, runtime: RuntimeEnv): bo
       `Invalid --mode "${String(opts.mode)}". Use "local" or "remote", or run ${formatCliCommand("openclaw onboard")} for interactive setup.`,
     );
   }
+  const remoteOnlyFlags = [
+    opts.remoteUrl !== undefined ? "--remote-url" : undefined,
+    opts.remoteToken !== undefined ? "--remote-token" : undefined,
+  ].filter((flag): flag is string => flag !== undefined);
+  if (opts.nonInteractive && (opts.mode ?? "local") === "local" && remoteOnlyFlags.length > 0) {
+    return rejectOption(
+      runtime,
+      `${remoteOnlyFlags.join(" and ")} ${remoteOnlyFlags.length === 1 ? "requires" : "require"} --mode remote in non-interactive setup.`,
+    );
+  }
   const choiceValidations: Array<readonly [string, string | undefined, readonly string[]]> = [
     ["--gateway-bind", opts.gatewayBind, ["loopback", "tailnet", "lan", "auto", "custom"]],
     ["--gateway-auth", opts.gatewayAuth, ["token", "password"]],


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where non-interactive local onboarding accepted `--remote-url` or `--remote-token`, exited successfully, and silently discarded the remote-only input. This affected both `openclaw onboard` and `openclaw setup`, so automation could report success while configuring a local Gateway instead of the requested remote connection.

## Why This Change Was Made

The shared onboarding preflight now rejects remote-only flags whenever non-interactive setup is explicitly or implicitly in local mode. Interactive onboarding keeps accepting `--remote-url` as a wizard prefill, and remote mode keeps its existing URL/token behavior.

This PR is AI-assisted. I reviewed the CLI registrations, shared setup entrypoint, local/remote dispatcher, interactive routing, and adjacent validation tests.

## User Impact

Automation now receives an actionable nonzero error instead of silently losing a remote Gateway URL or token. Ordinary local onboarding remains unchanged.

## Evidence

- Before on current main `ec4c90c45509a9f89dfb3cc12432ae27bf543459`: four source-blind CLI cases (`onboard`/`setup` crossed with `--remote-url`/`--remote-token`) all exited 0, wrote `openclaw.json`, and reported successful local onboarding.
- After on exact head `0105d621a91637a792d3a1bc69849b73649c2bbf`: all four invalid cases exit 1 with no config write and a precise `requires --mode remote` message; the valid local control still exits 0 and writes `mode: local`.
- Focused local test: `src/commands/onboard.test.ts` — 51/51 passed.
- Blacksmith Testbox `tbx_01kyp6dth3p6n6zgd208qqcf6m`: 51/51 focused tests followed by a clean `check:changed`; wrapper exit 0. Workflow: https://github.com/openclaw/openclaw/actions/runs/30425954029
- Exact-head autoreview: clean, no accepted/actionable findings (0.98 confidence).
- Duplicate search: local Gitcrawl plus live GitHub issue/PR search found no matching report or fix.

Provenance: the remote Gateway options originated in direct commit `bd7cd33b02edfd23c34c7754eab4f1c4da6dadf0` (Peter Steinberger, 2026-01-01) and the current CLI registration was carried forward by direct refactor commit `bcbfb357bec72500b304936fd2d37e1acd49edbb` (Peter Steinberger, 2026-01-14).
