### PR TITLE
fix(sessions): keep custom-provider models from crashing session lists

### DIFF
--- a/src/gateway/server.sessions.list-changed.test.ts
+++ b/src/gateway/server.sessions.list-changed.test.ts
@@ -423,6 +423,59 @@ test("sessions.list keeps bulk rows lightweight and uses persisted model fields"
   ws.close();
 });
 
+test.each([
+  ["my-ngc", "nvidia/nemotron-3-ultra-550b-a55b"],
+  ["my-ngc", "z-ai/glm-5.2"],
+  ["my-ngc", "deepseek-ai/deepseek-v4-pro"],
+  ["my-ngc:nvidia", "nvidia/nemotron-3-ultra-550b-a55b"],
+])(
+  "sessions.list preserves custom provider %s and nested models over WebSocket",
+  async (provider, model) => {
+    const { storePath } = await createSessionStoreDir();
+    await writeSessionStore({
+      entries: {
+        main: sessionStoreEntry("sess-parent"),
+        "dashboard:child": sessionStoreEntry("sess-custom-provider", {
+          modelProvider: provider,
+          model,
+          parentSessionKey: "agent:main:main",
+        }),
+      },
+    });
+    await seedSessionTranscript({
+      sessionId: "sess-custom-provider",
+      sessionKey: "agent:main:dashboard:child",
+      storePath,
+      messages: [
+        {
+          role: "user",
+          content: `List ${provider}/${model} sessions.`,
+        },
+        {
+          role: "assistant",
+          provider,
+          model,
+          content: `${provider} remains a model provider, not a plugin directory.`,
+        },
+      ],
+    });
+
+    const { ws } = await openClient();
+    const listed = await rpcReq<{
+      sessions: Array<{ key: string; modelProvider?: string; model?: string }>;
+    }>(ws, "sessions.list", {});
+    ws.close();
+
+    expect(listed.ok, JSON.stringify(listed)).toBe(true);
+    expect(
+      listed.payload?.sessions.find((session) => session.key === "agent:main:dashboard:child"),
+    ).toMatchObject({
+      modelProvider: provider,
+      model,
+    });
+  },
+);
+
 test("sessions.list uses the gateway model catalog for effective thinking defaults", async () => {
   testState.agentConfig = {
     model: { primary: "test-provider/reasoner" },

--- a/src/plugins/provider-model-routes.test.ts
+++ b/src/plugins/provider-model-routes.test.ts
@@ -119,6 +119,25 @@ describe("provider model route adapter", () => {
     ).toBeNull();
   });
 
+  it("does not treat namespaced custom providers as bundled route artifacts", () => {
+    const provider = "my-ngc:nvidia";
+    const modelId = "nvidia/nemotron-3-ultra-550b-a55b";
+    const config = {
+      models: {
+        providers: {
+          [provider]: {
+            api: "openai-completions",
+            baseUrl: "https://provider.example.test/v1",
+            models: [{ id: modelId }],
+          },
+        },
+      },
+    } as unknown as OpenClawConfig;
+
+    expect(resolveProviderModelCatalogId({ provider, modelId })).toBeNull();
+    expect(resolveProviderModelRoutes({ provider, modelId, config, env: {} })).toBeNull();
+  });
+
   it("preserves provider-scoped nested ids through route resolution", () => {
     const resolveModelRoutes = vi.fn((_context: ProviderResolveModelRoutesContext) => ({
       kind: "indeterminate" as const,

--- a/src/plugins/provider-policy-surface.ts
+++ b/src/plugins/provider-policy-surface.ts
@@ -86,6 +86,17 @@ function resolveCachedProviderPolicySurface(params: {
 export function resolveDirectBundledProviderPolicySurface(
   pluginId: string,
 ): BundledProviderPolicySurface | null {
+  // Provider refs are not necessarily plugin directories. Let manifest-owned
+  // policy resolution handle namespaced refs without weakening artifact path checks.
+  if (
+    pluginId === "." ||
+    pluginId === ".." ||
+    pluginId.includes("/") ||
+    pluginId.includes("\\") ||
+    pluginId.includes(":")
+  ) {
+    return null;
+  }
   return resolveCachedProviderPolicySurface({
     cacheKey: `${resolveBundledPluginsDir() ?? ""}\0${pluginId}`,
     loadModule: (artifactBasename) =>

--- a/src/plugins/provider-public-artifacts.test.ts
+++ b/src/plugins/provider-public-artifacts.test.ts
@@ -5,6 +5,7 @@ import path from "node:path";
 import { importFreshModule } from "openclaw/plugin-sdk/test-fixtures";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { ModelProviderConfig } from "../config/types.models.js";
+import { resolveDirectBundledProviderPolicySurface } from "./provider-policy-surface.js";
 import {
   resolveBundledProviderPolicySurface,
   resolveProviderPolicySurface,
@@ -51,6 +52,15 @@ describe("provider public artifacts", () => {
     vi.doUnmock("./public-surface-loader.js");
     vi.resetModules();
   });
+
+  it.each(["my-ngc:nvidia", "my-ngc/nvidia", "my-ngc\\nvidia", ".", ".."])(
+    "does not treat path-like provider %s as a bundled plugin directory",
+    (providerId) => {
+      expect(resolveDirectBundledProviderPolicySurface(providerId)).toBeNull();
+      expect(resolveBundledProviderPolicySurface(providerId)).toBeNull();
+      expect(resolveProviderPolicySurface(providerId)).toBeNull();
+    },
+  );
 
   it("loads a lightweight bundled provider policy artifact smoke", () => {
     const surface = resolveBundledProviderPolicySurface("openai");
@@ -212,6 +222,40 @@ describe("provider public artifacts", () => {
           ?.resolveThinkingProfile?.({ provider: "fixture-provider", modelId: "legacy" })
           ?.levels.map((level) => level.label),
       ).toEqual([undefined, "on"]);
+    } finally {
+      restoreBundledPluginEnv();
+      fs.rmSync(pluginRoot, { recursive: true, force: true });
+      fs.rmSync(bundledPluginsDir, { recursive: true, force: true });
+    }
+  });
+
+  it("resolves namespaced provider policies from their trusted external plugin root", () => {
+    const bundledPluginsDir = fs.mkdtempSync(
+      path.join(os.tmpdir(), "openclaw-empty-bundled-plugins-"),
+    );
+    const pluginRoot = writeExternalPolicyFixture();
+
+    try {
+      process.env.OPENCLAW_BUNDLED_PLUGINS_DIR = bundledPluginsDir;
+      process.env.OPENCLAW_TEST_TRUST_BUNDLED_PLUGINS_DIR = "1";
+      const fixturePlugin = {
+        id: "fixture-provider",
+        origin: "external",
+        trustedOfficialInstall: true,
+        rootDir: pluginRoot,
+        providers: ["fixture:nvidia"],
+        cliBackends: [],
+      } as const;
+
+      const surface = resolveProviderPolicySurface("fixture:nvidia", {
+        manifestRegistry: { plugins: [fixturePlugin as never] },
+      });
+
+      expect(
+        surface
+          ?.resolveThinkingProfile?.({ provider: "fixture:nvidia", modelId: "full" })
+          ?.levels.map((level) => level.id),
+      ).toEqual(["off", "high", "max"]);
     } finally {
       restoreBundledPluginEnv();
       fs.rmSync(pluginRoot, { recursive: true, force: true });

--- a/src/plugins/public-surface-runtime.test.ts
+++ b/src/plugins/public-surface-runtime.test.ts
@@ -41,6 +41,28 @@ describe("bundled plugin public surface runtime", () => {
     ]);
   });
 
+  it.each(["my-ngc:nvidia", "../outside", "..\\outside", ".", ".."])(
+    "continues rejecting %s as an actual bundled plugin directory",
+    (dirName) => {
+      const rootDir = createTempDir();
+
+      expect(() =>
+        resolveBundledPluginSourcePublicSurfacePath({
+          sourceRoot: rootDir,
+          dirName,
+          artifactBasename: "provider-policy-api.js",
+        }),
+      ).toThrow(/must be a single directory/);
+      expect(() =>
+        resolveBundledPluginPublicSurfacePath({
+          rootDir,
+          dirName,
+          artifactBasename: "provider-policy-api.js",
+        }),
+      ).toThrow(/must be a single directory/);
+    },
+  );
+
   it("resolves source public surfaces from the shared extension list", () => {
     const sourceRoot = createTempDir();
     const modulePath = path.join(sourceRoot, "demo", "api.mts");


### PR DESCRIPTION
Fixes #103744.

## What Problem This Solves

Fixes an issue where users listing sessions containing custom-provider models would receive `UNAVAILABLE: Bundled plugin dirName must be a single directory` instead of their session list. Both documented nested model IDs such as `my-ngc/nvidia/nemotron-3-ultra-550b-a55b` and already-persisted namespaced provider values remain safe to display.

## Why This Change Was Made

Stop only the private direct bundled-provider policy lookup from mistaking model/provider references for physical bundled plugin directories. Leave the strict public artifact traversal checks unchanged, and allow manifest-owned bundled aliases and trusted official external provider policies to resolve through their existing owner and installation paths.

## User Impact

`sessions.list` and `sessions_list` can list sessions using custom OpenAI-compatible providers and slash-containing upstream model IDs without crashing. Legitimate official provider policy, route resolution, and plugin path security continue to work.

## Evidence

Independently reproduced the reported issue on current trusted `main` with a real loopback Gateway, signed-device connect challenge, actual WebSocket `sessions.list` RPC, persisted session, and transcript containing the reported model reference.

Before the fix, the live WebSocket returns:

```
{"ok":false,"error":{"code":"UNAVAILABLE","message":"Error: Bundled plugin dirName must be a single directory: my-ngc:nvidia"}}
```

Six independent provider-owner regressions also fail before the fix, including a trusted official external plugin declaring a namespaced provider.

After the fix, exact-head validation:

- `node scripts/run-vitest.mjs src/gateway/server.sessions.list-changed.test.ts`: **33 passed**, including real WebSocket coverage for canonical NVIDIA, Z.AI, and DeepSeek nested custom model IDs plus the original persisted `my-ngc:nvidia` value.
- `node scripts/run-vitest.mjs src/plugins/provider-public-artifacts.test.ts src/plugins/provider-policy-surface.test.ts src/plugins/provider-model-routes.test.ts src/plugins/public-surface-runtime.test.ts`: **56 passed**, including trusted external namespaced policy ownership, all direct route facades, and explicit colon/slash/backslash/traversal rejection by both actual bundled-artifact security APIs.
- `./node_modules/.bin/oxfmt --check src/plugins/provider-policy-surface.ts src/plugins/provider-public-artifacts.test.ts src/plugins/provider-model-routes.test.ts src/plugins/public-surface-runtime.test.ts src/gateway/server.sessions.list-changed.test.ts`: passed.
- `git diff-tree --check HEAD`: passed.
- `./.agents/skills/autoreview/scripts/autoreview --mode commit --commit HEAD --thinking xhigh`: **clean; no accepted or actionable findings**.
