### PR TITLE
fix(qa-matrix): read account state from SQLite

### DIFF
--- a/extensions/matrix/src/matrix/monitor/inbound-dedupe.ts
+++ b/extensions/matrix/src/matrix/monitor/inbound-dedupe.ts
@@ -116,12 +116,21 @@ function pruneSeenEvents(params: {
   }
 }
 
-function createInboundDedupeStore(params: { env?: NodeJS.ProcessEnv; stateDir?: string }) {
-  return getMatrixRuntime().state.openKeyedStore<StoredMatrixInboundDedupeEntry>({
+export function openMatrixInboundDedupeStoreOptions(params: {
+  env?: NodeJS.ProcessEnv;
+  stateDir?: string;
+}) {
+  return {
     namespace: INBOUND_DEDUPE_NAMESPACE,
     maxEntries: DEFAULT_MAX_ENTRIES,
     env: resolveMatrixSqliteStateEnv(params),
-  });
+  };
+}
+
+function createInboundDedupeStore(params: { env?: NodeJS.ProcessEnv; stateDir?: string }) {
+  return getMatrixRuntime().state.openKeyedStore<StoredMatrixInboundDedupeEntry>(
+    openMatrixInboundDedupeStoreOptions(params),
+  );
 }
 
 function createInboundDedupeMigrationStore(params: { env?: NodeJS.ProcessEnv; stateDir?: string }) {

--- a/extensions/matrix/test-api.ts
+++ b/extensions/matrix/test-api.ts
@@ -5,6 +5,12 @@ export {
   openMatrixIdbSnapshotStoreOptions,
   openMatrixRecoveryKeyStoreOptions,
 } from "./src/matrix/crypto-state-store.js";
+export {
+  normalizeMatrixStorageMetadata,
+  openMatrixStorageMetaStoreOptions,
+} from "./src/matrix/client/storage.js";
+export type { MatrixStorageMetadata } from "./src/matrix/client/storage.js";
+export { openMatrixInboundDedupeStoreOptions } from "./src/matrix/monitor/inbound-dedupe.js";
 export type {
   EncryptedFile,
   MatrixDeviceVerificationStatus,

--- a/extensions/qa-matrix/src/runners/contract/scenario-runtime-e2ee-destructive.test.ts
+++ b/extensions/qa-matrix/src/runners/contract/scenario-runtime-e2ee-destructive.test.ts
@@ -1,0 +1,61 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import {
+  createPluginStateSyncKeyedStoreForTests,
+  resetPluginStateStoreForTests,
+} from "openclaw/plugin-sdk/plugin-state-test-runtime";
+import { afterEach, describe, expect, it } from "vitest";
+import { testing } from "./scenario-runtime-e2ee-destructive.js";
+
+const storageMetadataRuntime = {
+  normalizeMatrixStorageMetadata(value: unknown) {
+    if (!value || typeof value !== "object") {
+      return null;
+    }
+    const metadata = value as { deviceId?: unknown; userId?: unknown };
+    return {
+      ...(typeof metadata.deviceId === "string" ? { deviceId: metadata.deviceId } : {}),
+      ...(typeof metadata.userId === "string" ? { userId: metadata.userId } : {}),
+    };
+  },
+  openMatrixStorageMetaStoreOptions(storageRootDir: string) {
+    return {
+      namespace: "storage-meta",
+      maxEntries: 10,
+      env: { ...process.env, OPENCLAW_STATE_DIR: storageRootDir },
+    };
+  },
+};
+
+describe("Matrix destructive E2EE storage discovery", () => {
+  const tempDirs: string[] = [];
+
+  afterEach(async () => {
+    resetPluginStateStoreForTests();
+    await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { force: true, recursive: true })));
+  });
+
+  it("finds account metadata stored in account-local SQLite", async () => {
+    const stateDir = await mkdtemp(path.join(os.tmpdir(), "matrix-qa-storage-"));
+    tempDirs.push(stateDir);
+    const accountRoot = path.join(stateDir, "matrix", "accounts", "stored-key", "server", "token");
+    createPluginStateSyncKeyedStoreForTests(
+      "matrix",
+      storageMetadataRuntime.openMatrixStorageMetaStoreOptions(accountRoot),
+    ).register("current", {
+      deviceId: "DEVICE",
+      userId: "@owner:matrix-qa.test",
+    });
+    resetPluginStateStoreForTests();
+
+    await expect(
+      testing.findMatrixQaCliAccountRoot({
+        deviceId: "DEVICE",
+        runtime: { stateDir },
+        storageMetadataRuntime,
+        userId: "@owner:matrix-qa.test",
+      }),
+    ).resolves.toBe(accountRoot);
+  });
+});

