### PR TITLE
fix(delivery): prevent agent sessions from becoming message targets

### DIFF
--- a/src/infra/outbound/message-action-normalization.test.ts
+++ b/src/infra/outbound/message-action-normalization.test.ts
@@ -303,6 +303,58 @@ describe("normalizeMessageActionInput", () => {
   });
 
   it.each([
+    "agent:main:subagent:worker",
+    "agent:main:cron:job:run:turn",
+    "channel:agent:main:subagent:worker",
+    "channel:agent:main:main",
+  ])("does not infer internal session %s as a message target", (currentChannelId) => {
+    expect(() =>
+      normalizeMessageActionInput({
+        action: "send",
+        args: { channel: "discord" },
+        toolContext: {
+          currentChannelId,
+          currentChannelProvider: "discord",
+        },
+      }),
+    ).toThrow(/requires a target/);
+  });
+
+  it("uses a real current messaging target instead of an internal session channel", () => {
+    expect(
+      normalizeMessageActionInput({
+        action: "send",
+        args: { channel: "discord" },
+        toolContext: {
+          currentChannelId: "agent:main:subagent:worker",
+          currentMessagingTarget: "channel:123456789012345678",
+          currentChannelProvider: "discord",
+        },
+      }),
+    ).toMatchObject({
+      channel: "discord",
+      target: "channel:123456789012345678",
+      to: "channel:123456789012345678",
+    });
+  });
+
+  it("preserves an explicitly supplied target shaped like an internal session", () => {
+    expect(
+      normalizeMessageActionInput({
+        action: "send",
+        args: {
+          channel: "discord",
+          target: "agent:main:subagent:worker",
+        },
+      }),
+    ).toMatchObject({
+      channel: "discord",
+      target: "agent:main:subagent:worker",
+      to: "agent:main:subagent:worker",
+    });
+  });
+
+  it.each([
     { name: "a nonempty targets array", targets: ["C_TARGET"] },
     { name: "an empty targets array", targets: [] },
     { name: "a malformed targets value", targets: "C_TARGET" },

--- a/src/infra/outbound/message-action-normalization.ts
+++ b/src/infra/outbound/message-action-normalization.ts
@@ -5,6 +5,7 @@ import type {
   ChannelMessageActionName,
   ChannelThreadingToolContext,
 } from "../../channels/plugins/types.public.js";
+import { parseAgentSessionKey } from "../../sessions/session-key-utils.js";
 import {
   isDeliverableMessageChannel,
   normalizeMessageChannel,
@@ -17,6 +18,24 @@ import {
   resolveActionDeliveryTargetAlias,
   type ActionDeliveryTargetAliasSpec,
 } from "./message-action-spec.js";
+
+export function resolveImplicitMessageActionTarget(
+  toolContext: ChannelThreadingToolContext | undefined,
+): string | undefined {
+  for (const value of [toolContext?.currentChannelId, toolContext?.currentMessagingTarget]) {
+    const target = normalizeOptionalString(value);
+    if (!target) {
+      continue;
+    }
+    // A session can arrive bare or wrapped as a channel target; neither is
+    // a transport destination. Keep searching for the real conversation.
+    if (parseAgentSessionKey(target.replace(/^channel:/i, ""))) {
+      continue;
+    }
+    return target;
+  }
+  return undefined;
+}
 
 /** Normalizes message-action args before target validation and dispatch. */
 export function normalizeMessageActionInput(params: {
@@ -76,9 +95,7 @@ export function normalizeMessageActionInput(params: {
     actionRequiresTarget(action) &&
     (hasResourceReference || !actionHasTarget(action, normalizedArgs, { channel: inferredChannel }))
   ) {
-    const inferredTarget =
-      normalizeOptionalString(toolContext?.currentChannelId) ??
-      normalizeOptionalString(toolContext?.currentMessagingTarget);
+    const inferredTarget = resolveImplicitMessageActionTarget(toolContext);
     if (inferredTarget) {
       normalizedArgs.target = inferredTarget;
     }

--- a/src/infra/outbound/message-action-runner.core-send.test.ts
+++ b/src/infra/outbound/message-action-runner.core-send.test.ts
@@ -344,6 +344,67 @@ describe("runMessageAction core send routing", () => {
     expect(sendText).toHaveBeenCalledOnce();
   });
 
+  it.each([
+    "agent:main:subagent:worker",
+    "agent:main:cron:job:run:turn",
+    "channel:agent:main:main",
+  ])(
+    "rejects implicit delivery to internal session %s before sending",
+    async (currentChannelId) => {
+      const sendText = registerSlackTextPlugin();
+
+      await expect(
+        runMessageAction({
+          cfg: slackConfig,
+          action: "send",
+          params: {
+            channel: "slack",
+            message: "do not deliver to a session key",
+          },
+          toolContext: {
+            currentChannelProvider: "slack",
+            currentChannelId,
+          },
+          sessionKey: "agent:main:subagent:worker",
+          dryRun: false,
+        }),
+      ).rejects.toThrow(/requires a target/i);
+
+      expect(sendText).not.toHaveBeenCalled();
+    },
+  );
+
+  it("delivers to a real current conversation instead of an internal session channel", async () => {
+    const sendText = registerSlackTextPlugin();
+
+    const result = await runMessageAction({
+      cfg: slackConfig,
+      action: "send",
+      params: {
+        channel: "slack",
+        message: "deliver to the actual conversation",
+      },
+      toolContext: {
+        currentChannelProvider: "slack",
+        currentChannelId: "agent:main:subagent:worker",
+        currentMessagingTarget: "channel:C123",
+      },
+      sessionKey: "agent:main:subagent:worker",
+      dryRun: false,
+    });
+
+    expect(result).toMatchObject({
+      kind: "send",
+      channel: "slack",
+      to: "channel:C123",
+    });
+    expect(firstMockArg(sendText, "send text")).toMatchObject({
+      to: "channel:C123",
+      text: "deliver to the actual conversation",
+    });
+    expect(sendText).toHaveBeenCalledOnce();
+  });
+
   it("carries a prepared conversation-turn id to the channel send", async () => {
     const sendText = registerSlackTextPlugin();
 

--- a/src/infra/outbound/message-action-runner.ts
+++ b/src/infra/outbound/message-action-runner.ts
@@ -80,7 +80,10 @@ import {
   type MessageBroadcastAccountPlan,
   validateExplicitMessageAccountSelection,
 } from "./message-account-selection.js";
-import { normalizeMessageActionInput } from "./message-action-normalization.js";
+import {
+  normalizeMessageActionInput,
+  resolveImplicitMessageActionTarget,
+} from "./message-action-normalization.js";
 import { hasPotentialPluginActionParam } from "./message-action-param-keys.js";
 import {
   collectActionMediaSourceHints,
@@ -802,8 +805,7 @@ function hasPotentialActionTargetInput(
 ): boolean {
   return Boolean(
     hasExplicitSingularTargetParam(params) ||
-    normalizeOptionalString(input.toolContext?.currentChannelId) ||
-    normalizeOptionalString(input.toolContext?.currentMessagingTarget) ||
+    resolveImplicitMessageActionTarget(input.toolContext) ||
     hasPotentialPluginActionParam(params),
   );
 }


### PR DESCRIPTION
Closes #114159

## What Problem This Solves

Fixes an issue where users relying on Discord or another messaging channel for subagent, cron, or autonomous replies could see messages dead-lettered or delivered to an internal session identity instead of their actual channel. A session-shaped current channel could also hide a valid current conversation target.

## Why This Change Was Made

Infer outbound destinations only from actual conversation targets. Reuse the canonical agent-session parser at both message-action normalization and the pre-discovery target gate, skip bare and channel-wrapped internal sessions, keep searching for a real current messaging target, and leave every explicitly supplied destination unchanged. This is a provider-neutral core fix; it changes no channel plugin, configuration, authentication, schema, or Discord target grammar.

## User Impact

Subagent, cron, and autonomous messages use the real current conversation when available. When no channel destination exists, message sending fails immediately with the existing actionable target-required error instead of discovering a plugin, making a provider request, or producing a dead-letter.

## Evidence

- Current-main negative control: [Testbox run 30425768538](https://github.com/openclaw/openclaw/actions/runs/30425768538) reproduces all 9 original regressions, including a real registered outbound adapter accepting the channel-wrapped session key.
- Exact rebased head `faf0ded0d561890f404d5cbd7a713a0627c86823`: **495/495 remote tests passed** on Blacksmith Testbox `tbx_01kyp78n6px5kse5n2fbe82ew7`: canonical normalization, real registered outbound send/no-send, agent message tool, gateway send RPC, and actual Discord REST send, outbound adapter, target parser, and channel-action contract suites.
- Exact head: remote `pnpm check:changed` passed, including core and core-test tsgo, changed-file formatting, lint, SDK and plugin boundaries, dependency guards, dead exports, runtime cycles, and state-schema guards.
- Exact head: structured Codex `gpt-5.6-sol` autoreview at `xhigh` completed clean with no accepted/actionable findings.
- AI-assisted and human-reviewed; reporter credit: @coveredbygreco-hub.
