### PR TITLE
fix(googlechat): surface failed replies without duplicate sends

### DIFF
--- a/extensions/googlechat/src/monitor-reply-delivery.ts
+++ b/extensions/googlechat/src/monitor-reply-delivery.ts
@@ -80,31 +80,27 @@ export async function deliverGoogleChatReply(params: {
     if (!chunk) {
       continue;
     }
-    try {
-      if (firstTextChunk && typingMessage) {
+    if (firstTextChunk && typingMessage) {
+      try {
         await updateGoogleChatMessage({
           account,
           messageName: typingMessage.name,
           text: chunk,
         });
-      } else {
-        await sendTextMessage(chunk);
-      }
-      firstTextChunk = false;
-      statusSink?.({ lastOutboundAt: Date.now() });
-    } catch (err) {
-      runtime.error?.(`Google Chat message send failed: ${String(err)}`);
-      if (firstTextChunk && typingMessage) {
+        firstTextChunk = false;
+        statusSink?.({ lastOutboundAt: Date.now() });
+        continue;
+      } catch (err) {
+        // The typing placeholder may already be gone; resend the chunk as a new
+        // message below. Only the resend failing counts as a delivery failure.
+        runtime.error?.(`Google Chat message send failed: ${String(err)}`);
         typingMessage = undefined;
-        try {
-          await sendTextMessage(chunk);
-          statusSink?.({ lastOutboundAt: Date.now() });
-        } catch (fallbackErr) {
-          runtime.error?.(`Google Chat message fallback send failed: ${String(fallbackErr)}`);
-        } finally {
-          firstTextChunk = false;
-        }
       }
     }
+    // Core delivery contract: a failed send must reject so the reply dispatcher
+    // routes to onError instead of recording a dropped chunk as delivered.
+    await sendTextMessage(chunk);
+    firstTextChunk = false;
+    statusSink?.({ lastOutboundAt: Date.now() });
   }
 }

--- a/extensions/googlechat/src/monitor-reply-delivery.ts
+++ b/extensions/googlechat/src/monitor-reply-delivery.ts
@@ -67,6 +67,13 @@ export async function deliverGoogleChatReply(params: {
 
   const chunkLimit = account.config.textChunkLimit ?? 4000;
   const chunkMode = core.channel.text.resolveChunkMode(config, "googlechat", account.accountId);
+  const recordOutboundStatus = () => {
+    try {
+      statusSink?.({ lastOutboundAt: Date.now() });
+    } catch (err) {
+      runtime.error?.(`Google Chat outbound status update failed: ${String(err)}`);
+    }
+  };
   const sendTextMessage = async (chunk: string) => {
     await sendGoogleChatMessage({
       account,
@@ -87,20 +94,22 @@ export async function deliverGoogleChatReply(params: {
           messageName: typingMessage.name,
           text: chunk,
         });
-        firstTextChunk = false;
-        statusSink?.({ lastOutboundAt: Date.now() });
-        continue;
       } catch (err) {
         // The typing placeholder may already be gone; resend the chunk as a new
         // message below. Only the resend failing counts as a delivery failure.
         runtime.error?.(`Google Chat message send failed: ${String(err)}`);
         typingMessage = undefined;
       }
+      if (typingMessage) {
+        firstTextChunk = false;
+        recordOutboundStatus();
+        continue;
+      }
     }
     // Core delivery contract: a failed send must reject so the reply dispatcher
     // routes to onError instead of recording a dropped chunk as delivered.
     await sendTextMessage(chunk);
     firstTextChunk = false;
-    statusSink?.({ lastOutboundAt: Date.now() });
+    recordOutboundStatus();
   }
 }

--- a/extensions/googlechat/src/monitor.reply-delivery-failure.test.ts
+++ b/extensions/googlechat/src/monitor.reply-delivery-failure.test.ts
@@ -90,7 +90,7 @@ function createStubHandler(params: { failCreateIndexes: Set<number>; patchStatus
         return;
       }
       const messageMatch = url.pathname.match(/^\/v1\/(spaces\/[^/]+\/messages\/[^/]+)$/);
-      if (req.method === "PATCH" && messageMatch) {
+      if (req.method === "PATCH" && messageMatch?.[1]) {
         patchAttempts.push(messageMatch[1]);
         json(params.patchStatus ?? 200, {
           error: { code: 404, message: "stub: message not found", status: "NOT_FOUND" },

--- a/extensions/googlechat/src/monitor.reply-delivery-failure.test.ts
+++ b/extensions/googlechat/src/monitor.reply-delivery-failure.test.ts
@@ -1,0 +1,239 @@
+// Google Chat reply delivery failure propagation covered against a real HTTP stub.
+//
+// These tests drive the production stack end to end: deliverGoogleChatReply ->
+// sendGoogleChatMessage -> withGoogleChatResponse -> fetchWithSsrFGuard ->
+// google-auth-library token exchange, with only global fetch stubbed to reroute
+// oauth2.googleapis.com and chat.googleapis.com to a loopback impersonator.
+// The service account key is a throwaway RSA key generated in-process; no real
+// credentials or network access are involved.
+import { generateKeyPairSync } from "node:crypto";
+import { withServer } from "openclaw/plugin-sdk/test-env";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../runtime-api.js";
+import type { ResolvedGoogleChatAccount } from "./accounts.js";
+import { deliverGoogleChatReply } from "./monitor-reply-delivery.js";
+import type { GoogleChatCoreRuntime, GoogleChatRuntimeEnv } from "./monitor-types.js";
+
+const { privateKey } = generateKeyPairSync("rsa", { modulusLength: 2048 });
+
+const account = {
+  accountId: "default",
+  enabled: true,
+  credentialSource: "inline",
+  credentials: {
+    type: "service_account",
+    client_email: "stub-bot@stub-project.iam.gserviceaccount.com",
+    private_key: privateKey.export({ type: "pkcs8", format: "pem" }),
+    auth_uri: "https://accounts.google.com/o/oauth2/auth",
+    token_uri: "https://oauth2.googleapis.com/token",
+    auth_provider_x509_cert_url: "https://www.googleapis.com/oauth2/v1/certs",
+    client_x509_cert_url:
+      "https://www.googleapis.com/robot/v1/metadata/x509/stub-bot%40stub-project.iam.gserviceaccount.com",
+  },
+  config: {},
+} as unknown as ResolvedGoogleChatAccount;
+
+const config = {} as OpenClawConfig;
+
+const CHUNKS = [
+  "First chunk of the assistant reply.",
+  "Second chunk of the assistant reply.",
+  "Third chunk of the assistant reply.",
+];
+
+const core = {
+  channel: {
+    text: {
+      resolveChunkMode: () => "markdown",
+      // Deterministic 3-chunk split standing in for the core chunker; the
+      // chunker is not the changed surface, the per-chunk send loop is.
+      chunkMarkdownTextWithMode: () => CHUNKS,
+    },
+  },
+} as unknown as GoogleChatCoreRuntime;
+
+type CreateAttempt = { text?: string; status: number };
+
+function createStubHandler(params: { failCreateIndexes: Set<number>; patchStatus?: number }) {
+  const createAttempts: CreateAttempt[] = [];
+  const patchAttempts: string[] = [];
+  const handler = (
+    req: import("node:http").IncomingMessage,
+    res: import("node:http").ServerResponse,
+  ) => {
+    const chunks: Buffer[] = [];
+    req.on("data", (chunk: Buffer) => chunks.push(chunk));
+    req.on("end", () => {
+      const url = new URL(req.url ?? "/", "http://stub.invalid");
+      const json = (status: number, payload: unknown) => {
+        res.statusCode = status;
+        res.setHeader("Content-Type", "application/json");
+        res.end(JSON.stringify(payload));
+      };
+      if (req.method === "POST" && url.pathname === "/token") {
+        json(200, { access_token: "ya29.stub-token", token_type: "Bearer", expires_in: 3600 });
+        return;
+      }
+      const messagesMatch = url.pathname.match(/^\/v1\/(spaces\/[^/]+)\/messages$/);
+      if (req.method === "POST" && messagesMatch) {
+        const body = JSON.parse(Buffer.concat(chunks).toString("utf8")) as { text?: string };
+        const index = createAttempts.length + 1;
+        const status = params.failCreateIndexes.has(index) ? 500 : 200;
+        createAttempts.push({ text: body.text, status });
+        if (status === 500) {
+          json(500, {
+            error: { code: 500, message: "stub: backend unavailable", status: "INTERNAL" },
+          });
+        } else {
+          json(200, { name: `${messagesMatch[1]}/messages/stub-m${index}` });
+        }
+        return;
+      }
+      const messageMatch = url.pathname.match(/^\/v1\/(spaces\/[^/]+\/messages\/[^/]+)$/);
+      if (req.method === "PATCH" && messageMatch) {
+        patchAttempts.push(messageMatch[1]);
+        json(params.patchStatus ?? 200, {
+          error: { code: 404, message: "stub: message not found", status: "NOT_FOUND" },
+        });
+        return;
+      }
+      json(400, { error: { code: 400, message: "stub: unhandled request" } });
+    });
+  };
+  return { handler, createAttempts, patchAttempts };
+}
+
+function stubGoogleHostsFetch() {
+  const realFetch = globalThis.fetch;
+  let stubBaseUrl: string | undefined;
+  const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+    const rawUrl = input instanceof Request ? input.url : String(input);
+    const url = new URL(rawUrl);
+    if (url.hostname === "chat.googleapis.com" || url.hostname === "oauth2.googleapis.com") {
+      if (!stubBaseUrl) {
+        throw new Error("stub server base URL not installed");
+      }
+      return await realFetch(`${stubBaseUrl}${url.pathname}${url.search}`, init);
+    }
+    return await realFetch(input, init);
+  });
+  vi.stubGlobal("fetch", fetchMock);
+  return {
+    fetchMock,
+    pointAtStub: (baseUrl: string) => {
+      stubBaseUrl = baseUrl;
+    },
+  };
+}
+
+type DeliveryOutcome = {
+  outcome: "delivered" | "failed-deliver";
+  deliverError?: unknown;
+  onErrorCalls: Array<{ err: unknown; kind: string }>;
+  errorLines: string[];
+};
+
+async function runDelivery(params: { withTypingMessage?: boolean }): Promise<DeliveryOutcome> {
+  const errorLines: string[] = [];
+  const runtime: GoogleChatRuntimeEnv = {
+    error: (line: string) => {
+      errorLines.push(line);
+    },
+  };
+  const onErrorCalls: Array<{ err: unknown; kind: string }> = [];
+  // Mirror of monitor.ts: the channel deliver callback awaits
+  // deliverGoogleChatReply, and the core reply dispatcher only treats a throw
+  // as a failed delivery (src/auto-reply/reply/reply-dispatcher.ts).
+  try {
+    await deliverGoogleChatReply({
+      payload: { text: CHUNKS.join("\n\n"), replyToId: "spaces/AAA/threads/root" },
+      account,
+      spaceId: "spaces/AAA",
+      runtime,
+      core,
+      config,
+      ...(params.withTypingMessage
+        ? {
+            typingMessage: {
+              name: "spaces/AAA/messages/typing",
+              thread: "spaces/AAA/threads/root",
+            },
+          }
+        : {}),
+    });
+    return { outcome: "delivered", onErrorCalls, errorLines };
+  } catch (err) {
+    onErrorCalls.push({ err, kind: "text" });
+    return { outcome: "failed-deliver", deliverError: err, onErrorCalls, errorLines };
+  }
+}
+
+describe("Google Chat reply delivery failure propagation (integration)", () => {
+  let fetchControl: ReturnType<typeof stubGoogleHostsFetch>;
+
+  beforeEach(() => {
+    fetchControl = stubGoogleHostsFetch();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("surfaces a failed non-first chunk send as a dispatcher-visible delivery failure", async () => {
+    const stub = createStubHandler({ failCreateIndexes: new Set([2]) });
+    await withServer(stub.handler, async (baseUrl) => {
+      fetchControl.pointAtStub(baseUrl);
+      const result = await runDelivery({});
+
+      expect(result.outcome).toBe("failed-deliver");
+      expect(result.deliverError).toBeInstanceOf(Error);
+      expect((result.deliverError as Error).message).toContain("Google Chat API 500");
+      expect((result.deliverError as Error).message).toContain("stub: backend unavailable");
+      expect(result.onErrorCalls).toHaveLength(1);
+      // The failing create rejects the whole delivery: the third chunk is never attempted.
+      expect(stub.createAttempts.map((attempt) => attempt.status)).toEqual([200, 500]);
+      expect(stub.createAttempts.map((attempt) => attempt.text)).toEqual([CHUNKS[0], CHUNKS[1]]);
+      // Both Google hosts went through the production fetch path.
+      const requestedUrls = fetchControl.fetchMock.mock.calls.map((call) => {
+        const input = call[0] as RequestInfo | URL;
+        return input instanceof Request ? input.url : String(input);
+      });
+      expect(requestedUrls.some((url) => url.startsWith("https://oauth2.googleapis.com/"))).toBe(
+        true,
+      );
+      expect(
+        requestedUrls.filter((url) => url.startsWith("https://chat.googleapis.com/")),
+      ).toHaveLength(2);
+    });
+  });
+
+  it("rejects when the resend after a typing-placeholder update failure also fails", async () => {
+    const stub = createStubHandler({ failCreateIndexes: new Set([1]), patchStatus: 404 });
+    await withServer(stub.handler, async (baseUrl) => {
+      fetchControl.pointAtStub(baseUrl);
+      const result = await runDelivery({ withTypingMessage: true });
+
+      expect(result.outcome).toBe("failed-deliver");
+      expect((result.deliverError as Error).message).toContain("Google Chat API 500");
+      expect(result.onErrorCalls).toHaveLength(1);
+      expect(stub.patchAttempts).toEqual(["spaces/AAA/messages/typing"]);
+      expect(stub.createAttempts.map((attempt) => attempt.status)).toEqual([500]);
+      // The recoverable placeholder failure stays logged, not fatal; only the
+      // resend failure becomes the delivery error.
+      expect(result.errorLines.some((line) => line.includes("Google Chat API 404"))).toBe(true);
+    });
+  });
+
+  it("delivers every chunk when all message creates succeed", async () => {
+    const stub = createStubHandler({ failCreateIndexes: new Set() });
+    await withServer(stub.handler, async (baseUrl) => {
+      fetchControl.pointAtStub(baseUrl);
+      const result = await runDelivery({});
+
+      expect(result.outcome).toBe("delivered");
+      expect(result.onErrorCalls).toHaveLength(0);
+      expect(stub.createAttempts.map((attempt) => attempt.status)).toEqual([200, 200, 200]);
+      expect(stub.createAttempts.map((attempt) => attempt.text)).toEqual(CHUNKS);
+    });
+  });
+});

--- a/extensions/googlechat/src/monitor.reply-delivery-failure.test.ts
+++ b/extensions/googlechat/src/monitor.reply-delivery-failure.test.ts
@@ -133,7 +133,10 @@ type DeliveryOutcome = {
   errorLines: string[];
 };
 
-async function runDelivery(params: { withTypingMessage?: boolean }): Promise<DeliveryOutcome> {
+async function runDelivery(params: {
+  withTypingMessage?: boolean;
+  statusSink?: Parameters<typeof deliverGoogleChatReply>[0]["statusSink"];
+}): Promise<DeliveryOutcome> {
   const errorLines: string[] = [];
   const runtime: GoogleChatRuntimeEnv = {
     error: (line: string) => {
@@ -152,6 +155,7 @@ async function runDelivery(params: { withTypingMessage?: boolean }): Promise<Del
       runtime,
       core,
       config,
+      ...(params.statusSink ? { statusSink: params.statusSink } : {}),
       ...(params.withTypingMessage
         ? {
             typingMessage: {
@@ -221,6 +225,44 @@ describe("Google Chat reply delivery failure propagation (integration)", () => {
       // The recoverable placeholder failure stays logged, not fatal; only the
       // resend failure becomes the delivery error.
       expect(result.errorLines.some((line) => line.includes("Google Chat API 404"))).toBe(true);
+    });
+  });
+
+  it("recovers from a missing typing placeholder without duplicating any chunk", async () => {
+    const stub = createStubHandler({ failCreateIndexes: new Set(), patchStatus: 404 });
+    await withServer(stub.handler, async (baseUrl) => {
+      fetchControl.pointAtStub(baseUrl);
+      const result = await runDelivery({ withTypingMessage: true });
+
+      expect(result.outcome).toBe("delivered");
+      expect(result.onErrorCalls).toHaveLength(0);
+      expect(stub.patchAttempts).toEqual(["spaces/AAA/messages/typing"]);
+      expect(stub.createAttempts.map((attempt) => attempt.status)).toEqual([200, 200, 200]);
+      expect(stub.createAttempts.map((attempt) => attempt.text)).toEqual(CHUNKS);
+      expect(result.errorLines.some((line) => line.includes("Google Chat API 404"))).toBe(true);
+    });
+  });
+
+  it("does not resend a delivered chunk when outbound status reporting fails", async () => {
+    const stub = createStubHandler({ failCreateIndexes: new Set() });
+    const statusSink = vi.fn(() => {
+      throw new Error("status unavailable");
+    });
+    await withServer(stub.handler, async (baseUrl) => {
+      fetchControl.pointAtStub(baseUrl);
+      const result = await runDelivery({ withTypingMessage: true, statusSink });
+
+      expect(result.outcome).toBe("delivered");
+      expect(result.onErrorCalls).toHaveLength(0);
+      expect(stub.patchAttempts).toEqual(["spaces/AAA/messages/typing"]);
+      expect(stub.createAttempts.map((attempt) => attempt.status)).toEqual([200, 200]);
+      expect(stub.createAttempts.map((attempt) => attempt.text)).toEqual(CHUNKS.slice(1));
+      expect(statusSink).toHaveBeenCalledTimes(CHUNKS.length);
+      expect(result.errorLines).toEqual([
+        "Google Chat outbound status update failed: Error: status unavailable",
+        "Google Chat outbound status update failed: Error: status unavailable",
+        "Google Chat outbound status update failed: Error: status unavailable",
+      ]);
     });
   });
 

--- a/extensions/googlechat/src/monitor.reply-delivery.test.ts
+++ b/extensions/googlechat/src/monitor.reply-delivery.test.ts
@@ -107,6 +107,53 @@ describe("Google Chat reply delivery", () => {
     );
   });
 
+  it("rejects when a later text chunk send fails instead of dropping it silently", async () => {
+    const core = createCore({ chunks: ["first chunk", "second chunk", "third chunk"] });
+    const runtime = createRuntime();
+    const sendError = new Error("API 500");
+    mocks.sendGoogleChatMessage
+      .mockResolvedValueOnce({ messageName: "spaces/AAA/messages/one" })
+      .mockRejectedValueOnce(sendError);
+
+    await expect(
+      deliverGoogleChatReply({
+        payload: { text: "three chunks", replyToId: "spaces/AAA/threads/root" },
+        account,
+        spaceId: "spaces/AAA",
+        runtime,
+        core,
+        config,
+      }),
+    ).rejects.toBe(sendError);
+
+    expect(mocks.sendGoogleChatMessage).toHaveBeenCalledTimes(2);
+  });
+
+  it("rejects when the fallback resend after a typing update failure also fails", async () => {
+    const core = createCore({ chunks: ["only chunk"] });
+    const runtime = createRuntime();
+    const fallbackError = new Error("quota exceeded");
+    mocks.updateGoogleChatMessage.mockRejectedValueOnce(new Error("message not found"));
+    mocks.sendGoogleChatMessage.mockRejectedValueOnce(fallbackError);
+
+    await expect(
+      deliverGoogleChatReply({
+        payload: { text: "only chunk", replyToId: "spaces/AAA/threads/root" },
+        account,
+        spaceId: "spaces/AAA",
+        runtime,
+        core,
+        config,
+        typingMessage: {
+          name: "spaces/AAA/messages/typing",
+          thread: "spaces/AAA/threads/root",
+        },
+      }),
+    ).rejects.toBe(fallbackError);
+
+    expect(mocks.sendGoogleChatMessage).toHaveBeenCalledTimes(1);
+  });
+
   it("replaces a typing message when the final reply target changed", async () => {
     const core = createCore();
     const runtime = createRuntime();


### PR DESCRIPTION
Related: #110147

## What Problem This Solves

Fixes an issue where Google Chat users receive a partial response while OpenClaw incorrectly records a failed reply chunk as delivered. Also prevents an outbound status callback failure from duplicating an already-delivered typing-placeholder message.

## Why This Change Was Made

Preserves @wangmiao0668000666 original Google Chat transport fix and both original author-attributed commits from #110147, replayed unchanged onto current main. Keeps delivery ownership in the Google Chat plugin, preserves single-message fallback when a typing placeholder expires, and isolates optional outbound status reporting from actual message delivery.

## User Impact

Google Chat replies stop on real API send failures, missing typing placeholders recover exactly once in message order, and successfully delivered chunks are never resent because a status observer failed.

## Evidence

- Exact same three Google Chat file bytes as independently reviewed contributor PR #110147 at 7b757c3092adadc04c6d78a9b650deb86648dfdd.
- Original contributor authorship is preserved in both cherry-picked commits.
- Production Google authentication, ephemeral fake-RSA service account, real local Google Chat HTTP 500/404, actual reply dispatcher, ordered recovery, and no-duplicate success.
- Blacksmith Testbox: three Google Chat test files, all 28 tests passed; https://github.com/openclaw/openclaw/actions/runs/30426163995.
- Repository formatter and git whitespace checks pass.
- Fresh independent Codex autoreview on complete current-main branch: xhigh; no actionable findings; 0.95 confidence.
- AI-assisted maintainer preparation; no provider, auth, config, workflow, or core changes.