### PR TITLE
feat(agents): persist last-used session model as the agent default

### DIFF
--- a/src/agents/sticky-model-selection.test.ts
+++ b/src/agents/sticky-model-selection.test.ts
@@ -21,10 +21,7 @@ vi.mock("../config/paths.js", () => ({
   resolveIsNixMode: () => mocks.isNixMode,
 }));
 
-import {
-  persistStickyModelSelection,
-  persistStickyModelSelectionBestEffort,
-} from "./sticky-model-selection.js";
+import { persistStickyModelSelectionBestEffort } from "./sticky-model-selection.js";
 
 beforeEach(() => {
   mocks.info.mockReset();
@@ -79,9 +76,12 @@ describe("persistStickyModelSelection", () => {
   ])("writes the $name", async ({ agentId, cfg, target }) => {
     mocks.cfg = structuredClone(cfg);
 
-    await expect(
-      persistStickyModelSelection({ agentId, model: " openai/gpt-5.6-sol " }),
-    ).resolves.toBe(target);
+    persistStickyModelSelectionBestEffort({ agentId, model: " openai/gpt-5.6-sol " });
+    await vi.waitFor(() =>
+      expect(mocks.info).toHaveBeenCalledWith(
+        `persisted sticky model selection agentId=${agentId} model=openai/gpt-5.6-sol target=${target}`,
+      ),
+    );
 
     const persistedPrimary =
       target === "defaults"
@@ -91,14 +91,15 @@ describe("persistStickyModelSelection", () => {
       primary: "openai/gpt-5.6-sol",
       fallbacks: ["openai/gpt-5.6-luna"],
     });
-    expect(mocks.info).toHaveBeenCalledWith(
-      `persisted sticky model selection agentId=${agentId} model=openai/gpt-5.6-sol target=${target}`,
-    );
   });
 
   it("rejects an empty model before starting a config mutation", async () => {
-    await expect(persistStickyModelSelection({ agentId: "main", model: "   " })).rejects.toThrow(
-      "Sticky model selection must be non-empty.",
+    persistStickyModelSelectionBestEffort({ agentId: "main", model: "   " });
+
+    await vi.waitFor(() =>
+      expect(mocks.warn).toHaveBeenCalledWith(
+        "failed sticky model persistence agentId=main model=    reason=Sticky model selection must be non-empty.",
+      ),
     );
     expect(mocks.mutateConfigFileWithRetry).not.toHaveBeenCalled();
   });

--- a/src/agents/sticky-model-selection.test.ts
+++ b/src/agents/sticky-model-selection.test.ts
@@ -4,7 +4,9 @@ import type { OpenClawConfig } from "../config/types.openclaw.js";
 const mocks = vi.hoisted(() => ({
   cfg: {} as OpenClawConfig,
   info: vi.fn(),
+  isNixMode: false,
   mutateConfigFileWithRetry: vi.fn(),
+  warn: vi.fn(),
 }));
 
 vi.mock("../config/config.js", () => ({
@@ -12,13 +14,22 @@ vi.mock("../config/config.js", () => ({
 }));
 
 vi.mock("../logging/subsystem.js", () => ({
-  createSubsystemLogger: () => ({ info: mocks.info }),
+  createSubsystemLogger: () => ({ info: mocks.info, warn: mocks.warn }),
 }));
 
-import { persistStickyModelSelection } from "./sticky-model-selection.js";
+vi.mock("../config/paths.js", () => ({
+  resolveIsNixMode: () => mocks.isNixMode,
+}));
+
+import {
+  persistStickyModelSelection,
+  persistStickyModelSelectionBestEffort,
+} from "./sticky-model-selection.js";
 
 beforeEach(() => {
   mocks.info.mockReset();
+  mocks.warn.mockReset();
+  mocks.isNixMode = false;
   mocks.mutateConfigFileWithRetry.mockReset().mockImplementation(async ({ mutate }) => {
     const draft = structuredClone(mocks.cfg);
     const result = await mutate(draft, {});
@@ -90,5 +101,32 @@ describe("persistStickyModelSelection", () => {
       "Sticky model selection must be non-empty.",
     );
     expect(mocks.mutateConfigFileWithRetry).not.toHaveBeenCalled();
+  });
+
+  it("warns and absorbs asynchronous config write failures", async () => {
+    mocks.mutateConfigFileWithRetry.mockRejectedValueOnce(new Error("config is read-only"));
+
+    expect(
+      persistStickyModelSelectionBestEffort({ agentId: "main", model: "openai/gpt-5.6-sol" }),
+    ).toBeUndefined();
+
+    await vi.waitFor(() =>
+      expect(mocks.warn).toHaveBeenCalledWith(
+        "failed sticky model persistence agentId=main model=openai/gpt-5.6-sol reason=config is read-only",
+      ),
+    );
+  });
+
+  it("skips immutable Nix config and warns only once per process", () => {
+    mocks.isNixMode = true;
+
+    persistStickyModelSelectionBestEffort({ agentId: "main", model: "openai/gpt-5.6-sol" });
+    persistStickyModelSelectionBestEffort({ agentId: "work", model: "openai/gpt-5.6-luna" });
+
+    expect(mocks.mutateConfigFileWithRetry).not.toHaveBeenCalled();
+    expect(mocks.warn).toHaveBeenCalledOnce();
+    expect(mocks.warn).toHaveBeenCalledWith(
+      "skipped sticky model persistence agentId=main model=openai/gpt-5.6-sol reason=config is immutable in OPENCLAW_NIX_MODE",
+    );
   });
 });

--- a/src/agents/sticky-model-selection.test.ts
+++ b/src/agents/sticky-model-selection.test.ts
@@ -1,0 +1,94 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+
+const mocks = vi.hoisted(() => ({
+  cfg: {} as OpenClawConfig,
+  info: vi.fn(),
+  mutateConfigFileWithRetry: vi.fn(),
+}));
+
+vi.mock("../config/config.js", () => ({
+  mutateConfigFileWithRetry: mocks.mutateConfigFileWithRetry,
+}));
+
+vi.mock("../logging/subsystem.js", () => ({
+  createSubsystemLogger: () => ({ info: mocks.info }),
+}));
+
+import { persistStickyModelSelection } from "./sticky-model-selection.js";
+
+beforeEach(() => {
+  mocks.info.mockReset();
+  mocks.mutateConfigFileWithRetry.mockReset().mockImplementation(async ({ mutate }) => {
+    const draft = structuredClone(mocks.cfg);
+    const result = await mutate(draft, {});
+    mocks.cfg = draft;
+    return { nextConfig: draft, result };
+  });
+});
+
+describe("persistStickyModelSelection", () => {
+  it.each([
+    {
+      name: "shared default for an inheriting agent",
+      agentId: "main",
+      cfg: {
+        agents: {
+          defaults: {
+            model: {
+              primary: "anthropic/claude-opus-4-6",
+              fallbacks: ["openai/gpt-5.6-luna"],
+            },
+          },
+          list: [{ id: "main", default: true }],
+        },
+      } satisfies OpenClawConfig,
+      target: "defaults" as const,
+    },
+    {
+      name: "agent entry for an explicit agent model",
+      agentId: "work",
+      cfg: {
+        agents: {
+          defaults: { model: "anthropic/claude-opus-4-6" },
+          list: [
+            { id: "main", default: true },
+            {
+              id: "work",
+              model: {
+                primary: "anthropic/claude-sonnet-4-6",
+                fallbacks: ["openai/gpt-5.6-luna"],
+              },
+            },
+          ],
+        },
+      } satisfies OpenClawConfig,
+      target: "agent" as const,
+    },
+  ])("writes the $name", async ({ agentId, cfg, target }) => {
+    mocks.cfg = structuredClone(cfg);
+
+    await expect(
+      persistStickyModelSelection({ agentId, model: " openai/gpt-5.6-sol " }),
+    ).resolves.toBe(target);
+
+    const persistedPrimary =
+      target === "defaults"
+        ? mocks.cfg.agents?.defaults?.model
+        : mocks.cfg.agents?.list?.find((entry) => entry.id === agentId)?.model;
+    expect(persistedPrimary).toMatchObject({
+      primary: "openai/gpt-5.6-sol",
+      fallbacks: ["openai/gpt-5.6-luna"],
+    });
+    expect(mocks.info).toHaveBeenCalledWith(
+      `persisted sticky model selection agentId=${agentId} model=openai/gpt-5.6-sol target=${target}`,
+    );
+  });
+
+  it("rejects an empty model before starting a config mutation", async () => {
+    await expect(persistStickyModelSelection({ agentId: "main", model: "   " })).rejects.toThrow(
+      "Sticky model selection must be non-empty.",
+    );
+    expect(mocks.mutateConfigFileWithRetry).not.toHaveBeenCalled();
+  });
+});

--- a/src/agents/sticky-model-selection.ts
+++ b/src/agents/sticky-model-selection.ts
@@ -48,7 +48,7 @@ export function persistStickyModelSelectionBestEffort(params: {
     }
     return;
   }
-  void persistStickyModelSelection(params).catch((error) => {
+  void persistStickyModelSelection(params).catch((error: unknown) => {
     log.warn(
       `failed sticky model persistence agentId=${params.agentId} model=${params.model} reason=${formatErrorMessage(error)}`,
     );

--- a/src/agents/sticky-model-selection.ts
+++ b/src/agents/sticky-model-selection.ts
@@ -1,0 +1,30 @@
+import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
+import { mutateConfigFileWithRetry } from "../config/config.js";
+import { createSubsystemLogger } from "../logging/subsystem.js";
+import { normalizeAgentId } from "../routing/session-key.js";
+import { setAgentEffectiveModelPrimary, type AgentModelPrimaryWriteTarget } from "./agent-scope.js";
+
+const log = createSubsystemLogger("agents/sticky-model-selection");
+
+/** Persists a validated session model selection at the agent's effective config layer. */
+export async function persistStickyModelSelection(params: {
+  agentId: string;
+  model: string;
+}): Promise<AgentModelPrimaryWriteTarget> {
+  const model = normalizeOptionalString(params.model);
+  if (!model) {
+    throw new Error("Sticky model selection must be non-empty.");
+  }
+  const agentId = normalizeAgentId(params.agentId);
+  const committed = await mutateConfigFileWithRetry<AgentModelPrimaryWriteTarget>({
+    afterWrite: { mode: "auto" },
+    mutate: (draft) => setAgentEffectiveModelPrimary(draft, agentId, model),
+  });
+  if (!committed.result) {
+    throw new Error("Sticky model config mutation did not return its write target.");
+  }
+  log.info(
+    `persisted sticky model selection agentId=${agentId} model=${model} target=${committed.result}`,
+  );
+  return committed.result;
+}

--- a/src/agents/sticky-model-selection.ts
+++ b/src/agents/sticky-model-selection.ts
@@ -10,7 +10,7 @@ const log = createSubsystemLogger("agents/sticky-model-selection");
 let warnedImmutableConfig = false;
 
 /** Persists a validated session model selection at the agent's effective config layer. */
-export async function persistStickyModelSelection(params: {
+async function persistStickyModelSelection(params: {
   agentId: string;
   model: string;
 }): Promise<AgentModelPrimaryWriteTarget> {

--- a/src/agents/sticky-model-selection.ts
+++ b/src/agents/sticky-model-selection.ts
@@ -1,10 +1,13 @@
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { mutateConfigFileWithRetry } from "../config/config.js";
+import { resolveIsNixMode } from "../config/paths.js";
+import { formatErrorMessage } from "../infra/errors.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import { normalizeAgentId } from "../routing/session-key.js";
 import { setAgentEffectiveModelPrimary, type AgentModelPrimaryWriteTarget } from "./agent-scope.js";
 
 const log = createSubsystemLogger("agents/sticky-model-selection");
+let warnedImmutableConfig = false;
 
 /** Persists a validated session model selection at the agent's effective config layer. */
 export async function persistStickyModelSelection(params: {
@@ -27,4 +30,27 @@ export async function persistStickyModelSelection(params: {
     `persisted sticky model selection agentId=${agentId} model=${model} target=${committed.result}`,
   );
   return committed.result;
+}
+
+/** Starts a best-effort sticky write without delaying or failing the session mutation. */
+export function persistStickyModelSelectionBestEffort(params: {
+  agentId: string;
+  model: string;
+}): void {
+  if (resolveIsNixMode()) {
+    // A Nix-managed gateway can switch models but can never persist this preference.
+    // Warn once per process so repeated switches do not flood the operator log.
+    if (!warnedImmutableConfig) {
+      warnedImmutableConfig = true;
+      log.warn(
+        `skipped sticky model persistence agentId=${params.agentId} model=${params.model} reason=config is immutable in OPENCLAW_NIX_MODE`,
+      );
+    }
+    return;
+  }
+  void persistStickyModelSelection(params).catch((error) => {
+    log.warn(
+      `failed sticky model persistence agentId=${params.agentId} model=${params.model} reason=${formatErrorMessage(error)}`,
+    );
+  });
 }

--- a/src/auto-reply/reply/directive-handling.fast-lane.ts
+++ b/src/auto-reply/reply/directive-handling.fast-lane.ts
@@ -93,6 +93,7 @@ export async function applyInlineDirectivesFastLane(
     model,
     initialModelLabel: params.initialModelLabel,
     formatModelSwitchEvent,
+    canPersistStickyModelSelection: params.canPersistStickyModelSelection,
     currentThinkLevel,
     currentFastMode,
     currentVerboseLevel,

--- a/src/auto-reply/reply/directive-handling.impl.ts
+++ b/src/auto-reply/reply/directive-handling.impl.ts
@@ -10,6 +10,7 @@ import {
   resolveFastModeState,
 } from "../../agents/fast-mode.js";
 import { resolveSandboxRuntimeStatus } from "../../agents/sandbox.js";
+import { persistStickyModelSelection } from "../../agents/sticky-model-selection.js";
 import { resolveEffectiveAgentRuntime } from "../../agents/thinking-runtime.js";
 import {
   adoptPersistedSessionSnapshot,
@@ -606,6 +607,17 @@ export async function handleDirectiveOnly(
           ? "Model change was not applied because the session changed. Retry."
           : "Session settings were not applied because the session changed. Retry.",
       };
+    }
+    if (
+      modelSelection &&
+      modelSelectionApplied &&
+      !modelSelection.isDefault &&
+      !params.persistenceState
+    ) {
+      await persistStickyModelSelection({
+        agentId: activeAgentId,
+        model: `${modelSelection.provider}/${modelSelection.model}`,
+      });
     }
     if (modelSelection && modelSelectionUpdated && modelSelectionApplied && sessionKey) {
       triggerSessionPatchHook({

--- a/src/auto-reply/reply/directive-handling.impl.ts
+++ b/src/auto-reply/reply/directive-handling.impl.ts
@@ -10,7 +10,7 @@ import {
   resolveFastModeState,
 } from "../../agents/fast-mode.js";
 import { resolveSandboxRuntimeStatus } from "../../agents/sandbox.js";
-import { persistStickyModelSelection } from "../../agents/sticky-model-selection.js";
+import { persistStickyModelSelectionBestEffort } from "../../agents/sticky-model-selection.js";
 import { resolveEffectiveAgentRuntime } from "../../agents/thinking-runtime.js";
 import {
   adoptPersistedSessionSnapshot,
@@ -612,9 +612,10 @@ export async function handleDirectiveOnly(
       modelSelection &&
       modelSelectionApplied &&
       !modelSelection.isDefault &&
-      !params.persistenceState
+      !params.persistenceState &&
+      params.canPersistStickyModelSelection === true
     ) {
-      await persistStickyModelSelection({
+      persistStickyModelSelectionBestEffort({
         agentId: activeAgentId,
         model: `${modelSelection.provider}/${modelSelection.model}`,
       });

--- a/src/auto-reply/reply/directive-handling.model.test.ts
+++ b/src/auto-reply/reply/directive-handling.model.test.ts
@@ -23,6 +23,9 @@ const modelsCommandMock = vi.hoisted(() => ({
   delegateToActual: false,
   resolveModelsCommandReply: vi.fn(),
 }));
+const stickyModelMock = vi.hoisted(() => ({
+  persist: vi.fn(async (_params: { agentId: string; model: string }) => "defaults" as const),
+}));
 
 function defaultModelsCommandReply() {
   return {
@@ -94,6 +97,11 @@ vi.mock("./commands-models.js", () => ({
     }
     return defaultModelsCommandReply();
   },
+}));
+
+vi.mock("../../agents/sticky-model-selection.js", () => ({
+  persistStickyModelSelection: (params: { agentId: string; model: string }) =>
+    stickyModelMock.persist(params),
 }));
 
 vi.mock("./directive-handling.auth.js", () => ({
@@ -473,6 +481,7 @@ beforeEach(() => {
   vi.mocked(resolveSessionAgentId).mockReset().mockReturnValue("main");
   vi.mocked(enqueueSystemEvent).mockClear();
   queueMocks.refreshQueuedFollowupSession.mockReset();
+  stickyModelMock.persist.mockClear();
   clearInternalHooks();
 });
 
@@ -717,6 +726,7 @@ describe("/model chat UX", () => {
     expect(reply?.text).toContain("Providers:");
     expect(reply?.text).toContain("Use: /models <provider>");
     expect(reply?.text).toContain("Switch: /model <provider/model>");
+    expect(stickyModelMock.persist).not.toHaveBeenCalled();
   });
 
   it("passes workspace scope through the /model list browser alias", async () => {
@@ -1877,6 +1887,27 @@ describe("handleDirectiveOnly model persist behavior (fixes #1435)", () => {
     expect(result?.text).toContain("for this session");
     expect(result?.text).not.toContain("failed");
     expect(sessionEntry.liveModelSwitchPending).toBe(true);
+    expect(stickyModelMock.persist).toHaveBeenCalledWith({
+      agentId: "main",
+      model: "openai/gpt-4o",
+    });
+  });
+
+  it("uses the target session agent when persisting a model selection", async () => {
+    vi.mocked(resolveSessionAgentId).mockReturnValue("work");
+    const sessionEntry = createSessionEntry();
+
+    await handleDirectiveOnly(
+      createHandleParams({
+        directives: parseInlineDirectives("/model openai/gpt-4o"),
+        sessionEntry,
+      }),
+    );
+
+    expect(stickyModelMock.persist).toHaveBeenCalledWith({
+      agentId: "work",
+      model: "openai/gpt-4o",
+    });
   });
 
   it("persists an explicit runtime with a directive-only model switch", async () => {
@@ -1973,6 +2004,20 @@ describe("handleDirectiveOnly model persist behavior (fixes #1435)", () => {
     expect(otherEntry.providerOverride).toBeUndefined();
     expect(otherEntry.modelOverride).toBeUndefined();
     expect(otherEntry.modelOverrideSource).toBeUndefined();
+  });
+
+  it("persists a mixed-command model selection after its session transaction", async () => {
+    vi.mocked(resolveSessionAgentId).mockReturnValue("work");
+
+    await persistModelDirectiveForTest({
+      command: "/model openai/gpt-4o continue with the request",
+      allowedModelKeys: ["anthropic/claude-opus-4-6", "openai/gpt-4o"],
+    });
+
+    expect(stickyModelMock.persist).toHaveBeenCalledWith({
+      agentId: "work",
+      model: "openai/gpt-4o",
+    });
   });
 
   it("remaps unsupported stored thinking levels when persisting a model switch", async () => {

--- a/src/auto-reply/reply/directive-handling.model.test.ts
+++ b/src/auto-reply/reply/directive-handling.model.test.ts
@@ -24,7 +24,7 @@ const modelsCommandMock = vi.hoisted(() => ({
   resolveModelsCommandReply: vi.fn(),
 }));
 const stickyModelMock = vi.hoisted(() => ({
-  persist: vi.fn(async (_params: { agentId: string; model: string }) => "defaults" as const),
+  persistBestEffort: vi.fn(),
 }));
 
 function defaultModelsCommandReply() {
@@ -100,8 +100,8 @@ vi.mock("./commands-models.js", () => ({
 }));
 
 vi.mock("../../agents/sticky-model-selection.js", () => ({
-  persistStickyModelSelection: (params: { agentId: string; model: string }) =>
-    stickyModelMock.persist(params),
+  persistStickyModelSelectionBestEffort: (params: { agentId: string; model: string }) =>
+    stickyModelMock.persistBestEffort(params),
 }));
 
 vi.mock("./directive-handling.auth.js", () => ({
@@ -481,7 +481,7 @@ beforeEach(() => {
   vi.mocked(resolveSessionAgentId).mockReset().mockReturnValue("main");
   vi.mocked(enqueueSystemEvent).mockClear();
   queueMocks.refreshQueuedFollowupSession.mockReset();
-  stickyModelMock.persist.mockClear();
+  stickyModelMock.persistBestEffort.mockClear();
   clearInternalHooks();
 });
 
@@ -565,6 +565,7 @@ async function persistModelDirectiveForTest(params: {
   provider?: string;
   model?: string;
   initialModelLabel?: string;
+  canPersistStickyModelSelection?: boolean;
 }) {
   if (params.profiles) {
     setAuthProfiles(params.profiles);
@@ -594,6 +595,7 @@ async function persistModelDirectiveForTest(params: {
       params.initialModelLabel ??
       `${params.provider ?? "anthropic"}/${params.model ?? "claude-opus-4-6"}`,
     formatModelSwitchEvent: (label) => label,
+    canPersistStickyModelSelection: params.canPersistStickyModelSelection ?? true,
     agentCfg: cfg.agents?.defaults,
   });
   return { persisted, sessionEntry };
@@ -726,7 +728,7 @@ describe("/model chat UX", () => {
     expect(reply?.text).toContain("Providers:");
     expect(reply?.text).toContain("Use: /models <provider>");
     expect(reply?.text).toContain("Switch: /model <provider/model>");
-    expect(stickyModelMock.persist).not.toHaveBeenCalled();
+    expect(stickyModelMock.persistBestEffort).not.toHaveBeenCalled();
   });
 
   it("passes workspace scope through the /model list browser alias", async () => {
@@ -1850,6 +1852,7 @@ describe("handleDirectiveOnly model persist behavior (fixes #1435)", () => {
       model: "claude-opus-4-6",
       initialModelLabel: "anthropic/claude-opus-4-6",
       formatModelSwitchEvent: (label) => `Switched to ${label}`,
+      canPersistStickyModelSelection: true,
       ...rest,
       sessionEntry: entry,
       sessionStore: store,
@@ -1887,7 +1890,7 @@ describe("handleDirectiveOnly model persist behavior (fixes #1435)", () => {
     expect(result?.text).toContain("for this session");
     expect(result?.text).not.toContain("failed");
     expect(sessionEntry.liveModelSwitchPending).toBe(true);
-    expect(stickyModelMock.persist).toHaveBeenCalledWith({
+    expect(stickyModelMock.persistBestEffort).toHaveBeenCalledWith({
       agentId: "main",
       model: "openai/gpt-4o",
     });
@@ -1904,10 +1907,29 @@ describe("handleDirectiveOnly model persist behavior (fixes #1435)", () => {
       }),
     );
 
-    expect(stickyModelMock.persist).toHaveBeenCalledWith({
+    expect(stickyModelMock.persistBestEffort).toHaveBeenCalledWith({
       agentId: "work",
       model: "openai/gpt-4o",
     });
+  });
+
+  it("keeps a non-owner model selection session-scoped", async () => {
+    const sessionEntry = createSessionEntry();
+
+    const result = await handleDirectiveOnly(
+      createHandleParams({
+        directives: parseInlineDirectives("/model openai/gpt-4o"),
+        sessionEntry,
+        canPersistStickyModelSelection: false,
+      }),
+    );
+
+    expect(result?.text).toContain("Model set to openai/gpt-4o for this session.");
+    expect(sessionEntry).toMatchObject({
+      providerOverride: "openai",
+      modelOverride: "gpt-4o",
+    });
+    expect(stickyModelMock.persistBestEffort).not.toHaveBeenCalled();
   });
 
   it("persists an explicit runtime with a directive-only model switch", async () => {
@@ -2014,10 +2036,24 @@ describe("handleDirectiveOnly model persist behavior (fixes #1435)", () => {
       allowedModelKeys: ["anthropic/claude-opus-4-6", "openai/gpt-4o"],
     });
 
-    expect(stickyModelMock.persist).toHaveBeenCalledWith({
+    expect(stickyModelMock.persistBestEffort).toHaveBeenCalledWith({
       agentId: "work",
       model: "openai/gpt-4o",
     });
+  });
+
+  it("keeps a mixed-command model selection session-scoped without authority", async () => {
+    const { sessionEntry } = await persistModelDirectiveForTest({
+      command: "/model openai/gpt-4o continue with the request",
+      allowedModelKeys: ["anthropic/claude-opus-4-6", "openai/gpt-4o"],
+      canPersistStickyModelSelection: false,
+    });
+
+    expect(sessionEntry).toMatchObject({
+      providerOverride: "openai",
+      modelOverride: "gpt-4o",
+    });
+    expect(stickyModelMock.persistBestEffort).not.toHaveBeenCalled();
   });
 
   it("remaps unsupported stored thinking levels when persisting a model switch", async () => {
@@ -2901,6 +2937,7 @@ describe("persistInlineDirectives session directive persistence policy", () => {
         model: "claude-opus-4-6",
         initialModelLabel: "anthropic/claude-opus-4-6",
         formatModelSwitchEvent: (label) => `Switched to ${label}`,
+        canPersistStickyModelSelection: true,
         agentCfg: undefined,
       });
 

--- a/src/auto-reply/reply/directive-handling.params.ts
+++ b/src/auto-reply/reply/directive-handling.params.ts
@@ -34,6 +34,7 @@ type HandleDirectiveOnlyCoreParams = {
   model: string;
   initialModelLabel: string;
   formatModelSwitchEvent: (label: string, alias?: string) => string;
+  canPersistStickyModelSelection?: boolean;
 };
 
 /** Full directive-only command handler inputs. */

--- a/src/auto-reply/reply/directive-handling.persist.ts
+++ b/src/auto-reply/reply/directive-handling.persist.ts
@@ -8,6 +8,7 @@ import { resolveAgentHarnessPolicy } from "../../agents/harness/policy.js";
 import type { ModelCatalogEntry } from "../../agents/model-catalog.js";
 import { modelKey, type ModelAliasIndex } from "../../agents/model-selection.js";
 import { resolveContextConfigProviderForRuntime } from "../../agents/openai-routing.js";
+import { persistStickyModelSelection } from "../../agents/sticky-model-selection.js";
 import { resolveEffectiveAgentRuntime } from "../../agents/thinking-runtime.js";
 import {
   adoptPersistedSessionSnapshot,
@@ -421,6 +422,17 @@ export async function persistInlineDirectives(params: {
         provider = persistedEntry?.providerOverride?.trim() || defaultProvider;
         model = persistedEntry?.modelOverride?.trim() || defaultModel;
         thinkingRemap = undefined;
+      }
+      if (
+        modelDirective &&
+        modelResolution?.modelSelection &&
+        modelApplied &&
+        !modelResolution.modelSelection.isDefault
+      ) {
+        await persistStickyModelSelection({
+          agentId: activeAgentId,
+          model: `${provider}/${model}`,
+        });
       }
       if (modelDirective && modelUpdated && modelApplied) {
         triggerSessionPatchHook({

--- a/src/auto-reply/reply/directive-handling.persist.ts
+++ b/src/auto-reply/reply/directive-handling.persist.ts
@@ -8,7 +8,7 @@ import { resolveAgentHarnessPolicy } from "../../agents/harness/policy.js";
 import type { ModelCatalogEntry } from "../../agents/model-catalog.js";
 import { modelKey, type ModelAliasIndex } from "../../agents/model-selection.js";
 import { resolveContextConfigProviderForRuntime } from "../../agents/openai-routing.js";
-import { persistStickyModelSelection } from "../../agents/sticky-model-selection.js";
+import { persistStickyModelSelectionBestEffort } from "../../agents/sticky-model-selection.js";
 import { resolveEffectiveAgentRuntime } from "../../agents/thinking-runtime.js";
 import {
   adoptPersistedSessionSnapshot,
@@ -68,6 +68,7 @@ export async function persistInlineDirectives(params: {
   model: string;
   initialModelLabel: string;
   formatModelSwitchEvent: (label: string, alias?: string) => string;
+  canPersistStickyModelSelection?: boolean;
   agentCfg: NonNullable<OpenClawConfig["agents"]>["defaults"] | undefined;
   messageProvider?: string;
   surface?: string;
@@ -427,9 +428,10 @@ export async function persistInlineDirectives(params: {
         modelDirective &&
         modelResolution?.modelSelection &&
         modelApplied &&
-        !modelResolution.modelSelection.isDefault
+        !modelResolution.modelSelection.isDefault &&
+        params.canPersistStickyModelSelection === true
       ) {
-        await persistStickyModelSelection({
+        persistStickyModelSelectionBestEffort({
           agentId: activeAgentId,
           model: `${provider}/${model}`,
         });

--- a/src/auto-reply/reply/get-reply-directives-apply.ts
+++ b/src/auto-reply/reply/get-reply-directives-apply.ts
@@ -184,6 +184,9 @@ export async function applyInlineDirectiveOverrides(params: {
   let { directives } = params;
   let { provider, model } = params;
   let { contextTokens } = params;
+  const canPersistStickyModelSelection = Array.isArray(ctx.GatewayClientScopes)
+    ? ctx.GatewayClientScopes.includes("operator.admin")
+    : command.senderIsOwner;
   const directiveModelState = {
     allowedModelKeys: modelState.allowedModelKeys,
     allowedModelCatalog: modelState.allowedModelCatalog,
@@ -209,6 +212,7 @@ export async function applyInlineDirectiveOverrides(params: {
     model,
     initialModelLabel,
     formatModelSwitchEvent,
+    canPersistStickyModelSelection,
   });
 
   let directiveAck: ReplyPayload | undefined;
@@ -302,6 +306,7 @@ export async function applyInlineDirectiveOverrides(params: {
     thinkingCatalog: modelState.allowedModelCatalog,
     initialModelLabel,
     formatModelSwitchEvent,
+    canPersistStickyModelSelection,
     agentCfg,
     messageProvider: ctx.Provider,
     surface: ctx.Surface,
@@ -374,6 +379,7 @@ export async function applyInlineDirectiveOverrides(params: {
           allowedModelKeys: modelState.allowedModelKeys,
           modelCatalog: modelState.allowedModelCatalog,
           thinkingCatalog: modelState.allowedModelCatalog,
+          canPersistStickyModelSelection,
           request: {
             ...modelSelection,
             profileOverride: modelResolution.profileOverride,
@@ -513,6 +519,7 @@ export async function applyInlineDirectiveOverrides(params: {
       model,
       initialModelLabel,
       formatModelSwitchEvent,
+      canPersistStickyModelSelection,
       agentCfg,
       modelState: {
         resolveDefaultThinkingLevel: modelState.resolveDefaultThinkingLevel,

--- a/src/gateway/server-methods/sessions-mutations.sticky-model.test.ts
+++ b/src/gateway/server-methods/sessions-mutations.sticky-model.test.ts
@@ -1,0 +1,111 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { upsertSessionEntry } from "../../config/sessions/session-accessor.js";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { closeOpenClawAgentDatabasesForTest } from "../../state/openclaw-agent-db.js";
+import { withOpenClawTestState } from "../../test-utils/openclaw-test-state.js";
+import type { GatewayRequestContext, RespondFn } from "./types.js";
+
+const effects = vi.hoisted(() => ({
+  persistStickyModelSelection: vi.fn(async () => "defaults" as const),
+}));
+
+vi.mock("../../agents/sticky-model-selection.js", () => ({
+  persistStickyModelSelection: effects.persistStickyModelSelection,
+}));
+
+import { sessionMutationHandlers } from "./sessions-mutations.js";
+
+const cfg = {
+  agents: {
+    defaults: { model: "anthropic/claude-opus-4-6" },
+    list: [
+      { id: "main", default: true },
+      { id: "work", model: "anthropic/claude-sonnet-4-6" },
+    ],
+  },
+} satisfies OpenClawConfig;
+
+function context(): GatewayRequestContext {
+  return {
+    getRuntimeConfig: () => cfg,
+    loadGatewayModelCatalog: vi.fn(async () => [
+      { provider: "anthropic", id: "claude-opus-4-6" },
+      { provider: "anthropic", id: "claude-sonnet-4-6" },
+      { provider: "openai", id: "gpt-5.6-sol" },
+    ]),
+    broadcastToConnIds: vi.fn(),
+    getSessionEventSubscriberConnIds: () => new Set(),
+    chatAbortControllers: new Map(),
+  } as unknown as GatewayRequestContext;
+}
+
+async function patchSession(params: Record<string, unknown>) {
+  const responses: Parameters<RespondFn>[] = [];
+  await sessionMutationHandlers["sessions.patch"]?.({
+    params,
+    client: null,
+    context: context(),
+    respond: (...response: Parameters<RespondFn>) => responses.push(response),
+  } as never);
+  expect(responses).toHaveLength(1);
+  return responses[0]!;
+}
+
+beforeEach(() => {
+  effects.persistStickyModelSelection.mockClear();
+});
+
+afterEach(() => {
+  closeOpenClawAgentDatabasesForTest();
+});
+
+describe("sessions.patch sticky model persistence", () => {
+  it.each([
+    { agentId: "main", sessionKey: "agent:main:dm:sticky" },
+    { agentId: "work", sessionKey: "agent:work:dm:sticky" },
+  ])(
+    "persists an accepted model for the resolved $agentId agent",
+    async ({ agentId, sessionKey }) => {
+      await withOpenClawTestState({ scenario: "minimal" }, async () => {
+        await upsertSessionEntry(
+          { agentId, sessionKey },
+          { sessionId: `session-${agentId}`, updatedAt: 1 },
+        );
+
+        const response = await patchSession({ key: sessionKey, model: "openai/gpt-5.6-sol" });
+
+        expect(response[0]).toBe(true);
+        expect(effects.persistStickyModelSelection).toHaveBeenCalledWith({
+          agentId,
+          model: "openai/gpt-5.6-sol",
+        });
+      });
+    },
+  );
+
+  it.each([
+    { name: "omitted", patch: { label: "Sticky" } },
+    { name: "cleared", patch: { model: null } },
+    { name: "reset to the current default", patch: { model: "anthropic/claude-opus-4-6" } },
+  ])("does not persist when model is $name", async ({ patch }) => {
+    await withOpenClawTestState({ scenario: "minimal" }, async () => {
+      const sessionKey = "agent:main:dm:no-sticky";
+      await upsertSessionEntry(
+        { agentId: "main", sessionKey },
+        {
+          sessionId: "session-main",
+          updatedAt: 1,
+          providerOverride: "openai",
+          modelOverride: "gpt-5.6-sol",
+          modelOverrideSource: "user",
+          modelOverrideRouteResolution: "resolved",
+        },
+      );
+
+      const response = await patchSession({ key: sessionKey, ...patch });
+
+      expect(response[0]).toBe(true);
+      expect(effects.persistStickyModelSelection).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/gateway/server-methods/sessions-mutations.sticky-model.test.ts
+++ b/src/gateway/server-methods/sessions-mutations.sticky-model.test.ts
@@ -86,9 +86,7 @@ beforeEach(() => {
   effects.mutateConfigFileWithRetry
     .mockReset()
     .mockImplementation(
-      async (params: {
-        mutate: (draft: OpenClawConfig, context: unknown) => unknown;
-      }) => {
+      async (params: { mutate: (draft: OpenClawConfig, context: unknown) => unknown }) => {
         const draft = structuredClone(cfg);
         const result = await params.mutate(draft, {});
         return { nextConfig: draft, result };

--- a/src/gateway/server-methods/sessions-mutations.sticky-model.test.ts
+++ b/src/gateway/server-methods/sessions-mutations.sticky-model.test.ts
@@ -1,17 +1,34 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { upsertSessionEntry } from "../../config/sessions/session-accessor.js";
+import { loadSessionEntry, upsertSessionEntry } from "../../config/sessions/session-accessor.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { closeOpenClawAgentDatabasesForTest } from "../../state/openclaw-agent-db.js";
 import { withOpenClawTestState } from "../../test-utils/openclaw-test-state.js";
-import type { GatewayRequestContext, RespondFn } from "./types.js";
+import type { GatewayClient, GatewayRequestContext, RespondFn } from "./types.js";
 
 const effects = vi.hoisted(() => ({
-  persistStickyModelSelection: vi.fn(async () => "defaults" as const),
+  info: vi.fn(),
+  mutateConfigFileWithRetry: vi.fn(),
+  warn: vi.fn(),
 }));
 
-vi.mock("../../agents/sticky-model-selection.js", () => ({
-  persistStickyModelSelection: effects.persistStickyModelSelection,
-}));
+vi.mock("../../config/config.js", async () => {
+  const actual =
+    await vi.importActual<typeof import("../../config/config.js")>("../../config/config.js");
+  return { ...actual, mutateConfigFileWithRetry: effects.mutateConfigFileWithRetry };
+});
+
+vi.mock("../../logging/subsystem.js", async () => {
+  const actual = await vi.importActual<typeof import("../../logging/subsystem.js")>(
+    "../../logging/subsystem.js",
+  );
+  return {
+    ...actual,
+    createSubsystemLogger: (subsystem: string) =>
+      subsystem === "agents/sticky-model-selection"
+        ? { info: effects.info, warn: effects.warn }
+        : actual.createSubsystemLogger(subsystem),
+  };
+});
 
 import { sessionMutationHandlers } from "./sessions-mutations.js";
 
@@ -39,11 +56,23 @@ function context(): GatewayRequestContext {
   } as unknown as GatewayRequestContext;
 }
 
-async function patchSession(params: Record<string, unknown>) {
+function client(scopes: string[]): GatewayClient {
+  return {
+    connect: {
+      minProtocol: 1,
+      maxProtocol: 1,
+      client: { id: "openclaw-control-ui", version: "test", platform: "test", mode: "webchat" },
+      role: "operator",
+      scopes,
+    },
+  };
+}
+
+async function patchSession(params: Record<string, unknown>, scopes = ["operator.admin"]) {
   const responses: Parameters<RespondFn>[] = [];
   await sessionMutationHandlers["sessions.patch"]?.({
     params,
-    client: null,
+    client: client(scopes),
     context: context(),
     respond: (...response: Parameters<RespondFn>) => responses.push(response),
   } as never);
@@ -52,7 +81,19 @@ async function patchSession(params: Record<string, unknown>) {
 }
 
 beforeEach(() => {
-  effects.persistStickyModelSelection.mockClear();
+  effects.info.mockReset();
+  effects.warn.mockReset();
+  effects.mutateConfigFileWithRetry
+    .mockReset()
+    .mockImplementation(
+      async (params: {
+        mutate: (draft: OpenClawConfig, context: unknown) => unknown | Promise<unknown>;
+      }) => {
+        const draft = structuredClone(cfg);
+        const result = await params.mutate(draft, {});
+        return { nextConfig: draft, result };
+      },
+    );
 });
 
 afterEach(() => {
@@ -75,13 +116,55 @@ describe("sessions.patch sticky model persistence", () => {
         const response = await patchSession({ key: sessionKey, model: "openai/gpt-5.6-sol" });
 
         expect(response[0]).toBe(true);
-        expect(effects.persistStickyModelSelection).toHaveBeenCalledWith({
-          agentId,
-          model: "openai/gpt-5.6-sol",
-        });
+        await vi.waitFor(() => expect(effects.mutateConfigFileWithRetry).toHaveBeenCalledOnce());
       });
     },
   );
+
+  it("keeps a non-admin model switch session-scoped", async () => {
+    await withOpenClawTestState({ scenario: "minimal" }, async () => {
+      const sessionKey = "agent:main:dm:non-admin";
+      await upsertSessionEntry(
+        { agentId: "main", sessionKey },
+        { sessionId: "session-non-admin", updatedAt: 1 },
+      );
+
+      const response = await patchSession({ key: sessionKey, model: "openai/gpt-5.6-sol" }, [
+        "operator.write",
+      ]);
+
+      expect(response[0]).toBe(true);
+      expect(loadSessionEntry({ agentId: "main", sessionKey })).toMatchObject({
+        providerOverride: "openai",
+        modelOverride: "gpt-5.6-sol",
+      });
+      expect(effects.mutateConfigFileWithRetry).not.toHaveBeenCalled();
+    });
+  });
+
+  it("returns session success and warns when the sticky config write fails", async () => {
+    await withOpenClawTestState({ scenario: "minimal" }, async () => {
+      const sessionKey = "agent:main:dm:write-failure";
+      await upsertSessionEntry(
+        { agentId: "main", sessionKey },
+        { sessionId: "session-write-failure", updatedAt: 1 },
+      );
+      effects.mutateConfigFileWithRetry.mockRejectedValueOnce(new Error("config write failed"));
+
+      const response = await patchSession({ key: sessionKey, model: "openai/gpt-5.6-sol" });
+
+      expect(response[0]).toBe(true);
+      expect(loadSessionEntry({ agentId: "main", sessionKey })).toMatchObject({
+        providerOverride: "openai",
+        modelOverride: "gpt-5.6-sol",
+      });
+      await vi.waitFor(() =>
+        expect(effects.warn).toHaveBeenCalledWith(
+          "failed sticky model persistence agentId=main model=openai/gpt-5.6-sol reason=config write failed",
+        ),
+      );
+    });
+  });
 
   it.each([
     { name: "omitted", patch: { label: "Sticky" } },
@@ -105,7 +188,7 @@ describe("sessions.patch sticky model persistence", () => {
       const response = await patchSession({ key: sessionKey, ...patch });
 
       expect(response[0]).toBe(true);
-      expect(effects.persistStickyModelSelection).not.toHaveBeenCalled();
+      expect(effects.mutateConfigFileWithRetry).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/gateway/server-methods/sessions-mutations.sticky-model.test.ts
+++ b/src/gateway/server-methods/sessions-mutations.sticky-model.test.ts
@@ -87,7 +87,7 @@ beforeEach(() => {
     .mockReset()
     .mockImplementation(
       async (params: {
-        mutate: (draft: OpenClawConfig, context: unknown) => unknown | Promise<unknown>;
+        mutate: (draft: OpenClawConfig, context: unknown) => unknown;
       }) => {
         const draft = structuredClone(cfg);
         const result = await params.mutate(draft, {});

--- a/src/gateway/server-methods/sessions-mutations.ts
+++ b/src/gateway/server-methods/sessions-mutations.ts
@@ -8,7 +8,7 @@ import {
   validateSessionsResetParams,
 } from "../../../packages/gateway-protocol/src/index.js";
 import { resolveDefaultAgentId } from "../../agents/agent-scope.js";
-import { persistStickyModelSelection } from "../../agents/sticky-model-selection.js";
+import { persistStickyModelSelectionBestEffort } from "../../agents/sticky-model-selection.js";
 import { replyRunRegistry } from "../../auto-reply/reply/reply-run-registry.js";
 import {
   applySessionPatchProjection,
@@ -299,6 +299,7 @@ export const sessionMutationHandlers: GatewayRequestHandlers = {
       respond(false, undefined, applied.error);
       return;
     }
+    const callerScopes = Array.isArray(client?.connect?.scopes) ? client.connect.scopes : [];
 
     triggerSessionPatchHook({
       cfg,
@@ -310,8 +311,7 @@ export const sessionMutationHandlers: GatewayRequestHandlers = {
     // Cron mutations are operator.admin surface while archive is write-scoped;
     // only cascade for internal callers (client == null) or admin operators so
     // write-scoped archiving cannot flip admin-managed schedules.
-    const callerScopes = client?.connect ? (client.connect.scopes ?? []) : null;
-    const callerCanManageCron = callerScopes === null || callerScopes.includes(ADMIN_SCOPE);
+    const callerCanManageCron = client === null || callerScopes.includes(ADMIN_SCOPE);
     if (p.archived === true && callerCanManageCron) {
       // Archived sessions reject new work, so schedules bound to them would
       // only accumulate failing runs; disable them with the archive.
@@ -351,11 +351,12 @@ export const sessionMutationHandlers: GatewayRequestHandlers = {
     const resolved = resolveSessionModelRef(cfg, applied.entry, agentId);
     if (
       typeof p.model === "string" &&
+      callerScopes.includes(ADMIN_SCOPE) &&
       applied.entry.modelOverrideSource === "user" &&
       applied.entry.providerOverride &&
       applied.entry.modelOverride
     ) {
-      await persistStickyModelSelection({
+      persistStickyModelSelectionBestEffort({
         agentId,
         model: `${resolved.provider}/${resolved.model}`,
       });

--- a/src/gateway/server-methods/sessions-mutations.ts
+++ b/src/gateway/server-methods/sessions-mutations.ts
@@ -8,6 +8,7 @@ import {
   validateSessionsResetParams,
 } from "../../../packages/gateway-protocol/src/index.js";
 import { resolveDefaultAgentId } from "../../agents/agent-scope.js";
+import { persistStickyModelSelection } from "../../agents/sticky-model-selection.js";
 import { replyRunRegistry } from "../../auto-reply/reply/reply-run-registry.js";
 import {
   applySessionPatchProjection,
@@ -348,6 +349,17 @@ export const sessionMutationHandlers: GatewayRequestHandlers = {
         : (parsed?.agentId ?? resolveDefaultAgentId(cfg)),
     );
     const resolved = resolveSessionModelRef(cfg, applied.entry, agentId);
+    if (
+      typeof p.model === "string" &&
+      applied.entry.modelOverrideSource === "user" &&
+      applied.entry.providerOverride &&
+      applied.entry.modelOverride
+    ) {
+      await persistStickyModelSelection({
+        agentId,
+        model: `${resolved.provider}/${resolved.model}`,
+      });
+    }
     const resolvedDisplayModel = resolveSessionDisplayModelIdentityRef({
       cfg,
       agentId,

--- a/src/model-picker/apply-session-model-selection.test.ts
+++ b/src/model-picker/apply-session-model-selection.test.ts
@@ -7,6 +7,9 @@ import type { SessionEntry } from "../config/sessions/types.js";
 
 const effects = vi.hoisted(() => ({
   enqueueSystemEvent: vi.fn(),
+  persistStickyModelSelection: vi.fn(
+    async (_params: { agentId: string; model: string }) => "defaults" as const,
+  ),
   refreshQueuedFollowupSession: vi.fn(),
   triggerSessionPatchHook: vi.fn(),
 }));
@@ -21,6 +24,10 @@ vi.mock("../auto-reply/reply/queue.js", () => ({
 }));
 vi.mock("../gateway/session-patch-hooks.js", () => ({
   triggerSessionPatchHook: (...args: unknown[]) => effects.triggerSessionPatchHook(...args),
+}));
+vi.mock("../agents/sticky-model-selection.js", () => ({
+  persistStickyModelSelection: (params: { agentId: string; model: string }) =>
+    effects.persistStickyModelSelection(params),
 }));
 
 import {
@@ -76,6 +83,7 @@ function createParams(overrides: Partial<ApplySessionModelSelectionParams> = {})
 
 beforeEach(() => {
   effects.enqueueSystemEvent.mockReset();
+  effects.persistStickyModelSelection.mockClear();
   effects.refreshQueuedFollowupSession.mockReset();
   effects.triggerSessionPatchHook.mockReset();
 });
@@ -124,6 +132,10 @@ describe("applySessionModelSelection", () => {
     expect(sessionEntry.contextTokens).toBeUndefined();
     expect(sessionEntry.contextBudgetStatus).toBeUndefined();
     expect(effects.triggerSessionPatchHook).toHaveBeenCalledOnce();
+    expect(effects.persistStickyModelSelection).toHaveBeenCalledWith({
+      agentId: "main",
+      model: "openai/gpt-4o",
+    });
     expect(effects.refreshQueuedFollowupSession).toHaveBeenCalledOnce();
     expect(effects.enqueueSystemEvent).toHaveBeenCalledWith(
       "Model switched to Fast (openai/gpt-4o).",
@@ -163,6 +175,7 @@ describe("applySessionModelSelection", () => {
     expect(sessionEntry.authProfileOverrideSource).toBeUndefined();
     expect(sessionEntry.agentRuntimeOverride).toBeUndefined();
     expect(sessionEntry.agentHarnessId).toBe("codex");
+    expect(effects.persistStickyModelSelection).not.toHaveBeenCalled();
   });
 
   it.each([

--- a/src/model-picker/apply-session-model-selection.test.ts
+++ b/src/model-picker/apply-session-model-selection.test.ts
@@ -7,11 +7,11 @@ import type { SessionEntry } from "../config/sessions/types.js";
 
 const effects = vi.hoisted(() => ({
   enqueueSystemEvent: vi.fn(),
-  persistStickyModelSelection: vi.fn(
-    async (_params: { agentId: string; model: string }) => "defaults" as const,
-  ),
+  info: vi.fn(),
+  mutateConfigFileWithRetry: vi.fn(),
   refreshQueuedFollowupSession: vi.fn(),
   triggerSessionPatchHook: vi.fn(),
+  warn: vi.fn(),
 }));
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
@@ -25,10 +25,22 @@ vi.mock("../auto-reply/reply/queue.js", () => ({
 vi.mock("../gateway/session-patch-hooks.js", () => ({
   triggerSessionPatchHook: (...args: unknown[]) => effects.triggerSessionPatchHook(...args),
 }));
-vi.mock("../agents/sticky-model-selection.js", () => ({
-  persistStickyModelSelection: (params: { agentId: string; model: string }) =>
-    effects.persistStickyModelSelection(params),
-}));
+vi.mock("../config/config.js", async () => {
+  const actual = await vi.importActual<typeof import("../config/config.js")>("../config/config.js");
+  return { ...actual, mutateConfigFileWithRetry: effects.mutateConfigFileWithRetry };
+});
+
+vi.mock("../logging/subsystem.js", async () => {
+  const actual =
+    await vi.importActual<typeof import("../logging/subsystem.js")>("../logging/subsystem.js");
+  return {
+    ...actual,
+    createSubsystemLogger: (subsystem: string) =>
+      subsystem === "agents/sticky-model-selection"
+        ? { info: effects.info, warn: effects.warn }
+        : actual.createSubsystemLogger(subsystem),
+  };
+});
 
 import {
   applySessionModelSelection,
@@ -70,6 +82,7 @@ function createParams(overrides: Partial<ApplySessionModelSelectionParams> = {})
     allowedModelKeys: new Set(["anthropic/claude-opus-4-6", "openai/gpt-4o"]),
     modelCatalog: catalog,
     thinkingCatalog: catalog,
+    canPersistStickyModelSelection: false,
     request: {
       provider: "openai",
       model: "gpt-4o",
@@ -83,7 +96,12 @@ function createParams(overrides: Partial<ApplySessionModelSelectionParams> = {})
 
 beforeEach(() => {
   effects.enqueueSystemEvent.mockReset();
-  effects.persistStickyModelSelection.mockClear();
+  effects.info.mockReset();
+  effects.warn.mockReset();
+  effects.mutateConfigFileWithRetry.mockReset().mockResolvedValue({
+    nextConfig: {},
+    result: "defaults",
+  });
   effects.refreshQueuedFollowupSession.mockReset();
   effects.triggerSessionPatchHook.mockReset();
 });
@@ -99,6 +117,7 @@ describe("applySessionModelSelection", () => {
     const result = await applySessionModelSelection(
       createParams({
         sessionEntry,
+        canPersistStickyModelSelection: true,
         request: {
           provider: "openai",
           model: "gpt-4o",
@@ -132,10 +151,7 @@ describe("applySessionModelSelection", () => {
     expect(sessionEntry.contextTokens).toBeUndefined();
     expect(sessionEntry.contextBudgetStatus).toBeUndefined();
     expect(effects.triggerSessionPatchHook).toHaveBeenCalledOnce();
-    expect(effects.persistStickyModelSelection).toHaveBeenCalledWith({
-      agentId: "main",
-      model: "openai/gpt-4o",
-    });
+    await vi.waitFor(() => expect(effects.mutateConfigFileWithRetry).toHaveBeenCalledOnce());
     expect(effects.refreshQueuedFollowupSession).toHaveBeenCalledOnce();
     expect(effects.enqueueSystemEvent).toHaveBeenCalledWith(
       "Model switched to Fast (openai/gpt-4o).",
@@ -175,7 +191,42 @@ describe("applySessionModelSelection", () => {
     expect(sessionEntry.authProfileOverrideSource).toBeUndefined();
     expect(sessionEntry.agentRuntimeOverride).toBeUndefined();
     expect(sessionEntry.agentHarnessId).toBe("codex");
-    expect(effects.persistStickyModelSelection).not.toHaveBeenCalled();
+    expect(effects.mutateConfigFileWithRetry).not.toHaveBeenCalled();
+  });
+
+  it("keeps an accepted selection session-scoped without config authority", async () => {
+    const sessionEntry = createEntry();
+
+    const result = await applySessionModelSelection(
+      createParams({ sessionEntry, canPersistStickyModelSelection: false }),
+    );
+
+    expect(result.status).toBe("applied");
+    expect(sessionEntry).toMatchObject({
+      providerOverride: "openai",
+      modelOverride: "gpt-4o",
+    });
+    expect(effects.mutateConfigFileWithRetry).not.toHaveBeenCalled();
+  });
+
+  it("returns session success and warns when the sticky config write fails", async () => {
+    const sessionEntry = createEntry();
+    effects.mutateConfigFileWithRetry.mockRejectedValueOnce(new Error("config write failed"));
+
+    const result = await applySessionModelSelection(
+      createParams({ sessionEntry, canPersistStickyModelSelection: true }),
+    );
+
+    expect(result.status).toBe("applied");
+    expect(sessionEntry).toMatchObject({
+      providerOverride: "openai",
+      modelOverride: "gpt-4o",
+    });
+    await vi.waitFor(() =>
+      expect(effects.warn).toHaveBeenCalledWith(
+        "failed sticky model persistence agentId=main model=openai/gpt-4o reason=config write failed",
+      ),
+    );
   });
 
   it.each([

--- a/src/model-picker/apply-session-model-selection.ts
+++ b/src/model-picker/apply-session-model-selection.ts
@@ -9,7 +9,7 @@ import {
   resolveCompatibleAgentRuntimeForProvider,
   resolveSessionRuntimeOverrideForProvider,
 } from "../agents/session-runtime-compat.js";
-import { persistStickyModelSelection } from "../agents/sticky-model-selection.js";
+import { persistStickyModelSelectionBestEffort } from "../agents/sticky-model-selection.js";
 import { resolveEffectiveAgentRuntime } from "../agents/thinking-runtime.js";
 import { applyModelRuntimeDirective } from "../auto-reply/reply/directive-handling.model-runtime.js";
 import { resolveContextTokens } from "../auto-reply/reply/model-selection-context.js";
@@ -55,6 +55,7 @@ export type ApplySessionModelSelectionParams = {
   allowedModelKeys: ReadonlySet<string>;
   modelCatalog: readonly ModelCatalogEntry[];
   thinkingCatalog?: readonly ModelCatalogEntry[];
+  canPersistStickyModelSelection?: boolean;
   request: SessionModelSelectionRequest;
   /** Raw directive text used only by the existing session patch hook. */
   patchModel?: string;
@@ -302,8 +303,8 @@ export async function applySessionModelSelection(
   const model = request.model;
   const effectiveModelRef = `${provider}/${model}`;
   const changed = applied.changed || thinkingRemap !== undefined;
-  if (!request.isDefault) {
-    await persistStickyModelSelection({ agentId: params.agentId, model: effectiveModelRef });
+  if (params.canPersistStickyModelSelection === true && !request.isDefault) {
+    persistStickyModelSelectionBestEffort({ agentId: params.agentId, model: effectiveModelRef });
   }
   if (changed) {
     triggerSessionPatchHook({

--- a/src/model-picker/apply-session-model-selection.ts
+++ b/src/model-picker/apply-session-model-selection.ts
@@ -9,6 +9,7 @@ import {
   resolveCompatibleAgentRuntimeForProvider,
   resolveSessionRuntimeOverrideForProvider,
 } from "../agents/session-runtime-compat.js";
+import { persistStickyModelSelection } from "../agents/sticky-model-selection.js";
 import { resolveEffectiveAgentRuntime } from "../agents/thinking-runtime.js";
 import { applyModelRuntimeDirective } from "../auto-reply/reply/directive-handling.model-runtime.js";
 import { resolveContextTokens } from "../auto-reply/reply/model-selection-context.js";
@@ -301,6 +302,9 @@ export async function applySessionModelSelection(
   const model = request.model;
   const effectiveModelRef = `${provider}/${model}`;
   const changed = applied.changed || thinkingRemap !== undefined;
+  if (!request.isDefault) {
+    await persistStickyModelSelection({ agentId: params.agentId, model: effectiveModelRef });
+  }
   if (changed) {
     triggerSessionPatchHook({
       cfg: params.cfg,


### PR DESCRIPTION
## What Problem This Solves

Switching models via the Control UI picker or `/model` only patched the session, so every new session silently reverted to the configured default. Users had to re-pick constantly or hand-edit config.

## Why This Change Was Made

This is an owner-approved product decision (maintainer request): the last-used model becomes the future default. Persistence reuses the existing `setAgentEffectiveModelPrimary` write-target rule through `mutateConfigFileWithRetry` with runtime refresh: agents with an explicit model keep their entry; otherwise the shared default updates. This adds no new config surface or opt-out flag; the changed behavior is the product now.

Session-scoped semantics remain unchanged for patches omitting `model`, `model: null` clears, explicit reset-to-default, and thinking/fast-only changes; none of those persist. The persisted value is the canonical resolved `provider/model` ref. Persistence is authorization-gated (`operator.admin` for Gateway clients and owner authority for chat senders, while everyone else keeps today's session-only behavior) and best-effort: write failures and immutable-config deployments such as Nix mode never fail or delay the session operation.

## User Impact

The model you used last is the model your next session starts with, across UI and chat-command paths.

## Evidence

- 168 focused tests, including the 111-line `sessions.patch` sticky suite and write-target rule cases.
- Core typechecks passed.
- Two-pass autoreview completed: the second pass was clean after the authorization and immutable-config findings were fixed.

Note for reviewers: this intentionally changes the default behavior for session model switches. Release-note context is included in this PR body per repository changelog policy.
