### PR TITLE
fix(msteams): prevent duplicate replies after streaming failures

### DIFF
--- a/extensions/msteams/src/reply-stream-controller.sdk.test.ts
+++ b/extensions/msteams/src/reply-stream-controller.sdk.test.ts
@@ -1,0 +1,220 @@
+import { createServer, request as requestHttp } from "node:http";
+import { HttpStream } from "@microsoft/teams.apps/dist/http/http-stream.js";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import { createTeamsReplyStreamController } from "./reply-stream-controller.js";
+
+type TeamsLoopbackRequest = {
+  scenario: string;
+  type: string;
+  text: string;
+  status: number;
+};
+
+const acknowledgedPrefix = "a".repeat(4_000);
+const completeReply = `${acknowledgedPrefix}${"b".repeat(200)}`;
+const requests: TeamsLoopbackRequest[] = [];
+
+const provider = createServer((request, response) => {
+  const chunks: Buffer[] = [];
+  request.on("data", (chunk: Buffer | string) => {
+    chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+  });
+  request.on("end", () => {
+    const activity = JSON.parse(Buffer.concat(chunks).toString("utf8")) as {
+      type?: string;
+      text?: string;
+    };
+    const scenario = request.url?.slice(1) ?? "";
+    const rejected = scenario === "no-ack" || (activity.text?.length ?? 0) > 4_000;
+    const status = rejected ? 403 : 201;
+    requests.push({
+      scenario,
+      type: activity.type ?? "",
+      text: activity.text ?? "",
+      status,
+    });
+    response.writeHead(status, { "content-type": "application/json" });
+    response.end(
+      JSON.stringify(
+        rejected
+          ? {
+              error: {
+                message:
+                  scenario === "cancel"
+                    ? "Content stream was canceled by user"
+                    : "Message size too large",
+              },
+            }
+          : { id: `stream-${scenario}` },
+      ),
+    );
+  });
+  request.on("error", (error) => response.destroy(error));
+});
+
+let providerUrl = "";
+
+beforeAll(async () => {
+  await new Promise<void>((resolve, reject) => {
+    provider.once("error", reject);
+    provider.listen(0, "127.0.0.1", resolve);
+  });
+  const address = provider.address();
+  if (!address || typeof address === "string") {
+    throw new Error("Teams test provider did not expose a loopback address");
+  }
+  providerUrl = `http://127.0.0.1:${address.port}`;
+});
+
+afterAll(async () => {
+  await new Promise<void>((resolve, reject) => {
+    provider.close((error) => (error ? reject(error) : resolve()));
+  });
+});
+
+function createLoopbackController(scenario: string) {
+  const send = async (activity: Record<string, unknown>) => {
+    const result = await new Promise<{
+      status: number;
+      body: { id?: string; error?: { message?: string } };
+    }>((resolve, reject) => {
+      const outgoing = requestHttp(
+        `${providerUrl}/${scenario}`,
+        { method: "POST", headers: { "content-type": "application/json" } },
+        (response) => {
+          const chunks: Buffer[] = [];
+          response.on("data", (chunk: Buffer | string) => {
+            chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+          });
+          response.on("end", () => {
+            try {
+              resolve({
+                status: response.statusCode ?? 500,
+                body: JSON.parse(Buffer.concat(chunks).toString("utf8")) as {
+                  id?: string;
+                  error?: { message?: string };
+                },
+              });
+            } catch (error) {
+              reject(error instanceof Error ? error : new Error(String(error)));
+            }
+          });
+          response.on("error", reject);
+        },
+      );
+      outgoing.on("error", reject);
+      outgoing.end(JSON.stringify(activity));
+    });
+    if (result.status < 200 || result.status >= 300) {
+      throw Object.assign(new Error(result.body.error?.message ?? "Teams streaming failed"), {
+        response: { status: result.status, data: result.body },
+      });
+    }
+    return result.body;
+  };
+  const logger = {
+    child: vi.fn(),
+    debug: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+  };
+  logger.child.mockReturnValue(logger);
+  const stream = new HttpStream(
+    {
+      conversations: {
+        createActivity: (_conversationId: string, activity: Record<string, unknown>) =>
+          send(activity),
+        updateActivity: (
+          _conversationId: string,
+          _activityId: string,
+          activity: Record<string, unknown>,
+        ) => send(activity),
+      },
+    } as never,
+    {
+      bot: { id: "28:loopback-bot", name: "OpenClaw" },
+      conversation: { id: "loopback-conversation", conversationType: "personal" },
+      activityId: "loopback-inbound",
+    } as never,
+    logger as never,
+  );
+  const acknowledgements: Array<{ id: string; text: string }> = [];
+  stream.events.on("chunk", (activity) => {
+    acknowledgements.push({ id: activity.id, text: activity.text ?? "" });
+  });
+  const controller = createTeamsReplyStreamController({
+    allowProviderPreview: true,
+    conversationType: "personal",
+    context: { activity: { type: "message" }, stream } as never,
+    feedbackLoopEnabled: false,
+  });
+  return { acknowledgements, controller, logger, stream };
+}
+
+describe("Microsoft Teams SDK acknowledged stream fallback", () => {
+  it("redelivers only text not acknowledged by the real Teams SDK and HTTP provider", async () => {
+    const { acknowledgements, controller, logger } = createLoopbackController("size-limit");
+
+    controller.onPartialReply({ text: acknowledgedPrefix });
+    await vi.waitFor(() => {
+      expect(logger.error).not.toHaveBeenCalled();
+      expect(acknowledgements).toEqual([{ id: "stream-size-limit", text: acknowledgedPrefix }]);
+    });
+
+    controller.onPartialReply({ text: completeReply });
+    await vi.waitFor(() => {
+      expect(
+        requests.filter(
+          (request) =>
+            request.scenario === "size-limit" &&
+            request.type === "typing" &&
+            request.status === 403,
+        ),
+      ).toHaveLength(1);
+    });
+    expect(acknowledgements).toEqual([{ id: "stream-size-limit", text: acknowledgedPrefix }]);
+    expect(controller.preparePayload({ text: completeReply })).toBeUndefined();
+
+    await expect(controller.finalize()).resolves.toEqual({ text: "b".repeat(200) });
+    // Finalization queues its own metadata activity; this is a second
+    // provider operation, not a retry of the rejected streaming chunk.
+    expect(
+      requests.filter(
+        (request) =>
+          request.scenario === "size-limit" && request.type === "typing" && request.status === 403,
+      ),
+    ).toHaveLength(2);
+  });
+
+  it("never acknowledges a Teams HTTP request rejected before delivery", async () => {
+    const { acknowledgements, controller, logger } = createLoopbackController("no-ack");
+
+    controller.onPartialReply({ text: acknowledgedPrefix });
+    await vi.waitFor(() => {
+      expect(logger.error).toHaveBeenCalled();
+      expect(requests.filter((request) => request.scenario === "no-ack")).toHaveLength(1);
+    });
+
+    expect(acknowledgements).toEqual([]);
+    expect(requests.find((request) => request.scenario === "no-ack")?.status).toBe(403);
+  });
+
+  it("honors a real Teams HTTP cancellation without redelivering the remaining text", async () => {
+    const { acknowledgements, controller, logger, stream } = createLoopbackController("cancel");
+
+    controller.onPartialReply({ text: acknowledgedPrefix });
+    await vi.waitFor(() => {
+      expect(logger.error).not.toHaveBeenCalled();
+      expect(acknowledgements).toEqual([{ id: "stream-cancel", text: acknowledgedPrefix }]);
+    });
+    controller.onPartialReply({ text: completeReply });
+    await vi.waitFor(() => {
+      expect(stream.canceled).toBe(true);
+    });
+
+    expect(controller.preparePayload({ text: completeReply })).toBeUndefined();
+    await expect(controller.finalize()).resolves.toBeUndefined();
+    expect(requests.filter((request) => request.scenario === "cancel")).toHaveLength(2);
+  });
+});

