### PR TITLE
fix(telegram): auto-linked bare URL & in visible text navigates to wrong destination (#102162)

### DIFF
--- a/extensions/telegram/src/format.test.ts
+++ b/extensions/telegram/src/format.test.ts
@@ -194,6 +194,18 @@ describe("markdownToTelegramHtml", () => {
     );
   });
 
+  it("does not HTML-escape ampersands in auto-linked bare URL visible text (#102162)", () => {
+    const res = markdownToTelegramHtml("https://example.com/post.php?post=100&action=edit");
+    expect(res).toBe(
+      '<a href="https://example.com/post.php?post=100&amp;action=edit">https://example.com/post.php?post=100&action=edit</a>',
+    );
+  });
+
+  it("still escapes ampersands in authored link labels (#102162)", () => {
+    const res = markdownToTelegramHtml("[A & B](https://example.com/?a=1&b=2)");
+    expect(res).toBe('<a href="https://example.com/?a=1&amp;b=2">A &amp; B</a>');
+  });
+
   it("properly nests link inside bold", () => {
     const res = markdownToTelegramHtml("**bold [link](https://example.com) text**");
     expect(res).toBe('<b>bold <a href="https://example.com">link</a> text</b>');

--- a/extensions/telegram/src/format.ts
+++ b/extensions/telegram/src/format.ts
@@ -26,7 +26,15 @@ export function escapeTelegramHtml(text: string): string {
   return text.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
 }
 
-function escapeHtml(text: string): string {
+type EscapeContext = { inAutoLink?: boolean };
+
+function escapeHtml(text: string, context?: EscapeContext): string {
+  if (context?.inAutoLink) {
+    // Auto-linked bare URLs are already wrapped in <a>. Telegram clients show
+    // this visible text in the link-tap prompt, so we keep the raw '&'
+    // separator; only angle brackets need escaping to stay valid inside HTML.
+    return text.replace(/</g, "&lt;").replace(/>/g, "&gt;");
+  }
   return escapeTelegramHtml(text);
 }
 

--- a/packages/markdown-core/src/ir.links.test.ts
+++ b/packages/markdown-core/src/ir.links.test.ts
@@ -50,4 +50,51 @@ describe("markdownToIR link provenance", () => {
       origin: "linkify",
     });
   });
+
+  it("tells escapeText when it is inside an auto-link", () => {
+    const ir = markdownToIR("see https://example.com/?a=1&b=2 ok", { linkify: true });
+    const calls: Array<{ text: string; inAutoLink?: boolean }> = [];
+    renderMarkdownWithMarkers(ir, {
+      styleMarkers: {},
+      escapeText: (text, context) => {
+        calls.push({ text, inAutoLink: context?.inAutoLink });
+        return text;
+      },
+      buildLink: (link, text, context) => ({
+        start: link.start,
+        end: link.end,
+        open: `<a href="${link.href}">`,
+        close: "</a>",
+      }),
+    });
+
+    expect(calls).toEqual([
+      { text: "see ", inAutoLink: undefined },
+      { text: "https://example.com/?a=1&b=2", inAutoLink: true },
+      { text: " ok", inAutoLink: undefined },
+    ]);
+  });
+
+  it("does not mark authored link text as inAutoLink", () => {
+    const ir = markdownToIR("[A & B](https://example.com/?a=1&b=2)");
+    const calls: Array<{ text: string; inAutoLink?: boolean }> = [];
+    renderMarkdownWithMarkers(ir, {
+      styleMarkers: {},
+      escapeText: (text, context) => {
+        calls.push({ text, inAutoLink: context?.inAutoLink });
+        return text;
+      },
+      buildLink: (link, text) => ({
+        start: link.start,
+        end: link.end,
+        open: `<a href="${link.href}">`,
+        close: "</a>",
+      }),
+    });
+
+    expect(calls).toContainEqual({
+      text: "A & B",
+      inAutoLink: undefined,
+    });
+  });
 });

--- a/packages/markdown-core/src/render.ts
+++ b/packages/markdown-core/src/render.ts
@@ -41,11 +41,13 @@ function getMarkdownLinkOrigin(link: MarkdownLinkSpan): MarkdownLinkOrigin {
   return isAutoLinkedMarkdownLink(link) ? "linkify" : "authored";
 }
 
