### PR TITLE
fix(models): expose custom max and ultra reasoning tiers

### DIFF
--- a/scripts/code-mode-model-matrix.ts
+++ b/scripts/code-mode-model-matrix.ts
@@ -18,6 +18,8 @@ import {
 import type { AgentExecEnvelope } from "../src/commands/agent-exec.ts";
 import { previewForDevToolLog, redactJsonValueForDevToolLog } from "./lib/dev-tooling-safety.ts";
 
+export { validateQaEvidenceSummaryJson };
+
 const execFileAsync = promisify(execFile);
 const SOURCE_PATH = "scripts/code-mode-model-matrix.ts";
 const MATRIX_SCHEMA_VERSION = 1;

--- a/src/auto-reply/thinking.test.ts
+++ b/src/auto-reply/thinking.test.ts
@@ -601,6 +601,51 @@ describe("listThinkingLevels", () => {
     ).toBe(true);
   });
 
+  it("uses advanced catalog efforts and derives OpenClaw Ultra from Max", () => {
+    const catalog = [
+      {
+        provider: "myazure",
+        id: "gpt-5.6-sol",
+        name: "GPT 5.6 Sol via Azure",
+        api: "openai-responses",
+        reasoning: true,
+        compat: {
+          supportedReasoningEfforts: ["none", "low", "medium", "high", "xhigh", "max"],
+        },
+      },
+    ];
+
+    expect(listThinkingLevels("myazure", "gpt-5.6-sol", catalog, "openclaw")).toEqual([
+      "off",
+      "minimal",
+      "low",
+      "medium",
+      "high",
+      "xhigh",
+      "max",
+      "ultra",
+    ]);
+    expect(
+      isThinkingLevelSupported({
+        provider: "myazure",
+        model: "gpt-5.6-sol",
+        level: "max",
+        catalog,
+        agentRuntime: "openclaw",
+      }),
+    ).toBe(true);
+    expect(
+      isThinkingLevelSupported({
+        provider: "myazure",
+        model: "gpt-5.6-sol",
+        level: "ultra",
+        catalog,
+        agentRuntime: "openclaw",
+      }),
+    ).toBe(true);
+    expect(listThinkingLevels("myazure", "gpt-5.6-sol", catalog, "codex")).not.toContain("ultra");
+  });
+
   it("does not let catalog xhigh compat override binary thinking providers", () => {
     providerRuntimeMocks.resolveProviderThinkingProfile.mockReturnValue({
       levels: [

--- a/src/auto-reply/thinking.ts
+++ b/src/auto-reply/thinking.ts
@@ -94,14 +94,6 @@ function resolveThinkingPolicyContext(params: {
   };
 }
 
-function catalogSupportsXHigh(compat: ThinkingCatalogEntry["compat"]): boolean {
-  const efforts = compat?.supportedReasoningEfforts;
-  if (!Array.isArray(efforts)) {
-    return false;
-  }
-  return efforts.some((effort) => normalizeThinkLevel(effort) === "xhigh");
-}
-
 function normalizeProfileLevel(
   level: ProviderThinkingProfile["levels"][number],
 ): RankedThinkingLevelOption | undefined {
@@ -156,6 +148,32 @@ function appendProfileLevel(profile: ResolvedThinkingProfile, id: ThinkLevel) {
   }
   profile.levels.push({ id, label: id, rank: THINKING_LEVEL_RANKS[id] });
   profile.levels = profile.levels.toSorted((a, b) => a.rank - b.rank);
+}
+
+const CATALOG_ADVANCED_THINKING_LEVELS = new Set<ThinkLevel>(["adaptive", "xhigh", "max"]);
+
+function appendCatalogAdvancedThinkingLevels(
+  profile: ResolvedThinkingProfile,
+  compat: ThinkingCatalogEntry["compat"],
+  agentRuntime?: string | null,
+) {
+  const efforts = compat?.supportedReasoningEfforts;
+  if (!Array.isArray(efforts)) {
+    return;
+  }
+  let supportsMax = false;
+  for (const effort of efforts) {
+    const level = normalizeThinkLevel(effort);
+    if (level && CATALOG_ADVANCED_THINKING_LEVELS.has(level)) {
+      appendProfileLevel(profile, level);
+      supportsMax ||= level === "max";
+    }
+  }
+  const runtime = normalizeOptionalLowercaseString(agentRuntime);
+  if (supportsMax && (runtime === "openclaw" || runtime === "auto")) {
+    // Ultra is OpenClaw's orchestration tier; provider requests use Max.
+    appendProfileLevel(profile, "ultra");
+  }
 }
 
 /** Resolve supported thinking levels and default for a provider/model pair. */
@@ -215,9 +233,7 @@ export function resolveThinkingProfile(params: {
   }
 
   const profile = buildBaseThinkingProfile();
-  if (catalogSupportsXHigh(context.compat)) {
-    appendProfileLevel(profile, "xhigh");
-  }
+  appendCatalogAdvancedThinkingLevels(profile, context.compat, params.agentRuntime);
   return profile;
 }
 

--- a/src/cli/program/register.agent-turn.ts
+++ b/src/cli/program/register.agent-turn.ts
@@ -3,6 +3,7 @@ import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/st
 import type { Command } from "commander";
 import { formatDocsLink } from "../../../packages/terminal-core/src/links.js";
 import { theme } from "../../../packages/terminal-core/src/theme.js";
+import { THINKING_LEVELS_HELP } from "../../auto-reply/thinking.shared.js";
 import { formatHelpExamples } from "../help-format.js";
 
 type AgentViaGatewayModule = typeof import("../../commands/agent-via-gateway.js");
@@ -52,7 +53,7 @@ export function registerAgentTurnCommand(
     .option("--model <id>", "Model override for this run (provider/model or model id)")
     .option(
       "--thinking <level>",
-      "Thinking level: off | minimal | low | medium | high | xhigh | adaptive | max where supported",
+      `Thinking level: ${THINKING_LEVELS_HELP.replaceAll("|", " | ")} where supported`,
     )
     .option("--verbose <on|off>", "Persist agent verbose level for the session")
     .option(
@@ -130,7 +131,7 @@ ${theme.muted("Docs:")} ${formatDocsLink("/cli/agent", "docs.openclaw.ai/cli/age
     .option("--local-model-lean", "Use the reduced local-model tool surface")
     .option(
       "--thinking <level>",
-      "Thinking level: off | minimal | low | medium | high | xhigh | adaptive | max where supported",
+      `Thinking level: ${THINKING_LEVELS_HELP.replaceAll("|", " | ")} where supported`,
     )
     .option(
       "--fallback <provider/model>",

--- a/src/cli/program/register.agent.test.ts
+++ b/src/cli/program/register.agent.test.ts
@@ -102,6 +102,20 @@ describe("agent command registration", () => {
     return call;
   }
 
+  it("keeps both agent thinking help surfaces aligned with the canonical levels", () => {
+    const program = new Command();
+    registerAgentTurnCommand(program, { agentChannelOptions: "last|telegram|discord" });
+    const agent = program.commands.find((command) => command.name() === "agent");
+    const exec = agent?.commands.find((command) => command.name() === "exec");
+
+    expect(agent?.options.find((option) => option.long === "--thinking")?.description).toContain(
+      "ultra",
+    );
+    expect(exec?.options.find((option) => option.long === "--thinking")?.description).toContain(
+      "ultra",
+    );
+  });
+
   it("runs agent command with verbose enabled for --verbose on", async () => {
     await runCli(["agent", "--message", "hi", "--verbose", "ON", "--json"]);
 

--- a/test/scripts/code-mode-model-matrix.test.ts
+++ b/test/scripts/code-mode-model-matrix.test.ts
@@ -3,7 +3,6 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
-import { validateQaEvidenceSummaryJson } from "../../extensions/qa-lab/api.js";
 import {
   buildCodeModeMatrixAgentEnv,
   classifyCodeModeMatrixCell,
@@ -12,6 +11,7 @@ import {
   reserveCodeModeMatrixOutputDir,
   resolveCodeModeMatrixOutputDir,
   runCodeModeModelMatrix,
+  validateQaEvidenceSummaryJson,
   type CodeModeMatrixCellResult,
 } from "../../scripts/code-mode-model-matrix.ts";
 import type { AgentExecEnvelope } from "../../src/commands/agent-exec.ts";


### PR DESCRIPTION
Closes #115451

## What Problem This Solves

Fixes an issue where users registering reasoning models under custom providers could select `xhigh` but had explicitly declared `max` and logical `ultra` rejected before any model request. The `agent` and `agent exec` help text also omitted the supported `ultra` tier.

## Why This Change Was Made

The generic thinking-policy fallback now derives every advanced canonical level from the selected catalog row instead of special-casing only `xhigh`. Provider-owned profiles remain authoritative, and logical Ultra is added only for OpenClaw/auto runtimes when the provider explicitly supports Max; Codex runtime still requires its own native capability metadata. Both agent commands now render their help from the canonical thinking-level list.

The first CI run also exposed two unrelated failures already present on its merge base. This branch fixes them rather than landing onto red `main`: it formats the new Code Mode model-matrix script and routes the root test through that script's evidence-validator export instead of deep-importing QA Lab.

## User Impact

Custom Azure and OpenAI-compatible registrations can use their declared `max` capability, and OpenClaw can apply its Ultra orchestration tier on top of that Max-capable route. Models capped at `xhigh` remain capped.

## Evidence

- Before fix: focused regression failed because the custom catalog exposed `xhigh` but omitted `max` and `ultra`.
- Focused tests after rebase: `node scripts/run-vitest.mjs src/auto-reply/thinking.test.ts src/cli/program/register.agent.test.ts test/scripts/code-mode-model-matrix.test.ts test/extension-test-boundary.test.ts` — 119 passed.
- Exact six-file changed gate: `OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 CI=1 node scripts/check-changed.mjs` — passed across core, scripts, tooling, and root-test lanes.
- Built behavior proof on Blacksmith Testbox `tbx_01kyp7f8y0515qkafckhrmpxrh`: CLI help advertises `ultra`; custom `max` and `ultra` both reached the configured loopback Responses transport; a control model declaring only through `xhigh` was rejected before dispatch.
- Build: `pnpm build` — passed on the same Testbox.
- Codex autoreview: the final full branch against current `origin/main` is clean. An earlier finding about Ultra runtime boundaries was accepted and fixed.
- Upstream Codex contract checked at `d06c7ac055920c7cb140c25ebda3f3db20197b45`: `codex-rs/protocol/src/openai_models.rs` accepts Max/Ultra, `codex-rs/core/src/client.rs` maps Ultra requests to Max, and multi-agent mode consumes Ultra as proactive orchestration.

AI-assisted: implemented and reviewed with Codex; the maintainer verified the source, dependency contract, focused tests, changed gate, and built CLI behavior.
