### PR TITLE
fix(sessions): rebase stale explicit parents onto the transcript tail

### DIFF
--- a/src/agents/command/attempt-execution.cli.test.ts
+++ b/src/agents/command/attempt-execution.cli.test.ts
@@ -68,6 +68,9 @@ const providerAuthAliasMocks = vi.hoisted(() => ({
     },
   ),
 }));
+const sessionWriteLockMocks = vi.hoisted(() => ({
+  acquireSessionWriteLock: vi.fn(),
+}));
 vi.mock("../cli-runner.js", () => ({
   runCliAgent: runCliAgentMock,
 }));
@@ -123,6 +126,17 @@ vi.mock("../model-runtime-aliases.js", async () => {
 vi.mock("../embedded-agent.js", () => ({
   runEmbeddedAgent: runEmbeddedAgentMock,
 }));
+
+vi.mock("../session-write-lock.js", async () => {
+  const actual = await vi.importActual<typeof import("../session-write-lock.js")>(
+    "../session-write-lock.js",
+  );
+  sessionWriteLockMocks.acquireSessionWriteLock.mockImplementation(actual.acquireSessionWriteLock);
+  return {
+    ...actual,
+    acquireSessionWriteLock: sessionWriteLockMocks.acquireSessionWriteLock,
+  };
+});
 
 function makeCliResult(text: string): EmbeddedAgentRunResult {
   return {
@@ -333,6 +347,7 @@ describe("CLI attempt execution", () => {
     hasClaudeLiveSessionForOwnerMock.mockReturnValue(false);
     providerAuthAliasMocks.resolveProviderAuthAliasMap.mockClear();
     providerAuthAliasMocks.resolveProviderIdForAuth.mockClear();
+    sessionWriteLockMocks.acquireSessionWriteLock.mockClear();
   });
 
   async function writeSessionStoreSeed(sessionStore: Record<string, SessionEntry>): Promise<void> {
@@ -1860,6 +1875,39 @@ describe("CLI attempt execution", () => {
       role: "assistant",
       content: [{ type: "text", text: "runtime answer" }],
     });
+  });
+
+  it("holds the session-key lease for the embedded assistant gap-fill", async () => {
+    const sessionKey = "agent:main:direct:gap-fill-lease";
+    const sessionEntry: SessionEntry = {
+      sessionId: "session-gap-fill-lease",
+      updatedAt: Date.now(),
+    };
+    await writeSessionStoreSeed({ [sessionKey]: sessionEntry });
+    const release = vi.fn();
+    sessionWriteLockMocks.acquireSessionWriteLock.mockResolvedValueOnce({ release });
+
+    await persistCliTurnTranscript({
+      body: "ignored prompt",
+      result: makeCliResult("runtime answer"),
+      sessionId: sessionEntry.sessionId,
+      sessionKey,
+      sessionEntry,
+      storePath,
+      sessionAgentId: "main",
+      sessionCwd: tmpDir,
+      config: {},
+      embeddedAssistantGapFill: true,
+    });
+
+    expect(sessionWriteLockMocks.acquireSessionWriteLock).toHaveBeenCalledOnce();
+    expect(sessionWriteLockMocks.acquireSessionWriteLock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sessionFile: expect.any(String),
+        targetKind: "session-key",
+      }),
+    );
+    expect(release).toHaveBeenCalledOnce();
   });
 
   it("persists a media-only ACP user turn when the reply is empty", async () => {

--- a/src/agents/command/attempt-execution.ts
+++ b/src/agents/command/attempt-execution.ts
@@ -20,6 +20,7 @@ import {
 } from "../../auto-reply/reply/source-turn-id.js";
 import type { ThinkLevel, VerboseLevel } from "../../auto-reply/thinking.js";
 import { persistSessionTranscriptTurn } from "../../config/sessions/session-accessor.js";
+import { acquireOwnedSessionTranscriptWriteLock } from "../../config/sessions/transcript-write-context.js";
 import { readTailAssistantTextFromSessionTranscript } from "../../config/sessions/transcript.js";
 import type { SessionEntry } from "../../config/sessions/types.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
@@ -70,11 +71,16 @@ import { resolveAvailableAgentHarnessPolicy } from "../harness/selection.js";
 import { resolveCliRuntimeExecutionProvider } from "../model-runtime-aliases.js";
 import { isCliProvider } from "../model-selection.js";
 import { resolveOpenAIRuntimeProvider } from "../openai-routing.js";
-import type { AgentRunSessionTarget } from "../run-session-target.js";
+import { resolveAgentRunSessionTarget, type AgentRunSessionTarget } from "../run-session-target.js";
 import { resolveAgentRunAbortLifecycleFields } from "../run-termination.js";
 import { buildAgentRuntimeAuthPlan } from "../runtime-plan/auth.js";
 import type { AgentMessage } from "../runtime/index.js";
 import { withLocalSessionPlacementTurnAdmission } from "../session-placement-admission.js";
+import {
+  acquireSessionWriteLock,
+  resolveSessionWriteLockOptions,
+  resolveSessionWriteLockTargetKey,
+} from "../session-write-lock.js";
 import { buildUsageWithNoCost } from "../stream-message-shared.js";
 import { isSubagentAnnounceCompletionHandoff } from "../subagent-announce-handoff.js";
 import {
@@ -415,30 +421,65 @@ export async function persistCliTurnTranscript(params: {
   const gapFill = params.embeddedAssistantGapFill ?? false;
   const skipUserTurn = gapFill || params.skipUserTurn === true;
 
-  return await persistTextTurnTranscript({
-    body: skipUserTurn ? "" : params.body,
-    transcriptBody: skipUserTurn ? undefined : params.transcriptBody,
-    ...(!skipUserTurn && params.userMessage ? { userMessage: params.userMessage } : {}),
-    finalText: replyText,
+  const persist = async () =>
+    await persistTextTurnTranscript({
+      body: skipUserTurn ? "" : params.body,
+      transcriptBody: skipUserTurn ? undefined : params.transcriptBody,
+      ...(!skipUserTurn && params.userMessage ? { userMessage: params.userMessage } : {}),
+      finalText: replyText,
+      sessionId: params.sessionId,
+      sessionKey: params.sessionKey,
+      sessionFile: params.sessionFile,
+      sessionEntry: params.sessionEntry,
+      sessionStore: params.sessionStore,
+      storePath: params.storePath,
+      sessionAgentId: params.sessionAgentId,
+      threadId: params.threadId,
+      sessionCwd: params.sessionCwd,
+      config: params.config,
+      embeddedAssistantGapFill: gapFill,
+      assistant: {
+        api: "cli",
+        provider,
+        model,
+        usage: params.result.meta.agentMeta?.usage,
+      },
+      skipAssistantTurn: params.skipAssistantTurn,
+    });
+  if (!gapFill) {
+    return await persist();
+  }
+
+  const sessionTarget = await resolveAgentRunSessionTarget({
+    agentId: params.sessionAgentId,
+    config: params.config,
+    sessionFile: params.sessionFile,
     sessionId: params.sessionId,
     sessionKey: params.sessionKey,
-    sessionFile: params.sessionFile,
-    sessionEntry: params.sessionEntry,
-    sessionStore: params.sessionStore,
-    storePath: params.storePath,
-    sessionAgentId: params.sessionAgentId,
-    threadId: params.threadId,
-    sessionCwd: params.sessionCwd,
-    config: params.config,
-    embeddedAssistantGapFill: gapFill,
-    assistant: {
-      api: "cli",
-      provider,
-      model,
-      usage: params.result.meta.agentMeta?.usage,
+    sessionTarget: {
+      agentId: params.sessionAgentId,
+      sessionId: params.sessionId,
+      sessionKey: params.sessionKey,
+      ...(params.storePath ? { storePath: params.storePath } : {}),
+      ...(params.threadId !== undefined ? { threadId: params.threadId } : {}),
     },
-    skipAssistantTurn: params.skipAssistantTurn,
   });
+  const sessionLock =
+    (await acquireOwnedSessionTranscriptWriteLock({
+      sessionFile: params.sessionFile,
+      sessionKey: params.sessionKey,
+      sessionTarget,
+    })) ??
+    (await acquireSessionWriteLock({
+      sessionFile: resolveSessionWriteLockTargetKey(sessionTarget),
+      targetKind: "session-key",
+      ...resolveSessionWriteLockOptions(params.config),
+    }));
+  try {
+    return await persist();
+  } finally {
+    await sessionLock.release();
+  }
 }
 
 export function runAgentAttempt(params: {

--- a/src/agents/sessions/session-manager-core.ts
+++ b/src/agents/sessions/session-manager-core.ts
@@ -39,6 +39,7 @@ export class SessionManagerCore {
   protected leafId: string | null = null;
   protected appendParentId: string | null = null;
   protected appendMode: "side" | undefined;
+  protected pendingDeliberateAppend = false;
   protected promptReleasedSideBranchParentId: string | null | undefined;
   protected persistenceTarget: SessionManagerPersistenceTarget | undefined;
   protected persistenceHeaderPending = false;
@@ -137,6 +138,7 @@ export class SessionManagerCore {
     this.leafId = null;
     this.appendParentId = null;
     this.appendMode = undefined;
+    this.pendingDeliberateAppend = false;
     this.promptReleasedSideBranchParentId = undefined;
     return this.persistenceTarget ? this.sessionId : undefined;
   }
@@ -192,6 +194,7 @@ export class SessionManagerCore {
     this.leafId = null;
     this.appendParentId = null;
     this.appendMode = undefined;
+    this.pendingDeliberateAppend = false;
     this.promptReleasedSideBranchParentId = undefined;
     let opaqueIndex = 0;
     let latestResetId: string | undefined;
@@ -517,6 +520,7 @@ export class SessionManagerCore {
     this.invalidLeafControlIds.clear();
     this.appendParentId = null;
     this.appendMode = undefined;
+    this.pendingDeliberateAppend = false;
     this.promptReleasedSideBranchParentId = undefined;
   }
 

--- a/src/agents/sessions/session-manager-entries.ts
+++ b/src/agents/sessions/session-manager-entries.ts
@@ -35,7 +35,19 @@ export class SessionManagerEntries extends SessionManagerPersistence {
     if (!isIndexedSessionEntry(canonicalEntry)) {
       throw new Error(`Invalid session transcript entry: ${entry.type}`);
     }
-    this.persist(canonicalEntry, options);
+    const activeBranchAppend =
+      !this.pendingDeliberateAppend &&
+      this.appendMode !== "side" &&
+      !isSessionTranscriptSideAppendEntry(canonicalEntry);
+    const effectiveParentId = this.persist(canonicalEntry, {
+      ...options,
+      ...(activeBranchAppend ? { appendIntent: "active-branch" } : {}),
+    });
+    if (effectiveParentId !== undefined && effectiveParentId !== canonicalEntry.parentId) {
+      this.reloadPersistedTranscript();
+      this.pendingDeliberateAppend = false;
+      return;
+    }
     if (
       !isSessionTranscriptSideAppendEntry(canonicalEntry) &&
       canonicalEntry.parentId === this.appendParentId &&
@@ -46,6 +58,7 @@ export class SessionManagerEntries extends SessionManagerPersistence {
     this.fileEntries.push(canonicalEntry);
     this.byId.set(canonicalEntry.id, canonicalEntry);
     this.appendParentId = canonicalEntry.id;
+    this.pendingDeliberateAppend = false;
     if (isSessionTranscriptSideAppendEntry(canonicalEntry)) {
       this.appendMode = "side";
       this.promptReleasedSideBranchParentId = canonicalEntry.id;
@@ -244,6 +257,7 @@ export class SessionManagerEntries extends SessionManagerPersistence {
     this.appendMode = params.appendMode;
     this.promptReleasedSideBranchParentId =
       params.appendMode === "side" ? params.appendParentId : undefined;
+    this.pendingDeliberateAppend = false;
     return entry;
   }
 
@@ -379,6 +393,7 @@ export class SessionManagerEntries extends SessionManagerPersistence {
     this.appendParentId = branchTargetId;
     this.appendMode = undefined;
     this.promptReleasedSideBranchParentId = undefined;
+    this.pendingDeliberateAppend = true;
   }
 
   resetLeaf(): void {
@@ -386,6 +401,7 @@ export class SessionManagerEntries extends SessionManagerPersistence {
     this.appendParentId = null;
     this.appendMode = undefined;
     this.promptReleasedSideBranchParentId = undefined;
+    this.pendingDeliberateAppend = true;
   }
 
   branchWithSummary(

--- a/src/agents/sessions/session-manager-persistence.ts
+++ b/src/agents/sessions/session-manager-persistence.ts
@@ -128,19 +128,26 @@ export class SessionManagerPersistence extends SessionManagerCore {
     return removedEntries.length;
   }
 
-  protected persistRecord(entry: unknown, options?: AppendPersistenceOptions): void {
+  protected persistRecord(
+    entry: unknown,
+    options?: AppendPersistenceOptions,
+  ): string | null | undefined {
     if (this.persistenceTarget) {
-      this.persistSqliteRecord(entry, options);
+      return this.persistSqliteRecord(entry, options);
     }
+    return undefined;
   }
 
-  persist(entry: SessionEntry, options?: AppendPersistenceOptions): void {
-    this.persistRecord(entry, options);
+  persist(entry: SessionEntry, options?: AppendPersistenceOptions): string | null | undefined {
+    return this.persistRecord(entry, options);
   }
 
-  private persistSqliteRecord(entry: unknown, options?: AppendPersistenceOptions): void {
+  private persistSqliteRecord(
+    entry: unknown,
+    options?: AppendPersistenceOptions,
+  ): string | null | undefined {
     if (!this.persistenceTarget) {
-      return;
+      return undefined;
     }
     const scope = this.persistenceTarget;
     if (this.persistenceHeaderPending) {
@@ -155,16 +162,16 @@ export class SessionManagerPersistence extends SessionManagerCore {
       if (!appendTranscriptEventSync(scope, entry)) {
         throw new Error(`Session transcript leaf control was not persisted: ${leafEntry.id}`);
       }
-      return;
+      return undefined;
     }
     if (!isIndexedSessionEntry(entry)) {
-      return;
+      return undefined;
     }
     if (entry.type !== "message") {
       if (!appendTranscriptEventSync(scope, entry)) {
         throw new Error(`Session transcript entry was not persisted: ${entry.id}`);
       }
-      return;
+      return undefined;
     }
     const appendOptions = {
       cwd: this.cwd,
@@ -174,6 +181,7 @@ export class SessionManagerPersistence extends SessionManagerCore {
       message: entry.message,
       now: Date.parse(entry.timestamp),
       parentId: entry.parentId,
+      ...(options?.appendIntent === "active-branch" ? { appendIntent: options.appendIntent } : {}),
     } satisfies Parameters<typeof appendTranscriptMessageSync>[1];
     const result = appendTranscriptMessageSync(scope, appendOptions);
     if (!result) {
@@ -188,6 +196,10 @@ export class SessionManagerPersistence extends SessionManagerCore {
     ) {
       throw new Error(`Session transcript append was not persisted: ${entry.id}`);
     }
+    if (result.effectiveParentId === undefined) {
+      throw new Error(`Session transcript append parent was not returned: ${entry.id}`);
+    }
+    return result.effectiveParentId;
   }
 
   mergePromptReleasedSessionEntries(

--- a/src/agents/sessions/session-manager-types.ts
+++ b/src/agents/sessions/session-manager-types.ts
@@ -113,6 +113,7 @@ export type SessionEntry =
 export type FileEntry = SessionHeader | SessionEntry;
 
 export type AppendPersistenceOptions = {
+  appendIntent?: "active-branch";
   config?: OpenClawConfig;
   idempotencyLookup?: "scan" | "scan-assistant" | "caller-checked";
   invalidateSerializedPrefixCache?: boolean;

--- a/src/agents/sessions/session-manager.fork-rebase.test.ts
+++ b/src/agents/sessions/session-manager.fork-rebase.test.ts
@@ -1,0 +1,144 @@
+// Fork-regression coverage split from session-manager.test.ts (max-lines).
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  appendTranscriptMessage,
+  loadTranscriptEvents,
+  upsertSessionEntry,
+} from "../../config/sessions/session-accessor.js";
+import { SessionManager, type SessionMessageEntry } from "./session-manager.js";
+
+const tempPaths: string[] = [];
+
+async function makeTempDir(): Promise<string> {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-session-manager-"));
+  tempPaths.push(dir);
+  return dir;
+}
+
+describe("SessionManager stale-parent rebase", () => {
+  it("rebases a stale active append onto the out-of-band transcript tail", async () => {
+    const dir = await makeTempDir();
+    const target = {
+      agentId: "main",
+      sessionId: "stale-active-parent",
+      sessionKey: "agent:main:stale-active-parent",
+      storePath: path.join(dir, "sessions.json"),
+    };
+    await upsertSessionEntry(target, { sessionId: target.sessionId, updatedAt: 1 });
+    const base = await appendTranscriptMessage(target, {
+      eventId: "base",
+      message: { role: "user", content: "base", timestamp: 1 },
+      now: 1,
+    });
+    const manager = SessionManager.open(target, dir);
+    const outOfBand = await appendTranscriptMessage(target, {
+      eventId: "out-of-band",
+      message: { role: "assistant", content: [{ type: "text", text: "late" }], timestamp: 2 },
+      now: 2,
+    });
+
+    const appendedId = manager.appendMessage({ role: "user", content: "next", timestamp: 3 });
+
+    const messages = (
+      (await loadTranscriptEvents(target)) as Array<SessionMessageEntry & { type?: string }>
+    ).filter((entry) => entry.type === "message");
+    expect(messages.map(({ id, parentId }) => ({ id, parentId }))).toEqual([
+      { id: base.messageId, parentId: null },
+      { id: outOfBand.messageId, parentId: base.messageId },
+      { id: appendedId, parentId: outOfBand.messageId },
+    ]);
+    expect(manager.getEntry(appendedId)?.parentId).toBe(outOfBand.messageId);
+    expect(manager.getBranch().map((entry) => entry.id)).toEqual([
+      base.messageId,
+      outOfBand.messageId,
+      appendedId,
+    ]);
+    const replayed = await appendTranscriptMessage(target, {
+      appendIntent: "active-branch",
+      eventId: appendedId,
+      message: { role: "user", content: "next", timestamp: 3 },
+      parentId: base.messageId,
+    });
+    expect(replayed).toMatchObject({
+      appended: false,
+      effectiveParentId: outOfBand.messageId,
+      messageId: appendedId,
+    });
+  });
+
+  it("preserves a deliberate manager branch from an ancestor", async () => {
+    const dir = await makeTempDir();
+    const target = {
+      agentId: "main",
+      sessionId: "deliberate-manager-branch",
+      sessionKey: "agent:main:deliberate-manager-branch",
+      storePath: path.join(dir, "sessions.json"),
+    };
+    await upsertSessionEntry(target, { sessionId: target.sessionId, updatedAt: 1 });
+    const base = await appendTranscriptMessage(target, {
+      eventId: "branch-base",
+      message: { role: "user", content: "base", timestamp: 1 },
+      now: 1,
+    });
+    const oldTail = await appendTranscriptMessage(target, {
+      eventId: "old-tail",
+      message: { role: "assistant", content: [{ type: "text", text: "old" }], timestamp: 2 },
+      now: 2,
+    });
+    const manager = SessionManager.open(target, dir);
+
+    manager.branch(base.messageId);
+    const branchId = manager.appendMessage({ role: "user", content: "retry", timestamp: 3 });
+
+    expect(manager.getEntry(branchId)?.parentId).toBe(base.messageId);
+    expect(manager.getChildren(base.messageId).map((entry) => entry.id)).toEqual([
+      oldTail.messageId,
+      branchId,
+    ]);
+  });
+
+  it("honors an explicit active parent when the tail is not its descendant", async () => {
+    const dir = await makeTempDir();
+    const target = {
+      agentId: "main",
+      sessionId: "unrelated-explicit-parent",
+      sessionKey: "agent:main:unrelated-explicit-parent",
+      storePath: path.join(dir, "sessions.json"),
+    };
+    await upsertSessionEntry(target, { sessionId: target.sessionId, updatedAt: 1 });
+    const firstRoot = await appendTranscriptMessage(target, {
+      eventId: "first-root",
+      message: { role: "user", content: "first", timestamp: 1 },
+      now: 1,
+    });
+    const firstTail = await appendTranscriptMessage(target, {
+      eventId: "first-tail",
+      message: { role: "assistant", content: [{ type: "text", text: "first" }], timestamp: 2 },
+      now: 2,
+    });
+    await appendTranscriptMessage(target, {
+      eventId: "second-root",
+      message: { role: "user", content: "second", timestamp: 3 },
+      now: 3,
+      parentId: null,
+    });
+
+    const branched = await appendTranscriptMessage(target, {
+      appendIntent: "active-branch",
+      eventId: "preserved-branch",
+      message: { role: "user", content: "branch", timestamp: 4 },
+      now: 4,
+      parentId: firstTail.messageId,
+    });
+
+    expect(branched.effectiveParentId).toBe(firstTail.messageId);
+    const branchEntry = (
+      (await loadTranscriptEvents(target)) as Array<{ type?: string; id?: string }>
+    ).find((entry) => entry.type === "message" && entry.id === branched.messageId);
+    expect(branchEntry).toMatchObject({ parentId: firstTail.messageId });
+    expect(firstRoot.messageId).not.toBe(firstTail.messageId);
+  });
+});

--- a/src/agents/sessions/session-manager.ts
+++ b/src/agents/sessions/session-manager.ts
@@ -110,8 +110,11 @@ export class SessionManager extends SessionManagerBranching {
     return super.removeTrailingEntries(predicate, options);
   }
 
-  override persist(entry: SessionEntry, options?: AppendPersistenceOptions): void {
-    super.persist(entry, options);
+  override persist(
+    entry: SessionEntry,
+    options?: AppendPersistenceOptions,
+  ): string | null | undefined {
+    return super.persist(entry, options);
   }
 
   override mergePromptReleasedSessionEntries(

--- a/src/config/sessions/session-accessor.sqlite-contract.ts
+++ b/src/config/sessions/session-accessor.sqlite-contract.ts
@@ -102,6 +102,7 @@ export type {
 } from "./session-accessor.types.js";
 
 export type TranscriptMessageAppendOptions<TMessage> = {
+  appendIntent?: "active-branch";
   config?: OpenClawConfig;
   cwd?: string;
   idempotencyLookup?: "scan" | "scan-assistant" | "caller-checked";
@@ -115,6 +116,7 @@ export type TranscriptMessageAppendOptions<TMessage> = {
 
 export type TranscriptMessageAppendResult<TMessage> = {
   appended: boolean;
+  effectiveParentId?: string | null;
   message: TMessage;
   messageId: string;
 };

--- a/src/config/sessions/session-accessor.sqlite-transcript-parent.ts
+++ b/src/config/sessions/session-accessor.sqlite-transcript-parent.ts
@@ -1,0 +1,54 @@
+/** Resolves the effective parent for a transcript message append inside the write transaction. */
+import { executeSqliteQueryTakeFirstSync } from "../../infra/kysely-sync.js";
+import type { OpenClawAgentDatabase } from "../../state/openclaw-agent-db.js";
+import type { TranscriptMessageAppendOptions } from "./session-accessor.sqlite-contract.js";
+import { getSessionKysely } from "./session-accessor.sqlite-scope.js";
+import { readActiveTranscriptAppendParentId } from "./session-accessor.sqlite-transcript-store.js";
+
+export function resolveTranscriptMessageAppendParent<TMessage>(
+  database: OpenClawAgentDatabase,
+  sessionId: string,
+  options: Pick<TranscriptMessageAppendOptions<TMessage>, "appendIntent" | "parentId">,
+): string | null {
+  const tailId = readActiveTranscriptAppendParentId(database, sessionId);
+  if (options.parentId === undefined) {
+    return tailId;
+  }
+  if (options.appendIntent !== "active-branch" || tailId === options.parentId) {
+    return options.parentId;
+  }
+
+  const db = getSessionKysely(database.db);
+  const countRow = executeSqliteQueryTakeFirstSync(
+    database.db,
+    db
+      .selectFrom("transcript_event_identities")
+      .select((expression) => expression.fn.countAll<number | bigint>().as("count"))
+      .where("session_id", "=", sessionId),
+  );
+  const maxAncestors = Number(countRow?.count ?? 0);
+  let ancestorId: string | null = tailId;
+  for (let depth = 0; depth <= maxAncestors; depth += 1) {
+    if (ancestorId === options.parentId) {
+      // Active appends extend the append-only tree even when their manager snapshot is stale.
+      // Rebase only along known ancestry so deliberate branches keep their explicit parent.
+      return tailId;
+    }
+    if (ancestorId === null) {
+      break;
+    }
+    const row = executeSqliteQueryTakeFirstSync(
+      database.db,
+      db
+        .selectFrom("transcript_event_identities")
+        .select("parent_id")
+        .where("session_id", "=", sessionId)
+        .where("event_id", "=", ancestorId),
+    );
+    if (!row) {
+      break;
+    }
+    ancestorId = row.parent_id;
+  }
+  return options.parentId;
+}

--- a/src/config/sessions/session-accessor.sqlite-transcript-store.ts
+++ b/src/config/sessions/session-accessor.sqlite-transcript-store.ts
@@ -475,17 +475,17 @@ export function readTranscriptIdentityByEventId(
   database: OpenClawAgentDatabase,
   sessionId: string,
   eventId: string,
-): { eventId: string; seq: number } | undefined {
+): { eventId: string; parentId: string | null; seq: number } | undefined {
   const db = getSessionKysely(database.db);
   const row = executeSqliteQueryTakeFirstSync(
     database.db,
     db
       .selectFrom("transcript_event_identities")
-      .select(["event_id", "seq"])
+      .select(["event_id", "parent_id", "seq"])
       .where("session_id", "=", sessionId)
       .where("event_id", "=", eventId),
   );
-  return row ? { eventId: row.event_id, seq: row.seq } : undefined;
+  return row ? { eventId: row.event_id, parentId: row.parent_id, seq: row.seq } : undefined;
 }
 
 function readTranscriptIdentityByMessageIdempotencyKey(

--- a/src/config/sessions/session-accessor.sqlite-transcript-write.ts
+++ b/src/config/sessions/session-accessor.sqlite-transcript-write.ts
@@ -42,6 +42,7 @@ import {
   toDatabaseOptions,
   type ResolvedTranscriptScope,
 } from "./session-accessor.sqlite-scope.js";
+import { resolveTranscriptMessageAppendParent } from "./session-accessor.sqlite-transcript-parent.js";
 import { rememberCommittedSqliteTranscriptMessageSequencesInTransaction } from "./session-accessor.sqlite-transcript-sequences.js";
 import {
   advanceTranscriptMutationAtInTransaction,
@@ -51,8 +52,8 @@ import {
 import {
   appendTranscriptEventInTransaction,
   ensureTranscriptHeader,
-  readActiveTranscriptAppendParentId,
   readMessageIdempotencyKey,
+  readTranscriptIdentityByEventId,
   readTranscriptMessageByEventId,
   readTranscriptMessageByScopedIdempotencyKey,
   redactTranscriptMessageForStorage,
@@ -656,6 +657,16 @@ function appendSqliteTranscriptMessageInTransaction<TMessage>(
   resolved: ResolvedTranscriptScope,
   options: TranscriptMessageAppendOptions<TMessage> & { messageAlreadyRedacted?: boolean },
 ): TranscriptMessageAppendResult<TMessage> | undefined {
+  // Idempotent replays return the stored row with its persisted parent so callers
+  // adopt the durable tree instead of re-deriving one from a stale snapshot.
+  const existingAppendResult = (found: { message: unknown; messageId: string }) => ({
+    appended: false as const,
+    effectiveParentId:
+      readTranscriptIdentityByEventId(database, resolved.sessionId, found.messageId)?.parentId ??
+      null,
+    message: found.message as TMessage,
+    messageId: found.messageId,
+  });
   const idempotencyKey = readMessageIdempotencyKey(options.message);
   if (idempotencyKey && options.idempotencyLookup !== "caller-checked") {
     const existing = readTranscriptMessageByScopedIdempotencyKey(
@@ -665,11 +676,7 @@ function appendSqliteTranscriptMessageInTransaction<TMessage>(
       options.idempotencyLookup,
     );
     if (existing) {
-      return {
-        appended: false,
-        message: existing.message as TMessage,
-        messageId: existing.messageId,
-      };
+      return existingAppendResult(existing);
     }
   }
 
@@ -686,10 +693,7 @@ function appendSqliteTranscriptMessageInTransaction<TMessage>(
     ? prepared
     : redactTranscriptMessageForStorage(prepared, options);
   ensureTranscriptHeader(database, resolved, options.cwd, now);
-  const parentId =
-    options.parentId === undefined
-      ? readActiveTranscriptAppendParentId(database, resolved.sessionId)
-      : options.parentId;
+  const parentId = resolveTranscriptMessageAppendParent(database, resolved.sessionId, options);
   const event = {
     type: "message",
     id: messageId,
@@ -710,21 +714,13 @@ function appendSqliteTranscriptMessageInTransaction<TMessage>(
       options.idempotencyLookup,
     );
     if (existing) {
-      return {
-        appended: false,
-        message: existing.message as TMessage,
-        messageId: existing.messageId,
-      };
+      return existingAppendResult(existing);
     }
   }
   if (!appended) {
     const existing = readTranscriptMessageByEventId(database, resolved, messageId);
     if (existing) {
-      return {
-        appended: false,
-        message: existing.message as TMessage,
-        messageId: existing.messageId,
-      };
+      return existingAppendResult(existing);
     }
   }
   if (!appended) {
@@ -732,6 +728,7 @@ function appendSqliteTranscriptMessageInTransaction<TMessage>(
   }
   return {
     appended: true,
+    effectiveParentId: parentId ?? null,
     message: finalMessage,
     messageId,
   };

--- a/src/config/sessions/session-accessor.types.ts
+++ b/src/config/sessions/session-accessor.types.ts
@@ -286,6 +286,8 @@ export type SessionTranscriptVisibleMessageDeltaResult =
   | { kind: "missing" };
 
 export type TranscriptMessageAppendOptions<TMessage> = {
+  /** Rebase a stale explicit parent when the current tail still descends from it. */
+  appendIntent?: "active-branch";
   /** Runtime config used for message redaction and transcript header metadata. */
   config?: OpenClawConfig;
   /** Working directory recorded in a newly created transcript header. */
@@ -313,6 +315,8 @@ export type TranscriptMessageAppendResult<TMessage> = {
   message: TMessage;
   /** Existing or newly generated transcript message id. */
   messageId: string;
+  /** Parent id actually used by the durable transcript append. */
+  effectiveParentId?: string | null;
 };
 
 /** Transcript update fields supplied by callers; the target is resolved here. */


### PR DESCRIPTION
## What Problem This Solves

Concurrent writers can fork the session tree. Each transcript entry names its parent; agent runs stamp parents from an in-memory snapshot, while other writers resolve the parent from the DB tail at write time. One writer — the post-run assistant gap-fill — runs after the run's command-lane slot frees and without the cross-process session-key lease (which compaction dutifully takes), and sessions report themselves idle before that late write lands. So an agent-to-agent announce arriving at a turn boundary starts a new run against a stale snapshot; the late gap-fill extends the tail behind its back; both then append children of the same entry. The conversation splits into a Y, and the losing branch — often the assistant reply the user just saw delivered — becomes unreachable from the active branch: the model's next turn has no memory of it. One gateway process suffices; the trigger population is active chatting plus background subagent announces (#98790's reports).

Closes #98790.

## Why This Change Was Made

Three-part fix at the append-only philosophy's natural seam:

1. **The database refuses stale snapshots** (`src/config/sessions/session-accessor.sqlite-transcript-write.ts`): when an explicit parent arrives for a plain active-branch append and the DB tail has moved, a bounded synchronous ancestry walk inside the write transaction checks whether the tail descends from the claimed parent — if yes, the entry is rebased onto the actual tail (the append extends the chain instead of forking it); if no, the explicit parent is honored unchanged, so deliberate branching (`branch()`, side-appends, reset) keeps working. Idempotent replays return their stored effective parent.
2. **The manager adopts the rebase** (`session-manager-entries.ts`, `session-manager-persistence.ts`): appends are intent-tagged (active-branch vs deliberate via `pendingDeliberateAppend` after `branch()`/`resetLeaf()`), the append result returns the effective parent, and on a rebase the manager reloads from the store instead of diverging further.
3. **The common producer is fenced** (`attempt-execution.ts`): the post-run gap-fill now acquires the session-key write lease exactly like post-run compaction does, released in a finally block.

No schema change; the ancestry walk uses the existing `transcript_event_identities` table with synchronous Kysely queries inside the transaction.

## User Impact

Messages stop silently vanishing from active sessions when subagent announces or inter-session sends race a finishing turn. The failure mode was "agent repeats or contradicts itself because its own last reply fell off the visible branch" — append-only now means the visible branch actually contains everything appended to it.

## Evidence

- `node scripts/run-vitest.mjs` — SessionManager suite 25 passed (new regressions: stale-fork interleaving rebases to a single chain with in-memory adoption; deliberate branches and unrelated tails honored; idempotent replay), CLI attempt-execution suite 73 passed (gap-fill lease acquisition/release).
- Codex-backed autoreview on the commit: clean, no accepted findings (0.89).
- Session-accessor boundary guard and both Knip deadcode scans clean locally.
- Mechanism verified against main before the fix with a fully concrete two-writer interleaving (lock/lane/lease ordering documented in #98790).