+type EscapeTextContext = { inAutoLink?: boolean };
+
 /** Renderer hooks for converting Markdown IR into a marker-based target format. */
 export type RenderOptions = {
   styleMarkers: RenderStyleMap;
   annotationMarkers?: RenderAnnotationMap;
-  escapeText: (text: string) => string;
+  escapeText: (text: string, context?: EscapeTextContext) => string;
   buildLink?: (
     link: MarkdownLinkSpan,
     text: string,
@@ -272,7 +274,7 @@ export function renderMarkdownWithMarkers(
     }
   }
 
-  const linkStarts = new Map<number, RenderLink[]>();
+  const linkStarts = new Map<number, Array<{ rendered: RenderLink; source: MarkdownLinkSpan }>>();
   if (options.buildLink) {
     const links = projected.links.flatMap((span) =>
       subtractRanges(span, dominantAnnotationRanges)
@@ -297,19 +299,26 @@ export function renderMarkdownWithMarkers(
       boundaries.add(rendered.end);
       const openBucket = linkStarts.get(rendered.start);
       if (openBucket) {
-        openBucket.push(rendered);
+        openBucket.push({ rendered, source: link });
       } else {
-        linkStarts.set(rendered.start, [rendered]);
+        linkStarts.set(rendered.start, [{ rendered, source: link }]);
       }
     }
   }
 
   const points = [...boundaries].toSorted((a, b) => a - b);
   // Links and styles share one stack so equal-end spans close in exact reverse open order.
-  const stack: { close: string; end: number }[] = [];
   type OpeningItem =
     | { end: number; open: string; close: string; kind: "annotation"; index: number }
-    | { end: number; open: string; close: string; kind: "link"; index: number }
+    | {
+        end: number;
+        open: string;
+        close: string;
+        kind: "link";
+        index: number;
+        link: MarkdownLinkSpan;
+        autoLinked: boolean;
+      }
     | {
         end: number;
         open: string;
@@ -318,6 +327,7 @@ export function renderMarkdownWithMarkers(
         style: MarkdownStyle;
         index: number;
       };
+  const stack: OpeningItem[] = [];
   let out = "";
 
   for (const [i, pos] of points.entries()) {
@@ -350,13 +360,15 @@ export function renderMarkdownWithMarkers(
 
     const openingLinks = linkStarts.get(pos);
     if (openingLinks && openingLinks.length > 0) {
-      for (const [index, link] of openingLinks.entries()) {
+      for (const [index, { rendered, source }] of openingLinks.entries()) {
         openingItems.push({
-          end: link.end,
-          open: link.open,
-          close: link.close,
+          end: rendered.end,
+          open: rendered.open,
+          close: rendered.close,
           kind: "link",
           index,
+          link: source,
+          autoLinked: isAutoLinkedMarkdownLink(source),
         });
       }
     }
@@ -401,7 +413,7 @@ export function renderMarkdownWithMarkers(
       // Open outer spans first (larger end) so LIFO closes stay valid for same-start overlaps.
       for (const item of openingItems) {
         out += item.open;
-        stack.push({ close: item.close, end: item.end });
+        stack.push(item);
       }
     }
 
@@ -410,7 +422,11 @@ export function renderMarkdownWithMarkers(
       break;
     }
     if (next > pos) {
-      out += options.escapeText(text.slice(pos, next));
+      const inAutoLink = stack.some((item) => item.kind === "link" && item.autoLinked);
+      out += options.escapeText(
+        text.slice(pos, next),
+        inAutoLink ? { inAutoLink: true } : undefined,
+      );
     }
   }
 


### PR DESCRIPTION
Closes #102162

## What Problem This Solves

Fixes an issue where Telegram users who received an auto-linked bare URL containing query-string `&` separators would see `&amp;` in the link's visible text and, depending on the client, be directed to a URL with `&amp;` instead of a raw `&`.

## Why This Change Was Made

The Markdown core renderer now passes an `EscapeTextContext` to `escapeText` so renderers can tell when they are inside an auto-linked link. The Telegram formatter uses that context to keep the visible link text raw (only escaping angle brackets for valid HTML) while leaving the `href` attribute fully HTML-escaped. Authored link labels continue to escape `&` as before.

This avoids changing HTML-validity of the `href` attribute while fixing the user-visible prompt text and destination for bare auto-links.

## User Impact

Telegram users can now tap auto-linked URLs such as `https://example.com/post.php?post=100&action=edit` and reliably reach the intended page. Authored `[label](url)` links still render safely.

## Evidence

- `packages/markdown-core/src/ir.links.test.ts`: added tests proving `escapeText` receives `inAutoLink: true` only inside auto-links and not inside authored links.
- `extensions/telegram/src/format.test.ts`: added tests for auto-linked bare URL with `&` (visible text raw, href escaped) and authored link labels (still escaped).
- `node scripts/run-vitest.mjs packages/markdown-core/src/ir.links.test.ts packages/markdown-core/src/render.*.test.ts packages/markdown-core/src/tables.test.ts`
- `node scripts/run-vitest.mjs extensions/telegram/src/format.test.ts`
- `pnpm tsgo:core && pnpm tsgo:extensions` both passed.