### PR TITLE
fix(ui): guard Claude history redaction in Chromium

### DIFF
--- a/ui/src/e2e/chat-cli-history-redaction.e2e.test.ts
+++ b/ui/src/e2e/chat-cli-history-redaction.e2e.test.ts
@@ -1,0 +1,110 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { afterEach, expect, it } from "vitest";
+import type { AgentMessage } from "../../../src/agents/runtime/index.js";
+import { redactTranscriptMessage } from "../../../src/agents/transcript-redact.js";
+import { augmentChatHistoryWithCliSessionImports } from "../../../src/gateway/cli-session-history.js";
+import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
+import {
+  chatSessionListResponse,
+  createChatFlowE2eSuite,
+  installMockGateway,
+  requireRecord,
+  visibleChatBubbleTexts,
+  waitForRequests,
+} from "./chat-flow.test-support.ts";
+
+const suite = createChatFlowE2eSuite();
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+
+suite.define(() => {
+  it("renders a real imported Claude transcript once without exposing its unredacted secret", async () => {
+    const homeDir = tempDirs.make("openclaw-cli-history-redaction-");
+    const context = await suite.newBrowserContext({
+      locale: "en-US",
+      serviceWorkers: "block",
+      viewport: { height: 900, width: 1280 },
+    });
+
+    try {
+      const page = await context.newPage();
+      const cliSessionId = "control-ui-claude-history-redaction";
+      const secret = "sk-abcdef1234567890xyz";
+      const userText = `CLI user copy ${secret}`;
+      const assistantText = `CLI imported-only reply ${secret}`;
+      const projectsDir = path.join(homeDir, ".claude", "projects", "control-ui-e2e");
+      const filePath = path.join(projectsDir, `${cliSessionId}.jsonl`);
+      await fs.mkdir(projectsDir, { recursive: true });
+      await fs.writeFile(
+        filePath,
+        [
+          {
+            type: "user",
+            uuid: "control-ui-claude-user-copy",
+            timestamp: "2026-03-26T16:29:54.800Z",
+            message: { role: "user", content: userText },
+          },
+          {
+            type: "assistant",
+            uuid: "control-ui-claude-imported-assistant",
+            timestamp: "2026-03-26T16:29:55.800Z",
+            message: { role: "assistant", content: assistantText },
+          },
+        ]
+          .map((entry) => JSON.stringify(entry))
+          .join("\n"),
+        "utf-8",
+      );
+
+      const localUserMessage = redactTranscriptMessage({
+        role: "user",
+        content: userText,
+        timestamp: Date.parse("2026-03-26T16:29:54.800Z"),
+      } as AgentMessage);
+      const mergedMessages = augmentChatHistoryWithCliSessionImports({
+        entry: {
+          sessionId: "control-ui-local-claude-history",
+          updatedAt: Date.now(),
+          cliSessionBindings: { "claude-cli": { sessionId: cliSessionId } },
+        },
+        provider: "claude-cli",
+        localMessages: [localUserMessage],
+        homeDir,
+      });
+
+      expect(mergedMessages).toHaveLength(2);
+      expect(mergedMessages[0]).toBe(localUserMessage);
+      expect(requireRecord(requireRecord(mergedMessages[1])["__openclaw"])).toMatchObject({
+        cliSessionId,
+        externalId: "control-ui-claude-imported-assistant",
+        importedFrom: "claude-cli",
+      });
+      expect(JSON.stringify(mergedMessages)).not.toContain(secret);
+      expect(await fs.readFile(filePath, "utf-8")).toContain(secret);
+
+      const gateway = await installMockGateway(page, {
+        historyMessages: mergedMessages,
+        methodResponses: { "sessions.list": chatSessionListResponse() },
+        sessionKey: "agent:main:session-a",
+      });
+      await page.goto(`${suite.server.baseUrl}chat`);
+      await waitForRequests(gateway, "chat.startup", 1);
+      const thread = page.locator(".chat-thread");
+      await thread.getByText("CLI user copy", { exact: false }).waitFor({ timeout: 10_000 });
+      await thread.getByText("CLI imported-only reply", { exact: false }).waitFor({
+        timeout: 10_000,
+      });
+
+      const visibleMessages = await visibleChatBubbleTexts(page);
+      expect(visibleMessages.filter((message) => message.includes("CLI user copy"))).toHaveLength(
+        1,
+      );
+      expect(
+        visibleMessages.filter((message) => message.includes("CLI imported-only reply")),
+      ).toHaveLength(1);
+      expect(await thread.textContent()).not.toContain(secret);
+    } finally {
+      await suite.closeBrowserContext(context);
+    }
+  });
+});


### PR DESCRIPTION
Related: #112930
Follow-up to #115597

## What Problem This Solves

Adds durable real-browser regression coverage for a previously demonstrated Control UI history defect: a bound Claude CLI transcript could duplicate an already-redacted local user message and reveal a secret present only in the external transcript.

## Why This Change Was Made

A single, isolated Chromium test creates a real Claude projects JSONL, sends its contents through the production CLI history importer and merge boundary, and renders the resulting history using the existing Control UI browser harness. The test preserves imported assistant UUID/provider/session provenance, verifies that the external source JSONL is not modified, and uses only an existing synthetic secret fixture. No production logic, configuration, fixtures, snapshots, or golden artifacts are changed.

## User Impact

No new runtime behavior. The existing duplicate-message and imported-secret security fix is protected end to end so future changes cannot silently regress one displayed masked user message, independently redacted imported replies, or source identity.

## Evidence

- Deterministic fail-before/pass-after against the exact pre-fix gateway importer with a real Claude projects JSONL and actual Chromium: https://github.com/openclaw/openclaw/actions/runs/30426219625. The pre-fix gateway returns three messages instead of two; restoring the canonical importer passes.
- Final exact test-blob-verified Blacksmith run: https://github.com/openclaw/openclaw/actions/runs/30428163376. All 118 gateway importer, canonical transcript redactor, gateway page, and embedded gateway tests pass; all six real Chromium history scenarios pass; the complete path-scoped changed gate, TypeScript checks, formatting, lint, temporary-directory policy, i18n, dependency and export checks pass.
- Fresh gpt-5.6-sol xhigh autoreview: clean, with no accepted or actionable findings.
- Thanks to @he-yufeng for identifying the original local-redaction-versus-CLI-import mismatch and contributing the initial regression cases.