--- a/extensions/msteams/src/reply-stream-controller.test.ts
+++ b/extensions/msteams/src/reply-stream-controller.test.ts
@@ -14,6 +14,43 @@ function makeStream() {
   };
 }
 
+function makeAcknowledgedStream() {
+  type ChunkActivity = {
+    id?: string;
+    type?: string;
+    text?: string;
+    channelData?: { streamType?: string };
+  };
+  const handlers = new Map<number, (activity: ChunkActivity) => void>();
+  let nextSubscriptionId = 0;
+  const stream = {
+    ...makeStream(),
+    events: {
+      on: vi.fn((_event: "chunk", handler: (activity: ChunkActivity) => void) => {
+        const subscriptionId = nextSubscriptionId++;
+        handlers.set(subscriptionId, handler);
+        return subscriptionId;
+      }),
+      off: vi.fn((subscriptionId: number) => {
+        handlers.delete(subscriptionId);
+      }),
+    },
+    acknowledge(text: string, overrides: Partial<ChunkActivity> = {}) {
+      const activity: ChunkActivity = {
+        id: "stream-acknowledged",
+        type: "typing",
+        text,
+        channelData: { streamType: "streaming" },
+        ...overrides,
+      };
+      for (const handler of handlers.values()) {
+        handler(activity);
+      }
+    },
+  };
+  return stream;
+}
+
 function makeContext(stream?: ReturnType<typeof makeStream>) {
   return { activity: { type: "message" }, stream } as never;
 }
