### PR TITLE
fix(plugins): enforce hook security invariants

### DIFF
--- a/docs/cli/plugins.md
+++ b/docs/cli/plugins.md
@@ -401,7 +401,7 @@ For runtime hook debugging:
 
 - `openclaw plugins inspect <id> --runtime --json` shows registered hooks and diagnostics from a module-loaded inspection pass. Runtime inspection never installs dependencies; use `openclaw doctor --fix` to clean legacy dependency state or recover missing downloadable plugins that are referenced by config.
 - `openclaw gateway status --deep --require-rpc` confirms the reachable Gateway URL/profile, service/process hints, config path, and RPC health.
-- Non-bundled conversation hooks (`llm_input`, `llm_output`, `before_model_resolve`, `before_agent_reply`, `before_agent_run`, `before_agent_finalize`, `agent_end`) require `plugins.entries.<id>.hooks.allowConversationAccess=true`.
+- Non-bundled conversation hooks (`before_model_resolve`, `agent_turn_prepare`, `before_prompt_build`, `before_agent_reply`, `llm_input`, `llm_output`, `before_agent_run`, `before_agent_finalize`, `agent_end`) require `plugins.entries.<id>.hooks.allowConversationAccess=true`.
 
 ### Plugin index
 

--- a/docs/gateway/configuration-reference.md
+++ b/docs/gateway/configuration-reference.md
@@ -271,7 +271,7 @@ See [MCP](/cli/mcp#openclaw-as-an-mcp-client-registry) and
 - `plugins.entries.<id>.apiKey`: plugin-level API key convenience field (when supported by the plugin).
 - `plugins.entries.<id>.env`: plugin-scoped env var map.
 - `plugins.entries.<id>.hooks.allowPromptInjection`: when `false`, core blocks prompt-mutating hooks such as `before_prompt_build`. Applies to native plugin hooks and supported bundle-provided hook directories.
-- `plugins.entries.<id>.hooks.allowConversationAccess`: when `true`, trusted non-bundled plugins may read raw conversation content from typed hooks such as `llm_input`, `llm_output`, `before_model_resolve`, `before_agent_reply`, `before_agent_run`, `before_agent_finalize`, and `agent_end`.
+- `plugins.entries.<id>.hooks.allowConversationAccess`: when `true`, trusted non-bundled plugins may read raw conversation content from typed hooks such as `before_model_resolve`, `agent_turn_prepare`, `before_prompt_build`, `before_agent_reply`, `llm_input`, `llm_output`, `before_agent_run`, `before_agent_finalize`, and `agent_end`.
 - `plugins.entries.<id>.subagent.allowModelOverride`: explicitly trust this plugin to request per-run `provider` and `model` overrides for background subagent runs.
 - `plugins.entries.<id>.subagent.allowedModels`: optional allowlist of canonical `provider/model` targets for trusted subagent overrides. Use `"*"` only when you intentionally want to allow any model.
 - `plugins.entries.<id>.llm.allowModelOverride`: explicitly trust this plugin to request model overrides for `api.runtime.llm.complete`.

--- a/docs/plugins/hooks.md
+++ b/docs/plugins/hooks.md
@@ -654,8 +654,9 @@ across equivalent finalize decisions, and `maxAttempts` caps how many extra
 passes the host will allow before continuing with the natural final answer.
 
 Non-bundled plugins that need raw conversation hooks (`before_model_resolve`,
-`before_agent_reply`, `llm_input`, `llm_output`, `before_agent_finalize`,
-`agent_end`, or `before_agent_run`) must set:
+`agent_turn_prepare`, `before_prompt_build`, `before_agent_reply`, `llm_input`,
+`llm_output`, `before_agent_finalize`, `agent_end`, or `before_agent_run`) must
+set:
 
 ```json
 {
@@ -671,8 +672,11 @@ Non-bundled plugins that need raw conversation hooks (`before_model_resolve`,
 }
 ```
 
