### PR TITLE
fix: yielded turns surface a spurious '⏸️ Yield … failed' warning in channels

### DIFF
--- a/src/agents/agent-tools.abort.test.ts
+++ b/src/agents/agent-tools.abort.test.ts
@@ -2,6 +2,7 @@
 import { describe, expect, it, vi } from "vitest";
 import { wrapToolWithAbortSignal } from "./agent-tools.abort.js";
 import type { AnyAgentTool } from "./agent-tools.types.js";
+import { SESSIONS_YIELD_ABORT_REASON } from "./embedded-agent-runner/run/attempt.sessions-yield.js";
 
 type ExecuteMock = ReturnType<typeof vi.fn>;
 
@@ -190,6 +191,51 @@ describe("wrapToolWithAbortSignal", () => {
     );
 
     await expect(wrapped.execute("call-1", {})).rejects.toBe(toolRejection);
+  });
+
+  it("lets sessions_yield resolve its yielded result past its own handoff abort", async () => {
+    // sessions_yield aborts the run from inside execute; the handoff abort must
+    // not out-race the tool's own success result.
+    const runAbort = new AbortController();
+    const result = textResult(JSON.stringify({ status: "yielded" }));
+    const execute = vi.fn(async () => {
+      runAbort.abort(SESSIONS_YIELD_ABORT_REASON);
+      return result;
+    });
+    const wrapped = wrapToolWithAbortSignal(
+      asAgentTool({ name: "sessions_yield", execute }),
+      runAbort.signal,
+    );
+
+    await expect(wrapped.execute("call-1", {})).resolves.toBe(result);
+  });
+
+  it("still rejects sessions_yield on a real abort without the handoff reason", async () => {
+    const runAbort = new AbortController();
+    const execute = vi.fn(() => new Promise(() => {}));
+    const wrapped = wrapToolWithAbortSignal(
+      asAgentTool({ name: "sessions_yield", execute }),
+      runAbort.signal,
+    );
+
+    const executePromise = wrapped.execute("call-1", {});
+    runAbort.abort();
+    await expect(executePromise).rejects.toMatchObject({ name: "AbortError", message: "Aborted" });
+  });
+
+  it("still rejects other tools when the run aborts with the sessions_yield reason", async () => {
+    // Only the yield tool itself gets the pass-through; a wedged sibling tool
+    // must not keep the yielding run alive.
+    const runAbort = new AbortController();
+    const execute = vi.fn(() => new Promise(() => {}));
+    const wrapped = wrapToolWithAbortSignal(
+      asAgentTool({ name: "wedged", execute }),
+      runAbort.signal,
+    );
+
+    const executePromise = wrapped.execute("call-1", {});
+    runAbort.abort(SESSIONS_YIELD_ABORT_REASON);
+    await expect(executePromise).rejects.toMatchObject({ name: "AbortError", message: "Aborted" });
   });
 
   it("throws AbortError before invoking execute when the signal is already aborted", async () => {

--- a/src/agents/agent-tools.abort.ts
+++ b/src/agents/agent-tools.abort.ts
@@ -8,6 +8,7 @@ import { copyPluginToolMeta } from "../plugins/tools.js";
 import type { AnyAgentTool } from "./agent-tools.types.js";
 import { copyBeforeToolCallHookMarker } from "./before-tool-call-metadata.js";
 import { copyChannelAgentToolMeta } from "./channel-tools.js";
+import { isSessionsYieldAbortReason } from "./embedded-agent-runner/run/attempt.sessions-yield.js";
 
 function throwAbortError(): never {
   throw createAbortError("Aborted");
@@ -22,10 +23,17 @@ function throwAbortError(): never {
  * Tool settlements pass through untouched to preserve tool error semantics,
  * including non-Error rejections.
  */
-function raceWithAbortSignal<T>(promise: Promise<T>, signal: AbortSignal): Promise<T> {
+function raceWithAbortSignal<T>(
+  promise: Promise<T>,
+  signal: AbortSignal,
+  ignoreAbortReason?: (reason: unknown) => boolean,
+): Promise<T> {
   return new Promise<T>((resolve, reject) => {
     const onAbort = () => {
       signal.removeEventListener("abort", onAbort);
+      if (ignoreAbortReason?.(signal.reason)) {
+        return;
+      }
       reject(createAbortError("Aborted"));
     };
     signal.addEventListener("abort", onAbort, { once: true });
@@ -59,6 +67,12 @@ export function wrapToolWithAbortSignal(
   if (!execute) {
     return tool;
   }
+  // sessions_yield ends the turn by aborting its own run from inside execute
+  // (attempt.ts onYield). That handoff abort must not out-race the tool's own
+  // {status:"yielded"} result, or every yield records as a failed tool call and
+  // channels surface a spurious "⚠️ Yield … failed" warning. Real aborts don't
+  // carry the sessions_yield reason and still reject.
+  const ignoreAbortReason = tool.name === "sessions_yield" ? isSessionsYieldAbortReason : undefined;
   const wrappedTool: AnyAgentTool = {
     ...tool,
     execute: async (toolCallId, params, signal, onUpdate) => {
@@ -69,6 +83,7 @@ export function wrapToolWithAbortSignal(
       return await raceWithAbortSignal(
         execute(toolCallId, params, combinedSignal, onUpdate),
         combinedSignal,
+        ignoreAbortReason,
       );
     },
   };


### PR DESCRIPTION
Related: #110704

## What Problem This Solves

Fixes an issue where any turn that spawns a subagent and ends with `sessions_yield` posts a spurious `⚠️ ⏸️ Yield: <message> failed` warning to the channel (Slack, Telegram, Discord, …), even though the yield worked and the resumed turn delivers the real answer moments later.

The yield tool call is also persisted in the transcript as an `Aborted` tool error instead of its `{status: "yielded"}` result, so the resumed model sees its own yield as failed, and `isSessionsYieldToolResult` only matches through its adjacency fallback rather than the yielded status it was designed to read.

## Why This Change Was Made

`sessions_yield` ends the turn by aborting its own run from inside its `execute` (`attempt.ts` `onYield`). Since #110704, `wrapToolWithAbortSignal` races every tool's execute promise against the run abort signal — so the handoff abort deterministically rejects the yield tool with `Aborted` before its own success result can settle, and the turn records a failed tool call with no user-facing reply, which the payload builder surfaces as the warning.

The fix scopes a pass-through to exactly this case: when the wrapped tool is `sessions_yield` and the abort reason is the sessions-yield handoff (`isSessionsYieldAbortReason`), the race lets the tool's own result settle. Real aborts (cancel/timeout) don't carry the handoff reason and still reject, and sibling tools in-flight during a yield handoff still reject, so a wedged tool cannot keep a yielding run alive.

## User Impact

Yielded turns no longer show a false `Yield … failed` error in chat channels, and resumed transcripts carry the clean `yielded` tool result instead of an `Aborted` error the model may misread as a failure. No behavior change for real aborts or for any other tool.

## Evidence

Deterministic before this change: the handoff abort fires synchronously inside the yield tool's own execute, so the race always rejects first (reproduced with a Slack-connected agent — `⚠️ ⏸️ Yield: … failed` on every spawn-and-yield turn with no other visible reply, followed by the correct resumed answer).

Focused proof:

```
node scripts/run-vitest.mjs src/agents/agent-tools.abort.test.ts
  Test Files  1 passed (1)
       Tests  12 passed (12)   # 9 existing + 3 new

node scripts/run-vitest.mjs src/agents/tools/sessions-yield-tool.test.ts
  Test Files  1 passed (1)
       Tests  6 passed (6)
```

New tests pin the three boundaries: yield resolves past its own handoff abort; yield still rejects on a real (reason-less) abort; other tools still reject when the run aborts with the handoff reason.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
