### PR TITLE
fix(gateway): preserve complete streamed chat completions

### DIFF
--- a/src/agents/embedded-agent-subscribe.subscribe-embedded-agent-session.filters-final-suppresses-output-without-start-tag.test.ts
+++ b/src/agents/embedded-agent-subscribe.subscribe-embedded-agent-session.filters-final-suppresses-output-without-start-tag.test.ts
@@ -234,6 +234,22 @@ describe("subscribeEmbeddedAgentSession", () => {
     expect(payloads.some((payload) => payload.replace)).toBe(false);
   });
 
+  it("preserves literal custom XML tag openers split after a bare less-than", () => {
+    const { session, emit } = createStubSessionHarness();
+    const onAgentEvent = vi.fn();
+
+    subscribeEmbeddedAgentSession({ session, runId: "run", onAgentEvent });
+    emit({ type: "message_start", message: { role: "assistant" } });
+    for (const delta of ["<", "xiaohai-banli>milk tea</xiaohai-banli>"]) {
+      emitAssistantTextDelta({ emit, delta });
+    }
+
+    const payloads = extractAgentEventPayloads(onAgentEvent.mock.calls);
+    expect(payloads.map((payload) => payload.delta).join("")).toBe(
+      "<xiaohai-banli>milk tea</xiaohai-banli>",
+    );
+  });
+
   it("strips self-closing and attributed final tags from streamed deltas", () => {
     const { session, emit } = createStubSessionHarness();
 

--- a/src/gateway/openai-http.test.ts
+++ b/src/gateway/openai-http.test.ts
@@ -3,6 +3,7 @@
 import fs from "node:fs/promises";
 import http from "node:http";
 import path from "node:path";
+import OpenAI from "openai";
 import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 import { createClientToolNameConflictError } from "../agents/agent-tool-definition-adapter.js";
 import {
@@ -99,6 +100,15 @@ async function postChatCompletions(port: number, body: unknown, headers?: Record
     body: JSON.stringify(body),
   });
   return res;
+}
+
+function createOpenAiChatClient(port: number): OpenAI {
+  return new OpenAI({
+    apiKey: "test",
+    baseURL: `http://127.0.0.1:${port}/v1`,
+    defaultHeaders: { "x-openclaw-scopes": "operator.write" },
+    maxRetries: 0,
+  });
 }
 
 function parseSseDataLines(text: string): string[] {
@@ -1877,6 +1887,127 @@ describe("OpenAI-compatible HTTP API (e2e)", () => {
         },
       },
     );
+  });
+
+  it.each([
+    {
+      name: "a split custom XML opener",
+      deltas: ["<", "xiaohai-banli>milk tea</", "xiaohai-banli>"],
+      expected: "<xiaohai-banli>milk tea</xiaohai-banli>",
+    },
+    {
+      name: "literal script-like content",
+      deltas: ["<", "script>alert('literal')</", "script>"],
+      expected: "<script>alert('literal')</script>",
+    },
+  ])("preserves $name through the official OpenAI SDK SSE stream", async ({ deltas, expected }) => {
+    agentCommand.mockClear();
+    agentCommand.mockImplementationOnce((async (opts: unknown) => {
+      const runId = (opts as { runId?: string } | undefined)?.runId ?? "";
+      const { session, emit } = createStubSessionHarness();
+      subscribeEmbeddedAgentSession({ session, runId });
+      emit({ type: "message_start", message: { role: "assistant" } });
+      for (const delta of deltas) {
+        emitAssistantTextDelta({ emit, delta });
+      }
+      return { payloads: [{ text: expected }] };
+    }) as never);
+
+    const stream = await createOpenAiChatClient(enabledPort).chat.completions.create({
+      model: "openclaw",
+      messages: [{ role: "user", content: "Preserve the literal output." }],
+      stream: true,
+    });
+    const content: string[] = [];
+    const finishReasons: Array<string | null> = [];
+    for await (const chunk of stream) {
+      for (const choice of chunk.choices) {
+        if (typeof choice.delta.content === "string") {
+          content.push(choice.delta.content);
+        }
+        finishReasons.push(choice.finish_reason);
+      }
+    }
+
+    expect(content.join("")).toBe(expected);
+    expect(finishReasons.at(-1)).toBe("stop");
+    expect(agentCommand).toHaveBeenCalledTimes(1);
+  });
+
+  it("preserves buffered leading content in cumulative assistant snapshots", async () => {
+    const expected = "<xiaohai-banli>milk tea</xiaohai-banli>";
+    agentCommand.mockClear();
+    agentCommand.mockImplementationOnce((async (opts: unknown) => {
+      const runId = (opts as { runId?: string } | undefined)?.runId ?? "";
+      emitAgentEvent({
+        runId,
+        stream: "assistant",
+        data: {
+          text: expected,
+          delta: "xiaohai-banli>milk tea</xiaohai-banli>",
+        },
+      });
+      return { payloads: [{ text: expected }] };
+    }) as never);
+
+    const stream = await createOpenAiChatClient(enabledPort).chat.completions.create({
+      model: "openclaw",
+      messages: [{ role: "user", content: "Preserve the full snapshot." }],
+      stream: true,
+    });
+    const content: string[] = [];
+    const finishReasons: Array<string | null> = [];
+    for await (const chunk of stream) {
+      for (const choice of chunk.choices) {
+        if (typeof choice.delta.content === "string") {
+          content.push(choice.delta.content);
+        }
+        finishReasons.push(choice.finish_reason);
+      }
+    }
+
+    expect(content.join("")).toBe(expected);
+    expect(finishReasons.at(-1)).toBe("stop");
+  });
+
+  it("flushes same-turn assistant microtasks before the SSE done frame", async () => {
+    agentCommand.mockClear();
+    agentCommand.mockImplementationOnce(((opts: unknown) => {
+      const runId = (opts as { runId?: string } | undefined)?.runId ?? "";
+      emitAgentEvent({ runId, stream: "assistant", data: { delta: "start " } });
+      const result = Promise.resolve({ payloads: [{ text: "start finish" }] });
+      void result.then(() => {
+        emitAgentEvent({ runId, stream: "lifecycle", data: { phase: "end" } });
+        void Promise.resolve().then(() => {
+          emitAgentEvent({ runId, stream: "assistant", data: { delta: "finish" } });
+        });
+      });
+      return result;
+    }) as never);
+
+    const res = await postChatCompletions(enabledPort, {
+      stream: true,
+      model: "openclaw",
+      messages: [{ role: "user", content: "Finish the streamed response." }],
+    });
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toContain("text/event-stream");
+
+    const data = parseSseDataLines(await res.text());
+    expect(data.at(-1)).toBe("[DONE]");
+    const chunks = data
+      .filter((line) => line !== "[DONE]")
+      .map((line) => JSON.parse(line) as Record<string, unknown>);
+    const content = chunks
+      .flatMap((chunk) => (chunk.choices as Array<Record<string, unknown>> | undefined) ?? [])
+      .map((choice) => (choice.delta as Record<string, unknown> | undefined)?.content)
+      .filter((value): value is string => typeof value === "string")
+      .join("");
+    expect(content).toBe("start finish");
+    const finishChoice = chunks
+      .flatMap((chunk) => (chunk.choices as Array<Record<string, unknown>> | undefined) ?? [])
+      .at(-1);
+    expect(finishChoice?.finish_reason).toBe("stop");
   });
 
   it("streams SSE chunks when stream=true", async () => {

--- a/src/gateway/openai-http.ts
+++ b/src/gateway/openai-http.ts
@@ -1189,17 +1189,19 @@ export async function handleOpenAiHttpRequest(
   let wroteRole = false;
   let wroteStopChunk = false;
   let sawAssistantDelta = false;
+  let streamedAssistantText = "";
   let bufferedAssistantContent = "";
   let bufferedReplaceableAssistantContent = "";
   let finalUsage: OpenAiChatCompletionsUsage | undefined;
   let finalizeRequested = false;
+  let finalizeScheduled = false;
   let finalizeFinishReason: "stop" | "tool_calls" = "stop";
   let resultResolved = false;
   let closed = false;
   let stopWatchingDisconnect = () => {};
 
   const maybeFinalize = () => {
-    if (closed || !finalizeRequested) {
+    if (closed || finalizeScheduled || !finalizeRequested) {
       return;
     }
     if (!resultResolved) {
@@ -1208,22 +1210,32 @@ export async function handleOpenAiHttpRequest(
     if (streamIncludeUsage && !finalUsage) {
       return;
     }
-    closed = true;
-    stopWatchingDisconnect();
-    unsubscribe();
-    if (!wroteStopChunk) {
-      writeAssistantFinishChunk(res, { runId, model, finishReason: finalizeFinishReason });
-      wroteStopChunk = true;
-    }
-    if (streamIncludeUsage && finalUsage) {
-      writeUsageChunk(res, { runId, model, usage: finalUsage });
-    }
-    writeDone(res);
-    res.end();
+    // Agent text_end flushes run in a microtask. Keep the stream subscribed
+    // until those same-turn deltas arrive, then emit exactly one terminal frame.
+    finalizeScheduled = true;
+    queueMicrotask(() => {
+      if (closed) {
+        return;
+      }
+      closed = true;
+      stopWatchingDisconnect();
+      unsubscribe();
+      if (!wroteStopChunk) {
+        writeAssistantFinishChunk(res, { runId, model, finishReason: finalizeFinishReason });
+        wroteStopChunk = true;
+      }
+      if (streamIncludeUsage && finalUsage) {
+        writeUsageChunk(res, { runId, model, usage: finalUsage });
+      }
+      writeDone(res);
+      res.end();
+    });
   };
 
   const requestFinalize = (finishReason: "stop" | "tool_calls" = "stop") => {
-    finalizeFinishReason = finishReason;
+    if (!finalizeRequested || finishReason === "tool_calls") {
+      finalizeFinishReason = finishReason;
+    }
     finalizeRequested = true;
     maybeFinalize();
   };
@@ -1251,10 +1263,16 @@ export async function handleOpenAiHttpRequest(
         return;
       }
 
-      const content = resolveAssistantStreamDeltaText(evt) ?? "";
+      // Snapshots include prefixes held during tag-boundary filtering; the raw
+      // delta alone can omit a literal leading less-than.
+      const content =
+        typeof text === "string" && text.startsWith(streamedAssistantText)
+          ? text.slice(streamedAssistantText.length)
+          : resolveAssistantStreamDeltaText(evt);
       if (!content) {
         return;
       }
+      streamedAssistantText += content;
 
       // Hold prose until the run proves the requested client-tool call exists.
       // If the provider ignores `tool_choice`, no partial text should leak


### PR DESCRIPTION
Closes #81991
Related: #82355

## What Problem This Solves

Fixes an issue where users streaming Chat Completions from the Gateway receive incomplete assistant responses: a leading character buffered at an XML-style tag boundary can disappear, and the final assistant text can arrive after the stream has already sent its terminal `[DONE]` frame.

## Why This Change Was Made

Preserve the existing sanitized cumulative assistant snapshot when deriving OpenAI-compatible incremental chunks. Schedule stream completion after the current microtask so the agent's same-turn final text is emitted before the single finish and `[DONE]` frames. Preserve tool-call finish precedence, usage ordering, disconnect cleanup, replacement behavior, and intentional reasoning/final-tag suppression.

The root cause, proposed repair, and contributor-equivalent regression originate in @honor2030's #82355; the original report is #81991 by @boxiao-qd. The Gateway remains a JSON/SSE transport: literal custom tags and script-like text remain unmodified text, not HTML or executable markup.

## User Impact

Streaming OpenAI Chat Completions clients receive the complete assistant response in order, including literal leading `<` characters and the final text, before the normal stop and `[DONE]` frames. Existing structured tool calls, usage frames, authentication, suppressed reasoning, and non-streaming responses remain unchanged.

## Evidence

- Current-main fail-first on a real loopback Gateway and the official `openai@6.48.0` SDK: cumulative output loses its leading `<`, and same-turn final content is emitted after the stream closes; both regressions fail before the production change.
- The exact pinned SDK streaming contract is `Stream<ChatCompletionChunk>`, including `choices[].delta.content` and terminal `finish_reason`: https://github.com/openai/openai-node/blob/v6.48.0/src/resources/chat/completions/completions.ts. SSE framing is verified against https://html.spec.whatwg.org/multipage/server-sent-events.html.
- Real official SDK requests prove both split custom tags and literal script-like text are delivered byte-for-byte without changing markup, rendering, or HTML policy.
- Actual raw Gateway SSE proves the final assistant fragment precedes a single stop frame and terminal `[DONE]`.
- Contributor-equivalent agent regression proves arbitrary split literal tags survive while the existing 23 adjacent reasoning/final-tag suppression tests remain green.
- Blacksmith Testbox: `pnpm test src/gateway/openai-http.test.ts src/gateway/openresponses-http.test.ts src/gateway/openresponses-parity.test.ts src/gateway/openresponses-phase.test.ts src/agents/embedded-agent-subscribe.subscribe-embedded-agent-session.filters-final-suppresses-output-without-start-tag.test.ts` — **110 tests passed**.
- Blacksmith Testbox: `pnpm check:changed` — formatting, both core typecheck lanes, lint, and repository safety guards.
- Independent `gpt-5.6-sol` review with `xhigh` reasoning.
- AI-assisted; original report and solution credit preserved for @boxiao-qd and @honor2030.
