### PR TITLE
refactor(agents): deduplicate fallback observations

### DIFF
--- a/src/agents/model-fallback-runner.ts
+++ b/src/agents/model-fallback-runner.ts
@@ -222,6 +222,14 @@ async function runWithModelFallbackInternal<T>(
 
   const hasFallbackCandidates = candidates.length > 1;
   const requestedCandidate = candidates.find((candidate) => candidate.routeOrigin === "requested");
+  const runAttribution = { sessionId: params.sessionId, lane: params.lane };
+  const runObs = {
+    runId: params.runId,
+    ...runAttribution,
+    requestedProvider: params.provider,
+    requestedModel: params.model,
+    fallbackConfigured: hasFallbackCandidates,
+  };
 
   for (let i = 0; i < candidates.length; i += 1) {
     const candidate = candidates.at(i);
@@ -231,6 +239,7 @@ async function runWithModelFallbackInternal<T>(
     if (tlsFailedProviders.has(candidate.provider)) {
       continue;
     }
+    const candidateRef = { provider: candidate.provider, model: candidate.model };
     const nextCandidateIndex = resolveNextFallbackCandidateIndex({
       candidates,
       currentIndex: i,
@@ -250,6 +259,30 @@ async function runWithModelFallbackInternal<T>(
     const requestedModel = requestedCandidate
       ? sameModelCandidate(candidate, requestedCandidate)
       : false;
+    const attemptContext = { attempt: i + 1, total: candidates.length };
+    const candObs = {
+      ...runObs,
+      candidate,
+      ...attemptContext,
+      nextCandidate,
+      isPrimary,
+      requestedModelMatched: requestedModel,
+    };
+    const observeCandidateDecision = (
+      decision: ModelFallbackDecisionParams["decision"],
+      extra: Partial<ModelFallbackDecisionParams> = {},
+    ) => observeDecision({ decision, ...candObs, ...extra });
+    const pushAttempt = (
+      error: string,
+      reason: FailoverReason,
+      auth?: Pick<FallbackAttempt, "authMode">,
+    ) =>
+      attempts.push({
+        ...candidateRef,
+        error,
+        reason,
+        ...auth,
+      });
 
     // Skip-known-bad cache: when a previous turn in this session failed this
     // candidate with `auth` / `auth_permanent` (e.g. missing or expired
@@ -260,43 +293,23 @@ async function runWithModelFallbackInternal<T>(
     if (!isPrimary && params.sessionId) {
       const skipped = isFallbackCandidateSkipped({
         sessionId: params.sessionId,
-        provider: candidate.provider,
-        model: candidate.model,
+        ...candidateRef,
       });
       if (skipped) {
         const skipReason =
           getFallbackCandidateSkipReason({
             sessionId: params.sessionId,
-            provider: candidate.provider,
-            model: candidate.model,
+            ...candidateRef,
           }) ?? "auth";
         const reauthCommand = buildProviderReauthCommand(candidate.provider);
         const reauthHint = reauthCommand
           ? `run \`${reauthCommand}\` to re-authenticate`
           : "re-authenticate that provider";
         const error = `Skipping ${candidate.provider}/${candidate.model}: recent ${skipReason} failure in this session (${reauthHint})`;
-        attempts.push({
-          provider: candidate.provider,
-          model: candidate.model,
-          error,
-          reason: skipReason as FailoverReason,
-        });
-        await observeDecision({
-          decision: "skip_candidate",
-          runId: params.runId,
-          sessionId: params.sessionId,
-          lane: params.lane,
-          requestedProvider: params.provider,
-          requestedModel: params.model,
-          candidate,
-          attempt: i + 1,
-          total: candidates.length,
+        pushAttempt(error, skipReason as FailoverReason);
+        await observeCandidateDecision("skip_candidate", {
           reason: skipReason as FailoverReason,
           error,
-          nextCandidate,
-          isPrimary,
-          requestedModelMatched: requestedModel,
-          fallbackConfigured: hasFallbackCandidates,
         });
         continue;
       }
@@ -343,13 +356,7 @@ async function runWithModelFallbackInternal<T>(
 
         if (decision.type === "suspend_lanes") {
           const error = `Provider ${candidate.provider} is in cooldown (suspending lanes)`;
-          attempts.push({
-            provider: candidate.provider,
-            model: candidate.model,
-            error,
-            reason: decision.reason,
-            authMode,
-          });
+          pushAttempt(error, decision.reason, { authMode });
 
           // Only lock the lane when no remaining candidates can serve as
           // fallbacks. Per-provider cooldown state already prevents
@@ -379,51 +386,19 @@ async function runWithModelFallbackInternal<T>(
             }
           }
 
-          await observeDecision({
-            decision: "skip_candidate",
-            runId: params.runId,
-            sessionId: params.sessionId,
-            lane: params.lane,
-            requestedProvider: params.provider,
-            requestedModel: params.model,
-            candidate,
-            attempt: i + 1,
-            total: candidates.length,
+          await observeCandidateDecision("skip_candidate", {
             reason: decision.reason,
             error,
-            nextCandidate,
-            isPrimary,
-            requestedModelMatched: requestedModel,
-            fallbackConfigured: hasFallbackCandidates,
             profileCount: profileIds.length,
           });
           continue;
         }
 
         if (decision.type === "skip") {
-          attempts.push({
-            provider: candidate.provider,
-            model: candidate.model,
-            error: decision.error,
-            reason: decision.reason,
-            authMode,
-          });
-          await observeDecision({
-            decision: "skip_candidate",
-            runId: params.runId,
-            sessionId: params.sessionId,
-            lane: params.lane,
-            requestedProvider: params.provider,
-            requestedModel: params.model,
-            candidate,
-            attempt: i + 1,
-            total: candidates.length,
+          pushAttempt(decision.error, decision.reason, { authMode });
+          await observeCandidateDecision("skip_candidate", {
             reason: decision.reason,
             error: decision.error,
-            nextCandidate,
-            isPrimary,
-            requestedModelMatched: requestedModel,
-            fallbackConfigured: hasFallbackCandidates,
             profileCount: profileIds.length,
           });
           continue;
@@ -439,29 +414,10 @@ async function runWithModelFallbackInternal<T>(
           const isTransientCooldownReason = shouldUseTransientCooldownProbeSlot(decision.reason);
           if (isTransientCooldownReason && cooldownProbeUsedProviders.has(candidate.provider)) {
             const error = `Provider ${candidate.provider} is in cooldown (probe already attempted this run)`;
-            attempts.push({
-              provider: candidate.provider,
-              model: candidate.model,
-              error,
-              reason: decision.reason,
-              authMode,
-            });
-            await observeDecision({
-              decision: "skip_candidate",
-              runId: params.runId,
-              sessionId: params.sessionId,
-              lane: params.lane,
-              requestedProvider: params.provider,
-              requestedModel: params.model,
-              candidate,
-              attempt: i + 1,
-              total: candidates.length,
+            pushAttempt(error, decision.reason, { authMode });
+            await observeCandidateDecision("skip_candidate", {
               reason: decision.reason,
               error,
-              nextCandidate,
-              isPrimary,
-              requestedModelMatched: requestedModel,
-              fallbackConfigured: hasFallbackCandidates,
               profileCount: profileIds.length,
             });
             continue;
@@ -472,21 +428,8 @@ async function runWithModelFallbackInternal<T>(
           }
         }
         attemptedDuringCooldown = true;
-        await observeDecision({
-          decision: "probe_cooldown_candidate",
-          runId: params.runId,
-          sessionId: params.sessionId,
-          lane: params.lane,
-          requestedProvider: params.provider,
-          requestedModel: params.model,
-          candidate,
-          attempt: i + 1,
-          total: candidates.length,
+        await observeCandidateDecision("probe_cooldown_candidate", {
           reason: decision.reason,
-          nextCandidate,
-          isPrimary,
-          requestedModelMatched: requestedModel,
-          fallbackConfigured: hasFallbackCandidates,
           allowTransientCooldownProbe: runOptions?.allowTransientCooldownProbe,
           profileCount: profileIds.length,
         });
@@ -509,27 +452,14 @@ async function runWithModelFallbackInternal<T>(
         deferredSuspension.pending = suspension;
       },
       classifyResult: params.classifyResult,
-      attempt: i + 1,
-      total: candidates.length,
-      attribution: { sessionId: params.sessionId, lane: params.lane },
+      ...attemptContext,
+      attribution: runAttribution,
       abortSignal: params.abortSignal,
     });
     if ("success" in attemptRun) {
       if (i > 0 || attempts.length > 0 || attemptedDuringCooldown) {
-        await observeDecision({
-          decision: "candidate_succeeded",
-          runId: params.runId,
-          sessionId: params.sessionId,
-          lane: params.lane,
-          requestedProvider: params.provider,
-          requestedModel: params.model,
-          candidate,
-          attempt: i + 1,
-          total: candidates.length,
+        await observeCandidateDecision("candidate_succeeded", {
           previousAttempts: attempts,
-          isPrimary,
-          requestedModelMatched: requestedModel,
-          fallbackConfigured: hasFallbackCandidates,
         });
       }
       const notFoundAttempt =
@@ -551,11 +481,9 @@ async function runWithModelFallbackInternal<T>(
       !attemptRun.classifiedResult &&
       params.canFallbackAfterError &&
       !(await params.canFallbackAfterError({
-        provider: candidate.provider,
-        model: candidate.model,
+        ...candidateRef,
         error: err,
-        attempt: i + 1,
-        total: candidates.length,
+        ...attemptContext,
       }))
     ) {
       throw err;
@@ -604,10 +532,8 @@ async function runWithModelFallbackInternal<T>(
     }
     const normalized =
       coerceToFailoverError(err, {
-        provider: candidate.provider,
-        model: candidate.model,
-        sessionId: params.sessionId,
-        lane: params.lane,
+        ...candidateRef,
+        ...runAttribution,
       }) ?? err;
 
     // LiveSessionModelSwitchError during fallback may point at a later
@@ -640,27 +566,14 @@ async function runWithModelFallbackInternal<T>(
       const switchMsg = err.message;
       const switchNormalized = new FailoverError(switchMsg, {
         reason: "unknown",
-        provider: candidate.provider,
-        model: candidate.model,
-        sessionId: params.sessionId,
-        lane: params.lane,
+        ...candidateRef,
+        ...runAttribution,
       });
       lastError = switchNormalized;
       await observeFailedCandidate({
         attempts,
-        candidate,
+        ...candObs,
         error: switchNormalized,
-        runId: params.runId,
-        sessionId: params.sessionId,
-        lane: params.lane,
-        requestedProvider: params.provider,
-        requestedModel: params.model,
-        attempt: i + 1,
-        total: candidates.length,
-        nextCandidate,
-        isPrimary,
-        requestedModelMatched: requestedModel,
-        fallbackConfigured: hasFallbackCandidates,
       });
       continue;
     }
@@ -684,8 +597,7 @@ async function runWithModelFallbackInternal<T>(
     ) {
       markFallbackCandidateSkipped({
         sessionId: params.sessionId,
-        provider: candidate.provider,
-        model: candidate.model,
+        ...candidateRef,
         reason: normalized.reason,
       });
     }
@@ -701,26 +613,14 @@ async function runWithModelFallbackInternal<T>(
     lastError = isKnownFailover ? normalized : err;
     await observeFailedCandidate({
       attempts,
-      candidate,
+      ...candObs,
       error: normalized,
-      runId: params.runId,
-      sessionId: params.sessionId,
-      lane: params.lane,
-      requestedProvider: params.provider,
-      requestedModel: params.model,
-      attempt: i + 1,
-      total: candidates.length,
       nextCandidate: candidates[failedNextCandidateIndex],
-      isPrimary,
-      requestedModelMatched: requestedModel,
-      fallbackConfigured: hasFallbackCandidates,
     });
     await params.onError?.({
-      provider: candidate.provider,
-      model: candidate.model,
+      ...candidateRef,
       error: isKnownFailover ? normalized : err,
-      attempt: i + 1,
-      total: candidates.length,
+      ...attemptContext,
     });
     if (failedNextCandidateIndex > i + 1) {
       i = failedNextCandidateIndex - 1;


### PR DESCRIPTION
## What Problem This Solves

The model fallback runner rebuilt the same run, candidate, attempt, and attribution payload fields across skip, cooldown probe, success, and failure paths. That repetition made observability fields and attempt metadata harder to audit for drift.

## Why This Change Was Made

This behavior-neutral refactor defines stable run observation fields once, candidate-scoped fields once per iteration, and small local helpers for decision observation and attempt recording. Call-specific payloads are still spread last, so `reason`, `error`, `nextCandidate`, probe flags, profile counts, and failure overrides retain their existing values (`src/agents/model-fallback-runner.ts:225`, `src/agents/model-fallback-runner.ts:242`, `src/agents/model-fallback-runner.ts:262`, `src/agents/model-fallback-runner.ts:271`).

## User Impact

No user-visible behavior changes. Fallback selection, cooldown handling, emitted observation values, fallback-step callbacks, attempt summaries, and error attribution remain unchanged with less duplicated production code.

## Evidence

- Production numstat: +58/-158, net -100 LOC; tests: +0/-0.
- `node scripts/run-vitest.mjs src/agents/model-fallback.test.ts src/agents/model-fallback.probe.test.ts src/agents/model-fallback-observation.test.ts` — 3 files, 164/164 tests passed in 33.70s.
- `node scripts/check-changed.mjs -- src/agents/model-fallback-runner.ts` — hosted Testbox `tbx_01kyp7qa34bwqp39f5dadf076e`, Actions run 30427124785; all `core, coreTests` gates passed, including core/core-test tsgo, lint, Knip, formatting, guards, and import cycles.
- `.agents/skills/autoreview/scripts/autoreview --mode uncommitted --stream-engine-output` — clean, no accepted/actionable findings, confidence 0.93.
- `oxfmt --write src/agents/model-fallback-runner.ts` and `git diff --check` — clean.
- The broader `node scripts/run-vitest.mjs src/agents/model-fallback` selection passed its two production-focused files (156/156), then selected the embedded E2E file whose 18 cases all stopped before fallback execution at the untouched `src/agents/run-session-target.ts:72` file-backed transcript migration guard. Exact-head PR CI is the authoritative current-main integration proof.
- Initial exact-head CI run 30428741879 exposed unrelated current-main formatting drift in `scripts/code-mode-model-matrix.ts` and a runner timeout fetching the exact base SHA for `build-artifacts`. The formatting repair landed independently on main; this PR rebased onto it with no extra file diff, and the new exact-head run retries the infrastructure failure.
- Self-review re-read every final hunk against observation construction, failed-attempt recording, `runFallbackAttempt`, the production callers, and focused tests. No changes were needed; override spreads remain last and the shared attribution object is read-only downstream.