@@ -507,6 +544,150 @@ describe("createTeamsReplyStreamController", () => {
       // With the latch, block delivery sends the full final reply.
       const result = ctrl.preparePayload({ text: "hello world final" });
       expect(result).toEqual(expect.objectContaining({ text: "hello world final" }));
+    });
+
+    it("redelivers only the prefix Teams actually acknowledged after a later stream failure", () => {
+      const stream = makeAcknowledgedStream();
+      const ctrl = makeController({ stream });
+
+      ctrl.onPartialReply({ text: "hello" });
+      stream.acknowledge("hello");
+      stream.emit.mockImplementation(() => {
+        throw new Error("network failure");
+      });
+      ctrl.onPartialReply({ text: "hello world" });
+
+      expect(ctrl.preparePayload({ text: "hello world final" })).toEqual({
+        text: " world final",
+      });
+    });
+
+    it("preserves the full fallback when a failed stream has no provider acknowledgement", () => {
+      const stream = makeAcknowledgedStream();
+      const ctrl = makeController({ stream });
+
+      ctrl.onPartialReply({ text: "hello" });
+      stream.emit.mockImplementation(() => {
+        throw new Error("network failure");
+      });
+      ctrl.onPartialReply({ text: "hello world" });
+
+      expect(ctrl.preparePayload({ text: "hello world final" })).toEqual({
+        text: "hello world final",
+      });
+    });
+
+    it("does not trim an independent later payload using a previous stream acknowledgement", () => {
+      const stream = makeAcknowledgedStream();
+      const ctrl = makeController({ stream });
+
+      ctrl.onPartialReply({ text: "hello" });
+      stream.acknowledge("hello");
+      stream.emit.mockImplementation(() => {
+        throw new Error("network failure");
+      });
+      ctrl.onPartialReply({ text: "hello world" });
+
+      expect(ctrl.preparePayload({ text: "hello world" })).toEqual({
+        text: " world",
+      });
+      expect(ctrl.preparePayload({ text: "hello again" })).toEqual({
+        text: "hello again",
+      });
+      expect(stream.events.off).toHaveBeenCalledOnce();
+    });
+
+    it("ignores unrelated, informative, and out-of-order stream acknowledgements", () => {
+      const stream = makeAcknowledgedStream();
+      const ctrl = makeController({ stream });
+
+      ctrl.onPartialReply({ text: "hello" });
+      stream.acknowledge("hello", { type: "message" });
+      stream.acknowledge("hello", { channelData: { streamType: "informative" } });
+      stream.acknowledge("unrelated");
+      stream.acknowledge("he");
+      stream.acknowledge("hello", { id: "different-stream" });
+      stream.acknowledge("h");
+      stream.emit.mockImplementation(() => {
+        throw new Error("network failure");
+      });
+      ctrl.onPartialReply({ text: "hello world" });
+
+      expect(ctrl.preparePayload({ text: "hello world" })).toEqual({
+        text: "llo world",
+      });
+    });
+
+    it("suppresses a failed fallback when Teams already acknowledged the entire text", () => {
+      const stream = makeAcknowledgedStream();
+      const ctrl = makeController({ stream });
+
+      ctrl.onPartialReply({ text: "hello" });
+      stream.acknowledge("hello");
+      stream.emit.mockImplementation(() => {
+        throw new Error("network failure");
+      });
+      ctrl.onPartialReply({ text: "hello world" });
+
+      expect(ctrl.preparePayload({ text: "hello" })).toBeUndefined();
+    });
+
+    it("retains media when Teams already acknowledged all fallback text", () => {
+      const stream = makeAcknowledgedStream();
+      const ctrl = makeController({ stream });
+
+      ctrl.onPartialReply({ text: "hello" });
+      stream.acknowledge("hello");
+      stream.emit.mockImplementation(() => {
+        throw new Error("network failure");
+      });
+      ctrl.onPartialReply({ text: "hello world" });
+
+      expect(
+        ctrl.preparePayload({ text: "hello", mediaUrl: "https://example.com/image.png" }),
+      ).toEqual({
+        text: undefined,
+        mediaUrl: "https://example.com/image.png",
+      });
+    });
+
+    it("redelivers only unacknowledged text when stream close fails", async () => {
+      const stream = makeAcknowledgedStream();
+      const ctrl = makeController({ stream });
+
+      ctrl.onPartialReply({ text: "hello" });
+      stream.acknowledge("hello");
+      expect(ctrl.preparePayload({ text: "hello world" })).toBeUndefined();
+      stream.close.mockRejectedValueOnce(new Error("close failed"));
+
+      await expect(ctrl.finalize()).resolves.toEqual({ text: " world" });
+      expect(stream.events.off).toHaveBeenCalledWith(0);
+    });
+
+    it("does not redeliver an acknowledged final when stream close produces no activity", async () => {
+      const stream = makeAcknowledgedStream();
+      const ctrl = makeController({ stream });
+
+      ctrl.onPartialReply({ text: "hello" });
+      stream.acknowledge("hello");
+      expect(ctrl.preparePayload({ text: "hello" })).toBeUndefined();
+      stream.close.mockResolvedValueOnce(undefined);
+
+      await expect(ctrl.finalize()).resolves.toBeUndefined();
+      expect(stream.events.off).toHaveBeenCalledWith(0);
+    });
+
+    it("honors cancellation after an acknowledged stream prefix", async () => {
+      const stream = makeAcknowledgedStream();
+      const ctrl = makeController({ stream });
+
+      ctrl.onPartialReply({ text: "hello" });
+      stream.acknowledge("hello");
+      stream.canceled = true;
+
+      expect(ctrl.preparePayload({ text: "hello world" })).toBeUndefined();
+      await expect(ctrl.finalize()).resolves.toBeUndefined();
+      expect(stream.events.off).toHaveBeenCalledWith(0);
     });
 
     it("preserves the no-duplicate behavior for the active streamed segment", () => {

--- a/extensions/msteams/src/reply-stream-controller.ts
+++ b/extensions/msteams/src/reply-stream-controller.ts
@@ -18,6 +18,18 @@ import type { MSTeamsTurnContext } from "./sdk-types.js";
 
 type Maybe<T> = T | undefined;
 
+type TeamsStreamChunkActivity = {
+  id?: string;
+  type?: string;
+  text?: string;
+  channelData?: { streamType?: string };
+};
+
+type TeamsStreamChunkEvents = {
+  on(event: "chunk", handler: (activity: TeamsStreamChunkActivity) => void): number;
+  off(subscriptionId: number): void;
+};
+
 // The SDK throws StreamCancelledError synchronously from stream.emit/update
 // when the user pressed Stop in Teams (Teams replies 403 to the next chunk
 // update and the SDK flips _canceled). Match by `name` rather than importing
@@ -90,8 +102,56 @@ export function createTeamsReplyStreamController(params: {
   // delta. Holding text instead of length preserves the next chunk when the
   // pipeline normalizes trailing whitespace between cumulative snapshots.
   let emittedText = "";
+  let acknowledgedText = "";
+  let acknowledgedStreamId: string | undefined;
+  const streamEvents = (stream as { events?: TeamsStreamChunkEvents } | undefined)?.events;
+  let streamChunkSubscription: number | undefined;
+
+  // The SDK emits `chunk` only after Teams acknowledges a cumulative typing
+  // activity. Never infer delivered text from emit(), queued bytes, or errors.
+  if (typeof streamEvents?.on === "function" && typeof streamEvents.off === "function") {
+    streamChunkSubscription = streamEvents.on("chunk", (activity) => {
+      if (
+        activity.type !== "typing" ||
+        activity.channelData?.streamType !== "streaming" ||
+        !activity.id ||
+        !activity.text ||
+        (acknowledgedStreamId !== undefined && activity.id !== acknowledgedStreamId) ||
+        !activity.text.startsWith(acknowledgedText) ||
+        !emittedText.startsWith(activity.text)
+      ) {
+        return;
+      }
+      acknowledgedStreamId = activity.id;
+      acknowledgedText = activity.text;
+    });
+  }
 
   const wasCanceled = () => canceledLocally || Boolean(stream?.canceled);
+
+  const releaseStreamChunkSubscription = (): void => {
+    if (streamChunkSubscription === undefined) {
+      return;
+    }
+    streamEvents?.off(streamChunkSubscription);
+    streamChunkSubscription = undefined;
+  };
+
+  const fallbackPayloadAfterAcknowledgedText = (payload: ReplyPayload): Maybe<ReplyPayload> => {
+    if (
+      !acknowledgedText ||
+      typeof payload.text !== "string" ||
+      !payload.text.startsWith(acknowledgedText)
+    ) {
+      return payload;
+    }
+    const remainingText = payload.text.slice(acknowledgedText.length);
+    const hasMedia = Boolean(payload.mediaUrl || payload.mediaUrls?.length);
+    if (!remainingText && !hasMedia) {
+      return undefined;
+    }
+    return { ...payload, text: remainingText || undefined };
+  };
 
   const fallbackPayloadForSuppressedFinal = (payload: ReplyPayload): ReplyPayload => {
     const hasMedia = Boolean(payload.mediaUrl || payload.mediaUrls?.length);
@@ -203,11 +263,8 @@ export function createTeamsReplyStreamController(params: {
           canceledLocally = true;
           return;
         }
-        // Non-cancel failure: latch streamFailed so `preparePayload` lets
-        // block delivery happen even though tokens were already emitted.
-        // The user may see a duplicate (streamed prefix + full block reply)
-        // — that's intentional and matches the pre-migration recovery
-        // behavior; truncated-only is the worse outcome.
+        // Preserve full fallback unless the SDK has proved exactly which
+        // cumulative prefix Teams accepted; failed emits prove no delivery.
         streamFailed = true;
         params.log?.warn?.(
           `msteams stream emit failed, falling back to block delivery: ${err instanceof Error ? err.message : String(err)}`,
@@ -306,14 +363,24 @@ export function createTeamsReplyStreamController(params: {
       // Partial mode with tokens already streamed: stream carries the text;
       // strip text from the payload (keep media if any) so block delivery
       // doesn't duplicate. Exception: if a non-cancel stream failure was
-      // latched mid-flight, fall through to block delivery so the user gets
-      // the full reply instead of the truncated streamed prefix.
+      // latched mid-flight, deliver only a provider-acknowledged remainder;
+      // preserve the full reply when delivery was not acknowledged.
       if (tokensEmitted && !streamFailed) {
         const hasMedia = Boolean(payload.mediaUrl || payload.mediaUrls?.length);
         pendingFinalPayload = fallbackPayloadForSuppressedFinal(payload);
         streamFinalizationPending = true;
         tokensEmitted = false;
         return hasMedia ? { ...payload, text: undefined } : undefined;
+      }
+      if (streamFailed) {
+        const fallback = fallbackPayloadAfterAcknowledgedText(payload);
+        // An acknowledged prefix belongs to this failed segment only;
+        // later tool-round payloads must never inherit its trimming state.
+        pendingFinalPayload = undefined;
+        acknowledgedText = "";
+        acknowledgedStreamId = undefined;
+        releaseStreamChunkSubscription();
+        return fallback;
       }
       // Progress mode (or partial mode that received no tokens — e.g. a
       // tool-only response): emit the final text into the stream so the
@@ -347,6 +414,7 @@ export function createTeamsReplyStreamController(params: {
       // stop it before closing so it cannot fire against the closed stream.
       progressDraftGate.cancel();
       if (!stream || !streamFinalizationPending || wasCanceled()) {
+        releaseStreamChunkSubscription();
         return undefined;
       }
       // Emit a final MessageActivity carrying the AI-generated marker and (if
@@ -376,7 +444,9 @@ export function createTeamsReplyStreamController(params: {
         if (!result) {
           const fallback = pendingFinalPayload;
           pendingFinalPayload = undefined;
-          return fallback;
+          return fallback && !wasCanceled()
+            ? fallbackPayloadAfterAcknowledgedText(fallback)
+            : undefined;
         }
         pendingFinalPayload = undefined;
         return undefined;
@@ -400,7 +470,9 @@ export function createTeamsReplyStreamController(params: {
         );
         const fallback = pendingFinalPayload;
         pendingFinalPayload = undefined;
-        return fallback;
+        return fallback ? fallbackPayloadAfterAcknowledgedText(fallback) : undefined;
+      } finally {
+        releaseStreamChunkSubscription();
       }
     },
 


### PR DESCRIPTION
Fixes #91723

## What Problem This Solves

Fixes an issue where Microsoft Teams users receiving a streamed reply longer than 4,000 characters would see the already delivered text a second time when Teams rejected a later streaming chunk.

## Why This Change Was Made

Use the Microsoft Teams SDK's real provider-acknowledged `chunk` event as the only evidence that a cumulative text prefix was delivered. On a non-cancellation failure, deliver only the remaining text after that exact acknowledged prefix. Without a provider acknowledgement, preserve the existing full-reply fallback. Cancellation, later tool-round payloads, media, and the existing delivery-trace goldens retain their existing behavior.

The change stays inside the Microsoft Teams plugin and adds no public SDK types, configuration, or changed fallback goldens.

## User Impact

Long streamed Teams replies are delivered completely without duplicating text that Teams already acknowledged. Users who press Stop do not receive an unwanted fallback message, and unacknowledged failures still recover the complete reply.

## Evidence

- Blacksmith Testbox `tbx_01kyp6smx6dv0a5q1csv97p7m3`: exact final remote timing reports `exitCode=0` for all 95 focused tests and the complete changed gate.
- Real installed `@microsoft/teams.apps` `HttpStream` against a real loopback HTTP provider: a 4,000-character acknowledged chunk followed by a rejected 4,200-character chunk produces exactly the 200-character fallback; a first-write HTTP 403 produces no false acknowledgement; a real HTTP cancellation produces no fallback.
- All four existing Teams delivery-trace goldens, including full redelivery when acknowledgement evidence is unavailable, pass unchanged.
- Both extension and extension-test `tsgo` lanes, type-aware lint, formatting, plugin-boundary, public SDK, import-cycle, dependency, and all other changed-file guards pass.
- Exact-source Codex autoreview, `gpt-5.6-sol`, `xhigh`: no actionable findings; confidence 0.93.
- Microsoft contract: https://learn.microsoft.com/en-us/microsoftteams/platform/bots/streaming-ux
