### PR TITLE
fix(onboarding): Codex setup no longer fails after verification

### DIFF
--- a/src/system-agent/revalidate-inference-owner.test.ts
+++ b/src/system-agent/revalidate-inference-owner.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it, vi } from "vitest";
+import type { SystemAgentConfiguredRoute } from "./inference-route.js";
+import { revalidateSetupInferenceOwner } from "./revalidate-inference-owner.js";
+import type { SystemAgentVerifiedInferenceBinding } from "./verified-inference.js";
+
+function embeddedRoute(agentHarnessRuntimeOverride: string): SystemAgentConfiguredRoute {
+  return {
+    runner: "embedded",
+    provider: "openai",
+    model: "gpt-5.6-sol",
+    modelLabel: "openai/gpt-5.6-sol",
+    agentId: "main",
+    agentDir: "/tmp/openclaw-agent",
+    agentHarnessRuntimeOverride,
+    runConfig: {
+      agents: {
+        defaults: {
+          workspace: "/tmp/openclaw-workspace",
+        },
+      },
+    },
+  };
+}
+
+describe("revalidateSetupInferenceOwner", () => {
+  it("reloads a staged plugin harness before validating its runtime artifact", async () => {
+    const order: string[] = [];
+    const binding = {} as SystemAgentVerifiedInferenceBinding;
+    const ensureSelectedAgentHarnessPlugin = vi.fn(async () => {
+      order.push("ensure");
+    });
+    const createSystemAgentVerifiedInferenceBinding = vi.fn(async () => {
+      order.push("validate");
+      return binding;
+    });
+    const route = embeddedRoute("auto");
+
+    await expect(
+      revalidateSetupInferenceOwner({
+        route,
+        auth: {
+          agentHarnessId: "codex",
+          runtimeOwnerKind: "plugin-harness",
+        },
+        deps: {
+          ensureSelectedAgentHarnessPlugin,
+          createSystemAgentVerifiedInferenceBinding,
+        },
+      }),
+    ).resolves.toBe(binding);
+
+    expect(order).toEqual(["ensure", "validate"]);
+    expect(ensureSelectedAgentHarnessPlugin).toHaveBeenCalledWith({
+      provider: "openai",
+      modelId: "gpt-5.6-sol",
+      config: route.runConfig,
+      agentId: "main",
+      agentHarnessId: "codex",
+      workspaceDir: "/tmp/openclaw-workspace",
+    });
+  });
+
+  it("does not reload the built-in OpenClaw harness", async () => {
+    const ensureSelectedAgentHarnessPlugin = vi.fn(async () => {});
+    const binding = {} as SystemAgentVerifiedInferenceBinding;
+
+    await expect(
+      revalidateSetupInferenceOwner({
+        route: embeddedRoute("auto"),
+        auth: { agentHarnessId: "openclaw", authFingerprint: "auth" },
+        deps: {
+          ensureSelectedAgentHarnessPlugin,
+          createSystemAgentVerifiedInferenceBinding: vi.fn(async () => binding),
+        },
+      }),
+    ).resolves.toBe(binding);
+
+    expect(ensureSelectedAgentHarnessPlugin).not.toHaveBeenCalled();
+  });
+});

--- a/src/system-agent/revalidate-inference-owner.ts
+++ b/src/system-agent/revalidate-inference-owner.ts
@@ -1,5 +1,7 @@
 // Rebuilds an exact verified inference owner after a successful live probe.
+import { resolveAgentWorkspaceDir } from "../agents/agent-scope.js";
 import type { AgentExecutionAuthBinding } from "../agents/execution-auth-binding.js";
+import type { ensureSelectedAgentHarnessPlugin } from "../agents/harness/runtime-plugin.js";
 import type { SystemAgentConfiguredRoute } from "./inference-route.js";
 import {
   createSystemAgentVerifiedInferenceBinding,
@@ -9,6 +11,7 @@ import {
 
 type RevalidationDeps = SystemAgentVerifiedInferenceDeps & {
   createSystemAgentVerifiedInferenceBinding?: typeof createSystemAgentVerifiedInferenceBinding;
+  ensureSelectedAgentHarnessPlugin?: typeof ensureSelectedAgentHarnessPlugin;
 };
 
 export async function revalidateSetupInferenceOwner(params: {
@@ -16,6 +19,36 @@ export async function revalidateSetupInferenceOwner(params: {
   auth: AgentExecutionAuthBinding;
   deps: RevalidationDeps;
 }): Promise<SystemAgentVerifiedInferenceBinding> {
+  const configuredHarnessId =
+    params.route.runner === "embedded"
+      ? params.route.agentHarnessRuntimeOverride.trim()
+      : undefined;
+  const successfulHarnessId =
+    params.auth.agentHarnessId?.trim() ||
+    (configuredHarnessId && configuredHarnessId !== "auto" ? configuredHarnessId : undefined);
+  if (
+    params.route.runner === "embedded" &&
+    successfulHarnessId &&
+    successfulHarnessId !== "openclaw"
+  ) {
+    // Another gateway run can replace the process-global plugin registry while
+    // setup probes. Reload the staged harness before validating its exact artifact.
+    const ensureHarness =
+      params.deps.ensureSelectedAgentHarnessPlugin ??
+      (await import("../agents/harness/runtime-plugin.js")).ensureSelectedAgentHarnessPlugin;
+    await ensureHarness({
+      provider: params.route.provider,
+      modelId: params.route.model,
+      config: params.route.runConfig,
+      agentId: params.route.agentId,
+      agentHarnessId: successfulHarnessId,
+      workspaceDir: resolveAgentWorkspaceDir(
+        params.route.runConfig,
+        params.route.agentId,
+        process.env,
+      ),
+    });
+  }
   const createBinding =
     params.deps.createSystemAgentVerifiedInferenceBinding ??
     createSystemAgentVerifiedInferenceBinding;


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where macOS onboarding users with a working local Codex login could complete inference verification, then see activation fail because the successful inference harness runtime was no longer active.

## Why This Change Was Made

Activation now reloads the exact selected embedded non-core harness immediately before rebuilding the verified inference binding. This restores the runtime owner after intervening plugin-registry work while leaving the built-in OpenClaw path unchanged.

## User Impact

Users can connect an existing Codex CLI account during macOS onboarding without the successful verification being invalidated before activation completes.

## Evidence

- Reproduced before the fix with the released macOS app and the exact activation RPC:
  `The verified inference owner changed before activation completed.`
- Added focused coverage for reload ordering and the built-in OpenClaw skip path; 2 tests passed before the conflict-free base refresh.
- Exact candidate tree passed `pnpm check:changed --base origin/main` and a full `pnpm build` on Blacksmith Testbox.
- Rebuilt and ad-hoc signed a separately named macOS app bundle; `codesign --verify --deep --strict` passed.
- Retried activation against a clean isolated gateway state using the existing local Codex login:
  `{"ok":true,"modelRef":"openai/gpt-5.6-sol","latencyMs":30070,"lines":["Inference verified: openai/gpt-5.6-sol"]}`
- Fresh autoreview reported no accepted or actionable findings.
