### PR TITLE
perf(gateway): prewarm dashboard data caches after startup

### DIFF
--- a/src/gateway/server-methods/session-catalog.prewarm.test.ts
+++ b/src/gateway/server-methods/session-catalog.prewarm.test.ts
@@ -1,0 +1,157 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { SessionCatalogProvider } from "../../plugins/session-catalog.js";
+
+const hoisted = vi.hoisted(() => ({
+  activeRegistry: { sessionCatalogs: [] as unknown[] },
+  listSessionEntriesReadOnly: vi.fn(() => []),
+}));
+
+vi.mock("../../plugins/runtime.js", () => ({
+  getActivePluginSessionExtensionRegistry: () => hoisted.activeRegistry,
+}));
+
+vi.mock("../../config/sessions/session-accessor.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../config/sessions/session-accessor.js")>()),
+  listSessionEntriesReadOnly: hoisted.listSessionEntriesReadOnly,
+}));
+
+const { prewarmSessionCatalogList, sessionCatalogHandlers } = await import("./session-catalog.js");
+
+function provider(
+  id: string,
+  overrides: Partial<SessionCatalogProvider> = {},
+): SessionCatalogProvider {
+  return {
+    id,
+    label: id.toUpperCase(),
+    list: vi.fn(async () => []),
+    read: vi.fn(async ({ hostId, threadId }) => ({ hostId, threadId, items: [] })),
+    ...overrides,
+  };
+}
+
+function startList(params: {
+  config: Record<string, unknown>;
+  request: Record<string, unknown>;
+  connId?: string;
+  broadcastToConnIds?: ReturnType<typeof vi.fn>;
+}) {
+  const respond = vi.fn();
+  const completion = Promise.resolve(
+    sessionCatalogHandlers["sessions.catalog.list"]?.({
+      params: params.request,
+      respond,
+      client: params.connId ? { connId: params.connId } : undefined,
+      context: {
+        getRuntimeConfig: () => params.config,
+        ...(params.broadcastToConnIds ? { broadcastToConnIds: params.broadcastToConnIds } : {}),
+      },
+    } as never),
+  );
+  return { completion, respond };
+}
+
+describe("session catalog prewarm", () => {
+  beforeEach(() => {
+    hoisted.activeRegistry.sessionCatalogs = [];
+    hoisted.listSessionEntriesReadOnly.mockClear();
+  });
+
+  it("serves the first handler call from the warmed list cache", async () => {
+    const list = vi.fn(async () => []);
+    hoisted.activeRegistry.sessionCatalogs = [{ provider: provider("codex", { list }) }];
+    const config = { agents: { list: [{ id: "main", default: true }] } };
+
+    await prewarmSessionCatalogList({ config, agentId: "main", limitPerHost: 40 });
+    const handler = startList({
+      config,
+      request: { agentId: "main", limitPerHost: 40 },
+    });
+    await handler.completion;
+
+    expect(list).toHaveBeenCalledOnce();
+    expect(handler.respond).toHaveBeenCalledWith(true, {
+      catalogs: [expect.objectContaining({ id: "codex", hosts: [] })],
+    });
+  });
+
+  it("fans out headless-leader progress without leaking subscriptions", async () => {
+    let now = 1_000;
+    const nowSpy = vi.spyOn(Date, "now").mockImplementation(() => now);
+    let release!: () => void;
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const host = {
+      hostId: "gateway:local",
+      label: "Local",
+      kind: "gateway" as const,
+      connected: true,
+      sessions: [],
+    };
+    const list = vi.fn(async ({ onHost }: { onHost?: (value: typeof host) => void }) => {
+      await gate;
+      onHost?.(host);
+      return [host];
+    });
+    hoisted.activeRegistry.sessionCatalogs = [{ provider: provider("codex", { list }) }];
+    const agentId = "prewarm";
+    const config = { agents: { list: [{ id: agentId, default: true }] } };
+    const followerBroadcast = vi.fn();
+
+    try {
+      const prewarm = prewarmSessionCatalogList({
+        config,
+        agentId,
+        limitPerHost: 40,
+      });
+      await vi.waitFor(() => expect(list).toHaveBeenCalledOnce());
+      const follower = startList({
+        config,
+        request: {
+          agentId,
+          limitPerHost: 40,
+          progressId: "follower-progress",
+        },
+        connId: "follower",
+        broadcastToConnIds: followerBroadcast,
+      });
+
+      expect(list).toHaveBeenCalledOnce();
+      release();
+      await Promise.all([prewarm, follower.completion]);
+
+      expect(followerBroadcast).toHaveBeenCalledOnce();
+      expect(follower.respond).toHaveBeenCalledWith(true, {
+        catalogs: [expect.objectContaining({ id: "codex", hosts: [host] })],
+      });
+
+      now += 2_500;
+      const settledFollowerBroadcast = vi.fn();
+      const settledFollower = startList({
+        config,
+        request: { agentId, limitPerHost: 40, progressId: "settled-progress" },
+        connId: "settled",
+        broadcastToConnIds: settledFollowerBroadcast,
+      });
+      await settledFollower.completion;
+      expect(settledFollowerBroadcast).not.toHaveBeenCalled();
+
+      now += 501;
+      const nextBroadcast = vi.fn();
+      const next = startList({
+        config,
+        request: { agentId, limitPerHost: 40, progressId: "next-progress" },
+        connId: "next",
+        broadcastToConnIds: nextBroadcast,
+      });
+      await next.completion;
+      expect(list).toHaveBeenCalledTimes(2);
+      expect(nextBroadcast).toHaveBeenCalledOnce();
+      expect(followerBroadcast).toHaveBeenCalledOnce();
+    } finally {
+      release();
+      nowSpy.mockRestore();
+    }
+  });
+});

