### PR TITLE
fix(gateway): separate streamed chat completion finish chunks

### DIFF
--- a/src/gateway/openai-http.test.ts
+++ b/src/gateway/openai-http.test.ts
@@ -2010,6 +2010,49 @@ describe("OpenAI-compatible HTTP API (e2e)", () => {
     expect(finishChoice?.finish_reason).toBe("stop");
   });
 
+  it.each([
+    { name: "successful completion", fail: false, expected: "hello" },
+    { name: "internal agent error", fail: true, expected: "Error: internal error" },
+  ])(
+    "separates streamed content from the terminal finish for an official SDK $name",
+    async ({ fail, expected }) => {
+      agentCommand.mockClear();
+      if (fail) {
+        agentCommand.mockRejectedValueOnce(new Error("private upstream failure"));
+      } else {
+        agentCommand.mockImplementationOnce((async (opts: unknown) =>
+          buildAssistantDeltaResult({
+            opts,
+            emit: emitAgentEvent,
+            deltas: ["he", "llo"],
+            text: expected,
+          })) as never);
+      }
+
+      const stream = await createOpenAiChatClient(enabledPort).chat.completions.create({
+        model: "openclaw",
+        messages: [{ role: "user", content: "Return a complete streamed response." }],
+        stream: true,
+      });
+      const choices: Array<{
+        delta: { content?: string | null };
+        finish_reason: string | null;
+      }> = [];
+      for await (const chunk of stream) {
+        choices.push(...chunk.choices);
+      }
+
+      const contentChoices = choices.filter((choice) => typeof choice.delta.content === "string");
+      expect(contentChoices.map((choice) => choice.delta.content).join("")).toBe(expected);
+      expect(contentChoices.every((choice) => choice.finish_reason === null)).toBe(true);
+
+      const terminalChoices = choices.filter((choice) => choice.finish_reason === "stop");
+      expect(terminalChoices).toHaveLength(1);
+      expect(terminalChoices[0]?.delta).toEqual({});
+      expect(choices.at(-1)).toEqual(terminalChoices[0]);
+    },
+  );
+
   it("streams SSE chunks when stream=true", async () => {
     const port = enabledPort;
     try {
@@ -2045,6 +2088,18 @@ describe("OpenAI-compatible HTTP API (e2e)", () => {
           .filter((v): v is string => typeof v === "string")
           .join("");
         expect(allContent).toBe("hello");
+        const contentChoices = jsonChunks
+          .flatMap((chunk) => (chunk.choices as Array<Record<string, unknown>> | undefined) ?? [])
+          .filter(
+            (choice) =>
+              typeof (choice.delta as Record<string, unknown> | undefined)?.content === "string",
+          );
+        expect(contentChoices.every((choice) => choice.finish_reason === null)).toBe(true);
+        const stopChoices = jsonChunks
+          .flatMap((chunk) => (chunk.choices as Array<Record<string, unknown>> | undefined) ?? [])
+          .filter((choice) => choice.finish_reason === "stop");
+        expect(stopChoices).toHaveLength(1);
+        expect(stopChoices[0]?.delta).toEqual({});
         const usageChunks = jsonChunks.filter((c) => "usage" in c);
         expect(usageChunks).toHaveLength(0);
       }
@@ -2383,12 +2438,19 @@ describe("OpenAI-compatible HTTP API (e2e)", () => {
         const errorChunks = errorData
           .filter((d) => d !== "[DONE]")
           .map((d) => JSON.parse(d) as Record<string, unknown>);
-        const stopChoice = errorChunks
-          .flatMap((c) => (c.choices as Array<Record<string, unknown>> | undefined) ?? [])
-          .find((choice) => choice.finish_reason === "stop");
-        expect((stopChoice?.delta as Record<string, unknown> | undefined)?.content).toBe(
-          "Error: internal error",
+        const choices = errorChunks.flatMap(
+          (chunk) => (chunk.choices as Array<Record<string, unknown>> | undefined) ?? [],
         );
+        const errorContentChoice = choices.find(
+          (choice) =>
+            (choice.delta as Record<string, unknown> | undefined)?.content ===
+            "Error: internal error",
+        );
+        expect(errorContentChoice?.finish_reason).toBeNull();
+        const stopChoices = choices.filter((choice) => choice.finish_reason === "stop");
+        expect(stopChoices).toHaveLength(1);
+        expect(stopChoices[0]?.delta).toEqual({});
+        expect(choices.at(-1)).toEqual(stopChoices[0]);
       }
     } finally {
       // shared server

--- a/src/gateway/openai-http.ts
+++ b/src/gateway/openai-http.ts
@@ -283,7 +283,7 @@ function writeAssistantRoleChunk(res: ServerResponse, params: { runId: string; m
 
 function writeAssistantContentChunk(
   res: ServerResponse,
-  params: { runId: string; model: string; content: string; finishReason: "stop" | null },
+  params: { runId: string; model: string; content: string },
 ) {
   writeSse(res, {
     id: params.runId,
@@ -294,7 +294,7 @@ function writeAssistantContentChunk(
       {
         index: 0,
         delta: { content: params.content },
-        finish_reason: params.finishReason,
+        finish_reason: null,
       },
     ],
   });
@@ -1292,7 +1292,6 @@ export async function handleOpenAiHttpRequest(
         runId,
         model,
         content,
-        finishReason: null,
       });
       return;
     }
@@ -1370,7 +1369,6 @@ export async function handleOpenAiHttpRequest(
               runId,
               model,
               content: commentary,
-              finishReason: null,
             });
           }
         }
@@ -1400,7 +1398,6 @@ export async function handleOpenAiHttpRequest(
           runId,
           model,
           content,
-          finishReason: null,
         });
       }
       requestFinalize();
@@ -1436,9 +1433,7 @@ export async function handleOpenAiHttpRequest(
         runId,
         model,
         content,
-        finishReason: "stop",
       });
-      wroteStopChunk = true;
       finalUsage = {
         prompt_tokens: 0,
         completion_tokens: 0,


### PR DESCRIPTION
Related: #83203

## What Problem This Solves

Fixes an issue where the Gateway's OpenAI-compatible Chat Completions stream marks an internal-error text chunk as already finished and never sends the required separate empty terminal chunk. Official SDK consumers therefore receive the response body and `finish_reason: "stop"` in the same content event instead of the normal content-then-finish sequence.

## Why This Change Was Made

Make the existing content writer enforce `finish_reason: null` for every content chunk. Let the existing canonical finish writer emit the single empty `finish_reason: "stop"` chunk through the existing finalization path. This removes a misleading content-writer option and avoids duplicate stop chunks, new timers, protocol fallbacks, configuration, or error-detail leakage.

This preserves the original fix and focused regression from @niuma996 in #83203. The contributor receives actual Git commit coauthor credit.

## User Impact

Official OpenAI Chat Completions clients observe the same standards-compatible event ordering for successful and internal-error streaming responses: role, content chunks with null finish reasons, one empty terminal stop chunk, then `[DONE]`. User-visible errors continue to expose only the existing generic message. Tool-call finishes, streaming usage, previously fixed text boundaries, disconnections, and the sibling Responses endpoint remain unchanged.

## Evidence

- Source contract: the exact bundled `openai@6.48.0` SDK declares `Stream<ChatCompletionChunk>`, `Choice.Delta.content`, and a terminal nullable `finish_reason`: https://github.com/openai/openai-node/blob/v6.48.0/src/resources/chat/completions/completions.ts.
- Fail first: the actual SDK reading a real loopback Gateway and the independent raw SSE regression both fail on unchanged main because the internal-error content incorrectly carries `finish_reason: "stop"` and no empty terminal choice is sent.
- Pass after: official SDK tests cover successful and internal-error streams; actual raw HTTP/SSE asserts exact content ordering, one empty stop choice, and final `[DONE]`.
- Existing error redaction, structured tool calls, `tool_calls` finish reason, usage ordering, client disconnects, cumulative assistant snapshots, literal tags, final-fragment flushes, Responses parity, and hidden reasoning are retained.
- Blacksmith Testbox: `pnpm test src/gateway/openai-http.test.ts src/gateway/openresponses-http.test.ts src/gateway/openresponses-parity.test.ts src/gateway/openresponses-phase.test.ts src/agents/embedded-agent-subscribe.subscribe-embedded-agent-session.filters-final-suppresses-output-without-start-tag.test.ts` — **112 tests passed**.
- Blacksmith Testbox: `pnpm check:changed`.
- Independent `gpt-5.6-sol` review with `xhigh` reasoning.
- AI-assisted; original repair by @niuma996, preserved as Git coauthor.
