### PR TITLE
fix(ui): restore in-progress chat responses after reconnect

### DIFF
--- a/ui/src/e2e/chat-run-lifecycle.e2e.test.ts
+++ b/ui/src/e2e/chat-run-lifecycle.e2e.test.ts
@@ -87,6 +87,54 @@ describeControlUiE2e("Control UI chat run lifecycle", () => {
     });
   });
 
+  it("restores only the unpersisted assistant response after reconnecting", async () => {
+    const artifactDir = path.resolve(".artifacts/control-ui-e2e/chat-inflight-reconnect");
+    const captureProof = process.env.OPENCLAW_CAPTURE_UI_PROOF === "1";
+    if (captureProof) {
+      await mkdir(artifactDir, { recursive: true });
+    }
+    const context = await browser.newContext({
+      viewport: { height: 800, width: 1200 },
+      ...(captureProof
+        ? { recordVideo: { dir: artifactDir, size: { height: 800, width: 1200 } } }
+        : {}),
+    });
+    const currentPage = await context.newPage();
+    page = currentPage;
+    await installMockGateway(currentPage, {
+      historyMessages: [
+        { role: "user", content: "Continue working.", timestamp: Date.now() - 2_000 },
+        { role: "assistant", content: "Saved opening.", timestamp: Date.now() - 1_000 },
+      ],
+      inFlightRun: {
+        runId: "run-reconnected",
+        text: "Saved opening. Still working after reconnect.",
+      },
+      sessionInfo: {
+        activeRunIds: ["run-reconnected"],
+        hasActiveRun: true,
+        key: "main",
+      },
+    });
+
+    await currentPage.goto(`${server?.baseUrl ?? ""}chat`);
+    await currentPage.getByText("Saved opening.", { exact: true }).waitFor();
+    const stream = currentPage.locator(".chat-bubble.streaming", {
+      hasText: "Still working after reconnect.",
+    });
+    await stream.waitFor({ state: "visible" });
+
+    expect(await currentPage.getByText("Saved opening.", { exact: true }).count()).toBe(1);
+    expect(await stream.textContent()).not.toContain("Saved opening.");
+    await currentPage.getByRole("button", { name: "Stop generating" }).waitFor();
+    if (captureProof) {
+      await currentPage.screenshot({
+        path: path.join(artifactDir, "restored-inflight-tail.png"),
+        fullPage: true,
+      });
+    }
+  });
+
   it("shows compaction savings and live working time", async () => {
     const context = await browser.newContext({ viewport: { height: 800, width: 1200 } });
     const currentPage = await context.newPage();

--- a/ui/src/pages/chat/chat-history.inflight.test.ts
+++ b/ui/src/pages/chat/chat-history.inflight.test.ts
@@ -1,0 +1,420 @@
+// @vitest-environment node
+import { describe, expect, it, vi } from "vitest";
+import type { GatewayBrowserClient } from "../../api/gateway.ts";
+import { handleChatGatewayEvent } from "./chat-gateway.ts";
+import { loadChatHistory, type ChatHistoryResult, type ChatState } from "./chat-history.ts";
+
+function createState(result: ChatHistoryResult): ChatState {
+  return {
+    client: { request: vi.fn().mockResolvedValue(result) } as unknown as GatewayBrowserClient,
+    connected: true,
+    connectionEpoch: 1,
+    sessionKey: "main",
+    chatLoading: false,
+    chatMessages: [],
+    chatThinkingLevel: null,
+    chatVerboseLevel: null,
+    chatSending: false,
+    chatMessage: "",
+    chatAttachments: [],
+    chatQueue: [],
+    chatRunId: null,
+    chatStream: null,
+    chatStreamStartedAt: null,
+    planStatus: null,
+    lastError: null,
+    hello: null,
+    sessions: { setModelOverride: vi.fn(), reconcileRunTerminal: vi.fn() },
+    requestUpdate: vi.fn(),
+  };
+}
+
+function activeHistory(runId: string): ChatHistoryResult {
+  return {
+    messages: [],
+    sessionInfo: {
+      key: "main",
+      kind: "direct",
+      updatedAt: 1,
+      hasActiveRun: true,
+      activeRunIds: [runId],
+      status: "running",
+    },
+    inFlightRun: { runId, text: "" },
+  };
+}
+
+describe("chat history in-flight assistant recovery", () => {
+  it("restores an unpersisted assistant response from the active run snapshot", async () => {
+    const history = activeHistory("run-reconnected");
+    history.messages = [{ role: "user", content: "Continue working." }];
+    history.inFlightRun!.text = "The response survived the reconnect.";
+    const state = createState(history);
+
+    await loadChatHistory(state);
+
+    expect(state.chatRunId).toBe("run-reconnected");
+    expect(state.chatStream).toBe("The response survived the reconnect.");
+    expect(state.chatStreamStartedAt).toEqual(expect.any(Number));
+    expect(state.chatRunStartup).toEqual({ state: "activity", runId: "run-reconnected" });
+  });
+
+  it("restores only the active response after its persisted assistant prefix", async () => {
+    const history = activeHistory("run-reconnected");
+    history.messages = [
+      { role: "user", content: "Continue working." },
+      { role: "assistant", content: "Saved opening." },
+    ];
+    history.inFlightRun!.text = "Saved opening. Still working after reconnect.";
+    const state = createState(history);
+
+    await loadChatHistory(state);
+
+    expect(state.chatRunId).toBe("run-reconnected");
+    expect(state.chatStream).toBe(" Still working after reconnect.");
+    expect(state.chatMessages).toEqual(history.messages);
+  });
+
+  it("retains the active-run prefix when a persisted steer follows its assistant", async () => {
+    const history = activeHistory("run-reconnected");
+    history.messages = [
+      { role: "user", content: "Start working." },
+      {
+        role: "assistant",
+        content: "Saved opening.",
+        __openclaw: { idempotencyKey: "run-reconnected" },
+      },
+      {
+        role: "user",
+        content: "Also check the result.",
+        __openclaw: { idempotencyKey: "run-steer:user" },
+      },
+    ];
+    history.inFlightRun!.text = "Saved opening. Still working after the steer.";
+    const state = createState(history);
+
+    await loadChatHistory(state);
+
+    expect(state.chatRunId).toBe("run-reconnected");
+    expect(state.chatStream).toBe(" Still working after the steer.");
+    expect(state.chatMessages).toEqual(history.messages);
+  });
+
+  it("does not trim a matching assistant prefix owned by an earlier run", async () => {
+    const history = activeHistory("run-reconnected");
+    history.messages = [
+      { role: "user", content: "An earlier request." },
+      {
+        role: "assistant",
+        content: "Saved opening.",
+        __openclaw: { idempotencyKey: "run-earlier" },
+      },
+      { role: "user", content: "Start the next request." },
+    ];
+    history.inFlightRun!.text = "Saved opening. Still working after reconnect.";
+    const state = createState(history);
+
+    await loadChatHistory(state);
+
+    expect(state.chatRunId).toBe("run-reconnected");
+    expect(state.chatStream).toBe("Saved opening. Still working after reconnect.");
+  });
+
+  it("does not let unidentified older replies truncate a run-owned assistant", async () => {
+    const history = activeHistory("run-reconnected");
+    history.messages = [
+      { role: "user", content: "An earlier request." },
+      { role: "assistant", content: "OK. Finished." },
+      { role: "user", content: "Start the next request." },
+      {
+        role: "assistant",
+        content: "OK.",
+        __openclaw: { idempotencyKey: "run-reconnected" },
+      },
+    ];
+    history.inFlightRun!.text = "OK. Finished. New details";
+    const state = createState(history);
+
+    await loadChatHistory(state);
+
+    expect(state.chatRunId).toBe("run-reconnected");
+    expect(state.chatStream).toBe(" Finished. New details");
+  });
+
+  it("strips every persisted assistant segment from a tool-using turn", async () => {
+    const history = activeHistory("run-reconnected");
+    history.messages = [
+      { role: "user", content: "Continue working." },
+      { role: "assistant", content: "Saved " },
+      { role: "toolResult", content: "Tool output." },
+      { role: "assistant", content: "opening." },
+    ];
+    history.inFlightRun!.text = "Saved opening. Still working after reconnect.";
+    const state = createState(history);
+
+    await loadChatHistory(state);
+
+    expect(state.chatRunId).toBe("run-reconnected");
+    expect(state.chatStream).toBe(" Still working after reconnect.");
+    expect(state.chatMessages).toEqual(history.messages);
+  });
+
+  it("does not duplicate an assistant response already persisted in history", async () => {
+    const history = activeHistory("run-reconnected");
+    history.messages = [
+      { role: "user", content: "Continue working." },
+      { role: "assistant", content: "Already saved." },
+    ];
+    history.inFlightRun!.text = "Already saved.";
+    const state = createState(history);
+
+    await loadChatHistory(state);
+
+    expect(state.chatRunId).toBe("run-reconnected");
+    expect(state.chatStream).toBeNull();
+    expect(state.chatMessages).toEqual(history.messages);
+  });
+
+  it("adopts an active run before its first assistant text arrives", async () => {
+    const history = activeHistory("run-reconnected");
+    const state = createState(history);
+
+    await loadChatHistory(state);
+
+    expect(state.chatRunId).toBe("run-reconnected");
+    expect(state.chatStream).toBeNull();
+    expect(state.chatRunStartup).toEqual({ state: "activity", runId: "run-reconnected" });
+  });
+
+  it.each([
+    { name: "a terminal run", sessionInfo: { hasActiveRun: false, activeRunIds: [] } },
+    {
+      name: "a different authoritative active run",
+      sessionInfo: { hasActiveRun: true, activeRunIds: ["run-newer"] },
+    },
+  ])("does not restore $name", async ({ sessionInfo }) => {
+    const history = activeHistory("run-reconnected");
+    history.sessionInfo = { ...history.sessionInfo!, ...sessionInfo };
+    const state = createState(history);
+
+    await loadChatHistory(state);
+
+    expect(state.chatRunId).toBeNull();
+    expect(state.chatStream).toBeNull();
+  });
+
+  it.each(["NO_REPLY", "HEARTBEAT_OK"])(
+    "does not expose a suppressed %s response while restoring run ownership",
+    async (hiddenResponse) => {
+      const history = activeHistory("run-reconnected");
+      history.inFlightRun!.text = hiddenResponse;
+      const state = createState(history);
+
+      await loadChatHistory(state);
+
+      expect(state.chatRunId).toBe("run-reconnected");
+      expect(state.chatStream).toBeNull();
+    },
+  );
+
+  it("does not let delayed history overwrite a newer live run", async () => {
+    let resolveHistory!: (result: ChatHistoryResult) => void;
+    const historyPromise = new Promise<ChatHistoryResult>((resolve) => {
+      resolveHistory = resolve;
+    });
+    const request = vi.fn().mockReturnValue(historyPromise);
+    const state = createState(activeHistory("run-reconnected"));
+    state.client = { request } as unknown as GatewayBrowserClient;
+
+    const loadPromise = loadChatHistory(state);
+    await vi.waitFor(() => expect(request).toHaveBeenCalledOnce());
+    state.chatRunId = "run-newer";
+    state.chatStream = "A newer live response.";
+    resolveHistory(activeHistory("run-reconnected"));
+    await loadPromise;
+
+    expect(state.chatRunId).toBe("run-newer");
+    expect(state.chatStream).toBe("A newer live response.");
+  });
+
+  it.each([
+    {
+      name: "an incremental",
+      snapshotText: "Saved opening. Buffered before reconnect.",
+      deltaText: " And live.",
+      cumulativeText: "Saved opening. Buffered before reconnect. And live.",
+      expectedTail: " Buffered before reconnect. And live.",
+    },
+    {
+      name: "a repeated-token",
+      snapshotText: "Saved opening. repeat",
+      deltaText: "repeat",
+      cumulativeText: "Saved opening. repeatrepeat",
+      expectedTail: " repeatrepeat",
+    },
+  ])(
+    "merges $name same-run delta that arrives before history",
+    async ({ snapshotText, deltaText, cumulativeText, expectedTail }) => {
+      let resolveHistory!: (result: ChatHistoryResult) => void;
+      const historyPromise = new Promise<ChatHistoryResult>((resolve) => {
+        resolveHistory = resolve;
+      });
+      const request = vi.fn().mockReturnValue(historyPromise);
+      const history = activeHistory("run-reconnected");
+      history.messages = [
+        { role: "user", content: "Continue working." },
+        { role: "assistant", content: "Saved opening." },
+      ];
+      history.inFlightRun!.text = snapshotText;
+      const state = createState(history);
+      state.client = { request } as unknown as GatewayBrowserClient;
+
+      const loadPromise = loadChatHistory(state);
+      await vi.waitFor(() => expect(request).toHaveBeenCalledOnce());
+      handleChatGatewayEvent(state, {
+        runId: "run-reconnected",
+        sessionKey: "main",
+        state: "delta",
+        deltaText,
+        message: { role: "assistant", content: cumulativeText },
+      });
+      resolveHistory(history);
+      await loadPromise;
+
+      expect(state.chatRunId).toBe("run-reconnected");
+      expect(state.chatStream).toBe(expectedTail);
+      expect(state.chatMessages).toEqual(history.messages);
+    },
+  );
+
+  it("does not duplicate a live delta already covered by a newer history snapshot", async () => {
+    let resolveHistory!: (result: ChatHistoryResult) => void;
+    const historyPromise = new Promise<ChatHistoryResult>((resolve) => {
+      resolveHistory = resolve;
+    });
+    const request = vi.fn().mockReturnValue(historyPromise);
+    const history = activeHistory("run-reconnected");
+    history.messages = [
+      { role: "user", content: "Continue working." },
+      { role: "assistant", content: "Saved opening." },
+    ];
+    history.inFlightRun!.text = "Saved opening. Buffered before reconnect. And live.";
+    const state = createState(history);
+    state.client = { request } as unknown as GatewayBrowserClient;
+
+    const loadPromise = loadChatHistory(state);
+    await vi.waitFor(() => expect(request).toHaveBeenCalledOnce());
+    handleChatGatewayEvent(state, {
+      runId: "run-reconnected",
+      sessionKey: "main",
+      state: "delta",
+      deltaText: " Buffered before reconnect.",
+      message: {
+        role: "assistant",
+        content: "Saved opening. Buffered before reconnect.",
+      },
+    });
+    resolveHistory(history);
+    await loadPromise;
+
+    expect(state.chatRunId).toBe("run-reconnected");
+    expect(state.chatStream).toBe(" Buffered before reconnect. And live.");
+  });
+
+  it.each([
+    {
+      name: "ordinary persisted history",
+      messages: [
+        { role: "user", content: "Continue working." },
+        { role: "assistant", content: "Saved opening. Buffered" },
+      ],
+    },
+    {
+      name: "run-owned history followed by a steer",
+      messages: [
+        { role: "user", content: "Continue working." },
+        {
+          role: "assistant",
+          content: "Saved opening. Buffered",
+          __openclaw: { idempotencyKey: "run-reconnected" },
+        },
+        {
+          role: "user",
+          content: "Also check the result.",
+          __openclaw: { idempotencyKey: "run-steer:user" },
+        },
+      ],
+    },
+    {
+      name: "multiple persisted assistant segments",
+      messages: [
+        { role: "user", content: "Continue working." },
+        { role: "assistant", content: "Saved" },
+        { role: "toolResult", content: "Tool output." },
+        { role: "assistant", content: "opening. Buffered" },
+      ],
+    },
+  ])("does not revive a live delta covered by $name", async ({ messages }) => {
+    let resolveHistory!: (result: ChatHistoryResult) => void;
+    const historyPromise = new Promise<ChatHistoryResult>((resolve) => {
+      resolveHistory = resolve;
+    });
+    const request = vi.fn().mockReturnValue(historyPromise);
+    const history = activeHistory("run-reconnected");
+    history.messages = messages;
+    history.inFlightRun!.text = "Saved opening. Buffered. New";
+    const state = createState(history);
+    state.client = { request } as unknown as GatewayBrowserClient;
+
+    const loadPromise = loadChatHistory(state);
+    await vi.waitFor(() => expect(request).toHaveBeenCalledOnce());
+    handleChatGatewayEvent(state, {
+      runId: "run-reconnected",
+      sessionKey: "main",
+      state: "delta",
+      deltaText: "Saved opening.",
+      message: { role: "assistant", content: "Saved opening." },
+    });
+    resolveHistory(history);
+    await loadPromise;
+
+    expect(state.chatRunId).toBe("run-reconnected");
+    expect(state.chatStream).toBe(". New");
+    expect(state.chatMessages).toEqual(history.messages);
+  });
+
+  it.each([
+    { name: "the snapshot run", completedRunId: "run-reconnected" },
+    { name: "a newer intervening run", completedRunId: "run-newer" },
+  ])("does not resurrect delayed history after $name completes", async ({ completedRunId }) => {
+    let resolveHistory!: (result: ChatHistoryResult) => void;
+    const historyPromise = new Promise<ChatHistoryResult>((resolve) => {
+      resolveHistory = resolve;
+    });
+    const request = vi.fn().mockReturnValue(historyPromise);
+    const state = createState(activeHistory("run-reconnected"));
+    state.client = { request } as unknown as GatewayBrowserClient;
+
+    const loadPromise = loadChatHistory(state);
+    await vi.waitFor(() => expect(request).toHaveBeenCalledOnce());
+    handleChatGatewayEvent(state, {
+      runId: completedRunId,
+      sessionKey: "main",
+      state: "delta",
+      deltaText: "A response that completed while history was pending.",
+    });
+    handleChatGatewayEvent(state, {
+      runId: completedRunId,
+      sessionKey: "main",
+      state: "final",
+      message: { role: "assistant", content: "The intervening run completed." },
+    });
+    expect(state.chatRunId).toBeNull();
+
+    resolveHistory(activeHistory("run-reconnected"));
+    await loadPromise;
+
+    expect(state.chatRunId).toBeNull();
+    expect(state.chatStream).toBeNull();
+  });
+});

--- a/ui/src/pages/chat/chat-history.ts
+++ b/ui/src/pages/chat/chat-history.ts
@@ -1,5 +1,8 @@
 // Control UI page module owns Chat transcript loading and selected-session message subscription.
-import { readSessionMessageSequence } from "@openclaw/gateway-client/browser";
+import {
+  readSessionMessageIdentity,
+  readSessionMessageSequence,
+} from "@openclaw/gateway-client/browser";
 import type { CommandsListResult } from "../../../../packages/gateway-protocol/src/index.js";
 import type { GatewayBrowserClient, GatewayHelloOk } from "../../api/gateway.ts";
 import type {
@@ -51,7 +54,11 @@ import {
 } from "./chat-history-retry.ts";
 import type { ChatRunStartupPhase, ChatRunStartupState } from "./chat-run-startup.ts";
 import { persistChatComposerState } from "./composer-persistence.ts";
-import { readChatSessionProjectionScope, reduceChatSessionProjection } from "./history-merge.ts";
+import {
+  getChatSessionProjection,
+  readChatSessionProjectionScope,
+  reduceChatSessionProjection,
+} from "./history-merge.ts";
 import { reconcileInitialUserMessageHandoff } from "./initial-turn-handoff.ts";
 import {
   controlUiNowMs,
@@ -333,6 +340,127 @@ export type ChatHistoryResult = {
     };
   };
 };
+
+function resolveInFlightAssistantTail(
+  messages: unknown[],
+  bufferedText: unknown,
+  runId: string,
+): string | null {
+  if (
+    typeof bufferedText !== "string" ||
+    !bufferedText ||
+    isHiddenAssistantStreamText(bufferedText)
+  ) {
+    return null;
+  }
+
+  // A steered user turn can follow an assistant from the still-active run.
+  // Persisted run identity, not the latest user boundary, owns that prefix.
+  const ownedPrefixIndex = messages.findIndex((message) => {
+    const identity = readSessionMessageIdentity(message);
+    const persistedText = identity?.runId === runId ? extractText(message) : null;
+    return (
+      identity?.role === "assistant" &&
+      Boolean(
+        persistedText &&
+        (bufferedText.startsWith(persistedText) || persistedText.startsWith(bufferedText)),
+      )
+    );
+  });
+  let turnStart = ownedPrefixIndex === -1 ? 0 : ownedPrefixIndex;
+  if (ownedPrefixIndex === -1) {
+    for (let index = messages.length - 1; index >= 0; index -= 1) {
+      const message = messages[index];
+      if (
+        message &&
+        typeof message === "object" &&
+        normalizeLowercaseStringOrEmpty((message as Record<string, unknown>).role) === "user"
+      ) {
+        turnStart = index + 1;
+        break;
+      }
+    }
+  }
+
+  let persistedPrefixLength = 0;
+  for (let index = turnStart; index < messages.length; index += 1) {
+    const message = messages[index];
+    if (!message || typeof message !== "object") {
+      continue;
+    }
+    const identity = readSessionMessageIdentity(message);
+    if (identity?.role !== "assistant" || (identity.runId && identity.runId !== runId)) {
+      continue;
+    }
+
+    const persistedText = extractText(message);
+    if (!persistedText) {
+      continue;
+    }
+    // One tool-using turn may persist several assistant segments; the Gateway
+    // buffer includes them all, so matching only its newest row duplicates text.
+    const remainingText = bufferedText.slice(persistedPrefixLength);
+    if (remainingText.startsWith(persistedText)) {
+      persistedPrefixLength += persistedText.length;
+      continue;
+    }
+    // History can persist past a live delta while its request is pending.
+    // That older cumulative buffer is already rendered by the persisted row.
+    if (persistedText.startsWith(remainingText)) {
+      return null;
+    }
+    const whitespace = /^\s+/u.exec(remainingText)?.[0];
+    if (persistedPrefixLength > 0 && whitespace) {
+      const remainingAfterWhitespace = remainingText.slice(whitespace.length);
+      if (remainingAfterWhitespace.startsWith(persistedText)) {
+        persistedPrefixLength += whitespace.length + persistedText.length;
+        continue;
+      }
+      if (persistedText.startsWith(remainingAfterWhitespace)) {
+        return null;
+      }
+    }
+    if (persistedPrefixLength > 0) {
+      break;
+    }
+  }
+
+  const tail = bufferedText.slice(persistedPrefixLength);
+  return tail && !isHiddenAssistantStreamText(tail) ? tail : null;
+}
+
+function onlyInFlightRunProjectionChanged(
+  previous: ReturnType<typeof getChatSessionProjection>["runs"],
+  current: ReturnType<typeof getChatSessionProjection>["runs"],
+  runId: string,
+): boolean {
+  for (const [previousRunId, run] of Object.entries(previous)) {
+    if (previousRunId !== runId && current[previousRunId] !== run) {
+      return false;
+    }
+  }
+  for (const [currentRunId, run] of Object.entries(current)) {
+    if (currentRunId !== runId && previous[currentRunId] !== run) {
+      return false;
+    }
+  }
+  return true;
+}
+
+function mergeInFlightAssistantTails(
+  snapshotTail: string | null,
+  cumulativeLiveTail: string | null,
+): string | null {
+  if (!snapshotTail) {
+    return cumulativeLiveTail;
+  }
+  if (!cumulativeLiveTail || snapshotTail.startsWith(cumulativeLiveTail)) {
+    return snapshotTail;
+  }
+  // Every Gateway delta carries its full assistant message. Comparing complete
+  // projections preserves repeated tokens without guessing delta overlap.
+  return cumulativeLiveTail;
+}
 
 function reconcileHistoryPlanStatus(params: {
   canAdoptRunSnapshot: boolean;
@@ -1273,6 +1401,14 @@ async function loadChatHistoryUncached(
   );
   const startedAtMs = controlUiNowMs();
   const previousMessages = state.chatMessages;
+  const previousRunProjections = getChatSessionProjection(
+    state,
+    previousMessages,
+    readChatSessionProjectionScope(state, {
+      sessionKey,
+      ...(requestAgentId ? { agentId: requestAgentId } : {}),
+    }),
+  ).runs;
   const previousPagination = state.chatHistoryPagination;
   const previousSessionId = state.currentSessionId ?? null;
   const previousDisplayedLeafEntryId = state.chatDisplayedLeafEntryId;
@@ -1345,7 +1481,7 @@ async function loadChatHistoryUncached(
     // Only the pane-owned reducer proves which live and pending rows survive;
     // terminal-renderer cleanup must not reclassify them as history. A new
     // session or leaf starts empty.
-    reduceChatSessionProjection(
+    const historyProjection = reduceChatSessionProjection(
       state,
       {
         type: "snapshotLoaded",
@@ -1456,6 +1592,50 @@ async function loadChatHistoryUncached(
         prunePersistedToolStreamMessages(state, persistedToolStreamIds);
       }
     }
+
+    const inFlightRunId = res.inFlightRun?.runId?.trim();
+    const activeRunIds = res.sessionInfo?.activeRunIds;
+    const projectedInFlightRun = inFlightRunId ? historyProjection.runs[inFlightRunId] : undefined;
+    const sameRunContinued = Boolean(
+      inFlightRunId &&
+      state.chatRunId === inFlightRunId &&
+      projectedInFlightRun?.status === "streaming" &&
+      onlyInFlightRunProjectionChanged(
+        previousRunProjections,
+        historyProjection.runs,
+        inFlightRunId,
+      ),
+    );
+    if (
+      inFlightRunId &&
+      isSessionRunActive(res.sessionInfo ?? {}) &&
+      (!Array.isArray(activeRunIds) || activeRunIds.includes(inFlightRunId)) &&
+      (!projectedInFlightRun || projectedInFlightRun.status === "streaming") &&
+      ((resetStream && !state.chatRunId && historyProjection.runs === previousRunProjections) ||
+        sameRunContinued)
+    ) {
+      // Canonical run projections change on every live delta or terminal.
+      // Their identity fences ABA races where a run starts and finishes while
+      // history is pending; deltas from this same live run must still merge.
+      const snapshotTail = resolveInFlightAssistantTail(
+        state.chatMessages,
+        res.inFlightRun?.text,
+        inFlightRunId,
+      );
+      const liveTail = sameRunContinued
+        ? resolveInFlightAssistantTail(
+            state.chatMessages,
+            extractText(projectedInFlightRun?.message),
+            inFlightRunId,
+          )
+        : null;
+      const tail = mergeInFlightAssistantTails(snapshotTail, liveTail);
+      state.chatRunId = inFlightRunId;
+      state.chatStream = tail;
+      state.chatStreamStartedAt = tail ? (state.chatStreamStartedAt ?? Date.now()) : null;
+      state.chatRunStartup = { state: "activity", runId: inFlightRunId };
+    }
+
     // Plan reconciliation shares stream adoption: rejected history cannot clobber newer live state.
     // A missing plan is version-skew unknown; replacement or explicit terminal evidence clears it.
     state.planStatus = reconcileHistoryPlanStatus({


### PR DESCRIPTION
Closes #90755

## What Problem This Solves

Fixes an issue where users who reconnect to a running Control UI chat would see their last prompt but not the assistant response already streaming in the background.

## Why This Change Was Made

Restore only the unpersisted assistant tail from the existing authoritative Gateway history snapshot. Reconcile same-run updates using the Gateway's documented-in-source cumulative assistant-message contract and the shared pane-owned run projection, rather than guessing from repeated or overlapping delta text. Keep terminal, other-run, hidden-reply, branch, and plan ownership unchanged.

## User Impact

Refreshing or reopening a running chat immediately shows the response already produced, keeps its Stop control active, continues live streaming, and never duplicates text already saved in the transcript or resurrects a completed run.

## Evidence

Fail-first proof: on unchanged main, the new real Chromium reconnect test timed out waiting for the missing assistant response, while the existing four lifecycle browser scenarios remained green. Focused regressions also independently reproduced missing snapshots, repeated cumulative tokens, split tool-turn prefixes, stale completed-run ABA, same-run updates, history arriving after an earlier live delta, and persisted history overtaking live cumulative text in ordinary, steered, and tool-segmented turns.

510 passing end-to-end, Gateway, UI, and i18n tests on isolated Blacksmith Testbox tbx_01kyp8ma0f2het95varpk99bbb:

- 42 actual Chromium tests across reconnect lifecycle, plan replay, messaging, streaming, and follow-up suites; the new reconnect scenario verifies persisted text occurs exactly once, the unpersisted stream is visible, and Stop generating is present. Screenshot and recorded video remain outside the source tree.
- 129 real Gateway agent-event tests prove both production delta emitters carry the full cumulative assistant message, including segmented and throttled output.
- 40 Gateway active-run/snapshot tests.
- 281 focused Control UI history, Gateway, lifecycle, projection, and stream reconciliation tests, including 21 new reconnect/race regressions.
- 18 Control UI translation-verifier regression tests and the unchanged raw-copy baseline.
- Complete path-scoped pnpm check:changed, including UI/core tsgo, changed-file lint, max-lines, dead exports, formatting, package/dependency guards, and i18n.
- Fresh gpt-5.6-sol extra-high-effort autoreview with no accepted or actionable findings.