### PR TITLE
fix(cli): keep remote gateway calls read-only

### DIFF
--- a/src/cli/argv.test.ts
+++ b/src/cli/argv.test.ts
@@ -742,6 +742,12 @@ describe("argv helpers", () => {
     { argv: ["node", "openclaw", "models", "list"], expected: true },
     { argv: ["node", "openclaw", "models", "status"], expected: true },
     { argv: ["node", "openclaw", "update", "status", "--json"], expected: false },
+    { argv: ["node", "openclaw", "gateway", "call", "health", "--json"], expected: false },
+    {
+      argv: ["node", "openclaw", "--profile", "remote", "gateway", "call", "status"],
+      expected: false,
+    },
+    { argv: ["node", "openclaw", "gateway", "status"], expected: true },
     { argv: ["node", "openclaw", "agent", "--message", "hi"], expected: true },
     { argv: ["node", "openclaw", "agents", "list"], expected: true },
     { argv: ["node", "openclaw", "message", "send"], expected: true },
@@ -753,6 +759,9 @@ describe("argv helpers", () => {
   it.each([
     { path: ["status"], expected: true },
     { path: ["update", "status"], expected: false },
+    { path: ["gateway", "call"], expected: false },
+    { path: ["gateway", "health"], expected: true },
+    { path: ["gateway", "status"], expected: true },
     { path: ["config", "get"], expected: false },
     { path: ["agent"], expected: true },
     { path: ["models", "status"], expected: true },

--- a/src/cli/argv.ts
+++ b/src/cli/argv.ts
@@ -582,6 +582,10 @@ export function shouldMigrateStateFromPath(path: string[]): boolean {
   if (primary === "health" || primary === "sessions") {
     return false;
   }
+  // Remote RPC clients must not migrate state owned by the running gateway.
+  if (primary === "gateway" && secondary === "call") {
+    return false;
+  }
   if (primary === "update" && secondary === "status") {
     return false;
   }

--- a/src/cli/program/config-guard.test.ts
+++ b/src/cli/program/config-guard.test.ts
@@ -169,6 +169,11 @@ describe("ensureConfigReady", () => {
       expectedDoctorCalls: 0,
     },
     {
+      name: "skips doctor flow for remote gateway calls",
+      commandPath: ["gateway", "call"],
+      expectedDoctorCalls: 0,
+    },
+    {
       name: "skips doctor flow for agent without legacy state",
       commandPath: ["agent"],
       expectedDoctorCalls: 0,
@@ -201,6 +206,12 @@ describe("ensureConfigReady", () => {
     expect(readConfigFileSnapshotMock).toHaveBeenCalledWith({ observe: false });
   });
 
+  it("keeps remote gateway call config reads non-observing", async () => {
+    await runEnsureConfigReady(["gateway", "call"]);
+
+    expect(readConfigFileSnapshotMock).toHaveBeenCalledWith({ observe: false });
+  });
+
   it("runs doctor flow when lightweight startup detection finds legacy state", async () => {
     const root = useTempOpenClawHome();
     writeLegacyTaskSidecarMarker(root);
@@ -213,6 +224,15 @@ describe("ensureConfigReady", () => {
       invalidConfigNote: false,
       observe: false,
     });
+  });
+
+  it("keeps remote gateway calls from migrating existing local legacy state", async () => {
+    const root = useTempOpenClawHome();
+    writeLegacyTaskSidecarMarker(root);
+
+    await runEnsureConfigReady(["gateway", "call"]);
+
+    expect(loadAndMaybeMigrateDoctorConfigMock).not.toHaveBeenCalled();
   });
 
   it.each(["restart-sentinel.json", "restart-sentinel.json.doctor-importing"])(

--- a/src/cli/program/config-guard.ts
+++ b/src/cli/program/config-guard.ts
@@ -268,10 +268,12 @@ export async function ensureConfigReady(
     preflightSnapshot = await runStateMigrationPreflight();
   }
 
-  // Status performs a second non-observing read for its materialized/source pair;
-  // keep the startup guard from recording config health before the command begins.
+  // Status reads its materialized/source pair; remote Gateway calls must not
+  // record config health in the state owned by the Gateway being queried.
   const configSnapshotOptions =
-    commandName === "status" ? ({ observe: false } as const) : undefined;
+    commandName === "status" || (commandName === "gateway" && subcommandName === "call")
+      ? ({ observe: false } as const)
+      : undefined;
   let snapshot = preflightSnapshot ?? (await getConfigSnapshot(configSnapshotOptions));
   if (
     !preflightSnapshot &&


### PR DESCRIPTION
Closes #112626
Supersedes #112627; credit to @aspalagin for identifying the gateway-call state-migration race.

## What Problem This Solves

Fixes an issue where users running authenticated remote Gateway health or status monitoring would trigger local state migration and config-health writes even though a remote RPC client does not own the Gateway's state. On read-only installations, normal probes could fail with permission errors; with legacy task SQLite or sessions present, a monitoring probe could mutate and archive Gateway-owned data.

## Why This Change Was Made

Classify only the exact `gateway call` command as a remote RPC client, skip its local state-migration preflight, and reuse the existing non-observing config-snapshot contract used by status. The contributor's #112627 identifies and fixes the migration half; a real read-only authenticated Gateway reproduction showed that observing config-health snapshots independently still attempted state writes, so this change covers both boundaries. Local Gateway start/run/status/health, `doctor --fix`, plugin and session migrations, root named profiles, and snapshot pinning retain their existing behavior.

## User Impact

Remote Gateway health and status calls now complete normally when the local state directory and files are read-only. Monitoring does not modify or archive legacy task SQLite, sessions, or config-health state.

## Evidence

- Fail-first on current main: three exact argv/path cases, including root `--profile remote`; two actual command-guard cases with pristine and production-schema legacy task SQLite; and a third fail-first proving that the migration-only contributor patch still writes an observing config-health snapshot.
- Remote focused repository test: `pnpm test src/cli/argv.test.ts src/cli/program/config-guard.test.ts`: **192/192 pass**.
- Real end-to-end proof against a production Gateway server over authenticated WebSocket: run actual source CLI `gateway call health --json` and `gateway call status --json` against configured remote Gateway; seed valid production-schema SQLite task/delivery tables with a real row plus legacy sessions; chmod caller files 0444 and directories 0555; prove both commands return valid JSON, a full recursive SHA-256 state snapshot remains byte-identical, and no SQLite archive or config-health state is created.
- Full remote changed-surface gate: `pnpm check:changed -- src/cli/argv.ts src/cli/argv.test.ts src/cli/program/config-guard.ts src/cli/program/config-guard.test.ts`, including core and core-test typechecks, format, lint, dependency and plugin boundaries, dead exports, import cycles, state-schema and database-first guards: **exit 0**.
- Independent xhigh-effort exact-patch autoreview: clean; no actionable findings.
- Refreshed onto current `main`; verified all four final source/test file trees and the complete final patch are byte-identical to the remotely tested and autoreviewed patch.
