### PR TITLE
fix(agents): reject cancelled foreground commands

### DIFF
--- a/src/agents/bash-tools.exec-run.ts
+++ b/src/agents/bash-tools.exec-run.ts
@@ -2,6 +2,7 @@
  * Exec tool policy, host dispatch, and process lifecycle pipeline.
  */
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
+import { createAbortError } from "../infra/abort-signal.js";
 import {
   type ExecHost,
   loadExecApprovals,
@@ -548,6 +549,7 @@ export function createExecTool(
       let yielded = false;
       let yieldTimer: NodeJS.Timeout | null = null;
       let registeredAbortSignal: AbortSignal | null = null;
+      let toolAborted = false;
 
       // Tool-call abort should not kill backgrounded sessions; timeouts still must.
       const onAbortSignal = () => {
@@ -561,6 +563,13 @@ export function createExecTool(
         run.disableUpdates();
         if (yielded || run.session.backgrounded) {
           return;
+        }
+        // Cancellation must win over foreground-to-background promotion while
+        // the child settles; detached background sessions keep their owner.
+        toolAborted = true;
+        if (yieldTimer) {
+          clearTimeout(yieldTimer);
+          yieldTimer = null;
         }
         run.kill();
       };
@@ -584,6 +593,14 @@ export function createExecTool(
       }
 
       return new Promise<AgentToolResult<ExecToolDetails>>((resolve, reject) => {
+        const rejectIfAborted = () => {
+          if (!toolAborted) {
+            return false;
+          }
+          reject(createAbortError("Tool execution was aborted", { cause: signal?.reason }));
+          return true;
+        };
+
         const resolveRunning = () => {
           cleanupToolRunListeners();
           resolve({
@@ -607,7 +624,7 @@ export function createExecTool(
         };
 
         const onYieldNow = () => {
-          if (yielded) {
+          if (yielded || toolAborted) {
             return;
           }
           if (settledOutcome) {
@@ -634,7 +651,7 @@ export function createExecTool(
           resolveRunning();
         };
 
-        if (allowBackground && yieldWindow !== null) {
+        if (!toolAborted && allowBackground && yieldWindow !== null) {
           if (yieldWindow === 0) {
             onYieldNow();
           } else {
@@ -647,7 +664,7 @@ export function createExecTool(
         run.promise
           .then((outcome) => {
             cleanupToolRunListeners();
-            if (yielded || run.session.backgrounded) {
+            if (rejectIfAborted() || yielded || run.session.backgrounded) {
               return;
             }
             resolve(
@@ -660,7 +677,7 @@ export function createExecTool(
           })
           .catch((err: unknown) => {
             cleanupToolRunListeners();
-            if (yielded || run.session.backgrounded) {
+            if (rejectIfAborted() || yielded || run.session.backgrounded) {
               return;
             }
             reject(err as Error);

--- a/src/agents/bash-tools.exec-task-wiring.test.ts
+++ b/src/agents/bash-tools.exec-task-wiring.test.ts
@@ -7,6 +7,7 @@ const taskTracking = vi.hoisted(() => ({
 
 vi.mock("./bash-tools.exec-task-tracking.js", () => taskTracking);
 
+import { getFinishedSession } from "./bash-process-registry.js";
 import { createExecTool } from "./bash-tools.exec-run.js";
 
 describe("exec background task wiring", () => {
@@ -35,5 +36,79 @@ describe("exec background task wiring", () => {
       handle: null,
       outcome: expect.objectContaining({ status: "completed" }),
     });
+  });
+
+  it.each([
+    {
+      label: "foreground execution",
+      defaults: { allowBackground: false },
+      args: {},
+    },
+    {
+      label: "foreground execution before the yield timer",
+      defaults: { allowBackground: true, backgroundMs: 60_000 },
+      args: { yieldMs: 60_000 },
+    },
+  ])("finalizes and rejects an aborted real $label", async ({ defaults, args }) => {
+    const abortController = new AbortController();
+    const abortReason = new Error("operator cancelled the foreground command");
+    const onUpdate = vi.fn(() => abortController.abort(abortReason));
+    const tool = createExecTool({
+      host: "gateway",
+      security: "full",
+      ask: "off",
+      ...defaults,
+    });
+    const command =
+      `${JSON.stringify(process.execPath)} -e ` +
+      `"process.stdout.write('ready\\n');setTimeout(() => {}, 30_000)"`;
+
+    await expect(
+      tool.execute("abort-real-foreground", { command, ...args }, abortController.signal, onUpdate),
+    ).rejects.toMatchObject({
+      name: "AbortError",
+      message: "Tool execution was aborted",
+      cause: abortReason,
+    });
+
+    expect(onUpdate).toHaveBeenCalledTimes(1);
+    expect(taskTracking.createBackgroundExecTask).not.toHaveBeenCalled();
+    expect(taskTracking.finalizeBackgroundExecTask).toHaveBeenCalledWith({
+      handle: null,
+      outcome: expect.objectContaining({ status: "failed" }),
+    });
+  });
+
+  it("keeps a real background process running after its tool signal aborts", async () => {
+    const abortController = new AbortController();
+    const tool = createExecTool({
+      host: "gateway",
+      security: "full",
+      ask: "off",
+      allowBackground: true,
+      backgroundMs: 0,
+    });
+    const command =
+      `${JSON.stringify(process.execPath)} -e ` +
+      `"setTimeout(() => process.stdout.write('background-survived\\n'), 30)"`;
+    const result = await tool.execute(
+      "abort-real-background",
+      { command, background: true },
+      abortController.signal,
+    );
+
+    expect(result.details.status).toBe("running");
+    if (result.details.status !== "running") {
+      throw new Error("expected a running background process");
+    }
+    const { sessionId } = result.details;
+    abortController.abort();
+
+    await expect
+      .poll(() => getFinishedSession(sessionId)?.status, {
+        timeout: 5_000,
+        interval: 10,
+      })
+      .toBe("completed");
   });
 });

--- a/src/agents/bash-tools.test.ts
+++ b/src/agents/bash-tools.test.ts
@@ -1086,12 +1086,12 @@ describe("exec backgrounded onUpdate suppression", () => {
       const abortController = new AbortController();
       const onUpdateSpy = vi.fn(() => abortController.abort());
       // Run a command that produces output over time.
-      const command = joinCommands([
-        shellEcho("before-abort"),
-        shortDelayCmd,
-        shellEcho("after-abort"),
-      ]);
-      await execTool.execute(nextCallId(), { command }, abortController.signal, onUpdateSpy);
+      const beforeAbort = shellEcho("before-abort");
+      const afterAbort = shellEcho("after-abort");
+      const command = joinCommands([beforeAbort, shortDelayCmd, afterAbort]);
+      await expect(
+        execTool.execute(nextCallId(), { command }, abortController.signal, onUpdateSpy),
+      ).rejects.toMatchObject({ name: "AbortError" });
       expect(onUpdateSpy).toHaveBeenCalledTimes(1);
       // Allow a tick for any straggling stdout data events.
       await waitOneTurn();


### PR DESCRIPTION
Closes #105681
Supersedes #105726, with its original contributor credited as a commit co-author.

## What Problem This Solves

Fixes an issue where cancelling a running foreground shell command returned a normal failed tool result instead of stopping tool execution with an `AbortError`. A pending yield timer could also incorrectly promote the cancelled command into a background task.

## Why This Change Was Made

Track cancellation only while the command is genuinely in the foreground. Stop its pending promotion timer, terminate and fully settle the real child process, then reject with the existing canonical `AbortError` and preserve the original cancellation reason as its cause. Already-backgrounded processes, ordinary failures, process timeouts, output suppression, and normal yield ownership retain their existing behavior.

## User Impact

A stop or cancellation reliably ends an in-flight foreground command without producing misleading shell output or registering a phantom background task. Intentionally detached background jobs remain alive and finish normally after the originating tool signal is cancelled.

## Evidence

Independently reproduced the issue against fresh main and actual spawned Node child processes on Blacksmith Testbox `tbx_01kyp8p0bnry09xrf031y5n3p3`; no process supervisor or shell mocks were used by the new process regressions.

Before the fix, both real foreground cases failed identically:

```text
FAIL finalizes and rejects an aborted real foreground execution
FAIL finalizes and rejects an aborted real foreground execution before the yield timer
AssertionError: promise resolved instead of rejecting
exitReason: manual-cancel
exitSignal: SIGTERM
status: failed
PASS keeps a real background process running after its tool signal aborts
```

After the fix, the same Blacksmith lease passed all foreground, yield-race, real background-child, non-abort, timeout, output-suppression, and run-abort-wrapper coverage:

```text
pnpm test src/agents/bash-tools.exec-task-wiring.test.ts src/agents/bash-tools.test.ts src/agents/bash-tools.exec.background-abort.test.ts src/agents/bash-tools.exec-foreground-failures.test.ts src/agents/agent-tools.abort.test.ts
Test Files  5 passed (5)
Tests       69 passed (69)

pnpm check:changed
exit 0; core and test typechecks, formatting, changed-file lint, dependency, SDK, cycle, migration, and repository guard checks all passed

.agents/skills/autoreview/scripts/autoreview --mode uncommitted --engine codex --model gpt-5.6-sol --thinking xhigh
autoreview clean: no accepted/actionable findings reported
```

Thanks to @zw-xysk for the original report and fix direction in #105726; the commit retains their co-author credit while adding actual-child red/green proof, canonical abort causes, and the pre-registration yield-race guard.