### PR TITLE
fix(feishu): reject unsupported initial document content

### DIFF
--- a/docs/channels/feishu.md
+++ b/docs/channels/feishu.md
@@ -387,6 +387,10 @@ The plugin ships agent tools for Feishu documents, chats, knowledge base, cloud 
 
 Per-account gates live under `accounts.<id>.tools`.
 
+`feishu_doc` creates title-only documents. To add Markdown, pass the returned
+`document_id` as `doc_token` in a separate `write` action. A `create` request
+that includes `content` fails without creating an empty document.
+
 Grant `drive:drive.metadata:readonly` for direct `feishu_drive info` lookups outside the root
 directory, unless the app already has the full `drive:drive` scope. Without either scope, `info`
 keeps the legacy root-directory lookup available through `drive:drive:readonly`.

--- a/extensions/feishu/skills/feishu-doc/SKILL.md
+++ b/extensions/feishu/skills/feishu-doc/SKILL.md
@@ -57,6 +57,10 @@ With folder:
 }
 ```
 
+Document creation is title-only. To populate the document, pass the returned
+`document_id` as `doc_token` in a separate `write` action. Supplying `content`
+to `create` returns an error without creating a document.
+
 **Important:** Always pass `owner_open_id` with the requesting user's `open_id` (from inbound metadata `sender_id`) so the user automatically gets `full_access` permission on the created document. Without this, only the bot app has access.
 
 ### List Blocks

--- a/extensions/feishu/src/docx-create-loopback.test.ts
+++ b/extensions/feishu/src/docx-create-loopback.test.ts
@@ -1,0 +1,191 @@
+// Feishu tests prove the document create contract through the real Lark SDK.
+import { createServer } from "node:http";
+import type { AddressInfo } from "node:net";
+import * as Lark from "@larksuiteoapi/node-sdk";
+import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { createToolFactoryHarness } from "./tool-factory-test-harness.js";
+
+const createFeishuClientMock = vi.hoisted(() => vi.fn());
+const toolAccountModule = await import("./tool-account.js");
+
+vi.spyOn(toolAccountModule, "createFeishuToolClient").mockImplementation(() =>
+  createFeishuClientMock(),
+);
+vi.spyOn(toolAccountModule, "resolveAnyEnabledFeishuToolsConfig").mockReturnValue({
+  doc: true,
+  chat: false,
+  wiki: false,
+  drive: false,
+  perm: false,
+  scopes: false,
+  bitable: false,
+});
+vi.spyOn(toolAccountModule, "resolveFeishuToolAccount").mockReturnValue({
+  config: { mediaMaxMb: 30 },
+} as ReturnType<typeof toolAccountModule.resolveFeishuToolAccount>);
+
+const { registerFeishuDocTools } = await import("./docx.js");
+
+describe("feishu_doc create contract over the real Lark SDK", () => {
+  afterAll(() => {
+    vi.restoreAllMocks();
+    vi.resetModules();
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("rejects create content before HTTP and supports the create-then-write API workflow", async () => {
+    const requests: Array<{ method: string; path: string; body?: unknown }> = [];
+    const server = createServer((request, response) => {
+      void (async () => {
+        const bodyChunks: Buffer[] = [];
+        for await (const chunk of request) {
+          bodyChunks.push(typeof chunk === "string" ? Buffer.from(chunk) : chunk);
+        }
+        const pathname = new URL(request.url ?? "/", "http://127.0.0.1").pathname;
+        const rawBody = Buffer.concat(bodyChunks).toString("utf8");
+        requests.push({
+          method: request.method ?? "",
+          path: pathname,
+          ...(rawBody ? { body: JSON.parse(rawBody) as unknown } : {}),
+        });
+
+        const sendJson = (body: unknown) => {
+          response.writeHead(200, { "content-type": "application/json" });
+          response.end(JSON.stringify(body));
+        };
+        if (request.method === "POST" && pathname === "/open-apis/docx/v1/documents") {
+          sendJson({
+            code: 0,
+            data: { document: { document_id: "doc_loopback", title: "Loopback Doc" } },
+          });
+          return;
+        }
+        if (
+          request.method === "POST" &&
+          pathname === "/open-apis/docx/v1/documents/blocks/convert"
+        ) {
+          sendJson({
+            code: 0,
+            data: {
+              blocks: [{ block_type: 2, block_id: "body_loopback" }],
+              first_level_block_ids: ["body_loopback"],
+            },
+          });
+          return;
+        }
+        if (
+          request.method === "GET" &&
+          pathname === "/open-apis/docx/v1/documents/doc_loopback/blocks"
+        ) {
+          sendJson({ code: 0, data: { items: [] } });
+          return;
+        }
+        if (
+          request.method === "POST" &&
+          pathname === "/open-apis/docx/v1/documents/doc_loopback/blocks/doc_loopback/descendant"
+        ) {
+          sendJson({
+            code: 0,
+            data: { children: [{ block_type: 2, block_id: "body_loopback" }] },
+          });
+          return;
+        }
+        response.writeHead(404).end();
+      })().catch((error: unknown) => {
+        response.writeHead(500, { "content-type": "application/json" });
+        response.end(JSON.stringify({ error: String(error) }));
+      });
+    });
+
+    await new Promise<void>((resolve, reject) => {
+      server.once("error", reject);
+      server.listen(0, "127.0.0.1", resolve);
+    });
+
+    try {
+      const address = server.address() as AddressInfo;
+      const loopbackHttp = Object.create(Lark.defaultHttpInstance) as Lark.HttpInstance;
+      loopbackHttp.request = async (options) => {
+        const upstream = new URL(options.url ?? "");
+        const target = new URL(
+          `${upstream.pathname}${upstream.search}`,
+          `http://127.0.0.1:${address.port}`,
+        );
+        const method = options.method ?? "GET";
+        const response = await fetch(target, {
+          method,
+          headers: { "content-type": "application/json" },
+          ...(method === "GET" || method === "HEAD"
+            ? {}
+            : { body: JSON.stringify(options.data ?? {}) }),
+        });
+        return response.json();
+      };
+      const client = new Lark.Client({
+        appId: "loopback-test-app",
+        appSecret: "loopback-test-placeholder", // pragma: allowlist secret
+        domain: Lark.Domain.Feishu,
+        loggerLevel: Lark.LoggerLevel.error,
+        disableTokenCache: true,
+        httpInstance: loopbackHttp,
+      });
+      createFeishuClientMock.mockReturnValue(client);
+
+      const harness = createToolFactoryHarness({
+        channels: {
+          feishu: { enabled: true, appId: "app_id", appSecret: "app_secret" },
+        },
+      });
+      registerFeishuDocTools(harness.api);
+      const tool = harness.resolveTool("feishu_doc");
+      const markdown = "# Hello\n\nBody content here";
+
+      const rejected = await tool.execute("reject-create", {
+        action: "create",
+        title: "Loopback Doc",
+        content: markdown,
+      });
+      expect(rejected.details.error).toContain('call action "write"');
+      expect(createFeishuClientMock).not.toHaveBeenCalled();
+      expect(requests).toEqual([]);
+
+      const created = await tool.execute("create-document", {
+        action: "create",
+        title: "Loopback Doc",
+      });
+      expect(created.details).toMatchObject({ document_id: "doc_loopback" });
+      const written = await tool.execute("write-document", {
+        action: "write",
+        doc_token: created.details.document_id,
+        content: markdown,
+      });
+
+      expect(written.details).toMatchObject({ success: true, blocks_added: 1 });
+      expect(requests).toEqual([
+        {
+          method: "POST",
+          path: "/open-apis/docx/v1/documents",
+          body: { title: "Loopback Doc" },
+        },
+        {
+          method: "POST",
+          path: "/open-apis/docx/v1/documents/blocks/convert",
+          body: { content_type: "markdown", content: markdown },
+        },
+        { method: "GET", path: "/open-apis/docx/v1/documents/doc_loopback/blocks" },
+        {
+          method: "POST",
+          path: "/open-apis/docx/v1/documents/doc_loopback/blocks/doc_loopback/descendant",
+          body: expect.objectContaining({ children_id: ["body_loopback"] }),
+        },
+      ]);
+    } finally {
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()));
+      });
+    }
+  });
+});

