### PR TITLE
fix(telegram): stop retrying messages after a recipient blocks the bot

### DIFF
--- a/extensions/telegram/src/telegram-ingress-drain.test.ts
+++ b/extensions/telegram/src/telegram-ingress-drain.test.ts
@@ -2,6 +2,7 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import { GrammyError } from "grammy";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { createChannelIngressQueueForTests } from "openclaw/plugin-sdk/plugin-state-test-runtime";
 import { describe, expect, it, vi } from "vitest";
@@ -10,6 +11,7 @@ import {
   type TelegramSpooledReplayDeferredParticipant,
 } from "./bot-processing-outcome.js";
 import { createTelegramIngressMonitor } from "./telegram-ingress-drain.js";
+import { resolveTelegramIngressNonRetryableFailure } from "./telegram-ingress-non-retryable.js";
 import { telegramSpooledUpdateLaneKey } from "./telegram-ingress-spool.js";
 import {
   TelegramIngressPayloadError,
@@ -50,7 +52,85 @@ function updatePayload(updateId: number): TelegramSpooledUpdatePayload {
   };
 }
 
+function telegramSendError(errorCode: number, description: string): GrammyError {
+  return new GrammyError(
+    "Call to 'sendMessage' failed",
+    { ok: false, error_code: errorCode, description },
+    "sendMessage",
+    { chat_id: 111 },
+  );
+}
+
+describe("resolveTelegramIngressNonRetryableFailure", () => {
+  it.each([
+    "Forbidden: bot was blocked by the user",
+    "Forbidden: bot was kicked from the group chat",
+    "Forbidden: user is deactivated",
+  ])("classifies permanent Telegram recipient rejection: %s", (description) => {
+    expect(resolveTelegramIngressNonRetryableFailure(telegramSendError(403, description))).toEqual({
+      reason: "recipient-unreachable",
+      message: expect.stringContaining(description),
+    });
+  });
+
+  it("classifies a permanent recipient error nested inside a dispatch failure", () => {
+    const cause = telegramSendError(403, "Forbidden: bot was blocked by the user");
+
+    expect(
+      resolveTelegramIngressNonRetryableFailure(new Error("pairing reply failed", { cause })),
+    ).toEqual({
+      reason: "recipient-unreachable",
+      message: expect.stringContaining("bot was blocked by the user"),
+    });
+  });
+
+  it("keeps recoverable Telegram permission failures eligible for retry", () => {
+    const error = telegramSendError(403, "Forbidden: not enough rights to send text messages");
+
+    expect(resolveTelegramIngressNonRetryableFailure(error)).toBeNull();
+  });
+
+  it("keeps flood-control failures eligible for retry", () => {
+    const error = telegramSendError(429, "Too Many Requests: retry after 30");
+
+    expect(resolveTelegramIngressNonRetryableFailure(error)).toBeNull();
+  });
+});
+
 describe("createTelegramIngressMonitor", () => {
+  it("dead-letters a real blocked-recipient Telegram API error without retrying it", async () => {
+    await withTempState(async (stateDir) => {
+      const queue = createChannelIngressQueueForTests<TelegramSpooledUpdatePayload>({
+        channelId: "telegram",
+        accountId: "default",
+        stateDir,
+      });
+      const eventId = "3".padStart(16, "0");
+      const payload = updatePayload(3);
+      const laneKey = telegramSpooledUpdateLaneKey(payload.update);
+      await queue.enqueue(eventId, payload, { laneKey });
+
+      const error = telegramSendError(403, "Forbidden: bot was blocked by the user");
+      const dispatch = vi.fn(async () => ({ kind: "failed-retryable" as const, error }));
+      const monitor = createTelegramIngressMonitor({ queue, cfg, accountId: "default", dispatch });
+
+      monitor.start();
+      await monitor.waitForIdle();
+
+      expect(dispatch).toHaveBeenCalledOnce();
+      expect(await queue.listFailed?.({ limit: "all" })).toEqual([
+        expect.objectContaining({
+          id: eventId,
+          reason: "recipient-unreachable",
+          message: expect.stringContaining("bot was blocked by the user"),
+        }),
+      ]);
+      expect(await queue.listPending({ limit: "all" })).toEqual([]);
+
+      await monitor.stop();
+    });
+  });
+
   it("propagates failed-retryable dispatch results as claim release (not tombstone)", async () => {
     await withTempState(async (stateDir) => {
       const queue = createChannelIngressQueueForTests<TelegramSpooledUpdatePayload>({

--- a/extensions/telegram/src/telegram-ingress-non-retryable.ts
+++ b/extensions/telegram/src/telegram-ingress-non-retryable.ts
@@ -9,9 +9,17 @@ import { TelegramIngressPayloadError } from "./telegram-ingress-spool.payload.js
 
 const MISSING_AGENT_HARNESS_ERROR_NAME = "MissingAgentHarnessError";
 const MISSING_AGENT_HARNESS_MESSAGE_RE = /Requested agent harness "[^"]+" is not registered\./u;
+// Only rejected recipients are permanent: other Telegram 403s can recover
+// after chat permissions change and must remain eligible for retry.
+const TELEGRAM_UNREACHABLE_RECIPIENT_RE =
+  /\b403\b[\s\S]*\b(?:bot was blocked by the user|bot was kicked|user is deactivated)\b/iu;
 
 type TelegramIngressNonRetryableFailure = {
-  reason: "invalid-event" | "missing-agent-harness" | "dispatch-dedupe-rollback-failed";
+  reason:
+    | "invalid-event"
+    | "missing-agent-harness"
+    | "dispatch-dedupe-rollback-failed"
+    | "recipient-unreachable";
   message: string;
 };
 
@@ -31,6 +39,9 @@ export function resolveTelegramIngressNonRetryableFailure(
       // A committed dispatch key that cannot be rolled back makes retry unsafe:
       // the next replay can be duplicate-suppressed and then deleted.
       return { reason: "dispatch-dedupe-rollback-failed", message };
+    }
+    if (TELEGRAM_UNREACHABLE_RECIPIENT_RE.test(message)) {
+      return { reason: "recipient-unreachable", message };
     }
     if (
       readErrorName(candidate) === MISSING_AGENT_HARNESS_ERROR_NAME ||


### PR DESCRIPTION
Closes #112893

## What Problem This Solves

Fixes an issue where Telegram retries a pairing or reply update for up to a day after the recipient has permanently blocked the bot, kicked it from a chat, or deactivated their account. That poisoned SQLite ingress row delays real messages behind it.

## Why This Change Was Made

Classify only the pinned grammY Telegram Bot API 403 recipient-rejection contract as non-retryable at the existing Telegram-owned ingress boundary. Preserve retry for recoverable permission 403 responses, flood control, transient failures, and ordinary dispatch. Follow wrapped error causes; make no changes to core retry policy, SQLite schema, configuration, or providers.

## User Impact

A permanently unreachable Telegram recipient dead-letters once and releases the message lane immediately. Real network, permissions, and rate-limit problems remain retryable.

## Evidence

- Personally inspected the exact installed grammY 1.45.1 ApiError and GrammyError constructor, including numeric status, API description and wrapped-cause behavior.
- Real Blacksmith Linux integration: 93/93 passing across Telegram polling/restart and actual SQLite ingress drain. Replays a genuine GrammyError through the queue, proves one dispatch, correct recipient-unreachable dead letter and no pending retry. Covers blocked, kicked and deactivated recipients, wrapped causes, recoverable 403, 429, existing restart and replay behavior.
- The same Blacksmith lease tbx_01kyp61t795gn7zxxgnw1zbshm passes the full changed gate, production and test typechecks, formatting, lint, plugin boundaries and all repository guards; exitCode=0.
- Fresh source-isolated xhigh autoreview clean, correctness 0.91, TruffleHog clean.