### PR TITLE
fix(test): bound Testbox agentic and extension suites

### DIFF
--- a/scripts/pr-lib/gates.sh
+++ b/scripts/pr-lib/gates.sh
@@ -193,7 +193,7 @@ run_remote_testbox_full_test_gate() {
     --ttl 240m \
     --timing-json \
     --label "$lease_label" \
-    -- env CI=1 PNPM_CONFIG_VERIFY_DEPS_BEFORE_RUN=install corepack pnpm test
+    -- env CI=1 OPENCLAW_TESTBOX_REMOTE_RUN=1 PNPM_CONFIG_VERIFY_DEPS_BEFORE_RUN=install corepack pnpm test
 }
 
 read_remote_testbox_gate_stamp() {

--- a/scripts/test-projects.test-support.mjs
+++ b/scripts/test-projects.test-support.mjs
@@ -4758,7 +4758,12 @@ export function buildFullSuiteVitestRunPlans(args, cwd = process.cwd()) {
     ) {
       return [];
     }
-    const expandShard = expandToProjectConfigs;
+    // The remote Testbox full gate runs every extension project in this process tree.
+    // Bound project process lifetimes or the non-isolated aggregate exceeds V8's heap limit.
+    const expandShard =
+      expandToProjectConfigs ||
+      (shard.config === FULL_EXTENSIONS_VITEST_CONFIG &&
+        process.env.OPENCLAW_TESTBOX_REMOTE_RUN === "1");
     const configs = expandShard ? shard.projects : [shard.config];
     return configs.flatMap((config) => {
       if (expandShard && targetArgs.length === 0) {

--- a/scripts/test-projects.test-support.mjs
+++ b/scripts/test-projects.test-support.mjs
@@ -171,6 +171,7 @@ const EXTENSION_VOICE_CALL_VITEST_CONFIG = "test/vitest/vitest.extension-voice-c
 const EXTENSION_WHATSAPP_VITEST_CONFIG = "test/vitest/vitest.extension-whatsapp.config.ts";
 const EXTENSION_ZALO_VITEST_CONFIG = "test/vitest/vitest.extension-zalo.config.ts";
 const EXTENSIONS_VITEST_CONFIG = "test/vitest/vitest.extensions.config.ts";
+const FULL_AGENTIC_VITEST_CONFIG = "test/vitest/vitest.full-agentic.config.ts";
 const FULL_EXTENSIONS_VITEST_CONFIG = "test/vitest/vitest.full-extensions.config.ts";
 const GATEWAY_CLIENT_VITEST_CONFIG = "test/vitest/vitest.gateway-client.config.ts";
 const GATEWAY_CORE_VITEST_CONFIG = "test/vitest/vitest.gateway-core.config.ts";
@@ -4758,12 +4759,13 @@ export function buildFullSuiteVitestRunPlans(args, cwd = process.cwd()) {
     ) {
       return [];
     }
-    // The remote Testbox full gate runs every extension project in this process tree.
-    // Bound project process lifetimes or the non-isolated aggregate exceeds V8's heap limit.
+    // The remote Testbox full gate runs every agentic and extension project in one process tree.
+    // Bound project and worker lifetimes before either aggregate reaches V8's heap limit.
     const expandShard =
       expandToProjectConfigs ||
-      (shard.config === FULL_EXTENSIONS_VITEST_CONFIG &&
-        process.env.OPENCLAW_TESTBOX_REMOTE_RUN === "1");
+      (process.env.OPENCLAW_TESTBOX_REMOTE_RUN === "1" &&
+        (shard.config === FULL_AGENTIC_VITEST_CONFIG ||
+          shard.config === FULL_EXTENSIONS_VITEST_CONFIG));
     const configs = expandShard ? shard.projects : [shard.config];
     return configs.flatMap((config) => {
       if (expandShard && targetArgs.length === 0) {

--- a/test/scripts/pr-prepare-gates.test.ts
+++ b/test/scripts/pr-prepare-gates.test.ts
@@ -434,7 +434,8 @@ describe("remote testbox gate delegation", () => {
         "--blacksmith-ref main " +
         "--idle-timeout 90m --ttl 240m --timing-json " +
         "--label pr-424242-gates " +
-        "-- env CI=1 PNPM_CONFIG_VERIFY_DEPS_BEFORE_RUN=install corepack pnpm test",
+        "-- env CI=1 OPENCLAW_TESTBOX_REMOTE_RUN=1 " +
+        "PNPM_CONFIG_VERIFY_DEPS_BEFORE_RUN=install corepack pnpm test",
     );
   });
 

--- a/test/scripts/test-projects.test.ts
+++ b/test/scripts/test-projects.test.ts
@@ -4645,6 +4645,7 @@ describe("scripts/test-projects full-suite sharding", () => {
   it("keeps CI=1 full-suite runs on aggregate shard configs", () => {
     vi.stubEnv("CI", "1");
     vi.stubEnv("GITHUB_ACTIONS", "");
+    vi.stubEnv("OPENCLAW_TESTBOX_REMOTE_RUN", "");
     vi.stubEnv("OPENCLAW_TEST_PROJECTS_LEAF_SHARDS", "");
     vi.stubEnv("OPENCLAW_TEST_PROJECTS_PARALLEL", "");
     try {
@@ -4708,6 +4709,23 @@ describe("scripts/test-projects full-suite sharding", () => {
     ]);
 
     expect(specs[0]?.env.NODE_OPTIONS).toBe("--max-old-space-size=12288 --max_old_space_size=8192");
+  });
+
+  it("splits the Testbox full extension shard into bounded project processes", () => {
+    vi.stubEnv("CI", "1");
+    vi.stubEnv("GITHUB_ACTIONS", "");
+    vi.stubEnv("OPENCLAW_TESTBOX_REMOTE_RUN", "1");
+    vi.stubEnv("OPENCLAW_TEST_PROJECTS_LEAF_SHARDS", "");
+    vi.stubEnv("OPENCLAW_TEST_PROJECTS_PARALLEL", "");
+    try {
+      const configs = buildFullSuiteVitestRunPlans([], process.cwd()).map((plan) => plan.config);
+
+      expect(configs).toContain("test/vitest/vitest.full-agentic.config.ts");
+      expect(configs).not.toContain("test/vitest/vitest.full-extensions.config.ts");
+      expect(configs).toContain("test/vitest/vitest.extension-telegram.config.ts");
+    } finally {
+      vi.unstubAllEnvs();
+    }
   });
 
   it("keeps explicit parallel overrides ahead of the host-aware profile", () => {

--- a/test/scripts/test-projects.test.ts
+++ b/test/scripts/test-projects.test.ts
@@ -4711,7 +4711,7 @@ describe("scripts/test-projects full-suite sharding", () => {
     expect(specs[0]?.env.NODE_OPTIONS).toBe("--max-old-space-size=12288 --max_old_space_size=8192");
   });
 
-  it("splits the Testbox full extension shard into bounded project processes", () => {
+  it("splits the Testbox agentic and extension shards into bounded processes", () => {
     vi.stubEnv("CI", "1");
     vi.stubEnv("GITHUB_ACTIONS", "");
     vi.stubEnv("OPENCLAW_TESTBOX_REMOTE_RUN", "1");
@@ -4720,8 +4720,9 @@ describe("scripts/test-projects full-suite sharding", () => {
     try {
       const configs = buildFullSuiteVitestRunPlans([], process.cwd()).map((plan) => plan.config);
 
-      expect(configs).toContain("test/vitest/vitest.full-agentic.config.ts");
+      expect(configs).not.toContain("test/vitest/vitest.full-agentic.config.ts");
       expect(configs).not.toContain("test/vitest/vitest.full-extensions.config.ts");
+      expect(configs).toContain("test/vitest/vitest.agents-core.config.ts");
       expect(configs).toContain("test/vitest/vitest.extension-telegram.config.ts");
     } finally {
       vi.unstubAllEnvs();


### PR DESCRIPTION
## What Problem This Solves

Fixes remote Testbox full-test failures caused by long-lived aggregate Vitest workers retaining module state until they exhaust memory.

Two independent failures reproduced the same topology bug:

- the aggregate extension process accumulated 257 process exit listeners and aborted near the 4 GiB heap limit;
- the aggregate `agents-core` worker climbed to 4.019 GiB and exited immediately after `models-config.providers.stepfun.test.ts`.

## Why This Change Was Made

The PR gate marks its delegated full-suite command with `OPENCLAW_TESTBOX_REMOTE_RUN=1`. The full-suite planner uses that marker to expand only the two proven memory-heavy aggregate shards, `agentic` and `extensions`, into their existing project-level plans.

That activates the existing bounded process topology without changing ordinary CI:

- both aggregate configs are removed from the Testbox plan;
- `agents-core` uses its existing six process chunks of 104-105 files;
- extension projects retain their existing owner configs;
- CI-like Testbox execution remains serial, so the change bounds lifetime rather than adding concurrency.

The existing 8 GiB aggregate extension heap floor remains as a fallback outside this remote path.

## User Impact

No product behavior changes. Maintainers get a full Testbox gate that can complete agentic and extension coverage instead of losing a worker to cumulative retained state.

## Evidence

- Core-only reproduction: `agents-core` reached 4.019 GiB and exited unexpectedly after 7m28s: https://github.com/openclaw/openclaw/actions/runs/30462930063
- Focused planner and PR-gate proof: 297/297 tests passed: https://github.com/openclaw/openclaw/actions/runs/30463734947
- Direct planner probe emits 75 plans, removes both aggregate configs, retains Telegram coverage, and splits `agents-core` into six 104-105-file processes.
- Fresh autoreview reports no accepted or actionable findings (0.92).
- `git diff --check` passes.
