### PR TITLE
refactor: deduplicate extension normalization primitives

### DIFF
--- a/extensions/browser/plugin-registration.ts
+++ b/extensions/browser/plugin-registration.ts
@@ -14,6 +14,7 @@ import type {
   OpenClawPluginToolContext,
   OpenClawPluginToolFactory,
 } from "openclaw/plugin-sdk/plugin-entry";
+import { isTruthyEnvValue } from "openclaw/plugin-sdk/runtime-env";
 import { isBrowserMachineOutput } from "./cli-output-mode.js";
 import {
   BROWSER_REQUEST_GATEWAY_METHOD,
@@ -33,10 +34,6 @@ const EAGER_BROWSER_CONTROL_SERVICE_ENV = "OPENCLAW_EAGER_BROWSER_CONTROL_SERVER
 const loadBrowserRegistrationRuntimeModule = createLazyRuntimeModule(
   () => import("./register.runtime.js"),
 );
-
-function isTruthyEnvValue(value: string | undefined): boolean {
-  return /^(?:1|true|yes|on)$/iu.test(value?.trim() ?? "");
-}
 
 function deriveChatTypeFromSessionKey(
   sessionKey: string | undefined,

--- a/extensions/browser/src/browser-tool-binding.ts
+++ b/extensions/browser/src/browser-tool-binding.ts
@@ -1,3 +1,5 @@
+import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
+
 type BrowserTabToolBinding = {
   kind: "tab";
   tabId: number;
@@ -9,10 +11,6 @@ type BrowserTabToolBinding = {
 
 type BindingResult = { ok: true; binding: BrowserTabToolBinding } | { ok: false; error: string };
 
-function nonEmptyString(value: unknown): string | undefined {
-  return typeof value === "string" && value.trim() ? value.trim() : undefined;
-}
-
 /** Validate the plugin-owned run binding before any browser route is resolved. */
 export function parseBrowserTabToolBinding(value: unknown): BindingResult {
   if (!value || typeof value !== "object" || Array.isArray(value)) {
@@ -20,9 +18,9 @@ export function parseBrowserTabToolBinding(value: unknown): BindingResult {
   }
   const record = value as Record<string, unknown>;
   const target = record.target === "host" || record.target === "node" ? record.target : undefined;
-  const node = nonEmptyString(record.node);
-  const profile = nonEmptyString(record.profile);
-  const targetId = nonEmptyString(record.targetId);
+  const node = normalizeOptionalString(record.node);
+  const profile = normalizeOptionalString(record.profile);
+  const targetId = normalizeOptionalString(record.targetId);
   if (record.kind !== "tab") {
     return { ok: false, error: 'browser tool binding kind must be "tab"' };
   }
@@ -65,7 +63,7 @@ const TAB_BOUND_ACTIONS = new Set([
 ]);
 
 function bindTargetId(record: Record<string, unknown>, targetId: string): Record<string, unknown> {
-  const requestedTargetId = nonEmptyString(record.targetId);
+  const requestedTargetId = normalizeOptionalString(record.targetId);
   if (requestedTargetId && requestedTargetId !== targetId) {
     throw new Error("browser action cannot override its run-bound tab target");
   }
@@ -84,13 +82,13 @@ export function applyBrowserTabToolBinding(
   input: Record<string, unknown>,
   binding: BrowserTabToolBinding,
 ): Record<string, unknown> {
-  const action = nonEmptyString(input.action);
+  const action = normalizeOptionalString(input.action);
   if (!action || !TAB_BOUND_ACTIONS.has(action)) {
     throw new Error(`browser action ${JSON.stringify(action)} is unavailable in a tab-bound run`);
   }
-  const requestedTarget = nonEmptyString(input.target);
-  const requestedNode = nonEmptyString(input.node);
-  const requestedProfile = nonEmptyString(input.profile);
+  const requestedTarget = normalizeOptionalString(input.target);
+  const requestedNode = normalizeOptionalString(input.node);
+  const requestedProfile = normalizeOptionalString(input.profile);
   if (requestedTarget && requestedTarget !== binding.target) {
     throw new Error("browser action cannot override its run-bound target");
   }

--- a/extensions/browser/src/plugin-service.ts
+++ b/extensions/browser/src/plugin-service.ts
@@ -1,6 +1,7 @@
 /**
  * Browser plugin service factory that lazily starts the control server.
  */
+import { isTruthyEnvValue } from "openclaw/plugin-sdk/runtime-env";
 import {
   startLazyPluginServiceModule,
   type LazyPluginServiceHandle,
@@ -10,10 +11,6 @@ import {
 type BrowserControlHandle = LazyPluginServiceHandle | null;
 const EAGER_BROWSER_CONTROL_SERVICE_ENV = "OPENCLAW_EAGER_BROWSER_CONTROL_SERVER";
 const UNSAFE_BROWSER_CONTROL_OVERRIDE_SPECIFIER = /^(?:data|http|https|node):/i;
-
-function isTruthyEnvValue(value: string | undefined): boolean {
-  return /^(?:1|true|yes|on)$/iu.test(value?.trim() ?? "");
-}
 
 function validateBrowserControlOverrideSpecifier(specifier: string): string {
   const trimmed = specifier.trim();

--- a/extensions/discord/src/doctor.ts
+++ b/extensions/discord/src/doctor.ts
@@ -2,7 +2,11 @@ import type { ChannelDoctorAdapter } from "openclaw/plugin-sdk/channel-contract"
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 // Discord plugin module implements doctor behavior.
 import { expectDefined } from "openclaw/plugin-sdk/expect-runtime";
-import { collectProviderDangerousNameMatchingScopes } from "openclaw/plugin-sdk/runtime-doctor";
+import {
+  asObjectRecord,
+  collectChannelAccountScopes,
+  collectProviderDangerousNameMatchingScopes,
+} from "openclaw/plugin-sdk/runtime-doctor";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { inspectDiscordAccount } from "./account-inspect.js";
 import { resolveDefaultDiscordAccountId } from "./accounts.js";
@@ -18,37 +22,8 @@ type DiscordIdListRef = {
   key: string;
 };
 
-function asObjectRecord(value: unknown): Record<string, unknown> | null {
-  return value && typeof value === "object" && !Array.isArray(value)
-    ? (value as Record<string, unknown>)
-    : null;
-}
-
 function sanitizeForLog(value: string): string {
   return value.replace(/\p{Cc}+/gu, " ").trim();
-}
-
-function collectDiscordAccountScopes(
-  cfg: OpenClawConfig,
-): Array<{ prefix: string; account: Record<string, unknown> }> {
-  const scopes: Array<{ prefix: string; account: Record<string, unknown> }> = [];
-  const discord = asObjectRecord(cfg.channels?.discord);
-  if (!discord) {
-    return scopes;
-  }
-
-  scopes.push({ prefix: "channels.discord", account: discord });
-  const accounts = asObjectRecord(discord.accounts);
-  if (!accounts) {
-    return scopes;
-  }
-  for (const key of Object.keys(accounts)) {
-    const account = asObjectRecord(accounts[key]);
-    if (account) {
-      scopes.push({ prefix: `channels.discord.accounts.${key}`, account });
-    }
-  }
-  return scopes;
 }
 
 function collectDiscordIdLists(
@@ -124,7 +99,7 @@ export function scanDiscordNumericIdEntries(cfg: OpenClawConfig): DiscordNumeric
     }
   };
 
-  for (const scope of collectDiscordAccountScopes(cfg)) {
+  for (const scope of collectChannelAccountScopes({ cfg, channelId: "discord" })) {
     for (const ref of collectDiscordIdLists(scope.prefix, scope.account)) {
       scanList(ref.pathLabel, ref.holder[ref.key]);
     }
@@ -216,7 +191,7 @@ export function maybeRepairDiscordNumericIds(
     }
   };
 
-  for (const scope of collectDiscordAccountScopes(next)) {
+  for (const scope of collectChannelAccountScopes({ cfg: next, channelId: "discord" })) {
     for (const ref of collectDiscordIdLists(scope.prefix, scope.account)) {
       repairList(ref.pathLabel, ref.holder, ref.key);
     }

--- a/extensions/discord/src/monitor/ingress.ts
+++ b/extensions/discord/src/monitor/ingress.ts
@@ -7,6 +7,7 @@ import {
   type ChannelIngressMonitorLifecycle,
 } from "openclaw/plugin-sdk/channel-outbound";
 import { danger, type RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
+import { normalizeNullableString as nonEmptyString } from "openclaw/plugin-sdk/string-coerce-runtime";
 import type { Client } from "../internal/discord.js";
 import { mapGatewayDispatchData } from "../internal/gateway-dispatch.js";
 import { getDiscordRuntime } from "../runtime.js";
@@ -47,10 +48,6 @@ class DiscordIngressPayloadError extends Error {
     super(message, options);
     this.name = "DiscordIngressPayloadError";
   }
-}
-
-function nonEmptyString(value: unknown): string | null {
-  return typeof value === "string" && value.trim() ? value.trim() : null;
 }
 
 function inspectDiscordMessage(rawMessage: unknown): { eventId: string; laneKey: string } {

--- a/extensions/elevenlabs/speech-provider.ts
+++ b/extensions/elevenlabs/speech-provider.ts
@@ -29,7 +29,10 @@ import {
   fetchWithSsrFGuard,
   ssrfPolicyFromHttpBaseUrlAllowedHostname,
 } from "openclaw/plugin-sdk/ssrf-runtime";
-import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/string-coerce-runtime";
+import {
+  normalizeLowercaseStringOrEmpty,
+  parseBooleanValue,
+} from "openclaw/plugin-sdk/string-coerce-runtime";
 import { resolveElevenLabsApiKeyWithProfileFallback } from "./config-api.js";
 import { isValidElevenLabsVoiceId, normalizeElevenLabsBaseUrl } from "./shared.js";
 import { elevenLabsTTS, elevenLabsTTSStream } from "./tts.js";
@@ -79,17 +82,6 @@ type ElevenLabsProviderConfig = {
     speed: number;
   };
 };
-
-function parseBooleanValue(value: string): boolean | undefined {
-  const normalized = normalizeLowercaseStringOrEmpty(value);
-  if (["true", "1", "yes", "on"].includes(normalized)) {
-    return true;
-  }
-  if (["false", "0", "no", "off"].includes(normalized)) {
-    return false;
-  }
-  return undefined;
-}
 
 function parseNumberValue(value: string): number | undefined {
   return parseStrictFiniteNumber(value);

--- a/extensions/feishu/src/client.ts
+++ b/extensions/feishu/src/client.ts
@@ -2,6 +2,7 @@
 import type { Agent } from "node:https";
 import { createRequire } from "node:module";
 import * as Lark from "@larksuiteoapi/node-sdk";
+import { isRecord } from "openclaw/plugin-sdk/channel-secret-basic-runtime";
 import {
   readPluginPackageVersion,
   resolveAmbientNodeProxyAgent,
@@ -84,10 +85,6 @@ type FeishuHttpInstanceLike = Pick<
   typeof feishuClientSdk.defaultHttpInstance,
   "request" | "get" | "post" | "put" | "patch" | "delete" | "head" | "options"
 >;
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
-}
 
 function readHeader(headers: unknown, name: string): string | undefined {
   if (!isRecord(headers)) {

--- a/extensions/feishu/src/feishu-ingress.ts
+++ b/extensions/feishu/src/feishu-ingress.ts
@@ -8,6 +8,7 @@ import {
   type ChannelIngressMonitorLifecycle,
   type ChannelIngressQueue,
 } from "openclaw/plugin-sdk/channel-outbound";
+import { isRecord } from "openclaw/plugin-sdk/channel-secret-basic-runtime";
 import { collectErrorGraphCandidates, formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import type { ChannelReplayClaimHandle } from "openclaw/plugin-sdk/persistent-dedupe";
 import { getFeishuRuntime } from "./runtime.js";
@@ -76,10 +77,6 @@ export class FeishuIngressPermanentError extends Error {
     super(message, options);
     this.name = "FeishuIngressPermanentError";
   }
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
 function readString(value: unknown): string | null {

--- a/extensions/googlechat/src/monitor-event.ts
+++ b/extensions/googlechat/src/monitor-event.ts
@@ -1,4 +1,5 @@
 // Googlechat plugin module parses standard and Workspace Add-on webhook envelopes.
+import { isRecord } from "openclaw/plugin-sdk/channel-secret-basic-runtime";
 import type {
   GoogleChatAction,
   GoogleChatActionParameter,
@@ -19,10 +20,6 @@ type ParsedGoogleChatInboundPayload = {
   event: GoogleChatEvent;
   addOnBearerToken: string;
 };
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
-}
 
 function recordParamsToActionParameters(
   params?: Record<string, string>,

--- a/extensions/googlechat/src/monitor-ingress.ts
+++ b/extensions/googlechat/src/monitor-ingress.ts
@@ -5,6 +5,7 @@ import {
   type ChannelIngressMonitorDeliveryResult,
   type ChannelIngressMonitorLifecycle,
 } from "openclaw/plugin-sdk/channel-outbound";
+import { isRecord } from "openclaw/plugin-sdk/channel-secret-basic-runtime";
 import { collectErrorGraphCandidates, formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import { GoogleChatEventPayloadError, parseGoogleChatInboundPayload } from "./monitor-event.js";
 import { getGoogleChatRuntime } from "./runtime.js";
@@ -47,10 +48,6 @@ class GoogleChatIngressPermanentError extends Error {
     super(message, options);
     this.name = "GoogleChatIngressPermanentError";
   }
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
 function requiredString(value: unknown, field: string): string {

--- a/extensions/googlechat/src/monitor-webhook.ts
+++ b/extensions/googlechat/src/monitor-webhook.ts
@@ -1,5 +1,6 @@
 // Googlechat plugin module implements monitor webhook behavior.
 import type { IncomingMessage, ServerResponse } from "node:http";
+import { isRecord } from "openclaw/plugin-sdk/channel-secret-basic-runtime";
 import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/string-coerce-runtime";
 import {
   normalizeWebhookPath,
@@ -40,10 +41,6 @@ type ParsedGoogleChatInboundSuccess = {
   raw: Record<string, unknown>;
   addOnBearerToken: string;
 };
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
-}
 
 function parseGoogleChatInboundPayloadOrReject(
   raw: unknown,

--- a/extensions/imessage/src/monitor/conversation-repair.ts
+++ b/extensions/imessage/src/monitor/conversation-repair.ts
@@ -1,4 +1,5 @@
 // Imessage plugin module implements conversation repair behavior.
+import { hasNonEmptyString as isNonEmptyString } from "openclaw/plugin-sdk/string-coerce-runtime";
 import type { IMessageRpcClient } from "../client.js";
 import type { IMessagePayload } from "./types.js";
 
@@ -39,10 +40,6 @@ type AuthoritativeRecoveryProjection = {
   destination_caller_id?: string;
   is_from_me: boolean;
 };
-
-function isNonEmptyString(value: unknown): value is string {
-  return typeof value === "string" && value.trim() !== "";
-}
 
 function hasPositiveChatId(value: unknown): value is number {
   return typeof value === "number" && Number.isFinite(value) && value > 0;

--- a/extensions/imessage/src/monitor/ingress.ts
+++ b/extensions/imessage/src/monitor/ingress.ts
@@ -5,6 +5,7 @@ import {
   type ChannelIngressMonitorDeliveryResult,
   type ChannelIngressMonitorLifecycle,
 } from "openclaw/plugin-sdk/channel-outbound";
+import { isRecord } from "openclaw/plugin-sdk/channel-secret-basic-runtime";
 import { collectErrorGraphCandidates, formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import { KeyedAsyncQueue } from "openclaw/plugin-sdk/keyed-async-queue";
 import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
@@ -61,10 +62,6 @@ class IMessageIngressPayloadError extends Error {
     super(message, options);
     this.name = "IMessageIngressPayloadError";
   }
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
 function rawMessageRecord(raw: unknown): Record<string, unknown> | null {

--- a/extensions/irc/src/accounts.ts
+++ b/extensions/irc/src/accounts.ts
@@ -4,20 +4,16 @@ import { createAccountListHelpers } from "openclaw/plugin-sdk/account-helpers";
 import { DEFAULT_ACCOUNT_ID, normalizeAccountId } from "openclaw/plugin-sdk/account-id";
 import { parseOptionalDelimitedEntries } from "openclaw/plugin-sdk/channel-core";
 import { parseStrictPositiveInteger } from "openclaw/plugin-sdk/number-runtime";
+import { isTruthyEnvValue } from "openclaw/plugin-sdk/runtime-env";
 import { tryReadSecretFileSync } from "openclaw/plugin-sdk/secret-file-runtime";
 import { normalizeResolvedSecretInputString } from "openclaw/plugin-sdk/secret-input";
-import {
-  normalizeLowercaseStringOrEmpty,
-  normalizeOptionalString,
-} from "openclaw/plugin-sdk/string-coerce-runtime";
+import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
 import type { CoreConfig, IrcAccountConfig, IrcNickServConfig } from "./types.js";
 
 type CredentialUnavailableDiagnostic = Extract<
   ReturnType<typeof tryReadSecretFileSync>,
   { status: "configured_unavailable" }
 >["diagnostic"];
-
-const TRUTHY_ENV = new Set(["true", "1", "yes", "on"]);
 
 export type ResolvedIrcAccount = {
   accountId: string;
@@ -36,13 +32,6 @@ export type ResolvedIrcAccount = {
   credentialDiagnostics?: CredentialUnavailableDiagnostic[];
   config: IrcAccountConfig;
 };
-
-function parseTruthy(value?: string): boolean {
-  if (!value) {
-    return false;
-  }
-  return TRUTHY_ENV.has(normalizeLowercaseStringOrEmpty(value));
-}
 
 function parseIntEnv(value?: string): number | undefined {
   if (!value?.trim()) {
@@ -167,7 +156,7 @@ export function resolveIrcAccount(params: {
       typeof merged.tls === "boolean"
         ? merged.tls
         : accountId === DEFAULT_ACCOUNT_ID && process.env.IRC_TLS
-          ? parseTruthy(process.env.IRC_TLS)
+          ? isTruthyEnvValue(process.env.IRC_TLS)
           : true;
 
     const envPort =

--- a/extensions/line/src/actions.ts
+++ b/extensions/line/src/actions.ts
@@ -1,5 +1,6 @@
 // Line plugin module implements actions behavior.
 import type { messagingApi } from "@line/bot-sdk";
+import { isRecord } from "openclaw/plugin-sdk/channel-secret-basic-runtime";
 import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 
 export type Action = messagingApi.Action;
@@ -66,10 +67,6 @@ const actionTypes = new Set([
   "richmenuswitch",
   "uri",
 ]);
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
-}
 
 function isLineAction(value: unknown): value is Action {
   return isRecord(value) && typeof value.type === "string" && actionTypes.has(value.type);

--- a/extensions/line/src/webhook-spool.ts
+++ b/extensions/line/src/webhook-spool.ts
@@ -8,6 +8,7 @@ import {
   type ChannelIngressQueue,
 } from "openclaw/plugin-sdk/channel-outbound";
 import { danger, type RuntimeEnv, warn } from "openclaw/plugin-sdk/runtime-env";
+import { normalizeNullableString as nonEmptyString } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { runDetachedWebhookWork } from "openclaw/plugin-sdk/webhook-request-guards";
 import { getLineRuntime } from "./runtime.js";
 
@@ -71,10 +72,6 @@ type LineWebhookSpool = {
   start: () => void;
   stop: () => Promise<void>;
 };
-
-function nonEmptyString(value: unknown): string | null {
-  return typeof value === "string" && value.trim() ? value.trim() : null;
-}
 
 /** Message ids preserve the shipped replay-guard keyspace; other events use LINE's delivery id. */
 function eventIdFor(event: unknown): string {

--- a/extensions/linux-canvas/src/ipc-client.ts
+++ b/extensions/linux-canvas/src/ipc-client.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from "node:crypto";
 import net from "node:net";
+import { isRecord } from "openclaw/plugin-sdk/channel-secret-basic-runtime";
 
 // A2UI may stop a load, wait up to 6 seconds for the renderer, then evaluate.
 // Keep the outer IPC deadline above the app's complete 22-second phase budget.
@@ -40,10 +41,6 @@ function parseFrame(line: string): unknown {
   } catch {
     return undefined;
   }
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
 }
 
 export class LinuxCanvasIpcClient implements LinuxCanvasIpcTransport {

--- a/extensions/lmstudio/src/setup.ts
+++ b/extensions/lmstudio/src/setup.ts
@@ -26,6 +26,7 @@ import {
   type ProviderPrepareDynamicModelContext,
   type ProviderRuntimeModel,
 } from "openclaw/plugin-sdk/provider-setup";
+import { isTruthyEnvValue } from "openclaw/plugin-sdk/runtime-env";
 import { WizardCancelledError, type WizardPrompter } from "openclaw/plugin-sdk/setup";
 import { normalizeStringEntries } from "openclaw/plugin-sdk/string-coerce-runtime";
 import {
@@ -75,10 +76,6 @@ type LmstudioSetupDiscovery = {
   defaultModel: string | undefined;
   defaultModelId: string | undefined;
 };
-
-function isTruthyEnvValue(value: string | undefined): boolean {
-  return ["1", "true", "yes", "on"].includes(value?.trim().toLowerCase() ?? "");
-}
 
 function resolveLmstudioSetupDefaultBaseUrl(env: NodeJS.ProcessEnv = process.env): string {
   return isTruthyEnvValue(env.OPENCLAW_DOCKER_SETUP)

--- a/extensions/mattermost/src/mattermost/monitor-ingress.ts
+++ b/extensions/mattermost/src/mattermost/monitor-ingress.ts
@@ -4,6 +4,7 @@ import {
   type ChannelIngressQueue,
   type ChannelIngressMonitorDeliveryResult,
 } from "openclaw/plugin-sdk/channel-outbound";
+import { isRecord } from "openclaw/plugin-sdk/channel-secret-basic-runtime";
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
 import { getMattermostRuntime } from "../runtime.js";
@@ -53,10 +54,6 @@ class MattermostIngressPermanentError extends Error {
     super(message, options);
     this.name = "MattermostIngressPermanentError";
   }
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
 function parseRawObject(raw: string, subject: string): Record<string, unknown> {

--- a/extensions/migrate-hermes/config-mcp.ts
+++ b/extensions/migrate-hermes/config-mcp.ts
@@ -1,6 +1,7 @@
 // Hermes MCP config mapping and manual follow-up planning.
 import { createMigrationManualItem } from "openclaw/plugin-sdk/migration";
 import type { MigrationItem } from "openclaw/plugin-sdk/plugin-entry";
+import { parseBooleanValue } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { mcpValueHasEnvReferences, resolveMcpEnvReferences } from "./config-env.js";
 import { readPositiveNumber } from "./config-provider-contract.js";
 import { isRecord, readString, sanitizeName } from "./helpers.js";
@@ -10,20 +11,6 @@ const MCP_PROMPT_UTILITY_TOOLS = ["prompts_list", "prompts_get"] as const;
 
 function readBoolean(value: unknown): boolean | undefined {
   return typeof value === "boolean" ? value : undefined;
-}
-
-function readBooleanish(value: unknown): boolean | undefined {
-  if (typeof value === "boolean") {
-    return value;
-  }
-  if (typeof value !== "string") {
-    return undefined;
-  }
-  const normalized = value.trim().toLowerCase();
-  if (["true", "1", "yes", "on"].includes(normalized)) {
-    return true;
-  }
-  return ["false", "0", "no", "off"].includes(normalized) ? false : undefined;
 }
 
 function readPositiveNumeric(value: unknown): number | undefined {
@@ -68,8 +55,8 @@ function mapHermesToolFilter(value: Record<string, unknown>): Record<string, unk
   }
   const include = readToolFilterList(tools.include);
   const exclude = readToolFilterList(tools.exclude);
-  const resourcesEnabled = readBooleanish(tools.resources) !== false;
-  const promptsEnabled = readBooleanish(tools.prompts) !== false;
+  const resourcesEnabled = parseBooleanValue(tools.resources) !== false;
+  const promptsEnabled = parseBooleanValue(tools.prompts) !== false;
 
   // Hermes tests set truthiness here: `include: []` means no whitelist, so native tools remain.
   if (include && include.length > 0) {
@@ -344,8 +331,8 @@ export function mcpManualItems(params: {
     ) ||
       (tools.include !== undefined && !readToolFilterList(tools.include)) ||
       (tools.exclude !== undefined && !readToolFilterList(tools.exclude)) ||
-      (tools.resources !== undefined && readBooleanish(tools.resources) === undefined) ||
-      (tools.prompts !== undefined && readBooleanish(tools.prompts) === undefined))
+      (tools.resources !== undefined && parseBooleanValue(tools.resources) === undefined) ||
+      (tools.prompts !== undefined && parseBooleanValue(tools.prompts) === undefined))
   ) {
     add(
       "tool-policy",

--- a/extensions/msteams/src/msteams-ingress.ts
+++ b/extensions/msteams/src/msteams-ingress.ts
@@ -6,6 +6,7 @@ import {
   type ChannelIngressMonitorLifecycle,
 } from "openclaw/plugin-sdk/channel-outbound";
 import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
+import { normalizeNullableString as nonEmptyString } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { classifyMSTeamsSendError } from "./errors.js";
 import { MSTEAMS_REQUEST_TIMEOUT_MS } from "./request-timeout.js";
 import { getMSTeamsRuntime } from "./runtime.js";
@@ -57,10 +58,6 @@ class MSTeamsIngressPayloadError extends Error {
     super(message, options);
     this.name = "MSTeamsIngressPayloadError";
   }
-}
-
-function nonEmptyString(value: unknown): string | null {
-  return typeof value === "string" && value.trim() ? value.trim() : null;
 }
 
 function isDispatchableActivity(activity: MSTeamsIngressActivity): boolean {

--- a/extensions/msteams/src/outbound.ts
+++ b/extensions/msteams/src/outbound.ts
@@ -12,6 +12,7 @@ import {
   resolveTextChunksWithFallback,
   sendPayloadMediaSequence,
 } from "openclaw/plugin-sdk/reply-payload";
+import { asOptionalRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
 import {
   chunkTextForOutbound,
   normalizeStringEntries,
@@ -20,12 +21,6 @@ import {
 import { createMSTeamsPollStoreState } from "./polls.js";
 import { buildMSTeamsPresentationCard, MSTEAMS_PRESENTATION_CAPABILITIES } from "./presentation.js";
 import { sendAdaptiveCardMSTeams, sendMessageMSTeams, sendPollMSTeams } from "./send.js";
-
-function asObjectRecord(value: unknown): Record<string, unknown> | undefined {
-  return value && typeof value === "object" && !Array.isArray(value)
-    ? (value as Record<string, unknown>)
-    : undefined;
-}
 
 const MSTEAMS_TEXT_CHUNK_LIMIT = 4000;
 
@@ -94,7 +89,7 @@ export const msteamsOutbound: ChannelOutboundAdapter = {
       presentation,
       text: payload.text,
     });
-    const msteamsData = asObjectRecord(payload.channelData?.msteams) ?? {};
+    const msteamsData = asOptionalRecord(payload.channelData?.msteams) ?? {};
     return {
       ...payload,
       channelData: {
@@ -117,7 +112,7 @@ export const msteamsOutbound: ChannelOutboundAdapter = {
     deps,
     onDeliveryResult,
   }) => {
-    const msteamsData = asObjectRecord(payload.channelData?.msteams);
+    const msteamsData = asOptionalRecord(payload.channelData?.msteams);
     const presentationCard = msteamsData?.presentationCard;
     if (
       presentationCard &&

--- a/extensions/nextcloud-talk/src/accounts.ts
+++ b/extensions/nextcloud-talk/src/accounts.ts
@@ -6,22 +6,15 @@ import {
   resolveAccountWithDefaultFallback,
 } from "openclaw/plugin-sdk/account-core";
 import { createAccountListHelpers } from "openclaw/plugin-sdk/account-helpers";
+import { isTruthyEnvValue } from "openclaw/plugin-sdk/runtime-env";
 import { tryReadSecretFileSync } from "openclaw/plugin-sdk/secret-file-runtime";
-import {
-  normalizeLowercaseStringOrEmpty,
-  normalizeOptionalString,
-} from "openclaw/plugin-sdk/string-coerce-runtime";
+import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
 import {
   resolveNextcloudTalkApiCredentialsResult,
   type NextcloudTalkCredentialUnavailableDiagnostic,
 } from "./api-credentials.js";
 import { normalizeResolvedSecretInputString } from "./secret-input.js";
 import type { CoreConfig, NextcloudTalkAccountConfig } from "./types.js";
-
-function isTruthyEnvValue(value?: string): boolean {
-  const normalized = normalizeLowercaseStringOrEmpty(value);
-  return normalized === "true" || normalized === "1" || normalized === "yes" || normalized === "on";
-}
 
 const debugAccounts = (...args: unknown[]) => {
   if (isTruthyEnvValue(process.env.OPENCLAW_DEBUG_NEXTCLOUD_TALK_ACCOUNTS)) {

--- a/extensions/nextcloud-talk/src/webhook-spool-state.ts
+++ b/extensions/nextcloud-talk/src/webhook-spool-state.ts
@@ -1,5 +1,6 @@
 // Nextcloud Talk plugin module owns webhook ingress identity and legacy-state migration.
 import type { ChannelIngressQueue } from "openclaw/plugin-sdk/channel-outbound";
+import { isRecord } from "openclaw/plugin-sdk/channel-secret-basic-runtime";
 
 export const NEXTCLOUD_TALK_INGRESS_PAYLOAD_VERSION = 1;
 
@@ -24,10 +25,6 @@ export class NextcloudTalkWebhookPayloadError extends Error {
     super(message, options);
     this.name = "NextcloudTalkWebhookPayloadError";
   }
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
 export function parseRawObject(rawEvent: string): Record<string, unknown> {

--- a/extensions/onepassword/src/config.ts
+++ b/extensions/onepassword/src/config.ts
@@ -1,4 +1,5 @@
 import path from "node:path";
+import { isRecord } from "openclaw/plugin-sdk/channel-secret-basic-runtime";
 
 export const SLUG_PATTERN = /^[a-z0-9][a-z0-9-]{0,63}$/;
 export const MAX_REGISTERED_ITEMS = 32;
@@ -23,10 +24,6 @@ export type OnePasswordConfig = {
   opTimeoutMs: number;
   items: Record<string, OnePasswordItemConfig>;
 };
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
-}
 
 function requiredString(record: Record<string, unknown>, key: string): string {
   const value = record[key];

--- a/extensions/onepassword/src/secret-ref-cli.ts
+++ b/extensions/onepassword/src/secret-ref-cli.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from "node:crypto";
 import path from "node:path";
 import { createInterface } from "node:readline/promises";
+import { isRecord } from "openclaw/plugin-sdk/channel-secret-basic-runtime";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/plugin-entry";
 import {
   DEFAULT_SECRET_FILE_MAX_BYTES,
@@ -107,10 +108,6 @@ function writeLine(message = ""): void {
 
 function writeJson(value: unknown): void {
   process.stdout.write(`${JSON.stringify(value, null, 2)}\n`);
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
 }
 
 function normalizeOptionalString(value: unknown): string | undefined {

--- a/extensions/onepassword/src/tool.ts
+++ b/extensions/onepassword/src/tool.ts
@@ -1,3 +1,4 @@
+import { isRecord } from "openclaw/plugin-sdk/channel-secret-basic-runtime";
 import type { AnyAgentTool, OpenClawPluginToolContext } from "openclaw/plugin-sdk/plugin-entry";
 import { jsonResult } from "openclaw/plugin-sdk/tool-results";
 import type {
@@ -45,10 +46,6 @@ function errorResult(error: unknown) {
         : "OP_ERROR";
   const message = error instanceof Error ? error.message : "1Password request failed";
   return jsonResult({ ok: false, error: { code, message } });
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
 }
 
 export function redactPersistedOnePasswordResult(

--- a/extensions/policy/src/doctor/automatic-repairs.ts
+++ b/extensions/policy/src/doctor/automatic-repairs.ts
@@ -1,4 +1,5 @@
 // Policy automatic repairs apply only deterministic narrowing config changes.
+import { isRecord } from "openclaw/plugin-sdk/channel-secret-basic-runtime";
 import type {
   HealthFinding,
   HealthRepairContext,
@@ -445,10 +446,6 @@ function ensureRecord(parent: ConfigRecord, key: string): ConfigRecord {
   const next: ConfigRecord = {};
   parent[key] = next;
   return next;
-}
-
-function isRecord(value: unknown): value is ConfigRecord {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
 function uniqueStrings(values: readonly string[]): readonly string[] {

--- a/extensions/policy/src/doctor/routing-shapes.ts
+++ b/extensions/policy/src/doctor/routing-shapes.ts
@@ -1,5 +1,8 @@
 import type { HealthFinding } from "openclaw/plugin-sdk/health";
-import { isRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
+import {
+  hasNonEmptyString as nonEmptyString,
+  isRecord,
+} from "openclaw/plugin-sdk/string-coerce-runtime";
 import { ROUTING_MATCH_KINDS } from "../policy-routing.js";
 import { policyShapeFinding, unsupportedPolicyKey } from "./shape-helpers.js";
 import { ocPathSegment } from "./utils.js";
@@ -223,10 +226,6 @@ function expectShapeFinding(
     }
   }
   return undefined;
-}
-
-function nonEmptyString(value: unknown): value is string {
-  return typeof value === "string" && value.trim() !== "";
 }
 
 function invalid(ctx: ShapeContext, target: string, message: string): HealthFinding {

--- a/extensions/policy/src/doctor/scopes/gateway.ts
+++ b/extensions/policy/src/doctor/scopes/gateway.ts
@@ -1,4 +1,5 @@
 // Policy doctor checks and findings for gateway exposure policy.
+import { isRecord } from "openclaw/plugin-sdk/channel-secret-basic-runtime";
 import type { HealthCheck, HealthFinding } from "openclaw/plugin-sdk/health";
 import type { PolicyEvidence } from "../../policy-state.js";
 import { repairPolicyAutomaticNarrower } from "../automatic-repairs.js";
@@ -421,8 +422,4 @@ function hasValidOptionalStringList(policy: unknown, path: readonly string[]): b
     (Array.isArray(current) &&
       current.every((entry) => typeof entry === "string" && entry.trim() !== ""))
   );
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
 }

--- a/extensions/policy/src/doctor/strictness.ts
+++ b/extensions/policy/src/doctor/strictness.ts
@@ -2,6 +2,7 @@
 import { normalizeProviderId } from "openclaw/plugin-sdk/provider-model-shared";
 import { normalizeAccountId, normalizeAgentId } from "openclaw/plugin-sdk/routing";
 import {
+  hasNonEmptyString as nonEmptyString,
   isRecord,
   normalizeLowercaseStringOrEmpty,
 } from "openclaw/plugin-sdk/string-coerce-runtime";
@@ -169,10 +170,6 @@ function canonicalRoutingPeer(value: unknown): object | undefined | null {
 
 function normalizeRoutingId(value: unknown): string | undefined {
   return typeof value === "string" ? value.trim() : undefined;
-}
-
-function nonEmptyString(value: unknown): value is string {
-  return typeof value === "string" && value.trim() !== "";
 }
 
 function isPolicyOrderedStringAtLeastAsStrict(

--- a/extensions/qa-lab/src/code-mode-model-matrix.test.ts
+++ b/extensions/qa-lab/src/code-mode-model-matrix.test.ts
@@ -13,7 +13,6 @@ import {
   runCodeModeModelMatrix,
   type CodeModeMatrixCellResult,
 } from "../../../scripts/code-mode-model-matrix.ts";
-import { validateQaEvidenceSummaryJson } from "../api.ts";
 
 describe("Code Mode model matrix options", () => {
   it("defaults to the complete bounded matrix", () => {

--- a/extensions/qa-lab/src/code-mode-model-matrix.test.ts
+++ b/extensions/qa-lab/src/code-mode-model-matrix.test.ts
@@ -12,8 +12,9 @@ import {
   resolveCodeModeMatrixOutputDir,
   runCodeModeModelMatrix,
   type CodeModeMatrixCellResult,
-} from "../../scripts/code-mode-model-matrix.ts";
-import type { AgentExecEnvelope } from "../../src/commands/agent-exec.ts";
+} from "../../../scripts/code-mode-model-matrix.ts";
+import type { AgentExecEnvelope } from "../../../src/commands/agent-exec.ts";
+import { validateQaEvidenceSummaryJson } from "../api.ts";
 
 describe("Code Mode model matrix options", () => {
   it("defaults to the complete bounded matrix", () => {

--- a/extensions/qa-lab/src/code-mode-model-matrix.test.ts
+++ b/extensions/qa-lab/src/code-mode-model-matrix.test.ts
@@ -13,7 +13,6 @@ import {
   runCodeModeModelMatrix,
   type CodeModeMatrixCellResult,
 } from "../../../scripts/code-mode-model-matrix.ts";
-import type { AgentExecEnvelope } from "../../../src/commands/agent-exec.ts";
 import { validateQaEvidenceSummaryJson } from "../api.ts";
 
 describe("Code Mode model matrix options", () => {
@@ -136,7 +135,7 @@ describe("Code Mode model matrix classification", () => {
     model: "qwen3.5:9b",
     provider: "ollama",
     sessionId: "session",
-  } satisfies AgentExecEnvelope;
+  } satisfies Parameters<typeof classifyCodeModeMatrixCell>[0]["envelope"];
 
   it("requires engagement, tool execution, effect, and exact final text", () => {
     expect(

--- a/extensions/qa-lab/src/code-mode-model-matrix.test.ts
+++ b/extensions/qa-lab/src/code-mode-model-matrix.test.ts
@@ -11,6 +11,7 @@ import {
   reserveCodeModeMatrixOutputDir,
   resolveCodeModeMatrixOutputDir,
   runCodeModeModelMatrix,
+  validateQaEvidenceSummaryJson,
   type CodeModeMatrixCellResult,
 } from "../../../scripts/code-mode-model-matrix.ts";
 
@@ -609,9 +610,9 @@ describe("Code Mode model matrix artifacts", () => {
         failureCategory: "harness_error",
         error: { kind: "harness_error", message: "fixture exploded" },
       });
-      const evidence = JSON.parse(
-        await fs.readFile(path.join(repoRoot, "artifacts", "qa-evidence.json"), "utf8"),
-      ) as { entries: unknown[] };
+      const evidence = validateQaEvidenceSummaryJson(
+        JSON.parse(await fs.readFile(path.join(repoRoot, "artifacts", "qa-evidence.json"), "utf8")),
+      );
       expect(evidence.entries).toHaveLength(2);
       expect(evidence.entries[0]).toMatchObject({
         test: {

--- a/extensions/qa-lab/src/gateway-process-boundary.ts
+++ b/extensions/qa-lab/src/gateway-process-boundary.ts
@@ -4,6 +4,7 @@ import { constants as fsConstants } from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { setTimeout as sleep } from "node:timers/promises";
+import { isRecord } from "openclaw/plugin-sdk/channel-secret-basic-runtime";
 import { replaceFileAtomic } from "openclaw/plugin-sdk/security-runtime";
 
 const PROCESS_BOUNDARY_VERSION = 1;
@@ -116,10 +117,6 @@ type QaGatewayProcessBoundaryEvidenceLaunch = {
   quiescedAt?: string;
   terminalState?: "failed-before-ready" | "ready-exited";
 };
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
-}
 
 function sha256(value: Buffer | string) {
   return createHash("sha256").update(value).digest("hex");

--- a/extensions/qqbot/src/engine/gateway/ingress-envelope.ts
+++ b/extensions/qqbot/src/engine/gateway/ingress-envelope.ts
@@ -1,4 +1,5 @@
 // QQBot plugin module validates raw gateway envelopes for durable ingress.
+import { normalizeNullableString as nonEmptyString } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { GatewayEvent, GatewayOp } from "./constants.js";
 import type { WSPayload } from "./types.js";
 
@@ -23,10 +24,6 @@ type QQBotIngressEnvelopeFacts = {
   laneKey: string;
   payload: WSPayload;
 };
-
-function nonEmptyString(value: unknown): string | null {
-  return typeof value === "string" && value.trim() ? value.trim() : null;
-}
 
 function record(value: unknown, field: string): Record<string, unknown> {
   if (!value || typeof value !== "object" || Array.isArray(value)) {

--- a/extensions/reef/protocol/guard-adapters.ts
+++ b/extensions/reef/protocol/guard-adapters.ts
@@ -1,3 +1,4 @@
+import { isRecord } from "openclaw/plugin-sdk/channel-secret-basic-runtime";
 import { readProviderTextResponse } from "openclaw/plugin-sdk/provider-http";
 import {
   admitGuardAdapter,
@@ -199,8 +200,4 @@ function hasDuplicateKeys(text: string): boolean {
     keys.add(key);
   }
   return false;
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return value !== null && typeof value === "object" && !Array.isArray(value);
 }

--- a/extensions/signal/doctor-contract-api.ts
+++ b/extensions/signal/doctor-contract-api.ts
@@ -3,6 +3,7 @@ import type {
   ChannelDoctorConfigMutation,
   ChannelDoctorLegacyConfigRule,
 } from "openclaw/plugin-sdk/channel-contract";
+import { isRecord } from "openclaw/plugin-sdk/channel-secret-basic-runtime";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { defineChannelAliasMigration } from "openclaw/plugin-sdk/runtime-doctor";
 import { migrateLegacySignalTransportConfigSync } from "./src/config-compat.js";
@@ -18,10 +19,6 @@ const RETIRED_SIGNAL_ACCOUNT_TRANSPORT_FIELDS = [
   "receiveMode",
   "ignoreStories",
 ] as const;
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
-}
 
 function hasRetiredSignalAccountTransportFields(value: unknown): boolean {
   return (

--- a/extensions/signal/src/config-compat.ts
+++ b/extensions/signal/src/config-compat.ts
@@ -1,6 +1,7 @@
 import { DEFAULT_ACCOUNT_ID, normalizeAccountId } from "openclaw/plugin-sdk/account-resolution";
 // Signal compatibility migration moves shipped flat transport config into account ownership.
 import type { ChannelDoctorConfigMutation } from "openclaw/plugin-sdk/channel-contract";
+import { isRecord } from "openclaw/plugin-sdk/channel-secret-basic-runtime";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import type { SignalTransportConfig } from "./account-types.js";
 import {
@@ -40,10 +41,6 @@ type DetectTransport = (params: {
   url: string;
   account?: string;
 }) => Promise<SignalTransportConfig>;
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
-}
 
 function isSignalTransportConfig(value: unknown): value is SignalTransportConfig {
   if (!isRecord(value)) {

--- a/extensions/signal/src/config-schema.ts
+++ b/extensions/signal/src/config-schema.ts
@@ -16,6 +16,7 @@ import {
   requireAllowlistAllowFrom,
   requireOpenAllowFrom,
 } from "openclaw/plugin-sdk/channel-config-schema";
+import { isRecord } from "openclaw/plugin-sdk/channel-secret-basic-runtime";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { z } from "zod";
 import { signalChannelConfigUiHints } from "./config-ui-hints.js";
@@ -43,10 +44,6 @@ const SignalTransportUrlSchema = z
     SIGNAL_TRANSPORT_URL_PATTERN,
     "Expected http:// or https:// URL without embedded credentials",
   );
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
-}
 
 function projectSignalConfigForUpdateValidation(value: unknown): unknown {
   if (process.env.OPENCLAW_UPDATE_IN_PROGRESS !== "1" || !isRecord(value)) {

--- a/extensions/signal/src/signal-ingress.ts
+++ b/extensions/signal/src/signal-ingress.ts
@@ -5,7 +5,9 @@ import {
   type ChannelIngressMonitorDeliveryResult,
   type ChannelIngressMonitorLifecycle,
 } from "openclaw/plugin-sdk/channel-outbound";
+import { isRecord } from "openclaw/plugin-sdk/channel-secret-basic-runtime";
 import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
+import { normalizeNullableString as normalizeRawString } from "openclaw/plugin-sdk/string-coerce-runtime";
 import type { SignalSseEvent } from "./client-adapter.js";
 import { getOptionalSignalRuntime } from "./runtime.js";
 
@@ -56,14 +58,6 @@ class SignalIngressPermanentError extends Error {
     super(message, options);
     this.name = "SignalIngressPermanentError";
   }
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
-}
-
-function normalizeRawString(value: unknown): string | null {
-  return typeof value === "string" && value.trim() ? value.trim() : null;
 }
 
 function normalizeTimestamp(value: unknown): number | null {

--- a/extensions/slack/src/doctor.ts
+++ b/extensions/slack/src/doctor.ts
@@ -5,6 +5,7 @@ import {
   createDangerousNameMatchingMutableAllowlistWarningCollector,
 } from "openclaw/plugin-sdk/channel-policy";
 import type { GroupPolicy, OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import { asObjectRecord } from "openclaw/plugin-sdk/runtime-doctor";
 import { inspectSlackAccount } from "./account-inspect.js";
 import { listSlackAccountIds, mergeSlackAccountConfig } from "./accounts.js";
 import {
@@ -13,12 +14,6 @@ import {
 } from "./doctor-contract.js";
 import { probeSlack } from "./probe.js";
 import { isSlackMutableAllowEntry } from "./security-doctor.js";
-
-function asObjectRecord(value: unknown): Record<string, unknown> | null {
-  return value && typeof value === "object" && !Array.isArray(value)
-    ? (value as Record<string, unknown>)
-    : null;
-}
 
 const collectSlackMutableAllowlistWarnings =
   createDangerousNameMatchingMutableAllowlistWarningCollector({

--- a/extensions/synology-chat/src/webhook-ingress.ts
+++ b/extensions/synology-chat/src/webhook-ingress.ts
@@ -5,6 +5,7 @@ import {
   type ChannelIngressMonitorDeliveryResult,
   type ChannelIngressMonitorLifecycle,
 } from "openclaw/plugin-sdk/channel-outbound";
+import { isRecord } from "openclaw/plugin-sdk/channel-secret-basic-runtime";
 import { collectErrorGraphCandidates, formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import { getSynologyRuntime } from "./runtime.js";
 
@@ -96,10 +97,6 @@ function inspectSynologyIngressEvent(event: SynologyWebhookRawEvent): {
     eventId,
     laneKey: channelId ? `channel:${channelId}` : `direct:${userId}`,
   };
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
 function deserializeSynologyIngressEvent(

--- a/extensions/telegram/src/doctor.ts
+++ b/extensions/telegram/src/doctor.ts
@@ -9,6 +9,7 @@ import {
 } from "openclaw/plugin-sdk/channel-outbound";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
+import { asObjectRecord, collectChannelAccountScopes } from "openclaw/plugin-sdk/runtime-doctor";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { inspectTelegramAccount } from "./account-inspect.js";
 import {
@@ -44,52 +45,12 @@ type TelegramAllowFromListRef = {
   key: "allowFrom" | "groupAllowFrom";
 };
 
-function asObjectRecord(value: unknown): Record<string, unknown> | null {
-  return value && typeof value === "object" && !Array.isArray(value)
-    ? (value as Record<string, unknown>)
-    : null;
-}
-
 function sanitizeForLog(value: string): string {
   return value.replace(/\p{Cc}+/gu, " ").trim();
 }
 
 function hasAllowFromEntries(values?: DoctorAllowFromList): boolean {
   return Array.isArray(values) && values.some((entry) => normalizeOptionalString(String(entry)));
-}
-
-function collectTelegramAccountScopes(
-  cfg: OpenClawConfig,
-): Array<{ prefix: string; pathSegments: string[]; account: Record<string, unknown> }> {
-  const scopes: Array<{
-    prefix: string;
-    pathSegments: string[];
-    account: Record<string, unknown>;
-  }> = [];
-  const telegram = asObjectRecord((cfg.channels as Record<string, unknown> | undefined)?.telegram);
-  if (!telegram) {
-    return scopes;
-  }
-  scopes.push({
-    prefix: "channels.telegram",
-    pathSegments: ["channels", "telegram"],
-    account: telegram,
-  });
-  const accounts = asObjectRecord(telegram.accounts);
-  if (!accounts) {
-    return scopes;
-  }
-  for (const key of Object.keys(accounts)) {
-    const account = asObjectRecord(accounts[key]);
-    if (account) {
-      scopes.push({
-        prefix: `channels.telegram.accounts.${key}`,
-        pathSegments: ["channels", "telegram", "accounts", key],
-        account,
-      });
-    }
-  }
-  return scopes;
 }
 
 function collectTelegramAllowFromLists(
@@ -145,7 +106,7 @@ function describeConfigValueType(value: unknown): string {
 
 function scanTelegramMalformedGroupsConfig(cfg: OpenClawConfig): TelegramMalformedGroupsHit[] {
   const hits: TelegramMalformedGroupsHit[] = [];
-  for (const scope of collectTelegramAccountScopes(cfg)) {
+  for (const scope of collectChannelAccountScopes({ cfg, channelId: "telegram" })) {
     if (!Object.hasOwn(scope.account, "groups")) {
       continue;
     }
@@ -193,7 +154,7 @@ function scanTelegramInvalidAllowFromEntries(cfg: OpenClawConfig): TelegramAllow
     }
   };
 
-  for (const scope of collectTelegramAccountScopes(cfg)) {
+  for (const scope of collectChannelAccountScopes({ cfg, channelId: "telegram" })) {
     for (const ref of collectTelegramAllowFromLists(scope.prefix, scope.account)) {
       scanList(ref.pathLabel, ref.holder[ref.key]);
     }
@@ -217,7 +178,7 @@ function collectTelegramInvalidAllowFromWarnings(params: {
 
 function scanTelegramBotEndpointApiRoots(cfg: OpenClawConfig): TelegramApiRootBotEndpointHit[] {
   const hits: TelegramApiRootBotEndpointHit[] = [];
-  for (const scope of collectTelegramAccountScopes(cfg)) {
+  for (const scope of collectChannelAccountScopes({ cfg, channelId: "telegram" })) {
     const value = scope.account.apiRoot;
     if (typeof value !== "string" || !hasTelegramBotEndpointApiRoot(value)) {
       continue;
@@ -521,7 +482,7 @@ async function maybeRepairTelegramAllowFromUsernames(cfg: OpenClawConfig): Promi
     }
   };
 
-  for (const scope of collectTelegramAccountScopes(next)) {
+  for (const scope of collectChannelAccountScopes({ cfg: next, channelId: "telegram" })) {
     for (const ref of collectTelegramAllowFromLists(scope.prefix, scope.account)) {
       await repairList(ref.pathLabel, ref.holder, ref.key);
     }

--- a/extensions/telegram/src/target-writeback.ts
+++ b/extensions/telegram/src/target-writeback.ts
@@ -9,6 +9,7 @@ import {
   resolveCronStorePath,
   saveCronStore,
 } from "openclaw/plugin-sdk/cron-store-runtime";
+import { asObjectRecord } from "openclaw/plugin-sdk/runtime-doctor";
 import { createSubsystemLogger } from "openclaw/plugin-sdk/runtime-env";
 import {
   normalizeLowercaseStringOrEmpty,
@@ -22,13 +23,6 @@ import {
 
 const writebackLogger = createSubsystemLogger("telegram/target-writeback");
 const TELEGRAM_ADMIN_SCOPE = "operator.admin";
-
-function asObjectRecord(value: unknown): Record<string, unknown> | null {
-  if (!value || typeof value !== "object" || Array.isArray(value)) {
-    return null;
-  }
-  return value as Record<string, unknown>;
-}
 
 function normalizeTelegramLookupTargetForMatch(raw: string): string | undefined {
   const normalized = normalizeTelegramLookupTarget(raw);

--- a/extensions/tlon/src/monitor/ingress.ts
+++ b/extensions/tlon/src/monitor/ingress.ts
@@ -5,8 +5,10 @@ import {
   type ChannelIngressMonitorDeliveryResult,
   type ChannelIngressMonitorLifecycle,
 } from "openclaw/plugin-sdk/channel-outbound";
+import { isRecord } from "openclaw/plugin-sdk/channel-secret-basic-runtime";
 import { collectErrorGraphCandidates, formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
+import { normalizeNullableString as nonEmptyString } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { getTlonRuntime } from "../runtime.js";
 import { UrbitAuthError, UrbitHttpError } from "../urbit/errors.js";
 
@@ -56,14 +58,6 @@ class TlonIngressShutdownError extends Error {
     super("Tlon ingress stopped before dispatch adoption.");
     this.name = "TlonIngressShutdownError";
   }
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
-}
-
-function nonEmptyString(value: unknown): string | null {
-  return typeof value === "string" && value.trim() ? value.trim() : null;
 }
 
 function inspectChannelsEvent(event: unknown): { eventId: string; laneKey: string } | null {

--- a/extensions/twitch/src/twitch-ingress.ts
+++ b/extensions/twitch/src/twitch-ingress.ts
@@ -6,6 +6,7 @@ import {
   type ChannelIngressMonitorLifecycle,
 } from "openclaw/plugin-sdk/channel-outbound";
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
+import { normalizeNullableString as nonEmptyString } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { getTwitchRuntime } from "./runtime.js";
 import type { TwitchChatMessage } from "./types.js";
 import { normalizeTwitchChannel } from "./utils/twitch.js";
@@ -38,10 +39,6 @@ class TwitchIngressPermanentError extends Error {
     super(message, options);
     this.name = "TwitchIngressPermanentError";
   }
-}
-
-function nonEmptyString(value: unknown): string | null {
-  return typeof value === "string" && value.trim() ? value.trim() : null;
 }
 
 function inspectTwitchIngressEvent(event: unknown): { eventId: string; laneKey: string } {

--- a/extensions/vault/src/cli.ts
+++ b/extensions/vault/src/cli.ts
@@ -1,6 +1,7 @@
 import path from "node:path";
 import { createInterface } from "node:readline/promises";
 import { fileURLToPath } from "node:url";
+import { isRecord } from "openclaw/plugin-sdk/channel-secret-basic-runtime";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/plugin-entry";
 import { pluginSecretRefSetup } from "openclaw/plugin-sdk/secret-ref-runtime";
 import { pathExists } from "openclaw/plugin-sdk/security-runtime";
@@ -76,10 +77,6 @@ function writeLine(message = ""): void {
 
 function writeJson(value: unknown): void {
   process.stdout.write(`${JSON.stringify(value, null, 2)}\n`);
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
 }
 
 function normalizeOptionalString(value: unknown): string | undefined {

--- a/extensions/zalo/src/webhook-spool.ts
+++ b/extensions/zalo/src/webhook-spool.ts
@@ -6,6 +6,8 @@ import {
   DEFAULT_INGRESS_RETRY_MAX_ATTEMPTS,
   type ChannelIngressQueue,
 } from "openclaw/plugin-sdk/channel-outbound";
+import { isRecord } from "openclaw/plugin-sdk/channel-secret-basic-runtime";
+import { normalizeNullableString as nonEmptyString } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { runDetachedWebhookWork } from "openclaw/plugin-sdk/webhook-request-guards";
 import { ZaloApiError, type ZaloUpdate } from "./api.js";
 import type { ZaloRuntimeEnv } from "./monitor.types.js";
@@ -42,14 +44,6 @@ type ZaloWebhookIngress = {
   start: () => void;
   stop: () => Promise<void>;
 };
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
-}
-
-function nonEmptyString(value: unknown): string | null {
-  return typeof value === "string" && value.trim() ? value.trim() : null;
-}
 
 function parseRawRecord(rawEvent: string): Record<string, unknown> {
   let parsed: unknown;

--- a/extensions/zalouser/src/doctor.ts
+++ b/extensions/zalouser/src/doctor.ts
@@ -1,14 +1,9 @@
 // Zalouser plugin module implements doctor behavior.
 import type { ChannelDoctorAdapter } from "openclaw/plugin-sdk/channel-contract";
 import { createDangerousNameMatchingMutableAllowlistWarningCollector } from "openclaw/plugin-sdk/channel-policy";
+import { asObjectRecord } from "openclaw/plugin-sdk/runtime-doctor";
 import { legacyConfigRules, normalizeCompatibilityConfig } from "./doctor-contract.js";
 import { isZalouserMutableGroupEntry } from "./security-audit.js";
-
-function asObjectRecord(value: unknown): Record<string, unknown> | null {
-  return value && typeof value === "object" && !Array.isArray(value)
-    ? (value as Record<string, unknown>)
-    : null;
-}
 
 const collectZalouserMutableAllowlistWarnings =
   createDangerousNameMatchingMutableAllowlistWarningCollector({

--- a/extensions/zalouser/src/ingress.ts
+++ b/extensions/zalouser/src/ingress.ts
@@ -5,8 +5,10 @@ import {
   DEFAULT_INGRESS_ADOPTION_STALL_MS,
   type ChannelIngressQueue,
 } from "openclaw/plugin-sdk/channel-outbound";
+import { isRecord } from "openclaw/plugin-sdk/channel-secret-basic-runtime";
 import { collectErrorGraphCandidates, extractErrorCode } from "openclaw/plugin-sdk/error-runtime";
 import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime";
+import { normalizeNullableString as nonEmptyString } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { getZalouserRuntime } from "./runtime.js";
 import type { ZaloInboundMessage } from "./types.js";
 import { normalizeZaloInboundMessage } from "./zalo-js.js";
@@ -48,14 +50,6 @@ class ZalouserIngressPayloadError extends Error {
     super(message, options);
     this.name = "ZalouserIngressPayloadError";
   }
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
-}
-
-function nonEmptyString(value: unknown): string | null {
-  return typeof value === "string" && value.trim() ? value.trim() : null;
 }
 
 function inspectZalouserIngressMessage(message: unknown): {

--- a/src/plugin-sdk/runtime-doctor.test.ts
+++ b/src/plugin-sdk/runtime-doctor.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import type { OpenClawConfig } from "./config-contracts.js";
 import {
+  collectChannelAccountScopes,
   defineKeyMoveMigration,
   normalizeChannelConfigEntries,
   stripRetiredChannelKeys,
@@ -11,6 +12,26 @@ function cfgWith(entry: Record<string, unknown>): OpenClawConfig {
 }
 
 describe("runtime-doctor channel helpers", () => {
+  it("collects the channel root and object-shaped accounts in config order", () => {
+    expect(
+      collectChannelAccountScopes({
+        cfg: cfgWith({ accounts: { work: { enabled: true }, invalid: "skip" } }),
+        channelId: "sample",
+      }),
+    ).toEqual([
+      {
+        prefix: "channels.sample",
+        pathSegments: ["channels", "sample"],
+        account: { accounts: { work: { enabled: true }, invalid: "skip" } },
+      },
+      {
+        prefix: "channels.sample.accounts.work",
+        pathSegments: ["channels", "sample", "accounts", "work"],
+        account: { enabled: true },
+      },
+    ]);
+  });
+
   it("moves nested keys across wildcard entries and preserves canonical values", () => {
     const migration = defineKeyMoveMigration({
       scope: ["groups", "*"],

--- a/src/plugin-sdk/runtime-doctor.ts
+++ b/src/plugin-sdk/runtime-doctor.ts
@@ -3,6 +3,7 @@
  */
 import { asObjectRecord } from "../config/channel-compat-normalization.js";
 import type { CompatMutationResult } from "../config/channel-compat-normalization.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
 
 export { collectProviderDangerousNameMatchingScopes } from "../config/dangerous-name-matching.js";
 export { defineChannelAliasMigration } from "../config/channel-alias-migration.js";
@@ -65,6 +66,45 @@ type KeyMoveChangeContext = {
   targetValue: unknown;
   mappedValue: unknown;
 };
+
+/** Collects a channel's root config and object-shaped account overrides in config order. */
+export function collectChannelAccountScopes(params: {
+  cfg: OpenClawConfig;
+  channelId: string;
+}): Array<{
+  prefix: string;
+  pathSegments: string[];
+  account: Record<string, unknown>;
+}> {
+  const scopes: Array<{
+    prefix: string;
+    pathSegments: string[];
+    account: Record<string, unknown>;
+  }> = [];
+  const pathSegments = ["channels", params.channelId];
+  const channels = asObjectRecord(params.cfg.channels);
+  const channel = asObjectRecord(channels?.[params.channelId]);
+  if (!channel) {
+    return scopes;
+  }
+  scopes.push({ prefix: pathSegments.join("."), pathSegments, account: channel });
+  const accounts = asObjectRecord(channel.accounts);
+  if (!accounts) {
+    return scopes;
+  }
+  for (const [accountId, value] of Object.entries(accounts)) {
+    const account = asObjectRecord(value);
+    if (account) {
+      const accountPathSegments = [...pathSegments, "accounts", accountId];
+      scopes.push({
+        prefix: accountPathSegments.join("."),
+        pathSegments: accountPathSegments,
+        account,
+      });
+    }
+  }
+  return scopes;
+}
 
 function readKeyMovePath(entry: Record<string, unknown>, path: readonly string[], own = true) {
   let current = entry;


### PR DESCRIPTION
## What Problem This Solves

OpenClaw's bundled plugins carried dozens of local copies of the same record, string, environment-flag, and boolean normalization primitives. Those copies add maintenance surface and make semantic drift easy when the canonical Plugin SDK helpers evolve.

This is an AI-assisted, maintainer-authorized LOC-reduction fleet refactor.

## Why This Change Was Made

Replace behavior-equivalent plugin-local primitives with the narrow canonical `openclaw/plugin-sdk/*` exports, while retaining local implementations where semantics or runtime ownership differ. Add `collectChannelAccountScopes({ cfg, channelId })` to `runtime-doctor` so Discord and Telegram share the same ordered root/account config walk (`src/plugin-sdk/runtime-doctor.ts:70`, `extensions/discord/src/doctor.ts:102`, `extensions/telegram/src/doctor.ts:109`).

The change deliberately leaves browser-bundled Diffs parsing local because the channel-secret SDK barrel is Node-only, and leaves subtly different array-accepting and whitespace-preserving predicates unchanged.

## User Impact

No user-visible behavior changes. Plugin runtime behavior and validation semantics remain the same, with fewer duplicate production paths to maintain.

## Evidence

LOC (`origin/main...2b6469a578571388213b397356f6665e10400237`):

- Production: +126 / -333, net -207 LOC
- Tests: +27 / -6, net +21 LOC

Focused proof:

- `node scripts/run-vitest.mjs src/plugin-sdk/runtime-doctor.test.ts` — 5/5 passed on the final rebased head.
- `node scripts/run-vitest.mjs extensions/signal` — 42 files, 730 tests passed.
- `node scripts/run-vitest.mjs extensions/googlechat` — 25 files, 270 tests passed.
- `node scripts/run-vitest.mjs extensions/discord` — 203 files and 2,352 tests passed; two unrelated suites could not resolve the intentionally absent worktree-local `undici` package.
- `node scripts/run-vitest.mjs extensions/telegram` — 144 files and 2,052 tests passed; remaining import cascades had the same missing-worktree `undici` cause.
- Focused Browser, ElevenLabs, Hermes, Teams, 1Password, Policy, and Diffs tests — 116 tests passed across five shards.
- `extensions/qa-lab/src/code-mode-model-matrix.test.ts` — 23/23 passed after moving the QA-Lab-owned suite out of core tests.
- `test/extension-test-boundary.test.ts` — 11/11 passed after the move.
- `node --import tsx scripts/check-no-extension-test-core-imports.ts` — zero violations across 2,888 extension files after deriving the fixture type from the public script function contract.
- Full Oxfmt check — passed; the matrix-script formatting fix exposed by CI run 30429305942 landed independently on `main` and was absorbed during rebase.
- `node scripts/check-changed.mjs -- <50 changed files>` — all selected core/extension typechecks, lint, Plugin SDK API/surface checks, bundled metadata, boundaries, dead-export scan, import cycles, and guards passed in Blacksmith Testbox `tbx_01kyp71xyq5gbxmv8m08xkwdb1` (Actions run 30426499511). The final rebase retained stable patch ID `6ab0b9a7341c3c69a96a9b65b8827203dca15059`.
- `oxfmt --check <changed TypeScript files>` and `git diff --check origin/main...HEAD` — passed.
- `.agents/skills/autoreview/scripts/autoreview --mode uncommitted` — final run clean; the initial browser-bundle finding was accepted and fixed before the clean rerun.

The final pre-land rebase exposed unrelated `main` failures in exact-head CI runs 30427817919 and 30429305942. This PR includes the remaining smallest correct fix required by the landing contract: the code-mode matrix suite now lives under its QA-Lab owner, preserves serialized evidence schema validation, and derives its envelope fixture type without importing core internals. The matrix script's rejection-callback and formatting fixes landed independently on `main` and were retained during rebase.
