### PR TITLE
fix(compaction): drop context-engine fallback on codex ownership skip

### DIFF
--- a/src/agents/command/cli-compaction.test.ts
+++ b/src/agents/command/cli-compaction.test.ts
@@ -882,7 +882,7 @@ describe("runCliTurnCompactionLifecycle", () => {
     expect(recordCliCompactionInStore).not.toHaveBeenCalled();
   });
 
-  it("falls back to context-engine compaction when Codex owns automatic compaction", async () => {
+  it("skips context-engine fallback when Codex owns automatic compaction", async () => {
     const sessionKey = "agent:main:codex-native-auto-compaction";
     const sessionId = "session-codex-native-auto-compaction";
     const sessionFile = path.join(tmpDir, "session-codex-native-auto-compaction.jsonl");
@@ -954,20 +954,12 @@ describe("runCliTurnCompactionLifecycle", () => {
       model: "gpt-5.5",
     });
 
+    // Codex owns automatic compaction; the ownership skip must not fall back to
+    // context-engine compaction (OAuth-only sessions have no direct API key).
     expect(compactAgentHarnessSession).toHaveBeenCalledTimes(1);
-    expect(compactCalls).toHaveLength(1);
-    expect(compactCalls[0]?.sessionId).toBe(sessionId);
-    expect(compactCalls[0]?.sessionKey).toBe(sessionKey);
-    expect(compactCalls[0]?.currentTokenCount).toBe(950);
-    expect(maintenance).toHaveBeenCalledTimes(1);
-    expect(recordCliCompactionInStore).toHaveBeenCalledWith(
-      expect.objectContaining({
-        provider: "codex",
-        sessionKey,
-        tokensAfter: 100,
-      }),
-    );
-    expect(result?.compactionCount).toBe(1);
+    expect(compactCalls).toHaveLength(0);
+    expect(recordCliCompactionInStore).not.toHaveBeenCalled();
+    expect(result).toBe(sessionEntry);
 
     const lockedEntry: SessionEntry = { ...sessionEntry, modelSelectionLocked: true };
     sessionStore[sessionKey] = lockedEntry;
@@ -986,9 +978,8 @@ describe("runCliTurnCompactionLifecycle", () => {
     });
 
     expect(compactAgentHarnessSession).toHaveBeenCalledTimes(2);
-    expect(compactCalls).toHaveLength(1);
-    expect(maintenance).toHaveBeenCalledTimes(1);
-    expect(recordCliCompactionInStore).toHaveBeenCalledTimes(1);
+    expect(compactCalls).toHaveLength(0);
+    expect(recordCliCompactionInStore).not.toHaveBeenCalled();
     const lockedNativeCall = compactAgentHarnessSession.mock.calls[1]?.[0];
     expect(lockedNativeCall).toMatchObject({
       agentHarnessId: "codex",

--- a/src/agents/command/cli-compaction.ts
+++ b/src/agents/command/cli-compaction.ts
@@ -569,14 +569,13 @@ async function compactNativeHarnessCliTranscript(params: {
       return { compacted: false };
     }
     if (isIntentionalNativeAutoCompactionSkip(result)) {
-      if (params.sessionEntry.modelSelectionLocked === true) {
-        return { compacted: false };
-      }
-      return {
-        compacted: false,
-        fallbackToContextEngine: true,
-        failureReason: CODEX_APP_SERVER_OWNS_AUTO_COMPACTION_REASON,
-      };
+      // Codex owns automatic thread compaction (codex-rs runs it inline during
+      // turns); falling back to context-engine compaction here fought that
+      // ownership and failed OAuth-only sessions with "No API key found".
+      log.info(
+        `CLI native harness compaction skipped for ${params.provider}/${params.model}: ${CODEX_APP_SERVER_OWNS_AUTO_COMPACTION_REASON}`,
+      );
+      return { compacted: false };
     }
     const recoverableBindingFailure = isRecoverableNativeHarnessBindingFailure(result);
     const fallbackToContextEngine =


### PR DESCRIPTION
## What Problem This Solves

Budget-triggered compaction for Codex OAuth sessions failed with `No API key found for provider "openai"` after successful turns. The chain: post-turn CLI compaction asks the codex harness to compact; codex correctly declines with "codex app-server owns automatic compaction"; the unlocked branch of that intentional skip then set `fallbackToContextEngine: true`, and the context-engine pass requires a direct provider API key that OAuth-only sessions don't have — a non-benign failure that surfaced every turn.

Closes #114155. Supersedes the approach in #114182 (closed), whose diagnosis by @HOYALIM identified this exact chain (Co-authored-by on the commit).

## Why This Change Was Made

Post-#115284/#115514 the ownership contract is explicit: Codex owns native-thread token pressure (codex-rs runs inline auto-compaction during turns — `codex-rs/core/src/session/turn.rs:1016-1095`); OpenClaw owns only the host-transcript byte fuse. The intentional ownership skip is therefore a terminal no-op, not a reason to compact by other means: the unlocked branch now returns `{compacted: false}` exactly like the locked branch already did (`src/agents/command/cli-compaction.ts`), with the skip logged. Net −10 lines; deletes the last branch that fought the ownership boundary.

## User Impact

Codex OAuth (ChatGPT-auth) sessions no longer error after successful turns when budget compaction fires; codex's own automatic compaction continues to manage the thread, and the host byte fuse (#115514) continues to bound the host transcript independently.

## Evidence

- `node scripts/run-vitest.mjs src/agents/command/cli-compaction.test.ts` — 23 passed; the fallback test is rewritten to assert the clean skip for both unlocked and model-selection-locked sessions (no context-engine call, no compaction-store record).
- Codex-backed autoreview on the commit: clean, no accepted findings (0.98).
- Failure chain verified on current main before the fix (skip → `fallbackToContextEngine: true` → non-benign "No API key found" throw at `cli-compaction.ts:784-790`); codex inline auto-compaction verified in sibling `../codex` source.
