### PR TITLE
fix(browser): release unread CDP response streams

### DIFF
--- a/extensions/browser/src/browser/cdp.helpers.internal.test.ts
+++ b/extensions/browser/src/browser/cdp.helpers.internal.test.ts
@@ -133,6 +133,36 @@ describe("cdp.helpers internal", () => {
       expect(release).toHaveBeenCalledTimes(1);
     });
 
+    it("releases the guarded fetch even when cancelling the unread response fails", async () => {
+      const cancel = vi.fn(async () => {
+        throw new Error("fixture response cancellation failed");
+      });
+      const release = vi.fn(async () => {});
+      fetchWithSsrFGuardMock.mockResolvedValueOnce({
+        response: {
+          ok: true,
+          status: 200,
+          bodyUsed: false,
+          body: { cancel },
+        } as unknown as Response,
+        release,
+      });
+
+      const { release: guardedRelease } = await fetchCdpChecked(
+        "http://127.0.0.1:9222/json/version",
+        250,
+        undefined,
+        { dangerouslyAllowPrivateNetwork: false, allowedHostnames: ["127.0.0.1"] },
+      );
+
+      await expect(guardedRelease()).resolves.toBeUndefined();
+      expect(cancel).toHaveBeenCalledOnce();
+      expect(release).toHaveBeenCalledOnce();
+      expect(cancel.mock.invocationCallOrder[0]!).toBeLessThan(
+        release.mock.invocationCallOrder[0]!,
+      );
+    });
+
     it("registers a managed-proxy bypass for the exact sanitized fetch URL", async () => {
       const release = vi.fn();
       registerManagedProxyBrowserCdpBypassMock.mockReturnValueOnce(release);

--- a/extensions/browser/src/browser/cdp.helpers.transport.test.ts
+++ b/extensions/browser/src/browser/cdp.helpers.transport.test.ts
@@ -1,0 +1,185 @@
+// Exercise real authenticated browser CDP response streams and TCP cleanup.
+import { createServer, type Server } from "node:http";
+import type { Socket } from "node:net";
+import { describe, expect, it, vi } from "vitest";
+import { fetchCdpChecked, fetchJson, fetchOk } from "./cdp.helpers.js";
+
+const CDP_USERNAME = "openclaw";
+const CDP_FIXTURE_TOKEN = "browser-cdp-transport-test";
+const EXPECTED_AUTHORIZATION = `Basic ${Buffer.from(
+  `${CDP_USERNAME}:${CDP_FIXTURE_TOKEN}`,
+).toString("base64")}`;
+
+type AuthenticatedCdpServer = {
+  url: string;
+  sockets: Set<Socket>;
+  authorizations: Array<string | undefined>;
+  close: () => Promise<void>;
+};
+
+async function startAuthenticatedCdpServer(params: {
+  status: number;
+  streaming: boolean;
+}): Promise<AuthenticatedCdpServer> {
+  const sockets = new Set<Socket>();
+  const authorizations: Array<string | undefined> = [];
+  const server: Server = createServer((request, response) => {
+    authorizations.push(request.headers.authorization);
+    if (request.headers.authorization !== EXPECTED_AUTHORIZATION) {
+      response.writeHead(401);
+      response.end();
+      return;
+    }
+
+    response.writeHead(params.status, { "content-type": "application/json" });
+    if (params.streaming) {
+      // Keep the response body open until the actual CDP client cancels it.
+      response.write('{"Browser":');
+      return;
+    }
+    response.end(JSON.stringify({ Browser: "OpenClaw transport fixture" }));
+  });
+  server.on("connection", (socket) => {
+    sockets.add(socket);
+    socket.once("close", () => {
+      sockets.delete(socket);
+    });
+  });
+
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      server.off("error", reject);
+      resolve();
+    });
+  });
+  const address = server.address();
+  if (!address || typeof address === "string") {
+    throw new Error("expected the browser CDP fixture to bind a loopback TCP port");
+  }
+
+  return {
+    url: `http://${CDP_USERNAME}:${CDP_FIXTURE_TOKEN}@127.0.0.1:${address.port}/json/version`,
+    sockets,
+    authorizations,
+    close: async () => {
+      server.closeAllConnections();
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()));
+      });
+    },
+  };
+}
+
+async function expectAllSocketsReleased(server: AuthenticatedCdpServer): Promise<void> {
+  await vi.waitFor(
+    () => {
+      expect(server.sockets.size).toBe(0);
+    },
+    { timeout: 1_250, interval: 20 },
+  );
+}
+
+describe("browser CDP authenticated HTTP transport", () => {
+  it("closes every unread streaming response after concurrent status probes", async () => {
+    const server = await startAuthenticatedCdpServer({ status: 200, streaming: true });
+    try {
+      await Promise.all(Array.from({ length: 8 }, () => fetchOk(server.url, 1_000)));
+
+      expect(server.authorizations).toEqual(Array(8).fill(EXPECTED_AUTHORIZATION));
+      await expectAllSocketsReleased(server);
+    } finally {
+      await server.close();
+    }
+  });
+
+  it("releases an unread streaming response even when a caller clones it", async () => {
+    const server = await startAuthenticatedCdpServer({ status: 200, streaming: true });
+    try {
+      const { response, release } = await fetchCdpChecked(server.url, 1_000);
+      const clone = response.clone();
+      let released = false;
+      const releasing = release();
+      void releasing
+        .finally(() => {
+          released = true;
+        })
+        .catch(() => {});
+
+      expect(clone.bodyUsed).toBe(false);
+      await vi.waitFor(
+        () => {
+          expect(released).toBe(true);
+        },
+        { timeout: 1_250, interval: 20 },
+      );
+      await releasing;
+
+      expect(server.authorizations).toEqual([EXPECTED_AUTHORIZATION]);
+      await expectAllSocketsReleased(server);
+    } finally {
+      await server.close();
+    }
+  });
+
+  it("closes a partially consumed response while its stream reader remains locked", async () => {
+    const server = await startAuthenticatedCdpServer({ status: 200, streaming: true });
+    try {
+      const { response, release } = await fetchCdpChecked(server.url, 1_000);
+      const reader = response.body?.getReader();
+      if (!reader) {
+        throw new Error("expected the authenticated CDP response to expose a readable stream");
+      }
+      const readerClosed = reader.closed.catch(() => {});
+      const firstChunk = await reader.read();
+
+      expect(firstChunk.done).toBe(false);
+      expect(firstChunk.value?.byteLength).toBeGreaterThan(0);
+      expect(response.bodyUsed).toBe(true);
+      await release();
+
+      expect(server.authorizations).toEqual([EXPECTED_AUTHORIZATION]);
+      await expectAllSocketsReleased(server);
+      await readerClosed;
+    } finally {
+      await server.close();
+    }
+  });
+
+  it("closes an unread streaming response when a CDP request fails", async () => {
+    const server = await startAuthenticatedCdpServer({ status: 503, streaming: true });
+    try {
+      await expect(fetchCdpChecked(server.url, 1_000)).rejects.toThrow("HTTP 503");
+
+      expect(server.authorizations).toEqual([EXPECTED_AUTHORIZATION]);
+      await expectAllSocketsReleased(server);
+    } finally {
+      await server.close();
+    }
+  });
+
+  it("closes an unread streaming response without changing rate-limit errors", async () => {
+    const server = await startAuthenticatedCdpServer({ status: 429, streaming: true });
+    try {
+      await expect(fetchCdpChecked(server.url, 1_000)).rejects.toThrow(/rate[ -]?limit/i);
+
+      expect(server.authorizations).toEqual([EXPECTED_AUTHORIZATION]);
+      await expectAllSocketsReleased(server);
+    } finally {
+      await server.close();
+    }
+  });
+
+  it("preserves authenticated, fully consumed CDP JSON responses", async () => {
+    const server = await startAuthenticatedCdpServer({ status: 200, streaming: false });
+    try {
+      await expect(fetchJson(server.url, 1_000)).resolves.toEqual({
+        Browser: "OpenClaw transport fixture",
+      });
+
+      expect(server.authorizations).toEqual([EXPECTED_AUTHORIZATION]);
+    } finally {
+      await server.close();
+    }
+  });
+});

