### PR TITLE
fix: make Codex harness caching and benchmark parity exact

### DIFF
--- a/extensions/codex/src/app-server/thread-lifecycle-run.ts
+++ b/extensions/codex/src/app-server/thread-lifecycle-run.ts
@@ -567,6 +567,7 @@ export async function startOrResumeThread(
           dynamicToolsFingerprint,
           hostSystemAgentActive,
           lifecycleTiming,
+          nativeSkillIsolation,
           releaseConsumedThread: (threadId, cause) =>
             releaseCodexConsumedLiveThread({
               client: params.client,

--- a/extensions/codex/src/app-server/thread-lifecycle-warm.ts
+++ b/extensions/codex/src/app-server/thread-lifecycle-warm.ts
@@ -6,6 +6,7 @@ import {
 } from "./attempt-client-cleanup.js";
 import { consumeCodexAppServerLiveThread } from "./client-runtime.js";
 import type { CodexAppServerClient } from "./client.js";
+import { applyCodexNativeSkillIsolation } from "./native-skill-isolation.js";
 import {
   buildCodexPluginAppsConfigPatchFromPolicyContext,
   mergeCodexThreadConfigs,
@@ -40,6 +41,7 @@ type CodexWarmThreadReuseParams = {
   dynamicToolsFingerprint: string;
   hostSystemAgentActive: boolean;
   lifecycleTiming: CodexThreadLifecycleTimingTracker;
+  nativeSkillIsolation?: Parameters<typeof applyCodexNativeSkillIsolation>[1];
   releaseConsumedThread: (threadId: string, cause?: unknown) => Promise<void>;
   ringZeroActive: boolean;
   ringZeroInheritedMcpServerNames: string[];
@@ -123,6 +125,7 @@ export async function tryReuseCodexLiveThread(
     dynamicToolsFingerprint,
     hostSystemAgentActive,
     lifecycleTiming,
+    nativeSkillIsolation,
     releaseConsumedThread,
     ringZeroActive,
     ringZeroInheritedMcpServerNames,
@@ -171,7 +174,7 @@ export async function tryReuseCodexLiveThread(
       appServer: params.appServer,
       dynamicTools: params.dynamicTools,
       developerInstructions: params.developerInstructions,
-      config: resumeConfig,
+      config: applyCodexNativeSkillIsolation(resumeConfig, nativeSkillIsolation),
       nativeCodeModeEnabled: params.nativeCodeModeEnabled,
       nativeProviderWebSearchSupport: params.nativeProviderWebSearchSupport,
       nativeCodeModeOnlyEnabled: params.nativeCodeModeOnlyEnabled,

--- a/extensions/codex/src/app-server/thread-lifecycle.binding.test.ts
+++ b/extensions/codex/src/app-server/thread-lifecycle.binding.test.ts
@@ -1,4 +1,5 @@
 // Codex tests cover thread lifecycle.binding plugin behavior.
+import fs from "node:fs/promises";
 import path from "node:path";
 import { describe, expect, it, vi } from "vitest";
 import {
@@ -389,6 +390,80 @@ describe("Codex app-server thread lifecycle bindings", () => {
     expect(buildFinalConfigPatch).toHaveBeenNthCalledWith(2, {
       action: "resume",
       binding: expect.objectContaining({ threadId: "thread-warm" }),
+    });
+  });
+
+  it("reuses an isolated retained thread without dropping native skill isolation", async () => {
+    vi.stubEnv("HOME", tempDir);
+    vi.stubEnv("OPENCLAW_STATE_DIR", path.join(tempDir, "isolated-state"));
+    const sessionFile = path.join(tempDir, "warm-isolated-session.jsonl");
+    const workspaceDir = path.join(tempDir, "warm-isolated-workspace");
+    const personalSkill = path.join(tempDir, ".claude", "skills", "personal", "SKILL.md");
+    await fs.mkdir(path.dirname(personalSkill), { recursive: true });
+    await fs.writeFile(personalSkill, "personal");
+    const personalSkillRealPath = await fs.realpath(personalSkill);
+    const request = vi.fn(async (method: string, _requestParams?: unknown) => {
+      if (method === "skills/list") {
+        return {
+          data: [
+            {
+              cwd: workspaceDir,
+              errors: [],
+              skills: [
+                {
+                  name: "personal",
+                  description: "Personal skill",
+                  path: personalSkillRealPath,
+                  scope: "user",
+                  enabled: true,
+                },
+              ],
+            },
+          ],
+        };
+      }
+      if (method === "thread/start") {
+        return threadStartResult("thread-warm-isolated");
+      }
+      throw new Error(`unexpected method: ${method}`);
+    });
+    const client = {
+      getInstanceId: () => "client-warm-isolated",
+      request,
+      addNotificationHandler: () => () => undefined,
+      addRequestHandler: () => () => undefined,
+    } as never;
+    ensureCodexAppServerClientRuntime(client, { agentDir: workspaceDir });
+    const common = {
+      client,
+      params: createParams(sessionFile, workspaceDir),
+      cwd: workspaceDir,
+      dynamicTools: [],
+      appServer: createThreadLifecycleAppServerOptions(),
+      userMcpServersEnabled: false,
+    };
+
+    const started = await startOrResumeThread(common);
+    await expect(
+      retainCodexAppServerLiveThread(
+        client,
+        started.threadId,
+        undefined,
+        started.liveThreadConfigFingerprint,
+      ),
+    ).resolves.toEqual({});
+    await expect(startOrResumeThread(common)).resolves.toMatchObject({
+      threadId: "thread-warm-isolated",
+      lifecycle: { action: "resumed" },
+    });
+
+    expect(request.mock.calls.map(([method]) => method)).toEqual(["skills/list", "thread/start"]);
+    const startRequest = request.mock.calls.find(([method]) => method === "thread/start")?.[1];
+    expect(startRequest).toMatchObject({
+      config: {
+        "skills.include_instructions": false,
+        "skills.config": [{ path: personalSkillRealPath, enabled: false }],
+      },
     });
   });
 

--- a/extensions/codex/src/app-server/thread-lifecycle.test.ts
+++ b/extensions/codex/src/app-server/thread-lifecycle.test.ts
@@ -8,7 +8,10 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { CodexAppServerRpcError } from "./client.js";
 import { buildCodexAppServerConnectionFingerprint } from "./plugin-app-cache-key.js";
 import type { CodexPluginThreadConfig } from "./plugin-thread-config.js";
-import { CODEX_OPENCLAW_DIRECT_DYNAMIC_TOOL_NAMESPACE } from "./protocol.js";
+import {
+  CODEX_OPENCLAW_DIRECT_DYNAMIC_TOOL_NAMESPACE,
+  type CodexDynamicToolFunctionSpec,
+} from "./protocol.js";
 import {
   sessionBindingIdentity,
   type CodexAppServerBindingStore,
@@ -559,6 +562,41 @@ describe("Codex app-server native code mode config", () => {
     expect(withWrongNamespace).not.toContain("native `wait_agent`");
   });
 
+  it.each([
+    { namespace: "openclaw_direct", exposesNativeYield: true },
+    { namespace: "openclaw", exposesNativeYield: false },
+  ])(
+    "materializes the $namespace native-yield namespace exactly once",
+    ({ namespace, exposesNativeYield }) => {
+      let namespaceReads = 0;
+      const yieldTool = {
+        type: "function" as const,
+        name: "sessions_yield",
+        description: "End the current turn",
+        inputSchema: { type: "object" },
+      };
+
+      const instructions = buildDeveloperInstructions(createAttemptParams({ provider: "openai" }), {
+        dynamicTools: [
+          yieldTool,
+          {
+            type: "namespace",
+            name: namespace,
+            description: "",
+            get tools() {
+              namespaceReads += 1;
+              return [yieldTool];
+            },
+          },
+        ],
+      });
+
+      expect(namespaceReads).toBe(1);
+      expect(instructions.includes("`openclaw_direct.sessions_yield`")).toBe(exposesNativeYield);
+      expect(instructions.includes("native `wait_agent`")).toBe(exposesNativeYield);
+    },
+  );
+
   it("summarizes deferred dynamic tool names in developer instructions", () => {
     const instructions = buildDeveloperInstructions(createAttemptParams({ provider: "openai" }), {
       dynamicTools: [
@@ -597,6 +635,64 @@ describe("Codex app-server native code mode config", () => {
     );
     expect(instructions).toContain("Use `tool_search` to load exact callable specs before use.");
     expect(instructions).not.toContain("message,");
+  });
+
+  it("materializes namespaced prompt tools once while preserving all guidance", () => {
+    const params = createAttemptParams({ provider: "openai" });
+    params.sourceReplyDeliveryMode = "message_tool_only";
+    let namespaceReads = 0;
+    const tools: CodexDynamicToolFunctionSpec[] = [
+      {
+        type: "function" as const,
+        name: "zeta_tool",
+        description: "Deferred Zeta tool",
+        inputSchema: { type: "object" },
+        deferLoading: true,
+      },
+      {
+        type: "function" as const,
+        name: "message",
+        description: "Send a source reply",
+        inputSchema: { type: "object" },
+      },
+      {
+        type: "function" as const,
+        name: "skill_workshop",
+        description: "Manage skill proposals",
+        inputSchema: { type: "object" },
+        deferLoading: true,
+      },
+      {
+        type: "function" as const,
+        name: "alpha_tool",
+        description: "Deferred Alpha tool",
+        inputSchema: { type: "object" },
+        deferLoading: true,
+      },
+    ];
+
+    const instructions = buildDeveloperInstructions(params, {
+      dynamicTools: [
+        {
+          type: "namespace",
+          name: "openclaw",
+          description: "",
+          get tools() {
+            namespaceReads += 1;
+            return tools;
+          },
+        },
+      ],
+    });
+
+    expect(namespaceReads).toBe(1);
+    expect(instructions).toContain(
+      "Deferred searchable OpenClaw dynamic tools available: alpha_tool, skill_workshop, zeta_tool.",
+    );
+    expect(instructions).toContain("## Skill Workshop");
+    expect(instructions).toContain("Visible source replies are not automatically delivered");
+    expect(instructions).toContain("Use `message(action=send)`");
+    expect(instructions).not.toContain("`openclaw_direct.sessions_yield`");
   });
 
   it("uses the shared Skill Workshop guidance when skill_workshop is available", () => {

--- a/extensions/codex/src/app-server/thread-prompt.ts
+++ b/extensions/codex/src/app-server/thread-prompt.ts
@@ -6,7 +6,6 @@ import {
 import { listRegisteredPluginAgentPromptGuidance } from "openclaw/plugin-sdk/plugin-runtime";
 import {
   CODEX_OPENCLAW_DIRECT_DYNAMIC_TOOL_NAMESPACE,
-  flattenCodexDynamicToolFunctions,
   type CodexDynamicToolSpec,
 } from "./protocol.js";
 
@@ -14,79 +13,59 @@ export function buildDeveloperInstructions(
   params: EmbeddedRunAttemptParams,
   options: { dynamicTools?: readonly CodexDynamicToolSpec[] } = {},
 ): string {
+  const deferredToolNames = new Set<string>();
+  let hasSkillWorkshop = false;
+  let hasSessionsYield = false;
+  let hasSeenDirectNamespace = false;
+  let messageToolAvailable = options.dynamicTools ? false : params.disableMessageTool !== true;
+  for (const spec of options.dynamicTools ?? []) {
+    const isDirectNamespace =
+      spec.type === "namespace" &&
+      !hasSeenDirectNamespace &&
+      spec.name.trim() === CODEX_OPENCLAW_DIRECT_DYNAMIC_TOOL_NAMESPACE;
+    if (isDirectNamespace) {
+      hasSeenDirectNamespace = true;
+    }
+    for (const tool of spec.type === "namespace" ? spec.tools : [spec]) {
+      const name = tool.name.trim();
+      if (tool.deferLoading === true && name) {
+        deferredToolNames.add(name);
+      }
+      hasSkillWorkshop ||= name === SKILL_WORKSHOP_TOOL_NAME;
+      hasSessionsYield ||= isDirectNamespace && name === "sessions_yield";
+      messageToolAvailable ||= name === "message";
+    }
+  }
   const nativeCommandGuidance = listRegisteredPluginAgentPromptGuidance({
     surface: "codex_app_server",
     includeLegacyGlobalGuidance: false,
   }).join("\n");
   const sections = [
     "You are a personal agent running inside OpenClaw. OpenClaw has dynamic tools for OpenClaw-owned messaging, cron, sessions, media, gateway, and nodes.",
-    buildDeferredDynamicToolManifest(options.dynamicTools),
-    buildSkillWorkshopInstruction(options.dynamicTools),
+    deferredToolNames.size > 0
+      ? `Deferred searchable OpenClaw dynamic tools available: ${[...deferredToolNames]
+          .toSorted((left, right) => left.localeCompare(right))
+          .join(", ")}. Use \`tool_search\` to load exact callable specs before use.`
+      : undefined,
+    hasSkillWorkshop ? buildSkillWorkshopPromptSection().join("\n") : undefined,
     // Codex defers native collab tools behind tool_search on search-capable
     // models (codex-rs spec_plan add_collaboration_tools). Without this hint
     // models cannot see spawn_agent and grab the always-direct sessions_spawn.
     "Use Codex native `spawn_agent` for Codex subagents. `spawn_agent` and the other native collaboration tools may be deferred: when `spawn_agent` is not directly listed, load it with `tool_search` before spawning. Use OpenClaw `sessions_spawn` only for OpenClaw or ACP delegation, never as a substitute for `spawn_agent`.",
-    buildNativeSubagentCompletionInstruction(options.dynamicTools),
-    buildVisibleReplyInstruction(params, options.dynamicTools),
+    hasSessionsYield
+      ? "When a native child's result belongs in a later turn, end the current turn with `openclaw_direct.sessions_yield`; the completion arrives as the next model-visible input. Use native `wait_agent` only for an intentional same-turn wait when the immediate next step is blocked on the child. Never loop-poll for native child completion."
+      : undefined,
+    buildVisibleReplyInstruction(params, messageToolAvailable),
     nativeCommandGuidance,
     params.extraSystemPrompt,
   ];
   return sections.filter((section) => typeof section === "string" && section.trim()).join("\n\n");
 }
 
-function buildNativeSubagentCompletionInstruction(
-  dynamicTools: readonly CodexDynamicToolSpec[] | undefined,
-): string | undefined {
-  const directNamespace = dynamicTools?.find(
-    (tool) =>
-      tool.type === "namespace" &&
-      tool.name.trim() === CODEX_OPENCLAW_DIRECT_DYNAMIC_TOOL_NAMESPACE,
-  );
-  const hasSessionsYield =
-    directNamespace?.type === "namespace" &&
-    directNamespace.tools.some((tool) => tool.name.trim() === "sessions_yield");
-  if (!hasSessionsYield) {
-    return undefined;
-  }
-  return "When a native child's result belongs in a later turn, end the current turn with `openclaw_direct.sessions_yield`; the completion arrives as the next model-visible input. Use native `wait_agent` only for an intentional same-turn wait when the immediate next step is blocked on the child. Never loop-poll for native child completion.";
-}
-
-function buildDeferredDynamicToolManifest(
-  dynamicTools: readonly CodexDynamicToolSpec[] | undefined,
-): string | undefined {
-  const deferredToolNames = [
-    ...new Set(
-      flattenCodexDynamicToolFunctions(dynamicTools)
-        .filter((tool) => tool.deferLoading === true)
-        .map((tool) => tool.name.trim())
-        .filter(Boolean),
-    ),
-  ].toSorted((left, right) => left.localeCompare(right));
-  if (deferredToolNames.length === 0) {
-    return undefined;
-  }
-  return `Deferred searchable OpenClaw dynamic tools available: ${deferredToolNames.join(", ")}. Use \`tool_search\` to load exact callable specs before use.`;
-}
-
-function buildSkillWorkshopInstruction(
-  dynamicTools: readonly CodexDynamicToolSpec[] | undefined,
-): string | undefined {
-  const hasSkillWorkshop = flattenCodexDynamicToolFunctions(dynamicTools).some(
-    (tool) => tool.name.trim() === SKILL_WORKSHOP_TOOL_NAME,
-  );
-  if (!hasSkillWorkshop) {
-    return undefined;
-  }
-  return buildSkillWorkshopPromptSection().join("\n");
-}
-
 function buildVisibleReplyInstruction(
   params: EmbeddedRunAttemptParams,
-  dynamicTools: readonly CodexDynamicToolSpec[] | undefined,
+  messageToolAvailable: boolean,
 ): string {
-  const messageToolAvailable = dynamicTools
-    ? flattenCodexDynamicToolFunctions(dynamicTools).some((tool) => tool.name.trim() === "message")
-    : params.disableMessageTool !== true;
   if (params.sourceReplyDeliveryMode === "message_tool_only" && messageToolAvailable) {
     return "Visible source replies are not automatically delivered for this run. Use `message(action=send)` for user-visible source-channel output. For progress, set `final=false`. When the message is the completed reply to the current source conversation, set `final=true`; OpenClaw stops after confirming delivery. If `final` is omitted, OpenClaw continues and resolves the latest omitted source reply only when the turn ends successfully. Do not repeat visible message content in your final answer.";
   }

--- a/extensions/codex/src/app-server/transcript-mirror.ts
+++ b/extensions/codex/src/app-server/transcript-mirror.ts
@@ -627,7 +627,7 @@ async function mirror(params: {
         });
         const appended = await transcript.appendMessage({
           message: messageToAppend,
-          idempotencyLookup: idempotencyKey ? "caller-checked" : "scan",
+          idempotencyLookup: idempotencyKey && message.role !== "user" ? "caller-checked" : "scan",
           cwd: params.cwd,
         });
         if (!appended) {
@@ -647,11 +647,13 @@ async function mirror(params: {
           nextUserMessagesPresent.push(appendedMessage);
         }
         nextMessageSeq += 1;
-        nextAppendedUpdates.push({
-          messageId,
-          message: appendedMessage,
-          messageSeq: nextMessageSeq,
-        });
+        if (appended.appended) {
+          nextAppendedUpdates.push({
+            messageId,
+            message: appendedMessage,
+            messageSeq: nextMessageSeq,
+          });
+        }
         if (idempotencyKey) {
           mirrorState.idempotencyKeys.add(idempotencyKey);
         }

--- a/extensions/codex/src/app-server/transcript-mirror.user-idempotency.test.ts
+++ b/extensions/codex/src/app-server/transcript-mirror.user-idempotency.test.ts
@@ -1,0 +1,181 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import type { AgentMessage } from "openclaw/plugin-sdk/agent-harness-runtime";
+import {
+  initializeGlobalHookRunner,
+  resetGlobalHookRunner,
+} from "openclaw/plugin-sdk/hook-runtime";
+import { createMockPluginRegistry } from "openclaw/plugin-sdk/plugin-test-runtime";
+import { upsertSessionEntry } from "openclaw/plugin-sdk/session-store-runtime";
+import {
+  readSessionTranscriptEvents,
+  type SessionTranscriptWriteLockContext,
+} from "openclaw/plugin-sdk/session-transcript-runtime";
+import {
+  castAgentMessage,
+  makeAgentAssistantMessage,
+  makeAgentUserMessage,
+} from "openclaw/plugin-sdk/test-fixtures";
+import { afterEach, expect, it, vi } from "vitest";
+import {
+  attachCodexMirrorAttestation,
+  fingerprintCodexMirrorSourceMessage,
+} from "./transcript-mirror-attestation.js";
+import { codexTranscriptMirrorRuntime } from "./transcript-mirror.js";
+import { attachCodexMirrorIdentity } from "./upstream-prompt-provenance.js";
+
+const transcriptRace = vi.hoisted(() => ({
+  competingMessage: undefined as unknown,
+  lookups: [] as Array<string | undefined>,
+  publish: vi.fn(),
+}));
+
+vi.mock("openclaw/plugin-sdk/session-transcript-runtime", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("openclaw/plugin-sdk/session-transcript-runtime")>();
+  return {
+    ...actual,
+    publishSessionTranscriptUpdateByIdentity: transcriptRace.publish,
+    withSessionTranscriptWriteLock: async (
+      params: Parameters<typeof actual.withSessionTranscriptWriteLock>[0],
+      run: Parameters<typeof actual.withSessionTranscriptWriteLock>[1],
+    ) =>
+      await actual.withSessionTranscriptWriteLock(params, async (locked) => {
+        const competingMessage = transcriptRace.competingMessage;
+        if (!competingMessage) {
+          return await run(locked);
+        }
+        transcriptRace.competingMessage = undefined;
+        const staleEvents = await locked.readEvents();
+        await locked.appendMessage({
+          message: competingMessage as AgentMessage,
+          idempotencyLookup: "scan",
+        });
+        const intercepted: SessionTranscriptWriteLockContext = {
+          ...locked,
+          readEvents: async () => staleEvents,
+          appendMessage: async (options) => {
+            transcriptRace.lookups.push(options.idempotencyLookup);
+            return await locked.appendMessage(options);
+          },
+        };
+        return await run(intercepted);
+      }),
+  };
+});
+
+afterEach(() => {
+  resetGlobalHookRunner();
+  transcriptRace.competingMessage = undefined;
+  transcriptRace.lookups.length = 0;
+  transcriptRace.publish.mockReset();
+});
+
+it("adopts a competing indexed user without duplicating writes or slowing assistant mirrors", async () => {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "codex-mirror-user-race-"));
+  try {
+    const target = {
+      agentId: "main",
+      sessionId: "user-race",
+      sessionKey: "agent:main:user-race",
+      storePath: path.join(root, "openclaw-agent.sqlite"),
+    };
+    await upsertSessionEntry({
+      agentId: target.agentId,
+      sessionKey: target.sessionKey,
+      storePath: target.storePath,
+      entry: {
+        sessionFile: `sqlite:${target.agentId}:${target.sessionId}:${target.storePath}`,
+        sessionId: target.sessionId,
+        updatedAt: 1,
+      },
+    });
+
+    const beforeMessageWrite = vi.fn((...args: unknown[]) => {
+      const event = args[0] as { message: AgentMessage };
+      return {
+        message:
+          event.message.role === "user"
+            ? castAgentMessage({
+                ...event.message,
+                content: [{ type: "text", text: "[redacted by hook]" }],
+              })
+            : event.message,
+      };
+    });
+    initializeGlobalHookRunner(
+      createMockPluginRegistry([{ hookName: "before_message_write", handler: beforeMessageWrite }]),
+    );
+
+    const sourceUser = attachCodexMirrorIdentity(
+      castAgentMessage({
+        ...makeAgentUserMessage({
+          content: [{ type: "text", text: "private user prompt" }],
+          timestamp: 1,
+        }),
+        idempotencyKey: "codex-user-race:prompt",
+      }),
+      "turn-1:prompt",
+    );
+    const userFingerprint = fingerprintCodexMirrorSourceMessage(
+      sourceUser as Extract<AgentMessage, { role: "user" }>,
+    );
+    transcriptRace.competingMessage = attachCodexMirrorAttestation(
+      castAgentMessage({
+        ...sourceUser,
+        content: [{ type: "text", text: "[redacted by hook]" }],
+      }),
+      userFingerprint,
+    );
+    const sourceAssistant = attachCodexMirrorIdentity(
+      makeAgentAssistantMessage({
+        content: [{ type: "text", text: "answer" }],
+        timestamp: 2,
+      }),
+      "turn-1:assistant",
+    );
+
+    const result = await codexTranscriptMirrorRuntime.mirror({
+      ...target,
+      messages: [sourceUser, sourceAssistant],
+      idempotencyScope: "codex-app-server:thread-1",
+    });
+
+    const messages = (await readSessionTranscriptEvents(target))
+      .filter((event): event is { type: "message"; message: AgentMessage } => {
+        return Boolean(
+          event && typeof event === "object" && "type" in event && event.type === "message",
+        );
+      })
+      .map((event) => event.message);
+
+    expect(messages.filter((message) => message.role === "user")).toHaveLength(1);
+    expect(messages.filter((message) => message.role === "assistant")).toHaveLength(1);
+    expect(result.userMessagesPresent).toEqual([
+      expect.objectContaining({
+        role: "user",
+        content: [{ type: "text", text: "[redacted by hook]" }],
+        idempotencyKey: "codex-user-race:prompt",
+        __openclaw: expect.objectContaining({
+          mirrorOrigin: "codex-app-server",
+          mirrorSourceFingerprint: userFingerprint,
+        }),
+      }),
+    ]);
+    expect(result.assistantMirrorIdentitiesOwned).toEqual(["turn-1:assistant"]);
+    expect(transcriptRace.lookups).toEqual(["scan", "caller-checked"]);
+    expect(transcriptRace.publish).toHaveBeenCalledTimes(1);
+    expect(transcriptRace.publish).toHaveBeenCalledWith(
+      expect.objectContaining({
+        update: expect.objectContaining({
+          message: expect.objectContaining({ role: "assistant" }),
+          messageSeq: 2,
+        }),
+      }),
+    );
+    expect(beforeMessageWrite).toHaveBeenCalledTimes(2);
+  } finally {
+    await fs.rm(root, { recursive: true, force: true });
+  }
+});

--- a/extensions/qa-lab/src/cli.runtime.test.ts
+++ b/extensions/qa-lab/src/cli.runtime.test.ts
@@ -992,28 +992,61 @@ describe("qa cli runtime", () => {
     expect(runQaSuite).not.toHaveBeenCalled();
   });
 
-  it("passes runtime-pair suite selection through to the host runner", async () => {
-    await runQaSuiteCommand({
-      repoRoot: "/tmp/openclaw-repo",
-      providerMode: "mock-openai",
-      scenarioIds: ["approval-turn-tool-followthrough"],
-      runtimePair: "openclaw,codex",
-    });
+  it.each([
+    ["openclaw,codex", ["openclaw", "codex"]],
+    ["codex,openclaw", ["codex", "openclaw"]],
+    [" codex , pi ", ["codex", "openclaw"]],
+  ] as const)(
+    "passes the requested %s runtime order through to the host runner",
+    async (runtimePair, expectedRuntimePair) => {
+      await runQaSuiteCommand({
+        repoRoot: "/tmp/openclaw-repo",
+        providerMode: "mock-openai",
+        scenarioIds: ["approval-turn-tool-followthrough"],
+        runtimePair,
+      });
 
-    expect(runQaSuite).toHaveBeenCalledWith({
-      repoRoot: path.resolve("/tmp/openclaw-repo"),
-      outputDir: undefined,
-      transportId: "qa-channel",
-      channelDriver: undefined,
-      channelDriverSelection: undefined,
-      providerMode: "mock-openai",
-      primaryModel: undefined,
-      alternateModel: undefined,
-      fastMode: undefined,
-      scenarioIds: ["approval-turn-tool-followthrough"],
-      runtimePair: ["openclaw", "codex"],
-    });
-  });
+      expect(runQaSuite).toHaveBeenCalledWith({
+        repoRoot: path.resolve("/tmp/openclaw-repo"),
+        outputDir: undefined,
+        transportId: "qa-channel",
+        channelDriver: undefined,
+        channelDriverSelection: undefined,
+        providerMode: "mock-openai",
+        primaryModel: undefined,
+        alternateModel: undefined,
+        fastMode: undefined,
+        scenarioIds: ["approval-turn-tool-followthrough"],
+        runtimePair: [...expectedRuntimePair],
+      });
+    },
+  );
+
+  it.each([
+    ["openclaw,openclaw", /different runtimes/i],
+    ["codex,codex", /different runtimes/i],
+    ["pi,openclaw", /different runtimes/i],
+    ["openclaw,,codex", /exactly two runtimes/i],
+    ["openclaw,codex,", /exactly two runtimes/i],
+    [",openclaw,codex", /exactly two runtimes/i],
+    ["openclaw", /exactly two runtimes/i],
+    ["openclaw,codex,openclaw", /exactly two runtimes/i],
+  ] as const)(
+    "rejects the invalid %s runtime pair before starting a harness",
+    async (runtimePair, expectedError) => {
+      await expect(
+        runQaSuiteCommand({
+          repoRoot: "/tmp/openclaw-repo",
+          providerMode: "mock-openai",
+          scenarioIds: ["approval-turn-tool-followthrough"],
+          runtimePair,
+        }),
+      ).rejects.toThrow(expectedError);
+
+      expect(runQaSuite).not.toHaveBeenCalled();
+      expect(runQaMultipass).not.toHaveBeenCalled();
+    },
+  );
 
   it("rejects unknown runtime-pair ids at the CLI boundary", async () => {
     await expect(
@@ -2216,6 +2249,15 @@ describe("qa cli runtime", () => {
     }
   });
 
+  it("preserves the canonical runtime order for JSONL replay", async () => {
+    await expect(
+      runQaJsonlReplayCommand({
+        repoRoot: process.cwd(),
+        runtimePair: "codex,openclaw",
+      }),
+    ).rejects.toThrow('--runtime-pair for jsonl-replay must be "openclaw,codex".');
+  });
+
   it("keeps JSONL replay mock-only until real runtime cell replay is wired", async () => {
     await expect(
       runQaJsonlReplayCommand({
@@ -2465,23 +2507,29 @@ describe("qa cli runtime", () => {
     expect(runQaMultipass).not.toHaveBeenCalled();
   });
 
-  it("passes runtime-pair suite selection through to the multipass runner", async () => {
-    await runQaSuiteCommand({
-      repoRoot: "/tmp/openclaw-repo",
-      runner: "multipass",
-      providerMode: "mock-openai",
-      scenarioIds: ["approval-turn-tool-followthrough"],
-      runtimePair: "codex,openclaw",
-      allowFailures: true,
-    });
+  it.each([
+    ["openclaw,codex", ["openclaw", "codex"]],
+    ["codex,openclaw", ["codex", "openclaw"]],
+  ] as const)(
+    "passes the requested %s runtime order through to the multipass runner",
+    async (runtimePair, expectedRuntimePair) => {
+      await runQaSuiteCommand({
+        repoRoot: "/tmp/openclaw-repo",
+        runner: "multipass",
+        providerMode: "mock-openai",
+        scenarioIds: ["approval-turn-tool-followthrough"],
+        runtimePair,
+        allowFailures: true,
+      });
 
-    expect(runQaMultipass).toHaveBeenCalledWith(
-      expect.objectContaining({
-        repoRoot: path.resolve("/tmp/openclaw-repo"),
-        runtimePair: ["openclaw", "codex"],
-      }),
-    );
-  });
+      expect(runQaMultipass).toHaveBeenCalledWith(
+        expect.objectContaining({
+          repoRoot: path.resolve("/tmp/openclaw-repo"),
+          runtimePair: [...expectedRuntimePair],
+        }),
+      );
+    },
+  );
 
   it("passes live suite selection through to the multipass runner", async () => {
     await runQaSuiteCommand({

--- a/extensions/qa-lab/src/cli.runtime.ts
+++ b/extensions/qa-lab/src/cli.runtime.ts
@@ -279,22 +279,18 @@ function parseQaRuntimePair(value: string | undefined): [RuntimeId, RuntimeId] |
   if (!value?.trim()) {
     return undefined;
   }
-  const runtimes = value
-    .split(",")
-    .map((part) => part.trim().toLowerCase())
-    .filter(Boolean)
-    .map(normalizeQaRuntimeId);
-  if (runtimes.length !== 2) {
+  const runtimeNames = value.split(",");
+  if (runtimeNames.length !== 2) {
     throw new Error('--runtime-pair must use exactly two runtimes, e.g. "openclaw,codex".');
   }
-  const [left, right] = runtimes;
+  const [left, right] = runtimeNames.map((part) => normalizeQaRuntimeId(part.trim().toLowerCase()));
   if (!left || !right) {
     throw new Error('--runtime-pair only supports "openclaw" and "codex".');
   }
   if (left === right) {
     throw new Error("--runtime-pair must compare two different runtimes.");
   }
-  return ["openclaw", "codex"];
+  return [left, right];
 }
 
 function parseQaRuntimePairLaneFilters(input: string[] | undefined): QaRuntimePairLane[] {

--- a/extensions/qa-lab/src/run-config.test.ts
+++ b/extensions/qa-lab/src/run-config.test.ts
@@ -352,7 +352,7 @@ describe("qa run config", () => {
     expect(execution.excludedScenarios).toEqual([]);
   });
 
-  it("excludes live-only and unsupported thread scenarios from Crabline plans", () => {
+  it("keeps portable threads but excludes live-only scenarios from Crabline plans", () => {
     const catalog = readQaScenarioPack();
     const scenarioIds = new Set([
       "matrix-approval-channel-target-both",
@@ -378,7 +378,10 @@ describe("qa run config", () => {
       supportsChannel: () => true,
     });
 
-    expect(execution.selectedScenarios).toEqual([]);
+    expect(execution.selectedScenarios.map((scenario) => scenario.id).toSorted()).toEqual([
+      "thread-follow-up",
+      "thread-isolation",
+    ]);
     expect(
       Object.fromEntries(
         execution.excludedScenarios.map(({ scenario, reasons }) => [scenario.id, reasons]),
@@ -393,8 +396,6 @@ describe("qa run config", () => {
       "matrix-mxid-prefixed-command-block": ["channelDriver=live"],
       "slack-codex-approval-exec-native": ["channelDriver=live"],
       "slack-codex-approval-plugin-native": ["channelDriver=live"],
-      "thread-follow-up": ["channel=qa-channel|slack|matrix"],
-      "thread-isolation": ["channel=qa-channel|slack|matrix"],
     });
   });
 

--- a/extensions/qa-lab/src/runtime-parity.execution-order.test.ts
+++ b/extensions/qa-lab/src/runtime-parity.execution-order.test.ts
@@ -1,0 +1,111 @@
+// QA Lab tests cover requested runtime execution order and canonical result identity.
+import { describe, expect, it, vi } from "vitest";
+import {
+  isRuntimeParityResultPass,
+  runRuntimeParityScenario,
+  type RuntimeId,
+  type RuntimeParityCell,
+} from "./runtime-parity.js";
+
+function makeRuntimeParityCell(runtime: RuntimeId): RuntimeParityCell {
+  return {
+    runtime,
+    transcriptBytes: '{"message":{"role":"assistant","content":"done"}}\n',
+    toolCalls: [],
+    finalText: "done",
+    usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+    wallClockMs: 10,
+    bootStateLines: [],
+  };
+}
+
+describe("runtime parity execution order", () => {
+  it.each([
+    {
+      label: "the canonical default",
+      runtimePair: undefined,
+      expectedExecutionOrder: ["openclaw", "codex"],
+    },
+    {
+      label: "an explicitly canonical pair",
+      runtimePair: ["openclaw", "codex"],
+      expectedExecutionOrder: ["openclaw", "codex"],
+    },
+    {
+      label: "a reversed pair",
+      runtimePair: ["codex", "openclaw"],
+      expectedExecutionOrder: ["codex", "openclaw"],
+    },
+  ] satisfies Array<{
+    label: string;
+    runtimePair: [RuntimeId, RuntimeId] | undefined;
+    expectedExecutionOrder: [RuntimeId, RuntimeId];
+  }>)(
+    "runs $label in its requested order with canonical result cells",
+    async ({ runtimePair, expectedExecutionOrder }) => {
+      const runCell = vi.fn(async (runtime: RuntimeId) => ({
+        status: "pass" as const,
+        cell: makeRuntimeParityCell(runtime),
+      }));
+      const result = await runRuntimeParityScenario({
+        scenarioId: "runtime-execution-order",
+        ...(runtimePair ? { runtimePair } : {}),
+        runCell,
+      });
+
+      expect(runCell.mock.calls.map(([runtime]) => runtime)).toEqual(expectedExecutionOrder);
+      expect(Object.keys(result.cells)).toEqual(["openclaw", "codex"]);
+      expect(result.cells.openclaw).toMatchObject({ runtime: "openclaw", status: "pass" });
+      expect(result.cells.codex).toMatchObject({ runtime: "codex", status: "pass" });
+      expect(result.drift).toBe("none");
+    },
+  );
+
+  it.each(["openclaw", "codex"] as const)(
+    "rejects duplicate %s runtimes before executing a parity cell",
+    async (runtime) => {
+      const runCell = vi.fn(async (selectedRuntime: RuntimeId) => ({
+        status: "pass" as const,
+        cell: makeRuntimeParityCell(selectedRuntime),
+      }));
+
+      await expect(
+        runRuntimeParityScenario({
+          scenarioId: "duplicate-runtime-pair",
+          runtimePair: [runtime, runtime],
+          runCell,
+        }),
+      ).rejects.toThrow(/different|distinct|duplicate/i);
+      expect(runCell).not.toHaveBeenCalled();
+    },
+  );
+
+  it("attributes a failed reversed pair to its canonical runtime cell", async () => {
+    const executionOrder: RuntimeId[] = [];
+    const result = await runRuntimeParityScenario({
+      scenarioId: "reversed-runtime-cell-failure",
+      runtimePair: ["codex", "openclaw"],
+      runCell: async (runtime) => {
+        executionOrder.push(runtime);
+        return {
+          status: runtime === "codex" ? ("fail" as const) : ("pass" as const),
+          ...(runtime === "codex" ? { details: "Codex scenario failed" } : {}),
+          cell: makeRuntimeParityCell(runtime),
+        };
+      },
+    });
+
+    expect(executionOrder).toEqual(["codex", "openclaw"]);
+    expect(result.cells.openclaw.status).toBe("pass");
+    expect(result.cells.codex).toMatchObject({
+      runtime: "codex",
+      status: "fail",
+      details: "Codex scenario failed",
+    });
+    expect(result).toMatchObject({
+      drift: "failure-mode",
+      driftDetails: "runtime-pair cell status differs (pass vs fail)",
+    });
+    expect(isRuntimeParityResultPass(result)).toBe(false);
+  });
+});

--- a/extensions/qa-lab/src/runtime-parity.ts
+++ b/extensions/qa-lab/src/runtime-parity.ts
@@ -1491,10 +1491,16 @@ export async function captureRuntimeParityCell(
 export async function runRuntimeParityScenario(params: {
   scenarioId: string;
   runtimeParityUsage?: RuntimeParityUsagePolicy;
+  runtimePair?: readonly [RuntimeId, RuntimeId];
   runCell: (runtime: RuntimeId) => Promise<RuntimeParityScenarioExecution>;
 }): Promise<RuntimeParityResult> {
-  const openclaw = await params.runCell("openclaw");
-  const codex = await params.runCell("codex");
+  const [firstRuntime, secondRuntime] = params.runtimePair ?? CANONICAL_RUNTIME_IDS;
+  if (firstRuntime === secondRuntime) {
+    throw new Error("Runtime parity must compare two different runtimes.");
+  }
+  const first = await params.runCell(firstRuntime);
+  const second = await params.runCell(secondRuntime);
+  const [openclaw, codex] = firstRuntime === "openclaw" ? [first, second] : [second, first];
   const drift = classifyRuntimeParityCells({
     openclaw: openclaw.cell,
     codex: codex.cell,

--- a/extensions/qa-lab/src/suite-run-standard.parity-retry.test.ts
+++ b/extensions/qa-lab/src/suite-run-standard.parity-retry.test.ts
@@ -1,0 +1,177 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { QaLabServerHandle } from "./lab-server.types.js";
+import { runQaFlowSuiteStandard } from "./suite-run-standard.js";
+import { makeQaSuiteTestScenario } from "./suite-test-helpers.js";
+import type {
+  QaSuiteResolvedRunContext,
+  QaSuiteScenarioResult,
+  QaSuiteScenarioRunner,
+} from "./suite-types.js";
+
+const mocks = vi.hoisted(() => ({
+  captureRuntimeParityCell: vi.fn(async (params: { runtime: "codex"; wallClockMs: number }) => ({
+    runtime: params.runtime,
+    transcriptBytes: "",
+    toolCalls: [],
+    finalText: "",
+    usage: { inputTokens: 10, outputTokens: 1, totalTokens: 11 },
+    cacheDiagnostics: {
+      assistantTurns: 1,
+      cacheTelemetryTurns: 1,
+      cacheHitTurns: 0,
+      cacheWriteTurns: 0,
+      cacheMisses: [],
+      cacheMissInputTokens: 0,
+      unmeasuredPostWarmTurns: [],
+    },
+    wallClockMs: params.wallClockMs,
+    bootStateLines: [],
+  })),
+  startQaGatewayChild: vi.fn(async () => ({
+    baseUrl: "http://127.0.0.1:18789",
+    token: "qa-test-token",
+    cfg: {},
+    getProcessCpuMs: () => null,
+    getProcessRssBytes: () => null,
+    stop: vi.fn(async () => {}),
+  })),
+  writeQaSuiteArtifacts: vi.fn(async () => ({
+    evidence: undefined,
+    evidencePath: "/qa-output/qa-evidence.json",
+    report: "",
+    reportPath: "/qa-output/qa-suite-report.md",
+    summaryPath: "/qa-output/qa-suite-summary.json",
+  })),
+}));
+
+vi.mock("openclaw/plugin-sdk/agent-harness", () => ({
+  disposeRegisteredAgentHarnesses: vi.fn(async () => {}),
+}));
+vi.mock("./gateway-child.js", () => ({
+  startQaGatewayChild: mocks.startQaGatewayChild,
+}));
+vi.mock("./providers/server-runtime.js", () => ({
+  startQaProviderServer: vi.fn(async () => undefined),
+}));
+vi.mock("./runtime-parity.js", () => ({
+  captureRuntimeParityCell: mocks.captureRuntimeParityCell,
+}));
+vi.mock("./suite-artifacts.js", () => ({
+  writeQaSuiteArtifacts: mocks.writeQaSuiteArtifacts,
+}));
+vi.mock("./suite-runtime-gateway.js", () => ({
+  waitForGatewayHealthy: vi.fn(async () => {}),
+  waitForTransportReady: vi.fn(async () => {}),
+}));
+vi.mock("./suite.js", () => ({
+  buildQaSuiteRuntimeMetrics: vi.fn(() => ({ wallMs: 1 })),
+  captureGatewayHeapSnapshotCheckpoint: vi.fn(async () => undefined),
+  createQaSuiteTransportAdapter: vi.fn(async () => ({
+    adapter: { id: "qa-channel" },
+    cleanupBeforeGatewayStop: vi.fn(async () => {}),
+    cleanupAfterGatewayStop: vi.fn(async () => {}),
+  })),
+  requireQaSuiteStartLab: vi.fn(),
+  resolveQaSuiteTransportReadyTimeoutMs: vi.fn(() => 1_000),
+  runQaFlowSuiteCleanupPlan: vi.fn(async () => []),
+  throwQaSuiteCleanupErrors: vi.fn(),
+  waitForQaLabReadyOrStopOwned: vi.fn(async () => {}),
+  writeQaSuiteProgress: vi.fn(),
+}));
+vi.mock("./web-runtime.js", () => ({
+  closeQaWebSessions: vi.fn(async () => {}),
+}));
+
+function makeRetryTestLab(): QaLabServerHandle {
+  return {
+    baseUrl: "http://127.0.0.1:43123",
+    listenUrl: "http://127.0.0.1:43123",
+    state: {} as QaLabServerHandle["state"],
+    setControlUi: vi.fn(),
+    setScenarioRun: vi.fn(),
+    setLatestReport: vi.fn(),
+    runSelfCheck: vi.fn(),
+    stop: vi.fn(async () => {}),
+  };
+}
+
+function makeRetryTestContext(): QaSuiteResolvedRunContext {
+  return {
+    startedAt: new Date(),
+    repoRoot: "/qa-repo",
+    outputDir: "/qa-output",
+    transportId: "qa-channel",
+    selectedScenarios: [makeQaSuiteTestScenario("runtime-soak-100-turn")],
+    providerMode: "live-frontier",
+    primaryModel: "openai/gpt-5.6-luna",
+    alternateModel: "openai/gpt-5.6-luna",
+    fastMode: true,
+    enabledPluginIds: [],
+    gatewayConfigPatch: undefined,
+    gatewayRuntimeOptions: undefined,
+    concurrency: 1,
+    progressEnabled: false,
+    gatewayHeapCheckpointsEnabled: false,
+  };
+}
+
+function makeRetryTestResult(status: "pass" | "fail"): QaSuiteScenarioResult {
+  return {
+    name: "runtime-soak-100-turn",
+    status,
+    details: status === "fail" ? "expected 100 persisted user turns, got 101" : "passed",
+    steps: [],
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("QA runtime parity scenario retry isolation", () => {
+  it("captures one failed parity attempt without replaying its transcript or usage", async () => {
+    const runScenario = vi
+      .fn<QaSuiteScenarioRunner>()
+      .mockResolvedValueOnce(makeRetryTestResult("fail"))
+      .mockResolvedValueOnce(makeRetryTestResult("pass"));
+
+    const result = await runQaFlowSuiteStandard(
+      { lab: makeRetryTestLab(), forcedRuntime: "codex", captureRuntimeParityCell: true },
+      makeRetryTestContext(),
+      runScenario,
+    );
+
+    expect(runScenario).toHaveBeenCalledOnce();
+    expect(result.scenarios[0]).toMatchObject({ status: "fail" });
+    expect(mocks.captureRuntimeParityCell).toHaveBeenCalledOnce();
+    expect(mocks.captureRuntimeParityCell).toHaveBeenCalledWith(
+      expect.objectContaining({
+        runtime: "codex",
+        scenarioResult: expect.objectContaining({ status: "fail" }),
+        wallClockMs: expect.any(Number),
+      }),
+    );
+    expect(result.runtimeParityCell).toMatchObject({
+      usage: { inputTokens: 10, outputTokens: 1, totalTokens: 11 },
+      cacheDiagnostics: { assistantTurns: 1 },
+      wallClockMs: expect.any(Number),
+    });
+  });
+
+  it("preserves the existing single flake retry outside runtime parity", async () => {
+    const runScenario = vi
+      .fn<QaSuiteScenarioRunner>()
+      .mockResolvedValueOnce(makeRetryTestResult("fail"))
+      .mockResolvedValueOnce(makeRetryTestResult("pass"));
+
+    const result = await runQaFlowSuiteStandard(
+      { lab: makeRetryTestLab() },
+      makeRetryTestContext(),
+      runScenario,
+    );
+
+    expect(runScenario).toHaveBeenCalledTimes(2);
+    expect(result.scenarios[0]).toMatchObject({ status: "pass" });
+    expect(mocks.captureRuntimeParityCell).not.toHaveBeenCalled();
+  });
+});

--- a/extensions/qa-lab/src/suite-run-standard.ts
+++ b/extensions/qa-lab/src/suite-run-standard.ts
@@ -254,7 +254,7 @@ export async function runQaFlowSuiteStandard(
       const scenarioRetryCount =
         scenario.execution.kind === "flow" ? scenario.execution.retryCount : undefined;
       let result: QaSuiteScenarioResult =
-        scenarioRetryCount === 0
+        params?.captureRuntimeParityCell || scenarioRetryCount === 0
           ? await runSelectedScenario()
           : await runQaScenarioWithFlakeRetry(runSelectedScenario, () =>
               writeQaSuiteProgress(

--- a/extensions/qa-lab/src/suite-runtime-parity-runner.ts
+++ b/extensions/qa-lab/src/suite-runtime-parity-runner.ts
@@ -128,6 +128,7 @@ export async function runQaRuntimeParitySuite(params: {
         const parity = await runRuntimeParityScenario({
           scenarioId: scenario.id,
           runtimeParityUsage: scenario.runtimeParityUsage,
+          runtimePair: params.runtimePair,
           runCell: async (runtime) => {
             const cellOutputDir = path.join(
               params.outputDir,

--- a/packages/ai/src/providers/openai-chatgpt-responses.cache.test.ts
+++ b/packages/ai/src/providers/openai-chatgpt-responses.cache.test.ts
@@ -1,0 +1,185 @@
+import { zstdDecompressSync } from "node:zlib";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { configureAiTransportHost } from "../host.js";
+import type { Context, Model } from "../types.js";
+import {
+  closeOpenAICodexWebSocketSessions,
+  resetOpenAICodexWebSocketStateForTest,
+  streamOpenAICodexResponses,
+} from "./openai-chatgpt-responses.js";
+
+const model = {
+  id: "gpt-5.5",
+  name: "GPT-5.5",
+  api: "openai-chatgpt-responses",
+  provider: "openai",
+  baseUrl: "https://chatgpt.test/backend-api",
+  reasoning: true,
+  input: ["text"],
+  cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+  contextWindow: 128_000,
+  maxTokens: 16_000,
+} satisfies Model<"openai-chatgpt-responses">;
+
+const context = {
+  messages: [{ role: "user", content: "hi", timestamp: 1 }],
+} satisfies Context;
+
+function createJwt(): string {
+  const encode = (value: object) => Buffer.from(JSON.stringify(value)).toString("base64url");
+  return `${encode({ alg: "none", typ: "JWT" })}.${encode({
+    "https://api.openai.com/auth": { chatgpt_account_id: "acct-1" },
+  })}.signature`;
+}
+
+function completion(responseId: string) {
+  return {
+    type: "response.completed",
+    response: {
+      id: responseId,
+      status: "completed",
+      output: [],
+      usage: { input_tokens: 5, output_tokens: 3, total_tokens: 8 },
+    },
+  };
+}
+
+describe("ChatGPT Responses cached transport", () => {
+  afterEach(() => {
+    closeOpenAICodexWebSocketSessions();
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+    resetOpenAICodexWebSocketStateForTest();
+    configureAiTransportHost({});
+  });
+
+  it("does not prepare SSE requests or serialize full bodies for cached websocket turns", async () => {
+    const sentPayloads: string[] = [];
+
+    class CachedWebSocket extends EventTarget {
+      readyState = 1;
+
+      constructor() {
+        super();
+        queueMicrotask(() => this.dispatchEvent(new Event("open")));
+      }
+
+      send(payload: string): void {
+        sentPayloads.push(payload);
+        queueMicrotask(() => {
+          this.dispatchEvent(
+            Object.assign(new Event("message"), {
+              data: JSON.stringify(completion(`resp_ws_${sentPayloads.length}`)),
+            }),
+          );
+        });
+      }
+
+      close(): void {
+        this.readyState = 3;
+      }
+    }
+
+    const fetchMock = vi.fn();
+    vi.stubGlobal("WebSocket", CachedWebSocket);
+    vi.stubGlobal("fetch", fetchMock);
+    const apiKey = createJwt();
+    const headerSet = vi.spyOn(Headers.prototype, "set");
+    const jsonStringify = vi.spyOn(JSON, "stringify");
+    const options = {
+      apiKey,
+      sessionId: "cached-hot-path",
+      transport: "websocket-cached" as const,
+    };
+
+    const first = await streamOpenAICodexResponses(model, context, options).result();
+    const second = await streamOpenAICodexResponses(
+      model,
+      {
+        messages: [...context.messages, { role: "user", content: "follow-up", timestamp: 2 }],
+      },
+      options,
+    ).result();
+
+    expect(first.stopReason).toBe("stop");
+    expect(second.stopReason).toBe("stop");
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(headerSet).not.toHaveBeenCalledWith("accept", "text/event-stream");
+    expect(headerSet).not.toHaveBeenCalledWith("content-type", "application/json");
+    expect(sentPayloads).toHaveLength(2);
+
+    const continuation = JSON.parse(sentPayloads[1] as string) as {
+      input?: unknown[];
+      previous_response_id?: string;
+    };
+    expect(continuation.previous_response_id).toBe("resp_ws_1");
+    expect(continuation.input).toHaveLength(1);
+    expect(
+      jsonStringify.mock.calls.filter(([value]) => {
+        return (
+          typeof value === "object" &&
+          value !== null &&
+          "model" in value &&
+          "input" in value &&
+          !("type" in value)
+        );
+      }),
+    ).toEqual([]);
+  });
+
+  it("lazily builds authenticated SSE requests after session-scoped websocket fallback", async () => {
+    let websocketAttempts = 0;
+
+    class FailingWebSocket {
+      constructor() {
+        websocketAttempts += 1;
+        throw new Error("websocket connect failed");
+      }
+
+      send(): void {}
+      close(): void {}
+      addEventListener(): void {}
+      removeEventListener(): void {}
+    }
+
+    const captured: Array<{ headers: Headers; body: BodyInit | null | undefined }> = [];
+    const fetchMock = vi.fn(async (_input: unknown, init?: RequestInit) => {
+      captured.push({ headers: new Headers(init?.headers), body: init?.body });
+      return new Response(
+        `data: ${JSON.stringify(completion(`resp_sse_${captured.length}`))}\n\n`,
+        {
+          status: 200,
+          headers: { "content-type": "text/event-stream" },
+        },
+      );
+    });
+    vi.stubGlobal("WebSocket", FailingWebSocket);
+    vi.stubGlobal("fetch", fetchMock);
+    const apiKey = createJwt();
+    const options = { apiKey, sessionId: "sticky-sse-fallback" };
+
+    const first = await streamOpenAICodexResponses(model, context, options).result();
+    const second = await streamOpenAICodexResponses(model, context, options).result();
+
+    expect(first.stopReason).toBe("stop");
+    expect(second.stopReason).toBe("stop");
+    expect(websocketAttempts).toBe(1);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+
+    for (const { headers, body } of captured) {
+      expect(headers.get("authorization")).toBe(`Bearer ${apiKey}`);
+      expect(headers.get("chatgpt-account-id")).toBe("acct-1");
+      expect(headers.get("session_id")).toBe("sticky-sse-fallback");
+      expect(headers.get("accept")).toBe("text/event-stream");
+      expect(headers.get("content-type")).toBe("application/json");
+      expect(headers.get("content-encoding")).toBe("zstd");
+      expect(body).toBeInstanceOf(Uint8Array);
+      expect(
+        JSON.parse(Buffer.from(zstdDecompressSync(body as Uint8Array)).toString("utf8")),
+      ).toMatchObject({
+        model: model.id,
+        prompt_cache_key: "sticky-sse-fallback",
+      });
+    }
+  });
+});

--- a/packages/ai/src/providers/openai-chatgpt-responses.ts
+++ b/packages/ai/src/providers/openai-chatgpt-responses.ts
@@ -301,16 +301,6 @@ export const streamOpenAICodexResponses: StreamFunction<
       // backend routes by session_id/x-client-request-id). Left as-is for this fix;
       // see the SSE-path session_id addition in buildOpenAIClientHeaders (agents/openai-transport-stream.ts).
       const sessionId = clampOpenAIPromptCacheKey(options?.sessionId);
-      const websocketRequestId = sessionId || createCodexRequestId();
-      const sseHeaders = buildSSEHeaders(modelHeaders, optionHeaders, accountId, apiKey, sessionId);
-      const websocketHeaders = buildWebSocketHeaders(
-        modelHeaders,
-        optionHeaders,
-        accountId,
-        apiKey,
-        websocketRequestId,
-      );
-      const bodyJson = JSON.stringify(body);
       requestTimeoutMs = resolveRequestTimeoutMs(options);
       requestTimeoutSignal = buildRequestSignal(options?.signal, requestTimeoutMs);
       firstEventAbort = createFirstStreamEventAbortController(requestTimeoutSignal);
@@ -322,6 +312,13 @@ export const streamOpenAICodexResponses: StreamFunction<
         transport === "auto" && isWebSocketSseFallbackActive(options?.sessionId);
 
       if (transport !== "sse" && !websocketDisabledForSession) {
+        const websocketHeaders = buildWebSocketHeaders(
+          modelHeaders,
+          optionHeaders,
+          accountId,
+          apiKey,
+          sessionId || createCodexRequestId(),
+        );
         let websocketStarted = false;
         let retriedWebSocketConnectionLimit = false;
         while (true) {
@@ -371,7 +368,7 @@ export const streamOpenAICodexResponses: StreamFunction<
                 phase: websocketStarted
                   ? "after_message_stream_start"
                   : "before_message_stream_start",
-                requestBytes: new TextEncoder().encode(bodyJson).byteLength,
+                requestBytes: new TextEncoder().encode(JSON.stringify(body)).byteLength,
               }),
             );
             if (transport === "auto" && options?.sessionId) {
@@ -385,6 +382,8 @@ export const streamOpenAICodexResponses: StreamFunction<
         }
       }
 
+      const sseHeaders = buildSSEHeaders(modelHeaders, optionHeaders, accountId, apiKey, sessionId);
+      const bodyJson = JSON.stringify(body);
       const canCompressSseBody = model.provider === "openai" && !sseHeaders.has("content-encoding");
       const compressedBody = canCompressSseBody ? compressRequestBodyZstd(bodyJson) : null;
       if (compressedBody) {

--- a/src/agents/embedded-agent-runner/run/attempt-setup.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-setup.test.ts
@@ -18,6 +18,27 @@ describe("prepareEmbeddedAttemptSetup", () => {
     resolveProviderRuntimePluginHandle.mockReset();
   });
 
+  it("prepares the default and session agent identities together", async () => {
+    const setup = await prepareEmbeddedAttemptSetup({
+      config: {
+        agents: {
+          list: [{ id: "main", default: true }, { id: "marketing" }],
+        },
+      },
+      modelId: "gpt-5.4",
+      provider: "openai",
+      runId: "run-prepared-agent-identities",
+      sessionId: "session-prepared-agent-identities",
+      sessionKey: "agent:marketing:main",
+      thinkLevel: "high",
+      timeoutMs: 30_000,
+      workspaceDir: path.join(os.tmpdir(), "openclaw-attempt-setup-agent-identities"),
+    } as unknown as EmbeddedRunAttemptParams);
+
+    expect(setup.defaultAgentId).toBe("main");
+    expect(setup.sessionAgentId).toBe("marketing");
+  });
+
   it("reuses lifecycle metadata and the provider handle from the runtime plan", async () => {
     const metadataSnapshot = { plugins: [] } as never;
     const workspaceDir = path.join(os.tmpdir(), "openclaw-attempt-setup-prepared");

--- a/src/agents/embedded-agent-runner/run/attempt-setup.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-setup.ts
@@ -61,12 +61,13 @@ export async function resolveAttemptWorkspaceSandbox(params: AttemptWorkspacePar
     );
   }
   await fs.mkdir(effectiveWorkspace, { recursive: true });
-  const { sessionAgentId } = resolveSessionAgentIds({
+  const { defaultAgentId, sessionAgentId } = resolveSessionAgentIds({
     sessionKey: params.sessionKey,
     config: params.config,
     agentId: params.agentId,
   });
   return {
+    defaultAgentId,
     effectiveCwd: sandbox?.enabled ? effectiveWorkspace : (requestedCwd ?? effectiveWorkspace),
     effectiveFsWorkspaceOnly: resolveAttemptFsWorkspaceOnly({
       config: params.config,

--- a/src/agents/embedded-agent-runner/run/attempt.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.ts
@@ -13,7 +13,7 @@ import {
   projectAgentRunAttemptTerminal,
   type AgentRunAttemptTerminal,
 } from "../../agent-run-terminal-outcome.js";
-import { resolveAgentDir, resolveSessionAgentIds } from "../../agent-scope.js";
+import { resolveAgentDir } from "../../agent-scope.js";
 import type { guardSessionManager } from "../../session-tool-result-guard-wrapper.js";
 import type { AgentSession } from "../../sessions/index.js";
 import {
@@ -57,6 +57,7 @@ export async function runEmbeddedAttempt(
   const runAbortController = new AbortController();
   const {
     agentCoreThinkingLevel,
+    defaultAgentId,
     effectiveCwd,
     effectiveFsWorkspaceOnly,
     effectiveWorkspace,
@@ -228,11 +229,6 @@ export async function runEmbeddedAttempt(
       resolvedWorkspace,
       sessionAgentId,
       sessionLabel: params.sessionKey ?? params.sessionId,
-    });
-    const { defaultAgentId } = resolveSessionAgentIds({
-      sessionKey: params.sessionKey,
-      config: params.config,
-      agentId: params.agentId,
     });
     // Track sessions_yield tool invocation (callback pattern, like clientToolCallDetected)
     let yieldDetected = false;


### PR DESCRIPTION
Related: #115474
Related: #114574

## What Problem This Solves

Fixes an issue where users running long-lived Codex sessions could accumulate duplicate persisted user turns, lose warm-thread reuse, and receive misleading benchmark timing or token comparisons when a runtime pair was reversed or a failed parity scenario was silently retried.

## Why This Change Was Made

Keep Codex threads warm using the same authoritative native skill-isolation configuration as cold startup; materialize deterministic dynamic-tool instructions in one pass; and honor requested runtime execution order without changing canonical result attribution. Protect canonical gateway-owned user messages with the existing indexed SQLite idempotency lookup, preserve the assistant fast path, adopt the existing redacted row, publish only newly inserted events, and retain the correct assistant sequence. Disable flake retries only for measured runtime-parity cells. Defer ChatGPT OAuth SSE request preparation until genuine WebSocket fallback and reuse already prepared native agent identities.

## User Impact

Reliable warm Codex sessions and exact-once 100-turn transcripts; fair comparisons in either runtime order; honest cached-versus-uncached token accounting; less repeated prompt/tool, transport, and identity work. The change removes 16 production lines overall, excludes tests, and preserves native skill security, real apply_patch, SQLite persistence, canonical JSONL replay, default collaboration, and ordinary non-benchmark scenario retries.

## Evidence

- Read and verified actual upstream Codex cache-key, exact request reuse, thread lifecycle, user-item lifecycle, and authoritative force-reload contracts at Codex 07490c75234ed3c63291a8eb7629f04f647038fa.
- Frozen live-frontier baseline on c45daf7ea8e069f6bd86185e0fbe85f94493fe21, using the maintainer's OpenAI key fetched only inside task-owned tmux through 1Password.
- Actual real-provider reversed-order 20-turn run: Codex uncached input 25,040 -> 796 (-96.8%); post-warm cache misses 1 -> 0. Native, Codex, large-context stability, and real apply_patch all passed. Runtime result cells remain canonical while execution really starts with Codex.
- Real 100-turn stress exposed and reproduced the gateway/Codex duplicate-user race rather than treating the failed soak as a valid benchmark. A deterministic real-SQLite regression reproduces a stale transcript snapshot, proves exactly one canonical user, unchanged redaction and hook behavior, one assistant update at sequence 2, and indexed user lookup with fast assistant writes. The final real-key reversed 100-turn soak on immutable head 7d458a79b0ba8e4a881b5ee8ade62f094cd52f48 passed: Codex 100/100 in 392,653 ms (106,714 uncached input; 2,454,241 cache reads) and OpenClaw 100/100 in 400,710 ms (82,791 uncached input; 2,273,671 cache reads). These are measured observations, not a universal wall-clock speedup.
- A dedicated parity regression proves failed captured scenarios execute once, so usage/cache and elapsed time come from the same attempt; ordinary live scenarios still retry successfully.
- 655 targeted cross-domain regressions previously passed, including Codex lifecycle/security, reverse execution, JSONL replay, cache reports, SDK session writes, and authenticated compressed WebSocket fallback. The final expanded 32-file SQLite/cache/parity/provider/boundary regression suite, exact 12-file hosted core-support-boundary shard (113 tests), complete pnpm check:changed, and OPENCLAW_BUILD_PRIVATE_QA=1 pnpm build all passed on fresh Blacksmith Testbox for immutable head 7d458a79b0ba8e4a881b5ee8ade62f094cd52f48.
- Mandatory independent subagent review and gpt-5.6-sol structured autoreview: no actionable findings; TruffleHog clean.

- Rebased onto current main 844329284e433eae027b16c0826bf46645fbea26, inheriting the existing canonical public qa-lab api.js imports and formatting correction. Exact-head GitHub check-lint, build-artifacts, and required openclaw/ci-gate all passed; no plugin-boundary bypass or unrelated production fix was added.
