### PR TITLE
fix(ollama): keep active remote model streams from timing out

### DIFF
--- a/extensions/ollama/src/stream.test.ts
+++ b/extensions/ollama/src/stream.test.ts
@@ -1,4 +1,6 @@
 // Ollama tests cover stream plugin behavior.
+import { createServer } from "node:http";
+import type { AddressInfo } from "node:net";
 import { expectDefined } from "@openclaw/normalization-core";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -497,6 +499,155 @@ describe("createOllamaStreamFn thinking events", () => {
     await timerPromise;
 
     expect(yieldedBeforeDone).toBe(true);
+  });
+
+  it("refreshes the guarded-fetch idle timeout for each streamed Ollama response", async () => {
+    const chunks = [
+      {
+        model: "qwen3.5",
+        created_at: "2026-01-01T00:00:00Z",
+        message: { role: "assistant" as const, content: "Hello" },
+        done: false,
+      },
+      {
+        model: "qwen3.5",
+        created_at: "2026-01-01T00:00:01Z",
+        message: { role: "assistant" as const, content: " world" },
+        done: false,
+      },
+      makeOllamaResponse({ content: "" }),
+    ];
+    const refreshTimeout = vi.fn();
+    fetchWithSsrFGuardMock.mockResolvedValue({
+      response: new Response(makeNdjsonBody(chunks), { status: 200 }),
+      release: vi.fn(async () => undefined),
+      refreshTimeout,
+    });
+
+    const streamFn = createOllamaStreamFn("http://localhost:11434");
+    const stream = streamFn(
+      { api: "ollama", provider: "ollama", id: "qwen3.5", contextWindow: 65536 } as never,
+      { messages: [{ role: "user", content: "test" }] } as never,
+      {},
+    );
+
+    const events: Array<{ type: string }> = [];
+    for await (const event of stream as AsyncIterable<{ type: string }>) {
+      events.push(event);
+    }
+
+    expect(events.some((event) => event.type === "done")).toBe(true);
+    expect(refreshTimeout).toHaveBeenCalledTimes(chunks.length);
+  });
+
+  it("keeps a real slow native Ollama response alive while NDJSON chunks advance", async () => {
+    const server = createServer((_request, response) => {
+      response.writeHead(200, { "content-type": "application/x-ndjson" });
+
+      let chunkIndex = 0;
+      let nextChunk: ReturnType<typeof setTimeout> | undefined;
+      const sendChunk = () => {
+        if (chunkIndex === 6) {
+          response.end(`${JSON.stringify(makeOllamaResponse({ content: "" }))}\n`);
+          return;
+        }
+        response.write(
+          `${JSON.stringify({
+            model: "qwen3.5",
+            created_at: "2026-01-01T00:00:00Z",
+            message: { role: "assistant", content: String(chunkIndex) },
+            done: false,
+          })}\n`,
+        );
+        chunkIndex += 1;
+        nextChunk = setTimeout(sendChunk, 35);
+      };
+
+      response.once("close", () => {
+        if (nextChunk) {
+          clearTimeout(nextChunk);
+        }
+      });
+      sendChunk();
+    });
+
+    await new Promise<void>((resolve, reject) => {
+      server.once("error", reject);
+      server.listen(0, "127.0.0.1", resolve);
+    });
+
+    try {
+      const { fetchWithSsrFGuard } = await vi.importActual<
+        typeof import("openclaw/plugin-sdk/ssrf-runtime")
+      >("openclaw/plugin-sdk/ssrf-runtime");
+      fetchWithSsrFGuardMock.mockImplementation(fetchWithSsrFGuard);
+
+      const address = server.address() as AddressInfo;
+      const streamFn = createOllamaStreamFn(`http://127.0.0.1:${address.port}`);
+      const stream = streamFn(
+        { api: "ollama", provider: "ollama", id: "qwen3.5", contextWindow: 65536 } as never,
+        { messages: [{ role: "user", content: "test" }] } as never,
+        { requestTimeoutMs: 120 } as never,
+      );
+
+      const events: Array<{ type: string }> = [];
+      for await (const event of stream as AsyncIterable<{ type: string }>) {
+        events.push(event);
+      }
+
+      expect(events.some((event) => event.type === "error")).toBe(false);
+      expect(events.some((event) => event.type === "done")).toBe(true);
+    } finally {
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()));
+      });
+    }
+  });
+
+  it("still times out a real native Ollama stream that stops making progress", async () => {
+    const server = createServer((_request, response) => {
+      response.writeHead(200, { "content-type": "application/x-ndjson" });
+      response.write(
+        `${JSON.stringify({
+          model: "qwen3.5",
+          created_at: "2026-01-01T00:00:00Z",
+          message: { role: "assistant", content: "partial" },
+          done: false,
+        })}\n`,
+      );
+    });
+
+    await new Promise<void>((resolve, reject) => {
+      server.once("error", reject);
+      server.listen(0, "127.0.0.1", resolve);
+    });
+
+    try {
+      const { fetchWithSsrFGuard } = await vi.importActual<
+        typeof import("openclaw/plugin-sdk/ssrf-runtime")
+      >("openclaw/plugin-sdk/ssrf-runtime");
+      fetchWithSsrFGuardMock.mockImplementation(fetchWithSsrFGuard);
+
+      const address = server.address() as AddressInfo;
+      const streamFn = createOllamaStreamFn(`http://127.0.0.1:${address.port}`);
+      const stream = streamFn(
+        { api: "ollama", provider: "ollama", id: "qwen3.5", contextWindow: 65536 } as never,
+        { messages: [{ role: "user", content: "test" }] } as never,
+        { requestTimeoutMs: 120 } as never,
+      );
+
+      const events: Array<{ type: string }> = [];
+      for await (const event of stream as AsyncIterable<{ type: string }>) {
+        events.push(event);
+      }
+
+      expect(events.some((event) => event.type === "error")).toBe(true);
+      expect(events.some((event) => event.type === "done")).toBe(false);
+    } finally {
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()));
+      });
+    }
   });
 
   it("reports caller aborts during dense native stream processing as aborted", async () => {

--- a/extensions/ollama/src/stream.ts
+++ b/extensions/ollama/src/stream.ts
@@ -1215,7 +1215,7 @@ function createRawOllamaStreamFn(
           headers.Authorization = `Bearer ${options.apiKey}`;
         }
 
-        const { response, release } = await fetchWithSsrFGuard({
+        const { response, release, refreshTimeout } = await fetchWithSsrFGuard({
           url: chatUrl,
           init: {
             method: "POST",
@@ -1374,6 +1374,9 @@ function createRawOllamaStreamFn(
 
           for await (const chunk of parseNdjsonStream(reader)) {
             throwIfOllamaStreamAborted(options?.signal);
+            // Keep guarded timeouts tied to stream progress so slow remote
+            // inference is not aborted while Ollama is still emitting tokens.
+            refreshTimeout?.();
             const thinkingDelta = chunk.message?.thinking ?? chunk.message?.reasoning;
             if (thinkingDelta && shouldEmitThinking) {
               if (!streamStarted) {


### PR DESCRIPTION
Fixes #94251.

## What Problem This Solves

Fixes an issue where users streaming a slow remote Ollama model would lose an actively progressing response once the initial request timeout expired, even though valid tokens continued arriving.

## Why This Change Was Made

Honor the existing guarded fetch's idle-timeout contract whenever an actual Ollama NDJSON response makes progress. Preserve the existing SSRF guard, caller cancellation, dispatcher release, and timeout for a genuinely stalled stream.

This independently reviewed canonical fix builds on @henrybrewer00-dotcom's original diagnosis and patch in #96635. The official-repository commit explicitly retains Henry's original `Co-authored-by` credit.

## User Impact

Users can stream a slow remote Ollama model for longer than the configured idle timeout while valid responses continue arriving. A stream that actually stops responding still times out.

## Evidence

The regression uses a real local `node:http` TCP server and the actual native Ollama `application/x-ndjson` transport, not a simulated response: it sends token chunks every 35 ms with a 120 ms guarded idle timeout.

Before the fix:

- The guarded timeout's `refreshTimeout` callback was called zero times instead of three.
- The progressing real HTTP NDJSON stream failed before completion.

After the fix:

- The same progressing real HTTP NDJSON stream completes beyond the initial 120 ms deadline.
- A real HTTP NDJSON stream that sends one token and then stalls still expires as expected.
- Caller abort, dispatcher cleanup, and neighboring stream behavior remain covered.

Validation against the exact pushed commit:

- `node scripts/run-vitest.mjs extensions/ollama/src/stream.test.ts extensions/ollama/src/stream-runtime.test.ts`: **2 files, 142 tests passed**.
- `./node_modules/.bin/oxfmt --check extensions/ollama/src/stream.ts extensions/ollama/src/stream.test.ts`: passed.
- `git diff --check`: passed.
- `./.agents/skills/autoreview/scripts/autoreview --mode commit --commit HEAD --thinking xhigh`: **clean; no accepted or actionable findings**.
