### PR TITLE
fix(memory): reject invalid QMD search results

### DIFF
--- a/packages/memory-host-sdk/src/host/qmd-query-parser.test.ts
+++ b/packages/memory-host-sdk/src/host/qmd-query-parser.test.ts
@@ -14,6 +14,17 @@ describe("parseQmdQueryJson", () => {
     ]);
   });
 
+  it.each([
+    { name: "null", stdout: "[null]" },
+    { name: "string", stdout: '["noise"]' },
+    { name: "number", stdout: "[1]" },
+    { name: "boolean", stdout: "[true]" },
+    { name: "nested array", stdout: '[[{"docid":"abc"}]]' },
+    { name: "mixed object and primitive", stdout: '[{"docid":"abc"},null]' },
+  ])("rejects a $name QMD result before it reaches memory consumers", ({ stdout }) => {
+    expect(() => parseQmdQueryJson(stdout, "")).toThrow(/qmd query returned invalid JSON/i);
+  });
+
   it("extracts embedded result arrays from noisy stdout", () => {
     const results = parseQmdQueryJson(
       `initializing

--- a/packages/memory-host-sdk/src/host/qmd-query-parser.ts
+++ b/packages/memory-host-sdk/src/host/qmd-query-parser.ts
@@ -91,13 +91,13 @@ function summarizeQmdStderr(raw: string): string {
 function parseQmdQueryResultArray(raw: string): QmdQueryResult[] | null {
   try {
     const parsed = JSON.parse(raw) as unknown;
-    if (!Array.isArray(parsed)) {
+    if (
+      !Array.isArray(parsed) ||
+      parsed.some((item) => typeof item !== "object" || item === null || Array.isArray(item))
+    ) {
       return null;
     }
     return parsed.map((item) => {
-      if (typeof item !== "object" || item === null) {
-        return item as QmdQueryResult;
-      }
       const record = item as Record<string, unknown>;
       const docid = typeof record.docid === "string" ? record.docid : undefined;
       const score =


### PR DESCRIPTION
Closes #114315
Related contributor investigation: #114319 (thank you @kevin2966n).

## What Problem This Solves

Fixes an issue where QMD memory search accepted arrays containing null, strings, numbers, booleans, nested arrays, or mixed invalid entries as typed search results. Downstream memory-manager callers dereference result objects, so malformed provider output could escape its parsing boundary and crash memory retrieval.

## Why This Change Was Made

Validate every result array entry at the existing private QMD parser boundary before normalization. Reject an invalid payload as invalid JSON-shaped result data; preserve clean object results, QMD no-results markers, logged/noisy result recovery, and all existing plugin-facing signatures. No dependency, configuration, fallback, storage schema, provider change, or public Plugin SDK change.

## User Impact

Malformed QMD provider output fails safely with the existing actionable parse error; valid memory recall and existing noisy QMD search behavior continue unchanged.

## Evidence

- Genuine fail-first against fresh `main`: all six new QMD cases fail on unchanged production because invalid values are incorrectly returned to typed consumers.
- Exact final head: 23 parser tests (including all 6 regression cases), 27 QMD-process tests, and all 162 real QMD memory-manager tests pass: **212/212**.
- Standalone Node 24 real-parser proof: `REAL_QMD_RESULT_BOUNDARY_PASS`; rejected null/string/number/boolean/nested/mixed payloads while a real valid QMD result retained its document, score, and snippet.
- Full exact-head `CI=1 pnpm check:changed`: passed, including format, max-line ratchet, core and test typechecks, typed lint, SDK contract, plugin boundaries, schema/storage guards, and import-cycle checks.
- Independent exact-commit `gpt-5.6-sol` extra-high-effort review: clean, correctness 0.97.
- Blacksmith Testbox: `tbx_01kyp9c9e2k906hr6fdbwt05et`.
- Report and broader original investigation: thanks @kevin2966n (#114315, #114319). This PR intentionally claims only the independently proven malformed-QMD-result bug.

- Exact final commit: `6f9b436f80d064ab1f0f85b008a20258a4688c1a`.