--- a/src/gateway/server-methods/session-catalog.test.ts
+++ b/src/gateway/server-methods/session-catalog.test.ts
@@ -176,7 +176,7 @@ describe("session catalog Gateway methods", () => {
     });
   });
 
-  it("single-flights identical concurrent lists and gives followers only the final result", async () => {
+  it("single-flights identical concurrent lists and fans progress to active followers", async () => {
     let release!: () => void;
     const gate = new Promise<void>((resolve) => {
       release = resolve;
@@ -189,8 +189,8 @@ describe("session catalog Gateway methods", () => {
       sessions: [],
     };
     const list = vi.fn(async ({ onHost }: { onHost?: (value: typeof host) => void }) => {
-      onHost?.(host);
       await gate;
+      onHost?.(host);
       return [host];
     });
     hoisted.activeRegistry.sessionCatalogs = [{ provider: provider("codex", { list }) }];
@@ -224,7 +224,7 @@ describe("session catalog Gateway methods", () => {
     ]);
 
     expect(leaderBroadcast).toHaveBeenCalledOnce();
-    expect(followerBroadcast).not.toHaveBeenCalled();
+    expect(followerBroadcast).toHaveBeenCalledOnce();
     for (const pending of [leader, follower, otherAgent, otherParams]) {
       expect(pending.respond).toHaveBeenCalledWith(true, {
         catalogs: [expect.objectContaining({ id: "codex", hosts: [host] })],

--- a/src/gateway/server-methods/session-catalog.ts
+++ b/src/gateway/server-methods/session-catalog.ts
@@ -26,6 +26,7 @@ import { bindPluginSessionConversation } from "../../plugins/session-conversatio
 import { resolveAgentIdFromSessionKey } from "../../routing/session-key.js";
 import { recordSessionStateEvent } from "../../sessions/session-state-events.js";
 import { upsertSessionUpstreamLink } from "../../sessions/session-upstream-links.js";
+import type { GatewayBroadcastToConnIdsFn } from "../server-broadcast-types.js";
 import { resolveAgentIdOrRespondError } from "./agent-id-shared.js";
 import { createSessionCatalogRequestEntrySnapshot } from "./session-catalog-entry-snapshot.js";
 import type { GatewayRequestHandlers, RespondFn } from "./types.js";
@@ -129,8 +130,15 @@ const providerCreateTargetsByConfig = new WeakMap<
 
 type CatalogListResult = { catalogs: SessionCatalog[] };
 
+type CatalogListProgressSubscriber = {
+  broadcastToConnIds: GatewayBroadcastToConnIdsFn;
+  connId: string;
+  progressId: string;
+};
+
 type CatalogListCacheEntry = {
   expiresAt?: number;
+  progressSubscribers: Map<string, CatalogListProgressSubscriber>;
   result: Promise<CatalogListResult>;
 };
 
@@ -350,8 +358,15 @@ export const sessionCatalogHandlers: GatewayRequestHandlers = {
     const cache = catalogListCache(config, catalogRegistrations);
     const cached = cache.get(listKey);
     if (cached && (cached.expiresAt === undefined || cached.expiresAt > Date.now())) {
-      // progressId is connection-owned and excluded from the work key. Followers skip progressive
-      // frames and receive only the authoritative final result emitted for every caller below.
+      // progressId is connection-owned and excluded from the work key. Active followers register
+      // for the remaining host frames; settled followers receive only the authoritative result.
+      if (cached.expiresAt === undefined && progressConnId && progressId) {
+        cached.progressSubscribers.set(`${progressConnId}\0${progressId}`, {
+          broadcastToConnIds: context.broadcastToConnIds,
+          connId: progressConnId,
+          progressId,
+        });
+      }
       cache.delete(listKey);
       cache.set(listKey, cached);
       respond(true, await cached.result);
@@ -359,6 +374,14 @@ export const sessionCatalogHandlers: GatewayRequestHandlers = {
     }
     if (cached) {
       cache.delete(listKey);
+    }
+    const progressSubscribers = new Map<string, CatalogListProgressSubscriber>();
+    if (progressConnId && progressId) {
+      progressSubscribers.set(`${progressConnId}\0${progressId}`, {
+        broadcastToConnIds: context.broadcastToConnIds,
+        connId: progressConnId,
+        progressId,
+      });
     }
     const operation = (async () => {
       const requestEntries = createSessionCatalogRequestEntrySnapshot({
@@ -370,27 +393,28 @@ export const sessionCatalogHandlers: GatewayRequestHandlers = {
         selected.map(async (provider): Promise<SessionCatalog> => {
           const createTarget = resolveProviderCreateTarget(provider, resolvedAgent.agentId, config);
           const createSession = createTarget.ok ? { model: createTarget.target.model } : undefined;
-          const onHost = progressConnId
-            ? (host: SessionCatalog["hosts"][number]) => {
-                // Progressive frames are an optimization. The final RPC response remains
-                // authoritative when a slow client drops an intermediate host update.
-                context.broadcastToConnIds(
-                  "sessions.catalog.host",
-                  {
-                    progressId,
-                    agentId: resolvedAgent.agentId,
-                    catalog: catalogResult(
-                      provider,
-                      [requestEntries.projectHostCreatedActors(host)],
-                      undefined,
-                      createSession,
-                    ),
-                  },
-                  new Set([progressConnId]),
-                  { dropIfSlow: true },
-                );
-              }
-            : undefined;
+          const onHost = (host: SessionCatalog["hosts"][number]) => {
+            const catalog = catalogResult(
+              provider,
+              [requestEntries.projectHostCreatedActors(host)],
+              undefined,
+              createSession,
+            );
+            // Progressive frames are an optimization. The final RPC response remains
+            // authoritative when a slow client drops an intermediate host update.
+            for (const subscriber of progressSubscribers.values()) {
+              subscriber.broadcastToConnIds(
+                "sessions.catalog.host",
+                {
+                  progressId: subscriber.progressId,
+                  agentId: resolvedAgent.agentId,
+                  catalog,
+                },
+                new Set([subscriber.connId]),
+                { dropIfSlow: true },
+              );
+            }
+          };
           try {
             const hosts = await provider.list({
               search,
@@ -399,7 +423,7 @@ export const sessionCatalogHandlers: GatewayRequestHandlers = {
               ...(request.cursors !== undefined ? { cursors: request.cursors } : {}),
               sessionEntries: requestEntries.sessionEntries,
               listNodes,
-              ...(onHost ? { onHost } : {}),
+              onHost,
             });
             return catalogResult(
               provider,
@@ -414,7 +438,7 @@ export const sessionCatalogHandlers: GatewayRequestHandlers = {
       );
       return { catalogs: catalogList };
     })();
-    const entry: CatalogListCacheEntry = { result: operation };
+    const entry: CatalogListCacheEntry = { progressSubscribers, result: operation };
     // Exact request/config/registration results remain shareable for 3s after settling. This catches
     // out-of-phase clients but expires before the UI's 5s fast follow, so changed rows surface there.
     // Expired and rejected work is removed; retaining it would mask provider recovery or new sessions.
@@ -437,6 +461,8 @@ export const sessionCatalogHandlers: GatewayRequestHandlers = {
         cache.delete(listKey);
       }
       throw error;
+    } finally {
+      progressSubscribers.clear();
     }
   },
 
@@ -581,3 +607,40 @@ export const sessionCatalogHandlers: GatewayRequestHandlers = {
     }
   },
 };
+
+/** Fill the same list single-flight and provider caches used by the Gateway RPC. */
+export async function prewarmSessionCatalogList(params: {
+  config: OpenClawConfig;
+  agentId: string;
+  limitPerHost: number;
+}): Promise<void> {
+  const handler = sessionCatalogHandlers["sessions.catalog.list"];
+  if (!handler) {
+    throw new Error("sessions.catalog.list handler is unavailable");
+  }
+  let responded = false;
+  let responseError: string | undefined;
+  const respond: RespondFn = (ok, _payload, error) => {
+    responded = true;
+    if (!ok) {
+      responseError = error?.message || "sessions.catalog.list prewarm failed";
+    }
+  };
+  await handler({
+    params: {
+      agentId: params.agentId,
+      limitPerHost: params.limitPerHost,
+    },
+    client: null,
+    // A headless leader intentionally has no progress id or connection subscription.
+    // Concurrent clients still share its authoritative final result through the normal cache.
+    context: { getRuntimeConfig: () => params.config },
+    respond,
+  } as never);
+  if (!responded) {
+    throw new Error("sessions.catalog.list prewarm returned no result");
+  }
+  if (responseError) {
+    throw new Error(responseError);
+  }
+}

--- a/src/gateway/server-startup-handler-prewarm.test.ts
+++ b/src/gateway/server-startup-handler-prewarm.test.ts
@@ -1,0 +1,176 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { resetGatewayWorkAdmission } from "../process/gateway-work-admission.js";
+
+const mocks = vi.hoisted(() => ({
+  events: [] as string[],
+  loadCombinedSessionStoreForGateway: vi.fn((_cfg: unknown, options: { agentId: string }) => {
+    mocks.events.push(`sessions.load.${options.agentId}`);
+    return {
+      durableStorePath: `/state/${options.agentId}.sqlite`,
+      storePath: `/state/${options.agentId}.sqlite`,
+      store: {},
+    };
+  }),
+  listSessionsFromStoreAsync: vi.fn(async (params: { opts: { agentId: string } }) => {
+    mocks.events.push(`sessions.rows.${params.opts.agentId}`);
+    return { sessions: [] };
+  }),
+  listManagedPlugins: vi.fn(async () => {
+    mocks.events.push("plugins");
+    return { plugins: [] };
+  }),
+  prewarmSessionCatalogList: vi.fn(async (params: { agentId: string }) => {
+    mocks.events.push(`catalog.${params.agentId}`);
+  }),
+}));
+
+vi.mock("../config/sessions/combined-store-gateway.js", () => ({
+  loadCombinedSessionStoreForGateway: mocks.loadCombinedSessionStoreForGateway,
+}));
+
+vi.mock("./session-utils-list.js", () => ({
+  listSessionsFromStoreAsync: mocks.listSessionsFromStoreAsync,
+}));
+
+vi.mock("../plugins/management-service.js", () => ({
+  listManagedPlugins: mocks.listManagedPlugins,
+}));
+
+vi.mock("./server-methods/session-catalog.js", () => ({
+  prewarmSessionCatalogList: mocks.prewarmSessionCatalogList,
+}));
+
+const { scheduleGatewayHandlerPrewarm } = await import("./server-startup-handler-prewarm.js");
+
+beforeEach(() => {
+  mocks.events.length = 0;
+  mocks.loadCombinedSessionStoreForGateway.mockClear();
+  mocks.listSessionsFromStoreAsync.mockClear();
+  mocks.listManagedPlugins.mockClear();
+  mocks.prewarmSessionCatalogList.mockClear();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  resetGatewayWorkAdmission();
+});
+
+describe("scheduleGatewayHandlerPrewarm", () => {
+  it("warms the handler-owned caches in bounded dashboard order", async () => {
+    vi.useFakeTimers();
+    const cfg = {
+      agents: { list: [{ id: "main", default: true }, { id: "research" }] },
+    } as never;
+
+    const sidecar = scheduleGatewayHandlerPrewarm({
+      cfgAtStart: cfg,
+      log: { warn: vi.fn() },
+    });
+
+    expect(mocks.events).toEqual([]);
+    await vi.runAllTimersAsync();
+
+    expect(mocks.events).toEqual([
+      "sessions.load.main",
+      "sessions.rows.main",
+      "sessions.load.research",
+      "sessions.rows.research",
+      "plugins",
+      "catalog.main",
+      "catalog.research",
+    ]);
+    expect(mocks.loadCombinedSessionStoreForGateway).toHaveBeenNthCalledWith(1, cfg, {
+      agentId: "main",
+      projection: "list",
+    });
+    expect(mocks.loadCombinedSessionStoreForGateway).toHaveBeenNthCalledWith(2, cfg, {
+      agentId: "research",
+      projection: "list",
+    });
+    expect(mocks.listSessionsFromStoreAsync).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        cfg,
+        opts: {
+          agentId: "main",
+          configuredAgentsOnly: true,
+          includeDerivedTitles: true,
+          includeGlobal: true,
+          includeUnknown: true,
+          limit: 60,
+        },
+      }),
+    );
+    expect(mocks.listManagedPlugins).toHaveBeenCalledWith({ config: cfg });
+    expect(mocks.prewarmSessionCatalogList).toHaveBeenNthCalledWith(1, {
+      config: cfg,
+      agentId: "main",
+      limitPerHost: 40,
+    });
+    expect(mocks.prewarmSessionCatalogList).toHaveBeenNthCalledWith(2, {
+      config: cfg,
+      agentId: "research",
+      limitPerHost: 40,
+    });
+    sidecar.stop();
+  });
+
+  it("logs failures and continues without changing later request behavior", async () => {
+    vi.useFakeTimers();
+    const warn = vi.fn();
+    const laterPrewarm = vi.fn(async () => {});
+    const requestLoad = vi
+      .fn<() => Promise<string>>()
+      .mockRejectedValueOnce(new Error("cold read failed"))
+      .mockResolvedValue("request result");
+
+    scheduleGatewayHandlerPrewarm({
+      cfgAtStart: {} as never,
+      log: { warn },
+      items: [
+        {
+          name: "broken",
+          load: requestLoad,
+        },
+        { name: "later", load: laterPrewarm },
+      ],
+    });
+
+    await vi.runAllTimersAsync();
+
+    expect(warn).toHaveBeenCalledWith(
+      "post-ready gateway data prewarm failed for broken: Error: cold read failed",
+    );
+    expect(requestLoad).toHaveBeenCalledOnce();
+    expect(laterPrewarm).toHaveBeenCalledOnce();
+    await expect(requestLoad()).resolves.toBe("request result");
+  });
+
+  it("stops before scheduling another event-loop turn", async () => {
+    vi.useFakeTimers();
+    let releaseFirst!: () => void;
+    const first = vi.fn(
+      async () =>
+        await new Promise<void>((resolve) => {
+          releaseFirst = resolve;
+        }),
+    );
+    const second = vi.fn(async () => {});
+    const sidecar = scheduleGatewayHandlerPrewarm({
+      cfgAtStart: {} as never,
+      log: { warn: vi.fn() },
+      items: [
+        { name: "first", load: first },
+        { name: "second", load: second },
+      ],
+    });
+
+    await vi.advanceTimersToNextTimerAsync();
+    expect(first).toHaveBeenCalledOnce();
+    sidecar.stop();
+    releaseFirst();
+    await vi.runAllTimersAsync();
+
+    expect(second).not.toHaveBeenCalled();
+  });
+});

--- a/src/gateway/server-startup-handler-prewarm.ts
+++ b/src/gateway/server-startup-handler-prewarm.ts
@@ -1,0 +1,130 @@
+import { listAgentIds } from "../agents/agent-scope-config.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { runWithGatewayIndependentRootWorkAdmission } from "../process/gateway-work-admission.js";
+
+const SIDEBAR_SESSION_LIST_LIMIT = 60;
+const SIDEBAR_CATALOG_LIMIT_PER_HOST = 40;
+
+type StartupTrace = {
+  measure: <T>(name: string, run: () => T | Promise<T>) => Promise<T>;
+};
+
+type GatewayHandlerPrewarmItem = {
+  name: string;
+  load: () => Promise<unknown>;
+};
+
+type GatewayHandlerPrewarmHandle = {
+  stop: () => void;
+};
+
+async function prewarmGatewaySessionListData(cfg: OpenClawConfig, agentId: string): Promise<void> {
+  const [{ loadCombinedSessionStoreForGateway }, { listSessionsFromStoreAsync }] =
+    await Promise.all([
+      import("../config/sessions/combined-store-gateway.js"),
+      import("./session-utils-list.js"),
+    ]);
+  const { durableStorePath, storePath, store } = loadCombinedSessionStoreForGateway(cfg, {
+    agentId,
+    projection: "list",
+  });
+  await listSessionsFromStoreAsync({
+    cfg,
+    durableStorePath,
+    storePath,
+    store,
+    opts: {
+      agentId,
+      configuredAgentsOnly: true,
+      includeDerivedTitles: true,
+      includeGlobal: true,
+      includeUnknown: true,
+      limit: SIDEBAR_SESSION_LIST_LIMIT,
+    },
+  });
+}
+
+function dashboardDataPrewarmItems(cfg: OpenClawConfig): GatewayHandlerPrewarmItem[] {
+  const agentIds = listAgentIds(cfg);
+  return [
+    ...agentIds.map((agentId) => ({
+      name: `sessions.${agentId}`,
+      load: () => prewarmGatewaySessionListData(cfg, agentId),
+    })),
+    {
+      name: "plugins",
+      load: async () => {
+        const { listManagedPlugins } = await import("../plugins/management-service.js");
+        await listManagedPlugins({ config: cfg });
+      },
+    },
+    ...agentIds.map((agentId) => ({
+      name: `session-catalog.${agentId}`,
+      load: async () => {
+        const { prewarmSessionCatalogList } = await import("./server-methods/session-catalog.js");
+        await prewarmSessionCatalogList({
+          config: cfg,
+          agentId,
+          limitPerHost: SIDEBAR_CATALOG_LIMIT_PER_HOST,
+        });
+      },
+    })),
+  ];
+}
+
+export function scheduleGatewayHandlerPrewarm(params: {
+  cfgAtStart: OpenClawConfig;
+  startupTrace?: StartupTrace;
+  log: { warn: (msg: string) => void };
+  items?: readonly GatewayHandlerPrewarmItem[];
+}): GatewayHandlerPrewarmHandle {
+  // Frequent updater restarts make cold dashboard data the remaining slow tier.
+  // Keep cheap session reads first, process-stable plugin data second, and provider catalogs last.
+  const items = params.items ?? dashboardDataPrewarmItems(params.cfgAtStart);
+  let stopped = false;
+  let nextIndex = 0;
+  let timer: ReturnType<typeof setTimeout> | undefined;
+
+  const scheduleNext = () => {
+    if (stopped || nextIndex >= items.length) {
+      return;
+    }
+    timer = setTimeout(() => {
+      timer = undefined;
+      if (stopped) {
+        return;
+      }
+      const item = items[nextIndex++];
+      if (!item) {
+        return;
+      }
+      const load = () => item.load();
+      void runWithGatewayIndependentRootWorkAdmission(() =>
+        params.startupTrace
+          ? params.startupTrace.measure(`post-ready.gateway-data.${item.name}`, load)
+          : load(),
+      )
+        .catch((err: unknown) => {
+          // Prewarm only improves latency; readiness and request-time loaders remain authoritative.
+          params.log.warn(
+            `post-ready gateway data prewarm failed for ${item.name}: ${String(err)}`,
+          );
+        })
+        .finally(scheduleNext);
+    }, 0);
+    timer.unref?.();
+  };
+
+  // One cache fill per event-loop turn lets immediate client work run between steps.
+  scheduleNext();
+
+  return {
+    stop: () => {
+      stopped = true;
+      if (timer) {
+        clearTimeout(timer);
+        timer = undefined;
+      }
+    },
+  };
+}

--- a/src/gateway/server-startup-post-attach.test.ts
+++ b/src/gateway/server-startup-post-attach.test.ts
@@ -65,6 +65,7 @@ const hoisted = vi.hoisted(() => {
   const refreshPreparedModelRuntimeSnapshots = vi.fn(async (_cfg?: unknown) => {});
   const ensureRuntimePluginsLoaded = vi.fn();
   const ensureContextWindowCacheLoaded = vi.fn(async () => {});
+  const scheduleGatewayHandlerPrewarm = vi.fn(() => ({ stop: vi.fn() }));
   const clearCurrentProviderAuthState = vi.fn();
   const warmCurrentProviderAuthStateOffMainThread = vi.fn(
     async (_cfg?: unknown, _options?: unknown) => {},
@@ -105,6 +106,7 @@ const hoisted = vi.hoisted(() => {
     refreshPreparedModelRuntimeSnapshots,
     ensureRuntimePluginsLoaded,
     ensureContextWindowCacheLoaded,
+    scheduleGatewayHandlerPrewarm,
     clearCurrentProviderAuthState,
     warmCurrentProviderAuthStateOffMainThread,
     setAuthProfileFailureHook,
@@ -216,6 +218,10 @@ vi.mock("../agents/runtime-plugins.js", () => ({
 
 vi.mock("../agents/context.js", () => ({
   ensureContextWindowCacheLoaded: hoisted.ensureContextWindowCacheLoaded,
+}));
+
+vi.mock("./server-startup-handler-prewarm.js", () => ({
+  scheduleGatewayHandlerPrewarm: hoisted.scheduleGatewayHandlerPrewarm,
 }));
 
 vi.mock("../agents/model-provider-auth.js", () => ({
@@ -365,6 +371,7 @@ describe("startGatewayPostAttachRuntime", () => {
     hoisted.ensureRuntimePluginsLoaded.mockReset();
     hoisted.ensureContextWindowCacheLoaded.mockReset();
     hoisted.ensureContextWindowCacheLoaded.mockResolvedValue(undefined);
+    hoisted.scheduleGatewayHandlerPrewarm.mockClear();
     hoisted.clearCurrentProviderAuthState.mockClear();
     hoisted.warmCurrentProviderAuthStateOffMainThread.mockReset();
     hoisted.warmCurrentProviderAuthStateOffMainThread.mockResolvedValue(undefined);
@@ -1076,7 +1083,7 @@ describe("startGatewayPostAttachRuntime", () => {
       await vi.advanceTimersToNextTimerAsync();
       expect(postReadyRequestTurn).toHaveBeenCalledTimes(1);
       expect(onPostReadySidecars.mock.calls[0]?.[0]).toHaveLength(0);
-      expect(onGatewayLifetimeSidecars.mock.calls[0]?.[0]).toHaveLength(3);
+      expect(onGatewayLifetimeSidecars.mock.calls[0]?.[0]).toHaveLength(4);
       await vi.dynamicImportSettled();
       await waitForGatewayTestState(() => {
         expect(hoisted.setAuthProfileFailureHook).toHaveBeenCalledTimes(1);
@@ -1108,7 +1115,7 @@ describe("startGatewayPostAttachRuntime", () => {
       await waitForGatewayTestState(() => {
         expect(hoisted.setAuthProfileFailureHook).toHaveBeenCalledTimes(1);
       });
-      expect(onGatewayLifetimeSidecars.mock.calls[0]?.[0]).toHaveLength(3);
+      expect(onGatewayLifetimeSidecars.mock.calls[0]?.[0]).toHaveLength(4);
 
       await vi.advanceTimersByTimeAsync(10_000);
       expect(hoisted.warmCurrentProviderAuthStateOffMainThread).not.toHaveBeenCalled();
@@ -1232,7 +1239,7 @@ describe("startGatewayPostAttachRuntime", () => {
         | { stop: () => void }[]
         | undefined;
       expect(gmailSidecars).toHaveLength(1);
-      expect(lifetimeSidecars).toHaveLength(3);
+      expect(lifetimeSidecars).toHaveLength(4);
 
       for (const sidecar of gmailSidecars ?? []) {
         sidecar.stop();
@@ -1294,7 +1301,7 @@ describe("startGatewayPostAttachRuntime", () => {
       | Array<{ stop: () => Promise<void> | void }>
       | undefined;
     expect(gmailSidecars).toHaveLength(1);
-    expect(lifetimeSidecars).toHaveLength(3);
+    expect(lifetimeSidecars).toHaveLength(4);
 
     await waitForGatewayTestState(() => {
       expect(hoisted.transcriptsAutoStartService.start).toHaveBeenCalledTimes(1);
@@ -1789,7 +1796,7 @@ describe("startGatewayPostAttachRuntime", () => {
       name: "sidecars.ready",
       metrics: [
         ["loadedPluginCount", 2],
-        ["postReadySidecarCount", 2],
+        ["postReadySidecarCount", 3],
       ],
     });
   });

--- a/src/gateway/server-startup-post-attach.ts
+++ b/src/gateway/server-startup-post-attach.ts
@@ -29,6 +29,7 @@ import type { GatewayRecoveryRuntime } from "./server-instance-runtime.types.js"
 import type { refreshLatestUpdateRestartSentinel } from "./server-restart-sentinel.js";
 import type { GatewaySidecarStartupMode } from "./server-sidecar-startup-mode.js";
 import { scheduleContextCachePrewarm } from "./server-startup-context-cache-prewarm.js";
+import { scheduleGatewayHandlerPrewarm } from "./server-startup-handler-prewarm.js";
 import type { logGatewayStartup } from "./server-startup-log.js";
 import {
   createGatewayStartupOutcomeRecorder,
@@ -1234,7 +1235,10 @@ export async function startGatewayPostAttachRuntime(
           reportPluginServices(result.pluginServices);
         }
         const postReadySidecars = [...result.postReadySidecars];
-        const gatewayLifetimeSidecars = [scheduleContextCachePrewarm(params)];
+        const gatewayLifetimeSidecars = [
+          scheduleContextCachePrewarm(params),
+          scheduleGatewayHandlerPrewarm(params),
+        ];
         if (workerEnvironmentSidecar) {
           gatewayLifetimeSidecars.push(workerEnvironmentSidecar);
         }

--- a/src/gateway/server.sessions.list-store-materialization.test.ts
+++ b/src/gateway/server.sessions.list-store-materialization.test.ts
@@ -9,9 +9,11 @@ import * as sessionAccessor from "../config/sessions/session-accessor.js";
 import { resolveSqliteTargetFromSessionStorePath } from "../config/sessions/session-sqlite-target.js";
 import type { SessionEntry } from "../config/sessions/types.js";
 import { openOpenClawAgentDatabase } from "../state/openclaw-agent-db.js";
+import { scheduleGatewayHandlerPrewarm } from "./server-startup-handler-prewarm.js";
 import { testState, writeSessionStore } from "./test-helpers.js";
 import {
   directSessionReq,
+  seedSessionTranscript,
   sessionStoreEntry,
   setupGatewaySessionsTestHarness,
 } from "./test/server-sessions.test-helpers.js";
@@ -90,6 +92,86 @@ test("sessions.list discovers store targets at most once per agent", async () =>
     expect(discoverySpy.mock.calls.filter((call) => call[1] === "main")).toHaveLength(1);
   } finally {
     discoverySpy.mockRestore();
+  }
+});
+
+test("startup prewarm fills session snapshot and title caches before the first list", async () => {
+  const { storePath } = await createSessionStoreDir();
+  const sessionKey = "agent:main:warm-cache";
+  const sessionId = "warm-cache";
+  await writeSessionStore({
+    entries: {
+      [sessionKey]: sessionStoreEntry(sessionId),
+    },
+  });
+  await seedSessionTranscript({
+    agentId: "main",
+    messages: [
+      { role: "user", content: "Warm title" },
+      { role: "assistant", content: "Warm response" },
+    ],
+    sessionId,
+    sessionKey,
+    storePath,
+  });
+  const titlePageSpy = vi.spyOn(sessionAccessor, "readSessionTranscriptMessageEventPage");
+  let sidecar: ReturnType<typeof scheduleGatewayHandlerPrewarm> | undefined;
+  vi.useFakeTimers();
+  try {
+    const cfg = {
+      agents: { list: [{ id: "main", default: true }] },
+      session: { store: storePath },
+    } as never;
+    let resolveSessionPrewarm!: () => void;
+    const sessionPrewarm = new Promise<void>((resolve) => {
+      resolveSessionPrewarm = resolve;
+    });
+    sidecar = scheduleGatewayHandlerPrewarm({
+      cfgAtStart: cfg,
+      log: { warn: vi.fn() },
+      startupTrace: {
+        measure: async (name, run) => {
+          try {
+            return await run();
+          } finally {
+            if (name === "post-ready.gateway-data.sessions.main") {
+              resolveSessionPrewarm();
+            }
+          }
+        },
+      },
+    });
+    await vi.advanceTimersToNextTimerAsync();
+    await sessionPrewarm;
+    sidecar.stop();
+    expect(titlePageSpy).toHaveBeenCalled();
+    titlePageSpy.mockClear();
+    vi.useRealTimers();
+    const cachedEntries = sessionAccessor.listSessionEntriesReadOnly({
+      agentId: "main",
+      clone: false,
+      projection: "list",
+      storePath,
+    });
+
+    const result = await directSessionReq("sessions.list", {
+      ...LIST_PARAMS,
+      includeDerivedTitles: true,
+    });
+
+    expect(result.ok).toBe(true);
+    expect(titlePageSpy).not.toHaveBeenCalled();
+    const afterListEntries = sessionAccessor.listSessionEntriesReadOnly({
+      agentId: "main",
+      clone: false,
+      projection: "list",
+      storePath,
+    });
+    expect(afterListEntries[0]?.entry).toBe(cachedEntries[0]?.entry);
+  } finally {
+    sidecar?.stop();
+    vi.useRealTimers();
+    titlePageSpy.mockRestore();
   }
 });
 

--- a/src/plugins/management-service.lifecycle-cache.test.ts
+++ b/src/plugins/management-service.lifecycle-cache.test.ts
@@ -51,7 +51,7 @@ function metadataSnapshot(pluginId?: string) {
 }
 
 describe("plugin management catalog lifecycle", () => {
-  it("reuses the hosted official catalog until plugin metadata is invalidated", async () => {
+  it("serves the first plugins.list load from prewarmed metadata and official catalog caches", async () => {
     clearPluginMetadataLifecycleCaches();
     mocks.metadata
       .mockReturnValueOnce(metadataSnapshot())
@@ -81,11 +81,11 @@ describe("plugin management catalog lifecycle", () => {
       })
       .mockResolvedValueOnce({ source: "hosted", entries: [] });
 
-    const initial = await listManagedPlugins({ config: {}, env: {} });
-    const cached = await listManagedPlugins({ config: {}, env: {} });
+    const prewarmed = await listManagedPlugins({ config: {}, env: {} });
+    const firstHandlerLoad = await listManagedPlugins({ config: {}, env: {} });
 
-    expect(initial.plugins).toEqual([expect.objectContaining({ id: "diffs" })]);
-    expect(cached.plugins).toEqual(initial.plugins);
+    expect(prewarmed.plugins).toEqual([expect.objectContaining({ id: "diffs" })]);
+    expect(firstHandlerLoad.plugins).toEqual(prewarmed.plugins);
     expect(mocks.metadata).toHaveBeenCalledTimes(1);
     expect(mocks.officialCatalog).toHaveBeenCalledTimes(1);
 


### PR DESCRIPTION
## What Problem This Solves

team.openclaw.ai auto-restarts roughly hourly as main advances. Clustering 7 hours of ws slow-log entries for the four heaviest dashboard RPCs against systemd start markers: 9 restarts, 103/157 slow entries within 2 minutes of a start, 15 more within 10 minutes — only 39 in true steady state (~5.6/h combined). The caches landed this week all work; they just start cold every hour, so the first client polls after each restart pay full price: cold session snapshot (full ~800-row load), cold plugins metadata + hosted catalog (up to ~5s), cold catalog SWR (awaits the codex app-server roundtrip).

## Why This Change Was Made

The prewarm seam already exists for exactly this class of cost; extending it from module-warming to data-warming fills the same caches the handlers use, before the first poll arrives.

## User Impact

The post-restart minute stops producing slow dashboard responses; first paint after an update behaves like steady state.

## Evidence

- Prewarm chain (recreated src/gateway/server-startup-handler-prewarm.ts as data-warming only — deliberately NOT restoring the broad import-only handler warming main removed for memory reasons): sessions → plugins → catalogs, one setTimeout(0) turn per step, fail-open (failures logged, never fatal), stoppable, no retries beyond the underlying loaders.
- Sessions: loadCombinedSessionStoreForGateway + listSessionsFromStoreAsync per agent — fills the #115359 snapshot cache and title-watermark caches (spy test: first post-prewarm list is a cache hit).
- Plugins: listManagedPlugins — fills the metadata snapshot and official-catalog promise caches.
- Catalog: headless sessions.catalog.list with the sidebar's standard limitPerHost:40 — fills the #115403 SWR pages; active followers keep progressive updates and no subscriptions leak (dedicated prewarm test file).
- Usage prewarm skipped deliberately: hourly restarts would spend ~24 authenticated provider fan-outs/day for a comparatively infrequent page — documented tradeoff.
- Validation on Testbox (run https://github.com/openclaw/openclaw/actions/runs/30427102039): 35 focused tests, tsgo core+test, all deadcode lanes, full lint, repo-wide format, full build, git diff --check; autoreview clean.
