### PR TITLE
fix(memory): fully disable derived full-text indexes

### DIFF
--- a/packages/memory-host-sdk/src/host/memory-schema-fts.test.ts
+++ b/packages/memory-host-sdk/src/host/memory-schema-fts.test.ts
@@ -1,0 +1,56 @@
+// Memory FTS tests cover canonical and shipped custom index lifecycle.
+import { DatabaseSync } from "node:sqlite";
+import { describe, expect, it } from "vitest";
+import { ensureMemoryIndexSchema } from "./memory-schema.js";
+
+describe("memory index FTS lifecycle", () => {
+  it.each([
+    { name: "canonical", ftsTable: undefined },
+    { name: "custom", ftsTable: "chunks_fts" },
+  ])("drops path FTS and its source triggers with $name body FTS disabled", ({ ftsTable }) => {
+    const db = new DatabaseSync(":memory:");
+    try {
+      expect(
+        ensureMemoryIndexSchema({ db, cacheEnabled: false, ftsEnabled: true }).ftsAvailable,
+      ).toBe(true);
+      db.prepare(
+        "INSERT INTO memory_index_sources (path, source, hash, mtime, size) VALUES (?, ?, ?, ?, ?)",
+      ).run("before.md", "memory", "before-hash", 1, 1);
+
+      ensureMemoryIndexSchema({ db, cacheEnabled: false, ftsEnabled: false, ftsTable });
+
+      expect(
+        db
+          .prepare(
+            "SELECT type, name FROM sqlite_master WHERE name IN ('memory_index_paths_fts', 'memory_index_paths_fts_after_insert', 'memory_index_paths_fts_after_update', 'memory_index_paths_fts_after_delete') ORDER BY type, name",
+          )
+          .all(),
+      ).toEqual([]);
+      if (!ftsTable) {
+        expect(
+          db
+            .prepare(
+              "SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'memory_index_chunks_fts'",
+            )
+            .get(),
+        ).toBeUndefined();
+      }
+
+      db.prepare(
+        "INSERT INTO memory_index_sources (path, source, hash, mtime, size) VALUES (?, ?, ?, ?, ?)",
+      ).run("disabled.md", "memory", "disabled-hash", 2, 2);
+
+      expect(
+        ensureMemoryIndexSchema({ db, cacheEnabled: false, ftsEnabled: true }).ftsAvailable,
+      ).toBe(true);
+      expect(
+        db.prepare("SELECT path, source FROM memory_index_paths_fts ORDER BY path").all(),
+      ).toEqual([
+        { path: "before.md", source: "memory" },
+        { path: "disabled.md", source: "memory" },
+      ]);
+    } finally {
+      db.close();
+    }
+  });
+});

--- a/packages/memory-host-sdk/src/host/memory-schema-fts.ts
+++ b/packages/memory-host-sdk/src/host/memory-schema-fts.ts
@@ -56,14 +56,17 @@ export function rebuildMemoryChunkFts(db: DatabaseSync, ftsTable: string): void 
   `);
 }
 
-export function dropDisabledMemoryChunkFts(
-  db: DatabaseSync,
-  ftsTable: string,
-  enabled: boolean,
-): void {
-  if (!enabled && ftsTable === MEMORY_INDEX_FTS_TABLE) {
-    // Body FTS has no maintenance triggers while disabled. Recreate it from
-    // canonical chunks on enable instead of retaining a partial derived index.
+export function dropDisabledMemoryFts(db: DatabaseSync, ftsTable: string, enabled: boolean): void {
+  if (enabled) {
+    return;
+  }
+
+  // Path triggers must disappear before their derived table so canonical
+  // source writes stay independent of the selected body FTS table.
+  dropMemoryPathFtsTriggers(db);
+  db.exec(`DROP TABLE IF EXISTS ${MEMORY_INDEX_PATHS_FTS_TABLE}`);
+
+  if (ftsTable === MEMORY_INDEX_FTS_TABLE) {
     db.exec(`DROP TABLE IF EXISTS ${ftsTable}`);
   }
 }

--- a/packages/memory-host-sdk/src/host/memory-schema.ts
+++ b/packages/memory-host-sdk/src/host/memory-schema.ts
@@ -8,7 +8,7 @@ import {
   MEMORY_INDEX_STATE_TABLE,
 } from "./memory-schema-base.js";
 import {
-  dropDisabledMemoryChunkFts,
+  dropDisabledMemoryFts,
   dropMemoryPathFtsTriggers,
   ensureMemoryPathFtsSchema,
   ensureMemoryPathFtsTriggers,
@@ -654,7 +654,7 @@ export function ensureMemoryIndexSchema(params: {
   `);
   migrateLegacyMemoryIndexTables(params.db, params.embeddingCacheTable, ftsTable);
   provenanceSchema.ensureMemoryChunkProvenance(params.db);
-  dropDisabledMemoryChunkFts(params.db, ftsTable, params.ftsEnabled);
+  dropDisabledMemoryFts(params.db, ftsTable, params.ftsEnabled);
   if (params.cacheEnabled) {
     const updatedAtIndex =
       embeddingCacheTable === MEMORY_EMBEDDING_CACHE_TABLE


### PR DESCRIPTION
Closes #114317
Related contributor investigation: #114319 (thank you @kevin2966n).

## What Problem This Solves

Fixes an issue where operators disabling memory hybrid/full-text search still retained the SQLite path-search index and all three source-write triggers. Canonical memory writes therefore continued maintaining disabled derived state and could fail if that state was damaged.

## Why This Change Was Made

Keep the fix in the canonical memory-host SQLite owner: remove path maintenance triggers before dropping their derived path table whenever FTS is disabled, retain the shipped custom-body-table behavior, and let the existing enable path rebuild indexes exclusively from canonical memory sources. No schema-version bump, migration, dependency, provider knob, configuration, or public Plugin SDK change.

## User Impact

Disabling hybrid search fully disables its path-index write cost; source writes remain independent of derived search tables, and re-enabling search automatically recovers every memory path, including sources written while disabled.

## Evidence

- Genuine failing-before proof on current main using Blacksmith Testbox: the new real `node:sqlite` lifecycle regression received the disabled path FTS table and all three source triggers instead of an empty schema.
- Passing-after proof covers canonical and shipped custom body-table selections, live source insertion while disabled, and canonical-row backfill on re-enable.
- Remote focused memory proof: 2 focused canonical/custom SQLite lifecycle regressions, 23 existing schema tests, 8 legacy-migration tests, and 35 real memory-search tests: all 68 passed on the exact final head. The broader 106-test memory-index suite also passed before the final custom-body compatibility refinement.
- Full `CI=1 pnpm check:changed` on the exact final commit: passed, including format, max-line ratchet, core and test typechecks, typed lint, plugin boundaries, state-schema guard, database-first storage guard, runtime cycles, and all relevant SDK contracts.
- Independent `gpt-5.6-sol` extra-high-effort autoreview: clean, correctness 0.95.
- Report and original broader investigation: thanks @kevin2966n (#114317, #114319). This PR intentionally lands only the independently reproduced FTS-disable bug; it does not claim to fix the contributor's other reports.
- Standalone live Node 24 SQLite proof: `REAL_SQLITE_FTS_DISABLE_REENABLE_PASS` for canonical and custom body configurations; inserts while FTS is disabled are recovered through a real SQLite FTS `MATCH` after re-enable.
- Testbox proof: `tbx_01kyp7kezqx3msgw7kbk68xesf`; final commit: `6981f5d28617c83fee9b965153ef559658d8b58b`.