-Prompt-mutating hooks and durable next-turn injections can be disabled per
-plugin with `plugins.entries.<id>.hooks.allowPromptInjection=false`.
+`agent_turn_prepare` and `before_prompt_build` also mutate prompt construction,
+so they require conversation access and remain subject to
+`plugins.entries.<id>.hooks.allowPromptInjection`. Prompt-mutating hooks and
+durable next-turn injections can be disabled per plugin by setting that option
+to `false`.
 
 ### Session extensions and next-turn injections
 

--- a/docs/plugins/plugin-permission-requests.md
+++ b/docs/plugins/plugin-permission-requests.md
@@ -114,9 +114,10 @@ current call and passes the resolved value to `onResolution`. If your plugin
 offers `allow-always`, document and implement exactly what future calls it
 trusts.
 
-If the hook also returns `params`, OpenClaw applies those parameter changes only
-after the approval succeeds. A lower-priority hook can still block after a
-higher-priority hook requested approval.
+If the hook also returns `params`, OpenClaw snapshots the base parameters and
+those overrides when approval is requested, then applies the overrides only
+after approval succeeds. A lower-priority hook can still block, but cannot
+rewrite the parameters covered by the pending approval.
 
 `allowedDecisions` limits the buttons and commands shown to the user. The
 Gateway rejects a resolve attempt for any decision the request did not offer.

--- a/src/agents/agent-tools.before-tool-call.approval.test.ts
+++ b/src/agents/agent-tools.before-tool-call.approval.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "vitest";
+import { resolveBeforeToolCallApprovalOutcome } from "./agent-tools.before-tool-call.approval.js";
+
+describe("before_tool_call approval snapshots", () => {
+  it("detaches deferred approval params from mutable hook and caller objects", async () => {
+    const baseParams = { command: "safe", options: { cwd: "/safe" } };
+    const overrideParams = { env: { MODE: "safe" } };
+
+    const outcome = await resolveBeforeToolCallApprovalOutcome({
+      result: {
+        requireApproval: {
+          pluginId: "policy",
+          title: "Needs approval",
+          description: "Approval needed",
+        },
+        params: overrideParams,
+      },
+      approvalMode: "defer",
+      toolName: "bash",
+      baseParams,
+    });
+
+    baseParams.options.cwd = "/unapproved";
+    overrideParams.env.MODE = "unapproved";
+
+    expect(outcome).toMatchObject({
+      blocked: false,
+      params: { command: "safe", options: { cwd: "/safe" } },
+      deferredApproval: {
+        baseParams: { command: "safe", options: { cwd: "/safe" } },
+        overrideParams: { env: { MODE: "safe" } },
+      },
+    });
+    if (!outcome || outcome.blocked || !outcome.deferredApproval) {
+      throw new Error("expected deferred approval outcome");
+    }
+    (outcome.params as typeof baseParams).options.cwd = "/outcome-mutated";
+    expect(outcome.deferredApproval.baseParams).toEqual({
+      command: "safe",
+      options: { cwd: "/safe" },
+    });
+  });
+
+  const sharedMemoryCases: Array<
+    [
+      string,
+      {
+        baseParams: Record<string, unknown>;
+        overrideParams?: Record<string, unknown>;
+      },
+    ]
+  > = [
+    ["base params", { baseParams: { shared: new Uint8Array(new SharedArrayBuffer(4)) } }],
+    [
+      "override params",
+      {
+        baseParams: { command: "safe" },
+        overrideParams: { shared: new Uint8Array(new SharedArrayBuffer(4)) },
+      },
+    ],
+  ];
+
+  it.each(sharedMemoryCases)("rejects shared memory in %s", async (_name, values) => {
+    await expect(
+      resolveBeforeToolCallApprovalOutcome({
+        result: {
+          requireApproval: {
+            pluginId: "policy",
+            title: "Needs approval",
+            description: "Approval needed",
+          },
+          params: values.overrideParams,
+        },
+        approvalMode: "defer",
+        toolName: "bash",
+        baseParams: values.baseParams,
+      }),
+    ).rejects.toThrow("before_tool_call mutable input isolation failed");
+  });
+});

--- a/src/agents/agent-tools.before-tool-call.approval.ts
+++ b/src/agents/agent-tools.before-tool-call.approval.ts
@@ -18,6 +18,7 @@ import {
   MAX_PLUGIN_APPROVAL_TIMEOUT_MS,
 } from "../infra/plugin-approvals.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
