### PR TITLE
fix(whatsapp): keep QR login compatible with grammar-constrained models

### DIFF
--- a/extensions/whatsapp/src/agent-tools-login.test.ts
+++ b/extensions/whatsapp/src/agent-tools-login.test.ts
@@ -16,6 +16,21 @@ describe("createWhatsAppLoginTool", () => {
     vi.clearAllMocks();
   });
 
+  it("fully anchors the QR data URL pattern for grammar-constrained models", () => {
+    const tool = createWhatsAppLoginTool();
+    const pattern = (tool.parameters as { properties: { currentQrDataUrl?: { pattern?: string } } })
+      .properties.currentQrDataUrl?.pattern;
+
+    expect(pattern).toBe("^data:image/png;base64,.+$");
+    expect(pattern?.startsWith("^")).toBe(true);
+    expect(pattern?.endsWith("$")).toBe(true);
+
+    const expression = new RegExp(pattern ?? "");
+    expect(expression.test("data:image/png;base64,YQ==")).toBe(true);
+    expect(expression.test("data:image/png;base64,")).toBe(false);
+    expect(expression.test("data:image/jpeg;base64,YQ==")).toBe(false);
+  });
+
   it("passes the caller's current QR back into wait actions", async () => {
     const accountId = "account-1";
     waitForWebLoginMock.mockResolvedValueOnce({

--- a/extensions/whatsapp/src/agent-tools-login.ts
+++ b/extensions/whatsapp/src/agent-tools-login.ts
@@ -26,7 +26,9 @@ export function createWhatsAppLoginTool(): ChannelAgentTool {
       currentQrDataUrl: Type.Optional(
         Type.String({
           maxLength: QR_DATA_URL_MAX_LENGTH,
-          pattern: "^data:image/png;base64,",
+          // llama.cpp rejects a whole tool catalog when a model-facing pattern
+          // lacks either anchor; real QR images also require a nonempty payload.
+          pattern: "^data:image/png;base64,.+$",
         }),
       ),
     }),


### PR DESCRIPTION
Related: #113680

## What Problem This Solves

Fixes an issue where WhatsApp QR login could make an entire tool catalog unusable with llama.cpp and other grammar-constrained local models. The optional QR-image argument used a prefix-only JSON Schema pattern that the upstream grammar converter explicitly rejects.

## Why This Change Was Made

Fully anchor the existing nonempty PNG QR data URL pattern in the WhatsApp-owned login tool. Preserve the existing maximum size, start/wait actions, account routing, QR rendering, and every non-WhatsApp provider and plugin boundary.

This is a fresh-current-main, contributor-preserving replacement for #113680. Thank you to @guanbear for identifying the upstream grammar contract and the minimal original fix; the canonical commit includes `Co-authored-by: guanbear <123guan@gmail.com>`.

## User Impact

Grammar-constrained local models can retain the WhatsApp login tool and link an account normally. Valid nonempty PNG QR data URLs still work; empty and non-PNG image URLs are rejected.

## Evidence

- Independently verified upstream `ggml-org/llama.cpp/common/json-schema-to-grammar.cpp:348-351`: schema patterns must begin with `^` and end with `$`, or grammar generation rejects the tool catalog.
- Fail-first current-main source and the actual exported WhatsApp login-tool schema independently confirm the missing terminal anchor.
- Stronger regression checks both grammar anchors and actual valid PNG, empty PNG, and non-PNG URL behavior.
- Trusted Blacksmith Testbox: 30/30 tests passed across `agent-tools-login.test.ts`, `login-qr.test.ts`, and `login.test.ts`.
- Full remote `pnpm check:changed`: passed, including production/test typechecks, formatting, lint, plugin-boundary, dead-code, and import-cycle gates.
- Fresh isolated `gpt-5.6-sol` extra-high-effort structured review: clean, zero accepted or actionable findings.
