### PR TITLE
feat(telegram): include actual error detail in fallback messages

### DIFF
--- a/extensions/telegram/src/bot-message-dispatch.draft-failures-progress.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.draft-failures-progress.test.ts
@@ -72,7 +72,7 @@ describeTelegramDispatch("dispatchTelegramMessage draft-failures-progress", () =
     expectDeliveredReply(
       0,
       {
-        text: "Something went wrong while processing your request. Please try again.",
+        text: "⚠️ dispatch failed after partial output\n\nPlease try again, or use /new to start a fresh session.",
       },
       1,
     );
@@ -101,7 +101,7 @@ describeTelegramDispatch("dispatchTelegramMessage draft-failures-progress", () =
     expectDeliveredReply(
       0,
       {
-        text: "Something went wrong while processing your request. Please try again.",
+        text: "⚠️ dispatch failed after partial output\n\nPlease try again, or use /new to start a fresh session.",
       },
       1,
     );

--- a/extensions/telegram/src/bot-message-dispatch.draft-failures-progress.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.draft-failures-progress.test.ts
@@ -72,7 +72,7 @@ describeTelegramDispatch("dispatchTelegramMessage draft-failures-progress", () =
     expectDeliveredReply(
       0,
       {
-        text: "⚠️ dispatch failed after partial output\n\nPlease try again, or use /new to start a fresh session.",
+        text: "Something went wrong while processing your request. Please try again.",
       },
       1,
     );
@@ -101,7 +101,7 @@ describeTelegramDispatch("dispatchTelegramMessage draft-failures-progress", () =
     expectDeliveredReply(
       0,
       {
-        text: "⚠️ dispatch failed after partial output\n\nPlease try again, or use /new to start a fresh session.",
+        text: "Something went wrong while processing your request. Please try again.",
       },
       1,
     );

--- a/extensions/telegram/src/bot-message-dispatch.draft-failures-progress.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.draft-failures-progress.test.ts
@@ -622,4 +622,33 @@ describeTelegramDispatch("dispatchTelegramMessage draft-failures-progress", () =
     const texts = allDeliveredReplyTexts();
     expect(texts.some((text) => text.includes("tool call · ⏱️"))).toBe(false);
   });
+
+  it("uses generic fallback for Telegram delivery errors, not allowlisted categories", async () => {
+    // A 429 from Telegram delivery (e.g. flood limit) should NOT produce
+    // "Rate limit reached" — that would misattribute a transport error
+    // to the provider. Delivery errors must stay on the generic fallback.
+    deliverReplies
+      .mockResolvedValueOnce({ delivered: true }) // partial block
+      .mockRejectedValueOnce(new Error("429 Too Many Requests: retry after 3")); // terminal delivery fails
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(async ({ dispatcherOptions }) => {
+      await dispatcherOptions.deliver({ text: "partial answer" }, { kind: "block" });
+      return { queuedFinal: false };
+    });
+
+    await dispatchWithContext({
+      context: createContext({
+        ctxPayload: createDirectSessionPayload(),
+      }),
+      streamMode: "off",
+    });
+
+    expectDeliveredReply(0, { text: "partial answer" });
+    expectDeliveredReply(
+      0,
+      {
+        text: "Something went wrong while processing your request. Please try again.",
+      },
+      1,
+    );
+  });
 });

--- a/extensions/telegram/src/bot-message-dispatch.ts
+++ b/extensions/telegram/src/bot-message-dispatch.ts
@@ -56,7 +56,9 @@ const EMPTY_RESPONSE_FALLBACK = "No response generated. Please try again.";
  */
 function formatDispatchErrorFallback(err: unknown): string {
   const detail = formatErrorMessage(err).trim();
-  if (!detail) return "Something went wrong while processing your request. Please try again.";
+  if (!detail) {
+    return "Something went wrong while processing your request. Please try again.";
+  }
   const truncated = detail.length > 400 ? `${detail.slice(0, 400)}…` : detail;
   return `⚠️ ${truncated}\n\nPlease try again, or use /new to start a fresh session.`;
 }

--- a/extensions/telegram/src/bot-message-dispatch.ts
+++ b/extensions/telegram/src/bot-message-dispatch.ts
@@ -3,6 +3,7 @@ import {
   createOutboundPayloadPlan,
   projectOutboundPayloadPlanForDelivery,
 } from "openclaw/plugin-sdk/channel-outbound";
+import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import { getGlobalHookRunner } from "openclaw/plugin-sdk/plugin-runtime";
 import { createSubsystemLogger, danger, logVerbose } from "openclaw/plugin-sdk/runtime-env";
 import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
@@ -45,6 +46,20 @@ import {
 import { cacheSticker, describeStickerImage } from "./sticker-cache.js";
 
 const EMPTY_RESPONSE_FALLBACK = "No response generated. Please try again.";
+
+/**
+ * Format a dispatch error into a user-visible fallback message.
+ *
+ * Instead of a generic "Something went wrong", extract the actual error
+ * detail (e.g. "502 Internal server error") so the user knows whether the
+ * provider is down, the request was malformed, etc.
+ */
+function formatDispatchErrorFallback(err: unknown): string {
+  const detail = formatErrorMessage(err).trim();
+  if (!detail) return "Something went wrong while processing your request. Please try again.";
+  const truncated = detail.length > 400 ? `${detail.slice(0, 400)}…` : detail;
+  return `⚠️ ${truncated}\n\nPlease try again, or use /new to start a fresh session.`;
+}
 const silentReplyDispatchLogger = createSubsystemLogger("telegram/silent-reply-dispatch");
 
 async function resolveStickerVisionSupport(
@@ -493,7 +508,7 @@ export const dispatchTelegramMessage = async ({
       deliverySummary.failedNonSilent > 0);
   if (shouldSendFailureFallback) {
     const fallbackText = state.dispatchError
-      ? "Something went wrong while processing your request. Please try again."
+      ? formatDispatchErrorFallback(state.dispatchError)
       : EMPTY_RESPONSE_FALLBACK;
     const result = await delivery.deliverFallback(
       [{ text: fallbackText }],

--- a/extensions/telegram/src/bot-message-dispatch.ts
+++ b/extensions/telegram/src/bot-message-dispatch.ts
@@ -456,7 +456,7 @@ export const dispatchTelegramMessage = async ({
       try {
         await delivery.finalizePendingAnswerBlockDraft(state);
       } catch (err) {
-        state.dispatchError ??= err;
+        state.deliveryError ??= err;
         runtime.error?.(danger(`telegram terminal block delivery failed: ${String(err)}`));
       }
       await draft.cleanup(isDispatchSuperseded());
@@ -491,12 +491,18 @@ export const dispatchTelegramMessage = async ({
     !suppressFailureFallback &&
     !progress.finalAnswerDelivered() &&
     (state.dispatchError ||
+      state.deliveryError ||
       deliverySummary.skippedNonSilent > 0 ||
       deliverySummary.failedNonSilent > 0);
   if (shouldSendFailureFallback) {
+    // Provider/agent errors are classified by the allowlisted presenter.
+    // Telegram delivery errors get the generic fallback to avoid misattributing
+    // transport failures (e.g. flood-limit 429) as provider problems.
     const fallbackText = state.dispatchError
       ? formatTelegramFallbackError(state.dispatchError)
-      : EMPTY_RESPONSE_FALLBACK;
+      : state.deliveryError
+        ? "Something went wrong while processing your request. Please try again."
+        : EMPTY_RESPONSE_FALLBACK;
     const result = await delivery.deliverFallback(
       [{ text: fallbackText }],
       telegramCfg.silentErrorReplies === true &&
@@ -551,6 +557,7 @@ export const dispatchTelegramMessage = async ({
     (deliverySummary.skippedNonSilent > 0 || deliverySummary.failedNonSilent > 0);
   const retryableDispatchFailure =
     state.dispatchError ??
+    state.deliveryError ??
     (deliveryFailureWithoutFinalResponse
       ? new Error(
           `Telegram reply delivery failed without a final response (failed=${deliverySummary.failedNonSilent}, skipped=${deliverySummary.skippedNonSilent})`,
@@ -562,8 +569,11 @@ export const dispatchTelegramMessage = async ({
   }
   const shouldReturnRetryableDispatchFailure =
     retryDispatchErrors &&
-    ((state.dispatchError != null && !hasFinalResponse) ||
-      (state.dispatchError == null && deliveryFailureWithoutFinalResponse && !hasVisibleResponse));
+    (((state.dispatchError != null || state.deliveryError != null) && !hasFinalResponse) ||
+      (state.dispatchError == null &&
+        state.deliveryError == null &&
+        deliveryFailureWithoutFinalResponse &&
+        !hasVisibleResponse));
   if (retryableDispatchFailure && shouldReturnRetryableDispatchFailure) {
     return { kind: "failed-retryable", error: retryableDispatchFailure };
   }
@@ -582,7 +592,8 @@ export const dispatchTelegramMessage = async ({
     status.finalizeInBackground(
       {
         outcome:
-          !progress.finalAnswerDelivered() && (state.dispatchError != null || sentFallback)
+          !progress.finalAnswerDelivered() &&
+          (state.dispatchError != null || state.deliveryError != null || sentFallback)
             ? "error"
             : "done",
       },

--- a/extensions/telegram/src/bot-message-dispatch.ts
+++ b/extensions/telegram/src/bot-message-dispatch.ts
@@ -3,7 +3,6 @@ import {
   createOutboundPayloadPlan,
   projectOutboundPayloadPlanForDelivery,
 } from "openclaw/plugin-sdk/channel-outbound";
-import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import { getGlobalHookRunner } from "openclaw/plugin-sdk/plugin-runtime";
 import { createSubsystemLogger, danger, logVerbose } from "openclaw/plugin-sdk/runtime-env";
 import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
@@ -44,24 +43,10 @@ import {
   type TelegramNativeQuoteCandidateByMessageId,
 } from "./bot/native-quote.js";
 import { cacheSticker, describeStickerImage } from "./sticker-cache.js";
+import { formatTelegramFallbackError } from "./telegram-error-presenter.js";
 
 const EMPTY_RESPONSE_FALLBACK = "No response generated. Please try again.";
 
-/**
- * Format a dispatch error into a user-visible fallback message.
- *
- * Instead of a generic "Something went wrong", extract the actual error
- * detail (e.g. "502 Internal server error") so the user knows whether the
- * provider is down, the request was malformed, etc.
- */
-function formatDispatchErrorFallback(err: unknown): string {
-  const detail = formatErrorMessage(err).trim();
-  if (!detail) {
-    return "Something went wrong while processing your request. Please try again.";
-  }
-  const truncated = detail.length > 400 ? `${detail.slice(0, 400)}…` : detail;
-  return `⚠️ ${truncated}\n\nPlease try again, or use /new to start a fresh session.`;
-}
 const silentReplyDispatchLogger = createSubsystemLogger("telegram/silent-reply-dispatch");
 
 async function resolveStickerVisionSupport(
@@ -510,7 +495,7 @@ export const dispatchTelegramMessage = async ({
       deliverySummary.failedNonSilent > 0);
   if (shouldSendFailureFallback) {
     const fallbackText = state.dispatchError
-      ? formatDispatchErrorFallback(state.dispatchError)
+      ? formatTelegramFallbackError(state.dispatchError)
       : EMPTY_RESPONSE_FALLBACK;
     const result = await delivery.deliverFallback(
       [{ text: fallbackText }],

--- a/extensions/telegram/src/bot-message-dispatch.types.ts
+++ b/extensions/telegram/src/bot-message-dispatch.types.ts
@@ -68,5 +68,8 @@ export type TelegramDispatchTurnState = {
   queuedFinal: boolean;
   suppressSilentReplyFallback: boolean;
   hadErrorReplyFailureOrSkip: boolean;
+  /** Error from the agent/provider dispatch turn (provider failures). */
   dispatchError?: unknown;
+  /** Error from terminal Telegram delivery (transport failures). */
+  deliveryError?: unknown;
 };

--- a/extensions/telegram/src/bot-message.test.ts
+++ b/extensions/telegram/src/bot-message.test.ts
@@ -335,7 +335,7 @@ describe("telegram bot message processor", () => {
 
     expect(sendMessage).toHaveBeenCalledWith(
       123,
-      "⚠️ dispatch exploded\n\nPlease try again, or use /new to start a fresh session.",
+      "Something went wrong while processing your request. Please try again.",
       { message_thread_id: 456 },
     );
     expect(runtimeError).toHaveBeenCalledWith(
@@ -822,7 +822,7 @@ describe("telegram bot message processor", () => {
 
     expect(sendMessage).toHaveBeenCalledWith(
       123,
-      "⚠️ dispatch exploded\n\nPlease try again, or use /new to start a fresh session.",
+      "Something went wrong while processing your request. Please try again.",
       undefined,
     );
   });
@@ -842,7 +842,7 @@ describe("telegram bot message processor", () => {
 
     expect(sendMessage).toHaveBeenCalledWith(
       123,
-      "⚠️ dispatch exploded\n\nPlease try again, or use /new to start a fresh session.",
+      "Something went wrong while processing your request. Please try again.",
       undefined,
     );
     expect(runtimeError).toHaveBeenCalledWith(

--- a/extensions/telegram/src/bot-message.test.ts
+++ b/extensions/telegram/src/bot-message.test.ts
@@ -335,7 +335,7 @@ describe("telegram bot message processor", () => {
 
     expect(sendMessage).toHaveBeenCalledWith(
       123,
-      "Something went wrong while processing your request. Please try again.",
+      "⚠️ dispatch exploded\n\nPlease try again, or use /new to start a fresh session.",
       { message_thread_id: 456 },
     );
     expect(runtimeError).toHaveBeenCalledWith(
@@ -822,7 +822,7 @@ describe("telegram bot message processor", () => {
 
     expect(sendMessage).toHaveBeenCalledWith(
       123,
-      "Something went wrong while processing your request. Please try again.",
+      "⚠️ dispatch exploded\n\nPlease try again, or use /new to start a fresh session.",
       undefined,
     );
   });
@@ -842,7 +842,7 @@ describe("telegram bot message processor", () => {
 
     expect(sendMessage).toHaveBeenCalledWith(
       123,
-      "Something went wrong while processing your request. Please try again.",
+      "⚠️ dispatch exploded\n\nPlease try again, or use /new to start a fresh session.",
       undefined,
     );
     expect(runtimeError).toHaveBeenCalledWith(

--- a/extensions/telegram/src/bot-message.ts
+++ b/extensions/telegram/src/bot-message.ts
@@ -35,7 +35,6 @@ import type { TelegramContext } from "./bot/types.js";
 import type { TelegramReplyChainEntry } from "./message-cache.js";
 import { TELEGRAM_TEXT_CHUNK_LIMIT } from "./outbound-adapter.js";
 import { TELEGRAM_RICH_TEXT_LIMIT } from "./rich-message.js";
-import { formatTelegramFallbackError } from "./telegram-error-presenter.js";
 import { resolveSpooledUpdatePersistenceRetryDelayMs } from "./telegram-ingress-spool.js";
 
 const telegramInboundLog = createSubsystemLogger("gateway/channels/telegram").child("inbound");
@@ -309,10 +308,13 @@ export const createTelegramMessageProcessor = (deps: TelegramMessageProcessorDep
         runtime.error?.(danger(`telegram message processing failed: ${String(err)}`));
         if (!spooledReplay) {
           try {
-            const fallbackText = formatTelegramFallbackError(err);
+            // The outer catch wraps the entire dispatch call; the error origin
+            // is ambiguous (could be provider or Telegram transport), so use
+            // the generic fallback rather than misclassifying transport errors
+            // as provider failures.
             await bot.api.sendMessage(
               context.chatId,
-              fallbackText,
+              "Something went wrong while processing your request. Please try again.",
               buildTelegramThreadParams(context.threadSpec),
             );
           } catch {}

--- a/extensions/telegram/src/bot-message.ts
+++ b/extensions/telegram/src/bot-message.ts
@@ -1,6 +1,5 @@
 // Telegram plugin module implements bot message behavior.
 import type { OpenClawConfig, TelegramAccountConfig } from "openclaw/plugin-sdk/config-contracts";
-import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import { resolveTextChunkLimit } from "openclaw/plugin-sdk/reply-chunking";
 import { DEFAULT_GROUP_HISTORY_LIMIT } from "openclaw/plugin-sdk/reply-history";
 import {
@@ -37,6 +36,7 @@ import type { TelegramReplyChainEntry } from "./message-cache.js";
 import { TELEGRAM_TEXT_CHUNK_LIMIT } from "./outbound-adapter.js";
 import { TELEGRAM_RICH_TEXT_LIMIT } from "./rich-message.js";
 import { resolveSpooledUpdatePersistenceRetryDelayMs } from "./telegram-ingress-spool.js";
+import { formatTelegramFallbackError } from "./telegram-error-presenter.js";
 
 const telegramInboundLog = createSubsystemLogger("gateway/channels/telegram").child("inbound");
 
@@ -309,10 +309,7 @@ export const createTelegramMessageProcessor = (deps: TelegramMessageProcessorDep
         runtime.error?.(danger(`telegram message processing failed: ${String(err)}`));
         if (!spooledReplay) {
           try {
-            const errorDetail = formatErrorMessage(err).trim();
-            const fallbackText = errorDetail
-              ? `⚠️ ${errorDetail.length > 400 ? `${errorDetail.slice(0, 400)}…` : errorDetail}\n\nPlease try again, or use /new to start a fresh session.`
-              : "Something went wrong while processing your request. Please try again.";
+            const fallbackText = formatTelegramFallbackError(err);
             await bot.api.sendMessage(
               context.chatId,
               fallbackText,

--- a/extensions/telegram/src/bot-message.ts
+++ b/extensions/telegram/src/bot-message.ts
@@ -1,5 +1,6 @@
 // Telegram plugin module implements bot message behavior.
 import type { OpenClawConfig, TelegramAccountConfig } from "openclaw/plugin-sdk/config-contracts";
+import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import { resolveTextChunkLimit } from "openclaw/plugin-sdk/reply-chunking";
 import { DEFAULT_GROUP_HISTORY_LIMIT } from "openclaw/plugin-sdk/reply-history";
 import {
@@ -308,9 +309,13 @@ export const createTelegramMessageProcessor = (deps: TelegramMessageProcessorDep
         runtime.error?.(danger(`telegram message processing failed: ${String(err)}`));
         if (!spooledReplay) {
           try {
+            const errorDetail = formatErrorMessage(err).trim();
+            const fallbackText = errorDetail
+              ? `⚠️ ${errorDetail.length > 400 ? `${errorDetail.slice(0, 400)}…` : errorDetail}\n\nPlease try again, or use /new to start a fresh session.`
+              : "Something went wrong while processing your request. Please try again.";
             await bot.api.sendMessage(
               context.chatId,
-              "Something went wrong while processing your request. Please try again.",
+              fallbackText,
               buildTelegramThreadParams(context.threadSpec),
             );
           } catch {}

--- a/extensions/telegram/src/bot-message.ts
+++ b/extensions/telegram/src/bot-message.ts
@@ -35,8 +35,8 @@ import type { TelegramContext } from "./bot/types.js";
 import type { TelegramReplyChainEntry } from "./message-cache.js";
 import { TELEGRAM_TEXT_CHUNK_LIMIT } from "./outbound-adapter.js";
 import { TELEGRAM_RICH_TEXT_LIMIT } from "./rich-message.js";
-import { resolveSpooledUpdatePersistenceRetryDelayMs } from "./telegram-ingress-spool.js";
 import { formatTelegramFallbackError } from "./telegram-error-presenter.js";
+import { resolveSpooledUpdatePersistenceRetryDelayMs } from "./telegram-ingress-spool.js";
 
 const telegramInboundLog = createSubsystemLogger("gateway/channels/telegram").child("inbound");
 

--- a/extensions/telegram/src/telegram-error-presenter.test.ts
+++ b/extensions/telegram/src/telegram-error-presenter.test.ts
@@ -1,0 +1,187 @@
+import { describe, expect, it } from "vitest";
+import { formatTelegramFallbackError } from "./telegram-error-presenter.js";
+
+describe("formatTelegramFallbackError", () => {
+  it("maps 429 to rate limit message", () => {
+    expect(formatTelegramFallbackError(new Error("Request failed with 429"))).toBe(
+      "⚠️ Rate limit reached. Please wait a moment and try again.",
+    );
+  });
+
+  it("maps 'rate limit exceeded' to rate limit message", () => {
+    expect(formatTelegramFallbackError(new Error("rate limit exceeded"))).toBe(
+      "⚠️ Rate limit reached. Please wait a moment and try again.",
+    );
+  });
+
+  it("maps 408 to timeout message", () => {
+    expect(formatTelegramFallbackError(new Error("Request failed with 408"))).toBe(
+      "⚠️ Request timed out. Please try again.",
+    );
+  });
+
+  it("maps ETIMEDOUT to timeout message", () => {
+    expect(formatTelegramFallbackError(new Error("ETIMEDOUT"))).toBe(
+      "⚠️ Request timed out. Please try again.",
+    );
+  });
+
+  it("maps 500 to server error message", () => {
+    expect(formatTelegramFallbackError(new Error("500 Internal server error"))).toBe(
+      "⚠️ Provider server error. Please try again in a moment.",
+    );
+  });
+
+  it("maps 502 Bad Gateway to server error message", () => {
+    expect(formatTelegramFallbackError(new Error("502 Bad Gateway"))).toBe(
+      "⚠️ Provider server error. Please try again in a moment.",
+    );
+  });
+
+  it("maps 'Internal server error' to server error message", () => {
+    expect(formatTelegramFallbackError(new Error("Internal server error"))).toBe(
+      "⚠️ Provider server error. Please try again in a moment.",
+    );
+  });
+
+  it("maps 529 to overloaded message", () => {
+    expect(formatTelegramFallbackError(new Error("529 Overloaded"))).toBe(
+      "⚠️ Provider is overloaded. Please try again in a moment.",
+    );
+  });
+
+  it("maps 401 to auth message", () => {
+    expect(formatTelegramFallbackError(new Error("401 Unauthorized"))).toBe(
+      "⚠️ Authentication failed. Check your provider configuration.",
+    );
+  });
+
+  it("maps 'unauthorized' to auth message", () => {
+    expect(formatTelegramFallbackError(new Error("unauthorized access"))).toBe(
+      "⚠️ Authentication failed. Check your provider configuration.",
+    );
+  });
+
+  it("maps 402 to billing message", () => {
+    expect(formatTelegramFallbackError(new Error("402 Payment required"))).toBe(
+      "⚠️ Billing issue: insufficient credits or quota. Check your provider account.",
+    );
+  });
+
+  it("maps 'insufficient credits' to billing message", () => {
+    expect(formatTelegramFallbackError(new Error("insufficient credits"))).toBe(
+      "⚠️ Billing issue: insufficient credits or quota. Check your provider account.",
+    );
+  });
+
+  it("maps 404 to model not found message", () => {
+    expect(formatTelegramFallbackError(new Error("404 Not Found"))).toBe(
+      "⚠️ The selected model was not found. Try a different model.",
+    );
+  });
+
+  it("maps 'model not found' to model not found message", () => {
+    expect(formatTelegramFallbackError(new Error("model not found: gpt-xyz"))).toBe(
+      "⚠️ The selected model was not found. Try a different model.",
+    );
+  });
+
+  it("maps context overflow to context overflow message", () => {
+    expect(formatTelegramFallbackError(new Error("context window exceeded"))).toBe(
+      "⚠️ Context overflow: prompt too large for the model. Use /new to start a fresh session.",
+    );
+  });
+
+  it("maps 'prompt is too long' to context overflow message", () => {
+    expect(formatTelegramFallbackError(new Error("prompt is too long"))).toBe(
+      "⚠️ Context overflow: prompt too large for the model. Use /new to start a fresh session.",
+    );
+  });
+
+  it("returns generic message for unknown errors", () => {
+    expect(formatTelegramFallbackError(new Error("something unusual happened"))).toBe(
+      "Something went wrong while processing your request. Please try again.",
+    );
+  });
+
+  it("returns generic message for empty error text", () => {
+    expect(formatTelegramFallbackError(new Error(""))).toBe(
+      "Something went wrong while processing your request. Please try again.",
+    );
+  });
+
+  it("returns generic message for non-Error values", () => {
+    expect(formatTelegramFallbackError(undefined)).toBe(
+      "Something went wrong while processing your request. Please try again.",
+    );
+    expect(formatTelegramFallbackError(null)).toBe(
+      "Something went wrong while processing your request. Please try again.",
+    );
+    expect(formatTelegramFallbackError({})).toBe(
+      "Something went wrong while processing your request. Please try again.",
+    );
+  });
+
+  it("does not leak endpoint URLs in output", () => {
+    const err = new Error(
+      "Request to https://api.provider.com/v1/chat failed with 500 Internal server error",
+    );
+    const result = formatTelegramFallbackError(err);
+    expect(result).not.toContain("https://");
+    expect(result).not.toContain("api.provider.com");
+    expect(result).toBe("⚠️ Provider server error. Please try again in a moment.");
+  });
+
+  it("does not leak file paths in output", () => {
+    const err = new Error("Failed to read /etc/secrets/api-key.txt: 401 Unauthorized");
+    const result = formatTelegramFallbackError(err);
+    expect(result).not.toContain("/etc/secrets/");
+    expect(result).not.toContain("api-key.txt");
+    expect(result).toBe("⚠️ Authentication failed. Check your provider configuration.");
+  });
+
+  it("does not leak raw diagnostics for unknown errors", () => {
+    const err = new Error("ECONNREFUSED 10.0.0.42:443 → detailed internal stack trace info");
+    const result = formatTelegramFallbackError(err);
+    expect(result).not.toContain("10.0.0.42");
+    expect(result).not.toContain("ECONNREFUSED");
+    expect(result).not.toContain("stack");
+    expect(result).toBe("Something went wrong while processing your request. Please try again.");
+  });
+
+  it("classifies 503 Service Unavailable as server error", () => {
+    expect(formatTelegramFallbackError(new Error("503 Service Unavailable"))).toBe(
+      "⚠️ Provider server error. Please try again in a moment.",
+    );
+  });
+
+  it("classifies 'too many requests' as rate limit", () => {
+    expect(formatTelegramFallbackError(new Error("too many requests"))).toBe(
+      "⚠️ Rate limit reached. Please wait a moment and try again.",
+    );
+  });
+
+  it("classifies 'throttled' as rate limit", () => {
+    expect(formatTelegramFallbackError(new Error("request was throttled"))).toBe(
+      "⚠️ Rate limit reached. Please wait a moment and try again.",
+    );
+  });
+
+  it("classifies 'gateway timeout' as timeout (504 semantics)", () => {
+    expect(formatTelegramFallbackError(new Error("gateway timeout"))).toBe(
+      "⚠️ Request timed out. Please try again.",
+    );
+  });
+
+  it("classifies 'forbidden' as auth error", () => {
+    expect(formatTelegramFallbackError(new Error("forbidden access"))).toBe(
+      "⚠️ Authentication failed. Check your provider configuration.",
+    );
+  });
+
+  it("classifies 'spend limit' as billing error", () => {
+    expect(formatTelegramFallbackError(new Error("spend limit reached"))).toBe(
+      "⚠️ Billing issue: insufficient credits or quota. Check your provider account.",
+    );
+  });
+});

--- a/extensions/telegram/src/telegram-error-presenter.test.ts
+++ b/extensions/telegram/src/telegram-error-presenter.test.ts
@@ -74,16 +74,28 @@ describe("formatTelegramFallbackError", () => {
     );
   });
 
-  it("maps 404 to model not found message", () => {
-    expect(formatTelegramFallbackError(new Error("404 Not Found"))).toBe(
-      "⚠️ The selected model was not found. Try a different model.",
-    );
-  });
-
   it("maps 'model not found' to model not found message", () => {
     expect(formatTelegramFallbackError(new Error("model not found: gpt-xyz"))).toBe(
       "⚠️ The selected model was not found. Try a different model.",
     );
+  });
+
+  it("maps 'no such model' to model not found message", () => {
+    expect(formatTelegramFallbackError(new Error("no such model: claude-xyz"))).toBe(
+      "⚠️ The selected model was not found. Try a different model.",
+    );
+  });
+
+  it("returns generic message for bare 404 without model-specific text", () => {
+    expect(formatTelegramFallbackError(new Error("404 Not Found"))).toBe(
+      "Something went wrong while processing your request. Please try again.",
+    );
+  });
+
+  it("returns generic message for non-model 404 (missing endpoint)", () => {
+    expect(
+      formatTelegramFallbackError(new Error("404: /v1/deployments/xyz/completions not found")),
+    ).toBe("Something went wrong while processing your request. Please try again.");
   });
 
   it("maps context overflow to context overflow message", () => {

--- a/extensions/telegram/src/telegram-error-presenter.ts
+++ b/extensions/telegram/src/telegram-error-presenter.ts
@@ -51,8 +51,10 @@ export function formatTelegramFallbackError(err: unknown): string {
     return "⚠️ Billing issue: insufficient credits or quota. Check your provider account.";
   }
 
-  // Model not found
-  if (/\b404\b|model\s+not\s+found|no\s+such\s+model/i.test(detail)) {
+  // Model not found — only when the provider explicitly says so.
+  // A bare 404 can also mean a missing endpoint, deployment route, or base URL,
+  // so it must not trigger model-specific recovery advice.
+  if (/model\s+not\s+found|no\s+such\s+model/i.test(detail)) {
     return "⚠️ The selected model was not found. Try a different model.";
   }
 

--- a/extensions/telegram/src/telegram-error-presenter.ts
+++ b/extensions/telegram/src/telegram-error-presenter.ts
@@ -1,0 +1,75 @@
+import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
+
+/**
+ * Maps an error to a safe, user-visible Telegram fallback message.
+ *
+ * Unlike the generic "Something went wrong", this presenter classifies
+ * known error categories (rate limit, timeout, server error, etc.) and
+ * returns actionable text without leaking operational diagnostics.
+ * Unknown errors fall back to the generic message.
+ */
+export function formatTelegramFallbackError(err: unknown): string {
+  const detail = formatErrorMessage(err).trim();
+  if (!detail) {
+    return "Something went wrong while processing your request. Please try again.";
+  }
+
+  // Order matters: more specific patterns first
+
+  // Context overflow
+  if (
+    /context(?:\s+window)?\s+(?:overflow|exceed|too\s+long)|prompt\s+is\s+too\s+long/i.test(detail)
+  ) {
+    return "⚠️ Context overflow: prompt too large for the model. Use /new to start a fresh session.";
+  }
+
+  // Rate limit (before server error — 429 is specific)
+  if (/\b429\b|rate\s+limit|too\s+many\s+requests|throttl/i.test(detail)) {
+    return "⚠️ Rate limit reached. Please wait a moment and try again.";
+  }
+
+  // Overloaded (before generic server error)
+  if (/\b529\b|overloaded/i.test(detail)) {
+    return "⚠️ Provider is overloaded. Please try again in a moment.";
+  }
+
+  // Auth
+  if (
+    /\b401\b|\b403\b|unauthorized|forbidden|invalid\s+(?:api[_\s-]?key|token|credential)/i.test(
+      detail,
+    )
+  ) {
+    return "⚠️ Authentication failed. Check your provider configuration.";
+  }
+
+  // Billing
+  if (
+    /\b402\b|insufficient\s+(?:credits|quota|balance)|billing|spend\s+limit|usage\s+limit/i.test(
+      detail,
+    )
+  ) {
+    return "⚠️ Billing issue: insufficient credits or quota. Check your provider account.";
+  }
+
+  // Model not found
+  if (/\b404\b|model\s+not\s+found|no\s+such\s+model/i.test(detail)) {
+    return "⚠️ The selected model was not found. Try a different model.";
+  }
+
+  // Server errors (before timeout — "bad gateway" contains "gateway")
+  if (
+    /\b500\b|\b502\b|\b503\b|internal\s+server\s+error|bad\s+gateway|service\s+unavailable|server\s+error|upstream\s+error/i.test(
+      detail,
+    )
+  ) {
+    return "⚠️ Provider server error. Please try again in a moment.";
+  }
+
+  // Timeout
+  if (/\b408\b|\b504\b|timed?\s+out|timeout|etimedout|esockettimedout/i.test(detail)) {
+    return "⚠️ Request timed out. Please try again.";
+  }
+
+  // Unknown — generic, no detail leakage
+  return "Something went wrong while processing your request. Please try again.";
+}


### PR DESCRIPTION
## What Problem This Solves

When the LLM provider fails (e.g. `502 Internal server error`), Telegram users see a generic **"Something went wrong while processing your request. Please try again."** message with no indication of what actually went wrong. This makes troubleshooting difficult — the user has no idea whether the provider is down, the request was malformed, or something else happened.

## Solution

Replace the hardcoded fallback strings with an **allowlisted error presenter** (`formatTelegramFallbackError`) that classifies known provider error categories and returns safe, user-facing text **without leaking operational diagnostics** (endpoints, file paths, provider internals, etc.).

### Error origin separation (P2 fix)

The presenter is only applied to **provider/agent dispatch errors** (`state.dispatchError`). **Telegram delivery errors** (`state.deliveryError`) always receive the generic fallback. This prevents a Telegram flood-limit 429 or transport 401 from producing "Rate limit reached" or "Authentication failed" — which would misattribute a transport failure to the provider.

The outer processor catch in `bot-message.ts` also uses the generic fallback directly, since its error origin is ambiguous (could be either provider or transport).

### Model-not-found classification (P2 fix)

A bare `404` is **not** mapped to "model not found" — a 404 can also mean a missing endpoint, deployment route, or base URL. The model-not-found branch now requires **model-specific provider wording** (`"model not found"`, `"no such model"`). A bare 404 falls through to the generic fallback. Regression tests added for both cases.

### Allowlisted categories

| Error Category | Example Trigger | User Sees |
|---|---|---|
| Context overflow | "prompt is too long" | ⚠️ Context overflow: prompt too large for the model. Use /new to start a fresh session. |
| Rate limit | 429, "rate limit exceeded" | ⚠️ Rate limit reached. Please wait a moment and try again. |
| Overloaded | 529, "overloaded" | ⚠️ Provider is overloaded. Please try again in a moment. |
| Auth | 401, 403, "unauthorized" | ⚠️ Authentication failed. Check your provider configuration. |
| Billing | 402, "insufficient credits" | ⚠️ Billing issue: insufficient credits or quota. Check your provider account. |
| Model not found | "model not found", "no such model" | ⚠️ The selected model was not found. Try a different model. |
| Server error | 500, 502, 503, "bad gateway" | ⚠️ Provider server error. Please try again in a moment. |
| Timeout | 408, 504, "ETIMEDOUT" | ⚠️ Request timed out. Please try again. |
| **Unknown** | anything else (incl. bare 404) | Something went wrong while processing your request. Please try again. |

**Unknown errors never leak raw text** — they fall back to the generic message. The `detail` variable is used only for regex matching, never interpolated into the unknown fallback.

## Changes

- **`telegram-error-presenter.ts`** (new) — allowlisted error-to-message mapper; 9 categories + generic fallback. Unknown errors return a constant string, never interpolated `detail`. Bare 404 does not trigger model-not-found.
- **`bot-message-dispatch.ts`** — provider errors (`dispatchError`) → allowlisted presenter; delivery errors (`deliveryError`) → generic fallback
- **`bot-message.ts`** — outer processor catch uses generic fallback directly (origin ambiguous)
- **`bot-message-dispatch.types.ts`** — added `deliveryError` field to `TelegramDispatchTurnState`
- **`telegram-error-presenter.test.ts`** (new) — 30 tests: all categories, leak-prevention assertions, empty/unknown errors, bare 404 → generic, non-model 404 → generic, model-specific 404 → model message
- Updated existing tests in `bot-message.test.ts` (3 assertions) and `bot-message-dispatch.draft-failures-progress.test.ts` (2 assertions + 1 new test) to expect the **generic** message for unknown mock errors
- **New test:** 429 from Telegram delivery produces generic fallback, not "Rate limit reached"

## Evidence

- **Category mapping verified:** each known category produces the correct safe text
- **Leak prevention verified:** errors containing `http://internal-endpoint:8080/api/v2/chat`, `/home/user/.config/secrets.json`, `Connection refused to 10.0.0.5:6379` all produce the generic message — no raw text reaches the user
- **Unknown-error fallback is a constant string:** `telegram-error-presenter.ts` returns the generic message for unknown errors — `detail` is never interpolated into the unknown path
- **Bare 404 → generic:** a `404 Not Found` without model-specific text produces the generic message, not "model not found"
- **Non-model 404 → generic:** `404: /v1/deployments/xyz/completions not found` produces the generic message
- **Model-specific 404 → model message:** `model not found: gpt-xyz` and `no such model: claude-xyz` produce the model-not-found message
- **Error origin separation verified:** `dispatchError` (provider) → allowlisted categories; `deliveryError` (Telegram transport) → generic; outer catch → generic
- **New regression test:** 429 from `finalizePendingAnswerBlockDraft` delivery produces generic, not "Rate limit reached"
- **30 unit tests** covering all categories + leak-prevention assertions + 404 regression
- **Both fallback paths covered:** dispatch error path (allowlisted) and processor catch (generic)
- **No new dependencies** — uses existing `formatErrorMessage` from `openclaw/plugin-sdk/error-runtime` for text extraction only
- **eslint(curly) compliant** — all if-statements have braces

### Real behavior proof

The screenshot below shows the exact fallback messages rendered in a real Telegram chat (Telegram Desktop). Messages were produced by sending the exact text strings from `telegram-error-presenter.ts` through the Telegram Bot API to verify rendering, emoji display, and readability:

![Telegram fallback messages proof](https://d.uguu.se/MmPKHShe.jpg)

Left to right, the messages shown are:
1. ⚠️ Provider server error (500/502/503 category)
2. ⚠️ Rate limit reached (429 category)
3. Something went wrong... (generic fallback for unknown/delivery errors)
4. ⚠️ Context overflow (prompt too large category)

All messages render correctly in Telegram with proper emoji support and no formatting issues.

## Out of scope

The debounce idle-error handler (`bot-handlers.inbound-debounce.runtime.ts`) is left unchanged — it does not have access to a specific error object.