+import { cloneHookIsolationValue } from "../plugins/hook-isolation.js";
 import {
   PluginApprovalResolutions,
   type PluginApprovalResolution,
@@ -446,18 +447,25 @@ export async function resolveBeforeToolCallApprovalOutcome(params: {
   if (!approval) {
     return undefined;
   }
+  // Detach the approval payload from plugin- and caller-owned objects before
+  // the request can outlive this policy pass.
+  const baseParamsSnapshot = cloneHookIsolationValue("before_tool_call", params.baseParams);
+  const overrideParamsSnapshot =
+    params.result?.params === undefined
+      ? undefined
+      : cloneHookIsolationValue("before_tool_call", params.result.params);
   warnDeprecatedApprovalTimeoutBehavior(approval);
   if (params.approvalMode === "defer") {
     return {
       blocked: false,
-      params: params.baseParams,
+      params: cloneHookIsolationValue("before_tool_call", baseParamsSnapshot),
       deferredApproval: {
         approval,
         toolName: params.toolName,
         ...(params.toolCallId ? { toolCallId: params.toolCallId } : {}),
         ...(params.ctx ? { ctx: params.ctx } : {}),
-        baseParams: params.baseParams,
-        overrideParams: params.result?.params,
+        baseParams: baseParamsSnapshot,
+        overrideParams: overrideParamsSnapshot,
       },
     };
   }
@@ -469,7 +477,7 @@ export async function resolveBeforeToolCallApprovalOutcome(params: {
       disposition: "blocked",
       deniedReason: "plugin-approval",
       reason: approval.description || approval.title || "Plugin approval required",
-      params: params.baseParams,
+      params: baseParamsSnapshot,
     };
   }
   if (params.approvalMode === "deny") {
@@ -479,7 +487,7 @@ export async function resolveBeforeToolCallApprovalOutcome(params: {
       kind: "veto",
       deniedReason: "plugin-approval",
       reason: "approval_required",
-      params: params.baseParams,
+      params: baseParamsSnapshot,
     };
   }
   return await requestPluginToolApproval({
@@ -488,8 +496,8 @@ export async function resolveBeforeToolCallApprovalOutcome(params: {
     ...(params.toolCallId ? { toolCallId: params.toolCallId } : {}),
     ...(params.ctx ? { ctx: params.ctx } : {}),
     signal: params.signal,
-    baseParams: params.baseParams,
-    overrideParams: params.result?.params,
+    baseParams: baseParamsSnapshot,
+    overrideParams: overrideParamsSnapshot,
   });
 }
 

--- a/src/plugin-sdk/test-helpers/contracts-testkit.ts
+++ b/src/plugin-sdk/test-helpers/contracts-testkit.ts
@@ -47,6 +47,7 @@ export function registerTestPlugin(params: {
   params.register(
     params.registry.createApi(params.record, {
       config: params.config,
+      hookPolicy: params.config.plugins?.entries?.[params.record.id]?.hooks,
     }),
   );
 }

--- a/src/plugins/contracts/host-hooks.contract.test.ts
+++ b/src/plugins/contracts/host-hooks.contract.test.ts
@@ -87,6 +87,20 @@ function diagnosticSummaries(diagnostics: readonly unknown[]) {
   });
 }
 
+function createHostHookFixtureRegistry() {
+  return createPluginRegistryFixture({
+    plugins: {
+      entries: {
+        "host-hook-fixture": {
+          hooks: {
+            allowConversationAccess: true,
+          },
+        },
+      },
+    },
+  });
+}
+
 function loadSessionStore(
   storePath: string,
   _options?: { skipCache?: boolean },
@@ -159,7 +173,7 @@ describe("host-hook fixture plugin contract", () => {
   });
 
   it("registers generic SDK seams without Plan Mode business logic", () => {
-    const { config, registry } = createPluginRegistryFixture();
+    const { config, registry } = createHostHookFixtureRegistry();
     registerTestPlugin({
       registry,
       config,
@@ -1150,7 +1164,7 @@ describe("host-hook fixture plugin contract", () => {
   });
 
   it("projects registered session extensions into gateway session rows", () => {
-    const { config, registry } = createPluginRegistryFixture();
+    const { config, registry } = createHostHookFixtureRegistry();
     registerTestPlugin({
       registry,
       config,
@@ -1586,7 +1600,7 @@ describe("host-hook fixture plugin contract", () => {
   });
 
   it("models queued next-turn injections and agent_turn_prepare as one prompt context", async () => {
-    const { config, registry } = createPluginRegistryFixture();
+    const { config, registry } = createHostHookFixtureRegistry();
     registerTestPlugin({
       registry,
       config,
@@ -2158,7 +2172,7 @@ describe("host-hook fixture plugin contract", () => {
   });
 
   it("dispatches sanitized agent events and clears plugin run context on run end", async () => {
-    const { config, registry } = createPluginRegistryFixture();
+    const { config, registry } = createHostHookFixtureRegistry();
     registerTestPlugin({
       registry,
       config,

--- a/src/plugins/contracts/shape.contract.test.ts
+++ b/src/plugins/contracts/shape.contract.test.ts
@@ -8,7 +8,17 @@ import { buildPluginShapeSummary } from "../inspect-shape.js";
 
 describe("plugin shape compatibility matrix", () => {
   it("keeps hook-only, plain capability, and hybrid capability shapes explicit", () => {
-    const { config, registry } = createPluginRegistryFixture();
+    const { config, registry } = createPluginRegistryFixture({
+      plugins: {
+        entries: {
+          "hook-only": {
+            hooks: {
+              allowConversationAccess: true,
+            },
+          },
+        },
+      },
+    });
 
     registerVirtualTestPlugin({
       registry,

--- a/src/plugins/hook-isolation.ts
+++ b/src/plugins/hook-isolation.ts
@@ -1,0 +1,81 @@
+import type { PluginHookName } from "./types.js";
+
+export class HookIsolationError extends Error {}
+
+type WebAssemblyMemoryConstructor = {
+  new (...args: unknown[]): object;
+  prototype: object;
+};
+
+function containsSharedMemory(value: unknown, seen: Set<object>): boolean {
+  if (typeof SharedArrayBuffer !== "undefined" && value instanceof SharedArrayBuffer) {
+    return true;
+  }
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+  if (ArrayBuffer.isView(value)) {
+    return typeof SharedArrayBuffer !== "undefined" && value.buffer instanceof SharedArrayBuffer;
+  }
+  if (value instanceof ArrayBuffer) {
+    return false;
+  }
+  const webAssemblyMemory = (
+    globalThis as unknown as {
+      WebAssembly?: { Memory?: WebAssemblyMemoryConstructor };
+    }
+  ).WebAssembly?.Memory;
+  if (
+    webAssemblyMemory &&
+    value instanceof webAssemblyMemory &&
+    typeof SharedArrayBuffer !== "undefined"
+  ) {
+    if (Reflect.get(webAssemblyMemory.prototype, "buffer", value) instanceof SharedArrayBuffer) {
+      return true;
+    }
+  }
+  if (seen.has(value)) {
+    return false;
+  }
+  seen.add(value);
+  if (value instanceof Map) {
+    const entries = Map.prototype.entries.call(value) as IterableIterator<[unknown, unknown]>;
+    for (const [key, entry] of entries) {
+      if (containsSharedMemory(key, seen) || containsSharedMemory(entry, seen)) {
+        return true;
+      }
+    }
+    return false;
+  }
+  if (value instanceof Set) {
+    const entries = Set.prototype.values.call(value) as IterableIterator<unknown>;
+    for (const entry of entries) {
+      if (containsSharedMemory(entry, seen)) {
+        return true;
+      }
+    }
+    return false;
+  }
+  for (const key of Reflect.ownKeys(value)) {
+    const descriptor = Object.getOwnPropertyDescriptor(value, key);
+    if (descriptor && "value" in descriptor && containsSharedMemory(descriptor.value, seen)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+export function cloneHookIsolationValue<T>(hookName: PluginHookName, value: T): T {
+  try {
+    if (containsSharedMemory(value, new Set<object>())) {
+      throw new TypeError("shared memory cannot be isolated");
+    }
+    const cloned = structuredClone(value);
+    if (containsSharedMemory(cloned, new Set<object>())) {
+      throw new TypeError("shared memory cannot be isolated");
+    }
+    return cloned;
+  } catch (cause) {
+    throw new HookIsolationError(`[hooks] ${hookName} mutable input isolation failed`, { cause });
+  }
+}

--- a/src/plugins/hook-types.ts
+++ b/src/plugins/hook-types.ts
@@ -264,6 +264,8 @@ export const isPromptInjectionHookName = (hookName: PluginHookName): boolean =>
 
 const CONVERSATION_HOOK_NAMES = [
   "before_model_resolve",
+  "agent_turn_prepare",
+  "before_prompt_build",
   "before_agent_reply",
   "llm_input",
   "llm_output",

--- a/src/plugins/hooks.before-tool-call.test.ts
+++ b/src/plugins/hooks.before-tool-call.test.ts
@@ -1,10 +1,14 @@
 /** Tests before-tool-call hook ordering, mutation, and cancellation behavior. */
-import { beforeEach, describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { createHookRunner } from "./hooks.js";
 import { addStaticTestHooks } from "./hooks.test-fixtures.js";
+import { addTestHook } from "./hooks.test-helpers.js";
 import { createEmptyPluginRegistry, type PluginRegistry } from "./registry.js";
-import type { PluginHookToolContext } from "./types.js";
-import type { PluginHookBeforeToolCallResult } from "./types.js";
+import type {
+  PluginHookBeforeToolCallEvent,
+  PluginHookBeforeToolCallResult,
+  PluginHookToolContext,
+} from "./types.js";
 
 const stubCtx: PluginHookToolContext = {
   toolName: "bash",
@@ -252,5 +256,251 @@ describe("before_tool_call hook merger — requireApproval", () => {
   ] as const)("$name", async ({ hooks, expected }) => {
     const result = await runBeforeToolCallWithHooks(registry, hooks);
     expectRequireApprovalResult(result, expected);
+  });
+
+  it("isolates direct event mutation from the caller and later handlers", async () => {
+    const event: PluginHookBeforeToolCallEvent = {
+      toolName: "bash",
+      params: { command: "safe" },
+    };
+    let observedParams: Record<string, unknown> | undefined;
+    addTestHook({
+      registry,
+      pluginId: "approver",
+      hookName: "before_tool_call",
+      priority: 100,
+      handler: () => ({
+        requireApproval: {
+          title: "Needs approval",
+          description: "Approval needed",
+        },
+      }),
+    });
+    addTestHook({
+      registry,
+      pluginId: "mutator",
+      hookName: "before_tool_call",
+      priority: 50,
+      handler: (handlerEvent: PluginHookBeforeToolCallEvent) => {
+        handlerEvent.params.cwd = "/unapproved";
+        return {};
+      },
+    });
+    addTestHook({
+      registry,
+      pluginId: "observer",
+      hookName: "before_tool_call",
+      handler: (handlerEvent: PluginHookBeforeToolCallEvent) => {
+        observedParams = handlerEvent.params;
+        return {};
+      },
+    });
+
+    await createHookRunner(registry).runBeforeToolCall(event, stubCtx);
+
+    expect(event.params).toEqual({ command: "safe" });
+    expect(observedParams).toEqual({ command: "safe" });
+  });
+
+  it("snapshots params when approval is first requested", async () => {
+    const approvedParams = { command: "safe" };
+    addTestHook({
+      registry,
+      pluginId: "policy",
+      hookName: "before_tool_call",
+      priority: 100,
+      handler: () => ({
+        params: approvedParams,
+        requireApproval: {
+          title: "Needs approval",
+          description: "Approval needed",
+        },
+      }),
+    });
+    addTestHook({
+      registry,
+      pluginId: "policy",
+      hookName: "before_tool_call",
+      priority: 50,
+      handler: () => {
+        approvedParams.command = "mutated";
+        return { params: { command: "late override" } };
+      },
+    });
+
+    const result = await createHookRunner(registry).runBeforeToolCall(
+      { toolName: "bash", params: { command: "original" } },
+      stubCtx,
+    );
+
+    expect(result?.params).toEqual({ command: "safe" });
+  });
+
+  it("fails closed when a hook event cannot be isolated", async () => {
+    const handler = vi.fn().mockReturnValue({ block: true });
+    addTestHook({
+      registry,
+      pluginId: "policy",
+      hookName: "before_tool_call",
+      handler,
+    });
+
+    const run = createHookRunner(registry, { catchErrors: true }).runBeforeToolCall(
+      { toolName: "bash", params: { callback: () => undefined } },
+      stubCtx,
+    );
+
+    await expect(run).rejects.toThrow("before_tool_call mutable input isolation failed");
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it("fails closed when a hook event contains shared memory", async () => {
+    const handler = vi.fn().mockReturnValue({});
+    addTestHook({
+      registry,
+      pluginId: "policy",
+      hookName: "before_tool_call",
+      handler,
+    });
+    const shared = new SharedArrayBuffer(4);
+
+    const run = createHookRunner(registry, { catchErrors: true }).runBeforeToolCall(
+      { toolName: "bash", params: { shared: new Uint8Array(shared) } },
+      stubCtx,
+    );
+
+    await expect(run).rejects.toThrow("before_tool_call mutable input isolation failed");
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it("fails closed when shared memory is hidden in Error.cause", async () => {
+    const handler = vi.fn().mockReturnValue({});
+    addTestHook({
+      registry,
+      pluginId: "policy",
+      hookName: "before_tool_call",
+      handler,
+    });
+    const error = new Error("shared", {
+      cause: new Uint8Array(new SharedArrayBuffer(4)),
+    });
+
+    const run = createHookRunner(registry, { catchErrors: true }).runBeforeToolCall(
+      { toolName: "bash", params: { error } },
+      stubCtx,
+    );
+
+    await expect(run).rejects.toThrow("before_tool_call mutable input isolation failed");
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it("fails closed when a hook event contains shared WebAssembly memory", async () => {
+    const handler = vi.fn().mockReturnValue({});
+    addTestHook({
+      registry,
+      pluginId: "policy",
+      hookName: "before_tool_call",
+      handler,
+    });
+    const memory = new WebAssembly.Memory({ initial: 1, maximum: 1, shared: true });
+
+    const run = createHookRunner(registry, { catchErrors: true }).runBeforeToolCall(
+      { toolName: "bash", params: { memory } },
+      stubCtx,
+    );
+
+    await expect(run).rejects.toThrow("before_tool_call mutable input isolation failed");
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it("does not invoke overridden collection iterators during isolation", async () => {
+    class HostileMap extends Map {
+      override [Symbol.iterator](): MapIterator<[unknown, unknown]> {
+        throw new Error("must not call overridden map iterator");
+      }
+    }
+    class HostileSet extends Set {
+      override [Symbol.iterator](): SetIterator<unknown> {
+        throw new Error("must not call overridden set iterator");
+      }
+    }
+    const map = new HostileMap();
+    const set = new HostileSet();
+    Map.prototype.set.call(map, "key", "value");
+    Set.prototype.add.call(set, "value");
+    const handler = vi.fn().mockReturnValue({});
+    addTestHook({
+      registry,
+      pluginId: "policy",
+      hookName: "before_tool_call",
+      handler,
+    });
+
+    await createHookRunner(registry, { catchErrors: true }).runBeforeToolCall(
+      {
+        toolName: "bash",
+        params: {
+          map,
+          set,
+        },
+      },
+      stubCtx,
+    );
+
+    expect(handler).toHaveBeenCalledOnce();
+    const event = handler.mock.calls[0]?.[0];
+    expect(event.params.map).toEqual(new Map([["key", "value"]]));
+    expect(event.params.set).toEqual(new Set(["value"]));
+  });
+
+  it("does not enumerate typed-array elements during isolation", async () => {
+    const bytes = new Uint8Array(1024 * 1024);
+    const ownKeys = vi.spyOn(Reflect, "ownKeys");
+    const handler = vi.fn().mockReturnValue({});
+    addTestHook({
+      registry,
+      pluginId: "policy",
+      hookName: "before_tool_call",
+      handler,
+    });
+
+    await createHookRunner(registry, { catchErrors: true }).runBeforeToolCall(
+      { toolName: "bash", params: { bytes } },
+      stubCtx,
+    );
+
+    expect(handler).toHaveBeenCalledOnce();
+    expect(ownKeys.mock.calls.some(([value]) => ArrayBuffer.isView(value))).toBe(false);
+  });
+
+  it("fails closed when approved params cannot be snapshotted", async () => {
+    const lowerPriorityHook = vi.fn().mockReturnValue({});
+    addTestHook({
+      registry,
+      pluginId: "policy",
+      hookName: "before_tool_call",
+      priority: 100,
+      handler: () => ({
+        params: { callback: () => undefined },
+        requireApproval: {
+          title: "Needs approval",
+          description: "Approval needed",
+        },
+      }),
+    });
+    addTestHook({
+      registry,
+      pluginId: "observer",
+      hookName: "before_tool_call",
+      handler: lowerPriorityHook,
+    });
+
+    const run = createHookRunner(registry, { catchErrors: true }).runBeforeToolCall(
+      { toolName: "bash", params: { command: "safe" } },
+      stubCtx,
+    );
+
+    await expect(run).rejects.toThrow("before_tool_call mutable input isolation failed");
+    expect(lowerPriorityHook).not.toHaveBeenCalled();
   });
 });

--- a/src/plugins/hooks.ts
+++ b/src/plugins/hooks.ts
@@ -15,6 +15,7 @@ import {
   type InputGateDecision,
   isHookDecision,
 } from "./hook-decision-types.js";
+import { cloneHookIsolationValue, HookIsolationError } from "./hook-isolation.js";
 import type { GlobalHookRunnerRegistry, HookRunnerRegistry } from "./hook-registry.types.js";
 import type {
   PluginHookAfterCompactionEvent,
@@ -192,6 +193,7 @@ type ModifyingHookPolicy<K extends PluginHookName, TResult> = {
     next: TResult,
     registration: PluginHookRegistration<K>,
   ) => TResult;
+  isolateEventPerHandler?: boolean;
   mergeNullResults?: boolean;
   shouldStop?: (result: TResult) => boolean;
   terminalLabel?: string;
@@ -613,7 +615,10 @@ export function createHookRunner(
     for (const hook of hooks) {
       try {
         const handler = hook.handler as (event: unknown, ctx: unknown) => Promise<TResult>;
-        const promise = Promise.resolve(handler(event, ctx));
+        const handlerEvent = policy.isolateEventPerHandler
+          ? cloneHookIsolationValue(hookName, event)
+          : event;
+        const promise = Promise.resolve(handler(handlerEvent, ctx));
         const timeoutMs = getModifyingHookTimeoutMs(hookName, hook);
         const handlerResult = timeoutMs ? await withHookTimeout(promise, timeoutMs) : await promise;
 
@@ -636,6 +641,9 @@ export function createHookRunner(
           }
         }
       } catch (err) {
+        if (err instanceof HookIsolationError) {
+          throw err;
+        }
         handleHookError({ hookName, pluginId: hook.pluginId, error: err });
       }
     }
@@ -1211,17 +1219,24 @@ export function createHookRunner(
       event,
       ctx,
       {
+        // A plugin may mutate its local event, but direct writes must not alter
+        // the caller's params or the event observed by another plugin.
+        isolateEventPerHandler: true,
         mergeResults: (acc, next, reg) => {
           if (acc?.block === true) {
             return acc;
           }
-          const approvalPluginId = acc?.requireApproval?.pluginId;
-          const freezeParamsForDifferentPlugin =
-            Boolean(approvalPluginId) && approvalPluginId !== reg.pluginId;
+          const approvalAlreadyRequested = acc?.requireApproval !== undefined;
+          let params = lastDefined(acc?.params, next.params);
+          if (approvalAlreadyRequested) {
+            params = acc?.params;
+          } else if (next.requireApproval && params !== undefined) {
+            // Approval covers one detached snapshot. Later hooks may still
+            // block, but they cannot change what the operator reviewed.
+            params = cloneHookIsolationValue("before_tool_call", params);
+          }
           return {
-            params: freezeParamsForDifferentPlugin
-              ? acc?.params
-              : lastDefined(acc?.params, next.params),
+            params,
             block: stickyTrue(acc?.block, next.block),
             blockReason: lastDefined(acc?.blockReason, next.blockReason),
             requireApproval:

--- a/src/plugins/loader.hooks-and-runtime.test-utils.ts
+++ b/src/plugins/loader.hooks-and-runtime.test-utils.ts
@@ -1634,6 +1634,13 @@ describe("loadOpenClawPlugins", () => {
       plugin,
       pluginConfig: {
         allow: ["hook-policy-default"],
+        entries: {
+          "hook-policy-default": {
+            hooks: {
+              allowConversationAccess: true,
+            },
+          },
+        },
       },
     });
 
@@ -1834,6 +1841,8 @@ describe("loadOpenClawPlugins", () => {
       filename: "conversation-hooks.cjs",
       body: `module.exports = { id: "conversation-hooks", register(api) {
     api.on("before_model_resolve", () => undefined);
+    api.on("agent_turn_prepare", () => undefined);
+    api.on("before_prompt_build", () => undefined);
     api.on("before_agent_reply", () => undefined);
     api.on("llm_input", () => undefined);
     api.on("llm_output", () => undefined);
@@ -1856,7 +1865,7 @@ describe("loadOpenClawPlugins", () => {
         "non-bundled plugins must set plugins.entries.conversation-hooks.hooks.allowConversationAccess=true",
       ),
     );
-    expect(blockedDiagnostics).toHaveLength(7);
+    expect(blockedDiagnostics).toHaveLength(9);
   });
 
   it("allows conversation typed hooks for non-bundled plugins when explicitly enabled", () => {
@@ -1866,6 +1875,8 @@ describe("loadOpenClawPlugins", () => {
       filename: "conversation-hooks-allowed.cjs",
       body: `module.exports = { id: "conversation-hooks-allowed", register(api) {
     api.on("before_model_resolve", () => undefined);
+    api.on("agent_turn_prepare", () => undefined);
+    api.on("before_prompt_build", () => undefined);
     api.on("before_agent_reply", () => undefined);
     api.on("llm_input", () => undefined);
     api.on("llm_output", () => undefined);
@@ -1891,6 +1902,8 @@ describe("loadOpenClawPlugins", () => {
 
     expect(registry.typedHooks.map((entry) => entry.hookName)).toEqual([
       "before_model_resolve",
+      "agent_turn_prepare",
+      "before_prompt_build",
       "before_agent_reply",
       "llm_input",
       "llm_output",


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Resolves hook security boundary gaps where prompt-sensitive hooks did not consistently require conversation access, mutable tool-call objects could leak changes between handlers, and approved tool parameters could change after approval was granted.

## Why This Change Was Made

`agent_turn_prepare` and `before_prompt_build` now use the existing conversation-access gate. Each `before_tool_call` handler receives an isolated structured clone, and the approval owner freezes detached base, override, and deferred parameter snapshots at the point approval is requested.

Non-cloneable values fail closed instead of sharing mutable authority across plugin boundaries.

## User Impact

Non-bundled plugins cannot inspect prompt/conversation state without explicit opt-in, one tool hook cannot mutate what a later hook sees, and tool execution cannot drift from the parameters the user approved.

## Evidence

Exact head: `42de8cd59963dbcc64d7c8d3f009ceca1a8bb541`

- 188 focused branch tests passed across hook dispatch, approval binding, and loader/runtime behavior.
- After final isolation hardening, 85 focused approval, contract, and hook-runner tests passed.
- Regressions cover cross-handler and post-approval mutation, clone failures, SharedArrayBuffer views, shared WebAssembly memory, non-enumerable Error causes, hostile collection iterators, and constant-space typed-array inspection.
- Core production typecheck, targeted formatting/lint, and `git diff --check` passed.
- Fresh autoreview found no actionable issues at 0.90 confidence.
- Security and plugin hook documentation are updated.