--- a/extensions/feishu/src/docx.test.ts
+++ b/extensions/feishu/src/docx.test.ts
@@ -538,6 +538,63 @@ describe("feishu_doc image fetch hardening", () => {
     expect(result.details.images_processed).toBe(0);
   });
 
+  it.each([
+    { name: "Markdown body", content: "# Hello\n\nBody content here" },
+    { name: "empty body", content: "" },
+  ])("rejects a create request with a $name before creating a document", async ({ content }) => {
+    const feishuDocTool = resolveFeishuDocTool({
+      messageChannel: "feishu",
+      requesterSenderId: "ou_123",
+    });
+
+    const result = await executeFeishuDocTool(feishuDocTool, {
+      action: "create",
+      title: "Demo",
+      content,
+    });
+
+    expect(result.details.error).toBe(
+      'Feishu document creation does not support content. Call action "create" first, then call action "write" with the returned document_id as doc_token.',
+    );
+    expect(createFeishuClientMock).not.toHaveBeenCalled();
+    expect(documentCreateMock).not.toHaveBeenCalled();
+    expect(convertMock).not.toHaveBeenCalled();
+    expect(blockDescendantCreateMock).not.toHaveBeenCalled();
+    expect(permissionMemberCreateMock).not.toHaveBeenCalled();
+  });
+
+  it("creates and writes document content through the documented two-call workflow", async () => {
+    const feishuDocTool = resolveFeishuDocTool({
+      messageChannel: "feishu",
+      requesterSenderId: "ou_123",
+    });
+    const markdown = "# Hello\n\nBody content here";
+
+    const created = await executeFeishuDocTool(feishuDocTool, {
+      action: "create",
+      title: "Demo",
+    });
+    const written = await executeFeishuDocTool(feishuDocTool, {
+      action: "write",
+      doc_token: created.details.document_id,
+      content: markdown,
+    });
+
+    expect(documentCreateMock).toHaveBeenCalledTimes(1);
+    expect(permissionMemberCreateMock).toHaveBeenCalledTimes(1);
+    expect(convertMock).toHaveBeenCalledWith({
+      data: { content_type: "markdown", content: markdown },
+    });
+    expect(blockDescendantCreateMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        path: { document_id: "doc_created", block_id: "doc_created" },
+      }),
+    );
+    expect(created.details.document_id).toBe("doc_created");
+    expect(written.details.success).toBe(true);
+    expect(written.details.blocks_added).toBe(1);
+  });
+
   it("create grants permission only to trusted Feishu requester", async () => {
     const feishuDocTool = resolveFeishuDocTool({
       messageChannel: "feishu",

--- a/extensions/feishu/src/docx.ts
+++ b/extensions/feishu/src/docx.ts
@@ -1265,6 +1265,14 @@ export function registerFeishuDocTools(api: OpenClawPluginApi) {
           async execute(_toolCallId, params) {
             const p = params as FeishuDocExecuteParams;
             try {
+              // Feishu creates title-only docs; flattened tool schemas can still expose
+              // sibling `content`, so reject it before creating an empty document.
+              if (p.action === "create" && Object.hasOwn(p, "content")) {
+                return json({
+                  error:
+                    'Feishu document creation does not support content. Call action "create" first, then call action "write" with the returned document_id as doc_token.',
+                });
+              }
               const client = getClient(p, defaultAccountId);
               switch (p.action) {
                 case "read":


### PR DESCRIPTION
Closes #48373

## What Problem This Solves

Fixes an issue where users or agents creating a Feishu document with an initial Markdown content field would receive a successful response even though Feishu created an empty document and silently discarded all content.

## Why This Change Was Made

Feishu officially defines document creation as a title-and-folder-only operation: https://open.feishu.cn/document/server-docs/docs/docs/docx-v1/document/create?lang=zh-CN. The installed @larksuiteoapi/node-sdk@1.71.1 exposes the same create payload, containing title and folder_token but no content. Rejecting every create request that includes content before constructing a Feishu client preserves that upstream contract, prevents accidental document creation and permission grants, and avoids introducing a misleading multi-request transaction or new permissions. A successful title-only create followed by an explicit write remains unchanged.

## User Impact

Feishu users receive an actionable create-then-write error instead of a silently-created empty document. Both the bundled Feishu document skill and public channel documentation now explicitly describe the supported two-call Markdown workflow.

## Evidence

- Fail-first: both nonempty Markdown content and explicitly empty content reproduced the silent successful empty-document creation before the change.
- Exact installed SDK and real localhost HTTP end-to-end proof: rejected content makes zero client/document/network/permission requests; valid title-only creation followed by writing Markdown makes exactly the four official document-create, blocks-convert, blocks-list, and descendant-insert requests.
- Focused remote proof: 2 suites, 31 tests passed.
- Full Feishu remote regression proof: 13 suites, 341 tests passed.
- Full remote CI=1 pnpm check:changed passed, including formatting, extension and extension-test typechecks, changed-file lint, plugin boundaries, dead-code, SDK, database, and import-cycle guards.
- The already-merged canonical documentation index independently passes node scripts/generate-docs-map.mjs --check; this pull request does not modify the generated index.
- Fresh independent gpt-5.6-sol extra-high-effort autoreview: clean, no accepted or actionable findings.
- No live Feishu tenant, real credential, external API mutation, new configuration, or resource side effect was required.

Thanks to @wzx011011 for the original report and unmerged predecessor #48377 and to @forrystudio for independently confirming the shipped reproduction and fail-fast resolution.