--- a/extensions/browser/src/browser/cdp.helpers.ts
+++ b/extensions/browser/src/browser/cdp.helpers.ts
@@ -606,6 +606,7 @@ export async function fetchCdpChecked(
   const ctrl = new AbortController();
   const t = setTimeout(ctrl.abort.bind(ctrl), normalizeBrowserTimerDelayMs(timeoutMs));
   const signal = init?.signal ? AbortSignal.any([ctrl.signal, init.signal]) : ctrl.signal;
+  let response: Response | undefined;
   let guardedRelease: (() => Promise<void>) | undefined;
   let released = false;
   const release = async () => {
@@ -614,7 +615,20 @@ export async function fetchCdpChecked(
     }
     released = true;
     clearTimeout(t);
-    await guardedRelease?.();
+    // Abort first: cloned bodies can keep cancellation pending, and a
+    // caller-owned reader can leave a partially consumed stream locked.
+    ctrl.abort();
+    try {
+      // Status-only and failed probes do not consume their response streams.
+      // Cancel them before releasing the guard so Undici frees the CDP socket.
+      if (response && !response.bodyUsed) {
+        await response.body?.cancel();
+      }
+    } catch {
+      // A broken response stream must not mask the result or skip guard cleanup.
+    } finally {
+      await guardedRelease?.();
+    }
   };
   try {
     const headers = getHeadersWithAuth(url, (init?.headers as Record<string, string>) || {});
@@ -635,7 +649,8 @@ export async function fetchCdpChecked(
           auditContext: "browser-cdp",
         });
         guardedRelease = guarded.release;
-        return guarded.response;
+        response = guarded.response;
+        return response;
       }),
     );
     if (!res.ok) {


### PR DESCRIPTION
Supersedes #111227. Thanks to @hugenshen for identifying the original browser CDP response-stream leak and providing the earlier contributor patch.

## What Problem This Solves

Fixes an issue where ordinary authenticated browser status probes, partially consumed CDP responses, cloned streaming responses, failed browser CDP requests, and rate-limited CDP requests returned while leaving their HTTP connections open. Concurrent probes could retain one real TCP socket per request, and a response clone could make cleanup hang indefinitely.

## Why This Change Was Made

Abort only the browser owner's local request controller before cancelling an unread CDP response. This ordering releases cloned and caller-locked streams without waiting forever on a teed response body. Always release the SSRF-guarded dispatcher in `finally`, even if a response stream rejects cancellation.

Consumed JSON, Basic authentication, loopback and remote SSRF policy, error sanitization, rate-limit handling, and idempotent release remain unchanged. No new configuration, dependencies, public Plugin SDK APIs, or gateway protocol.

## User Impact

Browser status, tab, and diagnostics probes release their authenticated CDP connections immediately for ordinary, cloned, partially read, failed, and rate-limited responses. Concurrent browser activity no longer accumulates leaked sockets or hangs during response cleanup.

## Evidence

- Independently reproduced against frozen `main` `8fd49c84aa2dd144cf7a687a656de7ea50fc73a4` using a real authenticated loopback CDP server: eight simultaneous probes left **eight** real open sockets; streaming HTTP 503 and 429 each left a socket. All baseline regressions failed before the fix.
- Independent xhigh review separately identified both a partially read, reader-locked stream and an unread `Response.clone()` tee. Each was reproduced against the intermediate implementation as a real failing authenticated transport test before correcting it.
- Final real transport proves **eight connections become zero**, cloned cleanup completes, locked readers release, HTTP 503 and 429 preserve their errors while closing their sockets, and fully consumed authenticated JSON succeeds.
- Fresh Linux proof: **193 tests passed** across eight CDP, authenticated transport, fuzz, tab-selection, remote-profile, and managed-Chrome suites.
- Complete remote `pnpm check:changed`: passed, including formatting, lint, production and test typechecks, Plugin SDK API, plugin boundaries, dead code, database, and runtime import-cycle guards.
- Personally inspected [Undici's official response-body and garbage-collection contract](https://github.com/nodejs/undici?tab=readme-ov-file#garbage-collection).
- AI-assisted and source-audited. The original contributor PR #111227 remains open and credited until this canonical fix is safely landed.