### PR TITLE
refactor(memory): deduplicate promotion and CLI flows

### DIFF
--- a/extensions/memory-core/src/cli-index-search.runtime.ts
+++ b/extensions/memory-core/src/cli-index-search.runtime.ts
@@ -5,14 +5,10 @@ import path from "node:path";
 import { resolveMemoryDreamingConfig } from "openclaw/plugin-sdk/memory-core-host-status";
 import {
   buildCliMemorySearchSessionKey,
-  emitMemorySecretResolveDiagnostics,
   formatAuditCounts,
   formatExtraPaths,
-  loadMemoryCommandConfig,
-  resolveAgent,
-  resolveAgentIds,
   resolveMemoryPluginConfig,
-  withMemoryManagerForAgent,
+  withMemoryCommand,
   type MemoryManager,
 } from "./cli-runtime-common.js";
 import {
@@ -111,146 +107,141 @@ export async function runMemoryIndex(
   hostOptions?: MemoryCoreRuntimeHost,
 ) {
   setVerbose(Boolean(opts.verbose));
-  const { config: cfg, diagnostics } = await loadMemoryCommandConfig("memory index");
-  emitMemorySecretResolveDiagnostics(diagnostics);
-  const agentIds = resolveAgentIds(cfg, opts.agent);
-  for (const agentId of agentIds) {
-    await withMemoryManagerForAgent({
-      cfg,
-      agentId,
-      purpose: "cli",
-      acquireLocalService: hostOptions?.acquireLocalService,
-      withLease: hostOptions?.withLease,
-      run: async (manager) => {
-        try {
-          const syncFn = manager.sync ? manager.sync.bind(manager) : undefined;
-          if (opts.verbose) {
-            const status = manager.status();
-            const label = (text: string) => muted(`${text}:`);
-            const sourceLabels = (status.sources ?? []).map((source) =>
-              formatSourceLabel(source, status.workspaceDir ?? "", agentId),
-            );
-            const extraPaths = status.workspaceDir
-              ? formatExtraPaths(status.workspaceDir, status.extraPaths ?? [])
-              : [];
-            const requestedProvider = status.requestedProvider ?? status.provider;
-            const modelLabel = status.model ?? status.provider;
-            const lines = [
-              `${heading("Memory Index")} ${muted(`(${agentId})`)}`,
-              `${label("Provider")} ${info(status.provider)} ${muted(
-                `(requested: ${requestedProvider})`,
-              )}`,
-              `${label("Model")} ${info(modelLabel)}`,
-              sourceLabels.length ? `${label("Sources")} ${info(sourceLabels.join(", "))}` : null,
-              extraPaths.length ? `${label("Extra paths")} ${info(extraPaths.join(", "))}` : null,
-            ].filter(Boolean) as string[];
-            if (status.fallback) {
-              lines.push(`${label("Fallback")} ${warn(status.fallback.from)}`);
-            }
-            defaultRuntime.log(lines.join("\n"));
-            defaultRuntime.log("");
-          }
-          const startedAt = Date.now();
-          let lastLabel = "Indexing memory…";
-          let lastCompleted = 0;
-          let lastTotal = 0;
-          const formatDuration = (elapsedMs: number) => {
-            const seconds = Math.floor(elapsedMs / 1000);
-            return `${Math.floor(seconds / 60)}:${String(seconds % 60).padStart(2, "0")}`;
-          };
-          const buildLabel = () => {
-            const elapsedMs = Math.max(1, Date.now() - startedAt);
-            const elapsed = formatDuration(elapsedMs);
-            if (lastTotal <= 0 || lastCompleted <= 0) {
-              return `${lastLabel} · elapsed ${elapsed}`;
-            }
-            const remainingMs = Math.max(
-              0,
-              ((lastTotal - lastCompleted) * elapsedMs) / lastCompleted,
-            );
-            return `${lastLabel} · elapsed ${elapsed} · eta ${formatDuration(remainingMs)}`;
-          };
-          if (!syncFn) {
-            defaultRuntime.log("Memory backend does not support manual reindex.");
-            return;
-          }
-          await withProgressTotals(
-            {
-              label: "Indexing memory…",
-              total: 0,
-              fallback: opts.verbose ? "line" : undefined,
-            },
-            async (update, progress) => {
-              const interval = setInterval(() => {
-                progress.setLabel(buildLabel());
-              }, 1000);
-              try {
-                await syncFn({
-                  reason: "cli",
-                  force: Boolean(opts.force),
-                  progress: (syncUpdate) => {
-                    if (syncUpdate.label) {
-                      lastLabel = syncUpdate.label;
-                    }
-                    lastCompleted = syncUpdate.completed;
-                    lastTotal = syncUpdate.total;
-                    update({
-                      completed: syncUpdate.completed,
-                      total: syncUpdate.total,
-                      label: buildLabel(),
-                    });
-                    progress.setLabel(buildLabel());
-                  },
-                });
-              } finally {
-                clearInterval(interval);
-              }
-            },
+  await withMemoryCommand({
+    commandName: "memory index",
+    agent: opts.agent,
+    allAgents: true,
+    purpose: "cli",
+    ...hostOptions,
+    run: async ({ manager, agentId }) => {
+      try {
+        const syncFn = manager.sync ? manager.sync.bind(manager) : undefined;
+        if (opts.verbose) {
+          const status = manager.status();
+          const label = (text: string) => muted(`${text}:`);
+          const sourceLabels = (status.sources ?? []).map((source) =>
+            formatSourceLabel(source, status.workspaceDir ?? "", agentId),
           );
-          const qmdIndexSummary = await summarizeQmdIndexArtifact(manager);
-          if (qmdIndexSummary) {
-            defaultRuntime.log(qmdIndexSummary);
+          const extraPaths = status.workspaceDir
+            ? formatExtraPaths(status.workspaceDir, status.extraPaths ?? [])
+            : [];
+          const requestedProvider = status.requestedProvider ?? status.provider;
+          const modelLabel = status.model ?? status.provider;
+          const lines = [
+            `${heading("Memory Index")} ${muted(`(${agentId})`)}`,
+            `${label("Provider")} ${info(status.provider)} ${muted(
+              `(requested: ${requestedProvider})`,
+            )}`,
+            `${label("Model")} ${info(modelLabel)}`,
+            sourceLabels.length ? `${label("Sources")} ${info(sourceLabels.join(", "))}` : null,
+            extraPaths.length ? `${label("Extra paths")} ${info(extraPaths.join(", "))}` : null,
+          ].filter(Boolean) as string[];
+          if (status.fallback) {
+            lines.push(`${label("Fallback")} ${warn(status.fallback.from)}`);
           }
-          let postIndexStatus = manager.status();
-          let semanticVectorAvailable = postIndexStatus.vector?.semanticAvailable;
-          const vectorStoreAvailable =
-            postIndexStatus.vector?.storeAvailable ?? postIndexStatus.vector?.available;
-          if (
-            postIndexStatus.backend === "builtin" &&
-            (postIndexStatus.vector?.enabled ?? false) &&
-            semanticVectorAvailable === undefined &&
-            vectorStoreAvailable !== false &&
-            typeof manager.probeVectorAvailability === "function"
-          ) {
-            semanticVectorAvailable = await manager.probeVectorAvailability();
-            postIndexStatus = manager.status();
-            semanticVectorAvailable =
-              postIndexStatus.vector?.semanticAvailable ?? semanticVectorAvailable;
-          }
-          const vectorEnabled = postIndexStatus.vector?.enabled ?? false;
-          const vectorAvailable =
-            semanticVectorAvailable ??
-            postIndexStatus.vector?.semanticAvailable ??
-            postIndexStatus.vector?.available ??
-            postIndexStatus.vector?.storeAvailable;
-          const vectorLoadErr = postIndexStatus.vector?.loadError;
-          if (vectorEnabled && vectorAvailable === false) {
-            // Indexing still persisted chunks/FTS state; keep the command successful but
-            // emit a stderr warning so operators and scripts can detect degraded recall.
-            defaultRuntime.error(
-              `Memory index WARNING (${agentId}): chunks_vec not updated — ${formatMemoryVectorDegradedWriteReason(vectorLoadErr)}. Vector recall degraded.`,
-            );
-          } else {
-            defaultRuntime.log(`Memory index updated (${agentId}).`);
-          }
-        } catch (err) {
-          const message = formatErrorMessage(err);
-          defaultRuntime.error(`Memory index failed (${agentId}): ${message}`);
-          process.exitCode = 1;
+          defaultRuntime.log(lines.join("\n"));
+          defaultRuntime.log("");
         }
-      },
-    });
-  }
+        const startedAt = Date.now();
+        let lastLabel = "Indexing memory…";
+        let lastCompleted = 0;
+        let lastTotal = 0;
+        const formatDuration = (elapsedMs: number) => {
+          const seconds = Math.floor(elapsedMs / 1000);
+          return `${Math.floor(seconds / 60)}:${String(seconds % 60).padStart(2, "0")}`;
+        };
+        const buildLabel = () => {
+          const elapsedMs = Math.max(1, Date.now() - startedAt);
+          const elapsed = formatDuration(elapsedMs);
+          if (lastTotal <= 0 || lastCompleted <= 0) {
+            return `${lastLabel} · elapsed ${elapsed}`;
+          }
+          const remainingMs = Math.max(
+            0,
+            ((lastTotal - lastCompleted) * elapsedMs) / lastCompleted,
+          );
+          return `${lastLabel} · elapsed ${elapsed} · eta ${formatDuration(remainingMs)}`;
+        };
+        if (!syncFn) {
+          defaultRuntime.log("Memory backend does not support manual reindex.");
+          return;
+        }
+        await withProgressTotals(
+          {
+            label: "Indexing memory…",
+            total: 0,
+            fallback: opts.verbose ? "line" : undefined,
+          },
+          async (update, progress) => {
+            const interval = setInterval(() => {
+              progress.setLabel(buildLabel());
+            }, 1000);
+            try {
+              await syncFn({
+                reason: "cli",
+                force: Boolean(opts.force),
+                progress: (syncUpdate) => {
+                  if (syncUpdate.label) {
+                    lastLabel = syncUpdate.label;
+                  }
+                  lastCompleted = syncUpdate.completed;
+                  lastTotal = syncUpdate.total;
+                  update({
+                    completed: syncUpdate.completed,
+                    total: syncUpdate.total,
+                    label: buildLabel(),
+                  });
+                  progress.setLabel(buildLabel());
+                },
+              });
+            } finally {
+              clearInterval(interval);
+            }
+          },
+        );
+        const qmdIndexSummary = await summarizeQmdIndexArtifact(manager);
+        if (qmdIndexSummary) {
+          defaultRuntime.log(qmdIndexSummary);
+        }
+        let postIndexStatus = manager.status();
+        let semanticVectorAvailable = postIndexStatus.vector?.semanticAvailable;
+        const vectorStoreAvailable =
+          postIndexStatus.vector?.storeAvailable ?? postIndexStatus.vector?.available;
+        if (
+          postIndexStatus.backend === "builtin" &&
+          (postIndexStatus.vector?.enabled ?? false) &&
+          semanticVectorAvailable === undefined &&
+          vectorStoreAvailable !== false &&
+          typeof manager.probeVectorAvailability === "function"
+        ) {
+          semanticVectorAvailable = await manager.probeVectorAvailability();
+          postIndexStatus = manager.status();
+          semanticVectorAvailable =
+            postIndexStatus.vector?.semanticAvailable ?? semanticVectorAvailable;
+        }
+        const vectorEnabled = postIndexStatus.vector?.enabled ?? false;
+        const vectorAvailable =
+          semanticVectorAvailable ??
+          postIndexStatus.vector?.semanticAvailable ??
+          postIndexStatus.vector?.available ??
+          postIndexStatus.vector?.storeAvailable;
+        const vectorLoadErr = postIndexStatus.vector?.loadError;
+        if (vectorEnabled && vectorAvailable === false) {
+          // Indexing still persisted chunks/FTS state; keep the command successful but
+          // emit a stderr warning so operators and scripts can detect degraded recall.
+          defaultRuntime.error(
+            `Memory index WARNING (${agentId}): chunks_vec not updated — ${formatMemoryVectorDegradedWriteReason(vectorLoadErr)}. Vector recall degraded.`,
+          );
+        } else {
+          defaultRuntime.log(`Memory index updated (${agentId}).`);
+        }
+      } catch (err) {
+        const message = formatErrorMessage(err);
+        defaultRuntime.error(`Memory index failed (${agentId}): ${message}`);
+        process.exitCode = 1;
+      }
+    },
+  });
 }
 export async function runMemorySearch(
   queryArg: string | undefined,
@@ -263,25 +254,22 @@ export async function runMemorySearch(
     process.exitCode = 1;
     return;
   }
-  const { config: cfg, diagnostics } = await loadMemoryCommandConfig("memory search");
-  emitMemorySecretResolveDiagnostics(diagnostics, { json: Boolean(opts.json) });
-  const agentId = resolveAgent(cfg, opts.agent);
-  const memoryPluginConfig = resolveMemoryPluginConfig(cfg);
-  const dreamingEnabled = resolveMemoryDreamingConfig({
-    pluginConfig: memoryPluginConfig,
-    cfg,
-  }).enabled;
-  const dreaming = resolveShortTermPromotionDreamingConfig({
-    pluginConfig: memoryPluginConfig,
-    cfg,
-  });
-  await withMemoryManagerForAgent({
-    cfg,
-    agentId,
+  await withMemoryCommand({
+    commandName: "memory search",
+    agent: opts.agent,
+    diagnosticsToStderr: Boolean(opts.json),
     purpose: "cli",
-    acquireLocalService: hostOptions?.acquireLocalService,
-    withLease: hostOptions?.withLease,
-    run: async (manager) => {
+    ...hostOptions,
+    run: async ({ manager, cfg, agentId }) => {
+      const memoryPluginConfig = resolveMemoryPluginConfig(cfg);
+      const dreamingEnabled = resolveMemoryDreamingConfig({
+        pluginConfig: memoryPluginConfig,
+        cfg,
+      }).enabled;
+      const dreaming = resolveShortTermPromotionDreamingConfig({
+        pluginConfig: memoryPluginConfig,
+        cfg,
+      });
       const sessionKey = buildCliMemorySearchSessionKey(agentId);
       let results: Awaited<ReturnType<typeof manager.search>>;
       try {
@@ -363,16 +351,13 @@ export async function runMemoryPromote(
   opts: MemoryPromoteCommandOptions,
   hostOptions?: MemoryCoreRuntimeHost,
 ) {
-  const { config: cfg, diagnostics } = await loadMemoryCommandConfig("memory promote");
-  emitMemorySecretResolveDiagnostics(diagnostics, { json: Boolean(opts.json) });
-  const agentId = resolveAgent(cfg, opts.agent);
-  await withMemoryManagerForAgent({
-    cfg,
-    agentId,
+  await withMemoryCommand({
+    commandName: "memory promote",
+    agent: opts.agent,
+    diagnosticsToStderr: Boolean(opts.json),
     purpose: "status",
-    acquireLocalService: hostOptions?.acquireLocalService,
-    withLease: hostOptions?.withLease,
-    run: async (manager) => {
+    ...hostOptions,
+    run: async ({ manager, cfg, agentId }) => {
       const status = manager.status();
       const workspaceDir = status.workspaceDir?.trim();
       const dreaming = resolveShortTermPromotionDreamingConfig({
@@ -523,16 +508,13 @@ export async function runMemoryPromoteExplain(
     process.exitCode = 1;
     return;
   }
-  const { config: cfg, diagnostics } = await loadMemoryCommandConfig("memory promote-explain");
-  emitMemorySecretResolveDiagnostics(diagnostics, { json: Boolean(opts.json) });
-  const agentId = resolveAgent(cfg, opts.agent);
-  await withMemoryManagerForAgent({
-    cfg,
-    agentId,
+  await withMemoryCommand({
+    commandName: "memory promote-explain",
+    agent: opts.agent,
+    diagnosticsToStderr: Boolean(opts.json),
     purpose: "status",
-    acquireLocalService: hostOptions?.acquireLocalService,
-    withLease: hostOptions?.withLease,
-    run: async (manager) => {
+    ...hostOptions,
+    run: async ({ manager, cfg, agentId }) => {
       const status = manager.status();
       const workspaceDir = status.workspaceDir?.trim();
       const dreaming = resolveShortTermPromotionDreamingConfig({

--- a/extensions/memory-core/src/cli-rem.runtime.ts
+++ b/extensions/memory-core/src/cli-rem.runtime.ts
@@ -2,13 +2,7 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { resolveMemoryRemDreamingConfig } from "openclaw/plugin-sdk/memory-core-host-status";
 import { resolvePreferredOpenClawTmpDir } from "openclaw/plugin-sdk/temp-path";
-import {
-  emitMemorySecretResolveDiagnostics,
-  loadMemoryCommandConfig,
-  resolveAgent,
-  resolveMemoryPluginConfig,
-  withMemoryManagerForAgent,
-} from "./cli-runtime-common.js";
+import { resolveMemoryPluginConfig, withMemoryCommand } from "./cli-runtime-common.js";
 import { defaultRuntime, shortenHomePath, theme } from "./cli.host.runtime.js";
 import type { MemoryRemBackfillOptions, MemoryRemHarnessOptions } from "./cli.types.js";
 import { removeBackfillDiaryEntries, writeBackfillDiaryEntries } from "./dreaming-narrative.js";
@@ -27,16 +21,13 @@ export async function runMemorySessionBackfill(
   opts: MemorySessionBackfillOptions,
   hostOptions?: MemoryCoreRuntimeHost,
 ) {
-  const { config: cfg, diagnostics } = await loadMemoryCommandConfig("memory session-backfill");
-  emitMemorySecretResolveDiagnostics(diagnostics, { json: Boolean(opts.json) });
-  const agentId = resolveAgent(cfg, opts.agent);
-  await withMemoryManagerForAgent({
-    cfg,
-    agentId,
+  await withMemoryCommand({
+    commandName: "memory session-backfill",
+    agent: opts.agent,
+    diagnosticsToStderr: Boolean(opts.json),
     purpose: "status",
-    acquireLocalService: hostOptions?.acquireLocalService,
-    withLease: hostOptions?.withLease,
-    run: async (manager) => {
+    ...hostOptions,
+    run: async ({ manager, cfg, agentId }) => {
       const workspaceDir = manager.status().workspaceDir?.trim();
       if (!workspaceDir) {
         defaultRuntime.error("Memory session-backfill requires a resolvable workspace directory.");
@@ -117,16 +108,13 @@ export async function runMemoryRemHarness(
   opts: MemoryRemHarnessOptions,
   hostOptions?: MemoryCoreRuntimeHost,
 ) {
-  const { config: cfg, diagnostics } = await loadMemoryCommandConfig("memory rem-harness");
-  emitMemorySecretResolveDiagnostics(diagnostics, { json: Boolean(opts.json) });
-  const agentId = resolveAgent(cfg, opts.agent);
-  await withMemoryManagerForAgent({
-    cfg,
-    agentId,
+  await withMemoryCommand({
+    commandName: "memory rem-harness",
+    agent: opts.agent,
+    diagnosticsToStderr: Boolean(opts.json),
     purpose: "status",
-    acquireLocalService: hostOptions?.acquireLocalService,
-    withLease: hostOptions?.withLease,
-    run: async (manager) => {
+    ...hostOptions,
+    run: async ({ manager, cfg, agentId }) => {
       const status = manager.status();
       const managerWorkspaceDir = status.workspaceDir?.trim();
       const pluginConfig = resolveMemoryPluginConfig(cfg);
@@ -285,16 +273,13 @@ export async function runMemoryRemBackfill(
   opts: MemoryRemBackfillOptions,
   hostOptions?: MemoryCoreRuntimeHost,
 ) {
-  const { config: cfg, diagnostics } = await loadMemoryCommandConfig("memory rem-backfill");
-  emitMemorySecretResolveDiagnostics(diagnostics, { json: Boolean(opts.json) });
-  const agentId = resolveAgent(cfg, opts.agent);
-  await withMemoryManagerForAgent({
-    cfg,
-    agentId,
+  await withMemoryCommand({
+    commandName: "memory rem-backfill",
+    agent: opts.agent,
+    diagnosticsToStderr: Boolean(opts.json),
     purpose: "status",
-    acquireLocalService: hostOptions?.acquireLocalService,
-    withLease: hostOptions?.withLease,
-    run: async (manager) => {
+    ...hostOptions,
+    run: async ({ manager, cfg, agentId }) => {
       const status = manager.status();
       const workspaceDir = status.workspaceDir?.trim();
       const pluginConfig = resolveMemoryPluginConfig(cfg);

--- a/extensions/memory-core/src/cli-runtime-common.ts
+++ b/extensions/memory-core/src/cli-runtime-common.ts
@@ -30,7 +30,7 @@ type MemoryManagerPurpose = Parameters<typeof getMemorySearchManager>[0]["purpos
 function getMemoryCommandSecretTargetIds(): Set<string> {
   return new Set(["memory.search.remote.apiKey", "agents.entries.*.memory.search.remote.apiKey"]);
 }
-export async function loadMemoryCommandConfig(commandName: string) {
+async function loadMemoryCommandConfig(commandName: string) {
   const { resolvedConfig, diagnostics } = await resolveCommandSecretRefsViaGateway({
     config: getRuntimeConfig(),
     commandName,
@@ -41,7 +41,7 @@ export async function loadMemoryCommandConfig(commandName: string) {
     diagnostics,
   };
 }
-export function emitMemorySecretResolveDiagnostics(
+function emitMemorySecretResolveDiagnostics(
   diagnostics: string[],
   params?: { json?: boolean },
 ): void {
@@ -84,7 +84,7 @@ export function formatAuditCounts(audit: ShortTermAuditSummary): string {
   const suffix = scriptCoverage ? ` · scripts=${scriptCoverage}` : "";
   return `${audit.entryCount} entries · ${audit.promotedCount} promoted · ${audit.conceptTaggedEntryCount} concept-tagged · ${audit.spacedEntryCount} spaced${suffix}`;
 }
-export function resolveAgent(cfg: OpenClawConfig, agent?: string) {
+function resolveAgent(cfg: OpenClawConfig, agent?: string) {
   const trimmed = agent?.trim();
   if (trimmed) {
     return trimmed;
@@ -99,7 +99,7 @@ export function buildCliMemorySearchSessionKey(agentId: string): string {
     dmScope: "per-channel-peer",
   });
 }
-export function resolveAgentIds(cfg: OpenClawConfig, agent?: string): string[] {
+function resolveAgentIds(cfg: OpenClawConfig, agent?: string): string[] {
   const trimmed = agent?.trim();
   if (trimmed) {
     return [trimmed];
@@ -113,7 +113,7 @@ export function resolveAgentIds(cfg: OpenClawConfig, agent?: string): string[] {
 export function formatExtraPaths(workspaceDir: string, extraPaths: string[]): string[] {
   return normalizeExtraMemoryPaths(workspaceDir, extraPaths).map((entry) => shortenHomePath(entry));
 }
-export async function withMemoryManagerForAgent(params: {
+async function withMemoryManagerForAgent(params: {
   cfg: OpenClawConfig;
   agentId: string;
   purpose?: MemoryManagerPurpose;
@@ -144,6 +144,33 @@ export async function withMemoryManagerForAgent(params: {
     },
     run: params.run,
   });
+}
+export async function withMemoryCommand(params: {
+  commandName: string;
+  agent?: string;
+  allAgents?: boolean;
+  diagnosticsToStderr?: boolean;
+  purpose?: MemoryManagerPurpose;
+  acquireLocalService?: MemoryCoreAcquireLocalService;
+  withLease?: PluginStateLeaseRunner;
+  run: (context: { manager: MemoryManager; cfg: OpenClawConfig; agentId: string }) => Promise<void>;
+}): Promise<OpenClawConfig> {
+  const { config: cfg, diagnostics } = await loadMemoryCommandConfig(params.commandName);
+  emitMemorySecretResolveDiagnostics(diagnostics, { json: params.diagnosticsToStderr });
+  const agentIds = params.allAgents
+    ? resolveAgentIds(cfg, params.agent)
+    : [resolveAgent(cfg, params.agent)];
+  for (const agentId of agentIds) {
+    await withMemoryManagerForAgent({
+      cfg,
+      agentId,
+      purpose: params.purpose,
+      acquireLocalService: params.acquireLocalService,
+      withLease: params.withLease,
+      run: async (manager) => params.run({ manager, cfg, agentId }),
+    });
+  }
+  return cfg;
 }
 export type MemorySourceName = "memory" | "sessions";
 type SourceScan = {

--- a/extensions/memory-core/src/cli-status.runtime.ts
+++ b/extensions/memory-core/src/cli-status.runtime.ts
@@ -4,14 +4,11 @@ import {
   resolveMemoryRemDreamingConfig,
 } from "openclaw/plugin-sdk/memory-core-host-status";
 import {
-  emitMemorySecretResolveDiagnostics,
   formatAuditCounts,
   formatExtraPaths,
-  loadMemoryCommandConfig,
-  resolveAgentIds,
   resolveMemoryPluginConfig,
   scanMemorySources,
-  withMemoryManagerForAgent,
+  withMemoryCommand,
   type MemoryManager,
   type MemorySourceName,
   type MemorySourceScan,
@@ -177,9 +174,6 @@ export async function runMemoryStatus(
   hostOptions?: MemoryCoreRuntimeHost,
 ) {
   setVerbose(Boolean(opts.verbose));
-  const { config: cfg, diagnostics } = await loadMemoryCommandConfig("memory status");
-  emitMemorySecretResolveDiagnostics(diagnostics, { json: Boolean(opts.json) });
-  const agentIds = resolveAgentIds(cfg, opts.agent);
   const allResults: Array<{
     agentId: string;
     status: ReturnType<MemoryManager["status"]>;
@@ -191,133 +185,127 @@ export async function runMemoryStatus(
     dreamingAudit?: DreamingArtifactsAuditSummary;
     dreamingRepair?: RepairDreamingArtifactsResult;
   }> = [];
-  for (const agentId of agentIds) {
-    const managerPurpose = opts.index ? "cli" : "status";
-    await withMemoryManagerForAgent({
-      cfg,
-      agentId,
-      purpose: managerPurpose,
-      acquireLocalService: hostOptions?.acquireLocalService,
-      withLease: hostOptions?.withLease,
-      run: async (manager) => {
-        const deep = Boolean(opts.deep || opts.index);
-        let embeddingProbe: MemoryEmbeddingProbeResult | undefined;
-        let indexError: string | undefined;
-        const syncFn = manager.sync ? manager.sync.bind(manager) : undefined;
-        if (deep) {
-          const initialStatus = manager.status();
-          const hasVectorStoreProbe =
-            initialStatus.backend === "builtin" &&
-            typeof manager.probeVectorStoreAvailability === "function";
-          await withProgress(
-            { label: "Checking memory…", total: hasVectorStoreProbe ? 3 : 2 },
-            async (progress) => {
-              progress.setLabel(hasVectorStoreProbe ? "Probing vector store…" : "Probing vectors…");
-              if (hasVectorStoreProbe) {
-                await manager.probeVectorStoreAvailability?.();
-              } else {
-                await manager.probeVectorAvailability();
-              }
+  const cfg = await withMemoryCommand({
+    commandName: "memory status",
+    agent: opts.agent,
+    allAgents: true,
+    diagnosticsToStderr: Boolean(opts.json),
+    purpose: opts.index ? "cli" : "status",
+    ...hostOptions,
+    run: async ({ manager, agentId }) => {
+      const deep = Boolean(opts.deep || opts.index);
+      let embeddingProbe: MemoryEmbeddingProbeResult | undefined;
+      let indexError: string | undefined;
+      const syncFn = manager.sync ? manager.sync.bind(manager) : undefined;
+      if (deep) {
+        const initialStatus = manager.status();
+        const hasVectorStoreProbe =
+          initialStatus.backend === "builtin" &&
+          typeof manager.probeVectorStoreAvailability === "function";
+        await withProgress(
+          { label: "Checking memory…", total: hasVectorStoreProbe ? 3 : 2 },
+          async (progress) => {
+            progress.setLabel(hasVectorStoreProbe ? "Probing vector store…" : "Probing vectors…");
+            if (hasVectorStoreProbe) {
+              await manager.probeVectorStoreAvailability?.();
+            } else {
+              await manager.probeVectorAvailability();
+            }
+            progress.tick();
+            progress.setLabel("Probing embeddings…");
+            embeddingProbe = await manager.probeEmbeddingAvailability();
+            progress.tick();
+            if (hasVectorStoreProbe) {
+              progress.setLabel("Checking semantic vectors…");
+              await manager.probeVectorAvailability();
               progress.tick();
-              progress.setLabel("Probing embeddings…");
-              embeddingProbe = await manager.probeEmbeddingAvailability();
-              progress.tick();
-              if (hasVectorStoreProbe) {
-                progress.setLabel("Checking semantic vectors…");
-                await manager.probeVectorAvailability();
-                progress.tick();
+            }
+          },
+        );
+        if (opts.index && syncFn) {
+          await withProgressTotals(
+            {
+              label: "Indexing memory…",
+              total: 0,
+              fallback: opts.verbose ? "line" : undefined,
+            },
+            async (update, progress) => {
+              try {
+                await syncFn({
+                  reason: "cli",
+                  force: Boolean(opts.force),
+                  progress: (syncUpdate) => {
+                    update({
+                      completed: syncUpdate.completed,
+                      total: syncUpdate.total,
+                      label: syncUpdate.label,
+                    });
+                    if (syncUpdate.label) {
+                      progress.setLabel(syncUpdate.label);
+                    }
+                  },
+                });
+              } catch (err) {
+                indexError = formatErrorMessage(err);
+                defaultRuntime.error(`Memory index failed: ${indexError}`);
+                process.exitCode = 1;
               }
             },
           );
-          if (opts.index && syncFn) {
-            await withProgressTotals(
-              {
-                label: "Indexing memory…",
-                total: 0,
-                fallback: opts.verbose ? "line" : undefined,
-              },
-              async (update, progress) => {
-                try {
-                  await syncFn({
-                    reason: "cli",
-                    force: Boolean(opts.force),
-                    progress: (syncUpdate) => {
-                      update({
-                        completed: syncUpdate.completed,
-                        total: syncUpdate.total,
-                        label: syncUpdate.label,
-                      });
-                      if (syncUpdate.label) {
-                        progress.setLabel(syncUpdate.label);
-                      }
-                    },
-                  });
-                } catch (err) {
-                  indexError = formatErrorMessage(err);
-                  defaultRuntime.error(`Memory index failed: ${indexError}`);
-                  process.exitCode = 1;
-                }
-              },
-            );
-          } else if (opts.index && !syncFn) {
-            defaultRuntime.log("Memory backend does not support manual reindex.");
-          }
+        } else if (opts.index && !syncFn) {
+          defaultRuntime.log("Memory backend does not support manual reindex.");
         }
-        const status = manager.status();
-        const sources = (
-          status.sources?.length ? status.sources : ["memory"]
-        ) as MemorySourceName[];
-        const workspaceDir = status.workspaceDir;
-        const scan = workspaceDir
-          ? await scanMemorySources({
-              workspaceDir,
-              agentId,
-              sources,
-              extraPaths: status.extraPaths,
-            })
-          : undefined;
-        let audit: ShortTermAuditSummary | undefined;
-        let repair: RepairShortTermPromotionArtifactsResult | undefined;
-        let dreamingAudit: DreamingArtifactsAuditSummary | undefined;
-        let dreamingRepair: RepairDreamingArtifactsResult | undefined;
-        if (workspaceDir) {
-          dreamingAudit = await auditDreamingArtifacts({ workspaceDir });
-          if (opts.fix && dreamingAudit.issues.some((issue) => issue.fixable)) {
-            dreamingRepair = await repairDreamingArtifacts({ workspaceDir });
-            dreamingAudit = await auditDreamingArtifacts({ workspaceDir });
-          }
-          if (opts.fix) {
-            repair = await repairShortTermPromotionArtifacts({ workspaceDir });
-          }
-          const customQmd = asRecord(asRecord(status.custom)?.qmd);
-          audit = await auditShortTermPromotionArtifacts({
+      }
+      const status = manager.status();
+      const sources = (status.sources?.length ? status.sources : ["memory"]) as MemorySourceName[];
+      const workspaceDir = status.workspaceDir;
+      const scan = workspaceDir
+        ? await scanMemorySources({
             workspaceDir,
-            qmd:
-              status.backend === "qmd"
-                ? {
-                    dbPath: status.dbPath,
-                    collections:
-                      typeof customQmd?.collections === "number"
-                        ? customQmd.collections
-                        : undefined,
-                  }
-                : undefined,
-          });
+            agentId,
+            sources,
+            extraPaths: status.extraPaths,
+          })
+        : undefined;
+      let audit: ShortTermAuditSummary | undefined;
+      let repair: RepairShortTermPromotionArtifactsResult | undefined;
+      let dreamingAudit: DreamingArtifactsAuditSummary | undefined;
+      let dreamingRepair: RepairDreamingArtifactsResult | undefined;
+      if (workspaceDir) {
+        dreamingAudit = await auditDreamingArtifacts({ workspaceDir });
+        if (opts.fix && dreamingAudit.issues.some((issue) => issue.fixable)) {
+          dreamingRepair = await repairDreamingArtifacts({ workspaceDir });
+          dreamingAudit = await auditDreamingArtifacts({ workspaceDir });
         }
-        allResults.push({
-          agentId,
-          status,
-          embeddingProbe,
-          indexError,
-          scan,
-          audit,
-          repair,
-          dreamingAudit,
-          dreamingRepair,
+        if (opts.fix) {
+          repair = await repairShortTermPromotionArtifacts({ workspaceDir });
+        }
+        const customQmd = asRecord(asRecord(status.custom)?.qmd);
+        audit = await auditShortTermPromotionArtifacts({
+          workspaceDir,
+          qmd:
+            status.backend === "qmd"
+              ? {
+                  dbPath: status.dbPath,
+                  collections:
+                    typeof customQmd?.collections === "number" ? customQmd.collections : undefined,
+                }
+              : undefined,
         });
-      },
-    });
-  }
+      }
+      allResults.push({
+        agentId,
+        status,
+        embeddingProbe,
+        indexError,
+        scan,
+        audit,
+        repair,
+        dreamingAudit,
+        dreamingRepair,
+      });
+    },
+  });
   if (opts.json) {
     defaultRuntime.writeJson(allResults);
     return;

--- a/extensions/memory-core/src/short-term-promotion-record.ts
+++ b/extensions/memory-core/src/short-term-promotion-record.ts
@@ -9,7 +9,7 @@ import { appendMemoryHostEvent } from "openclaw/plugin-sdk/memory-host-events";
 import pLimit from "p-limit";
 import { deriveConceptTags } from "./concept-vocabulary.js";
 import { readStore, withShortTermLock, writeStore } from "./short-term-promotion-store.js";
-import type { ShortTermRecallEntry } from "./short-term-promotion-types.js";
+import type { ShortTermRecallEntry, ShortTermRecallStore } from "./short-term-promotion-types.js";
 import {
   buildDailyClaimEntryKey,
   buildClaimHash,
@@ -133,6 +133,21 @@ function buildMemoryRecallSkippedEvent(params: {
   };
 }
 
+async function updateShortTermRecallStore(
+  workspaceDir: string,
+  nowIso: string,
+  update: (store: ShortTermRecallStore) => void | Promise<void>,
+  afterWrite?: () => Promise<void>,
+): Promise<void> {
+  await withShortTermLock(workspaceDir, async () => {
+    const store = await readStore(workspaceDir, nowIso);
+    await update(store);
+    store.updatedAt = nowIso;
+    await writeStore(workspaceDir, store);
+    await afterWrite?.();
+  });
+}
+
 export async function recordShortTermRecalls(params: {
   workspaceDir?: string;
   query: string;
@@ -176,153 +191,154 @@ export async function recordShortTermRecalls(params: {
   const queryHash = hashQuery(query);
   const todayBucket =
     normalizeIsoDay(params.dayBucket ?? "") ?? formatMemoryDreamingDay(nowMs, params.timezone);
-  await withShortTermLock(workspaceDir, async () => {
-    const store = await readStore(workspaceDir, nowIso);
-
-    for (const result of relevant) {
-      const normalizedPath = normalizeMemoryPath(result.path);
-      const rawSnippet = normalizeSnippet(result.snippet);
-      const snippet = truncateShortTermSnippet(rawSnippet);
-      if (
-        !rawSnippet ||
-        isContaminatedDreamingSnippet(rawSnippet, {
-          allowTranscriptTurnSnippet: isShortTermSessionCorpusPath(normalizedPath),
-        })
-      ) {
-        continue;
-      }
-      const identitySnippet =
-        signalType === "daily"
-          ? normalizeSnippet(result.identitySnippet ?? rawSnippet)
-          : rawSnippet;
-      const claimHash = buildClaimHash(identitySnippet);
-      const nonDailyEntry =
-        signalType === "daily"
-          ? Object.values(store.entries).find(
-              (entry) =>
-                !entry.key.startsWith("memory:claim:") &&
-                Math.max(0, Math.floor(entry.recallCount ?? 0)) +
-                  Math.max(0, Math.floor(entry.groundedCount ?? 0)) >
-                  0 &&
-                entry.claimHash === claimHash,
-            )
-          : undefined;
-      // Interactive/grounded writers retain their path-qualified identity. Do
-      // not create a competing daily aggregate for the same claim; reinforce
-      // the existing authoritative candidate instead.
-      const groundedKey = claimHash
-        ? signalType === "daily"
-          ? // Interactive recall intentionally retains its path/range identity;
-            // only daily ingestion aggregates cross-file recurrence by claim.
-            buildDailyClaimEntryKey(claimHash)
-          : buildEntryKey({
-              path: normalizedPath,
-              startLine: Math.max(1, Math.floor(result.startLine)),
-              endLine: Math.max(1, Math.floor(result.endLine)),
-              source: "memory",
-              claimHash,
-            })
-        : null;
-      const baseKey = buildEntryKey(result);
-      const key =
-        nonDailyEntry?.key ??
-        (signalType === "daily" && groundedKey
-          ? groundedKey
-          : groundedKey && store.entries[groundedKey]
+  await updateShortTermRecallStore(
+    workspaceDir,
+    nowIso,
+    (store) => {
+      for (const result of relevant) {
+        const normalizedPath = normalizeMemoryPath(result.path);
+        const rawSnippet = normalizeSnippet(result.snippet);
+        const snippet = truncateShortTermSnippet(rawSnippet);
+        if (
+          !rawSnippet ||
+          isContaminatedDreamingSnippet(rawSnippet, {
+            allowTranscriptTurnSnippet: isShortTermSessionCorpusPath(normalizedPath),
+          })
+        ) {
+          continue;
+        }
+        const identitySnippet =
+          signalType === "daily"
+            ? normalizeSnippet(result.identitySnippet ?? rawSnippet)
+            : rawSnippet;
+        const claimHash = buildClaimHash(identitySnippet);
+        const nonDailyEntry =
+          signalType === "daily"
+            ? Object.values(store.entries).find(
+                (entry) =>
+                  !entry.key.startsWith("memory:claim:") &&
+                  Math.max(0, Math.floor(entry.recallCount ?? 0)) +
+                    Math.max(0, Math.floor(entry.groundedCount ?? 0)) >
+                    0 &&
+                  entry.claimHash === claimHash,
+              )
+            : undefined;
+        // Interactive/grounded writers retain their path-qualified identity. Do
+        // not create a competing daily aggregate for the same claim; reinforce
+        // the existing authoritative candidate instead.
+        const groundedKey = claimHash
+          ? signalType === "daily"
+            ? // Interactive recall intentionally retains its path/range identity;
+              // only daily ingestion aggregates cross-file recurrence by claim.
+              buildDailyClaimEntryKey(claimHash)
+            : buildEntryKey({
+                path: normalizedPath,
+                startLine: Math.max(1, Math.floor(result.startLine)),
+                endLine: Math.max(1, Math.floor(result.endLine)),
+                source: "memory",
+                claimHash,
+              })
+          : null;
+        const baseKey = buildEntryKey(result);
+        const key =
+          nonDailyEntry?.key ??
+          (signalType === "daily" && groundedKey
             ? groundedKey
-            : baseKey);
-      const existing = store.entries[key];
-      const score = clampScore(result.score);
-      const recallDaysBase = existing?.recallDays ?? [];
-      const queryHashesBase = existing?.queryHashes ?? [];
-      const dedupeSignal =
-        Boolean(params.dedupeByQueryPerDay) &&
-        queryHashesBase.includes(queryHash) &&
-        recallDaysBase.includes(todayBucket);
-      const recallCount =
-        signalType === "recall"
-          ? Math.max(0, Math.floor(existing?.recallCount ?? 0) + (dedupeSignal ? 0 : 1))
-          : Math.max(0, Math.floor(existing?.recallCount ?? 0));
-      const dailyCount =
-        signalType === "daily"
-          ? Math.max(0, Math.floor(existing?.dailyCount ?? 0) + (dedupeSignal ? 0 : 1))
-          : Math.max(0, Math.floor(existing?.dailyCount ?? 0));
-      const totalScore = Math.max(0, (existing?.totalScore ?? 0) + (dedupeSignal ? 0 : score));
-      const maxScore = Math.max(existing?.maxScore ?? 0, dedupeSignal ? 0 : score);
-      const queryHashes = mergeQueryHashes(existing?.queryHashes ?? [], queryHash);
-      const recallDays = mergeRecentDistinct(recallDaysBase, todayBucket, MAX_RECALL_DAYS);
-      const conceptTags = deriveConceptTags({ path: normalizedPath, snippet });
-      const provenance = mergeRecallProvenance(existing?.provenance, result.provenance, nowMs);
-      const projectKey = mergeProjectKeyLists(existing?.projectKey, result.projectKey);
+            : groundedKey && store.entries[groundedKey]
+              ? groundedKey
+              : baseKey);
+        const existing = store.entries[key];
+        const score = clampScore(result.score);
+        const recallDaysBase = existing?.recallDays ?? [];
+        const queryHashesBase = existing?.queryHashes ?? [];
+        const dedupeSignal =
+          Boolean(params.dedupeByQueryPerDay) &&
+          queryHashesBase.includes(queryHash) &&
+          recallDaysBase.includes(todayBucket);
+        const recallCount =
+          signalType === "recall"
+            ? Math.max(0, Math.floor(existing?.recallCount ?? 0) + (dedupeSignal ? 0 : 1))
+            : Math.max(0, Math.floor(existing?.recallCount ?? 0));
+        const dailyCount =
+          signalType === "daily"
+            ? Math.max(0, Math.floor(existing?.dailyCount ?? 0) + (dedupeSignal ? 0 : 1))
+            : Math.max(0, Math.floor(existing?.dailyCount ?? 0));
+        const totalScore = Math.max(0, (existing?.totalScore ?? 0) + (dedupeSignal ? 0 : score));
+        const maxScore = Math.max(existing?.maxScore ?? 0, dedupeSignal ? 0 : score);
+        const queryHashes = mergeQueryHashes(existing?.queryHashes ?? [], queryHash);
+        const recallDays = mergeRecentDistinct(recallDaysBase, todayBucket, MAX_RECALL_DAYS);
+        const conceptTags = deriveConceptTags({ path: normalizedPath, snippet });
+        const provenance = mergeRecallProvenance(existing?.provenance, result.provenance, nowMs);
+        const projectKey = mergeProjectKeyLists(existing?.projectKey, result.projectKey);
 
-      const unchangedRepeatedSignal =
-        (Boolean(params.dedupeByQueryPerDay) || signalType === "daily") &&
-        queryHashesBase.includes(queryHash) &&
-        existing?.snippet === snippet;
-      // This preserves freshness only. dedupeSignal above independently owns
-      // whether counts/scores advance, so changed-file daily ingestion still adds evidence.
-      const lastRecalledAt = unchangedRepeatedSignal
-        ? (existing?.lastRecalledAt ?? nowIso)
-        : nowIso;
-      // Daily claim keys deliberately omit the file path so the same fact in
-      // three distinct day files accumulates three query/day signals and can
-      // clear the default dreaming gates. Keep the first source for citation.
-      const preserveFirstDailySource = signalType === "daily" && existing !== undefined;
+        const unchangedRepeatedSignal =
+          (Boolean(params.dedupeByQueryPerDay) || signalType === "daily") &&
+          queryHashesBase.includes(queryHash) &&
+          existing?.snippet === snippet;
+        // This preserves freshness only. dedupeSignal above independently owns
+        // whether counts/scores advance, so changed-file daily ingestion still adds evidence.
+        const lastRecalledAt = unchangedRepeatedSignal
+          ? (existing?.lastRecalledAt ?? nowIso)
+          : nowIso;
+        // Daily claim keys deliberately omit the file path so the same fact in
+        // three distinct day files accumulates three query/day signals and can
+        // clear the default dreaming gates. Keep the first source for citation.
+        const preserveFirstDailySource = signalType === "daily" && existing !== undefined;
 
-      store.entries[key] = {
-        key,
-        path: preserveFirstDailySource ? existing.path : normalizedPath,
-        startLine: preserveFirstDailySource
-          ? existing.startLine
-          : Math.max(1, Math.floor(result.startLine)),
-        endLine: preserveFirstDailySource
-          ? existing.endLine
-          : Math.max(1, Math.floor(result.endLine)),
-        source: "memory",
-        snippet: snippet || existing?.snippet || "",
-        recallCount,
-        dailyCount,
-        groundedCount: Math.max(0, Math.floor(existing?.groundedCount ?? 0)),
-        totalScore,
-        maxScore,
-        firstRecalledAt: existing?.firstRecalledAt ?? nowIso,
-        lastRecalledAt,
-        queryHashes,
-        recallDays,
-        conceptTags: conceptTags.length > 0 ? conceptTags : (existing?.conceptTags ?? []),
-        provenance,
-        claimHash,
-        ...(projectKey ? { projectKey } : {}),
-        ...(existing?.promotedAt ? { promotedAt: existing.promotedAt } : {}),
-      };
-    }
-
-    store.updatedAt = nowIso;
-    await writeStore(workspaceDir, store);
-    await appendMemoryHostEvent(workspaceDir, {
-      type: "memory.recall.recorded",
-      timestamp: nowIso,
-      query,
-      resultCount: relevant.length,
-      results: relevant.map((result) => ({
-        path: normalizeMemoryPath(result.path),
-        startLine: Math.max(1, Math.floor(result.startLine)),
-        endLine: Math.max(1, Math.floor(result.endLine)),
-        score: clampScore(result.score),
-      })),
-    });
-    if (skipped.length > 0) {
-      await appendMemoryHostEvent(
-        workspaceDir,
-        buildMemoryRecallSkippedEvent({
-          timestamp: nowIso,
-          query,
-          eligibleResultCount: relevant.length,
-          skipped,
-        }),
-      );
-    }
-  });
+        store.entries[key] = {
+          key,
+          path: preserveFirstDailySource ? existing.path : normalizedPath,
+          startLine: preserveFirstDailySource
+            ? existing.startLine
+            : Math.max(1, Math.floor(result.startLine)),
+          endLine: preserveFirstDailySource
+            ? existing.endLine
+            : Math.max(1, Math.floor(result.endLine)),
+          source: "memory",
+          snippet: snippet || existing?.snippet || "",
+          recallCount,
+          dailyCount,
+          groundedCount: Math.max(0, Math.floor(existing?.groundedCount ?? 0)),
+          totalScore,
+          maxScore,
+          firstRecalledAt: existing?.firstRecalledAt ?? nowIso,
+          lastRecalledAt,
+          queryHashes,
+          recallDays,
+          conceptTags: conceptTags.length > 0 ? conceptTags : (existing?.conceptTags ?? []),
+          provenance,
+          claimHash,
+          ...(projectKey ? { projectKey } : {}),
+          ...(existing?.promotedAt ? { promotedAt: existing.promotedAt } : {}),
+        };
+      }
+    },
+    async () => {
+      await appendMemoryHostEvent(workspaceDir, {
+        type: "memory.recall.recorded",
+        timestamp: nowIso,
+        query,
+        resultCount: relevant.length,
+        results: relevant.map((result) => ({
+          path: normalizeMemoryPath(result.path),
+          startLine: Math.max(1, Math.floor(result.startLine)),
+          endLine: Math.max(1, Math.floor(result.endLine)),
+          score: clampScore(result.score),
+        })),
+      });
+      if (skipped.length > 0) {
+        await appendMemoryHostEvent(
+          workspaceDir,
+          buildMemoryRecallSkippedEvent({
+            timestamp: nowIso,
+            query,
+            eligibleResultCount: relevant.length,
+            skipped,
+          }),
+        );
+      }
+    },
+  );
 }
 
 export async function recordGroundedShortTermCandidates(params: {
@@ -388,9 +404,7 @@ export async function recordGroundedShortTermCandidates(params: {
   const nowMs = resolveMemoryCoreNowMs(params.nowMs);
   const nowIso = resolveMemoryCoreTimestamp(nowMs);
   const fallbackDayBucket = formatMemoryDreamingDay(nowMs, params.timezone);
-  await withShortTermLock(workspaceDir, async () => {
-    const store = await readStore(workspaceDir, nowIso);
-
+  await updateShortTermRecallStore(workspaceDir, nowIso, (store) => {
     for (const item of relevant) {
       const dayBucket = item.dayBucket ?? fallbackDayBucket;
       const effectiveQuery = item.query || query;
@@ -467,9 +481,6 @@ export async function recordGroundedShortTermCandidates(params: {
         ...(existing?.promotedAt ? { promotedAt: existing.promotedAt } : {}),
       };
     }
-
-    store.updatedAt = nowIso;
-    await writeStore(workspaceDir, store);
   });
 }
 

--- a/extensions/memory-core/src/short-term-promotion-stats.ts
+++ b/extensions/memory-core/src/short-term-promotion-stats.ts
@@ -14,6 +14,7 @@ import {
 import type {
   ShortTermDreamingStats,
   ShortTermDreamingStatsEntry,
+  ShortTermPhaseSignalEntry,
   ShortTermPhaseSignalStore,
   ShortTermRecallEntry,
 } from "./short-term-promotion-types.js";
@@ -226,12 +227,10 @@ export async function loadShortTermPromotionDreamingStats(params: {
   };
 }
 
-export async function recordDreamingPhaseSignals(params: {
-  workspaceDir?: string;
-  phase: "light" | "rem";
-  keys: string[];
-  nowMs?: number;
-}): Promise<void> {
+async function updatePhaseSignals(
+  params: { workspaceDir?: string; keys: string[]; nowMs?: number },
+  mutate: (entry: ShortTermPhaseSignalEntry, nowIso: string) => void,
+): Promise<void> {
   const workspaceDir = params.workspaceDir?.trim();
   if (!workspaceDir) {
     return;
@@ -240,8 +239,7 @@ export async function recordDreamingPhaseSignals(params: {
   if (keys.length === 0) {
     return;
   }
-  const nowMs = resolveMemoryCoreNowMs(params.nowMs);
-  const nowIso = resolveMemoryCoreTimestamp(nowMs);
+  const nowIso = resolveMemoryCoreTimestamp(resolveMemoryCoreNowMs(params.nowMs));
 
   await withShortTermLock(workspaceDir, async () => {
     const [store, phaseSignals] = await Promise.all([
@@ -249,34 +247,38 @@ export async function recordDreamingPhaseSignals(params: {
       readPhaseSignalStore(workspaceDir, nowIso),
     ]);
     const knownKeys = new Set(Object.keys(store.entries));
-
     for (const key of keys) {
       if (!knownKeys.has(key)) {
         continue;
       }
-      const entry = phaseSignals.entries[key] ?? {
-        key,
-        lightHits: 0,
-        remHits: 0,
-      };
-      if (params.phase === "light") {
-        entry.lightHits = Math.min(9999, entry.lightHits + 1);
-        entry.lastLightAt = nowIso;
-      } else {
-        entry.remHits = Math.min(9999, entry.remHits + 1);
-        entry.lastRemAt = nowIso;
-      }
+      const entry = phaseSignals.entries[key] ?? { key, lightHits: 0, remHits: 0 };
+      mutate(entry, nowIso);
       phaseSignals.entries[key] = entry;
     }
-
     for (const [key, entry] of Object.entries(phaseSignals.entries)) {
       if (!knownKeys.has(key) || (entry.lightHits <= 0 && entry.remHits <= 0)) {
         delete phaseSignals.entries[key];
       }
     }
-
     phaseSignals.updatedAt = nowIso;
     await writePhaseSignalStore(workspaceDir, phaseSignals);
+  });
+}
+
+export async function recordDreamingPhaseSignals(params: {
+  workspaceDir?: string;
+  phase: "light" | "rem";
+  keys: string[];
+  nowMs?: number;
+}): Promise<void> {
+  await updatePhaseSignals(params, (entry, nowIso) => {
+    if (params.phase === "light") {
+      entry.lightHits = Math.min(9999, entry.lightHits + 1);
+      entry.lastLightAt = nowIso;
+    } else {
+      entry.remHits = Math.min(9999, entry.remHits + 1);
+      entry.lastRemAt = nowIso;
+    }
   });
 }
 
@@ -285,45 +287,8 @@ export async function recordRemConsideredPhaseSignals(params: {
   keys: string[];
   nowMs?: number;
 }): Promise<void> {
-  const workspaceDir = params.workspaceDir?.trim();
-  if (!workspaceDir) {
-    return;
-  }
-  const keys = uniqueStrings(normalizeStringEntries(params.keys));
-  if (keys.length === 0) {
-    return;
-  }
-  const nowMs = resolveMemoryCoreNowMs(params.nowMs);
-  const nowIso = resolveMemoryCoreTimestamp(nowMs);
-
-  await withShortTermLock(workspaceDir, async () => {
-    const [store, phaseSignals] = await Promise.all([
-      readStore(workspaceDir, nowIso),
-      readPhaseSignalStore(workspaceDir, nowIso),
-    ]);
-    const knownKeys = new Set(Object.keys(store.entries));
-
-    for (const key of keys) {
-      if (!knownKeys.has(key)) {
-        continue;
-      }
-      const entry = phaseSignals.entries[key] ?? {
-        key,
-        lightHits: 0,
-        remHits: 0,
-      };
-      entry.lastRemConsideredAt = nowIso;
-      phaseSignals.entries[key] = entry;
-    }
-
-    for (const [key, entry] of Object.entries(phaseSignals.entries)) {
-      if (!knownKeys.has(key) || (entry.lightHits <= 0 && entry.remHits <= 0)) {
-        delete phaseSignals.entries[key];
-      }
-    }
-
-    phaseSignals.updatedAt = nowIso;
-    await writePhaseSignalStore(workspaceDir, phaseSignals);
+  await updatePhaseSignals(params, (entry, nowIso) => {
+    entry.lastRemConsideredAt = nowIso;
   });
 }
 


### PR DESCRIPTION
## What Problem This Solves

The recently expanded memory-core implementation repeated the same command setup and short-term store lifecycle across multiple CLI and promotion paths. That duplication made agent selection, secret diagnostics, manager cleanup, phase-signal pruning, and recall-store write ordering easier to drift independently.

## Why This Change Was Made

This AI-assisted refactor adds one existing-module `withMemoryCommand` seam for config/secret resolution, single-or-all-agent selection, manager lifecycle, and host leases; one phase-signal updater parameterized by the phase mutation; and one recall-store updater that preserves the existing post-write event ordering. The recall and grounded-candidate provenance calculations and their different event shapes remain separate and explicit.

## User Impact

No user-visible behavior changes. Memory CLI commands retain their output and diagnostic routing, and dreaming promotion signals retain the same lock, pruning, persistence, provenance, and event semantics.

## Evidence

- Numstat: production `+512/-554` (net `-42`); tests `+0/-0`. The current-main duplication was smaller than the older lane snapshot, so this does not claim the original `-150..-190` estimate.
- `OPENCLAW_HEAVY_CHECK_LOCK_SCOPE=worktree node scripts/run-vitest.mjs extensions/memory-core/src/cli.test.ts` — 75 tests passed.
- `OPENCLAW_HEAVY_CHECK_LOCK_SCOPE=worktree node scripts/run-vitest.mjs extensions/memory-core/src/short-term-promotion.test.ts extensions/memory-core/src/short-term-promotion-metadata.test.ts` — 86 tests passed.
- Post-rebase combined proof — 3 files, 161 tests passed.
- `node scripts/check-changed.mjs -- <six changed files>` — passed on Blacksmith Testbox ([run 30429174678](https://github.com/openclaw/openclaw/actions/runs/30429174678)), including format, Knip, extension prod/test typecheck, lint, database-first storage, and import cycles.
- A broad initial `extensions/memory-core` run passed 1,228/1,234 tests. Four REM CLI failures exposed a missing `agentId` destructure and were fixed; the remaining untouched manager blank-query failure and legacy-cleanup timeout reproduced together in isolation and are outside this diff.
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main --engine codex --model gpt-5.6-sol --thinking high` — clean, no accepted/actionable findings.
- Shared CLI ownership is at `extensions/memory-core/src/cli-runtime-common.ts:148`; phase mutation is at `extensions/memory-core/src/short-term-promotion-stats.ts:230`; recall store ordering is at `extensions/memory-core/src/short-term-promotion-record.ts:136`.
- Final self-review re-read every semantic hunk against all eight CLI callers, the store/lock owners, divergent event/provenance branches, and focused tests. It corrected index diagnostic routing and removed five obsolete exports; no other actionable issue remained.
