### PR TITLE
fix(ci): resolve code mode matrix lint failure

### DIFF
--- a/scripts/code-mode-model-matrix.ts
+++ b/scripts/code-mode-model-matrix.ts
@@ -401,7 +401,7 @@ async function canonicalizeExistingPathPrefix(value: string): Promise<string> {
 
 async function runtimeArtifactDirectories(repoRoot: string, outputDir: string): Promise<string[]> {
   const packagesRoot = path.join(repoRoot, "packages");
-  const packageEntries = await fs.readdir(packagesRoot, { withFileTypes: true }).catch((error) => {
+  const packageEntries = await fs.readdir(packagesRoot, { withFileTypes: true }).catch((error: unknown) => {
     if ((error as NodeJS.ErrnoException).code === "ENOENT") {
       return [];
     }


### PR DESCRIPTION
## What Problem This Solves

Resolves a CI lint failure in the code-mode model matrix script. The promise rejection callback parameter is inferred as `any`, violating the repository lint rule.

## Why This Change Was Made

Types the callback parameter as `unknown`, retaining the existing ENOENT handling while satisfying the lint contract.

## User Impact

No runtime user impact. CI can lint this script without the pre-existing failure.

## Evidence

- `git diff --check` passed.
- The local `oxlint` binary is unavailable in this linked worktree, so the focused lint command could not run locally.
- The failure was reproduced independently on `main` in Actions run 30427671741 before the unrelated Telegram workflow change.