### PR TITLE
fix(ci): unblock code mode matrix builds and formatting

### DIFF
--- a/scripts/code-mode-model-matrix.ts
+++ b/scripts/code-mode-model-matrix.ts
@@ -401,12 +401,14 @@ async function canonicalizeExistingPathPrefix(value: string): Promise<string> {
 
 async function runtimeArtifactDirectories(repoRoot: string, outputDir: string): Promise<string[]> {
   const packagesRoot = path.join(repoRoot, "packages");
-  const packageEntries = await fs.readdir(packagesRoot, { withFileTypes: true }).catch((error: unknown) => {
-    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
-      return [];
-    }
-    throw error;
-  });
+  const packageEntries = await fs
+    .readdir(packagesRoot, { withFileTypes: true })
+    .catch((error: unknown) => {
+      if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+        return [];
+      }
+      throw error;
+    });
   const artifacts = [
     path.join(repoRoot, "dist"),
     ...packageEntries

--- a/test/scripts/code-mode-model-matrix.test.ts
+++ b/test/scripts/code-mode-model-matrix.test.ts
@@ -3,7 +3,7 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
-import { validateQaEvidenceSummaryJson } from "../../extensions/qa-lab/api.ts";
+import { validateQaEvidenceSummaryJson } from "../../extensions/qa-lab/api.js";
 import {
   buildCodeModeMatrixAgentEnv,
   classifyCodeModeMatrixCell,


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where every pull request inherited failing build-artifacts and formatting jobs from the Code Mode model matrix on main, blocking unrelated fixes from landing.

## Why This Change Was Made

Use the QA Lab plugin's existing public api.js entry point in the root matrix test, as required by the extension test boundary and already used by sibling QA evidence tests. Format the existing unknown-typed filesystem callback without changing its behavior. Preserve the canonical QA evidence validator and the full original regression test.

## User Impact

Restores repository-wide build, plugin-boundary, and formatting checks without changing Code Mode, QA evidence, or plugin behavior.

## Evidence

- Confirmed fresh main fails oxfmt on scripts/code-mode-model-matrix.ts and the hosted extension boundary rejects the private api.ts test import.
- Linux Blacksmith Testbox: pnpm test test/scripts/code-mode-model-matrix.test.ts test/extension-test-boundary.test.ts — 34 passed (23 matrix, 11 extension boundary).
- oxfmt --check scripts/code-mode-model-matrix.ts test/scripts/code-mode-model-matrix.test.ts — passed.
- git diff --check — passed.
- Fresh isolated Codex autoreview with xhigh reasoning — clean, no actionable findings.
- Full changed gate and build are running on the same trusted Linux Testbox.
