### PR TITLE
fix(ci): grant Telegram QA runtime scratch access

### DIFF
--- a/.github/workflows/openclaw-release-telegram-qa.yml
+++ b/.github/workflows/openclaw-release-telegram-qa.yml
@@ -1235,6 +1235,7 @@ jobs:
           candidate_artifacts_dir="${CANDIDATE_ROOT}/.artifacts"
           sudo install -d -o "$sut_uid" -g "$sut_gid" -m 0700 "$candidate_artifacts_dir"
           [[ "$(stat -c '%F:%a:%u:%g' "$candidate_artifacts_dir")" == "directory:700:${sut_uid}:${sut_gid}" ]]
+          sudo install -d -o "$sut_uid" -g "$sut_gid" -m 0700 "${candidate_artifacts_dir}/qa-runtime"
           evidence_relative=".trusted-qa-evidence/release-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
           evidence_root="${CANDIDATE_ROOT}/${evidence_relative}"
           boundary_evidence_dir="${evidence_root}/process-boundary"


### PR DESCRIPTION
## What Problem This Solves

Resolves the full-release Telegram lane failure for frozen candidates: the isolated SUT could not traverse its pre-existing `.artifacts/qa-runtime` staging directory, so it failed with `EACCES` before scenarios ran.

## Why This Change Was Made

The trusted workflow continues to make the candidate tree read-only, but explicitly grants the SUT ownership of the one documented QA runtime scratch subtree. The regression test executes that workflow section against a root-owned legacy candidate layout.

## User Impact

Release validation can exercise frozen extended-stable candidates without weakening candidate isolation.

## Evidence

- Failure: https://github.com/openclaw/openclaw/actions/runs/30426450236/job/90494382725
- Focused behavioral workflow test added; formatting and autoreview completed locally.
- CI pending.