--- a/extensions/qa-matrix/src/runners/contract/scenario-runtime-e2ee-destructive.ts
+++ b/extensions/qa-matrix/src/runners/contract/scenario-runtime-e2ee-destructive.ts
@@ -1,6 +1,6 @@
 // Qa Matrix plugin module implements scenario runtime e2ee destructive behavior.
 import { randomUUID } from "node:crypto";
-import { mkdir, readdir, readFile, rm, writeFile } from "node:fs/promises";
+import { access, mkdir, readdir, readFile, rm, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { setTimeout as sleep } from "node:timers/promises";
 import type { OpenKeyedStoreOptions } from "openclaw/plugin-sdk/plugin-state-runtime";
@@ -46,6 +46,11 @@ import {
 import type { MatrixQaScenarioExecution } from "./scenario-types.js";
 
 type MatrixQaCliRuntime = Awaited<ReturnType<typeof createMatrixQaOpenClawCliRuntime>>;
+
+type MatrixQaStorageMetadataRuntime = Pick<
+  Awaited<ReturnType<typeof loadMatrixQaE2eeRuntime>>,
+  "normalizeMatrixStorageMetadata" | "openMatrixStorageMetaStoreOptions"
+>;
 
 type MatrixQaCliBackupStatus = {
   backup?: {
@@ -503,24 +508,59 @@ async function findFilesByName(params: { filename: string; rootDir: string }): P
 
 async function findMatrixQaCliAccountRoot(params: {
   deviceId: string;
-  runtime: MatrixQaCliRuntime;
+  runtime: Pick<MatrixQaCliRuntime, "stateDir">;
+  storageMetadataRuntime?: MatrixQaStorageMetadataRuntime;
   userId: string;
 }) {
-  const metadataPaths = await findFilesByName({
+  const storageMetadataRuntime = params.storageMetadataRuntime ?? (await loadMatrixQaE2eeRuntime());
+  const sqlitePaths = await findFilesByName({
+    filename: "openclaw.sqlite",
+    rootDir: params.runtime.stateDir,
+  });
+  const legacyMetadataPaths = await findFilesByName({
     filename: "storage-meta.json",
     rootDir: params.runtime.stateDir,
   });
-  for (const metadataPath of metadataPaths) {
+  // Current account metadata lives in account-local SQLite. Keep legacy JSON
+  // discovery for older tagged fixtures without making it the canonical path.
+  const accountRoots = new Set(
+    sqlitePaths
+      .filter((sqlitePath) => path.basename(path.dirname(sqlitePath)) === "state")
+      .map((sqlitePath) => path.dirname(path.dirname(sqlitePath))),
+  );
+  for (const metadataPath of legacyMetadataPaths) {
+    accountRoots.add(path.dirname(metadataPath));
+  }
+  for (const accountRoot of [...accountRoots].toSorted()) {
+    let metadata: { deviceId?: unknown; userId?: unknown } | null = null;
     try {
-      const metadata = JSON.parse(await readFile(metadataPath, "utf8")) as {
-        deviceId?: unknown;
-        userId?: unknown;
-      };
-      if (metadata.userId === params.userId && metadata.deviceId === params.deviceId) {
-        return path.dirname(metadataPath);
+      await access(path.join(accountRoot, "state", "openclaw.sqlite"));
+      try {
+        const store = createPluginStateSyncKeyedStoreForTests<unknown>(
+          "matrix",
+          storageMetadataRuntime.openMatrixStorageMetaStoreOptions(accountRoot),
+        );
+        metadata = storageMetadataRuntime.normalizeMatrixStorageMetadata(store.lookup("current"));
+      } finally {
+        resetPluginStateStoreForTests();
       }
     } catch {
-      continue;
+      // Fall through to the legacy sidecar for pre-SQLite fixtures.
+    }
+    if (!metadata) {
+      try {
+        metadata = JSON.parse(
+          await readFile(path.join(accountRoot, "storage-meta.json"), "utf8"),
+        ) as {
+          deviceId?: unknown;
+          userId?: unknown;
+        };
+      } catch {
+        continue;
+      }
+    }
+    if (metadata.userId === params.userId && metadata.deviceId === params.deviceId) {
+      return accountRoot;
     }
   }
   throw new Error(`Matrix CLI account storage root was not created for ${params.userId}`);
@@ -1685,3 +1725,7 @@ export async function runMatrixQaE2eeHistoryExistsBackupEmptyScenario(
     await cleanupMatrixQaTempDevices(setup.owner, [device.deviceId]);
   }
 }
+
+export const testing = {
+  findMatrixQaCliAccountRoot,
+};

--- a/extensions/qa-matrix/src/runners/contract/scenario-runtime-state-files.test.ts
+++ b/extensions/qa-matrix/src/runners/contract/scenario-runtime-state-files.test.ts
@@ -1,0 +1,69 @@
+import { createHash } from "node:crypto";
+import { mkdtemp, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import {
+  createPluginStateSyncKeyedStoreForTests,
+  resetPluginStateStoreForTests,
+} from "openclaw/plugin-sdk/plugin-state-test-runtime";
+import { afterEach, describe, expect, it } from "vitest";
+import type { MatrixQaScenarioContext } from "./scenario-runtime-shared.js";
+import { waitForMatrixInboundDedupeEntry } from "./scenario-runtime-state-files.js";
+
+const dedupeStoreRuntime = {
+  openMatrixInboundDedupeStoreOptions(params: { stateDir?: string }) {
+    return {
+      namespace: "inbound-dedupe",
+      maxEntries: 20_000,
+      env: { ...process.env, OPENCLAW_STATE_DIR: params.stateDir },
+    };
+  },
+};
+
+function buildDedupeKey(params: { accountId: string; eventId: string; roomId: string }) {
+  return `${params.accountId}:${createHash("sha256")
+    .update(params.accountId)
+    .update("\0")
+    .update(params.roomId)
+    .update("\0")
+    .update(params.eventId)
+    .digest("hex")}`;
+}
+
+describe("Matrix QA persisted state probes", () => {
+  const tempDirs: string[] = [];
+
+  afterEach(async () => {
+    resetPluginStateStoreForTests();
+    await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { force: true, recursive: true })));
+  });
+
+  it("observes inbound dedupe entries through the canonical plugin-state store", async () => {
+    const stateDir = await mkdtemp(path.join(os.tmpdir(), "matrix-qa-dedupe-"));
+    tempDirs.push(stateDir);
+    const accountRoot = path.join(stateDir, "matrix", "accounts", "sut", "server", "token");
+    const accountId = "sut";
+    const eventId = "$event";
+    const roomId = "!room:matrix-qa.test";
+    const options = dedupeStoreRuntime.openMatrixInboundDedupeStoreOptions({
+      stateDir: accountRoot,
+    });
+    const runtimeAccountId = "runtime-default";
+    createPluginStateSyncKeyedStoreForTests("matrix", options).register(
+      buildDedupeKey({ accountId: runtimeAccountId, eventId, roomId }),
+      { eventId, roomId, ts: Date.now() },
+    );
+    resetPluginStateStoreForTests();
+
+    await expect(
+      waitForMatrixInboundDedupeEntry({
+        context: { sutAccountId: accountId } as MatrixQaScenarioContext,
+        dedupeStoreRuntime,
+        eventId,
+        roomId,
+        stateDir,
+        timeoutMs: 1_000,
+      }),
+    ).resolves.toBe(path.join(accountRoot, "state", "openclaw.sqlite"));
+  });
+});

--- a/extensions/qa-matrix/src/runners/contract/scenario-runtime-state-files.ts
+++ b/extensions/qa-matrix/src/runners/contract/scenario-runtime-state-files.ts
@@ -3,19 +3,27 @@ import { createHash, randomUUID } from "node:crypto";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { setTimeout as sleep } from "node:timers/promises";
+import type { OpenKeyedStoreOptions } from "openclaw/plugin-sdk/plugin-state-runtime";
 import { isRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
+import { loadMatrixQaE2eeRuntime } from "../../substrate/e2ee-client.js";
 import type { MatrixQaScenarioContext } from "./scenario-runtime-shared.js";
 
 const MATRIX_SYNC_STORE_FILENAME = "bot-storage.json";
 const MATRIX_INBOUND_DEDUPE_FILENAME = "inbound-dedupe.json";
 const MATRIX_PLUGIN_ID = "matrix";
 const MATRIX_SYNC_CACHE_NAMESPACE = "sync-cache";
-const MATRIX_INBOUND_DEDUPE_NAMESPACE = "inbound-dedupe";
 const MATRIX_STATE_POLL_INTERVAL_MS = 100;
 const MATRIX_SYNC_CACHE_MAX_ENTRIES = 20_000;
 const MATRIX_SYNC_CACHE_MAX_CHUNKS = Math.floor((MATRIX_SYNC_CACHE_MAX_ENTRIES - 1) / 2);
 // PluginState serializes this string inside a row object; 24KB leaves room for JSON escaping.
 const MATRIX_SYNC_CACHE_CHUNK_BYTES = 24_000;
+
+type MatrixQaInboundDedupeStoreRuntime = {
+  openMatrixInboundDedupeStoreOptions: (params: {
+    env?: NodeJS.ProcessEnv;
+    stateDir?: string;
+  }) => OpenKeyedStoreOptions;
+};
 
 type MatrixSyncStoreCursor = {
   cursor: string;
@@ -521,6 +529,7 @@ function buildMatrixInboundDedupePluginStateKey(params: {
 
 async function hasPersistedMatrixPluginStateDedupeEntry(params: {
   accountId: string;
+  dedupeStoreRuntime?: MatrixQaInboundDedupeStoreRuntime;
   eventId: string;
   roomId: string;
   stateDir: string;
@@ -530,65 +539,70 @@ async function hasPersistedMatrixPluginStateDedupeEntry(params: {
     eventId: params.eventId,
     roomId: params.roomId,
   });
+  const dedupeStoreRuntime = params.dedupeStoreRuntime ?? (await loadMatrixQaE2eeRuntime());
   const databasePaths = await findFilesByName({
     filename: "openclaw.sqlite",
     rootDir: params.stateDir,
-    maxDepth: 4,
+    maxDepth: 10,
   });
-  if (databasePaths.length === 0) {
-    databasePaths.push(path.join(params.stateDir, "state", "openclaw.sqlite"));
-  }
-  const now = Date.now();
-  const isExpectedValue = (raw: unknown) => {
-    if (typeof raw !== "string") {
-      return false;
-    }
-    try {
-      const parsed = JSON.parse(raw) as unknown;
-      return (
-        isRecord(parsed) && parsed.roomId === params.roomId && parsed.eventId === params.eventId
-      );
-    } catch {
-      return false;
-    }
-  };
+  let sqlite: typeof import("node:sqlite");
   try {
-    const sqlite = await import("node:sqlite");
-    for (const databasePath of databasePaths) {
-      try {
-        await fs.access(databasePath);
-        const db = new sqlite.DatabaseSync(databasePath, { readOnly: true });
-        try {
-          const rows = db
-            .prepare(
-              `SELECT entry_key AS entryKey, value_json AS valueJson
-                 FROM plugin_state_entries
-                WHERE plugin_id = ?
-                  AND namespace = ?
-                  AND (expires_at IS NULL OR expires_at > ?)`,
-            )
-            .all(MATRIX_PLUGIN_ID, MATRIX_INBOUND_DEDUPE_NAMESPACE, now) as Array<{
-            entryKey?: unknown;
-            valueJson?: unknown;
-          }>;
-          if (rows.some((row) => row.entryKey === entryKey || isExpectedValue(row.valueJson))) {
-            return databasePath;
-          }
-        } finally {
-          db.close();
-        }
-      } catch {
-        continue;
-      }
-    }
+    sqlite = await import("node:sqlite");
   } catch {
     return null;
+  }
+  for (const databasePath of databasePaths) {
+    try {
+      const storageRootDir = path.dirname(path.dirname(databasePath));
+      const options = dedupeStoreRuntime.openMatrixInboundDedupeStoreOptions({
+        stateDir: storageRootDir,
+      });
+      const stateRoot = options.env?.OPENCLAW_STATE_DIR?.trim();
+      if (
+        !stateRoot ||
+        path.resolve(stateRoot, "state", "openclaw.sqlite") !== path.resolve(databasePath)
+      ) {
+        continue;
+      }
+      const db = new sqlite.DatabaseSync(databasePath, { readOnly: true });
+      try {
+        const rows = db
+          .prepare(
+            `SELECT entry_key AS entryKey, value_json AS valueJson
+               FROM plugin_state_entries
+              WHERE plugin_id = ?
+                AND namespace = ?
+                AND (expires_at IS NULL OR expires_at > ?)`,
+          )
+          .all(MATRIX_PLUGIN_ID, options.namespace, Date.now()) as Array<{
+          entryKey?: unknown;
+          valueJson?: unknown;
+        }>;
+        const matched = rows.some((row) => {
+          if (row.entryKey === entryKey) {
+            return true;
+          }
+          const entry = parsePluginStateJson(row.valueJson);
+          return (
+            isRecord(entry) && entry.roomId === params.roomId && entry.eventId === params.eventId
+          );
+        });
+        if (matched) {
+          return databasePath;
+        }
+      } finally {
+        db.close();
+      }
+    } catch {
+      continue;
+    }
   }
   return null;
 }
 
 export async function waitForMatrixInboundDedupeEntry(params: {
   context: MatrixQaScenarioContext;
+  dedupeStoreRuntime?: MatrixQaInboundDedupeStoreRuntime;
   eventId: string;
   roomId: string;
   stateDir: string;
@@ -598,6 +612,7 @@ export async function waitForMatrixInboundDedupeEntry(params: {
   while (Date.now() - startedAt < params.timeoutMs) {
     const sqlitePath = await hasPersistedMatrixPluginStateDedupeEntry({
       accountId: params.context.sutAccountId ?? "sut",
+      ...(params.dedupeStoreRuntime ? { dedupeStoreRuntime: params.dedupeStoreRuntime } : {}),
       eventId: params.eventId,
       roomId: params.roomId,
       stateDir: params.stateDir,

--- a/extensions/qa-matrix/src/runners/contract/scenarios.test.ts
+++ b/extensions/qa-matrix/src/runners/contract/scenarios.test.ts
@@ -7,12 +7,17 @@ import { describe, expect, it, beforeEach, vi } from "vitest";
 const { createMatrixQaClient } = vi.hoisted(() => ({
   createMatrixQaClient: vi.fn(),
 }));
-const { createMatrixQaE2eeScenarioClient, runMatrixQaE2eeBootstrap, startMatrixQaFaultProxy } =
-  vi.hoisted(() => ({
-    createMatrixQaE2eeScenarioClient: vi.fn(),
-    runMatrixQaE2eeBootstrap: vi.fn(),
-    startMatrixQaFaultProxy: vi.fn(),
-  }));
+const {
+  createMatrixQaE2eeScenarioClient,
+  loadMatrixQaE2eeRuntime,
+  runMatrixQaE2eeBootstrap,
+  startMatrixQaFaultProxy,
+} = vi.hoisted(() => ({
+  createMatrixQaE2eeScenarioClient: vi.fn(),
+  loadMatrixQaE2eeRuntime: vi.fn(),
+  runMatrixQaE2eeBootstrap: vi.fn(),
+  startMatrixQaFaultProxy: vi.fn(),
+}));
 const {
   formatMatrixQaCliCommand,
   redactMatrixQaCliOutput,
@@ -32,6 +37,7 @@ vi.mock("../../substrate/client.js", () => ({
 }));
 vi.mock("../../substrate/e2ee-client.js", () => ({
   createMatrixQaE2eeScenarioClient,
+  loadMatrixQaE2eeRuntime,
   runMatrixQaE2eeBootstrap,
 }));
 vi.mock("../../substrate/fault-proxy.js", () => ({
@@ -364,6 +370,13 @@ describe("matrix live qa scenarios", () => {
   beforeEach(() => {
     createMatrixQaClient.mockReset();
     createMatrixQaE2eeScenarioClient.mockReset();
+    loadMatrixQaE2eeRuntime.mockReset().mockResolvedValue({
+      openMatrixInboundDedupeStoreOptions: ({ stateDir }: { stateDir?: string }) => ({
+        namespace: "inbound-dedupe",
+        maxEntries: 20_000,
+        env: { ...process.env, OPENCLAW_STATE_DIR: stateDir },
+      }),
+    });
     runMatrixQaE2eeBootstrap.mockReset();
     runMatrixQaOpenClawCli.mockReset();
     startMatrixQaOpenClawCli.mockReset();
@@ -2058,7 +2071,7 @@ describe("matrix live qa scenarios", () => {
             accountId: "runtime-default",
             eventId: "$first-trigger",
             roomId: staleSyncRoomId,
-            stateRoot,
+            stateRoot: accountDir,
           });
         }
         return {


### PR DESCRIPTION
## What Problem This Solves

Resolves the 2026.6.34 full-release Matrix E2EE failures where destructive recovery scenarios could not find the CLI account state after the runtime moved metadata from `storage-meta.json` to account-local SQLite.

## Why This Change Was Made

This is the exact backport of the upstream SQLite-state repair (`49965ca381c`). It makes QA discovery read the canonical SQLite metadata while retaining legacy fixture discovery.

## User Impact

Extended-stable release validation covers the Matrix recovery scenarios against the actual persisted-state contract.

## Evidence

- Failure artifact: https://github.com/openclaw/openclaw/actions/runs/30426414176/job/90494171430
- Targeted upstream regression tests are included in the exact backport.
- Formatting and autoreview completed locally; CI pending.