### PR TITLE
fix: prevent sustained inbound messages from starving delivery

### DIFF
--- a/extensions/telegram/src/telegram-ingress-coalescing.e2e.test.ts
+++ b/extensions/telegram/src/telegram-ingress-coalescing.e2e.test.ts
@@ -344,6 +344,48 @@ describe("Telegram durable ingress coalescing", () => {
     await telegramTransport.close();
   });
 
+  it("dispatches sustained forwarded messages before their ingress stream falls quiet", async () => {
+    const { monitor, telegramTransport } = await createMonitor();
+    const messageCount = 24;
+    const updateIds = Array.from({ length: messageCount }, (_, index) => 501 + index);
+    monitor.start();
+
+    for (let index = 0; index < messageCount; index += 1) {
+      await monitor.admit(
+        forwardedTextUpdate({
+          updateId: 501 + index,
+          messageId: index + 1,
+          text: `sustained-forward-${String(index).padStart(2, "0")}`,
+        }),
+      );
+      await new Promise<void>((resolve) => {
+        setTimeout(resolve, 20);
+      });
+    }
+
+    expect(downstreamTurns.mock.calls.length).toBeGreaterThan(0);
+
+    await vi.waitFor(
+      () => {
+        const deliveredMessageIds = downstreamTurns.mock.calls.flatMap(([context]) => {
+          const turn = context as MsgContext;
+          return Array.from(
+            (turn.BodyForAgent ?? turn.Body ?? "").matchAll(/sustained-forward-(\d{2})/g),
+            (match) => match[1],
+          );
+        });
+        expect(deliveredMessageIds).toEqual(
+          Array.from({ length: messageCount }, (_, index) => String(index).padStart(2, "0")),
+        );
+      },
+      { timeout: 5_000, interval: 5 },
+    );
+    await assertSpoolTombstoned({ spoolDir, updateIds });
+
+    await monitor.stop();
+    await telegramTransport.close();
+  });
+
   it("coalesces a forwarded burst replayed from a durable restart backlog", async () => {
     await writeTelegramSpooledUpdate({
       spoolDir,

--- a/src/auto-reply/inbound-debounce.ts
+++ b/src/auto-reply/inbound-debounce.ts
@@ -40,6 +40,7 @@ type DebounceBuffer<T> = {
   items: T[];
   timeout: ReturnType<typeof setTimeout> | null;
   debounceMs: number;
+  flushDeadlineMs: number;
   releaseReady: () => void;
   readyReleased: boolean;
   task: Promise<void>;
@@ -127,6 +128,7 @@ function createInboundDebounceFlush(params: {
 }
 
 const DEFAULT_MAX_TRACKED_KEYS = 2048;
+const MAX_DEBOUNCE_WINDOW_MULTIPLIER = 5;
 
 /** Options for creating a keyed inbound debouncer. */
 export type InboundDebounceCreateParams<T> = {
@@ -330,9 +332,15 @@ export function createInboundDebouncer<T>(params: InboundDebounceCreateParams<T>
     if (buffer.timeout) {
       clearTimeout(buffer.timeout);
     }
+    // Keep the first item's monotonic deadline fixed so continuous arrivals
+    // and wall-clock changes cannot hold a reserved ingress lane indefinitely.
+    const delayMs = Math.min(
+      buffer.debounceMs,
+      Math.max(0, buffer.flushDeadlineMs - performance.now()),
+    );
     buffer.timeout = setTimeout(() => {
       void flushBuffer(key, buffer);
-    }, buffer.debounceMs);
+    }, delayMs);
     buffer.timeout.unref?.();
   };
 
@@ -416,6 +424,7 @@ export function createInboundDebouncer<T>(params: InboundDebounceCreateParams<T>
       items: [item],
       timeout: null,
       debounceMs,
+      flushDeadlineMs: performance.now() + debounceMs * MAX_DEBOUNCE_WINDOW_MULTIPLIER,
       releaseReady: reservedTask.release,
       readyReleased: false,
       task: reservedTask.task,

--- a/src/auto-reply/inbound.test.ts
+++ b/src/auto-reply/inbound.test.ts
@@ -449,6 +449,109 @@ describe("createInboundDebouncer", () => {
     vi.useRealTimers();
   });
 
+  it("flushes sustained same-key messages in complete, ordered batches", async () => {
+    vi.useFakeTimers();
+    try {
+      const calls: Array<string[]> = [];
+      const debouncer = createInboundDebouncer<{ key: string; id: string }>({
+        debounceMs: 50,
+        buildKey: (item) => item.key,
+        onFlush: (items) =>
+          flushOnCompletion(() => {
+            calls.push(items.map((entry) => entry.id));
+          }),
+      });
+
+      for (let index = 0; index < 12; index += 1) {
+        await debouncer.enqueue({ key: "a", id: String(index) });
+        await vi.advanceTimersByTimeAsync(20);
+      }
+      expect(calls).toStrictEqual([]);
+
+      await debouncer.enqueue({ key: "a", id: "12" });
+      await vi.advanceTimersByTimeAsync(10);
+      expect(calls).toEqual([Array.from({ length: 13 }, (_, index) => String(index))]);
+
+      for (let index = 13; index < 25; index += 1) {
+        await debouncer.enqueue({ key: "a", id: String(index) });
+        await vi.advanceTimersByTimeAsync(20);
+      }
+      expect(calls).toHaveLength(1);
+
+      await vi.advanceTimersByTimeAsync(10);
+      expect(calls).toEqual([
+        Array.from({ length: 13 }, (_, index) => String(index)),
+        Array.from({ length: 12 }, (_, index) => String(index + 13)),
+      ]);
+      await debouncer.drain();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("anchors sustained-message deadlines to the first item's debounce window", async () => {
+    vi.useFakeTimers();
+    try {
+      const calls: Array<string[]> = [];
+      const debouncer = createInboundDebouncer<{
+        key: string;
+        id: string;
+        windowMs: number;
+      }>({
+        debounceMs: 0,
+        buildKey: (item) => item.key,
+        resolveDebounceMs: (item) => item.windowMs,
+        onFlush: (items) =>
+          flushOnCompletion(() => {
+            calls.push(items.map((entry) => entry.id));
+          }),
+      });
+
+      await debouncer.enqueue({ key: "a", id: "first", windowMs: 50 });
+      await vi.advanceTimersByTimeAsync(40);
+      await debouncer.enqueue({ key: "a", id: "later", windowMs: 1_000 });
+      await vi.advanceTimersByTimeAsync(209);
+      expect(calls).toStrictEqual([]);
+
+      await vi.advanceTimersByTimeAsync(1);
+      expect(calls).toEqual([["first", "later"]]);
+      await debouncer.drain();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("flushes sustained messages even when the system clock moves backward", async () => {
+    vi.useFakeTimers();
+    try {
+      const calls: Array<string[]> = [];
+      const debouncer = createInboundDebouncer<{ key: string; id: string }>({
+        debounceMs: 50,
+        buildKey: (item) => item.key,
+        onFlush: (items) =>
+          flushOnCompletion(() => {
+            calls.push(items.map((entry) => entry.id));
+          }),
+      });
+
+      await debouncer.enqueue({ key: "a", id: "0" });
+      for (let index = 1; index < 13; index += 1) {
+        await vi.advanceTimersByTimeAsync(20);
+        if (index === 6) {
+          vi.setSystemTime(Date.now() - 60_000);
+        }
+        await debouncer.enqueue({ key: "a", id: String(index) });
+      }
+      expect(calls).toStrictEqual([]);
+
+      await vi.advanceTimersByTimeAsync(10);
+      expect(calls).toEqual([Array.from({ length: 13 }, (_, index) => String(index))]);
+      await debouncer.drain();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("reports buffered items when cancelling a key", async () => {
     vi.useFakeTimers();
     const calls: Array<string[]> = [];


### PR DESCRIPTION
Closes #104106

## What Problem This Solves

Fixes an issue where users sending continuous messages faster than their configured inbound debounce window would never receive an agent turn. The pending same-conversation batch could grow without bound until messages finally stopped. Thanks to @masatohoshino for the clear report and reproduction.

## Why This Change Was Made

Keep the existing trailing-edge debounce, one unreferenced timer per conversation, same-key order, ingress adoption, cancellation, shutdown, and disabled-by-default behavior. Bound each batch to five times its first configured quiet window using a monotonic deadline, so later per-message overrides and wall-clock corrections cannot indefinitely postpone delivery. The bound is internal: there is no new configuration, channel-specific heuristic, dropped message, or changed transport contract.

## User Impact

Sustained Telegram and other enabled channel conversations make forward progress in complete, ordered batches instead of silently starving. Normal bursts, immediate commands and media, and existing durable-ingress behavior remain unchanged.

## Evidence

All proof ran on the same dedicated Blacksmith Testbox against the exact change.

- Red first: 24 real Telegram forwarded updates arriving every 20 ms through the SQLite spool, ingress drain, grammY and 80 ms forward lane yielded zero downstream turns on current main. After the fix, they dispatch while updates are still arriving; every message is delivered exactly once and in order, and all 24 durable entries tombstone.
- Red first: deterministic 50 ms fake-clock regressions reproduced indefinite same-key starvation, deadline extension through a later per-message override, and a 60-second backward system-clock correction. All now pass with complete ordered batches and the first monotonic deadline.
- Shared owner: 59/59 inbound tests; full real Telegram durable-ingress E2E: 5/5.
- Sibling ingress proof: WhatsApp 98/98, Mattermost 19/19, Feishu 9/9, Microsoft Teams 3/3, and shared channel policy 3/3. Total: 196 relevant tests.
- Full `pnpm check:changed -- src/auto-reply/inbound-debounce.ts src/auto-reply/inbound.test.ts extensions/telegram/src/telegram-ingress-coalescing.e2e.test.ts`: passed core/core-test/extension-test typechecks, core and extension lint, format, plugin boundaries and SDK baseline, full dead-export scans, native schema, database-first, cycle, webhook and pairing guards.
- Fresh `gpt-5.6-sol` extra-high-effort independent autoreview: clean; the clock-correction finding from its first pass is fixed and covered by a red-first regression.