### PR TITLE
fix(ui): unify sidebar thread density

### DIFF
--- a/ui/src/e2e/codex-sessions.e2e.test.ts
+++ b/ui/src/e2e/codex-sessions.e2e.test.ts
@@ -262,7 +262,10 @@ suite("Codex native session catalog", () => {
   });
 
   it("groups sessions by host and hides empty offline nodes", async () => {
-    const page = await browser.newPage({ viewport: { height: 1100, width: 1440 } });
+    const page = await browser.newPage({
+      deviceScaleFactor: 2,
+      viewport: { height: 1100, width: 1440 },
+    });
     await page.addInitScript((key) => localStorage.removeItem(key), catalogGroupingStorageKey);
     await page.addInitScript(
       (key) => localStorage.removeItem(key),
@@ -271,6 +274,31 @@ suite("Codex native session catalog", () => {
     await installMockGateway(page, {
       featureMethods: ["chat.metadata", "chat.startup", "sessions.catalog.list"],
       methodResponses: {
+        "sessions.list": {
+          count: 1,
+          defaults: {
+            contextTokens: null,
+            model: "gpt-5.5",
+            modelProvider: "openai",
+          },
+          path: "",
+          sessions: [
+            {
+              contextTokens: null,
+              displayName: "Research thread",
+              hasActiveRun: false,
+              key: "agent:main:research",
+              kind: "direct",
+              label: "Research thread",
+              model: "gpt-5.5",
+              modelProvider: "openai",
+              status: "done",
+              totalTokens: 0,
+              updatedAt: Date.parse("2026-07-29T06:00:00.000Z"),
+            },
+          ],
+          ts: Date.parse("2026-07-29T06:00:00.000Z"),
+        },
         "sessions.catalog.list": {
           catalogs: [
             {
@@ -356,6 +384,10 @@ suite("Codex native session catalog", () => {
 
     try {
       await page.goto(`${server.baseUrl}chat`);
+      await page.evaluate(() => {
+        document.documentElement.setAttribute("data-theme", "openknot");
+        document.documentElement.setAttribute("data-theme-mode", "dark");
+      });
       await expandCodingSection(page);
       const section = page.locator('[data-session-section="catalog:codex"]');
       await section.waitFor({ state: "visible" });
@@ -375,6 +407,87 @@ suite("Codex native session catalog", () => {
       expect(
         await openclawProject.locator(".sidebar-session-catalog-project__count").textContent(),
       ).toBe("2");
+      const projectRows = section.locator(".sidebar-recent-session--catalog-project-child");
+      await expect.poll(() => projectRows.count()).toBe(3);
+      const threadRows = page.locator(
+        '[data-session-section="ungrouped"] .sidebar-recent-session, [data-session-section="catalog:codex"] .sidebar-recent-session--catalog-project-child',
+      );
+      await expect.poll(() => threadRows.count()).toBe(4);
+      const threadRowMetrics = await threadRows.evaluateAll((rows) =>
+        rows.map((row) => {
+          const link = row.querySelector(".sidebar-recent-session__link");
+          const name = row.querySelector(".sidebar-recent-session__name");
+          const rowStyle = getComputedStyle(row);
+          const linkStyle = link ? getComputedStyle(link) : null;
+          const nameStyle = name ? getComputedStyle(name) : null;
+          return {
+            height: row.getBoundingClientRect().height,
+            minHeight: rowStyle.minHeight,
+            nameFontSize: nameStyle?.fontSize ?? "",
+            paddingBottom: linkStyle?.paddingBottom ?? "",
+            paddingTop: linkStyle?.paddingTop ?? "",
+          };
+        }),
+      );
+      expect(threadRowMetrics).toEqual([
+        {
+          height: 30,
+          minHeight: "30px",
+          nameFontSize: "13px",
+          paddingBottom: "3px",
+          paddingTop: "3px",
+        },
+        {
+          height: 30,
+          minHeight: "30px",
+          nameFontSize: "13px",
+          paddingBottom: "3px",
+          paddingTop: "3px",
+        },
+        {
+          height: 30,
+          minHeight: "30px",
+          nameFontSize: "13px",
+          paddingBottom: "3px",
+          paddingTop: "3px",
+        },
+        {
+          height: 30,
+          minHeight: "30px",
+          nameFontSize: "13px",
+          paddingBottom: "3px",
+          paddingTop: "3px",
+        },
+      ]);
+      const projectLabelTone = await openclawProject
+        .locator(".sidebar-session-catalog-project__label")
+        .evaluate((label) => {
+          const probe = document.createElement("span");
+          document.body.append(probe);
+          const resolveColor = (value: string) => {
+            probe.style.color = value;
+            return getComputedStyle(probe).color;
+          };
+          const channels = (value: string) => {
+            const values =
+              value
+                .match(/[\d.]+/g)
+                ?.slice(0, 3)
+                .map(Number) ?? [];
+            return value.startsWith("color(srgb") ? values.map((channel) => channel * 255) : values;
+          };
+          const distance = (left: number[], right: number[]) =>
+            Math.hypot(...left.map((channel, index) => channel - (right[index] ?? 0)));
+          const labelColor = channels(getComputedStyle(label).color);
+          const textColor = channels(resolveColor("var(--text)"));
+          const mutedColor = channels(resolveColor("var(--muted)"));
+          probe.remove();
+          return {
+            distanceToMuted: distance(labelColor, mutedColor),
+            distanceToText: distance(labelColor, textColor),
+          };
+        });
+      expect(projectLabelTone.distanceToText).toBeLessThan(projectLabelTone.distanceToMuted);
       expect(
         await section
           .locator('[data-session-catalog-project="/Users/dev/other"]')

--- a/ui/src/styles/layout.css
+++ b/ui/src/styles/layout.css
@@ -1646,7 +1646,7 @@ html.openclaw-native-macos
   border: 0;
   border-radius: var(--radius-sm);
   background: transparent;
-  color: color-mix(in srgb, var(--muted) 90%, var(--text) 10%);
+  color: color-mix(in srgb, var(--muted) 35%, var(--text) 65%);
   font: inherit;
   cursor: pointer;
   text-align: left;
@@ -1688,19 +1688,14 @@ html.openclaw-native-macos
 .sidebar-session-catalog-project__count {
   width: 20px;
   flex: 0 0 20px;
-  color: var(--muted);
-  font-size: 9px;
+  color: color-mix(in srgb, var(--muted) 55%, var(--text) 45%);
+  font-size: 10px;
   font-variant-numeric: tabular-nums;
-  opacity: 0.58;
   text-align: center;
 }
 
 .sidebar-session-catalog-host__sessions .sidebar-recent-session__link {
   padding-left: 18px;
-}
-
-.sidebar-recent-session--catalog-project-child .sidebar-recent-session__name {
-  font-size: 10px;
 }
 
 .sidebar-session-pagination {
@@ -1764,13 +1759,13 @@ html.openclaw-native-macos
   opacity: 0.45;
 }
 
-/* Rows and row links are anchors (for middle-click/new-tab), but read as app
-   controls: override the UA link pointer back to the default arrow. */
+/* Every sidebar session source renders a thread. Keep density and text styling
+   here so gateway threads and native coding catalogs cannot drift apart. */
 .sidebar-recent-session {
   display: flex;
   align-items: center;
   min-width: 0;
-  min-height: 34px;
+  min-height: 30px;
   padding-right: 4px;
   border-radius: var(--radius-md);
   color: var(--muted);
@@ -1808,7 +1803,7 @@ html.openclaw-native-macos
   gap: 8px;
   flex: 1 1 auto;
   min-width: 0;
-  padding: 5px 4px 5px 9px;
+  padding: 3px 4px 3px 9px;
   color: inherit;
   cursor: default;
   text-decoration: none;
@@ -3318,22 +3313,6 @@ openclaw-tooltip.sidebar-hover-tooltip {
   background: var(--danger);
 }
 
-/* Groups zone: quiet compact rows. Coding zone: muted until expanded. */
-.sidebar-recent-sessions__group--zone-groups .sidebar-recent-session__link {
-  padding-top: 3px;
-  padding-bottom: 3px;
-}
-
-.sidebar-recent-sessions__group--zone-groups .sidebar-recent-session__name {
-  font-size: 12.5px;
-  color: var(--text);
-}
-
-.sidebar-recent-sessions__group--zone-coding .sidebar-recent-session__name,
-.sidebar-recent-sessions__group--zone-coding .sidebar-recent-session__subtitle {
-  color: var(--muted);
-}
-
 .sidebar-session-group-running {
   flex: none;
   margin-left: 4px;
@@ -4002,7 +3981,7 @@ html:not(.openclaw-native-macos):not(.openclaw-native-nav):not(.openclaw-native-
   text-overflow: ellipsis;
   white-space: nowrap;
   font-size: 11px;
-  color: var(--muted);
+  color: color-mix(in srgb, var(--muted) 55%, var(--text) 45%);
 }
 
 .sidebar-session-attention__icon {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where sidebar threads from Claude Code, Codex, and other coding-session sources could use different density and contrast from ordinary OpenClaw threads. Coding agents are threads, so their source should not change the row presentation.

## Why This Change Was Made

All top-level sidebar threads now use one shared visual contract: 30px minimum rows, 3px vertical link padding, 13px titles, and consistent subtitle contrast. Two-line status rows still grow naturally, while true child threads retain their smaller hierarchical type. Native catalog project headings and counts also receive stronger dark-theme contrast.

## User Impact

Threads remain compact and readable regardless of whether they come from OpenClaw, a work session, Claude Code, Codex, or another native coding catalog. Navigation, selection, menus, hierarchy, and provider behavior are unchanged.

## Evidence

### Before

![Before: coding-session rows with excess vertical spacing and low-contrast text](https://gist.githubusercontent.com/vincentkoc/e7454090bd11ddd4eb45806ed7711870/raw/bb42859aa581dfc4d02942f5d18f0b49c8dfb09e/before.png)

### After

![After: ordinary Threads and Coding rows using the same density and contrast](https://gist.githubusercontent.com/vincentkoc/e7454090bd11ddd4eb45806ed7711870/raw/9e7eb253374747398177b12e0800be2c420e12d9/after-unified.png)

- Native catalog E2E on Blacksmith Testbox: 7/7 passed
- Sidebar management E2E on Blacksmith Testbox: 8/8 passed
- Cross-surface fixture verifies ordinary Threads and coding-agent rows share 30px minimum height, 3px vertical padding, and 13px titles
- Targeted Stylelint, Oxfmt, and `git diff --check`: passed
- Final-head autoreview: clean, no accepted/actionable findings
